### PR TITLE
Update docs for MCP, readiness, and dev commands

### DIFF
--- a/docs/pages/concepts/mcp-binding.mdx
+++ b/docs/pages/concepts/mcp-binding.mdx
@@ -1,6 +1,6 @@
 # MCP Binding
 
-When `mcp.enabled` is set in the config, Gestalt mounts a Streamable HTTP MCP endpoint at `/mcp`. This gives AI assistants like Claude direct access to your integration operations.
+When at least one integration exposes MCP tools, Gestalt mounts a Streamable HTTP MCP endpoint at `/mcp`. REST and GraphQL upstreams opt in with `mcp: true`; `type: mcp` upstreams are always exposed. This gives AI assistants like Claude direct access to your integration operations.
 
 ## What MCP is
 
@@ -26,7 +26,7 @@ Each tool name is built from the provider name and operation ID:
 
 For example, `search_issues` on the `linear` provider becomes `linear_search_issues`.
 
-Set `tool_name_prefix` in the `mcp` config block to prepend a string to every tool name. A prefix of `gs_` produces `gs_linear_search_issues`.
+Set `mcp_tool_prefix` on an integration to prepend a string to that integration's MCP tool names. A prefix of `gs_` on the `linear` integration produces `gs_linear_search_issues`.
 
 ## Auth
 
@@ -41,7 +41,7 @@ The MCP binding is an alternative interface, not a replacement. It shares:
 - The same invoker: credential resolution, automatic token refresh, and upstream execution.
 - The same allow-list enforcement on operations.
 
-The `mcp.providers` filter lets you expose a subset of integrations to MCP clients without affecting the HTTP API.
+MCP exposure is configured per integration. For REST and GraphQL upstreams, set `mcp: true` on the upstream you want to expose. For upstream MCP servers, add a `type: mcp` upstream. Gestalt mounts `/mcp` automatically once at least one integration exposes MCP tools.
 
 ## MCP upstream passthrough
 

--- a/docs/pages/concepts/platform-model.mdx
+++ b/docs/pages/concepts/platform-model.mdx
@@ -11,7 +11,7 @@ Gestalt has a small set of primitives that compose into a complete API gateway f
 | **Secret manager** | Resolves `secret://` references in config before other components are built, keeping sensitive values out of plain-text YAML. |
 | **Integration definition** | Describes one or more upstreams (REST, GraphQL, or MCP) with their auth style, operations, and optional hooks. |
 | **Provider** | Runtime object that lists operations and executes them against upstream APIs. Built from the integration's upstreams at startup. |
-| **Operation** | A callable unit exposed by an integration, generated from an OpenAPI spec, GraphQL introspection, MCP tool listing, or declared in YAML. |
+| **Operation** | A callable unit exposed by an integration, generated from an OpenAPI spec, GraphQL introspection, or MCP tool listing. |
 | **Hooks** | Integration-specific code for non-standard auth, token parsing, response validation, or request shaping. |
 | **Runtime** | A background process that boots alongside the server and receives scoped access to a subset of providers. |
 | **Binding** | An alternative request surface (for example, webhooks or MCP) that forwards calls through the shared invoker. |
@@ -30,7 +30,7 @@ When an integration declares multiple upstream types — for example, a REST ups
 
 An **upstream** is a source of operations. Every integration declares at least one. Gestalt supports three upstream types:
 
-- A **REST upstream** loads operations from an OpenAPI specification, a local provider definition file, or a directory scan. Each path and method combination in the spec becomes a callable operation.
+- A **REST upstream** loads operations from an OpenAPI specification URL. Each path and method combination in the spec becomes a callable operation.
 - A **GraphQL upstream** introspects a GraphQL endpoint at startup and generates one operation per query and mutation field.
 - An **MCP upstream** connects to a remote MCP server and imports its tools as operations.
 
@@ -78,9 +78,7 @@ Like bindings, runtimes receive a scoped invoker limited to the providers listed
 
 A **provider artifact** is a precompiled JSON file containing a complete provider definition: metadata, auth configuration, and the full list of operations with their parameters and schemas.
 
