### PR TITLE
Add shared egress core primitives

### DIFF
--- a/internal/egress/credentials.go
+++ b/internal/egress/credentials.go
@@ -1,0 +1,76 @@
+package egress
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+// AuthStyle determines how a stored credential should be materialized.
+type AuthStyle string
+
+const (
+	AuthStyleBearer AuthStyle = "bearer"
+	AuthStyleRaw    AuthStyle = "raw"
+	AuthStyleNone   AuthStyle = "none"
+	AuthStyleBasic  AuthStyle = "basic"
+)
+
+// TokenParser transforms a stored token into an auth header plus extra headers.
+type TokenParser func(token string) (authHeader string, extraHeaders map[string]string, err error)
+
+// CredentialMaterialization is a transport-neutral representation of how a
+// credential should be injected into an outbound request.
+type CredentialMaterialization struct {
+	Authorization string
+	Headers       []HeaderMutation
+}
+
+// MaterializeCredential converts a stored token into a concrete injection shape.
+func MaterializeCredential(token string, style AuthStyle, parser TokenParser) (CredentialMaterialization, error) {
+	if parser != nil {
+		authHeader, extraHeaders, err := parser(token)
+		if err != nil {
+			return CredentialMaterialization{}, err
+		}
+		return CredentialMaterialization{
+			Authorization: authHeader,
+			Headers:       headerMutationsFromMap(extraHeaders),
+		}, nil
+	}
+
+	switch style {
+	case "", AuthStyleBearer:
+		if token == "" {
+			return CredentialMaterialization{}, nil
+		}
+		return CredentialMaterialization{Authorization: "Bearer " + token}, nil
+	case AuthStyleRaw:
+		return CredentialMaterialization{Authorization: token}, nil
+	case AuthStyleBasic:
+		if token == "" {
+			return CredentialMaterialization{}, nil
+		}
+		return CredentialMaterialization{
+			Authorization: "Basic " + base64.StdEncoding.EncodeToString([]byte(token)),
+		}, nil
+	case AuthStyleNone:
+		return CredentialMaterialization{}, nil
+	default:
+		return CredentialMaterialization{}, fmt.Errorf("unknown auth style %q", style)
+	}
+}
+
+func headerMutationsFromMap(headers map[string]string) []HeaderMutation {
+	if len(headers) == 0 {
+		return nil
+	}
+	out := make([]HeaderMutation, 0, len(headers))
+	for name, value := range headers {
+		out = append(out, HeaderMutation{
+			Action: HeaderActionSet,
+			Name:   name,
+			Value:  value,
+		})
+	}
+	return out
+}

