### PR TITLE
Add post-connect resource discovery with staged connections

### DIFF
--- a/core/datastore.go
+++ b/core/datastore.go
@@ -18,6 +18,10 @@ type Datastore interface {
 	ListAPITokens(ctx context.Context, userID string) ([]*APIToken, error)
 	RevokeAPIToken(ctx context.Context, userID, id string) error
 
+	StoreStagedConnection(ctx context.Context, sc *StagedConnection) error
+	GetStagedConnection(ctx context.Context, id string) (*StagedConnection, error)
+	DeleteStagedConnection(ctx context.Context, id string) error
+
 	Ping(ctx context.Context) error
 	Migrate(ctx context.Context) error
 	Close() error

--- a/core/integration/base.go
+++ b/core/integration/base.go
@@ -19,6 +19,7 @@ var (
 	_ core.CatalogProvider         = (*Base)(nil)
 	_ core.ConnectionParamProvider = (*Base)(nil)
 	_ core.PostConnectProvider     = (*Base)(nil)
+	_ core.DiscoveryConfigProvider = (*Base)(nil)
 )
 
 type manualChecker interface{ IsManual() bool }
@@ -115,6 +116,7 @@ type Base struct {
 
 	ConnectionDefs    map[string]core.ConnectionParamDef
 	PostConnectHookFn core.PostConnectHook
+	DiscoveryDef      *core.DiscoveryConfig
 	ManualAuthEnabled bool
 
 	catalog *catalog.Catalog
@@ -157,6 +159,10 @@ func (b *Base) ConnectionParamDefs() map[string]core.ConnectionParamDef {
 
 func (b *Base) PostConnectHook() core.PostConnectHook {
 	return b.PostConnectHookFn
+}
+
+func (b *Base) DiscoveryConfig() *core.DiscoveryConfig {
+	return b.DiscoveryDef
 }
 
 func (b *Base) TokenURL() string {

--- a/core/provider.go
+++ b/core/provider.go
@@ -54,7 +54,7 @@ type ConnectionParamDef struct {
 	Required    bool
 	Description string
 	Default     string
-	From        string // "" = user-provided, "token_response" = extracted from OAuth response
+	From        string // "" = user-provided, "token_response" = from OAuth response, "discovery" = from post-connect discovery
 	Field       string // JSON field name for token_response extraction
 }
 
@@ -70,4 +70,22 @@ type PostConnectProvider interface {
 
 type AuthTypeLister interface {
 	AuthTypes() []string
+}
+
+type DiscoveryCandidate struct {
+	ID       string            `json:"id"`
+	Name     string            `json:"name"`
+	Metadata map[string]string `json:"metadata"`
+}
+
+type DiscoveryConfig struct {
+	URL             string
+	ItemsPath       string
+	IDPath          string
+	NamePath        string
+	MetadataMapping map[string]string
+}
+
+type DiscoveryConfigProvider interface {
+	DiscoveryConfig() *DiscoveryConfig
 }

--- a/core/testing/datastore_suite.go
+++ b/core/testing/datastore_suite.go
@@ -24,6 +24,9 @@ func RunDatastoreTests(t *testing.T, newStore func(t *testing.T) core.Datastore)
 	t.Run("APITokens", func(t *testing.T) {
 		testDatastoreAPITokens(t, newStore)
 	})
+	t.Run("StagedConnections", func(t *testing.T) {
+		testDatastoreStagedConnections(t, newStore)
+	})
 }
 
 func mustCreateUser(t *testing.T, ctx context.Context, ds core.Datastore, email string) *core.User {
@@ -394,6 +397,79 @@ func testDatastoreAPITokens(t *testing.T, newStore func(t *testing.T) core.Datas
 		}
 		if got != nil {
 			t.Errorf("ValidateAPIToken for expired: expected nil, got %+v", got)
+		}
+	})
+}
+
+func testDatastoreStagedConnections(t *testing.T, newStore func(t *testing.T) core.Datastore) {
+	t.Run("store get delete lifecycle", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+		ctx := context.Background()
+
+		user := mustCreateUser(t, ctx, ds, "staged@example.com")
+		now := time.Now().UTC().Truncate(time.Second)
+		expiry := now.Add(10 * time.Minute)
+
+		sc := &core.StagedConnection{
+			ID:             "sc-1",
+			UserID:         user.ID,
+			Integration:    "test-provider",
+			Instance:       "default",
+			AccessToken:    "staged-access-token",
+			RefreshToken:   "staged-refresh-token",
+			TokenExpiresAt: &expiry,
+			MetadataJSON:   `{"env":"prod"}`,
+			CandidatesJSON: `[{"id":"c1","name":"Site A"},{"id":"c2","name":"Site B"}]`,
+			CreatedAt:      now,
+			ExpiresAt:      expiry,
+		}
+
+		if err := ds.StoreStagedConnection(ctx, sc); err != nil {
+			t.Fatalf("StoreStagedConnection: %v", err)
+		}
+
+		got, err := ds.GetStagedConnection(ctx, "sc-1")
+		if err != nil {
+			t.Fatalf("GetStagedConnection: %v", err)
+		}
+		if got == nil {
+			t.Fatal("GetStagedConnection returned nil")
+		}
+		if got.AccessToken != "staged-access-token" {
+			t.Errorf("AccessToken: got %q, want %q", got.AccessToken, "staged-access-token")
+		}
+		if got.RefreshToken != "staged-refresh-token" {
+			t.Errorf("RefreshToken: got %q, want %q", got.RefreshToken, "staged-refresh-token")
+		}
+		if got.Integration != "test-provider" {
+			t.Errorf("Integration: got %q, want %q", got.Integration, "test-provider")
+		}
+		if got.TokenExpiresAt == nil || !got.TokenExpiresAt.Truncate(time.Second).Equal(expiry.Truncate(time.Second)) {
+			t.Errorf("TokenExpiresAt: got %v, want %v", got.TokenExpiresAt, expiry)
+		}
+		if got.CandidatesJSON != sc.CandidatesJSON {
+			t.Errorf("CandidatesJSON: got %q, want %q", got.CandidatesJSON, sc.CandidatesJSON)
+		}
+
+		if err := ds.DeleteStagedConnection(ctx, "sc-1"); err != nil {
+			t.Fatalf("DeleteStagedConnection: %v", err)
+		}
+
+		_, err = ds.GetStagedConnection(ctx, "sc-1")
+		if !errors.Is(err, core.ErrNotFound) {
+			t.Fatalf("GetStagedConnection after delete: expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("get nonexistent returns ErrNotFound", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+		ctx := context.Background()
+
+		_, err := ds.GetStagedConnection(ctx, "nonexistent-id")
+		if !errors.Is(err, core.ErrNotFound) {
+			t.Fatalf("expected ErrNotFound, got %v", err)
 		}
 	})
 }

--- a/core/testing/stubs.go
+++ b/core/testing/stubs.go
@@ -30,6 +30,9 @@ type StubDatastore struct {
 	DeleteTokenFn              func(context.Context, string) error
 	ValidateAPITokenFn         func(context.Context, string) (*core.APIToken, error)
 	RevokeAPITokenFn           func(context.Context, string, string) error
+	StoreStagedConnectionFn    func(context.Context, *core.StagedConnection) error
+	GetStagedConnectionFn      func(context.Context, string) (*core.StagedConnection, error)
+	DeleteStagedConnectionFn   func(context.Context, string) error
 }
 
 func (s *StubDatastore) Ping(ctx context.Context) error {
@@ -108,6 +111,24 @@ func (s *StubDatastore) ListAPITokens(context.Context, string) ([]*core.APIToken
 func (s *StubDatastore) RevokeAPIToken(ctx context.Context, userID, id string) error {
 	if s.RevokeAPITokenFn != nil {
 		return s.RevokeAPITokenFn(ctx, userID, id)
+	}
+	return nil
+}
+func (s *StubDatastore) StoreStagedConnection(ctx context.Context, sc *core.StagedConnection) error {
+	if s.StoreStagedConnectionFn != nil {
+		return s.StoreStagedConnectionFn(ctx, sc)
+	}
+	return nil
+}
+func (s *StubDatastore) GetStagedConnection(ctx context.Context, id string) (*core.StagedConnection, error) {
+	if s.GetStagedConnectionFn != nil {
+		return s.GetStagedConnectionFn(ctx, id)
+	}
+	return nil, core.ErrNotFound
+}
+func (s *StubDatastore) DeleteStagedConnection(ctx context.Context, id string) error {
+	if s.DeleteStagedConnectionFn != nil {
+		return s.DeleteStagedConnectionFn(ctx, id)
 	}
 	return nil
 }

--- a/core/types.go
+++ b/core/types.go
@@ -66,6 +66,20 @@ type Parameter struct {
 	Default     any
 }
 
+type StagedConnection struct {
+	ID             string
+	UserID         string
+	Integration    string
+	Instance       string
+	AccessToken    string
+	RefreshToken   string
+	TokenExpiresAt *time.Time
+	MetadataJSON   string
+	CandidatesJSON string
+	CreatedAt      time.Time
+	ExpiresAt      time.Time
+}
+
 type OperationResult struct {
 	Status int
 	Body   string

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -1,0 +1,109 @@
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/core"
+)
+
+const maxDiscoveryResponseSize = 5 * 1024 * 1024 // 5 MB
+
+func Run(ctx context.Context, cfg *core.DiscoveryConfig, client *http.Client) ([]core.DiscoveryCandidate, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.URL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating discovery request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing discovery request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("discovery request failed: HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxDiscoveryResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("reading discovery response: %w", err)
+	}
+
+	var raw any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("parsing discovery response: %w", err)
+	}
+
+	items, err := extractItems(raw, cfg.ItemsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	candidates := make([]core.DiscoveryCandidate, 0, len(items))
+	for _, item := range items {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		c := core.DiscoveryCandidate{
+			Metadata: make(map[string]string),
+		}
+		if cfg.IDPath != "" {
+			if v, ok := extractPath(obj, cfg.IDPath); ok {
+				c.ID = fmt.Sprintf("%v", v)
+			}
+		}
+		if cfg.NamePath != "" {
+			if v, ok := extractPath(obj, cfg.NamePath); ok {
+				c.Name = fmt.Sprintf("%v", v)
+			}
+		}
+		for metaKey, jsonPath := range cfg.MetadataMapping {
+			if v, ok := extractPath(obj, jsonPath); ok {
+				c.Metadata[metaKey] = fmt.Sprintf("%v", v)
+			}
+		}
+		candidates = append(candidates, c)
+	}
+
+	return candidates, nil
+}
+
+func extractPath(data any, path string) (any, bool) {
+	current := data
+	for _, part := range strings.Split(path, ".") {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = m[part]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+func extractItems(data any, itemsPath string) ([]any, error) {
+	target := data
+	if itemsPath != "" {
+		v, ok := extractPath(data, itemsPath)
+		if !ok {
+			return nil, fmt.Errorf("discovery: path %q not found", itemsPath)
+		}
+		target = v
+	}
+	arr, ok := target.([]any)
+	if !ok {
+		if itemsPath == "" {
+			return nil, fmt.Errorf("discovery response is not an array")
+		}
+		return nil, fmt.Errorf("discovery: path %q is not an array", itemsPath)
+	}
+	return arr, nil
+}

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -1,0 +1,153 @@
+package discovery
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+)
+
+func TestRun_TopLevelArray(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"site_id": "s1", "site_name": "Alpha", "region": "us-east"},
+			{"site_id": "s2", "site_name": "Beta", "region": "eu-west"},
+			{"site_id": "s3", "site_name": "Gamma", "region": "ap-south"}
+		]`))
+	}))
+	defer srv.Close()
+
+	cfg := &core.DiscoveryConfig{
+		URL:      srv.URL,
+		IDPath:   "site_id",
+		NamePath: "site_name",
+		MetadataMapping: map[string]string{
+			"region": "region",
+		},
+	}
+
+	candidates, err := Run(context.Background(), cfg, srv.Client())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(candidates) != 3 {
+		t.Fatalf("got %d candidates, want 3", len(candidates))
+	}
+
+	if candidates[0].ID != "s1" {
+		t.Errorf("candidates[0].ID = %q, want %q", candidates[0].ID, "s1")
+	}
+	if candidates[0].Name != "Alpha" {
+		t.Errorf("candidates[0].Name = %q, want %q", candidates[0].Name, "Alpha")
+	}
+	if candidates[0].Metadata["region"] != "us-east" {
+		t.Errorf("candidates[0].Metadata[region] = %q, want %q", candidates[0].Metadata["region"], "us-east")
+	}
+
+	if candidates[2].ID != "s3" {
+		t.Errorf("candidates[2].ID = %q, want %q", candidates[2].ID, "s3")
+	}
+	if candidates[2].Name != "Gamma" {
+		t.Errorf("candidates[2].Name = %q, want %q", candidates[2].Name, "Gamma")
+	}
+}
+
+func TestRun_NestedItemsPath(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"resources": [
+					{"rid": "r1", "label": "Prod"},
+					{"rid": "r2", "label": "Staging"}
+				]
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	cfg := &core.DiscoveryConfig{
+		URL:       srv.URL,
+		ItemsPath: "data.resources",
+		IDPath:    "rid",
+		NamePath:  "label",
+	}
+
+	candidates, err := Run(context.Background(), cfg, srv.Client())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("got %d candidates, want 2", len(candidates))
+	}
+	if candidates[0].ID != "r1" {
+		t.Errorf("candidates[0].ID = %q, want %q", candidates[0].ID, "r1")
+	}
+	if candidates[1].Name != "Staging" {
+		t.Errorf("candidates[1].Name = %q, want %q", candidates[1].Name, "Staging")
+	}
+}
+
+func TestRun_EmptyArray(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	cfg := &core.DiscoveryConfig{
+		URL:    srv.URL,
+		IDPath: "id",
+	}
+
+	candidates, err := Run(context.Background(), cfg, srv.Client())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("got %d candidates, want 0", len(candidates))
+	}
+}
+
+func TestRun_HTTP401(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error": "invalid token"}`))
+	}))
+	defer srv.Close()
+
+	cfg := &core.DiscoveryConfig{
+		URL:    srv.URL,
+		IDPath: "id",
+	}
+
+	_, err := Run(context.Background(), cfg, srv.Client())
+	if err == nil {
+		t.Fatal("expected error for HTTP 401")
+	}
+}
+
+func TestRun_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer srv.Close()
+
+	cfg := &core.DiscoveryConfig{
+		URL:    srv.URL,
+		IDPath: "id",
+	}
+
+	_, err := Run(context.Background(), cfg, srv.Client())
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -185,12 +185,20 @@ func Build(def *Definition, intg config.IntegrationDef, allowedOperations map[st
 		base.RequestMutator = mutator
 	}
 
+	if def.PostConnect != "" && def.PostConnectDiscovery != nil {
+		return nil, fmt.Errorf("%s: cannot set both post_connect and post_connect_discovery", def.Provider)
+	}
+
 	if def.PostConnect != "" {
 		hook, ok := lookupPostConnectHook(def.PostConnect)
 		if !ok {
 			return nil, fmt.Errorf("%s: unknown post_connect %q", def.Provider, def.PostConnect)
 		}
 		base.PostConnectHookFn = hook
+	}
+
+	if def.PostConnectDiscovery != nil {
+		base.DiscoveryDef = def.PostConnectDiscovery.ToCore()
 	}
 
 	base.ManualAuthEnabled = def.ManualAuth

--- a/internal/provider/definition.go
+++ b/internal/provider/definition.go
@@ -1,6 +1,10 @@
 package provider
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/valon-technologies/gestalt/core"
+)
 
 type Definition struct {
 	Provider         string            `yaml:"provider" json:"provider"`
@@ -24,6 +28,8 @@ type Definition struct {
 	PostConnect             string            `yaml:"post_connect" json:"post_connect"`
 	ManualAuth              bool              `yaml:"manual_auth" json:"manual_auth"`
 
+	PostConnectDiscovery *PostConnectDiscoveryDef `yaml:"post_connect_discovery" json:"post_connect_discovery,omitempty"`
+
 	Connection map[string]ConnectionParamDef `yaml:"connection" json:"connection"`
 	Operations map[string]OperationDef       `yaml:"operations" json:"operations"`
 }
@@ -31,6 +37,24 @@ type Definition struct {
 type ResponseCheckDef struct {
 	SuccessBodyMatch map[string]any `yaml:"success_body_match" json:"success_body_match,omitempty"`
 	ErrorMessagePath string         `yaml:"error_message_path" json:"error_message_path,omitempty"`
+}
+
+type PostConnectDiscoveryDef struct {
+	URL             string            `yaml:"url" json:"url"`
+	ItemsPath       string            `yaml:"items_path" json:"items_path"`
+	IDPath          string            `yaml:"id_path" json:"id_path"`
+	NamePath        string            `yaml:"name_path" json:"name_path"`
+	MetadataMapping map[string]string `yaml:"metadata_mapping" json:"metadata_mapping"`
+}
+
+func (d *PostConnectDiscoveryDef) ToCore() *core.DiscoveryConfig {
+	return &core.DiscoveryConfig{
+		URL:             d.URL,
+		ItemsPath:       d.ItemsPath,
+		IDPath:          d.IDPath,
+		NamePath:        d.NamePath,
+		MetadataMapping: d.MetadataMapping,
+	}
 }
 
 type ConnectionParamDef struct {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/discovery"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	"github.com/valon-technologies/gestalt/internal/oauth"
 	"github.com/valon-technologies/gestalt/internal/paraminterp"
@@ -653,40 +654,36 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	now := s.now().UTC().Truncate(time.Second)
-	var expiresAt *time.Time
-	if tokenResp.ExpiresIn > 0 {
-		t := now.Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
-		expiresAt = &t
-	}
-
 	callbackInstance := state.Instance
 	if callbackInstance == "" {
 		callbackInstance = defaultTokenInstance
 	}
 
-	tok := &core.IntegrationToken{
-		ID:           uuid.NewString(),
-		UserID:       state.UserID,
-		Integration:  providerName,
-		Instance:     callbackInstance,
-		AccessToken:  tokenResp.AccessToken,
-		RefreshToken: tokenResp.RefreshToken,
-		ExpiresAt:    expiresAt,
-		MetadataJSON: metadata,
-		CreatedAt:    now,
-		UpdatedAt:    now,
+	var tokenExpiresAt *time.Time
+	if tokenResp.ExpiresIn > 0 {
+		t := s.now().UTC().Truncate(time.Second).Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+		tokenExpiresAt = &t
 	}
 
-	if err := s.datastore.StoreToken(r.Context(), tok); err != nil {
-		log.Printf("failed to store token for %s: %v", providerName, err)
-		writeError(w, http.StatusInternalServerError, "failed to store token")
+	tm := tokenMaterial{
+		UserID:         state.UserID,
+		Integration:    providerName,
+		Instance:       callbackInstance,
+		AccessToken:    tokenResp.AccessToken,
+		RefreshToken:   tokenResp.RefreshToken,
+		TokenExpiresAt: tokenExpiresAt,
+		MetadataJSON:   metadata,
+	}
+
+	result, err := s.runPostConnect(r.Context(), prov, tm)
+	if err != nil {
+		log.Printf("post_connect failed for %s: %v", providerName, err)
+		writeError(w, http.StatusBadGateway, "connection setup failed")
 		return
 	}
 
-	if err := s.runPostConnectHook(r.Context(), prov, tok); err != nil {
-		log.Printf("post_connect hook failed for %s: %v", providerName, err)
-		writeError(w, http.StatusBadGateway, "connection setup failed")
+	if result.Status == "selection_required" {
+		http.Redirect(w, r, "/integrations?pending="+url.QueryEscape(result.StagedID), http.StatusSeeOther)
 		return
 	}
 
@@ -753,35 +750,28 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	now := s.now().UTC().Truncate(time.Second)
-	tok := &core.IntegrationToken{
-		ID:          uuid.NewString(),
-		UserID:      dbUser.ID,
-		Integration: req.Integration,
-		Instance:    manualInstance,
-		AccessToken: req.Credential,
-		CreatedAt:   now,
-		UpdatedAt:   now,
-	}
 	manualMeta, metaErr := buildConnectionMetadata(prov, connParams, nil)
 	if metaErr != nil {
 		writeError(w, http.StatusBadRequest, metaErr.Error())
 		return
 	}
-	tok.MetadataJSON = manualMeta
-	if err := s.datastore.StoreToken(r.Context(), tok); err != nil {
-		log.Printf("failed to store credential for %s: %v", req.Integration, err)
-		writeError(w, http.StatusInternalServerError, "failed to store credential")
-		return
+
+	tm := tokenMaterial{
+		UserID:       dbUser.ID,
+		Integration:  req.Integration,
+		Instance:     manualInstance,
+		AccessToken:  req.Credential,
+		MetadataJSON: manualMeta,
 	}
 
-	if err := s.runPostConnectHook(r.Context(), prov, tok); err != nil {
-		log.Printf("post_connect hook failed for %s: %v", req.Integration, err)
+	result, err := s.runPostConnect(r.Context(), prov, tm)
+	if err != nil {
+		log.Printf("post_connect failed for %s: %v", req.Integration, err)
 		writeError(w, http.StatusBadGateway, "connection setup failed")
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]string{"status": "connected"})
+	writeJSON(w, http.StatusOK, result)
 }
 
 type createTokenRequest struct {
@@ -1032,7 +1022,7 @@ func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.base.RoundTrip(req)
 }
 
-func (s *Server) runPostConnectHook(ctx context.Context, prov core.Provider, tok *core.IntegrationToken) error {
+func (s *Server) runLegacyPostConnectHook(ctx context.Context, prov core.Provider, tok *core.IntegrationToken) error {
 	pcp, ok := prov.(core.PostConnectProvider)
 	if !ok {
 		return nil
@@ -1082,4 +1072,277 @@ func (s *Server) runPostConnectHook(ctx context.Context, prov core.Provider, tok
 	}
 
 	return nil
+}
+
+const stagedConnectionTTL = 30 * time.Minute
+
+type tokenMaterial struct {
+	UserID         string
+	Integration    string
+	Instance       string
+	AccessToken    string
+	RefreshToken   string
+	TokenExpiresAt *time.Time
+	MetadataJSON   string
+}
+
+type postConnectResult struct {
+	Status     string                    `json:"status"`
+	StagedID   string                    `json:"staged_id,omitempty"`
+	Candidates []core.DiscoveryCandidate `json:"candidates,omitempty"`
+}
+
+func (s *Server) storeTokenFromMaterial(ctx context.Context, tm tokenMaterial) (*core.IntegrationToken, error) {
+	now := s.now().UTC().Truncate(time.Second)
+	tok := &core.IntegrationToken{
+		ID:           uuid.NewString(),
+		UserID:       tm.UserID,
+		Integration:  tm.Integration,
+		Instance:     tm.Instance,
+		AccessToken:  tm.AccessToken,
+		RefreshToken: tm.RefreshToken,
+		ExpiresAt:    tm.TokenExpiresAt,
+		MetadataJSON: tm.MetadataJSON,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if err := s.datastore.StoreToken(ctx, tok); err != nil {
+		return nil, err
+	}
+	return tok, nil
+}
+
+func validateDiscoveryMetadata(metadata map[string]string) error {
+	for k, v := range metadata {
+		if !safeParamValue.MatchString(k) || !safeTokenResponseValue.MatchString(v) {
+			return fmt.Errorf("discovery returned invalid key or value for %q", k)
+		}
+	}
+	return nil
+}
+
+func mergeMetadataJSON(existing string, extra map[string]string) (string, error) {
+	m := make(map[string]string)
+	if existing != "" {
+		if err := json.Unmarshal([]byte(existing), &m); err != nil {
+			return "", fmt.Errorf("corrupt MetadataJSON: %w", err)
+		}
+	}
+	for k, v := range extra {
+		m[k] = v
+	}
+	b, _ := json.Marshal(m)
+	return string(b), nil
+}
+
+func (s *Server) runPostConnect(ctx context.Context, prov core.Provider, tm tokenMaterial) (*postConnectResult, error) {
+	if dcp, ok := prov.(core.DiscoveryConfigProvider); ok {
+		if cfg := dcp.DiscoveryConfig(); cfg != nil {
+			client := &http.Client{
+				Timeout:   30 * time.Second,
+				Transport: &bearerTransport{token: tm.AccessToken, base: http.DefaultTransport},
+			}
+			candidates, err := discovery.Run(ctx, cfg, client)
+			if err != nil {
+				return nil, fmt.Errorf("discovery: %w", err)
+			}
+			if len(candidates) == 0 {
+				return nil, fmt.Errorf("no resources discovered")
+			}
+			if len(candidates) == 1 {
+				if err := validateDiscoveryMetadata(candidates[0].Metadata); err != nil {
+					return nil, err
+				}
+				merged, err := mergeMetadataJSON(tm.MetadataJSON, candidates[0].Metadata)
+				if err != nil {
+					return nil, err
+				}
+				tm.MetadataJSON = merged
+				if _, err := s.storeTokenFromMaterial(ctx, tm); err != nil {
+					return nil, err
+				}
+				return &postConnectResult{Status: "connected"}, nil
+			}
+
+			candidatesJSON, _ := json.Marshal(candidates)
+			now := s.now().UTC().Truncate(time.Second)
+			sc := &core.StagedConnection{
+				ID:             uuid.NewString(),
+				UserID:         tm.UserID,
+				Integration:    tm.Integration,
+				Instance:       tm.Instance,
+				AccessToken:    tm.AccessToken,
+				RefreshToken:   tm.RefreshToken,
+				TokenExpiresAt: tm.TokenExpiresAt,
+				MetadataJSON:   tm.MetadataJSON,
+				CandidatesJSON: string(candidatesJSON),
+				CreatedAt:      now,
+				ExpiresAt:      now.Add(stagedConnectionTTL),
+			}
+			if err := s.datastore.StoreStagedConnection(ctx, sc); err != nil {
+				return nil, fmt.Errorf("storing staged connection: %w", err)
+			}
+			return &postConnectResult{
+				Status:     "selection_required",
+				StagedID:   sc.ID,
+				Candidates: candidates,
+			}, nil
+		}
+	}
+
+	if pcp, ok := prov.(core.PostConnectProvider); ok {
+		if hookFn := pcp.PostConnectHook(); hookFn != nil {
+			tok, err := s.storeTokenFromMaterial(ctx, tm)
+			if err != nil {
+				return nil, err
+			}
+			if err := s.runLegacyPostConnectHook(ctx, prov, tok); err != nil {
+				return nil, err
+			}
+			return &postConnectResult{Status: "connected"}, nil
+		}
+	}
+
+	if _, err := s.storeTokenFromMaterial(ctx, tm); err != nil {
+		return nil, err
+	}
+	return &postConnectResult{Status: "connected"}, nil
+}
+
+func (s *Server) loadStagedConnection(w http.ResponseWriter, r *http.Request, userID string) (*core.StagedConnection, bool) {
+	id := chi.URLParam(r, "id")
+	sc, err := s.datastore.GetStagedConnection(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "staged connection not found")
+			return nil, false
+		}
+		writeError(w, http.StatusInternalServerError, "failed to get staged connection")
+		return nil, false
+	}
+	if sc.UserID != userID {
+		writeError(w, http.StatusNotFound, "staged connection not found")
+		return nil, false
+	}
+	if s.now().After(sc.ExpiresAt) {
+		_ = s.datastore.DeleteStagedConnection(r.Context(), id)
+		writeError(w, http.StatusGone, "staged connection has expired")
+		return nil, false
+	}
+	return sc, true
+}
+
+func (s *Server) getStagedConnection(w http.ResponseWriter, r *http.Request) {
+	userID, ok := s.resolveUserID(w, r)
+	if !ok {
+		return
+	}
+	sc, ok := s.loadStagedConnection(w, r, userID)
+	if !ok {
+		return
+	}
+
+	var candidates []core.DiscoveryCandidate
+	if err := json.Unmarshal([]byte(sc.CandidatesJSON), &candidates); err != nil {
+		writeError(w, http.StatusInternalServerError, "corrupt candidates data")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"id":          sc.ID,
+		"integration": sc.Integration,
+		"instance":    sc.Instance,
+		"candidates":  candidates,
+	})
+}
+
+func (s *Server) selectStagedConnection(w http.ResponseWriter, r *http.Request) {
+	userID, ok := s.resolveUserID(w, r)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		CandidateID string `json:"candidate_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.CandidateID == "" {
+		writeError(w, http.StatusBadRequest, "candidate_id is required")
+		return
+	}
+
+	sc, ok := s.loadStagedConnection(w, r, userID)
+	if !ok {
+		return
+	}
+
+	var candidates []core.DiscoveryCandidate
+	if err := json.Unmarshal([]byte(sc.CandidatesJSON), &candidates); err != nil {
+		writeError(w, http.StatusInternalServerError, "corrupt candidates data")
+		return
+	}
+
+	var selected *core.DiscoveryCandidate
+	for i := range candidates {
+		if candidates[i].ID == req.CandidateID {
+			selected = &candidates[i]
+			break
+		}
+	}
+	if selected == nil {
+		writeError(w, http.StatusBadRequest, "candidate not found")
+		return
+	}
+
+	if err := validateDiscoveryMetadata(selected.Metadata); err != nil {
+		writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	merged, err := mergeMetadataJSON(sc.MetadataJSON, selected.Metadata)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to merge metadata")
+		return
+	}
+
+	tm := tokenMaterial{
+		UserID:         sc.UserID,
+		Integration:    sc.Integration,
+		Instance:       sc.Instance,
+		AccessToken:    sc.AccessToken,
+		RefreshToken:   sc.RefreshToken,
+		TokenExpiresAt: sc.TokenExpiresAt,
+		MetadataJSON:   merged,
+	}
+	if _, err := s.storeTokenFromMaterial(r.Context(), tm); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to store connection")
+		return
+	}
+
+	if err := s.datastore.DeleteStagedConnection(r.Context(), sc.ID); err != nil {
+		log.Printf("failed to delete staged connection %s: %v", sc.ID, err)
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "connected"})
+}
+
+func (s *Server) cancelStagedConnection(w http.ResponseWriter, r *http.Request) {
+	userID, ok := s.resolveUserID(w, r)
+	if !ok {
+		return
+	}
+
+	sc, ok := s.loadStagedConnection(w, r, userID)
+	if !ok {
+		return
+	}
+
+	if err := s.datastore.DeleteStagedConnection(r.Context(), sc.ID); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to cancel staged connection")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "canceled"})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -144,6 +144,10 @@ func (s *Server) routes() {
 			r.Post("/auth/start-oauth", s.startIntegrationOAuth)
 			r.Post("/auth/connect-manual", s.connectManual)
 
+			r.Get("/connections/staged/{id}", s.getStagedConnection)
+			r.Post("/connections/staged/{id}/select", s.selectStagedConnection)
+			r.Delete("/connections/staged/{id}", s.cancelStagedConnection)
+
 			r.Post("/tokens", s.createAPIToken)
 			r.Get("/tokens", s.listAPITokens)
 			r.Delete("/tokens/{id}", s.revokeAPIToken)

--- a/plugins/datastore/dynamodb/dynamodb.go
+++ b/plugins/datastore/dynamodb/dynamodb.go
@@ -448,6 +448,18 @@ func (s *Store) RevokeAPIToken(ctx context.Context, userID, id string) error {
 	return nil
 }
 
+func (s *Store) StoreStagedConnection(_ context.Context, _ *core.StagedConnection) error {
+	return fmt.Errorf("staged connections not supported by dynamodb datastore")
+}
+
+func (s *Store) GetStagedConnection(_ context.Context, _ string) (*core.StagedConnection, error) {
+	return nil, fmt.Errorf("staged connections not supported by dynamodb datastore")
+}
+
+func (s *Store) DeleteStagedConnection(_ context.Context, _ string) error {
+	return fmt.Errorf("staged connections not supported by dynamodb datastore")
+}
+
 func (s *Store) lookupKeysByGSI(ctx context.Context, indexName, keyAttr, keyValue, skPrefix string) (pk, sk string, err error) {
 	keyCond := expression.KeyAnd(
 		expression.Key(keyAttr).Equal(expression.Value(keyValue)),

--- a/plugins/datastore/firestore/firestore.go
+++ b/plugins/datastore/firestore/firestore.go
@@ -452,6 +452,18 @@ func (s *Store) RevokeAPIToken(ctx context.Context, userID, id string) error {
 	return nil
 }
 
+func (s *Store) StoreStagedConnection(_ context.Context, _ *core.StagedConnection) error {
+	return fmt.Errorf("staged connections not supported by firestore datastore")
+}
+
+func (s *Store) GetStagedConnection(_ context.Context, _ string) (*core.StagedConnection, error) {
+	return nil, fmt.Errorf("staged connections not supported by firestore datastore")
+}
+
+func (s *Store) DeleteStagedConnection(_ context.Context, _ string) error {
+	return fmt.Errorf("staged connections not supported by firestore datastore")
+}
+
 func snapToAPIToken(snap *gcpfirestore.DocumentSnapshot) (*core.APIToken, error) {
 	var doc apiTokenDoc
 	if err := snap.DataTo(&doc); err != nil {

--- a/plugins/datastore/mongodb/mongodb.go
+++ b/plugins/datastore/mongodb/mongodb.go
@@ -357,6 +357,18 @@ func (s *Store) integrationTokenFromDoc(doc *integrationTokenDoc) (*core.Integra
 	}, nil
 }
 
+func (s *Store) StoreStagedConnection(_ context.Context, _ *core.StagedConnection) error {
+	return fmt.Errorf("staged connections not supported by mongodb datastore")
+}
+
+func (s *Store) GetStagedConnection(_ context.Context, _ string) (*core.StagedConnection, error) {
+	return nil, fmt.Errorf("staged connections not supported by mongodb datastore")
+}
+
+func (s *Store) DeleteStagedConnection(_ context.Context, _ string) error {
+	return fmt.Errorf("staged connections not supported by mongodb datastore")
+}
+
 func apiTokenFromDoc(doc *apiTokenDoc) *core.APIToken {
 	return &core.APIToken{
 		ID:          doc.ID,

--- a/plugins/datastore/mysql/mysql.go
+++ b/plugins/datastore/mysql/mysql.go
@@ -106,6 +106,21 @@ func (s *Store) Migrate(ctx context.Context) error {
 			UNIQUE KEY idx_api_tokens_hashed (hashed_token),
 			CONSTRAINT fk_api_tokens_user FOREIGN KEY (user_id) REFERENCES users(id)
 		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`,
+
+		`CREATE TABLE IF NOT EXISTS staged_connections (
+			id VARCHAR(36) NOT NULL PRIMARY KEY,
+			user_id VARCHAR(36) NOT NULL,
+			integration VARCHAR(255) NOT NULL,
+			instance VARCHAR(255) NOT NULL,
+			access_token_encrypted TEXT NOT NULL,
+			refresh_token_encrypted TEXT NOT NULL,
+			token_expires_at DATETIME,
+			metadata_json TEXT NOT NULL,
+			candidates_json TEXT NOT NULL,
+			created_at DATETIME(6) NOT NULL,
+			expires_at DATETIME(6) NOT NULL,
+			CONSTRAINT fk_staged_connections_user FOREIGN KEY (user_id) REFERENCES users(id)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`,
 	}
 
 	for i, stmt := range migrations {

--- a/plugins/datastore/oracle/oracle.go
+++ b/plugins/datastore/oracle/oracle.go
@@ -133,6 +133,22 @@ func (s *Store) Migrate(ctx context.Context) error {
 				updated_at TIMESTAMP WITH TIME ZONE NOT NULL
 			)`,
 		},
+		{
+			name: "STAGED_CONNECTIONS",
+			ddl: `CREATE TABLE staged_connections (
+				id VARCHAR2(36) PRIMARY KEY,
+				user_id VARCHAR2(36) NOT NULL,
+				integration VARCHAR2(255) NOT NULL,
+				instance VARCHAR2(255) NOT NULL,
+				access_token_encrypted CLOB NOT NULL,
+				refresh_token_encrypted CLOB,
+				token_expires_at TIMESTAMP,
+				metadata_json CLOB,
+				candidates_json CLOB NOT NULL,
+				created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+				expires_at TIMESTAMP WITH TIME ZONE NOT NULL
+			)`,
+		},
 	}
 
 	for _, tbl := range tables {
@@ -170,6 +186,10 @@ func (s *Store) Migrate(ctx context.Context) error {
 		{
 			name: "FK_API_TOKENS_USER",
 			ddl:  "ALTER TABLE api_tokens ADD CONSTRAINT fk_api_tokens_user FOREIGN KEY (user_id) REFERENCES users(id)",
+		},
+		{
+			name: "FK_STAGED_CONN_USER",
+			ddl:  "ALTER TABLE staged_connections ADD CONSTRAINT fk_staged_conn_user FOREIGN KEY (user_id) REFERENCES users(id)",
 		},
 	}
 

--- a/plugins/datastore/postgres/postgres.go
+++ b/plugins/datastore/postgres/postgres.go
@@ -120,5 +120,21 @@ func (s *Store) Migrate(ctx context.Context) error {
 		)`); err != nil {
 		return fmt.Errorf("creating api_tokens table: %w", err)
 	}
+	if _, err := tx.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS staged_connections (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id),
+			integration TEXT NOT NULL,
+			instance TEXT NOT NULL,
+			access_token_encrypted TEXT NOT NULL,
+			refresh_token_encrypted TEXT NOT NULL DEFAULT '',
+			token_expires_at TIMESTAMPTZ,
+			metadata_json TEXT NOT NULL DEFAULT '',
+			candidates_json TEXT NOT NULL,
+			created_at TIMESTAMPTZ NOT NULL,
+			expires_at TIMESTAMPTZ NOT NULL
+		)`); err != nil {
+		return fmt.Errorf("creating staged_connections table: %w", err)
+	}
 	return tx.Commit()
 }

--- a/plugins/datastore/sqlite/sqlite.go
+++ b/plugins/datastore/sqlite/sqlite.go
@@ -98,6 +98,19 @@ func (s *Store) Migrate(ctx context.Context) error {
 			expires_at DATETIME,
 			created_at DATETIME NOT NULL,
 			updated_at DATETIME NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS staged_connections (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id),
+			integration TEXT NOT NULL,
+			instance TEXT NOT NULL,
+			access_token_encrypted TEXT NOT NULL,
+			refresh_token_encrypted TEXT NOT NULL DEFAULT '',
+			token_expires_at DATETIME,
+			metadata_json TEXT NOT NULL DEFAULT '',
+			candidates_json TEXT NOT NULL,
+			created_at DATETIME NOT NULL,
+			expires_at DATETIME NOT NULL
 		)
 	`)
 	return err

--- a/plugins/datastore/sqlserver/sqlserver.go
+++ b/plugins/datastore/sqlserver/sqlserver.go
@@ -136,6 +136,21 @@ func (s *Store) Migrate(ctx context.Context) error {
 				created_at DATETIME2(6) NOT NULL,
 				updated_at DATETIME2(6) NOT NULL
 			)`},
+		{"staged_connections", `
+			IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'staged_connections')
+			CREATE TABLE staged_connections (
+				id NVARCHAR(36) NOT NULL PRIMARY KEY,
+				user_id NVARCHAR(36) NOT NULL REFERENCES users(id),
+				integration NVARCHAR(255) NOT NULL,
+				instance NVARCHAR(255) NOT NULL,
+				access_token_encrypted NVARCHAR(MAX) NOT NULL,
+				refresh_token_encrypted NVARCHAR(MAX) NOT NULL DEFAULT '',
+				token_expires_at DATETIME2,
+				metadata_json NVARCHAR(MAX) NOT NULL DEFAULT '',
+				candidates_json NVARCHAR(MAX) NOT NULL,
+				created_at DATETIME2(6) NOT NULL,
+				expires_at DATETIME2(6) NOT NULL
+			)`},
 	}
 
 	for _, m := range migrations {

--- a/plugins/datastore/sqlstore/sqlstore.go
+++ b/plugins/datastore/sqlstore/sqlstore.go
@@ -366,3 +366,68 @@ func (s *Store) RevokeAPIToken(ctx context.Context, userID, id string) error {
 	}
 	return nil
 }
+
+func (s *Store) StoreStagedConnection(ctx context.Context, sc *core.StagedConnection) error {
+	accessEnc, refreshEnc, err := s.Enc.EncryptTokenPair(sc.AccessToken, sc.RefreshToken)
+	if err != nil {
+		return fmt.Errorf("encrypting staged connection tokens: %w", err)
+	}
+
+	_, err = s.DB.ExecContext(ctx, `
+		INSERT INTO staged_connections
+			(id, user_id, integration, instance, access_token_encrypted, refresh_token_encrypted,
+			 token_expires_at, metadata_json, candidates_json, created_at, expires_at)
+		VALUES (`+s.ph(1)+`, `+s.ph(2)+`, `+s.ph(3)+`, `+s.ph(4)+`, `+s.ph(5)+`, `+s.ph(6)+`,
+				`+s.ph(7)+`, `+s.ph(8)+`, `+s.ph(9)+`, `+s.ph(10)+`, `+s.ph(11)+`)`,
+		sc.ID, sc.UserID, sc.Integration, sc.Instance,
+		accessEnc, refreshEnc,
+		NullableTime(sc.TokenExpiresAt), sc.MetadataJSON, sc.CandidatesJSON,
+		sc.CreatedAt, sc.ExpiresAt,
+	)
+	if err != nil {
+		return fmt.Errorf("inserting staged connection: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetStagedConnection(ctx context.Context, id string) (*core.StagedConnection, error) {
+	row := s.DB.QueryRowContext(ctx, `
+		SELECT id, user_id, integration, instance, access_token_encrypted, refresh_token_encrypted,
+		       token_expires_at, metadata_json, candidates_json, created_at, expires_at
+		FROM staged_connections WHERE id = `+s.ph(1), id)
+
+	var sc core.StagedConnection
+	var accessEnc, refreshEnc sql.NullString
+	var metadataJSON sql.NullString
+	var tokenExpiresAt sql.NullTime
+
+	if err := row.Scan(&sc.ID, &sc.UserID, &sc.Integration, &sc.Instance,
+		&accessEnc, &refreshEnc,
+		&tokenExpiresAt, &metadataJSON, &sc.CandidatesJSON,
+		&sc.CreatedAt, &sc.ExpiresAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("querying staged connection: %w", err)
+	}
+
+	sc.MetadataJSON = metadataJSON.String
+	if tokenExpiresAt.Valid {
+		sc.TokenExpiresAt = &tokenExpiresAt.Time
+	}
+
+	var err error
+	sc.AccessToken, sc.RefreshToken, err = s.Enc.DecryptTokenPair(accessEnc.String, refreshEnc.String)
+	if err != nil {
+		return nil, err
+	}
+	return &sc, nil
+}
+
+func (s *Store) DeleteStagedConnection(ctx context.Context, id string) error {
+	_, err := s.DB.ExecContext(ctx, "DELETE FROM staged_connections WHERE id = "+s.ph(1), id)
+	if err != nil {
+		return fmt.Errorf("deleting staged connection: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add host-owned declarative post-connect discovery model (`post_connect_discovery` on provider definitions) for integrations that need to discover resources after OAuth
- Introduce `StagedConnection` type — holds token material separately from `integration_tokens` so the invocation broker never sees incomplete connections
- Refactor OAuth callback and manual connect to use `tokenMaterial` + `runPostConnect` (token storage moved inside the post-connect flow)
- Add selection API: `GET/POST/DELETE /api/v1/connections/staged/{id}` keyed by staged connection ID
- Add `from: discovery` as a connection param source, alongside existing `token_response`
- All SQL datastores get `staged_connections` table with encrypted token storage

## Test plan
- [x] Discovery execution: top-level array, nested items, empty array, HTTP errors, invalid JSON
- [x] Datastore conformance suite: staged connection store/get/delete lifecycle
- [x] `go test ./...` passes
- [ ] Manual: connect integration with 1 discovered resource → auto-completes
- [ ] Manual: connect with 3 resources → returns `selection_required` with staged ID
- [ ] Manual: select candidate → token created, staged connection deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)