### PR TITLE
Add Python sandbox runner for Claude conversations

### DIFF
--- a/sandbox/main.py
+++ b/sandbox/main.py
@@ -1,0 +1,51 @@
+import argparse
+import logging
+import signal
+import threading
+from concurrent import futures
+
+import grpc
+
+from sandbox.pb import sandbox_pb2_grpc
+from sandbox.service import SandboxServicer
+from sandbox.tools import ToolClient
+
+log = logging.getLogger(__name__)
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+    parser = argparse.ArgumentParser(description="Gestalt sandbox runner")
+    parser.add_argument("--listen-addr", required=True, help="gRPC listen address (e.g. localhost:50051)")
+    parser.add_argument("--tool-service-addr", required=True, help="Go ToolService gRPC address")
+    args = parser.parse_args()
+
+    tool_client = ToolClient(args.tool_service_addr)
+    servicer = SandboxServicer(tool_client)
+
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
+    sandbox_pb2_grpc.add_SandboxServiceServicer_to_server(servicer, server)
+    server.add_insecure_port(args.listen_addr)
+
+    stop_event = threading.Event()
+
+    def handle_signal(signum, frame):
+        log.info("received signal %s, shutting down", signum)
+        stop_event.set()
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, handle_signal)
+
+    server.start()
+    log.info("sandbox server listening on %s", args.listen_addr)
+
+    stop_event.wait()
+
+    server.stop(grace=5)
+    tool_client.close()
+    log.info("sandbox server stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/sandbox/pyproject.toml
+++ b/sandbox/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "gestalt-sandbox"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "grpcio>=1.60.0",
+    "grpcio-tools>=1.60.0",
+    "anthropic>=0.40.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/sandbox/service.py
+++ b/sandbox/service.py
@@ -52,12 +52,12 @@ class SandboxServicer(sandbox_pb2_grpc.SandboxServiceServicer):
 
         input_tokens = 0
         output_tokens = 0
-        full_text = ""
+        text_parts: list[str] = []
         num_turns = 0
         start_time = time.monotonic()
 
         try:
-            for turn in range(max_turns):
+            for _ in range(max_turns):
                 if not context.is_active():
                     return
 
@@ -81,7 +81,7 @@ class SandboxServicer(sandbox_pb2_grpc.SandboxServiceServicer):
 
                         if event.type == "content_block_delta":
                             if event.delta.type == "text_delta":
-                                full_text += event.delta.text
+                                text_parts.append(event.delta.text)
                                 yield sandbox_pb2.ConversationEvent(
                                     conversation_id=conversation_id,
                                     text_delta=sandbox_pb2.TextDelta(content=event.delta.text),
@@ -117,13 +117,12 @@ class SandboxServicer(sandbox_pb2_grpc.SandboxServiceServicer):
                         ),
                     )
 
-                    result = self._tool_client.execute(
+                    result, is_error = self._tool_client.execute(
                         conversation_id=conversation_id,
                         user_id=request.user_id,
                         tool_name=block.name,
                         params=block.input,
                     )
-                    is_error = "error" in result
 
                     yield sandbox_pb2.ConversationEvent(
                         conversation_id=conversation_id,
@@ -161,6 +160,6 @@ class SandboxServicer(sandbox_pb2_grpc.SandboxServiceServicer):
                 output_tokens=output_tokens,
                 duration_ms=duration_ms,
                 num_turns=num_turns,
-                full_text=full_text,
+                full_text="".join(text_parts),
             ),
         )

