### PR TITLE
Move `mcp` config from integration level to upstream level

### DIFF
--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -47,10 +47,23 @@ func run(args []string) error {
 
 	var mcpProviders []string
 	mcpPrefixes := make(map[string]string)
+	includeHTTP := make(map[string]bool)
 	for name := range env.Config.Integrations {
 		intg := env.Config.Integrations[name]
-		if intg.MCP {
+		hasMCP := false
+		apiMCP := false
+		for _, us := range intg.Upstreams {
+			if us.Type == config.UpstreamTypeMCP {
+				hasMCP = true
+			}
+			if (us.Type == config.UpstreamTypeREST || us.Type == config.UpstreamTypeGraphQL) && us.MCP {
+				hasMCP = true
+				apiMCP = true
+			}
+		}
+		if hasMCP {
 			mcpProviders = append(mcpProviders, name)
+			includeHTTP[name] = apiMCP
 			if intg.MCPToolPrefix != "" {
 				mcpPrefixes[name] = intg.MCPToolPrefix
 			}
@@ -140,6 +153,7 @@ func run(args []string) error {
 			Providers:        result.Providers,
 			AllowedProviders: mcpProviders,
 			ToolPrefixes:     mcpPrefixes,
+			IncludeHTTP:      includeHTTP,
 		}
 		mcpSlot.Set(mcpserver.NewStreamableHTTPServer(
 			gestaltmcp.NewServer(mcpCfg),

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -13,7 +13,6 @@
 | `bindings` | Alternative request surfaces such as webhooks and gRPC. |
 | `provider_dirs` | Directories searched for provider YAML files at startup. |
 | `server` | Port, base URL, encryption key, and development mode. |
-| `mcp` | MCP endpoint settings: enabled flag, provider filter, tool name prefix. |
 
 ## Server block
 
@@ -121,7 +120,7 @@ Each upstream declares a type and source:
 | `type` | `rest`, `graphql`, or `mcp`. |
 | `url` | For `rest`: OpenAPI spec URL. For `graphql`: the GraphQL endpoint (introspected at startup). For `mcp`: the upstream MCP server URL. |
 | `provider` | (`rest` only) Path to a provider YAML file. Used instead of `url`. |
-| `mcp` | (`rest` and `graphql` only) Boolean. When `true` and combined with a `type: mcp` upstream, this upstream's operations are also exposed as MCP tools. |
+| `mcp` | (`rest` and `graphql` only) Boolean. When `true`, this upstream's operations are exposed as MCP tools. `type: mcp` upstreams are always exposed — no flag needed. |
 | `allowed_operations` | Positive allow-list. Can be a YAML list (names only) or a map (names to description overrides). Omit to allow all operations. An empty value is invalid. |
 
 If a `rest` upstream has neither `url` nor `provider`, Gestalt falls back to searching `provider_dirs` for a matching YAML file.
@@ -235,23 +234,6 @@ bindings:
 | `signing_secret` | | Required when `auth_mode` is `signed`. |
 | `signature_header` | `X-Signature` | Header containing the HMAC signature. |
 | `user_header` | | Required when `auth_mode` is `trusted_user_header`. Header containing the user ID. |
-
-## MCP block
-
-```yaml
-mcp:
-  enabled: true
-  providers:
-    - linear
-    - slack
-  tool_name_prefix: ""
-```
-
-| Field | Default | Notes |
-|---|---|---|
-| `enabled` | `false` | Mount the MCP endpoint at `/mcp`. |
-| `providers` | all | Restrict which integrations are exposed to MCP clients. |
-| `tool_name_prefix` | `""` | String prepended to every MCP tool name. |
 
 ## Supported providers
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,7 +73,6 @@ type IntegrationDef struct {
 	Description    string        `yaml:"description"`
 	AuthProfile    string        `yaml:"auth_profile"`
 	ConnectionMode string        `yaml:"connection_mode"`
-	MCP            bool          `yaml:"mcp"`
 	MCPToolPrefix  string        `yaml:"mcp_tool_prefix"`
 
 	ClientID     string `yaml:"client_id"`
@@ -106,6 +105,7 @@ type UpstreamDef struct {
 	Type              string     `yaml:"type"`
 	URL               string     `yaml:"url"`
 	Provider          string     `yaml:"provider"`
+	MCP               bool       `yaml:"mcp"`
 	AllowedOperations AllowedOps `yaml:"allowed_operations"`
 }
 

--- a/internal/mcp/binding.go
+++ b/internal/mcp/binding.go
@@ -36,6 +36,7 @@ type Config struct {
 	Providers        *registry.PluginMap[core.Provider]
 	AllowedProviders []string
 	ToolPrefixes     map[string]string
+	IncludeHTTP      map[string]bool
 }
 
 func NewServer(cfg Config) *mcpserver.MCPServer {
@@ -80,6 +81,9 @@ func addCatalogTools(srv *mcpserver.MCPServer, cfg Config, provName string, cat 
 	for i := range cat.Operations {
 		op := &cat.Operations[i]
 		if op.Visible != nil && !*op.Visible {
+			continue
+		}
+		if cfg.IncludeHTTP != nil && op.Transport == catalog.TransportHTTP && !cfg.IncludeHTTP[provName] {
 			continue
 		}
 

--- a/internal/mcp/binding_test.go
+++ b/internal/mcp/binding_test.go
@@ -647,4 +647,55 @@ func TestNewServer_DirectCallerTokenResolveError(t *testing.T) {
 	}
 }
 
+func TestNewServer_IncludeHTTPFiltering(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		includeHTTP bool
+		wantCount   int
+	}{
+		{"excluded", false, 1},
+		{"included", true, 2},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cat := &catalog.Catalog{
+				Name: "acme",
+				Operations: []catalog.CatalogOperation{
+					{ID: "api_op", Method: "GET", Path: "/api", Transport: catalog.TransportHTTP},
+					{ID: "mcp_op", Description: "passthrough", Transport: catalog.TransportMCPPassthrough},
+				},
+			}
+
+			prov := &catalogProvider{
+				StubIntegration: coretesting.StubIntegration{N: "acme"},
+				ops:             ci.OperationsList(cat),
+				catalog:         cat,
+			}
+
+			providers := testutil.NewProviderRegistry(t, prov)
+			ds := stubDatastoreWithToken()
+			broker := invocation.NewBroker(providers, ds)
+
+			srv := gestaltmcp.NewServer(gestaltmcp.Config{
+				Invoker:     broker,
+				Providers:   providers,
+				IncludeHTTP: map[string]bool{"acme": tc.includeHTTP},
+			})
+
+			tools := srv.ListTools()
+			if len(tools) != tc.wantCount {
+				t.Fatalf("expected %d tools, got %d", tc.wantCount, len(tools))
+			}
+			if tools["acme_mcp_op"] == nil {
+				t.Fatal("expected acme_mcp_op to always be present")
+			}
+		})
+	}
+}
+
 func boolPtr(v bool) *bool { return &v }

--- a/internal/mcp/composite_test.go
+++ b/internal/mcp/composite_test.go
@@ -231,3 +231,52 @@ func TestComposite_ExecuteDelegatesToAPI(t *testing.T) {
 		t.Fatalf("expected execute on 'get_page', got %q", executedOp)
 	}
 }
+
+func TestComposite_IncludeHTTPFalseExcludesAPITools(t *testing.T) {
+	t.Parallel()
+
+	apiCat := &catalog.Catalog{
+		Name: "alpha",
+		Operations: []catalog.CatalogOperation{
+			{ID: "list_items", Method: "GET", Path: "/items", Description: "List items"},
+		},
+	}
+	apiProv := &catalogProvider{
+		StubIntegration: coretesting.StubIntegration{N: "alpha"},
+		ops:             ci.OperationsList(apiCat),
+		catalog:         apiCat,
+	}
+
+	mcpUp := &stubMCPUpstream{
+		cat: &catalog.Catalog{
+			Name: "alpha",
+			Operations: []catalog.CatalogOperation{
+				{ID: "search", Description: "Search items", InputSchema: json.RawMessage(`{"type":"object"}`)},
+			},
+		},
+	}
+
+	comp := composite.New("alpha", apiProv, mcpUp)
+	providers := testutil.NewProviderRegistry(t, comp)
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker:       &testutil.StubInvoker{},
+		TokenResolver: &stubTokenResolver{token: "t"},
+		Providers:     providers,
+		IncludeHTTP:   map[string]bool{"alpha": false},
+	})
+
+	tools := srv.ListTools()
+	if tools["alpha_search"] == nil {
+		t.Fatal("expected alpha_search from MCP upstream")
+	}
+	if tools["alpha_list_items"] != nil {
+		t.Fatal("expected alpha_list_items to be excluded when IncludeHTTP=false")
+	}
+	if len(tools) != 1 {
+		names := make([]string, 0, len(tools))
+		for n := range tools {
+			names = append(names, n)
+		}
+		t.Fatalf("expected 1 tool, got %d: %v", len(tools), names)
+	}
+}


### PR DESCRIPTION
The `mcp` boolean was on the integration definition, which meant it
either exposed all of an integration's operations as MCP tools or none.
This moves it to the upstream level so REST and GraphQL upstreams can
independently opt in to MCP exposure, while MCP-type upstreams are
always exposed implicitly since they are pure passthrough. The
never-implemented top-level `mcp:` config block has been removed from
the docs.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>