### PR TITLE
Allow proxy binding with zero providers

### DIFF
--- a/docs/adr/002-gateway-composition.md
+++ b/docs/adr/002-gateway-composition.md
@@ -1,0 +1,31 @@
+# ADR 002: Gateway Composition
+
+## Status
+
+Accepted
+
+## Context
+
+Gestalt currently assumes every proxy binding has exactly one provider configured. However, a gateway-only deployment (auth + datastore + secret manager + proxy binding + saved deny rules) is a useful shape that does not require any provider. We need to clarify which components are required, which are optional, and how the gateway relates to the full Gestalt deployment.
+
+## Decision
+
+1. **Gateway-only is a valid deployment shape.** A deployment with auth, datastore, secret manager, proxy binding, and saved deny rules is a supported composition of existing parts. It does not require providers.
+
+2. **Full Gestalt reuses the same substrate.** The full deployment uses the exact same auth and egress infrastructure as the gateway-only shape. Providers are additive.
+
+3. **Providers are optional capability adapters.** Providers supply credentials and policy for specific upstream services. A proxy binding with zero providers forwards requests without injecting provider credentials. A proxy binding with one provider resolves credentials through that provider. Two or more providers on a single binding are rejected.
+
+4. **v1 saved rules are deny-only.** The first version of saved rules supports deny rules only. Allow rules are deferred.
+
+5. **v1 admin control uses `admin_emails`.** Administrative access is governed by the `admin_emails` configuration field.
+
+6. **Shared/workload EgressClient scope is deferred.** Scoping EgressClient to shared or per-workload contexts is out of scope for v1.
+
+7. **Gateway-only is a composition, not a separate runtime.** A later gateway-service step can improve listener and routing ergonomics, but the gateway is not a separately optimized runtime surface.
+
+## Consequences
+
+- The proxy factory must accept zero providers (not just exactly one).
+- Tests must cover the zero-provider path.
+- Future PRs can layer provider-backed and gateway-service capabilities on this foundation without restructuring.

--- a/plugins/bindings/proxy/factory.go
+++ b/plugins/bindings/proxy/factory.go
@@ -18,12 +18,16 @@ var Factory bootstrap.BindingFactory = func(_ context.Context, name string, def 
 	if err := cfg.validate(name); err != nil {
 		return nil, err
 	}
-	if len(def.Providers) != 1 {
-		return nil, fmt.Errorf("proxy %q: exactly one provider must be configured in bindings.%s.providers", name, name)
+	if len(def.Providers) > 1 {
+		return nil, fmt.Errorf("proxy %q: at most one provider may be configured in bindings.%s.providers", name, name)
+	}
+	var provider string
+	if len(def.Providers) == 1 {
+		provider = def.Providers[0]
 	}
 	resolver := egress.Resolver{}
 	if deps.Egress.Resolver != nil {
 		resolver = *deps.Egress.Resolver
 	}
-	return New(name, def.Providers[0], cfg, resolver, nil), nil
+	return New(name, provider, cfg, resolver, nil), nil
 }

--- a/plugins/bindings/proxy/proxy_test.go
+++ b/plugins/bindings/proxy/proxy_test.go
@@ -522,7 +522,7 @@ func TestProxyFactoryValidation(t *testing.T) {
 	}
 }
 
-func TestProxyFactoryRejectsNoProvider(t *testing.T) {
+func TestProxyFactoryAcceptsZeroProviders(t *testing.T) {
 	t.Parallel()
 
 	cfgYAML := `path: /proxy`
@@ -531,12 +531,15 @@ func TestProxyFactoryRejectsNoProvider(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := Factory(context.Background(), "no-prov", config.BindingDef{
+	binding, err := Factory(context.Background(), "no-prov", config.BindingDef{
 		Type:   "proxy",
 		Config: *node.Content[0],
 	}, bootstrap.BindingDeps{})
-	if err == nil {
-		t.Fatal("expected error for zero providers")
+	if err != nil {
+		t.Fatalf("Factory: %v", err)
+	}
+	if binding.Name() != "no-prov" {
+		t.Fatalf("name = %q, want no-prov", binding.Name())
 	}
 }
 
@@ -556,6 +559,60 @@ func TestProxyFactoryRejectsMultipleProviders(t *testing.T) {
 	}, bootstrap.BindingDeps{})
 	if err == nil {
 		t.Fatal("expected error for multiple providers")
+	}
+	if !strings.Contains(err.Error(), "at most one") {
+		t.Fatalf("error = %q, want it to contain %q", err.Error(), "at most one")
+	}
+}
+
+func TestProxyZeroProviderForwardsRequest(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"path":   r.URL.Path,
+			"method": r.Method,
+		})
+	}))
+	t.Cleanup(upstream.Close)
+
+	cfgYAML := `path: /gw`
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(cfgYAML), &node); err != nil {
+		t.Fatal(err)
+	}
+
+	binding, err := Factory(context.Background(), "gw-proxy", config.BindingDef{
+		Type:   "proxy",
+		Config: *node.Content[0],
+	}, bootstrap.BindingDeps{})
+	if err != nil {
+		t.Fatalf("Factory: %v", err)
+	}
+
+	routes := binding.Routes()
+	if len(routes) == 0 {
+		t.Fatal("expected at least one route")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, upstream.URL+"/gw/v1/healthz", nil)
+	w := httptest.NewRecorder()
+	routes[0].Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["path"] != "/v1/healthz" {
+		t.Fatalf("upstream path = %q, want /v1/healthz", body["path"])
+	}
+	if body["method"] != http.MethodGet {
+		t.Fatalf("upstream method = %q, want GET", body["method"])
 	}
 }
 


### PR DESCRIPTION
The proxy factory previously required exactly one provider, which
prevented deploying a gateway-only shape (auth + datastore + proxy)
without any provider configured. This relaxes the constraint to accept
zero or one providers, rejecting only two or more. A zero-provider proxy
forwards requests without injecting provider credentials, which is the
correct behavior for a standalone gateway deployment.

An ADR documents the gateway composition decisions: gateway-only is a
valid deployment shape, providers are optional capability adapters, and
the full Gestalt deployment reuses the same auth/egress substrate.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>