### PR TITLE
Return connected status for integrations and redirect after OAuth

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -461,10 +462,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]string{
-		"status":      "connected",
-		"integration": providerName,
-	})
+	http.Redirect(w, r, "/integrations?connected="+url.QueryEscape(providerName), http.StatusSeeOther)
 }
 
 type connectManualRequest struct {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -142,6 +142,11 @@ func TestAuthMiddleware_ValidSession(t *testing.T) {
 				return nil, fmt.Errorf("invalid token")
 			},
 		}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -220,6 +225,11 @@ func TestAuthMiddleware_DevMode(t *testing.T) {
 	t.Parallel()
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.DevMode = true
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -267,6 +277,7 @@ func TestListIntegrations(t *testing.T) {
 		Name        string `json:"name"`
 		DisplayName string `json:"display_name"`
 		Description string `json:"description"`
+		Connected   bool   `json:"connected"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
 		t.Fatalf("decoding: %v", err)
@@ -279,6 +290,56 @@ func TestListIntegrations(t *testing.T) {
 	}
 	if integrations[0].DisplayName != "Slack" {
 		t.Fatalf("expected display name Slack, got %q", integrations[0].DisplayName)
+	}
+	if integrations[0].Connected {
+		t.Fatal("expected connected=false when no tokens stored")
+	}
+}
+
+func TestListIntegrationsShowsConnected(t *testing.T) {
+	t.Parallel()
+
+	stub := &coretesting.StubIntegration{N: "slack", DN: "Slack", Desc: "Team messaging"}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			ListTokensFn: func(_ context.Context, userID string) ([]*core.IntegrationToken, error) {
+				return []*core.IntegrationToken{
+					{UserID: userID, Integration: "slack", Instance: "default", AccessToken: "tok"},
+				}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var integrations []struct {
+		Name      string `json:"name"`
+		Connected bool   `json:"connected"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if len(integrations) != 1 {
+		t.Fatalf("expected 1 integration, got %d", len(integrations))
+	}
+	if !integrations[0].Connected {
+		t.Fatal("expected connected=true when token exists")
 	}
 }
 
@@ -305,6 +366,11 @@ func TestListIntegrationsWithIcon(t *testing.T) {
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.DevMode = true
 		cfg.Providers = testutil.NewProviderRegistry(t, prov)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
 	})
 	defer ts.Close()
 
@@ -922,26 +988,24 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		t.Fatalf("decoding start response: %v", err)
 	}
 
+	noRedirect := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := noRedirect.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", resp.StatusCode)
 	}
