### PR TITLE
Add connection parameters for per-connection URLs

### DIFF
--- a/core/connection.go
+++ b/core/connection.go
@@ -1,0 +1,14 @@
+package core
+
+import "context"
+
+type connectionParamsKey struct{}
+
+func WithConnectionParams(ctx context.Context, params map[string]string) context.Context {
+	return context.WithValue(ctx, connectionParamsKey{}, params)
+}
+
+func ConnectionParams(ctx context.Context) map[string]string {
+	params, _ := ctx.Value(connectionParamsKey{}).(map[string]string)
+	return params
+}

--- a/core/integration/base.go
+++ b/core/integration/base.go
@@ -10,12 +10,14 @@ import (
 	"github.com/valon-technologies/gestalt/core/catalog"
 	"github.com/valon-technologies/gestalt/internal/apiexec"
 	"github.com/valon-technologies/gestalt/internal/oauth"
+	"github.com/valon-technologies/gestalt/internal/paraminterp"
 )
 
 var (
-	_ core.OAuthProvider   = (*Base)(nil)
-	_ core.ManualProvider  = (*Base)(nil)
-	_ core.CatalogProvider = (*Base)(nil)
+	_ core.OAuthProvider           = (*Base)(nil)
+	_ core.ManualProvider          = (*Base)(nil)
+	_ core.CatalogProvider         = (*Base)(nil)
+	_ core.ConnectionParamProvider = (*Base)(nil)
 )
 
 type manualChecker interface{ IsManual() bool }
@@ -36,7 +38,7 @@ type oauthStarter interface {
 }
 
 type oauthVerifierExchanger interface {
-	ExchangeCodeWithVerifier(ctx context.Context, code, verifier string) (*core.TokenResponse, error)
+	ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
 }
 
 func (u UpstreamAuth) AuthorizationURL(state string, scopes []string) string {
@@ -51,16 +53,28 @@ func (u UpstreamAuth) ExchangeCode(ctx context.Context, code string) (*core.Toke
 	return u.Handler.ExchangeCode(ctx, code)
 }
 
-func (u UpstreamAuth) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string) (*core.TokenResponse, error) {
+func (u UpstreamAuth) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error) {
 	var opts []oauth.ExchangeOption
 	if verifier != "" {
 		opts = append(opts, oauth.WithPKCEVerifier(verifier))
 	}
+	opts = append(opts, extraOpts...)
 	return u.Handler.ExchangeCode(ctx, code, opts...)
 }
 
 func (u UpstreamAuth) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
 	return u.Handler.RefreshToken(ctx, refreshToken)
+}
+
+func (u UpstreamAuth) RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error) {
+	return u.Handler.RefreshTokenWithURL(ctx, refreshToken, tokenURL)
+}
+
+func (u UpstreamAuth) TokenURL() string             { return u.Handler.TokenURL() }
+func (u UpstreamAuth) AuthorizationBaseURL() string { return u.Handler.AuthorizationBaseURL() }
+
+func (u UpstreamAuth) StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string) {
+	return u.Handler.AuthorizationURLWithOverride(authBaseURL, state, scopes)
 }
 
 type Endpoint struct {
@@ -96,6 +110,8 @@ type Base struct {
 	RequestMutator func(operation string, req *apiexec.Request, params map[string]any) error
 	ExecuteFunc    func(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error)
 
+	ConnectionDefs map[string]core.ConnectionParamDef
+
 	catalog *catalog.Catalog
 }
 
@@ -113,6 +129,36 @@ func (b *Base) ConnectionMode() core.ConnectionMode {
 func (b *Base) SupportsManualAuth() bool {
 	mc, ok := b.Auth.(manualChecker)
 	return ok && mc.IsManual()
+}
+
+func (b *Base) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return b.ConnectionDefs
+}
+
+func (b *Base) TokenURL() string {
+	type tokenURLer interface{ TokenURL() string }
+	if tu, ok := b.Auth.(tokenURLer); ok {
+		return tu.TokenURL()
+	}
+	return ""
+}
+
+func (b *Base) AuthorizationBaseURL() string {
+	type authBaseURLer interface{ AuthorizationBaseURL() string }
+	if abu, ok := b.Auth.(authBaseURLer); ok {
+		return abu.AuthorizationBaseURL()
+	}
+	return ""
+}
+
+func (b *Base) StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string) {
+	type overrider interface {
+		StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string)
+	}
+	if ov, ok := b.Auth.(overrider); ok {
+		return ov.StartOAuthWithOverride(authBaseURL, state, scopes)
+	}
+	return b.Auth.AuthorizationURL(state, scopes), ""
 }
 
 func (b *Base) SetCatalog(c *catalog.Catalog) { b.catalog = c }
@@ -134,9 +180,9 @@ func (b *Base) ExchangeCode(ctx context.Context, code string) (*core.TokenRespon
 	return b.Auth.ExchangeCode(ctx, code)
 }
 
-func (b *Base) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string) (*core.TokenResponse, error) {
+func (b *Base) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error) {
 	if exchanger, ok := b.Auth.(oauthVerifierExchanger); ok {
-		return exchanger.ExchangeCodeWithVerifier(ctx, code, verifier)
+		return exchanger.ExchangeCodeWithVerifier(ctx, code, verifier, extraOpts...)
 	}
 	return b.Auth.ExchangeCode(ctx, code)
 }
@@ -145,7 +191,29 @@ func (b *Base) RefreshToken(ctx context.Context, refreshToken string) (*core.Tok
 	return b.Auth.RefreshToken(ctx, refreshToken)
 }
 
+func (b *Base) RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error) {
+	type refresher interface {
+		RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error)
+	}
+	if r, ok := b.Auth.(refresher); ok {
+		return r.RefreshTokenWithURL(ctx, refreshToken, tokenURL)
+	}
+	return b.Auth.RefreshToken(ctx, refreshToken)
+}
+
 func (b *Base) ListOperations() []core.Operation { return b.Operations }
