### PR TITLE
Add retry-with-backoff to apiexec.Do

### DIFF
--- a/internal/apiexec/apiexec.go
+++ b/internal/apiexec/apiexec.go
@@ -8,10 +8,24 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/valon-technologies/gestalt/core"
 )
+
+const (
+	defaultMaxRetries = 3
+	baseRetryDelay    = 1 * time.Second
+)
+
+var retryableStatusCodes = map[int]bool{
+	http.StatusTooManyRequests:    true,
+	http.StatusBadGateway:         true,
+	http.StatusServiceUnavailable: true,
+	http.StatusGatewayTimeout:     true,
+}
 
 var pathParamRe = regexp.MustCompile(`\{([^}]+)\}`)
 
@@ -46,6 +60,12 @@ type Request struct {
 
 	// CheckResponse, when set, replaces the default status >= 400 check.
 	CheckResponse ResponseChecker
+
+	// MaxRetries is the maximum number of retry attempts for transient errors.
+	// Zero uses the default (3). Set NoRetry to disable retries entirely.
+	MaxRetries int
+	// NoRetry disables automatic retry for this request.
+	NoRetry bool
 }
 
 // Do executes the request and returns an OperationResult.
@@ -59,32 +79,86 @@ func Do(ctx context.Context, client *http.Client, req Request) (*core.OperationR
 
 	fullURL := req.BaseURL + path
 
-	var httpReq *http.Request
-
+	var bodyBytes []byte
+	var contentType string
 	switch req.Method {
 	case http.MethodPost, http.MethodPut, http.MethodPatch:
-		var body []byte
 		if req.Body != nil {
-			body = req.Body
+			bodyBytes = req.Body
 		} else {
-			body, err = json.Marshal(params)
+			bodyBytes, err = json.Marshal(params)
 			if err != nil {
 				return nil, fmt.Errorf("marshaling request body: %w", err)
 			}
 		}
-		httpReq, err = http.NewRequestWithContext(ctx, req.Method, fullURL, bytes.NewReader(body))
+		contentType = req.ContentType
+		if contentType == "" {
+			contentType = "application/json"
+		}
+	}
+
+	maxRetries := req.MaxRetries
+	if maxRetries <= 0 {
+		maxRetries = defaultMaxRetries
+	}
+	if req.NoRetry {
+		maxRetries = 0
+	}
+
+	var lastErr error
+	for attempt := range maxRetries + 1 {
+		if attempt > 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
+
+		result, statusCode, retryAfter, retryable, err := doOnce(ctx, client, req, fullURL, bodyBytes, contentType, params)
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+
+		if !retryable || attempt >= maxRetries {
+			break
+		}
+
+		delay := retryDelay(statusCode, retryAfter, attempt)
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	return nil, lastErr
+}
+
+func doOnce(
+	ctx context.Context,
+	client *http.Client,
+	req Request,
+	fullURL string,
+	bodyBytes []byte,
+	contentType string,
+	params map[string]any,
+) (*core.OperationResult, int, string, bool, error) {
+	var httpReq *http.Request
+	var err error
+
+	switch req.Method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch:
+		httpReq, err = http.NewRequestWithContext(ctx, req.Method, fullURL, bytes.NewReader(bodyBytes))
 		if err != nil {
-			return nil, fmt.Errorf("creating request: %w", err)
+			return nil, 0, "", false, fmt.Errorf("creating request: %w", err)
 		}
-		ct := req.ContentType
-		if ct == "" {
-			ct = "application/json"
-		}
-		httpReq.Header.Set("Content-Type", ct)
+		httpReq.Header.Set("Content-Type", contentType)
 	default:
 		httpReq, err = http.NewRequestWithContext(ctx, req.Method, fullURL, nil)
 		if err != nil {
-			return nil, fmt.Errorf("creating request: %w", err)
+			return nil, 0, "", false, fmt.Errorf("creating request: %w", err)
 		}
 		if len(params) > 0 {
 			q := httpReq.URL.Query()
@@ -107,27 +181,41 @@ func Do(ctx context.Context, client *http.Client, req Request) (*core.OperationR
 
 	resp, err := client.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("executing request: %w", err)
+		return nil, 0, "", false, fmt.Errorf("executing request: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
 
+	retryAfter := resp.Header.Get("Retry-After")
 	respBody, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
 	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
+		return nil, 0, "", false, fmt.Errorf("reading response: %w", err)
 	}
 
 	if req.CheckResponse != nil {
 		if err := req.CheckResponse(resp.StatusCode, respBody); err != nil {
-			return nil, err
+			return nil, resp.StatusCode, retryAfter, retryableStatusCodes[resp.StatusCode], err
 		}
 	} else if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, respBody)
+		retryable := retryableStatusCodes[resp.StatusCode]
+		return nil, resp.StatusCode, retryAfter, retryable, fmt.Errorf("HTTP %d: %s", resp.StatusCode, respBody)
 	}
 
 	return &core.OperationResult{
 		Status: resp.StatusCode,
 		Body:   string(respBody),
-	}, nil
+	}, resp.StatusCode, retryAfter, false, nil
+}
+
+// retryDelay returns the delay before the next retry attempt. It honors the
+// Retry-After header when present (integer seconds form only), otherwise
+// falls back to exponential backoff.
+func retryDelay(_ int, retryAfter string, attempt int) time.Duration {
+	if retryAfter != "" {
+		if seconds, err := strconv.Atoi(retryAfter); err == nil && seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+	}
+	return baseRetryDelay * (1 << attempt)
 }
 
 // GraphQLRequest describes a GraphQL API call.

