### PR TITLE
Extend executable provider OAuth contract

### DIFF
--- a/internal/bootstrap/executable_plugin_test.go
+++ b/internal/bootstrap/executable_plugin_test.go
@@ -8,10 +8,14 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/valon-technologies/gestalt/core"
+	coretesting "github.com/valon-technologies/gestalt/core/testing"
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/invocation"
+	"github.com/valon-technologies/gestalt/internal/principal"
+	"github.com/valon-technologies/gestalt/internal/testutil"
 	"gopkg.in/yaml.v3"
 )
 
@@ -95,6 +99,70 @@ func TestExecutableProviderAndRuntimePlugins(t *testing.T) {
 	}
 	if got.ProbeBody != `{"message":"from runtime"}` {
 		t.Fatalf("runtime output probe_body = %q", got.ProbeBody)
+	}
+}
+
+func TestExecutableOAuthProviderRefreshesWithOverrides(t *testing.T) {
+	t.Parallel()
+
+	bin := testutil.BuildGoBinary(t, "./internal/testdata/oauthplugin", "gestalt-plugin-oauth-fixture")
+
+	cfg := &config.Config{
+		Integrations: map[string]config.IntegrationDef{
+			"exec-oauth": {
+				Plugin: &config.ExecutablePluginDef{
+					Command: bin,
+				},
+			},
+		},
+	}
+
+	factories := NewFactoryRegistry()
+	providers, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	ds := &coretesting.StubDatastore{
+		TokenFn: func(_ context.Context, userID, integration, instance string) (*core.IntegrationToken, error) {
+			if userID != "u1" || integration != "exec-oauth" || instance != "default" {
+				t.Fatalf("unexpected token lookup: user=%q integration=%q instance=%q", userID, integration, instance)
+			}
+			expired := time.Now().Add(-time.Minute)
+			return &core.IntegrationToken{
+				UserID:       userID,
+				Integration:  integration,
+				Instance:     instance,
+				AccessToken:  "stale",
+				RefreshToken: "refresh:acme",
+				ExpiresAt:    &expired,
+				MetadataJSON: `{"tenant":"acme"}`,
+			}, nil
+		},
+		StoreTokenFn: func(_ context.Context, tok *core.IntegrationToken) error {
+			if tok.AccessToken != "fresh:acme|refresh:acme|https://acme.example.com/token" {
+				t.Fatalf("stored access token = %q", tok.AccessToken)
+			}
+			return nil
+		},
+	}
+
+	broker := invocation.NewBroker(providers, ds)
+	res, err := broker.Invoke(context.Background(), &principal.Principal{UserID: "u1"}, "exec-oauth", "default", "echo_token", nil)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal([]byte(res.Body), &body); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if body["token"] != "fresh:acme|refresh:acme|https://acme.example.com/token" {
+		t.Fatalf("invoke token = %q", body["token"])
+	}
+	if body["tenant"] != "acme" {
+		t.Fatalf("invoke tenant = %q", body["tenant"])
 	}
 }
 

--- a/internal/oauth/upstream.go
+++ b/internal/oauth/upstream.go
@@ -98,6 +98,22 @@ type exchangeOptions struct {
 	tokenURL string
 }
 
+type ResolvedExchangeOptions struct {
+	Verifier string
+	TokenURL string
+}
+
+func ResolveExchangeOptions(opts ...ExchangeOption) ResolvedExchangeOptions {
+	var eo exchangeOptions
+	for _, opt := range opts {
+		opt(&eo)
+	}
+	return ResolvedExchangeOptions{
+		Verifier: eo.verifier,
+		TokenURL: eo.tokenURL,
+	}
+}
+
 func WithPKCEVerifier(verifier string) ExchangeOption {
 	return func(o *exchangeOptions) {
 		o.verifier = verifier

--- a/internal/pluginapi/provider_client.go
+++ b/internal/pluginapi/provider_client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
+	"github.com/valon-technologies/gestalt/internal/oauth"
 	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
@@ -66,11 +67,17 @@ func NewRemoteProvider(ctx context.Context, client pluginapiv1.ProviderPluginCli
 
 	switch {
 	case hasOAuth && hasSessionCatalog && hasPostConnect:
-		return &remoteProviderWithOAuthSessionCatalogPostConnect{remoteProviderBase: base}, nil
+		return &remoteProviderWithOAuthSessionCatalogPostConnect{
+			remoteProviderWithOAuth: &remoteProviderWithOAuth{remoteProviderBase: base},
+		}, nil
 	case hasOAuth && hasSessionCatalog:
-		return &remoteProviderWithOAuthSessionCatalog{remoteProviderBase: base}, nil
+		return &remoteProviderWithOAuthSessionCatalog{
+			remoteProviderWithOAuth: &remoteProviderWithOAuth{remoteProviderBase: base},
+		}, nil
 	case hasOAuth && hasPostConnect:
-		return &remoteProviderWithOAuthPostConnect{remoteProviderBase: base}, nil
+		return &remoteProviderWithOAuthPostConnect{
+			remoteProviderWithOAuth: &remoteProviderWithOAuth{remoteProviderBase: base},
+		}, nil
 	case hasSessionCatalog && hasPostConnect:
 		return &remoteProviderWithSessionCatalogPostConnect{remoteProviderBase: base}, nil
 	case hasOAuth:
@@ -139,27 +146,38 @@ func (p *remoteProviderBase) AuthTypes() []string {
 	return slices.Clone(p.metadata.GetAuthTypes())
 }
 
-func (p *remoteProviderBase) authorizationURL(state string, scopes []string) string {
+func (p *remoteProviderBase) authorizationURL(state string, scopes []string, includeVerifier bool, authBaseURL string) (string, string) {
 	resp, err := p.client.AuthorizationURL(context.Background(), &pluginapiv1.AuthorizationURLRequest{
-		State:  state,
-		Scopes: slices.Clone(scopes),
+		State:           state,
+		Scopes:          slices.Clone(scopes),
+		AuthBaseUrl:     authBaseURL,
+		IncludeVerifier: includeVerifier,
 	})
 	if err != nil {
-		return ""
+		return "", ""
 	}
-	return resp.GetUrl()
+	return resp.GetUrl(), resp.GetVerifier()
 }
 
-func (p *remoteProviderBase) exchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
-	resp, err := p.client.ExchangeCode(ctx, &pluginapiv1.ExchangeCodeRequest{Code: code})
+func (p *remoteProviderBase) exchangeCode(ctx context.Context, code, verifier, tokenURL string) (*core.TokenResponse, error) {
+	resp, err := p.client.ExchangeCode(ctx, &pluginapiv1.ExchangeCodeRequest{
+		Code:             code,
+		Verifier:         verifier,
+		TokenUrl:         tokenURL,
+		ConnectionParams: core.ConnectionParams(ctx),
+	})
 	if err != nil {
 		return nil, err
 	}
 	return tokenResponseFromProto(resp), nil
 }
 
-func (p *remoteProviderBase) refreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
-	resp, err := p.client.RefreshToken(ctx, &pluginapiv1.RefreshTokenRequest{RefreshToken: refreshToken})
+func (p *remoteProviderBase) refreshToken(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error) {
+	resp, err := p.client.RefreshToken(ctx, &pluginapiv1.RefreshTokenRequest{
+		RefreshToken:     refreshToken,
+		TokenUrl:         tokenURL,
+		ConnectionParams: core.ConnectionParams(ctx),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -192,15 +210,44 @@ func (p *remoteProviderBase) postConnectHook() core.PostConnectHook {
 type remoteProviderWithOAuth struct{ *remoteProviderBase }
 
 func (p *remoteProviderWithOAuth) AuthorizationURL(state string, scopes []string) string {
-	return p.authorizationURL(state, scopes)
+	url, _ := p.authorizationURL(state, scopes, false, "")
+	return url
+}
+
+func (p *remoteProviderWithOAuth) StartOAuth(state string, scopes []string) (string, string) {
+	return p.authorizationURL(state, scopes, true, "")
+}
+
+func (p *remoteProviderWithOAuth) StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string) {
+	return p.authorizationURL(state, scopes, true, authBaseURL)
 }
 
 func (p *remoteProviderWithOAuth) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
-	return p.exchangeCode(ctx, code)
+	return p.exchangeCode(ctx, code, "", "")
 }
 
 func (p *remoteProviderWithOAuth) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
-	return p.refreshToken(ctx, refreshToken)
+	return p.refreshToken(ctx, refreshToken, "")
+}
+
+func (p *remoteProviderWithOAuth) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error) {
+	resolved := oauth.ResolveExchangeOptions(extraOpts...)
+	if verifier == "" {
+		verifier = resolved.Verifier
+	}
+	return p.exchangeCode(ctx, code, verifier, resolved.TokenURL)
+}
+
+func (p *remoteProviderWithOAuth) RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error) {
+	return p.refreshToken(ctx, refreshToken, tokenURL)
+}
+
+func (p *remoteProviderWithOAuth) AuthorizationBaseURL() string {
+	return p.metadata.GetAuthorizationBaseUrl()
+}
+
+func (p *remoteProviderWithOAuth) TokenURL() string {
+	return p.metadata.GetTokenUrl()
 }
 
 type remoteProviderWithSessionCatalog struct{ *remoteProviderBase }
@@ -215,37 +262,13 @@ func (p *remoteProviderWithPostConnect) PostConnectHook() core.PostConnectHook {
 	return p.postConnectHook()
 }
 
-type remoteProviderWithOAuthSessionCatalog struct{ *remoteProviderBase }
-
-func (p *remoteProviderWithOAuthSessionCatalog) AuthorizationURL(state string, scopes []string) string {
-	return p.authorizationURL(state, scopes)
-}
-
-func (p *remoteProviderWithOAuthSessionCatalog) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
-	return p.exchangeCode(ctx, code)
-}
-
-func (p *remoteProviderWithOAuthSessionCatalog) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
-	return p.refreshToken(ctx, refreshToken)
-}
+type remoteProviderWithOAuthSessionCatalog struct{ *remoteProviderWithOAuth }
 
 func (p *remoteProviderWithOAuthSessionCatalog) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
 	return p.sessionCatalog(ctx, token)
 }
 
-type remoteProviderWithOAuthPostConnect struct{ *remoteProviderBase }
-
-func (p *remoteProviderWithOAuthPostConnect) AuthorizationURL(state string, scopes []string) string {
-	return p.authorizationURL(state, scopes)
-}
-
-func (p *remoteProviderWithOAuthPostConnect) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
-	return p.exchangeCode(ctx, code)
-}
-
-func (p *remoteProviderWithOAuthPostConnect) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
-	return p.refreshToken(ctx, refreshToken)
-}
+type remoteProviderWithOAuthPostConnect struct{ *remoteProviderWithOAuth }
 
 func (p *remoteProviderWithOAuthPostConnect) PostConnectHook() core.PostConnectHook {
 	return p.postConnectHook()
@@ -261,19 +284,7 @@ func (p *remoteProviderWithSessionCatalogPostConnect) PostConnectHook() core.Pos
 	return p.postConnectHook()
 }
 
