### PR TITLE
Replace global MCP config with per-integration enablement

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -197,7 +197,6 @@ func defaultProviderFactory(providerDirs []string) bootstrap.ProviderFactory {
 	return func(ctx context.Context, name string, intg config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
 		var apiProv core.Provider
 		var mcpUp *mcpupstream.Upstream
-		var mcpFromAPI bool
 
 		connMode := core.ConnectionModeUser
 		switch core.ConnectionMode(intg.ConnectionMode) {
@@ -233,7 +232,6 @@ func defaultProviderFactory(providerDirs []string) bootstrap.ProviderFactory {
 					return nil, err
 				}
 				apiProv = p
-				mcpFromAPI = us.MCP
 			case config.UpstreamTypeGraphQL:
 				if apiProv != nil {
 					cleanup()
@@ -250,7 +248,6 @@ func defaultProviderFactory(providerDirs []string) bootstrap.ProviderFactory {
 					return nil, err
 				}
 				apiProv = p
-				mcpFromAPI = us.MCP
 			case config.UpstreamTypeMCP:
 				if mcpUp != nil {
 					cleanup()
@@ -275,7 +272,7 @@ func defaultProviderFactory(providerDirs []string) bootstrap.ProviderFactory {
 
 		switch {
 		case apiProv != nil && mcpUp != nil:
-			return composite.New(name, apiProv, mcpUp, mcpFromAPI), nil
+			return composite.New(name, apiProv, mcpUp), nil
 		case apiProv != nil:
 			return apiProv, nil
 		case mcpUp != nil:

--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -45,9 +45,21 @@ func run(args []string) error {
 
 	result := env.Result
 
+	var mcpProviders []string
+	mcpPrefixes := make(map[string]string)
+	for name := range env.Config.Integrations {
+		intg := env.Config.Integrations[name]
+		if intg.MCP {
+			mcpProviders = append(mcpProviders, name)
+			if intg.MCPToolPrefix != "" {
+				mcpPrefixes[name] = intg.MCPToolPrefix
+			}
+		}
+	}
+
 	var mcpSlot *lateHandler
 	var mcpHandler http.Handler
-	if env.Config.MCP.Enabled {
+	if len(mcpProviders) > 0 {
 		mcpSlot = &lateHandler{}
 		mcpHandler = mcpSlot
 	}
@@ -123,15 +135,11 @@ func run(args []string) error {
 			return fmt.Errorf("MCP token resolution requires *invocation.Broker as invoker")
 		}
 		mcpCfg := gestaltmcp.Config{
-			Invoker:       result.Invoker,
-			TokenResolver: broker,
-			Providers:     result.Providers,
-		}
-		if env.Config.MCP.Providers != nil {
-			mcpCfg.AllowedProviders = env.Config.MCP.Providers
-		}
-		if env.Config.MCP.ToolNamePrefix != "" {
-			mcpCfg.ToolNamePrefix = env.Config.MCP.ToolNamePrefix
+			Invoker:          result.Invoker,
+			TokenResolver:    broker,
+			Providers:        result.Providers,
+			AllowedProviders: mcpProviders,
+			ToolPrefixes:     mcpPrefixes,
 		}
 		mcpSlot.Set(mcpserver.NewStreamableHTTPServer(
 			gestaltmcp.NewServer(mcpCfg),

--- a/internal/composite/provider.go
+++ b/internal/composite/provider.go
@@ -20,11 +20,10 @@ type MCPUpstream interface {
 // Provider wraps an HTTP API provider and an MCP upstream for a single
 // integration. Execute goes to the API; CallTool goes to the upstream.
 type Provider struct {
-	name       string
-	api        core.Provider
-	mcp        MCPUpstream
-	mcpFromAPI bool
-	cat        *catalog.Catalog
+	name string
+	api  core.Provider
+	mcp  MCPUpstream
+	cat  *catalog.Catalog
 }
 
 var (
@@ -34,12 +33,11 @@ var (
 
 // New creates a composite provider. If the API provider implements
 // OAuthProvider, the returned provider does too.
-func New(name string, apiProv core.Provider, mcpUp MCPUpstream, mcpFromAPI bool) core.Provider {
+func New(name string, apiProv core.Provider, mcpUp MCPUpstream) core.Provider {
 	p := &Provider{
-		name:       name,
-		api:        apiProv,
-		mcp:        mcpUp,
-		mcpFromAPI: mcpFromAPI,
+		name: name,
+		api:  apiProv,
+		mcp:  mcpUp,
 	}
 	p.cat = p.buildCatalog()
 	if oauth, ok := apiProv.(core.OAuthProvider); ok {
@@ -109,10 +107,6 @@ func (o *oauthProvider) RefreshToken(ctx context.Context, refreshToken string) (
 
 func (p *Provider) buildCatalog() *catalog.Catalog {
 	mcpCat := p.mcp.Catalog()
-
-	if !p.mcpFromAPI {
-		return tagMCPCatalog(mcpCat)
-	}
 
 	var apiCat *catalog.Catalog
 	if cp, ok := p.api.(core.CatalogProvider); ok {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,13 +24,6 @@ type Config struct {
 	Bindings     map[string]BindingDef     `yaml:"bindings"`
 	ProviderDirs []string                  `yaml:"provider_dirs"`
 	Server       ServerConfig              `yaml:"server"`
-	MCP          MCPConfig                 `yaml:"mcp"`
-}
-
-type MCPConfig struct {
-	Enabled        bool     `yaml:"enabled"`
-	Providers      []string `yaml:"providers"`
-	ToolNamePrefix string   `yaml:"tool_name_prefix"`
 }
 
 type RuntimeDef struct {
@@ -80,6 +73,8 @@ type IntegrationDef struct {
 	Description    string        `yaml:"description"`
 	AuthProfile    string        `yaml:"auth_profile"`
 	ConnectionMode string        `yaml:"connection_mode"`
+	MCP            bool          `yaml:"mcp"`
+	MCPToolPrefix  string        `yaml:"mcp_tool_prefix"`
 
 	ClientID     string `yaml:"client_id"`
 	ClientSecret string `yaml:"client_secret"`
@@ -110,7 +105,6 @@ type UpstreamDef struct {
 	Type              string     `yaml:"type"`
 	URL               string     `yaml:"url"`
 	Provider          string     `yaml:"provider"`
-	MCP               bool       `yaml:"mcp"`
 	AllowedOperations AllowedOps `yaml:"allowed_operations"`
 }
 

--- a/internal/mcp/binding.go
+++ b/internal/mcp/binding.go
@@ -35,7 +35,7 @@ type Config struct {
 	TokenResolver    TokenResolver
 	Providers        *registry.PluginMap[core.Provider]
 	AllowedProviders []string
-	ToolNamePrefix   string
+	ToolPrefixes     map[string]string
 }
 
 func NewServer(cfg Config) *mcpserver.MCPServer {
@@ -83,7 +83,7 @@ func addCatalogTools(srv *mcpserver.MCPServer, cfg Config, provName string, cat 
 			continue
 		}
 
-		name := toolName(cfg.ToolNamePrefix, provName, op.ID)
+		name := toolName(cfg.ToolPrefixes, provName, op.ID)
 
 		var tool mcpgo.Tool
 		if len(op.InputSchema) > 0 {
@@ -111,7 +111,7 @@ func addCatalogTools(srv *mcpserver.MCPServer, cfg Config, provName string, cat 
 
 func addFlatTools(srv *mcpserver.MCPServer, cfg Config, provName string, prov core.Provider) {
 	for _, op := range prov.ListOperations() {
-		name := toolName(cfg.ToolNamePrefix, provName, op.Name)
+		name := toolName(cfg.ToolPrefixes, provName, op.Name)
 
 		opts := []mcpgo.ToolOption{mcpgo.WithDescription(op.Description)}
 		annot := mapAnnotations(ci.AnnotationsFromMethod(op.Method))
@@ -177,8 +177,8 @@ func unwrapDirectCaller(prov core.Provider) (directToolCaller, bool) {
 	return nil, false
 }
 
-func toolName(prefix, provider, operation string) string {
-	return prefix + provider + toolNameSep + operation
+func toolName(prefixes map[string]string, provider, operation string) string {
+	return prefixes[provider] + provider + toolNameSep + operation
 }
 
 func mapAnnotations(a catalog.OperationAnnotations) mcpgo.ToolAnnotation {

--- a/internal/mcp/binding_test.go
+++ b/internal/mcp/binding_test.go
@@ -179,9 +179,9 @@ func TestNewServer_ToolNameConvention(t *testing.T) {
 	broker := invocation.NewBroker(providers, ds)
 
 	srv := gestaltmcp.NewServer(gestaltmcp.Config{
-		Invoker:        broker,
-		Providers:      providers,
-		ToolNamePrefix: "ts_",
+		Invoker:      broker,
+		Providers:    providers,
+		ToolPrefixes: map[string]string{"slack": "ts_"},
 	})
 
 	tools := srv.ListTools()

--- a/internal/mcp/composite_test.go
+++ b/internal/mcp/composite_test.go
@@ -71,7 +71,7 @@ func TestComposite_MCPPassthroughRouting(t *testing.T) {
 		},
 	}
 
-	comp := composite.New("notion", apiProv, mcpUp, false)
+	comp := composite.New("notion", apiProv, mcpUp)
 	providers := testutil.NewProviderRegistry(t, comp)
 	srv := gestaltmcp.NewServer(gestaltmcp.Config{
 		Invoker:       &testutil.StubInvoker{},
@@ -83,8 +83,8 @@ func TestComposite_MCPPassthroughRouting(t *testing.T) {
 	if tools["notion_search"] == nil {
 		t.Fatal("expected notion_search tool from MCP upstream")
 	}
-	if tools["notion_list_pages"] != nil {
-		t.Fatal("API tool should not appear when mcpFromAPI=false")
+	if tools["notion_list_pages"] == nil {
+		t.Fatal("expected notion_list_pages tool from API upstream")
 	}
 
 	tool := srv.GetTool("notion_search")
@@ -144,7 +144,7 @@ func TestComposite_MCPFromAPIExposesBothToolSets(t *testing.T) {
 		},
 	}
 
-	comp := composite.New("notion", apiProv, mcpUp, true)
+	comp := composite.New("notion", apiProv, mcpUp)
 	providers := testutil.NewProviderRegistry(t, comp)
 	ds := stubDatastoreWithToken()
 	broker := invocation.NewBroker(providers, ds)
@@ -218,7 +218,7 @@ func TestComposite_ExecuteDelegatesToAPI(t *testing.T) {
 		},
 	}
 
-	comp := composite.New("notion", apiProv, mcpUp, false)
+	comp := composite.New("notion", apiProv, mcpUp)
 
 	result, err := comp.Execute(context.Background(), "get_page", map[string]any{"id": "page1"}, "token")
 	if err != nil {


### PR DESCRIPTION
The global `mcp:` config block required maintaining a separate whitelist
of MCP-exposed providers, which meant adding a new integration touched
two places and you could not tell from an integration's config whether
it was MCP-exposed. Each integration now declares `mcp: true` to opt
in, and the `/mcp` endpoint is created automatically when any
integration enables it. The per-provider `mcp_tool_prefix` field
replaces the old global `tool_name_prefix`.

The upstream-level `mcp` flag and the `mcpFromAPI` gating in composite
providers are also removed. Composite providers now always merge all
upstream catalogs, since the upstream list itself already controls what
tools exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)