### PR TITLE
Add first-party Slack overlay providers

### DIFF
--- a/cmd/gestalt-plugin-slack-bot/main.go
+++ b/cmd/gestalt-plugin-slack-bot/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os/signal"
+	"syscall"
+
+	"github.com/valon-technologies/gestalt/internal/pluginapi"
+	"github.com/valon-technologies/gestalt/plugins/providers/slack"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	return pluginapi.ServeProvider(ctx, slack.NewOverlayProvider())
+}

--- a/cmd/gestalt-plugin-slack/main.go
+++ b/cmd/gestalt-plugin-slack/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os/signal"
+	"syscall"
+
+	"github.com/valon-technologies/gestalt/internal/pluginapi"
+	"github.com/valon-technologies/gestalt/plugins/providers/slack"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	return pluginapi.ServeProvider(ctx, slack.NewOverlayProvider())
+}

--- a/docs/pages/tasks/_meta.ts
+++ b/docs/pages/tasks/_meta.ts
@@ -2,8 +2,6 @@ export default {
   "run-locally": "Run Locally",
   "add-an-integration": "Add an Integration",
   "add-a-first-party-provider": "Add a First-Party Provider",
-  "configure-jira": "Configure Jira",
-  "configure-bigquery": "Configure BigQuery",
   "install-a-plugin": "Install a Plugin",
   "use-with-mcp": "Use with MCP",
 };

--- a/plugins/providers/slack/factory.go
+++ b/plugins/providers/slack/factory.go
@@ -1,0 +1,148 @@
+package slack
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+const (
+	slackAuthorizationURL = "https://slack.com/oauth/v2/authorize"
+	slackTokenURL         = "https://slack.com/api/oauth.v2.access"
+	scopeSeparator        = ","
+)
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("slack: parsing embedded definition: %w", err)
+	}
+
+	auth := newSlackAuthHandler(intg.ClientID, intg.ClientSecret, intg.RedirectURL, def.Auth.Scopes)
+	return provider.Build(&def, intg, nil,
+		provider.WithAuthHandler(auth),
+		provider.WithEgressResolver(deps.Egress.Resolver),
+	)
+}
+
+type slackAuthHandler struct {
+	clientID     string
+	clientSecret string
+	redirectURL  string
+	scopes       []string
+	httpClient   *http.Client
+}
+
+func newSlackAuthHandler(clientID, clientSecret, redirectURL string, scopes []string) *slackAuthHandler {
+	return &slackAuthHandler{
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		redirectURL:  redirectURL,
+		scopes:       scopes,
+		httpClient:   &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (h *slackAuthHandler) AuthorizationURL(state string, scopes []string) string {
+	effective := scopes
+	if len(effective) == 0 {
+		effective = h.scopes
+	}
+
+	params := url.Values{
+		"client_id":     {h.clientID},
+		"redirect_uri":  {h.redirectURL},
+		"response_type": {"code"},
+		"state":         {state},
+	}
+	if len(effective) > 0 {
+		params.Set("user_scope", strings.Join(effective, scopeSeparator))
+	}
+
+	return slackAuthorizationURL + "?" + params.Encode()
+}
+
+func (h *slackAuthHandler) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	return h.tokenRequest(ctx, url.Values{
+		"code":          {code},
+		"client_id":     {h.clientID},
+		"client_secret": {h.clientSecret},
+		"redirect_uri":  {h.redirectURL},
+	})
+}
+
+func (h *slackAuthHandler) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	return h.tokenRequest(ctx, url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+		"client_id":     {h.clientID},
+		"client_secret": {h.clientSecret},
+	})
+}
+
+func (h *slackAuthHandler) tokenRequest(ctx context.Context, data url.Values) (*core.TokenResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, slackTokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("creating token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending token request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var raw map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("decoding token response: %w", err)
+	}
+
+	ok, _ := raw["ok"].(bool)
+	if !ok {
+		errMsg, _ := raw["error"].(string)
+		if errMsg == "" {
+			errMsg = "unknown error"
+		}
+		return nil, fmt.Errorf("slack oauth error: %s", errMsg)
+	}
+
+	var accessToken, refreshToken string
+
+	if authedUser, _ := raw["authed_user"].(map[string]any); authedUser != nil {
+		accessToken, _ = authedUser["access_token"].(string)
+		refreshToken, _ = authedUser["refresh_token"].(string)
+	}
+
+	if accessToken == "" {
+		accessToken, _ = raw["access_token"].(string)
+	}
+	if refreshToken == "" {
+		refreshToken, _ = raw["refresh_token"].(string)
+	}
+
+	if accessToken == "" {
+		return nil, fmt.Errorf("slack token response missing access_token")
+	}
+
+	return &core.TokenResponse{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		Extra:        raw,
+	}, nil
+}

