### PR TITLE
Support multi-instance connections per integration

### DIFF
--- a/core/datastore.go
+++ b/core/datastore.go
@@ -10,6 +10,7 @@ type Datastore interface {
 	StoreToken(ctx context.Context, token *IntegrationToken) error
 	Token(ctx context.Context, userID, integration, instance string) (*IntegrationToken, error)
 	ListTokens(ctx context.Context, userID string) ([]*IntegrationToken, error)
+	ListTokensForIntegration(ctx context.Context, userID, integration string) ([]*IntegrationToken, error)
 	DeleteToken(ctx context.Context, id string) error
 
 	StoreAPIToken(ctx context.Context, token *APIToken) error

--- a/core/testing/stubs.go
+++ b/core/testing/stubs.go
@@ -2,6 +2,7 @@ package coretesting
 
 import (
 	"context"
+	"errors"
 
 	"github.com/valon-technologies/gestalt/core"
 )
@@ -19,15 +20,16 @@ func (s *StubSecretManager) GetSecret(_ context.Context, name string) (string, e
 
 // Set Fn fields to override individual methods; nil fields return zero values.
 type StubDatastore struct {
-	PingFn             func(context.Context) error
-	GetUserFn          func(context.Context, string) (*core.User, error)
-	FindOrCreateUserFn func(context.Context, string) (*core.User, error)
-	StoreTokenFn       func(context.Context, *core.IntegrationToken) error
-	TokenFn            func(context.Context, string, string, string) (*core.IntegrationToken, error)
-	ListTokensFn       func(context.Context, string) ([]*core.IntegrationToken, error)
-	DeleteTokenFn      func(context.Context, string) error
-	ValidateAPITokenFn func(context.Context, string) (*core.APIToken, error)
-	RevokeAPITokenFn   func(context.Context, string, string) error
+	PingFn                     func(context.Context) error
+	GetUserFn                  func(context.Context, string) (*core.User, error)
+	FindOrCreateUserFn         func(context.Context, string) (*core.User, error)
+	StoreTokenFn               func(context.Context, *core.IntegrationToken) error
+	TokenFn                    func(context.Context, string, string, string) (*core.IntegrationToken, error)
+	ListTokensFn               func(context.Context, string) ([]*core.IntegrationToken, error)
+	ListTokensForIntegrationFn func(context.Context, string, string) ([]*core.IntegrationToken, error)
+	DeleteTokenFn              func(context.Context, string) error
+	ValidateAPITokenFn         func(context.Context, string) (*core.APIToken, error)
+	RevokeAPITokenFn           func(context.Context, string, string) error
 }
 
 func (s *StubDatastore) Ping(ctx context.Context) error {
@@ -65,6 +67,25 @@ func (s *StubDatastore) Token(ctx context.Context, userID, integration, instance
 func (s *StubDatastore) ListTokens(ctx context.Context, userID string) ([]*core.IntegrationToken, error) {
 	if s.ListTokensFn != nil {
 		return s.ListTokensFn(ctx, userID)
+	}
+	return nil, nil
+}
+func (s *StubDatastore) ListTokensForIntegration(ctx context.Context, userID, integration string) ([]*core.IntegrationToken, error) {
+	if s.ListTokensForIntegrationFn != nil {
+		return s.ListTokensForIntegrationFn(ctx, userID, integration)
+	}
+	if s.TokenFn != nil {
+		tok, err := s.TokenFn(ctx, userID, integration, "default")
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		if tok == nil {
+			return nil, nil
+		}
+		return []*core.IntegrationToken{tok}, nil
 	}
 	return nil, nil
 }

--- a/internal/bootstrap/regression_test.go
+++ b/internal/bootstrap/regression_test.go
@@ -147,12 +147,12 @@ func TestPlatformMode_BindingsAndRuntimesWithSafetyLayer(t *testing.T) {
 		t.Fatal("expected binding deps to be scoped, not the shared invoker")
 	}
 
-	_, err = bindingDeps.Invoker.Invoke(ctx, &principal.Principal{}, "alpha", "do", nil)
+	_, err = bindingDeps.Invoker.Invoke(ctx, &principal.Principal{}, "alpha", "", "do", nil)
 	if err == nil || !strings.Contains(err.Error(), "not available in this scope") {
 		t.Fatalf("expected scoped binding invoker to reject alpha, got %v", err)
 	}
 
-	resultOp, err := bindingDeps.Invoker.Invoke(ctx, &principal.Principal{}, "beta", "do", nil)
+	resultOp, err := bindingDeps.Invoker.Invoke(ctx, &principal.Principal{}, "beta", "", "do", nil)
 	if err != nil {
 		t.Fatalf("expected scoped binding invoker to allow beta: %v", err)
 	}

--- a/internal/invocation/broker.go
+++ b/internal/invocation/broker.go
@@ -17,7 +17,7 @@ import (
 const tokenRefreshThreshold = 5 * time.Minute
 
 type Invoker interface {
-	Invoke(ctx context.Context, p *principal.Principal, providerName, operation string, params map[string]any) (*core.OperationResult, error)
+	Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error)
 }
 
 type CapabilityLister interface {
@@ -65,7 +65,7 @@ func (b *Broker) ListCapabilities() []core.Capability {
 	return caps
 }
 
-func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerName, operation string, params map[string]any) (*core.OperationResult, error) {
+func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
 	prov, err := b.providers.Get(providerName)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
@@ -90,7 +90,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		return nil, ErrNotAuthenticated
 	}
 
-	ctx, accessToken, err := b.resolveToken(ctx, prov, p, providerName)
+	ctx, accessToken, err := b.resolveToken(ctx, prov, p, providerName, instance)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	return result, nil
 }
 
-func (b *Broker) ResolveToken(ctx context.Context, p *principal.Principal, providerName string) (string, error) {
+func (b *Broker) ResolveToken(ctx context.Context, p *principal.Principal, providerName, instance string) (string, error) {
 	prov, err := b.providers.Get(providerName)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
@@ -111,11 +111,11 @@ func (b *Broker) ResolveToken(ctx context.Context, p *principal.Principal, provi
 		}
 		return "", fmt.Errorf("%w: looking up provider: %v", ErrInternal, err)
 	}
-	_, tok, resolveErr := b.resolveToken(ctx, prov, p, providerName)
+	_, tok, resolveErr := b.resolveToken(ctx, prov, p, providerName, instance)
 	return tok, resolveErr
 }
 
-func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *principal.Principal, providerName string) (context.Context, string, error) {
+func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *principal.Principal, providerName, instance string) (context.Context, string, error) {
 	mode := prov.ConnectionMode()
 	switch mode {
 	case core.ConnectionModeNone:
@@ -135,36 +135,63 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 			}
 			p.UserID = dbUser.ID
 		}
-		return b.resolveUserToken(ctx, prov, p.UserID, providerName)
+		return b.resolveUserToken(ctx, prov, p.UserID, providerName, instance)
 
 	case core.ConnectionModeIdentity:
-		return b.resolveUserToken(ctx, prov, principal.IdentityPrincipal, providerName)
+		return b.resolveUserToken(ctx, prov, principal.IdentityPrincipal, providerName, instance)
 
 	case core.ConnectionModeEither:
 		if p.UserID != "" {
-			enrichedCtx, tok, err := b.resolveUserToken(ctx, prov, p.UserID, providerName)
+			enrichedCtx, tok, err := b.resolveUserToken(ctx, prov, p.UserID, providerName, instance)
 			if err == nil {
 				return enrichedCtx, tok, nil
+			}
+			if errors.Is(err, ErrAmbiguousInstance) {
+				return ctx, "", err
 			}
 			if !errors.Is(err, ErrNoToken) {
 				return ctx, "", err
 			}
 		}
-		return b.resolveUserToken(ctx, prov, principal.IdentityPrincipal, providerName)
+		return b.resolveUserToken(ctx, prov, principal.IdentityPrincipal, providerName, instance)
 
 	default:
 		return ctx, "", fmt.Errorf("%w: unknown connection mode %q", ErrInternal, mode)
 	}
 }
 
