### PR TITLE
Strengthen plugin boundary tests with shared harnesses

### DIFF
--- a/internal/pluginapi/grpc_test.go
+++ b/internal/pluginapi/grpc_test.go
@@ -1,0 +1,66 @@
+package pluginapi
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+func newProviderPluginClient(t *testing.T, server pluginapiv1.ProviderPluginServer) pluginapiv1.ProviderPluginClient {
+	t.Helper()
+
+	conn := newBufconnConn(t, func(srv *grpc.Server) {
+		pluginapiv1.RegisterProviderPluginServer(srv, server)
+	})
+	return pluginapiv1.NewProviderPluginClient(conn)
+}
+
+func newRuntimePluginClient(t *testing.T, server pluginapiv1.RuntimePluginServer) pluginapiv1.RuntimePluginClient {
+	t.Helper()
+
+	conn := newBufconnConn(t, func(srv *grpc.Server) {
+		pluginapiv1.RegisterRuntimePluginServer(srv, server)
+	})
+	return pluginapiv1.NewRuntimePluginClient(conn)
+}
+
+func newRuntimeHostClient(t *testing.T, server pluginapiv1.RuntimeHostServer) pluginapiv1.RuntimeHostClient {
+	t.Helper()
+
+	conn := newBufconnConn(t, func(srv *grpc.Server) {
+		pluginapiv1.RegisterRuntimeHostServer(srv, server)
+	})
+	return pluginapiv1.NewRuntimeHostClient(conn)
+}
+
+func newBufconnConn(t *testing.T, register func(*grpc.Server)) *grpc.ClientConn {
+	t.Helper()
+
+	lis := bufconn.Listen(1024 * 1024)
+	srv := grpc.NewServer()
+	register(srv)
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	t.Cleanup(func() {
+		srv.Stop()
+		_ = lis.Close()
+	})
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return lis.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}

--- a/internal/pluginapi/provider_test.go
+++ b/internal/pluginapi/provider_test.go
@@ -3,15 +3,10 @@ package pluginapi
 import (
 	"context"
 	"fmt"
-	"net"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
-	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/test/bufconn"
 )
 
 type roundTripProvider struct{}
@@ -102,7 +97,7 @@ func (p *roundTripProvider) AuthTypes() []string {
 func TestRemoteProviderRoundTrip(t *testing.T) {
 	t.Parallel()
 
-	client := newProviderTestClient(t, &roundTripProvider{})
+	client := newProviderPluginClient(t, NewProviderServer(&roundTripProvider{}))
 	prov, err := NewRemoteProvider(context.Background(), client, "roundtrip", nil, "")
 	if err != nil {
 		t.Fatalf("NewRemoteProvider: %v", err)
@@ -177,31 +172,4 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 		t.Fatalf("unexpected connection param defs: %+v", defs)
 	}
 
-}
-
-func newProviderTestClient(t *testing.T, prov core.Provider) pluginapiv1.ProviderPluginClient {
-	t.Helper()
-
-	lis := bufconn.Listen(1024 * 1024)
-	srv := grpc.NewServer()
-	pluginapiv1.RegisterProviderPluginServer(srv, NewProviderServer(prov))
-	go func() {
-		_ = srv.Serve(lis)
-	}()
-	t.Cleanup(func() {
-		srv.Stop()
-		_ = lis.Close()
-	})
-
-	conn, err := grpc.NewClient("passthrough:///bufnet",
-		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
-			return lis.Dial()
-		}),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-	if err != nil {
-		t.Fatalf("grpc.NewClient: %v", err)
-	}
-	t.Cleanup(func() { _ = conn.Close() })
-	return pluginapiv1.NewProviderPluginClient(conn)
 }

