### PR TITLE
Support description override in integration config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,6 +77,8 @@ type ServerConfig struct {
 type IntegrationDef struct {
 	OpenAPI        string `yaml:"openapi"`
 	Provider       string `yaml:"provider"`
+	DisplayName    string `yaml:"display_name"`
+	Description    string `yaml:"description"`
 	AuthProfile    string `yaml:"auth_profile"`
 	ConnectionMode string `yaml:"connection_mode"`
 

--- a/internal/openapi/loader.go
+++ b/internal/openapi/loader.go
@@ -16,7 +16,10 @@ import (
 	"github.com/valon-technologies/gestalt/internal/provider"
 )
 
-const maxSpecSize = 100 << 20 // 100 MB
+const (
+	maxSpecSize       = 100 << 20 // 100 MB
+	maxDescriptionLen = 200
+)
 
 var defaultClient = &http.Client{Timeout: 30 * time.Second}
 
@@ -40,7 +43,7 @@ func LoadDefinition(ctx context.Context, name, specURL string, allowedOps map[st
 
 	if info := model.Model.Info; info != nil {
 		def.DisplayName = info.Title
-		def.Description = info.Description
+		def.Description = truncateDescription(info.Description)
 	}
 
 	if len(model.Model.Servers) > 0 {
@@ -282,4 +285,20 @@ func extractOperations(model *v3high.Document, def *provider.Definition, allowed
 			}
 		}
 	}
+}
+
+func truncateDescription(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = strings.TrimSpace(s[:i])
+	}
+	runes := []rune(s)
+	if len(runes) <= maxDescriptionLen {
+		return s
+	}
+	truncated := string(runes[:maxDescriptionLen])
+	if i := strings.LastIndexByte(truncated, ' '); i > len(truncated)/2 {
+		truncated = truncated[:i]
+	}
+	return truncated + "..."
 }

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -188,6 +188,8 @@ func Build(def *Definition, intg config.IntegrationDef) (core.Provider, error) {
 }
 
 func applyOverrides(def *Definition, intg config.IntegrationDef) error {
+	setStr(&def.DisplayName, intg.DisplayName)
+	setStr(&def.Description, intg.Description)
 	o := intg.Auth
 	setStr(&def.Auth.Type, o.Type)
 	setStr(&def.Auth.AuthorizationURL, o.AuthorizationURL)

--- a/web/src/components/IntegrationCard.tsx
+++ b/web/src/components/IntegrationCard.tsx
@@ -102,7 +102,7 @@ export default function IntegrationCard({
               {integration.display_name || integration.name}
             </h3>
             {integration.description && (
-              <p className="mt-1 text-sm text-stone-500">
+              <p className="mt-1 line-clamp-2 text-sm text-stone-500">
                 {integration.description}
               </p>
             )}


### PR DESCRIPTION
## Summary

- Adds `description` field to `IntegrationDef` in config
- Wires it through `applyOverrides` so config descriptions override OpenAPI-fetched ones
- Combined with `line-clamp-2` from PR #17, this fully solves verbose integration descriptions

## Test plan

- [ ] Tests pass
- [ ] Setting `description:` on an integration in config YAML overrides the OpenAPI description

🤖 Generated with [Claude Code](https://claude.com/claude-code)