### PR TITLE
Route REST execution through shared egress core

### DIFF
--- a/core/integration/base.go
+++ b/core/integration/base.go
@@ -2,14 +2,13 @@ package integration
 
 import (
 	"context"
-	"encoding/base64"
-	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
 	"github.com/valon-technologies/gestalt/internal/apiexec"
+	"github.com/valon-technologies/gestalt/internal/egress"
 	"github.com/valon-technologies/gestalt/internal/oauth"
 	"github.com/valon-technologies/gestalt/internal/paraminterp"
 )
@@ -255,37 +254,7 @@ func (b *Base) Execute(ctx context.Context, operation string, params map[string]
 		return b.executeGraphQL(ctx, query, params, token)
 	}
 
-	ep, ok := b.Endpoints[operation]
-	if !ok {
-		return nil, fmt.Errorf("unknown operation: %s", operation)
-	}
-
-	baseURL, headers := b.resolvedURLAndHeaders(ctx)
-
-	req := apiexec.Request{
-		Method:        ep.Method,
-		BaseURL:       baseURL,
-		Path:          ep.Path,
-		Params:        params,
-		CustomHeaders: headers,
-		CheckResponse: b.CheckResponse,
-	}
-
-	if err := b.applyAuth(&req, token); err != nil {
-		return nil, err
-	}
-
-	if b.RequestMutator != nil {
-		if err := b.RequestMutator(operation, &req, params); err != nil {
-			return nil, err
-		}
-	}
-
-	if pgn, ok := b.Pagination[operation]; ok {
-		return apiexec.DoPaginated(ctx, b.httpClient(), req, pgn)
-	}
-
-	return apiexec.Do(ctx, b.httpClient(), req)
+	return b.executeREST(ctx, operation, params, token)
 }
 
 func (b *Base) executeGraphQL(ctx context.Context, query string, params map[string]any, token string) (*core.OperationResult, error) {
@@ -303,62 +272,58 @@ func (b *Base) executeGraphQL(ctx context.Context, query string, params map[stri
 	return apiexec.DoGraphQL(ctx, b.httpClient(), gqlReq)
 }
 
-type resolvedAuth struct {
-	token        string
-	authHeader   string
-	extraHeaders map[string]string
+func (b *Base) egressAuthStyle() egress.AuthStyle {
+	switch b.AuthStyle {
+	case AuthStyleRaw:
+		return egress.AuthStyleRaw
+	case AuthStyleNone:
+		return egress.AuthStyleNone
+	case AuthStyleBasic:
+		return egress.AuthStyleBasic
+	default:
+		return egress.AuthStyleBearer
+	}
 }
 
-func (b *Base) resolveAuth(token string) (resolvedAuth, error) {
-	if b.TokenParser != nil {
-		authHeader, extraHeaders, err := b.TokenParser(token)
-		if err != nil {
-			return resolvedAuth{}, err
-		}
-		return resolvedAuth{authHeader: authHeader, extraHeaders: extraHeaders}, nil
-	}
-	switch b.AuthStyle {
-	case AuthStyleBearer:
-		return resolvedAuth{token: token}, nil
-	case AuthStyleRaw:
-		return resolvedAuth{authHeader: token}, nil
-	case AuthStyleBasic:
-		return resolvedAuth{authHeader: "Basic " + base64.StdEncoding.EncodeToString([]byte(token))}, nil
-	default:
-		return resolvedAuth{}, nil
-	}
+func (b *Base) materializeCredential(token string) (egress.CredentialMaterialization, error) {
+	return egress.MaterializeCredential(token, b.egressAuthStyle(), b.TokenParser)
 }
 
 func (b *Base) applyAuth(req *apiexec.Request, token string) error {
-	auth, err := b.resolveAuth(token)
+	auth, err := b.materializeCredential(token)
 	if err != nil {
 		return err
 	}
-	req.Token = auth.token
-	req.AuthHeader = auth.authHeader
-	for k, v := range auth.extraHeaders {
+	req.Token, req.AuthHeader = b.requestAuthFields(token, auth)
+	for _, header := range auth.Headers {
 		if req.CustomHeaders == nil {
 			req.CustomHeaders = make(map[string]string)
 		}
-		req.CustomHeaders[k] = v
+		req.CustomHeaders[header.Name] = header.Value
 	}
 	return nil
 }
 
 func (b *Base) applyGraphQLAuth(req *apiexec.GraphQLRequest, token string) error {
-	auth, err := b.resolveAuth(token)
+	auth, err := b.materializeCredential(token)
 	if err != nil {
 		return err
 	}
-	req.Token = auth.token
-	req.AuthHeader = auth.authHeader
-	for k, v := range auth.extraHeaders {
+	req.Token, req.AuthHeader = b.requestAuthFields(token, auth)
+	for _, header := range auth.Headers {
 		if req.CustomHeaders == nil {
 			req.CustomHeaders = make(map[string]string)
 		}
-		req.CustomHeaders[k] = v
+		req.CustomHeaders[header.Name] = header.Value
 	}
 	return nil
+}
+
+func (b *Base) requestAuthFields(token string, auth egress.CredentialMaterialization) (string, string) {
+	if b.TokenParser == nil && b.AuthStyle == AuthStyleBearer {
+		return token, ""
+	}
+	return "", auth.Authorization
 }
 
 func copyHeaders(h map[string]string) map[string]string {

--- a/core/integration/base_test.go
+++ b/core/integration/base_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/apiexec"
 )
 
 type mockAuth struct{}
@@ -100,6 +101,97 @@ func TestBaseTokenParserOverridesAuthorization(t *testing.T) {
 	}
 	if resp["custom"] != "value" {
 		t.Fatalf("custom = %v, want value", resp["custom"])
+	}
+}
+
+func TestBaseExecuteRESTUsesMaterializedRequestState(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"auth":    r.Header.Get("Authorization"),
+			"client":  r.Header.Get("X-Client"),
+			"mutated": r.Header.Get("X-Mutated"),
+		})
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL,
+		Endpoints: map[string]Endpoint{
+			"op": {Method: http.MethodGet, Path: "/test"},
+		},
+		TokenParser: func(token string) (string, map[string]string, error) {
+			return "Token " + token, map[string]string{"X-Client": "alpha"}, nil
+		},
+		RequestMutator: func(_ string, req *apiexec.Request, _ map[string]any) error {
+			req.AuthHeader = "Token override"
+			req.CustomHeaders["X-Mutated"] = "yes"
+			return nil
+		},
+	}
+
+	result, err := b.Execute(context.Background(), "op", nil, "original")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if resp["auth"] != "Token override" {
+		t.Fatalf("auth = %v, want Token override", resp["auth"])
+	}
+	if resp["client"] != "alpha" {
+		t.Fatalf("client = %v, want alpha", resp["client"])
+	}
+	if resp["mutated"] != "yes" {
+		t.Fatalf("mutated = %v, want yes", resp["mutated"])
+	}
+}
+
+func TestBaseExecuteRESTAllowsBearerTokenOverrideFromRequestMutator(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"auth":    r.Header.Get("Authorization"),
+			"mutated": r.Header.Get("X-Mutated"),
+		})
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL,
+		Endpoints: map[string]Endpoint{
+			"op": {Method: http.MethodGet, Path: "/test"},
+		},
+		RequestMutator: func(_ string, req *apiexec.Request, _ map[string]any) error {
+			req.Token = "override"
+			req.CustomHeaders = map[string]string{"X-Mutated": "yes"}
+			return nil
+		},
+	}
+
+	result, err := b.Execute(context.Background(), "op", nil, "original")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if resp["auth"] != "Bearer override" {
+		t.Fatalf("auth = %v, want Bearer override", resp["auth"])
+	}
+	if resp["mutated"] != "yes" {
+		t.Fatalf("mutated = %v, want yes", resp["mutated"])
 	}
 }
 

