### PR TITLE
Reject unexpected positional arguments in gestaltd

### DIFF
--- a/cmd/gestaltd/main_test.go
+++ b/cmd/gestaltd/main_test.go
@@ -35,3 +35,19 @@ func TestGestaltd_HelpExitsCleanly(t *testing.T) {
 		t.Fatalf("expected usage output containing '-config', got: %s", out)
 	}
 }
+
+func TestRun_RejectsPositionalArgs(t *testing.T) {
+	t.Parallel()
+	err := run([]string{"serve", "--config", "foo.yaml"})
+	if err == nil {
+		t.Fatal("expected error for positional arguments")
+	}
+}
+
+func TestRun_RejectsTrailingArgs(t *testing.T) {
+	t.Parallel()
+	err := run([]string{"--config", "foo.yaml", "extra"})
+	if err == nil {
+		t.Fatal("expected error for trailing arguments")
+	}
+}

--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -27,6 +27,9 @@ func run(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
 
 	if *check {
 		return runCheck(*configPath)


### PR DESCRIPTION
## Summary
- gestaltd now rejects unexpected positional arguments after flag parsing
- Previously, commands like `gestaltd config --config file.yaml` silently ignored the positional args and fell through to normal startup with the default config

## Test plan
- [x] Added TestRun_RejectsPositionalArgs
- [x] Added TestRun_RejectsTrailingArgs
- [x] go test ./cmd/gestaltd/... passes
- [x] go test ./... passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)