### PR TITLE
docs: add gateway-only deployment guide

### DIFF
--- a/docs/pages/deploy/_meta.ts
+++ b/docs/pages/deploy/_meta.ts
@@ -1,5 +1,6 @@
 export default {
   index: "Overview",
+  "gateway-only": "Gateway-Only",
   "fly-io": "Fly.io",
   railway: "Railway",
   render: "Render",

--- a/docs/pages/deploy/gateway-only.mdx
+++ b/docs/pages/deploy/gateway-only.mdx
@@ -1,0 +1,213 @@
+import { Callout } from 'nextra/components'
+
+# Gateway-Only Deployment
+
+A gateway-only deployment runs Gestalt as an HTTP proxy with centralized auth, egress policy, and credential injection. It does not load any providers, integrations, runtimes, or MCP surfaces.
+
+This is useful when you want to mediate outbound API calls -- injecting secrets, enforcing deny rules, and authenticating callers -- without building a capability catalog.
+
+## What You Get
+
+- Inbound auth via session tokens, API keys (`gst_api_`), or egress-client tokens (`gst_ec_`)
+- A proxy binding that forwards requests to arbitrary upstream hosts
+- Egress policy rules that deny or allow requests by host, path, method, or subject
+- Credential injection from secret-manager references (`secret_ref`) or provider tokens
+- Admin API for managing deny rules and credential grants at runtime
+
+## What You Do Not Get
+
+- No capability catalog or operation discovery
+- No provider integrations, REST/GraphQL upstreams, or MCP endpoints
+- No runtimes or background workers
+
+## Minimal Config
+
+```yaml
+server:
+  port: 8080
+  base_url: https://gateway.example.com
+  encryption_key: secret://gestalt-encryption-key
+  admin_emails:
+    - ops@example.com
+
+auth:
+  provider: oidc
+  config:
+    issuer_url: https://login.example.com
+    client_id: ${OIDC_CLIENT_ID}
+    client_secret: secret://oidc-client-secret
+    session_secret: secret://oidc-session-secret
+
+datastore:
+  provider: sqlite
+  config:
+    path: /data/gestalt.db
+
+secrets:
+  provider: file
+  config:
+    dir: /etc/gestalt-secrets
+
+bindings:
+  proxy:
+    type: proxy
+    config:
+      path: /proxy
+
+egress:
+  default_action: deny
+  policies:
+    - action: allow
+      host: api.openai.com
+    - action: allow
+      host: api.anthropic.com
+  credentials:
+    - host: api.openai.com
+      secret_ref: openai-api-key
+      auth_style: bearer
+    - host: api.anthropic.com
+      secret_ref: anthropic-api-key
+      auth_style: bearer
+```
+
+Key points:
+
+- The `bindings.proxy` section declares zero providers. This is the providerless proxy mode.
+- `egress.default_action: deny` blocks all outbound traffic except hosts explicitly allowed.
+- Each credential grant uses `secret_ref` to pull a secret at request time and `auth_style: bearer` to inject it as a `Bearer` token.
+- `admin_emails` grants the listed users access to the deny-rule and credential-grant admin APIs.
+
+<Callout>
+  `secret_ref` values are resolved at request time through the configured secret manager, not during config loading. This means the proxy always fetches the current secret value.
+</Callout>
+
+## Secret-Backed Credentials
+
+The `secret_ref` and `auth_style` fields on credential grants replace provider-token resolution with direct secret-manager lookups.
+
+```yaml
+egress:
+  credentials:
+    - host: api.openai.com
+      secret_ref: openai-api-key
+      auth_style: bearer
+```
+
+When a proxied request matches this grant's host, Gestalt resolves `openai-api-key` through the secret manager and sets the `Authorization: Bearer <value>` header.
+
+Supported `auth_style` values:
+
+| Style | Header |
+| --- | --- |
+| `bearer` | `Authorization: Bearer <secret>` |
+| `basic` | `Authorization: Basic <secret>` |
+| `raw` | `Authorization: <secret>` |
+
+## Multi-Tenant Host Credentials
+
+When different hosts need different secrets, add one credential grant per host:
+
+```yaml
+egress:
+  credentials:
+    - host: shop-1.myshopify.com
+      secret_ref: shop-1-token
+      auth_style: bearer
+    - host: shop-2.myshopify.com
+      secret_ref: shop-2-token
+      auth_style: bearer
+```
+
+Host matching is exact. Each request resolves credentials from the first grant whose host matches.
+
+## Full Platform With Egress
+
+The same egress substrate works in a full-platform deployment alongside providers and integrations. Provider-token grants and secret-backed grants can coexist:
+
+```yaml
+server:
+  port: 8080
+  base_url: https://gestalt.example.com
+  encryption_key: secret://gestalt-encryption-key
+  admin_emails:
+    - ops@example.com
+
+auth:
+  provider: oidc
+  config:
+    issuer_url: https://login.example.com
+    client_id: ${OIDC_CLIENT_ID}
+    client_secret: secret://oidc-client-secret
+    session_secret: secret://oidc-session-secret
+
+datastore:
+  provider: postgres
+  config:
+    dsn: ${DATABASE_URL}
+
+secrets:
+  provider: gcp_secret_manager
+  config:
+    project: my-project
+
+integrations:
+  github:
+    display_name: GitHub
+    auth_profile: github_oauth
+    connection_mode: user
+    upstreams:
+      - type: rest
+        url: https://api.github.com/openapi.json
+
+auth_profiles:
+  github_oauth:
+    client_id: ${GITHUB_CLIENT_ID}
+    client_secret: secret://github-client-secret
+    auth:
+      type: oauth2
+      authorization_url: https://github.com/login/oauth/authorize
+      token_url: https://github.com/login/oauth/access_token
+
+bindings:
+  proxy:
+    type: proxy
+    providers:
+      - github
+    config:
+      path: /proxy
+
+egress:
+  default_action: deny
+  policies:
+    - action: allow
+      host: api.github.com
+    - action: allow
+      host: api.openai.com
+  credentials:
+    # Provider-token grant: resolves from user's GitHub OAuth token
+    - provider: github
+      host: api.github.com
+    # Secret-backed grant: resolves from secret manager
+    - host: api.openai.com
+      secret_ref: openai-api-key
+      auth_style: bearer
+```
+
+The credential source chain evaluates config grants first, then saved DB grants. Within each source, the first matching grant wins.
+
+## Startup
+
+Gateway-only configs have no remote upstreams to fetch, so locked startup works without `gestaltd init`:
+
+```sh
+gestaltd serve --config ./gateway.yaml
+```
+
+For production, you can still use the locked flow:
+
+```sh
+gestaltd validate --init --config ./gateway.yaml
+gestaltd serve --locked --config ./gateway.yaml
+```
+
+See [Deploy Overview](/deploy) for Docker, Kubernetes, and other deployment targets.

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -457,6 +457,9 @@ egress:
       method: GET
       host: api.github.com
       path_prefix: /repos
+    - host: api.openai.com
+      secret_ref: openai-api-key
+      auth_style: bearer
 ```
 
 ### `policies`
@@ -476,8 +479,10 @@ egress:
 
 | Field | Notes |
 | --- | --- |
-| `provider` | Credential source provider. |
+| `provider` | Credential source provider. Not required when `secret_ref` is set. |
 | `instance` | Credential instance. |
+| `secret_ref` | Secret manager key. When set, the credential is resolved from the secret manager instead of a provider token. |
+| `auth_style` | How the resolved secret is injected: `bearer`, `basic`, or `raw`. Required when `secret_ref` is set. |
 | `subject_kind` | Subject filter. |
 | `subject_id` | Subject filter. |
 | `operation` | Optional operation filter. |


### PR DESCRIPTION
Document the gateway-only deployment pattern where Gestalt runs as a pure
HTTP proxy with auth, egress policy, and secret-backed credential injection
but no providers, integrations, or MCP. Includes minimal config, multi-tenant
host credentials, and a full-platform example showing provider-token and
secret-backed grants side by side. Also updates the config reference to
document the new `secret_ref` and `auth_style` credential fields.