### PR TITLE
Replace auth_type with auth_types in integrations API

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -62,7 +62,6 @@ type integrationInfo struct {
 	Description      string                         `json:"description,omitempty"`
 	IconSVG          string                         `json:"icon_svg,omitempty"`
 	Connected        bool                           `json:"connected"`
-	AuthType         string                         `json:"auth_type"`
 	AuthTypes        []string                       `json:"auth_types"`
 	ConnectionParams map[string]connectionParamInfo `json:"connection_params,omitempty"`
 }
@@ -101,7 +100,6 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 			DisplayName: prov.DisplayName(),
 			Description: prov.Description(),
 			Connected:   connected[name],
-			AuthType:    authTypes[0],
 			AuthTypes:   authTypes,
 		}
 		if cp, ok := prov.(core.CatalogProvider); ok {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -345,7 +345,7 @@ func TestListIntegrationsShowsConnected(t *testing.T) {
 	}
 }
 
-func TestListIntegrations_AuthType(t *testing.T) {
+func TestListIntegrations_AuthTypes(t *testing.T) {
 	t.Parallel()
 
 	oauthStub := &coretesting.StubIntegration{N: "oauth-svc", DN: "OAuth Service"}
@@ -376,8 +376,8 @@ func TestListIntegrations_AuthType(t *testing.T) {
 	}
 
 	var integrations []struct {
-		Name     string `json:"name"`
-		AuthType string `json:"auth_type"`
+		Name      string   `json:"name"`
+		AuthTypes []string `json:"auth_types"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
 		t.Fatalf("decoding: %v", err)
@@ -386,15 +386,15 @@ func TestListIntegrations_AuthType(t *testing.T) {
 		t.Fatalf("expected 2 integrations, got %d", len(integrations))
 	}
 
-	authTypes := make(map[string]string)
+	authTypes := make(map[string][]string)
 	for _, i := range integrations {
-		authTypes[i.Name] = i.AuthType
+		authTypes[i.Name] = i.AuthTypes
 	}
-	if authTypes["manual-svc"] != "manual" {
-		t.Fatalf("expected manual-svc auth_type=manual, got %q", authTypes["manual-svc"])
+	if len(authTypes["manual-svc"]) != 1 || authTypes["manual-svc"][0] != "manual" {
+		t.Fatalf("expected manual-svc auth_types=[manual], got %v", authTypes["manual-svc"])
 	}
-	if authTypes["oauth-svc"] != "oauth" {
-		t.Fatalf("expected oauth-svc auth_type=oauth, got %q", authTypes["oauth-svc"])
+	if len(authTypes["oauth-svc"]) != 1 || authTypes["oauth-svc"][0] != "oauth" {
+		t.Fatalf("expected oauth-svc auth_types=[oauth], got %v", authTypes["oauth-svc"])
 	}
 }
 

--- a/web/e2e/integrations.spec.ts
+++ b/web/e2e/integrations.spec.ts
@@ -6,7 +6,7 @@ const OAUTH_INTEGRATION: Integration = {
 };
 
 const MANUAL_INTEGRATION: Integration = {
-  name: "manual-svc", display_name: "Manual Service", description: "Example manual integration", auth_type: "manual",
+  name: "manual-svc", display_name: "Manual Service", description: "Example manual integration", auth_types: ["manual"],
 };
 
 const sampleIntegrations: Integration[] = [

--- a/web/src/components/IntegrationCard.tsx
+++ b/web/src/components/IntegrationCard.tsx
@@ -74,7 +74,7 @@ export default function IntegrationCard({
   const safeIconSVG = integration.icon_svg
     ? sanitizeSVG(integration.icon_svg)
     : "";
-  const authTypes = integration.auth_types ?? [integration.auth_type ?? "oauth"];
+  const authTypes = integration.auth_types ?? ["oauth"];
   const supportsOAuth = authTypes.includes("oauth");
   const supportsManual = authTypes.includes("manual");
   const isDualAuth = supportsOAuth && supportsManual;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -13,7 +13,6 @@ export interface Integration {
   description?: string;
   icon_svg?: string;
   connected?: boolean;
-  auth_type?: "oauth" | "manual";
   auth_types?: ("oauth" | "manual")[];
   connection_params?: Record<string, ConnectionParamDef>;
 }


### PR DESCRIPTION
The integrations list endpoint previously returned both `auth_type`
(string) and `auth_types` (array) for backward compatibility after
adding dual-auth support. This removes the redundant `auth_type` field
and keeps only `auth_types`, which is an array of supported auth methods
(e.g. `["oauth"]`, `["manual"]`, or `["oauth", "manual"]`).

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>