-type remoteProviderWithOAuthSessionCatalogPostConnect struct{ *remoteProviderBase }
-
-func (p *remoteProviderWithOAuthSessionCatalogPostConnect) AuthorizationURL(state string, scopes []string) string {
-	return p.authorizationURL(state, scopes)
-}
-
-func (p *remoteProviderWithOAuthSessionCatalogPostConnect) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
-	return p.exchangeCode(ctx, code)
-}
-
-func (p *remoteProviderWithOAuthSessionCatalogPostConnect) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
-	return p.refreshToken(ctx, refreshToken)
-}
+type remoteProviderWithOAuthSessionCatalogPostConnect struct{ *remoteProviderWithOAuth }
 
 func (p *remoteProviderWithOAuthSessionCatalogPostConnect) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
 	return p.sessionCatalog(ctx, token)

--- a/internal/pluginapi/provider_server.go
+++ b/internal/pluginapi/provider_server.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
+	"github.com/valon-technologies/gestalt/internal/oauth"
+	"github.com/valon-technologies/gestalt/internal/paraminterp"
 	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -48,6 +50,8 @@ func (s *ProviderServer) GetMetadata(_ context.Context, _ *emptypb.Empty) (*plug
 		StaticCatalogJson:      staticCatalog,
 		SupportsSessionCatalog: supportsSessionCatalog(s.provider),
 		SupportsPostConnect:    supportsPostConnect(s.provider),
+		AuthorizationBaseUrl:   authorizationBaseURLForProvider(s.provider),
+		TokenUrl:               tokenURLForProvider(s.provider),
 	}, nil
 }
 
@@ -77,9 +81,30 @@ func (s *ProviderServer) Execute(ctx context.Context, req *pluginapiv1.ExecuteRe
 }
 
 func (s *ProviderServer) AuthorizationURL(_ context.Context, req *pluginapiv1.AuthorizationURLRequest) (*pluginapiv1.AuthorizationURLResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
 	oauthProv, ok := s.provider.(core.OAuthProvider)
 	if !ok {
 		return nil, status.Error(codes.Unimplemented, "provider does not support OAuth")
+	}
+
+	authBaseURL := resolveAuthorizationBaseURL(s.provider, req.GetAuthBaseUrl(), req.GetConnectionParams())
+	if authBaseURL != "" {
+		if ov, ok := s.provider.(interface {
+			StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string)
+		}); ok {
+			url, verifier := ov.StartOAuthWithOverride(authBaseURL, req.GetState(), slices.Clone(req.GetScopes()))
+			return &pluginapiv1.AuthorizationURLResponse{Url: url, Verifier: verifier}, nil
+		}
+	}
+	if req.GetIncludeVerifier() {
+		if starter, ok := s.provider.(interface {
+			StartOAuth(state string, scopes []string) (string, string)
+		}); ok {
+			url, verifier := starter.StartOAuth(req.GetState(), slices.Clone(req.GetScopes()))
+			return &pluginapiv1.AuthorizationURLResponse{Url: url, Verifier: verifier}, nil
+		}
 	}
 	return &pluginapiv1.AuthorizationURLResponse{
 		Url: oauthProv.AuthorizationURL(req.GetState(), slices.Clone(req.GetScopes())),
@@ -87,11 +112,36 @@ func (s *ProviderServer) AuthorizationURL(_ context.Context, req *pluginapiv1.Au
 }
 
 func (s *ProviderServer) ExchangeCode(ctx context.Context, req *pluginapiv1.ExchangeCodeRequest) (*pluginapiv1.TokenResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
 	oauthProv, ok := s.provider.(core.OAuthProvider)
 	if !ok {
 		return nil, status.Error(codes.Unimplemented, "provider does not support OAuth")
 	}
-	resp, err := oauthProv.ExchangeCode(ctx, req.GetCode())
+	if len(req.GetConnectionParams()) > 0 {
+		ctx = core.WithConnectionParams(ctx, req.GetConnectionParams())
+	}
+
+	tokenURL := resolveTokenURL(s.provider, req.GetTokenUrl(), req.GetConnectionParams())
+
+	var resp *core.TokenResponse
+	var err error
+	if req.GetVerifier() != "" || tokenURL != "" {
+		if exchanger, ok := s.provider.(interface {
+			ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
+		}); ok {
+			var opts []oauth.ExchangeOption
+			if tokenURL != "" {
+				opts = append(opts, oauth.WithTokenURL(tokenURL))
+			}
+			resp, err = exchanger.ExchangeCodeWithVerifier(ctx, req.GetCode(), req.GetVerifier(), opts...)
+		} else {
+			resp, err = oauthProv.ExchangeCode(ctx, req.GetCode())
+		}
+	} else {
+		resp, err = oauthProv.ExchangeCode(ctx, req.GetCode())
+	}
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, "exchange code: %v", err)
 	}
@@ -103,11 +153,32 @@ func (s *ProviderServer) ExchangeCode(ctx context.Context, req *pluginapiv1.Exch
 }
 
 func (s *ProviderServer) RefreshToken(ctx context.Context, req *pluginapiv1.RefreshTokenRequest) (*pluginapiv1.TokenResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
 	oauthProv, ok := s.provider.(core.OAuthProvider)
 	if !ok {
 		return nil, status.Error(codes.Unimplemented, "provider does not support OAuth")
 	}
-	resp, err := oauthProv.RefreshToken(ctx, req.GetRefreshToken())
+	if len(req.GetConnectionParams()) > 0 {
+		ctx = core.WithConnectionParams(ctx, req.GetConnectionParams())
+	}
+
+	tokenURL := resolveTokenURL(s.provider, req.GetTokenUrl(), req.GetConnectionParams())
+
+	var resp *core.TokenResponse
+	var err error
+	if tokenURL != "" {
+		if refresher, ok := s.provider.(interface {
+			RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error)
+		}); ok {
+			resp, err = refresher.RefreshTokenWithURL(ctx, req.GetRefreshToken(), tokenURL)
+		} else {
+			resp, err = oauthProv.RefreshToken(ctx, req.GetRefreshToken())
+		}
+	} else {
+		resp, err = oauthProv.RefreshToken(ctx, req.GetRefreshToken())
+	}
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, "refresh token: %v", err)
 	}
@@ -192,4 +263,48 @@ func supportsSessionCatalog(prov core.Provider) bool {
 func supportsPostConnect(prov core.Provider) bool {
 	pcp, ok := prov.(core.PostConnectProvider)
 	return ok && pcp.PostConnectHook() != nil
+}
+
+func authorizationBaseURLForProvider(prov core.Provider) string {
+	if abu, ok := prov.(interface{ AuthorizationBaseURL() string }); ok {
+		return abu.AuthorizationBaseURL()
+	}
+	return ""
+}
+
+func tokenURLForProvider(prov core.Provider) string {
+	if tu, ok := prov.(interface{ TokenURL() string }); ok {
+		return tu.TokenURL()
+	}
+	return ""
+}
+
+func resolveAuthorizationBaseURL(prov core.Provider, explicit string, connParams map[string]string) string {
+	if explicit != "" {
+		return explicit
+	}
+	raw := authorizationBaseURLForProvider(prov)
+	if raw == "" || len(connParams) == 0 {
+		return ""
+	}
+	resolved := paraminterp.Interpolate(raw, connParams)
+	if resolved == raw {
+		return ""
+	}
+	return resolved
+}
+
+func resolveTokenURL(prov core.Provider, explicit string, connParams map[string]string) string {
+	if explicit != "" {
+		return explicit
+	}
+	raw := tokenURLForProvider(prov)
+	if raw == "" || len(connParams) == 0 {
+		return ""
+	}
+	resolved := paraminterp.Interpolate(raw, connParams)
+	if resolved == raw {
+		return ""
+	}
+	return resolved
 }

--- a/internal/pluginapi/provider_test.go
+++ b/internal/pluginapi/provider_test.go
@@ -9,13 +9,21 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
+	"github.com/valon-technologies/gestalt/internal/oauth"
 	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 )
 
-type roundTripProvider struct{}
+type roundTripProvider struct {
+	gotAuthBaseURL      string
+	gotExchangeVerifier string
+	gotExchangeTokenURL string
+	gotExchangeTenant   string
+	gotRefreshTokenURL  string
+	gotRefreshTenant    string
+}
 
 func (p *roundTripProvider) Name() string        { return "roundtrip" }
 func (p *roundTripProvider) DisplayName() string { return "Round Trip" }
