### PR TITLE
Add proxy binding skeleton

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -19,6 +19,7 @@ import (
 	"github.com/valon-technologies/gestalt/internal/provider"
 	"github.com/valon-technologies/gestalt/plugins/auth/google"
 	"github.com/valon-technologies/gestalt/plugins/auth/oidc"
+	"github.com/valon-technologies/gestalt/plugins/bindings/proxy"
 	"github.com/valon-technologies/gestalt/plugins/bindings/webhook"
 	dynamodbstore "github.com/valon-technologies/gestalt/plugins/datastore/dynamodb"
 	"github.com/valon-technologies/gestalt/plugins/datastore/firestore"
@@ -102,6 +103,7 @@ func buildFactories(preparedProviders map[string]string, devMode bool) *bootstra
 		factories.Runtimes["echo"] = echoruntime.Factory
 	}
 	factories.Bindings["webhook"] = webhook.Factory
+	factories.Bindings["proxy"] = proxy.Factory
 	factories.Secrets["env"] = secretsenv.Factory
 	factories.Secrets["file"] = secretsfile.Factory
 	factories.Secrets["gcp_secret_manager"] = secretsgcp.Factory

--- a/docs/pages/reference/built-in-plugins.mdx
+++ b/docs/pages/reference/built-in-plugins.mdx
@@ -45,6 +45,7 @@ All SQL-based datastores (postgres, mysql, oracle, sqlserver) share a common imp
 | Name | Notes |
 |---|---|
 | `webhook` | Exposes HTTP endpoints that forward to provider operations. Supports `public`, `signed` (HMAC-SHA256), and `trusted_user_header` auth modes. Configurable path, provider, operation, and signature headers. |
+| `proxy` | Skeletal proxy-oriented binding that normalizes inbound HTTP requests into shared egress context and returns a `501 Not Implemented` placeholder. Configurable path prefix. |
 
 ## Runtimes
 

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -10,7 +10,7 @@
 | `auth_profiles` | Reusable OAuth settings shared across integrations. |
 | `integrations` | Map of integration name to definition. |
 | `runtimes` | Background processes that boot alongside the server with scoped provider access. |
-| `bindings` | Alternative request surfaces such as webhooks and gRPC. |
+| `bindings` | Alternative request surfaces such as webhooks and proxy-oriented request normalizers. |
 | `server` | Port, base URL, encryption key, and development mode. |
 
 ## Server block
@@ -221,6 +221,11 @@ bindings:
       auth_mode: signed           # "public", "signed", or "trusted_user_header"
       signing_secret: ${WEBHOOK_SECRET}
       signature_header: X-Signature
