### PR TITLE
fix: make overlay base composition explicit

### DIFF
--- a/cmd/gestaltd/prepare_test.go
+++ b/cmd/gestaltd/prepare_test.go
@@ -228,35 +228,6 @@ integrations:
 	}
 }
 
-func TestValidateConfigRejectsLegacyEgressCredentials(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := `auth:
-  provider: google
-datastore:
-  provider: sqlite
-server:
-  dev_mode: true
-  encryption_key: test-key
-egress:
-  credentials:
-    - provider: sample
-`
-	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {
-		t.Fatalf("WriteFile config: %v", err)
-	}
-
-	err := validateConfig(cfgPath)
-	if err == nil {
-		t.Fatal("expected validateConfig to reject legacy egress.credentials")
-	}
-	if !strings.Contains(err.Error(), "field credentials not found") {
-		t.Fatalf("expected unknown field error, got: %v", err)
-	}
-}
-
 func TestValidateConfigRejectsOverlayWithoutSingleBaseSource(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/gestaltd/prepare_test.go
+++ b/cmd/gestaltd/prepare_test.go
@@ -228,6 +228,98 @@ integrations:
 	}
 }
 
+func TestValidateConfigRejectsLegacyEgressCredentials(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  dev_mode: true
+  encryption_key: test-key
+egress:
+  credentials:
+    - provider: sample
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	err := validateConfig(cfgPath)
+	if err == nil {
+		t.Fatal("expected validateConfig to reject legacy egress.credentials")
+	}
+	if !strings.Contains(err.Error(), "field credentials not found") {
+		t.Fatalf("expected unknown field error, got: %v", err)
+	}
+}
+
+func TestValidateConfigRejectsOverlayWithoutSingleBaseSource(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		body        string
+		wantContain string
+	}{
+		{
+			name: "missing base source",
+			body: `integrations:
+  sample:
+    plugin:
+      mode: overlay
+      command: /tmp/plugin
+`,
+			wantContain: "must declare a base source",
+		},
+		{
+			name: "multiple base sources",
+			body: `integrations:
+  sample:
+    plugin:
+      mode: overlay
+      base: sample-base
+      command: /tmp/plugin
+    upstreams:
+      - type: rest
+        url: https://example.com/spec.json
+`,
+			wantContain: "exactly one base source",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "config.yaml")
+			cfg := `auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  dev_mode: true
+  encryption_key: test-key
+` + tc.body
+			if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {
+				t.Fatalf("WriteFile config: %v", err)
+			}
+
+			err := validateConfig(cfgPath)
+			if err == nil {
+				t.Fatal("expected validateConfig to fail")
+			}
+			if !strings.Contains(err.Error(), tc.wantContain) {
+				t.Fatalf("expected error containing %q, got: %v", tc.wantContain, err)
+			}
+		})
+	}
+}
+
 func newPreparedTestOpenAPIServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := map[string]any{

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -12,7 +12,7 @@
 | `runtimes` | Background processes that boot alongside the server with scoped provider access. |
 | `bindings` | Alternative request surfaces such as webhooks and proxy-oriented request normalizers. |
 | `server` | Port, base URL, encryption key, and development mode. |
-| `egress` | Policy and credential rules for outbound requests made by runtimes and bindings. |
+| `egress` | Policy rules for outbound requests made by runtimes, bindings, and proxy surfaces. |
 
 ## Server block
 
@@ -87,11 +87,12 @@ secrets:
 
 ## Integration block
 
-Each integration is defined under `integrations.<name>` and contains one or more `upstreams` entries plus integration-level settings for auth and display.
+Each integration is defined under `integrations.<name>` and is backed by either `upstreams`, an executable `plugin`, or both when `plugin.mode: overlay` is used.
 
 | Field | Notes |
 |---|---|
-| `upstreams` | List of upstream definitions (see below). At least one is required. |
+| `upstreams` | List of upstream definitions (see below). Required unless the integration is fully served by `plugin.mode: replace`, and one of the two allowed base sources for `plugin.mode: overlay`. |
+| `plugin` | Executable provider plugin config. Use `mode: replace` to serve the whole provider from a binary, or `mode: overlay` to compose a binary on top of exactly one base source. |
 | `display_name` | Human-readable label for the integration. |
 | `description` | Short description shown in the web UI and CLI. |
 | `auth_profile` | Name of a reusable auth profile to inherit from. |
@@ -109,6 +110,21 @@ Each integration is defined under `integrations.<name>` and contains one or more
 | `icon_file` | Path to an SVG file used as the integration icon. Relative paths resolve from the config file's directory. |
 | `manual_auth` | Boolean. When `true`, the integration supports both OAuth and manual authentication. Users see both connection options in the web UI. The API returns `auth_types: ["oauth", "manual"]`. |
 | `error_message_path` | Dot-delimited path for extracting error messages from upstream JSON responses. |
+
+### Executable plugin config
+
+| Field | Notes |
+|---|---|
+| `command` | Required. Executable path. Relative paths resolve from the config file's directory. |
+| `args` | Optional argv passed to the executable. |
+| `env` | Optional extra environment variables for the plugin process. |
+| `mode` | `replace` (default) or `overlay`. |
+| `base` | `overlay` only. Names the registered first-party provider factory to compose under the plugin when `upstreams` are not used. |
+
+Overlay plugins must declare exactly one base source:
+
+- `upstreams` when the base provider comes from prepared REST/GraphQL/MCP config
+- `plugin.base` when the base provider comes from a registered Go factory
 
 ### Upstreams
 
@@ -261,7 +277,7 @@ Proxy bindings require exactly one entry in the top-level `providers` list. This
 
 ## Egress block
 
-Controls policy enforcement and credential injection for outbound requests made by runtimes, bindings, and the proxy surface.
+Controls policy enforcement for outbound requests made by runtimes, bindings, and the proxy surface.
 
 ```yaml
 egress:
@@ -273,10 +289,6 @@ egress:
       path_prefix: /v1/admin
     - action: allow
       provider: internal-api
-  credentials:
-    - provider: acme-api
-      instance: acme-api
-      subject_kind: user
 ```
 
 ### Policy rules
@@ -295,21 +307,6 @@ Rules are evaluated in order; the first matching rule wins. If no rule matches, 
 | `path_prefix` | Segment-aware path prefix match. Empty matches all. |
 
 All non-empty fields must match for a rule to apply (AND logic).
-
-### Credential grants
-
-Credential grants control which provider credentials are injected into outbound requests. They are matched using the same field set as policy rules (minus `action`), plus `instance` to identify the credential source.
-
-| Field | Notes |
-|---|---|
-| `provider` | The provider whose credentials to inject. |
-| `instance` | The credential instance name (defaults to `provider` if omitted). |
-| `subject_kind` | Restrict to a specific subject kind. Empty matches all. |
-| `subject_id` | Restrict to a specific subject ID. Empty matches all. |
-| `operation` | Match the target operation. Empty matches all. |
-| `method` | Match the HTTP method. Empty matches all. |
-| `host` | Exact match against the target host. Empty matches all. |
-| `path_prefix` | Segment-aware path prefix match. Empty matches all. |
 
 ## Supported providers
 

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -12,7 +12,7 @@
 | `runtimes` | Background processes that boot alongside the server with scoped provider access. |
 | `bindings` | Alternative request surfaces such as webhooks and proxy-oriented request normalizers. |
 | `server` | Port, base URL, encryption key, and development mode. |
-| `egress` | Policy rules for outbound requests made by runtimes, bindings, and proxy surfaces. |
+| `egress` | Policy and credential rules for outbound requests made by runtimes, bindings, and proxy surfaces. |
 
 ## Server block
 
@@ -277,7 +277,7 @@ Proxy bindings require exactly one entry in the top-level `providers` list. This
 
 ## Egress block
 
-Controls policy enforcement for outbound requests made by runtimes, bindings, and the proxy surface.
+Controls policy enforcement and credential injection for outbound requests made by runtimes, bindings, and the proxy surface.
 
 ```yaml
 egress:
@@ -289,6 +289,10 @@ egress:
       path_prefix: /v1/admin
     - action: allow
       provider: internal-api
+  credentials:
+    - provider: acme-api
+      instance: acme-api
+      subject_kind: user
 ```
 
 ### Policy rules
@@ -307,6 +311,21 @@ Rules are evaluated in order; the first matching rule wins. If no rule matches, 
 | `path_prefix` | Segment-aware path prefix match. Empty matches all. |
 
 All non-empty fields must match for a rule to apply (AND logic).
+
+### Credential grants
+
+Credential grants control which provider credentials are injected into outbound requests. They are matched using the same field set as policy rules (minus `action`), plus `instance` to identify the credential source.
+
+| Field | Notes |
+|---|---|
+| `provider` | The provider whose credentials to inject. |
+| `instance` | The credential instance name (defaults to `provider` if omitted). |
+| `subject_kind` | Restrict to a specific subject kind. Empty matches all. |
+| `subject_id` | Restrict to a specific subject ID. Empty matches all. |
+| `operation` | Match the target operation. Empty matches all. |
+| `method` | Match the HTTP method. Empty matches all. |
+| `host` | Exact match against the target host. Empty matches all. |
+| `path_prefix` | Segment-aware path prefix match. Empty matches all. |
 
 ## Supported providers
 

--- a/docs/pages/tasks/add-a-first-party-provider.mdx
+++ b/docs/pages/tasks/add-a-first-party-provider.mdx
@@ -142,3 +142,8 @@ func main() {
 ```
 
 The YAML definition handles the base operations; the overlay binary handles the rest. The bootstrap system composes them automatically when `mode: overlay` is set in the deployment config.
+
+Use exactly one base source for the overlay:
+
+- Keep `upstreams` in the integration config when the base comes from prepared REST/GraphQL/MCP definitions.
+- Set `plugin.base: <provider-name>` when the base comes from a registered first-party Go provider factory.

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -410,9 +410,9 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 	var wg sync.WaitGroup
 	for name := range cfg.Integrations {
 		intgDef := cfg.Integrations[name]
-		if !providerBuildAvailable(name, intgDef, factories) {
+		if err := validateProviderBuildAvailable(name, intgDef, factories); err != nil {
 			close(ready)
-			return nil, nil, fmt.Errorf("bootstrap: no provider factory for %q and no default factory registered", name)
+			return nil, nil, fmt.Errorf("bootstrap: %w", err)
 		}
 		wg.Add(1)
 		go func() {
@@ -515,14 +515,11 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 		if mode == config.PluginModeOverlay {
 			baseIntg := intg
 			baseIntg.Plugin = nil
-			factory, ok := factories.Providers[name]
-			if !ok {
-				factory = factories.DefaultProvider
+			baseFactory, err := overlayBaseFactory(name, intg, factories)
+			if err != nil {
+				return nil, err
 			}
-			if factory == nil {
-				return nil, fmt.Errorf("no provider factory for overlay base %q", name)
-			}
-			baseProv, err := factory(ctx, name, baseIntg, deps)
+			baseProv, err := baseFactory(ctx, name, baseIntg, deps)
 			if err != nil {
 				return nil, fmt.Errorf("building overlay base: %w", err)
 			}
@@ -563,24 +560,48 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 	return factory(ctx, name, intg, deps)
 }
 
-func providerBuildAvailable(name string, intg config.IntegrationDef, factories *FactoryRegistry) bool {
+func overlayBaseFactory(name string, intg config.IntegrationDef, factories *FactoryRegistry) (ProviderFactory, error) {
+	if len(intg.Upstreams) > 0 {
+		if factories.DefaultProvider == nil {
+			return nil, fmt.Errorf("no default provider factory for overlay base %q", name)
+		}
+		return factories.DefaultProvider, nil
+	}
+	baseName := intg.Plugin.Base
+	factory, ok := factories.Providers[baseName]
+	if !ok || factory == nil {
+		return nil, fmt.Errorf("no provider factory for overlay base %q", baseName)
+	}
+	return factory, nil
+}
+
+func validateProviderBuildAvailable(name string, intg config.IntegrationDef, factories *FactoryRegistry) error {
 	if intg.Plugin != nil {
 		mode := intg.Plugin.Mode
 		if mode == "" {
 			mode = config.PluginModeReplace
 		}
 		if mode == config.PluginModeOverlay {
-			if _, ok := factories.Providers[name]; ok {
-				return true
+			if len(intg.Upstreams) > 0 {
+				if factories.DefaultProvider == nil {
+					return fmt.Errorf("no default provider factory for overlay base %q", name)
+				}
+				return nil
 			}
-			return factories.DefaultProvider != nil
+			if _, ok := factories.Providers[intg.Plugin.Base]; !ok {
+				return fmt.Errorf("no provider factory for overlay base %q", intg.Plugin.Base)
+			}
+			return nil
 		}
-		return true
+		return nil
 	}
 	if _, ok := factories.Providers[name]; ok {
-		return true
+		return nil
 	}
-	return factories.DefaultProvider != nil
+	if factories.DefaultProvider == nil {
+		return fmt.Errorf("no provider factory for %q and no default factory registered", name)
+	}
+	return nil
 }
 
 func buildRuntime(ctx context.Context, name string, cfg config.RuntimeDef, factories *FactoryRegistry, deps RuntimeDeps) (core.Runtime, error) {

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -550,6 +550,14 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 		})
 	}
 
+	factory, err := providerFactoryForName(name, factories)
+	if err != nil {
+		return nil, err
+	}
+	return factory(ctx, name, intg, deps)
+}
+
+func providerFactoryForName(name string, factories *FactoryRegistry) (ProviderFactory, error) {
 	factory, ok := factories.Providers[name]
 	if !ok {
 		factory = factories.DefaultProvider
@@ -557,7 +565,7 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 	if factory == nil {
 		return nil, fmt.Errorf("no provider factory for %q and no default factory registered", name)
 	}
-	return factory(ctx, name, intg, deps)
+	return factory, nil
 }
 
 func overlayBaseFactory(name string, intg config.IntegrationDef, factories *FactoryRegistry) (ProviderFactory, error) {
@@ -568,9 +576,17 @@ func overlayBaseFactory(name string, intg config.IntegrationDef, factories *Fact
 		return factories.DefaultProvider, nil
 	}
 	baseName := intg.Plugin.Base
-	factory, ok := factories.Providers[baseName]
-	if !ok || factory == nil {
+	factory, err := registeredProviderFactory(baseName, factories)
+	if err != nil {
 		return nil, fmt.Errorf("no provider factory for overlay base %q", baseName)
+	}
+	return factory, nil
+}
+
+func registeredProviderFactory(name string, factories *FactoryRegistry) (ProviderFactory, error) {
+	factory, ok := factories.Providers[name]
+	if !ok || factory == nil {
+		return nil, fmt.Errorf("no provider factory for %q", name)
 	}
 	return factory, nil
 }
@@ -582,26 +598,13 @@ func validateProviderBuildAvailable(name string, intg config.IntegrationDef, fac
 			mode = config.PluginModeReplace
 		}
 		if mode == config.PluginModeOverlay {
-			if len(intg.Upstreams) > 0 {
-				if factories.DefaultProvider == nil {
-					return fmt.Errorf("no default provider factory for overlay base %q", name)
-				}
-				return nil
-			}
-			if _, ok := factories.Providers[intg.Plugin.Base]; !ok {
-				return fmt.Errorf("no provider factory for overlay base %q", intg.Plugin.Base)
-			}
-			return nil
+			_, err := overlayBaseFactory(name, intg, factories)
+			return err
 		}
 		return nil
 	}
-	if _, ok := factories.Providers[name]; ok {
-		return nil
-	}
-	if factories.DefaultProvider == nil {
-		return fmt.Errorf("no provider factory for %q and no default factory registered", name)
-	}
-	return nil
+	_, err := providerFactoryForName(name, factories)
+	return err
 }
 
 func buildRuntime(ctx context.Context, name string, cfg config.RuntimeDef, factories *FactoryRegistry, deps RuntimeDeps) (core.Runtime, error) {

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -311,6 +311,51 @@ func TestBootstrapUnknownProvider(t *testing.T) {
 	}
 }
 
+func TestBootstrapNilProviderFactoryFailsFast(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("direct provider", func(t *testing.T) {
+		t.Parallel()
+
+		factories := validFactories()
+		factories.Providers["alpha"] = nil
+
+		_, err := bootstrap.Bootstrap(ctx, validConfig(), factories)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `no provider factory for "alpha"`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("overlay base provider", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := validConfig()
+		delete(cfg.Integrations, "alpha")
+		cfg.Integrations["beta"] = config.IntegrationDef{
+			Plugin: &config.ExecutablePluginDef{
+				Mode:    config.PluginModeOverlay,
+				Base:    "alpha",
+				Command: "/tmp/plugin",
+			},
+		}
+
+		factories := validFactories()
+		factories.Providers["alpha"] = nil
+
+		_, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `no provider factory for overlay base "alpha"`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
 func TestBootstrapFactoryError(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/bootstrap/egress.go
+++ b/internal/bootstrap/egress.go
@@ -12,7 +12,8 @@ import (
 )
 
 type EgressDeps struct {
-	Resolver *egress.Resolver
+	Resolver         *egress.Resolver
+	CredentialGrants []config.EgressCredentialGrant
 }
 
 func newEgressDeps(cfg *config.Config, _ core.Datastore) EgressDeps {
@@ -27,6 +28,7 @@ func newEgressDeps(cfg *config.Config, _ core.Datastore) EgressDeps {
 			Subjects: egress.ContextSubjectResolver{},
 			Policy:   policy,
 		},
+		CredentialGrants: cfg.Egress.Credentials,
 	}
 }
 

--- a/internal/bootstrap/egress.go
+++ b/internal/bootstrap/egress.go
@@ -12,8 +12,7 @@ import (
 )
 
 type EgressDeps struct {
-	Resolver         *egress.Resolver
-	CredentialGrants []config.EgressCredentialGrant
+	Resolver *egress.Resolver
 }
 
 func newEgressDeps(cfg *config.Config, _ core.Datastore) EgressDeps {
@@ -28,7 +27,6 @@ func newEgressDeps(cfg *config.Config, _ core.Datastore) EgressDeps {
 			Subjects: egress.ContextSubjectResolver{},
 			Policy:   policy,
 		},
-		CredentialGrants: cfg.Egress.Credentials,
 	}
 }
 

--- a/internal/bootstrap/executable_plugin_test.go
+++ b/internal/bootstrap/executable_plugin_test.go
@@ -510,6 +510,156 @@ func TestExecutableProviderAcceptsMinOnlyProtocolVersion(t *testing.T) {
 	}
 }
 
+func TestExecutableProviderOverlayWithUpstreamsUsesDefaultBaseFactory(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	cfg := &config.Config{
+		Integrations: map[string]config.IntegrationDef{
+			"gadget": {
+				Plugin: &config.ExecutablePluginDef{
+					Mode:    config.PluginModeOverlay,
+					Command: bin,
+					Args:    []string{"provider"},
+				},
+				Upstreams: []config.UpstreamDef{
+					{Type: config.UpstreamTypeREST, URL: "https://example.com/spec.json"},
+				},
+			},
+		},
+	}
+
+	factories := NewFactoryRegistry()
+	factories.Providers["gadget"] = func(context.Context, string, config.IntegrationDef, Deps) (core.Provider, error) {
+		t.Fatalf("named provider factory should not be used for overlay upstream composition")
+		return nil, nil
+	}
+	factories.DefaultProvider = func(_ context.Context, name string, intg config.IntegrationDef, _ Deps) (core.Provider, error) {
+		if name != "gadget" {
+			t.Fatalf("default provider name = %q, want gadget", name)
+		}
+		if intg.Plugin != nil {
+			t.Fatalf("default provider received plugin config, want nil")
+		}
+		if len(intg.Upstreams) != 1 {
+			t.Fatalf("default provider upstream count = %d, want 1", len(intg.Upstreams))
+		}
+		return newBaseProvider(name), nil
+	}
+
+	providers, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	prov, err := providers.Get("gadget")
+	if err != nil {
+		t.Fatalf("providers.Get: %v", err)
+	}
+	if got := operationNames(prov.ListOperations()); !slices.Equal(got, []string{"base_op", "echo"}) {
+		t.Fatalf("provider operations = %v, want [base_op echo]", got)
+	}
+
+	baseResp, err := prov.Execute(context.Background(), "base_op", map[string]any{"id": "123"}, "")
+	if err != nil {
+		t.Fatalf("Execute(base_op): %v", err)
+	}
+	if baseResp.Body != `{"id":"123"}` {
+		t.Fatalf("base response body = %q", baseResp.Body)
+	}
+
+	echoResp, err := prov.Execute(context.Background(), "echo", map[string]any{"message": "hello"}, "")
+	if err != nil {
+		t.Fatalf("Execute(echo): %v", err)
+	}
+	if echoResp.Body != `{"message":"hello"}` {
+		t.Fatalf("echo response body = %q", echoResp.Body)
+	}
+}
+
+func TestExecutableProviderOverlayWithExplicitBaseUsesNamedFactory(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	cfg := &config.Config{
+		Integrations: map[string]config.IntegrationDef{
+			"gadget": {
+				Plugin: &config.ExecutablePluginDef{
+					Mode:    config.PluginModeOverlay,
+					Base:    "alpha",
+					Command: bin,
+					Args:    []string{"provider"},
+				},
+			},
+		},
+	}
+
+	factories := NewFactoryRegistry()
+	factories.DefaultProvider = func(context.Context, string, config.IntegrationDef, Deps) (core.Provider, error) {
+		t.Fatalf("default provider should not be used for explicit overlay base")
+		return nil, nil
+	}
+	factories.Providers["gadget"] = func(context.Context, string, config.IntegrationDef, Deps) (core.Provider, error) {
+		t.Fatalf("integration-name provider factory should not be used for explicit overlay base")
+		return nil, nil
+	}
+	factories.Providers["alpha"] = func(_ context.Context, name string, intg config.IntegrationDef, _ Deps) (core.Provider, error) {
+		if name != "gadget" {
+			t.Fatalf("named base provider name = %q, want gadget", name)
+		}
+		if intg.Plugin != nil {
+			t.Fatalf("named base provider received plugin config, want nil")
+		}
+		if len(intg.Upstreams) != 0 {
+			t.Fatalf("named base provider upstream count = %d, want 0", len(intg.Upstreams))
+		}
+		return newBaseProvider(name), nil
+	}
+
+	providers, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	prov, err := providers.Get("gadget")
+	if err != nil {
+		t.Fatalf("providers.Get: %v", err)
+	}
+	if got := operationNames(prov.ListOperations()); !slices.Equal(got, []string{"base_op", "echo"}) {
+		t.Fatalf("provider operations = %v, want [base_op echo]", got)
+	}
+}
+
+func newBaseProvider(name string) core.Provider {
+	return &catalogProviderWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        name,
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(_ context.Context, operation string, params map[string]any, _ string) (*core.OperationResult, error) {
+				body, err := json.Marshal(params)
+				if err != nil {
+					return nil, err
+				}
+				return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
+			},
+		},
+		ops: []core.Operation{
+			{Name: "base_op", Description: "Base op", Method: http.MethodGet},
+		},
+	}
+}
+
+func operationNames(ops []core.Operation) []string {
+	names := make([]string, 0, len(ops))
+	for _, op := range ops {
+		names = append(names, op.Name)
+	}
+	slices.Sort(names)
+	return names
+}
+
 func buildEchoPluginBinary(t *testing.T) string {
 	t.Helper()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,9 +29,8 @@ type Config struct {
 }
 
 type EgressConfig struct {
-	DefaultAction string                  `yaml:"default_action"`
-	Policies      []EgressPolicyRule      `yaml:"policies"`
-	Credentials   []EgressCredentialGrant `yaml:"credentials"`
+	DefaultAction string             `yaml:"default_action"`
+	Policies      []EgressPolicyRule `yaml:"policies"`
 }
 
 type EgressPolicyRule struct {
@@ -45,17 +44,6 @@ type EgressPolicyRule struct {
 	PathPrefix  string `yaml:"path_prefix"`
 }
 
-type EgressCredentialGrant struct {
-	Provider    string `yaml:"provider"`
-	Instance    string `yaml:"instance"`
-	SubjectKind string `yaml:"subject_kind"`
-	SubjectID   string `yaml:"subject_id"`
-	Operation   string `yaml:"operation"`
-	Method      string `yaml:"method"`
-	Host        string `yaml:"host"`
-	PathPrefix  string `yaml:"path_prefix"`
-}
-
 const (
 	PluginModeReplace = "replace"
 	PluginModeOverlay = "overlay"
@@ -63,6 +51,7 @@ const (
 
 type ExecutablePluginDef struct {
 	Mode    string            `yaml:"mode"`
+	Base    string            `yaml:"base"`
 	Command string            `yaml:"command"`
 	Args    []string          `yaml:"args"`
 	Env     map[string]string `yaml:"env"`
@@ -497,6 +486,14 @@ func validate(cfg *Config) error {
 				}
 				continue
 			case PluginModeOverlay:
+				hasUpstreams := len(intg.Upstreams) > 0
+				hasBase := intg.Plugin.Base != ""
+				switch {
+				case hasUpstreams && hasBase:
+					return fmt.Errorf("config validation: integration %q overlay plugin must declare exactly one base source via upstreams or plugin.base", name)
+				case !hasUpstreams && !hasBase:
+					return fmt.Errorf("config validation: integration %q overlay plugin must declare a base source via upstreams or plugin.base", name)
+				}
 			default:
 				return fmt.Errorf("config validation: integration %q has unknown plugin mode %q", name, intg.Plugin.Mode)
 			}
@@ -554,6 +551,13 @@ func validateExecutablePlugin(kind, name string, plugin *ExecutablePluginDef) er
 	}
 	if plugin.Command == "" {
 		return fmt.Errorf("config validation: %s %q plugin.command is required", kind, name)
+	}
+	mode := plugin.Mode
+	if mode == "" {
+		mode = PluginModeReplace
+	}
+	if plugin.Base != "" && mode == PluginModeReplace {
+		return fmt.Errorf("config validation: %s %q plugin.base requires mode: overlay", kind, name)
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,8 +29,9 @@ type Config struct {
 }
 
 type EgressConfig struct {
-	DefaultAction string             `yaml:"default_action"`
-	Policies      []EgressPolicyRule `yaml:"policies"`
+	DefaultAction string                  `yaml:"default_action"`
+	Policies      []EgressPolicyRule      `yaml:"policies"`
+	Credentials   []EgressCredentialGrant `yaml:"credentials"`
 }
 
 type EgressPolicyRule struct {
@@ -38,6 +39,17 @@ type EgressPolicyRule struct {
 	SubjectKind string `yaml:"subject_kind"`
 	SubjectID   string `yaml:"subject_id"`
 	Provider    string `yaml:"provider"`
+	Operation   string `yaml:"operation"`
+	Method      string `yaml:"method"`
+	Host        string `yaml:"host"`
+	PathPrefix  string `yaml:"path_prefix"`
+}
+
+type EgressCredentialGrant struct {
+	Provider    string `yaml:"provider"`
+	Instance    string `yaml:"instance"`
+	SubjectKind string `yaml:"subject_kind"`
+	SubjectID   string `yaml:"subject_id"`
 	Operation   string `yaml:"operation"`
 	Method      string `yaml:"method"`
 	Host        string `yaml:"host"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -354,7 +354,25 @@ integrations:
 			wantErr: false,
 		},
 		{
-			name: "overlay plugin without upstreams allowed",
+			name: "overlay plugin with explicit base is valid",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+integrations:
+  gadget:
+    plugin:
+      mode: overlay
+      base: jira
+      command: /tmp/plugin
+`,
+			wantErr: false,
+		},
+		{
+			name: "overlay plugin without base source rejected",
 			yaml: `
 auth:
   provider: google
@@ -368,7 +386,28 @@ integrations:
       mode: overlay
       command: /tmp/plugin
 `,
-			wantErr: false,
+			wantErr: true,
+		},
+		{
+			name: "overlay plugin with upstreams and explicit base rejected",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+integrations:
+  gadget:
+    plugin:
+      mode: overlay
+      base: jira
+      command: /tmp/plugin
+    upstreams:
+      - type: rest
+        url: https://example.com/spec.json
+`,
+			wantErr: true,
 		},
 		{
 			name: "replace plugin with upstreams rejected",
@@ -637,6 +676,61 @@ integrations:
       command: /tmp/plugin
 `,
 			wantContain: "unknown plugin mode",
+		},
+		{
+			name: "overlay requires explicit base source",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+integrations:
+  gadget:
+    plugin:
+      mode: overlay
+      command: /tmp/plugin
+`,
+			wantContain: "must declare a base source",
+		},
+		{
+			name: "overlay rejects both upstreams and explicit base",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+integrations:
+  gadget:
+    plugin:
+      mode: overlay
+      base: jira
+      command: /tmp/plugin
+    upstreams:
+      - type: rest
+        url: https://example.com/spec.json
+`,
+			wantContain: "exactly one base source",
+		},
+		{
+			name: "plugin base requires overlay",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+integrations:
+  gadget:
+    plugin:
+      base: jira
+      command: /tmp/plugin
+`,
+			wantContain: "plugin.base requires mode: overlay",
 		},
 		{
 			name: "runtime overlay",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -354,62 +354,6 @@ integrations:
 			wantErr: false,
 		},
 		{
-			name: "overlay plugin with explicit base is valid",
-			yaml: `
-auth:
-  provider: google
-datastore:
-  provider: sqlite
-server:
-  encryption_key: key123
-integrations:
-  gadget:
-    plugin:
-      mode: overlay
-      base: jira
-      command: /tmp/plugin
-`,
-			wantErr: false,
-		},
-		{
-			name: "overlay plugin without base source rejected",
-			yaml: `
-auth:
-  provider: google
-datastore:
-  provider: sqlite
-server:
-  encryption_key: key123
-integrations:
-  gadget:
-    plugin:
-      mode: overlay
-      command: /tmp/plugin
-`,
-			wantErr: true,
-		},
-		{
-			name: "overlay plugin with upstreams and explicit base rejected",
-			yaml: `
-auth:
-  provider: google
-datastore:
-  provider: sqlite
-server:
-  encryption_key: key123
-integrations:
-  gadget:
-    plugin:
-      mode: overlay
-      base: jira
-      command: /tmp/plugin
-    upstreams:
-      - type: rest
-        url: https://example.com/spec.json
-`,
-			wantErr: true,
-		},
-		{
 			name: "replace plugin with upstreams rejected",
 			yaml: `
 auth:
@@ -676,61 +620,6 @@ integrations:
       command: /tmp/plugin
 `,
 			wantContain: "unknown plugin mode",
-		},
-		{
-			name: "overlay requires explicit base source",
-			yaml: `
-auth:
-  provider: google
-datastore:
-  provider: sqlite
-server:
-  encryption_key: key123
-integrations:
-  gadget:
-    plugin:
-      mode: overlay
-      command: /tmp/plugin
-`,
-			wantContain: "must declare a base source",
-		},
-		{
-			name: "overlay rejects both upstreams and explicit base",
-			yaml: `
-auth:
-  provider: google
-datastore:
-  provider: sqlite
-server:
-  encryption_key: key123
-integrations:
-  gadget:
-    plugin:
-      mode: overlay
-      base: jira
-      command: /tmp/plugin
-    upstreams:
-      - type: rest
-        url: https://example.com/spec.json
-`,
-			wantContain: "exactly one base source",
-		},
-		{
-			name: "plugin base requires overlay",
-			yaml: `
-auth:
-  provider: google
-datastore:
-  provider: sqlite
-server:
-  encryption_key: key123
-integrations:
-  gadget:
-    plugin:
-      base: jira
-      command: /tmp/plugin
-`,
-			wantContain: "plugin.base requires mode: overlay",
 		},
 		{
 			name: "runtime overlay",


### PR DESCRIPTION
## Summary
- remove the inert `egress.credentials` config surface from config, bootstrap, and docs
- require overlay plugins to declare exactly one base source via `upstreams` or `plugin.base`
- make bootstrap use the prepared-provider path for upstream overlays and the named provider factory only for explicit `plugin.base` overlays
- add config and bootstrap coverage for the explicit overlay-base paths

## Testing
- go test ./internal/config ./internal/bootstrap