### PR TITLE
Forward upstream response headers through the proxy

### DIFF
--- a/core/types.go
+++ b/core/types.go
@@ -1,6 +1,9 @@
 package core
 
-import "time"
+import (
+	"net/http"
+	"time"
+)
 
 type User struct {
 	ID          string
@@ -67,6 +70,7 @@ type Parameter struct {
 }
 
 type OperationResult struct {
-	Status int
-	Body   string
+	Status  int
+	Headers http.Header
+	Body    string
 }

--- a/internal/apiexec/apiexec.go
+++ b/internal/apiexec/apiexec.go
@@ -203,8 +203,9 @@ func doOnce(
 	}
 
 	return &core.OperationResult{
-		Status: resp.StatusCode,
-		Body:   string(respBody),
+		Status:  resp.StatusCode,
+		Headers: resp.Header,
+		Body:    string(respBody),
 	}, resp.StatusCode, retryAfter, false, nil
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -21,7 +21,6 @@ import (
 	coretesting "github.com/valon-technologies/gestalt/core/testing"
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/internal/config"
-	"github.com/valon-technologies/gestalt/internal/egress"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	gestaltmcp "github.com/valon-technologies/gestalt/internal/mcp"
 	"github.com/valon-technologies/gestalt/internal/oauth"
@@ -2950,29 +2949,47 @@ func TestBindingRoutesMounted(t *testing.T) {
 func TestProxyBindingRoutesMountedAsPrefix(t *testing.T) {
 	t.Parallel()
 
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"path":   r.URL.Path,
+			"query":  r.URL.RawQuery,
+			"method": r.Method,
+			"body":   string(body),
+		})
+	}))
+	t.Cleanup(upstream.Close)
+
+	upstreamHost := upstream.Listener.Addr().String()
+
 	cases := []struct {
 		name           string
 		configuredPath string
 		nestedURL      string
 		exactURL       string
+		wantPath       string
 	}{
 		{
 			name:           "agent-proxy",
 			configuredPath: "/proxy",
 			nestedURL:      "/api/v1/bindings/agent-proxy/proxy/messages?cursor=123",
 			exactURL:       "/api/v1/bindings/agent-proxy/proxy",
+			wantPath:       "/messages",
 		},
 		{
 			name:           "api-proxy",
 			configuredPath: "/api",
 			nestedURL:      "/api/v1/bindings/api-proxy/api/messages?cursor=123",
 			exactURL:       "/api/v1/bindings/api-proxy/api",
+			wantPath:       "/messages",
 		},
 		{
 			name:           "root-proxy",
 			configuredPath: "/",
 			nestedURL:      "/api/v1/bindings/root-proxy/messages?cursor=123",
 			exactURL:       "/api/v1/bindings/root-proxy/",
+			wantPath:       "/messages",
 		},
 	}
 
@@ -2998,63 +3015,66 @@ func TestProxyBindingRoutesMountedAsPrefix(t *testing.T) {
 				t.Fatalf("new request: %v", err)
 			}
 			req.Header.Set("Content-Type", "text/plain")
-			req.Header.Set("X-Forwarded-Host", "api.example.com")
+			req.Header.Set("X-Forwarded-Host", upstreamHost)
+			req.Header.Set("X-Forwarded-Proto", "http")
 
 			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
 				t.Fatalf("request: %v", err)
 			}
 
-			if resp.StatusCode != http.StatusNotImplemented {
+			if resp.StatusCode != http.StatusOK {
 				_ = resp.Body.Close()
-				t.Fatalf("expected 501, got %d", resp.StatusCode)
+				t.Fatalf("expected 200, got %d", resp.StatusCode)
+			}
+			if resp.Header.Get("Content-Type") != "application/json" {
+				_ = resp.Body.Close()
+				t.Fatalf("Content-Type = %q, want application/json", resp.Header.Get("Content-Type"))
 			}
 
-			var result struct {
-				Policy egress.PolicyInput `json:"policy_input"`
-				Target egress.Target      `json:"target"`
-				Body   string             `json:"body"`
-			}
+			var result map[string]string
 			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 				t.Fatalf("decoding: %v", err)
 			}
-
-			if result.Target.Host != "api.example.com" {
-				t.Fatalf("target host = %q, want api.example.com", result.Target.Host)
-			}
-			if result.Target.Path != "/messages?cursor=123" {
-				t.Fatalf("target path = %q, want /messages?cursor=123", result.Target.Path)
-			}
-			if result.Policy.Subject.Kind != egress.SubjectSystem {
-				t.Fatalf("subject kind = %q, want system", result.Policy.Subject.Kind)
-			}
-			if result.Policy.Subject.ID != tc.name {
-				t.Fatalf("subject id = %q, want %s", result.Policy.Subject.ID, tc.name)
-			}
-			if result.Body != "hello" {
-				t.Fatalf("body = %q, want hello", result.Body)
-			}
 			_ = resp.Body.Close()
 
