### PR TITLE
Add dbt Cloud, Hex, Intercom, and Notion providers

### DIFF
--- a/cmd/gestaltd/providers.go
+++ b/cmd/gestaltd/providers.go
@@ -3,10 +3,18 @@ package main
 import (
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/plugins/providers/bigquery"
+	"github.com/valon-technologies/gestalt/plugins/providers/dbt_cloud"
+	"github.com/valon-technologies/gestalt/plugins/providers/hex"
+	"github.com/valon-technologies/gestalt/plugins/providers/intercom"
 	"github.com/valon-technologies/gestalt/plugins/providers/jira"
+	"github.com/valon-technologies/gestalt/plugins/providers/notion"
 )
 
 func registerProviders(f *bootstrap.FactoryRegistry) {
 	f.Providers["bigquery"] = bigquery.Factory
+	f.Providers["dbt_cloud"] = dbt_cloud.Factory
+	f.Providers["hex"] = hex.Factory
+	f.Providers["intercom"] = intercom.Factory
 	f.Providers["jira"] = jira.Factory
+	f.Providers["notion"] = notion.Factory
 }

--- a/docs/pages/tasks/_meta.ts
+++ b/docs/pages/tasks/_meta.ts
@@ -2,8 +2,6 @@ export default {
   "run-locally": "Run Locally",
   "add-an-integration": "Add an Integration",
   "add-a-first-party-provider": "Add a First-Party Provider",
-  "configure-jira": "Configure Jira",
-  "configure-bigquery": "Configure BigQuery",
   "install-a-plugin": "Install a Plugin",
   "use-with-mcp": "Use with MCP",
 };

