### PR TITLE
Add E2E functional tests for packaged plugin lifecycle

### DIFF
--- a/cmd/gestaltd/e2e_test.go
+++ b/cmd/gestaltd/e2e_test.go
@@ -1,0 +1,433 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/internal/pluginpkg"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
+)
+
+func TestE2EPluginPackageArchiveInitAndValidate(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+	archivePath := filepath.Join(dir, "plugin.tar.gz")
+
+	out, err := exec.Command(gestaltdBin, "plugin", "package", "--input", pluginDir, "--output", archivePath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd plugin package: %v\n%s", err, out)
+	}
+
+	cfgPath := writeE2EConfig(t, dir, "plugin.tar.gz", 0)
+	out, err = exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	lockPath := filepath.Join(dir, initLockfileName)
+	lock, err := readLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("readLockfile: %v", err)
+	}
+	entry, ok := lock.Plugins[lockPluginKey("integration", "example")]
+	if !ok {
+		t.Fatalf("lockfile missing plugin entry: %+v", lock.Plugins)
+	}
+	if entry.SourceDigest == "" {
+		t.Fatal("expected non-empty SourceDigest for archive package")
+	}
+	if entry.Package == "" {
+		t.Fatal("expected non-empty Package in lockfile entry")
+	}
+
+	out, err = exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd validate: %v\n%s", err, out)
+	}
+}
+
+func TestE2EPluginPackageDirectoryInit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+	cfgPath := writeE2EConfigForDir(t, dir, pluginDir)
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	lockPath := filepath.Join(dir, initLockfileName)
+	lock, err := readLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("readLockfile: %v", err)
+	}
+	entry, ok := lock.Plugins[lockPluginKey("integration", "example")]
+	if !ok {
+		t.Fatalf("lockfile missing plugin entry: %+v", lock.Plugins)
+	}
+	if entry.SourceDigest == "" {
+		t.Fatal("expected non-empty SourceDigest for directory package")
+	}
+}
+
+func TestE2EPluginPackageHTTPSInit(t *testing.T) { //nolint:paralleltest // mutates http.DefaultTransport
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+	archivePath := filepath.Join(dir, "plugin.tar.gz")
+	if err := pluginpkg.CreatePackageFromDir(pluginDir, archivePath); err != nil {
+		t.Fatalf("CreatePackageFromDir: %v", err)
+	}
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, archivePath)
+	}))
+	defer ts.Close()
+
+	savedTransport := http.DefaultTransport
+	http.DefaultTransport = ts.Client().Transport
+	t.Cleanup(func() { http.DefaultTransport = savedTransport })
+
+	cfgPath := writeE2EConfig(t, dir, ts.URL+"/plugin.tar.gz", 0)
+	if err := run([]string{"init", "--config", cfgPath}); err != nil {
+		t.Fatalf("run init: %v", err)
+	}
+
+	lockPath := filepath.Join(dir, initLockfileName)
+	lock, err := readLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("readLockfile: %v", err)
+	}
+	entry, ok := lock.Plugins[lockPluginKey("integration", "example")]
+	if !ok {
+		t.Fatalf("lockfile missing plugin entry: %+v", lock.Plugins)
+	}
+	if entry.SourceDigest != "" {
+		t.Fatalf("expected empty SourceDigest for HTTPS package, got %q", entry.SourceDigest)
+	}
+}
+
+func TestE2EPluginServeLockedGoldenPath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+	archivePath := filepath.Join(dir, "plugin.tar.gz")
+
+	out, err := exec.Command(gestaltdBin, "plugin", "package", "--input", pluginDir, "--output", archivePath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd plugin package: %v\n%s", err, out)
+	}
+
+	port := allocateTestPort(t)
+	cfgPath := writeE2EConfig(t, dir, "plugin.tar.gz", port)
+
+	out, err = exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	cmd := exec.Command(gestaltdBin, "serve", "--locked", "--config", cfgPath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start serve: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(os.Interrupt)
+		_ = cmd.Wait()
+	})
+
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	waitForReady(t, baseURL, 30*time.Second)
+
+	req, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/example/echo", strings.NewReader(`{"message":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Dev-User-Email", "test@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("invoke returned %d: %s", resp.StatusCode, body)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("unmarshal: %v\nbody: %s", err, body)
+	}
+	if result["echo"] != "hello" {
+		t.Fatalf("expected echo=hello, got %v", result)
+	}
+}
+
+func TestE2EPluginStaleArchiveAutoReinit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+	archivePath := filepath.Join(dir, "plugin.tar.gz")
+	if err := pluginpkg.CreatePackageFromDir(pluginDir, archivePath); err != nil {
+		t.Fatalf("CreatePackageFromDir: %v", err)
+	}
+
+	port := allocateTestPort(t)
+	cfgPath := writeE2EConfig(t, dir, "plugin.tar.gz", port)
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	lockPath := filepath.Join(dir, initLockfileName)
+	lockBefore, err := readLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("readLockfile before: %v", err)
+	}
+	digestBefore := lockBefore.Plugins[lockPluginKey("integration", "example")].SourceDigest
+
+	writeManifest(t, pluginDir, "0.2.0")
+	if err := pluginpkg.CreatePackageFromDir(pluginDir, archivePath); err != nil {
+		t.Fatalf("rebuild CreatePackageFromDir: %v", err)
+	}
+
+	cmd := exec.Command(gestaltdBin, "--config", cfgPath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start gestaltd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(os.Interrupt)
+		_ = cmd.Wait()
+	})
+
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	waitForHealth(t, baseURL, 20*time.Second)
+
+	lockAfter, err := readLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("readLockfile after: %v", err)
+	}
+	digestAfter := lockAfter.Plugins[lockPluginKey("integration", "example")].SourceDigest
+	if digestAfter == digestBefore {
+		t.Fatal("expected SourceDigest to change after stale archive reinit")
+	}
+}
+
+func TestE2EValidateNonMutating(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+	archivePath := filepath.Join(dir, "plugin.tar.gz")
+	if err := pluginpkg.CreatePackageFromDir(pluginDir, archivePath); err != nil {
+		t.Fatalf("CreatePackageFromDir: %v", err)
+	}
+
+	cfgPath := writeE2EConfig(t, dir, "plugin.tar.gz", 0)
+	lockPath := filepath.Join(dir, initLockfileName)
+
+	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected validate to fail without init, output: %s", out)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatal("expected no lockfile after non-mutating validate")
+	}
+
+	out, err = exec.Command(gestaltdBin, "validate", "--init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd validate --init: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("expected lockfile after validate --init: %v", err)
+	}
+}
+
+func setupPluginDir(t *testing.T, baseDir string) string {
+	t.Helper()
+	return setupPluginDirWithVersion(t, baseDir, "0.1.0")
+}
+
+func setupPluginDirWithVersion(t *testing.T, baseDir, version string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(baseDir, "plugin-src")
+	artifactRel := pluginArtifactRel()
+	artifactAbs := filepath.Join(pluginDir, filepath.FromSlash(artifactRel))
+
+	if err := os.MkdirAll(filepath.Dir(artifactAbs), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	if err := copyFile(pluginBin, artifactAbs); err != nil {
+		t.Fatalf("copy plugin binary: %v", err)
+	}
+
+	writeManifest(t, pluginDir, version)
+	return pluginDir
+}
+
+func writeManifest(t *testing.T, pluginDir, version string) {
+	t.Helper()
+
+	artifactRel := pluginArtifactRel()
+	artifactAbs := filepath.Join(pluginDir, filepath.FromSlash(artifactRel))
+
+	digest, err := fileSHA256(artifactAbs)
+	if err != nil {
+		t.Fatalf("compute artifact digest: %v", err)
+	}
+
+	manifest := &pluginmanifestv1.Manifest{
+		SchemaVersion: pluginmanifestv1.SchemaVersion,
+		ID:            "test/provider",
+		Version:       version,
+		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				Path:   artifactRel,
+				SHA256: digest,
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{
+				ArtifactPath: artifactRel,
+			},
+		},
+	}
+	data, err := pluginpkg.EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, pluginpkg.ManifestFile), data, 0644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+func pluginArtifactRel() string {
+	return filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider"))
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func writeE2EConfig(t *testing.T, dir, packageRef string, port int) string {
+	t.Helper()
+
+	if port == 0 {
+		port = 18080
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := fmt.Sprintf(`auth:
+  provider: local
+datastore:
+  provider: sqlite
+  config:
+    path: %s
+server:
+  port: %d
+  dev_mode: true
+  encryption_key: test-e2e-key
+integrations:
+  example:
+    connection_mode: none
+    plugin:
+      package: %s
+`, filepath.Join(dir, "gestalt.db"), port, packageRef)
+
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return cfgPath
+}
+
+func writeE2EConfigForDir(t *testing.T, dir, pluginDir string) string {
+	t.Helper()
+	return writeE2EConfig(t, dir, pluginDir, 0)
+}
+
+var nextTestPort atomic.Int32 // zero value; first allocation returns 19100
+
+func allocateTestPort(t *testing.T) int {
+	t.Helper()
+	return int(nextTestPort.Add(1)) + 19099
+}
+
+func waitForHealth(t *testing.T, baseURL string, timeout time.Duration) {
+	t.Helper()
+	waitForEndpoint(t, baseURL+"/health", timeout)
+}
+
+func waitForReady(t *testing.T, baseURL string, timeout time.Duration) {
+	t.Helper()
+	waitForEndpoint(t, baseURL+"/ready", timeout)
+}
+
+func waitForEndpoint(t *testing.T, url string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("%s did not return 200 within %s", url, timeout)
+}

--- a/cmd/gestaltd/testmain_test.go
+++ b/cmd/gestaltd/testmain_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+var (
+	gestaltdBin string
+	pluginBin   string
+)
+
+func TestMain(m *testing.M) {
+	tmpDir, err := os.MkdirTemp("", "gestaltd-e2e-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "create temp dir: %v\n", err)
+		os.Exit(1)
+	}
+
+	gestaltdBin = filepath.Join(tmpDir, "gestaltd")
+	pluginBin = filepath.Join(tmpDir, "provider")
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	wg.Add(2)
+	go func() { defer wg.Done(); errs[0] = buildGo(".", gestaltdBin) }()
+	go func() { defer wg.Done(); errs[1] = buildGo("../../examples/plugins/provider-go", pluginBin) }()
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "build %d: %v\n", i, err)
+			_ = os.RemoveAll(tmpDir)
+			os.Exit(1)
+		}
+	}
+
+	code := m.Run()
+	_ = os.RemoveAll(tmpDir)
+	os.Exit(code)
+}
+
+func buildGo(dir, output string) error {
+	cmd := exec.Command("go", "build", "-o", output, ".")
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}


### PR DESCRIPTION
The packaged plugin workflow (`plugin.package` config, `gestaltd init`,
`gestaltd serve --locked`) was added in Phase 4 but lacked end-to-end
coverage that exercises the full operator lifecycle through process
boundaries. This adds six functional tests that build the example
provider plugin binary, package it, and verify init, validate, and
locked serve all work correctly. Coverage includes archive, directory,
and HTTPS package sources, stale archive auto-reinit detection, and
non-mutating validate behavior. The golden-path test starts a real
server and invokes the plugin through HTTP to prove it responds through
the host boundary.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>