### PR TITLE
Fix oauth_registrations unique key exceeding MySQL max key length

### DIFF
--- a/internal/mcpoauth/sqlstore.go
+++ b/internal/mcpoauth/sqlstore.go
@@ -38,8 +38,8 @@ func (s *SQLStore) ph(n int) string { return s.dialect.Placeholder(n) }
 
 const defaultRegistrationDDL = `CREATE TABLE IF NOT EXISTS oauth_registrations (
 	id VARCHAR(36) PRIMARY KEY,
-	auth_server_url VARCHAR(500) NOT NULL,
-	redirect_uri VARCHAR(500) NOT NULL,
+	auth_server_url VARCHAR(255) NOT NULL,
+	redirect_uri VARCHAR(255) NOT NULL,
 	client_id VARCHAR(255) NOT NULL,
 	client_secret_encrypted TEXT,
 	authorization_endpoint VARCHAR(500) NOT NULL,

--- a/plugins/datastore/oracle/oracle.go
+++ b/plugins/datastore/oracle/oracle.go
@@ -49,8 +49,8 @@ func (dialect) RegistrationDDL() string {
 		IF v_count = 0 THEN
 			EXECUTE IMMEDIATE 'CREATE TABLE oauth_registrations (
 				id VARCHAR2(36) PRIMARY KEY,
-				auth_server_url VARCHAR2(500) NOT NULL,
-				redirect_uri VARCHAR2(500) NOT NULL,
+				auth_server_url VARCHAR2(255) NOT NULL,
+				redirect_uri VARCHAR2(255) NOT NULL,
 				client_id VARCHAR2(255) NOT NULL,
 				client_secret_encrypted CLOB,
 				authorization_endpoint VARCHAR2(500) NOT NULL,

--- a/plugins/datastore/sqlserver/sqlserver.go
+++ b/plugins/datastore/sqlserver/sqlserver.go
@@ -49,8 +49,8 @@ func (dialect) RegistrationDDL() string {
 	return `IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'oauth_registrations')
 		CREATE TABLE oauth_registrations (
 			id NVARCHAR(36) NOT NULL PRIMARY KEY,
-			auth_server_url NVARCHAR(500) NOT NULL,
-			redirect_uri NVARCHAR(500) NOT NULL,
+			auth_server_url NVARCHAR(255) NOT NULL,
+			redirect_uri NVARCHAR(255) NOT NULL,
 			client_id NVARCHAR(255) NOT NULL,
 			client_secret_encrypted NVARCHAR(MAX),
 			authorization_endpoint NVARCHAR(500) NOT NULL,


### PR DESCRIPTION
The UNIQUE constraint on (auth_server_url, redirect_uri) with VARCHAR(500)
columns exceeded MySQL's 3072-byte max key length under utf8mb4 encoding
(500*4 + 500*4 = 4000 bytes), causing CREATE TABLE IF NOT EXISTS to fail
silently at startup. Reduced both columns to VARCHAR(255) across all dialect
DDLs (MySQL default, PostgreSQL, SQL Server, Oracle). Authorization server
origins and redirect URIs are well within 255 characters in practice.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>