### PR TITLE
feat(plugin): add local packaging, inspection, and store primitives

### DIFF
--- a/cmd/gestaltd/main_test.go
+++ b/cmd/gestaltd/main_test.go
@@ -39,6 +39,9 @@ func TestGestaltd_HelpExitsCleanly(t *testing.T) {
 	if !strings.Contains(string(out), "gestaltd prepare") {
 		t.Fatalf("expected usage output containing 'gestaltd prepare', got: %s", out)
 	}
+	if !strings.Contains(string(out), "gestaltd plugin <command> [flags]") {
+		t.Fatalf("expected usage output containing 'gestaltd plugin <command> [flags]', got: %s", out)
+	}
 	if !strings.Contains(string(out), "gestaltd serve") {
 		t.Fatalf("expected usage output containing 'gestaltd serve', got: %s", out)
 	}
@@ -68,6 +71,18 @@ func TestGestaltdPrepareHelpExitsCleanly(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "gestaltd prepare") {
 		t.Fatalf("expected usage output containing 'gestaltd prepare', got: %s", out)
+	}
+}
+
+func TestGestaltdPluginHelpExitsCleanly(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("go", "run", ".", "plugin", "--help")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected exit 0 for 'plugin --help', got error: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(string(out), "gestaltd plugin <command> [flags]") {
+		t.Fatalf("expected usage output containing 'gestaltd plugin <command> [flags]', got: %s", out)
 	}
 }
 

--- a/cmd/gestaltd/plugin.go
+++ b/cmd/gestaltd/plugin.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/internal/pluginpkg"
+	"github.com/valon-technologies/gestalt/internal/pluginstore"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
+)
+
+func runPlugin(args []string) error {
+	if len(args) == 0 {
+		printPluginUsage(os.Stderr)
+		return flag.ErrHelp
+	}
+
+	switch args[0] {
+	case "-h", "--help", "help":
+		printPluginUsage(os.Stderr)
+		return flag.ErrHelp
+	case "package":
+		return runPluginPackage(args[1:])
+	case "install":
+		return runPluginInstall(args[1:])
+	case "inspect":
+		return runPluginInspect(args[1:])
+	case "list":
+		return runPluginList(args[1:])
+	default:
+		return fmt.Errorf("unknown plugin command %q", args[0])
+	}
+}
+
+func runPluginPackage(args []string) error {
+	fs := flag.NewFlagSet("gestaltd plugin package", flag.ContinueOnError)
+	fs.Usage = func() { printPluginPackageUsage(fs.Output()) }
+	input := fs.String("input", "", "path to plugin manifest or build directory")
+	output := fs.String("output", "", "path to write the packaged archive")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if *input == "" || *output == "" {
+		return fmt.Errorf("usage: gestaltd plugin package --input PATH --output PATH")
+	}
+
+	sourceDir := *input
+	if info, err := os.Stat(*input); err != nil {
+		return err
+	} else if !info.IsDir() {
+		if filepath.Base(*input) != pluginpkg.ManifestFile {
+			return fmt.Errorf("plugin package input must be a directory or %s, got %q", pluginpkg.ManifestFile, *input)
+		}
+		sourceDir = filepath.Dir(*input)
+	}
+
+	if err := pluginpkg.CreatePackageFromDir(sourceDir, *output); err != nil {
+		return err
+	}
+	writeUsageLine(os.Stdout, fmt.Sprintf("packaged %s -> %s", sourceDir, *output))
+	return nil
+}
+
+func runPluginInstall(args []string) error {
+	fs := flag.NewFlagSet("gestaltd plugin install", flag.ContinueOnError)
+	fs.Usage = func() { printPluginInstallUsage(fs.Output()) }
+	configPath := fs.String("config", "", "path to the Gestalt config file")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("usage: gestaltd plugin install [--config PATH] <package>")
+	}
+	store := pluginstore.New(resolveConfigPath(*configPath))
+	installed, err := store.Install(fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	writeUsageLine(os.Stdout, fmt.Sprintf("installed %s -> %s", installed.Ref.String(), installed.ExecutablePath))
+	return nil
+}
+
+func runPluginInspect(args []string) error {
+	fs := flag.NewFlagSet("gestaltd plugin inspect", flag.ContinueOnError)
+	fs.Usage = func() { printPluginInspectUsage(fs.Output()) }
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("usage: gestaltd plugin inspect <package-or-manifest>")
+	}
+	_, manifest, source, err := pluginpkg.LoadManifestFromPath(fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	printManifestSummary(os.Stdout, source, manifest)
+	return nil
+}
+
+func runPluginList(args []string) error {
+	fs := flag.NewFlagSet("gestaltd plugin list", flag.ContinueOnError)
+	fs.Usage = func() { printPluginListUsage(fs.Output()) }
+	configPath := fs.String("config", "", "path to the Gestalt config file")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	store := pluginstore.New(resolveConfigPath(*configPath))
+	installed, err := store.List()
+	if err != nil {
+		return err
+	}
+	for i := range installed {
+		item := installed[i]
+		writeUsageLine(os.Stdout, fmt.Sprintf("%s %s", item.Ref.String(), item.ExecutablePath))
+	}
+	return nil
+}
+
+func printPluginUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd plugin <command> [flags]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Commands:")
+	writeUsageLine(w, "  package     Build a plugin package archive")
+	writeUsageLine(w, "  install     Install a plugin package into the local store")
+	writeUsageLine(w, "  inspect     Inspect a plugin package or installed manifest")
+	writeUsageLine(w, "  list        List installed plugins")
+}
+
+func printPluginPackageUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd plugin package --input PATH --output PATH")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Package a plugin manifest or build directory into a distributable archive.")
+}
+
+func printPluginInstallUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd plugin install [--config PATH] <package>")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Install a packaged plugin into the project-local store.")
+}
+
+func printPluginInspectUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd plugin inspect <package-or-manifest>")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Inspect a plugin package or installed manifest without executing it.")
+}
+
+func printPluginListUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd plugin list [--config PATH]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "List installed plugins for a config-backed project store.")
+}
+
+func printManifestSummary(w io.Writer, source string, manifest *pluginmanifestv1.Manifest) {
+	writeUsageLine(w, fmt.Sprintf("source: %s", source))
+	writeUsageLine(w, fmt.Sprintf("id: %s", manifest.ID))
+	writeUsageLine(w, fmt.Sprintf("version: %s", manifest.Version))
+	writeUsageLine(w, fmt.Sprintf("kinds: %s", strings.Join(pluginpkg.Kinds(manifest), ", ")))
+	if manifest.Provider != nil {
+		writeUsageLine(w, fmt.Sprintf("provider protocol: %d-%d", manifest.Provider.Protocol.Min, manifest.Provider.Protocol.Max))
+		if manifest.Provider.ConfigSchemaPath != "" {
+			writeUsageLine(w, fmt.Sprintf("config schema: %s", manifest.Provider.ConfigSchemaPath))
+		}
+	}
+	for _, artifact := range manifest.Artifacts {
+		writeUsageLine(w, fmt.Sprintf("artifact: %s/%s %s", artifact.OS, artifact.Arch, artifact.Path))
+	}
+}

