### PR TITLE
Improve CLI table formatting for invoke and integrations list

### DIFF
--- a/client/cli/src/commands/invoke.rs
+++ b/client/cli/src/commands/invoke.rs
@@ -1,7 +1,31 @@
 use anyhow::{Context, Result};
+use serde::Deserialize;
 
 use crate::api::ApiClient;
 use crate::output::{self, Format};
+
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct Operation {
+    name: String,
+    description: String,
+    method: String,
+    parameters: Vec<Parameter>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct Parameter {
+    name: String,
+    #[serde(default = "default_type")]
+    r#type: String,
+    #[serde(default)]
+    required: bool,
+}
+
+fn default_type() -> String {
+    "string".to_string()
+}
 
 pub fn invoke(
     url_override: Option<&str>,
@@ -44,8 +68,33 @@ pub fn list_operations(
 
     match format {
         Format::Json => output::print_json(&resp),
-        Format::Table => output::print_json_table(&resp),
+        Format::Table => {
+            let operations: Vec<Operation> =
+                serde_json::from_value(resp).context("failed to parse operations response")?;
+            let rows: Vec<Vec<String>> = operations
+                .into_iter()
+                .map(|op| {
+                    let params = format_parameters(&op.parameters);
+                    vec![op.name, op.description, op.method, params]
+                })
+                .collect();
+            output::print_table(&["Name", "Description", "Method", "Parameters"], &rows);
+        }
     }
 
     Ok(())
+}
+
+fn format_parameters(params: &[Parameter]) -> String {
+    params
+        .iter()
+        .map(|p| {
+            let mut s = format!("-p {}=<{}>", p.name, p.r#type);
+            if p.required {
+                s.push_str(" (required)");
+            }
+            s
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
 }

--- a/client/cli/src/output.rs
+++ b/client/cli/src/output.rs
@@ -119,6 +119,23 @@ pub(crate) fn format_table(headers: &[&str], rows: &[Vec<String>], term_width: u
         }
     }
 
+    let total_content: usize = widths.iter().sum();
+    let slack = available.saturating_sub(total_content);
+    if slack > 0 && !widths.is_empty() {
+        let max_width = *widths.iter().max().unwrap_or(&0);
+        let max_indices: Vec<usize> = widths
+            .iter()
+            .enumerate()
+            .filter(|&(_, &w)| w == max_width)
+            .map(|(i, _)| i)
+            .collect();
+        let per_col = slack / max_indices.len();
+        let remainder = slack % max_indices.len();
+        for (j, &i) in max_indices.iter().enumerate() {
+            widths[i] += per_col + if j < remainder { 1 } else { 0 };
+        }
+    }
+
     let mut out = String::new();
 
     for (i, h) in headers.iter().enumerate() {

--- a/client/cli/tests/integration.rs
+++ b/client/cli/tests/integration.rs
@@ -1,3 +1,4 @@
+use gestalt::output::Format;
 use mockito::{Matcher, Server};
 
 fn create_client(server: &Server) -> gestalt::api::ApiClient {
@@ -108,6 +109,29 @@ fn test_execute_operation() {
 }
 
 #[test]
+fn test_list_integrations_table_format() {
+    let mut server = Server::new();
+    let mock = server
+        .mock("GET", "/api/v1/integrations")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(
+            r#"[
+                {"name": "test_svc", "description": "A short description", "connected": true},
+                {"name": "other_svc", "description": "Another service", "connected": false}
+            ]"#,
+        )
+        .create();
+
+    std::env::set_var("GESTALT_API_KEY", "test-token");
+    let result = gestalt::commands::integrations::list(Some(&server.url()), Format::Table);
+    std::env::remove_var("GESTALT_API_KEY");
+
+    mock.assert();
+    assert!(result.is_ok());
+}
+
+#[test]
 fn test_error_response() {
     let mut server = Server::new();
     let mock = server
@@ -124,6 +148,82 @@ fn test_error_response() {
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(err.contains("missing authorization header"));
+}
+
+#[test]
+fn test_list_operations_formats_parameters() {
+    let mut server = Server::new();
+    let mock = server
+        .mock("GET", "/api/v1/integrations/test_svc/operations")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(
+            r#"[{
+                "Name": "do_thing",
+                "Description": "Does a thing",
+                "Method": "POST",
+                "Parameters": [
+                    {"Name": "id", "Type": "string", "Required": true, "Default": null, "Description": "The ID"},
+                    {"Name": "mode", "Type": "string", "Required": false, "Default": null, "Description": "Mode"}
+                ]
+            }]"#,
+        )
+        .create();
+
+    std::env::set_var("GESTALT_API_KEY", "test-token");
+    let result =
+        gestalt::commands::invoke::list_operations(Some(&server.url()), "test_svc", Format::Table);
+    std::env::remove_var("GESTALT_API_KEY");
+
+    mock.assert();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_list_operations_json_format() {
+    let mut server = Server::new();
+    let mock = server
+        .mock("GET", "/api/v1/integrations/test_svc/operations")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(
+            r#"[{
+                "Name": "do_thing",
+                "Description": "Does a thing",
+                "Method": "POST",
+                "Parameters": [
+                    {"Name": "id", "Type": "string", "Required": true, "Default": null, "Description": "The ID"}
+                ]
+            }]"#,
+        )
+        .create();
+
+    std::env::set_var("GESTALT_API_KEY", "test-token");
+    let result =
+        gestalt::commands::invoke::list_operations(Some(&server.url()), "test_svc", Format::Json);
+    std::env::remove_var("GESTALT_API_KEY");
+
+    mock.assert();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_list_operations_empty_parameters() {
+    let mut server = Server::new();
+    let mock = server
+        .mock("GET", "/api/v1/integrations/test_svc/operations")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(r#"[{"Name": "list_items", "Description": "Lists items", "Method": "GET", "Parameters": []}]"#)
+        .create();
+
+    std::env::set_var("GESTALT_API_KEY", "test-token");
+    let result =
+        gestalt::commands::invoke::list_operations(Some(&server.url()), "test_svc", Format::Table);
+    std::env::remove_var("GESTALT_API_KEY");
+
+    mock.assert();
+    assert!(result.is_ok());
 }
 
 #[test]


### PR DESCRIPTION
The operations table from `gestalt invoke <INTEGRATION>` previously
showed parameters as raw JSON arrays, which was unreadable and didn't
reflect how parameters are actually passed to the CLI. Parameters now
display in CLI syntax like `-p documentId=<string> (required)` so users
can see exactly how to use them.

Separately, `gestalt integrations list` and other short tables left most
of the terminal width unused because the table formatter only shrank
columns to fit, never expanded them. The formatter now distributes
remaining terminal width to the widest column, so description text gets
room to breathe instead of hugging the left edge.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>