### PR TITLE
feat: add persisted egress credential grants

### DIFF
--- a/core/datastore.go
+++ b/core/datastore.go
@@ -56,3 +56,14 @@ type EgressDenyRuleStore interface {
 	ListEgressDenyRules(ctx context.Context, filter EgressDenyRuleFilter) ([]*EgressDenyRule, error)
 	DeleteEgressDenyRule(ctx context.Context, id string) error
 }
+
+type EgressCredentialGrantFilter struct {
+	Provider string
+}
+
+type EgressCredentialGrantStore interface {
+	CreateEgressCredentialGrant(ctx context.Context, grant *EgressCredentialGrant) error
+	GetEgressCredentialGrant(ctx context.Context, id string) (*EgressCredentialGrant, error)
+	ListEgressCredentialGrants(ctx context.Context, filter EgressCredentialGrantFilter) ([]*EgressCredentialGrant, error)
+	DeleteEgressCredentialGrant(ctx context.Context, id string) error
+}

--- a/core/testing/datastore_suite.go
+++ b/core/testing/datastore_suite.go
@@ -36,6 +36,9 @@ func RunDatastoreTests(t *testing.T, newStore func(t *testing.T) core.Datastore)
 	t.Run("EgressDenyRules", func(t *testing.T) {
 		testDatastoreEgressDenyRules(t, newStore)
 	})