--- a/plugins/providers/slack/factory_test.go
+++ b/plugins/providers/slack/factory_test.go
@@ -1,0 +1,63 @@
+package slack
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec := inv.Providers["slack"]
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "slack",
+		OperationCount: 13,
+		AuthType:       "oauth2",
+		ConnectionMode: "user",
+	})
+
+	auth := newSlackAuthHandler("dummy-id", "dummy-secret", "https://dummy.example.com/callback", def.Auth.Scopes)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID:     "dummy-id",
+		ClientSecret: "dummy-secret",
+	}, provider.WithAuthHandler(auth))
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "slack",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: 13,
+		OperationNames: baseOperationNames(),
+	})
+
+	providertest.CheckOAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}
+
+func TestSlackAuthHandler_AuthorizationURL(t *testing.T) {
+	t.Parallel()
+
+	h := newSlackAuthHandler("test-client-id", "test-secret", "https://example.com/cb", []string{"channels:read", "chat:write"})
+	authURL := h.AuthorizationURL("test-state", nil)
+
+	if authURL == "" {
+		t.Fatal("AuthorizationURL returned empty string")
+	}
+
+	for _, want := range []string{"user_scope=", "test-client-id", "test-state"} {
+		if !strings.Contains(authURL, want) {
+			t.Errorf("AuthorizationURL missing %q in %q", want, authURL)
+		}
+	}
+}

--- a/plugins/providers/slack/ops.go
+++ b/plugins/providers/slack/ops.go
@@ -1,0 +1,35 @@
+package slack
+
+var baseOps = []string{
+	"add_reaction",
+	"create_channel",
+	"get_channel_history",
+	"get_message",
+	"get_thread_replies",
+	"get_user_info",
+	"invite_to_channel",
+	"list_channels",
+	"schedule_message",
+	"search_messages",
+	"send_message",
+	"send_message_draft",
+	"set_channel_topic",
+}
+
+var overlayOps = []string{
+	"create_canvas",
+	"find_user_mentions",
+	"get_thread_participants",
+}
+
+func baseOperationNames() []string {
+	out := make([]string, len(baseOps))
+	copy(out, baseOps)
+	return out
+}
+
+func overlayOperationNames() []string {
+	out := make([]string, len(overlayOps))
+	copy(out, overlayOps)
+	return out
+}

