### PR TITLE
Add MCP OAuth discovery for remote MCP server authentication

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -6,14 +6,20 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
+	"database/sql"
+
 	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/crypto"
+	ci "github.com/valon-technologies/gestalt/core/integration"
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/internal/composite"
 	"github.com/valon-technologies/gestalt/internal/config"
 	graphqlupstream "github.com/valon-technologies/gestalt/internal/graphql"
+	"github.com/valon-technologies/gestalt/internal/mcpoauth"
 	"github.com/valon-technologies/gestalt/internal/mcpupstream"
 	"github.com/valon-technologies/gestalt/internal/openapi"
 	"github.com/valon-technologies/gestalt/internal/provider"
@@ -201,7 +207,11 @@ func shutdownPlugins(ctx context.Context, env *bootstrapEnv) {
 }
 
 func defaultProviderFactory(preparedProviders map[string]string) bootstrap.ProviderFactory {
-	return func(ctx context.Context, name string, intg config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
+	var regStoreOnce sync.Once
+	var regStore mcpoauth.RegistrationStore
+
+	return func(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+		regStoreOnce.Do(func() { regStore = buildRegistrationStore(deps) })
 		var apiProv core.Provider
 		var mcpUp *mcpupstream.Upstream
 
@@ -233,7 +243,13 @@ func defaultProviderFactory(preparedProviders map[string]string) bootstrap.Provi
 					cleanup()
 					return nil, err
 				}
-				p, err := provider.Build(def, intg, map[string]string(us.AllowedOperations))
+				var buildOpts []provider.BuildOption
+				if intg.Auth.Type == "mcp_oauth" {
+					mcpURL := mcpURLFromUpstreams(intg.Upstreams)
+					handler := buildMCPOAuthHandler(mcpURL, intg, regStore, deps)
+					buildOpts = append(buildOpts, provider.WithAuthHandler(handler))
+				}
+				p, err := provider.Build(def, intg, map[string]string(us.AllowedOperations), buildOpts...)
 				if err != nil {
 					cleanup()
 					return nil, err
@@ -267,11 +283,80 @@ func defaultProviderFactory(preparedProviders map[string]string) bootstrap.Provi
 		case apiProv != nil:
 			return apiProv, nil
 		case mcpUp != nil:
+			if intg.Auth.Type == "mcp_oauth" {
+				return buildMCPOAuthProvider(name, intg, mcpUp, regStore, deps)
+			}
 			return mcpUp, nil
 		default:
 			return nil, fmt.Errorf("no upstreams configured")
 		}
 	}
+}
+
+func buildRegistrationStore(deps bootstrap.Deps) mcpoauth.RegistrationStore {
+	db, ok := deps.SQLDB.(*sql.DB)
+	if !ok || db == nil {
+		return nil
+	}
+	dialect, ok := deps.SQLDialect.(mcpoauth.SQLDialect)
+	if !ok || dialect == nil {
+		return nil
+	}
+	enc, err := crypto.NewAESGCM(deps.EncryptionKey)
+	if err != nil {
+		log.Printf("WARNING: mcpoauth: cannot create encryptor for registration store: %v", err)
+		return nil
+	}
+	store := mcpoauth.NewSQLStore(db, enc, dialect)
+	if err := store.Migrate(context.Background()); err != nil {
+		log.Printf("WARNING: mcpoauth: migrating registration store: %v", err)
+	}
+	return store
+}
+
+func buildMCPOAuthHandler(mcpURL string, intg config.IntegrationDef, store mcpoauth.RegistrationStore, deps bootstrap.Deps) *mcpoauth.Handler {
+	redirectURL := intg.RedirectURL
+	if redirectURL == "" {
+		redirectURL = deps.BaseURL + config.IntegrationCallbackPath
+	}
+
+	return mcpoauth.NewHandler(mcpoauth.HandlerConfig{
+		MCPURL:       mcpURL,
+		Store:        store,
+		RedirectURL:  redirectURL,
+		ClientID:     intg.ClientID,
+		ClientSecret: intg.ClientSecret,
+	})
+}
+
+func mcpURLFromUpstreams(upstreams []config.UpstreamDef) string {
+	for _, us := range upstreams {
+		if us.Type == config.UpstreamTypeMCP {
+			return us.URL
+		}
+	}
+	return ""
+}
+
+func buildMCPOAuthProvider(name string, intg config.IntegrationDef, mcpUp *mcpupstream.Upstream, store mcpoauth.RegistrationStore, deps bootstrap.Deps) (core.Provider, error) {
+	mcpURL := mcpURLFromUpstreams(intg.Upstreams)
+	handler := buildMCPOAuthHandler(mcpURL, intg, store, deps)
+
+	connMode := core.ConnectionModeUser
+	if intg.ConnectionMode != "" {
+		connMode = core.ConnectionMode(intg.ConnectionMode)
+	}
+
+	baseProv := &ci.Base{
+		IntegrationName:    name,
+		IntegrationDisplay: intg.DisplayName,
+		IntegrationDesc:    intg.Description,
+		ConnMode:           connMode,
+		Auth:               handler,
+		ManualAuthEnabled:  true,
+	}
+
+	return composite.New(name, baseProv, mcpUp), nil
 }
 
 func loadAPIUpstream(ctx context.Context, name string, us config.UpstreamDef, preparedProviders map[string]string) (*provider.Definition, error) {

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -21,6 +21,8 @@ type Deps struct {
 	EncryptionKey []byte
 	BaseURL       string
 	SecretManager core.SecretManager
+	SQLDB         any // *sql.DB when available, nil otherwise
+	SQLDialect    any // Placeholder(int)string when available, nil otherwise
 }
 
 type AuthFactory func(node yaml.Node, deps Deps) (core.AuthProvider, error)
@@ -107,6 +109,17 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	ds, err := buildDatastore(cfg, factories, deps)
 	if err != nil {
 		return nil, err
+	}
+
+	// Expose the underlying *sql.DB and dialect for optional use by
+	// provider factories (e.g. MCP OAuth registration storage).
+	type sqlDBAccessor interface{ RawDB() any }
+	type sqlDialectAccessor interface{ RawDialect() any }
+	if acc, ok := ds.(sqlDBAccessor); ok {
+		deps.SQLDB = acc.RawDB()
+	}
+	if acc, ok := ds.(sqlDialectAccessor); ok {
+		deps.SQLDialect = acc.RawDialect()
 	}
 
 	providers, providersReady, err := buildProviders(ctx, cfg, factories, deps)

--- a/internal/composite/provider.go
+++ b/internal/composite/provider.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
+	"github.com/valon-technologies/gestalt/internal/oauth"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 )
@@ -119,6 +120,62 @@ func (o *oauthProvider) ExchangeCode(ctx context.Context, code string) (*core.To
 
 func (o *oauthProvider) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
 	return o.oauth.RefreshToken(ctx, refreshToken)
+}
+
+func (o *oauthProvider) RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error) {
+	type refresher interface {
+		RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error)
+	}
+	if rw, ok := o.oauth.(refresher); ok {
+		return rw.RefreshTokenWithURL(ctx, refreshToken, tokenURL)
+	}
+	return o.oauth.RefreshToken(ctx, refreshToken)
+}
+
+func (o *oauthProvider) StartOAuth(state string, scopes []string) (string, string) {
+	type starter interface {
+		StartOAuth(state string, scopes []string) (string, string)
+	}
+	if s, ok := o.oauth.(starter); ok {
+		return s.StartOAuth(state, scopes)
+	}
+	return o.oauth.AuthorizationURL(state, scopes), ""
+}
+
+func (o *oauthProvider) StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string) {
+	type overrider interface {
+		StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string)
+	}
+	if ov, ok := o.oauth.(overrider); ok {
+		return ov.StartOAuthWithOverride(authBaseURL, state, scopes)
+	}
+	return o.oauth.AuthorizationURL(state, scopes), ""
+}
+
+func (o *oauthProvider) AuthorizationBaseURL() string {
+	type authBaseURLer interface{ AuthorizationBaseURL() string }
+	if abu, ok := o.oauth.(authBaseURLer); ok {
+		return abu.AuthorizationBaseURL()
+	}
+	return ""
+}
+
+func (o *oauthProvider) TokenURL() string {
+	type tokenURLer interface{ TokenURL() string }
+	if tu, ok := o.oauth.(tokenURLer); ok {
+		return tu.TokenURL()
+	}
+	return ""
+}
+
+func (o *oauthProvider) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error) {
+	type exchanger interface {
+		ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
+	}
+	if e, ok := o.oauth.(exchanger); ok {
+		return e.ExchangeCodeWithVerifier(ctx, code, verifier, extraOpts...)
+	}
+	return o.oauth.ExchangeCode(ctx, code)
 }
 
 func (p *Provider) buildCatalog() *catalog.Catalog {

--- a/internal/mcpoauth/discovery.go
+++ b/internal/mcpoauth/discovery.go
@@ -1,0 +1,265 @@
+package mcpoauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const discoveryTimeout = 10 * time.Second
+
+type DiscoveredMetadata struct {
+	AuthServerURL                 string
+	AuthorizationEndpoint         string
+	TokenEndpoint                 string
+	RegistrationEndpoint          string
+	ScopesSupported               []string
+	CodeChallengeMethodsSupported []string
+	TokenEndpointAuthMethods      []string
+}
+
+// SupportsPKCE returns true if S256 is in the advertised code challenge methods,
+// or if no methods are advertised (MCP OAuth 2.1 mandates S256).
+func (m *DiscoveredMetadata) SupportsPKCE() bool {
+	if len(m.CodeChallengeMethodsSupported) == 0 {
+		return true
+	}
+	for _, method := range m.CodeChallengeMethodsSupported {
+		if method == "S256" {
+			return true
+		}
+	}
+	return false
+}
+
+// PreferredAuthMethod selects the best client auth method from the advertised
+// token endpoint auth methods. Prefers "none" (public client), then
+// "client_secret_post", then "client_secret_basic".
+func (m *DiscoveredMetadata) PreferredAuthMethod() string {
+	if len(m.TokenEndpointAuthMethods) == 0 {
+		return "none"
+	}
+	methods := make(map[string]bool, len(m.TokenEndpointAuthMethods))
+	for _, method := range m.TokenEndpointAuthMethods {
+		methods[method] = true
+	}
+	if methods["none"] {
+		return "none"
+	}
+	if methods["client_secret_post"] {
+		return "client_secret_post"
+	}
+	if methods["client_secret_basic"] {
+		return "client_secret_basic"
+	}
+	return m.TokenEndpointAuthMethods[0]
+}
+
+// Discover probes an MCP server to find its OAuth endpoints. Handles both
+// RFC 9728 indirection (authorization_servers) and servers that embed
+// endpoints directly in resource metadata (ClickHouse).
+func Discover(ctx context.Context, mcpURL string) (*DiscoveredMetadata, error) {
+	client := &http.Client{Timeout: discoveryTimeout}
+
+	resourceMetadataURL, err := probeForResourceMetadata(ctx, client, mcpURL)
+	if err != nil {
+		return nil, fmt.Errorf("mcpoauth discovery: probing %s: %w", mcpURL, err)
+	}
+
+	resourceMeta, err := fetchJSON(ctx, client, resourceMetadataURL)
+	if err != nil {
+		return nil, fmt.Errorf("mcpoauth discovery: fetching resource metadata from %s: %w", resourceMetadataURL, err)
+	}
+
+	return resolveMetadata(ctx, client, resourceMeta)
+}
+
+// probeForResourceMetadata sends an unauthenticated request to the MCP URL and
+// looks for a resource_metadata URL in the WWW-Authenticate header. Falls back
+// to constructing the .well-known URL from the MCP URL's origin.
+func probeForResourceMetadata(ctx context.Context, client *http.Client, mcpURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, mcpURL, strings.NewReader(`{"jsonrpc":"2.0","method":"initialize","id":1}`))
+	if err != nil {
+		return "", fmt.Errorf("creating probe request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("sending probe request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		if metaURL := parseResourceMetadataFromWWWAuth(resp.Header.Get("WWW-Authenticate")); metaURL != "" {
+			return metaURL, nil
+		}
+	}
+
+	return wellKnownResourceMetadataURL(mcpURL)
+}
+
+func parseResourceMetadataFromWWWAuth(header string) string {
+	if header == "" {
+		return ""
+	}
+	header = strings.TrimPrefix(header, "Bearer ")
+	for _, part := range strings.Split(header, ",") {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, "resource_metadata=") {
+			val := strings.TrimPrefix(part, "resource_metadata=")
+			val = strings.Trim(val, `"`)
+			return val
+		}
+	}
+	return ""
+}
+
+func wellKnownResourceMetadataURL(mcpURL string) (string, error) {
+	u, err := url.Parse(mcpURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing MCP URL: %w", err)
+	}
+	// RFC 9728 §3: /.well-known/oauth-protected-resource/<path>
+	wellKnown := &url.URL{
+		Scheme: u.Scheme,
+		Host:   u.Host,
+		Path:   "/.well-known/oauth-protected-resource" + u.Path,
+	}
+	return wellKnown.String(), nil
+}
+
+func resolveMetadata(ctx context.Context, client *http.Client, resourceMeta map[string]any) (*DiscoveredMetadata, error) {
+	md := &DiscoveredMetadata{}
+
+	// Try RFC 9728 indirection: authorization_servers -> AS metadata
+	if servers, ok := resourceMeta["authorization_servers"].([]any); ok && len(servers) > 0 {
+		serverURL, _ := servers[0].(string)
+		if serverURL != "" {
+			md.AuthServerURL = serverURL
+			asMeta, err := fetchASMetadata(ctx, client, serverURL)
+			if err != nil {
+				return nil, fmt.Errorf("fetching AS metadata from %s: %w", serverURL, err)
+			}
+			populateFromASMetadata(md, asMeta)
+		}
+	}
+
+	// Direct endpoint embedding (ClickHouse compat): resource metadata
+	// directly contains authorization_endpoint, token_endpoint, etc.
+	if md.AuthorizationEndpoint == "" {
+		if v, ok := resourceMeta["authorization_endpoint"].(string); ok {
+			md.AuthorizationEndpoint = v
+		}
+	}
+	if md.TokenEndpoint == "" {
+		if v, ok := resourceMeta["token_endpoint"].(string); ok {
+			md.TokenEndpoint = v
+		}
+	}
+	if md.RegistrationEndpoint == "" {
+		if v, ok := resourceMeta["registration_endpoint"].(string); ok {
+			md.RegistrationEndpoint = v
+		}
+	}
+	if len(md.ScopesSupported) == 0 {
+		md.ScopesSupported = stringSlice(resourceMeta, "scopes_supported")
+	}
+	if len(md.CodeChallengeMethodsSupported) == 0 {
+		md.CodeChallengeMethodsSupported = stringSlice(resourceMeta, "code_challenge_methods_supported")
+	}
+	if len(md.TokenEndpointAuthMethods) == 0 {
+		md.TokenEndpointAuthMethods = stringSlice(resourceMeta, "token_endpoint_auth_methods_supported")
+	}
+
+	if md.AuthorizationEndpoint == "" || md.TokenEndpoint == "" {
+		return nil, fmt.Errorf("discovery did not find authorization_endpoint and token_endpoint")
+	}
+
+	// Derive AuthServerURL from the authorization endpoint origin when not
+	// set via the authorization_servers field (ClickHouse compat path).
+	if md.AuthServerURL == "" {
+		if u, err := url.Parse(md.AuthorizationEndpoint); err == nil {
+			md.AuthServerURL = u.Scheme + "://" + u.Host
+		}
+	}
+
+	return md, nil
+}
+
+func fetchASMetadata(ctx context.Context, client *http.Client, serverURL string) (map[string]any, error) {
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing AS URL: %w", err)
+	}
+	// RFC 8414 §3: /.well-known/oauth-authorization-server/<path>
+	wellKnown := &url.URL{
+		Scheme: u.Scheme,
+		Host:   u.Host,
+		Path:   "/.well-known/oauth-authorization-server" + u.Path,
+	}
+	return fetchJSON(ctx, client, wellKnown.String())
+}
+
+func populateFromASMetadata(md *DiscoveredMetadata, asMeta map[string]any) {
+	if v, ok := asMeta["authorization_endpoint"].(string); ok {
+		md.AuthorizationEndpoint = v
+	}
+	if v, ok := asMeta["token_endpoint"].(string); ok {
+		md.TokenEndpoint = v
+	}
+	if v, ok := asMeta["registration_endpoint"].(string); ok {
+		md.RegistrationEndpoint = v
+	}
+	md.ScopesSupported = stringSlice(asMeta, "scopes_supported")
+	md.CodeChallengeMethodsSupported = stringSlice(asMeta, "code_challenge_methods_supported")
+	md.TokenEndpointAuthMethods = stringSlice(asMeta, "token_endpoint_auth_methods_supported")
+}
+
+func fetchJSON(ctx context.Context, client *http.Client, rawURL string) (map[string]any, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request for %s: %w", rawURL, err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching %s: %w", rawURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response from %s: %w", rawURL, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s returned %d: %s", rawURL, resp.StatusCode, body)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decoding JSON from %s: %w", rawURL, err)
+	}
+	return result, nil
+}
+
+func stringSlice(m map[string]any, key string) []string {
+	arr, ok := m[key].([]any)
+	if !ok {
+		return nil
+	}
+	result := make([]string, 0, len(arr))
+	for _, v := range arr {
+		if s, ok := v.(string); ok {
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/internal/mcpoauth/handler.go
+++ b/internal/mcpoauth/handler.go
@@ -1,0 +1,237 @@
+package mcpoauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/oauth"
+)
+
+const discoveryCacheTTL = 24 * time.Hour
+
+type HandlerConfig struct {
+	MCPURL      string
+	Store       RegistrationStore // nil for non-SQL deployments
+	RedirectURL string
+
+	// Static overrides: if set, skip DCR and use these directly.
+	ClientID     string
+	ClientSecret string
+}
+
+type Handler struct {
+	cfg HandlerConfig
+
+	mu           sync.Mutex
+	upstream     *oauth.UpstreamHandler
+	metadata     *DiscoveredMetadata
+	discoveredAt time.Time
+}
+
+func NewHandler(cfg HandlerConfig) *Handler {
+	return &Handler{cfg: cfg}
+}
+
+func (h *Handler) IsManual() bool { return false }
+
+func (h *Handler) ensure() (*oauth.UpstreamHandler, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.upstream != nil && time.Since(h.discoveredAt) < discoveryCacheTTL {
+		return h.upstream, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	md, err := Discover(ctx, h.cfg.MCPURL)
+	if err != nil {
+		if h.upstream != nil {
+			return h.upstream, nil
+		}
+		return nil, fmt.Errorf("mcp oauth discovery failed for %s: %w", h.cfg.MCPURL, err)
+	}
+
+	clientID := h.cfg.ClientID
+	clientSecret := h.cfg.ClientSecret
+
+	if clientID == "" {
+		reg, err := h.resolveRegistration(ctx, md)
+		if err != nil {
+			if h.upstream != nil {
+				return h.upstream, nil
+			}
+			return nil, err
+		}
+		if reg != nil {
+			clientID = reg.ClientID
+			clientSecret = reg.ClientSecret
+		}
+	}
+
+	if clientID == "" {
+		if h.upstream != nil {
+			return h.upstream, nil
+		}
+		return nil, fmt.Errorf("mcp oauth: no client_id available for %s (no static config and DCR failed or unavailable)", h.cfg.MCPURL)
+	}
+
+	authMethod := oauth.ClientAuthNone
+	switch md.PreferredAuthMethod() {
+	case "client_secret_post":
+		authMethod = oauth.ClientAuthBody
+	case "client_secret_basic":
+		authMethod = oauth.ClientAuthHeader
+	}
+
+	// If a client secret is available but the selected auth method would
+	// not send it, upgrade to client_secret_post so the secret is included
+	// in token exchange requests.
+	if clientSecret != "" && authMethod == oauth.ClientAuthNone {
+		authMethod = oauth.ClientAuthBody
+	}
+
+	upstream := oauth.NewUpstream(oauth.UpstreamConfig{
+		ClientID:         clientID,
+		ClientSecret:     clientSecret,
+		AuthorizationURL: md.AuthorizationEndpoint,
+		TokenURL:         md.TokenEndpoint,
+		RedirectURL:      h.cfg.RedirectURL,
+		ClientAuthMethod: authMethod,
+		PKCE:             md.SupportsPKCE(),
+		DefaultScopes:    md.ScopesSupported,
+	})
+
+	h.upstream = upstream
+	h.metadata = md
+	h.discoveredAt = time.Now()
+	return upstream, nil
+}
+
+func (h *Handler) resolveRegistration(ctx context.Context, md *DiscoveredMetadata) (*Registration, error) {
+	if h.cfg.Store == nil {
+		return nil, nil
+	}
+
+	authServerURL := md.AuthServerURL
+	existing, err := h.cfg.Store.GetRegistration(ctx, authServerURL, h.cfg.RedirectURL)
+	if err != nil {
+		log.Printf("WARNING: mcpoauth: reading registration for %s: %v", authServerURL, err)
+	}
+	if existing != nil {
+		return existing, nil
+	}
+
+	if md.RegistrationEndpoint == "" {
+		return nil, nil
+	}
+
+	reg, err := RegisterClient(ctx, md.RegistrationEndpoint, h.cfg.RedirectURL, "Gestalt", md.PreferredAuthMethod())
+	if err != nil {
+		return nil, fmt.Errorf("mcp oauth DCR for %s: %w", h.cfg.MCPURL, err)
+	}
+
+	reg.AuthServerURL = authServerURL
+	reg.RedirectURI = h.cfg.RedirectURL
+	reg.AuthorizationEndpoint = md.AuthorizationEndpoint
+	reg.TokenEndpoint = md.TokenEndpoint
+
+	if scopesJSON, err := json.Marshal(md.ScopesSupported); err == nil {
+		reg.ScopesSupported = string(scopesJSON)
+	}
+
+	if err := h.cfg.Store.StoreRegistration(ctx, reg); err != nil {
+		log.Printf("WARNING: mcpoauth: storing registration for %s: %v", authServerURL, err)
+	}
+
+	return reg, nil
+}
+
+// AuthorizationURL discards the PKCE verifier. Use StartOAuth when the
+// verifier is needed for code exchange.
+func (h *Handler) AuthorizationURL(state string, scopes []string) string {
+	upstream, err := h.ensure()
+	if err != nil {
+		log.Printf("ERROR: mcpoauth: ensure failed in AuthorizationURL: %v", err)
+		return ""
+	}
+	authURL, _ := upstream.AuthorizationURLWithPKCE(state, scopes)
+	return authURL
+}
+
+func (h *Handler) StartOAuth(state string, scopes []string) (string, string) {
+	upstream, err := h.ensure()
+	if err != nil {
+		log.Printf("ERROR: mcpoauth: ensure failed in StartOAuth: %v", err)
+		return "", ""
+	}
+	return upstream.AuthorizationURLWithPKCE(state, scopes)
+}
+
+func (h *Handler) StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string) {
+	upstream, err := h.ensure()
+	if err != nil {
+		log.Printf("ERROR: mcpoauth: ensure failed in StartOAuthWithOverride: %v", err)
+		return "", ""
+	}
+	return upstream.AuthorizationURLWithOverride(authBaseURL, state, scopes)
+}
+
+func (h *Handler) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	upstream, err := h.ensure()
+	if err != nil {
+		return nil, err
+	}
+	return upstream.ExchangeCode(ctx, code)
+}
+
+func (h *Handler) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error) {
+	upstream, err := h.ensure()
+	if err != nil {
+		return nil, err
+	}
+	var opts []oauth.ExchangeOption
+	if verifier != "" {
+		opts = append(opts, oauth.WithPKCEVerifier(verifier))
+	}
+	opts = append(opts, extraOpts...)
+	return upstream.ExchangeCode(ctx, code, opts...)
+}
+
+func (h *Handler) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	upstream, err := h.ensure()
+	if err != nil {
+		return nil, err
+	}
+	return upstream.RefreshToken(ctx, refreshToken)
+}
+
+func (h *Handler) RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error) {
+	upstream, err := h.ensure()
+	if err != nil {
+		return nil, err
+	}
+	return upstream.RefreshTokenWithURL(ctx, refreshToken, tokenURL)
+}
+
+func (h *Handler) TokenURL() string {
+	upstream, err := h.ensure()
+	if err != nil {
+		return ""
+	}
+	return upstream.TokenURL()
+}
+
+func (h *Handler) AuthorizationBaseURL() string {
+	upstream, err := h.ensure()
+	if err != nil {
+		return ""
+	}
+	return upstream.AuthorizationBaseURL()
+}

