### PR TITLE
Add first-party Google REST providers

### DIFF
--- a/cmd/gestaltd/providers.go
+++ b/cmd/gestaltd/providers.go
@@ -3,10 +3,18 @@ package main
 import (
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/plugins/providers/bigquery"
+	"github.com/valon-technologies/gestalt/plugins/providers/google_calendar"
+	"github.com/valon-technologies/gestalt/plugins/providers/google_docs"
+	"github.com/valon-technologies/gestalt/plugins/providers/google_drive"
+	"github.com/valon-technologies/gestalt/plugins/providers/google_sheets"
 	"github.com/valon-technologies/gestalt/plugins/providers/jira"
 )
 
 func registerProviders(f *bootstrap.FactoryRegistry) {
 	f.Providers["bigquery"] = bigquery.Factory
+	f.Providers["google_calendar"] = google_calendar.Factory
+	f.Providers["google_docs"] = google_docs.Factory
+	f.Providers["google_drive"] = google_drive.Factory
+	f.Providers["google_sheets"] = google_sheets.Factory
 	f.Providers["jira"] = jira.Factory
 }

--- a/docs/pages/tasks/_meta.ts
+++ b/docs/pages/tasks/_meta.ts
@@ -2,8 +2,6 @@ export default {
   "run-locally": "Run Locally",
   "add-an-integration": "Add an Integration",
   "add-a-first-party-provider": "Add a First-Party Provider",
-  "configure-jira": "Configure Jira",
-  "configure-bigquery": "Configure BigQuery",
   "install-a-plugin": "Install a Plugin",
   "use-with-mcp": "Use with MCP",
 };

