### PR TITLE
Add first-party providers for Extend, Figma, Gong, Ramp, and Rippling

### DIFF
--- a/cmd/gestaltd/providers.go
+++ b/cmd/gestaltd/providers.go
@@ -3,10 +3,20 @@ package main
 import (
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/plugins/providers/bigquery"
+	"github.com/valon-technologies/gestalt/plugins/providers/extend"
+	"github.com/valon-technologies/gestalt/plugins/providers/figma"
+	"github.com/valon-technologies/gestalt/plugins/providers/gong"
 	"github.com/valon-technologies/gestalt/plugins/providers/jira"
+	"github.com/valon-technologies/gestalt/plugins/providers/ramp"
+	"github.com/valon-technologies/gestalt/plugins/providers/rippling"
 )
 
 func registerProviders(f *bootstrap.FactoryRegistry) {
 	f.Providers["bigquery"] = bigquery.Factory
+	f.Providers["extend"] = extend.Factory
+	f.Providers["figma"] = figma.Factory
+	f.Providers["gong"] = gong.Factory
 	f.Providers["jira"] = jira.Factory
+	f.Providers["ramp"] = ramp.Factory
+	f.Providers["rippling"] = rippling.Factory
 }

--- a/plugins/providers/extend/factory.go
+++ b/plugins/providers/extend/factory.go
@@ -1,0 +1,25 @@
+package extend
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("extend: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/extend/factory_test.go
+++ b/plugins/providers/extend/factory_test.go
@@ -1,0 +1,57 @@
+package extend
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["extend"]
+	if !ok {
+		t.Fatal("extend not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "extend",
+		OperationCount: len(spec.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+	})
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["extend"]
+	if !ok {
+		t.Fatal("extend not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "extend",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+
+	providertest.CheckManualAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/extend/provider.yaml
+++ b/plugins/providers/extend/provider.yaml
@@ -1,0 +1,380 @@
+provider: extend
+display_name: Extend
+description: Document processing platform for parsing, extracting, and classifying files
+connection_mode: identity
+base_url: "https://api.extend.ai/v1"
+
+auth:
+  type: manual
+
+operations:
+  upload_file:
+    description: Upload a file from a URL or base64 content
+    method: POST
+    path: /files
+    parameters:
+      - {name: file_url, type: string, description: URL of the file to upload}
+      - {name: file_base64, type: string, description: Base64-encoded file content}
+      - {name: file_name, type: string, description: Filename (used with file_base64)}
+  list_files:
+    description: List uploaded files
+    method: GET
+    path: /files
+    parameters:
+      - {name: name_contains, type: string, description: Filter by filename substring}
+      - {name: sort_dir, type: string, description: "Sort direction: asc or desc"}
+      - {name: next_page_token, type: string, description: Pagination token}
+      - {name: max_page_size, type: integer, description: Max results per page}
+  get_file:
+    description: Get a file by ID
+    method: GET
+    path: "/files/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: File ID}
+      - {name: raw_text, type: boolean, description: Include raw text output}
+      - {name: markdown, type: boolean, description: Include markdown output}
+  delete_file:
+    description: Delete a file
+    method: DELETE
+    path: "/files/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: File ID}
+  parse_file:
+    description: Parse a document synchronously
+    method: POST
+    path: /parse
+    parameters:
+      - {name: file_url, type: string, description: URL of the file to parse}
+      - {name: file_id, type: string, description: ID of an uploaded file to parse}
+  parse_file_async:
+    description: Start an async parse run
+    method: POST
+    path: /parse_runs
+    parameters:
+      - {name: file_url, type: string, description: URL of the file to parse}
+      - {name: file_id, type: string, description: ID of an uploaded file to parse}
+  get_parse_run:
+    description: Get parse run status and results
+    method: GET
+    path: "/parse_runs/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Parse run ID}
+  delete_parse_run:
+    description: Delete a parse run
+    method: DELETE
+    path: "/parse_runs/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Parse run ID}
+  extract_file:
+    description: Extract structured data synchronously
+    method: POST
+    path: /extract
+    parameters:
+      - {name: file_url, type: string, description: URL of the file}
+      - {name: file_id, type: string, description: ID of an uploaded file}
+      - {name: extractor_id, type: string, description: Extractor ID to use}
+  extract_file_async:
+    description: Start an async extract run
+    method: POST
+    path: /extract_runs
+    parameters:
+      - {name: file_url, type: string, description: URL of the file}
+      - {name: file_id, type: string, description: ID of an uploaded file}
+      - {name: extractor_id, type: string, description: Extractor ID to use}
+  list_extract_runs:
+    description: List extract runs
+    method: GET
+    path: /extract_runs
+    parameters:
+      - {name: status, type: string, description: Filter by status}
+      - {name: extractor_id, type: string, description: Filter by extractor ID}
+      - {name: next_page_token, type: string, description: Pagination token}
+      - {name: max_page_size, type: integer, description: Max results per page}
+  get_extract_run:
+    description: Get extract run status and results
+    method: GET
+    path: "/extract_runs/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Extract run ID}
+  delete_extract_run:
+    description: Delete an extract run
+    method: DELETE
+    path: "/extract_runs/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Extract run ID}
+  cancel_extract_run:
+    description: Cancel an extract run
+    method: POST
+    path: "/extract_runs/{id}/cancel"
+    parameters:
+      - {name: id, type: string, required: true, description: Extract run ID}
+  create_extractor:
+    description: Create an extractor
+    method: POST
+    path: /extractors
+    parameters:
+      - {name: name, type: string, required: true, description: Extractor name}
+      - {name: clone_extractor_id, type: string, description: Clone from existing extractor}
+  list_extractors:
+    description: List extractors
+    method: GET
+    path: /extractors
+    parameters:
+      - {name: next_page_token, type: string, description: Pagination token}
+      - {name: max_page_size, type: integer, description: Max results per page}
+      - {name: sort_by, type: string, description: Sort field}
+      - {name: sort_dir, type: string, description: "Sort direction: asc or desc"}
+  get_extractor:
+    description: Get an extractor by ID
+    method: GET
+    path: "/extractors/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Extractor ID}
+  update_extractor:
+    description: Update an extractor
+    method: PATCH
+    path: "/extractors/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Extractor ID}
+      - {name: name, type: string, description: New name}
+  classify_file:
+    description: Classify a document synchronously
+    method: POST
+    path: /classify
+    parameters:
+      - {name: file_url, type: string, description: URL of the file}
+      - {name: file_id, type: string, description: ID of an uploaded file}
+      - {name: classifier_id, type: string, description: Classifier ID to use}
+  classify_file_async:
+    description: Start an async classify run
+    method: POST
+    path: /classify_runs
+    parameters:
+      - {name: file_url, type: string, description: URL of the file}
+      - {name: file_id, type: string, description: ID of an uploaded file}
+      - {name: classifier_id, type: string, description: Classifier ID to use}
+  list_classify_runs:
+    description: List classify runs
+    method: GET
+    path: /classify_runs
+    parameters:
+      - {name: status, type: string, description: Filter by status}
+      - {name: classifier_id, type: string, description: Filter by classifier ID}
+      - {name: next_page_token, type: string, description: Pagination token}
+      - {name: max_page_size, type: integer, description: Max results per page}
+  get_classify_run:
+    description: Get classify run status and results
+    method: GET
+    path: "/classify_runs/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Classify run ID}
+  delete_classify_run:
+    description: Delete a classify run
+    method: DELETE
+    path: "/classify_runs/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Classify run ID}
+  cancel_classify_run:
+    description: Cancel a classify run
+    method: POST
+    path: "/classify_runs/{id}/cancel"
+    parameters:
+      - {name: id, type: string, required: true, description: Classify run ID}
+  create_classifier:
+    description: Create a classifier
+    method: POST
+    path: /classifiers
+    parameters:
+      - {name: name, type: string, required: true, description: Classifier name}
+      - {name: clone_classifier_id, type: string, description: Clone from existing classifier}
+  list_classifiers:
+    description: List classifiers
+    method: GET
+    path: /classifiers
+    parameters:
+      - {name: next_page_token, type: string, description: Pagination token}
+      - {name: max_page_size, type: integer, description: Max results per page}
+      - {name: sort_by, type: string, description: Sort field}
+      - {name: sort_dir, type: string, description: "Sort direction: asc or desc"}
+  get_classifier:
+    description: Get a classifier by ID
+    method: GET
+    path: "/classifiers/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Classifier ID}
+  update_classifier:
+    description: Update a classifier
+    method: PATCH
+    path: "/classifiers/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Classifier ID}
+      - {name: name, type: string, description: New name}
+  split_file:
+    description: Split a multi-document file synchronously
+    method: POST
+    path: /split
+    parameters:
+      - {name: file_url, type: string, description: URL of the file}
+      - {name: file_id, type: string, description: ID of an uploaded file}
+      - {name: splitter_id, type: string, description: Splitter ID to use}
+  split_file_async:
+    description: Start an async split run
+    method: POST
+    path: /split_runs
+    parameters:
+      - {name: file_url, type: string, description: URL of the file}
+      - {name: file_id, type: string, description: ID of an uploaded file}
+      - {name: splitter_id, type: string, description: Splitter ID to use}
+  list_split_runs:
+    description: List split runs
+    method: GET
+    path: /split_runs
+    parameters:
+      - {name: status, type: string, description: Filter by status}
+      - {name: splitter_id, type: string, description: Filter by splitter ID}
+      - {name: next_page_token, type: string, description: Pagination token}
+      - {name: max_page_size, type: integer, description: Max results per page}
+  get_split_run:
+    description: Get split run status and results
+    method: GET
+    path: "/split_runs/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Split run ID}
+  delete_split_run:
+    description: Delete a split run
+    method: DELETE
+    path: "/split_runs/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Split run ID}
+  cancel_split_run:
+    description: Cancel a split run
+    method: POST
+    path: "/split_runs/{id}/cancel"
+    parameters:
+      - {name: id, type: string, required: true, description: Split run ID}
+  create_splitter:
+    description: Create a splitter
+    method: POST
+    path: /splitters
+    parameters:
+      - {name: name, type: string, required: true, description: Splitter name}
+      - {name: clone_splitter_id, type: string, description: Clone from existing splitter}
+  list_splitters:
+    description: List splitters
+    method: GET
+    path: /splitters
+    parameters:
+      - {name: next_page_token, type: string, description: Pagination token}
+      - {name: max_page_size, type: integer, description: Max results per page}
+      - {name: sort_by, type: string, description: Sort field}
+      - {name: sort_dir, type: string, description: "Sort direction: asc or desc"}
+  get_splitter:
+    description: Get a splitter by ID
+    method: GET
+    path: "/splitters/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Splitter ID}
+  update_splitter:
+    description: Update a splitter
+    method: PATCH
+    path: "/splitters/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Splitter ID}
+      - {name: name, type: string, description: New name}
+  edit_file:
+    description: Edit a PDF synchronously
+    method: POST
+    path: /edit
+    parameters:
+      - {name: file_url, type: string, description: URL of the file}
+      - {name: file_id, type: string, description: ID of an uploaded file}
+  edit_file_async:
+    description: Start an async edit run
+    method: POST
+    path: /edit_runs
+    parameters:
+      - {name: file_url, type: string, description: URL of the file}
+      - {name: file_id, type: string, description: ID of an uploaded file}
+  get_edit_run:
+    description: Get edit run status and results
+    method: GET
+    path: "/edit_runs/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Edit run ID}
+  delete_edit_run:
+    description: Delete an edit run
+    method: DELETE
+    path: "/edit_runs/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Edit run ID}
+  create_workflow:
+    description: Create a workflow
+    method: POST
+    path: /workflows
+    parameters:
+      - {name: name, type: string, required: true, description: Workflow name}
+  run_workflow:
+    description: Run a workflow on a file
+    method: POST
+    path: /workflow_runs
+    parameters:
+      - {name: workflow_id, type: string, required: true, description: Workflow ID}
+      - {name: file_url, type: string, description: URL of the file}
+      - {name: file_id, type: string, description: ID of an uploaded file}
+  list_workflow_runs:
+    description: List workflow runs
+    method: GET
+    path: /workflow_runs
+    parameters:
+      - {name: status, type: string, description: Filter by status}
+      - {name: workflow_id, type: string, description: Filter by workflow ID}
+      - {name: batch_id, type: string, description: Filter by batch ID}
+      - {name: next_page_token, type: string, description: Pagination token}
+      - {name: max_page_size, type: integer, description: Max results per page}
+  get_workflow_run:
+    description: Get workflow run status and results
+    method: GET
+    path: "/workflow_runs/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Workflow run ID}
+  update_workflow_run:
+    description: Update a workflow run
+    method: PATCH
+    path: "/workflow_runs/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Workflow run ID}
+      - {name: name, type: string, description: New name}
+  delete_workflow_run:
+    description: Delete a workflow run
+    method: DELETE
+    path: "/workflow_runs/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Workflow run ID}
+  cancel_workflow_run:
+    description: Cancel a workflow run
+    method: POST
+    path: "/workflow_runs/{id}/cancel"
+    parameters:
+      - {name: id, type: string, required: true, description: Workflow run ID}
+  create_evaluation_set:
+    description: Create an evaluation set
+    method: POST
+    path: /evaluation_sets
+    parameters:
+      - {name: name, type: string, required: true, description: Evaluation set name}
+      - {name: entity_id, type: string, required: true, description: Entity ID}
+      - {name: description, type: string, description: Description}
+  list_evaluation_sets:
+    description: List evaluation sets
+    method: GET
+    path: /evaluation_sets
+    parameters:
+      - {name: entity_id, type: string, description: Filter by entity ID}
+      - {name: next_page_token, type: string, description: Pagination token}
+      - {name: max_page_size, type: integer, description: Max results per page}
+  get_evaluation_set:
+    description: Get an evaluation set by ID
+    method: GET
+    path: "/evaluation_sets/{id}"
+    parameters:
+      - {name: id, type: string, required: true, description: Evaluation set ID}

--- a/plugins/providers/figma/factory.go
+++ b/plugins/providers/figma/factory.go
@@ -1,0 +1,25 @@
+package figma
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("figma: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/figma/factory_test.go
+++ b/plugins/providers/figma/factory_test.go
@@ -1,0 +1,65 @@
+package figma
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+const (
+	dummyClientID     = "dummy-client-id"
+	dummyClientSecret = "dummy-client-secret"
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["figma"]
+	if !ok {
+		t.Fatal("figma not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "figma",
+		OperationCount: len(spec.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+	})
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["figma"]
+	if !ok {
+		t.Fatal("figma not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID:     dummyClientID,
+		ClientSecret: dummyClientSecret,
+	})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "figma",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+
+	providertest.CheckOAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/figma/provider.yaml
+++ b/plugins/providers/figma/provider.yaml
@@ -1,0 +1,147 @@
+provider: figma
+display_name: Figma
+description: Figma design platform for files, comments, and dev resources
+connection_mode: user
+base_url: "https://api.figma.com/v1"
+
+auth:
+  type: oauth2
+  authorization_url: https://www.figma.com/oauth
+  token_url: https://api.figma.com/v1/oauth/token
+  scopes:
+    - current_user:read
+    - file_content:read
+    - file_metadata:read
+    - projects:read
+    - file_comments:write
+    - file_dev_resources:read
+    - file_dev_resources:write
+
+operations:
+  get_file:
+    description: Get a Figma file by key
+    method: GET
+    path: "/files/{file_key}"
+    parameters:
+      - {name: file_key, type: string, required: true, description: The file key}
+      - {name: depth, type: integer, description: Depth of nodes to return}
+      - {name: geometry, type: string, description: "Include geometry data ('paths')"}
+      - {name: plugin_data, type: string, description: Return plugin data}
+      - {name: branch_data, type: boolean, description: Return branch metadata}
+  get_file_nodes:
+    description: Get specific nodes from a Figma file
+    method: GET
+    path: "/files/{file_key}/nodes"
+    parameters:
+      - {name: file_key, type: string, required: true, description: The file key}
+      - {name: ids, type: string, required: true, description: Comma-separated list of node IDs}
+      - {name: depth, type: integer, description: Depth of nodes to return}
+      - {name: geometry, type: string, description: Include geometry data}
+      - {name: plugin_data, type: string, description: Return plugin data}
+  list_team_projects:
+    description: List projects in a team
+    method: GET
+    path: "/teams/{team_id}/projects"
+    parameters:
+      - {name: team_id, type: string, required: true, description: The team ID}
+  list_project_files:
+    description: List files in a project
+    method: GET
+    path: "/projects/{project_id}/files"
+    parameters:
+      - {name: project_id, type: string, required: true, description: The project ID}
+      - {name: branch_data, type: boolean, description: Include branch metadata}
+  export_images:
+    description: Export images from a Figma file as jpg, png, svg, or pdf
+    method: GET
+    path: "/images/{file_key}"
+    parameters:
+      - {name: file_key, type: string, required: true, description: The file key}
+      - {name: ids, type: string, required: true, description: Comma-separated list of node IDs to export}
+      - {name: format, type: string, description: "Image format: jpg, png, svg, pdf"}
+      - {name: scale, type: number, description: Image scale 0.01 to 4}
+      - {name: svg_include_id, type: boolean, description: Include id attribute in SVG}
+      - {name: svg_simplify_stroke, type: boolean, description: Simplify strokes in SVG}
+      - {name: use_absolute_bounds, type: boolean, description: Use full dimensions}
+  get_comments:
+    description: Get comments on a Figma file
+    method: GET
+    path: "/files/{file_key}/comments"
+    parameters:
+      - {name: file_key, type: string, required: true, description: The file key}
+      - {name: as_md, type: boolean, description: Return comments as markdown}
+  post_comment:
+    description: Post a comment on a Figma file
+    method: POST
+    path: "/files/{file_key}/comments"
+    parameters:
+      - {name: file_key, type: string, required: true, description: The file key}
+      - {name: message, type: string, required: true, description: Comment text}
+      - {name: comment_id, type: string, description: Parent comment ID for replies}
+      - {name: client_meta, type: object, description: Position for pinned comments}
+  delete_comment:
+    description: Delete a comment on a Figma file
+    method: DELETE
+    path: "/files/{file_key}/comments/{comment_id}"
+    parameters:
+      - {name: file_key, type: string, required: true, description: The file key}
+      - {name: comment_id, type: string, required: true, description: The comment ID to delete}
+  add_reaction:
+    description: Add an emoji reaction to a comment
+    method: POST
+    path: "/files/{file_key}/comments/{comment_id}/reactions"
+    parameters:
+      - {name: file_key, type: string, required: true, description: The file key}
+      - {name: comment_id, type: string, required: true, description: The comment ID to react to}
+      - {name: emoji, type: string, required: true, description: Emoji shortcode}
+  delete_reaction:
+    description: Delete an emoji reaction from a comment
+    method: DELETE
+    path: "/files/{file_key}/comments/{comment_id}/reactions"
+    parameters:
+      - {name: file_key, type: string, required: true, description: The file key}
+      - {name: comment_id, type: string, required: true, description: The comment ID}
+      - {name: emoji, type: string, required: true, description: Emoji shortcode to remove}
+  get_file_components:
+    description: Get components from a Figma file
+    method: GET
+    path: "/files/{file_key}/components"
+    parameters:
+      - {name: file_key, type: string, required: true, description: The file key}
+  get_file_styles:
+    description: Get styles from a Figma file
+    method: GET
+    path: "/files/{file_key}/styles"
+    parameters:
+      - {name: file_key, type: string, required: true, description: The file key}
+  get_me:
+    description: Get the current user's information
+    method: GET
+    path: /me
+    parameters: []
+  get_dev_resources:
+    description: Get dev resources from a Figma file
+    method: GET
+    path: "/files/{file_key}/dev_resources"
+    parameters:
+      - {name: file_key, type: string, required: true, description: The file key}
+      - {name: node_ids, type: string, description: Comma-separated node IDs to filter by}
+  create_dev_resources:
+    description: Bulk create dev resources across Figma files
+    method: POST
+    path: /dev_resources
+    parameters:
+      - {name: dev_resources, type: array, required: true, description: "List of dev resource objects (each needs: name, url, file_key, node_id)"}
+  update_dev_resources:
+    description: Bulk update dev resources across Figma files
+    method: PUT
+    path: /dev_resources
+    parameters:
+      - {name: dev_resources, type: array, required: true, description: "List of dev resource objects to update (each needs: id and fields to update)"}
+  delete_dev_resource:
+    description: Delete a dev resource from a Figma file
+    method: DELETE
+    path: "/files/{file_key}/dev_resources/{dev_resource_id}"
+    parameters:
+      - {name: file_key, type: string, required: true, description: The file key}
+      - {name: dev_resource_id, type: string, required: true, description: The dev resource ID to delete}

--- a/plugins/providers/gong/factory.go
+++ b/plugins/providers/gong/factory.go
@@ -1,0 +1,25 @@
+package gong
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("gong: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/gong/factory_test.go
+++ b/plugins/providers/gong/factory_test.go
@@ -1,0 +1,57 @@
+package gong
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["gong"]
+	if !ok {
+		t.Fatal("gong not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "gong",
+		OperationCount: len(spec.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+	})
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["gong"]
+	if !ok {
+		t.Fatal("gong not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "gong",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+
+	providertest.CheckManualAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/gong/provider.yaml
+++ b/plugins/providers/gong/provider.yaml
@@ -1,0 +1,30 @@
+provider: gong
+display_name: Gong
+description: Gong conversation intelligence for calls and transcripts
+connection_mode: identity
+base_url: "https://api.gong.io/v2"
+
+auth:
+  type: manual
+
+operations:
+  list_calls:
+    description: List Gong calls with optional date filtering and cursor-based pagination
+    method: GET
+    path: /calls
+    parameters:
+      - {name: cursor, type: string, description: Cursor for pagination}
+      - {name: fromDateTime, type: string, description: Start of date range (ISO 8601)}
+      - {name: toDateTime, type: string, description: End of date range (ISO 8601)}
+  get_call:
+    description: Get details of a specific Gong call by ID
+    method: GET
+    path: "/calls/{call_id}"
+    parameters:
+      - {name: call_id, type: string, required: true, description: Gong call ID}
+  list_users:
+    description: List Gong users with cursor-based pagination
+    method: GET
+    path: /users
+    parameters:
+      - {name: cursor, type: string, description: Cursor for pagination}

--- a/plugins/providers/inventory/inventory.yaml
+++ b/plugins/providers/inventory/inventory.yaml
@@ -255,7 +255,6 @@ providers:
     connection_mode: identity
     operations:
       - get_call
-      - get_call_transcript
       - list_calls
       - list_users
 

--- a/plugins/providers/ramp/factory.go
+++ b/plugins/providers/ramp/factory.go
@@ -1,0 +1,25 @@
+package ramp
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("ramp: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/ramp/factory_test.go
+++ b/plugins/providers/ramp/factory_test.go
@@ -1,0 +1,65 @@
+package ramp
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+const (
+	dummyClientID     = "dummy-client-id"
+	dummyClientSecret = "dummy-client-secret"
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["ramp"]
+	if !ok {
+		t.Fatal("ramp not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "ramp",
+		OperationCount: len(spec.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+	})
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["ramp"]
+	if !ok {
+		t.Fatal("ramp not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID:     dummyClientID,
+		ClientSecret: dummyClientSecret,
+	})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "ramp",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+
+	providertest.CheckOAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/ramp/provider.yaml
+++ b/plugins/providers/ramp/provider.yaml
@@ -1,0 +1,66 @@
+provider: ramp
+display_name: Ramp
+description: Ramp corporate card and expense management
+connection_mode: identity
+base_url: "https://api.ramp.com/developer/v1"
+
+auth:
+  type: oauth2
+  authorization_url: https://app.ramp.com/v1/authorize
+  token_url: https://api.ramp.com/developer/v1/token
+  client_auth: header
+  scopes:
+    - transactions:read
+    - cards:read
+    - users:read
+    - departments:read
+
+operations:
+  list_transactions:
+    description: List Ramp transactions with optional date filtering
+    method: GET
+    path: /transactions
+    parameters:
+      - {name: start, type: string, description: Cursor for pagination}
+      - {name: page_size, type: integer, description: Number of results per page}
+      - {name: from_date, type: string, description: Filter by start date (ISO 8601)}
+      - {name: to_date, type: string, description: Filter by end date (ISO 8601)}
+  get_transaction:
+    description: Get details of a specific Ramp transaction
+    method: GET
+    path: "/transactions/{transaction_id}"
+    parameters:
+      - {name: transaction_id, type: string, required: true, description: Transaction ID}
+  list_cards:
+    description: List Ramp cards with pagination
+    method: GET
+    path: /cards
+    parameters:
+      - {name: start, type: string, description: Cursor for pagination}
+      - {name: page_size, type: integer, description: Number of results per page}
+  get_card:
+    description: Get details of a specific Ramp card
+    method: GET
+    path: "/cards/{card_id}"
+    parameters:
+      - {name: card_id, type: string, required: true, description: Card ID}
+  list_users:
+    description: List Ramp users with pagination
+    method: GET
+    path: /users
+    parameters:
+      - {name: start, type: string, description: Cursor for pagination}
+      - {name: page_size, type: integer, description: Number of results per page}
+  get_user:
+    description: Get details of a specific Ramp user
+    method: GET
+    path: "/users/{user_id}"
+    parameters:
+      - {name: user_id, type: string, required: true, description: User ID}
+  list_departments:
+    description: List Ramp departments with pagination
+    method: GET
+    path: /departments
+    parameters:
+      - {name: start, type: string, description: Cursor for pagination}
+      - {name: page_size, type: integer, description: Number of results per page}

--- a/plugins/providers/rippling/factory.go
+++ b/plugins/providers/rippling/factory.go
@@ -1,0 +1,25 @@
+package rippling
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("rippling: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/rippling/factory_test.go
+++ b/plugins/providers/rippling/factory_test.go
@@ -1,0 +1,57 @@
+package rippling
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["rippling"]
+	if !ok {
+		t.Fatal("rippling not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "rippling",
+		OperationCount: len(spec.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+	})
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec, ok := inv.Providers["rippling"]
+	if !ok {
+		t.Fatal("rippling not found in inventory")
+	}
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "rippling",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(spec.Operations),
+		OperationNames: spec.Operations,
+	})
+
+	providertest.CheckManualAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/rippling/provider.yaml
+++ b/plugins/providers/rippling/provider.yaml
@@ -1,0 +1,68 @@
+provider: rippling
+display_name: Rippling
+description: Rippling HR platform for managing employees, departments, and leave
+connection_mode: identity
+base_url: "https://api.rippling.com/platform/api"
+
+auth:
+  type: manual
+
+operations:
+  list_employees:
+    description: List employees with optional filtering by department, work location, or employment type
+    method: GET
+    path: /employees
+    parameters:
+      - {name: cursor, type: string, description: Cursor for pagination}
+      - {name: limit, type: integer, description: Number of results per page}
+      - {name: department_id, type: string, description: Filter by department ID}
+      - {name: work_location_id, type: string, description: Filter by work location ID}
+      - {name: employment_type, type: string, description: Filter by employment type}
+  get_employee:
+    description: Get details of a specific employee
+    method: GET
+    path: "/employees/{employee_id}"
+    parameters:
+      - {name: employee_id, type: string, required: true, description: Employee ID}
+  list_departments:
+    description: List departments
+    method: GET
+    path: /departments
+    parameters:
+      - {name: cursor, type: string, description: Cursor for pagination}
+      - {name: limit, type: integer, description: Number of results per page}
+  list_groups:
+    description: List employee groups
+    method: GET
+    path: /groups
+    parameters:
+      - {name: cursor, type: string, description: Cursor for pagination}
+      - {name: limit, type: integer, description: Number of results per page}
+  list_work_locations:
+    description: List work locations
+    method: GET
+    path: /work_locations
+    parameters:
+      - {name: cursor, type: string, description: Cursor for pagination}
+      - {name: limit, type: integer, description: Number of results per page}
+  get_company:
+    description: Get company information
+    method: GET
+    path: /companies/current
+    parameters: []
+  list_leave_requests:
+    description: List leave/time-off requests
+    method: GET
+    path: /leave_requests
+    parameters:
+      - {name: cursor, type: string, description: Cursor for pagination}
+      - {name: limit, type: integer, description: Number of results per page}
+      - {name: status, type: string, description: Filter by status (PENDING, APPROVED, DENIED, CANCELLED)}
+  list_leave_balances:
+    description: List leave balances
+    method: GET
+    path: /leave_balances
+    parameters:
+      - {name: cursor, type: string, description: Cursor for pagination}
+      - {name: limit, type: integer, description: Number of results per page}
+      - {name: employee_id, type: string, description: Filter by employee ID}


### PR DESCRIPTION
These five new providers expand the set of built-in integrations
available without user-supplied OpenAPI specs or upstream configuration.
Extend covers document processing, Figma covers design collaboration,
Gong covers conversation intelligence, Ramp covers corporate expense
management, and Rippling covers HR and employee management. Each
provider ships a YAML definition with full operation coverage and is
registered in the main factory so it works out of the box.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>