@@ -48,6 +56,23 @@ func (p *roundTripProvider) AuthorizationURL(state string, scopes []string) stri
 	return fmt.Sprintf("https://example.com/oauth?state=%s&scope=%d", state, len(scopes))
 }
 
+func (p *roundTripProvider) StartOAuth(state string, scopes []string) (string, string) {
+	return fmt.Sprintf("https://default.example.com/oauth?state=%s&scope=%d", state, len(scopes)), "verifier:" + state
+}
+
+func (p *roundTripProvider) StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string) {
+	p.gotAuthBaseURL = authBaseURL
+	return fmt.Sprintf("%s?state=%s&scope=%d", authBaseURL, state, len(scopes)), "override-verifier:" + state
+}
+
+func (p *roundTripProvider) AuthorizationBaseURL() string {
+	return "https://{tenant}.example.com/oauth"
+}
+
+func (p *roundTripProvider) TokenURL() string {
+	return "https://{tenant}.example.com/token"
+}
+
 func (p *roundTripProvider) ExchangeCode(_ context.Context, code string) (*core.TokenResponse, error) {
 	return &core.TokenResponse{
 		AccessToken:  "access:" + code,
@@ -58,9 +83,31 @@ func (p *roundTripProvider) ExchangeCode(_ context.Context, code string) (*core.
 	}, nil
 }
 
+func (p *roundTripProvider) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error) {
+	resolved := oauth.ResolveExchangeOptions(extraOpts...)
+	p.gotExchangeVerifier = verifier
+	p.gotExchangeTokenURL = resolved.TokenURL
+	p.gotExchangeTenant = core.ConnectionParams(ctx)["tenant"]
+	return &core.TokenResponse{
+		AccessToken:  "access-with-verifier:" + code,
+		RefreshToken: "refresh-with-verifier:" + code,
+		TokenType:    "Bearer",
+		Extra:        map[string]any{"tenant": p.gotExchangeTenant},
+	}, nil
+}
+
 func (p *roundTripProvider) RefreshToken(_ context.Context, refreshToken string) (*core.TokenResponse, error) {
 	return &core.TokenResponse{
 		AccessToken: "fresh:" + refreshToken,
+		TokenType:   "Bearer",
+	}, nil
+}
+
+func (p *roundTripProvider) RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error) {
+	p.gotRefreshTokenURL = tokenURL
+	p.gotRefreshTenant = core.ConnectionParams(ctx)["tenant"]
+	return &core.TokenResponse{
+		AccessToken: "fresh-with-url:" + refreshToken,
 		TokenType:   "Bearer",
 	}, nil
 }
@@ -109,7 +156,8 @@ func (p *roundTripProvider) AuthTypes() []string {
 func TestRemoteProviderRoundTrip(t *testing.T) {
 	t.Parallel()
 
-	client := newProviderTestClient(t, &roundTripProvider{})
+	backing := &roundTripProvider{}
+	client := newProviderTestClient(t, backing)
 	prov, err := NewRemoteProvider(context.Background(), client)
 	if err != nil {
 		t.Fatalf("NewRemoteProvider: %v", err)
@@ -146,6 +194,32 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 	if _, ok := prov.(core.AuthTypeLister); !ok {
 		t.Fatal("expected remote provider to implement AuthTypeLister")
 	}
+	if _, ok := prov.(interface {
+		StartOAuth(state string, scopes []string) (string, string)
+	}); !ok {
+		t.Fatal("expected remote provider to implement PKCE-aware StartOAuth")
+	}
+	if _, ok := prov.(interface {
+		StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string)
+	}); !ok {
+		t.Fatal("expected remote provider to implement StartOAuthWithOverride")
+	}
+	if _, ok := prov.(interface{ AuthorizationBaseURL() string }); !ok {
+		t.Fatal("expected remote provider to expose AuthorizationBaseURL")
+	}
+	if _, ok := prov.(interface{ TokenURL() string }); !ok {
+		t.Fatal("expected remote provider to expose TokenURL")
+	}
+	if _, ok := prov.(interface {
+		ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
+	}); !ok {
+		t.Fatal("expected remote provider to implement ExchangeCodeWithVerifier")
+	}
+	if _, ok := prov.(interface {
+		RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error)
+	}); !ok {
+		t.Fatal("expected remote provider to implement RefreshTokenWithURL")
+	}
 
 	ctx := core.WithConnectionParams(context.Background(), map[string]string{"tenant": "acme"})
 	result, err := prov.Execute(ctx, "echo", map[string]any{"message": "hi"}, "secret-token")
@@ -166,6 +240,54 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 	}
 	if tok.AccessToken != "access:abc" || tok.RefreshToken != "refresh:abc" || tok.Extra["tenant"] != "acme" {
 		t.Fatalf("unexpected exchange token response: %+v", tok)
+	}
+
+	starter := prov.(interface {
+		StartOAuth(state string, scopes []string) (string, string)
+	})
+	startURL, verifier := starter.StartOAuth("state-456", []string{"read"})
+	if startURL != "https://default.example.com/oauth?state=state-456&scope=1" || verifier != "verifier:state-456" {
+		t.Fatalf("unexpected start oauth response: url=%q verifier=%q", startURL, verifier)
+	}
+
+	overrider := prov.(interface {
+		StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string)
+	})
+	overrideURL, overrideVerifier := overrider.StartOAuthWithOverride("https://acme.example.com/oauth", "state-789", []string{"read", "write"})
+	if overrideURL != "https://acme.example.com/oauth?state=state-789&scope=2" || overrideVerifier != "override-verifier:state-789" {
+		t.Fatalf("unexpected override oauth response: url=%q verifier=%q", overrideURL, overrideVerifier)
+	}
+	if backing.gotAuthBaseURL != "https://acme.example.com/oauth" {
+		t.Fatalf("got auth base override %q, want override URL", backing.gotAuthBaseURL)
+	}
+
+	if got := prov.(interface{ AuthorizationBaseURL() string }).AuthorizationBaseURL(); got != "https://{tenant}.example.com/oauth" {
+		t.Fatalf("unexpected authorization base URL: %q", got)
+	}
+	if got := prov.(interface{ TokenURL() string }).TokenURL(); got != "https://{tenant}.example.com/token" {
+		t.Fatalf("unexpected token URL: %q", got)
+	}
+
+	verifierExchanger := prov.(interface {
+		ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
+	})
+	advancedTok, err := verifierExchanger.ExchangeCodeWithVerifier(ctx, "code-123", "pkce-123", oauth.WithTokenURL("https://acme.example.com/token"))
+	if err != nil {
+		t.Fatalf("ExchangeCodeWithVerifier: %v", err)
+	}
+	if advancedTok.AccessToken != "access-with-verifier:code-123" || backing.gotExchangeVerifier != "pkce-123" || backing.gotExchangeTokenURL != "https://acme.example.com/token" || backing.gotExchangeTenant != "acme" {
+		t.Fatalf("unexpected advanced exchange result: token=%+v verifier=%q tokenURL=%q tenant=%q", advancedTok, backing.gotExchangeVerifier, backing.gotExchangeTokenURL, backing.gotExchangeTenant)
+	}
+
+	urlRefresher := prov.(interface {
+		RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error)
+	})
+	refreshed, err := urlRefresher.RefreshTokenWithURL(ctx, "refresh-123", "https://acme.example.com/token")
+	if err != nil {
+		t.Fatalf("RefreshTokenWithURL: %v", err)
+	}
+	if refreshed.AccessToken != "fresh-with-url:refresh-123" || backing.gotRefreshTokenURL != "https://acme.example.com/token" || backing.gotRefreshTenant != "acme" {
+		t.Fatalf("unexpected advanced refresh result: token=%+v tokenURL=%q tenant=%q", refreshed, backing.gotRefreshTokenURL, backing.gotRefreshTenant)
 	}
 
 	cp := prov.(core.CatalogProvider)

--- a/internal/pluginapi/provider_test.go
+++ b/internal/pluginapi/provider_test.go
@@ -9,21 +9,13 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
-	"github.com/valon-technologies/gestalt/internal/oauth"
 	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 )
 
-type roundTripProvider struct {
-	gotAuthBaseURL      string
-	gotExchangeVerifier string
-	gotExchangeTokenURL string
-	gotExchangeTenant   string
-	gotRefreshTokenURL  string
-	gotRefreshTenant    string
-}
+type roundTripProvider struct{}
 
 func (p *roundTripProvider) Name() string        { return "roundtrip" }
 func (p *roundTripProvider) DisplayName() string { return "Round Trip" }
@@ -56,23 +48,6 @@ func (p *roundTripProvider) AuthorizationURL(state string, scopes []string) stri
 	return fmt.Sprintf("https://example.com/oauth?state=%s&scope=%d", state, len(scopes))
 }
 
