### PR TITLE
Filter runtime capabilities to invokable operations

### DIFF
--- a/cmd/gestalt-plugin-echo/main.go
+++ b/cmd/gestalt-plugin-echo/main.go
@@ -77,6 +77,7 @@ func (p *echoRuntimePlugin) Start(ctx context.Context, req *pluginapiv1.StartRun
 	record := map[string]any{
 		"name":             req.GetName(),
 		"capability_count": len(capsResp.GetCapabilities()),
+		"capabilities":     capabilityNames(capsResp.GetCapabilities()),
 	}
 
 	probeProvider, _ := cfg["probe_provider"].(string)
@@ -119,6 +120,14 @@ func (p *echoRuntimePlugin) Stop(context.Context, *emptypb.Empty) (*emptypb.Empt
 	}
 	log.Printf("echo runtime %q stopped", p.name)
 	return &emptypb.Empty{}, nil
+}
+
+func capabilityNames(caps []*pluginapiv1.Capability) []string {
+	names := make([]string, 0, len(caps))
+	for _, cap := range caps {
+		names = append(names, cap.GetProvider()+"."+cap.GetOperation())
+	}
+	return names
 }
 
 func writeJSON(path string, value any) error {

--- a/internal/bootstrap/executable_plugin_test.go
+++ b/internal/bootstrap/executable_plugin_test.go
@@ -3,17 +3,46 @@ package bootstrap
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/core/testing"
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	"gopkg.in/yaml.v3"
 )
