### PR TITLE
Fix Connect button for manual auth integrations

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -56,6 +56,7 @@ type integrationInfo struct {
 	Description string `json:"description,omitempty"`
 	IconSVG     string `json:"icon_svg,omitempty"`
 	Connected   bool   `json:"connected"`
+	AuthType    string `json:"auth_type"`
 }
 
 func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
@@ -68,11 +69,16 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			continue
 		}
+		authType := "oauth"
+		if mp, ok := prov.(core.ManualProvider); ok && mp.SupportsManualAuth() {
+			authType = "manual"
+		}
 		info := integrationInfo{
 			Name:        name,
 			DisplayName: prov.DisplayName(),
 			Description: prov.Description(),
 			Connected:   connected[name],
+			AuthType:    authType,
 		}
 		if cp, ok := prov.(core.CatalogProvider); ok {
 			if cat := cp.Catalog(); cat != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -344,6 +344,59 @@ func TestListIntegrationsShowsConnected(t *testing.T) {
 	}
 }
 
+func TestListIntegrations_AuthType(t *testing.T) {
+	t.Parallel()
+
+	oauthStub := &coretesting.StubIntegration{N: "oauth-svc", DN: "OAuth Service"}
+	manualStub := &stubManualProvider{
+		StubIntegration: coretesting.StubIntegration{N: "manual-svc", DN: "Manual Service"},
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, oauthStub, manualStub)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var integrations []struct {
+		Name     string `json:"name"`
+		AuthType string `json:"auth_type"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if len(integrations) != 2 {
+		t.Fatalf("expected 2 integrations, got %d", len(integrations))
+	}
+
+	authTypes := make(map[string]string)
+	for _, i := range integrations {
+		authTypes[i.Name] = i.AuthType
+	}
+	if authTypes["manual-svc"] != "manual" {
+		t.Fatalf("expected manual-svc auth_type=manual, got %q", authTypes["manual-svc"])
+	}
+	if authTypes["oauth-svc"] != "oauth" {
+		t.Fatalf("expected oauth-svc auth_type=oauth, got %q", authTypes["oauth-svc"])
+	}
+}
+
 func TestListIntegrationsWithIcon(t *testing.T) {
 	t.Parallel()
 

--- a/web/e2e/fixtures.ts
+++ b/web/e2e/fixtures.ts
@@ -26,6 +26,21 @@ export async function mockIntegrations(
   });
 }
 
+export async function mockManualConnect(
+  page: Page,
+  opts?: { onConnect?: (integration: string, credential: string) => void },
+) {
+  await page.route("**/api/v1/auth/connect-manual", async (route: Route, request) => {
+    if (request.method() === "POST") {
+      const body = request.postDataJSON() as { integration: string; credential: string };
+      opts?.onConnect?.(body.integration, body.credential);
+      await route.fulfill({ json: { status: "connected" } });
+    } else {
+      await route.fallback();
+    }
+  });
+}
+
 export async function mockAuthInfo(
   page: Page,
   info: { provider: string; display_name: string },

--- a/web/e2e/integrations.spec.ts
+++ b/web/e2e/integrations.spec.ts
@@ -1,10 +1,18 @@
-import { test, expect, mockIntegrations, mockTokens } from "./fixtures";
+import { test, expect, mockIntegrations, mockManualConnect, mockTokens } from "./fixtures";
 import type { Integration } from "../src/lib/api";
 
+const OAUTH_INTEGRATION: Integration = {
+  name: "oauth-svc", display_name: "OAuth Service", description: "Example OAuth integration",
+};
+
+const MANUAL_INTEGRATION: Integration = {
+  name: "manual-svc", display_name: "Manual Service", description: "Example manual integration", auth_type: "manual",
+};
+
 const sampleIntegrations: Integration[] = [
-  { name: "slack", display_name: "Slack", description: "Team messaging" },
-  { name: "github", display_name: "GitHub", description: "Code hosting" },
-  { name: "jira", display_name: "Jira" },
+  OAUTH_INTEGRATION,
+  MANUAL_INTEGRATION,
+  { name: "another-svc", display_name: "Another Service" },
 ];
 
 test.describe("Integrations", () => {
@@ -17,9 +25,9 @@ test.describe("Integrations", () => {
     await expect(
       page.getByRole("heading", { name: "Integrations" }),
     ).toBeVisible();
-    await expect(page.getByText("Slack")).toBeVisible();
-    await expect(page.getByText("GitHub")).toBeVisible();
-    await expect(page.getByText("Jira")).toBeVisible();
+    await expect(page.getByText(OAUTH_INTEGRATION.display_name!)).toBeVisible();
+    await expect(page.getByText(MANUAL_INTEGRATION.display_name!)).toBeVisible();
+    await expect(page.getByText("Another Service")).toBeVisible();
   });
 
   test("shows descriptions on cards", async ({ authenticatedPage }) => {
@@ -28,8 +36,8 @@ test.describe("Integrations", () => {
     await mockTokens(page, []);
 
     await page.goto("/integrations");
-    await expect(page.getByText("Team messaging")).toBeVisible();
-    await expect(page.getByText("Code hosting")).toBeVisible();
+    await expect(page.getByText(OAUTH_INTEGRATION.description!)).toBeVisible();
+    await expect(page.getByText(MANUAL_INTEGRATION.description!)).toBeVisible();
   });
 
   test("each card has a Connect button", async ({ authenticatedPage }) => {
@@ -60,13 +68,13 @@ test.describe("Integrations", () => {
   }) => {
     const page = authenticatedPage;
     await mockIntegrations(page, [
-      { name: "slack", display_name: "Slack", description: "Messaging", connected: true },
-      { name: "github", display_name: "GitHub", description: "Code" },
+      { ...OAUTH_INTEGRATION, connected: true },
+      MANUAL_INTEGRATION,
     ]);
 
     await page.goto("/integrations");
-    await expect(page.getByText("Slack")).toBeVisible();
-    await expect(page.getByText("GitHub")).toBeVisible();
+    await expect(page.getByText(OAUTH_INTEGRATION.display_name!)).toBeVisible();
+    await expect(page.getByText(MANUAL_INTEGRATION.display_name!)).toBeVisible();
     await expect(page.getByText("Connected")).toBeVisible();
     await expect(page.getByRole("button", { name: "Connect", exact: true })).toHaveCount(1);
     await expect(page.getByRole("button", { name: "Reconnect", exact: true })).toHaveCount(1);
@@ -79,12 +87,8 @@ test.describe("Integrations", () => {
     const page = authenticatedPage;
     let disconnected = false;
 
-    const connectedList = [
-      { name: "slack", display_name: "Slack", description: "Messaging", connected: true },
-    ];
-    const disconnectedList = [
-      { name: "slack", display_name: "Slack", description: "Messaging", connected: false },
-    ];
+    const connectedList = [{ ...OAUTH_INTEGRATION, connected: true }];
+    const disconnectedList = [{ ...OAUTH_INTEGRATION, connected: false }];
 
     await mockIntegrations(page, connectedList, {
       onDisconnect: () => { disconnected = true; },
@@ -94,7 +98,6 @@ test.describe("Integrations", () => {
     await expect(page.getByText("Connected")).toBeVisible();
     await expect(page.getByRole("button", { name: "Disconnect" })).toBeVisible();
 
-    // After disconnect, re-mock to return disconnected state
     await page.route("**/api/v1/integrations", (route, request) => {
       if (request.method() === "GET") {
         route.fulfill({ json: disconnected ? disconnectedList : connectedList });
@@ -106,5 +109,79 @@ test.describe("Integrations", () => {
     await page.getByRole("button", { name: "Disconnect" }).click();
     await expect(page.getByRole("button", { name: "Connect" })).toBeVisible();
     await expect(page.getByText("Connected")).not.toBeVisible();
+  });
+
+  test("manual auth shows token input on Connect click", async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage;
+    await mockIntegrations(page, [MANUAL_INTEGRATION]);
+
+    await page.goto("/integrations");
+    await page.getByRole("button", { name: "Connect" }).click();
+    await expect(page.getByLabel("API Token")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Submit" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Cancel" })).toBeVisible();
+  });
+
+  test("manual auth submits credential and refreshes", async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage;
+    let connected = false;
+    let receivedCredential = "";
+
+    const disconnectedList: Integration[] = [MANUAL_INTEGRATION];
+    const connectedList: Integration[] = [{ ...MANUAL_INTEGRATION, connected: true }];
+
+    await mockIntegrations(page, disconnectedList);
+    await mockManualConnect(page, {
+      onConnect: (_name, cred) => {
+        connected = true;
+        receivedCredential = cred;
+      },
+    });
+
+    await page.goto("/integrations");
+    await page.getByRole("button", { name: "Connect" }).click();
+    await page.getByLabel("API Token").fill("test-api-key-123");
+
+    await page.route("**/api/v1/integrations", (route, request) => {
+      if (request.method() === "GET") {
+        route.fulfill({ json: connected ? connectedList : disconnectedList });
+      } else {
+        route.fallback();
+      }
+    });
+
+    await page.getByRole("button", { name: "Submit" }).click();
+    await expect(page.getByText("Connected")).toBeVisible();
+    expect(receivedCredential).toBe("test-api-key-123");
+  });
+
+  test("manual auth Cancel hides the form", async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage;
+    await mockIntegrations(page, [MANUAL_INTEGRATION]);
+
+    await page.goto("/integrations");
+    await page.getByRole("button", { name: "Connect" }).click();
+    await expect(page.getByLabel("API Token")).toBeVisible();
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(page.getByLabel("API Token")).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "Connect" })).toBeVisible();
+  });
+
+  test("manual auth reconnect opens token form", async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage;
+    await mockIntegrations(page, [{ ...MANUAL_INTEGRATION, connected: true }]);
+
+    await page.goto("/integrations");
+    await expect(page.getByText("Connected")).toBeVisible();
+    await page.getByRole("button", { name: "Reconnect" }).click();
+    await expect(page.getByLabel("API Token")).toBeVisible();
   });
 });

--- a/web/src/app/api/v1/auth/connect-manual/route.ts
+++ b/web/src/app/api/v1/auth/connect-manual/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { connectedIntegrations } from "../../_mock-state";
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const { integration, credential } = body;
+  if (!integration || !credential) {
+    return NextResponse.json(
+      { error: "integration and credential are required" },
+      { status: 400 },
+    );
+  }
+  connectedIntegrations.add(integration);
+  return NextResponse.json({ status: "connected" });
+}

--- a/web/src/app/api/v1/integrations/route.ts
+++ b/web/src/app/api/v1/integrations/route.ts
@@ -2,9 +2,9 @@ import { NextResponse } from "next/server";
 import { connectedIntegrations } from "../_mock-state";
 
 const mockIntegrations = [
-  { name: "acme_crm", display_name: "Acme CRM", description: "Example CRM integration" },
-  { name: "test_analytics", display_name: "Test Analytics", description: "Example analytics integration" },
-  { name: "sample_storage", display_name: "Sample Storage", description: "Example storage integration" },
+  { name: "acme_crm", display_name: "Acme CRM", description: "Example CRM integration", auth_type: "oauth" },
+  { name: "test_analytics", display_name: "Test Analytics", description: "Example analytics integration", auth_type: "manual" },
+  { name: "sample_storage", display_name: "Sample Storage", description: "Example storage integration", auth_type: "oauth" },
 ];
 
 export async function GET() {

--- a/web/src/app/integrations/page.tsx
+++ b/web/src/app/integrations/page.tsx
@@ -78,6 +78,7 @@ function IntegrationsContent() {
               <IntegrationCard
                 key={integration.name}
                 integration={integration}
+                onConnected={loadIntegrations}
                 onDisconnected={loadIntegrations}
               />
             ))}

--- a/web/src/components/IntegrationCard.tsx
+++ b/web/src/components/IntegrationCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Integration, startIntegrationOAuth, disconnectIntegration } from "@/lib/api";
+import { Integration, startIntegrationOAuth, connectManualIntegration, disconnectIntegration } from "@/lib/api";
 import Button from "./Button";
 import { useMemo, useState } from "react";
 
@@ -47,20 +47,32 @@ function DefaultIcon() {
 
 export default function IntegrationCard({
   integration,
+  onConnected,
   onDisconnected,
 }: {
   integration: Integration;
+  onConnected?: () => void;
   onDisconnected?: () => void;
 }) {
   const [loading, setLoading] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showTokenForm, setShowTokenForm] = useState(false);
+  const [credential, setCredential] = useState("");
+  const [submitting, setSubmitting] = useState(false);
   const safeIconSVG = useMemo(
     () => (integration.icon_svg ? sanitizeSVG(integration.icon_svg) : ""),
     [integration.icon_svg],
   );
 
+  const isManual = integration.auth_type === "manual";
+
   async function handleConnect() {
+    if (isManual) {
+      setShowTokenForm(true);
+      setError(null);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -71,6 +83,29 @@ export default function IntegrationCard({
     } finally {
       setLoading(false);
     }
+  }
+
+  async function handleSubmitManual(e: React.FormEvent) {
+    e.preventDefault();
+    if (!credential.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await connectManualIntegration(integration.name, credential.trim());
+      setShowTokenForm(false);
+      setCredential("");
+      onConnected?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to connect");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function handleCancelManual() {
+    setShowTokenForm(false);
+    setCredential("");
+    setError(null);
   }
 
   async function handleDisconnect() {
@@ -115,21 +150,47 @@ export default function IntegrationCard({
         )}
       </div>
       {error && <p className="mt-2 text-sm text-ember-500">{error}</p>}
-      {integration.connected ? (
-        <div className="mt-4 flex gap-2">
-          <Button onClick={handleConnect} disabled={loading}>
-            {loading ? "Connecting..." : "Reconnect"}
-          </Button>
-          <Button variant="danger" onClick={handleDisconnect} disabled={disconnecting}>
-            {disconnecting ? "Disconnecting..." : "Disconnect"}
-          </Button>
-        </div>
-      ) : (
-        <div className="mt-4">
-          <Button onClick={handleConnect} disabled={loading}>
-            {loading ? "Connecting..." : "Connect"}
-          </Button>
-        </div>
+      {showTokenForm && (
+        <form onSubmit={handleSubmitManual} className="mt-3">
+          <label htmlFor={`credential-${integration.name}`} className="block text-sm font-medium text-stone-700">
+            API Token
+          </label>
+          <input
+            id={`credential-${integration.name}`}
+            type="password"
+            value={credential}
+            onChange={(e) => setCredential(e.target.value)}
+            placeholder="Paste your API token"
+            autoFocus
+            className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
+          />
+          <div className="mt-2 flex gap-2">
+            <Button type="submit" disabled={submitting || !credential.trim()}>
+              {submitting ? "Connecting..." : "Submit"}
+            </Button>
+            <Button type="button" variant="secondary" onClick={handleCancelManual} disabled={submitting}>
+              Cancel
+            </Button>
+          </div>
+        </form>
+      )}
+      {!showTokenForm && (
+        integration.connected ? (
+          <div className="mt-4 flex gap-2">
+            <Button onClick={handleConnect} disabled={loading}>
+              {loading ? "Connecting..." : "Reconnect"}
+            </Button>
+            <Button variant="danger" onClick={handleDisconnect} disabled={disconnecting}>
+              {disconnecting ? "Disconnecting..." : "Disconnect"}
+            </Button>
+          </div>
+        ) : (
+          <div className="mt-4">
+            <Button onClick={handleConnect} disabled={loading}>
+              {loading ? "Connecting..." : "Connect"}
+            </Button>
+          </div>
+        )
       )}
     </div>
   );

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -7,6 +7,7 @@ export interface Integration {
   description?: string;
   icon_svg?: string;
   connected?: boolean;
+  auth_type?: "oauth" | "manual";
 }
 
 export interface APIToken {
@@ -111,6 +112,16 @@ export async function startIntegrationOAuth(
   return fetchAPI("/api/v1/auth/start-oauth", {
     method: "POST",
     body: JSON.stringify({ integration, scopes: scopes || [] }),
+  });
+}
+
+export async function connectManualIntegration(
+  integration: string,
+  credential: string,
+): Promise<{ status: string }> {
+  return fetchAPI("/api/v1/auth/connect-manual", {
+    method: "POST",
+    body: JSON.stringify({ integration, credential }),
   });
 }
 


### PR DESCRIPTION
## Summary
- The frontend Connect button always started an OAuth flow, which returned a 400 error for integrations using manual token auth (GitHub, LaunchDarkly, Hex, etc.)
- Adds `auth_type` field to the `GET /api/v1/integrations` response so the frontend knows whether to use OAuth or manual token entry
- For manual auth integrations, clicking Connect now shows an inline password input where users can paste their API token, which submits to the existing `POST /api/v1/auth/connect-manual` endpoint

## Test plan
- [x] Backend: `go test ./internal/server/ -run TestListIntegrations` — all pass including new `TestListIntegrations_AuthType`
- [x] Frontend: `npx playwright test e2e/integrations.spec.ts` — all 10 tests pass including 4 new manual auth tests
- [ ] Manual: visit `/integrations`, verify manual auth integration shows token form on Connect click, submits successfully, and shows Connected badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)