--- a/core/integration/egress_adapter.go
+++ b/core/integration/egress_adapter.go
@@ -1,0 +1,74 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/apiexec"
+	"github.com/valon-technologies/gestalt/internal/egress"
+)
+
+func (b *Base) executeREST(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
+	ep, ok := b.Endpoints[operation]
+	if !ok {
+		return nil, fmt.Errorf("unknown operation: %s", operation)
+	}
+
+	baseURL, headers := b.resolvedURLAndHeaders(ctx)
+	req := apiexec.Request{
+		Method:        ep.Method,
+		BaseURL:       baseURL,
+		Path:          ep.Path,
+		Params:        params,
+		CustomHeaders: headers,
+		CheckResponse: b.CheckResponse,
+	}
+
+	if err := b.applyAuth(&req, token); err != nil {
+		return nil, err
+	}
+
+	if b.RequestMutator != nil {
+		if err := b.RequestMutator(operation, &req, params); err != nil {
+			return nil, err
+		}
+	}
+
+	if pgn, ok := b.Pagination[operation]; ok {
+		return apiexec.DoPaginatedWithExecutor(ctx, b.httpClient(), req, pgn, executeEgressHTTP)
+	}
+
+	return executeEgressHTTP(ctx, b.httpClient(), req)
+}
+
+func executeEgressHTTP(ctx context.Context, client *http.Client, req apiexec.Request) (*core.OperationResult, error) {
+	return egress.ExecuteHTTP(ctx, client, egressRequestFromAPIExec(req))
+}
+
+func egressRequestFromAPIExec(req apiexec.Request) egress.HTTPRequestSpec {
+	credential := egress.CredentialMaterialization{}
+	switch {
+	case req.AuthHeader != "":
+		credential.Authorization = req.AuthHeader
+	case req.Token != "":
+		credential.Authorization = core.BearerScheme + req.Token
+	}
+
+	return egress.HTTPRequestSpec{
+		Target: egress.Target{
+			Method: req.Method,
+			Path:   req.Path,
+		},
+		BaseURL:     req.BaseURL,
+		Params:      req.Params,
+		Headers:     copyHeaders(req.CustomHeaders),
+		Body:        req.Body,
+		ContentType: req.ContentType,
+		Check:       req.CheckResponse,
+		MaxRetries:  req.MaxRetries,
+		NoRetry:     req.NoRetry,
+		Credential:  credential,
+	}
+}

