### PR TITLE
Fix docs build by removing dangling sidebar references

### DIFF
--- a/docs/pages/tasks/_meta.ts
+++ b/docs/pages/tasks/_meta.ts
@@ -2,8 +2,6 @@ export default {
   "run-locally": "Run Locally",
   "add-an-integration": "Add an Integration",
   "add-a-first-party-provider": "Add a First-Party Provider",
-  "configure-jira": "Configure Jira",
-  "configure-bigquery": "Configure BigQuery",
   "use-a-plugin-package": "Use a Plugin Package",
   "use-with-mcp": "Use with MCP",
 };


### PR DESCRIPTION
The `_meta.ts` sidebar config for the tasks section referenced
`configure-jira` and `configure-bigquery` pages that were deleted in
an earlier PR but accidentally re-introduced in #175. Nextra validates
all sidebar entries during static export, so the build fails when the
referenced pages do not exist.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>