### PR TITLE
Expose StartProvider and config schema in public SDK

### DIFF
--- a/sdk/pluginsdk/convert.go
+++ b/sdk/pluginsdk/convert.go
@@ -79,6 +79,15 @@ func operationsToProto(ops []Operation) ([]*pluginapiv1.Operation, error) {
 	return out, nil
 }
 
+func pluginModeFromProto(mode pluginapiv1.PluginMode) string {
+	switch mode {
+	case pluginapiv1.PluginMode_PLUGIN_MODE_OVERLAY:
+		return PluginModeOverlay
+	default:
+		return PluginModeReplace
+	}
+}
+
 func connectionParamDefsToProto(defs map[string]ConnectionParamDef) map[string]*pluginapiv1.ConnectionParamDef {
 	if len(defs) == 0 {
 		return nil

--- a/sdk/pluginsdk/plugin_test.go
+++ b/sdk/pluginsdk/plugin_test.go
@@ -35,6 +35,27 @@ func (p *stubProvider) Execute(_ context.Context, operation string, params map[s
 	}, nil
 }
 
+type startableStubProvider struct {
+	stubProvider
+	startName   string
+	startConfig map[string]any
+	startMode   string
+}
+
+func (p *startableStubProvider) Start(_ context.Context, name string, config map[string]any, mode string) error {
+	p.startName = name
+	p.startConfig = config
+	p.startMode = mode
+	return nil
+}
+
+type schemaStubProvider struct {
+	stubProvider
+	schema string
+}
+
+func (p *schemaStubProvider) ConfigSchemaJSON() string { return p.schema }
+
 func newTestProviderClient(t *testing.T, prov pluginsdk.Provider) pluginapiv1.ProviderPluginClient {
 	t.Helper()
 	lis := bufconn.Listen(1024 * 1024)
@@ -159,6 +180,104 @@ func TestProviderServerExecute(t *testing.T) {
 	}
 	if resp.GetBody() != `{"operation":"test_op"}` {
 		t.Errorf("Body = %q, want %q", resp.GetBody(), `{"operation":"test_op"}`)
+	}
+}
+
+func TestProviderServerStartProvider(t *testing.T) {
+	prov := &startableStubProvider{
+		stubProvider: stubProvider{
+			name:     "test-provider",
+			connMode: pluginsdk.ConnectionModeNone,
+		},
+	}
+
+	client := newTestProviderClient(t, prov)
+	ctx := context.Background()
+
+	cfg, _ := structpb.NewStruct(map[string]any{"key": "val"})
+	resp, err := client.StartProvider(ctx, &pluginapiv1.StartProviderRequest{
+		Name:            "my-instance",
+		Config:          cfg,
+		Mode:            pluginapiv1.PluginMode_PLUGIN_MODE_OVERLAY,
+		ProtocolVersion: 1,
+	})
+	if err != nil {
+		t.Fatalf("StartProvider: %v", err)
+	}
+	if resp.GetProtocolVersion() != 1 {
+		t.Errorf("ProtocolVersion = %d, want 1", resp.GetProtocolVersion())
+	}
+	if prov.startName != "my-instance" {
+		t.Errorf("startName = %q, want %q", prov.startName, "my-instance")
+	}
+	if prov.startConfig["key"] != "val" {
+		t.Errorf("startConfig[key] = %v, want %q", prov.startConfig["key"], "val")
+	}
+	if prov.startMode != pluginsdk.PluginModeOverlay {
+		t.Errorf("startMode = %q, want %q", prov.startMode, pluginsdk.PluginModeOverlay)
+	}
+}
+
+func TestProviderServerStartProviderNoOp(t *testing.T) {
+	prov := &stubProvider{
+		name:     "test-provider",
+		connMode: pluginsdk.ConnectionModeNone,
+	}
+
+	client := newTestProviderClient(t, prov)
+	ctx := context.Background()
+
+	resp, err := client.StartProvider(ctx, &pluginapiv1.StartProviderRequest{
+		Name:            "my-instance",
+		ProtocolVersion: 1,
+	})
+	if err != nil {
+		t.Fatalf("StartProvider: %v", err)
+	}
+	if resp.GetProtocolVersion() != 1 {
+		t.Errorf("ProtocolVersion = %d, want 1", resp.GetProtocolVersion())
+	}
+}
+
+func TestProviderServerConfigSchema(t *testing.T) {
+	prov := &schemaStubProvider{
+		stubProvider: stubProvider{
+			name:     "test-provider",
+			connMode: pluginsdk.ConnectionModeNone,
+		},
+		schema: `{"type":"object"}`,
+	}
+
+	client := newTestProviderClient(t, prov)
+	ctx := context.Background()
+
+	meta, err := client.GetMetadata(ctx, &emptypb.Empty{})
+	if err != nil {
+		t.Fatalf("GetMetadata: %v", err)
+	}
+	if meta.GetConfigSchemaJson() != `{"type":"object"}` {
+		t.Errorf("ConfigSchemaJson = %q, want %q", meta.GetConfigSchemaJson(), `{"type":"object"}`)
+	}
+}
+
+func TestProviderServerProtocolVersion(t *testing.T) {
+	prov := &stubProvider{
+		name:     "test-provider",
+		connMode: pluginsdk.ConnectionModeNone,
+	}
+
+	client := newTestProviderClient(t, prov)
+	ctx := context.Background()
+
+	meta, err := client.GetMetadata(ctx, &emptypb.Empty{})
+	if err != nil {
+		t.Fatalf("GetMetadata: %v", err)
+	}
+	if meta.GetMinProtocolVersion() != pluginapiv1.CurrentProtocolVersion {
+		t.Errorf("MinProtocolVersion = %d, want %d", meta.GetMinProtocolVersion(), pluginapiv1.CurrentProtocolVersion)
+	}
+	if meta.GetMaxProtocolVersion() != pluginapiv1.CurrentProtocolVersion {
+		t.Errorf("MaxProtocolVersion = %d, want %d", meta.GetMaxProtocolVersion(), pluginapiv1.CurrentProtocolVersion)
 	}
 }
 

--- a/sdk/pluginsdk/provider_server.go
+++ b/sdk/pluginsdk/provider_server.go
@@ -9,6 +9,18 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
+type StartableProvider interface {
+	Start(ctx context.Context, name string, config map[string]any, mode string) error
+}
+
+type ConfigSchemaProvider interface {
+	ConfigSchemaJSON() string
+}
+
+type ProtocolVersionProvider interface {
+	ProtocolVersionRange() (min, max int32)
+}
+
 type ProviderServer struct {
 	pluginapiv1.UnimplementedProviderPluginServer
 	provider Provider
@@ -18,18 +30,41 @@ func NewProviderServer(provider Provider) *ProviderServer {
 	return &ProviderServer{provider: provider}
 }
 
+func (s *ProviderServer) StartProvider(ctx context.Context, req *pluginapiv1.StartProviderRequest) (*pluginapiv1.StartProviderResponse, error) {
+	if sp, ok := s.provider.(StartableProvider); ok {
+		config := mapFromStruct(req.GetConfig())
+		mode := pluginModeFromProto(req.GetMode())
+		if err := sp.Start(ctx, req.GetName(), config, mode); err != nil {
+			return nil, status.Errorf(codes.Internal, "start provider: %v", err)
+		}
+	}
+	return &pluginapiv1.StartProviderResponse{
+		ProtocolVersion: req.GetProtocolVersion(),
+	}, nil
+}
+
 func (s *ProviderServer) GetMetadata(_ context.Context, _ *emptypb.Empty) (*pluginapiv1.ProviderMetadata, error) {
 	var connParams map[string]*pluginapiv1.ConnectionParamDef
 	if cpp, ok := s.provider.(ConnectionParamProvider); ok {
 		connParams = connectionParamDefsToProto(cpp.ConnectionParamDefs())
 	}
 
+	var configSchema string
+	if csp, ok := s.provider.(ConfigSchemaProvider); ok {
+		configSchema = csp.ConfigSchemaJSON()
+	}
+
+	minPV, maxPV := protocolVersionRange(s.provider)
+
 	return &pluginapiv1.ProviderMetadata{
-		Name:             s.provider.Name(),
-		DisplayName:      s.provider.DisplayName(),
-		Description:      s.provider.Description(),
-		ConnectionMode:   coreConnectionModeToProto(s.provider.ConnectionMode()),
-		ConnectionParams: connParams,
+		Name:               s.provider.Name(),
+		DisplayName:        s.provider.DisplayName(),
+		Description:        s.provider.Description(),
+		ConnectionMode:     coreConnectionModeToProto(s.provider.ConnectionMode()),
+		ConnectionParams:   connParams,
+		ConfigSchemaJson:   configSchema,
+		MinProtocolVersion: minPV,
+		MaxProtocolVersion: maxPV,
 	}, nil
 }
 
@@ -59,4 +94,11 @@ func (s *ProviderServer) Execute(ctx context.Context, req *pluginapiv1.ExecuteRe
 		Status: int32(result.Status),
 		Body:   result.Body,
 	}, nil
+}
+
+func protocolVersionRange(p Provider) (min, max int32) {
+	if pvp, ok := p.(ProtocolVersionProvider); ok {
+		return pvp.ProtocolVersionRange()
+	}
+	return pluginapiv1.CurrentProtocolVersion, pluginapiv1.CurrentProtocolVersion
 }

--- a/sdk/pluginsdk/types.go
+++ b/sdk/pluginsdk/types.go
@@ -11,6 +11,11 @@ const (
 	ConnectionModeEither   ConnectionMode = "either"
 )
 
+const (
+	PluginModeReplace = "replace"
+	PluginModeOverlay = "overlay"
+)
+
 type Provider interface {
 	Name() string
 	DisplayName() string


### PR DESCRIPTION
The host-side StartProvider RPC was added in a prior PR but the public
SDK had no way for plugin authors to receive startup config or declare
config schemas. This adds `StartableProvider` and `ConfigSchemaProvider`
optional interfaces to the SDK's `ProviderServer`, populates protocol
version fields in `GetMetadata` responses, and echoes the host's
protocol version in `StartProvider` responses. Plugin authors who do
not implement these interfaces get safe defaults.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>