+
+type runtimeOutput struct {
+	Name            string   `json:"name"`
+	CapabilityCount int      `json:"capability_count"`
+	Capabilities    []string `json:"capabilities"`
+	ProbeStatus     int      `json:"probe_status"`
+	ProbeBody       string   `json:"probe_body"`
+}
+
+type catalogProviderWithOps struct {
+	coretesting.StubIntegration
+	ops []core.Operation
+	cat *catalog.Catalog
+}
+
+func (p *catalogProviderWithOps) ListOperations() []core.Operation {
+	return slices.Clone(p.ops)
+}
+
+func (p *catalogProviderWithOps) Catalog() *catalog.Catalog {
+	if p.cat == nil {
+		return nil
+	}
+	return p.cat.Clone()
+}
 
 func TestExecutableProviderAndRuntimePlugins(t *testing.T) {
 	t.Parallel()
@@ -70,19 +99,7 @@ func TestExecutableProviderAndRuntimePlugins(t *testing.T) {
 		t.Fatalf("runtime.Start: %v", err)
 	}
 
-	var got struct {
-		Name            string `json:"name"`
-		CapabilityCount int    `json:"capability_count"`
-		ProbeStatus     int    `json:"probe_status"`
-		ProbeBody       string `json:"probe_body"`
-	}
-	data, err := os.ReadFile(outputFile)
-	if err != nil {
-		t.Fatalf("ReadFile(%s): %v", outputFile, err)
-	}
-	if err := json.Unmarshal(data, &got); err != nil {
-		t.Fatalf("json.Unmarshal: %v", err)
-	}
+	got := readRuntimeOutput(t, outputFile)
 
 	if got.Name != "echoextrt" {
 		t.Fatalf("runtime output name = %q", got.Name)
@@ -90,11 +107,262 @@ func TestExecutableProviderAndRuntimePlugins(t *testing.T) {
 	if got.CapabilityCount != 1 {
 		t.Fatalf("runtime output capability_count = %d", got.CapabilityCount)
 	}
-	if got.ProbeStatus != 200 {
+	if got.ProbeStatus != http.StatusOK {
 		t.Fatalf("runtime output probe_status = %d", got.ProbeStatus)
 	}
 	if got.ProbeBody != `{"message":"from runtime"}` {
 		t.Fatalf("runtime output probe_body = %q", got.ProbeBody)
+	}
+}
+
+func TestExecutableRuntimeCapabilities_OmitsMCPPassthroughOnlyCatalogOperations(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	outputFile := filepath.Join(t.TempDir(), "runtime-output.json")
+
+	cfg := &config.Config{
+		Integrations: map[string]config.IntegrationDef{
+			"search": {},
+		},
+		Runtimes: map[string]config.RuntimeDef{
+			"echoextrt": {
+				Providers: []string{"search"},
+				Plugin: &config.ExecutablePluginDef{
+					Command: bin,
+					Args:    []string{"runtime"},
+				},
+				Config: mustNode(t, map[string]any{
+					"output_file": outputFile,
+				}),
+			},
+		},
+	}
+
+	factories := NewFactoryRegistry()
+	factories.Providers["search"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ Deps) (core.Provider, error) {
+		return &catalogProviderWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "search",
+				ConnMode: core.ConnectionModeNone,
+			},
+			ops: []core.Operation{
+				{Name: "search_workspace", Description: "Search workspace", Method: http.MethodPost},
+			},
+			cat: &catalog.Catalog{
+				Name: "search",
+				Operations: []catalog.CatalogOperation{
+					{
+						ID:          "search_workspace",
+						Description: "Search workspace",
+						Transport:   catalog.TransportMCPPassthrough,
+					},
+				},
+			},
+		}, nil
+	}
+
+	providers, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	broker := invocation.NewBroker(providers, nil)
+	runtimes, err := buildRuntimes(context.Background(), cfg, factories, broker, broker, core.AuditSink(invocation.LogAuditSink{}), EgressDeps{})
+	if err != nil {
+		t.Fatalf("buildRuntimes: %v", err)
+	}
+	defer func() { _ = StopRuntimes(context.Background(), runtimes, runtimes.List()) }()
+
+	rt, err := runtimes.Get("echoextrt")
+	if err != nil {
+		t.Fatalf("runtimes.Get: %v", err)
+	}
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("runtime.Start: %v", err)
+	}
+
+	got := readRuntimeOutput(t, outputFile)
+	if got.CapabilityCount != 0 {
+		t.Fatalf("runtime output capability_count = %d, want 0", got.CapabilityCount)
+	}
+	if len(got.Capabilities) != 0 {
+		t.Fatalf("runtime output capabilities = %v, want []", got.Capabilities)
+	}
+}
+
+func TestExecutableRuntimeCapabilities_ExposeOnlyInvokableCatalogOperations(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	outputFile := filepath.Join(t.TempDir(), "runtime-output.json")
+
+	cfg := &config.Config{
+		Integrations: map[string]config.IntegrationDef{
+			"workspace": {},
+		},
+		Runtimes: map[string]config.RuntimeDef{
+			"echoextrt": {
+				Providers: []string{"workspace"},
+				Plugin: &config.ExecutablePluginDef{
+					Command: bin,
+					Args:    []string{"runtime"},
+				},
+				Config: mustNode(t, map[string]any{
+					"output_file":     outputFile,
+					"probe_provider":  "workspace",
+					"probe_operation": "fetch_record",
+					"probe_params": map[string]any{
+						"id": "abc123",
+					},
+				}),
+			},
+		},
+	}
+
+	factories := NewFactoryRegistry()
+	factories.Providers["workspace"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ Deps) (core.Provider, error) {
+		return &catalogProviderWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "workspace",
+				ConnMode: core.ConnectionModeNone,
+				ExecuteFn: func(_ context.Context, operation string, params map[string]any, _ string) (*core.OperationResult, error) {
+					body, err := json.Marshal(map[string]any{
+						"operation": operation,
+						"params":    params,
+					})
+					if err != nil {
+						return nil, err
+					}
+					return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
+				},
+			},
+			ops: []core.Operation{
+				{Name: "fetch_record", Description: "Fetch record", Method: http.MethodGet},
+				{Name: "search_workspace", Description: "Search workspace", Method: http.MethodPost},
+			},
+			cat: &catalog.Catalog{
+				Name: "workspace",
+				Operations: []catalog.CatalogOperation{
+					{
+						ID:          "fetch_record",
+						Description: "Fetch record",
+						Method:      http.MethodGet,
+						Path:        "/records/{id}",
+						Transport:   catalog.TransportHTTP,
+					},
+					{
+						ID:          "search_workspace",
+						Description: "Search workspace",
+						Transport:   catalog.TransportMCPPassthrough,
+					},
+				},
+			},
+		}, nil
+	}
+
+	providers, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	broker := invocation.NewBroker(providers, nil)
+	runtimes, err := buildRuntimes(context.Background(), cfg, factories, broker, broker, core.AuditSink(invocation.LogAuditSink{}), EgressDeps{})
+	if err != nil {
+		t.Fatalf("buildRuntimes: %v", err)
+	}
+	defer func() { _ = StopRuntimes(context.Background(), runtimes, runtimes.List()) }()
+
+	rt, err := runtimes.Get("echoextrt")
+	if err != nil {
+		t.Fatalf("runtimes.Get: %v", err)
+	}
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("runtime.Start: %v", err)
+	}
+
+	got := readRuntimeOutput(t, outputFile)
+	if got.CapabilityCount != 1 {
+		t.Fatalf("runtime output capability_count = %d, want 1", got.CapabilityCount)
+	}
+	if !slices.Equal(got.Capabilities, []string{"workspace.fetch_record"}) {
+		t.Fatalf("runtime output capabilities = %v, want [workspace.fetch_record]", got.Capabilities)
+	}
+	if got.ProbeStatus != http.StatusOK {
+		t.Fatalf("runtime output probe_status = %d, want %d", got.ProbeStatus, http.StatusOK)
+	}
+	if got.ProbeBody != `{"operation":"fetch_record","params":{"id":"abc123"}}` {
+		t.Fatalf("runtime output probe_body = %q", got.ProbeBody)
+	}
+}
+
+func TestExecutableRuntimeCapabilities_FilterMethodlessFallbackOperations(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	outputFile := filepath.Join(t.TempDir(), "runtime-output.json")
+
+	cfg := &config.Config{
+		Integrations: map[string]config.IntegrationDef{
+			"alpha": {},
+		},
+		Runtimes: map[string]config.RuntimeDef{
+			"echoextrt": {
+				Providers: []string{"alpha"},
+				Plugin: &config.ExecutablePluginDef{
+					Command: bin,
+					Args:    []string{"runtime"},
+				},
+				Config: mustNode(t, map[string]any{
+					"output_file": outputFile,
+				}),
+			},
+		},
+	}
+
+	factories := NewFactoryRegistry()
+	factories.Providers["alpha"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ Deps) (core.Provider, error) {
+		return &catalogProviderWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "alpha",
+				ConnMode: core.ConnectionModeNone,
+			},
+			ops: []core.Operation{
+				{Name: "http_op", Description: "HTTP op", Method: http.MethodPost},
+				{Name: "hidden_op", Description: "Hidden op"},
+			},
+		}, nil
+	}
+
+	providers, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	broker := invocation.NewBroker(providers, nil)
+	runtimes, err := buildRuntimes(context.Background(), cfg, factories, broker, broker, core.AuditSink(invocation.LogAuditSink{}), EgressDeps{})
+	if err != nil {
+		t.Fatalf("buildRuntimes: %v", err)
+	}
+	defer func() { _ = StopRuntimes(context.Background(), runtimes, runtimes.List()) }()
+
+	rt, err := runtimes.Get("echoextrt")
+	if err != nil {
+		t.Fatalf("runtimes.Get: %v", err)
+	}
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("runtime.Start: %v", err)
+	}
+
+	got := readRuntimeOutput(t, outputFile)
+	if got.CapabilityCount != 1 {
+		t.Fatalf("runtime output capability_count = %d, want 1", got.CapabilityCount)
+	}
+	if !slices.Equal(got.Capabilities, []string{"alpha.http_op"}) {
+		t.Fatalf("runtime output capabilities = %v, want [alpha.http_op]", got.Capabilities)
 	}
 }
 
