### PR TITLE
Rewrite gestaltd docs from first principles

### DIFF
--- a/deploy/docker/config.yaml
+++ b/deploy/docker/config.yaml
@@ -8,15 +8,16 @@ auth:
   config:
     client_id: ${GOOGLE_CLIENT_ID}
     client_secret: ${GOOGLE_CLIENT_SECRET}
-    redirect_url: ${GOOGLE_REDIRECT_URL}
-    session_secret: ${GESTALT_SESSION_SECRET}
+    # Optional. If omitted, Gestalt derives the callback from server.base_url.
+    # redirect_url: ${GOOGLE_REDIRECT_URL}
   # For OIDC (Okta, Azure AD, Auth0, Keycloak, Firebase, etc.):
   # provider: oidc
   # config:
   #   issuer_url: ${OIDC_ISSUER_URL}
   #   client_id: ${OIDC_CLIENT_ID}
   #   client_secret: ${OIDC_CLIENT_SECRET}
-  #   session_secret: ${GESTALT_SESSION_SECRET}
+  #   redirect_url: ${OIDC_REDIRECT_URL}
+  #   session_secret: ${OIDC_SESSION_SECRET}
   #   display_name: "Okta"
 
 datastore:

--- a/deploy/helm/gestalt/values.yaml
+++ b/deploy/helm/gestalt/values.yaml
@@ -71,13 +71,16 @@ config:
     config:
       client_id: "${GOOGLE_CLIENT_ID}"
       client_secret: "${GOOGLE_CLIENT_SECRET}"
+      # Optional. If omitted, Gestalt derives the callback from server.base_url.
+      # redirect_url: "${GOOGLE_REDIRECT_URL}"
     # For OIDC (Okta, Azure AD, Auth0, Keycloak, Firebase, etc.):
     # provider: oidc
     # config:
     #   issuer_url: "${OIDC_ISSUER_URL}"
     #   client_id: "${OIDC_CLIENT_ID}"
     #   client_secret: "${OIDC_CLIENT_SECRET}"
-    #   session_secret: "${GESTALT_SESSION_SECRET}"
+    #   redirect_url: "${OIDC_REDIRECT_URL}"
+    #   session_secret: "${OIDC_SESSION_SECRET}"
     #   display_name: "Okta"
   datastore:
     # SQLite is appropriate for local development or single-instance
@@ -120,8 +123,15 @@ extraEnv: []
 #     secretKeyRef:
 #       name: gestalt-secrets
 #       key: oidc-client-secret
+# - name: OIDC_SESSION_SECRET
+#   valueFrom:
+#     secretKeyRef:
+#       name: gestalt-secrets
+#       key: oidc-session-secret
 
 pluginInit:
+  # Enable this when your config uses remote REST/GraphQL upstreams or
+  # packaged plugins and you want the chart to prepare locked state for you.
   enabled: false
 
 livenessProbe:

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,10 +1,25 @@
 # Authentication
 
-Gestalt supports pluggable user authentication. Configure your provider under `auth:` in config.yaml.
+Gestalt has pluggable platform authentication. Configure it under `auth:` in `config.yaml`.
 
-## Google
+## Available Providers
 
-Uses Google's OAuth2 endpoints directly. Best for Google Workspace organizations.
+### `local`
+
+The built-in local provider is the simplest way to run Gestalt without any external identity system.
+
+```yaml
+auth:
+  provider: local
+  config:
+    email: local@example.com
+```
+
+`email` is optional. If omitted, Gestalt uses `local@gestalt.local`.
+
+### `google`
+
+Google uses Google's OAuth endpoints directly.
 
 ```yaml
 auth:
@@ -12,20 +27,19 @@ auth:
   config:
     client_id: ${GOOGLE_CLIENT_ID}
     client_secret: ${GOOGLE_CLIENT_SECRET}
-    allowed_domains:              # optional; empty = allow all
+    allowed_domains:
       - example.com
 ```
 
-### Setup
+If `redirect_url` is omitted and `server.base_url` is set, Gestalt derives the callback automatically as:
 
