### PR TITLE
Support deferred MCP upstream initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ internal/webui/out/
 
 # Exceptions
 !internal/manifest/
+.claude/scheduled_tasks.lock

--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/internal/composite"
@@ -263,10 +265,16 @@ func defaultProviderFactory(providerDirs []string) bootstrap.ProviderFactory {
 					return nil, fmt.Errorf("multiple mcp upstreams not supported")
 				}
 				up, err := mcpupstream.New(ctx, name, us.URL, connMode)
-				if err != nil {
+				switch {
+				case errors.Is(err, transport.ErrUnauthorized):
+					log.Printf("INFO: deferring MCP upstream %q: %v", name, err)
+					up = mcpupstream.NewDeferred(name, us.URL, connMode)
+					if us.AllowedOperations != nil {
+						up.SetAllowedOperations(map[string]string(us.AllowedOperations))
+					}
+				case err != nil:
 					return nil, err
-				}
-				if us.AllowedOperations != nil {
+				case us.AllowedOperations != nil:
 					if err := up.FilterOperations(map[string]string(us.AllowedOperations)); err != nil {
 						_ = up.Close()
 						return nil, err

--- a/internal/composite/provider.go
+++ b/internal/composite/provider.go
@@ -23,7 +23,6 @@ type Provider struct {
 	name string
 	api  core.Provider
 	mcp  MCPUpstream
-	cat  *catalog.Catalog
 }
 
 var (
@@ -39,7 +38,6 @@ func New(name string, apiProv core.Provider, mcpUp MCPUpstream) core.Provider {
 		api:  apiProv,
 		mcp:  mcpUp,
 	}
-	p.cat = p.buildCatalog()
 	if oauth, ok := apiProv.(core.OAuthProvider); ok {
 		return &oauthProvider{Provider: p, oauth: oauth}
 	}
@@ -51,7 +49,7 @@ func (p *Provider) DisplayName() string                 { return p.api.DisplayNa
 func (p *Provider) Description() string                 { return p.api.Description() }
 func (p *Provider) ConnectionMode() core.ConnectionMode { return p.api.ConnectionMode() }
 func (p *Provider) ListOperations() []core.Operation    { return p.api.ListOperations() }
-func (p *Provider) Catalog() *catalog.Catalog           { return p.cat }
+func (p *Provider) Catalog() *catalog.Catalog           { return p.buildCatalog() }
 
 func (p *Provider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
 	return p.api.Execute(ctx, operation, params, token)
@@ -62,6 +60,24 @@ func (p *Provider) CallTool(ctx context.Context, name string, args map[string]an
 }
 
 func (p *Provider) Inner() core.Provider { return p.api }
+
+func (p *Provider) IsDeferred() bool {
+	type deferred interface{ IsDeferred() bool }
+	if du, ok := p.mcp.(deferred); ok {
+		return du.IsDeferred()
+	}
+	return false
+}
+
+func (p *Provider) EnsureInitialized(ctx context.Context) (bool, error) {
+	type initializer interface {
+		EnsureInitialized(ctx context.Context) (bool, error)
+	}
+	if init, ok := p.mcp.(initializer); ok {
+		return init.EnsureInitialized(ctx)
+	}
+	return false, nil
+}
 
 // SupportsManualAuth delegates to the API provider only. The MCP
 // upstream's manual-auth support is irrelevant — the server uses this

--- a/internal/mcp/binding.go
+++ b/internal/mcp/binding.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"log"
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
@@ -30,6 +31,11 @@ type directToolCaller interface {
 	CallTool(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error)
 }
 
+type DeferredUpstream interface {
+	IsDeferred() bool
+	EnsureInitialized(ctx context.Context) (bool, error)
+}
+
 type Config struct {
 	Invoker          invocation.Invoker
 	TokenResolver    TokenResolver
@@ -40,12 +46,35 @@ type Config struct {
 }
 
 func NewServer(cfg Config) *mcpserver.MCPServer {
-	srv := mcpserver.NewMCPServer(serverName, serverVersion)
-
 	allowed := make(map[string]struct{}, len(cfg.AllowedProviders))
 	for _, p := range cfg.AllowedProviders {
 		allowed[p] = struct{}{}
 	}
+
+	var deferred []deferredInfo
+	for _, provName := range cfg.Providers.List() {
+		if cfg.AllowedProviders != nil {
+			if _, ok := allowed[provName]; !ok {
+				continue
+			}
+		}
+		prov, err := cfg.Providers.Get(provName)
+		if err != nil {
+			continue
+		}
+		if du := extractDeferredUpstream(prov); du != nil && du.IsDeferred() {
+			deferred = append(deferred, deferredInfo{provName: provName, upstream: du, prov: prov})
+		}
+	}
+
+	hooks := &mcpserver.Hooks{}
+	opts := []mcpserver.ServerOption{mcpserver.WithHooks(hooks)}
+	if len(deferred) > 0 {
+		// AddTool enables tool capabilities implicitly, but with only
+		// deferred providers the capability is never set.
+		opts = append(opts, mcpserver.WithToolCapabilities(true))
+	}
+	srv := mcpserver.NewMCPServer(serverName, serverVersion, opts...)
 
 	for _, provName := range cfg.Providers.List() {
 		if cfg.AllowedProviders != nil {
@@ -69,7 +98,61 @@ func NewServer(cfg Config) *mcpserver.MCPServer {
 		addFlatTools(srv, cfg, provName, prov)
 	}
 
+	if len(deferred) > 0 {
+		hooks.AddBeforeListTools(func(ctx context.Context, _ any, _ *mcpgo.ListToolsRequest) {
+			tryInitDeferred(ctx, srv, cfg, deferred)
+		})
+	}
+
 	return srv
+}
+
+type deferredInfo struct {
+	provName string
+	upstream DeferredUpstream
+	prov     core.Provider
+}
+
+func tryInitDeferred(ctx context.Context, srv *mcpserver.MCPServer, cfg Config, deferred []deferredInfo) {
+	p := principal.FromContext(ctx)
+	if p == nil || cfg.TokenResolver == nil {
+		return
+	}
+	for _, d := range deferred {
+		if !d.upstream.IsDeferred() {
+			continue
+		}
+		token, err := cfg.TokenResolver.ResolveToken(ctx, p, d.provName)
+		if err != nil {
+			continue
+		}
+		initCtx := mcpupstream.WithUpstreamToken(ctx, token)
+		initialized, err := d.upstream.EnsureInitialized(initCtx)
+		if err != nil {
+			log.Printf("WARNING: deferred init %q: %v", d.provName, err)
+			continue
+		}
+		if !initialized {
+			continue
+		}
+		cp, ok := d.prov.(core.CatalogProvider)
+		if !ok {
+			continue
+		}
+		cat := cp.Catalog()
+		if cat == nil {
+			continue
+		}
+		addCatalogTools(srv, cfg, d.provName, cat, d.prov)
+		log.Printf("deferred MCP upstream %q initialized, registered tools", d.provName)
+	}
+}
+
+func extractDeferredUpstream(prov core.Provider) DeferredUpstream {
+	if du, ok := prov.(DeferredUpstream); ok {
+		return du
+	}
+	return nil
 }
 
 func addCatalogTools(srv *mcpserver.MCPServer, cfg Config, provName string, cat *catalog.Catalog, prov core.Provider) {

--- a/internal/mcp/deferred_test.go
+++ b/internal/mcp/deferred_test.go
@@ -1,0 +1,268 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+	ci "github.com/valon-technologies/gestalt/core/integration"
+	coretesting "github.com/valon-technologies/gestalt/core/testing"
+	"github.com/valon-technologies/gestalt/internal/composite"
+	gestaltmcp "github.com/valon-technologies/gestalt/internal/mcp"
+	"github.com/valon-technologies/gestalt/internal/principal"
+	"github.com/valon-technologies/gestalt/internal/testutil"
+
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+)
+
+type stubDeferredUpstream struct {
+	coretesting.StubIntegration
+	mu          sync.Mutex
+	deferred    bool
+	cat         *catalog.Catalog
+	postInitCat *catalog.Catalog
+	callFn      func(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error)
+}
+
+func newStubDeferredUpstream(name string, postInitCat *catalog.Catalog) *stubDeferredUpstream {
+	return &stubDeferredUpstream{
+		StubIntegration: coretesting.StubIntegration{N: name},
+		deferred:        true,
+		cat:             &catalog.Catalog{Name: name},
+		postInitCat:     postInitCat,
+	}
+}
+
+func (u *stubDeferredUpstream) Catalog() *catalog.Catalog {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.cat
+}
+
+func (u *stubDeferredUpstream) SupportsManualAuth() bool { return true }
+func (u *stubDeferredUpstream) Close() error             { return nil }
+
+func (u *stubDeferredUpstream) CallTool(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
+	if u.callFn != nil {
+		return u.callFn(ctx, name, args)
+	}
+	return mcpgo.NewToolResultText("direct:" + name), nil
+}
+
+func (u *stubDeferredUpstream) IsDeferred() bool {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.deferred
+}
+
+func (u *stubDeferredUpstream) EnsureInitialized(_ context.Context) (bool, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if !u.deferred {
+		return false, nil
+	}
+	u.cat = u.postInitCat
+	u.deferred = false
+	return true, nil
+}
+
+func (u *stubDeferredUpstream) ListOperations() []core.Operation {
+	return ci.OperationsList(u.Catalog())
+}
+
+func listToolsViaClient(t *testing.T, srv *mcpserver.MCPServer) []mcpgo.Tool {
+	t.Helper()
+
+	client, err := mcpclient.NewInProcessClient(srv)
+	if err != nil {
+		t.Fatalf("NewInProcessClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	ctx := ctxWithPrincipal()
+	if err := client.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	initReq := mcpgo.InitializeRequest{}
+	initReq.Params.ProtocolVersion = mcpgo.LATEST_PROTOCOL_VERSION
+	initReq.Params.ClientInfo = mcpgo.Implementation{Name: "test", Version: "0.0.1"}
+	if _, err := client.Initialize(ctx, initReq); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	result, err := client.ListTools(ctx, mcpgo.ListToolsRequest{})
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	return result.Tools
+}
+
+type principalTokenResolver struct {
+	token string
+}
+
+func (r *principalTokenResolver) ResolveToken(ctx context.Context, p *principal.Principal, _ string) (string, error) {
+	if p == nil {
+		return "", nil
+	}
+	return r.token, nil
+}
+
+func TestNewServer_DeferredProviderSkipsMCPTools(t *testing.T) {
+	t.Parallel()
+
+	mcpUp := newStubDeferredUpstream("ch", &catalog.Catalog{
+		Name: "ch",
+		Operations: []catalog.CatalogOperation{
+			{ID: "run_query", Description: "Execute SQL", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		},
+	})
+
+	apiCat := &catalog.Catalog{
+		Name: "ch",
+		Operations: []catalog.CatalogOperation{
+			{ID: "api_op", Method: "GET", Path: "/api", Description: "API op"},
+		},
+	}
+	comp := composite.New("ch", &catalogProvider{
+		StubIntegration: coretesting.StubIntegration{N: "ch"},
+		ops:             ci.OperationsList(apiCat),
+		catalog:         apiCat,
+	}, mcpUp)
+
+	providers := testutil.NewProviderRegistry(t, comp)
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker:       &testutil.StubInvoker{},
+		TokenResolver: &principalTokenResolver{token: "t"},
+		Providers:     providers,
+		IncludeHTTP:   map[string]bool{"ch": true},
+	})
+
+	tools := srv.ListTools()
+	if tools["ch_api_op"] == nil {
+		t.Fatal("expected ch_api_op (API tool) to be present")
+	}
+	if tools["ch_run_query"] != nil {
+		t.Fatal("expected ch_run_query (deferred MCP tool) to be absent before init")
+	}
+}
+
+func TestNewServer_DeferredToolsAppearAfterListTools(t *testing.T) {
+	t.Parallel()
+
+	mcpUp := newStubDeferredUpstream("ch", &catalog.Catalog{
+		Name: "ch",
+		Operations: []catalog.CatalogOperation{
+			{ID: "run_query", Description: "Execute SQL", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		},
+	})
+
+	providers := testutil.NewProviderRegistry(t, mcpUp)
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker:       &testutil.StubInvoker{},
+		TokenResolver: &principalTokenResolver{token: "t"},
+		Providers:     providers,
+	})
+
+	// Before authenticated ListTools: no tools
+	tools := srv.ListTools()
+	if len(tools) != 0 {
+		t.Fatalf("expected 0 tools before authenticated ListTools, got %d", len(tools))
+	}
+
+	// ListTools via in-process client triggers the OnBeforeListTools hook
+	resultTools := listToolsViaClient(t, srv)
+	if len(resultTools) != 1 {
+		t.Fatalf("expected 1 tool after deferred init, got %d", len(resultTools))
+	}
+	if resultTools[0].Name != "ch_run_query" {
+		t.Fatalf("unexpected tool name: %q", resultTools[0].Name)
+	}
+}
+
+func TestNewServer_DeferredCompositeToolsAppearAfterInit(t *testing.T) {
+	t.Parallel()
+
+	mcpUp := newStubDeferredUpstream("notion", &catalog.Catalog{
+		Name: "notion",
+		Operations: []catalog.CatalogOperation{
+			{ID: "search", Description: "Search Notion", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		},
+	})
+
+	apiCat := &catalog.Catalog{
+		Name: "notion",
+		Operations: []catalog.CatalogOperation{
+			{ID: "list_pages", Method: "GET", Path: "/pages", Description: "List pages"},
+		},
+	}
+	apiProv := &catalogProvider{
+		StubIntegration: coretesting.StubIntegration{N: "notion"},
+		ops:             ci.OperationsList(apiCat),
+		catalog:         apiCat,
+	}
+
+	comp := composite.New("notion", apiProv, mcpUp)
+	providers := testutil.NewProviderRegistry(t, comp)
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker:       &testutil.StubInvoker{},
+		TokenResolver: &principalTokenResolver{token: "t"},
+		Providers:     providers,
+		IncludeHTTP:   map[string]bool{"notion": true},
+	})
+
+	// Before: only API tools
+	tools := srv.ListTools()
+	if tools["notion_list_pages"] == nil {
+		t.Fatal("expected notion_list_pages (API tool)")
+	}
+	if tools["notion_search"] != nil {
+		t.Fatal("expected notion_search (deferred MCP) to be absent")
+	}
+
+	// After hook fires via authenticated ListTools: MCP tools appear too
+	resultTools := listToolsViaClient(t, srv)
+	toolNames := make(map[string]bool)
+	for _, tool := range resultTools {
+		toolNames[tool.Name] = true
+	}
+	if !toolNames["notion_list_pages"] {
+		t.Fatal("expected notion_list_pages after init")
+	}
+	if !toolNames["notion_search"] {
+		t.Fatal("expected notion_search after deferred init")
+	}
+}
+
+func TestNewServer_DeferredTokenErrorSkipsInit(t *testing.T) {
+	t.Parallel()
+
+	mcpUp := newStubDeferredUpstream("ch", &catalog.Catalog{
+		Name: "ch",
+		Operations: []catalog.CatalogOperation{
+			{ID: "run_query", Description: "Execute SQL"},
+		},
+	})
+
+	providers := testutil.NewProviderRegistry(t, mcpUp)
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker:       &testutil.StubInvoker{},
+		TokenResolver: &stubTokenResolver{err: fmt.Errorf("no token stored")},
+		Providers:     providers,
+	})
+
+	resultTools := listToolsViaClient(t, srv)
+	if len(resultTools) != 0 {
+		t.Fatalf("expected 0 tools when token resolution fails, got %d", len(resultTools))
+	}
+	if !mcpUp.IsDeferred() {
+		t.Fatal("expected upstream to remain deferred")
+	}
+}

--- a/internal/mcpupstream/upstream.go
+++ b/internal/mcpupstream/upstream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/valon-technologies/gestalt/core"
@@ -30,6 +31,14 @@ type Upstream struct {
 	cat      *catalog.Catalog
 	ops      []core.Operation
 	client   mcpclient.MCPClient
+
+	// Deferred initialization fields. When deferred is true, the upstream
+	// was created without connecting; EnsureInitialized must be called
+	// with an authenticated context before the client can be used.
+	url        string
+	deferred   bool
+	mu         sync.RWMutex
+	allowedOps map[string]string
 }
 
 func New(ctx context.Context, name string, url string, connMode core.ConnectionMode) (*Upstream, error) {
@@ -37,39 +46,12 @@ func New(ctx context.Context, name string, url string, connMode core.ConnectionM
 		return nil, fmt.Errorf("mcpupstream %s: url is required", name)
 	}
 
-	client, err := mcpclient.NewStreamableHttpClient(url,
-		transport.WithHTTPTimeout(httpTimeout),
-		transport.WithHTTPHeaderFunc(func(ctx context.Context) map[string]string {
-			if token := UpstreamTokenFromContext(ctx); token != "" {
-				return map[string]string{"Authorization": core.BearerScheme + token}
-			}
-			return nil
-		}),
-	)
+	client, tools, err := connect(ctx, name, url)
 	if err != nil {
-		return nil, fmt.Errorf("mcpupstream %s: creating client: %w", name, err)
+		return nil, err
 	}
 
-	if err := client.Start(ctx); err != nil {
-		_ = client.Close()
-		return nil, fmt.Errorf("mcpupstream %s: starting client: %w", name, err)
-	}
-
-	initReq := mcpgo.InitializeRequest{}
-	initReq.Params.ProtocolVersion = mcpgo.LATEST_PROTOCOL_VERSION
-	initReq.Params.ClientInfo = mcpgo.Implementation{Name: "gestalt", Version: "0.1.0"}
-	if _, err := client.Initialize(ctx, initReq); err != nil {
-		_ = client.Close()
-		return nil, fmt.Errorf("mcpupstream %s: initialize: %w", name, err)
-	}
-
-	toolsResult, err := client.ListTools(ctx, mcpgo.ListToolsRequest{})
-	if err != nil {
-		_ = client.Close()
-		return nil, fmt.Errorf("mcpupstream %s: listing tools: %w", name, err)
-	}
-
-	cat, ops := buildCatalog(name, toolsResult.Tools)
+	cat, ops := buildCatalog(name, tools)
 
 	return &Upstream{
 		name:     name,
@@ -80,6 +62,107 @@ func New(ctx context.Context, name string, url string, connMode core.ConnectionM
 		ops:      ops,
 		client:   client,
 	}, nil
+}
+
+func NewDeferred(name string, url string, connMode core.ConnectionMode) *Upstream {
+	return &Upstream{
+		name:     name,
+		display:  name,
+		desc:     fmt.Sprintf("MCP upstream: %s", url),
+		connMode: connMode,
+		url:      url,
+		deferred: true,
+		cat:      &catalog.Catalog{Name: name},
+	}
+}
+
+func (u *Upstream) SetAllowedOperations(allowed map[string]string) {
+	u.allowedOps = allowed
+}
+
+func (u *Upstream) IsDeferred() bool {
+	u.mu.RLock()
+	defer u.mu.RUnlock()
+	return u.deferred
+}
+
+// EnsureInitialized connects a deferred upstream using the token present in
+// ctx. Safe to call concurrently; failed attempts allow retry on next call.
+// Returns true when this call performed the actual initialization, false when
+// the upstream was already initialized (by this or another goroutine).
+func (u *Upstream) EnsureInitialized(ctx context.Context) (bool, error) {
+	u.mu.RLock()
+	if !u.deferred {
+		u.mu.RUnlock()
+		return false, nil
+	}
+	u.mu.RUnlock()
+
+	client, tools, err := connect(ctx, u.name, u.url)
+	if err != nil {
+		return false, err
+	}
+
+	cat, ops := buildCatalog(u.name, tools)
+
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	if !u.deferred {
+		_ = client.Close()
+		return false, nil
+	}
+
+	u.cat = cat
+	u.ops = ops
+	if u.allowedOps != nil {
+		if err := u.FilterOperations(u.allowedOps); err != nil {
+			u.cat = &catalog.Catalog{Name: u.name}
+			u.ops = nil
+			_ = client.Close()
+			return false, fmt.Errorf("mcpupstream %s: %w", u.name, err)
+		}
+	}
+
+	u.client = client
+	u.deferred = false
+	return true, nil
+}
+
+func connect(ctx context.Context, name, url string) (mcpclient.MCPClient, []mcpgo.Tool, error) {
+	client, err := mcpclient.NewStreamableHttpClient(url,
+		transport.WithHTTPTimeout(httpTimeout),
+		transport.WithHTTPHeaderFunc(func(ctx context.Context) map[string]string {
+			if token := UpstreamTokenFromContext(ctx); token != "" {
+				return map[string]string{"Authorization": core.BearerScheme + token}
+			}
+			return nil
+		}),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("mcpupstream %s: creating client: %w", name, err)
+	}
+
+	if err := client.Start(ctx); err != nil {
+		_ = client.Close()
+		return nil, nil, fmt.Errorf("mcpupstream %s: starting client: %w", name, err)
+	}
+
+	initReq := mcpgo.InitializeRequest{}
+	initReq.Params.ProtocolVersion = mcpgo.LATEST_PROTOCOL_VERSION
+	initReq.Params.ClientInfo = mcpgo.Implementation{Name: "gestalt", Version: "0.1.0"}
+	if _, err := client.Initialize(ctx, initReq); err != nil {
+		_ = client.Close()
+		return nil, nil, fmt.Errorf("mcpupstream %s: initialize: %w", name, err)
+	}
+
+	toolsResult, err := client.ListTools(ctx, mcpgo.ListToolsRequest{})
+	if err != nil {
+		_ = client.Close()
+		return nil, nil, fmt.Errorf("mcpupstream %s: listing tools: %w", name, err)
+	}
+
+	return client, toolsResult.Tools, nil
 }
 
 func newFromClient(name string, client mcpclient.MCPClient, connMode core.ConnectionMode, tools []mcpgo.Tool) *Upstream {
@@ -99,23 +182,45 @@ func (u *Upstream) Name() string                        { return u.name }
 func (u *Upstream) DisplayName() string                 { return u.display }
 func (u *Upstream) Description() string                 { return u.desc }
 func (u *Upstream) ConnectionMode() core.ConnectionMode { return u.connMode }
-func (u *Upstream) ListOperations() []core.Operation    { return u.ops }
-func (u *Upstream) Catalog() *catalog.Catalog           { return u.cat }
 func (u *Upstream) SupportsManualAuth() bool            { return true }
+
+func (u *Upstream) ListOperations() []core.Operation {
+	u.mu.RLock()
+	defer u.mu.RUnlock()
+	return u.ops
+}
+
+func (u *Upstream) Catalog() *catalog.Catalog {
+	u.mu.RLock()
+	defer u.mu.RUnlock()
+	return u.cat
+}
 
 func (u *Upstream) Execute(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
 	return nil, core.ErrMCPOnly
 }
 
 func (u *Upstream) CallTool(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
+	if _, err := u.EnsureInitialized(ctx); err != nil {
+		return nil, fmt.Errorf("deferred init: %w", err)
+	}
+	u.mu.RLock()
+	c := u.client
+	u.mu.RUnlock()
 	req := mcpgo.CallToolRequest{}
 	req.Params.Name = name
 	req.Params.Arguments = args
-	return u.client.CallTool(ctx, req)
+	return c.CallTool(ctx, req)
 }
 
 func (u *Upstream) Close() error {
-	return u.client.Close()
+	u.mu.RLock()
+	c := u.client
+	u.mu.RUnlock()
+	if c == nil {
+		return nil
+	}
+	return c.Close()
 }
 
 func (u *Upstream) FilterOperations(allowed map[string]string) error {

--- a/internal/mcpupstream/upstream_test.go
+++ b/internal/mcpupstream/upstream_test.go
@@ -2,6 +2,7 @@ package mcpupstream
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/core"
@@ -234,5 +235,210 @@ func TestUpstream_ProviderMetadata(t *testing.T) {
 	}
 	if !u.SupportsManualAuth() {
 		t.Fatal("expected SupportsManualAuth to be true")
+	}
+}
+
+const testUpstreamName = "test-deferred"
+
+func newTestHTTPServerURL(t *testing.T) string {
+	t.Helper()
+	srv := newTestServer()
+	ts := mcpserver.NewTestStreamableHTTPServer(srv, mcpserver.WithStateLess(true))
+	t.Cleanup(ts.Close)
+	return ts.URL + "/mcp"
+}
+
+func TestNewDeferred_EmptyCatalog(t *testing.T) {
+	t.Parallel()
+
+	u := NewDeferred(testUpstreamName, "http://localhost:9999/mcp", core.ConnectionModeUser)
+
+	if u.client != nil {
+		t.Fatal("expected nil client on deferred upstream")
+	}
+
+	ops := u.ListOperations()
+	if len(ops) != 0 {
+		t.Fatalf("expected 0 operations, got %d", len(ops))
+	}
+
+	cat := u.Catalog()
+	if cat == nil {
+		t.Fatal("expected non-nil catalog")
+	}
+	if len(cat.Operations) != 0 {
+		t.Fatalf("expected 0 catalog operations, got %d", len(cat.Operations))
+	}
+}
+
+func TestDeferred_EnsureInitialized(t *testing.T) {
+	t.Parallel()
+
+	url := newTestHTTPServerURL(t)
+	u := NewDeferred(testUpstreamName, url, core.ConnectionModeUser)
+	t.Cleanup(func() { _ = u.Close() })
+
+	if !u.IsDeferred() {
+		t.Fatal("expected IsDeferred true before init")
+	}
+
+	ctx := context.Background()
+	if _, err := u.EnsureInitialized(ctx); err != nil {
+		t.Fatalf("EnsureInitialized: %v", err)
+	}
+
+	if u.IsDeferred() {
+		t.Fatal("expected IsDeferred false after init")
+	}
+
+	ops := u.ListOperations()
+	if len(ops) != 2 {
+		t.Fatalf("expected 2 operations, got %d", len(ops))
+	}
+
+	opNames := make(map[string]bool)
+	for _, op := range ops {
+		opNames[op.Name] = true
+	}
+	if !opNames["run_query"] || !opNames["list_databases"] {
+		t.Fatalf("unexpected operations: %v", ops)
+	}
+
+	if _, err := u.EnsureInitialized(ctx); err != nil {
+		t.Fatalf("second EnsureInitialized should be no-op: %v", err)
+	}
+}
+
+func TestDeferred_ConcurrentInit(t *testing.T) {
+	t.Parallel()
+
+	url := newTestHTTPServerURL(t)
+	u := NewDeferred(testUpstreamName, url, core.ConnectionModeUser)
+	t.Cleanup(func() { _ = u.Close() })
+
+	const goroutines = 10
+	ctx := context.Background()
+	errs := make(chan error, goroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			_, err := u.EnsureInitialized(ctx)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("EnsureInitialized from goroutine: %v", err)
+		}
+	}
+
+	if u.IsDeferred() {
+		t.Fatal("expected IsDeferred false after concurrent init")
+	}
+
+	ops := u.ListOperations()
+	if len(ops) != 2 {
+		t.Fatalf("expected 2 operations, got %d", len(ops))
+	}
+}
+
+func TestDeferred_CallToolTriggersInit(t *testing.T) {
+	t.Parallel()
+
+	url := newTestHTTPServerURL(t)
+	u := NewDeferred(testUpstreamName, url, core.ConnectionModeUser)
+	t.Cleanup(func() { _ = u.Close() })
+
+	if !u.IsDeferred() {
+		t.Fatal("expected IsDeferred true before CallTool")
+	}
+
+	result, err := u.CallTool(context.Background(), "run_query", map[string]any{"sql": "SELECT 42"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	if u.IsDeferred() {
+		t.Fatal("expected IsDeferred false after CallTool")
+	}
+
+	text, ok := result.Content[0].(mcpgo.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+	if text.Text != "result for: SELECT 42" {
+		t.Fatalf("unexpected text: %q", text.Text)
+	}
+}
+
+func TestDeferred_AllowedOpsApplied(t *testing.T) {
+	t.Parallel()
+
+	url := newTestHTTPServerURL(t)
+	u := NewDeferred(testUpstreamName, url, core.ConnectionModeUser)
+	t.Cleanup(func() { _ = u.Close() })
+
+	u.SetAllowedOperations(map[string]string{
+		"run_query": "Custom description",
+	})
+
+	ctx := context.Background()
+	if _, err := u.EnsureInitialized(ctx); err != nil {
+		t.Fatalf("EnsureInitialized: %v", err)
+	}
+
+	ops := u.ListOperations()
+	if len(ops) != 1 {
+		t.Fatalf("expected 1 operation after filtering, got %d", len(ops))
+	}
+	if ops[0].Name != "run_query" {
+		t.Fatalf("expected run_query, got %q", ops[0].Name)
+	}
+	if ops[0].Description != "Custom description" {
+		t.Fatalf("expected overridden description, got %q", ops[0].Description)
+	}
+
+	cat := u.Catalog()
+	if len(cat.Operations) != 1 {
+		t.Fatalf("expected 1 catalog operation, got %d", len(cat.Operations))
+	}
+	if cat.Operations[0].ID != "run_query" {
+		t.Fatalf("expected run_query in catalog, got %q", cat.Operations[0].ID)
+	}
+}
+
+func TestDeferred_CloseBeforeInit(t *testing.T) {
+	t.Parallel()
+
+	u := NewDeferred(testUpstreamName, "http://localhost:9999/mcp", core.ConnectionModeUser)
+	if err := u.Close(); err != nil {
+		t.Fatalf("Close on uninitialized deferred upstream: %v", err)
+	}
+}
+
+func TestDeferred_IsDeferred(t *testing.T) {
+	t.Parallel()
+
+	url := newTestHTTPServerURL(t)
+	u := NewDeferred(testUpstreamName, url, core.ConnectionModeUser)
+	t.Cleanup(func() { _ = u.Close() })
+
+	if !u.IsDeferred() {
+		t.Fatal("expected IsDeferred true before init")
+	}
+
+	ctx := context.Background()
+	if _, err := u.EnsureInitialized(ctx); err != nil {
+		t.Fatalf("EnsureInitialized: %v", err)
+	}
+
+	if u.IsDeferred() {
+		t.Fatal("expected IsDeferred false after init")
 	}
 }


### PR DESCRIPTION
MCP upstreams requiring authentication (like ClickHouse and Linear)
previously failed at startup with 401 because the system eagerly called
`Initialize` and `ListTools` before any user had connected. This caused
the provider to be skipped entirely, leaving its tools permanently
unavailable. The fix introduces a deferred mode: when eager
initialization fails, the upstream is created without connecting and
stays dormant until the first authenticated `tools/list` request, at
which point it connects, discovers tools, and registers them dynamically
via an `OnBeforeListTools` hook in mcp-go.

The composite provider's catalog is now derived from live children on
each call rather than cached at construction, so newly discovered MCP
tools are automatically reflected. All MCP server mutation stays in
`internal/mcp`, with the upstream exposing only state accessors. Tool
catalogs are treated as integration-global (not user-scoped), matching
the stateless `/mcp` endpoint design.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>