### PR TITLE
Add EgressClient as managed machine-caller resource

### DIFF
--- a/core/datastore.go
+++ b/core/datastore.go
@@ -28,3 +28,15 @@ type StagedConnectionStore interface {
 	GetStagedConnection(ctx context.Context, id string) (*StagedConnection, error)
 	DeleteStagedConnection(ctx context.Context, id string) error
 }
+
+type EgressClientStore interface {
+	CreateEgressClient(ctx context.Context, client *EgressClient) error
+	GetEgressClient(ctx context.Context, id string) (*EgressClient, error)
+	ListEgressClients(ctx context.Context, userID string) ([]*EgressClient, error)
+	DeleteEgressClient(ctx context.Context, id string) error
+
+	CreateEgressClientToken(ctx context.Context, token *EgressClientToken) error
+	ValidateEgressClientToken(ctx context.Context, hashedToken string) (*EgressClientToken, error)
+	ListEgressClientTokens(ctx context.Context, clientID string) ([]*EgressClientToken, error)
+	RevokeEgressClientToken(ctx context.Context, clientID, tokenID string) error
+}

--- a/core/testing/datastore_suite.go
+++ b/core/testing/datastore_suite.go
@@ -27,6 +27,12 @@ func RunDatastoreTests(t *testing.T, newStore func(t *testing.T) core.Datastore)
 	t.Run("StagedConnections", func(t *testing.T) {
 		testDatastoreStagedConnections(t, newStore)
 	})