-1. Go to [Google Cloud Console](https://console.cloud.google.com/apis/credentials)
-2. Create an OAuth 2.0 Client ID (Web application)
-3. Add `<your-base-url>/api/v1/auth/login/callback` as an authorized redirect URI
-4. Set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
+```text
+<base-url>/api/v1/auth/login/callback
+```
 
-## OIDC
+### `oidc`
 
-Generic OpenID Connect provider. Works with any IdP that supports OIDC discovery, including Okta, Azure AD, Auth0, Keycloak, Firebase Auth, Rippling, OneLogin, and others.
+OIDC works with providers such as Okta, Auth0, Azure AD, and Keycloak.
 
 ```yaml
 auth:
@@ -34,53 +48,39 @@ auth:
     issuer_url: https://login.example.com
     client_id: ${OIDC_CLIENT_ID}
     client_secret: ${OIDC_CLIENT_SECRET}
-    session_secret: ${GESTALT_SESSION_SECRET}
-    display_name: "Okta"          # shown on the login button
-    scopes:                       # optional; defaults to openid, email, profile
+    session_secret: ${OIDC_SESSION_SECRET}
+    display_name: Company SSO
+    scopes:
       - openid
       - email
       - profile
-    allowed_domains:              # optional; empty = allow all
+    allowed_domains:
       - example.com
-    pkce: false                   # set true for public clients
+    pkce: true
 ```
 
-### Common issuer URLs
+## Field Summary
 
-| Provider     | Issuer URL                                             |
-|-------------|--------------------------------------------------------|
-| Okta         | `https://<your-org>.okta.com`                          |
-| Azure AD     | `https://login.microsoftonline.com/<tenant-id>/v2.0`   |
-| Auth0        | `https://<your-tenant>.auth0.com`                      |
-| Keycloak     | `https://<host>/realms/<realm>`                        |
-| Google       | `https://accounts.google.com`                          |
-| Firebase     | `https://securetoken.google.com/<project-id>`          |
-| OneLogin     | `https://<your-org>.onelogin.com/oidc/2`               |
+| Field | Provider | Notes |
+| --- | --- | --- |
+| `email` | `local` | Optional local-login email. |
+| `client_id` | `google`, `oidc` | OAuth client ID. |
+| `client_secret` | `google`, `oidc` | OAuth client secret. |
+| `redirect_url` | `google`, `oidc` | Optional explicit callback URL. |
+| `allowed_domains` | `google`, `oidc` | Optional email-domain allowlist. |
+| `issuer_url` | `oidc` | OIDC discovery URL. |
+| `session_secret` | `oidc` | Secret used to sign OIDC-backed sessions. |
+| `session_ttl` | `oidc` | Optional session lifetime, defaults to `24h`. |
+| `scopes` | `oidc` | Optional scope list, defaults to `openid`, `email`, `profile`. |
+| `pkce` | `oidc` | Optional PKCE flag. |
+| `display_name` | `oidc` | Optional login button label, defaults to `SSO`. |
 
-### Setup (Okta example)
+## Callback Path
 
-1. Create a new OIDC Web Application in the Okta admin console
-2. Set the redirect URI to `<your-base-url>/api/v1/auth/login/callback`
-3. Copy the Client ID and Client Secret
-4. Set `issuer_url` to `https://<your-org>.okta.com`
-5. Set `display_name` to `"Okta"` so the login button reads "Sign in with Okta"
+Platform login callbacks always land on:
 
-## Config reference
+```text
+/api/v1/auth/login/callback
+```
 
-| Field            | Required | Default                     | Description                                     |
-|------------------|----------|-----------------------------|-------------------------------------------------|
-| `provider`       | yes      |                             | `google` or `oidc`                              |
-| `client_id`      | yes      |                             | OAuth client ID                                 |
-| `client_secret`  | yes*     |                             | OAuth client secret (*not needed with PKCE)     |
-| `issuer_url`     | oidc     |                             | OIDC discovery base URL                         |
-| `redirect_url`   | no       | derived from `base_url`     | OAuth callback URL                              |
-| `display_name`   | no       | `SSO`                       | Label on the login button (OIDC only)           |
-| `allowed_domains`| no       | allow all                   | Restrict login to these email domains           |
-| `scopes`         | no       | `openid`, `email`, `profile`| OIDC scopes to request                          |
-| `pkce`           | no       | `false`                     | Enable PKCE (OIDC only)                         |
-| `session_secret` | no       | derived from `encryption_key`| Key for signing session JWTs                   |
-| `session_ttl`    | no       | `24h`                       | Session token lifetime                          |
-
-## Domain restriction
-
-Both providers support `allowed_domains` to restrict which email domains can log in. When set, only users with an email address matching one of the listed domains are allowed to authenticate. An empty list (or omitting the field) allows all domains.
+That is distinct from the integration OAuth callback path used for upstream provider connections.

--- a/docs/pages/concepts/authentication-and-tokens.mdx
+++ b/docs/pages/concepts/authentication-and-tokens.mdx
@@ -1,71 +1,149 @@
-import { Callout } from 'nextra/components'
-
 # Authentication and Tokens
 
-Gestalt manages three distinct token flows: platform identity, API tokens for programmatic callers, and per-integration credentials for upstream APIs.
+Gestalt has two separate auth layers:
 
-## Platform auth
+1. platform auth: who is allowed to use Gestalt
+2. integration auth: which upstream credentials Gestalt should use on behalf of that subject
 
-**Platform auth** is the login flow that establishes a user's identity within Gestalt. You configure a single auth provider, and Gestalt handles the rest: redirects, token exchange, session creation, and session validation on every subsequent request.
+Keeping those layers separate is one of the core design choices in `gestaltd`.
 
-| Provider | Notes |
-|---|---|
-| `google` | Google OAuth 2.0. Simplest option for teams on Google Workspace. |
-| `oidc` | Any OpenID Connect provider: Okta, Azure AD, Auth0, Keycloak, Firebase, OneLogin, Rippling, or Google via OIDC discovery. Supports PKCE. |
+## Platform Auth Providers
 
-Both providers support:
+Gestalt currently ships three platform auth providers:
 
-- **Domain allow-lists**: Set `allowed_domains` to restrict which email domains can sign in.
-- **Session TTL**: Set `session_ttl` to control how long sessions last (default: 24 hours).
-- **Session secret**: Set `session_secret` to sign session JWTs.
+| Provider | When to use it |
+| --- | --- |
+| `local` | Local development, no external identity provider required. |
+| `google` | Google Workspace or Google account login. |
+| `oidc` | Any OIDC-compatible provider such as Okta, Auth0, Azure AD, or Keycloak. |
 
-After first login, the user record is created in the datastore. The session token is set as an HTTP cookie and validated on every request.
+### `local`
 
-## API tokens
+`local` is the auth provider used by the auto-generated out-of-the-box config.
 
-**API tokens** give programmatic callers (CLI tools, CI pipelines, MCP clients) persistent access without a browser-based login flow. Users generate API tokens through the web UI or API; the server returns the raw token exactly once. Only a SHA-256 hash is stored, so the token cannot be recovered after creation.
+```yaml
+auth:
+  provider: local
+  config:
+    email: you@example.com
+```
 
-The authentication path on every request:
+`email` is optional. If omitted, Gestalt uses `local@gestalt.local`.
 
-1. Check for a `Bearer` token in the `Authorization` header. If present, hash it and look it up in the datastore.
-2. If no bearer token, check for a valid session cookie.
-3. If neither is found, reject the request.
+### `google`
 
-<Callout>
-  API token scopes are stored but not yet enforced by middleware. Treat the scopes field as metadata for now.
-</Callout>
+```yaml
+auth:
+  provider: google
+  config:
+    client_id: ${GOOGLE_CLIENT_ID}
+    client_secret: secret://google-client-secret
+    allowed_domains:
+      - example.com
+```
 
-## Integration tokens
+If `redirect_url` is omitted and `server.base_url` is set, Gestalt derives the login callback automatically.
 
-**Integration tokens** are the credentials Gestalt stores for a user's connection to an upstream API such as Slack, Linear, or Datadog. When a user completes an OAuth flow (or pastes manual credentials), Gestalt encrypts the tokens and persists them in the datastore.
+### `oidc`
 
-Each stored credential includes:
+```yaml
+auth:
+  provider: oidc
+  config:
+    issuer_url: https://login.example.com
+    client_id: ${OIDC_CLIENT_ID}
+    client_secret: secret://oidc-client-secret
+    session_secret: secret://oidc-session-secret
+    allowed_domains:
+      - example.com
+    scopes:
+      - openid
+      - email
+      - profile
+    pkce: true
+    display_name: Company SSO
+```
 
-| Field | Purpose |
-|---|---|
-| Access token | Sent to the upstream API on each request. |
-| Refresh token | Used to obtain a new access token when the current one expires. |
-| Expiry time | Timestamp at which the access token expires. |
-| Integration name | Ties the credential to a specific integration. |
-| Instance | Distinguishes multiple connections to the same integration. Defaults to `"default"`. |
-| Metadata | Additional fields extracted from the token response (if `token_metadata` is configured). |
+OIDC exposes more knobs because the host identity provider can vary.
 
-### Multiple connections
+## Session Tokens
 
-A user can connect to the same integration more than once. Each connection is stored as a separate credential identified by the (user, integration, instance) tuple. This is useful when a user works across multiple accounts for the same service — for example, a personal Slack workspace and a work Slack workspace.
+Successful platform login produces a Gestalt session token:
 
-When only one connection exists, Gestalt selects it automatically. When multiple exist, the caller must specify which instance to use by passing `_instance` as a parameter on the request. See [Multi-instance connections](/concepts/integrations#multi-instance-connections) for details.
+- stored in the `session_token` cookie for browser flows
+- validated by the platform auth provider
+- used by the API when no bearer token is provided
 
-## Token refresh
+The auth middleware checks the session cookie first, then the `Authorization: Bearer ...` header.
 
-When the invoker resolves a credential and finds the access token within 5 minutes of expiry, it automatically refreshes it using the stored refresh token. The new tokens are encrypted and persisted before the upstream call proceeds. If refresh fails, the caller receives an error indicating re-authentication is needed.
+## API Tokens
 
-## Development mode
+Users can mint long-lived API tokens for direct HTTP access.
 
-When `dev_mode: true` is set in the server config:
+These tokens:
 
-- HTTPS is not required for OAuth callbacks.
-- The `X-Dev-User-Email` header impersonates a user without the full login flow.
-- The `/dev-login` endpoint creates a session without an external identity provider.
+- are created through `POST /api/v1/tokens`
+- are stored hashed, not in plaintext
+- use the prefix `gst_api_`
+- resolve back to the owning user at request time
 
-Never enable dev mode in production.
+API tokens authenticate to the same HTTP API as browser sessions.
+
+## Integration Tokens
+
+Integration tokens are the credentials Gestalt stores for upstream providers. These are different from platform sessions and API tokens.
+
+They are keyed by:
+
+- subject
+- integration name
+- instance
+
+The invocation broker resolves them based on `connection_mode`:
+
+| Mode | Token lookup |
+| --- | --- |
+| `user` | Find the calling user's token |
+| `identity` | Find the shared identity token |
+| `either` | Try user, then identity |
+| `none` | Do not look up a token |
+
+If an OAuth access token is near expiry and a refresh token exists, Gestalt refreshes it automatically and persists the new token.
+
+## Manual Auth
+
+Not every integration uses OAuth. Gestalt also supports manual connection flows, where a user pastes a token or key directly.
+
+At the config layer, that is controlled by the integration auth model:
+
+- auth type `manual`
+- or `manual_auth: true` when a provider exposes both OAuth and manual auth
+
+Manual auth still ends with a stored integration token. The difference is only how the token enters the system.
+
+## Egress Client Tokens
+
+Gestalt also has a machine-oriented token type for proxy and egress use cases.
+
+These tokens:
+
+- are created under `/api/v1/egress-clients/...`
+- use the prefix `gst_ec_`
+- authenticate as an egress client principal, not as a user
+
+They are mainly relevant when you use the proxy binding and egress policy controls.
+
+## Instances And Ambiguity
+
+If there is exactly one stored connection for an integration, Gestalt uses it automatically.
+
+If there are multiple stored instances and the caller does not specify which one to use, invocation fails with an ambiguity error. That is a deliberate safeguard; Gestalt does not guess when more than one upstream account could apply.
+
+## Dev Mode Overrides
+
+In `server.dev_mode: true`, Gestalt exposes local testing shortcuts:
+
+- `POST /api/dev-login`
+- `X-Dev-User-Email` on authenticated routes
+
+Those are development features only. They bypass normal browser auth flows so you can exercise provider and binding behavior quickly.

--- a/docs/pages/concepts/configuration.mdx
+++ b/docs/pages/concepts/configuration.mdx
@@ -1,93 +1,164 @@
 # Configuration
 
-Gestalt boots entirely from a YAML config file plus environment and secret resolution. The config is the contract between your deployment and the runtime.
+The Gestalt config file is the platform's control plane. `gestaltd` does not have a large imperative setup process; instead, it reads one YAML document and derives the runtime from it.
 
-## How config files are found
+## Config Discovery
 
-1. Explicit `--config` flag passed to the binary.
-2. `GESTALT_CONFIG` environment variable.
-3. `./config.yaml` in the current working directory.
-4. `~/.gestalt/config.yaml` as a user-level fallback.
-5. `/etc/gestalt/config.yaml` as a system-wide fallback.
+When you do not pass `--config`, `gestaltd` resolves the config path in this order:
 
-The first match wins. Gestalt does not merge multiple config files. When no config file is found and the command supports auto-generation (bare `gestaltd`), a default config is written to `~/.gestalt/config.yaml` with local auth, sqlite, and env secrets.
+1. `GESTALT_CONFIG`
+2. `./config.yaml`
+3. `~/.gestalt/config.yaml`
+4. `/etc/gestalt/config.yaml`
 
-## How values are resolved
+The default command `gestaltd` has one extra behavior: if no config exists anywhere in that search path, it generates `~/.gestalt/config.yaml` and starts with a local-only configuration.
 
-1. Raw YAML is parsed into the config struct.
-2. Environment variable references (`${VAR}`) are expanded from the process environment.
-3. Defaults are applied for any fields not explicitly set.
-4. `auth_profiles` entries are merged into integration configs that reference them by name.
-5. `base_url` from the server block is injected into OAuth callback URL construction.
-6. `secret://` references are resolved through the configured secret manager. This happens last so that secrets can contain values that would otherwise look like env vars.
+## What Happens During Load
 
-## Annotated example
+Loading a config is more than YAML parsing:
+
+1. `${ENV_VAR}` placeholders are expanded first.
+2. YAML is decoded with known-field checking.
+3. Defaults are applied.
+4. `auth_profiles` are merged into integrations and upstreams.
+5. Missing redirect URLs are derived from `server.base_url` where possible.
+6. Relative paths are resolved against the directory that contains the config file.
+7. Validation runs.
+8. During bootstrap, `secret://...` values are resolved through the configured secret manager.
+
+`secret://...` resolution is intentionally later than basic config parsing. That keeps the config loader simple and lets the secret manager itself be configured normally.
+
+## The Top-Level Feature Sets
+
+This is the complete top-level shape of the config:
+
+```yaml
+auth: {}
+datastore: {}
+secrets: {}
+auth_profiles: {}
+integrations: {}
+runtimes: {}
+bindings: {}
+server: {}
+egress: {}
+```
+
+Each block controls a distinct part of the runtime:
+
+| Block | What it defines |
+| --- | --- |
+| `server` | Port, base URL, encryption key, dev mode, and admin email allowlist. |
+| `auth` | How users authenticate to Gestalt itself. |
+| `datastore` | Where Gestalt stores users, tokens, and related runtime state. |
+| `secrets` | How `secret://...` values are resolved. |
+| `auth_profiles` | Reusable integration auth settings shared across integrations or upstreams. |
+| `integrations` | The provider graph users call. |
+| `runtimes` | Background workers. |
+| `bindings` | Additional inbound surfaces. |
+| `egress` | Outbound allow or deny policy plus credential grants. |
+
+## Defaults And Required Fields
+
+The loader applies a small number of defaults:
+
+- `server.port` defaults to `8080`
+- `secrets.provider` defaults to `env`
+
+Some fields are effectively mandatory:
+
+- `auth.provider`
+- `datastore.provider`
+- `server.encryption_key`, unless `server.dev_mode: true`
+
+`server.encryption_key` is the root secret for the deployment. Gestalt derives other cryptographic material from it, including session-related secrets for some auth providers.
+
+## Prepared State: `init`, `validate`, And `serve --locked`
+
+Gestalt supports both mutable startup and deterministic startup.
+
+### Mutable Startup
+
+`gestaltd` or `gestaltd serve` without `--locked` may mutate local state at startup:
+
+- remote REST or GraphQL upstreams can be fetched and compiled
+- packaged plugins can be prepared locally
+- missing or stale lock state can be regenerated
+
+This is convenient for development.
+
+### Deterministic Startup
+
+`gestaltd init` writes prepared artifacts next to the config:
+
+- `gestalt.lock.json`
+- `.gestalt/providers/*.json`
+- `.gestalt/plugins/...`
+
+After that, `gestaltd serve --locked` starts only if the prepared state exactly matches the config.
+
+### Validation
+
+`gestaltd validate --config PATH` is non-mutating and expects existing lock state.
+
+`gestaltd validate --init --config PATH` first prepares remote dependencies, then validates the resulting locked deployment.
+
+## Relative Paths
+
+Paths in config are resolved relative to the config file directory, not the process working directory. This matters for:
+
+- `integrations.<name>.icon_file`
+- `plugin.command`
+- local `plugin.package` paths
+
+That makes configs portable across local runs, Docker mounts, and Kubernetes volumes.
+
+## Secret References
+
+Any string value outside `secrets.config` may use the `secret://` scheme:
 
 ```yaml
 auth:
   provider: oidc
   config:
-    issuer_url: https://auth.example.com
-    client_id: ${GESTALT_OIDC_CLIENT_ID}
     client_secret: secret://oidc-client-secret
-    allowed_domains:
-      - example.com
-    session_ttl: 24h
-    pkce: true
-
-datastore:
-  provider: postgres
-  config:
-    dsn: secret://gestalt-postgres-dsn
-
-secrets:
-  provider: gcp_secret_manager
-  config:
-    project: platform-prod
-
-auth_profiles:
-  slack_shared:
-    client_id: secret://slack-client-id
-    client_secret: secret://slack-client-secret
-    auth:
-      authorization_url: https://slack.com/oauth/v2/authorize
-      token_url: https://slack.com/api/oauth.v2.access
-      response_check:
-        success_body_match:
-          ok: true
-        error_message_path: error
-
-integrations:
-  slack:
-    auth_profile: slack_shared
-    upstreams:
-      - type: rest
-        url: https://raw.githubusercontent.com/slackapi/slack-api-specs/master/web-api/slack_web_openapi_v2.json
-        allowed_operations:
-          conversations_list: ""
-          chat_postMessage: Send a message to a Slack channel
-    response_check:
-      success_body_match:
-        ok: true
-      error_message_path: error
-    connection_mode: user
-
-server:
-  port: 8080
-  base_url: https://gestalt.example.com
-  encryption_key: secret://gestalt-encryption-key
 ```
 
-## Key behaviors
+The secret manager resolves the part after `secret://`:
 
-**auth_profiles inheritance**: When an integration references an `auth_profile`, the profile's fields are merged into the integration config. Fields set directly on the integration override the profile.
+- `env` reads it from an environment variable name
+- `file` reads it from a file inside a configured directory
+- `gcp_secret_manager` reads it from Google Secret Manager
 
-**base_url for OAuth**: The server's `base_url` is used to construct OAuth redirect URIs. If it is wrong or missing, OAuth flows will fail with a redirect mismatch.
+## Dev Mode
 
-**relative paths**: `icon_file` resolves relative to the config file's directory, not the current shell working directory.
+`server.dev_mode: true` changes the server in a few important ways:
 
-**provider preparation**: `gestaltd init --config ...` writes `gestalt.lock.json` plus `.gestalt/providers/*.json` next to the source config. `gestaltd serve --config ...` uses that prepared state so runtime startup is deterministic without rewriting the config.
+- enables `POST /api/dev-login`
+- accepts `X-Dev-User-Email` for local testing
+- enables permissive dev CORS
+- registers dev-only built-ins such as the `echo` provider and `echo` runtime
 
-**allowed_operations**: A positive allow-list. Only operations listed here are callable. An empty map means no operations are exposed. The value is a human-readable description; an empty string means no custom description.
+That makes dev mode useful for local setup, but it is not a production setting.
 
-**connection_mode**: Controls credential resolution per integration. See [Platform Model](/concepts/platform-model#connection-modes) for the available modes.
+## The Smallest Explicit Config
+
+```yaml
+server:
+  port: 8080
+  base_url: http://localhost:8080
+  dev_mode: true
+  encryption_key: change-me
+
+auth:
+  provider: local
+
+datastore:
+  provider: sqlite
+  config:
+    path: ./gestalt.db
+
+integrations: {}
+```
+
+That is enough to boot a real server. Everything else is additive.

--- a/docs/pages/concepts/integrations.mdx
+++ b/docs/pages/concepts/integrations.mdx
@@ -1,224 +1,175 @@
 # Integrations
 
-Integrations are the unit of API exposure in Gestalt. Each integration declares one or more **upstreams** — the external services it connects to — along with auth settings.
+Integrations are the main user-facing primitive in Gestalt. Every integration becomes a provider at runtime, and every provider exposes operations that callers can invoke through the API, UI, bindings, runtimes, or MCP.
+
+## The Shape Of An Integration
+
+```yaml
+integrations:
+  github:
+    display_name: GitHub
+    description: GitHub REST API
+    auth_profile: github_oauth
+    connection_mode: user
+    mcp_tool_prefix: github_
+    headers:
+      X-GitHub-Api-Version: "2022-11-28"
+    upstreams:
+      - type: rest
+        url: https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json
+        mcp: true
+        allowed_operations:
+          repos_listForAuthenticatedUser: List repositories
+          issues_listForAuthenticatedUser: List assigned issues
+```
+
+This one block answers five questions:
+
+1. What should the provider be called
+2. Where do its operations come from
+3. How should credentials be resolved
+4. Which operations should be exposed
+5. Whether those operations should also appear on `/mcp`
 
 ## Upstreams
 
-Every integration has an `upstreams` list. Each entry specifies a `type` and a source:
+An integration must declare a base source of operations unless it fully replaces that source with a plugin.
 
-| Upstream type | What it does |
-|---|---|
-| `rest` | Loads operations from an OpenAPI spec URL. |
-| `graphql` | Introspects a GraphQL endpoint and generates operations from queries and mutations. |
-| `mcp` | Connects to an upstream MCP server and imports its tools as operations. |
+Supported upstream types are:
 
-An integration can combine upstream types. For example, a REST upstream and an MCP upstream together create a **composite integration** where HTTP operations are available over the REST API and MCP tools are proxied directly to the upstream MCP server.
+| Type | What it does |
+| --- | --- |
+| `rest` | Loads operations from an OpenAPI document. |
+| `graphql` | Introspects a GraphQL endpoint and exposes query and mutation fields as operations. |
+| `mcp` | Imports tools from an upstream MCP server. |
 
-## REST upstreams
+Composition is deliberately constrained:
 
-A REST upstream resolves its operations from an OpenAPI spec URL. For deterministic production startup, run `gestaltd init` ahead of time so Gestalt writes local provider artifacts into `.gestalt/providers/` and records them in `gestalt.lock.json`.
+- one `rest` or `graphql` upstream maximum
+- one `mcp` upstream maximum
+- one API upstream plus one MCP upstream is valid
 
-```yaml
-integrations:
-  slack:
-    upstreams:
-      - type: rest
-        url: https://raw.githubusercontent.com/.../slack_web_openapi_v2.json
-        allowed_operations:
-          conversations_list: List channels
-          chat_postMessage: Send a message
-    client_id: ${SLACK_CLIENT_ID}
-    client_secret: ${SLACK_CLIENT_SECRET}
-```
+## Operation Exposure
 
-## GraphQL upstreams
+`allowed_operations` narrows what a provider exposes.
 
-A GraphQL upstream introspects the endpoint at startup and generates one operation per query and mutation field. For deterministic production boots, run `gestaltd init` so the provider definition is compiled ahead of time and `gestaltd serve` can start without live introspection.
-
-```yaml
-integrations:
-  my-graphql-api:
-    upstreams:
-      - type: graphql
-        url: https://api.example.com/graphql
-        allowed_operations:
-          - searchUsers
-          - createProject
-    client_id: ${API_CLIENT_ID}
-    client_secret: ${API_CLIENT_SECRET}
-    auth:
-      authorization_url: https://example.com/oauth/authorize
-      token_url: https://example.com/oauth/token
-```
-
-Operation arguments are exposed with top-level type information so MCP clients can supply parameters. Scalar and enum types map to their JSON equivalents; complex input types map to `object`.
-
-## MCP upstreams
-
-An MCP upstream connects to a remote MCP server via Streamable HTTP, lists its tools, and imports them as Gestalt operations. These operations can only be invoked through the MCP binding — calling them over the HTTP API returns an error.
-
-```yaml
-integrations:
-  external-tools:
-    upstreams:
-      - type: mcp
-        url: https://mcp.example.com/sse
-    connection_mode: user
-```
-
-Tool annotations (read-only, destructive, idempotent) are preserved from the upstream server.
-
-## Mixed integrations
-
-An integration can combine a REST or GraphQL upstream with an MCP upstream. This creates a composite provider:
-
-```yaml
-integrations:
-  slack:
-    upstreams:
-      - type: rest
-        url: https://raw.githubusercontent.com/.../slack_web_openapi_v2.json
-        mcp: true
-        allowed_operations:
-          conversations_list: List channels
-          chat_postMessage: Send a message
-      - type: mcp
-        url: https://mcp.slack.com/sse
-    client_id: ${SLACK_CLIENT_ID}
-    client_secret: ${SLACK_CLIENT_SECRET}
-```
-
-The `mcp: true` flag on the REST upstream means its HTTP operations are also exposed as MCP tools alongside the tools from the MCP upstream.
-
-## allowed_operations
-
-The `allowed_operations` field on an upstream controls which operations are exposed. It accepts two formats:
-
-**As a list** (names only, descriptions from the upstream source):
+It supports two forms:
 
 ```yaml
 allowed_operations:
-  - conversations_list
-  - chat_postMessage
+  - repos_listForAuthenticatedUser
+  - issues_listForAuthenticatedUser
 ```
 
-**As a map** (names to description overrides):
+or:
 
 ```yaml
 allowed_operations:
-  conversations_list: List channels the user has access to
-  chat_postMessage: Send a message to a channel
+  repos_listForAuthenticatedUser: List repositories
+  issues_listForAuthenticatedUser: List assigned issues
 ```
 
-Omit `allowed_operations` entirely to allow all operations. An empty value is invalid — if you set the field, it must contain at least one entry.
+The list form keeps upstream descriptions. The map form lets you override descriptions.
 
-## What an operation looks like
+If you omit `allowed_operations`, Gestalt exposes every operation from the upstream.
 
-| Field | Description |
-|---|---|
-| Name | Unique identifier. For OpenAPI sources, this is the `operationId`. For GraphQL, the query/mutation field name. For MCP, the tool name. |
-| Description | Human-readable summary from the spec, or overridden via `allowed_operations`. |
-| Method and path | HTTP verb and URL path template (REST only). |
-| Parameters | Query, path, header, and body fields. |
-| Input schema | JSON Schema for parameters, passed to MCP clients for type information. |
-| Annotations | Automatic hints: GET/HEAD are read-only, PUT is idempotent, DELETE is destructive. MCP upstreams preserve the upstream server's annotations. |
+## Auth Inheritance
 
-## Manual auth versus OAuth
+Auth configuration can live at three layers:
 
-**OAuth**: Gestalt manages the full authorization code flow. It generates the authorization URL, handles the callback, exchanges the code for tokens, encrypts them, and stores them in the datastore. On subsequent requests, the stored access token is attached to upstream calls. If a refresh token is available and the access token is near expiry, Gestalt refreshes it automatically.
+1. `auth_profiles.<name>`
+2. `integrations.<name>`
+3. `integrations.<name>.upstreams[]`
 
-**Manual**: Set `auth.type` to `manual`. Users paste credentials directly through the web UI (`POST /api/v1/auth/connect-manual`) or CLI. Gestalt encrypts and stores them the same way it stores OAuth tokens.
+Resolution is cascading:
 
-## Dual auth
+- an integration may reference `auth_profile`
+- an upstream may reference its own `auth_profile`
+- integration-level auth fields flow down to upstreams that do not override them
 
-Some services support both OAuth and API keys. When an integration sets `manual_auth: true`, Gestalt advertises both authentication methods. Users see separate options in the web UI — "Connect with OAuth" to start the OAuth flow, or "Use API Token" to paste credentials directly.
+That lets you centralize OAuth details once and reuse them across multiple integrations.
+
+## Connection Modes
+
+`connection_mode` controls where credentials come from:
+
+| Value | Behavior |
+| --- | --- |
+| `user` | Use the authenticated caller's token. |
+| `identity` | Use a shared identity token. |
+| `either` | Prefer the user token, fall back to the identity token. |
+| `none` | Use no credential. |
+
+If you do not set it, Gestalt uses `user`.
+
+## Integration-Level Auth Behavior
+
+In addition to upstream auth config, integrations expose a few convenience fields:
+
+| Field | Purpose |
+| --- | --- |
+| `client_id`, `client_secret`, `redirect_url` | Common OAuth values applied to upstreams unless an upstream overrides them. |
+| `auth` | Low-level auth override block for OAuth or manual auth behavior. |
+| `auth_header` | Custom header used for token placement. |
+| `auth_mapping` | Maps header names to fields extracted from structured tokens. |
+| `token_prefix` | Prefix inserted before the raw token string. |
+| `auth_style` | Token style such as `bearer`, `raw`, `basic`, or `none`. |
+| `manual_auth` | Expose a manual-auth connection path alongside OAuth when supported. |
+| `response_check` | Declare success matching and error extraction. |
+| `headers` | Static request headers added to upstream calls. |
+
+## Plugins
+
+An integration can also be backed by an executable provider plugin:
 
 ```yaml
 integrations:
-  my-service:
+  example:
+    plugin:
+      command: ./example-provider
+      config:
+        greeting: hello
+```
+
+By default, that replaces upstreams entirely.
+
+If you need to wrap an existing integration, use overlay mode:
+
+```yaml
+integrations:
+  github:
     upstreams:
       - type: rest
-        url: https://api.example.com/openapi.json
-    client_id: ${SERVICE_CLIENT_ID}
-    client_secret: ${SERVICE_CLIENT_SECRET}
-    manual_auth: true
-    auth:
-      authorization_url: https://example.com/oauth/authorize
-      token_url: https://example.com/oauth/token
+        url: https://example.com/openapi.json
+    plugin:
+      mode: overlay
+      command: ./github-overlay
 ```
 
-The API returns `auth_types: ["oauth", "manual"]` for dual-auth integrations, `["oauth"]` for OAuth-only, and `["manual"]` for manual-only. Either authentication method produces the same kind of stored credential — the difference is only in how the user provides it.
+Overlay providers are only valid for integrations, not runtimes, and they must declare exactly one base source:
 
-## Multi-instance connections
+- either `upstreams`
+- or `plugin.base`
 
-By default, each user has one connection per integration. Multi-instance connections allow a user to maintain several connections to the same integration simultaneously — for example, two Slack workspaces or three Shopify stores.
+## Metadata And Presentation
 
-Each connection is identified by an **instance** name. The first connection uses the instance name `"default"`. When a user connects the same integration again with a different account, a new instance is created.
+These fields only affect how the provider is presented, not how it executes:
 
-Credential resolution follows two rules:
+- `display_name`
+- `description`
+- `icon_file`
+- `mcp_tool_prefix`
 
-- When a user has **one** connection to an integration, Gestalt selects it automatically. No instance parameter is needed.
-- When a user has **multiple** connections, the caller must specify which instance to use by passing `_instance` as a parameter. Omitting it returns a 409 error listing the available instances.
+`icon_file` is resolved relative to the config file and embedded into the prepared provider artifact during `init`.
 
-Multi-instance support requires no special configuration. Any integration can have multiple connections per user.
+## Instances
 
-To disconnect a specific instance, pass `?instance=NAME` to the disconnect endpoint. When only one connection exists, the instance parameter is optional.
+Gestalt stores connection state by `(subject, integration, instance)`.
 
-## Connection modes
+That means one integration can support:
 
-Each integration has a `connection_mode` that controls how credentials are resolved at invocation time:
+- one default connection
+- multiple named connections for the same user
+- a shared identity connection
 
-| Mode | Behavior |
-|---|---|
-| `user` | Resolve the calling user's personal token. Default. |
-| `identity` | Resolve a shared org-level or app-level token. |
-| `either` | Try the user's token first, fall back to the identity token. |
-| `none` | No credentials needed. |
-
-## Response checks
-
-Response checks handle the quirks of individual APIs without changing the core runtime.
-
-The `response_check` field provides declarative response validation. It supports two modes that can be used together or independently:
-
-**Success body match** — assert that specific fields in the JSON response have expected values. When the match fails, the error message is extracted from the path given by `error_message_path`:
-
-```yaml
-integrations:
-  my-api:
-    upstreams:
-      - type: rest
-        url: https://api.example.com/openapi.json
-    response_check:
-      success_body_match:
-        ok: true
-      error_message_path: error
-```
-
-**Error message path only** — extract a human-readable error message from error responses (HTTP 4xx/5xx) without checking success body fields:
-
-```yaml
-integrations:
-  my-api:
-    upstreams:
-      - type: rest
-        url: https://api.example.com/openapi.json
-    response_check:
-      error_message_path: error.message
-```
-
-The same structure can be used under `auth` to validate OAuth token exchange responses:
-
-```yaml
-integrations:
-  my-api:
-    auth:
-      response_check:
-        success_body_match:
-          ok: true
-        error_message_path: error
-```
-
-## Restrictions
-
-Gestalt keeps the integration model simple. There is no plugin discovery protocol, no remote registry, and no dynamic loading at runtime. Integrations are declared in config and resolved at startup. Adding or changing integrations requires a restart.
+When there is exactly one matching connection, Gestalt auto-selects it. When there are multiple, callers must name the instance explicitly.

--- a/docs/pages/concepts/mcp-binding.mdx
+++ b/docs/pages/concepts/mcp-binding.mdx
@@ -1,68 +1,87 @@
 # MCP Binding
 
-When at least one integration exposes MCP tools, Gestalt mounts a Streamable HTTP MCP endpoint at `/mcp`. REST and GraphQL upstreams opt in with `mcp: true`; `type: mcp` upstreams are always exposed. This gives AI assistants like Claude direct access to your integration operations.
+Gestalt exposes MCP as an HTTP surface mounted at `/mcp`. It is not configured under `bindings:`; instead, it appears automatically when at least one integration is MCP-enabled.
 
-## What MCP is
+## How An Integration Becomes MCP-Visible
 
-The [Model Context Protocol](https://modelcontextprotocol.io) (MCP) is an open standard for connecting AI assistants to external tools. An MCP server advertises a list of tools and handles tool calls. Gestalt's MCP binding maps each allowed integration operation to an MCP tool.
+There are two ways to expose tools on `/mcp`:
 
-## Tool generation
+### 1. Project REST Or GraphQL Operations Into MCP
 
-Gestalt generates MCP tools from provider catalogs. Providers that implement the `CatalogProvider` interface (including all REST, GraphQL, and MCP upstream providers) supply rich metadata for their operations:
-
-- **JSON Schema inputs** from OpenAPI specs are passed through directly. GraphQL operations expose top-level argument types, with complex inputs represented as `object`.
-- **Tool annotations** (read-only, destructive, idempotent) are set automatically from HTTP methods for REST operations, and preserved from the upstream server for MCP operations.
-- **Operation titles** come from the catalog when available, falling back to the operation ID.
-
-Providers without a catalog fall back to flat tool generation from the operation list with parameter-level type hints.
-
-## Tool names
-
-Each tool name is built from the provider name and operation ID:
-
-```
-{provider}_{operation}
+```yaml
+integrations:
+  github:
+    mcp_tool_prefix: github_
+    upstreams:
+      - type: rest
+        url: https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json
+        mcp: true
+        allowed_operations:
+          - repos_listForAuthenticatedUser
+          - issues_listForAuthenticatedUser
 ```
 
-For example, `search_issues` on the `linear` provider becomes `linear_search_issues`.
+Setting `mcp: true` on a REST or GraphQL upstream tells Gestalt to surface those operations as MCP tools in addition to the normal HTTP API.
 
-Set `mcp_tool_prefix` on an integration to prepend a string to that integration's MCP tool names. A prefix of `gs_` on the `linear` integration produces `gs_linear_search_issues`.
+### 2. Import Tools From An Upstream MCP Server
 
-## Auth
+```yaml
+integrations:
+  remote_tools:
+    connection_mode: user
+    upstreams:
+      - type: mcp
+        url: https://mcp.example.com
+```
 
-MCP requests use the same auth middleware as the REST API. Clients authenticate with a Bearer token in the `Authorization` header.
+In this case, Gestalt imports the upstream MCP server's tools and republishes them as part of the integration.
 
-## Relationship to the HTTP API
+## Composition Rules
 
-The MCP binding is an alternative interface, not a replacement. It shares:
+An integration may combine:
 
-- The same providers and integration definitions from config.
-- The same datastore for users, tokens, and credentials.
-- The same invoker: credential resolution, automatic token refresh, and upstream execution.
-- The same allow-list enforcement on operations.
+- one REST or GraphQL upstream
+- one MCP upstream
 
-MCP exposure is configured per integration. For REST and GraphQL upstreams, set `mcp: true` on the upstream you want to expose. For upstream MCP servers, add a `type: mcp` upstream. Gestalt mounts `/mcp` automatically once at least one integration exposes MCP tools.
+That gives you one provider namespace that can contain:
 
-## MCP upstream passthrough
+- generated HTTP operations
+- imported MCP tools
 
-When an integration includes a `type: mcp` upstream, those operations are proxied directly to the upstream MCP server rather than going through the HTTP invocation path. Gestalt resolves the user's stored credential, injects it as a Bearer token on the upstream request, and forwards the tool call. This avoids the HTTP serialization round-trip and preserves the full MCP protocol semantics.
+`mcp_tool_prefix` exists to avoid tool-name collisions when multiple integrations export similarly named operations.
 
-For composite integrations (REST/GraphQL + MCP), REST operations go through the standard invoker while MCP operations use direct passthrough.
+## What The MCP Client Sees
 
-## Mixed transport catalogs
+The MCP client does not talk directly to your upstream APIs. It talks to Gestalt:
 
-A composite integration can expose operations from different transports under a single provider name. For example, an integration with both a REST upstream and an MCP upstream presents all operations in one unified tool list. The MCP binding routes each tool call to the correct backend based on the operation's transport type.
+1. the client connects to `/mcp`
+2. Gestalt advertises tools from MCP-enabled integrations
+3. tool invocations flow through the same invocation broker as HTTP requests
+4. the broker resolves credentials, instances, refresh, and connection metadata
+5. Gestalt executes the underlying provider operation
 
-## MCP-only integrations
+This means MCP inherits the same auth and connection behavior as the rest of the platform.
 
-Integrations with only a `type: mcp` upstream cannot be invoked over the HTTP API. Calling their operations via `GET/POST /api/v1/{integration}/{operation}` returns a 400 error indicating the integration is accessible only via MCP.
+## Auth Behavior
 
-## Multi-instance tool calls
+The `/mcp` endpoint is behind the same auth middleware as the rest of the authenticated API.
 
-When a user has multiple connections to the same integration, MCP tool calls must include `_instance` as a tool argument to specify which connection to use. If the user has only one connection, the argument is optional — Gestalt selects the single connection automatically.
+That means callers authenticate with:
 
-When `_instance` is required but missing, the tool call returns an error listing the available instance names.
+- a browser session cookie
+- or `Authorization: Bearer ...` using a Gestalt API token
 
-## Limitations
+Once the request is authenticated, the integration's own `connection_mode` determines which upstream credential is used.
 
-Adding or removing integrations requires restarting the server.
+## When To Use MCP In Gestalt
+
+Use the built-in MCP surface when:
+
+- you already want Gestalt to own OAuth, token storage, and refresh
+- you want one MCP endpoint backed by many integrations
+- you want the same allowlists and connection rules to apply to both HTTP clients and MCP clients
+
+Use a direct `mcp` upstream when:
+
+- the upstream system already exposes MCP-native tools
+- you want to republish those tools through Gestalt's auth and connection model

--- a/docs/pages/concepts/platform-model.mdx
+++ b/docs/pages/concepts/platform-model.mdx
@@ -1,160 +1,143 @@
 # Platform Model
 
-Gestalt has a small set of primitives that compose into a complete API gateway for AI assistants and programmatic callers. Once you understand how they fit together, the rest of the system is predictable.
+Gestalt has a small number of primitives, but they compose into a full integration runtime. The easiest way to understand `gestaltd` is to follow the startup path from configuration to invocation.
 
-## Core primitives
+## The Core Model
 
-| Primitive | What it does |
-|---|---|
-| **Auth provider** | Authenticates users to the Gestalt platform and issues session tokens. |
-| **Datastore** | Persists users, integration tokens (encrypted), and API tokens in a pluggable backend such as Postgres, SQLite, or DynamoDB. |
-| **Secret manager** | Resolves `secret://` references in config before other components are built, keeping sensitive values out of plain-text YAML. |
-| **Integration definition** | Describes one or more upstreams (REST, GraphQL, or MCP) with their auth style, operations, and optional response checks. |
-| **Provider** | Runtime object that lists operations and executes them against upstream APIs. Built from the integration's upstreams at startup. |
-| **Operation** | A callable unit exposed by an integration, generated from an OpenAPI spec, GraphQL introspection, or MCP tool listing. |
-| **Runtime** | A background process that boots alongside the server and receives scoped access to a subset of providers. |
-| **Binding** | An alternative request surface (for example, webhooks or MCP) that forwards calls through the shared invoker. |
+At the highest level, `gestaltd` does four things:
 
-## Main concepts
+1. Load and validate a declarative config file.
+2. Bootstrap the platform components that config names.
+3. Build providers from integrations.
+4. Expose those providers through shared request surfaces.
 
-### Integrations and providers
+## The Main Primitives
 
-An **integration** is a named entry in your configuration file that describes how Gestalt connects to an external service. It declares which upstreams to use, how authentication works, and which operations to expose. Think of it as a blueprint: it tells Gestalt everything it needs to know about a service, but it does not execute anything by itself.
+| Primitive | Purpose |
+| --- | --- |
+| `auth` | Authenticates users to Gestalt itself and issues platform sessions. |
+| `datastore` | Persists users, API tokens, integration tokens, staged connections, and some egress data. |
+| `secrets` | Resolves `secret://...` references during bootstrap. |
+| `integrations` | Define the user-facing provider graph: upstreams, auth behavior, connection mode, operation allowlists, overlays, and metadata. |
+| `runtimes` | Long-lived background workers with scoped access to selected providers. |
+| `bindings` | Extra entry points, such as inbound webhooks or HTTP proxy routes. |
+| `egress` | Policy and credential rules for outbound traffic. |
 
-A **provider** is the runtime object that Gestalt builds from an integration definition at startup. The provider is what actually lists operations and executes them. When you invoke `slack/conversations_list`, the request is handled by the Slack provider, which was constructed from the `slack` integration in your config.
+## Bootstrap Order
 
-When an integration declares multiple upstream types — for example, a REST upstream and an MCP upstream — Gestalt builds a **composite provider** that merges operations from both sources into a single namespace.
+This is the actual shape of startup:
 
-### Upstreams
+1. Load YAML from the resolved config path.
+2. Expand `${ENV_VAR}` placeholders.
+3. Apply defaults such as `server.port: 8080` and `secrets.provider: env`.
+4. Resolve auth profiles and inherited upstream auth.
+5. Fill redirect URLs from `server.base_url` when possible.
+6. Resolve relative paths against the config file directory.
+7. Validate the config.
+8. Build the secret manager.
+9. Resolve `secret://...` references across the rest of the config.
+10. Build the platform auth provider.
+11. Build the datastore.
+12. Build providers from `integrations`.
+13. Build the shared invocation broker.
+14. Build scoped runtimes and bindings.
+15. Start the HTTP server, then start bindings and runtimes once providers are ready.
 
-An **upstream** is a source of operations. Every integration declares at least one. Gestalt supports three upstream types:
+## Integrations Become Providers
 
-- A **REST upstream** loads operations from an OpenAPI specification URL. Each path and method combination in the spec becomes a callable operation.
-- A **GraphQL upstream** introspects a GraphQL endpoint at startup and generates one operation per query and mutation field.
-- An **MCP upstream** connects to a remote MCP server and imports its tools as operations.
+An integration is a declarative definition. A provider is the runtime object built from it.
 
-A single integration can combine upstream types. A Slack integration, for example, might use a REST upstream for HTTP operations and an MCP upstream for additional tools. The resulting provider exposes both sets of operations under the same name.
+That distinction matters:
 
-### Operations
+- you edit `integrations.<name>` in YAML
+- `gestaltd` turns that entry into a provider at startup
+- every request surface invokes the provider, not the raw YAML
 
-An **operation** is the smallest callable unit in Gestalt. Every API call, GraphQL query, and MCP tool invocation maps to exactly one operation.
+Providers can come from three sources:
 
-Operations are identified by name. For REST upstreams, the name comes from the OpenAPI `operationId`. For GraphQL, it is the query or mutation field name. For MCP, it is the tool name. Each operation carries metadata: a human-readable description, parameter definitions with types, and annotations indicating whether the operation is read-only, destructive, or idempotent. This metadata flows through to MCP tool generation so that AI assistants can make informed decisions about which tools to call.
+| Source | How it works |
+| --- | --- |
+| Built-in named provider | `plugin.base` or a registered provider name such as `bigquery` or `jira`. |
+| Upstream-defined provider | Built from a REST, GraphQL, or MCP upstream in config. |
+| Executable plugin | Spawned as a separate process and connected over the plugin protocol. |
 
-### Plugins
+## Composition Rules
 
-A **plugin** is a Go package that implements one of Gestalt's core interfaces. Plugins are how you swap components in and out of the system without changing application code.
+The composition rules are intentionally narrow:
 
-Gestalt ships with plugins across seven categories:
+- an integration may have at most one REST or GraphQL upstream
+- an integration may have at most one MCP upstream
+- one API upstream plus one MCP upstream is valid
+- a provider plugin normally replaces upstreams entirely
+- `plugin.mode: overlay` lets a provider plugin wrap exactly one base source
 
-| Category | What it provides |
-|---|---|
-| Auth provider | Platform login and session management |
-| Datastore | Persistent storage for users and tokens |
-| Secret manager | Resolution of `secret://` references |
-| Binding | Alternative request surfaces |
-| Runtime | Background processes |
-| Provider | Operation sources |
+That gives you a predictable composition model:
 
-You select plugins by name in the config file. At startup, Gestalt instantiates the named plugin with the config you provide and wires it into the system. See [Built-in Plugins](/reference/built-in-plugins) for the full list.
+- REST only
+- GraphQL only
+- MCP only
+- REST plus MCP
+- GraphQL plus MCP
+- overlay plugin on top of one of the above
 
-### Bindings
+## The Shared Invocation Broker
 
-A **binding** is an alternative way to reach Gestalt's providers, separate from the HTTP API and MCP endpoint. Bindings receive external events and forward them through the same shared invoker that handles all other requests.
+Every execution path in Gestalt goes through the same invocation broker. That is the mechanism that makes the platform feel uniform.
 
-The built-in `webhook` binding listens for HTTP POST requests at a configured path and invokes a specific provider operation with the request body as parameters. You might use it to receive event callbacks from an upstream service and route them to an operation for processing.
+The broker is responsible for:
 
-Bindings are scoped: each binding config declares which providers it can access. This prevents a webhook endpoint from accidentally invoking operations on unrelated integrations.
+- locating the target provider and operation
+- resolving credentials based on `connection_mode`
+- choosing an instance when multiple connections exist
+- refreshing expiring OAuth tokens
+- injecting connection metadata into execution context
+- returning normalized operation results
 
-### Runtimes
+Because this broker is shared, the same token and policy behavior applies whether the caller is:
 
-A **runtime** is a long-lived background process that starts alongside the server and stops when the server shuts down. Runtimes are useful for periodic tasks, event loops, or any work that needs continuous access to provider operations without waiting for an external trigger.
+- the web UI
+- a direct HTTP client
+- an MCP client hitting `/mcp`
+- a webhook binding
+- a proxy binding
+- a background runtime
 
-Like bindings, runtimes receive a scoped invoker limited to the providers listed in their config. A runtime that only needs Slack and Linear cannot invoke operations on any other integration.
+## Connection Modes
 
-### Artifacts
+Each integration declares how credentials are resolved:
 
-A **provider artifact** is a precompiled JSON file containing a complete provider definition: metadata, auth configuration, and the full list of operations with their parameters and schemas.
+| Mode | Meaning |
+| --- | --- |
+| `user` | Use the authenticated caller's token. This is the default. |
+| `identity` | Use a shared platform-level token. |
+| `either` | Try the user's token first, then fall back to the identity token. |
+| `none` | Invoke with no credential at all. |
 
-Source configs always declare REST and GraphQL upstreams by `url`. In development, `gestaltd` resolves those upstreams live and writes prepared artifacts next to the config as needed. For deterministic deployment, run `gestaltd init` ahead of time to write `gestalt.lock.json` plus `.gestalt/providers/*.json`, then start with `gestaltd serve` so startup no longer depends on live spec fetches or GraphQL introspection.
+If an integration has more than one stored connection for the chosen subject, callers must specify an instance. If there is exactly one, Gestalt selects it automatically.
 
-### Connections and instances
+## Surfaces Built On Top
 
-A **connection** is a user's stored credential for an integration. When a user completes an OAuth flow or pastes an API key, Gestalt encrypts the resulting tokens and persists them in the datastore. Each subsequent request to that integration resolves the stored connection automatically.
+Once providers exist, `gestaltd` projects them into several surfaces:
 
-By default, each user has one connection per integration. Some integrations support multiple accounts — a user managing two Shopify stores or three Slack workspaces, for example. Gestalt handles this through **instances**: each connection is identified by a (user, integration, instance) tuple. The first connection uses the instance name `"default"`.
+| Surface | What it exposes |
+| --- | --- |
+| HTTP API | `/api/v1/...` for integration listing, auth flows, invocation, token management, egress clients, and admin egress rules. |
+| Embedded web UI | Served by the same server process and port as the API. |
+| MCP endpoint | `/mcp`, mounted only when at least one integration is MCP-enabled. |
+| Bindings | Additional routes and triggers declared under `bindings:`. |
+| Runtimes | Background workers declared under `runtimes:`. |
 
-When a user has a single connection, Gestalt selects it automatically. When multiple connections exist, the caller must pass `_instance` as a parameter to specify which one to use. Omitting it returns an error listing the available instances.
+## What The User Actually Programs Against
 
-## Execution model
+As a Gestalt operator, the main primitives you compose are:
 
-All request surfaces share a single invoker built once at startup:
+- top-level config blocks
+- integration definitions
+- upstream definitions
+- auth profiles
+- runtime definitions
+- binding definitions
+- egress rules
+- optional plugin manifests and packages
 
-| Piece | What it does |
-|---|---|
-| Shared invoker | Built in bootstrap. Used by HTTP handlers, MCP endpoint, bindings, and runtimes. |
-| Runtime deps | A runtime receives a scoped invoker plus a capability lister, limited to its allowed providers. |
-| Binding deps | A binding receives a scoped invoker so it can forward calls without accessing the full platform surface. |
-| Allowlists | Binding and runtime configs narrow which providers they can reach. |
-
-## How a request flows
-
-1. The caller authenticates with a session token or API token. Middleware resolves the caller's identity before the request reaches any handler.
-2. The shared invoker resolves the caller's stored credential for the target integration.
-3. If the access token is within 5 minutes of expiry, the invoker refreshes it automatically using the stored refresh token.
-4. The operation is matched by integration name and operation ID. If the operation is not in the integration's allow-list, the request is rejected.
-5. Gestalt applies any configured auth mapping or custom auth headers to transform the stored credential into the format the upstream API expects.
-6. Gestalt executes the upstream HTTP call, applies response checks if configured, and returns the result.
-
-## Connection modes
-
-Each integration has a connection mode that controls how credentials are resolved:
-
-| Mode | Behavior |
-|---|---|
-| `user` | Resolve the calling user's token. Each user connects independently. |
-| `identity` | Resolve a shared org-level or app-level token. |
-| `either` | Try the user's token first, fall back to the identity token. |
-| `none` | No credentials needed. The integration does not require authentication. |
-
-Set `connection_mode` on the integration config. Default is `user`.
-
-## Upstream types
-
-Each integration declares one or more upstreams that define where operations come from:
-
-| Upstream type | When to use |
-|---|---|
-| `rest` | Load operations from an OpenAPI spec URL. Use `gestaltd init` for deterministic startup. |
-| `graphql` | Introspect a GraphQL endpoint and generate operations from queries and mutations. |
-| `mcp` | Connect to an upstream MCP server and import its tools as operations. |
-
-An integration can combine multiple upstream types (e.g. REST + MCP) to create a composite provider.
-
-## Extension interfaces
-
-Gestalt's plugin system is built on interfaces defined in the `core/` package:
-
-| Interface | Package | Purpose |
-|---|---|---|
-| `AuthProvider` | `core/auth.go` | Authenticates users and issues session tokens. |
-| `Datastore` | `core/datastore.go` | Persists users, integration tokens, and API tokens. |
-| `SecretManager` | `core/secrets.go` | Resolves secret values by name. |
-| `Provider` | `core/provider.go` | Lists and executes operations against an upstream API. |
-| `OAuthProvider` | `core/provider.go` | Extends `Provider` with OAuth authorization and token exchange. |
-| `ManualProvider` | `core/provider.go` | Extends `Provider` for API-key services with no OAuth flow. |
-| `CatalogProvider` | `core/provider.go` | Exposes rich metadata (JSON Schema inputs, annotations) for MCP tool generation. |
-| `Runtime` | `core/runtime.go` | Background process with lifecycle management (`Start`/`Stop`). |
-| `Binding` | `core/binding.go` | Alternative request surface (triggers or surfaces) with HTTP routes. |
-| `Invoker` | `internal/invocation/broker.go` | Dispatches operations with credential resolution and token refresh. |
-| `CapabilityLister` | `internal/invocation/broker.go` | Lists all available operations across providers. |
-
-## Self-serve model
-
-You choose every component:
-
-- **Auth provider**: Google OAuth or any OIDC provider (Okta, Azure AD, Auth0, Keycloak, and others).
-- **Datastore**: SQLite for local dev, Postgres or MySQL for production, or DynamoDB, MongoDB, Firestore, Oracle, SQL Server for specialized environments.
-- **Secret manager**: environment variables, files, or Google Cloud Secret Manager.
-- **Integrations**: which upstream APIs to expose (Slack, Linear, Datadog, and others) and which operations within each are callable.
-- **Deployment**: laptop, VM, Kubernetes, Fly.io, Railway, Render, or AWS Lambda.
+Everything else is a consequence of those inputs.

--- a/docs/pages/concepts/plugin-packaging.mdx
+++ b/docs/pages/concepts/plugin-packaging.mdx
@@ -1,59 +1,110 @@
 # Plugin Packaging
 
-Phase 3 adds a local-first packaging workflow for third-party plugins. Instead of distributing a raw executable and pointing `plugin.command` at it, an author can ship a package archive and an operator can install it into a project-local store.
+Gestalt can run plugins directly from a local executable, but it can also install and lock packaged plugins. Packaged plugins are the better fit for deployment because they give `gestaltd init` something explicit to verify and install.
 
-## What a package contains
+## The Manifest
 
-A plugin package is a `.tar.gz` archive with:
+Every package is rooted by `plugin.json`.
 
-- `plugin.json`: the manifest
-- `artifacts/<os>/<arch>/...`: platform-specific executables
-- optional schema files such as `schemas/config.schema.json`
+A minimal provider package manifest looks like this:
 
-The manifest is the static source of truth for:
-
-- plugin ID and version
-- supported kinds (`provider`, `runtime`)
-- protocol compatibility
-- artifact inventory
-- packaged config schema path
-
-## Project-local store
-
-Installed packages live next to the config file:
-
-```text
-.gestalt/plugins/<publisher>/<name>/<version>/
+```json
+{
+  "schema_version": 1,
+  "id": "example-provider",
+  "version": "1.0.0",
+  "display_name": "Example Provider",
+  "description": "Minimal packaged provider",
+  "kinds": ["provider"],
+  "provider": {
+    "protocol": {
+      "min": 1,
+      "max": 1
+    },
+    "config_schema_path": "schemas/provider-config.json"
+  },
+  "artifacts": [
+    {
+      "os": "linux",
+      "arch": "amd64",
+      "path": "bin/example-provider-linux-amd64",
+      "sha256": "..."
+    }
+  ],
+  "entrypoints": {
+    "provider": {
+      "artifact_path": "bin/example-provider-linux-amd64"
+    }
+  }
+}
 ```
 
-This keeps deploys self-contained and reproducible. `gestaltd init` records the resolved manifest and executable path in `gestalt.lock.json`.
+The important ideas are:
 
-## CLI workflow
+- the package declares which kinds it supports
+- the manifest names platform-specific artifacts
+- entrypoints point at one of those packaged artifacts
+- provider packages may also ship a JSON Schema for config validation
 
-Package a plugin from a prepared directory:
+## Creating A Package
 
-```bash
-gestaltd plugin package --input ./package-dir --output ./acme-provider-0.1.0.tar.gz
+Build a directory that contains `plugin.json` plus the referenced artifacts, then run:
+
+```sh
+gestaltd plugin package --input ./build/example-provider --output ./dist/example-provider.tar.gz
 ```
 
-Reference the package in your config:
+That creates a distributable archive.
+
+## Using A Package In Config
+
+Packages can come from:
+
+- a local `.tar.gz`
+- a local directory
+- an HTTPS URL
+
+Example:
 
 ```yaml
 integrations:
-  acme:
+  example:
     plugin:
-      package: ./acme-provider-0.1.0.tar.gz
+      package: https://example.com/example-provider.tar.gz
+      config:
+        greeting: hello
 ```
 
-Prepare the config to extract and lock the package:
+or:
 
-```bash
-gestaltd init --config ./gestalt.yaml
+```yaml
+integrations:
+  example:
+    plugin:
+      package: ./dist/example-provider.tar.gz
 ```
 
-## `plugin.command` vs `plugin.package`
+Plain `http://` is rejected. Remote packages must use HTTPS.
 
-- `plugin.command` is the development path. Gestalt launches a local executable directly.
-- `plugin.package` is the distribution path. Points at a `.tar.gz` archive (local path or HTTPS URL). `gestaltd init` extracts it into `.gestalt/plugins/` and writes locked paths into `gestalt.lock.json`.
+## What `init` Does
 
-Use `plugin.command` while authoring and iterating locally. Use `plugin.package` for deterministic deployments and handoff to other operators.
+`gestaltd init` installs packaged plugins into local prepared state and records them in `gestalt.lock.json`.
+
+That prepared state lives under:
+
+- `.gestalt/plugins/...`
+- `gestalt.lock.json`
+
+When you later run `gestaltd serve --locked`, startup succeeds only if those prepared artifacts still match the config.
+
+## Why Packaging Matters
+
+Packaging gives you:
+
+- repeatable installs
+- artifact digest verification
+- platform-specific binaries in one archive
+- optional config schema validation
+- deterministic production startup
+
+For development, `plugin.command` is usually simpler. For deployment, `plugin.package` plus `gestaltd init` is the stronger model.

--- a/docs/pages/concepts/plugin-protocol.mdx
+++ b/docs/pages/concepts/plugin-protocol.mdx
@@ -1,366 +1,101 @@
 # Plugin Protocol
 
-Gestalt plugins are standalone executables that communicate with the host process over gRPC on Unix domain sockets. This page describes the wire protocol so you can write plugins in any language with gRPC support.
+Executable plugins let `gestaltd` extend integrations and runtimes without compiling new code into the host binary.
 
-## Why write a plugin?
+## What A Plugin Is
 
-The built-in integration system covers REST, GraphQL, and MCP upstreams declaratively. A plugin is the right choice when you need custom logic that goes beyond what declarative config supports: proprietary protocols, multi-step workflows, computed parameters, or deep integration with a language-specific SDK.
+A plugin is a separate process started by `gestaltd`. The host and plugin communicate over a local Unix socket using the Gestalt plugin gRPC protocol.
 
-A plugin is a separate process. It can be written in any language, use any dependencies, and crash without taking down the Gestalt server.
+Two plugin kinds are supported:
 
-## Architecture
+| Kind | Purpose |
+| --- | --- |
+| Provider plugin | Adds or overlays a provider for `integrations:`. |
+| Runtime plugin | Adds a background runtime under `runtimes:`. |
 
-```
-gestalt (host)                         plugin (subprocess)
-┌──────────────┐                       ┌──────────────┐
-│              │── spawns process ────→ │              │
-│              │                        │  binds to    │
-│              │                        │  unix socket │
-│              │◄─ gRPC connection ────→│              │
-│              │                        │              │
-│  Provider    │── GetMetadata ───────→ │  Provider    │
-│  client      │── StartProvider ─────→ │  server      │
-│              │── ListOperations ────→ │              │
-│              │── Execute ───────────→ │              │
-└──────────────┘                       └──────────────┘
-```
+## Startup Model
 
-The host creates a temporary directory under `/tmp` containing a Unix domain socket path. It passes this path to the plugin via the `GESTALT_PLUGIN_SOCKET` environment variable, spawns the plugin as a subprocess, then polls the socket until the plugin starts accepting connections (up to 10 seconds).
+When `gestaltd` starts a plugin process, it:
 
-All communication uses [Protocol Buffers](https://protobuf.dev/) over gRPC. The service definitions live in `sdk/pluginapi/v1/plugin.proto`.
+1. creates a temporary Unix socket
+2. sets `GESTALT_PLUGIN_SOCKET` for the child process
+3. for runtime plugins, also starts a host callback socket and sets `GESTALT_RUNTIME_HOST_SOCKET`
+4. launches the plugin executable
+5. dials the plugin and validates protocol compatibility
+6. sends the plugin its name, config, and mode
 
-## Plugin types
+The public Go SDK in `sdk/pluginsdk` handles this for you.
 
-Gestalt supports two plugin types, each defined as a separate gRPC service:
+## Provider Plugin Contract
 
-| Type | Service | Purpose |
-|---|---|---|
-| **Provider** | `ProviderPlugin` | Exposes operations that callers invoke through the Gestalt API. Equivalent to a REST or GraphQL upstream, but with arbitrary implementation logic. |
-| **Runtime** | `RuntimePlugin` | Background process that starts alongside the server and can call back into other providers through the host. |
+A provider plugin is expected to:
 
-A single binary can serve either role. The echo plugin (`cmd/gestalt-plugin-echo`) demonstrates both modes, selected by a command-line argument.
+- report provider metadata such as name, display name, description, and connection mode
+- list operations
+- execute operations
+- optionally expose a config schema
+- optionally run startup logic when the host sends `StartProvider`
 
-## Provider plugins
+The SDK's `ProviderStarter` path receives:
 
-A provider plugin implements the `ProviderPlugin` gRPC service. Four RPCs are required; five are optional.
+- the configured integration name
+- the plugin config block as a map
+- the plugin mode, such as replace or overlay
 
-### Required RPCs
+## Runtime Plugin Contract
 
-**`GetMetadata(google.protobuf.Empty) → ProviderMetadata`**
+A runtime plugin is long-lived. After startup, it can call back into the host through the runtime host socket to:
 
-Called once at startup immediately after the gRPC connection is established. Returns the provider's identity, connection mode, supported auth types, connection parameter definitions, and feature flags.
+- list the capabilities it has been granted
+- invoke allowed providers
 
-Key fields in `ProviderMetadata`:
+That is how a runtime plugin participates in the same execution model as built-in runtimes.
 
-| Field | Type | Notes |
-|---|---|---|
-| `name` | `string` | Internal identifier. Must be unique across all providers. |
-| `display_name` | `string` | Human-readable label. |
-| `description` | `string` | Short description shown in the UI and CLI. |
-| `connection_mode` | `ConnectionMode` | `NONE`, `USER`, `IDENTITY`, or `EITHER`. |
-| `auth_types` | `repeated string` | e.g. `["oauth"]`, `["manual"]`, or `["oauth", "manual"]`. |
-| `connection_params` | `map<string, ConnectionParamDef>` | Named parameters required to connect (e.g. workspace URL). |
-| `static_catalog_json` | `string` | Optional JSON-encoded catalog for resource discovery. |
-| `supports_session_catalog` | `bool` | Set `true` if you implement `GetSessionCatalog`. |
-| `supports_post_connect` | `bool` | Set `true` if you implement `PostConnect`. |
-| `config_schema_json` | `string` | Optional JSON Schema describing the `plugin.config` block. Used for startup validation for `plugin.command`, which still requires executing the binary, and for static validation when a packaged plugin is referenced via `plugin.package`. |
-| `min_protocol_version` | `int32` | Minimum protocol version the plugin supports. |
-| `max_protocol_version` | `int32` | Maximum protocol version the plugin supports. |
+## Protocol Versioning
 
-**`StartProvider(StartProviderRequest) → StartProviderResponse`**
+The host and plugin speak an explicit protocol version. Provider metadata includes a supported range, and startup fails if the current host version is outside that range.
 
-Called after `GetMetadata`, before `ListOperations`. The host sends the integration name, any `plugin.config` values from the YAML config, the plugin mode (`REPLACE` or `OVERLAY`), and the negotiated protocol version. The plugin returns its accepted protocol version.
+That check is what allows packaged plugins to be validated before or during `init`.
 
-This is where the plugin should perform any one-time initialization such as loading configuration, opening database connections, or starting background goroutines. The `config` struct contains the deserialized contents of `plugin.config` from the YAML file, with any `secret://` references already resolved by the host.
+## Config Placement
 
-**`ListOperations(google.protobuf.Empty) → ListOperationsResponse`**
-
-Called once at startup, after `StartProvider`. Returns the full list of operations this provider exposes. Each `Operation` has a `name`, `description`, HTTP `method`, and a list of `Parameter` definitions.
-
-**`Execute(ExecuteRequest) → OperationResult`**
-
-Called for every API invocation. The request contains the operation name, a `google.protobuf.Struct` of parameters, an OAuth access token (if the user is connected), and any connection parameters.
-
-Return an `OperationResult` with an HTTP-style `status` code and a `body` string (typically JSON).
-
-### Optional RPCs (OAuth)
-
-Implement these if your provider manages its own OAuth flow (when `auth_types` includes `"oauth"`):
-
-| RPC | Request | Response | Purpose |
-|---|---|---|---|
-| `AuthorizationURL` | `state`, `scopes` | `url` | Returns the OAuth authorization URL for the user to visit. |
-| `ExchangeCode` | `code` | `TokenResponse` | Exchanges an authorization code for tokens. |
-| `RefreshToken` | `refresh_token` | `TokenResponse` | Refreshes an expired access token. |
-
-### Optional RPCs (advanced)
-
-| RPC | Request | Response | Purpose |
-|---|---|---|---|
-| `GetSessionCatalog` | `token`, `connection_params` | `catalog_json` | Returns a per-session resource catalog. Only called if `supports_session_catalog` is `true` in metadata. |
-| `PostConnect` | `IntegrationToken` | `metadata` | Hook called after a user completes OAuth. Returns metadata to store alongside the token. Only called if `supports_post_connect` is `true` in metadata. |
-
-## Runtime plugins
-
-A runtime plugin implements the `RuntimePlugin` gRPC service.
-
-**`Start(StartRuntimeRequest) → google.protobuf.Empty`**
-
-Called once after the gRPC connection is established. The request contains the runtime's `name`, a `config` struct (from the YAML config), and the `initial_capabilities` list describing which provider operations are accessible.
-
-**`Stop(google.protobuf.Empty) → google.protobuf.Empty`**
-
-Called when the server is shutting down, before the process is terminated.
-
-### Host callbacks
-
-Runtime plugins can call back into the Gestalt host via the `RuntimeHost` service, available on a second Unix domain socket passed as `GESTALT_RUNTIME_HOST_SOCKET`:
-
-| RPC | Request | Response | Purpose |
-|---|---|---|---|
-| `Invoke` | `principal`, `provider`, `instance`, `operation`, `params` | `OperationResult` | Execute an operation on any provider in the runtime's scope. |
-| `ListCapabilities` | `(empty)` | `ListCapabilitiesResponse` | List all operations available to this runtime. |
-
-To use host callbacks, dial the `GESTALT_RUNTIME_HOST_SOCKET` address as a standard gRPC Unix socket connection.
-
-## Startup flow
-
-1. Gestalt creates a temporary directory (e.g. `/tmp/gstp-XXXXXX/`) containing `plugin.sock`. For runtime plugins, it also creates `host.sock` in the same directory and starts a gRPC server on it.
-2. Gestalt sets `GESTALT_PLUGIN_SOCKET` (and `GESTALT_RUNTIME_HOST_SOCKET` for runtimes) in the subprocess environment.
-3. Gestalt spawns the plugin process. The plugin's stdout and stderr are forwarded to the host's stderr.
-4. The plugin reads `GESTALT_PLUGIN_SOCKET`, binds a gRPC server to that Unix socket path, and starts serving.
-5. Gestalt polls the socket every 25ms. Once the connection succeeds:
-   - **Providers:** `GetMetadata` → protocol version compatibility check → `StartProvider` (with config and mode) → `ListOperations`.
-   - **Runtimes:** `Start` (with config and initial capabilities).
-6. If the plugin does not begin accepting connections within **10 seconds**, startup fails.
-
-### Provider startup lifecycle
-
-For provider plugins, the host follows this exact sequence:
-
-1. **`GetMetadata`** — The host reads the provider's identity and protocol version range (`min_protocol_version`, `max_protocol_version`).
-2. **Protocol compatibility check** — The host verifies that its protocol version falls within the plugin's declared range. If there is no overlap, startup fails with a version mismatch error.
-3. **`StartProvider`** — The host sends the integration name, the deserialized `plugin.config` map, the plugin mode (`REPLACE` or `OVERLAY`), and the negotiated protocol version. The plugin performs initialization and returns its accepted version.
-4. **`ListOperations`** — The host fetches the operation catalog. For overlay plugins, these operations are merged into the declarative provider's catalog.
-
-## Shutdown
-
-1. Gestalt sends `SIGTERM` to the plugin process.
-2. The plugin has **2 seconds** to shut down gracefully.
-3. If still running after 2 seconds, Gestalt sends `SIGKILL`.
-4. Gestalt removes the temporary socket directory.
-
-Your plugin should listen for `SIGTERM` and clean up promptly. For gRPC servers, call `GracefulStop()` from a signal handler.
-
-## Environment variables
-
-| Variable | Set for | Value |
-|---|---|---|
-| `GESTALT_PLUGIN_SOCKET` | All plugins | Unix socket path where the plugin must bind its gRPC server. |
-| `GESTALT_RUNTIME_HOST_SOCKET` | Runtime plugins only | Unix socket path where the host's `RuntimeHost` gRPC service is listening. |
-
-The plugin process also inherits the host's full environment, plus any additional variables specified in the `plugin.env` config block.
-
-## Configuration
-
-Plugins are configured in `gestalt.yaml`. A provider plugin is declared inside an `integrations` entry; a runtime plugin is declared inside a `runtimes` entry.
-
-Gestalt supports two plugin workflows:
-
-- `plugin.command`: local development or ad hoc execution. Gestalt launches the given executable directly.
-- `plugin.package`: packaged/distributable workflow. Points at a `.tar.gz` archive (local path or HTTPS URL). `gestaltd init` extracts the package, validates it, and writes a locked manifest and executable path into `gestalt.lock.json`.
-
-### Provider plugin
+Provider plugin config lives here:
 
 ```yaml
 integrations:
-  my-custom-provider:
+  example:
     plugin:
-      command: ./my-plugin
-      args: [provider]
-      env:
-        MY_API_KEY: ${API_KEY}
-    connection_mode: user
-```
-
-When `plugin` is set, `upstreams` cannot be used on the same integration. The plugin fully replaces the upstream-based provider.
-
-### Packaged provider plugin
-
-```yaml
-integrations:
-  my-custom-provider:
-    plugin:
-      package: ./plugins/acme-provider-0.1.0.tar.gz
-      env:
-        MY_API_KEY: ${API_KEY}
+      command: ./provider
       config:
-        some_setting: value
+        greeting: hello
 ```
 
-Then init and serve:
-
-```bash
-gestaltd init --config ./gestalt.yaml
-gestaltd serve --config ./gestalt.yaml
-```
-
-`init` extracts the package into `.gestalt/plugins/`, validates the manifest and platform-specific artifact, validates config against the packaged schema, and records the result in `gestalt.lock.json`.
-
-### Runtime plugin
+Runtime plugin config lives here:
 
 ```yaml
 runtimes:
-  my-agent:
+  syncer:
+    providers: [github]
+    plugin:
+      command: ./runtime
     config:
-      poll_interval: 30s
-    plugin:
-      command: ./my-plugin
-      args: [runtime]
-      env:
-        LOG_LEVEL: debug
-    providers:
-      - slack
-      - linear
+      interval: 30s
 ```
 
-When `plugin` is set, `type` cannot be used on the same runtime.
+That distinction matters because runtime plugin config belongs at `runtimes.<name>.config`, not under `runtimes.<name>.plugin.config`.
 
-### Plugin block fields
+## Overlay Semantics
 
-| Field | Required | Notes |
-|---|---|---|
-| `command` | Conditionally | Path to the executable. Relative paths resolve from the config file's directory. Bare names are looked up in `$PATH`. Mutually exclusive with `package`. |
-| `package` | Conditionally | Path to a `.tar.gz` plugin archive or an HTTPS URL. Relative paths resolve from the config file's directory. Mutually exclusive with `command`. |
-| `args` | No | Arguments passed to the command. Only valid with `command`. Packaged plugins use manifest-defined entrypoint args. |
-| `env` | No | Map of additional environment variables. Supports `${VAR}` expansion from the host environment. |
-| `config` | No | Provider plugins only. Arbitrary key-value map passed to `StartProvider`. Runtime plugins use `runtimes.<name>.config` instead. |
+Only provider plugins may use `mode: overlay`.
 
-### Provider plugin config
+Overlay means:
 
-The `plugin.config` block holds provider-plugin-specific configuration. It is sent as a `google.protobuf.Struct` during `StartProvider`, so the plugin receives it as a generic map of key-value pairs.
+- Gestalt first builds a base provider
+- then the plugin wraps that provider
 
-```yaml
-integrations:
-  my-provider:
-    plugin:
-      command: ./my-plugin
-      config:
-        api_endpoint: https://api.example.com
-        max_retries: 3
-        credentials: secret://my-vault/api-key
-```
+The base must come from exactly one source:
 
-Values prefixed with `secret://` are resolved by the host before being sent to the plugin. The host replaces them with the actual secret value from the configured secret manager, so the plugin never sees the `secret://` URI.
+- the integration's own `upstreams`
+- or `plugin.base`, which names a registered built-in provider factory
 
-Provider plugins can declare a `config_schema_json` field in `ProviderMetadata` to advertise a JSON Schema for this block. For `plugin.command`, the host still has to execute the binary to retrieve that schema before validating config. For packaged `plugin.package`, the schema is loaded statically from the prepared manifest during `gestaltd init` and `gestaltd validate`.
-
-### Runtime config
-
-Runtime plugin configuration lives on the runtime itself, not inside `plugin.config`. The host sends `runtimes.<name>.config` to the plugin during the `Start` RPC.
-
-```yaml
-runtimes:
-  my-agent:
-    config:
-      poll_interval: 30s
-      workspace: ops
-    plugin:
-      package: ./plugins/acme-runtime-0.1.0.tar.gz
-```
-
-For packaged runtime plugins, `gestaltd init` and `gestaltd validate` use the packaged manifest schema when one is present.
-
-## Protocol version handshake
-
-The plugin protocol uses a version negotiation scheme to allow the host and plugin to agree on compatible behavior.
-
-1. The plugin declares its supported range in `ProviderMetadata` via `min_protocol_version` and `max_protocol_version`.
-2. The host checks that its own protocol version falls within this range. If there is no overlap, the host rejects the plugin with a clear version mismatch error.
-3. During `StartProvider`, the host sends its chosen `protocol_version`. The plugin confirms by returning its accepted version in `StartProviderResponse`.
-
-Plugins that do not set `min_protocol_version` / `max_protocol_version` (i.e. they remain 0) are treated as compatible with any host version. This keeps older plugins forward-compatible until they adopt the versioned protocol.
-
-## Overlay plugins
-
-An overlay plugin extends a declarative integration rather than replacing it. When a plugin is configured with `mode: overlay`, the host composes the plugin's operations on top of the declarative provider's catalog.
-
-```yaml
-integrations:
-  jira:
-    upstreams:
-      - type: rest
-        base_url: https://api.atlassian.com
-    plugin:
-      command: ./jira-custom-ops
-      mode: overlay
-      config:
-        custom_field_id: "10042"
-```
-
-The overlay contract:
-
-- **Operations only.** The overlay plugin owns only the operations it returns from `ListOperations`. Authentication, session management, connection parameters, and catalog metadata all come from the declarative provider.
-- **No auth RPCs.** Overlay plugins should not implement `AuthorizationURL`, `ExchangeCode`, or `RefreshToken`. The host routes all auth through the declarative provider.
-- **Execute routing.** When a caller invokes an operation, the host checks the overlay's operation list first. If the operation matches, it is routed to the plugin. Otherwise, it falls through to the declarative upstream.
-- **Plugin mode.** The host sends `PLUGIN_MODE_OVERLAY` in the `StartProvider` call so the plugin knows it is running as an overlay.
-
-Exactly one of `command` or `package` must be set.
-
-## Error handling
-
-Use standard gRPC status codes to report errors. The host interprets these codes as follows:
-
-| Code | Meaning |
-|---|---|
-| `OK` | Success. |
-| `INVALID_ARGUMENT` | Bad input from the caller. |
-| `UNIMPLEMENTED` | The RPC is not supported (e.g. OAuth RPCs on a non-OAuth provider). |
-| `UNAVAILABLE` | Transient failure; the host may retry. |
-| `UNKNOWN` | Catch-all for upstream or internal errors. |
-
-Return `UNIMPLEMENTED` for optional RPCs you do not support. The Go SDK helper `UnimplementedProviderPluginServer` handles this automatically if you embed it.
-
-## Example: minimal Go provider
-
-The echo plugin (`cmd/gestalt-plugin-echo`) is a working reference. A complete example using only the public SDK lives in `examples/plugins/provider-go/`. Here is the minimal structure:
-
-```go
-package main
-
-import (
-    "context"
-    "os/signal"
-    "syscall"
-
-    pluginsdk "github.com/valon-technologies/gestalt/sdk/pluginsdk"
-)
-
-func main() {
-    ctx, stop := signal.NotifyContext(
-        context.Background(), syscall.SIGINT, syscall.SIGTERM,
-    )
-    defer stop()
-
-    // myProvider implements pluginsdk.Provider
-    if err := pluginsdk.ServeProvider(ctx, myProvider); err != nil {
-        panic(err)
-    }
-}
-```
-
-`pluginsdk.ServeProvider` reads `GESTALT_PLUGIN_SOCKET`, binds a gRPC server to it, and registers the `ProviderPlugin` service backed by your `pluginsdk.Provider` implementation. The function blocks until the context is cancelled (i.e. until the process receives SIGTERM).
-
-For non-Go languages, generate gRPC stubs from `sdk/pluginapi/v1/plugin.proto` and implement the `ProviderPlugin` or `RuntimePlugin` service directly. The startup contract is the same: read `GESTALT_PLUGIN_SOCKET`, bind a gRPC server, and start serving.
-
-## Writing plugins in other languages
-
-The plugin protocol is language-agnostic. To write a plugin in Python, TypeScript, Rust, or any other language:
-
-1. Generate gRPC client and server stubs from `sdk/pluginapi/v1/plugin.proto` using the standard protoc toolchain for your language.
-2. Read `GESTALT_PLUGIN_SOCKET` from the environment.
-3. Start a gRPC server listening on that Unix socket.
-4. Implement the `ProviderPlugin` or `RuntimePlugin` service.
-5. Handle `SIGTERM` for graceful shutdown.
-
-Official TypeScript and Python SDKs are planned but not yet available. In the meantime, generating stubs from the proto file is the supported path.
+Runtime plugins cannot use overlay mode.

--- a/docs/pages/contributing.mdx
+++ b/docs/pages/contributing.mdx
@@ -1,48 +1,45 @@
 # Contributing
 
-## Repository layout
+## Repository Layout
 
-| Directory | Purpose |
-|---|---|
-| `cmd/gestaltd` | Main Go binary. Registers all plugins and starts the server. |
-| `core` | Public interfaces: `AuthProvider`, `Datastore`, `SecretManager`, `Provider`, `OAuthProvider`, `ManualProvider`, `CatalogProvider`, `Runtime`, `Binding`. See `core/auth.go`, `core/datastore.go`, `core/secrets.go`, `core/provider.go`, `core/runtime.go`, `core/binding.go`. |
-| `internal` | Runtime packages: config loading, HTTP routing, middleware, invocation, token management, bootstrap. |
-| `plugins` | Implementations of core interfaces: auth, datastores, secrets, integrations, bindings, runtimes. |
-| `docs` | Nextra documentation site. |
-| `client/cli` | Rust CLI source. Produces the `gestalt` binary. |
-| `web` | Next.js web UI. |
-| `deploy` | Helm chart, Dockerfiles, and CI workflows. |
+| Path | Purpose |
+| --- | --- |
+| `cmd/gestaltd` | Server entrypoint, command handling, and built-in registration. |
+| `core` | Public interfaces for auth, datastore, secrets, providers, runtimes, and bindings. |
+| `internal` | Bootstrap, config loading, invocation, server routing, plugin process management, and other runtime internals. |
+| `plugins` | Built-in auth providers, datastores, secrets, bindings, runtimes, and named providers. |
+| `sdk` | Public SDKs and plugin manifest definitions. |
+| `web` | Frontend that is embedded into the server build. |
+| `docs` | Documentation site. |
+| `deploy` | Docker and Helm deployment assets. |
 
-## Add a new plugin
+## Working Principles
 
-1. Implement the interface from `core` (e.g. `core.AuthProvider`, `core.Datastore`, `core.SecretManager`).
-2. Expose a factory function that accepts the provider config and returns an initialized instance.
-3. Register the factory in `cmd/gestaltd/factories.go` so the runtime resolves it by name from config.
-4. Add tests that exercise the plugin through the same interface the runtime uses.
+When you update docs, keep them aligned with:
 
-## Add integration-specific behavior
+- config structs in `internal/config`
+- runtime wiring in `cmd/gestaltd` and `internal/bootstrap`
+- HTTP routes in `internal/server`
+- deployment assets in `Dockerfile`, `docker-compose.yml`, and `deploy/helm`
 
-Integration-specific behavior is handled through structured config fields (like `response_check` and `post_connect_discovery`) or gRPC plugins. See the [config file reference](/reference/config-file) and [gRPC plugin protocol](/reference/grpc-plugin-protocol) for details.
+The easiest way to make docs drift is to copy previous prose instead of reading the code path that actually implements the feature.
 
-## Development workflow
+## Useful Commands
 
 ```sh
-# Run tests
-cd gestalt
 go test ./...
 
-# Validate config
-gestaltd validate --config gestalt.dev.yaml
+gestaltd validate --init --config ./gestalt.dev.yaml
 
-# Run locally
-gestaltd --config gestalt.dev.yaml
-
-# Web UI
-cd web
-npm run check
+cd docs
 npm run build
 ```
 
-## Pre-push hook
+## Adding New Built-Ins
 
-The repository includes a managed pre-push hook at `.githooks/pre-push`. Git is configured to use this directory via `core.hooksPath`. The hook runs automatically when you push — do not bypass it with `--no-verify`.
+If you add a new built-in auth provider, datastore, secret manager, binding, runtime, or named provider:
+
+1. register it in the relevant `cmd/gestaltd` file
+2. add or update tests
+3. update [Built-in Plugins](/reference/built-in-plugins)
+4. update any docs or examples that describe the supported inventory

--- a/docs/pages/deploy/aws-lambda.mdx
+++ b/docs/pages/deploy/aws-lambda.mdx
@@ -1,119 +1,38 @@
-import { Callout } from 'nextra/components'
-
 # Deploy to AWS Lambda
 
-Run Gestalt as a Lambda function behind API Gateway, backed by RDS Postgres.
+AWS Lambda is possible, but it is not a first-class bundled deployment path for Gestalt. `gestaltd` is an HTTP server with long-lived semantics, so Lambda deployments need an adapter layer that converts Lambda events into HTTP traffic.
 
-<Callout>
-  Lambda fits if you already run infrastructure on AWS and want pay-per-request pricing. For simpler setups, consider [Fly.io](/deploy/fly-io), [Railway](/deploy/railway), or [Render](/deploy/render).
-</Callout>
+## When Lambda Makes Sense
 
-## Before you begin
+Choose Lambda only if you specifically want:
 
-- AWS account with permissions for Lambda, API Gateway, and RDS.
-- [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) installed and configured.
-- [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html) installed.
-- Go 1.26+ installed locally.
+- AWS-native operational tooling
+- scale-to-zero behavior
+- an adapter-based HTTP deployment model
 
-## Build the binary
+If you want the simplest operational shape, Docker, VMs, or Kubernetes are a better fit.
 
-```sh
-GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -tags lambda.norpc -o bootstrap ./cmd/gestaltd
-```
+## First-Principles Constraints
 
-The binary must be named `bootstrap` for the `provided.al2023` runtime.
+A Lambda deployment for Gestalt still needs:
 
-## Provision a database
+- one externally reachable base URL for callbacks
+- a real datastore, typically Postgres-compatible
+- the same `config.yaml` model
+- deterministic artifact preparation if you rely on remote upstream definitions or packaged plugins
 
-Aurora Serverless v2 is a good match for Lambda's bursty traffic pattern.
+SQLite is not a realistic Lambda datastore.
 
-```sh
-aws rds create-db-cluster \
-  --db-cluster-identifier gestalt-db \
-  --engine aurora-postgresql \
-  --engine-version 16.1 \
-  --serverless-v2-scaling-configuration MinCapacity=0.5,MaxCapacity=4 \
-  --master-username gestalt \
-  --master-user-password "$(openssl rand -base64 24)" \
-  --vpc-security-group-ids sg-xxxxxxxx
+## Practical Model
 
-aws rds create-db-instance \
-  --db-instance-identifier gestalt-db-1 \
-  --db-cluster-identifier gestalt-db \
-  --db-instance-class db.serverless \
-  --engine aurora-postgresql
-```
+The practical Lambda shape is:
 
-<Callout>
-  The Lambda function and RDS instance must be in the same VPC. Attach the Lambda to private subnets and allow port 5432 between them.
-</Callout>
+1. package Gestalt as a Lambda-compatible container image or custom runtime
+2. put an HTTP adapter in front of `gestaltd`
+3. use a managed SQL datastore
+4. keep `server.base_url` aligned with the API Gateway or custom domain URL
 
-## SAM template
-
-Create `template.yaml` at the repository root:
-
-```yaml
-AWSTemplateFormatVersion: "2010-09-09"
-Transform: AWS::Serverless-2016-10-31
-
-Globals:
-  Function:
-    Timeout: 30
-    MemorySize: 256
-
-Resources:
-  GestaltFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: bootstrap
-      Runtime: provided.al2023
-      Architectures:
-        - arm64
-      CodeUri: toolshed/
-      Environment:
-        Variables:
-          GESTALT_BASE_URL: !Sub "https://${GestaltApi}.execute-api.${AWS::Region}.amazonaws.com"
-          GESTALT_ENCRYPTION_KEY: "{{resolve:secretsmanager:gestalt/encryption-key}}"
-          GESTALT_SESSION_SECRET: "{{resolve:secretsmanager:gestalt/session-secret}}"
-          GOOGLE_CLIENT_ID: "{{resolve:secretsmanager:gestalt/google-client-id}}"
-          GOOGLE_CLIENT_SECRET: "{{resolve:secretsmanager:gestalt/google-client-secret}}"
-          DATABASE_URL: "{{resolve:secretsmanager:gestalt/database-url}}"
-      VpcConfig:
-        SecurityGroupIds:
-          - sg-xxxxxxxx
-        SubnetIds:
-          - subnet-xxxxxxxx
-          - subnet-yyyyyyyy
-      Events:
-        Api:
-          Type: HttpApi
-
-  GestaltApi:
-    Type: AWS::Serverless::HttpApi
-
-Outputs:
-  ApiUrl:
-    Value: !Sub "https://${GestaltApi}.execute-api.${AWS::Region}.amazonaws.com"
-```
-
-## Store secrets
-
-```sh
-aws secretsmanager create-secret --name gestalt/encryption-key \
-  --secret-string "$(openssl rand -base64 32)"
-aws secretsmanager create-secret --name gestalt/session-secret \
-  --secret-string "$(openssl rand -base64 32)"
-aws secretsmanager create-secret --name gestalt/google-client-id \
-  --secret-string "your-google-client-id"
-aws secretsmanager create-secret --name gestalt/google-client-secret \
-  --secret-string "your-google-client-secret"
-aws secretsmanager create-secret --name gestalt/database-url \
-  --secret-string "postgres://gestalt:password@cluster-endpoint:5432/gestalt"
-```
-
-## Configure
-
-Create `config.lambda.yaml`:
+## Config Shape
 
 ```yaml
 server:
@@ -122,11 +41,12 @@ server:
   encryption_key: "${GESTALT_ENCRYPTION_KEY}"
 
 auth:
-  provider: google
+  provider: oidc
   config:
-    client_id: "${GOOGLE_CLIENT_ID}"
-    client_secret: "${GOOGLE_CLIENT_SECRET}"
-    session_secret: "${GESTALT_SESSION_SECRET}"
+    issuer_url: "${OIDC_ISSUER_URL}"
+    client_id: "${OIDC_CLIENT_ID}"
+    client_secret: "${OIDC_CLIENT_SECRET}"
+    session_secret: "${OIDC_SESSION_SECRET}"
 
 datastore:
   provider: postgres
@@ -134,41 +54,8 @@ datastore:
     dsn: "${DATABASE_URL}"
 ```
 
-Bundle this alongside the `bootstrap` binary in the Lambda deployment package.
+## Operational Notes
 
-## Deploy
-
-```sh
-sam build
-sam deploy --guided
-```
-
-Subsequent deploys use the saved `samconfig.toml`:
-
-```sh
-sam deploy
-```
-
-## Verify
-
-SAM prints the API URL in the deploy output.
-
-```sh
-curl -s https://<api-id>.execute-api.<region>.amazonaws.com/health
-```
-
-## Custom domain
-
-1. Create or import a TLS certificate in ACM.
-2. Add a custom domain in API Gateway.
-3. Create a Route 53 alias record (or CNAME) pointing to the API Gateway domain.
-4. Update the base URL secret:
-
-```sh
-aws secretsmanager update-secret --secret-id gestalt/base-url \
-  --secret-string "https://gestalt.example.com"
-```
-
-## Cold starts
-
-Go on `provided.al2023` with ARM64 starts in roughly 50 to 150ms. For consistent sub-100ms latency, enable [provisioned concurrency](https://docs.aws.amazon.com/lambda/latest/dg/provisioned-concurrency.html).
+- treat Lambda as an advanced deployment, not the default
+- use locked startup if the image bakes in prepared state
+- avoid designs that depend on local filesystem mutation at cold start

--- a/docs/pages/deploy/fly-io.mdx
+++ b/docs/pages/deploy/fly-io.mdx
@@ -1,77 +1,55 @@
-import { Callout } from 'nextra/components'
-
 # Deploy to Fly.io
 
-## Before you begin
+Fly.io is a good fit when you want to run the standard Gestalt container as a single service close to users. Treat it as a manual single-container deployment, not as a separate Fly-specific runtime.
 
-- A [Fly.io](https://fly.io) account.
-- [`flyctl`](https://fly.io/docs/flyctl/install/) installed and authenticated (`fly auth login`).
+## Recommended Shape
 
-## Create the app
+Use:
 
-```sh
-fly launch --no-deploy \
-  --name gestalt \
-  --region iad \
-  --dockerfile Dockerfile
-```
+- the repo `Dockerfile`
+- a stable public hostname for `server.base_url`
+- Postgres for multi-machine deployments
+- a Fly volume only if you intentionally want SQLite
 
-Edit `fly.toml` to expose port 8080 and configure the health check:
+## Core Requirements
 
-```toml
-[http_service]
-  internal_port = 8080
-  force_https = true
+Your deployment must provide:
 
-  [[http_service.checks]]
-    grace_period = "5s"
-    interval = "15s"
-    method = "GET"
-    path = "/health"
-    timeout = "2s"
-```
+- the public base URL
+- an encryption key
+- auth-provider secrets
+- a config file mounted or baked into the image
 
-## Provision a database
+If you use SQLite, also mount persistent storage and stay on one machine.
 
-### Option A: Fly Postgres (recommended)
+## Startup Options
+
+### Simplest
+
+Start the container with:
 
 ```sh
-fly postgres create --name gestalt-db --region iad
-fly postgres attach gestalt-db --app gestalt
+/gestaltd --config /etc/gestalt/config.yaml
 ```
 
-This sets `DATABASE_URL` automatically.
+This allows mutable startup.
 
-### Option B: SQLite with a persistent volume
+### Preferred Production Shape
+
+Run `gestaltd init` before the main process starts, then run:
 
 ```sh
-fly volumes create gestalt_data --region iad --size 1
+/gestaltd serve --locked --config /etc/gestalt/config.yaml
 ```
 
-Add a mount in `fly.toml`:
+On Fly, that usually means either:
 
-```toml
-[mounts]
-  source = "gestalt_data"
-  destination = "/data"
-```
+- baking prepared state into the image
+- or using a release/init step that writes lock state to attached storage
 
-<Callout>
-  SQLite limits you to a single instance. Set `fly scale count 1` to prevent multiple machines from competing for the same file.
-</Callout>
+## Config Guidance
 
-## Configure
-
-```sh
-fly secrets set \
-  GESTALT_BASE_URL="https://gestalt.fly.dev" \
-  GESTALT_ENCRYPTION_KEY="$(openssl rand -base64 32)" \
-  GESTALT_SESSION_SECRET="$(openssl rand -base64 32)" \
-  GOOGLE_CLIENT_ID="your-google-client-id" \
-  GOOGLE_CLIENT_SECRET="your-google-client-secret"
-```
-
-Create `config.fly.yaml`:
+Use a config shaped like this:
 
 ```yaml
 server:
@@ -84,7 +62,6 @@ auth:
   config:
     client_id: "${GOOGLE_CLIENT_ID}"
     client_secret: "${GOOGLE_CLIENT_SECRET}"
-    session_secret: "${GESTALT_SESSION_SECRET}"
 
 datastore:
   provider: postgres
@@ -92,36 +69,18 @@ datastore:
     dsn: "${DATABASE_URL}"
 ```
 
-Point the process at the config in `fly.toml`:
+If you use SQLite instead:
 
-```toml
-[processes]
-  app = "/gestaltd --config /etc/gestalt/config.yaml"
+```yaml
+datastore:
+  provider: sqlite
+  config:
+    path: /data/gestalt.db
 ```
 
-## Deploy
+## Operational Notes
 
-```sh
-fly deploy
-```
-
-## Verify
-
-```sh
-fly status
-curl -s https://gestalt.fly.dev/health
-```
-
-You should see `{"status":"ok"}`.
-
-## Custom domain
-
-```sh
-fly certs add gestalt.example.com
-```
-
-Create a CNAME record pointing `gestalt.example.com` to `gestalt.fly.dev`, then update the base URL:
-
-```sh
-fly secrets set GESTALT_BASE_URL="https://gestalt.example.com"
-```
+- expose port `8080`
+- keep `server.base_url` aligned with the external Fly hostname or custom domain
+- use one machine when SQLite is active
+- prefer locked startup if your config depends on remote upstream definitions or packaged plugins

--- a/docs/pages/deploy/index.mdx
+++ b/docs/pages/deploy/index.mdx
@@ -1,97 +1,106 @@
-import { Callout, Cards } from 'nextra/components'
+import { Cards } from 'nextra/components'
 
 # Deploy
 
-Gestalt compiles to a single statically-linked Go binary and ships as a minimal Docker image. It runs anywhere you can run a container or a Linux binary.
+`gestaltd` deploys as a single HTTP service. The API, embedded web UI, health endpoints, and optional `/mcp` endpoint all come from the same server process and normally the same port.
 
-## Resource requirements
+## Deployment Checklist
 
-| | Minimum | Recommended |
-|---|---|---|
-| CPU | 1 vCPU | 2 vCPU |
-| Memory | 256 MB | 512 MB |
-| Disk | 1 GB (SQLite) | Managed database |
+Every deployment needs the same inputs:
 
-## What every deployment needs
+1. A `gestaltd` binary or container image.
+2. A `config.yaml`.
+3. Environment variables or secret-manager entries for sensitive values.
+4. A datastore choice that matches your scaling model.
+5. A clear startup mode: mutable startup or locked startup.
 
-1. **Gestalt image or binary.** Build from `Dockerfile` or compile with `CGO_ENABLED=0 go build ./cmd/gestaltd`.
-2. **Config YAML file.** Mounted or bundled. See [Config File](/reference/config-file) for the schema.
-3. **Environment variables for secrets.** The config supports `${VAR}` placeholders expanded at startup. Never hardcode secrets.
-4. **A database.** SQLite with a persistent volume, Postgres, MySQL, or any [supported datastore](/reference/built-in-plugins#datastores).
-5. **A stable `base_url`.** Gestalt derives OAuth callback URLs from this. It must be the externally-reachable URL.
+## Choose A Startup Mode
 
-## Environment variables
+| Mode | Command | When to use it |
+| --- | --- | --- |
+| Mutable | `gestaltd --config ...` or `gestaltd serve --config ...` | Local development or simple single-node deployments. |
+| Locked | `gestaltd init --config ...` then `gestaltd serve --locked --config ...` | Production deployments that should not fetch remote specs or mutate local state at boot. |
 
-### Server
+If your config depends on remote REST or GraphQL upstreams, or packaged plugins, the locked flow is the safer deployment model.
 
-| Variable | Purpose | Required |
-|---|---|---|
-| `GESTALT_BASE_URL` | External URL for OAuth callbacks | Yes |
-| `GESTALT_ENCRYPTION_KEY` | Symmetric key for encrypting stored tokens. Generate: `openssl rand -base64 32` | Yes |
-| `GESTALT_SESSION_SECRET` | Signs session cookies. Generate: `openssl rand -base64 32` | Yes |
+## Bundled Deployment Paths
 
-### Auth
+The repository ships these deployment assets:
 
-| Variable | Purpose | Required |
-|---|---|---|
-| `GOOGLE_CLIENT_ID` | Google OAuth client ID | If using Google auth |
-| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret | If using Google auth |
+| Path | What it gives you |
+| --- | --- |
+| `gestaltd` with no config | True out-of-the-box local startup. |
+| `Dockerfile` | Single-container image with `gestaltd` as the entrypoint. |
+| `docker-compose.yml` | Single-container local deployment with mounted config and SQLite volume. |
+| `deploy/helm/gestalt` | Helm chart for Kubernetes. |
 
-### Datastore
+## Docker And Compose
 
-| Variable | Purpose | Required |
-|---|---|---|
-| `DATABASE_URL` | Connection string for Postgres, MySQL, or other SQL datastores | If not using SQLite |
+The root `Dockerfile` builds:
 
-### Integrations
+- the frontend static export
+- the `gestaltd` binary
+- one final image that serves both API and UI
 
-Each integration needs its own OAuth credentials. Follow the pattern `<INTEGRATION>_CLIENT_ID` and `<INTEGRATION>_CLIENT_SECRET`.
-
-## Minimal production config
-
-```yaml
-server:
-  port: 8080
-  base_url: "${GESTALT_BASE_URL}"
-  encryption_key: "${GESTALT_ENCRYPTION_KEY}"
-
-auth:
-  provider: google
-  config:
-    client_id: "${GOOGLE_CLIENT_ID}"
-    client_secret: "${GOOGLE_CLIENT_SECRET}"
-    session_secret: "${GESTALT_SESSION_SECRET}"
-
-datastore:
-  provider: postgres
-  config:
-    dsn: "${DATABASE_URL}"
-```
-
-## Validate before deploying
+The image defaults to:
 
 ```sh
-gestaltd validate --config your-config.yaml
+/gestaltd --config /etc/gestalt/config.yaml
 ```
 
-`gestaltd validate` warns when SQLite is configured as the datastore, since it is not recommended for production.
+That is a mutable-startup path. If you want locked startup, override the command and make sure the lockfile and prepared artifacts exist next to the mounted config.
 
-## Choose a platform
+The bundled `docker-compose.yml` is the quickest containerized path:
+
+```sh
+docker compose up --build
+```
+
+It mounts:
+
+- `./deploy/docker/config.yaml` to `/etc/gestalt/config.yaml`
+- a named volume at `/data` for SQLite
+
+## Bare Binary
+
+The bare-binary model is straightforward:
+
+```sh
+gestaltd validate --init --config ./gestalt.yaml
+gestaltd serve --locked --config ./gestalt.yaml
+```
+
+That is often the cleanest way to run Gestalt on a VM, inside systemd, or in a custom container build.
+
+## Kubernetes
+
+The bundled Helm chart is the most complete production deployment path in the repo. It uses one Deployment for `gestaltd` and can optionally add an init container that runs `gestaltd init` before the main container starts.
+
+See [Kubernetes](/deploy/kubernetes) for the exact chart behavior.
+
+## Other Platforms
+
+Fly.io, Railway, Render, and Lambda are valid targets, but they are manual deployment patterns rather than separately maintained runtimes. The key idea is always the same:
+
+- run the same single `gestaltd` service
+- provide `config.yaml`
+- expose the public base URL
+- choose mutable or locked startup intentionally
 
 <Cards>
+  <Cards.Card title="Kubernetes" href="/deploy/kubernetes">
+    The bundled Helm chart. One Deployment, one Service, optional init container, and locked startup.
+  </Cards.Card>
   <Cards.Card title="Fly.io" href="/deploy/fly-io">
-    Container PaaS with built-in Postgres and persistent volumes.
+    Single-container deployment with either a Fly volume for SQLite or an external SQL datastore.
   </Cards.Card>
   <Cards.Card title="Railway" href="/deploy/railway">
-    Deploy from GitHub with one-click Postgres provisioning.
+    Manual Docker deployment. Best with Postgres and either baked or pre-prepared lock state.
   </Cards.Card>
   <Cards.Card title="Render" href="/deploy/render">
-    Managed web services with optional persistent disks.
+    Docker web service with either a persistent disk for SQLite or an external SQL datastore.
   </Cards.Card>
   <Cards.Card title="AWS Lambda" href="/deploy/aws-lambda">
-    Serverless with pay-per-request pricing and RDS.
-  </Cards.Card>
-  <Cards.Card title="Kubernetes" href="/deploy/kubernetes">
-    Helm chart for clusters you already operate.
+    Adapter-based deployment for a server that is fundamentally HTTP-first.
   </Cards.Card>
 </Cards>

--- a/docs/pages/deploy/kubernetes.mdx
+++ b/docs/pages/deploy/kubernetes.mdx
@@ -1,46 +1,69 @@
-import { Callout } from 'nextra/components'
-
 # Deploy to Kubernetes
 
-The repository ships a Helm chart at `deploy/helm/gestalt`.
+The repo ships a Helm chart at `deploy/helm/gestalt`. It runs `gestaltd` as a single Deployment and exposes it through one Kubernetes Service.
 
-## What the chart creates
+## What The Chart Actually Creates
 
-| Resource | Purpose |
-|---|---|
-| API Deployment | Runs the Go API server. |
-| Web Deployment | Runs the Next.js web UI, proxying API requests to the API service. |
-| Services | One for the API (port 8080), one for the web UI (port 3000). |
-| ConfigMap | Holds Gestalt config YAML with `${ENV_VAR}` placeholders. |
-| Ingress | Optional path-based routing (`/api/v1` to API, `/` to web). |
-| PVC | Persistent volume for SQLite when persistence is enabled. |
+The chart creates:
 
-<Callout>
-  The example chart values use SQLite with a single replica. Switch to Postgres or MySQL before scaling horizontally.
-</Callout>
+- one `Deployment`
+- one `Service`
+- an optional `Ingress`
+- an optional persistent volume claim for `/data`
+- an optional init container for `gestaltd init`
 
-## Minimal values
+There is no separate web Deployment. The web UI is served by the same `gestaltd` container as the API.
 
-The chart uses `${ENV_VAR}` placeholders in config, injected at runtime via `extraEnv`. This keeps secrets out of the ConfigMap.
+## Important Runtime Detail
+
+The main container always starts with:
+
+```sh
+gestaltd serve --locked --config /etc/gestalt/config.yaml
+```
+
+That means locked startup is the normal Kubernetes path.
+
+## `pluginInit.enabled`
+
+The chart supports an init container behind `pluginInit.enabled`.
+
+When enabled, the init container:
+
+1. copies the rendered config into a writable directory
+2. runs `gestaltd init --config /etc/gestalt/config.yaml`
+3. leaves `gestalt.lock.json` and `.gestalt/` in a shared volume
+
+The main container then reads from that prepared state.
+
+When disabled, the main container still uses `serve --locked`, so your config must not require preparation unless you have already baked the lock state into the image or mounted it yourself.
+
+## Recommended Values Shape
+
+For production, prefer a SQL datastore and an explicit base URL.
 
 ```yaml
-replicaCount: 1
+replicaCount: 2
 
 config:
   server:
     port: 8080
     base_url: "${GESTALT_BASE_URL}"
     encryption_key: "${GESTALT_ENCRYPTION_KEY}"
+    dev_mode: false
   auth:
-    provider: google
+    provider: oidc
     config:
-      client_id: "${GOOGLE_CLIENT_ID}"
-      client_secret: "${GOOGLE_CLIENT_SECRET}"
-      session_secret: "${GESTALT_SESSION_SECRET}"
+      issuer_url: "${OIDC_ISSUER_URL}"
+      client_id: "${OIDC_CLIENT_ID}"
+      client_secret: "${OIDC_CLIENT_SECRET}"
+      session_secret: "${OIDC_SESSION_SECRET}"
+      display_name: "Company SSO"
   datastore:
-    provider: sqlite
+    provider: postgres
     config:
-      path: /data/gestalt.db
+      dsn: "${DATABASE_URL}"
+  integrations: {}
 
 extraEnv:
   - name: GESTALT_BASE_URL
@@ -50,46 +73,66 @@ extraEnv:
       secretKeyRef:
         name: gestalt-secrets
         key: encryption-key
-  - name: GESTALT_SESSION_SECRET
+  - name: OIDC_ISSUER_URL
+    value: "https://login.example.com"
+  - name: OIDC_CLIENT_ID
     valueFrom:
       secretKeyRef:
         name: gestalt-secrets
-        key: session-secret
-  - name: GOOGLE_CLIENT_ID
+        key: oidc-client-id
+  - name: OIDC_CLIENT_SECRET
     valueFrom:
       secretKeyRef:
         name: gestalt-secrets
-        key: google-client-id
-  - name: GOOGLE_CLIENT_SECRET
+        key: oidc-client-secret
+  - name: OIDC_SESSION_SECRET
     valueFrom:
       secretKeyRef:
         name: gestalt-secrets
-        key: google-client-secret
+        key: oidc-session-secret
+  - name: DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: gestalt-secrets
+        key: database-url
 
-web:
+pluginInit:
   enabled: true
-  image:
-    repository: gestalt-web
-    tag: latest
 ```
 
 ## Install
 
 ```sh
-helm install gestalt ./deploy/helm/gestalt -f my-values.yaml
+helm upgrade --install gestalt ./deploy/helm/gestalt -f values.yaml
 ```
 
-## Verify
+If you use ingress, make sure `config.server.base_url` matches the public URL exactly. That is what Gestalt uses for callback derivation.
 
-```sh
-kubectl get pods
-kubectl port-forward svc/gestalt 8080:8080
-curl http://127.0.0.1:8080/health
-```
+## SQLite Versus SQL
 
-## Hardening
+The chart defaults to SQLite plus a persistent volume. That is acceptable for:
 
-- Inject secrets through `extraEnv` with `secretKeyRef` rather than inlining them in the config block.
-- Set `base_url` to a stable, externally reachable URL.
-- Switch to Postgres or MySQL before running more than one replica. SQLite does not support concurrent writers.
-- Enable ingress for path-based routing: `/api/v1` to the API service, `/` to the web UI.
+- local clusters
+- demos
+- single-replica deployments
+
+It is not the right default for horizontal scaling. If you want more than one replica, move to Postgres or MySQL.
+
+## Health And Readiness
+
+The chart probes:
+
+- `/health` for liveness
+- `/ready` for readiness
+
+`/ready` stays non-ready until providers finish loading and the datastore is reachable.
+
+## When To Enable The Init Container
+
+Enable `pluginInit.enabled` when any of these are true:
+
+- an integration uses a remote OpenAPI spec
+- an integration uses a remote GraphQL schema
+- an integration or runtime uses `plugin.package`
+
+If none of those apply, you can keep it off and still use locked startup.

--- a/docs/pages/deploy/railway.mdx
+++ b/docs/pages/deploy/railway.mdx
@@ -1,48 +1,62 @@
-import { Callout } from 'nextra/components'
-
 # Deploy to Railway
 
-## Before you begin
+Railway is a manual Docker deployment target for Gestalt. The core model stays the same: one `gestaltd` service, one config file, one public base URL, and either mutable or locked startup.
 
-- A [Railway](https://railway.app) account.
-- Your Gestalt repository on GitHub.
+## Recommended Shape
 
-## Deploy from GitHub
+For Railway, prefer:
 
-1. Create a new project in the Railway dashboard.
-2. Select **Deploy from GitHub repo** and connect your repository.
-3. Set **Root Directory** to `toolshed/`.
-4. Railway detects the Dockerfile and begins the first build.
+- Postgres over SQLite
+- a committed or baked config file
+- locked startup if your config references remote upstreams or packaged plugins
 
-<Callout>
-  The app will crash without a database and environment variables. Cancel the initial deploy or let it fail, then continue below.
-</Callout>
+## Port Handling
 
-## Add a database
-
-1. In your Railway project, click **New** then **Database** then **PostgreSQL**.
-2. Link the variable: in the Gestalt service's **Variables** tab, add `DATABASE_URL` set to `${{Postgres.DATABASE_URL}}`.
-
-## Set environment variables
-
-Add these in the Gestalt service's **Variables** tab:
-
-| Variable | Value |
-|---|---|
-| `GESTALT_BASE_URL` | `https://<domain>.up.railway.app` |
-| `GESTALT_ENCRYPTION_KEY` | Output of `openssl rand -base64 32` |
-| `GESTALT_SESSION_SECRET` | Output of `openssl rand -base64 32` |
-| `GOOGLE_CLIENT_ID` | Your Google OAuth client ID |
-| `GOOGLE_CLIENT_SECRET` | Your Google OAuth client secret |
-| `DATABASE_URL` | `${{Postgres.DATABASE_URL}}` |
-
-## Configure
-
-Commit a config file at `config.railway.yaml`:
+If your Railway service injects a dynamic port, wire it straight into config:
 
 ```yaml
 server:
-  port: 8080
+  port: ${PORT}
+  base_url: "${GESTALT_BASE_URL}"
+  encryption_key: "${GESTALT_ENCRYPTION_KEY}"
+```
+
+If you control the container port directly, `8080` is the natural default.
+
+## Datastore Guidance
+
+Use Postgres for normal Railway deployments:
+
+```yaml
+datastore:
+  provider: postgres
+  config:
+    dsn: "${DATABASE_URL}"
+```
+
+SQLite is possible only if you accept a single-instance deployment and durable mounted storage.
+
+## Startup Guidance
+
+Mutable startup:
+
+```sh
+/gestaltd --config /app/config.yaml
+```
+
+Locked startup:
+
+```sh
+/gestaltd serve --locked --config /app/config.yaml
+```
+
+If you choose locked startup, make sure `gestalt.lock.json` and `.gestalt/` exist next to the config inside the container image or on attached storage.
+
+## Minimum Config
+
+```yaml
+server:
+  port: ${PORT}
   base_url: "${GESTALT_BASE_URL}"
   encryption_key: "${GESTALT_ENCRYPTION_KEY}"
 
@@ -51,7 +65,6 @@ auth:
   config:
     client_id: "${GOOGLE_CLIENT_ID}"
     client_secret: "${GOOGLE_CLIENT_SECRET}"
-    session_secret: "${GESTALT_SESSION_SECRET}"
 
 datastore:
   provider: postgres
@@ -59,26 +72,8 @@ datastore:
     dsn: "${DATABASE_URL}"
 ```
 
-Override the container start command in Railway's service settings:
+## Operational Notes
 
-```
-/gestaltd --config /build/toolshed/config.railway.yaml
-```
-
-<Callout>
-  The path depends on how Railway copies your repo into the build context. Check the build logs if `/build/toolshed/` does not resolve.
-</Callout>
-
-## Verify
-
-Find the public URL in **Settings** then **Networking** then **Public Networking**.
-
-```sh
-curl -s https://<domain>.up.railway.app/health
-```
-
-## Custom domain
-
-1. Go to **Networking** then **Custom Domain** in service settings.
-2. Follow the DNS instructions Railway provides.
-3. Update `GESTALT_BASE_URL` to the new domain.
+- set `server.base_url` to the public Railway URL or your custom domain
+- keep secrets out of YAML and feed them via env vars or a secret manager
+- prefer locked startup for deterministic deploys

--- a/docs/pages/deploy/render.mdx
+++ b/docs/pages/deploy/render.mdx
@@ -1,79 +1,45 @@
-import { Callout } from 'nextra/components'
-
 # Deploy to Render
 
-## Before you begin
+Render runs Gestalt well as a standard Docker web service. The important choice is whether you want a simple single-instance SQLite deployment or a production-style SQL deployment.
 
-- A [Render](https://render.com) account.
-- Your Gestalt repository on GitHub or GitLab.
+## Recommended Shape
 
-## Create a web service
+Use:
 
-1. Click **New** then **Web Service** in the Render dashboard.
-2. Connect your repository.
-3. Set **Root Directory** to `toolshed/`.
-4. Render detects the Dockerfile. Set **Environment** to **Docker**.
-5. Select at least the **Starter** plan (512 MB RAM).
+- Docker web service
+- Postgres for normal production use
+- Render persistent disk only when you intentionally want SQLite
 
-## Add a database
+## Port Handling
 
-1. Click **New** then **PostgreSQL**.
-2. Choose a plan and region matching your web service.
-3. Copy the **Internal Database URL** (stays within Render's private network).
-
-## Set environment variables
-
-In the web service's **Environment** tab:
-
-| Key | Value |
-|---|---|
-| `GESTALT_BASE_URL` | `https://<service>.onrender.com` |
-| `GESTALT_ENCRYPTION_KEY` | Output of `openssl rand -base64 32` |
-| `GESTALT_SESSION_SECRET` | Output of `openssl rand -base64 32` |
-| `GOOGLE_CLIENT_ID` | Your Google OAuth client ID |
-| `GOOGLE_CLIENT_SECRET` | Your Google OAuth client secret |
-| `DATABASE_URL` | Internal Database URL from the Postgres dashboard |
-
-<Callout>
-  Use the **Internal** Database URL (starts with `postgres://`) to keep traffic on Render's private network. The external URL works but adds latency.
-</Callout>
-
-## Configure
-
-Commit `config.render.yaml`:
+If Render injects a service port, set:
 
 ```yaml
 server:
-  port: 8080
+  port: ${PORT}
+```
+
+Then layer in the rest of the normal server config:
+
+```yaml
+server:
+  port: ${PORT}
   base_url: "${GESTALT_BASE_URL}"
   encryption_key: "${GESTALT_ENCRYPTION_KEY}"
+```
 
-auth:
-  provider: google
-  config:
-    client_id: "${GOOGLE_CLIENT_ID}"
-    client_secret: "${GOOGLE_CLIENT_SECRET}"
-    session_secret: "${GESTALT_SESSION_SECRET}"
+## Datastore Options
 
+### Preferred
+
+```yaml
 datastore:
   provider: postgres
   config:
     dsn: "${DATABASE_URL}"
 ```
 
-Set the **Docker Command** override:
-
-```
-/gestaltd --config config.render.yaml
-```
-
-## Using SQLite instead
-
-Attach a **Persistent Disk** to the web service:
-
-1. Go to **Disks** in service settings.
-2. Add a disk with mount path `/data` and at least 1 GB.
-3. Set the datastore config:
+### Single-Instance SQLite
 
 ```yaml
 datastore:
@@ -82,18 +48,26 @@ datastore:
     path: /data/gestalt.db
 ```
 
-<Callout>
-  Render's persistent disks are tied to a single instance. You cannot scale beyond one replica with SQLite.
-</Callout>
+If you choose SQLite, attach a persistent disk and stay on one instance.
 
-## Verify
+## Startup Guidance
+
+Mutable startup:
 
 ```sh
-curl -s https://<service>.onrender.com/health
+/gestaltd --config /app/config.yaml
 ```
 
-## Custom domain
+Locked startup:
 
-1. Go to **Custom Domains** in service settings.
-2. Configure DNS as Render instructs.
-3. Update `GESTALT_BASE_URL` to the new domain.
+```sh
+/gestaltd serve --locked --config /app/config.yaml
+```
+
+Locked startup requires prepared state next to the config file inside the container or on mounted storage.
+
+## Operational Notes
+
+- keep `server.base_url` aligned with the public Render URL or custom domain
+- use env vars or secret-manager references for sensitive values
+- treat Render as the same single-service model as any other Docker target

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -2,103 +2,108 @@ import { Callout, Steps } from 'nextra/components'
 
 # Getting Started
 
-This guide walks you through standing up a local Gestalt instance, connecting a Slack integration, and invoking your first operation from the CLI. You will have a working setup in under five minutes.
+This guide starts with the true out-of-the-box flow, then moves to an explicit config and a production-style startup path.
 
-## Before you begin
+## 1. Run `gestaltd` With No Config
 
-- Google OAuth credentials (or any OIDC provider).
-- Node.js 18+ (for the web UI).
+```sh
+gestaltd
+```
 
-## Create a config file
+If no config file exists and you did not pass `--config`, `gestaltd` creates `~/.gestalt/config.yaml` for you and starts immediately.
 
-Save the following as `gestalt.local.yaml` in the project root. This file defines the server, auth provider, datastore, and one integration (Slack) with two allowed operations.
+The generated local config uses:
+
+- `auth.provider: local`
+- `datastore.provider: sqlite`
+- `secrets.provider: env`
+- `server.dev_mode: true`
+- a generated `server.encryption_key`
+- `~/.gestalt/gestalt.db` as the SQLite database
+
+The server listens on `http://localhost:8080`. The web UI is served from that same port.
+
+<Callout>
+  The default command `gestaltd` is intentionally local-friendly. It can auto-generate config and auto-prepare remote artifacts. Production deployments should usually use `gestaltd init` followed by `gestaltd serve --locked`.
+</Callout>
+
+## 2. Open The UI And Sign In
+
+<Steps>
+### Open the server
+
+Visit `http://localhost:8080`.
+
+### Sign in
+
+The generated config uses the built-in `local` auth provider, so you can sign in without Google or OIDC credentials.
+
+### Inspect the default environment
+
+Because the generated config enables `server.dev_mode: true`, dev-only surfaces such as the built-in `echo` provider are available for local experimentation.
+</Steps>
+
+## 3. Switch To An Explicit Config
+
+Save this as `gestalt.yaml`:
 
 ```yaml
 server:
   port: 8080
   base_url: http://localhost:8080
   dev_mode: true
-  encryption_key: local-dev-key
+  encryption_key: change-me
 
 auth:
-  provider: google
-  config:
-    client_id: ${GOOGLE_CLIENT_ID}
-    client_secret: ${GOOGLE_CLIENT_SECRET}
+  provider: local
 
 datastore:
   provider: sqlite
   config:
-    path: ./gestalt.local.db
+    path: ./gestalt.db
 
 integrations:
-  slack:
+  petstore:
+    display_name: Swagger Petstore
+    description: Public example API
+    connection_mode: none
     upstreams:
       - type: rest
-        url: https://raw.githubusercontent.com/slackapi/slack-api-specs/master/web-api/slack_web_openapi_v2.json
+        url: https://petstore3.swagger.io/api/v3/openapi.json
         allowed_operations:
-          conversations_list: List channels
-          chat_postMessage: Send a message
-    client_id: ${SLACK_CLIENT_ID}
-    client_secret: ${SLACK_CLIENT_SECRET}
-    response_check:
-      success_body_match:
-        ok: true
-      error_message_path: error
-    auth:
-      authorization_url: https://slack.com/oauth/v2/authorize
-      token_url: https://slack.com/api/oauth.v2.access
-      response_check:
-        success_body_match:
-          ok: true
-        error_message_path: error
+          findPetsByStatus: List pets by status
+          getPetById: Fetch a pet by id
 ```
 
-<Callout>
-  `base_url` tells Gestalt where to build OAuth callback URLs. If this value is wrong or missing, every OAuth flow will fail with a redirect mismatch error. For local development, `http://localhost:8080` is the correct value.
-</Callout>
+This is the smallest useful production-shaped config:
 
-## Start the server
+- explicit `server`, `auth`, and `datastore`
+- one named integration
+- one REST upstream
+- no per-user credential requirement because `connection_mode: none`
+
+## 4. Prepare And Validate It
 
 ```sh
-gestaltd --config gestalt.local.yaml
+gestaltd validate --init --config ./gestalt.yaml
 ```
 
-This starts both the API server (port 8080) and the web UI (port 3000). `gestaltd` also prepares any remote REST or GraphQL providers automatically for local use. When dev mode is enabled, you will see "dev mode enabled" in the output; this confirms that dev login and relaxed CORS are active.
+`--init` resolves remote provider inputs first, then validates the final locked state. For the config above, that writes:
 
-## Sign in and connect Slack
+- `gestalt.lock.json`
+- `.gestalt/providers/petstore.json`
 
-<Steps>
-### Open the web UI
-
-Go to `http://localhost:3000`. Sign in with your Google account, or use **Dev Login** if you are running in dev mode.
-
-### Connect the integration
-
-Navigate to **Integrations** and click **Connect** next to Slack. Complete the OAuth flow in your browser; Gestalt stores the resulting token and refreshes it automatically on future requests.
-
-### Invoke an operation
-
-Once connected, you can invoke any allowed operation from the web UI or the CLI. The next section covers CLI setup.
-</Steps>
-
-## Install and use the CLI
-
-Install the `gestalt` CLI via Homebrew, then authenticate against your local server:
+## 5. Start From Locked State
 
 ```sh
-brew install valon-technologies/toolshed/gestalt
-gestalt init
-gestalt auth login
-gestalt integrations list
-gestalt invoke slack conversations_list
+gestaltd serve --locked --config ./gestalt.yaml
 ```
 
-`gestalt init` creates a `.gestalt.json` file in your home directory that stores the server URL and session credentials. You can override the server URL at any time by setting the `GESTALT_URL` environment variable.
+This is the deployment path to model in Docker, Kubernetes, or any other production target. Startup becomes deterministic because `gestaltd` no longer needs to mutate local state or fetch remote specs.
 
-## Next steps
+## 6. What To Learn Next
 
-- [Platform Model](/concepts/platform-model): understand the core primitives that Gestalt builds on.
-- [Add an Integration](/tasks/add-an-integration): walk through adding a new API from scratch.
-- [Config File](/reference/config-file): full reference for every configuration key.
-- [Use with MCP](/tasks/use-with-mcp): connect Gestalt to Claude or any MCP-compatible client.
+- [Platform Model](/concepts/platform-model): how config turns into providers, runtimes, bindings, and MCP.
+- [Configuration](/concepts/configuration): config discovery, defaults, secret resolution, and lock state.
+- [Add an Integration](/tasks/add-an-integration): build a real integration from REST, GraphQL, MCP, or plugins.
+- [Deploy](/deploy): move the same config into Docker or Kubernetes.

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -2,53 +2,62 @@ import { Cards, Steps } from 'nextra/components'
 
 # Gestalt
 
-Gestalt is a self-hosted integration platform that provides a uniform interface to third-party APIs. You declare integrations in a configuration file; Gestalt handles OAuth, token storage, credential refresh, and request execution on your behalf. The result is a single API surface for every upstream provider, whether that provider is Slack, Linear, GitHub, or any service with an OpenAPI spec.
+`gestaltd` is a self-hosted integration runtime. You describe your platform in one YAML file, and `gestaltd` turns that file into a running server with authentication, token storage, integration execution, an optional MCP endpoint, optional bindings and runtimes, and an embedded web UI served from the same HTTP port.
 
-## How it works
+## What Actually Ships
+
+| Piece | What it does |
+| --- | --- |
+| `gestaltd` | The server binary. It loads config, bootstraps plugins, serves the HTTP API, serves the web UI, and mounts `/mcp` when MCP is enabled. |
+| `config.yaml` | The declarative control plane. This is where you define auth, datastore, secrets, integrations, runtimes, bindings, and egress policy. |
+| `gestalt.lock.json` and `.gestalt/` | Optional prepared state written by `gestaltd init`. Use it for deterministic startup when you depend on remote OpenAPI, GraphQL, or packaged plugins. |
+| Deploy assets | A Dockerfile, `docker-compose.yml`, and a Helm chart for the bundled deployment paths. |
+
+## The Four Foundations
 
 <Steps>
-### Caller sends a request
+### Configuration
 
-A caller (the CLI, a web UI session, an MCP client, or a webhook) sends an **operation invocation** to the Gestalt API server. An operation invocation names the target integration and the action to perform, along with any required parameters.
+Your YAML file declares the feature sets that make up a Gestalt deployment: platform auth, token storage, secret resolution, integrations, runtimes, bindings, and egress rules.
 
-### Gestalt resolves credentials
+### Prepared State
 
-Gestalt looks up the caller's stored token for the target integration and refreshes it automatically if it has expired. If no token exists, Gestalt returns an error directing the caller to complete an OAuth flow first.
+If your config points at remote OpenAPI specs, GraphQL endpoints, or packaged plugins, `gestaltd init` resolves them into local artifacts. Production deployments normally start from that prepared state with `gestaltd serve --locked`.
 
-### Gestalt executes the upstream call
+### Providers And Invocation
 
-Using the resolved credentials and the integration's OpenAPI definition, Gestalt builds the HTTP request and sends it to the third-party API. You do not construct provider-specific headers, query parameters, or authentication schemes yourself.
+Each integration becomes a runtime provider. All request surfaces share the same invocation broker, so token lookup, refresh, connection mode, instance selection, and auditing work the same way everywhere.
 
-### Response is returned
+### Surfaces
 
-The upstream response passes through any configured **response checks** and then returns to the caller in a normalized format.
+The same provider graph can be reached through the HTTP API, the embedded web UI, `/mcp`, webhook bindings, proxy bindings, and background runtimes.
 </Steps>
 
-## What ships
+## Deployment Paths
 
-| Component | Description |
-|---|---|
-| **Go API server (`gestaltd`)** | Configuration loading, auth provider management, token storage, operation dispatch, MCP endpoint, and webhook bindings. |
-| **Rust CLI (`gestalt`)** | Authenticate, list integrations, invoke operations, and manage API tokens from the terminal. |
-| **Next.js web UI** | Browse integrations, connect accounts, invoke operations interactively, and create API tokens. |
-| **Deployment assets** | Helm chart, Dockerfiles, and CI workflows for Kubernetes, Fly.io, Railway, Render, and AWS Lambda. |
+There are four real deployment modes to think about:
 
-## Documentation
+1. `gestaltd` with no config: local-only, auto-generated config, local auth, SQLite, dev mode on.
+2. Docker or Docker Compose: single container, single HTTP port, config mounted into `/etc/gestalt/config.yaml`.
+3. Helm on Kubernetes: one Deployment for `gestaltd`, optional init container for locked startup.
+4. Bare binary: `gestaltd`, `gestaltd serve`, `gestaltd init`, and `gestaltd validate`.
+
+## Start Here
 
 <Cards>
   <Cards.Card title="Getting Started" href="/getting-started">
-    Stand up a local instance in under five minutes.
+    Run `gestaltd` out of the box, then move to an explicit config and locked startup.
   </Cards.Card>
-  <Cards.Card title="Concepts" href="/concepts/platform-model">
-    Auth providers, datastores, integrations, operations, bindings, and runtimes.
+  <Cards.Card title="Platform Model" href="/concepts/platform-model">
+    See how config, providers, the invocation broker, bindings, runtimes, and MCP fit together.
   </Cards.Card>
-  <Cards.Card title="Tasks" href="/tasks/run-locally">
-    Run locally, add integrations, connect MCP clients.
+  <Cards.Card title="Configuration" href="/concepts/configuration">
+    Learn the top-level primitives and the lifecycle of `validate`, `init`, and `serve --locked`.
   </Cards.Card>
   <Cards.Card title="Deploy" href="/deploy">
-    Ship to Fly.io, Railway, Render, AWS Lambda, or Kubernetes.
+    Use the shipped Docker and Helm paths, then adapt the same model to Fly.io, Railway, Render, or Lambda.
   </Cards.Card>
-  <Cards.Card title="Reference" href="/reference/config-file">
-    Config schema, HTTP API, CLI commands, and built-in plugins.
+  <Cards.Card title="Config File" href="/reference/config-file">
+    Full reference for every top-level block and the fields inside them.
   </Cards.Card>
 </Cards>

--- a/docs/pages/reference/built-in-plugins.mdx
+++ b/docs/pages/reference/built-in-plugins.mdx
@@ -1,56 +1,57 @@
 # Built-in Plugins
 
-The Gestalt binary registers all plugins at startup. Bootstrap builds one shared invoker and passes scoped deps to runtimes and bindings.
+This page lists the components that the `gestaltd` binary actually registers today.
 
-## Auth providers
+## Auth Providers
 
 | Name | Notes |
-|---|---|
-| `google` | Google OAuth 2.0 with userinfo validation. Supports `allowed_domains` and `session_ttl`. |
-| `oidc` | Generic OIDC discovery. Supports Okta, Azure AD, Auth0, Keycloak, Firebase, OneLogin, Rippling, and Google. Optional PKCE, domain allow-lists, custom scopes, configurable display name. |
+| --- | --- |
+| `google` | Google OAuth login for the Gestalt platform. |
+| `local` | Local-only auth provider used by the generated no-config startup path. |
+| `oidc` | Generic OIDC platform auth provider. |
 
 ## Datastores
 
 | Name | Notes |
-|---|---|
-| `sqlite` | File-based. Suitable for local development and single-instance deployments. Not recommended for production. |
-| `postgres` | Recommended for production and multi-instance deployments. |
-| `mysql` | Alternative SQL backend using the shared sqlstore layer. |
-| `dynamodb` | AWS DynamoDB. Configurable table name, region, and optional custom endpoint. |
-| `mongodb` | MongoDB with configurable database name (default: `gestalt`). |
-| `firestore` | Google Cloud Firestore with configurable project and database. |
-| `oracle` | Oracle Database via shared sqlstore layer. |
-| `sqlserver` | Microsoft SQL Server via shared sqlstore layer. |
+| --- | --- |
+| `sqlite` | File-backed datastore. Best for local or single-node deployments. |
+| `postgres` | Recommended production datastore. |
+| `mysql` | SQL-backed production datastore. |
+| `dynamodb` | DynamoDB-backed datastore. |
+| `mongodb` | MongoDB-backed datastore. |
+| `oracle` | Oracle-backed datastore. |
+| `firestore` | Firestore-backed datastore. |
+| `sqlserver` | SQL Server-backed datastore. |
 
-All SQL-based datastores (postgres, mysql, oracle, sqlserver) share a common implementation layer with automatic schema migration on startup.
-
-## Secret managers
+## Secret Managers
 
 | Name | Notes |
-|---|---|
-| `env` | Resolves from environment variables. Optional prefix. Converts names to uppercase, replaces hyphens with underscores. |
-| `file` | One secret per file from a base directory. Path traversal protected. Trims trailing newlines. |
-| `gcp_secret_manager` | Google Cloud Secret Manager. Configurable project and version (default: `latest`). 10-second timeout per access. |
+| --- | --- |
+| `env` | Resolve secrets from environment variables. |
+| `file` | Resolve secrets from files in a configured directory. |
+| `gcp_secret_manager` | Resolve secrets from Google Secret Manager. |
 
 ## Bindings
 
 | Name | Notes |
-|---|---|
-| `webhook` | Exposes HTTP endpoints that forward to provider operations. Supports `public`, `signed` (HMAC-SHA256), and `trusted_user_header` auth modes. Configurable path, provider, operation, and signature headers. |
-| `proxy` | Provider-backed proxy binding that forwards inbound HTTP requests to upstream hosts. Derives egress subjects from the authenticated principal, sanitizes inbound auth headers, and resolves outbound credentials through the configured provider. Requires exactly one provider. Configurable path prefix and optional instance qualifier. |
+| --- | --- |
+| `webhook` | Inbound HTTP route that can optionally forward into a provider operation. |
+| `proxy` | HTTP proxy surface with egress policy and credential resolution. |
 
 ## Runtimes
 
 | Name | Notes |
-|---|---|
-| `echo` | Dev-only test runtime. Logs startup/shutdown and lists available capabilities. Enabled only when `dev_mode: true`. |
+| --- | --- |
+| `echo` | Dev-only runtime. Registered only when `server.dev_mode: true`. |
 
-## Built-in providers
+## Built-In Named Providers
 
 | Name | Notes |
-|---|---|
-| `echo` | Dev-only provider that echoes input parameters as JSON. Single `echo` operation. Enabled only when `dev_mode: true`. |
+| --- | --- |
+| `bigquery` | Built-in named provider registered by the server binary. |
+| `jira` | Built-in named provider registered by the server binary. |
+| `echo` | Dev-only provider registered only when `server.dev_mode: true`. |
 
-## What is not pluginized
+## What This Page Does Not Mean
 
-The HTTP route structure, middleware chain, and operation dispatch loop are fixed in the binary. There is no plugin point for injecting custom routes or middleware. Custom behavior at that layer means contributing to the core runtime.
+The repo contains provider inventory files and examples, but those are not the same thing as binary-registered built-ins. This page only lists components that are actually wired into `cmd/gestaltd`.

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -1,131 +1,95 @@
 # CLI
 
-Gestalt ships two binaries: the Go server (`gestaltd`) and the Rust client (`gestalt`).
+The most important CLI surface in this repo is the `gestaltd` server binary.
 
-## Server (`gestaltd`)
-
-`gestaltd` is the Gestalt API server. It loads configuration, manages auth providers and token storage, dispatches operations, and serves the MCP endpoint and webhook bindings.
+## `gestaltd`
 
 ### Usage
 
 ```sh
-gestaltd --config config.yaml
-gestaltd init --config config.yaml
-gestaltd serve --config config.yaml
-gestaltd validate --config config.yaml
+gestaltd [--config PATH]
+gestaltd plugin <command> [flags]
+gestaltd serve [--config PATH] [--locked]
+gestaltd init [--config PATH]
+gestaltd validate [--config PATH] [--init]
 ```
 
-### Commands
+## Command Meanings
 
-| Command | Purpose |
-|---|---|
-| `gestaltd --config config.yaml` | Prepare REST/GraphQL providers if needed, then start the server from the source config. |
-| `gestaltd init --config config.yaml` | Write `gestalt.lock.json` plus `.gestalt/providers/*.json` next to the source config. |
-| `gestaltd serve --config config.yaml` | Start the server strictly from the source config plus prepared provider artifacts. |
-| `gestaltd validate --config config.yaml` | Load and validate config, then exit without starting the server. |
+| Command | What it does |
+| --- | --- |
+| `gestaltd` | Default start command. Can auto-generate a local config and can auto-init missing prepared state. |
+| `gestaltd serve` | Start the server from an explicit config path. |
+| `gestaltd serve --locked` | Require exact prepared state. Do not auto-init. |
+| `gestaltd init` | Prepare remote provider artifacts and packaged plugins into locked local state. |
+| `gestaltd validate` | Load and validate config without starting the server. |
+| `gestaltd validate --init` | Prepare locked state first, then validate it. |
+| `gestaltd plugin package` | Build a distributable plugin archive from a manifest directory. |
 
-### Validate configuration
+## Default Command Behavior
+
+The plain `gestaltd` command has one extra convenience feature:
+
+- if you do not pass `--config`
+- and no config file can be found in the normal search path
+- it generates `~/.gestalt/config.yaml`
+
+That generated config is intentionally local-only:
+
+- `local` auth
+- SQLite
+- `env` secrets
+- dev mode enabled
+
+## Config Path Resolution
+
+When a command needs a config path, Gestalt resolves it in this order:
+
+1. `--config`
+2. `GESTALT_CONFIG`
+3. `./config.yaml`
+4. `~/.gestalt/config.yaml`
+5. `/etc/gestalt/config.yaml`
+
+## `init`
+
+`gestaltd init --config ./gestalt.yaml` writes:
+
+- `gestalt.lock.json`
+- `.gestalt/providers/*.json`
+- `.gestalt/plugins/...`
+
+Use it whenever your config contains:
+
+- remote REST upstreams
+- remote GraphQL upstreams
+- `plugin.package`
+
+## `serve --locked`
+
+Use locked mode in production:
 
 ```sh
-gestaltd validate --config config.yaml
+gestaltd init --config ./gestalt.yaml
+gestaltd serve --locked --config ./gestalt.yaml
 ```
 
-Prints: config file path, server settings, auth provider, datastore, secrets provider, integration count and details, runtime count, binding count. Exits with "config ok" if valid.
+If prepared state is missing or stale, startup fails instead of mutating local state.
 
-`gestaltd` prints datastore warnings at startup and during `validate`. SQLite always triggers a warning since it is not recommended for production.
+## `validate`
 
-### Prepare for deployment
+`gestaltd validate` is non-mutating by default. It expects lock state to already exist when the config depends on prepared artifacts.
+
+`gestaltd validate --init` is the most useful CI command for production-shaped configs.
+
+## `plugin package`
+
+Build a plugin archive from a manifest directory:
 
 ```sh
-gestaltd init --config config.yaml
-gestaltd serve --config config.yaml
+gestaltd plugin package --input ./build/my-plugin --output ./dist/my-plugin.tar.gz
 ```
 
-`gestaltd init` writes a lockfile and hidden provider cache next to the source config. `gestaltd serve` reads the same source config and uses the prepared artifacts, so production startup no longer depends on live spec downloads or GraphQL introspection.
+## Companion Client
 
-### Config file resolution
-
-1. `--config` flag.
-2. `GESTALT_CONFIG` environment variable.
-3. `./config.yaml` in the current directory.
-4. `~/.gestalt/config.yaml`.
-5. `/etc/gestalt/config.yaml`.
-
-## Client CLI (`gestalt`)
-
-### Install
-
-```sh
-brew install valon-technologies/toolshed/gestalt
-```
-
-Or build from source:
-
-```sh
-cd client/cli
-cargo build --release
-./target/release/gestalt --version
-```
-
-### Commands
-
-| Command | Purpose |
-|---|---|
-| `gestalt init` | Interactive setup wizard. |
-| `gestalt auth login` | Open browser for OAuth login. Refuses if `GESTALT_API_KEY` is set (unset it first or use the key directly). |
-| `gestalt auth logout` | Clear stored credentials. |
-| `gestalt auth status` | Show authentication status and credential source. |
-| `gestalt config get <key>` | Read a config value. |
-| `gestalt config set <key> <value>` | Write a config value. |
-| `gestalt config unset <key>` | Remove a config value. |
-| `gestalt config list` | List all config values. |
-| `gestalt integrations list` | List available integrations with name, display name, auth types, connected status, instance names, and description. |
-| `gestalt integrations connect <name>` | Start an OAuth connection flow. |
-| `gestalt invoke <integration> <operation> -p key=value` | Execute an operation. When multiple connections exist, pass `-p _instance=NAME` to select which one to use. |
-| `gestalt tokens create [--name <name>]` | Create an API token. |
-| `gestalt tokens list` | List API tokens. |
-| `gestalt tokens revoke <id>` | Revoke an API token. |
-
-### URL resolution order
-
-1. `--url` flag.
-2. `GESTALT_URL` environment variable.
-3. `.gestalt.json` in the current or ancestor directory.
-4. Global config file.
-5. `credentials.json` stored by `gestalt auth login`.
-6. `http://localhost:8080` as fallback.
-
-### Authentication
-
-The CLI resolves credentials in this order:
-
-1. **`GESTALT_API_KEY` environment variable** — if set and non-empty, used as the Bearer token on every request, overriding any session token. When active, `gestalt auth login` refuses to run and prints a message to unset the variable first.
-2. **Session token** — stored by `gestalt auth login` in the local credential store.
-
-`gestalt auth status` reports which source is active:
-
-- **`--format json`** returns `{"authenticated": bool, "source": "env"|"session"|"none", "env_var_set": bool, "session_stored": bool}`.
-- **`--format table`** prints a human-readable summary. If both `GESTALT_API_KEY` and a session token exist, it warns that the session token is being ignored.
-
-If a request fails with 401 while using `GESTALT_API_KEY`, the error message notes that the key came from the environment and suggests unsetting it.
-
-Credential files are written with `0600` permissions. Output formats: `--format json` (default) or `--format table`.
-
-### Common workflows
-
-```sh
-# Initial setup
-gestalt init
-gestalt auth login
-
-# Browse and connect
-gestalt integrations list --format table
-gestalt integrations connect slack
-
-# Invoke operations
-gestalt invoke slack conversations_list
-gestalt invoke slack chat_postMessage -p channel=C123 -p text=hello
-
-# API tokens for CI
-gestalt tokens create --name "ci-token"
-```
+The repo also contains a separate `gestalt` client binary, but the deployment and platform model documented here are centered on `gestaltd`.

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -1,340 +1,496 @@
 # Config File
 
-## Top-level keys
+This page is the authoritative reference for `gestaltd` configuration.
 
-| Key | Purpose |
-|---|---|
-| `auth` | Platform authentication provider and provider-specific config. |
-| `datastore` | Where users, API tokens, and integration tokens are stored. |
-| `secrets` | How `secret://` references are resolved. |
-| `auth_profiles` | Reusable OAuth settings shared across integrations. |
-| `integrations` | Map of integration name to definition. |
-| `runtimes` | Background processes that boot alongside the server with scoped provider access. |
-| `bindings` | Alternative request surfaces such as webhooks and proxy-oriented request normalizers. |
-| `server` | Port, base URL, encryption key, and development mode. |
-| `egress` | Policy and credential rules for outbound requests made by runtimes, bindings, and proxy surfaces. |
+## Top-Level Shape
 
-## Server block
+```yaml
+auth: {}
+datastore: {}
+secrets: {}
+auth_profiles: {}
+integrations: {}
+runtimes: {}
+bindings: {}
+server: {}
+egress: {}
+```
 
-| Field | Default | Notes |
-|---|---|---|
-| `port` | `8080` | HTTP listen port. |
-| `base_url` | | Used to derive missing OAuth callback URLs. Required in production. |
-| `encryption_key` | | Required outside dev mode. Derives the data-encryption key for stored tokens. |
-| `dev_mode` | `false` | Enables auth bypass header, Dev Login endpoint, and echo runtime. |
+## Load Semantics
 
-## Auth block
+Before you get into individual fields, these global rules matter:
+
+- `${ENV_VAR}` expansion happens before YAML decode
+- unknown YAML fields are rejected
+- `server.port` defaults to `8080`
+- `secrets.provider` defaults to `env`
+- relative paths resolve relative to the config file directory
+- `secret://...` values are resolved later during bootstrap, not during raw YAML parsing
+
+## `server`
+
+```yaml
+server:
+  port: 8080
+  base_url: https://gestalt.example.com
+  encryption_key: secret://gestalt-encryption-key
+  dev_mode: false
+  admin_emails:
+    - admin@example.com
+```
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `port` | no | Defaults to `8080`. |
+| `base_url` | no, but strongly recommended | Used to derive OAuth callback URLs when explicit redirect URLs are missing. |
+| `encryption_key` | yes unless `dev_mode: true` | Root deployment secret used for encryption and derived session material. |
+| `dev_mode` | no | Enables dev login, `X-Dev-User-Email`, dev CORS, and dev-only built-ins. |
+| `admin_emails` | no | Grants access to admin-only egress deny-rule endpoints. |
+
+## `auth`
+
+### `local`
 
 ```yaml
 auth:
-  provider: oidc     # "google" or "oidc"
+  provider: local
   config:
-    issuer_url: https://auth.example.com
-    client_id: ${CLIENT_ID}
-    client_secret: ${CLIENT_SECRET}
-    redirect_url: http://localhost:8080/api/v1/auth/login/callback
-    allowed_domains: [example.com]
-    session_secret: ${SESSION_SECRET}
-    session_ttl: 24h
-    display_name: "Okta"
-    scopes: [openid, email, profile]
-    pkce: false
+    email: local@example.com
 ```
 
-| Field | Notes |
-|---|---|
-| `allowed_domains` | Restrict sign-in to specific email domains. |
-| `session_ttl` | Session duration. Default: `24h`. |
-| `session_secret` | Signs session JWTs. |
-| `display_name` | Label shown on the login button (OIDC only). |
-| `scopes` | OIDC scopes. Default: `openid, email, profile`. |
-| `pkce` | Enable PKCE for public clients (OIDC only). |
+| Field | Required | Notes |
+| --- | --- | --- |
+| `email` | no | Defaults to `local@gestalt.local`. |
 
-## Datastore block
+### `google`
+
+```yaml
+auth:
+  provider: google
+  config:
+    client_id: ${GOOGLE_CLIENT_ID}
+    client_secret: secret://google-client-secret
+    redirect_url: https://gestalt.example.com/api/v1/auth/login/callback
+    allowed_domains:
+      - example.com
+```
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `client_id` | yes | Google OAuth client ID. |
+| `client_secret` | yes | Google OAuth client secret. |
+| `redirect_url` | no | If omitted and `server.base_url` is set, Gestalt derives the login callback. |
+| `allowed_domains` | no | Restrict login to selected email domains. |
+
+### `oidc`
+
+```yaml
+auth:
+  provider: oidc
+  config:
+    issuer_url: https://login.example.com
+    client_id: ${OIDC_CLIENT_ID}
+    client_secret: secret://oidc-client-secret
+    redirect_url: https://gestalt.example.com/api/v1/auth/login/callback
+    allowed_domains:
+      - example.com
+    scopes:
+      - openid
+      - email
+      - profile
+    session_secret: secret://oidc-session-secret
+    session_ttl: 24h
+    pkce: true
+    display_name: Company SSO
+```
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `issuer_url` | yes | OIDC discovery base URL. |
+| `client_id` | yes | OIDC client ID. |
+| `client_secret` | no in some PKCE setups, but commonly set | OIDC client secret. |
+| `redirect_url` | no | Derived from `server.base_url` when omitted. |
+| `allowed_domains` | no | Optional email-domain allowlist. |
+| `scopes` | no | Defaults to `openid`, `email`, `profile`. |
+| `session_secret` | yes | Secret used to sign OIDC-backed session tokens. |
+| `session_ttl` | no | Defaults to `24h`. |
+| `pkce` | no | Enables PKCE for the platform login flow. |
+| `display_name` | no | Defaults to `SSO`. |
+
+## `datastore`
 
 ```yaml
 datastore:
-  provider: postgres   # see table below
+  provider: postgres
   config:
-    dsn: postgres://user:pass@host:5432/gestalt
+    dsn: ${DATABASE_URL}
 ```
 
-| Provider | Config | Notes |
-|---|---|---|
-| `sqlite` | `path: ./gestalt.db` | Not recommended for production. |
-| `postgres` | `dsn: postgres://...` | Recommended for production. |
-| `mysql` | `dsn: user:pass@tcp(host:3306)/gestalt` | Alternative SQL backend. |
-| `dynamodb` | `table`, `region`, optional `endpoint` | AWS DynamoDB. |
-| `mongodb` | `uri`, optional `database` (default: `gestalt`) | MongoDB. |
-| `firestore` | `project_id`, optional `database` | Google Cloud Firestore. |
-| `oracle` | `dsn: ...` | Oracle Database. |
-| `sqlserver` | `dsn: ...` | Microsoft SQL Server. |
+| Provider | Config fields | Notes |
+| --- | --- | --- |
+| `sqlite` | `path` | Defaults to `./gestalt.db` if the provider itself applies its default. Good for local or single-node use. |
+| `postgres` | `dsn` | Recommended production choice. |
+| `mysql` | `dsn` | SQL-backed production option. |
+| `dynamodb` | `table`, `region`, `endpoint` | `table` defaults to `gestalt`. |
+| `mongodb` | `uri`, `database` | `database` defaults to `gestalt`. |
+| `oracle` | `dsn` | SQL-backed enterprise option. |
+| `firestore` | `project_id`, `database` | Firestore-backed deployment. |
+| `sqlserver` | `dsn` | SQL Server-backed deployment. |
 
-## Secrets block
+Some features, such as staged connections, rely on SQL-backed datastore support.
+
+## `secrets`
 
 ```yaml
 secrets:
-  provider: env      # "env", "file", or "gcp_secret_manager"
+  provider: file
   config:
-    prefix: GESTALT_  # env only
+    dir: /etc/gestalt-secrets
 ```
 
-| Provider | Config | Notes |
-|---|---|---|
-| `env` | Optional `prefix` | Resolves from environment variables. Converts names to uppercase, replaces hyphens with underscores. |
-| `file` | `path: /etc/secrets` | One secret per file. Path traversal protected. |
-| `gcp_secret_manager` | `project_id`, optional `version` (default: `latest`) | Google Cloud Secret Manager. |
+| Provider | Config fields | Notes |
+| --- | --- | --- |
+| `env` | `prefix` | Reads secrets from environment variables. |
+| `file` | `dir` | Reads one secret per file from a base directory. |
+| `gcp_secret_manager` | `project`, `version` | `version` defaults to `latest`. |
 
-## Integration block
+Any string value outside `secrets.config` may use:
 
-Each integration is defined under `integrations.<name>` and is backed by either `upstreams`, an executable `plugin`, or both when `plugin.mode: overlay` is used.
+```yaml
+secret://name-of-secret
+```
 
-| Field | Notes |
-|---|---|
-| `upstreams` | List of upstream definitions (see below). Required unless the integration is fully served by `plugin.mode: replace`, and one of the two allowed base sources for `plugin.mode: overlay`. |
-| `plugin` | Executable provider plugin config. Use `mode: replace` to serve the whole provider from a binary, or `mode: overlay` to compose a binary on top of exactly one base source. |
-| `display_name` | Human-readable label for the integration. |
-| `description` | Short description shown in the web UI and CLI. |
-| `auth_profile` | Name of a reusable auth profile to inherit from. |
-| `client_id`, `client_secret` | OAuth client credentials for the upstream integration. |
-| `redirect_url` | Override the integration callback URL. |
-| `base_url` | Override the base URL from the upstream spec. |
-| `connection_mode` | `user` (default), `identity`, `either`, or `none`. See [Connection Modes](/concepts/platform-model#connection-modes). |
-| `mcp_tool_prefix` | Prefix prepended to MCP tool names for this integration. Applies to any operations this integration exposes over MCP. |
-| `auth` | Auth overrides (see below). |
-| `auth_header` | Custom header name for sending the token (instead of `Authorization`). |
-| `auth_mapping` | Map of header names to JSON fields, for structured token-to-headers mapping. |
-| `token_prefix` | Prefix for the Authorization header value. |
-| `auth_style` | How the token is sent: `bearer` (default), `raw`, `basic`, or `none`. |
-| `headers` | Default headers sent with every upstream request. |
-| `icon_file` | Path to an SVG file used as the integration icon. Relative paths resolve from the config file's directory. |
-| `manual_auth` | Boolean. When `true`, the integration supports both OAuth and manual authentication. Users see both connection options in the web UI. The API returns `auth_types: ["oauth", "manual"]`. |
-| `error_message_path` | Dot-delimited path for extracting error messages from upstream JSON responses. |
+## `auth_profiles`
 
-### Executable plugin config
+Auth profiles let you define shared integration auth once and reference it from integrations or individual upstreams.
 
-| Field | Notes |
-|---|---|
-| `command` | Path to the executable. Relative paths resolve from the config file's directory. Mutually exclusive with `package`. |
-| `package` | Path to a `.tar.gz` plugin archive or an HTTPS URL. Relative paths resolve from the config file's directory. Mutually exclusive with `command`. |
-| `args` | Optional argv passed to the executable. Only valid with `command`. |
-| `env` | Optional extra environment variables for the plugin process. |
-| `config` | Provider plugins only. Arbitrary key-value map passed to `StartProvider`. Runtime plugins use `runtimes.<name>.config` instead. |
-| `mode` | `replace` (default) or `overlay`. |
-| `base` | `overlay` only. Names the registered first-party provider factory to compose under the plugin when `upstreams` are not used. |
+```yaml
+auth_profiles:
+  github_oauth:
+    client_id: ${GITHUB_CLIENT_ID}
+    client_secret: secret://github-client-secret
+    redirect_url: https://gestalt.example.com/api/v1/auth/callback
+    auth:
+      type: oauth2
+      authorization_url: https://github.com/login/oauth/authorize
+      token_url: https://github.com/login/oauth/access_token
+```
 
-Overlay plugins must declare exactly one base source:
+Profile fields are inherited unless the integration or upstream overrides them locally.
 
-- `upstreams` when the base provider comes from prepared REST/GraphQL/MCP config
-- `plugin.base` when the base provider comes from a registered Go factory
+## `integrations`
 
-### Upstreams
-
-Each upstream declares a type and source:
-
-| Field | Notes |
-|---|---|
-| `type` | `rest`, `graphql`, or `mcp`. |
-| `url` | For `rest`: OpenAPI spec URL. For `graphql`: the GraphQL endpoint (introspected at startup). For `mcp`: the upstream MCP server URL. |
-| `mcp` | (`rest` and `graphql` only) Boolean. When `true`, this upstream's operations are exposed as MCP tools. `type: mcp` upstreams are always exposed — no flag needed. |
-| `allowed_operations` | Positive allow-list. Can be a YAML list (names only) or a map (names to description overrides). Omit to allow all operations. An empty value is invalid. |
-
-REST, GraphQL, and MCP upstreams all require `url` in the source config. Deterministic startup comes from running `gestaltd init`, which writes `gestalt.lock.json` plus `.gestalt/providers/*.json` next to the source config. `gestaltd serve` then uses those prepared artifacts without changing the source config.
-
-Example with multiple upstreams:
+Integrations are the main user-facing primitive.
 
 ```yaml
 integrations:
-  slack:
-    upstreams:
-      - type: rest
-        url: https://raw.githubusercontent.com/.../slack_web_openapi_v2.json
-        allowed_operations:
-          conversations_list: List channels
-          chat_postMessage: Send a message
-      - type: mcp
-        url: https://mcp.slack.com/sse
-    client_id: ${SLACK_CLIENT_ID}
-    client_secret: ${SLACK_CLIENT_SECRET}
+  github:
+    display_name: GitHub
+    description: GitHub REST API
+    auth_profile: github_oauth
+    connection_mode: user
+    mcp_tool_prefix: github_
+    plugin: {}
+    client_id: ${GITHUB_CLIENT_ID}
+    client_secret: secret://github-client-secret
+    redirect_url: https://gestalt.example.com/api/v1/auth/callback
+    base_url: https://api.github.com
+    auth: {}
+    auth_header: Authorization
+    auth_mapping: {}
+    error_message_path: error.message
+    response_check: {}
+    manual_auth: false
+    token_prefix: Bearer
     auth_style: bearer
-    auth:
-      authorization_url: https://slack.com/oauth/v2/authorize
-      token_url: https://slack.com/api/oauth.v2.access
-      response_check:
-        success_body_match:
-          ok: true
-        error_message_path: error
+    icon_file: ./icons/github.svg
+    headers:
+      X-GitHub-Api-Version: "2022-11-28"
+    upstreams: []
 ```
 
-### Auth overrides
+| Field | Notes |
+| --- | --- |
+| `upstreams` | Source operations from REST, GraphQL, or MCP. |
+| `display_name`, `description` | Presentation metadata. |
+| `auth_profile` | Reuse shared auth values. |
+| `connection_mode` | `user`, `identity`, `either`, or `none`. Defaults to `user`. |
+| `mcp_tool_prefix` | Prefix tool names when exposing this integration over MCP. |
+| `plugin` | Executable provider plugin config. |
+| `client_id`, `client_secret`, `redirect_url` | Integration-level auth values that upstreams inherit unless they override them. |
+| `base_url` | Advanced override used by some provider builds. |
+| `auth` | Advanced auth override block. |
+| `auth_header` | Custom token header name. |
+| `auth_mapping` | Maps header names to fields extracted from structured token payloads. |
+| `error_message_path` | Error extraction path for upstream responses. |
+| `response_check` | Declarative success and error checks. |
+| `manual_auth` | Expose both OAuth and manual connection paths when supported. |
+| `token_prefix` | Prefix inserted before a raw token string. |
+| `auth_style` | `bearer`, `raw`, `none`, or `basic`. |
+| `icon_file` | SVG path, resolved relative to the config file. |
+| `headers` | Static request headers added to upstream calls. |
+
+### `upstreams`
+
+```yaml
+upstreams:
+  - type: rest
+    url: https://example.com/openapi.json
+    mcp: true
+    allowed_operations:
+      listThings: List things
+    auth_profile: shared_auth
+    auth: {}
+    client_id: ${CLIENT_ID}
+    client_secret: secret://client-secret
+    redirect_url: https://gestalt.example.com/api/v1/auth/callback
+```
+
+| Field | Notes |
+| --- | --- |
+| `type` | `rest`, `graphql`, or `mcp`. |
+| `url` | Required for all upstream types. |
+| `mcp` | For `rest` and `graphql`, also expose operations through `/mcp`. |
+| `allowed_operations` | Either a YAML list of names or a YAML map of name to description override. |
+| `auth_profile` | Optional upstream-specific auth profile. |
+| `auth`, `client_id`, `client_secret`, `redirect_url` | Upstream-level auth overrides. |
+
+Rules:
+
+- at most one REST or GraphQL upstream per integration
+- at most one MCP upstream per integration
+- one API upstream plus one MCP upstream is valid
+
+### `auth`
+
+This block is used at integration level or upstream level.
 
 ```yaml
 auth:
-  type: oauth2              # or "manual"
-  authorization_url: https://provider.com/authorize
-  token_url: https://provider.com/token
-  client_auth: body          # or "header"
+  type: oauth2
+  authorization_url: https://provider.example.com/oauth/authorize
+  token_url: https://provider.example.com/oauth/token
+  client_auth: body
+  token_exchange: form
+  scopes:
+    - read
+    - write
   scope_separator: ","
   pkce: true
   authorization_params:
     audience: https://api.example.com
   token_params:
-    grant_type: authorization_code
+    resource: api
   refresh_params: {}
-  token_exchange: form       # or "json"
   accept_header: application/json
   token_metadata:
-    - team_id
-    - team_name
+    - workspace_id
   response_check:
     success_body_match:
       ok: true
     error_message_path: error
+  auth_header: Authorization
 ```
 
-## Auth profiles
+Supported or notable fields:
 
-Reusable OAuth config referenced by `auth_profile` in integrations:
+- `type`
+- `authorization_url`
+- `token_url`
+- `client_auth`
+- `token_exchange`
+- `scopes`
+- `scope_separator`
+- `pkce`
+- `authorization_params`
+- `token_params`
+- `refresh_params`
+- `accept_header`
+- `token_metadata`
+- `response_check`
+- `auth_header`
+
+The normal auth types are `oauth2` and `manual`. `mcp_oauth` also exists as an advanced mode for MCP-driven OAuth discovery.
+
+### `plugin`
 
 ```yaml
-auth_profiles:
-  slack_shared:
-    client_id: ${SLACK_CLIENT_ID}
-    client_secret: ${SLACK_CLIENT_SECRET}
-    redirect_url: https://gestalt.example.com/api/v1/auth/callback
-    auth:
-      authorization_url: https://slack.com/oauth/v2/authorize
-      token_url: https://slack.com/api/oauth.v2.access
-      response_check:
-        success_body_match:
-          ok: true
-        error_message_path: error
+plugin:
+  mode: overlay
+  base: jira
+  command: ./my-plugin
+  package: https://example.com/my-plugin.tar.gz
+  args:
+    - --verbose
+  env:
+    LOG_LEVEL: debug
+  config:
+    greeting: hello
 ```
 
-Fields set directly on the integration override the profile.
+| Field | Notes |
+| --- | --- |
+| `mode` | `replace` or `overlay`. Defaults to `replace`. |
+| `base` | Only valid with `mode: overlay`. Names a built-in provider base. |
+| `command` | Local executable path. Mutually exclusive with `package`. |
+| `package` | Local directory, local archive, or HTTPS URL. Mutually exclusive with `command`. |
+| `args` | Only valid with `command`. |
+| `env` | Extra plugin environment variables. |
+| `config` | Arbitrary plugin config payload. |
 
-## Runtimes block
+Validation rules:
 
-Background processes that boot alongside the server with scoped provider access.
+- exactly one of `command` or `package`
+- plain `http://` package URLs are rejected
+- overlay integrations must declare exactly one base source via `upstreams` or `plugin.base`
+
+## `runtimes`
 
 ```yaml
 runtimes:
-  my-runtime:
-    type: echo             # runtime type (registered in binary)
+  syncer:
+    type: echo
     providers:
-      - slack
-      - linear
-    config: {}             # type-specific configuration
+      - github
+    config: {}
 ```
 
-The `providers` list scopes which integrations the runtime can invoke. The runtime receives a scoped invoker and capability lister.
+or:
 
-## Bindings block
+```yaml
+runtimes:
+  syncer:
+    providers:
+      - github
+    plugin:
+      command: ./runtime-plugin
+    config:
+      interval: 30s
+```
 
-Alternative request surfaces that forward calls through the shared invoker.
+| Field | Notes |
+| --- | --- |
+| `type` | Built-in runtime type. Currently only `echo`, and only in dev mode. |
+| `providers` | Allowlist of providers the runtime can access. |
+| `config` | Runtime config payload. |
+| `plugin` | Executable runtime plugin. Runtime plugins cannot use overlay mode. |
+
+## `bindings`
 
 ```yaml
 bindings:
-  slack-webhook:
+  inbound:
     type: webhook
     providers:
-      - slack
+      - github
     config:
-      path: /webhooks/slack
-      provider: slack
-      operation: chat_postMessage
-      auth_mode: signed           # "public", "signed", or "trusted_user_header"
-      signing_secret: ${WEBHOOK_SECRET}
-      signature_header: X-Signature
-
-  agent-proxy:
-    type: proxy
-    providers:
-      - slack
-    config:
-      path: /proxy
-      instance: workspace-1
+      path: /events/github
+      provider: github
+      operation: issues_listForAuthenticatedUser
+      auth_mode: signed
+      signing_secret: secret://webhook-secret
 ```
 
-### Webhook config
+or:
 
-| Config field | Default | Notes |
-|---|---|---|
-| `path` | | HTTP path for the webhook endpoint. Must start with `/`. |
-| `provider` | | Target provider to forward requests to. |
-| `operation` | | Target operation to invoke. |
-| `auth_mode` | `public` | `public` (no auth), `signed` (HMAC-SHA256), or `trusted_user_header`. |
-| `signing_secret` | | Required when `auth_mode` is `signed`. |
-| `signature_header` | `X-Signature` | Header containing the HMAC signature. |
-| `user_header` | | Required when `auth_mode` is `trusted_user_header`. Header containing the user ID. |
+```yaml
+bindings:
+  outbound_proxy:
+    type: proxy
+    providers:
+      - github
+    config:
+      path: /proxy
+      instance: default
+```
 
-### Proxy config
+### Common binding fields
 
-Proxy bindings require exactly one entry in the top-level `providers` list. This provider is used for credential resolution on outbound requests. The authenticated user's principal is mapped to an egress subject so that per-user tokens can be resolved.
+| Field | Notes |
+| --- | --- |
+| `type` | `webhook` or `proxy`. |
+| `providers` | Allowlist of providers the binding can access. |
+| `config` | Binding-type-specific config. |
 
-| Config field | Default | Notes |
-|---|---|---|
-| `path` | | HTTP path prefix for the proxy surface. Must start with `/`. |
-| `instance` | | Optional provider instance qualifier for credential resolution. |
+### Webhook binding config
 
-## Egress block
+| Field | Notes |
+| --- | --- |
+| `path` | Required. Must start with `/`. |
+| `provider` | Optional target provider for forwarding. |
+| `instance` | Optional provider instance. |
+| `operation` | Optional target operation. |
+| `auth_mode` | `public`, `signed`, or `trusted_user_header`. |
+| `signing_secret` | Required for `signed`. |
+| `signature_header` | Header carrying the signature. Defaults to `X-Signature`. |
+| `user_header` | Required for `trusted_user_header`. |
+| `trusted_sources` | Optional source IP allowlist for `trusted_user_header`. |
 
-Controls policy enforcement and credential injection for outbound requests made by runtimes, bindings, and the proxy surface.
+### Proxy binding config
+
+| Field | Notes |
+| --- | --- |
+| `path` | Required. Must start with `/`. |
+| `instance` | Optional provider instance to use for credential resolution. |
+
+Rules:
+
+- proxy bindings may declare zero or one provider in `bindings.<name>.providers`
+- webhook forwarding requires the forwarded provider to be present in the binding allowlist
+
+## `egress`
 
 ```yaml
 egress:
-  default_action: allow   # "allow" (default) or "deny"
+  default_action: deny
   policies:
-    - action: deny
-      subject_kind: agent
-      provider: internal-api
-      path_prefix: /v1/admin
     - action: allow
-      provider: internal-api
-  credentials:
-    - provider: acme-api
-      instance: acme-api
       subject_kind: user
+      provider: github
+      method: GET
+      host: api.github.com
+      path_prefix: /repos
+  credentials:
+    - provider: github
+      instance: default
+      subject_kind: user
+      method: GET
+      host: api.github.com
+      path_prefix: /repos
 ```
 
-### Policy rules
-
-Rules are evaluated in order; the first matching rule wins. If no rule matches, `default_action` applies (defaults to `allow`).
+### `policies`
 
 | Field | Notes |
-|---|---|
-| `action` | Required. `allow` or `deny`. |
-| `subject_kind` | Match subject kind: `user`, `identity`, `agent`, or `system`. Empty matches all. |
-| `subject_id` | Match a specific subject ID. Empty matches all. |
-| `provider` | Match the target provider name. Empty matches all. |
-| `operation` | Match the target operation name. Empty matches all. |
-| `method` | Match the HTTP method. Empty matches all. |
-| `host` | Exact match against the target host. Empty matches all. |
-| `path_prefix` | Segment-aware path prefix match. Empty matches all. |
+| --- | --- |
+| `action` | `allow` or `deny`. |
+| `subject_kind` | Match a subject kind. |
+| `subject_id` | Match a specific subject. |
+| `provider` | Match a provider name. |
+| `operation` | Match an operation name. |
+| `method` | Match an HTTP method. |
+| `host` | Match an outbound host. |
+| `path_prefix` | Match a path prefix. |
 
-All non-empty fields must match for a rule to apply (AND logic).
-
-### Credential grants
-
-Credential grants control which provider credentials are injected into outbound requests. They are matched using the same field set as policy rules (minus `action`), plus `instance` to identify the credential source.
+### `credentials`
 
 | Field | Notes |
-|---|---|
-| `provider` | The provider whose credentials to inject. |
-| `instance` | The credential instance name (defaults to `provider` if omitted). |
-| `subject_kind` | Restrict to a specific subject kind. Empty matches all. |
-| `subject_id` | Restrict to a specific subject ID. Empty matches all. |
-| `operation` | Match the target operation. Empty matches all. |
-| `method` | Match the HTTP method. Empty matches all. |
-| `host` | Exact match against the target host. Empty matches all. |
-| `path_prefix` | Segment-aware path prefix match. Empty matches all. |
+| --- | --- |
+| `provider` | Credential source provider. |
+| `instance` | Credential instance. |
+| `subject_kind` | Subject filter. |
+| `subject_id` | Subject filter. |
+| `operation` | Optional operation filter. |
+| `method` | Optional HTTP-method filter. |
+| `host` | Optional host filter. |
+| `path_prefix` | Optional path filter. |
 
-## Supported providers
+## Validation Rules Worth Remembering
 
-| Category | Providers |
-|---|---|
-| Auth | `google`, `oidc` |
-| Datastore | `sqlite`, `postgres`, `mysql`, `dynamodb`, `mongodb`, `firestore`, `oracle`, `sqlserver` |
-| Secrets | `env`, `file`, `gcp_secret_manager` |
-| Bindings | `webhook`, `proxy` |
-| Runtimes | `echo` (dev mode only) |
+- `auth.provider` is required
+- `datastore.provider` is required
+- `server.encryption_key` is required outside dev mode
+- integrations cannot mix `plugin` and `upstreams` unless `plugin.mode: overlay`
+- runtime plugins must use `runtimes.<name>.config`, not `runtimes.<name>.plugin.config`
+- runtime plugins cannot use overlay mode
+- `egress.default_action` and policy `action` must be `allow` or `deny`

--- a/docs/pages/reference/http-api.mdx
+++ b/docs/pages/reference/http-api.mdx
@@ -1,84 +1,148 @@
 # HTTP API
 
-## Unauthenticated endpoints
+This page documents the HTTP surface exposed by `gestaltd`.
+
+## Authentication Model
+
+Authenticated routes accept:
+
+- the `session_token` cookie
+- or `Authorization: Bearer <token>`
+
+For proxy routes, Gestalt also understands:
+
+- `Proxy-Authorization: Bearer <token>`
+
+Valid bearer tokens are:
+
+- platform session tokens
+- Gestalt API tokens
+- egress client tokens, where supported by the route
+
+## Unauthenticated Routes
 
 | Method | Path | Purpose |
-|---|---|---|
-| GET | `/health` | Health check. Returns `{"status":"ok"}`. |
-| GET | `/ready` | Readiness check. Returns `{"status":"ok"}` when providers are initialized and the datastore is reachable. Otherwise returns a 503 with a reason such as `{"status":"providers loading"}` or `{"status":"datastore unavailable"}`. |
-| POST | `/api/v1/auth/login` | Start platform login. Accepts `{"state": "...", "callback_port": 12345}`. Returns `{"url": "..."}` with the provider's login URL. |
-| GET | `/api/v1/auth/login/callback` | Complete platform login. Exchanges the authorization code for a session token. Returns `{"email": "...", "display_name": "...", "token": "..."}`. |
-| GET | `/api/v1/auth/info` | Returns `{"provider": "...", "display_name": "...", "dev_mode": true/false}`. |
+| --- | --- | --- |
+| `GET` | `/health` | Basic liveness check. |
+| `GET` | `/ready` | Readiness check. Returns `503` until providers and datastore are ready. |
+| `GET` | `/api/v1/auth/info` | Returns platform auth metadata. |
+| `POST` | `/api/v1/auth/login` | Starts platform login. |
+| `GET` | `/api/v1/auth/login/callback` | Completes platform login. |
+| `POST` | `/api/v1/auth/logout` | Clears the current platform session. |
+| `GET` | `/api/v1/auth/callback` | Completes integration OAuth. |
 
-In dev mode, an additional endpoint is available:
+In dev mode only:
 
 | Method | Path | Purpose |
-|---|---|---|
-| POST | `/api/dev-login` | Dev-only login. Accepts `{"email": "..."}` and returns a session token without OAuth. |
+| --- | --- | --- |
+| `POST` | `/api/dev-login` | Dev-only login shortcut. |
 
-## Authenticated endpoints
-
-All authenticated endpoints require an `Authorization: Bearer <token>` header. The token can be a session token from login or an API token.
+## Authenticated User Routes
 
 ### Integrations
 
 | Method | Path | Purpose |
-|---|---|---|
-| GET | `/api/v1/integrations` | List loaded integrations. Returns an array of objects with `name`, `display_name`, `description`, `icon_svg`, `connected` (boolean), `instances` (array of `{"name": "..."}` objects), and `auth_types` (array of strings, e.g. `["oauth"]`, `["manual"]`, or `["oauth", "manual"]`). |
-| DELETE | `/api/v1/integrations/{name}` | Disconnect an integration. Removes the stored token for the calling user. Pass `?instance=NAME` to disconnect a specific instance. When multiple connections exist and no instance is specified, returns 409 with the available instance names. Returns `{"status":"disconnected"}`. |
-| GET | `/api/v1/integrations/{name}/operations` | List operations exposed by an integration. |
-| GET or POST | `/api/v1/{integration}/{operation}` | Execute an integration operation. MCP-only integrations return a 400 error. |
+| --- | --- | --- |
+| `GET` | `/api/v1/integrations` | List integrations, connection state, auth types, instances, icons, and connection parameter hints. |
+| `DELETE` | `/api/v1/integrations/{name}` | Disconnect an integration. Use `?instance=...` when more than one connection exists. |
+| `GET` | `/api/v1/integrations/{name}/operations` | List operations for one integration. |
+| `GET` or `POST` | `/api/v1/{integration}/{operation}` | Invoke an integration operation. |
 
-### Auth flows
-
-| Method | Path | Purpose |
-|---|---|---|
-| POST | `/api/v1/auth/start-oauth` | Start an integration OAuth flow. Accepts `{"integration": "...", "scopes": [...]}`. Returns `{"url": "...", "state": "..."}`. |
-| GET | `/api/v1/auth/callback` | Complete integration OAuth. Exchanges code for tokens and stores them. Redirects to the web UI on success. |
-| POST | `/api/v1/auth/connect-manual` | Submit manual credentials. Accepts `{"integration": "...", "credential": "..."}`. Returns `{"status":"connected"}`. |
-
-### API tokens
+### Integration Connection Flows
 
 | Method | Path | Purpose |
-|---|---|---|
-| POST | `/api/v1/tokens` | Create an API token. Returns `{"id": "...", "name": "...", "token": "...", "expires_at": "..."}`. The plaintext token is shown only once. |
-| GET | `/api/v1/tokens` | List API tokens for the current user. Returns `id`, `name`, `scopes`, `created_at`, `expires_at`. |
-| DELETE | `/api/v1/tokens/{id}` | Revoke an API token. Returns `{"status":"revoked"}`. |
+| --- | --- | --- |
+| `POST` | `/api/v1/auth/start-oauth` | Start an integration OAuth flow. |
+| `POST` | `/api/v1/auth/connect-manual` | Submit manual integration credentials. |
+| `GET` | `/api/v1/connections/staged/{id}` | Inspect a staged connection. |
+| `POST` | `/api/v1/connections/staged/{id}/select` | Finalize a staged connection choice. |
+| `DELETE` | `/api/v1/connections/staged/{id}` | Cancel a staged connection. |
 
-### Runtimes and bindings
-
-| Method | Path | Purpose |
-|---|---|---|
-| GET | `/api/v1/runtimes` | List configured runtimes. |
-| GET | `/api/v1/bindings` | List configured bindings. |
-
-Bindings register dynamic routes at `/api/v1/bindings/{name}/*` based on their config.
-
-### MCP
+### API Tokens
 
 | Method | Path | Purpose |
-|---|---|---|
-| GET or POST | `/mcp` | Model Context Protocol endpoint. Mounted when at least one integration exposes MCP tools, either via `mcp: true` on a REST/GraphQL upstream or via a `type: mcp` upstream. |
+| --- | --- | --- |
+| `POST` | `/api/v1/tokens` | Create an API token. Plaintext is returned once. |
+| `GET` | `/api/v1/tokens` | List API tokens for the current user. |
+| `DELETE` | `/api/v1/tokens/{id}` | Revoke an API token. |
 
-## Execution semantics
+### Egress Clients
 
-- **GET** requests pass parameters as query string key-value pairs.
-- **POST** requests pass parameters as a JSON body.
-- Path placeholders like `{integration}` and `{operation}` are resolved from the URL. Remaining parameters are sent as query or body values depending on the method.
-- When a user has multiple connections to an integration, pass `_instance` as a parameter to specify which connection to use. If omitted when multiple connections exist, the request returns `409 Conflict` with the available instance names.
-- Integrations backed only by a `type: mcp` upstream cannot be invoked over HTTP. Attempting to do so returns `400: this integration is accessible only via MCP`.
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/api/v1/egress-clients` | Create an egress client. |
+| `GET` | `/api/v1/egress-clients` | List egress clients. |
+| `DELETE` | `/api/v1/egress-clients/{id}` | Delete an egress client. |
+| `POST` | `/api/v1/egress-clients/{id}/tokens` | Create an egress client token. |
+| `GET` | `/api/v1/egress-clients/{id}/tokens` | List egress client tokens. |
+| `DELETE` | `/api/v1/egress-clients/{id}/tokens/{tokenID}` | Revoke an egress client token. |
 
-## Authentication
+### Runtime And Binding Discovery
 
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/v1/runtimes` | List configured runtimes. |
+| `GET` | `/api/v1/bindings` | List configured bindings. |
+
+## Admin-Only Routes
+
+These routes require a logged-in or token-authenticated user whose email appears in `server.admin_emails`.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/api/v1/egress/deny-rules` | Create an egress deny rule. |
+| `GET` | `/api/v1/egress/deny-rules` | List egress deny rules. |
+| `DELETE` | `/api/v1/egress/deny-rules/{id}` | Delete an egress deny rule. |
+
+## Dynamic Binding Routes
+
+Bindings may add routes under:
+
+```text
+/api/v1/bindings/{binding-name}/...
 ```
-Authorization: Bearer <session-token-or-api-token>
+
+The exact paths and auth behavior depend on the binding type and its config.
+
+## MCP
+
+If any integration is MCP-enabled, Gestalt also mounts:
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` or `POST` | `/mcp` | Model Context Protocol endpoint. |
+
+`/mcp` is authenticated with the same session or bearer-token middleware as the rest of the authenticated API.
+
+## Invocation Semantics
+
+When you call:
+
+```text
+/api/v1/{integration}/{operation}
 ```
+
+Gestalt:
+
+1. authenticates the caller
+2. resolves the target provider and operation
+3. resolves credentials based on `connection_mode`
+4. auto-selects an instance when there is exactly one
+5. fails with an ambiguity error when there are multiple instances and none is specified
+6. refreshes OAuth tokens when needed
+7. executes the provider operation
+
+## Parameter Conventions
+
+- `GET` invocations read parameters from the query string
+- `POST` invocations read parameters from a JSON body
+- `_instance` can be supplied when an integration has more than one stored connection
 
 ## Example
 
 ```sh
-curl -X POST http://localhost:8080/api/v1/slack/chat_postMessage \
-  -H "Authorization: Bearer $GESTALT_API_KEY" \
+curl -X POST http://localhost:8080/api/v1/github/repos_listForAuthenticatedUser \
+  -H "Authorization: Bearer gst_api_..." \
   -H "Content-Type: application/json" \
-  -d '{"channel":"C123","text":"hello from gestalt"}'
+  -d '{}'
 ```

--- a/docs/pages/tasks/add-a-first-party-provider.mdx
+++ b/docs/pages/tasks/add-a-first-party-provider.mdx
@@ -1,149 +1,77 @@
 # Add a First-Party Provider
 
-A **first-party provider** ships with gestaltd and has its operation inventory checked into the repo. Use this approach for stable integrations that are tested in CI and versioned alongside the server.
+Most integrations should stay config-defined. Add a compiled-in first-party provider only when the behavior belongs in the `gestaltd` binary itself.
 
-For ad-hoc or user-configured integrations that point at remote OpenAPI/GraphQL specs, see [Add an Integration](/tasks/add-an-integration).
+## When A Built-In Provider Is Appropriate
 
-## 1. Create the provider package
+A built-in provider makes sense when:
 
-Every first-party provider lives under `plugins/providers/<name>/` with three files:
+- the provider is part of the product, not just one deployment
+- config-defined upstreams are not expressive enough
+- the code needs to ship and test with the host binary
 
-### `provider.yaml`
+## 1. Implement The Provider Package
 
-Declarative definition of the API surface. See `internal/provider/definition.go` for the full schema.
+Create a package under:
+
+```text
+plugins/providers/<name>
+```
+
+It should expose a factory with the provider signature used by bootstrap and return a `core.Provider`.
+
+Depending on behavior, the provider may also implement:
+
+- `core.OAuthProvider`
+- `core.ManualProvider`
+- `core.CatalogProvider`
+- connection-parameter interfaces used by the UI and MCP
+
+## 2. Register It
+
+Built-in named providers are registered in:
+
+```text
+cmd/gestaltd/providers.go
+```
+
+If the provider is intended to ship in the binary, it must be added there.
+
+## 3. Decide How Operators Compose It
+
+Built-in providers usually show up in one of two ways:
+
+### Directly
+
+An integration uses the registered provider as its entire implementation.
+
+### As An Overlay Base
+
+An integration uses:
 
 ```yaml
-provider: myservice
-display_name: My Service
-description: One-line description
-connection_mode: user   # none | user | identity | either
-base_url: "https://api.example.com/v1"
-
-auth:
-  type: oauth2          # oauth2 | manual
-  authorization_url: https://example.com/oauth/authorize
-  token_url: https://example.com/oauth/token
-  scopes: [read, write]
-
-operations:
-  list_items:
-    description: List all items
-    method: GET
-    path: /items
-    parameters:
-      - {name: limit, type: integer, description: Max results}
-  get_item:
-    description: Get an item by ID
-    method: GET
-    path: "/items/{id}"
-    parameters:
-      - {name: id, type: string, required: true, description: Item ID}
+plugin:
+  mode: overlay
+  base: <built-in-provider-name>
 ```
 
-### `factory.go`
+That lets an executable plugin extend the built-in provider.
 
-Embed the YAML, unmarshal, and call `provider.Build()`:
+## 4. Test It At The Provider Boundary
 
-```go
-package myservice
+Tests should validate:
 
-import (
-	"context"
-	_ "embed"
+- operation inventory
+- connection mode
+- auth behavior
+- execution behavior
 
-	"github.com/valon-technologies/gestalt/core"
-	"github.com/valon-technologies/gestalt/internal/bootstrap"
-	"github.com/valon-technologies/gestalt/internal/config"
-	"github.com/valon-technologies/gestalt/internal/provider"
-	"gopkg.in/yaml.v3"
-)
+The important boundary is the provider contract the rest of Gestalt sees, not just internal helper functions.
 
-//go:embed provider.yaml
-var definitionYAML []byte
+## 5. Update The Docs
 
-func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
-	var def provider.Definition
-	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
-		return nil, err
-	}
-	return provider.Build(&def, intg, nil, provider.WithEgressResolver(deps.Egress.Resolver))
-}
-```
+If you add a new first-party provider, update:
 
-### `factory_test.go`
-
-Use the shared `providertest` harness and validate against the `inventory` contract:
-
-```go
-package myservice
-
-import (
-	"testing"
-
-	"github.com/valon-technologies/gestalt/core"
-	"github.com/valon-technologies/gestalt/internal/config"
-	"github.com/valon-technologies/gestalt/plugins/providers/inventory"
-	"github.com/valon-technologies/gestalt/plugins/providers/providertest"
-)
-
-func TestBuildProvider(t *testing.T) {
-	t.Parallel()
-
-	inv, err := inventory.Load()
-	if err != nil {
-		t.Fatalf("inventory.Load: %v", err)
-	}
-	spec := inv.Providers["myservice"]
-
-	def := providertest.ParseDefinition(t, definitionYAML)
-	prov := providertest.BuildProvider(t, def, config.IntegrationDef{
-		ClientID: "dummy", ClientSecret: "dummy",
-	})
-
-	providertest.CheckProvider(t, prov, providertest.ProviderExpect{
-		Name:           "myservice",
-		ConnectionMode: core.ConnectionMode(spec.ConnectionMode),
-		OperationCount: len(spec.Operations),
-		OperationNames: spec.Operations,
-	})
-}
-```
-
-## 2. Registration
-
-Factory registration in `cmd/gestaltd/providers.go` is handled by the integrator, not the provider author. Your PR should only contain the `plugins/providers/<name>/` package.
-
-## 3. Overlay providers
-
-When Go code is needed for operations that cannot be expressed as REST/GraphQL YAML (custom request shaping, SDK calls, multi-step workflows), create an **overlay binary**:
-
-1. Implement a `core.Provider` with only the custom operations in your provider package
-2. Create `cmd/gestalt-plugin-<name>/main.go` that serves it via gRPC:
-
-```go
-package main
-
-import (
-	"context"
-	"log"
-	"os/signal"
-	"syscall"
-
-	"github.com/valon-technologies/gestalt/internal/pluginapi"
-)
-
-func main() {
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
-	if err := pluginapi.ServeProvider(ctx, newOverlayProvider()); err != nil {
-		log.Fatal(err)
-	}
-}
-```
-
-The YAML definition handles the base operations; the overlay binary handles the rest. The bootstrap system composes them automatically when `mode: overlay` is set in the deployment config.
-
-Use exactly one base source for the overlay:
-
-- Keep `upstreams` in the integration config when the base comes from prepared REST/GraphQL/MCP definitions.
-- Set `plugin.base: <provider-name>` when the base comes from a registered first-party Go provider factory.
+- [Built-in Plugins](/reference/built-in-plugins)
+- any task docs that rely on that provider
+- deploy or config examples if the provider becomes part of a recommended path

--- a/docs/pages/tasks/add-an-integration.mdx
+++ b/docs/pages/tasks/add-an-integration.mdx
@@ -1,119 +1,99 @@
 # Add an Integration
 
-Adding an **integration** means defining one or more upstreams, optionally configuring auth, and deciding which operations to expose.
+Most integrations in Gestalt are pure configuration. Start with a config-defined integration and only reach for a plugin when the upstream behavior cannot be expressed declaratively.
 
-## 1. Decide how to define it
+## 1. Pick The Base Source
 
-| Approach | Upstream type | When to use |
-|---|---|---|
-| OpenAPI spec | `type: rest` with `url` | Public or local OpenAPI document exists. Operations generated automatically. |
-| GraphQL endpoint | `type: graphql` with `url` | GraphQL API. Operations generated from introspection. |
-| MCP server | `type: mcp` with `url` | Upstream already speaks MCP. Tools imported directly. |
-| Manual auth | Any upstream type with `auth.type: manual` | API-key service with no OAuth flow. Users paste credentials directly. |
+Choose one of these:
 
-## 2. REST integration from OpenAPI
+| Source | Use when |
+| --- | --- |
+| `rest` | You have an OpenAPI document. |
+| `graphql` | You have a GraphQL endpoint. |
+| `mcp` | The upstream already exposes MCP tools. |
+| `plugin` | You need custom execution logic or custom auth behavior. |
+
+## 2. Start With The Smallest Useful Definition
+
+Public REST example:
 
 ```yaml
 integrations:
-  slack:
+  petstore:
+    display_name: Swagger Petstore
+    connection_mode: none
     upstreams:
       - type: rest
-        url: https://raw.githubusercontent.com/slackapi/slack-api-specs/master/web-api/slack_web_openapi_v2.json
+        url: https://petstore3.swagger.io/api/v3/openapi.json
         allowed_operations:
-          conversations_list: ""
-          chat_postMessage: Send a message to a channel
-    client_id: ${SLACK_CLIENT_ID}
-    client_secret: ${SLACK_CLIENT_SECRET}
-    icon_file: slack.svg
-    response_check:
-      success_body_match:
-        ok: true
-      error_message_path: error
-    auth:
-      authorization_url: https://slack.com/oauth/v2/authorize
-      token_url: https://slack.com/api/oauth.v2.access
-      response_check:
-        success_body_match:
-          ok: true
-        error_message_path: error
+          findPetsByStatus: List pets by status
+          getPetById: Fetch a pet by id
 ```
 
-The `icon_file` field sets the icon displayed in the web UI. Relative paths resolve from the config file's directory. The `error_message_path` field is a dot-delimited path that extracts a human-readable error from upstream JSON error responses.
+That is enough to build a real provider.
 
-## 3. GraphQL integration
+## 3. Add Auth If The Upstream Needs It
+
+OAuth-backed example:
 
 ```yaml
+auth_profiles:
+  github_oauth:
+    client_id: ${GITHUB_CLIENT_ID}
+    client_secret: secret://github-client-secret
+    auth:
+      type: oauth2
+      authorization_url: https://github.com/login/oauth/authorize
+      token_url: https://github.com/login/oauth/access_token
+
 integrations:
-  my-api:
+  github:
+    auth_profile: github_oauth
     upstreams:
-      - type: graphql
-        url: https://api.example.com/graphql
+      - type: rest
+        url: https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json
         allowed_operations:
-          - searchUsers
-          - createProject
-    client_id: ${API_CLIENT_ID}
-    client_secret: ${API_CLIENT_SECRET}
-    auth:
-      authorization_url: https://example.com/oauth/authorize
-      token_url: https://example.com/oauth/token
+          repos_listForAuthenticatedUser: List repositories
+          issues_listForAuthenticatedUser: List issues
 ```
 
-Gestalt introspects the GraphQL endpoint at startup and generates operations from queries and mutations. Arguments are exposed with top-level type information for MCP clients. For deterministic production deployments, run `gestaltd init` during build and `gestaltd serve` at runtime so the GraphQL provider definition is compiled ahead of time.
+If the upstream uses manual credentials instead, configure manual auth instead of OAuth.
 
-## 4. Manual auth for API-key services
+## 4. Add Runtime Behavior
 
-```yaml
-integrations:
-  datadog:
-    upstreams:
-      - type: rest
-        url: https://raw.githubusercontent.com/DataDog/documentation/master/static/resources/json/datadog-api-spec.json
-    auth:
-      type: manual
-    auth_mapping:
-      headers:
-        DD-API-KEY: api_key
-        DD-APPLICATION-KEY: app_key
-```
+You can refine the integration with:
 
-Users paste their credentials through the web UI or via `POST /api/v1/auth/connect-manual`. Gestalt encrypts and stores them the same way it stores OAuth tokens.
+- `headers` for static request headers
+- `response_check` for success and error extraction
+- `mcp: true` to project operations onto `/mcp`
+- `mcp_tool_prefix` to avoid MCP tool-name collisions
+- `manual_auth: true` if the provider supports both OAuth and manual auth
 
-## 5. Restrict operations
-
-The `allowed_operations` field on each upstream controls which operations are exposed. It accepts a YAML list (names only) or a map (names to description overrides). Omit it to allow all operations. Only expose what callers need — a tightly scoped integration is easier to audit, faster to load, and less likely to surprise anyone.
-
-## 6. Set the connection mode
-
-Control how credentials are resolved per integration:
-
-```yaml
-integrations:
-  slack:
-    upstreams:
-      - type: rest
-        url: https://...
-    connection_mode: user    # each user connects independently (default)
-  shared-service:
-    upstreams:
-      - type: rest
-        url: https://api.example.com/openapi.json
-    connection_mode: identity # single shared credential
-```
-
-See [Connection Modes](/concepts/platform-model#connection-modes) for all options.
-
-## 7. Validate end to end
+## 5. Validate And Prepare
 
 ```sh
-gestaltd validate --config your-config.yaml
-gestalt integrations list
-gestalt integrations connect slack
-gestalt invoke slack conversations_list
-
-curl -H "Authorization: Bearer $GESTALT_API_KEY" \
-  http://localhost:8080/api/v1/slack/conversations_list
+gestaltd validate --init --config ./gestalt.yaml
 ```
 
-## When to write code
+That catches config errors and prepares any remote provider artifacts.
 
-Most integrations need zero Go code. Write a plugin only when the upstream API has unusual auth flows, requires request rewrites the config cannot express, or needs custom execution logic beyond what declarative config supports.
+## 6. Run It
+
+```sh
+gestaltd serve --locked --config ./gestalt.yaml
+```
+
+Then:
+
+- connect the integration through the UI or API
+- list operations with `GET /api/v1/integrations/{name}/operations`
+- invoke operations over HTTP or MCP
+
+## 7. Reach For A Plugin Only When Needed
+
+Write a provider plugin when you need one of these:
+
+- request or response shaping that config cannot express
+- nonstandard auth behavior
+- multi-step execution
+- custom operation semantics that do not come from an upstream spec

--- a/docs/pages/tasks/run-locally.mdx
+++ b/docs/pages/tasks/run-locally.mdx
@@ -2,57 +2,61 @@ import { Callout } from 'nextra/components'
 
 # Run Locally
 
-## Full stack (API + web UI)
+There are three useful local workflows: zero-config startup, explicit config, and locked local startup.
+
+## Zero-Config Startup
 
 ```sh
-gestaltd --config gestalt.dev.yaml
+gestaltd
 ```
 
-This starts the API server and the Next.js web UI in a single process. The API runs on the port in your config (default 8080), the web UI on port 3000. `gestaltd` also prepares remote REST and GraphQL providers automatically when needed.
+If no config exists, `gestaltd` generates `~/.gestalt/config.yaml` and starts a local environment with:
 
-## Web UI with mock API
+- `local` auth
+- SQLite
+- `env` secrets
+- dev mode on
+
+The server and embedded UI are both available at `http://localhost:8080`.
+
+## Explicit Config
 
 ```sh
-cd gestalt/web
-./dev.sh web
+gestaltd --config ./gestalt.yaml
 ```
 
-Starts the Next.js app with built-in mock API routes. No Go server involved.
+Use this when you want to control:
 
-## Development mode
+- auth provider
+- datastore path or DSN
+- integrations
+- runtimes
+- bindings
 
-Set `dev_mode: true` in your config to:
+## Locked Local Startup
 
-- Relax HTTPS requirements for OAuth callbacks.
-- Enable the Dev Login auth path (no external IdP needed).
-- Enable the echo provider and echo runtime for testing.
+If your config includes remote REST or GraphQL upstreams, or packaged plugins, validate and prepare first:
 
-`encryption_key` must be set even in dev mode. Any stable string works locally.
+```sh
+gestaltd validate --init --config ./gestalt.yaml
+gestaltd serve --locked --config ./gestalt.yaml
+```
+
+This is the closest local approximation to a production deployment.
+
+## Local Dev Features
+
+With `server.dev_mode: true`, Gestalt enables:
+
+- `POST /api/dev-login`
+- `X-Dev-User-Email`
+- dev CORS
+- the built-in `echo` provider and `echo` runtime
 
 <Callout>
-  Never enable `dev_mode` in production.
+  Dev mode is for local work only. Do not carry it into production configs.
 </Callout>
 
-## Docker Compose
+## The Frontend In Isolation
 
-```sh
-cd gestalt && docker compose up --build
-```
-
-Runs the API on port 8080 and the web UI on port 3000. Config is mounted from `deploy/docker/config.yaml`. SQLite data is persisted in a named volume.
-
-## Validate your config
-
-```sh
-gestaltd validate --config gestalt.dev.yaml
-```
-
-Prints resolved server settings, auth provider, datastore, integrations, runtimes, and bindings. Exits with "config ok" if valid.
-
-## Sanity checks
-
-```sh
-curl http://localhost:8080/health
-gestalt --url http://localhost:8080 auth status
-gestalt --url http://localhost:8080 integrations list
-```
+If you are working on the web app itself rather than `gestaltd`, the repo also supports running the Next.js app separately. That is a frontend development workflow, not the normal runtime model.

--- a/docs/pages/tasks/use-a-plugin-package.mdx
+++ b/docs/pages/tasks/use-a-plugin-package.mdx
@@ -1,40 +1,54 @@
 # Use a Plugin Package
 
-This task covers the packaged plugin workflow for operators.
+Packaged plugins are the deployment-oriented way to run executable providers and runtimes.
 
-## 1. Reference the package in config
+## 1. Reference The Package
 
 ```yaml
 integrations:
   acme:
     plugin:
-      package: ./plugins/acme-provider-0.1.0.tar.gz
+      package: ./plugins/acme-provider.tar.gz
       config:
         endpoint: https://api.example.com
 ```
 
-`plugin.package` accepts a local path to a `.tar.gz` archive or an HTTPS URL. Relative paths resolve from the config file's directory.
+`plugin.package` accepts:
 
-## 2. Prepare the deployment
+- a local directory
+- a local `.tar.gz`
+- an HTTPS URL
 
-```bash
+## 2. Prepare It
+
+```sh
 gestaltd init --config ./gestalt.yaml
 ```
 
-This extracts the package into `.gestalt/plugins/`, validates the manifest and platform-specific artifact, and writes the locked manifest and executable paths into `gestalt.lock.json`.
+This validates the manifest, selects the current platform artifact, installs the package into `.gestalt/plugins/`, and records the prepared result in `gestalt.lock.json`.
 
-## 3. Validate
+## 3. Validate The Locked Deployment
 
-```bash
+```sh
 gestaltd validate --config ./gestalt.yaml
 ```
 
-For packaged plugins, validation uses the prepared manifest and packaged schema instead of launching the plugin binary just to read metadata.
+Validation now uses the prepared plugin state instead of re-resolving the package every time.
 
-## 4. Serve
+## 4. Start From Locked State
 
-```bash
-gestaltd serve --config ./gestalt.yaml
+```sh
+gestaltd serve --locked --config ./gestalt.yaml
 ```
 
-`serve` uses the locked executable path from `gestalt.lock.json`.
+That is the normal production path for packaged plugins.
+
+## 5. Refresh A Remote Package
+
+If `plugin.package` points at an HTTPS URL and the remote archive changes, rerun:
+
+```sh
+gestaltd init --config ./gestalt.yaml
+```
+
+Remote packages are intentionally refreshed during explicit `init`.

--- a/docs/pages/tasks/use-with-mcp.mdx
+++ b/docs/pages/tasks/use-with-mcp.mdx
@@ -1,63 +1,64 @@
 # Use with MCP
 
-Connect Gestalt to AI assistants like Claude Code or Claude Desktop via the **Model Context Protocol**.
+Gestalt can expose integrations to any MCP client through `/mcp`.
 
-## Before you begin
+## 1. Enable MCP On An Integration
 
-- A running Gestalt server with at least one integration.
-- A user account (sign in via the web UI or CLI).
-- An API token for that user.
+For REST or GraphQL, set `mcp: true` on the upstream:
 
-## 1. Create an API token
-
-```sh
-gestalt tokens create --name "mcp-token"
+```yaml
+integrations:
+  github:
+    mcp_tool_prefix: github_
+    upstreams:
+      - type: rest
+        url: https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json
+        mcp: true
+        allowed_operations:
+          - repos_listForAuthenticatedUser
+          - issues_listForAuthenticatedUser
 ```
 
-Or via the HTTP API:
+For an upstream MCP server, use `type: mcp`:
+
+```yaml
+integrations:
+  remote_tools:
+    upstreams:
+      - type: mcp
+        url: https://mcp.example.com
+```
+
+## 2. Start The Server
+
+```sh
+gestaltd serve --locked --config ./gestalt.yaml
+```
+
+If at least one integration is MCP-enabled, Gestalt mounts:
+
+```text
+/mcp
+```
+
+on the same HTTP server as the rest of the API.
+
+## 3. Create A Gestalt API Token
+
+Use the web UI or the HTTP API:
 
 ```sh
 curl -X POST http://localhost:8080/api/v1/tokens \
-  -H "Authorization: Bearer $SESSION_TOKEN" \
-  -d '{"name": "mcp-token"}'
+  -H "Authorization: Bearer <session-or-api-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"mcp"}'
 ```
 
-Save the returned token. It cannot be retrieved again.
+The returned token is what the MCP client uses to authenticate to Gestalt.
 
-## 2. Expose an integration over MCP
+## 4. Point Your MCP Client At Gestalt
 
-```yaml
-integrations:
-  linear:
-    upstreams:
-      - type: graphql
-        url: https://api.linear.app/graphql
-        mcp: true
-```
-
-For an upstream MCP server, use `type: mcp` instead. No extra flag is needed:
-
-```yaml
-integrations:
-  slack:
-    upstreams:
-      - type: mcp
-        url: https://mcp.slack.com/sse
-```
-
-Gestalt mounts `/mcp` automatically once at least one integration exposes MCP tools.
-
-## 3. Start the server
-
-```sh
-gestaltd --config config.yaml
-```
-
-The MCP endpoint is available at `/mcp` on the same server as the REST API.
-
-## 4. Configure Claude Code
-
-Add to `.mcp.json` in your project root or `~/.claude.json`:
+Example client config:
 
 ```json
 {
@@ -65,74 +66,24 @@ Add to `.mcp.json` in your project root or `~/.claude.json`:
     "gestalt": {
       "url": "http://localhost:8080/mcp",
       "headers": {
-        "Authorization": "Bearer your-api-token"
+        "Authorization": "Bearer gst_api_..."
       }
     }
   }
 }
 ```
 
-## 5. Configure Claude Desktop
+## 5. Understand The Auth Layers
 
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS):
+The MCP client authenticates to Gestalt with the API token above.
 
-```json
-{
-  "mcpServers": {
-    "gestalt": {
-      "url": "http://localhost:8080/mcp",
-      "headers": {
-        "Authorization": "Bearer your-api-token"
-      }
-    }
-  }
-}
-```
+Then Gestalt resolves upstream credentials using the integration's own `connection_mode`. That means MCP inherits the same per-user, shared-identity, or no-auth behavior as the regular HTTP API.
 
-## Minimal example config
+## 6. Troubleshoot Missing Tools
 
-A complete config with one GraphQL integration exposed over MCP:
+Check these in order:
 
-```yaml
-auth:
-  provider: oidc
-  config:
-    issuer_url: https://accounts.google.com
-    client_id: ${GOOGLE_CLIENT_ID}
-    client_secret: ${GOOGLE_CLIENT_SECRET}
-
-datastore:
-  provider: sqlite
-  config:
-    path: ./gestalt.db
-
-server:
-  dev_mode: true
-  encryption_key: ${GESTALT_ENCRYPTION_KEY}
-
-integrations:
-  linear:
-    mcp_tool_prefix: gs_
-    upstreams:
-      - type: graphql
-        url: https://api.linear.app/graphql
-        mcp: true
-        allowed_operations:
-          - searchIssues
-          - createIssue
-    client_id: ${LINEAR_CLIENT_ID}
-    client_secret: ${LINEAR_CLIENT_SECRET}
-    auth:
-      authorization_url: https://linear.app/oauth/authorize
-      token_url: https://api.linear.app/oauth/token
-```
-
-## Troubleshooting
-
-If tools do not appear in your MCP client:
-
-1. Verify the integration exposes MCP tools: use `mcp: true` on a REST/GraphQL upstream, or a `type: mcp` upstream.
-2. Check that your API token is valid (`gestalt auth status`).
-3. Confirm the token's owner has connected the integration (completed the OAuth flow or submitted manual credentials).
-4. Confirm the server has started and mounted `/mcp`.
-5. For MCP-only integrations (`type: mcp` upstream), note that they cannot be invoked over the HTTP API — they are only available via the MCP endpoint.
+1. the integration actually exposes MCP tools
+2. `/mcp` is mounted on the server
+3. the Gestalt API token is valid
+4. the token's owner has connected any required upstream credentials

--- a/docs/pages/troubleshooting.mdx
+++ b/docs/pages/troubleshooting.mdx
@@ -1,52 +1,69 @@
 # Troubleshooting
 
-## Integration is missing its provider
+## The UI Is Not On The Port I Expected
 
-Gestalt resolves providers at startup from the `upstreams` list. If no upstreams are configured, or a REST/GraphQL upstream is missing `url`, config loading fails. If `gestaltd serve` cannot find prepared artifacts for a remote REST/GraphQL upstream, startup fails.
+In normal runtime, the web UI is embedded in `gestaltd` and served from the same HTTP port as the API. If your server listens on `8080`, the UI is also on `8080`.
 
-**Fix**: Ensure each integration has at least one upstream with a valid `type` and `url`. For deterministic production startup, run `gestaltd init --config your-config.yaml` during build, then `gestaltd serve --config your-config.yaml` at runtime.
+## `serve --locked` Says Prepared Artifacts Are Missing
 
-## OAuth redirects are wrong
+Your config references something that must be prepared first, usually:
 
-Gestalt derives callback URLs from `server.base_url`. If it is unset or points to the wrong host, the identity provider rejects the redirect.
+- a remote REST upstream
+- a remote GraphQL upstream
+- a packaged plugin
 
-**Fix**: Set `server.base_url` to the externally-reachable URL of your deployment.
+Run:
 
-## Login works in dev but not production
+```sh
+gestaltd init --config ./gestalt.yaml
+```
 
-Dev mode enables a bypass login path. In production, a real auth provider must be configured.
+and then start again with `serve --locked`.
 
-**Fix**: Verify `dev_mode: false`, and that your auth provider config (issuer URL, client ID, client secret) is correct. Confirm the callback URL registered with your identity provider matches `server.base_url`.
+## OAuth Redirects Are Wrong
 
-## "No token stored" on invocation
+`server.base_url` is either missing or incorrect.
 
-The calling user has not connected the target integration. Each user must complete the OAuth flow (or paste manual credentials) for every integration they want to invoke.
+Gestalt derives callback URLs from it when explicit `redirect_url` fields are not set. Make sure it matches the external URL users and identity providers actually reach.
 
-**Fix**: Run `gestalt integrations connect <name>` or use the web UI.
+## Startup Fails Because `server.encryption_key` Is Missing
 
-## API token auth fails
+Outside dev mode, `server.encryption_key` is required. Set it explicitly or use a `secret://...` reference.
 
-- Verify the `Authorization` header uses the `Bearer` prefix.
-- Use the plaintext token returned at creation time, not the hash stored in the datastore.
-- If using the CLI, note that `GESTALT_API_KEY` takes priority over session tokens from `gestalt auth login`. Run `gestalt auth status` to see which credential source is active.
+## An Integration Cannot Find Credentials
 
-## Web UI does not talk to the local API
+Check the integration's `connection_mode` first.
 
-The web UI needs to know where the API server lives.
+- `user` expects a connection for the current user
+- `identity` expects a shared identity connection
+- `either` tries user first, then identity
+- `none` uses no credential
 
-**Fix**: Use `gestaltd` which starts both and wires them together automatically. If running separately, set `GESTALT_URL` to point to the API server.
+If the wrong mode is set, invocation fails even if a token exists somewhere else.
 
-## Config validation fails
+## Invocation Fails Because Multiple Connections Exist
 
-Run `gestaltd validate --config your-config.yaml` to see exactly which field is invalid. Common causes:
+The target integration has more than one stored instance and the caller did not choose one.
 
-- Missing `encryption_key` when `dev_mode` is not `true`.
-- Invalid provider name in `auth`, `datastore`, or `secrets`.
-- Integration references an `auth_profile` that does not exist.
+Pass an explicit instance when invoking, or disconnect the extra connection you do not want.
 
-## MCP tools do not appear
+## `/mcp` Is Missing
 
-1. Verify the integration has either `mcp: true` on a REST/GraphQL upstream or a `type: mcp` upstream.
-2. Check that your API token is valid.
-3. Confirm the token's owner has connected the integration.
-4. For MCP-only integrations, remember they only appear in the MCP endpoint, not the HTTP API.
+`/mcp` is only mounted when at least one integration is MCP-enabled.
+
+Enable it by either:
+
+- setting `mcp: true` on a REST or GraphQL upstream
+- or configuring an upstream with `type: mcp`
+
+## Webhook Or Proxy Behavior Is Missing
+
+Bindings are only available if they are declared in `bindings:` and start successfully after providers are ready. Check:
+
+- the binding type
+- the binding config
+- the binding's provider allowlist
+
+## Some Auth Or Connection Features Fail On My Datastore
+
+Some features rely on datastore capabilities beyond the base user and token store. SQL-backed datastores are the safest choice if you need the full platform surface.

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -4,10 +4,10 @@ import type { DocsThemeConfig } from "nextra-theme-docs";
 const config: DocsThemeConfig = {
   logo: <strong>Gestalt</strong>,
   project: {
-    link: "https://github.com/valon-technologies/toolshed",
+    link: "https://github.com/valon-technologies/gestalt",
   },
   docsRepositoryBase:
-    "https://github.com/valon-technologies/toolshed/tree/main/toolshed/docs",
+    "https://github.com/valon-technologies/gestalt/tree/main/docs",
   head: function Head() {
     const { title } = useConfig();
     const fullTitle = title ? `${title} – Gestalt` : "Gestalt";


### PR DESCRIPTION
## Summary
- rewrite the gestaltd docs from first principles around the actual runtime model
- clarify out-of-the-box deployment, locked startup, configuration primitives, and platform foundations
- fix shipped deploy examples and docs metadata to match the codebase

## What changed
- rewrite overview, getting started, concepts, deploy, tasks, reference, troubleshooting, and auth docs
- document the real single-process deployment model: API, embedded UI, and MCP on the same server
- document the real config surface from `internal/config`, including integrations, runtimes, bindings, plugins, and egress
- correct built-in inventory, auth fields, and Docker/Helm examples to match current code

## Verification
- `cd docs && npm ci`
- `cd docs && npm run typecheck`
- `cd docs && npm run build`