### PR TITLE
Add Gmail and Google Slides composite overlay providers

### DIFF
--- a/cmd/gestalt-plugin-gmail/main.go
+++ b/cmd/gestalt-plugin-gmail/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os/signal"
+	"syscall"
+
+	"github.com/valon-technologies/gestalt/internal/pluginapi"
+	"github.com/valon-technologies/gestalt/plugins/providers/gmail"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	return pluginapi.ServeProvider(ctx, gmail.NewOverlayProvider())
+}

--- a/cmd/gestalt-plugin-google-slides/main.go
+++ b/cmd/gestalt-plugin-google-slides/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os/signal"
+	"syscall"
+
+	"github.com/valon-technologies/gestalt/internal/pluginapi"
+	google_slides "github.com/valon-technologies/gestalt/plugins/providers/google_slides"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	return pluginapi.ServeProvider(ctx, google_slides.NewOverlayProvider())
+}

--- a/docs/pages/tasks/_meta.ts
+++ b/docs/pages/tasks/_meta.ts
@@ -2,8 +2,6 @@ export default {
   "run-locally": "Run Locally",
   "add-an-integration": "Add an Integration",
   "add-a-first-party-provider": "Add a First-Party Provider",
-  "configure-jira": "Configure Jira",
-  "configure-bigquery": "Configure BigQuery",
   "install-a-plugin": "Install a Plugin",
   "use-with-mcp": "Use with MCP",
 };

