### PR TITLE
Add BigQuery REST base provider and relax overlay validation

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -35,6 +35,7 @@ import (
 	"github.com/valon-technologies/gestalt/plugins/datastore/postgres"
 	"github.com/valon-technologies/gestalt/plugins/datastore/sqlite"
 	"github.com/valon-technologies/gestalt/plugins/datastore/sqlserver"
+	"github.com/valon-technologies/gestalt/plugins/providers/bigquery"
 	"github.com/valon-technologies/gestalt/plugins/providers/echo"
 	"github.com/valon-technologies/gestalt/plugins/providers/jira"
 	echoruntime "github.com/valon-technologies/gestalt/plugins/runtimes/echo"
@@ -105,6 +106,7 @@ func buildFactories(preparedProviders map[string]string, devMode bool) *bootstra
 	factories.Datastores["firestore"] = firestore.Factory
 	factories.Datastores["sqlserver"] = sqlserver.Factory
 	factories.Providers["jira"] = jira.Factory
+	factories.Providers["bigquery"] = bigquery.Factory
 	factories.DefaultProvider = defaultProviderFactory(preparedProviders)
 	if devMode {
 		factories.Builtins = append(factories.Builtins, echo.New())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -466,9 +466,6 @@ func validate(cfg *Config) error {
 				}
 				continue
 			case PluginModeOverlay:
-				if len(intg.Upstreams) == 0 {
-					return fmt.Errorf("config validation: integration %q overlay plugin requires at least one upstream", name)
-				}
 			default:
 				return fmt.Errorf("config validation: integration %q has unknown plugin mode %q", name, intg.Plugin.Mode)
 			}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -354,7 +354,7 @@ integrations:
 			wantErr: false,
 		},
 		{
-			name: "overlay plugin without upstreams",
+			name: "overlay plugin without upstreams allowed",
 			yaml: `
 auth:
   provider: google
@@ -368,7 +368,7 @@ integrations:
       mode: overlay
       command: /tmp/plugin
 `,
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "replace plugin with upstreams rejected",
@@ -514,23 +514,6 @@ func TestPluginModeValidationMessages(t *testing.T) {
 		yaml        string
 		wantContain string
 	}{
-		{
-			name: "overlay without upstreams",
-			yaml: `
-auth:
-  provider: google
-datastore:
-  provider: sqlite
-server:
-  encryption_key: key123
-integrations:
-  gadget:
-    plugin:
-      mode: overlay
-      command: /tmp/plugin
-`,
-			wantContain: "overlay plugin requires",
-		},
 		{
 			name: "replace with upstreams",
 			yaml: `

--- a/plugins/providers/bigquery/factory.go
+++ b/plugins/providers/bigquery/factory.go
@@ -1,0 +1,25 @@
+package bigquery
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("bigquery: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/bigquery/factory_test.go
+++ b/plugins/providers/bigquery/factory_test.go
@@ -1,0 +1,84 @@
+package bigquery
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+const (
+	dummyClientID     = "dummy-client-id"
+	dummyClientSecret = "dummy-client-secret"
+	expectedOpCount   = 5
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if def.Provider != "bigquery" {
+		t.Fatalf("provider = %q, want bigquery", def.Provider)
+	}
+	if def.ConnectionMode != "user" {
+		t.Fatalf("connection_mode = %q, want user", def.ConnectionMode)
+	}
+	if len(def.Operations) != expectedOpCount {
+		t.Fatalf("operations = %d, want %d", len(def.Operations), expectedOpCount)
+	}
+
+	wantOps := []string{"list_datasets", "get_dataset", "list_tables", "get_table", "list_routines"}
+	for _, name := range wantOps {
+		if _, ok := def.Operations[name]; !ok {
+			t.Errorf("missing operation %q", name)
+		}
+	}
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	intg := config.IntegrationDef{
+		ClientID:     dummyClientID,
+		ClientSecret: dummyClientSecret,
+	}
+
+	p, err := provider.Build(&def, intg, nil)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if p.Name() != "bigquery" {
+		t.Fatalf("Name() = %q, want bigquery", p.Name())
+	}
+	if p.ConnectionMode() != core.ConnectionModeUser {
+		t.Fatalf("ConnectionMode() = %q, want user", p.ConnectionMode())
+	}
+
+	ops := p.ListOperations()
+	if len(ops) != expectedOpCount {
+		t.Fatalf("ListOperations() = %d, want %d", len(ops), expectedOpCount)
+	}
+
+	opNames := make(map[string]bool, len(ops))
+	for _, op := range ops {
+		opNames[op.Name] = true
+	}
+	for _, name := range []string{"list_datasets", "get_dataset", "list_tables", "get_table", "list_routines"} {
+		if !opNames[name] {
+			t.Errorf("missing operation %q in built provider", name)
+		}
+	}
+}

--- a/plugins/providers/bigquery/provider.yaml
+++ b/plugins/providers/bigquery/provider.yaml
@@ -1,0 +1,55 @@
+provider: bigquery
+display_name: BigQuery
+description: Google BigQuery data warehouse
+connection_mode: user
+base_url: "https://bigquery.googleapis.com/bigquery/v2"
+
+auth:
+  type: oauth2
+  authorization_url: https://accounts.google.com/o/oauth2/v2/auth
+  token_url: https://oauth2.googleapis.com/token
+  scopes:
+    - https://www.googleapis.com/auth/bigquery
+  authorization_params:
+    access_type: offline
+    prompt: consent
+
+operations:
+  list_datasets:
+    description: List datasets in a project
+    method: GET
+    path: "/projects/{project_id}/datasets"
+    parameters:
+      - {name: project_id, type: string, required: true, description: GCP project ID}
+      - {name: maxResults, type: integer, description: Maximum results}
+  get_dataset:
+    description: Get dataset metadata
+    method: GET
+    path: "/projects/{project_id}/datasets/{dataset_id}"
+    parameters:
+      - {name: project_id, type: string, required: true, description: GCP project ID}
+      - {name: dataset_id, type: string, required: true, description: Dataset ID}
+  list_tables:
+    description: List tables in a dataset
+    method: GET
+    path: "/projects/{project_id}/datasets/{dataset_id}/tables"
+    parameters:
+      - {name: project_id, type: string, required: true, description: GCP project ID}
+      - {name: dataset_id, type: string, required: true, description: Dataset ID}
+      - {name: maxResults, type: integer, description: Maximum results}
+  get_table:
+    description: Get table metadata
+    method: GET
+    path: "/projects/{project_id}/datasets/{dataset_id}/tables/{table_id}"
+    parameters:
+      - {name: project_id, type: string, required: true, description: GCP project ID}
+      - {name: dataset_id, type: string, required: true, description: Dataset ID}
+      - {name: table_id, type: string, required: true, description: Table ID}
+  list_routines:
+    description: List routines in a dataset
+    method: GET
+    path: "/projects/{project_id}/datasets/{dataset_id}/routines"
+    parameters:
+      - {name: project_id, type: string, required: true, description: GCP project ID}
+      - {name: dataset_id, type: string, required: true, description: Dataset ID}
+      - {name: maxResults, type: integer, description: Maximum results}


### PR DESCRIPTION
BigQuery's REST metadata operations are now available as a named
provider, covering `list_datasets`, `get_dataset`, `list_tables`,
`get_table`, and `list_routines`. This serves as the declarative base
for an upcoming overlay plugin that adds SDK-backed SQL query execution.

Config validation previously rejected `plugin.mode: overlay` without
upstreams, but named factories can supply the overlay base directly.
Bootstrap already fails with a clear error when no factory handles the
base, making the validation check redundant.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>