### PR TITLE
Add subprocess provider plugins

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -17,6 +17,7 @@ import (
 	graphqlupstream "github.com/valon-technologies/gestalt/internal/graphql"
 	"github.com/valon-technologies/gestalt/internal/mcpupstream"
 	"github.com/valon-technologies/gestalt/internal/openapi"
+	"github.com/valon-technologies/gestalt/internal/pluginproc"
 	"github.com/valon-technologies/gestalt/internal/provider"
 	"github.com/valon-technologies/gestalt/internal/registry"
 	"github.com/valon-technologies/gestalt/plugins/auth/google"
@@ -195,6 +196,13 @@ func closeProviders(providers *registry.PluginMap[core.Provider]) {
 
 func defaultProviderFactory(providerDirs []string) bootstrap.ProviderFactory {
 	return func(ctx context.Context, name string, intg config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
+		if intg.Plugin != nil {
+			if len(intg.Upstreams) > 0 {
+				return nil, fmt.Errorf("integration %s: plugin and upstreams are mutually exclusive", name)
+			}
+			return pluginproc.New(ctx, name, intg, *intg.Plugin)
+		}
+
 		var apiProv core.Provider
 		var mcpUp *mcpupstream.Upstream
 		var mcpFromAPI bool

--- a/cmd/gestaltd/pluginproc_test.go
+++ b/cmd/gestaltd/pluginproc_test.go
@@ -1,0 +1,497 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	coretesting "github.com/valon-technologies/gestalt/core/testing"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/invocation"
+	"github.com/valon-technologies/gestalt/internal/pluginproc"
+	"github.com/valon-technologies/gestalt/internal/principal"
+	secretsenv "github.com/valon-technologies/gestalt/plugins/secrets/env"
+	"gopkg.in/yaml.v3"
+)
+
+const helperEnv = "GESTALT_PLUGIN_HELPER"
+
+func TestPluginSubprocessProviderExecuteAndFilter(t *testing.T) {
+	binary := os.Args[0]
+	t.Setenv("GESTALT_TEST_BINARY", binary)
+
+	cfg := mustWritePluginConfig(t, `
+auth:
+  provider: stub-auth
+datastore:
+  provider: stub-ds
+server:
+  dev_mode: true
+integrations:
+  demo:
+    plugin:
+      command:
+        - ${GESTALT_TEST_BINARY}
+        - -test.run=TestPluginHelperProcess$
+      env:
+        `+helperEnv+`: "1"
+        GESTALT_PLUGIN_MODE: "basic"
+      config:
+        label: demo-config
+      allowed_operations:
+        echo: Echo the payload
+      startup_timeout: 5s
+      request_timeout: 5s
+`)
+
+	result := mustBootstrapPluginEnv(t, cfg)
+
+	prov, err := result.Providers.Get("demo")
+	if err != nil {
+		t.Fatalf("Providers.Get: %v", err)
+	}
+	if got := prov.ListOperations(); len(got) != 1 || got[0].Name != "echo" {
+		t.Fatalf("ListOperations: got %+v, want [echo]", got)
+	}
+	if _, ok := prov.(core.ManualProvider); ok {
+		t.Fatal("expected basic plugin to not advertise manual auth")
+	}
+
+	p := &principal.Principal{UserID: "user-123"}
+	out, err := result.Invoker.Invoke(context.Background(), p, "demo", "echo", map[string]any{"hello": "world"})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if out.Status != 200 {
+		t.Fatalf("Invoke status: got %d, want 200", out.Status)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal([]byte(out.Body), &body); err != nil {
+		t.Fatalf("unmarshal response body: %v", err)
+	}
+	if body["token"] != "stored-access-token" {
+		t.Fatalf("response token: got %v, want stored-access-token", body["token"])
+	}
+	if body["operation"] != "echo" {
+		t.Fatalf("response operation: got %v, want echo", body["operation"])
+	}
+
+	params, ok := body["params"].(map[string]any)
+	if !ok || params["hello"] != "world" {
+		t.Fatalf("response params: got %v, want hello=world", body["params"])
+	}
+
+	pluginCfg, ok := body["plugin_config"].(map[string]any)
+	if !ok || pluginCfg["label"] != "demo-config" {
+		t.Fatalf("response plugin_config: got %v, want label=demo-config", body["plugin_config"])
+	}
+
+	if _, err := result.Invoker.Invoke(context.Background(), p, "demo", "hidden", map[string]any{}); !errors.Is(err, invocation.ErrOperationNotFound) {
+		t.Fatalf("Invoke(hidden): got %v, want ErrOperationNotFound", err)
+	}
+}
+
+func TestPluginSubprocessProviderManualAuth(t *testing.T) {
+	binary := os.Args[0]
+	t.Setenv("GESTALT_TEST_BINARY", binary)
+
+	cfg := mustWritePluginConfig(t, `
+auth:
+  provider: stub-auth
+datastore:
+  provider: stub-ds
+server:
+  dev_mode: true
+integrations:
+  manual-demo:
+    plugin:
+      command:
+        - ${GESTALT_TEST_BINARY}
+        - -test.run=TestPluginHelperProcess$
+      env:
+        `+helperEnv+`: "1"
+        GESTALT_PLUGIN_MODE: "manual"
+      startup_timeout: 5s
+      request_timeout: 5s
+`)
+
+	result := mustBootstrapPluginEnv(t, cfg)
+
+	prov, err := result.Providers.Get("manual-demo")
+	if err != nil {
+		t.Fatalf("Providers.Get: %v", err)
+	}
+	mp, ok := prov.(core.ManualProvider)
+	if !ok {
+		t.Fatal("expected manual plugin to advertise ManualProvider")
+	}
+	if !mp.SupportsManualAuth() {
+		t.Fatal("expected SupportsManualAuth to be true")
+	}
+	if got := prov.ListOperations(); len(got) != 1 || got[0].Name != "ping" {
+		t.Fatalf("ListOperations: got %+v, want [ping]", got)
+	}
+}
+
+func TestPluginSubprocessProviderOAuth(t *testing.T) {
+	binary := os.Args[0]
+	t.Setenv("GESTALT_TEST_BINARY", binary)
+
+	cfg := mustWritePluginConfig(t, `
+auth:
+  provider: stub-auth
+datastore:
+  provider: stub-ds
+server:
+  dev_mode: true
+integrations:
+  oauth-demo:
+    plugin:
+      command:
+        - ${GESTALT_TEST_BINARY}
+        - -test.run=TestPluginHelperProcess$
+      env:
+        `+helperEnv+`: "1"
+        GESTALT_PLUGIN_MODE: "oauth"
+      startup_timeout: 5s
+      request_timeout: 5s
+`)
+
+	result := mustBootstrapPluginEnv(t, cfg)
+
+	prov, err := result.Providers.Get("oauth-demo")
+	if err != nil {
+		t.Fatalf("Providers.Get: %v", err)
+	}
+	oauthProv, ok := prov.(core.OAuthProvider)
+	if !ok {
+		t.Fatal("expected oauth plugin to advertise OAuthProvider")
+	}
+
+	authURL := oauthProv.AuthorizationURL("state-123", []string{"scope:a"})
+	if authURL != "https://example.com/oauth/start" {
+		t.Fatalf("AuthorizationURL: got %q, want https://example.com/oauth/start", authURL)
+	}
+
+	type oauthStarter interface {
+		StartOAuth(state string, scopes []string) (authURL string, verifier string, err error)
+	}
+	starter, ok := prov.(oauthStarter)
+	if !ok {
+		t.Fatal("expected oauth plugin to expose StartOAuth")
+	}
+	authURL, verifier, startErr := starter.StartOAuth("state-123", []string{"scope:a"})
+	if startErr != nil {
+		t.Fatalf("StartOAuth: %v", startErr)
+	}
+	if authURL != "https://example.com/oauth/start" || verifier != "verifier-123" {
+		t.Fatalf("StartOAuth: got (%q, %q), want (https://example.com/oauth/start, verifier-123)", authURL, verifier)
+	}
+
+	type oauthVerifierExchanger interface {
+		ExchangeCodeWithVerifier(ctx context.Context, code, verifier string) (*core.TokenResponse, error)
+	}
+	exchanger, ok := prov.(oauthVerifierExchanger)
+	if !ok {
+		t.Fatal("expected oauth plugin to expose ExchangeCodeWithVerifier")
+	}
+	tokenResp, err := exchanger.ExchangeCodeWithVerifier(context.Background(), "code-123", "verifier-123")
+	if err != nil {
+		t.Fatalf("ExchangeCodeWithVerifier: %v", err)
+	}
+	if tokenResp.AccessToken != "oauth-access-token" || tokenResp.RefreshToken != "oauth-refresh-token" {
+		t.Fatalf("ExchangeCodeWithVerifier: got %+v", tokenResp)
+	}
+
+	refreshResp, err := oauthProv.RefreshToken(context.Background(), "oauth-refresh-token")
+	if err != nil {
+		t.Fatalf("RefreshToken: %v", err)
+	}
+	if refreshResp.AccessToken != "oauth-access-token-refreshed" {
+		t.Fatalf("RefreshToken: got %+v, want refreshed access token", refreshResp)
+	}
+}
+
+func TestPluginHelperProcess(t *testing.T) { //nolint:paralleltest // subprocess helper, not a real test
+	if os.Getenv(helperEnv) != "1" {
+		return
+	}
+
+	state := &helperState{}
+	codec := newHelperCodec(os.Stdin, os.Stdout)
+
+	for {
+		req, err := codec.read()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				os.Exit(0)
+			}
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		switch req.Method {
+		case "initialize":
+			var params pluginproc.InitializeParams
+			if err := json.Unmarshal(req.Params, &params); err != nil {
+				writeHelperError(codec, req.ID, -32700, err.Error())
+				continue
+			}
+			if params.Integration.Config != nil {
+				state.pluginConfig = params.Integration.Config
+			}
+			writeHelperResult(codec, req.ID, pluginproc.InitializeResult{
+				ProtocolVersion: pluginproc.ProtocolVersion,
+				PluginInfo: pluginproc.PluginInfo{
+					Name:    "test-plugin",
+					Version: "1.0.0",
+				},
+				Provider: state.manifest(),
+				Capabilities: pluginproc.PluginCapabilities{
+					ManualAuth: state.mode() == "manual",
+					OAuth:      state.mode() == "oauth",
+				},
+			})
+		case "provider.execute":
+			var params pluginproc.ExecuteParams
+			if err := json.Unmarshal(req.Params, &params); err != nil {
+				writeHelperError(codec, req.ID, -32700, err.Error())
+				continue
+			}
+			payload := map[string]any{
+				"operation":     params.Operation,
+				"token":         params.Token,
+				"params":        params.Params,
+				"plugin_config": state.pluginConfig,
+			}
+			body, err := json.Marshal(payload)
+			if err != nil {
+				writeHelperError(codec, req.ID, -32603, err.Error())
+				continue
+			}
+			writeHelperResult(codec, req.ID, core.OperationResult{
+				Status: 200,
+				Body:   string(body),
+			})
+		case "auth.start":
+			writeHelperResult(codec, req.ID, pluginproc.AuthStartResult{
+				AuthURL:  "https://example.com/oauth/start",
+				Verifier: "verifier-123",
+			})
+		case "auth.exchange_code":
+			writeHelperResult(codec, req.ID, core.TokenResponse{
+				AccessToken:  "oauth-access-token",
+				RefreshToken: "oauth-refresh-token",
+				ExpiresIn:    3600,
+				TokenType:    "Bearer",
+			})
+		case "auth.refresh_token":
+			writeHelperResult(codec, req.ID, core.TokenResponse{
+				AccessToken:  "oauth-access-token-refreshed",
+				RefreshToken: "oauth-refresh-token",
+				ExpiresIn:    3600,
+				TokenType:    "Bearer",
+			})
+		case "shutdown":
+			writeHelperResult(codec, req.ID, map[string]any{"ok": true})
+			os.Exit(0)
+		default:
+			writeHelperError(codec, req.ID, -32601, "unknown method")
+		}
+	}
+}
+
+func mustBootstrapPluginEnv(t *testing.T, cfgPath string) *bootstrap.Result {
+	t.Helper()
+
+	factories := bootstrap.NewFactoryRegistry()
+	factories.Auth["stub-auth"] = func(node yaml.Node, _ bootstrap.Deps) (core.AuthProvider, error) {
+		return &coretesting.StubAuthProvider{N: "stub-auth"}, nil
+	}
+	factories.Secrets["env"] = secretsenv.Factory
+	factories.Datastores["stub-ds"] = func(node yaml.Node, _ bootstrap.Deps) (core.Datastore, error) {
+		return &coretesting.StubDatastore{
+			TokenFn: func(ctx context.Context, userID, integration, instance string) (*core.IntegrationToken, error) {
+				if userID != "user-123" {
+					t.Fatalf("TokenFn userID: got %q, want user-123", userID)
+				}
+				if integration != "demo" && integration != "manual-demo" {
+					t.Fatalf("TokenFn integration: got %q", integration)
+				}
+				if instance != "default" {
+					t.Fatalf("TokenFn instance: got %q, want default", instance)
+				}
+				return &core.IntegrationToken{AccessToken: "stored-access-token"}, nil
+			},
+		}, nil
+	}
+	factories.DefaultProvider = defaultProviderFactory(nil)
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("bootstrap.Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+	return result
+}
+
+func mustWritePluginConfig(t *testing.T, content string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(path, []byte(strings.TrimSpace(content)+"\n"), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+type helperState struct {
+	pluginMode   string
+	pluginConfig any
+}
+
+func (s *helperState) mode() string {
+	if s.pluginMode != "" {
+		return s.pluginMode
+	}
+	s.pluginMode = os.Getenv("GESTALT_PLUGIN_MODE")
+	return s.pluginMode
+}
+
+func (s *helperState) manifest() pluginproc.ProviderManifest {
+	switch s.mode() {
+	case "manual":
+		return pluginproc.ProviderManifest{
+			DisplayName:    "Manual Demo",
+			Description:    "Subprocess plugin with manual auth",
+			ConnectionMode: string(core.ConnectionModeUser),
+			Operations: []core.Operation{
+				{Name: "ping", Description: "Ping the plugin", Method: "POST"},
+			},
+			Auth: &pluginproc.ProviderAuthConfig{Type: pluginproc.AuthTypeManual},
+		}
+	case "oauth":
+		return pluginproc.ProviderManifest{
+			DisplayName:    "OAuth Demo",
+			Description:    "Subprocess plugin with oauth",
+			ConnectionMode: string(core.ConnectionModeUser),
+			Operations: []core.Operation{
+				{Name: "ping", Description: "Ping the plugin", Method: "POST"},
+			},
+			Auth: &pluginproc.ProviderAuthConfig{Type: pluginproc.AuthTypeOAuth2},
+		}
+	default:
+		return pluginproc.ProviderManifest{
+			DisplayName:    "Demo Plugin",
+			Description:    "Subprocess plugin",
+			ConnectionMode: string(core.ConnectionModeUser),
+			Operations: []core.Operation{
+				{Name: "echo", Description: "Echo the payload", Method: "POST"},
+				{Name: "hidden", Description: "Should be filtered", Method: "POST"},
+			},
+		}
+	}
+}
+
+type helperCodec struct {
+	r *bufio.Reader
+	w *bufio.Writer
+}
+
+type helperMessage struct {
+	ID     *int64          `json:"id,omitempty"`
+	Method string          `json:"method,omitempty"`
+	Params json.RawMessage `json:"params,omitempty"`
+}
+
+func newHelperCodec(r io.Reader, w io.Writer) *helperCodec {
+	return &helperCodec{r: bufio.NewReader(r), w: bufio.NewWriter(w)}
+}
+
+func (c *helperCodec) read() (*helperMessage, error) {
+	length := -1
+	for {
+		line, err := c.r.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break
+		}
+		if strings.HasPrefix(strings.ToLower(line), "content-length:") {
+			if _, err := fmt.Sscanf(line, "Content-Length: %d", &length); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if length < 0 {
+		return nil, fmt.Errorf("missing Content-Length")
+	}
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(c.r, payload); err != nil {
+		return nil, err
+	}
+	var msg helperMessage
+	if err := json.Unmarshal(payload, &msg); err != nil {
+		return nil, err
+	}
+	return &msg, nil
+}
+
+func (c *helperCodec) write(id *int64, result any, rpcErr *helperRPCError) error {
+	msg := map[string]any{"jsonrpc": "2.0"}
+	if id != nil {
+		msg["id"] = *id
+	}
+	if rpcErr != nil {
+		msg["error"] = rpcErr
+	} else {
+		msg["result"] = result
+	}
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(c.w, "Content-Length: %d\r\n\r\n", len(payload)); err != nil {
+		return err
+	}
+	if _, err := c.w.Write(payload); err != nil {
+		return err
+	}
+	return c.w.Flush()
+}
+
+type helperRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func writeHelperResult(c *helperCodec, id *int64, result any) {
+	if err := c.write(id, result, nil); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func writeHelperError(c *helperCodec, id *int64, code int, message string) {
+	if err := c.write(id, nil, &helperRPCError{Code: code, Message: message}); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/core/integration/base.go
+++ b/core/integration/base.go
@@ -34,20 +34,13 @@ type UpstreamAuth struct {
 	Handler *oauth.UpstreamHandler
 }
 
-type oauthStarter interface {
-	StartOAuth(state string, scopes []string) (authURL string, verifier string)
-}
-
-type oauthVerifierExchanger interface {
-	ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
-}
-
 func (u UpstreamAuth) AuthorizationURL(state string, scopes []string) string {
 	return u.Handler.AuthorizationURL(state, scopes)
 }
 
-func (u UpstreamAuth) StartOAuth(state string, scopes []string) (string, string) {
-	return u.Handler.AuthorizationURLWithPKCE(state, scopes)
+func (u UpstreamAuth) StartOAuth(state string, scopes []string) (string, string, error) {
+	url, verifier := u.Handler.AuthorizationURLWithPKCE(state, scopes)
+	return url, verifier, nil
 }
 
 func (u UpstreamAuth) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
@@ -171,11 +164,14 @@ func (b *Base) AuthorizationURL(state string, scopes []string) string {
 	return b.Auth.AuthorizationURL(state, scopes)
 }
 
-func (b *Base) StartOAuth(state string, scopes []string) (string, string) {
-	if starter, ok := b.Auth.(oauthStarter); ok {
-		return starter.StartOAuth(state, scopes)
+func (b *Base) StartOAuth(state string, scopes []string) (string, string, error) {
+	type starter interface {
+		StartOAuth(state string, scopes []string) (string, string, error)
 	}
-	return b.Auth.AuthorizationURL(state, scopes), ""
+	if s, ok := b.Auth.(starter); ok {
+		return s.StartOAuth(state, scopes)
+	}
+	return b.Auth.AuthorizationURL(state, scopes), "", nil
 }
 
 func (b *Base) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
@@ -183,8 +179,11 @@ func (b *Base) ExchangeCode(ctx context.Context, code string) (*core.TokenRespon
 }
 
 func (b *Base) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error) {
-	if exchanger, ok := b.Auth.(oauthVerifierExchanger); ok {
-		return exchanger.ExchangeCodeWithVerifier(ctx, code, verifier, extraOpts...)
+	type exchanger interface {
+		ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
+	}
+	if e, ok := b.Auth.(exchanger); ok {
+		return e.ExchangeCodeWithVerifier(ctx, code, verifier, extraOpts...)
 	}
 	return b.Auth.ExchangeCode(ctx, code)
 }

--- a/core/provider.go
+++ b/core/provider.go
@@ -31,6 +31,14 @@ type OAuthProvider interface {
 	RefreshToken(ctx context.Context, refreshToken string) (*TokenResponse, error)
 }
 
+// OAuthStarterProvider extends OAuthProvider with error-returning
+// OAuth initiation. Wrappers must forward this interface to avoid
+// silently dropping verifier and error information.
+type OAuthStarterProvider interface {
+	OAuthProvider
+	StartOAuth(state string, scopes []string) (authURL string, verifier string, err error)
+}
+
 type ManualProvider interface {
 	Provider
 	SupportsManualAuth() bool

--- a/docs/pages/concepts/_meta.ts
+++ b/docs/pages/concepts/_meta.ts
@@ -2,6 +2,7 @@ export default {
   "platform-model": "Platform Model",
   configuration: "Configuration",
   integrations: "Integrations",
+  "plugin-protocol": "Subprocess Plugin Protocol",
   "authentication-and-tokens": "Authentication and Tokens",
   "mcp-binding": "MCP Binding",
 };

--- a/docs/pages/concepts/configuration.mdx
+++ b/docs/pages/concepts/configuration.mdx
@@ -66,6 +66,16 @@ integrations:
       conversations_list: ""
       chat_postMessage: Send a message to a Slack channel
 
+  my-plugin:
+    plugin:
+      command:
+        - node
+        - ./plugins/my-plugin/dist/index.js
+      config:
+        project_key: ENG
+      allowed_operations:
+        - enrich_loan
+
 mcp:
   enabled: true
   providers:
@@ -84,6 +94,10 @@ server:
 **base_url for OAuth**: The server's `base_url` is used to construct OAuth redirect URIs. If it is wrong or missing, OAuth flows will fail with a redirect mismatch.
 
 **provider_dirs**: Directories listed here are scanned at startup for provider YAML files. Each file becomes a registered provider whose operations are available to integrations.
+
+**integrations**: Each integration can now be declared with `openapi`, `provider`, or `plugin`. The `plugin` form launches a managed subprocess and exposes its provider surface through Gestalt.
+
+**plugin integrations**: The `plugin` block starts a managed child process and initializes it over stdio using the subprocess plugin protocol. The host still exposes the resulting provider through the normal API surfaces.
 
 **allowed_operations**: A positive allow-list. Only operations listed here are callable. An empty map means no operations are exposed. The value is a human-readable description; an empty string means no custom description.
 

--- a/docs/pages/concepts/integrations.mdx
+++ b/docs/pages/concepts/integrations.mdx
@@ -1,133 +1,37 @@
 # Integrations
 
-Integrations are the unit of API exposure in Gestalt. Each integration declares one or more **upstreams** — the external services it connects to — along with auth settings and optional hooks.
+Integrations are the unit of API exposure in Gestalt. Each integration declares where its definition comes from, how it authenticates, and which operations callers can invoke.
 
-## Upstreams
+## Four ways to define an integration
 
-Every integration has an `upstreams` list. Each entry specifies a `type` and a source:
-
-| Upstream type | What it does |
-|---|---|
-| `rest` | Loads operations from an OpenAPI spec (via `url`), a provider YAML file (via `provider`), or a directory scan (via `provider_dirs`). |
-| `graphql` | Introspects a GraphQL endpoint at startup and generates operations from queries and mutations. |
-| `mcp` | Connects to an upstream MCP server and imports its tools as operations. |
-
-An integration can combine upstream types. For example, a REST upstream and an MCP upstream together create a **composite integration** where HTTP operations are available over the REST API and MCP tools are proxied directly to the upstream MCP server.
-
-## REST upstreams
-
-A REST upstream resolves its operations from one of three sources:
-
-| Source | Upstream field | When to use |
+| Source | Config field | When to use |
 |---|---|---|
-| OpenAPI spec | `url` pointing to a spec | Public or local OpenAPI document exists. Operations generated automatically. |
-| Provider file | `provider` pointing to a YAML file | No spec exists or the spec is too noisy. Declare operations manually. |
-| Provider directory | Neither `url` nor `provider` | Gestalt searches `provider_dirs` for a matching YAML file by integration name. |
-
-```yaml
-integrations:
-  slack:
-    upstreams:
-      - type: rest
-        url: https://raw.githubusercontent.com/.../slack_web_openapi_v2.json
-        allowed_operations:
-          conversations_list: List channels
-          chat_postMessage: Send a message
-    client_id: ${SLACK_CLIENT_ID}
-    client_secret: ${SLACK_CLIENT_SECRET}
-```
-
-## GraphQL upstreams
-
-A GraphQL upstream introspects the endpoint at startup and generates one operation per query and mutation field.
-
-```yaml
-integrations:
-  my-graphql-api:
-    upstreams:
-      - type: graphql
-        url: https://api.example.com/graphql
-        allowed_operations:
-          - searchUsers
-          - createProject
-    client_id: ${API_CLIENT_ID}
-    client_secret: ${API_CLIENT_SECRET}
-    auth:
-      authorization_url: https://example.com/oauth/authorize
-      token_url: https://example.com/oauth/token
-```
-
-Operation arguments are converted to JSON Schema inputs so MCP clients get type information for parameters. Scalar and enum types map to their JSON equivalents; complex input types map to `object`.
-
-## MCP upstreams
-
-An MCP upstream connects to a remote MCP server via Streamable HTTP, lists its tools, and imports them as Gestalt operations. These operations can only be invoked through the MCP binding — calling them over the HTTP API returns an error.
-
-```yaml
-integrations:
-  external-tools:
-    upstreams:
-      - type: mcp
-        url: https://mcp.example.com/sse
-    connection_mode: user
-```
-
-Tool annotations (read-only, destructive, idempotent) are preserved from the upstream server.
-
-## Mixed integrations
-
-An integration can combine a REST or GraphQL upstream with an MCP upstream. This creates a composite provider:
-
-```yaml
-integrations:
-  slack:
-    upstreams:
-      - type: rest
-        url: https://raw.githubusercontent.com/.../slack_web_openapi_v2.json
-        mcp: true
-        allowed_operations:
-          conversations_list: List channels
-          chat_postMessage: Send a message
-      - type: mcp
-        url: https://mcp.slack.com/sse
-    client_id: ${SLACK_CLIENT_ID}
-    client_secret: ${SLACK_CLIENT_SECRET}
-```
-
-The `mcp: true` flag on the REST upstream means its HTTP operations are also exposed as MCP tools alongside the tools from the MCP upstream.
-
-## allowed_operations
-
-The `allowed_operations` field on an upstream controls which operations are exposed. It accepts two formats:
-
-**As a list** (names only, descriptions from the upstream source):
-
-```yaml
-allowed_operations:
-  - conversations_list
-  - chat_postMessage
-```
-
-**As a map** (names to description overrides):
-
-```yaml
-allowed_operations:
-  conversations_list: List channels the user has access to
-  chat_postMessage: Send a message to a channel
-```
-
-Omit `allowed_operations` entirely to allow all operations. An empty value is invalid — if you set the field, it must contain at least one entry.
+| OpenAPI spec | `openapi` | Point at a URL or local file. Operations, parameters, and descriptions are generated automatically. |
+| Provider file | `provider` | Write a standalone YAML file. Use when no spec exists or the spec is too noisy. |
+| Provider directory | `provider_dirs` | Scan a directory for multiple provider YAML files. Each file becomes a separate provider. |
+| Managed subprocess plugin | `plugin` | Launch a child process that speaks the Gestalt plugin protocol. Use when the provider is implemented in TypeScript, Python, or Rust and should still be invokable through Gestalt. |
 
 ## What an operation looks like
 
 | Field | Description |
 |---|---|
-| Name | Unique identifier. For OpenAPI sources, this is the `operationId`. For GraphQL, the query/mutation field name. For MCP, the tool name. |
-| Description | Human-readable summary from the spec, or overridden via `allowed_operations`. |
-| Method and path | HTTP verb and URL path template (REST only). |
-| Parameters | Query, path, header, and body fields. |
+| Name | Unique identifier. For OpenAPI sources, this is the `operationId` from the spec. |
+| Description | Human-readable summary from the spec or `allowed_operations` config. |
+| Method and path | HTTP verb and URL path template for the upstream call. |
+| Parameters | Query parameters, path parameters, headers, and body fields. |
 | Input schema | JSON Schema for parameters, passed to MCP clients for type information. |
-| Annotations | Automatic hints: GET/HEAD are read-only, PUT is idempotent, DELETE is destructive. MCP upstreams preserve the upstream server's annotations. |
+| Annotations | Automatic hints: GET/HEAD are read-only, PUT is idempotent, DELETE is destructive. |
+
+## How OpenAPI loading works
+
+When an integration includes an `openapi` field, Gestalt parses the spec at startup and extracts:
+
+- The display name from `info.title`.
+- The first server URL as the base URL.
+- OAuth authorization and token URLs from security scheme definitions.
+- Operations by iterating every path and method, keyed by `operationId`.
+
+Operations without an `operationId` are skipped. Security schemes inform the default auth configuration but can be overridden in the integration config.
 
 ## Manual auth versus OAuth
 
@@ -166,6 +70,23 @@ Hooks are registered by name in Go code and referenced by that name in config.
 | `slack_ok` | Slack | Checks `"ok": true` in response body. Used as both `response_check` and `response_hook`. |
 | `datadog_keys` | Datadog | Parses API and application keys from stored credentials, injects as `DD-API-KEY` and `DD-APPLICATION-KEY` headers. |
 | `hex_response` | Hex | Validates Hex-specific response format. |
+
+## Additional integration config fields
+
+| Field | Purpose |
+|---|---|
+| `icon_svg` | Inline SVG icon displayed in the web UI. |
+| `icon_file` | Load an SVG icon from a file path (alternative to inline `icon_svg`). |
+| `token_prefix` | Prefix for the Authorization header value (for example, `Bot` for Discord). |
+| `auth_style` | How the token is sent: `bearer`, `raw`, or `none`. |
+| `headers` | Default headers sent with every upstream request. |
+| `error_message_path` | JSONPath expression to extract error messages from upstream response bodies. |
+
+## Managed subprocess plugins
+
+Subprocess plugins are still integrations, not a separate runtime surface. Gestalt starts the child process from `plugin.command`, initializes it over stdio, and exposes the returned provider through the normal invocation path.
+
+This is the right shape for providers written in TypeScript, Python, or Rust when you want Gestalt to manage lifecycle but do not want to write Go code.
 
 ## Restrictions
 

--- a/docs/pages/concepts/plugin-protocol.mdx
+++ b/docs/pages/concepts/plugin-protocol.mdx
@@ -1,0 +1,124 @@
+# Subprocess Plugin Protocol
+
+Gestalt can load a provider from a managed child process instead of an in-process Go implementation. The host still treats the plugin as a normal provider, so the rest of the system can invoke it through the same REST and MCP paths.
+
+## Model
+
+The host starts the plugin command from config, performs a versioned initialization handshake, and then sends provider requests over stdio. The plugin writes protocol messages to `stdout` and logs to `stderr`.
+
+The protocol is intentionally small and language-agnostic. A plugin can be implemented in TypeScript, Python, or Rust without depending on Go internals.
+
+## Transport
+
+The wire format is JSON-RPC 2.0 with `Content-Length` framing, matching the common editor-plugin pattern used by systems like LSP.
+
+Each message is a framed JSON object. The plugin must not mix log output with protocol output on `stdout`.
+
+```text
+Content-Length: 123\r\n
+\r\n
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{...}}
+```
+
+## Lifecycle
+
+1. Gestalt launches the configured command.
+2. Gestalt sends `initialize`.
+3. The plugin returns its provider metadata, optional catalog metadata, and supported capabilities.
+4. Gestalt routes normal provider calls through `provider.execute`.
+5. Gestalt shuts the plugin down when the host stops or the integration is unloaded.
+
+If the child exits unexpectedly, the host can surface that as a provider failure. The protocol itself should stay focused on request/response and initialization.
+
+## Required methods
+
+The base contract is provider-oriented:
+
+- `initialize`
+- `provider.execute`
+
+Optional methods can be exposed when the plugin supports them:
+
+- `auth.start`
+- `auth.exchange_code`
+- `auth.refresh_token`
+- `shutdown`
+- `$/cancelRequest`
+
+## Payload shape
+
+Initialization returns the metadata Gestalt needs to expose the provider:
+
+```json
+{
+  "protocolVersion": "gestalt-plugin/1",
+  "pluginInfo": { "name": "my-plugin", "version": "0.1.0" },
+  "provider": {
+    "displayName": "My Plugin",
+    "description": "Custom loan enrichment",
+    "connectionMode": "user",
+    "operations": [
+      {
+        "name": "enrich_loan",
+        "description": "Fetch enrichment data",
+        "method": "POST",
+        "parameters": [
+          { "name": "loan_id", "type": "string", "required": true }
+        ]
+      }
+    ],
+    "catalog": {
+      "name": "my-plugin",
+      "operations": [
+        {
+          "id": "enrich_loan",
+          "title": "Fetch enrichment data",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "loan_id": { "type": "string" }
+            },
+            "required": ["loan_id"]
+          }
+        }
+      ]
+    },
+    "auth": {
+      "type": "manual"
+    }
+  },
+  "capabilities": {
+    "catalog": true,
+    "oauth": false,
+    "manualAuth": true,
+    "cancellation": true
+  }
+}
+```
+
+Catalog metadata is returned inline during `initialize`. There is no separate `provider.catalog` request in the current implementation.
+
+Execution uses the same operation and parameter model as `core.Provider`:
+
+```json
+{
+  "operation": "enrich_loan",
+  "params": { "loan_id": "123" },
+  "token": "opaque-access-token"
+}
+```
+
+The response is a simple HTTP-shaped result:
+
+```json
+{
+  "status": 200,
+  "body": "{\"ok\":true}"
+}
+```
+
+When the host-side request context is canceled, Gestalt may also send `$/cancelRequest` with the original JSON-RPC request ID. Plugins can ignore it if their work is not cancelable, but SDKs should expose it where the target language supports cancellation.
+
+## Configuration expectations
+
+Plugin authors declare the command and runtime settings in integration config. The plugin process should be self-contained, should not assume it can read Gestalt internals directly, and should use the SDK for the framing and message loop.

--- a/docs/pages/contributing.mdx
+++ b/docs/pages/contributing.mdx
@@ -5,10 +5,10 @@
 | Directory | Purpose |
 |---|---|
 | `cmd/gestaltd` | Main Go binary. Registers all plugins and starts the server. |
-| `core` | Public interfaces: `AuthProvider`, `Datastore`, `SecretManager`, `Provider`, `OAuthProvider`, `ManualProvider`, `CatalogProvider`, `Runtime`, `Binding`. See `core/auth.go`, `core/datastore.go`, `core/secrets.go`, `core/provider.go`, `core/runtime.go`, `core/binding.go`. |
+| `core` | Public interfaces: auth providers, datastores, secret managers, providers, runtimes, bindings, hooks. |
 | `internal` | Runtime packages: config loading, HTTP routing, middleware, invocation, token management, bootstrap. |
-| `plugins` | Implementations of core interfaces: auth, datastores, secrets, integrations, bindings, runtimes. |
-| `docs` | Nextra documentation site. |
+| `plugins` | Built-in Go implementations of core interfaces: auth, datastores, secrets, integrations, bindings, runtimes. |
+| `docs/pages/concepts/plugin-protocol.mdx` | Overview of the managed subprocess plugin protocol for TypeScript, Python, and Rust providers. |
 | `client/cli` | Rust CLI source. Produces the `gestalt` binary. |
 | `web` | Next.js web UI. |
 | `deploy` | Helm chart, Dockerfiles, and CI workflows. |
@@ -19,6 +19,8 @@
 2. Expose a factory function that accepts the provider config and returns an initialized instance.
 3. Register the factory in `cmd/gestaltd/factories.go` so the runtime resolves it by name from config.
 4. Add tests that exercise the plugin through the same interface the runtime uses.
+
+For non-Go providers, implement the subprocess plugin protocol described in `docs/pages/concepts/plugin-protocol.mdx` and expose a thin SDK wrapper in your target language. The host should still see a normal provider after initialization.
 
 ## Add integration-specific behavior
 
@@ -46,7 +48,3 @@ cd web
 npm run check
 npm run build
 ```
-
-## Pre-push hook
-
-The repository includes a managed pre-push hook at `.githooks/pre-push`. Git is configured to use this directory via `core.hooksPath`. The hook runs automatically when you push — do not bypass it with `--no-verify`.

--- a/docs/pages/reference/built-in-plugins.mdx
+++ b/docs/pages/reference/built-in-plugins.mdx
@@ -1,6 +1,6 @@
 # Built-in Plugins
 
-The Gestalt binary registers all plugins at startup. Bootstrap builds one shared invoker and passes scoped deps to runtimes and bindings.
+The Gestalt binary registers its built-in Go plugins at startup. It can also load provider implementations from a managed subprocess, so not every provider has to live in the main binary.
 
 ## Auth providers
 
@@ -57,6 +57,10 @@ All SQL-based datastores (postgres, mysql, oracle, sqlserver) share a common imp
 | Name | Notes |
 |---|---|
 | `echo` | Dev-only provider that echoes input parameters as JSON. Single `echo` operation. Enabled only when `dev_mode: true`. |
+
+## External providers
+
+Managed subprocess providers are not listed here because they are not compiled into the binary. They are declared in integration config and loaded through the subprocess plugin protocol at startup.
 
 ## What is not pluginized
 

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -8,12 +8,12 @@
 | `datastore` | Where users, API tokens, and integration tokens are stored. |
 | `secrets` | How `secret://` references are resolved. |
 | `auth_profiles` | Reusable OAuth settings shared across integrations. |
-| `integrations` | Map of integration name to definition. |
+| `integrations` | Map of integration name to definition. Each integration can be backed by `openapi`, `provider`, or `plugin`. |
 | `runtimes` | Background processes that boot alongside the server with scoped provider access. |
-| `bindings` | Alternative request surfaces such as webhooks and gRPC. |
+| `bindings` | Alternative request surfaces such as webhooks. |
 | `provider_dirs` | Directories searched for provider YAML files at startup. |
 | `server` | Port, base URL, encryption key, and development mode. |
-| `mcp` | MCP endpoint settings: enabled flag, provider filter, tool name prefix. |
+| `mcp` | MCP endpoint settings: enabled flag, provider filter, tool name prefix. Integration-level `mcp.url` enables upstream MCP proxying. |
 
 ## Server block
 
@@ -88,65 +88,67 @@ secrets:
 
 ## Integration block
 
-Each integration is defined under `integrations.<name>` and contains one or more `upstreams` entries plus integration-level settings for auth, display, and hooks.
-
 | Field | Notes |
 |---|---|
-| `upstreams` | List of upstream definitions (see below). At least one is required. |
-| `display_name` | Human-readable label for the integration. |
-| `description` | Short description shown in the web UI and CLI. |
+| `openapi` | OpenAPI spec URL or local file path. |
+| `provider` | Path to a provider YAML file. |
+| `plugin` | Managed subprocess plugin configuration. Use this when the provider lives outside the Go binary. |
 | `auth_profile` | Name of a reusable auth profile to inherit from. |
 | `client_id`, `client_secret` | OAuth client credentials for the upstream integration. |
 | `redirect_url` | Override the integration callback URL. |
 | `base_url` | Override the base URL from the spec or provider file. |
 | `connection_mode` | `user` (default), `identity`, `either`, or `none`. See [Connection Modes](/concepts/platform-model#connection-modes). |
 | `auth` | Auth overrides (see below). |
-| `auth_header` | Custom header name for sending the token (instead of `Authorization`). |
-| `auth_mapping` | Map of header names to JSON fields, for structured token-to-headers mapping. |
 | `response_check` | Named hook to validate responses. |
 | `token_parser` | Named hook to transform stored tokens into auth headers. |
 | `request_mutator` | Named hook to rewrite outgoing requests. |
 | `token_prefix` | Prefix for the Authorization header value. |
-| `auth_style` | How the token is sent: `bearer` (default), `raw`, `basic`, or `none`. |
+| `auth_style` | How the token is sent: `bearer`, `raw`, or `none`. |
 | `headers` | Default headers sent with every upstream request. |
+| `auth_headers` | YAML map of declarative auth headers injected into upstream requests. |
+| `icon_svg` | SVG icon displayed in the web UI. |
 | `icon_file` | Path to an SVG file used as the integration icon. |
-| `error_message_path` | Dot-delimited path for extracting error messages from upstream JSON responses. |
+| `error_message_path` | JSONPath expression for extracting error messages from upstream responses. |
+| `allowed_operations` | Positive allow-list of operation names with optional description overrides. |
+| `mcp` | MCP proxying config. Subfield `url` sets the upstream MCP server URL for passthrough proxying. |
 
-### Upstreams
+## Plugin block
 
-Each upstream declares a type and source:
-
-| Field | Notes |
-|---|---|
-| `type` | `rest`, `graphql`, or `mcp`. |
-| `url` | For `rest`: OpenAPI spec URL. For `graphql`: the GraphQL endpoint (introspected at startup). For `mcp`: the upstream MCP server URL. |
-| `provider` | (`rest` only) Path to a provider YAML file. Used instead of `url`. |
-| `mcp` | (`rest` and `graphql` only) Boolean. When `true` and combined with a `type: mcp` upstream, this upstream's operations are also exposed as MCP tools. |
-| `allowed_operations` | Positive allow-list. Can be a YAML list (names only) or a map (names to description overrides). Omit to allow all operations. An empty value is invalid. |
-
-If a `rest` upstream has neither `url` nor `provider`, Gestalt falls back to searching `provider_dirs` for a matching YAML file.
-
-Example with multiple upstreams:
+Use `plugin` when the integration is implemented by a managed subprocess instead of OpenAPI or a provider YAML file.
 
 ```yaml
 integrations:
-  slack:
-    upstreams:
-      - type: rest
-        url: https://raw.githubusercontent.com/.../slack_web_openapi_v2.json
-        allowed_operations:
-          conversations_list: List channels
-          chat_postMessage: Send a message
-      - type: mcp
-        url: https://mcp.slack.com/sse
-    client_id: ${SLACK_CLIENT_ID}
-    client_secret: ${SLACK_CLIENT_SECRET}
-    auth_style: bearer
-    auth:
-      authorization_url: https://slack.com/oauth/v2/authorize
-      token_url: https://slack.com/api/oauth.v2.access
-      response_hook: slack_ok
+  my-plugin:
+    plugin:
+      command:
+        - node
+        - ./plugins/my-plugin/dist/index.js
+      cwd: ./plugins/my-plugin
+      env:
+        VENDOR_BASE_URL: https://vendor.example.com
+      config:
+        project_key: ENG
+      allowed_operations:
+        - enrich_loan
+        - lookup_borrower
+      startup_timeout: 10s
+      request_timeout: 60s
+    display_name: My Plugin
+    description: Custom loan enrichment
+    connection_mode: user
 ```
+
+| Field | Notes |
+|---|---|
+| `command` | Required. Command and arguments Gestalt uses to start the plugin process. |
+| `cwd` | Optional working directory for the child process. |
+| `env` | Optional environment variables for the child process. |
+| `config` | Optional plugin-specific config payload passed during initialization. |
+| `allowed_operations` | Optional allow-list that limits which plugin operations Gestalt exposes. |
+| `startup_timeout` | Optional timeout for process startup and `initialize`. Defaults to `10s`. |
+| `request_timeout` | Optional per-request timeout for `execute` and auth RPCs. Defaults to `60s`. |
+
+Plugins started this way still expose the normal provider surface, so Gestalt can invoke them through the same REST and MCP paths as built-in Go providers.
 
 ### Auth overrides
 
@@ -252,6 +254,8 @@ mcp:
 | `enabled` | `false` | Mount the MCP endpoint at `/mcp`. |
 | `providers` | all | Restrict which integrations are exposed to MCP clients. |
 | `tool_name_prefix` | `""` | String prepended to every MCP tool name. |
+
+When an integration defines `mcp.url`, Gestalt proxies MCP requests to that upstream server, enabling MCP-to-MCP passthrough without additional configuration in this block.
 
 ## Supported providers
 

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -17,6 +17,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+var yamlNodeType = reflect.TypeOf(yaml.Node{})
+
 type Deps struct {
 	EncryptionKey []byte
 	BaseURL       string
@@ -187,6 +189,11 @@ func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretMa
 		if err := resolveStringFields(&intg, resolve); err != nil {
 			return err
 		}
+		if intg.Plugin != nil {
+			if err := resolveYAMLNode(&intg.Plugin.Config, resolve); err != nil {
+				return err
+			}
+		}
 		cfg.Integrations[name] = intg
 	}
 	for name := range cfg.AuthProfiles {
@@ -244,8 +251,17 @@ func resolveStringFields(ptr any, resolve func(string) (string, error)) error {
 			}
 			field.SetString(resolved)
 		case reflect.Struct:
+			if field.Type() == yamlNodeType {
+				continue
+			}
 			if field.CanSet() {
 				if err := resolveStringFields(field.Addr().Interface(), resolve); err != nil {
+					return err
+				}
+			}
+		case reflect.Ptr:
+			if !field.IsNil() && field.Elem().Kind() == reflect.Struct {
+				if err := resolveStringFields(field.Interface(), resolve); err != nil {
 					return err
 				}
 			}

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -745,6 +745,90 @@ func TestBootstrapSecretResolution(t *testing.T) {
 			t.Errorf("Auth.TokenMetadata: got %v, want [resolved-meta]", receivedDef.Auth.TokenMetadata)
 		}
 	})
+
+	t.Run("resolves secret:// in plugin yaml.Node config", func(t *testing.T) {
+		t.Parallel()
+
+		var receivedDef config.IntegrationDef
+		factories := validFactories()
+		factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+			return &coretesting.StubSecretManager{
+				Secrets: map[string]string{"plugin-secret": "resolved-plugin-secret"},
+			}, nil
+		}
+		factories.Providers["alpha"] = func(_ context.Context, _ string, intg config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
+			receivedDef = intg
+			return &coretesting.StubIntegration{N: "alpha"}, nil
+		}
+
+		cfg := validConfig()
+		intg := cfg.Integrations["alpha"]
+		intg.Plugin = &config.PluginDef{
+			Command: []string{"python3", "plugin.py"},
+			Config: yaml.Node{
+				Kind: yaml.MappingNode,
+				Content: []*yaml.Node{
+					{Kind: yaml.ScalarNode, Value: "api_key", Tag: "!!str"},
+					{Kind: yaml.ScalarNode, Value: "secret://plugin-secret", Tag: "!!str"},
+				},
+			},
+		}
+		cfg.Integrations["alpha"] = intg
+
+		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
+			t.Fatalf("Bootstrap: %v", err)
+		}
+		<-result.ProvidersReady
+
+		if receivedDef.Plugin == nil {
+			t.Fatal("receivedDef.Plugin: got nil, want non-nil")
+		}
+		var decoded map[string]string
+		if err := receivedDef.Plugin.Config.Decode(&decoded); err != nil {
+			t.Fatalf("Plugin.Config.Decode: %v", err)
+		}
+		if decoded["api_key"] != "resolved-plugin-secret" {
+			t.Errorf("Plugin.Config.api_key: got %q, want %q", decoded["api_key"], "resolved-plugin-secret")
+		}
+	})
+
+	t.Run("resolves secret:// in plugin env and command fields", func(t *testing.T) {
+		t.Parallel()
+
+		var receivedDef config.IntegrationDef
+		factories := validFactories()
+		factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+			return &coretesting.StubSecretManager{
+				Secrets: map[string]string{"env-secret": "resolved-env-value"},
+			}, nil
+		}
+		factories.Providers["alpha"] = func(_ context.Context, _ string, intg config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
+			receivedDef = intg
+			return &coretesting.StubIntegration{N: "alpha"}, nil
+		}
+
+		cfg := validConfig()
+		intg := cfg.Integrations["alpha"]
+		intg.Plugin = &config.PluginDef{
+			Command: []string{"python3", "plugin.py"},
+			Env:     map[string]string{"API_KEY": "secret://env-secret"},
+		}
+		cfg.Integrations["alpha"] = intg
+
+		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
+			t.Fatalf("Bootstrap: %v", err)
+		}
+		<-result.ProvidersReady
+
+		if receivedDef.Plugin == nil {
+			t.Fatal("receivedDef.Plugin: got nil, want non-nil")
+		}
+		if receivedDef.Plugin.Env["API_KEY"] != "resolved-env-value" {
+			t.Errorf("Plugin.Env[API_KEY]: got %q, want %q", receivedDef.Plugin.Env["API_KEY"], "resolved-env-value")
+		}
+	})
 }
 
 func TestBootstrapWithRuntimes(t *testing.T) {

--- a/internal/composite/provider.go
+++ b/internal/composite/provider.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
+	"github.com/valon-technologies/gestalt/internal/oauth"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 )
@@ -99,7 +100,24 @@ func (o *oauthProvider) AuthorizationURL(state string, scopes []string) string {
 	return o.oauth.AuthorizationURL(state, scopes)
 }
 
+func (o *oauthProvider) StartOAuth(state string, scopes []string) (string, string, error) {
+	if s, ok := o.oauth.(core.OAuthStarterProvider); ok {
+		return s.StartOAuth(state, scopes)
+	}
+	return o.oauth.AuthorizationURL(state, scopes), "", nil
+}
+
 func (o *oauthProvider) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	return o.oauth.ExchangeCode(ctx, code)
+}
+
+func (o *oauthProvider) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error) {
+	type exchanger interface {
+		ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
+	}
+	if e, ok := o.oauth.(exchanger); ok {
+		return e.ExchangeCodeWithVerifier(ctx, code, verifier, extraOpts...)
+	}
 	return o.oauth.ExchangeCode(ctx, code)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,6 +76,7 @@ type ServerConfig struct {
 
 type IntegrationDef struct {
 	Upstreams      []UpstreamDef `yaml:"upstreams"`
+	Plugin         *PluginDef    `yaml:"plugin"`
 	DisplayName    string        `yaml:"display_name"`
 	Description    string        `yaml:"description"`
 	AuthProfile    string        `yaml:"auth_profile"`
@@ -98,6 +99,16 @@ type IntegrationDef struct {
 	AuthStyle        string            `yaml:"auth_style"`
 	IconFile         string            `yaml:"icon_file"`
 	Headers          map[string]string `yaml:"headers"`
+}
+
+type PluginDef struct {
+	Command           []string          `yaml:"command"`
+	Cwd               string            `yaml:"cwd"`
+	Env               map[string]string `yaml:"env"`
+	Config            yaml.Node         `yaml:"config"`
+	AllowedOperations AllowedOps        `yaml:"allowed_operations"`
+	StartupTimeout    string            `yaml:"startup_timeout"`
+	RequestTimeout    string            `yaml:"request_timeout"`
 }
 
 const (

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -373,6 +373,69 @@ integrations:
 	}
 }
 
+func TestPluginConfigLoads(t *testing.T) {
+	t.Parallel()
+
+	yaml := `
+auth:
+  provider: google
+server:
+  encryption_key: key123
+integrations:
+  custom_plugin:
+    plugin:
+      command:
+        - node
+        - ./plugins/custom-plugin/index.js
+      cwd: ./plugins/custom-plugin
+      env:
+        API_BASE_URL: https://example.com
+      config:
+        project: ENG
+        retries: 2
+      allowed_operations:
+        run_task: Run the task
+      startup_timeout: 5s
+      request_timeout: 30s
+`
+	path := mustWriteConfigFile(t, yaml)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: unexpected error: %v", err)
+	}
+
+	intg := cfg.Integrations["custom_plugin"]
+	if intg.Plugin == nil {
+		t.Fatal("Integrations[custom_plugin].Plugin: got nil, want non-nil")
+	}
+	if len(intg.Plugin.Command) != 2 || intg.Plugin.Command[0] != "node" {
+		t.Fatalf("Plugin.Command: got %v", intg.Plugin.Command)
+	}
+	if intg.Plugin.Cwd != "./plugins/custom-plugin" {
+		t.Errorf("Plugin.Cwd: got %q, want %q", intg.Plugin.Cwd, "./plugins/custom-plugin")
+	}
+	if intg.Plugin.Env["API_BASE_URL"] != "https://example.com" {
+		t.Errorf("Plugin.Env[API_BASE_URL]: got %q, want %q", intg.Plugin.Env["API_BASE_URL"], "https://example.com")
+	}
+	if intg.Plugin.AllowedOperations["run_task"] != "Run the task" {
+		t.Errorf("Plugin.AllowedOperations[run_task]: got %q, want %q", intg.Plugin.AllowedOperations["run_task"], "Run the task")
+	}
+	if intg.Plugin.StartupTimeout != "5s" {
+		t.Errorf("Plugin.StartupTimeout: got %q, want %q", intg.Plugin.StartupTimeout, "5s")
+	}
+	if intg.Plugin.RequestTimeout != "30s" {
+		t.Errorf("Plugin.RequestTimeout: got %q, want %q", intg.Plugin.RequestTimeout, "30s")
+	}
+
+	var pluginCfg map[string]any
+	if err := intg.Plugin.Config.Decode(&pluginCfg); err != nil {
+		t.Fatalf("Plugin.Config.Decode: %v", err)
+	}
+	if pluginCfg["project"] != "ENG" {
+		t.Errorf("Plugin.Config.project: got %v, want ENG", pluginCfg["project"])
+	}
+}
+
 func TestAuthConfigMap(t *testing.T) {
 	t.Parallel()
 

--- a/internal/integration/restricted.go
+++ b/internal/integration/restricted.go
@@ -103,7 +103,24 @@ func (r *restrictedOAuth) AuthorizationURL(state string, scopes []string) string
 	return r.oauth.AuthorizationURL(state, scopes)
 }
 
+func (r *restrictedOAuth) StartOAuth(state string, scopes []string) (string, string, error) {
+	if s, ok := r.oauth.(core.OAuthStarterProvider); ok {
+		return s.StartOAuth(state, scopes)
+	}
+	return r.oauth.AuthorizationURL(state, scopes), "", nil
+}
+
 func (r *restrictedOAuth) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	return r.oauth.ExchangeCode(ctx, code)
+}
+
+func (r *restrictedOAuth) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error) {
+	type exchanger interface {
+		ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
+	}
+	if e, ok := r.oauth.(exchanger); ok {
+		return e.ExchangeCodeWithVerifier(ctx, code, verifier, extraOpts...)
+	}
 	return r.oauth.ExchangeCode(ctx, code)
 }
 
@@ -119,17 +136,6 @@ func (r *restrictedOAuth) RefreshTokenWithURL(ctx context.Context, refreshToken,
 		return rw.RefreshTokenWithURL(ctx, refreshToken, tokenURL)
 	}
 	return r.oauth.RefreshToken(ctx, refreshToken)
-}
-
-type oauthVerifierExchanger interface {
-	ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
-}
-
-func (r *restrictedOAuth) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error) {
-	if exchanger, ok := r.oauth.(oauthVerifierExchanger); ok {
-		return exchanger.ExchangeCodeWithVerifier(ctx, code, verifier, extraOpts...)
-	}
-	return r.oauth.ExchangeCode(ctx, code)
 }
 
 func (r *restrictedOAuth) TokenURL() string {

--- a/internal/pluginproc/client.go
+++ b/internal/pluginproc/client.go
@@ -1,0 +1,203 @@
+package pluginproc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+)
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+func (e *rpcError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Message == "" {
+		return fmt.Sprintf("plugin rpc error %d", e.Code)
+	}
+	return e.Message
+}
+
+type requestMessage struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      int64  `json:"id,omitempty"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+type responseMessage struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int64           `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type envelope struct {
+	ID     *int64           `json:"id,omitempty"`
+	Method string           `json:"method,omitempty"`
+	Result json.RawMessage  `json:"result,omitempty"`
+	Error  *rpcError        `json:"error,omitempty"`
+	Params *json.RawMessage `json:"params,omitempty"`
+}
+
+type Client struct {
+	codec *framedCodec
+
+	nextID atomic.Int64
+
+	pendingMu sync.Mutex
+	pending   map[int64]chan responseMessage
+
+	closeOnce sync.Once
+	done      chan struct{}
+	err       error
+}
+
+func newClient(r io.Reader, w io.Writer) *Client {
+	c := &Client{
+		codec:   newFramedCodec(r, w),
+		pending: make(map[int64]chan responseMessage),
+		done:    make(chan struct{}),
+	}
+	go c.readLoop()
+	return c
+}
+
+func (c *Client) Call(ctx context.Context, method string, params any, out any) error {
+	id := c.nextID.Add(1)
+	respCh := make(chan responseMessage, 1)
+
+	c.pendingMu.Lock()
+	c.pending[id] = respCh
+	c.pendingMu.Unlock()
+
+	req := requestMessage{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  method,
+		Params:  params,
+	}
+	if err := c.codec.writeMessage(req); err != nil {
+		c.unregisterPending(id)
+		return err
+	}
+
+	select {
+	case resp := <-respCh:
+		if resp.Error != nil {
+			return resp.Error
+		}
+		if out == nil || len(resp.Result) == 0 {
+			return nil
+		}
+		if err := json.Unmarshal(resp.Result, out); err != nil {
+			return fmt.Errorf("decode rpc result for %s: %w", method, err)
+		}
+		return nil
+	case <-ctx.Done():
+		_ = c.Notify(context.Background(), methodCancelRequest, cancelParams{ID: id})
+		c.unregisterPending(id)
+		return ctx.Err()
+	case <-c.done:
+		c.unregisterPending(id)
+		if c.err != nil {
+			return c.err
+		}
+		return io.EOF
+	}
+}
+
+func (c *Client) Notify(_ context.Context, method string, params any) error {
+	req := requestMessage{
+		JSONRPC: "2.0",
+		Method:  method,
+		Params:  params,
+	}
+	return c.codec.writeMessage(req)
+}
+
+func (c *Client) readLoop() {
+	for {
+		raw, err := c.codec.readMessage()
+		if err != nil {
+			c.stop(err)
+			return
+		}
+
+		var env envelope
+		if err := json.Unmarshal(raw, &env); err != nil {
+			c.stop(fmt.Errorf("decode plugin response: %w", err))
+			return
+		}
+
+		if env.ID == nil {
+			continue
+		}
+
+		resp := responseMessage{
+			JSONRPC: "2.0",
+			ID:      *env.ID,
+			Result:  env.Result,
+			Error:   env.Error,
+		}
+		c.resolvePending(resp)
+	}
+}
+
+func (c *Client) resolvePending(resp responseMessage) {
+	c.pendingMu.Lock()
+	ch, ok := c.pending[resp.ID]
+	if ok {
+		delete(c.pending, resp.ID)
+	}
+	c.pendingMu.Unlock()
+
+	if ok {
+		ch <- resp
+		close(ch)
+	}
+}
+
+func (c *Client) unregisterPending(id int64) {
+	c.pendingMu.Lock()
+	if ch, ok := c.pending[id]; ok {
+		delete(c.pending, id)
+		close(ch)
+	}
+	c.pendingMu.Unlock()
+}
+
+func (c *Client) stop(err error) {
+	c.closeOnce.Do(func() {
+		if err == nil {
+			err = io.EOF
+		}
+		c.err = err
+
+		c.pendingMu.Lock()
+		for id, ch := range c.pending {
+			delete(c.pending, id)
+			ch <- responseMessage{Error: &rpcError{Code: -1, Message: err.Error()}}
+			close(ch)
+		}
+		c.pendingMu.Unlock()
+
+		close(c.done)
+	})
+}
+
+func (c *Client) Wait() error {
+	<-c.done
+	if c.err != nil && !errors.Is(c.err, io.EOF) {
+		return c.err
+	}
+	return nil
+}

--- a/internal/pluginproc/protocol.go
+++ b/internal/pluginproc/protocol.go
@@ -1,0 +1,106 @@
+package pluginproc
+
+import (
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+)
+
+const ProtocolVersion = "gestalt-plugin/1"
+
+const (
+	methodInitialize         = "initialize"
+	methodProviderExecute    = "provider.execute"
+	methodAuthStart          = "auth.start"
+	methodAuthExchangeCode   = "auth.exchange_code"
+	methodAuthRefreshToken   = "auth.refresh_token"
+	methodShutdown           = "shutdown"
+	methodCancelRequest      = "$/cancelRequest"
+	defaultStartupTimeoutSec = 10
+	defaultRequestTimeoutSec = 60
+
+	AuthTypeNone   = "none"
+	AuthTypeManual = "manual"
+	AuthTypeOAuth2 = "oauth2"
+)
+
+type HostInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+}
+
+type IntegrationInfo struct {
+	Name   string `json:"name"`
+	Config any    `json:"config,omitempty"`
+}
+
+type InitializeParams struct {
+	ProtocolVersion string          `json:"protocolVersion"`
+	HostInfo        HostInfo        `json:"hostInfo"`
+	Integration     IntegrationInfo `json:"integration"`
+}
+
+type InitializeResult struct {
+	ProtocolVersion string             `json:"protocolVersion"`
+	PluginInfo      PluginInfo         `json:"pluginInfo"`
+	Provider        ProviderManifest   `json:"provider"`
+	Capabilities    PluginCapabilities `json:"capabilities,omitempty"`
+}
+
+type PluginInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+}
+
+type ProviderManifest struct {
+	DisplayName    string              `json:"displayName"`
+	Description    string              `json:"description,omitempty"`
+	ConnectionMode string              `json:"connectionMode,omitempty"`
+	Operations     []core.Operation    `json:"operations"`
+	Catalog        *catalog.Catalog    `json:"catalog,omitempty"`
+	Auth           *ProviderAuthConfig `json:"auth,omitempty"`
+}
+
+type ProviderAuthConfig struct {
+	Type string `json:"type,omitempty"`
+}
+
+type PluginCapabilities struct {
+	Catalog      bool `json:"catalog,omitempty"`
+	OAuth        bool `json:"oauth,omitempty"`
+	ManualAuth   bool `json:"manualAuth,omitempty"`
+	Cancellation bool `json:"cancellation,omitempty"`
+}
+
+type ExecuteParams struct {
+	Operation string         `json:"operation"`
+	Params    map[string]any `json:"params,omitempty"`
+	Token     string         `json:"token,omitempty"`
+	Meta      *RequestMeta   `json:"meta,omitempty"`
+}
+
+type RequestMeta struct {
+	RequestID string `json:"requestId,omitempty"`
+}
+
+type AuthStartParams struct {
+	State  string   `json:"state"`
+	Scopes []string `json:"scopes,omitempty"`
+}
+
+type AuthStartResult struct {
+	AuthURL  string `json:"authUrl"`
+	Verifier string `json:"verifier,omitempty"`
+}
+
+type AuthExchangeCodeParams struct {
+	Code     string `json:"code"`
+	Verifier string `json:"verifier,omitempty"`
+}
+
+type AuthRefreshTokenParams struct {
+	RefreshToken string `json:"refreshToken"`
+}
+
+type cancelParams struct {
+	ID int64 `json:"id"`
+}

--- a/internal/pluginproc/provider.go
+++ b/internal/pluginproc/provider.go
@@ -1,0 +1,462 @@
+package pluginproc
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+const closeGracePeriod = 2 * time.Second
+
+var (
+	_ core.Provider        = (*baseProvider)(nil)
+	_ core.CatalogProvider = (*baseProvider)(nil)
+	_ io.Closer            = (*baseProvider)(nil)
+	_ core.Provider        = (*manualProvider)(nil)
+	_ core.ManualProvider  = (*manualProvider)(nil)
+	_ core.Provider        = (*oauthProvider)(nil)
+	_ core.OAuthProvider   = (*oauthProvider)(nil)
+)
+
+type baseProvider struct {
+	name           string
+	displayName    string
+	description    string
+	connectionMode core.ConnectionMode
+	operations     []core.Operation
+	cat            *catalog.Catalog
+	session        *pluginSession
+	requestTimeout time.Duration
+}
+
+func New(ctx context.Context, name string, intg config.IntegrationDef, plugin config.PluginDef) (core.Provider, error) {
+	if len(plugin.Command) == 0 {
+		return nil, fmt.Errorf("integration %s: plugin.command is required", name)
+	}
+
+	startupTimeout, err := parseDuration(plugin.StartupTimeout, defaultStartupTimeoutSec*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("integration %s: invalid plugin.startup_timeout: %w", name, err)
+	}
+	requestTimeout, err := parseDuration(plugin.RequestTimeout, defaultRequestTimeoutSec*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("integration %s: invalid plugin.request_timeout: %w", name, err)
+	}
+
+	sess, err := startSession(name, plugin)
+	if err != nil {
+		return nil, fmt.Errorf("integration %s: starting plugin: %w", name, err)
+	}
+
+	initCtx, cancel := context.WithTimeout(ctx, startupTimeout)
+	defer cancel()
+
+	initResult := InitializeResult{}
+	if err := sess.client.Call(initCtx, methodInitialize, InitializeParams{
+		ProtocolVersion: ProtocolVersion,
+		HostInfo: HostInfo{
+			Name: "gestalt",
+		},
+		Integration: IntegrationInfo{
+			Name:   name,
+			Config: decodeConfigNode(plugin.Config),
+		},
+	}, &initResult); err != nil {
+		_ = sess.Close()
+		return nil, fmt.Errorf("initialize plugin: %w", err)
+	}
+
+	if initResult.ProtocolVersion != ProtocolVersion {
+		_ = sess.Close()
+		return nil, fmt.Errorf("initialize plugin: unsupported protocol version %q", initResult.ProtocolVersion)
+	}
+	if len(initResult.Provider.Operations) == 0 {
+		_ = sess.Close()
+		return nil, fmt.Errorf("initialize plugin: provider returned no operations")
+	}
+
+	displayName := firstNonEmpty(intg.DisplayName, initResult.Provider.DisplayName, name)
+	description := firstNonEmpty(intg.Description, initResult.Provider.Description)
+	connMode, err := normalizeConnectionMode(intg.ConnectionMode, initResult.Provider.ConnectionMode)
+	if err != nil {
+		_ = sess.Close()
+		return nil, fmt.Errorf("integration %s: %w", name, err)
+	}
+
+	ops, cat, err := filterManifest(name, initResult.Provider.Operations, initResult.Provider.Catalog, plugin.AllowedOperations)
+	if err != nil {
+		_ = sess.Close()
+		return nil, fmt.Errorf("integration %s: %w", name, err)
+	}
+	if cat != nil {
+		cat.Name = name
+		if cat.DisplayName == "" {
+			cat.DisplayName = displayName
+		}
+		if cat.Description == "" {
+			cat.Description = description
+		}
+	}
+
+	base := &baseProvider{
+		name:           name,
+		displayName:    displayName,
+		description:    description,
+		connectionMode: connMode,
+		operations:     ops,
+		cat:            cat,
+		session:        sess,
+		requestTimeout: requestTimeout,
+	}
+
+	authType := inferAuthType(initResult.Provider.Auth, initResult.Capabilities)
+	switch authType {
+	case "", AuthTypeNone:
+		return base, nil
+	case AuthTypeManual:
+		return &manualProvider{baseProvider: base}, nil
+	case AuthTypeOAuth2:
+		return &oauthProvider{baseProvider: base}, nil
+	default:
+		_ = sess.Close()
+		return nil, fmt.Errorf("initialize plugin: unknown auth type %q", authType)
+	}
+}
+
+func (p *baseProvider) Name() string                        { return p.name }
+func (p *baseProvider) DisplayName() string                 { return p.displayName }
+func (p *baseProvider) Description() string                 { return p.description }
+func (p *baseProvider) ConnectionMode() core.ConnectionMode { return p.connectionMode }
+func (p *baseProvider) ListOperations() []core.Operation    { return p.operations }
+func (p *baseProvider) Catalog() *catalog.Catalog           { return p.cat }
+
+func (p *baseProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
+	callCtx, cancel := withOptionalTimeout(ctx, p.requestTimeout)
+	defer cancel()
+
+	var result core.OperationResult
+	if err := p.session.client.Call(callCtx, methodProviderExecute, ExecuteParams{
+		Operation: operation,
+		Params:    params,
+		Token:     token,
+	}, &result); err != nil {
+		return nil, fmt.Errorf("plugin execute %s/%s: %w", p.name, operation, err)
+	}
+	return &result, nil
+}
+
+func (p *baseProvider) Close() error {
+	return p.session.Close()
+}
+
+type manualProvider struct {
+	*baseProvider
+}
+
+func (p *manualProvider) SupportsManualAuth() bool { return true }
+
+type oauthProvider struct {
+	*baseProvider
+}
+
+func (p *oauthProvider) AuthorizationURL(state string, scopes []string) string {
+	authURL, _, _ := p.StartOAuth(state, scopes)
+	return authURL
+}
+
+func (p *oauthProvider) StartOAuth(state string, scopes []string) (authURL string, verifier string, err error) {
+	callCtx, cancel := withOptionalTimeout(context.Background(), p.requestTimeout)
+	defer cancel()
+
+	var result AuthStartResult
+	if err := p.session.client.Call(callCtx, methodAuthStart, AuthStartParams{
+		State:  state,
+		Scopes: scopes,
+	}, &result); err != nil {
+		return "", "", fmt.Errorf("plugin %s: auth.start: %w", p.name, err)
+	}
+	return result.AuthURL, result.Verifier, nil
+}
+
+func (p *oauthProvider) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	return p.ExchangeCodeWithVerifier(ctx, code, "")
+}
+
+func (p *oauthProvider) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string) (*core.TokenResponse, error) {
+	callCtx, cancel := withOptionalTimeout(ctx, p.requestTimeout)
+	defer cancel()
+
+	var result core.TokenResponse
+	if err := p.session.client.Call(callCtx, methodAuthExchangeCode, AuthExchangeCodeParams{
+		Code:     code,
+		Verifier: verifier,
+	}, &result); err != nil {
+		return nil, fmt.Errorf("plugin auth exchange code: %w", err)
+	}
+	return &result, nil
+}
+
+func (p *oauthProvider) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	callCtx, cancel := withOptionalTimeout(ctx, p.requestTimeout)
+	defer cancel()
+
+	var result core.TokenResponse
+	if err := p.session.client.Call(callCtx, methodAuthRefreshToken, AuthRefreshTokenParams{
+		RefreshToken: refreshToken,
+	}, &result); err != nil {
+		return nil, fmt.Errorf("plugin auth refresh token: %w", err)
+	}
+	return &result, nil
+}
+
+type pluginSession struct {
+	client *Client
+	cmd    *exec.Cmd
+	waitCh chan error
+}
+
+func startSession(name string, cfg config.PluginDef) (*pluginSession, error) {
+	cmd := exec.Command(cfg.Command[0], cfg.Command[1:]...)
+	cmd.Dir = cfg.Cwd
+	cmd.Env = append(os.Environ(), flattenEnv(cfg.Env)...)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("create stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("create stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("create stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start process: %w", err)
+	}
+
+	go streamLogs(name, stderr)
+
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+		close(waitCh)
+	}()
+
+	return &pluginSession{
+		client: newClient(stdout, stdin),
+		cmd:    cmd,
+		waitCh: waitCh,
+	}, nil
+}
+
+func (s *pluginSession) Close() error {
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), closeGracePeriod)
+	err := s.client.Call(shutdownCtx, methodShutdown, map[string]any{}, nil)
+	shutdownCancel()
+	if err != nil && !errors.Is(err, os.ErrClosed) && !errors.Is(err, context.DeadlineExceeded) {
+		return s.kill(err)
+	}
+
+	select {
+	case err := <-s.waitCh:
+		return err
+	case <-time.After(closeGracePeriod):
+	}
+
+	if s.cmd.Process != nil {
+		_ = s.cmd.Process.Signal(os.Interrupt)
+	}
+
+	select {
+	case err := <-s.waitCh:
+		return err
+	case <-time.After(closeGracePeriod):
+	}
+
+	return s.kill(nil)
+}
+
+func (s *pluginSession) kill(firstErr error) error {
+	if s.cmd.Process != nil {
+		if err := s.cmd.Process.Kill(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if err := <-s.waitCh; err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}
+
+func streamLogs(name string, r io.Reader) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		log.Printf("plugin %s: %s", name, line)
+	}
+}
+
+func filterManifest(name string, ops []core.Operation, cat *catalog.Catalog, allowed config.AllowedOps) ([]core.Operation, *catalog.Catalog, error) {
+	if allowed == nil {
+		return ops, cat, nil
+	}
+	if len(allowed) == 0 {
+		return nil, nil, fmt.Errorf("plugin.allowed_operations cannot be empty; omit the field to allow all")
+	}
+
+	opSet := make(map[string]struct{}, len(ops))
+	for _, op := range ops {
+		opSet[op.Name] = struct{}{}
+	}
+	for opName := range allowed {
+		if _, ok := opSet[opName]; !ok {
+			return nil, nil, fmt.Errorf("plugin.allowed_operations contains unknown operation %q", opName)
+		}
+	}
+
+	filteredOps := make([]core.Operation, 0, len(allowed))
+	for _, op := range ops {
+		if desc, ok := allowed[op.Name]; ok {
+			if desc != "" {
+				op.Description = desc
+			}
+			filteredOps = append(filteredOps, op)
+		}
+	}
+
+	if cat == nil {
+		return filteredOps, nil, nil
+	}
+
+	filteredCat := *cat
+	filteredCat.Name = firstNonEmpty(filteredCat.Name, name)
+	filteredCat.Operations = make([]catalog.CatalogOperation, 0, len(allowed))
+	for i := range cat.Operations {
+		op := &cat.Operations[i]
+		if desc, ok := allowed[op.ID]; ok {
+			entry := *op
+			if desc != "" {
+				entry.Description = desc
+			}
+			filteredCat.Operations = append(filteredCat.Operations, entry)
+		}
+	}
+	return filteredOps, &filteredCat, nil
+}
+
+func inferAuthType(cfg *ProviderAuthConfig, caps PluginCapabilities) string {
+	switch {
+	case cfg != nil && cfg.Type != "":
+		return cfg.Type
+	case caps.ManualAuth:
+		return AuthTypeManual
+	case caps.OAuth:
+		return AuthTypeOAuth2
+	default:
+		return ""
+	}
+}
+
+func normalizeConnectionMode(override, manifest string) (core.ConnectionMode, error) {
+	mode := firstNonEmpty(override, manifest, string(core.ConnectionModeUser))
+	switch core.ConnectionMode(mode) {
+	case core.ConnectionModeNone, core.ConnectionModeUser, core.ConnectionModeIdentity, core.ConnectionModeEither:
+		return core.ConnectionMode(mode), nil
+	default:
+		return "", fmt.Errorf("unknown connection_mode %q", mode)
+	}
+}
+
+func withOptionalTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout <= 0 {
+		return ctx, func() {}
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		if time.Until(deadline) <= timeout {
+			return ctx, func() {}
+		}
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
+func parseDuration(raw string, fallback time.Duration) (time.Duration, error) {
+	if strings.TrimSpace(raw) == "" {
+		return fallback, nil
+	}
+	return time.ParseDuration(raw)
+}
+
+func flattenEnv(env map[string]string) []string {
+	if len(env) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(env))
+	for key, value := range env {
+		out = append(out, key+"="+value)
+	}
+	return out
+}
+
+func decodeConfigNode(node yaml.Node) any {
+	if node.Kind == 0 {
+		return nil
+	}
+
+	var v any
+	if err := node.Decode(&v); err != nil {
+		return nil
+	}
+	return normalizeYAMLValue(v)
+}
+
+func normalizeYAMLValue(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(t))
+		for key, value := range t {
+			out[key] = normalizeYAMLValue(value)
+		}
+		return out
+	case map[any]any:
+		out := make(map[string]any, len(t))
+		for key, value := range t {
+			out[fmt.Sprint(key)] = normalizeYAMLValue(value)
+		}
+		return out
+	case []any:
+		out := make([]any, len(t))
+		for i, value := range t {
+			out[i] = normalizeYAMLValue(value)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/pluginproc/transport.go
+++ b/internal/pluginproc/transport.go
@@ -1,0 +1,101 @@
+package pluginproc
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const (
+	headerContentLength = "content-length"
+	maxPayloadSize      = 64 << 20 // 64 MiB
+)
+
+type framedCodec struct {
+	r       *bufio.Reader
+	w       io.Writer
+	writeMu sync.Mutex
+}
+
+func newFramedCodec(r io.Reader, w io.Writer) *framedCodec {
+	return &framedCodec{
+		r: bufio.NewReader(r),
+		w: w,
+	}
+}
+
+func (c *framedCodec) writeMessage(v any) error {
+	payload, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshal message: %w", err)
+	}
+
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+
+	if _, err := fmt.Fprintf(c.w, "Content-Length: %d\r\n\r\n", len(payload)); err != nil {
+		return fmt.Errorf("write header: %w", err)
+	}
+	if _, err := c.w.Write(payload); err != nil {
+		return fmt.Errorf("write payload: %w", err)
+	}
+	return nil
+}
+
+func (c *framedCodec) readMessage() (json.RawMessage, error) {
+	contentLength, err := c.readContentLength()
+	if err != nil {
+		return nil, err
+	}
+
+	payload := make([]byte, contentLength)
+	if _, err := io.ReadFull(c.r, payload); err != nil {
+		return nil, fmt.Errorf("read payload: %w", err)
+	}
+	return payload, nil
+}
+
+func (c *framedCodec) readContentLength() (int, error) {
+	contentLength := -1
+
+	for {
+		line, err := c.r.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				return 0, io.EOF
+			}
+			return 0, fmt.Errorf("read header line: %w", err)
+		}
+
+		trimmed := strings.TrimRight(line, "\r\n")
+		if trimmed == "" {
+			break
+		}
+
+		key, value, ok := strings.Cut(trimmed, ":")
+		if !ok {
+			return 0, fmt.Errorf("invalid header line %q", trimmed)
+		}
+		if strings.ToLower(strings.TrimSpace(key)) != headerContentLength {
+			continue
+		}
+
+		n, err := strconv.Atoi(strings.TrimSpace(value))
+		if err != nil {
+			return 0, fmt.Errorf("parse content length: %w", err)
+		}
+		contentLength = n
+	}
+
+	if contentLength < 0 {
+		return 0, fmt.Errorf("missing Content-Length header")
+	}
+	if contentLength > maxPayloadSize {
+		return 0, fmt.Errorf("payload size %d exceeds limit %d", contentLength, maxPayloadSize)
+	}
+	return contentLength, nil
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -401,14 +401,6 @@ type startOAuthRequest struct {
 	ConnectionParams map[string]string `json:"connection_params"`
 }
 