@@ -127,4 +395,19 @@ func mustNode(t *testing.T, value any) yaml.Node {
 		t.Fatalf("node.Encode: %v", err)
 	}
 	return node
+}
+
+func readRuntimeOutput(t *testing.T, path string) runtimeOutput {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+
+	var got runtimeOutput
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	return got
 }

--- a/internal/bootstrap/regression_test.go
+++ b/internal/bootstrap/regression_test.go
@@ -86,7 +86,7 @@ func TestPlatformMode_BindingsAndRuntimesWithSafetyLayer(t *testing.T) {
 					return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
 				},
 			},
-			ops: []core.Operation{{Name: "do"}},
+			ops: []core.Operation{{Name: "do", Method: http.MethodPost}},
 		}, nil
 	}
 	factories.Providers["beta"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
@@ -98,7 +98,7 @@ func TestPlatformMode_BindingsAndRuntimesWithSafetyLayer(t *testing.T) {
 					return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
 				},
 			},
-			ops: []core.Operation{{Name: "do"}},
+			ops: []core.Operation{{Name: "do", Method: http.MethodPost}},
 		}, nil
 	}
 

--- a/internal/invocation/broker.go
+++ b/internal/invocation/broker.go
@@ -54,14 +54,7 @@ func (b *Broker) ListCapabilities() []core.Capability {
 		if err != nil {
 			continue
 		}
-		for _, op := range prov.ListOperations() {
-			caps = append(caps, core.Capability{
-				Provider:    name,
-				Operation:   op.Name,
-				Description: op.Description,
-				Parameters:  op.Parameters,
-			})
-		}
+		caps = append(caps, capabilitiesForProvider(name, prov)...)
 	}
 	return caps
 }

