### PR TITLE
test(functional-web-auth): keep CLI auth handoff on the callback page

### DIFF
--- a/web/e2e/auth.spec.ts
+++ b/web/e2e/auth.spec.ts
@@ -78,6 +78,38 @@ test.describe("Authentication", () => {
     await expect(page.getByText(/Invalid OAuth state/)).toBeVisible();
   });
 
+  test("auth callback hands off CLI state without navigating to localhost", async ({
+    page,
+  }) => {
+    const code = "test-code";
+    const state = "original-state";
+    const port = 12345;
+    let callbackRequestUrl: string | null = null;
+
+    await page.route(`**://127.0.0.1:${port}/**`, async (route, request) => {
+      callbackRequestUrl = request.url();
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: "<!doctype html><html><body>ok</body></html>",
+      });
+    });
+
+    await page.goto(`/auth/callback?code=${code}&state=cli:${port}:${state}`);
+
+    await expect.poll(() => callbackRequestUrl).toBeTruthy();
+    expect(callbackRequestUrl).toContain(`http://127.0.0.1:${port}/`);
+
+    const callbackUrl = new URL(callbackRequestUrl as string);
+    expect(callbackUrl.searchParams.get("code")).toBe(code);
+    expect(callbackUrl.searchParams.get("state")).toBe(state);
+
+    await expect(page).not.toHaveURL(new RegExp(`127\\.0\\.0\\.1:${port}`));
+    await expect(
+      page.getByText("Login successful! You can close this tab."),
+    ).toBeVisible();
+  });
+
   test("401 response clears session and redirects to login", async ({
     authenticatedPage,
   }) => {

--- a/web/src/app/auth/callback/page.tsx
+++ b/web/src/app/auth/callback/page.tsx
@@ -5,10 +5,16 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { loginCallback } from "@/lib/api";
 import { setUserEmail } from "@/lib/auth";
 
+const CLI_STATE_PREFIX = "cli:";
+const MAX_PORT = 65535;
+const cliHandoffKeys = new Set<string>();
+
 function CallbackHandler() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [error, setError] = useState<string | null>(null);
+  const [cliHandoffUrl, setCliHandoffUrl] = useState<string | null>(null);
+  const [cliHandoffComplete, setCliHandoffComplete] = useState(false);
 
   useEffect(() => {
     const code = searchParams.get("code");
@@ -21,16 +27,19 @@ function CallbackHandler() {
     }
 
     // CLI-initiated login encodes callback port in state as "cli:{port}:{original_state}".
-    const CLI_STATE_PREFIX = "cli:";
-    const MAX_PORT = 65535;
     if (returnedState?.startsWith(CLI_STATE_PREFIX)) {
       const parts = returnedState.split(":");
       if (parts.length >= 3) {
         const port = parseInt(parts[1], 10);
         const originalState = parts.slice(2).join(":");
         if (port > 0 && port <= MAX_PORT) {
-          const params = new URLSearchParams({ state: originalState, code });
-          window.location.href = `http://127.0.0.1:${port}/?${params}`;
+          const cliHandoffKey = `${port}:${code}:${originalState}`;
+          if (!cliHandoffKeys.has(cliHandoffKey)) {
+            cliHandoffKeys.add(cliHandoffKey);
+            sessionStorage.removeItem("oauth_state");
+            const params = new URLSearchParams({ state: originalState, code });
+            setCliHandoffUrl(`http://127.0.0.1:${port}/?${params}`);
+          }
           return;
         }
       }
@@ -63,6 +72,30 @@ function CallbackHandler() {
           <a href="/login" className="mt-4 inline-block text-sm text-timber-600 hover:underline">
             Back to login
           </a>
+        </div>
+      </div>
+    );
+  }
+
+  if (cliHandoffUrl) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="w-full max-w-sm rounded-lg border border-border bg-surface p-8 shadow-warm text-center">
+          <iframe
+            title="CLI login callback"
+            src={cliHandoffUrl}
+            className="hidden"
+            aria-hidden="true"
+            onLoad={() => setCliHandoffComplete(true)}
+            onError={() =>
+              setError("Unable to reach the CLI login callback listener")
+            }
+          />
+          <p className="text-sm text-stone-400">
+            {cliHandoffComplete
+              ? "Login successful! You can close this tab."
+              : "Completing login..."}
+          </p>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- stop CLI OAuth callback flows from navigating the browser to a dead localhost page
- hand off the code and state to the loopback listener through a hidden iframe while keeping the visible tab on the callback page
- add browser-level coverage for the localhost handoff with preserved code and state values

## Verification
- cd web && npm run typecheck
- cd web && npm run lint -- src/app/auth/callback/page.tsx e2e/auth.spec.ts
- cd web && npm run test:e2e -- auth.spec.ts