-func (p *roundTripProvider) StartOAuth(state string, scopes []string) (string, string) {
-	return fmt.Sprintf("https://default.example.com/oauth?state=%s&scope=%d", state, len(scopes)), "verifier:" + state
-}
-
-func (p *roundTripProvider) StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string) {
-	p.gotAuthBaseURL = authBaseURL
-	return fmt.Sprintf("%s?state=%s&scope=%d", authBaseURL, state, len(scopes)), "override-verifier:" + state
-}
-
-func (p *roundTripProvider) AuthorizationBaseURL() string {
-	return "https://{tenant}.example.com/oauth"
-}
-
-func (p *roundTripProvider) TokenURL() string {
-	return "https://{tenant}.example.com/token"
-}
-
 func (p *roundTripProvider) ExchangeCode(_ context.Context, code string) (*core.TokenResponse, error) {
 	return &core.TokenResponse{
 		AccessToken:  "access:" + code,
@@ -83,31 +58,9 @@ func (p *roundTripProvider) ExchangeCode(_ context.Context, code string) (*core.
 	}, nil
 }
 
-func (p *roundTripProvider) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error) {
-	resolved := oauth.ResolveExchangeOptions(extraOpts...)
-	p.gotExchangeVerifier = verifier
-	p.gotExchangeTokenURL = resolved.TokenURL
-	p.gotExchangeTenant = core.ConnectionParams(ctx)["tenant"]
-	return &core.TokenResponse{
-		AccessToken:  "access-with-verifier:" + code,
-		RefreshToken: "refresh-with-verifier:" + code,
-		TokenType:    "Bearer",
-		Extra:        map[string]any{"tenant": p.gotExchangeTenant},
-	}, nil
-}
-
 func (p *roundTripProvider) RefreshToken(_ context.Context, refreshToken string) (*core.TokenResponse, error) {
 	return &core.TokenResponse{
 		AccessToken: "fresh:" + refreshToken,
-		TokenType:   "Bearer",
-	}, nil
-}
-
-func (p *roundTripProvider) RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error) {
-	p.gotRefreshTokenURL = tokenURL
-	p.gotRefreshTenant = core.ConnectionParams(ctx)["tenant"]
-	return &core.TokenResponse{
-		AccessToken: "fresh-with-url:" + refreshToken,
 		TokenType:   "Bearer",
 	}, nil
 }
@@ -156,8 +109,7 @@ func (p *roundTripProvider) AuthTypes() []string {
 func TestRemoteProviderRoundTrip(t *testing.T) {
 	t.Parallel()
 
-	backing := &roundTripProvider{}
-	client := newProviderTestClient(t, backing)
+	client := newProviderTestClient(t, &roundTripProvider{})
 	prov, err := NewRemoteProvider(context.Background(), client)
 	if err != nil {
 		t.Fatalf("NewRemoteProvider: %v", err)
@@ -194,32 +146,6 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 	if _, ok := prov.(core.AuthTypeLister); !ok {
 		t.Fatal("expected remote provider to implement AuthTypeLister")
 	}
-	if _, ok := prov.(interface {
-		StartOAuth(state string, scopes []string) (string, string)
-	}); !ok {
-		t.Fatal("expected remote provider to implement PKCE-aware StartOAuth")
-	}
-	if _, ok := prov.(interface {
-		StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string)
-	}); !ok {
-		t.Fatal("expected remote provider to implement StartOAuthWithOverride")
-	}
-	if _, ok := prov.(interface{ AuthorizationBaseURL() string }); !ok {
-		t.Fatal("expected remote provider to expose AuthorizationBaseURL")
-	}
-	if _, ok := prov.(interface{ TokenURL() string }); !ok {
-		t.Fatal("expected remote provider to expose TokenURL")
-	}
-	if _, ok := prov.(interface {
-		ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
-	}); !ok {
-		t.Fatal("expected remote provider to implement ExchangeCodeWithVerifier")
-	}
-	if _, ok := prov.(interface {
-		RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error)
-	}); !ok {
-		t.Fatal("expected remote provider to implement RefreshTokenWithURL")
-	}
 
 	ctx := core.WithConnectionParams(context.Background(), map[string]string{"tenant": "acme"})
 	result, err := prov.Execute(ctx, "echo", map[string]any{"message": "hi"}, "secret-token")
@@ -240,54 +166,6 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 	}
 	if tok.AccessToken != "access:abc" || tok.RefreshToken != "refresh:abc" || tok.Extra["tenant"] != "acme" {
 		t.Fatalf("unexpected exchange token response: %+v", tok)
-	}
-
-	starter := prov.(interface {
-		StartOAuth(state string, scopes []string) (string, string)
-	})
-	startURL, verifier := starter.StartOAuth("state-456", []string{"read"})
-	if startURL != "https://default.example.com/oauth?state=state-456&scope=1" || verifier != "verifier:state-456" {
-		t.Fatalf("unexpected start oauth response: url=%q verifier=%q", startURL, verifier)
-	}
-
-	overrider := prov.(interface {
-		StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string)
-	})
-	overrideURL, overrideVerifier := overrider.StartOAuthWithOverride("https://acme.example.com/oauth", "state-789", []string{"read", "write"})
-	if overrideURL != "https://acme.example.com/oauth?state=state-789&scope=2" || overrideVerifier != "override-verifier:state-789" {
-		t.Fatalf("unexpected override oauth response: url=%q verifier=%q", overrideURL, overrideVerifier)
-	}
-	if backing.gotAuthBaseURL != "https://acme.example.com/oauth" {
-		t.Fatalf("got auth base override %q, want override URL", backing.gotAuthBaseURL)
-	}
-
-	if got := prov.(interface{ AuthorizationBaseURL() string }).AuthorizationBaseURL(); got != "https://{tenant}.example.com/oauth" {
-		t.Fatalf("unexpected authorization base URL: %q", got)
-	}
-	if got := prov.(interface{ TokenURL() string }).TokenURL(); got != "https://{tenant}.example.com/token" {
-		t.Fatalf("unexpected token URL: %q", got)
-	}
-
-	verifierExchanger := prov.(interface {
-		ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
-	})
-	advancedTok, err := verifierExchanger.ExchangeCodeWithVerifier(ctx, "code-123", "pkce-123", oauth.WithTokenURL("https://acme.example.com/token"))
-	if err != nil {
-		t.Fatalf("ExchangeCodeWithVerifier: %v", err)
-	}
-	if advancedTok.AccessToken != "access-with-verifier:code-123" || backing.gotExchangeVerifier != "pkce-123" || backing.gotExchangeTokenURL != "https://acme.example.com/token" || backing.gotExchangeTenant != "acme" {
-		t.Fatalf("unexpected advanced exchange result: token=%+v verifier=%q tokenURL=%q tenant=%q", advancedTok, backing.gotExchangeVerifier, backing.gotExchangeTokenURL, backing.gotExchangeTenant)
-	}
-
-	urlRefresher := prov.(interface {
-		RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error)
-	})
-	refreshed, err := urlRefresher.RefreshTokenWithURL(ctx, "refresh-123", "https://acme.example.com/token")
-	if err != nil {
-		t.Fatalf("RefreshTokenWithURL: %v", err)
-	}
-	if refreshed.AccessToken != "fresh-with-url:refresh-123" || backing.gotRefreshTokenURL != "https://acme.example.com/token" || backing.gotRefreshTenant != "acme" {
-		t.Fatalf("unexpected advanced refresh result: token=%+v tokenURL=%q tenant=%q", refreshed, backing.gotRefreshTokenURL, backing.gotRefreshTenant)
 	}
 
 	cp := prov.(core.CatalogProvider)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -632,13 +632,17 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	}
 
 	var tokenResp *core.TokenResponse
