### PR TITLE
Add ChatStore interface and SQLite implementation

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -27,6 +27,7 @@ import (
 	"github.com/valon-technologies/gestalt/plugins/datastore/mysql"
 	"github.com/valon-technologies/gestalt/plugins/datastore/oracle"
 	"github.com/valon-technologies/gestalt/plugins/datastore/postgres"
+	chatsqlite "github.com/valon-technologies/gestalt/plugins/chatstore/sqlite"
 	"github.com/valon-technologies/gestalt/plugins/datastore/sqlite"
 	"github.com/valon-technologies/gestalt/plugins/datastore/sqlserver"
 	"github.com/valon-technologies/gestalt/plugins/providers/echo"
@@ -70,6 +71,18 @@ func setupBootstrap(configFlag string) (*bootstrapEnv, error) {
 		return nil, fmt.Errorf("running datastore migrations: %v", err)
 	}
 
+	if result.ChatStore != nil {
+		if err := result.ChatStore.Migrate(ctx); err != nil {
+			_ = result.ChatStore.Close()
+			_ = result.Datastore.Close()
+			if closer, ok := result.SecretManager.(interface{ Close() error }); ok {
+				_ = closer.Close()
+			}
+			stop()
+			return nil, fmt.Errorf("running chatstore migrations: %v", err)
+		}
+	}
+
 	return &bootstrapEnv{
 		Ctx:    ctx,
 		Stop:   stop,
@@ -80,6 +93,9 @@ func setupBootstrap(configFlag string) (*bootstrapEnv, error) {
 
 func (e *bootstrapEnv) Close() {
 	e.Stop()
+	if e.Result.ChatStore != nil {
+		_ = e.Result.ChatStore.Close()
+	}
 	_ = e.Result.Datastore.Close()
 	if closer, ok := e.Result.SecretManager.(interface{ Close() error }); ok {
 		_ = closer.Close()
@@ -98,6 +114,7 @@ func buildFactories(providerDirs []string, devMode bool) *bootstrap.FactoryRegis
 	factories.Datastores["oracle"] = oracle.Factory
 	factories.Datastores["firestore"] = firestore.Factory
 	factories.Datastores["sqlserver"] = sqlserver.Factory
+	factories.ChatStores["sqlite"] = chatsqlite.Factory
 	factories.DefaultProvider = defaultProviderFactory(providerDirs)
 	if devMode {
 		factories.Builtins = append(factories.Builtins, echo.New())

--- a/core/chat_types.go
+++ b/core/chat_types.go
@@ -1,0 +1,75 @@
+package core
+
+import "time"
+
+type Agent struct {
+	ID           string
+	OwnerID      string
+	Name         string
+	SystemPrompt string
+	Model        string
+	Providers    []string
+	Temperature  float64
+	MaxTokens    int
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+type Conversation struct {
+	ID        string
+	AgentID   string
+	UserID    string
+	Title     string
+	Status    ConversationStatus
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+type ConversationStatus string
+
+const (
+	ConversationActive   ConversationStatus = "active"
+	ConversationArchived ConversationStatus = "archived"
+)
+
+type Message struct {
+	ID             string
+	ConversationID string
+	Role           MessageRole
+	Content        string
+	ToolCalls      string
+	ToolCallID     string
+	InputTokens    int
+	OutputTokens   int
+	CreatedAt      time.Time
+}
+
+type MessageRole string
+
+const (
+	RoleUser      MessageRole = "user"
+	RoleAssistant MessageRole = "assistant"
+	RoleTool      MessageRole = "tool"
+)
+
+type ChatEventType string
+
+const (
+	ChatEventTextDelta  ChatEventType = "text_delta"
+	ChatEventToolUse    ChatEventType = "tool_use"
+	ChatEventToolResult ChatEventType = "tool_result"
+	ChatEventComplete   ChatEventType = "complete"
+	ChatEventError      ChatEventType = "error"
+)
+
+type ChatEvent struct {
+	Type           ChatEventType
+	ConversationID string
+	Text           string
+	ToolCallID     string
+	ToolName       string
+	ToolInput      string
+	Error          string
+	InputTokens    int
+	OutputTokens   int
+}

--- a/core/chatstore.go
+++ b/core/chatstore.go
@@ -1,0 +1,27 @@
+package core
+
+import "context"
+
+type ChatStore interface {
+	GetAgent(ctx context.Context, id string) (*Agent, error)
+	ListAgents(ctx context.Context, ownerID string) ([]*Agent, error)
+	CreateAgent(ctx context.Context, agent *Agent) error
+	UpdateAgent(ctx context.Context, agent *Agent) error
+	DeleteAgent(ctx context.Context, id string) error
+
+	GetConversation(ctx context.Context, id string) (*Conversation, error)
+	ListConversations(ctx context.Context, userID string, limit, offset int) ([]*Conversation, error)
+	CreateConversation(ctx context.Context, conv *Conversation) error
+	UpdateConversation(ctx context.Context, conv *Conversation) error
+
+	ListMessages(ctx context.Context, conversationID string) ([]*Message, error)
+	AppendMessage(ctx context.Context, msg *Message) error
+
+	Migrate(ctx context.Context) error
+	Close() error
+}
+
+type ChatDispatcher interface {
+	SendMessage(ctx context.Context, conversationID, content, userID string) (<-chan ChatEvent, error)
+	CancelConversation(ctx context.Context, conversationID string) error
+}

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -25,15 +25,19 @@ type Deps struct {
 
 type AuthFactory func(node yaml.Node, deps Deps) (core.AuthProvider, error)
 type DatastoreFactory func(node yaml.Node, deps Deps) (core.Datastore, error)
+type ChatStoreFactory func(node yaml.Node, deps Deps) (core.ChatStore, error)
 type ProviderFactory func(ctx context.Context, name string, intg config.IntegrationDef, deps Deps) (core.Provider, error)
 type SecretManagerFactory func(node yaml.Node) (core.SecretManager, error)
 type BindingDeps struct {
-	Invoker invocation.Invoker
+	Invoker        invocation.Invoker
+	ChatStore      core.ChatStore
+	ChatDispatcher core.ChatDispatcher
 }
 
 type RuntimeDeps struct {
 	Invoker          invocation.Invoker
 	CapabilityLister invocation.CapabilityLister
+	ChatStore        core.ChatStore
 }
 
 type RuntimeFactory func(ctx context.Context, name string, cfg config.RuntimeDef, deps RuntimeDeps) (core.Runtime, error)
@@ -42,6 +46,7 @@ type BindingFactory func(ctx context.Context, name string, cfg config.BindingDef
 type FactoryRegistry struct {
 	Auth            map[string]AuthFactory
 	Datastores      map[string]DatastoreFactory
+	ChatStores      map[string]ChatStoreFactory
 	Providers       map[string]ProviderFactory
 	DefaultProvider ProviderFactory
 	Secrets         map[string]SecretManagerFactory
@@ -54,6 +59,7 @@ func NewFactoryRegistry() *FactoryRegistry {
 	return &FactoryRegistry{
 		Auth:       make(map[string]AuthFactory),
 		Datastores: make(map[string]DatastoreFactory),
+		ChatStores: make(map[string]ChatStoreFactory),
 		Providers:  make(map[string]ProviderFactory),
 		Secrets:    make(map[string]SecretManagerFactory),
 		Runtimes:   make(map[string]RuntimeFactory),
@@ -64,6 +70,7 @@ func NewFactoryRegistry() *FactoryRegistry {
 type Result struct {
 	Auth             core.AuthProvider
 	Datastore        core.Datastore
+	ChatStore        core.ChatStore
 	Providers        *registry.PluginMap[core.Provider]
 	Runtimes         *registry.PluginMap[core.Runtime]
 	Bindings         *registry.PluginMap[core.Binding]
@@ -108,6 +115,11 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		return nil, err
 	}
 
+	cs, err := buildChatStore(cfg, factories, deps)
+	if err != nil {
+		return nil, err
+	}
+
 	providers, err := buildProviders(ctx, cfg, factories, deps)
 	if err != nil {
 		return nil, err
@@ -116,12 +128,12 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	sharedInvoker := invocation.NewBroker(providers, ds)
 	audit := core.AuditSink(invocation.LogAuditSink{})
 
-	runtimes, err := buildRuntimes(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit)
+	runtimes, err := buildRuntimes(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, cs)
 	if err != nil {
 		return nil, err
 	}
 
-	bindings, err := buildBindings(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit)
+	bindings, err := buildBindings(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, cs)
 	if err != nil {
 		return nil, err
 	}
@@ -130,6 +142,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	return &Result{
 		Auth:             auth,
 		Datastore:        ds,
+		ChatStore:        cs,
 		Providers:        providers,
 		Runtimes:         runtimes,
 		Bindings:         bindings,
@@ -200,6 +213,9 @@ func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretMa
 		return err
 	}
 	if err := resolveYAMLNode(&cfg.Datastore.Config, resolve); err != nil {
+		return err
+	}
+	if err := resolveYAMLNode(&cfg.ChatStore.Config, resolve); err != nil {
 		return err
 	}
 	for name := range cfg.Runtimes {
@@ -334,6 +350,21 @@ func buildDatastore(cfg *config.Config, factories *FactoryRegistry, deps Deps) (
 	return ds, nil
 }
 
+func buildChatStore(cfg *config.Config, factories *FactoryRegistry, deps Deps) (core.ChatStore, error) {
+	if cfg.ChatStore.Provider == "" {
+		return nil, nil
+	}
+	factory, ok := factories.ChatStores[cfg.ChatStore.Provider]
+	if !ok {
+		return nil, fmt.Errorf("bootstrap: unknown chatstore %q", cfg.ChatStore.Provider)
+	}
+	cs, err := factory(cfg.ChatStore.Config, deps)
+	if err != nil {
+		return nil, fmt.Errorf("bootstrap: chatstore %q: %w", cfg.ChatStore.Provider, err)
+	}
+	return cs, nil
+}
+
 func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.PluginMap[core.Provider], error) {
 	providers := make(map[string]core.Provider, len(cfg.Integrations))
 	var mu sync.Mutex
@@ -385,7 +416,7 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 	return &reg.Providers, nil
 }
 
-func buildRuntimes(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink) (*registry.PluginMap[core.Runtime], error) {
+func buildRuntimes(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink, chatStore core.ChatStore) (*registry.PluginMap[core.Runtime], error) {
 	if len(cfg.Runtimes) == 0 {
 		return nil, nil
 	}
@@ -399,7 +430,7 @@ func buildRuntimes(ctx context.Context, cfg *config.Config, factories *FactoryRe
 			return nil, fmt.Errorf("bootstrap: unknown runtime type %q for runtime %q", def.Type, name)
 		}
 
-		deps := runtimeDepsForProviders(name, invoker, lister, def.Providers, audit)
+		deps := runtimeDepsForProviders(name, invoker, lister, def.Providers, audit, chatStore)
 		rt, err := factory(ctx, name, def, deps)
 		if err != nil {
 			return nil, fmt.Errorf("bootstrap: runtime %q: %w", name, err)
@@ -414,7 +445,7 @@ func buildRuntimes(ctx context.Context, cfg *config.Config, factories *FactoryRe
 	return runtimes, nil
 }
 
-func buildBindings(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink) (*registry.PluginMap[core.Binding], error) {
+func buildBindings(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink, chatStore core.ChatStore) (*registry.PluginMap[core.Binding], error) {
 	if len(cfg.Bindings) == 0 {
 		return nil, nil
 	}
@@ -428,7 +459,7 @@ func buildBindings(ctx context.Context, cfg *config.Config, factories *FactoryRe
 			return nil, fmt.Errorf("bootstrap: unknown binding type %q for binding %q", def.Type, name)
 		}
 
-		deps := bindingDepsForProviders(name, invoker, lister, def.Providers, audit)
+		deps := bindingDepsForProviders(name, invoker, lister, def.Providers, audit, chatStore, nil)
 		binding, err := factory(ctx, name, def, deps)
 		if err != nil {
 			return nil, fmt.Errorf("bootstrap: binding %q: %w", name, err)

--- a/internal/bootstrap/runtime_deps.go
+++ b/internal/bootstrap/runtime_deps.go
@@ -7,17 +7,20 @@ import (
 	"github.com/valon-technologies/gestalt/internal/invocation"
 )
 
-func runtimeDepsForProviders(name string, invoker invocation.Invoker, lister invocation.CapabilityLister, providers []string, audit core.AuditSink) RuntimeDeps {
+func runtimeDepsForProviders(name string, invoker invocation.Invoker, lister invocation.CapabilityLister, providers []string, audit core.AuditSink, chatStore core.ChatStore) RuntimeDeps {
 	guarded := guardedInvoker("runtime", name, invoker, lister, providers, audit)
 	return RuntimeDeps{
 		Invoker:          guarded,
 		CapabilityLister: guarded,
+		ChatStore:        chatStore,
 	}
 }
 
-func bindingDepsForProviders(name string, invoker invocation.Invoker, lister invocation.CapabilityLister, providers []string, audit core.AuditSink) BindingDeps {
+func bindingDepsForProviders(name string, invoker invocation.Invoker, lister invocation.CapabilityLister, providers []string, audit core.AuditSink, chatStore core.ChatStore, chatDispatcher core.ChatDispatcher) BindingDeps {
 	return BindingDeps{
-		Invoker: guardedInvoker("binding", name, invoker, lister, providers, audit),
+		Invoker:        guardedInvoker("binding", name, invoker, lister, providers, audit),
+		ChatStore:      chatStore,
+		ChatDispatcher: chatDispatcher,
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ const (
 type Config struct {
 	Auth         AuthConfig                `yaml:"auth"`
 	Datastore    DatastoreConfig           `yaml:"datastore"`
+	ChatStore    ChatStoreConfig           `yaml:"chatstore"`
 	Secrets      SecretsConfig             `yaml:"secrets"`
 	AuthProfiles map[string]AuthProfile    `yaml:"auth_profiles"`
 	Integrations map[string]IntegrationDef `yaml:"integrations"`
@@ -63,6 +64,11 @@ type AuthConfig struct {
 }
 
 type DatastoreConfig struct {
+	Provider string    `yaml:"provider"`
+	Config   yaml.Node `yaml:"config"`
+}
+
+type ChatStoreConfig struct {
 	Provider string    `yaml:"provider"`
 	Config   yaml.Node `yaml:"config"`
 }

--- a/plugins/chatstore/sqlchatstore/sqlchatstore.go
+++ b/plugins/chatstore/sqlchatstore/sqlchatstore.go
@@ -98,22 +98,33 @@ func (s *Store) ListAgents(ctx context.Context, ownerID string) ([]*core.Agent, 
 	return agents, rows.Err()
 }
 
+func marshalProviders(providers []string) (string, error) {
+	if providers == nil {
+		providers = []string{}
+	}
+	b, err := json.Marshal(providers)
+	if err != nil {
+		return "", fmt.Errorf("marshaling agent providers: %w", err)
+	}
+	return string(b), nil
+}
+
 func (s *Store) CreateAgent(ctx context.Context, agent *core.Agent) error {
 	now := time.Now().UTC().Truncate(time.Second)
 	agent.ID = uuid.NewString()
 	agent.CreatedAt = now
 	agent.UpdatedAt = now
 
-	providersJSON, err := json.Marshal(agent.Providers)
+	providersJSON, err := marshalProviders(agent.Providers)
 	if err != nil {
-		return fmt.Errorf("marshaling agent providers: %w", err)
+		return err
 	}
 
 	_, err = s.DB.ExecContext(ctx,
 		`INSERT INTO agents (id, owner_id, name, system_prompt, model, providers, temperature, max_tokens, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		agent.ID, agent.OwnerID, agent.Name, agent.SystemPrompt, agent.Model,
-		string(providersJSON), agent.Temperature, agent.MaxTokens, agent.CreatedAt, agent.UpdatedAt)
+		providersJSON, agent.Temperature, agent.MaxTokens, agent.CreatedAt, agent.UpdatedAt)
 	if err != nil {
 		return fmt.Errorf("inserting agent: %w", err)
 	}
@@ -123,15 +134,15 @@ func (s *Store) CreateAgent(ctx context.Context, agent *core.Agent) error {
 func (s *Store) UpdateAgent(ctx context.Context, agent *core.Agent) error {
 	agent.UpdatedAt = time.Now().UTC().Truncate(time.Second)
 
-	providersJSON, err := json.Marshal(agent.Providers)
+	providersJSON, err := marshalProviders(agent.Providers)
 	if err != nil {
-		return fmt.Errorf("marshaling agent providers: %w", err)
+		return err
 	}
 
 	result, err := s.DB.ExecContext(ctx,
 		`UPDATE agents SET name = ?, system_prompt = ?, model = ?, providers = ?, temperature = ?, max_tokens = ?, updated_at = ?
 		WHERE id = ?`,
-		agent.Name, agent.SystemPrompt, agent.Model, string(providersJSON),
+		agent.Name, agent.SystemPrompt, agent.Model, providersJSON,
 		agent.Temperature, agent.MaxTokens, agent.UpdatedAt, agent.ID)
 	if err != nil {
 		return fmt.Errorf("updating agent: %w", err)

--- a/plugins/chatstore/sqlchatstore/sqlchatstore.go
+++ b/plugins/chatstore/sqlchatstore/sqlchatstore.go
@@ -1,0 +1,279 @@
+package sqlchatstore
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/core"
+)
+
+type Scanner interface {
+	Scan(dest ...any) error
+}
+
+type Store struct {
+	DB *sql.DB
+}
+
+func New(db *sql.DB) *Store {
+	return &Store{DB: db}
+}
+
+func (s *Store) Close() error {
+	return s.DB.Close()
+}
+
+func scanAgent(row Scanner) (*core.Agent, error) {
+	var a core.Agent
+	var providersJSON string
+	if err := row.Scan(&a.ID, &a.OwnerID, &a.Name, &a.SystemPrompt, &a.Model,
+		&providersJSON, &a.Temperature, &a.MaxTokens, &a.CreatedAt, &a.UpdatedAt); err != nil {
+		return nil, err
+	}
+	if providersJSON != "" {
+		if err := json.Unmarshal([]byte(providersJSON), &a.Providers); err != nil {
+			return nil, fmt.Errorf("unmarshaling agent providers: %w", err)
+		}
+	}
+	return &a, nil
+}
+
+func scanConversation(row Scanner) (*core.Conversation, error) {
+	var c core.Conversation
+	if err := row.Scan(&c.ID, &c.AgentID, &c.UserID, &c.Title, &c.Status,
+		&c.CreatedAt, &c.UpdatedAt); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+func scanMessage(row Scanner) (*core.Message, error) {
+	var m core.Message
+	var toolCalls, toolCallID sql.NullString
+	if err := row.Scan(&m.ID, &m.ConversationID, &m.Role, &m.Content,
+		&toolCalls, &toolCallID, &m.InputTokens, &m.OutputTokens, &m.CreatedAt); err != nil {
+		return nil, err
+	}
+	m.ToolCalls = toolCalls.String
+	m.ToolCallID = toolCallID.String
+	return &m, nil
+}
+
+func (s *Store) GetAgent(ctx context.Context, id string) (*core.Agent, error) {
+	row := s.DB.QueryRowContext(ctx,
+		`SELECT id, owner_id, name, system_prompt, model, providers, temperature, max_tokens, created_at, updated_at
+		FROM agents WHERE id = ?`, id)
+	a, err := scanAgent(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, core.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying agent: %w", err)
+	}
+	return a, nil
+}
+
+func (s *Store) ListAgents(ctx context.Context, ownerID string) ([]*core.Agent, error) {
+	rows, err := s.DB.QueryContext(ctx,
+		`SELECT id, owner_id, name, system_prompt, model, providers, temperature, max_tokens, created_at, updated_at
+		FROM agents WHERE owner_id = ? ORDER BY created_at DESC`, ownerID)
+	if err != nil {
+		return nil, fmt.Errorf("listing agents: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var agents []*core.Agent
+	for rows.Next() {
+		a, err := scanAgent(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning agent row: %w", err)
+		}
+		agents = append(agents, a)
+	}
+	return agents, rows.Err()
+}
+
+func (s *Store) CreateAgent(ctx context.Context, agent *core.Agent) error {
+	now := time.Now().UTC().Truncate(time.Second)
+	agent.ID = uuid.NewString()
+	agent.CreatedAt = now
+	agent.UpdatedAt = now
+
+	providersJSON, err := json.Marshal(agent.Providers)
+	if err != nil {
+		return fmt.Errorf("marshaling agent providers: %w", err)
+	}
+
+	_, err = s.DB.ExecContext(ctx,
+		`INSERT INTO agents (id, owner_id, name, system_prompt, model, providers, temperature, max_tokens, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		agent.ID, agent.OwnerID, agent.Name, agent.SystemPrompt, agent.Model,
+		string(providersJSON), agent.Temperature, agent.MaxTokens, agent.CreatedAt, agent.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("inserting agent: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) UpdateAgent(ctx context.Context, agent *core.Agent) error {
+	agent.UpdatedAt = time.Now().UTC().Truncate(time.Second)
+
+	providersJSON, err := json.Marshal(agent.Providers)
+	if err != nil {
+		return fmt.Errorf("marshaling agent providers: %w", err)
+	}
+
+	result, err := s.DB.ExecContext(ctx,
+		`UPDATE agents SET name = ?, system_prompt = ?, model = ?, providers = ?, temperature = ?, max_tokens = ?, updated_at = ?
+		WHERE id = ?`,
+		agent.Name, agent.SystemPrompt, agent.Model, string(providersJSON),
+		agent.Temperature, agent.MaxTokens, agent.UpdatedAt, agent.ID)
+	if err != nil {
+		return fmt.Errorf("updating agent: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("updating agent: %w", err)
+	}
+	if n == 0 {
+		return core.ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) DeleteAgent(ctx context.Context, id string) error {
+	result, err := s.DB.ExecContext(ctx, `DELETE FROM agents WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("deleting agent: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("deleting agent: %w", err)
+	}
+	if n == 0 {
+		return core.ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) GetConversation(ctx context.Context, id string) (*core.Conversation, error) {
+	row := s.DB.QueryRowContext(ctx,
+		`SELECT id, agent_id, user_id, title, status, created_at, updated_at
+		FROM conversations WHERE id = ?`, id)
+	c, err := scanConversation(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, core.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying conversation: %w", err)
+	}
+	return c, nil
+}
+
+func (s *Store) ListConversations(ctx context.Context, userID string, limit, offset int) ([]*core.Conversation, error) {
+	rows, err := s.DB.QueryContext(ctx,
+		`SELECT id, agent_id, user_id, title, status, created_at, updated_at
+		FROM conversations WHERE user_id = ? ORDER BY updated_at DESC LIMIT ? OFFSET ?`,
+		userID, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("listing conversations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var convs []*core.Conversation
+	for rows.Next() {
+		c, err := scanConversation(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning conversation row: %w", err)
+		}
+		convs = append(convs, c)
+	}
+	return convs, rows.Err()
+}
+
+func (s *Store) CreateConversation(ctx context.Context, conv *core.Conversation) error {
+	now := time.Now().UTC().Truncate(time.Second)
+	conv.ID = uuid.NewString()
+	conv.CreatedAt = now
+	conv.UpdatedAt = now
+	if conv.Status == "" {
+		conv.Status = core.ConversationActive
+	}
+
+	_, err := s.DB.ExecContext(ctx,
+		`INSERT INTO conversations (id, agent_id, user_id, title, status, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		conv.ID, conv.AgentID, conv.UserID, conv.Title, conv.Status, conv.CreatedAt, conv.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("inserting conversation: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) UpdateConversation(ctx context.Context, conv *core.Conversation) error {
+	conv.UpdatedAt = time.Now().UTC().Truncate(time.Second)
+
+	result, err := s.DB.ExecContext(ctx,
+		`UPDATE conversations SET title = ?, status = ?, updated_at = ? WHERE id = ?`,
+		conv.Title, conv.Status, conv.UpdatedAt, conv.ID)
+	if err != nil {
+		return fmt.Errorf("updating conversation: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("updating conversation: %w", err)
+	}
+	if n == 0 {
+		return core.ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) ListMessages(ctx context.Context, conversationID string) ([]*core.Message, error) {
+	rows, err := s.DB.QueryContext(ctx,
+		`SELECT id, conversation_id, role, content, tool_calls, tool_call_id, input_tokens, output_tokens, created_at
+		FROM messages WHERE conversation_id = ? ORDER BY created_at ASC`, conversationID)
+	if err != nil {
+		return nil, fmt.Errorf("listing messages: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var msgs []*core.Message
+	for rows.Next() {
+		m, err := scanMessage(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning message row: %w", err)
+		}
+		msgs = append(msgs, m)
+	}
+	return msgs, rows.Err()
+}
+
+func (s *Store) AppendMessage(ctx context.Context, msg *core.Message) error {
+	now := time.Now().UTC().Truncate(time.Second)
+	msg.ID = uuid.NewString()
+	msg.CreatedAt = now
+
+	var toolCalls, toolCallID any
+	if msg.ToolCalls != "" {
+		toolCalls = msg.ToolCalls
+	}
+	if msg.ToolCallID != "" {
+		toolCallID = msg.ToolCallID
+	}
+
+	_, err := s.DB.ExecContext(ctx,
+		`INSERT INTO messages (id, conversation_id, role, content, tool_calls, tool_call_id, input_tokens, output_tokens, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		msg.ID, msg.ConversationID, msg.Role, msg.Content,
+		toolCalls, toolCallID, msg.InputTokens, msg.OutputTokens, msg.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("inserting message: %w", err)
+	}
+	return nil
+}

--- a/plugins/chatstore/sqlite/factory.go
+++ b/plugins/chatstore/sqlite/factory.go
@@ -1,0 +1,24 @@
+package sqlite
+
+import (
+	"fmt"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"gopkg.in/yaml.v3"
+)
+
+type yamlConfig struct {
+	Path string `yaml:"path"`
+}
+
+var Factory bootstrap.ChatStoreFactory = func(node yaml.Node, deps bootstrap.Deps) (core.ChatStore, error) {
+	var cfg yamlConfig
+	if err := node.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("sqlite chatstore: parsing config: %w", err)
+	}
+	if cfg.Path == "" {
+		cfg.Path = "./chat.db"
+	}
+	return New(cfg.Path)
+}

--- a/plugins/chatstore/sqlite/sqlite.go
+++ b/plugins/chatstore/sqlite/sqlite.go
@@ -61,7 +61,10 @@ func (s *Store) Migrate(ctx context.Context) error {
 			input_tokens INTEGER NOT NULL DEFAULT 0,
 			output_tokens INTEGER NOT NULL DEFAULT 0,
 			created_at DATETIME NOT NULL
-		)
+		);
+		CREATE INDEX IF NOT EXISTS idx_agents_owner ON agents(owner_id);
+		CREATE INDEX IF NOT EXISTS idx_conversations_user ON conversations(user_id, updated_at);
+		CREATE INDEX IF NOT EXISTS idx_messages_conversation ON messages(conversation_id, created_at)
 	`)
 	return err
 }

--- a/plugins/chatstore/sqlite/sqlite.go
+++ b/plugins/chatstore/sqlite/sqlite.go
@@ -1,0 +1,67 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/plugins/chatstore/sqlchatstore"
+
+	_ "modernc.org/sqlite"
+)
+
+type Store struct {
+	*sqlchatstore.Store
+}
+
+var _ core.ChatStore = (*Store)(nil)
+
+func New(dbPath string) (*Store, error) {
+	dsn := dbPath + "?_pragma=journal_mode(wal)&_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("opening sqlite: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+
+	return &Store{Store: sqlchatstore.New(db)}, nil
+}
+
+func (s *Store) Migrate(ctx context.Context) error {
+	_, err := s.DB.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS agents (
+			id TEXT PRIMARY KEY,
+			owner_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			system_prompt TEXT NOT NULL DEFAULT '',
+			model TEXT NOT NULL DEFAULT '',
+			providers TEXT NOT NULL DEFAULT '[]',
+			temperature REAL NOT NULL DEFAULT 0,
+			max_tokens INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS conversations (
+			id TEXT PRIMARY KEY,
+			agent_id TEXT NOT NULL REFERENCES agents(id),
+			user_id TEXT NOT NULL,
+			title TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'active',
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS messages (
+			id TEXT PRIMARY KEY,
+			conversation_id TEXT NOT NULL REFERENCES conversations(id),
+			role TEXT NOT NULL,
+			content TEXT NOT NULL DEFAULT '',
+			tool_calls TEXT,
+			tool_call_id TEXT,
+			input_tokens INTEGER NOT NULL DEFAULT 0,
+			output_tokens INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME NOT NULL
+		)
+	`)
+	return err
+}

--- a/plugins/chatstore/sqlite/sqlite_test.go
+++ b/plugins/chatstore/sqlite/sqlite_test.go
@@ -300,7 +300,7 @@ func TestListAgentsEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListAgents: %v", err)
 	}
-	if agents != nil {
-		t.Errorf("expected nil for empty list, got %v", agents)
+	if len(agents) != 0 {
+		t.Errorf("expected empty list, got %v", agents)
 	}
 }

--- a/plugins/chatstore/sqlite/sqlite_test.go
+++ b/plugins/chatstore/sqlite/sqlite_test.go
@@ -1,0 +1,306 @@
+package sqlite
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+)
+
+const (
+	testOwner = "owner-001"
+	testUser  = "user-001"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test-chat.db")
+	s, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrating: %v", err)
+	}
+	return s
+}
+
+func TestMigrateIdempotent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	if err := s.Migrate(ctx); err != nil {
+		t.Fatalf("second migrate should be idempotent: %v", err)
+	}
+}
+
+func TestAgentCRUD(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	agent := &core.Agent{
+		OwnerID:      testOwner,
+		Name:         "test-agent",
+		SystemPrompt: "you are helpful",
+		Model:        "test-model-v1",
+		Providers:    []string{"provider-a", "provider-b"},
+		Temperature:  0.7,
+		MaxTokens:    1024,
+	}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	if agent.ID == "" {
+		t.Fatal("expected ID to be set after create")
+	}
+
+	got, err := s.GetAgent(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("GetAgent: %v", err)
+	}
+	if got.Name != "test-agent" {
+		t.Errorf("name = %q, want %q", got.Name, "test-agent")
+	}
+	if got.Model != "test-model-v1" {
+		t.Errorf("model = %q, want %q", got.Model, "test-model-v1")
+	}
+	if len(got.Providers) != 2 || got.Providers[0] != "provider-a" {
+		t.Errorf("providers = %v, want [provider-a provider-b]", got.Providers)
+	}
+	if got.Temperature != 0.7 {
+		t.Errorf("temperature = %v, want 0.7", got.Temperature)
+	}
+
+	agents, err := s.ListAgents(ctx, testOwner)
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	if len(agents) != 1 {
+		t.Fatalf("len(agents) = %d, want 1", len(agents))
+	}
+
+	agent.Name = "updated-agent"
+	if err := s.UpdateAgent(ctx, agent); err != nil {
+		t.Fatalf("UpdateAgent: %v", err)
+	}
+	got, err = s.GetAgent(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("GetAgent after update: %v", err)
+	}
+	if got.Name != "updated-agent" {
+		t.Errorf("name after update = %q, want %q", got.Name, "updated-agent")
+	}
+
+	if err := s.DeleteAgent(ctx, agent.ID); err != nil {
+		t.Fatalf("DeleteAgent: %v", err)
+	}
+	_, err = s.GetAgent(ctx, agent.ID)
+	if err != core.ErrNotFound {
+		t.Errorf("GetAgent after delete: got %v, want ErrNotFound", err)
+	}
+}
+
+func TestAgentNotFound(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := s.GetAgent(ctx, "nonexistent")
+	if err != core.ErrNotFound {
+		t.Errorf("GetAgent: got %v, want ErrNotFound", err)
+	}
+
+	err = s.UpdateAgent(ctx, &core.Agent{ID: "nonexistent", Name: "x"})
+	if err != core.ErrNotFound {
+		t.Errorf("UpdateAgent: got %v, want ErrNotFound", err)
+	}
+
+	err = s.DeleteAgent(ctx, "nonexistent")
+	if err != core.ErrNotFound {
+		t.Errorf("DeleteAgent: got %v, want ErrNotFound", err)
+	}
+}
+
+func TestConversationCRUD(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	agent := &core.Agent{OwnerID: testOwner, Name: "conv-agent", Providers: []string{}}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	conv := &core.Conversation{
+		AgentID: agent.ID,
+		UserID:  testUser,
+		Title:   "test conversation",
+	}
+	if err := s.CreateConversation(ctx, conv); err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+	if conv.ID == "" {
+		t.Fatal("expected ID to be set after create")
+	}
+	if conv.Status != core.ConversationActive {
+		t.Errorf("status = %q, want %q", conv.Status, core.ConversationActive)
+	}
+
+	got, err := s.GetConversation(ctx, conv.ID)
+	if err != nil {
+		t.Fatalf("GetConversation: %v", err)
+	}
+	if got.Title != "test conversation" {
+		t.Errorf("title = %q, want %q", got.Title, "test conversation")
+	}
+
+	convs, err := s.ListConversations(ctx, testUser, 10, 0)
+	if err != nil {
+		t.Fatalf("ListConversations: %v", err)
+	}
+	if len(convs) != 1 {
+		t.Fatalf("len(convs) = %d, want 1", len(convs))
+	}
+
+	conv.Title = "updated title"
+	conv.Status = core.ConversationArchived
+	if err := s.UpdateConversation(ctx, conv); err != nil {
+		t.Fatalf("UpdateConversation: %v", err)
+	}
+	got, err = s.GetConversation(ctx, conv.ID)
+	if err != nil {
+		t.Fatalf("GetConversation after update: %v", err)
+	}
+	if got.Title != "updated title" {
+		t.Errorf("title after update = %q, want %q", got.Title, "updated title")
+	}
+	if got.Status != core.ConversationArchived {
+		t.Errorf("status after update = %q, want %q", got.Status, core.ConversationArchived)
+	}
+}
+
+func TestConversationNotFound(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := s.GetConversation(ctx, "nonexistent")
+	if err != core.ErrNotFound {
+		t.Errorf("GetConversation: got %v, want ErrNotFound", err)
+	}
+
+	err = s.UpdateConversation(ctx, &core.Conversation{ID: "nonexistent", Title: "x"})
+	if err != core.ErrNotFound {
+		t.Errorf("UpdateConversation: got %v, want ErrNotFound", err)
+	}
+}
+
+func TestMessageAppendAndList(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	agent := &core.Agent{OwnerID: testOwner, Name: "msg-agent", Providers: []string{}}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	conv := &core.Conversation{AgentID: agent.ID, UserID: testUser, Title: "msg test"}
+	if err := s.CreateConversation(ctx, conv); err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+
+	userMsg := &core.Message{
+		ConversationID: conv.ID,
+		Role:           core.RoleUser,
+		Content:        "hello",
+	}
+	if err := s.AppendMessage(ctx, userMsg); err != nil {
+		t.Fatalf("AppendMessage (user): %v", err)
+	}
+	if userMsg.ID == "" {
+		t.Fatal("expected message ID to be set")
+	}
+
+	assistantMsg := &core.Message{
+		ConversationID: conv.ID,
+		Role:           core.RoleAssistant,
+		Content:        "hi there",
+		InputTokens:    10,
+		OutputTokens:   5,
+	}
+	if err := s.AppendMessage(ctx, assistantMsg); err != nil {
+		t.Fatalf("AppendMessage (assistant): %v", err)
+	}
+
+	toolMsg := &core.Message{
+		ConversationID: conv.ID,
+		Role:           core.RoleTool,
+		Content:        `{"result": "ok"}`,
+		ToolCallID:     "call-123",
+	}
+	if err := s.AppendMessage(ctx, toolMsg); err != nil {
+		t.Fatalf("AppendMessage (tool): %v", err)
+	}
+
+	msgs, err := s.ListMessages(ctx, conv.ID)
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("len(msgs) = %d, want 3", len(msgs))
+	}
+
+	if msgs[0].Role != core.RoleUser || msgs[0].Content != "hello" {
+		t.Errorf("msg[0] = {role:%s content:%s}, want {role:user content:hello}", msgs[0].Role, msgs[0].Content)
+	}
+	if msgs[1].InputTokens != 10 || msgs[1].OutputTokens != 5 {
+		t.Errorf("msg[1] tokens = {in:%d out:%d}, want {in:10 out:5}", msgs[1].InputTokens, msgs[1].OutputTokens)
+	}
+	if msgs[2].ToolCallID != "call-123" {
+		t.Errorf("msg[2] tool_call_id = %q, want %q", msgs[2].ToolCallID, "call-123")
+	}
+}
+
+func TestListConversationsPagination(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	agent := &core.Agent{OwnerID: testOwner, Name: "page-agent", Providers: []string{}}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		conv := &core.Conversation{AgentID: agent.ID, UserID: testUser, Title: "conv"}
+		if err := s.CreateConversation(ctx, conv); err != nil {
+			t.Fatalf("CreateConversation: %v", err)
+		}
+	}
+
+	page, err := s.ListConversations(ctx, testUser, 2, 0)
+	if err != nil {
+		t.Fatalf("ListConversations page 1: %v", err)
+	}
+	if len(page) != 2 {
+		t.Errorf("page 1 len = %d, want 2", len(page))
+	}
+
+	page, err = s.ListConversations(ctx, testUser, 2, 3)
+	if err != nil {
+		t.Fatalf("ListConversations page 2: %v", err)
+	}
+	if len(page) != 2 {
+		t.Errorf("offset=3 limit=2 len = %d, want 2", len(page))
+	}
+}
+
+func TestListAgentsEmpty(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	agents, err := s.ListAgents(ctx, "no-such-owner")
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	if agents != nil {
+		t.Errorf("expected nil for empty list, got %v", agents)
+	}
+}


### PR DESCRIPTION
## Summary
- New `core.ChatStore` interface for managing AI agent conversations, agents, and messages
- SQLite implementation with shared SQL layer (following existing sqlstore pattern)
- Bootstrap wiring: ChatStoreFactory, config parsing, RuntimeDeps/BindingDeps extensions

## Test plan
- [x] Unit tests for full CRUD lifecycle (agents, conversations, messages)
- [x] `go build ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)