### PR TITLE
Require explicit datastore config and warn for SQLite

### DIFF
--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -204,11 +204,15 @@ func validateConfig(configFlag string) error {
 		return fmt.Errorf("config invalid: %v", err)
 	}
 
-	if err := bootstrap.Validate(context.Background(), cfg, buildFactories(cfg.ProviderDirs, cfg.Server.DevMode)); err != nil {
+	warnings, err := bootstrap.Validate(context.Background(), cfg, buildFactories(cfg.ProviderDirs, cfg.Server.DevMode))
+	if err != nil {
 		return fmt.Errorf("config invalid: %v", err)
 	}
 
 	logConfigSummary(path, cfg)
+	for _, w := range warnings {
+		log.Printf("WARNING: %s", w)
+	}
 	log.Printf("config ok")
 	return nil
 }

--- a/deploy/helm/gestalt/values.yaml
+++ b/deploy/helm/gestalt/values.yaml
@@ -1,4 +1,4 @@
-# SQLite defaults are for a single replica with persistent storage.
+# These example values use SQLite with a single replica.
 # Switch to Postgres or MySQL before scaling horizontally.
 replicaCount: 1
 

--- a/docs/pages/deploy/index.mdx
+++ b/docs/pages/deploy/index.mdx
@@ -74,7 +74,7 @@ datastore:
 gestaltd validate --config your-config.yaml
 ```
 
-`gestaltd` warns at startup when the SQLite datastore path looks risky, such as relative paths or temporary directories.
+`gestaltd validate` warns when SQLite is configured as the datastore, since it is not recommended for production.
 
 ## Choose a platform
 

--- a/docs/pages/deploy/kubernetes.mdx
+++ b/docs/pages/deploy/kubernetes.mdx
@@ -16,7 +16,7 @@ The repository ships a Helm chart at `deploy/helm/gestalt`.
 | PVC | Persistent volume for SQLite when persistence is enabled. |
 
 <Callout>
-  Default chart values assume SQLite and a single replica. Switch to Postgres or MySQL before scaling horizontally.
+  The example chart values use SQLite with a single replica. Switch to Postgres or MySQL before scaling horizontally.
 </Callout>
 
 ## Minimal values

--- a/docs/pages/reference/built-in-plugins.mdx
+++ b/docs/pages/reference/built-in-plugins.mdx
@@ -13,7 +13,7 @@ The Gestalt binary registers all plugins at startup. Bootstrap builds one shared
 
 | Name | Notes |
 |---|---|
-| `sqlite` | File-based. Default for local development and single-instance deployments. |
+| `sqlite` | File-based. Suitable for local development and single-instance deployments. Not recommended for production. |
 | `postgres` | Recommended for production and multi-instance deployments. |
 | `mysql` | Alternative SQL backend using the shared sqlstore layer. |
 | `dynamodb` | AWS DynamoDB. Configurable table name, region, and optional custom endpoint. |

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -28,7 +28,7 @@ gestaltd validate --config config.yaml
 
 Prints: config file path, server settings, auth provider, datastore, secrets provider, integration count and details, runtime count, binding count. Exits with "config ok" if valid.
 
-`gestaltd` prints datastore warnings at startup. SQLite triggers warnings for relative paths or temporary directory storage.
+`gestaltd` prints datastore warnings at startup and during `validate`. SQLite always triggers a warning since it is not recommended for production.
 
 ### Config file resolution
 

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -61,7 +61,7 @@ datastore:
 
 | Provider | Config | Notes |
 |---|---|---|
-| `sqlite` | `path: ./gestalt.db` | Default. Single-instance only. `gestaltd` warns for relative paths or temporary directory storage. |
+| `sqlite` | `path: ./gestalt.db` | Not recommended for production. |
 | `postgres` | `dsn: postgres://...` | Recommended for production. |
 | `mysql` | `dsn: user:pass@tcp(host:3306)/gestalt` | Alternative SQL backend. |
 | `dynamodb` | `table`, `region`, optional `endpoint` | AWS DynamoDB. |

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -135,7 +135,7 @@ func TestBootstrap(t *testing.T) {
 func TestValidate(t *testing.T) {
 	t.Parallel()
 
-	if err := bootstrap.Validate(context.Background(), validConfig(), validFactories()); err != nil {
+	if _, err := bootstrap.Validate(context.Background(), validConfig(), validFactories()); err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
 }
@@ -156,7 +156,7 @@ func TestValidateStopsConstructedRuntimes(t *testing.T) {
 		return nil
 	})
 
-	if err := bootstrap.Validate(context.Background(), cfg, factories); err != nil {
+	if _, err := bootstrap.Validate(context.Background(), cfg, factories); err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
 	if !stopped {
@@ -386,7 +386,7 @@ func TestValidateProviderErrorFails(t *testing.T) {
 		return nil, fmt.Errorf("provider broke")
 	}
 
-	err := bootstrap.Validate(ctx, cfg, factories)
+	_, err := bootstrap.Validate(ctx, cfg, factories)
 	if err == nil {
 		t.Fatal("expected Validate to fail when a provider fails")
 	}

--- a/internal/bootstrap/validate.go
+++ b/internal/bootstrap/validate.go
@@ -18,15 +18,15 @@ import (
 // Validate loads daemon dependencies and integration factories without
 // starting the server or running migrations. Unlike Bootstrap, provider
 // validation is strict: any provider construction failure is returned.
-func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) error {
+func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) ([]string, error) {
 	sm, err := buildSecretManager(cfg, factories)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer closeSecretManager(sm)
 
 	if err := resolveSecretRefs(ctx, cfg, sm); err != nil {
-		return err
+		return nil, err
 	}
 
 	deps := Deps{
@@ -36,18 +36,23 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 	}
 
 	if _, err := buildAuth(cfg, factories, deps); err != nil {
-		return err
+		return nil, err
 	}
 
 	ds, err := buildDatastore(cfg, factories, deps)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer func() { _ = ds.Close() }()
 
+	var warnings []string
+	if w, ok := ds.(interface{ Warnings() []string }); ok {
+		warnings = w.Warnings()
+	}
+
 	providers, err := buildProvidersStrict(ctx, cfg, factories, deps)
 	if err != nil {
-		return err
+		return warnings, err
 	}
 	defer func() { _ = CloseProviders(providers) }()
 
@@ -56,7 +61,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 
 	runtimes, err := buildRuntimes(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit)
 	if err != nil {
-		return err
+		return warnings, err
 	}
 	// Validation does not start runtimes, but factories may still allocate
 	// resources that need to be released after construction.
@@ -66,13 +71,13 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 
 	bindings, err := buildBindings(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit)
 	if err != nil {
-		return err
+		return warnings, err
 	}
 	if bindings != nil {
 		defer func() { _ = CloseBindings(bindings, bindings.List()) }()
 	}
 
-	return nil
+	return warnings, nil
 }
 
 func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.PluginMap[core.Provider], error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -194,9 +194,6 @@ func applyDefaults(cfg *Config) {
 	if cfg.Server.Port == 0 {
 		cfg.Server.Port = 8080
 	}
-	if cfg.Datastore.Provider == "" {
-		cfg.Datastore.Provider = "sqlite"
-	}
 	if cfg.Secrets.Provider == "" {
 		cfg.Secrets.Provider = "env"
 	}
@@ -298,6 +295,9 @@ func resolveBaseURL(cfg *Config) {
 func validate(cfg *Config) error {
 	if cfg.Auth.Provider == "" {
 		return fmt.Errorf("config validation: auth.provider is required")
+	}
+	if cfg.Datastore.Provider == "" {
+		return fmt.Errorf("config validation: datastore.provider is required")
 	}
 	if !cfg.Server.DevMode && cfg.Server.EncryptionKey == "" {
 		return fmt.Errorf("config validation: server.encryption_key is required (set server.dev_mode to true to skip)")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -88,6 +88,8 @@ func TestDefaults(t *testing.T) {
 	yaml := `
 auth:
   provider: google
+datastore:
+  provider: sqlite
 server:
   encryption_key: key123
 `
@@ -99,9 +101,6 @@ server:
 
 	if cfg.Server.Port != 8080 {
 		t.Errorf("Server.Port default: got %d, want 8080", cfg.Server.Port)
-	}
-	if cfg.Datastore.Provider != "sqlite" {
-		t.Errorf("Datastore.Provider default: got %q, want %q", cfg.Datastore.Provider, "sqlite")
 	}
 }
 
@@ -120,6 +119,8 @@ auth:
   provider: google
   config:
     client_id: ${GESTALT_TEST_CLIENT_ID}
+datastore:
+  provider: sqlite
 server:
   encryption_key: ${GESTALT_TEST_ENC_KEY}
 `
@@ -146,6 +147,8 @@ func TestEnvVarUnsetResolvesToEmpty(t *testing.T) {
 	yaml := `
 auth:
   provider: google
+datastore:
+  provider: sqlite
 server:
   dev_mode: true
   encryption_key: ${GESTALT_TEST_NONEXISTENT}
@@ -171,17 +174,22 @@ func TestValidation(t *testing.T) {
 	}{
 		{
 			name:    "missing auth provider",
-			yaml:    "server:\n  encryption_key: key123\n",
+			yaml:    "datastore:\n  provider: sqlite\nserver:\n  encryption_key: key123\n",
+			wantErr: true,
+		},
+		{
+			name:    "missing datastore provider",
+			yaml:    "auth:\n  provider: google\nserver:\n  encryption_key: key123\n",
 			wantErr: true,
 		},
 		{
 			name:    "missing encryption key",
-			yaml:    "auth:\n  provider: google\nserver:\n  port: 8080\n",
+			yaml:    "auth:\n  provider: google\ndatastore:\n  provider: sqlite\nserver:\n  port: 8080\n",
 			wantErr: true,
 		},
 		{
 			name:    "dev mode skips encryption key",
-			yaml:    "auth:\n  provider: google\nserver:\n  dev_mode: true\n",
+			yaml:    "auth:\n  provider: google\ndatastore:\n  provider: sqlite\nserver:\n  dev_mode: true\n",
 			wantErr: false,
 		},
 	}
@@ -260,6 +268,8 @@ func TestLoadRejectsUnknownFields(t *testing.T) {
 			yaml: `
 auth:
   provider: google
+datastore:
+  provider: sqlite
 server:
   encryption_key: key123
 mcp:
@@ -336,6 +346,8 @@ func TestAllowedOperationsListForm(t *testing.T) {
 	yaml := `
 auth:
   provider: google
+datastore:
+  provider: sqlite
 server:
   encryption_key: key123
 integrations:
@@ -371,6 +383,8 @@ func TestAllowedOperationsMapForm(t *testing.T) {
 	yaml := `
 auth:
   provider: google
+datastore:
+  provider: sqlite
 server:
   encryption_key: key123
 integrations:
@@ -406,6 +420,8 @@ func TestAllowedOperationsOmitted(t *testing.T) {
 	yaml := `
 auth:
   provider: google
+datastore:
+  provider: sqlite
 server:
   encryption_key: key123
 integrations:
@@ -436,6 +452,8 @@ auth:
     client_id: cid
     client_secret: csec
     allowed_domain: example.com
+datastore:
+  provider: sqlite
 server:
   encryption_key: key123
 `

--- a/plugins/datastore/sqlite/sqlite.go
+++ b/plugins/datastore/sqlite/sqlite.go
@@ -43,7 +43,6 @@ func (dialect) IsDuplicateKeyError(error) bool { return false }
 // Store embeds sqlstore.Store and adds SQLite-specific behavior.
 type Store struct {
 	*sqlstore.Store
-	path string
 }
 
 var _ core.Datastore = (*Store)(nil)
@@ -62,7 +61,7 @@ func New(dbPath string, encryptionKey []byte) (*Store, error) {
 		return nil, fmt.Errorf("creating encryptor: %w", err)
 	}
 
-	return &Store{Store: sqlstore.New(db, enc, dialect{}), path: dbPath}, nil
+	return &Store{Store: sqlstore.New(db, enc, dialect{})}, nil
 }
 
 func (s *Store) Migrate(ctx context.Context) error {

--- a/plugins/datastore/sqlite/warnings.go
+++ b/plugins/datastore/sqlite/warnings.go
@@ -1,39 +1,7 @@
 package sqlite
 
-import (
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-)
-
 func (s *Store) Warnings() []string {
-	if isTempPath(s.path) {
-		return []string{fmt.Sprintf(
-			"sqlite datastore path %q uses temporary storage; data will be lost on restart. Use a mounted persistent volume or switch to a shared datastore such as postgres.",
-			s.path,
-		)}
+	return []string{
+		"using SQLite for the datastore; this is not recommended for production. See https://gestalt.run/deploy for alternatives.",
 	}
-	if !filepath.IsAbs(s.path) {
-		return []string{fmt.Sprintf(
-			"sqlite datastore path %q uses local filesystem storage; in a container this path is ephemeral. Use an absolute path on a mounted persistent volume or switch to a shared datastore such as postgres.",
-			s.path,
-		)}
-	}
-	return nil
-}
-
-func isTempPath(path string) bool {
-	clean := filepath.Clean(path)
-	tempPrefixes := []string{
-		"/tmp",
-		"/var/tmp",
-		filepath.Clean(os.TempDir()),
-	}
-	for _, prefix := range tempPrefixes {
-		if clean == prefix || strings.HasPrefix(clean, prefix+string(filepath.Separator)) {
-			return true
-		}
-	}
-	return false
 }

--- a/plugins/datastore/sqlite/warnings_test.go
+++ b/plugins/datastore/sqlite/warnings_test.go
@@ -1,61 +1,19 @@
 package sqlite
 
 import (
-	"fmt"
+	"strings"
 	"testing"
 )
 
 func TestWarnings(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name string
-		path string
-		want string
-	}{
-		{
-			name: "relative path",
-			path: "./gestalt.db",
-			want: `sqlite datastore path "./gestalt.db" uses local filesystem storage; in a container this path is ephemeral. Use an absolute path on a mounted persistent volume or switch to a shared datastore such as postgres.`,
-		},
-		{
-			name: "temp path",
-			path: "/tmp/gestalt.db",
-			want: `sqlite datastore path "/tmp/gestalt.db" uses temporary storage; data will be lost on restart. Use a mounted persistent volume or switch to a shared datastore such as postgres.`,
-		},
-		{
-			name: "var tmp",
-			path: "/var/tmp/gestalt.db",
-			want: `sqlite datastore path "/var/tmp/gestalt.db" uses temporary storage; data will be lost on restart. Use a mounted persistent volume or switch to a shared datastore such as postgres.`,
-		},
-		{
-			name: "mounted absolute path",
-			path: "/data/gestalt.db",
-		},
+	s := &Store{}
+	warnings := s.Warnings()
+	if len(warnings) != 1 {
+		t.Fatalf("got %d warnings, want 1", len(warnings))
 	}
-
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			s := &Store{path: tc.path}
-			warnings := s.Warnings()
-
-			if tc.want == "" {
-				if len(warnings) != 0 {
-					t.Fatalf("got %v, want none", warnings)
-				}
-				return
-			}
-			if len(warnings) != 1 {
-				t.Fatalf("got %d warnings, want 1", len(warnings))
-			}
-			if warnings[0] != tc.want {
-				fmt.Println("got: ", warnings[0])
-				fmt.Println("want:", tc.want)
-				t.Fatal("warning mismatch")
-			}
-		})
+	if !strings.Contains(warnings[0], "not recommended for production") {
+		t.Fatalf("unexpected warning: %s", warnings[0])
 	}
 }


### PR DESCRIPTION
SQLite was silently used as the default when no datastore was
configured, which caused data loss in containerized deployments where
the filesystem is ephemeral. The datastore provider is now a required
config field, so misconfiguration is caught at startup rather than
discovered after data disappears. When SQLite is explicitly chosen, a
warning is printed at startup and during `gestaltd validate` since it
is not recommended for production use.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>