### PR TITLE
Compose GraphQL and MCP egress paths

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -266,7 +266,7 @@ func defaultProviderFactory(preparedProviders map[string]string) bootstrap.Provi
 					cleanup()
 					return nil, fmt.Errorf("multiple mcp upstreams not supported")
 				}
-				up, err := mcpupstream.New(ctx, name, us.URL, connMode)
+				up, err := mcpupstream.New(ctx, name, us.URL, connMode, deps.Egress.Resolver)
 				if err != nil {
 					return nil, err
 				}

--- a/core/integration/base.go
+++ b/core/integration/base.go
@@ -252,13 +252,13 @@ func (b *Base) Execute(ctx context.Context, operation string, params map[string]
 	}
 
 	if query, ok := b.Queries[operation]; ok {
-		return b.executeGraphQL(ctx, query, params, token)
+		return b.executeGraphQL(ctx, operation, query, params, token)
 	}
 
 	return b.executeREST(ctx, operation, params, token)
 }
 
-func (b *Base) executeGraphQL(ctx context.Context, query string, params map[string]any, token string) (*core.OperationResult, error) {
+func (b *Base) executeGraphQL(ctx context.Context, operation string, query string, params map[string]any, token string) (*core.OperationResult, error) {
 	gqlURL, headers := b.resolvedURLAndHeaders(ctx)
 
 	gqlReq := apiexec.GraphQLRequest{
@@ -270,7 +270,20 @@ func (b *Base) executeGraphQL(ctx context.Context, query string, params map[stri
 	if err := b.applyGraphQLAuth(&gqlReq, token); err != nil {
 		return nil, err
 	}
-	return apiexec.DoGraphQL(ctx, b.httpClient(), gqlReq)
+
+	resolved, err := b.resolveGraphQLEgress(ctx, operation, gqlReq)
+	if err != nil {
+		return nil, err
+	}
+
+	return egress.ExecuteGraphQL(ctx, b.httpClient(), egress.GraphQLRequestSpec{
+		Target:     resolved.Target,
+		URL:        gqlReq.URL,
+		Query:      gqlReq.Query,
+		Variables:  gqlReq.Variables,
+		Headers:    resolved.Headers,
+		Credential: resolved.Credential,
+	})
 }
 
 func (b *Base) egressAuthStyle() egress.AuthStyle {

--- a/core/integration/base_test.go
+++ b/core/integration/base_test.go
@@ -362,6 +362,80 @@ func TestBaseExecuteGraphQLWithVariables(t *testing.T) {
 	}
 }
 
+func TestBaseExecuteGraphQLRunsEgressResolutionOnFinalRequest(t *testing.T) {
+	t.Parallel()
+
+	var gotPolicy egress.PolicyInput
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/graphql" {
+			t.Fatalf("path = %s, want /graphql", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"viewer":{"auth":"` + r.Header.Get("Authorization") + `","org":"` + r.Header.Get("X-Org") + `"}}}`))
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL + "/graphql",
+		Queries: map[string]string{
+			"get_viewer": "{ viewer { login } }",
+		},
+		TokenParser: func(token string) (string, map[string]string, error) {
+			return "Token " + token, map[string]string{"X-Org": "acme"}, nil
+		},
+		IntegrationName: "github",
+		EgressResolver: &egress.Resolver{
+			Subjects: egress.ContextSubjectResolver{},
+			Policy: egresstest.PolicyFunc(func(_ context.Context, input egress.PolicyInput) error {
+				gotPolicy = input
+				return nil
+			}),
+		},
+	}
+
+	ctx := egress.WithSubject(context.Background(), egress.Subject{Kind: egress.SubjectAgent, ID: "agent-graphql"})
+	result, err := b.Execute(ctx, "get_viewer", nil, "gql-token")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", result.Status)
+	}
+
+	if gotPolicy.Subject != (egress.Subject{Kind: egress.SubjectAgent, ID: "agent-graphql"}) {
+		t.Fatalf("subject = %+v, want agent-graphql", gotPolicy.Subject)
+	}
+	if gotPolicy.Target.Provider != "github" || gotPolicy.Target.Operation != "get_viewer" {
+		t.Fatalf("target = %+v, want github/get_viewer", gotPolicy.Target)
+	}
+	if gotPolicy.Target.Method != http.MethodPost || gotPolicy.Target.Path != "/graphql" {
+		t.Fatalf("target = %+v, want POST /graphql", gotPolicy.Target)
+	}
+	if gotPolicy.Headers["Authorization"] != "Token gql-token" {
+		t.Fatalf("authorization = %q, want Token gql-token", gotPolicy.Headers["Authorization"])
+	}
+	if gotPolicy.Headers["X-Org"] != "acme" {
+		t.Fatalf("org = %q, want acme", gotPolicy.Headers["X-Org"])
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &data); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	viewer := data["viewer"].(map[string]any)
+	if viewer["auth"] != "Token gql-token" {
+		t.Fatalf("auth = %v, want Token gql-token", viewer["auth"])
+	}
+	if viewer["org"] != "acme" {
+		t.Fatalf("org = %v, want acme", viewer["org"])
+	}
+}
+
 func TestBaseExecuteGraphQLWithTokenParser(t *testing.T) {
 	t.Parallel()
 

--- a/core/integration/egress_adapter.go
+++ b/core/integration/egress_adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/apiexec"
@@ -67,15 +68,47 @@ func (b *Base) resolveEgress(ctx context.Context, operation string, req apiexec.
 	})
 }
 
-func credentialFromAPIRequest(req apiexec.Request) egress.CredentialMaterialization {
+func (b *Base) resolveGraphQLEgress(ctx context.Context, operation string, req apiexec.GraphQLRequest) (egress.Resolution, error) {
+	resolver := egress.Resolver{}
+	if b.EgressResolver != nil {
+		resolver = *b.EgressResolver
+	}
+
+	parsed, err := url.Parse(req.URL)
+	if err != nil {
+		return egress.Resolution{}, fmt.Errorf("parsing graphql url: %w", err)
+	}
+
+	return resolver.Resolve(ctx, egress.ResolutionInput{
+		Target: egress.Target{
+			Provider:  b.IntegrationName,
+			Operation: operation,
+			Method:    http.MethodPost,
+			Host:      parsed.Host,
+			Path:      parsed.Path,
+		},
+		Headers:    egress.CopyHeaders(req.CustomHeaders),
+		Credential: credentialFromGraphQLRequest(req),
+	})
+}
+
+func credentialFromAuth(token, authHeader string) egress.CredentialMaterialization {
 	switch {
-	case req.AuthHeader != "":
-		return egress.CredentialMaterialization{Authorization: req.AuthHeader}
-	case req.Token != "":
-		return egress.CredentialMaterialization{Authorization: core.BearerScheme + req.Token}
+	case authHeader != "":
+		return egress.CredentialMaterialization{Authorization: authHeader}
+	case token != "":
+		return egress.CredentialMaterialization{Authorization: core.BearerScheme + token}
 	default:
 		return egress.CredentialMaterialization{}
 	}
+}
+
+func credentialFromAPIRequest(req apiexec.Request) egress.CredentialMaterialization {
+	return credentialFromAuth(req.Token, req.AuthHeader)
+}
+
+func credentialFromGraphQLRequest(req apiexec.GraphQLRequest) egress.CredentialMaterialization {
+	return credentialFromAuth(req.Token, req.AuthHeader)
 }
 
 func executeEgressHTTP(ctx context.Context, client *http.Client, req apiexec.Request) (*core.OperationResult, error) {

--- a/internal/egress/graphql.go
+++ b/internal/egress/graphql.go
@@ -1,0 +1,38 @@
+package egress
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/apiexec"
+)
+
+// GraphQLRequestSpec is the generic outbound GraphQL representation shared by
+// product-specific adapters.
+type GraphQLRequestSpec struct {
+	Target     Target
+	URL        string
+	Query      string
+	Variables  map[string]any
+	Headers    map[string]string
+	Credential CredentialMaterialization
+}
+
+// BuildGraphQLRequest translates a generic GraphQL spec into the existing
+// apiexec request.
+func BuildGraphQLRequest(spec GraphQLRequestSpec) apiexec.GraphQLRequest {
+	return apiexec.GraphQLRequest{
+		URL:           spec.URL,
+		Query:         spec.Query,
+		Variables:     spec.Variables,
+		AuthHeader:    spec.Credential.Authorization,
+		CustomHeaders: ApplyHeaderMutations(spec.Headers, spec.Credential.Headers),
+	}
+}
+
+// ExecuteGraphQL executes the generic GraphQL request through the existing
+// apiexec transport.
+func ExecuteGraphQL(ctx context.Context, client *http.Client, spec GraphQLRequestSpec) (*core.OperationResult, error) {
+	return apiexec.DoGraphQL(ctx, client, BuildGraphQLRequest(spec))
+}

--- a/internal/egress/roundtripper.go
+++ b/internal/egress/roundtripper.go
@@ -1,0 +1,71 @@
+package egress
+
+import (
+	"fmt"
+	"net/http"
+	"net/textproto"
+	"strings"
+)
+
+// ResolvingRoundTripper runs requests through the shared egress resolver before
+// delegating to the wrapped transport.
+type ResolvingRoundTripper struct {
+	base     http.RoundTripper
+	resolver *Resolver
+}
+
+func NewResolvingRoundTripper(base http.RoundTripper, resolver *Resolver) http.RoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &ResolvingRoundTripper{base: base, resolver: resolver}
+}
+
+func (r *ResolvingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if r == nil || r.base == nil {
+		return nil, fmt.Errorf("egress resolving round tripper is not initialized")
+	}
+	if req == nil || req.URL == nil {
+		return nil, fmt.Errorf("nil request")
+	}
+	if r.resolver == nil {
+		return r.base.RoundTrip(req)
+	}
+
+	resolved, err := r.resolver.Resolve(req.Context(), ResolutionInput{
+		Target: Target{
+			Method: req.Method,
+			Host:   req.URL.Host,
+			Path:   req.URL.Path,
+		},
+		Headers: requestHeaders(req.Header),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	clone := req.Clone(req.Context())
+	clone.Header = make(http.Header, len(resolved.Headers)+1)
+	for key, value := range resolved.Headers {
+		clone.Header.Set(key, value)
+	}
+	if resolved.Credential.Authorization != "" {
+		clone.Header.Set("Authorization", resolved.Credential.Authorization)
+	}
+
+	return r.base.RoundTrip(clone)
+}
+
+func requestHeaders(h http.Header) map[string]string {
+	if len(h) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(h))
+	for k, values := range h {
+		if len(values) == 0 {
+			continue
+		}
+		out[textproto.CanonicalMIMEHeaderKey(k)] = strings.Join(values, ",")
+	}
+	return out
+}

--- a/internal/mcp/binding.go
+++ b/internal/mcp/binding.go
@@ -8,6 +8,7 @@ import (
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
 	ci "github.com/valon-technologies/gestalt/core/integration"
+	"github.com/valon-technologies/gestalt/internal/egress"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	"github.com/valon-technologies/gestalt/internal/mcpupstream"
 	"github.com/valon-technologies/gestalt/internal/principal"
@@ -152,6 +153,7 @@ func makeDirectHandler(cfg Config, provName, opName string, caller directToolCal
 		if p == nil {
 			return mcpgo.NewToolResultError("not authenticated"), nil
 		}
+		ctx = attachEgressSubject(ctx, p)
 
 		args := req.GetArguments()
 		instance, _ := args["_instance"].(string)
@@ -168,6 +170,10 @@ func makeDirectHandler(cfg Config, provName, opName string, caller directToolCal
 }
 
 func hydrateSessionTools(ctx context.Context, cfg Config, providerNames []string) {
+	if p := principal.FromContext(ctx); p != nil {
+		ctx = attachEgressSubject(ctx, p)
+	}
+
 	session := mcpserver.ClientSessionFromContext(ctx)
 	if session == nil {
 		return
@@ -219,6 +225,19 @@ func hydrateSessionTools(ctx context.Context, cfg Config, providerNames []string
 	if changed {
 		sessionWithTools.SetSessionTools(tools)
 	}
+}
+
+func attachEgressSubject(ctx context.Context, p *principal.Principal) context.Context {
+	if _, ok := egress.SubjectFromContext(ctx); ok {
+		return ctx
+	}
+	if p == nil || p.UserID == "" {
+		return ctx
+	}
+	return egress.WithSubject(ctx, egress.Subject{
+		Kind: egress.SubjectUser,
+		ID:   p.UserID,
+	})
 }
 
 func hasToolsWithPrefix(tools map[string]mcpserver.ServerTool, prefix string) bool {

--- a/internal/mcp/binding_test.go
+++ b/internal/mcp/binding_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/valon-technologies/gestalt/core/catalog"
 	ci "github.com/valon-technologies/gestalt/core/integration"
 	coretesting "github.com/valon-technologies/gestalt/core/testing"
+	"github.com/valon-technologies/gestalt/internal/egress"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	gestaltmcp "github.com/valon-technologies/gestalt/internal/mcp"
 	"github.com/valon-technologies/gestalt/internal/mcpupstream"
@@ -635,6 +636,7 @@ func TestNewServer_DirectCallerPassthrough(t *testing.T) {
 
 	var calledName string
 	var calledArgs map[string]any
+	var gotSubject egress.Subject
 
 	cat := &catalog.Catalog{
 		Name: "clickhouse",
@@ -651,7 +653,12 @@ func TestNewServer_DirectCallerPassthrough(t *testing.T) {
 		StubIntegration: coretesting.StubIntegration{N: "clickhouse"},
 		ops:             []core.Operation{{Name: "run_query", Description: "Execute a SQL query"}},
 		cat:             cat,
-		callFn: func(_ context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
+		callFn: func(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
+			subject, ok := egress.SubjectFromContext(ctx)
+			if !ok {
+				t.Fatal("expected egress subject in direct caller context")
+			}
+			gotSubject = subject
 			calledName = name
 			calledArgs = args
 			return mcpgo.NewToolResultText("query result"), nil
@@ -687,6 +694,9 @@ func TestNewServer_DirectCallerPassthrough(t *testing.T) {
 	}
 	if calledArgs["sql"] != "SELECT 1" {
 		t.Fatalf("expected sql=SELECT 1, got %v", calledArgs)
+	}
+	if gotSubject != (egress.Subject{Kind: egress.SubjectUser, ID: "u1"}) {
+		t.Fatalf("subject = %+v, want user u1", gotSubject)
 	}
 
 	text, ok := result.Content[0].(mcpgo.TextContent)
@@ -773,9 +783,15 @@ func TestNewServer_DynamicCatalogProviderListsSessionTools(t *testing.T) {
 	t.Parallel()
 
 	var gotToken string
+	var gotSubject egress.Subject
 	prov := &directCallerProvider{
 		StubIntegration: coretesting.StubIntegration{N: "clickhouse"},
-		sessionCatalogFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+		sessionCatalogFn: func(ctx context.Context, token string) (*catalog.Catalog, error) {
+			subject, ok := egress.SubjectFromContext(ctx)
+			if !ok {
+				t.Fatal("expected egress subject in session catalog context")
+			}
+			gotSubject = subject
 			gotToken = token
 			return &catalog.Catalog{
 				Name: "clickhouse",
@@ -805,6 +821,9 @@ func TestNewServer_DynamicCatalogProviderListsSessionTools(t *testing.T) {
 	if gotToken != "upstream-token" {
 		t.Fatalf("expected token upstream-token, got %q", gotToken)
 	}
+	if gotSubject != (egress.Subject{Kind: egress.SubjectUser, ID: "u1"}) {
+		t.Fatalf("subject = %+v, want user u1", gotSubject)
+	}
 	if len(result.Tools) != 1 {
 		t.Fatalf("expected 1 tool, got %d", len(result.Tools))
 	}
@@ -818,10 +837,16 @@ func TestNewServer_DynamicCatalogProviderCallsSessionTool(t *testing.T) {
 
 	var calledName string
 	var gotToken string
+	var gotSubject egress.Subject
 
 	prov := &directCallerProvider{
 		StubIntegration: coretesting.StubIntegration{N: "clickhouse"},
-		sessionCatalogFn: func(_ context.Context, _ string) (*catalog.Catalog, error) {
+		sessionCatalogFn: func(ctx context.Context, _ string) (*catalog.Catalog, error) {
+			subject, ok := egress.SubjectFromContext(ctx)
+			if !ok {
+				t.Fatal("expected egress subject in session catalog context")
+			}
+			gotSubject = subject
 			return &catalog.Catalog{
 				Name: "clickhouse",
 				Operations: []catalog.CatalogOperation{
@@ -859,6 +884,9 @@ func TestNewServer_DynamicCatalogProviderCallsSessionTool(t *testing.T) {
 	}
 	if gotToken != "upstream-token" {
 		t.Fatalf("expected upstream-token, got %q", gotToken)
+	}
+	if gotSubject != (egress.Subject{Kind: egress.SubjectUser, ID: "u1"}) {
+		t.Fatalf("subject = %+v, want user u1", gotSubject)
 	}
 }
 

--- a/internal/mcpupstream/upstream.go
+++ b/internal/mcpupstream/upstream.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"slices"
 	"time"
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
+	"github.com/valon-technologies/gestalt/internal/egress"
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
@@ -34,9 +36,10 @@ type Upstream struct {
 	ops      []core.Operation
 	client   mcpclient.MCPClient
 	allowed  map[string]string
+	resolver *egress.Resolver
 }
 
-func New(_ context.Context, name string, url string, connMode core.ConnectionMode) (*Upstream, error) {
+func New(_ context.Context, name string, url string, connMode core.ConnectionMode, resolver *egress.Resolver) (*Upstream, error) {
 	if url == "" {
 		return nil, fmt.Errorf("mcpupstream %s: url is required", name)
 	}
@@ -47,6 +50,7 @@ func New(_ context.Context, name string, url string, connMode core.ConnectionMod
 		desc:     fmt.Sprintf("MCP upstream: %s", url),
 		url:      url,
 		connMode: connMode,
+		resolver: resolver,
 	}, nil
 }
 
@@ -134,8 +138,13 @@ func (u *Upstream) connect(ctx context.Context, token string) (mcpclient.MCPClie
 		return u.client, nil
 	}
 
+	httpClient := &http.Client{
+		Timeout:   httpTimeout,
+		Transport: egress.NewResolvingRoundTripper(http.DefaultTransport, u.resolver),
+	}
+
 	client, err := mcpclient.NewStreamableHttpClient(u.url,
-		transport.WithHTTPTimeout(httpTimeout),
+		transport.WithHTTPBasicClient(httpClient),
 		transport.WithHTTPHeaderFunc(func(context.Context) map[string]string {
 			if token != "" {
 				return map[string]string{"Authorization": core.BearerScheme + token}

--- a/internal/mcpupstream/upstream_test.go
+++ b/internal/mcpupstream/upstream_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/egress"
+	"github.com/valon-technologies/gestalt/internal/egress/egresstest"
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -262,7 +264,7 @@ func TestUpstream_LazyDiscoveryUsesRequestToken(t *testing.T) {
 	ts := newAuthenticatedHTTPTestServer(t, "Bearer secret-token")
 	t.Cleanup(ts.Close)
 
-	u, err := New(context.Background(), "clickhouse", ts.URL, core.ConnectionModeUser)
+	u, err := New(context.Background(), "clickhouse", ts.URL, core.ConnectionModeUser, nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -277,6 +279,52 @@ func TestUpstream_LazyDiscoveryUsesRequestToken(t *testing.T) {
 
 	ctx := WithUpstreamToken(context.Background(), "secret-token")
 	result, err := u.CallTool(ctx, "run_query", map[string]any{"sql": "SELECT 1"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+}
+
+func TestUpstream_UsesSharedEgressResolver(t *testing.T) {
+	t.Parallel()
+
+	var gotPolicy egress.PolicyInput
+	ts := newAuthenticatedHTTPTestServer(t, "Bearer secret-token")
+	t.Cleanup(ts.Close)
+
+	u, err := New(context.Background(), "clickhouse", ts.URL, core.ConnectionModeUser, &egress.Resolver{
+		Subjects: egress.ContextSubjectResolver{},
+		Policy: egresstest.PolicyFunc(func(_ context.Context, input egress.PolicyInput) error {
+			gotPolicy = input
+			return nil
+		}),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := egress.WithSubject(context.Background(), egress.Subject{Kind: egress.SubjectUser, ID: "u1"})
+	cat, err := u.CatalogForRequest(ctx, "secret-token")
+	if err != nil {
+		t.Fatalf("CatalogForRequest: %v", err)
+	}
+	if len(cat.Operations) != 2 {
+		t.Fatalf("expected 2 operations, got %d", len(cat.Operations))
+	}
+	if gotPolicy.Subject != (egress.Subject{Kind: egress.SubjectUser, ID: "u1"}) {
+		t.Fatalf("subject = %+v, want user u1", gotPolicy.Subject)
+	}
+	if gotPolicy.Target.Method == "" {
+		t.Fatal("expected target method to be populated")
+	}
+
+	callCtx := WithUpstreamToken(
+		egress.WithSubject(context.Background(), egress.Subject{Kind: egress.SubjectUser, ID: "u1"}),
+		"secret-token",
+	)
+	result, err := u.CallTool(callCtx, "run_query", map[string]any{"sql": "SELECT 1"})
 	if err != nil {
 		t.Fatalf("CallTool: %v", err)
 	}


### PR DESCRIPTION
Wires GraphQL provider execution and MCP direct/upstream HTTP through shared egress primitives, including subject propagation for direct MCP bypasses.