### PR TITLE
Rewrite docs around upstreams-based integration model

### DIFF
--- a/docs/pages/concepts/integrations.mdx
+++ b/docs/pages/concepts/integrations.mdx
@@ -1,36 +1,133 @@
 # Integrations
 
-Integrations are the unit of API exposure in Gestalt. Each integration declares where its definition comes from, how it authenticates, and which operations callers can invoke.
+Integrations are the unit of API exposure in Gestalt. Each integration declares one or more **upstreams** — the external services it connects to — along with auth settings and optional hooks.
 
-## Three ways to define an integration
+## Upstreams
 
-| Source | Config field | When to use |
+Every integration has an `upstreams` list. Each entry specifies a `type` and a source:
+
+| Upstream type | What it does |
+|---|---|
+| `rest` | Loads operations from an OpenAPI spec (via `url`), a provider YAML file (via `provider`), or a directory scan (via `provider_dirs`). |
+| `graphql` | Introspects a GraphQL endpoint at startup and generates operations from queries and mutations. |
+| `mcp` | Connects to an upstream MCP server and imports its tools as operations. |
+
+An integration can combine upstream types. For example, a REST upstream and an MCP upstream together create a **composite integration** where HTTP operations are available over the REST API and MCP tools are proxied directly to the upstream MCP server.
+
+## REST upstreams
+
+A REST upstream resolves its operations from one of three sources:
+
+| Source | Upstream field | When to use |
 |---|---|---|
-| OpenAPI spec | `openapi` | Point at a URL or local file. Operations, parameters, and descriptions are generated automatically. |
-| Provider file | `provider` | Write a standalone YAML file. Use when no spec exists or the spec is too noisy. |
-| Provider directory | `provider_dirs` | Scan a directory for multiple provider YAML files. Each file becomes a separate provider. |
+| OpenAPI spec | `url` pointing to a spec | Public or local OpenAPI document exists. Operations generated automatically. |
+| Provider file | `provider` pointing to a YAML file | No spec exists or the spec is too noisy. Declare operations manually. |
+| Provider directory | Neither `url` nor `provider` | Gestalt searches `provider_dirs` for a matching YAML file by integration name. |
+
+```yaml
+integrations:
+  slack:
+    upstreams:
+      - type: rest
+        url: https://raw.githubusercontent.com/.../slack_web_openapi_v2.json
+        allowed_operations:
+          conversations_list: List channels
+          chat_postMessage: Send a message
+    client_id: ${SLACK_CLIENT_ID}
+    client_secret: ${SLACK_CLIENT_SECRET}
+```
+
+## GraphQL upstreams
+
+A GraphQL upstream introspects the endpoint at startup and generates one operation per query and mutation field.
+
+```yaml
+integrations:
+  my-graphql-api:
+    upstreams:
+      - type: graphql
+        url: https://api.example.com/graphql
+        allowed_operations:
+          - searchUsers
+          - createProject
+    client_id: ${API_CLIENT_ID}
+    client_secret: ${API_CLIENT_SECRET}
+    auth:
+      authorization_url: https://example.com/oauth/authorize
+      token_url: https://example.com/oauth/token
+```
+
+Operation arguments are converted to JSON Schema inputs so MCP clients get type information for parameters. Scalar and enum types map to their JSON equivalents; complex input types map to `object`.
+
+## MCP upstreams
+
+An MCP upstream connects to a remote MCP server via Streamable HTTP, lists its tools, and imports them as Gestalt operations. These operations can only be invoked through the MCP binding — calling them over the HTTP API returns an error.
+
+```yaml
+integrations:
+  external-tools:
+    upstreams:
+      - type: mcp
+        url: https://mcp.example.com/sse
+    connection_mode: user
+```
+
+Tool annotations (read-only, destructive, idempotent) are preserved from the upstream server.
+
+## Mixed integrations
+
+An integration can combine a REST or GraphQL upstream with an MCP upstream. This creates a composite provider:
+
+```yaml
+integrations:
+  slack:
+    upstreams:
+      - type: rest
+        url: https://raw.githubusercontent.com/.../slack_web_openapi_v2.json
+        mcp: true
+        allowed_operations:
+          conversations_list: List channels
+          chat_postMessage: Send a message
+      - type: mcp
+        url: https://mcp.slack.com/sse
+    client_id: ${SLACK_CLIENT_ID}
+    client_secret: ${SLACK_CLIENT_SECRET}
+```
+
+The `mcp: true` flag on the REST upstream means its HTTP operations are also exposed as MCP tools alongside the tools from the MCP upstream.
+
+## allowed_operations
+
+The `allowed_operations` field on an upstream controls which operations are exposed. It accepts two formats:
+
+**As a list** (names only, descriptions from the upstream source):
+
+```yaml
+allowed_operations:
+  - conversations_list
+  - chat_postMessage
+```
+
+**As a map** (names to description overrides):
+
+```yaml
+allowed_operations:
+  conversations_list: List channels the user has access to
+  chat_postMessage: Send a message to a channel
+```
+
+Omit `allowed_operations` entirely to allow all operations. An empty value is invalid — if you set the field, it must contain at least one entry.
 
 ## What an operation looks like
 
 | Field | Description |
 |---|---|