+	exchangeCtx := r.Context()
+	if len(connParams) > 0 {
+		exchangeCtx = core.WithConnectionParams(exchangeCtx, connParams)
+	}
 	if exchanger, ok := prov.(oauthVerifierExchanger); ok {
-		tokenResp, err = exchanger.ExchangeCodeWithVerifier(r.Context(), code, state.Verifier, exchangeOpts...)
+		tokenResp, err = exchanger.ExchangeCodeWithVerifier(exchangeCtx, code, state.Verifier, exchangeOpts...)
 	} else {
 		if len(exchangeOpts) > 0 {
 			log.Printf("WARNING: %s does not support exchange options (e.g. token URL override); connection params may not apply to token exchange", providerName)
 		}
-		tokenResp, err = oauthProv.ExchangeCode(r.Context(), code)
+		tokenResp, err = oauthProv.ExchangeCode(exchangeCtx, code)
 	}
 	if err != nil {
 		log.Printf("token exchange failed for %s: %v", providerName, err)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1623,6 +1623,26 @@ func (s *stubPKCEIntegration) ExchangeCodeWithVerifier(_ context.Context, code, 
 	return &core.TokenResponse{AccessToken: "pkce-token"}, nil
 }
 
+type stubPKCEConnParamIntegration struct {
+	stubPKCEIntegration
+	gotConnParam string
+}
+
+func (s *stubPKCEConnParamIntegration) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return map[string]core.ConnectionParamDef{
+		"org": {Required: true, Description: "Organization slug"},
+	}
+}
+
+func (s *stubPKCEConnParamIntegration) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, _ ...oauth.ExchangeOption) (*core.TokenResponse, error) {
+	s.gotVerifier = verifier
+	s.gotConnParam = core.ConnectionParams(ctx)["org"]
+	if code != "good-code" {
+		return nil, fmt.Errorf("bad code")
+	}
+	return &core.TokenResponse{AccessToken: "pkce-token"}, nil
+}
+
 func TestIntegrationOAuthCallback_PKCEUsesVerifier(t *testing.T) {
 	t.Parallel()
 
@@ -1679,6 +1699,67 @@ func TestIntegrationOAuthCallback_PKCEUsesVerifier(t *testing.T) {
 	}
 	if stub.gotVerifier != stub.wantVerifier {
 		t.Fatalf("got verifier %q, want %q", stub.gotVerifier, stub.wantVerifier)
+	}
+}
+
+func TestIntegrationOAuthCallback_AttachesConnectionParamsToExchangeContext(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubPKCEConnParamIntegration{
+		stubPKCEIntegration: stubPKCEIntegration{
+			StubIntegration: coretesting.StubIntegration{N: "gitlab"},
+			authURL:         "https://gitlab.com/oauth/authorize",
+			wantVerifier:    "verifier-123",
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	startBody := bytes.NewBufferString(`{"integration":"gitlab","connection_params":{"org":"acme"}}`)
+	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
+	startReq.Header.Set("X-Dev-User-Email", "dev@example.com")
+	startReq.Header.Set("Content-Type", "application/json")
+	startResp, err := http.DefaultClient.Do(startReq)
+	if err != nil {
+		t.Fatalf("start request: %v", err)
+	}
+	defer func() { _ = startResp.Body.Close() }()
+
+	if startResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from start-oauth, got %d", startResp.StatusCode)
+	}
+
+	var startResult map[string]string
+	if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
+		t.Fatalf("decoding start response: %v", err)
+	}
+
+	noRedirect := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
+	resp, err := noRedirect.Do(req)
+	if err != nil {
+		t.Fatalf("callback request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", resp.StatusCode)
+	}
+	if stub.gotConnParam != "acme" {
+		t.Fatalf("got connection param %q, want acme", stub.gotConnParam)
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	gestaltmcp "github.com/valon-technologies/gestalt/internal/mcp"
 	"github.com/valon-technologies/gestalt/internal/oauth"
+	"github.com/valon-technologies/gestalt/internal/pluginapi"
 	"github.com/valon-technologies/gestalt/internal/principal"
 	"github.com/valon-technologies/gestalt/internal/provider"
 	"github.com/valon-technologies/gestalt/internal/registry"
@@ -1760,6 +1761,91 @@ func TestIntegrationOAuthCallback_AttachesConnectionParamsToExchangeContext(t *t
 	}
 	if stub.gotConnParam != "acme" {
 		t.Fatalf("got connection param %q, want acme", stub.gotConnParam)
+	}
+}
+
+func TestIntegrationOAuthCallback_ExecutableProviderUsesPKCEAndOverrides(t *testing.T) {
+	t.Parallel()
+
+	bin := testutil.BuildGoBinary(t, "./internal/testdata/oauthplugin", "gestalt-plugin-oauth-fixture")
+	prov, err := pluginapi.NewExecutableProvider(context.Background(), pluginapi.ExecConfig{Command: bin})
+	if err != nil {
+		t.Fatalf("NewExecutableProvider: %v", err)
+	}
+	if c, ok := prov.(interface{ Close() error }); ok {
+		t.Cleanup(func() { _ = c.Close() })
+	}
+
+	var storedTokens []*core.IntegrationToken
+	ds := &coretesting.StubDatastore{
+		FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+			return &core.User{ID: "u1", Email: email}, nil
+		},
+		StoreTokenFn: func(_ context.Context, tok *core.IntegrationToken) error {
+			storedTokens = append(storedTokens, tok)
+			return nil
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, prov)
+		cfg.Datastore = ds
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	startBody := bytes.NewBufferString(`{"integration":"exec-oauth","connection_params":{"tenant":"acme"}}`)
+	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
+	startReq.Header.Set("X-Dev-User-Email", "dev@example.com")
+	startReq.Header.Set("Content-Type", "application/json")
+	startResp, err := http.DefaultClient.Do(startReq)
+	if err != nil {
+		t.Fatalf("start request: %v", err)
+	}
+	defer func() { _ = startResp.Body.Close() }()
+
+	if startResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(startResp.Body)
+		t.Fatalf("expected 200 from start-oauth, got %d: %s", startResp.StatusCode, body)
+	}
+
+	var startResult map[string]string
+	if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
+		t.Fatalf("decoding start response: %v", err)
+	}
+	if !strings.Contains(startResult["url"], "https://acme.example.com/oauth") {
+		t.Fatalf("start url = %q, want tenant-specific auth base", startResult["url"])
+	}
+
+	noRedirect := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
+	resp, err := noRedirect.Do(req)
+	if err != nil {
+		t.Fatalf("callback request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusSeeOther {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 303, got %d: %s", resp.StatusCode, body)
+	}
+	if len(storedTokens) == 0 {
+		t.Fatal("expected token to be stored")
+	}
+
+	lastTok := storedTokens[len(storedTokens)-1]
+	if lastTok.AccessToken != "access:good-code|acme|fixture-verifier|https://acme.example.com/token" {
+		t.Fatalf("stored access token = %q", lastTok.AccessToken)
+	}
+	if lastTok.RefreshToken != "refresh:acme" {
+		t.Fatalf("stored refresh token = %q", lastTok.RefreshToken)
+	}
+	if !strings.Contains(lastTok.MetadataJSON, `"tenant":"acme"`) {
+		t.Fatalf("expected MetadataJSON to contain tenant=acme, got %s", lastTok.MetadataJSON)
 	}
 }
 

--- a/internal/testdata/oauthplugin/main.go
+++ b/internal/testdata/oauthplugin/main.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/url"
+	"os/signal"
+	"syscall"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/oauth"
+	"github.com/valon-technologies/gestalt/internal/pluginapi"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if err := pluginapi.ServeProvider(ctx, &oauthFixtureProvider{}); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type oauthFixtureProvider struct{}
+
+func (p *oauthFixtureProvider) Name() string        { return "exec-oauth" }
+func (p *oauthFixtureProvider) DisplayName() string { return "Executable OAuth Fixture" }
+func (p *oauthFixtureProvider) Description() string { return "Test-only executable OAuth provider" }
+func (p *oauthFixtureProvider) ConnectionMode() core.ConnectionMode {
+	return core.ConnectionModeUser
+}
+
+func (p *oauthFixtureProvider) ListOperations() []core.Operation {
+	return []core.Operation{{
+		Name:        "echo_token",
+		Description: "Echo the token used for invocation",
+		Method:      "GET",
+	}}
+}
+
+func (p *oauthFixtureProvider) Execute(ctx context.Context, _ string, _ map[string]any, token string) (*core.OperationResult, error) {
+	body, err := json.Marshal(map[string]string{
+		"token":  token,
+		"tenant": core.ConnectionParams(ctx)["tenant"],
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &core.OperationResult{Status: 200, Body: string(body)}, nil
+}
+
+func (p *oauthFixtureProvider) AuthorizationURL(state string, scopes []string) string {
+	return fmt.Sprintf("https://default.example.com/oauth?state=%s&scope=%d", url.QueryEscape(state), len(scopes))
+}
+
+func (p *oauthFixtureProvider) StartOAuth(state string, scopes []string) (string, string) {
+	return p.AuthorizationURL(state, scopes), "fixture-verifier"
+}
+
+func (p *oauthFixtureProvider) AuthorizationBaseURL() string {
+	return "https://{tenant}.example.com/oauth"
+}
+
+func (p *oauthFixtureProvider) StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string) {
+	return fmt.Sprintf("%s?state=%s&scope=%d", authBaseURL, url.QueryEscape(state), len(scopes)), "fixture-verifier"
+}
+
+func (p *oauthFixtureProvider) TokenURL() string {
+	return "https://{tenant}.example.com/token"
+}
+
+func (p *oauthFixtureProvider) ExchangeCode(_ context.Context, code string) (*core.TokenResponse, error) {
+	return &core.TokenResponse{
+		AccessToken:  "access:" + code,
+		RefreshToken: "refresh:" + code,
+		TokenType:    "Bearer",
+	}, nil
+}
+
+func (p *oauthFixtureProvider) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error) {
+	opts := oauth.ResolveExchangeOptions(extraOpts...)
+	tenant := core.ConnectionParams(ctx)["tenant"]
+	return &core.TokenResponse{
+		AccessToken:  fmt.Sprintf("access:%s|%s|%s|%s", code, tenant, verifier, opts.TokenURL),
+		RefreshToken: "refresh:" + tenant,
+		TokenType:    "Bearer",
+	}, nil
+}
+
+func (p *oauthFixtureProvider) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	tenant := core.ConnectionParams(ctx)["tenant"]
+	return &core.TokenResponse{
+		AccessToken: fmt.Sprintf("fresh:%s|%s", tenant, refreshToken),
+		TokenType:   "Bearer",
+	}, nil
+}
+
+func (p *oauthFixtureProvider) RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error) {
+	tenant := core.ConnectionParams(ctx)["tenant"]
+	return &core.TokenResponse{
+		AccessToken: fmt.Sprintf("fresh:%s|%s|%s", tenant, refreshToken, tokenURL),
+		TokenType:   "Bearer",
+	}, nil
+}
+
+func (p *oauthFixtureProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return map[string]core.ConnectionParamDef{
+		"tenant": {Required: true, Description: "Tenant slug"},
+	}
+}

--- a/internal/testutil/build.go
+++ b/internal/testutil/build.go
@@ -1,0 +1,30 @@
+package testutil
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// BuildGoBinary builds the given package from the repository root into a temp binary.
+func BuildGoBinary(t *testing.T, pkgPath, binName string) string {
+	t.Helper()
+
+	bin := filepath.Join(t.TempDir(), binName)
+	cmd := exec.Command("go", "build", "-o", bin, pkgPath)
+	cmd.Dir = repoRoot(t)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build %s: %v\n%s", pkgPath, err, out)
+	}
+	return bin
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}