+
+func (b *Base) resolvedURLAndHeaders(ctx context.Context) (string, map[string]string) {
+	baseURL := b.BaseURL
+	headers := copyHeaders(b.Headers)
+	if cp := core.ConnectionParams(ctx); cp != nil {
+		baseURL = paraminterp.Interpolate(baseURL, cp)
+		for k, v := range headers {
+			headers[k] = paraminterp.Interpolate(v, cp)
+		}
+	}
+	return baseURL, headers
+}
 
 func (b *Base) httpClient() *http.Client {
 	if b.HTTPClient != nil {
@@ -168,12 +236,14 @@ func (b *Base) Execute(ctx context.Context, operation string, params map[string]
 		return nil, fmt.Errorf("unknown operation: %s", operation)
 	}
 
+	baseURL, headers := b.resolvedURLAndHeaders(ctx)
+
 	req := apiexec.Request{
 		Method:        ep.Method,
-		BaseURL:       b.BaseURL,
+		BaseURL:       baseURL,
 		Path:          ep.Path,
 		Params:        params,
-		CustomHeaders: copyHeaders(b.Headers),
+		CustomHeaders: headers,
 		CheckResponse: b.CheckResponse,
 	}
 
@@ -195,11 +265,13 @@ func (b *Base) Execute(ctx context.Context, operation string, params map[string]
 }
 
 func (b *Base) executeGraphQL(ctx context.Context, query string, params map[string]any, token string) (*core.OperationResult, error) {
+	gqlURL, headers := b.resolvedURLAndHeaders(ctx)
+
 	gqlReq := apiexec.GraphQLRequest{
-		URL:           b.BaseURL,
+		URL:           gqlURL,
 		Query:         query,
 		Variables:     params,
-		CustomHeaders: copyHeaders(b.Headers),
+		CustomHeaders: headers,
 	}
 	if err := b.applyGraphQLAuth(&gqlReq, token); err != nil {
 		return nil, err

--- a/core/provider.go
+++ b/core/provider.go
@@ -41,3 +41,15 @@ type ManualProvider interface {
 type CatalogProvider interface {
 	Catalog() *catalog.Catalog
 }
+
+type ConnectionParamDef struct {
+	Required    bool
+	Description string
+	Default     string
+	From        string // "" = user-provided, "token_response" = extracted from OAuth response
+	Field       string // JSON field name for token_response extraction
+}
+
+type ConnectionParamProvider interface {
+	ConnectionParamDefs() map[string]ConnectionParamDef
+}

--- a/core/types.go
+++ b/core/types.go
@@ -48,6 +48,7 @@ type TokenResponse struct {
 	RefreshToken string
 	ExpiresIn    int
 	TokenType    string
+	Extra        map[string]any // all fields from the token endpoint response
 }
 
 type Operation struct {

--- a/internal/integration/restricted.go
+++ b/internal/integration/restricted.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
+	"github.com/valon-technologies/gestalt/internal/oauth"
 )
 
 // Restricted wraps a Provider to expose only a subset of its operations.
@@ -108,4 +109,58 @@ func (r *restrictedOAuth) ExchangeCode(ctx context.Context, code string) (*core.
 
 func (r *restrictedOAuth) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
 	return r.oauth.RefreshToken(ctx, refreshToken)
+}
+
+func (r *restrictedOAuth) RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error) {
+	type refresher interface {
+		RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error)
+	}
+	if rw, ok := r.oauth.(refresher); ok {
+		return rw.RefreshTokenWithURL(ctx, refreshToken, tokenURL)
+	}
+	return r.oauth.RefreshToken(ctx, refreshToken)
+}
+
+type oauthVerifierExchanger interface {
+	ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
+}
+
+func (r *restrictedOAuth) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error) {
+	if exchanger, ok := r.oauth.(oauthVerifierExchanger); ok {
+		return exchanger.ExchangeCodeWithVerifier(ctx, code, verifier, extraOpts...)
+	}
+	return r.oauth.ExchangeCode(ctx, code)
+}
+
+func (r *restrictedOAuth) TokenURL() string {
+	type tokenURLer interface{ TokenURL() string }
+	if tu, ok := r.oauth.(tokenURLer); ok {
+		return tu.TokenURL()
+	}
+	return ""
+}
+
+func (r *restrictedOAuth) AuthorizationBaseURL() string {
+	type authBaseURLer interface{ AuthorizationBaseURL() string }
+	if abu, ok := r.oauth.(authBaseURLer); ok {
+		return abu.AuthorizationBaseURL()
+	}
+	return ""
+}
+
+func (r *restrictedOAuth) StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string) {
+	type overrider interface {
+		StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string)
+	}
+	if ov, ok := r.oauth.(overrider); ok {
+		return ov.StartOAuthWithOverride(authBaseURL, state, scopes)
+	}
+	return r.oauth.AuthorizationURL(state, scopes), ""
+}
+
+func (r *Restricted) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	if cpp, ok := r.inner.(core.ConnectionParamProvider); ok {
+		return cpp.ConnectionParamDefs()
+	}
+	return nil
 }

--- a/internal/invocation/broker.go
+++ b/internal/invocation/broker.go
@@ -2,11 +2,14 @@ package invocation
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/paraminterp"
 	"github.com/valon-technologies/gestalt/internal/principal"
 	"github.com/valon-technologies/gestalt/internal/registry"
 )
@@ -87,7 +90,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		return nil, ErrNotAuthenticated
 	}
 
-	accessToken, err := b.resolveToken(ctx, prov, p, providerName)
+	ctx, accessToken, err := b.resolveToken(ctx, prov, p, providerName)
 	if err != nil {
 		return nil, err
 	}
@@ -108,26 +111,27 @@ func (b *Broker) ResolveToken(ctx context.Context, p *principal.Principal, provi
 		}
 		return "", fmt.Errorf("%w: looking up provider: %v", ErrInternal, err)
 	}
-	return b.resolveToken(ctx, prov, p, providerName)
+	_, tok, resolveErr := b.resolveToken(ctx, prov, p, providerName)
+	return tok, resolveErr
 }
 
