### PR TITLE
Add `type: graphql` upstream with introspection-based discovery

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -14,6 +14,7 @@ import (
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/internal/composite"
 	"github.com/valon-technologies/gestalt/internal/config"
+	graphqlupstream "github.com/valon-technologies/gestalt/internal/graphql"
 	"github.com/valon-technologies/gestalt/internal/mcpupstream"
 	"github.com/valon-technologies/gestalt/internal/openapi"
 	"github.com/valon-technologies/gestalt/internal/provider"
@@ -222,6 +223,23 @@ func defaultProviderFactory(providerDirs []string) bootstrap.ProviderFactory {
 					return nil, fmt.Errorf("integration %s: multiple rest upstreams not supported", name)
 				}
 				def, err := loadHTTPUpstream(ctx, name, us, providerDirs)
+				if err != nil {
+					cleanup()
+					return nil, err
+				}
+				p, err := provider.Build(def, intg, map[string]string(us.AllowedOperations))
+				if err != nil {
+					cleanup()
+					return nil, err
+				}
+				apiProv = p
+				mcpFromAPI = us.MCP
+			case config.UpstreamTypeGraphQL:
+				if apiProv != nil {
+					cleanup()
+					return nil, fmt.Errorf("integration %s: multiple api upstreams not supported", name)
+				}
+				def, err := graphqlupstream.LoadDefinition(ctx, name, us.URL, map[string]string(us.AllowedOperations))
 				if err != nil {
 					cleanup()
 					return nil, err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,8 +101,9 @@ type IntegrationDef struct {
 }
 
 const (
-	UpstreamTypeREST = "rest"
-	UpstreamTypeMCP  = "mcp"
+	UpstreamTypeREST    = "rest"
+	UpstreamTypeGraphQL = "graphql"
+	UpstreamTypeMCP     = "mcp"
 )
 
 type UpstreamDef struct {

--- a/internal/graphql/introspect.go
+++ b/internal/graphql/introspect.go
@@ -1,0 +1,198 @@
+package graphql
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/valon-technologies/gestalt/internal/apiexec"
+)
+
+const (
+	KindScalar      = "SCALAR"
+	KindObject      = "OBJECT"
+	KindEnum        = "ENUM"
+	KindInputObject = "INPUT_OBJECT"
+	KindNonNull     = "NON_NULL"
+	KindList        = "LIST"
+)
+
+type Schema struct {
+	QueryType    *TypeName  `json:"queryType"`
+	MutationType *TypeName  `json:"mutationType"`
+	Types        []FullType `json:"types"`
+	typeIndex    map[string]*FullType
+}
+
+type TypeName struct {
+	Name string `json:"name"`
+}
+
+type FullType struct {
+	Kind        string       `json:"kind"`
+	Name        string       `json:"name"`
+	Description string       `json:"description"`
+	Fields      []Field      `json:"fields"`
+	InputFields []InputValue `json:"inputFields"`
+	EnumValues  []EnumValue  `json:"enumValues"`
+}
+
+type Field struct {
+	Name        string       `json:"name"`
+	Description string       `json:"description"`
+	Args        []InputValue `json:"args"`
+	Type        TypeRef      `json:"type"`
+}
+
+type InputValue struct {
+	Name         string  `json:"name"`
+	Description  string  `json:"description"`
+	Type         TypeRef `json:"type"`
+	DefaultValue *string `json:"defaultValue"`
+}
+
+type EnumValue struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type TypeRef struct {
+	Kind   string   `json:"kind"`
+	Name   *string  `json:"name"`
+	OfType *TypeRef `json:"ofType"`
+}
+
+func (s *Schema) buildIndex() {
+	s.typeIndex = make(map[string]*FullType, len(s.Types))
+	for i := range s.Types {
+		s.typeIndex[s.Types[i].Name] = &s.Types[i]
+	}
+}
+
+func (s *Schema) lookupType(name string) *FullType {
+	if s.typeIndex == nil {
+		s.buildIndex()
+	}
+	return s.typeIndex[name]
+}
+
+const introspectionQuery = `query IntrospectionQuery {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    types {
+      kind
+      name
+      description
+      fields(includeDeprecated: false) {
+        name
+        description
+        args {
+          name
+          description
+          type { ...TypeRef }
+          defaultValue
+        }
+        type { ...TypeRef }
+      }
+      inputFields {
+        name
+        description
+        type { ...TypeRef }
+        defaultValue
+      }
+      enumValues(includeDeprecated: false) {
+        name
+        description
+      }
+    }
+  }
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+var defaultClient = &http.Client{Timeout: 30 * time.Second}
+
+func introspect(ctx context.Context, endpoint string) (*Schema, error) {
+	result, err := apiexec.DoGraphQL(ctx, defaultClient, apiexec.GraphQLRequest{
+		URL:   endpoint,
+		Query: introspectionQuery,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("introspection query: %w", err)
+	}
+
+	var resp struct {
+		Schema Schema `json:"__schema"`
+	}
+	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
+		return nil, fmt.Errorf("parsing introspection response: %w", err)
+	}
+
+	resp.Schema.buildIndex()
+	return &resp.Schema, nil
+}
+
+func (ref TypeRef) namedType() string {
+	if ref.Name != nil {
+		return *ref.Name
+	}
+	if ref.OfType != nil {
+		return ref.OfType.namedType()
+	}
+	return ""
+}
+
+func (ref TypeRef) isNonNull() bool {
+	return ref.Kind == KindNonNull
+}
+
+func (ref TypeRef) isList() bool {
+	if ref.Kind == KindList {
+		return true
+	}
+	if ref.Kind == KindNonNull && ref.OfType != nil {
+		return ref.OfType.isList()
+	}
+	return false
+}
+
+func (ref TypeRef) innerType() TypeRef {
+	r := ref
+	for r.Kind == KindNonNull || r.Kind == KindList {
+		if r.OfType == nil {
+			break
+		}
+		r = *r.OfType
+	}
+	return r
+}

--- a/internal/graphql/loader.go
+++ b/internal/graphql/loader.go
@@ -1,0 +1,111 @@
+package graphql
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+func LoadDefinition(ctx context.Context, name, endpoint string, allowedOps map[string]string) (*provider.Definition, error) {
+	schema, err := introspect(ctx, endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("introspecting %s: %w", endpoint, err)
+	}
+
+	def := &provider.Definition{
+		Provider: name,
+		BaseURL:  strings.TrimRight(endpoint, "/"),
+	}
+
+	def.Operations = make(map[string]provider.OperationDef)
+	addOperations(schema, def, schema.QueryType, false, allowedOps)
+	addOperations(schema, def, schema.MutationType, true, allowedOps)
+
+	if len(def.Operations) == 0 {
+		return nil, fmt.Errorf("no operations found for %s", endpoint)
+	}
+
+	return def, nil
+}
+
+func addOperations(schema *Schema, def *provider.Definition, root *TypeName, isMutation bool, allowedOps map[string]string) {
+	if root == nil {
+		return
+	}
+	rootType := schema.lookupType(root.Name)
+	if rootType == nil {
+		return
+	}
+
+	for _, field := range rootType.Fields {
+		if strings.HasPrefix(field.Name, "__") {
+			continue
+		}
+
+		if allowedOps != nil {
+			if _, ok := allowedOps[field.Name]; !ok {
+				continue
+			}
+		}
+
+		desc := field.Description
+		if override, ok := allowedOps[field.Name]; ok && override != "" {
+			desc = override
+		}
+
+		query := generateQuery(schema, field, isMutation)
+		inputSchema := argsToJSONSchema(schema, field.Args)
+
+		opDef := provider.OperationDef{
+			Description: provider.TruncateDescription(desc),
+			Transport:   "graphql",
+			Query:       query,
+		}
+
+		opDef.Parameters = argsToParams(schema, field.Args)
+		opDef.InputSchema = inputSchema
+
+		def.Operations[field.Name] = opDef
+	}
+}
+
+func argsToParams(schema *Schema, args []InputValue) []provider.ParameterDef {
+	if len(args) == 0 {
+		return nil
+	}
+	params := make([]provider.ParameterDef, 0, len(args))
+	for _, arg := range args {
+		params = append(params, provider.ParameterDef{
+			Name:        arg.Name,
+			Type:        graphqlTypeToSimple(schema, arg.Type),
+			Description: arg.Description,
+			Required:    arg.Type.isNonNull(),
+		})
+	}
+	return params
+}
+
+func graphqlTypeToSimple(schema *Schema, ref TypeRef) string {
+	if ref.isList() {
+		return "array"
+	}
+	inner := ref.innerType()
+	typeName := inner.namedType()
+	switch typeName {
+	case "String", "ID", "DateTime", "Date", "URI", "URL", "UUID", "JSONString", "TimelessDate":
+		return "string"
+	case "Int":
+		return "integer"
+	case "Float":
+		return "number"
+	case "Boolean":
+		return "boolean"
+	default:
+		if ft := schema.lookupType(typeName); ft != nil && (ft.Kind == KindEnum || ft.Kind == KindScalar) {
+			return "string"
+		}
+		return "object"
+	}
+}

--- a/internal/graphql/loader_test.go
+++ b/internal/graphql/loader_test.go
@@ -1,0 +1,185 @@
+package graphql
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newTestSchema() Schema {
+	return Schema{
+		QueryType:    &TypeName{Name: "Query"},
+		MutationType: &TypeName{Name: "Mutation"},
+		Types: []FullType{
+			{Kind: "OBJECT", Name: "Query", Fields: []Field{
+				{
+					Name:        "teams",
+					Description: "List all teams",
+					Args: []InputValue{
+						{Name: "first", Type: TypeRef{Kind: "SCALAR", Name: strPtr("Int")}},
+					},
+					Type: TypeRef{Kind: "OBJECT", Name: strPtr("TeamConnection")},
+				},
+				{
+					Name:        "issue",
+					Description: "Get an issue by ID",
+					Args: []InputValue{
+						{Name: "id", Type: TypeRef{Kind: "NON_NULL", OfType: &TypeRef{Kind: "SCALAR", Name: strPtr("String")}}},
+					},
+					Type: TypeRef{Kind: "OBJECT", Name: strPtr("Issue")},
+				},
+			}},
+			{Kind: "OBJECT", Name: "Mutation", Fields: []Field{
+				{
+					Name:        "createIssue",
+					Description: "Create a new issue",
+					Args: []InputValue{
+						{Name: "input", Type: TypeRef{Kind: "NON_NULL", OfType: &TypeRef{Kind: "INPUT_OBJECT", Name: strPtr("CreateIssueInput")}}},
+					},
+					Type: TypeRef{Kind: "OBJECT", Name: strPtr("IssuePayload")},
+				},
+			}},
+			{Kind: "OBJECT", Name: "TeamConnection", Fields: []Field{
+				{Name: "nodes", Type: TypeRef{Kind: "LIST", OfType: &TypeRef{Kind: "OBJECT", Name: strPtr("Team")}}},
+				{Name: "pageInfo", Type: TypeRef{Kind: "OBJECT", Name: strPtr("PageInfo")}},
+			}},
+			{Kind: "OBJECT", Name: "Team", Fields: []Field{
+				{Name: "id", Type: TypeRef{Kind: "SCALAR", Name: strPtr("ID")}},
+				{Name: "name", Type: TypeRef{Kind: "SCALAR", Name: strPtr("String")}},
+			}},
+			{Kind: "OBJECT", Name: "Issue", Fields: []Field{
+				{Name: "id", Type: TypeRef{Kind: "SCALAR", Name: strPtr("ID")}},
+				{Name: "title", Type: TypeRef{Kind: "SCALAR", Name: strPtr("String")}},
+				{Name: "state", Type: TypeRef{Kind: "OBJECT", Name: strPtr("State")}},
+			}},
+			{Kind: "OBJECT", Name: "State", Fields: []Field{
+				{Name: "name", Type: TypeRef{Kind: "SCALAR", Name: strPtr("String")}},
+			}},
+			{Kind: "OBJECT", Name: "PageInfo", Fields: []Field{
+				{Name: "hasNextPage", Type: TypeRef{Kind: "SCALAR", Name: strPtr("Boolean")}},
+				{Name: "endCursor", Type: TypeRef{Kind: "SCALAR", Name: strPtr("String")}},
+			}},
+			{Kind: "INPUT_OBJECT", Name: "CreateIssueInput", InputFields: []InputValue{
+				{Name: "title", Type: TypeRef{Kind: "NON_NULL", OfType: &TypeRef{Kind: "SCALAR", Name: strPtr("String")}}},
+				{Name: "teamId", Type: TypeRef{Kind: "NON_NULL", OfType: &TypeRef{Kind: "SCALAR", Name: strPtr("String")}}},
+				{Name: "description", Type: TypeRef{Kind: "SCALAR", Name: strPtr("String")}},
+				{Name: "priority", Type: TypeRef{Kind: "ENUM", Name: strPtr("IssuePriority")}},
+			}},
+			{Kind: "ENUM", Name: "IssuePriority", EnumValues: []EnumValue{
+				{Name: "noPriority"}, {Name: "urgent"}, {Name: "high"}, {Name: "medium"}, {Name: "low"},
+			}},
+			{Kind: "OBJECT", Name: "IssuePayload", Fields: []Field{
+				{Name: "success", Type: TypeRef{Kind: "SCALAR", Name: strPtr("Boolean")}},
+				{Name: "issue", Type: TypeRef{Kind: "OBJECT", Name: strPtr("Issue")}},
+			}},
+		},
+	}
+}
+
+func startIntrospectionServer(t *testing.T, schema Schema) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"data": map[string]any{
+				"__schema": schema,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func TestLoadDefinitionAllOps(t *testing.T) {
+	t.Parallel()
+
+	srv := startIntrospectionServer(t, newTestSchema())
+	defer srv.Close()
+
+	def, err := LoadDefinition(t.Context(), "test", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("LoadDefinition: %v", err)
+	}
+
+	if def.Provider != "test" {
+		t.Errorf("Provider: got %q, want test", def.Provider)
+	}
+	if def.BaseURL != srv.URL {
+		t.Errorf("BaseURL: got %q, want %q", def.BaseURL, srv.URL)
+	}
+
+	if len(def.Operations) != 3 {
+		t.Fatalf("Operations: got %d, want 3 (teams, issue, createIssue)", len(def.Operations))
+	}
+
+	teams := def.Operations["teams"]
+	if teams.Transport != "graphql" {
+		t.Errorf("teams.Transport: got %q, want graphql", teams.Transport)
+	}
+	if teams.Query == "" {
+		t.Error("teams.Query should not be empty")
+	}
+	if teams.Description != "List all teams" {
+		t.Errorf("teams.Description: got %q", teams.Description)
+	}
+
+	createIssue := def.Operations["createIssue"]
+	if createIssue.Query == "" {
+		t.Error("createIssue.Query should not be empty")
+	}
+
+	var inputSchema map[string]any
+	if err := json.Unmarshal(createIssue.InputSchema, &inputSchema); err != nil {
+		t.Fatalf("createIssue.InputSchema: %v", err)
+	}
+	props := inputSchema["properties"].(map[string]any)
+	inputProp := props["input"].(map[string]any)
+	if inputProp["type"] != "object" {
+		t.Errorf("input type: got %v, want object", inputProp["type"])
+	}
+	inputProps := inputProp["properties"].(map[string]any)
+	priorityProp := inputProps["priority"].(map[string]any)
+	if _, hasEnum := priorityProp["enum"]; !hasEnum {
+		t.Error("priority should have enum values")
+	}
+}
+
+func TestLoadDefinitionWithAllowedOps(t *testing.T) {
+	t.Parallel()
+
+	srv := startIntrospectionServer(t, newTestSchema())
+	defer srv.Close()
+
+	def, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]string{
+		"teams": "My custom description",
+	})
+	if err != nil {
+		t.Fatalf("LoadDefinition: %v", err)
+	}
+
+	if len(def.Operations) != 1 {
+		t.Fatalf("Operations: got %d, want 1 (only teams)", len(def.Operations))
+	}
+
+	teams := def.Operations["teams"]
+	if teams.Description != "My custom description" {
+		t.Errorf("teams.Description: got %q, want custom override", teams.Description)
+	}
+}
+
+func TestLoadDefinitionEmptySchemaErrors(t *testing.T) {
+	t.Parallel()
+
+	srv := startIntrospectionServer(t, Schema{
+		QueryType: &TypeName{Name: "Query"},
+		Types: []FullType{
+			{Kind: "OBJECT", Name: "Query", Fields: []Field{}},
+		},
+	})
+	defer srv.Close()
+
+	_, err := LoadDefinition(t.Context(), "test", srv.URL, nil)
+	if err == nil {
+		t.Fatal("expected error for empty schema")
+	}
+}

--- a/internal/graphql/query.go
+++ b/internal/graphql/query.go
@@ -1,0 +1,178 @@
+package graphql
+
+import (
+	"fmt"
+	"strings"
+)
+
+const defaultMaxDepth = 2
+
+func generateQuery(schema *Schema, field Field, isMutation bool) string {
+	var b strings.Builder
+
+	if isMutation {
+		b.WriteString("mutation")
+	} else {
+		b.WriteString("query")
+	}
+
+	if len(field.Args) > 0 {
+		b.WriteByte('(')
+		for i, arg := range field.Args {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			fmt.Fprintf(&b, "$%s: %s", arg.Name, formatTypeRef(arg.Type))
+		}
+		b.WriteByte(')')
+	}
+
+	b.WriteString(" { ")
+	b.WriteString(field.Name)
+
+	if len(field.Args) > 0 {
+		b.WriteByte('(')
+		for i, arg := range field.Args {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			fmt.Fprintf(&b, "%s: $%s", arg.Name, arg.Name)
+		}
+		b.WriteByte(')')
+	}
+
+	selectionSet := buildSelectionSet(schema, field.Type, defaultMaxDepth, nil)
+	if selectionSet != "" {
+		b.WriteString(" ")
+		b.WriteString(selectionSet)
+	}
+
+	b.WriteString(" }")
+	return b.String()
+}
+
+func buildSelectionSet(schema *Schema, ref TypeRef, depth int, ancestors map[string]bool) string {
+	if depth < 0 {
+		return ""
+	}
+
+	inner := ref.innerType()
+	typeName := inner.namedType()
+	if typeName == "" {
+		return ""
+	}
+
+	ft := schema.lookupType(typeName)
+	if ft == nil || ft.Kind != KindObject {
+		return ""
+	}
+
+	if ancestors[typeName] {
+		return ""
+	}
+
+	if ancestors == nil {
+		ancestors = make(map[string]bool)
+	}
+	ancestors[typeName] = true
+	defer delete(ancestors, typeName)
+
+	if isConnectionType(ft) {
+		return buildConnectionSelectionSet(schema, ft, depth-1, ancestors)
+	}
+
+	var fields []string
+	for _, f := range ft.Fields {
+		if strings.HasPrefix(f.Name, "__") {
+			continue
+		}
+
+		fieldInner := f.Type.innerType()
+		fieldTypeName := fieldInner.namedType()
+		fieldType := schema.lookupType(fieldTypeName)
+
+		if fieldType == nil {
+			fields = append(fields, f.Name)
+			continue
+		}
+
+		switch fieldType.Kind {
+		case KindScalar, KindEnum:
+			fields = append(fields, f.Name)
+		case KindObject:
+			if depth <= 0 {
+				continue
+			}
+			sub := buildSelectionSet(schema, f.Type, depth-1, ancestors)
+			if sub != "" {
+				fields = append(fields, f.Name+" "+sub)
+			}
+		}
+	}
+
+	if len(fields) == 0 {
+		return ""
+	}
+	return "{ " + strings.Join(fields, " ") + " }"
+}
+
+func isConnectionType(ft *FullType) bool {
+	if !strings.HasSuffix(ft.Name, "Connection") {
+		return false
+	}
+	hasNodes := false
+	hasPageInfo := false
+	for _, f := range ft.Fields {
+		switch f.Name {
+		case "nodes":
+			hasNodes = true
+		case "pageInfo":
+			hasPageInfo = true
+		}
+		if hasNodes && hasPageInfo {
+			return true
+		}
+	}
+	return false
+}
+
+func buildConnectionSelectionSet(schema *Schema, ft *FullType, depth int, ancestors map[string]bool) string {
+	var parts []string
+
+	for _, f := range ft.Fields {
+		if f.Name == "nodes" {
+			sub := buildSelectionSet(schema, f.Type, depth, ancestors)
+			if sub != "" {
+				parts = append(parts, "nodes "+sub)
+			}
+		}
+		if f.Name == "pageInfo" {
+			parts = append(parts, "pageInfo { hasNextPage endCursor }")
+		}
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+	return "{ " + strings.Join(parts, " ") + " }"
+}
+
+func formatTypeRef(ref TypeRef) string {
+	switch ref.Kind {
+	case KindNonNull:
+		if ref.OfType != nil {
+			return formatTypeRef(*ref.OfType) + "!"
+		}
+		return "Unknown!"
+	case KindList:
+		if ref.OfType != nil {
+			return "[" + formatTypeRef(*ref.OfType) + "]"
+		}
+		return "[Unknown]"
+	default:
+		if ref.Name != nil {
+			return *ref.Name
+		}
+		return "Unknown"
+	}
+}

--- a/internal/graphql/query_test.go
+++ b/internal/graphql/query_test.go
@@ -1,0 +1,243 @@
+package graphql
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateQuerySimple(t *testing.T) {
+	t.Parallel()
+
+	schema := &Schema{
+		Types: []FullType{
+			{Kind: "OBJECT", Name: "Team", Fields: []Field{
+				{Name: "id", Type: TypeRef{Kind: "SCALAR", Name: strPtr("ID")}},
+				{Name: "name", Type: TypeRef{Kind: "SCALAR", Name: strPtr("String")}},
+			}},
+		},
+	}
+	schema.buildIndex()
+
+	field := Field{
+		Name: "team",
+		Args: []InputValue{
+			{Name: "id", Type: TypeRef{Kind: "NON_NULL", OfType: &TypeRef{Kind: "SCALAR", Name: strPtr("String")}}},
+		},
+		Type: TypeRef{Kind: "OBJECT", Name: strPtr("Team")},
+	}
+
+	query := generateQuery(schema, field, false)
+
+	if !strings.HasPrefix(query, "query(") {
+		t.Errorf("should start with query(: %s", query)
+	}
+	if !strings.Contains(query, "$id: String!") {
+		t.Errorf("should declare $id variable: %s", query)
+	}
+	if !strings.Contains(query, "team(id: $id)") {
+		t.Errorf("should pass id argument: %s", query)
+	}
+	if !strings.Contains(query, "{ id name }") {
+		t.Errorf("should select scalar fields: %s", query)
+	}
+}
+
+func TestGenerateQueryMutation(t *testing.T) {
+	t.Parallel()
+
+	schema := &Schema{
+		Types: []FullType{
+			{Kind: "OBJECT", Name: "Result", Fields: []Field{
+				{Name: "success", Type: TypeRef{Kind: "SCALAR", Name: strPtr("Boolean")}},
+			}},
+		},
+	}
+	schema.buildIndex()
+
+	field := Field{
+		Name: "deleteItem",
+		Args: []InputValue{
+			{Name: "id", Type: TypeRef{Kind: "NON_NULL", OfType: &TypeRef{Kind: "SCALAR", Name: strPtr("ID")}}},
+		},
+		Type: TypeRef{Kind: "OBJECT", Name: strPtr("Result")},
+	}
+
+	query := generateQuery(schema, field, true)
+
+	if !strings.HasPrefix(query, "mutation(") {
+		t.Errorf("should start with mutation(: %s", query)
+	}
+}
+
+func TestGenerateQueryNoArgs(t *testing.T) {
+	t.Parallel()
+
+	schema := &Schema{
+		Types: []FullType{
+			{Kind: "OBJECT", Name: "User", Fields: []Field{
+				{Name: "id", Type: TypeRef{Kind: "SCALAR", Name: strPtr("ID")}},
+				{Name: "email", Type: TypeRef{Kind: "SCALAR", Name: strPtr("String")}},
+			}},
+		},
+	}
+	schema.buildIndex()
+
+	field := Field{
+		Name: "viewer",
+		Type: TypeRef{Kind: "OBJECT", Name: strPtr("User")},
+	}
+
+	query := generateQuery(schema, field, false)
+
+	if !strings.HasPrefix(query, "query { viewer") {
+		t.Errorf("should be simple query: %s", query)
+	}
+	if strings.Contains(query, "(") && strings.Contains(query, "$") {
+		t.Errorf("should not have variable declaration: %s", query)
+	}
+}
+
+func TestConnectionTypeDetection(t *testing.T) {
+	t.Parallel()
+
+	schema := &Schema{
+		Types: []FullType{
+			{Kind: "OBJECT", Name: "IssueConnection", Fields: []Field{
+				{Name: "nodes", Type: TypeRef{Kind: "LIST", OfType: &TypeRef{Kind: "OBJECT", Name: strPtr("Issue")}}},
+				{Name: "pageInfo", Type: TypeRef{Kind: "OBJECT", Name: strPtr("PageInfo")}},
+			}},
+			{Kind: "OBJECT", Name: "Issue", Fields: []Field{
+				{Name: "id", Type: TypeRef{Kind: "SCALAR", Name: strPtr("ID")}},
+				{Name: "title", Type: TypeRef{Kind: "SCALAR", Name: strPtr("String")}},
+			}},
+			{Kind: "OBJECT", Name: "PageInfo", Fields: []Field{
+				{Name: "hasNextPage", Type: TypeRef{Kind: "SCALAR", Name: strPtr("Boolean")}},
+				{Name: "endCursor", Type: TypeRef{Kind: "SCALAR", Name: strPtr("String")}},
+			}},
+		},
+	}
+	schema.buildIndex()
+
+	field := Field{
+		Name: "issues",
+		Type: TypeRef{Kind: "OBJECT", Name: strPtr("IssueConnection")},
+	}
+
+	query := generateQuery(schema, field, false)
+
+	if !strings.Contains(query, "nodes { id title }") {
+		t.Errorf("should unwrap connection nodes: %s", query)
+	}
+	if !strings.Contains(query, "pageInfo { hasNextPage endCursor }") {
+		t.Errorf("should include pageInfo: %s", query)
+	}
+}
+
+func TestSelectionSetDepthLimit(t *testing.T) {
+	t.Parallel()
+
+	schema := &Schema{
+		Types: []FullType{
+			{Kind: "OBJECT", Name: "A", Fields: []Field{
+				{Name: "id", Type: TypeRef{Kind: "SCALAR", Name: strPtr("ID")}},
+				{Name: "b", Type: TypeRef{Kind: "OBJECT", Name: strPtr("B")}},
+			}},
+			{Kind: "OBJECT", Name: "B", Fields: []Field{
+				{Name: "name", Type: TypeRef{Kind: "SCALAR", Name: strPtr("String")}},
+				{Name: "c", Type: TypeRef{Kind: "OBJECT", Name: strPtr("C")}},
+			}},
+			{Kind: "OBJECT", Name: "C", Fields: []Field{
+				{Name: "value", Type: TypeRef{Kind: "SCALAR", Name: strPtr("String")}},
+				{Name: "d", Type: TypeRef{Kind: "OBJECT", Name: strPtr("D")}},
+			}},
+			{Kind: "OBJECT", Name: "D", Fields: []Field{
+				{Name: "deep", Type: TypeRef{Kind: "SCALAR", Name: strPtr("String")}},
+			}},
+		},
+	}
+	schema.buildIndex()
+
+	field := Field{
+		Name: "getA",
+		Type: TypeRef{Kind: "OBJECT", Name: strPtr("A")},
+	}
+
+	query := generateQuery(schema, field, false)
+
+	if !strings.Contains(query, "value") {
+		t.Errorf("depth 2 should include C.value: %s", query)
+	}
+	if strings.Contains(query, "deep") {
+		t.Errorf("depth 2 should NOT include D.deep: %s", query)
+	}
+}
+
+func TestSelectionSetCyclePrevention(t *testing.T) {
+	t.Parallel()
+
+	schema := &Schema{
+		Types: []FullType{
+			{Kind: "OBJECT", Name: "Node", Fields: []Field{
+				{Name: "id", Type: TypeRef{Kind: "SCALAR", Name: strPtr("ID")}},
+				{Name: "parent", Type: TypeRef{Kind: "OBJECT", Name: strPtr("Node")}},
+			}},
+		},
+	}
+	schema.buildIndex()
+
+	field := Field{
+		Name: "getNode",
+		Type: TypeRef{Kind: "OBJECT", Name: strPtr("Node")},
+	}
+
+	query := generateQuery(schema, field, false)
+
+	if strings.Count(query, "parent") > 1 {
+		t.Errorf("should not recurse into self-referential type: %s", query)
+	}
+}
+
+func TestFormatTypeRef(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ref  TypeRef
+		want string
+	}{
+		{
+			"simple",
+			TypeRef{Kind: "SCALAR", Name: strPtr("String")},
+			"String",
+		},
+		{
+			"non-null",
+			TypeRef{Kind: "NON_NULL", OfType: &TypeRef{Kind: "SCALAR", Name: strPtr("Int")}},
+			"Int!",
+		},
+		{
+			"list",
+			TypeRef{Kind: "LIST", OfType: &TypeRef{Kind: "SCALAR", Name: strPtr("String")}},
+			"[String]",
+		},
+		{
+			"non-null list of non-null",
+			TypeRef{Kind: "NON_NULL", OfType: &TypeRef{
+				Kind: "LIST", OfType: &TypeRef{
+					Kind: "NON_NULL", OfType: &TypeRef{Kind: "SCALAR", Name: strPtr("ID")},
+				},
+			}},
+			"[ID!]!",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := formatTypeRef(tc.ref)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/graphql/schema.go
+++ b/internal/graphql/schema.go
@@ -1,0 +1,127 @@
+package graphql
+
+import "encoding/json"
+
+func inputTypeToJSONSchema(schema *Schema, ref TypeRef, visited map[string]bool) json.RawMessage {
+	if ref.isNonNull() && ref.OfType != nil {
+		return inputTypeToJSONSchema(schema, *ref.OfType, visited)
+	}
+
+	if ref.isList() && ref.OfType != nil {
+		items := inputTypeToJSONSchema(schema, *ref.OfType, visited)
+		return marshalSchema(map[string]any{
+			"type":  "array",
+			"items": items,
+		})
+	}
+
+	typeName := ref.namedType()
+	switch typeName {
+	case "String", "DateTime", "Date", "URI", "URL", "UUID", "JSONString", "TimelessDate":
+		return marshalSchema(map[string]any{"type": "string"})
+	case "Int":
+		return marshalSchema(map[string]any{"type": "integer"})
+	case "Float":
+		return marshalSchema(map[string]any{"type": "number"})
+	case "Boolean":
+		return marshalSchema(map[string]any{"type": "boolean"})
+	case "ID":
+		return marshalSchema(map[string]any{"type": "string"})
+	}
+
+	ft := schema.lookupType(typeName)
+	if ft == nil {
+		return marshalSchema(map[string]any{"type": "string"})
+	}
+
+	switch ft.Kind {
+	case KindEnum:
+		vals := make([]string, len(ft.EnumValues))
+		for i, ev := range ft.EnumValues {
+			vals[i] = ev.Name
+		}
+		return marshalSchema(map[string]any{
+			"type": "string",
+			"enum": vals,
+		})
+
+	case KindInputObject:
+		if visited[typeName] {
+			return marshalSchema(map[string]any{"type": "object"})
+		}
+		visited[typeName] = true
+		defer delete(visited, typeName)
+
+		props := make(map[string]json.RawMessage, len(ft.InputFields))
+		var required []string
+		for _, field := range ft.InputFields {
+			props[field.Name] = inputTypeToJSONSchema(schema, field.Type, visited)
+			if field.Type.isNonNull() {
+				required = append(required, field.Name)
+			}
+		}
+		result := map[string]any{
+			"type":       "object",
+			"properties": props,
+		}
+		if len(required) > 0 {
+			result["required"] = required
+		}
+		return marshalSchema(result)
+
+	case KindScalar:
+		return marshalSchema(map[string]any{"type": "string"})
+
+	default:
+		return marshalSchema(map[string]any{"type": "string"})
+	}
+}
+
+func argsToJSONSchema(schema *Schema, args []InputValue) json.RawMessage {
+	if len(args) == 0 {
+		return marshalSchema(map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		})
+	}
+
+	props := make(map[string]json.RawMessage, len(args))
+	var required []string
+	visited := make(map[string]bool)
+
+	for _, arg := range args {
+		propSchema := inputTypeToJSONSchema(schema, arg.Type, visited)
+
+		if arg.Description != "" {
+			propSchema = withDescription(propSchema, arg.Description)
+		}
+
+		props[arg.Name] = propSchema
+		if arg.Type.isNonNull() {
+			required = append(required, arg.Name)
+		}
+	}
+
+	result := map[string]any{
+		"type":       "object",
+		"properties": props,
+	}
+	if len(required) > 0 {
+		result["required"] = required
+	}
+	return marshalSchema(result)
+}
+
+func marshalSchema(v any) json.RawMessage {
+	b, _ := json.Marshal(v)
+	return b
+}
+
+func withDescription(schema json.RawMessage, desc string) json.RawMessage {
+	var m map[string]any
+	if json.Unmarshal(schema, &m) != nil {
+		return schema
+	}
+	m["description"] = desc
+	return marshalSchema(m)
+}

--- a/internal/graphql/schema_test.go
+++ b/internal/graphql/schema_test.go
@@ -1,0 +1,327 @@
+package graphql
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestInputTypeToJSONSchemaScalars(t *testing.T) {
+	t.Parallel()
+
+	schema := &Schema{}
+	schema.buildIndex()
+
+	cases := []struct {
+		name     string
+		ref      TypeRef
+		wantType string
+	}{
+		{"String", TypeRef{Kind: "SCALAR", Name: strPtr("String")}, "string"},
+		{"Int", TypeRef{Kind: "SCALAR", Name: strPtr("Int")}, "integer"},
+		{"Float", TypeRef{Kind: "SCALAR", Name: strPtr("Float")}, "number"},
+		{"Boolean", TypeRef{Kind: "SCALAR", Name: strPtr("Boolean")}, "boolean"},
+		{"ID", TypeRef{Kind: "SCALAR", Name: strPtr("ID")}, "string"},
+		{"DateTime", TypeRef{Kind: "SCALAR", Name: strPtr("DateTime")}, "string"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := inputTypeToJSONSchema(schema, tc.ref, make(map[string]bool))
+			var parsed map[string]any
+			if err := json.Unmarshal(result, &parsed); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if parsed["type"] != tc.wantType {
+				t.Errorf("type: got %v, want %s", parsed["type"], tc.wantType)
+			}
+		})
+	}
+}
+
+func TestInputTypeToJSONSchemaEnum(t *testing.T) {
+	t.Parallel()
+
+	schema := &Schema{
+		Types: []FullType{
+			{
+				Kind: "ENUM",
+				Name: "Priority",
+				EnumValues: []EnumValue{
+					{Name: "LOW"},
+					{Name: "MEDIUM"},
+					{Name: "HIGH"},
+				},
+			},
+		},
+	}
+	schema.buildIndex()
+
+	ref := TypeRef{Kind: "ENUM", Name: strPtr("Priority")}
+	result := inputTypeToJSONSchema(schema, ref, make(map[string]bool))
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if parsed["type"] != "string" {
+		t.Errorf("type: got %v, want string", parsed["type"])
+	}
+
+	enumVals, ok := parsed["enum"].([]any)
+	if !ok || len(enumVals) != 3 {
+		t.Fatalf("enum: got %v, want 3 values", parsed["enum"])
+	}
+	if enumVals[0] != "LOW" || enumVals[1] != "MEDIUM" || enumVals[2] != "HIGH" {
+		t.Errorf("enum values: got %v", enumVals)
+	}
+}
+
+func TestInputTypeToJSONSchemaInputObject(t *testing.T) {
+	t.Parallel()
+
+	schema := &Schema{
+		Types: []FullType{
+			{
+				Kind: "INPUT_OBJECT",
+				Name: "CreateInput",
+				InputFields: []InputValue{
+					{
+						Name: "title",
+						Type: TypeRef{Kind: "NON_NULL", OfType: &TypeRef{Kind: "SCALAR", Name: strPtr("String")}},
+					},
+					{
+						Name: "count",
+						Type: TypeRef{Kind: "SCALAR", Name: strPtr("Int")},
+					},
+				},
+			},
+		},
+	}
+	schema.buildIndex()
+
+	ref := TypeRef{Kind: "INPUT_OBJECT", Name: strPtr("CreateInput")}
+	result := inputTypeToJSONSchema(schema, ref, make(map[string]bool))
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if parsed["type"] != "object" {
+		t.Errorf("type: got %v, want object", parsed["type"])
+	}
+
+	props, ok := parsed["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties: got %T, want map", parsed["properties"])
+	}
+	if len(props) != 2 {
+		t.Errorf("properties count: got %d, want 2", len(props))
+	}
+
+	titleProp, ok := props["title"].(map[string]any)
+	if !ok {
+		t.Fatalf("title property: got %T", props["title"])
+	}
+	if titleProp["type"] != "string" {
+		t.Errorf("title type: got %v, want string", titleProp["type"])
+	}
+
+	required, ok := parsed["required"].([]any)
+	if !ok || len(required) != 1 {
+		t.Fatalf("required: got %v, want [title]", parsed["required"])
+	}
+	if required[0] != "title" {
+		t.Errorf("required[0]: got %v, want title", required[0])
+	}
+}
+
+func TestInputTypeToJSONSchemaList(t *testing.T) {
+	t.Parallel()
+
+	schema := &Schema{}
+	schema.buildIndex()
+
+	ref := TypeRef{
+		Kind:   "LIST",
+		OfType: &TypeRef{Kind: "SCALAR", Name: strPtr("String")},
+	}
+	result := inputTypeToJSONSchema(schema, ref, make(map[string]bool))
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if parsed["type"] != "array" {
+		t.Errorf("type: got %v, want array", parsed["type"])
+	}
+
+	items, ok := parsed["items"].(map[string]any)
+	if !ok {
+		t.Fatalf("items: got %T, want map", parsed["items"])
+	}
+	if items["type"] != "string" {
+		t.Errorf("items type: got %v, want string", items["type"])
+	}
+}
+
+func TestInputTypeToJSONSchemaNestedList(t *testing.T) {
+	t.Parallel()
+
+	schema := &Schema{}
+	schema.buildIndex()
+
+	ref := TypeRef{
+		Kind: "LIST",
+		OfType: &TypeRef{
+			Kind:   "LIST",
+			OfType: &TypeRef{Kind: "SCALAR", Name: strPtr("String")},
+		},
+	}
+	result := inputTypeToJSONSchema(schema, ref, make(map[string]bool))
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if parsed["type"] != "array" {
+		t.Fatalf("outer type: got %v, want array", parsed["type"])
+	}
+
+	items, ok := parsed["items"].(map[string]any)
+	if !ok {
+		t.Fatalf("items: got %T, want map", parsed["items"])
+	}
+	if items["type"] != "array" {
+		t.Errorf("inner type: got %v, want array (nested list)", items["type"])
+	}
+
+	innerItems, ok := items["items"].(map[string]any)
+	if !ok {
+		t.Fatalf("inner items: got %T, want map", items["items"])
+	}
+	if innerItems["type"] != "string" {
+		t.Errorf("innermost type: got %v, want string", innerItems["type"])
+	}
+}
+
+func TestInputTypeToJSONSchemaCycleDetection(t *testing.T) {
+	t.Parallel()
+
+	schema := &Schema{
+		Types: []FullType{
+			{
+				Kind: "INPUT_OBJECT",
+				Name: "Filter",
+				InputFields: []InputValue{
+					{
+						Name: "name",
+						Type: TypeRef{Kind: "SCALAR", Name: strPtr("String")},
+					},
+					{
+						Name: "and",
+						Type: TypeRef{Kind: "LIST", OfType: &TypeRef{Kind: "INPUT_OBJECT", Name: strPtr("Filter")}},
+					},
+				},
+			},
+		},
+	}
+	schema.buildIndex()
+
+	ref := TypeRef{Kind: "INPUT_OBJECT", Name: strPtr("Filter")}
+	result := inputTypeToJSONSchema(schema, ref, make(map[string]bool))
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v (raw: %s)", err, string(result))
+	}
+
+	if parsed["type"] != "object" {
+		t.Errorf("type: got %v, want object", parsed["type"])
+	}
+
+	props := parsed["properties"].(map[string]any)
+	andProp := props["and"].(map[string]any)
+	if andProp["type"] != "array" {
+		t.Errorf("and type: got %v, want array", andProp["type"])
+	}
+	items := andProp["items"].(map[string]any)
+	if items["type"] != "object" {
+		t.Errorf("and items type: got %v, want object (cycle truncated)", items["type"])
+	}
+	if _, hasProps := items["properties"]; hasProps {
+		t.Error("cycle should be truncated: and.items should not have properties")
+	}
+}
+
+func TestArgsToJSONSchema(t *testing.T) {
+	t.Parallel()
+
+	schema := &Schema{}
+	schema.buildIndex()
+
+	args := []InputValue{
+		{
+			Name:        "id",
+			Description: "The item ID",
+			Type:        TypeRef{Kind: "NON_NULL", OfType: &TypeRef{Kind: "SCALAR", Name: strPtr("ID")}},
+		},
+		{
+			Name: "limit",
+			Type: TypeRef{Kind: "SCALAR", Name: strPtr("Int")},
+		},
+	}
+
+	result := argsToJSONSchema(schema, args)
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if parsed["type"] != "object" {
+		t.Errorf("type: got %v, want object", parsed["type"])
+	}
+
+	props := parsed["properties"].(map[string]any)
+	idProp := props["id"].(map[string]any)
+	if idProp["type"] != "string" {
+		t.Errorf("id type: got %v, want string", idProp["type"])
+	}
+	if idProp["description"] != "The item ID" {
+		t.Errorf("id description: got %v", idProp["description"])
+	}
+
+	required := parsed["required"].([]any)
+	if len(required) != 1 || required[0] != "id" {
+		t.Errorf("required: got %v, want [id]", required)
+	}
+}
+
+func TestNonNullUnwrapping(t *testing.T) {
+	t.Parallel()
+
+	schema := &Schema{}
+	schema.buildIndex()
+
+	ref := TypeRef{
+		Kind:   "NON_NULL",
+		OfType: &TypeRef{Kind: "SCALAR", Name: strPtr("String")},
+	}
+	result := inputTypeToJSONSchema(schema, ref, make(map[string]bool))
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if parsed["type"] != "string" {
+		t.Errorf("type: got %v, want string (NON_NULL unwrapped)", parsed["type"])
+	}
+}

--- a/internal/openapi/loader.go
+++ b/internal/openapi/loader.go
@@ -16,10 +16,7 @@ import (
 	"github.com/valon-technologies/gestalt/internal/provider"
 )
 
-const (
-	maxSpecSize       = 100 << 20 // 100 MB
-	maxDescriptionLen = 200
-)
+const maxSpecSize = 100 << 20 // 100 MB
 
 var defaultClient = &http.Client{Timeout: 30 * time.Second}
 
@@ -43,7 +40,7 @@ func LoadDefinition(ctx context.Context, name, specURL string, allowedOps map[st
 
 	if info := model.Model.Info; info != nil {
 		def.DisplayName = info.Title
-		def.Description = truncateDescription(info.Description)
+		def.Description = provider.TruncateDescription(info.Description)
 	}
 
 	if len(model.Model.Servers) > 0 {
@@ -285,20 +282,4 @@ func extractOperations(model *v3high.Document, def *provider.Definition, allowed
 			}
 		}
 	}
-}
-
-func truncateDescription(s string) string {
-	s = strings.TrimSpace(s)
-	if i := strings.IndexByte(s, '\n'); i >= 0 {
-		s = strings.TrimSpace(s[:i])
-	}
-	runes := []rune(s)
-	if len(runes) <= maxDescriptionLen {
-		return s
-	}
-	truncated := string(runes[:maxDescriptionLen])
-	if i := strings.LastIndexByte(truncated, ' '); i > len(truncated)/2 {
-		truncated = truncated[:i]
-	}
-	return truncated + "..."
 }

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -322,7 +322,8 @@ func extractJSONPath(data map[string]any, path string) (string, bool) {
 
 func buildPaginationConfigs(def *Definition) map[string]apiexec.PaginationConfig {
 	var configs map[string]apiexec.PaginationConfig
-	for name, opDef := range def.Operations {
+	for name := range def.Operations {
+		opDef := def.Operations[name] //nolint:gocritic // map values not addressable
 		if opDef.Pagination == nil {
 			continue
 		}

--- a/internal/provider/catalog_metadata.go
+++ b/internal/provider/catalog_metadata.go
@@ -20,7 +20,8 @@ func CatalogFromDefinition(def *Definition) *catalog.Catalog {
 	}
 
 	ops := make([]catalog.CatalogOperation, 0, len(def.Operations))
-	for name, opDef := range def.Operations {
+	for name := range def.Operations {
+		opDef := def.Operations[name] //nolint:gocritic // map values not addressable
 		catOp := catalog.CatalogOperation{
 			ID:          name,
 			Method:      strings.ToUpper(opDef.Method),
@@ -28,6 +29,7 @@ func CatalogFromDefinition(def *Definition) *catalog.Catalog {
 			Description: opDef.Description,
 			Transport:   opDef.Transport,
 			Query:       opDef.Query,
+			InputSchema: opDef.InputSchema,
 		}
 		for _, p := range opDef.Parameters {
 			catOp.Parameters = append(catOp.Parameters, catalog.CatalogParameter{

--- a/internal/provider/definition.go
+++ b/internal/provider/definition.go
@@ -1,5 +1,7 @@
 package provider
 
+import "encoding/json"
+
 type Definition struct {
 	Provider         string            `yaml:"provider"`
 	DisplayName      string            `yaml:"display_name"`
@@ -40,13 +42,14 @@ type AuthDef struct {
 }
 
 type OperationDef struct {
-	Description string         `yaml:"description"`
-	Method      string         `yaml:"method"`
-	Path        string         `yaml:"path"`
-	Parameters  []ParameterDef `yaml:"parameters"`
-	Query       string         `yaml:"query"`     // GraphQL query/mutation template
-	Transport   string         `yaml:"transport"` // "rest" (default) or "graphql"
-	Pagination  *PaginationDef `yaml:"pagination"`
+	Description string          `yaml:"description"`
+	Method      string          `yaml:"method"`
+	Path        string          `yaml:"path"`
+	Parameters  []ParameterDef  `yaml:"parameters"`
+	Query       string          `yaml:"query"`        // GraphQL query/mutation template
+	Transport   string          `yaml:"transport"`    // "rest" (default) or "graphql"
+	InputSchema json.RawMessage `yaml:"input_schema"` // pre-built JSON Schema (skips synthesis)
+	Pagination  *PaginationDef  `yaml:"pagination"`
 }
 
 type AuthMappingDef struct {

--- a/internal/provider/text.go
+++ b/internal/provider/text.go
@@ -1,0 +1,21 @@
+package provider
+
+import "strings"
+
+const MaxDescriptionLen = 200
+
+func TruncateDescription(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = strings.TrimSpace(s[:i])
+	}
+	runes := []rune(s)
+	if len(runes) <= MaxDescriptionLen {
+		return s
+	}
+	truncated := string(runes[:MaxDescriptionLen])
+	if i := strings.LastIndexByte(truncated, ' '); i > len(truncated)/2 {
+		truncated = truncated[:i]
+	}
+	return truncated + "..."
+}


### PR DESCRIPTION
GraphQL APIs could not be configured as upstreams because the existing
loader only supported OpenAPI specs for tool discovery. This adds a new
`graphql` upstream type that introspects any GraphQL endpoint at startup
to automatically discover queries and mutations, convert their input
types to rich JSON Schema parameters, and generate query strings with
sensible default selection sets. Configuring a GraphQL integration is
now a three-line YAML block with no hand-written queries required, and
`allowed_operations` can optionally filter which operations are exposed.

The duplicate `truncateDescription` helper was extracted to
`provider.TruncateDescription` so both the OpenAPI and GraphQL loaders
share a single implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)