### PR TITLE
Warn on risky SQLite datastore paths at startup

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -61,6 +61,7 @@ func setupBootstrap(configFlag string) (*bootstrapEnv, error) {
 		stop()
 		return nil, fmt.Errorf("bootstrap: %v", err)
 	}
+	logDatastoreWarnings(result.Datastore)
 
 	if err := result.Datastore.Migrate(ctx); err != nil {
 		_ = result.Datastore.Close()
@@ -122,6 +123,17 @@ func resolveConfigPath(flagValue string) string {
 		return "config.yaml"
 	}
 	return "/etc/gestalt/config.yaml"
+}
+
+func logDatastoreWarnings(ds core.Datastore) {
+	type warner interface {
+		Warnings() []string
+	}
+	if w, ok := ds.(warner); ok {
+		for _, msg := range w.Warnings() {
+			log.Printf("WARNING: %s", msg)
+		}
+	}
 }
 
 const gracefulShutdownTimeout = 15 * time.Second

--- a/deploy/docker/config.yaml
+++ b/deploy/docker/config.yaml
@@ -20,6 +20,8 @@ auth:
   #   display_name: "Okta"
 
 datastore:
+  # SQLite is appropriate for local development or single-instance
+  # deployments with mounted persistent storage at /data.
   provider: sqlite
   config:
     path: /data/gestalt.db

--- a/deploy/helm/gestalt/values.yaml
+++ b/deploy/helm/gestalt/values.yaml
@@ -1,4 +1,5 @@
-# SQLite limits to single writer; increase for PostgreSQL.
+# SQLite defaults are for a single replica with persistent storage.
+# Switch to Postgres or MySQL before scaling horizontally.
 replicaCount: 1
 
 image:
@@ -79,6 +80,8 @@ config:
     #   session_secret: "${GESTALT_SESSION_SECRET}"
     #   display_name: "Okta"
   datastore:
+    # SQLite is appropriate for local development or single-instance
+    # deployments with mounted persistent storage at /data.
     provider: sqlite
     config:
       path: /data/gestalt.db

--- a/docs/pages/deploy/index.mdx
+++ b/docs/pages/deploy/index.mdx
@@ -74,6 +74,8 @@ datastore:
 gestaltd --check --config your-config.yaml
 ```
 
+`gestaltd` warns at startup when the SQLite datastore path looks risky, such as relative paths or temporary directories.
+
 ## Choose a platform
 
 <Cards>

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -27,6 +27,8 @@ gestaltd --check --config config.yaml
 
 Prints: config file path, server settings, auth provider, datastore, secrets provider, integration count and details, runtime count, binding count. Exits with "config ok" if valid.
 
+`gestaltd` prints datastore warnings at startup. SQLite triggers warnings for relative paths or temporary directory storage.
+
 ### Config file resolution
 
 1. `--config` flag.

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -62,7 +62,7 @@ datastore:
 
 | Provider | Config | Notes |
 |---|---|---|
-| `sqlite` | `path: ./gestalt.db` | Default. Single-instance only. |
+| `sqlite` | `path: ./gestalt.db` | Default. Single-instance only. `gestaltd` warns for relative paths or temporary directory storage. |
 | `postgres` | `dsn: postgres://...` | Recommended for production. |
 | `mysql` | `dsn: user:pass@tcp(host:3306)/gestalt` | Alternative SQL backend. |
 | `dynamodb` | `table`, `region`, optional `endpoint` | AWS DynamoDB. |

--- a/plugins/datastore/sqlite/sqlite.go
+++ b/plugins/datastore/sqlite/sqlite.go
@@ -43,6 +43,7 @@ func (dialect) IsDuplicateKeyError(error) bool { return false }
 // Store embeds sqlstore.Store and adds SQLite-specific behavior.
 type Store struct {
 	*sqlstore.Store
+	path string
 }
 
 var _ core.Datastore = (*Store)(nil)
@@ -61,7 +62,7 @@ func New(dbPath string, encryptionKey []byte) (*Store, error) {
 		return nil, fmt.Errorf("creating encryptor: %w", err)
 	}
 
-	return &Store{Store: sqlstore.New(db, enc, dialect{})}, nil
+	return &Store{Store: sqlstore.New(db, enc, dialect{}), path: dbPath}, nil
 }
 
 func (s *Store) Migrate(ctx context.Context) error {

--- a/plugins/datastore/sqlite/warnings.go
+++ b/plugins/datastore/sqlite/warnings.go
@@ -1,0 +1,39 @@
+package sqlite
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func (s *Store) Warnings() []string {
+	if isTempPath(s.path) {
+		return []string{fmt.Sprintf(
+			"sqlite datastore path %q uses temporary storage; data will be lost on restart. Use a mounted persistent volume or switch to a shared datastore such as postgres.",
+			s.path,
+		)}
+	}
+	if !filepath.IsAbs(s.path) {
+		return []string{fmt.Sprintf(
+			"sqlite datastore path %q uses local filesystem storage; in a container this path is ephemeral. Use an absolute path on a mounted persistent volume or switch to a shared datastore such as postgres.",
+			s.path,
+		)}
+	}
+	return nil
+}
+
+func isTempPath(path string) bool {
+	clean := filepath.Clean(path)
+	tempPrefixes := []string{
+		"/tmp",
+		"/var/tmp",
+		filepath.Clean(os.TempDir()),
+	}
+	for _, prefix := range tempPrefixes {
+		if clean == prefix || strings.HasPrefix(clean, prefix+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}

--- a/plugins/datastore/sqlite/warnings_test.go
+++ b/plugins/datastore/sqlite/warnings_test.go
@@ -1,0 +1,61 @@
+package sqlite
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestWarnings(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "relative path",
+			path: "./gestalt.db",
+			want: `sqlite datastore path "./gestalt.db" uses local filesystem storage; in a container this path is ephemeral. Use an absolute path on a mounted persistent volume or switch to a shared datastore such as postgres.`,
+		},
+		{
+			name: "temp path",
+			path: "/tmp/gestalt.db",
+			want: `sqlite datastore path "/tmp/gestalt.db" uses temporary storage; data will be lost on restart. Use a mounted persistent volume or switch to a shared datastore such as postgres.`,
+		},
+		{
+			name: "var tmp",
+			path: "/var/tmp/gestalt.db",
+			want: `sqlite datastore path "/var/tmp/gestalt.db" uses temporary storage; data will be lost on restart. Use a mounted persistent volume or switch to a shared datastore such as postgres.`,
+		},
+		{
+			name: "mounted absolute path",
+			path: "/data/gestalt.db",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := &Store{path: tc.path}
+			warnings := s.Warnings()
+
+			if tc.want == "" {
+				if len(warnings) != 0 {
+					t.Fatalf("got %v, want none", warnings)
+				}
+				return
+			}
+			if len(warnings) != 1 {
+				t.Fatalf("got %d warnings, want 1", len(warnings))
+			}
+			if warnings[0] != tc.want {
+				fmt.Println("got: ", warnings[0])
+				fmt.Println("want:", tc.want)
+				t.Fatal("warning mismatch")
+			}
+		})
+	}
+}


### PR DESCRIPTION
SQLite with a relative path or a temporary directory is a common
misconfiguration in containerized deployments where the filesystem is
ephemeral. The sqlite datastore plugin now exposes a Warnings method
that inspects its configured path and returns actionable messages. The
wiring layer checks for this optional interface after construction and
logs any warnings before the server starts accepting traffic.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>