### PR TITLE
Use sessionStorage for tokens and add webhook trusted sources

### DIFF
--- a/plugins/bindings/webhook/webhook.go
+++ b/plugins/bindings/webhook/webhook.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
+	"net"
 	"net/http"
 
 	"github.com/valon-technologies/gestalt/core"
@@ -15,13 +17,14 @@ import (
 var _ core.Binding = (*Binding)(nil)
 
 type webhookConfig struct {
-	Path            string `yaml:"path"`
-	Provider        string `yaml:"provider"`
-	Operation       string `yaml:"operation"`
-	AuthMode        string `yaml:"auth_mode"`
-	SigningSecret   string `yaml:"signing_secret"`
-	SignatureHeader string `yaml:"signature_header"`
-	UserHeader      string `yaml:"user_header"`
+	Path            string   `yaml:"path"`
+	Provider        string   `yaml:"provider"`
+	Operation       string   `yaml:"operation"`
+	AuthMode        string   `yaml:"auth_mode"`
+	SigningSecret   string   `yaml:"signing_secret"`
+	SignatureHeader string   `yaml:"signature_header"`
+	UserHeader      string   `yaml:"user_header"`
+	TrustedSources  []string `yaml:"trusted_sources"`
 }
 
 type Binding struct {
@@ -31,6 +34,9 @@ type Binding struct {
 }
 
 func New(name string, cfg webhookConfig, invoker invocation.Invoker) *Binding {
+	if cfg.AuthMode == AuthModeTrustedUserHeader && len(cfg.TrustedSources) == 0 {
+		log.Printf("warning: webhook binding %q uses trusted_user_header auth without trusted_sources; any client can set the user header", name)
+	}
 	return &Binding{name: name, cfg: cfg, invoker: invoker}
 }
 
@@ -80,6 +86,24 @@ func (b *Binding) handle(w http.ResponseWriter, r *http.Request) {
 		}
 
 	case AuthModeTrustedUserHeader:
+		if len(b.cfg.TrustedSources) > 0 {
+			host, _, _ := net.SplitHostPort(r.RemoteAddr)
+			if host == "" {
+				host = r.RemoteAddr
+			}
+			remoteIP := net.ParseIP(host)
+			trusted := false
+			for _, src := range b.cfg.TrustedSources {
+				if srcIP := net.ParseIP(src); srcIP != nil && remoteIP != nil && srcIP.Equal(remoteIP) {
+					trusted = true
+					break
+				}
+			}
+			if !trusted {
+				writeError(w, http.StatusForbidden, "untrusted source")
+				return
+			}
+		}
 		userID = r.Header.Get(b.cfg.UserHeader)
 		if userID == "" {
 			writeError(w, http.StatusUnauthorized, "missing user header")

--- a/plugins/bindings/webhook/webhook_test.go
+++ b/plugins/bindings/webhook/webhook_test.go
@@ -542,6 +542,123 @@ func makeBindingWithAuth(t *testing.T, path, provider, operation, authMode, sign
 	return b
 }
 
+func makeBindingFromYAML(t *testing.T, cfgYAML string, invoker invocation.Invoker) core.Binding {
+	t.Helper()
+
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(cfgYAML), &node); err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed map[string]any
+	if err := yaml.Unmarshal([]byte(cfgYAML), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	def := config.BindingDef{Type: "webhook", Config: *node.Content[0]}
+	if p, ok := parsed["provider"].(string); ok && p != "" {
+		def.Providers = []string{p}
+	}
+
+	b, err := webhook.Factory(context.Background(), "test-webhook", def, bootstrap.BindingDeps{Invoker: invoker})
+	if err != nil {
+		t.Fatalf("Factory: %v", err)
+	}
+	return b
+}
+
+func TestTrustedUserHeader_UntrustedSource(t *testing.T) {
+	t.Parallel()
+
+	invoker := &testutil.StubInvoker{
+		Result: &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`},
+	}
+	cfgYAML := `
+path: /incoming
+provider: echo
+operation: echo
+auth_mode: trusted_user_header
+user_header: X-User-Email
+trusted_sources:
+  - "10.0.0.1"
+`
+	b := makeBindingFromYAML(t, cfgYAML, invoker)
+
+	payload := []byte(`{"data":"test"}`)
+	req := httptest.NewRequest(http.MethodPost, "/incoming", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-Email", "user@example.com")
+	w := httptest.NewRecorder()
+
+	b.Routes()[0].Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+	if invoker.Invoked {
+		t.Fatal("invoker should not be invoked for untrusted source")
+	}
+}
+
+func TestTrustedUserHeader_AllowedSource(t *testing.T) {
+	t.Parallel()
+
+	invoker := &testutil.StubInvoker{
+		Result: &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`},
+	}
+	cfgYAML := `
+path: /incoming
+provider: echo
+operation: echo
+auth_mode: trusted_user_header
+user_header: X-User-Email
+trusted_sources:
+  - "192.0.2.1"
+`
+	b := makeBindingFromYAML(t, cfgYAML, invoker)
+
+	payload := []byte(`{"data":"test"}`)
+	req := httptest.NewRequest(http.MethodPost, "/incoming", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-Email", "user@example.com")
+	w := httptest.NewRecorder()
+
+	b.Routes()[0].Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !invoker.Invoked {
+		t.Fatal("expected invoker to be invoked")
+	}
+	if invoker.LastP == nil || invoker.LastP.UserID != "user@example.com" {
+		t.Errorf("expected UserID user@example.com, got %v", invoker.LastP)
+	}
+}
+
+func TestTrustedUserHeader_NoAllowlist(t *testing.T) {
+	t.Parallel()
+
+	invoker := &testutil.StubInvoker{
+		Result: &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`},
+	}
+	b := makeBindingWithAuth(t, "/incoming", "echo", "echo", "trusted_user_header", "", "X-User-Email", "", invoker)
+
+	payload := []byte(`{"data":"test"}`)
+	req := httptest.NewRequest(http.MethodPost, "/incoming", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-Email", "user@example.com")
+	w := httptest.NewRecorder()
+
+	b.Routes()[0].Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !invoker.Invoked {
+		t.Fatal("expected invoker to be invoked")
+	}
+}
+
 func computeHMAC(secret, body []byte) string {
 	mac := hmac.New(sha256.New, secret)
 	mac.Write(body)

--- a/web/e2e/auth.spec.ts
+++ b/web/e2e/auth.spec.ts
@@ -42,8 +42,8 @@ test.describe("Authentication", () => {
   test("logout clears session and redirects to login", async ({ page }) => {
     await page.goto("/login");
     await page.evaluate(() => {
-      localStorage.setItem("session_token", "test-session-token");
-      localStorage.setItem("user_email", "test@gestalt.dev");
+      sessionStorage.setItem("session_token", "test-session-token");
+      sessionStorage.setItem("user_email", "test@gestalt.dev");
     });
     await mockIntegrations(page, []);
     await mockTokens(page, []);
@@ -51,7 +51,7 @@ test.describe("Authentication", () => {
     await page.goto("/");
     await page.getByRole("button", { name: /Logout/i }).click();
     await expect(page).toHaveURL(/\/login/);
-    const token = await page.evaluate(() => localStorage.getItem("session_token"));
+    const token = await page.evaluate(() => sessionStorage.getItem("session_token"));
     expect(token).toBeNull();
   });
 

--- a/web/e2e/fixtures.ts
+++ b/web/e2e/fixtures.ts
@@ -52,8 +52,8 @@ type CustomFixtures = {
 export const test = base.extend<CustomFixtures>({
   authenticatedPage: async ({ page }, use) => {
     await page.addInitScript(() => {
-      localStorage.setItem("session_token", "test-session-token");
-      localStorage.setItem("user_email", "test@gestalt.dev");
+      sessionStorage.setItem("session_token", "test-session-token");
+      sessionStorage.setItem("user_email", "test@gestalt.dev");
     });
     await use(page);
   },

--- a/web/e2e/integration.spec.ts
+++ b/web/e2e/integration.spec.ts
@@ -40,8 +40,8 @@ test.describe("Integration: Go server contract", () => {
   function injectAuth(page: import("@playwright/test").Page) {
     return page.addInitScript(
       ({ token }) => {
-        localStorage.setItem("session_token", token);
-        localStorage.setItem("user_email", "e2e@gestalt.dev");
+        sessionStorage.setItem("session_token", token);
+        sessionStorage.setItem("user_email", "e2e@gestalt.dev");
       },
       { token: authToken },
     );

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,14 +1,16 @@
+// TODO: migrate to httpOnly cookies set by the server.
+
 export function getSessionToken(): string | null {
-  return localStorage.getItem("session_token");
+  return sessionStorage.getItem("session_token");
 }
 
 export function setSessionToken(token: string): void {
-  localStorage.setItem("session_token", token);
+  sessionStorage.setItem("session_token", token);
 }
 
 export function clearSession(): void {
-  localStorage.removeItem("session_token");
-  localStorage.removeItem("user_email");
+  sessionStorage.removeItem("session_token");
+  sessionStorage.removeItem("user_email");
 }
 
 export function isAuthenticated(): boolean {
@@ -16,9 +18,9 @@ export function isAuthenticated(): boolean {
 }
 
 export function getUserEmail(): string | null {
-  return localStorage.getItem("user_email");
+  return sessionStorage.getItem("user_email");
 }
 
 export function setUserEmail(email: string): void {
-  localStorage.setItem("user_email", email);
+  sessionStorage.setItem("user_email", email);
 }


### PR DESCRIPTION
## Summary
- **sessionStorage:** Session tokens and user email moved from `localStorage` to `sessionStorage`, limiting XSS token persistence to the current browser tab. E2E test fixtures updated to match.
- **Webhook trusted sources:** `trusted_user_header` auth mode now supports an optional `trusted_sources` IP allowlist. Requests from unlisted IPs get 403. Backwards-compatible when unconfigured. Warning logged at startup if no allowlist is set.

## Test plan
- [ ] `go test ./...` passes
- [ ] Frontend E2E tests pass with sessionStorage
- [ ] Webhook: untrusted source returns 403
- [ ] Webhook: allowed source succeeds
- [ ] Webhook: no allowlist configured still works (backwards compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)