### PR TITLE
Support list-form allowed_operations and MCP operation filtering

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -226,7 +226,7 @@ func defaultProviderFactory(providerDirs []string) bootstrap.ProviderFactory {
 					cleanup()
 					return nil, err
 				}
-				p, err := provider.Build(def, intg, us.AllowedOperations)
+				p, err := provider.Build(def, intg, map[string]string(us.AllowedOperations))
 				if err != nil {
 					cleanup()
 					return nil, err
@@ -241,6 +241,12 @@ func defaultProviderFactory(providerDirs []string) bootstrap.ProviderFactory {
 				up, err := mcpupstream.New(ctx, name, us.URL, connMode)
 				if err != nil {
 					return nil, err
+				}
+				if us.AllowedOperations != nil {
+					if err := up.FilterOperations(map[string]string(us.AllowedOperations)); err != nil {
+						_ = up.Close()
+						return nil, fmt.Errorf("integration %s: %w", name, err)
+					}
 				}
 				mcpUp = up
 			default:
@@ -265,7 +271,7 @@ func defaultProviderFactory(providerDirs []string) bootstrap.ProviderFactory {
 func loadHTTPUpstream(ctx context.Context, name string, us config.UpstreamDef, providerDirs []string) (*provider.Definition, error) {
 	switch {
 	case us.URL != "":
-		return openapi.LoadDefinition(ctx, name, us.URL, us.AllowedOperations)
+		return openapi.LoadDefinition(ctx, name, us.URL, map[string]string(us.AllowedOperations))
 	case us.Provider != "":
 		return provider.LoadFile(us.Provider)
 	default:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,11 +106,35 @@ const (
 )
 
 type UpstreamDef struct {
-	Type              string            `yaml:"type"`
-	URL               string            `yaml:"url"`
-	Provider          string            `yaml:"provider"`
-	MCP               bool              `yaml:"mcp"`
-	AllowedOperations map[string]string `yaml:"allowed_operations"`
+	Type              string     `yaml:"type"`
+	URL               string     `yaml:"url"`
+	Provider          string     `yaml:"provider"`
+	MCP               bool       `yaml:"mcp"`
+	AllowedOperations AllowedOps `yaml:"allowed_operations"`
+}
+
+// AllowedOps is a map of operation name to optional description override.
+// It can be unmarshaled from either a YAML list (names only, descriptions
+// from upstream spec) or a YAML map (names to description overrides).
+type AllowedOps map[string]string
+
+func (a *AllowedOps) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.SequenceNode:
+		*a = make(AllowedOps, len(value.Content))
+		for _, item := range value.Content {
+			(*a)[item.Value] = ""
+		}
+	case yaml.MappingNode:
+		m := make(map[string]string)
+		if err := value.Decode(&m); err != nil {
+			return err
+		}
+		*a = m
+	default:
+		return fmt.Errorf("allowed_operations must be a list or map")
+	}
+	return nil
 }
 
 type AuthOverrides struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -277,6 +277,102 @@ func TestHelmValuesConfigLoads(t *testing.T) {
 	}
 }
 
+func TestAllowedOperationsListForm(t *testing.T) {
+	t.Parallel()
+
+	yaml := `
+auth:
+  provider: google
+server:
+  encryption_key: key123
+integrations:
+  test_api:
+    upstreams:
+      - type: http
+        url: https://example.com/spec.json
+        allowed_operations:
+          - list_items
+          - get_item
+`
+	path := mustWriteConfigFile(t, yaml)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: unexpected error: %v", err)
+	}
+
+	ops := cfg.Integrations["test_api"].Upstreams[0].AllowedOperations
+	if len(ops) != 2 {
+		t.Fatalf("AllowedOperations: got %d items, want 2", len(ops))
+	}
+	if ops["list_items"] != "" {
+		t.Errorf("list_items description: got %q, want empty", ops["list_items"])
+	}
+	if ops["get_item"] != "" {
+		t.Errorf("get_item description: got %q, want empty", ops["get_item"])
+	}
+}
+
+func TestAllowedOperationsMapForm(t *testing.T) {
+	t.Parallel()
+
+	yaml := `
+auth:
+  provider: google
+server:
+  encryption_key: key123
+integrations:
+  test_api:
+    upstreams:
+      - type: http
+        url: https://example.com/spec.json
+        allowed_operations:
+          list_items: List all items
+          get_item: ""
+`
+	path := mustWriteConfigFile(t, yaml)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: unexpected error: %v", err)
+	}
+
+	ops := cfg.Integrations["test_api"].Upstreams[0].AllowedOperations
+	if len(ops) != 2 {
+		t.Fatalf("AllowedOperations: got %d items, want 2", len(ops))
+	}
+	if ops["list_items"] != "List all items" {
+		t.Errorf("list_items description: got %q, want %q", ops["list_items"], "List all items")
+	}
+	if ops["get_item"] != "" {
+		t.Errorf("get_item description: got %q, want empty", ops["get_item"])
+	}
+}
+
+func TestAllowedOperationsOmitted(t *testing.T) {
+	t.Parallel()
+
+	yaml := `
+auth:
+  provider: google
+server:
+  encryption_key: key123
+integrations:
+  test_api:
+    upstreams:
+      - type: http
+        url: https://example.com/spec.json
+`
+	path := mustWriteConfigFile(t, yaml)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: unexpected error: %v", err)
+	}
+
+	ops := cfg.Integrations["test_api"].Upstreams[0].AllowedOperations
+	if ops != nil {
+		t.Fatalf("AllowedOperations: got %v, want nil", ops)
+	}
+}
+
 func TestAuthConfigMap(t *testing.T) {
 	t.Parallel()
 

--- a/internal/mcpupstream/upstream.go
+++ b/internal/mcpupstream/upstream.go
@@ -118,6 +118,46 @@ func (u *Upstream) Close() error {
 	return u.client.Close()
 }
 
+func (u *Upstream) FilterOperations(allowed map[string]string) error {
+	if len(allowed) == 0 {
+		return fmt.Errorf("allowed_operations cannot be empty; omit the field to allow all")
+	}
+
+	opSet := make(map[string]struct{}, len(u.ops))
+	for _, op := range u.ops {
+		opSet[op.Name] = struct{}{}
+	}
+	for name := range allowed {
+		if _, ok := opSet[name]; !ok {
+			return fmt.Errorf("allowed_operations contains unknown operation %q", name)
+		}
+	}
+
+	filteredOps := make([]core.Operation, 0, len(allowed))
+	for _, op := range u.ops {
+		if desc, ok := allowed[op.Name]; ok {
+			if desc != "" {
+				op.Description = desc
+			}
+			filteredOps = append(filteredOps, op)
+		}
+	}
+
+	filteredCatOps := make([]catalog.CatalogOperation, 0, len(allowed))
+	for i := range u.cat.Operations {
+		if desc, ok := allowed[u.cat.Operations[i].ID]; ok {
+			if desc != "" {
+				u.cat.Operations[i].Description = desc
+			}
+			filteredCatOps = append(filteredCatOps, u.cat.Operations[i])
+		}
+	}
+
+	u.ops = filteredOps
+	u.cat.Operations = filteredCatOps
+	return nil
+}
+
 func buildCatalog(name string, tools []mcpgo.Tool) (*catalog.Catalog, []core.Operation) {
 	cat := &catalog.Catalog{
 		Name:       name,

--- a/internal/mcpupstream/upstream_test.go
+++ b/internal/mcpupstream/upstream_test.go
@@ -132,6 +132,94 @@ func TestUpstream_ExecuteReturnsError(t *testing.T) {
 	}
 }
 
+func TestUpstream_FilterOperations(t *testing.T) {
+	t.Parallel()
+
+	u := newTestUpstream(t)
+	t.Cleanup(func() { _ = u.Close() })
+
+	err := u.FilterOperations(map[string]string{"run_query": ""})
+	if err != nil {
+		t.Fatalf("FilterOperations: %v", err)
+	}
+
+	ops := u.ListOperations()
+	if len(ops) != 1 {
+		t.Fatalf("expected 1 operation, got %d", len(ops))
+	}
+	if ops[0].Name != "run_query" {
+		t.Fatalf("expected run_query, got %q", ops[0].Name)
+	}
+	if ops[0].Description != "Execute a SQL query" {
+		t.Fatalf("expected spec description, got %q", ops[0].Description)
+	}
+
+	cat := u.Catalog()
+	if len(cat.Operations) != 1 {
+		t.Fatalf("expected 1 catalog operation, got %d", len(cat.Operations))
+	}
+	if cat.Operations[0].ID != "run_query" {
+		t.Fatalf("expected run_query in catalog, got %q", cat.Operations[0].ID)
+	}
+}
+
+func TestUpstream_FilterOperationsWithOverride(t *testing.T) {
+	t.Parallel()
+
+	u := newTestUpstream(t)
+	t.Cleanup(func() { _ = u.Close() })
+
+	err := u.FilterOperations(map[string]string{
+		"run_query":      "Custom query description",
+		"list_databases": "",
+	})
+	if err != nil {
+		t.Fatalf("FilterOperations: %v", err)
+	}
+
+	ops := u.ListOperations()
+	if len(ops) != 2 {
+		t.Fatalf("expected 2 operations, got %d", len(ops))
+	}
+
+	for _, op := range ops {
+		switch op.Name {
+		case "run_query":
+			if op.Description != "Custom query description" {
+				t.Errorf("run_query description: got %q, want override", op.Description)
+			}
+		case "list_databases":
+			if op.Description != "List all databases" {
+				t.Errorf("list_databases description: got %q, want spec default", op.Description)
+			}
+		}
+	}
+}
+
+func TestUpstream_FilterOperationsUnknown(t *testing.T) {
+	t.Parallel()
+
+	u := newTestUpstream(t)
+	t.Cleanup(func() { _ = u.Close() })
+
+	err := u.FilterOperations(map[string]string{"nonexistent": ""})
+	if err == nil {
+		t.Fatal("expected error for unknown operation")
+	}
+}
+
+func TestUpstream_FilterOperationsEmpty(t *testing.T) {
+	t.Parallel()
+
+	u := newTestUpstream(t)
+	t.Cleanup(func() { _ = u.Close() })
+
+	err := u.FilterOperations(map[string]string{})
+	if err == nil {
+		t.Fatal("expected error for empty allowed_operations")
+	}
+}
+
 func TestUpstream_ProviderMetadata(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- `allowed_operations` in upstream config now accepts both YAML list form (names only, descriptions forwarded from upstream spec) and the existing map form (names to description overrides)
- MCP upstreams now support `allowed_operations` for filtering exposed tools and optionally overriding their descriptions
- Backward compatible: existing map-form configs produce identical behavior

## Example

```yaml
# List form — descriptions from OpenAPI/MCP spec
allowed_operations:
  - conversations_list
  - chat_postMessage

# Map form — still supported
allowed_operations:
  conversations_list: Custom description
  chat_postMessage: ""  # uses spec description
```

## Test plan

- [x] Config loading: list form, map form, and omitted field all parse correctly
- [x] MCP FilterOperations: filters tools, applies description overrides, rejects unknown/empty ops
- [x] Full test suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)