### PR TITLE
Refactor HTTP host routes into explicit contract groups

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -1,0 +1,52 @@
+package server
+
+import "github.com/go-chi/chi/v5"
+
+func (s *Server) routes() {
+	r := s.router
+	r.Use(maxBodyMiddleware(1 << 20)) // 1 MB
+
+	if s.devMode {
+		r.Use(devCORS)
+	}
+
+	s.mountCoreRoutes(r)
+	s.mountMCPRoutes(r)
+	s.mountDevRoutes(r)
+	s.mountAPIRoutes(r)
+
+	if s.webUI != nil {
+		r.NotFound(s.webUI.ServeHTTP)
+	}
+}
+
+func (s *Server) mountCoreRoutes(r chi.Router) {
+	r.Get("/health", s.healthCheck)
+	r.Get("/ready", s.readinessCheck)
+}
+
+func (s *Server) mountMCPRoutes(r chi.Router) {
+	if s.mcpHandler == nil {
+		return
+	}
+	r.Group(func(r chi.Router) {
+		r.Use(s.authMiddleware)
+		r.Handle("/mcp", s.mcpHandler)
+	})
+}
+
+func (s *Server) mountDevRoutes(r chi.Router) {
+	if !s.devMode {
+		return
+	}
+	r.Post("/api/dev-login", s.devLogin)
+}
+
+func (s *Server) mountAPIRoutes(r chi.Router) {
+	r.Route("/api/v1", func(r chi.Router) {
+		s.mountAuthRoutes(r)
+		s.mountBindingRoutes(r)
+		s.mountAdminRoutes(r)
+		s.mountAuthenticatedRoutes(r)
+	})
+}

--- a/internal/server/routes_admin.go
+++ b/internal/server/routes_admin.go
@@ -1,0 +1,18 @@
+package server
+
+import "github.com/go-chi/chi/v5"
+
+func (s *Server) mountAdminRoutes(r chi.Router) {
+	r.Group(func(r chi.Router) {
+		r.Use(s.authMiddleware)
+		r.Use(s.adminMiddleware)
+
+		r.Post("/egress/deny-rules", s.createEgressDenyRule)
+		r.Get("/egress/deny-rules", s.listEgressDenyRules)
+		r.Delete("/egress/deny-rules/{id}", s.deleteEgressDenyRule)
+
+		r.Post("/egress/credential-grants", s.createEgressCredentialGrant)
+		r.Get("/egress/credential-grants", s.listEgressCredentialGrants)
+		r.Delete("/egress/credential-grants/{id}", s.deleteEgressCredentialGrant)
+	})
+}

--- a/internal/server/routes_auth.go
+++ b/internal/server/routes_auth.go
@@ -1,0 +1,11 @@
+package server
+
+import "github.com/go-chi/chi/v5"
+
+func (s *Server) mountAuthRoutes(r chi.Router) {
+	r.Get("/auth/info", s.authInfo)
+	r.Post("/auth/login", s.startLogin)
+	r.Get("/auth/login/callback", s.loginCallback)
+	r.Post("/auth/logout", s.logout)
+	r.Get("/auth/callback", s.integrationOAuthCallback)
+}

--- a/internal/server/routes_bindings.go
+++ b/internal/server/routes_bindings.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"log"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func (s *Server) mountBindingRoutes(r chi.Router) {
+	if s.bindings == nil {
+		return
+	}
+	for _, name := range s.bindings.List() {
+		binding, err := s.bindings.Get(name)
+		if err != nil {
+			log.Printf("warning: skipping binding %q routes: %v", name, err)
+			continue
+		}
+		for _, route := range binding.Routes() {
+			handler := route.Handler
+			if !route.Public {
+				if route.ProxyAuth {
+					handler = s.proxyAuthMiddleware(handler)
+				} else {
+					handler = s.authMiddleware(handler)
+				}
+			}
+			if route.Connect {
+				if s.connectHandler != nil {
+					log.Printf("warning: binding %q registers CONNECT but another binding already claimed it; skipping", name)
+					continue
+				}
+				s.connectHandler = handler
+				continue
+			}
+			r.Method(route.Method, "/bindings/"+name+route.Pattern, handler)
+		}
+	}
+}

