### PR TITLE
Forward StartOAuth through restrictedOAuth wrapper

### DIFF
--- a/internal/integration/restricted.go
+++ b/internal/integration/restricted.go
@@ -187,6 +187,16 @@ func (r *restrictedOAuth) AuthorizationBaseURL() string {
 	return ""
 }
 
+func (r *restrictedOAuth) StartOAuth(state string, scopes []string) (string, string) {
+	type starter interface {
+		StartOAuth(state string, scopes []string) (string, string)
+	}
+	if s, ok := r.oauth.(starter); ok {
+		return s.StartOAuth(state, scopes)
+	}
+	return r.oauth.AuthorizationURL(state, scopes), ""
+}
+
 func (r *restrictedOAuth) StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string) {
 	type overrider interface {
 		StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string)


### PR DESCRIPTION
When a PKCE-enabled integration has `allowed_operations` configured,
the server wraps it in `restrictedOAuth`. The server handler checks for
the `oauthStarter` interface, and without `StartOAuth` the restricted
provider falls through to `AuthorizationURL`, which panics when PKCE is
enabled. This adds the missing forwarding method, matching the pattern
already used by `composite.oauthProvider` and by
`restrictedOAuth.StartOAuthWithOverride`.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>