### PR TITLE
Add plugin authoring guide and overlay auth docs

### DIFF
--- a/cmd/gestaltd/plugin_init.go
+++ b/cmd/gestaltd/plugin_init.go
@@ -173,5 +173,5 @@ func printPluginInitUsage(w io.Writer) {
 	writeUsageLine(w, "  --binary    Path to pre-built binary (optional)")
 	writeUsageLine(w, "  --os        Target OS (default: current platform)")
 	writeUsageLine(w, "  --arch      Target architecture (default: current platform)")
-	writeUsageLine(w, "  --version   Manifest version (default: 0.1.0)")
+	writeUsageLine(w, "  --version   Manifest version (default: 0.0.0-alpha.1)")
 }

--- a/docs/pages/concepts/plugin-protocol.mdx
+++ b/docs/pages/concepts/plugin-protocol.mdx
@@ -99,3 +99,24 @@ The base must come from exactly one source:
 - or `plugin.base`, which names a registered built-in provider factory
 
 Runtime plugins cannot use overlay mode.
+
+### Auth and connection inheritance
+
+Overlay plugins inherit auth, session, and connection behavior from the base declarative integration. The plugin owns only its custom operations; the host handles token storage, OAuth flows, and credential resolution for the base upstream.
+
+If the overlay plugin does not need OAuth tokens (common for plugins that add operations without calling external APIs that require user credentials), set both `connection_mode: none` and `auth_style: none` on the integration. Without both, invocations will fail with "no token stored" because the host expects a connected OAuth session from the base provider.
+
+```yaml
+integrations:
+  my_tool:
+    connection_mode: none
+    auth_style: none
+    plugin:
+      mode: overlay
+      package: ./my-overlay.tar.gz
+    upstreams:
+      - type: rest
+        url: https://api.example.com/openapi.json
+```
+
+For overlays on top of OAuth-protected APIs (e.g. Gmail, Slack), keep the normal auth configuration. The overlay plugin receives the resolved token in its `Execute` call and can use it for its own API requests.

--- a/docs/pages/tasks/_meta.ts
+++ b/docs/pages/tasks/_meta.ts
@@ -2,6 +2,7 @@ export default {
   "run-locally": "Run Locally",
   "add-an-integration": "Add an Integration",
   "add-a-first-party-provider": "Add a First-Party Provider",
+  "write-a-plugin": "Write a Plugin",
   "use-a-plugin-package": "Use a Plugin Package",
   "use-with-mcp": "Use with MCP",
 };

