### PR TITLE
Add strict `gestaltd validate` command

### DIFF
--- a/Formula/gestalt.rb
+++ b/Formula/gestalt.rb
@@ -5,34 +5,34 @@ require_relative "lib/private_strategy"
 class Gestalt < Formula
   desc "CLI for Gestalt API - authentication, integration management, and operation invocation"
   homepage "https://github.com/valon-technologies/gestalt"
-  version "0.0.1-alpha.2"
+  version "0.0.1-alpha.3"
   license "Proprietary"
 
   on_macos do
     on_arm do
-      url "https://github.com/valon-technologies/gestalt/releases/download/v0.0.1-alpha.2/gestalt-macos-arm64.tar.gz",
+      url "https://github.com/valon-technologies/gestalt/releases/download/v0.0.1-alpha.3/gestalt-macos-arm64.tar.gz",
           using: GitHubPrivateRepositoryReleaseDownloadStrategy
-      sha256 "a280c71083a231f47a29a29e802b84a556858515569639e3a5fc727494aa57c1"
+      sha256 "9be356bba80ff90850c7f9d9a1df8c8f2f6052479bd770b4ab00e5a99771337f"
     end
 
     on_intel do
-      url "https://github.com/valon-technologies/gestalt/releases/download/v0.0.1-alpha.2/gestalt-macos-x86_64.tar.gz",
+      url "https://github.com/valon-technologies/gestalt/releases/download/v0.0.1-alpha.3/gestalt-macos-x86_64.tar.gz",
           using: GitHubPrivateRepositoryReleaseDownloadStrategy
-      sha256 "19b0079c0590688c681b06224b973bdbeda8266a0ac32968f84238811ac282be"
+      sha256 "eea9aca7573568581342b05353d28d0222af9fb4d1502edc8fe3bcdce5c4d169"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/valon-technologies/gestalt/releases/download/v0.0.1-alpha.2/gestalt-linux-arm64.tar.gz",
+      url "https://github.com/valon-technologies/gestalt/releases/download/v0.0.1-alpha.3/gestalt-linux-arm64.tar.gz",
           using: GitHubPrivateRepositoryReleaseDownloadStrategy
-      sha256 "ea6ef84a82365acfc0321640f46736071b3752a69e903e762aa582d1891d1be1"
+      sha256 "37dd7a5a7998bbac2b4340d481c28b9b5aac96fb83df6acfe448af881d0222e7"
     end
 
     on_intel do
-      url "https://github.com/valon-technologies/gestalt/releases/download/v0.0.1-alpha.2/gestalt-linux-x86_64.tar.gz",
+      url "https://github.com/valon-technologies/gestalt/releases/download/v0.0.1-alpha.3/gestalt-linux-x86_64.tar.gz",
           using: GitHubPrivateRepositoryReleaseDownloadStrategy
-      sha256 "2a4d9ab6080f4acdf18aecfef44baaedf835e33461ad7cfdcf265beb4be9c30b"
+      sha256 "15458ba8ba3049e483b820692166ea8550812abf5eb9569cc485c31bf27d1027"
     end
   end
 