--- a/plugins/providers/slack/overlay.go
+++ b/plugins/providers/slack/overlay.go
@@ -1,0 +1,410 @@
+package slack
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"time"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+)
+
+const (
+	opFindUserMentions      = "find_user_mentions"
+	opGetThreadParticipants = "get_thread_participants"
+	opCreateCanvas          = "create_canvas"
+
+	overlayProviderName = "slack"
+	overlayDisplayName  = "Slack"
+	overlayDescription  = "Slack overlay operations"
+
+	slackAPIBaseURL = "https://slack.com/api"
+
+	defaultHistoryLimit = 100
+	maxThreadReplies    = 1000
+)
+
+var userMentionPattern = regexp.MustCompile(`<@([UW][A-Z0-9]+)>`)
+
+type OverlayProvider struct {
+	httpClient *http.Client
+}
+
+var (
+	_ core.Provider        = (*OverlayProvider)(nil)
+	_ core.CatalogProvider = (*OverlayProvider)(nil)
+)
+
+func NewOverlayProvider() *OverlayProvider {
+	return &OverlayProvider{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (p *OverlayProvider) Name() string                        { return overlayProviderName }
+func (p *OverlayProvider) DisplayName() string                 { return overlayDisplayName }
+func (p *OverlayProvider) Description() string                 { return overlayDescription }
+func (p *OverlayProvider) ConnectionMode() core.ConnectionMode { return core.ConnectionModeUser }
+
+func (p *OverlayProvider) ListOperations() []core.Operation {
+	return []core.Operation{
+		{
+			Name:        opFindUserMentions,
+			Description: "Find user mentions in channel messages",
+			Method:      http.MethodPost,
+			Parameters: []core.Parameter{
+				{Name: "channel", Type: "string", Required: true, Description: "Channel ID to scan"},
+				{Name: "user_id", Type: "string", Description: "Filter to specific user's mentions"},
+				{Name: "limit", Type: "integer", Description: "Number of messages to scan"},
+				{Name: "oldest", Type: "string", Description: "Unix timestamp, only messages after this"},
+				{Name: "latest", Type: "string", Description: "Unix timestamp, only messages before this"},
+				{Name: "include_bots", Type: "boolean", Description: "Include bot mentions"},
+			},
+		},
+		{
+			Name:        opGetThreadParticipants,
+			Description: "Get unique participants in a thread",
+			Method:      http.MethodPost,
+			Parameters: []core.Parameter{
+				{Name: "channel", Type: "string", Required: true, Description: "Channel ID containing the thread"},
+				{Name: "ts", Type: "string", Required: true, Description: "Timestamp of the parent message"},
+				{Name: "include_user_info", Type: "boolean", Description: "Fetch full user profiles"},
+				{Name: "include_bots", Type: "boolean", Description: "Include bot users"},
+			},
+		},
+		{
+			Name:        opCreateCanvas,
+			Description: "Create a new Slack canvas with a title and optional markdown content",
+			Method:      http.MethodPost,
+			Parameters: []core.Parameter{
+				{Name: "title", Type: "string", Required: true, Description: "Canvas title"},
+				{Name: "document_content", Type: "string", Description: "Markdown content for the canvas"},
+			},
+		},
+	}
+}
+
+func (p *OverlayProvider) Catalog() *catalog.Catalog {
+	ops := p.ListOperations()
+	catOps := make([]catalog.CatalogOperation, len(ops))
+	for i, op := range ops {
+		params := make([]catalog.CatalogParameter, len(op.Parameters))
+		for j, param := range op.Parameters {
+			params[j] = catalog.CatalogParameter{
+				Name:        param.Name,
+				Type:        param.Type,
+				Description: param.Description,
+				Required:    param.Required,
+			}
+		}
+		catOps[i] = catalog.CatalogOperation{
+			ID:          op.Name,
+			Method:      op.Method,
+			Path:        "/",
+			Description: op.Description,
+			Parameters:  params,
+		}
+	}
+	return &catalog.Catalog{
+		Name:        overlayProviderName,
+		DisplayName: overlayDisplayName,
+		Description: overlayDescription,
+		Operations:  catOps,
+	}
+}
+
+func (p *OverlayProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
+	switch operation {
+	case opFindUserMentions:
+		return p.findUserMentions(ctx, params, token)
+	case opGetThreadParticipants:
+		return p.getThreadParticipants(ctx, params, token)
+	case opCreateCanvas:
+		return p.createCanvas(ctx, params, token)
+	default:
+		return nil, fmt.Errorf("unknown operation: %s", operation)
+	}
+}
+
+func (p *OverlayProvider) findUserMentions(ctx context.Context, params map[string]any, token string) (*core.OperationResult, error) {
+	channel, _ := params["channel"].(string)
+	if channel == "" {
+		return nil, fmt.Errorf("channel is required")
+	}
+
+	limit := intParamOr(params, "limit", defaultHistoryLimit)
+	filterUserID, _ := params["user_id"].(string)
+	includeBots, _ := params["include_bots"].(bool)
+
+	historyParams := map[string]any{
+		"channel": channel,
+		"limit":   limit,
+	}
+	if v, ok := params["oldest"]; ok {
+		historyParams["oldest"] = v
+	}
+	if v, ok := params["latest"]; ok {
+		historyParams["latest"] = v
+	}
+
+	body, err := p.slackPost(ctx, "/conversations.history", historyParams, token)
+	if err != nil {
+		return nil, fmt.Errorf("fetching channel history: %w", err)
+	}
+
+	messages, _ := body["messages"].([]any)
+
+	type mention struct {
+		UserID      string `json:"user_id"`
+		MessageTS   string `json:"message_ts"`
+		MentionedBy string `json:"mentioned_by"`
+		Text        string `json:"text"`
+		Channel     string `json:"channel"`
+	}
+
+	var mentions []mention
+	mentionedUserIDs := map[string]struct{}{}
+
+	for _, m := range messages {
+		msg, ok := m.(map[string]any)
+		if !ok {
+			continue
+		}
+		if !includeBots {
+			if _, hasBotID := msg["bot_id"]; hasBotID {
+				continue
+			}
+		}
+		text, _ := msg["text"].(string)
+		found := userMentionPattern.FindAllStringSubmatch(text, -1)
+		for _, match := range found {
+			userID := match[1]
+			if filterUserID != "" && userID != filterUserID {
+				continue
+			}
+			mentionedUserIDs[userID] = struct{}{}
+			ts, _ := msg["ts"].(string)
+			by, _ := msg["user"].(string)
+			mentions = append(mentions, mention{
+				UserID:      userID,
+				MessageTS:   ts,
+				MentionedBy: by,
+				Text:        text,
+				Channel:     channel,
+			})
+		}
+	}
+
+	ids := make([]string, 0, len(mentionedUserIDs))
+	for id := range mentionedUserIDs {
+		ids = append(ids, id)
+	}
+
+	return jsonResult(map[string]any{
+		"mentions":           mentions,
+		"mentioned_user_ids": ids,
+		"total_mentions":     len(mentions),
+		"messages_scanned":   len(messages),
+	})
+}
+
+func (p *OverlayProvider) getThreadParticipants(ctx context.Context, params map[string]any, token string) (*core.OperationResult, error) {
+	channel, _ := params["channel"].(string)
+	if channel == "" {
+		return nil, fmt.Errorf("channel is required")
+	}
+	ts, _ := params["ts"].(string)
+	if ts == "" {
+		return nil, fmt.Errorf("ts is required")
+	}
+
+	includeBots := true
+	if v, ok := params["include_bots"].(bool); ok {
+		includeBots = v
+	}
+	includeUserInfo, _ := params["include_user_info"].(bool)
+
+	body, err := p.slackPost(ctx, "/conversations.replies", map[string]any{
+		"channel": channel,
+		"ts":      ts,
+		"limit":   maxThreadReplies,
+	}, token)
+	if err != nil {
+		return nil, fmt.Errorf("fetching thread replies: %w", err)
+	}
+
+	messages, _ := body["messages"].([]any)
+
+	type participant struct {
+		UserID          string `json:"user_id"`
+		MessageCount    int    `json:"message_count"`
+		FirstReplyTS    string `json:"first_reply_ts"`
+		IsThreadStarter bool   `json:"is_thread_starter"`
+		DisplayName     string `json:"display_name,omitempty"`
+		RealName        string `json:"real_name,omitempty"`
+		IsBot           bool   `json:"is_bot,omitempty"`
+	}
+
+	var threadStarter string
+	if len(messages) > 0 {
+		if first, ok := messages[0].(map[string]any); ok {
+			threadStarter, _ = first["user"].(string)
+		}
+	}
+
+	participantMap := map[string]*participant{}
+
+	for _, m := range messages {
+		msg, ok := m.(map[string]any)
+		if !ok {
+			continue
+		}
+		userID, _ := msg["user"].(string)
+		if userID == "" {
+			continue
+		}
+		if !includeBots {
+			if _, hasBotID := msg["bot_id"]; hasBotID {
+				continue
+			}
+		}
+		if _, exists := participantMap[userID]; !exists {
+			msgTS, _ := msg["ts"].(string)
+			participantMap[userID] = &participant{
+				UserID:          userID,
+				FirstReplyTS:    msgTS,
+				IsThreadStarter: userID == threadStarter,
+			}
+		}
+		participantMap[userID].MessageCount++
+	}
+
+	if includeUserInfo {
+		for userID, pt := range participantMap {
+			userBody, err := p.slackPost(ctx, "/users.info", map[string]any{"user": userID}, token)
+			if err != nil {
+				continue
+			}
+			user, _ := userBody["user"].(map[string]any)
+			if user == nil {
+				continue
+			}
+			profile, _ := user["profile"].(map[string]any)
+			if profile != nil {
+				pt.DisplayName, _ = profile["display_name"].(string)
+			}
+			pt.RealName, _ = user["real_name"].(string)
+			isBot, _ := user["is_bot"].(bool)
+			pt.IsBot = isBot
+		}
+	}
+
+	participants := make([]*participant, 0, len(participantMap))
+	for _, p := range participantMap {
+		participants = append(participants, p)
+	}
+
+	totalReplies := len(messages) - 1
+	if totalReplies < 0 {
+		totalReplies = 0
+	}
+
+	return jsonResult(map[string]any{
+		"participants":      participants,
+		"participant_count": len(participants),
+		"total_replies":     totalReplies,
+	})
+}
+
+func (p *OverlayProvider) createCanvas(ctx context.Context, params map[string]any, token string) (*core.OperationResult, error) {
+	title, _ := params["title"].(string)
+	if title == "" {
+		return nil, fmt.Errorf("title is required")
+	}
+
+	payload := map[string]any{"title": title}
+	if content, ok := params["document_content"].(string); ok && content != "" {
+		payload["document_content"] = map[string]any{
+			"type":     "markdown",
+			"markdown": content,
+		}
+	}
+
+	body, err := p.slackPost(ctx, "/canvases.create", payload, token)
+	if err != nil {
+		return nil, fmt.Errorf("creating canvas: %w", err)
+	}
+
+	return jsonResult(map[string]any{"canvas": body})
+}
+
+func (p *OverlayProvider) slackPost(ctx context.Context, path string, params map[string]any, token string) (map[string]any, error) {
+	payload, err := json.Marshal(params)
+	if err != nil {
+		return nil, err
+	}
+	return p.doSlackRequest(ctx, path, payload, token)
+}
+
+const slackContentType = "application/json; charset=utf-8"
+
+func (p *OverlayProvider) doSlackRequest(ctx context.Context, path string, body []byte, token string) (map[string]any, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, slackAPIBaseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", slackContentType)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	ok, _ := result["ok"].(bool)
+	if !ok {
+		errMsg, _ := result["error"].(string)
+		if errMsg == "" {
+			errMsg = "unknown error"
+		}
+		return nil, fmt.Errorf("slack API error: %s", errMsg)
+	}
+
+	return result, nil
+}
+
+func jsonResult(data map[string]any) (*core.OperationResult, error) {
+	body, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling result: %w", err)
+	}
+	return &core.OperationResult{
+		Status: http.StatusOK,
+		Body:   string(body),
+	}, nil
+}
+
+func intParamOr(params map[string]any, key string, defaultVal int) int {
+	v, ok := params[key]
+	if !ok {
+		return defaultVal
+	}
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	default:
+		return defaultVal
+	}
+}

