### PR TITLE
Warn on risky SQLite deployment configs

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -52,6 +52,7 @@ func setupBootstrap(configFlag string) (*bootstrapEnv, error) {
 	if err != nil {
 		return nil, fmt.Errorf("loading config: %v", err)
 	}
+	logConfigWarnings(cfg)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
@@ -123,6 +124,12 @@ func resolveConfigPath(flagValue string) string {
 		return "config.yaml"
 	}
 	return "/etc/gestalt/config.yaml"
+}
+
+func logConfigWarnings(cfg *config.Config) {
+	for _, warning := range config.DatastoreWarnings(cfg, os.Getenv) {
+		log.Printf("WARNING: %s", warning)
+	}
 }
 
 const gracefulShutdownTimeout = 15 * time.Second

--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -169,6 +170,9 @@ func runCheck(configFlag string) error {
 	log.Printf("  provider:   %s", cfg.Datastore.Provider)
 	log.Printf("secrets:")
 	log.Printf("  provider:   %s", cfg.Secrets.Provider)
+	for _, warning := range config.DatastoreWarnings(cfg, os.Getenv) {
+		log.Printf("WARNING: %s", warning)
+	}
 
 	if len(cfg.Integrations) > 0 {
 		log.Printf("integrations: %d", len(cfg.Integrations))

--- a/deploy/docker/config.yaml
+++ b/deploy/docker/config.yaml
@@ -20,6 +20,8 @@ auth:
   #   display_name: "Okta"
 
 datastore:
+  # SQLite is appropriate for local development or single-instance
+  # deployments with mounted persistent storage at /data.
   provider: sqlite
   config:
     path: /data/gestalt.db

--- a/deploy/helm/gestalt/values.yaml
+++ b/deploy/helm/gestalt/values.yaml
@@ -1,4 +1,5 @@
-# SQLite limits to single writer; increase for PostgreSQL.
+# SQLite defaults are for a single replica with persistent storage.
+# Switch to Postgres or MySQL before scaling horizontally.
 replicaCount: 1
 
 image:
@@ -79,6 +80,8 @@ config:
     #   session_secret: "${GESTALT_SESSION_SECRET}"
     #   display_name: "Okta"
   datastore:
+    # SQLite is appropriate for local development or single-instance
+    # deployments with mounted persistent storage at /data.
     provider: sqlite
     config:
       path: /data/gestalt.db

--- a/docs/pages/deploy/index.mdx
+++ b/docs/pages/deploy/index.mdx
@@ -74,6 +74,8 @@ datastore:
 gestaltd --check --config your-config.yaml
 ```
 
+`gestaltd --check` warns when SQLite appears unsafe for deployment, including local or temporary filesystem paths and environments that should not scale past one replica.
+
 ## Choose a platform
 
 <Cards>

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -27,6 +27,8 @@ gestaltd --check --config config.yaml
 
 Prints: config file path, server settings, auth provider, datastore, secrets provider, integration count and details, runtime count, binding count. Exits with "config ok" if valid.
 
+If the resolved datastore config looks risky, `--check` also prints warnings. SQLite triggers warnings when it uses local or temporary filesystem storage, or when it appears to be running in environments that should stay single-instance.
+
 ### Config file resolution
 
 1. `--config` flag.

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -62,7 +62,7 @@ datastore:
 
 | Provider | Config | Notes |
 |---|---|---|
-| `sqlite` | `path: ./gestalt.db` | Default. Single-instance only. |
+| `sqlite` | `path: ./gestalt.db` | Default. Single-instance only. `gestaltd` warns when SQLite uses risky local or temporary paths, or when it appears to be running in environments that should not scale horizontally. |
 | `postgres` | `dsn: postgres://...` | Recommended for production. |
 | `mysql` | `dsn: user:pass@tcp(host:3306)/gestalt` | Alternative SQL backend. |
 | `dynamodb` | `table`, `region`, optional `endpoint` | AWS DynamoDB. |

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -25,6 +26,15 @@ func mustWriteConfigFile(t *testing.T, content string) string {
 		t.Fatalf("writing temp config: %v", err)
 	}
 	return path
+}
+
+func warningsContain(warnings []string, needle string) bool {
+	for _, warning := range warnings {
+		if strings.Contains(warning, needle) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestLoadValidConfig(t *testing.T) {
@@ -157,6 +167,135 @@ server:
 
 	if cfg.Server.EncryptionKey != "" {
 		t.Errorf("Server.EncryptionKey: got %q, want empty string", cfg.Server.EncryptionKey)
+	}
+}
+
+func TestDatastoreWarnings(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		yaml          string
+		env           map[string]string
+		wantSubstring string
+		wantWarnings  bool
+	}{
+		{
+			name: "default sqlite path warns for local filesystem",
+			yaml: `
+auth:
+  provider: google
+server:
+  encryption_key: key123
+`,
+			wantSubstring: `local filesystem storage`,
+			wantWarnings:  true,
+		},
+		{
+			name: "temp sqlite path warns for restart loss",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+  config:
+    path: /tmp/gestalt.db
+server:
+  encryption_key: key123
+`,
+			wantSubstring: `temporary storage`,
+			wantWarnings:  true,
+		},
+		{
+			name: "cloud run warns for non durable sqlite",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+  config:
+    path: /data/gestalt.db
+server:
+  encryption_key: key123
+`,
+			env: map[string]string{
+				"K_SERVICE": "gestalt",
+			},
+			wantSubstring: `not durable on Cloud Run`,
+			wantWarnings:  true,
+		},
+		{
+			name: "kubernetes warns for single instance sqlite",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+  config:
+    path: /data/gestalt.db
+server:
+  encryption_key: key123
+`,
+			env: map[string]string{
+				"KUBERNETES_SERVICE_HOST": "10.0.0.1",
+			},
+			wantSubstring: `single-instance only`,
+			wantWarnings:  true,
+		},
+		{
+			name: "postgres has no datastore warnings",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: postgres
+  config:
+    dsn: postgres://user:pass@localhost:5432/gestalt
+server:
+  encryption_key: key123
+`,
+		},
+		{
+			name: "mounted absolute sqlite path without platform signals stays quiet",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+  config:
+    path: /data/gestalt.db
+server:
+  encryption_key: key123
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := mustWriteConfigFile(t, tc.yaml)
+			getenv := func(key string) string {
+				return tc.env[key]
+			}
+
+			cfg, err := LoadWithMapping(path, getenv)
+			if err != nil {
+				t.Fatalf("LoadWithMapping: unexpected error: %v", err)
+			}
+
+			warnings := DatastoreWarnings(cfg, getenv)
+			if tc.wantWarnings && len(warnings) == 0 {
+				t.Fatalf("DatastoreWarnings: got none, want at least one")
+			}
+			if !tc.wantWarnings && len(warnings) != 0 {
+				t.Fatalf("DatastoreWarnings: got %v, want none", warnings)
+			}
+			if tc.wantSubstring != "" && !warningsContain(warnings, tc.wantSubstring) {
+				t.Fatalf("DatastoreWarnings: got %v, want substring %q", warnings, tc.wantSubstring)
+			}
+		})
 	}
 }
 

--- a/internal/config/diagnostics.go
+++ b/internal/config/diagnostics.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type sqliteDatastoreYAML struct {
+	Path string `yaml:"path"`
+}
+
+// DatastoreWarnings returns actionable warnings for risky datastore
+// configurations without rejecting supported single-instance setups.
+func DatastoreWarnings(cfg *Config, getenv func(string) string) []string {
+	if cfg == nil || cfg.Datastore.Provider != "sqlite" {
+		return nil
+	}
+
+	path := sqliteDatastorePath(cfg.Datastore.Config)
+	var warnings []string
+
+	if isTempSQLitePath(path) {
+		warnings = append(warnings, fmt.Sprintf(
+			"sqlite datastore path %q uses temporary storage; data will be lost on restart. Use a mounted persistent volume or switch to a shared datastore such as postgres.",
+			path,
+		))
+	} else if runtime := sqliteEphemeralRuntime(getenv); runtime != "" {
+		warnings = append(warnings, fmt.Sprintf(
+			"sqlite datastore is not durable on %s; data will not survive instance replacement and is not shared across instances. Use a shared datastore such as postgres or mysql.",
+			runtime,
+		))
+	} else if isLocalSQLitePath(path) {
+		warnings = append(warnings, fmt.Sprintf(
+			"sqlite datastore path %q uses local filesystem storage. This is appropriate for local development or single-instance deployments with mounted persistent storage.",
+			path,
+		))
+	}
+
+	if runtime := sqliteSingleInstanceRuntime(getenv); runtime != "" {
+		warnings = append(warnings, fmt.Sprintf(
+			"sqlite datastore is single-instance only. This deployment appears to run on %s; keep it at one replica and ensure %q is backed by persistent storage.",
+			runtime,
+			path,
+		))
+	}
+
+	return warnings
+}
+
+func sqliteDatastorePath(node yaml.Node) string {
+	var cfg sqliteDatastoreYAML
+	if err := node.Decode(&cfg); err != nil || strings.TrimSpace(cfg.Path) == "" {
+		return "./gestalt.db"
+	}
+	return cfg.Path
+}
+
+func isLocalSQLitePath(path string) bool {
+	return !filepath.IsAbs(path)
+}
+
+func isTempSQLitePath(path string) bool {
+	clean := filepath.Clean(path)
+	tempPrefixes := []string{
+		"/tmp",
+		"/var/tmp",
+		filepath.Clean(os.TempDir()),
+	}
+	for _, prefix := range tempPrefixes {
+		if clean == prefix || strings.HasPrefix(clean, prefix+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+func sqliteEphemeralRuntime(getenv func(string) string) string {
+	if getenv == nil {
+		return ""
+	}
+	switch {
+	case getenv("K_SERVICE") != "":
+		return "Cloud Run"
+	case getenv("AWS_LAMBDA_FUNCTION_NAME") != "":
+		return "AWS Lambda"
+	default:
+		return ""
+	}
+}
+
+func sqliteSingleInstanceRuntime(getenv func(string) string) string {
+	if getenv == nil {
+		return ""
+	}
+	switch {
+	case getenv("KUBERNETES_SERVICE_HOST") != "":
+		return "Kubernetes"
+	case getenv("RAILWAY_ENVIRONMENT") != "":
+		return "Railway"
+	case getenv("RENDER") != "":
+		return "Render"
+	case getenv("FLY_APP_NAME") != "":
+		return "Fly.io"
+	case getenv("ECS_CONTAINER_METADATA_URI_V4") != "":
+		return "Amazon ECS"
+	case getenv("ECS_CONTAINER_METADATA_URI") != "":
+		return "Amazon ECS"
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
## Summary
- add SQLite datastore diagnostics for local paths, temp paths, and deployment environments that should stay single-instance
- print those warnings during normal startup and in `gestaltd --check`
- document the warning behavior and clarify the expected SQLite deployment model in config and deploy docs

## Testing
- go test ./internal/config/...
- go test ./cmd/gestaltd/...
- go test ./...
