### PR TITLE
List available operations when invoke is called without an operation

### DIFF
--- a/client/cli/src/commands/invoke.rs
+++ b/client/cli/src/commands/invoke.rs
@@ -30,3 +30,22 @@ pub fn invoke(
 
     Ok(())
 }
+
+pub fn list_operations(
+    url_override: Option<&str>,
+    integration: &str,
+    format: Format,
+) -> Result<()> {
+    let client = ApiClient::from_env(url_override)?;
+    let path = format!("/api/v1/integrations/{}/operations", integration);
+    let resp = client
+        .get(&path)
+        .with_context(|| format!("failed to list operations for {}", integration))?;
+
+    match format {
+        Format::Json => output::print_json(&resp),
+        Format::Table => output::print_json_table(&resp),
+    }
+
+    Ok(())
+}

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -47,8 +47,8 @@ enum Commands {
         /// Integration name (e.g., github, slack)
         integration: String,
 
-        /// Operation name (e.g., search_code, list_channels)
-        operation: String,
+        /// Operation name (e.g., search_code, list_channels). Omit to list available operations.
+        operation: Option<String>,
 
         /// Parameters as key=value pairs
         #[arg(short = 'p', long = "param", value_parser = parse_key_val)]
@@ -156,7 +156,15 @@ fn main() {
             integration,
             operation,
             params,
-        } => commands::invoke::invoke(url, &integration, &operation, &params, format),
+        } => match operation {
+            Some(op) => commands::invoke::invoke(url, &integration, &op, &params, format),
+            None => {
+                if !params.is_empty() {
+                    output::print_warning("parameters ignored; no operation specified");
+                }
+                commands::invoke::list_operations(url, &integration, format)
+            }
+        },
         Commands::Tokens { command } => match command {
             TokenCommands::Create { name } => {
                 commands::tokens::create(url, name.as_deref(), format)


### PR DESCRIPTION
Running `gestalt invoke <integration>` without specifying an operation now queries the server for that integration's available operations and displays them. This uses the existing
`GET /api/v1/integrations/{name}/operations` endpoint that was already served but had no CLI surface. The `operation` argument is now optional, so `gestalt invoke slack` lists all slack operations while `gestalt invoke slack list_channels` continues to work as before.