--- a/plugins/providers/dbt_cloud/factory.go
+++ b/plugins/providers/dbt_cloud/factory.go
@@ -1,0 +1,25 @@
+package dbt_cloud
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("dbt_cloud: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/dbt_cloud/factory_test.go
+++ b/plugins/providers/dbt_cloud/factory_test.go
@@ -1,0 +1,65 @@
+package dbt_cloud
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+const (
+	dummyClientID     = "dummy-client-id"
+	dummyClientSecret = "dummy-client-secret"
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["dbt_cloud"]
+	if !ok {
+		t.Fatal("dbt_cloud not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "dbt_cloud",
+		OperationCount: len(spec.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+	})
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["dbt_cloud"]
+	if !ok {
+		t.Fatal("dbt_cloud not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID:     dummyClientID,
+		ClientSecret: dummyClientSecret,
+	})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "dbt_cloud",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+
+	providertest.CheckManualAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/dbt_cloud/provider.yaml
+++ b/plugins/providers/dbt_cloud/provider.yaml
@@ -1,0 +1,95 @@
+provider: dbt_cloud
+display_name: dbt Cloud
+description: dbt Cloud data transformation platform
+connection_mode: user
+base_url: "https://cloud.getdbt.com/api/v2"
+token_prefix: "Token "
+
+auth:
+  type: manual
+
+operations:
+  list_accounts:
+    description: List dbt Cloud accounts accessible with your token
+    method: GET
+    path: /accounts/
+  list_projects:
+    description: List projects in a dbt Cloud account
+    method: GET
+    path: "/accounts/{account_id}/projects/"
+    parameters:
+      - {name: account_id, type: integer, required: true, description: dbt Cloud account ID}
+  list_environments:
+    description: List environments in a project
+    method: GET
+    path: "/accounts/{account_id}/projects/{project_id}/environments/"
+    parameters:
+      - {name: account_id, type: integer, required: true, description: dbt Cloud account ID}
+      - {name: project_id, type: integer, required: true, description: Project ID}
+  list_jobs:
+    description: List jobs in a dbt Cloud account
+    method: GET
+    path: "/accounts/{account_id}/jobs/"
+    parameters:
+      - {name: account_id, type: integer, required: true, description: dbt Cloud account ID}
+      - {name: project_id, type: integer, description: Filter by project ID}
+      - {name: environment_id, type: integer, description: Filter by environment ID}
+  get_job:
+    description: Get details of a specific job
+    method: GET
+    path: "/accounts/{account_id}/jobs/{job_id}/"
+    parameters:
+      - {name: account_id, type: integer, required: true, description: dbt Cloud account ID}
+      - {name: job_id, type: integer, required: true, description: Job ID}
+  trigger_job:
+    description: Trigger a job run with optional overrides
+    method: POST
+    path: "/accounts/{account_id}/jobs/{job_id}/run/"
+    parameters:
+      - {name: account_id, type: integer, required: true, description: dbt Cloud account ID}
+      - {name: job_id, type: integer, required: true, description: Job ID to trigger}
+      - {name: cause, type: string, description: Reason for the run}
+      - {name: git_sha, type: string, description: Git SHA to checkout}
+      - {name: git_branch, type: string, description: Git branch to checkout}
+      - {name: schema_override, type: string, description: Schema name override}
+      - {name: dbt_version_override, type: string, description: dbt version override}
+      - {name: threads_override, type: integer, description: Thread count override}
+      - {name: target_name_override, type: string, description: Target name override}
+      - {name: generate_docs_override, type: boolean, description: Override docs generation setting}
+      - {name: timeout_seconds_override, type: integer, description: Timeout override in seconds}
+      - {name: steps_override, type: array, description: Override job steps (list of dbt commands)}
+  list_runs:
+    description: List runs in a dbt Cloud account with filtering options
+    method: GET
+    path: "/accounts/{account_id}/runs/"
+    parameters:
+      - {name: account_id, type: integer, required: true, description: dbt Cloud account ID}
+      - {name: job_definition_id, type: integer, description: Filter by job ID}
+      - {name: project_id, type: integer, description: Filter by project ID}
+      - {name: status, type: integer, description: "Filter by status (1=queued, 2=starting, 3=running, 10=success, 20=error, 30=cancelled)"}
+      - {name: limit, type: integer, description: Max runs to return (default 100)}
+      - {name: offset, type: integer, description: Pagination offset (default 0)}
+  get_run:
+    description: Get details of a specific run including status
+    method: GET
+    path: "/accounts/{account_id}/runs/{run_id}/"
+    parameters:
+      - {name: account_id, type: integer, required: true, description: dbt Cloud account ID}
+      - {name: run_id, type: integer, required: true, description: Run ID}
+      - {name: include_related, type: array, description: "Related data to include: job, trigger, debug_logs, run_steps"}
+  cancel_run:
+    description: Cancel a run that is currently in progress
+    method: POST
+    path: "/accounts/{account_id}/runs/{run_id}/cancel/"
+    parameters:
+      - {name: account_id, type: integer, required: true, description: dbt Cloud account ID}
+      - {name: run_id, type: integer, required: true, description: Run ID to cancel}
+  get_run_artifact:
+    description: Get an artifact from a completed run
+    method: GET
+    path: "/accounts/{account_id}/runs/{run_id}/artifacts/{path}"
+    parameters:
+      - {name: account_id, type: integer, required: true, description: dbt Cloud account ID}
+      - {name: run_id, type: integer, required: true, description: Run ID}
+      - {name: path, type: string, required: true, description: "Artifact path: manifest.json, catalog.json, run_results.json, or sources.json"}
+      - {name: step, type: integer, description: Step number for multi-step runs}

--- a/plugins/providers/hex/factory.go
+++ b/plugins/providers/hex/factory.go
@@ -1,0 +1,25 @@
+package hex
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("hex: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/hex/factory_test.go
+++ b/plugins/providers/hex/factory_test.go
@@ -1,0 +1,65 @@
+package hex
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+const (
+	dummyClientID     = "dummy-client-id"
+	dummyClientSecret = "dummy-client-secret"
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["hex"]
+	if !ok {
+		t.Fatal("hex not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "hex",
+		OperationCount: len(spec.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+	})
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["hex"]
+	if !ok {
+		t.Fatal("hex not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID:     dummyClientID,
+		ClientSecret: dummyClientSecret,
+	})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "hex",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+
+	providertest.CheckManualAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/hex/provider.yaml
+++ b/plugins/providers/hex/provider.yaml
@@ -1,0 +1,75 @@
+provider: hex
+display_name: Hex
+description: Hex collaborative data workspace
+connection_mode: identity
+base_url: "https://app.hex.tech/api/v1"
+
+auth:
+  type: manual
+
+operations:
+  list_projects:
+    description: List Hex projects accessible with your token
+    method: GET
+    path: /projects
+    parameters:
+      - {name: limit, type: integer, description: Maximum number of projects to return}
+      - {name: after, type: string, description: Cursor for next page of results}
+  get_project:
+    description: Get details of a specific Hex project
+    method: GET
+    path: "/projects/{project_id}"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Hex project ID}
+  run_project:
+    description: Run a published Hex project with optional input parameters
+    method: POST
+    path: "/projects/{project_id}/run"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Hex project ID}
+      - {name: input_params, type: object, description: Input parameters to override for this run}
+      - {name: update_cache, type: boolean, description: Whether to update cached data during the run}
+      - {name: notification_channels, type: array, description: Notification channels to send run completion to}
+  get_run_status:
+    description: Get the status of a project run
+    method: GET
+    path: "/projects/{project_id}/run/{run_id}"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Hex project ID}
+      - {name: run_id, type: string, required: true, description: Run ID returned from run_project}
+  get_project_runs:
+    description: Get the run history of a project
+    method: GET
+    path: "/projects/{project_id}/runs"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Hex project ID}
+      - {name: limit, type: integer, description: Maximum number of runs to return}
+      - {name: after, type: string, description: Cursor for next page of results}
+  cancel_run:
+    description: Cancel a running project execution
+    method: POST
+    path: "/projects/{project_id}/run/{run_id}/cancel"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Hex project ID}
+      - {name: run_id, type: string, required: true, description: Run ID to cancel}
+  update_project:
+    description: Update a project's status
+    method: PATCH
+    path: "/projects/{project_id}"
+    parameters:
+      - {name: project_id, type: string, required: true, description: Hex project ID}
+      - {name: status, type: string, description: New status for the project}
+  list_cells:
+    description: List cells accessible with your token
+    method: GET
+    path: /cells
+    parameters:
+      - {name: project_id, type: string, description: Filter cells by project ID}
+  update_cell:
+    description: Update a cell's source code and/or data connection
+    method: PATCH
+    path: "/cells/{cell_id}"
+    parameters:
+      - {name: cell_id, type: string, required: true, description: Cell ID to update}
+      - {name: source, type: string, description: New source code for the cell}
+      - {name: data_connection_id, type: string, description: Data connection ID for SQL cells}

--- a/plugins/providers/intercom/factory.go
+++ b/plugins/providers/intercom/factory.go
@@ -1,0 +1,25 @@
+package intercom
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("intercom: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/intercom/factory_test.go
+++ b/plugins/providers/intercom/factory_test.go
@@ -1,0 +1,65 @@
+package intercom
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+const (
+	dummyClientID     = "dummy-client-id"
+	dummyClientSecret = "dummy-client-secret"
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["intercom"]
+	if !ok {
+		t.Fatal("intercom not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "intercom",
+		OperationCount: len(spec.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+	})
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["intercom"]
+	if !ok {
+		t.Fatal("intercom not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID:     dummyClientID,
+		ClientSecret: dummyClientSecret,
+	})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "intercom",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+
+	providertest.CheckOAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/intercom/provider.yaml
+++ b/plugins/providers/intercom/provider.yaml
@@ -1,0 +1,83 @@
+provider: intercom
+display_name: Intercom
+description: Intercom customer messaging platform
+connection_mode: user
+base_url: "https://api.intercom.io"
+
+headers:
+  Intercom-Version: "2.11"
+
+auth:
+  type: oauth2
+  authorization_url: https://app.intercom.com/oauth
+  token_url: https://api.intercom.io/auth/eagle/token
+
+operations:
+  list_contacts:
+    description: List Intercom contacts with cursor-based pagination
+    method: GET
+    path: /contacts
+    parameters:
+      - {name: starting_after, type: string, description: Cursor for pagination}
+      - {name: per_page, type: integer, description: Results per page (default 50, max 150)}
+  get_contact:
+    description: Get details of a specific Intercom contact
+    method: GET
+    path: "/contacts/{contact_id}"
+    parameters:
+      - {name: contact_id, type: string, required: true, description: Contact ID}
+  create_contact:
+    description: Create a new Intercom contact (user or lead)
+    method: POST
+    path: /contacts
+    parameters:
+      - {name: role, type: string, required: true, description: "Contact role: 'user' or 'lead'"}
+      - {name: email, type: string, description: Contact email address}
+      - {name: external_id, type: string, description: External ID for the contact}
+      - {name: name, type: string, description: Contact full name}
+      - {name: phone, type: string, description: Contact phone number}
+  list_companies:
+    description: List Intercom companies with pagination
+    method: GET
+    path: /companies
+    parameters:
+      - {name: page, type: integer, description: Page number (default 1)}
+      - {name: per_page, type: integer, description: Results per page (default 50, max 60)}
+      - {name: order, type: string, description: "Sort order: 'asc' or 'desc'"}
+  get_company:
+    description: Get details of a specific Intercom company
+    method: GET
+    path: "/companies/{company_id}"
+    parameters:
+      - {name: company_id, type: string, required: true, description: Company ID}
+  list_conversations:
+    description: List Intercom conversations with cursor-based pagination
+    method: GET
+    path: /conversations
+    parameters:
+      - {name: starting_after, type: string, description: Cursor for pagination}
+      - {name: per_page, type: integer, description: Results per page (default 20)}
+  get_conversation:
+    description: Get an Intercom conversation with its message parts
+    method: GET
+    path: "/conversations/{conversation_id}"
+    parameters:
+      - {name: conversation_id, type: string, required: true, description: Conversation ID}
+  search_conversations:
+    description: Search Intercom conversations by field queries
+    method: POST
+    path: /conversations/search
+    parameters:
+      - {name: query, type: object, required: true, description: "Query object with field, operator, and value keys"}
+      - {name: pagination, type: object, description: "Pagination object with starting_after and per_page keys"}
+  list_tags:
+    description: List all Intercom tags
+    method: GET
+    path: /tags
+  create_note:
+    description: Create a note on an Intercom contact
+    method: POST
+    path: "/contacts/{contact_id}/notes"
+    parameters:
+      - {name: contact_id, type: string, required: true, description: Contact ID to add the note to}
+      - {name: body, type: string, required: true, description: Note body (supports HTML)}

--- a/plugins/providers/notion/factory.go
+++ b/plugins/providers/notion/factory.go
@@ -1,0 +1,25 @@
+package notion
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("notion: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/notion/factory_test.go
+++ b/plugins/providers/notion/factory_test.go
@@ -1,0 +1,65 @@
+package notion
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+const (
+	dummyClientID     = "dummy-client-id"
+	dummyClientSecret = "dummy-client-secret"
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["notion"]
+	if !ok {
+		t.Fatal("notion not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "notion",
+		OperationCount: len(spec.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+	})
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["notion"]
+	if !ok {
+		t.Fatal("notion not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID:     dummyClientID,
+		ClientSecret: dummyClientSecret,
+	})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "notion",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+
+	providertest.CheckOAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/notion/provider.yaml
+++ b/plugins/providers/notion/provider.yaml
@@ -1,0 +1,153 @@
+provider: notion
+display_name: Notion
+description: Notion workspace and knowledge management
+connection_mode: user
+base_url: "https://api.notion.com/v1"
+
+headers:
+  Notion-Version: "2022-06-28"
+
+auth:
+  type: oauth2
+  authorization_url: https://api.notion.com/v1/oauth/authorize
+  token_url: https://api.notion.com/v1/oauth/token
+  client_auth: header
+  token_exchange: json
+  scopes: []
+  authorization_params:
+    owner: user
+
+operations:
+  search:
+    description: Search Notion workspace for pages and databases
+    method: POST
+    path: /search
+    parameters:
+      - {name: query, type: string, description: Search query}
+      - {name: filter, type: object, description: "Filter by object type, e.g. {property: 'object', value: 'page'}"}
+      - {name: start_cursor, type: string, description: Pagination cursor}
+      - {name: page_size, type: integer, description: Results per page (default 100)}
+  get_page:
+    description: Get a Notion page by ID
+    method: GET
+    path: "/pages/{page_id}"
+    parameters:
+      - {name: page_id, type: string, required: true, description: Page ID}
+  get_page_content:
+    description: Get block content from a Notion page
+    method: GET
+    path: "/blocks/{page_id}/children"
+    parameters:
+      - {name: page_id, type: string, required: true, description: Page ID}
+      - {name: start_cursor, type: string, description: Pagination cursor}
+      - {name: page_size, type: integer, description: Results per page (default 100)}
+  query_database:
+    description: Query a Notion database with optional filters and sorts
+    method: POST
+    path: "/databases/{database_id}/query"
+    parameters:
+      - {name: database_id, type: string, required: true, description: Database ID}
+      - {name: filter, type: object, description: Filter object}
+      - {name: sorts, type: array, description: Sort array}
+      - {name: start_cursor, type: string, description: Pagination cursor}
+      - {name: page_size, type: integer, description: Results per page (default and max 100)}
+  get_database:
+    description: Get a Notion database schema
+    method: GET
+    path: "/databases/{database_id}"
+    parameters:
+      - {name: database_id, type: string, required: true, description: Database ID}
+  create_page:
+    description: Create a new Notion page in a database or as a child of another page
+    method: POST
+    path: /pages
+    parameters:
+      - {name: parent, type: object, required: true, description: Parent object (database_id or page_id)}
+      - {name: properties, type: object, required: true, description: Page properties}
+      - {name: children, type: array, description: Block children}
+  update_page:
+    description: Update an existing Notion page's properties, icon, or cover
+    method: PATCH
+    path: "/pages/{page_id}"
+    parameters:
+      - {name: page_id, type: string, required: true, description: Page ID}
+      - {name: properties, type: object, description: Properties to update}
+      - {name: archived, type: boolean, description: Set to true to archive the page}
+      - {name: icon, type: object, description: Page icon (emoji or external URL)}
+      - {name: cover, type: object, description: Page cover image (external URL)}
+  get_block:
+    description: Get a single Notion block by ID
+    method: GET
+    path: "/blocks/{block_id}"
+    parameters:
+      - {name: block_id, type: string, required: true, description: Block ID}
+  append_blocks:
+    description: Append child blocks to a page or existing block
+    method: PATCH
+    path: "/blocks/{block_id}/children"
+    parameters:
+      - {name: block_id, type: string, required: true, description: Parent block or page ID}
+      - {name: children, type: array, required: true, description: Array of block objects to append}
+      - {name: after, type: string, description: Block ID to insert children after}
+  update_block:
+    description: Update a Notion block's content
+    method: PATCH
+    path: "/blocks/{block_id}"
+    parameters:
+      - {name: block_id, type: string, required: true, description: Block ID}
+      - {name: block_content, type: object, required: true, description: Block type-specific content to update}
+      - {name: archived, type: boolean, description: Set to true to archive the block}
+  delete_block:
+    description: Delete (archive) a Notion block
+    method: DELETE
+    path: "/blocks/{block_id}"
+    parameters:
+      - {name: block_id, type: string, required: true, description: Block ID to delete}
+  create_database:
+    description: Create a new Notion database
+    method: POST
+    path: /databases
+    parameters:
+      - {name: parent, type: object, required: true, description: Parent object (page_id or block_id)}
+      - {name: title, type: array, required: true, description: Database title as rich text array}
+      - {name: properties, type: object, required: true, description: Property schema defining database columns}
+      - {name: icon, type: object, description: Database icon (emoji or external URL)}
+      - {name: cover, type: object, description: Database cover image (external URL)}
+  update_database:
+    description: Update a Notion database's title, properties, icon, or cover
+    method: PATCH
+    path: "/databases/{database_id}"
+    parameters:
+      - {name: database_id, type: string, required: true, description: Database ID}
+      - {name: title, type: array, description: New database title as rich text array}
+      - {name: properties, type: object, description: Property schema updates}
+      - {name: icon, type: object, description: Database icon (emoji or external URL)}
+      - {name: cover, type: object, description: Database cover image (external URL)}
+  list_users:
+    description: List all users in the Notion workspace
+    method: GET
+    path: /users
+    parameters:
+      - {name: start_cursor, type: string, description: Pagination cursor}
+      - {name: page_size, type: integer, description: Results per page (default 100)}
+  get_user:
+    description: Get a Notion user by ID
+    method: GET
+    path: "/users/{user_id}"
+    parameters:
+      - {name: user_id, type: string, required: true, description: User ID}
+  create_comment:
+    description: Create a comment on a Notion page or as a reply to a discussion
+    method: POST
+    path: /comments
+    parameters:
+      - {name: parent, type: object, required: true, description: Parent object (page_id or discussion_id)}
+      - {name: rich_text, type: array, required: true, description: Comment content as rich text array}
+  list_comments:
+    description: List comments on a Notion block or page
+    method: GET
+    path: /comments
+    parameters:
+      - {name: block_id, type: string, required: true, description: Block or page ID to get comments for}
+      - {name: start_cursor, type: string, description: Pagination cursor}
+      - {name: page_size, type: integer, description: Results per page (default 100)}


### PR DESCRIPTION
This adds four new workflow and knowledge providers, each with a
provider YAML definition, a factory, and factory tests. The Intercom
search operation uses the nested query object structure required by the
Intercom API. Stale doc nav entries for removed Jira and BigQuery
configuration pages are also cleaned up to fix the docs build.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>