### PR TITLE
test(integration): add gestaltd process harness

### DIFF
--- a/cmd/gestaltd/functional_smoke_test.go
+++ b/cmd/gestaltd/functional_smoke_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/internal/testutil"
+)
+
+func TestGestaltdFunctionalSmoke(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	port := testutil.FindFreePort(t)
+	cfgPath := writeFunctionalSmokeConfig(t, dir, port)
+
+	srv := testutil.StartGestaltd(t, cfgPath, port)
+	testutil.DevLogin(t, srv.Client, srv.BaseURL, "functional@gestalt.dev")
+
+	status, body := testutil.DoJSON(t, srv.Client, http.MethodGet, srv.BaseURL+"/health", nil)
+	if status != http.StatusOK {
+		t.Fatalf("health status=%d body=%s\n%s", status, string(body), srv.Logs())
+	}
+
+	status, body = testutil.DoJSON(t, srv.Client, http.MethodGet, srv.BaseURL+"/ready", nil)
+	if status != http.StatusOK {
+		t.Fatalf("ready status=%d body=%s\n%s", status, string(body), srv.Logs())
+	}
+
+	status, body = testutil.DoJSON(t, srv.Client, http.MethodGet, srv.BaseURL+"/api/v1/integrations", nil)
+	if status != http.StatusOK {
+		t.Fatalf("list integrations status=%d body=%s\n%s", status, string(body), srv.Logs())
+	}
+	integrations := testutil.DecodeJSON[[]struct {
+		Name        string `json:"name"`
+		DisplayName string `json:"display_name"`
+	}](t, body)
+
+	foundEcho := false
+	for _, integration := range integrations {
+		if integration.Name == "echo" {
+			foundEcho = true
+			if integration.DisplayName != "Echo" {
+				t.Fatalf("echo display name=%q", integration.DisplayName)
+			}
+		}
+	}
+	if !foundEcho {
+		t.Fatalf("echo integration missing from %+v", integrations)
+	}
+
+	status, body = testutil.DoJSON(t, srv.Client, http.MethodGet, srv.BaseURL+"/api/v1/integrations/echo/operations", nil)
+	if status != http.StatusOK {
+		t.Fatalf("list operations status=%d body=%s\n%s", status, string(body), srv.Logs())
+	}
+	operations := testutil.DecodeJSON[[]struct {
+		Name   string
+		Method string
+	}](t, body)
+	if len(operations) != 1 || operations[0].Name != "echo" || operations[0].Method != http.MethodPost {
+		t.Fatalf("unexpected echo operations: %+v", operations)
+	}
+
+	status, body = testutil.DoJSON(t, srv.Client, http.MethodPost, srv.BaseURL+"/api/v1/echo/echo", map[string]any{
+		"message": "hello",
+		"count":   2,
+	})
+	if status != http.StatusOK {
+		t.Fatalf("invoke echo status=%d body=%s\n%s", status, string(body), srv.Logs())
+	}
+	echoed := testutil.DecodeJSON[map[string]any](t, body)
+	if echoed["message"] != "hello" {
+		t.Fatalf("echoed message=%v", echoed["message"])
+	}
+	if echoed["count"] != float64(2) {
+		t.Fatalf("echoed count=%v", echoed["count"])
+	}
+
+	status, body = testutil.DoJSON(t, srv.Client, http.MethodPost, srv.BaseURL+"/api/v1/tokens", map[string]any{
+		"name": "functional-token",
+	})
+	if status != http.StatusCreated {
+		t.Fatalf("create token status=%d body=%s\n%s", status, string(body), srv.Logs())
+	}
+	created := testutil.DecodeJSON[map[string]any](t, body)
+	tokenID, _ := created["id"].(string)
+	tokenValue, _ := created["token"].(string)
+	if tokenID == "" || tokenValue == "" {
+		t.Fatalf("unexpected token response: %+v", created)
+	}
+
+	status, body = testutil.DoJSON(t, srv.Client, http.MethodGet, srv.BaseURL+"/api/v1/tokens", nil)
+	if status != http.StatusOK {
+		t.Fatalf("list tokens status=%d body=%s\n%s", status, string(body), srv.Logs())
+	}
+	tokens := testutil.DecodeJSON[[]map[string]any](t, body)
+	if len(tokens) != 1 || tokens[0]["name"] != "functional-token" {
+		t.Fatalf("unexpected tokens after create: %+v", tokens)
+	}
+
+	status, body = testutil.DoJSON(t, srv.Client, http.MethodDelete, srv.BaseURL+"/api/v1/tokens/"+tokenID, nil)
+	if status != http.StatusOK {
+		t.Fatalf("revoke token status=%d body=%s\n%s", status, string(body), srv.Logs())
+	}
+
+	status, body = testutil.DoJSON(t, srv.Client, http.MethodGet, srv.BaseURL+"/api/v1/tokens", nil)
+	if status != http.StatusOK {
+		t.Fatalf("list tokens after revoke status=%d body=%s\n%s", status, string(body), srv.Logs())
+	}
+	tokens = testutil.DecodeJSON[[]map[string]any](t, body)
+	if len(tokens) != 0 {
+		t.Fatalf("expected tokens to be empty after revoke, got %+v", tokens)
+	}
+}
+
+func writeFunctionalSmokeConfig(t *testing.T, dir string, port int) string {
+	t.Helper()
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	dbPath := filepath.Join(dir, "gestalt.db")
+	cfg := fmt.Sprintf(`auth:
+  provider: google
+  config:
+    client_id: test-client
+    client_secret: test-secret
+    redirect_url: http://127.0.0.1:%d/auth/callback
+datastore:
+  provider: sqlite
+  config:
+    path: %s
+server:
+  port: %d
+  base_url: http://127.0.0.1:%d
+  dev_mode: true
+  encryption_key: functional-smoke-key
+`, port, dbPath, port, port)
+
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	return cfgPath
+}

