### PR TITLE
Defer provider initialization to unblock HTTP server startup

### DIFF
--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/valon-technologies/gestalt/core"
@@ -42,39 +43,13 @@ func run(args []string) error {
 	}
 	defer env.Close()
 
-	if err := startPlugins(env); err != nil {
-		return err
-	}
-	defer func() {
-		ctx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
-		defer cancel()
-		shutdownPlugins(ctx, env)
-	}()
-
 	result := env.Result
 
+	var mcpSlot *lateHandler
 	var mcpHandler http.Handler
 	if env.Config.MCP.Enabled {
-		broker, ok := result.Invoker.(*invocation.Broker)
-		if !ok {
-			return fmt.Errorf("MCP token resolution requires *invocation.Broker as invoker")
-		}
-		mcpCfg := gestaltmcp.Config{
-			Invoker:       result.Invoker,
-			TokenResolver: broker,
-			Providers:     result.Providers,
-		}
-		if env.Config.MCP.Providers != nil {
-			mcpCfg.AllowedProviders = env.Config.MCP.Providers
-		}
-		if env.Config.MCP.ToolNamePrefix != "" {
-			mcpCfg.ToolNamePrefix = env.Config.MCP.ToolNamePrefix
-		}
-		mcpHandler = mcpserver.NewStreamableHTTPServer(
-			gestaltmcp.NewServer(mcpCfg),
-			mcpserver.WithStateLess(true),
-		)
-		log.Println("MCP endpoint enabled at /mcp")
+		mcpSlot = &lateHandler{}
+		mcpHandler = mcpSlot
 	}
 
 	srv, err := server.New(server.Config{
@@ -114,21 +89,63 @@ func run(args []string) error {
 		}
 	}()
 
+	pluginsStarted := false
+	defer func() {
+		drainCtx, drainCancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
+		defer drainCancel()
+		if err := httpServer.Shutdown(drainCtx); err != nil {
+			log.Printf("server shutdown: %v", err)
+		}
+		if pluginsStarted {
+			pluginCtx, pluginCancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
+			defer pluginCancel()
+			shutdownPlugins(pluginCtx, env)
+		}
+	}()
+
+	select {
+	case <-result.ProvidersReady:
+		log.Printf("all providers ready (%d loaded)", len(result.Providers.List()))
+	case err := <-listenErr:
+		return fmt.Errorf("http server: %v", err)
+	case <-env.Ctx.Done():
+		return nil
+	}
+
+	if err := startPlugins(env); err != nil {
+		return err
+	}
+	pluginsStarted = true
+
+	if mcpSlot != nil {
+		broker, ok := result.Invoker.(*invocation.Broker)
+		if !ok {
+			return fmt.Errorf("MCP token resolution requires *invocation.Broker as invoker")
+		}
+		mcpCfg := gestaltmcp.Config{
+			Invoker:       result.Invoker,
+			TokenResolver: broker,
+			Providers:     result.Providers,
+		}
+		if env.Config.MCP.Providers != nil {
+			mcpCfg.AllowedProviders = env.Config.MCP.Providers
+		}
+		if env.Config.MCP.ToolNamePrefix != "" {
+			mcpCfg.ToolNamePrefix = env.Config.MCP.ToolNamePrefix
+		}
+		mcpSlot.Set(mcpserver.NewStreamableHTTPServer(
+			gestaltmcp.NewServer(mcpCfg),
+			mcpserver.WithStateLess(true),
+		))
+		log.Println("MCP endpoint enabled at /mcp")
+	}
+
 	select {
 	case err := <-listenErr:
 		return fmt.Errorf("http server: %v", err)
 	case <-env.Ctx.Done():
 	}
-	log.Println("shutting down...")
 
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
-	defer cancel()
-
-	if err := httpServer.Shutdown(shutdownCtx); err != nil {
-		log.Printf("server shutdown: %v", err)
-	}
-
-	log.Println("shutdown complete")
 	return nil
 }
 