--- a/plugins/providers/slack/overlay_test.go
+++ b/plugins/providers/slack/overlay_test.go
@@ -1,0 +1,148 @@
+package slack
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+	"github.com/valon-technologies/gestalt/internal/composite"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+func TestOverlayProvider_Operations(t *testing.T) {
+	t.Parallel()
+
+	overlay := NewOverlayProvider()
+	ops := overlay.ListOperations()
+
+	if len(ops) != 3 {
+		t.Fatalf("ListOperations() = %d, want 3", len(ops))
+	}
+
+	got := make([]string, len(ops))
+	for i, op := range ops {
+		got[i] = op.Name
+	}
+	sort.Strings(got)
+
+	want := overlayOperationNames()
+	sort.Strings(want)
+
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("operation[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestOverlayProvider_Catalog(t *testing.T) {
+	t.Parallel()
+
+	overlay := NewOverlayProvider()
+	cat := overlay.Catalog()
+	if cat == nil {
+		t.Fatal("Catalog() returned nil")
+	}
+
+	gotIDs := make([]string, len(cat.Operations))
+	for i, op := range cat.Operations {
+		gotIDs[i] = op.ID
+	}
+	sort.Strings(gotIDs)
+
+	wantIDs := overlayOperationNames()
+	sort.Strings(wantIDs)
+
+	if len(gotIDs) != len(wantIDs) {
+		t.Fatalf("catalog ops = %d, want %d", len(gotIDs), len(wantIDs))
+	}
+	for i := range gotIDs {
+		if gotIDs[i] != wantIDs[i] {
+			t.Errorf("catalog op[%d] = %q, want %q", i, gotIDs[i], wantIDs[i])
+		}
+	}
+}
+
+func TestCompositeOverlay_Slack(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec := inv.Providers["slack"]
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	auth := newSlackAuthHandler("dummy-id", "dummy-secret", "https://dummy.example.com/callback", def.Auth.Scopes)
+	base := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID:     "dummy-id",
+		ClientSecret: "dummy-secret",
+	}, provider.WithAuthHandler(auth))
+
+	overlay := NewOverlayProvider()
+	comp := composite.NewOverlay("slack", base, overlay)
+
+	ops := comp.ListOperations()
+	gotNames := make([]string, len(ops))
+	for i, op := range ops {
+		gotNames[i] = op.Name
+	}
+	sort.Strings(gotNames)
+
+	wantNames := make([]string, len(spec.Operations))
+	copy(wantNames, spec.Operations)
+	sort.Strings(wantNames)
+
+	if len(gotNames) != len(wantNames) {
+		t.Fatalf("composite ops = %d, want %d\ngot:  %v\nwant: %v", len(gotNames), len(wantNames), gotNames, wantNames)
+	}
+	for i := range gotNames {
+		if gotNames[i] != wantNames[i] {
+			t.Errorf("composite op[%d] = %q, want %q", i, gotNames[i], wantNames[i])
+		}
+	}
+
+	cp, ok := comp.(core.CatalogProvider)
+	if !ok {
+		t.Fatal("composite does not implement CatalogProvider")
+	}
+	cat := cp.Catalog()
+	if cat == nil {
+		t.Fatal("composite Catalog() returned nil")
+	}
+
+	gotCatIDs := make([]string, len(cat.Operations))
+	for i, op := range cat.Operations {
+		gotCatIDs[i] = op.ID
+	}
+	sort.Strings(gotCatIDs)
+
+	if len(gotCatIDs) != len(wantNames) {
+		t.Fatalf("composite catalog ops = %d, want %d\ngot:  %v\nwant: %v", len(gotCatIDs), len(wantNames), gotCatIDs, wantNames)
+	}
+	for i := range gotCatIDs {
+		if gotCatIDs[i] != wantNames[i] {
+			t.Errorf("composite catalog op[%d] = %q, want %q", i, gotCatIDs[i], wantNames[i])
+		}
+	}
+
+	overlaySet := map[string]struct{}{}
+	for _, name := range overlayOperationNames() {
+		overlaySet[name] = struct{}{}
+	}
+	for _, op := range cat.Operations {
+		_, isOverlay := overlaySet[op.ID]
+		if isOverlay && op.Transport != catalog.TransportPlugin {
+			t.Errorf("overlay op %q transport = %q, want %q", op.ID, op.Transport, catalog.TransportPlugin)
+		}
+		if !isOverlay && op.Transport == catalog.TransportPlugin {
+			t.Errorf("base op %q should not have transport %q", op.ID, catalog.TransportPlugin)
+		}
+	}
+
+	providertest.CheckOAuth(t, comp)
+}

