### PR TITLE
feat: saved egress deny rules

### DIFF
--- a/core/datastore.go
+++ b/core/datastore.go
@@ -44,3 +44,15 @@ type EgressClientStore interface {
 	ListEgressClientTokens(ctx context.Context, clientID string) ([]*EgressClientToken, error)
 	RevokeEgressClientToken(ctx context.Context, clientID, tokenID string) error
 }
+
+type EgressDenyRuleFilter struct {
+	SubjectKind string
+	Host        string
+}
+
+type EgressDenyRuleStore interface {
+	CreateEgressDenyRule(ctx context.Context, rule *EgressDenyRule) error
+	GetEgressDenyRule(ctx context.Context, id string) (*EgressDenyRule, error)
+	ListEgressDenyRules(ctx context.Context, filter EgressDenyRuleFilter) ([]*EgressDenyRule, error)
+	DeleteEgressDenyRule(ctx context.Context, id string) error
+}

--- a/core/testing/datastore_suite.go
+++ b/core/testing/datastore_suite.go
@@ -33,6 +33,9 @@ func RunDatastoreTests(t *testing.T, newStore func(t *testing.T) core.Datastore)
 	t.Run("EgressClientTokens", func(t *testing.T) {
 		testDatastoreEgressClientTokens(t, newStore)
 	})
+	t.Run("EgressDenyRules", func(t *testing.T) {
+		testDatastoreEgressDenyRules(t, newStore)
+	})
 }
 
 func mustCreateUser(t *testing.T, ctx context.Context, ds core.Datastore, email string) *core.User {
@@ -873,6 +876,144 @@ func testDatastoreEgressClientTokens(t *testing.T, newStore func(t *testing.T) c
 		}
 		if got != nil {
 			t.Errorf("expected nil after cascade delete, got %+v", got)
+		}
+	})
+}
+
+func testDatastoreEgressDenyRules(t *testing.T, newStore func(t *testing.T) core.Datastore) {
+	t.Run("create get list and delete lifecycle", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		edrs, ok := ds.(core.EgressDenyRuleStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressDenyRuleStore")
+		}
+
+		ctx := context.Background()
+		user := mustCreateUser(t, ctx, ds, "deny-admin@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		rule := &core.EgressDenyRule{
+			ID:          "edr-1",
+			SubjectKind: "agent",
+			Host:        "blocked.test",
+			CreatedByID: user.ID,
+			Description: "block agent access to blocked.test",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		if err := edrs.CreateEgressDenyRule(ctx, rule); err != nil {
+			t.Fatalf("CreateEgressDenyRule: %v", err)
+		}
+
+		got, err := edrs.GetEgressDenyRule(ctx, "edr-1")
+		if err != nil {
+			t.Fatalf("GetEgressDenyRule: %v", err)
+		}
+		if got.SubjectKind != "agent" {
+			t.Errorf("SubjectKind: got %q, want %q", got.SubjectKind, "agent")
+		}
+		if got.Host != "blocked.test" {
+			t.Errorf("Host: got %q, want %q", got.Host, "blocked.test")
+		}
+		if got.CreatedByID != user.ID {
+			t.Errorf("CreatedByID: got %q, want %q", got.CreatedByID, user.ID)
+		}
+		if got.Description != "block agent access to blocked.test" {
+			t.Errorf("Description: got %q, want %q", got.Description, "block agent access to blocked.test")
+		}
+
+		rules, err := edrs.ListEgressDenyRules(ctx, core.EgressDenyRuleFilter{})
+		if err != nil {
+			t.Fatalf("ListEgressDenyRules (unfiltered): %v", err)
+		}
+		if len(rules) != 1 {
+			t.Fatalf("ListEgressDenyRules: got %d, want 1", len(rules))
+		}
+
+		if err := edrs.DeleteEgressDenyRule(ctx, "edr-1"); err != nil {
+			t.Fatalf("DeleteEgressDenyRule: %v", err)
+		}
+
+		_, err = edrs.GetEgressDenyRule(ctx, "edr-1")
+		if !errors.Is(err, core.ErrNotFound) {
+			t.Fatalf("GetEgressDenyRule after delete: expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("list filters by subject_kind and host", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		edrs, ok := ds.(core.EgressDenyRuleStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressDenyRuleStore")
+		}
+
+		ctx := context.Background()
+		user := mustCreateUser(t, ctx, ds, "deny-filter@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		if err := edrs.CreateEgressDenyRule(ctx, &core.EgressDenyRule{
+			ID: "edr-a", SubjectKind: "user", Host: "alpha.test",
+			CreatedByID: user.ID, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressDenyRule a: %v", err)
+		}
+		if err := edrs.CreateEgressDenyRule(ctx, &core.EgressDenyRule{
+			ID: "edr-b", SubjectKind: "agent", Host: "beta.test",
+			CreatedByID: user.ID, CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second),
+		}); err != nil {
+			t.Fatalf("CreateEgressDenyRule b: %v", err)
+		}
+
+		byKind, err := edrs.ListEgressDenyRules(ctx, core.EgressDenyRuleFilter{SubjectKind: "user"})
+		if err != nil {
+			t.Fatalf("ListEgressDenyRules by kind: %v", err)
+		}
+		if len(byKind) != 1 || byKind[0].ID != "edr-a" {
+			t.Fatalf("filter by subject_kind: got %d rules, want 1 (edr-a)", len(byKind))
+		}
+
+		byHost, err := edrs.ListEgressDenyRules(ctx, core.EgressDenyRuleFilter{Host: "beta.test"})
+		if err != nil {
+			t.Fatalf("ListEgressDenyRules by host: %v", err)
+		}
+		if len(byHost) != 1 || byHost[0].ID != "edr-b" {
+			t.Fatalf("filter by host: got %d rules, want 1 (edr-b)", len(byHost))
+		}
+	})
+
+	t.Run("get nonexistent returns ErrNotFound", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		edrs, ok := ds.(core.EgressDenyRuleStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressDenyRuleStore")
+		}
+
+		ctx := context.Background()
+		_, err := edrs.GetEgressDenyRule(ctx, "nonexistent-id")
+		if !errors.Is(err, core.ErrNotFound) {
+			t.Fatalf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("delete nonexistent returns ErrNotFound", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		edrs, ok := ds.(core.EgressDenyRuleStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressDenyRuleStore")
+		}
+
+		ctx := context.Background()
+		err := edrs.DeleteEgressDenyRule(ctx, "nonexistent-id")
+		if !errors.Is(err, core.ErrNotFound) {
+			t.Fatalf("expected ErrNotFound, got %v", err)
 		}
 	})
 }