--- a/cmd/gestaltd/process_integration_test.go
+++ b/cmd/gestaltd/process_integration_test.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"path/filepath"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/internal/testutil"
+)
+
+func TestGestaltdProcess_LoginConnectAndInvoke(t *testing.T) {
+	t.Parallel()
+
+	oidc := testutil.NewOAuthServer(t, testutil.OAuthServerOptions{
+		Email:       "process-test@gestalt.dev",
+		DisplayName: "Process Test",
+	})
+	api := testutil.NewOpenAPIFixture(t, testutil.OpenAPIFixtureOptions{
+		ExpectedBearerToken: "manual-token",
+	})
+
+	port := testutil.FreePort(t)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	dir := t.TempDir()
+	configPath := testutil.WriteConfigFile(t, dir, fmt.Sprintf(`auth:
+  provider: oidc
+  config:
+    issuer_url: %s
+    client_id: test-client
+    client_secret: test-secret
+    redirect_url: %s/api/v1/auth/login/callback
+    session_secret: session-secret
+datastore:
+  provider: sqlite
+  config:
+    path: %s
+server:
+  port: %d
+  base_url: %s
+  dev_mode: true
+  encryption_key: encryption-secret
+integrations:
+  warehouse:
+    display_name: Warehouse
+    description: Warehouse test integration
+    manual_auth: true
+    upstreams:
+      - type: rest
+        url: %s
+`, oidc.URL, baseURL, filepath.Join(dir, "gestalt.db"), port, baseURL, api.SpecURL))
+
+	proc := testutil.StartGestaltd(t, configPath, port)
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New: %v", err)
+	}
+	client := &http.Client{Jar: jar}
+
+	loginResp := postJSON(t, client, proc.BaseURL+"/api/v1/auth/login", map[string]any{
+		"state": "login-state",
+	})
+	defer func() { _ = loginResp.Body.Close() }()
+
+	var loginBody struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(loginResp.Body).Decode(&loginBody); err != nil {
+		t.Fatalf("decode login response: %v", err)
+	}
+	if loginBody.URL == "" {
+		t.Fatal("expected login URL")
+	}
+
+	callbackResp, err := client.Get(loginBody.URL)
+	if err != nil {
+		t.Fatalf("follow login URL: %v", err)
+	}
+	defer func() { _ = callbackResp.Body.Close() }()
+	if callbackResp.StatusCode != http.StatusOK {
+		t.Fatalf("login callback status = %d, want 200", callbackResp.StatusCode)
+	}
+
+	connectResp := postJSON(t, client, proc.BaseURL+"/api/v1/auth/connect-manual", map[string]any{
+		"integration": "warehouse",
+		"credential":  "manual-token",
+	})
+	defer func() { _ = connectResp.Body.Close() }()
+
+	var connectBody struct {
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(connectResp.Body).Decode(&connectBody); err != nil {
+		t.Fatalf("decode connect response: %v", err)
+	}
+	if connectBody.Status != "connected" {
+		t.Fatalf("connect status = %q, want %q", connectBody.Status, "connected")
+	}
+
+	invokeResp, err := client.Get(proc.BaseURL + "/api/v1/warehouse/list_items")
+	if err != nil {
+		t.Fatalf("invoke request: %v", err)
+	}
+	defer func() { _ = invokeResp.Body.Close() }()
+	if invokeResp.StatusCode != http.StatusOK {
+		t.Fatalf("invoke status = %d, want 200", invokeResp.StatusCode)
+	}
+
+	var invokeBody map[string]any
+	if err := json.NewDecoder(invokeResp.Body).Decode(&invokeBody); err != nil {
+		t.Fatalf("decode invoke response: %v", err)
+	}
+	items, ok := invokeBody["items"].([]any)
+	if !ok || len(items) != 2 {
+		t.Fatalf("invoke items = %#v, want 2 items", invokeBody["items"])
+	}
+
+	if auth := api.LastAuthorization(); auth != "Bearer manual-token" {
+		t.Fatalf("upstream Authorization = %q, want %q", auth, "Bearer manual-token")
+	}
+}
+
+func TestGestaltdProcess_DevLoginAndTokenCRUD(t *testing.T) {
+	t.Parallel()
+
+	port := testutil.FreePort(t)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	dir := t.TempDir()
+	configPath := testutil.WriteConfigFile(t, dir, fmt.Sprintf(`auth:
+  provider: google
+  config:
+    client_id: test-client
+    client_secret: test-secret
+    redirect_url: %s/api/v1/auth/login/callback
+datastore:
+  provider: sqlite
+  config:
+    path: %s
+server:
+  port: %d
+  base_url: %s
+  dev_mode: true
+  encryption_key: encryption-secret
+`, baseURL, filepath.Join(dir, "gestalt.db"), port, baseURL))
+
+	proc := testutil.StartGestaltd(t, configPath, port)
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New: %v", err)
+	}
+	client := &http.Client{Jar: jar}
+
+	devLoginResp := postJSON(t, client, proc.BaseURL+"/api/dev-login", map[string]any{
+		"email": "dev-login@gestalt.dev",
+	})
+	defer func() { _ = devLoginResp.Body.Close() }()
+
+	createResp := postJSON(t, client, proc.BaseURL+"/api/v1/tokens", map[string]any{
+		"name": "process-token",
+	})
+	defer func() { _ = createResp.Body.Close() }()
+
+	var created struct {
+		ID    string `json:"id"`
+		Name  string `json:"name"`
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create token response: %v", err)
+	}
+	if created.Name != "process-token" || created.Token == "" {
+		t.Fatalf("unexpected created token payload: %+v", created)
+	}
+
+	listResp, err := client.Get(proc.BaseURL + "/api/v1/tokens")
+	if err != nil {
+		t.Fatalf("list tokens request: %v", err)
+	}
+	defer func() { _ = listResp.Body.Close() }()
+
+	var listed []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list tokens response: %v", err)
+	}
+	if len(listed) != 1 || listed[0].Name != "process-token" {
+		t.Fatalf("listed tokens = %+v, want one process-token", listed)
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, proc.BaseURL+"/api/v1/tokens/"+created.ID, nil)
+	if err != nil {
+		t.Fatalf("new revoke request: %v", err)
+	}
+	revokeResp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("revoke token request: %v", err)
+	}
+	defer func() { _ = revokeResp.Body.Close() }()
+	if revokeResp.StatusCode != http.StatusOK {
+		t.Fatalf("revoke status = %d, want 200", revokeResp.StatusCode)
+	}
+}
+
+func postJSON(t *testing.T, client *http.Client, url string, body any) *http.Response {
+	t.Helper()
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	if resp.StatusCode >= 400 {
+		t.Fatalf("POST %s returned %d", url, resp.StatusCode)
+	}
+	return resp
+}

