### PR TITLE
test(integration): add gestaltd process coverage

### DIFF
--- a/cmd/gestaltd/process_integration_test.go
+++ b/cmd/gestaltd/process_integration_test.go
@@ -1,0 +1,467 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/internal/testutil"
+)
+
+func TestGestaltdProcess_PrepareServeOffline(t *testing.T) {
+	t.Parallel()
+
+	port := testutil.FreePort(t)
+	dir := t.TempDir()
+	openAPI := testutil.NewOpenAPIServer(t, "")
+	cfgPath := writeProcessConfig(t, dir, fmt.Sprintf(`
+auth:
+  provider: google
+  config:
+    client_id: test-client
+    client_secret: test-secret
+    redirect_url: http://127.0.0.1:%d/api/v1/auth/login/callback
+datastore:
+  provider: sqlite
+  config:
+    path: %s
+server:
+  port: %d
+  base_url: http://127.0.0.1:%d
+  dev_mode: true
+  encryption_key: test-key
+integrations:
+  restapi:
+    display_name: REST API
+    upstreams:
+      - type: rest
+        url: %s
+`, port, filepath.Join(dir, "gestalt.db"), port, port, openAPI.URL))
+
+	if err := prepareConfig(cfgPath); err != nil {
+		t.Fatalf("prepareConfig: %v", err)
+	}
+	openAPI.Close()
+
+	proc := testutil.StartGestaltd(t, cfgPath, port)
+	client := testutil.NewCookieClient(t)
+	testutil.DevLogin(t, client, proc.BaseURL, "dev@example.com")
+
+	status, body := testutil.DoJSON(t, client, http.MethodGet, proc.BaseURL+"/api/v1/integrations/restapi/operations", nil)
+	if status != http.StatusOK {
+		t.Fatalf("operations status=%d body=%s\nlogs:\n%s", status, string(body), proc.Logs())
+	}
+	var ops []map[string]any
+	if err := json.Unmarshal(body, &ops); err != nil {
+		t.Fatalf("decode operations: %v", err)
+	}
+	if len(ops) == 0 || ops[0]["Name"] != "list_items" {
+		t.Fatalf("expected prepared list_items operation, got %v", ops)
+	}
+
+	status, body = testutil.DoJSON(t, client, http.MethodGet, proc.BaseURL+"/api/v1/integrations", nil)
+	if status != http.StatusOK {
+		t.Fatalf("integrations status=%d body=%s\nlogs:\n%s", status, string(body), proc.Logs())
+	}
+	if !bytes.Contains(body, []byte(`"restapi"`)) {
+		t.Fatalf("expected restapi integration in list, got %s", string(body))
+	}
+}
+
+func TestGestaltdProcess_StagedConnectionSelection(t *testing.T) {
+	t.Parallel()
+
+	port := testutil.FreePort(t)
+	dir := t.TempDir()
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	openAPI := testutil.NewOpenAPIServer(t, "")
+	oauth := testutil.NewOAuthServer(t, testutil.OAuthServerOptions{})
+	discovery := testutil.NewDiscoveryServer(t, testutil.DiscoveryServerOptions{
+		Candidates: []map[string]any{
+			{"id": "acct-a", "name": "Alpha", "region": "us-east-1", "workspace_id": "alpha"},
+			{"id": "acct-b", "name": "Beta", "region": "us-west-2", "workspace_id": "beta"},
+		},
+	})
+	cfgPath := writeProcessConfig(t, dir, fmt.Sprintf(`
+auth:
+  provider: google
+  config:
+    client_id: test-client
+    client_secret: test-secret
+    redirect_url: http://127.0.0.1:%d/api/v1/auth/login/callback
+datastore:
+  provider: sqlite
+  config:
+    path: %s
+server:
+  port: %d
+  base_url: %s
+  dev_mode: true
+  encryption_key: test-key
+integrations:
+  stagedsvc:
+    display_name: Staged Service
+    auth:
+      type: oauth2
+      authorization_url: %s/authorize
+      token_url: %s/token
+    client_id: staged-client
+    client_secret: staged-secret
+    upstreams:
+      - type: rest
+        url: %s
+`, port, filepath.Join(dir, "gestalt.db"), port, baseURL, oauth.URL, oauth.URL, openAPI.URL))
+
+	if err := prepareConfig(cfgPath); err != nil {
+		t.Fatalf("prepareConfig: %v", err)
+	}
+	patchPreparedProviderDiscovery(t, cfgPath, "stagedsvc", discovery.URL)
+	openAPI.Close()
+
+	proc := testutil.StartGestaltd(t, cfgPath, port)
+	client := testutil.NewCookieClient(t)
+	testutil.DevLogin(t, client, proc.BaseURL, "dev@example.com")
+
+	startStatus, startBody := testutil.DoJSON(t, client, http.MethodPost, proc.BaseURL+"/api/v1/auth/start-oauth", map[string]any{
+		"integration": "stagedsvc",
+		"scopes":      []string{},
+	})
+	if startStatus != http.StatusOK {
+		t.Fatalf("start oauth status=%d body=%s\nlogs:\n%s", startStatus, string(startBody), proc.Logs())
+	}
+	startResp := testutil.DecodeJSON[map[string]string](t, startBody)
+	authURL := startResp["url"]
+	if authURL == "" {
+		t.Fatal("missing oauth url")
+	}
+
+	callbackResp := followOAuthFlowToCallback(t, client, authURL, baseURL)
+	defer func() { _ = callbackResp.Body.Close() }()
+	if callbackResp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("callback status=%d\nlogs:\n%s", callbackResp.StatusCode, proc.Logs())
+	}
+	location := callbackResp.Header.Get("Location")
+	if !strings.Contains(location, "/integrations?pending=") {
+		t.Fatalf("expected staged redirect, got %q", location)
+	}
+	stagedID := queryParam(t, location, "pending")
+
+	status, body := testutil.DoJSON(t, client, http.MethodGet, proc.BaseURL+"/api/v1/connections/staged/"+stagedID, nil)
+	if status != http.StatusOK {
+		t.Fatalf("staged connection status=%d body=%s\nlogs:\n%s", status, string(body), proc.Logs())
+	}
+	var staged map[string]any
+	if err := json.Unmarshal(body, &staged); err != nil {
+		t.Fatalf("decode staged connection: %v", err)
+	}
+	candidates, ok := staged["candidates"].([]any)
+	if !ok || len(candidates) != 2 {
+		t.Fatalf("expected 2 staged candidates, got %v", staged["candidates"])
+	}
+	firstCandidate := candidates[0].(map[string]any)
+	candidateID, _ := firstCandidate["id"].(string)
+	if candidateID == "" {
+		t.Fatalf("missing candidate id in %v", firstCandidate)
+	}
+
+	status, body = testutil.DoJSON(t, client, http.MethodPost, proc.BaseURL+"/api/v1/connections/staged/"+stagedID+"/select", map[string]string{
+		"candidate_id": candidateID,
+	})
+	if status != http.StatusOK {
+		t.Fatalf("select staged status=%d body=%s\nlogs:\n%s", status, string(body), proc.Logs())
+	}
+	selected := testutil.DecodeJSON[map[string]string](t, body)
+	if selected["status"] != "connected" {
+		t.Fatalf("expected connected status, got %v", selected)
+	}
+
+	status, body = testutil.DoJSON(t, client, http.MethodGet, proc.BaseURL+"/api/v1/integrations", nil)
+	if status != http.StatusOK {
+		t.Fatalf("integrations status=%d body=%s\nlogs:\n%s", status, string(body), proc.Logs())
+	}
+	if !bytes.Contains(body, []byte(`"stagedsvc"`)) {
+		t.Fatalf("expected stagedsvc to appear in integrations list, got %s", string(body))
+	}
+}
+
+func TestGestaltdProcess_MCPAndBindings(t *testing.T) {
+	t.Parallel()
+
+	port := testutil.FreePort(t)
+	dir := t.TempDir()
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	mcpUp := testutil.NewMCPServer(t)
+	proxyUp := testutil.NewOpenAPIServer(t, "proxy-token")
+	cfgPath := writeProcessConfig(t, dir, fmt.Sprintf(`
+auth:
+  provider: google
+  config:
+    client_id: test-client
+    client_secret: test-secret
+    redirect_url: http://127.0.0.1:%d/api/v1/auth/login/callback
+datastore:
+  provider: sqlite
+  config:
+    path: %s
+server:
+  port: %d
+  base_url: %s
+  dev_mode: true
+  encryption_key: test-key
+integrations:
+  mcpsvc:
+    display_name: MCP Service
+    auth:
+      type: manual
+    manual_auth: true
+    upstreams:
+      - type: mcp
+        url: %s
+  proxysvc:
+    display_name: Proxy Service
+    auth:
+      type: manual
+    manual_auth: true
+    upstreams:
+      - type: rest
+        url: %s
+bindings:
+  echo-webhook:
+    type: webhook
+    config:
+      path: /incoming
+  proxy-route:
+    type: proxy
+    providers:
+      - proxysvc
+    config:
+      path: /proxy
+`, port, filepath.Join(dir, "gestalt.db"), port, baseURL, mcpUp.URL, proxyUp.URL))
+
+	proc := testutil.StartGestaltd(t, cfgPath, port)
+	client := testutil.NewCookieClient(t)
+	testutil.DevLogin(t, client, proc.BaseURL, "dev@example.com")
+
+	status, body := testutil.DoJSON(t, client, http.MethodPost, proc.BaseURL+"/api/v1/auth/connect-manual", map[string]any{
+		"integration": "mcpsvc",
+		"credential":  "mcp-token",
+	})
+	if status != http.StatusOK {
+		t.Fatalf("connect mcp manual status=%d body=%s\nlogs:\n%s", status, string(body), proc.Logs())
+	}
+
+	waitForMCPMounted(t, client, proc.BaseURL)
+
+	status, resp := doMCPJSONRPC(t, client, proc.BaseURL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-03-26",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+		},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("initialize: expected 200, got %d\nresp=%v\nlogs:\n%s", status, resp, proc.Logs())
+	}
+	status, resp = doMCPJSONRPC(t, client, proc.BaseURL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/list",
+	})
+	if status != http.StatusOK {
+		t.Fatalf("tools/list: expected 200, got %d\nresp=%v\nlogs:\n%s", status, resp, proc.Logs())
+	}
+	result, _ := resp["result"].(map[string]any)
+	tools, _ := result["tools"].([]any)
+	if len(tools) == 0 {
+		t.Fatalf("expected MCP tools, got %v", result)
+	}
+	foundEcho := false
+	for _, tool := range tools {
+		m := tool.(map[string]any)
+		if m["name"] == "mcpsvc_echo" {
+			foundEcho = true
+			break
+		}
+	}
+	if !foundEcho {
+		t.Fatalf("expected mcpsvc_echo in tools list, got %v", tools)
+	}
+
+	status, resp = doMCPJSONRPC(t, client, proc.BaseURL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      3,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "mcpsvc_echo",
+			"arguments": map[string]any{"message": "hello"},
+		},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("tools/call: expected 200, got %d\nresp=%v\nlogs:\n%s", status, resp, proc.Logs())
+	}
+	result, _ = resp["result"].(map[string]any)
+	content, _ := result["content"].([]any)
+	if len(content) == 0 {
+		t.Fatalf("expected MCP call content, got %v", result)
+	}
+
+	status, body = testutil.DoJSON(t, client, http.MethodPost, proc.BaseURL+"/api/v1/bindings/echo-webhook/incoming", map[string]any{
+		"ok": true,
+	})
+	if status != http.StatusOK {
+		t.Fatalf("webhook binding status=%d body=%s\nlogs:\n%s", status, string(body), proc.Logs())
+	}
+	if !bytes.Contains(body, []byte(`"ok":true`)) {
+		t.Fatalf("expected webhook binding to echo body, got %s", string(body))
+	}
+}
+
+func writeProcessConfig(t *testing.T, dir, body string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func patchPreparedProviderDiscovery(t *testing.T, cfgPath, integration, discoveryURL string) {
+	t.Helper()
+
+	providerPath := filepath.Join(filepath.Dir(cfgPath), preparedProvidersDir, integration+".json")
+	data, err := os.ReadFile(providerPath)
+	if err != nil {
+		t.Fatalf("read prepared provider: %v", err)
+	}
+
+	var def map[string]any
+	if err := json.Unmarshal(data, &def); err != nil {
+		t.Fatalf("decode prepared provider: %v", err)
+	}
+	def["post_connect_discovery"] = map[string]any{
+		"url":        discoveryURL,
+		"items_path": "accounts",
+		"id_path":    "id",
+		"name_path":  "name",
+		"metadata_mapping": map[string]string{
+			"region":       "region",
+			"workspace_id": "workspace_id",
+		},
+	}
+
+	updated, err := json.MarshalIndent(def, "", "  ")
+	if err != nil {
+		t.Fatalf("encode prepared provider: %v", err)
+	}
+	if err := os.WriteFile(providerPath, updated, 0o644); err != nil {
+		t.Fatalf("write prepared provider: %v", err)
+	}
+}
+
+func followOAuthFlowToCallback(t *testing.T, client *http.Client, authURL, baseURL string) *http.Response {
+	t.Helper()
+
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		t.Fatalf("parse base url: %v", err)
+	}
+
+	oldRedirect := client.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if req.URL.Host == base.Host && req.URL.Path == "/api/v1/auth/callback" {
+			return nil
+		}
+		if req.URL.Host == base.Host && req.URL.Path == "/integrations" {
+			return http.ErrUseLastResponse
+		}
+		return nil
+	}
+	defer func() { client.CheckRedirect = oldRedirect }()
+
+	req, err := http.NewRequest(http.MethodGet, authURL, nil)
+	if err != nil {
+		t.Fatalf("new oauth request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("follow oauth flow: %v", err)
+	}
+	return resp
+}
+
+func queryParam(t *testing.T, rawURL, key string) string {
+	t.Helper()
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	return parsed.Query().Get(key)
+}
+
+func doMCPJSONRPC(t *testing.T, client *http.Client, baseURL string, body map[string]any) (int, map[string]any) {
+	t.Helper()
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal mcp request: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/mcp", bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("new mcp request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("mcp request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read mcp response: %v", err)
+	}
+	var result map[string]any
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &result); err != nil {
+			t.Fatalf("decode mcp response: %v\nbody=%s", err, string(raw))
+		}
+	}
+	return resp.StatusCode, result
+}
+
+func waitForMCPMounted(t *testing.T, client *http.Client, baseURL string) {
+	t.Helper()
+
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		status, _ := doMCPJSONRPC(t, client, baseURL, map[string]any{
+			"jsonrpc": "2.0",
+			"id":      99,
+			"method":  "initialize",
+			"params": map[string]any{
+				"protocolVersion": "2025-03-26",
+				"capabilities":    map[string]any{},
+				"clientInfo":      map[string]any{"name": "probe", "version": "1.0"},
+			},
+		})
+		if status != http.StatusNotFound {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for MCP endpoint to mount")
+}

--- a/internal/testutil/gestaltd_process.go
+++ b/internal/testutil/gestaltd_process.go
@@ -1,0 +1,281 @@
+package testutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/cookiejar"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+type GestaltdProcess struct {
+	BaseURL string
+
+	cmd    *exec.Cmd
+	stdout bytes.Buffer
+	stderr bytes.Buffer
+	done   chan error
+}
+
+var gestaltdBinary struct {
+	once sync.Once
+	path string
+	err  error
+}
+
+func FreePort(t *testing.T) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for free port: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("unexpected listener address type %T", listener.Addr())
+	}
+	return addr.Port
+}
+
+func StartGestaltd(t *testing.T, configPath string, port int) *GestaltdProcess {
+	t.Helper()
+
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	cmd := exec.Command(gestaltdBinaryPath(t), "--config", configPath)
+	cmd.Dir = RepoRoot(t)
+
+	proc := &GestaltdProcess{
+		BaseURL: baseURL,
+		cmd:     cmd,
+		done:    make(chan error, 1),
+	}
+	cmd.Stdout = &proc.stdout
+	cmd.Stderr = &proc.stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start gestaltd: %v", err)
+	}
+
+	go func() {
+		proc.done <- cmd.Wait()
+	}()
+
+	if err := proc.waitForReady(45 * time.Second); err != nil {
+		_ = proc.stop(2 * time.Second)
+		t.Fatalf("wait for gestaltd readiness: %v\nstdout:\n%s\nstderr:\n%s", err, proc.stdout.String(), proc.stderr.String())
+	}
+
+	t.Cleanup(func() {
+		if err := proc.stop(5 * time.Second); err != nil {
+			t.Fatalf("stop gestaltd: %v\nstdout:\n%s\nstderr:\n%s", err, proc.stdout.String(), proc.stderr.String())
+		}
+	})
+
+	return proc
+}
+
+func RepoRoot(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve repo root: runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func gestaltdBinaryPath(t *testing.T) string {
+	t.Helper()
+
+	gestaltdBinary.once.Do(func() {
+		dir, err := os.MkdirTemp("", "gestaltd-bin-*")
+		if err != nil {
+			gestaltdBinary.err = fmt.Errorf("create temp dir for gestaltd binary: %w", err)
+			return
+		}
+
+		bin := filepath.Join(dir, "gestaltd")
+		cmd := exec.Command("go", "build", "-o", bin, "./cmd/gestaltd")
+		cmd.Dir = RepoRoot(t)
+
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			gestaltdBinary.err = fmt.Errorf("build gestaltd: %w\n%s", err, out)
+			return
+		}
+		gestaltdBinary.path = bin
+	})
+
+	if gestaltdBinary.err != nil {
+		t.Fatal(gestaltdBinary.err)
+	}
+	return gestaltdBinary.path
+}
+
+func WriteConfigFile(t *testing.T, dir, body string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+	return path
+}
+
+func NewCookieClient(t *testing.T) *http.Client {
+	t.Helper()
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("create cookie jar: %v", err)
+	}
+
+	return &http.Client{
+		Jar:     jar,
+		Timeout: 10 * time.Second,
+	}
+}
+
+func DevLogin(t *testing.T, client *http.Client, baseURL, email string) {
+	t.Helper()
+
+	status, body := DoJSON(t, client, http.MethodPost, baseURL+"/api/dev-login", map[string]string{
+		"email": email,
+	})
+	if status != http.StatusOK {
+		t.Fatalf("dev login status=%d body=%s", status, string(body))
+	}
+}
+
+func DoJSON(t *testing.T, client *http.Client, method, url string, payload any) (int, []byte) {
+	t.Helper()
+
+	var body io.Reader
+	if payload != nil {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatalf("marshal request: %v", err)
+		}
+		body = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		t.Fatalf("new request %s %s: %v", method, url, err)
+	}
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+
+	return resp.StatusCode, respBody
+}
+
+func DecodeJSON[T any](t *testing.T, body []byte) T {
+	t.Helper()
+
+	var out T
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody=%s", err, string(body))
+	}
+	return out
+}
+
+func (p *GestaltdProcess) Logs() string {
+	return "stdout:\n" + p.stdout.String() + "\nstderr:\n" + p.stderr.String()
+}
+
+func (p *GestaltdProcess) waitForReady(timeout time.Duration) error {
+	client := &http.Client{Timeout: time.Second}
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-p.done:
+			return fmt.Errorf("process exited before ready: %w", err)
+		default:
+		}
+
+		resp, err := client.Get(p.BaseURL + "/ready")
+		if err == nil {
+			func() {
+				defer func() { _ = resp.Body.Close() }()
+				if resp.StatusCode == http.StatusOK {
+					err = nil
+				} else {
+					err = fmt.Errorf("unexpected /ready status %d", resp.StatusCode)
+				}
+			}()
+			if err == nil {
+				return nil
+			}
+		}
+
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	return fmt.Errorf("timed out waiting for %s/ready", p.BaseURL)
+}
+
+func (p *GestaltdProcess) stop(timeout time.Duration) error {
+	if p.cmd.Process == nil {
+		return nil
+	}
+
+	if err := p.cmd.Process.Signal(os.Interrupt); err != nil && !isDone(p.done) {
+		return fmt.Errorf("interrupt gestaltd: %w", err)
+	}
+
+	select {
+	case err := <-p.done:
+		if err != nil {
+			return err
+		}
+		return nil
+	case <-time.After(timeout):
+	}
+
+	if err := p.cmd.Process.Kill(); err != nil {
+		return fmt.Errorf("kill gestaltd: %w", err)
+	}
+
+	select {
+	case err := <-p.done:
+		if err != nil {
+			return err
+		}
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("timed out waiting for process exit")
+	}
+}
+
+func isDone(ch <-chan error) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/testutil/upstreams.go
+++ b/internal/testutil/upstreams.go
@@ -1,0 +1,325 @@
+package testutil
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+)
+
+type OAuthServerOptions struct {
+	Email        string
+	DisplayName  string
+	PictureURL   string
+	TokenExtras  map[string]any
+	RefreshToken string
+}
+
+type OAuthServer struct {
+	URL string
+
+	server *httptest.Server
+
+	email        string
+	displayName  string
+	pictureURL   string
+	tokenExtras  map[string]any
+	refreshToken string
+
+	mu          sync.Mutex
+	nextCodeID  int
+	tokenByCode map[string]string
+}
+
+func NewOAuthServer(t *testing.T, opts OAuthServerOptions) *OAuthServer {
+	t.Helper()
+
+	srv := &OAuthServer{
+		email:        opts.Email,
+		displayName:  opts.DisplayName,
+		pictureURL:   opts.PictureURL,
+		tokenExtras:  cloneMap(opts.TokenExtras),
+		refreshToken: opts.RefreshToken,
+		tokenByCode:  make(map[string]string),
+	}
+	if srv.email == "" {
+		srv.email = "integration-test@gestalt.dev"
+	}
+	if srv.displayName == "" {
+		srv.displayName = "Integration Test User"
+	}
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authorize":
+			redirectURI := r.URL.Query().Get("redirect_uri")
+			state := r.URL.Query().Get("state")
+			if redirectURI == "" {
+				http.Error(w, "missing redirect_uri", http.StatusBadRequest)
+				return
+			}
+			code, accessToken := srv.issueCode()
+			srv.mu.Lock()
+			srv.tokenByCode[code] = accessToken
+			srv.mu.Unlock()
+
+			target := fmt.Sprintf("%s?code=%s", redirectURI, code)
+			if state != "" {
+				target += "&state=" + state
+			}
+			http.Redirect(w, r, target, http.StatusFound)
+		case "/token":
+			if err := r.ParseForm(); err != nil {
+				http.Error(w, "invalid token request", http.StatusBadRequest)
+				return
+			}
+			code := r.Form.Get("code")
+			accessToken, ok := srv.accessTokenForCode(code)
+			if !ok {
+				writeJSONResponse(w, http.StatusBadRequest, map[string]any{
+					"error":             "invalid_grant",
+					"error_description": "unknown authorization code",
+				})
+				return
+			}
+			resp := map[string]any{
+				"access_token": accessToken,
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			}
+			if srv.refreshToken != "" {
+				resp["refresh_token"] = srv.refreshToken
+			}
+			for key, value := range srv.tokenExtras {
+				resp[key] = value
+			}
+			writeJSONResponse(w, http.StatusOK, resp)
+		case "/userinfo":
+			token := bearerToken(r)
+			if token == "" || !srv.hasAccessToken(token) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			writeJSONResponse(w, http.StatusOK, map[string]any{
+				"email":          srv.email,
+				"name":           srv.displayName,
+				"picture":        srv.pictureURL,
+				"email_verified": true,
+			})
+		case "/.well-known/openid-configuration":
+			writeJSONResponse(w, http.StatusOK, map[string]any{
+				"issuer":                 server.URL,
+				"authorization_endpoint": server.URL + "/authorize",
+				"token_endpoint":         server.URL + "/token",
+				"userinfo_endpoint":      server.URL + "/userinfo",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	srv.server = server
+	srv.URL = server.URL
+	t.Cleanup(server.Close)
+	return srv
+}
+
+func (s *OAuthServer) Close() {
+	if s != nil && s.server != nil {
+		s.server.Close()
+	}
+}
+
+func (s *OAuthServer) issueCode() (string, string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.nextCodeID++
+	code := fmt.Sprintf("code-%d", s.nextCodeID)
+	accessToken := fmt.Sprintf("access-token-%d", s.nextCodeID)
+	return code, accessToken
+}
+
+func (s *OAuthServer) accessTokenForCode(code string) (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	token, ok := s.tokenByCode[code]
+	return token, ok
+}
+
+func (s *OAuthServer) hasAccessToken(token string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, issued := range s.tokenByCode {
+		if issued == token {
+			return true
+		}
+	}
+	return false
+}
+
+type DiscoveryServerOptions struct {
+	Candidates []map[string]any
+}
+
+type DiscoveryServer struct {
+	URL string
+
+	server *httptest.Server
+}
+
+func NewDiscoveryServer(t *testing.T, opts DiscoveryServerOptions) *DiscoveryServer {
+	t.Helper()
+
+	candidates := opts.Candidates
+	if len(candidates) == 0 {
+		candidates = []map[string]any{
+			{"id": "acct-a", "name": "Alpha", "region": "us-east-1"},
+			{"id": "acct-b", "name": "Beta", "region": "us-west-2"},
+		}
+	}
+
+	srv := &DiscoveryServer{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSONResponse(w, http.StatusOK, map[string]any{
+			"accounts": candidates,
+		})
+	}))
+	srv.server = server
+	srv.URL = server.URL + "/accounts"
+	t.Cleanup(server.Close)
+	return srv
+}
+
+func (s *DiscoveryServer) Close() {
+	if s != nil && s.server != nil {
+		s.server.Close()
+	}
+}
+
+type OpenAPIServer struct {
+	URL string
+
+	server *httptest.Server
+}
+
+func NewOpenAPIServer(t *testing.T, expectedBearer string) *OpenAPIServer {
+	t.Helper()
+
+	srv := &OpenAPIServer{}
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/openapi.json":
+			writeJSONResponse(w, http.StatusOK, map[string]any{
+				"openapi": "3.0.0",
+				"info": map[string]any{
+					"title":   "Warehouse API",
+					"version": "1.0.0",
+				},
+				"servers": []map[string]any{{"url": server.URL}},
+				"paths": map[string]any{
+					"/items": map[string]any{
+						"get": map[string]any{
+							"operationId": "list_items",
+							"summary":     "List items",
+						},
+					},
+				},
+			})
+		case "/items":
+			if expectedBearer != "" {
+				want := "Bearer " + expectedBearer
+				if r.Header.Get("Authorization") != want {
+					writeJSONResponse(w, http.StatusUnauthorized, map[string]any{
+						"error": "unexpected authorization header",
+					})
+					return
+				}
+			}
+			writeJSONResponse(w, http.StatusOK, map[string]any{
+				"items": []map[string]any{
+					{"id": "1", "name": "alpha"},
+					{"id": "2", "name": "beta"},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	srv.server = server
+	srv.URL = server.URL + "/openapi.json"
+	t.Cleanup(server.Close)
+	return srv
+}
+
+func (s *OpenAPIServer) Close() {
+	if s != nil && s.server != nil {
+		s.server.Close()
+	}
+}
+
+type MCPServer struct {
+	URL string
+
+	server *httptest.Server
+}
+
+func NewMCPServer(t *testing.T) *MCPServer {
+	t.Helper()
+
+	srv := mcpserver.NewMCPServer("test-remote", "1.0.0")
+	srv.AddTool(
+		mcpgo.NewTool("echo", mcpgo.WithDescription("Echo input")),
+		func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+			return mcpgo.NewToolResultText(fmt.Sprintf("%v", req.GetArguments()["message"])), nil
+		},
+	)
+
+	handler := mcpserver.NewStreamableHTTPServer(srv, mcpserver.WithStateLess(true))
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	return &MCPServer{URL: server.URL, server: server}
+}
+
+func (s *MCPServer) Close() {
+	if s != nil && s.server != nil {
+		s.server.Close()
+	}
+}
+
+func writeJSONResponse(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func bearerToken(r *http.Request) string {
+	header := r.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if len(header) <= len(prefix) || header[:len(prefix)] != prefix {
+		return ""
+	}
+	return header[len(prefix):]
+}


### PR DESCRIPTION
Adds real process coverage for prepare->serve offline startup, staged connection selection, MCP hydration, and binding startup/routing via the actual gestaltd binary.\n\nTests: go test ./cmd/gestaltd ./internal/testutil -count=1