--- a/core/testing/stubs.go
+++ b/core/testing/stubs.go
@@ -20,6 +20,7 @@ func (s *StubSecretManager) GetSecret(_ context.Context, name string) (string, e
 
 var _ core.StagedConnectionStore = (*StubDatastore)(nil)
 var _ core.EgressClientStore = (*StubDatastore)(nil)
+var _ core.EgressDenyRuleStore = (*StubDatastore)(nil)
 
 // Set Fn fields to override individual methods; nil fields return zero values.
 type StubDatastore struct {
@@ -44,6 +45,10 @@ type StubDatastore struct {
 	ValidateEgressClientTokenFn func(context.Context, string) (*core.EgressClientToken, error)
 	ListEgressClientTokensFn    func(context.Context, string) ([]*core.EgressClientToken, error)
 	RevokeEgressClientTokenFn   func(context.Context, string, string) error
+	CreateEgressDenyRuleFn      func(context.Context, *core.EgressDenyRule) error
+	GetEgressDenyRuleFn         func(context.Context, string) (*core.EgressDenyRule, error)
+	ListEgressDenyRulesFn       func(context.Context, core.EgressDenyRuleFilter) ([]*core.EgressDenyRule, error)
+	DeleteEgressDenyRuleFn      func(context.Context, string) error
 }
 
 func (s *StubDatastore) Ping(ctx context.Context) error {
@@ -188,6 +193,30 @@ func (s *StubDatastore) ListEgressClientTokens(ctx context.Context, clientID str
 func (s *StubDatastore) RevokeEgressClientToken(ctx context.Context, clientID, tokenID string) error {
 	if s.RevokeEgressClientTokenFn != nil {
 		return s.RevokeEgressClientTokenFn(ctx, clientID, tokenID)
+	}
+	return nil
+}
+func (s *StubDatastore) CreateEgressDenyRule(ctx context.Context, rule *core.EgressDenyRule) error {
+	if s.CreateEgressDenyRuleFn != nil {
+		return s.CreateEgressDenyRuleFn(ctx, rule)
+	}
+	return nil
+}
+func (s *StubDatastore) GetEgressDenyRule(ctx context.Context, id string) (*core.EgressDenyRule, error) {
+	if s.GetEgressDenyRuleFn != nil {
+		return s.GetEgressDenyRuleFn(ctx, id)
+	}
+	return nil, core.ErrNotFound
+}
+func (s *StubDatastore) ListEgressDenyRules(ctx context.Context, filter core.EgressDenyRuleFilter) ([]*core.EgressDenyRule, error) {
+	if s.ListEgressDenyRulesFn != nil {
+		return s.ListEgressDenyRulesFn(ctx, filter)
+	}
+	return nil, nil
+}
+func (s *StubDatastore) DeleteEgressDenyRule(ctx context.Context, id string) error {
+	if s.DeleteEgressDenyRuleFn != nil {
+		return s.DeleteEgressDenyRuleFn(ctx, id)
 	}
 	return nil
 }

--- a/core/types.go
+++ b/core/types.go
@@ -107,3 +107,18 @@ type EgressClientToken struct {
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 }
+
+type EgressDenyRule struct {
+	ID          string
+	SubjectKind string
+	SubjectID   string
+	Provider    string
+	Operation   string
+	Method      string
+	Host        string
+	PathPrefix  string
+	CreatedByID string
+	Description string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}

--- a/docs/pages/tasks/_meta.ts
+++ b/docs/pages/tasks/_meta.ts
@@ -2,8 +2,6 @@ export default {
   "run-locally": "Run Locally",
   "add-an-integration": "Add an Integration",
   "add-a-first-party-provider": "Add a First-Party Provider",
-  "configure-jira": "Configure Jira",
-  "configure-bigquery": "Configure BigQuery",
   "use-a-plugin-package": "Use a Plugin Package",
   "use-with-mcp": "Use with MCP",
 };

--- a/internal/bootstrap/egress.go
+++ b/internal/bootstrap/egress.go
@@ -16,11 +16,22 @@ type EgressDeps struct {
 	CredentialGrants []config.EgressCredentialGrant
 }
 
-func newEgressDeps(cfg *config.Config, _ core.Datastore) EgressDeps {
-	var policy egress.PolicyEnforcer
+func newEgressDeps(cfg *config.Config, ds core.Datastore) EgressDeps {
+	staticEnforcer := buildStaticPolicyEnforcer(cfg.Egress)
 	defaultAction := egress.PolicyAction(cfg.Egress.DefaultAction)
-	if len(cfg.Egress.Policies) > 0 || defaultAction == egress.PolicyDeny {
-		policy = buildStaticPolicyEnforcer(cfg.Egress)
+	hasStaticRules := len(cfg.Egress.Policies) > 0 || defaultAction == egress.PolicyDeny
+
+	denyStore, hasDenyStore := ds.(core.EgressDenyRuleStore)
+
+	var policy egress.PolicyEnforcer
+	switch {
+	case hasDenyStore:
+		policy = &egress.CompositePolicyEnforcer{
+			Static: staticEnforcer,
+			Store:  &denyRuleStoreAdapter{store: denyStore},
+		}
+	case hasStaticRules:
+		policy = staticEnforcer
 	}
 
 	return EgressDeps{
@@ -30,6 +41,31 @@ func newEgressDeps(cfg *config.Config, _ core.Datastore) EgressDeps {
 		},
 		CredentialGrants: cfg.Egress.Credentials,
 	}
+}
+
+type denyRuleStoreAdapter struct {
+	store core.EgressDenyRuleStore
+}
+
+func (a *denyRuleStoreAdapter) LoadDenyRules(ctx context.Context) ([]egress.DenyRuleRecord, error) {
+	rules, err := a.store.ListEgressDenyRules(ctx, core.EgressDenyRuleFilter{})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]egress.DenyRuleRecord, len(rules))
+	for i, r := range rules {
+		out[i] = egress.DenyRuleRecord{
+			ID:          r.ID,
+			SubjectKind: r.SubjectKind,
+			SubjectID:   r.SubjectID,
+			Provider:    r.Provider,
+			Operation:   r.Operation,
+			Method:      r.Method,
+			Host:        r.Host,
+			PathPrefix:  r.PathPrefix,
+		}
+	}
+	return out, nil
 }
 
 func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, providers *registry.PluginMap[core.Provider]) {

--- a/internal/bootstrap/regression_test.go
+++ b/internal/bootstrap/regression_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/valon-technologies/gestalt/internal/egress"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	"github.com/valon-technologies/gestalt/internal/principal"
+	"gopkg.in/yaml.v3"
 )
 
 func TestGatewayMode_NoRuntimesOrBindingsRequired(t *testing.T) {
@@ -213,6 +214,66 @@ func TestEgressPolicyWiredThroughBootstrap(t *testing.T) {
 	}
 	if err := resolve("/v1/admin/users"); err == nil {
 		t.Fatal("default-deny should block unmatched path")
+	}
+}
+
+func TestSavedDenyRuleBlocksEgressThroughCompositeEnforcer(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cfg := validConfig()
+	cfg.Bindings = map[string]config.BindingDef{
+		"my-binding": {
+			Type:      "test-binding",
+			Providers: []string{"alpha"},
+		},
+	}
+
+	factories := validFactories()
+
+	rules := []*core.EgressDenyRule{
+		{ID: "dr-1", Host: "blocked.test"},
+	}
+
+	factories.Datastores["test-store"] = func(cfg2 yaml.Node, deps bootstrap.Deps) (core.Datastore, error) {
+		return &coretesting.StubDatastore{
+			ListEgressDenyRulesFn: func(_ context.Context, _ core.EgressDenyRuleFilter) ([]*core.EgressDenyRule, error) {
+				return rules, nil
+			},
+		}, nil
+	}
+
+	var receivedEgress bootstrap.EgressDeps
+	factories.Bindings["test-binding"] = func(_ context.Context, name string, _ config.BindingDef, deps bootstrap.BindingDeps) (core.Binding, error) {
+		receivedEgress = deps.Egress
+		return &coretesting.StubBinding{N: name}, nil
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	if receivedEgress.Resolver == nil {
+		t.Fatal("expected egress resolver to be wired")
+	}
+	if receivedEgress.Resolver.Policy == nil {
+		t.Fatal("expected composite policy enforcer to be set for SQL-backed store")
+	}
+
+	resolve := func(host string) error {
+		_, err := receivedEgress.Resolver.Resolve(ctx, egress.ResolutionInput{
+			Target: egress.Target{Method: "GET", Host: host, Path: "/"},
+		})
+		return err
+	}
+
+	if err := resolve("allowed.test"); err != nil {
+		t.Fatalf("unblocked host should pass: %v", err)
+	}
+	if err := resolve("blocked.test"); err == nil {
+		t.Fatal("blocked host should be denied by saved deny rule")
 	}
 }
 

--- a/internal/egress/composite_policy.go
+++ b/internal/egress/composite_policy.go
@@ -1,0 +1,58 @@
+package egress
+
+import (
+	"context"
+	"fmt"
+)
+
+type DenyRuleRecord struct {
+	SubjectKind string
+	SubjectID   string
+	Provider    string
+	Operation   string
+	Method      string
+	Host        string
+	PathPrefix  string
+	ID          string
+}
+
+type DenyRuleLoader interface {
+	LoadDenyRules(ctx context.Context) ([]DenyRuleRecord, error)
+}
+
+type CompositePolicyEnforcer struct {
+	Static StaticPolicyEnforcer
+	Store  DenyRuleLoader
+}
+
+func (c *CompositePolicyEnforcer) Evaluate(ctx context.Context, input PolicyInput) error {
+	if err := c.Static.Evaluate(ctx, input); err != nil {
+		return err
+	}
+
+	if c.Store == nil {
+		return nil
+	}
+
+	rules, err := c.Store.LoadDenyRules(ctx)
+	if err != nil {
+		return fmt.Errorf("%w: deny rule lookup failed: %v", ErrEgressDenied, err)
+	}
+
+	for i := range rules {
+		mc := MatchCriteria{
+			SubjectKind: SubjectKind(rules[i].SubjectKind),
+			SubjectID:   rules[i].SubjectID,
+			Provider:    rules[i].Provider,
+			Operation:   rules[i].Operation,
+			Method:      rules[i].Method,
+			Host:        rules[i].Host,
+			PathPrefix:  rules[i].PathPrefix,
+		}
+		if mc.Matches(input.Subject, input.Target) {
+			return fmt.Errorf("%w: matched deny rule %s", ErrEgressDenied, rules[i].ID)
+		}
+	}
+
+	return nil
+}

--- a/plugins/datastore/mysql/mysql.go
+++ b/plugins/datastore/mysql/mysql.go
@@ -47,6 +47,7 @@ type Store struct {
 var _ core.Datastore = (*Store)(nil)
 var _ core.StagedConnectionStore = (*Store)(nil)
 var _ core.EgressClientStore = (*Store)(nil)
+var _ core.EgressDenyRuleStore = (*Store)(nil)
 
 func New(dsn string, encryptionKey []byte) (*Store, error) {
 	cfg, err := mysqldriver.ParseDSN(dsn)
@@ -145,6 +146,22 @@ func (s *Store) Migrate(ctx context.Context) error {
 			updated_at DATETIME(6) NOT NULL,
 			UNIQUE KEY idx_egress_client_tokens_hashed (hashed_token),
 			CONSTRAINT fk_egress_client_tokens_client FOREIGN KEY (client_id) REFERENCES egress_clients(id) ON DELETE CASCADE
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`,
+
+		`CREATE TABLE IF NOT EXISTS egress_deny_rules (
+			id VARCHAR(36) NOT NULL PRIMARY KEY,
+			subject_kind VARCHAR(255) NOT NULL DEFAULT '',
+			subject_id VARCHAR(255) NOT NULL DEFAULT '',
+			provider VARCHAR(255) NOT NULL DEFAULT '',
+			operation VARCHAR(255) NOT NULL DEFAULT '',
+			method VARCHAR(255) NOT NULL DEFAULT '',
+			host VARCHAR(255) NOT NULL DEFAULT '',
+			path_prefix VARCHAR(255) NOT NULL DEFAULT '',
+			created_by_id VARCHAR(36) NOT NULL,
+			description TEXT NOT NULL,
+			created_at DATETIME(6) NOT NULL,
+			updated_at DATETIME(6) NOT NULL,
+			CONSTRAINT fk_egress_deny_rules_user FOREIGN KEY (created_by_id) REFERENCES users(id)
 		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`,
 	}
 

--- a/plugins/datastore/oracle/oracle.go
+++ b/plugins/datastore/oracle/oracle.go
@@ -80,6 +80,7 @@ type Store struct {
 var _ core.Datastore = (*Store)(nil)
 var _ core.StagedConnectionStore = (*Store)(nil)
 var _ core.EgressClientStore = (*Store)(nil)
+var _ core.EgressDenyRuleStore = (*Store)(nil)
 
 func New(dsn string, encryptionKey []byte) (*Store, error) {
 	s, err := sqlstore.Open("oracle", dsn, encryptionKey, dialect{})
@@ -174,6 +175,23 @@ func (s *Store) Migrate(ctx context.Context) error {
 				updated_at TIMESTAMP WITH TIME ZONE NOT NULL
 			)`,
 		},
+		{
+			name: "EGRESS_DENY_RULES",
+			ddl: `CREATE TABLE egress_deny_rules (
+				id VARCHAR2(36) PRIMARY KEY,
+				subject_kind VARCHAR2(255) DEFAULT '' NOT NULL,
+				subject_id VARCHAR2(255) DEFAULT '' NOT NULL,
+				provider VARCHAR2(255) DEFAULT '' NOT NULL,
+				operation VARCHAR2(255) DEFAULT '' NOT NULL,
+				method VARCHAR2(255) DEFAULT '' NOT NULL,
+				host VARCHAR2(255) DEFAULT '' NOT NULL,
+				path_prefix VARCHAR2(255) DEFAULT '' NOT NULL,
+				created_by_id VARCHAR2(36) NOT NULL,
+				description CLOB,
+				created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+				updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+			)`,
+		},
 	}
 
 	for _, tbl := range tables {
@@ -231,6 +249,10 @@ func (s *Store) Migrate(ctx context.Context) error {
 		{
 			name: "FK_ECLT_CLIENT",
 			ddl:  "ALTER TABLE egress_client_tokens ADD CONSTRAINT fk_eclt_client FOREIGN KEY (client_id) REFERENCES egress_clients(id) ON DELETE CASCADE",
+		},
+		{
+			name: "FK_EDR_USER",
+			ddl:  "ALTER TABLE egress_deny_rules ADD CONSTRAINT fk_edr_user FOREIGN KEY (created_by_id) REFERENCES users(id)",
 		},
 	}
 

--- a/plugins/datastore/postgres/postgres.go
+++ b/plugins/datastore/postgres/postgres.go
@@ -64,6 +64,7 @@ type Store struct {
 var _ core.Datastore = (*Store)(nil)
 var _ core.StagedConnectionStore = (*Store)(nil)
 var _ core.EgressClientStore = (*Store)(nil)
+var _ core.EgressDenyRuleStore = (*Store)(nil)
 
 func New(dsn string, encryptionKey []byte) (*Store, error) {
 	s, err := sqlstore.Open("pgx", dsn, encryptionKey, dialect{})
@@ -161,6 +162,23 @@ func (s *Store) Migrate(ctx context.Context) error {
 			updated_at TIMESTAMPTZ NOT NULL
 		)`); err != nil {
 		return fmt.Errorf("creating egress_client_tokens table: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS egress_deny_rules (
+			id TEXT PRIMARY KEY,
+			subject_kind TEXT NOT NULL DEFAULT '',
+			subject_id TEXT NOT NULL DEFAULT '',
+			provider TEXT NOT NULL DEFAULT '',
+			operation TEXT NOT NULL DEFAULT '',
+			method TEXT NOT NULL DEFAULT '',
+			host TEXT NOT NULL DEFAULT '',
+			path_prefix TEXT NOT NULL DEFAULT '',
+			created_by_id TEXT NOT NULL REFERENCES users(id),
+			description TEXT NOT NULL DEFAULT '',
+			created_at TIMESTAMPTZ NOT NULL,
+			updated_at TIMESTAMPTZ NOT NULL
+		)`); err != nil {
+		return fmt.Errorf("creating egress_deny_rules table: %w", err)
 	}
 	return tx.Commit()
 }

--- a/plugins/datastore/sqlite/sqlite.go
+++ b/plugins/datastore/sqlite/sqlite.go
@@ -51,6 +51,7 @@ type Store struct {
 var _ core.Datastore = (*Store)(nil)
 var _ core.StagedConnectionStore = (*Store)(nil)
 var _ core.EgressClientStore = (*Store)(nil)
+var _ core.EgressDenyRuleStore = (*Store)(nil)
 
 func New(dbPath string, encryptionKey []byte) (*Store, error) {
 	dsn := dbPath + "?_pragma=journal_mode(wal)&_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)"
@@ -132,6 +133,20 @@ func (s *Store) Migrate(ctx context.Context) error {
 			name TEXT NOT NULL,
 			hashed_token TEXT UNIQUE NOT NULL,
 			expires_at DATETIME,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS egress_deny_rules (
+			id TEXT PRIMARY KEY,
+			subject_kind TEXT NOT NULL DEFAULT '',
+			subject_id TEXT NOT NULL DEFAULT '',
+			provider TEXT NOT NULL DEFAULT '',
+			operation TEXT NOT NULL DEFAULT '',
+			method TEXT NOT NULL DEFAULT '',
+			host TEXT NOT NULL DEFAULT '',
+			path_prefix TEXT NOT NULL DEFAULT '',
+			created_by_id TEXT NOT NULL REFERENCES users(id),
+			description TEXT NOT NULL DEFAULT '',
 			created_at DATETIME NOT NULL,
 			updated_at DATETIME NOT NULL
 		)

--- a/plugins/datastore/sqlserver/sqlserver.go
+++ b/plugins/datastore/sqlserver/sqlserver.go
@@ -79,6 +79,7 @@ type Store struct {
 var _ core.Datastore = (*Store)(nil)
 var _ core.StagedConnectionStore = (*Store)(nil)
 var _ core.EgressClientStore = (*Store)(nil)
+var _ core.EgressDenyRuleStore = (*Store)(nil)
 
 func New(dsn string, encryptionKey []byte) (*Store, error) {
 	s, err := sqlstore.Open(driverName, dsn, encryptionKey, dialect{})
@@ -172,6 +173,22 @@ func (s *Store) Migrate(ctx context.Context) error {
 				name NVARCHAR(255) NOT NULL,
 				hashed_token NVARCHAR(255) NOT NULL UNIQUE,
 				expires_at DATETIME2(6) NULL,
+				created_at DATETIME2(6) NOT NULL,
+				updated_at DATETIME2(6) NOT NULL
+			)`},
+		{"egress_deny_rules", `
+			IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'egress_deny_rules')
+			CREATE TABLE egress_deny_rules (
+				id NVARCHAR(36) NOT NULL PRIMARY KEY,
+				subject_kind NVARCHAR(255) NOT NULL DEFAULT '',
+				subject_id NVARCHAR(255) NOT NULL DEFAULT '',
+				provider NVARCHAR(255) NOT NULL DEFAULT '',
+				operation NVARCHAR(255) NOT NULL DEFAULT '',
+				method NVARCHAR(255) NOT NULL DEFAULT '',
+				host NVARCHAR(255) NOT NULL DEFAULT '',
+				path_prefix NVARCHAR(255) NOT NULL DEFAULT '',
+				created_by_id NVARCHAR(36) NOT NULL REFERENCES users(id),
+				description NVARCHAR(MAX) NOT NULL DEFAULT '',
 				created_at DATETIME2(6) NOT NULL,
 				updated_at DATETIME2(6) NOT NULL
 			)`},

--- a/plugins/datastore/sqlstore/sqlstore.go
+++ b/plugins/datastore/sqlstore/sqlstore.go
@@ -599,3 +599,101 @@ func (s *Store) RevokeEgressClientToken(ctx context.Context, clientID, tokenID s
 	}
 	return nil
 }
+
+// ---------------------------------------------------------------------------
+// EgressDenyRule methods
+// ---------------------------------------------------------------------------
+
+func scanEgressDenyRule(row Scanner) (*core.EgressDenyRule, error) {
+	var r core.EgressDenyRule
+	var description sql.NullString
+	if err := row.Scan(&r.ID, &r.SubjectKind, &r.SubjectID, &r.Provider,
+		&r.Operation, &r.Method, &r.Host, &r.PathPrefix,
+		&r.CreatedByID, &description, &r.CreatedAt, &r.UpdatedAt); err != nil {
+		return nil, err
+	}
+	r.Description = description.String
+	return &r, nil
+}
+
+func (s *Store) CreateEgressDenyRule(ctx context.Context, rule *core.EgressDenyRule) error {
+	defaultTimestamps(&rule.CreatedAt, &rule.UpdatedAt)
+	_, err := s.DB.ExecContext(ctx, `
+		INSERT INTO egress_deny_rules (id, subject_kind, subject_id, provider, operation, method, host, path_prefix, created_by_id, description, created_at, updated_at)
+		VALUES (`+s.ph(1)+`, `+s.ph(2)+`, `+s.ph(3)+`, `+s.ph(4)+`, `+s.ph(5)+`, `+s.ph(6)+`, `+s.ph(7)+`, `+s.ph(8)+`, `+s.ph(9)+`, `+s.ph(10)+`, `+s.ph(11)+`, `+s.ph(12)+`)`,
+		rule.ID, rule.SubjectKind, rule.SubjectID, rule.Provider,
+		rule.Operation, rule.Method, rule.Host, rule.PathPrefix,
+		rule.CreatedByID, rule.Description, rule.CreatedAt, rule.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("inserting egress deny rule: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetEgressDenyRule(ctx context.Context, id string) (*core.EgressDenyRule, error) {
+	row := s.DB.QueryRowContext(ctx, `
+		SELECT id, subject_kind, subject_id, provider, operation, method, host, path_prefix, created_by_id, description, created_at, updated_at
+		FROM egress_deny_rules WHERE id = `+s.ph(1), id)
+	r, err := scanEgressDenyRule(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, core.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying egress deny rule: %w", err)
+	}
+	return r, nil
+}
+
+func (s *Store) ListEgressDenyRules(ctx context.Context, filter core.EgressDenyRuleFilter) ([]*core.EgressDenyRule, error) {
+	query := `SELECT id, subject_kind, subject_id, provider, operation, method, host, path_prefix, created_by_id, description, created_at, updated_at FROM egress_deny_rules`
+	var args []any
+	var conditions []string
+	argN := 1
+	if filter.SubjectKind != "" {
+		conditions = append(conditions, `subject_kind = `+s.ph(argN))
+		args = append(args, filter.SubjectKind)
+		argN++
+	}
+	if filter.Host != "" {
+		conditions = append(conditions, `host = `+s.ph(argN))
+		args = append(args, filter.Host)
+	}
+	if len(conditions) > 0 {
+		query += ` WHERE ` + conditions[0]
+		for _, c := range conditions[1:] {
+			query += ` AND ` + c
+		}
+	}
+	query += ` ORDER BY created_at ASC`
+	rows, err := s.DB.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("listing egress deny rules: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var rules []*core.EgressDenyRule
+	for rows.Next() {
+		r, err := scanEgressDenyRule(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning egress deny rule row: %w", err)
+		}
+		rules = append(rules, r)
+	}
+	return rules, rows.Err()
+}
+
+func (s *Store) DeleteEgressDenyRule(ctx context.Context, id string) error {
+	result, err := s.DB.ExecContext(ctx, "DELETE FROM egress_deny_rules WHERE id = "+s.ph(1), id)
+	if err != nil {
+		return fmt.Errorf("deleting egress deny rule: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("deleting egress deny rule: %w", err)
+	}
+	if n == 0 {
+		return core.ErrNotFound
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add `EgressDenyRule` core type and `EgressDenyRuleStore` interface for persisting deny-only egress policy rules
- Implement sqlstore CRUD (create, get, list with filter, delete) and DDL migrations for all five SQL dialects (sqlite, postgres, mysql, sqlserver, oracle)
- Add `CompositePolicyEnforcer` that evaluates static config rules first, then saved deny rules from the store, with fail-closed behavior on store errors
- Wire composite enforcer into bootstrap for all SQL-backed deployments, falling back to static-only for non-SQL datastores

## Test plan
- [x] Conformance tests in datastore suite: create, get, list with subject_kind/host filters, delete, not-found cases
- [x] Bootstrap regression test: saved deny rule blocks egress through composite enforcer
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)