### PR TITLE
Add egress config surface and static policy enforcer

### DIFF
--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -12,6 +12,7 @@
 | `runtimes` | Background processes that boot alongside the server with scoped provider access. |
 | `bindings` | Alternative request surfaces such as webhooks and proxy-oriented request normalizers. |
 | `server` | Port, base URL, encryption key, and development mode. |
+| `egress` | Policy and credential rules for outbound requests made by runtimes and bindings. |
 
 ## Server block
 
@@ -252,6 +253,58 @@ bindings:
 | Config field | Default | Notes |
 |---|---|---|
 | `path` | | HTTP path prefix for the proxy surface. Must start with `/`. |
+
+## Egress block
+
+Controls policy enforcement and credential injection for outbound requests made by runtimes, bindings, and the proxy surface.
+
+```yaml
+egress:
+  default_action: allow   # "allow" (default) or "deny"
+  policies:
+    - action: deny
+      subject_kind: agent
+      provider: internal-api
+      path_prefix: /v1/admin
+    - action: allow
+      provider: internal-api
+  credentials:
+    - provider: acme-api
+      instance: acme-api
+      subject_kind: user
+```
+
+### Policy rules
+
+Rules are evaluated in order; the first matching rule wins. If no rule matches, `default_action` applies (defaults to `allow`).
+
+| Field | Notes |
+|---|---|
+| `action` | Required. `allow` or `deny`. |
+| `subject_kind` | Match subject kind: `user`, `identity`, `agent`, or `system`. Empty matches all. |
+| `subject_id` | Match a specific subject ID. Empty matches all. |
+| `provider` | Match the target provider name. Empty matches all. |
+| `operation` | Match the target operation name. Empty matches all. |
+| `method` | Match the HTTP method. Empty matches all. |
+| `host` | Exact match against the target host. Empty matches all. |
+| `path_prefix` | Segment-aware path prefix match. Empty matches all. |
+
+All non-empty fields must match for a rule to apply (AND logic).
+
+### Credential grants
+
+Credential grants control which provider credentials are injected into outbound requests. They are matched using the same field set as policy rules (minus `action`), plus `instance` to identify the credential source.
+
+| Field | Notes |
+|---|---|
+| `provider` | The provider whose credentials to inject. |
+| `instance` | The credential instance name (defaults to `provider` if omitted). |
+| `subject_kind` | Restrict to a specific subject kind. Empty matches all. |
+| `subject_id` | Restrict to a specific subject ID. Empty matches all. |
+| `operation` | Match the target operation. Empty matches all. |
+| `method` | Match the HTTP method. Empty matches all. |
+| `host` | Exact match against the target host. Empty matches all. |
+| `path_prefix` | Segment-aware path prefix match. Empty matches all. |
 
 ## Supported providers
 

--- a/internal/bootstrap/egress.go
+++ b/internal/bootstrap/egress.go
@@ -7,13 +7,49 @@ import (
 )
 
 type EgressDeps struct {
-	Resolver *egress.Resolver
+	Resolver         *egress.Resolver
+	CredentialGrants []config.EgressCredentialGrant
 }
 