@@ -227,4 +244,26 @@ func stopRuntimes(ctx context.Context, runtimes *registry.PluginMap[core.Runtime
 			log.Printf("stopping runtime %q: %v", name, err)
 		}
 	}
+}
+
+type lateHandler struct {
+	mu      sync.RWMutex
+	handler http.Handler
+}
+
+func (h *lateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.mu.RLock()
+	inner := h.handler
+	h.mu.RUnlock()
+	if inner == nil {
+		http.Error(w, "service starting", http.StatusServiceUnavailable)
+		return
+	}
+	inner.ServeHTTP(w, r)
+}
+
+func (h *lateHandler) Set(handler http.Handler) {
+	h.mu.Lock()
+	h.handler = handler
+	h.mu.Unlock()
 }

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -65,6 +65,7 @@ type Result struct {
 	Auth             core.AuthProvider
 	Datastore        core.Datastore
 	Providers        *registry.PluginMap[core.Provider]
+	ProvidersReady   <-chan struct{}
 	Runtimes         *registry.PluginMap[core.Runtime]
 	Bindings         *registry.PluginMap[core.Binding]
 	Invoker          invocation.Invoker
@@ -108,7 +109,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		return nil, err
 	}
 
-	providers, err := buildProviders(ctx, cfg, factories, deps)
+	providers, providersReady, err := buildProviders(ctx, cfg, factories, deps)
 	if err != nil {
 		return nil, err
 	}
@@ -131,6 +132,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		Auth:             auth,
 		Datastore:        ds,
 		Providers:        providers,
+		ProvidersReady:   providersReady,
 		Runtimes:         runtimes,
 		Bindings:         bindings,
 		Invoker:          sharedInvoker,
@@ -334,55 +336,56 @@ func buildDatastore(cfg *config.Config, factories *FactoryRegistry, deps Deps) (
 	return ds, nil
 }
 