--- a/internal/testutil/gestaltd_process.go
+++ b/internal/testutil/gestaltd_process.go
@@ -1,0 +1,303 @@
+package testutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/cookiejar"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+type GestaltdProcess struct {
+	BaseURL    string
+	ConfigPath string
+	Client     *http.Client
+
+	cmd    *exec.Cmd
+	stdout bytes.Buffer
+	stderr bytes.Buffer
+	done   chan error
+}
+
+type GestaltdCommandResult struct {
+	Output string
+	Err    error
+}
+
+var (
+	gestaltdBinaryOnce sync.Once
+	gestaltdBinaryPath string
+	gestaltdBinaryErr  error
+)
+
+func FreePort(t *testing.T) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for free port: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("unexpected listener address type %T", listener.Addr())
+	}
+	return addr.Port
+}
+
+func FindFreePort(t *testing.T) int {
+	t.Helper()
+	return FreePort(t)
+}
+
+func AllocatePort(t *testing.T) int {
+	t.Helper()
+	return FreePort(t)
+}
+
+func RunGestaltd(t *testing.T, args ...string) GestaltdCommandResult {
+	t.Helper()
+
+	cmd := exec.Command(gestaltdBinary(t), args...)
+	cmd.Dir = RepoRoot(t)
+
+	out, err := cmd.CombinedOutput()
+	return GestaltdCommandResult{
+		Output: string(out),
+		Err:    err,
+	}
+}
+
+func StartGestaltd(t *testing.T, configPath string, port int) *GestaltdProcess {
+	t.Helper()
+
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	cmd := exec.Command(gestaltdBinary(t), "--config", configPath)
+	cmd.Dir = RepoRoot(t)
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("create cookie jar: %v", err)
+	}
+
+	proc := &GestaltdProcess{
+		BaseURL:    baseURL,
+		ConfigPath: configPath,
+		Client:     &http.Client{Jar: jar},
+		cmd:        cmd,
+		done:       make(chan error, 1),
+	}
+	cmd.Stdout = &proc.stdout
+	cmd.Stderr = &proc.stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start gestaltd: %v", err)
+	}
+
+	go func() {
+		proc.done <- cmd.Wait()
+	}()
+
+	if err := proc.waitForReady(45 * time.Second); err != nil {
+		_ = proc.stop(2 * time.Second)
+		t.Fatalf("wait for gestaltd readiness: %v\nstdout:\n%s\nstderr:\n%s", err, proc.stdout.String(), proc.stderr.String())
+	}
+
+	t.Cleanup(func() {
+		if err := proc.stop(5 * time.Second); err != nil {
+			t.Fatalf("stop gestaltd: %v\nstdout:\n%s\nstderr:\n%s", err, proc.stdout.String(), proc.stderr.String())
+		}
+	})
+
+	return proc
+}
+
+func RepoRoot(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve repo root: runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func gestaltdBinary(t *testing.T) string {
+	t.Helper()
+
+	gestaltdBinaryOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "gestaltd-bin-*")
+		if err != nil {
+			gestaltdBinaryErr = fmt.Errorf("create temp binary dir: %w", err)
+			return
+		}
+
+		path := filepath.Join(dir, "gestaltd")
+		cmd := exec.Command("go", "build", "-o", path, "./cmd/gestaltd")
+		cmd.Dir = RepoRoot(t)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			gestaltdBinaryErr = fmt.Errorf("build gestaltd: %w\n%s", err, out)
+			return
+		}
+		gestaltdBinaryPath = path
+	})
+
+	if gestaltdBinaryErr != nil {
+		t.Fatal(gestaltdBinaryErr)
+	}
+	return gestaltdBinaryPath
+}
+
+func WriteConfigFile(t *testing.T, dir, body string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+	return path
+}
+
+func (p *GestaltdProcess) Logs() string {
+	return p.stdout.String() + p.stderr.String()
+}
+
+func (p *GestaltdProcess) waitForReady(timeout time.Duration) error {
+	client := &http.Client{Timeout: time.Second}
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-p.done:
+			return fmt.Errorf("process exited before ready: %w", err)
+		default:
+		}
+
+		resp, err := client.Get(p.BaseURL + "/ready")
+		if err == nil {
+			func() {
+				defer func() { _ = resp.Body.Close() }()
+				if resp.StatusCode == http.StatusOK {
+					err = nil
+				} else {
+					err = fmt.Errorf("unexpected /ready status %d", resp.StatusCode)
+				}
+			}()
+			if err == nil {
+				return nil
+			}
+		}
+
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	return fmt.Errorf("timed out waiting for %s/ready", p.BaseURL)
+}
+
+func (p *GestaltdProcess) stop(timeout time.Duration) error {
+	if p.cmd.Process == nil {
+		return nil
+	}
+
+	if err := p.cmd.Process.Signal(os.Interrupt); err != nil && !isDone(p.done) {
+		return fmt.Errorf("interrupt gestaltd: %w", err)
+	}
+
+	select {
+	case err := <-p.done:
+		if err != nil {
+			return err
+		}
+		return nil
+	case <-time.After(timeout):
+	}
+
+	if err := p.cmd.Process.Kill(); err != nil {
+		return fmt.Errorf("kill gestaltd: %w", err)
+	}
+
+	select {
+	case err := <-p.done:
+		if err != nil {
+			return err
+		}
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("timed out waiting for process exit")
+	}
+}
+
+func isDone(ch <-chan error) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
+func DevLogin(t *testing.T, client *http.Client, baseURL, email string) {
+	t.Helper()
+
+	status, body := DoJSON(t, client, http.MethodPost, baseURL+"/api/dev-login", map[string]string{
+		"email": email,
+	})
+	if status != http.StatusOK {
+		t.Fatalf("dev login status=%d body=%s", status, string(body))
+	}
+}
+
+func DoJSON(t *testing.T, client *http.Client, method, url string, payload any) (int, []byte) {
+	t.Helper()
+
+	var body io.Reader
+	if payload != nil {
+		buf := new(bytes.Buffer)
+		if err := json.NewEncoder(buf).Encode(payload); err != nil {
+			t.Fatalf("encode JSON payload: %v", err)
+		}
+		body = buf
+	}
+
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+
+	return resp.StatusCode, respBody
+}
+
+func DecodeJSON[T any](t *testing.T, body []byte) T {
+	t.Helper()
+
+	var value T
+	if err := json.Unmarshal(body, &value); err != nil {
+		t.Fatalf("decode JSON: %v\nbody=%s", err, body)
+	}
+	return value
+}

