### PR TITLE
Add buf proto generation pipeline for plugin SDK

### DIFF
--- a/scripts/generate-pluginapi.sh
+++ b/scripts/generate-pluginapi.sh
@@ -3,13 +3,23 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-export PATH="$(go env GOPATH)/bin:${PATH}"
 
-cd "${ROOT}"
+cd "${ROOT}/sdk/pluginapi"
 
-protoc \
-  --go_out=. \
-  --go_opt=paths=source_relative \
-  --go-grpc_out=. \
-  --go-grpc_opt=paths=source_relative \
-  sdk/pluginapi/v1/plugin.proto
+if command -v buf &>/dev/null; then
+  buf generate
+else
+  echo "buf is not installed — falling back to protoc (Go only)."
+  echo "Install buf from https://buf.build/docs/installation for multi-language generation."
+  echo ""
+
+  export PATH="$(go env GOPATH)/bin:${PATH}"
+  cd "${ROOT}"
+
+  protoc \
+    --go_out=. \
+    --go_opt=paths=source_relative \
+    --go-grpc_out=. \
+    --go-grpc_opt=paths=source_relative \
+    sdk/pluginapi/v1/plugin.proto
+fi

--- a/sdk/pluginapi/README.md
+++ b/sdk/pluginapi/README.md
@@ -1,0 +1,41 @@
+# Plugin API
+
+The proto definition at `v1/plugin.proto` is the gRPC contract between Gestalt
+and its provider/runtime plugins. It defines three services:
+
+- **ProviderPlugin** — implemented by provider plugins (metadata, operations,
+  auth, session catalog).
+- **RuntimePlugin** — implemented by runtime plugins (start/stop lifecycle).
+- **RuntimeHost** — implemented by the Gestalt host for runtime callbacks
+  (capability listing, cross-provider invocation).
+
+## Regenerating stubs
+
+The recommended tool is [buf](https://buf.build/docs/installation):
+
+```sh
+# From the repo root:
+./scripts/generate-pluginapi.sh
+
+# Or directly:
+cd sdk/pluginapi && buf generate
+```
+
+This produces stubs for Go, TypeScript, and Python. Output locations:
+
+| Language   | Path                          |
+|------------|-------------------------------|
+| Go         | `sdk/pluginapi/v1/`           |
+| TypeScript | `sdk/plugin/typescript/gen/`  |
+| Python     | `sdk/plugin/python/gen/`      |
+
+If buf is not installed, the script falls back to `protoc` for Go-only
+generation (the original workflow).
+
+### Prerequisites
+
+**buf (recommended):** `brew install bufbuild/buf/buf` or see
+https://buf.build/docs/installation.
+
+**protoc fallback (Go only):** requires `protoc`, `protoc-gen-go`, and
+`protoc-gen-go-grpc` on `$PATH`.

--- a/sdk/pluginapi/buf.gen.yaml
+++ b/sdk/pluginapi/buf.gen.yaml
@@ -1,0 +1,30 @@
+version: v2
+managed:
+  enabled: true
+  override:
+    - file_option: go_package
+      value: github.com/valon-technologies/gestalt/sdk/pluginapi/v1;pluginapiv1
+plugins:
+  # Go messages
+  - remote: buf.build/protocolbuffers/go
+    out: .
+    opt:
+      - paths=source_relative
+
+  # Go gRPC stubs
+  - remote: buf.build/grpc/go
+    out: .
+    opt:
+      - paths=source_relative
+
+  # TypeScript (ts-proto generates both messages and gRPC client/server code)
+  - remote: buf.build/community/timostamm-protobuf-ts
+    out: ../../sdk/plugin/typescript/gen
+    opt:
+      - long_type_string
+
+  # Python messages + gRPC stubs
+  - remote: buf.build/protocolbuffers/python
+    out: ../../sdk/plugin/python/gen
+  - remote: buf.build/grpc/python
+    out: ../../sdk/plugin/python/gen

--- a/sdk/pluginapi/buf.yaml
+++ b/sdk/pluginapi/buf.yaml
@@ -1,0 +1,10 @@
+version: v2
+modules:
+  - path: .
+    name: buf.build/valon-technologies/gestalt-pluginapi
+lint:
+  use:
+    - STANDARD
+breaking:
+  use:
+    - FILE


### PR DESCRIPTION
The gRPC plugin contract exists but there was no reproducible way to
generate stubs for non-Go languages. This adds buf configuration and
updates the generation script to support multi-language output, unblocking
TypeScript and Python SDK development from the existing proto definition.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>