-| Name | Unique identifier. For OpenAPI sources, this is the `operationId` from the spec. |
-| Description | Human-readable summary from the spec or `allowed_operations` config. |
-| Method and path | HTTP verb and URL path template for the upstream call. |
-| Parameters | Query parameters, path parameters, headers, and body fields. |
+| Name | Unique identifier. For OpenAPI sources, this is the `operationId`. For GraphQL, the query/mutation field name. For MCP, the tool name. |
+| Description | Human-readable summary from the spec, or overridden via `allowed_operations`. |
+| Method and path | HTTP verb and URL path template (REST only). |
+| Parameters | Query, path, header, and body fields. |
 | Input schema | JSON Schema for parameters, passed to MCP clients for type information. |
-| Annotations | Automatic hints: GET/HEAD are read-only, PUT is idempotent, DELETE is destructive. |
-
-## How OpenAPI loading works
-
-When an integration includes an `openapi` field, Gestalt parses the spec at startup and extracts:
-
-- The display name from `info.title`.
-- The first server URL as the base URL.
-- OAuth authorization and token URLs from security scheme definitions.
-- Operations by iterating every path and method, keyed by `operationId`.
-
-Operations without an `operationId` are skipped. Security schemes inform the default auth configuration but can be overridden in the integration config.
+| Annotations | Automatic hints: GET/HEAD are read-only, PUT is idempotent, DELETE is destructive. MCP upstreams preserve the upstream server's annotations. |
 
 ## Manual auth versus OAuth
 
@@ -69,17 +166,6 @@ Hooks are registered by name in Go code and referenced by that name in config.
 | `slack_ok` | Slack | Checks `"ok": true` in response body. Used as both `response_check` and `response_hook`. |
 | `datadog_keys` | Datadog | Parses API and application keys from stored credentials, injects as `DD-API-KEY` and `DD-APPLICATION-KEY` headers. |
 | `hex_response` | Hex | Validates Hex-specific response format. |
-
-## Additional integration config fields
-
-| Field | Purpose |
-|---|---|
-| `icon_svg` | Inline SVG icon displayed in the web UI. |
-| `icon_file` | Load an SVG icon from a file path (alternative to inline `icon_svg`). |
-| `token_prefix` | Prefix for the Authorization header value (for example, `Bot` for Discord). |
-| `auth_style` | How the token is sent: `bearer`, `raw`, or `none`. |
-| `headers` | Default headers sent with every upstream request. |
-| `error_message_path` | JSONPath expression to extract error messages from upstream response bodies. |
 
 ## Restrictions
 