--- a/internal/pluginapi/runtime_test.go
+++ b/internal/pluginapi/runtime_test.go
@@ -2,16 +2,12 @@ package pluginapi
 
 import (
 	"context"
-	"net"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/principal"
 	"github.com/valon-technologies/gestalt/internal/testutil"
 	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -37,7 +33,7 @@ func TestRemoteRuntimeRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	stub := &stubRuntimePluginServer{}
-	client := newRuntimeTestClient(t, stub)
+	client := newRuntimePluginClient(t, stub)
 
 	rt, err := NewRemoteRuntime("echo", client, map[string]any{"enabled": true}, []core.Capability{
 		{Provider: "alpha", Operation: "read"},
@@ -117,57 +113,3 @@ type stubCapabilityLister struct {
 }
 
 func (s *stubCapabilityLister) ListCapabilities() []core.Capability { return s.caps }
-
-func newRuntimeTestClient(t *testing.T, server pluginapiv1.RuntimePluginServer) pluginapiv1.RuntimePluginClient {
-	t.Helper()
-
-	lis := bufconn.Listen(1024 * 1024)
-	srv := grpc.NewServer()
-	pluginapiv1.RegisterRuntimePluginServer(srv, server)
-	go func() {
-		_ = srv.Serve(lis)
-	}()
-	t.Cleanup(func() {
-		srv.Stop()
-		_ = lis.Close()
-	})
-
-	conn, err := grpc.NewClient("passthrough:///bufnet",
-		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
-			return lis.Dial()
-		}),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-	if err != nil {
-		t.Fatalf("grpc.NewClient: %v", err)
-	}
-	t.Cleanup(func() { _ = conn.Close() })
-	return pluginapiv1.NewRuntimePluginClient(conn)
-}
-
-func newRuntimeHostClient(t *testing.T, host pluginapiv1.RuntimeHostServer) pluginapiv1.RuntimeHostClient {
-	t.Helper()
-
-	lis := bufconn.Listen(1024 * 1024)
-	srv := grpc.NewServer()
-	pluginapiv1.RegisterRuntimeHostServer(srv, host)
-	go func() {
-		_ = srv.Serve(lis)
-	}()
-	t.Cleanup(func() {
-		srv.Stop()
-		_ = lis.Close()
-	})
-
-	conn, err := grpc.NewClient("passthrough:///bufnet",
-		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
-			return lis.Dial()
-		}),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-	if err != nil {
-		t.Fatalf("grpc.NewClient: %v", err)
-	}
-	t.Cleanup(func() { _ = conn.Close() })
-	return pluginapiv1.NewRuntimeHostClient(conn)
-}

--- a/internal/pluginapi/validate_test.go
+++ b/internal/pluginapi/validate_test.go
@@ -2,14 +2,10 @@ package pluginapi
 
 import (
 	"context"
-	"net"
 	"strings"
 	"testing"
 
 	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -91,7 +87,7 @@ func TestNewRemoteProvider_NoSchema(t *testing.T) {
 			DisplayName: "Test Plugin",
 		},
 	}
-	client := newStubProviderClient(t, stub)
+	client := newProviderPluginClient(t, stub)
 	prov, err := NewRemoteProvider(context.Background(), client, "test-plugin", map[string]any{"anything": "goes"}, "")
 	if err != nil {
 		t.Fatalf("expected no error without schema: %v", err)
@@ -111,7 +107,7 @@ func TestNewRemoteProvider_SchemaRejectsInvalidConfig(t *testing.T) {
 			ConfigSchemaJson: testConfigSchema,
 		},
 	}
-	client := newStubProviderClient(t, stub)
+	client := newProviderPluginClient(t, stub)
 	_, err := NewRemoteProvider(context.Background(), client, "test-plugin", map[string]any{"retries": 3}, "")
 	if err == nil {
 		t.Fatal("expected error for config missing required field")
@@ -131,7 +127,7 @@ func TestNewRemoteProvider_SchemaAcceptsValidConfig(t *testing.T) {
 			ConfigSchemaJson: testConfigSchema,
 		},
 	}
-	client := newStubProviderClient(t, stub)
+	client := newProviderPluginClient(t, stub)
 	prov, err := NewRemoteProvider(context.Background(), client, "test-plugin", map[string]any{"api_key": "sk-test"}, "")
 	if err != nil {
 		t.Fatalf("expected valid config to pass: %v", err)
@@ -151,34 +147,9 @@ func TestNewRemoteProvider_SchemaRejectsNilConfig(t *testing.T) {
 			ConfigSchemaJson: testConfigSchema,
 		},
 	}
-	client := newStubProviderClient(t, stub)
+	client := newProviderPluginClient(t, stub)
 	_, err := NewRemoteProvider(context.Background(), client, "test-plugin", nil, "")
 	if err == nil {
 		t.Fatal("expected nil config to fail validation against schema with required fields")
 	}
-}
-
-func newStubProviderClient(t *testing.T, stub pluginapiv1.ProviderPluginServer) pluginapiv1.ProviderPluginClient {
-	t.Helper()
-
-	lis := bufconn.Listen(1024 * 1024)
-	srv := grpc.NewServer()
-	pluginapiv1.RegisterProviderPluginServer(srv, stub)
-	go func() { _ = srv.Serve(lis) }()
-	t.Cleanup(func() {
-		srv.Stop()
-		_ = lis.Close()
-	})
-
-	conn, err := grpc.NewClient("passthrough:///bufnet",
-		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
-			return lis.Dial()
-		}),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-	if err != nil {
-		t.Fatalf("grpc.NewClient: %v", err)
-	}
-	t.Cleanup(func() { _ = conn.Close() })
-	return pluginapiv1.NewProviderPluginClient(conn)
 }