--- a/internal/apiexec/pagination.go
+++ b/internal/apiexec/pagination.go
@@ -31,6 +31,8 @@ type PaginationConfig struct {
 	MaxPages     int
 }
 
+type RequestExecutor func(context.Context, *http.Client, Request) (*core.OperationResult, error)
+
 func (p PaginationConfig) maxPages() int {
 	if p.MaxPages > 0 {
 		return p.MaxPages
@@ -41,6 +43,20 @@ func (p PaginationConfig) maxPages() int {
 // DoPaginated fetches all pages of a paginated API endpoint and combines the
 // results into a single JSON array. It delegates each individual request to Do.
 func DoPaginated(ctx context.Context, client *http.Client, req Request, pgn PaginationConfig) (*core.OperationResult, error) {
+	return doPaginated(ctx, client, req, pgn, Do)
+}
+
+// DoPaginatedWithExecutor runs the shared pagination loop using a custom
+// request executor. This is used by callers that want apiexec's pagination
+// semantics while swapping the transport implementation.
+func DoPaginatedWithExecutor(ctx context.Context, client *http.Client, req Request, pgn PaginationConfig, exec RequestExecutor) (*core.OperationResult, error) {
+	if exec == nil {
+		exec = Do
+	}
+	return doPaginated(ctx, client, req, pgn, exec)
+}
+
+func doPaginated(ctx context.Context, client *http.Client, req Request, pgn PaginationConfig, exec RequestExecutor) (*core.OperationResult, error) {
 	params := copyParams(req.Params)
 	if params == nil {
 		params = make(map[string]any)
@@ -66,7 +82,7 @@ func DoPaginated(ctx context.Context, client *http.Client, req Request, pgn Pagi
 		pageReq := req
 		pageReq.Params = copyParams(params)
 
-		result, err := Do(ctx, client, pageReq)
+		result, err := exec(ctx, client, pageReq)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- route REST provider execution through `internal/egress`
- keep GraphQL on the existing execution path to preserve behavior
- add coverage proving REST execution now uses the shared egress semantics

## Stack
- depends on #86