-
-	var result map[string]string
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		t.Fatalf("decoding: %v", err)
-	}
-	if result["status"] != "connected" {
-		t.Fatalf("expected connected, got %q", result["status"])
-	}
-	if result["integration"] != "slack" {
-		t.Fatalf("expected integration slack, got %q", result["integration"])
+	loc := resp.Header.Get("Location")
+	if loc != "/integrations?connected=slack" {
+		t.Fatalf("expected redirect to /integrations?connected=slack, got %q", loc)
 	}
 	if stored == nil {
 		t.Fatal("expected token to be stored")
@@ -1274,15 +1338,20 @@ func TestIntegrationOAuthCallback_PKCEUsesVerifier(t *testing.T) {
 		t.Fatalf("decoding start response: %v", err)
 	}
 
+	noRedirect := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := noRedirect.Do(req)
 	if err != nil {
 		t.Fatalf("callback request: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", resp.StatusCode)
 	}
 	if stub.gotVerifier != stub.wantVerifier {
 		t.Fatalf("got verifier %q, want %q", stub.gotVerifier, stub.wantVerifier)

--- a/web/src/app/integrations/page.tsx
+++ b/web/src/app/integrations/page.tsx
@@ -1,15 +1,27 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { Suspense, useEffect, useState, useCallback } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
 import { getIntegrations, Integration } from "@/lib/api";
 import Nav from "@/components/Nav";
 import IntegrationCard from "@/components/IntegrationCard";
 import AuthGuard from "@/components/AuthGuard";
 
-export default function IntegrationsPage() {
+function IntegrationsContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
   const [integrations, setIntegrations] = useState<Integration[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  useEffect(() => {
+    const connected = searchParams.get("connected");
+    if (connected) {
+      setToast(`${connected} connected successfully.`);
+      router.replace("/integrations");
+    }
+  }, [searchParams, router]);
 
   const loadIntegrations = useCallback(() => {
     getIntegrations()
@@ -25,42 +37,63 @@ export default function IntegrationsPage() {
   }, [loadIntegrations]);
 
   return (
-    <AuthGuard>
-      <div className="min-h-screen">
-        <Nav />
-        <main className="mx-auto max-w-5xl px-6 py-8">
-          <h1 className="text-2xl font-heading font-bold text-stone-900">Integrations</h1>
-          <p className="mt-1 text-sm text-stone-500">
-            Browse and connect third-party services.
+    <div className="min-h-screen">
+      <Nav />
+      <main className="mx-auto max-w-5xl px-6 py-8">
+        {toast && (
+          <div className="mb-6 flex items-center justify-between rounded-lg border border-grove-200 bg-grove-50 px-4 py-3 text-sm text-grove-700">
+            <span>{toast}</span>
+            <button
+              onClick={() => setToast(null)}
+              className="ml-4 text-grove-400 hover:text-grove-600"
+              aria-label="Dismiss"
+            >
+              &times;
+            </button>
+          </div>
+        )}
+
+        <h1 className="text-2xl font-heading font-bold text-stone-900">Integrations</h1>
+        <p className="mt-1 text-sm text-stone-500">
+          Browse and connect third-party services.
+        </p>
+
+        {loading && (
+          <p className="mt-8 text-sm text-stone-400">Loading...</p>
+        )}
+
+        {error && (
+          <p className="mt-8 text-sm text-ember-500">{error}</p>
+        )}
+
+        {!loading && !error && integrations.length === 0 && (
+          <p className="mt-8 text-sm text-stone-400">
+            No integrations registered.
           </p>
+        )}
 
-          {loading && (
-            <p className="mt-8 text-sm text-stone-400">Loading...</p>
-          )}
+        {!loading && !error && integrations.length > 0 && (
+          <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {integrations.map((integration) => (
+              <IntegrationCard
+                key={integration.name}
+                integration={integration}
+                onDisconnected={loadIntegrations}
+              />
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
 
-          {error && (
-            <p className="mt-8 text-sm text-ember-500">{error}</p>
-          )}
-
-          {!loading && !error && integrations.length === 0 && (
-            <p className="mt-8 text-sm text-stone-400">
-              No integrations registered.
-            </p>
-          )}
-
-          {!loading && !error && integrations.length > 0 && (
-            <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {integrations.map((integration) => (
-                <IntegrationCard
-                  key={integration.name}
-                  integration={integration}
-                  onDisconnected={loadIntegrations}
-                />
-              ))}
-            </div>
-          )}
-        </main>
-      </div>
+export default function IntegrationsPage() {
+  return (
+    <AuthGuard>
+      <Suspense fallback={<div className="min-h-screen"><Nav /><main className="mx-auto max-w-5xl px-6 py-8"><p className="text-sm text-stone-400">Loading...</p></main></div>}>
+        <IntegrationsContent />
+      </Suspense>
     </AuthGuard>
   );
 }


### PR DESCRIPTION
## Summary
- The `GET /api/v1/integrations` endpoint now includes a `connected` boolean for each integration, determined by querying the user's stored tokens from the datastore
- The OAuth callback handler (`GET /api/v1/auth/callback`) redirects to `/integrations?connected={name}` instead of returning raw JSON, so the browser returns to the UI
- The integrations page reads the `?connected=` query param and shows a dismissible success toast

## Test plan
- [x] All existing Go tests pass (`go test ./...`)
- [x] New `TestListIntegrationsShowsConnected` verifies `connected: true` when a token exists
- [x] Updated `TestIntegrationOAuthCallback` verifies 303 redirect to `/integrations?connected=slack`
- [x] Frontend builds cleanly (`next build`)
- [ ] Manual: run `./web/dev.sh full`, connect an integration, verify card shows "Connected" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)