-func newEgressDeps(_ *config.Config, _ core.Datastore) EgressDeps {
+func newEgressDeps(cfg *config.Config, _ core.Datastore) EgressDeps {
+	var policy egress.PolicyEnforcer
+	defaultAction := egress.PolicyAction(cfg.Egress.DefaultAction)
+	if len(cfg.Egress.Policies) > 0 || defaultAction == egress.PolicyDeny {
+		policy = buildStaticPolicyEnforcer(cfg.Egress)
+	}
+
 	return EgressDeps{
 		Resolver: &egress.Resolver{
 			Subjects: egress.ContextSubjectResolver{},
+			Policy:   policy,
 		},
+		CredentialGrants: cfg.Egress.Credentials,
+	}
+}
+
+func buildStaticPolicyEnforcer(cfg config.EgressConfig) egress.StaticPolicyEnforcer {
+	defaultAction := egress.PolicyAction(cfg.DefaultAction)
+	if defaultAction == "" {
+		defaultAction = egress.PolicyAllow
+	}
+
+	rules := make([]egress.StaticPolicyRule, len(cfg.Policies))
+	for i := range cfg.Policies {
+		r := &cfg.Policies[i]
+		rules[i] = egress.StaticPolicyRule{
+			Action:      egress.PolicyAction(r.Action),
+			SubjectKind: egress.SubjectKind(r.SubjectKind),
+			SubjectID:   r.SubjectID,
+			Provider:    r.Provider,
+			Operation:   r.Operation,
+			Method:      r.Method,
+			Host:        r.Host,
+			PathPrefix:  r.PathPrefix,
+		}
+	}
+
+	return egress.StaticPolicyEnforcer{
+		DefaultAction: defaultAction,
+		Rules:         rules,
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,35 @@ type Config struct {
 	Runtimes     map[string]RuntimeDef     `yaml:"runtimes"`
 	Bindings     map[string]BindingDef     `yaml:"bindings"`
 	Server       ServerConfig              `yaml:"server"`
+	Egress       EgressConfig              `yaml:"egress"`
+}
+
+type EgressConfig struct {
+	DefaultAction string                  `yaml:"default_action"`
+	Policies      []EgressPolicyRule      `yaml:"policies"`
+	Credentials   []EgressCredentialGrant `yaml:"credentials"`
+}
+
+type EgressPolicyRule struct {
+	Action      string `yaml:"action"`
+	SubjectKind string `yaml:"subject_kind"`
+	SubjectID   string `yaml:"subject_id"`
+	Provider    string `yaml:"provider"`
+	Operation   string `yaml:"operation"`
+	Method      string `yaml:"method"`
+	Host        string `yaml:"host"`
+	PathPrefix  string `yaml:"path_prefix"`
+}
+
+type EgressCredentialGrant struct {
+	Provider    string `yaml:"provider"`
+	Instance    string `yaml:"instance"`
+	SubjectKind string `yaml:"subject_kind"`
+	SubjectID   string `yaml:"subject_id"`
+	Operation   string `yaml:"operation"`
+	Method      string `yaml:"method"`
+	Host        string `yaml:"host"`
+	PathPrefix  string `yaml:"path_prefix"`
 }
 
 const (
@@ -449,6 +478,9 @@ func validate(cfg *Config) error {
 	if !cfg.Server.DevMode && cfg.Server.EncryptionKey == "" {
 		return fmt.Errorf("config validation: server.encryption_key is required (set server.dev_mode to true to skip)")
 	}
+	if err := validateEgress(&cfg.Egress); err != nil {
+		return err
+	}
 	for name := range cfg.Integrations {
 		intg := cfg.Integrations[name]
 		if err := validateExecutablePlugin("integration", name, intg.Plugin); err != nil {
@@ -523,6 +555,22 @@ func validateExecutablePlugin(kind, name string, plugin *ExecutablePluginDef) er
 	}
 	if plugin.Command == "" {
 		return fmt.Errorf("config validation: %s %q plugin.command is required", kind, name)
+	}
+	return nil
+}
+
+func validateEgress(cfg *EgressConfig) error {
+	switch cfg.DefaultAction {
+	case "", "allow", "deny":
+	default:
+		return fmt.Errorf("config validation: egress.default_action must be \"allow\" or \"deny\", got %q", cfg.DefaultAction)
+	}
+	for i := range cfg.Policies {
+		switch cfg.Policies[i].Action {
+		case "allow", "deny":
+		default:
+			return fmt.Errorf("config validation: egress.policies[%d].action must be \"allow\" or \"deny\", got %q", i, cfg.Policies[i].Action)
+		}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -489,6 +489,93 @@ integrations:
 `,
 			wantErr: true,
 		},
+		{
+			name: "egress default_action allow is valid",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+egress:
+  default_action: allow
+`,
+			wantErr: false,
+		},
+		{
+			name: "egress default_action deny is valid",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+egress:
+  default_action: deny
+`,
+			wantErr: false,
+		},
+		{
+			name: "egress default_action invalid",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+egress:
+  default_action: block
+`,
+			wantErr: true,
+		},
+		{
+			name: "egress policy rule valid",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+egress:
+  policies:
+    - action: deny
+      provider: restricted
+`,
+			wantErr: false,
+		},
+		{
+			name: "egress policy rule invalid action",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+egress:
+  policies:
+    - action: block
+      provider: restricted
+`,
+			wantErr: true,
+		},
+		{
+			name: "egress empty is valid",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+egress: {}
+`,
+			wantErr: false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/egress/static_policy.go
+++ b/internal/egress/static_policy.go
@@ -1,0 +1,72 @@
+package egress
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+var ErrEgressDenied = errors.New("egress denied by policy")
+
+type PolicyAction string
+
+const (
+	PolicyAllow PolicyAction = "allow"
+	PolicyDeny  PolicyAction = "deny"
+)
+
+type StaticPolicyRule struct {
+	Action      PolicyAction
+	SubjectKind SubjectKind
+	SubjectID   string
+	Provider    string
+	Operation   string
+	Method      string
+	Host        string
+	PathPrefix  string
+}
+
+type StaticPolicyEnforcer struct {
+	DefaultAction PolicyAction
+	Rules         []StaticPolicyRule
+}
+
+func (e StaticPolicyEnforcer) Evaluate(_ context.Context, input PolicyInput) error {
+	for i := range e.Rules {
+		if matchesRule(&e.Rules[i], &input) {
+			if e.Rules[i].Action == PolicyDeny {
+				return fmt.Errorf("%w: %s %s", ErrEgressDenied, input.Target.Method, input.Target.Path)
+			}
+			return nil
+		}
+	}
+	if e.DefaultAction == PolicyDeny {
+		return fmt.Errorf("%w: %s %s", ErrEgressDenied, input.Target.Method, input.Target.Path)
+	}
+	return nil
+}
+
+func matchesRule(rule *StaticPolicyRule, input *PolicyInput) bool {
+	if rule.SubjectKind != "" && rule.SubjectKind != input.Subject.Kind {
+		return false
+	}
+	if rule.SubjectID != "" && rule.SubjectID != input.Subject.ID {
+		return false
+	}
+	if rule.Provider != "" && rule.Provider != input.Target.Provider {
+		return false
+	}
+	if rule.Operation != "" && rule.Operation != input.Target.Operation {
+		return false
+	}
+	if rule.Method != "" && rule.Method != input.Target.Method {
+		return false
+	}
+	if rule.Host != "" && rule.Host != input.Target.Host {
+		return false
+	}
+	if rule.PathPrefix != "" && !MatchPathPrefix(rule.PathPrefix, input.Target.Path) {
+		return false
+	}
+	return true
+}

--- a/internal/egress/static_policy_test.go
+++ b/internal/egress/static_policy_test.go
@@ -1,0 +1,222 @@
+package egress_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/internal/egress"
+)
+
+func TestStaticPolicyNoRulesAllowsByDefault(t *testing.T) {
+	t.Parallel()
+
+	resolver := egress.Resolver{
+		Subjects: egress.StaticSubjectResolver{
+			Subject: egress.Subject{Kind: egress.SubjectAgent, ID: "bot-1"},
+		},
+	}
+
+	ctx := context.Background()
+	_, err := resolver.Resolve(ctx, egress.ResolutionInput{
+		Target: egress.Target{
+			Provider:  "acme-api",
+			Operation: "list_items",
+			Method:    "GET",
+			Host:      "api.acme.test",
+			Path:      "/v1/items",
+		},
+	})
+	if err != nil {
+		t.Fatalf("no policy should allow all requests, got: %v", err)
+	}
+}
+
+func TestStaticPolicyDenyRuleBlocksResolution(t *testing.T) {
+	t.Parallel()
+
+	resolver := egress.Resolver{
+		Subjects: egress.StaticSubjectResolver{
+			Subject: egress.Subject{Kind: egress.SubjectAgent, ID: "bot-1"},
+		},
+		Policy: egress.StaticPolicyEnforcer{
+			DefaultAction: egress.PolicyAllow,
+			Rules: []egress.StaticPolicyRule{
+				{
+					Action:   egress.PolicyDeny,
+					Provider: "secret-api",
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	_, err := resolver.Resolve(ctx, egress.ResolutionInput{
+		Target: egress.Target{
+			Provider:  "secret-api",
+			Operation: "read_secrets",
+			Method:    "GET",
+			Host:      "secrets.internal.test",
+			Path:      "/v1/secrets",
+		},
+	})
+	if !errors.Is(err, egress.ErrEgressDenied) {
+		t.Fatalf("deny rule should block resolution, got: %v", err)
+	}
+
+	_, err = resolver.Resolve(ctx, egress.ResolutionInput{
+		Target: egress.Target{
+			Provider:  "public-api",
+			Operation: "list_items",
+			Method:    "GET",
+			Host:      "api.public.test",
+			Path:      "/v1/items",
+		},
+	})
+	if err != nil {
+		t.Fatalf("non-matching request should be allowed, got: %v", err)
+	}
+}
+
+func TestStaticPolicyDefaultDenyBlocksUnmatched(t *testing.T) {
+	t.Parallel()
+
+	resolver := egress.Resolver{
+		Subjects: egress.StaticSubjectResolver{
+			Subject: egress.Subject{Kind: egress.SubjectUser, ID: "user-42"},
+		},
+		Policy: egress.StaticPolicyEnforcer{
+			DefaultAction: egress.PolicyDeny,
+			Rules: []egress.StaticPolicyRule{
+				{
+					Action:   egress.PolicyAllow,
+					Provider: "trusted-api",
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	_, err := resolver.Resolve(ctx, egress.ResolutionInput{
+		Target: egress.Target{
+			Provider: "trusted-api",
+			Method:   "POST",
+			Host:     "api.trusted.test",
+			Path:     "/v1/actions",
+		},
+	})
+	if err != nil {
+		t.Fatalf("allow rule should permit resolution, got: %v", err)
+	}
+
+	_, err = resolver.Resolve(ctx, egress.ResolutionInput{
+		Target: egress.Target{
+			Provider: "unknown-api",
+			Method:   "GET",
+			Host:     "api.unknown.test",
+			Path:     "/v1/data",
+		},
+	})
+	if !errors.Is(err, egress.ErrEgressDenied) {
+		t.Fatalf("default-deny should block unmatched requests, got: %v", err)
+	}
+}
+
+func TestStaticPolicyFirstMatchWins(t *testing.T) {
+	t.Parallel()
+
+	resolver := egress.Resolver{
+		Subjects: egress.StaticSubjectResolver{
+			Subject: egress.Subject{Kind: egress.SubjectAgent, ID: "bot-1"},
+		},
+		Policy: egress.StaticPolicyEnforcer{
+			DefaultAction: egress.PolicyAllow,
+			Rules: []egress.StaticPolicyRule{
+				{
+					Action:     egress.PolicyDeny,
+					Provider:   "multi-api",
+					PathPrefix: "/v1/admin",
+				},
+				{
+					Action:   egress.PolicyAllow,
+					Provider: "multi-api",
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	_, err := resolver.Resolve(ctx, egress.ResolutionInput{
+		Target: egress.Target{
+			Provider: "multi-api",
+			Method:   "GET",
+			Host:     "api.multi.test",
+			Path:     "/v1/admin/users",
+		},
+	})
+	if !errors.Is(err, egress.ErrEgressDenied) {
+		t.Fatalf("first matching rule (deny) should win over later allow, got: %v", err)
+	}
+
+	_, err = resolver.Resolve(ctx, egress.ResolutionInput{
+		Target: egress.Target{
+			Provider: "multi-api",
+			Method:   "GET",
+			Host:     "api.multi.test",
+			Path:     "/v1/public/items",
+		},
+	})
+	if err != nil {
+		t.Fatalf("second rule (allow) should match non-admin paths, got: %v", err)
+	}
+}
+
+func TestStaticPolicyMultiFieldMatch(t *testing.T) {
+	t.Parallel()
+
+	resolver := egress.Resolver{
+		Subjects: egress.StaticSubjectResolver{
+			Subject: egress.Subject{Kind: egress.SubjectAgent, ID: "bot-1"},
+		},
+		Policy: egress.StaticPolicyEnforcer{
+			DefaultAction: egress.PolicyAllow,
+			Rules: []egress.StaticPolicyRule{
+				{
+					Action:      egress.PolicyDeny,
+					SubjectKind: egress.SubjectAgent,
+					Provider:    "restricted-api",
+					Method:      "DELETE",
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	_, err := resolver.Resolve(ctx, egress.ResolutionInput{
+		Target: egress.Target{
+			Provider: "restricted-api",
+			Method:   "DELETE",
+			Host:     "api.restricted.test",
+			Path:     "/v1/resources/123",
+		},
+	})
+	if !errors.Is(err, egress.ErrEgressDenied) {
+		t.Fatalf("all-fields-match rule should deny, got: %v", err)
+	}
+
+	_, err = resolver.Resolve(ctx, egress.ResolutionInput{
+		Target: egress.Target{
+			Provider: "restricted-api",
+			Method:   "GET",
+			Host:     "api.restricted.test",
+			Path:     "/v1/resources/123",
+		},
+	})
+	if err != nil {
+		t.Fatalf("partial match (wrong method) should not trigger deny, got: %v", err)
+	}
+}

--- a/internal/egress/subject_principal.go
+++ b/internal/egress/subject_principal.go
@@ -1,0 +1,34 @@
+package egress
+
+import (
+	"context"
+
+	"github.com/valon-technologies/gestalt/internal/principal"
+)
+
+func SubjectForPrincipal(p *principal.Principal) (Subject, bool) {
+	if p == nil {
+		return Subject{}, false
+	}
+	if p.UserID != "" && p.UserID != principal.IdentityPrincipal {
+		return Subject{Kind: SubjectUser, ID: p.UserID}, true
+	}
+	if p.Identity != nil && p.Identity.Email != "" {
+		return Subject{Kind: SubjectIdentity, ID: p.Identity.Email}, true
+	}
+	if p.UserID == principal.IdentityPrincipal {
+		return Subject{Kind: SubjectIdentity, ID: principal.IdentityPrincipal}, true
+	}
+	return Subject{}, false
+}
+
+func WithSubjectFromPrincipal(ctx context.Context, p *principal.Principal) context.Context {
+	if _, ok := SubjectFromContext(ctx); ok {
+		return ctx
+	}
+	subject, ok := SubjectForPrincipal(p)
+	if !ok {
+		return ctx
+	}
+	return WithSubject(ctx, subject)
+}

--- a/internal/invocation/broker.go
+++ b/internal/invocation/broker.go
@@ -112,13 +112,7 @@ func (b *Broker) ResolveToken(ctx context.Context, p *principal.Principal, provi
 }
 
 func (b *Broker) withSubject(ctx context.Context, p *principal.Principal) context.Context {
-	if _, ok := egress.SubjectFromContext(ctx); ok {
-		return ctx
-	}
-	if p == nil || p.UserID == "" {
-		return ctx
-	}
-	return egress.WithSubject(ctx, egress.Subject{Kind: egress.SubjectUser, ID: p.UserID})
+	return egress.WithSubjectFromPrincipal(ctx, p)
 }
 
 func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *principal.Principal, providerName, instance string) (context.Context, string, error) {

--- a/internal/mcp/binding.go
+++ b/internal/mcp/binding.go
@@ -228,16 +228,7 @@ func hydrateSessionTools(ctx context.Context, cfg Config, providerNames []string
 }
 
 func attachEgressSubject(ctx context.Context, p *principal.Principal) context.Context {
-	if _, ok := egress.SubjectFromContext(ctx); ok {
-		return ctx
-	}
-	if p == nil || p.UserID == "" {
-		return ctx
-	}
-	return egress.WithSubject(ctx, egress.Subject{
-		Kind: egress.SubjectUser,
-		ID:   p.UserID,
-	})
+	return egress.WithSubjectFromPrincipal(ctx, p)
 }
 
 func hasToolsWithPrefix(tools map[string]mcpserver.ServerTool, prefix string) bool {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -116,21 +116,11 @@ func (s *Server) routes() {
 		r.Post("/auth/logout", s.logout)
 		r.Get("/auth/callback", s.integrationOAuthCallback)
 
-		if s.bindings != nil {
-			for _, name := range s.bindings.List() {
-				binding, err := s.bindings.Get(name)
-				if err != nil {
-					log.Printf("warning: skipping binding %q routes: %v", name, err)
-					continue
-				}
-				for _, route := range binding.Routes() {
-					r.Method(route.Method, "/bindings/"+name+route.Pattern, route.Handler)
-				}
-			}
-		}
+		s.mountBindingRoutes(r, core.BindingTrigger)
 
 		r.Group(func(r chi.Router) {
 			r.Use(s.authMiddleware)
+			s.mountBindingRoutes(r, core.BindingSurface)
 
 			r.Get("/integrations", s.listIntegrations)
 			r.Delete("/integrations/{name}", s.disconnectIntegration)
@@ -165,6 +155,25 @@ func (s *Server) stagedConnectionStore() (core.StagedConnectionStore, error) {
 		return nil, fmt.Errorf("datastore does not support staged connections; use a SQL-backed datastore (sqlite, postgres, mysql)")
 	}
 	return scs, nil
+}
+
+func (s *Server) mountBindingRoutes(r chi.Router, kind core.BindingKind) {
+	if s.bindings == nil {
+		return
+	}
+	for _, name := range s.bindings.List() {
+		binding, err := s.bindings.Get(name)
+		if err != nil {
+			log.Printf("warning: skipping binding %q routes: %v", name, err)
+			continue
+		}
+		if binding.Kind() != kind {
+			continue
+		}
+		for _, route := range binding.Routes() {
+			r.Method(route.Method, "/bindings/"+name+route.Pattern, route.Handler)
+		}
+	}
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2946,6 +2946,78 @@ func TestBindingRoutesMounted(t *testing.T) {
 	}
 }
 
+func TestSurfaceBindingRequiresAuth(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	bindings := registry.NewBindingMap()
+	if err := bindings.Register("test-surface", &coretesting.StubBinding{
+		N: "test-surface",
+		K: core.BindingSurface,
+		R: []core.Route{
+			{Method: http.MethodPost, Pattern: "/invoke", Handler: handler},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Bindings = bindings
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Post(ts.URL+"/api/v1/bindings/test-surface/invoke", "application/json", nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestTriggerBindingRemainsPublic(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	bindings := registry.NewBindingMap()
+	if err := bindings.Register("test-trigger", &coretesting.StubBinding{
+		N: "test-trigger",
+		K: core.BindingTrigger,
+		R: []core.Route{
+			{Method: http.MethodPost, Pattern: "/incoming", Handler: handler},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Bindings = bindings
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Post(ts.URL+"/api/v1/bindings/test-trigger/incoming", "application/json", nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
 func TestProxyBindingRoutesMountedAsPrefix(t *testing.T) {
 	t.Parallel()
 
@@ -3007,6 +3079,11 @@ func TestProxyBindingRoutesMountedAsPrefix(t *testing.T) {
 			ts := newTestServer(t, func(cfg *server.Config) {
 				cfg.DevMode = true
 				cfg.Bindings = bindings
+				cfg.Datastore = &coretesting.StubDatastore{
+					FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+						return &core.User{ID: "u1", Email: email}, nil
+					},
+				}
 			})
 			testutil.CloseOnCleanup(t, ts)
 
@@ -3017,6 +3094,7 @@ func TestProxyBindingRoutesMountedAsPrefix(t *testing.T) {
 			req.Header.Set("Content-Type", "text/plain")
 			req.Header.Set("X-Forwarded-Host", upstreamHost)
 			req.Header.Set("X-Forwarded-Proto", "http")
+			req.Header.Set("X-Dev-User-Email", "dev@example.com")
 
 			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
@@ -3057,6 +3135,7 @@ func TestProxyBindingRoutesMountedAsPrefix(t *testing.T) {
 			}
 			exactReq.Header.Set("X-Forwarded-Host", upstreamHost)
 			exactReq.Header.Set("X-Forwarded-Proto", "http")
+			exactReq.Header.Set("X-Dev-User-Email", "dev@example.com")
 
 			resp, err = http.DefaultClient.Do(exactReq)
 			if err != nil {


### PR DESCRIPTION
Adds a top-level `egress` config block with three sections: `default_action`, `policies`, and `credentials`. The policy section is backed by a `StaticPolicyEnforcer` that evaluates ordered rules with first-match semantics over subject, provider, host, and path dimensions. The credentials section defines grant shapes for Phase 4 but is not yet wired. Config validation rejects invalid action values at parse time rather than deferring to bootstrap.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

> Part 3 of 5 in the egress resolution stack. Stacked on #121.