### PR TITLE
Add Jira Cloud integration with post-auth discovery

### DIFF
--- a/cmd/gestaltd/main.go
+++ b/cmd/gestaltd/main.go
@@ -8,6 +8,7 @@ import (
 
 	_ "github.com/valon-technologies/gestalt/plugins/integrations/datadog"
 	_ "github.com/valon-technologies/gestalt/plugins/integrations/hex"
+	_ "github.com/valon-technologies/gestalt/plugins/integrations/jira"
 	_ "github.com/valon-technologies/gestalt/plugins/integrations/slack"
 )
 

--- a/plugins/integrations/jira/hooks.go
+++ b/plugins/integrations/jira/hooks.go
@@ -1,0 +1,57 @@
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+func init() {
+	provider.RegisterPostConnectHook("jira_discovery", jiraDiscovery)
+}
+
+type accessibleResource struct {
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	URL       string   `json:"url"`
+	Scopes    []string `json:"scopes"`
+	AvatarURL string   `json:"avatarUrl"`
+}
+
+func jiraDiscovery(ctx context.Context, _ *core.IntegrationToken, client *http.Client) (map[string]string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://api.atlassian.com/oauth/token/accessible-resources", nil)
+	if err != nil {
+		return nil, fmt.Errorf("building accessible-resources request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching accessible resources: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading accessible-resources response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("accessible-resources returned %d: %s", resp.StatusCode, body)
+	}
+
+	var resources []accessibleResource
+	if err := json.Unmarshal(body, &resources); err != nil {
+		return nil, fmt.Errorf("decoding accessible-resources response: %w", err)
+	}
+
+	if len(resources) == 0 {
+		return nil, fmt.Errorf("no Jira sites accessible with this token")
+	}
+
+	return map[string]string{"cloud_id": resources[0].ID}, nil
+}

--- a/plugins/providers/jira.yaml
+++ b/plugins/providers/jira.yaml
@@ -1,0 +1,111 @@
+provider: jira
+display_name: Jira Cloud
+description: Atlassian Jira Cloud issue tracking
+base_url: https://api.atlassian.com/ex/jira/{cloud_id}/rest/api/3
+
+auth:
+  type: oauth2
+  authorization_url: https://auth.atlassian.com/authorize
+  token_url: https://auth.atlassian.com/oauth/token
+  scopes:
+    - read:me
+    - read:jira-work
+    - write:jira-work
+    - offline_access
+  authorization_params:
+    audience: api.atlassian.com
+    prompt: consent
+
+post_connect: jira_discovery
+
+connection:
+  cloud_id:
+    required: true
+    description: Jira Cloud site ID (discovered automatically)
+    from: post_connect
+
+operations:
+  list_projects:
+    description: List accessible projects
+    method: GET
+    path: /project
+    pagination:
+      style: offset
+      cursor_param: startAt
+      limit_param: maxResults
+      default_limit: 50
+
+  get_issue:
+    description: Get an issue by key or ID
+    method: GET
+    path: /issue/{issue_key}
+    parameters:
+      - name: issue_key
+        type: string
+        required: true
+        description: "Issue key (e.g. PROJ-123) or ID"
+
+  search_issues:
+    description: Search issues using JQL
+    method: GET
+    path: /search
+    parameters:
+      - name: jql
+        type: string
+        required: true
+        description: JQL query string
+      - name: maxResults
+        type: integer
+        default: 50
+    pagination:
+      style: offset
+      cursor_param: startAt
+      limit_param: maxResults
+      default_limit: 50
+      results_path: issues
+
+  create_issue:
+    description: Create a new issue
+    method: POST
+    path: /issue
+    parameters:
+      - name: fields
+        type: object
+        required: true
+        description: "Issue fields including project, summary, issuetype, etc."
+
+  add_comment:
+    description: Add a comment to an issue
+    method: POST
+    path: /issue/{issue_key}/comment
+    parameters:
+      - name: issue_key
+        type: string
+        required: true
+        description: "Issue key (e.g. PROJ-123)"
+      - name: body
+        type: object
+        required: true
+        description: Comment body in Atlassian Document Format
+
+  get_transitions:
+    description: Get available status transitions for an issue
+    method: GET
+    path: /issue/{issue_key}/transitions
+    parameters:
+      - name: issue_key
+        type: string
+        required: true
+
+  transition_issue:
+    description: Transition an issue to a new status
+    method: POST
+    path: /issue/{issue_key}/transitions
+    parameters:
+      - name: issue_key
+        type: string
+        required: true
+      - name: transition
+        type: object
+        required: true
+        description: "Transition object with id field"


### PR DESCRIPTION
Jira Cloud requires discovering the user's cloud site ID after OAuth
before any API calls can be made, since each site has a unique base URL.
This adds a Jira provider with OAuth2 auth, seven operations (projects,
issues, comments, transitions), and a `post_connect` hook that calls
Atlassian's accessible-resources endpoint to discover the site ID. The
ID is then interpolated into the base URL at request time via connection
parameters.

This is the first provider to use the `post_connect` hook framework,
serving as a proof-of-concept for post-auth API discovery.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>