### PR TITLE
Add integration connection status and disconnect support

### DIFF
--- a/core/testing/stubs.go
+++ b/core/testing/stubs.go
@@ -24,6 +24,8 @@ type StubDatastore struct {
 	FindOrCreateUserFn func(context.Context, string) (*core.User, error)
 	StoreTokenFn       func(context.Context, *core.IntegrationToken) error
 	TokenFn            func(context.Context, string, string, string) (*core.IntegrationToken, error)
+	ListTokensFn       func(context.Context, string) ([]*core.IntegrationToken, error)
+	DeleteTokenFn      func(context.Context, string) error
 	ValidateAPITokenFn func(context.Context, string) (*core.APIToken, error)
 }
 
@@ -59,10 +61,18 @@ func (s *StubDatastore) Token(ctx context.Context, userID, integration, instance
 	}
 	return nil, nil
 }
-func (s *StubDatastore) ListTokens(context.Context, string) ([]*core.IntegrationToken, error) {
+func (s *StubDatastore) ListTokens(ctx context.Context, userID string) ([]*core.IntegrationToken, error) {
+	if s.ListTokensFn != nil {
+		return s.ListTokensFn(ctx, userID)
+	}
 	return nil, nil
 }
-func (s *StubDatastore) DeleteToken(context.Context, string) error           { return nil }
+func (s *StubDatastore) DeleteToken(ctx context.Context, id string) error {
+	if s.DeleteTokenFn != nil {
+		return s.DeleteTokenFn(ctx, id)
+	}
+	return nil
+}
 func (s *StubDatastore) StoreAPIToken(context.Context, *core.APIToken) error { return nil }
 func (s *StubDatastore) ValidateAPIToken(ctx context.Context, hashedToken string) (*core.APIToken, error) {
 	if s.ValidateAPITokenFn != nil {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -53,9 +53,12 @@ type integrationInfo struct {
 	DisplayName string `json:"display_name,omitempty"`
 	Description string `json:"description,omitempty"`
 	IconSVG     string `json:"icon_svg,omitempty"`
+	Connected   bool   `json:"connected"`
 }
 
-func (s *Server) listIntegrations(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
+	connected := s.userConnectedIntegrations(r)
+
 	names := s.providers.List()
 	out := make([]integrationInfo, 0, len(names))
 	for _, name := range names {
@@ -67,6 +70,7 @@ func (s *Server) listIntegrations(w http.ResponseWriter, _ *http.Request) {
 			Name:        name,
 			DisplayName: prov.DisplayName(),
 			Description: prov.Description(),
+			Connected:   connected[name],
 		}
 		if cp, ok := prov.(core.CatalogProvider); ok {
 			if cat := cp.Catalog(); cat != nil {
@@ -76,6 +80,68 @@ func (s *Server) listIntegrations(w http.ResponseWriter, _ *http.Request) {
 		out = append(out, info)
 	}
 	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) userConnectedIntegrations(r *http.Request) map[string]bool {
+	user := UserFromContext(r.Context())
+	if user == nil || user.Email == "" {
+		return nil
+	}
+	userID := UserIDFromContext(r.Context())
+	if userID == "" {
+		dbUser, err := s.datastore.FindOrCreateUser(r.Context(), user.Email)
+		if err != nil || dbUser == nil || dbUser.ID == "" {
+			return nil
+		}
+		userID = dbUser.ID
+	}
+	tokens, err := s.datastore.ListTokens(r.Context(), userID)
+	if err != nil {
+		return nil
+	}
+	m := make(map[string]bool, len(tokens))
+	for _, tok := range tokens {
+		m[tok.Integration] = true
+	}
+	return m
+}
+
+func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
+	userID, ok := s.resolveUserID(w, r)
+	if !ok {
+		return
+	}
+
+	name := chi.URLParam(r, "name")
+	if _, ok := s.getProvider(w, name); !ok {
+		return
+	}
+
+	tokens, err := s.datastore.ListTokens(r.Context(), userID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list tokens")
+		return
+	}
+
+	var tokenID string
+	for _, tok := range tokens {
+		if tok.Integration == name {
+			tokenID = tok.ID
+			break
+		}
+	}
+
+	if tokenID == "" {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("no connection found for integration %q", name))
+		return
+	}
+
+	if err := s.datastore.DeleteToken(r.Context(), tokenID); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to disconnect integration")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "disconnected"})
 }
 
 func (s *Server) getProvider(w http.ResponseWriter, name string) (core.Provider, bool) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -112,6 +112,7 @@ func (s *Server) routes() {
 			r.Use(s.authMiddleware)
 
 			r.Get("/integrations", s.listIntegrations)
+			r.Delete("/integrations/{name}", s.disconnectIntegration)
 			r.Get("/integrations/{name}/operations", s.listOperations)
 			r.Get("/runtimes", s.listRuntimes)
 			r.Get("/bindings", s.listBindings)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -335,6 +335,138 @@ func TestListIntegrationsWithIcon(t *testing.T) {
 	}
 }
 
+func TestListIntegrations_ShowsConnectedStatus(t *testing.T) {
+	t.Parallel()
+
+	stub := &coretesting.StubIntegration{N: "slack", DN: "Slack"}
+	stub2 := &coretesting.StubIntegration{N: "github", DN: "GitHub"}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, stub, stub2)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, _ string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: "dev@example.com"}, nil
+			},
+			ListTokensFn: func(_ context.Context, userID string) ([]*core.IntegrationToken, error) {
+				if userID == "u1" {
+					return []*core.IntegrationToken{
+						{ID: "tok-1", UserID: "u1", Integration: "slack"},
+					}, nil
+				}
+				return nil, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var integrations []struct {
+		Name      string `json:"name"`
+		Connected bool   `json:"connected"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if len(integrations) != 2 {
+		t.Fatalf("expected 2 integrations, got %d", len(integrations))
+	}
+
+	connected := make(map[string]bool)
+	for _, i := range integrations {
+		connected[i.Name] = i.Connected
+	}
+	if !connected["slack"] {
+		t.Fatal("expected slack to be connected")
+	}
+	if connected["github"] {
+		t.Fatal("expected github to be disconnected")
+	}
+}
+
+func TestDisconnectIntegration(t *testing.T) {
+	t.Parallel()
+
+	stub := &coretesting.StubIntegration{N: "slack", DN: "Slack"}
+	var deletedID string
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, _ string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: "dev@example.com"}, nil
+			},
+			ListTokensFn: func(_ context.Context, _ string) ([]*core.IntegrationToken, error) {
+				return []*core.IntegrationToken{
+					{ID: "tok-1", UserID: "u1", Integration: "slack"},
+				}, nil
+			},
+			DeleteTokenFn: func(_ context.Context, id string) error {
+				deletedID = id
+				return nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/integrations/slack", nil)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if deletedID != "tok-1" {
+		t.Fatalf("expected token tok-1 to be deleted, got %q", deletedID)
+	}
+}
+
+func TestDisconnectIntegration_NotConnected(t *testing.T) {
+	t.Parallel()
+
+	stub := &coretesting.StubIntegration{N: "slack", DN: "Slack"}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, _ string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: "dev@example.com"}, nil
+			},
+			ListTokensFn: func(_ context.Context, _ string) ([]*core.IntegrationToken, error) {
+				return nil, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/integrations/slack", nil)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
 func TestListOperations(t *testing.T) {
 	t.Parallel()
 

--- a/web/e2e/fixtures.ts
+++ b/web/e2e/fixtures.ts
@@ -1,10 +1,25 @@
 import { test as base, expect, type Page, type Route } from "@playwright/test";
 import type { Integration, APIToken } from "../src/lib/api";
 
-export async function mockIntegrations(page: Page, integrations: Integration[]) {
+export async function mockIntegrations(
+  page: Page,
+  integrations: Integration[],
+  opts?: { onDisconnect?: (name: string) => void },
+) {
   await page.route("**/api/v1/integrations", (route: Route, request) => {
     if (request.method() === "GET") {
       route.fulfill({ json: integrations });
+    } else {
+      route.fallback();
+    }
+  });
+
+  await page.route("**/api/v1/integrations/*", (route: Route, request) => {
+    if (request.method() === "DELETE") {
+      const url = new URL(request.url());
+      const name = url.pathname.split("/").pop() || "";
+      opts?.onDisconnect?.(name);
+      route.fulfill({ json: { status: "disconnected" } });
     } else {
       route.fallback();
     }

--- a/web/e2e/integrations.spec.ts
+++ b/web/e2e/integrations.spec.ts
@@ -38,7 +38,7 @@ test.describe("Integrations", () => {
     await mockTokens(page, []);
 
     await page.goto("/integrations");
-    const connectButtons = page.getByRole("button", { name: "Connect" });
+    const connectButtons = page.getByRole("button", { name: "Connect", exact: true });
     await expect(connectButtons).toHaveCount(3);
   });
 
@@ -55,7 +55,7 @@ test.describe("Integrations", () => {
     ).toBeVisible();
   });
 
-  test("connected integration shows badge and hides Connect button", async ({
+  test("connected integration shows badge, Reconnect, and Disconnect", async ({
     authenticatedPage,
   }) => {
     const page = authenticatedPage;
@@ -68,7 +68,43 @@ test.describe("Integrations", () => {
     await expect(page.getByText("Slack")).toBeVisible();
     await expect(page.getByText("GitHub")).toBeVisible();
     await expect(page.getByText("Connected")).toBeVisible();
-    // Only the unconnected integration should have a Connect button.
-    await expect(page.getByRole("button", { name: "Connect" })).toHaveCount(1);
+    await expect(page.getByRole("button", { name: "Connect", exact: true })).toHaveCount(1);
+    await expect(page.getByRole("button", { name: "Reconnect", exact: true })).toHaveCount(1);
+    await expect(page.getByRole("button", { name: "Disconnect", exact: true })).toHaveCount(1);
+  });
+
+  test("disconnect calls API and refreshes list", async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage;
+    let disconnected = false;
+
+    const connectedList = [
+      { name: "slack", display_name: "Slack", description: "Messaging", connected: true },
+    ];
+    const disconnectedList = [
+      { name: "slack", display_name: "Slack", description: "Messaging", connected: false },
+    ];
+
+    await mockIntegrations(page, connectedList, {
+      onDisconnect: () => { disconnected = true; },
+    });
+
+    await page.goto("/integrations");
+    await expect(page.getByText("Connected")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Disconnect" })).toBeVisible();
+
+    // After disconnect, re-mock to return disconnected state
+    await page.route("**/api/v1/integrations", (route, request) => {
+      if (request.method() === "GET") {
+        route.fulfill({ json: disconnected ? disconnectedList : connectedList });
+      } else {
+        route.fallback();
+      }
+    });
+
+    await page.getByRole("button", { name: "Disconnect" }).click();
+    await expect(page.getByRole("button", { name: "Connect" })).toBeVisible();
+    await expect(page.getByText("Connected")).not.toBeVisible();
   });
 });

--- a/web/src/app/api/v1/integrations/[name]/route.ts
+++ b/web/src/app/api/v1/integrations/[name]/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { connectedIntegrations } from "../../_mock-state";
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ name: string }> },
+) {
+  const { name } = await params;
+  if (!connectedIntegrations.has(name)) {
+    return NextResponse.json(
+      { error: `no connection found for integration "${name}"` },
+      { status: 404 },
+    );
+  }
+  connectedIntegrations.delete(name);
+  return NextResponse.json({ status: "disconnected" });
+}

--- a/web/src/app/integrations/page.tsx
+++ b/web/src/app/integrations/page.tsx
@@ -54,6 +54,7 @@ export default function IntegrationsPage() {
                 <IntegrationCard
                   key={integration.name}
                   integration={integration}
+                  onDisconnected={loadIntegrations}
                 />
               ))}
             </div>

--- a/web/src/components/IntegrationCard.tsx
+++ b/web/src/components/IntegrationCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Integration, startIntegrationOAuth } from "@/lib/api";
+import { Integration, startIntegrationOAuth, disconnectIntegration } from "@/lib/api";
 import Button from "./Button";
 import { useMemo, useState } from "react";
 
@@ -47,10 +47,13 @@ function DefaultIcon() {
 
 export default function IntegrationCard({
   integration,
+  onDisconnected,
 }: {
   integration: Integration;
+  onDisconnected?: () => void;
 }) {
   const [loading, setLoading] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const safeIconSVG = useMemo(
     () => (integration.icon_svg ? sanitizeSVG(integration.icon_svg) : ""),
@@ -67,6 +70,19 @@ export default function IntegrationCard({
       setError(err instanceof Error ? err.message : "Failed to start OAuth");
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function handleDisconnect() {
+    setDisconnecting(true);
+    setError(null);
+    try {
+      await disconnectIntegration(integration.name);
+      onDisconnected?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to disconnect");
+    } finally {
+      setDisconnecting(false);
     }
   }
 
@@ -99,7 +115,16 @@ export default function IntegrationCard({
         )}
       </div>
       {error && <p className="mt-2 text-sm text-ember-500">{error}</p>}
-      {!integration.connected && (
+      {integration.connected ? (
+        <div className="mt-4 flex gap-2">
+          <Button onClick={handleConnect} disabled={loading}>
+            {loading ? "Connecting..." : "Reconnect"}
+          </Button>
+          <Button variant="danger" onClick={handleDisconnect} disabled={disconnecting}>
+            {disconnecting ? "Disconnecting..." : "Disconnect"}
+          </Button>
+        </div>
+      ) : (
         <div className="mt-4">
           <Button onClick={handleConnect} disabled={loading}>
             {loading ? "Connecting..." : "Connect"}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -114,6 +114,14 @@ export async function startIntegrationOAuth(
   });
 }
 
+export async function disconnectIntegration(
+  name: string,
+): Promise<void> {
+  await fetchAPI(`/api/v1/integrations/${encodeURIComponent(name)}`, {
+    method: "DELETE",
+  });
+}
+
 export async function getTokens(): Promise<APIToken[]> {
   return fetchAPI("/api/v1/tokens");
 }


### PR DESCRIPTION
## Summary

- Go backend `listIntegrations` now returns `connected: true/false` by checking the user's stored tokens in the datastore
- New `DELETE /api/v1/integrations/{name}` endpoint to disconnect integrations
- Frontend cards show Reconnect + Disconnect buttons when connected
- Disconnect refreshes the integration list so the UI updates immediately

## Test plan

- [x] Go tests: `TestListIntegrations_ShowsConnectedStatus`, `TestDisconnectIntegration`, `TestDisconnectIntegration_NotConnected`
- [x] Existing Go tests pass (backward-compatible: connection status is best-effort)
- [x] E2e: connected card shows badge, Reconnect, and Disconnect buttons
- [x] E2e: disconnect calls API and refreshes list to show Connect button
- [x] TypeScript types pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)