--- a/internal/pluginpkg/archive_boundary_test.go
+++ b/internal/pluginpkg/archive_boundary_test.go
@@ -41,6 +41,8 @@ func TestLoadManifestFromPath_DirectoryManifestFileAndArchive(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			data, parsed, gotPath, err := LoadManifestFromPath(tc.input)
 			if err != nil {
 				t.Fatalf("LoadManifestFromPath(%q): %v", tc.input, err)

--- a/internal/pluginpkg/archive_boundary_test.go
+++ b/internal/pluginpkg/archive_boundary_test.go
@@ -1,0 +1,111 @@
+package pluginpkg
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadManifestFromPath_DirectoryManifestFileAndArchive(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sourceDir, manifest := mustWriteProviderPackageDir(t, dir, "acme/provider", "0.1.0", "provider")
+	archivePath := filepath.Join(dir, "acme-provider-0.1.0.tar.gz")
+	if err := CreatePackageFromDir(sourceDir, archivePath); err != nil {
+		t.Fatalf("CreatePackageFromDir: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		wantPath string
+	}{
+		{
+			name:     "directory",
+			input:    sourceDir,
+			wantPath: filepath.Join(sourceDir, ManifestFile),
+		},
+		{
+			name:     "manifest file",
+			input:    filepath.Join(sourceDir, ManifestFile),
+			wantPath: filepath.Join(sourceDir, ManifestFile),
+		},
+		{
+			name:     "archive",
+			input:    archivePath,
+			wantPath: archivePath,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			data, parsed, gotPath, err := LoadManifestFromPath(tc.input)
+			if err != nil {
+				t.Fatalf("LoadManifestFromPath(%q): %v", tc.input, err)
+			}
+			if len(data) == 0 {
+				t.Fatal("expected manifest bytes")
+			}
+			if gotPath != tc.wantPath {
+				t.Fatalf("path = %q, want %q", gotPath, tc.wantPath)
+			}
+			if !ManifestEqual(parsed, manifest) {
+				t.Fatalf("unexpected manifest: %+v", parsed)
+			}
+		})
+	}
+}
+
+func TestValidatePackageDirRejectsMissingProviderSchema(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sourceDir, manifest := mustWriteProviderPackageDir(t, dir, "acme/provider", "0.1.0", "provider")
+	manifest.Provider.ConfigSchemaPath = "schemas/config.schema.json"
+	mustWriteManifest(t, sourceDir, manifest)
+
+	_, err := ValidatePackageDir(sourceDir)
+	if err == nil {
+		t.Fatal("expected missing provider schema error")
+	}
+	if !strings.Contains(err.Error(), "validate provider config schema") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestReadArchiveEntryRejectsDuplicateEntry(t *testing.T) {
+	t.Parallel()
+
+	archivePath := filepath.Join(t.TempDir(), "duplicate-entry.tar.gz")
+	mustCreateArchive(t, archivePath,
+		archiveTestFile{name: "dup.txt", data: []byte("first"), mode: 0644},
+		archiveTestFile{name: "dup.txt", data: []byte("second"), mode: 0644},
+	)
+
+	_, err := ReadArchiveEntry(archivePath, "dup.txt")
+	if err == nil {
+		t.Fatal("expected duplicate archive entry error")
+	}
+	if !strings.Contains(err.Error(), "appears more than once") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestExtractPackageRejectsEscapingEntry(t *testing.T) {
+	t.Parallel()
+
+	archivePath := filepath.Join(t.TempDir(), "escaping-entry.tar.gz")
+	mustCreateArchive(t, archivePath,
+		archiveTestFile{name: "../evil", data: []byte("oops"), mode: 0644},
+	)
+
+	err := ExtractPackage(archivePath, filepath.Join(t.TempDir(), "out"))
+	if err == nil {
+		t.Fatal("expected escaping archive entry error")
+	}
+	if !strings.Contains(err.Error(), "escapes the package root") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/pluginpkg/manifest_test.go
+++ b/internal/pluginpkg/manifest_test.go
@@ -1,8 +1,6 @@
 package pluginpkg
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"testing"
 
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
@@ -114,9 +112,4 @@ func TestEncodeManifest_RoundTrip(t *testing.T) {
 	if !ManifestEqual(manifest, got) {
 		t.Fatal("manifest changed across round trip")
 	}
-}
-
-func sha256Hex(value string) string {
-	sum := sha256.Sum256([]byte(value))
-	return hex.EncodeToString(sum[:])
 }

--- a/internal/pluginpkg/test_helpers_test.go
+++ b/internal/pluginpkg/test_helpers_test.go
@@ -1,0 +1,124 @@
+package pluginpkg
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
+)
+
+type archiveTestFile struct {
+	name string
+	data []byte
+	mode int64
+}
+
+func sha256Hex(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+func currentArtifactPath(binary string) string {
+	return filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, binary))
+}
+
+func newProviderManifest(id, version, artifactPath, digest string) *pluginmanifestv1.Manifest {
+	return &pluginmanifestv1.Manifest{
+		SchemaVersion: pluginmanifestv1.SchemaVersion,
+		ID:            id,
+		Version:       version,
+		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				Path:   artifactPath,
+				SHA256: digest,
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{ArtifactPath: artifactPath},
+		},
+	}
+}
+
+func mustWriteFile(t *testing.T, path string, data []byte, mode os.FileMode) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, data, mode); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+}
+
+func mustWriteManifest(t *testing.T, dir string, manifest *pluginmanifestv1.Manifest) []byte {
+	t.Helper()
+
+	data, err := EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	mustWriteFile(t, filepath.Join(dir, ManifestFile), data, 0644)
+	return data
+}
+
+func mustCreateArchive(t *testing.T, archivePath string, files ...archiveTestFile) {
+	t.Helper()
+
+	out, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("Create(%q): %v", archivePath, err)
+	}
+	defer func() {
+		if err := out.Close(); err != nil {
+			t.Fatalf("close archive: %v", err)
+		}
+	}()
+
+	gzw := gzip.NewWriter(out)
+	defer func() {
+		if err := gzw.Close(); err != nil {
+			t.Fatalf("close gzip: %v", err)
+		}
+	}()
+
+	tw := tar.NewWriter(gzw)
+	defer func() {
+		if err := tw.Close(); err != nil {
+			t.Fatalf("close tar: %v", err)
+		}
+	}()
+
+	for _, file := range files {
+		hdr := &tar.Header{Name: file.name, Mode: file.mode, Size: int64(len(file.data))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("WriteHeader(%q): %v", file.name, err)
+		}
+		if _, err := tw.Write(file.data); err != nil {
+			t.Fatalf("Write(%q): %v", file.name, err)
+		}
+	}
+}
+
+func mustWriteProviderPackageDir(t *testing.T, root, id, version, content string) (string, *pluginmanifestv1.Manifest) {
+	t.Helper()
+
+	sourceDir := filepath.Join(root, "src")
+	artifactPath := currentArtifactPath("provider")
+	mustWriteFile(t, filepath.Join(sourceDir, filepath.FromSlash(artifactPath)), []byte(content), 0755)
+
+	manifest := newProviderManifest(id, version, artifactPath, sha256Hex(content))
+	mustWriteManifest(t, sourceDir, manifest)
+	return sourceDir, manifest
+}

