### PR TITLE
Extract staged connection storage as an optional capability

### DIFF
--- a/core/datastore.go
+++ b/core/datastore.go
@@ -18,11 +18,13 @@ type Datastore interface {
 	ListAPITokens(ctx context.Context, userID string) ([]*APIToken, error)
 	RevokeAPIToken(ctx context.Context, userID, id string) error
 
-	StoreStagedConnection(ctx context.Context, sc *StagedConnection) error
-	GetStagedConnection(ctx context.Context, id string) (*StagedConnection, error)
-	DeleteStagedConnection(ctx context.Context, id string) error
-
 	Ping(ctx context.Context) error
 	Migrate(ctx context.Context) error
 	Close() error
+}
+
+type StagedConnectionStore interface {
+	StoreStagedConnection(ctx context.Context, sc *StagedConnection) error
+	GetStagedConnection(ctx context.Context, id string) (*StagedConnection, error)
+	DeleteStagedConnection(ctx context.Context, id string) error
 }

--- a/core/testing/datastore_suite.go
+++ b/core/testing/datastore_suite.go
@@ -405,6 +405,12 @@ func testDatastoreStagedConnections(t *testing.T, newStore func(t *testing.T) co
 	t.Run("store get delete lifecycle", func(t *testing.T) {
 		ds := newStore(t)
 		t.Cleanup(func() { ds.Close() })
+
+		scs, ok := ds.(core.StagedConnectionStore)
+		if !ok {
+			t.Skip("datastore does not implement StagedConnectionStore")
+		}
+
 		ctx := context.Background()
 
 		user := mustCreateUser(t, ctx, ds, "staged@example.com")
@@ -425,11 +431,11 @@ func testDatastoreStagedConnections(t *testing.T, newStore func(t *testing.T) co
 			ExpiresAt:      expiry,
 		}
 
-		if err := ds.StoreStagedConnection(ctx, sc); err != nil {
+		if err := scs.StoreStagedConnection(ctx, sc); err != nil {
 			t.Fatalf("StoreStagedConnection: %v", err)
 		}
 
-		got, err := ds.GetStagedConnection(ctx, "sc-1")
+		got, err := scs.GetStagedConnection(ctx, "sc-1")
 		if err != nil {
 			t.Fatalf("GetStagedConnection: %v", err)
 		}
@@ -452,11 +458,11 @@ func testDatastoreStagedConnections(t *testing.T, newStore func(t *testing.T) co
 			t.Errorf("CandidatesJSON: got %q, want %q", got.CandidatesJSON, sc.CandidatesJSON)
 		}
 
-		if err := ds.DeleteStagedConnection(ctx, "sc-1"); err != nil {
+		if err := scs.DeleteStagedConnection(ctx, "sc-1"); err != nil {
 			t.Fatalf("DeleteStagedConnection: %v", err)
 		}
 
-		_, err = ds.GetStagedConnection(ctx, "sc-1")
+		_, err = scs.GetStagedConnection(ctx, "sc-1")
 		if !errors.Is(err, core.ErrNotFound) {
 			t.Fatalf("GetStagedConnection after delete: expected ErrNotFound, got %v", err)
 		}
@@ -465,9 +471,15 @@ func testDatastoreStagedConnections(t *testing.T, newStore func(t *testing.T) co
 	t.Run("get nonexistent returns ErrNotFound", func(t *testing.T) {
 		ds := newStore(t)
 		t.Cleanup(func() { ds.Close() })
+
+		scs, ok := ds.(core.StagedConnectionStore)
+		if !ok {
+			t.Skip("datastore does not implement StagedConnectionStore")
+		}
+
 		ctx := context.Background()
 
-		_, err := ds.GetStagedConnection(ctx, "nonexistent-id")
+		_, err := scs.GetStagedConnection(ctx, "nonexistent-id")
 		if !errors.Is(err, core.ErrNotFound) {
 			t.Fatalf("expected ErrNotFound, got %v", err)
 		}

--- a/core/testing/stubs.go
+++ b/core/testing/stubs.go
@@ -18,6 +18,8 @@ func (s *StubSecretManager) GetSecret(_ context.Context, name string) (string, e
 	return "", core.ErrSecretNotFound
 }
 
+var _ core.StagedConnectionStore = (*StubDatastore)(nil)
+
 // Set Fn fields to override individual methods; nil fields return zero values.
 type StubDatastore struct {
 	PingFn                     func(context.Context) error

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1163,6 +1163,10 @@ func (s *Server) runPostConnect(ctx context.Context, prov core.Provider, tm toke
 				return &postConnectResult{Status: "connected"}, nil
 			}
 
+			scs, err := s.stagedConnectionStore()
+			if err != nil {
+				return nil, err
+			}
 			candidatesJSON, _ := json.Marshal(candidates)
 			now := s.now().UTC().Truncate(time.Second)
 			sc := &core.StagedConnection{
@@ -1178,7 +1182,7 @@ func (s *Server) runPostConnect(ctx context.Context, prov core.Provider, tm toke
 				CreatedAt:      now,
 				ExpiresAt:      now.Add(stagedConnectionTTL),
 			}
-			if err := s.datastore.StoreStagedConnection(ctx, sc); err != nil {
+			if err := scs.StoreStagedConnection(ctx, sc); err != nil {
 				return nil, fmt.Errorf("storing staged connection: %w", err)
 			}
 			return &postConnectResult{
@@ -1208,9 +1212,9 @@ func (s *Server) runPostConnect(ctx context.Context, prov core.Provider, tm toke
 	return &postConnectResult{Status: "connected"}, nil
 }
 
-func (s *Server) loadStagedConnection(w http.ResponseWriter, r *http.Request, userID string) (*core.StagedConnection, bool) {
+func (s *Server) loadStagedConnection(w http.ResponseWriter, r *http.Request, userID string, scs core.StagedConnectionStore) (*core.StagedConnection, bool) {
 	id := chi.URLParam(r, "id")
-	sc, err := s.datastore.GetStagedConnection(r.Context(), id)
+	sc, err := scs.GetStagedConnection(r.Context(), id)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "staged connection not found")
@@ -1224,7 +1228,7 @@ func (s *Server) loadStagedConnection(w http.ResponseWriter, r *http.Request, us
 		return nil, false
 	}
 	if s.now().After(sc.ExpiresAt) {
-		_ = s.datastore.DeleteStagedConnection(r.Context(), id)
+		_ = scs.DeleteStagedConnection(r.Context(), id)
 		writeError(w, http.StatusGone, "staged connection has expired")
 		return nil, false
 	}
@@ -1232,11 +1236,16 @@ func (s *Server) loadStagedConnection(w http.ResponseWriter, r *http.Request, us
 }
 
 func (s *Server) getStagedConnection(w http.ResponseWriter, r *http.Request) {
+	scs, err := s.stagedConnectionStore()
+	if err != nil {
+		writeError(w, http.StatusNotImplemented, err.Error())
+		return
+	}
 	userID, ok := s.resolveUserID(w, r)
 	if !ok {
 		return
 	}
-	sc, ok := s.loadStagedConnection(w, r, userID)
+	sc, ok := s.loadStagedConnection(w, r, userID, scs)
 	if !ok {
 		return
 	}
@@ -1256,6 +1265,11 @@ func (s *Server) getStagedConnection(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) selectStagedConnection(w http.ResponseWriter, r *http.Request) {
+	scs, err := s.stagedConnectionStore()
+	if err != nil {
+		writeError(w, http.StatusNotImplemented, err.Error())
+		return
+	}
 	userID, ok := s.resolveUserID(w, r)
 	if !ok {
 		return
@@ -1273,7 +1287,7 @@ func (s *Server) selectStagedConnection(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	sc, ok := s.loadStagedConnection(w, r, userID)
+	sc, ok := s.loadStagedConnection(w, r, userID, scs)
 	if !ok {
 		return
 	}
@@ -1320,7 +1334,7 @@ func (s *Server) selectStagedConnection(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if err := s.datastore.DeleteStagedConnection(r.Context(), sc.ID); err != nil {
+	if err := scs.DeleteStagedConnection(r.Context(), sc.ID); err != nil {
 		log.Printf("failed to delete staged connection %s: %v", sc.ID, err)
 	}
 
@@ -1328,17 +1342,22 @@ func (s *Server) selectStagedConnection(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) cancelStagedConnection(w http.ResponseWriter, r *http.Request) {
+	scs, err := s.stagedConnectionStore()
+	if err != nil {
+		writeError(w, http.StatusNotImplemented, err.Error())
+		return
+	}
 	userID, ok := s.resolveUserID(w, r)
 	if !ok {
 		return
 	}
 
-	sc, ok := s.loadStagedConnection(w, r, userID)
+	sc, ok := s.loadStagedConnection(w, r, userID, scs)
 	if !ok {
 		return
 	}
 
-	if err := s.datastore.DeleteStagedConnection(r.Context(), sc.ID); err != nil {
+	if err := scs.DeleteStagedConnection(r.Context(), sc.ID); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to cancel staged connection")
 		return
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -159,6 +159,14 @@ func (s *Server) routes() {
 	}
 }
 
+func (s *Server) stagedConnectionStore() (core.StagedConnectionStore, error) {
+	scs, ok := s.datastore.(core.StagedConnectionStore)
+	if !ok {
+		return nil, fmt.Errorf("datastore does not support staged connections; use a SQL-backed datastore (sqlite, postgres, mysql)")
+	}
+	return scs, nil
+}
+
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.router.ServeHTTP(w, r)
 }

--- a/plugins/datastore/dynamodb/dynamodb.go
+++ b/plugins/datastore/dynamodb/dynamodb.go
@@ -448,18 +448,6 @@ func (s *Store) RevokeAPIToken(ctx context.Context, userID, id string) error {
 	return nil
 }
 
-func (s *Store) StoreStagedConnection(_ context.Context, _ *core.StagedConnection) error {
-	return fmt.Errorf("staged connections not supported by dynamodb datastore")
-}
-
-func (s *Store) GetStagedConnection(_ context.Context, _ string) (*core.StagedConnection, error) {
-	return nil, fmt.Errorf("staged connections not supported by dynamodb datastore")
-}
-
-func (s *Store) DeleteStagedConnection(_ context.Context, _ string) error {
-	return fmt.Errorf("staged connections not supported by dynamodb datastore")
-}
-
 func (s *Store) lookupKeysByGSI(ctx context.Context, indexName, keyAttr, keyValue, skPrefix string) (pk, sk string, err error) {
 	keyCond := expression.KeyAnd(
 		expression.Key(keyAttr).Equal(expression.Value(keyValue)),

--- a/plugins/datastore/firestore/firestore.go
+++ b/plugins/datastore/firestore/firestore.go
@@ -452,18 +452,6 @@ func (s *Store) RevokeAPIToken(ctx context.Context, userID, id string) error {
 	return nil
 }
 
-func (s *Store) StoreStagedConnection(_ context.Context, _ *core.StagedConnection) error {
-	return fmt.Errorf("staged connections not supported by firestore datastore")
-}
-
-func (s *Store) GetStagedConnection(_ context.Context, _ string) (*core.StagedConnection, error) {
-	return nil, fmt.Errorf("staged connections not supported by firestore datastore")
-}
-
-func (s *Store) DeleteStagedConnection(_ context.Context, _ string) error {
-	return fmt.Errorf("staged connections not supported by firestore datastore")
-}
-
 func snapToAPIToken(snap *gcpfirestore.DocumentSnapshot) (*core.APIToken, error) {
 	var doc apiTokenDoc
 	if err := snap.DataTo(&doc); err != nil {

--- a/plugins/datastore/mongodb/mongodb.go
+++ b/plugins/datastore/mongodb/mongodb.go
@@ -357,18 +357,6 @@ func (s *Store) integrationTokenFromDoc(doc *integrationTokenDoc) (*core.Integra
 	}, nil
 }
 
-func (s *Store) StoreStagedConnection(_ context.Context, _ *core.StagedConnection) error {
-	return fmt.Errorf("staged connections not supported by mongodb datastore")
-}
-
-func (s *Store) GetStagedConnection(_ context.Context, _ string) (*core.StagedConnection, error) {
-	return nil, fmt.Errorf("staged connections not supported by mongodb datastore")
-}
-
-func (s *Store) DeleteStagedConnection(_ context.Context, _ string) error {
-	return fmt.Errorf("staged connections not supported by mongodb datastore")
-}
-
 func apiTokenFromDoc(doc *apiTokenDoc) *core.APIToken {
 	return &core.APIToken{
 		ID:          doc.ID,

--- a/plugins/datastore/mysql/mysql.go
+++ b/plugins/datastore/mysql/mysql.go
@@ -45,6 +45,7 @@ type Store struct {
 }
 
 var _ core.Datastore = (*Store)(nil)
+var _ core.StagedConnectionStore = (*Store)(nil)
 
 func New(dsn string, encryptionKey []byte) (*Store, error) {
 	cfg, err := mysqldriver.ParseDSN(dsn)

--- a/plugins/datastore/oracle/oracle.go
+++ b/plugins/datastore/oracle/oracle.go
@@ -78,6 +78,7 @@ type Store struct {
 }
 
 var _ core.Datastore = (*Store)(nil)
+var _ core.StagedConnectionStore = (*Store)(nil)
 
 func New(dsn string, encryptionKey []byte) (*Store, error) {
 	s, err := sqlstore.Open("oracle", dsn, encryptionKey, dialect{})

--- a/plugins/datastore/postgres/postgres.go
+++ b/plugins/datastore/postgres/postgres.go
@@ -62,6 +62,7 @@ type Store struct {
 }
 
 var _ core.Datastore = (*Store)(nil)
+var _ core.StagedConnectionStore = (*Store)(nil)
 
 func New(dsn string, encryptionKey []byte) (*Store, error) {
 	s, err := sqlstore.Open("pgx", dsn, encryptionKey, dialect{})

--- a/plugins/datastore/sqlite/sqlite.go
+++ b/plugins/datastore/sqlite/sqlite.go
@@ -46,6 +46,7 @@ type Store struct {
 }
 
 var _ core.Datastore = (*Store)(nil)
+var _ core.StagedConnectionStore = (*Store)(nil)
 
 func New(dbPath string, encryptionKey []byte) (*Store, error) {
 	dsn := dbPath + "?_pragma=journal_mode(wal)&_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)"

--- a/plugins/datastore/sqlserver/sqlserver.go
+++ b/plugins/datastore/sqlserver/sqlserver.go
@@ -77,6 +77,7 @@ type Store struct {
 }
 
 var _ core.Datastore = (*Store)(nil)
+var _ core.StagedConnectionStore = (*Store)(nil)
 
 func New(dsn string, encryptionKey []byte) (*Store, error) {
 	s, err := sqlstore.Open(driverName, dsn, encryptionKey, dialect{})


### PR DESCRIPTION
Staged connections for post-connect discovery were previously required
on all datastore implementations, which meant DynamoDB, Firestore, and
MongoDB had to carry stub methods that failed at runtime. This extracts
the staged connection methods into a separate `StagedConnectionStore`
interface so only SQL-backed datastores implement it, and the server
checks for the capability before attempting to stage a connection.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>