### PR TITLE
Show credential source in CLI auth commands

### DIFF
--- a/client/cli/src/api.rs
+++ b/client/cli/src/api.rs
@@ -6,6 +6,7 @@ use crate::config::ConfigStore;
 use crate::credentials::CredentialStore;
 
 pub const DEFAULT_URL: &str = "http://localhost:8080";
+pub const ENV_API_KEY: &str = "GESTALT_API_KEY";
 
 pub fn normalize_url(url: &str) -> String {
     let trimmed = url.trim().trim_end_matches('/');
@@ -53,28 +54,47 @@ fn find_project_config_value(key: &str) -> Option<String> {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenSource {
+    EnvVar,
+    Session,
+}
+
+pub fn env_api_key_is_set() -> bool {
+    std::env::var(ENV_API_KEY)
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
+}
+
 pub struct ApiClient {
     client: Client,
     base_url: String,
     token: String,
+    token_source: TokenSource,
 }
 
 impl ApiClient {
     pub fn from_env(url_override: Option<&str>) -> Result<Self> {
-        let token = if let Ok(key) = std::env::var("GESTALT_API_KEY") {
-            key
-        } else {
-            let store = CredentialStore::new()?;
-            match store.load()? {
-                Some(creds) => creds.session_token,
-                None => {
-                    bail!("not authenticated: set GESTALT_API_KEY or run 'gestalt auth login'")
+        let (token, source) =
+            if let Some(key) = std::env::var(ENV_API_KEY).ok().filter(|v| !v.is_empty()) {
+                (key, TokenSource::EnvVar)
+            } else {
+                let store = CredentialStore::new()?;
+                match store.load()? {
+                    Some(creds) => (creds.session_token, TokenSource::Session),
+                    None => {
+                        bail!(
+                            "not authenticated: set {} or run 'gestalt auth login'",
+                            ENV_API_KEY
+                        )
+                    }
                 }
-            }
-        };
+            };
 
         let base_url = resolve_url(url_override)?;
-        Self::new(&base_url, &token)
+        let mut client = Self::new(&base_url, &token)?;
+        client.token_source = source;
+        Ok(client)
     }
 
     pub fn new(base_url: &str, token: &str) -> Result<Self> {
@@ -87,6 +107,7 @@ impl ApiClient {
             client,
             base_url: base_url.trim_end_matches('/').to_string(),
             token: token.to_string(),
+            token_source: TokenSource::Session,
         })
     }
 
@@ -159,6 +180,15 @@ impl ApiClient {
                 .ok()
                 .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(String::from))
                 .unwrap_or_else(|| format!("HTTP {}: {}", status.as_u16(), body));
+
+            if status == StatusCode::UNAUTHORIZED && self.token_source == TokenSource::EnvVar {
+                bail!(
+                    "{} (using {} from environment; \
+                     unset it to use your session token from 'gestalt auth login')",
+                    message,
+                    ENV_API_KEY,
+                );
+            }
 
             bail!("{}", message);
         }

--- a/client/cli/src/commands/auth.rs
+++ b/client/cli/src/commands/auth.rs
@@ -7,6 +7,14 @@ use crate::credentials::{CredentialStore, Credentials};
 use crate::output::{self, Format};
 
 pub fn login(url_override: Option<&str>) -> Result<()> {
+    if api::env_api_key_is_set() {
+        bail!(
+            "{} is set in your environment and takes priority over session tokens. \
+             Unset it before logging in, or use the API key directly.",
+            api::ENV_API_KEY,
+        );
+    }
+
     let base_url = api::resolve_url(url_override)?;
 
     let listener =
@@ -137,14 +145,57 @@ pub fn logout() -> Result<()> {
 }
 
 pub fn status(url_override: Option<&str>, format: Format) -> Result<()> {
+    let has_env_key = api::env_api_key_is_set();
     let authenticated = ApiClient::from_env(url_override).is_ok();
+    // Only probe the credential store when the env key is active, since
+    // from_env already loaded it otherwise (authenticated implies has_session).
+    let has_session = if has_env_key {
+        CredentialStore::new()
+            .and_then(|s| s.load())
+            .map(|c| c.is_some())
+            .unwrap_or(false)
+    } else {
+        authenticated
+    };
+
     match format {
-        Format::Json => output::print_json(&serde_json::json!({"authenticated": authenticated})),
+        Format::Json => {
+            let source = if has_env_key {
+                "env"
+            } else if has_session {
+                "session"
+            } else {
+                "none"
+            };
+            output::print_json(&serde_json::json!({
+                "authenticated": authenticated,
+                "source": source,
+                "env_var_set": has_env_key,
+                "session_stored": has_session,
+            }));
+        }
         Format::Table => {
             if authenticated {
-                eprintln!("Authenticated.");
+                if has_env_key {
+                    eprintln!(
+                        "Authenticated via {} environment variable.",
+                        api::ENV_API_KEY
+                    );
+                    if has_session {
+                        output::print_warning(&format!(
+                            "A session token from 'gestalt auth login' also exists but is being ignored. \
+                             Unset {} to use it.",
+                            api::ENV_API_KEY,
+                        ));
+                    }
+                } else {
+                    eprintln!("Authenticated via session token.");
+                }
             } else {
-                eprintln!("Not authenticated. Run 'gestalt auth login' or set GESTALT_API_KEY.");
+                eprintln!(
+                    "Not authenticated. Run 'gestalt auth login' or set {}.",
+                    api::ENV_API_KEY
+                );
             }
         }
     }

--- a/client/cli/src/output.rs
+++ b/client/cli/src/output.rs
@@ -99,6 +99,14 @@ pub fn print_success(msg: &str) {
     }
 }
 
+pub fn print_warning(msg: &str) {
+    if std::io::stderr().is_terminal() {
+        eprintln!("{}: {}", "warning".yellow().bold(), msg);
+    } else {
+        eprintln!("warning: {}", msg);
+    }
+}
+
 pub fn print_error(msg: &str) {
     if std::io::stderr().is_terminal() {
         eprintln!("{}: {}", "error".red().bold(), msg);

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -80,8 +80,9 @@ cargo build --release
 
 ### Authentication
 
-- If `GESTALT_API_KEY` is set, it is sent as the Bearer token on every request.
+- If `GESTALT_API_KEY` is set, it is sent as the Bearer token on every request, overriding any session token.
 - Otherwise, the CLI uses the session token stored by `gestalt auth login`.
+- Run `gestalt auth status` to see which credential source is active.
 - Credential files are written with `0600` permissions.
 - Output formats: `--format json` (default) or `--format table`.
 

--- a/docs/pages/troubleshooting.mdx
+++ b/docs/pages/troubleshooting.mdx
@@ -28,7 +28,7 @@ The calling user has not connected the target integration. Each user must comple
 
 - Verify the `Authorization` header uses the `Bearer` prefix.
 - Use the plaintext token returned at creation time, not the hash stored in the datastore.
-- If using the CLI, check that `GESTALT_API_KEY` is set correctly and is not overridden by an expired session token.
+- If using the CLI, note that `GESTALT_API_KEY` takes priority over session tokens from `gestalt auth login`. Run `gestalt auth status` to see which credential source is active.
 
 ## Web UI does not talk to the local API
 


### PR DESCRIPTION
When `GESTALT_API_KEY` is set in the environment, it silently overrides
session tokens from `gestalt auth login`. This caused confusing failures
where a user would log in successfully, then immediately get "invalid
token" on every command because the CLI was sending a stale env var
value instead of their fresh session token.

Following GitHub CLI's precedent, `gestalt auth login` now refuses to
run when `GESTALT_API_KEY` is set, since the resulting session token
would never be used. `gestalt auth status` reports which credential
source is active and warns when an env var shadows a stored session
token. API commands that receive a 401 while using `GESTALT_API_KEY`
now include the token source in the error message so users know what
to fix.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>