--- a/docs/pages/tasks/write-a-plugin.mdx
+++ b/docs/pages/tasks/write-a-plugin.mdx
@@ -1,0 +1,153 @@
+# Write a Plugin
+
+This guide covers writing, packaging, and running a provider plugin from an external repository.
+
+## Install the SDK
+
+```sh
+GOPRIVATE=github.com/valon-technologies/gestalt \
+  go get github.com/valon-technologies/gestalt/sdk/pluginsdk@latest
+```
+
+## Implement the provider interface
+
+Create `main.go`:
+
+```go
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	pluginsdk "github.com/valon-technologies/gestalt/sdk/pluginsdk"
+)
+
+type myProvider struct{}
+
+func (p *myProvider) Name() string                        { return "my-tool" }
+func (p *myProvider) DisplayName() string                 { return "My Tool" }
+func (p *myProvider) Description() string                 { return "A custom provider plugin" }
+func (p *myProvider) ConnectionMode() pluginsdk.ConnectionMode { return pluginsdk.ConnectionModeNone }
+
+func (p *myProvider) ListOperations() []pluginsdk.Operation {
+	return []pluginsdk.Operation{
+		{
+			Name:        "hello",
+			Description: "Return a greeting",
+			Method:      "GET",
+			Parameters: []pluginsdk.Parameter{
+				{Name: "name", Type: "string", Description: "Name to greet", Required: true},
+			},
+		},
+	}
+}
+
+func (p *myProvider) Execute(_ context.Context, operation string, params map[string]any, _ string) (*pluginsdk.OperationResult, error) {
+	switch operation {
+	case "hello":
+		name, _ := params["name"].(string)
+		if name == "" {
+			name = "World"
+		}
+		body, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("Hello, %s!", name)})
+		return &pluginsdk.OperationResult{Status: 200, Body: string(body)}, nil
+	default:
+		return &pluginsdk.OperationResult{Status: 404, Body: `{"error":"unknown operation"}`}, nil
+	}
+}
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if err := pluginsdk.ServeProvider(ctx, &myProvider{}); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+```
+
+## Build
+
+```sh
+go build -o ./my-tool .
+```
+
+## Scaffold and package
+
+Use `gestaltd plugin init` to generate the manifest and artifact layout, then package:
+
+```sh
+gestaltd plugin init --id myorg/my-tool --kind provider --binary ./my-tool --output ./pkg
+gestaltd plugin package --input ./pkg --output ./my-tool.tar.gz
+```
+
+The `--os` and `--arch` flags default to your current platform. For cross-compilation:
+
+```sh
+GOOS=linux GOARCH=amd64 go build -o ./my-tool-linux .
+gestaltd plugin init --id myorg/my-tool --kind provider --binary ./my-tool-linux \
+  --os linux --arch amd64 --output ./pkg
+```
+
+## Configure and run
+
+Reference the package in your Gestalt config:
+
+```yaml
+integrations:
+  my-tool:
+    connection_mode: none
+    plugin:
+      package: ./my-tool.tar.gz
+```
+
+Then hydrate and serve:
+
+```sh
+gestaltd init --config config.yaml
+gestaltd serve --locked --config config.yaml
+```
+
+## Overlay plugins
+
+An overlay plugin adds custom operations on top of an existing REST or GraphQL upstream. The base upstream handles its own operations; the plugin handles only the operations it declares.
+
+```yaml
+integrations:
+  enhanced-api:
+    connection_mode: none
+    auth_style: none
+    plugin:
+      mode: overlay
+      package: ./my-overlay.tar.gz
+    upstreams:
+      - type: rest
+        url: https://api.example.com/openapi.json
+```
+
+The overlay plugin receives `mode: "overlay"` during startup via the `Start` method. It should return only its custom operations from `ListOperations`; the host merges them with the base upstream's operations.
+
+### Auth inheritance
+
+Overlay plugins inherit auth and connection behavior from the base declarative integration. If your overlay does not need OAuth tokens, set both `connection_mode: none` and `auth_style: none` on the integration. Without both, invocations will fail because the host expects a connected session.
+
+For overlays on OAuth-protected APIs (Gmail, Slack, etc.), keep the normal auth configuration. The resolved token is passed to `Execute` so the plugin can make its own authenticated API calls.
+
+## Optional interfaces
+
+The SDK supports several optional interfaces beyond the core `Provider`:
+
+| Interface | Purpose |
+|---|---|
+| `ProviderStarter` | Receive integration name, config, and mode at startup. |
+| `ConfigSchemaProvider` | Advertise a JSON Schema for the `plugin.config` block. |
+| `ConnectionParamProvider` | Define parameters required to connect (shown in the UI). |
+| `ProtocolVersionProvider` | Declare supported protocol version range. |
+
+Implement any of these on your provider struct to opt in. See the [Plugin Protocol](/concepts/plugin-protocol) reference for details.


### PR DESCRIPTION
External plugin authors had no task-level guide for writing, packaging,
and running a provider plugin. The overlay auth inheritance behavior
was also underdocumented, causing first-time authors to hit a "no token
stored" error when they did not realize both `connection_mode: none`
and `auth_style: none` are needed for no-auth overlays. This adds a
`write-a-plugin.mdx` task page covering the full author workflow and
expands the overlay semantics section in the protocol reference with
concrete auth inheritance guidance. Also fixes a version mismatch in
the `plugin init` help text.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>