--- a/sdk/pluginsdk/plugin_test.go
+++ b/sdk/pluginsdk/plugin_test.go
@@ -2,15 +2,11 @@ package pluginsdk_test
 
 import (
 	"context"
-	"net"
 	"testing"
 
 	pluginsdk "github.com/valon-technologies/gestalt/sdk/pluginsdk"
 
 	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -57,30 +53,6 @@ type schemaStubProvider struct {
 
 func (p *schemaStubProvider) ConfigSchemaJSON() string { return p.schema }
 
-func newTestProviderClient(t *testing.T, prov pluginsdk.Provider) pluginapiv1.ProviderPluginClient {
-	t.Helper()
-	lis := bufconn.Listen(1024 * 1024)
-	srv := grpc.NewServer()
-	pluginapiv1.RegisterProviderPluginServer(srv, pluginsdk.NewProviderServer(prov))
-
-	go func() { _ = srv.Serve(lis) }()
-	t.Cleanup(srv.Stop)
-
-	conn, err := grpc.NewClient(
-		"passthrough:///bufconn",
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-			return lis.DialContext(ctx)
-		}),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = conn.Close() })
-
-	return pluginapiv1.NewProviderPluginClient(conn)
-}
-
 func TestProviderServerGetMetadata(t *testing.T) {
 	t.Parallel()
 
@@ -90,7 +62,7 @@ func TestProviderServerGetMetadata(t *testing.T) {
 		description: "A test provider for SDK validation",
 	}
 
-	client := newTestProviderClient(t, prov)
+	client := newProviderPluginClient(t, prov)
 	ctx := context.Background()
 
 	meta, err := client.GetMetadata(ctx, &emptypb.Empty{})
@@ -134,7 +106,7 @@ func TestProviderServerListOperations(t *testing.T) {
 		},
 	}
 
