### PR TITLE
Add integration settings modal with disconnect flow

### DIFF
--- a/web/e2e/integrations.spec.ts
+++ b/web/e2e/integrations.spec.ts
@@ -63,7 +63,7 @@ test.describe("Integrations", () => {
     ).toBeVisible();
   });
 
-  test("connected integration shows badge, Reconnect, and Disconnect", async ({
+  test("connected integration shows check icon and settings gear", async ({
     authenticatedPage,
   }) => {
     const page = authenticatedPage;
@@ -75,10 +75,83 @@ test.describe("Integrations", () => {
     await page.goto("/integrations");
     await expect(page.getByText(OAUTH_INTEGRATION.display_name!)).toBeVisible();
     await expect(page.getByText(MANUAL_INTEGRATION.display_name!)).toBeVisible();
-    await expect(page.getByText("Connected")).toBeVisible();
+    await expect(page.getByRole("button", { name: "OAuth Service settings" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Connect", exact: true })).toHaveCount(1);
-    await expect(page.getByRole("button", { name: "Reconnect", exact: true })).toHaveCount(1);
-    await expect(page.getByRole("button", { name: "Disconnect", exact: true })).toHaveCount(1);
+    await expect(page.getByRole("button", { name: "Reconnect", exact: true })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Disconnect", exact: true })).toHaveCount(0);
+  });
+
+  test("settings modal opens and shows connected status", async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage;
+    await mockIntegrations(page, [
+      { ...OAUTH_INTEGRATION, connected: true },
+    ]);
+
+    await page.goto("/integrations");
+    await page.getByRole("button", { name: "OAuth Service settings" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText("OAuth Service")).toBeVisible();
+    await expect(dialog.getByText("Connected")).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Reconnect" })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Disconnect" })).toBeVisible();
+  });
+
+  test("settings modal closes on backdrop click", async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage;
+    await mockIntegrations(page, [
+      { ...OAUTH_INTEGRATION, connected: true },
+    ]);
+
+    await page.goto("/integrations");
+    await page.getByRole("button", { name: "OAuth Service settings" }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    // Click outside the centered modal panel
+    await page.mouse.click(10, 10);
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+  });
+
+  test("settings modal closes on ESC", async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage;
+    await mockIntegrations(page, [
+      { ...OAUTH_INTEGRATION, connected: true },
+    ]);
+
+    await page.goto("/integrations");
+    await page.getByRole("button", { name: "OAuth Service settings" }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+  });
+
+  test("disconnect confirmation shows warning and allows cancel", async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage;
+    await mockIntegrations(page, [
+      { ...OAUTH_INTEGRATION, connected: true },
+    ]);
+
+    await page.goto("/integrations");
+    await page.getByRole("button", { name: "OAuth Service settings" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await dialog.getByRole("button", { name: "Disconnect" }).click();
+
+    await expect(dialog.getByText("Disconnect OAuth Service?")).toBeVisible();
+    await expect(dialog.getByText("This will remove your OAuth Service integration.")).toBeVisible();
+
+    await dialog.getByRole("button", { name: "Cancel" }).click();
+    await expect(dialog.getByRole("button", { name: "Reconnect" })).toBeVisible();
   });
 
   test("disconnect calls API and refreshes list", async ({
@@ -95,9 +168,9 @@ test.describe("Integrations", () => {
     });
 
     await page.goto("/integrations");
-    await expect(page.getByText("Connected")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Disconnect" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "OAuth Service settings" })).toBeVisible();
 
+    // Re-mock so GET returns disconnected state after DELETE fires
     await page.route("**/api/v1/integrations", (route, request) => {
       if (request.method() === "GET") {
         route.fulfill({ json: disconnected ? disconnectedList : connectedList });
@@ -106,9 +179,15 @@ test.describe("Integrations", () => {
       }
     });
 
-    await page.getByRole("button", { name: "Disconnect" }).click();
+    await page.getByRole("button", { name: "OAuth Service settings" }).click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByRole("button", { name: "Disconnect" }).click();
+    // Confirm the disconnect
+    await dialog.getByRole("button", { name: "Disconnect" }).click();
+
+    await expect(page.getByRole("dialog")).not.toBeVisible();
     await expect(page.getByRole("button", { name: "Connect" })).toBeVisible();
-    await expect(page.getByText("Connected")).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "OAuth Service settings" })).not.toBeVisible();
   });
 
   test("manual auth shows token input on Connect click", async ({
@@ -155,7 +234,7 @@ test.describe("Integrations", () => {
     });
 
     await page.getByRole("button", { name: "Submit" }).click();
-    await expect(page.getByText("Connected")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Manual Service settings" })).toBeVisible();
     expect(receivedCredential).toBe("test-api-key-123");
   });
 
@@ -173,15 +252,19 @@ test.describe("Integrations", () => {
     await expect(page.getByRole("button", { name: "Connect" })).toBeVisible();
   });
 
-  test("manual auth reconnect opens token form", async ({
+  test("manual auth reconnect opens token form via settings modal", async ({
     authenticatedPage,
   }) => {
     const page = authenticatedPage;
     await mockIntegrations(page, [{ ...MANUAL_INTEGRATION, connected: true }]);
 
     await page.goto("/integrations");
-    await expect(page.getByText("Connected")).toBeVisible();
-    await page.getByRole("button", { name: "Reconnect" }).click();
+    await page.getByRole("button", { name: "Manual Service settings" }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText("Connected")).toBeVisible();
+    await dialog.getByRole("button", { name: "Reconnect" }).click();
+    // Modal must close so the token form isn't trapped behind the overlay
+    await expect(page.getByRole("dialog")).not.toBeVisible();
     await expect(page.getByLabel("API Token")).toBeVisible();
   });
 });

--- a/web/src/components/IntegrationCard.tsx
+++ b/web/src/components/IntegrationCard.tsx
@@ -2,7 +2,18 @@
 
 import { Integration, startIntegrationOAuth, connectManualIntegration, disconnectIntegration } from "@/lib/api";
 import Button from "./Button";
-import { useMemo, useState } from "react";
+import { CheckCircleIcon } from "./icons";
+import IntegrationSettingsModal from "./IntegrationSettingsModal";
+import { useCallback, useMemo, useState } from "react";
+
+function GearIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    </svg>
+  );
+}
 
 const DANGEROUS_ELEMENTS = [
   "script", "foreignObject", "iframe", "embed", "object",
@@ -57,6 +68,7 @@ export default function IntegrationCard({
   const [loading, setLoading] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const [showTokenForm, setShowTokenForm] = useState(false);
   const [credential, setCredential] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -67,8 +79,9 @@ export default function IntegrationCard({
 
   const isManual = integration.auth_type === "manual";
 
-  async function handleConnect() {
+  const handleConnect = useCallback(async () => {
     if (isManual) {
+      setSettingsOpen(false);
       setShowTokenForm(true);
       setError(null);
       return;
@@ -83,7 +96,7 @@ export default function IntegrationCard({
     } finally {
       setLoading(false);
     }
-  }
+  }, [integration.name, isManual]);
 
   async function handleSubmitManual(e: React.FormEvent) {
     e.preventDefault();
@@ -108,18 +121,24 @@ export default function IntegrationCard({
     setError(null);
   }
 
-  async function handleDisconnect() {
+  const handleDisconnect = useCallback(async () => {
     setDisconnecting(true);
     setError(null);
     try {
       await disconnectIntegration(integration.name);
+      setSettingsOpen(false);
       onDisconnected?.();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to disconnect");
     } finally {
       setDisconnecting(false);
     }
-  }
+  }, [integration.name, onDisconnected]);
+
+  const handleSettingsClose = useCallback(() => {
+    setSettingsOpen(false);
+    setError(null);
+  }, []);
 
   return (
     <div className="rounded-lg border border-border bg-surface p-5 shadow-warm">
@@ -144,12 +163,19 @@ export default function IntegrationCard({
           </div>
         </div>
         {integration.connected && (
-          <span className="inline-block rounded-full border border-grove-200 bg-grove-50 px-2 py-0.5 text-xs font-medium text-grove-600">
-            Connected
-          </span>
+          <div className="flex items-center gap-1">
+            <CheckCircleIcon className="h-5 w-5 text-grove-500" />
+            <button
+              onClick={() => setSettingsOpen(true)}
+              className="flex h-8 w-8 items-center justify-center rounded text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-600"
+              aria-label={`${integration.display_name || integration.name} settings`}
+            >
+              <GearIcon className="h-4 w-4" />
+            </button>
+          </div>
         )}
       </div>
-      {error && <p className="mt-2 text-sm text-ember-500">{error}</p>}
+      {error && !settingsOpen && <p className="mt-2 text-sm text-ember-500">{error}</p>}
       {showTokenForm && (
         <form onSubmit={handleSubmitManual} className="mt-3">
           <label htmlFor={`credential-${integration.name}`} className="block text-sm font-medium text-stone-700">
@@ -174,23 +200,23 @@ export default function IntegrationCard({
           </div>
         </form>
       )}
-      {!showTokenForm && (
-        integration.connected ? (
-          <div className="mt-4 flex gap-2">
-            <Button onClick={handleConnect} disabled={loading}>
-              {loading ? "Connecting..." : "Reconnect"}
-            </Button>
-            <Button variant="danger" onClick={handleDisconnect} disabled={disconnecting}>
-              {disconnecting ? "Disconnecting..." : "Disconnect"}
-            </Button>
-          </div>
-        ) : (
-          <div className="mt-4">
-            <Button onClick={handleConnect} disabled={loading}>
-              {loading ? "Connecting..." : "Connect"}
-            </Button>
-          </div>
-        )
+      {!showTokenForm && !integration.connected && (
+        <div className="mt-4">
+          <Button onClick={handleConnect} disabled={loading}>
+            {loading ? "Connecting..." : "Connect"}
+          </Button>
+        </div>
+      )}
+      {settingsOpen && (
+        <IntegrationSettingsModal
+          integration={integration}
+          onClose={handleSettingsClose}
+          onReconnect={handleConnect}
+          onDisconnect={handleDisconnect}
+          reconnecting={loading}
+          disconnecting={disconnecting}
+          error={error}
+        />
       )}
     </div>
   );

--- a/web/src/components/IntegrationSettingsModal.tsx
+++ b/web/src/components/IntegrationSettingsModal.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Integration } from "@/lib/api";
+import Button from "./Button";
+import { CheckCircleIcon } from "./icons";
+
+const FOCUSABLE = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+function CloseIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}
+
+interface IntegrationSettingsModalProps {
+  integration: Integration;
+  onClose: () => void;
+  onReconnect: () => void;
+  onDisconnect: () => void;
+  reconnecting: boolean;
+  disconnecting: boolean;
+  error: string | null;
+}
+
+export default function IntegrationSettingsModal({
+  integration,
+  onClose,
+  onReconnect,
+  onDisconnect,
+  reconnecting,
+  disconnecting,
+  error,
+}: IntegrationSettingsModalProps) {
+  const [mounted, setMounted] = useState(false);
+  const [confirmingDisconnect, setConfirmingDisconnect] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const handleDismiss = useCallback(() => {
+    if (!disconnecting) onClose();
+  }, [disconnecting, onClose]);
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      handleDismiss();
+      return;
+    }
+    if (e.key === "Tab" && panelRef.current) {
+      const focusable = panelRef.current.querySelectorAll<HTMLElement>(FOCUSABLE);
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }, [handleDismiss]);
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!panelRef.current) return;
+    panelRef.current.querySelector<HTMLElement>(FOCUSABLE)?.focus();
+  }, [confirmingDisconnect, mounted]);
+
+  if (!mounted) return null;
+
+  const displayName = integration.display_name || integration.name;
+  const headingId = `settings-modal-heading-${integration.name}`;
+
+  const modal = (
+    <div className="fixed inset-0 z-50" role="presentation">
+      <div className="fixed inset-0 bg-stone-900/50" aria-hidden="true" />
+      <div className="fixed inset-0 flex items-center justify-center p-4" onClick={handleDismiss}>
+        <div
+          ref={panelRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={headingId}
+          className="relative w-full max-w-sm rounded-lg border border-border bg-surface p-6 shadow-warm"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {confirmingDisconnect ? (
+            <>
+              <h2 id={headingId} className="text-lg font-heading font-semibold text-stone-900">
+                Disconnect {displayName}?
+              </h2>
+              <p className="mt-2 text-sm text-stone-500">
+                This will remove your {displayName} integration. You can reconnect at any time.
+              </p>
+              {error && <p className="mt-3 text-sm text-ember-500">{error}</p>}
+              <div className="mt-6 flex gap-3">
+                <Button
+                  variant="secondary"
+                  className="flex-1"
+                  onClick={() => setConfirmingDisconnect(false)}
+                  disabled={disconnecting}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="danger"
+                  className="flex-1"
+                  onClick={onDisconnect}
+                  disabled={disconnecting}
+                >
+                  {disconnecting ? "Disconnecting..." : "Disconnect"}
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="flex items-start justify-between">
+                <h2 id={headingId} className="text-lg font-heading font-semibold text-stone-900">
+                  {displayName}
+                </h2>
+                <button
+                  onClick={onClose}
+                  className="rounded p-1 text-stone-400 hover:text-stone-600 transition-colors"
+                  aria-label="Close"
+                >
+                  <CloseIcon className="h-4 w-4" />
+                </button>
+              </div>
+
+              <div className="mt-4 flex items-center gap-2">
+                <CheckCircleIcon className="h-5 w-5 text-grove-500" />
+                <span className="text-sm font-medium text-grove-600">Connected</span>
+              </div>
+
+              {error && <p className="mt-3 text-sm text-ember-500">{error}</p>}
+
+              <div className="mt-6">
+                <Button className="w-full" onClick={onReconnect} disabled={reconnecting}>
+                  {reconnecting ? "Connecting..." : "Reconnect"}
+                </Button>
+              </div>
+
+              <div className="mt-4 border-t border-border pt-4">
+                <Button variant="danger" className="w-full" onClick={() => setConfirmingDisconnect(true)}>
+                  Disconnect
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(modal, document.body);
+}

--- a/web/src/components/icons.tsx
+++ b/web/src/components/icons.tsx
@@ -1,0 +1,8 @@
+export function CheckCircleIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" />
+      <path d="m9 12 2 2 4-4" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace the inline "Connected" text badge with a green check circle icon and a settings gear button on connected integration cards
- Clicking the gear opens a settings modal with Reconnect and Disconnect actions
- Disconnecting requires a confirmation step to prevent accidental disconnections
- Modal built from scratch with portal rendering, ESC/backdrop close, focus trap, and scroll lock

## Test plan
- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] All 26 E2E tests pass (10 integration tests including 4 new modal tests)
- [ ] Manual verification: connect an integration, verify check icon + gear appear, open settings modal, walk through disconnect confirmation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)