### PR TITLE
Add code-host providers for GitHub, GitHub App, and GitLab

### DIFF
--- a/cmd/gestaltd/providers.go
+++ b/cmd/gestaltd/providers.go
@@ -3,10 +3,16 @@ package main
 import (
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/plugins/providers/bigquery"
+	"github.com/valon-technologies/gestalt/plugins/providers/github"
+	"github.com/valon-technologies/gestalt/plugins/providers/github_app"
+	"github.com/valon-technologies/gestalt/plugins/providers/gitlab"
 	"github.com/valon-technologies/gestalt/plugins/providers/jira"
 )
 
 func registerProviders(f *bootstrap.FactoryRegistry) {
 	f.Providers["bigquery"] = bigquery.Factory
+	f.Providers["github"] = github.Factory
+	f.Providers["github_app"] = github_app.Factory
+	f.Providers["gitlab"] = gitlab.Factory
 	f.Providers["jira"] = jira.Factory
 }

--- a/docs/pages/tasks/_meta.ts
+++ b/docs/pages/tasks/_meta.ts
@@ -2,8 +2,6 @@ export default {
   "run-locally": "Run Locally",
   "add-an-integration": "Add an Integration",
   "add-a-first-party-provider": "Add a First-Party Provider",
-  "configure-jira": "Configure Jira",
-  "configure-bigquery": "Configure BigQuery",
   "install-a-plugin": "Install a Plugin",
   "use-with-mcp": "Use with MCP",
 };