+	t.Run("EgressClients", func(t *testing.T) {
+		testDatastoreEgressClients(t, newStore)
+	})
+	t.Run("EgressClientTokens", func(t *testing.T) {
+		testDatastoreEgressClientTokens(t, newStore)
+	})
 }
 
 func mustCreateUser(t *testing.T, ctx context.Context, ds core.Datastore, email string) *core.User {
@@ -414,7 +420,7 @@ func testDatastoreStagedConnections(t *testing.T, newStore func(t *testing.T) co
 		ctx := context.Background()
 
 		user := mustCreateUser(t, ctx, ds, "staged@example.com")
-		now := time.Now().UTC().Truncate(time.Second)
+		now := time.Now().Truncate(time.Second)
 		expiry := now.Add(10 * time.Minute)
 
 		sc := &core.StagedConnection{
@@ -482,6 +488,383 @@ func testDatastoreStagedConnections(t *testing.T, newStore func(t *testing.T) co
 		_, err := scs.GetStagedConnection(ctx, "nonexistent-id")
 		if !errors.Is(err, core.ErrNotFound) {
 			t.Fatalf("expected ErrNotFound, got %v", err)
+		}
+	})
+}
+
+func testDatastoreEgressClients(t *testing.T, newStore func(t *testing.T) core.Datastore) {
+	t.Run("create get and list lifecycle", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecs, ok := ds.(core.EgressClientStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressClientStore")
+		}
+
+		ctx := context.Background()
+		user := mustCreateUser(t, ctx, ds, "egress-admin@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		client := &core.EgressClient{
+			ID:          "ec-1",
+			Name:        "ci-bot",
+			Description: "CI/CD pipeline agent",
+			CreatedByID: user.ID,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		if err := ecs.CreateEgressClient(ctx, client); err != nil {
+			t.Fatalf("CreateEgressClient: %v", err)
+		}
+
+		got, err := ecs.GetEgressClient(ctx, "ec-1")
+		if err != nil {
+			t.Fatalf("GetEgressClient: %v", err)
+		}
+		if got.Name != "ci-bot" {
+			t.Errorf("Name: got %q, want %q", got.Name, "ci-bot")
+		}
+		if got.Description != "CI/CD pipeline agent" {
+			t.Errorf("Description: got %q, want %q", got.Description, "CI/CD pipeline agent")
+		}
+		if got.CreatedByID != user.ID {
+			t.Errorf("CreatedByID: got %q, want %q", got.CreatedByID, user.ID)
+		}
+
+		clients, err := ecs.ListEgressClients(ctx, user.ID)
+		if err != nil {
+			t.Fatalf("ListEgressClients: %v", err)
+		}
+		if len(clients) != 1 {
+			t.Fatalf("ListEgressClients: got %d, want 1", len(clients))
+		}
+	})
+
+	t.Run("delete removes client", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecs, ok := ds.(core.EgressClientStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressClientStore")
+		}
+
+		ctx := context.Background()
+		user := mustCreateUser(t, ctx, ds, "egress-del@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-del", Name: "deletable", CreatedByID: user.ID,
+			CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClient: %v", err)
+		}
+
+		if err := ecs.DeleteEgressClient(ctx, "ec-del"); err != nil {
+			t.Fatalf("DeleteEgressClient: %v", err)
+		}
+
+		_, err := ecs.GetEgressClient(ctx, "ec-del")
+		if !errors.Is(err, core.ErrNotFound) {
+			t.Fatalf("GetEgressClient after delete: expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("delete nonexistent returns ErrNotFound", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecs, ok := ds.(core.EgressClientStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressClientStore")
+		}
+
+		ctx := context.Background()
+		err := ecs.DeleteEgressClient(ctx, "nonexistent-id")
+		if !errors.Is(err, core.ErrNotFound) {
+			t.Fatalf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("duplicate name for same user returns ErrAlreadyRegistered", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecs, ok := ds.(core.EgressClientStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressClientStore")
+		}
+
+		ctx := context.Background()
+		user := mustCreateUser(t, ctx, ds, "egress-dup@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-dup-1", Name: "same-name", CreatedByID: user.ID,
+			CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("first CreateEgressClient: %v", err)
+		}
+
+		err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-dup-2", Name: "same-name", CreatedByID: user.ID,
+			CreatedAt: now, UpdatedAt: now,
+		})
+		if !errors.Is(err, core.ErrAlreadyRegistered) {
+			t.Fatalf("expected ErrAlreadyRegistered, got %v", err)
+		}
+	})
+
+	t.Run("same name allowed for different users and list is scoped", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecs, ok := ds.(core.EgressClientStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressClientStore")
+		}
+
+		ctx := context.Background()
+		userA := mustCreateUser(t, ctx, ds, "egress-a@example.com")
+		userB := mustCreateUser(t, ctx, ds, "egress-b@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-a", Name: "shared-name", CreatedByID: userA.ID,
+			CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClient userA: %v", err)
+		}
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-b", Name: "shared-name", CreatedByID: userB.ID,
+			CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClient userB: %v", err)
+		}
+
+		clientsA, err := ecs.ListEgressClients(ctx, userA.ID)
+		if err != nil {
+			t.Fatalf("ListEgressClients userA: %v", err)
+		}
+		if len(clientsA) != 1 || clientsA[0].ID != "ec-a" {
+			t.Fatalf("ListEgressClients userA: got %+v, want only ec-a", clientsA)
+		}
+
+		clientsB, err := ecs.ListEgressClients(ctx, userB.ID)
+		if err != nil {
+			t.Fatalf("ListEgressClients userB: %v", err)
+		}
+		if len(clientsB) != 1 || clientsB[0].ID != "ec-b" {
+			t.Fatalf("ListEgressClients userB: got %+v, want only ec-b", clientsB)
+		}
+	})
+}
+
+func testDatastoreEgressClientTokens(t *testing.T, newStore func(t *testing.T) core.Datastore) {
+	t.Run("create validate and list lifecycle", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecs, ok := ds.(core.EgressClientStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressClientStore")
+		}
+
+		ctx := context.Background()
+		user := mustCreateUser(t, ctx, ds, "token-admin@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-tok", Name: "token-client", CreatedByID: user.ID,
+			CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClient: %v", err)
+		}
+
+		token := &core.EgressClientToken{
+			ID:          "eclt-1",
+			ClientID:    "ec-tok",
+			Name:        "deploy-token",
+			HashedToken: "sha256:eclt-hash-1",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		if err := ecs.CreateEgressClientToken(ctx, token); err != nil {
+			t.Fatalf("CreateEgressClientToken: %v", err)
+		}
+
+		got, err := ecs.ValidateEgressClientToken(ctx, "sha256:eclt-hash-1")
+		if err != nil {
+			t.Fatalf("ValidateEgressClientToken: %v", err)
+		}
+		if got == nil {
+			t.Fatal("ValidateEgressClientToken returned nil")
+		}
+		if got.ClientID != "ec-tok" {
+			t.Errorf("ClientID: got %q, want %q", got.ClientID, "ec-tok")
+		}
+		if got.Name != "deploy-token" {
+			t.Errorf("Name: got %q, want %q", got.Name, "deploy-token")
+		}
+
+		tokens, err := ecs.ListEgressClientTokens(ctx, "ec-tok")
+		if err != nil {
+			t.Fatalf("ListEgressClientTokens: %v", err)
+		}
+		if len(tokens) != 1 {
+			t.Fatalf("ListEgressClientTokens: got %d, want 1", len(tokens))
+		}
+	})
+
+	t.Run("validate expired token returns nil", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecs, ok := ds.(core.EgressClientStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressClientStore")
+		}
+
+		ctx := context.Background()
+		user := mustCreateUser(t, ctx, ds, "expired-ect@example.com")
+		now := time.Now().Truncate(time.Second)
+		pastExpiry := now.Add(-1 * time.Hour)
+
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-exp", Name: "expired-client", CreatedByID: user.ID,
+			CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClient: %v", err)
+		}
+
+		if err := ecs.CreateEgressClientToken(ctx, &core.EgressClientToken{
+			ID: "eclt-exp", ClientID: "ec-exp", Name: "expired",
+			HashedToken: "sha256:eclt-expired", ExpiresAt: &pastExpiry,
+			CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClientToken: %v", err)
+		}
+
+		got, err := ecs.ValidateEgressClientToken(ctx, "sha256:eclt-expired")
+		if err != nil {
+			t.Fatalf("ValidateEgressClientToken: %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil for expired token, got %+v", got)
+		}
+	})
+
+	t.Run("revoke removes token", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecs, ok := ds.(core.EgressClientStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressClientStore")
+		}
+
+		ctx := context.Background()
+		user := mustCreateUser(t, ctx, ds, "revoke-ect@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-rev", Name: "revoke-client", CreatedByID: user.ID,
+			CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClient: %v", err)
+		}
+
+		if err := ecs.CreateEgressClientToken(ctx, &core.EgressClientToken{
+			ID: "eclt-rev", ClientID: "ec-rev", Name: "revokable",
+			HashedToken: "sha256:eclt-revoke", CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClientToken: %v", err)
+		}
+
+		if err := ecs.RevokeEgressClientToken(ctx, "ec-rev", "eclt-rev"); err != nil {
+			t.Fatalf("RevokeEgressClientToken: %v", err)
+		}
+
+		got, err := ecs.ValidateEgressClientToken(ctx, "sha256:eclt-revoke")
+		if err != nil {
+			t.Fatalf("ValidateEgressClientToken after revoke: %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil after revoke, got %+v", got)
+		}
+	})
+
+	t.Run("revoke with wrong client_id returns ErrNotFound", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecs, ok := ds.(core.EgressClientStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressClientStore")
+		}
+
+		ctx := context.Background()
+		user := mustCreateUser(t, ctx, ds, "wrong-client-ect@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-owner", Name: "owner-client", CreatedByID: user.ID,
+			CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClient: %v", err)
+		}
+
+		if err := ecs.CreateEgressClientToken(ctx, &core.EgressClientToken{
+			ID: "eclt-owned", ClientID: "ec-owner", Name: "owned-token",
+			HashedToken: "sha256:eclt-owned", CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClientToken: %v", err)
+		}
+
+		err := ecs.RevokeEgressClientToken(ctx, "wrong-client-id", "eclt-owned")
+		if !errors.Is(err, core.ErrNotFound) {
+			t.Fatalf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("cascade delete removes tokens", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecs, ok := ds.(core.EgressClientStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressClientStore")
+		}
+
+		ctx := context.Background()
+		user := mustCreateUser(t, ctx, ds, "cascade-ect@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-cascade", Name: "cascade-client", CreatedByID: user.ID,
+			CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClient: %v", err)
+		}
+
+		if err := ecs.CreateEgressClientToken(ctx, &core.EgressClientToken{
+			ID: "eclt-cascade", ClientID: "ec-cascade", Name: "cascade-token",
+			HashedToken: "sha256:eclt-cascade", CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClientToken: %v", err)
+		}
+
+		if err := ecs.DeleteEgressClient(ctx, "ec-cascade"); err != nil {
+			t.Fatalf("DeleteEgressClient: %v", err)
+		}
+
+		got, err := ecs.ValidateEgressClientToken(ctx, "sha256:eclt-cascade")
+		if err != nil {
+			t.Fatalf("ValidateEgressClientToken after cascade delete: %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil after cascade delete, got %+v", got)
 		}
 	})
 }

--- a/core/testing/stubs.go
+++ b/core/testing/stubs.go
@@ -19,22 +19,31 @@ func (s *StubSecretManager) GetSecret(_ context.Context, name string) (string, e
 }
 
 var _ core.StagedConnectionStore = (*StubDatastore)(nil)
+var _ core.EgressClientStore = (*StubDatastore)(nil)
 
 // Set Fn fields to override individual methods; nil fields return zero values.
 type StubDatastore struct {
-	PingFn                     func(context.Context) error
-	GetUserFn                  func(context.Context, string) (*core.User, error)
-	FindOrCreateUserFn         func(context.Context, string) (*core.User, error)
-	StoreTokenFn               func(context.Context, *core.IntegrationToken) error
-	TokenFn                    func(context.Context, string, string, string) (*core.IntegrationToken, error)
-	ListTokensFn               func(context.Context, string) ([]*core.IntegrationToken, error)
-	ListTokensForIntegrationFn func(context.Context, string, string) ([]*core.IntegrationToken, error)
-	DeleteTokenFn              func(context.Context, string) error
-	ValidateAPITokenFn         func(context.Context, string) (*core.APIToken, error)
-	RevokeAPITokenFn           func(context.Context, string, string) error
-	StoreStagedConnectionFn    func(context.Context, *core.StagedConnection) error
-	GetStagedConnectionFn      func(context.Context, string) (*core.StagedConnection, error)
-	DeleteStagedConnectionFn   func(context.Context, string) error
+	PingFn                      func(context.Context) error
+	GetUserFn                   func(context.Context, string) (*core.User, error)
+	FindOrCreateUserFn          func(context.Context, string) (*core.User, error)
+	StoreTokenFn                func(context.Context, *core.IntegrationToken) error
+	TokenFn                     func(context.Context, string, string, string) (*core.IntegrationToken, error)
+	ListTokensFn                func(context.Context, string) ([]*core.IntegrationToken, error)
+	ListTokensForIntegrationFn  func(context.Context, string, string) ([]*core.IntegrationToken, error)
+	DeleteTokenFn               func(context.Context, string) error
+	ValidateAPITokenFn          func(context.Context, string) (*core.APIToken, error)
+	RevokeAPITokenFn            func(context.Context, string, string) error
+	StoreStagedConnectionFn     func(context.Context, *core.StagedConnection) error
+	GetStagedConnectionFn       func(context.Context, string) (*core.StagedConnection, error)
+	DeleteStagedConnectionFn    func(context.Context, string) error
+	CreateEgressClientFn        func(context.Context, *core.EgressClient) error
+	GetEgressClientFn           func(context.Context, string) (*core.EgressClient, error)
+	ListEgressClientsFn         func(context.Context, string) ([]*core.EgressClient, error)
+	DeleteEgressClientFn        func(context.Context, string) error
+	CreateEgressClientTokenFn   func(context.Context, *core.EgressClientToken) error
+	ValidateEgressClientTokenFn func(context.Context, string) (*core.EgressClientToken, error)
+	ListEgressClientTokensFn    func(context.Context, string) ([]*core.EgressClientToken, error)
+	RevokeEgressClientTokenFn   func(context.Context, string, string) error
 }
 
 func (s *StubDatastore) Ping(ctx context.Context) error {
@@ -131,6 +140,54 @@ func (s *StubDatastore) GetStagedConnection(ctx context.Context, id string) (*co
 func (s *StubDatastore) DeleteStagedConnection(ctx context.Context, id string) error {
 	if s.DeleteStagedConnectionFn != nil {
 		return s.DeleteStagedConnectionFn(ctx, id)
+	}
+	return nil
+}
+func (s *StubDatastore) CreateEgressClient(ctx context.Context, client *core.EgressClient) error {
+	if s.CreateEgressClientFn != nil {
+		return s.CreateEgressClientFn(ctx, client)
+	}
+	return nil
+}
+func (s *StubDatastore) GetEgressClient(ctx context.Context, id string) (*core.EgressClient, error) {
+	if s.GetEgressClientFn != nil {
+		return s.GetEgressClientFn(ctx, id)
+	}
+	return nil, core.ErrNotFound
+}
+func (s *StubDatastore) ListEgressClients(ctx context.Context, userID string) ([]*core.EgressClient, error) {
+	if s.ListEgressClientsFn != nil {
+		return s.ListEgressClientsFn(ctx, userID)
+	}
+	return nil, nil
+}
+func (s *StubDatastore) DeleteEgressClient(ctx context.Context, id string) error {
+	if s.DeleteEgressClientFn != nil {
+		return s.DeleteEgressClientFn(ctx, id)
+	}
+	return nil
+}
+func (s *StubDatastore) CreateEgressClientToken(ctx context.Context, token *core.EgressClientToken) error {
+	if s.CreateEgressClientTokenFn != nil {
+		return s.CreateEgressClientTokenFn(ctx, token)
+	}
+	return nil
+}
+func (s *StubDatastore) ValidateEgressClientToken(ctx context.Context, hashedToken string) (*core.EgressClientToken, error) {
+	if s.ValidateEgressClientTokenFn != nil {
+		return s.ValidateEgressClientTokenFn(ctx, hashedToken)
+	}
+	return nil, nil
+}
+func (s *StubDatastore) ListEgressClientTokens(ctx context.Context, clientID string) ([]*core.EgressClientToken, error) {
+	if s.ListEgressClientTokensFn != nil {
+		return s.ListEgressClientTokensFn(ctx, clientID)
+	}
+	return nil, nil
+}
+func (s *StubDatastore) RevokeEgressClientToken(ctx context.Context, clientID, tokenID string) error {
+	if s.RevokeEgressClientTokenFn != nil {
+		return s.RevokeEgressClientTokenFn(ctx, clientID, tokenID)
 	}
 	return nil
 }

--- a/core/types.go
+++ b/core/types.go
@@ -88,3 +88,22 @@ type OperationResult struct {
 	Headers http.Header
 	Body    string
 }
+
+type EgressClient struct {
+	ID          string
+	Name        string
+	Description string
+	CreatedByID string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+type EgressClientToken struct {
+	ID          string
+	ClientID    string
+	Name        string
+	HashedToken string
+	ExpiresAt   *time.Time
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}

--- a/internal/server/egress_clients.go
+++ b/internal/server/egress_clients.go
@@ -1,0 +1,295 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/principal"
+)
+
+func (s *Server) egressClientStore() (core.EgressClientStore, error) {
+	ecs, ok := s.datastore.(core.EgressClientStore)
+	if !ok {
+		return nil, fmt.Errorf("datastore does not support egress clients; use a SQL-backed datastore (sqlite, postgres, mysql, sqlserver, oracle)")
+	}
+	return ecs, nil
+}
+
+func (s *Server) resolveOwnedEgressClient(w http.ResponseWriter, r *http.Request, ecs core.EgressClientStore) (*core.EgressClient, bool) {
+	userID, ok := s.resolveUserID(w, r)
+	if !ok {
+		return nil, false
+	}
+	clientID := chi.URLParam(r, "id")
+	client, err := ecs.GetEgressClient(r.Context(), clientID)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "egress client not found")
+			return nil, false
+		}
+		writeError(w, http.StatusInternalServerError, "failed to look up egress client")
+		return nil, false
+	}
+	if client.CreatedByID != userID {
+		writeError(w, http.StatusNotFound, "egress client not found")
+		return nil, false
+	}
+	return client, true
+}
+
+type createEgressClientRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type egressClientResponse struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	CreatedByID string    `json:"created_by_id"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+func (s *Server) createEgressClient(w http.ResponseWriter, r *http.Request) {
+	userID, ok := s.resolveUserID(w, r)
+	if !ok {
+		return
+	}
+
+	ecs, err := s.egressClientStore()
+	if err != nil {
+		writeError(w, http.StatusNotImplemented, err.Error())
+		return
+	}
+
+	var req createEgressClientRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+
+	now := s.now().UTC().Truncate(time.Second)
+	client := &core.EgressClient{
+		ID:          uuid.NewString(),
+		Name:        req.Name,
+		Description: req.Description,
+		CreatedByID: userID,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	if err := ecs.CreateEgressClient(r.Context(), client); err != nil {
+		if errors.Is(err, core.ErrAlreadyRegistered) {
+			writeError(w, http.StatusConflict, "egress client name already exists")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to create egress client")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, egressClientResponse{
+		ID:          client.ID,
+		Name:        client.Name,
+		Description: client.Description,
+		CreatedByID: client.CreatedByID,
+		CreatedAt:   client.CreatedAt,
+		UpdatedAt:   client.UpdatedAt,
+	})
+}
+
+func (s *Server) listEgressClients(w http.ResponseWriter, r *http.Request) {
+	userID, ok := s.resolveUserID(w, r)
+	if !ok {
+		return
+	}
+
+	ecs, err := s.egressClientStore()
+	if err != nil {
+		writeError(w, http.StatusNotImplemented, err.Error())
+		return
+	}
+
+	clients, err := ecs.ListEgressClients(r.Context(), userID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list egress clients")
+		return
+	}
+
+	out := make([]egressClientResponse, 0, len(clients))
+	for _, c := range clients {
+		out = append(out, egressClientResponse{
+			ID:          c.ID,
+			Name:        c.Name,
+			Description: c.Description,
+			CreatedByID: c.CreatedByID,
+			CreatedAt:   c.CreatedAt,
+			UpdatedAt:   c.UpdatedAt,
+		})
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) deleteEgressClient(w http.ResponseWriter, r *http.Request) {
+	ecs, err := s.egressClientStore()
+	if err != nil {
+		writeError(w, http.StatusNotImplemented, err.Error())
+		return
+	}
+
+	client, ok := s.resolveOwnedEgressClient(w, r, ecs)
+	if !ok {
+		return
+	}
+
+	if err := ecs.DeleteEgressClient(r.Context(), client.ID); err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "egress client not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to delete egress client")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+type createEgressClientTokenRequest struct {
+	Name string `json:"name"`
+}
+
+type createEgressClientTokenResponse struct {
+	ID        string     `json:"id"`
+	Name      string     `json:"name"`
+	Token     string     `json:"token"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+}
+
+type egressClientTokenInfo struct {
+	ID        string     `json:"id"`
+	Name      string     `json:"name"`
+	CreatedAt time.Time  `json:"created_at"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+}
+
+const defaultEgressClientTokenExpiry = 90 * 24 * time.Hour
+
+func (s *Server) createEgressClientToken(w http.ResponseWriter, r *http.Request) {
+	ecs, err := s.egressClientStore()
+	if err != nil {
+		writeError(w, http.StatusNotImplemented, err.Error())
+		return
+	}
+
+	client, ok := s.resolveOwnedEgressClient(w, r, ecs)
+	if !ok {
+		return
+	}
+	clientID := client.ID
+
+	var req createEgressClientTokenRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+
+	plaintext, err := generateRandomHex(32)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to generate token")
+		return
+	}
+
+	hashed := principal.HashToken(plaintext)
+	now := s.now().UTC().Truncate(time.Second)
+	expiry := now.Add(defaultEgressClientTokenExpiry)
+
+	token := &core.EgressClientToken{
+		ID:          uuid.NewString(),
+		ClientID:    clientID,
+		Name:        req.Name,
+		HashedToken: hashed,
+		ExpiresAt:   &expiry,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	if err := ecs.CreateEgressClientToken(r.Context(), token); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create egress client token")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, createEgressClientTokenResponse{
+		ID:        token.ID,
+		Name:      token.Name,
+		Token:     plaintext,
+		ExpiresAt: token.ExpiresAt,
+	})
+}
+
+func (s *Server) listEgressClientTokens(w http.ResponseWriter, r *http.Request) {
+	ecs, err := s.egressClientStore()
+	if err != nil {
+		writeError(w, http.StatusNotImplemented, err.Error())
+		return
+	}
+
+	client, ok := s.resolveOwnedEgressClient(w, r, ecs)
+	if !ok {
+		return
+	}
+
+	tokens, err := ecs.ListEgressClientTokens(r.Context(), client.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list egress client tokens")
+		return
+	}
+
+	out := make([]egressClientTokenInfo, 0, len(tokens))
+	for _, t := range tokens {
+		out = append(out, egressClientTokenInfo{
+			ID:        t.ID,
+			Name:      t.Name,
+			CreatedAt: t.CreatedAt,
+			ExpiresAt: t.ExpiresAt,
+		})
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) revokeEgressClientToken(w http.ResponseWriter, r *http.Request) {
+	ecs, err := s.egressClientStore()
+	if err != nil {
+		writeError(w, http.StatusNotImplemented, err.Error())
+		return
+	}
+
+	client, ok := s.resolveOwnedEgressClient(w, r, ecs)
+	if !ok {
+		return
+	}
+
+	clientID := client.ID
+	tokenID := chi.URLParam(r, "tokenID")
+	if err := ecs.RevokeEgressClientToken(r.Context(), clientID, tokenID); err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "token not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to revoke egress client token")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "revoked"})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -141,6 +141,13 @@ func (s *Server) routes() {
 			r.Post("/tokens", s.createAPIToken)
 			r.Get("/tokens", s.listAPITokens)
 			r.Delete("/tokens/{id}", s.revokeAPIToken)
+
+			r.Post("/egress-clients", s.createEgressClient)
+			r.Get("/egress-clients", s.listEgressClients)
+			r.Delete("/egress-clients/{id}", s.deleteEgressClient)
+			r.Post("/egress-clients/{id}/tokens", s.createEgressClientToken)
+			r.Get("/egress-clients/{id}/tokens", s.listEgressClientTokens)
+			r.Delete("/egress-clients/{id}/tokens/{tokenID}", s.revokeEgressClientToken)
 		})
 	})
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1441,6 +1441,396 @@ func TestCreateAPIToken_DefaultExpiry(t *testing.T) {
 	}
 }
 
+func TestCreateAndListEgressClients(t *testing.T) {
+	t.Parallel()
+
+	var stored []*core.EgressClient
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			CreateEgressClientFn: func(_ context.Context, c *core.EgressClient) error {
+				stored = append(stored, c)
+				return nil
+			},
+			ListEgressClientsFn: func(_ context.Context, userID string) ([]*core.EgressClient, error) {
+				if userID != "u1" {
+					t.Fatalf("expected userID u1, got %q", userID)
+				}
+				return stored, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"name":"ci-bot","description":"CI agent"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/egress-clients", body)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 201, got %d: %s", resp.StatusCode, respBody)
+	}
+
+	var created map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decoding create response: %v", err)
+	}
+	if created["name"] != "ci-bot" {
+		t.Fatalf("expected name ci-bot, got %q", created["name"])
+	}
+	if created["id"] == "" {
+		t.Fatal("expected non-empty id")
+	}
+
+	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/egress-clients", nil)
+	listReq.Header.Set("X-Dev-User-Email", "dev@example.com")
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("list request: %v", err)
+	}
+	defer func() { _ = listResp.Body.Close() }()
+
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", listResp.StatusCode)
+	}
+
+	var listed []map[string]any
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decoding list response: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("expected 1 client, got %d", len(listed))
+	}
+}
+
+func TestDeleteEgressClient(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			GetEgressClientFn: func(_ context.Context, id string) (*core.EgressClient, error) {
+				if id == "ec-123" {
+					return &core.EgressClient{ID: "ec-123", Name: "test", CreatedByID: "u1"}, nil
+				}
+				return nil, core.ErrNotFound
+			},
+			DeleteEgressClientFn: func(_ context.Context, id string) error {
+				if id == "ec-123" {
+					return nil
+				}
+				return core.ErrNotFound
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/egress-clients/ec-123", nil)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if result["status"] != "deleted" {
+		t.Fatalf("expected deleted, got %q", result["status"])
+	}
+}
+
+func TestDeleteEgressClient_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			DeleteEgressClientFn: func(_ context.Context, id string) error {
+				return core.ErrNotFound
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/egress-clients/nonexistent", nil)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestCreateAndListEgressClientTokens(t *testing.T) {
+	t.Parallel()
+
+	var storedTokens []*core.EgressClientToken
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			GetEgressClientFn: func(_ context.Context, id string) (*core.EgressClient, error) {
+				if id == "ec-1" {
+					return &core.EgressClient{ID: "ec-1", Name: "test-client", CreatedByID: "u1"}, nil
+				}
+				return nil, core.ErrNotFound
+			},
+			CreateEgressClientTokenFn: func(_ context.Context, token *core.EgressClientToken) error {
+				storedTokens = append(storedTokens, token)
+				return nil
+			},
+			ListEgressClientTokensFn: func(_ context.Context, clientID string) ([]*core.EgressClientToken, error) {
+				return storedTokens, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"name":"deploy-token"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/egress-clients/ec-1/tokens", body)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 201, got %d: %s", resp.StatusCode, respBody)
+	}
+
+	var created map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decoding create response: %v", err)
+	}
+	if created["token"] == nil || created["token"] == "" {
+		t.Fatal("expected non-empty plaintext token in response")
+	}
+	if created["name"] != "deploy-token" {
+		t.Fatalf("expected name deploy-token, got %q", created["name"])
+	}
+
+	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/egress-clients/ec-1/tokens", nil)
+	listReq.Header.Set("X-Dev-User-Email", "dev@example.com")
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("list request: %v", err)
+	}
+	defer func() { _ = listResp.Body.Close() }()
+
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", listResp.StatusCode)
+	}
+
+	var listed []map[string]any
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decoding list response: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("expected 1 token, got %d", len(listed))
+	}
+	if _, hasToken := listed[0]["token"]; hasToken {
+		t.Fatal("list response should not include plaintext token")
+	}
+	if _, hasHashed := listed[0]["hashed_token"]; hasHashed {
+		t.Fatal("list response should not include hashed token")
+	}
+}
+
+func TestRevokeEgressClientToken(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			GetEgressClientFn: func(_ context.Context, id string) (*core.EgressClient, error) {
+				if id == "ec-1" {
+					return &core.EgressClient{ID: "ec-1", Name: "test", CreatedByID: "u1"}, nil
+				}
+				return nil, core.ErrNotFound
+			},
+			RevokeEgressClientTokenFn: func(_ context.Context, clientID, tokenID string) error {
+				if clientID == "ec-1" && tokenID == "eclt-1" {
+					return nil
+				}
+				return core.ErrNotFound
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/egress-clients/ec-1/tokens/eclt-1", nil)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if result["status"] != "revoked" {
+		t.Fatalf("expected revoked, got %q", result["status"])
+	}
+}
+
+func TestDeleteEgressClient_WrongOwner(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u-other", Email: email}, nil
+			},
+			GetEgressClientFn: func(_ context.Context, id string) (*core.EgressClient, error) {
+				if id == "ec-owned" {
+					return &core.EgressClient{ID: "ec-owned", Name: "owned", CreatedByID: "u-owner"}, nil
+				}
+				return nil, core.ErrNotFound
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/egress-clients/ec-owned", nil)
+	req.Header.Set("X-Dev-User-Email", "attacker@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 404, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+func TestListEgressClientTokens_MissingClient(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			GetEgressClientFn: func(_ context.Context, id string) (*core.EgressClient, error) {
+				return nil, core.ErrNotFound
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/egress-clients/nonexistent/tokens", nil)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 404, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+func TestEgressClientEndpoints_NoCapability(t *testing.T) {
+	t.Parallel()
+
+	// Use a datastore that does NOT implement EgressClientStore
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Datastore = &minimalDatastore{}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/egress-clients", nil)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotImplemented {
+		t.Fatalf("expected 501, got %d", resp.StatusCode)
+	}
+}
+
+// minimalDatastore implements core.Datastore but NOT core.EgressClientStore.
+type minimalDatastore struct{}
+
+func (d *minimalDatastore) GetUser(context.Context, string) (*core.User, error) {
+	return nil, core.ErrNotFound
+}
+func (d *minimalDatastore) FindOrCreateUser(_ context.Context, email string) (*core.User, error) {
+	return &core.User{ID: "u1", Email: email}, nil
+}
+func (d *minimalDatastore) StoreToken(context.Context, *core.IntegrationToken) error { return nil }
+func (d *minimalDatastore) Token(context.Context, string, string, string) (*core.IntegrationToken, error) {
+	return nil, nil
+}
+func (d *minimalDatastore) ListTokens(context.Context, string) ([]*core.IntegrationToken, error) {
+	return nil, nil
+}
+func (d *minimalDatastore) ListTokensForIntegration(context.Context, string, string) ([]*core.IntegrationToken, error) {
+	return nil, nil
+}
+func (d *minimalDatastore) DeleteToken(context.Context, string) error           { return nil }
+func (d *minimalDatastore) StoreAPIToken(context.Context, *core.APIToken) error { return nil }
+func (d *minimalDatastore) ValidateAPIToken(context.Context, string) (*core.APIToken, error) {
+	return nil, nil
+}
+func (d *minimalDatastore) ListAPITokens(context.Context, string) ([]*core.APIToken, error) {
+	return nil, nil
+}
+func (d *minimalDatastore) RevokeAPIToken(context.Context, string, string) error { return nil }
+func (d *minimalDatastore) Ping(context.Context) error                           { return nil }
+func (d *minimalDatastore) Migrate(context.Context) error                        { return nil }
+func (d *minimalDatastore) Close() error                                         { return nil }
+
 func TestExecuteOperation_POST(t *testing.T) {
 	t.Parallel()
 

--- a/plugins/datastore/mysql/mysql.go
+++ b/plugins/datastore/mysql/mysql.go
@@ -46,6 +46,7 @@ type Store struct {
 
 var _ core.Datastore = (*Store)(nil)
 var _ core.StagedConnectionStore = (*Store)(nil)
+var _ core.EgressClientStore = (*Store)(nil)
 
 func New(dsn string, encryptionKey []byte) (*Store, error) {
 	cfg, err := mysqldriver.ParseDSN(dsn)
@@ -121,6 +122,29 @@ func (s *Store) Migrate(ctx context.Context) error {
 			created_at DATETIME(6) NOT NULL,
 			expires_at DATETIME(6) NOT NULL,
 			CONSTRAINT fk_staged_connections_user FOREIGN KEY (user_id) REFERENCES users(id)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`,
+
+		`CREATE TABLE IF NOT EXISTS egress_clients (
+			id VARCHAR(36) NOT NULL PRIMARY KEY,
+			name VARCHAR(255) NOT NULL,
+			description TEXT NOT NULL,
+			created_by_id VARCHAR(36) NOT NULL,
+			created_at DATETIME(6) NOT NULL,
+			updated_at DATETIME(6) NOT NULL,
+			UNIQUE KEY idx_egress_clients_owner_name (created_by_id, name),
+			CONSTRAINT fk_egress_clients_user FOREIGN KEY (created_by_id) REFERENCES users(id)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`,
+
+		`CREATE TABLE IF NOT EXISTS egress_client_tokens (
+			id VARCHAR(36) NOT NULL PRIMARY KEY,
+			client_id VARCHAR(36) NOT NULL,
+			name VARCHAR(255) NOT NULL,
+			hashed_token VARCHAR(255) NOT NULL,
+			expires_at DATETIME(6) NULL,
+			created_at DATETIME(6) NOT NULL,
+			updated_at DATETIME(6) NOT NULL,
+			UNIQUE KEY idx_egress_client_tokens_hashed (hashed_token),
+			CONSTRAINT fk_egress_client_tokens_client FOREIGN KEY (client_id) REFERENCES egress_clients(id) ON DELETE CASCADE
 		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`,
 	}
 

