### PR TITLE
Add ops and incident provider definitions

### DIFF
--- a/cmd/gestaltd/providers.go
+++ b/cmd/gestaltd/providers.go
@@ -3,10 +3,18 @@ package main
 import (
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/plugins/providers/bigquery"
+	"github.com/valon-technologies/gestalt/plugins/providers/datadog"
+	"github.com/valon-technologies/gestalt/plugins/providers/incident_io"
 	"github.com/valon-technologies/gestalt/plugins/providers/jira"
+	"github.com/valon-technologies/gestalt/plugins/providers/launchdarkly"
+	"github.com/valon-technologies/gestalt/plugins/providers/pagerduty"
 )
 
 func registerProviders(f *bootstrap.FactoryRegistry) {
 	f.Providers["bigquery"] = bigquery.Factory
+	f.Providers["datadog"] = datadog.Factory
+	f.Providers["incident_io"] = incident_io.Factory
 	f.Providers["jira"] = jira.Factory
+	f.Providers["launchdarkly"] = launchdarkly.Factory
+	f.Providers["pagerduty"] = pagerduty.Factory
 }

--- a/docs/pages/tasks/_meta.ts
+++ b/docs/pages/tasks/_meta.ts
@@ -2,8 +2,6 @@ export default {
   "run-locally": "Run Locally",
   "add-an-integration": "Add an Integration",
   "add-a-first-party-provider": "Add a First-Party Provider",
-  "configure-jira": "Configure Jira",
-  "configure-bigquery": "Configure BigQuery",
   "install-a-plugin": "Install a Plugin",
   "use-with-mcp": "Use with MCP",
 };

