### PR TITLE
fix: include runtime config schema in DirectoryDigest

### DIFF
--- a/internal/pluginpkg/digest.go
+++ b/internal/pluginpkg/digest.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -43,6 +44,15 @@ func DirectoryDigest(dirPath string, manifest *pluginmanifestv1.Manifest) (strin
 		sum, err := fileSHA256(filepath.Join(dirPath, filepath.FromSlash(manifest.Provider.ConfigSchemaPath)))
 		if err != nil {
 			return "", fmt.Errorf("digest provider config schema: %w", err)
+		}
+		digests = append(digests, sum)
+	}
+
+	runtimeSchema := filepath.Join(dirPath, filepath.FromSlash(runtimeConfigSchemaPath))
+	if _, err := os.Stat(runtimeSchema); err == nil {
+		sum, err := fileSHA256(runtimeSchema)
+		if err != nil {
+			return "", fmt.Errorf("digest runtime config schema: %w", err)
 		}
 		digests = append(digests, sum)
 	}


### PR DESCRIPTION
## Summary
- `DirectoryDigest` only hashed provider config schemas (`manifest.Provider.ConfigSchemaPath`), but `InstallFromDir` also copies runtime config schemas (`schemas/config.schema.json`). When a runtime plugin's config schema changed on disk, the digest remained the same, so the lockfile was considered valid and `gestaltd` wouldn't auto-reinit with the updated schema.
- Adds an `os.Stat` check for the runtime config schema file (mirroring `configSchemaPaths` in `store.go`) and includes its SHA256 in the composite digest when present.

## Test plan
- [ ] Existing `pluginpkg` tests pass (`go test ./internal/pluginpkg/`)
- [ ] Modify a runtime plugin's `schemas/config.schema.json` and verify `gestaltd init` detects the change and re-installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)