### PR TITLE
refactor(connection-spec): migrate host metadata resolution

### DIFF
--- a/internal/pluginapi/provider_client.go
+++ b/internal/pluginapi/provider_client.go
@@ -16,11 +16,12 @@ import (
 )
 
 type remoteProviderBase struct {
-	client   pluginapiv1.ProviderPluginClient
-	metadata *pluginapiv1.ProviderMetadata
-	ops      []core.Operation
-	catalog  *catalog.Catalog
-	closer   io.Closer
+	client         pluginapiv1.ProviderPluginClient
+	metadata       *pluginapiv1.ProviderMetadata
+	connectionSpec core.ConnectionSpec
+	ops            []core.Operation
+	catalog        *catalog.Catalog
+	closer         io.Closer
 }
 
 // RemoteProviderOption configures a remote provider returned by NewRemoteProvider.
@@ -70,16 +71,17 @@ func NewRemoteProvider(ctx context.Context, client pluginapiv1.ProviderPluginCli
 	}
 
 	base := &remoteProviderBase{
-		client:   client,
-		metadata: meta,
-		ops:      operationsFromProto(opsResp.GetOperations()),
-		catalog:  staticCatalog,
+		client:         client,
+		metadata:       meta,
+		connectionSpec: connectionSpecFromMetadata(meta),
+		ops:            operationsFromProto(opsResp.GetOperations()),
+		catalog:        staticCatalog,
 	}
 	for _, opt := range opts {
 		opt(base)
 	}
 
