### PR TITLE
Fix docs examples after runtime audit

### DIFF
--- a/docs/pages/contributing.mdx
+++ b/docs/pages/contributing.mdx
@@ -32,6 +32,8 @@ go test ./...
 gestaltd validate --init --config ./gestalt.dev.yaml
 
 cd docs
+npm ci
+npm run typecheck
 npm run build
 ```
 

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -67,6 +67,7 @@ integrations:
     display_name: Swagger Petstore
     description: Public example API
     connection_mode: none
+    base_url: https://petstore3.swagger.io/api/v3
     upstreams:
       - type: rest
         url: https://petstore3.swagger.io/api/v3/openapi.json
@@ -80,6 +81,7 @@ This is the smallest useful production-shaped config:
 - explicit `server`, `auth`, and `datastore`
 - one named integration
 - one REST upstream
+- an explicit integration `base_url` for live requests
 - no per-user credential requirement because `connection_mode: none`
 
 ## 4. Prepare And Validate It

--- a/docs/pages/tasks/add-an-integration.mdx
+++ b/docs/pages/tasks/add-an-integration.mdx
@@ -22,6 +22,7 @@ integrations:
   petstore:
     display_name: Swagger Petstore
     connection_mode: none
+    base_url: https://petstore3.swagger.io/api/v3
     upstreams:
       - type: rest
         url: https://petstore3.swagger.io/api/v3/openapi.json
@@ -30,7 +31,7 @@ integrations:
           getPetById: Fetch a pet by id
 ```
 
-That is enough to build a real provider.
+That is enough to build a real provider and invoke the public API.
 
 ## 3. Add Auth If The Upstream Needs It
 


### PR DESCRIPTION
## Summary
- make the Petstore examples actually invokable by adding an explicit integration `base_url`
- clarify that the minimal integration example supports live invocation, not just provider generation
- fix the contributing docs so the docs build path works from a clean checkout

## Validation
- `cd docs && npm ci`
- `cd docs && npm run typecheck`
- `cd docs && npm run build`
- `go build -o /tmp/gestaltd-doc-audit-fixes ./cmd/gestaltd`
- `/tmp/gestaltd-doc-audit-fixes validate --init --config /tmp/gestaltd-doc-audit-fixes-smoke/gestalt.yaml`
- `/tmp/gestaltd-doc-audit-fixes serve --locked --config /tmp/gestaltd-doc-audit-fixes-smoke/gestalt.yaml`
- `curl http://localhost:8084/api/v1/integrations/petstore/operations -H "X-Dev-User-Email: audit@example.com"`
- `curl "http://localhost:8084/api/v1/petstore/findPetsByStatus?status=available" -H "X-Dev-User-Email: audit@example.com"`