-			resp, err = http.Get(ts.URL + tc.exactURL)
+			if result["path"] != tc.wantPath {
+				t.Fatalf("upstream path = %q, want %q", result["path"], tc.wantPath)
+			}
+			if result["query"] != "cursor=123" {
+				t.Fatalf("upstream query = %q, want cursor=123", result["query"])
+			}
+			if result["method"] != http.MethodPost {
+				t.Fatalf("upstream method = %q, want POST", result["method"])
+			}
+			if result["body"] != "hello" {
+				t.Fatalf("upstream body = %q, want hello", result["body"])
+			}
+
+			exactReq, err := http.NewRequest(http.MethodGet, ts.URL+tc.exactURL, nil)
+			if err != nil {
+				t.Fatalf("new exact request: %v", err)
+			}
+			exactReq.Header.Set("X-Forwarded-Host", upstreamHost)
+			exactReq.Header.Set("X-Forwarded-Proto", "http")
+
+			resp, err = http.DefaultClient.Do(exactReq)
 			if err != nil {
 				t.Fatalf("exact request: %v", err)
 			}
 
-			if resp.StatusCode != http.StatusNotImplemented {
+			if resp.StatusCode != http.StatusOK {
 				_ = resp.Body.Close()
-				t.Fatalf("expected exact route to return 501, got %d", resp.StatusCode)
+				t.Fatalf("expected exact route to return 200, got %d", resp.StatusCode)
 			}
 
-			var exact struct {
-				Target egress.Target `json:"target"`
-			}
+			var exact map[string]string
 			if err := json.NewDecoder(resp.Body).Decode(&exact); err != nil {
 				t.Fatalf("decoding exact route: %v", err)
 			}
 			_ = resp.Body.Close()
-			if exact.Target.Path != "/" {
-				t.Fatalf("exact target path = %q, want /", exact.Target.Path)
+			if exact["path"] != "/" {
+				t.Fatalf("exact upstream path = %q, want /", exact["path"])
 			}
 		})
 	}

--- a/plugins/bindings/proxy/binding.go
+++ b/plugins/bindings/proxy/binding.go
@@ -10,9 +10,12 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/apiexec"
 	"github.com/valon-technologies/gestalt/internal/egress"
 	"github.com/valon-technologies/gestalt/plugins/bindings/internal/httpjson"
 )
+
+const maxRequestBodySize = 1 << 20 // 1 MB
 
 var _ core.Binding = (*Binding)(nil)
 
@@ -20,10 +23,14 @@ type Binding struct {
 	name     string
 	cfg      proxyConfig
 	resolver egress.Resolver
+	client   *http.Client
 }
 