+
+  agent-proxy:
+    type: proxy
+    config:
+      path: /proxy
 ```
 
 ### Webhook config
@@ -235,6 +240,12 @@ bindings:
 | `signature_header` | `X-Signature` | Header containing the HMAC signature. |
 | `user_header` | | Required when `auth_mode` is `trusted_user_header`. Header containing the user ID. |
 
+### Proxy config
+
+| Config field | Default | Notes |
+|---|---|---|
+| `path` | | HTTP path prefix for the proxy surface. Must start with `/`. |
+
 ## Supported providers
 
 | Category | Providers |
@@ -242,5 +253,5 @@ bindings:
 | Auth | `google`, `oidc` |
 | Datastore | `sqlite`, `postgres`, `mysql`, `dynamodb`, `mongodb`, `firestore`, `oracle`, `sqlserver` |
 | Secrets | `env`, `file`, `gcp_secret_manager` |
-| Bindings | `webhook` |
+| Bindings | `webhook`, `proxy` |
 | Runtimes | `echo` (dev mode only) |

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -19,7 +19,9 @@ import (
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
 	coretesting "github.com/valon-technologies/gestalt/core/testing"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/egress"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	gestaltmcp "github.com/valon-technologies/gestalt/internal/mcp"
 	"github.com/valon-technologies/gestalt/internal/oauth"
@@ -28,6 +30,8 @@ import (
 	"github.com/valon-technologies/gestalt/internal/registry"
 	"github.com/valon-technologies/gestalt/internal/server"
 	"github.com/valon-technologies/gestalt/internal/testutil"
+	"github.com/valon-technologies/gestalt/plugins/bindings/proxy"
+	"gopkg.in/yaml.v3"
 )
 
 func newTestServer(t *testing.T, opts ...func(*server.Config)) *httptest.Server {
@@ -2935,6 +2939,138 @@ func TestBindingRoutesMounted(t *testing.T) {
 	if result["binding"] != "reached" {
 		t.Fatalf("expected binding handler to be reached, got %v", result)
 	}
+}
+
+func TestProxyBindingRoutesMountedAsPrefix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		configuredPath string
+		nestedURL      string
+		exactURL       string
+	}{
+		{
+			name:           "agent-proxy",
+			configuredPath: "/proxy",
+			nestedURL:      "/api/v1/bindings/agent-proxy/proxy/messages?cursor=123",
+			exactURL:       "/api/v1/bindings/agent-proxy/proxy",
+		},
+		{
+			name:           "api-proxy",
+			configuredPath: "/api",
+			nestedURL:      "/api/v1/bindings/api-proxy/api/messages?cursor=123",
+			exactURL:       "/api/v1/bindings/api-proxy/api",
+		},
+		{
+			name:           "root-proxy",
+			configuredPath: "/",
+			nestedURL:      "/api/v1/bindings/root-proxy/messages?cursor=123",
+			exactURL:       "/api/v1/bindings/root-proxy/",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			binding := newTestProxyBinding(t, tc.name, tc.configuredPath)
+			bindings := registry.NewBindingMap()
+			if err := bindings.Register(tc.name, binding); err != nil {
+				t.Fatal(err)
+			}
+
+			ts := newTestServer(t, func(cfg *server.Config) {
+				cfg.DevMode = true
+				cfg.Bindings = bindings
+			})
+			testutil.CloseOnCleanup(t, ts)
+
+			req, err := http.NewRequest(http.MethodPost, ts.URL+tc.nestedURL, bytes.NewBufferString("hello"))
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			req.Header.Set("Content-Type", "text/plain")
+			req.Header.Set("X-Forwarded-Host", "api.example.com")
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+
+			if resp.StatusCode != http.StatusNotImplemented {
+				_ = resp.Body.Close()
+				t.Fatalf("expected 501, got %d", resp.StatusCode)
+			}
+
+			var result struct {
+				Policy egress.PolicyInput `json:"policy_input"`
+				Target egress.Target      `json:"target"`
+				Body   string             `json:"body"`
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+				t.Fatalf("decoding: %v", err)
+			}
+
+			if result.Target.Host != "api.example.com" {
+				t.Fatalf("target host = %q, want api.example.com", result.Target.Host)
+			}
+			if result.Target.Path != "/messages?cursor=123" {
+				t.Fatalf("target path = %q, want /messages?cursor=123", result.Target.Path)
+			}
+			if result.Policy.Subject.Kind != egress.SubjectSystem {
+				t.Fatalf("subject kind = %q, want system", result.Policy.Subject.Kind)
+			}
+			if result.Policy.Subject.ID != tc.name {
+				t.Fatalf("subject id = %q, want %s", result.Policy.Subject.ID, tc.name)
+			}
+			if result.Body != "hello" {
+				t.Fatalf("body = %q, want hello", result.Body)
+			}
+			_ = resp.Body.Close()
+
+			resp, err = http.Get(ts.URL + tc.exactURL)
+			if err != nil {
+				t.Fatalf("exact request: %v", err)
+			}
+
+			if resp.StatusCode != http.StatusNotImplemented {
+				_ = resp.Body.Close()
+				t.Fatalf("expected exact route to return 501, got %d", resp.StatusCode)
+			}
+
+			var exact struct {
+				Target egress.Target `json:"target"`
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&exact); err != nil {
+				t.Fatalf("decoding exact route: %v", err)
+			}
+			_ = resp.Body.Close()
+			if exact.Target.Path != "/" {
+				t.Fatalf("exact target path = %q, want /", exact.Target.Path)
+			}
+		})
+	}
+}
+
+func newTestProxyBinding(t *testing.T, name, path string) core.Binding {
+	t.Helper()
+
+	cfgYAML := "path: " + path
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(cfgYAML), &node); err != nil {
+		t.Fatalf("unmarshal proxy config: %v", err)
+	}
+
+	binding, err := proxy.Factory(context.Background(), name, config.BindingDef{
+		Type:   "proxy",
+		Config: *node.Content[0],
+	}, bootstrap.BindingDeps{})
+	if err != nil {
+		t.Fatalf("proxy factory: %v", err)
+	}
+	return binding
 }
 
 func newMCPHandler(t *testing.T, providers *registry.PluginMap[core.Provider], ds core.Datastore) http.Handler {

--- a/plugins/bindings/internal/httpjson/httpjson.go
+++ b/plugins/bindings/internal/httpjson/httpjson.go
@@ -1,0 +1,16 @@
+package httpjson
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func WriteJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func WriteError(w http.ResponseWriter, status int, message string) {
+	WriteJSON(w, status, map[string]string{"error": message})
+}

--- a/plugins/bindings/proxy/binding.go
+++ b/plugins/bindings/proxy/binding.go
@@ -1,0 +1,185 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/textproto"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/egress"
+	"github.com/valon-technologies/gestalt/plugins/bindings/internal/httpjson"
+)
+
+var _ core.Binding = (*Binding)(nil)
+
+type Binding struct {
+	name string
+	cfg  proxyConfig
+}
+
+func New(name string, cfg proxyConfig) *Binding {
+	return &Binding{name: name, cfg: cfg}
+}
+
+func (b *Binding) Name() string           { return b.name }
+func (b *Binding) Kind() core.BindingKind { return core.BindingSurface }
+
+func (b *Binding) Start(_ context.Context) error { return nil }
+func (b *Binding) Close() error                  { return nil }
+
+func (b *Binding) Routes() []core.Route {
+	patterns := b.cfg.routePatterns()
+	routes := make([]core.Route, 0, len(b.cfg.methods())*len(patterns))
+	for _, method := range b.cfg.methods() {
+		for _, pattern := range patterns {
+			routes = append(routes, core.Route{
+				Method:  method,
+				Pattern: pattern,
+				Handler: http.HandlerFunc(b.handle),
+			})
+		}
+	}
+	return routes
+}
+
+func (b *Binding) handle(w http.ResponseWriter, r *http.Request) {
+	norm, err := b.normalize(r)
+	if err != nil {
+		httpjson.WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if r.Method == http.MethodConnect {
+		norm.Note = "CONNECT proxying is not implemented yet"
+	} else {
+		norm.Note = "proxy binding skeleton: request normalized, dispatch not wired"
+	}
+
+	httpjson.WriteJSON(w, http.StatusNotImplemented, norm)
+}
+
+func (b *Binding) normalize(r *http.Request) (normalizedRequest, error) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		return normalizedRequest{}, fmt.Errorf("reading request body: %w", err)
+	}
+	defer func() { _ = r.Body.Close() }()
+
+	headers := normalizeHeaders(r.Header)
+	target := egress.Target{
+		Method: r.Method,
+		Host:   resolveHost(r),
+		Path:   resolvePath(r, b.cfg.normalizedPath()),
+	}
+
+	policy := egress.PolicyInput{
+		Subject: egress.Subject{
+			Kind: egress.SubjectSystem,
+			ID:   b.name,
+		},
+		Target:  target,
+		Headers: headers,
+	}
+
+	norm := normalizedRequest{
+		Policy: policy,
+		Target: target,
+	}
+	if len(body) > 0 {
+		norm.Body = string(body)
+	}
+	return norm, nil
+}
+
+func resolveHost(r *http.Request) string {
+	if r.URL != nil && r.URL.Host != "" {
+		return r.URL.Host
+	}
+	if host := r.Header.Get("X-Forwarded-Host"); host != "" {
+		return host
+	}
+	if r.Host != "" {
+		return r.Host
+	}
+	return ""
+}
+
+func resolvePath(r *http.Request, configuredPath string) string {
+	suffix := strings.TrimPrefix(chi.URLParam(r, "*"), "/")
+	if suffix == "" && shouldUseConfiguredPathFallback(r) {
+		if fallback, ok := configuredPathSuffix(r, configuredPath); ok {
+			suffix = fallback
+		}
+	}
+
+	path := "/"
+	if suffix != "" {
+		path += suffix
+	}
+	if rawQuery := requestRawQuery(r); rawQuery != "" {
+		return path + "?" + rawQuery
+	}
+	return path
+}
+
+func normalizeHeaders(headers http.Header) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(headers))
+	for k, values := range headers {
+		if len(values) == 0 {
+			continue
+		}
+		out[textproto.CanonicalMIMEHeaderKey(k)] = strings.Join(values, ",")
+	}
+	return out
+}
+
+func configuredPathSuffix(r *http.Request, configuredPath string) (string, bool) {
+	path := requestPath(r)
+	switch {
+	case configuredPath == "/":
+		return strings.TrimPrefix(path, "/"), true
+	case path == configuredPath:
+		return "", true
+	case strings.HasPrefix(path, configuredPath+"/"):
+		return strings.TrimPrefix(path, configuredPath+"/"), true
+	default:
+		return "", false
+	}
+}
+
+func shouldUseConfiguredPathFallback(r *http.Request) bool {
+	rctx := chi.RouteContext(r.Context())
+	return rctx == nil || len(rctx.RoutePatterns) == 0
+}
+
+func requestPath(r *http.Request) string {
+	if r.URL != nil && r.URL.Path != "" {
+		return r.URL.Path
+	}
+	if r.RequestURI == "" {
+		return "/"
+	}
+	path, _, _ := strings.Cut(r.RequestURI, "?")
+	if path == "" {
+		return "/"
+	}
+	return path
+}
+
+func requestRawQuery(r *http.Request) string {
+	if r.URL != nil {
+		return r.URL.RawQuery
+	}
+	_, rawQuery, ok := strings.Cut(r.RequestURI, "?")
+	if !ok {
+		return ""
+	}
+	return rawQuery
+}

--- a/plugins/bindings/proxy/config.go
+++ b/plugins/bindings/proxy/config.go
@@ -1,0 +1,56 @@
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/internal/egress"
+)
+
+type proxyConfig struct {
+	Path string `yaml:"path"`
+}
+
+type normalizedRequest struct {
+	Note   string             `json:"note"`
+	Policy egress.PolicyInput `json:"policy_input"`
+	Target egress.Target      `json:"target"`
+	Body   string             `json:"body,omitempty"`
+}
+
+func (c proxyConfig) validate(name string) error {
+	if c.Path == "" || !strings.HasPrefix(c.Path, "/") {
+		return fmt.Errorf("proxy %q: path must be non-empty and start with /", name)
+	}
+	return nil
+}
+
+func (c proxyConfig) methods() []string {
+	return []string{
+		http.MethodGet,
+		http.MethodHead,
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodPatch,
+		http.MethodDelete,
+		http.MethodOptions,
+		http.MethodConnect,
+	}
+}
+
+func (c proxyConfig) normalizedPath() string {
+	path := strings.TrimSuffix(c.Path, "/")
+	if path == "" {
+		return "/"
+	}
+	return path
+}
+
+func (c proxyConfig) routePatterns() []string {
+	path := c.normalizedPath()
+	if path == "/" {
+		return []string{"/", "/*"}
+	}
+	return []string{path, path + "/*"}
+}

--- a/plugins/bindings/proxy/factory.go
+++ b/plugins/bindings/proxy/factory.go
@@ -1,0 +1,20 @@
+package proxy
+
+import (
+	"context"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+)
+
+var Factory bootstrap.BindingFactory = func(_ context.Context, name string, def config.BindingDef, _ bootstrap.BindingDeps) (core.Binding, error) {
+	var cfg proxyConfig
+	if err := def.Config.Decode(&cfg); err != nil {
+		return nil, err
+	}
+	if err := cfg.validate(name); err != nil {
+		return nil, err
+	}
+	return New(name, cfg), nil
+}

--- a/plugins/bindings/proxy/proxy_test.go
+++ b/plugins/bindings/proxy/proxy_test.go
@@ -1,0 +1,144 @@
+package proxy_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/egress"
+	"github.com/valon-technologies/gestalt/plugins/bindings/proxy"
+	"gopkg.in/yaml.v3"
+)
+
+func TestProxyRoutes(t *testing.T) {
+	t.Parallel()
+
+	b := makeBinding(t, "/proxy")
+	routes := b.Routes()
+	if len(routes) != 16 {
+		t.Fatalf("expected 16 routes, got %d", len(routes))
+	}
+	patterns := map[string]int{}
+	for _, route := range routes {
+		patterns[route.Pattern]++
+	}
+	if patterns["/proxy"] != 8 {
+		t.Fatalf("expected 8 exact routes, got %d", patterns["/proxy"])
+	}
+	if patterns["/proxy/*"] != 8 {
+		t.Fatalf("expected 8 wildcard routes, got %d", patterns["/proxy/*"])
+	}
+}
+
+func TestProxyNormalizeRequest(t *testing.T) {
+	t.Parallel()
+
+	b := makeBinding(t, "/proxy")
+	req := httptest.NewRequest(http.MethodPost, "/proxy/messages?cursor=123", bytes.NewBufferString("hello"))
+	req.Host = "api.example.com"
+	req.Header.Set("X-Proxy-Token", "abc")
+
+	w := httptest.NewRecorder()
+	b.Routes()[0].Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501", w.Code)
+	}
+
+	var resp struct {
+		Note   string             `json:"note"`
+		Policy egress.PolicyInput `json:"policy_input"`
+		Target egress.Target      `json:"target"`
+		Body   string             `json:"body"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Target.Host != "api.example.com" {
+		t.Fatalf("target host = %q, want api.example.com", resp.Target.Host)
+	}
+	if resp.Target.Method != http.MethodPost {
+		t.Fatalf("target method = %q, want POST", resp.Target.Method)
+	}
+	if resp.Target.Path != "/messages?cursor=123" {
+		t.Fatalf("target path = %q, want /messages?cursor=123", resp.Target.Path)
+	}
+	if resp.Policy.Subject.Kind != egress.SubjectSystem {
+		t.Fatalf("subject kind = %q, want system", resp.Policy.Subject.Kind)
+	}
+	if resp.Body != "hello" {
+		t.Fatalf("body = %q, want hello", resp.Body)
+	}
+}
+
+func TestProxyFactory(t *testing.T) {
+	t.Parallel()
+
+	cfgYAML := `path: /proxy`
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(cfgYAML), &node); err != nil {
+		t.Fatal(err)
+	}
+
+	def := config.BindingDef{
+		Type:   "proxy",
+		Config: *node.Content[0],
+	}
+
+	binding, err := proxy.Factory(context.Background(), "proxy-surface", def, bootstrap.BindingDeps{})
+	if err != nil {
+		t.Fatalf("Factory: %v", err)
+	}
+
+	if binding.Name() != "proxy-surface" {
+		t.Fatalf("name = %q, want proxy-surface", binding.Name())
+	}
+	if binding.Kind() != core.BindingSurface {
+		t.Fatalf("kind = %v, want BindingSurface", binding.Kind())
+	}
+}
+
+func TestProxyFactoryValidation(t *testing.T) {
+	t.Parallel()
+
+	cfgYAML := `path: proxy`
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(cfgYAML), &node); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := proxy.Factory(context.Background(), "bad-proxy", config.BindingDef{
+		Type:   "proxy",
+		Config: *node.Content[0],
+	}, bootstrap.BindingDeps{})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func makeBinding(t *testing.T, path string) *proxy.Binding {
+	t.Helper()
+
+	cfgYAML := "path: " + path
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(cfgYAML), &node); err != nil {
+		t.Fatal(err)
+	}
+
+	binding, err := proxy.Factory(context.Background(), "proxy-surface", config.BindingDef{
+		Type:   "proxy",
+		Config: *node.Content[0],
+	}, bootstrap.BindingDeps{})
+	if err != nil {
+		t.Fatalf("Factory: %v", err)
+	}
+
+	return binding.(*proxy.Binding)
+}

