### PR TITLE
Simplify binding mounting and remove kind-based core contract

### DIFF
--- a/core/binding.go
+++ b/core/binding.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 )
 
+// Deprecated: BindingKind is no longer used by the core Binding contract.
 type BindingKind int
 
 const (
@@ -14,7 +15,6 @@ const (
 
 type Binding interface {
 	Name() string
-	Kind() BindingKind
 	Start(ctx context.Context) error
 	Routes() []Route
 	Close() error
@@ -24,4 +24,5 @@ type Route struct {
 	Method  string
 	Pattern string
 	Handler http.Handler
+	Public  bool
 }

--- a/core/testing/stubs.go
+++ b/core/testing/stubs.go
@@ -180,7 +180,6 @@ func (r *StubRuntime) Stop(ctx context.Context) error {
 
 type StubBinding struct {
 	N       string
-	K       core.BindingKind
 	StartFn func(context.Context) error
 	CloseFn func() error
 	R       []core.Route

--- a/core/testing/stubs.go
+++ b/core/testing/stubs.go
@@ -186,9 +186,8 @@ type StubBinding struct {
 	R       []core.Route
 }
 
-func (b *StubBinding) Name() string           { return b.N }
-func (b *StubBinding) Kind() core.BindingKind { return b.K }
-func (b *StubBinding) Routes() []core.Route   { return b.R }
+func (b *StubBinding) Name() string         { return b.N }
+func (b *StubBinding) Routes() []core.Route { return b.R }
 func (b *StubBinding) Start(ctx context.Context) error {
 	if b.StartFn != nil {
 		return b.StartFn(ctx)

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -875,7 +875,7 @@ func TestBootstrapWithBindings(t *testing.T) {
 
 	factories := validFactories()
 	factories.Bindings["webhook"] = func(_ context.Context, name string, _ config.BindingDef, _ bootstrap.BindingDeps) (core.Binding, error) {
-		return &coretesting.StubBinding{N: name, K: core.BindingTrigger}, nil
+		return &coretesting.StubBinding{N: name}, nil
 	}
 
 	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
@@ -940,7 +940,7 @@ func TestBootstrapBindingWithProviders(t *testing.T) {
 	var receivedDeps bootstrap.BindingDeps
 	factories.Bindings["webhook"] = func(_ context.Context, name string, _ config.BindingDef, deps bootstrap.BindingDeps) (core.Binding, error) {
 		receivedDeps = deps
-		return &coretesting.StubBinding{N: name, K: core.BindingTrigger}, nil
+		return &coretesting.StubBinding{N: name}, nil
 	}
 
 	result, err := bootstrap.Bootstrap(ctx, cfg, factories)

--- a/internal/bootstrap/regression_test.go
+++ b/internal/bootstrap/regression_test.go
@@ -111,7 +111,7 @@ func TestPlatformMode_BindingsAndRuntimesWithSafetyLayer(t *testing.T) {
 	var bindingDeps bootstrap.BindingDeps
 	factories.Bindings["test-binding"] = func(_ context.Context, name string, _ config.BindingDef, deps bootstrap.BindingDeps) (core.Binding, error) {
 		bindingDeps = deps
-		return &coretesting.StubBinding{N: name, K: core.BindingTrigger}, nil
+		return &coretesting.StubBinding{N: name}, nil
 	}
 
 	result, err := bootstrap.Bootstrap(ctx, cfg, factories)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -116,11 +116,10 @@ func (s *Server) routes() {
 		r.Post("/auth/logout", s.logout)
 		r.Get("/auth/callback", s.integrationOAuthCallback)
 
-		s.mountBindingRoutes(r, core.BindingTrigger)
+		s.mountBindingRoutes(r)
 
 		r.Group(func(r chi.Router) {
 			r.Use(s.authMiddleware)
-			s.mountBindingRoutes(r, core.BindingSurface)
 
 			r.Get("/integrations", s.listIntegrations)
 			r.Delete("/integrations/{name}", s.disconnectIntegration)
@@ -157,7 +156,7 @@ func (s *Server) stagedConnectionStore() (core.StagedConnectionStore, error) {
 	return scs, nil
 }
 
-func (s *Server) mountBindingRoutes(r chi.Router, kind core.BindingKind) {
+func (s *Server) mountBindingRoutes(r chi.Router) {
 	if s.bindings == nil {
 		return
 	}
@@ -167,11 +166,12 @@ func (s *Server) mountBindingRoutes(r chi.Router, kind core.BindingKind) {
 			log.Printf("warning: skipping binding %q routes: %v", name, err)
 			continue
 		}
-		if binding.Kind() != kind {
-			continue
-		}
 		for _, route := range binding.Routes() {
-			r.Method(route.Method, "/bindings/"+name+route.Pattern, route.Handler)
+			handler := route.Handler
+			if !route.Public {
+				handler = s.authMiddleware(handler)
+			}
+			r.Method(route.Method, "/bindings/"+name+route.Pattern, handler)
 		}
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/valon-technologies/gestalt/internal/server"
 	"github.com/valon-technologies/gestalt/internal/testutil"
 	"github.com/valon-technologies/gestalt/plugins/bindings/proxy"
+	"github.com/valon-technologies/gestalt/plugins/bindings/webhook"
 	"gopkg.in/yaml.v3"
 )
 
@@ -2868,7 +2869,6 @@ func TestListBindings_WithBindings(t *testing.T) {
 	bindings := registry.NewBindingMap()
 	if err := bindings.Register("my-webhook", &coretesting.StubBinding{
 		N: "my-webhook",
-		K: core.BindingTrigger,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -2912,9 +2912,8 @@ func TestBindingRoutesMounted(t *testing.T) {
 	bindings := registry.NewBindingMap()
 	if err := bindings.Register("my-webhook", &coretesting.StubBinding{
 		N: "my-webhook",
-		K: core.BindingTrigger,
 		R: []core.Route{
-			{Method: http.MethodPost, Pattern: "/incoming", Handler: handler},
+			{Method: http.MethodPost, Pattern: "/incoming", Handler: handler, Public: true},
 		},
 	}); err != nil {
 		t.Fatal(err)
@@ -2958,7 +2957,6 @@ func TestSurfaceBindingRequiresAuth(t *testing.T) {
 	bindings := registry.NewBindingMap()
 	if err := bindings.Register("test-surface", &coretesting.StubBinding{
 		N: "test-surface",
-		K: core.BindingSurface,
 		R: []core.Route{
 			{Method: http.MethodPost, Pattern: "/invoke", Handler: handler},
 		},
@@ -2994,9 +2992,8 @@ func TestTriggerBindingRemainsPublic(t *testing.T) {
 	bindings := registry.NewBindingMap()
 	if err := bindings.Register("test-trigger", &coretesting.StubBinding{
 		N: "test-trigger",
-		K: core.BindingTrigger,
 		R: []core.Route{
-			{Method: http.MethodPost, Pattern: "/incoming", Handler: handler},
+			{Method: http.MethodPost, Pattern: "/incoming", Handler: handler, Public: true},
 		},
 	}); err != nil {
 		t.Fatal(err)
@@ -3015,6 +3012,58 @@ func TestTriggerBindingRemainsPublic(t *testing.T) {
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestWebhookBindingRemainsPublic(t *testing.T) {
+	t.Parallel()
+
+	bindings := registry.NewBindingMap()
+	if err := bindings.Register("webhook-public", newTestWebhookBinding(t, "webhook-public", "/incoming")); err != nil {
+		t.Fatal(err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Bindings = bindings
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Post(ts.URL+"/api/v1/bindings/webhook-public/incoming", "application/json", bytes.NewBufferString(`{"ok":true}`))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestProxyBindingRequiresAuth(t *testing.T) {
+	t.Parallel()
+
+	bindings := registry.NewBindingMap()
+	if err := bindings.Register("test-proxy", newTestProxyBinding(t, "test-proxy", "/proxy")); err != nil {
+		t.Fatal(err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Bindings = bindings
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/bindings/test-proxy/proxy/messages", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", resp.StatusCode)
 	}
 }
 
@@ -3175,6 +3224,25 @@ func newTestProxyBinding(t *testing.T, name, path string) core.Binding {
 	}, bootstrap.BindingDeps{})
 	if err != nil {
 		t.Fatalf("proxy factory: %v", err)
+	}
+	return binding
+}
+
+func newTestWebhookBinding(t *testing.T, name, path string) core.Binding {
+	t.Helper()
+
+	cfgYAML := "path: " + path
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(cfgYAML), &node); err != nil {
+		t.Fatalf("unmarshal webhook config: %v", err)
+	}
+
+	binding, err := webhook.Factory(context.Background(), name, config.BindingDef{
+		Type:   "webhook",
+		Config: *node.Content[0],
+	}, bootstrap.BindingDeps{Invoker: &testutil.StubInvoker{}})
+	if err != nil {
+		t.Fatalf("webhook factory: %v", err)
 	}
 	return binding
 }

--- a/plugins/bindings/proxy/binding.go
+++ b/plugins/bindings/proxy/binding.go
@@ -35,8 +35,7 @@ func New(name, provider string, cfg proxyConfig, resolver egress.Resolver, clien
 	return &Binding{name: name, provider: provider, cfg: cfg, resolver: resolver, client: client}
 }
 
-func (b *Binding) Name() string           { return b.name }
-func (b *Binding) Kind() core.BindingKind { return core.BindingSurface }
+func (b *Binding) Name() string { return b.name }
 
 func (b *Binding) Start(_ context.Context) error { return nil }
 func (b *Binding) Close() error                  { return nil }
@@ -50,6 +49,7 @@ func (b *Binding) Routes() []core.Route {
 				Method:  method,
 				Pattern: pattern,
 				Handler: http.HandlerFunc(b.handle),
+				Public:  false,
 			})
 		}
 	}

--- a/plugins/bindings/proxy/proxy_test.go
+++ b/plugins/bindings/proxy/proxy_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/egress"
@@ -391,9 +390,6 @@ func TestProxyFactory(t *testing.T) {
 
 	if binding.Name() != "proxy-surface" {
 		t.Fatalf("name = %q, want proxy-surface", binding.Name())
-	}
-	if binding.Kind() != core.BindingSurface {
-		t.Fatalf("kind = %v, want BindingSurface", binding.Kind())
 	}
 }
 

--- a/plugins/bindings/webhook/webhook.go
+++ b/plugins/bindings/webhook/webhook.go
@@ -42,8 +42,7 @@ func New(name string, cfg webhookConfig, invoker invocation.Invoker) *Binding {
 	return &Binding{name: name, cfg: cfg, invoker: invoker}
 }
 
-func (b *Binding) Name() string           { return b.name }
-func (b *Binding) Kind() core.BindingKind { return core.BindingTrigger }
+func (b *Binding) Name() string { return b.name }
 
 func (b *Binding) Start(_ context.Context) error {
 	return nil
@@ -57,6 +56,7 @@ func (b *Binding) Routes() []core.Route {
 			Method:  http.MethodPost,
 			Pattern: b.cfg.Path,
 			Handler: http.HandlerFunc(b.handle),
+			Public:  true,
 		},
 	}
 }

--- a/plugins/bindings/webhook/webhook_test.go
+++ b/plugins/bindings/webhook/webhook_test.go
@@ -161,15 +161,6 @@ func TestWebhookInvokerError(t *testing.T) {
 	}
 }
 
-func TestWebhookKind(t *testing.T) {
-	t.Parallel()
-
-	b := makeBinding(t, "/incoming", "", "", &testutil.StubInvoker{})
-	if b.Kind() != core.BindingTrigger {
-		t.Fatalf("expected BindingTrigger, got %d", b.Kind())
-	}
-}
-
 func TestWebhookFactory(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Summary:\n- Remove Kind() from the core Binding interface and move binding auth behavior to core.Route.Public.\n- Simplify server mounting to a single binding pass with per-route auth wrapping while preserving /api/v1/bindings/{name} paths.\n- Keep webhook routes public and proxy routes authenticated.\n- Add server regression tests using real webhook and proxy bindings.\n\nValidation:\n- go test ./internal/server ./plugins/bindings/webhook ./plugins/bindings/proxy\n- go test ./...\n\nNote:\n- BindingKind remains as deprecated compatibility scaffolding in core/binding.go for this PR scope.