### PR TITLE
Support per-upstream auth overrides in integration config

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -231,25 +231,28 @@ func defaultProviderFactory(preparedProviders map[string]string) bootstrap.Provi
 			}
 		}
 
-		for _, us := range intg.Upstreams {
+		var mcpUpDef *config.UpstreamDef
+
+		for i := range intg.Upstreams {
+			us := &intg.Upstreams[i]
 			switch us.Type {
 			case config.UpstreamTypeREST, config.UpstreamTypeGraphQL:
 				if apiProv != nil {
 					cleanup()
 					return nil, fmt.Errorf("multiple api upstreams not supported")
 				}
-				def, err := loadAPIUpstream(ctx, name, us, preparedProviders)
+				def, err := loadAPIUpstream(ctx, name, *us, preparedProviders)
 				if err != nil {
 					cleanup()
 					return nil, err
 				}
+				intgForBuild := intgWithUpstreamAuth(intg, *us)
 				var buildOpts []provider.BuildOption
-				if intg.Auth.Type == "mcp_oauth" {
-					mcpURL := mcpURLFromUpstreams(intg.Upstreams)
-					handler := buildMCPOAuthHandler(mcpURL, intg, regStore, deps)
+				if us.Auth.Type == "mcp_oauth" {
+					handler := buildMCPOAuthHandlerFromUpstream(*us, regStore, deps)
 					buildOpts = append(buildOpts, provider.WithAuthHandler(handler))
 				}
-				p, err := provider.Build(def, intg, map[string]string(us.AllowedOperations), buildOpts...)
+				p, err := provider.Build(def, intgForBuild, map[string]string(us.AllowedOperations), buildOpts...)
 				if err != nil {
 					cleanup()
 					return nil, err
@@ -271,6 +274,7 @@ func defaultProviderFactory(preparedProviders map[string]string) bootstrap.Provi
 					}
 				}
 				mcpUp = up
+				mcpUpDef = us
 			default:
 				cleanup()
 				return nil, fmt.Errorf("unknown upstream type %q", us.Type)
@@ -283,14 +287,32 @@ func defaultProviderFactory(preparedProviders map[string]string) bootstrap.Provi
 		case apiProv != nil:
 			return apiProv, nil
 		case mcpUp != nil:
-			if intg.Auth.Type == "mcp_oauth" {
-				return buildMCPOAuthProvider(name, intg, mcpUp, regStore, deps)
+			if mcpUpDef != nil && mcpUpDef.Auth.Type == "mcp_oauth" {
+				return buildMCPOAuthProvider(name, intg, *mcpUpDef, mcpUp, regStore, deps)
 			}
 			return mcpUp, nil
 		default:
 			return nil, fmt.Errorf("no upstreams configured")
 		}
 	}
+}
+
+// Empty upstream fields are left as-is so integration-level defaults
+// (including redirect_url resolved later by resolveBaseURL) are preserved.
+func intgWithUpstreamAuth(intg config.IntegrationDef, us config.UpstreamDef) config.IntegrationDef {
+	if us.Auth.Type != "" {
+		intg.Auth = us.Auth
+	}
+	if us.ClientID != "" {
+		intg.ClientID = us.ClientID
+	}
+	if us.ClientSecret != "" {
+		intg.ClientSecret = us.ClientSecret
+	}
+	if us.RedirectURL != "" {
+		intg.RedirectURL = us.RedirectURL
+	}
+	return intg
 }
 
 func buildRegistrationStore(deps bootstrap.Deps) mcpoauth.RegistrationStore {
@@ -314,33 +336,28 @@ func buildRegistrationStore(deps bootstrap.Deps) mcpoauth.RegistrationStore {
 	return store
 }
 
-func buildMCPOAuthHandler(mcpURL string, intg config.IntegrationDef, store mcpoauth.RegistrationStore, deps bootstrap.Deps) *mcpoauth.Handler {
-	redirectURL := intg.RedirectURL
+func buildMCPOAuthHandlerFromUpstream(us config.UpstreamDef, store mcpoauth.RegistrationStore, deps bootstrap.Deps) *mcpoauth.Handler {
+	redirectURL := us.RedirectURL
 	if redirectURL == "" {
 		redirectURL = deps.BaseURL + config.IntegrationCallbackPath
+	}
+
+	mcpURL := us.URL
+	if us.MCPURL != "" {
+		mcpURL = us.MCPURL
 	}
 
 	return mcpoauth.NewHandler(mcpoauth.HandlerConfig{
 		MCPURL:       mcpURL,
 		Store:        store,
 		RedirectURL:  redirectURL,
-		ClientID:     intg.ClientID,
-		ClientSecret: intg.ClientSecret,
+		ClientID:     us.ClientID,
+		ClientSecret: us.ClientSecret,
 	})
 }
 
-func mcpURLFromUpstreams(upstreams []config.UpstreamDef) string {
-	for _, us := range upstreams {
-		if us.Type == config.UpstreamTypeMCP {
-			return us.URL
-		}
-	}
-	return ""
-}
-
-func buildMCPOAuthProvider(name string, intg config.IntegrationDef, mcpUp *mcpupstream.Upstream, store mcpoauth.RegistrationStore, deps bootstrap.Deps) (core.Provider, error) {
-	mcpURL := mcpURLFromUpstreams(intg.Upstreams)
-	handler := buildMCPOAuthHandler(mcpURL, intg, store, deps)
+func buildMCPOAuthProvider(name string, intg config.IntegrationDef, us config.UpstreamDef, mcpUp *mcpupstream.Upstream, store mcpoauth.RegistrationStore, deps bootstrap.Deps) (core.Provider, error) {
+	handler := buildMCPOAuthHandlerFromUpstream(us, store, deps)
 
 	connMode := core.ConnectionModeUser
 	if intg.ConnectionMode != "" {

--- a/cmd/gestaltd/prepare.go
+++ b/cmd/gestaltd/prepare.go
@@ -225,11 +225,12 @@ func writePreparedArtifacts(ctx context.Context, cfg *config.Config, paths prepa
 }
 
 func remoteAPIUpstreamForPrepare(intg config.IntegrationDef) (config.UpstreamDef, bool) {
-	for _, us := range intg.Upstreams {
+	for i := range intg.Upstreams {
+		us := &intg.Upstreams[i]
 		switch us.Type {
 		case config.UpstreamTypeREST, config.UpstreamTypeGraphQL:
 			if us.URL != "" {
-				return us, true
+				return *us, true
 			}
 		}
 	}

--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -82,7 +82,8 @@ func runStartCommand(name string, usage func(io.Writer), args []string, mode pro
 		intg := env.Config.Integrations[name]
 		hasMCP := false
 		apiMCP := false
-		for _, us := range intg.Upstreams {
+		for i := range intg.Upstreams {
+			us := &intg.Upstreams[i]
 			if us.Type == config.UpstreamTypeMCP {
 				hasMCP = true
 			}
@@ -257,8 +258,8 @@ func logConfigSummary(path string, cfg *config.Config) {
 		for name := range cfg.Integrations {
 			intg := cfg.Integrations[name]
 			var sources []string
-			for _, us := range intg.Upstreams {
-				sources = append(sources, us.Type)
+			for i := range intg.Upstreams {
+				sources = append(sources, intg.Upstreams[i].Type)
 			}
 			auth := "oauth"
 			if intg.Auth.Type == "manual" || intg.ConnectionMode == "manual" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,6 +108,20 @@ type UpstreamDef struct {
 	URL               string     `yaml:"url"`
 	MCP               bool       `yaml:"mcp"`
 	AllowedOperations AllowedOps `yaml:"allowed_operations"`
+
+	// Per-upstream auth overrides. When set, these take precedence over
+	// integration-level auth for this upstream. When empty, the
+	// integration-level values are inherited during config resolution.
+	AuthProfile  string        `yaml:"auth_profile"`
+	Auth         AuthOverrides `yaml:"auth"`
+	ClientID     string        `yaml:"client_id"`
+	ClientSecret string        `yaml:"client_secret"`
+	RedirectURL  string        `yaml:"redirect_url"`
+
+	// MCPURL is set during config resolution for non-MCP upstreams that use
+	// mcp_oauth auth. It points to the sibling MCP upstream's URL so that
+	// OAuth discovery probes the correct endpoint.
+	MCPURL string `yaml:"-"`
 }
 
 // AllowedOps is a map of operation name to optional description override.
@@ -181,6 +195,10 @@ func LoadWithMapping(path string, getenv func(string) string) (*Config, error) {
 		return nil, err
 	}
 
+	if err := resolveUpstreamAuth(&cfg); err != nil {
+		return nil, err
+	}
+
 	resolveBaseURL(&cfg) // after resolveAuthProfiles so inherited fields take priority
 	resolveRelativePaths(path, &cfg)
 
@@ -219,54 +237,121 @@ func resolveAuthProfiles(cfg *Config) error {
 		if intg.RedirectURL == "" {
 			intg.RedirectURL = profile.RedirectURL
 		}
-		if intg.Auth.Type == "" {
-			intg.Auth.Type = profile.Auth.Type
-		}
-		if intg.Auth.AuthorizationURL == "" {
-			intg.Auth.AuthorizationURL = profile.Auth.AuthorizationURL
-		}
-		if intg.Auth.TokenURL == "" {
-			intg.Auth.TokenURL = profile.Auth.TokenURL
-		}
-		if intg.Auth.ClientAuth == "" {
-			intg.Auth.ClientAuth = profile.Auth.ClientAuth
-		}
-		if intg.Auth.TokenExchange == "" {
-			intg.Auth.TokenExchange = profile.Auth.TokenExchange
-		}
-		if !intg.Auth.PKCE && profile.Auth.PKCE {
-			intg.Auth.PKCE = true
-		}
-		if intg.Auth.AuthorizationParams == nil {
-			intg.Auth.AuthorizationParams = profile.Auth.AuthorizationParams
-		}
-		if intg.Auth.TokenParams == nil {
-			intg.Auth.TokenParams = profile.Auth.TokenParams
-		}
-		if intg.Auth.RefreshParams == nil {
-			intg.Auth.RefreshParams = profile.Auth.RefreshParams
-		}
-		if intg.Auth.Scopes == nil {
-			intg.Auth.Scopes = profile.Auth.Scopes
-		}
-		if intg.Auth.ScopeSeparator == "" {
-			intg.Auth.ScopeSeparator = profile.Auth.ScopeSeparator
-		}
-		if intg.Auth.AcceptHeader == "" {
-			intg.Auth.AcceptHeader = profile.Auth.AcceptHeader
-		}
-		if intg.Auth.TokenMetadata == nil {
-			intg.Auth.TokenMetadata = profile.Auth.TokenMetadata
-		}
-		if intg.Auth.ResponseHook == "" {
-			intg.Auth.ResponseHook = profile.Auth.ResponseHook
-		}
-		if intg.Auth.AuthHeader == "" {
-			intg.Auth.AuthHeader = profile.Auth.AuthHeader
-		}
+		fillAuthDefaults(&intg.Auth, &profile.Auth)
 		cfg.Integrations[name] = intg
 	}
 	return nil
+}
+
+// resolveUpstreamAuth cascades integration-level auth to upstreams that don't
+// specify their own, and resolves upstream-level auth profiles.
+func resolveUpstreamAuth(cfg *Config) error {
+	for name := range cfg.Integrations {
+		intg := cfg.Integrations[name]
+		for i := range intg.Upstreams {
+			us := &intg.Upstreams[i]
+
+			if us.AuthProfile != "" {
+				profile, ok := cfg.AuthProfiles[us.AuthProfile]
+				if !ok {
+					return fmt.Errorf("integration %q upstream %d references unknown auth_profile %q", name, i, us.AuthProfile)
+				}
+				fillUpstreamFromProfile(us, profile)
+			}
+
+			if us.Auth.Type == "" {
+				us.Auth.Type = intg.Auth.Type
+			}
+			if us.ClientID == "" {
+				us.ClientID = intg.ClientID
+			}
+			if us.ClientSecret == "" {
+				us.ClientSecret = intg.ClientSecret
+			}
+			if us.RedirectURL == "" {
+				us.RedirectURL = intg.RedirectURL
+			}
+			fillAuthDefaults(&us.Auth, &intg.Auth)
+		}
+
+		// Populate MCPURL so non-MCP upstreams with mcp_oauth can discover
+		// OAuth endpoints from the sibling MCP server.
+		for i := range intg.Upstreams {
+			us := &intg.Upstreams[i]
+			if us.Auth.Type == "mcp_oauth" && us.Type != UpstreamTypeMCP && us.MCPURL == "" {
+				for j := range intg.Upstreams {
+					if intg.Upstreams[j].Type == UpstreamTypeMCP {
+						us.MCPURL = intg.Upstreams[j].URL
+						break
+					}
+				}
+			}
+		}
+
+		cfg.Integrations[name] = intg
+	}
+	return nil
+}
+
+func fillUpstreamFromProfile(us *UpstreamDef, profile AuthProfile) {
+	if us.ClientID == "" {
+		us.ClientID = profile.ClientID
+	}
+	if us.ClientSecret == "" {
+		us.ClientSecret = profile.ClientSecret
+	}
+	if us.RedirectURL == "" {
+		us.RedirectURL = profile.RedirectURL
+	}
+	fillAuthDefaults(&us.Auth, &profile.Auth)
+}
+
+func fillAuthDefaults(dst, src *AuthOverrides) {
+	if dst.Type == "" {
+		dst.Type = src.Type
+	}
+	if dst.AuthorizationURL == "" {
+		dst.AuthorizationURL = src.AuthorizationURL
+	}
+	if dst.TokenURL == "" {
+		dst.TokenURL = src.TokenURL
+	}
+	if dst.ClientAuth == "" {
+		dst.ClientAuth = src.ClientAuth
+	}
+	if dst.TokenExchange == "" {
+		dst.TokenExchange = src.TokenExchange
+	}
+	if !dst.PKCE && src.PKCE {
+		dst.PKCE = true
+	}
+	if dst.Scopes == nil {
+		dst.Scopes = src.Scopes
+	}
+	if dst.ScopeSeparator == "" {
+		dst.ScopeSeparator = src.ScopeSeparator
+	}
+	if dst.AuthorizationParams == nil {
+		dst.AuthorizationParams = src.AuthorizationParams
+	}
+	if dst.TokenParams == nil {
+		dst.TokenParams = src.TokenParams
+	}
+	if dst.RefreshParams == nil {
+		dst.RefreshParams = src.RefreshParams
+	}
+	if dst.AcceptHeader == "" {
+		dst.AcceptHeader = src.AcceptHeader
+	}
+	if dst.TokenMetadata == nil {
+		dst.TokenMetadata = src.TokenMetadata
+	}
+	if dst.ResponseHook == "" {
+		dst.ResponseHook = src.ResponseHook
+	}
+	if dst.AuthHeader == "" {
+		dst.AuthHeader = src.AuthHeader
+	}
 }
 
 func resolveBaseURL(cfg *Config) {
@@ -328,7 +413,8 @@ func validate(cfg *Config) error {
 	for name := range cfg.Integrations {
 		intg := cfg.Integrations[name]
 		apiCount := 0
-		for _, us := range intg.Upstreams {
+		for i := range intg.Upstreams {
+			us := &intg.Upstreams[i]
 			switch us.Type {
 			case UpstreamTypeREST, UpstreamTypeGraphQL:
 				apiCount++


### PR DESCRIPTION
Auth configuration can now be specified on individual upstreams instead of
only at the integration level. When an upstream has its own auth block, it
takes precedence; otherwise the integration-level auth cascades down as a
default. This eliminates the need to search for MCP URLs across sibling
upstreams when building auth handlers, since each upstream carries its own
resolved auth config.

The config resolution phase now runs a new `resolveUpstreamAuth` step after
profile resolution, filling empty upstream auth fields from the integration
defaults. Upstream-level auth profiles are also supported, resolved the same
way as integration-level profiles.

Stacked on: #81

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>