--- a/plugins/providers/datadog/factory.go
+++ b/plugins/providers/datadog/factory.go
@@ -1,0 +1,23 @@
+package datadog
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, err
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/datadog/factory_test.go
+++ b/plugins/providers/datadog/factory_test.go
@@ -1,0 +1,35 @@
+package datadog
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["datadog"]
+	if !ok {
+		t.Fatal("provider datadog not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "datadog",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+	providertest.CheckManualAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/datadog/provider.yaml
+++ b/plugins/providers/datadog/provider.yaml
@@ -1,0 +1,160 @@
+provider: datadog
+display_name: Datadog
+description: Datadog monitoring, alerting, and incident management
+connection_mode: user
+base_url: "https://api.datadoghq.com"
+
+auth:
+  type: manual
+
+auth_style: none
+auth_mapping:
+  headers:
+    DD-API-KEY: api_key
+    DD-APPLICATION-KEY: app_key
+
+error_message_path: errors
+
+operations:
+  list_dashboards:
+    description: List dashboards
+    method: GET
+    path: /api/v1/dashboard
+    parameters:
+      - {name: filter_shared, type: boolean, description: Filter by shared dashboards}
+      - {name: filter_deleted, type: boolean, description: Include deleted dashboards}
+      - {name: count, type: integer, description: Max dashboards to return}
+      - {name: start, type: integer, description: Pagination offset}
+  get_dashboard:
+    description: Get a specific dashboard by ID
+    method: GET
+    path: "/api/v1/dashboard/{dashboard_id}"
+    parameters:
+      - {name: dashboard_id, type: string, required: true, description: Dashboard ID}
+  list_monitors:
+    description: List monitors
+    method: GET
+    path: /api/v1/monitor
+    parameters:
+      - {name: name, type: string, description: Filter by name}
+      - {name: tags, type: string, description: Filter by tags}
+      - {name: monitor_tags, type: string, description: Filter by monitor tags}
+      - {name: page, type: integer, description: Page number}
+      - {name: page_size, type: integer, description: Results per page}
+  get_monitor:
+    description: Get a specific monitor by ID
+    method: GET
+    path: "/api/v1/monitor/{monitor_id}"
+    parameters:
+      - {name: monitor_id, type: integer, required: true, description: Monitor ID}
+  create_monitor:
+    description: Create a monitor
+    method: POST
+    path: /api/v1/monitor
+    parameters:
+      - {name: name, type: string, required: true, description: Monitor name}
+      - {name: type, type: string, required: true, description: Monitor type}
+      - {name: query, type: string, required: true, description: Monitor query string}
+      - {name: message, type: string, description: Notification message}
+      - {name: tags, type: array, description: Tags for the monitor}
+      - {name: priority, type: integer, description: Monitor priority (1-5)}
+  update_monitor:
+    description: Update an existing monitor
+    method: PUT
+    path: "/api/v1/monitor/{monitor_id}"
+    parameters:
+      - {name: monitor_id, type: integer, required: true, description: Monitor ID}
+      - {name: name, type: string, description: Monitor name}
+      - {name: query, type: string, description: Monitor query string}
+      - {name: message, type: string, description: Notification message}
+      - {name: tags, type: array, description: Tags for the monitor}
+      - {name: priority, type: integer, description: Monitor priority (1-5)}
+  query_metrics:
+    description: Query metrics over a time range
+    method: GET
+    path: /api/v1/query
+    parameters:
+      - {name: from, type: integer, required: true, description: Start timestamp in seconds}
+      - {name: to, type: integer, required: true, description: End timestamp in seconds}
+      - {name: query, type: string, required: true, description: Metric query string}
+  list_incidents:
+    description: List incidents
+    method: GET
+    path: /api/v2/incidents
+    parameters:
+      - {name: "page[size]", type: integer, description: Results per page}
+      - {name: "page[offset]", type: integer, description: Page offset}
+  create_incident:
+    description: Create an incident
+    method: POST
+    path: /api/v2/incidents
+    parameters:
+      - {name: data, type: object, required: true, description: Incident create payload}
+  update_incident:
+    description: Update an existing incident
+    method: PATCH
+    path: "/api/v2/incidents/{incident_id}"
+    parameters:
+      - {name: incident_id, type: string, required: true, description: Incident ID}
+      - {name: data, type: object, required: true, description: Incident update payload}
+  search_logs:
+    description: Search logs with a query string
+    method: POST
+    path: /api/v2/logs/events/search
+    parameters:
+      - {name: filter, type: object, required: true, description: Log search filter with query, from, and to}
+      - {name: page, type: object, description: Pagination options}
+      - {name: sort, type: string, description: Sort order}
+  create_downtime:
+    description: Schedule a downtime
+    method: POST
+    path: /api/v2/downtime
+    parameters:
+      - {name: data, type: object, required: true, description: Downtime create payload}
+  create_dashboard:
+    description: Create a dashboard
+    method: POST
+    path: /api/v1/dashboard
+    parameters:
+      - {name: title, type: string, required: true, description: Dashboard title}
+      - {name: widgets, type: array, required: true, description: Dashboard widgets}
+      - {name: layout_type, type: string, required: true, description: Layout type (ordered or free)}
+      - {name: description, type: string, description: Dashboard description}
+      - {name: template_variables, type: array, description: Template variables}
+  update_dashboard:
+    description: Update an existing dashboard
+    method: PUT
+    path: "/api/v1/dashboard/{dashboard_id}"
+    parameters:
+      - {name: dashboard_id, type: string, required: true, description: Dashboard ID}
+      - {name: title, type: string, required: true, description: Dashboard title}
+      - {name: widgets, type: array, required: true, description: Dashboard widgets}
+      - {name: layout_type, type: string, required: true, description: Layout type}
+      - {name: description, type: string, description: Dashboard description}
+      - {name: template_variables, type: array, description: Template variables}
+  search_rum_events:
+    description: Search RUM events
+    method: POST
+    path: /api/v2/rum/events/search
+    parameters:
+      - {name: filter, type: object, required: true, description: RUM search filter}
+      - {name: page, type: object, description: Pagination options}
+      - {name: sort, type: string, description: Sort order}
+  aggregate_rum_events:
+    description: Aggregate RUM events
+    method: POST
+    path: /api/v2/rum/analytics/aggregate
+    parameters:
+      - {name: filter, type: object, required: true, description: RUM query filter}
+      - {name: compute, type: array, required: true, description: Aggregation compute definitions}
+      - {name: group_by, type: array, description: Group by definitions}
+  list_rum_events:
+    description: List RUM events
+    method: GET
+    path: /api/v2/rum/events
+    parameters:
+      - {name: "filter[query]", type: string, required: true, description: RUM filter query}
+      - {name: "filter[from]", type: string, description: Start time}
+      - {name: "filter[to]", type: string, description: End time}
+      - {name: "page[limit]", type: integer, description: Max events to return}
+      - {name: sort, type: string, description: Sort order}

--- a/plugins/providers/incident_io/factory.go
+++ b/plugins/providers/incident_io/factory.go
@@ -1,0 +1,23 @@
+package incident_io
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, err
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/incident_io/factory_test.go
+++ b/plugins/providers/incident_io/factory_test.go
@@ -1,0 +1,35 @@
+package incident_io
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["incident_io"]
+	if !ok {
+		t.Fatal("provider incident_io not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "incident_io",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+	providertest.CheckManualAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/incident_io/provider.yaml
+++ b/plugins/providers/incident_io/provider.yaml
@@ -1,0 +1,80 @@
+provider: incident_io
+display_name: incident.io
+description: Incident management for tracking and resolving incidents
+connection_mode: identity
+base_url: "https://api.incident.io/v2"
+
+auth:
+  type: manual
+
+operations:
+  list_incidents:
+    description: List incidents
+    method: GET
+    path: /incidents
+    parameters:
+      - {name: page_size, type: integer, description: Max incidents to return}
+      - {name: status, type: string, description: Filter by status}
+  get_incident:
+    description: Get a specific incident
+    method: GET
+    path: "/incidents/{incident_id}"
+    parameters:
+      - {name: incident_id, type: string, required: true, description: Incident ID or reference number}
+  create_incident:
+    description: Create a new incident
+    method: POST
+    path: /incidents
+    parameters:
+      - {name: name, type: string, required: true, description: Name of the incident}
+      - {name: idempotency_key, type: string, required: true, description: Unique key for deduplication}
+      - {name: visibility, type: string, required: true, description: Visibility (public or private)}
+      - {name: summary, type: string, description: Summary of the incident}
+      - {name: severity_id, type: string, description: Severity ID}
+      - {name: incident_status_id, type: string, description: Incident status ID}
+      - {name: mode, type: string, description: "Mode: standard, retrospective, or test"}
+  update_incident:
+    description: Update an existing incident
+    method: POST
+    path: "/incidents/{incident_id}/actions/edit"
+    parameters:
+      - {name: incident_id, type: string, required: true, description: Incident ID to update}
+      - {name: name, type: string, description: New name}
+      - {name: summary, type: string, description: New summary}
+      - {name: severity_id, type: string, description: New severity ID}
+      - {name: incident_status_id, type: string, description: New incident status ID}
+  list_users:
+    description: List users
+    method: GET
+    path: /users
+    parameters:
+      - {name: page_size, type: integer, description: Max users to return}
+      - {name: email, type: string, description: Filter by email address}
+  get_user:
+    description: Get a specific user
+    method: GET
+    path: "/users/{user_id}"
+    parameters:
+      - {name: user_id, type: string, required: true, description: User ID}
+  list_schedules:
+    description: List on-call schedules
+    method: GET
+    path: /schedules
+    parameters:
+      - {name: page_size, type: integer, description: Max schedules to return}
+  get_schedule_entries:
+    description: Get schedule entries to see who is currently on-call
+    method: GET
+    path: /schedule_entries
+    parameters:
+      - {name: schedule_id, type: string, required: true, description: Schedule ID}
+  list_severities:
+    description: List incident severities
+    method: GET
+    path: /severities
+    parameters: []
+  list_statuses:
+    description: List incident statuses
+    method: GET
+    path: /incident_statuses
+    parameters: []

--- a/plugins/providers/launchdarkly/factory.go
+++ b/plugins/providers/launchdarkly/factory.go
@@ -1,0 +1,23 @@
+package launchdarkly
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, err
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/launchdarkly/factory_test.go
+++ b/plugins/providers/launchdarkly/factory_test.go
@@ -1,0 +1,35 @@
+package launchdarkly
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["launchdarkly"]
+	if !ok {
+		t.Fatal("provider launchdarkly not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "launchdarkly",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+	providertest.CheckManualAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/launchdarkly/provider.yaml
+++ b/plugins/providers/launchdarkly/provider.yaml
@@ -1,0 +1,35 @@
+provider: launchdarkly
+display_name: LaunchDarkly
+description: Feature flag management and experimentation
+connection_mode: identity
+base_url: "https://app.launchdarkly.com/api/v2"
+
+auth:
+  type: manual
+
+auth_style: raw
+
+operations:
+  list_projects:
+    description: List projects
+    method: GET
+    path: /projects
+    parameters:
+      - {name: limit, type: integer, description: Max projects to return}
+      - {name: offset, type: integer, description: Pagination offset}
+  list_feature_flags:
+    description: List feature flags in a project
+    method: GET
+    path: "/flags/{project_key}"
+    parameters:
+      - {name: project_key, type: string, required: true, description: Project key}
+      - {name: limit, type: integer, description: Max flags to return}
+      - {name: offset, type: integer, description: Pagination offset}
+      - {name: filter, type: string, description: Filter flags by name or key}
+  get_feature_flag:
+    description: Get a specific feature flag
+    method: GET
+    path: "/flags/{project_key}/{flag_key}"
+    parameters:
+      - {name: project_key, type: string, required: true, description: Project key}
+      - {name: flag_key, type: string, required: true, description: Feature flag key}

--- a/plugins/providers/pagerduty/factory.go
+++ b/plugins/providers/pagerduty/factory.go
@@ -1,0 +1,23 @@
+package pagerduty
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, err
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/pagerduty/factory_test.go
+++ b/plugins/providers/pagerduty/factory_test.go
@@ -1,0 +1,35 @@
+package pagerduty
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["pagerduty"]
+	if !ok {
+		t.Fatal("provider pagerduty not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "pagerduty",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+	providertest.CheckManualAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/pagerduty/provider.yaml
+++ b/plugins/providers/pagerduty/provider.yaml
@@ -1,0 +1,105 @@
+provider: pagerduty
+display_name: PagerDuty
+description: Incident management, on-call scheduling, and alerting
+connection_mode: user
+base_url: "https://api.pagerduty.com"
+
+auth:
+  type: manual
+
+token_prefix: "Token token="
+
+operations:
+  list_incidents:
+    description: List incidents
+    method: GET
+    path: /incidents
+    parameters:
+      - {name: "statuses[]", type: string, description: "Filter by status (triggered, acknowledged, resolved)"}
+      - {name: "service_ids[]", type: string, description: Filter by service IDs}
+      - {name: since, type: string, description: Start date (ISO 8601)}
+      - {name: until, type: string, description: End date (ISO 8601)}
+      - {name: limit, type: integer, description: Results per page}
+      - {name: offset, type: integer, description: Pagination offset}
+  get_incident:
+    description: Get a specific incident
+    method: GET
+    path: "/incidents/{incident_id}"
+    parameters:
+      - {name: incident_id, type: string, required: true, description: Incident ID}
+  create_incident:
+    description: Create a new incident
+    method: POST
+    path: /incidents
+    parameters:
+      - {name: incident, type: object, required: true, description: Incident payload}
+  acknowledge_incident:
+    description: Acknowledge an incident
+    method: PUT
+    path: "/incidents/{incident_id}"
+    parameters:
+      - {name: incident_id, type: string, required: true, description: Incident ID}
+      - {name: incident, type: object, required: true, description: Incident update payload}
+  resolve_incident:
+    description: Resolve an incident
+    method: PUT
+    path: "/incidents/{incident_id}"
+    parameters:
+      - {name: incident_id, type: string, required: true, description: Incident ID}
+      - {name: incident, type: object, required: true, description: Incident update payload}
+  reassign_incident:
+    description: Reassign an incident to different users
+    method: PUT
+    path: "/incidents/{incident_id}"
+    parameters:
+      - {name: incident_id, type: string, required: true, description: Incident ID}
+      - {name: incident, type: object, required: true, description: Incident update payload with assignments}
+  snooze_incident:
+    description: Snooze an incident for a specified duration
+    method: POST
+    path: "/incidents/{incident_id}/snooze"
+    parameters:
+      - {name: incident_id, type: string, required: true, description: Incident ID}
+      - {name: duration, type: integer, required: true, description: Snooze duration in seconds}
+  add_note:
+    description: Add a note to an incident
+    method: POST
+    path: "/incidents/{incident_id}/notes"
+    parameters:
+      - {name: incident_id, type: string, required: true, description: Incident ID}
+      - {name: note, type: object, required: true, description: Note payload with content field}
+  list_services:
+    description: List services
+    method: GET
+    path: /services
+    parameters:
+      - {name: query, type: string, description: Filter by name}
+      - {name: "team_ids[]", type: string, description: Filter by team IDs}
+      - {name: limit, type: integer, description: Results per page}
+      - {name: offset, type: integer, description: Pagination offset}
+  get_service:
+    description: Get a specific service
+    method: GET
+    path: "/services/{service_id}"
+    parameters:
+      - {name: service_id, type: string, required: true, description: Service ID}
+  get_on_calls:
+    description: Get current on-call users
+    method: GET
+    path: /oncalls
+    parameters:
+      - {name: "schedule_ids[]", type: string, description: Filter by schedule IDs}
+      - {name: "escalation_policy_ids[]", type: string, description: Filter by escalation policy IDs}
+      - {name: since, type: string, description: Start time (ISO 8601)}
+      - {name: until, type: string, description: End time (ISO 8601)}
+      - {name: limit, type: integer, description: Results per page}
+      - {name: offset, type: integer, description: Pagination offset}
+  list_users:
+    description: List users
+    method: GET
+    path: /users
+    parameters:
+      - {name: query, type: string, description: Filter by name or email}
+      - {name: "team_ids[]", type: string, description: Filter by team IDs}
+      - {name: limit, type: integer, description: Results per page}
+      - {name: offset, type: integer, description: Pagination offset}


### PR DESCRIPTION
This adds first-party providers for Datadog, incident.io, LaunchDarkly,
and PagerDuty covering monitoring, incident management, feature flags,
and on-call operations. Each provider follows the existing YAML
definition pattern with factory, tests, and registration in the central
provider registry.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>