### PR TITLE
Add provider scaffolding, conformance harness, and operation inventory

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -35,9 +35,7 @@ import (
 	"github.com/valon-technologies/gestalt/plugins/datastore/postgres"
 	"github.com/valon-technologies/gestalt/plugins/datastore/sqlite"
 	"github.com/valon-technologies/gestalt/plugins/datastore/sqlserver"
-	"github.com/valon-technologies/gestalt/plugins/providers/bigquery"
 	"github.com/valon-technologies/gestalt/plugins/providers/echo"
-	"github.com/valon-technologies/gestalt/plugins/providers/jira"
 	echoruntime "github.com/valon-technologies/gestalt/plugins/runtimes/echo"
 	secretsenv "github.com/valon-technologies/gestalt/plugins/secrets/env"
 	secretsfile "github.com/valon-technologies/gestalt/plugins/secrets/file"
@@ -105,8 +103,7 @@ func buildFactories(preparedProviders map[string]string, devMode bool) *bootstra
 	factories.Datastores["oracle"] = oracle.Factory
 	factories.Datastores["firestore"] = firestore.Factory
 	factories.Datastores["sqlserver"] = sqlserver.Factory
-	factories.Providers["jira"] = jira.Factory
-	factories.Providers["bigquery"] = bigquery.Factory
+	registerProviders(factories)
 	factories.DefaultProvider = defaultProviderFactory(preparedProviders)
 	if devMode {
 		factories.Builtins = append(factories.Builtins, echo.New())

--- a/cmd/gestaltd/providers.go
+++ b/cmd/gestaltd/providers.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/plugins/providers/bigquery"
+	"github.com/valon-technologies/gestalt/plugins/providers/jira"
+)
+
+func registerProviders(f *bootstrap.FactoryRegistry) {
+	f.Providers["bigquery"] = bigquery.Factory
+	f.Providers["jira"] = jira.Factory
+}

--- a/docs/pages/tasks/_meta.ts
+++ b/docs/pages/tasks/_meta.ts
@@ -1,5 +1,6 @@
 export default {
   "run-locally": "Run Locally",
   "add-an-integration": "Add an Integration",
+  "add-a-first-party-provider": "Add a First-Party Provider",
   "use-with-mcp": "Use with MCP",
 };

--- a/docs/pages/tasks/add-a-first-party-provider.mdx
+++ b/docs/pages/tasks/add-a-first-party-provider.mdx
@@ -1,0 +1,144 @@
+# Add a First-Party Provider
+
+A **first-party provider** ships with gestaltd and has its operation inventory checked into the repo. Use this approach for stable integrations that are tested in CI and versioned alongside the server.
+
+For ad-hoc or user-configured integrations that point at remote OpenAPI/GraphQL specs, see [Add an Integration](/tasks/add-an-integration).
+
+## 1. Create the provider package
+
+Every first-party provider lives under `plugins/providers/<name>/` with three files:
+
+### `provider.yaml`
+
+Declarative definition of the API surface. See `internal/provider/definition.go` for the full schema.
+
+```yaml
+provider: myservice
+display_name: My Service
+description: One-line description
+connection_mode: user   # none | user | identity | either
+base_url: "https://api.example.com/v1"
+
+auth:
+  type: oauth2          # oauth2 | manual
+  authorization_url: https://example.com/oauth/authorize
+  token_url: https://example.com/oauth/token
+  scopes: [read, write]
+
+operations:
+  list_items:
+    description: List all items
+    method: GET
+    path: /items
+    parameters:
+      - {name: limit, type: integer, description: Max results}
+  get_item:
+    description: Get an item by ID
+    method: GET
+    path: "/items/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Item ID}
+```
+
+### `factory.go`
+
+Embed the YAML, unmarshal, and call `provider.Build()`:
+
+```go
+package myservice
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, err
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}
+```
+
+### `factory_test.go`
+
+Use the shared `providertest` harness and validate against the `inventory` contract:
+
+```go
+package myservice
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec := inv.Providers["myservice"]
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID: "dummy", ClientSecret: "dummy",
+	})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "myservice",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+}
+```
+
+## 2. Registration
+
+Factory registration in `cmd/gestaltd/providers.go` is handled by the integrator, not the provider author. Your PR should only contain the `plugins/providers/<name>/` package.
+
+## 3. Overlay providers
+
+When Go code is needed for operations that cannot be expressed as REST/GraphQL YAML (custom request shaping, SDK calls, multi-step workflows), create an **overlay binary**:
+
+1. Implement a `core.Provider` with only the custom operations in your provider package
+2. Create `cmd/gestalt-plugin-<name>/main.go` that serves it via gRPC:
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"os/signal"
+	"syscall"
+
+	"github.com/valon-technologies/gestalt/internal/pluginapi"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	if err := pluginapi.ServeProvider(ctx, newOverlayProvider()); err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+The YAML definition handles the base operations; the overlay binary handles the rest. The bootstrap system composes them automatically when `mode: overlay` is set in the deployment config.

--- a/plugins/providers/bigquery/factory_test.go
+++ b/plugins/providers/bigquery/factory_test.go
@@ -3,82 +3,54 @@ package bigquery
 import (
 	"testing"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/config"
-	"github.com/valon-technologies/gestalt/internal/provider"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
 )
 
 const (
 	dummyClientID     = "dummy-client-id"
 	dummyClientSecret = "dummy-client-secret"
-	expectedOpCount   = 5
 )
 
 func TestDefinitionParses(t *testing.T) {
 	t.Parallel()
 
-	var def provider.Definition
-	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
-		t.Fatalf("unmarshal: %v", err)
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
 	}
+	spec := inv.Providers["bigquery"]
 
-	if def.Provider != "bigquery" {
-		t.Fatalf("provider = %q, want bigquery", def.Provider)
-	}
-	if def.ConnectionMode != "user" {
-		t.Fatalf("connection_mode = %q, want user", def.ConnectionMode)
-	}
-	if len(def.Operations) != expectedOpCount {
-		t.Fatalf("operations = %d, want %d", len(def.Operations), expectedOpCount)
-	}
-
-	wantOps := []string{"list_datasets", "get_dataset", "list_tables", "get_table", "list_routines"}
-	for _, name := range wantOps {
-		if _, ok := def.Operations[name]; !ok {
-			t.Errorf("missing operation %q", name)
-		}
-	}
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "bigquery",
+		OperationCount: len(spec.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+	})
 }
 
 func TestBuildProvider(t *testing.T) {
 	t.Parallel()
 
-	var def provider.Definition
-	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
-		t.Fatalf("unmarshal: %v", err)
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
 	}
