### PR TITLE
Add functional tests for MCP OAuth discovery and DCR flow

### DIFF
--- a/internal/mcpoauth/mcpoauth_test.go
+++ b/internal/mcpoauth/mcpoauth_test.go
@@ -1,0 +1,237 @@
+package mcpoauth_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/internal/mcpoauth"
+	"github.com/valon-technologies/gestalt/internal/testutil"
+)
+
+type memStore struct {
+	mu   sync.Mutex
+	regs map[string]*mcpoauth.Registration
+}
+
+func (s *memStore) GetRegistration(_ context.Context, authServerURL, redirectURI string) (*mcpoauth.Registration, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.regs[authServerURL+"|"+redirectURI], nil
+}
+
+func (s *memStore) StoreRegistration(_ context.Context, reg *mcpoauth.Registration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.regs[reg.AuthServerURL+"|"+reg.RedirectURI] = reg
+	return nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	if status != 0 {
+		w.WriteHeader(status)
+	}
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func TestMCPOAuthFlow(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RFC9728", func(t *testing.T) {
+		t.Parallel()
+
+		var dcrBody map[string]any
+
+		mux := http.NewServeMux()
+
+		mux.HandleFunc("POST /mcp", func(w http.ResponseWriter, r *http.Request) {
+			baseURL := "http://" + r.Host
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf(
+				`Bearer resource_metadata="%s/.well-known/oauth-protected-resource/mcp"`, baseURL))
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+
+		mux.HandleFunc("GET /.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
+			baseURL := "http://" + r.Host
+			writeJSON(w, 0, map[string]any{
+				"resource":              baseURL + "/mcp",
+				"authorization_servers": []string{baseURL},
+				"scopes_supported":      []string{"read", "write"},
+			})
+		})
+
+		mux.HandleFunc("GET /.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+			baseURL := "http://" + r.Host
+			writeJSON(w, 0, map[string]any{
+				"issuer":                                baseURL,
+				"authorization_endpoint":                baseURL + "/oauth/authorize",
+				"token_endpoint":                        baseURL + "/oauth/token",
+				"registration_endpoint":                 baseURL + "/oauth/register",
+				"scopes_supported":                      []string{"read", "write"},
+				"code_challenge_methods_supported":      []string{"S256"},
+				"token_endpoint_auth_methods_supported": []string{"none", "client_secret_post"},
+			})
+		})
+
+		mux.HandleFunc("POST /oauth/register", func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewDecoder(r.Body).Decode(&dcrBody)
+			writeJSON(w, http.StatusCreated, map[string]any{
+				"client_id": "dcr-client-001",
+			})
+		})
+
+		mux.HandleFunc("POST /oauth/token", func(w http.ResponseWriter, r *http.Request) {
+			_ = r.ParseForm()
+			if r.Form.Get("grant_type") != "authorization_code" {
+				http.Error(w, "bad grant_type", http.StatusBadRequest)
+				return
+			}
+			if r.Form.Get("code") == "" {
+				http.Error(w, "missing code", http.StatusBadRequest)
+				return
+			}
+			writeJSON(w, 0, map[string]any{
+				"access_token":  "access-tok-123",
+				"refresh_token": "refresh-tok-456",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+			})
+		})
+
+		srv := httptest.NewServer(mux)
+		testutil.CloseOnCleanup(t, srv)
+
+		store := &memStore{regs: make(map[string]*mcpoauth.Registration)}
+		handler := mcpoauth.NewHandler(mcpoauth.HandlerConfig{
+			MCPURL:      srv.URL + "/mcp",
+			Store:       store,
+			RedirectURL: "http://localhost:9999/callback",
+		})
+
+		authURL, verifier := handler.StartOAuth("test-state", nil)
+
+		if authURL == "" {
+			t.Fatal("expected non-empty auth URL")
+		}
+		if verifier == "" {
+			t.Fatal("expected non-empty PKCE verifier")
+		}
+
+		parsed, err := url.Parse(authURL)
+		if err != nil {
+			t.Fatalf("parsing auth URL: %v", err)
+		}
+		if !strings.HasPrefix(parsed.Path, "/oauth/authorize") {
+			t.Errorf("auth URL path = %q, want /oauth/authorize prefix", parsed.Path)
+		}
+		if parsed.Query().Get("client_id") != "dcr-client-001" {
+			t.Errorf("client_id = %q, want dcr-client-001", parsed.Query().Get("client_id"))
+		}
+		if parsed.Query().Get("code_challenge_method") != "S256" {
+			t.Errorf("code_challenge_method = %q, want S256", parsed.Query().Get("code_challenge_method"))
+		}
+
+		grantTypes, _ := dcrBody["grant_types"].([]any)
+		if len(grantTypes) != 2 {
+			t.Fatalf("DCR grant_types length = %d, want 2", len(grantTypes))
+		}
+		if grantTypes[0] != "authorization_code" || grantTypes[1] != "refresh_token" {
+			t.Errorf("DCR grant_types = %v, want [authorization_code, refresh_token]", grantTypes)
+		}
+
+		reg, _ := store.GetRegistration(context.Background(), srv.URL, "http://localhost:9999/callback")
+		if reg == nil {
+			t.Fatal("expected stored registration")
+		}
+		if reg.ClientID != "dcr-client-001" {
+			t.Errorf("stored client_id = %q, want dcr-client-001", reg.ClientID)
+		}
+
+		tokenResp, err := handler.ExchangeCodeWithVerifier(context.Background(), "auth-code-xyz", verifier)
+		if err != nil {
+			t.Fatalf("ExchangeCodeWithVerifier: %v", err)
+		}
+		if tokenResp.AccessToken != "access-tok-123" {
+			t.Errorf("access_token = %q, want access-tok-123", tokenResp.AccessToken)
+		}
+		if tokenResp.RefreshToken != "refresh-tok-456" {
+			t.Errorf("refresh_token = %q, want refresh-tok-456", tokenResp.RefreshToken)
+		}
+	})
+
+	t.Run("DirectEndpoints", func(t *testing.T) {
+		t.Parallel()
+
+		mux := http.NewServeMux()
+
+		mux.HandleFunc("POST /mcp", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+
+		mux.HandleFunc("GET /.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
+			baseURL := "http://" + r.Host
+			writeJSON(w, 0, map[string]any{
+				"authorization_endpoint":                baseURL + "/oauth/authorize",
+				"token_endpoint":                        baseURL + "/oauth/token",
+				"registration_endpoint":                 baseURL + "/oauth/register",
+				"scopes_supported":                      []string{"query"},
+				"code_challenge_methods_supported":      []string{"S256"},
+				"token_endpoint_auth_methods_supported": []string{"none"},
+			})
+		})
+
+		mux.HandleFunc("POST /oauth/register", func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, http.StatusCreated, map[string]any{
+				"client_id": "direct-client-001",
+			})
+		})
+
+		mux.HandleFunc("POST /oauth/token", func(w http.ResponseWriter, r *http.Request) {
+			_ = r.ParseForm()
+			if r.Form.Get("client_id") == "" {
+				http.Error(w, "missing client_id", http.StatusBadRequest)
+				return
+			}
+			writeJSON(w, 0, map[string]any{
+				"access_token": "direct-access-tok",
+				"token_type":   "Bearer",
+				"expires_in":   7200,
+			})
+		})
+
+		srv := httptest.NewServer(mux)
+		testutil.CloseOnCleanup(t, srv)
+
+		store := &memStore{regs: make(map[string]*mcpoauth.Registration)}
+		handler := mcpoauth.NewHandler(mcpoauth.HandlerConfig{
+			MCPURL:      srv.URL + "/mcp",
+			Store:       store,
+			RedirectURL: "http://localhost:9999/callback",
+		})
+
+		authURL, verifier := handler.StartOAuth("test-state", nil)
+		if authURL == "" {
+			t.Fatal("expected non-empty auth URL")
+		}
+
+		parsed, _ := url.Parse(authURL)
+		if parsed.Query().Get("client_id") != "direct-client-001" {
+			t.Errorf("client_id = %q, want direct-client-001", parsed.Query().Get("client_id"))
+		}
+
+		tokenResp, err := handler.ExchangeCodeWithVerifier(context.Background(), "test-code", verifier)
+		if err != nil {
+			t.Fatalf("ExchangeCodeWithVerifier: %v", err)
+		}
+		if tokenResp.AccessToken != "direct-access-tok" {
+			t.Errorf("access_token = %q, want direct-access-tok", tokenResp.AccessToken)
+		}
+	})
+}


### PR DESCRIPTION
Tests the end-to-end MCP OAuth flow against a mock server: probe for
401 challenge, fetch resource metadata, resolve authorization server
metadata, perform Dynamic Client Registration, generate auth URL with
PKCE, and exchange an authorization code for tokens. Two subtests cover
both the RFC 9728 indirection path (Linear-style, with authorization_servers
and AS metadata lookup) and the direct-endpoints path (ClickHouse-style,
where endpoints are embedded in resource metadata).

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>