### PR TITLE
Add Python sandbox runner with Claude streaming

### DIFF
--- a/sandbox/main.py
+++ b/sandbox/main.py
@@ -6,7 +6,6 @@ Go host's ToolService for executing integration operations.
 import argparse
 import logging
 import signal
-import threading
 from concurrent import futures
 
 import grpc
@@ -39,12 +38,10 @@ def main():
     server.start()
     log.info("sandbox listening on %s", args.listen_addr)
 
-    stop_event = threading.Event()
-
     def handle_signal(signum, frame):
         log.info("received signal %s, shutting down", signum)
-        stop_event.set()
         server.stop(grace=5)
+        tool_client.close()
 
     signal.signal(signal.SIGTERM, handle_signal)
     signal.signal(signal.SIGINT, handle_signal)

--- a/sandbox/main.py
+++ b/sandbox/main.py
@@ -1,0 +1,56 @@
+"""Gestalt sandbox process entry point.
+
+Starts a gRPC server implementing SandboxService and connects to the
+Go host's ToolService for executing integration operations.
+"""
+import argparse
+import logging
+import signal
+import threading
+from concurrent import futures
+
+import grpc
+
+from sandbox.pb import sandbox_pb2_grpc
+from sandbox.service import SandboxServicer
+from sandbox.tools import ToolClient
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+log = logging.getLogger("sandbox")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Gestalt sandbox process")
+    parser.add_argument("--listen-addr", required=True,
+                        help="Address for the gRPC server (e.g. unix:///tmp/sandbox.sock)")
+    parser.add_argument("--tool-service-addr", required=True,
+                        help="Address of the Go ToolService (e.g. localhost:50051)")
+    args = parser.parse_args()
+
+    tool_client = ToolClient(args.tool_service_addr)
+    servicer = SandboxServicer(tool_client)
+
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
+    sandbox_pb2_grpc.add_SandboxServiceServicer_to_server(servicer, server)
+    server.add_insecure_port(args.listen_addr)
+    server.start()
+    log.info("sandbox listening on %s", args.listen_addr)
+
+    stop_event = threading.Event()
+
+    def handle_signal(signum, frame):
+        log.info("received signal %s, shutting down", signum)
+        stop_event.set()
+        server.stop(grace=5)
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, handle_signal)
+
+    server.wait_for_termination()
+
+
+if __name__ == "__main__":
+    main()

