### PR TITLE
Add shared egress resolution primitives

### DIFF
--- a/internal/egress/egresstest/helpers.go
+++ b/internal/egress/egresstest/helpers.go
@@ -1,0 +1,14 @@
+package egresstest
+
+import (
+	"context"
+
+	"github.com/valon-technologies/gestalt/internal/egress"
+)
+
+// PolicyFunc adapts a plain function to the egress.PolicyEnforcer interface.
+type PolicyFunc func(context.Context, egress.PolicyInput) error
+
+func (f PolicyFunc) Evaluate(ctx context.Context, input egress.PolicyInput) error {
+	return f(ctx, input)
+}

--- a/internal/egress/resolution.go
+++ b/internal/egress/resolution.go
@@ -1,0 +1,76 @@
+package egress
+
+import "context"
+
+type ResolutionInput struct {
+	Target     Target
+	Headers    map[string]string
+	Credential CredentialMaterialization
+}
+
+type Resolution struct {
+	Subject    Subject
+	Target     Target
+	Headers    map[string]string
+	Credential CredentialMaterialization
+	Policy     PolicyInput
+}
+
+type Resolver struct {
+	Subjects SubjectResolver
+	Policy   PolicyEnforcer
+}
+
+func (r Resolver) Resolve(ctx context.Context, input ResolutionInput) (Resolution, error) {
+	subjectResolver := r.Subjects
+	if subjectResolver == nil {
+		subjectResolver = ContextSubjectResolver{}
+	}
+
+	subject, err := subjectResolver.ResolveSubject(ctx, input.Target)
+	if err != nil {
+		return Resolution{}, err
+	}
+
+	headers := ApplyHeaderMutations(input.Headers, input.Credential.Headers)
+
+	if input.Credential.Authorization != "" {
+		delete(headers, "Authorization")
+	}
+
+	policyHeaders := CopyHeaders(headers)
+	if input.Credential.Authorization != "" {
+		if policyHeaders == nil {
+			policyHeaders = map[string]string{}
+		}
+		policyHeaders["Authorization"] = input.Credential.Authorization
+	}
+
+	policy := PolicyInput{
+		Subject: subject,
+		Target:  input.Target,
+		Headers: policyHeaders,
+	}
+	if err := EvaluatePolicy(ctx, r.Policy, policy); err != nil {
+		return Resolution{}, err
+	}
+
+	return Resolution{
+		Subject:    subject,
+		Target:     input.Target,
+		Headers:    headers,
+		Credential: CredentialMaterialization{Authorization: input.Credential.Authorization},
+		Policy:     policy,
+	}, nil
+}
+
+func CopyHeaders(headers map[string]string) map[string]string {
+	if headers == nil {
+		return nil
+	}
+	out := make(map[string]string, len(headers))
+	for k, v := range headers {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/egress/subject.go
+++ b/internal/egress/subject.go
@@ -1,0 +1,36 @@
+package egress
+
+import "context"
+
+type SubjectResolver interface {
+	ResolveSubject(ctx context.Context, target Target) (Subject, error)
+}
+
+type subjectContextKey struct{}
+
+func WithSubject(ctx context.Context, subject Subject) context.Context {
+	return context.WithValue(ctx, subjectContextKey{}, subject)
+}
+
+func SubjectFromContext(ctx context.Context) (Subject, bool) {
+	subject, ok := ctx.Value(subjectContextKey{}).(Subject)
+	if !ok {
+		return Subject{}, false
+	}
+	return subject, true
+}
+
+type ContextSubjectResolver struct{}
+
+func (ContextSubjectResolver) ResolveSubject(ctx context.Context, _ Target) (Subject, error) {
+	subject, _ := SubjectFromContext(ctx)
+	return subject, nil
+}
+
+type StaticSubjectResolver struct {
+	Subject Subject
+}
+
+func (r StaticSubjectResolver) ResolveSubject(_ context.Context, _ Target) (Subject, error) {
+	return r.Subject, nil
+}


### PR DESCRIPTION
This introduces a transport-neutral egress resolver that normalizes
subjects and evaluates policy before any outbound request leaves the
system. Egress subjects are carried in context independently from
authentication principals, so the low-level egress package does not need
to understand principal-to-subject translation.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>