-	hasOAuth := slices.Contains(meta.GetAuthTypes(), "oauth")
+	hasOAuth := slices.Contains(base.connectionSpec.AuthTypes, "oauth")
 	hasSessionCatalog := meta.GetSupportsSessionCatalog()
 
 	switch {
@@ -102,6 +104,10 @@ func (p *remoteProviderBase) Description() string { return p.metadata.GetDescrip
 
 func (p *remoteProviderBase) ConnectionMode() core.ConnectionMode {
 	return protoConnectionModeToCore(p.metadata.GetConnectionMode())
+}
+
+func (p *remoteProviderBase) ConnectionSpec() core.ConnectionSpec {
+	return p.connectionSpec.Clone()
 }
 
 func (p *remoteProviderBase) ListOperations() []core.Operation {
@@ -131,7 +137,7 @@ func (p *remoteProviderBase) Execute(ctx context.Context, operation string, para
 }
 
 func (p *remoteProviderBase) SupportsManualAuth() bool {
-	return slices.Contains(p.metadata.GetAuthTypes(), "manual")
+	return slices.Contains(p.connectionSpec.AuthTypes, "manual")
 }
 
 func (p *remoteProviderBase) Catalog() *catalog.Catalog {
@@ -142,11 +148,11 @@ func (p *remoteProviderBase) Catalog() *catalog.Catalog {
 }
 
 func (p *remoteProviderBase) ConnectionParamDefs() map[string]core.ConnectionParamDef {
-	return connectionParamDefsFromProto(p.metadata.GetConnectionParams())
+	return p.connectionSpec.Clone().ConnectionParams
 }
 
 func (p *remoteProviderBase) AuthTypes() []string {
-	return slices.Clone(p.metadata.GetAuthTypes())
+	return slices.Clone(p.connectionSpec.AuthTypes)
 }
 
 func (p *remoteProviderBase) authorizationURL(state string, scopes []string) string {
@@ -223,6 +229,17 @@ func (p *remoteProviderWithOAuthSessionCatalog) RefreshToken(ctx context.Context
 
 func (p *remoteProviderWithOAuthSessionCatalog) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
 	return p.sessionCatalog(ctx, token)
+}
+
+func connectionSpecFromMetadata(meta *pluginapiv1.ProviderMetadata) core.ConnectionSpec {
+	spec := core.ConnectionSpec{
+		AuthTypes:        slices.Clone(meta.GetAuthTypes()),
+		ConnectionParams: connectionParamDefsFromProto(meta.GetConnectionParams()),
+	}
+	if len(spec.AuthTypes) == 0 {
+		spec.AuthTypes = []string{"oauth"}
+	}
+	return spec
 }
 
 func checkProtocolCompatibility(meta *pluginapiv1.ProviderMetadata) error {

--- a/internal/pluginapi/provider_test.go
+++ b/internal/pluginapi/provider_test.go
@@ -64,8 +64,6 @@ func (p *roundTripProvider) RefreshToken(_ context.Context, refreshToken string)
 	}, nil
 }
 
-func (p *roundTripProvider) SupportsManualAuth() bool { return true }
-
 func (p *roundTripProvider) Catalog() *catalog.Catalog {
 	return &catalog.Catalog{
 		Name:        "roundtrip",
@@ -88,15 +86,14 @@ func (p *roundTripProvider) CatalogForRequest(_ context.Context, token string) (
 	}, nil
 }
 
-func (p *roundTripProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
-	return map[string]core.ConnectionParamDef{
-		"tenant":  {Required: true, Description: "Tenant slug"},
-		"team_id": {From: "token_response", Field: "team_id"},
+func (p *roundTripProvider) ConnectionSpec() core.ConnectionSpec {
+	return core.ConnectionSpec{
+		AuthTypes: []string{"oauth", "manual"},
+		ConnectionParams: map[string]core.ConnectionParamDef{
+			"tenant":  {Required: true, Description: "Tenant slug"},
+			"team_id": {From: "token_response", Field: "team_id"},
+		},
 	}
-}
-
-func (p *roundTripProvider) AuthTypes() []string {
-	return []string{"oauth", "manual"}
 }
 
 func TestRemoteProviderRoundTrip(t *testing.T) {
@@ -135,6 +132,9 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 	}
 	if _, ok := prov.(core.AuthTypeLister); !ok {
 		t.Fatal("expected remote provider to implement AuthTypeLister")
+	}
+	if _, ok := prov.(core.ConnectionSpecProvider); !ok {
+		t.Fatal("expected remote provider to implement ConnectionSpecProvider")
 	}
 
 	ctx := core.WithConnectionParams(context.Background(), map[string]string{"tenant": "acme"})
@@ -176,7 +176,27 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 	if defs := cpp.ConnectionParamDefs(); defs["tenant"].Description != "Tenant slug" || defs["team_id"].Field != "team_id" {
 		t.Fatalf("unexpected connection param defs: %+v", defs)
 	}
+	csp := prov.(core.ConnectionSpecProvider)
+	if spec := csp.ConnectionSpec(); len(spec.AuthTypes) != 2 || spec.ConnectionParams["team_id"].Field != "team_id" {
+		t.Fatalf("unexpected connection spec: %+v", spec)
+	}
+}
 
+func TestConnectionSpecFromMetadata_DefaultsOAuthWhenAuthTypesMissing(t *testing.T) {
+	t.Parallel()
+
+	spec := connectionSpecFromMetadata(&pluginapiv1.ProviderMetadata{
+		ConnectionParams: map[string]*pluginapiv1.ConnectionParamDef{
+			"tenant": {Required: true, Description: "Tenant slug"},
+		},
+	})
+
+	if len(spec.AuthTypes) != 1 || spec.AuthTypes[0] != "oauth" {
+		t.Fatalf("auth types = %+v, want [oauth]", spec.AuthTypes)
+	}
+	if spec.ConnectionParams["tenant"].Description != "Tenant slug" {
+		t.Fatalf("connection params = %+v", spec.ConnectionParams)
+	}
 }
 
 func newProviderTestClient(t *testing.T, prov core.Provider) pluginapiv1.ProviderPluginClient {

--- a/internal/pluginapi/provider_test.go
+++ b/internal/pluginapi/provider_test.go
@@ -182,23 +182,6 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 	}
 }
 
-func TestConnectionSpecFromMetadata_DefaultsOAuthWhenAuthTypesMissing(t *testing.T) {
-	t.Parallel()
-
-	spec := connectionSpecFromMetadata(&pluginapiv1.ProviderMetadata{
-		ConnectionParams: map[string]*pluginapiv1.ConnectionParamDef{
-			"tenant": {Required: true, Description: "Tenant slug"},
-		},
-	})
-
-	if len(spec.AuthTypes) != 1 || spec.AuthTypes[0] != "oauth" {
-		t.Fatalf("auth types = %+v, want [oauth]", spec.AuthTypes)
-	}
-	if spec.ConnectionParams["tenant"].Description != "Tenant slug" {
-		t.Fatalf("connection params = %+v", spec.ConnectionParams)
-	}
-}
-
 func newProviderTestClient(t *testing.T, prov core.Provider) pluginapiv1.ProviderPluginClient {
 	t.Helper()
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"slices"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -21,6 +22,7 @@ import (
 	"github.com/valon-technologies/gestalt/internal/oauth"
 	"github.com/valon-technologies/gestalt/internal/paraminterp"
 	"github.com/valon-technologies/gestalt/internal/principal"
+	"github.com/valon-technologies/gestalt/internal/providerinfo"
 )
 
 const defaultTokenInstance = "default"
@@ -98,14 +100,7 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			continue
 		}
-		var authTypes []string
-		if atl, ok := prov.(core.AuthTypeLister); ok {
-			authTypes = atl.AuthTypes()
-		} else if mp, ok := prov.(core.ManualProvider); ok && mp.SupportsManualAuth() {
-			authTypes = []string{"manual"}
-		} else {
-			authTypes = []string{"oauth"}
-		}
+		spec := providerinfo.ResolveConnectionSpec(prov)
 		instances := connected[name]
 		info := integrationInfo{
 			Name:        name,
@@ -113,23 +108,20 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 			Description: prov.Description(),
 			Connected:   len(instances) > 0,
 			Instances:   instances,
-			AuthTypes:   authTypes,
+			AuthTypes:   spec.AuthTypes,
 		}
 		if cp, ok := prov.(core.CatalogProvider); ok {
 			if cat := cp.Catalog(); cat != nil {
 				info.IconSVG = cat.IconSVG
 			}
 		}
-		if cpp, ok := prov.(core.ConnectionParamProvider); ok {
-			defs := cpp.ConnectionParamDefs()
+		if defs := providerinfo.UserConnectionParams(spec); len(defs) > 0 {
 			userParams := make(map[string]connectionParamInfo)
 			for name, def := range defs {
-				if def.From == "" {
-					userParams[name] = connectionParamInfo{
-						Required:    def.Required,
-						Description: def.Description,
-						Default:     def.Default,
-					}
+				userParams[name] = connectionParamInfo{
+					Required:    def.Required,
+					Description: def.Description,
+					Default:     def.Default,
 				}
 			}
 			if len(userParams) > 0 {
@@ -245,20 +237,8 @@ func (s *Server) requireOAuthProvider(w http.ResponseWriter, name string) (core.
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("integration %q does not support OAuth", name))
 		return nil, false
 	}
-	if atl, ok := prov.(core.AuthTypeLister); ok {
-		hasOAuth := false
-		for _, t := range atl.AuthTypes() {
-			if t == "oauth" {
-				hasOAuth = true
-				break
-			}
-		}
-		if !hasOAuth {
-			writeError(w, http.StatusBadRequest,
-				fmt.Sprintf("integration %q uses manual auth; use POST /api/v1/auth/connect-manual instead", name))
-			return nil, false
-		}
-	} else if mp, ok := prov.(core.ManualProvider); ok && mp.SupportsManualAuth() {
+	spec := providerinfo.ResolveConnectionSpec(prov)
+	if !slices.Contains(spec.AuthTypes, "oauth") {
 		writeError(w, http.StatusBadRequest,
 			fmt.Sprintf("integration %q uses manual auth; use POST /api/v1/auth/connect-manual instead", name))
 		return nil, false
@@ -511,6 +491,7 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	prov, _ := s.providers.Get(req.Integration)
+	spec := providerinfo.ResolveConnectionSpec(prov)
 
 	if s.stateCodec == nil {
 		writeError(w, http.StatusInternalServerError, "oauth state encryption is not configured")
@@ -532,13 +513,11 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var connParams map[string]string
-	if cpp, ok := prov.(core.ConnectionParamProvider); ok {
-		var valErr error
-		connParams, valErr = validateConnectionParams(cpp.ConnectionParamDefs(), req.ConnectionParams)
-		if valErr != nil {
-			writeError(w, http.StatusBadRequest, valErr.Error())
-			return
-		}
+	var valErr error
+	connParams, valErr = validateConnectionParams(spec.ConnectionParams, req.ConnectionParams)
+	if valErr != nil {
+		writeError(w, http.StatusBadRequest, valErr.Error())
+		return
 	}
 
 	var (
@@ -647,7 +626,8 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	metadata, metaErr := buildConnectionMetadata(prov, connParams, tokenResp)
+	spec := providerinfo.ResolveConnectionSpec(prov)
+	metadata, metaErr := buildConnectionMetadata(spec, connParams, tokenResp)
 	if metaErr != nil {
 		log.Printf("connection metadata extraction failed for %s: %v", providerName, metaErr)
 		writeError(w, http.StatusBadGateway, "failed to extract connection metadata from token response")
@@ -713,8 +693,8 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	mp, ok := prov.(core.ManualProvider)
-	if !ok || !mp.SupportsManualAuth() {
+	spec := providerinfo.ResolveConnectionSpec(prov)
+	if !slices.Contains(spec.AuthTypes, "manual") {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("integration %q does not support manual auth; use OAuth connect instead", req.Integration))
 		return
 	}
@@ -741,16 +721,14 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var connParams map[string]string
-	if cpp, ok := prov.(core.ConnectionParamProvider); ok {
-		var valErr error
-		connParams, valErr = validateConnectionParams(cpp.ConnectionParamDefs(), req.ConnectionParams)
-		if valErr != nil {
-			writeError(w, http.StatusBadRequest, valErr.Error())
-			return
-		}
+	var valErr error
+	connParams, valErr = validateConnectionParams(spec.ConnectionParams, req.ConnectionParams)
+	if valErr != nil {
+		writeError(w, http.StatusBadRequest, valErr.Error())
+		return
 	}
 
-	manualMeta, metaErr := buildConnectionMetadata(prov, connParams, nil)
+	manualMeta, metaErr := buildConnectionMetadata(spec, connParams, nil)
 	if metaErr != nil {
 		writeError(w, http.StatusBadRequest, metaErr.Error())
 		return
@@ -973,32 +951,33 @@ func validateConnectionParams(defs map[string]core.ConnectionParamDef, provided 
 	return result, nil
 }
 
-func buildConnectionMetadata(prov core.Provider, userParams map[string]string, tokenResp *core.TokenResponse) (string, error) {
+func buildConnectionMetadata(spec core.ConnectionSpec, userParams map[string]string, tokenResp *core.TokenResponse) (string, error) {
 	metadata := make(map[string]string)
 	for k, v := range userParams {
 		metadata[k] = v
 	}
 
-	if cpp, ok := prov.(core.ConnectionParamProvider); ok && tokenResp != nil && tokenResp.Extra != nil {
-		for name, def := range cpp.ConnectionParamDefs() {
-			if def.From == "token_response" {
-				field := def.Field
-				if field == "" {
-					field = name
-				}
-				val, ok := tokenResp.Extra[field]
-				if !ok {
-					if def.Required {
-						return "", fmt.Errorf("token response missing required field %q for connection param %q", field, name)
-					}
-					continue
-				}
-				s := fmt.Sprintf("%v", val)
-				if !safeTokenResponseValue.MatchString(s) {
-					return "", fmt.Errorf("token response field %q for connection param %q contains invalid characters", field, name)
-				}
-				metadata[name] = s
+	if tokenResp != nil && tokenResp.Extra != nil {
+		for name, def := range spec.ConnectionParams {
+			if def.From != "token_response" {
+				continue
 			}
+			field := def.Field
+			if field == "" {
+				field = name
+			}
+			val, ok := tokenResp.Extra[field]
+			if !ok {
+				if def.Required {
+					return "", fmt.Errorf("token response missing required field %q for connection param %q", field, name)
+				}
+				continue
+			}
+			s := fmt.Sprintf("%v", val)
+			if !safeTokenResponseValue.MatchString(s) {
+				return "", fmt.Errorf("token response field %q for connection param %q contains invalid characters", field, name)
+			}
+			metadata[name] = s
 		}
 	}
 
@@ -1083,62 +1062,61 @@ func mergeMetadataJSON(existing string, extra map[string]string) (string, error)
 }
 
 func (s *Server) runPostConnect(ctx context.Context, prov core.Provider, tm tokenMaterial) (*postConnectResult, error) {
-	if dcp, ok := prov.(core.DiscoveryConfigProvider); ok {
-		if cfg := dcp.DiscoveryConfig(); cfg != nil {
-			client := &http.Client{
-				Timeout:   30 * time.Second,
-				Transport: &bearerTransport{token: tm.AccessToken, base: http.DefaultTransport},
+	spec := providerinfo.ResolveConnectionSpec(prov)
+	if cfg := spec.Discovery; cfg != nil {
+		client := &http.Client{
+			Timeout:   30 * time.Second,
+			Transport: &bearerTransport{token: tm.AccessToken, base: http.DefaultTransport},
+		}
+		candidates, err := discovery.Run(ctx, cfg, client)
+		if err != nil {
+			return nil, fmt.Errorf("discovery: %w", err)
+		}
+		if len(candidates) == 0 {
+			return nil, fmt.Errorf("no resources discovered")
+		}
+		if len(candidates) == 1 {
+			if err := validateDiscoveryMetadata(candidates[0].Metadata); err != nil {
+				return nil, err
 			}
-			candidates, err := discovery.Run(ctx, cfg, client)
-			if err != nil {
-				return nil, fmt.Errorf("discovery: %w", err)
-			}
-			if len(candidates) == 0 {
-				return nil, fmt.Errorf("no resources discovered")
-			}
-			if len(candidates) == 1 {
-				if err := validateDiscoveryMetadata(candidates[0].Metadata); err != nil {
-					return nil, err
-				}
-				merged, err := mergeMetadataJSON(tm.MetadataJSON, candidates[0].Metadata)
-				if err != nil {
-					return nil, err
-				}
-				tm.MetadataJSON = merged
-				if _, err := s.storeTokenFromMaterial(ctx, tm); err != nil {
-					return nil, err
-				}
-				return &postConnectResult{Status: "connected"}, nil
-			}
-
-			scs, err := s.stagedConnectionStore()
+			merged, err := mergeMetadataJSON(tm.MetadataJSON, candidates[0].Metadata)
 			if err != nil {
 				return nil, err
 			}
-			candidatesJSON, _ := json.Marshal(candidates)
-			now := s.now().UTC().Truncate(time.Second)
-			sc := &core.StagedConnection{
-				ID:             uuid.NewString(),
-				UserID:         tm.UserID,
-				Integration:    tm.Integration,
-				Instance:       tm.Instance,
-				AccessToken:    tm.AccessToken,
-				RefreshToken:   tm.RefreshToken,
-				TokenExpiresAt: tm.TokenExpiresAt,
-				MetadataJSON:   tm.MetadataJSON,
-				CandidatesJSON: string(candidatesJSON),
-				CreatedAt:      now,
-				ExpiresAt:      now.Add(stagedConnectionTTL),
+			tm.MetadataJSON = merged
+			if _, err := s.storeTokenFromMaterial(ctx, tm); err != nil {
+				return nil, err
 			}
-			if err := scs.StoreStagedConnection(ctx, sc); err != nil {
-				return nil, fmt.Errorf("storing staged connection: %w", err)
-			}
-			return &postConnectResult{
-				Status:     "selection_required",
-				StagedID:   sc.ID,
-				Candidates: candidates,
-			}, nil
+			return &postConnectResult{Status: "connected"}, nil
 		}
+
+		scs, err := s.stagedConnectionStore()
+		if err != nil {
+			return nil, err
+		}
+		candidatesJSON, _ := json.Marshal(candidates)
+		now := s.now().UTC().Truncate(time.Second)
+		sc := &core.StagedConnection{
+			ID:             uuid.NewString(),
+			UserID:         tm.UserID,
+			Integration:    tm.Integration,
+			Instance:       tm.Instance,
+			AccessToken:    tm.AccessToken,
+			RefreshToken:   tm.RefreshToken,
+			TokenExpiresAt: tm.TokenExpiresAt,
+			MetadataJSON:   tm.MetadataJSON,
+			CandidatesJSON: string(candidatesJSON),
+			CreatedAt:      now,
+			ExpiresAt:      now.Add(stagedConnectionTTL),
+		}
+		if err := scs.StoreStagedConnection(ctx, sc); err != nil {
+			return nil, fmt.Errorf("storing staged connection: %w", err)
+		}
+		return &postConnectResult{
+			Status:     "selection_required",
+			StagedID:   sc.ID,
+			Candidates: candidates,
+		}, nil
 	}
 
 	if _, err := s.storeTokenFromMaterial(ctx, tm); err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1244,6 +1244,181 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 	}
 }
 
+func TestIntegrationOAuthCallback_ConnectionSpecProviderMetadata(t *testing.T) {
+	t.Parallel()
+
+	var stored *core.IntegrationToken
+	prov := &specBackedIntegration{
+		StubIntegration: coretesting.StubIntegration{
+			N: "spec-oauth",
+			ExchangeCodeFn: func(_ context.Context, code string) (*core.TokenResponse, error) {
+				if code != "good-code" {
+					return nil, fmt.Errorf("bad code")
+				}
+				return &core.TokenResponse{
+					AccessToken: "spec-token",
+					Extra:       map[string]any{"team_id": "team-123"},
+				}, nil
+			},
+		},
+		authURL: "https://example.com/oauth/authorize",
+		spec: core.ConnectionSpec{
+			AuthTypes: []string{"oauth"},
+			ConnectionParams: map[string]core.ConnectionParamDef{
+				"tenant":  {Required: true},
+				"team_id": {From: "token_response", Field: "team_id", Required: true},
+			},
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, prov)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			StoreTokenFn: func(_ context.Context, tok *core.IntegrationToken) error {
+				stored = tok
+				return nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	startBody := bytes.NewBufferString(`{"integration":"spec-oauth","connection_params":{"tenant":"acme"}}`)
+	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
+	startReq.Header.Set("X-Dev-User-Email", "dev@example.com")
+	startReq.Header.Set("Content-Type", "application/json")
+	startResp, err := http.DefaultClient.Do(startReq)
+	if err != nil {
+		t.Fatalf("start request: %v", err)
+	}
+	defer func() { _ = startResp.Body.Close() }()
+
+	if startResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from start-oauth, got %d", startResp.StatusCode)
+	}
+
+	var startResult map[string]string
+	if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
+		t.Fatalf("decoding start response: %v", err)
+	}
+
+	noRedirect := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
+	resp, err := noRedirect.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", resp.StatusCode)
+	}
+	if stored == nil {
+		t.Fatal("expected token to be stored")
+	}
+	if stored.MetadataJSON != `{"team_id":"team-123","tenant":"acme"}` && stored.MetadataJSON != `{"tenant":"acme","team_id":"team-123"}` {
+		t.Fatalf("metadata JSON = %q, want tenant and team_id metadata", stored.MetadataJSON)
+	}
+}
+
+func TestIntegrationOAuthCallback_ConnectionSpecProviderDiscovery(t *testing.T) {
+	t.Parallel()
+
+	discoveryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer spec-token" {
+			t.Fatalf("Authorization header = %q, want Bearer spec-token", got)
+		}
+		_, _ = io.WriteString(w, `[{"id":"acct-1","name":"Primary","region":"us-east-1"}]`)
+	}))
+	defer discoveryServer.Close()
+
+	var stored *core.IntegrationToken
+	prov := &specBackedIntegration{
+		StubIntegration: coretesting.StubIntegration{
+			N: "discover-spec",
+			ExchangeCodeFn: func(_ context.Context, code string) (*core.TokenResponse, error) {
+				if code != "good-code" {
+					return nil, fmt.Errorf("bad code")
+				}
+				return &core.TokenResponse{AccessToken: "spec-token"}, nil
+			},
+		},
+		authURL: "https://example.com/oauth/authorize",
+		spec: core.ConnectionSpec{
+			AuthTypes: []string{"oauth"},
+			Discovery: &core.DiscoveryConfig{
+				URL:             discoveryServer.URL,
+				IDPath:          "id",
+				NamePath:        "name",
+				MetadataMapping: map[string]string{"region": "region"},
+			},
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, prov)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			StoreTokenFn: func(_ context.Context, tok *core.IntegrationToken) error {
+				stored = tok
+				return nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	startBody := bytes.NewBufferString(`{"integration":"discover-spec"}`)
+	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
+	startReq.Header.Set("X-Dev-User-Email", "dev@example.com")
+	startReq.Header.Set("Content-Type", "application/json")
+	startResp, err := http.DefaultClient.Do(startReq)
+	if err != nil {
+		t.Fatalf("start request: %v", err)
+	}
+	defer func() { _ = startResp.Body.Close() }()
+
+	if startResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from start-oauth, got %d", startResp.StatusCode)
+	}
+
+	var startResult map[string]string
+	if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
+		t.Fatalf("decoding start response: %v", err)
+	}
+
+	noRedirect := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
+	resp, err := noRedirect.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", resp.StatusCode)
+	}
+	if stored == nil {
+		t.Fatal("expected token to be stored")
+	}
+	if stored.MetadataJSON != `{"region":"us-east-1"}` {
+		t.Fatalf("metadata JSON = %q, want discovery metadata", stored.MetadataJSON)
+	}
+}
+
 func TestIntegrationOAuthCallback_InvalidState(t *testing.T) {
 	t.Parallel()
 
@@ -2669,10 +2844,39 @@ func TestListRuntimes_WithRuntimes(t *testing.T) {
 }
 
 type stubManualProvider struct {
-	coretesting.StubIntegration
+	StubIntegration coretesting.StubIntegration
 }
 
+func (s *stubManualProvider) Name() string        { return s.StubIntegration.Name() }
+func (s *stubManualProvider) DisplayName() string { return s.StubIntegration.DisplayName() }
+func (s *stubManualProvider) Description() string { return s.StubIntegration.Description() }
+func (s *stubManualProvider) ConnectionMode() core.ConnectionMode {
+	return s.StubIntegration.ConnectionMode()
+}
+func (s *stubManualProvider) ListOperations() []core.Operation {
+	return s.StubIntegration.ListOperations()
+}
+func (s *stubManualProvider) Execute(ctx context.Context, op string, params map[string]any, token string) (*core.OperationResult, error) {
+	return s.StubIntegration.Execute(ctx, op, params, token)
+}
 func (s *stubManualProvider) SupportsManualAuth() bool { return true }
+
+type specBackedIntegration struct {
+	coretesting.StubIntegration
+	spec    core.ConnectionSpec
+	authURL string
+}
+
+func (s *specBackedIntegration) ConnectionSpec() core.ConnectionSpec {
+	return s.spec.Clone()
+}
+
+func (s *specBackedIntegration) AuthorizationURL(_ string, _ []string) string {
+	if s.authURL != "" {
+		return s.authURL
+	}
+	return s.StubIntegration.AuthorizationURL("", nil)
+}
 
 func TestConnectManual(t *testing.T) {
 	t.Parallel()
@@ -2727,6 +2931,118 @@ func TestConnectManual(t *testing.T) {
 	}
 	if stored.AccessToken != "my-api-key" {
 		t.Fatalf("expected credential my-api-key, got %q", stored.AccessToken)
+	}
+}
+
+func TestListIntegrations_ConnectionSpecProviderMetadata(t *testing.T) {
+	t.Parallel()
+
+	prov := &specBackedIntegration{
+		StubIntegration: coretesting.StubIntegration{N: "spec-svc", DN: "Spec Service"},
+		spec: core.ConnectionSpec{
+			AuthTypes: []string{"manual"},
+			ConnectionParams: map[string]core.ConnectionParamDef{
+				"tenant":  {Required: true, Description: "Tenant slug"},
+				"team_id": {From: "token_response", Field: "team_id"},
+			},
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, prov)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var integrations []struct {
+		Name             string                    `json:"name"`
+		AuthTypes        []string                  `json:"auth_types"`
+		ConnectionParams map[string]map[string]any `json:"connection_params"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if len(integrations) != 1 {
+		t.Fatalf("expected 1 integration, got %d", len(integrations))
+	}
+	if len(integrations[0].AuthTypes) != 1 || integrations[0].AuthTypes[0] != "manual" {
+		t.Fatalf("auth types = %v, want [manual]", integrations[0].AuthTypes)
+	}
+	if len(integrations[0].ConnectionParams) != 1 {
+		t.Fatalf("connection params = %+v, want only user-provided params", integrations[0].ConnectionParams)
+	}
+	if _, ok := integrations[0].ConnectionParams["tenant"]; !ok {
+		t.Fatalf("tenant missing from connection params: %+v", integrations[0].ConnectionParams)
+	}
+	if _, ok := integrations[0].ConnectionParams["team_id"]; ok {
+		t.Fatalf("team_id should not be exposed in connection params: %+v", integrations[0].ConnectionParams)
+	}
+}
+
+func TestConnectManual_ConnectionSpecProvider(t *testing.T) {
+	t.Parallel()
+
+	var stored *core.IntegrationToken
+	prov := &specBackedIntegration{
+		StubIntegration: coretesting.StubIntegration{N: "manual-spec"},
+		spec: core.ConnectionSpec{
+			AuthTypes: []string{"manual"},
+			ConnectionParams: map[string]core.ConnectionParamDef{
+				"tenant": {Required: true},
+			},
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, prov)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			StoreTokenFn: func(_ context.Context, tok *core.IntegrationToken) error {
+				stored = tok
+				return nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"integration":"manual-spec","credential":"my-api-key","connection_params":{"tenant":"acme"}}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if stored == nil {
+		t.Fatal("expected StoreToken to be called")
+	}
+	if stored.MetadataJSON != `{"tenant":"acme"}` {
+		t.Fatalf("metadata JSON = %q, want tenant metadata", stored.MetadataJSON)
 	}
 }
 
@@ -2831,6 +3147,37 @@ func TestStartOAuth_ManualProviderRejected(t *testing.T) {
 	}
 	if result["error"] == "" {
 		t.Fatal("expected error message in response")
+	}
+}
+
+func TestStartOAuth_ConnectionSpecProviderManualRejected(t *testing.T) {
+	t.Parallel()
+
+	prov := &specBackedIntegration{
+		StubIntegration: coretesting.StubIntegration{N: "manual-spec"},
+		spec: core.ConnectionSpec{
+			AuthTypes: []string{"manual"},
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, prov)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"integration":"manual-spec","scopes":[]}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", body)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
 	}
 }
 


### PR DESCRIPTION
## Summary
- switch server-side auth, connection-param, metadata extraction, and discovery handling to resolved connection specs
- derive plugin transport metadata from resolved specs and normalize remote provider metadata while keeping legacy compatibility shims
- add coverage for spec-backed providers, OAuth metadata extraction, discovery, and missing-auth-type fallback

## Testing
- go test ./internal/pluginapi ./internal/server
- go test ./...