### PR TITLE
Default zero-value timestamps in token storage

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -611,9 +611,10 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	now := s.now().UTC().Truncate(time.Second)
 	var expiresAt *time.Time
 	if tokenResp.ExpiresIn > 0 {
-		t := s.now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+		t := now.Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
 		expiresAt = &t
 	}
 
@@ -631,6 +632,8 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		RefreshToken: tokenResp.RefreshToken,
 		ExpiresAt:    expiresAt,
 		MetadataJSON: metadata,
+		CreatedAt:    now,
+		UpdatedAt:    now,
 	}
 
 	if err := s.datastore.StoreToken(r.Context(), tok); err != nil {
@@ -708,12 +711,15 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	now := s.now().UTC().Truncate(time.Second)
 	tok := &core.IntegrationToken{
 		ID:          uuid.NewString(),
 		UserID:      dbUser.ID,
 		Integration: req.Integration,
 		Instance:    manualInstance,
 		AccessToken: req.Credential,
+		CreatedAt:   now,
+		UpdatedAt:   now,
 	}
 	manualMeta, metaErr := buildConnectionMetadata(prov, connParams, nil)
 	if metaErr != nil {

--- a/plugins/datastore/sqlstore/sqlstore.go
+++ b/plugins/datastore/sqlstore/sqlstore.go
@@ -122,6 +122,16 @@ func NullableTime(t *time.Time) any {
 	return *t
 }
 
+func defaultTimestamps(createdAt, updatedAt *time.Time) {
+	now := time.Now().UTC().Truncate(time.Second)
+	if createdAt.IsZero() {
+		*createdAt = now
+	}
+	if updatedAt.IsZero() {
+		*updatedAt = now
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Datastore methods
 // ---------------------------------------------------------------------------
@@ -195,6 +205,8 @@ func (s *Store) FindOrCreateUser(ctx context.Context, email string) (*core.User,
 }
 
 func (s *Store) StoreToken(ctx context.Context, token *core.IntegrationToken) error {
+	defaultTimestamps(&token.CreatedAt, &token.UpdatedAt)
+
 	accessEnc, refreshEnc, err := s.Enc.EncryptTokenPair(token.AccessToken, token.RefreshToken)
 	if err != nil {
 		return fmt.Errorf("encrypting token pair: %w", err)
@@ -281,6 +293,8 @@ func (s *Store) DeleteToken(ctx context.Context, id string) error {
 }
 
 func (s *Store) StoreAPIToken(ctx context.Context, token *core.APIToken) error {
+	defaultTimestamps(&token.CreatedAt, &token.UpdatedAt)
+
 	_, err := s.DB.ExecContext(ctx, `
 		INSERT INTO api_tokens (id, user_id, name, hashed_token, scopes, expires_at, created_at, updated_at)
 		VALUES (`+s.ph(1)+`, `+s.ph(2)+`, `+s.ph(3)+`, `+s.ph(4)+`, `+s.ph(5)+`, `+s.ph(6)+`, `+s.ph(7)+`, `+s.ph(8)+`)`,


### PR DESCRIPTION
MySQL 8.0 rejects Go's zero-value `time.Time` (serialized as
`0000-00-00`) when `NO_ZERO_DATE` is active in `sql_mode`, which is the
default. The OAuth callback and manual connect flows were not setting
`CreatedAt` or `UpdatedAt` on new tokens, so the zero values reached the
database and caused Error 1292 on every token upsert.

The datastore layer now defaults zero timestamps to the current time
before writing, so no caller can accidentally send invalid datetimes
regardless of which database backend is in use. The two affected handlers
also set timestamps explicitly at creation, matching the pattern already
used by the API token handler.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>