--- a/sandbox/pyproject.toml
+++ b/sandbox/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "gestalt-sandbox"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "grpcio>=1.78.0",
+    "grpcio-tools>=1.78.0",
+    "anthropic>=0.40.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/sandbox/service.py
+++ b/sandbox/service.py
@@ -1,0 +1,176 @@
+"""SandboxService gRPC implementation."""
+import json
+import logging
+import time
+from typing import Iterator
+
+import anthropic
+import grpc
+
+from sandbox.pb import sandbox_pb2, sandbox_pb2_grpc
+from sandbox.tools import ToolClient
+
+log = logging.getLogger("sandbox.service")
+
+
+class SandboxServicer(sandbox_pb2_grpc.SandboxServiceServicer):
+    def __init__(self, tool_client: ToolClient):
+        self._tool_client = tool_client
+        self._status = "ready"
+        self._anthropic = anthropic.Anthropic()
+
+    def Health(self, request, context):
+        return sandbox_pb2.HealthResponse(
+            ready=self._status == "ready",
+            status=self._status,
+        )
+
+    def Shutdown(self, request, context):
+        self._status = "shutting_down"
+        return sandbox_pb2.ShutdownResponse(clean=True)
+
+    def Converse(self, request: sandbox_pb2.ConversationRequest, context) -> Iterator[sandbox_pb2.ConversationEvent]:
+        """Run a conversation turn with Claude, streaming events back to Go."""
+        self._status = "busy"
+        conv_id = request.conversation_id
+        start_time = time.monotonic()
+        full_text = ""
+        input_tokens = 0
+        output_tokens = 0
+
+        try:
+            messages = self._build_messages(request)
+            tools = self._tool_client.get_tools()
+
+            model = request.model or "claude-sonnet-4-20250514"
+            max_tokens = 8192
+            if request.settings.max_tokens > 0:
+                max_tokens = request.settings.max_tokens
+            temperature = None
+            if request.settings.temperature > 0:
+                temperature = request.settings.temperature
+
+            max_turns = 10
+            if request.settings.max_turns > 0:
+                max_turns = request.settings.max_turns
+
+            for turn in range(max_turns):
+                if not context.is_active():
+                    break
+
+                kwargs = dict(
+                    model=model,
+                    max_tokens=max_tokens,
+                    messages=messages,
+                    stream=True,
+                )
+                if request.system_prompt:
+                    kwargs["system"] = request.system_prompt
+                if tools:
+                    kwargs["tools"] = tools
+                if temperature is not None:
+                    kwargs["temperature"] = temperature
+
+                tool_calls = []
+                current_text = ""
+
+                with self._anthropic.messages.stream(**kwargs) as stream:
+                    for event in stream:
+                        if not context.is_active():
+                            break
+
+                        if hasattr(event, "type") and event.type == "content_block_delta":
+                            if hasattr(event.delta, "text"):
+                                current_text += event.delta.text
+                                full_text += event.delta.text
+                                yield sandbox_pb2.ConversationEvent(
+                                    conversation_id=conv_id,
+                                    text_delta=sandbox_pb2.TextDelta(content=event.delta.text),
+                                )
+
+                    final_message = stream.get_final_message()
+                    input_tokens += final_message.usage.input_tokens
+                    output_tokens += final_message.usage.output_tokens
+
+                    tool_calls = [
+                        {"id": block.id, "name": block.name, "input": block.input}
+                        for block in final_message.content
+                        if block.type == "tool_use"
+                    ]
+
+                if not tool_calls:
+                    break
+
+                # Execute each tool call and feed results back for the next turn
+                messages.append({"role": "assistant", "content": final_message.content})
+                tool_results = []
+
+                for tc in tool_calls:
+                    yield sandbox_pb2.ConversationEvent(
+                        conversation_id=conv_id,
+                        tool_use=sandbox_pb2.ToolUse(
+                            tool_call_id=tc["id"],
+                            tool_name=tc["name"],
+                            input_json=json.dumps(tc["input"]),
+                        ),
+                    )
+
+                    result = self._tool_client.execute(
+                        conversation_id=conv_id,
+                        user_id=request.user_id,
+                        tool_name=tc["name"],
+                        params=tc["input"],
+                    )
+
+                    is_error = result.get("error", "") != ""
+                    content = result.get("error") if is_error else result.get("result", "")
+
+                    yield sandbox_pb2.ConversationEvent(
+                        conversation_id=conv_id,
+                        tool_result=sandbox_pb2.ToolResult(
+                            tool_call_id=tc["id"],
+                            content_json=json.dumps(content) if not isinstance(content, str) else content,
+                            is_error=is_error,
+                        ),
+                    )
+
+                    tool_results.append({
+                        "type": "tool_result",
+                        "tool_use_id": tc["id"],
+                        "content": str(content),
+                        "is_error": is_error,
+                    })
+
+                messages.append({"role": "user", "content": tool_results})
+
+            duration_ms = int((time.monotonic() - start_time) * 1000)
+            yield sandbox_pb2.ConversationEvent(
+                conversation_id=conv_id,
+                turn_complete=sandbox_pb2.TurnComplete(
+                    model=model,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    duration_ms=duration_ms,
+                    num_turns=turn + 1,
+                    full_text=full_text,
+                ),
+            )
+
+        except Exception as e:
+            log.exception("error in conversation %s", conv_id)
+            yield sandbox_pb2.ConversationEvent(
+                conversation_id=conv_id,
+                error=sandbox_pb2.ErrorEvent(
+                    message=str(e),
+                    code="internal",
+                    recoverable=False,
+                ),
+            )
+        finally:
+            self._status = "ready"
+
+    def _build_messages(self, request):
+        messages = []
+        if request.user_message:
+            messages.append({"role": "user", "content": request.user_message})
+        return messages

--- a/sandbox/service.py
+++ b/sandbox/service.py
@@ -5,7 +5,6 @@ import time
 from typing import Iterator
 
 import anthropic
-import grpc
 
 from sandbox.pb import sandbox_pb2, sandbox_pb2_grpc
 from sandbox.tools import ToolClient
@@ -54,6 +53,7 @@ class SandboxServicer(sandbox_pb2_grpc.SandboxServiceServicer):
             if request.settings.max_turns > 0:
                 max_turns = request.settings.max_turns
 
+            turn = 0
             for turn in range(max_turns):
                 if not context.is_active():
                     break
@@ -62,7 +62,6 @@ class SandboxServicer(sandbox_pb2_grpc.SandboxServiceServicer):
                     model=model,
                     max_tokens=max_tokens,
                     messages=messages,
-                    stream=True,
                 )
                 if request.system_prompt:
                     kwargs["system"] = request.system_prompt
