### PR TITLE
feat(plugin): validate packaged refs from prepared manifests

### DIFF
--- a/cmd/gestaltd/prepare.go
+++ b/cmd/gestaltd/prepare.go
@@ -369,7 +369,8 @@ func preparedLockMatchesConfig(cfg *config.Config, paths preparedPaths, lock *pr
 			continue
 		}
 		entry, found := lock.Plugins[preparedPluginKey("integration", name)]
-		if !pluginEntryMatches(paths, name, intg.Plugin, entry, found) {
+		configMap, err := config.NodeToMap(intg.Plugin.Config)
+		if err != nil || !pluginEntryMatches(paths, name, intg.Plugin, configMap, entry, found) {
 			return false
 		}
 	}
@@ -379,7 +380,8 @@ func preparedLockMatchesConfig(cfg *config.Config, paths preparedPaths, lock *pr
 			continue
 		}
 		entry, found := lock.Plugins[preparedPluginKey("runtime", name)]
-		if !pluginEntryMatches(paths, name, rt.Plugin, entry, found) {
+		configMap, err := config.NodeToMap(rt.Config)
+		if err != nil || !pluginEntryMatches(paths, name, rt.Plugin, configMap, entry, found) {
 			return false
 		}
 	}
@@ -396,7 +398,7 @@ type preparedPluginFingerprintInput struct {
 	Config  map[string]any    `json:"config,omitempty"`
 }
 