--- a/internal/mcpoauth/registration.go
+++ b/internal/mcpoauth/registration.go
@@ -1,0 +1,79 @@
+package mcpoauth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+type Registration struct {
+	AuthServerURL         string
+	RedirectURI           string
+	ClientID              string
+	ClientSecret          string // empty for public clients
+	AuthorizationEndpoint string
+	TokenEndpoint         string
+	ScopesSupported       string // JSON array
+	DiscoveredAt          time.Time
+}
+
+func RegisterClient(ctx context.Context, endpoint, redirectURI, clientName, tokenAuthMethod string) (*Registration, error) {
+	if tokenAuthMethod == "" {
+		tokenAuthMethod = "none"
+	}
+	reqBody := map[string]any{
+		"client_name":                clientName,
+		"redirect_uris":              []string{redirectURI},
+		"grant_types":                []string{"authorization_code", "refresh_token"},
+		"response_types":             []string{"code"},
+		"token_endpoint_auth_method": tokenAuthMethod,
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("encoding DCR request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating DCR request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: discoveryTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending DCR request to %s: %w", endpoint, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading DCR response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("DCR endpoint %s returned %d: %s", endpoint, resp.StatusCode, respBody)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("decoding DCR response: %w", err)
+	}
+
+	clientID, _ := result["client_id"].(string)
+	if clientID == "" {
+		return nil, fmt.Errorf("DCR response missing client_id")
+	}
+	clientSecret, _ := result["client_secret"].(string)
+
+	return &Registration{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		DiscoveredAt: time.Now(),
+	}, nil
+}

--- a/internal/mcpoauth/sqlstore.go
+++ b/internal/mcpoauth/sqlstore.go
@@ -1,0 +1,150 @@
+package mcpoauth
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/core/crypto"
+)
+
+// SQLDialect abstracts database-specific SQL syntax. Matches the subset of
+// sqlstore.Dialect needed for registration storage.
+type SQLDialect interface {
+	Placeholder(n int) string
+}
+
+// RegistrationDDLProvider is an optional interface that SQLDialect
+// implementations can satisfy to provide database-specific DDL for the
+// oauth_registrations table. When not implemented, Migrate uses generic DDL
+// compatible with MySQL, PostgreSQL, and SQLite.
+type RegistrationDDLProvider interface {
+	RegistrationDDL() string
+}
+
+type SQLStore struct {
+	db      *sql.DB
+	enc     *crypto.AESGCMEncryptor
+	dialect SQLDialect
+}
+
+func NewSQLStore(db *sql.DB, enc *crypto.AESGCMEncryptor, dialect SQLDialect) *SQLStore {
+	return &SQLStore{db: db, enc: enc, dialect: dialect}
+}
+
+func (s *SQLStore) ph(n int) string { return s.dialect.Placeholder(n) }
+
+const defaultRegistrationDDL = `CREATE TABLE IF NOT EXISTS oauth_registrations (
+	id VARCHAR(36) PRIMARY KEY,
+	auth_server_url VARCHAR(500) NOT NULL,
+	redirect_uri VARCHAR(500) NOT NULL,
+	client_id VARCHAR(255) NOT NULL,
+	client_secret_encrypted TEXT,
+	authorization_endpoint VARCHAR(500) NOT NULL,
+	token_endpoint VARCHAR(500) NOT NULL,
+	scopes_supported TEXT,
+	discovered_at DATETIME NOT NULL,
+	created_at DATETIME NOT NULL,
+	updated_at DATETIME NOT NULL,
+	UNIQUE (auth_server_url, redirect_uri)
+)`
+
+func (s *SQLStore) Migrate(ctx context.Context) error {
+	ddl := defaultRegistrationDDL
+	if p, ok := s.dialect.(RegistrationDDLProvider); ok {
+		ddl = p.RegistrationDDL()
+	}
+	_, err := s.db.ExecContext(ctx, ddl)
+	return err
+}
+
+func (s *SQLStore) GetRegistration(ctx context.Context, authServerURL, redirectURI string) (*Registration, error) {
+	query := `SELECT id, auth_server_url, redirect_uri, client_id, client_secret_encrypted,
+	       authorization_endpoint, token_endpoint, scopes_supported, discovered_at
+	FROM oauth_registrations
+	WHERE auth_server_url = ` + s.ph(1) + ` AND redirect_uri = ` + s.ph(2)
+
+	row := s.db.QueryRowContext(ctx, query, authServerURL, redirectURI)
+
+	var reg Registration
+	var secretEnc sql.NullString
+	var scopes sql.NullString
+	var id string
+	err := row.Scan(&id, &reg.AuthServerURL, &reg.RedirectURI, &reg.ClientID,
+		&secretEnc, &reg.AuthorizationEndpoint, &reg.TokenEndpoint,
+		&scopes, &reg.DiscoveredAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying registration: %w", err)
+	}
+
+	if secretEnc.String != "" {
+		decrypted, err := s.enc.Decrypt(secretEnc.String)
+		if err != nil {
+			return nil, fmt.Errorf("decrypting client_secret: %w", err)
+		}
+		reg.ClientSecret = decrypted
+	}
+	reg.ScopesSupported = scopes.String
+
+	return &reg, nil
+}
+
+func (s *SQLStore) StoreRegistration(ctx context.Context, reg *Registration) error {
+	var secretEnc sql.NullString
+	if reg.ClientSecret != "" {
+		encrypted, err := s.enc.Encrypt(reg.ClientSecret)
+		if err != nil {
+			return fmt.Errorf("encrypting client_secret: %w", err)
+		}
+		secretEnc = sql.NullString{String: encrypted, Valid: true}
+	}
+
+	now := time.Now()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Try UPDATE first, then INSERT if no rows affected. This avoids
+	// database-specific upsert syntax (ON DUPLICATE KEY / ON CONFLICT).
+	res, err := tx.ExecContext(ctx, `UPDATE oauth_registrations SET
+		client_id = `+s.ph(1)+`,
+		client_secret_encrypted = `+s.ph(2)+`,
+		authorization_endpoint = `+s.ph(3)+`,
+		token_endpoint = `+s.ph(4)+`,
+		scopes_supported = `+s.ph(5)+`,
+		discovered_at = `+s.ph(6)+`,
+		updated_at = `+s.ph(7)+`
+		WHERE auth_server_url = `+s.ph(8)+` AND redirect_uri = `+s.ph(9),
+		reg.ClientID, secretEnc, reg.AuthorizationEndpoint, reg.TokenEndpoint,
+		reg.ScopesSupported, reg.DiscoveredAt, now,
+		reg.AuthServerURL, reg.RedirectURI,
+	)
+	if err != nil {
+		return fmt.Errorf("updating registration: %w", err)
+	}
+
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		_, err = tx.ExecContext(ctx, `INSERT INTO oauth_registrations
+			(id, auth_server_url, redirect_uri, client_id, client_secret_encrypted,
+			 authorization_endpoint, token_endpoint, scopes_supported, discovered_at, created_at, updated_at)
+			VALUES (`+s.ph(1)+`, `+s.ph(2)+`, `+s.ph(3)+`, `+s.ph(4)+`, `+s.ph(5)+`, `+s.ph(6)+`, `+s.ph(7)+`, `+s.ph(8)+`, `+s.ph(9)+`, `+s.ph(10)+`, `+s.ph(11)+`)`,
+			uuid.NewString(), reg.AuthServerURL, reg.RedirectURI, reg.ClientID,
+			secretEnc, reg.AuthorizationEndpoint, reg.TokenEndpoint,
+			reg.ScopesSupported, reg.DiscoveredAt, now, now,
+		)
+		if err != nil {
+			return fmt.Errorf("inserting registration: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}

--- a/internal/mcpoauth/store.go
+++ b/internal/mcpoauth/store.go
@@ -1,0 +1,10 @@
+package mcpoauth
+
+import "context"
+
+// Keyed by (auth server URL, redirect URI) since the same auth server may
+// issue different credentials for different redirect URIs.
+type RegistrationStore interface {
+	GetRegistration(ctx context.Context, authServerURL, redirectURI string) (*Registration, error)
+	StoreRegistration(ctx context.Context, reg *Registration) error
+}

--- a/internal/oauth/upstream.go
+++ b/internal/oauth/upstream.go
@@ -26,6 +26,7 @@ type ClientAuthMethod int
 const (
 	ClientAuthBody ClientAuthMethod = iota
 	ClientAuthHeader
+	ClientAuthNone
 )
 
 type TokenExchangeFormat string
@@ -176,9 +177,12 @@ func (h *UpstreamHandler) ExchangeCode(ctx context.Context, code string, opts ..
 		"redirect_uri": {h.cfg.RedirectURL},
 	}
 
-	if h.cfg.ClientAuthMethod == ClientAuthBody {
+	switch h.cfg.ClientAuthMethod {
+	case ClientAuthBody:
 		data.Set("client_id", h.cfg.ClientID)
 		data.Set("client_secret", h.cfg.ClientSecret)
+	case ClientAuthNone:
+		data.Set("client_id", h.cfg.ClientID)
 	}
 
 	if eo.verifier != "" {
@@ -202,9 +206,12 @@ func (h *UpstreamHandler) RefreshTokenWithURL(ctx context.Context, refreshToken,
 		"refresh_token": {refreshToken},
 	}
 
-	if h.cfg.ClientAuthMethod == ClientAuthBody {
+	switch h.cfg.ClientAuthMethod {
+	case ClientAuthBody:
 		data.Set("client_id", h.cfg.ClientID)
 		data.Set("client_secret", h.cfg.ClientSecret)
+	case ClientAuthNone:
+		data.Set("client_id", h.cfg.ClientID)
 	}
 
 	for k, v := range h.cfg.RefreshParams {
@@ -251,9 +258,11 @@ func (h *UpstreamHandler) tokenRequest(ctx context.Context, data url.Values, tok
 		req.Header.Set("Accept", h.cfg.AcceptHeader)
 	}
 
-	if h.cfg.ClientAuthMethod == ClientAuthHeader {
+	switch h.cfg.ClientAuthMethod {
+	case ClientAuthHeader:
 		// RFC 6749 §2.3.1: URL-encode client credentials before base64.
 		req.SetBasicAuth(url.QueryEscape(h.cfg.ClientID), url.QueryEscape(h.cfg.ClientSecret))
+	case ClientAuthNone:
 	}
 
 	resp, err := h.httpClient.Do(req)

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -17,7 +17,24 @@ import (
 	"github.com/valon-technologies/gestalt/internal/oauth"
 )
 
-func Build(def *Definition, intg config.IntegrationDef, allowedOperations map[string]string) (core.Provider, error) {
+// BuildOption configures optional aspects of provider construction.
+type BuildOption func(*buildOptions)
+
+type buildOptions struct {
+	authOverride ci.AuthHandler
+}
+
+// WithAuthHandler injects a pre-built auth handler, bypassing buildAuth.
+func WithAuthHandler(h ci.AuthHandler) BuildOption {
+	return func(o *buildOptions) { o.authOverride = h }
+}
+
+func Build(def *Definition, intg config.IntegrationDef, allowedOperations map[string]string, opts ...BuildOption) (core.Provider, error) {
+	var bo buildOptions
+	for _, opt := range opts {
+		opt(&bo)
+	}
+
 	d := *def // shallow copy so we don't mutate the caller's definition
 	def = &d
 	if err := ApplyIntegrationOverrides(def, intg); err != nil {
@@ -31,7 +48,13 @@ func Build(def *Definition, intg config.IntegrationDef, allowedOperations map[st
 
 	client := &http.Client{Timeout: 10 * time.Second}
 
-	auth, err := buildAuth(def, intg, baseURL, client)
+	var auth ci.AuthHandler
+	var err error
+	if bo.authOverride != nil {
+		auth = bo.authOverride
+	} else {
+		auth, err = buildAuth(def, intg, baseURL, client)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", def.Provider, err)
 	}

--- a/plugins/datastore/oracle/oracle.go
+++ b/plugins/datastore/oracle/oracle.go
@@ -41,6 +41,30 @@ VALUES (src.id, src.user_id, src.integration, src.instance, src.access_token_enc
         src.refresh_error_count, src.metadata_json, src.created_at, src.updated_at)`
 }
 
+func (dialect) RegistrationDDL() string {
+	return `DECLARE
+		v_count NUMBER;
+	BEGIN
+		SELECT COUNT(*) INTO v_count FROM user_tables WHERE table_name = 'OAUTH_REGISTRATIONS';
+		IF v_count = 0 THEN
+			EXECUTE IMMEDIATE 'CREATE TABLE oauth_registrations (
+				id VARCHAR2(36) PRIMARY KEY,
+				auth_server_url VARCHAR2(500) NOT NULL,
+				redirect_uri VARCHAR2(500) NOT NULL,
+				client_id VARCHAR2(255) NOT NULL,
+				client_secret_encrypted CLOB,
+				authorization_endpoint VARCHAR2(500) NOT NULL,
+				token_endpoint VARCHAR2(500) NOT NULL,
+				scopes_supported CLOB,
+				discovered_at TIMESTAMP WITH TIME ZONE NOT NULL,
+				created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+				updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+				UNIQUE (auth_server_url, redirect_uri)
+			)';
+		END IF;
+	END;`
+}
+
 func (dialect) IsDuplicateKeyError(err error) bool {
 	if err == nil {
 		return false

--- a/plugins/datastore/postgres/postgres.go
+++ b/plugins/datastore/postgres/postgres.go
@@ -34,6 +34,23 @@ func (dialect) UpsertTokenSQL() string {
 			updated_at = EXCLUDED.updated_at`
 }
 
+func (dialect) RegistrationDDL() string {
+	return `CREATE TABLE IF NOT EXISTS oauth_registrations (
+		id TEXT PRIMARY KEY,
+		auth_server_url TEXT NOT NULL,
+		redirect_uri TEXT NOT NULL,
+		client_id TEXT NOT NULL,
+		client_secret_encrypted TEXT,
+		authorization_endpoint TEXT NOT NULL,
+		token_endpoint TEXT NOT NULL,
+		scopes_supported TEXT,
+		discovered_at TIMESTAMPTZ NOT NULL,
+		created_at TIMESTAMPTZ NOT NULL,
+		updated_at TIMESTAMPTZ NOT NULL,
+		UNIQUE (auth_server_url, redirect_uri)
+	)`
+}
+
 func (dialect) IsDuplicateKeyError(err error) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) && pgErr.Code == "23505"

--- a/plugins/datastore/sqlserver/sqlserver.go
+++ b/plugins/datastore/sqlserver/sqlserver.go
@@ -45,6 +45,24 @@ func (dialect) UpsertTokenSQL() string {
 				src.refresh_error_count, src.metadata_json, src.created_at, src.updated_at);`
 }
 
+func (dialect) RegistrationDDL() string {
+	return `IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'oauth_registrations')
+		CREATE TABLE oauth_registrations (
+			id NVARCHAR(36) NOT NULL PRIMARY KEY,
+			auth_server_url NVARCHAR(500) NOT NULL,
+			redirect_uri NVARCHAR(500) NOT NULL,
+			client_id NVARCHAR(255) NOT NULL,
+			client_secret_encrypted NVARCHAR(MAX),
+			authorization_endpoint NVARCHAR(500) NOT NULL,
+			token_endpoint NVARCHAR(500) NOT NULL,
+			scopes_supported NVARCHAR(MAX),
+			discovered_at DATETIME2(6) NOT NULL,
+			created_at DATETIME2(6) NOT NULL,
+			updated_at DATETIME2(6) NOT NULL,
+			UNIQUE(auth_server_url, redirect_uri)
+		)`
+}
+
 func (dialect) IsDuplicateKeyError(err error) bool {
 	var mssqlErr *mssql.Error
 	if errors.As(err, &mssqlErr) {

--- a/plugins/datastore/sqlstore/sqlstore.go
+++ b/plugins/datastore/sqlstore/sqlstore.go
@@ -48,6 +48,14 @@ func New(db *sql.DB, enc *crypto.AESGCMEncryptor, dialect Dialect) *Store {
 	return &Store{DB: db, Enc: enc, Dialect: dialect}
 }
 
+// RawDB exposes the underlying *sql.DB for optional use by subsystems that
+// manage their own tables (e.g. MCP OAuth registration storage).
+func (s *Store) RawDB() any { return s.DB }
+
+// RawDialect exposes the Dialect for subsystems that need cross-database
+// compatible SQL generation.
+func (s *Store) RawDialect() any { return s.Dialect }
+
 // Ping verifies the database connection is alive.
 func (s *Store) Ping(ctx context.Context) error {
 	return s.DB.PingContext(ctx)


### PR DESCRIPTION
Integrations backed by remote MCP servers (like ClickHouse and Linear) support the MCP spec's OAuth 2.1 discovery flow, where the server advertises its OAuth endpoints via RFC 9728 metadata. This adds a new `mcp_oauth` auth type that discovers those endpoints automatically, performs Dynamic Client Registration when available, and runs a standard PKCE authorization code flow so users authenticate via browser redirect instead of pasting tokens.

The discovery algorithm is tolerant of real-world variance: it handles both the strict RFC 9728 flow (Linear, which returns a `WWW-Authenticate` challenge and publishes `authorization_servers` indirection) and servers that embed endpoints directly in their resource metadata (ClickHouse). Public-client OAuth (`token_endpoint_auth_method: none`) is now supported for servers that do not require a client secret. The composite provider's OAuth interface forwarding is also fixed to pass through all optional methods the server handlers rely on.