### PR TITLE
feat(plugin): resolve plugin refs via prepare and lockfile v2

### DIFF
--- a/cmd/gestaltd/prepare.go
+++ b/cmd/gestaltd/prepare.go
@@ -16,13 +16,16 @@ import (
 	"strings"
 
 	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/pluginpkg"
+	"github.com/valon-technologies/gestalt/internal/pluginstore"
 	"github.com/valon-technologies/gestalt/internal/provider"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
 )
 
 const (
 	preparedLockfileName = "gestalt.lock.json"
 	preparedProvidersDir = ".gestalt/providers"
-	preparedLockVersion  = 1
+	preparedLockVersion  = 2
 )
 
 const (
@@ -43,11 +46,20 @@ type preparedPaths struct {
 type preparedLockfile struct {
 	Version   int                              `json:"version"`
 	Providers map[string]preparedProviderEntry `json:"providers"`
+	Plugins   map[string]preparedPluginEntry   `json:"plugins"`
 }
 
 type preparedProviderEntry struct {
 	Fingerprint string `json:"fingerprint"`
 	Provider    string `json:"provider"`
+}
+
+type preparedPluginEntry struct {
+	Fingerprint string `json:"fingerprint"`
+	Ref         string `json:"ref"`
+	Manifest    string `json:"manifest"`
+	Executable  string `json:"executable"`
+	SHA256      string `json:"sha256"`
 }
 
 type preparedFingerprintInput struct {
@@ -95,6 +107,7 @@ func prepareConfigAtPath(configPath string) (*preparedLockfile, error) {
 	lock := &preparedLockfile{
 		Version:   preparedLockVersion,
 		Providers: make(map[string]preparedProviderEntry),
+		Plugins:   make(map[string]preparedPluginEntry),
 	}
 
 	written, err := writePreparedArtifacts(context.Background(), cfg, paths)
@@ -103,6 +116,13 @@ func prepareConfigAtPath(configPath string) (*preparedLockfile, error) {
 	}
 	for name, entry := range written {
 		lock.Providers[name] = entry
+	}
+	resolvedPlugins, err := writePreparedPlugins(configPath, cfg, paths)
+	if err != nil {
+		return nil, err
+	}
+	for key, entry := range resolvedPlugins {
+		lock.Plugins[key] = entry
 	}
 
 	if err := writePreparedLockfile(paths.lockfilePath, lock); err != nil {
@@ -124,6 +144,9 @@ func loadConfigForExecution(configFlag string, mode providerResolutionMode) (str
 
 	preparedProviders, err := preparedProvidersForConfig(configPath, cfg, mode)
 	if err != nil {
+		return "", nil, nil, err
+	}
+	if err := applyPreparedPlugins(configPath, cfg, mode); err != nil {
 		return "", nil, nil, err
 	}
 
@@ -247,6 +270,22 @@ func configHasRemoteAPIUpstreams(cfg *config.Config) bool {
 	return false
 }
 
+func configHasPluginRefs(cfg *config.Config) bool {
+	for name := range cfg.Integrations {
+		intg := cfg.Integrations[name]
+		if intg.Plugin != nil && intg.Plugin.Ref != "" {
+			return true
+		}
+	}
+	for name := range cfg.Runtimes {
+		rt := cfg.Runtimes[name]
+		if rt.Plugin != nil && rt.Plugin.Ref != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func resolveProviderPath(baseDir, provider string) string {
 	if filepath.IsAbs(provider) {
 		return provider
@@ -288,6 +327,9 @@ func readPreparedLockfile(path string) (*preparedLockfile, error) {
 	if lock.Providers == nil {
 		lock.Providers = make(map[string]preparedProviderEntry)
 	}
+	if lock.Plugins == nil {
+		lock.Plugins = make(map[string]preparedPluginEntry)
+	}
 	return &lock, nil
 }
 
@@ -321,7 +363,243 @@ func preparedLockMatchesConfig(cfg *config.Config, paths preparedPaths, lock *pr
 			return false
 		}
 	}
+	for name := range cfg.Integrations {
+		intg := cfg.Integrations[name]
+		if intg.Plugin == nil || intg.Plugin.Ref == "" {
+			continue
+		}
+		entry, found := lock.Plugins[preparedPluginKey("integration", name)]
+		if !pluginEntryMatches(paths, name, intg.Plugin, entry, found) {
+			return false
+		}
+	}
+	for name := range cfg.Runtimes {
+		rt := cfg.Runtimes[name]
+		if rt.Plugin == nil || rt.Plugin.Ref == "" {
+			continue
+		}
+		entry, found := lock.Plugins[preparedPluginKey("runtime", name)]
+		if !pluginEntryMatches(paths, name, rt.Plugin, entry, found) {
+			return false
+		}
+	}
 	return true
+}
+
+type preparedPluginFingerprintInput struct {
+	Name    string            `json:"name"`
+	Mode    string            `json:"mode,omitempty"`
+	Command string            `json:"command,omitempty"`
+	Ref     string            `json:"ref,omitempty"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+	Config  map[string]any    `json:"config,omitempty"`
+}
+
+func pluginFingerprint(name string, plugin *config.ExecutablePluginDef) (string, error) {
+	if plugin == nil {
+		return "", nil
+	}
+
+	input := preparedPluginFingerprintInput{
+		Name:    name,
+		Mode:    plugin.Mode,
+		Command: plugin.Command,
+		Ref:     plugin.Ref,
+		Args:    plugin.Args,
+		Env:     plugin.Env,
+	}
+	if plugin.Config.Kind != 0 {
+		var cfg map[string]any
+		if err := plugin.Config.Decode(&cfg); err != nil {
+			return "", fmt.Errorf("decoding plugin config fingerprint input: %w", err)
+		}
+		input.Config = cfg
+	}
+
+	payload, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func preparedPluginKey(kind, name string) string {
+	return kind + ":" + name
+}
+
+func resolveInstalledPluginRef(store *pluginstore.Store, raw string) (*pluginstore.InstalledPlugin, error) {
+	ref, err := pluginstore.ParseRef(raw)
+	if err != nil {
+		return nil, err
+	}
+	return store.Resolve(ref)
+}
+
+func pluginEntryMatches(paths preparedPaths, name string, plugin *config.ExecutablePluginDef, entry preparedPluginEntry, found bool) bool {
+	if !found {
+		return false
+	}
+	fingerprint, err := pluginFingerprint(name, plugin)
+	if err != nil || entry.Fingerprint != fingerprint || entry.Ref != plugin.Ref {
+		return false
+	}
+	manifestPath := resolveProviderPath(paths.configDir, entry.Manifest)
+	executablePath := resolveProviderPath(paths.configDir, entry.Executable)
+	if _, err := os.Stat(manifestPath); err != nil {
+		return false
+	}
+	if _, err := os.Stat(executablePath); err != nil {
+		return false
+	}
+	installed, err := resolveInstalledPluginRef(pluginstore.New(paths.configPath), plugin.Ref)
+	if err != nil {
+		return false
+	}
+	return installed.SHA256 == entry.SHA256
+}
+
+func writePreparedPlugins(configPath string, cfg *config.Config, paths preparedPaths) (map[string]preparedPluginEntry, error) {
+	store := pluginstore.New(configPath)
+	written := make(map[string]preparedPluginEntry)
+	for name := range cfg.Integrations {
+		intg := cfg.Integrations[name]
+		if intg.Plugin == nil || intg.Plugin.Ref == "" {
+			continue
+		}
+		entry, err := preparedPluginEntryForConfigItem(paths, store, "integration", name, intg.Plugin)
+		if err != nil {
+			return nil, err
+		}
+		written[preparedPluginKey("integration", name)] = entry
+	}
+	for name := range cfg.Runtimes {
+		rt := cfg.Runtimes[name]
+		if rt.Plugin == nil || rt.Plugin.Ref == "" {
+			continue
+		}
+		entry, err := preparedPluginEntryForConfigItem(paths, store, "runtime", name, rt.Plugin)
+		if err != nil {
+			return nil, err
+		}
+		written[preparedPluginKey("runtime", name)] = entry
+	}
+	return written, nil
+}
+
+func preparedPluginEntryForConfigItem(paths preparedPaths, store *pluginstore.Store, kind, name string, plugin *config.ExecutablePluginDef) (preparedPluginEntry, error) {
+	installed, err := resolveInstalledPluginRef(store, plugin.Ref)
+	if err != nil {
+		return preparedPluginEntry{}, fmt.Errorf("%s %q plugin.ref %q is not installed; run `gestaltd plugin install --config %s <package>`: %w", kind, name, plugin.Ref, paths.configPath, err)
+	}
+	fingerprint, err := pluginFingerprint(name, plugin)
+	if err != nil {
+		return preparedPluginEntry{}, fmt.Errorf("fingerprinting %s %q plugin: %w", kind, name, err)
+	}
+	manifestPath, err := filepath.Rel(paths.configDir, installed.ManifestPath)
+	if err != nil {
+		return preparedPluginEntry{}, fmt.Errorf("compute manifest path for %s %q: %w", kind, name, err)
+	}
+	executablePath, err := filepath.Rel(paths.configDir, installed.ExecutablePath)
+	if err != nil {
+		return preparedPluginEntry{}, fmt.Errorf("compute executable path for %s %q: %w", kind, name, err)
+	}
+	return preparedPluginEntry{
+		Fingerprint: fingerprint,
+		Ref:         plugin.Ref,
+		Manifest:    filepath.ToSlash(manifestPath),
+		Executable:  filepath.ToSlash(executablePath),
+		SHA256:      installed.SHA256,
+	}, nil
+}
+
+func applyPreparedPlugins(configPath string, cfg *config.Config, mode providerResolutionMode) error {
+	if !configHasPluginRefs(cfg) {
+		return nil
+	}
+
+	paths := preparePathsForConfig(configPath)
+	lock, err := readPreparedLockfile(paths.lockfilePath)
+	if mode == providerResolutionAuto && (err != nil || !preparedLockMatchesConfig(cfg, paths, lock)) {
+		lock, err = prepareConfigAtPath(configPath)
+	}
+	if err != nil {
+		return fmt.Errorf("plugin refs require prepared artifacts; run `gestaltd prepare --config %s`: %w", configPath, err)
+	}
+
+	for name := range cfg.Integrations {
+		intg := cfg.Integrations[name]
+		if intg.Plugin == nil || intg.Plugin.Ref == "" {
+			continue
+		}
+		if err := applyPreparedPluginEntry(paths, lock, "integration", name, intg.Plugin); err != nil {
+			return err
+		}
+	}
+	for name := range cfg.Runtimes {
+		rt := cfg.Runtimes[name]
+		if rt.Plugin == nil || rt.Plugin.Ref == "" {
+			continue
+		}
+		if err := applyPreparedPluginEntry(paths, lock, "runtime", name, rt.Plugin); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyPreparedPluginEntry(paths preparedPaths, lock *preparedLockfile, kind, name string, plugin *config.ExecutablePluginDef) error {
+	key := preparedPluginKey(kind, name)
+	entry, ok := lock.Plugins[key]
+	if !ok {
+		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd prepare --config %s`", kind, name, paths.configPath)
+	}
+	fingerprint, err := pluginFingerprint(name, plugin)
+	if err != nil {
+		return fmt.Errorf("fingerprinting %s %q plugin: %w", kind, name, err)
+	}
+	if entry.Fingerprint != fingerprint || entry.Ref != plugin.Ref {
+		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd prepare --config %s`", kind, name, paths.configPath)
+	}
+
+	manifestPath := resolveProviderPath(paths.configDir, entry.Manifest)
+	executablePath := resolveProviderPath(paths.configDir, entry.Executable)
+	if _, err := os.Stat(manifestPath); err != nil {
+		return fmt.Errorf("prepared manifest for %s %q not found at %s; run `gestaltd prepare --config %s`", kind, name, manifestPath, paths.configPath)
+	}
+	if _, err := os.Stat(executablePath); err != nil {
+		return fmt.Errorf("prepared executable for %s %q not found at %s; run `gestaltd prepare --config %s`", kind, name, executablePath, paths.configPath)
+	}
+
+	_, manifest, err := pluginpkg.ReadManifestFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("read prepared manifest for %s %q: %w", kind, name, err)
+	}
+	args, err := preparedEntrypointArgs(kind, manifest)
+	if err != nil {
+		return fmt.Errorf("resolve entrypoint for %s %q: %w", kind, name, err)
+	}
+
+	plugin.Command = executablePath
+	plugin.Args = append([]string(nil), args...)
+	return nil
+}
+
+func preparedEntrypointArgs(kind string, manifest *pluginmanifestv1.Manifest) ([]string, error) {
+	var entry *pluginmanifestv1.Entrypoint
+	switch kind {
+	case "integration":
+		entry = manifest.Entrypoints.Provider
+	case "runtime":
+		entry = manifest.Entrypoints.Runtime
+	default:
+		return nil, fmt.Errorf("unknown plugin kind %q", kind)
+	}
+	if entry == nil {
+		return nil, fmt.Errorf("manifest does not define an entrypoint for %s", kind)
+	}
+	return append([]string(nil), entry.Args...), nil
 }
 
 func integrationFingerprint(name string, intg config.IntegrationDef, upstream config.UpstreamDef) (string, error) {

--- a/cmd/gestaltd/prepare_test.go
+++ b/cmd/gestaltd/prepare_test.go
@@ -1,13 +1,21 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/pluginpkg"
+	"github.com/valon-technologies/gestalt/internal/pluginstore"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
 )
 
 func TestPrepareConfigWritesLockfileAndHiddenProviders(t *testing.T) {
@@ -45,6 +53,12 @@ func TestPrepareConfigWritesLockfileAndHiddenProviders(t *testing.T) {
 	}
 	if entry.Fingerprint == "" {
 		t.Fatal("expected non-empty fingerprint")
+	}
+	if lock.Version != preparedLockVersion {
+		t.Fatalf("lockfile version = %d, want %d", lock.Version, preparedLockVersion)
+	}
+	if lock.Plugins == nil {
+		t.Fatal("expected plugins map to be initialized")
 	}
 }
 
@@ -291,6 +305,141 @@ server:
 	}
 }
 
+func TestPreparedLockfileV2RoundTripPreservesPluginsSection(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, preparedLockfileName)
+	want := &preparedLockfile{
+		Version: preparedLockVersion,
+		Providers: map[string]preparedProviderEntry{
+			"restapi": {
+				Fingerprint: "provider-fingerprint",
+				Provider:    ".gestalt/providers/restapi.json",
+			},
+		},
+		Plugins: map[string]preparedPluginEntry{
+			"external": {
+				Fingerprint: "plugin-fingerprint",
+				Ref:         "acme/provider@0.1.0",
+				Manifest:    ".gestalt/plugins/acme/provider/0.1.0/plugin.json",
+				Executable:  ".gestalt/plugins/acme/provider/0.1.0/artifacts/linux/amd64/provider",
+				SHA256:      "deadbeef",
+			},
+		},
+	}
+
+	if err := writePreparedLockfile(lockPath, want); err != nil {
+		t.Fatalf("writePreparedLockfile: %v", err)
+	}
+
+	got, err := readPreparedLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("readPreparedLockfile: %v", err)
+	}
+	if got.Version != preparedLockVersion {
+		t.Fatalf("lockfile version = %d, want %d", got.Version, preparedLockVersion)
+	}
+	if got.Providers["restapi"].Fingerprint != want.Providers["restapi"].Fingerprint {
+		t.Fatalf("provider fingerprint = %q, want %q", got.Providers["restapi"].Fingerprint, want.Providers["restapi"].Fingerprint)
+	}
+	if got.Plugins["external"].Ref != want.Plugins["external"].Ref {
+		t.Fatalf("plugin ref = %q, want %q", got.Plugins["external"].Ref, want.Plugins["external"].Ref)
+	}
+	if got.Plugins["external"].Manifest != want.Plugins["external"].Manifest {
+		t.Fatalf("plugin manifest = %q, want %q", got.Plugins["external"].Manifest, want.Plugins["external"].Manifest)
+	}
+}
+
+func TestPluginFingerprintStable(t *testing.T) {
+	t.Parallel()
+
+	plugin := &config.ExecutablePluginDef{
+		Mode:    config.PluginModeReplace,
+		Command: "/tmp/plugin",
+		Ref:     "",
+		Args:    []string{"--verbose"},
+		Env:     map[string]string{"API_KEY": "abc123"},
+	}
+
+	first, err := pluginFingerprint("external", plugin)
+	if err != nil {
+		t.Fatalf("pluginFingerprint: %v", err)
+	}
+	second, err := pluginFingerprint("external", plugin)
+	if err != nil {
+		t.Fatalf("pluginFingerprint second: %v", err)
+	}
+	if first != second {
+		t.Fatalf("fingerprint changed between identical inputs: %q != %q", first, second)
+	}
+
+	plugin.Ref = "acme/provider@0.1.0"
+	third, err := pluginFingerprint("external", plugin)
+	if err != nil {
+		t.Fatalf("pluginFingerprint third: %v", err)
+	}
+	if third == first {
+		t.Fatal("expected ref change to affect fingerprint")
+	}
+}
+
+func TestPrepareConfigResolvesInstalledPluginRefs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := writePreparedPluginRefConfig(t, dir, "acme/provider@0.1.0")
+	packagePath := buildPreparedTestPluginPackage(t, dir, "acme/provider", "0.1.0", "provider")
+	store := pluginstore.New(cfgPath)
+	installed, err := store.Install(packagePath)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	if err := prepareConfig(cfgPath); err != nil {
+		t.Fatalf("prepareConfig: %v", err)
+	}
+
+	lock, err := readPreparedLockfile(filepath.Join(dir, preparedLockfileName))
+	if err != nil {
+		t.Fatalf("readPreparedLockfile: %v", err)
+	}
+	entry, ok := lock.Plugins[preparedPluginKey("integration", "example")]
+	if !ok {
+		t.Fatalf("lockfile missing plugin entry: %+v", lock.Plugins)
+	}
+	if entry.Ref != "acme/provider@0.1.0" {
+		t.Fatalf("entry.Ref = %q", entry.Ref)
+	}
+
+	_, cfg, _, err := loadConfigForExecution(cfgPath, providerResolutionRequire)
+	if err != nil {
+		t.Fatalf("loadConfigForExecution: %v", err)
+	}
+	plugin := cfg.Integrations["example"].Plugin
+	if plugin.Command != installed.ExecutablePath {
+		t.Fatalf("plugin.Command = %q, want %q", plugin.Command, installed.ExecutablePath)
+	}
+	if plugin.Ref != "acme/provider@0.1.0" {
+		t.Fatalf("plugin.Ref = %q", plugin.Ref)
+	}
+}
+
+func TestLoadConfigForExecutionPreferRejectsUnpreparedPluginRef(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := writePreparedPluginRefConfig(t, dir, "acme/provider@0.1.0")
+
+	_, _, _, err := loadConfigForExecution(cfgPath, providerResolutionPrefer)
+	if err == nil {
+		t.Fatal("expected unprepared plugin ref to fail")
+	}
+	if !strings.Contains(err.Error(), "gestaltd prepare") {
+		t.Fatalf("expected prepare guidance, got: %v", err)
+	}
+}
+
 func newPreparedTestOpenAPIServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := map[string]any{
@@ -339,4 +488,80 @@ integrations:
 		t.Fatalf("WriteFile config: %v", err)
 	}
 	return cfgPath
+}
+
+func writePreparedPluginRefConfig(t *testing.T, dir, ref string) string {
+	t.Helper()
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  dev_mode: true
+  encryption_key: test-key
+integrations:
+  example:
+    plugin:
+      ref: ` + ref + `
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	return cfgPath
+}
+
+func buildPreparedTestPluginPackage(t *testing.T, dir, id, version, content string) string {
+	t.Helper()
+
+	source := filepath.Join(dir, "plugin-src")
+	artifactRel := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider"))
+	if err := os.MkdirAll(filepath.Join(source, filepath.FromSlash(filepath.Dir(artifactRel))), 0755); err != nil {
+		t.Fatalf("MkdirAll artifact dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(source, filepath.FromSlash(artifactRel)), []byte(content), 0755); err != nil {
+		t.Fatalf("WriteFile artifact: %v", err)
+	}
+
+	manifest := &pluginmanifestv1.Manifest{
+		SchemaVersion: pluginmanifestv1.SchemaVersion,
+		ID:            id,
+		Version:       version,
+		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				Path:   artifactRel,
+				SHA256: sha256HexForPrepareTest(content),
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{
+				ArtifactPath: artifactRel,
+			},
+		},
+	}
+	data, err := pluginpkg.EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(source, pluginpkg.ManifestFile), data, 0644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	archivePath := filepath.Join(dir, "plugin.tar.gz")
+	if err := pluginpkg.CreatePackageFromDir(source, archivePath); err != nil {
+		t.Fatalf("CreatePackageFromDir: %v", err)
+	}
+	return archivePath
+}
+
+func sha256HexForPrepareTest(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,7 @@ type ExecutablePluginDef struct {
 	Mode    string            `yaml:"mode"`
 	Base    string            `yaml:"base"`
 	Command string            `yaml:"command"`
+	Ref     string            `yaml:"ref"`
 	Args    []string          `yaml:"args"`
 	Env     map[string]string `yaml:"env"`
 	Config  yaml.Node         `yaml:"config"`
@@ -561,8 +562,13 @@ func validateExecutablePlugin(kind, name string, plugin *ExecutablePluginDef) er
 	if plugin == nil {
 		return nil
 	}
-	if plugin.Command == "" {
-		return fmt.Errorf("config validation: %s %q plugin.command is required", kind, name)
+	switch {
+	case plugin.Command == "" && plugin.Ref == "":
+		return fmt.Errorf("config validation: %s %q plugin.command or plugin.ref is required", kind, name)
+	case plugin.Command != "" && plugin.Ref != "":
+		return fmt.Errorf("config validation: %s %q plugin.command and plugin.ref are mutually exclusive", kind, name)
+	case plugin.Ref != "" && len(plugin.Args) > 0:
+		return fmt.Errorf("config validation: %s %q plugin.args are only valid with plugin.command", kind, name)
 	}
 	mode := plugin.Mode
 	if mode == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -427,6 +427,100 @@ integrations:
 	}
 }
 
+func TestPluginRefValidation(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+	}{
+		{
+			name: "integration plugin ref is valid",
+			yaml: `
+auth:
+  provider: auth-provider
+datastore:
+  provider: data-store
+server:
+  encryption_key: server-key
+integrations:
+  external:
+    plugin:
+      ref: acme/provider@0.1.0
+`,
+		},
+		{
+			name: "integration plugin command and ref are mutually exclusive",
+			yaml: `
+auth:
+  provider: auth-provider
+datastore:
+  provider: data-store
+server:
+  encryption_key: server-key
+integrations:
+  external:
+    plugin:
+      command: /tmp/plugin
+      ref: acme/provider@0.1.0
+`,
+			wantErr: true,
+		},
+		{
+			name: "integration plugin args require command",
+			yaml: `
+auth:
+  provider: auth-provider
+datastore:
+  provider: data-store
+server:
+  encryption_key: server-key
+integrations:
+  external:
+    plugin:
+      ref: acme/provider@0.1.0
+      args:
+        - --verbose
+`,
+			wantErr: true,
+		},
+		{
+			name: "runtime plugin ref is valid",
+			yaml: `
+auth:
+  provider: auth-provider
+datastore:
+  provider: data-store
+server:
+  encryption_key: server-key
+runtimes:
+  worker:
+    plugin:
+      ref: acme/runtime@0.1.0
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := mustWriteConfigFile(t, tc.yaml)
+			_, err := Load(path)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("Load: expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+		})
+	}
+}
+
 func TestAuthConfigMap(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add `plugin.ref` to config validation and enforce command/ref rules
- bump `gestalt.lock.json` to v2 with plugin entries and fingerprints
- resolve installed plugin refs during `gestaltd prepare` and inject locked executable paths for execution

## Testing
- go test ./cmd/gestaltd ./internal/config ./internal/pluginpkg ./internal/pluginstore