### PR TITLE
Wire proxy normalization through egress resolution

### DIFF
--- a/plugins/bindings/proxy/binding.go
+++ b/plugins/bindings/proxy/binding.go
@@ -17,12 +17,13 @@ import (
 var _ core.Binding = (*Binding)(nil)
 
 type Binding struct {
-	name string
-	cfg  proxyConfig
+	name     string
+	cfg      proxyConfig
+	resolver egress.Resolver
 }
 
-func New(name string, cfg proxyConfig) *Binding {
-	return &Binding{name: name, cfg: cfg}
+func New(name string, cfg proxyConfig, resolver egress.Resolver) *Binding {
+	return &Binding{name: name, cfg: cfg, resolver: resolver}
 }
 
 func (b *Binding) Name() string           { return b.name }
@@ -76,18 +77,21 @@ func (b *Binding) normalize(r *http.Request) (normalizedRequest, error) {
 		Path:   resolvePath(r, b.cfg.normalizedPath()),
 	}
 
-	policy := egress.PolicyInput{
-		Subject: egress.Subject{
-			Kind: egress.SubjectSystem,
-			ID:   b.name,
-		},
+	ctx := egress.WithSubject(r.Context(), egress.Subject{
+		Kind: egress.SubjectSystem,
+		ID:   b.name,
+	})
+	resolved, err := b.resolver.Resolve(ctx, egress.ResolutionInput{
 		Target:  target,
 		Headers: headers,
+	})
+	if err != nil {
+		return normalizedRequest{}, err
 	}
 
 	norm := normalizedRequest{
-		Policy: policy,
-		Target: target,
+		Policy: resolved.Policy,
+		Target: resolved.Target,
 	}
 	if len(body) > 0 {
 		norm.Body = string(body)

--- a/plugins/bindings/proxy/binding_internal_test.go
+++ b/plugins/bindings/proxy/binding_internal_test.go
@@ -1,0 +1,44 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/internal/egress"
+	"github.com/valon-technologies/gestalt/internal/egress/egresstest"
+)
+
+func TestBindingNormalizeRunsResolver(t *testing.T) {
+	t.Parallel()
+
+	var got egress.PolicyInput
+	b := New("agent-proxy", proxyConfig{Path: "/proxy"}, egress.Resolver{
+		Policy: egresstest.PolicyFunc(func(_ context.Context, input egress.PolicyInput) error {
+			got = input
+			return nil
+		}),
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/proxy/messages?cursor=123", bytes.NewBufferString("hello"))
+	req.Host = "api.example.com"
+	req.Header.Set("X-Proxy-Token", "abc")
+
+	w := httptest.NewRecorder()
+	b.Routes()[0].Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501", w.Code)
+	}
+	if got.Subject != (egress.Subject{Kind: egress.SubjectSystem, ID: "agent-proxy"}) {
+		t.Fatalf("subject = %+v, want system agent-proxy", got.Subject)
+	}
+	if got.Target.Path != "/messages?cursor=123" {
+		t.Fatalf("target path = %q, want /messages?cursor=123", got.Target.Path)
+	}
+	if got.Headers["X-Proxy-Token"] != "abc" {
+		t.Fatalf("header = %q, want abc", got.Headers["X-Proxy-Token"])
+	}
+}

--- a/plugins/bindings/proxy/factory.go
+++ b/plugins/bindings/proxy/factory.go
@@ -6,6 +6,7 @@ import (
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/egress"
 )
 
 var Factory bootstrap.BindingFactory = func(_ context.Context, name string, def config.BindingDef, _ bootstrap.BindingDeps) (core.Binding, error) {
@@ -16,5 +17,5 @@ var Factory bootstrap.BindingFactory = func(_ context.Context, name string, def 
 	if err := cfg.validate(name); err != nil {
 		return nil, err
 	}
-	return New(name, cfg), nil
+	return New(name, cfg, egress.Resolver{}), nil
 }


### PR DESCRIPTION
The proxy binding now attaches a binding-scoped system subject and runs
the shared egress resolver during request normalization. This replaces
the inline policy construction with the centralized resolution path,
keeping the proxy surface consistent with the rest of the egress layer
while remaining a 501 scaffold.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>