### PR TITLE
Add SDK release script for pluginapi and pluginsdk

### DIFF
--- a/scripts/release-sdk.sh
+++ b/scripts/release-sdk.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+set -eu
+
+REPO_MODULE="github.com/valon-technologies/gestalt"
+API_MODULE="$REPO_MODULE/sdk/pluginapi"
+SDK_MODULE="$REPO_MODULE/sdk/pluginsdk"
+
+usage() {
+    echo "Usage: $0 VERSION [--dry-run]"
+    echo ""
+    echo "Release sdk/pluginapi and sdk/pluginsdk as Go sub-module tags."
+    echo "Main branch is never modified; the pluginsdk release commit"
+    echo "is created in a temporary git worktree."
+    echo ""
+    echo "  VERSION   Semver without leading v (e.g. 0.1.0)"
+    echo "  --dry-run Show commands without executing"
+    exit 1
+}
+
+VERSION=""
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --help|-h) usage ;;
+        *)
+            if [ -z "$VERSION" ]; then
+                VERSION="$arg"
+            else
+                echo "unexpected argument: $arg" >&2
+                usage
+            fi
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    usage
+fi
+
+if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+    echo "error: VERSION must be semver (e.g. 0.1.0 or 0.0.0-alpha.1), got: $VERSION" >&2
+    exit 1
+fi
+
+API_TAG="sdk/pluginapi/v$VERSION"
+SDK_TAG="sdk/pluginsdk/v$VERSION"
+
+run() {
+    echo "+ $*"
+    if [ "$DRY_RUN" = false ]; then
+        "$@"
+    fi
+}
+
+ORIG_DIR="$(pwd)"
+
+if [ "$DRY_RUN" = false ] && [ -n "$(git status --porcelain)" ]; then
+    echo "error: working tree is not clean" >&2
+    exit 1
+fi
+
+echo "=== Step 1: Tag pluginapi ==="
+run git tag "$API_TAG"
+run git push origin "$API_TAG"
+
+echo ""
+echo "=== Step 2: Create worktree for pluginsdk release ==="
+WORK=$(mktemp -u -d)
+BRANCH="release-sdk-v$VERSION"
+run git worktree add "$WORK" -b "$BRANCH" HEAD
+
+echo ""
+echo "=== Step 3: Pin pluginsdk to released pluginapi ==="
+if [ "$DRY_RUN" = false ]; then
+    cd "$WORK/sdk/pluginsdk"
+    go mod edit -dropreplace="$API_MODULE"
+    go mod edit -require="$API_MODULE@v$VERSION"
+    go mod tidy
+    cd "$WORK"
+    git add sdk/pluginsdk/go.mod sdk/pluginsdk/go.sum
+    git commit -m "sdk/pluginsdk: pin pluginapi v$VERSION for release"
+else
+    echo "+ cd $WORK/sdk/pluginsdk"
+    echo "+ go mod edit -dropreplace=$API_MODULE"
+    echo "+ go mod edit -require=$API_MODULE@v$VERSION"
+    echo "+ go mod tidy"
+    echo "+ git add sdk/pluginsdk/go.mod sdk/pluginsdk/go.sum"
+    echo "+ git commit -m 'sdk/pluginsdk: pin pluginapi v$VERSION for release'"
+fi
+
+echo ""
+echo "=== Step 4: Tag and push pluginsdk ==="
+run git -C "$WORK" tag "$SDK_TAG"
+run git push origin "$SDK_TAG"
+
+echo ""
+echo "=== Step 5: Cleanup worktree ==="
+run git worktree remove "$WORK"
+run git branch -D "$BRANCH"
+
+echo ""
+echo "=== Done ==="
+echo ""
+echo "Tags pushed:"
+echo "  $API_TAG"
+echo "  $SDK_TAG"
+echo ""
+echo "Warm the proxy cache:"
+echo "  GOPROXY=proxy.golang.org go list -m $API_MODULE@v$VERSION"
+echo "  GOPROXY=proxy.golang.org go list -m $SDK_MODULE@v$VERSION"

--- a/sdk/pluginapi/README.md
+++ b/sdk/pluginapi/README.md
@@ -40,20 +40,16 @@ sdk/pluginapi/v0.1.0
 sdk/pluginsdk/v0.1.0
 ```
 
-When cutting a release:
+When cutting a release, use the automated script:
 
-1. Tag the pluginapi module first since pluginsdk depends on it:
-   ```sh
-   git tag sdk/pluginapi/v0.X.Y
-   git push origin sdk/pluginapi/v0.X.Y
-   ```
-2. Update the `pluginsdk/go.mod` require for pluginapi to the new tag, then tag:
-   ```sh
-   git tag sdk/pluginsdk/v0.X.Y
-   git push origin sdk/pluginsdk/v0.X.Y
-   ```
-3. Run `GOPROXY=proxy.golang.org go list -m` for both modules to warm the proxy
-   cache.
+```sh
+./scripts/release-sdk.sh 0.1.0        # release both modules
+./scripts/release-sdk.sh 0.1.0 --dry-run  # preview without executing
+```
+
+The script tags `pluginapi` first, creates a temporary git worktree to pin
+`pluginsdk` to the released `pluginapi` version, tags `pluginsdk`, pushes
+both tags, and cleans up. Main branch is never modified.
 
 The root module and example modules use `replace` directives to point at the
 local source tree, so they always build against HEAD regardless of published


### PR DESCRIPTION
External plugin authors cannot consume the SDK via normal `go get`
because no module tags have been published. This adds a release script
that tags both `sdk/pluginapi` and `sdk/pluginsdk` as Go sub-modules.
The script uses a temporary git worktree to create the pluginsdk
release commit (pinning pluginapi to the released version) so main
keeps its local replace directives permanently. A `--dry-run` flag
previews all commands without executing.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>