### PR TITLE
Use httpOnly cookies for session tokens

### DIFF
--- a/client/cli/src/commands/auth.rs
+++ b/client/cli/src/commands/auth.rs
@@ -111,18 +111,21 @@ pub fn login(url_override: Option<&str>) -> Result<()> {
         );
     }
 
-    let callback_body: serde_json::Value = callback_resp
-        .json()
-        .context("failed to parse callback response")?;
-
-    let token = callback_body["token"]
-        .as_str()
-        .context("callback response missing 'token' field")?;
+    let token = callback_resp
+        .headers()
+        .get_all("set-cookie")
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .find_map(|v| {
+            v.strip_prefix("session_token=")
+                .map(|rest| rest.split(';').next().unwrap_or(rest).to_string())
+        })
+        .context("callback response missing session cookie")?;
 
     let store = CredentialStore::new()?;
     store.save(&Credentials {
         api_url: base_url,
-        session_token: token.to_string(),
+        session_token: token,
     })?;
 
     let _ = send_browser_response(&stream, "Login successful! You can close this tab.");

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -27,6 +27,9 @@ const defaultTokenInstance = "default"
 const cliStatePrefix = "cli:"
 const maxPort = 65535
 
+const sessionCookieName = "session_token"
+const defaultSessionCookieTTL = 24 * time.Hour
+
 func (s *Server) resolveUserID(w http.ResponseWriter, r *http.Request) (string, bool) {
 	user := UserFromContext(r.Context())
 	if user == nil || user.Email == "" {
@@ -394,6 +397,40 @@ type SessionTokenIssuer interface {
 	IssueSessionToken(identity *core.UserIdentity) (string, error)
 }
 
+// SessionTokenTTLProvider is an optional interface that auth providers can
+// implement to expose their configured session TTL for cookie MaxAge.
+type SessionTokenTTLProvider interface {
+	SessionTokenTTL() time.Duration
+}
+
+func (s *Server) setSessionCookie(w http.ResponseWriter, token string) {
+	maxAge := int(defaultSessionCookieTTL.Seconds())
+	if p, ok := s.auth.(SessionTokenTTLProvider); ok {
+		maxAge = int(p.SessionTokenTTL().Seconds())
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    token,
+		Path:     "/",
+		MaxAge:   maxAge,
+		HttpOnly: true,
+		Secure:   !s.devMode,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func (s *Server) clearSessionCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   !s.devMode,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
 // StatefulCallbackHandler is an optional interface for auth providers that need
 // the OAuth state parameter during callback (e.g., for PKCE where the
 // code_verifier is encrypted in the state).
@@ -428,14 +465,17 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 		"display_name": identity.DisplayName,
 	}
 
-	if issuer, ok := s.auth.(SessionTokenIssuer); ok {
-		token, err := issuer.IssueSessionToken(identity)
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to issue session token")
-			return
-		}
-		resp["token"] = token
+	issuer, ok := s.auth.(SessionTokenIssuer)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "auth provider does not support session tokens")
+		return
 	}
+	token, err := issuer.IssueSessionToken(identity)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to issue session token")
+		return
+	}
+	s.setSessionCookie(w, token)
 
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -856,6 +896,11 @@ func (s *Server) revokeAPIToken(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "revoked"})
 }
 
+func (s *Server) logout(w http.ResponseWriter, r *http.Request) {
+	s.clearSessionCookie(w)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
 func (s *Server) devLogin(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Email string `json:"email"`
@@ -886,9 +931,9 @@ func (s *Server) devLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]string{
+	s.setSessionCookie(w, token)
+	writeJSON(w, http.StatusOK, map[string]any{
 		"email": req.Email,
-		"token": token,
 	})
 }
 

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -57,21 +57,32 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			}
 		}
 
