### PR TITLE
Document new features and expand key concepts

### DIFF
--- a/docs/pages/concepts/authentication-and-tokens.mdx
+++ b/docs/pages/concepts/authentication-and-tokens.mdx
@@ -47,7 +47,14 @@ Each stored credential includes:
 | Refresh token | Used to obtain a new access token when the current one expires. |
 | Expiry time | Timestamp at which the access token expires. |
 | Integration name | Ties the credential to a specific integration. |
+| Instance | Distinguishes multiple connections to the same integration. Defaults to `"default"`. |
 | Metadata | Additional fields extracted from the token response (if `token_metadata` is configured). |
+
+### Multiple connections
+
+A user can connect to the same integration more than once. Each connection is stored as a separate credential identified by the (user, integration, instance) tuple. This is useful when a user works across multiple accounts for the same service — for example, a personal Slack workspace and a work Slack workspace.
+
+When only one connection exists, Gestalt selects it automatically. When multiple exist, the caller must specify which instance to use by passing `_instance` as a parameter on the request. See [Multi-instance connections](/concepts/integrations#multi-instance-connections) for details.
 
 ## Token refresh
 

--- a/docs/pages/concepts/integrations.mdx
+++ b/docs/pages/concepts/integrations.mdx
@@ -135,6 +135,41 @@ Omit `allowed_operations` entirely to allow all operations. An empty value is in
 
 **Manual**: Set `auth.type` to `manual`. Users paste credentials directly through the web UI (`POST /api/v1/auth/connect-manual`) or CLI. Gestalt encrypts and stores them the same way it stores OAuth tokens.
 
+## Dual auth
+
+Some services support both OAuth and API keys. When an integration sets `manual_auth: true`, Gestalt advertises both authentication methods. Users see separate options in the web UI — "Connect with OAuth" to start the OAuth flow, or "Use API Token" to paste credentials directly.
+
+```yaml
+integrations:
+  my-service:
+    upstreams:
+      - type: rest
+        url: https://api.example.com/openapi.json
+    client_id: ${SERVICE_CLIENT_ID}
+    client_secret: ${SERVICE_CLIENT_SECRET}
+    manual_auth: true
+    auth:
+      authorization_url: https://example.com/oauth/authorize
+      token_url: https://example.com/oauth/token
+```
+
+The API returns `auth_types: ["oauth", "manual"]` for dual-auth integrations, `["oauth"]` for OAuth-only, and `["manual"]` for manual-only. Either authentication method produces the same kind of stored credential — the difference is only in how the user provides it.
+
+## Multi-instance connections
+
+By default, each user has one connection per integration. Multi-instance connections allow a user to maintain several connections to the same integration simultaneously — for example, two Slack workspaces or three Shopify stores.
+
+Each connection is identified by an **instance** name. The first connection uses the instance name `"default"`. When a user connects the same integration again with a different account, a new instance is created.
+
+Credential resolution follows two rules:
+
+- When a user has **one** connection to an integration, Gestalt selects it automatically. No instance parameter is needed.
+- When a user has **multiple** connections, the caller must specify which instance to use by passing `_instance` as a parameter. Omitting it returns a 409 error listing the available instances.
+
+Multi-instance support requires no special configuration. Any integration can have multiple connections per user.
+
+To disconnect a specific instance, pass `?instance=NAME` to the disconnect endpoint. When only one connection exists, the instance parameter is optional.
+
 ## Connection modes
 
 Each integration has a `connection_mode` that controls how credentials are resolved at invocation time:

--- a/docs/pages/concepts/mcp-binding.mdx
+++ b/docs/pages/concepts/mcp-binding.mdx
@@ -57,6 +57,12 @@ A composite integration can expose operations from different transports under a 
 
 Integrations with only a `type: mcp` upstream cannot be invoked over the HTTP API. Calling their operations via `GET/POST /api/v1/{integration}/{operation}` returns a 400 error indicating the integration is accessible only via MCP.
 
+## Multi-instance tool calls
+
+When a user has multiple connections to the same integration, MCP tool calls must include `_instance` as a tool argument to specify which connection to use. If the user has only one connection, the argument is optional — Gestalt selects the single connection automatically.
+
+When `_instance` is required but missing, the tool call returns an error listing the available instance names.
+
 ## Limitations
 
 Adding or removing integrations requires restarting the server.

--- a/docs/pages/concepts/platform-model.mdx
+++ b/docs/pages/concepts/platform-model.mdx
@@ -48,15 +48,15 @@ A **plugin** is a Go package that implements one of Gestalt's core interfaces. P
 
 Gestalt ships with plugins across seven categories:
 
-| Category | What it provides | Examples |
-|---|---|---|
-| Auth provider | Platform login and session management | `google`, `oidc` |
-| Datastore | Persistent storage for users and tokens | `sqlite`, `mysql`, `postgres`, `dynamodb` |
-| Secret manager | Resolution of `secret://` references | `env`, `file`, `gcp_secret_manager` |
-| Integration hooks | API-specific auth and response handling | `slack_ok`, `datadog_keys` |
-| Binding | Alternative request surfaces | `webhook` |
-| Runtime | Background processes | `echo` |
-| Provider | Operation sources | `echo` |
+| Category | What it provides |
+|---|---|
+| Auth provider | Platform login and session management |
+| Datastore | Persistent storage for users and tokens |
+| Secret manager | Resolution of `secret://` references |
+| Integration hooks | API-specific auth and response handling |
+| Binding | Alternative request surfaces |
+| Runtime | Background processes |
+| Provider | Operation sources |
 
 You select plugins by name in the config file. At startup, Gestalt instantiates the named plugin with the config you provide and wires it into the system. See [Built-in Plugins](/reference/built-in-plugins) for the full list.
 

--- a/docs/pages/concepts/platform-model.mdx
+++ b/docs/pages/concepts/platform-model.mdx
@@ -16,6 +16,80 @@ Gestalt has a small set of primitives that compose into a complete API gateway f
 | **Runtime** | A background process that boots alongside the server and receives scoped access to a subset of providers. |
 | **Binding** | An alternative request surface (for example, webhooks or MCP) that forwards calls through the shared invoker. |
 
+## Main concepts
+
+### Integrations and providers
+
+An **integration** is a named entry in your configuration file that describes how Gestalt connects to an external service. It declares which upstreams to use, how authentication works, and which operations to expose. Think of it as a blueprint: it tells Gestalt everything it needs to know about a service, but it does not execute anything by itself.
+
+A **provider** is the runtime object that Gestalt builds from an integration definition at startup. The provider is what actually lists operations and executes them. When you invoke `slack/conversations_list`, the request is handled by the Slack provider, which was constructed from the `slack` integration in your config.
+
+When an integration declares multiple upstream types — for example, a REST upstream and an MCP upstream — Gestalt builds a **composite provider** that merges operations from both sources into a single namespace.
+
+### Upstreams
+
+An **upstream** is a source of operations. Every integration declares at least one. Gestalt supports three upstream types:
+
+- A **REST upstream** loads operations from an OpenAPI specification, a local provider definition file, or a directory scan. Each path and method combination in the spec becomes a callable operation.
+- A **GraphQL upstream** introspects a GraphQL endpoint at startup and generates one operation per query and mutation field.
+- An **MCP upstream** connects to a remote MCP server and imports its tools as operations.
+
+A single integration can combine upstream types. A Slack integration, for example, might use a REST upstream for HTTP operations and an MCP upstream for additional tools. The resulting provider exposes both sets of operations under the same name.
+
+### Operations
+
+An **operation** is the smallest callable unit in Gestalt. Every API call, GraphQL query, and MCP tool invocation maps to exactly one operation.
+
+Operations are identified by name. For REST upstreams, the name comes from the OpenAPI `operationId`. For GraphQL, it is the query or mutation field name. For MCP, it is the tool name. Each operation carries metadata: a human-readable description, parameter definitions with types, and annotations indicating whether the operation is read-only, destructive, or idempotent. This metadata flows through to MCP tool generation so that AI assistants can make informed decisions about which tools to call.
+
+### Plugins
+
+A **plugin** is a Go package that implements one of Gestalt's core interfaces. Plugins are how you swap components in and out of the system without changing application code.
+
+Gestalt ships with plugins across seven categories:
+
+| Category | What it provides | Examples |
+|---|---|---|
+| Auth provider | Platform login and session management | `google`, `oidc` |
+| Datastore | Persistent storage for users and tokens | `sqlite`, `mysql`, `postgres`, `dynamodb` |
+| Secret manager | Resolution of `secret://` references | `env`, `file`, `gcp_secret_manager` |
+| Integration hooks | API-specific auth and response handling | `slack_ok`, `datadog_keys` |
+| Binding | Alternative request surfaces | `webhook` |
+| Runtime | Background processes | `echo` |
+| Provider | Operation sources | `echo` |
+
+You select plugins by name in the config file. At startup, Gestalt instantiates the named plugin with the config you provide and wires it into the system. See [Built-in Plugins](/reference/built-in-plugins) for the full list.
+
+### Bindings
+
+A **binding** is an alternative way to reach Gestalt's providers, separate from the HTTP API and MCP endpoint. Bindings receive external events and forward them through the same shared invoker that handles all other requests.
+
+The built-in `webhook` binding listens for HTTP POST requests at a configured path and invokes a specific provider operation with the request body as parameters. You might use it to receive event callbacks from an upstream service and route them to an operation for processing.
+
+Bindings are scoped: each binding config declares which providers it can access. This prevents a webhook endpoint from accidentally invoking operations on unrelated integrations.
+
+### Runtimes
+
+A **runtime** is a long-lived background process that starts alongside the server and stops when the server shuts down. Runtimes are useful for periodic tasks, event loops, or any work that needs continuous access to provider operations without waiting for an external trigger.
+
+Like bindings, runtimes receive a scoped invoker limited to the providers listed in their config. A runtime that only needs Slack and Linear cannot invoke operations on any other integration.
+
+### Artifacts
+
+A **provider artifact** is a precompiled JSON file containing a complete provider definition: metadata, auth configuration, and the full list of operations with their parameters and schemas.
+
+By default, Gestalt builds providers by fetching OpenAPI specs or introspecting GraphQL endpoints at startup. This works well in development but introduces external dependencies at boot time. Artifacts eliminate this: you compile them once with `gestaltd compile-providers`, and subsequent startups load the local files instead of reaching out to the network.
+
+The `gestaltd bundle` command takes this further. It writes a self-contained directory with a generated config file and all provider artifacts, ready for deployment. No live spec fetches, no GraphQL introspection, no network dependencies at startup.
+
+### Connections and instances
+
+A **connection** is a user's stored credential for an integration. When a user completes an OAuth flow or pastes an API key, Gestalt encrypts the resulting tokens and persists them in the datastore. Each subsequent request to that integration resolves the stored connection automatically.
+
+By default, each user has one connection per integration. Some integrations support multiple accounts — a user managing two Shopify stores or three Slack workspaces, for example. Gestalt handles this through **instances**: each connection is identified by a (user, integration, instance) tuple. The first connection uses the instance name `"default"`.
+
+When a user has a single connection, Gestalt selects it automatically. When multiple connections exist, the caller must pass `_instance` as a parameter to specify which one to use. Omitting it returns an error listing the available instances.
+
 ## Execution model
 
 All request surfaces share a single invoker built once at startup:

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -86,9 +86,9 @@ cargo build --release
 | `gestalt config set <key> <value>` | Write a config value. |
 | `gestalt config unset <key>` | Remove a config value. |
 | `gestalt config list` | List all config values. |
-| `gestalt integrations list` | List available integrations with name, display name, auth type, connected status, and description. |
+| `gestalt integrations list` | List available integrations with name, display name, auth types, connected status, instance names, and description. |
 | `gestalt integrations connect <name>` | Start an OAuth connection flow. |
-| `gestalt invoke <integration> <operation> -p key=value` | Execute an operation. |
+| `gestalt invoke <integration> <operation> -p key=value` | Execute an operation. When multiple connections exist, pass `-p _instance=NAME` to select which one to use. |
 | `gestalt tokens create [--name <name>]` | Create an API token. |
 | `gestalt tokens list` | List API tokens. |
 | `gestalt tokens revoke <id>` | Revoke an API token. |

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -109,6 +109,7 @@ Each integration is defined under `integrations.<name>` and contains one or more
 | `auth_style` | How the token is sent: `bearer` (default), `raw`, `basic`, or `none`. |
 | `headers` | Default headers sent with every upstream request. |
 | `icon_file` | Path to an SVG file used as the integration icon. Relative paths resolve from the config file's directory. |
+| `manual_auth` | Boolean. When `true`, the integration supports both OAuth and manual authentication. Users see both connection options in the web UI. The API returns `auth_types: ["oauth", "manual"]`. |
 | `error_message_path` | Dot-delimited path for extracting error messages from upstream JSON responses. |
 
 ### Upstreams

--- a/docs/pages/reference/http-api.mdx
+++ b/docs/pages/reference/http-api.mdx
@@ -24,8 +24,8 @@ All authenticated endpoints require an `Authorization: Bearer <token>` header. T
 
 | Method | Path | Purpose |
 |---|---|---|
-| GET | `/api/v1/integrations` | List loaded integrations. Returns an array of objects with `name`, `display_name`, `description`, `icon_svg`, `connected` (boolean), and `auth_type` (`"oauth"` or `"manual"`). |
-| DELETE | `/api/v1/integrations/{name}` | Disconnect an integration. Removes the stored token for the calling user. Returns `{"status":"disconnected"}`. |
+| GET | `/api/v1/integrations` | List loaded integrations. Returns an array of objects with `name`, `display_name`, `description`, `icon_svg`, `connected` (boolean), `instances` (array of `{"name": "..."}` objects), and `auth_types` (array of strings, e.g. `["oauth"]`, `["manual"]`, or `["oauth", "manual"]`). |
+| DELETE | `/api/v1/integrations/{name}` | Disconnect an integration. Removes the stored token for the calling user. Pass `?instance=NAME` to disconnect a specific instance. When multiple connections exist and no instance is specified, returns 409 with the available instance names. Returns `{"status":"disconnected"}`. |
 | GET | `/api/v1/integrations/{name}/operations` | List operations exposed by an integration. |
 | GET or POST | `/api/v1/{integration}/{operation}` | Execute an integration operation. MCP-only integrations return a 400 error. |
 
@@ -65,6 +65,7 @@ Bindings register dynamic routes at `/api/v1/bindings/{name}/*` based on their c
 - **GET** requests pass parameters as query string key-value pairs.
 - **POST** requests pass parameters as a JSON body.
 - Path placeholders like `{integration}` and `{operation}` are resolved from the URL. Remaining parameters are sent as query or body values depending on the method.
+- When a user has multiple connections to an integration, pass `_instance` as a parameter to specify which connection to use. If omitted when multiple connections exist, the request returns `409 Conflict` with the available instance names.
 - Integrations backed only by a `type: mcp` upstream cannot be invoked over HTTP. Attempting to do so returns `400: this integration is accessible only via MCP`.
 
 ## Authentication


### PR DESCRIPTION
## Summary

- Expands platform model page with detailed explanations of all core primitives (integrations, providers, upstreams, operations, plugins, bindings, runtimes, artifacts, connections/instances) — each gets 2-3 paragraphs instead of a one-liner table row
- Documents multi-instance connections across integrations, auth-tokens, MCP binding, HTTP API, and CLI reference pages
- Documents dual auth (`manual_auth: true`) in integrations concept page and config-file reference
- Fixes HTTP API reference: `auth_type` string → `auth_types` array, adds `instances` array, documents `?instance=NAME` and `_instance` parameter

## Test plan

- [x] `npm run build` passes with no errors across all 28 pages
- [ ] Spot-check rendered pages for formatting (tables, code blocks, internal links)
- [ ] Verify no stale `auth_type` (singular) references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)