### PR TITLE
Wire provider invocation through egress resolution

### DIFF
--- a/core/integration/base.go
+++ b/core/integration/base.go
@@ -111,6 +111,7 @@ type Base struct {
 	CheckResponse  apiexec.ResponseChecker
 	RequestMutator func(operation string, req *apiexec.Request, params map[string]any) error
 	ExecuteFunc    func(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error)
+	EgressResolver *egress.Resolver
 
 	ConnectionDefs    map[string]core.ConnectionParamDef
 	PostConnectHookFn core.PostConnectHook
@@ -228,7 +229,7 @@ func (b *Base) ListOperations() []core.Operation { return b.Operations }
 
 func (b *Base) resolvedURLAndHeaders(ctx context.Context) (string, map[string]string) {
 	baseURL := b.BaseURL
-	headers := copyHeaders(b.Headers)
+	headers := egress.CopyHeaders(b.Headers)
 	if cp := core.ConnectionParams(ctx); cp != nil {
 		baseURL = paraminterp.Interpolate(baseURL, cp)
 		for k, v := range headers {
@@ -326,23 +327,12 @@ func (b *Base) requestAuthFields(token string, auth egress.CredentialMaterializa
 	return "", auth.Authorization
 }
 
-func copyHeaders(h map[string]string) map[string]string {
-	if h == nil {
-		return nil
-	}
-	c := make(map[string]string, len(h))
-	for k, v := range h {
-		c[k] = v
-	}
-	return c
-}
-
 func mergeHeaders(baseHeaders, overrideHeaders map[string]string) map[string]string {
 	if len(baseHeaders) == 0 && len(overrideHeaders) == 0 {
 		return nil
 	}
 
-	merged := copyHeaders(baseHeaders)
+	merged := egress.CopyHeaders(baseHeaders)
 	if merged == nil {
 		merged = make(map[string]string, len(overrideHeaders))
 	}

--- a/core/integration/base_test.go
+++ b/core/integration/base_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/apiexec"
+	"github.com/valon-technologies/gestalt/internal/egress"
+	"github.com/valon-technologies/gestalt/internal/egress/egresstest"
 )
 
 type mockAuth struct{}
@@ -192,6 +194,61 @@ func TestBaseExecuteRESTAllowsBearerTokenOverrideFromRequestMutator(t *testing.T
 	}
 	if resp["mutated"] != "yes" {
 		t.Fatalf("mutated = %v, want yes", resp["mutated"])
+	}
+}
+
+func TestBaseExecuteRESTRunsEgressResolutionOnFinalRequest(t *testing.T) {
+	t.Parallel()
+
+	var gotPolicy egress.PolicyInput
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"auth":    r.Header.Get("Authorization"),
+			"mutated": r.Header.Get("X-Mutated"),
+		})
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	b := &Base{
+		Auth:            mockAuth{},
+		IntegrationName: "test-provider",
+		BaseURL:         srv.URL,
+		Endpoints: map[string]Endpoint{
+			"op": {Method: http.MethodGet, Path: "/test"},
+		},
+		EgressResolver: &egress.Resolver{
+			Subjects: egress.StaticSubjectResolver{
+				Subject: egress.Subject{Kind: egress.SubjectAgent, ID: "agent-1"},
+			},
+			Policy: egresstest.PolicyFunc(func(_ context.Context, input egress.PolicyInput) error {
+				gotPolicy = input
+				return nil
+			}),
+		},
+		RequestMutator: func(_ string, req *apiexec.Request, _ map[string]any) error {
+			req.AuthHeader = "Token override"
+			req.CustomHeaders = map[string]string{"X-Mutated": "yes"}
+			return nil
+		},
+	}
+
+	if _, err := b.Execute(context.Background(), "op", nil, "original"); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if gotPolicy.Subject.Kind != egress.SubjectAgent || gotPolicy.Subject.ID != "agent-1" {
+		t.Fatalf("subject = %+v, want agent-1", gotPolicy.Subject)
+	}
+	if gotPolicy.Target.Provider != "test-provider" || gotPolicy.Target.Operation != "op" {
+		t.Fatalf("target = %+v, want test-provider/op", gotPolicy.Target)
+	}
+	if gotPolicy.Headers["Authorization"] != "Token override" {
+		t.Fatalf("authorization = %q, want Token override", gotPolicy.Headers["Authorization"])
+	}
+	if gotPolicy.Headers["X-Mutated"] != "yes" {
+		t.Fatalf("mutated header = %q, want yes", gotPolicy.Headers["X-Mutated"])
 	}
 }
 

--- a/core/integration/egress_adapter.go
+++ b/core/integration/egress_adapter.go
@@ -36,6 +36,12 @@ func (b *Base) executeREST(ctx context.Context, operation string, params map[str
 		}
 	}
 
+	resolved, err := b.resolveEgress(ctx, operation, req)
+	if err != nil {
+		return nil, err
+	}
+	req.CustomHeaders = egress.CopyHeaders(resolved.Headers)
+
 	if pgn, ok := b.Pagination[operation]; ok {
 		return apiexec.DoPaginatedWithExecutor(ctx, b.httpClient(), req, pgn, executeEgressHTTP)
 	}
@@ -43,19 +49,40 @@ func (b *Base) executeREST(ctx context.Context, operation string, params map[str
 	return executeEgressHTTP(ctx, b.httpClient(), req)
 }
 
+func (b *Base) resolveEgress(ctx context.Context, operation string, req apiexec.Request) (egress.Resolution, error) {
+	resolver := egress.Resolver{}
+	if b.EgressResolver != nil {
+		resolver = *b.EgressResolver
+	}
+
+	return resolver.Resolve(ctx, egress.ResolutionInput{
+		Target: egress.Target{
+			Provider:  b.IntegrationName,
+			Operation: operation,
+			Method:    req.Method,
+			Path:      apiexec.ExpandedPath(req.Method, req.Path, req.Params),
+		},
+		Headers:    egress.CopyHeaders(req.CustomHeaders),
+		Credential: credentialFromAPIRequest(req),
+	})
+}
+
+func credentialFromAPIRequest(req apiexec.Request) egress.CredentialMaterialization {
+	switch {
+	case req.AuthHeader != "":
+		return egress.CredentialMaterialization{Authorization: req.AuthHeader}
+	case req.Token != "":
+		return egress.CredentialMaterialization{Authorization: core.BearerScheme + req.Token}
+	default:
+		return egress.CredentialMaterialization{}
+	}
+}
+
 func executeEgressHTTP(ctx context.Context, client *http.Client, req apiexec.Request) (*core.OperationResult, error) {
 	return egress.ExecuteHTTP(ctx, client, egressRequestFromAPIExec(req))
 }
 
 func egressRequestFromAPIExec(req apiexec.Request) egress.HTTPRequestSpec {
-	credential := egress.CredentialMaterialization{}
-	switch {
-	case req.AuthHeader != "":
-		credential.Authorization = req.AuthHeader
-	case req.Token != "":
-		credential.Authorization = core.BearerScheme + req.Token
-	}
-
 	return egress.HTTPRequestSpec{
 		Target: egress.Target{
 			Method: req.Method,
@@ -63,12 +90,12 @@ func egressRequestFromAPIExec(req apiexec.Request) egress.HTTPRequestSpec {
 		},
 		BaseURL:     req.BaseURL,
 		Params:      req.Params,
-		Headers:     copyHeaders(req.CustomHeaders),
+		Headers:     egress.CopyHeaders(req.CustomHeaders),
 		Body:        req.Body,
 		ContentType: req.ContentType,
 		Check:       req.CheckResponse,
 		MaxRetries:  req.MaxRetries,
 		NoRetry:     req.NoRetry,
-		Credential:  credential,
+		Credential:  credentialFromAPIRequest(req),
 	}
 }

--- a/internal/apiexec/apiexec.go
+++ b/internal/apiexec/apiexec.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -319,6 +320,25 @@ func ParseJSONToken(token string, dest any) error {
 		return fmt.Errorf("parsing token: %w", err)
 	}
 	return nil
+}
+
+func ExpandedPath(method, path string, params map[string]any) string {
+	params = copyParams(params)
+	expanded, err := substitutePath(path, params)
+	if err != nil {
+		return path
+	}
+	switch method {
+	case http.MethodGet, http.MethodDelete:
+		if len(params) > 0 {
+			q := url.Values{}
+			for k, v := range params {
+				q.Set(k, fmt.Sprintf("%v", v))
+			}
+			return expanded + "?" + q.Encode()
+		}
+	}
+	return expanded
 }
 
 func copyParams(params map[string]any) map[string]any {

--- a/internal/invocation/broker.go
+++ b/internal/invocation/broker.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/egress"
 	"github.com/valon-technologies/gestalt/internal/paraminterp"
 	"github.com/valon-technologies/gestalt/internal/principal"
 	"github.com/valon-technologies/gestalt/internal/registry"
@@ -95,6 +96,8 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		return nil, err
 	}
 
+	ctx = b.withSubject(ctx, p)
+
 	result, err := prov.Execute(ctx, operation, params, accessToken)
 	if err != nil {
 		return nil, err
@@ -113,6 +116,16 @@ func (b *Broker) ResolveToken(ctx context.Context, p *principal.Principal, provi
 	}
 	_, tok, resolveErr := b.resolveToken(ctx, prov, p, providerName, instance)
 	return tok, resolveErr
+}
+
+func (b *Broker) withSubject(ctx context.Context, p *principal.Principal) context.Context {
+	if _, ok := egress.SubjectFromContext(ctx); ok {
+		return ctx
+	}
+	if p == nil || p.UserID == "" {
+		return ctx
+	}
+	return egress.WithSubject(ctx, egress.Subject{Kind: egress.SubjectUser, ID: p.UserID})
 }
 
 func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *principal.Principal, providerName, instance string) (context.Context, string, error) {

--- a/internal/invocation/broker_test.go
+++ b/internal/invocation/broker_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	coretesting "github.com/valon-technologies/gestalt/core/testing"
+	"github.com/valon-technologies/gestalt/internal/egress"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	"github.com/valon-technologies/gestalt/internal/principal"
 	"github.com/valon-technologies/gestalt/internal/registry"
@@ -254,5 +255,62 @@ func TestInvoke_MetadataJSONFlowsToContext(t *testing.T) {
 	}
 	if cp["region"] != "us" {
 		t.Errorf("region = %q, want us", cp["region"])
+	}
+}
+
+func TestInvoke_AttachesEgressSubjectFromPrincipal(t *testing.T) {
+	t.Parallel()
+
+	var gotSubject egress.Subject
+
+	prov := &stubProviderWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "test-int",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(ctx context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				gotSubject, _ = egress.SubjectFromContext(ctx)
+				return &core.OperationResult{Status: http.StatusOK, Body: `{}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "do_thing", Method: "GET"}},
+	}
+
+	b := invocation.NewBroker(testutil.NewProviderRegistry(t, prov), &coretesting.StubDatastore{})
+	p := &principal.Principal{UserID: "u1"}
+
+	if _, err := b.Invoke(context.Background(), p, "test-int", "", "do_thing", nil); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if gotSubject != (egress.Subject{Kind: egress.SubjectUser, ID: "u1"}) {
+		t.Fatalf("subject = %+v, want user u1", gotSubject)
+	}
+}
+
+func TestInvoke_PreservesExplicitEgressSubject(t *testing.T) {
+	t.Parallel()
+
+	var gotSubject egress.Subject
+
+	prov := &stubProviderWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "test-int",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(ctx context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				gotSubject, _ = egress.SubjectFromContext(ctx)
+				return &core.OperationResult{Status: http.StatusOK, Body: `{}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "do_thing", Method: "GET"}},
+	}
+
+	b := invocation.NewBroker(testutil.NewProviderRegistry(t, prov), &coretesting.StubDatastore{})
+	ctx := egress.WithSubject(context.Background(), egress.Subject{Kind: egress.SubjectAgent, ID: "agent-1"})
+	p := &principal.Principal{UserID: "u1"}
+
+	if _, err := b.Invoke(ctx, p, "test-int", "", "do_thing", nil); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if gotSubject != (egress.Subject{Kind: egress.SubjectAgent, ID: "agent-1"}) {
+		t.Fatalf("subject = %+v, want agent agent-1", gotSubject)
 	}
 }


### PR DESCRIPTION
The invocation broker now translates the authenticated principal into a
normalized egress subject before calling into the provider, and the REST
adapter runs the shared egress resolver on the fully mutated request.
This means subject propagation and policy evaluation happen consistently
for both provider and proxy paths.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>