--- a/plugins/datastore/oracle/oracle.go
+++ b/plugins/datastore/oracle/oracle.go
@@ -79,6 +79,7 @@ type Store struct {
 
 var _ core.Datastore = (*Store)(nil)
 var _ core.StagedConnectionStore = (*Store)(nil)
+var _ core.EgressClientStore = (*Store)(nil)
 
 func New(dsn string, encryptionKey []byte) (*Store, error) {
 	s, err := sqlstore.Open("oracle", dsn, encryptionKey, dialect{})
@@ -150,6 +151,29 @@ func (s *Store) Migrate(ctx context.Context) error {
 				expires_at TIMESTAMP WITH TIME ZONE NOT NULL
 			)`,
 		},
+		{
+			name: "EGRESS_CLIENTS",
+			ddl: `CREATE TABLE egress_clients (
+				id VARCHAR2(36) PRIMARY KEY,
+				name VARCHAR2(255) NOT NULL,
+				description CLOB,
+				created_by_id VARCHAR2(36) NOT NULL,
+				created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+				updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+			)`,
+		},
+		{
+			name: "EGRESS_CLIENT_TOKENS",
+			ddl: `CREATE TABLE egress_client_tokens (
+				id VARCHAR2(36) PRIMARY KEY,
+				client_id VARCHAR2(36) NOT NULL,
+				name VARCHAR2(255) NOT NULL,
+				hashed_token VARCHAR2(255) NOT NULL,
+				expires_at TIMESTAMP WITH TIME ZONE,
+				created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+				updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+			)`,
+		},
 	}
 
 	for _, tbl := range tables {
@@ -191,6 +215,22 @@ func (s *Store) Migrate(ctx context.Context) error {
 		{
 			name: "FK_STAGED_CONN_USER",
 			ddl:  "ALTER TABLE staged_connections ADD CONSTRAINT fk_staged_conn_user FOREIGN KEY (user_id) REFERENCES users(id)",
+		},
+		{
+			name: "UQ_EGRESS_CLIENTS_OWNER_NAME",
+			ddl:  "ALTER TABLE egress_clients ADD CONSTRAINT uq_egress_clients_owner_name UNIQUE (created_by_id, name)",
+		},
+		{
+			name: "FK_EGRESS_CLIENTS_USER",
+			ddl:  "ALTER TABLE egress_clients ADD CONSTRAINT fk_egress_clients_user FOREIGN KEY (created_by_id) REFERENCES users(id)",
+		},
+		{
+			name: "UQ_ECLT_HASHED_TOKEN",
+			ddl:  "ALTER TABLE egress_client_tokens ADD CONSTRAINT uq_eclt_hashed_token UNIQUE (hashed_token)",
+		},
+		{
+			name: "FK_ECLT_CLIENT",
+			ddl:  "ALTER TABLE egress_client_tokens ADD CONSTRAINT fk_eclt_client FOREIGN KEY (client_id) REFERENCES egress_clients(id) ON DELETE CASCADE",
 		},
 	}
 

--- a/plugins/datastore/postgres/postgres.go
+++ b/plugins/datastore/postgres/postgres.go
@@ -63,6 +63,7 @@ type Store struct {
 
 var _ core.Datastore = (*Store)(nil)
 var _ core.StagedConnectionStore = (*Store)(nil)
+var _ core.EgressClientStore = (*Store)(nil)
 
 func New(dsn string, encryptionKey []byte) (*Store, error) {
 	s, err := sqlstore.Open("pgx", dsn, encryptionKey, dialect{})
@@ -136,6 +137,30 @@ func (s *Store) Migrate(ctx context.Context) error {
 			expires_at TIMESTAMPTZ NOT NULL
 		)`); err != nil {
 		return fmt.Errorf("creating staged_connections table: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS egress_clients (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			created_by_id TEXT NOT NULL REFERENCES users(id),
+			created_at TIMESTAMPTZ NOT NULL,
+			updated_at TIMESTAMPTZ NOT NULL,
+			UNIQUE(created_by_id, name)
+		)`); err != nil {
+		return fmt.Errorf("creating egress_clients table: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS egress_client_tokens (
+			id TEXT PRIMARY KEY,
+			client_id TEXT NOT NULL REFERENCES egress_clients(id) ON DELETE CASCADE,
+			name TEXT NOT NULL,
+			hashed_token TEXT UNIQUE NOT NULL,
+			expires_at TIMESTAMPTZ,
+			created_at TIMESTAMPTZ NOT NULL,
+			updated_at TIMESTAMPTZ NOT NULL
+		)`); err != nil {
+		return fmt.Errorf("creating egress_client_tokens table: %w", err)
 	}
 	return tx.Commit()
 }