--- a/docs/pages/concepts/mcp-binding.mdx
+++ b/docs/pages/concepts/mcp-binding.mdx
@@ -6,6 +6,16 @@ When `mcp.enabled` is set in the config, Gestalt mounts a Streamable HTTP MCP en
 
 The [Model Context Protocol](https://modelcontextprotocol.io) (MCP) is an open standard for connecting AI assistants to external tools. An MCP server advertises a list of tools and handles tool calls. Gestalt's MCP binding maps each allowed integration operation to an MCP tool.
 
+## Tool generation
+
+Gestalt generates MCP tools from provider catalogs. Providers that implement the `CatalogProvider` interface (including all REST, GraphQL, and MCP upstream providers) supply rich metadata for their operations:
+
+- **JSON Schema inputs** from OpenAPI specs and GraphQL introspection are passed through directly, giving MCP clients full type information.
+- **Tool annotations** (read-only, destructive, idempotent) are set automatically from HTTP methods for REST operations, and preserved from the upstream server for MCP operations.
+- **Operation titles** come from the catalog when available, falling back to the operation ID.
+
+Providers without a catalog fall back to flat tool generation from the operation list with parameter-level type hints.
+
 ## Tool names
 
 Each tool name is built from the provider name and operation ID:
@@ -33,22 +43,20 @@ The MCP binding is an alternative interface, not a replacement. It shares:
 
 The `mcp.providers` filter lets you expose a subset of integrations to MCP clients without affecting the HTTP API.
 
-## Tool metadata
+## MCP upstream passthrough
 
-Gestalt populates MCP tool annotations automatically:
+When an integration includes a `type: mcp` upstream, those operations are proxied directly to the upstream MCP server rather than going through the HTTP invocation path. Gestalt resolves the user's stored credential, injects it as a Bearer token on the upstream request, and forwards the tool call. This avoids the HTTP serialization round-trip and preserves the full MCP protocol semantics.
 
-| HTTP method | Annotation |
-|---|---|
-| GET, HEAD | Read-only |
-| PUT | Idempotent |
-| DELETE | Destructive |
+For composite integrations (REST/GraphQL + MCP), REST operations go through the standard invoker while MCP operations use direct passthrough.
 
-Input schemas from OpenAPI specs are passed through as JSON Schema, giving MCP clients type information for parameters. Providers that implement the catalog interface can supply richer metadata for their operations.
+## Mixed transport catalogs
+
+A composite integration can expose operations from different transports under a single provider name. For example, an integration with both a REST upstream and an MCP upstream presents all operations in one unified tool list. The MCP binding routes each tool call to the correct backend based on the operation's transport type.
+
+## MCP-only integrations
+
+Integrations with only a `type: mcp` upstream cannot be invoked over the HTTP API. Calling their operations via `GET/POST /api/v1/{integration}/{operation}` returns a 400 error indicating the integration is accessible only via MCP.
 
 ## Limitations
 
 Adding or removing integrations requires restarting the server.
-
-## MCP upstream proxying
-
-Integrations can proxy requests to an upstream MCP server by setting `mcp.url` in the integration config block. When configured, Gestalt forwards tool calls to the upstream MCP server instead of executing HTTP operations. This allows Gestalt to act as a unified gateway for both REST and MCP-native providers; you expose a single MCP endpoint to your AI assistants, and Gestalt routes each tool call to the correct backend regardless of whether the upstream speaks REST or MCP.

--- a/docs/pages/concepts/platform-model.mdx
+++ b/docs/pages/concepts/platform-model.mdx
@@ -9,9 +9,9 @@ Gestalt has a small set of primitives that compose into a complete API gateway f
 | **Auth provider** | Authenticates users to the Gestalt platform and issues session tokens. |
 | **Datastore** | Persists users, integration tokens (encrypted), and API tokens in a pluggable backend such as Postgres, SQLite, or DynamoDB. |
 | **Secret manager** | Resolves `secret://` references in config before other components are built, keeping sensitive values out of plain-text YAML. |
-| **Integration definition** | Describes an upstream API: base URL, auth style, operations, and optional hooks; for example, Slack, Linear, or Datadog. |
-| **Provider** | Runtime object that lists operations and executes them against the upstream API. |
-| **Operation** | A callable unit exposed by an integration, generated from an OpenAPI spec or declared in YAML. |
+| **Integration definition** | Describes one or more upstreams (REST, GraphQL, or MCP) with their auth style, operations, and optional hooks. |
+| **Provider** | Runtime object that lists operations and executes them against upstream APIs. Built from the integration's upstreams at startup. |
+| **Operation** | A callable unit exposed by an integration, generated from an OpenAPI spec, GraphQL introspection, MCP tool listing, or declared in YAML. |
 | **Hooks** | Integration-specific code for non-standard auth, token parsing, response validation, or request shaping. |
 | **Runtime** | A background process that boots alongside the server and receives scoped access to a subset of providers. |
 | **Binding** | An alternative request surface (for example, webhooks or MCP) that forwards calls through the shared invoker. |
@@ -49,13 +49,35 @@ Each integration has a connection mode that controls how credentials are resolve
 
 Set `connection_mode` on the integration config. Default is `user`.
 
-## Source of truth for an integration
+## Upstream types
 
-| Source | When to use |
+Each integration declares one or more upstreams that define where operations come from:
+
+| Upstream type | When to use |
 |---|---|
-| OpenAPI spec | Set the `openapi` field to a URL or local path. Operations, parameters, and descriptions are generated automatically. |
-| Provider YAML | A standalone file that declares operations manually. Use when no spec exists or when the spec is too noisy. |
-| Provider directory | The `provider_dirs` config field tells Gestalt where to scan for provider YAML files at boot. |
+| `rest` | Load operations from an OpenAPI spec URL, a provider YAML file, or a provider directory scan. |
+| `graphql` | Introspect a GraphQL endpoint and generate operations from queries and mutations. |
+| `mcp` | Connect to an upstream MCP server and import its tools as operations. |
+
+An integration can combine multiple upstream types (e.g. REST + MCP) to create a composite provider.
+
+## Extension interfaces
+
+Gestalt's plugin system is built on interfaces defined in the `core/` package:
+
+| Interface | Package | Purpose |
+|---|---|---|
+| `AuthProvider` | `core/auth.go` | Authenticates users and issues session tokens. |
+| `Datastore` | `core/datastore.go` | Persists users, integration tokens, and API tokens. |
+| `SecretManager` | `core/secrets.go` | Resolves secret values by name. |
+| `Provider` | `core/provider.go` | Lists and executes operations against an upstream API. |
+| `OAuthProvider` | `core/provider.go` | Extends `Provider` with OAuth authorization and token exchange. |
+| `ManualProvider` | `core/provider.go` | Extends `Provider` for API-key services with no OAuth flow. |
+| `CatalogProvider` | `core/provider.go` | Exposes rich metadata (JSON Schema inputs, annotations) for MCP tool generation. |
+| `Runtime` | `core/runtime.go` | Background process with lifecycle management (`Start`/`Stop`). |
+| `Binding` | `core/binding.go` | Alternative request surface (triggers or surfaces) with HTTP routes. |
+| `Invoker` | `internal/invocation/broker.go` | Dispatches operations with credential resolution and token refresh. |
+| `CapabilityLister` | `internal/invocation/broker.go` | Lists all available operations across providers. |
 
 ## Self-serve model
 

--- a/docs/pages/contributing.mdx
+++ b/docs/pages/contributing.mdx
@@ -5,10 +5,10 @@
 | Directory | Purpose |
 |---|---|
 | `cmd/gestaltd` | Main Go binary. Registers all plugins and starts the server. |
-| `core` | Public interfaces: auth providers, datastores, secret managers, providers, runtimes, bindings, hooks. |
+| `core` | Public interfaces: `AuthProvider`, `Datastore`, `SecretManager`, `Provider`, `OAuthProvider`, `ManualProvider`, `CatalogProvider`, `Runtime`, `Binding`. See `core/auth.go`, `core/datastore.go`, `core/secrets.go`, `core/provider.go`, `core/runtime.go`, `core/binding.go`. |
 | `internal` | Runtime packages: config loading, HTTP routing, middleware, invocation, token management, bootstrap. |
 | `plugins` | Implementations of core interfaces: auth, datastores, secrets, integrations, bindings, runtimes. |
-| `proto/` | gRPC protobuf service definitions. |
+| `docs` | Nextra documentation site. |
 | `client/cli` | Rust CLI source. Produces the `gestalt` binary. |
 | `web` | Next.js web UI. |
 | `deploy` | Helm chart, Dockerfiles, and CI workflows. |
@@ -46,3 +46,7 @@ cd web
 npm run check
 npm run build
 ```
+
+## Pre-push hook
+
+The repository includes a managed pre-push hook at `.githooks/pre-push`. Git is configured to use this directory via `core.hooksPath`. The hook runs automatically when you push — do not bypass it with `--no-verify`.

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -33,7 +33,12 @@ datastore:
 
 integrations:
   slack:
-    openapi: https://raw.githubusercontent.com/slackapi/slack-api-specs/master/web-api/slack_web_openapi_v2.json
+    upstreams:
+      - type: rest
+        url: https://raw.githubusercontent.com/slackapi/slack-api-specs/master/web-api/slack_web_openapi_v2.json
+        allowed_operations:
+          conversations_list: List channels
+          chat_postMessage: Send a message
     client_id: ${SLACK_CLIENT_ID}
     client_secret: ${SLACK_CLIENT_SECRET}
     response_check: slack_ok
@@ -41,9 +46,6 @@ integrations:
       authorization_url: https://slack.com/oauth/v2/authorize
       token_url: https://slack.com/api/oauth.v2.access
       response_hook: slack_ok
-    allowed_operations:
-      conversations_list: List channels
-      chat_postMessage: Send a message
 ```
 
 <Callout>
@@ -86,7 +88,7 @@ gestalt integrations list
 gestalt invoke slack conversations_list
 ```
 
-`gestalt init` creates a `.gestalt.json` file in your home directory that stores the server URL and session credentials. You can override the server URL at any time by setting the `GESTALT_SERVER_URL` environment variable.
+`gestalt init` creates a `.gestalt.json` file in your home directory that stores the server URL and session credentials. You can override the server URL at any time by setting the `GESTALT_URL` environment variable.
 
 ## Next steps
 

--- a/docs/pages/reference/built-in-plugins.mdx
+++ b/docs/pages/reference/built-in-plugins.mdx
@@ -45,7 +45,6 @@ All SQL-based datastores (postgres, mysql, oracle, sqlserver) share a common imp
 | Name | Notes |
 |---|---|
 | `webhook` | Exposes HTTP endpoints that forward to provider operations. Supports `public`, `signed` (HMAC-SHA256), and `trusted_user_header` auth modes. Configurable path, provider, operation, and signature headers. |
-| `grpc` | Exposes a gRPC server on a configurable port. Forwards protobuf-defined service calls to provider operations. Config: `port` (listen port), `providers` (allowed providers). |
 
 ## Runtimes
 

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -55,14 +55,14 @@ cargo build --release
 | Command | Purpose |
 |---|---|
 | `gestalt init` | Interactive setup wizard. |
-| `gestalt auth login` | Open browser for OAuth login. |
+| `gestalt auth login` | Open browser for OAuth login. Refuses if `GESTALT_API_KEY` is set (unset it first or use the key directly). |
 | `gestalt auth logout` | Clear stored credentials. |
-| `gestalt auth status` | Show authentication status. |
+| `gestalt auth status` | Show authentication status and credential source. |
 | `gestalt config get <key>` | Read a config value. |
 | `gestalt config set <key> <value>` | Write a config value. |
 | `gestalt config unset <key>` | Remove a config value. |
 | `gestalt config list` | List all config values. |
-| `gestalt integrations list` | List available integrations. |
+| `gestalt integrations list` | List available integrations with name, display name, auth type, connected status, and description. |
 | `gestalt integrations connect <name>` | Start an OAuth connection flow. |
 | `gestalt invoke <integration> <operation> -p key=value` | Execute an operation. |
 | `gestalt tokens create [--name <name>]` | Create an API token. |
@@ -73,18 +73,26 @@ cargo build --release
 
 1. `--url` flag.
 2. `GESTALT_URL` environment variable.
-3. `.gestalt.json` in the current directory.
+3. `.gestalt.json` in the current or ancestor directory.
 4. Global config file.
 5. `credentials.json` stored by `gestalt auth login`.
 6. `http://localhost:8080` as fallback.
 
 ### Authentication
 
-- If `GESTALT_API_KEY` is set, it is sent as the Bearer token on every request, overriding any session token.
-- Otherwise, the CLI uses the session token stored by `gestalt auth login`.
-- Run `gestalt auth status` to see which credential source is active.
-- Credential files are written with `0600` permissions.
-- Output formats: `--format json` (default) or `--format table`.
+The CLI resolves credentials in this order:
+
+1. **`GESTALT_API_KEY` environment variable** — if set and non-empty, used as the Bearer token on every request, overriding any session token. When active, `gestalt auth login` refuses to run and prints a message to unset the variable first.
+2. **Session token** — stored by `gestalt auth login` in the local credential store.
+
+`gestalt auth status` reports which source is active:
+
+- **`--format json`** returns `{"authenticated": bool, "source": "env"|"session"|"none", "env_var_set": bool, "session_stored": bool}`.
+- **`--format table`** prints a human-readable summary. If both `GESTALT_API_KEY` and a session token exist, it warns that the session token is being ignored.
+
+If a request fails with 401 while using `GESTALT_API_KEY`, the error message notes that the key came from the environment and suggests unsetting it.
+
+Credential files are written with `0600` permissions. Output formats: `--format json` (default) or `--format table`.
 
 ### Common workflows
 

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -13,7 +13,7 @@
 | `bindings` | Alternative request surfaces such as webhooks and gRPC. |
 | `provider_dirs` | Directories searched for provider YAML files at startup. |
 | `server` | Port, base URL, encryption key, and development mode. |
-| `mcp` | MCP endpoint settings: enabled flag, provider filter, tool name prefix. Integration-level `mcp.url` enables upstream MCP proxying. |
+| `mcp` | MCP endpoint settings: enabled flag, provider filter, tool name prefix. |
 
 ## Server block
 
@@ -88,28 +88,65 @@ secrets:
 
 ## Integration block
 
+Each integration is defined under `integrations.<name>` and contains one or more `upstreams` entries plus integration-level settings for auth, display, and hooks.
+
 | Field | Notes |
 |---|---|
-| `openapi` | OpenAPI spec URL or local file path. |
-| `provider` | Path to a provider YAML file. |
+| `upstreams` | List of upstream definitions (see below). At least one is required. |
+| `display_name` | Human-readable label for the integration. |
+| `description` | Short description shown in the web UI and CLI. |
 | `auth_profile` | Name of a reusable auth profile to inherit from. |
 | `client_id`, `client_secret` | OAuth client credentials for the upstream integration. |
 | `redirect_url` | Override the integration callback URL. |
 | `base_url` | Override the base URL from the spec or provider file. |
 | `connection_mode` | `user` (default), `identity`, `either`, or `none`. See [Connection Modes](/concepts/platform-model#connection-modes). |
 | `auth` | Auth overrides (see below). |
+| `auth_header` | Custom header name for sending the token (instead of `Authorization`). |
+| `auth_mapping` | Map of header names to JSON fields, for structured token-to-headers mapping. |
 | `response_check` | Named hook to validate responses. |
 | `token_parser` | Named hook to transform stored tokens into auth headers. |
 | `request_mutator` | Named hook to rewrite outgoing requests. |
 | `token_prefix` | Prefix for the Authorization header value. |
-| `auth_style` | How the token is sent: `bearer`, `raw`, or `none`. |
+| `auth_style` | How the token is sent: `bearer` (default), `raw`, `basic`, or `none`. |
 | `headers` | Default headers sent with every upstream request. |
-| `auth_headers` | YAML map of declarative auth headers injected into upstream requests. |
-| `icon_svg` | SVG icon displayed in the web UI. |
 | `icon_file` | Path to an SVG file used as the integration icon. |
-| `error_message_path` | JSONPath expression for extracting error messages from upstream responses. |
-| `allowed_operations` | Positive allow-list of operation names with optional description overrides. |
-| `mcp` | MCP proxying config. Subfield `url` sets the upstream MCP server URL for passthrough proxying. |
+| `error_message_path` | Dot-delimited path for extracting error messages from upstream JSON responses. |
+
+### Upstreams
+
+Each upstream declares a type and source:
+
+| Field | Notes |
+|---|---|
+| `type` | `rest`, `graphql`, or `mcp`. |
+| `url` | For `rest`: OpenAPI spec URL. For `graphql`: the GraphQL endpoint (introspected at startup). For `mcp`: the upstream MCP server URL. |
+| `provider` | (`rest` only) Path to a provider YAML file. Used instead of `url`. |
+| `mcp` | (`rest` and `graphql` only) Boolean. When `true` and combined with a `type: mcp` upstream, this upstream's operations are also exposed as MCP tools. |
+| `allowed_operations` | Positive allow-list. Can be a YAML list (names only) or a map (names to description overrides). Omit to allow all operations. An empty value is invalid. |
+
+If a `rest` upstream has neither `url` nor `provider`, Gestalt falls back to searching `provider_dirs` for a matching YAML file.
+
+Example with multiple upstreams:
+
+```yaml
+integrations:
+  slack:
+    upstreams:
+      - type: rest
+        url: https://raw.githubusercontent.com/.../slack_web_openapi_v2.json
+        allowed_operations:
+          conversations_list: List channels
+          chat_postMessage: Send a message
+      - type: mcp
+        url: https://mcp.slack.com/sse
+    client_id: ${SLACK_CLIENT_ID}
+    client_secret: ${SLACK_CLIENT_SECRET}
+    auth_style: bearer
+    auth:
+      authorization_url: https://slack.com/oauth/v2/authorize
+      token_url: https://slack.com/api/oauth.v2.access
+      response_hook: slack_ok
+```
 
 ### Auth overrides
 
@@ -185,15 +222,6 @@ bindings:
       auth_mode: signed           # "public", "signed", or "trusted_user_header"
       signing_secret: ${WEBHOOK_SECRET}
       signature_header: X-Signature
-
-  linear-grpc:
-    type: grpc
-    providers:
-      - linear
-    config:
-      port: 9090
-      providers:
-        - linear
 ```
 
 ### Webhook config
@@ -207,13 +235,6 @@ bindings:
 | `signing_secret` | | Required when `auth_mode` is `signed`. |
 | `signature_header` | `X-Signature` | Header containing the HMAC signature. |
 | `user_header` | | Required when `auth_mode` is `trusted_user_header`. Header containing the user ID. |
-
-### gRPC config
-
-| Config field | Default | Notes |
-|---|---|---|
-| `port` | | Listen port for the gRPC server. |
-| `providers` | | Allowed providers for this binding. |
 
 ## MCP block
 
@@ -232,8 +253,6 @@ mcp:
 | `providers` | all | Restrict which integrations are exposed to MCP clients. |
 | `tool_name_prefix` | `""` | String prepended to every MCP tool name. |
 
-When an integration defines `mcp.url`, Gestalt proxies MCP requests to that upstream server, enabling MCP-to-MCP passthrough without additional configuration in this block.
-
 ## Supported providers
 
 | Category | Providers |
@@ -241,5 +260,5 @@ When an integration defines `mcp.url`, Gestalt proxies MCP requests to that upst
 | Auth | `google`, `oidc` |
 | Datastore | `sqlite`, `postgres`, `mysql`, `dynamodb`, `mongodb`, `firestore`, `oracle`, `sqlserver` |
 | Secrets | `env`, `file`, `gcp_secret_manager` |
-| Bindings | `webhook`, `grpc` |
+| Bindings | `webhook` |
 | Runtimes | `echo` (dev mode only) |

--- a/docs/pages/reference/http-api.mdx
+++ b/docs/pages/reference/http-api.mdx
@@ -5,38 +5,45 @@
 | Method | Path | Purpose |
 |---|---|---|
 | GET | `/health` | Health check. Returns `{"status":"ok"}`. |
-| GET | `/ready` | Readiness check. Returns `{"status":"ready"}` when the server can accept traffic. |
-| POST | `/api/v1/auth/login` | Start platform login. Returns a browser redirect URL. |
-| GET | `/api/v1/auth/login/callback` | Complete platform login. Issues a session token. |
-| GET | `/api/v1/auth/info` | Returns the auth provider name and display label. |
+| GET | `/ready` | Readiness check. Returns `{"status":"ok"}` when the datastore is reachable, or `{"status":"unavailable"}` with a 503 when it is not. |
+| POST | `/api/v1/auth/login` | Start platform login. Accepts `{"state": "...", "callback_port": 12345}`. Returns `{"url": "..."}` with the provider's login URL. |
+| GET | `/api/v1/auth/login/callback` | Complete platform login. Exchanges the authorization code for a session token. Returns `{"email": "...", "display_name": "...", "token": "..."}`. |
+| GET | `/api/v1/auth/info` | Returns `{"provider": "...", "display_name": "...", "dev_mode": true/false}`. |
+
+In dev mode, an additional endpoint is available:
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/api/dev-login` | Dev-only login. Accepts `{"email": "..."}` and returns a session token without OAuth. |
 
 ## Authenticated endpoints
 
-All authenticated endpoints require an `Authorization: Bearer <token>` header or a valid session cookie.
+All authenticated endpoints require an `Authorization: Bearer <token>` header. The token can be a session token from login or an API token.
 
 ### Integrations
 
 | Method | Path | Purpose |
 |---|---|---|
-| GET | `/api/v1/integrations` | List loaded integrations with metadata (name, display name, description, icon, connection status). |
+| GET | `/api/v1/integrations` | List loaded integrations. Returns an array of objects with `name`, `display_name`, `description`, `icon_svg`, `connected` (boolean), and `auth_type` (`"oauth"` or `"manual"`). |
+| DELETE | `/api/v1/integrations/{name}` | Disconnect an integration. Removes the stored token for the calling user. Returns `{"status":"disconnected"}`. |
 | GET | `/api/v1/integrations/{name}/operations` | List operations exposed by an integration. |
-| GET or POST | `/api/v1/{integration}/{operation}` | Execute an integration operation. |
+| GET or POST | `/api/v1/{integration}/{operation}` | Execute an integration operation. MCP-only integrations return a 400 error. |
 
 ### Auth flows
 
 | Method | Path | Purpose |
 |---|---|---|
-| POST | `/api/v1/auth/start-oauth` | Start an integration OAuth flow. Returns the provider's authorization URL. |
-| GET | `/api/v1/auth/callback` | Complete integration OAuth. Exchanges code for tokens and stores them. |
-| POST | `/api/v1/auth/connect-manual` | Submit manual credentials for non-OAuth integrations. |
+| POST | `/api/v1/auth/start-oauth` | Start an integration OAuth flow. Accepts `{"integration": "...", "scopes": [...]}`. Returns `{"url": "...", "state": "..."}`. |
+| GET | `/api/v1/auth/callback` | Complete integration OAuth. Exchanges code for tokens and stores them. Redirects to the web UI on success. |
+| POST | `/api/v1/auth/connect-manual` | Submit manual credentials. Accepts `{"integration": "...", "credential": "..."}`. Returns `{"status":"connected"}`. |
 
 ### API tokens
 
 | Method | Path | Purpose |
 |---|---|---|
-| POST | `/api/v1/tokens` | Create an API token. Returns the plaintext token once. |
-| GET | `/api/v1/tokens` | List API tokens for the current user. |
-| DELETE | `/api/v1/tokens/{id}` | Revoke an API token. |
+| POST | `/api/v1/tokens` | Create an API token. Returns `{"id": "...", "name": "...", "token": "...", "expires_at": "..."}`. The plaintext token is shown only once. |
+| GET | `/api/v1/tokens` | List API tokens for the current user. Returns `id`, `name`, `scopes`, `created_at`, `expires_at`. |
+| DELETE | `/api/v1/tokens/{id}` | Revoke an API token. Returns `{"status":"revoked"}`. |
 
 ### Runtimes and bindings
 
@@ -58,6 +65,7 @@ Bindings register dynamic routes at `/api/v1/bindings/{name}/*` based on their c
 - **GET** requests pass parameters as query string key-value pairs.
 - **POST** requests pass parameters as a JSON body.
 - Path placeholders like `{integration}` and `{operation}` are resolved from the URL. Remaining parameters are sent as query or body values depending on the method.
+- Integrations backed only by a `type: mcp` upstream cannot be invoked over HTTP. Attempting to do so returns `400: this integration is accessible only via MCP`.
 
 ## Authentication
 

--- a/docs/pages/tasks/add-an-integration.mdx
+++ b/docs/pages/tasks/add-an-integration.mdx
@@ -1,42 +1,56 @@
 # Add an Integration
 
-Adding an **integration** means choosing a source of truth, optionally correcting its auth details, and deciding which operations to expose.
+Adding an **integration** means defining one or more upstreams, optionally configuring auth, and deciding which operations to expose.
 
 ## 1. Decide how to define it
 
-| Approach | When to use |
-|---|---|
-| OpenAPI spec | Public or local OpenAPI document exists. Operations generated automatically. |
-| Provider YAML | No spec exists, or the spec is too noisy. Declare operations manually. |
-| Manual auth | API-key service with no OAuth flow. Users paste credentials directly. |
+| Approach | Upstream type | When to use |
+|---|---|---|
+| OpenAPI spec | `type: rest` with `url` | Public or local OpenAPI document exists. Operations generated automatically. |
+| Provider YAML | `type: rest` with `provider` | No spec exists, or the spec is too noisy. Declare operations manually. |
+| GraphQL endpoint | `type: graphql` with `url` | GraphQL API. Operations generated from introspection. |
+| MCP server | `type: mcp` with `url` | Upstream already speaks MCP. Tools imported directly. |
+| Manual auth | Any upstream type with `auth.type: manual` | API-key service with no OAuth flow. Users paste credentials directly. |
 
-## 2. OpenAPI-backed integration
+## 2. REST integration from OpenAPI
 
 ```yaml
 integrations:
   slack:
-    openapi: https://raw.githubusercontent.com/slackapi/slack-api-specs/master/web-api/slack_web_openapi_v2.json
+    upstreams:
+      - type: rest
+        url: https://raw.githubusercontent.com/slackapi/slack-api-specs/master/web-api/slack_web_openapi_v2.json
+        allowed_operations:
+          conversations_list: ""
+          chat_postMessage: Send a message to a channel
     client_id: ${SLACK_CLIENT_ID}
     client_secret: ${SLACK_CLIENT_SECRET}
     icon_file: slack.svg
     response_check: slack_ok
+    error_message_path: error
     auth:
       authorization_url: https://slack.com/oauth/v2/authorize
       token_url: https://slack.com/api/oauth.v2.access
       response_hook: slack_ok
-      auth_headers:
-        Accept: application/json
-    error_message_path: $.error
-    allowed_operations:
-      conversations_list: ""
-      chat_postMessage: Send a message to a channel
 ```
 
-The `icon_file` field sets the icon displayed in the web UI. The `auth_headers` map adds static headers to token exchange requests. The `error_message_path` field is a JSONPath expression that extracts a human-readable error from upstream error responses.
+The `icon_file` field sets the icon displayed in the web UI. The `error_message_path` field is a dot-delimited path that extracts a human-readable error from upstream JSON error responses.
 
-## 3. Provider file
+## 3. REST integration from a provider file
 
 Use when the OpenAPI spec does not exist or does not fit.
+
+```yaml
+integrations:
+  internal-api:
+    upstreams:
+      - type: rest
+        provider: /etc/gestalt/providers/internal-api.yaml
+    auth:
+      type: manual
+```
+
+The provider file declares operations manually:
 
 ```yaml
 provider: internal-api
@@ -68,12 +82,34 @@ operations:
         description: Job identifier
 ```
 
-## 4. Manual auth for API-key services
+## 4. GraphQL integration
+
+```yaml
+integrations:
+  my-api:
+    upstreams:
+      - type: graphql
+        url: https://api.example.com/graphql
+        allowed_operations:
+          - searchUsers
+          - createProject
+    client_id: ${API_CLIENT_ID}
+    client_secret: ${API_CLIENT_SECRET}
+    auth:
+      authorization_url: https://example.com/oauth/authorize
+      token_url: https://example.com/oauth/token
+```
+
+Gestalt introspects the GraphQL endpoint at startup and generates operations from queries and mutations. Arguments are converted to JSON Schema inputs for MCP clients.
+
+## 5. Manual auth for API-key services
 
 ```yaml
 integrations:
   datadog:
-    provider: /etc/gestalt/providers/datadog.yaml
+    upstreams:
+      - type: rest
+        provider: /etc/gestalt/providers/datadog.yaml
     auth:
       type: manual
     token_parser: datadog_keys
@@ -81,25 +117,31 @@ integrations:
 
 Users paste their credentials through the web UI or via `POST /api/v1/auth/connect-manual`. Gestalt encrypts and stores them the same way it stores OAuth tokens.
 
-## 5. Restrict operations
+## 6. Restrict operations
 
-The `allowed_operations` map is your product design surface. Only expose what callers need. A tightly scoped integration is easier to audit, faster to load, and less likely to surprise anyone.
+The `allowed_operations` field on each upstream controls which operations are exposed. It accepts a YAML list (names only) or a map (names to description overrides). Omit it to allow all operations. Only expose what callers need — a tightly scoped integration is easier to audit, faster to load, and less likely to surprise anyone.
 
-## 6. Set the connection mode
+## 7. Set the connection mode
 
 Control how credentials are resolved per integration:
 
 ```yaml
 integrations:
   slack:
+    upstreams:
+      - type: rest
+        url: https://...
     connection_mode: user    # each user connects independently (default)
   shared-service:
+    upstreams:
+      - type: rest
+        provider: shared-service.yaml
     connection_mode: identity # single shared credential
 ```
 
 See [Connection Modes](/concepts/platform-model#connection-modes) for all options.
 
-## 7. Validate end to end
+## 8. Validate end to end
 
 ```sh
 gestaltd --check --config your-config.yaml
@@ -110,8 +152,6 @@ gestalt invoke slack conversations_list
 curl -H "Authorization: Bearer $GESTALT_API_KEY" \
   http://localhost:8080/api/v1/slack/conversations_list
 ```
-
-During validation, confirm that `icon_file`, `auth_headers`, and `error_message_path` resolve correctly in the config check output if you have set them.
 
 ## When to write code
 

--- a/docs/pages/tasks/use-with-mcp.mdx
+++ b/docs/pages/tasks/use-with-mcp.mdx
@@ -110,12 +110,17 @@ server:
 
 integrations:
   linear:
-    openapi: https://raw.githubusercontent.com/linear/linear/master/packages/sdk/src/schema.graphql
+    upstreams:
+      - type: graphql
+        url: https://api.linear.app/graphql
+        allowed_operations:
+          - searchIssues
+          - createIssue
     client_id: ${LINEAR_CLIENT_ID}
     client_secret: ${LINEAR_CLIENT_SECRET}
-    allowed_operations:
-      search_issues: Search issues in Linear
-      create_issue: Create a new Linear issue
+    auth:
+      authorization_url: https://linear.app/oauth/authorize
+      token_url: https://api.linear.app/oauth/token
 
 mcp:
   enabled: true
@@ -129,5 +134,6 @@ If tools do not appear in your MCP client:
 
 1. Verify the server is running with `mcp.enabled: true`.
 2. Check that your API token is valid (`gestalt auth status`).
-3. Confirm the token's owner has connected the integration (completed the OAuth flow).
-4. Verify `allowed_operations` is defined for the integration.
+3. Confirm the token's owner has connected the integration (completed the OAuth flow or submitted manual credentials).
+4. If using `mcp.providers`, confirm the integration is in the list.
+5. For MCP-only integrations (`type: mcp` upstream), note that they cannot be invoked over the HTTP API — they are only available via the MCP endpoint.

--- a/docs/pages/troubleshooting.mdx
+++ b/docs/pages/troubleshooting.mdx
@@ -2,9 +2,9 @@
 
 ## Integration is missing its provider
 
-Gestalt resolves providers at startup. If neither `openapi` nor `provider` is set on an integration entry, and no matching file exists in `provider_dirs`, the server logs an error and skips the integration.
+Gestalt resolves providers at startup from the `upstreams` list. If no upstreams are configured, or a REST upstream has no `url`, `provider`, or matching file in `provider_dirs`, the server logs an error and skips the integration.
 
-**Fix**: Check that `provider_dirs` includes the directory with your provider YAML files, and that the integration config includes either an `openapi` URL or a `provider` path.
+**Fix**: Ensure each integration has at least one entry in its `upstreams` list with a valid `type` and source (`url` or `provider`).
 
 ## OAuth redirects are wrong
 
@@ -34,7 +34,7 @@ The calling user has not connected the target integration. Each user must comple
 
 The web UI needs to know where the API server lives.
 
-**Fix**: Use `gestaltd` which starts both and wires them together automatically. If running separately, set `GESTALT_API_URL` to point to the API server.
+**Fix**: Use `gestaltd` which starts both and wires them together automatically. If running separately, set `GESTALT_URL` to point to the API server.
 
 ## Config validation fails
 
@@ -49,5 +49,5 @@ Run `gestaltd --check --config your-config.yaml` to see exactly which field is i
 1. Verify `mcp.enabled: true` in config.
 2. Check that your API token is valid.
 3. Confirm the token's owner has connected the integration.
-4. Verify `allowed_operations` is defined for the integration.
-5. If using `mcp.providers`, confirm the integration is in the list.
+4. If using `mcp.providers`, confirm the integration is in the list.
+5. For MCP-only integrations, remember they only appear in the MCP endpoint, not the HTTP API.


### PR DESCRIPTION
The documentation was materially behind the current code. Integrations
are now built from typed `upstreams[]` entries (`type: rest`, `graphql`,
or `mcp`) rather than top-level `openapi` or `provider` fields.
`allowed_operations` moved from integration-level to upstream-level and
now accepts both list and map formats. This rewrites all 12 doc pages
to reflect the current contract, adds coverage for GraphQL upstreams,
MCP upstream passthrough, composite integrations, the `basic` auth
style, `DELETE /api/v1/integrations/{name}`, and the full `/auth/info`
response shape including `dev_mode`.

Several incorrect references are also fixed: `GESTALT_SERVER_URL` and
`GESTALT_API_URL` are corrected to `GESTALT_URL`, the nonexistent
`auth_headers` field is removed, the unregistered gRPC binding is
removed from docs, CLI credential precedence and `auth status` output
formats are documented, and the contributing page now links to the
public `core/` interfaces and mentions the `.githooks/pre-push` hook.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>