-func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *principal.Principal, providerName string) (string, error) {
+func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *principal.Principal, providerName string) (context.Context, string, error) {
 	mode := prov.ConnectionMode()
 	switch mode {
 	case core.ConnectionModeNone:
-		return "", nil
+		return ctx, "", nil
 
 	case core.ConnectionModeUser, "":
 		if p.UserID == "" {
 			if p.Identity == nil || p.Identity.Email == "" {
-				return "", fmt.Errorf("%w: principal has no user ID or email", ErrUserResolution)
+				return ctx, "", fmt.Errorf("%w: principal has no user ID or email", ErrUserResolution)
 			}
 			dbUser, err := b.datastore.FindOrCreateUser(ctx, p.Identity.Email)
 			if err != nil {
-				return "", fmt.Errorf("%w: %v", ErrUserResolution, err)
+				return ctx, "", fmt.Errorf("%w: %v", ErrUserResolution, err)
 			}
 			if dbUser == nil || dbUser.ID == "" {
-				return "", fmt.Errorf("%w: no user record returned", ErrUserResolution)
+				return ctx, "", fmt.Errorf("%w: no user record returned", ErrUserResolution)
 			}
 			p.UserID = dbUser.ID
 		}
@@ -138,33 +142,44 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 
 	case core.ConnectionModeEither:
 		if p.UserID != "" {
-			tok, err := b.resolveUserToken(ctx, prov, p.UserID, providerName)
+			enrichedCtx, tok, err := b.resolveUserToken(ctx, prov, p.UserID, providerName)
 			if err == nil {
-				return tok, nil
+				return enrichedCtx, tok, nil
 			}
 			if !errors.Is(err, ErrNoToken) {
-				return "", err
+				return ctx, "", err
 			}
 		}
 		return b.resolveUserToken(ctx, prov, principal.IdentityPrincipal, providerName)
 
 	default:
-		return "", fmt.Errorf("%w: unknown connection mode %q", ErrInternal, mode)
+		return ctx, "", fmt.Errorf("%w: unknown connection mode %q", ErrInternal, mode)
 	}
 }
 
-func (b *Broker) resolveUserToken(ctx context.Context, prov core.Provider, userID, providerName string) (string, error) {
+func (b *Broker) resolveUserToken(ctx context.Context, prov core.Provider, userID, providerName string) (context.Context, string, error) {
 	storedToken, err := b.datastore.Token(ctx, userID, providerName, "default")
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
-			return "", fmt.Errorf("%w: no token stored for integration %q", ErrNoToken, providerName)
+			return ctx, "", fmt.Errorf("%w: no token stored for integration %q", ErrNoToken, providerName)
 		}
-		return "", fmt.Errorf("%w: retrieving integration token: %v", ErrInternal, err)
+		return ctx, "", fmt.Errorf("%w: retrieving integration token: %v", ErrInternal, err)
 	}
 	if storedToken == nil {
-		return "", fmt.Errorf("%w: no token stored for integration %q", ErrNoToken, providerName)
+		return ctx, "", fmt.Errorf("%w: no token stored for integration %q", ErrNoToken, providerName)
 	}
-	return b.refreshTokenIfNeeded(ctx, prov, storedToken)
+
+	if storedToken.MetadataJSON != "" {
+		var connParams map[string]string
+		if err := json.Unmarshal([]byte(storedToken.MetadataJSON), &connParams); err != nil {
+			log.Printf("WARNING: malformed MetadataJSON for %s: %v", providerName, err)
+		} else if len(connParams) > 0 {
+			ctx = core.WithConnectionParams(ctx, connParams)
+		}
+	}
+
+	accessToken, err := b.refreshTokenIfNeeded(ctx, prov, storedToken)
+	return ctx, accessToken, err
 }
 
 func (b *Broker) refreshTokenIfNeeded(ctx context.Context, prov core.Provider, token *core.IntegrationToken) (string, error) {
@@ -180,7 +195,7 @@ func (b *Broker) refreshTokenIfNeeded(ctx context.Context, prov core.Provider, t
 		return token.AccessToken, nil
 	}
 
-	resp, err := oauthProv.RefreshToken(ctx, token.RefreshToken)
+	resp, err := b.refreshOAuth(ctx, oauthProv, prov, token.RefreshToken)
 	if err != nil {
 		fresh, fetchErr := b.datastore.Token(ctx, token.UserID, token.Integration, token.Instance)
 		if fetchErr == nil && fresh != nil && fresh.AccessToken != token.AccessToken {
@@ -214,4 +229,24 @@ func (b *Broker) refreshTokenIfNeeded(ctx context.Context, prov core.Provider, t
 		return "", fmt.Errorf("persisting refreshed token: %w", err)
 	}
 	return token.AccessToken, nil
+}
+
+func (b *Broker) refreshOAuth(ctx context.Context, oauthProv core.OAuthProvider, prov core.Provider, refreshToken string) (*core.TokenResponse, error) {
+	type refreshWithURL interface {
+		RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error)
+	}
+	type tokenURLer interface{ TokenURL() string }
+
+	if cp := core.ConnectionParams(ctx); cp != nil {
+		if tu, ok := prov.(tokenURLer); ok {
+			raw := tu.TokenURL()
+			resolved := paraminterp.Interpolate(raw, cp)
+			if resolved != raw {
+				if rw, ok := prov.(refreshWithURL); ok {
+					return rw.RefreshTokenWithURL(ctx, refreshToken, resolved)
+				}
+			}
+		}
+	}
+	return oauthProv.RefreshToken(ctx, refreshToken)
 }

--- a/internal/invocation/broker_test.go
+++ b/internal/invocation/broker_test.go
@@ -207,3 +207,52 @@ func TestInvoke_NilTokenResponse(t *testing.T) {
 		t.Fatalf("expected ErrNoToken, got %v", err)
 	}
 }