--- a/internal/testutil/gestaltd_process.go
+++ b/internal/testutil/gestaltd_process.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -84,6 +85,7 @@ func StartGestaltd(t *testing.T, configPath string, port int) *GestaltdProcess {
 	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
 	cmd := exec.Command(gestaltdBinary(t), "--config", configPath)
 	cmd.Dir = RepoRoot(t)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	jar, err := cookiejar.New(nil)
 	if err != nil {
@@ -209,9 +211,10 @@ func (p *GestaltdProcess) stop(timeout time.Duration) error {
 	if p.cmd.Process == nil {
 		return nil
 	}
+	p.Client.CloseIdleConnections()
 
-	if err := p.cmd.Process.Signal(os.Interrupt); err != nil && !isDone(p.done) {
-		return fmt.Errorf("interrupt gestaltd: %w", err)
+	if err := syscall.Kill(-p.cmd.Process.Pid, syscall.SIGTERM); err != nil && !isDone(p.done) {
+		return fmt.Errorf("terminate gestaltd: %w", err)
 	}
 
 	select {
@@ -223,7 +226,7 @@ func (p *GestaltdProcess) stop(timeout time.Duration) error {
 	case <-time.After(timeout):
 	}
 
-	if err := p.cmd.Process.Kill(); err != nil {
+	if err := syscall.Kill(-p.cmd.Process.Pid, syscall.SIGKILL); err != nil {
 		return fmt.Errorf("kill gestaltd: %w", err)
 	}
 

--- a/internal/testutil/test_config.go
+++ b/internal/testutil/test_config.go
@@ -1,0 +1,66 @@
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type DevConfigOptions struct {
+	Port         int
+	BaseURL      string
+	DatabasePath string
+	ExtraYAML    string
+}
+
+func WriteDevConfig(t *testing.T, dir string, opts DevConfigOptions) string {
+	t.Helper()
+
+	port := opts.Port
+	if port == 0 {
+		port = FreePort(t)
+	}
+
+	baseURL := opts.BaseURL
+	if baseURL == "" {
+		baseURL = fmt.Sprintf("http://127.0.0.1:%d", port)
+	}
+
+	dbPath := opts.DatabasePath
+	if dbPath == "" {
+		dbPath = filepath.Join(dir, "gestalt.db")
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, `auth:
+  provider: google
+  config:
+    client_id: test-client
+    client_secret: test-secret
+    redirect_url: %s/api/v1/auth/login/callback
+datastore:
+  provider: sqlite
+  config:
+    path: %s
+server:
+  port: %d
+  base_url: %s
+  dev_mode: true
+  encryption_key: test-encryption-key
+`, baseURL, dbPath, port, baseURL)
+
+	if extra := strings.TrimSpace(opts.ExtraYAML); extra != "" {
+		b.WriteByte('\n')
+		b.WriteString(extra)
+		b.WriteByte('\n')
+	}
+
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(b.String()), 0644); err != nil {
+		t.Fatalf("write test config: %v", err)
+	}
+
+	return path
+}

--- a/internal/testutil/upstreams.go
+++ b/internal/testutil/upstreams.go
@@ -1,0 +1,279 @@
+package testutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+type OAuthServerOptions struct {
+	Email        string
+	DisplayName  string
+	PictureURL   string
+	TokenExtras  map[string]any
+	RefreshToken string
+}
+
+type OAuthServer struct {
+	URL string
+
+	server *httptest.Server
+
+	email        string
+	displayName  string
+	pictureURL   string
+	tokenExtras  map[string]any
+	refreshToken string
+
+	mu          sync.Mutex
+	nextCodeID  int
+	tokenByCode map[string]string
+}
+
+func NewOAuthServer(t *testing.T, opts OAuthServerOptions) *OAuthServer {
+	t.Helper()
+
+	srv := &OAuthServer{
+		email:        opts.Email,
+		displayName:  opts.DisplayName,
+		pictureURL:   opts.PictureURL,
+		tokenExtras:  cloneMap(opts.TokenExtras),
+		refreshToken: opts.RefreshToken,
+		tokenByCode:  make(map[string]string),
+	}
+	if srv.email == "" {
+		srv.email = "integration-test@gestalt.dev"
+	}
+	if srv.displayName == "" {
+		srv.displayName = "Integration Test User"
+	}
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			writeJSONResponse(w, http.StatusOK, map[string]any{
+				"issuer":                 server.URL,
+				"authorization_endpoint": server.URL + "/authorize",
+				"token_endpoint":         server.URL + "/token",
+				"userinfo_endpoint":      server.URL + "/userinfo",
+			})
+		case "/authorize":
+			redirectURI := r.URL.Query().Get("redirect_uri")
+			state := r.URL.Query().Get("state")
+			if redirectURI == "" {
+				http.Error(w, "missing redirect_uri", http.StatusBadRequest)
+				return
+			}
+
+			code, accessToken := srv.issueCode()
+			srv.mu.Lock()
+			srv.tokenByCode[code] = accessToken
+			srv.mu.Unlock()
+
+			target := fmt.Sprintf("%s?code=%s", redirectURI, code)
+			if state != "" {
+				target += "&state=" + state
+			}
+			http.Redirect(w, r, target, http.StatusFound)
+		case "/token":
+			if err := r.ParseForm(); err != nil {
+				http.Error(w, "invalid token request", http.StatusBadRequest)
+				return
+			}
+
+			code := r.Form.Get("code")
+			accessToken, ok := srv.accessTokenForCode(code)
+			if !ok {
+				writeJSONResponse(w, http.StatusBadRequest, map[string]any{
+					"error":             "invalid_grant",
+					"error_description": "unknown authorization code",
+				})
+				return
+			}
+
+			resp := map[string]any{
+				"access_token": accessToken,
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			}
+			if srv.refreshToken != "" {
+				resp["refresh_token"] = srv.refreshToken
+			}
+			for key, value := range srv.tokenExtras {
+				resp[key] = value
+			}
+			writeJSONResponse(w, http.StatusOK, resp)
+		case "/userinfo":
+			token := bearerToken(r)
+			if token == "" || !srv.hasAccessToken(token) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			writeJSONResponse(w, http.StatusOK, map[string]any{
+				"email":          srv.email,
+				"name":           srv.displayName,
+				"picture":        srv.pictureURL,
+				"email_verified": true,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	srv.server = server
+	srv.URL = server.URL
+	t.Cleanup(server.Close)
+	return srv
+}
+
+func (s *OAuthServer) issueCode() (string, string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.nextCodeID++
+	code := fmt.Sprintf("code-%d", s.nextCodeID)
+	accessToken := fmt.Sprintf("access-token-%d", s.nextCodeID)
+	return code, accessToken
+}
+
+func (s *OAuthServer) accessTokenForCode(code string) (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	token, ok := s.tokenByCode[code]
+	return token, ok
+}
+
+func (s *OAuthServer) hasAccessToken(token string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, issued := range s.tokenByCode {
+		if issued == token {
+			return true
+		}
+	}
+	return false
+}
+
+type OpenAPIFixtureOptions struct {
+	ExpectedBearerToken string
+	DiscoveryCandidates []map[string]any
+}
+
+type OpenAPIFixture struct {
+	Server  *httptest.Server
+	SpecURL string
+
+	expectedBearerToken string
+	lastAuthorization   atomic.Value
+	discoveryCandidates atomic.Value
+}
+
+func NewOpenAPIFixture(t *testing.T, opts OpenAPIFixtureOptions) *OpenAPIFixture {
+	t.Helper()
+
+	fixture := &OpenAPIFixture{
+		expectedBearerToken: opts.ExpectedBearerToken,
+	}
+	if len(opts.DiscoveryCandidates) > 0 {
+		fixture.discoveryCandidates.Store(opts.DiscoveryCandidates)
+	}
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/openapi.json":
+			writeJSONResponse(w, http.StatusOK, map[string]any{
+				"openapi": "3.0.0",
+				"info": map[string]any{
+					"title":   "Warehouse API",
+					"version": "1.0.0",
+				},
+				"servers": []map[string]any{{"url": server.URL}},
+				"paths": map[string]any{
+					"/items": map[string]any{
+						"get": map[string]any{
+							"operationId": "list_items",
+							"summary":     "List items",
+						},
+					},
+				},
+			})
+		case "/items":
+			fixture.lastAuthorization.Store(r.Header.Get("Authorization"))
+			if fixture.expectedBearerToken != "" {
+				expected := "Bearer " + fixture.expectedBearerToken
+				if r.Header.Get("Authorization") != expected {
+					writeJSONResponse(w, http.StatusUnauthorized, map[string]any{
+						"error": "unexpected authorization header",
+					})
+					return
+				}
+			}
+			writeJSONResponse(w, http.StatusOK, map[string]any{
+				"items": []map[string]any{
+					{"id": "1", "name": "alpha"},
+					{"id": "2", "name": "beta"},
+				},
+			})
+		case "/discovery/accounts":
+			candidates, _ := fixture.discoveryCandidates.Load().([]map[string]any)
+			if len(candidates) == 0 {
+				candidates = []map[string]any{
+					{"id": "acct-1", "name": "Primary", "region": "us-east-1"},
+				}
+			}
+			writeJSONResponse(w, http.StatusOK, map[string]any{
+				"accounts": candidates,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	fixture.Server = server
+	fixture.SpecURL = server.URL + "/openapi.json"
+	t.Cleanup(server.Close)
+	return fixture
+}
+
+func (f *OpenAPIFixture) LastAuthorization() string {
+	value := f.lastAuthorization.Load()
+	if value == nil {
+		return ""
+	}
+	auth, _ := value.(string)
+	return auth
+}
+
+func writeJSONResponse(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func bearerToken(r *http.Request) string {
+	header := r.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if len(header) <= len(prefix) || header[:len(prefix)] != prefix {
+		return ""
+	}
+	return header[len(prefix):]
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- add reusable test helpers for building and launching a real `gestaltd` subprocess
- add temp config and upstream fixtures for process-level integration tests
- add black-box `cmd/gestaltd` smoke coverage for real auth, invoke, and token flows

## Verification
- go test ./cmd/gestaltd -count=1