-By default, Gestalt builds providers by fetching OpenAPI specs or introspecting GraphQL endpoints at startup. This works well in development but introduces external dependencies at boot time. Artifacts eliminate this: you compile them once with `gestaltd compile-providers`, and subsequent startups load the local files instead of reaching out to the network.
-
-The `gestaltd bundle` command takes this further. It writes a self-contained directory with a generated config file and all provider artifacts, ready for deployment. No live spec fetches, no GraphQL introspection, no network dependencies at startup.
+Source configs always declare REST and GraphQL upstreams by `url`. In development, `gestaltd dev` resolves those upstreams live and writes prepared artifacts next to the config as needed. For deterministic deployment, run `gestaltd prepare` ahead of time to write `gestalt.lock.json` plus `.gestalt/providers/*.json`, then start with `gestaltd serve` so startup no longer depends on live spec fetches or GraphQL introspection.
 
 ### Connections and instances
 

--- a/docs/pages/contributing.mdx
+++ b/docs/pages/contributing.mdx
@@ -39,7 +39,7 @@ go test ./...
 gestaltd validate --config gestalt.dev.yaml
 
 # Run locally
-gestaltd --config gestalt.dev.yaml
+gestaltd dev --config gestalt.dev.yaml
 
 # Web UI
 cd web

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -55,10 +55,10 @@ integrations:
 ## Start the server
 
 ```sh
-gestaltd --config gestalt.local.yaml
+gestaltd dev --config gestalt.local.yaml
 ```
 
