### PR TITLE
Add request/response body size limits and sanitize errors

### DIFF
--- a/internal/apiexec/apiexec.go
+++ b/internal/apiexec/apiexec.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	defaultMaxRetries = 3
-	baseRetryDelay    = 1 * time.Second
+	defaultMaxRetries   = 3
+	baseRetryDelay      = 1 * time.Second
+	maxResponseBodySize = 50 << 20 // 50 MB
 )
 
 var retryableStatusCodes = map[int]bool{
@@ -185,7 +186,7 @@ func doOnce(
 	}
 
 	retryAfter := resp.Header.Get("Retry-After")
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
 	_ = resp.Body.Close()
 	if err != nil {
 		return nil, 0, "", false, fmt.Errorf("reading response: %w", err)
@@ -276,7 +277,7 @@ func DoGraphQL(ctx context.Context, client *http.Client, req GraphQLRequest) (*c
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
 	if err != nil {
 		return nil, fmt.Errorf("reading graphql response: %w", err)
 	}

--- a/internal/apiexec/apiexec_test.go
+++ b/internal/apiexec/apiexec_test.go
@@ -538,3 +538,41 @@ func TestNonRetryableErrorsNotRetried(t *testing.T) {
 		})
 	}
 }
+
+func TestResponseBodySizeLimit(t *testing.T) {
+	t.Parallel()
+
+	oversized := int64(maxResponseBodySize + 1024)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		buf := make([]byte, 32*1024)
+		var written int64
+		for written < oversized {
+			n := int64(len(buf))
+			if remaining := oversized - written; remaining < n {
+				n = remaining
+			}
+			nn, err := w.Write(buf[:n])
+			if err != nil {
+				return
+			}
+			written += int64(nn)
+		}
+	}))
+	testutil.CloseOnCleanup(t, srv)
+
+	result, err := Do(context.Background(), srv.Client(), Request{
+		Method:  http.MethodGet,
+		BaseURL: srv.URL,
+		Path:    "/large",
+		NoRetry: true,
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+
+	if got := int64(len(result.Body)); got != maxResponseBodySize {
+		t.Fatalf("response body size = %d, want %d (truncated at limit)", got, maxResponseBodySize)
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"time"
 
@@ -240,7 +241,8 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, core.ErrMCPOnly):
 			writeError(w, http.StatusBadRequest, "this integration is accessible only via MCP")
 		default:
-			writeError(w, http.StatusBadGateway, fmt.Sprintf("operation failed: %v", err))
+			log.Printf("operation %s/%s failed: %v", providerName, operationName, err)
+			writeError(w, http.StatusBadGateway, "operation failed")
 		}
 		return
 	}
@@ -315,7 +317,8 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 		identity, err = s.auth.HandleCallback(r.Context(), code)
 	}
 	if err != nil {
-		writeError(w, http.StatusUnauthorized, fmt.Sprintf("login failed: %v", err))
+		log.Printf("login callback failed: %v", err)
+		writeError(w, http.StatusUnauthorized, "login failed")
 		return
 	}
 
@@ -437,7 +440,8 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		tokenResp, err = oauthProv.ExchangeCode(r.Context(), code)
 	}
 	if err != nil {
-		writeError(w, http.StatusBadGateway, fmt.Sprintf("token exchange failed: %v", err))
+		log.Printf("token exchange failed for %s: %v", providerName, err)
+		writeError(w, http.StatusBadGateway, "token exchange failed")
 		return
 	}
 

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -37,6 +37,15 @@ func PrincipalFromContext(ctx context.Context) *principal.Principal {
 	return principal.FromContext(ctx)
 }
 
+func maxBodyMiddleware(limit int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.Body = http.MaxBytesReader(w, r.Body, limit)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if s.devMode {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -78,6 +78,7 @@ func New(cfg Config) (*Server, error) {
 
 func (s *Server) routes() {
 	r := s.router
+	r.Use(maxBodyMiddleware(1 << 20)) // 1 MB
 
 	r.Get("/health", s.healthCheck)
 	r.Get("/ready", s.readinessCheck)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -2837,5 +2838,102 @@ func TestMCPEndpoint_NotMountedWhenDisabled(t *testing.T) {
 
 	if resp.StatusCode != http.StatusNotFound && resp.StatusCode != http.StatusMethodNotAllowed {
 		t.Fatalf("expected 404/405 when MCP not enabled, got %d", resp.StatusCode)
+	}
+}
+
+func TestMaxBodySize(t *testing.T) {
+	t.Parallel()
+
+	fullStub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N: "test-int",
+			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		ops: []core.Operation{
+			{Name: "do_thing", Description: "Do a thing", Method: "POST"},
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, fullStub)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+				return &core.IntegrationToken{AccessToken: "tok"}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	largeBody := bytes.NewReader(bytes.Repeat([]byte("A"), (1<<20)+1))
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/test-int/do_thing", largeBody)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 400, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+func TestErrorSanitization(t *testing.T) {
+	t.Parallel()
+
+	sensitiveMsg := "secret-internal-db-password-leaked"
+	fullStub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N: "test-int",
+			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				return nil, fmt.Errorf("upstream broke: %s", sensitiveMsg)
+			},
+		},
+		ops: []core.Operation{
+			{Name: "do_thing", Description: "Do a thing", Method: "GET"},
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, fullStub)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+				return &core.IntegrationToken{AccessToken: "tok"}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/test-int/do_thing", nil)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(body), sensitiveMsg) {
+		t.Fatalf("response body contains sensitive error details: %s", body)
+	}
+
+	var errResp map[string]string
+	if err := json.Unmarshal(body, &errResp); err != nil {
+		t.Fatalf("decoding error response: %v", err)
+	}
+	if errResp["error"] != "operation failed" {
+		t.Fatalf("expected generic error message, got %q", errResp["error"])
 	}
 }


### PR DESCRIPTION
## Summary
- **Request body limit:** 1 MB `MaxBytesReader` middleware applied to all routes, preventing memory exhaustion from oversized payloads.
- **Response body limit:** 50 MB `LimitReader` cap on upstream API response reads in both REST and GraphQL execution paths.
- **Error sanitization:** Three handlers (`executeOperation`, `loginCallback`, `integrationOAuthCallback`) now log upstream errors server-side and return generic messages to clients.

## Test plan
- [ ] `go test ./...` passes
- [ ] Oversized POST body (>1MB) returns 400
- [ ] Error responses don't contain upstream error details
- [ ] Oversized upstream response is truncated at limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)