-		header := r.Header.Get("Authorization")
-		if header == "" {
-			writeError(w, http.StatusUnauthorized, "missing authorization header")
-			return
+		// Try the session cookie first, then the Authorization header.
+		// If either yields a valid principal, use it.
+		var p *principal.Principal
+		var lastErr error
+
+		if c, err := r.Cookie(sessionCookieName); err == nil && c.Value != "" {
+			p, lastErr = s.resolver.ResolveToken(r.Context(), c.Value)
 		}
 
-		token := strings.TrimPrefix(header, core.BearerScheme)
-		if token == header {
-			writeError(w, http.StatusUnauthorized, "invalid authorization header format")
-			return
+		if p == nil {
+			if header := r.Header.Get("Authorization"); header != "" {
+				bearer := strings.TrimPrefix(header, core.BearerScheme)
+				if bearer == header {
+					writeError(w, http.StatusUnauthorized, "invalid authorization header format")
+					return
+				}
+				p, lastErr = s.resolver.ResolveToken(r.Context(), bearer)
+			}
 		}
 
-		p, err := s.resolver.ResolveToken(r.Context(), token)
-		if err != nil {
-			if errors.Is(err, principal.ErrInvalidToken) {
+		if p == nil {
+			if lastErr == nil {
+				writeError(w, http.StatusUnauthorized, "missing authorization")
+				return
+			}
+			if errors.Is(lastErr, principal.ErrInvalidToken) {
 				writeError(w, http.StatusUnauthorized, "invalid token")
 				return
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -105,6 +105,7 @@ func (s *Server) routes() {
 		r.Get("/auth/info", s.authInfo)
 		r.Post("/auth/login", s.startLogin)
 		r.Get("/auth/login/callback", s.loginCallback)
+		r.Post("/auth/logout", s.logout)
 		r.Get("/auth/callback", s.integrationOAuthCallback)
 
 		if s.bindings != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -991,13 +991,15 @@ func TestLoginCallback(t *testing.T) {
 	t.Parallel()
 
 	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Auth = &coretesting.StubAuthProvider{
-			N: "test",
-			HandleCallbackFn: func(_ context.Context, code string) (*core.UserIdentity, error) {
-				if code == "good-code" {
-					return &core.UserIdentity{Email: "user@example.com", DisplayName: "User"}, nil
-				}
-				return nil, fmt.Errorf("bad code")
+		cfg.Auth = &stubAuthWithToken{
+			StubAuthProvider: coretesting.StubAuthProvider{
+				N: "test",
+				HandleCallbackFn: func(_ context.Context, code string) (*core.UserIdentity, error) {
+					if code == "good-code" {
+						return &core.UserIdentity{Email: "user@example.com", DisplayName: "User"}, nil
+					}
+					return nil, fmt.Errorf("bad code")
+				},
 			},
 		}
 	})
@@ -2362,6 +2364,10 @@ func (s *stubStatefulAuth) HandleCallbackWithState(ctx context.Context, code, st
 	return s.handleWithState(ctx, code, state)
 }
 
+func (s *stubStatefulAuth) IssueSessionToken(identity *core.UserIdentity) (string, error) {
+	return "session-token-" + identity.Email, nil
+}
+
 func TestExecuteOperation_ConnectionModeNone(t *testing.T) {
 	t.Parallel()
 
@@ -3290,6 +3296,10 @@ func (s *stubAuthWithToken) IssueSessionToken(identity *core.UserIdentity) (stri
 	return "dev-token-" + identity.Email, nil
 }
 
+func (s *stubAuthWithToken) SessionTokenTTL() time.Duration {
+	return time.Hour
+}
+
 func TestDevLogin(t *testing.T) {
 	t.Parallel()
 
@@ -3310,12 +3320,29 @@ func TestDevLogin(t *testing.T) {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
 
-	var result map[string]string
+	var result map[string]any
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		t.Fatalf("decoding: %v", err)
 	}
-	if result["token"] != "dev-token-dev@test.local" {
-		t.Fatalf("expected token dev-token-dev@test.local, got %q", result["token"])
+	if result["email"] != "dev@test.local" {
+		t.Fatalf("expected email dev@test.local, got %v", result["email"])
+	}
+	cookies := resp.Cookies()
+	var sessionCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == "session_token" {
+			sessionCookie = c
+			break
+		}
+	}
+	if sessionCookie == nil {
+		t.Fatal("expected session_token cookie to be set")
+	}
+	if sessionCookie.Value != "dev-token-dev@test.local" {
+		t.Fatalf("expected cookie value dev-token-dev@test.local, got %q", sessionCookie.Value)
+	}
+	if !sessionCookie.HttpOnly {
+		t.Fatal("expected session cookie to be HttpOnly")
 	}
 }
 
@@ -3357,6 +3384,80 @@ func TestDevLogin_EmptyEmail(t *testing.T) {
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestCookieAuth(t *testing.T) {
+	t.Parallel()
+
+	stub := &coretesting.StubAuthProvider{
+		N: "test",
+		ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+			if token == "valid-cookie-token" {
+				return &core.UserIdentity{Email: "cookie@test.local"}, nil
+			}
+			return nil, fmt.Errorf("invalid token")
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = stub
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	// Request without cookie should be rejected.
+	reqNoCookie, _ := http.NewRequest("GET", ts.URL+"/api/v1/integrations", nil)
+	noAuthResp, err := http.DefaultClient.Do(reqNoCookie)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = noAuthResp.Body.Close() }()
+	if noAuthResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without cookie, got %d", noAuthResp.StatusCode)
+	}
+
+	// Request with cookie should pass auth middleware.
+	req, _ := http.NewRequest("GET", ts.URL+"/api/v1/integrations", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "valid-cookie-token"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		t.Fatal("cookie auth should have passed middleware, got 401")
+	}
+}
+
+func TestLogout(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest("POST", ts.URL+"/api/v1/auth/logout", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var found bool
+	for _, c := range resp.Cookies() {
+		if c.Name == "session_token" {
+			found = true
+			if c.MaxAge != -1 {
+				t.Fatalf("expected MaxAge -1, got %d", c.MaxAge)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected session_token cookie to be cleared")
 	}
 }
 

--- a/plugins/auth/google/google.go
+++ b/plugins/auth/google/google.go
@@ -76,8 +76,9 @@ func New(cfg Config) (*Provider, error) {
 	}, nil
 }
 
-func (p *Provider) Name() string        { return "google" }
-func (p *Provider) DisplayName() string { return "Google" }
+func (p *Provider) Name() string                   { return "google" }
+func (p *Provider) DisplayName() string            { return "Google" }
+func (p *Provider) SessionTokenTTL() time.Duration { return p.ttl }
 
 func (p *Provider) LoginURL(state string) (string, error) {
 	return p.oauth2Config.AuthCodeURL(state, oauth2.AccessTypeOffline), nil

--- a/plugins/auth/oidc/oidc.go
+++ b/plugins/auth/oidc/oidc.go
@@ -124,8 +124,9 @@ func New(cfg Config) (*Provider, error) {
 	}, nil
 }
 
-func (p *Provider) Name() string        { return "oidc" }
-func (p *Provider) DisplayName() string { return p.displayName }
+func (p *Provider) Name() string                   { return "oidc" }
+func (p *Provider) DisplayName() string            { return p.displayName }
+func (p *Provider) SessionTokenTTL() time.Duration { return p.ttl }
 
 func (p *Provider) LoginURL(state string) (string, error) {
 	if !p.pkce {

--- a/web/e2e/auth.spec.ts
+++ b/web/e2e/auth.spec.ts
@@ -42,17 +42,19 @@ test.describe("Authentication", () => {
   test("logout clears session and redirects to login", async ({ page }) => {
     await page.goto("/login");
     await page.evaluate(() => {
-      sessionStorage.setItem("session_token", "test-session-token");
-      sessionStorage.setItem("user_email", "test@gestalt.dev");
+      localStorage.setItem("user_email", "test@gestalt.dev");
     });
     await mockIntegrations(page, []);
     await mockTokens(page, []);
+    await page.route("**/api/v1/auth/logout", (route) => {
+      route.fulfill({ json: { status: "ok" } });
+    });
 
     await page.goto("/");
     await page.getByRole("button", { name: /Logout/i }).click();
     await expect(page).toHaveURL(/\/login/);
-    const token = await page.evaluate(() => sessionStorage.getItem("session_token"));
-    expect(token).toBeNull();
+    const email = await page.evaluate(() => localStorage.getItem("user_email"));
+    expect(email).toBeNull();
   });
 
   test("auth callback rejects mismatched OAuth state (CSRF protection)", async ({

--- a/web/e2e/fixtures.ts
+++ b/web/e2e/fixtures.ts
@@ -67,8 +67,7 @@ type CustomFixtures = {
 export const test = base.extend<CustomFixtures>({
   authenticatedPage: async ({ page }, use) => {
     await page.addInitScript(() => {
-      sessionStorage.setItem("session_token", "test-session-token");
-      sessionStorage.setItem("user_email", "test@gestalt.dev");
+      localStorage.setItem("user_email", "test@gestalt.dev");
     });
     await use(page);
   },

--- a/web/e2e/integration.spec.ts
+++ b/web/e2e/integration.spec.ts
@@ -7,7 +7,8 @@ test.describe("Integration: Go server contract", () => {
 
   test.describe.configure({ mode: "serial" });
 
-  let authToken: string;
+  let sessionCookie: string;
+  let serverHost: string;
 
   async function devLogin(
     baseURL: string,
@@ -21,8 +22,9 @@ test.describe("Integration: Go server contract", () => {
         body: JSON.stringify({ email }),
       });
       if (res.ok) {
-        const data = await res.json();
-        if (data.token) return data.token;
+        const setCookie = res.headers.get("set-cookie") || "";
+        const match = setCookie.match(/session_token=([^;]+)/);
+        if (match) return match[1];
       }
       if (attempt < retries) {
         await new Promise((r) => setTimeout(r, 1000));
@@ -34,17 +36,22 @@ test.describe("Integration: Go server contract", () => {
   test.beforeAll(async ({}, testInfo) => {
     const baseURL =
       testInfo.project.use.baseURL || "http://localhost:8080";
-    authToken = await devLogin(baseURL);
+    serverHost = new URL(baseURL).hostname;
+    sessionCookie = await devLogin(baseURL);
   });
 
-  function injectAuth(page: import("@playwright/test").Page) {
-    return page.addInitScript(
-      ({ token }) => {
-        sessionStorage.setItem("session_token", token);
-        sessionStorage.setItem("user_email", "e2e@gestalt.dev");
-      },
-      { token: authToken },
-    );
+  async function injectAuth(page: import("@playwright/test").Page) {
+    await page.context().addCookies([{
+      name: "session_token",
+      value: sessionCookie,
+      domain: serverHost,
+      path: "/",
+      httpOnly: true,
+      secure: false,
+    }]);
+    await page.addInitScript(() => {
+      localStorage.setItem("user_email", "e2e@gestalt.dev");
+    });
   }
 
   test("integrations page loads from Go server", async ({ page }) => {

--- a/web/src/app/auth/callback/page.tsx
+++ b/web/src/app/auth/callback/page.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { loginCallback } from "@/lib/api";
-import { setSessionToken, setUserEmail } from "@/lib/auth";
+import { setUserEmail } from "@/lib/auth";
 
 function CallbackHandler() {
   const router = useRouter();
@@ -47,11 +47,6 @@ function CallbackHandler() {
 
     loginCallback(code, returnedState ?? undefined)
       .then((result) => {
-        if (!result.token) {
-          setError("Login failed — no session token returned");
-          return;
-        }
-        setSessionToken(result.token);
         setUserEmail(result.email);
         router.replace("/");
       })

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { fetchAPI, getAuthInfo, startLogin } from "@/lib/api";
-import { isAuthenticated, setSessionToken, setUserEmail } from "@/lib/auth";
+import { isAuthenticated, setUserEmail } from "@/lib/auth";
 import Button from "@/components/Button";
 
 export default function LoginPage() {
@@ -48,14 +48,12 @@ export default function LoginPage() {
     setLoading(true);
     setError(null);
     try {
-      const { email, token } = await fetchAPI<{
+      const { email } = await fetchAPI<{
         email: string;
-        token: string;
       }>("/api/dev-login", {
         method: "POST",
         body: JSON.stringify({ email: devEmail }),
       });
-      setSessionToken(token);
       setUserEmail(email);
       window.location.replace("/");
     } catch (err) {

--- a/web/src/components/Nav.tsx
+++ b/web/src/components/Nav.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { clearSession, getUserEmail } from "@/lib/auth";
+import { logout } from "@/lib/api";
 import { LOGIN_PATH } from "@/lib/constants";
 
 const links = [
@@ -16,7 +17,8 @@ export default function Nav() {
   const pathname = usePathname();
   const email = getUserEmail();
 
-  function handleLogout() {
+  async function handleLogout() {
+    await logout().catch(() => {});
     clearSession();
     window.location.href = LOGIN_PATH;
   }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { clearSession, getSessionToken } from "./auth";
+import { clearSession } from "./auth";
 import { HTTP_UNAUTHORIZED, LOGIN_PATH } from "./constants";
 
 export interface ConnectionParamDef {
@@ -46,12 +46,6 @@ export class APIError extends Error {
   }
 }
 
-function getAuthHeaders(): Record<string, string> {
-  const token = getSessionToken();
-  if (!token) return {};
-  return { Authorization: `Bearer ${token}` };
-}
-
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "";
 
 export async function fetchAPI<T>(
@@ -60,9 +54,9 @@ export async function fetchAPI<T>(
 ): Promise<T> {
   const res = await fetch(API_BASE + path, {
     ...options,
+    credentials: "include",
     headers: {
       "Content-Type": "application/json",
-      ...getAuthHeaders(),
       ...options?.headers,
     },
   });
@@ -110,10 +104,14 @@ export async function startLogin(state: string): Promise<{ url: string }> {
 export async function loginCallback(
   code: string,
   state?: string,
-): Promise<{ email: string; display_name: string; token?: string }> {
+): Promise<{ email: string; display_name: string }> {
   const params = new URLSearchParams({ code });
   if (state) params.set("state", state);
   return fetchAPI(`/api/v1/auth/login/callback?${params}`);
+}
+
+export async function logout(): Promise<void> {
+  await fetchAPI("/api/v1/auth/logout", { method: "POST" });
 }
 
 export async function getIntegrations(): Promise<Integration[]> {

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,26 +1,15 @@
-// TODO: migrate to httpOnly cookies set by the server.
-
-export function getSessionToken(): string | null {
-  return sessionStorage.getItem("session_token");
-}
-
-export function setSessionToken(token: string): void {
-  sessionStorage.setItem("session_token", token);
-}
-
 export function clearSession(): void {
-  sessionStorage.removeItem("session_token");
-  sessionStorage.removeItem("user_email");
+  localStorage.removeItem("user_email");
 }
 
 export function isAuthenticated(): boolean {
-  return getSessionToken() !== null;
+  return getUserEmail() !== null;
 }
 
 export function getUserEmail(): string | null {
-  return sessionStorage.getItem("user_email");
+  return localStorage.getItem("user_email");
 }
 
 export function setUserEmail(email: string): void {
-  sessionStorage.setItem("user_email", email);
+  localStorage.setItem("user_email", email);
 }


### PR DESCRIPTION
The web UI stored JWT session tokens in the browser's sessionStorage,
which clears when the tab closes, forcing users to re-authenticate on
every visit. This migrates session management to httpOnly cookies set
by the server. The login callback and dev login handlers now set a
Secure, SameSite=Lax cookie instead of returning the token in the JSON
response body, and the auth middleware reads the cookie before falling
back to the Authorization header for API tokens.

On the frontend, fetchAPI now sends credentials with every request and
no longer manages tokens manually. A logout endpoint and corresponding
UI integration clear the cookie server-side.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>