--- a/plugins/providers/slack/provider.yaml
+++ b/plugins/providers/slack/provider.yaml
@@ -1,0 +1,157 @@
+provider: slack
+display_name: Slack
+description: Send messages, search conversations, and manage channels in Slack
+connection_mode: user
+base_url: "https://slack.com/api"
+
+auth:
+  type: oauth2
+  authorization_url: https://slack.com/oauth/v2/authorize
+  token_url: https://slack.com/api/oauth.v2.access
+  scopes:
+    - channels:read
+    - channels:history
+    - groups:read
+    - groups:history
+    - im:read
+    - im:history
+    - mpim:read
+    - mpim:history
+    - search:read
+    - users:read
+    - chat:write
+    - reactions:write
+    - channels:write
+    - groups:write
+  scope_separator: ","
+
+response_check:
+  success_body_match:
+    ok: true
+  error_message_path: error
+
+operations:
+  list_channels:
+    description: List channels in the workspace
+    method: POST
+    path: /conversations.list
+    parameters:
+      - {name: limit, type: integer, description: "Max channels to return"}
+      - {name: cursor, type: string, description: "Pagination cursor"}
+      - {name: types, type: string, description: "Channel types to include"}
+
+  get_channel_history:
+    description: Get message history from a channel
+    method: POST
+    path: /conversations.history
+    parameters:
+      - {name: channel, type: string, required: true, description: "Channel ID"}
+      - {name: limit, type: integer, description: "Number of messages to return"}
+      - {name: cursor, type: string, description: "Pagination cursor"}
+      - {name: oldest, type: string, description: "Unix timestamp, only messages after this"}
+      - {name: latest, type: string, description: "Unix timestamp, only messages before this"}
+      - {name: inclusive, type: boolean, description: "Include boundary timestamp messages"}
+
+  get_message:
+    description: Fetch a single message by channel and timestamp
+    method: POST
+    path: /conversations.history
+    parameters:
+      - {name: channel, type: string, required: true, description: "Channel ID"}
+      - {name: latest, type: string, required: true, description: "Message timestamp"}
+      - {name: oldest, type: string, required: true, description: "Message timestamp"}
+      - {name: inclusive, type: boolean, description: "Include boundary timestamp messages"}
+      - {name: limit, type: integer, description: "Number of messages to return"}
+
+  search_messages:
+    description: Search for messages in the workspace
+    method: POST
+    path: /search.messages
+    parameters:
+      - {name: query, type: string, required: true, description: "Search query"}
+      - {name: count, type: integer, description: "Number of results"}
+      - {name: page, type: integer, description: "Page number"}
+
+  get_user_info:
+    description: Get user profile information
+    method: POST
+    path: /users.info
+    parameters:
+      - {name: user, type: string, required: true, description: "User ID"}
+
+  get_thread_replies:
+    description: Get all replies in a thread
+    method: POST
+    path: /conversations.replies
+    parameters:
+      - {name: channel, type: string, required: true, description: "Channel ID containing the thread"}
+      - {name: ts, type: string, required: true, description: "Timestamp of the parent message"}
+      - {name: limit, type: integer, description: "Max replies to return"}
+      - {name: cursor, type: string, description: "Pagination cursor"}
+      - {name: oldest, type: string, description: "Unix timestamp, only messages after this"}
+      - {name: latest, type: string, description: "Unix timestamp, only messages before this"}
+      - {name: inclusive, type: boolean, description: "Include boundary timestamp messages"}
+
+  send_message:
+    description: Send a message to a channel or thread
+    method: POST
+    path: /chat.postMessage
+    parameters:
+      - {name: channel, type: string, required: true, description: "Channel ID"}
+      - {name: text, type: string, required: true, description: "Message text"}
+      - {name: thread_ts, type: string, description: "Thread timestamp to reply to"}
+      - {name: unfurl_links, type: boolean, description: "Enable link unfurling"}
+      - {name: unfurl_media, type: boolean, description: "Enable media unfurling"}
+
+  schedule_message:
+    description: Schedule a message to be sent at a future time
+    method: POST
+    path: /chat.scheduleMessage
+    parameters:
+      - {name: channel, type: string, required: true, description: "Channel ID"}
+      - {name: text, type: string, required: true, description: "Message text"}
+      - {name: post_at, type: string, required: true, description: "Unix timestamp for when to send"}
+      - {name: thread_ts, type: string, description: "Thread timestamp to reply to"}
+
+  add_reaction:
+    description: Add an emoji reaction to a message
+    method: POST
+    path: /reactions.add
+    parameters:
+      - {name: channel, type: string, required: true, description: "Channel ID"}
+      - {name: timestamp, type: string, required: true, description: "Timestamp of the message"}
+      - {name: name, type: string, required: true, description: "Emoji name without colons"}
+
+  set_channel_topic:
+    description: Set a channel topic
+    method: POST
+    path: /conversations.setTopic
+    parameters:
+      - {name: channel, type: string, required: true, description: "Channel ID"}
+      - {name: topic, type: string, required: true, description: "New channel topic"}
+
+  create_channel:
+    description: Create a new public or private channel
+    method: POST
+    path: /conversations.create
+    parameters:
+      - {name: name, type: string, required: true, description: "Channel name"}
+      - {name: is_private, type: boolean, description: "Create as private channel"}
+
+  invite_to_channel:
+    description: Invite users to a channel
+    method: POST
+    path: /conversations.invite
+    parameters:
+      - {name: channel, type: string, required: true, description: "Channel ID"}
+      - {name: users, type: string, required: true, description: "Comma-separated list of user IDs"}
+
+  send_message_draft:
+    description: Send an ephemeral message visible only to a specific user
+    method: POST
+    path: /chat.postEphemeral
+    parameters:
+      - {name: channel, type: string, required: true, description: "Channel ID"}
+      - {name: text, type: string, required: true, description: "Message text"}
+      - {name: user, type: string, required: true, description: "User ID who will see the message"}
+      - {name: thread_ts, type: string, description: "Thread timestamp to reply to"}

