### PR TITLE
Remove deprecated code remnants and rename response_check

### DIFF
--- a/cmd/gestaltd/main_test.go
+++ b/cmd/gestaltd/main_test.go
@@ -17,15 +17,6 @@ func TestRun_ValidateWithMissingConfig(t *testing.T) {
 	}
 }
 
-func TestRun_CheckFlagRejected(t *testing.T) {
-	t.Parallel()
-
-	err := run([]string{"--check"})
-	if err == nil {
-		t.Fatal("expected error for removed --check flag")
-	}
-}
-
 func TestRun_UnknownFlag(t *testing.T) {
 	t.Parallel()
 
@@ -139,31 +130,5 @@ integrations:
 	}
 	if !strings.Contains(err.Error(), `unknown upstream type "http"`) {
 		t.Fatalf("expected unknown upstream type error, got: %v", err)
-	}
-}
-
-func TestRun_ValidateRejectsLegacyGlobalMCPConfig(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := `auth:
-  provider: google
-server:
-  dev_mode: true
-  encryption_key: test-key
-mcp:
-  enabled: true
-`
-	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	err := run([]string{"validate", "--config", cfgPath})
-	if err == nil {
-		t.Fatal("expected validation error, got nil")
-	}
-	if !strings.Contains(err.Error(), `field mcp not found in type config.Config`) {
-		t.Fatalf("expected unknown mcp field error, got: %v", err)
 	}
 }

--- a/docs/pages/concepts/configuration.mdx
+++ b/docs/pages/concepts/configuration.mdx
@@ -51,7 +51,7 @@ auth_profiles:
     auth:
       authorization_url: https://slack.com/oauth/v2/authorize
       token_url: https://slack.com/api/oauth.v2.access
-      structured_response_check:
+      response_check:
         success_body_match:
           ok: true
         error_message_path: error
@@ -65,7 +65,7 @@ integrations:
         allowed_operations:
           conversations_list: ""
           chat_postMessage: Send a message to a Slack channel
-    structured_response_check:
+    response_check:
       success_body_match:
         ok: true
       error_message_path: error

--- a/docs/pages/concepts/integrations.mdx
+++ b/docs/pages/concepts/integrations.mdx
@@ -181,12 +181,12 @@ Hooks handle the quirks of individual APIs without changing the core runtime.
 
 | Hook type | Config field | Purpose |
 |---|---|---|
-| Structured response check | `structured_response_check` | Declarative response validation using body matching and error extraction. |
+| Response check | `response_check` | Declarative response validation using body matching and error extraction. |
 | Request mutator | `request_mutator` | Rewrite or augment outgoing requests before execution. |
 
-### Structured response check
+### Response check
 
-The `structured_response_check` field provides declarative response validation. It supports two modes that can be used together or independently:
+The `response_check` field provides declarative response validation. It supports two modes that can be used together or independently:
 
 **Success body match** — assert that specific fields in the JSON response have expected values. When the match fails, the error message is extracted from the path given by `error_message_path`:
 
@@ -196,7 +196,7 @@ integrations:
     upstreams:
       - type: rest
         url: https://api.example.com/openapi.json
-    structured_response_check:
+    response_check:
       success_body_match:
         ok: true
       error_message_path: error
@@ -210,7 +210,7 @@ integrations:
     upstreams:
       - type: rest
         url: https://api.example.com/openapi.json