--- a/plugins/bindings/webhook/webhook.go
+++ b/plugins/bindings/webhook/webhook.go
@@ -12,6 +12,7 @@ import (
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	"github.com/valon-technologies/gestalt/internal/principal"
+	"github.com/valon-technologies/gestalt/plugins/bindings/internal/httpjson"
 )
 
 var _ core.Binding = (*Binding)(nil)
@@ -63,7 +64,7 @@ func (b *Binding) Routes() []core.Route {
 func (b *Binding) handle(w http.ResponseWriter, r *http.Request) {
 	rawBody, err := io.ReadAll(r.Body)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "failed to read body")
+		httpjson.WriteError(w, http.StatusBadRequest, "failed to read body")
 		return
 	}
 	defer func() { _ = r.Body.Close() }()
@@ -78,11 +79,11 @@ func (b *Binding) handle(w http.ResponseWriter, r *http.Request) {
 		}
 		sig := r.Header.Get(header)
 		if sig == "" {
-			writeError(w, http.StatusUnauthorized, "missing signature")
+			httpjson.WriteError(w, http.StatusUnauthorized, "missing signature")
 			return
 		}
 		if err := verifySignature([]byte(b.cfg.SigningSecret), rawBody, sig); err != nil {
-			writeError(w, http.StatusUnauthorized, "invalid signature")
+			httpjson.WriteError(w, http.StatusUnauthorized, "invalid signature")
 			return
 		}
 
