### PR TITLE
fix: move egress subject mapping to invocation boundaries

### DIFF
--- a/internal/invocation/broker_test.go
+++ b/internal/invocation/broker_test.go
@@ -314,3 +314,62 @@ func TestInvoke_PreservesExplicitEgressSubject(t *testing.T) {
 		t.Fatalf("subject = %+v, want agent agent-1", gotSubject)
 	}
 }
+
+func TestInvoke_AttachesIdentitySubjectFromPrincipalEmail(t *testing.T) {
+	t.Parallel()
+
+	var gotSubject egress.Subject
+
+	prov := &stubProviderWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "test-int",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(ctx context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				gotSubject, _ = egress.SubjectFromContext(ctx)
+				return &core.OperationResult{Status: http.StatusOK, Body: `{}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "do_thing", Method: "GET"}},
+	}
+
+	b := invocation.NewBroker(testutil.NewProviderRegistry(t, prov), &coretesting.StubDatastore{})
+	p := &principal.Principal{
+		Identity: &core.UserIdentity{Email: "identity@example.invalid"},
+		UserID:   principal.IdentityPrincipal,
+	}
+
+	if _, err := b.Invoke(context.Background(), p, "test-int", "", "do_thing", nil); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if gotSubject != (egress.Subject{Kind: egress.SubjectIdentity, ID: "identity@example.invalid"}) {
+		t.Fatalf("subject = %+v, want identity email subject", gotSubject)
+	}
+}
+
+func TestInvoke_AttachesIdentitySubjectFromSentinelPrincipal(t *testing.T) {
+	t.Parallel()
+
+	var gotSubject egress.Subject
+
+	prov := &stubProviderWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "test-int",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(ctx context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				gotSubject, _ = egress.SubjectFromContext(ctx)
+				return &core.OperationResult{Status: http.StatusOK, Body: `{}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "do_thing", Method: "GET"}},
+	}
+
+	b := invocation.NewBroker(testutil.NewProviderRegistry(t, prov), &coretesting.StubDatastore{})
+	p := &principal.Principal{UserID: principal.IdentityPrincipal}
+
+	if _, err := b.Invoke(context.Background(), p, "test-int", "", "do_thing", nil); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if gotSubject != (egress.Subject{Kind: egress.SubjectIdentity, ID: principal.IdentityPrincipal}) {
+		t.Fatalf("subject = %+v, want identity sentinel subject", gotSubject)
+	}
+}

--- a/internal/mcp/binding_test.go
+++ b/internal/mcp/binding_test.go
@@ -56,6 +56,15 @@ func ctxWithPrincipal() context.Context {
 	return principal.WithPrincipal(context.Background(), p)
 }
 
+func ctxWithIdentityPrincipal(email, userID string) context.Context {
+	p := &principal.Principal{
+		Identity: &core.UserIdentity{Email: email},
+		UserID:   userID,
+		Source:   principal.SourceAPIToken,
+	}
+	return principal.WithPrincipal(context.Background(), p)
+}
+
 type testSessionWithTools struct {
 	id            string
 	initialized   bool
@@ -740,6 +749,110 @@ func TestNewServer_DirectCallerNoPrincipal(t *testing.T) {
 	}
 	if !result.IsError {
 		t.Fatal("expected IsError when no principal")
+	}
+}
+
+func TestNewServer_DirectCallerUsesIdentitySubjectEmail(t *testing.T) {
+	t.Parallel()
+
+	var gotSubject egress.Subject
+
+	cat := &catalog.Catalog{
+		Name: "sample",
+		Operations: []catalog.CatalogOperation{
+			{ID: "perform", Description: "Perform action"},
+		},
+	}
+	prov := &directCallerProvider{
+		StubIntegration: coretesting.StubIntegration{N: "sample"},
+		ops:             []core.Operation{{Name: "perform", Description: "Perform action"}},
+		cat:             cat,
+		callFn: func(ctx context.Context, _ string, _ map[string]any) (*mcpgo.CallToolResult, error) {
+			var ok bool
+			gotSubject, ok = egress.SubjectFromContext(ctx)
+			if !ok {
+				t.Fatal("expected egress subject in direct caller context")
+			}
+			return mcpgo.NewToolResultText("ok"), nil
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, prov)
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker:       &testutil.StubInvoker{},
+		TokenResolver: &stubTokenResolver{token: "test-token"},
+		Providers:     providers,
+	})
+
+	tool := srv.GetTool("sample_perform")
+	if tool == nil {
+		t.Fatal("tool not found")
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Name = "sample_perform"
+
+	result, err := tool.Handler(ctxWithIdentityPrincipal("identity@example.invalid", principal.IdentityPrincipal), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+	if gotSubject != (egress.Subject{Kind: egress.SubjectIdentity, ID: "identity@example.invalid"}) {
+		t.Fatalf("subject = %+v, want identity email subject", gotSubject)
+	}
+}
+
+func TestNewServer_DirectCallerUsesIdentitySubjectSentinel(t *testing.T) {
+	t.Parallel()
+
+	var gotSubject egress.Subject
+
+	cat := &catalog.Catalog{
+		Name: "sample",
+		Operations: []catalog.CatalogOperation{
+			{ID: "perform", Description: "Perform action"},
+		},
+	}
+	prov := &directCallerProvider{
+		StubIntegration: coretesting.StubIntegration{N: "sample"},
+		ops:             []core.Operation{{Name: "perform", Description: "Perform action"}},
+		cat:             cat,
+		callFn: func(ctx context.Context, _ string, _ map[string]any) (*mcpgo.CallToolResult, error) {
+			var ok bool
+			gotSubject, ok = egress.SubjectFromContext(ctx)
+			if !ok {
+				t.Fatal("expected egress subject in direct caller context")
+			}
+			return mcpgo.NewToolResultText("ok"), nil
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, prov)
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker:       &testutil.StubInvoker{},
+		TokenResolver: &stubTokenResolver{token: "test-token"},
+		Providers:     providers,
+	})
+
+	tool := srv.GetTool("sample_perform")
+	if tool == nil {
+		t.Fatal("tool not found")
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Name = "sample_perform"
+
+	result, err := tool.Handler(ctxWithIdentityPrincipal("", principal.IdentityPrincipal), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+	if gotSubject != (egress.Subject{Kind: egress.SubjectIdentity, ID: principal.IdentityPrincipal}) {
+		t.Fatalf("subject = %+v, want identity sentinel subject", gotSubject)
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove principal-to-subject mapping from `internal/egress`
- map principals to egress subjects at the invocation and MCP boundaries instead
- add focused coverage for preserving an existing subject plus the identity-email and `__identity__` branches

## Testing
- go test ./internal/egress ./internal/invocation ./internal/mcp