--- a/sdk/pluginapi/v1/plugin.pb.go
+++ b/sdk/pluginapi/v1/plugin.pb.go
@@ -550,6 +550,8 @@ type ProviderMetadata struct {
 	StaticCatalogJson      string                         `protobuf:"bytes,7,opt,name=static_catalog_json,json=staticCatalogJson,proto3" json:"static_catalog_json,omitempty"`
 	SupportsSessionCatalog bool                           `protobuf:"varint,8,opt,name=supports_session_catalog,json=supportsSessionCatalog,proto3" json:"supports_session_catalog,omitempty"`
 	SupportsPostConnect    bool                           `protobuf:"varint,9,opt,name=supports_post_connect,json=supportsPostConnect,proto3" json:"supports_post_connect,omitempty"`
+	AuthorizationBaseUrl   string                         `protobuf:"bytes,10,opt,name=authorization_base_url,json=authorizationBaseUrl,proto3" json:"authorization_base_url,omitempty"`
+	TokenUrl               string                         `protobuf:"bytes,11,opt,name=token_url,json=tokenUrl,proto3" json:"token_url,omitempty"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -645,6 +647,20 @@ func (x *ProviderMetadata) GetSupportsPostConnect() bool {
 		return x.SupportsPostConnect
 	}
 	return false
+}
+
+func (x *ProviderMetadata) GetAuthorizationBaseUrl() string {
+	if x != nil {
+		return x.AuthorizationBaseUrl
+	}
+	return ""
+}
+
+func (x *ProviderMetadata) GetTokenUrl() string {
+	if x != nil {
+		return x.TokenUrl
+	}
+	return ""
 }
 
 type TokenResponse struct {
@@ -1028,11 +1044,14 @@ func (x *ExecuteRequest) GetConnectionParams() map[string]string {
 }
 
 type AuthorizationURLRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	State         string                 `protobuf:"bytes,1,opt,name=state,proto3" json:"state,omitempty"`
-	Scopes        []string               `protobuf:"bytes,2,rep,name=scopes,proto3" json:"scopes,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	State            string                 `protobuf:"bytes,1,opt,name=state,proto3" json:"state,omitempty"`
+	Scopes           []string               `protobuf:"bytes,2,rep,name=scopes,proto3" json:"scopes,omitempty"`
+	ConnectionParams map[string]string      `protobuf:"bytes,3,rep,name=connection_params,json=connectionParams,proto3" json:"connection_params,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	AuthBaseUrl      string                 `protobuf:"bytes,4,opt,name=auth_base_url,json=authBaseUrl,proto3" json:"auth_base_url,omitempty"`
+	IncludeVerifier  bool                   `protobuf:"varint,5,opt,name=include_verifier,json=includeVerifier,proto3" json:"include_verifier,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *AuthorizationURLRequest) Reset() {
@@ -1079,9 +1098,31 @@ func (x *AuthorizationURLRequest) GetScopes() []string {
 	return nil
 }
 
+func (x *AuthorizationURLRequest) GetConnectionParams() map[string]string {
+	if x != nil {
+		return x.ConnectionParams
+	}
+	return nil
+}
+
+func (x *AuthorizationURLRequest) GetAuthBaseUrl() string {
+	if x != nil {
+		return x.AuthBaseUrl
+	}
+	return ""
+}
+
+func (x *AuthorizationURLRequest) GetIncludeVerifier() bool {
+	if x != nil {
+		return x.IncludeVerifier
+	}
+	return false
+}
+
 type AuthorizationURLResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Url           string                 `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
+	Verifier      string                 `protobuf:"bytes,2,opt,name=verifier,proto3" json:"verifier,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1123,11 +1164,21 @@ func (x *AuthorizationURLResponse) GetUrl() string {
 	return ""
 }
 
+func (x *AuthorizationURLResponse) GetVerifier() string {
+	if x != nil {
+		return x.Verifier
+	}
+	return ""
+}
+
 type ExchangeCodeRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Code          string                 `protobuf:"bytes,1,opt,name=code,proto3" json:"code,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	Code             string                 `protobuf:"bytes,1,opt,name=code,proto3" json:"code,omitempty"`
+	Verifier         string                 `protobuf:"bytes,2,opt,name=verifier,proto3" json:"verifier,omitempty"`
+	TokenUrl         string                 `protobuf:"bytes,3,opt,name=token_url,json=tokenUrl,proto3" json:"token_url,omitempty"`
+	ConnectionParams map[string]string      `protobuf:"bytes,4,rep,name=connection_params,json=connectionParams,proto3" json:"connection_params,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *ExchangeCodeRequest) Reset() {
@@ -1167,11 +1218,34 @@ func (x *ExchangeCodeRequest) GetCode() string {
 	return ""
 }
 
+func (x *ExchangeCodeRequest) GetVerifier() string {
+	if x != nil {
+		return x.Verifier
+	}
+	return ""
+}
+
+func (x *ExchangeCodeRequest) GetTokenUrl() string {
+	if x != nil {
+		return x.TokenUrl
+	}
+	return ""
+}
+
+func (x *ExchangeCodeRequest) GetConnectionParams() map[string]string {
+	if x != nil {
+		return x.ConnectionParams
+	}
+	return nil
+}
+
 type RefreshTokenRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	RefreshToken  string                 `protobuf:"bytes,1,opt,name=refresh_token,json=refreshToken,proto3" json:"refresh_token,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	RefreshToken     string                 `protobuf:"bytes,1,opt,name=refresh_token,json=refreshToken,proto3" json:"refresh_token,omitempty"`
+	TokenUrl         string                 `protobuf:"bytes,2,opt,name=token_url,json=tokenUrl,proto3" json:"token_url,omitempty"`
+	ConnectionParams map[string]string      `protobuf:"bytes,3,rep,name=connection_params,json=connectionParams,proto3" json:"connection_params,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *RefreshTokenRequest) Reset() {
@@ -1209,6 +1283,20 @@ func (x *RefreshTokenRequest) GetRefreshToken() string {
 		return x.RefreshToken
 	}
 	return ""
