### PR TITLE
Add GraphQL transport for provider operations

### DIFF
--- a/core/catalog/catalog.go
+++ b/core/catalog/catalog.go
@@ -36,6 +36,8 @@ type CatalogOperation struct {
 	Tags           []string             `yaml:"tags,omitempty"           json:"tags,omitempty"`
 	ReadOnly       bool                 `yaml:"read_only,omitempty"      json:"readOnly,omitempty"`
 	Visible        *bool                `yaml:"visible,omitempty"        json:"visible,omitempty"`
+	Transport      string               `yaml:"transport,omitempty"      json:"transport,omitempty"`
+	Query          string               `yaml:"query,omitempty"          json:"query,omitempty"`
 }
 
 type OperationAnnotations struct {

--- a/core/integration/base.go
+++ b/core/integration/base.go
@@ -85,6 +85,7 @@ type Base struct {
 	BaseURL            string
 	Operations         []core.Operation
 	Endpoints          map[string]Endpoint
+	Queries            map[string]string // operation_name -> graphql query
 	Headers            map[string]string
 	AuthStyle          AuthStyle
 	HTTPClient         *http.Client
@@ -157,6 +158,10 @@ func (b *Base) Execute(ctx context.Context, operation string, params map[string]
 		return b.ExecuteFunc(ctx, operation, params, token)
 	}
 
+	if query, ok := b.Queries[operation]; ok {
+		return b.executeGraphQL(ctx, query, params, token)
+	}
+
 	ep, ok := b.Endpoints[operation]
 	if !ok {
 		return nil, fmt.Errorf("unknown operation: %s", operation)
@@ -171,26 +176,8 @@ func (b *Base) Execute(ctx context.Context, operation string, params map[string]
 		CheckResponse: b.CheckResponse,
 	}
 
-	if b.TokenParser != nil {
-		authHeader, extraHeaders, err := b.TokenParser(token)
-		if err != nil {
-			return nil, err
-		}
-		req.AuthHeader = authHeader
-		if req.CustomHeaders == nil {
-			req.CustomHeaders = make(map[string]string)
-		}
-		for k, v := range extraHeaders {
-			req.CustomHeaders[k] = v
-		}
-	} else {
-		switch b.AuthStyle {
-		case AuthStyleBearer:
-			req.Token = token
-		case AuthStyleRaw:
-			req.AuthHeader = token
-		case AuthStyleNone:
-		}
+	if err := b.applyAuth(&req, token); err != nil {
+		return nil, err
 	}
 
 	if b.RequestMutator != nil {
@@ -200,6 +187,75 @@ func (b *Base) Execute(ctx context.Context, operation string, params map[string]
 	}
 
 	return apiexec.Do(ctx, b.httpClient(), req)
+}
+
+func (b *Base) executeGraphQL(ctx context.Context, query string, params map[string]any, token string) (*core.OperationResult, error) {
+	gqlReq := apiexec.GraphQLRequest{
+		URL:           b.BaseURL,
+		Query:         query,
+		Variables:     params,
+		CustomHeaders: copyHeaders(b.Headers),
+	}
+	if err := b.applyGraphQLAuth(&gqlReq, token); err != nil {
+		return nil, err
+	}
+	return apiexec.DoGraphQL(ctx, b.httpClient(), gqlReq)
+}
+
+type resolvedAuth struct {
+	token        string
+	authHeader   string
+	extraHeaders map[string]string
+}
+
+func (b *Base) resolveAuth(token string) (resolvedAuth, error) {
+	if b.TokenParser != nil {
+		authHeader, extraHeaders, err := b.TokenParser(token)
+		if err != nil {
+			return resolvedAuth{}, err
+		}
+		return resolvedAuth{authHeader: authHeader, extraHeaders: extraHeaders}, nil
+	}
+	switch b.AuthStyle {
+	case AuthStyleBearer:
+		return resolvedAuth{token: token}, nil
+	case AuthStyleRaw:
+		return resolvedAuth{authHeader: token}, nil
+	default:
+		return resolvedAuth{}, nil
+	}
+}
+
+func (b *Base) applyAuth(req *apiexec.Request, token string) error {
+	auth, err := b.resolveAuth(token)
+	if err != nil {
+		return err
+	}
+	req.Token = auth.token
+	req.AuthHeader = auth.authHeader
+	for k, v := range auth.extraHeaders {
+		if req.CustomHeaders == nil {
+			req.CustomHeaders = make(map[string]string)
+		}
+		req.CustomHeaders[k] = v
+	}
+	return nil
+}
+
+func (b *Base) applyGraphQLAuth(req *apiexec.GraphQLRequest, token string) error {
+	auth, err := b.resolveAuth(token)
+	if err != nil {
+		return err
+	}
+	req.Token = auth.token
+	req.AuthHeader = auth.authHeader
+	for k, v := range auth.extraHeaders {
+		if req.CustomHeaders == nil {
+			req.CustomHeaders = make(map[string]string)
+		}
+		req.CustomHeaders[k] = v
+	}
+	return nil
 }
 
 func copyHeaders(h map[string]string) map[string]string {

--- a/core/integration/base_test.go
+++ b/core/integration/base_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/core"
@@ -120,5 +121,177 @@ func TestBaseExecuteFuncOverridesDefaultExecution(t *testing.T) {
 	}
 	if result.Body != "custom-anything" {
 		t.Fatalf("body = %q, want %q", result.Body, "custom-anything")
+	}
+}
+
+func TestBaseExecuteRoutesGraphQLOperations(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+
+		query, _ := body["query"].(string)
+		auth := r.Header.Get("Authorization")
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"viewer":{"login":"test","query":"` + query + `","auth":"` + auth + `"}}}`))
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL,
+		Queries: map[string]string{
+			"get_viewer": "{ viewer { login } }",
+		},
+		Endpoints: map[string]Endpoint{
+			"list_items": {Method: http.MethodGet, Path: "/api/items"},
+		},
+	}
+
+	result, err := b.Execute(context.Background(), "get_viewer", nil, "gql-token")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", result.Status)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &data); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	viewer := data["viewer"].(map[string]any)
+	if viewer["auth"] != "Bearer gql-token" {
+		t.Fatalf("auth = %v, want Bearer gql-token", viewer["auth"])
+	}
+}
+
+func TestBaseExecuteGraphQLWithVariables(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		vars, _ := body["variables"].(map[string]any)
+		first := vars["first"]
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"repos": map[string]any{"count": first},
+			},
+		})
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL,
+		Queries: map[string]string{
+			"list_repos": "query($first: Int) { viewer { repositories(first: $first) { nodes { name } } } }",
+		},
+	}
+
+	result, err := b.Execute(context.Background(), "list_repos", map[string]any{"first": 5}, "tok")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &data); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	repos := data["repos"].(map[string]any)
+	if repos["count"] != float64(5) {
+		t.Fatalf("count = %v, want 5", repos["count"])
+	}
+}
+
+func TestBaseExecuteGraphQLWithTokenParser(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		extra := r.Header.Get("X-Org")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"auth":"` + auth + `","org":"` + extra + `"}}`))
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL,
+		Queries: map[string]string{
+			"get_viewer": "{ viewer { login } }",
+		},
+		TokenParser: func(token string) (string, map[string]string, error) {
+			return "Token " + token, map[string]string{"X-Org": "acme"}, nil
+		},
+	}
+
+	result, err := b.Execute(context.Background(), "get_viewer", nil, "my-token")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &data); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if data["auth"] != "Token my-token" {
+		t.Fatalf("auth = %v, want Token my-token", data["auth"])
+	}
+	if data["org"] != "acme" {
+		t.Fatalf("org = %v, want acme", data["org"])
+	}
+}
+
+func TestBaseExecuteGraphQLErrorsReturned(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"errors":[{"message":"rate limited"}]}`))
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL,
+		Queries: map[string]string{
+			"get_viewer": "{ viewer { login } }",
+		},
+	}
+
+	_, err := b.Execute(context.Background(), "get_viewer", nil, "tok")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "rate limited") {
+		t.Fatalf("error = %v, want to contain 'rate limited'", err)
+	}
+}
+
+func TestBaseExecuteUnknownOperationFallsThrough(t *testing.T) {
+	t.Parallel()
+
+	b := &Base{
+		Auth: mockAuth{},
+		Queries: map[string]string{
+			"get_viewer": "{ viewer { login } }",
+		},
+	}
+
+	_, err := b.Execute(context.Background(), "nonexistent", nil, "tok")
+	if err == nil {
+		t.Fatal("expected error for unknown operation, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown operation") {
+		t.Fatalf("error = %v, want to contain 'unknown operation'", err)
 	}
 }

--- a/core/integration/catalog.go
+++ b/core/integration/catalog.go
@@ -20,6 +20,9 @@ func OperationsList(c *catalog.Catalog) []core.Operation {
 	ops := make([]core.Operation, 0, len(c.Operations))
 	for i := range c.Operations {
 		op := &c.Operations[i]
+		if op.Transport == transportGraphQL && op.Query == "" {
+			continue
+		}
 		params := make([]core.Parameter, 0, len(op.Parameters))
 		for _, param := range op.Parameters {
 			params = append(params, core.Parameter{
@@ -30,10 +33,14 @@ func OperationsList(c *catalog.Catalog) []core.Operation {
 				Default:     param.Default,
 			})
 		}
+		method := strings.ToUpper(strings.TrimSpace(op.Method))
+		if method == "" && op.Query != "" {
+			method = "POST"
+		}
 		ops = append(ops, core.Operation{
 			Name:        op.ID,
 			Description: op.Description,
-			Method:      strings.ToUpper(strings.TrimSpace(op.Method)),
+			Method:      method,
 			Parameters:  params,
 		})
 	}
@@ -44,6 +51,9 @@ func EndpointsMap(c *catalog.Catalog) (map[string]Endpoint, error) {
 	endpoints := make(map[string]Endpoint, len(c.Operations))
 	for i := range c.Operations {
 		op := &c.Operations[i]
+		if op.Transport == transportGraphQL || op.Query != "" {
+			continue
+		}
 		if strings.TrimSpace(op.Method) == "" {
 			return nil, fmt.Errorf("catalog %q operation %q is missing method", c.Name, op.ID)
 		}
@@ -56,6 +66,22 @@ func EndpointsMap(c *catalog.Catalog) (map[string]Endpoint, error) {
 		}
 	}
 	return endpoints, nil
+}
+
+const transportGraphQL = "graphql"
+
+func QueriesMap(c *catalog.Catalog) map[string]string {
+	queries := make(map[string]string)
+	for i := range c.Operations {
+		op := &c.Operations[i]
+		if op.Query != "" {
+			queries[op.ID] = op.Query
+		}
+	}
+	if len(queries) == 0 {
+		return nil
+	}
+	return queries
 }
 
 func AuthStyleValue(c *catalog.Catalog) (AuthStyle, error) {
@@ -96,6 +122,7 @@ func BaseFromCatalog(cat *catalog.Catalog, runtime Base) (Base, error) {
 		return Base{}, err
 	}
 	base.Endpoints = endpoints
+	base.Queries = QueriesMap(cat)
 	base.Headers = mergeHeaders(cat.Headers, runtime.Headers)
 	base.catalog = cat
 

--- a/internal/apiexec/apiexec.go
+++ b/internal/apiexec/apiexec.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/valon-technologies/gestalt/core"
 )
@@ -126,6 +127,100 @@ func Do(ctx context.Context, client *http.Client, req Request) (*core.OperationR
 	return &core.OperationResult{
 		Status: resp.StatusCode,
 		Body:   string(respBody),
+	}, nil
+}
+
+// GraphQLRequest describes a GraphQL API call.
+type GraphQLRequest struct {
+	URL           string
+	Query         string
+	Variables     map[string]any
+	Token         string
+	AuthHeader    string
+	CustomHeaders map[string]string
+}
+
+const (
+	graphqlBodyKeyQuery     = "query"
+	graphqlBodyKeyVariables = "variables"
+	graphqlRespKeyData      = "data"
+	graphqlRespKeyErrors    = "errors"
+)
+
+type graphqlError struct {
+	Message string `json:"message"`
+}
+
+// DoGraphQL executes a GraphQL operation. The query is sent as a JSON POST body
+// with the variables. If the response contains errors, they are returned as an error.
+func DoGraphQL(ctx context.Context, client *http.Client, req GraphQLRequest) (*core.OperationResult, error) {
+	payload := map[string]any{
+		graphqlBodyKeyQuery: req.Query,
+	}
+	if len(req.Variables) > 0 {
+		payload[graphqlBodyKeyVariables] = req.Variables
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling graphql body: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, req.URL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating graphql request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	if req.AuthHeader != "" {
+		httpReq.Header.Set("Authorization", req.AuthHeader)
+	} else if req.Token != "" {
+		httpReq.Header.Set("Authorization", core.BearerScheme+req.Token)
+	}
+
+	for k, v := range req.CustomHeaders {
+		httpReq.Header.Set(k, v)
+	}
+
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("executing graphql request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading graphql response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, respBody)
+	}
+
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, fmt.Errorf("parsing graphql response: %w", err)
+	}
+
+	if raw, ok := parsed[graphqlRespKeyErrors]; ok {
+		var gqlErrs []graphqlError
+		if err := json.Unmarshal(raw, &gqlErrs); err == nil && len(gqlErrs) > 0 {
+			msgs := make([]string, len(gqlErrs))
+			for i, e := range gqlErrs {
+				msgs[i] = e.Message
+			}
+			return nil, fmt.Errorf("graphql: %s", strings.Join(msgs, "; "))
+		}
+	}
+
+	resultBody := string(respBody)
+	if raw, ok := parsed[graphqlRespKeyData]; ok {
+		resultBody = string(raw)
+	}
+
+	return &core.OperationResult{
+		Status: resp.StatusCode,
+		Body:   resultBody,
 	}, nil
 }
 

--- a/internal/apiexec/apiexec_test.go
+++ b/internal/apiexec/apiexec_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/internal/testutil"
@@ -121,4 +122,188 @@ func TestDoUsesCustomAuthHeaderAndBodyOverride(t *testing.T) {
 	if resp["auth"] != "Token abc123" {
 		t.Fatalf("auth = %v, want Token abc123", resp["auth"])
 	}
+}
+
+func TestDoGraphQLBasicQuery(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body[graphqlBodyKeyQuery] != "{ viewer { login } }" {
+			t.Fatalf("query = %v, want { viewer { login } }", body[graphqlBodyKeyQuery])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"viewer":{"login":"test"}}}`))
+	}))
+	testutil.CloseOnCleanup(t, srv)
+
+	result, err := DoGraphQL(context.Background(), srv.Client(), GraphQLRequest{
+		URL:   srv.URL,
+		Query: "{ viewer { login } }",
+	})
+	if err != nil {
+		t.Fatalf("DoGraphQL: %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", result.Status)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &data); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	viewer := data["viewer"].(map[string]any)
+	if viewer["login"] != "test" {
+		t.Fatalf("login = %v, want test", viewer["login"])
+	}
+}
+
+func TestDoGraphQLWithVariables(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		vars, ok := body[graphqlBodyKeyVariables].(map[string]any)
+		if !ok {
+			t.Fatal("variables not present in request body")
+		}
+		if vars["first"] != float64(10) {
+			t.Fatalf("first = %v, want 10", vars["first"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"repos":[{"name":"toolshed"}]}}`))
+	}))
+	testutil.CloseOnCleanup(t, srv)
+
+	result, err := DoGraphQL(context.Background(), srv.Client(), GraphQLRequest{
+		URL:       srv.URL,
+		Query:     "query($first: Int) { repos(first: $first) { name } }",
+		Variables: map[string]any{"first": 10},
+	})
+	if err != nil {
+		t.Fatalf("DoGraphQL: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &data); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	repos := data["repos"].([]any)
+	if len(repos) != 1 {
+		t.Fatalf("repos len = %d, want 1", len(repos))
+	}
+}
+
+func TestDoGraphQLErrors(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"errors":[{"message":"Not found"}]}`))
+	}))
+	testutil.CloseOnCleanup(t, srv)
+
+	_, err := DoGraphQL(context.Background(), srv.Client(), GraphQLRequest{
+		URL:   srv.URL,
+		Query: "{ viewer { login } }",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "Not found") {
+		t.Fatalf("error = %v, want to contain 'Not found'", err)
+	}
+}
+
+func TestDoGraphQLPartialErrors(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"viewer":null},"errors":[{"message":"Forbidden field"}]}`))
+	}))
+	testutil.CloseOnCleanup(t, srv)
+
+	_, err := DoGraphQL(context.Background(), srv.Client(), GraphQLRequest{
+		URL:   srv.URL,
+		Query: "{ viewer { email } }",
+	})
+	if err == nil {
+		t.Fatal("expected error for partial errors response, got nil")
+	}
+	if !strings.Contains(err.Error(), "Forbidden field") {
+		t.Fatalf("error = %v, want to contain 'Forbidden field'", err)
+	}
+}
+
+func TestDoGraphQLAuthHeaders(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bearer token", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			auth := r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"auth":"` + auth + `"}}`))
+		}))
+		testutil.CloseOnCleanup(t, srv)
+
+		result, err := DoGraphQL(context.Background(), srv.Client(), GraphQLRequest{
+			URL:   srv.URL,
+			Query: "{ viewer { login } }",
+			Token: "gh-token",
+		})
+		if err != nil {
+			t.Fatalf("DoGraphQL: %v", err)
+		}
+
+		var data map[string]any
+		if err := json.Unmarshal([]byte(result.Body), &data); err != nil {
+			t.Fatalf("json.Unmarshal: %v", err)
+		}
+		if data["auth"] != "Bearer gh-token" {
+			t.Fatalf("auth = %v, want Bearer gh-token", data["auth"])
+		}
+	})
+
+	t.Run("custom auth header", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			auth := r.Header.Get("Authorization")
+			custom := r.Header.Get("X-Api-Key")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"auth":"` + auth + `","key":"` + custom + `"}}`))
+		}))
+		testutil.CloseOnCleanup(t, srv)
+
+		result, err := DoGraphQL(context.Background(), srv.Client(), GraphQLRequest{
+			URL:        srv.URL,
+			Query:      "{ viewer { login } }",
+			AuthHeader: "Token custom-val",
+			CustomHeaders: map[string]string{
+				"X-Api-Key": "key-123",
+			},
+		})
+		if err != nil {
+			t.Fatalf("DoGraphQL: %v", err)
+		}
+
+		var data map[string]any
+		if err := json.Unmarshal([]byte(result.Body), &data); err != nil {
+			t.Fatalf("json.Unmarshal: %v", err)
+		}
+		if data["auth"] != "Token custom-val" {
+			t.Fatalf("auth = %v, want Token custom-val", data["auth"])
+		}
+		if data["key"] != "key-123" {
+			t.Fatalf("key = %v, want key-123", data["key"])
+		}
+	})
 }

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -51,6 +51,7 @@ func Build(def *Definition, intg config.IntegrationDef) (core.Provider, error) {
 		HTTPClient:         client,
 		Operations:         ci.OperationsList(cat),
 		Endpoints:          endpoints,
+		Queries:            ci.QueriesMap(cat),
 		Headers:            def.Headers,
 	}
 

--- a/internal/provider/catalog_metadata.go
+++ b/internal/provider/catalog_metadata.go
@@ -26,6 +26,8 @@ func CatalogFromDefinition(def *Definition) *catalog.Catalog {
 			Method:      strings.ToUpper(opDef.Method),
 			Path:        opDef.Path,
 			Description: opDef.Description,
+			Transport:   opDef.Transport,
+			Query:       opDef.Query,
 		}
 		for _, p := range opDef.Parameters {
 			catOp.Parameters = append(catOp.Parameters, catalog.CatalogParameter{

--- a/internal/provider/definition.go
+++ b/internal/provider/definition.go
@@ -41,6 +41,8 @@ type OperationDef struct {
 	Method      string         `yaml:"method"`
 	Path        string         `yaml:"path"`
 	Parameters  []ParameterDef `yaml:"parameters"`
+	Query       string         `yaml:"query"`     // GraphQL query/mutation template
+	Transport   string         `yaml:"transport"` // "rest" (default) or "graphql"
 }
 
 type ParameterDef struct {


### PR DESCRIPTION
## Summary
- Add `DoGraphQL` function to `apiexec` for executing GraphQL operations with query/variables serialization, error extraction, and data-only body unwrapping
- Add `GraphQLRequest` type with auth header, custom headers, and bearer token support
- Extend `Base.Execute` to check a `Queries` map before falling back to REST `Endpoints`, enabling mixed REST/GraphQL providers
- Add `QueriesMap` and `transportGraphQL` constant to `catalog.go` for extracting GraphQL operations from catalogs
- Add `Query` and `Transport` fields to `OperationDef`, `CatalogOperation`, and wire them through `CatalogFromDefinition` and `Build`
- Skip GraphQL operations in `EndpointsMap` so they don't require method/path
- Default GraphQL operations to POST method in `OperationsList`

## Test plan
- [x] `TestDoGraphQLBasicQuery` - sends query, returns data-only body
- [x] `TestDoGraphQLWithVariables` - passes variables in request body
- [x] `TestDoGraphQLErrors` - returns error for GraphQL error responses
- [x] `TestDoGraphQLPartialErrors` - returns error when data + errors both present
- [x] `TestDoGraphQLAuthHeaders` - bearer token and custom auth header
- [x] `TestBaseExecuteRoutesGraphQLOperations` - dispatches to GraphQL when operation is in Queries map
- [x] `TestBaseExecuteGraphQLWithVariables` - passes params as GraphQL variables
- [x] `TestBaseExecuteGraphQLWithTokenParser` - token parser applies to GraphQL requests
- [x] `TestBaseExecuteGraphQLErrorsReturned` - GraphQL errors propagated through Execute
- [x] `TestBaseExecuteUnknownOperationFallsThrough` - unknown operation returns error
- [x] Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)