### PR TITLE
Show settings icon for all integrations, not just connected ones

### DIFF
--- a/web/e2e/auth.spec.ts
+++ b/web/e2e/auth.spec.ts
@@ -7,19 +7,19 @@ test.describe("Authentication", () => {
   });
 
   test("login page renders with provider button", async ({ page }) => {
-    await mockAuthInfo(page, { provider: "google", display_name: "Google" });
+    await mockAuthInfo(page, { provider: "test-sso", display_name: "Test SSO" });
     await page.goto("/login");
     await expect(
       page.getByRole("heading", { name: "Gestalt" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: /Sign in with Google/i }),
+      page.getByRole("button", { name: /Sign in with Test SSO/i }),
     ).toBeVisible();
   });
 
   test("authenticated user sees dashboard", async ({ authenticatedPage }) => {
     const page = authenticatedPage;
-    await mockIntegrations(page, [{ name: "slack", display_name: "Slack" }]);
+    await mockIntegrations(page, [{ name: "test-svc", display_name: "Test Service" }]);
     await mockTokens(page, []);
 
     await page.goto("/");

--- a/web/e2e/navigation.spec.ts
+++ b/web/e2e/navigation.spec.ts
@@ -6,7 +6,7 @@ test.describe("Navigation", () => {
   }) => {
     const page = authenticatedPage;
     await mockIntegrations(page, [
-      { name: "slack", display_name: "Slack", description: "Team messaging" },
+      { name: "test-svc", display_name: "Test Service", description: "A test integration" },
     ]);
     await mockTokens(page, []);
 
@@ -35,7 +35,7 @@ test.describe("Navigation", () => {
   test("navigating to /integrations works", async ({ authenticatedPage }) => {
     const page = authenticatedPage;
     await mockIntegrations(page, [
-      { name: "slack", display_name: "Slack", description: "Team messaging" },
+      { name: "test-svc", display_name: "Test Service", description: "A test integration" },
     ]);
     await mockTokens(page, []);
 

--- a/web/src/components/IntegrationCard.tsx
+++ b/web/src/components/IntegrationCard.tsx
@@ -228,18 +228,18 @@ export default function IntegrationCard({
             )}
           </div>
         </div>
-        {integration.connected && (
-          <div className="flex items-center gap-1">
+        <div className="flex items-center gap-1">
+          {integration.connected && (
             <CheckCircleIcon className="h-5 w-5 text-grove-500" />
-            <button
-              onClick={() => setSettingsOpen(true)}
-              className="flex h-8 w-8 items-center justify-center rounded text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-600"
-              aria-label={`${integration.display_name || integration.name} settings`}
-            >
-              <GearIcon className="h-4 w-4" />
-            </button>
-          </div>
-        )}
+          )}
+          <button
+            onClick={() => setSettingsOpen(true)}
+            className="flex h-8 w-8 items-center justify-center rounded text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-600"
+            aria-label={`${integration.display_name || integration.name} settings`}
+          >
+            <GearIcon className="h-4 w-4" />
+          </button>
+        </div>
       </div>
       {error && !settingsOpen && (
         <p className="mt-2 text-sm text-ember-500">{error}</p>
@@ -294,13 +294,6 @@ export default function IntegrationCard({
             </Button>
           </div>
         </form>
-      )}
-      {!showTokenForm && !showParamForm && !integration.connected && (
-        <div className="mt-4">
-          <Button onClick={handleConnect} disabled={loading}>
-            {loading ? "Connecting..." : "Connect"}
-          </Button>
-        </div>
       )}
       {settingsOpen && (
         <IntegrationSettingsModal

--- a/web/src/components/IntegrationSettingsModal.tsx
+++ b/web/src/components/IntegrationSettingsModal.tsx
@@ -110,34 +110,54 @@ export default function IntegrationSettingsModal({
               </button>
             </div>
 
-            <div className="mt-4 flex items-center gap-2">
-              <CheckCircleIcon className="h-5 w-5 text-grove-500" />
-              <span className="text-sm font-medium text-grove-600">
-                Connected
-              </span>
-            </div>
+            {integration.connected ? (
+              <>
+                <div className="mt-4 flex items-center gap-2">
+                  <CheckCircleIcon className="h-5 w-5 text-grove-500" />
+                  <span className="text-sm font-medium text-grove-600">
+                    Connected
+                  </span>
+                </div>
 
-            {error && <p className="mt-3 text-sm text-ember-500">{error}</p>}
+                {error && <p className="mt-3 text-sm text-ember-500">{error}</p>}
 
-            <div className="mt-6">
-              <Button
-                className="w-full"
-                onClick={onReconnect}
-                disabled={reconnecting}
-              >
-                {reconnecting ? "Connecting..." : "Reconnect"}
-              </Button>
-            </div>
+                <div className="mt-6">
+                  <Button
+                    className="w-full"
+                    onClick={onReconnect}
+                    disabled={reconnecting}
+                  >
+                    {reconnecting ? "Connecting..." : "Reconnect"}
+                  </Button>
+                </div>
 
-            <div className="mt-4 border-t border-border pt-4">
-              <Button
-                variant="danger"
-                className="w-full"
-                onClick={() => setConfirmingDisconnect(true)}
-              >
-                Disconnect
-              </Button>
-            </div>
+                <div className="mt-4 border-t border-border pt-4">
+                  <Button
+                    variant="danger"
+                    className="w-full"
+                    onClick={() => setConfirmingDisconnect(true)}
+                  >
+                    Disconnect
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <>
+                <p className="mt-4 text-sm text-stone-500">Not connected</p>
+
+                {error && <p className="mt-3 text-sm text-ember-500">{error}</p>}
+
+                <div className="mt-6">
+                  <Button
+                    className="w-full"
+                    onClick={onReconnect}
+                    disabled={reconnecting}
+                  >
+                    {reconnecting ? "Connecting..." : "Connect"}
+                  </Button>
+                </div>
+              </>
+            )}
           </>
         )}
       </div>


### PR DESCRIPTION
The integrations page previously showed a "Connect" button for
disconnected integrations and a gear icon only for connected ones.
This always shows the gear icon, moving the connect action into the
settings modal that opens when clicked. Disconnected integrations
show a "Connect" button in the modal, while connected ones continue
to show "Reconnect" and "Disconnect" as before.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>