--- a/plugins/providers/github/factory.go
+++ b/plugins/providers/github/factory.go
@@ -1,0 +1,25 @@
+package github
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("github: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/github/factory_test.go
+++ b/plugins/providers/github/factory_test.go
@@ -1,0 +1,65 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+const (
+	dummyClientID     = "dummy-client-id"
+	dummyClientSecret = "dummy-client-secret"
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["github"]
+	if !ok {
+		t.Fatal("provider github not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "github",
+		OperationCount: len(spec.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+	})
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["github"]
+	if !ok {
+		t.Fatal("provider github not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID:     dummyClientID,
+		ClientSecret: dummyClientSecret,
+	})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "github",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+
+	providertest.CheckOAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/github/provider.yaml
+++ b/plugins/providers/github/provider.yaml
@@ -1,0 +1,439 @@
+provider: github
+display_name: GitHub
+description: GitHub code hosting and collaboration platform
+connection_mode: user
+base_url: "https://api.github.com"
+
+headers:
+  Accept: "application/vnd.github+json"
+  X-GitHub-Api-Version: "2022-11-28"
+
+auth:
+  type: oauth2
+  authorization_url: https://github.com/login/oauth/authorize
+  token_url: https://github.com/login/oauth/access_token
+  scopes: [repo]
+  accept_header: application/json
+
+operations:
+  compare_commits:
+    description: Compare two commits
+    method: GET
+    path: "/repos/{owner}/{repo}/compare/{basehead}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: basehead, type: string, required: true, description: "Base and head in format base...head"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  create_branch:
+    description: Create a new branch
+    method: POST
+    path: "/repos/{owner}/{repo}/git/refs"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: ref, type: string, required: true, description: "Full ref name (e.g. refs/heads/my-branch)"}
+      - {name: sha, type: string, required: true, description: SHA to create the branch from}
+
+  create_comment:
+    description: Create a comment on an issue or pull request
+    method: POST
+    path: "/repos/{owner}/{repo}/issues/{issue_number}/comments"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: issue_number, type: integer, required: true, description: Issue or PR number}
+      - {name: body, type: string, required: true, description: Comment body}
+
+  create_issue:
+    description: Create a new issue
+    method: POST
+    path: "/repos/{owner}/{repo}/issues"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: title, type: string, required: true, description: Issue title}
+      - {name: body, type: string, description: Issue body}
+      - {name: labels, type: array, description: Labels to add}
+      - {name: assignees, type: array, description: Assignees (usernames)}
+      - {name: milestone, type: integer, description: Milestone number}
+
+  create_or_update_file:
+    description: Create or update a file in a repository
+    method: PUT
+    path: "/repos/{owner}/{repo}/contents/{path}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: path, type: string, required: true, description: Path to the file}
+      - {name: message, type: string, required: true, description: Commit message}
+      - {name: content, type: string, required: true, description: Base64-encoded file content}
+      - {name: sha, type: string, description: SHA of the file being replaced (required for updates)}
+      - {name: branch, type: string, description: Branch to commit to}
+      - {name: committer, type: object, description: Committer info (name and email)}
+
+  create_pull_request:
+    description: Create a pull request
+    method: POST
+    path: "/repos/{owner}/{repo}/pulls"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: title, type: string, required: true, description: PR title}
+      - {name: head, type: string, required: true, description: Head branch}
+      - {name: base, type: string, required: true, description: Base branch}
+      - {name: body, type: string, description: PR body}
+      - {name: draft, type: boolean, description: Create as draft}
+      - {name: maintainer_can_modify, type: boolean, description: Allow maintainer edits}
+
+  create_release:
+    description: Create a release
+    method: POST
+    path: "/repos/{owner}/{repo}/releases"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: tag_name, type: string, required: true, description: Tag name for the release}
+      - {name: target_commitish, type: string, description: Commitish value for the tag}
+      - {name: name, type: string, description: Release name}
+      - {name: body, type: string, description: Release notes}
+      - {name: draft, type: boolean, description: Create as draft release}
+      - {name: prerelease, type: boolean, description: Mark as pre-release}
+      - {name: generate_release_notes, type: boolean, description: Auto-generate release notes}
+
+  create_review:
+    description: Create a pull request review
+    method: POST
+    path: "/repos/{owner}/{repo}/pulls/{pull_number}/reviews"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: pull_number, type: integer, required: true, description: Pull request number}
+      - {name: event, type: string, required: true, description: "Review action: APPROVE, REQUEST_CHANGES, or COMMENT"}
+      - {name: body, type: string, description: Review body}
+      - {name: commit_id, type: string, description: SHA of commit to review}
+      - {name: comments, type: array, description: Review comments with path and body}
+
+  create_review_comment:
+    description: Create an inline review comment on a pull request
+    method: POST
+    path: "/repos/{owner}/{repo}/pulls/{pull_number}/comments"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: pull_number, type: integer, required: true, description: Pull request number}
+      - {name: body, type: string, required: true, description: Comment body}
+      - {name: commit_id, type: string, required: true, description: SHA of the commit to comment on}
+      - {name: path, type: string, required: true, description: Relative path of the file}
+      - {name: line, type: integer, description: Line number in the diff}
+      - {name: side, type: string, description: "Which side of the diff: LEFT or RIGHT"}
+      - {name: start_line, type: integer, description: Start line for multi-line comments}
+      - {name: start_side, type: string, description: "Start side: LEFT or RIGHT"}
+
+  delete_file:
+    description: Delete a file from a repository
+    method: DELETE
+    path: "/repos/{owner}/{repo}/contents/{path}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: path, type: string, required: true, description: Path to the file}
+      - {name: message, type: string, required: true, description: Commit message}
+      - {name: sha, type: string, required: true, description: SHA of the file to delete}
+      - {name: branch, type: string, description: Branch to delete from}
+
+  get_authenticated_user:
+    description: Get the authenticated user
+    method: GET
+    path: /user
+    parameters: []
+
+  get_commit:
+    description: Get a commit by ref
+    method: GET
+    path: "/repos/{owner}/{repo}/commits/{ref}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: ref, type: string, required: true, description: "Commit SHA, branch name, or tag name"}
+
+  get_file_contents:
+    description: Get file or directory contents
+    method: GET
+    path: "/repos/{owner}/{repo}/contents/{path}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: path, type: string, required: true, description: Path to file or directory}
+      - {name: ref, type: string, description: "Git ref (branch, tag, or commit SHA)"}
+
+  get_latest_release:
+    description: Get the latest release
+    method: GET
+    path: "/repos/{owner}/{repo}/releases/latest"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+
+  get_pull_request:
+    description: Get a pull request
+    method: GET
+    path: "/repos/{owner}/{repo}/pulls/{pull_number}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: pull_number, type: integer, required: true, description: Pull request number}
+
+  get_ref:
+    description: Get a git reference
+    method: GET
+    path: "/repos/{owner}/{repo}/git/ref/{ref}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: ref, type: string, required: true, description: "The ref (e.g. heads/main or tags/v1.0)"}
+
+  get_workflow_run:
+    description: Get a workflow run
+    method: GET
+    path: "/repos/{owner}/{repo}/actions/runs/{run_id}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: run_id, type: integer, required: true, description: Workflow run ID}
+
+  list_branches:
+    description: List branches
+    method: GET
+    path: "/repos/{owner}/{repo}/branches"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: protected, type: boolean, description: Filter by protected status}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_check_runs:
+    description: List check runs for a git reference
+    method: GET
+    path: "/repos/{owner}/{repo}/commits/{ref}/check-runs"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: ref, type: string, required: true, description: "Git ref (SHA, branch name, or tag name)"}
+      - {name: check_name, type: string, description: Filter by check name}
+      - {name: status, type: string, description: "Filter by status: queued, in_progress, completed"}
+      - {name: filter, type: string, description: "Filter: latest or all"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_comments:
+    description: List comments on an issue or pull request
+    method: GET
+    path: "/repos/{owner}/{repo}/issues/{issue_number}/comments"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: issue_number, type: integer, required: true, description: Issue or PR number}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_commits:
+    description: List commits
+    method: GET
+    path: "/repos/{owner}/{repo}/commits"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: sha, type: string, description: SHA or branch to list commits from}
+      - {name: path, type: string, description: Only commits containing this file path}
+      - {name: author, type: string, description: Filter by author username or email}
+      - {name: since, type: string, description: Only commits after this date (ISO 8601)}
+      - {name: until, type: string, description: Only commits before this date (ISO 8601)}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_issues:
+    description: List issues for a repository
+    method: GET
+    path: "/repos/{owner}/{repo}/issues"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: state, type: string, description: "Filter by state (open, closed, all)"}
+      - {name: labels, type: string, description: Filter by labels (comma-separated)}
+      - {name: sort, type: string, description: "Sort by (created, updated, comments)"}
+      - {name: direction, type: string, description: "Sort direction (asc, desc)"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_pull_requests:
+    description: List pull requests
+    method: GET
+    path: "/repos/{owner}/{repo}/pulls"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: state, type: string, description: "Filter by state (open, closed, all)"}
+      - {name: head, type: string, description: "Filter by head branch (format: user:ref-name)"}
+      - {name: base, type: string, description: Filter by base branch}
+      - {name: sort, type: string, description: "Sort by (created, updated, popularity, long-running)"}
+      - {name: direction, type: string, description: "Sort direction (asc, desc)"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_releases:
+    description: List releases
+    method: GET
+    path: "/repos/{owner}/{repo}/releases"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_repos:
+    description: List repositories for the authenticated user
+    method: GET
+    path: /user/repos
+    parameters:
+      - {name: visibility, type: string, description: "Filter by visibility (all, public, private)"}
+      - {name: affiliation, type: string, description: "Filter by affiliation (owner, collaborator, organization_member)"}
+      - {name: sort, type: string, description: "Sort by (created, updated, pushed, full_name)"}
+      - {name: direction, type: string, description: "Sort direction (asc, desc)"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_review_comments:
+    description: List review comments on a pull request
+    method: GET
+    path: "/repos/{owner}/{repo}/pulls/{pull_number}/comments"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: pull_number, type: integer, required: true, description: Pull request number}
+      - {name: sort, type: string, description: "Sort by: created or updated"}
+      - {name: direction, type: string, description: "Sort direction: asc or desc"}
+      - {name: since, type: string, description: Only comments after this date (ISO 8601)}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_reviews:
+    description: List reviews on a pull request
+    method: GET
+    path: "/repos/{owner}/{repo}/pulls/{pull_number}/reviews"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: pull_number, type: integer, required: true, description: Pull request number}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_user_orgs:
+    description: List organizations for the authenticated user
+    method: GET
+    path: /user/orgs
+    parameters:
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_workflow_runs:
+    description: List workflow runs
+    method: GET
+    path: "/repos/{owner}/{repo}/actions/runs"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: actor, type: string, description: Filter by user who triggered the run}
+      - {name: branch, type: string, description: Filter by branch}
+      - {name: event, type: string, description: "Filter by event type (push, pull_request, etc.)"}
+      - {name: status, type: string, description: "Filter by status (queued, in_progress, completed, etc.)"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  merge_pull_request:
+    description: Merge a pull request
+    method: PUT
+    path: "/repos/{owner}/{repo}/pulls/{pull_number}/merge"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: pull_number, type: integer, required: true, description: Pull request number}
+      - {name: commit_title, type: string, description: Title for the merge commit}
+      - {name: commit_message, type: string, description: Message for the merge commit}
+      - {name: merge_method, type: string, description: "Merge method (merge, squash, or rebase)"}
+      - {name: sha, type: string, description: SHA that PR head must match}
+
+  rerun_workflow:
+    description: Re-run a workflow
+    method: POST
+    path: "/repos/{owner}/{repo}/actions/runs/{run_id}/rerun"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: run_id, type: integer, required: true, description: Workflow run ID}
+      - {name: enable_debug_logging, type: boolean, description: Enable debug logging for the re-run}
+
+  search_code:
+    description: Search code
+    method: GET
+    path: /search/code
+    parameters:
+      - {name: q, type: string, required: true, description: Search query}
+      - {name: sort, type: string, description: "Sort by: indexed"}
+      - {name: order, type: string, description: "Sort order: asc or desc"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  search_issues:
+    description: Search issues and pull requests
+    method: GET
+    path: /search/issues
+    parameters:
+      - {name: q, type: string, required: true, description: Search query}
+      - {name: sort, type: string, description: "Sort by: comments, reactions, created, updated, etc."}
+      - {name: order, type: string, description: "Sort order: asc or desc"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  search_repos:
+    description: Search repositories
+    method: GET
+    path: /search/repositories
+    parameters:
+      - {name: q, type: string, required: true, description: Search query}
+      - {name: sort, type: string, description: "Sort by: stars, forks, help-wanted-issues, updated"}
+      - {name: order, type: string, description: "Sort order: asc or desc"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  update_issue:
+    description: Update an issue
+    method: PATCH
+    path: "/repos/{owner}/{repo}/issues/{issue_number}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: issue_number, type: integer, required: true, description: Issue number}
+      - {name: title, type: string, description: New title}
+      - {name: body, type: string, description: New body}
+      - {name: state, type: string, description: "New state (open or closed)"}
+      - {name: labels, type: array, description: Labels}
+      - {name: assignees, type: array, description: Assignees (usernames)}
+      - {name: milestone, type: integer, description: Milestone number}
+
+  update_pull_request:
+    description: Update a pull request
+    method: PATCH
+    path: "/repos/{owner}/{repo}/pulls/{pull_number}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: pull_number, type: integer, required: true, description: Pull request number}
+      - {name: title, type: string, description: New title}
+      - {name: body, type: string, description: New body}
+      - {name: state, type: string, description: "New state (open or closed)"}
+      - {name: base, type: string, description: New base branch}
+      - {name: maintainer_can_modify, type: boolean, description: Allow maintainer edits}

--- a/plugins/providers/github_app/factory.go
+++ b/plugins/providers/github_app/factory.go
@@ -1,0 +1,25 @@
+package github_app
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("github_app: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/github_app/factory_test.go
+++ b/plugins/providers/github_app/factory_test.go
@@ -1,0 +1,65 @@
+package github_app
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+const (
+	dummyClientID     = "dummy-client-id"
+	dummyClientSecret = "dummy-client-secret"
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["github_app"]
+	if !ok {
+		t.Fatal("provider github_app not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "github_app",
+		OperationCount: len(spec.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+	})
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["github_app"]
+	if !ok {
+		t.Fatal("provider github_app not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID:     dummyClientID,
+		ClientSecret: dummyClientSecret,
+	})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "github_app",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+
+	providertest.CheckManualAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/github_app/provider.yaml
+++ b/plugins/providers/github_app/provider.yaml
@@ -1,0 +1,425 @@
+provider: github_app
+display_name: GitHub App
+description: GitHub App installation-based access
+connection_mode: identity
+base_url: "https://api.github.com"
+manual_auth: true
+
+headers:
+  Accept: "application/vnd.github+json"
+  X-GitHub-Api-Version: "2022-11-28"
+
+auth:
+  type: manual
+
+operations:
+  compare_commits:
+    description: Compare two commits
+    method: GET
+    path: "/repos/{owner}/{repo}/compare/{basehead}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: basehead, type: string, required: true, description: "Base and head in format base...head"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  create_branch:
+    description: Create a new branch
+    method: POST
+    path: "/repos/{owner}/{repo}/git/refs"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: ref, type: string, required: true, description: "Full ref name (e.g. refs/heads/my-branch)"}
+      - {name: sha, type: string, required: true, description: SHA to create the branch from}
+
+  create_comment:
+    description: Create a comment on an issue or pull request
+    method: POST
+    path: "/repos/{owner}/{repo}/issues/{issue_number}/comments"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: issue_number, type: integer, required: true, description: Issue or PR number}
+      - {name: body, type: string, required: true, description: Comment body}
+
+  create_issue:
+    description: Create a new issue
+    method: POST
+    path: "/repos/{owner}/{repo}/issues"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: title, type: string, required: true, description: Issue title}
+      - {name: body, type: string, description: Issue body}
+      - {name: labels, type: array, description: Labels to add}
+      - {name: assignees, type: array, description: Assignees (usernames)}
+      - {name: milestone, type: integer, description: Milestone number}
+
+  create_or_update_file:
+    description: Create or update a file in a repository
+    method: PUT
+    path: "/repos/{owner}/{repo}/contents/{path}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: path, type: string, required: true, description: Path to the file}
+      - {name: message, type: string, required: true, description: Commit message}
+      - {name: content, type: string, required: true, description: Base64-encoded file content}
+      - {name: sha, type: string, description: SHA of the file being replaced (required for updates)}
+      - {name: branch, type: string, description: Branch to commit to}
+      - {name: committer, type: object, description: Committer info (name and email)}
+
+  create_pull_request:
+    description: Create a pull request
+    method: POST
+    path: "/repos/{owner}/{repo}/pulls"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: title, type: string, required: true, description: PR title}
+      - {name: head, type: string, required: true, description: Head branch}
+      - {name: base, type: string, required: true, description: Base branch}
+      - {name: body, type: string, description: PR body}
+      - {name: draft, type: boolean, description: Create as draft}
+      - {name: maintainer_can_modify, type: boolean, description: Allow maintainer edits}
+
+  create_release:
+    description: Create a release
+    method: POST
+    path: "/repos/{owner}/{repo}/releases"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: tag_name, type: string, required: true, description: Tag name for the release}
+      - {name: target_commitish, type: string, description: Commitish value for the tag}
+      - {name: name, type: string, description: Release name}
+      - {name: body, type: string, description: Release notes}
+      - {name: draft, type: boolean, description: Create as draft release}
+      - {name: prerelease, type: boolean, description: Mark as pre-release}
+      - {name: generate_release_notes, type: boolean, description: Auto-generate release notes}
+
+  create_review:
+    description: Create a pull request review
+    method: POST
+    path: "/repos/{owner}/{repo}/pulls/{pull_number}/reviews"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: pull_number, type: integer, required: true, description: Pull request number}
+      - {name: event, type: string, required: true, description: "Review action: APPROVE, REQUEST_CHANGES, or COMMENT"}
+      - {name: body, type: string, description: Review body}
+      - {name: commit_id, type: string, description: SHA of commit to review}
+      - {name: comments, type: array, description: Review comments with path and body}
+
+  create_review_comment:
+    description: Create an inline review comment on a pull request
+    method: POST
+    path: "/repos/{owner}/{repo}/pulls/{pull_number}/comments"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: pull_number, type: integer, required: true, description: Pull request number}
+      - {name: body, type: string, required: true, description: Comment body}
+      - {name: commit_id, type: string, required: true, description: SHA of the commit to comment on}
+      - {name: path, type: string, required: true, description: Relative path of the file}
+      - {name: line, type: integer, description: Line number in the diff}
+      - {name: side, type: string, description: "Which side of the diff: LEFT or RIGHT"}
+      - {name: start_line, type: integer, description: Start line for multi-line comments}
+      - {name: start_side, type: string, description: "Start side: LEFT or RIGHT"}
+
+  delete_file:
+    description: Delete a file from a repository
+    method: DELETE
+    path: "/repos/{owner}/{repo}/contents/{path}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: path, type: string, required: true, description: Path to the file}
+      - {name: message, type: string, required: true, description: Commit message}
+      - {name: sha, type: string, required: true, description: SHA of the file to delete}
+      - {name: branch, type: string, description: Branch to delete from}
+
+  get_installation:
+    description: Get the current app installation
+    method: GET
+    path: /app/installations/{installation_id}
+    parameters:
+      - {name: installation_id, type: integer, required: true, description: Installation ID}
+
+  get_commit:
+    description: Get a commit by ref
+    method: GET
+    path: "/repos/{owner}/{repo}/commits/{ref}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: ref, type: string, required: true, description: "Commit SHA, branch name, or tag name"}
+
+  get_file_contents:
+    description: Get file or directory contents
+    method: GET
+    path: "/repos/{owner}/{repo}/contents/{path}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: path, type: string, required: true, description: Path to file or directory}
+      - {name: ref, type: string, description: "Git ref (branch, tag, or commit SHA)"}
+
+  get_latest_release:
+    description: Get the latest release
+    method: GET
+    path: "/repos/{owner}/{repo}/releases/latest"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+
+  get_pull_request:
+    description: Get a pull request
+    method: GET
+    path: "/repos/{owner}/{repo}/pulls/{pull_number}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: pull_number, type: integer, required: true, description: Pull request number}
+
+  get_ref:
+    description: Get a git reference
+    method: GET
+    path: "/repos/{owner}/{repo}/git/ref/{ref}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: ref, type: string, required: true, description: "The ref (e.g. heads/main or tags/v1.0)"}
+
+  get_workflow_run:
+    description: Get a workflow run
+    method: GET
+    path: "/repos/{owner}/{repo}/actions/runs/{run_id}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: run_id, type: integer, required: true, description: Workflow run ID}
+
+  list_branches:
+    description: List branches
+    method: GET
+    path: "/repos/{owner}/{repo}/branches"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: protected, type: boolean, description: Filter by protected status}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_check_runs:
+    description: List check runs for a git reference
+    method: GET
+    path: "/repos/{owner}/{repo}/commits/{ref}/check-runs"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: ref, type: string, required: true, description: "Git ref (SHA, branch name, or tag name)"}
+      - {name: check_name, type: string, description: Filter by check name}
+      - {name: status, type: string, description: "Filter by status: queued, in_progress, completed"}
+      - {name: filter, type: string, description: "Filter: latest or all"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_comments:
+    description: List comments on an issue or pull request
+    method: GET
+    path: "/repos/{owner}/{repo}/issues/{issue_number}/comments"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: issue_number, type: integer, required: true, description: Issue or PR number}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_commits:
+    description: List commits
+    method: GET
+    path: "/repos/{owner}/{repo}/commits"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: sha, type: string, description: SHA or branch to list commits from}
+      - {name: path, type: string, description: Only commits containing this file path}
+      - {name: author, type: string, description: Filter by author username or email}
+      - {name: since, type: string, description: Only commits after this date (ISO 8601)}
+      - {name: until, type: string, description: Only commits before this date (ISO 8601)}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_issues:
+    description: List issues for a repository
+    method: GET
+    path: "/repos/{owner}/{repo}/issues"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: state, type: string, description: "Filter by state (open, closed, all)"}
+      - {name: labels, type: string, description: Filter by labels (comma-separated)}
+      - {name: sort, type: string, description: "Sort by (created, updated, comments)"}
+      - {name: direction, type: string, description: "Sort direction (asc, desc)"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_pull_requests:
+    description: List pull requests
+    method: GET
+    path: "/repos/{owner}/{repo}/pulls"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: state, type: string, description: "Filter by state (open, closed, all)"}
+      - {name: head, type: string, description: "Filter by head branch (format: user:ref-name)"}
+      - {name: base, type: string, description: Filter by base branch}
+      - {name: sort, type: string, description: "Sort by (created, updated, popularity, long-running)"}
+      - {name: direction, type: string, description: "Sort direction (asc, desc)"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_releases:
+    description: List releases
+    method: GET
+    path: "/repos/{owner}/{repo}/releases"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_repos:
+    description: List repositories accessible to the app installation
+    method: GET
+    path: /installation/repositories
+    parameters:
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_review_comments:
+    description: List review comments on a pull request
+    method: GET
+    path: "/repos/{owner}/{repo}/pulls/{pull_number}/comments"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: pull_number, type: integer, required: true, description: Pull request number}
+      - {name: sort, type: string, description: "Sort by: created or updated"}
+      - {name: direction, type: string, description: "Sort direction: asc or desc"}
+      - {name: since, type: string, description: Only comments after this date (ISO 8601)}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_reviews:
+    description: List reviews on a pull request
+    method: GET
+    path: "/repos/{owner}/{repo}/pulls/{pull_number}/reviews"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: pull_number, type: integer, required: true, description: Pull request number}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_workflow_runs:
+    description: List workflow runs
+    method: GET
+    path: "/repos/{owner}/{repo}/actions/runs"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: actor, type: string, description: Filter by user who triggered the run}
+      - {name: branch, type: string, description: Filter by branch}
+      - {name: event, type: string, description: "Filter by event type (push, pull_request, etc.)"}
+      - {name: status, type: string, description: "Filter by status (queued, in_progress, completed, etc.)"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  merge_pull_request:
+    description: Merge a pull request
+    method: PUT
+    path: "/repos/{owner}/{repo}/pulls/{pull_number}/merge"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: pull_number, type: integer, required: true, description: Pull request number}
+      - {name: commit_title, type: string, description: Title for the merge commit}
+      - {name: commit_message, type: string, description: Message for the merge commit}
+      - {name: merge_method, type: string, description: "Merge method (merge, squash, or rebase)"}
+      - {name: sha, type: string, description: SHA that PR head must match}
+
+  rerun_workflow:
+    description: Re-run a workflow
+    method: POST
+    path: "/repos/{owner}/{repo}/actions/runs/{run_id}/rerun"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: run_id, type: integer, required: true, description: Workflow run ID}
+      - {name: enable_debug_logging, type: boolean, description: Enable debug logging for the re-run}
+
+  search_code:
+    description: Search code
+    method: GET
+    path: /search/code
+    parameters:
+      - {name: q, type: string, required: true, description: Search query}
+      - {name: sort, type: string, description: "Sort by: indexed"}
+      - {name: order, type: string, description: "Sort order: asc or desc"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  search_issues:
+    description: Search issues and pull requests
+    method: GET
+    path: /search/issues
+    parameters:
+      - {name: q, type: string, required: true, description: Search query}
+      - {name: sort, type: string, description: "Sort by: comments, reactions, created, updated, etc."}
+      - {name: order, type: string, description: "Sort order: asc or desc"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  search_repos:
+    description: Search repositories
+    method: GET
+    path: /search/repositories
+    parameters:
+      - {name: q, type: string, required: true, description: Search query}
+      - {name: sort, type: string, description: "Sort by: stars, forks, help-wanted-issues, updated"}
+      - {name: order, type: string, description: "Sort order: asc or desc"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  update_issue:
+    description: Update an issue
+    method: PATCH
+    path: "/repos/{owner}/{repo}/issues/{issue_number}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: issue_number, type: integer, required: true, description: Issue number}
+      - {name: title, type: string, description: New title}
+      - {name: body, type: string, description: New body}
+      - {name: state, type: string, description: "New state (open or closed)"}
+      - {name: labels, type: array, description: Labels}
+      - {name: assignees, type: array, description: Assignees (usernames)}
+      - {name: milestone, type: integer, description: Milestone number}
+
+  update_pull_request:
+    description: Update a pull request
+    method: PATCH
+    path: "/repos/{owner}/{repo}/pulls/{pull_number}"
+    parameters:
+      - {name: owner, type: string, required: true, description: Repository owner}
+      - {name: repo, type: string, required: true, description: Repository name}
+      - {name: pull_number, type: integer, required: true, description: Pull request number}
+      - {name: title, type: string, description: New title}
+      - {name: body, type: string, description: New body}
+      - {name: state, type: string, description: "New state (open or closed)"}
+      - {name: base, type: string, description: New base branch}
+      - {name: maintainer_can_modify, type: boolean, description: Allow maintainer edits}

--- a/plugins/providers/gitlab/factory.go
+++ b/plugins/providers/gitlab/factory.go
@@ -1,0 +1,25 @@
+package gitlab
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("gitlab: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/gitlab/factory_test.go
+++ b/plugins/providers/gitlab/factory_test.go
@@ -1,0 +1,65 @@
+package gitlab
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+const (
+	dummyClientID     = "dummy-client-id"
+	dummyClientSecret = "dummy-client-secret"
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["gitlab"]
+	if !ok {
+		t.Fatal("provider gitlab not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "gitlab",
+		OperationCount: len(spec.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+	})
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["gitlab"]
+	if !ok {
+		t.Fatal("provider gitlab not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID:     dummyClientID,
+		ClientSecret: dummyClientSecret,
+	})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "gitlab",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+
+	providertest.CheckOAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/gitlab/provider.yaml
+++ b/plugins/providers/gitlab/provider.yaml
@@ -1,0 +1,242 @@
+provider: gitlab
+display_name: GitLab
+description: GitLab code hosting and CI/CD platform
+connection_mode: user
+base_url: "https://gitlab.com/api/v4"
+
+auth:
+  type: oauth2
+  authorization_url: https://gitlab.com/oauth/authorize
+  token_url: https://gitlab.com/oauth/token
+  scopes: [api]
+  pkce: true
+
+operations:
+  create_issue:
+    description: Create a new issue
+    method: POST
+    path: "/projects/{project_id}/issues"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Project ID or URL-encoded path}
+      - {name: title, type: string, required: true, description: Issue title}
+      - {name: description, type: string, description: Issue description}
+      - {name: labels, type: string, description: Labels (comma-separated)}
+      - {name: assignee_ids, type: array, description: Assignee user IDs}
+      - {name: milestone_id, type: integer, description: Milestone ID}
+      - {name: due_date, type: string, description: Due date (YYYY-MM-DD)}
+
+  create_issue_note:
+    description: Create a comment on an issue
+    method: POST
+    path: "/projects/{project_id}/issues/{issue_iid}/notes"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Project ID or URL-encoded path}
+      - {name: issue_iid, type: integer, required: true, description: Issue IID}
+      - {name: body, type: string, required: true, description: Note body text}
+
+  create_merge_request:
+    description: Create a merge request
+    method: POST
+    path: "/projects/{project_id}/merge_requests"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Project ID or URL-encoded path}
+      - {name: source_branch, type: string, required: true, description: Source branch name}
+      - {name: target_branch, type: string, required: true, description: Target branch name}
+      - {name: title, type: string, required: true, description: Merge request title}
+      - {name: description, type: string, description: Merge request description}
+      - {name: labels, type: string, description: Labels (comma-separated)}
+      - {name: assignee_id, type: integer, description: Assignee user ID}
+      - {name: reviewer_ids, type: array, description: Reviewer user IDs}
+      - {name: remove_source_branch, type: boolean, description: Remove source branch on merge}
+
+  create_mr_note:
+    description: Create a comment on a merge request
+    method: POST
+    path: "/projects/{project_id}/merge_requests/{merge_request_iid}/notes"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Project ID or URL-encoded path}
+      - {name: merge_request_iid, type: integer, required: true, description: Merge request IID}
+      - {name: body, type: string, required: true, description: Note body text}
+
+  create_file:
+    description: Create a new file in a repository
+    method: POST
+    path: "/projects/{project_id}/repository/files/{file_path}"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Project ID or URL-encoded path}
+      - {name: file_path, type: string, required: true, description: Path to the file in the repository}
+      - {name: branch, type: string, required: true, description: Branch to commit to}
+      - {name: content, type: string, required: true, description: File content}
+      - {name: commit_message, type: string, required: true, description: Commit message}
+      - {name: author_email, type: string, description: Commit author email}
+      - {name: author_name, type: string, description: Commit author name}
+      - {name: encoding, type: string, description: "Content encoding: text or base64"}
+
+  update_file:
+    description: Update an existing file in a repository
+    method: PUT
+    path: "/projects/{project_id}/repository/files/{file_path}"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Project ID or URL-encoded path}
+      - {name: file_path, type: string, required: true, description: Path to the file in the repository}
+      - {name: branch, type: string, required: true, description: Branch to commit to}
+      - {name: content, type: string, required: true, description: File content}
+      - {name: commit_message, type: string, required: true, description: Commit message}
+      - {name: last_commit_id, type: string, description: Last known commit ID for conflict detection}
+      - {name: author_email, type: string, description: Commit author email}
+      - {name: author_name, type: string, description: Commit author name}
+      - {name: encoding, type: string, description: "Content encoding: text or base64"}
+
+  delete_file:
+    description: Delete a file from a repository
+    method: DELETE
+    path: "/projects/{project_id}/repository/files/{file_path}"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Project ID or URL-encoded path}
+      - {name: file_path, type: string, required: true, description: Path to the file in the repository}
+      - {name: branch, type: string, required: true, description: Branch to delete from}
+      - {name: commit_message, type: string, required: true, description: Commit message}
+      - {name: last_commit_id, type: string, description: Last known commit ID}
+
+  get_merge_request:
+    description: Get a merge request
+    method: GET
+    path: "/projects/{project_id}/merge_requests/{merge_request_iid}"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Project ID or URL-encoded path}
+      - {name: merge_request_iid, type: integer, required: true, description: Merge request IID}
+
+  get_pipeline:
+    description: Get a pipeline
+    method: GET
+    path: "/projects/{project_id}/pipelines/{pipeline_id}"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Project ID or URL-encoded path}
+      - {name: pipeline_id, type: integer, required: true, description: Pipeline ID}
+
+  get_project:
+    description: Get a project
+    method: GET
+    path: "/projects/{project_id}"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Project ID or URL-encoded path}
+
+  get_repository_file:
+    description: Get a file from a repository
+    method: GET
+    path: "/projects/{project_id}/repository/files/{file_path}"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Project ID or URL-encoded path}
+      - {name: file_path, type: string, required: true, description: Path to the file in the repository}
+      - {name: ref, type: string, required: true, description: Branch or tag to get the file from}
+
+  list_issues:
+    description: List issues for a project
+    method: GET
+    path: "/projects/{project_id}/issues"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Project ID or URL-encoded path}
+      - {name: state, type: string, description: "Filter by state (opened, closed, all)"}
+      - {name: scope, type: string, description: "Filter by scope (created_by_me, assigned_to_me, all)"}
+      - {name: labels, type: string, description: Filter by labels (comma-separated)}
+      - {name: milestone, type: string, description: Filter by milestone}
+      - {name: search, type: string, description: Search issues}
+      - {name: order_by, type: string, description: "Order by (created_at, updated_at, priority, etc.)"}
+      - {name: sort, type: string, description: "Sort direction (asc, desc)"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_jobs:
+    description: List jobs in a pipeline
+    method: GET
+    path: "/projects/{project_id}/pipelines/{pipeline_id}/jobs"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Project ID or URL-encoded path}
+      - {name: pipeline_id, type: integer, required: true, description: Pipeline ID}
+      - {name: scope, type: string, description: "Filter by scope (created, pending, running, failed, etc.)"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_merge_requests:
+    description: List merge requests for a project
+    method: GET
+    path: "/projects/{project_id}/merge_requests"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Project ID or URL-encoded path}
+      - {name: state, type: string, description: "Filter by state (opened, closed, merged, all)"}
+      - {name: scope, type: string, description: "Filter by scope (created_by_me, assigned_to_me, all)"}
+      - {name: target_branch, type: string, description: Filter by target branch}
+      - {name: source_branch, type: string, description: Filter by source branch}
+      - {name: labels, type: string, description: Filter by labels (comma-separated)}
+      - {name: order_by, type: string, description: "Order by (created_at, updated_at)"}
+      - {name: sort, type: string, description: "Sort direction (asc, desc)"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_pipelines:
+    description: List pipelines for a project
+    method: GET
+    path: "/projects/{project_id}/pipelines"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Project ID or URL-encoded path}
+      - {name: scope, type: string, description: "Filter by scope (running, pending, finished, etc.)"}
+      - {name: status, type: string, description: "Filter by status (created, preparing, running, etc.)"}
+      - {name: ref, type: string, description: Filter by ref (branch or tag)}
+      - {name: sha, type: string, description: Filter by commit SHA}
+      - {name: order_by, type: string, description: "Order by (id, status, ref, updated_at, user_id)"}
+      - {name: sort, type: string, description: "Sort direction (asc, desc)"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_projects:
+    description: List projects for the authenticated user
+    method: GET
+    path: /projects
+    parameters:
+      - {name: membership, type: boolean, description: Limit to projects user is a member of}
+      - {name: visibility, type: string, description: "Filter by visibility (public, internal, private)"}
+      - {name: owned, type: boolean, description: Limit to projects owned by user}
+      - {name: starred, type: boolean, description: Limit to starred projects}
+      - {name: search, type: string, description: Search projects by name}
+      - {name: order_by, type: string, description: "Order by (id, name, path, created_at, updated_at, last_activity_at)"}
+      - {name: sort, type: string, description: "Sort direction (asc, desc)"}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  list_repository_tree:
+    description: List a repository directory tree
+    method: GET
+    path: "/projects/{project_id}/repository/tree"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Project ID or URL-encoded path}
+      - {name: path, type: string, description: Path inside repository to list}
+      - {name: ref, type: string, description: Branch or tag to list}
+      - {name: recursive, type: boolean, description: Get tree recursively}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  search_code:
+    description: Search code in a project
+    method: GET
+    path: "/projects/{project_id}/search"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Project ID or URL-encoded path}
+      - {name: search, type: string, required: true, description: Search query string}
+      - {name: scope, type: string, required: true, description: "Search scope (e.g. blobs for code)"}
+      - {name: ref, type: string, description: Branch or tag to search in}
+      - {name: per_page, type: integer, description: Results per page (max 100)}
+      - {name: page, type: integer, description: Page number}
+
+  update_issue:
+    description: Update an issue
+    method: PUT
+    path: "/projects/{project_id}/issues/{issue_iid}"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Project ID or URL-encoded path}
+      - {name: issue_iid, type: integer, required: true, description: Issue IID}
+      - {name: title, type: string, description: New title}
+      - {name: description, type: string, description: New description}
+      - {name: state_event, type: string, description: "State change: close or reopen"}
+      - {name: labels, type: string, description: Labels (comma-separated)}
+      - {name: assignee_ids, type: array, description: Assignee user IDs}
+      - {name: milestone_id, type: integer, description: Milestone ID}