+	spec := inv.Providers["bigquery"]
 
-	intg := config.IntegrationDef{
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
 		ClientID:     dummyClientID,
 		ClientSecret: dummyClientSecret,
-	}
+	})
 
-	p, err := provider.Build(&def, intg, nil)
-	if err != nil {
-		t.Fatalf("Build: %v", err)
-	}
-
-	if p.Name() != "bigquery" {
-		t.Fatalf("Name() = %q, want bigquery", p.Name())
-	}
-	if p.ConnectionMode() != core.ConnectionModeUser {
-		t.Fatalf("ConnectionMode() = %q, want user", p.ConnectionMode())
-	}
-
-	ops := p.ListOperations()
-	if len(ops) != expectedOpCount {
-		t.Fatalf("ListOperations() = %d, want %d", len(ops), expectedOpCount)
-	}
-
-	opNames := make(map[string]bool, len(ops))
-	for _, op := range ops {
-		opNames[op.Name] = true
-	}
-	for _, name := range []string{"list_datasets", "get_dataset", "list_tables", "get_table", "list_routines"} {
-		if !opNames[name] {
-			t.Errorf("missing operation %q in built provider", name)
-		}
-	}
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "bigquery",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
 }

--- a/plugins/providers/inventory/inventory.go
+++ b/plugins/providers/inventory/inventory.go
@@ -1,0 +1,28 @@
+package inventory
+
+import (
+	_ "embed"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed inventory.yaml
+var rawYAML []byte
+
+type ProviderSpec struct {
+	AuthType       string   `yaml:"auth_type"`
+	ConnectionMode string   `yaml:"connection_mode"`
+	Operations     []string `yaml:"operations"`
+}
+
+type Inventory struct {
+	Providers map[string]ProviderSpec `yaml:"providers"`
+}
+
+func Load() (*Inventory, error) {
+	var inv Inventory
+	if err := yaml.Unmarshal(rawYAML, &inv); err != nil {
+		return nil, err
+	}
+	return &inv, nil
+}

--- a/plugins/providers/inventory/inventory.yaml
+++ b/plugins/providers/inventory/inventory.yaml
@@ -1,0 +1,567 @@
+providers:
+  bigquery:
+    auth_type: oauth2
+    connection_mode: user
+    operations:
+      - get_dataset
+      - get_table
+      - list_datasets
+      - list_routines
+      - list_tables
+
+  datadog:
+    auth_type: manual
+    connection_mode: user
+    operations:
+      - aggregate_rum_events
+      - create_dashboard
+      - create_downtime
+      - create_incident
+      - create_monitor
+      - get_dashboard
+      - get_monitor
+      - list_dashboards
+      - list_incidents
+      - list_monitors
+      - list_rum_events
+      - query_metrics
+      - search_logs
+      - search_rum_events
+      - update_dashboard
+      - update_incident
+      - update_monitor
+
+  dbt_cloud:
+    auth_type: manual
+    connection_mode: user
+    operations:
+      - cancel_run
+      - get_job
+      - get_run
+      - get_run_artifact
+      - list_accounts
+      - list_environments
+      - list_jobs
+      - list_projects
+      - list_runs
+      - trigger_job
+
+  extend:
+    auth_type: manual
+    connection_mode: identity
+    operations:
+      - cancel_classify_run
+      - cancel_extract_run
+      - cancel_split_run
+      - cancel_workflow_run
+      - classify_file
+      - classify_file_async
+      - create_classifier
+      - create_evaluation_set
+      - create_extractor
+      - create_splitter
+      - create_workflow
+      - delete_classify_run
+      - delete_edit_run
+      - delete_extract_run
+      - delete_file
+      - delete_parse_run
+      - delete_split_run
+      - delete_workflow_run
+      - edit_file
+      - edit_file_async
+      - extract_file
+      - extract_file_async
+      - get_classifier
+      - get_classify_run
+      - get_edit_run
+      - get_evaluation_set
+      - get_extract_run
+      - get_extractor
+      - get_file
+      - get_parse_run
+      - get_split_run
+      - get_splitter
+      - get_workflow_run
+      - list_classifiers
+      - list_classify_runs
+      - list_evaluation_sets
+      - list_extract_runs
+      - list_extractors
+      - list_files
+      - list_split_runs
+      - list_splitters
+      - list_workflow_runs
+      - parse_file
+      - parse_file_async
+      - run_workflow
+      - split_file
+      - split_file_async
+      - update_classifier
+      - update_extractor
+      - update_splitter
+      - update_workflow_run
+      - upload_file
+
+  figma:
+    auth_type: oauth2
+    connection_mode: user
+    operations:
+      - add_reaction
+      - create_dev_resources
+      - delete_comment
+      - delete_dev_resource
+      - delete_reaction
+      - export_images
+      - get_comments
+      - get_dev_resources
+      - get_file
+      - get_file_components
+      - get_file_nodes
+      - get_file_styles
+      - get_me
+      - list_project_files
+      - list_team_projects
+      - post_comment
+      - update_dev_resources
+
+  github:
+    auth_type: oauth2
+    connection_mode: user
+    operations:
+      - compare_commits
+      - create_branch
+      - create_comment
+      - create_issue
+      - create_or_update_file
+      - create_pull_request
+      - create_release
+      - create_review
+      - create_review_comment
+      - delete_file
+      - get_authenticated_user
+      - get_commit
+      - get_file_contents
+      - get_latest_release
+      - get_pull_request
+      - get_ref
+      - get_workflow_run
+      - list_branches
+      - list_check_runs
+      - list_comments
+      - list_commits
+      - list_issues
+      - list_pull_requests
+      - list_releases
+      - list_repos
+      - list_review_comments
+      - list_reviews
+      - list_user_orgs
+      - list_workflow_runs
+      - merge_pull_request
+      - rerun_workflow
+      - search_code
+      - search_issues
+      - search_repos
+      - update_issue
+      - update_pull_request
+
+  github_app:
+    auth_type: manual
+    connection_mode: identity
+    operations:
+      - compare_commits
+      - create_branch
+      - create_comment
+      - create_issue
+      - create_or_update_file
+      - create_pull_request
+      - create_release
+      - create_review
+      - create_review_comment
+      - delete_file
+      - get_authenticated_user
+      - get_commit
+      - get_file_contents
+      - get_latest_release
+      - get_pull_request
+      - get_ref
+      - get_workflow_run
+      - list_branches
+      - list_check_runs
+      - list_comments
+      - list_commits
+      - list_issues
+      - list_pull_requests
+      - list_releases
+      - list_repos
+      - list_review_comments
+      - list_reviews
+      - list_user_orgs
+      - list_workflow_runs
+      - merge_pull_request
+      - rerun_workflow
+      - search_code
+      - search_issues
+      - search_repos
+      - update_issue
+      - update_pull_request
+
+  gitlab:
+    auth_type: oauth2
+    connection_mode: user
+    operations:
+      - create_issue
+      - create_issue_note
+      - create_merge_request
+      - create_mr_note
+      - create_or_update_file
+      - delete_file
+      - get_merge_request
+      - get_pipeline
+      - get_project
+      - get_repository_file
+      - list_issues
+      - list_jobs
+      - list_merge_requests
+      - list_pipelines
+      - list_projects
+      - list_repository_tree
+      - search_code
+      - update_issue
+
+  gmail:
+    auth_type: oauth2
+    connection_mode: user
+    operations:
+      - add_label
+      - create_draft
+      - forward_message
+      - get_message
+      - get_profile
+      - get_thread
+      - list_labels
+      - list_messages
+      - mark_as_read
+      - remove_label
+      - reply_to_message
+      - search_messages
+      - send_message
+      - trash_message
+      - update_label
+
+  gong:
+    auth_type: manual
+    connection_mode: identity
+    operations:
+      - get_call
+      - get_call_transcript
+      - list_calls
+      - list_users
+
+  google_calendar:
+    auth_type: oauth2
+    connection_mode: user
+    operations:
+      - create_event
+      - delete_event
+      - get_calendar
+      - get_event
+      - list_calendars
+      - list_events
+      - quick_add_event
+      - update_event
+
+  google_docs:
+    auth_type: oauth2
+    connection_mode: user
+    operations:
+      - batch_update
+      - create_document
+      - get_document
+
+  google_drive:
+    auth_type: oauth2
+    connection_mode: user
+    operations:
+      - copy_file
+      - create_file
+      - create_permission
+      - delete_file
+      - delete_permission
+      - download_file
+      - export_file
+      - get_file
+      - list_files
+      - list_permissions
+      - update_file
+      - update_permission
+
+  google_sheets:
+    auth_type: oauth2
+    connection_mode: user
+    operations:
+      - add_sheet
+      - append_values
+      - batch_get_values
+      - batch_update_values
+      - clear_values
+      - create_spreadsheet
+      - delete_sheet
+      - find_replace
+      - get_spreadsheet
+      - get_values
+      - update_sheet_properties
+      - update_values
+
+  google_slides:
+    auth_type: oauth2
+    connection_mode: user
+    operations:
+      - create_bullet_list
+      - create_image
+      - create_line
+      - create_paragraph_bullets
+      - create_presentation
+      - create_shape
+      - create_slide
+      - create_styled_text_box
+      - create_table
+      - create_title_slide
+      - delete_object
+      - delete_text
+      - duplicate_object
+      - get_page
+      - get_presentation
+      - get_thumbnail
+      - group_objects
+      - insert_text
+      - replace_all_shapes_with_image
+      - replace_all_text
+      - ungroup_objects
+      - update_page_element_transform
+      - update_page_elements_z_order
+      - update_page_properties
+      - update_paragraph_style
+      - update_shape_properties
+      - update_slides_position
+      - update_table_cell_properties
+      - update_text_style
+
+  hex:
+    auth_type: manual
+    connection_mode: identity
+    operations:
+      - cancel_run
+      - get_project
+      - get_project_runs
+      - get_run_status
+      - list_cells
+      - list_projects
+      - run_project
+      - update_cell
+      - update_project
+
+  incident_io:
+    auth_type: manual
+    connection_mode: identity
+    operations:
+      - create_incident
+      - get_incident
+      - get_schedule_entries
+      - get_user
+      - list_incidents
+      - list_schedules
+      - list_severities
+      - list_statuses
+      - list_users
+      - update_incident
+
+  intercom:
+    auth_type: oauth2
+    connection_mode: user
+    operations:
+      - create_contact
+      - create_note
+      - get_company
+      - get_contact
+      - get_conversation
+      - list_companies
+      - list_contacts
+      - list_conversations
+      - list_tags
+      - search_conversations
+
+  jira:
+    auth_type: oauth2
+    connection_mode: user
+    operations:
+      - add_comment
+      - create_issue
+      - get_issue
+      - get_transitions
+      - list_projects
+      - search_issues
+      - transition_issue
+
+  launchdarkly:
+    auth_type: manual
+    connection_mode: identity
+    operations:
+      - get_feature_flag
+      - list_feature_flags
+      - list_projects
+
+  linear:
+    auth_type: oauth2
+    connection_mode: user
+    operations:
+      - create_comment
+      - create_initiative
+      - create_issue
+      - create_issue_label
+      - create_milestone
+      - create_project
+      - delete_status_update
+      - get_current_user
+      - get_issue
+      - list_issues
+      - list_projects
+      - list_teams
+      - list_users
+      - list_workflow_states
+      - save_status_update
+      - search_issues
+      - update_initiative
+      - update_issue
+      - update_milestone
+
+  linear_app:
+    auth_type: manual
+    connection_mode: identity
+    operations:
+      - create_comment
+      - create_initiative
+      - create_issue
+      - create_issue_label
+      - create_milestone
+      - create_project
+      - delete_status_update
+      - get_current_user
+      - get_issue
+      - list_issues
+      - list_projects
+      - list_teams
+      - list_users
+      - list_workflow_states
+      - save_status_update
+      - search_issues
+      - update_initiative
+      - update_issue
+      - update_milestone
+
+  notion:
+    auth_type: oauth2
+    connection_mode: user
+    operations:
+      - append_blocks
+      - create_comment
+      - create_database
+      - create_page
+      - delete_block
+      - get_block
+      - get_database
+      - get_page
+      - get_page_content
+      - get_user
+      - list_comments
+      - list_users
+      - query_database
+      - search
+      - update_block
+      - update_database
+      - update_page
+
+  pagerduty:
+    auth_type: manual
+    connection_mode: user
+    operations:
+      - acknowledge_incident
+      - add_note
+      - create_incident
+      - get_incident
+      - get_on_calls
+      - get_service
+      - list_incidents
+      - list_services
+      - list_users
+      - reassign_incident
+      - resolve_incident
+      - snooze_incident
+
+  ramp:
+    auth_type: oauth2
+    connection_mode: identity
+    operations:
+      - get_card
+      - get_transaction
+      - get_user
+      - list_cards
+      - list_departments
+      - list_transactions
+      - list_users
+
+  rippling:
+    auth_type: manual
+    connection_mode: identity
+    operations:
+      - get_company
+      - get_employee
+      - list_departments
+      - list_employees
+      - list_groups
+      - list_leave_balances
+      - list_leave_requests
+      - list_work_locations
+
+  slack:
+    auth_type: oauth2
+    connection_mode: user
+    operations:
+      - add_reaction
+      - create_canvas
+      - create_channel
+      - find_user_mentions
+      - get_channel_history
+      - get_message
+      - get_thread_participants
+      - get_thread_replies
+      - get_user_info
+      - invite_to_channel
+      - list_channels
+      - schedule_message
+      - search_messages
+      - send_message
+      - send_message_draft
+      - set_channel_topic
+
+  slack_bot:
+    auth_type: manual
+    connection_mode: identity
+    operations:
+      - add_reaction
+      - create_canvas
+      - create_channel
+      - find_user_mentions
+      - get_channel_history
+      - get_message
+      - get_thread_participants
+      - get_thread_replies
+      - get_user_info
+      - invite_to_channel
+      - list_channels
+      - schedule_message
+      - search_messages
+      - send_message
+      - send_message_draft
+      - set_channel_topic

--- a/plugins/providers/inventory/inventory_test.go
+++ b/plugins/providers/inventory/inventory_test.go
@@ -1,0 +1,112 @@
+package inventory
+
+import (
+	"sort"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestInventoryLoads(t *testing.T) {
+	t.Parallel()
+
+	inv, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(inv.Providers) == 0 {
+		t.Fatal("inventory has no providers")
+	}
+}
+
+func TestProviderKeysUnique(t *testing.T) {
+	t.Parallel()
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(rawYAML, &root); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+		t.Fatal("unexpected YAML structure")
+	}
+	topMap := root.Content[0]
+	if topMap.Kind != yaml.MappingNode {
+		t.Fatal("expected top-level mapping")
+	}
+
+	var providersNode *yaml.Node
+	for i := 0; i < len(topMap.Content)-1; i += 2 {
+		if topMap.Content[i].Value == "providers" {
+			providersNode = topMap.Content[i+1]
+			break
+		}
+	}
+	if providersNode == nil || providersNode.Kind != yaml.MappingNode {
+		t.Fatal("missing providers mapping")
+	}
+
+	seen := make(map[string]int)
+	for i := 0; i < len(providersNode.Content)-1; i += 2 {
+		key := providersNode.Content[i].Value
+		if prev, ok := seen[key]; ok {
+			t.Errorf("duplicate provider key %q at lines %d and %d", key, prev, providersNode.Content[i].Line)
+		}
+		seen[key] = providersNode.Content[i].Line
+	}
+}
+
+func TestOperationsUniquePerProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	for name, spec := range inv.Providers {
+		seen := make(map[string]struct{}, len(spec.Operations))
+		for _, op := range spec.Operations {
+			if _, ok := seen[op]; ok {
+				t.Errorf("provider %q: duplicate operation %q", name, op)
+			}
+			seen[op] = struct{}{}
+		}
+	}
+}
+
+func TestOperationsSorted(t *testing.T) {
+	t.Parallel()
+
+	inv, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	for name, spec := range inv.Providers {
+		if !sort.StringsAreSorted(spec.Operations) {
+			t.Errorf("provider %q: operations are not sorted alphabetically", name)
+		}
+	}
+}
+
+func TestAllProvidersHaveOperations(t *testing.T) {
+	t.Parallel()
+
+	inv, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	for name, spec := range inv.Providers {
+		if len(spec.Operations) == 0 {
+			t.Errorf("provider %q: has no operations", name)
+		}
+		if spec.AuthType == "" {
+			t.Errorf("provider %q: missing auth_type", name)
+		}
+		if spec.ConnectionMode == "" {
+			t.Errorf("provider %q: missing connection_mode", name)
+		}
+	}
+}

