### PR TITLE
Add credential source chain for composable resolution

### DIFF
--- a/internal/bootstrap/egress.go
+++ b/internal/bootstrap/egress.go
@@ -33,31 +33,39 @@ func newEgressDeps(cfg *config.Config, _ core.Datastore) EgressDeps {
 }
 
 func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, providers *registry.PluginMap[core.Provider]) {
-	if len(deps.CredentialGrants) == 0 {
-		return
-	}
+	var sources []egress.CredentialResolver
 
-	grants := make([]egress.CredentialGrant, len(deps.CredentialGrants))
-	for i := range deps.CredentialGrants {
-		g := &deps.CredentialGrants[i]
-		grants[i] = egress.CredentialGrant{
-			Instance: g.Instance,
-			MatchCriteria: egress.MatchCriteria{
-				SubjectKind: egress.SubjectKind(g.SubjectKind),
-				SubjectID:   g.SubjectID,
-				Provider:    g.Provider,
-				Operation:   g.Operation,
-				Method:      g.Method,
-				Host:        g.Host,
-				PathPrefix:  g.PathPrefix,
-			},
+	if len(deps.CredentialGrants) > 0 {
+		grants := make([]egress.CredentialGrant, len(deps.CredentialGrants))
+		for i := range deps.CredentialGrants {
+			g := &deps.CredentialGrants[i]
+			grants[i] = egress.CredentialGrant{
+				Instance: g.Instance,
+				MatchCriteria: egress.MatchCriteria{
+					SubjectKind: egress.SubjectKind(g.SubjectKind),
+					SubjectID:   g.SubjectID,
+					Provider:    g.Provider,
+					Operation:   g.Operation,
+					Method:      g.Method,
+					Host:        g.Host,
+					PathPrefix:  g.PathPrefix,
+				},
+			}
 		}
+		sources = append(sources, &egress.ProviderCredentialResolver{
+			TokenResolver: &brokerTokenResolver{broker: broker},
+			Materializer:  &registryMaterializer{providers: providers},
+			Grants:        grants,
+		})
 	}
 
-	deps.Resolver.Credentials = &egress.ProviderCredentialResolver{
-		TokenResolver: &brokerTokenResolver{broker: broker},
-		Materializer:  &registryMaterializer{providers: providers},
-		Grants:        grants,
+	switch len(sources) {
+	case 0:
+		return
+	case 1:
+		deps.Resolver.Credentials = sources[0]
+	default:
+		deps.Resolver.Credentials = &egress.CredentialSourceChain{Sources: sources}
 	}
 }
 

--- a/internal/egress/credential_chain.go
+++ b/internal/egress/credential_chain.go
@@ -1,0 +1,20 @@
+package egress
+
+import "context"
+
+type CredentialSourceChain struct {
+	Sources []CredentialResolver
+}
+
+func (c *CredentialSourceChain) ResolveCredential(ctx context.Context, subject Subject, target Target) (CredentialMaterialization, error) {
+	for _, src := range c.Sources {
+		mat, err := src.ResolveCredential(ctx, subject, target)
+		if err != nil {
+			return CredentialMaterialization{}, err
+		}
+		if mat.Authorization != "" || len(mat.Headers) > 0 {
+			return mat, nil
+		}
+	}
+	return CredentialMaterialization{}, nil
+}

--- a/internal/egress/credential_chain_test.go
+++ b/internal/egress/credential_chain_test.go
@@ -1,0 +1,146 @@
+package egress_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/internal/egress"
+)
+
+type staticCredentialResolver struct {
+	mat    egress.CredentialMaterialization
+	err    error
+	called bool
+}
+
+func (r *staticCredentialResolver) ResolveCredential(_ context.Context, _ egress.Subject, _ egress.Target) (egress.CredentialMaterialization, error) {
+	r.called = true
+	return r.mat, r.err
+}
+
+var (
+	testSubject = egress.Subject{Kind: egress.SubjectUser, ID: "test-user"}
+	testTarget  = egress.Target{Provider: "test-provider", Host: "api.test"}
+)
+
+func TestCredentialSourceChain_EmptyChain(t *testing.T) {
+	t.Parallel()
+	chain := &egress.CredentialSourceChain{}
+
+	mat, err := chain.ResolveCredential(context.Background(), testSubject, testTarget)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mat.Authorization != "" || len(mat.Headers) > 0 {
+		t.Fatalf("expected empty materialization, got %+v", mat)
+	}
+}
+
+func TestCredentialSourceChain_SingleSourceMatch(t *testing.T) {
+	t.Parallel()
+	src := &staticCredentialResolver{
+		mat: egress.CredentialMaterialization{Authorization: "Bearer tok-abc"},
+	}
+	chain := &egress.CredentialSourceChain{Sources: []egress.CredentialResolver{src}}
+
+	mat, err := chain.ResolveCredential(context.Background(), testSubject, testTarget)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mat.Authorization != "Bearer tok-abc" {
+		t.Fatalf("expected Bearer tok-abc, got %q", mat.Authorization)
+	}
+}
+
+func TestCredentialSourceChain_FirstEmptySecondWins(t *testing.T) {
+	t.Parallel()
+	first := &staticCredentialResolver{}
+	second := &staticCredentialResolver{
+		mat: egress.CredentialMaterialization{Authorization: "Bearer from-second"},
+	}
+	chain := &egress.CredentialSourceChain{
+		Sources: []egress.CredentialResolver{first, second},
+	}
+
+	mat, err := chain.ResolveCredential(context.Background(), testSubject, testTarget)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !first.called {
+		t.Fatal("expected first source to be called")
+	}
+	if !second.called {
+		t.Fatal("expected second source to be called")
+	}
+	if mat.Authorization != "Bearer from-second" {
+		t.Fatalf("expected Bearer from-second, got %q", mat.Authorization)
+	}
+}
+
+func TestCredentialSourceChain_FirstMatchShortCircuits(t *testing.T) {
+	t.Parallel()
+	first := &staticCredentialResolver{
+		mat: egress.CredentialMaterialization{Authorization: "Bearer from-first"},
+	}
+	second := &staticCredentialResolver{
+		mat: egress.CredentialMaterialization{Authorization: "Bearer from-second"},
+	}
+	chain := &egress.CredentialSourceChain{
+		Sources: []egress.CredentialResolver{first, second},
+	}
+
+	mat, err := chain.ResolveCredential(context.Background(), testSubject, testTarget)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !first.called {
+		t.Fatal("expected first source to be called")
+	}
+	if second.called {
+		t.Fatal("expected second source to NOT be called")
+	}
+	if mat.Authorization != "Bearer from-first" {
+		t.Fatalf("expected Bearer from-first, got %q", mat.Authorization)
+	}
+}
+
+func TestCredentialSourceChain_ErrorPropagates(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("resolver failure")
+	first := &staticCredentialResolver{err: sentinel}
+	second := &staticCredentialResolver{
+		mat: egress.CredentialMaterialization{Authorization: "Bearer unreachable"},
+	}
+	chain := &egress.CredentialSourceChain{
+		Sources: []egress.CredentialResolver{first, second},
+	}
+
+	_, err := chain.ResolveCredential(context.Background(), testSubject, testTarget)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+	if second.called {
+		t.Fatal("expected second source to NOT be called after error")
+	}
+}
+
+func TestCredentialSourceChain_HeaderOnlyMaterialization(t *testing.T) {
+	t.Parallel()
+	src := &staticCredentialResolver{
+		mat: egress.CredentialMaterialization{
+			Headers: []egress.HeaderMutation{
+				{Action: egress.HeaderActionSet, Name: "X-Api-Key", Value: "key-123"},
+			},
+		},
+	}
+	chain := &egress.CredentialSourceChain{Sources: []egress.CredentialResolver{src}}
+
+	mat, err := chain.ResolveCredential(context.Background(), testSubject, testTarget)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mat.Headers) != 1 || mat.Headers[0].Value != "key-123" {
+		t.Fatalf("expected header-only materialization, got %+v", mat)
+	}
+}


### PR DESCRIPTION
## Summary
- Introduce `CredentialSourceChain` in `internal/egress/credential_chain.go` that implements `CredentialResolver` by trying sources in order
- Refactor `wireCredentialResolver` in `internal/bootstrap/egress.go` to build a sources list and wrap in the chain
- First non-empty `CredentialMaterialization` wins; errors are fatal; empty chain returns empty materialization

This is the second step toward making the egress pipeline composable for gateway-only deployments. The chain allows future credential sources (saved grants, secret-backed) to be added alongside provider-backed resolution without modifying existing code.

## Test plan
- [x] Chain with zero sources returns empty materialization
- [x] Single source match returns that source's materialization
- [x] First-match short-circuits (second source not called)
- [x] Error in source propagates immediately
- [x] Header-only materialization detected as non-empty
- [x] `go test ./internal/egress/... ./internal/bootstrap/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)