--- a/cmd/gestaltd/plugin_test.go
+++ b/cmd/gestaltd/plugin_test.go
@@ -1,0 +1,263 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+var stdoutMu sync.Mutex
+
+func TestRun_PluginHelpExitsCleanly(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command("go", "run", ".", "plugin", "--help")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected exit 0 for 'plugin --help', got error: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(string(out), "gestaltd plugin <command> [flags]") {
+		t.Fatalf("expected plugin usage output, got: %s", out)
+	}
+}
+
+func TestRun_PluginPackageHelpExitsCleanly(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command("go", "run", ".", "plugin", "package", "--help")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected exit 0 for 'plugin package --help', got error: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(string(out), "gestaltd plugin package --input PATH --output PATH") {
+		t.Fatalf("expected package usage output, got: %s", out)
+	}
+}
+
+func TestRun_PluginRootReturnsHelpWhenNoSubcommandProvided(t *testing.T) {
+	t.Parallel()
+
+	err := run([]string{"plugin"})
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp, got: %v", err)
+	}
+}
+
+//nolint:paralleltest // Swaps os.Stdout via captureStdout.
+func TestRun_PluginPackageCreatesArchive(t *testing.T) {
+	dir := t.TempDir()
+	src := newPluginPackageFixture(t, dir)
+	outPath := filepath.Join(dir, "acme-provider-0.1.0.tar.gz")
+
+	output := captureStdout(t, func() error {
+		return run([]string{"plugin", "package", "--input", src, "--output", outPath})
+	})
+
+	if _, err := os.Stat(outPath); err != nil {
+		t.Fatalf("expected package archive to exist: %v", err)
+	}
+	if !strings.Contains(output, "packaged") {
+		t.Fatalf("expected package output, got: %q", output)
+	}
+}
+
+//nolint:paralleltest // Swaps os.Stdout via captureStdout.
+func TestRun_PluginInspectPrintsManifestSummary(t *testing.T) {
+	dir := t.TempDir()
+	src := newPluginPackageFixture(t, dir)
+	outPath := filepath.Join(dir, "acme-provider-0.1.0.tar.gz")
+	captureStdout(t, func() error {
+		return run([]string{"plugin", "package", "--input", src, "--output", outPath})
+	})
+
+	output := captureStdout(t, func() error {
+		return run([]string{"plugin", "inspect", outPath})
+	})
+
+	if !strings.Contains(output, "id: acme/provider") {
+		t.Fatalf("expected manifest summary, got: %q", output)
+	}
+	if !strings.Contains(output, "artifact:") {
+		t.Fatalf("expected artifact summary, got: %q", output)
+	}
+}
+
+//nolint:paralleltest // Swaps os.Stdout via captureStdout.
+func TestRun_PluginInstallAndListUseLocalStore(t *testing.T) {
+	dir := t.TempDir()
+	src := newPluginPackageFixture(t, dir)
+	outPath := filepath.Join(dir, "acme-provider-0.1.0.tar.gz")
+	captureStdout(t, func() error {
+		return run([]string{"plugin", "package", "--input", src, "--output", outPath})
+	})
+	configPath := filepath.Join(dir, "config", "gestalt.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		t.Fatalf("MkdirAll(config): %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("auth:\n  provider: google\ndatastore:\n  provider: sqlite\nserver:\n  encryption_key: key123\n"), 0644); err != nil {
+		t.Fatalf("WriteFile(config): %v", err)
+	}
+
+	installOutput := captureStdout(t, func() error {
+		return run([]string{"plugin", "install", "--config", configPath, outPath})
+	})
+	if !strings.Contains(installOutput, "installed acme/provider@0.1.0") {
+		t.Fatalf("expected install output, got: %q", installOutput)
+	}
+
+	executablePath := filepath.Join(filepath.Dir(configPath), ".gestalt", "plugins", "acme", "provider", "0.1.0", "artifacts", runtime.GOOS, runtime.GOARCH, "provider")
+	if _, err := os.Stat(executablePath); err != nil {
+		t.Fatalf("expected installed executable at %s: %v", executablePath, err)
+	}
+
+	listOutput := captureStdout(t, func() error {
+		return run([]string{"plugin", "list", "--config", configPath})
+	})
+	if !strings.Contains(listOutput, "acme/provider@0.1.0") {
+		t.Fatalf("expected list output to contain installed ref, got: %q", listOutput)
+	}
+}
+
+func TestRun_PluginInstallRejectsMissingPackageArgument(t *testing.T) {
+	t.Parallel()
+
+	err := run([]string{"plugin", "install", "--config", "config.yaml"})
+	if err == nil {
+		t.Fatal("expected usage error")
+	}
+	if !strings.Contains(err.Error(), "usage: gestaltd plugin install") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_PluginListRejectsTrailingArguments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "list", args: []string{"plugin", "list", "--config", "config.yaml", "extra"}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := run(tt.args)
+			if err == nil {
+				t.Fatalf("expected error for %s", tt.name)
+			}
+			if !strings.Contains(err.Error(), "unexpected arguments") {
+				t.Fatalf("expected trailing args error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestRun_PluginRejectsUnknownSubcommand(t *testing.T) {
+	t.Parallel()
+
+	err := run([]string{"plugin", "bogus"})
+	if err == nil {
+		t.Fatal("expected error for unknown plugin subcommand")
+	}
+	if !strings.Contains(err.Error(), `unknown plugin command "bogus"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func newPluginPackageFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	src := filepath.Join(dir, "src")
+	artifactDir := filepath.Join(src, "artifacts", runtime.GOOS, runtime.GOARCH)
+	if err := os.MkdirAll(artifactDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(artifactDir, "provider"), []byte("provider"), 0755); err != nil {
+		t.Fatalf("WriteFile(provider): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(src, "schemas"), 0755); err != nil {
+		t.Fatalf("MkdirAll(schemas): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "schemas", "config.schema.json"), []byte(`{"type":"object"}`), 0644); err != nil {
+		t.Fatalf("WriteFile(schema): %v", err)
+	}
+
+	manifest := `{
+  "schema_version": 1,
+  "id": "acme/provider",
+  "version": "0.1.0",
+  "kinds": ["provider"],
+  "provider": {
+    "protocol": { "min": 1, "max": 1 },
+    "config_schema_path": "schemas/config.schema.json"
+  },
+  "artifacts": [
+    {
+      "os": "` + runtime.GOOS + `",
+      "arch": "` + runtime.GOARCH + `",
+      "path": "artifacts/` + runtime.GOOS + `/` + runtime.GOARCH + `/provider",
+      "sha256": "` + sha256HexForTest("provider") + `"
+    }
+  ],
+  "entrypoints": {
+    "provider": {
+      "artifact_path": "artifacts/` + runtime.GOOS + `/` + runtime.GOARCH + `/provider"
+    }
+  }
+}`
+	if err := os.WriteFile(filepath.Join(src, "plugin.json"), []byte(manifest), 0644); err != nil {
+		t.Fatalf("WriteFile(plugin.json): %v", err)
+	}
+	return src
+}
+
+func captureStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+
+	// This helper swaps the process-global os.Stdout, so callers must not run in
+	// parallel with other tests in this package.
+	stdoutMu.Lock()
+	defer stdoutMu.Unlock()
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+
+	runErr := fn()
+
+	_ = w.Close()
+	os.Stdout = orig
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("copy stdout: %v", err)
+	}
+	_ = r.Close()
+
+	if runErr != nil {
+		t.Fatalf("run: %v", runErr)
+	}
+	return buf.String()
+}
+
+func sha256HexForTest(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}

--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -30,6 +30,8 @@ func run(args []string) error {
 		case "-h", "--help", "help":
 			printMainUsage(os.Stderr)
 			return flag.ErrHelp
+		case "plugin":
+			return runPlugin(args[1:])
 		case "dev":
 			return runDev(args[1:])
 		case "serve":
@@ -304,12 +306,14 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
 	writeUsageLine(w, "  gestaltd [--config PATH]")
 	writeUsageLine(w, "  gestaltd dev [--config PATH]")
+	writeUsageLine(w, "  gestaltd plugin <command> [flags]")
 	writeUsageLine(w, "  gestaltd serve [--config PATH]")
 	writeUsageLine(w, "  gestaltd prepare [--config PATH]")
 	writeUsageLine(w, "  gestaltd validate [--config PATH]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
 	writeUsageLine(w, "  dev         Refresh prepared provider artifacts if needed, then start the server")
+	writeUsageLine(w, "  plugin      Package, install, inspect, or list plugins")
 	writeUsageLine(w, "  serve       Start the server with prepared REST/GraphQL providers only")
 	writeUsageLine(w, "  prepare     Resolve remote REST/GraphQL upstreams into gestalt.lock.json and .gestalt/providers/")
 	writeUsageLine(w, "  validate    Load and validate configuration, then exit")

--- a/internal/pluginpkg/archive.go
+++ b/internal/pluginpkg/archive.go
@@ -1,0 +1,300 @@
+package pluginpkg
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
+)
+
+func ReadPackageManifest(packagePath string) (_ []byte, _ *pluginmanifestv1.Manifest, err error) {
+	data, err := ReadArchiveEntry(packagePath, ManifestFile)
+	if err != nil {
+		return nil, nil, err
+	}
+	manifest, err := DecodeManifest(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, manifest, nil
+}
+
+func ReadManifestFile(path string) ([]byte, *pluginmanifestv1.Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read manifest %q: %w", path, err)
+	}
+	manifest, err := DecodeManifest(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, manifest, nil
+}
+
+func LoadManifestFromPath(inputPath string) ([]byte, *pluginmanifestv1.Manifest, string, error) {
+	info, err := os.Stat(inputPath)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("stat %q: %w", inputPath, err)
+	}
+	if info.IsDir() {
+		manifestPath := filepath.Join(inputPath, ManifestFile)
+		data, manifest, err := ReadManifestFile(manifestPath)
+		return data, manifest, manifestPath, err
+	}
+	if filepath.Base(inputPath) == ManifestFile {
+		data, manifest, err := ReadManifestFile(inputPath)
+		return data, manifest, inputPath, err
+	}
+	data, manifest, err := ReadPackageManifest(inputPath)
+	return data, manifest, inputPath, err
+}
+
+func CreatePackageFromDir(sourceDir, outputPath string) (err error) {
+	sourceDir = filepath.Clean(sourceDir)
+	if _, err := ValidatePackageDir(sourceDir); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+	out, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("create package %q: %w", outputPath, err)
+	}
+	defer joinCloseError(&err, fmt.Sprintf("close package %q", outputPath), out)
+
+	gzw := gzip.NewWriter(out)
+	defer joinCloseError(&err, "close gzip stream", gzw)
+
+	tw := tar.NewWriter(gzw)
+	defer joinCloseError(&err, "close tar stream", tw)
+
+	var files []string
+	err = filepath.WalkDir(sourceDir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(sourceDir, p)
+		if err != nil {
+			return err
+		}
+		files = append(files, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("walk source dir: %w", err)
+	}
+	slices.Sort(files)
+
+	for _, rel := range files {
+		absPath := filepath.Join(sourceDir, filepath.FromSlash(rel))
+		info, err := os.Stat(absPath)
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", rel, err)
+		}
+		hdr, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return fmt.Errorf("build tar header for %s: %w", rel, err)
+		}
+		hdr.Name = rel
+		if err := tw.WriteHeader(hdr); err != nil {
+			return fmt.Errorf("write tar header for %s: %w", rel, err)
+		}
+		f, err := os.Open(absPath)
+		if err != nil {
+			return fmt.Errorf("open %s: %w", rel, err)
+		}
+		if _, err := io.Copy(tw, f); err != nil {
+			_ = f.Close()
+			return fmt.Errorf("write %s: %w", rel, err)
+		}
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("close %s: %w", rel, err)
+		}
+	}
+
+	return nil
+}
+
+func ExtractPackage(packagePath, destDir string) (err error) {
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return fmt.Errorf("create destination dir: %w", err)
+	}
+
+	file, err := os.Open(packagePath)
+	if err != nil {
+		return fmt.Errorf("open package %q: %w", packagePath, err)
+	}
+	defer joinCloseError(&err, fmt.Sprintf("close package %q", packagePath), file)
+
+	gzr, err := gzip.NewReader(file)
+	if err != nil {
+		return fmt.Errorf("open gzip stream: %w", err)
+	}
+	defer joinCloseError(&err, "close gzip stream", gzr)
+
+	tr := tar.NewReader(gzr)
+	seen := make(map[string]struct{})
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read tar stream: %w", err)
+		}
+
+		rel, err := archiveEntryPath(hdr.Name)
+		if err != nil {
+			return err
+		}
+		if _, ok := seen[rel]; ok {
+			return fmt.Errorf("archive entry %q appears more than once", rel)
+		}
+		seen[rel] = struct{}{}
+		target := filepath.Join(destDir, filepath.FromSlash(rel))
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, os.FileMode(hdr.Mode)); err != nil {
+				return fmt.Errorf("create directory %s: %w", rel, err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return fmt.Errorf("create parent dir for %s: %w", rel, err)
+			}
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(hdr.Mode))
+			if err != nil {
+				return fmt.Errorf("create file %s: %w", rel, err)
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				_ = f.Close()
+				return fmt.Errorf("extract file %s: %w", rel, err)
+			}
+			if err := f.Close(); err != nil {
+				return fmt.Errorf("close file %s: %w", rel, err)
+			}
+		default:
+			return fmt.Errorf("unsupported tar entry type for %s", rel)
+		}
+	}
+}
+
+func ReadArchiveEntry(packagePath, wanted string) (_ []byte, err error) {
+	file, err := os.Open(packagePath)
+	if err != nil {
+		return nil, fmt.Errorf("open package %q: %w", packagePath, err)
+	}
+	defer joinCloseError(&err, fmt.Sprintf("close package %q", packagePath), file)
+
+	gzr, err := gzip.NewReader(file)
+	if err != nil {
+		return nil, fmt.Errorf("open gzip stream: %w", err)
+	}
+	defer joinCloseError(&err, "close gzip stream", gzr)
+
+	tr := tar.NewReader(gzr)
+	var found []byte
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read tar stream: %w", err)
+		}
+		if hdr.FileInfo().IsDir() {
+			continue
+		}
+		name, err := archiveEntryPath(hdr.Name)
+		if err != nil {
+			return nil, err
+		}
+		if name != wanted {
+			continue
+		}
+		if found != nil {
+			return nil, fmt.Errorf("archive entry %q appears more than once", wanted)
+		}
+		found, err = io.ReadAll(tr)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", wanted, err)
+		}
+	}
+	if found == nil {
+		return nil, fmt.Errorf("package %q does not contain %s", packagePath, wanted)
+	}
+	return found, nil
+}
+
+func ValidatePackageDir(sourceDir string) (*pluginmanifestv1.Manifest, error) {
+	_, manifest, err := loadManifestFromDir(sourceDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, artifact := range manifest.Artifacts {
+		path := filepath.Join(sourceDir, filepath.FromSlash(artifact.Path))
+		sum, err := fileSHA256(path)
+		if err != nil {
+			return nil, fmt.Errorf("validate artifact %s: %w", artifact.Path, err)
+		}
+		if sum != artifact.SHA256 {
+			return nil, fmt.Errorf("artifact %s sha256 %s does not match manifest %s", artifact.Path, sum, artifact.SHA256)
+		}
+	}
+	if manifest.Provider != nil && manifest.Provider.ConfigSchemaPath != "" {
+		schemaPath := filepath.Join(sourceDir, filepath.FromSlash(manifest.Provider.ConfigSchemaPath))
+		if _, err := os.Stat(schemaPath); err != nil {
+			return nil, fmt.Errorf("validate provider config schema %s: %w", manifest.Provider.ConfigSchemaPath, err)
+		}
+	}
+	return manifest, nil
+}
+
+func loadManifestFromDir(sourceDir string) ([]byte, *pluginmanifestv1.Manifest, error) {
+	return ReadManifestFile(filepath.Join(sourceDir, ManifestFile))
+}
+
+func archiveEntryPath(name string) (string, error) {
+	if strings.Contains(name, "\\") {
+		return "", fmt.Errorf("archive entry %q must use forward slashes", name)
+	}
+	cleaned := path.Clean(strings.TrimPrefix(name, "./"))
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("archive entry %q escapes the package root", name)
+	}
+	return cleaned, nil
+}
+
+func fileSHA256(path string) (_ string, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer joinCloseError(&err, fmt.Sprintf("close %q", path), f)
+	sum := sha256.New()
+	if _, err := io.Copy(sum, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(sum.Sum(nil)), nil
+}
+
+func joinCloseError(errp *error, label string, closer io.Closer) {
+	if closeErr := closer.Close(); closeErr != nil {
+		*errp = errors.Join(*errp, fmt.Errorf("%s: %w", label, closeErr))
+	}
+}

--- a/internal/pluginpkg/archive_test.go
+++ b/internal/pluginpkg/archive_test.go
@@ -1,0 +1,61 @@
+package pluginpkg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCreatePackageFromDirAndReadManifest(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(filepath.Join(src, "artifacts", "darwin", "arm64"), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "artifacts", "darwin", "arm64", "provider"), []byte("provider"), 0755); err != nil {
+		t.Fatalf("WriteFile(provider): %v", err)
+	}
+	manifest := `{
+  "schema_version": 1,
+  "id": "acme/provider",
+  "version": "0.1.0",
+  "kinds": ["provider"],
+  "provider": {
+    "protocol": { "min": 1, "max": 1 }
+  },
+  "artifacts": [
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "path": "artifacts/darwin/arm64/provider",
+      "sha256": "` + sha256Hex("provider") + `"
+    }
+  ],
+  "entrypoints": {
+    "provider": {
+      "artifact_path": "artifacts/darwin/arm64/provider"
+    }
+  }
+}`
+	if err := os.WriteFile(filepath.Join(src, ManifestFile), []byte(manifest), 0644); err != nil {
+		t.Fatalf("WriteFile(plugin.json): %v", err)
+	}
+
+	archivePath := filepath.Join(dir, "acme-provider-0.1.0.tar.gz")
+	if err := CreatePackageFromDir(src, archivePath); err != nil {
+		t.Fatalf("CreatePackageFromDir: %v", err)
+	}
+
+	data, parsed, err := ReadPackageManifest(archivePath)
+	if err != nil {
+		t.Fatalf("ReadPackageManifest: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected manifest bytes")
+	}
+	if parsed.ID != "acme/provider" {
+		t.Fatalf("unexpected id %q", parsed.ID)
+	}
+}

--- a/internal/pluginpkg/manifest.go
+++ b/internal/pluginpkg/manifest.go
@@ -1,0 +1,184 @@
+package pluginpkg
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"path"
+	"runtime"
+	"slices"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
+)
+
+const ManifestFile = "plugin.json"
+
+func DecodeManifest(data []byte) (*pluginmanifestv1.Manifest, error) {
+	var doc any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse manifest JSON: %w", err)
+	}
+	var schemaDoc any
+	if err := json.Unmarshal(pluginmanifestv1.ManifestJSONSchema, &schemaDoc); err != nil {
+		return nil, fmt.Errorf("parse embedded manifest schema: %w", err)
+	}
+
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("manifest.schema.json", schemaDoc); err != nil {
+		return nil, fmt.Errorf("load manifest schema: %w", err)
+	}
+	schema, err := compiler.Compile("manifest.schema.json")
+	if err != nil {
+		return nil, fmt.Errorf("compile manifest schema: %w", err)
+	}
+	if err := schema.Validate(doc); err != nil {
+		return nil, fmt.Errorf("manifest validation failed: %w", err)
+	}
+
+	var manifest pluginmanifestv1.Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("decode manifest: %w", err)
+	}
+	if err := ValidateManifest(&manifest); err != nil {
+		return nil, err
+	}
+	return &manifest, nil
+}
+
+func ValidateManifest(manifest *pluginmanifestv1.Manifest) error {
+	if manifest == nil {
+		return fmt.Errorf("manifest is required")
+	}
+	if manifest.SchemaVersion != pluginmanifestv1.SchemaVersion {
+		return fmt.Errorf("manifest schema_version must be %d", pluginmanifestv1.SchemaVersion)
+	}
+
+	artifactPaths := make(map[string]struct{}, len(manifest.Artifacts))
+	artifactPlatforms := make(map[string]struct{}, len(manifest.Artifacts))
+	for _, artifact := range manifest.Artifacts {
+		if err := validateRelativePackagePath(artifact.Path, "artifact path"); err != nil {
+			return err
+		}
+		if _, exists := artifactPaths[artifact.Path]; exists {
+			return fmt.Errorf("duplicate artifact path %q", artifact.Path)
+		}
+		artifactPaths[artifact.Path] = struct{}{}
+
+		key := artifact.OS + "/" + artifact.Arch
+		if _, exists := artifactPlatforms[key]; exists {
+			return fmt.Errorf("duplicate artifact platform %q", key)
+		}
+		artifactPlatforms[key] = struct{}{}
+	}
+
+	for _, kind := range manifest.Kinds {
+		switch kind {
+		case pluginmanifestv1.KindProvider:
+			if manifest.Provider == nil {
+				return fmt.Errorf("provider metadata is required when kind %q is present", pluginmanifestv1.KindProvider)
+			}
+			if manifest.Provider.Protocol.Min > manifest.Provider.Protocol.Max {
+				return fmt.Errorf("provider.protocol.min must be <= provider.protocol.max")
+			}
+			if manifest.Provider.ConfigSchemaPath != "" {
+				if err := validateRelativePackagePath(manifest.Provider.ConfigSchemaPath, "provider config schema path"); err != nil {
+					return err
+				}
+			}
+			if err := validateEntrypoint(kind, manifest.Entrypoints.Provider, artifactPaths); err != nil {
+				return err
+			}
+		case pluginmanifestv1.KindRuntime:
+			if err := validateEntrypoint(kind, manifest.Entrypoints.Runtime, artifactPaths); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported manifest kind %q", kind)
+		}
+	}
+
+	return nil
+}
+
+func CurrentPlatformArtifact(manifest *pluginmanifestv1.Manifest) (*pluginmanifestv1.Artifact, error) {
+	if manifest == nil {
+		return nil, fmt.Errorf("manifest is required")
+	}
+	for _, artifact := range manifest.Artifacts {
+		if artifact.OS == runtime.GOOS && artifact.Arch == runtime.GOARCH {
+			artifact := artifact
+			return &artifact, nil
+		}
+	}
+	return nil, fmt.Errorf("no artifact for current platform %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+func validateEntrypoint(kind string, entry *pluginmanifestv1.Entrypoint, artifactPaths map[string]struct{}) error {
+	if entry == nil {
+		return fmt.Errorf("%s entrypoint is required", kind)
+	}
+	if err := validateRelativePackagePath(entry.ArtifactPath, kind+" entrypoint artifact path"); err != nil {
+		return err
+	}
+	if _, ok := artifactPaths[entry.ArtifactPath]; !ok {
+		return fmt.Errorf("%s entrypoint references unknown artifact %q", kind, entry.ArtifactPath)
+	}
+	return nil
+}
+
+func validateRelativePackagePath(value, label string) error {
+	if value == "" {
+		return fmt.Errorf("%s is required", label)
+	}
+	if strings.HasPrefix(value, "/") {
+		return fmt.Errorf("%s must be relative", label)
+	}
+	cleaned := path.Clean(value)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return fmt.Errorf("%s must stay within the package", label)
+	}
+	if strings.Contains(value, "\\") {
+		return fmt.Errorf("%s must use forward slashes", label)
+	}
+	if cleaned != value {
+		return fmt.Errorf("%s must be normalized", label)
+	}
+	return nil
+}
+
+func EncodeManifest(manifest *pluginmanifestv1.Manifest) ([]byte, error) {
+	if err := ValidateManifest(manifest); err != nil {
+		return nil, err
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal manifest: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+func Kinds(manifest *pluginmanifestv1.Manifest) []string {
+	if manifest == nil {
+		return nil
+	}
+	out := append([]string(nil), manifest.Kinds...)
+	slices.Sort(out)
+	return out
+}
+
+func ManifestEqual(a, b *pluginmanifestv1.Manifest) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	aj, err := EncodeManifest(a)
+	if err != nil {
+		return false
+	}
+	bj, err := EncodeManifest(b)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(aj, bj)
+}

--- a/internal/pluginpkg/manifest_test.go
+++ b/internal/pluginpkg/manifest_test.go
@@ -1,0 +1,122 @@
+package pluginpkg
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
+)
+
+func TestDecodeManifest_ValidProviderManifest(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+  "schema_version": 1,
+  "id": "acme/provider",
+  "version": "0.1.0",
+  "kinds": ["provider"],
+  "provider": {
+    "protocol": { "min": 1, "max": 1 },
+    "config_schema_path": "schemas/config.schema.json"
+  },
+  "artifacts": [
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "path": "artifacts/darwin/arm64/provider",
+      "sha256": "` + sha256Hex("provider") + `"
+    }
+  ],
+  "entrypoints": {
+    "provider": {
+      "artifact_path": "artifacts/darwin/arm64/provider",
+      "args": []
+    }
+  }
+}`)
+
+	manifest, err := DecodeManifest(data)
+	if err != nil {
+		t.Fatalf("DecodeManifest: %v", err)
+	}
+	if manifest.ID != "acme/provider" {
+		t.Fatalf("unexpected manifest id %q", manifest.ID)
+	}
+}
+
+func TestDecodeManifest_RejectsMissingEntrypointArtifact(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+  "schema_version": 1,
+  "id": "acme/provider",
+  "version": "0.1.0",
+  "kinds": ["provider"],
+  "provider": {
+    "protocol": { "min": 1, "max": 1 }
+  },
+  "artifacts": [
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "path": "artifacts/darwin/arm64/provider",
+      "sha256": "` + sha256Hex("provider") + `"
+    }
+  ],
+  "entrypoints": {
+    "provider": {
+      "artifact_path": "artifacts/linux/amd64/provider"
+    }
+  }
+}`)
+
+	_, err := DecodeManifest(data)
+	if err == nil {
+		t.Fatal("expected invalid manifest")
+	}
+}
+
+func TestEncodeManifest_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	manifest := &pluginmanifestv1.Manifest{
+		SchemaVersion: pluginmanifestv1.SchemaVersion,
+		ID:            "acme/provider",
+		Version:       "0.1.0",
+		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     "darwin",
+				Arch:   "arm64",
+				Path:   "artifacts/darwin/arm64/provider",
+				SHA256: sha256Hex("provider"),
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{
+				ArtifactPath: "artifacts/darwin/arm64/provider",
+			},
+		},
+	}
+
+	data, err := EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	got, err := DecodeManifest(data)
+	if err != nil {
+		t.Fatalf("DecodeManifest: %v", err)
+	}
+	if !ManifestEqual(manifest, got) {
+		t.Fatal("manifest changed across round trip")
+	}
+}
+
+func sha256Hex(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/pluginstore/store.go
+++ b/internal/pluginstore/store.go
@@ -1,0 +1,289 @@
+package pluginstore
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	pluginpkg "github.com/valon-technologies/gestalt/internal/pluginpkg"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
+)
+
+var refPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9._+:-]*$`)
+
+type Ref struct {
+	Publisher string
+	Name      string
+	Version   string
+}
+
+func ParseRef(raw string) (Ref, error) {
+	if strings.TrimSpace(raw) != raw {
+		return Ref{}, fmt.Errorf("invalid plugin ref %q: leading or trailing whitespace is not allowed", raw)
+	}
+	if !refPattern.MatchString(raw) {
+		return Ref{}, fmt.Errorf("invalid plugin ref %q: expected publisher/name@version", raw)
+	}
+
+	left, version, ok := strings.Cut(raw, "@")
+	if !ok || version == "" {
+		return Ref{}, fmt.Errorf("invalid plugin ref %q: expected publisher/name@version", raw)
+	}
+	publisher, name, ok := strings.Cut(left, "/")
+	if !ok || publisher == "" || name == "" {
+		return Ref{}, fmt.Errorf("invalid plugin ref %q: expected publisher/name@version", raw)
+	}
+
+	return Ref{Publisher: publisher, Name: name, Version: version}, nil
+}
+
+func (r Ref) String() string {
+	if r.Publisher == "" && r.Name == "" && r.Version == "" {
+		return ""
+	}
+	return r.Publisher + "/" + r.Name + "@" + r.Version
+}
+
+func (r Ref) IsZero() bool {
+	return r.Publisher == "" && r.Name == "" && r.Version == ""
+}
+
+func storeRootForConfigPath(configPath string) string {
+	if configPath == "" {
+		return filepath.Join(".gestalt", "plugins")
+	}
+	return filepath.Join(filepath.Dir(configPath), ".gestalt", "plugins")
+}
+
+type Store struct {
+	root string
+}
+
+func New(configPath string) *Store {
+	return &Store{root: storeRootForConfigPath(configPath)}
+}
+
+func (s *Store) Root() string {
+	if s == nil {
+		return ""
+	}
+	return s.root
+}
+
+type InstalledPlugin struct {
+	Ref            Ref
+	Root           string
+	ManifestPath   string
+	ExecutablePath string
+	ArtifactPath   string
+	SHA256         string
+	Manifest       *pluginmanifestv1.Manifest
+	Artifact       *pluginmanifestv1.Artifact
+}
+
+func (s *Store) Install(packagePath string) (*InstalledPlugin, error) {
+	if s == nil {
+		return nil, fmt.Errorf("store is required")
+	}
+	_, manifest, err := pluginpkg.ReadPackageManifest(packagePath)
+	if err != nil {
+		return nil, err
+	}
+	ref, err := refFromManifest(manifest)
+	if err != nil {
+		return nil, err
+	}
+	artifact, err := pluginpkg.CurrentPlatformArtifact(manifest)
+	if err != nil {
+		return nil, err
+	}
+	artifactBytes, err := pluginpkg.ReadArchiveEntry(packagePath, artifact.Path)
+	if err != nil {
+		return nil, err
+	}
+	sum := sha256.Sum256(artifactBytes)
+	if got := hex.EncodeToString(sum[:]); got != artifact.SHA256 {
+		return nil, fmt.Errorf("artifact digest mismatch for %s: package has %s, manifest expects %s", artifact.Path, got, artifact.SHA256)
+	}
+
+	root := s.root
+	if root == "" {
+		return nil, fmt.Errorf("store root is required")
+	}
+	destDir := filepath.Join(root, ref.Publisher, ref.Name, ref.Version)
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return nil, fmt.Errorf("create plugin directory: %w", err)
+	}
+	if err := pluginpkg.ExtractPackage(packagePath, destDir); err != nil {
+		return nil, err
+	}
+
+	manifestPath := filepath.Join(destDir, pluginpkg.ManifestFile)
+	executablePath, err := executablePathForManifest(destDir, manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	installed := &InstalledPlugin{
+		Ref:            ref,
+		Root:           destDir,
+		ManifestPath:   manifestPath,
+		ExecutablePath: executablePath,
+		ArtifactPath:   artifact.Path,
+		SHA256:         artifact.SHA256,
+		Manifest:       manifest,
+		Artifact:       artifact,
+	}
+	return installed, nil
+}
+
+func (s *Store) List() ([]InstalledPlugin, error) {
+	if s == nil {
+		return nil, fmt.Errorf("store is required")
+	}
+	root := s.root
+	if root == "" {
+		return nil, fmt.Errorf("store root is required")
+	}
+	if _, err := os.Stat(root); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat store root: %w", err)
+	}
+
+	var items []InstalledPlugin
+	pattern := filepath.Join(root, "*", "*", "*", pluginpkg.ManifestFile)
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("list plugin manifests: %w", err)
+	}
+	for _, manifestPath := range matches {
+		data, err := os.ReadFile(manifestPath)
+		if err != nil {
+			return nil, fmt.Errorf("read manifest %s: %w", manifestPath, err)
+		}
+		manifest, err := pluginpkg.DecodeManifest(data)
+		if err != nil {
+			return nil, fmt.Errorf("decode manifest %s: %w", manifestPath, err)
+		}
+		ref, err := refFromManifest(manifest)
+		if err != nil {
+			return nil, err
+		}
+		artifact, err := pluginpkg.CurrentPlatformArtifact(manifest)
+		if err != nil {
+			return nil, err
+		}
+		executablePath, err := executablePathForManifest(filepath.Dir(manifestPath), manifest)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, InstalledPlugin{
+			Ref:            ref,
+			Root:           filepath.Dir(manifestPath),
+			ManifestPath:   manifestPath,
+			ExecutablePath: executablePath,
+			ArtifactPath:   artifact.Path,
+			SHA256:         artifact.SHA256,
+			Manifest:       manifest,
+			Artifact:       artifact,
+		})
+	}
+
+	slices.SortFunc(items, func(a, b InstalledPlugin) int {
+		return strings.Compare(a.Ref.String(), b.Ref.String())
+	})
+	return items, nil
+}
+
+func (s *Store) Resolve(ref Ref) (*InstalledPlugin, error) {
+	if s == nil {
+		return nil, fmt.Errorf("store is required")
+	}
+	if ref.IsZero() {
+		return nil, fmt.Errorf("plugin ref is required")
+	}
+	root := filepath.Join(s.root, ref.Publisher, ref.Name, ref.Version)
+	manifestPath := filepath.Join(root, pluginpkg.ManifestFile)
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("read installed manifest %q: %w", manifestPath, err)
+	}
+	manifest, err := pluginpkg.DecodeManifest(data)
+	if err != nil {
+		return nil, fmt.Errorf("decode installed manifest %q: %w", manifestPath, err)
+	}
+	installedRef, err := refFromManifest(manifest)
+	if err != nil {
+		return nil, err
+	}
+	if installedRef != ref {
+		return nil, fmt.Errorf("installed plugin %s does not match requested ref %s", installedRef, ref)
+	}
+	artifact, err := pluginpkg.CurrentPlatformArtifact(manifest)
+	if err != nil {
+		return nil, err
+	}
+	executablePath, err := executablePathForManifest(root, manifest)
+	if err != nil {
+		return nil, err
+	}
+	return &InstalledPlugin{
+		Ref:            ref,
+		Root:           root,
+		ManifestPath:   manifestPath,
+		ExecutablePath: executablePath,
+		ArtifactPath:   artifact.Path,
+		SHA256:         artifact.SHA256,
+		Manifest:       manifest,
+		Artifact:       artifact,
+	}, nil
+}
+
+func RootForConfigPath(configPath string) string {
+	return storeRootForConfigPath(configPath)
+}
+
+func refFromManifest(manifest *pluginmanifestv1.Manifest) (Ref, error) {
+	if manifest == nil {
+		return Ref{}, fmt.Errorf("manifest is required")
+	}
+	ref, err := ParseRef(manifest.ID + "@" + manifest.Version)
+	if err != nil {
+		return Ref{}, fmt.Errorf("manifest id/version must form a valid plugin ref: %w", err)
+	}
+	return ref, nil
+}
+
+func executablePathForManifest(root string, manifest *pluginmanifestv1.Manifest) (string, error) {
+	if manifest == nil {
+		return "", fmt.Errorf("manifest is required")
+	}
+	var entry *pluginmanifestv1.Entrypoint
+	for _, kind := range manifest.Kinds {
+		switch kind {
+		case pluginmanifestv1.KindProvider:
+			entry = manifest.Entrypoints.Provider
+		case pluginmanifestv1.KindRuntime:
+			entry = manifest.Entrypoints.Runtime
+		default:
+			continue
+		}
+		if entry != nil {
+			break
+		}
+	}
+	if entry == nil {
+		return "", fmt.Errorf("manifest does not define an executable entrypoint")
+	}
+	if entry.ArtifactPath == "" {
+		return "", fmt.Errorf("manifest entrypoint artifact_path is required")
+	}
+	return filepath.Join(root, filepath.FromSlash(entry.ArtifactPath)), nil
+}