--- a/plugins/providers/jira/factory_test.go
+++ b/plugins/providers/jira/factory_test.go
@@ -5,87 +5,61 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/config"
-	"github.com/valon-technologies/gestalt/internal/provider"
-	"gopkg.in/yaml.v3"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
 )
 
 const (
-	testClientID     = "dummy-client-id"
-	testClientSecret = "dummy-client-secret"
-	expectedOps      = 7
-	discoveryURL     = "https://api.atlassian.com/oauth/token/accessible-resources"
+	dummyClientID     = "dummy-client-id"
+	dummyClientSecret = "dummy-client-secret"
+	discoveryURL      = "https://api.atlassian.com/oauth/token/accessible-resources"
 )
 
 func TestDefinitionParses(t *testing.T) {
 	t.Parallel()
 
-	var def provider.Definition
-	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
-		t.Fatalf("unmarshal: %v", err)
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
 	}
+	spec := inv.Providers["jira"]
 
-	if def.Provider != "jira" {
-		t.Fatalf("expected provider jira, got %q", def.Provider)
-	}
-	if len(def.Operations) != expectedOps {
-		t.Fatalf("expected %d operations, got %d", expectedOps, len(def.Operations))
-	}
-
-	cloudID, ok := def.Connection["cloud_id"]
-	if !ok {
-		t.Fatal("missing cloud_id connection param")
-	}
-	if cloudID.From != "discovery" {
-		t.Fatalf("expected cloud_id from=discovery, got %q", cloudID.From)
-	}
-	if !cloudID.Required {
-		t.Fatal("expected cloud_id to be required")
-	}
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "jira",
+		OperationCount: len(spec.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+		Connection: map[string]providertest.ConnParam{
+			"cloud_id": {Required: true, From: "discovery"},
+		},
+	})
 }
 
 func TestBuildProvider(t *testing.T) {
 	t.Parallel()
 
-	var def provider.Definition
-	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-
-	intg := config.IntegrationDef{
-		ClientID:     testClientID,
-		ClientSecret: testClientSecret,
-	}
-
-	prov, err := provider.Build(&def, intg, nil)
+	inv, err := inventory.Load()
 	if err != nil {
-		t.Fatalf("Build: %v", err)
+		t.Fatalf("inventory.Load: %v", err)
 	}
+	spec := inv.Providers["jira"]
 
-	if prov.Name() != "jira" {
-		t.Fatalf("expected name jira, got %q", prov.Name())
-	}
-	if prov.ConnectionMode() != core.ConnectionModeUser {
-		t.Fatalf("expected connection mode user, got %q", prov.ConnectionMode())
-	}
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID:     dummyClientID,
+		ClientSecret: dummyClientSecret,
+	})
 
