### PR TITLE
Update CLI release infrastructure from toolshed to gestalt

### DIFF
--- a/.claude/skills/release-cli/SKILL.md
+++ b/.claude/skills/release-cli/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: release-cli
+description: "Release the gestalt CLI. Handles version bumping, tagging, and triggering the release pipeline. Triggers: release CLI, release gestalt, cut a release, tag a release, new CLI version."
+allowed-tools: Bash Read Edit Glob Grep
+---
+
+# Release Gestalt CLI
+
+Guide for releasing a new version of the gestalt CLI.
+
+## Prerequisites
+
+- All changes must be merged to `main`
+- The `valon-technologies/homebrew-gestalt` repo must exist (for Homebrew tap sync)
+- The `PAT_TOKEN` secret must be configured in the repo (for cross-repo formula sync)
+
+## How the Release Pipeline Works
+
+Pushing a `v*` tag to `main` triggers this automated chain:
+
+1. **Build** (`rust-build-matrix.yml`): Compiles for macOS ARM64/x86_64, Linux x86_64/ARM64, Windows x86_64
+2. **Release** (`release-gestalt-cli.yml`): Creates a GitHub Release with tar.gz/zip archives + SHA256 checksums
+3. **Update Formula** (`release-gestalt-cli.yml`): Checks out `main`, downloads SHA256 files from the release, updates `Formula/gestalt.rb` with real checksums and version, commits and pushes
+4. **Sync Homebrew** (`sync-homebrew-formula.yml`): Triggered by the formula commit on `main`, syncs `Formula/` to `valon-technologies/homebrew-gestalt`
+
+Tags containing `-alpha`, `-beta`, or `-rc` are marked as pre-releases on GitHub.
+
+## Release Steps
+
+### 1. Decide on a version
+
+The version lives in `client/Cargo.toml` (workspace version). Current versioning uses semver with optional pre-release suffixes.
+
+If bumping the version, update these files:
+- `client/Cargo.toml` — `[workspace.package] version`
+- `deploy/helm/gestalt/Chart.yaml` — `version` and `appVersion` (if keeping them in sync)
+
+### 2. Tag and push
+
+```bash
+# Make sure you're on main and up to date
+git checkout main
+git pull
+
+# Tag (use the version from Cargo.toml, prefixed with v)
+git tag v<VERSION>
+git push origin v<VERSION>
+```
+
+Example: `git tag v0.1.0 && git push origin v0.1.0`
+
+### 3. Verify
+
+- Check the Actions tab for the "Release Gestalt CLI" workflow
+- All 3 jobs should succeed: Build → Create Release → Update Homebrew Formula
+- The GitHub Release page should have 10 assets (5 platforms x 2 files each: archive + checksum)
+- A follow-up commit on `main` should update `Formula/gestalt.rb` with real SHA256 values
+- The "Sync Homebrew Formula" workflow should run after that commit
+
+### 4. Test installation
+
+```bash
+brew update
+brew install valon-technologies/gestalt/gestalt
+gestalt --version
+```
+
+## Troubleshooting
+
+- **Release workflow fails at "Update Homebrew Formula"**: Check that `PAT_TOKEN` secret is set and has repo access
+- **Sync workflow fails**: Check that `valon-technologies/homebrew-gestalt` repo exists and `PAT_TOKEN` can push to it
+- **`brew install` fails with SHA mismatch**: The formula update job may not have run yet — wait for the workflow to complete
+- **`brew install` fails with auth error**: User needs `gh auth login` or `HOMEBREW_GITHUB_API_TOKEN` set (private repo)

--- a/.github/workflows/release-gestalt-cli.yml
+++ b/.github/workflows/release-gestalt-cli.yml
@@ -45,3 +45,96 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
+
+  update-formula:
+    name: Update Homebrew Formula
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Download SHA256 files from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p checksums
+          gh release download "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" \
+            --pattern "*.sha256" \
+            --dir checksums
+
+      - name: Parse checksums
+        id: checksums
+        run: |
+          for platform in macos-arm64 macos-x86_64 linux-arm64 linux-x86_64; do
+            hash=$(awk '{print $1}' "checksums/gestalt-${platform}.tar.gz.sha256")
+            echo "${platform}=${hash}" >> "$GITHUB_OUTPUT"
+          done
+
+      - name: Update formula
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          SHA_MACOS_ARM64: ${{ steps.checksums.outputs.macos-arm64 }}
+          SHA_MACOS_X86: ${{ steps.checksums.outputs.macos-x86_64 }}
+          SHA_LINUX_ARM64: ${{ steps.checksums.outputs.linux-arm64 }}
+          SHA_LINUX_X86: ${{ steps.checksums.outputs.linux-x86_64 }}
+        run: |
+          FORMULA="Formula/gestalt.rb"
+          OLD_VERSION=$(grep '^\s*version ' "$FORMULA" | sed 's/.*version "\(.*\)"/\1/')
+
+          # Update version
+          sed -i "s/version \"${OLD_VERSION}\"/version \"${VERSION}\"/" "$FORMULA"
+
+          # Update download URLs (version appears in the URL path)
+          sed -i "s|/download/v${OLD_VERSION}/|/download/v${VERSION}/|g" "$FORMULA"
+
+          # Update SHA256 for each platform by matching the URL above it
+          awk -v sha_macos_arm64="$SHA_MACOS_ARM64" \
+              -v sha_macos_x86="$SHA_MACOS_X86" \
+              -v sha_linux_arm64="$SHA_LINUX_ARM64" \
+              -v sha_linux_x86="$SHA_LINUX_X86" \
+          '
+          /gestalt-macos-arm64\.tar\.gz/ { found="macos-arm64" }
+          /gestalt-macos-x86_64\.tar\.gz/ { found="macos-x86" }
+          /gestalt-linux-arm64\.tar\.gz/ { found="linux-arm64" }
+          /gestalt-linux-x86_64\.tar\.gz/ { found="linux-x86" }
+          /sha256 "/ {
+            if (found == "macos-arm64") { sub(/"[^"]*"/, "\"" sha_macos_arm64 "\"") }
+            if (found == "macos-x86") { sub(/"[^"]*"/, "\"" sha_macos_x86 "\"") }
+            if (found == "linux-arm64") { sub(/"[^"]*"/, "\"" sha_linux_arm64 "\"") }
+            if (found == "linux-x86") { sub(/"[^"]*"/, "\"" sha_linux_x86 "\"") }
+            found=""
+          }
+          { print }
+          ' "$FORMULA" > "${FORMULA}.tmp" && mv "${FORMULA}.tmp" "$FORMULA"
+
+      - name: Verify formula was updated
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          echo "=== Updated formula ==="
+          cat Formula/gestalt.rb
+          echo ""
+          echo "=== Verification ==="
+          grep -q "version \"${VERSION}\"" Formula/gestalt.rb || { echo "ERROR: version not updated"; exit 1; }
+          grep -q "PLACEHOLDER" Formula/gestalt.rb && { echo "ERROR: PLACEHOLDER still present"; exit 1; }
+          echo "Formula verified successfully"
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/gestalt.rb
+          git diff --cached --quiet && { echo "No formula changes to commit"; exit 0; }
+          git commit -m "Update gestalt formula to v${{ steps.version.outputs.version }}"
+          git push

