### PR TITLE
feat: add secret-backed credential materialization

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -142,7 +142,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	}()
 
 	sharedInvoker := invocation.NewBroker(providers, ds)
-	wireCredentialResolver(&deps.Egress, sharedInvoker, providers, ds)
+	wireCredentialResolver(&deps.Egress, sharedInvoker, providers, ds, sm)
 	audit := core.AuditSink(invocation.LogAuditSink{})
 
 	runtimes, err := buildRuntimes(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress)

--- a/internal/bootstrap/egress.go
+++ b/internal/bootstrap/egress.go
@@ -68,7 +68,7 @@ func (a *denyRuleStoreAdapter) LoadDenyRules(ctx context.Context) ([]egress.Deny
 	return out, nil
 }
 
-func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, providers *registry.PluginMap[core.Provider], ds core.Datastore) {
+func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, providers *registry.PluginMap[core.Provider], ds core.Datastore, sm core.SecretManager) {
 	var sources []egress.CredentialResolver
 
 	if len(deps.CredentialGrants) > 0 {
@@ -76,7 +76,9 @@ func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, provide
 		for i := range deps.CredentialGrants {
 			g := &deps.CredentialGrants[i]
 			grants[i] = egress.CredentialGrant{
-				Instance: g.Instance,
+				Instance:  g.Instance,
+				SecretRef: g.SecretRef,
+				AuthStyle: egress.AuthStyle(g.AuthStyle),
 				MatchCriteria: egress.MatchCriteria{
 					SubjectKind: egress.SubjectKind(g.SubjectKind),
 					SubjectID:   g.SubjectID,
@@ -89,17 +91,19 @@ func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, provide
 			}
 		}
 		sources = append(sources, &egress.ProviderCredentialResolver{
-			TokenResolver: &brokerTokenResolver{broker: broker},
-			Materializer:  &registryMaterializer{providers: providers},
-			Grants:        grants,
+			TokenResolver:  &brokerTokenResolver{broker: broker},
+			Materializer:   &registryMaterializer{providers: providers},
+			SecretResolver: sm,
+			Grants:         grants,
 		})
 	}
 
 	if grantStore, ok := ds.(core.EgressCredentialGrantStore); ok {
 		sources = append(sources, &egress.SavedGrantCredentialResolver{
-			Store:         &credentialGrantStoreAdapter{store: grantStore},
-			TokenResolver: &brokerTokenResolver{broker: broker},
-			Materializer:  &registryMaterializer{providers: providers},
+			Store:          &credentialGrantStoreAdapter{store: grantStore},
+			TokenResolver:  &brokerTokenResolver{broker: broker},
+			Materializer:   &registryMaterializer{providers: providers},
+			SecretResolver: sm,
 		})
 	}
 
@@ -125,7 +129,9 @@ func (a *credentialGrantStoreAdapter) ListCandidateCredentialGrants(ctx context.
 	out := make([]egress.CredentialGrant, len(grants))
 	for i, g := range grants {
 		out[i] = egress.CredentialGrant{
-			Instance: g.Instance,
+			Instance:  g.Instance,
+			SecretRef: g.SecretRef,
+			AuthStyle: egress.AuthStyle(g.AuthStyle),
 			MatchCriteria: egress.MatchCriteria{
 				SubjectKind: egress.SubjectKind(g.SubjectKind),
 				SubjectID:   g.SubjectID,

--- a/internal/bootstrap/regression_test.go
+++ b/internal/bootstrap/regression_test.go
@@ -389,3 +389,280 @@ func TestSavedCredentialGrantResolvesThroughBootstrap(t *testing.T) {
 		t.Errorf("expected authorization to contain %q, got %q", tokenValue, resolution.Credential.Authorization)
 	}
 }
+
+func TestSecretBackedCredentialGrant_ConfigGrant(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const secretName = "vendor-api-key"
+	const secretValue = "sk-test-secret-abc123"
+
+	cfg := validConfig()
+	cfg.Egress = config.EgressConfig{
+		Credentials: []config.EgressCredentialGrant{
+			{
+				Host:      "api.vendor.test",
+				SecretRef: secretName,
+				AuthStyle: "bearer",
+			},
+		},
+	}
+	cfg.Bindings = map[string]config.BindingDef{
+		"my-binding": {Type: "test-binding"},
+	}
+
+	factories := validFactories()
+	factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+		return &coretesting.StubSecretManager{
+			Secrets: map[string]string{secretName: secretValue},
+		}, nil
+	}
+
+	var receivedEgress bootstrap.EgressDeps
+	factories.Bindings["test-binding"] = func(_ context.Context, name string, _ config.BindingDef, deps bootstrap.BindingDeps) (core.Binding, error) {
+		receivedEgress = deps.Egress
+		return &coretesting.StubBinding{N: name}, nil
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	if receivedEgress.Resolver == nil || receivedEgress.Resolver.Credentials == nil {
+		t.Fatal("expected credential resolver to be wired")
+	}
+
+	agentCtx := egress.WithSubject(ctx, egress.Subject{Kind: egress.SubjectAgent, ID: "ec-agent-1"})
+	resolution, err := receivedEgress.Resolver.Resolve(agentCtx, egress.ResolutionInput{
+		Target: egress.Target{Method: "GET", Host: "api.vendor.test", Path: "/v1/data"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	const wantAuth = "Bearer " + secretValue
+	if resolution.Credential.Authorization != wantAuth {
+		t.Fatalf("got Authorization %q, want %q", resolution.Credential.Authorization, wantAuth)
+	}
+}
+
+func TestSecretBackedCredentialGrant_MultiTenantHostMatching(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const (
+		secretNameShop1 = "shop-1-key"
+		secretNameShop2 = "shop-2-key"
+		secretShop1     = "sk-shop-one"
+		secretShop2     = "sk-shop-two"
+		hostShop1       = "shop-1.example.com"
+		hostShop2       = "shop-2.example.com"
+	)
+
+	cfg := validConfig()
+	cfg.Egress = config.EgressConfig{
+		Credentials: []config.EgressCredentialGrant{
+			{Host: hostShop1, SecretRef: secretNameShop1, AuthStyle: "raw"},
+			{Host: hostShop2, SecretRef: secretNameShop2, AuthStyle: "raw"},
+		},
+	}
+	cfg.Bindings = map[string]config.BindingDef{
+		"my-binding": {Type: "test-binding"},
+	}
+
+	factories := validFactories()
+	factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+		return &coretesting.StubSecretManager{
+			Secrets: map[string]string{
+				secretNameShop1: secretShop1,
+				secretNameShop2: secretShop2,
+			},
+		}, nil
+	}
+
+	var receivedEgress bootstrap.EgressDeps
+	factories.Bindings["test-binding"] = func(_ context.Context, name string, _ config.BindingDef, deps bootstrap.BindingDeps) (core.Binding, error) {
+		receivedEgress = deps.Egress
+		return &coretesting.StubBinding{N: name}, nil
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	agentCtx := egress.WithSubject(ctx, egress.Subject{Kind: egress.SubjectAgent, ID: "ec-agent-1"})
+
+	resolve := func(host string) string {
+		t.Helper()
+		res, err := receivedEgress.Resolver.Resolve(agentCtx, egress.ResolutionInput{
+			Target: egress.Target{Method: "GET", Host: host, Path: "/api/orders"},
+		})
+		if err != nil {
+			t.Fatalf("Resolve(%s): %v", host, err)
+		}
+		return res.Credential.Authorization
+	}
+
+	if auth := resolve(hostShop1); auth != secretShop1 {
+		t.Fatalf("shop-1: got %q, want %q", auth, secretShop1)
+	}
+	if auth := resolve(hostShop2); auth != secretShop2 {
+		t.Fatalf("shop-2: got %q, want %q", auth, secretShop2)
+	}
+}
+
+func TestSecretBackedGrant_CoexistsWithProviderTokenGrant(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const (
+		secretName  = "ext-api-key"
+		secretValue = "sk-external-key"
+		tokenValue  = "tok-provider-token"
+	)
+
+	cfg := validConfig()
+	cfg.Egress = config.EgressConfig{
+		Credentials: []config.EgressCredentialGrant{
+			{Host: "api.external.test", SecretRef: secretName, AuthStyle: "bearer"},
+			{Provider: "alpha", Host: "api.provider.test"},
+		},
+	}
+	cfg.Bindings = map[string]config.BindingDef{
+		"my-binding": {Type: "test-binding", Providers: []string{"alpha"}},
+	}
+
+	factories := validFactories()
+	factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+		return &coretesting.StubSecretManager{
+			Secrets: map[string]string{secretName: secretValue},
+		}, nil
+	}
+	factories.Datastores["test-store"] = func(_ yaml.Node, _ bootstrap.Deps) (core.Datastore, error) {
+		return &coretesting.StubDatastore{
+			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+				return &core.IntegrationToken{AccessToken: tokenValue}, nil
+			},
+		}, nil
+	}
+
+	var receivedEgress bootstrap.EgressDeps
+	factories.Bindings["test-binding"] = func(_ context.Context, name string, _ config.BindingDef, deps bootstrap.BindingDeps) (core.Binding, error) {
+		receivedEgress = deps.Egress
+		return &coretesting.StubBinding{N: name}, nil
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	agentCtx := egress.WithSubject(ctx, egress.Subject{Kind: egress.SubjectAgent, ID: "ec-agent-1"})
+	secretRes, err := receivedEgress.Resolver.Resolve(agentCtx, egress.ResolutionInput{
+		Target: egress.Target{Method: "GET", Host: "api.external.test", Path: "/v1/data"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve secret grant: %v", err)
+	}
+	if secretRes.Credential.Authorization != "Bearer "+secretValue {
+		t.Fatalf("secret grant: got %q, want %q", secretRes.Credential.Authorization, "Bearer "+secretValue)
+	}
+
+	userCtx := egress.WithSubject(ctx, egress.Subject{Kind: egress.SubjectUser, ID: "user-456"})
+	providerRes, err := receivedEgress.Resolver.Resolve(userCtx, egress.ResolutionInput{
+		Target: egress.Target{Provider: "alpha", Method: "GET", Host: "api.provider.test", Path: "/v1/data"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve provider grant: %v", err)
+	}
+	if !strings.Contains(providerRes.Credential.Authorization, tokenValue) {
+		t.Fatalf("provider grant: got %q, want to contain %q", providerRes.Credential.Authorization, tokenValue)
+	}
+}
+
+func TestSecretRefNotEagerlyResolvedByBootstrap(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const secretRefValue = "my-key"
+
+	cfg := validConfig()
+	cfg.Egress = config.EgressConfig{
+		Credentials: []config.EgressCredentialGrant{
+			{Host: "api.test", SecretRef: secretRefValue},
+		},
+	}
+
+	factories := validFactories()
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	if len(result.Egress.CredentialGrants) != 1 {
+		t.Fatalf("expected 1 credential grant, got %d", len(result.Egress.CredentialGrants))
+	}
+	if result.Egress.CredentialGrants[0].SecretRef != secretRefValue {
+		t.Fatalf("secret_ref was modified by bootstrap: got %q, want %q",
+			result.Egress.CredentialGrants[0].SecretRef, secretRefValue)
+	}
+}
+
+func TestSecretBackedGrant_SecretURIPrefixStripped(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const (
+		secretName  = "prefixed-key"
+		secretValue = "sk-with-prefix"
+	)
+
+	cfg := validConfig()
+	cfg.Egress = config.EgressConfig{
+		Credentials: []config.EgressCredentialGrant{
+			{Host: "api.prefix.test", SecretRef: "secret://" + secretName, AuthStyle: "bearer"},
+		},
+	}
+	cfg.Bindings = map[string]config.BindingDef{
+		"my-binding": {Type: "test-binding"},
+	}
+
+	factories := validFactories()
+	factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+		return &coretesting.StubSecretManager{
+			Secrets: map[string]string{secretName: secretValue},
+		}, nil
+	}
+
+	var receivedEgress bootstrap.EgressDeps
+	factories.Bindings["test-binding"] = func(_ context.Context, name string, _ config.BindingDef, deps bootstrap.BindingDeps) (core.Binding, error) {
+		receivedEgress = deps.Egress
+		return &coretesting.StubBinding{N: name}, nil
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	agentCtx := egress.WithSubject(ctx, egress.Subject{Kind: egress.SubjectAgent, ID: "ec-agent-1"})
+	resolution, err := receivedEgress.Resolver.Resolve(agentCtx, egress.ResolutionInput{
+		Target: egress.Target{Method: "GET", Host: "api.prefix.test", Path: "/v1"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	const wantAuth = "Bearer " + secretValue
+	if resolution.Credential.Authorization != wantAuth {
+		t.Fatalf("got Authorization %q, want %q", resolution.Credential.Authorization, wantAuth)
+	}
+}

--- a/internal/bootstrap/validate.go
+++ b/internal/bootstrap/validate.go
@@ -60,7 +60,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 	defer func() { _ = CloseProviders(providers) }()
 
 	sharedInvoker := invocation.NewBroker(providers, ds)
-	wireCredentialResolver(&deps.Egress, sharedInvoker, providers, ds)
+	wireCredentialResolver(&deps.Egress, sharedInvoker, providers, ds, sm)
 	audit := core.AuditSink(invocation.LogAuditSink{})
 
 	runtimes, err := buildRuntimesWith(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress, buildRuntimeForValidation)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,8 @@ type EgressPolicyRule struct {
 type EgressCredentialGrant struct {
 	Provider    string `yaml:"provider"`
 	Instance    string `yaml:"instance"`
+	SecretRef   string `yaml:"secret_ref"`
+	AuthStyle   string `yaml:"auth_style"`
 	SubjectKind string `yaml:"subject_kind"`
 	SubjectID   string `yaml:"subject_id"`
 	Operation   string `yaml:"operation"`
@@ -623,6 +625,15 @@ func validateEgress(cfg *EgressConfig) error {
 		case "allow", "deny":
 		default:
 			return fmt.Errorf("config validation: egress.policies[%d].action must be \"allow\" or \"deny\", got %q", i, cfg.Policies[i].Action)
+		}
+	}
+	for i := range cfg.Credentials {
+		if style := cfg.Credentials[i].AuthStyle; style != "" {
+			switch style {
+			case "bearer", "raw", "basic", "none":
+			default:
+				return fmt.Errorf("config validation: egress.credentials[%d].auth_style must be one of \"bearer\", \"raw\", \"basic\", \"none\", got %q", i, style)
+			}
 		}
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -709,6 +709,70 @@ server:
 egress: {}
 `,
 		},
+		{
+			name: "egress credential auth_style bearer is valid",
+			yaml: `
+auth:
+  provider: auth-provider
+datastore:
+  provider: data-store
+server:
+  encryption_key: server-key
+egress:
+  credentials:
+    - host: api.vendor.test
+      secret_ref: vendor-key
+      auth_style: bearer
+`,
+		},
+		{
+			name: "egress credential auth_style raw is valid",
+			yaml: `
+auth:
+  provider: auth-provider
+datastore:
+  provider: data-store
+server:
+  encryption_key: server-key
+egress:
+  credentials:
+    - host: api.vendor.test
+      secret_ref: vendor-key
+      auth_style: raw
+`,
+		},
+		{
+			name: "egress credential auth_style omitted is valid",
+			yaml: `
+auth:
+  provider: auth-provider
+datastore:
+  provider: data-store
+server:
+  encryption_key: server-key
+egress:
+  credentials:
+    - host: api.vendor.test
+      secret_ref: vendor-key
+`,
+		},
+		{
+			name: "egress credential invalid auth_style rejected",
+			yaml: `
+auth:
+  provider: auth-provider
+datastore:
+  provider: data-store
+server:
+  encryption_key: server-key
+egress:
+  credentials:
+    - host: api.vendor.test
+      secret_ref: vendor-key
+      auth_style: oauth2
+`,
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/egress/provider_credentials.go
+++ b/internal/egress/provider_credentials.go
@@ -3,6 +3,7 @@ package egress
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 type CredentialResolver interface {
@@ -17,8 +18,32 @@ type CredentialMaterializer interface {
 	MaterializeProviderCredential(provider string, token string) (CredentialMaterialization, error)
 }
 
+type SecretResolver interface {
+	GetSecret(ctx context.Context, name string) (string, error)
+}
+
+const secretURIPrefix = "secret://"
+
+func resolveSecretGrant(ctx context.Context, sr SecretResolver, grant *CredentialGrant) (CredentialMaterialization, error) {
+	if sr == nil {
+		return CredentialMaterialization{}, fmt.Errorf("egress credentials: no secret resolver configured")
+	}
+	name := strings.TrimPrefix(grant.SecretRef, secretURIPrefix)
+	secret, err := sr.GetSecret(ctx, name)
+	if err != nil {
+		return CredentialMaterialization{}, fmt.Errorf("egress credentials: resolving secret %q: %w", name, err)
+	}
+	style := grant.AuthStyle
+	if style == "" {
+		style = AuthStyleBearer
+	}
+	return MaterializeCredential(secret, style, nil)
+}
+
 type CredentialGrant struct {
-	Instance string
+	Instance  string
+	SecretRef string
+	AuthStyle AuthStyle
 	MatchCriteria
 }
 
@@ -41,18 +66,28 @@ func (g *CredentialGrant) ResolveProvider(target Target) (provider, instance str
 }
 
 type ProviderCredentialResolver struct {
-	TokenResolver ProviderTokenResolver
-	Materializer  CredentialMaterializer
-	Grants        []CredentialGrant
+	TokenResolver  ProviderTokenResolver
+	Materializer   CredentialMaterializer
+	SecretResolver SecretResolver
+	Grants         []CredentialGrant
 }
 
 func (r *ProviderCredentialResolver) ResolveCredential(ctx context.Context, subject Subject, target Target) (CredentialMaterialization, error) {
-	provider, instance, ok := r.matchGrant(subject, target)
+	grant, ok := r.matchGrant(subject, target)
 	if !ok {
 		return CredentialMaterialization{}, nil
 	}
 
+	if grant.SecretRef != "" {
+		return resolveSecretGrant(ctx, r.SecretResolver, grant)
+	}
+
 	if _, canResolve := PrincipalForSubject(subject); !canResolve {
+		return CredentialMaterialization{}, nil
+	}
+
+	provider, instance, ok := grant.ResolveProvider(target)
+	if !ok {
 		return CredentialMaterialization{}, nil
 	}
 
@@ -71,17 +106,19 @@ func (r *ProviderCredentialResolver) ResolveCredential(ctx context.Context, subj
 	return r.Materializer.MaterializeProviderCredential(provider, token)
 }
 
-func (r *ProviderCredentialResolver) matchGrant(subject Subject, target Target) (provider, instance string, matched bool) {
+func (r *ProviderCredentialResolver) matchGrant(subject Subject, target Target) (*CredentialGrant, bool) {
 	for i := range r.Grants {
 		g := &r.Grants[i]
 		if !g.Matches(subject, target) {
 			continue
 		}
-		p, inst, ok := g.ResolveProvider(target)
-		if !ok {
+		if g.SecretRef != "" {
+			return g, true
+		}
+		if _, _, ok := g.ResolveProvider(target); !ok {
 			continue
 		}
-		return p, inst, true
+		return g, true
 	}
-	return "", "", false
+	return nil, false
 }

--- a/internal/egress/saved_credential_resolver.go
+++ b/internal/egress/saved_credential_resolver.go
@@ -10,9 +10,10 @@ type SavedCredentialGrantLoader interface {
 }
 
 type SavedGrantCredentialResolver struct {
-	Store         SavedCredentialGrantLoader
-	TokenResolver ProviderTokenResolver
-	Materializer  CredentialMaterializer
+	Store          SavedCredentialGrantLoader
+	TokenResolver  ProviderTokenResolver
+	Materializer   CredentialMaterializer
+	SecretResolver SecretResolver
 }
 
 func (r *SavedGrantCredentialResolver) ResolveCredential(ctx context.Context, subject Subject, target Target) (CredentialMaterialization, error) {
@@ -25,6 +26,10 @@ func (r *SavedGrantCredentialResolver) ResolveCredential(ctx context.Context, su
 		g := &candidates[i]
 		if !g.Matches(subject, target) {
 			continue
+		}
+
+		if g.SecretRef != "" {
+			return resolveSecretGrant(ctx, r.SecretResolver, g)
 		}
 
 		provider, instance, ok := g.ResolveProvider(target)


### PR DESCRIPTION
Credential grants can now reference secrets by name instead of requiring a provider token flow. When a grant specifies a `secret_ref`, the credential is fetched at request time through the configured secret manager and injected using the grant's `auth_style`. This enables gateway-only deployments to inject API keys for upstream services without provider integrations, and supports multi-tenant host matching where each tenant resolves a different secret.

The `secret_ref` config field is intentionally not resolved during bootstrap startup. Secrets are resolved lazily at request time, so rotating a secret in the backing store takes effect immediately without a restart.