--- a/plugins/providers/gmail/factory.go
+++ b/plugins/providers/gmail/factory.go
@@ -1,0 +1,25 @@
+package gmail
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("gmail: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/gmail/factory_test.go
+++ b/plugins/providers/gmail/factory_test.go
@@ -12,6 +12,8 @@ import (
 const (
 	dummyClientID     = "dummy-client-id"
 	dummyClientSecret = "dummy-client-secret"
+
+	passthroughOpCount = 10
 )
 
 func TestDefinitionParses(t *testing.T) {
@@ -26,7 +28,7 @@ func TestDefinitionParses(t *testing.T) {
 	def := providertest.ParseDefinition(t, definitionYAML)
 	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
 		Name:           "gmail",
-		OperationCount: len(def.Operations),
+		OperationCount: passthroughOpCount,
 		AuthType:       spec.AuthType,
 		ConnectionMode: spec.ConnectionMode,
 	})
@@ -50,7 +52,7 @@ func TestBuildProvider(t *testing.T) {
 	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
 		Name:           "gmail",
 		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
-		OperationCount: len(def.Operations),
+		OperationCount: passthroughOpCount,
 	})
 
 	providertest.CheckOAuth(t, prov)

--- a/plugins/providers/gmail/factory_test.go
+++ b/plugins/providers/gmail/factory_test.go
@@ -1,0 +1,58 @@
+package gmail
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+const (
+	dummyClientID     = "dummy-client-id"
+	dummyClientSecret = "dummy-client-secret"
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec := inv.Providers["gmail"]
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "gmail",
+		OperationCount: len(def.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+	})
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec := inv.Providers["gmail"]
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID:     dummyClientID,
+		ClientSecret: dummyClientSecret,
+	})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "gmail",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(def.Operations),
+	})
+
+	providertest.CheckOAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/gmail/overlay.go
+++ b/plugins/providers/gmail/overlay.go
@@ -1,0 +1,518 @@
+package gmail
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+)
+
+const (
+	overlayProviderName        = "gmail"
+	overlayProviderDisplayName = "Gmail"
+	overlayProviderDescription = "Gmail overlay operations requiring MIME message building"
+	gmailAPIBase               = "https://gmail.googleapis.com/gmail/v1"
+
+	opSendMessage    = "send_message"
+	opCreateDraft    = "create_draft"
+	opReplyToMessage = "reply_to_message"
+	opForwardMessage = "forward_message"
+	opUpdateLabel    = "update_label"
+
+	paramTo                    = "to"
+	paramSubject               = "subject"
+	paramBody                  = "body"
+	paramCC                    = "cc"
+	paramBCC                   = "bcc"
+	paramHTMLBody              = "html_body"
+	paramMessageID             = "message_id"
+	paramReplyAll              = "reply_all"
+	paramAdditionalText        = "additional_text"
+	paramLabelID               = "label_id"
+	paramName                  = "name"
+	paramLabelListVisibility   = "label_list_visibility"
+	paramMessageListVisibility = "message_list_visibility"
+	paramBackgroundColor       = "background_color"
+	paramTextColor             = "text_color"
+
+	contentTypeJSON = "application/json"
+)
+
+var overlayOps = []core.Operation{
+	{
+		Name:        opSendMessage,
+		Description: "Send an email message",
+		Method:      http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramTo, Type: "string", Required: true, Description: "Recipient email address"},
+			{Name: paramSubject, Type: "string", Required: true, Description: "Email subject line"},
+			{Name: paramBody, Type: "string", Required: true, Description: "Plain text email body"},
+			{Name: paramCC, Type: "string", Description: "CC recipients (comma-separated)"},
+			{Name: paramBCC, Type: "string", Description: "BCC recipients (comma-separated)"},
+			{Name: paramHTMLBody, Type: "string", Description: "HTML email body"},
+		},
+	},
+	{
+		Name:        opCreateDraft,
+		Description: "Create an email draft",
+		Method:      http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramTo, Type: "string", Required: true, Description: "Recipient email address"},
+			{Name: paramSubject, Type: "string", Required: true, Description: "Email subject line"},
+			{Name: paramBody, Type: "string", Required: true, Description: "Plain text email body"},
+			{Name: paramCC, Type: "string", Description: "CC recipients (comma-separated)"},
+			{Name: paramBCC, Type: "string", Description: "BCC recipients (comma-separated)"},
+			{Name: paramHTMLBody, Type: "string", Description: "HTML email body"},
+		},
+	},
+	{
+		Name:        opReplyToMessage,
+		Description: "Reply to an existing email message",
+		Method:      http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramMessageID, Type: "string", Required: true, Description: "ID of the message to reply to"},
+			{Name: paramBody, Type: "string", Required: true, Description: "Plain text reply body"},
+			{Name: paramCC, Type: "string", Description: "CC recipients (comma-separated)"},
+			{Name: paramReplyAll, Type: "boolean", Description: "Reply to all recipients (default false)"},
+			{Name: paramHTMLBody, Type: "string", Description: "HTML reply body"},
+		},
+	},
+	{
+		Name:        opForwardMessage,
+		Description: "Forward an email message to new recipients",
+		Method:      http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramMessageID, Type: "string", Required: true, Description: "ID of the message to forward"},
+			{Name: paramTo, Type: "string", Required: true, Description: "Recipient email address to forward to"},
+			{Name: paramAdditionalText, Type: "string", Description: "Additional text to prepend to forwarded message"},
+			{Name: paramCC, Type: "string", Description: "CC recipients (comma-separated)"},
+		},
+	},
+	{
+		Name:        opUpdateLabel,
+		Description: "Update a Gmail label (rename, move in hierarchy, or change visibility/color)",
+		Method:      http.MethodPatch,
+		Parameters: []core.Parameter{
+			{Name: paramLabelID, Type: "string", Required: true, Description: "Label ID to update"},
+			{Name: paramName, Type: "string", Description: "New label name"},
+			{Name: paramLabelListVisibility, Type: "string", Description: "Visibility: labelShow, labelShowIfUnread, or labelHide"},
+			{Name: paramMessageListVisibility, Type: "string", Description: "Visibility: show or hide"},
+			{Name: paramBackgroundColor, Type: "string", Description: "Background color hex code"},
+			{Name: paramTextColor, Type: "string", Description: "Text color hex code"},
+		},
+	},
+}
+
+var _ core.Provider = (*OverlayProvider)(nil)
+var _ core.CatalogProvider = (*OverlayProvider)(nil)
+
+type OverlayProvider struct {
+	client *http.Client
+}
+
+func NewOverlayProvider() *OverlayProvider {
+	return &OverlayProvider{client: http.DefaultClient}
+}
+
+func (p *OverlayProvider) Name() string                        { return overlayProviderName }
+func (p *OverlayProvider) DisplayName() string                 { return overlayProviderDisplayName }
+func (p *OverlayProvider) Description() string                 { return overlayProviderDescription }
+func (p *OverlayProvider) ConnectionMode() core.ConnectionMode { return core.ConnectionModeUser }
+func (p *OverlayProvider) ListOperations() []core.Operation    { return overlayOps }
+
+func (p *OverlayProvider) Catalog() *catalog.Catalog {
+	ops := make([]catalog.CatalogOperation, len(overlayOps))
+	for i, op := range overlayOps {
+		params := make([]catalog.CatalogParameter, len(op.Parameters))
+		for j, param := range op.Parameters {
+			params[j] = catalog.CatalogParameter{
+				Name:        param.Name,
+				Type:        param.Type,
+				Description: param.Description,
+				Required:    param.Required,
+			}
+		}
+		ops[i] = catalog.CatalogOperation{
+			ID:          op.Name,
+			Method:      op.Method,
+			Description: op.Description,
+			Parameters:  params,
+		}
+	}
+	return &catalog.Catalog{
+		Name:        overlayProviderName,
+		DisplayName: overlayProviderDisplayName,
+		Description: overlayProviderDescription,
+		Operations:  ops,
+	}
+}
+
+func (p *OverlayProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
+	switch operation {
+	case opSendMessage:
+		return p.sendMessage(ctx, params, token)
+	case opCreateDraft:
+		return p.createDraft(ctx, params, token)
+	case opReplyToMessage:
+		return p.replyToMessage(ctx, params, token)
+	case opForwardMessage:
+		return p.forwardMessage(ctx, params, token)
+	case opUpdateLabel:
+		return p.updateLabel(ctx, params, token)
+	default:
+		return nil, fmt.Errorf("unknown operation: %s", operation)
+	}
+}
+
+func (p *OverlayProvider) sendMessage(ctx context.Context, params map[string]any, token string) (*core.OperationResult, error) {
+	raw, err := buildRawFromParams(params)
+	if err != nil {
+		return nil, err
+	}
+	payload, _ := json.Marshal(map[string]string{"raw": raw})
+	return p.doPost(ctx, gmailAPIBase+"/users/me/messages/send", payload, token)
+}
+
+func (p *OverlayProvider) createDraft(ctx context.Context, params map[string]any, token string) (*core.OperationResult, error) {
+	raw, err := buildRawFromParams(params)
+	if err != nil {
+		return nil, err
+	}
+	payload, _ := json.Marshal(map[string]any{
+		"message": map[string]string{"raw": raw},
+	})
+	return p.doPost(ctx, gmailAPIBase+"/users/me/drafts", payload, token)
+}
+
+func buildRawFromParams(params map[string]any) (string, error) {
+	to := stringParam(params, paramTo)
+	subject := stringParam(params, paramSubject)
+	body := stringParam(params, paramBody)
+	if to == "" || subject == "" || body == "" {
+		return "", fmt.Errorf("%s, %s, and %s are required", paramTo, paramSubject, paramBody)
+	}
+	return buildMIMEMessage(to, subject, body,
+		stringParam(params, paramCC),
+		stringParam(params, paramBCC),
+		stringParam(params, paramHTMLBody),
+		"", ""), nil
+}
+
+func (p *OverlayProvider) replyToMessage(ctx context.Context, params map[string]any, token string) (*core.OperationResult, error) {
+	messageID := stringParam(params, paramMessageID)
+	body := stringParam(params, paramBody)
+	if messageID == "" || body == "" {
+		return nil, fmt.Errorf("%s and %s are required", paramMessageID, paramBody)
+	}
+
+	original, err := p.getMessage(ctx, messageID, "metadata", token)
+	if err != nil {
+		return nil, fmt.Errorf("fetching original message: %w", err)
+	}
+
+	threadID, _ := original["threadId"].(string)
+	headers := extractHeaders(original)
+	origFrom := headers["from"]
+	origTo := headers["to"]
+	origSubject := headers["subject"]
+	origMessageID := headers["message-id"]
+
+	replyAll := boolParam(params, paramReplyAll, false)
+	to := origFrom
+	cc := stringParam(params, paramCC)
+	if replyAll {
+		ccParts := []string{}
+		if origTo != "" {
+			ccParts = append(ccParts, origTo)
+		}
+		if origCC := headers["cc"]; origCC != "" {
+			ccParts = append(ccParts, origCC)
+		}
+		if cc != "" {
+			ccParts = append(ccParts, cc)
+		}
+		if len(ccParts) > 0 {
+			cc = strings.Join(ccParts, ", ")
+		}
+	}
+
+	subject := origSubject
+	if !strings.HasPrefix(strings.ToLower(subject), "re:") {
+		subject = "Re: " + subject
+	}
+
+	raw := buildMIMEMessage(to, subject, body, cc, "",
+		stringParam(params, paramHTMLBody),
+		origMessageID, origMessageID)
+
+	payload, _ := json.Marshal(map[string]string{"raw": raw, "threadId": threadID})
+	return p.doPost(ctx, gmailAPIBase+"/users/me/messages/send", payload, token)
+}
+
+func (p *OverlayProvider) forwardMessage(ctx context.Context, params map[string]any, token string) (*core.OperationResult, error) {
+	messageID := stringParam(params, paramMessageID)
+	to := stringParam(params, paramTo)
+	if messageID == "" || to == "" {
+		return nil, fmt.Errorf("%s and %s are required", paramMessageID, paramTo)
+	}
+
+	original, err := p.getMessage(ctx, messageID, "full", token)
+	if err != nil {
+		return nil, fmt.Errorf("fetching original message: %w", err)
+	}
+
+	headers := extractHeaders(original)
+	origSubject := headers["subject"]
+	origFrom := headers["from"]
+	origDate := headers["date"]
+	origBody := extractBody(original)
+
+	subject := origSubject
+	if !strings.HasPrefix(strings.ToLower(subject), "fwd:") {
+		subject = "Fwd: " + subject
+	}
+
+	forwardHeader := fmt.Sprintf(
+		"\n\n---------- Forwarded message ----------\nFrom: %s\nDate: %s\nSubject: %s\n\n",
+		origFrom, origDate, origSubject)
+
+	additionalText := stringParam(params, paramAdditionalText)
+	body := forwardHeader + origBody
+	if additionalText != "" {
+		body = additionalText + body
+	}
+
+	raw := buildMIMEMessage(to, subject, body,
+		stringParam(params, paramCC), "", "", "", "")
+
+	payload, _ := json.Marshal(map[string]string{"raw": raw})
+	return p.doPost(ctx, gmailAPIBase+"/users/me/messages/send", payload, token)
+}
+
+func (p *OverlayProvider) updateLabel(ctx context.Context, params map[string]any, token string) (*core.OperationResult, error) {
+	labelID := stringParam(params, paramLabelID)
+	if labelID == "" {
+		return nil, fmt.Errorf("%s is required", paramLabelID)
+	}
+
+	body := map[string]any{}
+	if v := stringParam(params, paramName); v != "" {
+		body["name"] = v
+	}
+	if v := stringParam(params, paramLabelListVisibility); v != "" {
+		body["labelListVisibility"] = v
+	}
+	if v := stringParam(params, paramMessageListVisibility); v != "" {
+		body["messageListVisibility"] = v
+	}
+
+	bgColor := stringParam(params, paramBackgroundColor)
+	textColor := stringParam(params, paramTextColor)
+	if bgColor != "" || textColor != "" {
+		colorMap := map[string]string{}
+		if bgColor != "" {
+			colorMap["backgroundColor"] = bgColor
+		}
+		if textColor != "" {
+			colorMap["textColor"] = textColor
+		}
+		body["color"] = colorMap
+	}
+
+	if len(body) == 0 {
+		return nil, fmt.Errorf("at least one field to update must be provided")
+	}
+
+	payload, _ := json.Marshal(body)
+	url := fmt.Sprintf("%s/users/me/labels/%s", gmailAPIBase, labelID)
+	return p.doPatch(ctx, url, payload, token)
+}
+
+func (p *OverlayProvider) getMessage(ctx context.Context, messageID, format, token string) (map[string]any, error) {
+	url := fmt.Sprintf("%s/users/me/messages/%s?format=%s", gmailAPIBase, messageID, format)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("gmail API returned %d: %s", resp.StatusCode, string(data))
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (p *OverlayProvider) doPost(ctx context.Context, url string, payload []byte, token string) (*core.OperationResult, error) {
+	return p.doRequest(ctx, http.MethodPost, url, payload, token)
+}
+
+func (p *OverlayProvider) doPatch(ctx context.Context, url string, payload []byte, token string) (*core.OperationResult, error) {
+	return p.doRequest(ctx, http.MethodPatch, url, payload, token)
+}
+
+func (p *OverlayProvider) doRequest(ctx context.Context, method, url string, payload []byte, token string) (*core.OperationResult, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", contentTypeJSON)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return &core.OperationResult{
+		Status: resp.StatusCode,
+		Body:   string(data),
+	}, nil
+}
+
+func buildMIMEMessage(to, subject, body, cc, bcc, htmlBody, inReplyTo, references string) string {
+	var buf strings.Builder
+
+	if htmlBody != "" {
+		w := multipart.NewWriter(&buf)
+		boundary := w.Boundary()
+
+		header := buildRawHeaders(to, subject, cc, bcc, inReplyTo, references)
+		header += fmt.Sprintf("MIME-Version: 1.0\r\nContent-Type: multipart/alternative; boundary=%q\r\n\r\n", boundary)
+		buf.Reset()
+		buf.WriteString(header)
+
+		plainHeader := make(textproto.MIMEHeader)
+		plainHeader.Set("Content-Type", "text/plain; charset=utf-8")
+		pw, _ := w.CreatePart(plainHeader)
+		_, _ = fmt.Fprint(pw, body)
+
+		htmlHeader := make(textproto.MIMEHeader)
+		htmlHeader.Set("Content-Type", "text/html; charset=utf-8")
+		hw, _ := w.CreatePart(htmlHeader)
+		_, _ = fmt.Fprint(hw, htmlBody)
+
+		_ = w.Close()
+	} else {
+		header := buildRawHeaders(to, subject, cc, bcc, inReplyTo, references)
+		header += "MIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n"
+		buf.WriteString(header)
+		buf.WriteString(body)
+	}
+
+	return base64.RawURLEncoding.EncodeToString([]byte(buf.String()))
+}
+
+func buildRawHeaders(to, subject, cc, bcc, inReplyTo, references string) string {
+	var h strings.Builder
+	h.WriteString("To: " + to + "\r\n")
+	h.WriteString("Subject: " + subject + "\r\n")
+	if cc != "" {
+		h.WriteString("Cc: " + cc + "\r\n")
+	}
+	if bcc != "" {
+		h.WriteString("Bcc: " + bcc + "\r\n")
+	}
+	if inReplyTo != "" {
+		h.WriteString("In-Reply-To: " + inReplyTo + "\r\n")
+	}
+	if references != "" {
+		h.WriteString("References: " + references + "\r\n")
+	}
+	return h.String()
+}
+
+func extractHeaders(msg map[string]any) map[string]string {
+	result := map[string]string{}
+	payload, _ := msg["payload"].(map[string]any)
+	if payload == nil {
+		return result
+	}
+	rawHeaders, _ := payload["headers"].([]any)
+	for _, h := range rawHeaders {
+		hMap, _ := h.(map[string]any)
+		if hMap == nil {
+			continue
+		}
+		name, _ := hMap["name"].(string)
+		value, _ := hMap["value"].(string)
+		result[strings.ToLower(name)] = value
+	}
+	return result
+}
+
+func extractBody(msg map[string]any) string {
+	payload, _ := msg["payload"].(map[string]any)
+	if payload == nil {
+		return ""
+	}
+	if bodyData, ok := payload["body"].(map[string]any); ok {
+		if data, ok := bodyData["data"].(string); ok && data != "" {
+			decoded, err := base64.RawURLEncoding.DecodeString(data)
+			if err == nil {
+				return string(decoded)
+			}
+		}
+	}
+	parts, _ := payload["parts"].([]any)
+	for _, part := range parts {
+		p, _ := part.(map[string]any)
+		if p == nil {
+			continue
+		}
+		mimeType, _ := p["mimeType"].(string)
+		if mimeType == "text/plain" {
+			if bodyData, ok := p["body"].(map[string]any); ok {
+				if data, ok := bodyData["data"].(string); ok && data != "" {
+					decoded, err := base64.RawURLEncoding.DecodeString(data)
+					if err == nil {
+						return string(decoded)
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func stringParam(params map[string]any, key string) string {
+	v, _ := params[key].(string)
+	return v
+}
+
+func boolParam(params map[string]any, key string, defaultVal bool) bool {
+	v, ok := params[key].(bool)
+	if !ok {
+		return defaultVal
+	}
+	return v
+}

--- a/plugins/providers/gmail/overlay_test.go
+++ b/plugins/providers/gmail/overlay_test.go
@@ -1,0 +1,133 @@
+package gmail
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+	"github.com/valon-technologies/gestalt/internal/composite"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+var gmailOverlayOpIDs = []string{
+	opSendMessage,
+	opCreateDraft,
+	opReplyToMessage,
+	opForwardMessage,
+	opUpdateLabel,
+}
+
+func TestOverlayCatalog(t *testing.T) {
+	t.Parallel()
+
+	var prov core.Provider = NewOverlayProvider()
+
+	cp, ok := prov.(core.CatalogProvider)
+	if !ok {
+		t.Fatal("overlay does not implement CatalogProvider")
+	}
+
+	cat := cp.Catalog()
+	if cat == nil {
+		t.Fatal("Catalog() returned nil")
+	}
+
+	gotIDs := make([]string, len(cat.Operations))
+	for i, op := range cat.Operations {
+		gotIDs[i] = op.ID
+	}
+	sort.Strings(gotIDs)
+
+	wantIDs := make([]string, len(gmailOverlayOpIDs))
+	copy(wantIDs, gmailOverlayOpIDs)
+	sort.Strings(wantIDs)
+
+	if len(gotIDs) != len(wantIDs) {
+		t.Fatalf("overlay catalog ops = %d, want %d", len(gotIDs), len(wantIDs))
+	}
+	for i := range gotIDs {
+		if gotIDs[i] != wantIDs[i] {
+			t.Errorf("overlay catalog op[%d] = %q, want %q", i, gotIDs[i], wantIDs[i])
+		}
+	}
+}
+
+func TestOverlayComposite(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec := inv.Providers["gmail"]
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	base := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID: dummyClientID, ClientSecret: dummyClientSecret,
+	})
+
+	overlay := NewOverlayProvider()
+	comp := composite.NewOverlay("gmail", base, overlay)
+
+	ops := comp.ListOperations()
+	if len(ops) != len(spec.Operations) {
+		t.Fatalf("composite ListOperations() = %d, want %d", len(ops), len(spec.Operations))
+	}
+
+	gotNames := make([]string, len(ops))
+	for i, op := range ops {
+		gotNames[i] = op.Name
+	}
+	sort.Strings(gotNames)
+
+	wantNames := make([]string, len(spec.Operations))
+	copy(wantNames, spec.Operations)
+	sort.Strings(wantNames)
+
+	for i := range gotNames {
+		if gotNames[i] != wantNames[i] {
+			t.Errorf("composite op[%d] = %q, want %q", i, gotNames[i], wantNames[i])
+		}
+	}
+
+	cp, ok := comp.(core.CatalogProvider)
+	if !ok {
+		t.Fatal("composite does not implement CatalogProvider")
+	}
+
+	cat := cp.Catalog()
+	if cat == nil {
+		t.Fatal("composite Catalog() returned nil")
+	}
+
+	catIDs := make([]string, len(cat.Operations))
+	for i, op := range cat.Operations {
+		catIDs[i] = op.ID
+	}
+	sort.Strings(catIDs)
+
+	if len(catIDs) != len(wantNames) {
+		t.Fatalf("composite catalog ops = %d, want %d", len(catIDs), len(wantNames))
+	}
+	for i := range catIDs {
+		if catIDs[i] != wantNames[i] {
+			t.Errorf("composite catalog op[%d] = %q, want %q", i, catIDs[i], wantNames[i])
+		}
+	}
+
+	overlaySet := map[string]struct{}{}
+	for _, id := range gmailOverlayOpIDs {
+		overlaySet[id] = struct{}{}
+	}
+
+	for _, op := range cat.Operations {
+		if _, isOverlay := overlaySet[op.ID]; isOverlay {
+			if op.Transport != catalog.TransportPlugin {
+				t.Errorf("overlay op %q transport = %q, want %q", op.ID, op.Transport, catalog.TransportPlugin)
+			}
+		}
+	}
+}

--- a/plugins/providers/gmail/provider.yaml
+++ b/plugins/providers/gmail/provider.yaml
@@ -1,0 +1,93 @@
+provider: gmail
+display_name: Gmail
+description: Google Gmail email service
+connection_mode: user
+base_url: "https://gmail.googleapis.com/gmail/v1"
+
+auth:
+  type: oauth2
+  authorization_url: https://accounts.google.com/o/oauth2/v2/auth
+  token_url: https://oauth2.googleapis.com/token
+  scopes:
+    - https://www.googleapis.com/auth/gmail.modify
+    - https://www.googleapis.com/auth/gmail.send
+  authorization_params:
+    access_type: offline
+    prompt: consent
+
+operations:
+  list_messages:
+    description: List emails in the mailbox with optional filtering
+    method: GET
+    path: "/users/me/messages"
+    parameters:
+      - {name: q, type: string, description: "Search query using Gmail search syntax"}
+      - {name: max_results, type: integer, description: "Maximum number of messages to return (default 20, max 500)"}
+      - {name: page_token, type: string, description: "Token for pagination"}
+      - {name: label_ids, type: string, description: "Comma-separated label IDs to filter by"}
+      - {name: include_spam_trash, type: boolean, description: "Include spam and trash messages"}
+
+  get_message:
+    description: Get a specific email message with full content
+    method: GET
+    path: "/users/me/messages/{message_id}"
+    parameters:
+      - {name: message_id, type: string, required: true, description: "Message ID"}
+      - {name: format, type: string, description: "Response format: full, metadata, minimal, or raw"}
+
+  search_messages:
+    description: Search emails using Gmail search syntax
+    method: GET
+    path: "/users/me/messages"
+    parameters:
+      - {name: query, type: string, required: true, description: "Search query using Gmail search syntax"}
+      - {name: max_results, type: integer, description: "Maximum messages to return (default 20)"}
+      - {name: page_token, type: string, description: "Token for pagination"}
+
+  list_labels:
+    description: List all labels (folders/categories) in the mailbox
+    method: GET
+    path: "/users/me/labels"
+
+  get_thread:
+    description: Get an email thread (conversation) with all messages
+    method: GET
+    path: "/users/me/threads/{thread_id}"
+    parameters:
+      - {name: thread_id, type: string, required: true, description: "Thread ID"}
+      - {name: format, type: string, description: "Response format (default full)"}
+
+  get_profile:
+    description: "Get the current user's Gmail profile"
+    method: GET
+    path: "/users/me/profile"
+
+  add_label:
+    description: Add labels to a Gmail message
+    method: POST
+    path: "/users/me/messages/{message_id}/modify"
+    parameters:
+      - {name: message_id, type: string, required: true, description: "Message ID"}
+      - {name: label_ids, type: string, required: true, description: "Comma-separated label IDs to add"}
+
+  remove_label:
+    description: Remove labels from a Gmail message
+    method: POST
+    path: "/users/me/messages/{message_id}/modify"
+    parameters:
+      - {name: message_id, type: string, required: true, description: "Message ID"}
+      - {name: label_ids, type: string, required: true, description: "Comma-separated label IDs to remove"}
+
+  trash_message:
+    description: Move a message to trash
+    method: POST
+    path: "/users/me/messages/{message_id}/trash"
+    parameters:
+      - {name: message_id, type: string, required: true, description: "Message ID to move to trash"}
+
+  mark_as_read:
+    description: Mark a message as read by removing the UNREAD label
+    method: POST
+    path: "/users/me/messages/{message_id}/modify"
+    parameters:
+      - {name: message_id, type: string, required: true, description: "Message ID to mark as read"}

--- a/plugins/providers/google_slides/factory.go
+++ b/plugins/providers/google_slides/factory.go
@@ -1,0 +1,25 @@
+package google_slides
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+//go:embed provider.yaml
+var definitionYAML []byte
+
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+	var def provider.Definition
+	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
+		return nil, fmt.Errorf("google_slides: parsing embedded definition: %w", err)
+	}
+	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+}

--- a/plugins/providers/google_slides/factory_test.go
+++ b/plugins/providers/google_slides/factory_test.go
@@ -12,6 +12,8 @@ import (
 const (
 	dummyClientID     = "dummy-client-id"
 	dummyClientSecret = "dummy-client-secret"
+
+	passthroughOpCount = 3
 )
 
 func TestDefinitionParses(t *testing.T) {
@@ -26,7 +28,7 @@ func TestDefinitionParses(t *testing.T) {
 	def := providertest.ParseDefinition(t, definitionYAML)
 	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
 		Name:           "google_slides",
-		OperationCount: len(def.Operations),
+		OperationCount: passthroughOpCount,
 		AuthType:       spec.AuthType,
 		ConnectionMode: spec.ConnectionMode,
 	})
@@ -50,7 +52,7 @@ func TestBuildProvider(t *testing.T) {
 	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
 		Name:           "google_slides",
 		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
-		OperationCount: len(def.Operations),
+		OperationCount: passthroughOpCount,
 	})
 
 	providertest.CheckOAuth(t, prov)

--- a/plugins/providers/google_slides/factory_test.go
+++ b/plugins/providers/google_slides/factory_test.go
@@ -1,0 +1,58 @@
+package google_slides
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+const (
+	dummyClientID     = "dummy-client-id"
+	dummyClientSecret = "dummy-client-secret"
+)
+
+func TestDefinitionParses(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec := inv.Providers["google_slides"]
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	providertest.CheckDefinition(t, def, providertest.DefinitionExpect{
+		Name:           "google_slides",
+		OperationCount: len(def.Operations),
+		AuthType:       spec.AuthType,
+		ConnectionMode: spec.ConnectionMode,
+	})
+}
+
+func TestBuildProvider(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec := inv.Providers["google_slides"]
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID:     dummyClientID,
+		ClientSecret: dummyClientSecret,
+	})
+
+	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
+		Name:           "google_slides",
+		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
+		OperationCount: len(def.Operations),
+	})
+
+	providertest.CheckOAuth(t, prov)
+	providertest.CheckCatalog(t, prov)
+}