--- a/plugins/providers/slack_bot/factory.go
+++ b/plugins/providers/slack_bot/factory.go
@@ -1,0 +1,25 @@
+package slackbot
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("slack_bot: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/slack_bot/factory_test.go
+++ b/plugins/providers/slack_bot/factory_test.go
@@ -1,0 +1,40 @@
+package slackbot
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec := inv.Providers["slack_bot"]
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "slack_bot",
+		OperationCount: 13,
+		AuthType:       "manual",
+		ConnectionMode: "identity",
+	})
+
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "slack_bot",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: 13,
+		OperationNames: baseOperationNames(),
+	})
+
+	providertest.CheckManualAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/slack_bot/ops.go
+++ b/plugins/providers/slack_bot/ops.go
@@ -1,0 +1,23 @@
+package slackbot
+
+var baseOps = []string{
+	"add_reaction",
+	"create_channel",
+	"get_channel_history",
+	"get_message",
+	"get_thread_replies",
+	"get_user_info",
+	"invite_to_channel",
+	"list_channels",
+	"schedule_message",
+	"search_messages",
+	"send_message",
+	"send_message_draft",
+	"set_channel_topic",
+}
+
+func baseOperationNames() []string {
+	out := make([]string, len(baseOps))
+	copy(out, baseOps)
+	return out
+}