--- a/plugins/datastore/sqlite/sqlite.go
+++ b/plugins/datastore/sqlite/sqlite.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 
+	"strings"
+
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/crypto"
 	"github.com/valon-technologies/gestalt/plugins/datastore/sqlstore"
@@ -34,11 +36,12 @@ func (dialect) UpsertTokenSQL() string {
 			updated_at = excluded.updated_at`
 }
 
-// IsDuplicateKeyError always returns false for SQLite because
-// FindOrCreateUser uses INSERT without ON CONFLICT for the users
-// table (SQLite serializes writes via a single connection, so races
-// don't occur in practice).
-func (dialect) IsDuplicateKeyError(error) bool { return false }
+func (dialect) IsDuplicateKeyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "UNIQUE constraint failed")
+}
 
 // Store embeds sqlstore.Store and adds SQLite-specific behavior.
 type Store struct {
@@ -47,6 +50,7 @@ type Store struct {
 
 var _ core.Datastore = (*Store)(nil)
 var _ core.StagedConnectionStore = (*Store)(nil)
+var _ core.EgressClientStore = (*Store)(nil)
 
 func New(dbPath string, encryptionKey []byte) (*Store, error) {
 	dsn := dbPath + "?_pragma=journal_mode(wal)&_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)"
@@ -112,6 +116,24 @@ func (s *Store) Migrate(ctx context.Context) error {
 			candidates_json TEXT NOT NULL,
 			created_at DATETIME NOT NULL,
 			expires_at DATETIME NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS egress_clients (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			created_by_id TEXT NOT NULL REFERENCES users(id),
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			UNIQUE(created_by_id, name)
+		);
+		CREATE TABLE IF NOT EXISTS egress_client_tokens (
+			id TEXT PRIMARY KEY,
+			client_id TEXT NOT NULL REFERENCES egress_clients(id) ON DELETE CASCADE,
+			name TEXT NOT NULL,
+			hashed_token TEXT UNIQUE NOT NULL,
+			expires_at DATETIME,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
 		)
 	`)
 	return err

