### PR TITLE
Show auth type and connection status in integrations table

### DIFF
--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-reqwest = { version = "0.12", features = ["blocking", "json", "native-tls-vendored"] }
+reqwest = { version = "0.13", features = ["blocking", "json", "native-tls-vendored"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/client/cli/src/commands/integrations.rs
+++ b/client/cli/src/commands/integrations.rs
@@ -16,14 +16,29 @@ pub fn list(url_override: Option<&str>, format: Format) -> Result<()> {
             let rows: Vec<Vec<String>> = items
                 .iter()
                 .map(|item| {
+                    let connected = match item["connected"].as_bool() {
+                        Some(true) => "yes",
+                        _ => "no",
+                    };
                     vec![
                         item["name"].as_str().unwrap_or("-").to_string(),
                         item["display_name"].as_str().unwrap_or("-").to_string(),
+                        item["auth_type"].as_str().unwrap_or("-").to_string(),
+                        connected.into(),
                         item["description"].as_str().unwrap_or("-").to_string(),
                     ]
                 })
                 .collect();
-            output::print_table(&["Name", "Display Name", "Description"], &rows);
+            output::print_table(
+                &[
+                    "Name",
+                    "Display Name",
+                    "Auth Type",
+                    "Connected",
+                    "Description",
+                ],
+                &rows,
+            );
         }
     }
     Ok(())


### PR DESCRIPTION
The `gestalt integrations list` table previously showed only the name,
display name, and description for each integration. The API already
returns `auth_type` and `connected` fields, so this surfaces them as
new columns in the table output, making it easy to see which
integrations are connected at a glance. Also bumps `reqwest` from
0.12 to 0.13.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>