-func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.PluginMap[core.Provider], error) {
-	providers := make(map[string]core.Provider, len(cfg.Integrations))
-	var mu sync.Mutex
-
-	if len(cfg.Integrations) > 0 {
-		var wg sync.WaitGroup
-		for name := range cfg.Integrations {
-			intgDef := cfg.Integrations[name]
-			factory, ok := factories.Providers[name]
-			if !ok {
-				factory = factories.DefaultProvider
-			}
-			if factory == nil {
-				return nil, fmt.Errorf("bootstrap: no provider factory for %q and no default factory registered", name)
-			}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				prov, err := factory(ctx, name, intgDef, deps)
-				if err != nil {
-					log.Printf("WARNING: skipping provider %q: %v", name, err)
-					return
-				}
-				mu.Lock()
-				providers[name] = prov
-				mu.Unlock()
-			}()
-		}
-		wg.Wait()
-	}
-
+func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.PluginMap[core.Provider], <-chan struct{}, error) {
 	reg := registry.New()
-	for name, prov := range providers {
-		if err := reg.Providers.Register(name, prov); err != nil {
-			return nil, fmt.Errorf("bootstrap: registering provider %q: %w", name, err)
-		}
-		log.Printf("loaded provider %s (%d operations)", name, len(prov.ListOperations()))
-	}
 
 	for _, builtin := range factories.Builtins {
 		if err := reg.Providers.Register(builtin.Name(), builtin); errors.Is(err, core.ErrAlreadyRegistered) {
 			continue
 		} else if err != nil {
-			return nil, fmt.Errorf("bootstrap: registering builtin %q: %w", builtin.Name(), err)
+			return nil, nil, fmt.Errorf("bootstrap: registering builtin %q: %w", builtin.Name(), err)
 		}
 		log.Printf("loaded builtin provider %s (%d operations)", builtin.Name(), len(builtin.ListOperations()))
 	}
 
-	return &reg.Providers, nil
+	ready := make(chan struct{})
+	if len(cfg.Integrations) == 0 {
+		close(ready)
+		return &reg.Providers, ready, nil
+	}
+
+	var wg sync.WaitGroup
+	for name := range cfg.Integrations {
+		intgDef := cfg.Integrations[name]
+		factory, ok := factories.Providers[name]
+		if !ok {
+			factory = factories.DefaultProvider
+		}
+		if factory == nil {
+			close(ready)
+			return nil, nil, fmt.Errorf("bootstrap: no provider factory for %q and no default factory registered", name)
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			prov, err := factory(ctx, name, intgDef, deps)
+			if err != nil {
+				log.Printf("WARNING: skipping provider %q: %v", name, err)
+				return
+			}
+			if err := reg.Providers.Register(name, prov); err != nil {
+				log.Printf("WARNING: registering provider %q: %v", name, err)
+				return
+			}
+			log.Printf("loaded provider %s (%d operations)", name, len(prov.ListOperations()))
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(ready)
+	}()
+
+	return &reg.Providers, ready, nil
 }
 
 func buildRuntimes(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink) (*registry.PluginMap[core.Runtime], error) {

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -92,6 +92,7 @@ func TestBootstrap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
+	<-result.ProvidersReady
 	if result.Auth == nil {
 		t.Fatal("Auth is nil")
 	}
@@ -118,6 +119,7 @@ func TestBootstrap(t *testing.T) {
 	if invoker != lister {
 		t.Fatal("expected shared invoker and capability lister to be the same instance")
 	}
+	<-result.ProvidersReady
 	names := result.Providers.List()
 	if len(names) != 1 || names[0] != "alpha" {
 		t.Errorf("Providers.List: got %v, want [alpha]", names)
@@ -138,6 +140,8 @@ func TestBootstrapMultipleProviders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
+	<-result.ProvidersReady
+	<-result.ProvidersReady
 	names := result.Providers.List()
 	if len(names) != 2 {
 		t.Fatalf("Providers.List: got %d items, want 2", len(names))
@@ -155,6 +159,8 @@ func TestBootstrapNoIntegrations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
+	<-result.ProvidersReady
+	<-result.ProvidersReady
 	if got := result.Providers.List(); len(got) != 0 {
 		t.Errorf("expected empty providers, got %v", got)
 	}
@@ -171,6 +177,7 @@ func TestBootstrapDevMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
+	<-result.ProvidersReady
 	if !result.DevMode {
 		t.Error("DevMode: got false, want true")
 	}
@@ -191,6 +198,8 @@ func TestBootstrapDefaultProviderFactory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
+	<-result.ProvidersReady
+	<-result.ProvidersReady
 	names := result.Providers.List()
 	if len(names) != 1 || names[0] != "alpha" {
 		t.Errorf("Providers.List: got %v, want [alpha]", names)
@@ -215,6 +224,8 @@ func TestBootstrapNamedOverridesDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
+	<-result.ProvidersReady
+	<-result.ProvidersReady
 	names := result.Providers.List()
 	if len(names) != 1 || names[0] != "alpha" {
 		t.Errorf("Providers.List: got %v, want [alpha]", names)
@@ -317,6 +328,8 @@ func TestBootstrapProviderErrorSkipsProvider(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Bootstrap should succeed when a provider fails: %v", err)
 	}
+	<-result.ProvidersReady
+	<-result.ProvidersReady
 	names := result.Providers.List()
 	if len(names) != 1 || names[0] != "alpha" {
 		t.Errorf("Providers.List: got %v, want [alpha] (beta should be skipped)", names)
@@ -340,9 +353,11 @@ func TestBootstrapEncryptionKeyDerivation(t *testing.T) {
 		cfg := validConfig()
 		cfg.Server.EncryptionKey = "my-passphrase"
 
-		if _, err := bootstrap.Bootstrap(ctx, cfg, factories); err != nil {
+		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
 			t.Fatalf("Bootstrap: %v", err)
 		}
+		<-result.ProvidersReady
 		if len(receivedKey) != 32 {
 			t.Errorf("key length: got %d, want 32", len(receivedKey))
 		}
@@ -367,9 +382,11 @@ func TestBootstrapEncryptionKeyDerivation(t *testing.T) {
 		cfg := validConfig()
 		cfg.Server.EncryptionKey = hexKey
 
-		if _, err := bootstrap.Bootstrap(ctx, cfg, factories); err != nil {
+		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
 			t.Fatalf("Bootstrap: %v", err)
 		}
+		<-result.ProvidersReady
 		if hex.EncodeToString(receivedKey) != hexKey {
 			t.Errorf("hex key not decoded: got %x, want %x", receivedKey, want)
 		}
@@ -387,9 +404,11 @@ func TestBootstrapEncryptionKeyDerivation(t *testing.T) {
 			}
 			cfg := validConfig()
 			cfg.Server.EncryptionKey = "deterministic"
-			if _, err := bootstrap.Bootstrap(ctx, cfg, factories); err != nil {
+			result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+			if err != nil {
 				t.Fatalf("Bootstrap: %v", err)
 			}
+			<-result.ProvidersReady
 		}
 		if hex.EncodeToString(keys[0]) != hex.EncodeToString(keys[1]) {
 			t.Error("key derivation is not deterministic")
@@ -435,9 +454,11 @@ integrations:
 		t.Fatalf("config.Load: %v", err)
 	}
 
-	if _, err := bootstrap.Bootstrap(context.Background(), cfg, factories); err != nil {
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
+	<-result.ProvidersReady
 
 	if receivedBaseURL != "https://gestalt.example.com" {
 		t.Errorf("auth factory deps.BaseURL = %q, want %q", receivedBaseURL, "https://gestalt.example.com")
@@ -466,7 +487,9 @@ func TestBootstrapAllowedOperations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
+	<-result.ProvidersReady
 
+	<-result.ProvidersReady
 	prov, err := result.Providers.Get("alpha")
 	if err != nil {
 		t.Fatalf("provider 'alpha' not found: %v", err)
@@ -498,9 +521,11 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		cfg := validConfig()
 		cfg.Server.EncryptionKey = "secret://enc-key"
 
-		if _, err := bootstrap.Bootstrap(ctx, cfg, factories); err != nil {
+		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
 			t.Fatalf("Bootstrap: %v", err)
 		}
+		<-result.ProvidersReady
 		if len(receivedKey) != 32 {
 			t.Errorf("key length: got %d, want 32", len(receivedKey))
 		}
@@ -526,9 +551,11 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		intg.ClientSecret = "secret://slack-secret"
 		cfg.Integrations["alpha"] = intg
 
-		if _, err := bootstrap.Bootstrap(ctx, cfg, factories); err != nil {
+		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
 			t.Fatalf("Bootstrap: %v", err)
 		}
+		<-result.ProvidersReady
 		if receivedDef.ClientSecret != "resolved-secret" {
 			t.Errorf("ClientSecret: got %q, want %q", receivedDef.ClientSecret, "resolved-secret")
 		}
@@ -544,6 +571,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Bootstrap: %v", err)
 		}
+		<-result.ProvidersReady
 		if result.Auth == nil {
 			t.Fatal("Auth is nil")
 		}
@@ -612,9 +640,11 @@ func TestBootstrapSecretResolution(t *testing.T) {
 			},
 		}
 
-		if _, err := bootstrap.Bootstrap(ctx, cfg, factories); err != nil {
+		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
 			t.Fatalf("Bootstrap: %v", err)
 		}
+		<-result.ProvidersReady
 
 		// The resolved node should have the value replaced.
 		var decoded map[string]string
@@ -633,6 +663,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Bootstrap: %v", err)
 		}
+		<-result.ProvidersReady
 		if result.SecretManager == nil {
 			t.Fatal("SecretManager is nil")
 		}
@@ -675,9 +706,11 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		intg.Headers = map[string]string{"Authorization": "secret://api-key"}
 		cfg.Integrations["alpha"] = intg
 
-		if _, err := bootstrap.Bootstrap(ctx, cfg, factories); err != nil {
+		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
 			t.Fatalf("Bootstrap: %v", err)
 		}
+		<-result.ProvidersReady
 		if receivedDef.Headers["Authorization"] != "resolved-key" {
 			t.Errorf("Headers[Authorization]: got %q, want %q", receivedDef.Headers["Authorization"], "resolved-key")
 		}
@@ -703,9 +736,11 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		intg.Auth.TokenMetadata = []string{"secret://meta-val"}
 		cfg.Integrations["alpha"] = intg
 
-		if _, err := bootstrap.Bootstrap(ctx, cfg, factories); err != nil {
+		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
 			t.Fatalf("Bootstrap: %v", err)
 		}
+		<-result.ProvidersReady
 		if len(receivedDef.Auth.TokenMetadata) != 1 || receivedDef.Auth.TokenMetadata[0] != "resolved-meta" {
 			t.Errorf("Auth.TokenMetadata: got %v, want [resolved-meta]", receivedDef.Auth.TokenMetadata)
 		}
@@ -731,6 +766,7 @@ func TestBootstrapWithRuntimes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
+	<-result.ProvidersReady
 	if result.Runtimes == nil {
 		t.Fatal("expected Runtimes to be non-nil")
 	}
@@ -748,6 +784,7 @@ func TestBootstrapNoRuntimes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
+	<-result.ProvidersReady
 	if result.Runtimes != nil {
 		t.Fatalf("expected Runtimes to be nil, got %v", result.Runtimes.List())
 	}
@@ -786,6 +823,7 @@ func TestBootstrapWithBindings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
+	<-result.ProvidersReady
 	if result.Bindings == nil {
 		t.Fatal("expected Bindings to be non-nil")
 	}
@@ -803,6 +841,7 @@ func TestBootstrapNoBindings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
+	<-result.ProvidersReady
 	if result.Bindings != nil {
 		t.Fatalf("expected Bindings to be nil, got %v", result.Bindings.List())
 	}
@@ -849,6 +888,7 @@ func TestBootstrapBindingWithProviders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
+	<-result.ProvidersReady
 	if result.Bindings == nil {
 		t.Fatal("expected Bindings to be non-nil")
 	}

--- a/internal/bootstrap/regression_test.go
+++ b/internal/bootstrap/regression_test.go
@@ -43,6 +43,7 @@ func TestGatewayMode_NoRuntimesOrBindingsRequired(t *testing.T) {
 	if invoker != lister {
 		t.Fatal("expected Invoker and CapabilityLister to reference the same shared instance")
 	}
+	<-result.ProvidersReady
 	names := result.Providers.List()
 	if len(names) != 1 || names[0] != "alpha" {
 		t.Errorf("Providers.List: got %v, want [alpha]", names)
@@ -117,6 +118,7 @@ func TestPlatformMode_BindingsAndRuntimesWithSafetyLayer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
+	<-result.ProvidersReady
 	if result.AuditSink == nil {
 		t.Fatal("expected AuditSink to be non-nil")
 	}


### PR DESCRIPTION
Provider factories (OpenAPI spec fetches, GraphQL introspection, MCP
handshakes) ran synchronously during bootstrap, blocking the HTTP server
from listening until every integration finished loading. With 24+
integrations each making network calls, this exceeded Cloud Run's
startup timeout. Providers now initialize in background goroutines and
register themselves into the thread-safe registry as they complete,
while the HTTP server starts accepting connections immediately. The MCP
endpoint returns 503 until all providers are ready, then activates with
the full tool list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)