--- a/internal/invocation/capabilities.go
+++ b/internal/invocation/capabilities.go
@@ -1,0 +1,33 @@
+package invocation
+
+import (
+	"strings"
+
+	"github.com/valon-technologies/gestalt/core"
+	ci "github.com/valon-technologies/gestalt/core/integration"
+)
+
+func capabilitiesForProvider(name string, prov core.Provider) []core.Capability {
+	if cp, ok := prov.(core.CatalogProvider); ok {
+		if cat := cp.Catalog(); cat != nil {
+			return capabilitiesFromOperations(name, ci.OperationsList(cat))
+		}
+	}
+	return capabilitiesFromOperations(name, prov.ListOperations())
+}
+
+func capabilitiesFromOperations(name string, ops []core.Operation) []core.Capability {
+	caps := make([]core.Capability, 0, len(ops))
+	for _, op := range ops {
+		if strings.TrimSpace(op.Method) == "" {
+			continue
+		}
+		caps = append(caps, core.Capability{
+			Provider:    name,
+			Operation:   op.Name,
+			Description: op.Description,
+			Parameters:  op.Parameters,
+		})
+	}
+	return caps
+}

--- a/internal/invocation/guarded_test.go
+++ b/internal/invocation/guarded_test.go
@@ -200,14 +200,14 @@ func TestGuardedInvoker_ListCapabilities(t *testing.T) {
 	alpha := &stubProviderWithOps{
 		StubIntegration: coretesting.StubIntegration{N: "alpha"},
 		ops: []core.Operation{
-			{Name: "op1", Description: "Alpha op 1"},
-			{Name: "op2", Description: "Alpha op 2"},
+			{Name: "op1", Description: "Alpha op 1", Method: http.MethodGet},
+			{Name: "op2", Description: "Alpha op 2", Method: http.MethodPost},
 		},
 	}
 	beta := &stubProviderWithOps{
 		StubIntegration: coretesting.StubIntegration{N: "beta"},
 		ops: []core.Operation{
-			{Name: "op3", Description: "Beta op 3"},
+			{Name: "op3", Description: "Beta op 3", Method: http.MethodGet},
 		},
 	}
 

--- a/internal/mcpupstream/upstream.go
+++ b/internal/mcpupstream/upstream.go
@@ -223,6 +223,7 @@ func buildCatalog(name string, tools []mcpgo.Tool) (*catalog.Catalog, []core.Ope
 			Title:       tools[i].Annotations.Title,
 			Description: tools[i].Description,
 			InputSchema: schema,
+			Transport:   catalog.TransportMCPPassthrough,
 		}
 		catOp.Annotations = catalog.OperationAnnotations{
 			ReadOnlyHint:    tools[i].Annotations.ReadOnlyHint,


### PR DESCRIPTION
Runtime plugins previously received all operations from their providers,
including MCP passthrough operations that cannot be invoked through the
broker. This filters the capabilities list to only include operations
that have an HTTP method, which excludes MCP passthrough-only catalog
entries and methodless fallback operations. MCP upstream tools now
correctly tag their catalog entries with `TransportMCPPassthrough` so
the filtering can distinguish them.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>