--- a/sandbox/service.py
+++ b/sandbox/service.py
@@ -1,0 +1,166 @@
+import json
+import logging
+import time
+
+import anthropic
+
+from sandbox.pb import sandbox_pb2, sandbox_pb2_grpc
+from sandbox.tools import ToolClient
+
+log = logging.getLogger(__name__)
+
+DEFAULT_MAX_TURNS = 25
+DEFAULT_MAX_TOKENS = 8192
+DEFAULT_MODEL = "claude-sonnet-4-20250514"
+
+
+class SandboxServicer(sandbox_pb2_grpc.SandboxServiceServicer):
+    def __init__(self, tool_client: ToolClient):
+        self._tool_client = tool_client
+        self._anthropic = anthropic.Anthropic()
+        self._shutting_down = False
+
+    def Health(self, request, context):
+        return sandbox_pb2.HealthResponse(
+            ready=not self._shutting_down,
+            status="shutting_down" if self._shutting_down else "ok",
+        )
+
+    def Shutdown(self, request, context):
+        self._shutting_down = True
+        return sandbox_pb2.ShutdownResponse(clean=True)
+
+    def Converse(self, request, context):
+        conversation_id = request.conversation_id
+        model = request.model or DEFAULT_MODEL
+        system_prompt = request.system_prompt or ""
+        max_turns = request.settings.max_turns if request.settings.max_turns else DEFAULT_MAX_TURNS
+        max_tokens = request.settings.max_tokens if request.settings.max_tokens else DEFAULT_MAX_TOKENS
+        temperature = request.settings.temperature if request.settings.temperature else None
+
+        messages = [{"role": "user", "content": request.user_message}]
+
+        try:
+            tools = self._tool_client.get_tools()
+        except Exception as e:
+            log.error("failed to get tools: %s", e)
+            yield sandbox_pb2.ConversationEvent(
+                conversation_id=conversation_id,
+                error=sandbox_pb2.ErrorEvent(message=f"failed to get tools: {e}", code="tool_error"),
+            )
+            return
+
+        input_tokens = 0
+        output_tokens = 0
+        full_text = ""
+        num_turns = 0
+        start_time = time.monotonic()
+
+        try:
+            for turn in range(max_turns):
+                if not context.is_active():
+                    return
+
+                num_turns += 1
+                kwargs = {
+                    "model": model,
+                    "max_tokens": max_tokens,
+                    "messages": messages,
+                }
+                if system_prompt:
+                    kwargs["system"] = system_prompt
+                if tools:
+                    kwargs["tools"] = tools
+                if temperature is not None:
+                    kwargs["temperature"] = temperature
+
+                with self._anthropic.messages.stream(**kwargs) as stream:
+                    for event in stream:
+                        if not context.is_active():
+                            return
+
+                        if event.type == "content_block_delta":
+                            if event.delta.type == "text_delta":
+                                full_text += event.delta.text
+                                yield sandbox_pb2.ConversationEvent(
+                                    conversation_id=conversation_id,
+                                    text_delta=sandbox_pb2.TextDelta(content=event.delta.text),
+                                )
+                            elif event.delta.type == "thinking_delta":
+                                yield sandbox_pb2.ConversationEvent(
+                                    conversation_id=conversation_id,
+                                    thinking_delta=sandbox_pb2.ThinkingDelta(content=event.delta.thinking),
+                                )
+
+                    final_message = stream.get_final_message()
+
+                input_tokens += final_message.usage.input_tokens
+                output_tokens += final_message.usage.output_tokens
+
+                tool_use_blocks = [b for b in final_message.content if b.type == "tool_use"]
+                if not tool_use_blocks:
+                    break
+
+                messages.append({"role": "assistant", "content": final_message.content})
+                tool_results = []
+
+                for block in tool_use_blocks:
+                    if not context.is_active():
+                        return
+
+                    yield sandbox_pb2.ConversationEvent(
+                        conversation_id=conversation_id,
+                        tool_use=sandbox_pb2.ToolUse(
+                            tool_call_id=block.id,
+                            tool_name=block.name,
+                            input_json=json.dumps(block.input),
+                        ),
+                    )
+
+                    result = self._tool_client.execute(
+                        conversation_id=conversation_id,
+                        user_id=request.user_id,
+                        tool_name=block.name,
+                        params=block.input,
+                    )
+                    is_error = "error" in result
+
+                    yield sandbox_pb2.ConversationEvent(
+                        conversation_id=conversation_id,
+                        tool_result=sandbox_pb2.ToolResult(
+                            tool_call_id=block.id,
+                            content_json=json.dumps(result),
+                            is_error=is_error,
+                        ),
+                    )
+
+                    tool_results.append({
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": json.dumps(result),
+                        "is_error": is_error,
+                    })
+
+                messages.append({"role": "user", "content": tool_results})
+
+        except Exception as e:
+            log.error("converse error: %s", e)
+            yield sandbox_pb2.ConversationEvent(
+                conversation_id=conversation_id,
+                error=sandbox_pb2.ErrorEvent(message=str(e), code="internal_error"),
+            )
+            return
+
+        duration_ms = int((time.monotonic() - start_time) * 1000)
+        yield sandbox_pb2.ConversationEvent(
+            conversation_id=conversation_id,
+            turn_complete=sandbox_pb2.TurnComplete(
+                session_id=request.session_id,
+                model=model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                duration_ms=duration_ms,
+                num_turns=num_turns,
+                full_text=full_text,
+            ),
+        )

