### PR TITLE
PR1: canonicalize capability listing across transports

### DIFF
--- a/core/capability.go
+++ b/core/capability.go
@@ -1,8 +1,22 @@
 package core
 
+import "encoding/json"
+
+type CapabilityAnnotations struct {
+	ReadOnlyHint    *bool
+	IdempotentHint  *bool
+	DestructiveHint *bool
+	OpenWorldHint   *bool
+}
+
 type Capability struct {
 	Provider    string
 	Operation   string
+	Title       string
 	Description string
 	Parameters  []Parameter
+	InputSchema json.RawMessage
+	Method      string
+	Transport   string
+	Annotations CapabilityAnnotations
 }

--- a/internal/bootstrap/executable_plugin_test.go
+++ b/internal/bootstrap/executable_plugin_test.go
@@ -184,11 +184,11 @@ func TestExecutableRuntimeCapabilities_OmitsMCPPassthroughOnlyCatalogOperations(
 	}
 
 	got := readRuntimeOutput(t, outputFile)
-	if got.CapabilityCount != 0 {
-		t.Fatalf("runtime output capability_count = %d, want 0", got.CapabilityCount)
+	if got.CapabilityCount != 1 {
+		t.Fatalf("runtime output capability_count = %d, want 1", got.CapabilityCount)
 	}
-	if len(got.Capabilities) != 0 {
-		t.Fatalf("runtime output capabilities = %v, want []", got.Capabilities)
+	if !slices.Equal(got.Capabilities, []string{"search.search_workspace"}) {
+		t.Fatalf("runtime output capabilities = %v, want [search.search_workspace]", got.Capabilities)
 	}
 }
 
@@ -284,11 +284,11 @@ func TestExecutableRuntimeCapabilities_ExposeOnlyInvokableCatalogOperations(t *t
 	}
 
 	got := readRuntimeOutput(t, outputFile)
-	if got.CapabilityCount != 1 {
-		t.Fatalf("runtime output capability_count = %d, want 1", got.CapabilityCount)
+	if got.CapabilityCount != 2 {
+		t.Fatalf("runtime output capability_count = %d, want 2", got.CapabilityCount)
 	}
-	if !slices.Equal(got.Capabilities, []string{"workspace.fetch_record"}) {
-		t.Fatalf("runtime output capabilities = %v, want [workspace.fetch_record]", got.Capabilities)
+	if !slices.Equal(got.Capabilities, []string{"workspace.fetch_record", "workspace.search_workspace"}) {
+		t.Fatalf("runtime output capabilities = %v, want [workspace.fetch_record workspace.search_workspace]", got.Capabilities)
 	}
 	if got.ProbeStatus != http.StatusOK {
 		t.Fatalf("runtime output probe_status = %d, want %d", got.ProbeStatus, http.StatusOK)
@@ -358,11 +358,11 @@ func TestExecutableRuntimeCapabilities_FilterMethodlessFallbackOperations(t *tes
 	}
 
 	got := readRuntimeOutput(t, outputFile)
-	if got.CapabilityCount != 1 {
-		t.Fatalf("runtime output capability_count = %d, want 1", got.CapabilityCount)
+	if got.CapabilityCount != 2 {
+		t.Fatalf("runtime output capability_count = %d, want 2", got.CapabilityCount)
 	}
-	if !slices.Equal(got.Capabilities, []string{"alpha.http_op"}) {
-		t.Fatalf("runtime output capabilities = %v, want [alpha.http_op]", got.Capabilities)
+	if !slices.Equal(got.Capabilities, []string{"alpha.http_op", "alpha.hidden_op"}) {
+		t.Fatalf("runtime output capabilities = %v, want [alpha.http_op alpha.hidden_op]", got.Capabilities)
 	}
 }
 

--- a/internal/invocation/broker_test.go
+++ b/internal/invocation/broker_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
 	coretesting "github.com/valon-technologies/gestalt/core/testing"
 	"github.com/valon-technologies/gestalt/internal/egress"
 	"github.com/valon-technologies/gestalt/internal/invocation"
@@ -23,6 +24,15 @@ type stubProviderWithOps struct {
 
 func (s *stubProviderWithOps) ListOperations() []core.Operation {
 	return s.ops
+}
+
+type stubCatalogProvider struct {
+	*stubProviderWithOps
+	cat *catalog.Catalog
+}
+
+func (s *stubCatalogProvider) Catalog() *catalog.Catalog {
+	return s.cat
 }
 
 func TestInvoke_Success(t *testing.T) {
@@ -371,5 +381,72 @@ func TestInvoke_AttachesIdentitySubjectFromSentinelPrincipal(t *testing.T) {
 	}
 	if gotSubject != (egress.Subject{Kind: egress.SubjectIdentity, ID: principal.IdentityPrincipal}) {
 		t.Fatalf("subject = %+v, want identity sentinel subject", gotSubject)
+	}
+}
+
+func TestBroker_ListCapabilities_IncludesMCPOnlyCatalogOperations(t *testing.T) {
+	t.Parallel()
+
+	prov := &stubCatalogProvider{
+		stubProviderWithOps: &stubProviderWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "clickhouse"},
+			ops: []core.Operation{
+				{Name: "list_databases", Method: http.MethodGet, Description: "List databases"},
+			},
+		},
+		cat: &catalog.Catalog{
+			Name: "clickhouse",
+			Operations: []catalog.CatalogOperation{
+				{
+					ID:          "run_query",
+					Title:       "Run Query",
+					Description: "Execute a SQL query",
+					Transport:   catalog.TransportMCPPassthrough,
+					InputSchema: []byte(`{"type":"object","properties":{"sql":{"type":"string"}}}`),
+				},
+				{
+					ID:          "list_databases",
+					Method:      http.MethodGet,
+					Path:        "/databases",
+					Description: "List databases",
+				},
+			},
+		},
+	}
+
+	b := invocation.NewBroker(testutil.NewProviderRegistry(t, prov), &coretesting.StubDatastore{})
+	caps := b.ListCapabilities()
+	if len(caps) != 2 {
+		t.Fatalf("expected 2 capabilities, got %d", len(caps))
+	}
+
+	byOp := make(map[string]core.Capability, len(caps))
+	for _, cap := range caps {
+		byOp[cap.Operation] = cap
+	}
+
+	runQuery, ok := byOp["run_query"]
+	if !ok {
+		t.Fatalf("expected run_query capability in %+v", caps)
+	}
+	if runQuery.Transport != catalog.TransportMCPPassthrough {
+		t.Fatalf("run_query transport = %q, want %q", runQuery.Transport, catalog.TransportMCPPassthrough)
+	}
+	if runQuery.Method != "" {
+		t.Fatalf("run_query method = %q, want empty", runQuery.Method)
+	}
+	if len(runQuery.InputSchema) == 0 {
+		t.Fatal("expected run_query input schema to be present")
+	}
+
+	listDatabases, ok := byOp["list_databases"]
+	if !ok {
+		t.Fatalf("expected list_databases capability in %+v", caps)
+	}
+	if listDatabases.Transport != catalog.TransportHTTP {
+		t.Fatalf("list_databases transport = %q, want %q", listDatabases.Transport, catalog.TransportHTTP)
+	}
+	if listDatabases.Method != http.MethodGet {
+		t.Fatalf("list_databases method = %q, want %q", listDatabases.Method, http.MethodGet)
 	}
 }

--- a/internal/invocation/capabilities.go
+++ b/internal/invocation/capabilities.go
@@ -1,32 +1,87 @@
 package invocation
 
 import (
+	"bytes"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/core"
-	ci "github.com/valon-technologies/gestalt/core/integration"
+	"github.com/valon-technologies/gestalt/core/catalog"
 )
 
 func capabilitiesForProvider(name string, prov core.Provider) []core.Capability {
 	if cp, ok := prov.(core.CatalogProvider); ok {
 		if cat := cp.Catalog(); cat != nil {
-			return capabilitiesFromOperations(name, ci.OperationsList(cat))
+			return capabilitiesFromCatalog(name, cat)
 		}
 	}
 	return capabilitiesFromOperations(name, prov.ListOperations())
 }
 
+func capabilitiesFromCatalog(name string, cat *catalog.Catalog) []core.Capability {
+	caps := make([]core.Capability, 0, len(cat.Operations))
+	for i := range cat.Operations {
+		op := cat.Operations[i]
+		if strings.TrimSpace(op.ID) == "" {
+			continue
+		}
+
+		params := make([]core.Parameter, 0, len(op.Parameters))
+		for _, p := range op.Parameters {
+			params = append(params, core.Parameter{
+				Name:        p.Name,
+				Type:        p.Type,
+				Description: p.Description,
+				Required:    p.Required,
+				Default:     p.Default,
+			})
+		}
+
+		method := strings.ToUpper(strings.TrimSpace(op.Method))
+		transport := strings.TrimSpace(op.Transport)
+		if transport == "" && method != "" {
+			transport = catalog.TransportHTTP
+		}
+
+		caps = append(caps, core.Capability{
+			Provider:    name,
+			Operation:   op.ID,
+			Title:       op.Title,
+			Description: op.Description,
+			Parameters:  params,
+			InputSchema: bytes.Clone(op.InputSchema),
+			Method:      method,
+			Transport:   transport,
+			Annotations: core.CapabilityAnnotations{
+				ReadOnlyHint:    op.Annotations.ReadOnlyHint,
+				IdempotentHint:  op.Annotations.IdempotentHint,
+				DestructiveHint: op.Annotations.DestructiveHint,
+				OpenWorldHint:   op.Annotations.OpenWorldHint,
+			},
+		})
+	}
+	return caps
+}
+
 func capabilitiesFromOperations(name string, ops []core.Operation) []core.Capability {
 	caps := make([]core.Capability, 0, len(ops))
 	for _, op := range ops {
-		if strings.TrimSpace(op.Method) == "" {
+		if strings.TrimSpace(op.Name) == "" {
 			continue
 		}
+
+		method := strings.ToUpper(strings.TrimSpace(op.Method))
+		transport := ""
+		if method != "" {
+			transport = catalog.TransportHTTP
+		}
+
 		caps = append(caps, core.Capability{
 			Provider:    name,
 			Operation:   op.Name,
 			Description: op.Description,
 			Parameters:  op.Parameters,
+			Method:      method,
+			Transport:   transport,
 		})
 	}
 	return caps

--- a/internal/invocation/guarded.go
+++ b/internal/invocation/guarded.go
@@ -126,9 +126,9 @@ func (g *GuardedInvoker) ListCapabilities() []core.Capability {
 	}
 
 	filtered := make([]core.Capability, 0, len(caps))
-	for _, cap := range caps {
-		if _, ok := g.allowed[cap.Provider]; ok {
-			filtered = append(filtered, cap)
+	for i := range caps {
+		if _, ok := g.allowed[caps[i].Provider]; ok {
+			filtered = append(filtered, caps[i])
 		}
 	}
 	return filtered

--- a/internal/mcp/binding_test.go
+++ b/internal/mcp/binding_test.go
@@ -653,6 +653,7 @@ func TestNewServer_DirectCallerPassthrough(t *testing.T) {
 			{
 				ID:          "run_query",
 				Description: "Execute a SQL query",
+				Transport:   catalog.TransportMCPPassthrough,
 				InputSchema: json.RawMessage(`{"type":"object","properties":{"sql":{"type":"string"}}}`),
 			},
 		},
@@ -675,8 +676,20 @@ func TestNewServer_DirectCallerPassthrough(t *testing.T) {
 	}
 
 	providers := testutil.NewProviderRegistry(t, prov)
+	broker := invocation.NewBroker(providers, stubDatastoreWithToken())
+	caps := broker.ListCapabilities()
+	if len(caps) != 1 {
+		t.Fatalf("expected 1 capability, got %d", len(caps))
+	}
+	if caps[0].Operation != "run_query" {
+		t.Fatalf("expected run_query capability, got %q", caps[0].Operation)
+	}
+	if caps[0].Transport != catalog.TransportMCPPassthrough {
+		t.Fatalf("capability transport = %q, want %q", caps[0].Transport, catalog.TransportMCPPassthrough)
+	}
+
 	srv := gestaltmcp.NewServer(gestaltmcp.Config{
-		Invoker:       &testutil.StubInvoker{},
+		Invoker:       broker,
 		TokenResolver: &stubTokenResolver{token: "upstream-token"},
 		Providers:     providers,
 	})

--- a/internal/pluginapi/convert.go
+++ b/internal/pluginapi/convert.go
@@ -192,7 +192,7 @@ func operationsFromProto(ops []*pluginapiv1.Operation) []core.Operation {
 	return out
 }
 
-func capabilityToProto(cap core.Capability) (*pluginapiv1.Capability, error) {
+func capabilityToProto(cap *core.Capability) (*pluginapiv1.Capability, error) {
 	params, err := parametersToProto(cap.Parameters)
 	if err != nil {
 		return nil, fmt.Errorf("capability %q/%q: %w", cap.Provider, cap.Operation, err)
@@ -207,8 +207,8 @@ func capabilityToProto(cap core.Capability) (*pluginapiv1.Capability, error) {
 
 func capabilitiesToProto(caps []core.Capability) ([]*pluginapiv1.Capability, error) {
 	out := make([]*pluginapiv1.Capability, 0, len(caps))
-	for _, cap := range caps {
-		msg, err := capabilityToProto(cap)
+	for i := range caps {
+		msg, err := capabilityToProto(&caps[i])
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- make broker capability derivation catalog-first and transport-agnostic
- remove HTTP-method filtering so MCP-only catalog operations are surfaced as first-class capabilities
- extend core.Capability with optional metadata (title, method, transport, annotations, input schema)
- add tests proving MCP-only tools appear in capability listing and remain invokable via MCP passthrough

## Notes
- this keeps invocation and MCP route behavior stable while exposing richer capability metadata
- bootstrap runtime capability expectations were updated to reflect the new transport-agnostic listing behavior

## Testing
- go test ./internal/invocation ./internal/mcp ./internal/mcpupstream ./internal/pluginapi
- go test ./internal/bootstrap ./internal/invocation ./internal/mcp ./internal/mcpupstream ./internal/pluginapi
- go test ./...