-This starts both the API server (port 8080) and the web UI (port 3000). When dev mode is enabled, you will see "dev mode enabled" in the output; this confirms that dev login and relaxed CORS are active.
+This starts both the API server (port 8080) and the web UI (port 3000). `gestaltd dev` also prepares any remote REST or GraphQL providers automatically for local use. When dev mode is enabled, you will see "dev mode enabled" in the output; this confirms that dev login and relaxed CORS are active.
 
 ## Sign in and connect Slack
 

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -98,6 +98,7 @@ Each integration is defined under `integrations.<name>` and contains one or more
 | `redirect_url` | Override the integration callback URL. |
 | `base_url` | Override the base URL from the upstream spec. |
 | `connection_mode` | `user` (default), `identity`, `either`, or `none`. See [Connection Modes](/concepts/platform-model#connection-modes). |
+| `mcp_tool_prefix` | Prefix prepended to MCP tool names for this integration. Applies to any operations this integration exposes over MCP. |
 | `auth` | Auth overrides (see below). |
 | `auth_header` | Custom header name for sending the token (instead of `Authorization`). |
 | `auth_mapping` | Map of header names to JSON fields, for structured token-to-headers mapping. |

--- a/docs/pages/reference/http-api.mdx
+++ b/docs/pages/reference/http-api.mdx
@@ -5,7 +5,7 @@
 | Method | Path | Purpose |
 |---|---|---|
 | GET | `/health` | Health check. Returns `{"status":"ok"}`. |
-| GET | `/ready` | Readiness check. Returns `{"status":"ok"}` when the datastore is reachable, or `{"status":"unavailable"}` with a 503 when it is not. |
+| GET | `/ready` | Readiness check. Returns `{"status":"ok"}` when providers are initialized and the datastore is reachable. Otherwise returns a 503 with a reason such as `{"status":"providers loading"}` or `{"status":"datastore unavailable"}`. |
 | POST | `/api/v1/auth/login` | Start platform login. Accepts `{"state": "...", "callback_port": 12345}`. Returns `{"url": "..."}` with the provider's login URL. |
 | GET | `/api/v1/auth/login/callback` | Complete platform login. Exchanges the authorization code for a session token. Returns `{"email": "...", "display_name": "...", "token": "..."}`. |
 | GET | `/api/v1/auth/info` | Returns `{"provider": "...", "display_name": "...", "dev_mode": true/false}`. |
@@ -58,7 +58,7 @@ Bindings register dynamic routes at `/api/v1/bindings/{name}/*` based on their c
 
 | Method | Path | Purpose |
 |---|---|---|
-| GET or POST | `/mcp` | Model Context Protocol endpoint (when `mcp.enabled: true`). |
+| GET or POST | `/mcp` | Model Context Protocol endpoint. Mounted when at least one integration exposes MCP tools, either via `mcp: true` on a REST/GraphQL upstream or via a `type: mcp` upstream. |
 
 ## Execution semantics
 

--- a/docs/pages/tasks/run-locally.mdx
+++ b/docs/pages/tasks/run-locally.mdx
@@ -5,10 +5,10 @@ import { Callout } from 'nextra/components'
 ## Full stack (API + web UI)
 
 ```sh
-gestaltd --config gestalt.dev.yaml
+gestaltd dev --config gestalt.dev.yaml
 ```
 
-This starts the API server and the Next.js web UI in a single process. The API runs on the port in your config (default 8080), the web UI on port 3000.
+This starts the API server and the Next.js web UI in a single process. The API runs on the port in your config (default 8080), the web UI on port 3000. `gestaltd dev` also prepares remote REST and GraphQL providers automatically when needed.
 
 ## Web UI with mock API
 

--- a/docs/pages/tasks/use-with-mcp.mdx
+++ b/docs/pages/tasks/use-with-mcp.mdx
@@ -1,5 +1,3 @@
-import { Callout } from 'nextra/components'
-
 # Use with MCP
 
 Connect Gestalt to AI assistants like Claude Code or Claude Desktop via the **Model Context Protocol**.
@@ -26,29 +24,33 @@ curl -X POST http://localhost:8080/api/v1/tokens \
 
 Save the returned token. It cannot be retrieved again.
 
-## 2. Enable MCP in your config
+## 2. Expose an integration over MCP
 
 ```yaml
-mcp:
-  enabled: true
+integrations:
+  linear:
+    upstreams:
+      - type: graphql
+        url: https://api.linear.app/graphql
+        mcp: true
 ```
 
-To expose only specific integrations:
+For an upstream MCP server, use `type: mcp` instead. No extra flag is needed:
 
 ```yaml
-mcp:
-  enabled: true
-  providers:
-    - linear
-    - slack
+integrations:
+  slack:
+    upstreams:
+      - type: mcp
+        url: https://mcp.slack.com/sse
 ```
 
-Omit `providers` to expose all configured integrations.
+Gestalt mounts `/mcp` automatically once at least one integration exposes MCP tools.
 
 ## 3. Start the server
 
 ```sh
-gestaltd --config config.yaml
+gestaltd dev --config config.yaml
 ```
 
 The MCP endpoint is available at `/mcp` on the same server as the REST API.
@@ -89,7 +91,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 
 ## Minimal example config
 
-A complete config with MCP enabled for a single integration:
+A complete config with one GraphQL integration exposed over MCP:
 
 ```yaml
 auth:
@@ -110,9 +112,11 @@ server:
 
 integrations:
   linear:
+    mcp_tool_prefix: gs_
     upstreams:
       - type: graphql
         url: https://api.linear.app/graphql
+        mcp: true
         allowed_operations:
           - searchIssues
           - createIssue
@@ -121,19 +125,14 @@ integrations:
     auth:
       authorization_url: https://linear.app/oauth/authorize
       token_url: https://api.linear.app/oauth/token
-
-mcp:
-  enabled: true
-  providers:
-    - linear
 ```
 
 ## Troubleshooting
 
 If tools do not appear in your MCP client:
 
-1. Verify the server is running with `mcp.enabled: true`.
+1. Verify the integration exposes MCP tools: use `mcp: true` on a REST/GraphQL upstream, or a `type: mcp` upstream.
 2. Check that your API token is valid (`gestalt auth status`).
 3. Confirm the token's owner has connected the integration (completed the OAuth flow or submitted manual credentials).
-4. If using `mcp.providers`, confirm the integration is in the list.
+4. Confirm the server has started and mounted `/mcp`.
 5. For MCP-only integrations (`type: mcp` upstream), note that they cannot be invoked over the HTTP API — they are only available via the MCP endpoint.


### PR DESCRIPTION
## Summary
- fix MCP docs to describe per-upstream exposure and per-integration `mcp_tool_prefix`
- update `/ready` docs to reflect provider initialization plus datastore readiness
- replace stale `bundle`/`compile-providers` language and make local guides use `gestaltd dev`

## Testing
- npm ci
- npm run build