--- a/sandbox/tools.py
+++ b/sandbox/tools.py
@@ -34,10 +34,10 @@ class ToolClient:
         self._tools_cache = tools
         return tools
 
-    def execute(self, conversation_id: str, user_id: str, tool_name: str, params: dict) -> dict:
+    def execute(self, conversation_id: str, user_id: str, tool_name: str, params: dict) -> tuple[dict, bool]:
         provider, operation = self._tool_map.get(tool_name, ("", ""))
         if not provider:
-            return {"error": f"unknown tool: {tool_name}"}
+            return {"error": f"unknown tool: {tool_name}"}, True
 
         try:
             resp = self._stub.ExecuteTool(sandbox_pb2.ToolRequest(
@@ -49,11 +49,12 @@ class ToolClient:
             ))
         except grpc.RpcError as e:
             log.error("tool execute failed: %s", e)
-            return {"error": str(e)}
+            return {"error": str(e)}, True
 
         if resp.is_error:
-            return {"error": resp.error_message}
-        return json.loads(resp.result_json) if resp.result_json else {}
+            return {"error": resp.error_message}, True
+        result = json.loads(resp.result_json) if resp.result_json else {}
+        return result, False
 
     def close(self):
         self._channel.close()

--- a/sandbox/tools.py
+++ b/sandbox/tools.py
@@ -1,0 +1,59 @@
+import json
+import logging
+
+import grpc
+
+from sandbox.pb import sandbox_pb2, sandbox_pb2_grpc
+
+log = logging.getLogger(__name__)
+
+
+class ToolClient:
+    def __init__(self, addr: str):
+        self._channel = grpc.insecure_channel(addr)
+        self._stub = sandbox_pb2_grpc.ToolServiceStub(self._channel)
+        self._tools_cache: list[dict] | None = None
+        self._tool_map: dict[str, tuple[str, str]] = {}
+
+    def get_tools(self) -> list[dict]:
+        if self._tools_cache is not None:
+            return self._tools_cache
+
+        resp = self._stub.ListTools(sandbox_pb2.ListToolsRequest())
+        tools = []
+        for td in resp.tools:
+            name = f"{td.provider}_{td.operation}"
+            self._tool_map[name] = (td.provider, td.operation)
+            tool = {
+                "name": name,
+                "description": td.description,
+                "input_schema": json.loads(td.input_schema_json) if td.input_schema_json else {"type": "object"},
+            }
+            tools.append(tool)
+
+        self._tools_cache = tools
+        return tools
+
+    def execute(self, conversation_id: str, user_id: str, tool_name: str, params: dict) -> dict:
+        provider, operation = self._tool_map.get(tool_name, ("", ""))
+        if not provider:
+            return {"error": f"unknown tool: {tool_name}"}
+
+        try:
+            resp = self._stub.ExecuteTool(sandbox_pb2.ToolRequest(
+                conversation_id=conversation_id,
+                user_id=user_id,
+                provider=provider,
+                operation=operation,
+                params_json=json.dumps(params),
+            ))
+        except grpc.RpcError as e:
+            log.error("tool execute failed: %s", e)
+            return {"error": str(e)}
+
+        if resp.is_error:
+            return {"error": resp.error_message}
+        return json.loads(resp.result_json) if resp.result_json else {}
+
+    def close(self):
+        self._channel.close()


### PR DESCRIPTION
This is the Python process that the agentic runtime spawns to handle AI conversations. It implements the sandbox side of the gRPC protocol, calling the Anthropic streaming API with tool use. When Claude wants to invoke an integration (Slack, Gmail, etc.), the sandbox calls back to Go's ToolService over gRPC, which executes the operation through Gestalt's normal invocation path with the user's credentials.