--- a/plugins/providers/inventory/inventory.yaml
+++ b/plugins/providers/inventory/inventory.yaml
@@ -180,9 +180,9 @@ providers:
       - create_review
       - create_review_comment
       - delete_file
-      - get_authenticated_user
       - get_commit
       - get_file_contents
+      - get_installation
       - get_latest_release
       - get_pull_request
       - get_ref
@@ -197,7 +197,6 @@ providers:
       - list_repos
       - list_review_comments
       - list_reviews
-      - list_user_orgs
       - list_workflow_runs
       - merge_pull_request
       - rerun_workflow
@@ -211,11 +210,11 @@ providers:
     auth_type: oauth2
     connection_mode: user
     operations:
+      - create_file
       - create_issue
       - create_issue_note
       - create_merge_request
       - create_mr_note
-      - create_or_update_file
       - delete_file
       - get_merge_request
       - get_pipeline
@@ -228,6 +227,7 @@ providers:
       - list_projects
       - list_repository_tree
       - search_code
+      - update_file
       - update_issue
 
   gmail:


### PR DESCRIPTION
These three new first-party providers give Gestalt native support for
the most common code hosting platforms. The `github` provider uses
OAuth2 for user-level access, `github_app` uses installation auth for
app-level access, and `gitlab` uses OAuth2 with PKCE. Each provider
defines a comprehensive set of API operations covering repositories,
issues, pull/merge requests, CI/CD, and code search.

The `github_app` provider uses installation-specific endpoints
(`/installation/repositories`, `/app/installations/{id}`) rather than
user-scoped endpoints that are inaccessible to app installation tokens.
The `gitlab` provider splits file management into separate `create_file`
(POST) and `update_file` (PUT) operations to match GitLab's API
semantics. This also removes stale `configure-jira` and
`configure-bigquery` entries from the docs navigation that were breaking
the docs build.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>