### PR TITLE
Add basic auth style for base64-encoded credentials

### DIFF
--- a/core/catalog/catalog.go
+++ b/core/catalog/catalog.go
@@ -85,6 +85,7 @@ var validAuthStyles = map[string]struct{}{
 	"bearer": {},
 	"raw":    {},
 	"none":   {},
+	"basic":  {},
 }
 
 func IsValidAuthStyle(s string) bool {

--- a/core/integration/base.go
+++ b/core/integration/base.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"time"
@@ -74,6 +75,7 @@ const (
 	AuthStyleBearer AuthStyle = iota
 	AuthStyleRaw
 	AuthStyleNone
+	AuthStyleBasic
 )
 
 type Base struct {
@@ -226,6 +228,8 @@ func (b *Base) resolveAuth(token string) (resolvedAuth, error) {
 		return resolvedAuth{token: token}, nil
 	case AuthStyleRaw:
 		return resolvedAuth{authHeader: token}, nil
+	case AuthStyleBasic:
+		return resolvedAuth{authHeader: "Basic " + base64.StdEncoding.EncodeToString([]byte(token))}, nil
 	default:
 		return resolvedAuth{}, nil
 	}

--- a/core/integration/base_test.go
+++ b/core/integration/base_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -274,6 +275,42 @@ func TestBaseExecuteGraphQLErrorsReturned(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "rate limited") {
 		t.Fatalf("error = %v, want to contain 'rate limited'", err)
+	}
+}
+
+func TestBaseExecuteBasicAuthStyle(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"auth": r.Header.Get("Authorization"),
+		})
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	b := &Base{
+		Auth:      mockAuth{},
+		BaseURL:   srv.URL,
+		AuthStyle: AuthStyleBasic,
+		Endpoints: map[string]Endpoint{
+			"op": {Method: http.MethodGet, Path: "/test"},
+		},
+	}
+
+	result, err := b.Execute(context.Background(), "op", nil, "user:pass")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:pass"))
+	if resp["auth"] != want {
+		t.Fatalf("auth = %v, want %v", resp["auth"], want)
 	}
 }
 

--- a/core/integration/catalog.go
+++ b/core/integration/catalog.go
@@ -93,6 +93,8 @@ func AuthStyleValue(c *catalog.Catalog) (AuthStyle, error) {
 		return AuthStyleRaw, nil
 	case "none":
 		return AuthStyleNone, nil
+	case "basic":
+		return AuthStyleBasic, nil
 	default:
 		return AuthStyleBearer, nil
 	}

--- a/core/integration/catalog_test.go
+++ b/core/integration/catalog_test.go
@@ -153,6 +153,29 @@ operations:
 	}
 }
 
+func TestBaseFromCatalogBasicAuthStyle(t *testing.T) {
+	t.Parallel()
+
+	cat := MustLoadCatalogYAML([]byte(`
+name: basic_example
+display_name: Basic Example
+base_url: https://api.example.com
+auth_style: basic
+operations:
+  - id: list
+    method: GET
+    path: /list
+`))
+
+	base, err := BaseFromCatalog(cat, Base{})
+	if err != nil {
+		t.Fatalf("BaseFromCatalog: %v", err)
+	}
+	if base.AuthStyle != AuthStyleBasic {
+		t.Fatalf("AuthStyle = %v, want %v", base.AuthStyle, AuthStyleBasic)
+	}
+}
+
 func TestCompileSchemasFillsInputSchema(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -78,6 +78,8 @@ func Build(def *Definition, intg config.IntegrationDef, allowedOperations map[st
 		base.AuthStyle = ci.AuthStyleRaw
 	case "none":
 		base.AuthStyle = ci.AuthStyleNone
+	case "basic":
+		base.AuthStyle = ci.AuthStyleBasic
 	default:
 		return nil, fmt.Errorf("%s: unknown auth_style %q", def.Provider, def.AuthStyle)
 	}

--- a/internal/provider/build_test.go
+++ b/internal/provider/build_test.go
@@ -186,6 +186,28 @@ func TestBuildUnknownAuthStyle(t *testing.T) {
 	}
 }
 
+func TestBuildBasicAuthStyle(t *testing.T) {
+	t.Parallel()
+
+	def := &Definition{
+		Provider:    "basic_api",
+		DisplayName: "Basic API",
+		BaseURL:     "https://api.example.com",
+		Auth:        AuthDef{Type: "manual"},
+		AuthStyle:   "basic",
+		Operations: map[string]OperationDef{
+			"list": {Description: "List", Method: "GET", Path: "/list"},
+		},
+	}
+	intg, err := Build(def, config.IntegrationDef{}, nil)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if intg.Name() != "basic_api" {
+		t.Errorf("Name() = %q", intg.Name())
+	}
+}
+
 func TestLoadFromDir(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Gestalt can connect to APIs that use bearer tokens, raw headers, or no
auth, but has no support for HTTP Basic Authentication. This adds
`AuthStyleBasic` which base64-encodes the token as `Basic <credentials>`
in the Authorization header, wired through catalog validation,
`AuthStyleValue`, and provider `Build`. OpenAPI auto-extraction of basic
auth schemes is intentionally deferred to a follow-up.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>