### PR TITLE
Fix Dockerfile go mod download with local replace directives

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ RUN npm run build
 FROM golang:1.26-alpine AS builder
 WORKDIR /build
 COPY go.mod go.sum ./
+COPY sdk/pluginapi/go.mod sdk/pluginapi/go.sum sdk/pluginapi/
+COPY sdk/pluginsdk/go.mod sdk/pluginsdk/go.sum sdk/pluginsdk/
+COPY examples/plugins/provider-go/go.mod examples/plugins/provider-go/go.sum examples/plugins/provider-go/
+COPY examples/plugins/runtime-go/go.mod examples/plugins/runtime-go/go.sum examples/plugins/runtime-go/
 RUN go mod download
 COPY . .
 COPY --from=frontend /web/out/ internal/webui/out/


### PR DESCRIPTION
The root `go.mod` uses replace directives pointing to local SDK and
example sub-modules. The Dockerfile copies only `go.mod` and `go.sum`
before running `go mod download`, so the replaced module directories
do not exist yet and the download fails. This copies the sub-module
`go.mod` and `go.sum` files before the download step so the local
replace directives can resolve.

This has been broken since the SDK sub-modules were added, causing all
`valontechnologies/gestalt:latest` image publishes to fail. The
toolshed deploy depends on an updated image with `gestaltd init`
support.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>