### PR TITLE
Add overlay provider composition for hybrid integrations

### DIFF
--- a/core/catalog/catalog.go
+++ b/core/catalog/catalog.go
@@ -11,6 +11,7 @@ import (
 const (
 	TransportMCPPassthrough = "mcp-passthrough"
 	TransportHTTP           = "http"
+	TransportPlugin         = "plugin"
 )
 
 // Catalog is the normalized on-disk representation for a provider's tool

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/crypto"
+	"github.com/valon-technologies/gestalt/internal/composite"
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	"github.com/valon-technologies/gestalt/internal/pluginapi"
@@ -490,6 +491,39 @@ func buildBindings(ctx context.Context, cfg *config.Config, factories *FactoryRe
 
 func buildProvider(ctx context.Context, name string, intg config.IntegrationDef, factories *FactoryRegistry, deps Deps) (core.Provider, error) {
 	if intg.Plugin != nil {
+		mode := intg.Plugin.Mode
+		if mode == "" {
+			mode = config.PluginModeReplace
+		}
+
+		if mode == config.PluginModeOverlay {
+			baseIntg := intg
+			baseIntg.Plugin = nil
+			factory, ok := factories.Providers[name]
+			if !ok {
+				factory = factories.DefaultProvider
+			}
+			if factory == nil {
+				return nil, fmt.Errorf("no provider factory for overlay base %q", name)
+			}
+			baseProv, err := factory(ctx, name, baseIntg, deps)
+			if err != nil {
+				return nil, fmt.Errorf("building overlay base: %w", err)
+			}
+			overlayProv, err := pluginapi.NewExecutableProvider(ctx, pluginapi.ExecConfig{
+				Command: intg.Plugin.Command,
+				Args:    intg.Plugin.Args,
+				Env:     intg.Plugin.Env,
+			})
+			if err != nil {
+				if c, ok := baseProv.(interface{ Close() error }); ok {
+					_ = c.Close()
+				}
+				return nil, fmt.Errorf("building overlay plugin: %w", err)
+			}
+			return composite.NewOverlay(name, baseProv, overlayProv), nil
+		}
+
 		return pluginapi.NewExecutableProvider(ctx, pluginapi.ExecConfig{
 			Command: intg.Plugin.Command,
 			Args:    intg.Plugin.Args,
@@ -509,6 +543,16 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 
 func providerBuildAvailable(name string, intg config.IntegrationDef, factories *FactoryRegistry) bool {
 	if intg.Plugin != nil {
+		mode := intg.Plugin.Mode
+		if mode == "" {
+			mode = config.PluginModeReplace
+		}
+		if mode == config.PluginModeOverlay {
+			if _, ok := factories.Providers[name]; ok {
+				return true
+			}
+			return factories.DefaultProvider != nil
+		}
 		return true
 	}
 	if _, ok := factories.Providers[name]; ok {

--- a/internal/composite/oauth.go
+++ b/internal/composite/oauth.go
@@ -1,0 +1,83 @@
+package composite
+
+import (
+	"context"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/oauth"
+)
+
+// oauthDelegator implements all OAuth-related methods by delegating to a
+// core.OAuthProvider. Both oauthProvider and overlayOAuthProvider embed
+// this to avoid duplicating the delegation logic.
+type oauthDelegator struct {
+	oauth core.OAuthProvider
+}
+
+func (d *oauthDelegator) AuthorizationURL(state string, scopes []string) string {
+	return d.oauth.AuthorizationURL(state, scopes)
+}
+
+func (d *oauthDelegator) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	return d.oauth.ExchangeCode(ctx, code)
+}
+
+func (d *oauthDelegator) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	return d.oauth.RefreshToken(ctx, refreshToken)
+}
+
+func (d *oauthDelegator) RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error) {
+	type refresher interface {
+		RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error)
+	}
+	if rw, ok := d.oauth.(refresher); ok {
+		return rw.RefreshTokenWithURL(ctx, refreshToken, tokenURL)
+	}
+	return d.oauth.RefreshToken(ctx, refreshToken)
+}
+
+func (d *oauthDelegator) StartOAuth(state string, scopes []string) (string, string) {
+	type starter interface {
+		StartOAuth(state string, scopes []string) (string, string)
+	}
+	if s, ok := d.oauth.(starter); ok {
+		return s.StartOAuth(state, scopes)
+	}
+	return d.oauth.AuthorizationURL(state, scopes), ""
+}
+
+func (d *oauthDelegator) StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string) {
+	type overrider interface {
+		StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string)
+	}
+	if ov, ok := d.oauth.(overrider); ok {
+		return ov.StartOAuthWithOverride(authBaseURL, state, scopes)
+	}
+	return d.oauth.AuthorizationURL(state, scopes), ""
+}
+
+func (d *oauthDelegator) AuthorizationBaseURL() string {
+	type authBaseURLer interface{ AuthorizationBaseURL() string }
+	if abu, ok := d.oauth.(authBaseURLer); ok {
+		return abu.AuthorizationBaseURL()
+	}
+	return ""
+}
+
+func (d *oauthDelegator) TokenURL() string {
+	type tokenURLer interface{ TokenURL() string }
+	if tu, ok := d.oauth.(tokenURLer); ok {
+		return tu.TokenURL()
+	}
+	return ""
+}
+
+func (d *oauthDelegator) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error) {
+	type exchanger interface {
+		ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
+	}
+	if e, ok := d.oauth.(exchanger); ok {
+		return e.ExchangeCodeWithVerifier(ctx, code, verifier, extraOpts...)
+	}
+	return d.oauth.ExchangeCode(ctx, code)
+}

--- a/internal/composite/overlay.go
+++ b/internal/composite/overlay.go
@@ -1,0 +1,189 @@
+package composite
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+)
+
+type OverlayProvider struct {
+	name       string
+	base       core.Provider
+	overlay    core.Provider
+	overlayOps map[string]struct{}
+}
+
+var (
+	_ core.Provider               = (*OverlayProvider)(nil)
+	_ core.CatalogProvider        = (*OverlayProvider)(nil)
+	_ core.SessionCatalogProvider = (*OverlayProvider)(nil)
+	_ core.AuthTypeLister         = (*OverlayProvider)(nil)
+)
+
+func NewOverlay(name string, base core.Provider, overlay core.Provider) core.Provider {
+	ops := make(map[string]struct{})
+	for _, op := range overlay.ListOperations() {
+		ops[op.Name] = struct{}{}
+	}
+	p := &OverlayProvider{name: name, base: base, overlay: overlay, overlayOps: ops}
+	if oauthProv, ok := base.(core.OAuthProvider); ok {
+		return &overlayOAuthProvider{OverlayProvider: p, oauthDelegator: oauthDelegator{oauth: oauthProv}}
+	}
+	return p
+}
+
+func (p *OverlayProvider) Name() string                        { return p.name }
+func (p *OverlayProvider) DisplayName() string                 { return p.base.DisplayName() }
+func (p *OverlayProvider) Description() string                 { return p.base.Description() }
+func (p *OverlayProvider) ConnectionMode() core.ConnectionMode { return p.base.ConnectionMode() }
+
+func (p *OverlayProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
+	if _, ok := p.overlayOps[operation]; ok {
+		return p.overlay.Execute(ctx, operation, params, token)
+	}
+	return p.base.Execute(ctx, operation, params, token)
+}
+
+func (p *OverlayProvider) ListOperations() []core.Operation {
+	baseOps := p.base.ListOperations()
+	overlayOps := p.overlay.ListOperations()
+	seen := make(map[string]struct{}, len(overlayOps))
+	result := make([]core.Operation, 0, len(baseOps)+len(overlayOps))
+	for _, op := range overlayOps {
+		result = append(result, op)
+		seen[op.Name] = struct{}{}
+	}
+	for _, op := range baseOps {
+		if _, ok := seen[op.Name]; !ok {
+			result = append(result, op)
+		}
+	}
+	return result
+}
+
+func (p *OverlayProvider) Catalog() *catalog.Catalog {
+	var baseCat, overlayCat *catalog.Catalog
+	if cp, ok := p.base.(core.CatalogProvider); ok {
+		baseCat = cp.Catalog()
+	}
+	if cp, ok := p.overlay.(core.CatalogProvider); ok {
+		overlayCat = cp.Catalog()
+	}
+	if baseCat == nil && overlayCat == nil {
+		return nil
+	}
+	if baseCat == nil {
+		return tagPluginCatalog(overlayCat)
+	}
+	if overlayCat == nil {
+		return baseCat
+	}
+
+	seen := make(map[string]struct{})
+	merged := &catalog.Catalog{
+		Name:        p.name,
+		DisplayName: baseCat.DisplayName,
+		Description: baseCat.Description,
+		IconSVG:     baseCat.IconSVG,
+		BaseURL:     baseCat.BaseURL,
+		AuthStyle:   baseCat.AuthStyle,
+		Headers:     copyHeaders(baseCat.Headers),
+		Operations:  make([]catalog.CatalogOperation, 0, len(baseCat.Operations)+len(overlayCat.Operations)),
+	}
+	for i := range overlayCat.Operations {
+		op := overlayCat.Operations[i]
+		op.Transport = catalog.TransportPlugin
+		merged.Operations = append(merged.Operations, op)
+		seen[op.ID] = struct{}{}
+	}
+	for i := range baseCat.Operations {
+		op := baseCat.Operations[i]
+		if _, ok := seen[op.ID]; !ok {
+			merged.Operations = append(merged.Operations, op)
+		}
+	}
+	return merged
+}
+
+func (p *OverlayProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
+	if scp, ok := p.base.(core.SessionCatalogProvider); ok {
+		return scp.CatalogForRequest(ctx, token)
+	}
+	return nil, nil
+}
+
+func tagPluginCatalog(src *catalog.Catalog) *catalog.Catalog {
+	out := src.Clone()
+	for i := range out.Operations {
+		out.Operations[i].Transport = catalog.TransportPlugin
+	}
+	return out
+}
+
+func copyHeaders(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func (p *OverlayProvider) SupportsManualAuth() bool {
+	if mp, ok := p.base.(core.ManualProvider); ok {
+		return mp.SupportsManualAuth()
+	}
+	return false
+}
+
+func (p *OverlayProvider) AuthTypes() []string {
+	if atl, ok := p.base.(core.AuthTypeLister); ok {
+		return atl.AuthTypes()
+	}
+	return nil
+}
+
+func (p *OverlayProvider) PostConnectHook() core.PostConnectHook {
+	if pcp, ok := p.base.(core.PostConnectProvider); ok {
+		return pcp.PostConnectHook()
+	}
+	return nil
+}
+
+func (p *OverlayProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	if cpp, ok := p.base.(core.ConnectionParamProvider); ok {
+		return cpp.ConnectionParamDefs()
+	}
+	return nil
+}
+
+func (p *OverlayProvider) DiscoveryConfig() *core.DiscoveryConfig {
+	if dcp, ok := p.base.(core.DiscoveryConfigProvider); ok {
+		return dcp.DiscoveryConfig()
+	}
+	return nil
+}
+
+func (p *OverlayProvider) Close() error {
+	var firstErr error
+	if c, ok := p.overlay.(interface{ Close() error }); ok {
+		if err := c.Close(); err != nil {
+			firstErr = fmt.Errorf("closing overlay: %w", err)
+		}
+	}
+	if c, ok := p.base.(interface{ Close() error }); ok {
+		if err := c.Close(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("closing base: %w", err)
+		}
+	}
+	return firstErr
+}
+
+type overlayOAuthProvider struct {
+	*OverlayProvider
+	oauthDelegator
+}

--- a/internal/composite/overlay_test.go
+++ b/internal/composite/overlay_test.go
@@ -1,0 +1,405 @@
+package composite
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+)
+
+type stubProvider struct {
+	name       string
+	operations []core.Operation
+	executeFn  func(ctx context.Context, op string, params map[string]any, token string) (*core.OperationResult, error)
+	closed     bool
+}
+
+func (s *stubProvider) Name() string                        { return s.name }
+func (s *stubProvider) DisplayName() string                 { return s.name + " display" }
+func (s *stubProvider) Description() string                 { return s.name + " desc" }
+func (s *stubProvider) ConnectionMode() core.ConnectionMode { return core.ConnectionModeUser }
+func (s *stubProvider) ListOperations() []core.Operation    { return s.operations }
+func (s *stubProvider) Execute(ctx context.Context, op string, params map[string]any, token string) (*core.OperationResult, error) {
+	if s.executeFn != nil {
+		return s.executeFn(ctx, op, params, token)
+	}
+	return &core.OperationResult{Status: 200, Body: s.name + ":" + op}, nil
+}
+func (s *stubProvider) Close() error { s.closed = true; return nil }
+
+type stubCatalogProvider struct {
+	stubProvider
+	cat *catalog.Catalog
+}
+
+func (s *stubCatalogProvider) Catalog() *catalog.Catalog { return s.cat }
+
+type stubOAuthProvider struct {
+	stubCatalogProvider
+	authURL string
+}
+
+func (s *stubOAuthProvider) AuthorizationURL(state string, scopes []string) string {
+	return s.authURL + "?state=" + state
+}
+func (s *stubOAuthProvider) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	return &core.TokenResponse{AccessToken: "tok-" + code}, nil
+}
+func (s *stubOAuthProvider) RefreshToken(ctx context.Context, rt string) (*core.TokenResponse, error) {
+	return &core.TokenResponse{AccessToken: "refreshed"}, nil
+}
+
+type stubManualProvider struct {
+	stubProvider
+	manual bool
+}
+
+func (s *stubManualProvider) SupportsManualAuth() bool { return s.manual }
+
+type stubConnectionParamProvider struct {
+	stubProvider
+	defs map[string]core.ConnectionParamDef
+}
+
+func (s *stubConnectionParamProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return s.defs
+}
+
+type stubPostConnectProvider struct {
+	stubProvider
+	hook core.PostConnectHook
+}
+
+func (s *stubPostConnectProvider) PostConnectHook() core.PostConnectHook { return s.hook }
+
+func TestOverlayExecuteRouting(t *testing.T) {
+	t.Parallel()
+
+	base := &stubProvider{
+		name:       "base",
+		operations: []core.Operation{{Name: "base_op"}, {Name: "shared_op"}},
+	}
+	overlay := &stubProvider{
+		name:       "overlay",
+		operations: []core.Operation{{Name: "overlay_op"}, {Name: "shared_op"}},
+	}
+
+	p := NewOverlay("test", base, overlay)
+
+	res, err := p.Execute(context.Background(), "overlay_op", nil, "")
+	if err != nil {
+		t.Fatalf("Execute overlay_op: %v", err)
+	}
+	if res.Body != "overlay:overlay_op" {
+		t.Errorf("overlay_op body = %q, want %q", res.Body, "overlay:overlay_op")
+	}
+
+	res, err = p.Execute(context.Background(), "base_op", nil, "")
+	if err != nil {
+		t.Fatalf("Execute base_op: %v", err)
+	}
+	if res.Body != "base:base_op" {
+		t.Errorf("base_op body = %q, want %q", res.Body, "base:base_op")
+	}
+
+	res, err = p.Execute(context.Background(), "shared_op", nil, "")
+	if err != nil {
+		t.Fatalf("Execute shared_op: %v", err)
+	}
+	if res.Body != "overlay:shared_op" {
+		t.Errorf("shared_op body = %q, want %q", res.Body, "overlay:shared_op")
+	}
+}
+
+func TestOverlayExecuteUnknown(t *testing.T) {
+	t.Parallel()
+
+	base := &stubProvider{
+		name:       "base",
+		operations: []core.Operation{{Name: "base_op"}},
+		executeFn: func(_ context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
+			return nil, errors.New("unknown operation: " + op)
+		},
+	}
+	overlay := &stubProvider{
+		name:       "overlay",
+		operations: []core.Operation{{Name: "overlay_op"}},
+	}
+
+	p := NewOverlay("test", base, overlay)
+	_, err := p.Execute(context.Background(), "no_such_op", nil, "")
+	if err == nil {
+		t.Fatal("expected error for unknown operation")
+	}
+}
+
+func TestOverlayListOperationsUnion(t *testing.T) {
+	t.Parallel()
+
+	base := &stubProvider{
+		name:       "base",
+		operations: []core.Operation{{Name: "base_op"}, {Name: "shared_op", Description: "from base"}},
+	}
+	overlay := &stubProvider{
+		name:       "overlay",
+		operations: []core.Operation{{Name: "overlay_op"}, {Name: "shared_op", Description: "from overlay"}},
+	}
+
+	p := NewOverlay("test", base, overlay)
+	ops := p.ListOperations()
+
+	if len(ops) != 3 {
+		t.Fatalf("ListOperations: got %d, want 3", len(ops))
+	}
+
+	byName := make(map[string]core.Operation)
+	for _, op := range ops {
+		byName[op.Name] = op
+	}
+	if _, ok := byName["base_op"]; !ok {
+		t.Error("missing base_op")
+	}
+	if _, ok := byName["overlay_op"]; !ok {
+		t.Error("missing overlay_op")
+	}
+	if byName["shared_op"].Description != "from overlay" {
+		t.Errorf("shared_op description = %q, want %q", byName["shared_op"].Description, "from overlay")
+	}
+}
+
+func TestOverlayCatalogMerge(t *testing.T) {
+	t.Parallel()
+
+	base := &stubCatalogProvider{
+		stubProvider: stubProvider{name: "base", operations: []core.Operation{{Name: "base_op"}}},
+		cat: &catalog.Catalog{
+			Name:        "base",
+			DisplayName: "Base",
+			Description: "base desc",
+			Operations: []catalog.CatalogOperation{
+				{ID: "base_op", Transport: catalog.TransportHTTP},
+				{ID: "shared_op", Transport: catalog.TransportHTTP},
+			},
+		},
+	}
+	overlay := &stubCatalogProvider{
+		stubProvider: stubProvider{name: "overlay", operations: []core.Operation{{Name: "overlay_op"}, {Name: "shared_op"}}},
+		cat: &catalog.Catalog{
+			Name: "overlay",
+			Operations: []catalog.CatalogOperation{
+				{ID: "overlay_op"},
+				{ID: "shared_op"},
+			},
+		},
+	}
+
+	p := NewOverlay("test", base, overlay)
+	cp := p.(core.CatalogProvider)
+	cat := cp.Catalog()
+
+	if cat == nil {
+		t.Fatal("Catalog() returned nil")
+	}
+	if cat.DisplayName != "Base" {
+		t.Errorf("DisplayName = %q, want %q", cat.DisplayName, "Base")
+	}
+
+	if len(cat.Operations) != 3 {
+		t.Fatalf("got %d ops, want 3", len(cat.Operations))
+	}
+
+	byID := make(map[string]catalog.CatalogOperation)
+	for _, op := range cat.Operations {
+		byID[op.ID] = op
+	}
+	if byID["overlay_op"].Transport != catalog.TransportPlugin {
+		t.Errorf("overlay_op transport = %q, want %q", byID["overlay_op"].Transport, catalog.TransportPlugin)
+	}
+	if byID["shared_op"].Transport != catalog.TransportPlugin {
+		t.Errorf("shared_op transport = %q, want %q", byID["shared_op"].Transport, catalog.TransportPlugin)
+	}
+	if byID["base_op"].Transport != catalog.TransportHTTP {
+		t.Errorf("base_op transport = %q, want %q", byID["base_op"].Transport, catalog.TransportHTTP)
+	}
+}
+
+func TestOverlayOAuthDelegation(t *testing.T) {
+	t.Parallel()
+
+	base := &stubOAuthProvider{
+		stubCatalogProvider: stubCatalogProvider{
+			stubProvider: stubProvider{name: "base", operations: []core.Operation{{Name: "base_op"}}},
+		},
+		authURL: "https://auth.example.com",
+	}
+	overlay := &stubProvider{
+		name:       "overlay",
+		operations: []core.Operation{{Name: "overlay_op"}},
+	}
+
+	p := NewOverlay("test", base, overlay)
+
+	oauthP, ok := p.(core.OAuthProvider)
+	if !ok {
+		t.Fatal("expected OAuthProvider interface")
+	}
+
+	url := oauthP.AuthorizationURL("abc", nil)
+	if url != "https://auth.example.com?state=abc" {
+		t.Errorf("AuthorizationURL = %q", url)
+	}
+
+	tok, err := oauthP.ExchangeCode(context.Background(), "code123")
+	if err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if tok.AccessToken != "tok-code123" {
+		t.Errorf("AccessToken = %q", tok.AccessToken)
+	}
+}
+
+func TestOverlaySupportsManualAuth(t *testing.T) {
+	t.Parallel()
+
+	base := &stubManualProvider{
+		stubProvider: stubProvider{name: "base", operations: []core.Operation{{Name: "op1"}}},
+		manual:       true,
+	}
+	overlay := &stubProvider{
+		name:       "overlay",
+		operations: []core.Operation{{Name: "op2"}},
+	}
+
+	p := NewOverlay("test", base, overlay).(*OverlayProvider)
+	if !p.SupportsManualAuth() {
+		t.Error("SupportsManualAuth should delegate to base")
+	}
+}
+
+func TestOverlayConnectionParamDefs(t *testing.T) {
+	t.Parallel()
+
+	defs := map[string]core.ConnectionParamDef{
+		"project_id": {Required: true, Description: "Project ID"},
+	}
+	base := &stubConnectionParamProvider{
+		stubProvider: stubProvider{name: "base", operations: []core.Operation{{Name: "op1"}}},
+		defs:         defs,
+	}
+	overlay := &stubProvider{
+		name:       "overlay",
+		operations: []core.Operation{{Name: "op2"}},
+	}
+
+	p := NewOverlay("test", base, overlay).(*OverlayProvider)
+	got := p.ConnectionParamDefs()
+	if len(got) != 1 || got["project_id"].Description != "Project ID" {
+		t.Errorf("ConnectionParamDefs = %v", got)
+	}
+}
+
+func TestOverlayPostConnectHook(t *testing.T) {
+	t.Parallel()
+
+	base := &stubPostConnectProvider{
+		stubProvider: stubProvider{name: "base", operations: []core.Operation{{Name: "op1"}}},
+		hook: func(_ context.Context, _ *core.IntegrationToken, _ *http.Client) (map[string]string, error) {
+			return nil, nil
+		},
+	}
+	overlay := &stubProvider{
+		name:       "overlay",
+		operations: []core.Operation{{Name: "op2"}},
+	}
+
+	p := NewOverlay("test", base, overlay).(*OverlayProvider)
+	if p.PostConnectHook() == nil {
+		t.Error("PostConnectHook should delegate to base")
+	}
+}
+
+func TestOverlayClose(t *testing.T) {
+	t.Parallel()
+
+	base := &stubProvider{name: "base", operations: []core.Operation{{Name: "op1"}}}
+	overlay := &stubProvider{name: "overlay", operations: []core.Operation{{Name: "op2"}}}
+
+	p := NewOverlay("test", base, overlay).(*OverlayProvider)
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !base.closed {
+		t.Error("base not closed")
+	}
+	if !overlay.closed {
+		t.Error("overlay not closed")
+	}
+}
+
+type stubSessionCatalogProvider struct {
+	stubProvider
+	cat    *catalog.Catalog
+	catErr error
+}
+
+func (s *stubSessionCatalogProvider) CatalogForRequest(_ context.Context, _ string) (*catalog.Catalog, error) {
+	return s.cat, s.catErr
+}
+
+func TestOverlayCatalogForRequest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("delegates to base", func(t *testing.T) {
+		t.Parallel()
+
+		want := &catalog.Catalog{Name: "session-cat", Operations: []catalog.CatalogOperation{{ID: "op1"}}}
+		base := &stubSessionCatalogProvider{
+			stubProvider: stubProvider{name: "base", operations: []core.Operation{{Name: "op1"}}},
+			cat:          want,
+		}
+		overlay := &stubProvider{name: "overlay", operations: []core.Operation{{Name: "op2"}}}
+
+		p := NewOverlay("test", base, overlay).(*OverlayProvider)
+		got, err := p.CatalogForRequest(context.Background(), "tok-123")
+		if err != nil {
+			t.Fatalf("CatalogForRequest: %v", err)
+		}
+		if got != want {
+			t.Errorf("CatalogForRequest = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("returns nil when base lacks interface", func(t *testing.T) {
+		t.Parallel()
+
+		base := &stubProvider{name: "base", operations: []core.Operation{{Name: "op1"}}}
+		overlay := &stubProvider{name: "overlay", operations: []core.Operation{{Name: "op2"}}}
+
+		p := NewOverlay("test", base, overlay).(*OverlayProvider)
+		got, err := p.CatalogForRequest(context.Background(), "tok-123")
+		if err != nil {
+			t.Fatalf("CatalogForRequest: %v", err)
+		}
+		if got != nil {
+			t.Errorf("CatalogForRequest = %v, want nil", got)
+		}
+	})
+}
+
+func TestOverlayNonOAuthBase(t *testing.T) {
+	t.Parallel()
+
+	base := &stubProvider{name: "base", operations: []core.Operation{{Name: "op1"}}}
+	overlay := &stubProvider{name: "overlay", operations: []core.Operation{{Name: "op2"}}}
+
+	p := NewOverlay("test", base, overlay)
+	if _, ok := p.(*OverlayProvider); !ok {
+		t.Errorf("expected *OverlayProvider, got %T", p)
+	}
+	if _, ok := p.(core.OAuthProvider); ok {
+		t.Error("non-OAuth base should not produce OAuthProvider")
+	}
+}

--- a/internal/composite/provider.go
+++ b/internal/composite/provider.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
-	"github.com/valon-technologies/gestalt/internal/oauth"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 )
@@ -42,8 +41,8 @@ func New(name string, apiProv core.Provider, mcpUp MCPUpstream) core.Provider {
 		api:  apiProv,
 		mcp:  mcpUp,
 	}