--- a/internal/pluginstore/store_test.go
+++ b/internal/pluginstore/store_test.go
@@ -1,0 +1,361 @@
+package pluginstore
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	pluginpkg "github.com/valon-technologies/gestalt/internal/pluginpkg"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
+)
+
+func TestRootForConfigPath(t *testing.T) {
+	t.Parallel()
+
+	got := RootForConfigPath("/tmp/project/configs/gestalt.yaml")
+	want := filepath.Join("/tmp/project/configs", ".gestalt", "plugins")
+	if got != want {
+		t.Fatalf("RootForConfigPath = %q, want %q", got, want)
+	}
+}
+
+func TestParseRef(t *testing.T) {
+	t.Parallel()
+
+	ref, err := ParseRef("acme/provider@0.1.0")
+	if err != nil {
+		t.Fatalf("ParseRef: %v", err)
+	}
+	if ref.Publisher != "acme" || ref.Name != "provider" || ref.Version != "0.1.0" {
+		t.Fatalf("unexpected ref: %+v", ref)
+	}
+
+	for _, raw := range []string{"", "acme/provider", "acme@0.1.0", " acme/provider@0.1.0 ", "acme/provider@", "acme//provider@0.1.0"} {
+		if _, err := ParseRef(raw); err == nil {
+			t.Fatalf("expected ParseRef(%q) to fail", raw)
+		}
+	}
+}
+
+func TestInstallAndList(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "configs", "gestalt.yaml")
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	store := New(cfgPath)
+	pkg1 := mustBuildPackage(t, dir, "acme/provider", "0.1.0", "hello from acme")
+	pkg2 := mustBuildPackage(t, dir, "beta/provider", "1.2.3", "hello from beta")
+
+	installed1, err := store.Install(pkg1)
+	if err != nil {
+		t.Fatalf("Install pkg1: %v", err)
+	}
+	if installed1.Ref.String() != "acme/provider@0.1.0" {
+		t.Fatalf("installed ref = %q", installed1.Ref.String())
+	}
+	if installed1.Manifest == nil || installed1.Manifest.ID != "acme/provider" {
+		t.Fatalf("unexpected installed manifest: %+v", installed1.Manifest)
+	}
+	if installed1.ManifestPath != filepath.Join(store.Root(), "acme", "provider", "0.1.0", pluginpkg.ManifestFile) {
+		t.Fatalf("ManifestPath = %q", installed1.ManifestPath)
+	}
+	if installed1.ExecutablePath != filepath.Join(store.Root(), "acme", "provider", "0.1.0", "artifacts", runtime.GOOS, runtime.GOARCH, "provider") {
+		t.Fatalf("ExecutablePath = %q", installed1.ExecutablePath)
+	}
+	data, err := os.ReadFile(installed1.ExecutablePath)
+	if err != nil {
+		t.Fatalf("ReadFile executable: %v", err)
+	}
+	if string(data) != "hello from acme" {
+		t.Fatalf("unexpected executable content: %q", data)
+	}
+
+	installed2, err := store.Install(pkg2)
+	if err != nil {
+		t.Fatalf("Install pkg2: %v", err)
+	}
+	if installed2.Ref.String() != "beta/provider@1.2.3" {
+		t.Fatalf("installed ref = %q", installed2.Ref.String())
+	}
+
+	listed, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(listed) != 2 {
+		t.Fatalf("List returned %d items, want 2", len(listed))
+	}
+	if listed[0].Ref.String() != "acme/provider@0.1.0" || listed[1].Ref.String() != "beta/provider@1.2.3" {
+		t.Fatalf("unexpected list order: %s, %s", listed[0].Ref.String(), listed[1].Ref.String())
+	}
+
+	resolved, err := store.Resolve(installed1.Ref)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if resolved.ExecutablePath != installed1.ExecutablePath {
+		t.Fatalf("resolved executable path = %q, want %q", resolved.ExecutablePath, installed1.ExecutablePath)
+	}
+}
+
+func TestInstallRejectsDigestMismatch(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	store := New(cfgPath)
+
+	pkg := mustBuildMismatchPackage(t, dir, "acme/provider", "0.1.0", "hello", strings.Repeat("deadbeef", 8))
+	_, err := store.Install(pkg)
+	if err == nil {
+		t.Fatal("expected digest mismatch error")
+	}
+	if !strings.Contains(err.Error(), "digest mismatch") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestInstallRejectsUnsafeManifestVersion(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	store := New(cfgPath)
+
+	pkg := mustBuildPackage(t, dir, "acme/provider", "../evil", "hello")
+	_, err := store.Install(pkg)
+	if err == nil {
+		t.Fatal("expected invalid manifest version error")
+	}
+	if !strings.Contains(err.Error(), "valid plugin ref") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestInstallRejectsDuplicateArtifactEntries(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	store := New(cfgPath)
+
+	pkg := mustBuildPackageWithDuplicateArtifact(t, dir, "acme/provider", "0.1.0", "good", "evil")
+	_, err := store.Install(pkg)
+	if err == nil {
+		t.Fatal("expected duplicate artifact entry error")
+	}
+	if !strings.Contains(err.Error(), "appears more than once") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func mustBuildPackage(t *testing.T, dir, id, version, content string) string {
+	t.Helper()
+	return mustBuildPackageWithDigest(t, dir, id, version, content, "")
+}
+
+func mustBuildPackageWithDigest(t *testing.T, dir, id, version, content, digestOverride string) string {
+	t.Helper()
+
+	source := filepath.Join(dir, strings.NewReplacer("/", "-", "@", "-", ".", "_").Replace(id+"-"+version))
+	if err := os.MkdirAll(filepath.Join(source, "artifacts", runtime.GOOS, runtime.GOARCH), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	artifactPath := filepath.Join(source, "artifacts", runtime.GOOS, runtime.GOARCH, "provider")
+	if err := os.WriteFile(artifactPath, []byte(content), 0755); err != nil {
+		t.Fatalf("WriteFile artifact: %v", err)
+	}
+	sum := sha256.Sum256([]byte(content))
+	digest := hex.EncodeToString(sum[:])
+	if digestOverride != "" {
+		digest = digestOverride
+	}
+	manifest := &pluginmanifestv1.Manifest{
+		SchemaVersion: pluginmanifestv1.SchemaVersion,
+		ID:            id,
+		Version:       version,
+		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				Path:   filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider")),
+				SHA256: digest,
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{
+				ArtifactPath: filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider")),
+			},
+		},
+	}
+	manifestBytes, err := pluginpkg.EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(source, pluginpkg.ManifestFile), manifestBytes, 0644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	archivePath := filepath.Join(dir, filepath.Base(source)+".tar.gz")
+	if err := pluginpkg.CreatePackageFromDir(source, archivePath); err != nil {
+		t.Fatalf("CreatePackageFromDir: %v", err)
+	}
+	return archivePath
+}
+
+func mustBuildMismatchPackage(t *testing.T, dir, id, version, content, digest string) string {
+	t.Helper()
+
+	manifest := &pluginmanifestv1.Manifest{
+		SchemaVersion: pluginmanifestv1.SchemaVersion,
+		ID:            id,
+		Version:       version,
+		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				Path:   filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider")),
+				SHA256: digest,
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{
+				ArtifactPath: filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider")),
+			},
+		},
+	}
+	manifestBytes, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent manifest: %v", err)
+	}
+	manifestBytes = append(manifestBytes, '\n')
+
+	archivePath := filepath.Join(dir, "mismatch.tar.gz")
+	out, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("Create archive: %v", err)
+	}
+	gzw := gzip.NewWriter(out)
+	tw := tar.NewWriter(gzw)
+
+	writeFile := func(name string, data []byte, mode int64) {
+		hdr := &tar.Header{Name: name, Mode: mode, Size: int64(len(data))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("WriteHeader %s: %v", name, err)
+		}
+		if _, err := io.Copy(tw, bytes.NewReader(data)); err != nil {
+			t.Fatalf("Write file %s: %v", name, err)
+		}
+	}
+	writeFile(pluginpkg.ManifestFile, manifestBytes, 0644)
+	writeFile(filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider")), []byte(content), 0755)
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatalf("close archive: %v", err)
+	}
+	return archivePath
+}
+
+func mustBuildPackageWithDuplicateArtifact(t *testing.T, dir, id, version, firstContent, secondContent string) string {
+	t.Helper()
+
+	artifactName := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider"))
+	sum := sha256.Sum256([]byte(firstContent))
+	manifest := &pluginmanifestv1.Manifest{
+		SchemaVersion: pluginmanifestv1.SchemaVersion,
+		ID:            id,
+		Version:       version,
+		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				Path:   artifactName,
+				SHA256: hex.EncodeToString(sum[:]),
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{
+				ArtifactPath: artifactName,
+			},
+		},
+	}
+	manifestBytes, err := pluginpkg.EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+
+	archivePath := filepath.Join(dir, "duplicate-artifact.tar.gz")
+	out, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("Create archive: %v", err)
+	}
+	gzw := gzip.NewWriter(out)
+	tw := tar.NewWriter(gzw)
+
+	writeFile := func(name string, data []byte, mode int64) {
+		hdr := &tar.Header{Name: name, Mode: mode, Size: int64(len(data))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("WriteHeader %s: %v", name, err)
+		}
+		if _, err := io.Copy(tw, bytes.NewReader(data)); err != nil {
+			t.Fatalf("Write file %s: %v", name, err)
+		}
+	}
+	writeFile(pluginpkg.ManifestFile, manifestBytes, 0644)
+	writeFile(artifactName, []byte(firstContent), 0755)
+	writeFile(artifactName, []byte(secondContent), 0755)
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatalf("close archive: %v", err)
+	}
+	return archivePath
+}