-	client := newTestProviderClient(t, prov)
+	client := newProviderPluginClient(t, prov)
 	ctx := context.Background()
 
 	resp, err := client.ListOperations(ctx, &emptypb.Empty{})
@@ -169,7 +141,7 @@ func TestProviderServerExecute(t *testing.T) {
 		connMode: pluginsdk.ConnectionModeNone,
 	}
 
-	client := newTestProviderClient(t, prov)
+	client := newProviderPluginClient(t, prov)
 	ctx := context.Background()
 
 	params, _ := structpb.NewStruct(map[string]any{"key": "value"})
@@ -199,7 +171,7 @@ func TestProviderServerStartProvider(t *testing.T) {
 		},
 	}
 
-	client := newTestProviderClient(t, prov)
+	client := newProviderPluginClient(t, prov)
 	ctx := context.Background()
 
 	cfg, _ := structpb.NewStruct(map[string]any{"key": "val"})
@@ -234,7 +206,7 @@ func TestProviderServerStartProviderNoOp(t *testing.T) {
 		connMode: pluginsdk.ConnectionModeNone,
 	}
 
-	client := newTestProviderClient(t, prov)
+	client := newProviderPluginClient(t, prov)
 	ctx := context.Background()
 
 	resp, err := client.StartProvider(ctx, &pluginapiv1.StartProviderRequest{
@@ -260,7 +232,7 @@ func TestProviderServerConfigSchema(t *testing.T) {
 		schema: `{"type":"object"}`,
 	}
 
-	client := newTestProviderClient(t, prov)
+	client := newProviderPluginClient(t, prov)
 	ctx := context.Background()
 
 	meta, err := client.GetMetadata(ctx, &emptypb.Empty{})
@@ -280,7 +252,7 @@ func TestProviderServerMetadataProtocolVersions(t *testing.T) {
 		connMode: pluginsdk.ConnectionModeNone,
 	}
 
-	client := newTestProviderClient(t, prov)
+	client := newProviderPluginClient(t, prov)
 	ctx := context.Background()
 
 	meta, err := client.GetMetadata(ctx, &emptypb.Empty{})
@@ -303,7 +275,7 @@ func TestProviderServerUnimplementedRPCs(t *testing.T) {
 		connMode: pluginsdk.ConnectionModeNone,
 	}
 
-	client := newTestProviderClient(t, prov)
+	client := newProviderPluginClient(t, prov)
 	ctx := context.Background()
 
 	_, err := client.AuthorizationURL(ctx, &pluginapiv1.AuthorizationURLRequest{State: "s"})

--- a/sdk/pluginsdk/plugin_transport_test.go
+++ b/sdk/pluginsdk/plugin_transport_test.go
@@ -1,0 +1,142 @@
+package pluginsdk_test
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
+	pluginsdk "github.com/valon-technologies/gestalt/sdk/pluginsdk"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type stubRuntimePlugin struct {
+	pluginapiv1.UnimplementedRuntimePluginServer
+	started int
+	stopped int
+	lastReq *pluginapiv1.StartRuntimeRequest
+}
+
+func (s *stubRuntimePlugin) Start(_ context.Context, req *pluginapiv1.StartRuntimeRequest) (*emptypb.Empty, error) {
+	s.started++
+	s.lastReq = req
+	return &emptypb.Empty{}, nil
+}
+
+func (s *stubRuntimePlugin) Stop(context.Context, *emptypb.Empty) (*emptypb.Empty, error) {
+	s.stopped++
+	return &emptypb.Empty{}, nil
+}
+
+type stubRuntimeHost struct {
+	pluginapiv1.UnimplementedRuntimeHostServer
+}
+
+func (s *stubRuntimeHost) ListCapabilities(context.Context, *emptypb.Empty) (*pluginapiv1.ListCapabilitiesResponse, error) {
+	return &pluginapiv1.ListCapabilitiesResponse{
+		Capabilities: []*pluginapiv1.Capability{
+			{Provider: "alpha", Operation: "read"},
+		},
+	}, nil
+}
+
+func TestServeProviderRoundTrip(t *testing.T) {
+	socket := filepath.Join(t.TempDir(), "plugin.sock")
+	t.Setenv(pluginapiv1.EnvPluginSocket, socket)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- pluginsdk.ServeProvider(ctx, &stubProvider{
+			name:        "test-provider",
+			displayName: "Test Provider",
+			connMode:    pluginsdk.ConnectionModeEither,
+		})
+	}()
+	t.Cleanup(func() {
+		cancel()
+		waitServeResult(t, errCh)
+	})
+
+	conn := newUnixConn(t, socket)
+	client := pluginapiv1.NewProviderPluginClient(conn)
+
+	rpcCtx, rpcCancel := context.WithTimeout(context.Background(), time.Second)
+	defer rpcCancel()
+
+	meta, err := client.GetMetadata(rpcCtx, &emptypb.Empty{}, grpc.WaitForReady(true))
+	if err != nil {
+		t.Fatalf("GetMetadata: %v", err)
+	}
+	if meta.GetName() != "test-provider" || meta.GetConnectionMode() != pluginapiv1.ConnectionMode_CONNECTION_MODE_EITHER {
+		t.Fatalf("unexpected metadata: %+v", meta)
+	}
+}
+
+func TestServeRuntimeRoundTrip(t *testing.T) {
+	socket := filepath.Join(t.TempDir(), "runtime.sock")
+	t.Setenv(pluginapiv1.EnvPluginSocket, socket)
+
+	server := &stubRuntimePlugin{}
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- pluginsdk.ServeRuntime(ctx, server)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		waitServeResult(t, errCh)
+	})
+
+	conn := newUnixConn(t, socket)
+	client := pluginapiv1.NewRuntimePluginClient(conn)
+
+	rpcCtx, rpcCancel := context.WithTimeout(context.Background(), time.Second)
+	defer rpcCancel()
+
+	if _, err := client.Start(rpcCtx, &pluginapiv1.StartRuntimeRequest{Name: "echo"}, grpc.WaitForReady(true)); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := client.Stop(rpcCtx, &emptypb.Empty{}, grpc.WaitForReady(true)); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if server.started != 1 || server.stopped != 1 || server.lastReq.GetName() != "echo" {
+		t.Fatalf("unexpected runtime server state: %+v", server)
+	}
+}
+
+func TestDialRuntimeHostRoundTrip(t *testing.T) {
+	socket := filepath.Join(t.TempDir(), "host.sock")
+	t.Setenv(pluginapiv1.EnvRuntimeHostSocket, socket)
+
+	lis, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = lis.Close() })
+
+	srv := grpc.NewServer()
+	pluginapiv1.RegisterRuntimeHostServer(srv, &stubRuntimeHost{})
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	conn, client, err := pluginsdk.DialRuntimeHost(context.Background())
+	if err != nil {
+		t.Fatalf("DialRuntimeHost: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	rpcCtx, rpcCancel := context.WithTimeout(context.Background(), time.Second)
+	defer rpcCancel()
+
+	resp, err := client.ListCapabilities(rpcCtx, &emptypb.Empty{}, grpc.WaitForReady(true))
+	if err != nil {
+		t.Fatalf("ListCapabilities: %v", err)
+	}
+	if len(resp.GetCapabilities()) != 1 || resp.GetCapabilities()[0].GetProvider() != "alpha" {
+		t.Fatalf("unexpected capabilities: %+v", resp.GetCapabilities())
+	}
+}

--- a/sdk/pluginsdk/test_helpers_test.go
+++ b/sdk/pluginsdk/test_helpers_test.go
@@ -1,0 +1,81 @@
+package pluginsdk_test
+
+import (
+	"context"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
+	pluginsdk "github.com/valon-technologies/gestalt/sdk/pluginsdk"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+func newProviderPluginClient(t *testing.T, prov pluginsdk.Provider) pluginapiv1.ProviderPluginClient {
+	t.Helper()
+
+	lis := bufconn.Listen(1024 * 1024)
+	srv := grpc.NewServer()
+	pluginapiv1.RegisterProviderPluginServer(srv, pluginsdk.NewProviderServer(prov))
+
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufconn",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return pluginapiv1.NewProviderPluginClient(conn)
+}
+
+func newUnixConn(t *testing.T, socket string) *grpc.ClientConn {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(socket); err == nil {
+			conn, dialErr := grpc.NewClient(
+				"passthrough:///"+socket,
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+				grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+					var d net.Dialer
+					return d.DialContext(ctx, "unix", addr)
+				}),
+			)
+			if dialErr != nil {
+				t.Fatalf("grpc.NewClient: %v", dialErr)
+			}
+			conn.Connect()
+			t.Cleanup(func() { _ = conn.Close() })
+			return conn
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("socket %q was not created", socket)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func waitServeResult(t *testing.T, errCh <-chan error) {
+	t.Helper()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("serve returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve did not stop after context cancellation")
+	}
+}


### PR DESCRIPTION
## Summary
- add package-local transport/boundary test harnesses for `internal/pluginapi`, `internal/pluginpkg`, and `sdk/pluginsdk`
- remove duplicated bufconn setup from individual plugin tests
- make manifest/archive validation behavior directly owned by `internal/pluginpkg`

## Testing
- go test ./internal/pluginapi ./internal/pluginpkg ./internal/pluginstore
- go test ./internal/pluginapi -run 'TestRemoteProviderRoundTrip'
- (cd sdk/pluginsdk && go test ./...)
- note: `go test ./internal/pluginapi ./internal/pluginpkg ./internal/pluginstore ./sdk/pluginsdk` still fails because `sdk/pluginsdk` is a separate Go module
