### PR TITLE
Fix gestaltd --help to exit cleanly

### DIFF
--- a/cmd/gestaltd/main.go
+++ b/cmd/gestaltd/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"flag"
 	"log"
 	"os"
 
@@ -11,6 +13,9 @@ import (
 
 func main() {
 	if err := run(os.Args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return
+		}
 		log.Fatal(err)
 	}
 }

--- a/cmd/gestaltd/main_test.go
+++ b/cmd/gestaltd/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -19,5 +21,17 @@ func TestRun_UnknownFlag(t *testing.T) {
 	err := run([]string{"--bogus"})
 	if err == nil {
 		t.Fatal("expected error for unknown flag")
+	}
+}
+
+func TestGestaltd_HelpExitsCleanly(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("go", "run", ".", "--help")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected exit 0 for --help, got error: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(string(out), "-config") {
+		t.Fatalf("expected usage output containing '-config', got: %s", out)
 	}
 }


### PR DESCRIPTION
## Summary
- `gestaltd --help` now exits cleanly (status 0) instead of through log.Fatal (status 1)
- The `run()` function still returns `flag.ErrHelp` as expected; `main()` now recognizes it and exits gracefully

## Test plan
- [x] Added TestRun_HelpFlag
- [x] go test ./cmd/gestaltd/... passes
- [x] go test ./... passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)