### PR TITLE
Add Jira Cloud as a first-party declarative provider

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -36,6 +36,7 @@ import (
 	"github.com/valon-technologies/gestalt/plugins/datastore/sqlite"
 	"github.com/valon-technologies/gestalt/plugins/datastore/sqlserver"
 	"github.com/valon-technologies/gestalt/plugins/providers/echo"
+	"github.com/valon-technologies/gestalt/plugins/providers/jira"
 	echoruntime "github.com/valon-technologies/gestalt/plugins/runtimes/echo"
 	secretsenv "github.com/valon-technologies/gestalt/plugins/secrets/env"
 	secretsfile "github.com/valon-technologies/gestalt/plugins/secrets/file"
@@ -103,6 +104,7 @@ func buildFactories(preparedProviders map[string]string, devMode bool) *bootstra
 	factories.Datastores["oracle"] = oracle.Factory
 	factories.Datastores["firestore"] = firestore.Factory
 	factories.Datastores["sqlserver"] = sqlserver.Factory
+	factories.Providers["jira"] = jira.Factory
 	factories.DefaultProvider = defaultProviderFactory(preparedProviders)
 	if devMode {
 		factories.Builtins = append(factories.Builtins, echo.New())

--- a/plugins/providers/jira/factory.go
+++ b/plugins/providers/jira/factory.go
@@ -1,0 +1,23 @@
+package jira
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, err
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/jira/factory_test.go
+++ b/plugins/providers/jira/factory_test.go
@@ -1,0 +1,91 @@
+package jira
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	testClientID     = "dummy-client-id"
+	testClientSecret = "dummy-client-secret"
+	expectedOps      = 7
+	discoveryURL     = "https://api.atlassian.com/oauth/token/accessible-resources"
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if def.Provider != "jira" {
+		t.Fatalf("expected provider jira, got %q", def.Provider)
+	}
+	if len(def.Operations) != expectedOps {
+		t.Fatalf("expected %d operations, got %d", expectedOps, len(def.Operations))
+	}
+
+	cloudID, ok := def.Connection["cloud_id"]
+	if !ok {
+		t.Fatal("missing cloud_id connection param")
+	}
+	if cloudID.From != "discovery" {
+		t.Fatalf("expected cloud_id from=discovery, got %q", cloudID.From)
+	}
+	if !cloudID.Required {
+		t.Fatal("expected cloud_id to be required")
+	}
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	intg := config.IntegrationDef{
+		ClientID:     testClientID,
+		ClientSecret: testClientSecret,
+	}
+
+	prov, err := provider.Build(&def, intg, nil)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if prov.Name() != "jira" {
+		t.Fatalf("expected name jira, got %q", prov.Name())
+	}
+	if prov.ConnectionMode() != core.ConnectionModeUser {
+		t.Fatalf("expected connection mode user, got %q", prov.ConnectionMode())
+	}
+
+	ops := prov.ListOperations()
+	if len(ops) != expectedOps {
+		t.Fatalf("expected %d operations, got %d", expectedOps, len(ops))
+	}
+
+	dcp, ok := prov.(core.DiscoveryConfigProvider)
+	if !ok {
+		t.Fatal("provider does not implement DiscoveryConfigProvider")
+	}
+
+	dc := dcp.DiscoveryConfig()
+	if dc == nil {
+		t.Fatal("DiscoveryConfig() returned nil")
+	}
+	if dc.URL != discoveryURL {
+		t.Fatalf("expected discovery URL %q, got %q", discoveryURL, dc.URL)
+	}
+	if dc.MetadataMapping["cloud_id"] != "id" {
+		t.Fatalf("expected metadata_mapping cloud_id=id, got %q", dc.MetadataMapping["cloud_id"])
+	}
+}

--- a/plugins/providers/jira/provider.yaml
+++ b/plugins/providers/jira/provider.yaml
@@ -1,0 +1,77 @@
+provider: jira
+display_name: Jira Cloud
+description: Atlassian Jira Cloud project and issue management
+connection_mode: user
+base_url: "https://api.atlassian.com/ex/jira/{cloud_id}/rest/api/3"
+
+auth:
+  type: oauth2
+  authorization_url: https://auth.atlassian.com/authorize
+  token_url: https://auth.atlassian.com/oauth/token
+  scopes: [read:me, read:jira-work, write:jira-work, offline_access]
+  authorization_params:
+    audience: api.atlassian.com
+    prompt: consent
+
+post_connect_discovery:
+  url: https://api.atlassian.com/oauth/token/accessible-resources
+  id_path: id
+  name_path: name
+  metadata_mapping:
+    cloud_id: id
+
+connection:
+  cloud_id:
+    required: true
+    description: Jira Cloud site identifier (discovered automatically)
+    from: discovery
+
+operations:
+  list_projects:
+    description: List all accessible projects
+    method: GET
+    path: /project
+    parameters:
+      - {name: maxResults, type: integer, description: Maximum results to return}
+  get_issue:
+    description: Get a Jira issue by key
+    method: GET
+    path: "/issue/{issueIdOrKey}"
+    parameters:
+      - {name: issueIdOrKey, type: string, required: true, description: "Issue key (e.g. PROJ-123)"}
+      - {name: fields, type: string, description: Comma-separated list of fields}
+  search_issues:
+    description: Search issues using JQL
+    method: POST
+    path: /search
+    parameters:
+      - {name: jql, type: string, required: true, description: JQL query string}
+      - {name: maxResults, type: integer, description: Maximum results}
+      - {name: startAt, type: integer, description: Starting index}
+      - {name: fields, type: array, description: List of field names to return}
+  create_issue:
+    description: Create a new issue
+    method: POST
+    path: /issue
+    parameters:
+      - {name: fields, type: object, required: true, description: "Issue fields (project, issuetype, summary, etc.)"}
+  add_comment:
+    description: Add a comment to an issue
+    method: POST
+    path: "/issue/{issueIdOrKey}/comment"
+    parameters:
+      - {name: issueIdOrKey, type: string, required: true, description: Issue key}
+      - {name: body, type: object, required: true, description: Comment body in ADF format}
+  get_transitions:
+    description: Get available transitions for an issue
+    method: GET
+    path: "/issue/{issueIdOrKey}/transitions"
+    parameters:
+      - {name: issueIdOrKey, type: string, required: true, description: Issue key}
+  transition_issue:
+    description: Transition an issue to a new status
+    method: POST
+    path: "/issue/{issueIdOrKey}/transitions"
+    parameters:
+      - {name: issueIdOrKey, type: string, required: true, description: Issue key}
+      - {name: transition, type: object, required: true, description: Transition object with id field}


### PR DESCRIPTION
Jira Cloud is now available as a named provider requiring only
`client_id` and `client_secret` in the user's config. The provider
uses post-connect discovery to call Atlassian's accessible-resources
endpoint after OAuth, resolving the cloud site ID automatically. For
accounts with access to multiple Jira sites, the staged connection
selection flow lets the user choose which site to connect. The
resolved `cloud_id` is interpolated into the base URL for all
subsequent API calls.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>