+	t.Run("EgressCredentialGrants", func(t *testing.T) {
+		testDatastoreEgressCredentialGrants(t, newStore)
+	})
 }
 
 func mustCreateUser(t *testing.T, ctx context.Context, ds core.Datastore, email string) *core.User {
@@ -1012,6 +1015,140 @@ func testDatastoreEgressDenyRules(t *testing.T, newStore func(t *testing.T) core
 
 		ctx := context.Background()
 		err := edrs.DeleteEgressDenyRule(ctx, "nonexistent-id")
+		if !errors.Is(err, core.ErrNotFound) {
+			t.Fatalf("expected ErrNotFound, got %v", err)
+		}
+	})
+}
+
+func testDatastoreEgressCredentialGrants(t *testing.T, newStore func(t *testing.T) core.Datastore) {
+	t.Run("create get list and delete lifecycle", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecgs, ok := ds.(core.EgressCredentialGrantStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressCredentialGrantStore")
+		}
+
+		ctx := context.Background()
+		user := mustCreateUser(t, ctx, ds, "grant-admin@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		grant := &core.EgressCredentialGrant{
+			ID:          "ecg-1",
+			Provider:    "acme",
+			Instance:    "acme-prod",
+			SubjectKind: "agent",
+			Host:        "api.acme.test",
+			CreatedByID: user.ID,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		if err := ecgs.CreateEgressCredentialGrant(ctx, grant); err != nil {
+			t.Fatalf("CreateEgressCredentialGrant: %v", err)
+		}
+
+		got, err := ecgs.GetEgressCredentialGrant(ctx, "ecg-1")
+		if err != nil {
+			t.Fatalf("GetEgressCredentialGrant: %v", err)
+		}
+		if got.Provider != "acme" {
+			t.Errorf("Provider: got %q, want %q", got.Provider, "acme")
+		}
+		if got.Instance != "acme-prod" {
+			t.Errorf("Instance: got %q, want %q", got.Instance, "acme-prod")
+		}
+		if got.SubjectKind != "agent" {
+			t.Errorf("SubjectKind: got %q, want %q", got.SubjectKind, "agent")
+		}
+		if got.Host != "api.acme.test" {
+			t.Errorf("Host: got %q, want %q", got.Host, "api.acme.test")
+		}
+		if got.CreatedByID != user.ID {
+			t.Errorf("CreatedByID: got %q, want %q", got.CreatedByID, user.ID)
+		}
+
+		grants, err := ecgs.ListEgressCredentialGrants(ctx, core.EgressCredentialGrantFilter{})
+		if err != nil {
+			t.Fatalf("ListEgressCredentialGrants (unfiltered): %v", err)
+		}
+		if len(grants) != 1 {
+			t.Fatalf("ListEgressCredentialGrants: got %d, want 1", len(grants))
+		}
+
+		if err := ecgs.DeleteEgressCredentialGrant(ctx, "ecg-1"); err != nil {
+			t.Fatalf("DeleteEgressCredentialGrant: %v", err)
+		}
+
+		_, err = ecgs.GetEgressCredentialGrant(ctx, "ecg-1")
+		if !errors.Is(err, core.ErrNotFound) {
+			t.Fatalf("GetEgressCredentialGrant after delete: expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("list filters by provider", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecgs, ok := ds.(core.EgressCredentialGrantStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressCredentialGrantStore")
+		}
+
+		ctx := context.Background()
+		user := mustCreateUser(t, ctx, ds, "grant-filter@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		if err := ecgs.CreateEgressCredentialGrant(ctx, &core.EgressCredentialGrant{
+			ID: "ecg-a", Provider: "acme", Host: "alpha.test",
+			CreatedByID: user.ID, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressCredentialGrant a: %v", err)
+		}
+		if err := ecgs.CreateEgressCredentialGrant(ctx, &core.EgressCredentialGrant{
+			ID: "ecg-b", Provider: "globex", Host: "beta.test",
+			CreatedByID: user.ID, CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second),
+		}); err != nil {
+			t.Fatalf("CreateEgressCredentialGrant b: %v", err)
+		}
+
+		byProvider, err := ecgs.ListEgressCredentialGrants(ctx, core.EgressCredentialGrantFilter{Provider: "acme"})
+		if err != nil {
+			t.Fatalf("ListEgressCredentialGrants by provider: %v", err)
+		}
+		if len(byProvider) != 1 || byProvider[0].ID != "ecg-a" {
+			t.Fatalf("filter by provider: got %d grants, want 1 (ecg-a)", len(byProvider))
+		}
+	})
+
+	t.Run("get nonexistent returns ErrNotFound", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecgs, ok := ds.(core.EgressCredentialGrantStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressCredentialGrantStore")
+		}
+
+		ctx := context.Background()
+		_, err := ecgs.GetEgressCredentialGrant(ctx, "nonexistent-id")
+		if !errors.Is(err, core.ErrNotFound) {
+			t.Fatalf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("delete nonexistent returns ErrNotFound", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecgs, ok := ds.(core.EgressCredentialGrantStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressCredentialGrantStore")
+		}
+
+		ctx := context.Background()
+		err := ecgs.DeleteEgressCredentialGrant(ctx, "nonexistent-id")
 		if !errors.Is(err, core.ErrNotFound) {
 			t.Fatalf("expected ErrNotFound, got %v", err)
 		}

--- a/core/testing/stubs.go
+++ b/core/testing/stubs.go
@@ -21,34 +21,39 @@ func (s *StubSecretManager) GetSecret(_ context.Context, name string) (string, e
 var _ core.StagedConnectionStore = (*StubDatastore)(nil)
 var _ core.EgressClientStore = (*StubDatastore)(nil)
 var _ core.EgressDenyRuleStore = (*StubDatastore)(nil)
+var _ core.EgressCredentialGrantStore = (*StubDatastore)(nil)
 
 // Set Fn fields to override individual methods; nil fields return zero values.
 type StubDatastore struct {
-	PingFn                      func(context.Context) error
-	GetUserFn                   func(context.Context, string) (*core.User, error)
-	FindOrCreateUserFn          func(context.Context, string) (*core.User, error)
-	StoreTokenFn                func(context.Context, *core.IntegrationToken) error
-	TokenFn                     func(context.Context, string, string, string) (*core.IntegrationToken, error)
-	ListTokensFn                func(context.Context, string) ([]*core.IntegrationToken, error)
-	ListTokensForIntegrationFn  func(context.Context, string, string) ([]*core.IntegrationToken, error)
-	DeleteTokenFn               func(context.Context, string) error
-	ValidateAPITokenFn          func(context.Context, string) (*core.APIToken, error)
-	RevokeAPITokenFn            func(context.Context, string, string) error
-	StoreStagedConnectionFn     func(context.Context, *core.StagedConnection) error
-	GetStagedConnectionFn       func(context.Context, string) (*core.StagedConnection, error)
-	DeleteStagedConnectionFn    func(context.Context, string) error
-	CreateEgressClientFn        func(context.Context, *core.EgressClient) error
-	GetEgressClientFn           func(context.Context, string) (*core.EgressClient, error)
-	ListEgressClientsFn         func(context.Context, core.EgressClientFilter) ([]*core.EgressClient, error)
-	DeleteEgressClientFn        func(context.Context, string) error
-	CreateEgressClientTokenFn   func(context.Context, *core.EgressClientToken) error
-	ValidateEgressClientTokenFn func(context.Context, string) (*core.EgressClientToken, error)
-	ListEgressClientTokensFn    func(context.Context, string) ([]*core.EgressClientToken, error)
-	RevokeEgressClientTokenFn   func(context.Context, string, string) error
-	CreateEgressDenyRuleFn      func(context.Context, *core.EgressDenyRule) error
-	GetEgressDenyRuleFn         func(context.Context, string) (*core.EgressDenyRule, error)
-	ListEgressDenyRulesFn       func(context.Context, core.EgressDenyRuleFilter) ([]*core.EgressDenyRule, error)
-	DeleteEgressDenyRuleFn      func(context.Context, string) error
+	PingFn                        func(context.Context) error
+	GetUserFn                     func(context.Context, string) (*core.User, error)
+	FindOrCreateUserFn            func(context.Context, string) (*core.User, error)
+	StoreTokenFn                  func(context.Context, *core.IntegrationToken) error
+	TokenFn                       func(context.Context, string, string, string) (*core.IntegrationToken, error)
+	ListTokensFn                  func(context.Context, string) ([]*core.IntegrationToken, error)
+	ListTokensForIntegrationFn    func(context.Context, string, string) ([]*core.IntegrationToken, error)
+	DeleteTokenFn                 func(context.Context, string) error
+	ValidateAPITokenFn            func(context.Context, string) (*core.APIToken, error)
+	RevokeAPITokenFn              func(context.Context, string, string) error
+	StoreStagedConnectionFn       func(context.Context, *core.StagedConnection) error
+	GetStagedConnectionFn         func(context.Context, string) (*core.StagedConnection, error)
+	DeleteStagedConnectionFn      func(context.Context, string) error
+	CreateEgressClientFn          func(context.Context, *core.EgressClient) error
+	GetEgressClientFn             func(context.Context, string) (*core.EgressClient, error)
+	ListEgressClientsFn           func(context.Context, core.EgressClientFilter) ([]*core.EgressClient, error)
+	DeleteEgressClientFn          func(context.Context, string) error
+	CreateEgressClientTokenFn     func(context.Context, *core.EgressClientToken) error
+	ValidateEgressClientTokenFn   func(context.Context, string) (*core.EgressClientToken, error)
+	ListEgressClientTokensFn      func(context.Context, string) ([]*core.EgressClientToken, error)
+	RevokeEgressClientTokenFn     func(context.Context, string, string) error
+	CreateEgressDenyRuleFn        func(context.Context, *core.EgressDenyRule) error
+	GetEgressDenyRuleFn           func(context.Context, string) (*core.EgressDenyRule, error)
+	ListEgressDenyRulesFn         func(context.Context, core.EgressDenyRuleFilter) ([]*core.EgressDenyRule, error)
+	DeleteEgressDenyRuleFn        func(context.Context, string) error
+	CreateEgressCredentialGrantFn func(context.Context, *core.EgressCredentialGrant) error
+	GetEgressCredentialGrantFn    func(context.Context, string) (*core.EgressCredentialGrant, error)
+	ListEgressCredentialGrantsFn  func(context.Context, core.EgressCredentialGrantFilter) ([]*core.EgressCredentialGrant, error)
+	DeleteEgressCredentialGrantFn func(context.Context, string) error
 }
 
 func (s *StubDatastore) Ping(ctx context.Context) error {
@@ -217,6 +222,30 @@ func (s *StubDatastore) ListEgressDenyRules(ctx context.Context, filter core.Egr
 func (s *StubDatastore) DeleteEgressDenyRule(ctx context.Context, id string) error {
 	if s.DeleteEgressDenyRuleFn != nil {
 		return s.DeleteEgressDenyRuleFn(ctx, id)
+	}
+	return nil
+}
+func (s *StubDatastore) CreateEgressCredentialGrant(ctx context.Context, grant *core.EgressCredentialGrant) error {
+	if s.CreateEgressCredentialGrantFn != nil {
+		return s.CreateEgressCredentialGrantFn(ctx, grant)
+	}
+	return nil
+}
+func (s *StubDatastore) GetEgressCredentialGrant(ctx context.Context, id string) (*core.EgressCredentialGrant, error) {
+	if s.GetEgressCredentialGrantFn != nil {
+		return s.GetEgressCredentialGrantFn(ctx, id)
+	}
+	return nil, core.ErrNotFound
+}
+func (s *StubDatastore) ListEgressCredentialGrants(ctx context.Context, filter core.EgressCredentialGrantFilter) ([]*core.EgressCredentialGrant, error) {
+	if s.ListEgressCredentialGrantsFn != nil {
+		return s.ListEgressCredentialGrantsFn(ctx, filter)
+	}
+	return nil, nil
+}
+func (s *StubDatastore) DeleteEgressCredentialGrant(ctx context.Context, id string) error {
+	if s.DeleteEgressCredentialGrantFn != nil {
+		return s.DeleteEgressCredentialGrantFn(ctx, id)
 	}
 	return nil
 }

--- a/core/types.go
+++ b/core/types.go
@@ -122,3 +122,20 @@ type EgressDenyRule struct {
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 }
+
+type EgressCredentialGrant struct {
+	ID          string
+	Provider    string
+	Instance    string
+	SecretRef   string
+	AuthStyle   string
+	SubjectKind string
+	SubjectID   string
+	Operation   string
+	Method      string
+	Host        string
+	PathPrefix  string
+	CreatedByID string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -142,7 +142,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	}()
 
 	sharedInvoker := invocation.NewBroker(providers, ds)
-	wireCredentialResolver(&deps.Egress, sharedInvoker, providers)
+	wireCredentialResolver(&deps.Egress, sharedInvoker, providers, ds)
 	audit := core.AuditSink(invocation.LogAuditSink{})
 
 	runtimes, err := buildRuntimes(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress)

--- a/internal/bootstrap/egress.go
+++ b/internal/bootstrap/egress.go
@@ -68,7 +68,7 @@ func (a *denyRuleStoreAdapter) LoadDenyRules(ctx context.Context) ([]egress.Deny
 	return out, nil
 }
 
-func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, providers *registry.PluginMap[core.Provider]) {
+func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, providers *registry.PluginMap[core.Provider], ds core.Datastore) {
 	var sources []egress.CredentialResolver
 
 	if len(deps.CredentialGrants) > 0 {
@@ -95,6 +95,14 @@ func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, provide
 		})
 	}
 
+	if grantStore, ok := ds.(core.EgressCredentialGrantStore); ok {
+		sources = append(sources, &egress.SavedGrantCredentialResolver{
+			Store:         &credentialGrantStoreAdapter{store: grantStore},
+			TokenResolver: &brokerTokenResolver{broker: broker},
+			Materializer:  &registryMaterializer{providers: providers},
+		})
+	}
+
 	switch len(sources) {
 	case 0:
 		return
@@ -103,6 +111,33 @@ func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, provide
 	default:
 		deps.Resolver.Credentials = &egress.CredentialSourceChain{Sources: sources}
 	}
+}
+
+type credentialGrantStoreAdapter struct {
+	store core.EgressCredentialGrantStore
+}
+
+func (a *credentialGrantStoreAdapter) ListCandidateCredentialGrants(ctx context.Context, _ egress.Subject, _ egress.Target) ([]egress.CredentialGrant, error) {
+	grants, err := a.store.ListEgressCredentialGrants(ctx, core.EgressCredentialGrantFilter{})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]egress.CredentialGrant, len(grants))
+	for i, g := range grants {
+		out[i] = egress.CredentialGrant{
+			Instance: g.Instance,
+			MatchCriteria: egress.MatchCriteria{
+				SubjectKind: egress.SubjectKind(g.SubjectKind),
+				SubjectID:   g.SubjectID,
+				Provider:    g.Provider,
+				Operation:   g.Operation,
+				Method:      g.Method,
+				Host:        g.Host,
+				PathPrefix:  g.PathPrefix,
+			},
+		}
+	}
+	return out, nil
 }
 
 type brokerTokenResolver struct {

--- a/internal/bootstrap/regression_test.go
+++ b/internal/bootstrap/regression_test.go
@@ -315,3 +315,77 @@ func TestEgressCredentialGrantWiredThroughBootstrap(t *testing.T) {
 		t.Fatal("expected credential resolver to be wired when grants are configured")
 	}
 }
+
+func TestSavedCredentialGrantResolvesThroughBootstrap(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cfg := validConfig()
+	cfg.Bindings = map[string]config.BindingDef{
+		"my-binding": {
+			Type:      "test-binding",
+			Providers: []string{"alpha"},
+		},
+	}
+
+	factories := validFactories()
+
+	const tokenValue = "tok-saved-grant"
+	factories.Providers["alpha"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
+		return &stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "alpha"},
+			ops:             []core.Operation{{Name: "do", Method: "POST"}},
+		}, nil
+	}
+
+	savedGrants := []*core.EgressCredentialGrant{
+		{
+			ID:       "ecg-saved-1",
+			Provider: "alpha",
+			Host:     "api.saved.test",
+		},
+	}
+	factories.Datastores["test-store"] = func(_ yaml.Node, _ bootstrap.Deps) (core.Datastore, error) {
+		return &coretesting.StubDatastore{
+			ListEgressCredentialGrantsFn: func(_ context.Context, _ core.EgressCredentialGrantFilter) ([]*core.EgressCredentialGrant, error) {
+				return savedGrants, nil
+			},
+			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+				return &core.IntegrationToken{AccessToken: tokenValue}, nil
+			},
+		}, nil
+	}
+
+	var receivedEgress bootstrap.EgressDeps
+	factories.Bindings["test-binding"] = func(_ context.Context, name string, _ config.BindingDef, deps bootstrap.BindingDeps) (core.Binding, error) {
+		receivedEgress = deps.Egress
+		return &coretesting.StubBinding{N: name}, nil
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	if receivedEgress.Resolver == nil {
+		t.Fatal("expected egress resolver to be wired")
+	}
+	if receivedEgress.Resolver.Credentials == nil {
+		t.Fatal("expected credential resolver to be wired for DB-backed grant store")
+	}
+
+	userCtx := egress.WithSubject(ctx, egress.Subject{Kind: egress.SubjectUser, ID: "user-123"})
+	resolution, err := receivedEgress.Resolver.Resolve(userCtx, egress.ResolutionInput{
+		Target: egress.Target{Provider: "alpha", Method: "GET", Host: "api.saved.test", Path: "/data"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if resolution.Credential.Authorization == "" {
+		t.Fatal("expected saved DB grant to produce a credential, got empty authorization")
+	}
+	if !strings.Contains(resolution.Credential.Authorization, tokenValue) {
+		t.Errorf("expected authorization to contain %q, got %q", tokenValue, resolution.Credential.Authorization)
+	}
+}

--- a/internal/bootstrap/validate.go
+++ b/internal/bootstrap/validate.go
@@ -60,7 +60,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 	defer func() { _ = CloseProviders(providers) }()
 
 	sharedInvoker := invocation.NewBroker(providers, ds)
-	wireCredentialResolver(&deps.Egress, sharedInvoker, providers)
+	wireCredentialResolver(&deps.Egress, sharedInvoker, providers, ds)
 	audit := core.AuditSink(invocation.LogAuditSink{})
 
 	runtimes, err := buildRuntimesWith(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress, buildRuntimeForValidation)

--- a/internal/egress/provider_credentials.go
+++ b/internal/egress/provider_credentials.go
@@ -22,6 +22,24 @@ type CredentialGrant struct {
 	MatchCriteria
 }
 
+func (g *CredentialGrant) ResolveProvider(target Target) (provider, instance string, ok bool) {
+	p := g.Provider
+	if p == "" {
+		p = target.Provider
+	}
+	if p == "" {
+		return "", "", false
+	}
+	inst := g.Instance
+	if inst == "" {
+		inst = target.Instance
+	}
+	if inst == "" {
+		inst = p
+	}
+	return p, inst, true
+}
+
 type ProviderCredentialResolver struct {
 	TokenResolver ProviderTokenResolver
 	Materializer  CredentialMaterializer
@@ -59,19 +77,9 @@ func (r *ProviderCredentialResolver) matchGrant(subject Subject, target Target) 
 		if !g.Matches(subject, target) {
 			continue
 		}
-		p := g.Provider
-		if p == "" {
-			p = target.Provider
-		}
-		if p == "" {
+		p, inst, ok := g.ResolveProvider(target)
+		if !ok {
 			continue
-		}
-		inst := g.Instance
-		if inst == "" {
-			inst = target.Instance
-		}
-		if inst == "" {
-			inst = p
 		}
 		return p, inst, true
 	}

--- a/internal/egress/saved_credential_resolver.go
+++ b/internal/egress/saved_credential_resolver.go
@@ -1,0 +1,55 @@
+package egress
+
+import (
+	"context"
+	"fmt"
+)
+
+type SavedCredentialGrantLoader interface {
+	ListCandidateCredentialGrants(ctx context.Context, subject Subject, target Target) ([]CredentialGrant, error)
+}
+
+type SavedGrantCredentialResolver struct {
+	Store         SavedCredentialGrantLoader
+	TokenResolver ProviderTokenResolver
+	Materializer  CredentialMaterializer
+}
+
+func (r *SavedGrantCredentialResolver) ResolveCredential(ctx context.Context, subject Subject, target Target) (CredentialMaterialization, error) {
+	candidates, err := r.Store.ListCandidateCredentialGrants(ctx, subject, target)
+	if err != nil {
+		return CredentialMaterialization{}, fmt.Errorf("egress saved grants: loading candidates: %w", err)
+	}
+
+	for i := range candidates {
+		g := &candidates[i]
+		if !g.Matches(subject, target) {
+			continue
+		}
+
+		provider, instance, ok := g.ResolveProvider(target)
+		if !ok {
+			continue
+		}
+
+		if _, canResolve := PrincipalForSubject(subject); !canResolve {
+			return CredentialMaterialization{}, nil
+		}
+
+		if r.TokenResolver == nil {
+			return CredentialMaterialization{}, fmt.Errorf("egress saved grants: no token resolver configured")
+		}
+
+		token, err := r.TokenResolver.ResolveProviderToken(ctx, subject, provider, instance)
+		if err != nil {
+			return CredentialMaterialization{}, fmt.Errorf("egress saved grants: resolving token for %q: %w", provider, err)
+		}
+
+		if r.Materializer == nil {
+			return MaterializeCredential(token, AuthStyleBearer, nil)
+		}
+		return r.Materializer.MaterializeProviderCredential(provider, token)
+	}
+
+	return CredentialMaterialization{}, nil
+}

--- a/plugins/datastore/mysql/mysql.go
+++ b/plugins/datastore/mysql/mysql.go
@@ -48,6 +48,7 @@ var _ core.Datastore = (*Store)(nil)
 var _ core.StagedConnectionStore = (*Store)(nil)
 var _ core.EgressClientStore = (*Store)(nil)
 var _ core.EgressDenyRuleStore = (*Store)(nil)
+var _ core.EgressCredentialGrantStore = (*Store)(nil)
 
 func New(dsn string, encryptionKey []byte) (*Store, error) {
 	cfg, err := mysqldriver.ParseDSN(dsn)
@@ -162,6 +163,24 @@ func (s *Store) Migrate(ctx context.Context) error {
 			created_at DATETIME(6) NOT NULL,
 			updated_at DATETIME(6) NOT NULL,
 			CONSTRAINT fk_egress_deny_rules_user FOREIGN KEY (created_by_id) REFERENCES users(id)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`,
+
+		`CREATE TABLE IF NOT EXISTS egress_credential_grants (
+			id VARCHAR(36) NOT NULL PRIMARY KEY,
+			provider VARCHAR(255) NOT NULL DEFAULT '',
+			instance VARCHAR(255) NOT NULL DEFAULT '',
+			secret_ref VARCHAR(255) NOT NULL DEFAULT '',
+			auth_style VARCHAR(255) NOT NULL DEFAULT '',
+			subject_kind VARCHAR(255) NOT NULL DEFAULT '',
+			subject_id VARCHAR(255) NOT NULL DEFAULT '',
+			operation VARCHAR(255) NOT NULL DEFAULT '',
+			method VARCHAR(255) NOT NULL DEFAULT '',
+			host VARCHAR(255) NOT NULL DEFAULT '',
+			path_prefix VARCHAR(255) NOT NULL DEFAULT '',
+			created_by_id VARCHAR(36) NOT NULL,
+			created_at DATETIME(6) NOT NULL,
+			updated_at DATETIME(6) NOT NULL,
+			CONSTRAINT fk_egress_cred_grants_user FOREIGN KEY (created_by_id) REFERENCES users(id)
 		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`,
 	}
 

--- a/plugins/datastore/oracle/oracle.go
+++ b/plugins/datastore/oracle/oracle.go
@@ -81,6 +81,7 @@ var _ core.Datastore = (*Store)(nil)
 var _ core.StagedConnectionStore = (*Store)(nil)
 var _ core.EgressClientStore = (*Store)(nil)
 var _ core.EgressDenyRuleStore = (*Store)(nil)
+var _ core.EgressCredentialGrantStore = (*Store)(nil)
 
 func New(dsn string, encryptionKey []byte) (*Store, error) {
 	s, err := sqlstore.Open("oracle", dsn, encryptionKey, dialect{})
@@ -192,6 +193,25 @@ func (s *Store) Migrate(ctx context.Context) error {
 				updated_at TIMESTAMP WITH TIME ZONE NOT NULL
 			)`,
 		},
+		{
+			name: "EGRESS_CREDENTIAL_GRANTS",
+			ddl: `CREATE TABLE egress_credential_grants (
+				id VARCHAR2(36) PRIMARY KEY,
+				provider VARCHAR2(255) DEFAULT '' NOT NULL,
+				instance VARCHAR2(255) DEFAULT '' NOT NULL,
+				secret_ref VARCHAR2(255) DEFAULT '' NOT NULL,
+				auth_style VARCHAR2(255) DEFAULT '' NOT NULL,
+				subject_kind VARCHAR2(255) DEFAULT '' NOT NULL,
+				subject_id VARCHAR2(255) DEFAULT '' NOT NULL,
+				operation VARCHAR2(255) DEFAULT '' NOT NULL,
+				method VARCHAR2(255) DEFAULT '' NOT NULL,
+				host VARCHAR2(255) DEFAULT '' NOT NULL,
+				path_prefix VARCHAR2(255) DEFAULT '' NOT NULL,
+				created_by_id VARCHAR2(36) NOT NULL,
+				created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+				updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+			)`,
+		},
 	}
 
 	for _, tbl := range tables {
@@ -253,6 +273,10 @@ func (s *Store) Migrate(ctx context.Context) error {
 		{
 			name: "FK_EDR_USER",
 			ddl:  "ALTER TABLE egress_deny_rules ADD CONSTRAINT fk_edr_user FOREIGN KEY (created_by_id) REFERENCES users(id)",
+		},
+		{
+			name: "FK_ECG_USER",
+			ddl:  "ALTER TABLE egress_credential_grants ADD CONSTRAINT fk_ecg_user FOREIGN KEY (created_by_id) REFERENCES users(id)",
 		},
 	}
 

--- a/plugins/datastore/postgres/postgres.go
+++ b/plugins/datastore/postgres/postgres.go
@@ -65,6 +65,7 @@ var _ core.Datastore = (*Store)(nil)
 var _ core.StagedConnectionStore = (*Store)(nil)
 var _ core.EgressClientStore = (*Store)(nil)
 var _ core.EgressDenyRuleStore = (*Store)(nil)
+var _ core.EgressCredentialGrantStore = (*Store)(nil)
 
 func New(dsn string, encryptionKey []byte) (*Store, error) {
 	s, err := sqlstore.Open("pgx", dsn, encryptionKey, dialect{})
@@ -179,6 +180,25 @@ func (s *Store) Migrate(ctx context.Context) error {
 			updated_at TIMESTAMPTZ NOT NULL
 		)`); err != nil {
 		return fmt.Errorf("creating egress_deny_rules table: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS egress_credential_grants (
+			id TEXT PRIMARY KEY,
+			provider TEXT NOT NULL DEFAULT '',
+			instance TEXT NOT NULL DEFAULT '',
+			secret_ref TEXT NOT NULL DEFAULT '',
+			auth_style TEXT NOT NULL DEFAULT '',
+			subject_kind TEXT NOT NULL DEFAULT '',
+			subject_id TEXT NOT NULL DEFAULT '',
+			operation TEXT NOT NULL DEFAULT '',
+			method TEXT NOT NULL DEFAULT '',
+			host TEXT NOT NULL DEFAULT '',
+			path_prefix TEXT NOT NULL DEFAULT '',
+			created_by_id TEXT NOT NULL REFERENCES users(id),
+			created_at TIMESTAMPTZ NOT NULL,
+			updated_at TIMESTAMPTZ NOT NULL
+		)`); err != nil {
+		return fmt.Errorf("creating egress_credential_grants table: %w", err)
 	}
 	return tx.Commit()
 }

--- a/plugins/datastore/sqlite/sqlite.go
+++ b/plugins/datastore/sqlite/sqlite.go
@@ -52,6 +52,7 @@ var _ core.Datastore = (*Store)(nil)
 var _ core.StagedConnectionStore = (*Store)(nil)
 var _ core.EgressClientStore = (*Store)(nil)
 var _ core.EgressDenyRuleStore = (*Store)(nil)
+var _ core.EgressCredentialGrantStore = (*Store)(nil)
 
 func New(dbPath string, encryptionKey []byte) (*Store, error) {
 	dsn := dbPath + "?_pragma=journal_mode(wal)&_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)"
@@ -147,6 +148,22 @@ func (s *Store) Migrate(ctx context.Context) error {
 			path_prefix TEXT NOT NULL DEFAULT '',
 			created_by_id TEXT NOT NULL REFERENCES users(id),
 			description TEXT NOT NULL DEFAULT '',
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS egress_credential_grants (
+			id TEXT PRIMARY KEY,
+			provider TEXT NOT NULL DEFAULT '',
+			instance TEXT NOT NULL DEFAULT '',
+			secret_ref TEXT NOT NULL DEFAULT '',
+			auth_style TEXT NOT NULL DEFAULT '',
+			subject_kind TEXT NOT NULL DEFAULT '',
+			subject_id TEXT NOT NULL DEFAULT '',
+			operation TEXT NOT NULL DEFAULT '',
+			method TEXT NOT NULL DEFAULT '',
+			host TEXT NOT NULL DEFAULT '',
+			path_prefix TEXT NOT NULL DEFAULT '',
+			created_by_id TEXT NOT NULL REFERENCES users(id),
 			created_at DATETIME NOT NULL,
 			updated_at DATETIME NOT NULL
 		)

--- a/plugins/datastore/sqlserver/sqlserver.go
+++ b/plugins/datastore/sqlserver/sqlserver.go
@@ -80,6 +80,7 @@ var _ core.Datastore = (*Store)(nil)
 var _ core.StagedConnectionStore = (*Store)(nil)
 var _ core.EgressClientStore = (*Store)(nil)
 var _ core.EgressDenyRuleStore = (*Store)(nil)
+var _ core.EgressCredentialGrantStore = (*Store)(nil)
 
 func New(dsn string, encryptionKey []byte) (*Store, error) {
 	s, err := sqlstore.Open(driverName, dsn, encryptionKey, dialect{})
@@ -189,6 +190,24 @@ func (s *Store) Migrate(ctx context.Context) error {
 				path_prefix NVARCHAR(255) NOT NULL DEFAULT '',
 				created_by_id NVARCHAR(36) NOT NULL REFERENCES users(id),
 				description NVARCHAR(MAX) NOT NULL DEFAULT '',
+				created_at DATETIME2(6) NOT NULL,
+				updated_at DATETIME2(6) NOT NULL
+			)`},
+		{"egress_credential_grants", `
+			IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'egress_credential_grants')
+			CREATE TABLE egress_credential_grants (
+				id NVARCHAR(36) NOT NULL PRIMARY KEY,
+				provider NVARCHAR(255) NOT NULL DEFAULT '',
+				instance NVARCHAR(255) NOT NULL DEFAULT '',
+				secret_ref NVARCHAR(255) NOT NULL DEFAULT '',
+				auth_style NVARCHAR(255) NOT NULL DEFAULT '',
+				subject_kind NVARCHAR(255) NOT NULL DEFAULT '',
+				subject_id NVARCHAR(255) NOT NULL DEFAULT '',
+				operation NVARCHAR(255) NOT NULL DEFAULT '',
+				method NVARCHAR(255) NOT NULL DEFAULT '',
+				host NVARCHAR(255) NOT NULL DEFAULT '',
+				path_prefix NVARCHAR(255) NOT NULL DEFAULT '',
+				created_by_id NVARCHAR(36) NOT NULL REFERENCES users(id),
 				created_at DATETIME2(6) NOT NULL,
 				updated_at DATETIME2(6) NOT NULL
 			)`},

--- a/plugins/datastore/sqlstore/sqlstore.go
+++ b/plugins/datastore/sqlstore/sqlstore.go
@@ -697,3 +697,84 @@ func (s *Store) DeleteEgressDenyRule(ctx context.Context, id string) error {
 	}
 	return nil
 }
+
+// --- Egress Credential Grants ---
+
+func scanEgressCredentialGrant(row Scanner) (*core.EgressCredentialGrant, error) {
+	var g core.EgressCredentialGrant
+	if err := row.Scan(&g.ID, &g.Provider, &g.Instance, &g.SecretRef, &g.AuthStyle,
+		&g.SubjectKind, &g.SubjectID, &g.Operation, &g.Method, &g.Host, &g.PathPrefix,
+		&g.CreatedByID, &g.CreatedAt, &g.UpdatedAt); err != nil {
+		return nil, err
+	}
+	return &g, nil
+}
+
+func (s *Store) CreateEgressCredentialGrant(ctx context.Context, grant *core.EgressCredentialGrant) error {
+	defaultTimestamps(&grant.CreatedAt, &grant.UpdatedAt)
+	_, err := s.DB.ExecContext(ctx, `
+		INSERT INTO egress_credential_grants (id, provider, instance, secret_ref, auth_style, subject_kind, subject_id, operation, method, host, path_prefix, created_by_id, created_at, updated_at)
+		VALUES (`+s.ph(1)+`, `+s.ph(2)+`, `+s.ph(3)+`, `+s.ph(4)+`, `+s.ph(5)+`, `+s.ph(6)+`, `+s.ph(7)+`, `+s.ph(8)+`, `+s.ph(9)+`, `+s.ph(10)+`, `+s.ph(11)+`, `+s.ph(12)+`, `+s.ph(13)+`, `+s.ph(14)+`)`,
+		grant.ID, grant.Provider, grant.Instance, grant.SecretRef, grant.AuthStyle,
+		grant.SubjectKind, grant.SubjectID, grant.Operation, grant.Method, grant.Host, grant.PathPrefix,
+		grant.CreatedByID, grant.CreatedAt, grant.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("inserting egress credential grant: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetEgressCredentialGrant(ctx context.Context, id string) (*core.EgressCredentialGrant, error) {
+	row := s.DB.QueryRowContext(ctx, `
+		SELECT id, provider, instance, secret_ref, auth_style, subject_kind, subject_id, operation, method, host, path_prefix, created_by_id, created_at, updated_at
+		FROM egress_credential_grants WHERE id = `+s.ph(1), id)
+	g, err := scanEgressCredentialGrant(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, core.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying egress credential grant: %w", err)
+	}
+	return g, nil
+}
+
+func (s *Store) ListEgressCredentialGrants(ctx context.Context, filter core.EgressCredentialGrantFilter) ([]*core.EgressCredentialGrant, error) {
+	query := `SELECT id, provider, instance, secret_ref, auth_style, subject_kind, subject_id, operation, method, host, path_prefix, created_by_id, created_at, updated_at FROM egress_credential_grants`
+	var args []any
+	if filter.Provider != "" {
+		query += ` WHERE provider = ` + s.ph(1)
+		args = append(args, filter.Provider)
+	}
+	query += ` ORDER BY created_at ASC`
+	rows, err := s.DB.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("listing egress credential grants: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var grants []*core.EgressCredentialGrant
+	for rows.Next() {
+		g, err := scanEgressCredentialGrant(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning egress credential grant row: %w", err)
+		}
+		grants = append(grants, g)
+	}
+	return grants, rows.Err()
+}
+
+func (s *Store) DeleteEgressCredentialGrant(ctx context.Context, id string) error {
+	result, err := s.DB.ExecContext(ctx, "DELETE FROM egress_credential_grants WHERE id = "+s.ph(1), id)
+	if err != nil {
+		return fmt.Errorf("deleting egress credential grant: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("deleting egress credential grant: %w", err)
+	}
+	if n == 0 {
+		return core.ErrNotFound
+	}
+	return nil
+}


### PR DESCRIPTION
Credential grants can now be stored in the database alongside the
existing config-file grants. The new `EgressCredentialGrantStore`
interface and `egress_credential_grants` table (all five SQL dialects)
give operators a runtime-mutable way to authorize outbound credentials
without restarting. Bootstrap wires the DB-backed resolver as a second
source in the credential chain, so config grants take precedence and
saved grants fill in behind them.

The `SecretRef` and `AuthStyle` columns are included in the schema now
to avoid a future migration when secret-backed credential
materialization lands.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>