--- a/plugins/providers/slack_bot/overlay_test.go
+++ b/plugins/providers/slack_bot/overlay_test.go
@@ -1,0 +1,91 @@
+package slackbot
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+	"github.com/valon-technologies/gestalt/internal/composite"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+	"github.com/valon-technologies/gestalt/plugins/providers/slack"
+)
+
+func TestCompositeOverlay_SlackBot(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec := inv.Providers["slack_bot"]
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	base := providertest.BuildProvider(t, def, config.IntegrationDef{})
+
+	overlay := slack.NewOverlayProvider()
+	comp := composite.NewOverlay("slack_bot", base, overlay)
+
+	ops := comp.ListOperations()
+	gotNames := make([]string, len(ops))
+	for i, op := range ops {
+		gotNames[i] = op.Name
+	}
+	sort.Strings(gotNames)
+
+	wantNames := make([]string, len(spec.Operations))
+	copy(wantNames, spec.Operations)
+	sort.Strings(wantNames)
+
+	if len(gotNames) != len(wantNames) {
+		t.Fatalf("composite ops = %d, want %d\ngot:  %v\nwant: %v", len(gotNames), len(wantNames), gotNames, wantNames)
+	}
+	for i := range gotNames {
+		if gotNames[i] != wantNames[i] {
+			t.Errorf("composite op[%d] = %q, want %q", i, gotNames[i], wantNames[i])
+		}
+	}
+
+	cp, ok := comp.(core.CatalogProvider)
+	if !ok {
+		t.Fatal("composite does not implement CatalogProvider")
+	}
+	cat := cp.Catalog()
+	if cat == nil {
+		t.Fatal("composite Catalog() returned nil")
+	}
+
+	gotCatIDs := make([]string, len(cat.Operations))
+	for i, op := range cat.Operations {
+		gotCatIDs[i] = op.ID
+	}
+	sort.Strings(gotCatIDs)
+
+	if len(gotCatIDs) != len(wantNames) {
+		t.Fatalf("composite catalog ops = %d, want %d\ngot:  %v\nwant: %v", len(gotCatIDs), len(wantNames), gotCatIDs, wantNames)
+	}
+	for i := range gotCatIDs {
+		if gotCatIDs[i] != wantNames[i] {
+			t.Errorf("composite catalog op[%d] = %q, want %q", i, gotCatIDs[i], wantNames[i])
+		}
+	}
+
+	overlayOpNames := []string{"create_canvas", "find_user_mentions", "get_thread_participants"}
+	overlaySet := map[string]struct{}{}
+	for _, name := range overlayOpNames {
+		overlaySet[name] = struct{}{}
+	}
+	for _, op := range cat.Operations {
+		_, isOverlay := overlaySet[op.ID]
+		if isOverlay && op.Transport != catalog.TransportPlugin {
+			t.Errorf("overlay op %q transport = %q, want %q", op.ID, op.Transport, catalog.TransportPlugin)
+		}
+		if !isOverlay && op.Transport == catalog.TransportPlugin {
+			t.Errorf("base op %q should not have transport %q", op.ID, catalog.TransportPlugin)
+		}
+	}
+
+	providertest.CheckManualAuth(t, comp)
+}

