### PR TITLE
Add admin CRUD API for egress credential grants

### DIFF
--- a/internal/server/egress_credential_grants.go
+++ b/internal/server/egress_credential_grants.go
@@ -1,0 +1,163 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/core"
+)
+
+func (s *Server) egressCredentialGrantStore() (core.EgressCredentialGrantStore, error) {
+	ecgs, ok := s.datastore.(core.EgressCredentialGrantStore)
+	if !ok {
+		return nil, fmt.Errorf("datastore does not support egress credential grants; use a SQL-backed datastore (sqlite, postgres, mysql, sqlserver, oracle)")
+	}
+	return ecgs, nil
+}
+
+type createEgressCredentialGrantRequest struct {
+	Provider    string `json:"provider"`
+	Instance    string `json:"instance"`
+	SecretRef   string `json:"secret_ref"`
+	AuthStyle   string `json:"auth_style"`
+	SubjectKind string `json:"subject_kind"`
+	SubjectID   string `json:"subject_id"`
+	Operation   string `json:"operation"`
+	Method      string `json:"method"`
+	Host        string `json:"host"`
+	PathPrefix  string `json:"path_prefix"`
+}
+
+type egressCredentialGrantResponse struct {
+	ID          string    `json:"id"`
+	Provider    string    `json:"provider,omitempty"`
+	Instance    string    `json:"instance,omitempty"`
+	SecretRef   string    `json:"secret_ref,omitempty"`
+	AuthStyle   string    `json:"auth_style,omitempty"`
+	SubjectKind string    `json:"subject_kind,omitempty"`
+	SubjectID   string    `json:"subject_id,omitempty"`
+	Operation   string    `json:"operation,omitempty"`
+	Method      string    `json:"method,omitempty"`
+	Host        string    `json:"host,omitempty"`
+	PathPrefix  string    `json:"path_prefix,omitempty"`
+	CreatedByID string    `json:"created_by_id"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+func egressCredentialGrantResponseFromCore(g *core.EgressCredentialGrant) egressCredentialGrantResponse {
+	return egressCredentialGrantResponse{
+		ID:          g.ID,
+		Provider:    g.Provider,
+		Instance:    g.Instance,
+		SecretRef:   g.SecretRef,
+		AuthStyle:   g.AuthStyle,
+		SubjectKind: g.SubjectKind,
+		SubjectID:   g.SubjectID,
+		Operation:   g.Operation,
+		Method:      g.Method,
+		Host:        g.Host,
+		PathPrefix:  g.PathPrefix,
+		CreatedByID: g.CreatedByID,
+		CreatedAt:   g.CreatedAt,
+		UpdatedAt:   g.UpdatedAt,
+	}
+}
+
+func (s *Server) createEgressCredentialGrant(w http.ResponseWriter, r *http.Request) {
+	userID, ok := s.resolveUserID(w, r)
+	if !ok {
+		return
+	}
+
+	store, err := s.egressCredentialGrantStore()
+	if err != nil {
+		writeError(w, http.StatusNotImplemented, err.Error())
+		return
+	}
+
+	var req createEgressCredentialGrantRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	if req.Provider == "" && req.Host == "" && req.SubjectKind == "" && req.SubjectID == "" &&
+		req.Operation == "" && req.Method == "" && req.PathPrefix == "" && req.Instance == "" {
+		writeError(w, http.StatusBadRequest, "at least one match criterion is required")
+		return
+	}
+
+	now := s.nowUTCSecond()
+	grant := &core.EgressCredentialGrant{
+		ID:          uuid.NewString(),
+		Provider:    req.Provider,
+		Instance:    req.Instance,
+		SecretRef:   req.SecretRef,
+		AuthStyle:   req.AuthStyle,
+		SubjectKind: req.SubjectKind,
+		SubjectID:   req.SubjectID,
+		Operation:   req.Operation,
+		Method:      req.Method,
+		Host:        req.Host,
+		PathPrefix:  req.PathPrefix,
+		CreatedByID: userID,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	if err := store.CreateEgressCredentialGrant(r.Context(), grant); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create egress credential grant")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, egressCredentialGrantResponseFromCore(grant))
+}
+
+func (s *Server) listEgressCredentialGrants(w http.ResponseWriter, r *http.Request) {
+	store, err := s.egressCredentialGrantStore()
+	if err != nil {
+		writeError(w, http.StatusNotImplemented, err.Error())
+		return
+	}
+
+	filter := core.EgressCredentialGrantFilter{
+		Provider: r.URL.Query().Get("provider"),
+	}
+
+	grants, err := store.ListEgressCredentialGrants(r.Context(), filter)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list egress credential grants")
+		return
+	}
+
+	out := make([]egressCredentialGrantResponse, 0, len(grants))
+	for _, g := range grants {
+		out = append(out, egressCredentialGrantResponseFromCore(g))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) deleteEgressCredentialGrant(w http.ResponseWriter, r *http.Request) {
+	store, err := s.egressCredentialGrantStore()
+	if err != nil {
+		writeError(w, http.StatusNotImplemented, err.Error())
+		return
+	}
+
+	id := chi.URLParam(r, "id")
+	if err := store.DeleteEgressCredentialGrant(r.Context(), id); err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "egress credential grant not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to delete egress credential grant")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -135,6 +135,9 @@ func (s *Server) routes() {
 			r.Post("/egress/deny-rules", s.createEgressDenyRule)
 			r.Get("/egress/deny-rules", s.listEgressDenyRules)
 			r.Delete("/egress/deny-rules/{id}", s.deleteEgressDenyRule)
+			r.Post("/egress/credential-grants", s.createEgressCredentialGrant)
+			r.Get("/egress/credential-grants", s.listEgressCredentialGrants)
+			r.Delete("/egress/credential-grants/{id}", s.deleteEgressCredentialGrant)
 		})
 
 		r.Group(func(r chi.Router) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4877,3 +4877,329 @@ func TestAdminDenyRules_RequiresMatchCriterion(t *testing.T) {
 		t.Fatalf("expected 400 for empty match criteria, got %d", resp.StatusCode)
 	}
 }
+
+func TestAdminCredentialGrants_CRUD(t *testing.T) {
+	t.Parallel()
+
+	const adminEmail = "admin@testcorp.example"
+	var storedGrants []*core.EgressCredentialGrant
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.AdminEmails = []string{adminEmail}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u-admin", Email: email}, nil
+			},
+			CreateEgressCredentialGrantFn: func(_ context.Context, grant *core.EgressCredentialGrant) error {
+				storedGrants = append(storedGrants, grant)
+				return nil
+			},
+			ListEgressCredentialGrantsFn: func(_ context.Context, _ core.EgressCredentialGrantFilter) ([]*core.EgressCredentialGrant, error) {
+				return storedGrants, nil
+			},
+			DeleteEgressCredentialGrantFn: func(_ context.Context, id string) error {
+				for i, g := range storedGrants {
+					if g.ID == id {
+						storedGrants = append(storedGrants[:i], storedGrants[i+1:]...)
+						return nil
+					}
+				}
+				return core.ErrNotFound
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"host":"api.vendor.test","provider":"vendorx","auth_style":"bearer"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/egress/credential-grants", body)
+	req.Header.Set("X-Dev-User-Email", adminEmail)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: expected 201, got %d: %s", resp.StatusCode, respBody)
+	}
+
+	var created map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	grantID, _ := created["id"].(string)
+	if grantID == "" {
+		t.Fatal("expected id in create response")
+	}
+	if created["host"] != "api.vendor.test" {
+		t.Fatalf("expected host api.vendor.test, got %v", created["host"])
+	}
+	if created["provider"] != "vendorx" {
+		t.Fatalf("expected provider vendorx, got %v", created["provider"])
+	}
+	if created["auth_style"] != "bearer" {
+		t.Fatalf("expected auth_style bearer, got %v", created["auth_style"])
+	}
+	if created["created_by_id"] != "u-admin" {
+		t.Fatalf("expected created_by_id u-admin, got %v", created["created_by_id"])
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/egress/credential-grants", nil)
+	req.Header.Set("X-Dev-User-Email", adminEmail)
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("list request: %v", err)
+	}
+	defer func() { _ = resp2.Body.Close() }()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d", resp2.StatusCode)
+	}
+
+	var listed []map[string]any
+	if err := json.NewDecoder(resp2.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("expected 1 grant, got %d", len(listed))
+	}
+
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/egress/credential-grants/"+grantID, nil)
+	req.Header.Set("X-Dev-User-Email", adminEmail)
+	resp3, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("delete request: %v", err)
+	}
+	defer func() { _ = resp3.Body.Close() }()
+	if resp3.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp3.Body)
+		t.Fatalf("delete: expected 200, got %d: %s", resp3.StatusCode, respBody)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/egress/credential-grants", nil)
+	req.Header.Set("X-Dev-User-Email", adminEmail)
+	resp4, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("list-after-delete request: %v", err)
+	}
+	defer func() { _ = resp4.Body.Close() }()
+
+	var afterDelete []map[string]any
+	if err := json.NewDecoder(resp4.Body).Decode(&afterDelete); err != nil {
+		t.Fatalf("decode list-after-delete response: %v", err)
+	}
+	if len(afterDelete) != 0 {
+		t.Fatalf("expected 0 grants after delete, got %d", len(afterDelete))
+	}
+}
+
+func TestAdminCredentialGrants_NonAdminForbidden(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.AdminEmails = []string{"admin@testcorp.example"}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	endpoints := []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{http.MethodPost, "/api/v1/egress/credential-grants", `{"host":"api.vendor.test"}`},
+		{http.MethodGet, "/api/v1/egress/credential-grants", ""},
+		{http.MethodDelete, "/api/v1/egress/credential-grants/some-id", ""},
+	}
+
+	for _, ep := range endpoints {
+		var bodyReader io.Reader
+		if ep.body != "" {
+			bodyReader = bytes.NewBufferString(ep.body)
+		}
+		req, _ := http.NewRequest(ep.method, ts.URL+ep.path, bodyReader)
+		req.Header.Set("X-Dev-User-Email", "nonadmin@testcorp.example")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s %s: %v", ep.method, ep.path, err)
+		}
+		_ = resp.Body.Close()
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("%s %s: expected 403 for non-admin, got %d", ep.method, ep.path, resp.StatusCode)
+		}
+	}
+}
+
+func TestAdminCredentialGrants_EgressClientPrincipalForbidden(t *testing.T) {
+	t.Parallel()
+
+	ecToken := &core.EgressClientToken{
+		ID:          "ectoken-1",
+		ClientID:    "ec-1",
+		Name:        "test-token",
+		HashedToken: principal.HashToken("gst_ec_testtoken123"),
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+	ecClient := &core.EgressClient{
+		ID:          "ec-1",
+		Name:        "test-machine",
+		CreatedByID: "u-owner",
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.AdminEmails = []string{"admin@testcorp.example"}
+		cfg.Datastore = &coretesting.StubDatastore{
+			ValidateEgressClientTokenFn: func(_ context.Context, hashed string) (*core.EgressClientToken, error) {
+				if hashed == ecToken.HashedToken {
+					return ecToken, nil
+				}
+				return nil, core.ErrNotFound
+			},
+			GetEgressClientFn: func(_ context.Context, id string) (*core.EgressClient, error) {
+				if id == ecClient.ID {
+					return ecClient, nil
+				}
+				return nil, core.ErrNotFound
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	endpoints := []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{http.MethodPost, "/api/v1/egress/credential-grants", `{"host":"api.vendor.test"}`},
+		{http.MethodGet, "/api/v1/egress/credential-grants", ""},
+		{http.MethodDelete, "/api/v1/egress/credential-grants/some-id", ""},
+	}
+
+	for _, ep := range endpoints {
+		var bodyReader io.Reader
+		if ep.body != "" {
+			bodyReader = bytes.NewBufferString(ep.body)
+		}
+		req, _ := http.NewRequest(ep.method, ts.URL+ep.path, bodyReader)
+		req.Header.Set("Authorization", "Bearer gst_ec_testtoken123")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s %s: %v", ep.method, ep.path, err)
+		}
+		_ = resp.Body.Close()
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("%s %s: expected 403 for egress-client principal, got %d", ep.method, ep.path, resp.StatusCode)
+		}
+	}
+}
+
+func TestAdminCredentialGrants_DeleteNotFound(t *testing.T) {
+	t.Parallel()
+
+	const adminEmail = "admin@testcorp.example"
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.AdminEmails = []string{adminEmail}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u-admin", Email: email}, nil
+			},
+			DeleteEgressCredentialGrantFn: func(_ context.Context, _ string) error {
+				return core.ErrNotFound
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/egress/credential-grants/nonexistent-id", nil)
+	req.Header.Set("X-Dev-User-Email", adminEmail)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("delete request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing grant, got %d", resp.StatusCode)
+	}
+}
+
+func TestAdminCredentialGrants_RequiresMatchCriterion(t *testing.T) {
+	t.Parallel()
+
+	const adminEmail = "admin@testcorp.example"
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.AdminEmails = []string{adminEmail}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u-admin", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"secret_ref":"my-secret","auth_style":"bearer"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/egress/credential-grants", body)
+	req.Header.Set("X-Dev-User-Email", adminEmail)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty match criteria, got %d", resp.StatusCode)
+	}
+}
+
+func TestAdminCredentialGrants_ListFilterByProvider(t *testing.T) {
+	t.Parallel()
+
+	const adminEmail = "admin@testcorp.example"
+	var lastFilter core.EgressCredentialGrantFilter
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.AdminEmails = []string{adminEmail}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u-admin", Email: email}, nil
+			},
+			ListEgressCredentialGrantsFn: func(_ context.Context, filter core.EgressCredentialGrantFilter) ([]*core.EgressCredentialGrant, error) {
+				lastFilter = filter
+				return nil, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/egress/credential-grants?provider=vendorx", nil)
+	req.Header.Set("X-Dev-User-Email", adminEmail)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if lastFilter.Provider != "vendorx" {
+		t.Fatalf("expected provider filter vendorx, got %q", lastFilter.Provider)
+	}
+}


### PR DESCRIPTION
Expose admin-only endpoints for managing persisted credential grants
(POST/GET/DELETE on /api/v1/egress/credential-grants). This builds on
the credential grants foundation from PR #183, adding the HTTP layer
that lets operators create, list, and delete grants without restarting
the server. The handlers follow the same pattern as the deny-rules API
and are gated behind the existing admin middleware.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>