### PR TITLE
Truncate long integration descriptions to 2 lines

### DIFF
--- a/web/src/components/IntegrationCard.tsx
+++ b/web/src/components/IntegrationCard.tsx
@@ -102,7 +102,7 @@ export default function IntegrationCard({
               {integration.display_name || integration.name}
             </h3>
             {integration.description && (
-              <p className="mt-1 text-sm text-stone-500">
+              <p className="mt-1 line-clamp-2 text-sm text-stone-500">
                 {integration.description}
               </p>
             )}


### PR DESCRIPTION
## Summary

- Adds `line-clamp-2` to the description text in `IntegrationCard.tsx`
- Prevents OpenAPI specs with full API docs in `info.description` (like dbt Cloud) from rendering as a wall of text

## Test plan

- [ ] Verify dbt Cloud card no longer shows pages of text
- [ ] Verify short descriptions (like Slack, GitHub) still display normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)