--- a/plugins/providers/slack_bot/provider.yaml
+++ b/plugins/providers/slack_bot/provider.yaml
@@ -1,0 +1,140 @@
+provider: slack_bot
+display_name: Slack Bot
+description: Send messages, search conversations, and manage channels in Slack via bot token
+connection_mode: identity
+base_url: "https://slack.com/api"
+manual_auth: true
+
+auth:
+  type: manual
+
+response_check:
+  success_body_match:
+    ok: true
+  error_message_path: error
+
+operations:
+  list_channels:
+    description: List channels in the workspace
+    method: POST
+    path: /conversations.list
+    parameters:
+      - {name: limit, type: integer, description: "Max channels to return"}
+      - {name: cursor, type: string, description: "Pagination cursor"}
+      - {name: types, type: string, description: "Channel types to include"}
+
+  get_channel_history:
+    description: Get message history from a channel
+    method: POST
+    path: /conversations.history
+    parameters:
+      - {name: channel, type: string, required: true, description: "Channel ID"}
+      - {name: limit, type: integer, description: "Number of messages to return"}
+      - {name: cursor, type: string, description: "Pagination cursor"}
+      - {name: oldest, type: string, description: "Unix timestamp, only messages after this"}
+      - {name: latest, type: string, description: "Unix timestamp, only messages before this"}
+      - {name: inclusive, type: boolean, description: "Include boundary timestamp messages"}
+
+  get_message:
+    description: Fetch a single message by channel and timestamp
+    method: POST
+    path: /conversations.history
+    parameters:
+      - {name: channel, type: string, required: true, description: "Channel ID"}
+      - {name: latest, type: string, required: true, description: "Message timestamp"}
+      - {name: oldest, type: string, required: true, description: "Message timestamp"}
+      - {name: inclusive, type: boolean, description: "Include boundary timestamp messages"}
+      - {name: limit, type: integer, description: "Number of messages to return"}
+
+  search_messages:
+    description: Search for messages in the workspace
+    method: POST
+    path: /search.messages
+    parameters:
+      - {name: query, type: string, required: true, description: "Search query"}
+      - {name: count, type: integer, description: "Number of results"}
+      - {name: page, type: integer, description: "Page number"}
+
+  get_user_info:
+    description: Get user profile information
+    method: POST
+    path: /users.info
+    parameters:
+      - {name: user, type: string, required: true, description: "User ID"}
+
+  get_thread_replies:
+    description: Get all replies in a thread
+    method: POST
+    path: /conversations.replies
+    parameters:
+      - {name: channel, type: string, required: true, description: "Channel ID containing the thread"}
+      - {name: ts, type: string, required: true, description: "Timestamp of the parent message"}
+      - {name: limit, type: integer, description: "Max replies to return"}
+      - {name: cursor, type: string, description: "Pagination cursor"}
+      - {name: oldest, type: string, description: "Unix timestamp, only messages after this"}
+      - {name: latest, type: string, description: "Unix timestamp, only messages before this"}
+      - {name: inclusive, type: boolean, description: "Include boundary timestamp messages"}
+
+  send_message:
+    description: Send a message to a channel or thread
+    method: POST
+    path: /chat.postMessage
+    parameters:
+      - {name: channel, type: string, required: true, description: "Channel ID"}
+      - {name: text, type: string, required: true, description: "Message text"}
+      - {name: thread_ts, type: string, description: "Thread timestamp to reply to"}
+      - {name: unfurl_links, type: boolean, description: "Enable link unfurling"}
+      - {name: unfurl_media, type: boolean, description: "Enable media unfurling"}
+
+  schedule_message:
+    description: Schedule a message to be sent at a future time
+    method: POST
+    path: /chat.scheduleMessage
+    parameters:
+      - {name: channel, type: string, required: true, description: "Channel ID"}
+      - {name: text, type: string, required: true, description: "Message text"}
+      - {name: post_at, type: string, required: true, description: "Unix timestamp for when to send"}
+      - {name: thread_ts, type: string, description: "Thread timestamp to reply to"}
+
+  add_reaction:
+    description: Add an emoji reaction to a message
+    method: POST
+    path: /reactions.add
+    parameters:
+      - {name: channel, type: string, required: true, description: "Channel ID"}
+      - {name: timestamp, type: string, required: true, description: "Timestamp of the message"}
+      - {name: name, type: string, required: true, description: "Emoji name without colons"}
+
+  set_channel_topic:
+    description: Set a channel topic
+    method: POST
+    path: /conversations.setTopic
+    parameters:
+      - {name: channel, type: string, required: true, description: "Channel ID"}
+      - {name: topic, type: string, required: true, description: "New channel topic"}
+
+  create_channel:
+    description: Create a new public or private channel
+    method: POST
+    path: /conversations.create
+    parameters:
+      - {name: name, type: string, required: true, description: "Channel name"}
+      - {name: is_private, type: boolean, description: "Create as private channel"}
+
+  invite_to_channel:
+    description: Invite users to a channel
+    method: POST
+    path: /conversations.invite
+    parameters:
+      - {name: channel, type: string, required: true, description: "Channel ID"}
+      - {name: users, type: string, required: true, description: "Comma-separated list of user IDs"}
+
+  send_message_draft:
+    description: Send an ephemeral message visible only to a specific user
+    method: POST
+    path: /chat.postEphemeral
+    parameters:
+      - {name: channel, type: string, required: true, description: "Channel ID"}
+      - {name: text, type: string, required: true, description: "Message text"}
+      - {name: user, type: string, required: true, description: "User ID who will see the message"}
+      - {name: thread_ts, type: string, description: "Thread timestamp to reply to"}


### PR DESCRIPTION
This introduces two new Slack providers: `slack` (OAuth2, user connection
mode) and `slack_bot` (manual auth, identity connection mode). Both share
13 base operations defined in `provider.yaml` for standard Slack API
calls like messaging, channel management, and user lookups. The `slack`
package also provides an overlay plugin with three composite operations
(`find_user_mentions`, `get_thread_participants`, `create_canvas`) that
are backed by multi-step Slack API calls and served via the plugin
protocol.

The `slack_bot` provider reuses the same overlay from the `slack` package
through `composite.NewOverlay`, so both providers expose the full 16
operation set while the `slack_bot` variant uses a manually configured
bot token instead of OAuth2.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>