-    structured_response_check:
+    response_check:
       error_message_path: error.message
 ```
 
@@ -220,7 +220,7 @@ The same structure can be used under `auth` to validate OAuth token exchange res
 integrations:
   my-api:
     auth:
-      structured_response_check:
+      response_check:
         success_body_match:
           ok: true
         error_message_path: error

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -41,14 +41,14 @@ integrations:
           chat_postMessage: Send a message
     client_id: ${SLACK_CLIENT_ID}
     client_secret: ${SLACK_CLIENT_SECRET}
-    structured_response_check:
+    response_check:
       success_body_match:
         ok: true
       error_message_path: error
     auth:
       authorization_url: https://slack.com/oauth/v2/authorize
       token_url: https://slack.com/api/oauth.v2.access
-      structured_response_check:
+      response_check:
         success_body_match:
           ok: true
         error_message_path: error

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -142,7 +142,7 @@ integrations:
     auth:
       authorization_url: https://slack.com/oauth/v2/authorize
       token_url: https://slack.com/api/oauth.v2.access
-      structured_response_check:
+      response_check:
         success_body_match:
           ok: true
         error_message_path: error
@@ -168,7 +168,7 @@ auth:
   token_metadata:
     - team_id
     - team_name
-  structured_response_check:
+  response_check:
     success_body_match:
       ok: true
     error_message_path: error
@@ -187,7 +187,7 @@ auth_profiles:
     auth:
       authorization_url: https://slack.com/oauth/v2/authorize
       token_url: https://slack.com/api/oauth.v2.access
-      structured_response_check:
+      response_check:
         success_body_match:
           ok: true
         error_message_path: error

--- a/docs/pages/tasks/add-an-integration.mdx
+++ b/docs/pages/tasks/add-an-integration.mdx
@@ -25,14 +25,14 @@ integrations:
     client_id: ${SLACK_CLIENT_ID}
     client_secret: ${SLACK_CLIENT_SECRET}
     icon_file: slack.svg
-    structured_response_check:
+    response_check:
       success_body_match:
         ok: true
       error_message_path: error
     auth:
       authorization_url: https://slack.com/oauth/v2/authorize
       token_url: https://slack.com/api/oauth.v2.access
-      structured_response_check:
+      response_check:
         success_body_match:
           ok: true
         error_message_path: error

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,17 +91,17 @@ type IntegrationDef struct {
 
 	Auth AuthOverrides `yaml:"auth"`
 
-	AuthHeader              string            `yaml:"auth_header"`
-	AuthMapping             *AuthMappingDef   `yaml:"auth_mapping"`
-	ErrorMessagePath        string            `yaml:"error_message_path"`
-	StructuredResponseCheck *ResponseCheckDef `yaml:"structured_response_check"`
-	RequestMutator          string            `yaml:"request_mutator"`
-	PostConnect             string            `yaml:"post_connect"`
-	ManualAuth              bool              `yaml:"manual_auth"`
-	TokenPrefix             string            `yaml:"token_prefix"`
-	AuthStyle               string            `yaml:"auth_style"`
-	IconFile                string            `yaml:"icon_file"`
-	Headers                 map[string]string `yaml:"headers"`
+	AuthHeader       string            `yaml:"auth_header"`
+	AuthMapping      *AuthMappingDef   `yaml:"auth_mapping"`
+	ErrorMessagePath string            `yaml:"error_message_path"`
+	ResponseCheck    *ResponseCheckDef `yaml:"response_check"`
+	RequestMutator   string            `yaml:"request_mutator"`
+	PostConnect      string            `yaml:"post_connect"`
+	ManualAuth       bool              `yaml:"manual_auth"`
+	TokenPrefix      string            `yaml:"token_prefix"`
+	AuthStyle        string            `yaml:"auth_style"`
+	IconFile         string            `yaml:"icon_file"`
+	Headers          map[string]string `yaml:"headers"`
 }
 
 const (
@@ -156,21 +156,21 @@ func (a *AllowedOps) UnmarshalYAML(value *yaml.Node) error {
 }
 
 type AuthOverrides struct {
-	Type                    string            `yaml:"type"`
-	AuthorizationURL        string            `yaml:"authorization_url"`
-	TokenURL                string            `yaml:"token_url"`
-	ClientAuth              string            `yaml:"client_auth"`
-	TokenExchange           string            `yaml:"token_exchange"`
-	Scopes                  []string          `yaml:"scopes"`
-	ScopeSeparator          string            `yaml:"scope_separator"`
-	PKCE                    bool              `yaml:"pkce"`
-	AuthorizationParams     map[string]string `yaml:"authorization_params"`
-	TokenParams             map[string]string `yaml:"token_params"`
-	RefreshParams           map[string]string `yaml:"refresh_params"`
-	AcceptHeader            string            `yaml:"accept_header"`
-	TokenMetadata           []string          `yaml:"token_metadata"`
-	StructuredResponseCheck *ResponseCheckDef `yaml:"structured_response_check"`
-	AuthHeader              string            `yaml:"auth_header"`
+	Type                string            `yaml:"type"`
+	AuthorizationURL    string            `yaml:"authorization_url"`
+	TokenURL            string            `yaml:"token_url"`
+	ClientAuth          string            `yaml:"client_auth"`
+	TokenExchange       string            `yaml:"token_exchange"`
+	Scopes              []string          `yaml:"scopes"`
+	ScopeSeparator      string            `yaml:"scope_separator"`
+	PKCE                bool              `yaml:"pkce"`
+	AuthorizationParams map[string]string `yaml:"authorization_params"`
+	TokenParams         map[string]string `yaml:"token_params"`
+	RefreshParams       map[string]string `yaml:"refresh_params"`
+	AcceptHeader        string            `yaml:"accept_header"`
+	TokenMetadata       []string          `yaml:"token_metadata"`
+	ResponseCheck       *ResponseCheckDef `yaml:"response_check"`
+	AuthHeader          string            `yaml:"auth_header"`
 }
 
 type AuthMappingDef struct {
@@ -358,8 +358,8 @@ func fillAuthDefaults(dst, src *AuthOverrides) {
 	if dst.TokenMetadata == nil {
 		dst.TokenMetadata = src.TokenMetadata
 	}
-	if dst.StructuredResponseCheck == nil {
-		dst.StructuredResponseCheck = src.StructuredResponseCheck
+	if dst.ResponseCheck == nil {
+		dst.ResponseCheck = src.ResponseCheck
 	}
 	if dst.AuthHeader == "" {
 		dst.AuthHeader = src.AuthHeader

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -442,45 +442,6 @@ func TestLoadEmptyConfigFallsThrough(t *testing.T) {
 	}
 }
 
-func TestLoadRejectsUnknownFields(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name        string
-		yaml        string
-		wantMessage string
-	}{
-		{
-			name: "legacy global mcp block",
-			yaml: `
-auth:
-  provider: google
-datastore:
-  provider: sqlite
-server:
-  encryption_key: key123
-mcp:
-  enabled: true
-`,
-			wantMessage: "field mcp not found in type config.Config",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			path := mustWriteConfigFile(t, tc.yaml)
-			_, err := Load(path)
-			if err == nil {
-				t.Fatal("Load: expected error, got nil")
-			}
-			if !strings.Contains(err.Error(), tc.wantMessage) {
-				t.Fatalf("Load: expected error containing %q, got %v", tc.wantMessage, err)
-			}
-		})
-	}
-}
-
 func TestHelmValuesConfigLoads(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -115,8 +115,8 @@ func Build(def *Definition, intg config.IntegrationDef, allowedOperations map[st
 	}
 
 	switch {
-	case def.StructuredResponseCheck != nil:
-		base.CheckResponse = buildStructuredResponseChecker(def.StructuredResponseCheck)
+	case def.ResponseCheck != nil:
+		base.CheckResponse = buildResponseChecker(def.ResponseCheck)
 	case def.ErrorMessagePath != "":
 		msgPath := def.ErrorMessagePath
 		base.CheckResponse = func(status int, body []byte) error {
@@ -289,16 +289,16 @@ func ApplyIntegrationOverrides(def *Definition, intg config.IntegrationDef) erro
 	if intg.AuthMapping != nil {
 		def.AuthMapping = &AuthMappingDef{Headers: intg.AuthMapping.Headers}
 	}
-	if intg.StructuredResponseCheck != nil {
-		def.StructuredResponseCheck = &ResponseCheckDef{
-			SuccessBodyMatch: intg.StructuredResponseCheck.SuccessBodyMatch,
-			ErrorMessagePath: intg.StructuredResponseCheck.ErrorMessagePath,
+	if intg.ResponseCheck != nil {
+		def.ResponseCheck = &ResponseCheckDef{
+			SuccessBodyMatch: intg.ResponseCheck.SuccessBodyMatch,
+			ErrorMessagePath: intg.ResponseCheck.ErrorMessagePath,
 		}
 	}
-	if intg.Auth.StructuredResponseCheck != nil {
-		def.Auth.StructuredResponseCheck = &ResponseCheckDef{
-			SuccessBodyMatch: intg.Auth.StructuredResponseCheck.SuccessBodyMatch,
-			ErrorMessagePath: intg.Auth.StructuredResponseCheck.ErrorMessagePath,
+	if intg.Auth.ResponseCheck != nil {
+		def.Auth.ResponseCheck = &ResponseCheckDef{
+			SuccessBodyMatch: intg.Auth.ResponseCheck.SuccessBodyMatch,
+			ErrorMessagePath: intg.Auth.ResponseCheck.ErrorMessagePath,
 		}
 	}
 	setStr(&def.ErrorMessagePath, intg.ErrorMessagePath)
@@ -370,8 +370,8 @@ func buildAuth(def *Definition, intg config.IntegrationDef, baseURL string, clie
 	var opts []oauth.Option
 	opts = append(opts, oauth.WithHTTPClient(client))
 
-	if def.Auth.StructuredResponseCheck != nil {
-		rcd := def.Auth.StructuredResponseCheck
+	if def.Auth.ResponseCheck != nil {
+		rcd := def.Auth.ResponseCheck
 		opts = append(opts, oauth.WithResponseHook(func(body []byte) error {
 			var data map[string]any
 			if err := json.Unmarshal(body, &data); err != nil {
@@ -393,7 +393,7 @@ func buildAuth(def *Definition, intg config.IntegrationDef, baseURL string, clie
 	return ci.UpstreamAuth{Handler: upstream}, nil
 }
 
-func buildStructuredResponseChecker(rcd *ResponseCheckDef) apiexec.ResponseChecker {
+func buildResponseChecker(rcd *ResponseCheckDef) apiexec.ResponseChecker {
 	return func(status int, body []byte) error {
 		var data map[string]any
 		if err := json.Unmarshal(body, &data); err != nil {

--- a/internal/provider/build_test.go
+++ b/internal/provider/build_test.go
@@ -689,7 +689,7 @@ func TestBuildUnknownPostConnectHook(t *testing.T) {
 	}
 }
 
-func TestBuildStructuredResponseCheck_SuccessMatch(t *testing.T) {
+func TestBuildResponseCheck_SuccessMatch(t *testing.T) {
 	t.Parallel()
 
 	const successKey = "ok"
@@ -705,7 +705,7 @@ func TestBuildStructuredResponseCheck_SuccessMatch(t *testing.T) {
 		DisplayName: "Check OK API",
 		BaseURL:     srv.URL,
 		Auth:        AuthDef{Type: "manual"},
-		StructuredResponseCheck: &ResponseCheckDef{
+		ResponseCheck: &ResponseCheckDef{
 			SuccessBodyMatch: map[string]any{successKey: true},
 			ErrorMessagePath: "error",
 		},
@@ -728,7 +728,7 @@ func TestBuildStructuredResponseCheck_SuccessMatch(t *testing.T) {
 	}
 }
 
-func TestBuildStructuredResponseCheck_FailureMatch(t *testing.T) {
+func TestBuildResponseCheck_FailureMatch(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -748,7 +748,7 @@ func TestBuildStructuredResponseCheck_FailureMatch(t *testing.T) {
 		DisplayName: "Check Fail API",
 		BaseURL:     srv.URL,
 		Auth:        AuthDef{Type: "manual"},
-		StructuredResponseCheck: &ResponseCheckDef{
+		ResponseCheck: &ResponseCheckDef{
 			SuccessBodyMatch: map[string]any{successKey: true},
 			ErrorMessagePath: errorKey,
 		},
@@ -771,7 +771,7 @@ func TestBuildStructuredResponseCheck_FailureMatch(t *testing.T) {
 	}
 }
 
-func TestBuildStructuredResponseCheck_NonJSON200(t *testing.T) {
+func TestBuildResponseCheck_NonJSON200(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -786,7 +786,7 @@ func TestBuildStructuredResponseCheck_NonJSON200(t *testing.T) {
 		DisplayName: "Check Text OK API",
 		BaseURL:     srv.URL,
 		Auth:        AuthDef{Type: "manual"},
-		StructuredResponseCheck: &ResponseCheckDef{
+		ResponseCheck: &ResponseCheckDef{
 			SuccessBodyMatch: map[string]any{"ok": true},
 			ErrorMessagePath: "error",
 		},
@@ -806,7 +806,7 @@ func TestBuildStructuredResponseCheck_NonJSON200(t *testing.T) {
 	}
 }
 
-func TestBuildStructuredResponseCheck_NonJSON500(t *testing.T) {
+func TestBuildResponseCheck_NonJSON500(t *testing.T) {
 	t.Parallel()
 
 	const serverErrorStatus = http.StatusInternalServerError
@@ -823,7 +823,7 @@ func TestBuildStructuredResponseCheck_NonJSON500(t *testing.T) {
 		DisplayName: "Check Text Err API",
 		BaseURL:     srv.URL,
 		Auth:        AuthDef{Type: "manual"},
-		StructuredResponseCheck: &ResponseCheckDef{
+		ResponseCheck: &ResponseCheckDef{
 			SuccessBodyMatch: map[string]any{"ok": true},
 			ErrorMessagePath: "error",
 		},
@@ -843,7 +843,7 @@ func TestBuildStructuredResponseCheck_NonJSON500(t *testing.T) {
 	}
 }
 
-func TestBuildStructuredResponseCheck_SuccessMatchOnly(t *testing.T) {
+func TestBuildResponseCheck_SuccessMatchOnly(t *testing.T) {
 	t.Parallel()
 
 	def := &Definition{
@@ -851,7 +851,7 @@ func TestBuildStructuredResponseCheck_SuccessMatchOnly(t *testing.T) {
 		DisplayName: "Check Match Only API",
 		BaseURL:     "https://api.example.com",
 		Auth:        AuthDef{Type: "manual"},
-		StructuredResponseCheck: &ResponseCheckDef{
+		ResponseCheck: &ResponseCheckDef{
 			SuccessBodyMatch: map[string]any{"ok": true},
 		},
 		Operations: map[string]OperationDef{
@@ -865,7 +865,7 @@ func TestBuildStructuredResponseCheck_SuccessMatchOnly(t *testing.T) {
 	}
 }
 
-func TestBuildStructuredResponseCheck_ErrorMessagePathOnly(t *testing.T) {
+func TestBuildResponseCheck_ErrorMessagePathOnly(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -885,7 +885,7 @@ func TestBuildStructuredResponseCheck_ErrorMessagePathOnly(t *testing.T) {
 		DisplayName: "Check ErrPath API",
 		BaseURL:     srv.URL,
 		Auth:        AuthDef{Type: "manual"},
-		StructuredResponseCheck: &ResponseCheckDef{
+		ResponseCheck: &ResponseCheckDef{
 			ErrorMessagePath: msgKey,
 		},
 		Operations: map[string]OperationDef{

--- a/internal/provider/definition.go
+++ b/internal/provider/definition.go
@@ -17,10 +17,10 @@ type Definition struct {
 	AuthMapping      *AuthMappingDef   `yaml:"auth_mapping" json:"auth_mapping"`
 	ErrorMessagePath string            `yaml:"error_message_path" json:"error_message_path"`
 
-	StructuredResponseCheck *ResponseCheckDef `yaml:"structured_response_check" json:"structured_response_check,omitempty"`
-	RequestMutator          string            `yaml:"request_mutator" json:"request_mutator"`
-	PostConnect             string            `yaml:"post_connect" json:"post_connect"`
-	ManualAuth              bool              `yaml:"manual_auth" json:"manual_auth"`
+	ResponseCheck  *ResponseCheckDef `yaml:"response_check" json:"response_check,omitempty"`
+	RequestMutator string            `yaml:"request_mutator" json:"request_mutator"`
+	PostConnect    string            `yaml:"post_connect" json:"post_connect"`
+	ManualAuth     bool              `yaml:"manual_auth" json:"manual_auth"`
 
 	Connection map[string]ConnectionParamDef `yaml:"connection" json:"connection"`
 	Operations map[string]OperationDef       `yaml:"operations" json:"operations"`
@@ -40,20 +40,20 @@ type ConnectionParamDef struct {
 }
 
 type AuthDef struct {
-	Type                    string            `yaml:"type" json:"type"` // oauth2, manual
-	AuthorizationURL        string            `yaml:"authorization_url" json:"authorization_url"`
-	TokenURL                string            `yaml:"token_url" json:"token_url"`
-	ClientAuth              string            `yaml:"client_auth" json:"client_auth"`       // body (default), header
-	TokenExchange           string            `yaml:"token_exchange" json:"token_exchange"` // form (default), json
-	Scopes                  []string          `yaml:"scopes" json:"scopes"`
-	ScopeSeparator          string            `yaml:"scope_separator" json:"scope_separator"`
-	PKCE                    bool              `yaml:"pkce" json:"pkce"`
-	AuthorizationParams     map[string]string `yaml:"authorization_params" json:"authorization_params"`
-	TokenParams             map[string]string `yaml:"token_params" json:"token_params"`
-	RefreshParams           map[string]string `yaml:"refresh_params" json:"refresh_params"`
-	AcceptHeader            string            `yaml:"accept_header" json:"accept_header"`
-	TokenMetadata           []string          `yaml:"token_metadata" json:"token_metadata"`
-	StructuredResponseCheck *ResponseCheckDef `yaml:"structured_response_check" json:"structured_response_check,omitempty"`
+	Type                string            `yaml:"type" json:"type"` // oauth2, manual
+	AuthorizationURL    string            `yaml:"authorization_url" json:"authorization_url"`
+	TokenURL            string            `yaml:"token_url" json:"token_url"`
+	ClientAuth          string            `yaml:"client_auth" json:"client_auth"`       // body (default), header
+	TokenExchange       string            `yaml:"token_exchange" json:"token_exchange"` // form (default), json
+	Scopes              []string          `yaml:"scopes" json:"scopes"`
+	ScopeSeparator      string            `yaml:"scope_separator" json:"scope_separator"`
+	PKCE                bool              `yaml:"pkce" json:"pkce"`
+	AuthorizationParams map[string]string `yaml:"authorization_params" json:"authorization_params"`
+	TokenParams         map[string]string `yaml:"token_params" json:"token_params"`
+	RefreshParams       map[string]string `yaml:"refresh_params" json:"refresh_params"`
+	AcceptHeader        string            `yaml:"accept_header" json:"accept_header"`
+	TokenMetadata       []string          `yaml:"token_metadata" json:"token_metadata"`
+	ResponseCheck       *ResponseCheckDef `yaml:"response_check" json:"response_check,omitempty"`
 }
 
 type OperationDef struct {


### PR DESCRIPTION
The `structured_response_check` field was named with a "structured_"
prefix to distinguish it from the old string-based `response_check`
field, which has since been removed. With no ambiguity remaining, this
renames it to the simpler `response_check` across Go types, config
parsing, YAML/JSON tags, tests, and documentation.

This also removes guard tests that existed solely to validate rejection
of previously removed features (the `--check` CLI flag and the
top-level `mcp` config block). Both are already rejected by standard
flag parsing and strict YAML decoding respectively, making the
dedicated tests redundant.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>