### PR TITLE
Document executable plugins, upstream-level auth, and auth API changes

### DIFF
--- a/docs/pages/concepts/authentication-and-tokens.mdx
+++ b/docs/pages/concepts/authentication-and-tokens.mdx
@@ -27,8 +27,8 @@ After first login, the user record is created in the datastore. The session toke
 
 The authentication path on every request:
 
-1. Check for a `Bearer` token in the `Authorization` header. If present, hash it and look it up in the datastore.
-2. If no bearer token, check for a valid session cookie.
+1. Check for a valid `session_token` cookie. If present, validate the session.
+2. If no valid cookie, check for a `Bearer` token in the `Authorization` header. If present, hash it and look it up in the datastore.
 3. If neither is found, reject the request.
 
 <Callout>
@@ -66,6 +66,6 @@ When `dev_mode: true` is set in the server config:
 
 - HTTPS is not required for OAuth callbacks.
 - The `X-Dev-User-Email` header impersonates a user without the full login flow.
-- The `/dev-login` endpoint creates a session without an external identity provider.
+- The `/api/dev-login` endpoint creates a session without an external identity provider.
 
 Never enable dev mode in production.

--- a/docs/pages/concepts/configuration.mdx
+++ b/docs/pages/concepts/configuration.mdx
@@ -16,9 +16,10 @@ The first match wins. Gestalt does not merge multiple config files.
 1. Raw YAML is parsed into the config struct.
 2. Environment variable references (`${VAR}`) are expanded from the process environment.
 3. Defaults are applied for any fields not explicitly set.
-4. `auth_profiles` entries are merged into integration configs that reference them by name.
-5. `base_url` from the server block is injected into OAuth callback URL construction.
-6. `secret://` references are resolved through the configured secret manager. This happens last so that secrets can contain values that would otherwise look like env vars.
+4. Executable plugin paths are resolved: absolute paths are left unchanged, relative paths starting with `.` or containing a path separator resolve from the config file's directory, and bare names are looked up on `PATH`.
+5. `auth_profiles` entries are merged into integration configs that reference them by name. Upstream-level `auth_profile` references are resolved next, then empty upstream auth fields are filled from integration-level defaults.
+6. `base_url` from the server block is injected into OAuth callback URL construction.
+7. `secret://` references are resolved through the configured secret manager. This happens last so that secrets can contain values that would otherwise look like env vars.
 
 ## Annotated example
 
@@ -77,7 +78,9 @@ server:
 
 **base_url for OAuth**: The server's `base_url` is used to construct OAuth redirect URIs. If it is wrong or missing, OAuth flows will fail with a redirect mismatch.
 
-**relative paths**: `icon_file` resolves relative to the config file's directory, not the current shell working directory.
+**upstream auth cascade**: Each upstream can override auth settings individually. When an upstream references an `auth_profile`, the profile fields are merged first. Then any remaining empty auth fields inherit from the integration level. Fields already set on the upstream are never overwritten.
+
+**relative paths**: `icon_file` and executable plugin `command` paths resolve relative to the config file's directory, not the current shell working directory.
 
 **provider preparation**: `gestaltd prepare --config ...` writes `gestalt.lock.json` plus `.gestalt/providers/*.json` next to the source config. `gestaltd serve --config ...` uses that prepared state so runtime startup is deterministic without rewriting the config.
 

--- a/docs/pages/concepts/integrations.mdx
+++ b/docs/pages/concepts/integrations.mdx
@@ -4,7 +4,7 @@ Integrations are the unit of API exposure in Gestalt. Each integration declares 
 
 ## Upstreams
 
