### PR TITLE
Make proxy binding provider-backed with credential resolution

### DIFF
--- a/core/integration/base.go
+++ b/core/integration/base.go
@@ -308,6 +308,10 @@ func (b *Base) materializeCredential(token string) (egress.CredentialMaterializa
 	return egress.MaterializeCredential(token, b.egressAuthStyle(), b.TokenParser)
 }
 
+func (b *Base) EgressMaterializeCredential(token string) (egress.CredentialMaterialization, error) {
+	return b.materializeCredential(token)
+}
+
 func (b *Base) applyAuth(req *apiexec.Request, token string) error {
 	auth, err := b.materializeCredential(token)
 	if err != nil {

--- a/docs/pages/reference/built-in-plugins.mdx
+++ b/docs/pages/reference/built-in-plugins.mdx
@@ -37,7 +37,7 @@ All SQL-based datastores (postgres, mysql, oracle, sqlserver) share a common imp
 | Name | Notes |
 |---|---|
 | `webhook` | Exposes HTTP endpoints that forward to provider operations. Supports `public`, `signed` (HMAC-SHA256), and `trusted_user_header` auth modes. Configurable path, provider, operation, and signature headers. |
-| `proxy` | Skeletal proxy-oriented binding that normalizes inbound HTTP requests into shared egress context and returns a `501 Not Implemented` placeholder. Configurable path prefix. |
+| `proxy` | Provider-backed proxy binding that forwards inbound HTTP requests to upstream hosts. Derives egress subjects from the authenticated principal, sanitizes inbound auth headers, and resolves outbound credentials through the configured provider. Requires exactly one provider. Configurable path prefix and optional instance qualifier. |
 
 ## Runtimes
 

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -231,8 +231,11 @@ bindings:
 
   agent-proxy:
     type: proxy
+    providers:
+      - slack
     config:
       path: /proxy
+      instance: workspace-1
 ```
 
 ### Webhook config
@@ -249,9 +252,12 @@ bindings:
 
 ### Proxy config
 
+Proxy bindings require exactly one entry in the top-level `providers` list. This provider is used for credential resolution on outbound requests. The authenticated user's principal is mapped to an egress subject so that per-user tokens can be resolved.
+
 | Config field | Default | Notes |
 |---|---|---|
 | `path` | | HTTP path prefix for the proxy surface. Must start with `/`. |
+| `instance` | | Optional provider instance qualifier for credential resolution. |
 
 ## Egress block
 

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -142,6 +142,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	}()
 
 	sharedInvoker := invocation.NewBroker(providers, ds)
+	wireCredentialResolver(&deps.Egress, sharedInvoker, providers)
 	audit := core.AuditSink(invocation.LogAuditSink{})
 
 	runtimes, err := buildRuntimes(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress)

--- a/internal/bootstrap/egress.go
+++ b/internal/bootstrap/egress.go
@@ -1,9 +1,14 @@
 package bootstrap
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/egress"
+	"github.com/valon-technologies/gestalt/internal/invocation"
+	"github.com/valon-technologies/gestalt/internal/registry"
 )
 
 type EgressDeps struct {
@@ -27,6 +32,73 @@ func newEgressDeps(cfg *config.Config, _ core.Datastore) EgressDeps {
 	}
 }
 
+func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, providers *registry.PluginMap[core.Provider]) {
+	if len(deps.CredentialGrants) == 0 {
+		return
+	}
+
+	grants := make([]egress.CredentialGrant, len(deps.CredentialGrants))
+	for i := range deps.CredentialGrants {
+		g := &deps.CredentialGrants[i]
+		grants[i] = egress.CredentialGrant{
+			Instance: g.Instance,
+			MatchCriteria: egress.MatchCriteria{
+				SubjectKind: egress.SubjectKind(g.SubjectKind),
+				SubjectID:   g.SubjectID,
+				Provider:    g.Provider,
+				Operation:   g.Operation,
+				Method:      g.Method,
+				Host:        g.Host,
+				PathPrefix:  g.PathPrefix,
+			},
+		}
+	}
+
+	deps.Resolver.Credentials = &egress.ProviderCredentialResolver{
+		TokenResolver: &brokerTokenResolver{broker: broker},
+		Materializer:  &registryMaterializer{providers: providers},
+		Grants:        grants,
+	}
+}
+
+type brokerTokenResolver struct {
+	broker *invocation.Broker
+}
+
+func (r *brokerTokenResolver) ResolveProviderToken(ctx context.Context, subject egress.Subject, provider, instance string) (string, error) {
+	p, ok := egress.PrincipalForSubject(subject)
+	if !ok {
+		return "", fmt.Errorf("subject %s/%s cannot resolve provider tokens", subject.Kind, subject.ID)
+	}
+	return r.broker.ResolveToken(ctx, p, provider, instance)
+}
+
+type registryMaterializer struct {
+	providers *registry.PluginMap[core.Provider]
+}
+
+type egressMaterializer interface {
+	EgressMaterializeCredential(token string) (egress.CredentialMaterialization, error)
+}
+
+func (m *registryMaterializer) MaterializeProviderCredential(provider string, token string) (egress.CredentialMaterialization, error) {
+	prov, err := m.providers.Get(provider)
+	if err != nil {
+		return egress.CredentialMaterialization{}, fmt.Errorf("loading provider %q for credential materialization: %w", provider, err)
+	}
+	for prov != nil {
+		if em, ok := prov.(egressMaterializer); ok {
+			return em.EgressMaterializeCredential(token)
+		}
+		unwrapper, ok := prov.(interface{ Inner() core.Provider })
+		if !ok {
+			break
+		}
+		prov = unwrapper.Inner()
+	}
+	return egress.MaterializeCredential(token, egress.AuthStyleBearer, nil)
+}
+
 func buildStaticPolicyEnforcer(cfg config.EgressConfig) egress.StaticPolicyEnforcer {
 	defaultAction := egress.PolicyAction(cfg.DefaultAction)
 	if defaultAction == "" {
@@ -37,14 +109,16 @@ func buildStaticPolicyEnforcer(cfg config.EgressConfig) egress.StaticPolicyEnfor
 	for i := range cfg.Policies {
 		r := &cfg.Policies[i]
 		rules[i] = egress.StaticPolicyRule{
-			Action:      egress.PolicyAction(r.Action),
-			SubjectKind: egress.SubjectKind(r.SubjectKind),
-			SubjectID:   r.SubjectID,
-			Provider:    r.Provider,
-			Operation:   r.Operation,
-			Method:      r.Method,
-			Host:        r.Host,
-			PathPrefix:  r.PathPrefix,
+			Action: egress.PolicyAction(r.Action),
+			MatchCriteria: egress.MatchCriteria{
+				SubjectKind: egress.SubjectKind(r.SubjectKind),
+				SubjectID:   r.SubjectID,
+				Provider:    r.Provider,
+				Operation:   r.Operation,
+				Method:      r.Method,
+				Host:        r.Host,
+				PathPrefix:  r.PathPrefix,
+			},
 		}
 	}
 

--- a/internal/bootstrap/validate.go
+++ b/internal/bootstrap/validate.go
@@ -58,6 +58,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 	defer func() { _ = CloseProviders(providers) }()
 
 	sharedInvoker := invocation.NewBroker(providers, ds)
+	wireCredentialResolver(&deps.Egress, sharedInvoker, providers)
 	audit := core.AuditSink(invocation.LogAuditSink{})
 
 	runtimes, err := buildRuntimes(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress)

--- a/internal/egress/match.go
+++ b/internal/egress/match.go
@@ -2,6 +2,41 @@ package egress
 
 import "strings"
 
+type MatchCriteria struct {
+	SubjectKind SubjectKind
+	SubjectID   string
+	Provider    string
+	Operation   string
+	Method      string
+	Host        string
+	PathPrefix  string
+}
+
+func (c *MatchCriteria) Matches(subject Subject, target Target) bool {
+	if c.SubjectKind != "" && c.SubjectKind != subject.Kind {
+		return false
+	}
+	if c.SubjectID != "" && c.SubjectID != subject.ID {
+		return false
+	}
+	if c.Provider != "" && c.Provider != target.Provider {
+		return false
+	}
+	if c.Operation != "" && c.Operation != target.Operation {
+		return false
+	}
+	if c.Method != "" && c.Method != target.Method {
+		return false
+	}
+	if c.Host != "" && c.Host != target.Host {
+		return false
+	}
+	if c.PathPrefix != "" && !MatchPathPrefix(c.PathPrefix, target.Path) {
+		return false
+	}
+	return true
+}
+
 // MatchPathPrefix reports whether path begins with the given prefix,
 // respecting path-segment boundaries. A prefix of "/" matches every path.
 // Trailing slashes on the prefix are tolerated: "/repos/" is equivalent

--- a/internal/egress/provider_credentials.go
+++ b/internal/egress/provider_credentials.go
@@ -1,0 +1,79 @@
+package egress
+
+import (
+	"context"
+	"fmt"
+)
+
+type CredentialResolver interface {
+	ResolveCredential(ctx context.Context, subject Subject, target Target) (CredentialMaterialization, error)
+}
+
+type ProviderTokenResolver interface {
+	ResolveProviderToken(ctx context.Context, subject Subject, provider, instance string) (string, error)
+}
+
+type CredentialMaterializer interface {
+	MaterializeProviderCredential(provider string, token string) (CredentialMaterialization, error)
+}
+
+type CredentialGrant struct {
+	Instance string
+	MatchCriteria
+}
+
+type ProviderCredentialResolver struct {
+	TokenResolver ProviderTokenResolver
+	Materializer  CredentialMaterializer
+	Grants        []CredentialGrant
+}
+
+func (r *ProviderCredentialResolver) ResolveCredential(ctx context.Context, subject Subject, target Target) (CredentialMaterialization, error) {
+	provider, instance, ok := r.matchGrant(subject, target)
+	if !ok {
+		return CredentialMaterialization{}, nil
+	}
+
+	if _, canResolve := PrincipalForSubject(subject); !canResolve {
+		return CredentialMaterialization{}, nil
+	}
+
+	if r.TokenResolver == nil {
+		return CredentialMaterialization{}, fmt.Errorf("egress credentials: no token resolver configured")
+	}
+
+	token, err := r.TokenResolver.ResolveProviderToken(ctx, subject, provider, instance)
+	if err != nil {
+		return CredentialMaterialization{}, fmt.Errorf("egress credentials: resolving token for %q: %w", provider, err)
+	}
+
+	if r.Materializer == nil {
+		return MaterializeCredential(token, AuthStyleBearer, nil)
+	}
+	return r.Materializer.MaterializeProviderCredential(provider, token)
+}
+
+func (r *ProviderCredentialResolver) matchGrant(subject Subject, target Target) (provider, instance string, matched bool) {
+	for i := range r.Grants {
+		g := &r.Grants[i]
+		if !g.Matches(subject, target) {
+			continue
+		}
+		p := g.Provider
+		if p == "" {
+			p = target.Provider
+		}
+		if p == "" {
+			continue
+		}
+		inst := g.Instance
+		if inst == "" {
+			inst = target.Instance
+		}
+		if inst == "" {
+			inst = p
+		}
+		return p, inst, true
+	}
+	return "", "", false
+}

--- a/internal/egress/provider_credentials_test.go
+++ b/internal/egress/provider_credentials_test.go
@@ -1,0 +1,269 @@
+package egress_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/internal/egress"
+)
+
+type staticTokenResolver struct {
+	token string
+	err   error
+}
+
+func (r *staticTokenResolver) ResolveProviderToken(_ context.Context, _ egress.Subject, _, _ string) (string, error) {
+	if r.err != nil {
+		return "", r.err
+	}
+	return r.token, nil
+}
+
+type staticMaterializer struct {
+	style egress.AuthStyle
+}
+
+func (m *staticMaterializer) MaterializeProviderCredential(_ string, token string) (egress.CredentialMaterialization, error) {
+	return egress.MaterializeCredential(token, m.style, nil)
+}
+
+func TestResolverUsesCredentialResolverForMatchingGrant(t *testing.T) {
+	t.Parallel()
+
+	resolver := egress.Resolver{
+		Subjects: egress.StaticSubjectResolver{
+			Subject: egress.Subject{Kind: egress.SubjectUser, ID: "u-100"},
+		},
+		Credentials: &egress.ProviderCredentialResolver{
+			TokenResolver: &staticTokenResolver{token: "resolved-tok"},
+			Materializer:  &staticMaterializer{style: egress.AuthStyleBearer},
+			Grants: []egress.CredentialGrant{
+				{MatchCriteria: egress.MatchCriteria{Provider: "acme", Host: "api.acme.dev"}},
+			},
+		},
+	}
+
+	res, err := resolver.Resolve(context.Background(), egress.ResolutionInput{
+		Target: egress.Target{
+			Provider: "acme",
+			Method:   "GET",
+			Host:     "api.acme.dev",
+			Path:     "/v1/items",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Credential.Authorization != "Bearer resolved-tok" {
+		t.Fatalf("expected resolved credential, got %q", res.Credential.Authorization)
+	}
+}
+
+func TestResolverPreservesExplicitCredential(t *testing.T) {
+	t.Parallel()
+
+	resolver := egress.Resolver{
+		Subjects: egress.StaticSubjectResolver{
+			Subject: egress.Subject{Kind: egress.SubjectUser, ID: "u-100"},
+		},
+		Credentials: &egress.ProviderCredentialResolver{
+			TokenResolver: &staticTokenResolver{token: "should-not-be-used"},
+			Materializer:  &staticMaterializer{style: egress.AuthStyleBearer},
+			Grants: []egress.CredentialGrant{
+				{MatchCriteria: egress.MatchCriteria{Provider: "acme"}},
+			},
+		},
+	}
+
+	res, err := resolver.Resolve(context.Background(), egress.ResolutionInput{
+		Target: egress.Target{
+			Provider: "acme",
+			Method:   "POST",
+			Host:     "api.acme.dev",
+			Path:     "/v1/items",
+		},
+		Credential: egress.CredentialMaterialization{
+			Authorization: "Bearer explicit-tok",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Credential.Authorization != "Bearer explicit-tok" {
+		t.Fatalf("expected explicit credential preserved, got %q", res.Credential.Authorization)
+	}
+}
+
+func TestResolverReturnsEmptyWhenNoGrantMatches(t *testing.T) {
+	t.Parallel()
+
+	resolver := egress.Resolver{
+		Subjects: egress.StaticSubjectResolver{
+			Subject: egress.Subject{Kind: egress.SubjectUser, ID: "u-100"},
+		},
+		Credentials: &egress.ProviderCredentialResolver{
+			TokenResolver: &staticTokenResolver{token: "should-not-be-used"},
+			Materializer:  &staticMaterializer{style: egress.AuthStyleBearer},
+			Grants: []egress.CredentialGrant{
+				{MatchCriteria: egress.MatchCriteria{Provider: "other-provider"}},
+			},
+		},
+	}
+
+	res, err := resolver.Resolve(context.Background(), egress.ResolutionInput{
+		Target: egress.Target{
+			Provider: "acme",
+			Method:   "GET",
+			Host:     "api.acme.dev",
+			Path:     "/v1/items",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Credential.Authorization != "" {
+		t.Fatalf("expected no credential, got %q", res.Credential.Authorization)
+	}
+}
+
+func TestResolverPropagatesCredentialResolutionError(t *testing.T) {
+	t.Parallel()
+
+	resolver := egress.Resolver{
+		Subjects: egress.StaticSubjectResolver{
+			Subject: egress.Subject{Kind: egress.SubjectUser, ID: "u-100"},
+		},
+		Credentials: &egress.ProviderCredentialResolver{
+			TokenResolver: &staticTokenResolver{err: fmt.Errorf("token store unavailable")},
+			Materializer:  &staticMaterializer{style: egress.AuthStyleBearer},
+			Grants: []egress.CredentialGrant{
+				{MatchCriteria: egress.MatchCriteria{Provider: "acme"}},
+			},
+		},
+	}
+
+	_, err := resolver.Resolve(context.Background(), egress.ResolutionInput{
+		Target: egress.Target{
+			Provider: "acme",
+			Method:   "GET",
+			Host:     "api.acme.dev",
+			Path:     "/v1/items",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error when token resolution fails")
+	}
+}
+
+func TestCredentialGrantMatchesPathPrefix(t *testing.T) {
+	t.Parallel()
+
+	resolver := egress.Resolver{
+		Subjects: egress.StaticSubjectResolver{
+			Subject: egress.Subject{Kind: egress.SubjectUser, ID: "u-100"},
+		},
+		Credentials: &egress.ProviderCredentialResolver{
+			TokenResolver: &staticTokenResolver{token: "scoped-tok"},
+			Materializer:  &staticMaterializer{style: egress.AuthStyleBearer},
+			Grants: []egress.CredentialGrant{
+				{MatchCriteria: egress.MatchCriteria{Provider: "acme", PathPrefix: "/v1/items"}},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	res, err := resolver.Resolve(ctx, egress.ResolutionInput{
+		Target: egress.Target{
+			Provider: "acme",
+			Method:   "GET",
+			Host:     "api.acme.dev",
+			Path:     "/v1/items/123",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Credential.Authorization != "Bearer scoped-tok" {
+		t.Fatalf("expected credential for matching path, got %q", res.Credential.Authorization)
+	}
+
+	res, err = resolver.Resolve(ctx, egress.ResolutionInput{
+		Target: egress.Target{
+			Provider: "acme",
+			Method:   "GET",
+			Host:     "api.acme.dev",
+			Path:     "/v2/other",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Credential.Authorization != "" {
+		t.Fatalf("expected no credential for non-matching path, got %q", res.Credential.Authorization)
+	}
+}
+
+func TestCredentialGrantMatchesSubjectKind(t *testing.T) {
+	t.Parallel()
+
+	resolver := egress.Resolver{
+		Subjects: egress.StaticSubjectResolver{
+			Subject: egress.Subject{Kind: egress.SubjectSystem, ID: "daemon"},
+		},
+		Credentials: &egress.ProviderCredentialResolver{
+			TokenResolver: &staticTokenResolver{token: "user-tok"},
+			Materializer:  &staticMaterializer{style: egress.AuthStyleBearer},
+			Grants: []egress.CredentialGrant{
+				{MatchCriteria: egress.MatchCriteria{Provider: "acme", SubjectKind: egress.SubjectUser}},
+			},
+		},
+	}
+
+	res, err := resolver.Resolve(context.Background(), egress.ResolutionInput{
+		Target: egress.Target{
+			Provider: "acme",
+			Method:   "GET",
+			Host:     "api.acme.dev",
+			Path:     "/v1/items",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Credential.Authorization != "" {
+		t.Fatalf("expected no credential for non-matching subject kind, got %q", res.Credential.Authorization)
+	}
+}
+
+func TestCredentialFallsBackToBearerWithoutMaterializer(t *testing.T) {
+	t.Parallel()
+
+	resolver := egress.Resolver{
+		Subjects: egress.StaticSubjectResolver{
+			Subject: egress.Subject{Kind: egress.SubjectUser, ID: "u-100"},
+		},
+		Credentials: &egress.ProviderCredentialResolver{
+			TokenResolver: &staticTokenResolver{token: "fallback-tok"},
+			Grants: []egress.CredentialGrant{
+				{MatchCriteria: egress.MatchCriteria{Provider: "acme"}},
+			},
+		},
+	}
+
+	res, err := resolver.Resolve(context.Background(), egress.ResolutionInput{
+		Target: egress.Target{
+			Provider: "acme",
+			Method:   "GET",
+			Host:     "api.acme.dev",
+			Path:     "/v1/items",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Credential.Authorization != "Bearer fallback-tok" {
+		t.Fatalf("expected bearer fallback, got %q", res.Credential.Authorization)
+	}
+}

--- a/internal/egress/resolution.go
+++ b/internal/egress/resolution.go
@@ -17,8 +17,9 @@ type Resolution struct {
 }
 
 type Resolver struct {
-	Subjects SubjectResolver
-	Policy   PolicyEnforcer
+	Subjects    SubjectResolver
+	Policy      PolicyEnforcer
+	Credentials CredentialResolver
 }
 
 func (r Resolver) Resolve(ctx context.Context, input ResolutionInput) (Resolution, error) {
@@ -32,18 +33,27 @@ func (r Resolver) Resolve(ctx context.Context, input ResolutionInput) (Resolutio
 		return Resolution{}, err
 	}
 
-	headers := ApplyHeaderMutations(input.Headers, input.Credential.Headers)
+	credential := input.Credential
+	if r.Credentials != nil && credential.Authorization == "" && len(credential.Headers) == 0 {
+		resolved, err := r.Credentials.ResolveCredential(ctx, subject, input.Target)
+		if err != nil {
+			return Resolution{}, err
+		}
+		credential = resolved
+	}
 
-	if input.Credential.Authorization != "" {
+	headers := ApplyHeaderMutations(input.Headers, credential.Headers)
+
+	if credential.Authorization != "" {
 		delete(headers, "Authorization")
 	}
 
 	policyHeaders := CopyHeaders(headers)
-	if input.Credential.Authorization != "" {
+	if credential.Authorization != "" {
 		if policyHeaders == nil {
 			policyHeaders = map[string]string{}
 		}
-		policyHeaders["Authorization"] = input.Credential.Authorization
+		policyHeaders["Authorization"] = credential.Authorization
 	}
 
 	policy := PolicyInput{
@@ -59,7 +69,7 @@ func (r Resolver) Resolve(ctx context.Context, input ResolutionInput) (Resolutio
 		Subject:    subject,
 		Target:     input.Target,
 		Headers:    headers,
-		Credential: CredentialMaterialization{Authorization: input.Credential.Authorization},
+		Credential: CredentialMaterialization{Authorization: credential.Authorization},
 		Policy:     policy,
 	}, nil
 }

--- a/internal/egress/static_policy.go
+++ b/internal/egress/static_policy.go
@@ -16,14 +16,8 @@ const (
 )
 
 type StaticPolicyRule struct {
-	Action      PolicyAction
-	SubjectKind SubjectKind
-	SubjectID   string
-	Provider    string
-	Operation   string
-	Method      string
-	Host        string
-	PathPrefix  string
+	Action PolicyAction
+	MatchCriteria
 }
 
 type StaticPolicyEnforcer struct {
@@ -33,7 +27,7 @@ type StaticPolicyEnforcer struct {
 
 func (e StaticPolicyEnforcer) Evaluate(_ context.Context, input PolicyInput) error {
 	for i := range e.Rules {
-		if matchesRule(&e.Rules[i], &input) {
+		if e.Rules[i].Matches(input.Subject, input.Target) {
 			if e.Rules[i].Action == PolicyDeny {
 				return fmt.Errorf("%w: %s %s", ErrEgressDenied, input.Target.Method, input.Target.Path)
 			}
@@ -44,29 +38,4 @@ func (e StaticPolicyEnforcer) Evaluate(_ context.Context, input PolicyInput) err
 		return fmt.Errorf("%w: %s %s", ErrEgressDenied, input.Target.Method, input.Target.Path)
 	}
 	return nil
-}
-
-func matchesRule(rule *StaticPolicyRule, input *PolicyInput) bool {
-	if rule.SubjectKind != "" && rule.SubjectKind != input.Subject.Kind {
-		return false
-	}
-	if rule.SubjectID != "" && rule.SubjectID != input.Subject.ID {
-		return false
-	}
-	if rule.Provider != "" && rule.Provider != input.Target.Provider {
-		return false
-	}
-	if rule.Operation != "" && rule.Operation != input.Target.Operation {
-		return false
-	}
-	if rule.Method != "" && rule.Method != input.Target.Method {
-		return false
-	}
-	if rule.Host != "" && rule.Host != input.Target.Host {
-		return false
-	}
-	if rule.PathPrefix != "" && !MatchPathPrefix(rule.PathPrefix, input.Target.Path) {
-		return false
-	}
-	return true
 }

--- a/internal/egress/static_policy_test.go
+++ b/internal/egress/static_policy_test.go
@@ -43,8 +43,8 @@ func TestStaticPolicyDenyRuleBlocksResolution(t *testing.T) {
 			DefaultAction: egress.PolicyAllow,
 			Rules: []egress.StaticPolicyRule{
 				{
-					Action:   egress.PolicyDeny,
-					Provider: "secret-api",
+					Action:        egress.PolicyDeny,
+					MatchCriteria: egress.MatchCriteria{Provider: "secret-api"},
 				},
 			},
 		},
@@ -90,8 +90,8 @@ func TestStaticPolicyDefaultDenyBlocksUnmatched(t *testing.T) {
 			DefaultAction: egress.PolicyDeny,
 			Rules: []egress.StaticPolicyRule{
 				{
-					Action:   egress.PolicyAllow,
-					Provider: "trusted-api",
+					Action:        egress.PolicyAllow,
+					MatchCriteria: egress.MatchCriteria{Provider: "trusted-api"},
 				},
 			},
 		},
@@ -135,13 +135,12 @@ func TestStaticPolicyFirstMatchWins(t *testing.T) {
 			DefaultAction: egress.PolicyAllow,
 			Rules: []egress.StaticPolicyRule{
 				{
-					Action:     egress.PolicyDeny,
-					Provider:   "multi-api",
-					PathPrefix: "/v1/admin",
+					Action:        egress.PolicyDeny,
+					MatchCriteria: egress.MatchCriteria{Provider: "multi-api", PathPrefix: "/v1/admin"},
 				},
 				{
-					Action:   egress.PolicyAllow,
-					Provider: "multi-api",
+					Action:        egress.PolicyAllow,
+					MatchCriteria: egress.MatchCriteria{Provider: "multi-api"},
 				},
 			},
 		},
@@ -185,10 +184,12 @@ func TestStaticPolicyMultiFieldMatch(t *testing.T) {
 			DefaultAction: egress.PolicyAllow,
 			Rules: []egress.StaticPolicyRule{
 				{
-					Action:      egress.PolicyDeny,
-					SubjectKind: egress.SubjectAgent,
-					Provider:    "restricted-api",
-					Method:      "DELETE",
+					Action: egress.PolicyDeny,
+					MatchCriteria: egress.MatchCriteria{
+						SubjectKind: egress.SubjectAgent,
+						Provider:    "restricted-api",
+						Method:      "DELETE",
+					},
 				},
 			},
 		},

--- a/internal/egress/subject_principal.go
+++ b/internal/egress/subject_principal.go
@@ -3,6 +3,7 @@ package egress
 import (
 	"context"
 
+	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/principal"
 )
 
@@ -20,6 +21,26 @@ func SubjectForPrincipal(p *principal.Principal) (Subject, bool) {
 		return Subject{Kind: SubjectIdentity, ID: principal.IdentityPrincipal}, true
 	}
 	return Subject{}, false
+}
+
+func PrincipalForSubject(s Subject) (*principal.Principal, bool) {
+	switch s.Kind {
+	case SubjectUser:
+		if s.ID == "" {
+			return nil, false
+		}
+		return &principal.Principal{UserID: s.ID}, true
+	case SubjectIdentity:
+		if s.ID == principal.IdentityPrincipal {
+			return &principal.Principal{UserID: principal.IdentityPrincipal}, true
+		}
+		if s.ID == "" {
+			return nil, false
+		}
+		return &principal.Principal{Identity: &core.UserIdentity{Email: s.ID}}, true
+	default:
+		return nil, false
+	}
 }
 
 func WithSubjectFromPrincipal(ctx context.Context, p *principal.Principal) context.Context {

--- a/internal/egress/types.go
+++ b/internal/egress/types.go
@@ -19,6 +19,7 @@ type Subject struct {
 // Target describes the destination and logical source for an outbound request.
 type Target struct {
 	Provider  string
+	Instance  string
 	Operation string
 	Method    string
 	Host      string

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3169,8 +3169,9 @@ func newTestProxyBinding(t *testing.T, name, path string) core.Binding {
 	}
 
 	binding, err := proxy.Factory(context.Background(), name, config.BindingDef{
-		Type:   "proxy",
-		Config: *node.Content[0],
+		Type:      "proxy",
+		Providers: []string{"test-provider"},
+		Config:    *node.Content[0],
 	}, bootstrap.BindingDeps{})
 	if err != nil {
 		t.Fatalf("proxy factory: %v", err)

--- a/plugins/bindings/proxy/binding.go
+++ b/plugins/bindings/proxy/binding.go
@@ -12,6 +12,7 @@ import (
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/apiexec"
 	"github.com/valon-technologies/gestalt/internal/egress"
+	"github.com/valon-technologies/gestalt/internal/principal"
 	"github.com/valon-technologies/gestalt/plugins/bindings/internal/httpjson"
 )
 
@@ -21,16 +22,17 @@ var _ core.Binding = (*Binding)(nil)
 
 type Binding struct {
 	name     string
+	provider string
 	cfg      proxyConfig
 	resolver egress.Resolver
 	client   *http.Client
 }
 
-func New(name string, cfg proxyConfig, resolver egress.Resolver, client *http.Client) *Binding {
+func New(name, provider string, cfg proxyConfig, resolver egress.Resolver, client *http.Client) *Binding {
 	if client == nil {
 		client = http.DefaultClient
 	}
-	return &Binding{name: name, cfg: cfg, resolver: resolver, client: client}
+	return &Binding{name: name, provider: provider, cfg: cfg, resolver: resolver, client: client}
 }
 
 func (b *Binding) Name() string           { return b.name }
@@ -98,8 +100,6 @@ func writeProxyResponse(w http.ResponseWriter, result *core.OperationResult) {
 	_, _ = io.WriteString(w, result.Body)
 }
 
-// hopByHopHeaders are headers that apply to a single transport connection and
-// must not be forwarded by proxies (RFC 7230 section 6.1).
 var hopByHopHeaders = map[string]bool{
 	"Connection":          true,
 	"Keep-Alive":          true,
@@ -122,17 +122,23 @@ func (b *Binding) resolve(r *http.Request) (egress.Resolution, []byte, error) {
 	}
 	defer func() { _ = r.Body.Close() }()
 
-	headers := normalizeHeaders(r.Header)
+	headers := sanitizeForwardHeaders(normalizeHeaders(r.Header))
 	target := egress.Target{
-		Method: r.Method,
-		Host:   resolveHost(r),
-		Path:   resolvePath(r, b.cfg.normalizedPath()),
+		Provider: b.provider,
+		Instance: b.cfg.Instance,
+		Method:   r.Method,
+		Host:     resolveHost(r),
+		Path:     resolvePath(r, b.cfg.normalizedPath()),
 	}
 
-	ctx := egress.WithSubject(r.Context(), egress.Subject{
-		Kind: egress.SubjectSystem,
-		ID:   b.name,
-	})
+	ctx := egress.WithSubjectFromPrincipal(r.Context(), principal.FromContext(r.Context()))
+	if _, ok := egress.SubjectFromContext(ctx); !ok {
+		ctx = egress.WithSubject(ctx, egress.Subject{
+			Kind: egress.SubjectSystem,
+			ID:   b.name,
+		})
+	}
+
 	resolved, err := b.resolver.Resolve(ctx, egress.ResolutionInput{
 		Target:  target,
 		Headers: headers,
@@ -144,9 +150,40 @@ func (b *Binding) resolve(r *http.Request) (egress.Resolution, []byte, error) {
 	return resolved, body, nil
 }
 
-// acceptAllStatuses allows the proxy to forward upstream error responses
-// instead of treating them as transport failures.
 var acceptAllStatuses apiexec.ResponseChecker = func(int, []byte) error { return nil }
+
+var sanitizedHeaders = func() map[string]bool {
+	m := map[string]bool{
+		"Authorization":     true,
+		"Cookie":            true,
+		"Host":              true,
+		"Content-Length":    true,
+		"X-Dev-User-Email":  true,
+		"X-Forwarded-Host":  true,
+		"X-Forwarded-Proto": true,
+	}
+	for k := range hopByHopHeaders {
+		m[k] = true
+	}
+	return m
+}()
+
+func sanitizeForwardHeaders(headers map[string]string) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(headers))
+	for k, v := range headers {
+		if sanitizedHeaders[k] {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
 
 const (
 	schemeHTTP  = "http"

--- a/plugins/bindings/proxy/binding_internal_test.go
+++ b/plugins/bindings/proxy/binding_internal_test.go
@@ -15,7 +15,7 @@ func TestBindingNormalizeRunsResolver(t *testing.T) {
 	t.Parallel()
 
 	var got egress.PolicyInput
-	b := New("agent-proxy", proxyConfig{Path: "/proxy"}, egress.Resolver{
+	b := New("agent-proxy", "test-provider", proxyConfig{Path: "/proxy"}, egress.Resolver{
 		Policy: egresstest.PolicyFunc(func(_ context.Context, input egress.PolicyInput) error {
 			got = input
 			return nil

--- a/plugins/bindings/proxy/config.go
+++ b/plugins/bindings/proxy/config.go
@@ -7,7 +7,8 @@ import (
 )
 
 type proxyConfig struct {
-	Path string `yaml:"path"`
+	Path     string `yaml:"path"`
+	Instance string `yaml:"instance"`
 }
 
 func (c proxyConfig) validate(name string) error {

--- a/plugins/bindings/proxy/factory.go
+++ b/plugins/bindings/proxy/factory.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
@@ -17,9 +18,12 @@ var Factory bootstrap.BindingFactory = func(_ context.Context, name string, def 
 	if err := cfg.validate(name); err != nil {
 		return nil, err
 	}
+	if len(def.Providers) != 1 {
+		return nil, fmt.Errorf("proxy %q: exactly one provider must be configured in bindings.%s.providers", name, name)
+	}
 	resolver := egress.Resolver{}
 	if deps.Egress.Resolver != nil {
 		resolver = *deps.Egress.Resolver
 	}
-	return New(name, cfg, resolver, nil), nil
+	return New(name, def.Providers[0], cfg, resolver, nil), nil
 }

--- a/plugins/bindings/proxy/proxy_test.go
+++ b/plugins/bindings/proxy/proxy_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/egress"
+	"github.com/valon-technologies/gestalt/internal/principal"
 	"gopkg.in/yaml.v3"
 )
 
@@ -207,6 +208,167 @@ func TestProxyCONNECTNotImplemented(t *testing.T) {
 	}
 }
 
+func TestProxySanitizesInboundAuthHeaders(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"authorization":       r.Header.Get("Authorization"),
+			"cookie":              r.Header.Get("Cookie"),
+			"proxy_authorization": r.Header.Get("Proxy-Authorization"),
+			"x_dev_user_email":    r.Header.Get("X-Dev-User-Email"),
+			"x_custom":            r.Header.Get("X-Custom"),
+		})
+	}))
+	t.Cleanup(upstream.Close)
+
+	b := testBinding(t, "/proxy", upstream.Client())
+
+	req := httptest.NewRequest(http.MethodGet, upstream.URL+"/proxy/api", nil)
+	req.Header.Set("Authorization", "Bearer inbound-token")
+	req.Header.Set("Cookie", "session=abc123")
+	req.Header.Set("Proxy-Authorization", "Basic creds")
+	req.Header.Set("X-Dev-User-Email", "user@example.com")
+	req.Header.Set("X-Custom", "should-pass")
+	w := httptest.NewRecorder()
+	b.Routes()[0].Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["authorization"] != "" {
+		t.Fatalf("inbound Authorization should be stripped, got %q", resp["authorization"])
+	}
+	if resp["cookie"] != "" {
+		t.Fatalf("inbound Cookie should be stripped, got %q", resp["cookie"])
+	}
+	if resp["proxy_authorization"] != "" {
+		t.Fatalf("inbound Proxy-Authorization should be stripped, got %q", resp["proxy_authorization"])
+	}
+	if resp["x_dev_user_email"] != "" {
+		t.Fatalf("inbound X-Dev-User-Email should be stripped, got %q", resp["x_dev_user_email"])
+	}
+	if resp["x_custom"] != "should-pass" {
+		t.Fatalf("X-Custom = %q, want should-pass", resp["x_custom"])
+	}
+}
+
+func TestProxyInjectsProviderCredential(t *testing.T) {
+	t.Parallel()
+
+	const providerToken = "resolved-provider-token"
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"authorization": r.Header.Get("Authorization"),
+		})
+	}))
+	t.Cleanup(upstream.Close)
+
+	resolver := egress.Resolver{
+		Subjects: egress.ContextSubjectResolver{},
+		Credentials: staticCredentialResolver{
+			Credential: egress.CredentialMaterialization{
+				Authorization: "Bearer " + providerToken,
+			},
+		},
+	}
+
+	b := New("test-proxy", "test-provider", proxyConfig{Path: "/proxy"}, resolver, upstream.Client())
+
+	req := httptest.NewRequest(http.MethodGet, upstream.URL+"/proxy/data", nil)
+	req.Header.Set("Authorization", "Bearer inbound-should-be-stripped")
+	ctx := principal.WithPrincipal(req.Context(), &principal.Principal{UserID: "user-42"})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	b.Routes()[0].Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["authorization"] != "Bearer "+providerToken {
+		t.Fatalf("outbound Authorization = %q, want Bearer %s", resp["authorization"], providerToken)
+	}
+}
+
+func TestProxyDerivesPrincipalSubject(t *testing.T) {
+	t.Parallel()
+
+	var capturedSubject egress.Subject
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	resolver := egress.Resolver{
+		Subjects: egress.ContextSubjectResolver{},
+		Credentials: subjectCapturingResolver{
+			capture: func(s egress.Subject) {
+				capturedSubject = s
+			},
+		},
+	}
+
+	b := New("test-proxy", "test-provider", proxyConfig{Path: "/proxy"}, resolver, upstream.Client())
+
+	req := httptest.NewRequest(http.MethodGet, upstream.URL+"/proxy/check", nil)
+	ctx := principal.WithPrincipal(req.Context(), &principal.Principal{UserID: "user-99"})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	b.Routes()[0].Handler.ServeHTTP(w, req)
+
+	if capturedSubject.Kind != egress.SubjectUser {
+		t.Fatalf("subject kind = %q, want %q", capturedSubject.Kind, egress.SubjectUser)
+	}
+	if capturedSubject.ID != "user-99" {
+		t.Fatalf("subject ID = %q, want user-99", capturedSubject.ID)
+	}
+}
+
+func TestProxyFallsBackToSubjectSystem(t *testing.T) {
+	t.Parallel()
+
+	var capturedSubject egress.Subject
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	resolver := egress.Resolver{
+		Subjects: egress.ContextSubjectResolver{},
+		Credentials: subjectCapturingResolver{
+			capture: func(s egress.Subject) {
+				capturedSubject = s
+			},
+		},
+	}
+
+	b := New("my-proxy", "test-provider", proxyConfig{Path: "/proxy"}, resolver, upstream.Client())
+
+	req := httptest.NewRequest(http.MethodGet, upstream.URL+"/proxy/check", nil)
+	w := httptest.NewRecorder()
+	b.Routes()[0].Handler.ServeHTTP(w, req)
+
+	if capturedSubject.Kind != egress.SubjectSystem {
+		t.Fatalf("subject kind = %q, want %q", capturedSubject.Kind, egress.SubjectSystem)
+	}
+	if capturedSubject.ID != "my-proxy" {
+		t.Fatalf("subject ID = %q, want my-proxy", capturedSubject.ID)
+	}
+}
+
 func TestProxyFactory(t *testing.T) {
 	t.Parallel()
 
@@ -217,8 +379,9 @@ func TestProxyFactory(t *testing.T) {
 	}
 
 	def := config.BindingDef{
-		Type:   "proxy",
-		Config: *node.Content[0],
+		Type:      "proxy",
+		Providers: []string{"my-provider"},
+		Config:    *node.Content[0],
 	}
 
 	binding, err := Factory(context.Background(), "proxy-surface", def, bootstrap.BindingDeps{})
@@ -244,17 +407,72 @@ func TestProxyFactoryValidation(t *testing.T) {
 	}
 
 	_, err := Factory(context.Background(), "bad-proxy", config.BindingDef{
-		Type:   "proxy",
-		Config: *node.Content[0],
+		Type:      "proxy",
+		Providers: []string{"some-provider"},
+		Config:    *node.Content[0],
 	}, bootstrap.BindingDeps{})
 	if err == nil {
 		t.Fatal("expected validation error")
 	}
 }
 
+func TestProxyFactoryRejectsNoProvider(t *testing.T) {
+	t.Parallel()
+
+	cfgYAML := `path: /proxy`
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(cfgYAML), &node); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Factory(context.Background(), "no-prov", config.BindingDef{
+		Type:   "proxy",
+		Config: *node.Content[0],
+	}, bootstrap.BindingDeps{})
+	if err == nil {
+		t.Fatal("expected error for zero providers")
+	}
+}
+
+func TestProxyFactoryRejectsMultipleProviders(t *testing.T) {
+	t.Parallel()
+
+	cfgYAML := `path: /proxy`
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(cfgYAML), &node); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Factory(context.Background(), "multi-prov", config.BindingDef{
+		Type:      "proxy",
+		Providers: []string{"alpha", "beta"},
+		Config:    *node.Content[0],
+	}, bootstrap.BindingDeps{})
+	if err == nil {
+		t.Fatal("expected error for multiple providers")
+	}
+}
+
 func testBinding(t *testing.T, path string, client *http.Client) *Binding {
 	t.Helper()
-	return New("test-proxy", proxyConfig{Path: path}, egress.Resolver{
+	return New("test-proxy", "test-provider", proxyConfig{Path: path}, egress.Resolver{
 		Subjects: egress.ContextSubjectResolver{},
 	}, client)
+}
+
+type staticCredentialResolver struct {
+	Credential egress.CredentialMaterialization
+}
+
+func (r staticCredentialResolver) ResolveCredential(_ context.Context, _ egress.Subject, _ egress.Target) (egress.CredentialMaterialization, error) {
+	return r.Credential, nil
+}
+
+type subjectCapturingResolver struct {
+	capture func(egress.Subject)
+}
+
+func (r subjectCapturingResolver) ResolveCredential(_ context.Context, subject egress.Subject, _ egress.Target) (egress.CredentialMaterialization, error) {
+	r.capture(subject)
+	return egress.CredentialMaterialization{}, nil
 }


### PR DESCRIPTION
The proxy binding now requires exactly one provider in its providers list, derives the egress subject from the authenticated principal instead of hardcoding a system subject, and sanitizes inbound request headers (stripping Authorization, Cookie, hop-by-hop, and session headers) before forwarding. With Target.Provider and Target.Instance set, the shared credential resolver can automatically inject provider-backed outbound auth when a matching credential grant is configured. The SubjectSystem fallback is retained defensively for non-server embedding but should not be hit in normal authenticated traffic.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

> Part 5 of 5 in the egress resolution stack. Stacked on #123.