### PR TITLE
Add ADRs for credential unification and client scope

### DIFF
--- a/docs/adr/003-unified-credential-resolution.md
+++ b/docs/adr/003-unified-credential-resolution.md
@@ -1,0 +1,28 @@
+# ADR 003: Unified Credential Resolution
+
+## Status
+
+Proposed
+
+## Context
+
+Gestalt resolves credentials through two independent paths. The data plane (egress proxy) resolves credentials via subject+target grant matching through `CredentialSourceChain`, where a `ProviderCredentialResolver` iterates `CredentialGrant` entries with `MatchCriteria` to find a (provider, instance) pair and then materializes a token. The capability plane resolves credentials via the provider's `ConnectionMode` enum (`none`, `user`, `identity`, `either`) and per-user token lookup in `internal/invocation/broker.go`. Both paths ultimately call into the same datastore token storage, but they arrive there through different control structures: grants with match criteria vs. connection mode switch statements.
+
+This divergence means that adding a new credential source (e.g., secret-backed credentials, workload identity) requires updating both paths independently. It also means the capability plane cannot benefit from host/path-based grant targeting, and the egress plane cannot express "use the identity-level token when no user token exists" without reimplementing the `ConnectionModeEither` fallback logic.
+
+## Decision
+
+1. **Capability invocation should eventually use the same grant source chain as egress.** The `Broker.resolveToken` method's `ConnectionMode` switch would be replaced by grant evaluation, where provider connection modes become one credential source (an adapter that produces grants from provider config) rather than the root control model.
+
+2. **Provider (provider, instance) maps to host/tenant via grant match criteria.** A capability invocation for `(provider=shopify, instance=shop-1)` is equivalent to an egress grant matching `host=shop-1.myshopify.com`. The grant abstraction unifies both addressing schemes.
+
+3. **Migration is incremental, not a big-bang rewrite.** The broker continues to use `ConnectionMode` today. Each provider's connection mode can be wrapped as a credential source adapter one at a time. The grant chain accepts multiple sources, so old and new paths coexist.
+
+4. **No new credential source types are introduced by this ADR.** This decision covers the convergence direction, not new features. Secret-backed credentials and workload identity are separate decisions that benefit from this convergence.
+
+## Consequences
+
+- Provider `ConnectionMode` stays as-is for now. No immediate code changes are required.
+- Future work can wrap each `ConnectionMode` variant as a `CredentialResolver` adapter, allowing the broker to delegate to `CredentialSourceChain` instead of switching on mode directly.
+- The `ProviderTokenResolver` interface already bridges the two planes (the broker satisfies it for egress). Unification would make this bridge the primary path rather than a secondary one.
+- Grant match criteria may need to be extended to support provider/instance addressing alongside host/path addressing.

--- a/docs/adr/004-egress-client-scope.md
+++ b/docs/adr/004-egress-client-scope.md
@@ -1,0 +1,30 @@
+# ADR 004: EgressClient Scope
+
+## Status
+
+Proposed
+
+## Context
+
+EgressClient currently has a `UNIQUE(created_by_id, name)` constraint, and `resolveOwnedEgressClient` enforces strict creator ownership: a user can only see and manage clients they created. There is no mechanism for operator-managed or shared clients. This means an operator cannot provision a client for a workload and hand off the token, and two users cannot share a client identity for the same external service.
+
+The gateway deployment shape (ADR 002) defers shared/workload EgressClient scope, but the need is becoming concrete as operators want to pre-provision machine callers that are not tied to a specific user's session.
+
+## Decision
+
+1. **Add a scope column to EgressClient.** Scope values are `personal` (current behavior, default) and `global`. Personal clients retain `UNIQUE(created_by_id, name)` semantics. Global clients have `UNIQUE(name)` within the global scope.
+
+2. **`admin_emails` gates global client management.** Only admin users (as determined by `admin_emails` configuration) can create, list, and delete global-scoped clients. Personal client management remains available to all authenticated users.
+
+3. **`CreatedByID` stays as audit metadata.** Global clients still record who created them, but ownership checks are replaced by scope-based authorization. Personal clients continue to use creator-based ownership.
+
+4. **No teams or groups scope.** The first non-personal scope is global. Organization, team, or group scoping is deferred until there is a concrete need and an identity model to support it.
+
+5. **Listing behavior is scope-aware.** A non-admin user listing clients sees only their personal clients. An admin listing clients sees their personal clients plus all global clients (or can filter by scope).
+
+## Consequences
+
+- A future schema migration adds a `scope` column (default `personal`) to the `egress_clients` table and updates the uniqueness constraint.
+- The API gains a `scope` parameter on create and a `scope` filter on list.
+- `resolveOwnedEgressClient` evolves into scope-aware authorization: personal clients check creator, global clients check admin status.
+- Token authentication for egress clients is unaffected; `gst_ec_` tokens resolve to a client regardless of scope.


### PR DESCRIPTION
## Summary

Two architecture decision records for the next phase of the gateway substrate work.

ADR 003 (unified credential resolution) establishes that the capability plane should eventually use the same grant-based credential source chain as the egress/data plane, with provider connection modes becoming one credential source rather than the root control model. This is a future migration direction, not an immediate change.

ADR 004 (EgressClient scope) decides that the first non-personal scope for machine clients should be global/operator-managed, gated by admin_emails. CreatedByID stays as audit metadata. No teams/groups yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)