@@ -101,13 +102,13 @@ func (b *Binding) handle(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 			if !trusted {
-				writeError(w, http.StatusForbidden, "untrusted source")
+				httpjson.WriteError(w, http.StatusForbidden, "untrusted source")
 				return
 			}
 		}
 		userID = r.Header.Get(b.cfg.UserHeader)
 		if userID == "" {
-			writeError(w, http.StatusUnauthorized, "missing user header")
+			httpjson.WriteError(w, http.StatusUnauthorized, "missing user header")
 			return
 		}
 	}
@@ -115,13 +116,13 @@ func (b *Binding) handle(w http.ResponseWriter, r *http.Request) {
 	var body map[string]any
 	if len(rawBody) > 0 {
 		if err := json.Unmarshal(rawBody, &body); err != nil {
-			writeError(w, http.StatusBadRequest, err.Error())
+			httpjson.WriteError(w, http.StatusBadRequest, err.Error())
 			return
 		}
 	}
 
 	if b.cfg.Provider == "" || b.cfg.Operation == "" {
-		writeJSON(w, http.StatusOK, body)
+		httpjson.WriteJSON(w, http.StatusOK, body)
 		return
 	}
 
@@ -132,21 +133,11 @@ func (b *Binding) handle(w http.ResponseWriter, r *http.Request) {
 
 	result, err := b.invoker.Invoke(ctx, p, b.cfg.Provider, b.cfg.Instance, b.cfg.Operation, body)
 	if err != nil {
-		writeError(w, http.StatusBadGateway, "upstream invocation failed")
+		httpjson.WriteError(w, http.StatusBadGateway, "upstream invocation failed")
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(result.Status)
 	_, _ = fmt.Fprint(w, result.Body)
-}
-
-func writeJSON(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(v)
-}
-
-func writeError(w http.ResponseWriter, status int, message string) {
-	writeJSON(w, status, map[string]string{"error": message})
 }


### PR DESCRIPTION
## Summary
- add a new `proxy` binding plugin and register it in `gestaltd`
- normalize inbound requests into `egress.Target` and `egress.PolicyInput`
- return a structured `501 Not Implemented` placeholder while the credential/policy engine is still being wired
- add focused tests and config/docs updates

## Stack
- depends on #86