-Every integration has an `upstreams` list. Each entry specifies a `type` and a source:
+Most integrations declare an `upstreams` list. Each entry specifies a `type` and a source. Alternatively, an integration can use a [`plugin`](/reference/config-file#executable-plugins) block to delegate to an executable plugin.
 
 | Upstream type | What it does |
 |---|---|
@@ -89,6 +89,40 @@ integrations:
 ```
 
 The `mcp: true` flag on the REST upstream means its HTTP operations are also exposed as MCP tools alongside the tools from the MCP upstream.
+
+## Per-upstream auth
+
+Individual upstreams can override the integration-level auth settings. The available fields are `auth_profile`, `auth`, `client_id`, `client_secret`, and `redirect_url`.
+
+Resolution order:
+
+1. If the upstream sets `auth_profile`, the named profile is resolved first.
+2. Any remaining empty auth fields are filled from the integration-level values. Fields already set on the upstream are never overwritten.
+
+This allows a single integration to connect upstreams that require different credentials or OAuth flows:
+
+```yaml
+integrations:
+  multi-service:
+    client_id: ${DEFAULT_CLIENT_ID}
+    client_secret: ${DEFAULT_CLIENT_SECRET}
+    auth:
+      type: oauth2
+      authorization_url: https://auth.example.com/authorize
+      token_url: https://auth.example.com/token
+    upstreams:
+      - type: rest
+        url: https://api.example.com/openapi.json
+        # inherits integration-level auth
+      - type: mcp
+        url: https://mcp.example.com/sse
+        auth:
+          type: mcp_oauth
+        client_id: ${MCP_CLIENT_ID}
+        client_secret: ${MCP_CLIENT_SECRET}
+```
+
+When `auth.type` is `mcp_oauth`, Gestalt performs OAuth discovery against an MCP server following RFC 9728. For a non-MCP upstream with `mcp_oauth`, the discovery URL is auto-populated from the sibling `type: mcp` upstream in the same integration. If no static `client_id` is configured, Gestalt attempts Dynamic Client Registration when the server advertises a registration endpoint.
 
 ## allowed_operations
 
@@ -196,6 +230,21 @@ Hooks are registered by name in Go code and referenced by that name in config.
 | `datadog_keys` | Datadog | Parses API and application keys from stored credentials, injects as `DD-API-KEY` and `DD-APPLICATION-KEY` headers. |
 | `hex_response` | Hex | Validates Hex-specific response format. |
 
+## Executable plugin integrations
+
+An integration can set `plugin` instead of `upstreams` to delegate provider behavior to an external executable. The executable communicates with Gestalt over gRPC on a Unix socket and implements the provider plugin contract. This is useful when the upstream API cannot be described by an OpenAPI spec, GraphQL endpoint, or MCP server.
+
+```yaml
+integrations:
+  custom-service:
+    plugin:
+      command: ./my-provider-plugin
+      args: [--config, production]
+    display_name: Custom Service
+```
+
+See the [config file reference](/reference/config-file#executable-plugins) for the full field list and path resolution rules.
+
 ## Restrictions
 
-Gestalt keeps the integration model simple. There is no plugin discovery protocol, no remote registry, and no dynamic loading at runtime. Integrations are declared in config and resolved at startup. Adding or changing integrations requires a restart.
+Gestalt keeps the integration model simple. There is no plugin discovery protocol and no remote registry. Executable plugins are loaded at startup and communicate over gRPC. Adding or changing integrations requires a restart.

--- a/docs/pages/concepts/platform-model.mdx
+++ b/docs/pages/concepts/platform-model.mdx
@@ -44,9 +44,12 @@ Operations are identified by name. For REST upstreams, the name comes from the O
 
 ### Plugins
 
-A **plugin** is a Go package that implements one of Gestalt's core interfaces. Plugins are how you swap components in and out of the system without changing application code.
+A **plugin** is a component that implements one of Gestalt's core interfaces. Plugins come in two forms:
 
-Gestalt ships with plugins across seven categories:
+- **Compiled plugins** are Go packages linked into the Gestalt binary at build time. You select them by name in the config file.
+- **Executable plugins** are standalone binaries that communicate with Gestalt over gRPC using Unix sockets. You declare them with a `plugin` block in the config instead of a type name. Executable plugins can be written in any language that supports gRPC. The Provider and Runtime categories support both forms.
+
+Gestalt ships with compiled plugins across seven categories:
 
 | Category | What it provides |
 |---|---|

--- a/docs/pages/contributing.mdx
+++ b/docs/pages/contributing.mdx
@@ -20,6 +20,17 @@
 3. Register the factory in `cmd/gestaltd/factories.go` so the runtime resolves it by name from config.
 4. Add tests that exercise the plugin through the same interface the runtime uses.
 
+### Executable plugins
+
+Provider and runtime plugins can also be implemented as standalone executables that communicate over gRPC:
+
+1. Create a binary under `cmd/` (e.g., `cmd/gestalt-plugin-myname/main.go`).
+2. For a provider: implement `core.Provider` and call `pluginapi.ServeProvider(ctx, provider)`.
+3. For a runtime: implement `pluginapiv1.RuntimePluginServer` and call `pluginapi.ServeRuntime(ctx, server)`. Use `pluginapi.DialRuntimeHost(ctx)` to call back into Gestalt for invocation and capability listing.
+4. Reference the binary from config with a `plugin` block instead of a `type` or `upstreams` entry.
+
+See `cmd/gestalt-plugin-echo` for a working example.
+
 ## Add integration-specific behavior
 
 Integration hooks live under `plugins/integrations`. Each package exports named hook functions registered in the factory file. To add behavior for a new upstream API:

--- a/docs/pages/reference/built-in-plugins.mdx
+++ b/docs/pages/reference/built-in-plugins.mdx
@@ -59,6 +59,19 @@ All SQL-based datastores (postgres, mysql, oracle, sqlserver) share a common imp
 |---|---|
 | `echo` | Dev-only provider that echoes input parameters as JSON. Single `echo` operation. Enabled only when `dev_mode: true`. |
 
+## Executable plugins
+
+The Provider and Runtime categories also support **executable plugins** — standalone binaries that communicate with Gestalt over gRPC on Unix sockets. Use executable plugins when provider or runtime logic cannot be expressed as config-only integrations and you want to write it in any language, not just Go.
+
+The host manages the plugin lifecycle: spawning the process, waiting for socket readiness, and graceful shutdown (SIGTERM with a 2-second grace period before SIGKILL). Two environment variables are injected:
+
+| Variable | Set for | Purpose |
+|---|---|---|
+| `GESTALT_PLUGIN_SOCKET` | Providers and runtimes | Unix socket path the plugin must bind to serve its gRPC interface. |
+| `GESTALT_RUNTIME_HOST_SOCKET` | Runtimes only | Unix socket path the runtime dials to invoke operations and list capabilities on the host. |
+
+The gRPC contract is defined in `sdk/pluginapi/v1`. For Go plugins, helper functions `pluginapi.ServeProvider` and `pluginapi.ServeRuntime` handle the gRPC server setup. See `cmd/gestalt-plugin-echo` for a working example that implements both a provider and a runtime plugin.
+
 ## What is not pluginized
 
 The HTTP route structure, middleware chain, and operation dispatch loop are fixed in the binary. There is no plugin point for injecting custom routes or middleware. Custom behavior at that layer means contributing to the core runtime.

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -90,7 +90,8 @@ Each integration is defined under `integrations.<name>` and contains one or more
 
 | Field | Notes |
 |---|---|
-| `upstreams` | List of upstream definitions (see below). At least one is required. |
+| `upstreams` | List of upstream definitions (see below). Required unless `plugin` is set. |
+| `plugin` | Executable plugin definition (see [Executable plugins](#executable-plugins) below). Mutually exclusive with `upstreams`. |
 | `display_name` | Human-readable label for the integration. |
 | `description` | Short description shown in the web UI and CLI. |
 | `auth_profile` | Name of a reusable auth profile to inherit from. |
@@ -122,6 +123,13 @@ Each upstream declares a type and source:
 | `url` | For `rest`: OpenAPI spec URL. For `graphql`: the GraphQL endpoint (introspected at startup). For `mcp`: the upstream MCP server URL. |
 | `mcp` | (`rest` and `graphql` only) Boolean. When `true`, this upstream's operations are exposed as MCP tools. `type: mcp` upstreams are always exposed — no flag needed. |
 | `allowed_operations` | Positive allow-list. Can be a YAML list (names only) or a map (names to description overrides). Omit to allow all operations. An empty value is invalid. |
+| `auth_profile` | Name of an auth profile to apply to this upstream. Resolved before integration-level cascade. |
+| `auth` | Auth overrides specific to this upstream. Same structure as [integration-level auth](#auth-overrides). |
+| `client_id` | OAuth client ID for this upstream. |
+| `client_secret` | OAuth client secret for this upstream. |
+| `redirect_url` | OAuth redirect URL for this upstream. |
+
+When an upstream sets `auth_profile`, the profile is resolved first. Then any empty auth fields on the upstream are filled from the integration-level values. Each field is checked individually — only unset values inherit.
 
 REST, GraphQL, and MCP upstreams all require `url` in the source config. Deterministic startup comes from running `gestaltd prepare`, which writes `gestalt.lock.json` plus `.gestalt/providers/*.json` next to the source config. `gestaltd serve` then uses those prepared artifacts without changing the source config.
 
@@ -151,7 +159,7 @@ integrations:
 
 ```yaml
 auth:
-  type: oauth2              # or "manual"
+  type: oauth2              # or "manual" or "mcp_oauth"
   authorization_url: https://provider.com/authorize
   token_url: https://provider.com/token
   client_auth: body          # or "header"
@@ -169,6 +177,8 @@ auth:
     - team_name
   response_hook: slack_ok
 ```
+
+When `type` is `mcp_oauth`, Gestalt performs OAuth discovery against an MCP server following RFC 9728. The `authorization_url` and `token_url` fields are optional — if omitted, they are discovered automatically. For a non-MCP upstream (e.g., REST) with `mcp_oauth`, Gestalt locates the sibling `type: mcp` upstream in the same integration and uses its URL for discovery. If no static `client_id` is provided, Gestalt attempts Dynamic Client Registration (DCR) when the server advertises a registration endpoint.
 
 ## Auth profiles
 
@@ -188,6 +198,29 @@ auth_profiles:
 
 Fields set directly on the integration override the profile.
 
+### Executable plugins
+
+An integration can set `plugin` instead of `upstreams` to delegate provider behavior to an external executable that communicates over gRPC. Validation rejects setting both `plugin` and `upstreams` on the same integration.
+
+| Field | Notes |
+|---|---|
+| `command` | Path to the executable. Required. Absolute paths are used as-is. Relative paths starting with `.` or containing a path separator resolve from the config file's directory. Bare names are looked up on `PATH`. |
+| `args` | List of command-line arguments passed to the executable. |
+| `env` | Map of additional environment variables merged into the process environment. |
+
+The host automatically sets `GESTALT_PLUGIN_SOCKET` to the Unix socket path the plugin must bind for gRPC communication.
+
+```yaml
+integrations:
+  custom-provider:
+    plugin:
+      command: ./gestalt-plugin-echo
+      args: [provider]
+      env:
+        LOG_LEVEL: debug
+    display_name: Custom Provider
+```
+
 ## Runtimes block
 
 Background processes that boot alongside the server with scoped provider access.
@@ -201,6 +234,20 @@ runtimes:
       - linear
     config: {}             # type-specific configuration
 ```
+
+A runtime can use `plugin` instead of `type` to delegate to an external executable. Validation rejects setting both.
+
+```yaml
+runtimes:
+  custom-runtime:
+    plugin:
+      command: ./gestalt-plugin-echo
+      args: [runtime]
+    providers:
+      - slack
+```
+
+The `plugin` block accepts the same fields as [integration executable plugins](#executable-plugins). Runtime plugins receive both `GESTALT_PLUGIN_SOCKET` and `GESTALT_RUNTIME_HOST_SOCKET` — the latter is a Unix socket the plugin can dial to invoke operations and list capabilities on the host.
 
 The `providers` list scopes which integrations the runtime can invoke. The runtime receives a scoped invoker and capability lister.
 

--- a/docs/pages/reference/http-api.mdx
+++ b/docs/pages/reference/http-api.mdx
@@ -7,18 +7,18 @@
 | GET | `/health` | Health check. Returns `{"status":"ok"}`. |
 | GET | `/ready` | Readiness check. Returns `{"status":"ok"}` when providers are initialized and the datastore is reachable. Otherwise returns a 503 with a reason such as `{"status":"providers loading"}` or `{"status":"datastore unavailable"}`. |
 | POST | `/api/v1/auth/login` | Start platform login. Accepts `{"state": "...", "callback_port": 12345}`. Returns `{"url": "..."}` with the provider's login URL. |
-| GET | `/api/v1/auth/login/callback` | Complete platform login. Exchanges the authorization code for a session token. Returns `{"email": "...", "display_name": "...", "token": "..."}`. |
+| GET | `/api/v1/auth/login/callback` | Complete platform login. Exchanges the authorization code and sets an httpOnly `session_token` cookie. Returns `{"email": "...", "display_name": "..."}`. |
 | GET | `/api/v1/auth/info` | Returns `{"provider": "...", "display_name": "...", "dev_mode": true/false}`. |
 
 In dev mode, an additional endpoint is available:
 
 | Method | Path | Purpose |
 |---|---|---|
-| POST | `/api/dev-login` | Dev-only login. Accepts `{"email": "..."}` and returns a session token without OAuth. |
+| POST | `/api/dev-login` | Dev-only login. Accepts `{"email": "..."}` and returns `{"email": "..."}`. Sets an httpOnly `session_token` cookie. |
 
 ## Authenticated endpoints
 
-All authenticated endpoints require an `Authorization: Bearer <token>` header. The token can be a session token from login or an API token.
+All authenticated endpoints require either a valid `session_token` cookie or an `Authorization: Bearer <token>` header. The cookie is checked first, with the header as fallback.
 
 ### Integrations
 
@@ -36,6 +36,7 @@ All authenticated endpoints require an `Authorization: Bearer <token>` header. T
 | POST | `/api/v1/auth/start-oauth` | Start an integration OAuth flow. Accepts `{"integration": "...", "scopes": [...]}`. Returns `{"url": "...", "state": "..."}`. |
 | GET | `/api/v1/auth/callback` | Complete integration OAuth. Exchanges code for tokens and stores them. Redirects to the web UI on success. |
 | POST | `/api/v1/auth/connect-manual` | Submit manual credentials. Accepts `{"integration": "...", "credential": "..."}`. Returns `{"status":"connected"}`. |
+| POST | `/api/v1/auth/logout` | Clear session. Removes the `session_token` cookie. Returns `{"status":"ok"}`. |
 
 ### API tokens
 
@@ -69,6 +70,12 @@ Bindings register dynamic routes at `/api/v1/bindings/{name}/*` based on their c
 - Integrations backed only by a `type: mcp` upstream cannot be invoked over HTTP. Attempting to do so returns `400: this integration is accessible only via MCP`.
 
 ## Authentication
+
+Gestalt accepts two authentication methods. The session cookie is checked first.
+
+**Session cookie**: The login and dev-login endpoints set an httpOnly `session_token` cookie. Browser clients send it automatically. Cookie attributes: `HttpOnly`, `Secure` (production only), `SameSite: Lax`, `Path: /`, `MaxAge: 24h` (configurable via `session_ttl`).
+
+**Bearer token**: Pass an API token or session token in the `Authorization` header:
 
 ```
 Authorization: Bearer <session-token-or-api-token>

--- a/docs/pages/tasks/add-an-integration.mdx
+++ b/docs/pages/tasks/add-an-integration.mdx
@@ -10,6 +10,7 @@ Adding an **integration** means defining one or more upstreams, optionally confi
 | GraphQL endpoint | `type: graphql` with `url` | GraphQL API. Operations generated from introspection. |
 | MCP server | `type: mcp` with `url` | Upstream already speaks MCP. Tools imported directly. |
 | Manual auth | Any upstream type with `auth.type: manual` | API-key service with no OAuth flow. Users paste credentials directly. |
+| Executable plugin | `plugin` block with `command` | Custom provider logic in any gRPC-capable language. No spec or MCP server needed. |
 
 ## 2. REST integration from OpenAPI
 


### PR DESCRIPTION
Update documentation across nine pages to cover three features that merged after the last docs refresh. Executable plugins (PR #96) allow integrations and runtimes to delegate to standalone executables over gRPC instead of requiring compiled Go code or upstream specs. Upstream- level auth (PRs #81, #83) lets individual upstreams override integration auth settings with per-upstream credentials, profiles, and the new mcp_oauth discovery type. Auth API changes (PR #82) replace the token- in-body login response with httpOnly session cookies and add a logout endpoint.

Also fixes the auth middleware check order in the authentication concepts page (cookie is checked before Bearer header, not after) and corrects the /dev-login endpoint path.