-	ops := prov.ListOperations()
-	if len(ops) != expectedOps {
-		t.Fatalf("expected %d operations, got %d", expectedOps, len(ops))
-	}
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "jira",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
 
-	dcp, ok := prov.(core.DiscoveryConfigProvider)
-	if !ok {
-		t.Fatal("provider does not implement DiscoveryConfigProvider")
-	}
-
-	dc := dcp.DiscoveryConfig()
-	if dc == nil {
-		t.Fatal("DiscoveryConfig() returned nil")
-	}
-	if dc.URL != discoveryURL {
-		t.Fatalf("expected discovery URL %q, got %q", discoveryURL, dc.URL)
-	}
-	if dc.MetadataMapping["cloud_id"] != "id" {
-		t.Fatalf("expected metadata_mapping cloud_id=id, got %q", dc.MetadataMapping["cloud_id"])
-	}
+	providertest.CheckDiscovery(t, prov, providertest.DiscoveryExpect{
+		URL:             discoveryURL,
+		MetadataMapping: map[string]string{"cloud_id": "id"},
+	})
 }

--- a/plugins/providers/providertest/providertest.go
+++ b/plugins/providers/providertest/providertest.go
@@ -1,0 +1,197 @@
+package providertest
+
+import (
+	"sort"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+type DefinitionExpect struct {
+	Name           string
+	OperationCount int
+	AuthType       string
+	ConnectionMode string
+	Connection     map[string]ConnParam
+}
+
+type ConnParam struct {
+	Required bool
+	From     string
+}
+
+type ProviderExpect struct {
+	Name           string
+	ConnectionMode core.ConnectionMode
+	OperationCount int
+	OperationNames []string
+}
+
+type DiscoveryExpect struct {
+	URL             string
+	MetadataMapping map[string]string
+}
+
+func ParseDefinition(t *testing.T, yamlData []byte) *provider.Definition {
+	t.Helper()
+	var def provider.Definition
+	if err := yaml.Unmarshal(yamlData, &def); err != nil {
+		t.Fatalf("unmarshal provider definition: %v", err)
+	}
+	return &def
+}
+
+func CheckDefinition(t *testing.T, def *provider.Definition, expect DefinitionExpect) {
+	t.Helper()
+
+	if def.Provider != expect.Name {
+		t.Fatalf("provider = %q, want %q", def.Provider, expect.Name)
+	}
+	if len(def.Operations) != expect.OperationCount {
+		t.Fatalf("operations = %d, want %d", len(def.Operations), expect.OperationCount)
+	}
+	if expect.AuthType != "" && def.Auth.Type != expect.AuthType {
+		t.Fatalf("auth.type = %q, want %q", def.Auth.Type, expect.AuthType)
+	}
+	if expect.ConnectionMode != "" && def.ConnectionMode != expect.ConnectionMode {
+		t.Fatalf("connection_mode = %q, want %q", def.ConnectionMode, expect.ConnectionMode)
+	}
+	for name, expected := range expect.Connection {
+		cp, ok := def.Connection[name]
+		if !ok {
+			t.Fatalf("missing connection param %q", name)
+		}
+		if cp.Required != expected.Required {
+			t.Errorf("connection[%q].required = %v, want %v", name, cp.Required, expected.Required)
+		}
+		if cp.From != expected.From {
+			t.Errorf("connection[%q].from = %q, want %q", name, cp.From, expected.From)
+		}
+	}
+}
+
+func BuildProvider(t *testing.T, def *provider.Definition, intg config.IntegrationDef, opts ...provider.BuildOption) core.Provider {
+	t.Helper()
+	prov, err := provider.Build(def, intg, nil, opts...)
+	if err != nil {
+		t.Fatalf("provider.Build: %v", err)
+	}
+	return prov
+}
+
+func CheckProvider(t *testing.T, prov core.Provider, expect ProviderExpect) {
+	t.Helper()
+
+	if prov.Name() != expect.Name {
+		t.Fatalf("Name() = %q, want %q", prov.Name(), expect.Name)
+	}
+	if prov.ConnectionMode() != expect.ConnectionMode {
+		t.Fatalf("ConnectionMode() = %q, want %q", prov.ConnectionMode(), expect.ConnectionMode)
+	}
+
+	ops := prov.ListOperations()
+
+	wantCount := expect.OperationCount
+	if expect.OperationNames != nil {
+		wantCount = len(expect.OperationNames)
+	}
+	if len(ops) != wantCount {
+		t.Fatalf("ListOperations() = %d, want %d", len(ops), wantCount)
+	}
+
+	if expect.OperationNames != nil {
+		got := make([]string, len(ops))
+		for i, op := range ops {
+			got[i] = op.Name
+		}
+		sort.Strings(got)
+
+		want := make([]string, len(expect.OperationNames))
+		copy(want, expect.OperationNames)
+		sort.Strings(want)
+
+		for i := range got {
+			if got[i] != want[i] {
+				t.Errorf("operation mismatch at sorted index %d: got %q, want %q", i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func CheckDiscovery(t *testing.T, prov core.Provider, expect DiscoveryExpect) {
+	t.Helper()
+	dcp, ok := prov.(core.DiscoveryConfigProvider)
+	if !ok {
+		t.Fatal("provider does not implement DiscoveryConfigProvider")
+	}
+	dc := dcp.DiscoveryConfig()
+	if dc == nil {
+		t.Fatal("DiscoveryConfig() returned nil")
+	}
+	if dc.URL != expect.URL {
+		t.Fatalf("DiscoveryConfig().URL = %q, want %q", dc.URL, expect.URL)
+	}
+	for key, wantVal := range expect.MetadataMapping {
+		gotVal, ok := dc.MetadataMapping[key]
+		if !ok {
+			t.Errorf("DiscoveryConfig().MetadataMapping missing key %q", key)
+		} else if gotVal != wantVal {
+			t.Errorf("DiscoveryConfig().MetadataMapping[%q] = %q, want %q", key, gotVal, wantVal)
+		}
+	}
+}
+
+func CheckConnectionParams(t *testing.T, prov core.Provider, expected map[string]ConnParam) {
+	t.Helper()
+	cpp, ok := prov.(core.ConnectionParamProvider)
+	if !ok {
+		t.Fatal("provider does not implement ConnectionParamProvider")
+	}
+	defs := cpp.ConnectionParamDefs()
+	for name, expect := range expected {
+		cpd, ok := defs[name]
+		if !ok {
+			t.Errorf("missing connection param %q", name)
+			continue
+		}
+		if cpd.Required != expect.Required {
+			t.Errorf("connection param %q: required = %v, want %v", name, cpd.Required, expect.Required)
+		}
+		if cpd.From != expect.From {
+			t.Errorf("connection param %q: from = %q, want %q", name, cpd.From, expect.From)
+		}
+	}
+}
+
+func CheckOAuth(t *testing.T, prov core.Provider) {
+	t.Helper()
+	if _, ok := prov.(core.OAuthProvider); !ok {
+		t.Fatal("provider does not implement OAuthProvider")
+	}
+}
+
+func CheckManualAuth(t *testing.T, prov core.Provider) {
+	t.Helper()
+	mp, ok := prov.(core.ManualProvider)
+	if !ok {
+		t.Fatal("provider does not implement ManualProvider")
+	}
+	if !mp.SupportsManualAuth() {
+		t.Fatal("SupportsManualAuth() = false, want true")
+	}
+}
+
+func CheckCatalog(t *testing.T, prov core.Provider) {
+	t.Helper()
+	cp, ok := prov.(core.CatalogProvider)
+	if !ok {
+		t.Fatal("provider does not implement CatalogProvider")
+	}
+	if cp.Catalog() == nil {
+		t.Fatal("Catalog() returned nil")
+	}
+}


### PR DESCRIPTION
This establishes the shared infrastructure for parallel first-party
provider development. A machine-readable inventory in
`plugins/providers/inventory/inventory.yaml` freezes the canonical
operation set for 28 providers, validated by tests that enforce unique
keys, unique operations per provider, and alphabetical sort order.
Provider tests import expected operations from the inventory rather than
hardcoding them, so the contract is enforced at test time.

A shared `providertest` package provides composable assertion helpers
(`ParseDefinition`, `BuildProvider`, `CheckProvider`, `CheckDiscovery`,
etc.) that eliminate boilerplate from provider test files. Both the Jira
and BigQuery tests are refactored to use the new harness. Provider
factory registrations are extracted from `buildFactories` into a
dedicated `cmd/gestaltd/providers.go` file owned by the integrator, so
parallel provider PRs never touch the same function. A new docs page
covers the first-party provider development workflow.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>