### PR TITLE
Rename repo-owned HTTP transport terminology to REST

### DIFF
--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -105,7 +105,7 @@ func runServer(env *bootstrapEnv) error {
 
 	var mcpProviders []string
 	mcpPrefixes := make(map[string]string)
-	includeHTTP := make(map[string]bool)
+	includeREST := make(map[string]bool)
 	for name := range env.Config.Integrations {
 		intg := env.Config.Integrations[name]
 		hasMCP := false
@@ -122,7 +122,7 @@ func runServer(env *bootstrapEnv) error {
 		}
 		if hasMCP {
 			mcpProviders = append(mcpProviders, name)
-			includeHTTP[name] = apiMCP
+			includeREST[name] = apiMCP
 			if intg.MCPToolPrefix != "" {
 				mcpPrefixes[name] = intg.MCPToolPrefix
 			}
@@ -217,7 +217,7 @@ func runServer(env *bootstrapEnv) error {
 			Providers:        result.Providers,
 			AllowedProviders: mcpProviders,
 			ToolPrefixes:     mcpPrefixes,
-			IncludeHTTP:      includeHTTP,
+			IncludeREST:      includeREST,
 		}
 		mcpSlot.Set(mcpserver.NewStreamableHTTPServer(
 			gestaltmcp.NewServer(mcpCfg),

--- a/core/catalog/catalog.go
+++ b/core/catalog/catalog.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	TransportMCPPassthrough = "mcp-passthrough"
-	TransportHTTP           = "http"
+	TransportREST           = "rest"
 	TransportPlugin         = "plugin"
 )
 

--- a/internal/bootstrap/executable_plugin_test.go
+++ b/internal/bootstrap/executable_plugin_test.go
@@ -251,7 +251,7 @@ func TestExecutableRuntimeCapabilities_ExposeOnlyInvokableCatalogOperations(t *t
 						Description: "Fetch record",
 						Method:      http.MethodGet,
 						Path:        "/records/{id}",
-						Transport:   catalog.TransportHTTP,
+						Transport:   catalog.TransportREST,
 					},
 					{
 						ID:          "search_workspace",
@@ -331,7 +331,7 @@ func TestExecutableRuntimeCapabilities_FilterMethodlessFallbackOperations(t *tes
 				ConnMode: core.ConnectionModeNone,
 			},
 			ops: []core.Operation{
-				{Name: "http_op", Description: "HTTP op", Method: http.MethodPost},
+				{Name: "rest_op", Description: "REST op", Method: http.MethodPost},
 				{Name: "hidden_op", Description: "Hidden op"},
 			},
 		}, nil
@@ -362,8 +362,8 @@ func TestExecutableRuntimeCapabilities_FilterMethodlessFallbackOperations(t *tes
 	if got.CapabilityCount != 2 {
 		t.Fatalf("runtime output capability_count = %d, want 2", got.CapabilityCount)
 	}
-	if !slices.Equal(got.Capabilities, []string{"alpha.http_op", "alpha.hidden_op"}) {
-		t.Fatalf("runtime output capabilities = %v, want [alpha.http_op alpha.hidden_op]", got.Capabilities)
+	if !slices.Equal(got.Capabilities, []string{"alpha.rest_op", "alpha.hidden_op"}) {
+		t.Fatalf("runtime output capabilities = %v, want [alpha.rest_op alpha.hidden_op]", got.Capabilities)
 	}
 }
 

--- a/internal/composite/provider.go
+++ b/internal/composite/provider.go
@@ -18,7 +18,7 @@ type MCPUpstream interface {
 	Close() error
 }
 
-// Provider wraps an HTTP API provider and an MCP upstream for a single
+// Provider wraps a REST-backed API provider and an MCP upstream for a single
 // integration. Execute goes to the API; CallTool goes to the upstream.
 type Provider struct {
 	name string
@@ -121,7 +121,7 @@ func (p *Provider) buildCatalog() *catalog.Catalog {
 		return tagMCPCatalog(mcpCat)
 	}
 	if mcpCat == nil {
-		return tagHTTPCatalog(apiCat)
+		return tagRESTCatalog(apiCat)
 	}
 
 	merged := &catalog.Catalog{
@@ -137,16 +137,16 @@ func (p *Provider) buildCatalog() *catalog.Catalog {
 	}
 	for i := range apiCat.Operations {
 		op := apiCat.Operations[i]
-		op.Transport = catalog.TransportHTTP
+		op.Transport = catalog.TransportREST
 		merged.Operations = append(merged.Operations, op)
 	}
 	return merged
 }
 
-func tagHTTPCatalog(src *catalog.Catalog) *catalog.Catalog {
+func tagRESTCatalog(src *catalog.Catalog) *catalog.Catalog {
 	out := src.Clone()
 	for i := range out.Operations {
-		out.Operations[i].Transport = catalog.TransportHTTP
+		out.Operations[i].Transport = catalog.TransportREST
 	}
 	return out
 }

--- a/internal/invocation/capabilities.go
+++ b/internal/invocation/capabilities.go
@@ -39,7 +39,7 @@ func capabilitiesFromCatalog(name string, cat *catalog.Catalog) []core.Capabilit
 		method := strings.ToUpper(strings.TrimSpace(op.Method))
 		transport := strings.TrimSpace(op.Transport)
 		if transport == "" && method != "" {
-			transport = catalog.TransportHTTP
+			transport = catalog.TransportREST
 		}
 
 		caps = append(caps, core.Capability{
@@ -72,7 +72,7 @@ func capabilitiesFromOperations(name string, ops []core.Operation) []core.Capabi
 		method := strings.ToUpper(strings.TrimSpace(op.Method))
 		transport := ""
 		if method != "" {
-			transport = catalog.TransportHTTP
+			transport = catalog.TransportREST
 		}
 
 		caps = append(caps, core.Capability{

--- a/internal/mcp/binding.go
+++ b/internal/mcp/binding.go
@@ -39,7 +39,7 @@ type Config struct {
 	Providers        *registry.PluginMap[core.Provider]
 	AllowedProviders []string
 	ToolPrefixes     map[string]string
-	IncludeHTTP      map[string]bool
+	IncludeREST      map[string]bool
 }
 
 func NewServer(cfg Config) *mcpserver.MCPServer {
@@ -252,7 +252,7 @@ func buildToolMap(cfg Config, provName string, prov core.Provider, cat *catalog.
 		if op.Visible != nil && !*op.Visible {
 			continue
 		}
-		if cfg.IncludeHTTP != nil && op.Transport == catalog.TransportHTTP && !cfg.IncludeHTTP[provName] {
+		if cfg.IncludeREST != nil && op.Transport == catalog.TransportREST && !cfg.IncludeREST[provName] {
 			continue
 		}
 
@@ -273,7 +273,7 @@ func buildToolMap(cfg Config, provName string, prov core.Provider, cat *catalog.
 		}
 
 		var handler mcpserver.ToolHandlerFunc
-		if isDirect && op.Transport != catalog.TransportHTTP && op.Transport != catalog.TransportPlugin {
+		if isDirect && op.Transport != catalog.TransportREST && op.Transport != catalog.TransportPlugin {
 			handler = makeDirectHandler(cfg, provName, op.ID, caller)
 		} else {
 			handler = makeHandler(cfg.Invoker, provName, op.ID)

--- a/internal/mcp/binding_test.go
+++ b/internal/mcp/binding_test.go
@@ -1016,12 +1016,12 @@ func TestNewServer_DynamicCatalogProviderCallsSessionTool(t *testing.T) {
 	}
 }
 
-func TestNewServer_IncludeHTTPFiltering(t *testing.T) {
+func TestNewServer_IncludeRESTFiltering(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
 		name        string
-		includeHTTP bool
+		includeREST bool
 		wantCount   int
 	}{
 		{"excluded", false, 1},
@@ -1035,7 +1035,7 @@ func TestNewServer_IncludeHTTPFiltering(t *testing.T) {
 			cat := &catalog.Catalog{
 				Name: "acme",
 				Operations: []catalog.CatalogOperation{
-					{ID: "api_op", Method: "GET", Path: "/api", Transport: catalog.TransportHTTP},
+					{ID: "api_op", Method: "GET", Path: "/api", Transport: catalog.TransportREST},
 					{ID: "mcp_op", Description: "passthrough", Transport: catalog.TransportMCPPassthrough},
 				},
 			}
@@ -1053,7 +1053,7 @@ func TestNewServer_IncludeHTTPFiltering(t *testing.T) {
 			srv := gestaltmcp.NewServer(gestaltmcp.Config{
 				Invoker:     broker,
 				Providers:   providers,
-				IncludeHTTP: map[string]bool{"acme": tc.includeHTTP},
+				IncludeREST: map[string]bool{"acme": tc.includeREST},
 			})
 
 			tools := srv.ListTools()

--- a/internal/mcp/composite_test.go
+++ b/internal/mcp/composite_test.go
@@ -235,7 +235,7 @@ func TestComposite_ExecuteDelegatesToAPI(t *testing.T) {
 	}
 }
 
-func TestComposite_IncludeHTTPFalseExcludesAPITools(t *testing.T) {
+func TestComposite_IncludeRESTFalseExcludesAPITools(t *testing.T) {
 	t.Parallel()
 
 	apiCat := &catalog.Catalog{
@@ -265,7 +265,7 @@ func TestComposite_IncludeHTTPFalseExcludesAPITools(t *testing.T) {
 		Invoker:       &testutil.StubInvoker{},
 		TokenResolver: &stubTokenResolver{token: "t"},
 		Providers:     providers,
-		IncludeHTTP:   map[string]bool{"alpha": false},
+		IncludeREST:   map[string]bool{"alpha": false},
 	})
 
 	tools := srv.ListTools()
@@ -273,7 +273,7 @@ func TestComposite_IncludeHTTPFalseExcludesAPITools(t *testing.T) {
 		t.Fatal("expected alpha_search from MCP upstream")
 	}
 	if tools["alpha_list_items"] != nil {
-		t.Fatal("expected alpha_list_items to be excluded when IncludeHTTP=false")
+		t.Fatal("expected alpha_list_items to be excluded when IncludeREST=false")
 	}
 	if len(tools) != 1 {
 		names := make([]string, 0, len(tools))

--- a/internal/pluginapi/provider_test.go
+++ b/internal/pluginapi/provider_test.go
@@ -72,7 +72,7 @@ func (p *roundTripProvider) Catalog() *catalog.Catalog {
 		DisplayName: "Round Trip",
 		Description: "test provider",
 		Operations: []catalog.CatalogOperation{
-			{ID: "echo", Method: "POST", Path: "/echo", Transport: catalog.TransportHTTP},
+			{ID: "echo", Method: "POST", Path: "/echo", Transport: catalog.TransportREST},
 		},
 	}
 }
@@ -83,7 +83,7 @@ func (p *roundTripProvider) CatalogForRequest(_ context.Context, token string) (
 		DisplayName: token,
 		Description: "session catalog",
 		Operations: []catalog.CatalogOperation{
-			{ID: "echo", Method: "POST", Path: "/echo", Transport: catalog.TransportHTTP},
+			{ID: "echo", Method: "POST", Path: "/echo", Transport: catalog.TransportREST},
 		},
 	}, nil
 }


### PR DESCRIPTION
## Summary
- rename repo-owned REST transport terminology from `HTTP` to `REST`
- update MCP projection config and transport-sensitive fixtures/tests
- preserve literal protocol terminology where the code means real HTTP behavior

## Testing
- go test ./core/catalog ./internal/invocation ./internal/composite
- go test ./internal/mcp ./internal/mcpupstream
- go test ./internal/pluginapi ./internal/bootstrap
- go test ./internal/server -run 'TestExecuteOperation_HTTPAndMCPEquivalent'
- go test ./internal/openapi ./internal/apiexec ./internal/discovery
- go test ./...
