### PR TITLE
Make icon_file errors non-fatal during provider build

### DIFF
--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -182,9 +183,10 @@ func applyOverrides(def *Definition, intg config.IntegrationDef) error {
 	if intg.IconFile != "" {
 		data, err := os.ReadFile(intg.IconFile)
 		if err != nil {
-			return fmt.Errorf("reading icon_file %q: %w", intg.IconFile, err)
+			log.Printf("WARNING: could not read icon_file %q: %v", intg.IconFile, err)
+		} else {
+			def.IconSVG = strings.TrimSpace(string(data))
 		}
-		def.IconSVG = strings.TrimSpace(string(data))
 	}
 	if intg.Headers != nil {
 		def.Headers = intg.Headers

--- a/internal/provider/build_test.go
+++ b/internal/provider/build_test.go
@@ -341,9 +341,16 @@ func TestBuildIconFileMissing(t *testing.T) {
 		},
 	}
 
-	_, err := Build(def, config.IntegrationDef{IconFile: "/nonexistent/icon.svg"})
-	if err == nil {
-		t.Fatal("expected error for missing icon file")
+	prov, err := Build(def, config.IntegrationDef{IconFile: "/nonexistent/icon.svg"})
+	if err != nil {
+		t.Fatalf("Build should succeed with missing icon: %v", err)
+	}
+	cp, ok := prov.(core.CatalogProvider)
+	if !ok {
+		t.Fatal("expected CatalogProvider")
+	}
+	if cat := cp.Catalog(); cat != nil && cat.IconSVG != "" {
+		t.Errorf("expected empty IconSVG, got %q", cat.IconSVG)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Make `icon_file` read errors non-fatal in `applyOverrides()` so a missing icon does not silently skip the entire integration during bootstrap
- Update `TestBuildIconFileMissing` to expect success with empty `IconSVG`

Port of valon-technologies/toolshed counterpart.

## Test plan

- [x] `go test ./internal/provider/... ./internal/bootstrap/...` passes
- [ ] Verify integrations with missing icons still load and appear on /integrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)