--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"os/signal"
@@ -18,7 +17,6 @@ import (
 	"github.com/valon-technologies/gestalt/internal/mcpupstream"
 	"github.com/valon-technologies/gestalt/internal/openapi"
 	"github.com/valon-technologies/gestalt/internal/provider"
-	"github.com/valon-technologies/gestalt/internal/registry"
 	"github.com/valon-technologies/gestalt/plugins/auth/google"
 	"github.com/valon-technologies/gestalt/plugins/auth/oidc"
 	"github.com/valon-technologies/gestalt/plugins/bindings/webhook"
@@ -136,7 +134,9 @@ func startPlugins(env *bootstrapEnv) error {
 				return fmt.Errorf("getting runtime %q: %v", name, err)
 			}
 			if err := rt.Start(env.Ctx); err != nil {
-				stopRuntimes(env.Ctx, result.Runtimes, started)
+				if stopErr := bootstrap.StopRuntimes(env.Ctx, result.Runtimes, started); stopErr != nil {
+					log.Printf("stopping runtimes after startup failure: %v", stopErr)
+				}
 				return fmt.Errorf("starting runtime %q: %v", name, err)
 			}
 			started = append(started, name)
@@ -147,16 +147,24 @@ func startPlugins(env *bootstrapEnv) error {
 		for _, name := range result.Bindings.List() {
 			binding, err := result.Bindings.Get(name)
 			if err != nil {
-				closeBindings(result.Bindings, started)
+				if closeErr := bootstrap.CloseBindings(result.Bindings, started); closeErr != nil {
+					log.Printf("closing bindings after startup failure: %v", closeErr)
+				}
 				if result.Runtimes != nil {
-					stopRuntimes(env.Ctx, result.Runtimes, result.Runtimes.List())
+					if stopErr := bootstrap.StopRuntimes(env.Ctx, result.Runtimes, result.Runtimes.List()); stopErr != nil {
+						log.Printf("stopping runtimes after startup failure: %v", stopErr)
+					}
 				}
 				return fmt.Errorf("getting binding %q: %v", name, err)
 			}
 			if err := binding.Start(env.Ctx); err != nil {
-				closeBindings(result.Bindings, started)
+				if closeErr := bootstrap.CloseBindings(result.Bindings, started); closeErr != nil {
+					log.Printf("closing bindings after startup failure: %v", closeErr)
+				}
 				if result.Runtimes != nil {
-					stopRuntimes(env.Ctx, result.Runtimes, result.Runtimes.List())
+					if stopErr := bootstrap.StopRuntimes(env.Ctx, result.Runtimes, result.Runtimes.List()); stopErr != nil {
+						log.Printf("stopping runtimes after startup failure: %v", stopErr)
+					}
 				}
 				return fmt.Errorf("starting binding %q: %v", name, err)
 			}
@@ -168,28 +176,17 @@ func startPlugins(env *bootstrapEnv) error {
 
 func shutdownPlugins(ctx context.Context, env *bootstrapEnv) {
 	if env.Result.Bindings != nil {
-		closeBindings(env.Result.Bindings, env.Result.Bindings.List())
+		if err := bootstrap.CloseBindings(env.Result.Bindings, env.Result.Bindings.List()); err != nil {
+			log.Printf("closing bindings: %v", err)
+		}
 	}
 	if env.Result.Runtimes != nil {
-		stopRuntimes(ctx, env.Result.Runtimes, env.Result.Runtimes.List())
-	}
-	closeProviders(env.Result.Providers)
-}
-
-func closeProviders(providers *registry.PluginMap[core.Provider]) {
-	if providers == nil {
-		return
-	}
-	for _, name := range providers.List() {
-		prov, err := providers.Get(name)
-		if err != nil {
-			continue
+		if err := bootstrap.StopRuntimes(ctx, env.Result.Runtimes, env.Result.Runtimes.List()); err != nil {
+			log.Printf("stopping runtimes: %v", err)
 		}
-		if c, ok := prov.(io.Closer); ok {
-			if err := c.Close(); err != nil {
-				log.Printf("closing provider %q: %v", name, err)
-			}
-		}
+	}
+	if err := bootstrap.CloseProviders(env.Result.Providers); err != nil {
+		log.Printf("closing providers: %v", err)
 	}
 }
 
@@ -205,7 +202,7 @@ func defaultProviderFactory(providerDirs []string) bootstrap.ProviderFactory {
 				connMode = core.ConnectionMode(intg.ConnectionMode)
 			}
 		default:
-			return nil, fmt.Errorf("integration %s: unknown connection_mode %q", name, intg.ConnectionMode)
+			return nil, fmt.Errorf("unknown connection_mode %q", intg.ConnectionMode)
 		}
 
 		cleanup := func() {
@@ -219,7 +216,7 @@ func defaultProviderFactory(providerDirs []string) bootstrap.ProviderFactory {
 			case config.UpstreamTypeREST:
 				if apiProv != nil {
 					cleanup()
-					return nil, fmt.Errorf("integration %s: multiple rest upstreams not supported", name)
+					return nil, fmt.Errorf("multiple rest upstreams not supported")
 				}
 				def, err := loadHTTPUpstream(ctx, name, us, providerDirs)
 				if err != nil {
@@ -235,7 +232,7 @@ func defaultProviderFactory(providerDirs []string) bootstrap.ProviderFactory {
 			case config.UpstreamTypeGraphQL:
 				if apiProv != nil {
 					cleanup()
-					return nil, fmt.Errorf("integration %s: multiple api upstreams not supported", name)
+					return nil, fmt.Errorf("multiple api upstreams not supported")
 				}
 				def, err := graphqlupstream.LoadDefinition(ctx, name, us.URL, map[string]string(us.AllowedOperations))
 				if err != nil {
@@ -251,7 +248,7 @@ func defaultProviderFactory(providerDirs []string) bootstrap.ProviderFactory {
 			case config.UpstreamTypeMCP:
 				if mcpUp != nil {
 					cleanup()
-					return nil, fmt.Errorf("integration %s: multiple mcp upstreams not supported", name)
+					return nil, fmt.Errorf("multiple mcp upstreams not supported")
 				}
 				up, err := mcpupstream.New(ctx, name, us.URL, connMode)
 				if err != nil {
@@ -260,13 +257,13 @@ func defaultProviderFactory(providerDirs []string) bootstrap.ProviderFactory {
 				if us.AllowedOperations != nil {
 					if err := up.FilterOperations(map[string]string(us.AllowedOperations)); err != nil {
 						_ = up.Close()
-						return nil, fmt.Errorf("integration %s: %w", name, err)
+						return nil, err
 					}
 				}
 				mcpUp = up
 			default:
 				cleanup()
-				return nil, fmt.Errorf("integration %s: unknown upstream type %q", name, us.Type)
+				return nil, fmt.Errorf("unknown upstream type %q", us.Type)
 			}
 		}
 
@@ -278,7 +275,7 @@ func defaultProviderFactory(providerDirs []string) bootstrap.ProviderFactory {
 		case mcpUp != nil:
 			return mcpUp, nil
 		default:
-			return nil, fmt.Errorf("integration %s: no upstreams configured", name)
+			return nil, fmt.Errorf("no upstreams configured")
 		}
 	}
 }

--- a/cmd/gestaltd/main_test.go
+++ b/cmd/gestaltd/main_test.go
@@ -1,17 +1,28 @@
 package main
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestRun_CheckWithMissingConfig(t *testing.T) {
+func TestRun_ValidateWithMissingConfig(t *testing.T) {
 	t.Parallel()
 
-	err := run([]string{"--check", "--config", "nonexistent.yaml"})
+	err := run([]string{"validate", "--config", "nonexistent.yaml"})
 	if err == nil {
 		t.Fatal("expected error for missing config file")
+	}
+}
+
+func TestRun_CheckFlagRejected(t *testing.T) {
+	t.Parallel()
+
+	err := run([]string{"--check"})
+	if err == nil {
+		t.Fatal("expected error for removed --check flag")
 	}
 }
 
@@ -31,8 +42,20 @@ func TestGestaltd_HelpExitsCleanly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected exit 0 for --help, got error: %v\noutput: %s", err, out)
 	}
-	if !strings.Contains(string(out), "-config") {
-		t.Fatalf("expected usage output containing '-config', got: %s", out)
+	if !strings.Contains(string(out), "gestaltd validate") {
+		t.Fatalf("expected usage output containing 'gestaltd validate', got: %s", out)
+	}
+}
+
+func TestGestaltdValidateHelpExitsCleanly(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("go", "run", ".", "validate", "--help")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected exit 0 for 'validate --help', got error: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(string(out), "gestaltd validate") {
+		t.Fatalf("expected usage output containing 'gestaltd validate', got: %s", out)
 	}
 }
 
@@ -49,5 +72,77 @@ func TestRun_RejectsTrailingArgs(t *testing.T) {
 	err := run([]string{"--config", "foo.yaml", "extra"})
 	if err == nil {
 		t.Fatal("expected error for trailing arguments")
+	}
+}
+
+func TestRun_ValidateRejectsTrailingArgs(t *testing.T) {
+	t.Parallel()
+
+	err := run([]string{"validate", "--config", "foo.yaml", "extra"})
+	if err == nil {
+		t.Fatal("expected error for trailing arguments")
+	}
+}
+
+func TestRun_ValidateWithStrictProviderErrors(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `auth:
+  provider: google
+  config:
+    client_id: test-client
+    client_secret: test-secret
+    redirect_url: http://localhost:8080/api/v1/auth/login/callback
+datastore:
+  provider: sqlite
+  config:
+    path: ` + filepath.Join(dir, "gestalt.db") + `
+server:
+  dev_mode: true
+  encryption_key: test-key
+integrations:
+  broken:
+    upstreams:
+      - type: http
+        url: https://example.com/openapi.json
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	err := run([]string{"validate", "--config", cfgPath})
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), `unknown upstream type "http"`) {
+		t.Fatalf("expected unknown upstream type error, got: %v", err)
+	}
+}
+
+func TestRun_ValidateRejectsLegacyGlobalMCPConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `auth:
+  provider: google
+server:
+  dev_mode: true
+  encryption_key: test-key
+mcp:
+  enabled: true
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	err := run([]string{"validate", "--config", cfgPath})
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), `field mcp not found in type config.Config`) {
+		t.Fatalf("expected unknown mcp field error, got: %v", err)
 	}
 }

--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -4,18 +4,19 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/crypto"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	gestaltmcp "github.com/valon-technologies/gestalt/internal/mcp"
-	"github.com/valon-technologies/gestalt/internal/registry"
 	"github.com/valon-technologies/gestalt/internal/server"
 	"github.com/valon-technologies/gestalt/internal/webui"
 
@@ -23,18 +24,28 @@ import (
 )
 
 func run(args []string) error {
+	if len(args) > 0 {
+		switch args[0] {
+		case "-h", "--help", "help":
+			printMainUsage(os.Stderr)
+			return flag.ErrHelp
+		case "validate":
+			return runValidate(args[1:])
+		}
+	}
+
+	return runServe(args)
+}
+
+func runServe(args []string) error {
 	fs := flag.NewFlagSet("gestaltd", flag.ContinueOnError)
+	fs.Usage = func() { printMainUsage(fs.Output()) }
 	configPath := fs.String("config", "", "path to config file")
-	check := fs.Bool("check", false, "validate configuration and exit")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if fs.NArg() > 0 {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
-	}
-
-	if *check {
-		return runCheck(*configPath)
 	}
 
 	env, err := setupBootstrap(*configPath)
@@ -157,7 +168,21 @@ func run(args []string) error {
 	return nil
 }
 
-func runCheck(configFlag string) error {
+func runValidate(args []string) error {
+	fs := flag.NewFlagSet("gestaltd validate", flag.ContinueOnError)
+	fs.Usage = func() { printValidateUsage(fs.Output()) }
+	configPath := fs.String("config", "", "path to config file")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+
+	return validateConfig(*configPath)
+}
+
+func validateConfig(configFlag string) error {
 	path := resolveConfigPath(configFlag)
 
 	cfg, err := config.Load(path)
@@ -165,6 +190,16 @@ func runCheck(configFlag string) error {
 		return fmt.Errorf("config invalid: %v", err)
 	}
 
+	if err := bootstrap.Validate(context.Background(), cfg, buildFactories(cfg.ProviderDirs, cfg.Server.DevMode)); err != nil {
+		return fmt.Errorf("config invalid: %v", err)
+	}
+
+	logConfigSummary(path, cfg)
+	log.Printf("config ok")
+	return nil
+}
+
+func logConfigSummary(path string, cfg *config.Config) {
 	log.Printf("config file: %s", path)
 	log.Printf("server:")
 	log.Printf("  port:       %d", cfg.Server.Port)
@@ -209,9 +244,6 @@ func runCheck(configFlag string) error {
 			log.Printf("  %s: type=%s", name, b.Type)
 		}
 	}
-
-	log.Printf("config ok")
-	return nil
 }
 
 func maskSecret(s string) string {
@@ -228,30 +260,28 @@ func maskEmpty(s string) string {
 	return s
 }
 
-func closeBindings(bindings *registry.PluginMap[core.Binding], names []string) {
-	for _, name := range names {
-		b, err := bindings.Get(name)
-		if err != nil {
-			log.Printf("looking up binding %q during shutdown: %v", name, err)
-			continue
-		}
-		if err := b.Close(); err != nil {
-			log.Printf("closing binding %q: %v", name, err)
-		}
-	}
+func printMainUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd [--config PATH]")
+	writeUsageLine(w, "  gestaltd validate [--config PATH]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Commands:")
+	writeUsageLine(w, "  validate    Load and validate configuration, then exit")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Flags:")
+	writeUsageLine(w, "  --config    Path to the config file")
 }
 
-func stopRuntimes(ctx context.Context, runtimes *registry.PluginMap[core.Runtime], names []string) {
-	for _, name := range names {
-		rt, err := runtimes.Get(name)
-		if err != nil {
-			log.Printf("looking up runtime %q during shutdown: %v", name, err)
-			continue
-		}
-		if err := rt.Stop(ctx); err != nil {
-			log.Printf("stopping runtime %q: %v", name, err)
-		}
-	}
+func printValidateUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd validate [--config PATH]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Validate the configuration using the daemon's full bootstrap path,")
+	writeUsageLine(w, "without starting the server or running datastore migrations.")
+}
+
+func writeUsageLine(w io.Writer, line string) {
+	_, _ = fmt.Fprintln(w, line)
 }
 
 type lateHandler struct {

--- a/core/integration/base.go
+++ b/core/integration/base.go
@@ -19,6 +19,7 @@ var (
 	_ core.ManualProvider          = (*Base)(nil)
 	_ core.CatalogProvider         = (*Base)(nil)
 	_ core.ConnectionParamProvider = (*Base)(nil)
+	_ core.PostConnectProvider     = (*Base)(nil)
 )
 
 type manualChecker interface{ IsManual() bool }
@@ -112,7 +113,8 @@ type Base struct {
 	RequestMutator func(operation string, req *apiexec.Request, params map[string]any) error
 	ExecuteFunc    func(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error)
 
-	ConnectionDefs map[string]core.ConnectionParamDef
+	ConnectionDefs    map[string]core.ConnectionParamDef
+	PostConnectHookFn core.PostConnectHook
 
 	catalog *catalog.Catalog
 }
@@ -135,6 +137,10 @@ func (b *Base) SupportsManualAuth() bool {
 
 func (b *Base) ConnectionParamDefs() map[string]core.ConnectionParamDef {
 	return b.ConnectionDefs
+}
+
+func (b *Base) PostConnectHook() core.PostConnectHook {
+	return b.PostConnectHookFn
 }
 
 func (b *Base) TokenURL() string {

--- a/core/provider.go
+++ b/core/provider.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/valon-technologies/gestalt/core/catalog"
 )
@@ -52,4 +53,10 @@ type ConnectionParamDef struct {
 
 type ConnectionParamProvider interface {
 	ConnectionParamDefs() map[string]ConnectionParamDef
+}
+
+type PostConnectHook func(ctx context.Context, token *IntegrationToken, client *http.Client) (map[string]string, error)
+
+type PostConnectProvider interface {
+	PostConnectHook() PostConnectHook
 }

--- a/docs/pages/contributing.mdx
+++ b/docs/pages/contributing.mdx
@@ -36,7 +36,7 @@ cd gestalt
 go test ./...
 
 # Validate config
-gestaltd --check --config gestalt.dev.yaml
+gestaltd validate --config gestalt.dev.yaml
 
 # Run locally
 gestaltd --config gestalt.dev.yaml

--- a/docs/pages/deploy/index.mdx
+++ b/docs/pages/deploy/index.mdx
@@ -71,7 +71,7 @@ datastore:
 ## Validate before deploying
 
 ```sh
-gestaltd --check --config your-config.yaml
+gestaltd validate --config your-config.yaml
 ```
 
 ## Choose a platform

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -10,19 +10,20 @@ Gestalt ships two binaries: the Go server (`gestaltd`) and the Rust client (`ges
 
 ```sh
 gestaltd --config config.yaml
+gestaltd validate --config config.yaml
 ```
 
-### Flags
+### Commands
 
-| Flag | Default | Purpose |
-|---|---|---|
-| `--config` | (see resolution order) | Path to config file. |
-| `--check` | `false` | Validate configuration, print resolved values, and exit. |
+| Command | Purpose |
+|---|---|
+| `gestaltd --config config.yaml` | Start the server. |
+| `gestaltd validate --config config.yaml` | Load and validate config, then exit without starting the server. |
 
 ### Validate configuration
 
 ```sh
-gestaltd --check --config config.yaml
+gestaltd validate --config config.yaml
 ```
 
 Prints: config file path, server settings, auth provider, datastore, secrets provider, integration count and details, runtime count, binding count. Exits with "config ok" if valid.

--- a/docs/pages/tasks/add-an-integration.mdx
+++ b/docs/pages/tasks/add-an-integration.mdx
@@ -144,7 +144,7 @@ See [Connection Modes](/concepts/platform-model#connection-modes) for all option
 ## 8. Validate end to end
 
 ```sh
-gestaltd --check --config your-config.yaml
+gestaltd validate --config your-config.yaml
 gestalt integrations list
 gestalt integrations connect slack
 gestalt invoke slack conversations_list

--- a/docs/pages/tasks/run-locally.mdx
+++ b/docs/pages/tasks/run-locally.mdx
@@ -44,7 +44,7 @@ Runs the API on port 8080 and the web UI on port 3000. Config is mounted from `d
 ## Validate your config
 
 ```sh
-gestaltd --check --config gestalt.dev.yaml
+gestaltd validate --config gestalt.dev.yaml
 ```
 
 Prints resolved server settings, auth provider, datastore, integrations, runtimes, and bindings. Exits with "config ok" if valid.

--- a/docs/pages/troubleshooting.mdx
+++ b/docs/pages/troubleshooting.mdx
@@ -38,7 +38,7 @@ The web UI needs to know where the API server lives.
 
 ## Config validation fails
 
-Run `gestaltd --check --config your-config.yaml` to see exactly which field is invalid. Common causes:
+Run `gestaltd validate --config your-config.yaml` to see exactly which field is invalid. Common causes:
 
 - Missing `encryption_key` when `dev_mode` is not `true`.
 - Invalid provider name in `auth`, `datastore`, or `secrets`.

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -36,6 +36,12 @@ func stubProviderFactory(name string) bootstrap.ProviderFactory {
 	}
 }
 
+func stubRuntimeFactory(name string, stopFn func(context.Context) error) bootstrap.RuntimeFactory {
+	return func(_ context.Context, _ string, _ config.RuntimeDef, _ bootstrap.RuntimeDeps) (core.Runtime, error) {
+		return &coretesting.StubRuntime{N: name, StopFn: stopFn}, nil
+	}
+}
+
 type stubIntegrationWithOps struct {
 	coretesting.StubIntegration
 	ops []core.Operation
@@ -123,6 +129,38 @@ func TestBootstrap(t *testing.T) {
 	names := result.Providers.List()
 	if len(names) != 1 || names[0] != "alpha" {
 		t.Errorf("Providers.List: got %v, want [alpha]", names)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	if err := bootstrap.Validate(context.Background(), validConfig(), validFactories()); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestValidateStopsConstructedRuntimes(t *testing.T) {
+	t.Parallel()
+
+	stopped := false
+
+	cfg := validConfig()
+	cfg.Runtimes = map[string]config.RuntimeDef{
+		"echo": {Type: "test-runtime"},
+	}
+
+	factories := validFactories()
+	factories.Runtimes["test-runtime"] = stubRuntimeFactory("echo", func(context.Context) error {
+		stopped = true
+		return nil
+	})
+
+	if err := bootstrap.Validate(context.Background(), cfg, factories); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if !stopped {
+		t.Fatal("expected Validate to stop constructed runtimes")
 	}
 }
 
@@ -333,6 +371,27 @@ func TestBootstrapProviderErrorSkipsProvider(t *testing.T) {
 	names := result.Providers.List()
 	if len(names) != 1 || names[0] != "alpha" {
 		t.Errorf("Providers.List: got %v, want [alpha] (beta should be skipped)", names)
+	}
+}
+
+func TestValidateProviderErrorFails(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cfg := validConfig()
+	cfg.Integrations["beta"] = config.IntegrationDef{}
+
+	factories := validFactories()
+	factories.Providers["beta"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
+		return nil, fmt.Errorf("provider broke")
+	}
+
+	err := bootstrap.Validate(ctx, cfg, factories)
+	if err == nil {
+		t.Fatal("expected Validate to fail when a provider fails")
+	}
+	if !strings.Contains(err.Error(), `integration "beta": provider broke`) {
+		t.Fatalf("unexpected validation error: %v", err)
 	}
 }
 

--- a/internal/bootstrap/cleanup.go
+++ b/internal/bootstrap/cleanup.go
@@ -1,0 +1,76 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/registry"
+)
+
+// CloseProviders closes all registered providers that implement io.Closer.
+func CloseProviders(providers *registry.PluginMap[core.Provider]) error {
+	if providers == nil {
+		return nil
+	}
+
+	var errs []error
+	for _, name := range providers.List() {
+		prov, err := providers.Get(name)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("looking up provider %q during shutdown: %w", name, err))
+			continue
+		}
+		c, ok := prov.(io.Closer)
+		if !ok {
+			continue
+		}
+		if err := c.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("closing provider %q: %w", name, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func CloseBindings(bindings *registry.PluginMap[core.Binding], names []string) error {
+	if bindings == nil {
+		return nil
+	}
+
+	var errs []error
+	for _, name := range names {
+		binding, err := bindings.Get(name)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("looking up binding %q during shutdown: %w", name, err))
+			continue
+		}
+		if err := binding.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("closing binding %q: %w", name, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func StopRuntimes(ctx context.Context, runtimes *registry.PluginMap[core.Runtime], names []string) error {
+	if runtimes == nil {
+		return nil
+	}
+
+	var errs []error
+	for _, name := range names {
+		rt, err := runtimes.Get(name)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("looking up runtime %q during shutdown: %w", name, err))
+			continue
+		}
+		if err := rt.Stop(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("stopping runtime %q: %w", name, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/internal/bootstrap/validate.go
+++ b/internal/bootstrap/validate.go
@@ -1,0 +1,129 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"slices"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/crypto"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/invocation"
+	"github.com/valon-technologies/gestalt/internal/registry"
+)
+
+// Validate loads daemon dependencies and integration factories without
+// starting the server or running migrations. Unlike Bootstrap, provider
+// validation is strict: any provider construction failure is returned.
+func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) error {
+	sm, err := buildSecretManager(cfg, factories)
+	if err != nil {
+		return err
+	}
+	defer closeSecretManager(sm)
+
+	if err := resolveSecretRefs(ctx, cfg, sm); err != nil {
+		return err
+	}
+
+	deps := Deps{
+		EncryptionKey: crypto.DeriveKey(cfg.Server.EncryptionKey),
+		BaseURL:       cfg.Server.BaseURL,
+		SecretManager: sm,
+	}
+
+	if _, err := buildAuth(cfg, factories, deps); err != nil {
+		return err
+	}
+
+	ds, err := buildDatastore(cfg, factories, deps)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = ds.Close() }()
+
+	providers, err := buildProvidersStrict(ctx, cfg, factories, deps)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	sharedInvoker := invocation.NewBroker(providers, ds)
+	audit := core.AuditSink(invocation.LogAuditSink{})
+
+	runtimes, err := buildRuntimes(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit)
+	if err != nil {
+		return err
+	}
+	// Validation does not start runtimes, but factories may still allocate
+	// resources that need to be released after construction.
+	if runtimes != nil {
+		defer func() { _ = StopRuntimes(context.Background(), runtimes, runtimes.List()) }()
+	}
+
+	bindings, err := buildBindings(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit)
+	if err != nil {
+		return err
+	}
+	if bindings != nil {
+		defer func() { _ = CloseBindings(bindings, bindings.List()) }()
+	}
+
+	return nil
+}
+
+func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.PluginMap[core.Provider], error) {
+	reg := registry.New()
+
+	for _, builtin := range factories.Builtins {
+		if err := reg.Providers.Register(builtin.Name(), builtin); errors.Is(err, core.ErrAlreadyRegistered) {
+			continue
+		} else if err != nil {
+			_ = CloseProviders(&reg.Providers)
+			return nil, fmt.Errorf("bootstrap: registering builtin %q: %w", builtin.Name(), err)
+		}
+	}
+
+	names := slices.Sorted(maps.Keys(cfg.Integrations))
+
+	var errs []error
+	for _, name := range names {
+		intgDef := cfg.Integrations[name]
+		factory, ok := factories.Providers[name]
+		if !ok {
+			factory = factories.DefaultProvider
+		}
+		if factory == nil {
+			errs = append(errs, fmt.Errorf("bootstrap: no provider factory for %q and no default factory registered", name))
+			continue
+		}
+
+		prov, err := factory(ctx, name, intgDef, deps)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("integration %q: %w", name, err))
+			continue
+		}
+		if err := reg.Providers.Register(name, prov); err != nil {
+			if c, ok := prov.(io.Closer); ok {
+				_ = c.Close()
+			}
+			errs = append(errs, fmt.Errorf("bootstrap: registering provider %q: %w", name, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		_ = CloseProviders(&reg.Providers)
+		return nil, fmt.Errorf("bootstrap: provider validation failed: %w", errors.Join(errs...))
+	}
+
+	return &reg.Providers, nil
+}
+
+func closeSecretManager(sm core.SecretManager) {
+	if closer, ok := sm.(interface{ Close() error }); ok {
+		_ = closer.Close()
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -89,6 +90,7 @@ type IntegrationDef struct {
 	ResponseCheck    string            `yaml:"response_check"`
 	TokenParser      string            `yaml:"token_parser"`
 	RequestMutator   string            `yaml:"request_mutator"`
+	PostConnect      string            `yaml:"post_connect"`
 	TokenPrefix      string            `yaml:"token_prefix"`
 	AuthStyle        string            `yaml:"auth_style"`
 	IconFile         string            `yaml:"icon_file"`
@@ -167,7 +169,9 @@ func LoadWithMapping(path string, getenv func(string) string) (*Config, error) {
 	resolved := os.Expand(string(data), getenv)
 
 	var cfg Config
-	if err := yaml.Unmarshal([]byte(resolved), &cfg); err != nil {
+	dec := yaml.NewDecoder(strings.NewReader(resolved))
+	dec.KnownFields(true)
+	if err := dec.Decode(&cfg); err != nil && err != io.EOF {
 		return nil, fmt.Errorf("parsing config YAML: %w", err)
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -226,6 +227,58 @@ func TestLoadErrors(t *testing.T) {
 			_, err := Load(path)
 			if err == nil {
 				t.Fatal("Load: expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestLoadEmptyConfigFallsThrough(t *testing.T) {
+	t.Parallel()
+
+	for _, content := range []string{"", "# just a comment\n"} {
+		path := mustWriteConfigFile(t, content)
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected validation error, got nil")
+		}
+		if strings.Contains(err.Error(), "EOF") {
+			t.Fatalf("Load: got confusing EOF error for empty config: %v", err)
+		}
+	}
+}
+
+func TestLoadRejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		yaml        string
+		wantMessage string
+	}{
+		{
+			name: "legacy global mcp block",
+			yaml: `
+auth:
+  provider: google
+server:
+  encryption_key: key123
+mcp:
+  enabled: true
+`,
+			wantMessage: "field mcp not found in type config.Config",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := mustWriteConfigFile(t, tc.yaml)
+			_, err := Load(path)
+			if err == nil {
+				t.Fatal("Load: expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantMessage) {
+				t.Fatalf("Load: expected error containing %q, got %v", tc.wantMessage, err)
 			}
 		})
 	}

--- a/internal/integration/restricted.go
+++ b/internal/integration/restricted.go
@@ -17,11 +17,12 @@ type Restricted struct {
 
 // Compile-time interface checks.
 var (
-	_ core.Provider        = (*Restricted)(nil)
-	_ core.ManualProvider  = (*Restricted)(nil)
-	_ core.CatalogProvider = (*Restricted)(nil)
-	_ core.OAuthProvider   = (*restrictedOAuth)(nil)
-	_ core.ManualProvider  = (*restrictedOAuth)(nil)
+	_ core.Provider            = (*Restricted)(nil)
+	_ core.ManualProvider      = (*Restricted)(nil)
+	_ core.CatalogProvider     = (*Restricted)(nil)
+	_ core.PostConnectProvider = (*Restricted)(nil)
+	_ core.OAuthProvider       = (*restrictedOAuth)(nil)
+	_ core.ManualProvider      = (*restrictedOAuth)(nil)
 )
 
 // NewRestricted returns a Provider that gates operations to the allowed set.
@@ -161,6 +162,13 @@ func (r *restrictedOAuth) StartOAuthWithOverride(authBaseURL, state string, scop
 func (r *Restricted) ConnectionParamDefs() map[string]core.ConnectionParamDef {
 	if cpp, ok := r.inner.(core.ConnectionParamProvider); ok {
 		return cpp.ConnectionParamDefs()
+	}
+	return nil
+}
+
+func (r *Restricted) PostConnectHook() core.PostConnectHook {
+	if pcp, ok := r.inner.(core.PostConnectProvider); ok {
+		return pcp.PostConnectHook()
 	}
 	return nil
 }

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -150,6 +150,14 @@ func Build(def *Definition, intg config.IntegrationDef, allowedOperations map[st
 		base.RequestMutator = mutator
 	}
 
+	if def.PostConnect != "" {
+		hook, ok := lookupPostConnectHook(def.PostConnect)
+		if !ok {
+			return nil, fmt.Errorf("%s: unknown post_connect %q", def.Provider, def.PostConnect)
+		}
+		base.PostConnectHookFn = hook
+	}
+
 	if len(def.Connection) > 0 {
 		base.ConnectionDefs = make(map[string]core.ConnectionParamDef, len(def.Connection))
 		for name, cpd := range def.Connection {
@@ -242,6 +250,7 @@ func applyOverrides(def *Definition, intg config.IntegrationDef) error {
 	setStr(&def.ResponseCheck, intg.ResponseCheck)
 	setStr(&def.TokenParser, intg.TokenParser)
 	setStr(&def.RequestMutator, intg.RequestMutator)
+	setStr(&def.PostConnect, intg.PostConnect)
 	setStr(&def.TokenPrefix, intg.TokenPrefix)
 	setStr(&def.AuthStyle, intg.AuthStyle)
 	if intg.IconFile != "" {

--- a/internal/provider/build_test.go
+++ b/internal/provider/build_test.go
@@ -714,6 +714,59 @@ func TestBuildConnectionParamsBaseURLInterpolation(t *testing.T) {
 	}
 }
 
+func TestBuildWithPostConnectHook(t *testing.T) {
+	t.Parallel()
+
+	RegisterPostConnectHook("test_discovery", func(_ context.Context, _ *core.IntegrationToken, _ *http.Client) (map[string]string, error) {
+		return map[string]string{"cloud_id": "abc123"}, nil
+	})
+	t.Cleanup(func() {
+		hooksMu.Lock()
+		delete(postConnectHooks, "test_discovery")
+		hooksMu.Unlock()
+	})
+
+	def := &Definition{
+		Provider:    "pc_hook_test",
+		DisplayName: "PostConnect Hook Test",
+		BaseURL:     "https://example.com",
+		Auth:        AuthDef{Type: "manual"},
+		PostConnect: "test_discovery",
+		Operations:  map[string]OperationDef{"op": {Description: "Op", Method: "GET", Path: "/op"}},
+	}
+
+	prov, err := Build(def, config.IntegrationDef{}, nil)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	pcp, ok := prov.(core.PostConnectProvider)
+	if !ok {
+		t.Fatal("provider does not implement PostConnectProvider")
+	}
+	if pcp.PostConnectHook() == nil {
+		t.Fatal("PostConnectHook() returned nil")
+	}
+}
+
+func TestBuildUnknownPostConnectHook(t *testing.T) {
+	t.Parallel()
+
+	def := &Definition{
+		Provider:    "bad_hook_test",
+		DisplayName: "Bad Hook Test",
+		BaseURL:     "https://example.com",
+		Auth:        AuthDef{Type: "manual"},
+		PostConnect: "nonexistent_hook",
+		Operations:  map[string]OperationDef{"op": {Description: "Op", Method: "GET", Path: "/op"}},
+	}
+
+	_, err := Build(def, config.IntegrationDef{}, nil)
+	if err == nil {
+		t.Fatal("expected error for unknown post_connect hook")
+	}
+}
+
 func writeProviderYAML(t *testing.T, dir, name, displayName string) {
 	t.Helper()
 	content := fmt.Sprintf(minimalProviderYAML, name, displayName, name)

--- a/internal/provider/definition.go
+++ b/internal/provider/definition.go
@@ -20,6 +20,7 @@ type Definition struct {
 	ResponseCheck  string `yaml:"response_check"`
 	TokenParser    string `yaml:"token_parser"`
 	RequestMutator string `yaml:"request_mutator"`
+	PostConnect    string `yaml:"post_connect"`
 
 	Connection map[string]ConnectionParamDef `yaml:"connection"`
 	Operations map[string]OperationDef       `yaml:"operations"`

--- a/internal/provider/hooks.go
+++ b/internal/provider/hooks.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"sync"
 
+	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/apiexec"
 	"github.com/valon-technologies/gestalt/internal/oauth"
 )
@@ -13,6 +14,7 @@ var (
 	tokenParsers     = map[string]func(string) (string, map[string]string, error){}
 	requestMutators  = map[string]func(string, *apiexec.Request, map[string]any) error{}
 	responseHooks    = map[string]oauth.ResponseHook{}
+	postConnectHooks = map[string]core.PostConnectHook{}
 )
 
 func RegisterResponseChecker(name string, fn apiexec.ResponseChecker) {
@@ -64,5 +66,18 @@ func lookupResponseHook(name string) (oauth.ResponseHook, bool) {
 	hooksMu.RLock()
 	defer hooksMu.RUnlock()
 	fn, ok := responseHooks[name]
+	return fn, ok
+}
+
+func RegisterPostConnectHook(name string, fn core.PostConnectHook) {
+	hooksMu.Lock()
+	defer hooksMu.Unlock()
+	postConnectHooks[name] = fn
+}
+
+func lookupPostConnectHook(name string) (core.PostConnectHook, bool) {
+	hooksMu.RLock()
+	defer hooksMu.RUnlock()
+	fn, ok := postConnectHooks[name]
 	return fn, ok
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -578,6 +578,12 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	if err := s.runPostConnectHook(r.Context(), prov, tok); err != nil {
+		log.Printf("post_connect hook failed for %s: %v", providerName, err)
+		writeError(w, http.StatusBadGateway, "connection setup failed")
+		return
+	}
+
 	http.Redirect(w, r, "/integrations?connected="+url.QueryEscape(providerName), http.StatusSeeOther)
 }
 
@@ -647,6 +653,12 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 	if err := s.datastore.StoreToken(r.Context(), tok); err != nil {
 		log.Printf("failed to store credential for %s: %v", req.Integration, err)
 		writeError(w, http.StatusInternalServerError, "failed to store credential")
+		return
+	}
+
+	if err := s.runPostConnectHook(r.Context(), prov, tok); err != nil {
+		log.Printf("post_connect hook failed for %s: %v", req.Integration, err)
+		writeError(w, http.StatusBadGateway, "connection setup failed")
 		return
 	}
 
@@ -881,4 +893,69 @@ func buildConnectionMetadata(prov core.Provider, userParams map[string]string, t
 	}
 	b, _ := json.Marshal(metadata)
 	return string(b), nil
+}
+
+type bearerTransport struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("Authorization") == "" {
+		req = req.Clone(req.Context())
+		req.Header.Set("Authorization", "Bearer "+t.token)
+	}
+	return t.base.RoundTrip(req)
+}
+
+func (s *Server) runPostConnectHook(ctx context.Context, prov core.Provider, tok *core.IntegrationToken) error {
+	pcp, ok := prov.(core.PostConnectProvider)
+	if !ok {
+		return nil
+	}
+	hookFn := pcp.PostConnectHook()
+	if hookFn == nil {
+		return nil
+	}
+
+	client := &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: &bearerTransport{token: tok.AccessToken, base: http.DefaultTransport},
+	}
+	extra, err := hookFn(ctx, tok, client)
+	if err != nil {
+		_ = s.datastore.DeleteToken(ctx, tok.ID)
+		return fmt.Errorf("post_connect: %w", err)
+	}
+
+	if len(extra) == 0 {
+		return nil
+	}
+
+	for k, v := range extra {
+		if !safeParamValue.MatchString(k) || !safeTokenResponseValue.MatchString(v) {
+			_ = s.datastore.DeleteToken(ctx, tok.ID)
+			return fmt.Errorf("post_connect returned invalid key or value for %q", k)
+		}
+	}
+
+	existing := make(map[string]string)
+	if tok.MetadataJSON != "" {
+		if err := json.Unmarshal([]byte(tok.MetadataJSON), &existing); err != nil {
+			_ = s.datastore.DeleteToken(ctx, tok.ID)
+			return fmt.Errorf("post_connect: corrupt MetadataJSON: %w", err)
+		}
+	}
+	for k, v := range extra {
+		existing[k] = v
+	}
+	b, _ := json.Marshal(existing)
+	tok.MetadataJSON = string(b)
+
+	if err := s.datastore.StoreToken(ctx, tok); err != nil {
+		_ = s.datastore.DeleteToken(ctx, tok.ID)
+		return fmt.Errorf("post_connect: failed to update metadata: %w", err)
+	}
+
+	return nil
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3354,3 +3354,152 @@ func TestDevLogin_EmptyEmail(t *testing.T) {
 		t.Fatalf("expected 400, got %d", resp.StatusCode)
 	}
 }
+
+type stubOAuthPostConnect struct {
+	coretesting.StubIntegration
+	hookFn func(context.Context, *core.IntegrationToken, *http.Client) (map[string]string, error)
+}
+
+func (s *stubOAuthPostConnect) AuthorizationURL(state string, _ []string) string {
+	return "https://example.com/authorize?state=" + url.QueryEscape(state)
+}
+
+func (s *stubOAuthPostConnect) ExchangeCode(_ context.Context, code string) (*core.TokenResponse, error) {
+	if code == "good-code" {
+		return &core.TokenResponse{AccessToken: "tok-123"}, nil
+	}
+	return nil, fmt.Errorf("bad code")
+}
+
+func (s *stubOAuthPostConnect) RefreshToken(_ context.Context, _ string) (*core.TokenResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *stubOAuthPostConnect) PostConnectHook() core.PostConnectHook {
+	return s.hookFn
+}
+
+func TestOAuthCallback_PostConnectHook(t *testing.T) {
+	t.Parallel()
+
+	var storedTokens []*core.IntegrationToken
+
+	stub := &stubOAuthPostConnect{
+		StubIntegration: coretesting.StubIntegration{N: "hook-test"},
+		hookFn: func(_ context.Context, tok *core.IntegrationToken, _ *http.Client) (map[string]string, error) {
+			return map[string]string{"cloud_id": "abc123"}, nil
+		},
+	}
+
+	ds := &coretesting.StubDatastore{
+		FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+			return &core.User{ID: "u1", Email: email}, nil
+		},
+		StoreTokenFn: func(_ context.Context, tok *core.IntegrationToken) error {
+			storedTokens = append(storedTokens, tok)
+			return nil
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Datastore = ds
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	startBody := bytes.NewBufferString(`{"integration":"hook-test"}`)
+	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
+	startReq.Header.Set("X-Dev-User-Email", "dev@example.com")
+	startReq.Header.Set("Content-Type", "application/json")
+	startResp, err := http.DefaultClient.Do(startReq)
+	if err != nil {
+		t.Fatalf("start request: %v", err)
+	}
+	defer func() { _ = startResp.Body.Close() }()
+
+	var startResult map[string]string
+	_ = json.NewDecoder(startResp.Body).Decode(&startResult)
+
+	noRedirect := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	cbReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
+	cbResp, err := noRedirect.Do(cbReq)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	defer func() { _ = cbResp.Body.Close() }()
+
+	if cbResp.StatusCode != http.StatusSeeOther {
+		body, _ := io.ReadAll(cbResp.Body)
+		t.Fatalf("expected 303, got %d: %s", cbResp.StatusCode, body)
+	}
+
+	if len(storedTokens) < 2 {
+		t.Fatalf("expected at least 2 StoreToken calls (initial + metadata update), got %d", len(storedTokens))
+	}
+	lastTok := storedTokens[len(storedTokens)-1]
+	if !strings.Contains(lastTok.MetadataJSON, "cloud_id") {
+		t.Fatalf("expected MetadataJSON to contain cloud_id, got %s", lastTok.MetadataJSON)
+	}
+}
+
+func TestOAuthCallback_PostConnectHookFailure(t *testing.T) {
+	t.Parallel()
+
+	var deleted []string
+
+	stub := &stubOAuthPostConnect{
+		StubIntegration: coretesting.StubIntegration{N: "fail-hook"},
+		hookFn: func(_ context.Context, _ *core.IntegrationToken, _ *http.Client) (map[string]string, error) {
+			return nil, fmt.Errorf("discovery failed")
+		},
+	}
+
+	ds := &coretesting.StubDatastore{
+		FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+			return &core.User{ID: "u1", Email: email}, nil
+		},
+		StoreTokenFn: func(_ context.Context, tok *core.IntegrationToken) error {
+			return nil
+		},
+		DeleteTokenFn: func(_ context.Context, id string) error {
+			deleted = append(deleted, id)
+			return nil
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Datastore = ds
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	startBody := bytes.NewBufferString(`{"integration":"fail-hook"}`)
+	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
+	startReq.Header.Set("X-Dev-User-Email", "dev@example.com")
+	startReq.Header.Set("Content-Type", "application/json")
+	startResp, err := http.DefaultClient.Do(startReq)
+	if err != nil {
+		t.Fatalf("start request: %v", err)
+	}
+	defer func() { _ = startResp.Body.Close() }()
+
+	var startResult map[string]string
+	_ = json.NewDecoder(startResp.Body).Decode(&startResult)
+
+	noRedirect := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	cbReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
+	cbResp, err := noRedirect.Do(cbReq)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	defer func() { _ = cbResp.Body.Close() }()
+
+	if cbResp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected 502 on hook failure, got %d", cbResp.StatusCode)
+	}
+	if len(deleted) == 0 {
+		t.Fatal("expected token to be deleted on hook failure (rollback)")
+	}
+}

--- a/web/e2e/integrations.spec.ts
+++ b/web/e2e/integrations.spec.ts
@@ -269,6 +269,7 @@ test.describe("Integrations", () => {
     await expect(page.getByLabel("API Token")).toBeVisible();
     await page.getByRole("button", { name: "Cancel" }).click();
     await expect(page.getByLabel("API Token")).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "Manual Service settings" })).toBeVisible();
   });
 
   test("manual auth reconnect opens token form via settings modal", async ({


### PR DESCRIPTION
`gestaltd validate` is the primary validation entrypoint. The validation
path now rejects unknown config fields, surfaces provider semantic errors
before deployment, and follows the same bootstrap path as the running
server so downstream deploys can trust it as the source of truth.

The old `--check` flag is removed in favor of the subcommand.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>