-func (b *Broker) resolveUserToken(ctx context.Context, prov core.Provider, userID, providerName string) (context.Context, string, error) {
-	storedToken, err := b.datastore.Token(ctx, userID, providerName, "default")
-	if err != nil {
-		if errors.Is(err, core.ErrNotFound) {
-			return ctx, "", fmt.Errorf("%w: no token stored for integration %q", ErrNoToken, providerName)
+func (b *Broker) resolveUserToken(ctx context.Context, prov core.Provider, userID, providerName, instance string) (context.Context, string, error) {
+	var storedToken *core.IntegrationToken
+	var err error
+
+	if instance != "" {
+		storedToken, err = b.datastore.Token(ctx, userID, providerName, instance)
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				return ctx, "", fmt.Errorf("%w: no token stored for integration %q instance %q", ErrNoToken, providerName, instance)
+			}
+			return ctx, "", fmt.Errorf("%w: retrieving integration token: %v", ErrInternal, err)
 		}
-		return ctx, "", fmt.Errorf("%w: retrieving integration token: %v", ErrInternal, err)
+	} else {
+		tokens, listErr := b.datastore.ListTokensForIntegration(ctx, userID, providerName)
+		if listErr != nil {
+			return ctx, "", fmt.Errorf("%w: listing tokens: %v", ErrInternal, listErr)
+		}
+		switch len(tokens) {
+		case 0:
+			return ctx, "", fmt.Errorf("%w: no token stored for integration %q", ErrNoToken, providerName)
+		case 1:
+			storedToken = tokens[0]
+		default:
+			instances := make([]string, len(tokens))
+			for i, t := range tokens {
+				instances[i] = t.Instance
+			}
+			return ctx, "", fmt.Errorf("%w: integration %q has %d connections (%v); specify which instance to use",
+				ErrAmbiguousInstance, providerName, len(tokens), instances)
+		}
 	}
+
 	if storedToken == nil {
 		return ctx, "", fmt.Errorf("%w: no token stored for integration %q", ErrNoToken, providerName)
 	}

--- a/internal/invocation/broker_test.go
+++ b/internal/invocation/broker_test.go
@@ -53,7 +53,7 @@ func TestInvoke_Success(t *testing.T) {
 		Source:   principal.SourceSession,
 	}
 
-	result, err := b.Invoke(context.Background(), p, "test-int", "do_thing", nil)
+	result, err := b.Invoke(context.Background(), p, "test-int", "", "do_thing", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestInvoke_ProviderNotFound(t *testing.T) {
 		UserID:   "u1",
 	}
 
-	_, err := b.Invoke(context.Background(), p, "nonexistent", "op", nil)
+	_, err := b.Invoke(context.Background(), p, "nonexistent", "", "op", nil)
 	if !errors.Is(err, invocation.ErrProviderNotFound) {
 		t.Fatalf("expected ErrProviderNotFound, got %v", err)
 	}
@@ -96,7 +96,7 @@ func TestInvoke_OperationNotFound(t *testing.T) {
 		UserID:   "u1",
 	}
 
-	_, err := b.Invoke(context.Background(), p, "test-int", "nonexistent", nil)
+	_, err := b.Invoke(context.Background(), p, "test-int", "", "nonexistent", nil)
 	if !errors.Is(err, invocation.ErrOperationNotFound) {
 		t.Fatalf("expected ErrOperationNotFound, got %v", err)
 	}
@@ -113,7 +113,7 @@ func TestInvoke_NilPrincipal(t *testing.T) {
 	ds := &coretesting.StubDatastore{}
 	b := invocation.NewBroker(testutil.NewProviderRegistry(t, prov), ds)
 
-	_, err := b.Invoke(context.Background(), nil, "test-int", "do_thing", nil)
+	_, err := b.Invoke(context.Background(), nil, "test-int", "", "do_thing", nil)
 	if !errors.Is(err, invocation.ErrNotAuthenticated) {
 		t.Fatalf("expected ErrNotAuthenticated, got %v", err)
 	}
@@ -139,7 +139,7 @@ func TestInvoke_NoStoredToken(t *testing.T) {
 		UserID:   "u1",
 	}
 
-	_, err := b.Invoke(context.Background(), p, "test-int", "do_thing", nil)
+	_, err := b.Invoke(context.Background(), p, "test-int", "", "do_thing", nil)
 	if !errors.Is(err, invocation.ErrNoToken) {
 		t.Fatalf("expected ErrNoToken, got %v", err)
 	}
@@ -173,7 +173,7 @@ func TestInvoke_UserIDResolution(t *testing.T) {
 		Source:   principal.SourceSession,
 	}
 
-	_, err := b.Invoke(context.Background(), p, "test-int", "do_thing", nil)
+	_, err := b.Invoke(context.Background(), p, "test-int", "", "do_thing", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestInvoke_NilTokenResponse(t *testing.T) {
 		UserID:   "u1",
 	}
 
-	_, err := b.Invoke(context.Background(), p, "test-int", "do_thing", nil)
+	_, err := b.Invoke(context.Background(), p, "test-int", "", "do_thing", nil)
 	if !errors.Is(err, invocation.ErrNoToken) {
 		t.Fatalf("expected ErrNoToken, got %v", err)
 	}
@@ -240,7 +240,7 @@ func TestInvoke_MetadataJSONFlowsToContext(t *testing.T) {
 	b := invocation.NewBroker(reg, ds)
 
 	p := &principal.Principal{UserID: "u1"}
-	_, err := b.Invoke(context.Background(), p, "shopify", "list_products", nil)
+	_, err := b.Invoke(context.Background(), p, "shopify", "", "list_products", nil)
 	if err != nil {
 		t.Fatalf("Invoke: %v", err)
 	}

--- a/internal/invocation/connection_modes_test.go
+++ b/internal/invocation/connection_modes_test.go
@@ -45,7 +45,7 @@ func TestInvoke_ConnectionModeIdentity(t *testing.T) {
 	}
 
 	b := newConnectionModeBroker(t, connectionModeProvider("svc", core.ConnectionModeIdentity), ds)
-	result, err := b.Invoke(context.Background(), &principal.Principal{}, "svc", "do", nil)
+	result, err := b.Invoke(context.Background(), &principal.Principal{}, "svc", "", "do", nil)
 	if err != nil {
 		t.Fatalf("Invoke: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestInvoke_ConnectionModeIdentity_NoToken(t *testing.T) {
 	}
 
 	b := newConnectionModeBroker(t, connectionModeProvider("svc", core.ConnectionModeIdentity), ds)
-	_, err := b.Invoke(context.Background(), &principal.Principal{}, "svc", "do", nil)
+	_, err := b.Invoke(context.Background(), &principal.Principal{}, "svc", "", "do", nil)
 	if !errors.Is(err, invocation.ErrNoToken) {
 		t.Fatalf("expected ErrNoToken, got %v", err)
 	}
@@ -87,7 +87,7 @@ func TestInvoke_ConnectionModeEither_PrefersUser(t *testing.T) {
 	}
 
 	b := newConnectionModeBroker(t, connectionModeProvider("svc", core.ConnectionModeEither), ds)
-	result, err := b.Invoke(context.Background(), &principal.Principal{UserID: "user-1"}, "svc", "do", nil)
+	result, err := b.Invoke(context.Background(), &principal.Principal{UserID: "user-1"}, "svc", "", "do", nil)
 	if err != nil {
 		t.Fatalf("Invoke: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestInvoke_ConnectionModeEither_FallsBackToIdentity(t *testing.T) {
 	}
 
 	b := newConnectionModeBroker(t, connectionModeProvider("svc", core.ConnectionModeEither), ds)
-	result, err := b.Invoke(context.Background(), &principal.Principal{UserID: "user-1"}, "svc", "do", nil)
+	result, err := b.Invoke(context.Background(), &principal.Principal{UserID: "user-1"}, "svc", "", "do", nil)
 	if err != nil {
 		t.Fatalf("Invoke: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestInvoke_ConnectionModeEither_EmptyPrincipalFallsBackToIdentity(t *testin
 	}
 
 	b := newConnectionModeBroker(t, connectionModeProvider("svc", core.ConnectionModeEither), ds)
-	result, err := b.Invoke(context.Background(), &principal.Principal{}, "svc", "do", nil)
+	result, err := b.Invoke(context.Background(), &principal.Principal{}, "svc", "", "do", nil)
 	if err != nil {
 		t.Fatalf("Invoke: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestInvoke_ConnectionModeEither_NoTokens(t *testing.T) {
 	}
 
 	b := newConnectionModeBroker(t, connectionModeProvider("svc", core.ConnectionModeEither), ds)
-	_, err := b.Invoke(context.Background(), &principal.Principal{UserID: "user-1"}, "svc", "do", nil)
+	_, err := b.Invoke(context.Background(), &principal.Principal{UserID: "user-1"}, "svc", "", "do", nil)
 	if !errors.Is(err, invocation.ErrNoToken) {
 		t.Fatalf("expected ErrNoToken, got %v", err)
 	}
@@ -169,7 +169,7 @@ func TestInvoke_ConnectionModeEither_InfraErrorNotSwallowed(t *testing.T) {
 	}
 
 	b := newConnectionModeBroker(t, connectionModeProvider("alpha", core.ConnectionModeEither), ds)
-	_, err := b.Invoke(context.Background(), &principal.Principal{UserID: "user-1"}, "alpha", "do", nil)
+	_, err := b.Invoke(context.Background(), &principal.Principal{UserID: "user-1"}, "alpha", "", "do", nil)
 	if err == nil {
 		t.Fatal("expected infrastructure error")
 	}

--- a/internal/invocation/errors.go
+++ b/internal/invocation/errors.go
@@ -7,6 +7,7 @@ var (
 	ErrOperationNotFound = errors.New("operation not found")
 	ErrNotAuthenticated  = errors.New("not authenticated")
 	ErrNoToken           = errors.New("no integration token")
+	ErrAmbiguousInstance = errors.New("ambiguous instance")
 	ErrUserResolution    = errors.New("user resolution failed")
 	ErrInternal          = errors.New("internal error")
 )

--- a/internal/invocation/guarded.go
+++ b/internal/invocation/guarded.go
@@ -68,7 +68,7 @@ func NewGuarded(inner Invoker, lister CapabilityLister, source string, audit cor
 	return guarded
 }
 
-func (g *GuardedInvoker) Invoke(ctx context.Context, p *principal.Principal, providerName, operation string, params map[string]any) (*core.OperationResult, error) {
+func (g *GuardedInvoker) Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
 	ctx, meta := ensureMeta(ctx)
 
 	if p == nil {
@@ -90,7 +90,7 @@ func (g *GuardedInvoker) Invoke(ctx context.Context, p *principal.Principal, pro
 		entry.UserID = p.UserID
 	}
 
-	if err := g.check(meta, providerName, operation); err != nil {
+	if err := g.check(meta, providerName, instance, operation); err != nil {
 		entry.Allowed = false
 		entry.Error = err.Error()
 		g.logAudit(entry)
@@ -100,7 +100,11 @@ func (g *GuardedInvoker) Invoke(ctx context.Context, p *principal.Principal, pro
 	entry.Allowed = true
 	g.logAudit(entry)
 
-	chainKey := providerName + "/" + operation
+	chainInstance := instance
+	if chainInstance == "" {
+		chainInstance = "default"
+	}
+	chainKey := providerName + "/" + chainInstance + "/" + operation
 	next := &InvocationMeta{
 		RequestID: meta.RequestID,
 		Depth:     meta.Depth + 1,
@@ -108,7 +112,7 @@ func (g *GuardedInvoker) Invoke(ctx context.Context, p *principal.Principal, pro
 	}
 	ctx = ContextWithMeta(ctx, next)
 
-	return g.inner.Invoke(ctx, p, providerName, operation, params)
+	return g.inner.Invoke(ctx, p, providerName, instance, operation, params)
 }
 
 func (g *GuardedInvoker) ListCapabilities() []core.Capability {
@@ -130,12 +134,16 @@ func (g *GuardedInvoker) ListCapabilities() []core.Capability {
 	return filtered
 }
 
-func (g *GuardedInvoker) check(meta *InvocationMeta, providerName, operation string) error {
+func (g *GuardedInvoker) check(meta *InvocationMeta, providerName, instance, operation string) error {
 	if meta.Depth >= g.maxDepth {
 		return &MaxDepthError{Depth: meta.Depth, Max: g.maxDepth}
 	}
 
-	chainKey := providerName + "/" + operation
+	checkInstance := instance
+	if checkInstance == "" {
+		checkInstance = "default"
+	}
+	chainKey := providerName + "/" + checkInstance + "/" + operation
 	for _, entry := range meta.CallChain {
 		if entry == chainKey {
 			return &RecursionError{Provider: providerName, Operation: operation}

--- a/internal/invocation/guarded_test.go
+++ b/internal/invocation/guarded_test.go
@@ -45,7 +45,7 @@ func TestGuardedInvoker_AllowedProvider(t *testing.T) {
 	base := newGuardedTestInvoker(t, guardTestProvider("alpha"))
 	guarded := invocation.NewGuarded(base, base, "test", &capturingSink{}, invocation.WithAllowedProviders([]string{"alpha"}), invocation.WithoutRateLimit())
 
-	result, err := guarded.Invoke(context.Background(), nil, "alpha", "ping", nil)
+	result, err := guarded.Invoke(context.Background(), nil, "alpha", "", "ping", nil)
 	if err != nil {
 		t.Fatalf("Invoke: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestGuardedInvoker_DisallowedProvider(t *testing.T) {
 	base := newGuardedTestInvoker(t, guardTestProvider("alpha"))
 	guarded := invocation.NewGuarded(base, base, "test", &capturingSink{}, invocation.WithAllowedProviders([]string{"beta"}), invocation.WithoutRateLimit())
 
-	_, err := guarded.Invoke(context.Background(), nil, "alpha", "ping", nil)
+	_, err := guarded.Invoke(context.Background(), nil, "alpha", "", "ping", nil)
 	if err == nil {
 		t.Fatal("expected error for disallowed provider")
 	}
@@ -76,7 +76,7 @@ func TestGuardedInvoker_NoAllowlist(t *testing.T) {
 	guarded := invocation.NewGuarded(base, base, "test", &capturingSink{}, invocation.WithoutRateLimit())
 
 	for _, provider := range []string{"alpha", "beta"} {
-		result, err := guarded.Invoke(context.Background(), nil, provider, "ping", nil)
+		result, err := guarded.Invoke(context.Background(), nil, provider, "", "ping", nil)
 		if err != nil {
 			t.Fatalf("Invoke %s: %v", provider, err)
 		}
@@ -93,7 +93,7 @@ func TestGuardedInvoker_MaxDepthEnforced(t *testing.T) {
 	guarded := invocation.NewGuarded(base, base, "test", &capturingSink{}, invocation.WithMaxDepth(2), invocation.WithoutRateLimit())
 
 	ctx := invocation.ContextWithMeta(context.Background(), &invocation.InvocationMeta{RequestID: "test-id", Depth: 2})
-	_, err := guarded.Invoke(ctx, nil, "alpha", "ping", nil)
+	_, err := guarded.Invoke(ctx, nil, "alpha", "", "ping", nil)
 	if err == nil {
 		t.Fatal("expected max depth error")
 	}
@@ -115,9 +115,9 @@ func TestGuardedInvoker_RecursionDetected(t *testing.T) {
 	ctx := invocation.ContextWithMeta(context.Background(), &invocation.InvocationMeta{
 		RequestID: "test-id",
 		Depth:     1,
-		CallChain: []string{"alpha/ping"},
+		CallChain: []string{"alpha/default/ping"},
 	})
-	_, err := guarded.Invoke(ctx, nil, "alpha", "ping", nil)
+	_, err := guarded.Invoke(ctx, nil, "alpha", "", "ping", nil)
 	if err == nil {
 		t.Fatal("expected recursion error")
 	}
@@ -133,13 +133,13 @@ func TestGuardedInvoker_RateLimitExceeded(t *testing.T) {
 	base := newGuardedTestInvoker(t, guardTestProvider("alpha"))
 	guarded := invocation.NewGuarded(base, base, "test", &capturingSink{}, invocation.WithRateLimit(1, 1))
 
-	if _, err := guarded.Invoke(context.Background(), nil, "alpha", "ping", nil); err != nil {
+	if _, err := guarded.Invoke(context.Background(), nil, "alpha", "", "ping", nil); err != nil {
 		t.Fatalf("first Invoke: %v", err)
 	}
 
 	var rateLimited bool
 	for i := 0; i < 10; i++ {
-		if _, err := guarded.Invoke(context.Background(), nil, "alpha", "ping", nil); err != nil {
+		if _, err := guarded.Invoke(context.Background(), nil, "alpha", "", "ping", nil); err != nil {
 			var rateLimitErr *invocation.RateLimitError
 			if errors.As(err, &rateLimitErr) {
 				rateLimited = true
@@ -160,7 +160,7 @@ func TestGuardedInvoker_AuditLogged(t *testing.T) {
 	base := newGuardedTestInvoker(t, guardTestProvider("alpha"))
 	guarded := invocation.NewGuarded(base, base, "binding:my-hook", sink, invocation.WithAllowedProviders([]string{"alpha"}), invocation.WithoutRateLimit())
 
-	_, _ = guarded.Invoke(context.Background(), nil, "alpha", "ping", nil)
+	_, _ = guarded.Invoke(context.Background(), nil, "alpha", "", "ping", nil)
 	if len(sink.entries) != 1 {
 		t.Fatalf("expected 1 audit entry, got %d", len(sink.entries))
 	}
@@ -181,7 +181,7 @@ func TestGuardedInvoker_AuditLogged(t *testing.T) {
 		t.Error("expected non-empty RequestID")
 	}
 
-	_, _ = guarded.Invoke(context.Background(), nil, "beta", "ping", nil)
+	_, _ = guarded.Invoke(context.Background(), nil, "beta", "", "ping", nil)
 	if len(sink.entries) != 2 {
 		t.Fatalf("expected 2 audit entries, got %d", len(sink.entries))
 	}

--- a/internal/mcp/binding.go
+++ b/internal/mcp/binding.go
@@ -24,7 +24,7 @@ const (
 )
 
 type TokenResolver interface {
-	ResolveToken(ctx context.Context, p *principal.Principal, providerName string) (string, error)
+	ResolveToken(ctx context.Context, p *principal.Principal, providerName, instance string) (string, error)
 }
 
 type directToolCaller interface {
@@ -122,7 +122,7 @@ func tryInitDeferred(ctx context.Context, srv *mcpserver.MCPServer, cfg Config, 
 		if !d.upstream.IsDeferred() {
 			continue
 		}
-		token, err := cfg.TokenResolver.ResolveToken(ctx, p, d.provName)
+		token, err := cfg.TokenResolver.ResolveToken(ctx, p, d.provName, "")
 		if err != nil {
 			continue
 		}
@@ -222,7 +222,11 @@ func makeHandler(invoker invocation.Invoker, provName, opName string) mcpserver.
 			return mcpgo.NewToolResultError("not authenticated"), nil
 		}
 
-		result, err := invoker.Invoke(ctx, p, provName, opName, req.GetArguments())
+		args := req.GetArguments()
+		instance, _ := args["_instance"].(string)
+		delete(args, "_instance")
+
+		result, err := invoker.Invoke(ctx, p, provName, instance, opName, args)
 		if err != nil {
 			return mcpgo.NewToolResultError(err.Error()), nil
 		}
@@ -242,13 +246,17 @@ func makeDirectHandler(cfg Config, provName, opName string, caller directToolCal
 			return mcpgo.NewToolResultError("not authenticated"), nil
 		}
 
-		token, err := cfg.TokenResolver.ResolveToken(ctx, p, provName)
+		args := req.GetArguments()
+		instance, _ := args["_instance"].(string)
+		delete(args, "_instance")
+
+		token, err := cfg.TokenResolver.ResolveToken(ctx, p, provName, instance)
 		if err != nil {
 			return mcpgo.NewToolResultError(err.Error()), nil
 		}
 
 		ctx = mcpupstream.WithUpstreamToken(ctx, token)
-		return caller.CallTool(ctx, opName, req.GetArguments())
+		return caller.CallTool(ctx, opName, args)
 	}
 }
 

--- a/internal/mcp/binding_test.go
+++ b/internal/mcp/binding_test.go
@@ -265,7 +265,7 @@ func TestNewServer_ToolCallUsesInjectedInvoker(t *testing.T) {
 	providers := testutil.NewProviderRegistry(t, prov)
 	srv := gestaltmcp.NewServer(gestaltmcp.Config{
 		Invoker: &testutil.StubInvoker{
-			InvokeFn: func(_ context.Context, p *principal.Principal, providerName, operation string, params map[string]any) (*core.OperationResult, error) {
+			InvokeFn: func(_ context.Context, p *principal.Principal, providerName, _, operation string, params map[string]any) (*core.OperationResult, error) {
 				called = true
 				gotProvider = providerName
 				gotOperation = operation
@@ -504,7 +504,7 @@ type stubTokenResolver struct {
 	err   error
 }
 
-func (r *stubTokenResolver) ResolveToken(_ context.Context, _ *principal.Principal, _ string) (string, error) {
+func (r *stubTokenResolver) ResolveToken(_ context.Context, _ *principal.Principal, _, _ string) (string, error) {
 	return r.token, r.err
 }
 

--- a/internal/mcp/deferred_test.go
+++ b/internal/mcp/deferred_test.go
@@ -108,7 +108,7 @@ type principalTokenResolver struct {
 	token string
 }
 
-func (r *principalTokenResolver) ResolveToken(ctx context.Context, p *principal.Principal, _ string) (string, error) {
+func (r *principalTokenResolver) ResolveToken(ctx context.Context, p *principal.Principal, _, _ string) (string, error) {
 	if p == nil {
 		return "", nil
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -56,12 +56,17 @@ func (s *Server) readinessCheck(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
+type instanceInfo struct {
+	Name string `json:"name"`
+}
+
 type integrationInfo struct {
 	Name             string                         `json:"name"`
 	DisplayName      string                         `json:"display_name,omitempty"`
 	Description      string                         `json:"description,omitempty"`
 	IconSVG          string                         `json:"icon_svg,omitempty"`
 	Connected        bool                           `json:"connected"`
+	Instances        []instanceInfo                 `json:"instances,omitempty"`
 	AuthTypes        []string                       `json:"auth_types"`
 	ConnectionParams map[string]connectionParamInfo `json:"connection_params,omitempty"`
 }
@@ -95,11 +100,13 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		} else {
 			authTypes = []string{"oauth"}
 		}
+		instances := connected[name]
 		info := integrationInfo{
 			Name:        name,
 			DisplayName: prov.DisplayName(),
 			Description: prov.Description(),
-			Connected:   connected[name],
+			Connected:   len(instances) > 0,
+			Instances:   instances,
 			AuthTypes:   authTypes,
 		}
 		if cp, ok := prov.(core.CatalogProvider); ok {
@@ -128,7 +135,7 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, out)
 }
 
-func (s *Server) userConnectedIntegrations(r *http.Request) (map[string]bool, error) {
+func (s *Server) userConnectedIntegrations(r *http.Request) (map[string][]instanceInfo, error) {
 	user := UserFromContext(r.Context())
 	if user == nil || user.Email == "" {
 		return nil, nil
@@ -148,9 +155,9 @@ func (s *Server) userConnectedIntegrations(r *http.Request) (map[string]bool, er
 	if err != nil {
 		return nil, fmt.Errorf("listing tokens: %w", err)
 	}
-	m := make(map[string]bool, len(tokens))
+	m := make(map[string][]instanceInfo, len(tokens))
 	for _, tok := range tokens {
-		m[tok.Integration] = true
+		m[tok.Integration] = append(m[tok.Integration], instanceInfo{Name: tok.Instance})
 	}
 	return m, nil
 }
@@ -166,22 +173,38 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tokens, err := s.datastore.ListTokens(r.Context(), userID)
+	requestedInstance := r.URL.Query().Get("instance")
+
+	tokens, err := s.datastore.ListTokensForIntegration(r.Context(), userID, name)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list tokens")
 		return
 	}
 
+	if len(tokens) == 0 {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("no connection found for integration %q", name))
+		return
+	}
+
+	if requestedInstance == "" && len(tokens) > 1 {
+		instances := make([]string, len(tokens))
+		for i, t := range tokens {
+			instances[i] = t.Instance
+		}
+		writeError(w, http.StatusConflict, fmt.Sprintf("multiple connections exist for %q (%v); specify ?instance=NAME", name, instances))
+		return
+	}
+
 	var tokenID string
 	for _, tok := range tokens {
-		if tok.Integration == name {
+		if requestedInstance == "" || tok.Instance == requestedInstance {
 			tokenID = tok.ID
 			break
 		}
 	}
 
 	if tokenID == "" {
-		writeError(w, http.StatusNotFound, fmt.Sprintf("no connection found for integration %q", name))
+		writeError(w, http.StatusNotFound, fmt.Sprintf("no connection found for integration %q instance %q", name, requestedInstance))
 		return
 	}
 
@@ -284,7 +307,10 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	result, err := s.invoker.Invoke(r.Context(), p, providerName, operationName, params)
+	instance, _ := params["_instance"].(string)
+	delete(params, "_instance")
+
+	result, err := s.invoker.Invoke(r.Context(), p, providerName, instance, operationName, params)
 	if err != nil {
 		switch {
 		case errors.Is(err, invocation.ErrProviderNotFound):
@@ -295,6 +321,8 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusUnauthorized, "not authenticated")
 		case errors.Is(err, invocation.ErrNoToken):
 			writeError(w, http.StatusPreconditionFailed, fmt.Sprintf("no token stored for integration %q; connect via OAuth first", providerName))
+		case errors.Is(err, invocation.ErrAmbiguousInstance):
+			writeError(w, http.StatusConflict, err.Error())
 		case errors.Is(err, invocation.ErrUserResolution):
 			writeError(w, http.StatusInternalServerError, "failed to resolve user")
 		case errors.Is(err, invocation.ErrInternal):
@@ -414,6 +442,7 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 
 type startOAuthRequest struct {
 	Integration      string            `json:"integration"`
+	Instance         string            `json:"instance"`
 	Scopes           []string          `json:"scopes"`
 	ConnectionParams map[string]string `json:"connection_params"`
 }
@@ -447,6 +476,15 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 
 	dbUserID, ok := s.resolveUserID(w, r)
 	if !ok {
+		return
+	}
+
+	instance := req.Instance
+	if instance == "" {
+		instance = "default"
+	}
+	if !safeParamValue.MatchString(instance) {
+		writeError(w, http.StatusBadRequest, "instance name contains invalid characters")
 		return
 	}
 
@@ -492,6 +530,7 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 	state, err := s.stateCodec.Encode(integrationOAuthState{
 		UserID:           dbUserID,
 		Integration:      req.Integration,
+		Instance:         instance,
 		Verifier:         verifier,
 		ConnectionParams: connParams,
 		ExpiresAt:        s.now().Add(integrationOAuthStateTTL).Unix(),
@@ -578,11 +617,16 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		expiresAt = &t
 	}
 
+	callbackInstance := state.Instance
+	if callbackInstance == "" {
+		callbackInstance = defaultTokenInstance
+	}
+
 	tok := &core.IntegrationToken{
 		ID:           uuid.NewString(),
 		UserID:       state.UserID,
 		Integration:  providerName,
-		Instance:     defaultTokenInstance,
+		Instance:     callbackInstance,
 		AccessToken:  tokenResp.AccessToken,
 		RefreshToken: tokenResp.RefreshToken,
 		ExpiresAt:    expiresAt,
@@ -606,6 +650,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 
 type connectManualRequest struct {
 	Integration      string            `json:"integration"`
+	Instance         string            `json:"instance"`
 	Credential       string            `json:"credential"`
 	ConnectionParams map[string]string `json:"connection_params"`
 }
@@ -644,6 +689,15 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	manualInstance := req.Instance
+	if manualInstance == "" {
+		manualInstance = "default"
+	}
+	if !safeParamValue.MatchString(manualInstance) {
+		writeError(w, http.StatusBadRequest, "instance name contains invalid characters")
+		return
+	}
+
 	var connParams map[string]string
 	if cpp, ok := prov.(core.ConnectionParamProvider); ok {
 		var valErr error
@@ -658,7 +712,7 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		ID:          uuid.NewString(),
 		UserID:      dbUser.ID,
 		Integration: req.Integration,
-		Instance:    defaultTokenInstance,
+		Instance:    manualInstance,
 		AccessToken: req.Credential,
 	}
 	manualMeta, metaErr := buildConnectionMetadata(prov, connParams, nil)

--- a/internal/server/oauth_state.go
+++ b/internal/server/oauth_state.go
@@ -14,6 +14,7 @@ const integrationOAuthStateTTL = 10 * time.Minute
 type integrationOAuthState struct {
 	UserID           string            `json:"uid"`
 	Integration      string            `json:"int"`
+	Instance         string            `json:"ins,omitempty"`
 	Verifier         string            `json:"ver,omitempty"`
 	ConnectionParams map[string]string `json:"cp,omitempty"`
 	ExpiresAt        int64             `json:"exp"`

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -588,7 +588,12 @@ func TestDisconnectIntegration(t *testing.T) {
 			},
 			ListTokensFn: func(_ context.Context, _ string) ([]*core.IntegrationToken, error) {
 				return []*core.IntegrationToken{
-					{ID: "tok-1", UserID: "u1", Integration: "slack"},
+					{ID: "tok-1", UserID: "u1", Integration: "slack", Instance: "default"},
+				}, nil
+			},
+			ListTokensForIntegrationFn: func(_ context.Context, _, _ string) ([]*core.IntegrationToken, error) {
+				return []*core.IntegrationToken{
+					{ID: "tok-1", UserID: "u1", Integration: "slack", Instance: "default"},
 				}, nil
 			},
 			DeleteTokenFn: func(_ context.Context, id string) error {
@@ -760,7 +765,7 @@ func TestExecuteOperation_UsesInjectedInvoker(t *testing.T) {
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.DevMode = true
 		cfg.Invoker = &testutil.StubInvoker{
-			InvokeFn: func(_ context.Context, p *principal.Principal, providerName, operation string, params map[string]any) (*core.OperationResult, error) {
+			InvokeFn: func(_ context.Context, p *principal.Principal, providerName, _, operation string, params map[string]any) (*core.OperationResult, error) {
 				called = true
 				gotProvider = providerName
 				gotOperation = operation

--- a/internal/testutil/invoker.go
+++ b/internal/testutil/invoker.go
@@ -7,16 +7,14 @@ import (
 	"github.com/valon-technologies/gestalt/internal/principal"
 )
 
-// StubInvoker is a configurable test double for invocation.Invoker.
-// When InvokeFn is set, Invoke delegates to it; otherwise it returns nil, nil.
-// All calls record state in the exported fields for assertion.
 type StubInvoker struct {
-	InvokeFn func(ctx context.Context, p *principal.Principal, providerName, operation string, params map[string]any) (*core.OperationResult, error)
+	InvokeFn func(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error)
 
 	Invoked   bool
 	LastCtx   context.Context
 	LastP     *principal.Principal
 	Provider  string
+	Instance  string
 	Operation string
 	Params    map[string]any
 
@@ -24,16 +22,17 @@ type StubInvoker struct {
 	Err    error
 }
 
-func (s *StubInvoker) Invoke(ctx context.Context, p *principal.Principal, providerName, operation string, params map[string]any) (*core.OperationResult, error) {
+func (s *StubInvoker) Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
 	s.Invoked = true
 	s.LastCtx = ctx
 	s.LastP = p
 	s.Provider = providerName
+	s.Instance = instance
 	s.Operation = operation
 	s.Params = params
 
 	if s.InvokeFn != nil {
-		return s.InvokeFn(ctx, p, providerName, operation, params)
+		return s.InvokeFn(ctx, p, providerName, instance, operation, params)
 	}
 	if s.Err != nil {
 		return nil, s.Err

--- a/plugins/bindings/webhook/webhook.go
+++ b/plugins/bindings/webhook/webhook.go
@@ -19,6 +19,7 @@ var _ core.Binding = (*Binding)(nil)
 type webhookConfig struct {
 	Path            string   `yaml:"path"`
 	Provider        string   `yaml:"provider"`
+	Instance        string   `yaml:"instance"`
 	Operation       string   `yaml:"operation"`
 	AuthMode        string   `yaml:"auth_mode"`
 	SigningSecret   string   `yaml:"signing_secret"`
@@ -129,7 +130,7 @@ func (b *Binding) handle(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx := principal.WithPrincipal(r.Context(), p)
 
-	result, err := b.invoker.Invoke(ctx, p, b.cfg.Provider, b.cfg.Operation, body)
+	result, err := b.invoker.Invoke(ctx, p, b.cfg.Provider, b.cfg.Instance, b.cfg.Operation, body)
 	if err != nil {
 		writeError(w, http.StatusBadGateway, "upstream invocation failed")
 		return

--- a/plugins/datastore/dynamodb/dynamodb.go
+++ b/plugins/datastore/dynamodb/dynamodb.go
@@ -294,6 +294,38 @@ func (s *Store) ListTokens(ctx context.Context, userID string) ([]*core.Integrat
 	return tokens, nil
 }
 
+func (s *Store) ListTokensForIntegration(ctx context.Context, userID, integration string) ([]*core.IntegrationToken, error) {
+	keyCond := expression.KeyAnd(
+		expression.Key(attrPK).Equal(expression.Value(userPKPrefix+userID)),
+		expression.KeyBeginsWith(expression.Key(attrSK), tokenSKPrefix),
+	)
+	filt := expression.Name(attrIntegration).Equal(expression.Value(integration))
+	expr, err := expression.NewBuilder().WithKeyCondition(keyCond).WithFilter(filt).Build()
+	if err != nil {
+		return nil, fmt.Errorf("dynamodb: building expression: %w", err)
+	}
+	out, err := s.client.Query(ctx, &dynamodb.QueryInput{
+		TableName:                 &s.tableName,
+		KeyConditionExpression:    expr.KeyCondition(),
+		FilterExpression:          expr.Filter(),
+		ExpressionAttributeNames:  expr.Names(),
+		ExpressionAttributeValues: expr.Values(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("dynamodb: listing tokens for integration: %w", err)
+	}
+
+	tokens := make([]*core.IntegrationToken, 0, len(out.Items))
+	for _, item := range out.Items {
+		t, err := s.unmarshalIntegrationToken(item)
+		if err != nil {
+			return nil, err
+		}
+		tokens = append(tokens, t)
+	}
+	return tokens, nil
+}
+
 func (s *Store) DeleteToken(ctx context.Context, id string) error {
 	pk, sk, err := s.lookupKeysByGSI(ctx, gsiID, attrID, id, tokenSKPrefix)
 	if err != nil {

--- a/plugins/datastore/firestore/firestore.go
+++ b/plugins/datastore/firestore/firestore.go
@@ -292,6 +292,31 @@ func (s *Store) ListTokens(ctx context.Context, userID string) ([]*core.Integrat
 	return tokens, nil
 }
 
+func (s *Store) ListTokensForIntegration(ctx context.Context, userID, integration string) ([]*core.IntegrationToken, error) {
+	iter := s.client.Collection(datastore.IntegrationTokensCollection).
+		Where("user_id", "==", userID).
+		Where("integration", "==", integration).
+		Documents(ctx)
+	defer iter.Stop()
+
+	var tokens []*core.IntegrationToken
+	for {
+		snap, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("firestore: listing tokens for integration: %w", err)
+		}
+		t, err := s.snapToIntegrationToken(snap)
+		if err != nil {
+			return nil, err
+		}
+		tokens = append(tokens, t)
+	}
+	return tokens, nil
+}
+
 func (s *Store) DeleteToken(ctx context.Context, id string) error {
 	_, err := s.client.Collection(datastore.IntegrationTokensCollection).Doc(id).Delete(ctx)
 	if err != nil {

--- a/plugins/datastore/mongodb/mongodb.go
+++ b/plugins/datastore/mongodb/mongodb.go
@@ -228,6 +228,28 @@ func (s *Store) ListTokens(ctx context.Context, userID string) ([]*core.Integrat
 	return tokens, cursor.Err()
 }
 
+func (s *Store) ListTokensForIntegration(ctx context.Context, userID, integration string) ([]*core.IntegrationToken, error) {
+	cursor, err := s.db.Collection(datastore.IntegrationTokensCollection).Find(ctx, bson.M{"user_id": userID, "integration": integration})
+	if err != nil {
+		return nil, fmt.Errorf("mongodb: listing tokens for integration: %w", err)
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	var tokens []*core.IntegrationToken
+	for cursor.Next(ctx) {
+		var doc integrationTokenDoc
+		if err := cursor.Decode(&doc); err != nil {
+			return nil, fmt.Errorf("mongodb: decoding token: %w", err)
+		}
+		t, err := s.integrationTokenFromDoc(&doc)
+		if err != nil {
+			return nil, err
+		}
+		tokens = append(tokens, t)
+	}
+	return tokens, cursor.Err()
+}
+
 func (s *Store) DeleteToken(ctx context.Context, id string) error {
 	_, err := s.db.Collection(datastore.IntegrationTokensCollection).DeleteOne(ctx, bson.M{"_id": id})
 	if err != nil {

--- a/plugins/datastore/sqlstore/sqlstore.go
+++ b/plugins/datastore/sqlstore/sqlstore.go
@@ -248,6 +248,27 @@ func (s *Store) ListTokens(ctx context.Context, userID string) ([]*core.Integrat
 	return tokens, rows.Err()
 }
 
+func (s *Store) ListTokensForIntegration(ctx context.Context, userID, integration string) ([]*core.IntegrationToken, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT id, user_id, integration, instance, access_token_encrypted, refresh_token_encrypted,
+		       scopes, expires_at, last_refreshed_at, refresh_error_count, metadata_json, created_at, updated_at
+		FROM integration_tokens WHERE user_id = `+s.ph(1)+` AND integration = `+s.ph(2), userID, integration)
+	if err != nil {
+		return nil, fmt.Errorf("listing tokens for integration: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tokens []*core.IntegrationToken
+	for rows.Next() {
+		t, err := s.scanIntegrationToken(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning token row: %w", err)
+		}
+		tokens = append(tokens, t)
+	}
+	return tokens, rows.Err()
+}
+
 func (s *Store) DeleteToken(ctx context.Context, id string) error {
 	_, err := s.DB.ExecContext(ctx, "DELETE FROM integration_tokens WHERE id = "+s.ph(1), id)
 	if err != nil {

--- a/web/e2e/integrations.spec.ts
+++ b/web/e2e/integrations.spec.ts
@@ -69,7 +69,7 @@ test.describe("Integrations", () => {
   }) => {
     const page = authenticatedPage;
     await mockIntegrations(page, [
-      { ...OAUTH_INTEGRATION, connected: true },
+      { ...OAUTH_INTEGRATION, connected: true, instances: [{ name: "default" }] },
       MANUAL_INTEGRATION,
     ]);
 
@@ -82,8 +82,8 @@ test.describe("Integrations", () => {
     // Connected integration's settings shows Reconnect/Disconnect
     await page.getByRole("button", { name: "OAuth Service settings" }).click();
     const dialog = page.getByRole("dialog");
-    await expect(dialog.getByText("Connected")).toBeVisible();
-    await expect(dialog.getByRole("button", { name: "Reconnect" })).toBeVisible();
+    await expect(dialog.getByText("default")).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Add Connection" })).toBeVisible();
     await expect(dialog.getByRole("button", { name: "Disconnect" })).toBeVisible();
     await page.keyboard.press("Escape");
     await expect(dialog).not.toBeVisible();
@@ -98,7 +98,7 @@ test.describe("Integrations", () => {
   }) => {
     const page = authenticatedPage;
     await mockIntegrations(page, [
-      { ...OAUTH_INTEGRATION, connected: true },
+      { ...OAUTH_INTEGRATION, connected: true, instances: [{ name: "default" }] },
     ]);
 
     await page.goto("/integrations");
@@ -107,8 +107,8 @@ test.describe("Integrations", () => {
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible();
     await expect(dialog.getByText("OAuth Service")).toBeVisible();
-    await expect(dialog.getByText("Connected")).toBeVisible();
-    await expect(dialog.getByRole("button", { name: "Reconnect" })).toBeVisible();
+    await expect(dialog.getByText("default")).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Add Connection" })).toBeVisible();
     await expect(dialog.getByRole("button", { name: "Disconnect" })).toBeVisible();
   });
 
@@ -117,7 +117,7 @@ test.describe("Integrations", () => {
   }) => {
     const page = authenticatedPage;
     await mockIntegrations(page, [
-      { ...OAUTH_INTEGRATION, connected: true },
+      { ...OAUTH_INTEGRATION, connected: true, instances: [{ name: "default" }] },
     ]);
 
     await page.goto("/integrations");
@@ -134,7 +134,7 @@ test.describe("Integrations", () => {
   }) => {
     const page = authenticatedPage;
     await mockIntegrations(page, [
-      { ...OAUTH_INTEGRATION, connected: true },
+      { ...OAUTH_INTEGRATION, connected: true, instances: [{ name: "default" }] },
     ]);
 
     await page.goto("/integrations");
@@ -150,7 +150,7 @@ test.describe("Integrations", () => {
   }) => {
     const page = authenticatedPage;
     await mockIntegrations(page, [
-      { ...OAUTH_INTEGRATION, connected: true },
+      { ...OAUTH_INTEGRATION, connected: true, instances: [{ name: "default" }] },
     ]);
 
     await page.goto("/integrations");
@@ -163,7 +163,7 @@ test.describe("Integrations", () => {
     await expect(dialog.getByText("This will remove your OAuth Service integration.")).toBeVisible();
 
     await dialog.getByRole("button", { name: "Cancel" }).click();
-    await expect(dialog.getByRole("button", { name: "Reconnect" })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Add Connection" })).toBeVisible();
   });
 
   test("disconnect calls API and refreshes list", async ({
@@ -172,7 +172,7 @@ test.describe("Integrations", () => {
     const page = authenticatedPage;
     let disconnected = false;
 
-    const connectedList = [{ ...OAUTH_INTEGRATION, connected: true }];
+    const connectedList = [{ ...OAUTH_INTEGRATION, connected: true, instances: [{ name: "default" }] }];
     const disconnectedList = [{ ...OAUTH_INTEGRATION, connected: false }];
 
     await mockIntegrations(page, connectedList, {
@@ -276,15 +276,18 @@ test.describe("Integrations", () => {
     authenticatedPage,
   }) => {
     const page = authenticatedPage;
-    await mockIntegrations(page, [{ ...MANUAL_INTEGRATION, connected: true }]);
+    await mockIntegrations(page, [{ ...MANUAL_INTEGRATION, connected: true, instances: [{ name: "default" }] }]);
 
     await page.goto("/integrations");
     await page.getByRole("button", { name: "Manual Service settings" }).click();
     const dialog = page.getByRole("dialog");
-    await expect(dialog.getByText("Connected")).toBeVisible();
-    await dialog.getByRole("button", { name: "Reconnect" }).click();
-    // Modal must close so the token form isn't trapped behind the overlay
+    await expect(dialog.getByText("default")).toBeVisible();
+    await dialog.getByRole("button", { name: "Add Connection" }).click();
+    // Modal closes and instance name form appears
     await expect(page.getByRole("dialog")).not.toBeVisible();
+    await expect(page.getByLabel("Connection name")).toBeVisible();
+    await page.getByLabel("Connection name").fill("second");
+    await page.getByRole("button", { name: "Continue" }).click();
     await expect(page.getByLabel("API Token")).toBeVisible();
   });
 });

--- a/web/src/components/IntegrationCard.tsx
+++ b/web/src/components/IntegrationCard.tsx
@@ -69,6 +69,9 @@ export default function IntegrationCard({
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [showTokenForm, setShowTokenForm] = useState(false);
   const [showParamForm, setShowParamForm] = useState(false);
+  const [showInstanceForm, setShowInstanceForm] = useState(false);
+  const [pendingInstance, setPendingInstance] = useState("");
+  const [pendingAuthMethod, setPendingAuthMethod] = useState<"oauth" | "manual">("oauth");
   const [submitting, setSubmitting] = useState(false);
 
   const safeIconSVG = integration.icon_svg
@@ -93,13 +96,24 @@ export default function IntegrationCard({
     return params;
   }
 
+  function promptForInstance(method: "oauth" | "manual") {
+    setPendingAuthMethod(method);
+    setSettingsOpen(false);
+    setShowInstanceForm(true);
+    setError(null);
+  }
+
   function handleConnectManual() {
+    if (integration.connected) {
+      promptForInstance("manual");
+      return;
+    }
     setSettingsOpen(false);
     setShowTokenForm(true);
     setError(null);
   }
 
-  async function handleConnectOAuth() {
+  async function startOAuthFlow(instance?: string) {
     if (needsParams && !showParamForm) {
       setSettingsOpen(false);
       setShowParamForm(true);
@@ -109,7 +123,7 @@ export default function IntegrationCard({
     setLoading(true);
     setError(null);
     try {
-      const { url } = await startIntegrationOAuth(integration.name);
+      const { url } = await startIntegrationOAuth(integration.name, undefined, undefined, instance);
       window.location.href = url;
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to start OAuth");
@@ -118,11 +132,32 @@ export default function IntegrationCard({
     }
   }
 
+  function handleConnectOAuth() {
+    if (integration.connected) {
+      promptForInstance("oauth");
+      return;
+    }
+    startOAuthFlow();
+  }
+
   function handleConnect() {
     if (isManualOnly) {
       handleConnectManual();
     } else {
       handleConnectOAuth();
+    }
+  }
+
+  function handleInstanceSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const name = (new FormData(e.currentTarget).get("instance_name") as string)?.trim();
+    if (!name) return;
+    setPendingInstance(name);
+    setShowInstanceForm(false);
+    if (pendingAuthMethod === "manual") {
+      setShowTokenForm(true);
+    } else {
+      startOAuthFlow(name);
     }
   }
 
@@ -136,6 +171,7 @@ export default function IntegrationCard({
         integration.name,
         undefined,
         params,
+        pendingInstance || undefined,
       );
       window.location.href = url;
     } catch (err) {
@@ -157,6 +193,7 @@ export default function IntegrationCard({
         integration.name,
         credential,
         Object.keys(params).length > 0 ? params : undefined,
+        pendingInstance || undefined,
       );
       setShowTokenForm(false);
       onConnected?.();
@@ -170,14 +207,16 @@ export default function IntegrationCard({
   function handleCancelForm() {
     setShowTokenForm(false);
     setShowParamForm(false);
+    setShowInstanceForm(false);
+    setPendingInstance("");
     setError(null);
   }
 
-  async function handleDisconnect() {
+  async function handleDisconnect(instance?: string) {
     setDisconnecting(true);
     setError(null);
     try {
-      await disconnectIntegration(integration.name);
+      await disconnectIntegration(integration.name, instance);
       onDisconnected?.();
       setSettingsOpen(false);
     } catch (err) {
@@ -255,6 +294,29 @@ export default function IntegrationCard({
       </div>
       {error && !settingsOpen && (
         <p className="mt-2 text-sm text-ember-500">{error}</p>
+      )}
+      {showInstanceForm && (
+        <form onSubmit={handleInstanceSubmit} className="mt-3">
+          <label
+            htmlFor={`instance-name-${integration.name}`}
+            className="block text-sm font-medium text-stone-700"
+          >
+            Connection name
+          </label>
+          <input
+            id={`instance-name-${integration.name}`}
+            name="instance_name"
+            type="text"
+            required
+            placeholder="e.g. my-store, acme-workspace"
+            autoFocus
+            className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
+          />
+          <div className="mt-2 flex gap-2">
+            <Button type="submit">Continue</Button>
+            <Button type="button" variant="secondary" onClick={handleCancelForm}>Cancel</Button>
+          </div>
+        </form>
       )}
       {showParamForm && !isManualOnly && (
         <form onSubmit={handleParamSubmit} className="mt-3">

--- a/web/src/components/IntegrationSettingsModal.tsx
+++ b/web/src/components/IntegrationSettingsModal.tsx
@@ -10,7 +10,7 @@ interface IntegrationSettingsModalProps {
   onClose: () => void;
   onReconnect: () => void;
   onReconnectManual?: () => void;
-  onDisconnect: () => void;
+  onDisconnect: (instance?: string) => void;
   reconnecting: boolean;
   disconnecting: boolean;
   error: string | null;
@@ -28,6 +28,7 @@ export default function IntegrationSettingsModal({
 }: IntegrationSettingsModalProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const [confirmingDisconnect, setConfirmingDisconnect] = useState(false);
+  const [disconnectInstance, setDisconnectInstance] = useState<string | undefined>();
 
   useEffect(() => {
     dialogRef.current?.showModal();
@@ -79,7 +80,7 @@ export default function IntegrationSettingsModal({
               <Button
                 variant="secondary"
                 className="flex-1"
-                onClick={() => setConfirmingDisconnect(false)}
+                onClick={() => { setConfirmingDisconnect(false); setDisconnectInstance(undefined); }}
                 disabled={disconnecting}
               >
                 Cancel
@@ -87,7 +88,7 @@ export default function IntegrationSettingsModal({
               <Button
                 variant="danger"
                 className="flex-1"
-                onClick={onDisconnect}
+                onClick={() => onDisconnect(disconnectInstance)}
                 disabled={disconnecting}
               >
                 {disconnecting ? "Disconnecting..." : "Disconnect"}
@@ -114,33 +115,46 @@ export default function IntegrationSettingsModal({
 
             {integration.connected ? (
               <>
-                <div className="mt-4 flex items-center gap-2">
-                  <CheckCircleIcon className="h-5 w-5 text-grove-500" />
-                  <span className="text-sm font-medium text-grove-600">
-                    Connected
-                  </span>
-                </div>
+                {integration.instances && integration.instances.length > 0 && (
+                  <div className="mt-4 space-y-2">
+                    {integration.instances.map((inst) => (
+                      <div key={inst.name} className="flex items-center justify-between rounded border border-border px-3 py-2">
+                        <div className="flex items-center gap-2">
+                          <CheckCircleIcon className="h-4 w-4 text-grove-500" />
+                          <span className="text-sm text-stone-700">{inst.name}</span>
+                        </div>
+                        <button
+                          onClick={() => { setDisconnectInstance(inst.name); setConfirmingDisconnect(true); }}
+                          disabled={disconnecting}
+                          className="text-xs text-ember-500 hover:text-ember-600"
+                        >
+                          Disconnect
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
 
                 {error && <p className="mt-3 text-sm text-ember-500">{error}</p>}
 
-                <div className="mt-6">
+                <div className="mt-6 flex flex-col gap-2">
                   <Button
                     className="w-full"
                     onClick={onReconnect}
                     disabled={reconnecting}
                   >
-                    {reconnecting ? "Connecting..." : "Reconnect"}
+                    {reconnecting ? "Connecting..." : "Add Connection"}
                   </Button>
-                </div>
-
-                <div className="mt-4 border-t border-border pt-4">
-                  <Button
-                    variant="danger"
-                    className="w-full"
-                    onClick={() => setConfirmingDisconnect(true)}
-                  >
-                    Disconnect
-                  </Button>
+                  {onReconnectManual && (
+                    <Button
+                      variant="secondary"
+                      className="w-full"
+                      onClick={onReconnectManual}
+                      disabled={reconnecting}
+                    >
+                      Add with API Token
+                    </Button>
+                  )}
                 </div>
               </>
             ) : (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -7,12 +7,17 @@ export interface ConnectionParamDef {
   default?: string;
 }
 
+export interface InstanceInfo {
+  name: string;
+}
+
 export interface Integration {
   name: string;
   display_name?: string;
   description?: string;
   icon_svg?: string;
   connected?: boolean;
+  instances?: InstanceInfo[];
   auth_types?: ("oauth" | "manual")[];
   connection_params?: Record<string, ConnectionParamDef>;
 }
@@ -119,11 +124,13 @@ export async function startIntegrationOAuth(
   integration: string,
   scopes?: string[],
   connectionParams?: Record<string, string>,
+  instance?: string,
 ): Promise<{ url: string; state: string }> {
   return fetchAPI("/api/v1/auth/start-oauth", {
     method: "POST",
     body: JSON.stringify({
       integration,
+      instance,
       scopes: scopes || [],
       connection_params: connectionParams,
     }),
@@ -134,11 +141,13 @@ export async function connectManualIntegration(
   integration: string,
   credential: string,
   connectionParams?: Record<string, string>,
+  instance?: string,
 ): Promise<{ status: string }> {
   return fetchAPI("/api/v1/auth/connect-manual", {
     method: "POST",
     body: JSON.stringify({
       integration,
+      instance,
       credential,
       connection_params: connectionParams,
     }),
@@ -147,8 +156,10 @@ export async function connectManualIntegration(
 
 export async function disconnectIntegration(
   name: string,
+  instance?: string,
 ): Promise<void> {
-  await fetchAPI(`/api/v1/integrations/${encodeURIComponent(name)}`, {
+  const params = instance ? `?instance=${encodeURIComponent(instance)}` : "";
+  await fetchAPI(`/api/v1/integrations/${encodeURIComponent(name)}${params}`, {
     method: "DELETE",
   });
 }


### PR DESCRIPTION
Users can now have multiple connections to the same provider, for
example two Shopify stores or three Slack workspaces. Each connection
is identified by an instance name (defaulting to "default" for backward
compatibility). The broker auto-selects the single instance when only
one exists; when multiple exist, callers must specify which instance to
use. The integrations API now returns an `instances` array alongside the
`connected` boolean, and the settings modal shows per-instance details
with individual disconnect buttons.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>