### PR TITLE
Add post_connect hook for post-auth API discovery

### DIFF
--- a/core/integration/base.go
+++ b/core/integration/base.go
@@ -19,6 +19,7 @@ var (
 	_ core.ManualProvider          = (*Base)(nil)
 	_ core.CatalogProvider         = (*Base)(nil)
 	_ core.ConnectionParamProvider = (*Base)(nil)
+	_ core.PostConnectProvider     = (*Base)(nil)
 )
 
 type manualChecker interface{ IsManual() bool }
@@ -112,7 +113,8 @@ type Base struct {
 	RequestMutator func(operation string, req *apiexec.Request, params map[string]any) error
 	ExecuteFunc    func(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error)
 
-	ConnectionDefs map[string]core.ConnectionParamDef
+	ConnectionDefs    map[string]core.ConnectionParamDef
+	PostConnectHookFn core.PostConnectHook
 
 	catalog *catalog.Catalog
 }
@@ -135,6 +137,10 @@ func (b *Base) SupportsManualAuth() bool {
 
 func (b *Base) ConnectionParamDefs() map[string]core.ConnectionParamDef {
 	return b.ConnectionDefs
+}
+
+func (b *Base) PostConnectHook() core.PostConnectHook {
+	return b.PostConnectHookFn
 }
 
 func (b *Base) TokenURL() string {

--- a/core/provider.go
+++ b/core/provider.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/valon-technologies/gestalt/core/catalog"
 )
@@ -52,4 +53,10 @@ type ConnectionParamDef struct {
 
 type ConnectionParamProvider interface {
 	ConnectionParamDefs() map[string]ConnectionParamDef
+}
+
+type PostConnectHook func(ctx context.Context, token *IntegrationToken, client *http.Client) (map[string]string, error)
+
+type PostConnectProvider interface {
+	PostConnectHook() PostConnectHook
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,6 +89,7 @@ type IntegrationDef struct {
 	ResponseCheck    string            `yaml:"response_check"`
 	TokenParser      string            `yaml:"token_parser"`
 	RequestMutator   string            `yaml:"request_mutator"`
+	PostConnect      string            `yaml:"post_connect"`
 	TokenPrefix      string            `yaml:"token_prefix"`
 	AuthStyle        string            `yaml:"auth_style"`
 	IconFile         string            `yaml:"icon_file"`

--- a/internal/integration/restricted.go
+++ b/internal/integration/restricted.go
@@ -17,11 +17,12 @@ type Restricted struct {
 
 // Compile-time interface checks.
 var (
-	_ core.Provider        = (*Restricted)(nil)
-	_ core.ManualProvider  = (*Restricted)(nil)
-	_ core.CatalogProvider = (*Restricted)(nil)
-	_ core.OAuthProvider   = (*restrictedOAuth)(nil)
-	_ core.ManualProvider  = (*restrictedOAuth)(nil)
+	_ core.Provider            = (*Restricted)(nil)
+	_ core.ManualProvider      = (*Restricted)(nil)
+	_ core.CatalogProvider     = (*Restricted)(nil)
+	_ core.PostConnectProvider = (*Restricted)(nil)
+	_ core.OAuthProvider       = (*restrictedOAuth)(nil)
+	_ core.ManualProvider      = (*restrictedOAuth)(nil)
 )
 
 // NewRestricted returns a Provider that gates operations to the allowed set.
@@ -161,6 +162,13 @@ func (r *restrictedOAuth) StartOAuthWithOverride(authBaseURL, state string, scop
 func (r *Restricted) ConnectionParamDefs() map[string]core.ConnectionParamDef {
 	if cpp, ok := r.inner.(core.ConnectionParamProvider); ok {
 		return cpp.ConnectionParamDefs()
+	}
+	return nil
+}
+
+func (r *Restricted) PostConnectHook() core.PostConnectHook {
+	if pcp, ok := r.inner.(core.PostConnectProvider); ok {
+		return pcp.PostConnectHook()
 	}
 	return nil
 }

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -150,6 +150,14 @@ func Build(def *Definition, intg config.IntegrationDef, allowedOperations map[st
 		base.RequestMutator = mutator
 	}
 
+	if def.PostConnect != "" {
+		hook, ok := lookupPostConnectHook(def.PostConnect)
+		if !ok {
+			return nil, fmt.Errorf("%s: unknown post_connect %q", def.Provider, def.PostConnect)
+		}
+		base.PostConnectHookFn = hook
+	}
+
 	if len(def.Connection) > 0 {
 		base.ConnectionDefs = make(map[string]core.ConnectionParamDef, len(def.Connection))
 		for name, cpd := range def.Connection {
@@ -242,6 +250,7 @@ func applyOverrides(def *Definition, intg config.IntegrationDef) error {
 	setStr(&def.ResponseCheck, intg.ResponseCheck)
 	setStr(&def.TokenParser, intg.TokenParser)
 	setStr(&def.RequestMutator, intg.RequestMutator)
+	setStr(&def.PostConnect, intg.PostConnect)
 	setStr(&def.TokenPrefix, intg.TokenPrefix)
 	setStr(&def.AuthStyle, intg.AuthStyle)
 	if intg.IconFile != "" {

--- a/internal/provider/build_test.go
+++ b/internal/provider/build_test.go
@@ -714,6 +714,59 @@ func TestBuildConnectionParamsBaseURLInterpolation(t *testing.T) {
 	}
 }
 
+func TestBuildWithPostConnectHook(t *testing.T) {
+	t.Parallel()
+
+	RegisterPostConnectHook("test_discovery", func(_ context.Context, _ *core.IntegrationToken, _ *http.Client) (map[string]string, error) {
+		return map[string]string{"cloud_id": "abc123"}, nil
+	})
+	t.Cleanup(func() {
+		hooksMu.Lock()
+		delete(postConnectHooks, "test_discovery")
+		hooksMu.Unlock()
+	})
+
+	def := &Definition{
+		Provider:    "pc_hook_test",
+		DisplayName: "PostConnect Hook Test",
+		BaseURL:     "https://example.com",
+		Auth:        AuthDef{Type: "manual"},
+		PostConnect: "test_discovery",
+		Operations:  map[string]OperationDef{"op": {Description: "Op", Method: "GET", Path: "/op"}},
+	}
+
+	prov, err := Build(def, config.IntegrationDef{}, nil)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	pcp, ok := prov.(core.PostConnectProvider)
+	if !ok {
+		t.Fatal("provider does not implement PostConnectProvider")
+	}
+	if pcp.PostConnectHook() == nil {
+		t.Fatal("PostConnectHook() returned nil")
+	}
+}
+
+func TestBuildUnknownPostConnectHook(t *testing.T) {
+	t.Parallel()
+
+	def := &Definition{
+		Provider:    "bad_hook_test",
+		DisplayName: "Bad Hook Test",
+		BaseURL:     "https://example.com",
+		Auth:        AuthDef{Type: "manual"},
+		PostConnect: "nonexistent_hook",
+		Operations:  map[string]OperationDef{"op": {Description: "Op", Method: "GET", Path: "/op"}},
+	}
+
+	_, err := Build(def, config.IntegrationDef{}, nil)
+	if err == nil {
+		t.Fatal("expected error for unknown post_connect hook")
+	}
+}
+
 func writeProviderYAML(t *testing.T, dir, name, displayName string) {
 	t.Helper()
 	content := fmt.Sprintf(minimalProviderYAML, name, displayName, name)

--- a/internal/provider/definition.go
+++ b/internal/provider/definition.go
@@ -20,6 +20,7 @@ type Definition struct {
 	ResponseCheck  string `yaml:"response_check"`
 	TokenParser    string `yaml:"token_parser"`
 	RequestMutator string `yaml:"request_mutator"`
+	PostConnect    string `yaml:"post_connect"`
 
 	Connection map[string]ConnectionParamDef `yaml:"connection"`
 	Operations map[string]OperationDef       `yaml:"operations"`

--- a/internal/provider/hooks.go
+++ b/internal/provider/hooks.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"sync"
 
+	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/apiexec"
 	"github.com/valon-technologies/gestalt/internal/oauth"
 )
@@ -13,6 +14,7 @@ var (
 	tokenParsers     = map[string]func(string) (string, map[string]string, error){}
 	requestMutators  = map[string]func(string, *apiexec.Request, map[string]any) error{}
 	responseHooks    = map[string]oauth.ResponseHook{}
+	postConnectHooks = map[string]core.PostConnectHook{}
 )
 
 func RegisterResponseChecker(name string, fn apiexec.ResponseChecker) {
@@ -64,5 +66,18 @@ func lookupResponseHook(name string) (oauth.ResponseHook, bool) {
 	hooksMu.RLock()
 	defer hooksMu.RUnlock()
 	fn, ok := responseHooks[name]
+	return fn, ok
+}
+
+func RegisterPostConnectHook(name string, fn core.PostConnectHook) {
+	hooksMu.Lock()
+	defer hooksMu.Unlock()
+	postConnectHooks[name] = fn
+}
+
+func lookupPostConnectHook(name string) (core.PostConnectHook, bool) {
+	hooksMu.RLock()
+	defer hooksMu.RUnlock()
+	fn, ok := postConnectHooks[name]
 	return fn, ok
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -578,6 +578,12 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	if err := s.runPostConnectHook(r.Context(), prov, tok); err != nil {
+		log.Printf("post_connect hook failed for %s: %v", providerName, err)
+		writeError(w, http.StatusBadGateway, "connection setup failed")
+		return
+	}
+
 	http.Redirect(w, r, "/integrations?connected="+url.QueryEscape(providerName), http.StatusSeeOther)
 }
 
@@ -647,6 +653,12 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 	if err := s.datastore.StoreToken(r.Context(), tok); err != nil {
 		log.Printf("failed to store credential for %s: %v", req.Integration, err)
 		writeError(w, http.StatusInternalServerError, "failed to store credential")
+		return
+	}
+
+	if err := s.runPostConnectHook(r.Context(), prov, tok); err != nil {
+		log.Printf("post_connect hook failed for %s: %v", req.Integration, err)
+		writeError(w, http.StatusBadGateway, "connection setup failed")
 		return
 	}
 
@@ -881,4 +893,69 @@ func buildConnectionMetadata(prov core.Provider, userParams map[string]string, t
 	}
 	b, _ := json.Marshal(metadata)
 	return string(b), nil
+}
+
+type bearerTransport struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("Authorization") == "" {
+		req = req.Clone(req.Context())
+		req.Header.Set("Authorization", "Bearer "+t.token)
+	}
+	return t.base.RoundTrip(req)
+}
+
+func (s *Server) runPostConnectHook(ctx context.Context, prov core.Provider, tok *core.IntegrationToken) error {
+	pcp, ok := prov.(core.PostConnectProvider)
+	if !ok {
+		return nil
+	}
+	hookFn := pcp.PostConnectHook()
+	if hookFn == nil {
+		return nil
+	}
+
+	client := &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: &bearerTransport{token: tok.AccessToken, base: http.DefaultTransport},
+	}
+	extra, err := hookFn(ctx, tok, client)
+	if err != nil {
+		_ = s.datastore.DeleteToken(ctx, tok.ID)
+		return fmt.Errorf("post_connect: %w", err)
+	}
+
+	if len(extra) == 0 {
+		return nil
+	}
+
+	for k, v := range extra {
+		if !safeParamValue.MatchString(k) || !safeTokenResponseValue.MatchString(v) {
+			_ = s.datastore.DeleteToken(ctx, tok.ID)
+			return fmt.Errorf("post_connect returned invalid key or value for %q", k)
+		}
+	}
+
+	existing := make(map[string]string)
+	if tok.MetadataJSON != "" {
+		if err := json.Unmarshal([]byte(tok.MetadataJSON), &existing); err != nil {
+			_ = s.datastore.DeleteToken(ctx, tok.ID)
+			return fmt.Errorf("post_connect: corrupt MetadataJSON: %w", err)
+		}
+	}
+	for k, v := range extra {
+		existing[k] = v
+	}
+	b, _ := json.Marshal(existing)
+	tok.MetadataJSON = string(b)
+
+	if err := s.datastore.StoreToken(ctx, tok); err != nil {
+		_ = s.datastore.DeleteToken(ctx, tok.ID)
+		return fmt.Errorf("post_connect: failed to update metadata: %w", err)
+	}
+
+	return nil
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3354,3 +3354,152 @@ func TestDevLogin_EmptyEmail(t *testing.T) {
 		t.Fatalf("expected 400, got %d", resp.StatusCode)
 	}
 }
+
+type stubOAuthPostConnect struct {
+	coretesting.StubIntegration
+	hookFn func(context.Context, *core.IntegrationToken, *http.Client) (map[string]string, error)
+}
+
+func (s *stubOAuthPostConnect) AuthorizationURL(state string, _ []string) string {
+	return "https://example.com/authorize?state=" + url.QueryEscape(state)
+}
+
+func (s *stubOAuthPostConnect) ExchangeCode(_ context.Context, code string) (*core.TokenResponse, error) {
+	if code == "good-code" {
+		return &core.TokenResponse{AccessToken: "tok-123"}, nil
+	}
+	return nil, fmt.Errorf("bad code")
+}
+
+func (s *stubOAuthPostConnect) RefreshToken(_ context.Context, _ string) (*core.TokenResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *stubOAuthPostConnect) PostConnectHook() core.PostConnectHook {
+	return s.hookFn
+}
+
+func TestOAuthCallback_PostConnectHook(t *testing.T) {
+	t.Parallel()
+
+	var storedTokens []*core.IntegrationToken
+
+	stub := &stubOAuthPostConnect{
+		StubIntegration: coretesting.StubIntegration{N: "hook-test"},
+		hookFn: func(_ context.Context, tok *core.IntegrationToken, _ *http.Client) (map[string]string, error) {
+			return map[string]string{"cloud_id": "abc123"}, nil
+		},
+	}
+
+	ds := &coretesting.StubDatastore{
+		FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+			return &core.User{ID: "u1", Email: email}, nil
+		},
+		StoreTokenFn: func(_ context.Context, tok *core.IntegrationToken) error {
+			storedTokens = append(storedTokens, tok)
+			return nil
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Datastore = ds
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	startBody := bytes.NewBufferString(`{"integration":"hook-test"}`)
+	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
+	startReq.Header.Set("X-Dev-User-Email", "dev@example.com")
+	startReq.Header.Set("Content-Type", "application/json")
+	startResp, err := http.DefaultClient.Do(startReq)
+	if err != nil {
+		t.Fatalf("start request: %v", err)
+	}
+	defer func() { _ = startResp.Body.Close() }()
+
+	var startResult map[string]string
+	_ = json.NewDecoder(startResp.Body).Decode(&startResult)
+
+	noRedirect := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	cbReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
+	cbResp, err := noRedirect.Do(cbReq)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	defer func() { _ = cbResp.Body.Close() }()
+
+	if cbResp.StatusCode != http.StatusSeeOther {
+		body, _ := io.ReadAll(cbResp.Body)
+		t.Fatalf("expected 303, got %d: %s", cbResp.StatusCode, body)
+	}
+
+	if len(storedTokens) < 2 {
+		t.Fatalf("expected at least 2 StoreToken calls (initial + metadata update), got %d", len(storedTokens))
+	}
+	lastTok := storedTokens[len(storedTokens)-1]
+	if !strings.Contains(lastTok.MetadataJSON, "cloud_id") {
+		t.Fatalf("expected MetadataJSON to contain cloud_id, got %s", lastTok.MetadataJSON)
+	}
+}
+
+func TestOAuthCallback_PostConnectHookFailure(t *testing.T) {
+	t.Parallel()
+
+	var deleted []string
+
+	stub := &stubOAuthPostConnect{
+		StubIntegration: coretesting.StubIntegration{N: "fail-hook"},
+		hookFn: func(_ context.Context, _ *core.IntegrationToken, _ *http.Client) (map[string]string, error) {
+			return nil, fmt.Errorf("discovery failed")
+		},
+	}
+
+	ds := &coretesting.StubDatastore{
+		FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+			return &core.User{ID: "u1", Email: email}, nil
+		},
+		StoreTokenFn: func(_ context.Context, tok *core.IntegrationToken) error {
+			return nil
+		},
+		DeleteTokenFn: func(_ context.Context, id string) error {
+			deleted = append(deleted, id)
+			return nil
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Datastore = ds
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	startBody := bytes.NewBufferString(`{"integration":"fail-hook"}`)
+	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
+	startReq.Header.Set("X-Dev-User-Email", "dev@example.com")
+	startReq.Header.Set("Content-Type", "application/json")
+	startResp, err := http.DefaultClient.Do(startReq)
+	if err != nil {
+		t.Fatalf("start request: %v", err)
+	}
+	defer func() { _ = startResp.Body.Close() }()
+
+	var startResult map[string]string
+	_ = json.NewDecoder(startResp.Body).Decode(&startResult)
+
+	noRedirect := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	cbReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
+	cbResp, err := noRedirect.Do(cbReq)
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	defer func() { _ = cbResp.Body.Close() }()
+
+	if cbResp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected 502 on hook failure, got %d", cbResp.StatusCode)
+	}
+	if len(deleted) == 0 {
+		t.Fatal("expected token to be deleted on hook failure (rollback)")
+	}
+}


### PR DESCRIPTION
Providers like Jira Cloud need to make an authenticated API call after
OAuth completes to discover metadata (such as a cloud ID or portal ID)
before the connection is usable. Provider YAML definitions can now
specify a `post_connect` hook name that references a registered Go
plugin function. The hook runs after the token is stored, receives an
authenticated HTTP client, and returns metadata to merge into the
connection. If the hook fails, the token is rolled back.

This follows the same plugin pattern as the existing `response_check`,
`token_parser`, and `request_mutator` hooks, where each provider plugin
is a small Go file (~20-60 lines) registered via `init()`.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>