--- a/plugins/providers/google_slides/overlay.go
+++ b/plugins/providers/google_slides/overlay.go
@@ -1,0 +1,1360 @@
+package google_slides
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+)
+
+const (
+	overlayProviderName        = "google_slides"
+	overlayProviderDisplayName = "Google Slides"
+	overlayProviderDescription = "Google Slides overlay operations using batchUpdate API"
+	slidesAPIBase              = "https://slides.googleapis.com/v1"
+
+	opCreatePresentation         = "create_presentation"
+	opCreateSlide                = "create_slide"
+	opDeleteObject               = "delete_object"
+	opDuplicateObject            = "duplicate_object"
+	opUpdateSlidesPosition       = "update_slides_position"
+	opCreateShape                = "create_shape"
+	opInsertText                 = "insert_text"
+	opDeleteText                 = "delete_text"
+	opCreateImage                = "create_image"
+	opCreateTable                = "create_table"
+	opCreateLine                 = "create_line"
+	opReplaceAllText             = "replace_all_text"
+	opReplaceAllShapesWithImage  = "replace_all_shapes_with_image"
+	opUpdateTextStyle            = "update_text_style"
+	opUpdateShapeProperties      = "update_shape_properties"
+	opUpdatePageProperties       = "update_page_properties"
+	opUpdateParagraphStyle       = "update_paragraph_style"
+	opCreateParagraphBullets     = "create_paragraph_bullets"
+	opUpdatePageElementTransform = "update_page_element_transform"
+	opUpdatePageElementsZOrder   = "update_page_elements_z_order"
+	opGroupObjects               = "group_objects"
+	opUngroupObjects             = "ungroup_objects"
+	opUpdateTableCellProperties  = "update_table_cell_properties"
+	opCreateStyledTextBox        = "create_styled_text_box"
+	opCreateBulletList           = "create_bullet_list"
+	opCreateTitleSlide           = "create_title_slide"
+
+	paramPresentationID       = "presentation_id"
+	paramTitle                = "title"
+	paramInsertionIndex       = "insertion_index"
+	paramLayout               = "layout"
+	paramObjectID             = "object_id"
+	paramPageObjectID         = "page_object_id"
+	paramShapeType            = "shape_type"
+	paramX                    = "x"
+	paramY                    = "y"
+	paramWidth                = "width"
+	paramHeight               = "height"
+	paramText                 = "text"
+	paramSlideObjectIDs       = "slide_object_ids"
+	paramStartIndex           = "start_index"
+	paramEndIndex             = "end_index"
+	paramRangeType            = "type"
+	paramURL                  = "url"
+	paramRows                 = "rows"
+	paramColumns              = "columns"
+	paramFind                 = "find"
+	paramReplacement          = "replacement"
+	paramMatchCase            = "match_case"
+	paramImageURL             = "image_url"
+	paramReplaceMethod        = "replace_method"
+	paramBold                 = "bold"
+	paramItalic               = "italic"
+	paramUnderline            = "underline"
+	paramFontFamily           = "font_family"
+	paramFontSize             = "font_size"
+	paramForegroundColor      = "foreground_color"
+	paramBackgroundColor      = "background_color"
+	paramLinkURL              = "link_url"
+	paramFillColor            = "fill_color"
+	paramOutlineColor         = "outline_color"
+	paramOutlineWeight        = "outline_weight"
+	paramAlignment            = "alignment"
+	paramLineSpacing          = "line_spacing"
+	paramSpaceAbove           = "space_above"
+	paramSpaceBelow           = "space_below"
+	paramLineCategory         = "line_category"
+	paramStartX               = "start_x"
+	paramStartY               = "start_y"
+	paramEndX                 = "end_x"
+	paramEndY                 = "end_y"
+	paramBulletPreset         = "bullet_preset"
+	paramTranslateX           = "translate_x"
+	paramTranslateY           = "translate_y"
+	paramScaleX               = "scale_x"
+	paramScaleY               = "scale_y"
+	paramApplyMode            = "apply_mode"
+	paramPageElementObjectIDs = "page_element_object_ids"
+	paramOperation            = "operation"
+	paramChildrenObjectIDs    = "children_object_ids"
+	paramGroupObjectID        = "group_object_id"
+	paramObjectIDs            = "object_ids"
+	paramRowIndex             = "row_index"
+	paramColumnIndex          = "column_index"
+	paramPaddingTop           = "padding_top"
+	paramPaddingBottom        = "padding_bottom"
+	paramPaddingLeft          = "padding_left"
+	paramPaddingRight         = "padding_right"
+	paramItems                = "items"
+	paramSubtitle             = "subtitle"
+	paramTitleColor           = "title_color"
+	paramSubtitleColor        = "subtitle_color"
+	paramTitleFont            = "title_font"
+	paramTitleSize            = "title_size"
+	paramSubtitleFont         = "subtitle_font"
+	paramSubtitleSize         = "subtitle_size"
+
+	contentTypeJSON = "application/json"
+)
+
+var overlayOps = []core.Operation{
+	{Name: opCreatePresentation, Description: "Create a new Google Slides presentation", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramTitle, Type: "string", Required: true, Description: "Presentation title"},
+		}},
+	{Name: opCreateSlide, Description: "Create a new slide in a presentation", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramInsertionIndex, Type: "integer", Description: "Position to insert slide"},
+			{Name: paramLayout, Type: "string", Description: "Predefined layout"},
+			{Name: paramObjectID, Type: "string", Description: "Custom object ID for the slide"},
+		}},
+	{Name: opDeleteObject, Description: "Delete an object from a presentation", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramObjectID, Type: "string", Required: true, Description: "Object ID to delete"},
+		}},
+	{Name: opDuplicateObject, Description: "Duplicate a slide or element", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramObjectID, Type: "string", Required: true, Description: "Object ID to duplicate"},
+		}},
+	{Name: opUpdateSlidesPosition, Description: "Reorder slides in a presentation", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramSlideObjectIDs, Type: "array", Required: true, Description: "List of slide IDs to move"},
+			{Name: paramInsertionIndex, Type: "integer", Required: true, Description: "Target position"},
+		}},
+	{Name: opCreateShape, Description: "Create a shape on a slide", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramPageObjectID, Type: "string", Required: true, Description: "Target slide ID"},
+			{Name: paramShapeType, Type: "string", Required: true, Description: "Shape type: TEXT_BOX, RECTANGLE, ELLIPSE, etc."},
+			{Name: paramObjectID, Type: "string", Description: "Custom object ID"},
+			{Name: paramX, Type: "number", Description: "X position in points"},
+			{Name: paramY, Type: "number", Description: "Y position in points"},
+			{Name: paramWidth, Type: "number", Description: "Width in points"},
+			{Name: paramHeight, Type: "number", Description: "Height in points"},
+		}},
+	{Name: opInsertText, Description: "Insert text into a shape", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramObjectID, Type: "string", Required: true, Description: "Target shape ID"},
+			{Name: paramText, Type: "string", Required: true, Description: "Text to insert"},
+			{Name: paramInsertionIndex, Type: "integer", Description: "Character position to insert at"},
+		}},
+	{Name: opDeleteText, Description: "Delete text from a shape", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramObjectID, Type: "string", Required: true, Description: "Target shape ID"},
+			{Name: paramStartIndex, Type: "integer", Description: "Start character index"},
+			{Name: paramEndIndex, Type: "integer", Description: "End character index"},
+			{Name: paramRangeType, Type: "string", Description: "Range type: ALL, FROM_START_INDEX, FIXED_RANGE"},
+		}},
+	{Name: opCreateImage, Description: "Insert an image into a slide", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramPageObjectID, Type: "string", Required: true, Description: "Target slide ID"},
+			{Name: paramURL, Type: "string", Required: true, Description: "Public image URL"},
+			{Name: paramObjectID, Type: "string", Description: "Custom object ID"},
+			{Name: paramX, Type: "number", Description: "X position in points"},
+			{Name: paramY, Type: "number", Description: "Y position in points"},
+			{Name: paramWidth, Type: "number", Description: "Width in points"},
+			{Name: paramHeight, Type: "number", Description: "Height in points"},
+		}},
+	{Name: opCreateTable, Description: "Create a table on a slide", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramPageObjectID, Type: "string", Required: true, Description: "Target slide ID"},
+			{Name: paramRows, Type: "integer", Required: true, Description: "Number of rows"},
+			{Name: paramColumns, Type: "integer", Required: true, Description: "Number of columns"},
+			{Name: paramObjectID, Type: "string", Description: "Custom object ID"},
+		}},
+	{Name: opCreateLine, Description: "Create a line on a slide", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramPageObjectID, Type: "string", Required: true, Description: "Target slide ID"},
+			{Name: paramLineCategory, Type: "string", Description: "Line type: STRAIGHT, BENT, or CURVED"},
+			{Name: paramObjectID, Type: "string", Description: "Custom object ID"},
+			{Name: paramStartX, Type: "number", Description: "Start X position in points"},
+			{Name: paramStartY, Type: "number", Description: "Start Y position in points"},
+			{Name: paramEndX, Type: "number", Description: "End X position in points"},
+			{Name: paramEndY, Type: "number", Description: "End Y position in points"},
+		}},
+	{Name: opReplaceAllText, Description: "Find and replace text throughout a presentation", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramFind, Type: "string", Required: true, Description: "Text to find"},
+			{Name: paramReplacement, Type: "string", Required: true, Description: "Replacement text"},
+			{Name: paramMatchCase, Type: "boolean", Description: "Case-sensitive match"},
+		}},
+	{Name: opReplaceAllShapesWithImage, Description: "Replace shapes containing text with an image", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramFind, Type: "string", Required: true, Description: "Text to find in shapes"},
+			{Name: paramImageURL, Type: "string", Required: true, Description: "URL of replacement image"},
+			{Name: paramReplaceMethod, Type: "string", Description: "Replace method: CENTER_INSIDE or CENTER_CROP"},
+		}},
+	{Name: opUpdateTextStyle, Description: "Update text styling", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramObjectID, Type: "string", Required: true, Description: "Shape ID containing the text"},
+			{Name: paramStartIndex, Type: "integer", Description: "Start character index"},
+			{Name: paramEndIndex, Type: "integer", Description: "End character index"},
+			{Name: paramBold, Type: "boolean", Description: "Make text bold"},
+			{Name: paramItalic, Type: "boolean", Description: "Make text italic"},
+			{Name: paramUnderline, Type: "boolean", Description: "Underline text"},
+			{Name: paramFontFamily, Type: "string", Description: "Font name"},
+			{Name: paramFontSize, Type: "number", Description: "Font size in points"},
+			{Name: paramForegroundColor, Type: "string", Description: "Text color as hex #RRGGBB"},
+			{Name: paramBackgroundColor, Type: "string", Description: "Text background color as hex #RRGGBB"},
+			{Name: paramLinkURL, Type: "string", Description: "Make text a hyperlink"},
+		}},
+	{Name: opUpdateShapeProperties, Description: "Update shape properties", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramObjectID, Type: "string", Required: true, Description: "Shape ID"},
+			{Name: paramFillColor, Type: "string", Description: "Fill color as hex #RRGGBB"},
+			{Name: paramOutlineColor, Type: "string", Description: "Outline color as hex #RRGGBB"},
+			{Name: paramOutlineWeight, Type: "number", Description: "Outline thickness in points"},
+		}},
+	{Name: opUpdatePageProperties, Description: "Update page/slide properties", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramObjectID, Type: "string", Required: true, Description: "Page/slide ID"},
+			{Name: paramBackgroundColor, Type: "string", Description: "Background color as hex #RRGGBB"},
+		}},
+	{Name: opUpdateParagraphStyle, Description: "Update paragraph styling", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramObjectID, Type: "string", Required: true, Description: "Shape ID containing the text"},
+			{Name: paramAlignment, Type: "string", Description: "Text alignment: START, CENTER, END, JUSTIFIED"},
+			{Name: paramLineSpacing, Type: "number", Description: "Line spacing percentage"},
+			{Name: paramSpaceAbove, Type: "number", Description: "Space above paragraph in points"},
+			{Name: paramSpaceBelow, Type: "number", Description: "Space below paragraph in points"},
+		}},
+	{Name: opCreateParagraphBullets, Description: "Add bullet points or numbering to text", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramObjectID, Type: "string", Required: true, Description: "Shape ID containing the text"},
+			{Name: paramBulletPreset, Type: "string", Description: "Bullet style preset"},
+			{Name: paramStartIndex, Type: "integer", Description: "Start character index"},
+			{Name: paramEndIndex, Type: "integer", Description: "End character index"},
+		}},
+	{Name: opUpdatePageElementTransform, Description: "Update position and size of a page element", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramObjectID, Type: "string", Required: true, Description: "Element ID to transform"},
+			{Name: paramTranslateX, Type: "number", Description: "New X position in points"},
+			{Name: paramTranslateY, Type: "number", Description: "New Y position in points"},
+			{Name: paramScaleX, Type: "number", Description: "Horizontal scale factor"},
+			{Name: paramScaleY, Type: "number", Description: "Vertical scale factor"},
+			{Name: paramApplyMode, Type: "string", Description: "Apply mode: RELATIVE or ABSOLUTE"},
+		}},
+	{Name: opUpdatePageElementsZOrder, Description: "Change the z-order of page elements", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramPageElementObjectIDs, Type: "array", Required: true, Description: "List of element IDs to reorder"},
+			{Name: paramOperation, Type: "string", Required: true, Description: "Z-order operation: BRING_TO_FRONT, BRING_FORWARD, SEND_BACKWARD, SEND_TO_BACK"},
+		}},
+	{Name: opGroupObjects, Description: "Group multiple page elements together", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramChildrenObjectIDs, Type: "array", Required: true, Description: "List of element IDs to group (minimum 2)"},
+			{Name: paramGroupObjectID, Type: "string", Description: "Custom ID for the new group"},
+		}},
+	{Name: opUngroupObjects, Description: "Ungroup a group element into its parts", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramObjectIDs, Type: "array", Required: true, Description: "List of group IDs to ungroup"},
+		}},
+	{Name: opUpdateTableCellProperties, Description: "Update table cell properties", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramObjectID, Type: "string", Required: true, Description: "Table ID"},
+			{Name: paramRowIndex, Type: "integer", Required: true, Description: "Row index (0-based)"},
+			{Name: paramColumnIndex, Type: "integer", Required: true, Description: "Column index (0-based)"},
+			{Name: paramBackgroundColor, Type: "string", Description: "Cell background color as hex #RRGGBB"},
+			{Name: paramPaddingTop, Type: "number", Description: "Top padding in points"},
+			{Name: paramPaddingBottom, Type: "number", Description: "Bottom padding in points"},
+			{Name: paramPaddingLeft, Type: "number", Description: "Left padding in points"},
+			{Name: paramPaddingRight, Type: "number", Description: "Right padding in points"},
+		}},
+	{Name: opCreateStyledTextBox, Description: "Create a text box with text and styling in a single operation", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramPageObjectID, Type: "string", Required: true, Description: "Target slide ID"},
+			{Name: paramText, Type: "string", Required: true, Description: "Text content"},
+			{Name: paramX, Type: "number", Description: "X position in points"},
+			{Name: paramY, Type: "number", Description: "Y position in points"},
+			{Name: paramWidth, Type: "number", Description: "Width in points"},
+			{Name: paramHeight, Type: "number", Description: "Height in points"},
+			{Name: paramObjectID, Type: "string", Description: "Custom object ID"},
+			{Name: paramFontFamily, Type: "string", Description: "Font name"},
+			{Name: paramFontSize, Type: "number", Description: "Font size in points"},
+			{Name: paramBold, Type: "boolean", Description: "Make text bold"},
+			{Name: paramItalic, Type: "boolean", Description: "Make text italic"},
+			{Name: paramForegroundColor, Type: "string", Description: "Text color as hex #RRGGBB"},
+			{Name: paramFillColor, Type: "string", Description: "Background fill color as hex #RRGGBB"},
+			{Name: paramAlignment, Type: "string", Description: "Text alignment: START, CENTER, END, JUSTIFIED"},
+		}},
+	{Name: opCreateBulletList, Description: "Create a text box with bullet points in a single operation", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramPageObjectID, Type: "string", Required: true, Description: "Target slide ID"},
+			{Name: paramItems, Type: "array", Required: true, Description: "List of bullet point strings"},
+			{Name: paramX, Type: "number", Description: "X position in points"},
+			{Name: paramY, Type: "number", Description: "Y position in points"},
+			{Name: paramWidth, Type: "number", Description: "Width in points"},
+			{Name: paramHeight, Type: "number", Description: "Height in points"},
+			{Name: paramObjectID, Type: "string", Description: "Custom object ID"},
+			{Name: paramBulletPreset, Type: "string", Description: "Bullet style"},
+			{Name: paramFontFamily, Type: "string", Description: "Font name"},
+			{Name: paramFontSize, Type: "number", Description: "Font size in points"},
+			{Name: paramForegroundColor, Type: "string", Description: "Text color as hex #RRGGBB"},
+		}},
+	{Name: opCreateTitleSlide, Description: "Create a complete title slide with title, subtitle, and styling", Method: http.MethodPost,
+		Parameters: []core.Parameter{
+			{Name: paramPresentationID, Type: "string", Required: true, Description: "Presentation ID"},
+			{Name: paramTitle, Type: "string", Required: true, Description: "Title text"},
+			{Name: paramSubtitle, Type: "string", Description: "Subtitle text"},
+			{Name: paramBackgroundColor, Type: "string", Description: "Slide background color as hex #RRGGBB"},
+			{Name: paramTitleColor, Type: "string", Description: "Title text color as hex #RRGGBB"},
+			{Name: paramSubtitleColor, Type: "string", Description: "Subtitle text color as hex #RRGGBB"},
+			{Name: paramTitleFont, Type: "string", Description: "Title font family"},
+			{Name: paramTitleSize, Type: "number", Description: "Title font size in points"},
+			{Name: paramSubtitleFont, Type: "string", Description: "Subtitle font family"},
+			{Name: paramSubtitleSize, Type: "number", Description: "Subtitle font size in points"},
+			{Name: paramInsertionIndex, Type: "integer", Description: "Position to insert slide"},
+		}},
+}
+
+var _ core.Provider = (*OverlayProvider)(nil)
+var _ core.CatalogProvider = (*OverlayProvider)(nil)
+
+type OverlayProvider struct {
+	client *http.Client
+}
+
+func NewOverlayProvider() *OverlayProvider {
+	return &OverlayProvider{client: http.DefaultClient}
+}
+
+func (p *OverlayProvider) Name() string                        { return overlayProviderName }
+func (p *OverlayProvider) DisplayName() string                 { return overlayProviderDisplayName }
+func (p *OverlayProvider) Description() string                 { return overlayProviderDescription }
+func (p *OverlayProvider) ConnectionMode() core.ConnectionMode { return core.ConnectionModeUser }
+func (p *OverlayProvider) ListOperations() []core.Operation    { return overlayOps }
+
+func (p *OverlayProvider) Catalog() *catalog.Catalog {
+	ops := make([]catalog.CatalogOperation, len(overlayOps))
+	for i, op := range overlayOps {
+		params := make([]catalog.CatalogParameter, len(op.Parameters))
+		for j, param := range op.Parameters {
+			params[j] = catalog.CatalogParameter{
+				Name:        param.Name,
+				Type:        param.Type,
+				Description: param.Description,
+				Required:    param.Required,
+			}
+		}
+		ops[i] = catalog.CatalogOperation{
+			ID:          op.Name,
+			Method:      op.Method,
+			Description: op.Description,
+			Parameters:  params,
+		}
+	}
+	return &catalog.Catalog{
+		Name:        overlayProviderName,
+		DisplayName: overlayProviderDisplayName,
+		Description: overlayProviderDescription,
+		Operations:  ops,
+	}
+}
+
+func (p *OverlayProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
+	switch operation {
+	case opCreatePresentation:
+		return p.createPresentation(ctx, params, token)
+	case opCreateSlide:
+		return p.executeBatchOp(ctx, params, token, p.buildCreateSlide)
+	case opDeleteObject:
+		return p.executeBatchOp(ctx, params, token, p.buildDeleteObject)
+	case opDuplicateObject:
+		return p.executeBatchOp(ctx, params, token, p.buildDuplicateObject)
+	case opUpdateSlidesPosition:
+		return p.executeBatchOp(ctx, params, token, p.buildUpdateSlidesPosition)
+	case opCreateShape:
+		return p.executeBatchOp(ctx, params, token, p.buildCreateShape)
+	case opInsertText:
+		return p.executeBatchOp(ctx, params, token, p.buildInsertText)
+	case opDeleteText:
+		return p.executeBatchOp(ctx, params, token, p.buildDeleteText)
+	case opCreateImage:
+		return p.executeBatchOp(ctx, params, token, p.buildCreateImage)
+	case opCreateTable:
+		return p.executeBatchOp(ctx, params, token, p.buildCreateTable)
+	case opCreateLine:
+		return p.executeBatchOp(ctx, params, token, p.buildCreateLine)
+	case opReplaceAllText:
+		return p.executeBatchOp(ctx, params, token, p.buildReplaceAllText)
+	case opReplaceAllShapesWithImage:
+		return p.executeBatchOp(ctx, params, token, p.buildReplaceAllShapesWithImage)
+	case opUpdateTextStyle:
+		return p.executeBatchOp(ctx, params, token, p.buildUpdateTextStyle)
+	case opUpdateShapeProperties:
+		return p.executeBatchOp(ctx, params, token, p.buildUpdateShapeProperties)
+	case opUpdatePageProperties:
+		return p.executeBatchOp(ctx, params, token, p.buildUpdatePageProperties)
+	case opUpdateParagraphStyle:
+		return p.executeBatchOp(ctx, params, token, p.buildUpdateParagraphStyle)
+	case opCreateParagraphBullets:
+		return p.executeBatchOp(ctx, params, token, p.buildCreateParagraphBullets)
+	case opUpdatePageElementTransform:
+		return p.executeBatchOp(ctx, params, token, p.buildUpdatePageElementTransform)
+	case opUpdatePageElementsZOrder:
+		return p.executeBatchOp(ctx, params, token, p.buildUpdatePageElementsZOrder)
+	case opGroupObjects:
+		return p.executeBatchOp(ctx, params, token, p.buildGroupObjects)
+	case opUngroupObjects:
+		return p.executeBatchOp(ctx, params, token, p.buildUngroupObjects)
+	case opUpdateTableCellProperties:
+		return p.executeBatchOp(ctx, params, token, p.buildUpdateTableCellProperties)
+	case opCreateStyledTextBox:
+		return p.executeBatchOp(ctx, params, token, p.buildCreateStyledTextBox)
+	case opCreateBulletList:
+		return p.executeBatchOp(ctx, params, token, p.buildCreateBulletList)
+	case opCreateTitleSlide:
+		return p.executeBatchOp(ctx, params, token, p.buildCreateTitleSlide)
+	default:
+		return nil, fmt.Errorf("unknown operation: %s", operation)
+	}
+}
+
+type batchBuilder func(params map[string]any) (string, []map[string]any, error)
+
+func (p *OverlayProvider) executeBatchOp(ctx context.Context, params map[string]any, token string, builder batchBuilder) (*core.OperationResult, error) {
+	presID, reqs, err := builder(params)
+	if err != nil {
+		return nil, err
+	}
+	return p.batchUpdate(ctx, presID, reqs, token)
+}
+
+func (p *OverlayProvider) createPresentation(ctx context.Context, params map[string]any, token string) (*core.OperationResult, error) {
+	title := strParam(params, paramTitle)
+	if title == "" {
+		return nil, fmt.Errorf("%s is required", paramTitle)
+	}
+	payload, _ := json.Marshal(map[string]string{"title": title})
+	return p.doPost(ctx, slidesAPIBase+"/presentations", payload, token)
+}
+
+func (p *OverlayProvider) buildCreateSlide(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	if presID == "" {
+		return "", nil, fmt.Errorf("%s is required", paramPresentationID)
+	}
+	req := map[string]any{}
+	if v := strParam(params, paramObjectID); v != "" {
+		req["objectId"] = v
+	}
+	if v, ok := intParamOk(params, paramInsertionIndex); ok {
+		req["insertionIndex"] = v
+	}
+	if v := strParam(params, paramLayout); v != "" {
+		req["slideLayoutReference"] = map[string]string{"predefinedLayout": v}
+	}
+	return presID, []map[string]any{{"createSlide": req}}, nil
+}
+
+func (p *OverlayProvider) buildDeleteObject(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	objID := strParam(params, paramObjectID)
+	if presID == "" || objID == "" {
+		return "", nil, fmt.Errorf("%s and %s are required", paramPresentationID, paramObjectID)
+	}
+	return presID, []map[string]any{{"deleteObject": map[string]any{"objectId": objID}}}, nil
+}
+
+func (p *OverlayProvider) buildDuplicateObject(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	objID := strParam(params, paramObjectID)
+	if presID == "" || objID == "" {
+		return "", nil, fmt.Errorf("%s and %s are required", paramPresentationID, paramObjectID)
+	}
+	return presID, []map[string]any{{"duplicateObject": map[string]any{"objectId": objID}}}, nil
+}
+
+func (p *OverlayProvider) buildUpdateSlidesPosition(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	if presID == "" {
+		return "", nil, fmt.Errorf("%s is required", paramPresentationID)
+	}
+	slideIDs := strSliceParam(params, paramSlideObjectIDs)
+	idx, ok := intParamOk(params, paramInsertionIndex)
+	if !ok || len(slideIDs) == 0 {
+		return "", nil, fmt.Errorf("%s and %s are required", paramSlideObjectIDs, paramInsertionIndex)
+	}
+	return presID, []map[string]any{{"updateSlidesPosition": map[string]any{
+		"slideObjectIds": slideIDs,
+		"insertionIndex": idx,
+	}}}, nil
+}
+
+func (p *OverlayProvider) buildCreateShape(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	pageID := strParam(params, paramPageObjectID)
+	shapeType := strParam(params, paramShapeType)
+	if presID == "" || pageID == "" || shapeType == "" {
+		return "", nil, fmt.Errorf("%s, %s, and %s are required", paramPresentationID, paramPageObjectID, paramShapeType)
+	}
+	req := map[string]any{
+		"shapeType":         shapeType,
+		"elementProperties": elementProperties(pageID, params, 100, 100, 300, 100),
+	}
+	if v := strParam(params, paramObjectID); v != "" {
+		req["objectId"] = v
+	}
+	return presID, []map[string]any{{"createShape": req}}, nil
+}
+
+func (p *OverlayProvider) buildInsertText(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	objID := strParam(params, paramObjectID)
+	text := strParam(params, paramText)
+	if presID == "" || objID == "" || text == "" {
+		return "", nil, fmt.Errorf("%s, %s, and %s are required", paramPresentationID, paramObjectID, paramText)
+	}
+	idx, _ := intParamOk(params, paramInsertionIndex)
+	return presID, []map[string]any{{"insertText": map[string]any{
+		"objectId":       objID,
+		"text":           text,
+		"insertionIndex": idx,
+	}}}, nil
+}
+
+func (p *OverlayProvider) buildDeleteText(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	objID := strParam(params, paramObjectID)
+	if presID == "" || objID == "" {
+		return "", nil, fmt.Errorf("%s and %s are required", paramPresentationID, paramObjectID)
+	}
+	tr := map[string]any{"type": strParamDefault(params, paramRangeType, "ALL")}
+	if v, ok := intParamOk(params, paramStartIndex); ok {
+		tr["startIndex"] = v
+	}
+	if v, ok := intParamOk(params, paramEndIndex); ok {
+		tr["endIndex"] = v
+	}
+	return presID, []map[string]any{{"deleteText": map[string]any{
+		"objectId":  objID,
+		"textRange": tr,
+	}}}, nil
+}
+
+func (p *OverlayProvider) buildCreateImage(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	pageID := strParam(params, paramPageObjectID)
+	url := strParam(params, paramURL)
+	if presID == "" || pageID == "" || url == "" {
+		return "", nil, fmt.Errorf("%s, %s, and %s are required", paramPresentationID, paramPageObjectID, paramURL)
+	}
+	req := map[string]any{
+		"url":               url,
+		"elementProperties": elementProperties(pageID, params, 50, 50, 400, 300),
+	}
+	if v := strParam(params, paramObjectID); v != "" {
+		req["objectId"] = v
+	}
+	return presID, []map[string]any{{"createImage": req}}, nil
+}
+
+func (p *OverlayProvider) buildCreateTable(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	pageID := strParam(params, paramPageObjectID)
+	if presID == "" || pageID == "" {
+		return "", nil, fmt.Errorf("%s and %s are required", paramPresentationID, paramPageObjectID)
+	}
+	rows, rowsOK := intParamOk(params, paramRows)
+	cols, colsOK := intParamOk(params, paramColumns)
+	if !rowsOK || !colsOK {
+		return "", nil, fmt.Errorf("%s and %s are required", paramRows, paramColumns)
+	}
+	req := map[string]any{
+		"rows":    rows,
+		"columns": cols,
+		"elementProperties": map[string]any{
+			"pageObjectId": pageID,
+		},
+	}
+	if v := strParam(params, paramObjectID); v != "" {
+		req["objectId"] = v
+	}
+	return presID, []map[string]any{{"createTable": req}}, nil
+}
+
+func (p *OverlayProvider) buildCreateLine(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	pageID := strParam(params, paramPageObjectID)
+	if presID == "" || pageID == "" {
+		return "", nil, fmt.Errorf("%s and %s are required", paramPresentationID, paramPageObjectID)
+	}
+	startX := floatParamDefault(params, paramStartX, 100)
+	startY := floatParamDefault(params, paramStartY, 100)
+	endX := floatParamDefault(params, paramEndX, 400)
+	endY := floatParamDefault(params, paramEndY, 100)
+
+	w := math.Abs(endX - startX)
+	if w == 0 {
+		w = 1
+	}
+	h := math.Abs(endY - startY)
+	if h == 0 {
+		h = 1
+	}
+
+	req := map[string]any{
+		"lineCategory": strParamDefault(params, paramLineCategory, "STRAIGHT"),
+		"elementProperties": map[string]any{
+			"pageObjectId": pageID,
+			"size": map[string]any{
+				"width":  dim(w),
+				"height": dim(h),
+			},
+			"transform": map[string]any{
+				"scaleX":     1,
+				"scaleY":     1,
+				"translateX": min(startX, endX),
+				"translateY": min(startY, endY),
+				"unit":       "PT",
+			},
+		},
+	}
+	if v := strParam(params, paramObjectID); v != "" {
+		req["objectId"] = v
+	}
+	return presID, []map[string]any{{"createLine": req}}, nil
+}
+
+func (p *OverlayProvider) buildReplaceAllText(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	find := strParam(params, paramFind)
+	replacement := strParam(params, paramReplacement)
+	if presID == "" || find == "" {
+		return "", nil, fmt.Errorf("%s and %s are required", paramPresentationID, paramFind)
+	}
+	matchCase := boolParamDefault(params, paramMatchCase, true)
+	return presID, []map[string]any{{"replaceAllText": map[string]any{
+		"containsText": map[string]any{"text": find, "matchCase": matchCase},
+		"replaceText":  replacement,
+	}}}, nil
+}
+
+func (p *OverlayProvider) buildReplaceAllShapesWithImage(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	find := strParam(params, paramFind)
+	imageURL := strParam(params, paramImageURL)
+	if presID == "" || find == "" || imageURL == "" {
+		return "", nil, fmt.Errorf("%s, %s, and %s are required", paramPresentationID, paramFind, paramImageURL)
+	}
+	return presID, []map[string]any{{"replaceAllShapesWithImage": map[string]any{
+		"containsText":       map[string]any{"text": find, "matchCase": true},
+		"imageUrl":           imageURL,
+		"imageReplaceMethod": strParamDefault(params, paramReplaceMethod, "CENTER_INSIDE"),
+	}}}, nil
+}
+
+func (p *OverlayProvider) buildUpdateTextStyle(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	objID := strParam(params, paramObjectID)
+	if presID == "" || objID == "" {
+		return "", nil, fmt.Errorf("%s and %s are required", paramPresentationID, paramObjectID)
+	}
+
+	tr := map[string]any{"type": "ALL"}
+	if _, hasStart := intParamOk(params, paramStartIndex); hasStart {
+		tr = map[string]any{"type": "FIXED_RANGE", "startIndex": mustInt(params, paramStartIndex)}
+		if v, ok := intParamOk(params, paramEndIndex); ok {
+			tr["endIndex"] = v
+		}
+	}
+
+	style := map[string]any{}
+	fields := []string{}
+	addBoolField(params, paramBold, "bold", style, &fields)
+	addBoolField(params, paramItalic, "italic", style, &fields)
+	addBoolField(params, paramUnderline, "underline", style, &fields)
+	if v := strParam(params, paramFontFamily); v != "" {
+		style["fontFamily"] = v
+		fields = append(fields, "fontFamily")
+	}
+	if v := floatParamOpt(params, paramFontSize); v > 0 {
+		style["fontSize"] = dim(v)
+		fields = append(fields, "fontSize")
+	}
+	if v := strParam(params, paramForegroundColor); v != "" {
+		style["foregroundColor"] = hexToRGBA(v)
+		fields = append(fields, "foregroundColor")
+	}
+	if v := strParam(params, paramBackgroundColor); v != "" {
+		style["backgroundColor"] = hexToRGBA(v)
+		fields = append(fields, "backgroundColor")
+	}
+	if v := strParam(params, paramLinkURL); v != "" {
+		style["link"] = map[string]string{"url": v}
+		fields = append(fields, "link")
+	}
+	if len(fields) == 0 {
+		return "", nil, fmt.Errorf("at least one style property must be specified")
+	}
+	return presID, []map[string]any{{"updateTextStyle": map[string]any{
+		"objectId":  objID,
+		"textRange": tr,
+		"style":     style,
+		"fields":    strings.Join(fields, ","),
+	}}}, nil
+}
+
+func (p *OverlayProvider) buildUpdateShapeProperties(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	objID := strParam(params, paramObjectID)
+	if presID == "" || objID == "" {
+		return "", nil, fmt.Errorf("%s and %s are required", paramPresentationID, paramObjectID)
+	}
+	props := map[string]any{}
+	fields := []string{}
+	if v := strParam(params, paramFillColor); v != "" {
+		props["shapeBackgroundFill"] = map[string]any{"solidFill": map[string]any{"color": hexToRGB(v)}}
+		fields = append(fields, "shapeBackgroundFill.solidFill.color")
+	}
+	if v := strParam(params, paramOutlineColor); v != "" {
+		outline := ensureMap(props, "outline")
+		outline["outlineFill"] = map[string]any{"solidFill": map[string]any{"color": hexToRGB(v)}}
+		fields = append(fields, "outline.outlineFill.solidFill.color")
+	}
+	if v := floatParamOpt(params, paramOutlineWeight); v > 0 {
+		outline := ensureMap(props, "outline")
+		outline["weight"] = dim(v)
+		fields = append(fields, "outline.weight")
+	}
+	if len(fields) == 0 {
+		return "", nil, fmt.Errorf("at least one property must be specified")
+	}
+	return presID, []map[string]any{{"updateShapeProperties": map[string]any{
+		"objectId":        objID,
+		"shapeProperties": props,
+		"fields":          strings.Join(fields, ","),
+	}}}, nil
+}
+
+func (p *OverlayProvider) buildUpdatePageProperties(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	objID := strParam(params, paramObjectID)
+	if presID == "" || objID == "" {
+		return "", nil, fmt.Errorf("%s and %s are required", paramPresentationID, paramObjectID)
+	}
+	props := map[string]any{}
+	fields := []string{}
+	if v := strParam(params, paramBackgroundColor); v != "" {
+		props["pageBackgroundFill"] = map[string]any{"solidFill": map[string]any{"color": hexToRGB(v)}}
+		fields = append(fields, "pageBackgroundFill.solidFill.color")
+	}
+	if len(fields) == 0 {
+		return "", nil, fmt.Errorf("at least one property must be specified")
+	}
+	return presID, []map[string]any{{"updatePageProperties": map[string]any{
+		"objectId":       objID,
+		"pageProperties": props,
+		"fields":         strings.Join(fields, ","),
+	}}}, nil
+}
+
+func (p *OverlayProvider) buildUpdateParagraphStyle(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	objID := strParam(params, paramObjectID)
+	if presID == "" || objID == "" {
+		return "", nil, fmt.Errorf("%s and %s are required", paramPresentationID, paramObjectID)
+	}
+	style := map[string]any{}
+	fields := []string{}
+	if v := strParam(params, paramAlignment); v != "" {
+		style["alignment"] = v
+		fields = append(fields, "alignment")
+	}
+	if v := floatParamOpt(params, paramLineSpacing); v > 0 {
+		style["lineSpacing"] = v
+		fields = append(fields, "lineSpacing")
+	}
+	if v := floatParamOpt(params, paramSpaceAbove); v > 0 {
+		style["spaceAbove"] = dim(v)
+		fields = append(fields, "spaceAbove")
+	}
+	if v := floatParamOpt(params, paramSpaceBelow); v > 0 {
+		style["spaceBelow"] = dim(v)
+		fields = append(fields, "spaceBelow")
+	}
+	if len(fields) == 0 {
+		return "", nil, fmt.Errorf("at least one style property must be specified")
+	}
+	return presID, []map[string]any{{"updateParagraphStyle": map[string]any{
+		"objectId":  objID,
+		"textRange": map[string]string{"type": "ALL"},
+		"style":     style,
+		"fields":    strings.Join(fields, ","),
+	}}}, nil
+}
+
+func (p *OverlayProvider) buildCreateParagraphBullets(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	objID := strParam(params, paramObjectID)
+	if presID == "" || objID == "" {
+		return "", nil, fmt.Errorf("%s and %s are required", paramPresentationID, paramObjectID)
+	}
+	tr := map[string]any{"type": "ALL"}
+	if _, hasStart := intParamOk(params, paramStartIndex); hasStart {
+		tr = map[string]any{"type": "FIXED_RANGE", "startIndex": mustInt(params, paramStartIndex)}
+		if v, ok := intParamOk(params, paramEndIndex); ok {
+			tr["endIndex"] = v
+		}
+	}
+	return presID, []map[string]any{{"createParagraphBullets": map[string]any{
+		"objectId":     objID,
+		"textRange":    tr,
+		"bulletPreset": strParamDefault(params, paramBulletPreset, "BULLET_DISC_CIRCLE_SQUARE"),
+	}}}, nil
+}
+
+func (p *OverlayProvider) buildUpdatePageElementTransform(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	objID := strParam(params, paramObjectID)
+	if presID == "" || objID == "" {
+		return "", nil, fmt.Errorf("%s and %s are required", paramPresentationID, paramObjectID)
+	}
+	transform := map[string]any{
+		"unit":   "PT",
+		"scaleX": floatParamDefault(params, paramScaleX, 1),
+		"scaleY": floatParamDefault(params, paramScaleY, 1),
+	}
+	if _, ok := params[paramTranslateX]; ok {
+		transform["translateX"] = floatParamOpt(params, paramTranslateX)
+	}
+	if _, ok := params[paramTranslateY]; ok {
+		transform["translateY"] = floatParamOpt(params, paramTranslateY)
+	}
+	return presID, []map[string]any{{"updatePageElementTransform": map[string]any{
+		"objectId":  objID,
+		"transform": transform,
+		"applyMode": strParamDefault(params, paramApplyMode, "ABSOLUTE"),
+	}}}, nil
+}
+
+func (p *OverlayProvider) buildUpdatePageElementsZOrder(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	if presID == "" {
+		return "", nil, fmt.Errorf("%s is required", paramPresentationID)
+	}
+	ids := strSliceParam(params, paramPageElementObjectIDs)
+	op := strParam(params, paramOperation)
+	if len(ids) == 0 || op == "" {
+		return "", nil, fmt.Errorf("%s and %s are required", paramPageElementObjectIDs, paramOperation)
+	}
+	return presID, []map[string]any{{"updatePageElementsZOrder": map[string]any{
+		"pageElementObjectIds": ids,
+		"operation":            op,
+	}}}, nil
+}
+
+func (p *OverlayProvider) buildGroupObjects(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	if presID == "" {
+		return "", nil, fmt.Errorf("%s is required", paramPresentationID)
+	}
+	ids := strSliceParam(params, paramChildrenObjectIDs)
+	if len(ids) < 2 {
+		return "", nil, fmt.Errorf("%s requires at least 2 element IDs", paramChildrenObjectIDs)
+	}
+	req := map[string]any{"childrenObjectIds": ids}
+	if v := strParam(params, paramGroupObjectID); v != "" {
+		req["groupObjectId"] = v
+	}
+	return presID, []map[string]any{{"groupObjects": req}}, nil
+}
+
+func (p *OverlayProvider) buildUngroupObjects(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	if presID == "" {
+		return "", nil, fmt.Errorf("%s is required", paramPresentationID)
+	}
+	ids := strSliceParam(params, paramObjectIDs)
+	if len(ids) == 0 {
+		return "", nil, fmt.Errorf("%s is required", paramObjectIDs)
+	}
+	return presID, []map[string]any{{"ungroupObjects": map[string]any{"objectIds": ids}}}, nil
+}
+
+func (p *OverlayProvider) buildUpdateTableCellProperties(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	objID := strParam(params, paramObjectID)
+	if presID == "" || objID == "" {
+		return "", nil, fmt.Errorf("%s and %s are required", paramPresentationID, paramObjectID)
+	}
+	rowIdx, rowOK := intParamOk(params, paramRowIndex)
+	colIdx, colOK := intParamOk(params, paramColumnIndex)
+	if !rowOK || !colOK {
+		return "", nil, fmt.Errorf("%s and %s are required", paramRowIndex, paramColumnIndex)
+	}
+	props := map[string]any{}
+	fields := []string{}
+	if v := strParam(params, paramBackgroundColor); v != "" {
+		props["tableCellBackgroundFill"] = map[string]any{"solidFill": map[string]any{"color": hexToRGB(v)}}
+		fields = append(fields, "tableCellBackgroundFill.solidFill.color")
+	}
+	for _, pair := range []struct{ param, api string }{
+		{paramPaddingTop, "paddingTop"},
+		{paramPaddingBottom, "paddingBottom"},
+		{paramPaddingLeft, "paddingLeft"},
+		{paramPaddingRight, "paddingRight"},
+	} {
+		if v := floatParamOpt(params, pair.param); v > 0 {
+			props[pair.api] = dim(v)
+			fields = append(fields, pair.api)
+		}
+	}
+	if len(fields) == 0 {
+		return "", nil, fmt.Errorf("at least one property must be specified")
+	}
+	return presID, []map[string]any{{"updateTableCellProperties": map[string]any{
+		"objectId": objID,
+		"tableRange": map[string]any{
+			"location":   map[string]any{"rowIndex": rowIdx, "columnIndex": colIdx},
+			"rowSpan":    1,
+			"columnSpan": 1,
+		},
+		"tableCellProperties": props,
+		"fields":              strings.Join(fields, ","),
+	}}}, nil
+}
+
+func (p *OverlayProvider) buildCreateStyledTextBox(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	pageID := strParam(params, paramPageObjectID)
+	text := strParam(params, paramText)
+	if presID == "" || pageID == "" || text == "" {
+		return "", nil, fmt.Errorf("%s, %s, and %s are required", paramPresentationID, paramPageObjectID, paramText)
+	}
+	objID := strParam(params, paramObjectID)
+	if objID == "" {
+		objID = uniqueID("styledtextbox_")
+	}
+
+	reqs := []map[string]any{
+		{"createShape": map[string]any{
+			"objectId":          objID,
+			"shapeType":         "TEXT_BOX",
+			"elementProperties": elementProperties(pageID, params, 100, 100, 300, 100),
+		}},
+		{"insertText": map[string]any{"objectId": objID, "text": text, "insertionIndex": 0}},
+	}
+
+	style := map[string]any{}
+	fields := []string{}
+	if v := strParam(params, paramFontFamily); v != "" {
+		style["fontFamily"] = v
+		fields = append(fields, "fontFamily")
+	}
+	if v := floatParamOpt(params, paramFontSize); v > 0 {
+		style["fontSize"] = dim(v)
+		fields = append(fields, "fontSize")
+	}
+	addBoolField(params, paramBold, "bold", style, &fields)
+	addBoolField(params, paramItalic, "italic", style, &fields)
+	if v := strParam(params, paramForegroundColor); v != "" {
+		style["foregroundColor"] = hexToRGBA(v)
+		fields = append(fields, "foregroundColor")
+	}
+	if len(fields) > 0 {
+		reqs = append(reqs, map[string]any{"updateTextStyle": map[string]any{
+			"objectId":  objID,
+			"textRange": map[string]string{"type": "ALL"},
+			"style":     style,
+			"fields":    strings.Join(fields, ","),
+		}})
+	}
+
+	if v := strParam(params, paramFillColor); v != "" {
+		reqs = append(reqs, map[string]any{"updateShapeProperties": map[string]any{
+			"objectId": objID,
+			"shapeProperties": map[string]any{
+				"shapeBackgroundFill": map[string]any{"solidFill": map[string]any{"color": hexToRGB(v)}},
+			},
+			"fields": "shapeBackgroundFill.solidFill.color",
+		}})
+	}
+
+	if v := strParam(params, paramAlignment); v != "" {
+		reqs = append(reqs, map[string]any{"updateParagraphStyle": map[string]any{
+			"objectId":  objID,
+			"textRange": map[string]string{"type": "ALL"},
+			"style":     map[string]string{"alignment": v},
+			"fields":    "alignment",
+		}})
+	}
+
+	return presID, reqs, nil
+}
+
+func (p *OverlayProvider) buildCreateBulletList(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	pageID := strParam(params, paramPageObjectID)
+	if presID == "" || pageID == "" {
+		return "", nil, fmt.Errorf("%s and %s are required", paramPresentationID, paramPageObjectID)
+	}
+	items := strSliceParam(params, paramItems)
+	if len(items) == 0 {
+		return "", nil, fmt.Errorf("%s is required and must be a list", paramItems)
+	}
+	objID := strParam(params, paramObjectID)
+	if objID == "" {
+		objID = uniqueID("bulletlist_")
+	}
+	text := strings.Join(items, "\n")
+
+	reqs := []map[string]any{
+		{"createShape": map[string]any{
+			"objectId":          objID,
+			"shapeType":         "TEXT_BOX",
+			"elementProperties": elementProperties(pageID, params, 50, 100, 400, 250),
+		}},
+		{"insertText": map[string]any{"objectId": objID, "text": text, "insertionIndex": 0}},
+		{"createParagraphBullets": map[string]any{
+			"objectId":     objID,
+			"textRange":    map[string]string{"type": "ALL"},
+			"bulletPreset": strParamDefault(params, paramBulletPreset, "BULLET_DISC_CIRCLE_SQUARE"),
+		}},
+	}
+
+	style := map[string]any{}
+	fields := []string{}
+	if v := strParam(params, paramFontFamily); v != "" {
+		style["fontFamily"] = v
+		fields = append(fields, "fontFamily")
+	}
+	if v := floatParamOpt(params, paramFontSize); v > 0 {
+		style["fontSize"] = dim(v)
+		fields = append(fields, "fontSize")
+	}
+	if v := strParam(params, paramForegroundColor); v != "" {
+		style["foregroundColor"] = hexToRGBA(v)
+		fields = append(fields, "foregroundColor")
+	}
+	if len(fields) > 0 {
+		reqs = append(reqs, map[string]any{"updateTextStyle": map[string]any{
+			"objectId":  objID,
+			"textRange": map[string]string{"type": "ALL"},
+			"style":     style,
+			"fields":    strings.Join(fields, ","),
+		}})
+	}
+
+	return presID, reqs, nil
+}
+
+func (p *OverlayProvider) buildCreateTitleSlide(params map[string]any) (string, []map[string]any, error) {
+	presID := strParam(params, paramPresentationID)
+	title := strParam(params, paramTitle)
+	if presID == "" || title == "" {
+		return "", nil, fmt.Errorf("%s and %s are required", paramPresentationID, paramTitle)
+	}
+
+	slideID := uniqueID("titleslide_")
+	titleBoxID := uniqueID("titlebox_")
+	subtitleBoxID := uniqueID("subtitlebox_")
+
+	reqs := []map[string]any{}
+	createSlide := map[string]any{
+		"objectId":             slideID,
+		"slideLayoutReference": map[string]string{"predefinedLayout": "BLANK"},
+	}
+	if v, ok := intParamOk(params, paramInsertionIndex); ok {
+		createSlide["insertionIndex"] = v
+	}
+	reqs = append(reqs, map[string]any{"createSlide": createSlide})
+
+	if v := strParam(params, paramBackgroundColor); v != "" {
+		reqs = append(reqs, map[string]any{"updatePageProperties": map[string]any{
+			"objectId":       slideID,
+			"pageProperties": map[string]any{"pageBackgroundFill": map[string]any{"solidFill": map[string]any{"color": hexToRGB(v)}}},
+			"fields":         "pageBackgroundFill.solidFill.color",
+		}})
+	}
+
+	reqs = append(reqs,
+		map[string]any{"createShape": map[string]any{
+			"objectId":  titleBoxID,
+			"shapeType": "TEXT_BOX",
+			"elementProperties": map[string]any{
+				"pageObjectId": slideID,
+				"size":         map[string]any{"width": dim(620), "height": dim(80)},
+				"transform":    map[string]any{"scaleX": 1, "scaleY": 1, "translateX": 50, "translateY": 120, "unit": "PT"},
+			},
+		}},
+		map[string]any{"insertText": map[string]any{"objectId": titleBoxID, "text": title, "insertionIndex": 0}},
+	)
+
+	titleColor := strParamDefault(params, paramTitleColor, "#000000")
+	reqs = append(reqs,
+		map[string]any{"updateTextStyle": map[string]any{
+			"objectId":  titleBoxID,
+			"textRange": map[string]string{"type": "ALL"},
+			"style": map[string]any{
+				"fontFamily":      strParamDefault(params, paramTitleFont, "Arial"),
+				"fontSize":        dim(floatParamDefault(params, paramTitleSize, 44)),
+				"bold":            true,
+				"foregroundColor": hexToRGBA(titleColor),
+			},
+			"fields": "fontFamily,fontSize,bold,foregroundColor",
+		}},
+		map[string]any{"updateParagraphStyle": map[string]any{
+			"objectId":  titleBoxID,
+			"textRange": map[string]string{"type": "ALL"},
+			"style":     map[string]string{"alignment": "CENTER"},
+			"fields":    "alignment",
+		}},
+	)
+
+	if subtitle := strParam(params, paramSubtitle); subtitle != "" {
+		reqs = append(reqs,
+			map[string]any{"createShape": map[string]any{
+				"objectId":  subtitleBoxID,
+				"shapeType": "TEXT_BOX",
+				"elementProperties": map[string]any{
+					"pageObjectId": slideID,
+					"size":         map[string]any{"width": dim(620), "height": dim(50)},
+					"transform":    map[string]any{"scaleX": 1, "scaleY": 1, "translateX": 50, "translateY": 210, "unit": "PT"},
+				},
+			}},
+			map[string]any{"insertText": map[string]any{"objectId": subtitleBoxID, "text": subtitle, "insertionIndex": 0}},
+		)
+
+		subColor := strParamDefault(params, paramSubtitleColor, titleColor)
+		reqs = append(reqs,
+			map[string]any{"updateTextStyle": map[string]any{
+				"objectId":  subtitleBoxID,
+				"textRange": map[string]string{"type": "ALL"},
+				"style": map[string]any{
+					"fontFamily":      strParamDefault(params, paramSubtitleFont, "Arial"),
+					"fontSize":        dim(floatParamDefault(params, paramSubtitleSize, 24)),
+					"foregroundColor": hexToRGBA(subColor),
+				},
+				"fields": "fontFamily,fontSize,foregroundColor",
+			}},
+			map[string]any{"updateParagraphStyle": map[string]any{
+				"objectId":  subtitleBoxID,
+				"textRange": map[string]string{"type": "ALL"},
+				"style":     map[string]string{"alignment": "CENTER"},
+				"fields":    "alignment",
+			}},
+		)
+	}
+
+	return presID, reqs, nil
+}
+
+func (p *OverlayProvider) batchUpdate(ctx context.Context, presentationID string, requests []map[string]any, token string) (*core.OperationResult, error) {
+	url := fmt.Sprintf("%s/presentations/%s:batchUpdate", slidesAPIBase, presentationID)
+	payload, _ := json.Marshal(map[string]any{"requests": requests})
+	return p.doPost(ctx, url, payload, token)
+}
+
+func (p *OverlayProvider) doPost(ctx context.Context, url string, payload []byte, token string) (*core.OperationResult, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", contentTypeJSON)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return &core.OperationResult{Status: resp.StatusCode, Body: string(data)}, nil
+}
+
+func uniqueID(prefix string) string {
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	return prefix + hex.EncodeToString(b[:])
+}
+
+func hexToRGBA(hex string) map[string]any {
+	return map[string]any{"opaqueColor": map[string]any{"rgbColor": parseRGB(hex)}}
+}
+
+func hexToRGB(hex string) map[string]any {
+	return map[string]any{"rgbColor": parseRGB(hex)}
+}
+
+func parseRGB(hex string) map[string]any {
+	hex = strings.TrimPrefix(hex, "#")
+	if len(hex) < 6 {
+		hex = "000000"
+	}
+	r, _ := strconv.ParseUint(hex[0:2], 16, 8)
+	g, _ := strconv.ParseUint(hex[2:4], 16, 8)
+	b, _ := strconv.ParseUint(hex[4:6], 16, 8)
+	return map[string]any{"red": float64(r) / 255, "green": float64(g) / 255, "blue": float64(b) / 255}
+}
+
+func dim(magnitude float64) map[string]any {
+	return map[string]any{"magnitude": magnitude, "unit": "PT"}
+}
+
+func elementProperties(pageObjectID string, params map[string]any, defX, defY, defW, defH float64) map[string]any {
+	x := floatParamDefault(params, paramX, defX)
+	y := floatParamDefault(params, paramY, defY)
+	w := floatParamDefault(params, paramWidth, defW)
+	h := floatParamDefault(params, paramHeight, defH)
+	return map[string]any{
+		"pageObjectId": pageObjectID,
+		"size": map[string]any{
+			"width":  dim(w),
+			"height": dim(h),
+		},
+		"transform": map[string]any{
+			"scaleX":     1,
+			"scaleY":     1,
+			"translateX": x,
+			"translateY": y,
+			"unit":       "PT",
+		},
+	}
+}
+
+func ensureMap(parent map[string]any, key string) map[string]any {
+	if m, ok := parent[key].(map[string]any); ok {
+		return m
+	}
+	m := map[string]any{}
+	parent[key] = m
+	return m
+}
+
+func addBoolField(params map[string]any, paramName, fieldName string, style map[string]any, fields *[]string) {
+	if v, ok := params[paramName]; ok {
+		if b, ok := v.(bool); ok {
+			style[fieldName] = b
+			*fields = append(*fields, fieldName)
+		}
+	}
+}
+
+func strParam(params map[string]any, key string) string {
+	v, _ := params[key].(string)
+	return v
+}
+
+func strParamDefault(params map[string]any, key, def string) string {
+	if v := strParam(params, key); v != "" {
+		return v
+	}
+	return def
+}
+
+func intParamOk(params map[string]any, key string) (int, bool) {
+	switch v := params[key].(type) {
+	case float64:
+		return int(v), true
+	case int:
+		return v, true
+	case json.Number:
+		i, err := v.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return int(i), true
+	}
+	return 0, false
+}
+
+func mustInt(params map[string]any, key string) int {
+	v, _ := intParamOk(params, key)
+	return v
+}
+
+func floatParamOpt(params map[string]any, key string) float64 {
+	switch v := params[key].(type) {
+	case float64:
+		return v
+	case int:
+		return float64(v)
+	case json.Number:
+		f, _ := v.Float64()
+		return f
+	}
+	return 0
+}
+
+func floatParamDefault(params map[string]any, key string, def float64) float64 {
+	if _, ok := params[key]; ok {
+		return floatParamOpt(params, key)
+	}
+	return def
+}
+
+func boolParamDefault(params map[string]any, key string, def bool) bool {
+	if v, ok := params[key].(bool); ok {
+		return v
+	}
+	return def
+}
+
+func strSliceParam(params map[string]any, key string) []string {
+	switch v := params[key].(type) {
+	case []string:
+		return v
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}

--- a/plugins/providers/google_slides/overlay_test.go
+++ b/plugins/providers/google_slides/overlay_test.go
@@ -1,0 +1,154 @@
+package google_slides
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+	"github.com/valon-technologies/gestalt/internal/composite"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
+	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
+)
+
+var slidesOverlayOpIDs = []string{
+	opCreatePresentation,
+	opCreateSlide,
+	opDeleteObject,
+	opDuplicateObject,
+	opUpdateSlidesPosition,
+	opCreateShape,
+	opInsertText,
+	opDeleteText,
+	opCreateImage,
+	opCreateTable,
+	opCreateLine,
+	opReplaceAllText,
+	opReplaceAllShapesWithImage,
+	opUpdateTextStyle,
+	opUpdateShapeProperties,
+	opUpdatePageProperties,
+	opUpdateParagraphStyle,
+	opCreateParagraphBullets,
+	opUpdatePageElementTransform,
+	opUpdatePageElementsZOrder,
+	opGroupObjects,
+	opUngroupObjects,
+	opUpdateTableCellProperties,
+	opCreateStyledTextBox,
+	opCreateBulletList,
+	opCreateTitleSlide,
+}
+
+func TestOverlayCatalog(t *testing.T) {
+	t.Parallel()
+
+	var prov core.Provider = NewOverlayProvider()
+
+	cp, ok := prov.(core.CatalogProvider)
+	if !ok {
+		t.Fatal("overlay does not implement CatalogProvider")
+	}
+
+	cat := cp.Catalog()
+	if cat == nil {
+		t.Fatal("Catalog() returned nil")
+	}
+
+	gotIDs := make([]string, len(cat.Operations))
+	for i, op := range cat.Operations {
+		gotIDs[i] = op.ID
+	}
+	sort.Strings(gotIDs)
+
+	wantIDs := make([]string, len(slidesOverlayOpIDs))
+	copy(wantIDs, slidesOverlayOpIDs)
+	sort.Strings(wantIDs)
+
+	if len(gotIDs) != len(wantIDs) {
+		t.Fatalf("overlay catalog ops = %d, want %d\ngot:  %v\nwant: %v", len(gotIDs), len(wantIDs), gotIDs, wantIDs)
+	}
+	for i := range gotIDs {
+		if gotIDs[i] != wantIDs[i] {
+			t.Errorf("overlay catalog op[%d] = %q, want %q", i, gotIDs[i], wantIDs[i])
+		}
+	}
+}
+
+func TestOverlayComposite(t *testing.T) {
+	t.Parallel()
+
+	inv, err := inventory.Load()
+	if err != nil {
+		t.Fatalf("inventory.Load: %v", err)
+	}
+	spec := inv.Providers["google_slides"]
+
+	def := providertest.ParseDefinition(t, definitionYAML)
+	base := providertest.BuildProvider(t, def, config.IntegrationDef{
+		ClientID: dummyClientID, ClientSecret: dummyClientSecret,
+	})
+
+	overlay := NewOverlayProvider()
+	comp := composite.NewOverlay("google_slides", base, overlay)
+
+	ops := comp.ListOperations()
+	if len(ops) != len(spec.Operations) {
+		t.Fatalf("composite ListOperations() = %d, want %d", len(ops), len(spec.Operations))
+	}
+
+	gotNames := make([]string, len(ops))
+	for i, op := range ops {
+		gotNames[i] = op.Name
+	}
+	sort.Strings(gotNames)
+
+	wantNames := make([]string, len(spec.Operations))
+	copy(wantNames, spec.Operations)
+	sort.Strings(wantNames)
+
+	for i := range gotNames {
+		if gotNames[i] != wantNames[i] {
+			t.Errorf("composite op[%d] = %q, want %q", i, gotNames[i], wantNames[i])
+		}
+	}
+
+	cp, ok := comp.(core.CatalogProvider)
+	if !ok {
+		t.Fatal("composite does not implement CatalogProvider")
+	}
+
+	cat := cp.Catalog()
+	if cat == nil {
+		t.Fatal("composite Catalog() returned nil")
+	}
+
+	catIDs := make([]string, len(cat.Operations))
+	for i, op := range cat.Operations {
+		catIDs[i] = op.ID
+	}
+	sort.Strings(catIDs)
+
+	if len(catIDs) != len(wantNames) {
+		t.Fatalf("composite catalog ops = %d, want %d", len(catIDs), len(wantNames))
+	}
+	for i := range catIDs {
+		if catIDs[i] != wantNames[i] {
+			t.Errorf("composite catalog op[%d] = %q, want %q", i, catIDs[i], wantNames[i])
+		}
+	}
+
+	overlaySet := map[string]struct{}{}
+	for _, id := range slidesOverlayOpIDs {
+		overlaySet[id] = struct{}{}
+	}
+
+	for _, op := range cat.Operations {
+		if _, isOverlay := overlaySet[op.ID]; isOverlay {
+			if op.Transport != catalog.TransportPlugin {
+				t.Errorf("overlay op %q transport = %q, want %q", op.ID, op.Transport, catalog.TransportPlugin)
+			}
+		}
+	}
+}