--- a/plugins/datastore/sqlserver/sqlserver.go
+++ b/plugins/datastore/sqlserver/sqlserver.go
@@ -78,6 +78,7 @@ type Store struct {
 
 var _ core.Datastore = (*Store)(nil)
 var _ core.StagedConnectionStore = (*Store)(nil)
+var _ core.EgressClientStore = (*Store)(nil)
 
 func New(dsn string, encryptionKey []byte) (*Store, error) {
 	s, err := sqlstore.Open(driverName, dsn, encryptionKey, dialect{})
@@ -151,6 +152,28 @@ func (s *Store) Migrate(ctx context.Context) error {
 				candidates_json NVARCHAR(MAX) NOT NULL,
 				created_at DATETIME2(6) NOT NULL,
 				expires_at DATETIME2(6) NOT NULL
+			)`},
+		{"egress_clients", `
+			IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'egress_clients')
+			CREATE TABLE egress_clients (
+				id NVARCHAR(36) NOT NULL PRIMARY KEY,
+				name NVARCHAR(255) NOT NULL,
+				description NVARCHAR(MAX) NOT NULL DEFAULT '',
+				created_by_id NVARCHAR(36) NOT NULL REFERENCES users(id),
+				created_at DATETIME2(6) NOT NULL,
+				updated_at DATETIME2(6) NOT NULL,
+				UNIQUE (created_by_id, name)
+			)`},
+		{"egress_client_tokens", `
+			IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'egress_client_tokens')
+			CREATE TABLE egress_client_tokens (
+				id NVARCHAR(36) NOT NULL PRIMARY KEY,
+				client_id NVARCHAR(36) NOT NULL REFERENCES egress_clients(id) ON DELETE CASCADE,
+				name NVARCHAR(255) NOT NULL,
+				hashed_token NVARCHAR(255) NOT NULL UNIQUE,
+				expires_at DATETIME2(6) NULL,
+				created_at DATETIME2(6) NOT NULL,
+				updated_at DATETIME2(6) NOT NULL
 			)`},
 	}
 

--- a/plugins/datastore/sqlstore/sqlstore.go
+++ b/plugins/datastore/sqlstore/sqlstore.go
@@ -431,3 +431,168 @@ func (s *Store) DeleteStagedConnection(ctx context.Context, id string) error {
 	}
 	return nil
 }
+
+// ---------------------------------------------------------------------------
+// EgressClient methods
+// ---------------------------------------------------------------------------
+
+func scanEgressClient(row Scanner) (*core.EgressClient, error) {
+	var c core.EgressClient
+	var description sql.NullString
+	if err := row.Scan(&c.ID, &c.Name, &description, &c.CreatedByID,
+		&c.CreatedAt, &c.UpdatedAt); err != nil {
+		return nil, err
+	}
+	c.Description = description.String
+	return &c, nil
+}
+
+func scanEgressClientToken(row Scanner) (*core.EgressClientToken, error) {
+	var t core.EgressClientToken
+	var expiresAt sql.NullTime
+	if err := row.Scan(&t.ID, &t.ClientID, &t.Name, &t.HashedToken,
+		&expiresAt, &t.CreatedAt, &t.UpdatedAt); err != nil {
+		return nil, err
+	}
+	if expiresAt.Valid {
+		t.ExpiresAt = &expiresAt.Time
+	}
+	return &t, nil
+}
+
+func (s *Store) CreateEgressClient(ctx context.Context, client *core.EgressClient) error {
+	defaultTimestamps(&client.CreatedAt, &client.UpdatedAt)
+	_, err := s.DB.ExecContext(ctx, `
+		INSERT INTO egress_clients (id, name, description, created_by_id, created_at, updated_at)
+		VALUES (`+s.ph(1)+`, `+s.ph(2)+`, `+s.ph(3)+`, `+s.ph(4)+`, `+s.ph(5)+`, `+s.ph(6)+`)`,
+		client.ID, client.Name, client.Description, client.CreatedByID,
+		client.CreatedAt, client.UpdatedAt,
+	)
+	if err != nil {
+		if s.Dialect.IsDuplicateKeyError(err) {
+			return core.ErrAlreadyRegistered
+		}
+		return fmt.Errorf("inserting egress client: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetEgressClient(ctx context.Context, id string) (*core.EgressClient, error) {
+	row := s.DB.QueryRowContext(ctx, `
+		SELECT id, name, description, created_by_id, created_at, updated_at
+		FROM egress_clients WHERE id = `+s.ph(1), id)
+	c, err := scanEgressClient(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, core.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying egress client: %w", err)
+	}
+	return c, nil
+}
+
+func (s *Store) ListEgressClients(ctx context.Context, userID string) ([]*core.EgressClient, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT id, name, description, created_by_id, created_at, updated_at
+		FROM egress_clients
+		WHERE created_by_id = `+s.ph(1)+`
+		ORDER BY created_at`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("listing egress clients: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var clients []*core.EgressClient
+	for rows.Next() {
+		c, err := scanEgressClient(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning egress client row: %w", err)
+		}
+		clients = append(clients, c)
+	}
+	return clients, rows.Err()
+}
+
+func (s *Store) DeleteEgressClient(ctx context.Context, id string) error {
+	result, err := s.DB.ExecContext(ctx, "DELETE FROM egress_clients WHERE id = "+s.ph(1), id)
+	if err != nil {
+		return fmt.Errorf("deleting egress client: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("deleting egress client: %w", err)
+	}
+	if n == 0 {
+		return core.ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) CreateEgressClientToken(ctx context.Context, token *core.EgressClientToken) error {
+	defaultTimestamps(&token.CreatedAt, &token.UpdatedAt)
+	_, err := s.DB.ExecContext(ctx, `
+		INSERT INTO egress_client_tokens (id, client_id, name, hashed_token, expires_at, created_at, updated_at)
+		VALUES (`+s.ph(1)+`, `+s.ph(2)+`, `+s.ph(3)+`, `+s.ph(4)+`, `+s.ph(5)+`, `+s.ph(6)+`, `+s.ph(7)+`)`,
+		token.ID, token.ClientID, token.Name, token.HashedToken,
+		NullableTime(token.ExpiresAt), token.CreatedAt, token.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("inserting egress client token: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) ValidateEgressClientToken(ctx context.Context, hashedToken string) (*core.EgressClientToken, error) {
+	row := s.DB.QueryRowContext(ctx, `
+		SELECT id, client_id, name, hashed_token, expires_at, created_at, updated_at
+		FROM egress_client_tokens WHERE hashed_token = `+s.ph(1)+`
+		AND (expires_at IS NULL OR expires_at > `+s.ph(2)+`)`,
+		hashedToken, time.Now(),
+	)
+	t, err := scanEgressClientToken(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("validating egress client token: %w", err)
+	}
+	return t, nil
+}
+
+func (s *Store) ListEgressClientTokens(ctx context.Context, clientID string) ([]*core.EgressClientToken, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT id, client_id, name, hashed_token, expires_at, created_at, updated_at
+		FROM egress_client_tokens WHERE client_id = `+s.ph(1), clientID)
+	if err != nil {
+		return nil, fmt.Errorf("listing egress client tokens: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tokens []*core.EgressClientToken
+	for rows.Next() {
+		t, err := scanEgressClientToken(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning egress client token row: %w", err)
+		}
+		tokens = append(tokens, t)
+	}
+	return tokens, rows.Err()
+}
+
+func (s *Store) RevokeEgressClientToken(ctx context.Context, clientID, tokenID string) error {
+	result, err := s.DB.ExecContext(ctx,
+		"DELETE FROM egress_client_tokens WHERE id = "+s.ph(1)+" AND client_id = "+s.ph(2),
+		tokenID, clientID,
+	)
+	if err != nil {
+		return fmt.Errorf("revoking egress client token: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("revoking egress client token: %w", err)
+	}
+	if n == 0 {
+		return core.ErrNotFound
+	}
+	return nil
+}


### PR DESCRIPTION
This introduces a first-class persisted resource for machine callers,
closing the first parity gap with OneCLI. `EgressClient` and
`EgressClientToken` provide a management surface for creating,
listing, and deleting machine-caller identities and their bearer
tokens through six new HTTP API endpoints under `/api/v1/egress-clients`.
Tokens are hashed at rest and plaintext is returned only on creation.

The feature is implemented as an optional datastore capability
(`EgressClientStore`), so non-SQL backends are not blocked. All five
in-tree SQL stores (postgres, mysql, sqlite, sqlserver, oracle)
include migrations for the new tables with cascade-delete from clients
to tokens. Authentication of these tokens is deferred to a follow-up
PR that will wire them into the principal resolver and auth middleware.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>