--- a/internal/server/routes_user.go
+++ b/internal/server/routes_user.go
@@ -1,0 +1,36 @@
+package server
+
+import "github.com/go-chi/chi/v5"
+
+func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
+	r.Group(func(r chi.Router) {
+		r.Use(s.authMiddleware)
+
+		r.Get("/integrations", s.listIntegrations)
+		r.Delete("/integrations/{name}", s.disconnectIntegration)
+		r.Get("/integrations/{name}/operations", s.listOperations)
+		r.Get("/runtimes", s.listRuntimes)
+		r.Get("/bindings", s.listBindings)
+
+		r.Get("/{integration}/{operation}", s.executeOperation)
+		r.Post("/{integration}/{operation}", s.executeOperation)
+
+		r.Post("/auth/start-oauth", s.startIntegrationOAuth)
+		r.Post("/auth/connect-manual", s.connectManual)
+
+		r.Get("/connections/staged/{id}", s.getStagedConnection)
+		r.Post("/connections/staged/{id}/select", s.selectStagedConnection)
+		r.Delete("/connections/staged/{id}", s.cancelStagedConnection)
+
+		r.Post("/tokens", s.createAPIToken)
+		r.Get("/tokens", s.listAPITokens)
+		r.Delete("/tokens/{id}", s.revokeAPIToken)
+
+		r.Post("/egress-clients", s.createEgressClient)
+		r.Get("/egress-clients", s.listEgressClients)
+		r.Delete("/egress-clients/{id}", s.deleteEgressClient)
+		r.Post("/egress-clients/{id}/tokens", s.createEgressClientToken)
+		r.Get("/egress-clients/{id}/tokens", s.listEgressClientTokens)
+		r.Delete("/egress-clients/{id}/tokens/{tokenID}", s.revokeEgressClientToken)
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -98,85 +97,6 @@ func New(cfg Config) (*Server, error) {
 	return s, nil
 }
 
-func (s *Server) routes() {
-	r := s.router
-	r.Use(maxBodyMiddleware(1 << 20)) // 1 MB
-
-	if s.devMode {
-		r.Use(devCORS)
-	}
-
-	r.Get("/health", s.healthCheck)
-	r.Get("/ready", s.readinessCheck)
-
-	if s.mcpHandler != nil {
-		r.Group(func(r chi.Router) {
-			r.Use(s.authMiddleware)
-			r.Handle("/mcp", s.mcpHandler)
-		})
-	}
-
-	if s.devMode {
-		r.Post("/api/dev-login", s.devLogin)
-	}
-
-	r.Route("/api/v1", func(r chi.Router) {
-		r.Get("/auth/info", s.authInfo)
-		r.Post("/auth/login", s.startLogin)
-		r.Get("/auth/login/callback", s.loginCallback)
-		r.Post("/auth/logout", s.logout)
-		r.Get("/auth/callback", s.integrationOAuthCallback)
-
-		s.mountBindingRoutes(r)
-
-		r.Group(func(r chi.Router) {
-			r.Use(s.authMiddleware)
-			r.Use(s.adminMiddleware)
-			r.Post("/egress/deny-rules", s.createEgressDenyRule)
-			r.Get("/egress/deny-rules", s.listEgressDenyRules)
-			r.Delete("/egress/deny-rules/{id}", s.deleteEgressDenyRule)
-			r.Post("/egress/credential-grants", s.createEgressCredentialGrant)
-			r.Get("/egress/credential-grants", s.listEgressCredentialGrants)
-			r.Delete("/egress/credential-grants/{id}", s.deleteEgressCredentialGrant)
-		})
-
-		r.Group(func(r chi.Router) {
-			r.Use(s.authMiddleware)
-
-			r.Get("/integrations", s.listIntegrations)
-			r.Delete("/integrations/{name}", s.disconnectIntegration)
-			r.Get("/integrations/{name}/operations", s.listOperations)
-			r.Get("/runtimes", s.listRuntimes)
-			r.Get("/bindings", s.listBindings)
-
-			r.Get("/{integration}/{operation}", s.executeOperation)
-			r.Post("/{integration}/{operation}", s.executeOperation)
-
-			r.Post("/auth/start-oauth", s.startIntegrationOAuth)
-			r.Post("/auth/connect-manual", s.connectManual)
-
-			r.Get("/connections/staged/{id}", s.getStagedConnection)
-			r.Post("/connections/staged/{id}/select", s.selectStagedConnection)
-			r.Delete("/connections/staged/{id}", s.cancelStagedConnection)
-
-			r.Post("/tokens", s.createAPIToken)
-			r.Get("/tokens", s.listAPITokens)
-			r.Delete("/tokens/{id}", s.revokeAPIToken)
-
-			r.Post("/egress-clients", s.createEgressClient)
-			r.Get("/egress-clients", s.listEgressClients)
-			r.Delete("/egress-clients/{id}", s.deleteEgressClient)
-			r.Post("/egress-clients/{id}/tokens", s.createEgressClientToken)
-			r.Get("/egress-clients/{id}/tokens", s.listEgressClientTokens)
-			r.Delete("/egress-clients/{id}/tokens/{tokenID}", s.revokeEgressClientToken)
-		})
-	})
-
-	if s.webUI != nil {
-		r.NotFound(s.webUI.ServeHTTP)
-	}
-}
-
 func resolverOpts(ds core.Datastore) []principal.ResolverOption {
 	var opts []principal.ResolverOption
 	if ecs, ok := ds.(core.EgressClientStore); ok {
@@ -191,38 +111,6 @@ func (s *Server) stagedConnectionStore() (core.StagedConnectionStore, error) {
 		return nil, fmt.Errorf("datastore does not support staged connections; use a SQL-backed datastore (sqlite, postgres, mysql)")
 	}
 	return scs, nil
-}
-
-func (s *Server) mountBindingRoutes(r chi.Router) {
-	if s.bindings == nil {
-		return
-	}
-	for _, name := range s.bindings.List() {
-		binding, err := s.bindings.Get(name)
-		if err != nil {
-			log.Printf("warning: skipping binding %q routes: %v", name, err)
-			continue
-		}
-		for _, route := range binding.Routes() {
-			handler := route.Handler
-			if !route.Public {
-				if route.ProxyAuth {
-					handler = s.proxyAuthMiddleware(handler)
-				} else {
-					handler = s.authMiddleware(handler)
-				}
-			}
-			if route.Connect {
-				if s.connectHandler != nil {
-					log.Printf("warning: binding %q registers CONNECT but another binding already claimed it; skipping", name)
-					continue
-				}
-				s.connectHandler = handler
-				continue
-			}
-			r.Method(route.Method, "/bindings/"+name+route.Pattern, handler)
-		}
-	}
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- split the `/api/v1` host surface into explicit route groups inside `internal/server`
- keep HTTP terminology and behavior for the real host protocol surface
- leave server behavior inside `internal/server` rather than pushing it into bootstrap

## Testing
- go test ./internal/server
- go test ./internal/server -run 'Test(Health|Readiness|AuthMiddleware|.*Integrations.*|.*Tokens.*|.*Bindings.*)'