-type oauthStarter interface {
-	StartOAuth(state string, scopes []string) (authURL string, verifier string)
-}
-
-type oauthVerifierExchanger interface {
-	ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
-}
-
 func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 	var req startOAuthRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -465,8 +457,13 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if authURL == "" {
-		if starter, ok := prov.(oauthStarter); ok {
-			authURL, verifier = starter.StartOAuth("_", req.Scopes)
+		if starter, ok := prov.(core.OAuthStarterProvider); ok {
+			var startErr error
+			authURL, verifier, startErr = starter.StartOAuth("_", req.Scopes)
+			if startErr != nil {
+				writeError(w, http.StatusBadGateway, fmt.Sprintf("oauth start: %v", startErr))
+				return
+			}
 		} else {
 			authURL = oauthProv.AuthorizationURL("_", req.Scopes)
 		}
@@ -534,7 +531,10 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	}
 
 	var tokenResp *core.TokenResponse
-	if exchanger, ok := prov.(oauthVerifierExchanger); ok {
+	type verifierExchanger interface {
+		ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
+	}
+	if exchanger, ok := prov.(verifierExchanger); ok {
 		tokenResp, err = exchanger.ExchangeCodeWithVerifier(r.Context(), code, state.Verifier, exchangeOpts...)
 	} else {
 		if len(exchangeOpts) > 0 {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1558,8 +1558,8 @@ func (s *stubPKCEIntegration) AuthorizationURL(state string, _ []string) string 
 	return s.authURL + "?state=" + url.QueryEscape(state)
 }
 
-func (s *stubPKCEIntegration) StartOAuth(state string, _ []string) (string, string) {
-	return s.AuthorizationURL(state, nil), s.wantVerifier
+func (s *stubPKCEIntegration) StartOAuth(state string, _ []string) (string, string, error) {
+	return s.AuthorizationURL(state, nil), s.wantVerifier, nil
 }
 
 func (s *stubPKCEIntegration) ExchangeCodeWithVerifier(_ context.Context, code, verifier string, _ ...oauth.ExchangeOption) (*core.TokenResponse, error) {

--- a/sdk/plugin/README.md
+++ b/sdk/plugin/README.md
@@ -1,0 +1,21 @@
+# Gestalt Plugin SDKs
+
+These SDK shims implement the subprocess plugin protocol used by Gestalt for
+custom code-based providers.
+
+The transport is JSON-RPC 2.0 over stdio with LSP-style `Content-Length`
+framing. Gestalt starts the plugin process, sends an `initialize` request, and
+then dispatches `provider.execute` and optional auth methods.
+
+Protocol shape:
+
+- `initialize` request: `protocolVersion`, `hostInfo`, `integration{name, config}`
+- `initialize` result: `protocolVersion`, `pluginInfo{name, version}`, `provider{displayName, description, connectionMode, operations, catalog?, auth?}`, `capabilities{catalog?, oauth?, manualAuth?, cancellation?}`
+- `provider.execute` request: `operation`, `params`, `token`, `meta?`
+- `provider.execute` result: `status`, `body`
+- `auth.start` result: `authUrl`, `verifier?`
+- `auth.exchange_code` and `auth.refresh_token` results: `accessToken`, `refreshToken?`, `expiresIn?`, `tokenType?`
+
+Each language directory contains a thin runtime helper and a README with a
+minimal example.
+

--- a/sdk/plugin/python/README.md
+++ b/sdk/plugin/python/README.md
@@ -1,0 +1,34 @@
+# Gestalt Plugin SDK for Python
+
+This is a thin helper for implementing a Gestalt subprocess plugin in Python.
+
+```py
+from gestalt_plugin import Plugin, PluginInfo, ProviderManifest, OperationDef
+
+plugin = Plugin(
+    plugin_info=PluginInfo(name="loan-enrichment", version="0.1.0"),
+    provider=ProviderManifest(
+        display_name="Loan Enrichment",
+        description="Fetches enrichment data for a loan",
+        connection_mode="user",
+        operations=[
+            OperationDef(
+                name="enrich_loan",
+                description="Fetch enrichment data",
+                method="POST",
+                parameters=[{"name": "loan_id", "type": "string", "required": True}],
+            )
+        ],
+    ),
+)
+
+@plugin.execute
+def execute(request):
+    return {"status": 200, "body": "{\"ok\": true}"}
+
+plugin.serve()
+```
+
+The SDK reads framed JSON-RPC messages from stdin and writes responses to
+stdout. Use stderr for logs.
+

--- a/sdk/plugin/python/gestalt_plugin.py
+++ b/sdk/plugin/python/gestalt_plugin.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+import sys
+from typing import Any, Callable, Dict, IO, List, Optional
+
+PROTOCOL_VERSION = "gestalt-plugin/1"
+JSONRPC_VERSION = "2.0"
+
+ERR_PARSE = -32700
+ERR_INVALID_REQUEST = -32600
+ERR_METHOD_NOT_FOUND = -32601
+ERR_INVALID_PARAMS = -32602
+ERR_INTERNAL = -32603
+
+JsonObject = Dict[str, Any]
+
+
+@dataclasses.dataclass
+class HostInfo:
+    name: str
+    version: str
+
+
+@dataclasses.dataclass
+class IntegrationInfo:
+    name: str
+    config: JsonObject
+
+
+@dataclasses.dataclass
+class ParameterDef:
+    name: str
+    type: str
+    description: str = ""
+    required: bool = False
+    default: Any = None
+
+
+@dataclasses.dataclass
+class OperationDef:
+    name: str
+    description: str = ""
+    method: str = ""
+    parameters: List[ParameterDef] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass
+class CatalogOperationDef:
+    id: str
+    title: str = ""
+    description: str = ""
+    input_schema: Any = None
+    parameters: List[ParameterDef] = dataclasses.field(default_factory=list)
+    required_scopes: List[str] = dataclasses.field(default_factory=list)
+    tags: List[str] = dataclasses.field(default_factory=list)
+    read_only: bool = False
+    visible: Optional[bool] = None
+    transport: str = ""
+    query: str = ""
+
+
+@dataclasses.dataclass
+class CatalogDef:
+    name: str
+    display_name: str = ""
+    description: str = ""
+    icon_svg: str = ""
+    base_url: str = ""
+    auth_style: str = ""
+    headers: Dict[str, str] = dataclasses.field(default_factory=dict)
+    operations: List[CatalogOperationDef] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass
+class ProviderManifest:
+    display_name: str
+    description: str
+    connection_mode: str
+    operations: List[OperationDef]
+    catalog: Any = None
+    auth: Optional[JsonObject] = None
+
+
+@dataclasses.dataclass
+class PluginInfo:
+    name: str
+    version: str
+
+
+@dataclasses.dataclass
+class Capabilities:
+    catalog: bool = False
+    oauth: bool = False
+    manual_auth: bool = False
+    cancellation: bool = False
+
+
+@dataclasses.dataclass
+class InitializeRequest:
+    protocol_version: str
+    host_info: HostInfo
+    integration: IntegrationInfo
+
+
+@dataclasses.dataclass
+class InitializeResult:
+    protocol_version: str
+    plugin_info: PluginInfo
+    provider: ProviderManifest
+    capabilities: Optional[Capabilities] = None
+
+
+@dataclasses.dataclass
+class ExecuteRequest:
+    operation: str
+    params: JsonObject
+    token: str
+    meta: Optional[JsonObject] = None
+
+
+@dataclasses.dataclass
+class ExecuteResult:
+    status: int
+    body: str
+
+
+@dataclasses.dataclass
+class AuthStartRequest:
+    state: str
+    scopes: List[str]
+
+
+@dataclasses.dataclass
+class AuthStartResult:
+    auth_url: str
+    verifier: Optional[str] = None
+
+
+@dataclasses.dataclass
+class AuthExchangeRequest:
+    code: str
+    verifier: Optional[str] = None
+
+
+@dataclasses.dataclass
+class TokenResult:
+    access_token: str
+    refresh_token: Optional[str] = None
+    expires_in: Optional[int] = None
+    token_type: Optional[str] = None
+
+
+@dataclasses.dataclass
+class AuthRefreshRequest:
+    refresh_token: str
+
+
+def _to_camel(name: str) -> str:
+    parts = name.split("_")
+    return parts[0] + "".join(p.capitalize() for p in parts[1:])
+
+
+def _asdict(value: Any) -> Any:
+    if dataclasses.is_dataclass(value):
+        return {
+            _to_camel(f.name): _asdict(getattr(value, f.name))
+            for f in dataclasses.fields(value)
+        }
+    if isinstance(value, list):
+        return [_asdict(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _asdict(item) for key, item in value.items()}
+    return value
+
+
+def _read_frame(stream: IO[bytes]) -> Optional[bytes]:
+    headers: Dict[str, str] = {}
+    while True:
+        line = stream.readline()
+        if line == b"":
+            return None
+        stripped = line.strip()
+        if stripped == b"":
+            break
+        key, _, value = line.decode("utf-8").partition(":")
+        headers[key.strip().lower()] = value.strip()
+    if "content-length" not in headers:
+        raise ValueError("missing Content-Length header")
+    length = int(headers["content-length"])
+    body = stream.read(length)
+    if body is None or len(body) < length:
+        return None
+    return body
+
+
+def _write_frame(stream: IO[bytes], payload: Any) -> None:
+    body = json.dumps(payload, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    stream.write(f"Content-Length: {len(body)}\r\n\r\n".encode("utf-8"))
+    stream.write(body)
+    stream.flush()
+
+
+def _response_ok(id_: Any, result: Any) -> Dict[str, Any]:
+    return {"jsonrpc": JSONRPC_VERSION, "id": id_, "result": result}
+
+
+def _response_err(id_: Any, code: int, message: str, data: Any = None) -> Dict[str, Any]:
+    error = {"code": code, "message": message}
+    if data is not None:
+        error["data"] = data
+    return {"jsonrpc": JSONRPC_VERSION, "id": id_, "error": error}
+
+
+class Plugin:
+    def __init__(
+        self,
+        plugin_info: PluginInfo,
+        provider: ProviderManifest,
+        *,
+        capabilities: Optional[Capabilities] = None,
+        initialize: Optional[Callable[[InitializeRequest], InitializeResult]] = None,
+        execute: Optional[Callable[[ExecuteRequest], ExecuteResult]] = None,
+        auth_start: Optional[Callable[[AuthStartRequest], AuthStartResult]] = None,
+        auth_exchange_code: Optional[Callable[[AuthExchangeRequest], TokenResult]] = None,
+        auth_refresh_token: Optional[Callable[[AuthRefreshRequest], TokenResult]] = None,
+        on_shutdown: Optional[Callable[[], None]] = None,
+        stdin: IO[bytes] = sys.stdin.buffer,
+        stdout: IO[bytes] = sys.stdout.buffer,
+        stderr: IO[bytes] = sys.stderr.buffer,
+    ) -> None:
+        self.plugin_info = plugin_info
+        self.provider = provider
+        self.capabilities = capabilities
+        self.initialize_handler = initialize
+        self.execute_handler = execute
+        self.auth_start_handler = auth_start
+        self.auth_exchange_code_handler = auth_exchange_code
+        self.auth_refresh_token_handler = auth_refresh_token
+        self.on_shutdown = on_shutdown
+        self.stdin = stdin
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def execute(self, fn: Callable[[ExecuteRequest], ExecuteResult]) -> Callable[[ExecuteRequest], ExecuteResult]:
+        self.execute_handler = fn
+        return fn
+
+    def auth_start(self, fn: Callable[[AuthStartRequest], AuthStartResult]) -> Callable[[AuthStartRequest], AuthStartResult]:
+        self.auth_start_handler = fn
+        return fn
+
+    def auth_exchange_code(self, fn: Callable[[AuthExchangeRequest], TokenResult]) -> Callable[[AuthExchangeRequest], TokenResult]:
+        self.auth_exchange_code_handler = fn
+        return fn
+
+    def auth_refresh_token(self, fn: Callable[[AuthRefreshRequest], TokenResult]) -> Callable[[AuthRefreshRequest], TokenResult]:
+        self.auth_refresh_token_handler = fn
+        return fn
+
+    def serve(self) -> None:
+        if self.execute_handler is None:
+            raise ValueError("execute handler is required")
+        while True:
+            raw = _read_frame(self.stdin)
+            if raw is None:
+                return
+            try:
+                message = json.loads(raw.decode("utf-8"))
+            except json.JSONDecodeError as exc:
+                _write_frame(self.stdout, _response_err(None, ERR_PARSE, "invalid JSON payload", str(exc)))
+                continue
+
+            if not isinstance(message, dict) or "method" not in message:
+                _write_frame(self.stdout, _response_err(message.get("id") if isinstance(message, dict) else None, ERR_INVALID_REQUEST, "invalid JSON-RPC request"))
+                continue
+
+            if "id" not in message:
+                if self._handle_notification(message):
+                    return
+                continue
+
+            if self._handle_request(message):
+                return
+
+    def _handle_notification(self, message: Dict[str, Any]) -> bool:
+        if message.get("method") == "exit":
+            self._shutdown()
+            return True
+        return False
+
+    def _handle_request(self, message: Dict[str, Any]) -> bool:
+        id_ = message.get("id")
+        method = message.get("method")
+        try:
+            if method == "initialize":
+                result = self._handle_initialize(message.get("params"))
+                _write_frame(self.stdout, _response_ok(id_, _asdict(result)))
+                return False
+            if method == "provider.execute":
+                result = self._handle_execute(message.get("params"))
+                _write_frame(self.stdout, _response_ok(id_, _asdict(result)))
+                return False
+            if method == "auth.start":
+                result = self._handle_auth_start(message.get("params"))
+                _write_frame(self.stdout, _response_ok(id_, _asdict(result)))
+                return False
+            if method == "auth.exchange_code":
+                result = self._handle_auth_exchange_code(message.get("params"))
+                _write_frame(self.stdout, _response_ok(id_, _asdict(result)))
+                return False
+            if method == "auth.refresh_token":
+                result = self._handle_auth_refresh_token(message.get("params"))
+                _write_frame(self.stdout, _response_ok(id_, _asdict(result)))
+                return False
+            if method == "shutdown":
+                _write_frame(self.stdout, _response_ok(id_, None))
+                self._shutdown()
+                return True
+            _write_frame(self.stdout, _response_err(id_, ERR_METHOD_NOT_FOUND, f"method not found: {method}"))
+            return False
+        except Exception as exc:
+            _write_frame(self.stdout, _response_err(id_, ERR_INTERNAL, str(exc)))
+        return False
+
+    def _require_object(self, params: Any, method: str) -> Dict[str, Any]:
+        if not isinstance(params, dict):
+            raise ValueError(f"{method} requires a JSON object")
+        return params
+
+    def _handle_initialize(self, params: Any) -> InitializeResult:
+        payload = self._require_object(params, "initialize")
+        host_info = payload.get("hostInfo", {})
+        integration = payload.get("integration", {})
+        request = InitializeRequest(
+            protocol_version=payload.get("protocolVersion", ""),
+            host_info=HostInfo(
+                name=host_info.get("name", ""),
+                version=host_info.get("version", ""),
+            ),
+            integration=IntegrationInfo(
+                name=integration.get("name", ""),
+                config=integration.get("config", {}),
+            ),
+        )
+        if self.initialize_handler is not None:
+            return self.initialize_handler(request)
+        return InitializeResult(
+            protocol_version=PROTOCOL_VERSION,
+            plugin_info=self.plugin_info,
+            provider=self.provider,
+            capabilities=self.capabilities,
+        )
+
+    def _handle_execute(self, params: Any) -> ExecuteResult:
+        request = self._require_object(params, "provider.execute")
+        assert self.execute_handler is not None
+        return self.execute_handler(ExecuteRequest(
+            operation=request.get("operation", ""),
+            params=request.get("params", {}) if isinstance(request.get("params", {}), dict) else {},
+            token=request.get("token", ""),
+            meta=request.get("meta") if isinstance(request.get("meta"), dict) else None,
+        ))
+
+    def _handle_auth_start(self, params: Any) -> AuthStartResult:
+        if self.auth_start_handler is None:
+            raise ValueError("auth.start is not implemented")
+        request = self._require_object(params, "auth.start")
+        return self.auth_start_handler(AuthStartRequest(
+            state=request.get("state", ""),
+            scopes=list(request.get("scopes", [])),
+        ))
+
+    def _handle_auth_exchange_code(self, params: Any) -> TokenResult:
+        if self.auth_exchange_code_handler is None:
+            raise ValueError("auth.exchange_code is not implemented")
+        request = self._require_object(params, "auth.exchange_code")
+        return self.auth_exchange_code_handler(AuthExchangeRequest(
+            code=request.get("code", ""),
+            verifier=request.get("verifier"),
+        ))
+
+    def _handle_auth_refresh_token(self, params: Any) -> TokenResult:
+        if self.auth_refresh_token_handler is None:
+            raise ValueError("auth.refresh_token is not implemented")
+        request = self._require_object(params, "auth.refresh_token")
+        return self.auth_refresh_token_handler(AuthRefreshRequest(
+            refresh_token=request.get("refreshToken", ""),
+        ))
+
+    def _shutdown(self) -> None:
+        if self.on_shutdown is not None:
+            self.on_shutdown()
+
+
+def create_plugin(*, plugin_info: PluginInfo, provider: ProviderManifest, capabilities: Optional[Capabilities] = None) -> Plugin:
+    return Plugin(plugin_info=plugin_info, provider=provider, capabilities=capabilities)

--- a/sdk/plugin/rust/Cargo.toml
+++ b/sdk/plugin/rust/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "gestalt-plugin"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+

--- a/sdk/plugin/rust/README.md
+++ b/sdk/plugin/rust/README.md
@@ -1,0 +1,35 @@
+# Gestalt Plugin SDK for Rust
+
+This is a thin helper for implementing a Gestalt subprocess plugin in Rust.
+
+```rust
+use gestalt_plugin::{Capabilities, ExecuteRequest, ExecuteResult, Plugin, PluginInfo, ProviderManifest, OperationDef};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let plugin = Plugin::new(
+        PluginInfo { name: "loan-enrichment".into(), version: "0.1.0".into() },
+        ProviderManifest {
+            display_name: "Loan Enrichment".into(),
+            description: "Fetches enrichment data for a loan".into(),
+            connection_mode: "user".into(),
+            operations: vec![OperationDef {
+                name: "enrich_loan".into(),
+                description: "Fetch enrichment data".into(),
+                method: "POST".into(),
+                parameters: vec![],
+            }],
+            catalog: None,
+            auth: None,
+        },
+        |request: ExecuteRequest| -> Result<ExecuteResult, gestalt_plugin::PluginError> {
+            Ok(ExecuteResult { status: 200, body: format!("{{\"operation\":\"{}\"}}", request.operation) })
+        },
+    );
+
+    plugin.serve()
+}
+```
+
+The SDK reads framed JSON-RPC messages from stdin and writes responses to
+stdout. Use stderr for logs.
+

--- a/sdk/plugin/rust/src/lib.rs
+++ b/sdk/plugin/rust/src/lib.rs
@@ -1,0 +1,560 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::io::{self, BufRead, Write};
+
+pub const PROTOCOL_VERSION: &str = "gestalt-plugin/1";
+const JSONRPC_VERSION: &str = "2.0";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HostInfo {
+    pub name: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IntegrationInfo {
+    pub name: String,
+    pub config: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParameterDef {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default)]
+    pub default: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperationDef {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub method: String,
+    #[serde(default)]
+    pub parameters: Vec<ParameterDef>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogOperationDef {
+    pub id: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(rename = "inputSchema", default)]
+    pub input_schema: Value,
+    #[serde(default)]
+    pub parameters: Vec<ParameterDef>,
+    #[serde(rename = "requiredScopes", default)]
+    pub required_scopes: Vec<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(rename = "readOnly", default)]
+    pub read_only: bool,
+    #[serde(default)]
+    pub visible: Option<bool>,
+    #[serde(default)]
+    pub transport: String,
+    #[serde(default)]
+    pub query: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogDef {
+    pub name: String,
+    #[serde(rename = "displayName", default)]
+    pub display_name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(rename = "iconSvg", default)]
+    pub icon_svg: String,
+    #[serde(rename = "baseUrl", default)]
+    pub base_url: String,
+    #[serde(rename = "authStyle", default)]
+    pub auth_style: String,
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+    #[serde(default)]
+    pub operations: Vec<CatalogOperationDef>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderManifest {
+    #[serde(rename = "displayName")]
+    pub display_name: String,
+    pub description: String,
+    #[serde(rename = "connectionMode")]
+    pub connection_mode: String,
+    pub operations: Vec<OperationDef>,
+    #[serde(default)]
+    pub catalog: Option<Value>,
+    #[serde(default)]
+    pub auth: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginInfo {
+    pub name: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Capabilities {
+    #[serde(default)]
+    pub catalog: bool,
+    #[serde(default)]
+    pub oauth: bool,
+    #[serde(rename = "manualAuth", default)]
+    pub manual_auth: bool,
+    #[serde(default)]
+    pub cancellation: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InitializeRequest {
+    #[serde(rename = "protocolVersion")]
+    pub protocol_version: String,
+    #[serde(rename = "hostInfo")]
+    pub host_info: HostInfo,
+    pub integration: IntegrationInfo,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InitializeResult {
+    #[serde(rename = "protocolVersion")]
+    pub protocol_version: String,
+    #[serde(rename = "pluginInfo")]
+    pub plugin_info: PluginInfo,
+    pub provider: ProviderManifest,
+    #[serde(default)]
+    pub capabilities: Option<Capabilities>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecuteRequest {
+    pub operation: String,
+    pub params: Value,
+    pub token: String,
+    #[serde(default)]
+    pub meta: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecuteResult {
+    pub status: i32,
+    pub body: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthStartRequest {
+    pub state: String,
+    pub scopes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthStartResult {
+    #[serde(rename = "authUrl")]
+    pub auth_url: String,
+    #[serde(default)]
+    pub verifier: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthExchangeRequest {
+    pub code: String,
+    #[serde(default)]
+    pub verifier: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenResult {
+    #[serde(rename = "accessToken")]
+    pub access_token: String,
+    #[serde(rename = "refreshToken", default)]
+    pub refresh_token: Option<String>,
+    #[serde(rename = "expiresIn", default)]
+    pub expires_in: Option<i64>,
+    #[serde(rename = "tokenType", default)]
+    pub token_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthRefreshRequest {
+    #[serde(rename = "refreshToken")]
+    pub refresh_token: String,
+}
+
+#[derive(Debug)]
+pub struct PluginError {
+    pub message: String,
+}
+
+impl std::fmt::Display for PluginError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for PluginError {}
+
+impl From<&str> for PluginError {
+    fn from(message: &str) -> Self {
+        Self { message: message.to_string() }
+    }
+}
+
+impl From<String> for PluginError {
+    fn from(message: String) -> Self {
+        Self { message }
+    }
+}
+
+#[derive(Deserialize)]
+struct JsonRpcRequest {
+    #[serde(rename = "jsonrpc")]
+    _jsonrpc: Option<String>,
+    method: String,
+    #[serde(default)]
+    params: Value,
+    #[serde(default)]
+    id: Option<Value>,
+}
+
+#[derive(Serialize)]
+struct JsonRpcResponse {
+    jsonrpc: &'static str,
+    id: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<JsonRpcError>,
+}
+
+#[derive(Serialize)]
+struct JsonRpcError {
+    code: i32,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<Value>,
+}
+
+type InitializeHandler = Box<dyn Fn(InitializeRequest) -> Result<InitializeResult, PluginError> + Send + Sync>;
+type ExecuteHandler = Box<dyn Fn(ExecuteRequest) -> Result<ExecuteResult, PluginError> + Send + Sync>;
+type AuthStartHandler = Box<dyn Fn(AuthStartRequest) -> Result<AuthStartResult, PluginError> + Send + Sync>;
+type AuthExchangeHandler = Box<dyn Fn(AuthExchangeRequest) -> Result<TokenResult, PluginError> + Send + Sync>;
+type AuthRefreshHandler = Box<dyn Fn(AuthRefreshRequest) -> Result<TokenResult, PluginError> + Send + Sync>;
+type ShutdownHandler = Box<dyn Fn() -> Result<(), PluginError> + Send + Sync>;
+
+pub struct Plugin {
+    plugin_info: PluginInfo,
+    provider: ProviderManifest,
+    capabilities: Option<Capabilities>,
+    initialize_handler: Option<InitializeHandler>,
+    execute_handler: ExecuteHandler,
+    auth_start_handler: Option<AuthStartHandler>,
+    auth_exchange_handler: Option<AuthExchangeHandler>,
+    auth_refresh_handler: Option<AuthRefreshHandler>,
+    shutdown_handler: Option<ShutdownHandler>,
+}
+
+impl Plugin {
+    pub fn new<F>(
+        plugin_info: PluginInfo,
+        provider: ProviderManifest,
+        execute: F,
+    ) -> Self
+    where
+        F: Fn(ExecuteRequest) -> Result<ExecuteResult, PluginError> + Send + Sync + 'static,
+    {
+        Self {
+            plugin_info,
+            provider,
+            capabilities: None,
+            initialize_handler: None,
+            execute_handler: Box::new(execute),
+            auth_start_handler: None,
+            auth_exchange_handler: None,
+            auth_refresh_handler: None,
+            shutdown_handler: None,
+        }
+    }
+
+    pub fn capabilities(mut self, capabilities: Capabilities) -> Self {
+        self.capabilities = Some(capabilities);
+        self
+    }
+
+    pub fn on_initialize<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(InitializeRequest) -> Result<InitializeResult, PluginError> + Send + Sync + 'static,
+    {
+        self.initialize_handler = Some(Box::new(handler));
+        self
+    }
+
+    pub fn on_auth_start<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(AuthStartRequest) -> Result<AuthStartResult, PluginError> + Send + Sync + 'static,
+    {
+        self.auth_start_handler = Some(Box::new(handler));
+        self
+    }
+
+    pub fn on_auth_exchange_code<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(AuthExchangeRequest) -> Result<TokenResult, PluginError> + Send + Sync + 'static,
+    {
+        self.auth_exchange_handler = Some(Box::new(handler));
+        self
+    }
+
+    pub fn on_auth_refresh_token<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(AuthRefreshRequest) -> Result<TokenResult, PluginError> + Send + Sync + 'static,
+    {
+        self.auth_refresh_handler = Some(Box::new(handler));
+        self
+    }
+
+    pub fn on_shutdown<F>(mut self, handler: F) -> Self
+    where
+        F: Fn() -> Result<(), PluginError> + Send + Sync + 'static,
+    {
+        self.shutdown_handler = Some(Box::new(handler));
+        self
+    }
+
+    pub fn serve(self) -> Result<(), Box<dyn std::error::Error>> {
+        let stdin = io::stdin();
+        let stdout = io::stdout();
+        let mut reader = stdin.lock();
+        let mut writer = stdout.lock();
+        self.serve_with_io(&mut reader, &mut writer)
+    }
+
+    pub fn serve_with_io<R: BufRead, W: Write>(
+        self,
+        reader: &mut R,
+        writer: &mut W,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let plugin = self;
+        loop {
+            let body = match read_frame(reader)? {
+                Some(body) => body,
+                None => return Ok(()),
+            };
+            let request: JsonRpcRequest = match serde_json::from_slice(&body) {
+                Ok(request) => request,
+                Err(err) => {
+                    write_response(
+                        writer,
+                        JsonRpcResponse {
+                            jsonrpc: JSONRPC_VERSION,
+                            id: None,
+                            result: None,
+                            error: Some(JsonRpcError {
+                                code: -32700,
+                                message: "invalid JSON payload".to_string(),
+                                data: Some(json!(err.to_string())),
+                            }),
+                        },
+                    )?;
+                    continue;
+                }
+            };
+
+            if request.id.is_none() {
+                if request.method == "exit" {
+                    plugin.shutdown()?;
+                    return Ok(());
+                }
+                continue;
+            }
+
+            let id = request.id.clone();
+            let response = match request.method.as_str() {
+                "initialize" => match plugin.handle_initialize(request.params) {
+                    Ok(result) => JsonRpcResponse {
+                        jsonrpc: JSONRPC_VERSION,
+                        id,
+                        result: Some(serde_json::to_value(result)?),
+                        error: None,
+                    },
+                    Err(err) => error_response(id, -32603, err.to_string()),
+                },
+                "provider.execute" => match plugin.handle_execute(request.params) {
+                    Ok(result) => JsonRpcResponse {
+                        jsonrpc: JSONRPC_VERSION,
+                        id,
+                        result: Some(serde_json::to_value(result)?),
+                        error: None,
+                    },
+                    Err(err) => error_response(id, -32603, err.to_string()),
+                },
+                "auth.start" => match plugin.handle_auth_start(request.params) {
+                    Ok(result) => JsonRpcResponse {
+                        jsonrpc: JSONRPC_VERSION,
+                        id,
+                        result: Some(serde_json::to_value(result)?),
+                        error: None,
+                    },
+                    Err(err) => error_response(id, -32603, err.to_string()),
+                },
+                "auth.exchange_code" => match plugin.handle_auth_exchange_code(request.params) {
+                    Ok(result) => JsonRpcResponse {
+                        jsonrpc: JSONRPC_VERSION,
+                        id,
+                        result: Some(serde_json::to_value(result)?),
+                        error: None,
+                    },
+                    Err(err) => error_response(id, -32603, err.to_string()),
+                },
+                "auth.refresh_token" => match plugin.handle_auth_refresh_token(request.params) {
+                    Ok(result) => JsonRpcResponse {
+                        jsonrpc: JSONRPC_VERSION,
+                        id,
+                        result: Some(serde_json::to_value(result)?),
+                        error: None,
+                    },
+                    Err(err) => error_response(id, -32603, err.to_string()),
+                },
+                "shutdown" => JsonRpcResponse {
+                    jsonrpc: JSONRPC_VERSION,
+                    id,
+                    result: Some(Value::Null),
+                    error: None,
+                }
+                _ => error_response(id, -32601, format!("method not found: {}", request.method)),
+            };
+
+            write_response(writer, response)?;
+            if request.method == "shutdown" {
+                plugin.shutdown()?;
+                return Ok(());
+            }
+        }
+    }
+
+    fn shutdown(&self) -> Result<(), Box<dyn std::error::Error>> {
+        if let Some(handler) = &self.shutdown_handler {
+            handler()?;
+        }
+        Ok(())
+    }
+
+    fn handle_initialize(&self, params: Value) -> Result<InitializeResult, PluginError> {
+        let request = deserialize_params::<InitializeRequest>(params, "initialize")?;
+        if let Some(handler) = &self.initialize_handler {
+            return handler(request);
+        }
+        Ok(InitializeResult {
+            protocol_version: PROTOCOL_VERSION.to_string(),
+            plugin_info: self.plugin_info.clone(),
+            provider: self.provider.clone(),
+            capabilities: self.capabilities.clone(),
+        })
+    }
+
+    fn handle_execute(&self, params: Value) -> Result<ExecuteResult, PluginError> {
+        let request = deserialize_params::<ExecuteRequest>(params, "provider.execute")?;
+        (self.execute_handler)(request)
+    }
+
+    fn handle_auth_start(&self, params: Value) -> Result<AuthStartResult, PluginError> {
+        let request = deserialize_params::<AuthStartRequest>(params, "auth.start")?;
+        let handler = self
+            .auth_start_handler
+            .as_ref()
+            .ok_or_else(|| PluginError::from("auth.start is not implemented"))?;
+        handler(request)
+    }
+
+    fn handle_auth_exchange_code(&self, params: Value) -> Result<TokenResult, PluginError> {
+        let request = deserialize_params::<AuthExchangeRequest>(params, "auth.exchange_code")?;
+        let handler = self
+            .auth_exchange_handler
+            .as_ref()
+            .ok_or_else(|| PluginError::from("auth.exchange_code is not implemented"))?;
+        handler(request)
+    }
+
+    fn handle_auth_refresh_token(&self, params: Value) -> Result<TokenResult, PluginError> {
+        let request = deserialize_params::<AuthRefreshRequest>(params, "auth.refresh_token")?;
+        let handler = self
+            .auth_refresh_handler
+            .as_ref()
+            .ok_or_else(|| PluginError::from("auth.refresh_token is not implemented"))?;
+        handler(request)
+    }
+}
+
+fn deserialize_params<T: for<'de> Deserialize<'de>>(params: Value, method: &str) -> Result<T, PluginError> {
+    if !params.is_object() {
+        return Err(PluginError::from(format!("{} requires a JSON object", method)));
+    }
+    serde_json::from_value(params).map_err(|err| PluginError::from(err.to_string()))
+}
+
+fn read_frame<R: BufRead>(reader: &mut R) -> io::Result<Option<Vec<u8>>> {
+    let mut content_length: Option<usize> = None;
+    loop {
+        let mut line = String::new();
+        let bytes = reader.read_line(&mut line)?;
+        if bytes == 0 {
+            return Ok(None);
+        }
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            break;
+        }
+        if let Some((key, value)) = trimmed.split_once(':') {
+            if key.trim().eq_ignore_ascii_case("Content-Length") {
+                content_length = Some(value.trim().parse().map_err(|_| {
+                    io::Error::new(io::ErrorKind::InvalidData, "invalid Content-Length header")
+                })?);
+            }
+        }
+    }
+    let length = match content_length {
+        Some(length) => length,
+        None => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "missing Content-Length header",
+            ))
+        }
+    };
+    let mut body = vec![0u8; length];
+    reader.read_exact(&mut body)?;
+    Ok(Some(body))
+}
+
+fn write_response<W: Write>(writer: &mut W, response: JsonRpcResponse) -> io::Result<()> {
+    let body = serde_json::to_vec(&response)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
+    write!(writer, "Content-Length: {}\r\n\r\n", body.len())?;
+    writer.write_all(&body)?;
+    writer.flush()?;
+    Ok(())
+}
+
+fn error_response(id: Option<Value>, code: i32, message: String) -> JsonRpcResponse {
+    JsonRpcResponse {
+        jsonrpc: JSONRPC_VERSION,
+        id,
+        result: None,
+        error: Some(JsonRpcError {
+            code,
+            message,
+            data: None,
+        }),
+    }
+}

--- a/sdk/plugin/typescript/README.md
+++ b/sdk/plugin/typescript/README.md
@@ -1,0 +1,38 @@
+# Gestalt Plugin SDK for TypeScript
+
+This is a thin helper for implementing a Gestalt subprocess plugin in
+TypeScript.
+
+```ts
+import { createPlugin } from "./index";
+
+createPlugin({
+  pluginInfo: { name: "loan-enrichment", version: "0.1.0" },
+  provider: {
+    displayName: "Loan Enrichment",
+    description: "Fetches enrichment data for a loan",
+    connectionMode: "user",
+    operations: [
+      {
+        name: "enrich_loan",
+        description: "Fetch enrichment data",
+        method: "POST",
+        parameters: [{ name: "loan_id", type: "string", required: true }],
+      },
+    ],
+  },
+  async execute(request) {
+    return {
+      status: 200,
+      body: JSON.stringify({ operation: request.operation, params: request.params }),
+    };
+  },
+}).serve().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+```
+
+The SDK reads framed JSON-RPC messages from stdin and writes responses to
+stdout. Use stderr for logs.
+

--- a/sdk/plugin/typescript/index.ts
+++ b/sdk/plugin/typescript/index.ts
@@ -1,0 +1,534 @@
+declare const process: any;
+declare const Buffer: any;
+
+export const PROTOCOL_VERSION = "gestalt-plugin/1";
+
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export type JsonObject = Record<string, unknown>;
+
+export interface HostInfo {
+  name: string;
+  version: string;
+}
+
+export interface IntegrationInfo {
+  name: string;
+  config: JsonObject;
+}
+
+export interface ParameterDef {
+  name: string;
+  type: string;
+  description?: string;
+  required?: boolean;
+  default?: unknown;
+}
+
+export interface OperationDef {
+  name: string;
+  description?: string;
+  method?: string;
+  parameters?: ParameterDef[];
+}
+
+export interface CatalogOperationDef {
+  id: string;
+  title?: string;
+  description?: string;
+  inputSchema?: JsonValue;
+  parameters?: ParameterDef[];
+  requiredScopes?: string[];
+  tags?: string[];
+  readOnly?: boolean;
+  visible?: boolean;
+  transport?: string;
+  query?: string;
+}
+
+export interface CatalogDef {
+  name: string;
+  displayName?: string;
+  description?: string;
+  iconSvg?: string;
+  baseUrl?: string;
+  authStyle?: string;
+  headers?: Record<string, string>;
+  operations: CatalogOperationDef[];
+}
+
+export type ConnectionMode = "none" | "user" | "identity" | "either";
+
+export interface ProviderManifest {
+  displayName: string;
+  description: string;
+  connectionMode: ConnectionMode;
+  operations: OperationDef[];
+  catalog?: CatalogDef | JsonObject;
+  auth?: JsonObject;
+}
+
+export interface PluginInfo {
+  name: string;
+  version: string;
+}
+
+export interface Capabilities {
+  catalog?: boolean;
+  oauth?: boolean;
+  manualAuth?: boolean;
+  cancellation?: boolean;
+}
+
+export interface InitializeRequest {
+  protocolVersion: string;
+  hostInfo: HostInfo;
+  integration: IntegrationInfo;
+}
+
+export interface InitializeResult {
+  protocolVersion: string;
+  pluginInfo: PluginInfo;
+  provider: ProviderManifest;
+  capabilities?: Capabilities;
+}
+
+export interface ExecuteRequest {
+  operation: string;
+  params: JsonObject;
+  token: string;
+  meta?: JsonObject;
+}
+
+export interface ExecuteResult {
+  status: number;
+  body: string;
+}
+
+export interface AuthStartRequest {
+  state: string;
+  scopes: string[];
+}
+
+export interface AuthStartResult {
+  authUrl: string;
+  verifier?: string;
+}
+
+export interface AuthExchangeRequest {
+  code: string;
+  verifier?: string;
+}
+
+export interface TokenResult {
+  accessToken: string;
+  refreshToken?: string;
+  expiresIn?: number;
+  tokenType?: string;
+}
+
+export interface AuthRefreshRequest {
+  refreshToken: string;
+}
+
+export interface PluginDefinition {
+  pluginInfo: PluginInfo;
+  provider: ProviderManifest;
+  capabilities?: Capabilities;
+  initialize?(request: InitializeRequest): Promise<InitializeResult> | InitializeResult;
+  execute(request: ExecuteRequest): Promise<ExecuteResult> | ExecuteResult;
+  auth?: {
+    start?(request: AuthStartRequest): Promise<AuthStartResult> | AuthStartResult;
+    exchangeCode?(request: AuthExchangeRequest): Promise<TokenResult> | TokenResult;
+    refreshToken?(request: AuthRefreshRequest): Promise<TokenResult> | TokenResult;
+  };
+  onShutdown?(): Promise<void> | void;
+}
+
+export interface JsonRpcRequest {
+  jsonrpc?: string;
+  method: string;
+  params?: unknown;
+  id?: string | number | null;
+}
+
+export interface JsonRpcError {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  result?: unknown;
+  error?: JsonRpcError;
+}
+
+const JSONRPC_VERSION = "2.0";
+
+const ERR_PARSE = -32700;
+const ERR_INVALID_REQUEST = -32600;
+const ERR_METHOD_NOT_FOUND = -32601;
+const ERR_INVALID_PARAMS = -32602;
+const ERR_INTERNAL = -32603;
+
+class StdioJsonRpcReader {
+  private buffer = Buffer.alloc(0);
+  private queue: any[] = [];
+  private waiters: Array<{
+    resolve: (value: any | null) => void;
+    reject: (reason: Error) => void;
+  }> = [];
+  private closed = false;
+  private failure: Error | null = null;
+
+  constructor(stream: any) {
+    stream.on("data", (chunk: any) => {
+      this.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+    stream.on("end", () => this.finish());
+    stream.on("close", () => this.finish());
+    stream.on("error", (err: Error) => this.fail(err));
+  }
+
+  read(): Promise<any | null> {
+    if (this.queue.length > 0) {
+      return Promise.resolve(this.queue.shift() ?? null);
+    }
+    if (this.failure) {
+      return Promise.reject(this.failure);
+    }
+    if (this.closed) {
+      return Promise.resolve(null);
+    }
+    return new Promise((resolve, reject) => {
+      this.waiters.push({ resolve, reject });
+    });
+  }
+
+  private push(chunk: any): void {
+    if (this.closed || this.failure) {
+      return;
+    }
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    this.pump();
+  }
+
+  private finish(): void {
+    this.closed = true;
+    this.drainWaiters(null);
+  }
+
+  private fail(err: Error): void {
+    if (this.failure) {
+      return;
+    }
+    this.failure = err;
+    while (this.waiters.length > 0) {
+      const waiter = this.waiters.shift();
+      if (waiter) {
+        waiter.reject(err);
+      }
+    }
+  }
+
+  private drainWaiters(value: any | null): void {
+    while (this.waiters.length > 0 && this.queue.length > 0) {
+      const waiter = this.waiters.shift();
+      const item = this.queue.shift();
+      if (waiter) {
+        waiter.resolve(item ?? value);
+      }
+    }
+    if (value === null && this.waiters.length > 0) {
+      while (this.waiters.length > 0) {
+        const waiter = this.waiters.shift();
+        if (waiter) {
+          waiter.resolve(null);
+        }
+      }
+    }
+  }
+
+  private pump(): void {
+    while (true) {
+      const frame = this.nextFrame();
+      if (frame === null) {
+        return;
+      }
+      if (this.waiters.length > 0) {
+        const waiter = this.waiters.shift();
+        if (waiter) {
+          waiter.resolve(frame);
+        }
+      } else {
+        this.queue.push(frame);
+      }
+    }
+  }
+
+  private nextFrame(): any | null {
+    const crlf = this.buffer.indexOf("\r\n\r\n");
+    const lf = this.buffer.indexOf("\n\n");
+    let boundary = -1;
+    let separatorLength = 0;
+
+    if (crlf >= 0 && (lf < 0 || crlf < lf)) {
+      boundary = crlf;
+      separatorLength = 4;
+    } else if (lf >= 0) {
+      boundary = lf;
+      separatorLength = 2;
+    }
+
+    if (boundary < 0) {
+      return null;
+    }
+
+    const headerText = this.buffer.slice(0, boundary).toString("utf8");
+    const contentLength = parseContentLength(headerText);
+    if (contentLength === null) {
+      this.fail(new Error("missing Content-Length header"));
+      return null;
+    }
+
+    const bodyStart = boundary + separatorLength;
+    const bodyEnd = bodyStart + contentLength;
+    if (this.buffer.length < bodyEnd) {
+      return null;
+    }
+
+    const frame = this.buffer.slice(bodyStart, bodyEnd);
+    this.buffer = this.buffer.slice(bodyEnd);
+    return frame;
+  }
+}
+
+function parseContentLength(headers: string): number | null {
+  for (const line of headers.split(/\r?\n/)) {
+    const match = /^Content-Length:\s*(\d+)$/i.exec(line.trim());
+    if (match) {
+      return Number.parseInt(match[1] ?? "", 10);
+    }
+  }
+  return null;
+}
+
+async function writeFrame(stream: any, value: unknown): Promise<void> {
+  const body = Buffer.from(JSON.stringify(value), "utf8");
+  const header = Buffer.from(`Content-Length: ${body.length}\r\n\r\n`, "utf8");
+  if (!stream.write(header)) {
+    await onceDrain(stream);
+  }
+  if (!stream.write(body)) {
+    await onceDrain(stream);
+  }
+}
+
+function onceDrain(stream: any): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onDrain = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+    const cleanup = () => {
+      stream.off("drain", onDrain);
+      stream.off("error", onError);
+    };
+    stream.once("drain", onDrain);
+    stream.once("error", onError);
+  });
+}
+
+function errorResponse(id: string | number | null, code: number, message: string, data?: unknown): JsonRpcResponse {
+  return { jsonrpc: JSONRPC_VERSION, id, error: { code, message, data } };
+}
+
+function successResponse(id: string | number | null, result: unknown): JsonRpcResponse {
+  return { jsonrpc: JSONRPC_VERSION, id, result };
+}
+
+async function maybeAsync<T>(value: T | Promise<T>): Promise<T> {
+  return await value;
+}
+
+export class PluginRuntime {
+  private readonly definition: PluginDefinition;
+  private readonly input: any;
+  private readonly output: any;
+  private readonly stderr: any;
+
+  constructor(
+    definition: PluginDefinition,
+    input: any = process.stdin,
+    output: any = process.stdout,
+    stderr: any = process.stderr,
+  ) {
+    this.definition = definition;
+    this.input = input;
+    this.output = output;
+    this.stderr = stderr;
+  }
+
+  async serve(): Promise<void> {
+    const reader = new StdioJsonRpcReader(this.input);
+    while (true) {
+      const raw = await reader.read();
+      if (raw === null) {
+        break;
+      }
+
+      let message: JsonRpcRequest;
+      try {
+        message = JSON.parse(raw.toString("utf8")) as JsonRpcRequest;
+      } catch (error) {
+        await this.reply(null, errorResponse(null, ERR_PARSE, "invalid JSON payload", String(error)));
+        continue;
+      }
+
+      if (!message || typeof message.method !== "string") {
+        await this.reply(message?.id ?? null, errorResponse(message?.id ?? null, ERR_INVALID_REQUEST, "invalid JSON-RPC request"));
+        continue;
+      }
+
+      if (message.id === undefined) {
+        const shouldExit = await this.handleNotification(message);
+        if (shouldExit) {
+          break;
+        }
+        continue;
+      }
+
+      const shouldExit = await this.handleRequest(message);
+      if (shouldExit) {
+        break;
+      }
+    }
+  }
+
+  private async handleNotification(message: JsonRpcRequest): Promise<boolean> {
+    if (message.method === "exit") {
+      await this.shutdown();
+      return true;
+    }
+    return false;
+  }
+
+  private async handleRequest(message: JsonRpcRequest): Promise<boolean> {
+    const id = message.id ?? null;
+    try {
+      switch (message.method) {
+        case "initialize":
+          await this.reply(id, successResponse(id, await this.handleInitialize(message.params)));
+          return false;
+        case "provider.execute":
+          await this.reply(id, successResponse(id, await this.handleExecute(message.params)));
+          return false;
+        case "auth.start":
+          await this.reply(id, successResponse(id, await this.handleAuthStart(message.params)));
+          return false;
+        case "auth.exchange_code":
+          await this.reply(id, successResponse(id, await this.handleAuthExchangeCode(message.params)));
+          return false;
+        case "auth.refresh_token":
+          await this.reply(id, successResponse(id, await this.handleAuthRefreshToken(message.params)));
+          return false;
+        case "shutdown":
+          await this.reply(id, successResponse(id, null));
+          await this.shutdown();
+          return true;
+        default:
+          await this.reply(id, errorResponse(id, ERR_METHOD_NOT_FOUND, `method not found: ${message.method}`));
+          return false;
+      }
+    } catch (error) {
+      await this.reply(id, errorResponse(id, ERR_INTERNAL, error instanceof Error ? error.message : String(error)));
+    }
+    return false;
+  }
+
+  private async handleInitialize(params: unknown): Promise<InitializeResult> {
+    const request = this.requireParams<InitializeRequest>(params, "initialize");
+    if (this.definition.initialize) {
+      return await maybeAsync(this.definition.initialize(request));
+    }
+    return {
+      protocolVersion: PROTOCOL_VERSION,
+      pluginInfo: this.definition.pluginInfo,
+      provider: this.definition.provider,
+      capabilities: this.definition.capabilities,
+    };
+  }
+
+  private async handleExecute(params: unknown): Promise<ExecuteResult> {
+    const request = this.requireParams<ExecuteRequest>(params, "provider.execute");
+    return await maybeAsync(this.definition.execute(request));
+  }
+
+  private async handleAuthStart(params: unknown): Promise<AuthStartResult> {
+    const request = this.requireParams<AuthStartRequest>(params, "auth.start");
+    const handler = this.definition.auth?.start;
+    if (!handler) {
+      throw new Error("auth.start is not implemented");
+    }
+    return await maybeAsync(handler(request));
+  }
+
+  private async handleAuthExchangeCode(params: unknown): Promise<TokenResult> {
+    const request = this.requireParams<AuthExchangeRequest>(params, "auth.exchange_code");
+    const handler = this.definition.auth?.exchangeCode;
+    if (!handler) {
+      throw new Error("auth.exchange_code is not implemented");
+    }
+    return await maybeAsync(handler(request));
+  }
+
+  private async handleAuthRefreshToken(params: unknown): Promise<TokenResult> {
+    const request = this.requireParams<AuthRefreshRequest>(params, "auth.refresh_token");
+    const handler = this.definition.auth?.refreshToken;
+    if (!handler) {
+      throw new Error("auth.refresh_token is not implemented");
+    }
+    return await maybeAsync(handler(request));
+  }
+
+  private requireParams<T>(params: unknown, method: string): T {
+    if (!params || typeof params !== "object") {
+      throw new Error(`${method} requires a JSON object`);
+    }
+    return params as T;
+  }
+
+  private async reply(id: string | number | null, response: JsonRpcResponse): Promise<void> {
+    if (id === null && response.error) {
+      await writeFrame(this.output, response);
+      return;
+    }
+    await writeFrame(this.output, response);
+  }
+
+  private async shutdown(): Promise<void> {
+    if (this.definition.onShutdown) {
+      await maybeAsync(this.definition.onShutdown());
+    }
+  }
+}
+
+export function createPlugin(definition: PluginDefinition): PluginRuntime {
+  return new PluginRuntime(definition);
+}
+
+export async function servePlugin(definition: PluginDefinition): Promise<void> {
+  await createPlugin(definition).serve();
+}


### PR DESCRIPTION
This adds a `plugin` integration backend that lets Gestalt launch a managed child process and treat it like a normal provider, so custom integrations written in TypeScript, Python, or Rust are invokable through the existing REST and MCP surfaces.

This also documents the `gestalt-plugin/1` protocol, includes starter SDKs for TypeScript, Python, and Rust, and adds end to end coverage for execution, manual auth, and OAuth so the cross language path is exercised with the same provider semantics as in process Go implementations.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
