### PR TITLE
Fix CLI login OAuth callback failing with CSRF error

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -21,6 +21,9 @@ import (
 
 const defaultTokenInstance = "default"
 
+const cliStatePrefix = "cli:"
+const maxPort = 65535
+
 func (s *Server) resolveUserID(w http.ResponseWriter, r *http.Request) (string, bool) {
 	user := UserFromContext(r.Context())
 	if user == nil || user.Email == "" {
@@ -254,7 +257,8 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 }
 
 type loginRequest struct {
-	State string `json:"state"`
+	State        string `json:"state"`
+	CallbackPort int    `json:"callback_port,omitempty"`
 }
 
 func (s *Server) authInfo(w http.ResponseWriter, _ *http.Request) {
@@ -275,7 +279,11 @@ func (s *Server) startLogin(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	url, err := s.auth.LoginURL(req.State)
+	state := req.State
+	if req.CallbackPort > 0 && req.CallbackPort <= maxPort {
+		state = fmt.Sprintf("%s%d:%s", cliStatePrefix, req.CallbackPort, req.State)
+	}
+	url, err := s.auth.LoginURL(state)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to generate login URL")
 		return

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -813,6 +813,62 @@ func TestStartLogin(t *testing.T) {
 	}
 }
 
+func TestStartLoginWithCallbackPort(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubAuthWithLoginURL{
+		StubAuthProvider: coretesting.StubAuthProvider{N: "test"},
+		loginURL:         "https://auth.example.com/login",
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = stub
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"state":"abc","callback_port":12345}`)
+	resp, err := http.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	if stub.capturedState != "cli:12345:abc" {
+		t.Fatalf("expected state 'cli:12345:abc', got %q", stub.capturedState)
+	}
+}
+
+func TestStartLoginWithInvalidCallbackPort(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubAuthWithLoginURL{
+		StubAuthProvider: coretesting.StubAuthProvider{N: "test"},
+		loginURL:         "https://auth.example.com/login",
+	}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = stub
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"state":"abc","callback_port":99999}`)
+	resp, err := http.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	if stub.capturedState != "abc" {
+		t.Fatalf("expected state 'abc', got %q", stub.capturedState)
+	}
+}
+
 func TestLoginCallback(t *testing.T) {
 	t.Parallel()
 
@@ -1360,10 +1416,12 @@ func (s *stubIntegrationWithOps) ListOperations() []core.Operation {
 
 type stubAuthWithLoginURL struct {
 	coretesting.StubAuthProvider
-	loginURL string
+	loginURL      string
+	capturedState string
 }
 
-func (s *stubAuthWithLoginURL) LoginURL(_ string) (string, error) {
+func (s *stubAuthWithLoginURL) LoginURL(state string) (string, error) {
+	s.capturedState = state
 	return s.loginURL, nil
 }
 

--- a/web/src/app/auth/callback/page.tsx
+++ b/web/src/app/auth/callback/page.tsx
@@ -20,6 +20,24 @@ function CallbackHandler() {
       return;
     }
 
+    // CLI-initiated login encodes callback port in state as "cli:{port}:{original_state}".
+    const CLI_STATE_PREFIX = "cli:";
+    const MAX_PORT = 65535;
+    if (returnedState?.startsWith(CLI_STATE_PREFIX)) {
+      const parts = returnedState.split(":");
+      if (parts.length >= 3) {
+        const port = parseInt(parts[1], 10);
+        const originalState = parts.slice(2).join(":");
+        if (port > 0 && port <= MAX_PORT) {
+          const params = new URLSearchParams({ state: originalState, code });
+          window.location.href = `http://127.0.0.1:${port}/?${params}`;
+          return;
+        }
+      }
+      setError("Invalid CLI callback state");
+      return;
+    }
+
     if (!savedState || returnedState !== savedState) {
       setError("Invalid OAuth state — possible CSRF attack");
       return;


### PR DESCRIPTION
## Summary
- When `gestalt init` initiates OAuth login, Google redirects back to the web frontend's `/auth/callback` page which checks `sessionStorage` for a saved state — but since the CLI (not the browser) initiated the flow, there's no state, causing a spurious CSRF error.
- The server now accepts `callback_port` from the CLI and encodes it into the OAuth state as a `cli:{port}:{state}` prefix. The frontend detects this prefix and redirects the browser to the CLI's local TCP listener to complete the flow.
- Port values are validated to 1–65535 on both server and client side.

## Test plan
- [x] Existing server tests pass
- [x] New test verifies callback_port is encoded into state as `cli:` prefix
- [x] New test verifies out-of-range ports (e.g. 99999) are ignored (state passed through unchanged)
- [ ] Manual: run `gestalt init` against a deployed instance and verify OAuth completes without CSRF error

🤖 Generated with [Claude Code](https://claude.com/claude-code)