-func New(name string, cfg proxyConfig, resolver egress.Resolver) *Binding {
-	return &Binding{name: name, cfg: cfg, resolver: resolver}
+func New(name string, cfg proxyConfig, resolver egress.Resolver, client *http.Client) *Binding {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &Binding{name: name, cfg: cfg, resolver: resolver, client: client}
 }
 
 func (b *Binding) Name() string           { return b.name }
@@ -48,25 +55,70 @@ func (b *Binding) Routes() []core.Route {
 }
 
 func (b *Binding) handle(w http.ResponseWriter, r *http.Request) {
-	norm, err := b.normalize(r)
+	if r.Method == http.MethodConnect {
+		httpjson.WriteError(w, http.StatusNotImplemented, "CONNECT proxying is not implemented yet")
+		return
+	}
+
+	resolved, body, err := b.resolve(r)
 	if err != nil {
 		httpjson.WriteError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	if r.Method == http.MethodConnect {
-		norm.Note = "CONNECT proxying is not implemented yet"
-	} else {
-		norm.Note = "proxy binding skeleton: request normalized, dispatch not wired"
+	scheme := resolveScheme(r)
+	result, err := egress.ExecuteHTTP(r.Context(), b.client, egress.HTTPRequestSpec{
+		Target:      resolved.Target,
+		BaseURL:     scheme + "://" + resolved.Target.Host,
+		Headers:     resolved.Headers,
+		Body:        body,
+		ContentType: r.Header.Get("Content-Type"),
+		Credential:  resolved.Credential,
+		Check:       acceptAllStatuses,
+		NoRetry:     true,
+	})
+	if err != nil {
+		httpjson.WriteError(w, http.StatusBadGateway, err.Error())
+		return
 	}
 
-	httpjson.WriteJSON(w, http.StatusNotImplemented, norm)
+	writeProxyResponse(w, result)
 }
 
-func (b *Binding) normalize(r *http.Request) (normalizedRequest, error) {
-	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+func writeProxyResponse(w http.ResponseWriter, result *core.OperationResult) {
+	for key, values := range result.Headers {
+		if isHopByHopHeader(key) {
+			continue
+		}
+		for _, v := range values {
+			w.Header().Add(key, v)
+		}
+	}
+	w.WriteHeader(result.Status)
+	_, _ = io.WriteString(w, result.Body)
+}
+
+// hopByHopHeaders are headers that apply to a single transport connection and
+// must not be forwarded by proxies (RFC 7230 section 6.1).
+var hopByHopHeaders = map[string]bool{
+	"Connection":          true,
+	"Keep-Alive":          true,
+	"Proxy-Authenticate":  true,
+	"Proxy-Authorization": true,
+	"Te":                  true,
+	"Trailer":             true,
+	"Transfer-Encoding":   true,
+	"Upgrade":             true,
+}
+
+func isHopByHopHeader(key string) bool {
+	return hopByHopHeaders[key]
+}
+
+func (b *Binding) resolve(r *http.Request) (egress.Resolution, []byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxRequestBodySize))
 	if err != nil {
-		return normalizedRequest{}, fmt.Errorf("reading request body: %w", err)
+		return egress.Resolution{}, nil, fmt.Errorf("reading request body: %w", err)
 	}
 	defer func() { _ = r.Body.Close() }()
 
@@ -86,17 +138,29 @@ func (b *Binding) normalize(r *http.Request) (normalizedRequest, error) {
 		Headers: headers,
 	})
 	if err != nil {
-		return normalizedRequest{}, err
+		return egress.Resolution{}, nil, err
 	}
 
-	norm := normalizedRequest{
-		Policy: resolved.Policy,
-		Target: resolved.Target,
+	return resolved, body, nil
+}
+
+// acceptAllStatuses allows the proxy to forward upstream error responses
+// instead of treating them as transport failures.
+var acceptAllStatuses apiexec.ResponseChecker = func(int, []byte) error { return nil }
+
+const (
+	schemeHTTP  = "http"
+	schemeHTTPS = "https"
+)
+
+func resolveScheme(r *http.Request) string {
+	if r.URL != nil && r.URL.Scheme != "" {
+		return r.URL.Scheme
 	}
-	if len(body) > 0 {
-		norm.Body = string(body)
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto == schemeHTTP || proto == schemeHTTPS {
+		return proto
 	}
-	return norm, nil
+	return schemeHTTPS
 }
 
 func resolveHost(r *http.Request) string {

--- a/plugins/bindings/proxy/binding_internal_test.go
+++ b/plugins/bindings/proxy/binding_internal_test.go
@@ -20,7 +20,7 @@ func TestBindingNormalizeRunsResolver(t *testing.T) {
 			got = input
 			return nil
 		}),
-	})
+	}, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/proxy/messages?cursor=123", bytes.NewBufferString("hello"))
 	req.Host = "api.example.com"
