### PR TITLE
feat: agent auth substrate

### DIFF
--- a/core/binding.go
+++ b/core/binding.go
@@ -21,8 +21,10 @@ type Binding interface {
 }
 
 type Route struct {
-	Method  string
-	Pattern string
-	Handler http.Handler
-	Public  bool
+	Method    string
+	Pattern   string
+	Handler   http.Handler
+	Public    bool
+	ProxyAuth bool // use proxy auth semantics (Proxy-Authorization, 407 responses)
+	Connect   bool // handle CONNECT method (dispatched outside path-based routing)
 }

--- a/core/datastore.go
+++ b/core/datastore.go
@@ -29,10 +29,14 @@ type StagedConnectionStore interface {
 	DeleteStagedConnection(ctx context.Context, id string) error
 }
 
+type EgressClientFilter struct {
+	CreatedByID string // if non-empty, filter by creator
+}
+
 type EgressClientStore interface {
 	CreateEgressClient(ctx context.Context, client *EgressClient) error
 	GetEgressClient(ctx context.Context, id string) (*EgressClient, error)
-	ListEgressClients(ctx context.Context, userID string) ([]*EgressClient, error)
+	ListEgressClients(ctx context.Context, filter EgressClientFilter) ([]*EgressClient, error)
 	DeleteEgressClient(ctx context.Context, id string) error
 
 	CreateEgressClientToken(ctx context.Context, token *EgressClientToken) error

--- a/core/integration/base_test.go
+++ b/core/integration/base_test.go
@@ -146,8 +146,8 @@ func TestBaseExecuteRESTRunsEgressResolutionOnFinalRequest(t *testing.T) {
 	if gotPolicy.Target.Provider != "test-provider" || gotPolicy.Target.Operation != "op" {
 		t.Fatalf("target = %+v, want test-provider/op", gotPolicy.Target)
 	}
-	if gotPolicy.Headers["Authorization"] != "Bearer test-token" {
-		t.Fatalf("authorization = %q, want Bearer test-token", gotPolicy.Headers["Authorization"])
+	if gotPolicy.Headers["Authorization"] != "" {
+		t.Fatalf("policy should not see credential Authorization (policy runs before credentials), got %q", gotPolicy.Headers["Authorization"])
 	}
 }
 
@@ -315,11 +315,11 @@ func TestBaseExecuteGraphQLRunsEgressResolutionOnFinalRequest(t *testing.T) {
 	if gotPolicy.Target.Method != http.MethodPost || gotPolicy.Target.Path != "/graphql" {
 		t.Fatalf("target = %+v, want POST /graphql", gotPolicy.Target)
 	}
-	if gotPolicy.Headers["Authorization"] != "Token gql-token" {
-		t.Fatalf("authorization = %q, want Token gql-token", gotPolicy.Headers["Authorization"])
+	if gotPolicy.Headers["Authorization"] != "" {
+		t.Fatalf("policy should not see credential Authorization (policy runs before credentials), got %q", gotPolicy.Headers["Authorization"])
 	}
 	if gotPolicy.Headers["X-Org"] != "acme" {
-		t.Fatalf("org = %q, want acme", gotPolicy.Headers["X-Org"])
+		t.Fatalf("X-Org should be visible to policy (it's an input header, not a credential header), got %q", gotPolicy.Headers["X-Org"])
 	}
 
 	var data map[string]any

--- a/core/testing/datastore_suite.go
+++ b/core/testing/datastore_suite.go
@@ -532,7 +532,7 @@ func testDatastoreEgressClients(t *testing.T, newStore func(t *testing.T) core.D
 			t.Errorf("CreatedByID: got %q, want %q", got.CreatedByID, user.ID)
 		}
 
-		clients, err := ecs.ListEgressClients(ctx, user.ID)
+		clients, err := ecs.ListEgressClients(ctx, core.EgressClientFilter{CreatedByID: user.ID})
 		if err != nil {
 			t.Fatalf("ListEgressClients: %v", err)
 		}
@@ -643,7 +643,7 @@ func testDatastoreEgressClients(t *testing.T, newStore func(t *testing.T) core.D
 			t.Fatalf("CreateEgressClient userB: %v", err)
 		}
 
-		clientsA, err := ecs.ListEgressClients(ctx, userA.ID)
+		clientsA, err := ecs.ListEgressClients(ctx, core.EgressClientFilter{CreatedByID: userA.ID})
 		if err != nil {
 			t.Fatalf("ListEgressClients userA: %v", err)
 		}
@@ -651,12 +651,20 @@ func testDatastoreEgressClients(t *testing.T, newStore func(t *testing.T) core.D
 			t.Fatalf("ListEgressClients userA: got %+v, want only ec-a", clientsA)
 		}
 
-		clientsB, err := ecs.ListEgressClients(ctx, userB.ID)
+		clientsB, err := ecs.ListEgressClients(ctx, core.EgressClientFilter{CreatedByID: userB.ID})
 		if err != nil {
 			t.Fatalf("ListEgressClients userB: %v", err)
 		}
 		if len(clientsB) != 1 || clientsB[0].ID != "ec-b" {
 			t.Fatalf("ListEgressClients userB: got %+v, want only ec-b", clientsB)
+		}
+
+		all, err := ecs.ListEgressClients(ctx, core.EgressClientFilter{})
+		if err != nil {
+			t.Fatalf("ListEgressClients unfiltered: %v", err)
+		}
+		if len(all) != 2 {
+			t.Fatalf("ListEgressClients unfiltered: got %d, want 2", len(all))
 		}
 	})
 }

--- a/core/testing/stubs.go
+++ b/core/testing/stubs.go
@@ -38,7 +38,7 @@ type StubDatastore struct {
 	DeleteStagedConnectionFn    func(context.Context, string) error
 	CreateEgressClientFn        func(context.Context, *core.EgressClient) error
 	GetEgressClientFn           func(context.Context, string) (*core.EgressClient, error)
-	ListEgressClientsFn         func(context.Context, string) ([]*core.EgressClient, error)
+	ListEgressClientsFn         func(context.Context, core.EgressClientFilter) ([]*core.EgressClient, error)
 	DeleteEgressClientFn        func(context.Context, string) error
 	CreateEgressClientTokenFn   func(context.Context, *core.EgressClientToken) error
 	ValidateEgressClientTokenFn func(context.Context, string) (*core.EgressClientToken, error)
@@ -155,9 +155,9 @@ func (s *StubDatastore) GetEgressClient(ctx context.Context, id string) (*core.E
 	}
 	return nil, core.ErrNotFound
 }
-func (s *StubDatastore) ListEgressClients(ctx context.Context, userID string) ([]*core.EgressClient, error) {
+func (s *StubDatastore) ListEgressClients(ctx context.Context, filter core.EgressClientFilter) ([]*core.EgressClient, error) {
 	if s.ListEgressClientsFn != nil {
-		return s.ListEgressClientsFn(ctx, userID)
+		return s.ListEgressClientsFn(ctx, filter)
 	}
 	return nil, nil
 }

--- a/docs/pages/tasks/_meta.ts
+++ b/docs/pages/tasks/_meta.ts
@@ -2,8 +2,6 @@ export default {
   "run-locally": "Run Locally",
   "add-an-integration": "Add an Integration",
   "add-a-first-party-provider": "Add a First-Party Provider",
-  "configure-jira": "Configure Jira",
-  "configure-bigquery": "Configure BigQuery",
   "install-a-plugin": "Install a Plugin",
   "use-with-mcp": "Use with MCP",
 };

--- a/internal/egress/resolution.go
+++ b/internal/egress/resolution.go
@@ -33,6 +33,17 @@ func (r Resolver) Resolve(ctx context.Context, input ResolutionInput) (Resolutio
 		return Resolution{}, err
 	}
 
+	// Policy evaluation runs before credential resolution so that denied
+	// requests never trigger secret fetches or decryption.
+	policy := PolicyInput{
+		Subject: subject,
+		Target:  input.Target,
+		Headers: CopyHeaders(input.Headers),
+	}
+	if err := EvaluatePolicy(ctx, r.Policy, policy); err != nil {
+		return Resolution{}, err
+	}
+
 	credential := input.Credential
 	if r.Credentials != nil && credential.Authorization == "" && len(credential.Headers) == 0 {
 		resolved, err := r.Credentials.ResolveCredential(ctx, subject, input.Target)
@@ -46,23 +57,6 @@ func (r Resolver) Resolve(ctx context.Context, input ResolutionInput) (Resolutio
 
 	if credential.Authorization != "" {
 		delete(headers, "Authorization")
-	}
-
-	policyHeaders := CopyHeaders(headers)
-	if credential.Authorization != "" {
-		if policyHeaders == nil {
-			policyHeaders = map[string]string{}
-		}
-		policyHeaders["Authorization"] = credential.Authorization
-	}
-
-	policy := PolicyInput{
-		Subject: subject,
-		Target:  input.Target,
-		Headers: policyHeaders,
-	}
-	if err := EvaluatePolicy(ctx, r.Policy, policy); err != nil {
-		return Resolution{}, err
 	}
 
 	return Resolution{

--- a/internal/egress/subject_principal.go
+++ b/internal/egress/subject_principal.go
@@ -11,6 +11,9 @@ func SubjectForPrincipal(p *principal.Principal) (Subject, bool) {
 	if p == nil {
 		return Subject{}, false
 	}
+	if p.EgressClientID != "" {
+		return Subject{Kind: SubjectAgent, ID: p.EgressClientID}, true
+	}
 	if p.UserID != "" && p.UserID != principal.IdentityPrincipal {
 		return Subject{Kind: SubjectUser, ID: p.UserID}, true
 	}
@@ -38,6 +41,11 @@ func PrincipalForSubject(s Subject) (*principal.Principal, bool) {
 			return nil, false
 		}
 		return &principal.Principal{Identity: &core.UserIdentity{Email: s.ID}}, true
+	case SubjectAgent:
+		if s.ID == "" {
+			return nil, false
+		}
+		return &principal.Principal{EgressClientID: s.ID}, true
 	default:
 		return nil, false
 	}

--- a/internal/principal/principal.go
+++ b/internal/principal/principal.go
@@ -12,14 +12,16 @@ const (
 	SourceSession Source = iota
 	SourceAPIToken
 	SourceEnv
+	SourceEgressClient
 )
 
 const IdentityPrincipal = "__identity__"
 
 type Principal struct {
-	Identity *core.UserIdentity
-	UserID   string
-	Source   Source
+	Identity       *core.UserIdentity
+	UserID         string
+	EgressClientID string
+	Source         Source
 }
 
 type contextKey struct{}

--- a/internal/principal/principal_test.go
+++ b/internal/principal/principal_test.go
@@ -42,21 +42,21 @@ func TestResolveToken(t *testing.T) {
 		}
 	})
 
-	t.Run("api token", func(t *testing.T) {
+	t.Run("prefixed api token", func(t *testing.T) {
 		t.Parallel()
 
-		auth := &coretesting.StubAuthProvider{
-			N: "auth-provider",
-			ValidateTokenFn: func(_ context.Context, _ string) (*core.UserIdentity, error) {
-				return nil, errors.New("session token rejected")
-			},
+		plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+		if err != nil {
+			t.Fatalf("GenerateToken: %v", err)
 		}
+
+		auth := &coretesting.StubAuthProvider{N: "auth-provider"}
 		ds := &coretesting.StubDatastore{
-			ValidateAPITokenFn: func(_ context.Context, hashed string) (*core.APIToken, error) {
-				if hashed == "" {
-					t.Fatal("expected hashed token")
+			ValidateAPITokenFn: func(_ context.Context, h string) (*core.APIToken, error) {
+				if h == hashed {
+					return &core.APIToken{UserID: "user-123", Name: "api-token"}, nil
 				}
-				return &core.APIToken{UserID: "user-123", Name: "api-token"}, nil
+				return nil, core.ErrNotFound
 			},
 			GetUserFn: func(_ context.Context, id string) (*core.User, error) {
 				if id != "user-123" {
@@ -67,7 +67,7 @@ func TestResolveToken(t *testing.T) {
 		}
 		r := principal.NewResolver(auth, ds)
 
-		p, err := r.ResolveToken(context.Background(), "api-token")
+		p, err := r.ResolveToken(context.Background(), plaintext)
 		if err != nil {
 			t.Fatalf("ResolveToken: %v", err)
 		}
@@ -101,6 +101,105 @@ func TestResolveToken(t *testing.T) {
 		_, err := r.ResolveToken(context.Background(), "bad-token")
 		if !errors.Is(err, principal.ErrInvalidToken) {
 			t.Fatalf("err = %v, want ErrInvalidToken", err)
+		}
+	})
+
+	t.Run("unprefixed token rejected even if valid in database", func(t *testing.T) {
+		t.Parallel()
+
+		auth := &coretesting.StubAuthProvider{
+			N: "auth-provider",
+			ValidateTokenFn: func(_ context.Context, _ string) (*core.UserIdentity, error) {
+				return nil, errors.New("not a session")
+			},
+		}
+		ds := &coretesting.StubDatastore{
+			ValidateAPITokenFn: func(_ context.Context, _ string) (*core.APIToken, error) {
+				return &core.APIToken{UserID: "user-1", Name: "legacy-key"}, nil
+			},
+			GetUserFn: func(_ context.Context, id string) (*core.User, error) {
+				return &core.User{ID: id, Email: "legacy@example.test"}, nil
+			},
+		}
+		r := principal.NewResolver(auth, ds)
+
+		_, err := r.ResolveToken(context.Background(), "unprefixed-legacy-token")
+		if !errors.Is(err, principal.ErrInvalidToken) {
+			t.Fatalf("err = %v, want ErrInvalidToken (unprefixed tokens must be rejected)", err)
+		}
+	})
+
+	t.Run("prefixed egress client token", func(t *testing.T) {
+		t.Parallel()
+
+		plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeEgressClient)
+		if err != nil {
+			t.Fatalf("GenerateToken: %v", err)
+		}
+
+		auth := &coretesting.StubAuthProvider{N: "auth-provider"}
+		ecs := &coretesting.StubDatastore{
+			ValidateEgressClientTokenFn: func(_ context.Context, h string) (*core.EgressClientToken, error) {
+				if h == hashed {
+					return &core.EgressClientToken{ID: "tok-1", ClientID: "ec-1"}, nil
+				}
+				return nil, core.ErrNotFound
+			},
+			GetEgressClientFn: func(_ context.Context, id string) (*core.EgressClient, error) {
+				if id == "ec-1" {
+					return &core.EgressClient{ID: "ec-1", Name: "ci-bot"}, nil
+				}
+				return nil, core.ErrNotFound
+			},
+		}
+		r := principal.NewResolver(auth, &coretesting.StubDatastore{}, principal.WithEgressClientStore(ecs))
+
+		p, err := r.ResolveToken(context.Background(), plaintext)
+		if err != nil {
+			t.Fatalf("ResolveToken: %v", err)
+		}
+		if p.Source != principal.SourceEgressClient {
+			t.Fatalf("Source = %v, want SourceEgressClient", p.Source)
+		}
+		if p.EgressClientID != "ec-1" {
+			t.Fatalf("EgressClientID = %q, want ec-1", p.EgressClientID)
+		}
+	})
+
+	t.Run("prefixed api token skips oauth", func(t *testing.T) {
+		t.Parallel()
+
+		plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+		if err != nil {
+			t.Fatalf("GenerateToken: %v", err)
+		}
+
+		auth := &coretesting.StubAuthProvider{
+			N: "auth-provider",
+			ValidateTokenFn: func(_ context.Context, _ string) (*core.UserIdentity, error) {
+				t.Fatal("OAuth should not be called for prefixed API tokens")
+				return nil, nil
+			},
+		}
+		ds := &coretesting.StubDatastore{
+			ValidateAPITokenFn: func(_ context.Context, h string) (*core.APIToken, error) {
+				if h == hashed {
+					return &core.APIToken{UserID: "user-1", Name: "key"}, nil
+				}
+				return nil, core.ErrNotFound
+			},
+			GetUserFn: func(_ context.Context, id string) (*core.User, error) {
+				return &core.User{ID: id, Email: "api@example.test"}, nil
+			},
+		}
+		r := principal.NewResolver(auth, ds)
+
+		p, err := r.ResolveToken(context.Background(), plaintext)
+		if err != nil {
+			t.Fatalf("ResolveToken: %v", err)
+		}
+		if p.Source != principal.SourceAPIToken {
+			t.Fatalf("Source = %v, want SourceAPIToken", p.Source)
 		}
 	})
 }

--- a/internal/principal/resolver.go
+++ b/internal/principal/resolver.go
@@ -2,28 +2,100 @@ package principal
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/valon-technologies/gestalt/core"
 )
 
-type Resolver struct {
-	auth      core.AuthProvider
-	datastore core.Datastore
+type TokenType int
+
+const (
+	TokenTypeAPI TokenType = iota
+	TokenTypeEgressClient
+)
+
+const (
+	prefixAPI          = "gst_api_"
+	prefixEgressClient = "gst_ec_"
+)
+
+func GenerateToken(typ TokenType) (plaintext, hashed string, err error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", "", fmt.Errorf("generating random bytes: %w", err)
+	}
+	raw := hex.EncodeToString(b)
+
+	var prefix string
+	switch typ {
+	case TokenTypeAPI:
+		prefix = prefixAPI
+	case TokenTypeEgressClient:
+		prefix = prefixEgressClient
+	default:
+		return "", "", fmt.Errorf("unknown token type %d", typ)
+	}
+
+	plaintext = prefix + raw
+	hashed = HashToken(plaintext)
+	return plaintext, hashed, nil
 }
 
-func NewResolver(auth core.AuthProvider, ds core.Datastore) *Resolver {
-	return &Resolver{auth: auth, datastore: ds}
+func ParseTokenType(token string) (TokenType, bool) {
+	switch {
+	case strings.HasPrefix(token, prefixAPI):
+		return TokenTypeAPI, true
+	case strings.HasPrefix(token, prefixEgressClient):
+		return TokenTypeEgressClient, true
+	default:
+		return 0, false
+	}
+}
+
+type ResolverOption func(*Resolver)
+
+func WithEgressClientStore(ecs core.EgressClientStore) ResolverOption {
+	return func(r *Resolver) { r.egressClients = ecs }
+}
+
+type Resolver struct {
+	auth          core.AuthProvider
+	datastore     core.Datastore
+	egressClients core.EgressClientStore
+}
+
+func NewResolver(auth core.AuthProvider, ds core.Datastore, opts ...ResolverOption) *Resolver {
+	r := &Resolver{auth: auth, datastore: ds}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
 }
 
 func (r *Resolver) ResolveToken(ctx context.Context, token string) (*Principal, error) {
+	if typ, ok := ParseTokenType(token); ok {
+		switch typ {
+		case TokenTypeAPI:
+			return r.resolveAPIToken(ctx, token)
+		case TokenTypeEgressClient:
+			return r.resolveEgressClientToken(ctx, token)
+		}
+	}
+
 	identity, err := r.auth.ValidateToken(ctx, token)
 	if err == nil && identity != nil {
 		return &Principal{Identity: identity, Source: SourceSession}, nil
 	}
 
+	return nil, ErrInvalidToken
+}
+
+func (r *Resolver) resolveAPIToken(ctx context.Context, token string) (*Principal, error) {
 	hashed := HashToken(token)
 	apiToken, err := r.datastore.ValidateAPIToken(ctx, hashed)
 	if err != nil {
@@ -51,6 +123,37 @@ func (r *Resolver) ResolveToken(ctx context.Context, token string) (*Principal, 
 		},
 		UserID: user.ID,
 		Source: SourceAPIToken,
+	}, nil
+}
+
+func (r *Resolver) resolveEgressClientToken(ctx context.Context, token string) (*Principal, error) {
+	if r.egressClients == nil {
+		return nil, ErrInvalidToken
+	}
+
+	hashed := HashToken(token)
+	ecToken, err := r.egressClients.ValidateEgressClientToken(ctx, hashed)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			return nil, ErrInvalidToken
+		}
+		return nil, err
+	}
+	if ecToken == nil {
+		return nil, ErrInvalidToken
+	}
+
+	client, err := r.egressClients.GetEgressClient(ctx, ecToken.ClientID)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			return nil, ErrInvalidToken
+		}
+		return nil, err
+	}
+
+	return &Principal{
+		EgressClientID: client.ID,
+		Source:         SourceEgressClient,
 	}, nil
 }
 

--- a/internal/server/egress_clients.go
+++ b/internal/server/egress_clients.go
@@ -112,7 +112,7 @@ func (s *Server) listEgressClients(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clients, err := ecs.ListEgressClients(r.Context(), userID)
+	clients, err := ecs.ListEgressClients(r.Context(), core.EgressClientFilter{CreatedByID: userID})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list egress clients")
 		return
@@ -189,7 +189,7 @@ func (s *Server) createEgressClientToken(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	issued, err := s.issueToken()
+	issued, err := s.issueEgressClientToken()
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to generate token")
 		return

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -2,8 +2,6 @@ package server
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -916,14 +914,6 @@ func (s *Server) devLogin(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		"email": req.Email,
 	})
-}
-
-func generateRandomHex(n int) (string, error) {
-	b := make([]byte, n)
-	if _, err := rand.Read(b); err != nil {
-		return "", fmt.Errorf("generating random bytes: %w", err)
-	}
-	return hex.EncodeToString(b), nil
 }
 
 var (

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -95,6 +95,51 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+func (s *Server) proxyAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.devMode {
+			if email := r.Header.Get("X-Dev-User-Email"); email != "" {
+				p := s.resolver.ResolveEmail(email)
+				ctx := principal.WithPrincipal(r.Context(), p)
+				next.ServeHTTP(w, r.WithContext(ctx))
+				return
+			}
+		}
+
+		var p *principal.Principal
+		var lastErr error
+
+		if header := r.Header.Get("Proxy-Authorization"); header != "" {
+			bearer := strings.TrimPrefix(header, core.BearerScheme)
+			if bearer != header {
+				p, lastErr = s.resolver.ResolveToken(r.Context(), bearer)
+			}
+		}
+
+		if p == nil {
+			if header := r.Header.Get("Authorization"); header != "" {
+				bearer := strings.TrimPrefix(header, core.BearerScheme)
+				if bearer != header {
+					p, lastErr = s.resolver.ResolveToken(r.Context(), bearer)
+				}
+			}
+		}
+
+		if p == nil {
+			w.Header().Set("Proxy-Authenticate", "Bearer")
+			if lastErr != nil && !errors.Is(lastErr, principal.ErrInvalidToken) {
+				writeError(w, http.StatusInternalServerError, "token validation failed")
+				return
+			}
+			writeError(w, http.StatusProxyAuthRequired, "proxy authentication required")
+			return
+		}
+
+		ctx := principal.WithPrincipal(r.Context(), p)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
 // devCORS permits cross-origin requests in dev mode so the Next.js dev
 // server (hot reload on a different port) can reach the API.
 func devCORS(next http.Handler) http.Handler {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,20 +19,21 @@ import (
 type ReadinessChecker func() string
 
 type Server struct {
-	router     chi.Router
-	auth       core.AuthProvider
-	datastore  core.Datastore
-	providers  *registry.PluginMap[core.Provider]
-	runtimes   *registry.PluginMap[core.Runtime]
-	bindings   *registry.PluginMap[core.Binding]
-	resolver   *principal.Resolver
-	invoker    invocation.Invoker
-	devMode    bool
-	stateCodec *integrationOAuthStateCodec
-	now        func() time.Time
-	readiness  ReadinessChecker
-	mcpHandler http.Handler
-	webUI      http.Handler
+	router         chi.Router
+	auth           core.AuthProvider
+	datastore      core.Datastore
+	providers      *registry.PluginMap[core.Provider]
+	runtimes       *registry.PluginMap[core.Runtime]
+	bindings       *registry.PluginMap[core.Binding]
+	resolver       *principal.Resolver
+	invoker        invocation.Invoker
+	devMode        bool
+	stateCodec     *integrationOAuthStateCodec
+	now            func() time.Time
+	readiness      ReadinessChecker
+	mcpHandler     http.Handler
+	webUI          http.Handler
+	connectHandler http.Handler // CONNECT dispatched outside chi (authority-form URIs bypass path routing)
 }
 
 type Config struct {
@@ -73,7 +74,7 @@ func New(cfg Config) (*Server, error) {
 		providers:  cfg.Providers,
 		runtimes:   cfg.Runtimes,
 		bindings:   cfg.Bindings,
-		resolver:   principal.NewResolver(cfg.Auth, cfg.Datastore),
+		resolver:   principal.NewResolver(cfg.Auth, cfg.Datastore, resolverOpts(cfg.Datastore)...),
 		invoker:    cfg.Invoker,
 		devMode:    cfg.DevMode,
 		stateCodec: stateCodec,
@@ -155,6 +156,14 @@ func (s *Server) routes() {
 	}
 }
 
+func resolverOpts(ds core.Datastore) []principal.ResolverOption {
+	var opts []principal.ResolverOption
+	if ecs, ok := ds.(core.EgressClientStore); ok {
+		opts = append(opts, principal.WithEgressClientStore(ecs))
+	}
+	return opts
+}
+
 func (s *Server) stagedConnectionStore() (core.StagedConnectionStore, error) {
 	scs, ok := s.datastore.(core.StagedConnectionStore)
 	if !ok {
@@ -176,7 +185,19 @@ func (s *Server) mountBindingRoutes(r chi.Router) {
 		for _, route := range binding.Routes() {
 			handler := route.Handler
 			if !route.Public {
-				handler = s.authMiddleware(handler)
+				if route.ProxyAuth {
+					handler = s.proxyAuthMiddleware(handler)
+				} else {
+					handler = s.authMiddleware(handler)
+				}
+			}
+			if route.Connect {
+				if s.connectHandler != nil {
+					log.Printf("warning: binding %q registers CONNECT but another binding already claimed it; skipping", name)
+					continue
+				}
+				s.connectHandler = handler
+				continue
 			}
 			r.Method(route.Method, "/bindings/"+name+route.Pattern, handler)
 		}
@@ -184,5 +205,9 @@ func (s *Server) mountBindingRoutes(r chi.Router) {
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodConnect && s.connectHandler != nil {
+		s.connectHandler.ServeHTTP(w, r)
+		return
+	}
 	s.router.ServeHTTP(w, r)
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -214,6 +214,12 @@ func TestAuthMiddleware_ValidSession(t *testing.T) {
 
 func TestAuthMiddleware_ValidAPIToken(t *testing.T) {
 	t.Parallel()
+
+	plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
 			N: "test",
@@ -222,8 +228,11 @@ func TestAuthMiddleware_ValidAPIToken(t *testing.T) {
 			},
 		}
 		cfg.Datastore = &coretesting.StubDatastore{
-			ValidateAPITokenFn: func(_ context.Context, _ string) (*core.APIToken, error) {
-				return &core.APIToken{UserID: "u1", Name: "test-key"}, nil
+			ValidateAPITokenFn: func(_ context.Context, h string) (*core.APIToken, error) {
+				if h == hashed {
+					return &core.APIToken{UserID: "u1", Name: "test-key"}, nil
+				}
+				return nil, core.ErrNotFound
 			},
 			GetUserFn: func(_ context.Context, id string) (*core.User, error) {
 				return &core.User{ID: id, Email: "user@example.com", DisplayName: "Test User"}, nil
@@ -233,7 +242,7 @@ func TestAuthMiddleware_ValidAPIToken(t *testing.T) {
 	testutil.CloseOnCleanup(t, ts)
 
 	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
-	req.Header.Set("Authorization", "Bearer some-api-key")
+	req.Header.Set("Authorization", "Bearer "+plaintext)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -1457,9 +1466,9 @@ func TestCreateAndListEgressClients(t *testing.T) {
 				stored = append(stored, c)
 				return nil
 			},
-			ListEgressClientsFn: func(_ context.Context, userID string) ([]*core.EgressClient, error) {
-				if userID != "u1" {
-					t.Fatalf("expected userID u1, got %q", userID)
+			ListEgressClientsFn: func(_ context.Context, filter core.EgressClientFilter) ([]*core.EgressClient, error) {
+				if filter.CreatedByID != "u1" {
+					t.Fatalf("expected CreatedByID u1, got %q", filter.CreatedByID)
 				}
 				return stored, nil
 			},
@@ -3511,8 +3520,11 @@ func TestProxyBindingRequiresAuth(t *testing.T) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusUnauthorized {
-		t.Fatalf("expected 401, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusProxyAuthRequired {
+		t.Fatalf("expected 407, got %d", resp.StatusCode)
+	}
+	if resp.Header.Get("Proxy-Authenticate") != "Bearer" {
+		t.Fatalf("expected Proxy-Authenticate: Bearer header, got %q", resp.Header.Get("Proxy-Authenticate"))
 	}
 }
 
@@ -4606,12 +4618,20 @@ func TestExecuteOperation_ConnectionModeEither(t *testing.T) {
 	t.Run("prefers user token", func(t *testing.T) {
 		t.Parallel()
 
+		apiToken, apiHash, err := principal.GenerateToken(principal.TokenTypeAPI)
+		if err != nil {
+			t.Fatalf("GenerateToken: %v", err)
+		}
+
 		ts := newTestServer(t, func(cfg *server.Config) {
 			cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
 			cfg.Providers = testutil.NewProviderRegistry(t, stub)
 			cfg.Datastore = &coretesting.StubDatastore{
-				ValidateAPITokenFn: func(_ context.Context, _ string) (*core.APIToken, error) {
-					return &core.APIToken{UserID: "u1", Name: "test-key"}, nil
+				ValidateAPITokenFn: func(_ context.Context, h string) (*core.APIToken, error) {
+					if h == apiHash {
+						return &core.APIToken{UserID: "u1", Name: "test-key"}, nil
+					}
+					return nil, core.ErrNotFound
 				},
 				GetUserFn: func(_ context.Context, id string) (*core.User, error) {
 					return &core.User{ID: id, Email: "dev@example.com"}, nil
@@ -4630,7 +4650,7 @@ func TestExecuteOperation_ConnectionModeEither(t *testing.T) {
 		testutil.CloseOnCleanup(t, ts)
 
 		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/do", nil)
-		req.Header.Set("Authorization", "Bearer test-api-key")
+		req.Header.Set("Authorization", "Bearer "+apiToken)
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			t.Fatalf("request: %v", err)

--- a/internal/server/token_helpers.go
+++ b/internal/server/token_helpers.go
@@ -22,7 +22,15 @@ func (s *Server) nowUTCSecond() time.Time {
 }
 
 func (s *Server) issueToken() (*issuedToken, error) {
-	plaintext, err := generateRandomHex(32)
+	return s.issueTokenWithType(principal.TokenTypeAPI)
+}
+
+func (s *Server) issueEgressClientToken() (*issuedToken, error) {
+	return s.issueTokenWithType(principal.TokenTypeEgressClient)
+}
+
+func (s *Server) issueTokenWithType(typ principal.TokenType) (*issuedToken, error) {
+	plaintext, hashed, err := principal.GenerateToken(typ)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +39,7 @@ func (s *Server) issueToken() (*issuedToken, error) {
 	expiry := now.Add(defaultIssuedTokenExpiry)
 	return &issuedToken{
 		Plaintext: plaintext,
-		Hashed:    principal.HashToken(plaintext),
+		Hashed:    hashed,
 		CreatedAt: now,
 		UpdatedAt: now,
 		ExpiresAt: &expiry,

--- a/plugins/bindings/proxy/binding.go
+++ b/plugins/bindings/proxy/binding.go
@@ -42,23 +42,32 @@ func (b *Binding) Close() error                  { return nil }
 
 func (b *Binding) Routes() []core.Route {
 	patterns := b.cfg.routePatterns()
-	routes := make([]core.Route, 0, len(b.cfg.methods())*len(patterns))
+	routes := make([]core.Route, 0, len(b.cfg.methods())*len(patterns)+1)
 	for _, method := range b.cfg.methods() {
 		for _, pattern := range patterns {
 			routes = append(routes, core.Route{
-				Method:  method,
-				Pattern: pattern,
-				Handler: http.HandlerFunc(b.handle),
-				Public:  false,
+				Method:    method,
+				Pattern:   pattern,
+				Handler:   http.HandlerFunc(b.handle),
+				Public:    false,
+				ProxyAuth: true,
 			})
 		}
+	}
+	if b.resolver.Policy != nil {
+		routes = append(routes, core.Route{
+			Method:    http.MethodConnect,
+			Handler:   http.HandlerFunc(b.handle),
+			ProxyAuth: true,
+			Connect:   true,
+		})
 	}
 	return routes
 }
 
 func (b *Binding) handle(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodConnect {
-		httpjson.WriteError(w, http.StatusNotImplemented, "CONNECT proxying is not implemented yet")
+		b.handleConnect(w, r)
 		return
 	}
 
@@ -131,13 +140,7 @@ func (b *Binding) resolve(r *http.Request) (egress.Resolution, []byte, error) {
 		Path:     resolvePath(r, b.cfg.normalizedPath()),
 	}
 
-	ctx := egress.WithSubjectFromPrincipal(r.Context(), principal.FromContext(r.Context()))
-	if _, ok := egress.SubjectFromContext(ctx); !ok {
-		ctx = egress.WithSubject(ctx, egress.Subject{
-			Kind: egress.SubjectSystem,
-			ID:   b.name,
-		})
-	}
+	ctx := b.subjectContext(r.Context())
 
 	resolved, err := b.resolver.Resolve(ctx, egress.ResolutionInput{
 		Target:  target,
@@ -148,6 +151,17 @@ func (b *Binding) resolve(r *http.Request) (egress.Resolution, []byte, error) {
 	}
 
 	return resolved, body, nil
+}
+
+func (b *Binding) subjectContext(ctx context.Context) context.Context {
+	ctx = egress.WithSubjectFromPrincipal(ctx, principal.FromContext(ctx))
+	if _, ok := egress.SubjectFromContext(ctx); !ok {
+		ctx = egress.WithSubject(ctx, egress.Subject{
+			Kind: egress.SubjectSystem,
+			ID:   b.name,
+		})
+	}
+	return ctx
 }
 
 var acceptAllStatuses apiexec.ResponseChecker = func(int, []byte) error { return nil }

--- a/plugins/bindings/proxy/config.go
+++ b/plugins/bindings/proxy/config.go
@@ -27,7 +27,6 @@ func (c proxyConfig) methods() []string {
 		http.MethodPatch,
 		http.MethodDelete,
 		http.MethodOptions,
-		http.MethodConnect,
 	}
 }
 

--- a/plugins/bindings/proxy/connect.go
+++ b/plugins/bindings/proxy/connect.go
@@ -1,0 +1,124 @@
+package proxy
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/valon-technologies/gestalt/internal/egress"
+	"github.com/valon-technologies/gestalt/plugins/bindings/internal/httpjson"
+)
+
+const (
+	connectDialTimeout = 10 * time.Second
+	connectIdleTimeout = 5 * time.Minute
+)
+
+func (b *Binding) handleConnect(w http.ResponseWriter, r *http.Request) {
+	// For CONNECT, the canonical target is the request-URI (host:port),
+	// not the Host header which a client could set independently.
+	targetHost := r.RequestURI
+	if targetHost == "" && r.URL != nil {
+		targetHost = r.URL.Host
+	}
+	if targetHost == "" {
+		targetHost = r.Host
+	}
+	if targetHost == "" {
+		httpjson.WriteError(w, http.StatusBadRequest, "missing CONNECT target host")
+		return
+	}
+
+	target := egress.Target{
+		Provider: b.provider,
+		Instance: b.cfg.Instance,
+		Method:   http.MethodConnect,
+		Host:     targetHost,
+	}
+
+	ctx := b.subjectContext(r.Context())
+	subject, _ := egress.SubjectFromContext(ctx)
+
+	if err := egress.EvaluatePolicy(ctx, b.resolver.Policy, egress.PolicyInput{
+		Subject: subject,
+		Target:  target,
+	}); err != nil {
+		httpjson.WriteError(w, http.StatusForbidden, err.Error())
+		return
+	}
+
+	upstream, err := net.DialTimeout("tcp", targetHost, connectDialTimeout)
+	if err != nil {
+		httpjson.WriteError(w, http.StatusBadGateway, "failed to connect to upstream")
+		return
+	}
+
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		_ = upstream.Close()
+		httpjson.WriteError(w, http.StatusInternalServerError, "server does not support connection hijacking")
+		return
+	}
+	clientConn, bufrw, err := hj.Hijack()
+	if err != nil {
+		_ = upstream.Close()
+		return
+	}
+
+	_, _ = clientConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+
+	// Drain any bytes the HTTP server buffered beyond the CONNECT headers
+	// before switching to raw bidirectional copy.
+	if bufrw != nil && bufrw.Reader.Buffered() > 0 {
+		_, _ = io.CopyN(upstream, bufrw.Reader, int64(bufrw.Reader.Buffered()))
+	}
+
+	tunnel(clientConn, upstream)
+}
+
+func tunnel(client, upstream net.Conn) {
+	defer func() { _ = client.Close() }()
+	defer func() { _ = upstream.Close() }()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		copyWithIdleTimeout(upstream, client, connectIdleTimeout)
+		closeWrite(upstream)
+	}()
+
+	go func() {
+		defer wg.Done()
+		copyWithIdleTimeout(client, upstream, connectIdleTimeout)
+		closeWrite(client)
+	}()
+
+	wg.Wait()
+}
+
+func closeWrite(c net.Conn) {
+	if cw, ok := c.(interface{ CloseWrite() error }); ok {
+		_ = cw.CloseWrite()
+	}
+}
+
+func copyWithIdleTimeout(dst, src net.Conn, idle time.Duration) {
+	buf := make([]byte, 32*1024)
+	for {
+		_ = src.SetReadDeadline(time.Now().Add(idle))
+		n, readErr := src.Read(buf)
+		if n > 0 {
+			_ = dst.SetWriteDeadline(time.Now().Add(idle))
+			if _, writeErr := dst.Write(buf[:n]); writeErr != nil {
+				break
+			}
+		}
+		if readErr != nil {
+			break
+		}
+	}
+}

--- a/plugins/bindings/proxy/proxy_test.go
+++ b/plugins/bindings/proxy/proxy_test.go
@@ -1,11 +1,14 @@
 package proxy
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
@@ -20,18 +23,39 @@ func TestProxyRoutes(t *testing.T) {
 
 	b := testBinding(t, "/proxy", nil)
 	routes := b.Routes()
-	if len(routes) != 16 {
-		t.Fatalf("expected 16 routes, got %d", len(routes))
+	if len(routes) != 14 {
+		t.Fatalf("expected 14 routes (7 methods x 2 patterns, no CONNECT without policy), got %d", len(routes))
 	}
+	for _, route := range routes {
+		if route.Connect {
+			t.Fatal("CONNECT should not be registered without a policy enforcer")
+		}
+	}
+
+	withPolicy := New("test-proxy", "test-provider", proxyConfig{Path: "/proxy"}, egress.Resolver{
+		Subjects: egress.ContextSubjectResolver{},
+		Policy:   egress.StaticPolicyEnforcer{DefaultAction: egress.PolicyAllow},
+	}, nil)
+	policyRoutes := withPolicy.Routes()
+	var hasConnect bool
+	for _, route := range policyRoutes {
+		if route.Connect {
+			hasConnect = true
+		}
+	}
+	if !hasConnect {
+		t.Fatal("expected CONNECT route when policy enforcer is configured")
+	}
+
 	patterns := map[string]int{}
 	for _, route := range routes {
 		patterns[route.Pattern]++
 	}
-	if patterns["/proxy"] != 8 {
-		t.Fatalf("expected 8 exact routes, got %d", patterns["/proxy"])
+	if patterns["/proxy"] != 7 {
+		t.Fatalf("expected 7 exact routes, got %d", patterns["/proxy"])
 	}
-	if patterns["/proxy/*"] != 8 {
-		t.Fatalf("expected 8 wildcard routes, got %d", patterns["/proxy/*"])
+	if patterns["/proxy/*"] != 7 {
+		t.Fatalf("expected 7 wildcard routes, got %d", patterns["/proxy/*"])
 	}
 }
 
@@ -194,16 +218,102 @@ func TestProxyForwardsUpstreamErrors(t *testing.T) {
 	}
 }
 
-func TestProxyCONNECTNotImplemented(t *testing.T) {
+func TestProxyCONNECTEstablishesTunnel(t *testing.T) {
 	t.Parallel()
 
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		buf := make([]byte, 256)
+		n, _ := conn.Read(buf)
+		if n > 0 {
+			_, _ = conn.Write(buf[:n])
+		}
+	}()
+
+	host := ln.Addr().String()
 	b := testBinding(t, "/proxy", nil)
-	req := httptest.NewRequest(http.MethodConnect, "/proxy/tunnel", nil)
+
+	clientConn, serverConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+
+	hijacker := &fakeHijacker{
+		ResponseRecorder: httptest.NewRecorder(),
+		conn:             serverConn,
+	}
+
+	req := httptest.NewRequest(http.MethodConnect, host, nil)
+	req.Host = host
+	req.RequestURI = host
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		b.Routes()[0].Handler.ServeHTTP(hijacker, req)
+	}()
+
+	buf := make([]byte, 256)
+	n, err := clientConn.Read(buf)
+	if err != nil {
+		t.Fatalf("read from tunnel: %v", err)
+	}
+	response := string(buf[:n])
+	if !strings.Contains(response, "200 Connection Established") {
+		t.Fatalf("expected 200 Connection Established, got: %s", response)
+	}
+
+	_, err = clientConn.Write([]byte("hello"))
+	if err != nil {
+		t.Fatalf("write to tunnel: %v", err)
+	}
+
+	n, err = clientConn.Read(buf)
+	if err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+	if string(buf[:n]) != "hello" {
+		t.Fatalf("echo = %q, want hello", string(buf[:n]))
+	}
+
+	_ = clientConn.Close()
+	<-done
+}
+
+func TestProxyCONNECTPolicyDenied(t *testing.T) {
+	t.Parallel()
+
+	policy := egress.StaticPolicyEnforcer{
+		DefaultAction: egress.PolicyDeny,
+	}
+
+	resolver := egress.Resolver{
+		Subjects: egress.ContextSubjectResolver{},
+		Policy:   policy,
+	}
+
+	b := New("test-proxy", "test-provider", proxyConfig{Path: "/proxy"}, resolver, nil)
+
+	req := httptest.NewRequest(http.MethodConnect, "api.example.com:443", nil)
+	req.Host = "api.example.com:443"
+	req.RequestURI = "api.example.com:443"
+
+	ctx := principal.WithPrincipal(req.Context(), &principal.Principal{UserID: "user-1"})
+	req = req.WithContext(ctx)
+
 	w := httptest.NewRecorder()
 	b.Routes()[0].Handler.ServeHTTP(w, req)
 
-	if w.Code != http.StatusNotImplemented {
-		t.Fatalf("status = %d, want 501", w.Code)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
 	}
 }
 
@@ -471,4 +581,14 @@ type subjectCapturingResolver struct {
 func (r subjectCapturingResolver) ResolveCredential(_ context.Context, subject egress.Subject, _ egress.Target) (egress.CredentialMaterialization, error) {
 	r.capture(subject)
 	return egress.CredentialMaterialization{}, nil
+}
+
+type fakeHijacker struct {
+	*httptest.ResponseRecorder
+	conn net.Conn
+}
+
+func (h *fakeHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	rw := bufio.NewReadWriter(bufio.NewReader(h.conn), bufio.NewWriter(h.conn))
+	return h.conn, rw, nil
 }

--- a/plugins/datastore/sqlstore/sqlstore.go
+++ b/plugins/datastore/sqlstore/sqlstore.go
@@ -491,12 +491,15 @@ func (s *Store) GetEgressClient(ctx context.Context, id string) (*core.EgressCli
 	return c, nil
 }
 
-func (s *Store) ListEgressClients(ctx context.Context, userID string) ([]*core.EgressClient, error) {
-	rows, err := s.DB.QueryContext(ctx, `
-		SELECT id, name, description, created_by_id, created_at, updated_at
-		FROM egress_clients
-		WHERE created_by_id = `+s.ph(1)+`
-		ORDER BY created_at`, userID)
+func (s *Store) ListEgressClients(ctx context.Context, filter core.EgressClientFilter) ([]*core.EgressClient, error) {
+	query := `SELECT id, name, description, created_by_id, created_at, updated_at FROM egress_clients`
+	var args []any
+	if filter.CreatedByID != "" {
+		query += ` WHERE created_by_id = ` + s.ph(1)
+		args = append(args, filter.CreatedByID)
+	}
+	query += ` ORDER BY created_at`
+	rows, err := s.DB.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("listing egress clients: %w", err)
 	}


### PR DESCRIPTION
All bearer tokens now require type-discriminated prefixes (`gst_api_`,
`gst_ec_`) with no unprefixed legacy fallback. Egress client tokens
authenticate as first-class machine principals with `SubjectAgent`,
letting policy rules target humans and agents independently. The egress
resolution pipeline evaluates policy before materializing credentials,
so denied requests never trigger secret fetches.

Proxy routes authenticate via `Proxy-Authorization` with proper 407
responses, and CONNECT tunneling is supported with bidirectional TCP
forwarding, half-close propagation, idle timeouts, and policy
enforcement on the full `host:port` target. The `ListEgressClients`
store interface accepts a filter struct instead of a bare `userID`,
decoupling the data-access contract from ownership policy while
preserving all existing handler authorization checks.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>