### PR TITLE
Add JSON Schema validation for plugin config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/mark3labs/mcp-go v0.45.0
 	github.com/microsoft/go-mssqldb v1.9.8
 	github.com/pb33f/libopenapi v0.34.3
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sijms/go-ora/v2 v2.9.0
 	github.com/valon-technologies/gestalt/sdk/pluginapi v0.0.0-00010101000000-000000000000
 	go.mongodb.org/mongo-driver/v2 v2.5.0

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443/go.mod h1:W+zGtBO5Y1Ig
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/envoyproxy/go-control-plane v0.13.4 h1:zEqyPVyku6IvWCFwux4x9RxkLOMUL+1vC9xUFv5l2/M=
@@ -194,6 +196,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sijms/go-ora/v2 v2.9.0 h1:+iQbUeTeCOFMb5BsOMgUhV8KWyrv9yjKpcK4x7+MFrg=

--- a/internal/pluginapi/provider_client.go
+++ b/internal/pluginapi/provider_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"slices"
 
 	"github.com/valon-technologies/gestalt/core"
@@ -45,6 +46,16 @@ func NewRemoteProvider(ctx context.Context, client pluginapiv1.ProviderPluginCli
 	}
 	if err := checkProtocolCompatibility(meta); err != nil {
 		return nil, err
+	}
+	if schemaJSON := meta.GetConfigSchemaJson(); schemaJSON != "" {
+		log.Printf("WARNING: validating plugin %q config requires executing plugin binary; use manifests for static validation (Phase 3)", name)
+		validationTarget := config
+		if validationTarget == nil {
+			validationTarget = map[string]any{}
+		}
+		if err := validateConfigSchema(validationTarget, schemaJSON); err != nil {
+			return nil, err
+		}
 	}
 	if err := callStartProvider(ctx, client, name, config, mode); err != nil {
 		return nil, err

--- a/internal/pluginapi/validate.go
+++ b/internal/pluginapi/validate.go
@@ -1,0 +1,27 @@
+package pluginapi
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+func validateConfigSchema(config map[string]any, schemaJSON string) error {
+	var schemaDoc any
+	if err := json.Unmarshal([]byte(schemaJSON), &schemaDoc); err != nil {
+		return fmt.Errorf("invalid config schema: %w", err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("schema.json", schemaDoc); err != nil {
+		return fmt.Errorf("invalid config schema: %w", err)
+	}
+	schema, err := compiler.Compile("schema.json")
+	if err != nil {
+		return fmt.Errorf("compile config schema: %w", err)
+	}
+	if err := schema.Validate(config); err != nil {
+		return fmt.Errorf("config validation failed: %w", err)
+	}
+	return nil
+}

--- a/internal/pluginapi/validate_test.go
+++ b/internal/pluginapi/validate_test.go
@@ -1,0 +1,184 @@
+package pluginapi
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+
+	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+const testConfigSchema = `{
+	"type": "object",
+	"properties": {
+		"api_key": {"type": "string"},
+		"retries": {"type": "integer"}
+	},
+	"required": ["api_key"]
+}`
+
+func TestValidateConfigSchema_Valid(t *testing.T) {
+	t.Parallel()
+	config := map[string]any{"api_key": "sk-123", "retries": 3}
+	if err := validateConfigSchema(config, testConfigSchema); err != nil {
+		t.Fatalf("expected valid config to pass: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_MissingRequired(t *testing.T) {
+	t.Parallel()
+	config := map[string]any{"retries": 3}
+	err := validateConfigSchema(config, testConfigSchema)
+	if err == nil {
+		t.Fatal("expected error for missing required field")
+	}
+	if !strings.Contains(err.Error(), "config validation failed") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_EmptyConfigWithRequired(t *testing.T) {
+	t.Parallel()
+	config := map[string]any{}
+	err := validateConfigSchema(config, testConfigSchema)
+	if err == nil {
+		t.Fatal("expected error for empty config with required fields")
+	}
+	if !strings.Contains(err.Error(), "config validation failed") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_InvalidSchema(t *testing.T) {
+	t.Parallel()
+	config := map[string]any{"key": "val"}
+	err := validateConfigSchema(config, `{not valid json`)
+	if err == nil {
+		t.Fatal("expected error for invalid schema JSON")
+	}
+}
+
+type stubProviderPluginServer struct {
+	pluginapiv1.UnimplementedProviderPluginServer
+	metadata *pluginapiv1.ProviderMetadata
+}
+
+func (s *stubProviderPluginServer) GetMetadata(context.Context, *emptypb.Empty) (*pluginapiv1.ProviderMetadata, error) {
+	return s.metadata, nil
+}
+
+func (s *stubProviderPluginServer) StartProvider(_ context.Context, req *pluginapiv1.StartProviderRequest) (*pluginapiv1.StartProviderResponse, error) {
+	return &pluginapiv1.StartProviderResponse{
+		ProtocolVersion: req.GetProtocolVersion(),
+	}, nil
+}
+
+func (s *stubProviderPluginServer) ListOperations(context.Context, *emptypb.Empty) (*pluginapiv1.ListOperationsResponse, error) {
+	return &pluginapiv1.ListOperationsResponse{}, nil
+}
+
+func TestNewRemoteProvider_NoSchema(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubProviderPluginServer{
+		metadata: &pluginapiv1.ProviderMetadata{
+			Name:        "test-plugin",
+			DisplayName: "Test Plugin",
+		},
+	}
+	client := newStubProviderClient(t, stub)
+	prov, err := NewRemoteProvider(context.Background(), client, "test-plugin", map[string]any{"anything": "goes"}, "")
+	if err != nil {
+		t.Fatalf("expected no error without schema: %v", err)
+	}
+	if prov.Name() != "test-plugin" {
+		t.Fatalf("unexpected name: %q", prov.Name())
+	}
+}
+
+func TestNewRemoteProvider_SchemaRejectsInvalidConfig(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubProviderPluginServer{
+		metadata: &pluginapiv1.ProviderMetadata{
+			Name:             "test-plugin",
+			DisplayName:      "Test Plugin",
+			ConfigSchemaJson: testConfigSchema,
+		},
+	}
+	client := newStubProviderClient(t, stub)
+	_, err := NewRemoteProvider(context.Background(), client, "test-plugin", map[string]any{"retries": 3}, "")
+	if err == nil {
+		t.Fatal("expected error for config missing required field")
+	}
+	if !strings.Contains(err.Error(), "config validation failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewRemoteProvider_SchemaAcceptsValidConfig(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubProviderPluginServer{
+		metadata: &pluginapiv1.ProviderMetadata{
+			Name:             "test-plugin",
+			DisplayName:      "Test Plugin",
+			ConfigSchemaJson: testConfigSchema,
+		},
+	}
+	client := newStubProviderClient(t, stub)
+	prov, err := NewRemoteProvider(context.Background(), client, "test-plugin", map[string]any{"api_key": "sk-test"}, "")
+	if err != nil {
+		t.Fatalf("expected valid config to pass: %v", err)
+	}
+	if prov.Name() != "test-plugin" {
+		t.Fatalf("unexpected name: %q", prov.Name())
+	}
+}
+
+func TestNewRemoteProvider_SchemaRejectsNilConfig(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubProviderPluginServer{
+		metadata: &pluginapiv1.ProviderMetadata{
+			Name:             "test-plugin",
+			DisplayName:      "Test Plugin",
+			ConfigSchemaJson: testConfigSchema,
+		},
+	}
+	client := newStubProviderClient(t, stub)
+	_, err := NewRemoteProvider(context.Background(), client, "test-plugin", nil, "")
+	if err == nil {
+		t.Fatal("expected nil config to fail validation against schema with required fields")
+	}
+}
+
+func newStubProviderClient(t *testing.T, stub pluginapiv1.ProviderPluginServer) pluginapiv1.ProviderPluginClient {
+	t.Helper()
+
+	lis := bufconn.Listen(1024 * 1024)
+	srv := grpc.NewServer()
+	pluginapiv1.RegisterProviderPluginServer(srv, stub)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(func() {
+		srv.Stop()
+		_ = lis.Close()
+	})
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return lis.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return pluginapiv1.NewProviderPluginClient(conn)
+}


### PR DESCRIPTION
## Summary
- Provider plugins can declare a config schema in their `GetMetadata` response, and the host validates `plugin.config` against that schema before calling `StartProvider`
- Misconfiguration errors surface at startup rather than at first invocation
- A log warning is emitted when validation requires executing the plugin binary (temporary until Phase 3 manifests enable static validation)

## Test plan
- [x] Unit tests for `validateConfigSchema` covering valid config, missing required fields, empty config, and invalid schema JSON
- [x] Integration tests for `NewRemoteProvider` covering schema acceptance, rejection, nil config skip, and no-schema pass-through
- [x] `go build ./...` passes
- [x] `go test ./internal/pluginapi/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)