@@ -72,7 +71,6 @@ class SandboxServicer(sandbox_pb2_grpc.SandboxServiceServicer):
                     kwargs["temperature"] = temperature
 
                 tool_calls = []
-                current_text = ""
 
                 with self._anthropic.messages.stream(**kwargs) as stream:
                     for event in stream:
@@ -81,7 +79,6 @@ class SandboxServicer(sandbox_pb2_grpc.SandboxServiceServicer):
 
                         if hasattr(event, "type") and event.type == "content_block_delta":
                             if hasattr(event.delta, "text"):
-                                current_text += event.delta.text
                                 full_text += event.delta.text
                                 yield sandbox_pb2.ConversationEvent(
                                     conversation_id=conv_id,
@@ -122,7 +119,7 @@ class SandboxServicer(sandbox_pb2_grpc.SandboxServiceServicer):
                         params=tc["input"],
                     )
 
-                    is_error = result.get("error", "") != ""
+                    is_error = bool(result.get("error"))
                     content = result.get("error") if is_error else result.get("result", "")
 
                     yield sandbox_pb2.ConversationEvent(

--- a/sandbox/tools.py
+++ b/sandbox/tools.py
@@ -63,7 +63,8 @@ class ToolClient:
             return {"result": response.result_json, "status": response.status}
         except grpc.RpcError as e:
             log.error("tool execution failed: %s", e)
-            return {"error": f"tool execution failed: {e.details()}"}
+            details = e.details() if callable(getattr(e, "details", None)) else str(e)
+            return {"error": f"tool execution failed: {details}"}
 
     def close(self):
         self._channel.close()

--- a/sandbox/tools.py
+++ b/sandbox/tools.py
@@ -1,0 +1,69 @@
+"""ToolService gRPC client for calling Gestalt integration operations."""
+import json
+import logging
+
+import grpc
+
+from sandbox.pb import sandbox_pb2, sandbox_pb2_grpc
+
+log = logging.getLogger("sandbox.tools")
+
+
+class ToolClient:
+    def __init__(self, tool_service_addr: str):
+        self._channel = grpc.insecure_channel(tool_service_addr)
+        self._stub = sandbox_pb2_grpc.ToolServiceStub(self._channel)
+        self._tools_cache = None
+        self._tool_map: dict[str, tuple[str, str]] = {}
+
+    def get_tools(self) -> list[dict]:
+        """Fetch tools from Go's ToolService, formatted for the Anthropic API."""
+        if self._tools_cache is not None:
+            return self._tools_cache
+
+        response = self._stub.ListTools(sandbox_pb2.ListToolsRequest())
+        tools = []
+        for td in response.tools:
+            tool_name = f"{td.provider}_{td.operation}"
+            self._tool_map[tool_name] = (td.provider, td.operation)
+
+            if td.input_schema_json:
+                input_schema = json.loads(td.input_schema_json)
+            else:
+                input_schema = {"type": "object", "properties": {}}
+
+            tools.append({
+                "name": tool_name,
+                "description": td.description or f"{td.provider} {td.operation}",
+                "input_schema": input_schema,
+            })
+
+        self._tools_cache = tools
+        log.info("loaded %d tools from ToolService", len(tools))
+        return tools
+
+    def execute(self, conversation_id: str, user_id: str, tool_name: str, params: dict) -> dict:
+        """Execute a tool via Go's ToolService."""
+        provider, operation = self._tool_map.get(tool_name, (None, None))
+        if provider is None:
+            return {"error": f"unknown tool: {tool_name}"}
+
+        try:
+            response = self._stub.ExecuteTool(sandbox_pb2.ToolRequest(
+                conversation_id=conversation_id,
+                user_id=user_id,
+                provider=provider,
+                operation=operation,
+                params_json=json.dumps(params),
+            ))
+
+            if response.error:
+                return {"error": response.error}
+
+            return {"result": response.result_json, "status": response.status}
+        except grpc.RpcError as e:
+            log.error("tool execution failed: %s", e)
+            return {"error": f"tool execution failed: {e.details()}"}
+
+    def close(self):
+        self._channel.close()


### PR DESCRIPTION
## Summary
- Python gRPC sandbox process implementing SandboxService (Converse, Health, Shutdown)
- ToolClient wrapper for calling Go's ToolService (ExecuteTool, ListTools)
- Anthropic streaming API integration with agentic tool-use loop
- CLI entry point with configurable listen and tool service addresses

## Test plan
- [x] Python imports resolve correctly
- [ ] Integration test with Go sandbox manager
- [ ] End-to-end conversation with tool use

🤖 Generated with [Claude Code](https://claude.com/claude-code)