-	if oauth, ok := apiProv.(core.OAuthProvider); ok {
-		return &oauthProvider{Provider: p, oauth: oauth}
+	if oauthProv, ok := apiProv.(core.OAuthProvider); ok {
+		return &oauthProvider{Provider: p, oauthDelegator: oauthDelegator{oauth: oauthProv}}
 	}
 	return p
 }
@@ -103,79 +102,9 @@ func (p *Provider) Close() error {
 	return firstErr
 }
 
-// oauthProvider wraps a composite Provider and delegates OAuth methods
-// to the API provider, following the same pattern as restrictedOAuth.
 type oauthProvider struct {
 	*Provider
-	oauth core.OAuthProvider
-}
-
-func (o *oauthProvider) AuthorizationURL(state string, scopes []string) string {
-	return o.oauth.AuthorizationURL(state, scopes)
-}
-
-func (o *oauthProvider) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
-	return o.oauth.ExchangeCode(ctx, code)
-}
-
-func (o *oauthProvider) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
-	return o.oauth.RefreshToken(ctx, refreshToken)
-}
-
-func (o *oauthProvider) RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error) {
-	type refresher interface {
-		RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error)
-	}
-	if rw, ok := o.oauth.(refresher); ok {
-		return rw.RefreshTokenWithURL(ctx, refreshToken, tokenURL)
-	}
-	return o.oauth.RefreshToken(ctx, refreshToken)
-}
-
-func (o *oauthProvider) StartOAuth(state string, scopes []string) (string, string) {
-	type starter interface {
-		StartOAuth(state string, scopes []string) (string, string)
-	}
-	if s, ok := o.oauth.(starter); ok {
-		return s.StartOAuth(state, scopes)
-	}
-	return o.oauth.AuthorizationURL(state, scopes), ""
-}
-
-func (o *oauthProvider) StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string) {
-	type overrider interface {
-		StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string)
-	}
-	if ov, ok := o.oauth.(overrider); ok {
-		return ov.StartOAuthWithOverride(authBaseURL, state, scopes)
-	}
-	return o.oauth.AuthorizationURL(state, scopes), ""
-}
-
-func (o *oauthProvider) AuthorizationBaseURL() string {
-	type authBaseURLer interface{ AuthorizationBaseURL() string }
-	if abu, ok := o.oauth.(authBaseURLer); ok {
-		return abu.AuthorizationBaseURL()
-	}
-	return ""
-}
-
-func (o *oauthProvider) TokenURL() string {
-	type tokenURLer interface{ TokenURL() string }
-	if tu, ok := o.oauth.(tokenURLer); ok {
-		return tu.TokenURL()
-	}
-	return ""
-}
-
-func (o *oauthProvider) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error) {
-	type exchanger interface {
-		ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
-	}
-	if e, ok := o.oauth.(exchanger); ok {
-		return e.ExchangeCodeWithVerifier(ctx, code, verifier, extraOpts...)
-	}
-	return o.oauth.ExchangeCode(ctx, code)
+	oauthDelegator
 }
 
 func (p *Provider) buildCatalog() *catalog.Catalog {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,7 +27,13 @@ type Config struct {
 	Server       ServerConfig              `yaml:"server"`
 }
 
+const (
+	PluginModeReplace = "replace"
+	PluginModeOverlay = "overlay"
+)
+
 type ExecutablePluginDef struct {
+	Mode    string            `yaml:"mode"`
 	Command string            `yaml:"command"`
 	Args    []string          `yaml:"args"`
 	Env     map[string]string `yaml:"env"`
@@ -449,10 +455,23 @@ func validate(cfg *Config) error {
 			return err
 		}
 		if intg.Plugin != nil {
-			if len(intg.Upstreams) > 0 {
-				return fmt.Errorf("config validation: integration %q cannot set both plugin and upstreams", name)
+			mode := intg.Plugin.Mode
+			if mode == "" {
+				mode = PluginModeReplace
 			}
-			continue
+			switch mode {
+			case PluginModeReplace:
+				if len(intg.Upstreams) > 0 {
+					return fmt.Errorf("config validation: integration %q cannot set both plugin and upstreams; use mode: overlay to combine them", name)
+				}
+				continue
+			case PluginModeOverlay:
+				if len(intg.Upstreams) == 0 {
+					return fmt.Errorf("config validation: integration %q overlay plugin requires at least one upstream", name)
+				}
+			default:
+				return fmt.Errorf("config validation: integration %q has unknown plugin mode %q", name, intg.Plugin.Mode)
+			}
 		}
 		apiCount := 0
 		for i := range intg.Upstreams {
@@ -483,6 +502,9 @@ func validate(cfg *Config) error {
 			return err
 		}
 		if rt.Plugin != nil {
+			if rt.Plugin.Mode == PluginModeOverlay {
+				return fmt.Errorf("config validation: runtime %q plugin.mode cannot be overlay", name)
+			}
 			if rt.Type != "" {
 				return fmt.Errorf("config validation: runtime %q cannot set both plugin and type", name)
 			}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -334,6 +334,116 @@ integrations:
 			wantErr: true,
 		},
 		{
+			name: "overlay plugin with upstreams is valid",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+integrations:
+  gadget:
+    plugin:
+      mode: overlay
+      command: /tmp/plugin
+    upstreams:
+      - type: rest
+        url: https://example.com/spec.json
+`,
+			wantErr: false,
+		},
+		{
+			name: "overlay plugin without upstreams",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+integrations:
+  gadget:
+    plugin:
+      mode: overlay
+      command: /tmp/plugin
+`,
+			wantErr: true,
+		},
+		{
+			name: "replace plugin with upstreams rejected",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+integrations:
+  gadget:
+    plugin:
+      mode: replace
+      command: /tmp/plugin
+    upstreams:
+      - type: rest
+        url: https://example.com/spec.json
+`,
+			wantErr: true,
+		},
+		{
+			name: "empty mode defaults to replace rejects upstreams",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+integrations:
+  gadget:
+    plugin:
+      command: /tmp/plugin
+    upstreams:
+      - type: rest
+        url: https://example.com/spec.json
+`,
+			wantErr: true,
+		},
+		{
+			name: "unknown plugin mode",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+integrations:
+  gadget:
+    plugin:
+      mode: turbo
+      command: /tmp/plugin
+`,
+			wantErr: true,
+		},
+		{
+			name: "runtime overlay mode rejected",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+runtimes:
+  worker:
+    plugin:
+      mode: overlay
+      command: /tmp/plugin
+`,
+			wantErr: true,
+		},
+		{
 			name: "runtime requires type or plugin",
 			yaml: `
 auth:
@@ -391,6 +501,102 @@ integrations:
 			}
 			if !tc.wantErr && err != nil {
 				t.Fatalf("Load: unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestPluginModeValidationMessages(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		yaml        string
+		wantContain string
+	}{
+		{
+			name: "overlay without upstreams",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+integrations:
+  gadget:
+    plugin:
+      mode: overlay
+      command: /tmp/plugin
+`,
+			wantContain: "overlay plugin requires",
+		},
+		{
+			name: "replace with upstreams",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+integrations:
+  gadget:
+    plugin:
+      mode: replace
+      command: /tmp/plugin
+    upstreams:
+      - type: rest
+        url: https://example.com/spec.json
+`,
+			wantContain: "cannot set both",
+		},
+		{
+			name: "unknown mode",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+integrations:
+  gadget:
+    plugin:
+      mode: turbo
+      command: /tmp/plugin
+`,
+			wantContain: "unknown plugin mode",
+		},
+		{
+			name: "runtime overlay",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+runtimes:
+  worker:
+    plugin:
+      mode: overlay
+      command: /tmp/plugin
+`,
+			wantContain: "cannot be overlay",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := mustWriteConfigFile(t, tc.yaml)
+			_, err := Load(path)
+			if err == nil {
+				t.Fatal("Load: expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantContain) {
+				t.Fatalf("Load error = %q, want it to contain %q", err, tc.wantContain)
 			}
 		})
 	}

--- a/internal/mcp/binding.go
+++ b/internal/mcp/binding.go
@@ -282,7 +282,7 @@ func buildToolMap(cfg Config, provName string, prov core.Provider, cat *catalog.
 		}
 
 		var handler mcpserver.ToolHandlerFunc
-		if isDirect && op.Transport != catalog.TransportHTTP {
+		if isDirect && op.Transport != catalog.TransportHTTP && op.Transport != catalog.TransportPlugin {
 			handler = makeDirectHandler(cfg, provName, op.ID, caller)
 		} else {
 			handler = makeHandler(cfg.Invoker, provName, op.ID)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1120,7 +1120,6 @@ func validateDiscoveryMetadata(metadata map[string]string) error {
 	}
 	return nil
 }
-
 func mergeMetadataJSON(existing string, extra map[string]string) (string, error) {
 	m := make(map[string]string)
 	if existing != "" {


### PR DESCRIPTION
## Summary
- Add `plugin.mode: overlay` to combine declarative REST/GraphQL upstreams with an executable plugin that adds or overrides operations
- Create `OverlayProvider` in `internal/composite/overlay.go` following the existing `composite.Provider` pattern
- Execute routes overlay operations to the plugin and base operations to the declarative provider
- Auth, connection management, and post-connect hooks stay with the base provider
- Add `TransportPlugin` catalog constant for MCP binding transport routing
- Update bootstrap to build both base (via factory) and overlay (via executable plugin) and compose them

## Test plan
- [x] Config validation: overlay requires upstreams, runtime rejects overlay, unknown mode rejected
- [x] Execute routing: overlay ops → overlay, base ops → base
- [x] ListOperations union: overlay takes precedence on name collision
- [x] Catalog merge: overlay ops tagged `TransportPlugin`, base ops keep tags
- [x] Auth/ManualAuth/ConnectionParams/PostConnect delegation to base
- [x] Close propagation: both providers closed
- [x] Non-OAuth base: returns `OverlayProvider` not `overlayOAuthProvider`
- [x] MCP binding: plugin-transport operations use invoker path
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)