### PR TITLE
Fix GHCR tags and add Docker Hub publish

### DIFF
--- a/.github/workflows/publish-gestalt-server-image.yml
+++ b/.github/workflows/publish-gestalt-server-image.yml
@@ -29,8 +29,8 @@ jobs:
           file: Dockerfile
           push: true
           tags: |
-            ghcr.io/hughhan/gestalt:latest
-            ghcr.io/hughhan/gestalt:${{ github.sha }}
+            ghcr.io/valon-technologies/gestalt:latest
+            ghcr.io/valon-technologies/gestalt:${{ github.sha }}
             hughhan/gestalt:latest
             hughhan/gestalt:${{ github.sha }}
 
@@ -53,5 +53,5 @@ jobs:
           file: web/Dockerfile
           push: true
           tags: |
-            ghcr.io/hughhan/gestalt-web:latest
-            ghcr.io/hughhan/gestalt-web:${{ github.sha }}
+            ghcr.io/valon-technologies/gestalt-web:latest
+            ghcr.io/valon-technologies/gestalt-web:${{ github.sha }}


### PR DESCRIPTION
## Summary

- Restores GHCR tags to `valon-technologies/` namespace (accidentally changed to `hughhan/` in #13)
- Keeps Docker Hub tags as `hughhan/gestalt` for cross-repo access

## Test plan

- [ ] Merge and verify both GHCR and Docker Hub images are published

🤖 Generated with [Claude Code](https://claude.com/claude-code)