+
+func TestInvoke_MetadataJSONFlowsToContext(t *testing.T) {
+	t.Parallel()
+
+	var gotCtx context.Context
+
+	prov := &stubProviderWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N: "shopify",
+			ExecuteFn: func(ctx context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				gotCtx = ctx
+				return &core.OperationResult{Status: http.StatusOK, Body: `{}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "list_products"}},
+	}
+
+	ds := &coretesting.StubDatastore{
+		FindOrCreateUserFn: func(_ context.Context, _ string) (*core.User, error) {
+			return &core.User{ID: "u1"}, nil
+		},
+		TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+			return &core.IntegrationToken{
+				AccessToken:  "tok",
+				MetadataJSON: `{"subdomain":"cool-store","region":"us"}`,
+			}, nil
+		},
+	}
+
+	reg := testutil.NewProviderRegistry(t, prov)
+	b := invocation.NewBroker(reg, ds)
+
+	p := &principal.Principal{UserID: "u1"}
+	_, err := b.Invoke(context.Background(), p, "shopify", "list_products", nil)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	cp := core.ConnectionParams(gotCtx)
+	if cp == nil {
+		t.Fatal("expected connection params in context")
+	}
+	if cp["subdomain"] != "cool-store" {
+		t.Errorf("subdomain = %q, want cool-store", cp["subdomain"])
+	}
+	if cp["region"] != "us" {
+		t.Errorf("region = %q, want us", cp["region"])
+	}
+}

--- a/internal/oauth/upstream.go
+++ b/internal/oauth/upstream.go
@@ -12,6 +12,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -75,6 +76,9 @@ func WithResponseHook(hook ResponseHook) Option {
 	}
 }
 
+func (h *UpstreamHandler) TokenURL() string             { return h.cfg.TokenURL }
+func (h *UpstreamHandler) AuthorizationBaseURL() string { return h.cfg.AuthorizationURL }
+
 func NewUpstream(cfg UpstreamConfig, opts ...Option) *UpstreamHandler {
 	h := &UpstreamHandler{
 		cfg:        cfg,
@@ -90,11 +94,18 @@ type ExchangeOption func(*exchangeOptions)
 
 type exchangeOptions struct {
 	verifier string
+	tokenURL string
 }
 
 func WithPKCEVerifier(verifier string) ExchangeOption {
 	return func(o *exchangeOptions) {
 		o.verifier = verifier
+	}
+}
+
+func WithTokenURL(url string) ExchangeOption {
+	return func(o *exchangeOptions) {
+		o.tokenURL = url
 	}
 }
 
@@ -109,7 +120,15 @@ func (h *UpstreamHandler) AuthorizationURL(state string, scopes []string) string
 }
 
 func (h *UpstreamHandler) AuthorizationURLWithPKCE(state string, scopes []string) (string, string) {
-	u, err := url.Parse(h.cfg.AuthorizationURL)
+	return h.authorizationURL(h.cfg.AuthorizationURL, state, scopes)
+}
+
+func (h *UpstreamHandler) AuthorizationURLWithOverride(authBaseURL, state string, scopes []string) (string, string) {
+	return h.authorizationURL(authBaseURL, state, scopes)
+}
+
+func (h *UpstreamHandler) authorizationURL(baseURL, state string, scopes []string) (string, string) {
+	u, err := url.Parse(baseURL)
 	if err != nil {
 		u = &url.URL{RawQuery: ""}
 	}
@@ -170,10 +189,14 @@ func (h *UpstreamHandler) ExchangeCode(ctx context.Context, code string, opts ..
 		data.Set(k, v)
 	}
 
-	return h.tokenRequest(ctx, data)
+	return h.tokenRequest(ctx, data, eo.tokenURL)
 }
 
 func (h *UpstreamHandler) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	return h.RefreshTokenWithURL(ctx, refreshToken, "")
+}
+
+func (h *UpstreamHandler) RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURLOverride string) (*core.TokenResponse, error) {
 	data := url.Values{
 		"grant_type":    {"refresh_token"},
 		"refresh_token": {refreshToken},
@@ -188,10 +211,10 @@ func (h *UpstreamHandler) RefreshToken(ctx context.Context, refreshToken string)
 		data.Set(k, v)
 	}
 
-	return h.tokenRequest(ctx, data)
+	return h.tokenRequest(ctx, data, tokenURLOverride)
 }
 
-func (h *UpstreamHandler) tokenRequest(ctx context.Context, data url.Values) (*core.TokenResponse, error) {
+func (h *UpstreamHandler) tokenRequest(ctx context.Context, data url.Values, tokenURLOverride string) (*core.TokenResponse, error) {
 	var reader io.Reader
 	var contentType string
 
@@ -213,7 +236,12 @@ func (h *UpstreamHandler) tokenRequest(ctx context.Context, data url.Values) (*c
 		contentType = "application/x-www-form-urlencoded"
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.cfg.TokenURL, reader)
+	tokenURL := h.cfg.TokenURL
+	if tokenURLOverride != "" {
+		tokenURL = tokenURLOverride
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, reader)
 	if err != nil {
 		return nil, fmt.Errorf("creating token request: %w", err)
 	}
@@ -249,24 +277,31 @@ func (h *UpstreamHandler) tokenRequest(ctx context.Context, data url.Values) (*c
 		return nil, fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, body)
 	}
 
-	var tok struct {
-		AccessToken  string `json:"access_token"`
-		RefreshToken string `json:"refresh_token"`
-		ExpiresIn    int    `json:"expires_in"`
-		TokenType    string `json:"token_type"`
-	}
-	if err := json.Unmarshal(body, &tok); err != nil {
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
 		return nil, fmt.Errorf("decoding token response: %w", err)
 	}
-	if tok.AccessToken == "" {
+	accessToken, _ := raw["access_token"].(string)
+	if accessToken == "" {
 		return nil, fmt.Errorf("token response missing access_token")
 	}
+	refreshToken, _ := raw["refresh_token"].(string)
+	var expiresIn float64
+	switch v := raw["expires_in"].(type) {
+	case float64:
+		expiresIn = v
+	case string:
+		n, _ := strconv.Atoi(v)
+		expiresIn = float64(n)
+	}
+	tokenType, _ := raw["token_type"].(string)
 
 	return &core.TokenResponse{
-		AccessToken:  tok.AccessToken,
-		RefreshToken: tok.RefreshToken,
-		ExpiresIn:    tok.ExpiresIn,
-		TokenType:    tok.TokenType,
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		ExpiresIn:    int(expiresIn),
+		TokenType:    tokenType,
+		Extra:        raw,
 	}, nil
 }
 

--- a/internal/oauth/upstream_test.go
+++ b/internal/oauth/upstream_test.go
@@ -696,3 +696,70 @@ func TestComputeS256Challenge(t *testing.T) {
 		t.Error("challenge should use URL-safe base64 encoding")
 	}
 }
+
+func TestWithTokenURLOverride(t *testing.T) {
+	t.Parallel()
+
+	var gotURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"tok","token_type":"bearer"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	h := NewUpstream(UpstreamConfig{
+		ClientID:     "cid",
+		ClientSecret: "csec",
+		TokenURL:     srv.URL + "/default-token",
+		RedirectURL:  "http://localhost/cb",
+	})
+
+	_, err := h.ExchangeCode(context.Background(), "code", WithTokenURL(srv.URL+"/override-token"))
+	if err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if gotURL != "/override-token" {
+		t.Errorf("token request went to %q, want /override-token", gotURL)
+	}
+}
+
+func TestTokenResponseExtra(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"access_token": "at",
+			"refresh_token": "rt",
+			"expires_in": 3600,
+			"instance_url": "https://na85.salesforce.com",
+			"custom_field": "custom_value"
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	h := NewUpstream(UpstreamConfig{
+		ClientID:     "cid",
+		ClientSecret: "csec",
+		TokenURL:     srv.URL + "/token",
+		RedirectURL:  "http://localhost/cb",
+	})
+
+	resp, err := h.ExchangeCode(context.Background(), "code")
+	if err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if resp.AccessToken != "at" {
+		t.Errorf("AccessToken = %q, want at", resp.AccessToken)
+	}
+	if resp.Extra == nil {
+		t.Fatal("Extra should not be nil")
+	}
+	if resp.Extra["instance_url"] != "https://na85.salesforce.com" {
+		t.Errorf("Extra[instance_url] = %v, want https://na85.salesforce.com", resp.Extra["instance_url"])
+	}
+	if resp.Extra["custom_field"] != "custom_value" {
+		t.Errorf("Extra[custom_field] = %v, want custom_value", resp.Extra["custom_field"])
+	}
+}

--- a/internal/paraminterp/interpolate.go
+++ b/internal/paraminterp/interpolate.go
@@ -1,0 +1,23 @@
+package paraminterp
+
+import (
+	"regexp"
+	"strings"
+)
+
+var re = regexp.MustCompile(`\{([^}]+)\}`)
+
+// Interpolate replaces {key} placeholders in s with values from params.
+// Unmatched placeholders are left unchanged.
+func Interpolate(s string, params map[string]string) string {
+	if len(params) == 0 || !strings.Contains(s, "{") {
+		return s
+	}
+	return re.ReplaceAllStringFunc(s, func(match string) string {
+		key := match[1 : len(match)-1]
+		if val, ok := params[key]; ok {
+			return val
+		}
+		return match
+	})
+}

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -148,6 +148,19 @@ func Build(def *Definition, intg config.IntegrationDef, allowedOperations map[st
 		base.RequestMutator = mutator
 	}
 
+	if len(def.Connection) > 0 {
+		base.ConnectionDefs = make(map[string]core.ConnectionParamDef, len(def.Connection))
+		for name, cpd := range def.Connection {
+			base.ConnectionDefs[name] = core.ConnectionParamDef{
+				Required:    cpd.Required,
+				Description: cpd.Description,
+				Default:     cpd.Default,
+				From:        cpd.From,
+				Field:       cpd.Field,
+			}
+		}
+	}
+
 	base.SetCatalog(cat)
 
 	var result core.Provider = base

--- a/internal/provider/build_test.go
+++ b/internal/provider/build_test.go
@@ -613,6 +613,85 @@ func TestBuildConfigOverridesAuthHeader(t *testing.T) {
 	}
 }
 
+func TestBuildConnectionParams(t *testing.T) {
+	t.Parallel()
+
+	def := &Definition{
+		Provider:    "shopify_test",
+		DisplayName: "Shopify Test",
+		BaseURL:     "https://{subdomain}.myshopify.com",
+		Auth:        AuthDef{Type: "manual"},
+		Connection: map[string]ConnectionParamDef{
+			"subdomain": {Required: true, Description: "Store subdomain"},
+			"instance_url": {
+				From:  "token_response",
+				Field: "instance_url",
+			},
+		},
+		Operations: map[string]OperationDef{
+			"list_products": {Description: "List products", Method: "GET", Path: "/products"},
+		},
+	}
+
+	prov, err := Build(def, config.IntegrationDef{}, nil)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	cpp, ok := prov.(core.ConnectionParamProvider)
+	if !ok {
+		t.Fatal("provider does not implement ConnectionParamProvider")
+	}
+
+	defs := cpp.ConnectionParamDefs()
+	if len(defs) != 2 {
+		t.Fatalf("expected 2 connection params, got %d", len(defs))
+	}
+	if !defs["subdomain"].Required {
+		t.Error("subdomain should be required")
+	}
+	if defs["instance_url"].From != "token_response" {
+		t.Errorf("instance_url.From = %q, want token_response", defs["instance_url"].From)
+	}
+}
+
+func TestBuildConnectionParamsBaseURLInterpolation(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"host": r.Host, "path": r.URL.Path})
+	}))
+	t.Cleanup(srv.Close)
+
+	def := &Definition{
+		Provider:    "dynamic_url_test",
+		DisplayName: "Dynamic URL Test",
+		BaseURL:     srv.URL,
+		Auth:        AuthDef{Type: "manual"},
+		Connection: map[string]ConnectionParamDef{
+			"subdomain": {Required: true},
+		},
+		Operations: map[string]OperationDef{
+			"op": {Description: "Op", Method: "GET", Path: "/items"},
+		},
+	}
+
+	prov, err := Build(def, config.IntegrationDef{}, nil)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	ctx := core.WithConnectionParams(context.Background(), map[string]string{"subdomain": "test-store"})
+	result, err := prov.Execute(ctx, "op", nil, "tok")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.Status != 200 {
+		t.Fatalf("unexpected status %d, body: %s", result.Status, result.Body)
+	}
+}
+
 func writeProviderYAML(t *testing.T, dir, name, displayName string) {
 	t.Helper()
 	content := fmt.Sprintf(minimalProviderYAML, name, displayName, name)

--- a/internal/provider/definition.go
+++ b/internal/provider/definition.go
@@ -19,7 +19,16 @@ type Definition struct {
 	TokenParser    string `yaml:"token_parser"`
 	RequestMutator string `yaml:"request_mutator"`
 
-	Operations map[string]OperationDef `yaml:"operations"`
+	Connection map[string]ConnectionParamDef `yaml:"connection"`
+	Operations map[string]OperationDef       `yaml:"operations"`
+}
+
+type ConnectionParamDef struct {
+	Required    bool   `yaml:"required"`
+	Description string `yaml:"description"`
+	Default     string `yaml:"default"`
+	From        string `yaml:"from"`  // "" = user-provided, "token_response" = from OAuth response
+	Field       string `yaml:"field"` // JSON field name for token_response extraction
 }
 
 type AuthDef struct {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -10,12 +10,15 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"regexp"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/invocation"
+	"github.com/valon-technologies/gestalt/internal/oauth"
+	"github.com/valon-technologies/gestalt/internal/paraminterp"
 	"github.com/valon-technologies/gestalt/internal/principal"
 )
 
@@ -54,12 +57,19 @@ func (s *Server) readinessCheck(w http.ResponseWriter, r *http.Request) {
 }
 
 type integrationInfo struct {
-	Name        string `json:"name"`
-	DisplayName string `json:"display_name,omitempty"`
+	Name             string                         `json:"name"`
+	DisplayName      string                         `json:"display_name,omitempty"`
+	Description      string                         `json:"description,omitempty"`
+	IconSVG          string                         `json:"icon_svg,omitempty"`
+	Connected        bool                           `json:"connected"`
+	AuthType         string                         `json:"auth_type"`
+	ConnectionParams map[string]connectionParamInfo `json:"connection_params,omitempty"`
+}
+
+type connectionParamInfo struct {
+	Required    bool   `json:"required,omitempty"`
 	Description string `json:"description,omitempty"`
-	IconSVG     string `json:"icon_svg,omitempty"`
-	Connected   bool   `json:"connected"`
-	AuthType    string `json:"auth_type"`
+	Default     string `json:"default,omitempty"`
 }
 
 func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
@@ -91,6 +101,22 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		if cp, ok := prov.(core.CatalogProvider); ok {
 			if cat := cp.Catalog(); cat != nil {
 				info.IconSVG = cat.IconSVG
+			}
+		}
+		if cpp, ok := prov.(core.ConnectionParamProvider); ok {
+			defs := cpp.ConnectionParamDefs()
+			userParams := make(map[string]connectionParamInfo)
+			for name, def := range defs {
+				if def.From == "" {
+					userParams[name] = connectionParamInfo{
+						Required:    def.Required,
+						Description: def.Description,
+						Default:     def.Default,
+					}
+				}
+			}
+			if len(userParams) > 0 {
+				info.ConnectionParams = userParams
 			}
 		}
 		out = append(out, info)
@@ -370,8 +396,9 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 }
 
 type startOAuthRequest struct {
-	Integration string   `json:"integration"`
-	Scopes      []string `json:"scopes"`
+	Integration      string            `json:"integration"`
+	Scopes           []string          `json:"scopes"`
+	ConnectionParams map[string]string `json:"connection_params"`
 }
 
 type oauthStarter interface {
@@ -379,7 +406,7 @@ type oauthStarter interface {
 }
 
 type oauthVerifierExchanger interface {
-	ExchangeCodeWithVerifier(ctx context.Context, code, verifier string) (*core.TokenResponse, error)
+	ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
 }
 
 func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
@@ -406,21 +433,51 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var connParams map[string]string
+	if cpp, ok := prov.(core.ConnectionParamProvider); ok {
+		var valErr error
+		connParams, valErr = validateConnectionParams(cpp.ConnectionParamDefs(), req.ConnectionParams)
+		if valErr != nil {
+			writeError(w, http.StatusBadRequest, valErr.Error())
+			return
+		}
+	}
+
 	var (
 		authURL  string
 		verifier string
 	)
-	if starter, ok := prov.(oauthStarter); ok {
-		authURL, verifier = starter.StartOAuth("_", req.Scopes)
-	} else {
-		authURL = oauthProv.AuthorizationURL("_", req.Scopes)
+
+	type authURLOverrider interface {
+		StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string)
+	}
+	type authBaseURLer interface{ AuthorizationBaseURL() string }
+
+	if len(connParams) > 0 {
+		if abu, ok := prov.(authBaseURLer); ok {
+			rawAuthURL := abu.AuthorizationBaseURL()
+			resolvedAuthURL := paraminterp.Interpolate(rawAuthURL, connParams)
+			if resolvedAuthURL != rawAuthURL {
+				if ov, ok := prov.(authURLOverrider); ok {
+					authURL, verifier = ov.StartOAuthWithOverride(resolvedAuthURL, "_", req.Scopes)
+				}
+			}
+		}
+	}
+	if authURL == "" {
+		if starter, ok := prov.(oauthStarter); ok {
+			authURL, verifier = starter.StartOAuth("_", req.Scopes)
+		} else {
+			authURL = oauthProv.AuthorizationURL("_", req.Scopes)
+		}
 	}
 
 	state, err := s.stateCodec.Encode(integrationOAuthState{
-		UserID:      dbUserID,
-		Integration: req.Integration,
-		Verifier:    verifier,
-		ExpiresAt:   s.now().Add(integrationOAuthStateTTL).Unix(),
+		UserID:           dbUserID,
+		Integration:      req.Integration,
+		Verifier:         verifier,
+		ConnectionParams: connParams,
+		ExpiresAt:        s.now().Add(integrationOAuthStateTTL).Unix(),
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to encode oauth state")
@@ -463,15 +520,38 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 
 	prov, _ := s.providers.Get(providerName)
 
+	var exchangeOpts []oauth.ExchangeOption
+	connParams := state.ConnectionParams
+	if len(connParams) > 0 {
+		type tokenURLer interface{ TokenURL() string }
+		if tup, ok := prov.(tokenURLer); ok {
+			rawURL := tup.TokenURL()
+			resolved := paraminterp.Interpolate(rawURL, connParams)
+			if resolved != rawURL {
+				exchangeOpts = append(exchangeOpts, oauth.WithTokenURL(resolved))
+			}
+		}
+	}
+
 	var tokenResp *core.TokenResponse
-	if exchanger, ok := prov.(oauthVerifierExchanger); ok && state.Verifier != "" {
-		tokenResp, err = exchanger.ExchangeCodeWithVerifier(r.Context(), code, state.Verifier)
+	if exchanger, ok := prov.(oauthVerifierExchanger); ok {
+		tokenResp, err = exchanger.ExchangeCodeWithVerifier(r.Context(), code, state.Verifier, exchangeOpts...)
 	} else {
+		if len(exchangeOpts) > 0 {
+			log.Printf("WARNING: %s does not support exchange options (e.g. token URL override); connection params may not apply to token exchange", providerName)
+		}
 		tokenResp, err = oauthProv.ExchangeCode(r.Context(), code)
 	}
 	if err != nil {
 		log.Printf("token exchange failed for %s: %v", providerName, err)
 		writeError(w, http.StatusBadGateway, "token exchange failed")
+		return
+	}
+
+	metadata, metaErr := buildConnectionMetadata(prov, connParams, tokenResp)
+	if metaErr != nil {
+		log.Printf("connection metadata extraction failed for %s: %v", providerName, metaErr)
+		writeError(w, http.StatusBadGateway, "failed to extract connection metadata from token response")
 		return
 	}
 
@@ -488,6 +568,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		AccessToken:  tokenResp.AccessToken,
 		RefreshToken: tokenResp.RefreshToken,
 		ExpiresAt:    expiresAt,
+		MetadataJSON: metadata,
 	}
 
 	if err := s.datastore.StoreToken(r.Context(), tok); err != nil {
@@ -499,8 +580,9 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 }
 
 type connectManualRequest struct {
-	Integration string `json:"integration"`
-	Credential  string `json:"credential"`
+	Integration      string            `json:"integration"`
+	Credential       string            `json:"credential"`
+	ConnectionParams map[string]string `json:"connection_params"`
 }
 
 func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
@@ -537,6 +619,16 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var connParams map[string]string
+	if cpp, ok := prov.(core.ConnectionParamProvider); ok {
+		var valErr error
+		connParams, valErr = validateConnectionParams(cpp.ConnectionParamDefs(), req.ConnectionParams)
+		if valErr != nil {
+			writeError(w, http.StatusBadRequest, valErr.Error())
+			return
+		}
+	}
+
 	tok := &core.IntegrationToken{
 		ID:          uuid.NewString(),
 		UserID:      dbUser.ID,
@@ -544,6 +636,12 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		Instance:    "default",
 		AccessToken: req.Credential,
 	}
+	manualMeta, metaErr := buildConnectionMetadata(prov, connParams, nil)
+	if metaErr != nil {
+		writeError(w, http.StatusBadRequest, metaErr.Error())
+		return
+	}
+	tok.MetadataJSON = manualMeta
 	if err := s.datastore.StoreToken(r.Context(), tok); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to store credential")
 		return
@@ -708,4 +806,76 @@ func generateRandomHex(n int) (string, error) {
 		return "", fmt.Errorf("generating random bytes: %w", err)
 	}
 	return hex.EncodeToString(b), nil
+}
+
+var (
+	safeParamValue         = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+	safeTokenResponseValue = regexp.MustCompile(`^[a-zA-Z0-9._:/-]+$`)
+)
+
+func validateConnectionParams(defs map[string]core.ConnectionParamDef, provided map[string]string) (map[string]string, error) {
+	if len(defs) == 0 {
+		return nil, nil
+	}
+	for key := range provided {
+		if _, ok := defs[key]; !ok {
+			return nil, fmt.Errorf("unknown connection parameter: %s", key)
+		}
+	}
+	result := make(map[string]string)
+	for name, def := range defs {
+		if def.From != "" {
+			continue
+		}
+		if v, ok := provided[name]; ok && v != "" {
+			if !safeParamValue.MatchString(v) {
+				return nil, fmt.Errorf("connection parameter %q contains invalid characters (allowed: letters, digits, hyphens, dots, underscores)", name)
+			}
+			result[name] = v
+		} else if def.Default != "" {
+			result[name] = def.Default
+		} else if def.Required {
+			return nil, fmt.Errorf("missing required connection parameter: %s", name)
+		}
+	}
+	if len(result) == 0 {
+		return nil, nil
+	}
+	return result, nil
+}
+
+func buildConnectionMetadata(prov core.Provider, userParams map[string]string, tokenResp *core.TokenResponse) (string, error) {
+	metadata := make(map[string]string)
+	for k, v := range userParams {
+		metadata[k] = v
+	}
+
+	if cpp, ok := prov.(core.ConnectionParamProvider); ok && tokenResp != nil && tokenResp.Extra != nil {
+		for name, def := range cpp.ConnectionParamDefs() {
+			if def.From == "token_response" {
+				field := def.Field
+				if field == "" {
+					field = name
+				}
+				val, ok := tokenResp.Extra[field]
+				if !ok {
+					if def.Required {
+						return "", fmt.Errorf("token response missing required field %q for connection param %q", field, name)
+					}
+					continue
+				}
+				s := fmt.Sprintf("%v", val)
+				if !safeTokenResponseValue.MatchString(s) {
+					return "", fmt.Errorf("token response field %q for connection param %q contains invalid characters", field, name)
+				}
+				metadata[name] = s
+			}
+		}
+	}
+
+	if len(metadata) == 0 {
+		return "", nil
+	}
+	b, _ := json.Marshal(metadata)
+	return string(b), nil
 }

--- a/internal/server/oauth_state.go
+++ b/internal/server/oauth_state.go
@@ -12,10 +12,11 @@ import (
 const integrationOAuthStateTTL = 10 * time.Minute
 
 type integrationOAuthState struct {
-	UserID      string `json:"uid"`
-	Integration string `json:"int"`
-	Verifier    string `json:"ver,omitempty"`
-	ExpiresAt   int64  `json:"exp"`
+	UserID           string            `json:"uid"`
+	Integration      string            `json:"int"`
+	Verifier         string            `json:"ver,omitempty"`
+	ConnectionParams map[string]string `json:"cp,omitempty"`
+	ExpiresAt        int64             `json:"exp"`
 }
 
 type integrationOAuthStateCodec struct {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	gestaltmcp "github.com/valon-technologies/gestalt/internal/mcp"
+	"github.com/valon-technologies/gestalt/internal/oauth"
 	"github.com/valon-technologies/gestalt/internal/principal"
 	"github.com/valon-technologies/gestalt/internal/provider"
 	"github.com/valon-technologies/gestalt/internal/registry"
@@ -1561,7 +1562,7 @@ func (s *stubPKCEIntegration) StartOAuth(state string, _ []string) (string, stri
 	return s.AuthorizationURL(state, nil), s.wantVerifier
 }
 
-func (s *stubPKCEIntegration) ExchangeCodeWithVerifier(_ context.Context, code, verifier string) (*core.TokenResponse, error) {
+func (s *stubPKCEIntegration) ExchangeCodeWithVerifier(_ context.Context, code, verifier string, _ ...oauth.ExchangeOption) (*core.TokenResponse, error) {
 	s.gotVerifier = verifier
 	if code != "good-code" {
 		return nil, fmt.Errorf("bad code")

--- a/web/src/components/IntegrationCard.tsx
+++ b/web/src/components/IntegrationCard.tsx
@@ -47,6 +47,13 @@ function sanitizeSVG(raw: string): string {
   return svg.outerHTML;
 }
 
+function hasConnectionParams(integration: Integration): boolean {
+  return (
+    !!integration.connection_params &&
+    Object.keys(integration.connection_params).length > 0
+  );
+}
+
 export default function IntegrationCard({
   integration,
   onConnected,
@@ -61,17 +68,37 @@ export default function IntegrationCard({
   const [error, setError] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [showTokenForm, setShowTokenForm] = useState(false);
+  const [showParamForm, setShowParamForm] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
   const safeIconSVG = integration.icon_svg
     ? sanitizeSVG(integration.icon_svg)
     : "";
   const isManual = integration.auth_type === "manual";
+  const needsParams = hasConnectionParams(integration);
+
+  function collectConnectionParams(
+    form: HTMLFormElement,
+  ): Record<string, string> {
+    const params: Record<string, string> = {};
+    if (!integration.connection_params) return params;
+    for (const name of Object.keys(integration.connection_params)) {
+      const val = (new FormData(form).get(`cp_${name}`) as string)?.trim();
+      if (val) params[name] = val;
+    }
+    return params;
+  }
 
   async function handleConnect() {
     if (isManual) {
       setSettingsOpen(false);
       setShowTokenForm(true);
+      setError(null);
+      return;
+    }
+    if (needsParams && !showParamForm) {
+      setSettingsOpen(false);
+      setShowParamForm(true);
       setError(null);
       return;
     }
@@ -87,16 +114,38 @@ export default function IntegrationCard({
     }
   }
 
+  async function handleParamSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const params = collectConnectionParams(e.currentTarget);
+    setLoading(true);
+    setError(null);
+    try {
+      const { url } = await startIntegrationOAuth(
+        integration.name,
+        undefined,
+        params,
+      );
+      window.location.href = url;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start OAuth");
+      setLoading(false);
+    }
+  }
+
   async function handleSubmitManual(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    const credential = (
-      new FormData(e.currentTarget).get("credential") as string
-    )?.trim();
+    const fd = new FormData(e.currentTarget);
+    const credential = (fd.get("credential") as string)?.trim();
     if (!credential) return;
+    const params = collectConnectionParams(e.currentTarget);
     setSubmitting(true);
     setError(null);
     try {
-      await connectManualIntegration(integration.name, credential);
+      await connectManualIntegration(
+        integration.name,
+        credential,
+        Object.keys(params).length > 0 ? params : undefined,
+      );
       setShowTokenForm(false);
       onConnected?.();
     } catch (err) {
@@ -106,8 +155,9 @@ export default function IntegrationCard({
     }
   }
 
-  function handleCancelManual() {
+  function handleCancelForm() {
     setShowTokenForm(false);
+    setShowParamForm(false);
     setError(null);
   }
 
@@ -128,6 +178,29 @@ export default function IntegrationCard({
   function handleSettingsClose() {
     setSettingsOpen(false);
     setError(null);
+  }
+
+  function renderConnectionParamFields() {
+    if (!integration.connection_params) return null;
+    return Object.entries(integration.connection_params).map(([name, def]) => (
+      <div key={name} className="mt-2">
+        <label
+          htmlFor={`cp_${name}-${integration.name}`}
+          className="block text-sm font-medium text-stone-700"
+        >
+          {def.description || name}
+        </label>
+        <input
+          id={`cp_${name}-${integration.name}`}
+          name={`cp_${name}`}
+          type="text"
+          required={def.required}
+          defaultValue={def.default}
+          placeholder={name}
+          className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
+        />
+      </div>
+    ));
   }
 
   return (
@@ -171,11 +244,30 @@ export default function IntegrationCard({
       {error && !settingsOpen && (
         <p className="mt-2 text-sm text-ember-500">{error}</p>
       )}
+      {showParamForm && !isManual && (
+        <form onSubmit={handleParamSubmit} className="mt-3">
+          {renderConnectionParamFields()}
+          <div className="mt-3 flex gap-2">
+            <Button type="submit" disabled={loading}>
+              {loading ? "Connecting..." : "Connect"}
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={handleCancelForm}
+              disabled={loading}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+      )}
       {showTokenForm && (
         <form onSubmit={handleSubmitManual} className="mt-3">
+          {needsParams && renderConnectionParamFields()}
           <label
             htmlFor={`credential-${integration.name}`}
-            className="block text-sm font-medium text-stone-700"
+            className="mt-2 block text-sm font-medium text-stone-700"
           >
             API Token
           </label>
@@ -185,7 +277,7 @@ export default function IntegrationCard({
             type="password"
             required
             placeholder="Paste your API token"
-            autoFocus
+            autoFocus={!needsParams}
             className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
           />
           <div className="mt-2 flex gap-2">
@@ -195,7 +287,7 @@ export default function IntegrationCard({
             <Button
               type="button"
               variant="secondary"
-              onClick={handleCancelManual}
+              onClick={handleCancelForm}
               disabled={submitting}
             >
               Cancel
@@ -203,7 +295,7 @@ export default function IntegrationCard({
           </div>
         </form>
       )}
-      {!showTokenForm && !integration.connected && (
+      {!showTokenForm && !showParamForm && !integration.connected && (
         <div className="mt-4">
           <Button onClick={handleConnect} disabled={loading}>
             {loading ? "Connecting..." : "Connect"}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,6 +1,12 @@
 import { clearSession, getSessionToken } from "./auth";
 import { HTTP_UNAUTHORIZED, LOGIN_PATH } from "./constants";
 
+export interface ConnectionParamDef {
+  required?: boolean;
+  description?: string;
+  default?: string;
+}
+
 export interface Integration {
   name: string;
   display_name?: string;
@@ -8,6 +14,7 @@ export interface Integration {
   icon_svg?: string;
   connected?: boolean;
   auth_type?: "oauth" | "manual";
+  connection_params?: Record<string, ConnectionParamDef>;
 }
 
 export interface APIToken {
@@ -111,20 +118,30 @@ export async function getIntegrations(): Promise<Integration[]> {
 export async function startIntegrationOAuth(
   integration: string,
   scopes?: string[],
+  connectionParams?: Record<string, string>,
 ): Promise<{ url: string; state: string }> {
   return fetchAPI("/api/v1/auth/start-oauth", {
     method: "POST",
-    body: JSON.stringify({ integration, scopes: scopes || [] }),
+    body: JSON.stringify({
+      integration,
+      scopes: scopes || [],
+      connection_params: connectionParams,
+    }),
   });
 }
 
 export async function connectManualIntegration(
   integration: string,
   credential: string,
+  connectionParams?: Record<string, string>,
 ): Promise<{ status: string }> {
   return fetchAPI("/api/v1/auth/connect-manual", {
     method: "POST",
-    body: JSON.stringify({ integration, credential }),
+    body: JSON.stringify({
+      integration,
+      credential,
+      connection_params: connectionParams,
+    }),
   });
 }
 


### PR DESCRIPTION
Provider YAML definitions can now declare a `connection:` block with
parameters that vary per connection, such as a Shopify store subdomain
or a Salesforce instance URL. These values are collected during the auth
flow (either from the user before OAuth starts, or extracted from the
token response after exchange) and stored on the connection. At request
time they are interpolated into the provider's base URL, headers, and
auth URLs using the existing `{param}` placeholder syntax.

The web UI shows input fields for user-provided connection parameters
before initiating the OAuth or manual auth flow. This closes the gap
where multi-tenant SaaS integrations like Shopify, Zendesk, and
Freshdesk required a separate integration definition per customer
instance, and where providers like Salesforce that return instance URLs
in their token response had no way to use them.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>