### PR TITLE
Add shared bootstrap egress deps

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -250,6 +250,7 @@ func defaultProviderFactory(preparedProviders map[string]string) bootstrap.Provi
 				}
 				intgForBuild := intgWithUpstreamAuth(intg, *us)
 				var buildOpts []provider.BuildOption
+				buildOpts = append(buildOpts, provider.WithEgressResolver(deps.Egress.Resolver))
 				if us.Auth.Type == "mcp_oauth" {
 					handler := buildMCPOAuthHandlerFromUpstream(*us, regStore, deps)
 					buildOpts = append(buildOpts, provider.WithAuthHandler(handler))
@@ -373,6 +374,7 @@ func buildMCPOAuthProvider(name string, intg config.IntegrationDef, us config.Up
 		ConnMode:           connMode,
 		Auth:               handler,
 		ManualAuthEnabled:  true,
+		EgressResolver:     deps.Egress.Resolver,
 	}
 
 	return composite.New(name, baseProv, mcpUp), nil

--- a/internal/apiexec/pagination.go
+++ b/internal/apiexec/pagination.go
@@ -46,9 +46,6 @@ func DoPaginated(ctx context.Context, client *http.Client, req Request, pgn Pagi
 	return doPaginated(ctx, client, req, pgn, Do)
 }
 
-// DoPaginatedWithExecutor runs the shared pagination loop using a custom
-// request executor. This is used by callers that want apiexec's pagination
-// semantics while swapping the transport implementation.
 func DoPaginatedWithExecutor(ctx context.Context, client *http.Client, req Request, pgn PaginationConfig, exec RequestExecutor) (*core.OperationResult, error) {
 	if exec == nil {
 		exec = Do

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -23,6 +23,7 @@ type Deps struct {
 	SecretManager core.SecretManager
 	SQLDB         any // *sql.DB when available, nil otherwise
 	SQLDialect    any // Placeholder(int)string when available, nil otherwise
+	Egress        EgressDeps
 }
 
 type AuthFactory func(node yaml.Node, deps Deps) (core.AuthProvider, error)
@@ -31,11 +32,13 @@ type ProviderFactory func(ctx context.Context, name string, intg config.Integrat
 type SecretManagerFactory func(node yaml.Node) (core.SecretManager, error)
 type BindingDeps struct {
 	Invoker invocation.Invoker
+	Egress  EgressDeps
 }
 
 type RuntimeDeps struct {
 	Invoker          invocation.Invoker
 	CapabilityLister invocation.CapabilityLister
+	Egress           EgressDeps
 }
 
 type RuntimeFactory func(ctx context.Context, name string, cfg config.RuntimeDef, deps RuntimeDeps) (core.Runtime, error)
@@ -74,6 +77,7 @@ type Result struct {
 	CapabilityLister invocation.CapabilityLister
 	AuditSink        core.AuditSink
 	SecretManager    core.SecretManager
+	Egress           EgressDeps
 	DevMode          bool
 }
 
@@ -110,6 +114,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	if err != nil {
 		return nil, err
 	}
+	deps.Egress = newEgressDeps(cfg, ds)
 
 	// Expose the underlying *sql.DB and dialect for optional use by
 	// provider factories (e.g. MCP OAuth registration storage).
@@ -130,12 +135,12 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	sharedInvoker := invocation.NewBroker(providers, ds)
 	audit := core.AuditSink(invocation.LogAuditSink{})
 
-	runtimes, err := buildRuntimes(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit)
+	runtimes, err := buildRuntimes(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress)
 	if err != nil {
 		return nil, err
 	}
 
-	bindings, err := buildBindings(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit)
+	bindings, err := buildBindings(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress)
 	if err != nil {
 		return nil, err
 	}
@@ -152,6 +157,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		CapabilityLister: sharedInvoker,
 		AuditSink:        audit,
 		SecretManager:    sm,
+		Egress:           deps.Egress,
 		DevMode:          cfg.Server.DevMode,
 	}, nil
 }
@@ -401,7 +407,7 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 	return &reg.Providers, ready, nil
 }
 
-func buildRuntimes(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink) (*registry.PluginMap[core.Runtime], error) {
+func buildRuntimes(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink, egressDeps EgressDeps) (*registry.PluginMap[core.Runtime], error) {
 	if len(cfg.Runtimes) == 0 {
 		return nil, nil
 	}
@@ -415,7 +421,7 @@ func buildRuntimes(ctx context.Context, cfg *config.Config, factories *FactoryRe
 			return nil, fmt.Errorf("bootstrap: unknown runtime type %q for runtime %q", def.Type, name)
 		}
 
-		deps := runtimeDepsForProviders(name, invoker, lister, def.Providers, audit)
+		deps := runtimeDepsForProviders(name, invoker, lister, def.Providers, audit, egressDeps)
 		rt, err := factory(ctx, name, def, deps)
 		if err != nil {
 			return nil, fmt.Errorf("bootstrap: runtime %q: %w", name, err)
@@ -430,7 +436,7 @@ func buildRuntimes(ctx context.Context, cfg *config.Config, factories *FactoryRe
 	return runtimes, nil
 }
 
-func buildBindings(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink) (*registry.PluginMap[core.Binding], error) {
+func buildBindings(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink, egressDeps EgressDeps) (*registry.PluginMap[core.Binding], error) {
 	if len(cfg.Bindings) == 0 {
 		return nil, nil
 	}
@@ -444,7 +450,7 @@ func buildBindings(ctx context.Context, cfg *config.Config, factories *FactoryRe
 			return nil, fmt.Errorf("bootstrap: unknown binding type %q for binding %q", def.Type, name)
 		}
 
-		deps := bindingDepsForProviders(name, invoker, lister, def.Providers, audit)
+		deps := bindingDepsForProviders(name, invoker, lister, def.Providers, audit, egressDeps)
 		binding, err := factory(ctx, name, def, deps)
 		if err != nil {
 			return nil, fmt.Errorf("bootstrap: binding %q: %w", name, err)

--- a/internal/bootstrap/egress.go
+++ b/internal/bootstrap/egress.go
@@ -1,0 +1,21 @@
+package bootstrap
+
+import (
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/egress"
+)
+
+// EgressDeps carries shared outbound request resolution dependencies that can
+// be reused by providers, bindings, and runtimes.
+type EgressDeps struct {
+	Resolver *egress.Resolver
+}
+
+func newEgressDeps(_ *config.Config, _ core.Datastore) EgressDeps {
+	return EgressDeps{
+		Resolver: &egress.Resolver{
+			Subjects: egress.ContextSubjectResolver{},
+		},
+	}
+}

--- a/internal/bootstrap/egress.go
+++ b/internal/bootstrap/egress.go
@@ -6,8 +6,6 @@ import (
 	"github.com/valon-technologies/gestalt/internal/egress"
 )
 
-// EgressDeps carries shared outbound request resolution dependencies that can
-// be reused by providers, bindings, and runtimes.
 type EgressDeps struct {
 	Resolver *egress.Resolver
 }

--- a/internal/bootstrap/runtime_deps.go
+++ b/internal/bootstrap/runtime_deps.go
@@ -7,17 +7,19 @@ import (
 	"github.com/valon-technologies/gestalt/internal/invocation"
 )
 
-func runtimeDepsForProviders(name string, invoker invocation.Invoker, lister invocation.CapabilityLister, providers []string, audit core.AuditSink) RuntimeDeps {
+func runtimeDepsForProviders(name string, invoker invocation.Invoker, lister invocation.CapabilityLister, providers []string, audit core.AuditSink, egressDeps EgressDeps) RuntimeDeps {
 	guarded := guardedInvoker("runtime", name, invoker, lister, providers, audit)
 	return RuntimeDeps{
 		Invoker:          guarded,
 		CapabilityLister: guarded,
+		Egress:           egressDeps,
 	}
 }
 
-func bindingDepsForProviders(name string, invoker invocation.Invoker, lister invocation.CapabilityLister, providers []string, audit core.AuditSink) BindingDeps {
+func bindingDepsForProviders(name string, invoker invocation.Invoker, lister invocation.CapabilityLister, providers []string, audit core.AuditSink, egressDeps EgressDeps) BindingDeps {
 	return BindingDeps{
 		Invoker: guardedInvoker("binding", name, invoker, lister, providers, audit),
+		Egress:  egressDeps,
 	}
 }
 

--- a/internal/bootstrap/validate.go
+++ b/internal/bootstrap/validate.go
@@ -44,6 +44,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 		return nil, err
 	}
 	defer func() { _ = ds.Close() }()
+	deps.Egress = newEgressDeps(cfg, ds)
 
 	var warnings []string
 	if w, ok := ds.(interface{ Warnings() []string }); ok {
@@ -59,7 +60,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 	sharedInvoker := invocation.NewBroker(providers, ds)
 	audit := core.AuditSink(invocation.LogAuditSink{})
 
-	runtimes, err := buildRuntimes(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit)
+	runtimes, err := buildRuntimes(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress)
 	if err != nil {
 		return warnings, err
 	}
@@ -69,7 +70,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 		defer func() { _ = StopRuntimes(context.Background(), runtimes, runtimes.List()) }()
 	}
 
-	bindings, err := buildBindings(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit)
+	bindings, err := buildBindings(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress)
 	if err != nil {
 		return warnings, err
 	}

--- a/internal/egress/egresstest/helpers.go
+++ b/internal/egress/egresstest/helpers.go
@@ -6,7 +6,6 @@ import (
 	"github.com/valon-technologies/gestalt/internal/egress"
 )
 
-// PolicyFunc adapts a plain function to the egress.PolicyEnforcer interface.
 type PolicyFunc func(context.Context, egress.PolicyInput) error
 
 func (f PolicyFunc) Evaluate(ctx context.Context, input egress.PolicyInput) error {

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -13,6 +13,7 @@ import (
 	ci "github.com/valon-technologies/gestalt/core/integration"
 	"github.com/valon-technologies/gestalt/internal/apiexec"
 	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/egress"
 	"github.com/valon-technologies/gestalt/internal/integration"
 	"github.com/valon-technologies/gestalt/internal/oauth"
 )
@@ -22,11 +23,17 @@ type BuildOption func(*buildOptions)
 
 type buildOptions struct {
 	authOverride ci.AuthHandler
+	egress       *egress.Resolver
 }
 
 // WithAuthHandler injects a pre-built auth handler, bypassing buildAuth.
 func WithAuthHandler(h ci.AuthHandler) BuildOption {
 	return func(o *buildOptions) { o.authOverride = h }
+}
+
+// WithEgressResolver injects a shared outbound request resolver.
+func WithEgressResolver(r *egress.Resolver) BuildOption {
+	return func(o *buildOptions) { o.egress = r }
 }
 
 func Build(def *Definition, intg config.IntegrationDef, allowedOperations map[string]string, opts ...BuildOption) (core.Provider, error) {
@@ -80,6 +87,7 @@ func Build(def *Definition, intg config.IntegrationDef, allowedOperations map[st
 		Queries:            ci.QueriesMap(cat),
 		Headers:            def.Headers,
 		Pagination:         buildPaginationConfigs(def),
+		EgressResolver:     bo.egress,
 	}
 
 	connMode := def.ConnectionMode

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -31,7 +31,6 @@ func WithAuthHandler(h ci.AuthHandler) BuildOption {
 	return func(o *buildOptions) { o.authOverride = h }
 }
 
-// WithEgressResolver injects a shared outbound request resolver.
 func WithEgressResolver(r *egress.Resolver) BuildOption {
 	return func(o *buildOptions) { o.egress = r }
 }

--- a/plugins/bindings/proxy/factory.go
+++ b/plugins/bindings/proxy/factory.go
@@ -9,7 +9,7 @@ import (
 	"github.com/valon-technologies/gestalt/internal/egress"
 )
 
-var Factory bootstrap.BindingFactory = func(_ context.Context, name string, def config.BindingDef, _ bootstrap.BindingDeps) (core.Binding, error) {
+var Factory bootstrap.BindingFactory = func(_ context.Context, name string, def config.BindingDef, deps bootstrap.BindingDeps) (core.Binding, error) {
 	var cfg proxyConfig
 	if err := def.Config.Decode(&cfg); err != nil {
 		return nil, err
@@ -17,5 +17,9 @@ var Factory bootstrap.BindingFactory = func(_ context.Context, name string, def 
 	if err := cfg.validate(name); err != nil {
 		return nil, err
 	}
-	return New(name, cfg, egress.Resolver{}), nil
+	resolver := egress.Resolver{}
+	if deps.Egress.Resolver != nil {
+		resolver = *deps.Egress.Resolver
+	}
+	return New(name, cfg, resolver), nil
 }


### PR DESCRIPTION
Shared bootstrap-owned egress dependency wiring for providers, bindings, and runtimes.