+}
+
+func (x *RefreshTokenRequest) GetTokenUrl() string {
+	if x != nil {
+		return x.TokenUrl
+	}
+	return ""
+}
+
+func (x *RefreshTokenRequest) GetConnectionParams() map[string]string {
+	if x != nil {
+		return x.ConnectionParams
+	}
+	return nil
 }
 
 type GetSessionCatalogRequest struct {
@@ -1615,7 +1703,7 @@ const file_sdk_pluginapi_v1_plugin_proto_rawDesc = "" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12#\n" +
 	"\rdefault_value\x18\x03 \x01(\tR\fdefaultValue\x12\x12\n" +
 	"\x04from\x18\x04 \x01(\tR\x04from\x12\x14\n" +
-	"\x05field\x18\x05 \x01(\tR\x05field\"\xc8\x04\n" +
+	"\x05field\x18\x05 \x01(\tR\x05field\"\x9b\x05\n" +
 	"\x10ProviderMetadata\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12!\n" +
 	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x12 \n" +
@@ -1626,7 +1714,10 @@ const file_sdk_pluginapi_v1_plugin_proto_rawDesc = "" +
 	"\x11connection_params\x18\x06 \x03(\v29.gestalt.plugin.v1.ProviderMetadata.ConnectionParamsEntryR\x10connectionParams\x12.\n" +
 	"\x13static_catalog_json\x18\a \x01(\tR\x11staticCatalogJson\x128\n" +
 	"\x18supports_session_catalog\x18\b \x01(\bR\x16supportsSessionCatalog\x122\n" +
-	"\x15supports_post_connect\x18\t \x01(\bR\x13supportsPostConnect\x1aj\n" +
+	"\x15supports_post_connect\x18\t \x01(\bR\x13supportsPostConnect\x124\n" +
+	"\x16authorization_base_url\x18\n" +
+	" \x01(\tR\x14authorizationBaseUrl\x12\x1b\n" +
+	"\ttoken_url\x18\v \x01(\tR\btokenUrl\x1aj\n" +
 	"\x15ConnectionParamsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12;\n" +
 	"\x05value\x18\x02 \x01(\v2%.gestalt.plugin.v1.ConnectionParamDefR\x05value:\x028\x01\"\xc4\x01\n" +
@@ -1670,16 +1761,34 @@ const file_sdk_pluginapi_v1_plugin_proto_rawDesc = "" +
 	"\x11connection_params\x18\x04 \x03(\v27.gestalt.plugin.v1.ExecuteRequest.ConnectionParamsEntryR\x10connectionParams\x1aC\n" +
 	"\x15ConnectionParamsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"G\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xca\x02\n" +
 	"\x17AuthorizationURLRequest\x12\x14\n" +
 	"\x05state\x18\x01 \x01(\tR\x05state\x12\x16\n" +
-	"\x06scopes\x18\x02 \x03(\tR\x06scopes\",\n" +
+	"\x06scopes\x18\x02 \x03(\tR\x06scopes\x12m\n" +
+	"\x11connection_params\x18\x03 \x03(\v2@.gestalt.plugin.v1.AuthorizationURLRequest.ConnectionParamsEntryR\x10connectionParams\x12\"\n" +
+	"\rauth_base_url\x18\x04 \x01(\tR\vauthBaseUrl\x12)\n" +
+	"\x10include_verifier\x18\x05 \x01(\bR\x0fincludeVerifier\x1aC\n" +
+	"\x15ConnectionParamsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"H\n" +
 	"\x18AuthorizationURLResponse\x12\x10\n" +
-	"\x03url\x18\x01 \x01(\tR\x03url\")\n" +
+	"\x03url\x18\x01 \x01(\tR\x03url\x12\x1a\n" +
+	"\bverifier\x18\x02 \x01(\tR\bverifier\"\x92\x02\n" +
 	"\x13ExchangeCodeRequest\x12\x12\n" +
-	"\x04code\x18\x01 \x01(\tR\x04code\":\n" +
+	"\x04code\x18\x01 \x01(\tR\x04code\x12\x1a\n" +
+	"\bverifier\x18\x02 \x01(\tR\bverifier\x12\x1b\n" +
+	"\ttoken_url\x18\x03 \x01(\tR\btokenUrl\x12i\n" +
+	"\x11connection_params\x18\x04 \x03(\v2<.gestalt.plugin.v1.ExchangeCodeRequest.ConnectionParamsEntryR\x10connectionParams\x1aC\n" +
+	"\x15ConnectionParamsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x87\x02\n" +
 	"\x13RefreshTokenRequest\x12#\n" +
-	"\rrefresh_token\x18\x01 \x01(\tR\frefreshToken\"\xe5\x01\n" +
+	"\rrefresh_token\x18\x01 \x01(\tR\frefreshToken\x12\x1b\n" +
+	"\ttoken_url\x18\x02 \x01(\tR\btokenUrl\x12i\n" +
+	"\x11connection_params\x18\x03 \x03(\v2<.gestalt.plugin.v1.RefreshTokenRequest.ConnectionParamsEntryR\x10connectionParams\x1aC\n" +
+	"\x15ConnectionParamsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xe5\x01\n" +
 	"\x18GetSessionCatalogRequest\x12\x14\n" +
 	"\x05token\x18\x01 \x01(\tR\x05token\x12n\n" +
 	"\x11connection_params\x18\x02 \x03(\v2A.gestalt.plugin.v1.GetSessionCatalogRequest.ConnectionParamsEntryR\x10connectionParams\x1aC\n" +
@@ -1747,7 +1856,7 @@ func file_sdk_pluginapi_v1_plugin_proto_rawDescGZIP() []byte {
 }
 
 var file_sdk_pluginapi_v1_plugin_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_sdk_pluginapi_v1_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
+var file_sdk_pluginapi_v1_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_sdk_pluginapi_v1_plugin_proto_goTypes = []any{
 	(ConnectionMode)(0),               // 0: gestalt.plugin.v1.ConnectionMode
 	(PrincipalSource)(0),              // 1: gestalt.plugin.v1.PrincipalSource
@@ -1776,67 +1885,73 @@ var file_sdk_pluginapi_v1_plugin_proto_goTypes = []any{
 	(*StartRuntimeRequest)(nil),       // 24: gestalt.plugin.v1.StartRuntimeRequest
 	nil,                               // 25: gestalt.plugin.v1.ProviderMetadata.ConnectionParamsEntry
 	nil,                               // 26: gestalt.plugin.v1.ExecuteRequest.ConnectionParamsEntry
-	nil,                               // 27: gestalt.plugin.v1.GetSessionCatalogRequest.ConnectionParamsEntry
-	nil,                               // 28: gestalt.plugin.v1.PostConnectResponse.MetadataEntry
-	(*structpb.Value)(nil),            // 29: google.protobuf.Value
-	(*structpb.Struct)(nil),           // 30: google.protobuf.Struct
-	(*timestamppb.Timestamp)(nil),     // 31: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),             // 32: google.protobuf.Empty
+	nil,                               // 27: gestalt.plugin.v1.AuthorizationURLRequest.ConnectionParamsEntry
+	nil,                               // 28: gestalt.plugin.v1.ExchangeCodeRequest.ConnectionParamsEntry
+	nil,                               // 29: gestalt.plugin.v1.RefreshTokenRequest.ConnectionParamsEntry
+	nil,                               // 30: gestalt.plugin.v1.GetSessionCatalogRequest.ConnectionParamsEntry
+	nil,                               // 31: gestalt.plugin.v1.PostConnectResponse.MetadataEntry
+	(*structpb.Value)(nil),            // 32: google.protobuf.Value
+	(*structpb.Struct)(nil),           // 33: google.protobuf.Struct
+	(*timestamppb.Timestamp)(nil),     // 34: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),             // 35: google.protobuf.Empty
 }
 var file_sdk_pluginapi_v1_plugin_proto_depIdxs = []int32{
 	2,  // 0: gestalt.plugin.v1.Principal.identity:type_name -> gestalt.plugin.v1.UserIdentity
 	1,  // 1: gestalt.plugin.v1.Principal.source:type_name -> gestalt.plugin.v1.PrincipalSource
-	29, // 2: gestalt.plugin.v1.Parameter.default_value:type_name -> google.protobuf.Value
+	32, // 2: gestalt.plugin.v1.Parameter.default_value:type_name -> google.protobuf.Value
 	4,  // 3: gestalt.plugin.v1.Operation.parameters:type_name -> gestalt.plugin.v1.Parameter
 	4,  // 4: gestalt.plugin.v1.Capability.parameters:type_name -> gestalt.plugin.v1.Parameter
 	0,  // 5: gestalt.plugin.v1.ProviderMetadata.connection_mode:type_name -> gestalt.plugin.v1.ConnectionMode
 	25, // 6: gestalt.plugin.v1.ProviderMetadata.connection_params:type_name -> gestalt.plugin.v1.ProviderMetadata.ConnectionParamsEntry
-	30, // 7: gestalt.plugin.v1.TokenResponse.extra:type_name -> google.protobuf.Struct
-	31, // 8: gestalt.plugin.v1.IntegrationToken.expires_at:type_name -> google.protobuf.Timestamp
-	31, // 9: gestalt.plugin.v1.IntegrationToken.last_refreshed_at:type_name -> google.protobuf.Timestamp
-	31, // 10: gestalt.plugin.v1.IntegrationToken.created_at:type_name -> google.protobuf.Timestamp
-	31, // 11: gestalt.plugin.v1.IntegrationToken.updated_at:type_name -> google.protobuf.Timestamp
+	33, // 7: gestalt.plugin.v1.TokenResponse.extra:type_name -> google.protobuf.Struct
+	34, // 8: gestalt.plugin.v1.IntegrationToken.expires_at:type_name -> google.protobuf.Timestamp
+	34, // 9: gestalt.plugin.v1.IntegrationToken.last_refreshed_at:type_name -> google.protobuf.Timestamp
+	34, // 10: gestalt.plugin.v1.IntegrationToken.created_at:type_name -> google.protobuf.Timestamp
+	34, // 11: gestalt.plugin.v1.IntegrationToken.updated_at:type_name -> google.protobuf.Timestamp
 	5,  // 12: gestalt.plugin.v1.ListOperationsResponse.operations:type_name -> gestalt.plugin.v1.Operation
-	30, // 13: gestalt.plugin.v1.ExecuteRequest.params:type_name -> google.protobuf.Struct
+	33, // 13: gestalt.plugin.v1.ExecuteRequest.params:type_name -> google.protobuf.Struct
 	26, // 14: gestalt.plugin.v1.ExecuteRequest.connection_params:type_name -> gestalt.plugin.v1.ExecuteRequest.ConnectionParamsEntry
-	27, // 15: gestalt.plugin.v1.GetSessionCatalogRequest.connection_params:type_name -> gestalt.plugin.v1.GetSessionCatalogRequest.ConnectionParamsEntry
-	11, // 16: gestalt.plugin.v1.PostConnectRequest.token:type_name -> gestalt.plugin.v1.IntegrationToken
-	28, // 17: gestalt.plugin.v1.PostConnectResponse.metadata:type_name -> gestalt.plugin.v1.PostConnectResponse.MetadataEntry
-	6,  // 18: gestalt.plugin.v1.ListCapabilitiesResponse.capabilities:type_name -> gestalt.plugin.v1.Capability
-	3,  // 19: gestalt.plugin.v1.InvokeRequest.principal:type_name -> gestalt.plugin.v1.Principal
-	30, // 20: gestalt.plugin.v1.InvokeRequest.params:type_name -> google.protobuf.Struct
-	30, // 21: gestalt.plugin.v1.StartRuntimeRequest.config:type_name -> google.protobuf.Struct
-	6,  // 22: gestalt.plugin.v1.StartRuntimeRequest.initial_capabilities:type_name -> gestalt.plugin.v1.Capability
-	7,  // 23: gestalt.plugin.v1.ProviderMetadata.ConnectionParamsEntry.value:type_name -> gestalt.plugin.v1.ConnectionParamDef
-	32, // 24: gestalt.plugin.v1.ProviderPlugin.GetMetadata:input_type -> google.protobuf.Empty
-	32, // 25: gestalt.plugin.v1.ProviderPlugin.ListOperations:input_type -> google.protobuf.Empty
-	13, // 26: gestalt.plugin.v1.ProviderPlugin.Execute:input_type -> gestalt.plugin.v1.ExecuteRequest
-	14, // 27: gestalt.plugin.v1.ProviderPlugin.AuthorizationURL:input_type -> gestalt.plugin.v1.AuthorizationURLRequest
-	16, // 28: gestalt.plugin.v1.ProviderPlugin.ExchangeCode:input_type -> gestalt.plugin.v1.ExchangeCodeRequest
-	17, // 29: gestalt.plugin.v1.ProviderPlugin.RefreshToken:input_type -> gestalt.plugin.v1.RefreshTokenRequest
-	18, // 30: gestalt.plugin.v1.ProviderPlugin.GetSessionCatalog:input_type -> gestalt.plugin.v1.GetSessionCatalogRequest
-	20, // 31: gestalt.plugin.v1.ProviderPlugin.PostConnect:input_type -> gestalt.plugin.v1.PostConnectRequest
-	24, // 32: gestalt.plugin.v1.RuntimePlugin.Start:input_type -> gestalt.plugin.v1.StartRuntimeRequest
-	32, // 33: gestalt.plugin.v1.RuntimePlugin.Stop:input_type -> google.protobuf.Empty
-	23, // 34: gestalt.plugin.v1.RuntimeHost.Invoke:input_type -> gestalt.plugin.v1.InvokeRequest
-	32, // 35: gestalt.plugin.v1.RuntimeHost.ListCapabilities:input_type -> google.protobuf.Empty
-	8,  // 36: gestalt.plugin.v1.ProviderPlugin.GetMetadata:output_type -> gestalt.plugin.v1.ProviderMetadata
-	12, // 37: gestalt.plugin.v1.ProviderPlugin.ListOperations:output_type -> gestalt.plugin.v1.ListOperationsResponse
-	10, // 38: gestalt.plugin.v1.ProviderPlugin.Execute:output_type -> gestalt.plugin.v1.OperationResult
-	15, // 39: gestalt.plugin.v1.ProviderPlugin.AuthorizationURL:output_type -> gestalt.plugin.v1.AuthorizationURLResponse
-	9,  // 40: gestalt.plugin.v1.ProviderPlugin.ExchangeCode:output_type -> gestalt.plugin.v1.TokenResponse
-	9,  // 41: gestalt.plugin.v1.ProviderPlugin.RefreshToken:output_type -> gestalt.plugin.v1.TokenResponse
-	19, // 42: gestalt.plugin.v1.ProviderPlugin.GetSessionCatalog:output_type -> gestalt.plugin.v1.GetSessionCatalogResponse
-	21, // 43: gestalt.plugin.v1.ProviderPlugin.PostConnect:output_type -> gestalt.plugin.v1.PostConnectResponse
-	32, // 44: gestalt.plugin.v1.RuntimePlugin.Start:output_type -> google.protobuf.Empty
-	32, // 45: gestalt.plugin.v1.RuntimePlugin.Stop:output_type -> google.protobuf.Empty
-	10, // 46: gestalt.plugin.v1.RuntimeHost.Invoke:output_type -> gestalt.plugin.v1.OperationResult
-	22, // 47: gestalt.plugin.v1.RuntimeHost.ListCapabilities:output_type -> gestalt.plugin.v1.ListCapabilitiesResponse
-	36, // [36:48] is the sub-list for method output_type
-	24, // [24:36] is the sub-list for method input_type
-	24, // [24:24] is the sub-list for extension type_name
-	24, // [24:24] is the sub-list for extension extendee
-	0,  // [0:24] is the sub-list for field type_name
+	27, // 15: gestalt.plugin.v1.AuthorizationURLRequest.connection_params:type_name -> gestalt.plugin.v1.AuthorizationURLRequest.ConnectionParamsEntry
+	28, // 16: gestalt.plugin.v1.ExchangeCodeRequest.connection_params:type_name -> gestalt.plugin.v1.ExchangeCodeRequest.ConnectionParamsEntry
+	29, // 17: gestalt.plugin.v1.RefreshTokenRequest.connection_params:type_name -> gestalt.plugin.v1.RefreshTokenRequest.ConnectionParamsEntry
+	30, // 18: gestalt.plugin.v1.GetSessionCatalogRequest.connection_params:type_name -> gestalt.plugin.v1.GetSessionCatalogRequest.ConnectionParamsEntry
+	11, // 19: gestalt.plugin.v1.PostConnectRequest.token:type_name -> gestalt.plugin.v1.IntegrationToken
+	31, // 20: gestalt.plugin.v1.PostConnectResponse.metadata:type_name -> gestalt.plugin.v1.PostConnectResponse.MetadataEntry
+	6,  // 21: gestalt.plugin.v1.ListCapabilitiesResponse.capabilities:type_name -> gestalt.plugin.v1.Capability
+	3,  // 22: gestalt.plugin.v1.InvokeRequest.principal:type_name -> gestalt.plugin.v1.Principal
+	33, // 23: gestalt.plugin.v1.InvokeRequest.params:type_name -> google.protobuf.Struct
+	33, // 24: gestalt.plugin.v1.StartRuntimeRequest.config:type_name -> google.protobuf.Struct
+	6,  // 25: gestalt.plugin.v1.StartRuntimeRequest.initial_capabilities:type_name -> gestalt.plugin.v1.Capability
+	7,  // 26: gestalt.plugin.v1.ProviderMetadata.ConnectionParamsEntry.value:type_name -> gestalt.plugin.v1.ConnectionParamDef
+	35, // 27: gestalt.plugin.v1.ProviderPlugin.GetMetadata:input_type -> google.protobuf.Empty
+	35, // 28: gestalt.plugin.v1.ProviderPlugin.ListOperations:input_type -> google.protobuf.Empty
+	13, // 29: gestalt.plugin.v1.ProviderPlugin.Execute:input_type -> gestalt.plugin.v1.ExecuteRequest
+	14, // 30: gestalt.plugin.v1.ProviderPlugin.AuthorizationURL:input_type -> gestalt.plugin.v1.AuthorizationURLRequest
+	16, // 31: gestalt.plugin.v1.ProviderPlugin.ExchangeCode:input_type -> gestalt.plugin.v1.ExchangeCodeRequest
+	17, // 32: gestalt.plugin.v1.ProviderPlugin.RefreshToken:input_type -> gestalt.plugin.v1.RefreshTokenRequest
+	18, // 33: gestalt.plugin.v1.ProviderPlugin.GetSessionCatalog:input_type -> gestalt.plugin.v1.GetSessionCatalogRequest
+	20, // 34: gestalt.plugin.v1.ProviderPlugin.PostConnect:input_type -> gestalt.plugin.v1.PostConnectRequest
+	24, // 35: gestalt.plugin.v1.RuntimePlugin.Start:input_type -> gestalt.plugin.v1.StartRuntimeRequest
+	35, // 36: gestalt.plugin.v1.RuntimePlugin.Stop:input_type -> google.protobuf.Empty
+	23, // 37: gestalt.plugin.v1.RuntimeHost.Invoke:input_type -> gestalt.plugin.v1.InvokeRequest
+	35, // 38: gestalt.plugin.v1.RuntimeHost.ListCapabilities:input_type -> google.protobuf.Empty
+	8,  // 39: gestalt.plugin.v1.ProviderPlugin.GetMetadata:output_type -> gestalt.plugin.v1.ProviderMetadata
+	12, // 40: gestalt.plugin.v1.ProviderPlugin.ListOperations:output_type -> gestalt.plugin.v1.ListOperationsResponse
+	10, // 41: gestalt.plugin.v1.ProviderPlugin.Execute:output_type -> gestalt.plugin.v1.OperationResult
+	15, // 42: gestalt.plugin.v1.ProviderPlugin.AuthorizationURL:output_type -> gestalt.plugin.v1.AuthorizationURLResponse
+	9,  // 43: gestalt.plugin.v1.ProviderPlugin.ExchangeCode:output_type -> gestalt.plugin.v1.TokenResponse
+	9,  // 44: gestalt.plugin.v1.ProviderPlugin.RefreshToken:output_type -> gestalt.plugin.v1.TokenResponse
+	19, // 45: gestalt.plugin.v1.ProviderPlugin.GetSessionCatalog:output_type -> gestalt.plugin.v1.GetSessionCatalogResponse
+	21, // 46: gestalt.plugin.v1.ProviderPlugin.PostConnect:output_type -> gestalt.plugin.v1.PostConnectResponse
+	35, // 47: gestalt.plugin.v1.RuntimePlugin.Start:output_type -> google.protobuf.Empty
+	35, // 48: gestalt.plugin.v1.RuntimePlugin.Stop:output_type -> google.protobuf.Empty
+	10, // 49: gestalt.plugin.v1.RuntimeHost.Invoke:output_type -> gestalt.plugin.v1.OperationResult
+	22, // 50: gestalt.plugin.v1.RuntimeHost.ListCapabilities:output_type -> gestalt.plugin.v1.ListCapabilitiesResponse
+	39, // [39:51] is the sub-list for method output_type
+	27, // [27:39] is the sub-list for method input_type
+	27, // [27:27] is the sub-list for extension type_name
+	27, // [27:27] is the sub-list for extension extendee
+	0,  // [0:27] is the sub-list for field type_name
 }
 
 func init() { file_sdk_pluginapi_v1_plugin_proto_init() }
@@ -1850,7 +1965,7 @@ func file_sdk_pluginapi_v1_plugin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_sdk_pluginapi_v1_plugin_proto_rawDesc), len(file_sdk_pluginapi_v1_plugin_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   27,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   3,
 		},

--- a/sdk/pluginapi/v1/plugin.proto
+++ b/sdk/pluginapi/v1/plugin.proto
@@ -75,6 +75,8 @@ message ProviderMetadata {
   string static_catalog_json = 7;
   bool supports_session_catalog = 8;
   bool supports_post_connect = 9;
+  string authorization_base_url = 10;
+  string token_url = 11;
 }
 
 message TokenResponse {
@@ -120,18 +122,27 @@ message ExecuteRequest {
 message AuthorizationURLRequest {
   string state = 1;
   repeated string scopes = 2;
+  map<string, string> connection_params = 3;
+  string auth_base_url = 4;
+  bool include_verifier = 5;
 }
 
 message AuthorizationURLResponse {
   string url = 1;
+  string verifier = 2;
 }
 
 message ExchangeCodeRequest {
   string code = 1;
+  string verifier = 2;
+  string token_url = 3;
+  map<string, string> connection_params = 4;
 }
 
 message RefreshTokenRequest {
   string refresh_token = 1;
+  string token_url = 2;
+  map<string, string> connection_params = 3;
 }
 
 message GetSessionCatalogRequest {


### PR DESCRIPTION
## Summary
- widen the provider plugin OAuth RPC payloads and metadata so remote providers can round-trip PKCE verifiers plus auth/token URL overrides
- teach the remote provider client/server adapters to expose the same optional OAuth side interfaces used by the host for start, callback, and refresh flows
- cover the new behavior with functional executable-plugin tests through the host server and bootstrap/invocation paths, and remove the unit-style pluginapi test additions

## Testing
- go test ./internal/oauth ./internal/pluginapi ./internal/server ./internal/invocation ./internal/bootstrap -count=1