--- a/.github/workflows/sync-homebrew-formula.yml
+++ b/.github/workflows/sync-homebrew-formula.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sync:
-    name: Sync to homebrew-toolshed
+    name: Sync to homebrew-gestalt
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -15,17 +15,17 @@ jobs:
       - name: Checkout gestalt
         uses: actions/checkout@v4
 
-      - name: Checkout homebrew-toolshed
+      - name: Checkout homebrew-gestalt
         uses: actions/checkout@v4
         with:
-          repository: valon-technologies/homebrew-toolshed
+          repository: valon-technologies/homebrew-gestalt
           token: ${{ secrets.PAT_TOKEN }}
-          path: homebrew-toolshed
+          path: homebrew-gestalt
 
       - name: Sync Formula directory
         run: |
-          rsync -av --delete Formula/ homebrew-toolshed/Formula/
-          cd homebrew-toolshed
+          rsync -av --delete Formula/ homebrew-gestalt/Formula/
+          cd homebrew-gestalt
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A

--- a/Formula/gestalt.rb
+++ b/Formula/gestalt.rb
@@ -2,21 +2,21 @@
 
 require_relative "lib/private_strategy"
 
-class Toolshed < Formula
-  desc "CLI for Toolshed API - authentication, integration management, and operation invocation"
+class Gestalt < Formula
+  desc "CLI for Gestalt API - authentication, integration management, and operation invocation"
   homepage "https://github.com/valon-technologies/gestalt"
   version "0.0.1-alpha.1"
   license "Proprietary"
 
   on_macos do
     on_arm do
-      url "https://github.com/valon-technologies/gestalt/releases/download/v0.0.1-alpha.1/tshed-macos-arm64.tar.gz",
+      url "https://github.com/valon-technologies/gestalt/releases/download/v0.0.1-alpha.1/gestalt-macos-arm64.tar.gz",
           using: GitHubPrivateRepositoryReleaseDownloadStrategy
       sha256 "PLACEHOLDER"
     end
 
     on_intel do
-      url "https://github.com/valon-technologies/gestalt/releases/download/v0.0.1-alpha.1/tshed-macos-x86_64.tar.gz",
+      url "https://github.com/valon-technologies/gestalt/releases/download/v0.0.1-alpha.1/gestalt-macos-x86_64.tar.gz",
           using: GitHubPrivateRepositoryReleaseDownloadStrategy
       sha256 "PLACEHOLDER"
     end
@@ -24,23 +24,23 @@ class Toolshed < Formula
 
   on_linux do
     on_arm do
-      url "https://github.com/valon-technologies/gestalt/releases/download/v0.0.1-alpha.1/tshed-linux-arm64.tar.gz",
+      url "https://github.com/valon-technologies/gestalt/releases/download/v0.0.1-alpha.1/gestalt-linux-arm64.tar.gz",
           using: GitHubPrivateRepositoryReleaseDownloadStrategy
       sha256 "PLACEHOLDER"
     end
 
     on_intel do
-      url "https://github.com/valon-technologies/gestalt/releases/download/v0.0.1-alpha.1/tshed-linux-x86_64.tar.gz",
+      url "https://github.com/valon-technologies/gestalt/releases/download/v0.0.1-alpha.1/gestalt-linux-x86_64.tar.gz",
           using: GitHubPrivateRepositoryReleaseDownloadStrategy
       sha256 "PLACEHOLDER"
     end
   end
 
   def install
-    bin.install "tshed"
+    bin.install "gestalt"
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/tshed --version")
+    assert_match version.to_s, shell_output("#{bin}/gestalt --version")
   end
 end


### PR DESCRIPTION
The Homebrew formula and sync workflow still referenced the old "toolshed" / "tshed" naming. This replaces Formula/toolshed.rb with Formula/gestalt.rb using the correct binary and artifact names, retargets the Homebrew sync workflow to valon-technologies/homebrew-gestalt, and adds an update-formula job to the release workflow that automatically updates the formula's SHA256 checksums and version after each release.