@@ -29,8 +29,8 @@ func TestBindingNormalizeRunsResolver(t *testing.T) {
 	w := httptest.NewRecorder()
 	b.Routes()[0].Handler.ServeHTTP(w, req)
 
-	if w.Code != http.StatusNotImplemented {
-		t.Fatalf("status = %d, want 501", w.Code)
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", w.Code)
 	}
 	if got.Subject != (egress.Subject{Kind: egress.SubjectSystem, ID: "agent-proxy"}) {
 		t.Fatalf("subject = %+v, want system agent-proxy", got.Subject)

--- a/plugins/bindings/proxy/config.go
+++ b/plugins/bindings/proxy/config.go
@@ -4,19 +4,10 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-
-	"github.com/valon-technologies/gestalt/internal/egress"
 )
 
 type proxyConfig struct {
 	Path string `yaml:"path"`
-}
-
-type normalizedRequest struct {
-	Note   string             `json:"note"`
-	Policy egress.PolicyInput `json:"policy_input"`
-	Target egress.Target      `json:"target"`
-	Body   string             `json:"body,omitempty"`
 }
 
 func (c proxyConfig) validate(name string) error {

--- a/plugins/bindings/proxy/factory.go
+++ b/plugins/bindings/proxy/factory.go
@@ -21,5 +21,5 @@ var Factory bootstrap.BindingFactory = func(_ context.Context, name string, def 
 	if deps.Egress.Resolver != nil {
 		resolver = *deps.Egress.Resolver
 	}
-	return New(name, cfg, resolver), nil
+	return New(name, cfg, resolver, nil), nil
 }

--- a/plugins/bindings/proxy/proxy_test.go
+++ b/plugins/bindings/proxy/proxy_test.go
@@ -1,4 +1,4 @@
-package proxy_test
+package proxy
 
 import (
 	"bytes"
@@ -12,14 +12,13 @@ import (
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/egress"
-	"github.com/valon-technologies/gestalt/plugins/bindings/proxy"
 	"gopkg.in/yaml.v3"
 )
 
 func TestProxyRoutes(t *testing.T) {
 	t.Parallel()
 
-	b := makeBinding(t, "/proxy")
+	b := testBinding(t, "/proxy", nil)
 	routes := b.Routes()
 	if len(routes) != 16 {
 		t.Fatalf("expected 16 routes, got %d", len(routes))
@@ -36,45 +35,175 @@ func TestProxyRoutes(t *testing.T) {
 	}
 }
 
-func TestProxyNormalizeRequest(t *testing.T) {
+func TestProxyForwardsResponseHeaders(t *testing.T) {
 	t.Parallel()
 
-	b := makeBinding(t, "/proxy")
-	req := httptest.NewRequest(http.MethodPost, "/proxy/messages?cursor=123", bytes.NewBufferString("hello"))
-	req.Host = "api.example.com"
-	req.Header.Set("X-Proxy-Token", "abc")
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-Id", "req-abc")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"path":   r.URL.Path,
+			"method": r.Method,
+		})
+	}))
+	t.Cleanup(upstream.Close)
 
+	b := testBinding(t, "/proxy", upstream.Client())
+
+	req := httptest.NewRequest(http.MethodGet, upstream.URL+"/proxy/v1/items", nil)
+	w := httptest.NewRecorder()
+	b.Routes()[0].Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+	if rid := w.Header().Get("X-Request-Id"); rid != "req-abc" {
+		t.Fatalf("X-Request-Id = %q, want req-abc", rid)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["path"] != "/v1/items" {
+		t.Fatalf("upstream path = %q, want /v1/items", body["path"])
+	}
+	if body["method"] != http.MethodGet {
+		t.Fatalf("upstream method = %q, want GET", body["method"])
+	}
+}
+
+func TestProxyForwardsRedirectHeaders(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "https://example.com/new-path")
+		w.WriteHeader(http.StatusMovedPermanently)
+	}))
+	t.Cleanup(upstream.Close)
+
+	noRedirectClient := upstream.Client()
+	noRedirectClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	b := testBinding(t, "/proxy", noRedirectClient)
+
+	req := httptest.NewRequest(http.MethodGet, upstream.URL+"/proxy/old-path", nil)
+	w := httptest.NewRecorder()
+	b.Routes()[0].Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMovedPermanently {
+		t.Fatalf("status = %d, want 301", w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "https://example.com/new-path" {
+		t.Fatalf("Location = %q, want https://example.com/new-path", loc)
+	}
+}
+
+func TestProxyForwardsPostBody(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		var payload map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"echo":         payload["message"],
+			"content_type": r.Header.Get("Content-Type"),
+		})
+	}))
+	t.Cleanup(upstream.Close)
+
+	b := testBinding(t, "/proxy", upstream.Client())
+
+	body := `{"message":"hello"}`
+	req := httptest.NewRequest(http.MethodPost, upstream.URL+"/proxy/echo", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	b.Routes()[0].Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["echo"] != "hello" {
+		t.Fatalf("echo = %q, want hello", resp["echo"])
+	}
+	if resp["content_type"] != "application/json" {
+		t.Fatalf("upstream content_type = %q, want application/json", resp["content_type"])
+	}
+}
+
+func TestProxyStripsHopByHopHeaders(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Keep-Alive", "timeout=5")
+		w.Header().Set("X-Custom", "preserved")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	b := testBinding(t, "/proxy", upstream.Client())
+
+	req := httptest.NewRequest(http.MethodGet, upstream.URL+"/proxy/test", nil)
+	w := httptest.NewRecorder()
+	b.Routes()[0].Handler.ServeHTTP(w, req)
+
+	if w.Header().Get("Connection") != "" {
+		t.Fatal("hop-by-hop Connection header should be stripped")
+	}
+	if w.Header().Get("Keep-Alive") != "" {
+		t.Fatal("hop-by-hop Keep-Alive header should be stripped")
+	}
+	if w.Header().Get("X-Custom") != "preserved" {
+		t.Fatalf("X-Custom = %q, want preserved", w.Header().Get("X-Custom"))
+	}
+}
+
+func TestProxyForwardsUpstreamErrors(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"access denied"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	b := testBinding(t, "/proxy", upstream.Client())
+
+	req := httptest.NewRequest(http.MethodGet, upstream.URL+"/proxy/secret", nil)
+	w := httptest.NewRecorder()
+	b.Routes()[0].Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+}
+
+func TestProxyCONNECTNotImplemented(t *testing.T) {
+	t.Parallel()
+
+	b := testBinding(t, "/proxy", nil)
+	req := httptest.NewRequest(http.MethodConnect, "/proxy/tunnel", nil)
 	w := httptest.NewRecorder()
 	b.Routes()[0].Handler.ServeHTTP(w, req)
 
 	if w.Code != http.StatusNotImplemented {
 		t.Fatalf("status = %d, want 501", w.Code)
-	}
-
-	var resp struct {
-		Note   string             `json:"note"`
-		Policy egress.PolicyInput `json:"policy_input"`
-		Target egress.Target      `json:"target"`
-		Body   string             `json:"body"`
-	}
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-
-	if resp.Target.Host != "api.example.com" {
-		t.Fatalf("target host = %q, want api.example.com", resp.Target.Host)
-	}
-	if resp.Target.Method != http.MethodPost {
-		t.Fatalf("target method = %q, want POST", resp.Target.Method)
-	}
-	if resp.Target.Path != "/messages?cursor=123" {
-		t.Fatalf("target path = %q, want /messages?cursor=123", resp.Target.Path)
-	}
-	if resp.Policy.Subject.Kind != egress.SubjectSystem {
-		t.Fatalf("subject kind = %q, want system", resp.Policy.Subject.Kind)
-	}
-	if resp.Body != "hello" {
-		t.Fatalf("body = %q, want hello", resp.Body)
 	}
 }
 
