### PR TITLE
Extract runtime and binding extension boundary from bootstrap

### DIFF
--- a/internal/bootstrap/binding_boundary.go
+++ b/internal/bootstrap/binding_boundary.go
@@ -1,0 +1,59 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/invocation"
+	"github.com/valon-technologies/gestalt/internal/registry"
+)
+
+type BindingDeps struct {
+	Invoker invocation.Invoker
+	Egress  EgressDeps
+}
+
+type BindingFactory func(ctx context.Context, name string, cfg config.BindingDef, deps BindingDeps) (core.Binding, error)
+
+func buildBindings(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink, egressDeps EgressDeps) (*registry.PluginMap[core.Binding], error) {
+	if len(cfg.Bindings) == 0 {
+		return nil, nil
+	}
+
+	bindings := registry.NewBindingMap()
+
+	for name := range cfg.Bindings {
+		def := cfg.Bindings[name]
+		factory, ok := factories.Bindings[def.Type]
+		if !ok {
+			_ = CloseBindings(bindings, bindingNames(bindings))
+			return nil, fmt.Errorf("bootstrap: unknown binding type %q for binding %q", def.Type, name)
+		}
+
+		deps := bindingDepsForProviders(name, invoker, lister, def.Providers, audit, egressDeps)
+		binding, err := factory(ctx, name, def, deps)
+		if err != nil {
+			_ = CloseBindings(bindings, bindingNames(bindings))
+			return nil, fmt.Errorf("bootstrap: binding %q: %w", name, err)
+		}
+
+		if err := bindings.Register(name, binding); err != nil {
+			_ = binding.Close()
+			_ = CloseBindings(bindings, bindingNames(bindings))
+			return nil, fmt.Errorf("bootstrap: registering binding %q: %w", name, err)
+		}
+		log.Printf("loaded binding %s (type=%s, providers=%v)", name, def.Type, def.Providers)
+	}
+
+	return bindings, nil
+}
+
+func bindingNames(bindings *registry.PluginMap[core.Binding]) []string {
+	if bindings == nil {
+		return nil
+	}
+	return bindings.List()
+}

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -32,19 +32,6 @@ type AuthFactory func(node yaml.Node, deps Deps) (core.AuthProvider, error)
 type DatastoreFactory func(node yaml.Node, deps Deps) (core.Datastore, error)
 type ProviderFactory func(ctx context.Context, name string, intg config.IntegrationDef, deps Deps) (core.Provider, error)
 type SecretManagerFactory func(node yaml.Node) (core.SecretManager, error)
