### PR TITLE
Refactor egress to use ordered credential source chain

### DIFF
--- a/internal/bootstrap/egress.go
+++ b/internal/bootstrap/egress.go
@@ -54,10 +54,13 @@ func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, provide
 		}
 	}
 
-	deps.Resolver.Credentials = &egress.ProviderCredentialResolver{
+	providerSource := &egress.ProviderCredentialResolver{
 		TokenResolver: &brokerTokenResolver{broker: broker},
 		Materializer:  &registryMaterializer{providers: providers},
 		Grants:        grants,
+	}
+	deps.Resolver.CredentialSources = egress.CredentialSourceChain{
+		Sources: []egress.CredentialSource{providerSource},
 	}
 }
 

--- a/internal/egress/credential_source_chain_test.go
+++ b/internal/egress/credential_source_chain_test.go
@@ -1,0 +1,145 @@
+package egress_test
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/internal/egress"
+)
+
+type recordingCredentialSource struct {
+	name       string
+	order      *[]string
+	credential egress.CredentialMaterialization
+	err        error
+}
+
+func (s recordingCredentialSource) ResolveCredential(_ context.Context, _ egress.Subject, _ egress.Target) (egress.CredentialMaterialization, error) {
+	*s.order = append(*s.order, s.name)
+	if s.err != nil {
+		return egress.CredentialMaterialization{}, s.err
+	}
+	return s.credential, nil
+}
+
+func TestCredentialSourceChainUsesFirstNonEmptyCredential(t *testing.T) {
+	t.Parallel()
+
+	order := []string{}
+	resolver := egress.Resolver{
+		Subjects: egress.StaticSubjectResolver{
+			Subject: egress.Subject{Kind: egress.SubjectUser, ID: "u-100"},
+		},
+		CredentialSources: egress.CredentialSourceChain{
+			Sources: []egress.CredentialSource{
+				recordingCredentialSource{name: "first-empty", order: &order},
+				recordingCredentialSource{
+					name:  "second-hit",
+					order: &order,
+					credential: egress.CredentialMaterialization{
+						Authorization: "Bearer second-token",
+					},
+				},
+				recordingCredentialSource{
+					name:  "third-should-not-run",
+					order: &order,
+					credential: egress.CredentialMaterialization{
+						Authorization: "Bearer third-token",
+					},
+				},
+			},
+		},
+	}
+
+	res, err := resolver.Resolve(context.Background(), egress.ResolutionInput{
+		Target: egress.Target{Provider: "acme", Host: "api.acme.dev"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Credential.Authorization != "Bearer second-token" {
+		t.Fatalf("expected second source credential, got %q", res.Credential.Authorization)
+	}
+
+	wantOrder := []string{"first-empty", "second-hit"}
+	if !slices.Equal(order, wantOrder) {
+		t.Fatalf("evaluation order = %v, want %v", order, wantOrder)
+	}
+}
+
+func TestCredentialSourceChainStopsOnError(t *testing.T) {
+	t.Parallel()
+
+	order := []string{}
+	resolver := egress.Resolver{
+		Subjects: egress.StaticSubjectResolver{
+			Subject: egress.Subject{Kind: egress.SubjectUser, ID: "u-100"},
+		},
+		CredentialSources: egress.CredentialSourceChain{
+			Sources: []egress.CredentialSource{
+				recordingCredentialSource{
+					name:  "first-error",
+					order: &order,
+					err:   fmt.Errorf("backend unavailable"),
+				},
+				recordingCredentialSource{
+					name:  "second-should-not-run",
+					order: &order,
+					credential: egress.CredentialMaterialization{
+						Authorization: "Bearer never",
+					},
+				},
+			},
+		},
+	}
+
+	_, err := resolver.Resolve(context.Background(), egress.ResolutionInput{
+		Target: egress.Target{Provider: "acme", Host: "api.acme.dev"},
+	})
+	if err == nil {
+		t.Fatal("expected error from first source")
+	}
+
+	wantOrder := []string{"first-error"}
+	if !slices.Equal(order, wantOrder) {
+		t.Fatalf("evaluation order = %v, want %v", order, wantOrder)
+	}
+}
+
+func TestCredentialSourceChainPreservesProviderBackedResolution(t *testing.T) {
+	t.Parallel()
+
+	resolver := egress.Resolver{
+		Subjects: egress.StaticSubjectResolver{
+			Subject: egress.Subject{Kind: egress.SubjectUser, ID: "u-100"},
+		},
+		CredentialSources: egress.CredentialSourceChain{
+			Sources: []egress.CredentialSource{
+				&egress.ProviderCredentialResolver{
+					TokenResolver: &staticTokenResolver{token: "provider-token"},
+					Materializer:  &staticMaterializer{style: egress.AuthStyleBearer},
+					Grants: []egress.CredentialGrant{
+						{MatchCriteria: egress.MatchCriteria{Provider: "acme", Host: "api.acme.dev"}},
+					},
+				},
+			},
+		},
+	}
+
+	res, err := resolver.Resolve(context.Background(), egress.ResolutionInput{
+		Target: egress.Target{
+			Provider: "acme",
+			Method:   "GET",
+			Host:     "api.acme.dev",
+			Path:     "/v1/items",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Credential.Authorization != "Bearer provider-token" {
+		t.Fatalf("expected provider-backed credential, got %q", res.Credential.Authorization)
+	}
+}

--- a/internal/egress/provider_credentials.go
+++ b/internal/egress/provider_credentials.go
@@ -9,6 +9,34 @@ type CredentialResolver interface {
 	ResolveCredential(ctx context.Context, subject Subject, target Target) (CredentialMaterialization, error)
 }
 
+// CredentialSource resolves outbound credentials for a given subject and target.
+// Implementations can resolve from provider-backed tokens, vault backends, or
+// other future credential stores.
+type CredentialSource = CredentialResolver
+
+// CredentialSourceChain evaluates sources in order and returns the first
+// non-empty materialization.
+type CredentialSourceChain struct {
+	Sources []CredentialSource
+}
+
+func (c CredentialSourceChain) ResolveCredential(ctx context.Context, subject Subject, target Target) (CredentialMaterialization, error) {
+	for i := range c.Sources {
+		source := c.Sources[i]
+		if source == nil {
+			continue
+		}
+		credential, err := source.ResolveCredential(ctx, subject, target)
+		if err != nil {
+			return CredentialMaterialization{}, err
+		}
+		if hasCredentialMaterialization(credential) {
+			return credential, nil
+		}
+	}
+	return CredentialMaterialization{}, nil
+}
+
 type ProviderTokenResolver interface {
 	ResolveProviderToken(ctx context.Context, subject Subject, provider, instance string) (string, error)
 }

--- a/internal/egress/resolution.go
+++ b/internal/egress/resolution.go
@@ -17,9 +17,12 @@ type Resolution struct {
 }
 
 type Resolver struct {
-	Subjects    SubjectResolver
-	Policy      PolicyEnforcer
-	Credentials CredentialResolver
+	Subjects SubjectResolver
+	Policy   PolicyEnforcer
+	// CredentialSources is the preferred credential resolution entrypoint.
+	// Credentials is kept for compatibility with existing callsites/tests.
+	CredentialSources CredentialResolver
+	Credentials       CredentialResolver
 }
 
 func (r Resolver) Resolve(ctx context.Context, input ResolutionInput) (Resolution, error) {
@@ -34,8 +37,12 @@ func (r Resolver) Resolve(ctx context.Context, input ResolutionInput) (Resolutio
 	}
 
 	credential := input.Credential
-	if r.Credentials != nil && credential.Authorization == "" && len(credential.Headers) == 0 {
-		resolved, err := r.Credentials.ResolveCredential(ctx, subject, input.Target)
+	credentialResolver := r.CredentialSources
+	if credentialResolver == nil {
+		credentialResolver = r.Credentials
+	}
+	if credentialResolver != nil && !hasCredentialMaterialization(credential) {
+		resolved, err := credentialResolver.ResolveCredential(ctx, subject, input.Target)
 		if err != nil {
 			return Resolution{}, err
 		}
@@ -83,4 +90,8 @@ func CopyHeaders(headers map[string]string) map[string]string {
 		out[k] = v
 	}
 	return out
+}
+
+func hasCredentialMaterialization(credential CredentialMaterialization) bool {
+	return credential.Authorization != "" || len(credential.Headers) > 0
 }


### PR DESCRIPTION
## Summary
- introduce egress.CredentialSourceChain to evaluate credential sources in order and return the first non-empty materialization
- keep resolver compatibility by preserving the existing Resolver.Credentials path while adding Resolver.CredentialSources as the preferred field
- wire bootstrap egress credential setup to use provider-backed resolution as a source in the chain

## Behavior
- existing provider-backed credential behavior remains unchanged
- explicit credentials on the request still bypass source resolution
- source chain ordering is now explicit and extensible for future vault/providerless sources

## Tests
- added egress tests for ordered source evaluation, stop-on-error semantics, and provider-backed resolution through the new chain
- go test ./internal/egress ./plugins/bindings/proxy
- go test ./...