@@ -92,7 +221,7 @@ func TestProxyFactory(t *testing.T) {
 		Config: *node.Content[0],
 	}
 
-	binding, err := proxy.Factory(context.Background(), "proxy-surface", def, bootstrap.BindingDeps{})
+	binding, err := Factory(context.Background(), "proxy-surface", def, bootstrap.BindingDeps{})
 	if err != nil {
 		t.Fatalf("Factory: %v", err)
 	}
@@ -114,7 +243,7 @@ func TestProxyFactoryValidation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := proxy.Factory(context.Background(), "bad-proxy", config.BindingDef{
+	_, err := Factory(context.Background(), "bad-proxy", config.BindingDef{
 		Type:   "proxy",
 		Config: *node.Content[0],
 	}, bootstrap.BindingDeps{})
@@ -123,22 +252,9 @@ func TestProxyFactoryValidation(t *testing.T) {
 	}
 }
 
-func makeBinding(t *testing.T, path string) *proxy.Binding {
+func testBinding(t *testing.T, path string, client *http.Client) *Binding {
 	t.Helper()
-
-	cfgYAML := "path: " + path
-	var node yaml.Node
-	if err := yaml.Unmarshal([]byte(cfgYAML), &node); err != nil {
-		t.Fatal(err)
-	}
-
-	binding, err := proxy.Factory(context.Background(), "proxy-surface", config.BindingDef{
-		Type:   "proxy",
-		Config: *node.Content[0],
-	}, bootstrap.BindingDeps{})
-	if err != nil {
-		t.Fatalf("Factory: %v", err)
-	}
-
-	return binding.(*proxy.Binding)
+	return New("test-proxy", proxyConfig{Path: path}, egress.Resolver{
+		Subjects: egress.ContextSubjectResolver{},
+	}, client)
 }


### PR DESCRIPTION
The proxy binding previously returned a 501 stub instead of dispatching
to the upstream. Responses that did flow through the egress path lost
all headers because `OperationResult` only carried status and body.
JSON responses were served as text/plain and redirect Location headers
were dropped entirely.

The proxy now dispatches to the resolved upstream, forwards all response
headers (stripping hop-by-hop headers per RFC 7230), and relays the
status code and body. Upstream error responses (4xx/5xx) are passed
through to the caller rather than converted into 502 errors. Scheme
resolution honors `X-Forwarded-Proto` so the proxy works behind load
balancers.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>