-type BindingDeps struct {
-	Invoker invocation.Invoker
-	Egress  EgressDeps
-}
-
-type RuntimeDeps struct {
-	Invoker          invocation.Invoker
-	CapabilityLister invocation.CapabilityLister
-	Egress           EgressDeps
-}
-
-type RuntimeFactory func(ctx context.Context, name string, cfg config.RuntimeDef, deps RuntimeDeps) (core.Runtime, error)
-type BindingFactory func(ctx context.Context, name string, cfg config.BindingDef, deps BindingDeps) (core.Binding, error)
 
 type FactoryRegistry struct {
 	Auth            map[string]AuthFactory
@@ -145,32 +132,27 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	wireCredentialResolver(&deps.Egress, sharedInvoker, providers, ds, sm)
 	audit := core.AuditSink(invocation.LogAuditSink{})
 
-	runtimes, err := buildRuntimes(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress)
+	extensions, err := buildExtensions(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress)
 	if err != nil {
 		return nil, err
 	}
-	stopRuntimes := true
+	shutdownExtensions := true
 	defer func() {
-		if stopRuntimes {
-			_ = StopRuntimes(context.Background(), runtimes, runtimeNames(runtimes))
+		if shutdownExtensions {
+			_ = extensions.Shutdown(context.Background())
 		}
 	}()
 
-	bindings, err := buildBindings(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress)
-	if err != nil {
-		return nil, err
-	}
-
 	closeProviders = false
-	stopRuntimes = false
+	shutdownExtensions = false
 	closeSM = false
 	return &Result{
 		Auth:             auth,
 		Datastore:        ds,
 		Providers:        providers,
 		ProvidersReady:   providersReady,
-		Runtimes:         runtimes,
-		Bindings:         bindings,
+		Runtimes:         extensions.Runtimes,
+		Bindings:         extensions.Bindings,
 		Invoker:          sharedInvoker,
 		CapabilityLister: sharedInvoker,
 		AuditSink:        audit,
@@ -440,70 +422,6 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 	return &reg.Providers, ready, nil
 }
 
-func buildRuntimes(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink, egressDeps EgressDeps) (*registry.PluginMap[core.Runtime], error) {
-	return buildRuntimesWith(ctx, cfg, factories, invoker, lister, audit, egressDeps, buildRuntime)
-}
-
-func buildRuntimesWith(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink, egressDeps EgressDeps, buildRuntimeFn func(context.Context, string, config.RuntimeDef, *FactoryRegistry, RuntimeDeps) (core.Runtime, error)) (*registry.PluginMap[core.Runtime], error) {
-	if len(cfg.Runtimes) == 0 {
-		return nil, nil
-	}
-
-	runtimes := registry.NewRuntimeMap()
-
-	for name := range cfg.Runtimes {
-		def := cfg.Runtimes[name]
-		deps := runtimeDepsForProviders(name, invoker, lister, def.Providers, audit, egressDeps)
-		rt, err := buildRuntimeFn(ctx, name, def, factories, deps)
-		if err != nil {
-			_ = StopRuntimes(context.Background(), runtimes, runtimes.List())
-			return nil, fmt.Errorf("bootstrap: runtime %q: %w", name, err)
-		}
-
-		if err := runtimes.Register(name, rt); err != nil {
-			_ = rt.Stop(context.Background())
-			_ = StopRuntimes(context.Background(), runtimes, runtimes.List())
-			return nil, fmt.Errorf("bootstrap: registering runtime %q: %w", name, err)
-		}
-		log.Printf("loaded runtime %s (type=%s, providers=%v)", name, def.Type, def.Providers)
-	}
-
-	return runtimes, nil
-}
-
-func buildBindings(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink, egressDeps EgressDeps) (*registry.PluginMap[core.Binding], error) {
-	if len(cfg.Bindings) == 0 {
-		return nil, nil
-	}
-
-	bindings := registry.NewBindingMap()
-
-	for name := range cfg.Bindings {
-		def := cfg.Bindings[name]
-		factory, ok := factories.Bindings[def.Type]
-		if !ok {
-			_ = CloseBindings(bindings, bindings.List())
-			return nil, fmt.Errorf("bootstrap: unknown binding type %q for binding %q", def.Type, name)
-		}
-
-		deps := bindingDepsForProviders(name, invoker, lister, def.Providers, audit, egressDeps)
-		binding, err := factory(ctx, name, def, deps)
-		if err != nil {
-			_ = CloseBindings(bindings, bindings.List())
-			return nil, fmt.Errorf("bootstrap: binding %q: %w", name, err)
-		}
-
-		if err := bindings.Register(name, binding); err != nil {
-			_ = binding.Close()
-			_ = CloseBindings(bindings, bindings.List())
-			return nil, fmt.Errorf("bootstrap: registering binding %q: %w", name, err)
-		}
-		log.Printf("loaded binding %s (type=%s, providers=%v)", name, def.Type, def.Providers)
-	}
-
-	return bindings, nil
-}
-
 func buildProvider(ctx context.Context, name string, intg config.IntegrationDef, factories *FactoryRegistry, deps Deps) (core.Provider, error) {
 	if intg.Plugin != nil {
 		mode := intg.Plugin.Mode
@@ -609,34 +527,4 @@ func validateProviderBuildAvailable(name string, intg config.IntegrationDef, fac
 	}
 	_, err := providerFactoryForName(name, factories)
 	return err
-}
-
-func buildRuntime(ctx context.Context, name string, cfg config.RuntimeDef, factories *FactoryRegistry, deps RuntimeDeps) (core.Runtime, error) {
-	if cfg.Plugin != nil {
-		m, err := config.NodeToMap(cfg.Config)
-		if err != nil {
-			return nil, fmt.Errorf("decode runtime plugin config for %q: %w", name, err)
-		}
-		return pluginapi.NewExecutableRuntime(ctx, name, pluginapi.ExecConfig{
-			Command: cfg.Plugin.Command,
-			Args:    cfg.Plugin.Args,
-			Env:     cfg.Plugin.Env,
-			Name:    name,
-			Config:  m,
-			Mode:    cfg.Plugin.Mode,
-		}, deps.Invoker, deps.CapabilityLister)
-	}
-
-	factory, ok := factories.Runtimes[cfg.Type]
-	if !ok {
-		return nil, fmt.Errorf("unknown runtime type %q", cfg.Type)
-	}
-	return factory(ctx, name, cfg, deps)
-}
-
-func runtimeNames(runtimes *registry.PluginMap[core.Runtime]) []string {
-	if runtimes == nil {
-		return nil
-	}
-	return runtimes.List()
 }

--- a/internal/bootstrap/extension_boundary.go
+++ b/internal/bootstrap/extension_boundary.go
@@ -1,0 +1,50 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/invocation"
+	"github.com/valon-technologies/gestalt/internal/registry"
+)
+
+// ExtensionBoundary owns runtime and binding assembly once provider
+// construction has produced the shared invoker/capability surface.
+type ExtensionBoundary struct {
+	Runtimes *registry.PluginMap[core.Runtime]
+	Bindings *registry.PluginMap[core.Binding]
+}
+
+func buildExtensions(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink, egressDeps EgressDeps) (*ExtensionBoundary, error) {
+	return buildExtensionsWith(ctx, cfg, factories, invoker, lister, audit, egressDeps, buildRuntime)
+}
+
+func buildExtensionsWith(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink, egressDeps EgressDeps, buildRuntimeFn runtimeBuilder) (*ExtensionBoundary, error) {
+	runtimes, err := buildRuntimesWith(ctx, cfg, factories, invoker, lister, audit, egressDeps, buildRuntimeFn)
+	if err != nil {
+		return nil, err
+	}
+
+	bindings, err := buildBindings(ctx, cfg, factories, invoker, lister, audit, egressDeps)
+	if err != nil {
+		_ = StopRuntimes(context.Background(), runtimes, runtimeNames(runtimes))
+		return nil, err
+	}
+
+	return &ExtensionBoundary{
+		Runtimes: runtimes,
+		Bindings: bindings,
+	}, nil
+}
+
+func (b *ExtensionBoundary) Shutdown(ctx context.Context) error {
+	if b == nil {
+		return nil
+	}
+	return errors.Join(
+		CloseBindings(b.Bindings, bindingNames(b.Bindings)),
+		StopRuntimes(ctx, b.Runtimes, runtimeNames(b.Runtimes)),
+	)
+}

--- a/internal/bootstrap/extension_boundary_test.go
+++ b/internal/bootstrap/extension_boundary_test.go
@@ -1,0 +1,106 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	coretesting "github.com/valon-technologies/gestalt/core/testing"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/registry"
+)
+
+func TestBuildExtensions_ShutsDownRuntimesWhenBindingConstructionFails(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Runtimes: map[string]config.RuntimeDef{
+			"echo": {Type: "test-runtime"},
+		},
+		Bindings: map[string]config.BindingDef{
+			"bad": {Type: "test-binding"},
+		},
+	}
+
+	runtimeStopped := false
+	factories := NewFactoryRegistry()
+	factories.Runtimes["test-runtime"] = func(_ context.Context, name string, _ config.RuntimeDef, _ RuntimeDeps) (core.Runtime, error) {
+		return &coretesting.StubRuntime{
+			N: name,
+			StopFn: func(context.Context) error {
+				runtimeStopped = true
+				return nil
+			},
+		}, nil
+	}
+	factories.Bindings["test-binding"] = func(_ context.Context, _ string, _ config.BindingDef, _ BindingDeps) (core.Binding, error) {
+		return nil, errors.New("boom")
+	}
+
+	_, err := buildExtensions(context.Background(), cfg, factories, nil, nil, nil, EgressDeps{})
+	if err == nil {
+		t.Fatal("expected buildExtensions to fail")
+	}
+	if !strings.Contains(err.Error(), `binding "bad"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !runtimeStopped {
+		t.Fatal("expected buildExtensions to stop constructed runtimes when binding construction fails")
+	}
+}
+
+func TestExtensionBoundaryShutdown_ClosesBindingsAndRuntimes(t *testing.T) {
+	t.Parallel()
+
+	bindingClosed := false
+	runtimeStopped := false
+
+	extensions := &ExtensionBoundary{
+		Runtimes: registryWithRuntime(t, "echo", &coretesting.StubRuntime{
+			N: "echo",
+			StopFn: func(context.Context) error {
+				runtimeStopped = true
+				return nil
+			},
+		}),
+		Bindings: registryWithBinding(t, "hook", &coretesting.StubBinding{
+			N: "hook",
+			CloseFn: func() error {
+				bindingClosed = true
+				return nil
+			},
+		}),
+	}
+
+	if err := extensions.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if !bindingClosed {
+		t.Fatal("expected Shutdown to close bindings")
+	}
+	if !runtimeStopped {
+		t.Fatal("expected Shutdown to stop runtimes")
+	}
+}
+
+func registryWithRuntime(t *testing.T, name string, runtime core.Runtime) *registry.PluginMap[core.Runtime] {
+	t.Helper()
+
+	runtimes := registry.NewRuntimeMap()
+	if err := runtimes.Register(name, runtime); err != nil {
+		t.Fatalf("Register runtime %q: %v", name, err)
+	}
+	return runtimes
+}
+
+func registryWithBinding(t *testing.T, name string, binding core.Binding) *registry.PluginMap[core.Binding] {
+	t.Helper()
+
+	bindings := registry.NewBindingMap()
+	if err := bindings.Register(name, binding); err != nil {
+		t.Fatalf("Register binding %q: %v", name, err)
+	}
+	return bindings
+}

--- a/internal/bootstrap/runtime_boundary.go
+++ b/internal/bootstrap/runtime_boundary.go
@@ -1,0 +1,84 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/invocation"
+	"github.com/valon-technologies/gestalt/internal/pluginapi"
+	"github.com/valon-technologies/gestalt/internal/registry"
+)
+
+type RuntimeDeps struct {
+	Invoker          invocation.Invoker
+	CapabilityLister invocation.CapabilityLister
+	Egress           EgressDeps
+}
+
+type RuntimeFactory func(ctx context.Context, name string, cfg config.RuntimeDef, deps RuntimeDeps) (core.Runtime, error)
+
+type runtimeBuilder func(context.Context, string, config.RuntimeDef, *FactoryRegistry, RuntimeDeps) (core.Runtime, error)
+
+func buildRuntimes(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink, egressDeps EgressDeps) (*registry.PluginMap[core.Runtime], error) {
+	return buildRuntimesWith(ctx, cfg, factories, invoker, lister, audit, egressDeps, buildRuntime)
+}
+
+func buildRuntimesWith(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, invoker invocation.Invoker, lister invocation.CapabilityLister, audit core.AuditSink, egressDeps EgressDeps, buildRuntimeFn runtimeBuilder) (*registry.PluginMap[core.Runtime], error) {
+	if len(cfg.Runtimes) == 0 {
+		return nil, nil
+	}
+
+	runtimes := registry.NewRuntimeMap()
+
+	for name := range cfg.Runtimes {
+		def := cfg.Runtimes[name]
+		deps := runtimeDepsForProviders(name, invoker, lister, def.Providers, audit, egressDeps)
+		rt, err := buildRuntimeFn(ctx, name, def, factories, deps)
+		if err != nil {
+			_ = StopRuntimes(context.Background(), runtimes, runtimeNames(runtimes))
+			return nil, fmt.Errorf("bootstrap: runtime %q: %w", name, err)
+		}
+
+		if err := runtimes.Register(name, rt); err != nil {
+			_ = rt.Stop(context.Background())
+			_ = StopRuntimes(context.Background(), runtimes, runtimeNames(runtimes))
+			return nil, fmt.Errorf("bootstrap: registering runtime %q: %w", name, err)
+		}
+		log.Printf("loaded runtime %s (type=%s, providers=%v)", name, def.Type, def.Providers)
+	}
+
+	return runtimes, nil
+}
+
+func buildRuntime(ctx context.Context, name string, cfg config.RuntimeDef, factories *FactoryRegistry, deps RuntimeDeps) (core.Runtime, error) {
+	if cfg.Plugin != nil {
+		m, err := config.NodeToMap(cfg.Config)
+		if err != nil {
+			return nil, fmt.Errorf("decode runtime plugin config for %q: %w", name, err)
+		}
+		return pluginapi.NewExecutableRuntime(ctx, name, pluginapi.ExecConfig{
+			Command: cfg.Plugin.Command,
+			Args:    cfg.Plugin.Args,
+			Env:     cfg.Plugin.Env,
+			Name:    name,
+			Config:  m,
+			Mode:    cfg.Plugin.Mode,
+		}, deps.Invoker, deps.CapabilityLister)
+	}
+
+	factory, ok := factories.Runtimes[cfg.Type]
+	if !ok {
+		return nil, fmt.Errorf("unknown runtime type %q", cfg.Type)
+	}
+	return factory(ctx, name, cfg, deps)
+}
+
+func runtimeNames(runtimes *registry.PluginMap[core.Runtime]) []string {
+	if runtimes == nil {
+		return nil
+	}
+	return runtimes.List()
+}

--- a/internal/bootstrap/validate.go
+++ b/internal/bootstrap/validate.go
@@ -63,22 +63,14 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 	wireCredentialResolver(&deps.Egress, sharedInvoker, providers, ds, sm)
 	audit := core.AuditSink(invocation.LogAuditSink{})
 
-	runtimes, err := buildRuntimesWith(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress, buildRuntimeForValidation)
+	extensions, err := buildExtensionsWith(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress, buildRuntimeForValidation)
 	if err != nil {
 		return warnings, err
 	}
-	// Validation does not start runtimes, but factories may still allocate
-	// resources that need to be released after construction.
-	if runtimes != nil {
-		defer func() { _ = StopRuntimes(context.Background(), runtimes, runtimes.List()) }()
-	}
-
-	bindings, err := buildBindings(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress)
-	if err != nil {
-		return warnings, err
-	}
-	if bindings != nil {
-		defer func() { _ = CloseBindings(bindings, bindings.List()) }()
+	if extensions != nil {
+		// Validation does not start runtimes, but extension factories may still
+		// allocate resources that need to be released after construction.
+		defer func() { _ = extensions.Shutdown(context.Background()) }()
 	}
 
 	return warnings, nil

--- a/plugins/runtimes/echo/factory_test.go
+++ b/plugins/runtimes/echo/factory_test.go
@@ -1,0 +1,39 @@
+package echo_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/testutil"
+	echoruntime "github.com/valon-technologies/gestalt/plugins/runtimes/echo"
+)
+
+func TestFactoryUsesExplicitDeps(t *testing.T) {
+	t.Parallel()
+
+	lister := &stubCapabilityLister{
+		caps: []core.Capability{
+			{Provider: "alpha", Operation: "echo"},
+		},
+	}
+
+	rt, err := echoruntime.Factory(context.Background(), "factory-echo", config.RuntimeDef{}, bootstrap.RuntimeDeps{
+		Invoker:          &testutil.StubInvoker{},
+		CapabilityLister: lister,
+	})
+	if err != nil {
+		t.Fatalf("Factory: %v", err)
+	}
+	if rt.Name() != "factory-echo" {
+		t.Fatalf("runtime name = %q, want factory-echo", rt.Name())
+	}
+	if err := rt.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if lister.calls != 1 {
+		t.Fatalf("expected capability lister to be called once, got %d", lister.calls)
+	}
+}


### PR DESCRIPTION
## Summary
- extract runtime and binding construction behind a dedicated extension boundary in `internal/bootstrap`
- keep bootstrap as top-level composition while moving runtime/binding assembly into focused boundary files
- add package-local/runtime-boundary coverage so bootstrap does not own all extension checks

## Testing
- go test ./internal/bootstrap ./plugins/runtimes/... ./plugins/bindings/...
- go test ./internal/bootstrap -run 'Test(Validate|Bootstrap.*|.*Runtime.*|.*Binding.*)'