--- a/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -1,0 +1,188 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1/manifest.jsonschema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "version",
+    "kinds",
+    "artifacts",
+    "entrypoints"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$"
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "display_name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "kinds": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "provider",
+          "runtime"
+        ]
+      }
+    },
+    "provider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "protocol"
+      ],
+      "properties": {
+        "protocol": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "min",
+            "max"
+          ],
+          "properties": {
+            "min": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "max": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        },
+        "config_schema_path": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/artifact"
+      }
+    },
+    "entrypoints": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "$ref": "#/$defs/entrypoint"
+        },
+        "runtime": {
+          "$ref": "#/$defs/entrypoint"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "kinds": {
+            "contains": {
+              "const": "provider"
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "provider"
+        ],
+        "properties": {
+          "entrypoints": {
+            "required": [
+              "provider"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kinds": {
+            "contains": {
+              "const": "runtime"
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "entrypoints": {
+            "required": [
+              "runtime"
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "os",
+        "arch",
+        "path",
+        "sha256"
+      ],
+      "properties": {
+        "os": {
+          "type": "string",
+          "minLength": 1
+        },
+        "arch": {
+          "type": "string",
+          "minLength": 1
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "entrypoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_path"
+      ],
+      "properties": {
+        "artifact_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/sdk/pluginmanifest/v1/types.go
+++ b/sdk/pluginmanifest/v1/types.go
@@ -1,0 +1,52 @@
+package pluginmanifestv1
+
+import _ "embed"
+
+const (
+	SchemaVersion = 1
+
+	KindProvider = "provider"
+	KindRuntime  = "runtime"
+)
+
+type Manifest struct {
+	SchemaVersion int         `json:"schema_version"`
+	ID            string      `json:"id"`
+	Version       string      `json:"version"`
+	DisplayName   string      `json:"display_name,omitempty"`
+	Description   string      `json:"description,omitempty"`
+	Kinds         []string    `json:"kinds"`
+	Provider      *Provider   `json:"provider,omitempty"`
+	Artifacts     []Artifact  `json:"artifacts"`
+	Entrypoints   Entrypoints `json:"entrypoints"`
+}
+
+type Provider struct {
+	Protocol         ProtocolRange `json:"protocol"`
+	ConfigSchemaPath string        `json:"config_schema_path,omitempty"`
+}
+
+type ProtocolRange struct {
+	Min int `json:"min"`
+	Max int `json:"max"`
+}
+
+type Artifact struct {
+	OS     string `json:"os"`
+	Arch   string `json:"arch"`
+	Path   string `json:"path"`
+	SHA256 string `json:"sha256"`
+}
+
+type Entrypoints struct {
+	Provider *Entrypoint `json:"provider,omitempty"`
+	Runtime  *Entrypoint `json:"runtime,omitempty"`
+}
+
+type Entrypoint struct {
+	ArtifactPath string   `json:"artifact_path"`
+	Args         []string `json:"args,omitempty"`
+}
+
+//go:embed manifest.jsonschema.json
+var ManifestJSONSchema []byte


### PR DESCRIPTION
## Summary
- add a versioned plugin manifest schema and package/archive helpers
- add a project-local plugin store with install, list, and resolve support
- add `gestaltd plugin package|inspect|install|list` commands and tests

## Testing
- go test ./cmd/gestaltd ./internal/pluginpkg ./internal/pluginstore