### PR TITLE
Add CI guardrails for provider bundle safety

### DIFF
--- a/cmd/gestaltd/bundle_test.go
+++ b/cmd/gestaltd/bundle_test.go
@@ -14,6 +14,96 @@ import (
 	"github.com/valon-technologies/gestalt/internal/provider"
 )
 
+func TestBundleAndValidateRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	openAPIServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"openapi": "3.0.0",
+			"info":    map[string]any{"title": "REST API"},
+			"servers": []map[string]any{{"url": "https://api.example.com"}},
+			"paths": map[string]any{
+				"/items": map[string]any{
+					"get": map[string]any{"operationId": "listItems", "summary": "List items"},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer openAPIServer.Close()
+
+	graphQLServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"data": map[string]any{
+				"__schema": map[string]any{
+					"queryType":    map[string]any{"name": "Query"},
+					"mutationType": nil,
+					"types": []map[string]any{
+						{
+							"kind": "OBJECT", "name": "Query", "description": "",
+							"fields": []map[string]any{
+								{
+									"name": "search", "description": "Search",
+									"args": []map[string]any{},
+									"type": map[string]any{"kind": "OBJECT", "name": "Result", "ofType": nil},
+								},
+							},
+							"inputFields": nil, "enumValues": nil,
+						},
+						{"kind": "OBJECT", "name": "Result", "description": "", "fields": []map[string]any{}, "inputFields": nil, "enumValues": nil},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer graphQLServer.Close()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	outDir := filepath.Join(dir, "bundle")
+	cfg := `auth:
+  provider: google
+  config:
+    client_id: test-client
+    client_secret: test-secret
+    redirect_url: http://localhost:8080/api/v1/auth/login/callback
+datastore:
+  provider: sqlite
+  config:
+    path: ` + filepath.Join(dir, "gestalt.db") + `
+server:
+  dev_mode: true
+  encryption_key: test-key
+integrations:
+  restapi:
+    upstreams:
+      - type: rest
+        url: ` + openAPIServer.URL + `
+  graphapi:
+    upstreams:
+      - type: graphql
+        url: ` + graphQLServer.URL + `
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	if err := bundleConfig(cfgPath, outDir); err != nil {
+		t.Fatalf("bundleConfig: %v", err)
+	}
+
+	openAPIServer.Close()
+	graphQLServer.Close()
+
+	bundledConfigPath := filepath.Join(outDir, bundleConfigName)
+	if err := run([]string{"validate", "--config", bundledConfigPath}); err != nil {
+		t.Fatalf("validate bundled config: %v", err)
+	}
+}
+
 func TestBundleConfigWritesSelfContainedBundle(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/gestaltd/compile_providers_test.go
+++ b/cmd/gestaltd/compile_providers_test.go
@@ -122,6 +122,17 @@ integrations:
   restapi:
     display_name: REST API
     icon_file: ` + iconPath + `
+    headers:
+      X-Api-Key: secret-key-value
+    auth_header: X-Custom-Auth
+    auth_mapping:
+      headers:
+        Authorization: "Bearer {{token}}"
+    response_check: check_ok
+    token_prefix: "Token "
+    auth_style: raw
+    manual_auth: true
+    error_message_path: error.message
     upstreams:
       - type: rest
         url: ` + openAPIServer.URL + `
@@ -171,6 +182,30 @@ provider_dirs:
 	}
 	if restDef.IconSVG == "" {
 		t.Fatal("rest artifact missing embedded IconSVG")
+	}
+	if restDef.Headers != nil {
+		t.Fatalf("rest artifact Headers = %v, want nil (runtime-only field)", restDef.Headers)
+	}
+	if restDef.AuthHeader != "" {
+		t.Fatalf("rest artifact AuthHeader = %q, want empty (runtime-only field)", restDef.AuthHeader)
+	}
+	if restDef.AuthMapping != nil {
+		t.Fatalf("rest artifact AuthMapping = %v, want nil (runtime-only field)", restDef.AuthMapping)
+	}
+	if restDef.ResponseCheck != "" {
+		t.Fatalf("rest artifact ResponseCheck = %q, want empty (runtime-only field)", restDef.ResponseCheck)
+	}
+	if restDef.TokenPrefix != "" {
+		t.Fatalf("rest artifact TokenPrefix = %q, want empty (runtime-only field)", restDef.TokenPrefix)
+	}
+	if restDef.AuthStyle != "" {
+		t.Fatalf("rest artifact AuthStyle = %q, want empty (runtime-only field)", restDef.AuthStyle)
+	}
+	if restDef.ManualAuth {
+		t.Fatal("rest artifact ManualAuth = true, want false (runtime-only field)")
+	}
+	if restDef.ErrorMessagePath != "" {
+		t.Fatalf("rest artifact ErrorMessagePath = %q, want empty (runtime-only field)", restDef.ErrorMessagePath)
 	}
 
 	graphDef, err := provider.LoadFile(filepath.Join(outDir, "graphapi.json"))


### PR DESCRIPTION
Compiled provider artifacts must never contain runtime-only fields like
headers, auth_mapping, or response_check that could hold expanded
secrets. The existing `TestCompileProvidersWritesArtifacts` now sets
every runtime-only field on the restapi integration config and asserts
none of them appear in the compiled JSON artifact, catching both
`ApplyArtifactOverrides` regressions and accidental rewiring to the
full `ApplyIntegrationOverrides`.

A new `TestBundleAndValidateRoundTrip` test bundles a config against
mock REST and GraphQL servers, shuts down the servers, then validates
the bundled config offline. This proves that bundled configs pass full
`gestaltd validate` without any live spec fetches or introspection,
catching regressions where startup re-introduces network dependencies.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>