### PR TITLE
Redesign integration config around typed upstreams

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/composite"
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/mcpupstream"
 	"github.com/valon-technologies/gestalt/internal/openapi"
@@ -193,23 +194,80 @@ func closeProviders(providers *registry.PluginMap[core.Provider]) {
 
 func defaultProviderFactory(providerDirs []string) bootstrap.ProviderFactory {
 	return func(ctx context.Context, name string, intg config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
-		if intg.MCP != nil {
-			return mcpupstream.New(ctx, name, intg)
+		var apiProv core.Provider
+		var mcpUp *mcpupstream.Upstream
+		var mcpFromAPI bool
+
+		connMode := core.ConnectionModeUser
+		switch core.ConnectionMode(intg.ConnectionMode) {
+		case "", core.ConnectionModeNone, core.ConnectionModeUser, core.ConnectionModeIdentity, core.ConnectionModeEither:
+			if intg.ConnectionMode != "" {
+				connMode = core.ConnectionMode(intg.ConnectionMode)
+			}
+		default:
+			return nil, fmt.Errorf("integration %s: unknown connection_mode %q", name, intg.ConnectionMode)
 		}
-		def, err := loadDefinition(ctx, name, intg, providerDirs)
-		if err != nil {
-			return nil, err
+
+		cleanup := func() {
+			if mcpUp != nil {
+				_ = mcpUp.Close()
+			}
 		}
-		return provider.Build(def, intg)
+
+		for _, us := range intg.Upstreams {
+			switch us.Type {
+			case config.UpstreamTypeHTTP:
+				if apiProv != nil {
+					cleanup()
+					return nil, fmt.Errorf("integration %s: multiple http upstreams not supported", name)
+				}
+				def, err := loadHTTPUpstream(ctx, name, us, providerDirs)
+				if err != nil {
+					cleanup()
+					return nil, err
+				}
+				p, err := provider.Build(def, intg, us.AllowedOperations)
+				if err != nil {
+					cleanup()
+					return nil, err
+				}
+				apiProv = p
+				mcpFromAPI = us.MCP
+			case config.UpstreamTypeMCP:
+				if mcpUp != nil {
+					cleanup()
+					return nil, fmt.Errorf("integration %s: multiple mcp upstreams not supported", name)
+				}
+				up, err := mcpupstream.New(ctx, name, us.URL, connMode)
+				if err != nil {
+					return nil, err
+				}
+				mcpUp = up
+			default:
+				cleanup()
+				return nil, fmt.Errorf("integration %s: unknown upstream type %q", name, us.Type)
+			}
+		}
+
+		switch {
+		case apiProv != nil && mcpUp != nil:
+			return composite.New(name, apiProv, mcpUp, mcpFromAPI), nil
+		case apiProv != nil:
+			return apiProv, nil
+		case mcpUp != nil:
+			return mcpUp, nil
+		default:
+			return nil, fmt.Errorf("integration %s: no upstreams configured", name)
+		}
 	}
 }
 
-func loadDefinition(ctx context.Context, name string, intgDef config.IntegrationDef, providerDirs []string) (*provider.Definition, error) {
+func loadHTTPUpstream(ctx context.Context, name string, us config.UpstreamDef, providerDirs []string) (*provider.Definition, error) {
 	switch {
-	case intgDef.OpenAPI != "":
-		return openapi.LoadDefinition(ctx, name, intgDef.OpenAPI, intgDef.AllowedOperations)
-	case intgDef.Provider != "":
-		return provider.LoadFile(intgDef.Provider)
+	case us.URL != "":
+		return openapi.LoadDefinition(ctx, name, us.URL, us.AllowedOperations)
+	case us.Provider != "":
+		return provider.LoadFile(us.Provider)
 	default:
 		return provider.LoadFromDir(name, providerDirs)
 	}

--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -152,21 +152,15 @@ func runCheck(configFlag string) error {
 		log.Printf("integrations: %d", len(cfg.Integrations))
 		for name := range cfg.Integrations {
 			intg := cfg.Integrations[name]
-			source := "provider-dir"
-			if intg.OpenAPI != "" {
-				source = "openapi"
-			} else if intg.Provider != "" {
-				source = "provider-file"
+			var sources []string
+			for _, us := range intg.Upstreams {
+				sources = append(sources, us.Type)
 			}
 			auth := "oauth"
 			if intg.Auth.Type == "manual" || intg.ConnectionMode == "manual" {
 				auth = "manual"
 			}
-			ops := "all"
-			if len(intg.AllowedOperations) > 0 {
-				ops = fmt.Sprintf("%d allowed", len(intg.AllowedOperations))
-			}
-			log.Printf("  %s: source=%s auth=%s ops=%s", name, source, auth, ops)
+			log.Printf("  %s: upstreams=[%s] auth=%s", name, strings.Join(sources, ","), auth)
 		}
 	}
 

--- a/core/catalog/catalog.go
+++ b/core/catalog/catalog.go
@@ -8,6 +8,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	TransportMCPPassthrough = "mcp-passthrough"
+	TransportHTTP           = "http"
+)
+
 // Catalog is the normalized on-disk representation for a provider's tool
 // surface. It intentionally carries richer metadata than core.Operation so the
 // rest of Gestalt can derive runtime and MCP views from a single source.

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -258,7 +258,8 @@ func resolveStringFields(ptr any, resolve func(string) (string, error)) error {
 				}
 			}
 		case reflect.Slice:
-			if field.Type().Elem().Kind() == reflect.String {
+			switch field.Type().Elem().Kind() {
+			case reflect.String:
 				for j := 0; j < field.Len(); j++ {
 					elem := field.Index(j)
 					resolved, err := resolve(elem.String())
@@ -266,6 +267,12 @@ func resolveStringFields(ptr any, resolve func(string) (string, error)) error {
 						return err
 					}
 					elem.SetString(resolved)
+				}
+			case reflect.Struct:
+				for j := 0; j < field.Len(); j++ {
+					if err := resolveStringFields(field.Index(j).Addr().Interface(), resolve); err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/internal/composite/provider.go
+++ b/internal/composite/provider.go
@@ -1,0 +1,156 @@
+package composite
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
+
+type MCPUpstream interface {
+	core.CatalogProvider
+	CallTool(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error)
+	SupportsManualAuth() bool
+	Close() error
+}
+
+// Provider wraps an HTTP API provider and an MCP upstream for a single
+// integration. Execute goes to the API; CallTool goes to the upstream.
+type Provider struct {
+	name       string
+	api        core.Provider
+	mcp        MCPUpstream
+	mcpFromAPI bool
+	cat        *catalog.Catalog
+}
+
+var (
+	_ core.Provider        = (*Provider)(nil)
+	_ core.CatalogProvider = (*Provider)(nil)
+)
+
+// New creates a composite provider. If the API provider implements
+// OAuthProvider, the returned provider does too.
+func New(name string, apiProv core.Provider, mcpUp MCPUpstream, mcpFromAPI bool) core.Provider {
+	p := &Provider{
+		name:       name,
+		api:        apiProv,
+		mcp:        mcpUp,
+		mcpFromAPI: mcpFromAPI,
+	}
+	p.cat = p.buildCatalog()
+	if oauth, ok := apiProv.(core.OAuthProvider); ok {
+		return &oauthProvider{Provider: p, oauth: oauth}
+	}
+	return p
+}
+
+func (p *Provider) Name() string                        { return p.name }
+func (p *Provider) DisplayName() string                 { return p.api.DisplayName() }
+func (p *Provider) Description() string                 { return p.api.Description() }
+func (p *Provider) ConnectionMode() core.ConnectionMode { return p.api.ConnectionMode() }
+func (p *Provider) ListOperations() []core.Operation    { return p.api.ListOperations() }
+func (p *Provider) Catalog() *catalog.Catalog           { return p.cat }
+
+func (p *Provider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
+	return p.api.Execute(ctx, operation, params, token)
+}
+
+func (p *Provider) CallTool(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
+	return p.mcp.CallTool(ctx, name, args)
+}
+
+func (p *Provider) Inner() core.Provider { return p.api }
+
+// SupportsManualAuth delegates to the API provider only. The MCP
+// upstream's manual-auth support is irrelevant — the server uses this
+// to decide whether to block the OAuth connection flow.
+func (p *Provider) SupportsManualAuth() bool {
+	if mp, ok := p.api.(core.ManualProvider); ok {
+		return mp.SupportsManualAuth()
+	}
+	return false
+}
+
+func (p *Provider) Close() error {
+	var firstErr error
+	if err := p.mcp.Close(); err != nil {
+		firstErr = fmt.Errorf("closing mcp upstream: %w", err)
+	}
+	if c, ok := p.api.(interface{ Close() error }); ok {
+		if err := c.Close(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("closing api provider: %w", err)
+		}
+	}
+	return firstErr
+}
+
+// oauthProvider wraps a composite Provider and delegates OAuth methods
+// to the API provider, following the same pattern as restrictedOAuth.
+type oauthProvider struct {
+	*Provider
+	oauth core.OAuthProvider
+}
+
+func (o *oauthProvider) AuthorizationURL(state string, scopes []string) string {
+	return o.oauth.AuthorizationURL(state, scopes)
+}
+
+func (o *oauthProvider) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	return o.oauth.ExchangeCode(ctx, code)
+}
+
+func (o *oauthProvider) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	return o.oauth.RefreshToken(ctx, refreshToken)
+}
+
+func (p *Provider) buildCatalog() *catalog.Catalog {
+	mcpCat := p.mcp.Catalog()
+
+	if !p.mcpFromAPI {
+		return tagMCPCatalog(mcpCat)
+	}
+
+	var apiCat *catalog.Catalog
+	if cp, ok := p.api.(core.CatalogProvider); ok {
+		apiCat = cp.Catalog()
+	}
+	if apiCat == nil {
+		return tagMCPCatalog(mcpCat)
+	}
+
+	merged := &catalog.Catalog{
+		Name:        p.name,
+		DisplayName: mcpCat.DisplayName,
+		Description: mcpCat.Description,
+		Operations:  make([]catalog.CatalogOperation, 0, len(mcpCat.Operations)+len(apiCat.Operations)),
+	}
+	for i := range mcpCat.Operations {
+		op := mcpCat.Operations[i]
+		op.Transport = catalog.TransportMCPPassthrough
+		merged.Operations = append(merged.Operations, op)
+	}
+	for i := range apiCat.Operations {
+		op := apiCat.Operations[i]
+		op.Transport = catalog.TransportHTTP
+		merged.Operations = append(merged.Operations, op)
+	}
+	return merged
+}
+
+func tagMCPCatalog(src *catalog.Catalog) *catalog.Catalog {
+	out := &catalog.Catalog{
+		Name:        src.Name,
+		DisplayName: src.DisplayName,
+		Description: src.Description,
+		Operations:  make([]catalog.CatalogOperation, len(src.Operations)),
+	}
+	copy(out.Operations, src.Operations)
+	for i := range out.Operations {
+		out.Operations[i].Transport = catalog.TransportMCPPassthrough
+	}
+	return out
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,12 +75,11 @@ type ServerConfig struct {
 }
 
 type IntegrationDef struct {
-	OpenAPI        string `yaml:"openapi"`
-	Provider       string `yaml:"provider"`
-	DisplayName    string `yaml:"display_name"`
-	Description    string `yaml:"description"`
-	AuthProfile    string `yaml:"auth_profile"`
-	ConnectionMode string `yaml:"connection_mode"`
+	Upstreams      []UpstreamDef `yaml:"upstreams"`
+	DisplayName    string        `yaml:"display_name"`
+	Description    string        `yaml:"description"`
+	AuthProfile    string        `yaml:"auth_profile"`
+	ConnectionMode string        `yaml:"connection_mode"`
 
 	ClientID     string `yaml:"client_id"`
 	ClientSecret string `yaml:"client_secret"`
@@ -99,14 +98,19 @@ type IntegrationDef struct {
 	AuthStyle        string            `yaml:"auth_style"`
 	IconFile         string            `yaml:"icon_file"`
 	Headers          map[string]string `yaml:"headers"`
-
-	AllowedOperations map[string]string `yaml:"allowed_operations"`
-
-	MCP *MCPUpstreamDef `yaml:"mcp"`
 }
 
-type MCPUpstreamDef struct {
-	URL string `yaml:"url"`
+const (
+	UpstreamTypeHTTP = "http"
+	UpstreamTypeMCP  = "mcp"
+)
+
+type UpstreamDef struct {
+	Type              string            `yaml:"type"`
+	URL               string            `yaml:"url"`
+	Provider          string            `yaml:"provider"`
+	MCP               bool              `yaml:"mcp"`
+	AllowedOperations map[string]string `yaml:"allowed_operations"`
 }
 
 type AuthOverrides struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -44,7 +44,9 @@ integrations:
   alpha:
     client_id: key-1
   beta:
-    openapi: https://example.com/spec.json
+    upstreams:
+      - type: http
+        url: https://example.com/spec.json
     client_id: key-2
 server:
   port: 9090
@@ -74,8 +76,8 @@ server:
 	if cfg.Integrations["alpha"].ClientID != "key-1" {
 		t.Errorf("Integrations[alpha].ClientID: got %q, want %q", cfg.Integrations["alpha"].ClientID, "key-1")
 	}
-	if cfg.Integrations["beta"].OpenAPI != "https://example.com/spec.json" {
-		t.Errorf("Integrations[beta].OpenAPI: got %q", cfg.Integrations["beta"].OpenAPI)
+	if len(cfg.Integrations["beta"].Upstreams) != 1 || cfg.Integrations["beta"].Upstreams[0].URL != "https://example.com/spec.json" {
+		t.Errorf("Integrations[beta].Upstreams: got %+v", cfg.Integrations["beta"].Upstreams)
 	}
 }
 

--- a/internal/mcp/binding.go
+++ b/internal/mcp/binding.go
@@ -100,7 +100,7 @@ func addCatalogTools(srv *mcpserver.MCPServer, cfg Config, provName string, cat 
 		}
 
 		var handler mcpserver.ToolHandlerFunc
-		if isDirect {
+		if isDirect && op.Transport != catalog.TransportHTTP {
 			handler = makeDirectHandler(cfg, provName, op.ID, caller)
 		} else {
 			handler = makeHandler(cfg.Invoker, provName, op.ID)

--- a/internal/mcp/composite_test.go
+++ b/internal/mcp/composite_test.go
@@ -1,0 +1,233 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+	ci "github.com/valon-technologies/gestalt/core/integration"
+	coretesting "github.com/valon-technologies/gestalt/core/testing"
+	"github.com/valon-technologies/gestalt/internal/composite"
+	"github.com/valon-technologies/gestalt/internal/invocation"
+	gestaltmcp "github.com/valon-technologies/gestalt/internal/mcp"
+	"github.com/valon-technologies/gestalt/internal/testutil"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
+
+type stubMCPUpstream struct {
+	cat    *catalog.Catalog
+	callFn func(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error)
+}
+
+func (u *stubMCPUpstream) Catalog() *catalog.Catalog { return u.cat }
+func (u *stubMCPUpstream) SupportsManualAuth() bool  { return true }
+func (u *stubMCPUpstream) Close() error              { return nil }
+
+func (u *stubMCPUpstream) CallTool(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
+	if u.callFn != nil {
+		return u.callFn(ctx, name, args)
+	}
+	return mcpgo.NewToolResultText("direct:" + name), nil
+}
+
+func TestComposite_MCPPassthroughRouting(t *testing.T) {
+	t.Parallel()
+
+	var directCalled bool
+	var invokerCalled bool
+
+	apiCat := &catalog.Catalog{
+		Name: "notion",
+		Operations: []catalog.CatalogOperation{
+			{ID: "list_pages", Method: "GET", Path: "/pages", Description: "List pages"},
+		},
+	}
+	apiProv := &catalogProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N: "notion",
+			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				invokerCalled = true
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"from":"api"}`}, nil
+			},
+		},
+		ops:     ci.OperationsList(apiCat),
+		catalog: apiCat,
+	}
+
+	mcpUp := &stubMCPUpstream{
+		cat: &catalog.Catalog{
+			Name: "notion",
+			Operations: []catalog.CatalogOperation{
+				{ID: "search", Description: "Search Notion", InputSchema: json.RawMessage(`{"type":"object"}`)},
+			},
+		},
+		callFn: func(_ context.Context, _ string, _ map[string]any) (*mcpgo.CallToolResult, error) {
+			directCalled = true
+			return mcpgo.NewToolResultText("from-mcp"), nil
+		},
+	}
+
+	comp := composite.New("notion", apiProv, mcpUp, false)
+	providers := testutil.NewProviderRegistry(t, comp)
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker:       &testutil.StubInvoker{},
+		TokenResolver: &stubTokenResolver{token: "t"},
+		Providers:     providers,
+	})
+
+	tools := srv.ListTools()
+	if tools["notion_search"] == nil {
+		t.Fatal("expected notion_search tool from MCP upstream")
+	}
+	if tools["notion_list_pages"] != nil {
+		t.Fatal("API tool should not appear when mcpFromAPI=false")
+	}
+
+	tool := srv.GetTool("notion_search")
+	ctx := ctxWithPrincipal()
+	req := mcpgo.CallToolRequest{}
+	req.Params.Name = "notion_search"
+	req.Params.Arguments = map[string]any{"query": "hello"}
+	result, err := tool.Handler(ctx, req)
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+	if !directCalled {
+		t.Fatal("expected MCP upstream CallTool to be invoked")
+	}
+	if invokerCalled {
+		t.Fatal("API Execute should not have been called")
+	}
+}
+
+func TestComposite_MCPFromAPIExposesBothToolSets(t *testing.T) {
+	t.Parallel()
+
+	var directCalled string
+	var invokerCalled string
+
+	apiCat := &catalog.Catalog{
+		Name: "notion",
+		Operations: []catalog.CatalogOperation{
+			{ID: "list_pages", Method: "GET", Path: "/pages", Description: "List pages"},
+		},
+	}
+	apiProv := &catalogProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N: "notion",
+			ExecuteFn: func(_ context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				invokerCalled = op
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"from":"api"}`}, nil
+			},
+		},
+		ops:     ci.OperationsList(apiCat),
+		catalog: apiCat,
+	}
+
+	mcpUp := &stubMCPUpstream{
+		cat: &catalog.Catalog{
+			Name: "notion",
+			Operations: []catalog.CatalogOperation{
+				{ID: "search", Description: "Search Notion", InputSchema: json.RawMessage(`{"type":"object"}`)},
+			},
+		},
+		callFn: func(_ context.Context, name string, _ map[string]any) (*mcpgo.CallToolResult, error) {
+			directCalled = name
+			return mcpgo.NewToolResultText("from-mcp"), nil
+		},
+	}
+
+	comp := composite.New("notion", apiProv, mcpUp, true)
+	providers := testutil.NewProviderRegistry(t, comp)
+	ds := stubDatastoreWithToken()
+	broker := invocation.NewBroker(providers, ds)
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker:       broker,
+		TokenResolver: &stubTokenResolver{token: "t"},
+		Providers:     providers,
+	})
+
+	tools := srv.ListTools()
+	if tools["notion_search"] == nil {
+		t.Fatal("expected notion_search from MCP upstream")
+	}
+	if tools["notion_list_pages"] == nil {
+		t.Fatal("expected notion_list_pages from API (mcpFromAPI=true)")
+	}
+
+	ctx := ctxWithPrincipal()
+
+	mcpTool := srv.GetTool("notion_search")
+	req := mcpgo.CallToolRequest{}
+	req.Params.Name = "notion_search"
+	if _, err := mcpTool.Handler(ctx, req); err != nil {
+		t.Fatal(err)
+	}
+	if directCalled != "search" {
+		t.Fatalf("expected direct call to 'search', got %q", directCalled)
+	}
+
+	apiTool := srv.GetTool("notion_list_pages")
+	req2 := mcpgo.CallToolRequest{}
+	req2.Params.Name = "notion_list_pages"
+	result, err := apiTool.Handler(ctx, req2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error: %v", result.Content)
+	}
+	if invokerCalled != "list_pages" {
+		t.Fatalf("expected invoker to call 'list_pages', got %q", invokerCalled)
+	}
+}
+
+func TestComposite_ExecuteDelegatesToAPI(t *testing.T) {
+	t.Parallel()
+
+	apiCat := &catalog.Catalog{
+		Name: "notion",
+		Operations: []catalog.CatalogOperation{
+			{ID: "get_page", Method: "GET", Path: "/pages/{id}", Description: "Get page"},
+		},
+	}
+	var executedOp string
+	apiProv := &catalogProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N: "notion",
+			ExecuteFn: func(_ context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				executedOp = op
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"id":"page1"}`}, nil
+			},
+		},
+		ops:     ci.OperationsList(apiCat),
+		catalog: apiCat,
+	}
+
+	mcpUp := &stubMCPUpstream{
+		cat: &catalog.Catalog{
+			Name:       "notion",
+			Operations: []catalog.CatalogOperation{{ID: "search", Description: "Search"}},
+		},
+	}
+
+	comp := composite.New("notion", apiProv, mcpUp, false)
+
+	result, err := comp.Execute(context.Background(), "get_page", map[string]any{"id": "page1"}, "token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("status=%d", result.Status)
+	}
+	if executedOp != "get_page" {
+		t.Fatalf("expected execute on 'get_page', got %q", executedOp)
+	}
+}

--- a/internal/mcpupstream/upstream.go
+++ b/internal/mcpupstream/upstream.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
-	"github.com/valon-technologies/gestalt/internal/config"
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
@@ -33,12 +32,12 @@ type Upstream struct {
 	client   mcpclient.MCPClient
 }
 
-func New(ctx context.Context, name string, intg config.IntegrationDef) (*Upstream, error) {
-	if intg.MCP == nil || intg.MCP.URL == "" {
-		return nil, fmt.Errorf("mcpupstream %s: mcp.url is required", name)
+func New(ctx context.Context, name string, url string, connMode core.ConnectionMode) (*Upstream, error) {
+	if url == "" {
+		return nil, fmt.Errorf("mcpupstream %s: url is required", name)
 	}
 
-	client, err := mcpclient.NewStreamableHttpClient(intg.MCP.URL,
+	client, err := mcpclient.NewStreamableHttpClient(url,
 		transport.WithHTTPTimeout(httpTimeout),
 		transport.WithHTTPHeaderFunc(func(ctx context.Context) map[string]string {
 			if token := UpstreamTokenFromContext(ctx); token != "" {
@@ -72,15 +71,10 @@ func New(ctx context.Context, name string, intg config.IntegrationDef) (*Upstrea
 
 	cat, ops := buildCatalog(name, toolsResult.Tools)
 
-	connMode := core.ConnectionModeUser
-	if intg.ConnectionMode != "" {
-		connMode = core.ConnectionMode(intg.ConnectionMode)
-	}
-
 	return &Upstream{
 		name:     name,
 		display:  name,
-		desc:     fmt.Sprintf("MCP upstream: %s", intg.MCP.URL),
+		desc:     fmt.Sprintf("MCP upstream: %s", url),
 		connMode: connMode,
 		cat:      cat,
 		ops:      ops,

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -17,7 +17,7 @@ import (
 	"github.com/valon-technologies/gestalt/internal/oauth"
 )
 
-func Build(def *Definition, intg config.IntegrationDef) (core.Provider, error) {
+func Build(def *Definition, intg config.IntegrationDef, allowedOperations map[string]string) (core.Provider, error) {
 	d := *def // shallow copy so we don't mutate the caller's definition
 	def = &d
 	if err := applyOverrides(def, intg); err != nil {
@@ -152,7 +152,7 @@ func Build(def *Definition, intg config.IntegrationDef) (core.Provider, error) {
 
 	var result core.Provider = base
 
-	if ops := intg.AllowedOperations; ops != nil {
+	if ops := allowedOperations; ops != nil {
 		if len(ops) == 0 {
 			return nil, fmt.Errorf("%s: allowed_operations cannot be empty; omit the field to allow all", def.Provider)
 		}

--- a/internal/provider/build_test.go
+++ b/internal/provider/build_test.go
@@ -58,7 +58,7 @@ func TestBuild(t *testing.T) {
 	t.Parallel()
 
 	def := testDefinition("example")
-	intg, err := Build(def, testCreds())
+	intg, err := Build(def, testCreds(), nil)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestBuildManualAuth(t *testing.T) {
 			"list": {Description: "List", Method: "GET", Path: "/list"},
 		},
 	}
-	intg, err := Build(def, config.IntegrationDef{})
+	intg, err := Build(def, config.IntegrationDef{}, nil)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestBuildWithHooks(t *testing.T) {
 	def.ResponseCheck = "test_checker"
 	def.Auth.ResponseHook = "test_hook"
 
-	intg, err := Build(def, testCreds())
+	intg, err := Build(def, testCreds(), nil)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestBuildUnknownHook(t *testing.T) {
 	def := testDefinition("bad")
 	def.ResponseCheck = "nonexistent_hook"
 
-	_, err := Build(def, testCreds())
+	_, err := Build(def, testCreds(), nil)
 	if err == nil {
 		t.Fatal("expected error for unknown hook")
 	}
@@ -129,7 +129,7 @@ func TestBuildDoesNotMutateDefinition(t *testing.T) {
 	_, err := Build(def, config.IntegrationDef{
 		ClientID: "test",
 		Auth:     config.AuthOverrides{TokenURL: "https://override.example.com/token"},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -143,11 +143,10 @@ func TestBuildAllowedOperations(t *testing.T) {
 
 	def := testDefinition("filtered")
 	intg, err := Build(def, config.IntegrationDef{
-		ClientID:          "test",
-		ClientSecret:      "test",
-		RedirectURL:       "http://localhost/callback",
-		AllowedOperations: map[string]string{"list_items": ""},
-	})
+		ClientID:     "test",
+		ClientSecret: "test",
+		RedirectURL:  "http://localhost/callback",
+	}, map[string]string{"list_items": ""})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -160,9 +159,7 @@ func TestBuildAllowedOperationsUnknown(t *testing.T) {
 	t.Parallel()
 
 	def := testDefinition("bad")
-	_, err := Build(def, config.IntegrationDef{
-		AllowedOperations: map[string]string{"nonexistent": ""},
-	})
+	_, err := Build(def, config.IntegrationDef{}, map[string]string{"nonexistent": ""})
 	if err == nil {
 		t.Fatal("expected error for unknown allowed operation")
 	}
@@ -172,9 +169,7 @@ func TestBuildAllowedOperationsEmpty(t *testing.T) {
 	t.Parallel()
 
 	def := testDefinition("bad")
-	_, err := Build(def, config.IntegrationDef{
-		AllowedOperations: map[string]string{},
-	})
+	_, err := Build(def, config.IntegrationDef{}, map[string]string{})
 	if err == nil {
 		t.Fatal("expected error for empty allowed_operations")
 	}
@@ -185,7 +180,7 @@ func TestBuildUnknownAuthStyle(t *testing.T) {
 
 	def := testDefinition("bad")
 	def.AuthStyle = "bogus"
-	_, err := Build(def, testCreds())
+	_, err := Build(def, testCreds(), nil)
 	if err == nil {
 		t.Fatal("expected error for unknown auth_style")
 	}
@@ -254,7 +249,7 @@ func TestBuildSatisfiesCatalogProvider(t *testing.T) {
 		},
 	}
 
-	provider, err := Build(def, config.IntegrationDef{})
+	provider, err := Build(def, config.IntegrationDef{}, nil)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -314,7 +309,7 @@ func TestBuildAppliesIconFile(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.IntegrationDef{IconFile: iconPath})
+	prov, err := Build(def, config.IntegrationDef{IconFile: iconPath}, nil)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -345,7 +340,7 @@ func TestBuildIconFileMissing(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.IntegrationDef{IconFile: "/nonexistent/icon.svg"})
+	prov, err := Build(def, config.IntegrationDef{IconFile: "/nonexistent/icon.svg"}, nil)
 	if err != nil {
 		t.Fatalf("Build should succeed with missing icon: %v", err)
 	}
@@ -381,7 +376,7 @@ func TestBuildAuthHeader(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.IntegrationDef{})
+	prov, err := Build(def, config.IntegrationDef{}, nil)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -432,7 +427,7 @@ func TestBuildAuthMapping(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.IntegrationDef{})
+	prov, err := Build(def, config.IntegrationDef{}, nil)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -479,7 +474,7 @@ func TestBuildAuthMappingMissingField(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.IntegrationDef{})
+	prov, err := Build(def, config.IntegrationDef{}, nil)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -518,7 +513,7 @@ func TestBuildErrorMessagePath(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.IntegrationDef{})
+	prov, err := Build(def, config.IntegrationDef{}, nil)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -555,7 +550,7 @@ func TestBuildErrorMessagePathSuccessPassthrough(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.IntegrationDef{})
+	prov, err := Build(def, config.IntegrationDef{}, nil)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -596,7 +591,7 @@ func TestBuildConfigOverridesAuthHeader(t *testing.T) {
 		AuthHeader: "X-Override-Key",
 	}
 
-	prov, err := Build(def, intg)
+	prov, err := Build(def, intg, nil)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -359,7 +359,7 @@ func TestListIntegrationsWithIcon(t *testing.T) {
 			"op": {Description: "An op", Method: "GET", Path: "/op"},
 		},
 	}
-	prov, err := provider.Build(def, config.IntegrationDef{})
+	prov, err := provider.Build(def, config.IntegrationDef{}, nil)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Replace implicit priority chain (`mcp` > `openapi` > `provider` > `provider_dirs`) with explicit `upstreams` list on each integration, typed as `http` or `mcp`
- For http upstreams, `mcp: true` opts into generating MCP tools from the OpenAPI spec (default: false)
- Single integration can now combine both an HTTP API source (for REST/runtimes) and an MCP upstream (for native passthrough) via a composite provider
- Transport constants live in `core/catalog` so the binding routes each tool correctly without cross-layer imports

## Test plan
- [ ] `go test ./...` passes
- [ ] Functional tests cover: passthrough routing, dual tool sets (mcpFromAPI=true), and Execute delegation
- [ ] Test config with dual-source integration (http + mcp upstreams)
- [ ] Verify duplicate upstream types are rejected
- [ ] Update valon-tools config to new schema and verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)