### PR TITLE
feat: deny rules admin API

### DIFF
--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -155,8 +155,9 @@ func runServer(env *bootstrapEnv) error {
 			readinessFromChannel(result.ProvidersReady, "providers loading"),
 			datastoreReadiness(result.Datastore),
 		),
-		MCPHandler: mcpHandler,
-		WebUI:      webui.Handler(),
+		MCPHandler:  mcpHandler,
+		WebUI:       webui.Handler(),
+		AdminEmails: env.Config.Server.AdminEmails,
 	})
 	if err != nil {
 		return fmt.Errorf("creating server: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,10 +109,11 @@ type DatastoreConfig struct {
 }
 
 type ServerConfig struct {
-	Port          int    `yaml:"port"`
-	BaseURL       string `yaml:"base_url"`
-	EncryptionKey string `yaml:"encryption_key"`
-	DevMode       bool   `yaml:"dev_mode"`
+	Port          int      `yaml:"port"`
+	BaseURL       string   `yaml:"base_url"`
+	EncryptionKey string   `yaml:"encryption_key"`
+	DevMode       bool     `yaml:"dev_mode"`
+	AdminEmails   []string `yaml:"admin_emails"`
 }
 
 type IntegrationDef struct {

--- a/internal/server/egress_deny_rules.go
+++ b/internal/server/egress_deny_rules.go
@@ -1,0 +1,156 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/core"
+)
+
+func (s *Server) egressDenyRuleStore() (core.EgressDenyRuleStore, error) {
+	edrs, ok := s.datastore.(core.EgressDenyRuleStore)
+	if !ok {
+		return nil, fmt.Errorf("datastore does not support egress deny rules; use a SQL-backed datastore (sqlite, postgres, mysql, sqlserver, oracle)")
+	}
+	return edrs, nil
+}
+
+type createEgressDenyRuleRequest struct {
+	SubjectKind string `json:"subject_kind"`
+	SubjectID   string `json:"subject_id"`
+	Provider    string `json:"provider"`
+	Operation   string `json:"operation"`
+	Method      string `json:"method"`
+	Host        string `json:"host"`
+	PathPrefix  string `json:"path_prefix"`
+	Description string `json:"description"`
+}
+
+type egressDenyRuleResponse struct {
+	ID          string    `json:"id"`
+	SubjectKind string    `json:"subject_kind,omitempty"`
+	SubjectID   string    `json:"subject_id,omitempty"`
+	Provider    string    `json:"provider,omitempty"`
+	Operation   string    `json:"operation,omitempty"`
+	Method      string    `json:"method,omitempty"`
+	Host        string    `json:"host,omitempty"`
+	PathPrefix  string    `json:"path_prefix,omitempty"`
+	CreatedByID string    `json:"created_by_id"`
+	Description string    `json:"description,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+func egressDenyRuleResponseFromCore(r *core.EgressDenyRule) egressDenyRuleResponse {
+	return egressDenyRuleResponse{
+		ID:          r.ID,
+		SubjectKind: r.SubjectKind,
+		SubjectID:   r.SubjectID,
+		Provider:    r.Provider,
+		Operation:   r.Operation,
+		Method:      r.Method,
+		Host:        r.Host,
+		PathPrefix:  r.PathPrefix,
+		CreatedByID: r.CreatedByID,
+		Description: r.Description,
+		CreatedAt:   r.CreatedAt,
+		UpdatedAt:   r.UpdatedAt,
+	}
+}
+
+func (s *Server) createEgressDenyRule(w http.ResponseWriter, r *http.Request) {
+	userID, ok := s.resolveUserID(w, r)
+	if !ok {
+		return
+	}
+
+	store, err := s.egressDenyRuleStore()
+	if err != nil {
+		writeError(w, http.StatusNotImplemented, err.Error())
+		return
+	}
+
+	var req createEgressDenyRuleRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	if req.SubjectKind == "" && req.SubjectID == "" && req.Provider == "" &&
+		req.Operation == "" && req.Method == "" && req.Host == "" && req.PathPrefix == "" {
+		writeError(w, http.StatusBadRequest, "at least one match criterion is required")
+		return
+	}
+
+	now := s.nowUTCSecond()
+	rule := &core.EgressDenyRule{
+		ID:          uuid.NewString(),
+		SubjectKind: req.SubjectKind,
+		SubjectID:   req.SubjectID,
+		Provider:    req.Provider,
+		Operation:   req.Operation,
+		Method:      req.Method,
+		Host:        req.Host,
+		PathPrefix:  req.PathPrefix,
+		CreatedByID: userID,
+		Description: req.Description,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	if err := store.CreateEgressDenyRule(r.Context(), rule); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create egress deny rule")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, egressDenyRuleResponseFromCore(rule))
+}
+
+func (s *Server) listEgressDenyRules(w http.ResponseWriter, r *http.Request) {
+	store, err := s.egressDenyRuleStore()
+	if err != nil {
+		writeError(w, http.StatusNotImplemented, err.Error())
+		return
+	}
+
+	filter := core.EgressDenyRuleFilter{
+		SubjectKind: r.URL.Query().Get("subject_kind"),
+		Host:        r.URL.Query().Get("host"),
+	}
+
+	rules, err := store.ListEgressDenyRules(r.Context(), filter)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list egress deny rules")
+		return
+	}
+
+	out := make([]egressDenyRuleResponse, 0, len(rules))
+	for _, rule := range rules {
+		out = append(out, egressDenyRuleResponseFromCore(rule))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) deleteEgressDenyRule(w http.ResponseWriter, r *http.Request) {
+	store, err := s.egressDenyRuleStore()
+	if err != nil {
+		writeError(w, http.StatusNotImplemented, err.Error())
+		return
+	}
+
+	id := chi.URLParam(r, "id")
+	if err := store.DeleteEgressDenyRule(r.Context(), id); err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "egress deny rule not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to delete egress deny rule")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -10,6 +10,8 @@ import (
 	"github.com/valon-technologies/gestalt/internal/principal"
 )
 
+const adminForbiddenMessage = "forbidden"
+
 type contextKey string
 
 const (
@@ -92,6 +94,21 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 
 		ctx := principal.WithPrincipal(r.Context(), p)
 		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func (s *Server) adminMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := principal.FromContext(r.Context())
+		if p == nil || p.Identity == nil || p.Identity.Email == "" {
+			writeError(w, http.StatusForbidden, adminForbiddenMessage)
+			return
+		}
+		if _, ok := s.adminEmails[strings.ToLower(p.Identity.Email)]; !ok {
+			writeError(w, http.StatusForbidden, adminForbiddenMessage)
+			return
+		}
+		next.ServeHTTP(w, r)
 	})
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -34,6 +35,7 @@ type Server struct {
 	mcpHandler     http.Handler
 	webUI          http.Handler
 	connectHandler http.Handler // CONNECT dispatched outside chi (authority-form URIs bypass path routing)
+	adminEmails    map[string]struct{}
 }
 
 type Config struct {
@@ -49,6 +51,7 @@ type Config struct {
 	Readiness   ReadinessChecker
 	MCPHandler  http.Handler
 	WebUI       http.Handler
+	AdminEmails []string
 }
 
 func New(cfg Config) (*Server, error) {
@@ -67,21 +70,28 @@ func New(cfg Config) (*Server, error) {
 	if now == nil {
 		now = time.Now
 	}
+
+	adminSet := make(map[string]struct{}, len(cfg.AdminEmails))
+	for _, email := range cfg.AdminEmails {
+		adminSet[strings.ToLower(email)] = struct{}{}
+	}
+
 	s := &Server{
-		router:     chi.NewRouter(),
-		auth:       cfg.Auth,
-		datastore:  cfg.Datastore,
-		providers:  cfg.Providers,
-		runtimes:   cfg.Runtimes,
-		bindings:   cfg.Bindings,
-		resolver:   principal.NewResolver(cfg.Auth, cfg.Datastore, resolverOpts(cfg.Datastore)...),
-		invoker:    cfg.Invoker,
-		devMode:    cfg.DevMode,
-		stateCodec: stateCodec,
-		now:        now,
-		readiness:  cfg.Readiness,
-		mcpHandler: cfg.MCPHandler,
-		webUI:      cfg.WebUI,
+		router:      chi.NewRouter(),
+		auth:        cfg.Auth,
+		datastore:   cfg.Datastore,
+		providers:   cfg.Providers,
+		runtimes:    cfg.Runtimes,
+		bindings:    cfg.Bindings,
+		resolver:    principal.NewResolver(cfg.Auth, cfg.Datastore, resolverOpts(cfg.Datastore)...),
+		invoker:     cfg.Invoker,
+		devMode:     cfg.DevMode,
+		stateCodec:  stateCodec,
+		now:         now,
+		readiness:   cfg.Readiness,
+		mcpHandler:  cfg.MCPHandler,
+		webUI:       cfg.WebUI,
+		adminEmails: adminSet,
 	}
 
 	s.routes()
@@ -118,6 +128,14 @@ func (s *Server) routes() {
 		r.Get("/auth/callback", s.integrationOAuthCallback)
 
 		s.mountBindingRoutes(r)
+
+		r.Group(func(r chi.Router) {
+			r.Use(s.authMiddleware)
+			r.Use(s.adminMiddleware)
+			r.Post("/egress/deny-rules", s.createEgressDenyRule)
+			r.Get("/egress/deny-rules", s.listEgressDenyRules)
+			r.Delete("/egress/deny-rules/{id}", s.deleteEgressDenyRule)
+		})
 
 		r.Group(func(r chi.Router) {
 			r.Use(s.authMiddleware)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4699,3 +4699,181 @@ func TestExecuteOperation_ConnectionModeEither(t *testing.T) {
 		}
 	})
 }
+
+func TestAdminDenyRules_CRUD(t *testing.T) {
+	t.Parallel()
+
+	const adminEmail = "admin@example.com"
+	var storedRules []*core.EgressDenyRule
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.AdminEmails = []string{adminEmail}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u-admin", Email: email}, nil
+			},
+			CreateEgressDenyRuleFn: func(_ context.Context, rule *core.EgressDenyRule) error {
+				storedRules = append(storedRules, rule)
+				return nil
+			},
+			ListEgressDenyRulesFn: func(_ context.Context, _ core.EgressDenyRuleFilter) ([]*core.EgressDenyRule, error) {
+				return storedRules, nil
+			},
+			DeleteEgressDenyRuleFn: func(_ context.Context, id string) error {
+				for i, r := range storedRules {
+					if r.ID == id {
+						storedRules = append(storedRules[:i], storedRules[i+1:]...)
+						return nil
+					}
+				}
+				return core.ErrNotFound
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"host":"blocked.test","description":"test deny"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/egress/deny-rules", body)
+	req.Header.Set("X-Dev-User-Email", adminEmail)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: expected 201, got %d: %s", resp.StatusCode, respBody)
+	}
+
+	var created map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	ruleID, _ := created["id"].(string)
+	if ruleID == "" {
+		t.Fatal("expected id in create response")
+	}
+	if created["host"] != "blocked.test" {
+		t.Fatalf("expected host blocked.test, got %v", created["host"])
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/egress/deny-rules", nil)
+	req.Header.Set("X-Dev-User-Email", adminEmail)
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("list request: %v", err)
+	}
+	defer func() { _ = resp2.Body.Close() }()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d", resp2.StatusCode)
+	}
+
+	var listed []map[string]any
+	if err := json.NewDecoder(resp2.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(listed))
+	}
+
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/egress/deny-rules/"+ruleID, nil)
+	req.Header.Set("X-Dev-User-Email", adminEmail)
+	resp3, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("delete request: %v", err)
+	}
+	defer func() { _ = resp3.Body.Close() }()
+	if resp3.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp3.Body)
+		t.Fatalf("delete: expected 200, got %d: %s", resp3.StatusCode, respBody)
+	}
+}
+
+func TestAdminDenyRules_NonAdminForbidden(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.AdminEmails = []string{"admin@example.com"}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"host":"blocked.test"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/egress/deny-rules", body)
+	req.Header.Set("X-Dev-User-Email", "nonadmin@example.com")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-admin, got %d", resp.StatusCode)
+	}
+}
+
+func TestAdminDenyRules_UnauthenticatedForbidden(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.AdminEmails = []string{"admin@example.com"}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"host":"blocked.test"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/egress/deny-rules", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 401 for unauthenticated, got %d: %s", resp.StatusCode, respBody)
+	}
+}
+
+func TestAdminDenyRules_RequiresMatchCriterion(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.AdminEmails = []string{"admin@example.com"}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"description":"empty match"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/egress/deny-rules", body)
+	req.Header.Set("X-Dev-User-Email", "admin@example.com")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty match criteria, got %d", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `admin_emails` config field and email-based admin middleware that gates admin-only API routes
- Add CRUD handlers for egress deny rules: POST/GET/DELETE at `/api/v1/egress/deny-rules`
- Validate at least one match criterion on create to prevent accidental deny-all rules
- Wire `AdminEmails` from config through to server in `cmd/gestaltd/run.go`

Stacked on #179.

## Test plan
- [x] Admin can create, list, and delete deny rules
- [x] Non-admin human gets 403
- [x] Unauthenticated request gets 401
- [x] Empty match criteria rejected with 400
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)