### PR TITLE
refactor(simplify): dedupe server token handling

### DIFF
--- a/internal/server/egress_clients.go
+++ b/internal/server/egress_clients.go
@@ -10,7 +10,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/core"
-	"github.com/valon-technologies/gestalt/internal/principal"
 )
 
 func (s *Server) egressClientStore() (core.EgressClientStore, error) {
@@ -79,7 +78,7 @@ func (s *Server) createEgressClient(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	now := s.now().UTC().Truncate(time.Second)
+	now := s.nowUTCSecond()
 	client := &core.EgressClient{
 		ID:          uuid.NewString(),
 		Name:        req.Name,
@@ -98,14 +97,7 @@ func (s *Server) createEgressClient(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusCreated, egressClientResponse{
-		ID:          client.ID,
-		Name:        client.Name,
-		Description: client.Description,
-		CreatedByID: client.CreatedByID,
-		CreatedAt:   client.CreatedAt,
-		UpdatedAt:   client.UpdatedAt,
-	})
+	writeJSON(w, http.StatusCreated, egressClientResponseFromCore(client))
 }
 
 func (s *Server) listEgressClients(w http.ResponseWriter, r *http.Request) {
@@ -128,14 +120,7 @@ func (s *Server) listEgressClients(w http.ResponseWriter, r *http.Request) {
 
 	out := make([]egressClientResponse, 0, len(clients))
 	for _, c := range clients {
-		out = append(out, egressClientResponse{
-			ID:          c.ID,
-			Name:        c.Name,
-			Description: c.Description,
-			CreatedByID: c.CreatedByID,
-			CreatedAt:   c.CreatedAt,
-			UpdatedAt:   c.UpdatedAt,
-		})
+		out = append(out, egressClientResponseFromCore(c))
 	}
 	writeJSON(w, http.StatusOK, out)
 }
@@ -181,8 +166,6 @@ type egressClientTokenInfo struct {
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
 
-const defaultEgressClientTokenExpiry = 90 * 24 * time.Hour
-
 func (s *Server) createEgressClientToken(w http.ResponseWriter, r *http.Request) {
 	ecs, err := s.egressClientStore()
 	if err != nil {
@@ -206,24 +189,20 @@ func (s *Server) createEgressClientToken(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	plaintext, err := generateRandomHex(32)
+	issued, err := s.issueToken()
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to generate token")
 		return
 	}
 
-	hashed := principal.HashToken(plaintext)
-	now := s.now().UTC().Truncate(time.Second)
-	expiry := now.Add(defaultEgressClientTokenExpiry)
-
 	token := &core.EgressClientToken{
 		ID:          uuid.NewString(),
 		ClientID:    clientID,
 		Name:        req.Name,
-		HashedToken: hashed,
-		ExpiresAt:   &expiry,
-		CreatedAt:   now,
-		UpdatedAt:   now,
+		HashedToken: issued.Hashed,
+		ExpiresAt:   issued.ExpiresAt,
+		CreatedAt:   issued.CreatedAt,
+		UpdatedAt:   issued.UpdatedAt,
 	}
 
 	if err := ecs.CreateEgressClientToken(r.Context(), token); err != nil {
@@ -234,7 +213,7 @@ func (s *Server) createEgressClientToken(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusCreated, createEgressClientTokenResponse{
 		ID:        token.ID,
 		Name:      token.Name,
-		Token:     plaintext,
+		Token:     issued.Plaintext,
 		ExpiresAt: token.ExpiresAt,
 	})
 }
@@ -259,12 +238,7 @@ func (s *Server) listEgressClientTokens(w http.ResponseWriter, r *http.Request) 
 
 	out := make([]egressClientTokenInfo, 0, len(tokens))
 	for _, t := range tokens {
-		out = append(out, egressClientTokenInfo{
-			ID:        t.ID,
-			Name:      t.Name,
-			CreatedAt: t.CreatedAt,
-			ExpiresAt: t.ExpiresAt,
-		})
+		out = append(out, egressClientTokenInfoFromCore(t))
 	}
 	writeJSON(w, http.StatusOK, out)
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -20,7 +20,6 @@ import (
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	"github.com/valon-technologies/gestalt/internal/oauth"
 	"github.com/valon-technologies/gestalt/internal/paraminterp"
-	"github.com/valon-technologies/gestalt/internal/principal"
 )
 
 const defaultTokenInstance = "default"
@@ -803,25 +802,21 @@ func (s *Server) createAPIToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	plaintext, err := generateRandomHex(32)
+	issued, err := s.issueToken()
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to generate token")
 		return
 	}
 
-	hashed := principal.HashToken(plaintext)
-
-	now := s.now().UTC().Truncate(time.Second)
-	defaultExpiry := now.Add(90 * 24 * time.Hour)
 	apiToken := &core.APIToken{
 		ID:          uuid.NewString(),
 		UserID:      userID,
 		Name:        req.Name,
-		HashedToken: hashed,
+		HashedToken: issued.Hashed,
 		Scopes:      req.Scopes,
-		ExpiresAt:   &defaultExpiry,
-		CreatedAt:   now,
-		UpdatedAt:   now,
+		ExpiresAt:   issued.ExpiresAt,
+		CreatedAt:   issued.CreatedAt,
+		UpdatedAt:   issued.UpdatedAt,
 	}
 
 	if err := s.datastore.StoreAPIToken(r.Context(), apiToken); err != nil {
@@ -832,7 +827,7 @@ func (s *Server) createAPIToken(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, createTokenResponse{
 		ID:        apiToken.ID,
 		Name:      apiToken.Name,
-		Token:     plaintext,
+		Token:     issued.Plaintext,
 		ExpiresAt: apiToken.ExpiresAt,
 	})
 }
@@ -859,13 +854,7 @@ func (s *Server) listAPITokens(w http.ResponseWriter, r *http.Request) {
 
 	out := make([]apiTokenInfo, 0, len(tokens))
 	for _, t := range tokens {
-		out = append(out, apiTokenInfo{
-			ID:        t.ID,
-			Name:      t.Name,
-			Scopes:    t.Scopes,
-			CreatedAt: t.CreatedAt,
-			ExpiresAt: t.ExpiresAt,
-		})
+		out = append(out, apiTokenInfoFromCore(t))
 	}
 	writeJSON(w, http.StatusOK, out)
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1668,6 +1668,64 @@ func TestCreateAndListEgressClientTokens(t *testing.T) {
 	}
 }
 
+func TestCreateEgressClientToken_DefaultExpiry(t *testing.T) {
+	t.Parallel()
+
+	fixedNow := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Now = func() time.Time { return fixedNow }
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			GetEgressClientFn: func(_ context.Context, id string) (*core.EgressClient, error) {
+				if id == "ec-1" {
+					return &core.EgressClient{ID: "ec-1", Name: "test-client", CreatedByID: "u1"}, nil
+				}
+				return nil, core.ErrNotFound
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"name":"expiry-test"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/egress-clients/ec-1/tokens", body)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 201, got %d: %s", resp.StatusCode, respBody)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	expiresAtRaw, ok := result["expires_at"]
+	if !ok || expiresAtRaw == nil {
+		t.Fatal("expected expires_at in response, got nil")
+	}
+	expiresAtStr, ok := expiresAtRaw.(string)
+	if !ok {
+		t.Fatalf("expected expires_at to be a string, got %T", expiresAtRaw)
+	}
+	expiresAt, err := time.Parse(time.RFC3339, expiresAtStr)
+	if err != nil {
+		t.Fatalf("parsing expires_at: %v", err)
+	}
+	expected := fixedNow.Add(90 * 24 * time.Hour).UTC().Truncate(time.Second)
+	if !expiresAt.Equal(expected) {
+		t.Fatalf("expected expires_at %v, got %v", expected, expiresAt)
+	}
+}
+
 func TestRevokeEgressClientToken(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/token_helpers.go
+++ b/internal/server/token_helpers.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"time"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/principal"
+)
+
+const defaultIssuedTokenExpiry = 90 * 24 * time.Hour
+
+type issuedToken struct {
+	Plaintext string
+	Hashed    string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	ExpiresAt *time.Time
+}
+
+func (s *Server) nowUTCSecond() time.Time {
+	return s.now().UTC().Truncate(time.Second)
+}
+
+func (s *Server) issueToken() (*issuedToken, error) {
+	plaintext, err := generateRandomHex(32)
+	if err != nil {
+		return nil, err
+	}
+
+	now := s.nowUTCSecond()
+	expiry := now.Add(defaultIssuedTokenExpiry)
+	return &issuedToken{
+		Plaintext: plaintext,
+		Hashed:    principal.HashToken(plaintext),
+		CreatedAt: now,
+		UpdatedAt: now,
+		ExpiresAt: &expiry,
+	}, nil
+}
+
+func apiTokenInfoFromCore(token *core.APIToken) apiTokenInfo {
+	return apiTokenInfo{
+		ID:        token.ID,
+		Name:      token.Name,
+		Scopes:    token.Scopes,
+		CreatedAt: token.CreatedAt,
+		ExpiresAt: token.ExpiresAt,
+	}
+}
+
+func egressClientResponseFromCore(client *core.EgressClient) egressClientResponse {
+	return egressClientResponse{
+		ID:          client.ID,
+		Name:        client.Name,
+		Description: client.Description,
+		CreatedByID: client.CreatedByID,
+		CreatedAt:   client.CreatedAt,
+		UpdatedAt:   client.UpdatedAt,
+	}
+}
+
+func egressClientTokenInfoFromCore(token *core.EgressClientToken) egressClientTokenInfo {
+	return egressClientTokenInfo{
+		ID:        token.ID,
+		Name:      token.Name,
+		CreatedAt: token.CreatedAt,
+		ExpiresAt: token.ExpiresAt,
+	}
+}


### PR DESCRIPTION
## Summary
- centralize shared server-side token issuance and default expiry handling for API tokens and egress client tokens
- factor repeated response mapping for token and egress client payloads out of the handlers
- add an HTTP-surface regression test for egress client token expiry so the shared behavior stays covered at the service boundary

## Testing
- go test ./...