--- a/plugins/providers/google_slides/provider.yaml
+++ b/plugins/providers/google_slides/provider.yaml
@@ -1,0 +1,40 @@
+provider: google_slides
+display_name: Google Slides
+description: Google Slides presentation service
+connection_mode: user
+base_url: "https://slides.googleapis.com"
+
+auth:
+  type: oauth2
+  authorization_url: https://accounts.google.com/o/oauth2/v2/auth
+  token_url: https://oauth2.googleapis.com/token
+  scopes:
+    - https://www.googleapis.com/auth/presentations
+  authorization_params:
+    access_type: offline
+    prompt: consent
+
+operations:
+  get_presentation:
+    description: Get presentation metadata and content
+    method: GET
+    path: "/v1/presentations/{presentation_id}"
+    parameters:
+      - {name: presentation_id, type: string, required: true, description: "Presentation ID"}
+
+  get_page:
+    description: Get a specific page (slide) from a presentation
+    method: GET
+    path: "/v1/presentations/{presentation_id}/pages/{page_object_id}"
+    parameters:
+      - {name: presentation_id, type: string, required: true, description: "Presentation ID"}
+      - {name: page_object_id, type: string, required: true, description: "Page/slide object ID"}
+
+  get_thumbnail:
+    description: Get a thumbnail image of a page
+    method: GET
+    path: "/v1/presentations/{presentation_id}/pages/{page_object_id}/thumbnail"
+    parameters:
+      - {name: presentation_id, type: string, required: true, description: "Presentation ID"}
+      - {name: page_object_id, type: string, required: true, description: "Page/slide object ID"}
+      - {name: thumbnail_size, type: string, description: "Thumbnail size: SMALL (200px), MEDIUM (800px), or LARGE (1600px)"}


### PR DESCRIPTION
These are the first two first-party Google composite providers. Gmail exposes 15 operations covering message sending, drafting, replying, forwarding, and label management, with an RFC 2822 MIME overlay that builds proper multipart messages for the Gmail API. Google Slides exposes 29 operations covering presentation creation and a full set of slide manipulation actions, with a `batchUpdate` overlay that translates individual operations into the Slides API batch request format.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>