### PR TITLE
Move BindingSurface routes behind auth middleware

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -116,21 +116,11 @@ func (s *Server) routes() {
 		r.Post("/auth/logout", s.logout)
 		r.Get("/auth/callback", s.integrationOAuthCallback)
 
-		if s.bindings != nil {
-			for _, name := range s.bindings.List() {
-				binding, err := s.bindings.Get(name)
-				if err != nil {
-					log.Printf("warning: skipping binding %q routes: %v", name, err)
-					continue
-				}
-				for _, route := range binding.Routes() {
-					r.Method(route.Method, "/bindings/"+name+route.Pattern, route.Handler)
-				}
-			}
-		}
+		s.mountBindingRoutes(r, core.BindingTrigger)
 
 		r.Group(func(r chi.Router) {
 			r.Use(s.authMiddleware)
+			s.mountBindingRoutes(r, core.BindingSurface)
 
 			r.Get("/integrations", s.listIntegrations)
 			r.Delete("/integrations/{name}", s.disconnectIntegration)
@@ -165,6 +155,25 @@ func (s *Server) stagedConnectionStore() (core.StagedConnectionStore, error) {
 		return nil, fmt.Errorf("datastore does not support staged connections; use a SQL-backed datastore (sqlite, postgres, mysql)")
 	}
 	return scs, nil
+}
+
+func (s *Server) mountBindingRoutes(r chi.Router, kind core.BindingKind) {
+	if s.bindings == nil {
+		return
+	}
+	for _, name := range s.bindings.List() {
+		binding, err := s.bindings.Get(name)
+		if err != nil {
+			log.Printf("warning: skipping binding %q routes: %v", name, err)
+			continue
+		}
+		if binding.Kind() != kind {
+			continue
+		}
+		for _, route := range binding.Routes() {
+			r.Method(route.Method, "/bindings/"+name+route.Pattern, route.Handler)
+		}
+	}
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2946,6 +2946,78 @@ func TestBindingRoutesMounted(t *testing.T) {
 	}
 }
 
+func TestSurfaceBindingRequiresAuth(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	bindings := registry.NewBindingMap()
+	if err := bindings.Register("test-surface", &coretesting.StubBinding{
+		N: "test-surface",
+		K: core.BindingSurface,
+		R: []core.Route{
+			{Method: http.MethodPost, Pattern: "/invoke", Handler: handler},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Bindings = bindings
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Post(ts.URL+"/api/v1/bindings/test-surface/invoke", "application/json", nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestTriggerBindingRemainsPublic(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	bindings := registry.NewBindingMap()
+	if err := bindings.Register("test-trigger", &coretesting.StubBinding{
+		N: "test-trigger",
+		K: core.BindingTrigger,
+		R: []core.Route{
+			{Method: http.MethodPost, Pattern: "/incoming", Handler: handler},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Bindings = bindings
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Post(ts.URL+"/api/v1/bindings/test-trigger/incoming", "application/json", nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
 func TestProxyBindingRoutesMountedAsPrefix(t *testing.T) {
 	t.Parallel()
 
@@ -3007,6 +3079,11 @@ func TestProxyBindingRoutesMountedAsPrefix(t *testing.T) {
 			ts := newTestServer(t, func(cfg *server.Config) {
 				cfg.DevMode = true
 				cfg.Bindings = bindings
+				cfg.Datastore = &coretesting.StubDatastore{
+					FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+						return &core.User{ID: "u1", Email: email}, nil
+					},
+				}
 			})
 			testutil.CloseOnCleanup(t, ts)
 
@@ -3017,6 +3094,7 @@ func TestProxyBindingRoutesMountedAsPrefix(t *testing.T) {
 			req.Header.Set("Content-Type", "text/plain")
 			req.Header.Set("X-Forwarded-Host", upstreamHost)
 			req.Header.Set("X-Forwarded-Proto", "http")
+			req.Header.Set("X-Dev-User-Email", "dev@example.com")
 
 			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
@@ -3057,6 +3135,7 @@ func TestProxyBindingRoutesMountedAsPrefix(t *testing.T) {
 			}
 			exactReq.Header.Set("X-Forwarded-Host", upstreamHost)
 			exactReq.Header.Set("X-Forwarded-Proto", "http")
+			exactReq.Header.Set("X-Dev-User-Email", "dev@example.com")
 
 			resp, err = http.DefaultClient.Do(exactReq)
 			if err != nil {


### PR DESCRIPTION
Binding routes were previously mounted outside the auth middleware, making proxy endpoints effectively unauthenticated. This splits binding mounting by kind: BindingTrigger routes (webhooks) stay public, while BindingSurface routes (proxy) now require the same session or bearer-token auth as other protected endpoints.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

> Part 1 of 5 in the egress resolution stack.