### PR TITLE
Fix WIF auth for docs deploy workflow

### DIFF
--- a/docs/terraform/main.tf
+++ b/docs/terraform/main.tf
@@ -116,3 +116,13 @@ resource "google_dns_record_set" "docs" {
   ttl          = 300
   rrdatas      = [google_compute_global_address.docs.address]
 }
+
+# ---------- Workload Identity Federation ----------
+
+data "google_project" "current" {}
+
+resource "google_service_account_iam_member" "github_actions_wif" {
+  service_account_id = "projects/${var.project_id}/serviceAccounts/github-actions@${var.project_id}.iam.gserviceaccount.com"
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/${var.wif_pool_id}/attribute.repository/${var.github_repository}"
+}

--- a/docs/terraform/variables.tf
+++ b/docs/terraform/variables.tf
@@ -29,7 +29,18 @@ variable "domain" {
 }
 
 variable "docs_image" {
-  description = "Initial container image for the docs service"
+  description = "Container image for the docs service (required, no default to prevent accidental reverts)"
   type        = string
-  default     = "us-docker.pkg.dev/cloudrun/container/hello"
+}
+
+variable "wif_pool_id" {
+  description = "Workload Identity Pool ID for GitHub Actions OIDC"
+  type        = string
+  default     = "github-pool"
+}
+
+variable "github_repository" {
+  description = "GitHub repository (owner/repo) allowed to authenticate via WIF"
+  type        = string
+  default     = "valon-technologies/gestalt"
 }


### PR DESCRIPTION
The Deploy Gestalt Docs workflow has been failing since the repo was extracted and renamed from its parent. The GCP Workload
  Identity Federation IAM binding only allowed the old repository to authenticate, so GitHub Actions could never obtain an access
   token for the service account. This adds a Terraform-managed IAM binding granting roles/iam.workloadIdentityUser to
  valon-technologies/gestalt, and removes the default from docs_image so local terraform apply cannot accidentally revert the
  production container image.