### PR TITLE
Fix missing token ID in OAuth callback

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -482,6 +482,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	}
 
 	tok := &core.IntegrationToken{
+		ID:           uuid.NewString(),
 		UserID:       state.UserID,
 		Integration:  providerName,
 		Instance:     defaultTokenInstance,
@@ -491,6 +492,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := s.datastore.StoreToken(r.Context(), tok); err != nil {
+		log.Printf("failed to store token for %s: %v", providerName, err)
 		writeError(w, http.StatusInternalServerError, "failed to store token")
 		return
 	}
@@ -541,10 +543,11 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		ID:          uuid.NewString(),
 		UserID:      dbUser.ID,
 		Integration: req.Integration,
-		Instance:    "default",
+		Instance:    defaultTokenInstance,
 		AccessToken: req.Credential,
 	}
 	if err := s.datastore.StoreToken(r.Context(), tok); err != nil {
+		log.Printf("failed to store credential for %s: %v", req.Integration, err)
 		writeError(w, http.StatusInternalServerError, "failed to store credential")
 		return
 	}


### PR DESCRIPTION
The `integrationOAuthCallback` handler constructed an `IntegrationToken`
without setting the `ID` field, leaving it as an empty string. The first
OAuth integration connected successfully, but any subsequent integration
for the same user hit a primary key collision on `id=""` because the
upsert's `ON CONFLICT` clause only covers the `(user_id, integration,
instance)` unique constraint, not the primary key. This adds
`uuid.NewString()` to match what `connectManual` already does, and logs
the underlying error for easier debugging.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>