### PR TITLE
Gate readiness probe behind provider initialization

### DIFF
--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/crypto"
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/internal/config"
@@ -107,8 +108,12 @@ func runServe(args []string) error {
 		Invoker:     result.Invoker,
 		DevMode:     result.DevMode,
 		StateSecret: crypto.DeriveKey(env.Config.Server.EncryptionKey),
-		MCPHandler:  mcpHandler,
-		WebUI:       webui.Handler(),
+		Readiness: composeReadiness(
+			readinessFromChannel(result.ProvidersReady, "providers loading"),
+			datastoreReadiness(result.Datastore),
+		),
+		MCPHandler: mcpHandler,
+		WebUI:      webui.Handler(),
 	})
 	if err != nil {
 		return fmt.Errorf("creating server: %w", err)
@@ -386,4 +391,37 @@ func (h *lateHandler) Set(handler http.Handler) {
 	h.mu.Lock()
 	h.handler = handler
 	h.mu.Unlock()
+}
+
+func readinessFromChannel(ch <-chan struct{}, reason string) server.ReadinessChecker {
+	return func() string {
+		select {
+		case <-ch:
+			return ""
+		default:
+			return reason
+		}
+	}
+}
+
+func composeReadiness(checks ...server.ReadinessChecker) server.ReadinessChecker {
+	return func() string {
+		for _, check := range checks {
+			if reason := check(); reason != "" {
+				return reason
+			}
+		}
+		return ""
+	}
+}
+
+func datastoreReadiness(ds core.Datastore) server.ReadinessChecker {
+	return func() string {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if err := ds.Ping(ctx); err != nil {
+			return "datastore unavailable"
+		}
+		return ""
+	}
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -48,10 +48,12 @@ func (s *Server) healthCheck(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
-func (s *Server) readinessCheck(w http.ResponseWriter, r *http.Request) {
-	if err := s.datastore.Ping(r.Context()); err != nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"status": "unavailable"})
-		return
+func (s *Server) readinessCheck(w http.ResponseWriter, _ *http.Request) {
+	if s.readiness != nil {
+		if reason := s.readiness(); reason != "" {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"status": reason})
+			return
+		}
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,6 +13,11 @@ import (
 	"github.com/valon-technologies/gestalt/internal/registry"
 )
 
+// ReadinessChecker reports whether the server is ready to handle requests.
+// Returning a non-empty string means not ready; the string is used as the
+// status message in the /ready response.
+type ReadinessChecker func() string
+
 type Server struct {
 	router     chi.Router
 	auth       core.AuthProvider
@@ -25,6 +30,7 @@ type Server struct {
 	devMode    bool
 	stateCodec *integrationOAuthStateCodec
 	now        func() time.Time
+	readiness  ReadinessChecker
 	mcpHandler http.Handler
 	webUI      http.Handler
 }
@@ -39,6 +45,7 @@ type Config struct {
 	DevMode     bool
 	StateSecret []byte
 	Now         func() time.Time
+	Readiness   ReadinessChecker
 	MCPHandler  http.Handler
 	WebUI       http.Handler
 }
@@ -71,6 +78,7 @@ func New(cfg Config) (*Server, error) {
 		devMode:    cfg.DevMode,
 		stateCodec: stateCodec,
 		now:        now,
+		readiness:  cfg.Readiness,
 		mcpHandler: cfg.MCPHandler,
 		webUI:      cfg.WebUI,
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -102,13 +103,54 @@ func TestReadinessCheck(t *testing.T) {
 	}
 }
 
+func TestReadinessCheck_NotReady(t *testing.T) {
+	t.Parallel()
+	var ready atomic.Bool
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Readiness = func() string {
+			if !ready.Load() {
+				return "providers loading"
+			}
+			return ""
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/ready")
+	if err != nil {
+		t.Fatalf("GET /ready: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 while not ready, got %d", resp.StatusCode)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if body["status"] != "providers loading" {
+		t.Fatalf("expected status 'providers loading', got %q", body["status"])
+	}
+
+	ready.Store(true)
+
+	resp2, err := http.Get(ts.URL + "/ready")
+	if err != nil {
+		t.Fatalf("GET /ready after ready: %v", err)
+	}
+	defer func() { _ = resp2.Body.Close() }()
+
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 after ready, got %d", resp2.StatusCode)
+	}
+}
+
 func TestReadinessCheck_DatastoreDown(t *testing.T) {
 	t.Parallel()
 	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Datastore = &coretesting.StubDatastore{
-			PingFn: func(context.Context) error {
-				return fmt.Errorf("connection refused")
-			},
+		cfg.Readiness = func() string {
+			return "datastore unavailable"
 		}
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -127,8 +169,8 @@ func TestReadinessCheck_DatastoreDown(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		t.Fatalf("decoding response: %v", err)
 	}
-	if body["status"] != "unavailable" {
-		t.Fatalf("expected status unavailable, got %q", body["status"])
+	if body["status"] != "datastore unavailable" {
+		t.Fatalf("expected status 'datastore unavailable', got %q", body["status"])
 	}
 }
 


### PR DESCRIPTION
The `/ready` endpoint previously only checked datastore connectivity,
so Cloud Run routed traffic as soon as the TCP port was listening, well
before providers finished loading from remote OpenAPI specs. Users saw
missing integrations or "Service Unavailable" during the 30-120s loading
window on every cold start.

This introduces a `ReadinessChecker` function type that the server
delegates to from `/ready`. The caller composes the check from whatever
conditions matter (provider readiness, datastore health) without leaking
bootstrap internals into the server. Cloud Run can now use `GET /ready`
as an HTTP startup probe so traffic is held until the instance is
genuinely ready to serve.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>