### PR TITLE
Rename upstream type "http" to "rest"

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -216,10 +216,10 @@ func defaultProviderFactory(providerDirs []string) bootstrap.ProviderFactory {
 
 		for _, us := range intg.Upstreams {
 			switch us.Type {
-			case config.UpstreamTypeHTTP:
+			case config.UpstreamTypeREST:
 				if apiProv != nil {
 					cleanup()
-					return nil, fmt.Errorf("integration %s: multiple http upstreams not supported", name)
+					return nil, fmt.Errorf("integration %s: multiple rest upstreams not supported", name)
 				}
 				def, err := loadHTTPUpstream(ctx, name, us, providerDirs)
 				if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,7 +101,7 @@ type IntegrationDef struct {
 }
 
 const (
-	UpstreamTypeHTTP = "http"
+	UpstreamTypeREST = "rest"
 	UpstreamTypeMCP  = "mcp"
 )
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -45,7 +45,7 @@ integrations:
     client_id: key-1
   beta:
     upstreams:
-      - type: http
+      - type: rest
         url: https://example.com/spec.json
     client_id: key-2
 server:
@@ -288,7 +288,7 @@ server:
 integrations:
   test_api:
     upstreams:
-      - type: http
+      - type: rest
         url: https://example.com/spec.json
         allowed_operations:
           - list_items
@@ -323,7 +323,7 @@ server:
 integrations:
   test_api:
     upstreams:
-      - type: http
+      - type: rest
         url: https://example.com/spec.json
         allowed_operations:
           list_items: List all items
@@ -358,7 +358,7 @@ server:
 integrations:
   test_api:
     upstreams:
-      - type: http
+      - type: rest
         url: https://example.com/spec.json
 `
 	path := mustWriteConfigFile(t, yaml)


### PR DESCRIPTION
The three upstream types (rest, graphql, mcp) are all HTTP-based, so
"http" was a misleading name for the REST/OpenAPI upstream. Renaming to
"rest" makes the taxonomy describe the API paradigm rather than the
transport protocol, consistent with the upcoming "graphql" upstream type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)