### PR TITLE
Redirect OAuth callback to frontend integrations page

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -17,7 +18,12 @@ import (
 	"github.com/valon-technologies/gestalt/internal/principal"
 )
 
-const defaultTokenInstance = "default"
+const (
+	defaultTokenInstance = "default"
+	integrationsPagePath = "/integrations"
+	oauthConnectedParam  = "connected"
+	oauthErrorParam      = "error"
+)
 
 func (s *Server) resolveUserID(w http.ResponseWriter, r *http.Request) (string, bool) {
 	user := UserFromContext(r.Context())
@@ -317,10 +323,13 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		authURL = oauthProv.AuthorizationURL("_", req.Scopes)
 	}
 
+	redirectURL := requestOrigin(r)
+
 	state, err := s.stateCodec.Encode(integrationOAuthState{
 		UserID:      dbUserID,
 		Integration: req.Integration,
 		Verifier:    verifier,
+		RedirectURL: redirectURL,
 		ExpiresAt:   s.now().Add(integrationOAuthStateTTL).Unix(),
 	})
 	if err != nil {
@@ -371,7 +380,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		tokenResp, err = oauthProv.ExchangeCode(r.Context(), code)
 	}
 	if err != nil {
-		writeError(w, http.StatusBadGateway, fmt.Sprintf("token exchange failed: %v", err))
+		s.oauthCallbackError(w, r, state.RedirectURL, http.StatusBadGateway, fmt.Sprintf("token exchange failed: %v", err))
 		return
 	}
 
@@ -391,10 +400,15 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := s.datastore.StoreToken(r.Context(), tok); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to store token")
+		s.oauthCallbackError(w, r, state.RedirectURL, http.StatusInternalServerError, "failed to store token")
 		return
 	}
 
+	if state.RedirectURL != "" {
+		target := state.RedirectURL + integrationsPagePath + "?" + oauthConnectedParam + "=" + url.QueryEscape(providerName)
+		http.Redirect(w, r, target, http.StatusFound)
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]string{
 		"status":      "connected",
 		"integration": providerName,
@@ -558,6 +572,43 @@ func (s *Server) revokeAPIToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "revoked"})
+}
+
+func requestOrigin(r *http.Request) string {
+	if origin := r.Header.Get("Origin"); origin != "" {
+		if sanitized := sanitizeRedirectOrigin(origin); sanitized != "" {
+			return sanitized
+		}
+	}
+	if ref := r.Header.Get("Referer"); ref != "" {
+		if u, err := url.Parse(ref); err == nil {
+			return sanitizeRedirectOrigin(u.Scheme + "://" + u.Host)
+		}
+	}
+	return ""
+}
+
+func sanitizeRedirectOrigin(origin string) string {
+	u, err := url.Parse(origin)
+	if err != nil {
+		return ""
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return ""
+	}
+	if u.Host == "" {
+		return ""
+	}
+	return u.Scheme + "://" + u.Host
+}
+
+func (s *Server) oauthCallbackError(w http.ResponseWriter, r *http.Request, redirectURL string, status int, msg string) {
+	if redirectURL != "" {
+		target := redirectURL + integrationsPagePath + "?" + oauthErrorParam + "=" + url.QueryEscape(msg)
+		http.Redirect(w, r, target, http.StatusFound)
+		return
+	}
+	writeError(w, status, msg)
 }
 
 func generateRandomHex(n int) (string, error) {

--- a/internal/server/oauth_state.go
+++ b/internal/server/oauth_state.go
@@ -15,6 +15,7 @@ type integrationOAuthState struct {
 	UserID      string `json:"uid"`
 	Integration string `json:"int"`
 	Verifier    string `json:"ver,omitempty"`
+	RedirectURL string `json:"ret,omitempty"`
 	ExpiresAt   int64  `json:"exp"`
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -1154,6 +1155,125 @@ func TestIntegrationOAuthCallback_PKCEUsesVerifier(t *testing.T) {
 	}
 	if stub.gotVerifier != stub.wantVerifier {
 		t.Fatalf("got verifier %q, want %q", stub.gotVerifier, stub.wantVerifier)
+	}
+}
+
+func TestIntegrationOAuthCallback_RedirectsToFrontend(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubIntegrationWithAuthURL{
+		StubIntegration: coretesting.StubIntegration{
+			N: "test-provider",
+			ExchangeCodeFn: func(context.Context, string) (*core.TokenResponse, error) {
+				return &core.TokenResponse{AccessToken: "tok"}, nil
+			},
+		},
+		authURL: "https://auth.example.com/authorize",
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	startBody := bytes.NewBufferString(`{"integration":"test-provider"}`)
+	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
+	startReq.Header.Set("X-Dev-User-Email", "dev@example.com")
+	startReq.Header.Set("Content-Type", "application/json")
+	startReq.Header.Set("Origin", "https://my-frontend.example.com")
+	startResp, err := http.DefaultClient.Do(startReq)
+	if err != nil {
+		t.Fatalf("start request: %v", err)
+	}
+	defer func() { _ = startResp.Body.Close() }()
+
+	var startResult map[string]string
+	if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
+		t.Fatalf("decoding start response: %v", err)
+	}
+
+	noRedirectClient := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	cbURL := ts.URL + "/api/v1/auth/callback?code=test-code&state=" + url.QueryEscape(startResult["state"])
+	resp, err := noRedirectClient.Get(cbURL)
+	if err != nil {
+		t.Fatalf("callback request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302, got %d", resp.StatusCode)
+	}
+	loc := resp.Header.Get("Location")
+	if !strings.HasPrefix(loc, "https://my-frontend.example.com/integrations?connected=test-provider") {
+		t.Errorf("Location = %q, want redirect to frontend integrations page", loc)
+	}
+}
+
+func TestIntegrationOAuthCallback_FallsBackToJSON(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubIntegrationWithAuthURL{
+		StubIntegration: coretesting.StubIntegration{
+			N: "test-provider",
+			ExchangeCodeFn: func(context.Context, string) (*core.TokenResponse, error) {
+				return &core.TokenResponse{AccessToken: "tok"}, nil
+			},
+		},
+		authURL: "https://auth.example.com/authorize",
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	startBody := bytes.NewBufferString(`{"integration":"test-provider"}`)
+	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
+	startReq.Header.Set("X-Dev-User-Email", "dev@example.com")
+	startReq.Header.Set("Content-Type", "application/json")
+	startResp, err := http.DefaultClient.Do(startReq)
+	if err != nil {
+		t.Fatalf("start request: %v", err)
+	}
+	defer func() { _ = startResp.Body.Close() }()
+
+	var startResult map[string]string
+	if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
+		t.Fatalf("decoding start response: %v", err)
+	}
+
+	cbURL := ts.URL + "/api/v1/auth/callback?code=test-code&state=" + url.QueryEscape(startResult["state"])
+	resp, err := http.Get(cbURL)
+	if err != nil {
+		t.Fatalf("callback request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decoding callback response: %v", err)
+	}
+	if body["status"] != "connected" {
+		t.Errorf("status = %q, want %q", body["status"], "connected")
 	}
 }
 

--- a/web/e2e/integrations.spec.ts
+++ b/web/e2e/integrations.spec.ts
@@ -55,6 +55,30 @@ test.describe("Integrations", () => {
     ).toBeVisible();
   });
 
