### PR TITLE
Surface token lookup errors in /api/v1/integrations

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -60,7 +60,12 @@ type integrationInfo struct {
 }
 
 func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
-	connected := s.userConnectedIntegrations(r)
+	connected, err := s.userConnectedIntegrations(r)
+	if err != nil {
+		log.Printf("listing integrations: %v", err)
+		writeError(w, http.StatusInternalServerError, "failed to check integration status")
+		return
+	}
 
 	names := s.providers.List()
 	out := make([]integrationInfo, 0, len(names))
@@ -90,28 +95,31 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, out)
 }
 
-func (s *Server) userConnectedIntegrations(r *http.Request) map[string]bool {
+func (s *Server) userConnectedIntegrations(r *http.Request) (map[string]bool, error) {
 	user := UserFromContext(r.Context())
 	if user == nil || user.Email == "" {
-		return nil
+		return nil, nil
 	}
 	userID := UserIDFromContext(r.Context())
 	if userID == "" {
 		dbUser, err := s.datastore.FindOrCreateUser(r.Context(), user.Email)
-		if err != nil || dbUser == nil || dbUser.ID == "" {
-			return nil
+		if err != nil {
+			return nil, fmt.Errorf("resolving user: %w", err)
+		}
+		if dbUser == nil || dbUser.ID == "" {
+			return nil, fmt.Errorf("resolving user: empty result")
 		}
 		userID = dbUser.ID
 	}
 	tokens, err := s.datastore.ListTokens(r.Context(), userID)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("listing tokens: %w", err)
 	}
 	m := make(map[string]bool, len(tokens))
 	for _, tok := range tokens {
 		m[tok.Integration] = true
 	}
-	return m
+	return m, nil
 }
 
 func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -514,6 +514,65 @@ func TestListIntegrations_ShowsConnectedStatus(t *testing.T) {
 	}
 }
 
+func TestListIntegrations_FindOrCreateUserError(t *testing.T) {
+	t.Parallel()
+
+	stub := &coretesting.StubIntegration{N: "test-integ", DN: "Test"}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, _ string) (*core.User, error) {
+				return nil, fmt.Errorf("database unavailable")
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", resp.StatusCode)
+	}
+}
+
+func TestListIntegrations_ListTokensError(t *testing.T) {
+	t.Parallel()
+
+	stub := &coretesting.StubIntegration{N: "test-integ", DN: "Test"}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			ListTokensFn: func(_ context.Context, _ string) ([]*core.IntegrationToken, error) {
+				return nil, fmt.Errorf("token store unavailable")
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", resp.StatusCode)
+	}
+}
+
 func TestDisconnectIntegration(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- `userConnectedIntegrations` now returns errors instead of silently returning nil
- `listIntegrations` returns HTTP 500 when token status lookup fails, instead of 200 with all integrations shown as disconnected
- Previously, datastore/auth failures were masked as "not connected" state

## Test plan
- [x] Added TestListIntegrations_FindOrCreateUserError
- [x] Added TestListIntegrations_ListTokensError
- [x] go test ./internal/server/... passes
- [x] go test ./... passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)