### PR TITLE
Update Docker Hub image to valontechnologies org and remove GHCR

### DIFF
--- a/.github/workflows/publish-gestaltd-image.yml
+++ b/.github/workflows/publish-gestaltd-image.yml
@@ -11,14 +11,8 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -29,7 +23,5 @@ jobs:
           file: Dockerfile
           push: true
           tags: |
-            ghcr.io/valon-technologies/gestalt:latest
-            ghcr.io/valon-technologies/gestalt:${{ github.sha }}
-            hughhan/gestalt:latest
-            hughhan/gestalt:${{ github.sha }}
+            valontechnologies/gestalt:latest
+            valontechnologies/gestalt:${{ github.sha }}


### PR DESCRIPTION
Move the Docker Hub image from hughhan/gestalt to the valontechnologies
organization. Also remove the GHCR login and tags since we're no longer
publishing there.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>