--- a/internal/apiexec/apiexec_test.go
+++ b/internal/apiexec/apiexec_test.go
@@ -3,10 +3,13 @@ package apiexec
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/valon-technologies/gestalt/internal/testutil"
 )
@@ -306,4 +309,232 @@ func TestDoGraphQLAuthHeaders(t *testing.T) {
 			t.Fatalf("key = %v, want key-123", data["key"])
 		}
 	})
+}
+
+func TestRetryOn429ThenSuccess(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if attempts.Add(1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte("rate limited"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	testutil.CloseOnCleanup(t, srv)
+
+	result, err := Do(context.Background(), srv.Client(), Request{
+		Method:     http.MethodGet,
+		BaseURL:    srv.URL,
+		Path:       "/test",
+		MaxRetries: 2,
+	})
+	if err != nil {
+		t.Fatalf("expected success after retry, got: %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", result.Status, http.StatusOK)
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("attempts = %d, want 2", got)
+	}
+}
+
+func TestRetryOn503WithBackoff(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if attempts.Add(1) <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("unavailable"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "recovered"})
+	}))
+	testutil.CloseOnCleanup(t, srv)
+
+	start := time.Now()
+	result, err := Do(context.Background(), srv.Client(), Request{
+		Method:     http.MethodGet,
+		BaseURL:    srv.URL,
+		Path:       "/test",
+		MaxRetries: 3,
+	})
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected success after retries, got: %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", result.Status, http.StatusOK)
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Fatalf("attempts = %d, want 3", got)
+	}
+	// Two retries: 1s + 2s = 3s minimum backoff
+	if elapsed < 3*time.Second {
+		t.Fatalf("elapsed = %v, expected at least 3s of backoff", elapsed)
+	}
+}
+
+func TestRetryAfterHeaderRespected(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if attempts.Add(1) == 1 {
+			w.Header().Set("Retry-After", "2")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte("rate limited"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	testutil.CloseOnCleanup(t, srv)
+
+	start := time.Now()
+	result, err := Do(context.Background(), srv.Client(), Request{
+		Method:     http.MethodGet,
+		BaseURL:    srv.URL,
+		Path:       "/test",
+		MaxRetries: 2,
+	})
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", result.Status, http.StatusOK)
+	}
+	if elapsed < 2*time.Second {
+		t.Fatalf("elapsed = %v, expected at least 2s from Retry-After", elapsed)
+	}
+}
+
+func TestNoRetryDisablesRetry(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte("rate limited"))
+	}))
+	testutil.CloseOnCleanup(t, srv)
+
+	_, err := Do(context.Background(), srv.Client(), Request{
+		Method:  http.MethodGet,
+		BaseURL: srv.URL,
+		Path:    "/test",
+		NoRetry: true,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("attempts = %d, want 1 (no retry)", got)
+	}
+}
+
+func TestRetriesStopAfterMaxRetries(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("bad gateway"))
+	}))
+	testutil.CloseOnCleanup(t, srv)
+
+	_, err := Do(context.Background(), srv.Client(), Request{
+		Method:     http.MethodGet,
+		BaseURL:    srv.URL,
+		Path:       "/test",
+		MaxRetries: 2,
+	})
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	// 1 initial + 2 retries = 3 total
+	if got := attempts.Load(); got != 3 {
+		t.Fatalf("attempts = %d, want 3", got)
+	}
+}
+
+func TestContextCancellationStopsRetries(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("unavailable"))
+	}))
+	testutil.CloseOnCleanup(t, srv)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := Do(ctx, srv.Client(), Request{
+		Method:     http.MethodGet,
+		BaseURL:    srv.URL,
+		Path:       "/test",
+		MaxRetries: 5,
+	})
+	if err == nil {
+		t.Fatal("expected error from context cancellation")
+	}
+	if err != context.Canceled {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if got := attempts.Load(); got > 2 {
+		t.Fatalf("attempts = %d, want at most 2", got)
+	}
+}
+
+func TestNonRetryableErrorsNotRetried(t *testing.T) {
+	t.Parallel()
+
+	for _, code := range []int{
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+		http.StatusInternalServerError,
+	} {
+		t.Run(fmt.Sprintf("HTTP_%d", code), func(t *testing.T) {
+			t.Parallel()
+
+			var attempts atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				attempts.Add(1)
+				w.WriteHeader(code)
+				_, _ = fmt.Fprintf(w, "error %d", code)
+			}))
+			testutil.CloseOnCleanup(t, srv)
+
+			_, err := Do(context.Background(), srv.Client(), Request{
+				Method:  http.MethodGet,
+				BaseURL: srv.URL,
+				Path:    "/test",
+			})
+			if err == nil {
+				t.Fatalf("expected error for HTTP %d", code)
+			}
+			if got := attempts.Load(); got != 1 {
+				t.Fatalf("attempts = %d, want 1 (no retry for HTTP %d)", got, code)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- Refactor `Do` into a retry loop around a new `doOnce` helper for automatic retries on transient HTTP errors (429, 502, 503, 504)
- Support exponential backoff with Retry-After header respect
- Add `MaxRetries` and `NoRetry` fields to `Request` struct for caller control
- Fix bodyclose lint: read and close response body eagerly in `doOnce` instead of using defer
- Fix errcheck lint: use `_, _ = w.Write(...)` and `_, _ = fmt.Fprintf(...)` in test handlers

## Test plan
- [x] `TestRetryOn429ThenSuccess` -- retries on 429, succeeds on second attempt
- [x] `TestRetryOn503WithBackoff` -- verifies exponential backoff timing (1s + 2s)
- [x] `TestRetryAfterHeaderRespected` -- honors Retry-After header delay
- [x] `TestNoRetryDisablesRetry` -- NoRetry=true makes exactly 1 attempt
- [x] `TestRetriesStopAfterMaxRetries` -- respects MaxRetries limit
- [x] `TestContextCancellationStopsRetries` -- context cancellation aborts retry loop
- [x] `TestNonRetryableErrorsNotRetried` -- 400/401/403/404/500 are not retried
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)