--- a/plugins/providers/google_calendar/factory.go
+++ b/plugins/providers/google_calendar/factory.go
@@ -1,0 +1,25 @@
+package google_calendar
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("google_calendar: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/google_calendar/factory_test.go
+++ b/plugins/providers/google_calendar/factory_test.go
@@ -1,0 +1,65 @@
+package google_calendar
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+const (
+	dummyClientID     = "dummy-client-id"
+	dummyClientSecret = "dummy-client-secret"
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["google_calendar"]
+	if !ok {
+		t.Fatal("provider google_calendar not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "google_calendar",
+		OperationCount: len(spec.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+	})
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["google_calendar"]
+	if !ok {
+		t.Fatal("provider google_calendar not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID:     dummyClientID,
+		ClientSecret: dummyClientSecret,
+	})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "google_calendar",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+
+	providertest.CheckOAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/google_calendar/provider.yaml
+++ b/plugins/providers/google_calendar/provider.yaml
@@ -1,0 +1,89 @@
+provider: google_calendar
+display_name: Google Calendar
+description: Google Calendar event and schedule management
+connection_mode: user
+base_url: "https://www.googleapis.com/calendar/v3"
+
+auth:
+  type: oauth2
+  authorization_url: https://accounts.google.com/o/oauth2/v2/auth
+  token_url: https://oauth2.googleapis.com/token
+  scopes:
+    - https://www.googleapis.com/auth/calendar
+  authorization_params:
+    access_type: offline
+    prompt: consent
+
+operations:
+  list_calendars:
+    description: List all calendars accessible to the user
+    method: GET
+    path: /users/me/calendarList
+    parameters:
+      - {name: showHidden, type: boolean, description: Show hidden calendars}
+      - {name: showDeleted, type: boolean, description: Show deleted calendars}
+
+  get_calendar:
+    description: Get details of a specific calendar by ID
+    method: GET
+    path: "/users/me/calendarList/{calendarId}"
+    parameters:
+      - {name: calendarId, type: string, required: true, description: Calendar ID}
+
+  list_events:
+    description: List calendar events with optional time range and search filters
+    method: GET
+    path: "/calendars/{calendarId}/events"
+    parameters:
+      - {name: calendarId, type: string, required: true, description: "Calendar ID (use 'primary' for main calendar)"}
+      - {name: timeMin, type: string, description: Lower bound for event start time (RFC3339)}
+      - {name: timeMax, type: string, description: Upper bound for event start time (RFC3339)}
+      - {name: maxResults, type: integer, description: Maximum events to return}
+      - {name: singleEvents, type: boolean, description: Expand recurring events into instances}
+      - {name: orderBy, type: string, description: "Sort order: startTime or updated"}
+      - {name: q, type: string, description: Free text search query}
+      - {name: pageToken, type: string, description: Token for pagination}
+
+  get_event:
+    description: Get details of a specific calendar event
+    method: GET
+    path: "/calendars/{calendarId}/events/{eventId}"
+    parameters:
+      - {name: calendarId, type: string, required: true, description: Calendar ID}
+      - {name: eventId, type: string, required: true, description: Event ID}
+
+  create_event:
+    description: Create a new calendar event
+    method: POST
+    path: "/calendars/{calendarId}/events"
+    parameters:
+      - {name: calendarId, type: string, required: true, description: Calendar ID}
+      - {name: summary, type: string, required: true, description: Event title}
+      - {name: start, type: object, required: true, description: Start time object with dateTime or date}
+      - {name: end, type: object, required: true, description: End time object with dateTime or date}
+      - {name: description, type: string, description: Event description}
+      - {name: location, type: string, description: Event location}
+      - {name: attendees, type: array, description: List of attendee objects}
+
+  update_event:
+    description: Update an existing calendar event
+    method: PATCH
+    path: "/calendars/{calendarId}/events/{eventId}"
+    parameters:
+      - {name: calendarId, type: string, required: true, description: Calendar ID}
+      - {name: eventId, type: string, required: true, description: Event ID}
+      - {name: summary, type: string, description: New event title}
+      - {name: start, type: object, description: New start time object}
+      - {name: end, type: object, description: New end time object}
+      - {name: description, type: string, description: New description}
+      - {name: location, type: string, description: New location}
+      - {name: attendees, type: array, description: New attendees list}
+
+  delete_event:
+    description: Delete a calendar event
+    method: DELETE
+    path: "/calendars/{calendarId}/events/{eventId}"
+    parameters:
+      - {name: calendarId, type: string, required: true, description: Calendar ID}
+      - {name: eventId, type: string, required: true, description: Event ID}
+      - {name: sendUpdates, type: string, description: "Notification mode: all, externalOnly, or none"}

--- a/plugins/providers/google_docs/factory.go
+++ b/plugins/providers/google_docs/factory.go
@@ -1,0 +1,25 @@
+package google_docs
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("google_docs: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/google_docs/factory_test.go
+++ b/plugins/providers/google_docs/factory_test.go
@@ -1,0 +1,65 @@
+package google_docs
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+const (
+	dummyClientID     = "dummy-client-id"
+	dummyClientSecret = "dummy-client-secret"
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["google_docs"]
+	if !ok {
+		t.Fatal("provider google_docs not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "google_docs",
+		OperationCount: len(spec.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+	})
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["google_docs"]
+	if !ok {
+		t.Fatal("provider google_docs not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID:     dummyClientID,
+		ClientSecret: dummyClientSecret,
+	})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "google_docs",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+
+	providertest.CheckOAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/google_docs/provider.yaml
+++ b/plugins/providers/google_docs/provider.yaml
@@ -1,0 +1,38 @@
+provider: google_docs
+display_name: Google Docs
+description: Google Docs document creation and editing
+connection_mode: user
+base_url: "https://docs.googleapis.com/v1"
+
+auth:
+  type: oauth2
+  authorization_url: https://accounts.google.com/o/oauth2/v2/auth
+  token_url: https://oauth2.googleapis.com/token
+  scopes:
+    - https://www.googleapis.com/auth/documents
+  authorization_params:
+    access_type: offline
+    prompt: consent
+
+operations:
+  get_document:
+    description: Get a document with content and metadata
+    method: GET
+    path: "/documents/{documentId}"
+    parameters:
+      - {name: documentId, type: string, required: true, description: Document ID}
+
+  create_document:
+    description: Create a new document
+    method: POST
+    path: /documents
+    parameters:
+      - {name: title, type: string, required: true, description: Document title}
+
+  batch_update:
+    description: Apply batch updates to a document
+    method: POST
+    path: "/documents/{documentId}:batchUpdate"
+    parameters:
+      - {name: documentId, type: string, required: true, description: Document ID}
+      - {name: requests, type: array, required: true, description: List of update request objects}

--- a/plugins/providers/google_drive/factory.go
+++ b/plugins/providers/google_drive/factory.go
@@ -1,0 +1,25 @@
+package google_drive
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("google_drive: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/google_drive/factory_test.go
+++ b/plugins/providers/google_drive/factory_test.go
@@ -1,0 +1,65 @@
+package google_drive
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+const (
+	dummyClientID     = "dummy-client-id"
+	dummyClientSecret = "dummy-client-secret"
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["google_drive"]
+	if !ok {
+		t.Fatal("provider google_drive not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "google_drive",
+		OperationCount: len(spec.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+	})
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["google_drive"]
+	if !ok {
+		t.Fatal("provider google_drive not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID:     dummyClientID,
+		ClientSecret: dummyClientSecret,
+	})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "google_drive",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+
+	providertest.CheckOAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/google_drive/provider.yaml
+++ b/plugins/providers/google_drive/provider.yaml
@@ -1,0 +1,125 @@
+provider: google_drive
+display_name: Google Drive
+description: Google Drive file and permission management
+connection_mode: user
+base_url: "https://www.googleapis.com/drive/v3"
+
+auth:
+  type: oauth2
+  authorization_url: https://accounts.google.com/o/oauth2/v2/auth
+  token_url: https://oauth2.googleapis.com/token
+  scopes:
+    - https://www.googleapis.com/auth/drive
+  authorization_params:
+    access_type: offline
+    prompt: consent
+
+operations:
+  list_files:
+    description: List and search files in Google Drive
+    method: GET
+    path: /files
+    parameters:
+      - {name: q, type: string, description: Search query (Drive query syntax)}
+      - {name: pageSize, type: integer, description: Number of files per page}
+      - {name: pageToken, type: string, description: Token for pagination}
+      - {name: orderBy, type: string, description: "Sort order (e.g. modifiedTime desc)"}
+      - {name: fields, type: string, description: Fields to include in response}
+      - {name: spaces, type: string, description: "Spaces to search (drive, appDataFolder)"}
+
+  get_file:
+    description: Get file metadata
+    method: GET
+    path: "/files/{fileId}"
+    parameters:
+      - {name: fileId, type: string, required: true, description: File ID}
+      - {name: fields, type: string, description: Fields to include in response}
+
+  download_file:
+    description: Download file content
+    method: GET
+    path: "/files/{fileId}?alt=media"
+    parameters:
+      - {name: fileId, type: string, required: true, description: File ID}
+
+  export_file:
+    description: Export a Google Workspace document to a different format
+    method: GET
+    path: "/files/{fileId}/export"
+    parameters:
+      - {name: fileId, type: string, required: true, description: File ID}
+      - {name: mimeType, type: string, required: true, description: Target MIME type for export}
+
+  create_file:
+    description: Create a new file or folder
+    method: POST
+    path: /files
+    parameters:
+      - {name: name, type: string, required: true, description: File name}
+      - {name: mimeType, type: string, description: MIME type}
+      - {name: parents, type: array, description: List of parent folder IDs}
+      - {name: description, type: string, description: File description}
+
+  update_file:
+    description: Update file metadata
+    method: PATCH
+    path: "/files/{fileId}"
+    parameters:
+      - {name: fileId, type: string, required: true, description: File ID}
+      - {name: name, type: string, description: New name}
+      - {name: description, type: string, description: New description}
+
+  delete_file:
+    description: Permanently delete a file
+    method: DELETE
+    path: "/files/{fileId}"
+    parameters:
+      - {name: fileId, type: string, required: true, description: File ID}
+
+  copy_file:
+    description: Copy a file
+    method: POST
+    path: "/files/{fileId}/copy"
+    parameters:
+      - {name: fileId, type: string, required: true, description: Source file ID}
+      - {name: name, type: string, description: Name for the copy}
+      - {name: parents, type: array, description: Parent folder IDs for the copy}
+
+  list_permissions:
+    description: List permissions for a file
+    method: GET
+    path: "/files/{fileId}/permissions"
+    parameters:
+      - {name: fileId, type: string, required: true, description: File ID}
+      - {name: pageSize, type: integer, description: Number of permissions per page}
+      - {name: pageToken, type: string, description: Token for pagination}
+
+  create_permission:
+    description: Create a permission to share a file
+    method: POST
+    path: "/files/{fileId}/permissions"
+    parameters:
+      - {name: fileId, type: string, required: true, description: File ID}
+      - {name: type, type: string, required: true, description: "Permission type: user, group, domain, or anyone"}
+      - {name: role, type: string, required: true, description: "Permission role: reader, commenter, writer, etc."}
+      - {name: emailAddress, type: string, description: Email for user/group type}
+      - {name: domain, type: string, description: Domain for domain type}
+      - {name: sendNotificationEmail, type: boolean, description: Whether to send notification email}
+      - {name: emailMessage, type: string, description: Custom notification message}
+
+  update_permission:
+    description: Update a permission on a file
+    method: PATCH
+    path: "/files/{fileId}/permissions/{permissionId}"
+    parameters:
+      - {name: fileId, type: string, required: true, description: File ID}
+      - {name: permissionId, type: string, required: true, description: Permission ID}
+      - {name: role, type: string, required: true, description: New role}
+
+  delete_permission:
+    description: Delete a permission to revoke access
+    method: DELETE
+    path: "/files/{fileId}/permissions/{permissionId}"
+    parameters:
+      - {name: fileId, type: string, required: true, description: File ID}
+      - {name: permissionId, type: string, required: true, description: Permission ID}

--- a/plugins/providers/google_sheets/factory.go
+++ b/plugins/providers/google_sheets/factory.go
@@ -1,0 +1,25 @@
+package google_sheets
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("google_sheets: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/google_sheets/factory_test.go
+++ b/plugins/providers/google_sheets/factory_test.go
@@ -1,0 +1,65 @@
+package google_sheets
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+const (
+	dummyClientID     = "dummy-client-id"
+	dummyClientSecret = "dummy-client-secret"
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["google_sheets"]
+	if !ok {
+		t.Fatal("provider google_sheets not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "google_sheets",
+		OperationCount: len(spec.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+	})
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["google_sheets"]
+	if !ok {
+		t.Fatal("provider google_sheets not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID:     dummyClientID,
+		ClientSecret: dummyClientSecret,
+	})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "google_sheets",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+
+	providertest.CheckOAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/google_sheets/provider.yaml
+++ b/plugins/providers/google_sheets/provider.yaml
@@ -1,0 +1,122 @@
+provider: google_sheets
+display_name: Google Sheets
+description: Google Sheets spreadsheet and data management
+connection_mode: user
+base_url: "https://sheets.googleapis.com/v4/spreadsheets"
+
+auth:
+  type: oauth2
+  authorization_url: https://accounts.google.com/o/oauth2/v2/auth
+  token_url: https://oauth2.googleapis.com/token
+  scopes:
+    - https://www.googleapis.com/auth/spreadsheets
+  authorization_params:
+    access_type: offline
+    prompt: consent
+
+operations:
+  create_spreadsheet:
+    description: Create a new spreadsheet
+    method: POST
+    path: /
+    parameters:
+      - {name: properties, type: object, required: true, description: Spreadsheet properties including title}
+      - {name: sheets, type: array, description: List of sheet definitions}
+
+  get_spreadsheet:
+    description: Get spreadsheet metadata and structure
+    method: GET
+    path: "/{spreadsheetId}"
+    parameters:
+      - {name: spreadsheetId, type: string, required: true, description: Spreadsheet ID}
+      - {name: includeGridData, type: boolean, description: Whether to include cell data}
+      - {name: ranges, type: array, description: Specific ranges to include}
+
+  get_values:
+    description: Read values from a range in A1 notation
+    method: GET
+    path: "/{spreadsheetId}/values/{range}"
+    parameters:
+      - {name: spreadsheetId, type: string, required: true, description: Spreadsheet ID}
+      - {name: range, type: string, required: true, description: "A1 notation range (e.g. Sheet1!A1:D10)"}
+      - {name: majorDimension, type: string, description: "ROWS or COLUMNS"}
+      - {name: valueRenderOption, type: string, description: "FORMATTED_VALUE, UNFORMATTED_VALUE, or FORMULA"}
+      - {name: dateTimeRenderOption, type: string, description: "SERIAL_NUMBER or FORMATTED_STRING"}
+
+  batch_get_values:
+    description: Read values from multiple ranges
+    method: GET
+    path: "/{spreadsheetId}/values:batchGet"
+    parameters:
+      - {name: spreadsheetId, type: string, required: true, description: Spreadsheet ID}
+      - {name: ranges, type: array, required: true, description: List of A1 notation ranges}
+      - {name: majorDimension, type: string, description: "ROWS or COLUMNS"}
+      - {name: valueRenderOption, type: string, description: Value render option}
+      - {name: dateTimeRenderOption, type: string, description: Date/time render option}
+
+  update_values:
+    description: Write values to a range (values are parsed as if typed by a user)
+    method: PUT
+    path: "/{spreadsheetId}/values/{range}?valueInputOption=USER_ENTERED"
+    parameters:
+      - {name: spreadsheetId, type: string, required: true, description: Spreadsheet ID}
+      - {name: range, type: string, required: true, description: A1 notation range}
+      - {name: values, type: array, required: true, description: 2D array of values}
+
+  batch_update_values:
+    description: Write values to multiple ranges (values are parsed as if typed by a user)
+    method: POST
+    path: "/{spreadsheetId}/values:batchUpdate"
+    parameters:
+      - {name: spreadsheetId, type: string, required: true, description: Spreadsheet ID}
+      - {name: valueInputOption, type: string, required: true, default: USER_ENTERED, description: "How to interpret input: RAW or USER_ENTERED"}
+      - {name: data, type: array, required: true, description: List of range data with values}
+
+  append_values:
+    description: Append rows to a sheet (values are parsed as if typed by a user)
+    method: POST
+    path: "/{spreadsheetId}/values/{range}:append?valueInputOption=USER_ENTERED&insertDataOption=INSERT_ROWS"
+    parameters:
+      - {name: spreadsheetId, type: string, required: true, description: Spreadsheet ID}
+      - {name: range, type: string, required: true, description: A1 notation range to append after}
+      - {name: values, type: array, required: true, description: 2D array of values to append}
+
+  clear_values:
+    description: Clear values from a range
+    method: POST
+    path: "/{spreadsheetId}/values/{range}:clear"
+    parameters:
+      - {name: spreadsheetId, type: string, required: true, description: Spreadsheet ID}
+      - {name: range, type: string, required: true, description: A1 notation range to clear}
+
+  add_sheet:
+    description: Add a new sheet tab to a spreadsheet
+    method: POST
+    path: "/{spreadsheetId}:batchUpdate"
+    parameters:
+      - {name: spreadsheetId, type: string, required: true, description: Spreadsheet ID}
+      - {name: requests, type: array, required: true, description: Batch update requests containing addSheet}
+
+  delete_sheet:
+    description: Delete a sheet tab from a spreadsheet
+    method: POST
+    path: "/{spreadsheetId}:batchUpdate"
+    parameters:
+      - {name: spreadsheetId, type: string, required: true, description: Spreadsheet ID}
+      - {name: requests, type: array, required: true, description: Batch update requests containing deleteSheet}
+
+  update_sheet_properties:
+    description: Update sheet properties such as title and tab color
+    method: POST
+    path: "/{spreadsheetId}:batchUpdate"
+    parameters:
+      - {name: spreadsheetId, type: string, required: true, description: Spreadsheet ID}
+      - {name: requests, type: array, required: true, description: Batch update requests containing updateSheetProperties}
+
+  find_replace:
+    description: Find and replace text in a spreadsheet
+    method: POST
+    path: "/{spreadsheetId}:batchUpdate"
+    parameters:
+      - {name: spreadsheetId, type: string, required: true, description: Spreadsheet ID}
+      - {name: requests, type: array, required: true, description: Batch update requests containing findReplace}

--- a/plugins/providers/inventory/inventory.yaml
+++ b/plugins/providers/inventory/inventory.yaml
@@ -269,7 +269,6 @@ providers:
       - get_event
       - list_calendars
       - list_events
-      - quick_add_event
       - update_event
 
   google_docs:


### PR DESCRIPTION
This adds four new declarative REST providers for Google Workspace
services: `google_calendar`, `google_docs`, `google_drive`, and
`google_sheets`. Each provider uses OAuth2 with offline access for
token refresh and covers the core operations for its respective
Google API, giving agents built-in access to calendars, documents,
files, and spreadsheets without requiring external plugin installation.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>