### PR TITLE
Support dual auth for providers (OAuth + manual)

### DIFF
--- a/core/integration/base.go
+++ b/core/integration/base.go
@@ -115,6 +115,7 @@ type Base struct {
 
 	ConnectionDefs    map[string]core.ConnectionParamDef
 	PostConnectHookFn core.PostConnectHook
+	ManualAuthEnabled bool
 
 	catalog *catalog.Catalog
 }
@@ -131,8 +132,23 @@ func (b *Base) ConnectionMode() core.ConnectionMode {
 }
 
 func (b *Base) SupportsManualAuth() bool {
+	if b.ManualAuthEnabled {
+		return true
+	}
 	mc, ok := b.Auth.(manualChecker)
 	return ok && mc.IsManual()
+}
+
+func (b *Base) AuthTypes() []string {
+	mc, ok := b.Auth.(manualChecker)
+	manualOnly := ok && mc.IsManual()
+	if manualOnly {
+		return []string{"manual"}
+	}
+	if b.ManualAuthEnabled {
+		return []string{"oauth", "manual"}
+	}
+	return []string{"oauth"}
 }
 
 func (b *Base) ConnectionParamDefs() map[string]core.ConnectionParamDef {

--- a/core/provider.go
+++ b/core/provider.go
@@ -60,3 +60,7 @@ type PostConnectHook func(ctx context.Context, token *IntegrationToken, client *
 type PostConnectProvider interface {
 	PostConnectHook() PostConnectHook
 }
+
+type AuthTypeLister interface {
+	AuthTypes() []string
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,6 +90,7 @@ type IntegrationDef struct {
 	TokenParser      string            `yaml:"token_parser"`
 	RequestMutator   string            `yaml:"request_mutator"`
 	PostConnect      string            `yaml:"post_connect"`
+	ManualAuth       bool              `yaml:"manual_auth"`
 	TokenPrefix      string            `yaml:"token_prefix"`
 	AuthStyle        string            `yaml:"auth_style"`
 	IconFile         string            `yaml:"icon_file"`

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -158,6 +158,8 @@ func Build(def *Definition, intg config.IntegrationDef, allowedOperations map[st
 		base.PostConnectHookFn = hook
 	}
 
+	base.ManualAuthEnabled = def.ManualAuth
+
 	if len(def.Connection) > 0 {
 		base.ConnectionDefs = make(map[string]core.ConnectionParamDef, len(def.Connection))
 		for name, cpd := range def.Connection {
@@ -251,6 +253,9 @@ func applyOverrides(def *Definition, intg config.IntegrationDef) error {
 	setStr(&def.TokenParser, intg.TokenParser)
 	setStr(&def.RequestMutator, intg.RequestMutator)
 	setStr(&def.PostConnect, intg.PostConnect)
+	if intg.ManualAuth {
+		def.ManualAuth = true
+	}
 	setStr(&def.TokenPrefix, intg.TokenPrefix)
 	setStr(&def.AuthStyle, intg.AuthStyle)
 	if intg.IconFile != "" {

--- a/internal/provider/definition.go
+++ b/internal/provider/definition.go
@@ -21,6 +21,7 @@ type Definition struct {
 	TokenParser    string `yaml:"token_parser"`
 	RequestMutator string `yaml:"request_mutator"`
 	PostConnect    string `yaml:"post_connect"`
+	ManualAuth     bool   `yaml:"manual_auth"`
 
 	Connection map[string]ConnectionParamDef `yaml:"connection"`
 	Operations map[string]OperationDef       `yaml:"operations"`

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -63,6 +63,7 @@ type integrationInfo struct {
 	IconSVG          string                         `json:"icon_svg,omitempty"`
 	Connected        bool                           `json:"connected"`
 	AuthType         string                         `json:"auth_type"`
+	AuthTypes        []string                       `json:"auth_types"`
 	ConnectionParams map[string]connectionParamInfo `json:"connection_params,omitempty"`
 }
 
@@ -87,16 +88,21 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			continue
 		}
-		authType := "oauth"
-		if mp, ok := prov.(core.ManualProvider); ok && mp.SupportsManualAuth() {
-			authType = "manual"
+		var authTypes []string
+		if atl, ok := prov.(core.AuthTypeLister); ok {
+			authTypes = atl.AuthTypes()
+		} else if mp, ok := prov.(core.ManualProvider); ok && mp.SupportsManualAuth() {
+			authTypes = []string{"manual"}
+		} else {
+			authTypes = []string{"oauth"}
 		}
 		info := integrationInfo{
 			Name:        name,
 			DisplayName: prov.DisplayName(),
 			Description: prov.Description(),
 			Connected:   connected[name],
-			AuthType:    authType,
+			AuthType:    authTypes[0],
+			AuthTypes:   authTypes,
 		}
 		if cp, ok := prov.(core.CatalogProvider); ok {
 			if cat := cp.Catalog(); cat != nil {
@@ -207,14 +213,27 @@ func (s *Server) requireOAuthProvider(w http.ResponseWriter, name string) (core.
 	if !ok {
 		return nil, false
 	}
-	if mp, ok := prov.(core.ManualProvider); ok && mp.SupportsManualAuth() {
-		writeError(w, http.StatusBadRequest,
-			fmt.Sprintf("integration %q uses manual auth; use POST /api/v1/auth/connect-manual instead", name))
-		return nil, false
-	}
 	oauthProv, ok := prov.(core.OAuthProvider)
 	if !ok {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("integration %q does not support OAuth", name))
+		return nil, false
+	}
+	if atl, ok := prov.(core.AuthTypeLister); ok {
+		hasOAuth := false
+		for _, t := range atl.AuthTypes() {
+			if t == "oauth" {
+				hasOAuth = true
+				break
+			}
+		}
+		if !hasOAuth {
+			writeError(w, http.StatusBadRequest,
+				fmt.Sprintf("integration %q uses manual auth; use POST /api/v1/auth/connect-manual instead", name))
+			return nil, false
+		}
+	} else if mp, ok := prov.(core.ManualProvider); ok && mp.SupportsManualAuth() {
+		writeError(w, http.StatusBadRequest,
+			fmt.Sprintf("integration %q uses manual auth; use POST /api/v1/auth/connect-manual instead", name))
 		return nil, false
 	}
 	return oauthProv, true

--- a/web/src/components/IntegrationCard.tsx
+++ b/web/src/components/IntegrationCard.tsx
@@ -74,7 +74,11 @@ export default function IntegrationCard({
   const safeIconSVG = integration.icon_svg
     ? sanitizeSVG(integration.icon_svg)
     : "";
-  const isManual = integration.auth_type === "manual";
+  const authTypes = integration.auth_types ?? [integration.auth_type ?? "oauth"];
+  const supportsOAuth = authTypes.includes("oauth");
+  const supportsManual = authTypes.includes("manual");
+  const isDualAuth = supportsOAuth && supportsManual;
+  const isManualOnly = supportsManual && !supportsOAuth;
   const needsParams = hasConnectionParams(integration);
 
   function collectConnectionParams(
@@ -89,13 +93,13 @@ export default function IntegrationCard({
     return params;
   }
 
-  async function handleConnect() {
-    if (isManual) {
-      setSettingsOpen(false);
-      setShowTokenForm(true);
-      setError(null);
-      return;
-    }
+  function handleConnectManual() {
+    setSettingsOpen(false);
+    setShowTokenForm(true);
+    setError(null);
+  }
+
+  async function handleConnectOAuth() {
     if (needsParams && !showParamForm) {
       setSettingsOpen(false);
       setShowParamForm(true);
@@ -111,6 +115,14 @@ export default function IntegrationCard({
       setError(err instanceof Error ? err.message : "Failed to start OAuth");
     } finally {
       setLoading(false);
+    }
+  }
+
+  function handleConnect() {
+    if (isManualOnly) {
+      handleConnectManual();
+    } else {
+      handleConnectOAuth();
     }
   }
 
@@ -244,7 +256,7 @@ export default function IntegrationCard({
       {error && !settingsOpen && (
         <p className="mt-2 text-sm text-ember-500">{error}</p>
       )}
-      {showParamForm && !isManual && (
+      {showParamForm && !isManualOnly && (
         <form onSubmit={handleParamSubmit} className="mt-3">
           {renderConnectionParamFields()}
           <div className="mt-3 flex gap-2">
@@ -299,7 +311,8 @@ export default function IntegrationCard({
         <IntegrationSettingsModal
           integration={integration}
           onClose={handleSettingsClose}
-          onReconnect={handleConnect}
+          onReconnect={isDualAuth ? handleConnectOAuth : handleConnect}
+          onReconnectManual={isDualAuth ? handleConnectManual : undefined}
           onDisconnect={handleDisconnect}
           reconnecting={loading}
           disconnecting={disconnecting}

--- a/web/src/components/IntegrationSettingsModal.tsx
+++ b/web/src/components/IntegrationSettingsModal.tsx
@@ -9,6 +9,7 @@ interface IntegrationSettingsModalProps {
   integration: Integration;
   onClose: () => void;
   onReconnect: () => void;
+  onReconnectManual?: () => void;
   onDisconnect: () => void;
   reconnecting: boolean;
   disconnecting: boolean;
@@ -19,6 +20,7 @@ export default function IntegrationSettingsModal({
   integration,
   onClose,
   onReconnect,
+  onReconnectManual,
   onDisconnect,
   reconnecting,
   disconnecting,
@@ -147,14 +149,24 @@ export default function IntegrationSettingsModal({
 
                 {error && <p className="mt-3 text-sm text-ember-500">{error}</p>}
 
-                <div className="mt-6">
+                <div className="mt-6 flex flex-col gap-2">
                   <Button
                     className="w-full"
                     onClick={onReconnect}
                     disabled={reconnecting}
                   >
-                    {reconnecting ? "Connecting..." : "Connect"}
+                    {reconnecting ? "Connecting..." : onReconnectManual ? "Connect with OAuth" : "Connect"}
                   </Button>
+                  {onReconnectManual && (
+                    <Button
+                      variant="secondary"
+                      className="w-full"
+                      onClick={onReconnectManual}
+                      disabled={reconnecting}
+                    >
+                      Use API Token
+                    </Button>
+                  )}
                 </div>
               </>
             )}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -14,6 +14,7 @@ export interface Integration {
   icon_svg?: string;
   connected?: boolean;
   auth_type?: "oauth" | "manual";
+  auth_types?: ("oauth" | "manual")[];
   connection_params?: Record<string, ConnectionParamDef>;
 }
 


### PR DESCRIPTION
Many APIs like Jira, GitHub, and Slack support both OAuth for end-user
delegation and API tokens for service accounts. Providers can now set
`manual_auth: true` in their YAML definition to indicate they accept
both auth methods. The integrations API returns an `auth_types` array
alongside the existing `auth_type` field for backward compatibility.
When both methods are available, the settings modal shows separate
"Connect with OAuth" and "Use API Token" buttons so users can choose
their preferred authentication flow.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>