### PR TITLE
Add generic primitives for building agentic plugins

### DIFF
--- a/core/sse/writer.go
+++ b/core/sse/writer.go
@@ -1,0 +1,44 @@
+package sse
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Writer writes Server-Sent Events to an http.ResponseWriter.
+type Writer struct {
+	w       http.ResponseWriter
+	flusher http.Flusher
+}
+
+// NewWriter creates an SSE writer. It sets the required headers and
+// verifies the ResponseWriter supports flushing.
+func NewWriter(w http.ResponseWriter) (*Writer, error) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return nil, fmt.Errorf("sse: response writer does not support flushing")
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	return &Writer{w: w, flusher: flusher}, nil
+}
+
+// WriteEvent writes a single SSE event and flushes.
+func (w *Writer) WriteEvent(event, data string) error {
+	if _, err := fmt.Fprintf(w.w, "event: %s\ndata: %s\n\n", event, data); err != nil {
+		return err
+	}
+	w.flusher.Flush()
+	return nil
+}
+
+// WriteJSON marshals v as JSON and writes it as an SSE event.
+func (w *Writer) WriteJSON(event string, v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return w.WriteEvent(event, string(data))
+}

--- a/core/sse/writer_test.go
+++ b/core/sse/writer_test.go
@@ -1,0 +1,90 @@
+package sse
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewWriter_SetsHeaders(t *testing.T) {
+	t.Parallel()
+	rec := httptest.NewRecorder()
+	w, err := NewWriter(rec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w == nil {
+		t.Fatal("expected non-nil writer")
+	}
+
+	if got := rec.Header().Get("Content-Type"); got != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want %q", got, "text/event-stream")
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Errorf("Cache-Control = %q, want %q", got, "no-cache")
+	}
+	if got := rec.Header().Get("Connection"); got != "keep-alive" {
+		t.Errorf("Connection = %q, want %q", got, "keep-alive")
+	}
+}
+
+func TestNewWriter_FailsWithoutFlusher(t *testing.T) {
+	t.Parallel()
+	w, err := NewWriter(noFlushWriter{})
+	if err == nil {
+		t.Fatal("expected error for non-flusher")
+	}
+	if w != nil {
+		t.Fatal("expected nil writer on error")
+	}
+	if !strings.Contains(err.Error(), "flushing") {
+		t.Errorf("error should mention flushing: %v", err)
+	}
+}
+
+func TestWriteEvent_Format(t *testing.T) {
+	t.Parallel()
+	rec := httptest.NewRecorder()
+	w, err := NewWriter(rec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := w.WriteEvent("ping", "hello"); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+
+	got := rec.Body.String()
+	want := "event: ping\ndata: hello\n\n"
+	if got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+}
+
+func TestWriteJSON_MarshalsAndWrites(t *testing.T) {
+	t.Parallel()
+	rec := httptest.NewRecorder()
+	w, err := NewWriter(rec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	payload := map[string]string{"key": "value"}
+	if err := w.WriteJSON("data", payload); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+
+	got := rec.Body.String()
+	want := "event: data\ndata: {\"key\":\"value\"}\n\n"
+	if got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+}
+
+// noFlushWriter implements http.ResponseWriter but not http.Flusher.
+type noFlushWriter struct{}
+
+func (noFlushWriter) Header() http.Header       { return http.Header{} }
+func (noFlushWriter) Write([]byte) (int, error) { return 0, nil }
+func (noFlushWriter) WriteHeader(int)           {}

--- a/core/tools/schema.go
+++ b/core/tools/schema.go
@@ -1,0 +1,65 @@
+package tools
+
+import "github.com/valon-technologies/gestalt/core"
+
+// ToolDefinition represents a tool in a format suitable for LLM APIs.
+type ToolDefinition struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	InputSchema map[string]any `json:"input_schema"`
+}
+
+// ParameterSchema converts a slice of core.Parameter into a JSON Schema object.
+func ParameterSchema(params []core.Parameter) map[string]any {
+	props := make(map[string]any, len(params))
+	var required []string
+	for _, p := range params {
+		prop := map[string]any{"type": schemaType(p.Type)}
+		if p.Description != "" {
+			prop["description"] = p.Description
+		}
+		props[p.Name] = prop
+		if p.Required {
+			required = append(required, p.Name)
+		}
+	}
+	schema := map[string]any{
+		"type":       "object",
+		"properties": props,
+	}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+// CapabilitiesToTools converts a list of capabilities into tool definitions.
+// Tool names are formatted as "provider_operation" (e.g. "slack_list_channels").
+func CapabilitiesToTools(caps []core.Capability) []ToolDefinition {
+	defs := make([]ToolDefinition, 0, len(caps))
+	for _, cap := range caps {
+		defs = append(defs, ToolDefinition{
+			Name:        cap.Provider + "_" + cap.Operation,
+			Description: cap.Description,
+			InputSchema: ParameterSchema(cap.Parameters),
+		})
+	}
+	return defs
+}
+
+func schemaType(t string) string {
+	switch t {
+	case "integer", "int":
+		return "integer"
+	case "number", "float", "double":
+		return "number"
+	case "boolean", "bool":
+		return "boolean"
+	case "array":
+		return "array"
+	case "object":
+		return "object"
+	default:
+		return "string"
+	}
+}

--- a/core/tools/schema_test.go
+++ b/core/tools/schema_test.go
@@ -1,0 +1,130 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+)
+
+func TestParameterSchema_Empty(t *testing.T) {
+	t.Parallel()
+	schema := ParameterSchema(nil)
+
+	if schema["type"] != "object" {
+		t.Fatalf("expected type=object, got %v", schema["type"])
+	}
+	props := schema["properties"].(map[string]any)
+	if len(props) != 0 {
+		t.Fatalf("expected empty properties, got %v", props)
+	}
+	if _, ok := schema["required"]; ok {
+		t.Fatal("expected no required key for empty params")
+	}
+}
+
+func TestParameterSchema_MixedRequiredOptional(t *testing.T) {
+	t.Parallel()
+	params := []core.Parameter{
+		{Name: "channel", Type: "string", Description: "target channel", Required: true},
+		{Name: "limit", Type: "integer", Required: false},
+		{Name: "verbose", Type: "bool", Description: "enable verbose output", Required: true},
+	}
+
+	schema := ParameterSchema(params)
+
+	props := schema["properties"].(map[string]any)
+	if len(props) != 3 {
+		t.Fatalf("expected 3 properties, got %d", len(props))
+	}
+
+	channelProp := props["channel"].(map[string]any)
+	if channelProp["type"] != "string" {
+		t.Errorf("channel type: got %v, want string", channelProp["type"])
+	}
+	if channelProp["description"] != "target channel" {
+		t.Errorf("channel description: got %v", channelProp["description"])
+	}
+
+	limitProp := props["limit"].(map[string]any)
+	if limitProp["type"] != "integer" {
+		t.Errorf("limit type: got %v, want integer", limitProp["type"])
+	}
+	if _, ok := limitProp["description"]; ok {
+		t.Error("limit should have no description")
+	}
+
+	required := schema["required"].([]string)
+	if len(required) != 2 || required[0] != "channel" || required[1] != "verbose" {
+		t.Errorf("required: got %v, want [channel verbose]", required)
+	}
+}
+
+func TestSchemaType_Mappings(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"string", "string"},
+		{"integer", "integer"},
+		{"int", "integer"},
+		{"number", "number"},
+		{"float", "number"},
+		{"double", "number"},
+		{"boolean", "boolean"},
+		{"bool", "boolean"},
+		{"array", "array"},
+		{"object", "object"},
+		{"", "string"},
+		{"unknown", "string"},
+	}
+	for _, tt := range tests {
+		got := schemaType(tt.input)
+		if got != tt.want {
+			t.Errorf("schemaType(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestCapabilitiesToTools(t *testing.T) {
+	t.Parallel()
+	caps := []core.Capability{
+		{
+			Provider:    "acme",
+			Operation:   "list_widgets",
+			Description: "List all widgets",
+			Parameters: []core.Parameter{
+				{Name: "status", Type: "string", Required: true},
+			},
+		},
+		{
+			Provider:    "acme",
+			Operation:   "create_widget",
+			Description: "Create a widget",
+			Parameters:  nil,
+		},
+	}
+
+	defs := CapabilitiesToTools(caps)
+	if len(defs) != 2 {
+		t.Fatalf("expected 2 tool definitions, got %d", len(defs))
+	}
+
+	if defs[0].Name != "acme_list_widgets" {
+		t.Errorf("tool 0 name: got %q, want %q", defs[0].Name, "acme_list_widgets")
+	}
+	if defs[0].Description != "List all widgets" {
+		t.Errorf("tool 0 description: got %q", defs[0].Description)
+	}
+	required := defs[0].InputSchema["required"].([]string)
+	if len(required) != 1 || required[0] != "status" {
+		t.Errorf("tool 0 required: got %v", required)
+	}
+
+	if defs[1].Name != "acme_create_widget" {
+		t.Errorf("tool 1 name: got %q, want %q", defs[1].Name, "acme_create_widget")
+	}
+	if _, ok := defs[1].InputSchema["required"]; ok {
+		t.Error("tool 1 should have no required key")
+	}
+}

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -28,7 +28,8 @@ type DatastoreFactory func(node yaml.Node, deps Deps) (core.Datastore, error)
 type ProviderFactory func(ctx context.Context, name string, intg config.IntegrationDef, deps Deps) (core.Provider, error)
 type SecretManagerFactory func(node yaml.Node) (core.SecretManager, error)
 type BindingDeps struct {
-	Invoker invocation.Invoker
+	Invoker  invocation.Invoker
+	Runtimes *registry.PluginMap[core.Runtime]
 }
 
 type RuntimeDeps struct {
@@ -120,8 +121,11 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	if err != nil {
 		return nil, err
 	}
+	if runtimes == nil {
+		runtimes = registry.NewRuntimeMap()
+	}
 
-	bindings, err := buildBindings(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit)
+	bindings, err := buildBindings(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, runtimes)
 	if err != nil {
 		return nil, err
 	}
@@ -414,7 +418,7 @@ func buildRuntimes(ctx context.Context, cfg *config.Config, factories *FactoryRe
 	return runtimes, nil
 }
 
-func buildBindings(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink) (*registry.PluginMap[core.Binding], error) {
+func buildBindings(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink, runtimes *registry.PluginMap[core.Runtime]) (*registry.PluginMap[core.Binding], error) {
 	if len(cfg.Bindings) == 0 {
 		return nil, nil
 	}
@@ -428,7 +432,7 @@ func buildBindings(ctx context.Context, cfg *config.Config, factories *FactoryRe
 			return nil, fmt.Errorf("bootstrap: unknown binding type %q for binding %q", def.Type, name)
 		}
 
-		deps := bindingDepsForProviders(name, invoker, lister, def.Providers, audit)
+		deps := bindingDepsForProviders(name, invoker, lister, def.Providers, audit, runtimes)
 		binding, err := factory(ctx, name, def, deps)
 		if err != nil {
 			return nil, fmt.Errorf("bootstrap: binding %q: %w", name, err)

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -748,8 +748,8 @@ func TestBootstrapNoRuntimes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
-	if result.Runtimes != nil {
-		t.Fatalf("expected Runtimes to be nil, got %v", result.Runtimes.List())
+	if result.Runtimes != nil && len(result.Runtimes.List()) > 0 {
+		t.Fatalf("expected no runtimes, got %v", result.Runtimes.List())
 	}
 }
 

--- a/internal/bootstrap/regression_test.go
+++ b/internal/bootstrap/regression_test.go
@@ -47,8 +47,8 @@ func TestGatewayMode_NoRuntimesOrBindingsRequired(t *testing.T) {
 	if len(names) != 1 || names[0] != "alpha" {
 		t.Errorf("Providers.List: got %v, want [alpha]", names)
 	}
-	if result.Runtimes != nil {
-		t.Error("expected Runtimes to be nil")
+	if result.Runtimes != nil && len(result.Runtimes.List()) > 0 {
+		t.Error("expected no runtimes")
 	}
 	if result.Bindings != nil {
 		t.Error("expected Bindings to be nil")

--- a/internal/bootstrap/runtime_deps.go
+++ b/internal/bootstrap/runtime_deps.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/invocation"
+	"github.com/valon-technologies/gestalt/internal/registry"
 )
 
 func runtimeDepsForProviders(name string, invoker invocation.Invoker, lister invocation.CapabilityLister, providers []string, audit core.AuditSink) RuntimeDeps {
@@ -15,9 +16,10 @@ func runtimeDepsForProviders(name string, invoker invocation.Invoker, lister inv
 	}
 }
 
-func bindingDepsForProviders(name string, invoker invocation.Invoker, lister invocation.CapabilityLister, providers []string, audit core.AuditSink) BindingDeps {
+func bindingDepsForProviders(name string, invoker invocation.Invoker, lister invocation.CapabilityLister, providers []string, audit core.AuditSink, runtimes *registry.PluginMap[core.Runtime]) BindingDeps {
 	return BindingDeps{
-		Invoker: guardedInvoker("binding", name, invoker, lister, providers, audit),
+		Invoker:  guardedInvoker("binding", name, invoker, lister, providers, audit),
+		Runtimes: runtimes,
 	}
 }
 


### PR DESCRIPTION
Gestalt plugins that integrate LLM tool-calling need to convert provider capabilities into JSON Schema and stream long-running responses over SSE. This adds two small core packages for those needs, plus wires the runtime registry into binding dependencies so a binding can look up its paired runtime by name.