+  test("shows success flash when redirected after OAuth connect", async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage;
+    await mockIntegrations(page, [
+      { name: "test-provider", display_name: "Test Provider", connected: true },
+    ]);
+
+    await page.goto("/integrations?connected=test-provider");
+    await expect(page.getByText("test-provider connected successfully.")).toBeVisible();
+    await expect(page).toHaveURL(/\/integrations$/);
+  });
+
+  test("shows error flash when redirected after OAuth failure", async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage;
+    await mockIntegrations(page, []);
+
+    await page.goto("/integrations?error=token+exchange+failed");
+    await expect(page.getByText("token exchange failed")).toBeVisible();
+    await expect(page).toHaveURL(/\/integrations$/);
+  });
+
   test("connected integration shows badge and hides Connect button", async ({
     authenticatedPage,
   }) => {

--- a/web/src/app/integrations/page.tsx
+++ b/web/src/app/integrations/page.tsx
@@ -1,10 +1,51 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { Suspense, useEffect, useState, useCallback } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
 import { getIntegrations, Integration } from "@/lib/api";
 import Nav from "@/components/Nav";
 import IntegrationCard from "@/components/IntegrationCard";
 import AuthGuard from "@/components/AuthGuard";
+
+function OAuthFlashBanner() {
+  const [flash, setFlash] = useState<{ type: "success" | "error"; message: string } | null>(null);
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  useEffect(() => {
+    const connected = searchParams.get("connected");
+    const oauthError = searchParams.get("error");
+    if (connected) {
+      setFlash({ type: "success", message: `${connected} connected successfully.` });
+      router.replace("/integrations", { scroll: false });
+    } else if (oauthError) {
+      setFlash({ type: "error", message: oauthError });
+      router.replace("/integrations", { scroll: false });
+    }
+  }, [searchParams, router]);
+
+  if (!flash) return null;
+
+  return (
+    <div
+      className={`mt-4 rounded-lg border px-4 py-3 text-sm ${
+        flash.type === "success"
+          ? "border-grove-200 bg-grove-50 text-grove-700"
+          : "border-ember-200 bg-ember-50 text-ember-700"
+      }`}
+    >
+      <div className="flex items-center justify-between">
+        <span>{flash.message}</span>
+        <button
+          onClick={() => setFlash(null)}
+          className="ml-4 text-current opacity-50 hover:opacity-100"
+        >
+          &times;
+        </button>
+      </div>
+    </div>
+  );
+}
 
 export default function IntegrationsPage() {
   const [integrations, setIntegrations] = useState<Integration[]>([]);
@@ -33,6 +74,10 @@ export default function IntegrationsPage() {
           <p className="mt-1 text-sm text-stone-500">
             Browse and connect third-party services.
           </p>
+
+          <Suspense>
+            <OAuthFlashBanner />
+          </Suspense>
 
           {loading && (
             <p className="mt-8 text-sm text-stone-400">Loading...</p>


### PR DESCRIPTION
The OAuth callback handler was returning JSON after a successful token exchange, leaving users staring at raw API output. The handler now captures the frontend origin from the request that starts the OAuth flow, stores it in the encrypted state token, and redirects back to the integrations page with status params after the callback completes. When no origin is available, the handler falls back to the previous JSON response for backward compatibility.