### PR TITLE
Add self-contained agentic plugin

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -18,6 +18,7 @@ import (
 	"github.com/valon-technologies/gestalt/internal/openapi"
 	"github.com/valon-technologies/gestalt/internal/provider"
 	"github.com/valon-technologies/gestalt/internal/registry"
+	"github.com/valon-technologies/gestalt/plugins/agentic"
 	"github.com/valon-technologies/gestalt/plugins/auth/google"
 	"github.com/valon-technologies/gestalt/plugins/auth/oidc"
 	"github.com/valon-technologies/gestalt/plugins/bindings/webhook"
@@ -103,6 +104,8 @@ func buildFactories(providerDirs []string, devMode bool) *bootstrap.FactoryRegis
 		factories.Builtins = append(factories.Builtins, echo.New())
 		factories.Runtimes["echo"] = echoruntime.Factory
 	}
+	factories.Runtimes["agentic"] = agentic.RuntimeFactory
+	factories.Bindings["agentic"] = agentic.BindingFactory
 	factories.Bindings["webhook"] = webhook.Factory
 	factories.Secrets["env"] = secretsenv.Factory
 	factories.Secrets["file"] = secretsfile.Factory

--- a/plugins/agentic/binding.go
+++ b/plugins/agentic/binding.go
@@ -1,0 +1,344 @@
+package agentic
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/sse"
+)
+
+var _ core.Binding = (*Binding)(nil)
+
+type bindingConfig struct {
+	Runtime string `yaml:"runtime"`
+}
+
+type Binding struct {
+	name       string
+	store      Store
+	dispatcher Dispatcher
+}
+
+func NewBinding(name string, store Store, dispatcher Dispatcher) *Binding {
+	return &Binding{name: name, store: store, dispatcher: dispatcher}
+}
+
+func (b *Binding) Name() string                  { return b.name }
+func (b *Binding) Kind() core.BindingKind        { return core.BindingSurface }
+func (b *Binding) Start(_ context.Context) error { return nil }
+func (b *Binding) Close() error                  { return nil }
+
+func (b *Binding) Routes() []core.Route {
+	return []core.Route{
+		{Method: http.MethodGet, Pattern: "/agents", Handler: http.HandlerFunc(b.listAgents)},
+		{Method: http.MethodPost, Pattern: "/agents", Handler: http.HandlerFunc(b.createAgent)},
+		{Method: http.MethodGet, Pattern: "/agents/{id}", Handler: http.HandlerFunc(b.getAgent)},
+		{Method: http.MethodPut, Pattern: "/agents/{id}", Handler: http.HandlerFunc(b.updateAgent)},
+		{Method: http.MethodDelete, Pattern: "/agents/{id}", Handler: http.HandlerFunc(b.deleteAgent)},
+		{Method: http.MethodGet, Pattern: "/conversations", Handler: http.HandlerFunc(b.listConversations)},
+		{Method: http.MethodPost, Pattern: "/conversations", Handler: http.HandlerFunc(b.createConversation)},
+		{Method: http.MethodGet, Pattern: "/conversations/{id}", Handler: http.HandlerFunc(b.getConversation)},
+		{Method: http.MethodGet, Pattern: "/conversations/{id}/messages", Handler: http.HandlerFunc(b.listMessages)},
+		{Method: http.MethodPost, Pattern: "/conversations/{id}/messages", Handler: http.HandlerFunc(b.sendMessage)},
+	}
+}
+
+func (b *Binding) listAgents(w http.ResponseWriter, r *http.Request) {
+	userID := r.Header.Get("X-User-ID")
+	if userID == "" {
+		writeError(w, http.StatusUnauthorized, "missing X-User-ID header")
+		return
+	}
+
+	agents, err := b.store.ListAgents(r.Context(), userID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list agents")
+		return
+	}
+	if agents == nil {
+		agents = []*Agent{}
+	}
+	writeJSON(w, http.StatusOK, agents)
+}
+
+func (b *Binding) createAgent(w http.ResponseWriter, r *http.Request) {
+	userID := r.Header.Get("X-User-ID")
+	if userID == "" {
+		writeError(w, http.StatusUnauthorized, "missing X-User-ID header")
+		return
+	}
+
+	var agent Agent
+	if err := json.NewDecoder(r.Body).Decode(&agent); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	agent.OwnerID = userID
+	if agent.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+
+	if err := b.store.CreateAgent(r.Context(), &agent); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create agent")
+		return
+	}
+	writeJSON(w, http.StatusCreated, agent)
+}
+
+func (b *Binding) getAgent(w http.ResponseWriter, r *http.Request) {
+	agent, err := b.store.GetAgent(r.Context(), chi.URLParam(r, "id"))
+	if errors.Is(err, core.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "agent not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get agent")
+		return
+	}
+	writeJSON(w, http.StatusOK, agent)
+}
+
+func (b *Binding) updateAgent(w http.ResponseWriter, r *http.Request) {
+	userID := r.Header.Get("X-User-ID")
+	if userID == "" {
+		writeError(w, http.StatusUnauthorized, "missing X-User-ID header")
+		return
+	}
+
+	id := chi.URLParam(r, "id")
+	existing, err := b.store.GetAgent(r.Context(), id)
+	if errors.Is(err, core.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "agent not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get agent")
+		return
+	}
+	if existing.OwnerID != userID {
+		writeError(w, http.StatusForbidden, "not the owner of this agent")
+		return
+	}
+
+	var update Agent
+	if err := json.NewDecoder(r.Body).Decode(&update); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	update.ID = id
+	update.OwnerID = existing.OwnerID
+	update.CreatedAt = existing.CreatedAt
+
+	if err := b.store.UpdateAgent(r.Context(), &update); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update agent")
+		return
+	}
+	writeJSON(w, http.StatusOK, update)
+}
+
+func (b *Binding) deleteAgent(w http.ResponseWriter, r *http.Request) {
+	userID := r.Header.Get("X-User-ID")
+	if userID == "" {
+		writeError(w, http.StatusUnauthorized, "missing X-User-ID header")
+		return
+	}
+
+	id := chi.URLParam(r, "id")
+	existing, err := b.store.GetAgent(r.Context(), id)
+	if errors.Is(err, core.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "agent not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get agent")
+		return
+	}
+	if existing.OwnerID != userID {
+		writeError(w, http.StatusForbidden, "not the owner of this agent")
+		return
+	}
+
+	if err := b.store.DeleteAgent(r.Context(), id); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete agent")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (b *Binding) listConversations(w http.ResponseWriter, r *http.Request) {
+	userID := r.Header.Get("X-User-ID")
+	if userID == "" {
+		writeError(w, http.StatusUnauthorized, "missing X-User-ID header")
+		return
+	}
+
+	limit := 50
+	offset := 0
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	if v := r.URL.Query().Get("offset"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			offset = n
+		}
+	}
+
+	convs, err := b.store.ListConversations(r.Context(), userID, limit, offset)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list conversations")
+		return
+	}
+	if convs == nil {
+		convs = []*Conversation{}
+	}
+	writeJSON(w, http.StatusOK, convs)
+}
+
+func (b *Binding) createConversation(w http.ResponseWriter, r *http.Request) {
+	userID := r.Header.Get("X-User-ID")
+	if userID == "" {
+		writeError(w, http.StatusUnauthorized, "missing X-User-ID header")
+		return
+	}
+
+	var conv Conversation
+	if err := json.NewDecoder(r.Body).Decode(&conv); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if conv.AgentID == "" {
+		writeError(w, http.StatusBadRequest, "agent_id is required")
+		return
+	}
+
+	agent, err := b.store.GetAgent(r.Context(), conv.AgentID)
+	if errors.Is(err, core.ErrNotFound) {
+		writeError(w, http.StatusBadRequest, "agent not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to validate agent")
+		return
+	}
+	_ = agent
+
+	conv.UserID = userID
+	if conv.Title == "" {
+		conv.Title = "New conversation"
+	}
+
+	if err := b.store.CreateConversation(r.Context(), &conv); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create conversation")
+		return
+	}
+	writeJSON(w, http.StatusCreated, conv)
+}
+
+func (b *Binding) getConversation(w http.ResponseWriter, r *http.Request) {
+	conv, err := b.store.GetConversation(r.Context(), chi.URLParam(r, "id"))
+	if errors.Is(err, core.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "conversation not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get conversation")
+		return
+	}
+	writeJSON(w, http.StatusOK, conv)
+}
+
+func (b *Binding) listMessages(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	_, err := b.store.GetConversation(r.Context(), id)
+	if errors.Is(err, core.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "conversation not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get conversation")
+		return
+	}
+
+	msgs, err := b.store.ListMessages(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list messages")
+		return
+	}
+	if msgs == nil {
+		msgs = []*Message{}
+	}
+	writeJSON(w, http.StatusOK, msgs)
+}
+
+func (b *Binding) sendMessage(w http.ResponseWriter, r *http.Request) {
+	userID := r.Header.Get("X-User-ID")
+	if userID == "" {
+		writeError(w, http.StatusUnauthorized, "missing X-User-ID header")
+		return
+	}
+
+	convID := chi.URLParam(r, "id")
+	conv, err := b.store.GetConversation(r.Context(), convID)
+	if errors.Is(err, core.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "conversation not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get conversation")
+		return
+	}
+	if conv.UserID != userID {
+		writeError(w, http.StatusForbidden, "not the owner of this conversation")
+		return
+	}
+
+	var body struct {
+		Content string `json:"content"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if body.Content == "" {
+		writeError(w, http.StatusBadRequest, "content is required")
+		return
+	}
+
+	sw, err := sse.NewWriter(w)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	events, err := b.dispatcher.SendMessage(r.Context(), convID, body.Content, userID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to send message")
+		return
+	}
+
+	for ev := range events {
+		_ = sw.WriteJSON(string(ev.Type), ev)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}

--- a/plugins/agentic/factory.go
+++ b/plugins/agentic/factory.go
@@ -1,0 +1,56 @@
+package agentic
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+)
+
+var RuntimeFactory bootstrap.RuntimeFactory = func(_ context.Context, name string, def config.RuntimeDef, deps bootstrap.RuntimeDeps) (core.Runtime, error) {
+	var cfg runtimeConfig
+	if err := def.Config.Decode(&cfg); err != nil {
+		return nil, err
+	}
+	if cfg.PythonCommand == "" {
+		cfg.PythonCommand = "python3"
+	}
+	if cfg.MaxSandboxes == 0 {
+		cfg.MaxSandboxes = 5
+	}
+	if cfg.GRPCPort == 0 {
+		cfg.GRPCPort = 50051
+	}
+	if cfg.StorePath == "" {
+		cfg.StorePath = "./chat.db"
+	}
+	return NewRuntime(name, cfg, deps)
+}
+
+var BindingFactory bootstrap.BindingFactory = func(_ context.Context, name string, def config.BindingDef, deps bootstrap.BindingDeps) (core.Binding, error) {
+	var cfg bindingConfig
+	if err := def.Config.Decode(&cfg); err != nil {
+		return nil, err
+	}
+	if cfg.Runtime == "" {
+		return nil, fmt.Errorf("agentic binding %q: runtime is required", name)
+	}
+	if deps.Runtimes == nil {
+		return nil, fmt.Errorf("agentic binding %q: no runtimes available", name)
+	}
+	rt, err := deps.Runtimes.Get(cfg.Runtime)
+	if err != nil {
+		return nil, fmt.Errorf("agentic binding %q: runtime %q: %w", name, cfg.Runtime, err)
+	}
+	dispatcher, ok := rt.(Dispatcher)
+	if !ok {
+		return nil, fmt.Errorf("agentic binding %q: runtime %q does not implement Dispatcher", name, cfg.Runtime)
+	}
+	sp, ok := rt.(StoreProvider)
+	if !ok {
+		return nil, fmt.Errorf("agentic binding %q: runtime %q does not implement StoreProvider", name, cfg.Runtime)
+	}
+	return NewBinding(name, sp.Store(), dispatcher), nil
+}

--- a/plugins/agentic/runtime.go
+++ b/plugins/agentic/runtime.go
@@ -1,0 +1,214 @@
+package agentic
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/plugins/agentic/sandbox"
+	pb "github.com/valon-technologies/gestalt/plugins/agentic/sandbox/pb"
+)
+
+var (
+	_ core.Runtime  = (*Runtime)(nil)
+	_ Dispatcher    = (*Runtime)(nil)
+	_ StoreProvider = (*Runtime)(nil)
+)
+
+type runtimeConfig struct {
+	StorePath     string `yaml:"store_path"`
+	PythonCommand string `yaml:"python_command"`
+	SandboxScript string `yaml:"sandbox_script"`
+	MaxSandboxes  int    `yaml:"max_sandboxes"`
+	IdleTimeout   string `yaml:"idle_timeout"`
+	GRPCPort      int    `yaml:"grpc_port"`
+}
+
+type Runtime struct {
+	name       string
+	cfg        runtimeConfig
+	deps       bootstrap.RuntimeDeps
+	store      Store
+	pool       *sandbox.Pool
+	grpcServer *grpc.Server
+	listener   net.Listener
+}
+
+func NewRuntime(name string, cfg runtimeConfig, deps bootstrap.RuntimeDeps) (*Runtime, error) {
+	store, err := NewSQLiteStore(cfg.StorePath)
+	if err != nil {
+		return nil, err
+	}
+	if err := store.Migrate(context.Background()); err != nil {
+		_ = store.Close()
+		return nil, err
+	}
+	return &Runtime{name: name, cfg: cfg, deps: deps, store: store}, nil
+}
+
+func (r *Runtime) Name() string { return r.name }
+func (r *Runtime) Store() Store { return r.store }
+
+func (r *Runtime) Start(_ context.Context) error {
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", r.cfg.GRPCPort))
+	if err != nil {
+		return err
+	}
+	r.listener = lis
+	r.grpcServer = grpc.NewServer()
+	pb.RegisterToolServiceServer(r.grpcServer, sandbox.NewToolServer(r.deps.Invoker, r.deps.CapabilityLister))
+	go func() { _ = r.grpcServer.Serve(lis) }()
+
+	idleTimeout, _ := time.ParseDuration(r.cfg.IdleTimeout)
+	if idleTimeout == 0 {
+		idleTimeout = 5 * time.Minute
+	}
+	toolAddr := fmt.Sprintf("localhost:%d", r.cfg.GRPCPort)
+	r.pool = sandbox.NewPool(r.cfg.PythonCommand, r.cfg.SandboxScript, toolAddr, r.cfg.MaxSandboxes, idleTimeout)
+
+	log.Printf("agentic runtime %q started: grpc=:%d, store=%s", r.name, r.cfg.GRPCPort, r.cfg.StorePath)
+	return nil
+}
+
+func (r *Runtime) Stop(ctx context.Context) error {
+	if r.pool != nil {
+		r.pool.Shutdown(ctx)
+	}
+	if r.grpcServer != nil {
+		r.grpcServer.GracefulStop()
+	}
+	if r.store != nil {
+		_ = r.store.Close()
+	}
+	return nil
+}
+
+func (r *Runtime) SendMessage(ctx context.Context, conversationID, content, userID string) (<-chan ChatEvent, error) {
+	conv, err := r.store.GetConversation(ctx, conversationID)
+	if err != nil {
+		return nil, err
+	}
+
+	agent, err := r.store.GetAgent(ctx, conv.AgentID)
+	if err != nil {
+		return nil, fmt.Errorf("loading agent %s: %w", conv.AgentID, err)
+	}
+
+	userMsg := &Message{
+		ConversationID: conversationID,
+		Role:           RoleUser,
+		Content:        content,
+	}
+	if err := r.store.AppendMessage(ctx, userMsg); err != nil {
+		return nil, fmt.Errorf("storing user message: %w", err)
+	}
+
+	proc, err := r.pool.Acquire()
+	if err != nil {
+		return nil, fmt.Errorf("acquiring sandbox: %w", err)
+	}
+
+	var allowedTools []string
+	for _, p := range agent.Providers {
+		allowedTools = append(allowedTools, p+"_*")
+	}
+
+	req := &pb.ConversationRequest{
+		ConversationId: conversationID,
+		UserMessage:    content,
+		UserId:         userID,
+		Model:          agent.Model,
+		SystemPrompt:   agent.SystemPrompt,
+		AllowedTools:   allowedTools,
+		Settings: &pb.AgentSettings{
+			Temperature: agent.Temperature,
+			MaxTokens:   int32(agent.MaxTokens),
+		},
+	}
+
+	events, err := proc.Converse(ctx, req)
+	if err != nil {
+		r.pool.Release(proc)
+		return nil, fmt.Errorf("starting conversation: %w", err)
+	}
+
+	out := make(chan ChatEvent, 64)
+	go func() {
+		defer close(out)
+		defer r.pool.Release(proc)
+
+		var fullText string
+		var inputTokens, outputTokens int
+
+		for ev := range events {
+			if ev.TextDelta != "" {
+				out <- ChatEvent{
+					Type:           ChatEventTextDelta,
+					ConversationID: conversationID,
+					Text:           ev.TextDelta,
+				}
+			}
+			if ev.ToolName != "" {
+				out <- ChatEvent{
+					Type:           ChatEventToolUse,
+					ConversationID: conversationID,
+					ToolCallID:     ev.ToolCallID,
+					ToolName:       ev.ToolName,
+					ToolInput:      ev.ToolInput,
+				}
+			}
+			if ev.ToolResult != "" {
+				out <- ChatEvent{
+					Type:           ChatEventToolResult,
+					ConversationID: conversationID,
+					ToolCallID:     ev.ToolCallID,
+					Text:           ev.ToolResult,
+				}
+			}
+			if ev.Error != "" {
+				out <- ChatEvent{
+					Type:           ChatEventError,
+					ConversationID: conversationID,
+					Error:          ev.Error,
+				}
+			}
+			if ev.Done && ev.Error == "" {
+				fullText = ev.FullText
+				inputTokens = int(ev.InputTokens)
+				outputTokens = int(ev.OutputTokens)
+			}
+		}
+
+		if fullText != "" {
+			assistantMsg := &Message{
+				ID:             uuid.NewString(),
+				ConversationID: conversationID,
+				Role:           RoleAssistant,
+				Content:        fullText,
+				InputTokens:    inputTokens,
+				OutputTokens:   outputTokens,
+			}
+			_ = r.store.AppendMessage(context.Background(), assistantMsg)
+		}
+
+		out <- ChatEvent{
+			Type:           ChatEventComplete,
+			ConversationID: conversationID,
+			InputTokens:    inputTokens,
+			OutputTokens:   outputTokens,
+		}
+	}()
+
+	return out, nil
+}
+
+func (r *Runtime) CancelConversation(_ context.Context, _ string) error {
+	return nil
+}

--- a/plugins/agentic/sandbox/pool.go
+++ b/plugins/agentic/sandbox/pool.go
@@ -1,0 +1,102 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Pool struct {
+	mu          sync.Mutex
+	processes   map[string]*Process
+	count       int
+	maxSize     int
+	pythonCmd   string
+	script      string
+	toolAddr    string
+	idleTimeout time.Duration
+}
+
+func NewPool(pythonCmd, script, toolAddr string, maxSize int, idleTimeout time.Duration) *Pool {
+	if maxSize <= 0 {
+		maxSize = 5
+	}
+	if idleTimeout <= 0 {
+		idleTimeout = 5 * time.Minute
+	}
+	return &Pool{
+		processes:   make(map[string]*Process),
+		maxSize:     maxSize,
+		pythonCmd:   pythonCmd,
+		script:      script,
+		toolAddr:    toolAddr,
+		idleTimeout: idleTimeout,
+	}
+}
+
+func (p *Pool) Acquire() (*Process, error) {
+	p.mu.Lock()
+
+	for _, proc := range p.processes {
+		if !proc.IsBusy() {
+			proc.SetBusy()
+			p.mu.Unlock()
+			return proc, nil
+		}
+	}
+
+	if p.count >= p.maxSize {
+		p.mu.Unlock()
+		return nil, fmt.Errorf("sandbox pool exhausted (max %d)", p.maxSize)
+	}
+
+	p.count++
+	p.mu.Unlock()
+
+	id := uuid.NewString()[:8]
+	proc, err := SpawnProcess(id, p.pythonCmd, p.script, p.toolAddr)
+	if err != nil {
+		p.mu.Lock()
+		p.count--
+		p.mu.Unlock()
+		return nil, fmt.Errorf("spawning sandbox: %w", err)
+	}
+
+	proc.SetBusy()
+
+	p.mu.Lock()
+	p.processes[proc.ID()] = proc
+	p.mu.Unlock()
+
+	return proc, nil
+}
+
+func (p *Pool) Release(proc *Process) {
+	proc.SetIdle()
+}
+
+func (p *Pool) Shutdown(ctx context.Context) {
+	p.mu.Lock()
+	procs := make([]*Process, 0, len(p.processes))
+	for _, proc := range p.processes {
+		procs = append(procs, proc)
+	}
+	p.processes = make(map[string]*Process)
+	p.count = 0
+	p.mu.Unlock()
+
+	var wg sync.WaitGroup
+	for _, proc := range procs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			log.Printf("shutting down sandbox %s", proc.ID())
+			proc.Shutdown(ctx)
+		}()
+	}
+	wg.Wait()
+}

--- a/plugins/agentic/sandbox/process.go
+++ b/plugins/agentic/sandbox/process.go
@@ -1,0 +1,184 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"sync/atomic"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	pb "github.com/valon-technologies/gestalt/plugins/agentic/sandbox/pb"
+)
+
+const (
+	healthPollInterval = 200 * time.Millisecond
+	healthTimeout      = 30 * time.Second
+	shutdownGrace      = 5 * time.Second
+)
+
+type Process struct {
+	id        string
+	cmd       *exec.Cmd
+	client    pb.SandboxServiceClient
+	conn      *grpc.ClientConn
+	sockPath  string
+	busy      atomic.Bool
+	startedAt time.Time
+}
+
+func SpawnProcess(id, pythonCmd, script, toolServiceAddr string) (*Process, error) {
+	sockPath := fmt.Sprintf("/tmp/gestalt-sandbox-%s.sock", id)
+	_ = os.Remove(sockPath)
+
+	listenAddr := fmt.Sprintf("unix://%s", sockPath)
+	cmd := exec.Command(pythonCmd, script, "--listen-addr", listenAddr, "--tool-service-addr", toolServiceAddr)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("starting sandbox process: %w", err)
+	}
+
+	p := &Process{
+		id:        id,
+		cmd:       cmd,
+		sockPath:  sockPath,
+		startedAt: time.Now(),
+	}
+
+	conn, err := grpc.NewClient("unix://"+sockPath, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		_ = cmd.Process.Kill()
+		return nil, fmt.Errorf("dialing sandbox: %w", err)
+	}
+	p.conn = conn
+	p.client = pb.NewSandboxServiceClient(conn)
+
+	if err := p.waitForHealth(); err != nil {
+		p.cleanup()
+		return nil, err
+	}
+
+	return p, nil
+}
+
+func (p *Process) waitForHealth() error {
+	ctx, cancel := context.WithTimeout(context.Background(), healthTimeout)
+	defer cancel()
+
+	for {
+		_, err := p.client.Health(ctx, &pb.HealthRequest{})
+		if err == nil {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("sandbox %s health check timed out", p.id)
+		case <-time.After(healthPollInterval):
+		}
+	}
+}
+
+func (p *Process) ID() string   { return p.id }
+func (p *Process) IsBusy() bool { return p.busy.Load() }
+func (p *Process) SetBusy()     { p.busy.Store(true) }
+func (p *Process) SetIdle()     { p.busy.Store(false) }
+
+type ChatEvent struct {
+	TextDelta    string
+	ToolCallID   string
+	ToolName     string
+	ToolInput    string
+	ToolResult   string
+	IsToolError  bool
+	FullText     string
+	InputTokens  int64
+	OutputTokens int64
+	Error        string
+	Done         bool
+}
+
+func (p *Process) Converse(ctx context.Context, req *pb.ConversationRequest) (<-chan ChatEvent, error) {
+	stream, err := p.client.Converse(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("calling Converse: %w", err)
+	}
+
+	ch := make(chan ChatEvent, 64)
+	go func() {
+		defer close(ch)
+		for {
+			ev, err := stream.Recv()
+			if err == io.EOF {
+				return
+			}
+			if err != nil {
+				ch <- ChatEvent{Error: err.Error(), Done: true}
+				return
+			}
+
+			switch e := ev.Event.(type) {
+			case *pb.ConversationEvent_TextDelta:
+				ch <- ChatEvent{TextDelta: e.TextDelta.GetContent()}
+			case *pb.ConversationEvent_ToolUse:
+				ch <- ChatEvent{
+					ToolCallID: e.ToolUse.GetToolCallId(),
+					ToolName:   e.ToolUse.GetToolName(),
+					ToolInput:  e.ToolUse.GetInputJson(),
+				}
+			case *pb.ConversationEvent_ToolResult:
+				ch <- ChatEvent{
+					ToolCallID:  e.ToolResult.GetToolCallId(),
+					ToolResult:  e.ToolResult.GetContentJson(),
+					IsToolError: e.ToolResult.GetIsError(),
+				}
+			case *pb.ConversationEvent_TurnComplete:
+				ch <- ChatEvent{
+					Done:         true,
+					FullText:     e.TurnComplete.GetFullText(),
+					InputTokens:  e.TurnComplete.GetInputTokens(),
+					OutputTokens: e.TurnComplete.GetOutputTokens(),
+				}
+				return
+			case *pb.ConversationEvent_Error:
+				ch <- ChatEvent{Error: e.Error.GetMessage(), Done: true}
+				return
+			}
+		}
+	}()
+
+	return ch, nil
+}
+
+func (p *Process) Shutdown(ctx context.Context) {
+	if p.client != nil {
+		shutCtx, cancel := context.WithTimeout(ctx, shutdownGrace)
+		defer cancel()
+		_, _ = p.client.Shutdown(shutCtx, &pb.ShutdownRequest{})
+	}
+	p.cleanup()
+}
+
+func (p *Process) cleanup() {
+	if p.conn != nil {
+		_ = p.conn.Close()
+	}
+	if p.cmd != nil && p.cmd.Process != nil {
+		done := make(chan error, 1)
+		go func() { done <- p.cmd.Wait() }()
+		select {
+		case <-done:
+		case <-time.After(shutdownGrace):
+			log.Printf("sandbox %s did not exit in time, killing", p.id)
+			_ = p.cmd.Process.Kill()
+			<-done
+		}
+	}
+	_ = os.Remove(p.sockPath)
+}

--- a/plugins/agentic/sandbox/toolserver.go
+++ b/plugins/agentic/sandbox/toolserver.go
@@ -1,0 +1,70 @@
+package sandbox
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/tools"
+	"github.com/valon-technologies/gestalt/internal/invocation"
+	"github.com/valon-technologies/gestalt/internal/principal"
+	pb "github.com/valon-technologies/gestalt/plugins/agentic/sandbox/pb"
+)
+
+type ToolServer struct {
+	pb.UnimplementedToolServiceServer
+	invoker invocation.Invoker
+	lister  invocation.CapabilityLister
+}
+
+func NewToolServer(invoker invocation.Invoker, lister invocation.CapabilityLister) *ToolServer {
+	return &ToolServer{invoker: invoker, lister: lister}
+}
+
+func (s *ToolServer) ExecuteTool(ctx context.Context, req *pb.ToolRequest) (*pb.ToolResponse, error) {
+	var params map[string]any
+	if req.ParamsJson != "" {
+		if err := json.Unmarshal([]byte(req.ParamsJson), &params); err != nil {
+			return &pb.ToolResponse{IsError: true, ErrorMessage: "invalid params: " + err.Error()}, nil //nolint:nilerr // application error in response body
+		}
+	}
+	p := &principal.Principal{UserID: req.UserId}
+	result, err := s.invoker.Invoke(ctx, p, req.Provider, req.Operation, params)
+	if err != nil {
+		return &pb.ToolResponse{IsError: true, ErrorMessage: err.Error()}, nil //nolint:nilerr // application error in response body
+	}
+	return &pb.ToolResponse{ResultJson: result.Body}, nil
+}
+
+func (s *ToolServer) ListTools(_ context.Context, req *pb.ListToolsRequest) (*pb.ListToolsResponse, error) {
+	caps := s.lister.ListCapabilities()
+
+	if len(req.Providers) > 0 {
+		allowed := make(map[string]bool, len(req.Providers))
+		for _, p := range req.Providers {
+			allowed[p] = true
+		}
+		var filtered []core.Capability
+		for _, c := range caps {
+			if allowed[c.Provider] {
+				filtered = append(filtered, c)
+			}
+		}
+		caps = filtered
+	}
+
+	toolDefs := tools.CapabilitiesToTools(caps)
+
+	resp := &pb.ListToolsResponse{}
+	for i, td := range toolDefs {
+		schemaJSON, _ := json.Marshal(td.InputSchema)
+		resp.Tools = append(resp.Tools, &pb.ToolDefinition{
+			Name:            td.Name,
+			Description:     td.Description,
+			InputSchemaJson: string(schemaJSON),
+			Provider:        caps[i].Provider,
+			Operation:       caps[i].Operation,
+		})
+	}
+	return resp, nil
+}

--- a/plugins/agentic/sqlitestore.go
+++ b/plugins/agentic/sqlitestore.go
@@ -1,0 +1,337 @@
+package agentic
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/core"
+
+	_ "modernc.org/sqlite" // register database/sql driver
+)
+
+type SQLiteStore struct {
+	db *sql.DB
+}
+
+func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
+	dsn := dbPath + "?_pragma=journal_mode(wal)&_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("opening sqlite: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	return &SQLiteStore{db: db}, nil
+}
+
+func (s *SQLiteStore) Migrate(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS agents (
+			id TEXT PRIMARY KEY,
+			owner_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			system_prompt TEXT NOT NULL DEFAULT '',
+			model TEXT NOT NULL DEFAULT '',
+			providers TEXT NOT NULL DEFAULT '[]',
+			temperature REAL NOT NULL DEFAULT 0,
+			max_tokens INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		);
+		CREATE INDEX IF NOT EXISTS idx_agents_owner_id ON agents(owner_id);
+
+		CREATE TABLE IF NOT EXISTS conversations (
+			id TEXT PRIMARY KEY,
+			agent_id TEXT NOT NULL,
+			user_id TEXT NOT NULL,
+			title TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'active',
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		);
+		CREATE INDEX IF NOT EXISTS idx_conversations_user_updated ON conversations(user_id, updated_at);
+
+		CREATE TABLE IF NOT EXISTS messages (
+			id TEXT PRIMARY KEY,
+			conversation_id TEXT NOT NULL,
+			role TEXT NOT NULL,
+			content TEXT NOT NULL DEFAULT '',
+			tool_calls TEXT NOT NULL DEFAULT '',
+			tool_call_id TEXT NOT NULL DEFAULT '',
+			input_tokens INTEGER NOT NULL DEFAULT 0,
+			output_tokens INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME NOT NULL
+		);
+		CREATE INDEX IF NOT EXISTS idx_messages_conv_created ON messages(conversation_id, created_at);
+	`)
+	return err
+}
+
+func (s *SQLiteStore) Close() error {
+	return s.db.Close()
+}
+
+func (s *SQLiteStore) GetAgent(ctx context.Context, id string) (*Agent, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT id, owner_id, name, system_prompt, model, providers, temperature, max_tokens, created_at, updated_at
+		 FROM agents WHERE id = ?`, id)
+	a, err := scanAgent(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, core.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying agent: %w", err)
+	}
+	return a, nil
+}
+
+func (s *SQLiteStore) ListAgents(ctx context.Context, ownerID string) ([]*Agent, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, owner_id, name, system_prompt, model, providers, temperature, max_tokens, created_at, updated_at
+		 FROM agents WHERE owner_id = ? ORDER BY created_at DESC`, ownerID)
+	if err != nil {
+		return nil, fmt.Errorf("listing agents: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var agents []*Agent
+	for rows.Next() {
+		a, err := scanAgent(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning agent: %w", err)
+		}
+		agents = append(agents, a)
+	}
+	return agents, rows.Err()
+}
+
+func (s *SQLiteStore) CreateAgent(ctx context.Context, agent *Agent) error {
+	if agent.ID == "" {
+		agent.ID = uuid.NewString()
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	agent.CreatedAt = now
+	agent.UpdatedAt = now
+
+	providersJSON, err := json.Marshal(agent.Providers)
+	if err != nil {
+		return fmt.Errorf("marshaling providers: %w", err)
+	}
+	if agent.Providers == nil {
+		providersJSON = []byte("[]")
+	}
+
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO agents (id, owner_id, name, system_prompt, model, providers, temperature, max_tokens, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		agent.ID, agent.OwnerID, agent.Name, agent.SystemPrompt, agent.Model,
+		string(providersJSON), agent.Temperature, agent.MaxTokens,
+		agent.CreatedAt, agent.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("inserting agent: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) UpdateAgent(ctx context.Context, agent *Agent) error {
+	agent.UpdatedAt = time.Now().UTC().Truncate(time.Second)
+
+	providersJSON, err := json.Marshal(agent.Providers)
+	if err != nil {
+		return fmt.Errorf("marshaling providers: %w", err)
+	}
+	if agent.Providers == nil {
+		providersJSON = []byte("[]")
+	}
+
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE agents SET name = ?, system_prompt = ?, model = ?, providers = ?,
+		 temperature = ?, max_tokens = ?, updated_at = ? WHERE id = ?`,
+		agent.Name, agent.SystemPrompt, agent.Model, string(providersJSON),
+		agent.Temperature, agent.MaxTokens, agent.UpdatedAt, agent.ID)
+	if err != nil {
+		return fmt.Errorf("updating agent: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("updating agent: %w", err)
+	}
+	if n == 0 {
+		return core.ErrNotFound
+	}
+	return nil
+}
+
+func (s *SQLiteStore) DeleteAgent(ctx context.Context, id string) error {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM agents WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("deleting agent: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("deleting agent: %w", err)
+	}
+	if n == 0 {
+		return core.ErrNotFound
+	}
+	return nil
+}
+
+func (s *SQLiteStore) GetConversation(ctx context.Context, id string) (*Conversation, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT id, agent_id, user_id, title, status, created_at, updated_at
+		 FROM conversations WHERE id = ?`, id)
+	c, err := scanConversation(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, core.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying conversation: %w", err)
+	}
+	return c, nil
+}
+
+func (s *SQLiteStore) ListConversations(ctx context.Context, userID string, limit, offset int) ([]*Conversation, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, agent_id, user_id, title, status, created_at, updated_at
+		 FROM conversations WHERE user_id = ? ORDER BY updated_at DESC LIMIT ? OFFSET ?`,
+		userID, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("listing conversations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var convs []*Conversation
+	for rows.Next() {
+		c, err := scanConversation(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning conversation: %w", err)
+		}
+		convs = append(convs, c)
+	}
+	return convs, rows.Err()
+}
+
+func (s *SQLiteStore) CreateConversation(ctx context.Context, conv *Conversation) error {
+	if conv.ID == "" {
+		conv.ID = uuid.NewString()
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	conv.CreatedAt = now
+	conv.UpdatedAt = now
+	if conv.Status == "" {
+		conv.Status = ConversationActive
+	}
+
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO conversations (id, agent_id, user_id, title, status, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		conv.ID, conv.AgentID, conv.UserID, conv.Title, conv.Status,
+		conv.CreatedAt, conv.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("inserting conversation: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) UpdateConversation(ctx context.Context, conv *Conversation) error {
+	conv.UpdatedAt = time.Now().UTC().Truncate(time.Second)
+
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE conversations SET title = ?, status = ?, updated_at = ? WHERE id = ?`,
+		conv.Title, conv.Status, conv.UpdatedAt, conv.ID)
+	if err != nil {
+		return fmt.Errorf("updating conversation: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("updating conversation: %w", err)
+	}
+	if n == 0 {
+		return core.ErrNotFound
+	}
+	return nil
+}
+
+func (s *SQLiteStore) ListMessages(ctx context.Context, conversationID string) ([]*Message, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, conversation_id, role, content, tool_calls, tool_call_id, input_tokens, output_tokens, created_at
+		 FROM messages WHERE conversation_id = ? ORDER BY created_at ASC`, conversationID)
+	if err != nil {
+		return nil, fmt.Errorf("listing messages: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var msgs []*Message
+	for rows.Next() {
+		m, err := scanMessage(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning message: %w", err)
+		}
+		msgs = append(msgs, m)
+	}
+	return msgs, rows.Err()
+}
+
+func (s *SQLiteStore) AppendMessage(ctx context.Context, msg *Message) error {
+	if msg.ID == "" {
+		msg.ID = uuid.NewString()
+	}
+	if msg.CreatedAt.IsZero() {
+		msg.CreatedAt = time.Now().UTC().Truncate(time.Second)
+	}
+
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO messages (id, conversation_id, role, content, tool_calls, tool_call_id, input_tokens, output_tokens, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		msg.ID, msg.ConversationID, msg.Role, msg.Content, msg.ToolCalls,
+		msg.ToolCallID, msg.InputTokens, msg.OutputTokens, msg.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("inserting message: %w", err)
+	}
+	return nil
+}
+
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAgent(row scanner) (*Agent, error) {
+	var a Agent
+	var providersJSON string
+	if err := row.Scan(&a.ID, &a.OwnerID, &a.Name, &a.SystemPrompt, &a.Model,
+		&providersJSON, &a.Temperature, &a.MaxTokens, &a.CreatedAt, &a.UpdatedAt); err != nil {
+		return nil, err
+	}
+	if providersJSON != "" {
+		if err := json.Unmarshal([]byte(providersJSON), &a.Providers); err != nil {
+			return nil, fmt.Errorf("unmarshaling providers: %w", err)
+		}
+	}
+	if a.Providers == nil {
+		a.Providers = []string{}
+	}
+	return &a, nil
+}
+
+func scanConversation(row scanner) (*Conversation, error) {
+	var c Conversation
+	if err := row.Scan(&c.ID, &c.AgentID, &c.UserID, &c.Title, &c.Status,
+		&c.CreatedAt, &c.UpdatedAt); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+func scanMessage(row scanner) (*Message, error) {
+	var m Message
+	if err := row.Scan(&m.ID, &m.ConversationID, &m.Role, &m.Content, &m.ToolCalls,
+		&m.ToolCallID, &m.InputTokens, &m.OutputTokens, &m.CreatedAt); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}

--- a/plugins/agentic/sqlitestore_test.go
+++ b/plugins/agentic/sqlitestore_test.go
@@ -1,0 +1,268 @@
+package agentic
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+)
+
+func newTestStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func TestAgentCRUD(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	agent := &Agent{
+		OwnerID:      "test-user",
+		Name:         "test-agent",
+		SystemPrompt: "you are helpful",
+		Model:        "gpt-4",
+		Providers:    []string{"slack", "github"},
+		Temperature:  0.7,
+		MaxTokens:    1024,
+	}
+
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatal(err)
+	}
+	if agent.ID == "" {
+		t.Fatal("expected ID to be set")
+	}
+
+	got, err := s.GetAgent(ctx, agent.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "test-agent" {
+		t.Fatalf("got name %q, want %q", got.Name, "test-agent")
+	}
+	if len(got.Providers) != 2 || got.Providers[0] != "slack" {
+		t.Fatalf("unexpected providers: %v", got.Providers)
+	}
+
+	got.Name = "updated-agent"
+	if err := s.UpdateAgent(ctx, got); err != nil {
+		t.Fatal(err)
+	}
+	got2, err := s.GetAgent(ctx, agent.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got2.Name != "updated-agent" {
+		t.Fatalf("got name %q after update, want %q", got2.Name, "updated-agent")
+	}
+
+	agents, err := s.ListAgents(ctx, "test-user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(agents) != 1 {
+		t.Fatalf("got %d agents, want 1", len(agents))
+	}
+
+	if err := s.DeleteAgent(ctx, agent.ID); err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.GetAgent(ctx, agent.ID)
+	if !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestAgentNotFound(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := s.GetAgent(ctx, "nonexistent")
+	if !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+
+	if err := s.DeleteAgent(ctx, "nonexistent"); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestAgentNilProviders(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	agent := &Agent{
+		OwnerID: "test-user",
+		Name:    "no-providers",
+	}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.GetAgent(ctx, agent.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Providers == nil {
+		t.Fatal("expected non-nil providers slice")
+	}
+	if len(got.Providers) != 0 {
+		t.Fatalf("expected empty providers, got %v", got.Providers)
+	}
+}
+
+func TestConversationCRUD(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	conv := &Conversation{
+		AgentID: "agent-1",
+		UserID:  "test-user",
+		Title:   "test conversation",
+	}
+
+	if err := s.CreateConversation(ctx, conv); err != nil {
+		t.Fatal(err)
+	}
+	if conv.ID == "" {
+		t.Fatal("expected ID to be set")
+	}
+	if conv.Status != ConversationActive {
+		t.Fatalf("expected status %q, got %q", ConversationActive, conv.Status)
+	}
+
+	got, err := s.GetConversation(ctx, conv.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Title != "test conversation" {
+		t.Fatalf("got title %q, want %q", got.Title, "test conversation")
+	}
+
+	got.Title = "updated title"
+	got.Status = ConversationArchived
+	if err := s.UpdateConversation(ctx, got); err != nil {
+		t.Fatal(err)
+	}
+	got2, err := s.GetConversation(ctx, conv.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got2.Title != "updated title" || got2.Status != ConversationArchived {
+		t.Fatalf("unexpected state after update: title=%q status=%q", got2.Title, got2.Status)
+	}
+}
+
+func TestConversationNotFound(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := s.GetConversation(ctx, "nonexistent")
+	if !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestConversationPagination(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		conv := &Conversation{
+			AgentID: "agent-1",
+			UserID:  "test-user",
+			Title:   "conversation",
+		}
+		if err := s.CreateConversation(ctx, conv); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	page1, err := s.ListConversations(ctx, "test-user", 3, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page1) != 3 {
+		t.Fatalf("got %d conversations, want 3", len(page1))
+	}
+
+	page2, err := s.ListConversations(ctx, "test-user", 3, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page2) != 2 {
+		t.Fatalf("got %d conversations, want 2", len(page2))
+	}
+}
+
+func TestMessageLifecycle(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	conv := &Conversation{AgentID: "agent-1", UserID: "test-user"}
+	if err := s.CreateConversation(ctx, conv); err != nil {
+		t.Fatal(err)
+	}
+
+	userMsg := &Message{
+		ConversationID: conv.ID,
+		Role:           RoleUser,
+		Content:        "hello",
+	}
+	if err := s.AppendMessage(ctx, userMsg); err != nil {
+		t.Fatal(err)
+	}
+
+	assistantMsg := &Message{
+		ConversationID: conv.ID,
+		Role:           RoleAssistant,
+		Content:        "hi there",
+		InputTokens:    10,
+		OutputTokens:   5,
+	}
+	if err := s.AppendMessage(ctx, assistantMsg); err != nil {
+		t.Fatal(err)
+	}
+
+	msgs, err := s.ListMessages(ctx, conv.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("got %d messages, want 2", len(msgs))
+	}
+	if msgs[0].Role != RoleUser || msgs[1].Role != RoleAssistant {
+		t.Fatalf("unexpected message order: %q, %q", msgs[0].Role, msgs[1].Role)
+	}
+}
+
+func TestIdempotentMigration(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	if err := s.Migrate(ctx); err != nil {
+		t.Fatal("second migration should be idempotent:", err)
+	}
+	if err := s.Migrate(ctx); err != nil {
+		t.Fatal("third migration should be idempotent:", err)
+	}
+}

--- a/plugins/agentic/store.go
+++ b/plugins/agentic/store.go
@@ -1,0 +1,31 @@
+package agentic
+
+import "context"
+
+type Store interface {
+	GetAgent(ctx context.Context, id string) (*Agent, error)
+	ListAgents(ctx context.Context, ownerID string) ([]*Agent, error)
+	CreateAgent(ctx context.Context, agent *Agent) error
+	UpdateAgent(ctx context.Context, agent *Agent) error
+	DeleteAgent(ctx context.Context, id string) error
+
+	GetConversation(ctx context.Context, id string) (*Conversation, error)
+	ListConversations(ctx context.Context, userID string, limit, offset int) ([]*Conversation, error)
+	CreateConversation(ctx context.Context, conv *Conversation) error
+	UpdateConversation(ctx context.Context, conv *Conversation) error
+
+	ListMessages(ctx context.Context, conversationID string) ([]*Message, error)
+	AppendMessage(ctx context.Context, msg *Message) error
+
+	Migrate(ctx context.Context) error
+	Close() error
+}
+
+type Dispatcher interface {
+	SendMessage(ctx context.Context, conversationID, content, userID string) (<-chan ChatEvent, error)
+	CancelConversation(ctx context.Context, conversationID string) error
+}
+
+type StoreProvider interface {
+	Store() Store
+}

--- a/plugins/agentic/types.go
+++ b/plugins/agentic/types.go
@@ -1,0 +1,75 @@
+package agentic
+
+import "time"
+
+type Agent struct {
+	ID           string    `json:"id"`
+	OwnerID      string    `json:"owner_id"`
+	Name         string    `json:"name"`
+	SystemPrompt string    `json:"system_prompt"`
+	Model        string    `json:"model"`
+	Providers    []string  `json:"providers"`
+	Temperature  float64   `json:"temperature"`
+	MaxTokens    int       `json:"max_tokens"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+type Conversation struct {
+	ID        string             `json:"id"`
+	AgentID   string             `json:"agent_id"`
+	UserID    string             `json:"user_id"`
+	Title     string             `json:"title"`
+	Status    ConversationStatus `json:"status"`
+	CreatedAt time.Time          `json:"created_at"`
+	UpdatedAt time.Time          `json:"updated_at"`
+}
+
+type ConversationStatus string
+
+const (
+	ConversationActive   ConversationStatus = "active"
+	ConversationArchived ConversationStatus = "archived"
+)
+
+type Message struct {
+	ID             string      `json:"id"`
+	ConversationID string      `json:"conversation_id"`
+	Role           MessageRole `json:"role"`
+	Content        string      `json:"content"`
+	ToolCalls      string      `json:"tool_calls,omitempty"`
+	ToolCallID     string      `json:"tool_call_id,omitempty"`
+	InputTokens    int         `json:"input_tokens,omitempty"`
+	OutputTokens   int         `json:"output_tokens,omitempty"`
+	CreatedAt      time.Time   `json:"created_at"`
+}
+
+type MessageRole string
+
+const (
+	RoleUser      MessageRole = "user"
+	RoleAssistant MessageRole = "assistant"
+	RoleTool      MessageRole = "tool"
+)
+
+type ChatEvent struct {
+	Type           ChatEventType `json:"type"`
+	ConversationID string        `json:"conversation_id"`
+	Text           string        `json:"text,omitempty"`
+	ToolCallID     string        `json:"tool_call_id,omitempty"`
+	ToolName       string        `json:"tool_name,omitempty"`
+	ToolInput      string        `json:"tool_input,omitempty"`
+	Error          string        `json:"error,omitempty"`
+	InputTokens    int           `json:"input_tokens,omitempty"`
+	OutputTokens   int           `json:"output_tokens,omitempty"`
+}
+
+type ChatEventType string
+
+const (
+	ChatEventTextDelta  ChatEventType = "text_delta"
+	ChatEventToolUse    ChatEventType = "tool_use"
+	ChatEventToolResult ChatEventType = "tool_result"
+	ChatEventComplete   ChatEventType = "complete"
+	ChatEventError      ChatEventType = "error"
+)


### PR DESCRIPTION
This plugin lets Gestalt host AI agent conversations backed by the Anthropic API. It registers both a runtime and a binding under the agentic type. The runtime spawns Python sandbox subprocesses that run Claude with tool access to any configured Gestalt integration, while the binding exposes a REST and SSE API for managing agents, conversations, and streaming messages. All types and storage live inside the plugin rather than in core, so Gestalt deployments that do not need agent capabilities carry zero extra weight.