--- a/internal/egress/egress_test.go
+++ b/internal/egress/egress_test.go
@@ -1,0 +1,135 @@
+package egress
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestApplyHeaderMutations(t *testing.T) {
+	t.Parallel()
+
+	got := ApplyHeaderMutations(map[string]string{
+		"x-api-key": "old",
+		"X-Trace":   "trace-1",
+	}, []HeaderMutation{
+		{Action: HeaderActionReplace, Name: "x-api-key", Value: "new"},
+		{Action: HeaderActionSet, Name: "x-org", Value: "acme"},
+		{Action: HeaderActionRemove, Name: "x-trace"},
+	})
+
+	if got["X-Api-Key"] != "new" {
+		t.Fatalf("X-Api-Key = %q, want new", got["X-Api-Key"])
+	}
+	if got["X-Org"] != "acme" {
+		t.Fatalf("X-Org = %q, want acme", got["X-Org"])
+	}
+	if _, ok := got["X-Trace"]; ok {
+		t.Fatal("X-Trace still present after remove")
+	}
+}
+
+func TestMaterializeCredentialWithParser(t *testing.T) {
+	t.Parallel()
+
+	mat, err := MaterializeCredential("tok", AuthStyleBearer, func(token string) (string, map[string]string, error) {
+		return "Token " + token, map[string]string{"X-Org": "acme"}, nil
+	})
+	if err != nil {
+		t.Fatalf("MaterializeCredential: %v", err)
+	}
+	if mat.Authorization != "Token tok" {
+		t.Fatalf("Authorization = %q, want %q", mat.Authorization, "Token tok")
+	}
+	if len(mat.Headers) != 1 {
+		t.Fatalf("headers = %d, want 1", len(mat.Headers))
+	}
+}
+
+func TestMaterializeCredentialBasic(t *testing.T) {
+	t.Parallel()
+
+	mat, err := MaterializeCredential("user:pass", AuthStyleBasic, nil)
+	if err != nil {
+		t.Fatalf("MaterializeCredential: %v", err)
+	}
+	if mat.Authorization == "" || mat.Authorization[:6] != "Basic " {
+		t.Fatalf("Authorization = %q, want basic auth header", mat.Authorization)
+	}
+}
+
+func TestExecuteHTTP(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"path": r.URL.Path,
+			"auth": r.Header.Get("Authorization"),
+			"org":  r.Header.Get("X-Org"),
+		})
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	result, err := ExecuteHTTP(context.Background(), srv.Client(), HTTPRequestSpec{
+		Target: Target{
+			Method: http.MethodGet,
+			Path:   "/v1/messages",
+		},
+		BaseURL: srv.URL,
+		Credential: CredentialMaterialization{
+			Authorization: "Bearer real-token",
+			Headers: []HeaderMutation{{
+				Action: HeaderActionSet,
+				Name:   "X-Org",
+				Value:  "acme",
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteHTTP: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if resp["path"] != "/v1/messages" {
+		t.Fatalf("path = %v, want /v1/messages", resp["path"])
+	}
+	if resp["auth"] != "Bearer real-token" {
+		t.Fatalf("auth = %v, want Bearer real-token", resp["auth"])
+	}
+	if resp["org"] != "acme" {
+		t.Fatalf("org = %v, want acme", resp["org"])
+	}
+}
+
+type stubPolicy struct {
+	err error
+}
+
+func (s stubPolicy) Evaluate(_ context.Context, _ PolicyInput) error {
+	return s.err
+}
+
+func TestEvaluatePolicyNilSafe(t *testing.T) {
+	t.Parallel()
+
+	if err := EvaluatePolicy(context.Background(), nil, PolicyInput{}); err != nil {
+		t.Fatalf("EvaluatePolicy(nil): %v", err)
+	}
+}
+
+func TestEvaluatePolicyReturnsError(t *testing.T) {
+	t.Parallel()
+
+	want := errors.New("blocked")
+	err := EvaluatePolicy(context.Background(), stubPolicy{err: want}, PolicyInput{})
+	if !errors.Is(err, want) {
+		t.Fatalf("EvaluatePolicy error = %v, want %v", err, want)
+	}
+}

--- a/internal/egress/headers.go
+++ b/internal/egress/headers.go
@@ -1,0 +1,43 @@
+package egress
+
+import "net/http"
+
+// HeaderAction describes how a header mutation should be applied.
+type HeaderAction string
+
+const (
+	HeaderActionSet     HeaderAction = "set"
+	HeaderActionRemove  HeaderAction = "remove"
+	HeaderActionReplace HeaderAction = "replace"
+)
+
+// HeaderMutation applies a single case-insensitive header operation.
+type HeaderMutation struct {
+	Action HeaderAction
+	Name   string
+	Value  string
+}
+
+// ApplyHeaderMutations returns a new header map with the mutations applied.
+func ApplyHeaderMutations(headers map[string]string, mutations []HeaderMutation) map[string]string {
+	out := make(map[string]string, len(headers))
+	for k, v := range headers {
+		out[http.CanonicalHeaderKey(k)] = v
+	}
+
+	for _, mutation := range mutations {
+		name := http.CanonicalHeaderKey(mutation.Name)
+		switch mutation.Action {
+		case HeaderActionRemove:
+			delete(out, name)
+		case HeaderActionReplace:
+			if _, ok := out[name]; ok {
+				out[name] = mutation.Value
+			}
+		default:
+			out[name] = mutation.Value
+		}
+	}
+
+	return out
+}

--- a/internal/egress/http.go
+++ b/internal/egress/http.go
@@ -1,0 +1,48 @@
+package egress
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/apiexec"
+)
+
+// HTTPRequestSpec is the generic outbound HTTP representation shared by
+// product-specific adapters.
+type HTTPRequestSpec struct {
+	Target      Target
+	BaseURL     string
+	Params      map[string]any
+	Headers     map[string]string
+	Body        []byte
+	ContentType string
+	Check       apiexec.ResponseChecker
+	MaxRetries  int
+	NoRetry     bool
+	Credential  CredentialMaterialization
+}
+
+// BuildRequest translates a generic HTTP spec into the existing apiexec request.
+func BuildRequest(spec HTTPRequestSpec) apiexec.Request {
+	headers := ApplyHeaderMutations(spec.Headers, spec.Credential.Headers)
+	return apiexec.Request{
+		Method:        spec.Target.Method,
+		BaseURL:       spec.BaseURL,
+		Path:          spec.Target.Path,
+		Params:        spec.Params,
+		AuthHeader:    spec.Credential.Authorization,
+		CustomHeaders: headers,
+		ContentType:   spec.ContentType,
+		Body:          spec.Body,
+		CheckResponse: spec.Check,
+		MaxRetries:    spec.MaxRetries,
+		NoRetry:       spec.NoRetry,
+	}
+}
+
+// ExecuteHTTP executes the generic HTTP request through the existing apiexec
+// transport.
+func ExecuteHTTP(ctx context.Context, client *http.Client, spec HTTPRequestSpec) (*core.OperationResult, error) {
+	return apiexec.Do(ctx, client, BuildRequest(spec))
+}

--- a/internal/egress/policy.go
+++ b/internal/egress/policy.go
@@ -1,0 +1,24 @@
+package egress
+
+import "context"
+
+// PolicyInput is the normalized request context that policy engines can inspect
+// regardless of whether the call came from a provider invocation or a proxy.
+type PolicyInput struct {
+	Subject Subject
+	Target  Target
+	Headers map[string]string
+}
+
+// PolicyEnforcer decides whether a normalized outbound request is allowed.
+type PolicyEnforcer interface {
+	Evaluate(ctx context.Context, input PolicyInput) error
+}
+
+// EvaluatePolicy is nil-safe so callers can add policy later without branching.
+func EvaluatePolicy(ctx context.Context, enforcer PolicyEnforcer, input PolicyInput) error {
+	if enforcer == nil {
+		return nil
+	}
+	return enforcer.Evaluate(ctx, input)
+}

--- a/internal/egress/types.go
+++ b/internal/egress/types.go
@@ -1,0 +1,26 @@
+package egress
+
+// SubjectKind identifies the caller shape for an outbound egress request.
+type SubjectKind string
+
+const (
+	SubjectUser     SubjectKind = "user"
+	SubjectIdentity SubjectKind = "identity"
+	SubjectAgent    SubjectKind = "agent"
+	SubjectSystem   SubjectKind = "system"
+)
+
+// Subject identifies who initiated an outbound request.
+type Subject struct {
+	Kind SubjectKind
+	ID   string
+}
+
+// Target describes the destination and logical source for an outbound request.
+type Target struct {
+	Provider  string
+	Operation string
+	Method    string
+	Host      string
+	Path      string
+}


### PR DESCRIPTION
## Summary
- add a new `internal/egress` package for shared outbound request building
- model normalized subjects, targets, credential materialization, header mutations, and policy hooks
- add focused tests and a short foundation design note

## Why
This creates a common layer below `core.Provider` that can be reused by both the existing integration platform and a future OneCLI-style proxy surface.

## Stack
- base for follow-up provider and proxy PRs in this egress series