### PR TITLE
Load provider and runtime plugins from executables

### DIFF
--- a/cmd/gestalt-plugin-echo/main.go
+++ b/cmd/gestalt-plugin-echo/main.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/valon-technologies/gestalt/internal/pluginapi"
+	"github.com/valon-technologies/gestalt/plugins/providers/echo"
+	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatal("usage: gestalt-plugin-echo <provider|runtime>")
+	}
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	switch os.Args[1] {
+	case "provider":
+		return pluginapi.ServeProvider(ctx, echo.New())
+	case "runtime":
+		return pluginapi.ServeRuntime(ctx, &echoRuntimePlugin{})
+	default:
+		return fmt.Errorf("unknown mode %q", os.Args[1])
+	}
+}
+
+type echoRuntimePlugin struct {
+	pluginapiv1.UnimplementedRuntimePluginServer
+	hostConn *grpc.ClientConn
+	host     pluginapiv1.RuntimeHostClient
+	name     string
+}
+
+func (p *echoRuntimePlugin) Start(ctx context.Context, req *pluginapiv1.StartRuntimeRequest) (*emptypb.Empty, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
+
+	if p.hostConn == nil {
+		conn, host, err := pluginapi.DialRuntimeHost(ctx)
+		if err != nil {
+			return nil, status.Errorf(codes.Unavailable, "dial runtime host: %v", err)
+		}
+		p.hostConn = conn
+		p.host = host
+	}
+
+	capsResp, err := p.host.ListCapabilities(ctx, &emptypb.Empty{})
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "list capabilities: %v", err)
+	}
+
+	cfg := map[string]any(nil)
+	if req.GetConfig() != nil {
+		cfg = req.GetConfig().AsMap()
+	}
+
+	record := map[string]any{
+		"name":             req.GetName(),
+		"capability_count": len(capsResp.GetCapabilities()),
+	}
+
+	probeProvider, _ := cfg["probe_provider"].(string)
+	probeOperation, _ := cfg["probe_operation"].(string)
+	if probeProvider != "" && probeOperation != "" {
+		probeParams, _ := cfg["probe_params"].(map[string]any)
+		params, err := structpb.NewStruct(probeParams)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "probe_params: %v", err)
+		}
+		resp, err := p.host.Invoke(ctx, &pluginapiv1.InvokeRequest{
+			Principal: &pluginapiv1.Principal{},
+			Provider:  probeProvider,
+			Operation: probeOperation,
+			Params:    params,
+		})
+		if err != nil {
+			return nil, status.Errorf(codes.Unknown, "probe invoke: %v", err)
+		}
+		record["probe_status"] = resp.GetStatus()
+		record["probe_body"] = resp.GetBody()
+	}
+
+	if outputFile, _ := cfg["output_file"].(string); outputFile != "" {
+		if err := writeJSON(outputFile, record); err != nil {
+			return nil, status.Errorf(codes.Internal, "write output: %v", err)
+		}
+	}
+
+	p.name = req.GetName()
+	log.Printf("echo runtime %q started with %d capabilities", p.name, len(capsResp.GetCapabilities()))
+	return &emptypb.Empty{}, nil
+}
+
+func (p *echoRuntimePlugin) Stop(context.Context, *emptypb.Empty) (*emptypb.Empty, error) {
+	if p.hostConn != nil {
+		_ = p.hostConn.Close()
+		p.hostConn = nil
+		p.host = nil
+	}
+	log.Printf("echo runtime %q stopped", p.name)
+	return &emptypb.Empty{}, nil
+}
+
+func writeJSON(path string, value any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -13,6 +13,7 @@ import (
 	"github.com/valon-technologies/gestalt/core/crypto"
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/invocation"
+	"github.com/valon-technologies/gestalt/internal/pluginapi"
 	"github.com/valon-technologies/gestalt/internal/registry"
 	"gopkg.in/yaml.v3"
 )
@@ -131,6 +132,13 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	if err != nil {
 		return nil, err
 	}
+	closeProviders := true
+	defer func() {
+		if closeProviders {
+			<-providersReady
+			_ = CloseProviders(providers)
+		}
+	}()
 
 	sharedInvoker := invocation.NewBroker(providers, ds)
 	audit := core.AuditSink(invocation.LogAuditSink{})
@@ -139,12 +147,20 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	if err != nil {
 		return nil, err
 	}
+	stopRuntimes := true
+	defer func() {
+		if stopRuntimes {
+			_ = StopRuntimes(context.Background(), runtimes, runtimeNames(runtimes))
+		}
+	}()
 
 	bindings, err := buildBindings(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress)
 	if err != nil {
 		return nil, err
 	}
 
+	closeProviders = false
+	stopRuntimes = false
 	closeSM = false
 	return &Result{
 		Auth:             auth,
@@ -268,6 +284,12 @@ func resolveStringFields(ptr any, resolve func(string) (string, error)) error {
 					return err
 				}
 			}
+		case reflect.Pointer:
+			if !field.IsNil() && field.Elem().Kind() == reflect.Struct {
+				if err := resolveStringFields(field.Interface(), resolve); err != nil {
+					return err
+				}
+			}
 		case reflect.Map:
 			if field.Type().Key().Kind() == reflect.String && field.Type().Elem().Kind() == reflect.String {
 				for _, k := range field.MapKeys() {
@@ -376,23 +398,22 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 	var wg sync.WaitGroup
 	for name := range cfg.Integrations {
 		intgDef := cfg.Integrations[name]
-		factory, ok := factories.Providers[name]
-		if !ok {
-			factory = factories.DefaultProvider
-		}
-		if factory == nil {
+		if !providerBuildAvailable(name, intgDef, factories) {
 			close(ready)
 			return nil, nil, fmt.Errorf("bootstrap: no provider factory for %q and no default factory registered", name)
 		}
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			prov, err := factory(ctx, name, intgDef, deps)
+			prov, err := buildProvider(ctx, name, intgDef, factories, deps)
 			if err != nil {
 				log.Printf("WARNING: skipping provider %q: %v", name, err)
 				return
 			}
 			if err := reg.Providers.Register(name, prov); err != nil {
+				if c, ok := prov.(interface{ Close() error }); ok {
+					_ = c.Close()
+				}
 				log.Printf("WARNING: registering provider %q: %v", name, err)
 				return
 			}
@@ -416,18 +437,16 @@ func buildRuntimes(ctx context.Context, cfg *config.Config, factories *FactoryRe
 
 	for name := range cfg.Runtimes {
 		def := cfg.Runtimes[name]
-		factory, ok := factories.Runtimes[def.Type]
-		if !ok {
-			return nil, fmt.Errorf("bootstrap: unknown runtime type %q for runtime %q", def.Type, name)
-		}
-
 		deps := runtimeDepsForProviders(name, invoker, lister, def.Providers, audit, egressDeps)
-		rt, err := factory(ctx, name, def, deps)
+		rt, err := buildRuntime(ctx, name, def, factories, deps)
 		if err != nil {
+			_ = StopRuntimes(context.Background(), runtimes, runtimes.List())
 			return nil, fmt.Errorf("bootstrap: runtime %q: %w", name, err)
 		}
 
 		if err := runtimes.Register(name, rt); err != nil {
+			_ = rt.Stop(context.Background())
+			_ = StopRuntimes(context.Background(), runtimes, runtimes.List())
 			return nil, fmt.Errorf("bootstrap: registering runtime %q: %w", name, err)
 		}
 		log.Printf("loaded runtime %s (type=%s, providers=%v)", name, def.Type, def.Providers)
@@ -447,20 +466,91 @@ func buildBindings(ctx context.Context, cfg *config.Config, factories *FactoryRe
 		def := cfg.Bindings[name]
 		factory, ok := factories.Bindings[def.Type]
 		if !ok {
+			_ = CloseBindings(bindings, bindings.List())
 			return nil, fmt.Errorf("bootstrap: unknown binding type %q for binding %q", def.Type, name)
 		}
 
 		deps := bindingDepsForProviders(name, invoker, lister, def.Providers, audit, egressDeps)
 		binding, err := factory(ctx, name, def, deps)
 		if err != nil {
+			_ = CloseBindings(bindings, bindings.List())
 			return nil, fmt.Errorf("bootstrap: binding %q: %w", name, err)
 		}
 
 		if err := bindings.Register(name, binding); err != nil {
+			_ = binding.Close()
+			_ = CloseBindings(bindings, bindings.List())
 			return nil, fmt.Errorf("bootstrap: registering binding %q: %w", name, err)
 		}
 		log.Printf("loaded binding %s (type=%s, providers=%v)", name, def.Type, def.Providers)
 	}
 
 	return bindings, nil
+}
+
+func buildProvider(ctx context.Context, name string, intg config.IntegrationDef, factories *FactoryRegistry, deps Deps) (core.Provider, error) {
+	if intg.Plugin != nil {
+		return pluginapi.NewExecutableProvider(ctx, pluginapi.ExecConfig{
+			Command: intg.Plugin.Command,
+			Args:    intg.Plugin.Args,
+			Env:     intg.Plugin.Env,
+		})
+	}
+
+	factory, ok := factories.Providers[name]
+	if !ok {
+		factory = factories.DefaultProvider
+	}
+	if factory == nil {
+		return nil, fmt.Errorf("no provider factory for %q and no default factory registered", name)
+	}
+	return factory(ctx, name, intg, deps)
+}
+
+func providerBuildAvailable(name string, intg config.IntegrationDef, factories *FactoryRegistry) bool {
+	if intg.Plugin != nil {
+		return true
+	}
+	if _, ok := factories.Providers[name]; ok {
+		return true
+	}
+	return factories.DefaultProvider != nil
+}
+
+func buildRuntime(ctx context.Context, name string, cfg config.RuntimeDef, factories *FactoryRegistry, deps RuntimeDeps) (core.Runtime, error) {
+	if cfg.Plugin != nil {
+		m, err := nodeToMap(cfg.Config)
+		if err != nil {
+			return nil, fmt.Errorf("decode runtime config: %w", err)
+		}
+		return pluginapi.NewExecutableRuntime(ctx, name, pluginapi.ExecConfig{
+			Command: cfg.Plugin.Command,
+			Args:    cfg.Plugin.Args,
+			Env:     cfg.Plugin.Env,
+		}, m, deps.Invoker, deps.CapabilityLister)
+	}
+
+	factory, ok := factories.Runtimes[cfg.Type]
+	if !ok {
+		return nil, fmt.Errorf("unknown runtime type %q", cfg.Type)
+	}
+	return factory(ctx, name, cfg, deps)
+}
+
+func nodeToMap(node yaml.Node) (map[string]any, error) {
+	if node.Kind == 0 {
+		return nil, nil
+	}
+	var out map[string]any
+	if err := node.Decode(&out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func runtimeNames(runtimes *registry.PluginMap[core.Runtime]) []string {
+	if runtimes == nil {
+		return nil
+	}
+	return runtimes.List()
 }

--- a/internal/bootstrap/executable_plugin_test.go
+++ b/internal/bootstrap/executable_plugin_test.go
@@ -1,0 +1,130 @@
+package bootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/invocation"
+	"gopkg.in/yaml.v3"
+)
+
+func TestExecutableProviderAndRuntimePlugins(t *testing.T) {
+	t.Parallel()
+	bin := buildEchoPluginBinary(t)
+	outputFile := filepath.Join(t.TempDir(), "runtime-output.json")
+
+	cfg := &config.Config{
+		Integrations: map[string]config.IntegrationDef{
+			"echoext": {
+				Plugin: &config.ExecutablePluginDef{
+					Command: bin,
+					Args:    []string{"provider"},
+				},
+			},
+		},
+		Runtimes: map[string]config.RuntimeDef{
+			"echoextrt": {
+				Providers: []string{"echoext"},
+				Plugin: &config.ExecutablePluginDef{
+					Command: bin,
+					Args:    []string{"runtime"},
+				},
+				Config: mustNode(t, map[string]any{
+					"output_file":     outputFile,
+					"probe_provider":  "echoext",
+					"probe_operation": "echo",
+					"probe_params": map[string]any{
+						"message": "from runtime",
+					},
+				}),
+			},
+		},
+	}
+
+	factories := NewFactoryRegistry()
+	providers, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	broker := invocation.NewBroker(providers, nil)
+	runtimes, err := buildRuntimes(context.Background(), cfg, factories, broker, broker, core.AuditSink(invocation.LogAuditSink{}), EgressDeps{})
+	if err != nil {
+		t.Fatalf("buildRuntimes: %v", err)
+	}
+	defer func() { _ = StopRuntimes(context.Background(), runtimes, runtimes.List()) }()
+
+	rt, err := runtimes.Get("echoextrt")
+	if err != nil {
+		t.Fatalf("runtimes.Get: %v", err)
+	}
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("runtime.Start: %v", err)
+	}
+
+	var got struct {
+		Name            string `json:"name"`
+		CapabilityCount int    `json:"capability_count"`
+		ProbeStatus     int    `json:"probe_status"`
+		ProbeBody       string `json:"probe_body"`
+	}
+	data, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", outputFile, err)
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	if got.Name != "echoextrt" {
+		t.Fatalf("runtime output name = %q", got.Name)
+	}
+	if got.CapabilityCount != 1 {
+		t.Fatalf("runtime output capability_count = %d", got.CapabilityCount)
+	}
+	if got.ProbeStatus != 200 {
+		t.Fatalf("runtime output probe_status = %d", got.ProbeStatus)
+	}
+	if got.ProbeBody != `{"message":"from runtime"}` {
+		t.Fatalf("runtime output probe_body = %q", got.ProbeBody)
+	}
+}
+
+func buildEchoPluginBinary(t *testing.T) string {
+	t.Helper()
+
+	bin := filepath.Join(t.TempDir(), "gestalt-plugin-echo")
+	root := repoRoot(t)
+	cmd := exec.Command("go", "build", "-o", bin, "./cmd/gestalt-plugin-echo")
+	cmd.Dir = root
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build plugin binary: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func mustNode(t *testing.T, value any) yaml.Node {
+	t.Helper()
+	var node yaml.Node
+	if err := node.Encode(value); err != nil {
+		t.Fatalf("node.Encode: %v", err)
+	}
+	return node
+}

--- a/internal/bootstrap/validate.go
+++ b/internal/bootstrap/validate.go
@@ -98,16 +98,7 @@ func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *Fa
 	var errs []error
 	for _, name := range names {
 		intgDef := cfg.Integrations[name]
-		factory, ok := factories.Providers[name]
-		if !ok {
-			factory = factories.DefaultProvider
-		}
-		if factory == nil {
-			errs = append(errs, fmt.Errorf("bootstrap: no provider factory for %q and no default factory registered", name))
-			continue
-		}
-
-		prov, err := factory(ctx, name, intgDef, deps)
+		prov, err := buildProvider(ctx, name, intgDef, factories, deps)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("integration %q: %w", name, err))
 			continue

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,10 +27,17 @@ type Config struct {
 	Server       ServerConfig              `yaml:"server"`
 }
 
+type ExecutablePluginDef struct {
+	Command string            `yaml:"command"`
+	Args    []string          `yaml:"args"`
+	Env     map[string]string `yaml:"env"`
+}
+
 type RuntimeDef struct {
-	Type      string    `yaml:"type"`
-	Providers []string  `yaml:"providers"`
-	Config    yaml.Node `yaml:"config"`
+	Type      string               `yaml:"type"`
+	Providers []string             `yaml:"providers"`
+	Config    yaml.Node            `yaml:"config"`
+	Plugin    *ExecutablePluginDef `yaml:"plugin"`
 }
 
 type BindingDef struct {
@@ -69,12 +76,13 @@ type ServerConfig struct {
 }
 
 type IntegrationDef struct {
-	Upstreams      []UpstreamDef `yaml:"upstreams"`
-	DisplayName    string        `yaml:"display_name"`
-	Description    string        `yaml:"description"`
-	AuthProfile    string        `yaml:"auth_profile"`
-	ConnectionMode string        `yaml:"connection_mode"`
-	MCPToolPrefix  string        `yaml:"mcp_tool_prefix"`
+	Upstreams      []UpstreamDef        `yaml:"upstreams"`
+	DisplayName    string               `yaml:"display_name"`
+	Description    string               `yaml:"description"`
+	AuthProfile    string               `yaml:"auth_profile"`
+	ConnectionMode string               `yaml:"connection_mode"`
+	MCPToolPrefix  string               `yaml:"mcp_tool_prefix"`
+	Plugin         *ExecutablePluginDef `yaml:"plugin"`
 
 	ClientID     string `yaml:"client_id"`
 	ClientSecret string `yaml:"client_secret"`
@@ -389,7 +397,18 @@ func resolveRelativePaths(configPath string, cfg *Config) {
 		if intg.IconFile != "" {
 			intg.IconFile = resolveRelativePath(baseDir, intg.IconFile)
 		}
+		if intg.Plugin != nil {
+			intg.Plugin.Command = resolveExecutablePath(baseDir, intg.Plugin.Command)
+		}
 		cfg.Integrations[name] = intg
+	}
+
+	for name := range cfg.Runtimes {
+		rt := cfg.Runtimes[name]
+		if rt.Plugin != nil {
+			rt.Plugin.Command = resolveExecutablePath(baseDir, rt.Plugin.Command)
+		}
+		cfg.Runtimes[name] = rt
 	}
 }
 
@@ -398,6 +417,16 @@ func resolveRelativePath(baseDir, value string) string {
 		return value
 	}
 	return filepath.Clean(filepath.Join(baseDir, value))
+}
+
+func resolveExecutablePath(baseDir, value string) string {
+	if value == "" || filepath.IsAbs(value) {
+		return value
+	}
+	if strings.HasPrefix(value, ".") || strings.ContainsRune(value, os.PathSeparator) {
+		return filepath.Clean(filepath.Join(baseDir, value))
+	}
+	return value
 }
 
 func validate(cfg *Config) error {
@@ -412,6 +441,15 @@ func validate(cfg *Config) error {
 	}
 	for name := range cfg.Integrations {
 		intg := cfg.Integrations[name]
+		if err := validateExecutablePlugin("integration", name, intg.Plugin); err != nil {
+			return err
+		}
+		if intg.Plugin != nil {
+			if len(intg.Upstreams) > 0 {
+				return fmt.Errorf("config validation: integration %q cannot set both plugin and upstreams", name)
+			}
+			continue
+		}
 		apiCount := 0
 		for i := range intg.Upstreams {
 			us := &intg.Upstreams[i]
@@ -434,6 +472,31 @@ func validate(cfg *Config) error {
 		if apiCount > 1 {
 			return fmt.Errorf("config validation: integration %q has multiple REST/GraphQL upstreams; only one is supported", name)
 		}
+	}
+	for name := range cfg.Runtimes {
+		rt := cfg.Runtimes[name]
+		if err := validateExecutablePlugin("runtime", name, rt.Plugin); err != nil {
+			return err
+		}
+		if rt.Plugin != nil {
+			if rt.Type != "" {
+				return fmt.Errorf("config validation: runtime %q cannot set both plugin and type", name)
+			}
+			continue
+		}
+		if rt.Type == "" {
+			return fmt.Errorf("config validation: runtime %q requires either type or plugin", name)
+		}
+	}
+	return nil
+}
+
+func validateExecutablePlugin(kind, name string, plugin *ExecutablePluginDef) error {
+	if plugin == nil {
+		return nil
+	}
+	if plugin.Command == "" {
+		return fmt.Errorf("config validation: %s %q plugin.command is required", kind, name)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -209,6 +209,48 @@ integrations:
 	}
 }
 
+func TestLoadResolvesPluginCommandPathsRelativeToConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "configs", "gestalt.yaml")
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0755); err != nil {
+		t.Fatalf("MkdirAll config dir: %v", err)
+	}
+
+	content := `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+integrations:
+  external:
+    plugin:
+      command: ../bin/provider
+runtimes:
+  worker:
+    plugin:
+      command: ../bin/runtime
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: unexpected error: %v", err)
+	}
+
+	if got := cfg.Integrations["external"].Plugin.Command; got != filepath.Join(dir, "bin", "provider") {
+		t.Fatalf("integration plugin command = %q", got)
+	}
+	if got := cfg.Runtimes["worker"].Plugin.Command; got != filepath.Join(dir, "bin", "runtime") {
+		t.Fatalf("runtime plugin command = %q", got)
+	}
+}
+
 func TestValidation(t *testing.T) {
 	t.Parallel()
 
@@ -269,6 +311,71 @@ integrations:
         url: https://example.com/openapi.json
       - type: graphql
         url: https://example.com/graphql
+`,
+			wantErr: true,
+		},
+		{
+			name: "integration plugin cannot also define upstreams",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+integrations:
+  external:
+    plugin:
+      command: /tmp/plugin
+    upstreams:
+      - type: rest
+        url: https://example.com/spec.json
+`,
+			wantErr: true,
+		},
+		{
+			name: "runtime requires type or plugin",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+runtimes:
+  worker: {}
+`,
+			wantErr: true,
+		},
+		{
+			name: "runtime plugin cannot also define type",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+runtimes:
+  worker:
+    type: echo
+    plugin:
+      command: /tmp/plugin
+`,
+			wantErr: true,
+		},
+		{
+			name: "plugin command is required",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+integrations:
+  external:
+    plugin: {}
 `,
 			wantErr: true,
 		},

--- a/internal/pluginapi/process.go
+++ b/internal/pluginapi/process.go
@@ -1,0 +1,357 @@
+package pluginapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/invocation"
+	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const (
+	processStartupTimeout  = 10 * time.Second
+	processShutdownTimeout = 2 * time.Second
+)
+
+type ExecConfig struct {
+	Command string
+	Args    []string
+	Env     map[string]string
+}
+
+type managedRuntime struct {
+	core.Runtime
+	proc     *pluginProcess
+	stopOnce sync.Once
+	stopErr  error
+}
+
+func (r *managedRuntime) Stop(ctx context.Context) error {
+	r.stopOnce.Do(func() {
+		var errs []error
+		if r.Runtime != nil {
+			if err := r.Runtime.Stop(ctx); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		if r.proc != nil {
+			if err := r.proc.Close(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		r.stopErr = errors.Join(errs...)
+	})
+	return r.stopErr
+}
+
+type pluginProcess struct {
+	cmd       *exec.Cmd
+	dir       string
+	conn      *grpc.ClientConn
+	waitCh    chan error
+	hostSrv   *grpc.Server
+	hostLis   net.Listener
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func NewExecutableProvider(ctx context.Context, cfg ExecConfig) (core.Provider, error) {
+	proc, err := startPluginProcess(ctx, cfg, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	client := pluginapiv1.NewProviderPluginClient(proc.conn)
+	prov, err := NewRemoteProvider(ctx, client, WithCloser(proc))
+	if err != nil {
+		_ = proc.Close()
+		return nil, err
+	}
+	return prov, nil
+}
+
+func NewExecutableRuntime(
+	ctx context.Context,
+	name string,
+	cfg ExecConfig,
+	config map[string]any,
+	invoker invocation.Invoker,
+	lister invocation.CapabilityLister,
+) (core.Runtime, error) {
+	proc, err := startPluginProcess(ctx, cfg, func(srv *grpc.Server) {
+		pluginapiv1.RegisterRuntimeHostServer(srv, NewRuntimeHostServer(invoker, lister))
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var initialCaps []core.Capability
+	if lister != nil {
+		initialCaps = lister.ListCapabilities()
+	}
+
+	rt, err := NewRemoteRuntime(name, pluginapiv1.NewRuntimePluginClient(proc.conn), config, initialCaps)
+	if err != nil {
+		_ = proc.Close()
+		return nil, err
+	}
+	return &managedRuntime{Runtime: rt, proc: proc}, nil
+}
+
+func ServeProvider(ctx context.Context, provider core.Provider) error {
+	return servePlugin(ctx, func(srv *grpc.Server) {
+		pluginapiv1.RegisterProviderPluginServer(srv, NewProviderServer(provider))
+	})
+}
+
+func ServeRuntime(ctx context.Context, server pluginapiv1.RuntimePluginServer) error {
+	return servePlugin(ctx, func(srv *grpc.Server) {
+		pluginapiv1.RegisterRuntimePluginServer(srv, server)
+	})
+}
+
+func DialRuntimeHost(ctx context.Context) (*grpc.ClientConn, pluginapiv1.RuntimeHostClient, error) {
+	socket := os.Getenv(pluginapiv1.EnvRuntimeHostSocket)
+	if socket == "" {
+		return nil, nil, fmt.Errorf("%s is required", pluginapiv1.EnvRuntimeHostSocket)
+	}
+	conn, err := dialUnixSocket(ctx, socket)
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, pluginapiv1.NewRuntimeHostClient(conn), nil
+}
+
+func servePlugin(ctx context.Context, register func(*grpc.Server)) error {
+	socket := os.Getenv(pluginapiv1.EnvPluginSocket)
+	if socket == "" {
+		return fmt.Errorf("%s is required", pluginapiv1.EnvPluginSocket)
+	}
+	if err := os.RemoveAll(socket); err != nil {
+		return fmt.Errorf("remove stale socket %q: %w", socket, err)
+	}
+
+	lis, err := net.Listen("unix", socket)
+	if err != nil {
+		return fmt.Errorf("listen on plugin socket %q: %w", socket, err)
+	}
+	defer func() {
+		_ = lis.Close()
+		_ = os.Remove(socket)
+	}()
+
+	srv := grpc.NewServer()
+	register(srv)
+
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		<-ctx.Done()
+		srv.GracefulStop()
+	}()
+
+	err = srv.Serve(lis)
+	if ctx.Err() != nil {
+		<-stopped
+		return nil
+	}
+	return err
+}
+
+func startPluginProcess(ctx context.Context, cfg ExecConfig, registerHost func(*grpc.Server)) (*pluginProcess, error) {
+	if cfg.Command == "" {
+		return nil, fmt.Errorf("plugin command is required")
+	}
+
+	dir, err := newSocketDir()
+	if err != nil {
+		return nil, err
+	}
+	pluginSocket := filepath.Join(dir, "plugin.sock")
+	env := mergeExecEnv(cfg.Env, map[string]string{
+		pluginapiv1.EnvPluginSocket: pluginSocket,
+	})
+
+	proc := &pluginProcess{dir: dir}
+	if registerHost != nil {
+		hostSocket := filepath.Join(dir, "host.sock")
+		lis, err := net.Listen("unix", hostSocket)
+		if err != nil {
+			_ = os.RemoveAll(dir)
+			return nil, fmt.Errorf("listen on runtime host socket: %w", err)
+		}
+		srv := grpc.NewServer()
+		registerHost(srv)
+		proc.hostLis = lis
+		proc.hostSrv = srv
+		go func() {
+			_ = srv.Serve(lis)
+		}()
+		env[pluginapiv1.EnvRuntimeHostSocket] = hostSocket
+	}
+
+	cmd := exec.Command(cfg.Command, cfg.Args...)
+	cmd.Env = append(os.Environ(), envSlice(env)...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		_ = proc.Close()
+		return nil, fmt.Errorf("start plugin process: %w", err)
+	}
+	proc.cmd = cmd
+	proc.waitCh = make(chan error, 1)
+	go func() {
+		proc.waitCh <- cmd.Wait()
+		close(proc.waitCh)
+	}()
+
+	startCtx, cancel := context.WithTimeout(ctx, processStartupTimeout)
+	defer cancel()
+
+	conn, err := waitForPluginConn(startCtx, pluginSocket, proc.waitCh)
+	if err != nil {
+		_ = proc.Close()
+		return nil, err
+	}
+	proc.conn = conn
+
+	return proc, nil
+}
+
+func (p *pluginProcess) Close() error {
+	if p == nil {
+		return nil
+	}
+
+	p.closeOnce.Do(func() {
+		var errs []error
+		if p.conn != nil {
+			if err := p.conn.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("close plugin connection: %w", err))
+			}
+		}
+		if p.hostSrv != nil {
+			p.hostSrv.Stop()
+		}
+		if p.hostLis != nil {
+			if err := p.hostLis.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("close runtime host listener: %w", err))
+			}
+		}
+		if p.cmd != nil && p.cmd.Process != nil {
+			_ = p.cmd.Process.Signal(syscall.SIGTERM)
+			select {
+			case err := <-p.waitCh:
+				if err != nil && !errors.Is(err, context.Canceled) {
+					var exitErr *exec.ExitError
+					if !errors.As(err, &exitErr) || (exitErr.ExitCode() != 0 && exitErr.ExitCode() != -1) {
+						errs = append(errs, fmt.Errorf("wait for plugin process: %w", err))
+					}
+				}
+			case <-time.After(processShutdownTimeout):
+				if err := p.cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+					errs = append(errs, fmt.Errorf("kill plugin process: %w", err))
+				}
+				if err := <-p.waitCh; err != nil && !errors.Is(err, context.Canceled) {
+					var exitErr *exec.ExitError
+					if !errors.As(err, &exitErr) || exitErr.ExitCode() != -1 {
+						errs = append(errs, fmt.Errorf("wait for killed plugin process: %w", err))
+					}
+				}
+			}
+		}
+		if p.dir != "" {
+			if err := os.RemoveAll(p.dir); err != nil {
+				errs = append(errs, fmt.Errorf("remove plugin temp dir: %w", err))
+			}
+		}
+		p.closeErr = errors.Join(errs...)
+	})
+
+	return p.closeErr
+}
+
+func newSocketDir() (string, error) {
+	base := "/tmp"
+	if info, err := os.Stat(base); err != nil || !info.IsDir() {
+		base = os.TempDir()
+	}
+	dir, err := os.MkdirTemp(base, "gstp-")
+	if err != nil {
+		return "", fmt.Errorf("create plugin temp dir: %w", err)
+	}
+	return dir, nil
+}
+
+func mergeExecEnv(base, extra map[string]string) map[string]string {
+	out := make(map[string]string, len(base)+len(extra))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range extra {
+		out[k] = v
+	}
+	return out
+}
+
+func envSlice(values map[string]string) []string {
+	out := make([]string, 0, len(values))
+	for k, v := range values {
+		out = append(out, k+"="+v)
+	}
+	return out
+}
+
+func waitForPluginConn(ctx context.Context, socket string, waitCh <-chan error) (*grpc.ClientConn, error) {
+	for {
+		if _, err := os.Stat(socket); err == nil {
+			conn, dialErr := dialUnixSocket(ctx, socket)
+			if dialErr == nil {
+				return conn, nil
+			}
+			var pathErr *os.PathError
+			if !errors.As(dialErr, &pathErr) {
+				return nil, fmt.Errorf("dial plugin socket: %w", dialErr)
+			}
+		}
+
+		select {
+		case err, ok := <-waitCh:
+			if !ok || err == nil {
+				return nil, fmt.Errorf("plugin process exited before serving gRPC")
+			}
+			return nil, fmt.Errorf("plugin process exited before serving gRPC: %w", err)
+		case <-ctx.Done():
+			return nil, fmt.Errorf("waiting for plugin socket: %w", ctx.Err())
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+}
+
+func dialUnixSocket(ctx context.Context, socket string) (*grpc.ClientConn, error) {
+	conn, err := grpc.NewClient(
+		"passthrough:///"+socket,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, "unix", addr)
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+	conn.Connect()
+	return conn, nil
+}

--- a/sdk/pluginapi/v1/env.go
+++ b/sdk/pluginapi/v1/env.go
@@ -1,0 +1,10 @@
+package pluginapiv1
+
+const (
+	// EnvPluginSocket is the Unix socket path an executable plugin should bind.
+	EnvPluginSocket = "GESTALT_PLUGIN_SOCKET"
+
+	// EnvRuntimeHostSocket is the Unix socket path a runtime plugin should dial
+	// to reach host callbacks such as capability listing and provider invocation.
+	EnvRuntimeHostSocket = "GESTALT_RUNTIME_HOST_SOCKET"
+)


### PR DESCRIPTION
Integrations and runtimes can now be backed by external executables
instead of compiled-in factories. Setting a `plugin:` block in the
config with a `command` (and optional `args`/`env`) causes Gestalt to
spawn the executable as a child process and communicate with it over
the pluginapi gRPC protocol. This lets plugin authors write providers
and runtimes in any language without linking against Gestalt internals.

The bootstrap layer manages the full lifecycle: starting the process,
waiting for the gRPC socket, and tearing down gracefully on shutdown.
An echo plugin binary exercises the end-to-end path in tests, including
a runtime that calls back into the host to invoke a provider.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>