-func pluginFingerprint(name string, plugin *config.ExecutablePluginDef) (string, error) {
+func pluginFingerprint(name string, plugin *config.ExecutablePluginDef, configMap map[string]any) (string, error) {
 	if plugin == nil {
 		return "", nil
 	}
@@ -409,12 +411,8 @@ func pluginFingerprint(name string, plugin *config.ExecutablePluginDef) (string,
 		Args:    plugin.Args,
 		Env:     plugin.Env,
 	}
-	if plugin.Config.Kind != 0 {
-		var cfg map[string]any
-		if err := plugin.Config.Decode(&cfg); err != nil {
-			return "", fmt.Errorf("decoding plugin config fingerprint input: %w", err)
-		}
-		input.Config = cfg
+	if configMap != nil {
+		input.Config = configMap
 	}
 
 	payload, err := json.Marshal(input)
@@ -437,11 +435,11 @@ func resolveInstalledPluginRef(store *pluginstore.Store, raw string) (*pluginsto
 	return store.Resolve(ref)
 }
 
-func pluginEntryMatches(paths preparedPaths, name string, plugin *config.ExecutablePluginDef, entry preparedPluginEntry, found bool) bool {
+func pluginEntryMatches(paths preparedPaths, name string, plugin *config.ExecutablePluginDef, configMap map[string]any, entry preparedPluginEntry, found bool) bool {
 	if !found {
 		return false
 	}
-	fingerprint, err := pluginFingerprint(name, plugin)
+	fingerprint, err := pluginFingerprint(name, plugin, configMap)
 	if err != nil || entry.Fingerprint != fingerprint || entry.Ref != plugin.Ref {
 		return false
 	}
@@ -468,7 +466,11 @@ func writePreparedPlugins(configPath string, cfg *config.Config, paths preparedP
 		if intg.Plugin == nil || intg.Plugin.Ref == "" {
 			continue
 		}
-		entry, err := preparedPluginEntryForConfigItem(paths, store, "integration", name, intg.Plugin)
+		configMap, err := config.NodeToMap(intg.Plugin.Config)
+		if err != nil {
+			return nil, fmt.Errorf("decode plugin config for integration %q: %w", name, err)
+		}
+		entry, err := preparedPluginEntryForConfigItem(paths, store, "integration", name, intg.Plugin, configMap)
 		if err != nil {
 			return nil, err
 		}
@@ -479,7 +481,11 @@ func writePreparedPlugins(configPath string, cfg *config.Config, paths preparedP
 		if rt.Plugin == nil || rt.Plugin.Ref == "" {
 			continue
 		}
-		entry, err := preparedPluginEntryForConfigItem(paths, store, "runtime", name, rt.Plugin)
+		configMap, err := config.NodeToMap(rt.Config)
+		if err != nil {
+			return nil, fmt.Errorf("decode runtime config for runtime %q: %w", name, err)
+		}
+		entry, err := preparedPluginEntryForConfigItem(paths, store, "runtime", name, rt.Plugin, configMap)
 		if err != nil {
 			return nil, err
 		}
@@ -488,12 +494,15 @@ func writePreparedPlugins(configPath string, cfg *config.Config, paths preparedP
 	return written, nil
 }
 
-func preparedPluginEntryForConfigItem(paths preparedPaths, store *pluginstore.Store, kind, name string, plugin *config.ExecutablePluginDef) (preparedPluginEntry, error) {
+func preparedPluginEntryForConfigItem(paths preparedPaths, store *pluginstore.Store, kind, name string, plugin *config.ExecutablePluginDef, configMap map[string]any) (preparedPluginEntry, error) {
 	installed, err := resolveInstalledPluginRef(store, plugin.Ref)
 	if err != nil {
 		return preparedPluginEntry{}, fmt.Errorf("%s %q plugin.ref %q is not installed; run `gestaltd plugin install --config %s <package>`: %w", kind, name, plugin.Ref, paths.configPath, err)
 	}
-	fingerprint, err := pluginFingerprint(name, plugin)
+	if err := pluginpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, manifestKindForPreparedPlugin(kind), configMap); err != nil {
+		return preparedPluginEntry{}, fmt.Errorf("plugin config validation for %s %q: %w", kind, name, err)
+	}
+	fingerprint, err := pluginFingerprint(name, plugin, configMap)
 	if err != nil {
 		return preparedPluginEntry{}, fmt.Errorf("fingerprinting %s %q plugin: %w", kind, name, err)
 	}
@@ -533,7 +542,11 @@ func applyPreparedPlugins(configPath string, cfg *config.Config, mode providerRe
 		if intg.Plugin == nil || intg.Plugin.Ref == "" {
 			continue
 		}
-		if err := applyPreparedPluginEntry(paths, lock, "integration", name, intg.Plugin); err != nil {
+		configMap, err := config.NodeToMap(intg.Plugin.Config)
+		if err != nil {
+			return fmt.Errorf("decode plugin config for integration %q: %w", name, err)
+		}
+		if err := applyPreparedPluginEntry(paths, lock, "integration", name, intg.Plugin, configMap); err != nil {
 			return err
 		}
 	}
@@ -542,20 +555,24 @@ func applyPreparedPlugins(configPath string, cfg *config.Config, mode providerRe
 		if rt.Plugin == nil || rt.Plugin.Ref == "" {
 			continue
 		}
-		if err := applyPreparedPluginEntry(paths, lock, "runtime", name, rt.Plugin); err != nil {
+		configMap, err := config.NodeToMap(rt.Config)
+		if err != nil {
+			return fmt.Errorf("decode runtime config for runtime %q: %w", name, err)
+		}
+		if err := applyPreparedPluginEntry(paths, lock, "runtime", name, rt.Plugin, configMap); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func applyPreparedPluginEntry(paths preparedPaths, lock *preparedLockfile, kind, name string, plugin *config.ExecutablePluginDef) error {
+func applyPreparedPluginEntry(paths preparedPaths, lock *preparedLockfile, kind, name string, plugin *config.ExecutablePluginDef, configMap map[string]any) error {
 	key := preparedPluginKey(kind, name)
 	entry, ok := lock.Plugins[key]
 	if !ok {
 		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd prepare --config %s`", kind, name, paths.configPath)
 	}
-	fingerprint, err := pluginFingerprint(name, plugin)
+	fingerprint, err := pluginFingerprint(name, plugin, configMap)
 	if err != nil {
 		return fmt.Errorf("fingerprinting %s %q plugin: %w", kind, name, err)
 	}
@@ -576,6 +593,9 @@ func applyPreparedPluginEntry(paths preparedPaths, lock *preparedLockfile, kind,
 	if err != nil {
 		return fmt.Errorf("read prepared manifest for %s %q: %w", kind, name, err)
 	}
+	if err := pluginpkg.ValidateConfigForManifest(manifestPath, manifest, manifestKindForPreparedPlugin(kind), configMap); err != nil {
+		return fmt.Errorf("plugin config validation for %s %q: %w", kind, name, err)
+	}
 	args, err := preparedEntrypointArgs(kind, manifest)
 	if err != nil {
 		return fmt.Errorf("resolve entrypoint for %s %q: %w", kind, name, err)
@@ -583,6 +603,7 @@ func applyPreparedPluginEntry(paths preparedPaths, lock *preparedLockfile, kind,
 
 	plugin.Command = executablePath
 	plugin.Args = append([]string(nil), args...)
+	plugin.PreparedManifestPath = manifestPath
 	return nil
 }
 
@@ -600,6 +621,17 @@ func preparedEntrypointArgs(kind string, manifest *pluginmanifestv1.Manifest) ([
 		return nil, fmt.Errorf("manifest does not define an entrypoint for %s", kind)
 	}
 	return append([]string(nil), entry.Args...), nil
+}
+
+func manifestKindForPreparedPlugin(kind string) string {
+	switch kind {
+	case "integration":
+		return pluginmanifestv1.KindProvider
+	case "runtime":
+		return pluginmanifestv1.KindRuntime
+	default:
+		return ""
+	}
 }
 
 func integrationFingerprint(name string, intg config.IntegrationDef, upstream config.UpstreamDef) (string, error) {

--- a/cmd/gestaltd/prepare_test.go
+++ b/cmd/gestaltd/prepare_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -125,7 +126,7 @@ func TestValidatePrefersPreparedProviders(t *testing.T) {
 	}
 }
 
-func TestValidateRejectsTopLevelConfigForRuntimePlugins(t *testing.T) {
+func TestValidateRejectsPluginConfigForRuntimePlugins(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -148,8 +149,8 @@ runtimes:
     providers: []
     plugin:
       command: /tmp/runtime-plugin
-    config:
-      poll_interval: 30s
+      config:
+        poll_interval: 30s
 `
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {
 		t.Fatalf("WriteFile config: %v", err)
@@ -157,7 +158,7 @@ runtimes:
 
 	err := validateConfig(cfgPath)
 	if err == nil {
-		t.Fatal("expected validateConfig to reject top-level config for runtime plugins")
+		t.Fatal("expected validateConfig to reject runtime plugin.config")
 	}
 	if !strings.Contains(err.Error(), "plugin.config") {
 		t.Fatalf("expected plugin.config guidance, got: %v", err)
@@ -362,11 +363,11 @@ func TestPluginFingerprintStable(t *testing.T) {
 		Env:     map[string]string{"API_KEY": "abc123"},
 	}
 
-	first, err := pluginFingerprint("external", plugin)
+	first, err := pluginFingerprint("external", plugin, nil)
 	if err != nil {
 		t.Fatalf("pluginFingerprint: %v", err)
 	}
-	second, err := pluginFingerprint("external", plugin)
+	second, err := pluginFingerprint("external", plugin, nil)
 	if err != nil {
 		t.Fatalf("pluginFingerprint second: %v", err)
 	}
@@ -375,12 +376,30 @@ func TestPluginFingerprintStable(t *testing.T) {
 	}
 
 	plugin.Ref = "acme/provider@0.1.0"
-	third, err := pluginFingerprint("external", plugin)
+	third, err := pluginFingerprint("external", plugin, nil)
 	if err != nil {
 		t.Fatalf("pluginFingerprint third: %v", err)
 	}
 	if third == first {
 		t.Fatal("expected ref change to affect fingerprint")
+	}
+}
+
+func TestPluginFingerprintIncludesPreparedConfig(t *testing.T) {
+	t.Parallel()
+
+	plugin := &config.ExecutablePluginDef{Ref: "acme/runtime@0.1.0"}
+
+	first, err := pluginFingerprint("runtime", plugin, map[string]any{"runtime_key": "one"})
+	if err != nil {
+		t.Fatalf("pluginFingerprint first: %v", err)
+	}
+	second, err := pluginFingerprint("runtime", plugin, map[string]any{"runtime_key": "two"})
+	if err != nil {
+		t.Fatalf("pluginFingerprint second: %v", err)
+	}
+	if first == second {
+		t.Fatal("expected prepared config to affect fingerprint")
 	}
 }
 
@@ -440,6 +459,83 @@ func TestLoadConfigForExecutionPreferRejectsUnpreparedPluginRef(t *testing.T) {
 	}
 }
 
+func TestValidateConfigUsesPreparedManifestForPluginRef(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := writePreparedPluginRefConfigWithConfig(t, dir, "acme/provider@0.1.0", map[string]any{
+		"api_key": "sk-test",
+	})
+	packagePath := buildPreparedTestPluginPackageWithSchema(t, dir, "acme/provider", "0.1.0", "not-an-executable", `{
+  "type": "object",
+  "required": ["api_key"],
+  "properties": {
+    "api_key": { "type": "string" }
+  }
+}`)
+	store := pluginstore.New(cfgPath)
+	if _, err := store.Install(packagePath); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if err := prepareConfig(cfgPath); err != nil {
+		t.Fatalf("prepareConfig: %v", err)
+	}
+
+	if err := validateConfig(cfgPath); err != nil {
+		t.Fatalf("validateConfig: %v", err)
+	}
+}
+
+func TestValidateConfigRejectsPreparedPluginRefSchemaViolation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := writePreparedPluginRefConfigWithConfig(t, dir, "acme/provider@0.1.0", map[string]any{
+		"wrong_key": "value",
+	})
+	packagePath := buildPreparedTestPluginPackageWithSchema(t, dir, "acme/provider", "0.1.0", "not-an-executable", `{
+  "type": "object",
+  "required": ["api_key"],
+  "properties": {
+    "api_key": { "type": "string" }
+  }
+}`)
+	store := pluginstore.New(cfgPath)
+	if _, err := store.Install(packagePath); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if err := prepareConfig(cfgPath); err == nil {
+		t.Fatal("expected schema validation failure during prepare")
+	}
+}
+
+func TestValidateConfigUsesPreparedManifestForRuntimePluginRef(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := writePreparedRuntimePluginRefConfigWithConfig(t, dir, "acme/runtime@0.1.0", map[string]any{
+		"runtime_key": "rk-test",
+	})
+	packagePath := buildPreparedTestRuntimePackageWithSchema(t, dir, "acme/runtime", "0.1.0", "not-an-executable", `{
+  "type": "object",
+  "required": ["runtime_key"],
+  "properties": {
+    "runtime_key": { "type": "string" }
+  }
+}`)
+	store := pluginstore.New(cfgPath)
+	if _, err := store.Install(packagePath); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if err := prepareConfig(cfgPath); err != nil {
+		t.Fatalf("prepareConfig: %v", err)
+	}
+
+	if err := validateConfig(cfgPath); err != nil {
+		t.Fatalf("validateConfig: %v", err)
+	}
+}
+
 func newPreparedTestOpenAPIServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := map[string]any{
@@ -492,17 +588,87 @@ integrations:
 
 func writePreparedPluginRefConfig(t *testing.T, dir, ref string) string {
 	t.Helper()
+	return writePreparedPluginRefConfigWithConfig(t, dir, ref, nil)
+}
+
+func writePreparedPluginRefConfigWithConfig(t *testing.T, dir, ref string, pluginConfig map[string]any) string {
+	t.Helper()
 
 	cfgPath := filepath.Join(dir, "config.yaml")
+	var configBlock string
+	if pluginConfig != nil {
+		configBlock += "\n      config:"
+		payload, err := json.Marshal(pluginConfig)
+		if err != nil {
+			t.Fatalf("Marshal(pluginConfig): %v", err)
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal(payload, &decoded); err != nil {
+			t.Fatalf("Unmarshal(pluginConfig): %v", err)
+		}
+		for key, value := range decoded {
+			configBlock += fmt.Sprintf("\n        %s: %q", key, value)
+		}
+	}
 	cfg := `auth:
   provider: google
+  config:
+    client_id: test-client
+    client_secret: test-secret
+    redirect_url: http://localhost:8080/api/v1/auth/login/callback
 datastore:
   provider: sqlite
+  config:
+    path: ` + filepath.Join(dir, "gestalt.db") + `
 server:
   dev_mode: true
   encryption_key: test-key
 integrations:
   example:
+    plugin:
+      ref: ` + ref + configBlock + `
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	return cfgPath
+}
+
+func writePreparedRuntimePluginRefConfigWithConfig(t *testing.T, dir, ref string, runtimeConfig map[string]any) string {
+	t.Helper()
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	var configBlock string
+	if runtimeConfig != nil {
+		configBlock += "\n    config:"
+		payload, err := json.Marshal(runtimeConfig)
+		if err != nil {
+			t.Fatalf("Marshal(runtimeConfig): %v", err)
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal(payload, &decoded); err != nil {
+			t.Fatalf("Unmarshal(runtimeConfig): %v", err)
+		}
+		for key, value := range decoded {
+			configBlock += fmt.Sprintf("\n      %s: %q", key, value)
+		}
+	}
+	cfg := `auth:
+  provider: google
+  config:
+    client_id: test-client
+    client_secret: test-secret
+    redirect_url: http://localhost:8080/api/v1/auth/login/callback
+datastore:
+  provider: sqlite
+  config:
+    path: ` + filepath.Join(dir, "gestalt.db") + `
+server:
+  dev_mode: true
+  encryption_key: test-key
+runtimes:
+  example:
+` + configBlock + `
     plugin:
       ref: ` + ref + `
 `
@@ -514,6 +680,11 @@ integrations:
 
 func buildPreparedTestPluginPackage(t *testing.T, dir, id, version, content string) string {
 	t.Helper()
+	return buildPreparedTestPluginPackageWithSchema(t, dir, id, version, content, "")
+}
+
+func buildPreparedTestPluginPackageWithSchema(t *testing.T, dir, id, version, content, schema string) string {
+	t.Helper()
 
 	source := filepath.Join(dir, "plugin-src")
 	artifactRel := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider"))
@@ -523,6 +694,16 @@ func buildPreparedTestPluginPackage(t *testing.T, dir, id, version, content stri
 	if err := os.WriteFile(filepath.Join(source, filepath.FromSlash(artifactRel)), []byte(content), 0755); err != nil {
 		t.Fatalf("WriteFile artifact: %v", err)
 	}
+	var schemaPath string
+	if schema != "" {
+		schemaPath = filepath.ToSlash(filepath.Join("schemas", "config.schema.json"))
+		if err := os.MkdirAll(filepath.Join(source, "schemas"), 0755); err != nil {
+			t.Fatalf("MkdirAll schema dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(source, filepath.FromSlash(schemaPath)), []byte(schema), 0644); err != nil {
+			t.Fatalf("WriteFile schema: %v", err)
+		}
+	}
 
 	manifest := &pluginmanifestv1.Manifest{
 		SchemaVersion: pluginmanifestv1.SchemaVersion,
@@ -530,7 +711,8 @@ func buildPreparedTestPluginPackage(t *testing.T, dir, id, version, content stri
 		Version:       version,
 		Kinds:         []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
-			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
+			Protocol:         pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
+			ConfigSchemaPath: schemaPath,
 		},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
@@ -555,6 +737,61 @@ func buildPreparedTestPluginPackage(t *testing.T, dir, id, version, content stri
 	}
 
 	archivePath := filepath.Join(dir, "plugin.tar.gz")
+	if err := pluginpkg.CreatePackageFromDir(source, archivePath); err != nil {
+		t.Fatalf("CreatePackageFromDir: %v", err)
+	}
+	return archivePath
+}
+
+func buildPreparedTestRuntimePackageWithSchema(t *testing.T, dir, id, version, content, schema string) string {
+	t.Helper()
+
+	source := filepath.Join(dir, "runtime-plugin-src")
+	artifactRel := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "runtime"))
+	if err := os.MkdirAll(filepath.Join(source, filepath.FromSlash(filepath.Dir(artifactRel))), 0755); err != nil {
+		t.Fatalf("MkdirAll artifact dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(source, filepath.FromSlash(artifactRel)), []byte(content), 0755); err != nil {
+		t.Fatalf("WriteFile artifact: %v", err)
+	}
+	if schema != "" {
+		schemaPath := filepath.Join(source, "schemas", "config.schema.json")
+		if err := os.MkdirAll(filepath.Dir(schemaPath), 0755); err != nil {
+			t.Fatalf("MkdirAll schema dir: %v", err)
+		}
+		if err := os.WriteFile(schemaPath, []byte(schema), 0644); err != nil {
+			t.Fatalf("WriteFile schema: %v", err)
+		}
+	}
+
+	manifest := &pluginmanifestv1.Manifest{
+		SchemaVersion: pluginmanifestv1.SchemaVersion,
+		ID:            id,
+		Version:       version,
+		Kinds:         []string{pluginmanifestv1.KindRuntime},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				Path:   artifactRel,
+				SHA256: sha256HexForPrepareTest(content),
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Runtime: &pluginmanifestv1.Entrypoint{
+				ArtifactPath: artifactRel,
+			},
+		},
+	}
+	data, err := pluginpkg.EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(source, pluginpkg.ManifestFile), data, 0644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	archivePath := filepath.Join(dir, "runtime-plugin.tar.gz")
 	if err := pluginpkg.CreatePackageFromDir(source, archivePath); err != nil {
 		t.Fatalf("CreatePackageFromDir: %v", err)
 	}

--- a/docs/pages/concepts/_meta.ts
+++ b/docs/pages/concepts/_meta.ts
@@ -5,4 +5,5 @@ export default {
   "authentication-and-tokens": "Authentication and Tokens",
   "mcp-binding": "MCP Binding",
   "plugin-protocol": "Plugin Protocol",
+  "plugin-packaging": "Plugin Packaging",
 };

--- a/docs/pages/concepts/plugin-packaging.mdx
+++ b/docs/pages/concepts/plugin-packaging.mdx
@@ -1,0 +1,68 @@
+# Plugin Packaging
+
+Phase 3 adds a local-first packaging workflow for third-party plugins. Instead of distributing a raw executable and pointing `plugin.command` at it, an author can ship a package archive and an operator can install it into a project-local store.
+
+## What a package contains
+
+A plugin package is a `.tar.gz` archive with:
+
+- `plugin.json`: the manifest
+- `artifacts/<os>/<arch>/...`: platform-specific executables
+- optional schema files such as `schemas/config.schema.json`
+
+The manifest is the static source of truth for:
+
+- plugin ID and version
+- supported kinds (`provider`, `runtime`)
+- protocol compatibility
+- artifact inventory
+- packaged config schema path
+
+## Project-local store
+
+Installed packages live next to the config file:
+
+```text
+.gestalt/plugins/<publisher>/<name>/<version>/
+```
+
+This keeps deploys self-contained and reproducible. `gestaltd prepare` records the resolved manifest and executable path in `gestalt.lock.json`.
+
+## CLI workflow
+
+Package a plugin from a prepared directory:
+
+```bash
+gestaltd plugin package --input ./package-dir --output ./acme-provider-0.1.0.tar.gz
+```
+
+Inspect a package without executing it:
+
+```bash
+gestaltd plugin inspect ./acme-provider-0.1.0.tar.gz
+```
+
+Install it into the local store:
+
+```bash
+gestaltd plugin install --config ./gestalt.yaml ./acme-provider-0.1.0.tar.gz
+```
+
+List installed packages for a config:
+
+```bash
+gestaltd plugin list --config ./gestalt.yaml
+```
+
+Prepare the config so refs resolve deterministically:
+
+```bash
+gestaltd prepare --config ./gestalt.yaml
+```
+
+## `plugin.command` vs `plugin.ref`
+
+- `plugin.command` is the development path. Gestalt launches a local executable directly.
+- `plugin.ref` is the packaged path. Gestalt resolves an installed package via the local store and `gestalt.lock.json`.
+
+Use `plugin.command` while authoring and iterating locally. Use `plugin.ref` for deterministic deployments and handoff to other operators.

--- a/docs/pages/concepts/plugin-protocol.mdx
+++ b/docs/pages/concepts/plugin-protocol.mdx
@@ -63,9 +63,9 @@ Key fields in `ProviderMetadata`:
 | `static_catalog_json` | `string` | Optional JSON-encoded catalog for resource discovery. |
 | `supports_session_catalog` | `bool` | Set `true` if you implement `GetSessionCatalog`. |
 | `supports_post_connect` | `bool` | Set `true` if you implement `PostConnect`. |
-| `config_schema_json` | `string` | Optional JSON Schema describing the `plugin.config` structure. Currently advisory only; validation requires executing the binary. Phase 3 will introduce static manifests that allow validation without a running process. |
-| `min_protocol_version` | `int32` | Minimum protocol version the plugin supports (for handshake). |
-| `max_protocol_version` | `int32` | Maximum protocol version the plugin supports (for handshake). |
+| `config_schema_json` | `string` | Optional JSON Schema describing the `plugin.config` block. Used for startup validation for `plugin.command`, which still requires executing the binary, and for static validation when a packaged plugin is referenced via `plugin.ref`. |
+| `min_protocol_version` | `int32` | Minimum protocol version the plugin supports. |
+| `max_protocol_version` | `int32` | Maximum protocol version the plugin supports. |
 
 **`StartProvider(StartProviderRequest) → StartProviderResponse`**
 
@@ -165,6 +165,11 @@ The plugin process also inherits the host's full environment, plus any additiona
 
 Plugins are configured in `gestalt.yaml`. A provider plugin is declared inside an `integrations` entry; a runtime plugin is declared inside a `runtimes` entry.
 
+Gestalt supports two plugin workflows:
+
+- `plugin.command`: local development or ad hoc execution. Gestalt launches the given executable directly.
+- `plugin.ref`: packaged/installable workflow. Gestalt resolves an installed package from `.gestalt/plugins/` after `gestaltd prepare` writes a locked manifest and executable path into `gestalt.lock.json`.
+
 ### Provider plugin
 
 ```yaml
@@ -180,18 +185,40 @@ integrations:
 
 When `plugin` is set, `upstreams` cannot be used on the same integration. The plugin fully replaces the upstream-based provider.
 
+### Packaged provider plugin
+
+```yaml
+integrations:
+  my-custom-provider:
+    plugin:
+      ref: acme/provider@0.1.0
+      env:
+        MY_API_KEY: ${API_KEY}
+      config:
+        some_setting: value
+```
+
+For `plugin.ref`, install the package first, then run `gestaltd prepare`:
+
+```bash
+gestaltd plugin install --config ./gestalt.yaml ./acme-provider-0.1.0.tar.gz
+gestaltd prepare --config ./gestalt.yaml
+```
+
+`prepare` resolves the ref to a manifest and platform-specific executable path, validates packaged config against the manifest schema, and records the result in `gestalt.lock.json`.
+
 ### Runtime plugin
 
 ```yaml
 runtimes:
   my-agent:
+    config:
+      poll_interval: 30s
     plugin:
       command: ./my-plugin
       args: [runtime]
       env:
         LOG_LEVEL: debug
-      config:
-        poll_interval: 30s
     providers:
       - slack
       - linear
@@ -203,14 +230,15 @@ When `plugin` is set, `type` cannot be used on the same runtime.
 
 | Field | Required | Notes |
 |---|---|---|
-| `command` | Yes | Path to the executable. Relative paths resolve from the config file's directory. Bare names are looked up in `$PATH`. |
-| `args` | No | Arguments passed to the command. |
+| `command` | Conditionally | Path to the executable. Relative paths resolve from the config file's directory. Bare names are looked up in `$PATH`. Mutually exclusive with `ref`. |
+| `ref` | Conditionally | Stable package reference in `publisher/name@version` form. Mutually exclusive with `command`. |
+| `args` | No | Arguments passed to the command. Only valid with `command`. Packaged plugins use manifest-defined entrypoint args. |
 | `env` | No | Map of additional environment variables. Supports `${VAR}` expansion from the host environment. |
-| `config` | No | Arbitrary key-value map passed to the plugin via `StartProvider` (providers) or `Start` (runtimes). See below. |
+| `config` | No | Provider plugins only. Arbitrary key-value map passed to `StartProvider`. Runtime plugins use `runtimes.<name>.config` instead. |
 
-### Plugin config
+### Provider plugin config
 
-The `plugin.config` block holds plugin-specific configuration. It is sent as a `google.protobuf.Struct` to the plugin during the `StartProvider` or `Start` RPC, so the plugin receives it as a generic map of key-value pairs.
+The `plugin.config` block holds provider-plugin-specific configuration. It is sent as a `google.protobuf.Struct` during `StartProvider`, so the plugin receives it as a generic map of key-value pairs.
 
 ```yaml
 integrations:
@@ -225,7 +253,23 @@ integrations:
 
 Values prefixed with `secret://` are resolved by the host before being sent to the plugin. The host replaces them with the actual secret value from the configured secret manager, so the plugin never sees the `secret://` URI.
 
-Plugins can declare a `config_schema_json` field in their `ProviderMetadata` to advertise a JSON Schema for their config block. This is currently advisory only: because the schema is only available after the binary is running, the host cannot validate config before starting the process. Phase 3 will introduce static plugin manifests that allow pre-execution validation.
+Provider plugins can declare a `config_schema_json` field in `ProviderMetadata` to advertise a JSON Schema for this block. For `plugin.command`, the host still has to execute the binary to retrieve that schema before validating config. For packaged `plugin.ref`, the schema is loaded statically from the prepared manifest during `gestaltd prepare` and `gestaltd validate`.
+
+### Runtime config
+
+Runtime plugin configuration lives on the runtime itself, not inside `plugin.config`. The host sends `runtimes.<name>.config` to the plugin during the `Start` RPC.
+
+```yaml
+runtimes:
+  my-agent:
+    config:
+      poll_interval: 30s
+      workspace: ops
+    plugin:
+      ref: acme/runtime@0.1.0
+```
+
+For packaged runtime plugins, `gestaltd prepare` and `gestaltd validate` use the packaged manifest schema when one is present.
 
 ## Protocol version handshake
 
@@ -260,6 +304,8 @@ The overlay contract:
 - **No auth RPCs.** Overlay plugins should not implement `AuthorizationURL`, `ExchangeCode`, or `RefreshToken`. The host routes all auth through the declarative provider.
 - **Execute routing.** When a caller invokes an operation, the host checks the overlay's operation list first. If the operation matches, it is routed to the plugin. Otherwise, it falls through to the declarative upstream.
 - **Plugin mode.** The host sends `PLUGIN_MODE_OVERLAY` in the `StartProvider` call so the plugin knows it is running as an overlay.
+
+Exactly one of `command` or `ref` must be set.
 
 ## Error handling
 

--- a/docs/pages/tasks/_meta.ts
+++ b/docs/pages/tasks/_meta.ts
@@ -2,5 +2,8 @@ export default {
   "run-locally": "Run Locally",
   "add-an-integration": "Add an Integration",
   "add-a-first-party-provider": "Add a First-Party Provider",
+  "configure-jira": "Configure Jira",
+  "configure-bigquery": "Configure BigQuery",
+  "install-a-plugin": "Install a Plugin",
   "use-with-mcp": "Use with MCP",
 };

--- a/docs/pages/tasks/install-a-plugin.mdx
+++ b/docs/pages/tasks/install-a-plugin.mdx
@@ -1,0 +1,46 @@
+# Install a Plugin
+
+This task covers the packaged plugin workflow for operators.
+
+## 1. Install the package
+
+```bash
+gestaltd plugin install --config ./gestalt.yaml ./acme-provider-0.1.0.tar.gz
+```
+
+This extracts the package into `.gestalt/plugins/` next to your config file and verifies the current-platform artifact digest against the manifest.
+
+## 2. Reference it from config
+
+```yaml
+integrations:
+  acme:
+    plugin:
+      ref: acme/provider@0.1.0
+      config:
+        endpoint: https://api.example.com
+```
+
+## 3. Prepare the deployment
+
+```bash
+gestaltd prepare --config ./gestalt.yaml
+```
+
+This resolves the ref into a locked manifest path and executable path in `gestalt.lock.json`.
+
+## 4. Validate
+
+```bash
+gestaltd validate --config ./gestalt.yaml
+```
+
+For packaged plugins, validation uses the prepared manifest and packaged schema instead of launching the plugin binary just to read metadata.
+
+## 5. Serve
+
+```bash
+gestaltd serve --config ./gestalt.yaml
+```
+
+`serve` uses the locked executable path from `gestalt.lock.json`.

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -441,6 +441,10 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 }
 
 func buildRuntimes(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink, egressDeps EgressDeps) (*registry.PluginMap[core.Runtime], error) {
+	return buildRuntimesWith(ctx, cfg, factories, invoker, lister, audit, egressDeps, buildRuntime)
+}
+
+func buildRuntimesWith(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink, egressDeps EgressDeps, buildRuntimeFn func(context.Context, string, config.RuntimeDef, *FactoryRegistry, RuntimeDeps) (core.Runtime, error)) (*registry.PluginMap[core.Runtime], error) {
 	if len(cfg.Runtimes) == 0 {
 		return nil, nil
 	}
@@ -450,7 +454,7 @@ func buildRuntimes(ctx context.Context, cfg *config.Config, factories *FactoryRe
 	for name := range cfg.Runtimes {
 		def := cfg.Runtimes[name]
 		deps := runtimeDepsForProviders(name, invoker, lister, def.Providers, audit, egressDeps)
-		rt, err := buildRuntime(ctx, name, def, factories, deps)
+		rt, err := buildRuntimeFn(ctx, name, def, factories, deps)
 		if err != nil {
 			_ = StopRuntimes(context.Background(), runtimes, runtimes.List())
 			return nil, fmt.Errorf("bootstrap: runtime %q: %w", name, err)
@@ -507,7 +511,7 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 			mode = config.PluginModeReplace
 		}
 
-		pluginConfig, err := nodeToMap(intg.Plugin.Config)
+		pluginConfig, err := config.NodeToMap(intg.Plugin.Config)
 		if err != nil {
 			return nil, fmt.Errorf("decode plugin config for %q: %w", name, err)
 		}
@@ -609,7 +613,7 @@ func validateProviderBuildAvailable(name string, intg config.IntegrationDef, fac
 
 func buildRuntime(ctx context.Context, name string, cfg config.RuntimeDef, factories *FactoryRegistry, deps RuntimeDeps) (core.Runtime, error) {
 	if cfg.Plugin != nil {
-		pluginConfig, err := nodeToMap(cfg.Plugin.Config)
+		m, err := config.NodeToMap(cfg.Config)
 		if err != nil {
 			return nil, fmt.Errorf("decode runtime plugin config for %q: %w", name, err)
 		}
@@ -618,7 +622,7 @@ func buildRuntime(ctx context.Context, name string, cfg config.RuntimeDef, facto
 			Args:    cfg.Plugin.Args,
 			Env:     cfg.Plugin.Env,
 			Name:    name,
-			Config:  pluginConfig,
+			Config:  m,
 			Mode:    cfg.Plugin.Mode,
 		}, deps.Invoker, deps.CapabilityLister)
 	}
@@ -628,17 +632,6 @@ func buildRuntime(ctx context.Context, name string, cfg config.RuntimeDef, facto
 		return nil, fmt.Errorf("unknown runtime type %q", cfg.Type)
 	}
 	return factory(ctx, name, cfg, deps)
-}
-
-func nodeToMap(node yaml.Node) (map[string]any, error) {
-	if node.Kind == 0 {
-		return nil, nil
-	}
-	var out map[string]any
-	if err := node.Decode(&out); err != nil {
-		return nil, err
-	}
-	return out, nil
 }
 
 func runtimeNames(runtimes *registry.PluginMap[core.Runtime]) []string {

--- a/internal/bootstrap/executable_plugin_test.go
+++ b/internal/bootstrap/executable_plugin_test.go
@@ -62,17 +62,17 @@ func TestExecutableProviderAndRuntimePlugins(t *testing.T) {
 		Runtimes: map[string]config.RuntimeDef{
 			"echoextrt": {
 				Providers: []string{"echoext"},
+				Config: mustNode(t, map[string]any{
+					"output_file":     outputFile,
+					"probe_provider":  "echoext",
+					"probe_operation": "echo",
+					"probe_params": map[string]any{
+						"message": "from runtime",
+					},
+				}),
 				Plugin: &config.ExecutablePluginDef{
 					Command: bin,
 					Args:    []string{"runtime"},
-					Config: mustNode(t, map[string]any{
-						"output_file":     outputFile,
-						"probe_provider":  "echoext",
-						"probe_operation": "echo",
-						"probe_params": map[string]any{
-							"message": "from runtime",
-						},
-					}),
 				},
 			},
 		},
@@ -129,12 +129,12 @@ func TestExecutableRuntimeCapabilities_OmitsMCPPassthroughOnlyCatalogOperations(
 		Runtimes: map[string]config.RuntimeDef{
 			"echoextrt": {
 				Providers: []string{"search"},
+				Config: mustNode(t, map[string]any{
+					"output_file": outputFile,
+				}),
 				Plugin: &config.ExecutablePluginDef{
 					Command: bin,
 					Args:    []string{"runtime"},
-					Config: mustNode(t, map[string]any{
-						"output_file": outputFile,
-					}),
 				},
 			},
 		},
@@ -206,17 +206,17 @@ func TestExecutableRuntimeCapabilities_ExposeOnlyInvokableCatalogOperations(t *t
 		Runtimes: map[string]config.RuntimeDef{
 			"echoextrt": {
 				Providers: []string{"workspace"},
+				Config: mustNode(t, map[string]any{
+					"output_file":     outputFile,
+					"probe_provider":  "workspace",
+					"probe_operation": "fetch_record",
+					"probe_params": map[string]any{
+						"id": "abc123",
+					},
+				}),
 				Plugin: &config.ExecutablePluginDef{
 					Command: bin,
 					Args:    []string{"runtime"},
-					Config: mustNode(t, map[string]any{
-						"output_file":     outputFile,
-						"probe_provider":  "workspace",
-						"probe_operation": "fetch_record",
-						"probe_params": map[string]any{
-							"id": "abc123",
-						},
-					}),
 				},
 			},
 		},
@@ -312,12 +312,12 @@ func TestExecutableRuntimeCapabilities_FilterMethodlessFallbackOperations(t *tes
 		Runtimes: map[string]config.RuntimeDef{
 			"echoextrt": {
 				Providers: []string{"alpha"},
+				Config: mustNode(t, map[string]any{
+					"output_file": outputFile,
+				}),
 				Plugin: &config.ExecutablePluginDef{
 					Command: bin,
 					Args:    []string{"runtime"},
-					Config: mustNode(t, map[string]any{
-						"output_file": outputFile,
-					}),
 				},
 			},
 		},
@@ -376,14 +376,14 @@ func TestExecutableRuntimeReceivesPluginConfig(t *testing.T) {
 	cfg := &config.Config{
 		Runtimes: map[string]config.RuntimeDef{
 			"echoextrt": {
+				Config: mustNode(t, map[string]any{
+					"output_file":  outputFile,
+					"plugin_only":  "from runtime config",
+					"runtime_only": "from runtime config",
+				}),
 				Plugin: &config.ExecutablePluginDef{
 					Command: bin,
 					Args:    []string{"runtime"},
-					Config: mustNode(t, map[string]any{
-						"output_file":  outputFile,
-						"plugin_only":  "from plugin config",
-						"runtime_only": "from plugin config",
-					}),
 				},
 			},
 		},
@@ -406,10 +406,10 @@ func TestExecutableRuntimeReceivesPluginConfig(t *testing.T) {
 	}
 
 	got := readRuntimeOutput(t, outputFile)
-	if got.Config["runtime_only"] != "from plugin config" {
+	if got.Config["runtime_only"] != "from runtime config" {
 		t.Fatalf("runtime config missing runtime_only: %+v", got.Config)
 	}
-	if got.Config["plugin_only"] != "from plugin config" {
+	if got.Config["plugin_only"] != "from runtime config" {
 		t.Fatalf("runtime config missing plugin_only: %+v", got.Config)
 	}
 }

--- a/internal/bootstrap/validate.go
+++ b/internal/bootstrap/validate.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/crypto"
+	"github.com/valon-technologies/gestalt/internal/composite"
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/invocation"
+	"github.com/valon-technologies/gestalt/internal/pluginpkg"
 	"github.com/valon-technologies/gestalt/internal/registry"
 )
 
@@ -61,7 +63,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 	wireCredentialResolver(&deps.Egress, sharedInvoker, providers)
 	audit := core.AuditSink(invocation.LogAuditSink{})
 
-	runtimes, err := buildRuntimes(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress)
+	runtimes, err := buildRuntimesWith(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress, buildRuntimeForValidation)
 	if err != nil {
 		return warnings, err
 	}
@@ -99,7 +101,7 @@ func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *Fa
 	var errs []error
 	for _, name := range names {
 		intgDef := cfg.Integrations[name]
-		prov, err := buildProvider(ctx, name, intgDef, factories, deps)
+		prov, err := buildProviderForValidation(ctx, name, intgDef, factories, deps)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("integration %q: %w", name, err))
 			continue
@@ -118,6 +120,107 @@ func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *Fa
 	}
 
 	return &reg.Providers, nil
+}
+
+func buildProviderForValidation(ctx context.Context, name string, intg config.IntegrationDef, factories *FactoryRegistry, deps Deps) (core.Provider, error) {
+	if intg.Plugin == nil || intg.Plugin.Ref == "" || intg.Plugin.PreparedManifestPath == "" {
+		return buildProvider(ctx, name, intg, factories, deps)
+	}
+
+	mode := intg.Plugin.Mode
+	if mode == "" {
+		mode = config.PluginModeReplace
+	}
+
+	overlayProv, err := newPreparedProviderStub(name, intg, intg.Plugin.PreparedManifestPath)
+	if err != nil {
+		return nil, err
+	}
+	if mode != config.PluginModeOverlay {
+		return overlayProv, nil
+	}
+
+	baseIntg := intg
+	baseIntg.Plugin = nil
+	factory, ok := factories.Providers[name]
+	if !ok {
+		factory = factories.DefaultProvider
+	}
+	if factory == nil {
+		return nil, fmt.Errorf("no provider factory for overlay base %q", name)
+	}
+	baseProv, err := factory(ctx, name, baseIntg, deps)
+	if err != nil {
+		return nil, fmt.Errorf("building overlay base: %w", err)
+	}
+	return composite.NewOverlay(name, baseProv, overlayProv), nil
+}
+
+func buildRuntimeForValidation(ctx context.Context, name string, cfg config.RuntimeDef, factories *FactoryRegistry, deps RuntimeDeps) (core.Runtime, error) {
+	if cfg.Plugin != nil && cfg.Plugin.Ref != "" && cfg.Plugin.PreparedManifestPath != "" {
+		return &preparedRuntimeStub{name: name}, nil
+	}
+	return buildRuntime(ctx, name, cfg, factories, deps)
+}
+
+type preparedProviderStub struct {
+	name           string
+	displayName    string
+	description    string
+	connectionMode core.ConnectionMode
+}
+
+func newPreparedProviderStub(name string, intg config.IntegrationDef, manifestPath string) (core.Provider, error) {
+	_, manifest, err := pluginpkg.ReadManifestFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("read prepared manifest: %w", err)
+	}
+	displayName := manifest.DisplayName
+	if displayName == "" {
+		displayName = name
+	}
+	description := manifest.Description
+	if description == "" {
+		description = fmt.Sprintf("prepared plugin stub for %s", name)
+	}
+	return &preparedProviderStub{
+		name:           name,
+		displayName:    displayName,
+		description:    description,
+		connectionMode: connectionModeForValidation(intg.ConnectionMode),
+	}, nil
+}
+
+func (p *preparedProviderStub) Name() string                        { return p.name }
+func (p *preparedProviderStub) DisplayName() string                 { return p.displayName }
+func (p *preparedProviderStub) Description() string                 { return p.description }
+func (p *preparedProviderStub) ConnectionMode() core.ConnectionMode { return p.connectionMode }
+func (p *preparedProviderStub) ListOperations() []core.Operation    { return nil }
+func (p *preparedProviderStub) Execute(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
+	return nil, fmt.Errorf("prepared validation stub cannot execute operations")
+}
+
+type preparedRuntimeStub struct {
+	name string
+}
+
+func (r *preparedRuntimeStub) Name() string                { return r.name }
+func (r *preparedRuntimeStub) Start(context.Context) error { return nil }
+func (r *preparedRuntimeStub) Stop(context.Context) error  { return nil }
+
+func connectionModeForValidation(raw string) core.ConnectionMode {
+	switch raw {
+	case string(core.ConnectionModeUser):
+		return core.ConnectionModeUser
+	case string(core.ConnectionModeIdentity):
+		return core.ConnectionModeIdentity
+	case string(core.ConnectionModeEither):
+		return core.ConnectionModeEither
+	case string(core.ConnectionModeNone), "":
+		return core.ConnectionModeNone
+	default:
+		return core.ConnectionModeNone
+	}
 }
 
 func closeSecretManager(sm core.SecretManager) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,8 @@ type ExecutablePluginDef struct {
 	Args    []string          `yaml:"args"`
 	Env     map[string]string `yaml:"env"`
 	Config  yaml.Node         `yaml:"config"`
+
+	PreparedManifestPath string `yaml:"-"`
 }
 
 type RuntimeDef struct {
@@ -540,14 +542,14 @@ func validate(cfg *Config) error {
 			return err
 		}
 		if rt.Plugin != nil {
+			if rt.Plugin.Config.Kind != 0 {
+				return fmt.Errorf("config validation: runtime %q must use config at runtimes.%s.config, not runtimes.%s.plugin.config", name, name, name)
+			}
 			if rt.Plugin.Mode == PluginModeOverlay {
 				return fmt.Errorf("config validation: runtime %q plugin.mode cannot be overlay", name)
 			}
 			if rt.Type != "" {
 				return fmt.Errorf("config validation: runtime %q cannot set both plugin and type", name)
-			}
-			if rt.Config.Kind != 0 {
-				return fmt.Errorf("config validation: runtime %q uses plugin.config when plugin is set; top-level runtime config is not supported", name)
 			}
 			continue
 		}
@@ -578,6 +580,17 @@ func validateExecutablePlugin(kind, name string, plugin *ExecutablePluginDef) er
 		return fmt.Errorf("config validation: %s %q plugin.base requires mode: overlay", kind, name)
 	}
 	return nil
+}
+
+func NodeToMap(node yaml.Node) (map[string]any, error) {
+	if node.Kind == 0 {
+		return nil, nil
+	}
+	var out map[string]any
+	if err := node.Decode(&out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func validateEgress(cfg *EgressConfig) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -499,6 +499,158 @@ runtimes:
     plugin:
       ref: acme/runtime@0.1.0
 `,
+			wantErr: false,
+		},
+		{
+			name: "runtime plugin config must be sibling config block",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+runtimes:
+  worker:
+    plugin:
+      ref: acme/runtime@0.1.0
+      config:
+        poll_interval: 30s
+`,
+			wantErr: true,
+		},
+		{
+			name: "runtime requires type or plugin",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+runtimes:
+  worker: {}
+`,
+			wantErr: true,
+		},
+		{
+			name: "runtime plugin cannot also define type",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+runtimes:
+  worker:
+    type: echo
+    plugin:
+      command: /tmp/plugin
+`,
+			wantErr: true,
+		},
+		{
+			name: "plugin command is required",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+integrations:
+  external:
+    plugin: {}
+`,
+			wantErr: true,
+		},
+		{
+			name: "egress default_action allow is valid",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+egress:
+  default_action: allow
+`,
+			wantErr: false,
+		},
+		{
+			name: "egress default_action deny is valid",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+egress:
+  default_action: deny
+`,
+			wantErr: false,
+		},
+		{
+			name: "egress default_action invalid",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+egress:
+  default_action: block
+`,
+			wantErr: true,
+		},
+		{
+			name: "egress policy rule valid",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+egress:
+  policies:
+    - action: deny
+      provider: restricted
+`,
+			wantErr: false,
+		},
+		{
+			name: "egress policy rule invalid action",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+egress:
+  policies:
+    - action: block
+      provider: restricted
+`,
+			wantErr: true,
+		},
+		{
+			name: "egress empty is valid",
+			yaml: `
+auth:
+  provider: google
+datastore:
+  provider: sqlite
+server:
+  encryption_key: key123
+egress: {}
+`,
+			wantErr: false,
 		},
 	}
 

--- a/internal/pluginpkg/config.go
+++ b/internal/pluginpkg/config.go
@@ -1,0 +1,73 @@
+package pluginpkg
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
+)
+
+const runtimeConfigSchemaPath = "schemas/config.schema.json"
+
+func ValidateConfigForManifest(manifestPath string, manifest *pluginmanifestv1.Manifest, kind string, config map[string]any) error {
+	schemaPath, schemaName, ok, err := configSchemaForManifest(manifestPath, manifest, kind)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	data, err := os.ReadFile(schemaPath)
+	if err != nil {
+		return fmt.Errorf("read config schema %q: %w", schemaName, err)
+	}
+
+	var schemaDoc any
+	if err := json.Unmarshal(data, &schemaDoc); err != nil {
+		return fmt.Errorf("invalid config schema: %w", err)
+	}
+
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("config.schema.json", schemaDoc); err != nil {
+		return fmt.Errorf("invalid config schema: %w", err)
+	}
+	schema, err := compiler.Compile("config.schema.json")
+	if err != nil {
+		return fmt.Errorf("compile config schema: %w", err)
+	}
+
+	if config == nil {
+		config = map[string]any{}
+	}
+	if err := schema.Validate(config); err != nil {
+		return fmt.Errorf("config validation failed: %w", err)
+	}
+	return nil
+}
+
+func configSchemaForManifest(manifestPath string, manifest *pluginmanifestv1.Manifest, kind string) (path string, name string, ok bool, err error) {
+	if manifest == nil {
+		return "", "", false, nil
+	}
+
+	switch kind {
+	case pluginmanifestv1.KindProvider:
+		if manifest.Provider == nil || manifest.Provider.ConfigSchemaPath == "" {
+			return "", "", false, nil
+		}
+		return filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(manifest.Provider.ConfigSchemaPath)), manifest.Provider.ConfigSchemaPath, true, nil
+	case pluginmanifestv1.KindRuntime:
+		schemaPath := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(runtimeConfigSchemaPath))
+		if _, statErr := os.Stat(schemaPath); statErr == nil {
+			return schemaPath, runtimeConfigSchemaPath, true, nil
+		} else if !os.IsNotExist(statErr) {
+			return "", "", false, fmt.Errorf("stat runtime config schema %q: %w", runtimeConfigSchemaPath, statErr)
+		}
+		return "", "", false, nil
+	default:
+		return "", "", false, fmt.Errorf("unsupported manifest config kind %q", kind)
+	}
+}

--- a/internal/pluginpkg/config_test.go
+++ b/internal/pluginpkg/config_test.go
@@ -1,0 +1,153 @@
+package pluginpkg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
+)
+
+func TestValidateConfigForManifest(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, ManifestFile)
+	if err := os.MkdirAll(filepath.Join(dir, "schemas"), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "schemas", "config.schema.json"), []byte(`{
+  "type": "object",
+  "required": ["api_key"],
+  "properties": {
+    "api_key": { "type": "string" }
+  }
+}`), 0644); err != nil {
+		t.Fatalf("WriteFile(schema): %v", err)
+	}
+	manifest := &pluginmanifestv1.Manifest{
+		SchemaVersion: pluginmanifestv1.SchemaVersion,
+		ID:            "acme/provider",
+		Version:       "0.1.0",
+		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			Protocol:         pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
+			ConfigSchemaPath: "schemas/config.schema.json",
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     "darwin",
+				Arch:   "arm64",
+				Path:   "artifacts/darwin/arm64/provider",
+				SHA256: sha256Hex("provider"),
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{ArtifactPath: "artifacts/darwin/arm64/provider"},
+		},
+	}
+	data, err := EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(manifestPath, data, 0644); err != nil {
+		t.Fatalf("WriteFile(manifest): %v", err)
+	}
+
+	if err := ValidateConfigForManifest(manifestPath, manifest, pluginmanifestv1.KindProvider, map[string]any{"api_key": "sk-test"}); err != nil {
+		t.Fatalf("ValidateConfigForManifest(valid): %v", err)
+	}
+	if err := ValidateConfigForManifest(manifestPath, manifest, pluginmanifestv1.KindProvider, map[string]any{"missing": true}); err == nil {
+		t.Fatal("expected schema validation failure")
+	}
+}
+
+func TestValidateConfigForManifestRuntimeFallback(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, ManifestFile)
+	if err := os.MkdirAll(filepath.Join(dir, "schemas"), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, filepath.FromSlash(runtimeConfigSchemaPath)), []byte(`{
+  "type": "object",
+  "required": ["runtime_key"],
+  "properties": {
+    "runtime_key": { "type": "string" }
+  }
+}`), 0644); err != nil {
+		t.Fatalf("WriteFile(schema): %v", err)
+	}
+	manifest := &pluginmanifestv1.Manifest{
+		SchemaVersion: pluginmanifestv1.SchemaVersion,
+		ID:            "acme/runtime",
+		Version:       "0.1.0",
+		Kinds:         []string{pluginmanifestv1.KindRuntime},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     "darwin",
+				Arch:   "arm64",
+				Path:   "artifacts/darwin/arm64/runtime",
+				SHA256: sha256Hex("runtime"),
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Runtime: &pluginmanifestv1.Entrypoint{ArtifactPath: "artifacts/darwin/arm64/runtime"},
+		},
+	}
+	data, err := EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(manifestPath, data, 0644); err != nil {
+		t.Fatalf("WriteFile(manifest): %v", err)
+	}
+
+	if err := ValidateConfigForManifest(manifestPath, manifest, pluginmanifestv1.KindRuntime, map[string]any{"runtime_key": "value"}); err != nil {
+		t.Fatalf("ValidateConfigForManifest(runtime valid): %v", err)
+	}
+	if err := ValidateConfigForManifest(manifestPath, manifest, pluginmanifestv1.KindRuntime, map[string]any{"missing": true}); err == nil {
+		t.Fatal("expected runtime schema validation failure")
+	}
+}
+
+func TestValidateConfigForManifestRuntimeDoesNotUseProviderSchema(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, ManifestFile)
+	manifest := &pluginmanifestv1.Manifest{
+		SchemaVersion: pluginmanifestv1.SchemaVersion,
+		ID:            "acme/plugin",
+		Version:       "0.1.0",
+		Kinds:         []string{pluginmanifestv1.KindProvider, pluginmanifestv1.KindRuntime},
+		Provider: &pluginmanifestv1.Provider{
+			Protocol:         pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
+			ConfigSchemaPath: "schemas/provider.schema.json",
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     "darwin",
+				Arch:   "arm64",
+				Path:   "artifacts/darwin/arm64/plugin",
+				SHA256: sha256Hex("plugin"),
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{ArtifactPath: "artifacts/darwin/arm64/plugin"},
+			Runtime:  &pluginmanifestv1.Entrypoint{ArtifactPath: "artifacts/darwin/arm64/plugin"},
+		},
+	}
+	data, err := EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(manifestPath, data, 0644); err != nil {
+		t.Fatalf("WriteFile(manifest): %v", err)
+	}
+
+	if err := ValidateConfigForManifest(manifestPath, manifest, pluginmanifestv1.KindRuntime, map[string]any{"missing": true}); err != nil {
+		t.Fatalf("ValidateConfigForManifest(runtime without fallback schema): %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- validate packaged plugin config against manifest-declared schemas during `prepare`
- avoid executing `plugin.ref` providers and runtimes during `gestaltd validate` by using prepared manifest stubs
- document the packaged workflow and add operator docs for install/prepare/validate

## Testing
- go test ./cmd/gestaltd ./internal/bootstrap ./internal/pluginpkg ./internal/pluginstore ./internal/config