### PR TITLE
Extract provider compiler boundary from init and factories

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -18,11 +18,10 @@ import (
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/internal/composite"
 	"github.com/valon-technologies/gestalt/internal/config"
-	graphqlupstream "github.com/valon-technologies/gestalt/internal/graphql"
 	"github.com/valon-technologies/gestalt/internal/mcpoauth"
 	"github.com/valon-technologies/gestalt/internal/mcpupstream"
-	"github.com/valon-technologies/gestalt/internal/openapi"
 	"github.com/valon-technologies/gestalt/internal/provider"
+	providercompiler "github.com/valon-technologies/gestalt/internal/provider/compiler"
 	"github.com/valon-technologies/gestalt/plugins/auth/google"
 	"github.com/valon-technologies/gestalt/plugins/auth/local"
 	"github.com/valon-technologies/gestalt/plugins/auth/oidc"
@@ -251,19 +250,13 @@ func defaultProviderFactory(preparedProviders map[string]string) bootstrap.Provi
 					cleanup()
 					return nil, fmt.Errorf("multiple api upstreams not supported")
 				}
-				def, err := loadAPIUpstream(ctx, name, *us, preparedProviders)
-				if err != nil {
-					cleanup()
-					return nil, err
-				}
-				intgForBuild := intgWithUpstreamAuth(intg, *us)
 				var buildOpts []provider.BuildOption
 				buildOpts = append(buildOpts, provider.WithEgressResolver(deps.Egress.Resolver))
 				if us.Auth.Type == "mcp_oauth" {
 					handler := buildMCPOAuthHandlerFromUpstream(*us, regStore, deps)
 					buildOpts = append(buildOpts, provider.WithAuthHandler(handler))
 				}
-				p, err := provider.Build(def, intgForBuild, map[string]string(us.AllowedOperations), buildOpts...)
+				p, err := providercompiler.BuildProvider(ctx, name, intg, *us, preparedProviders, buildOpts...)
 				if err != nil {
 					cleanup()
 					return nil, err
@@ -306,24 +299,6 @@ func defaultProviderFactory(preparedProviders map[string]string) bootstrap.Provi
 			return nil, fmt.Errorf("no upstreams configured")
 		}
 	}
-}
-
-// Empty upstream fields are left as-is so integration-level defaults
-// (including redirect_url resolved later by resolveBaseURL) are preserved.
-func intgWithUpstreamAuth(intg config.IntegrationDef, us config.UpstreamDef) config.IntegrationDef {
-	if us.Auth.Type != "" {
-		intg.Auth = us.Auth
-	}
-	if us.ClientID != "" {
-		intg.ClientID = us.ClientID
-	}
-	if us.ClientSecret != "" {
-		intg.ClientSecret = us.ClientSecret
-	}
-	if us.RedirectURL != "" {
-		intg.RedirectURL = us.RedirectURL
-	}
-	return intg
 }
 
 func buildRegistrationStore(deps bootstrap.Deps) mcpoauth.RegistrationStore {
@@ -386,25 +361,4 @@ func buildMCPOAuthProvider(name string, intg config.IntegrationDef, us config.Up
 	}
 
 	return composite.New(name, baseProv, mcpUp), nil
-}
-
-func loadAPIUpstream(ctx context.Context, name string, us config.UpstreamDef, preparedProviders map[string]string) (*provider.Definition, error) {
-	if preparedPath := preparedProviders[name]; preparedPath != "" {
-		return provider.LoadFile(preparedPath)
-	}
-
-	switch us.Type {
-	case config.UpstreamTypeREST:
-		if us.URL != "" {
-			return openapi.LoadDefinition(ctx, name, us.URL, map[string]string(us.AllowedOperations))
-		}
-	case config.UpstreamTypeGraphQL:
-		if us.URL != "" {
-			return graphqlupstream.LoadDefinition(ctx, name, us.URL, map[string]string(us.AllowedOperations))
-		}
-	default:
-		return nil, fmt.Errorf("unsupported api upstream type %q", us.Type)
-	}
-
-	return nil, fmt.Errorf("api upstream %q requires a url or prepared artifact", name)
 }

--- a/cmd/gestaltd/init.go
+++ b/cmd/gestaltd/init.go
@@ -9,6 +9,7 @@ import (
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/operator"
 	"github.com/valon-technologies/gestalt/internal/provider"
+	providercompiler "github.com/valon-technologies/gestalt/internal/provider/compiler"
 )
 
 const (
@@ -37,7 +38,7 @@ func runInit(args []string) error {
 
 func operatorLifecycle() *operator.Lifecycle {
 	return operator.NewLifecycle(func(ctx context.Context, name string, upstream config.UpstreamDef) (*provider.Definition, error) {
-		return loadAPIUpstream(ctx, name, upstream, nil)
+		return providercompiler.LoadDefinition(ctx, name, upstream, nil)
 	})
 }
 

--- a/internal/provider/compiler/compiler.go
+++ b/internal/provider/compiler/compiler.go
@@ -12,15 +12,11 @@ import (
 	"github.com/valon-technologies/gestalt/internal/provider"
 )
 
-// Result is the normalized compiler output for a remote upstream or prepared
-// provider artifact.
 type Result struct {
 	Definition *provider.Definition
 	Catalog    *catalog.Catalog
 }
 
-// Compile normalizes a remote upstream or prepared provider artifact into the
-// definition and catalog forms used by the rest of Gestalt.
 func Compile(ctx context.Context, name string, upstream config.UpstreamDef, preparedProviders map[string]string) (*Result, error) {
 	def, err := loadDefinition(ctx, name, upstream, preparedProviders)
 	if err != nil {
@@ -32,19 +28,12 @@ func Compile(ctx context.Context, name string, upstream config.UpstreamDef, prep
 	}, nil
 }
 
-// LoadDefinition exposes the compiler's definition output for callers that only
-// need the provider artifact representation.
 func LoadDefinition(ctx context.Context, name string, upstream config.UpstreamDef, preparedProviders map[string]string) (*provider.Definition, error) {
-	result, err := Compile(ctx, name, upstream, preparedProviders)
-	if err != nil {
-		return nil, err
-	}
-	return result.Definition, nil
+	return loadDefinition(ctx, name, upstream, preparedProviders)
 }
 
-// BuildProvider constructs the runtime provider for a REST or GraphQL upstream.
 func BuildProvider(ctx context.Context, name string, intg config.IntegrationDef, upstream config.UpstreamDef, preparedProviders map[string]string, opts ...provider.BuildOption) (core.Provider, error) {
-	def, err := LoadDefinition(ctx, name, upstream, preparedProviders)
+	def, err := loadDefinition(ctx, name, upstream, preparedProviders)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/compiler/compiler.go
+++ b/internal/provider/compiler/compiler.go
@@ -1,0 +1,89 @@
+package compiler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+	"github.com/valon-technologies/gestalt/internal/config"
+	graphqlupstream "github.com/valon-technologies/gestalt/internal/graphql"
+	"github.com/valon-technologies/gestalt/internal/openapi"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+// Result is the normalized compiler output for a remote upstream or prepared
+// provider artifact.
+type Result struct {
+	Definition *provider.Definition
+	Catalog    *catalog.Catalog
+}
+
+// Compile normalizes a remote upstream or prepared provider artifact into the
+// definition and catalog forms used by the rest of Gestalt.
+func Compile(ctx context.Context, name string, upstream config.UpstreamDef, preparedProviders map[string]string) (*Result, error) {
+	def, err := loadDefinition(ctx, name, upstream, preparedProviders)
+	if err != nil {
+		return nil, err
+	}
+	return &Result{
+		Definition: def,
+		Catalog:    provider.CatalogFromDefinition(def),
+	}, nil
+}
+
+// LoadDefinition exposes the compiler's definition output for callers that only
+// need the provider artifact representation.
+func LoadDefinition(ctx context.Context, name string, upstream config.UpstreamDef, preparedProviders map[string]string) (*provider.Definition, error) {
+	result, err := Compile(ctx, name, upstream, preparedProviders)
+	if err != nil {
+		return nil, err
+	}
+	return result.Definition, nil
+}
+
+// BuildProvider constructs the runtime provider for a REST or GraphQL upstream.
+func BuildProvider(ctx context.Context, name string, intg config.IntegrationDef, upstream config.UpstreamDef, preparedProviders map[string]string, opts ...provider.BuildOption) (core.Provider, error) {
+	def, err := LoadDefinition(ctx, name, upstream, preparedProviders)
+	if err != nil {
+		return nil, err
+	}
+	return provider.Build(def, integrationWithUpstreamAuth(intg, upstream), map[string]string(upstream.AllowedOperations), opts...)
+}
+
+func loadDefinition(ctx context.Context, name string, upstream config.UpstreamDef, preparedProviders map[string]string) (*provider.Definition, error) {
+	if preparedPath := preparedProviders[name]; preparedPath != "" {
+		return provider.LoadFile(preparedPath)
+	}
+
+	switch upstream.Type {
+	case config.UpstreamTypeREST:
+		if upstream.URL != "" {
+			return openapi.LoadDefinition(ctx, name, upstream.URL, map[string]string(upstream.AllowedOperations))
+		}
+	case config.UpstreamTypeGraphQL:
+		if upstream.URL != "" {
+			return graphqlupstream.LoadDefinition(ctx, name, upstream.URL, map[string]string(upstream.AllowedOperations))
+		}
+	default:
+		return nil, fmt.Errorf("unsupported api upstream type %q", upstream.Type)
+	}
+
+	return nil, fmt.Errorf("api upstream %q requires a url or prepared artifact", name)
+}
+
+func integrationWithUpstreamAuth(intg config.IntegrationDef, upstream config.UpstreamDef) config.IntegrationDef {
+	if upstream.Auth.Type != "" {
+		intg.Auth = upstream.Auth
+	}
+	if upstream.ClientID != "" {
+		intg.ClientID = upstream.ClientID
+	}
+	if upstream.ClientSecret != "" {
+		intg.ClientSecret = upstream.ClientSecret
+	}
+	if upstream.RedirectURL != "" {
+		intg.RedirectURL = upstream.RedirectURL
+	}
+	return intg
+}

--- a/internal/provider/compiler/compiler_test.go
+++ b/internal/provider/compiler/compiler_test.go
@@ -1,0 +1,139 @@
+package compiler
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
+	"github.com/valon-technologies/gestalt/internal/provider"
+)
+
+func TestCompileUsesPreparedArtifact(t *testing.T) {
+	t.Parallel()
+
+	preparedPath := writePreparedDefinition(t, provider.Definition{
+		Provider:    "prepared",
+		DisplayName: "Prepared Provider",
+		Operations: map[string]provider.OperationDef{
+			"list_users": {
+				Method:      "GET",
+				Path:        "/users",
+				Description: "List users",
+				Transport:   "rest",
+			},
+		},
+	})
+
+	result, err := Compile(context.Background(), "prepared", config.UpstreamDef{
+		Type: config.UpstreamTypeREST,
+	}, map[string]string{
+		"prepared": preparedPath,
+	})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	if result.Definition == nil {
+		t.Fatal("expected definition output")
+	}
+	if result.Catalog == nil {
+		t.Fatal("expected catalog output")
+	}
+	if result.Definition.Provider != "prepared" {
+		t.Fatalf("Definition.Provider = %q, want %q", result.Definition.Provider, "prepared")
+	}
+	if result.Catalog.Name != "prepared" {
+		t.Fatalf("Catalog.Name = %q, want %q", result.Catalog.Name, "prepared")
+	}
+	if len(result.Catalog.Operations) != 1 {
+		t.Fatalf("len(Catalog.Operations) = %d, want %d", len(result.Catalog.Operations), 1)
+	}
+	if result.Catalog.Operations[0].ID != "list_users" {
+		t.Fatalf("Catalog.Operations[0].ID = %q, want %q", result.Catalog.Operations[0].ID, "list_users")
+	}
+}
+
+func TestBuildProviderAppliesRuntimeOverridesAndAllowedOperations(t *testing.T) {
+	t.Parallel()
+
+	preparedPath := writePreparedDefinition(t, provider.Definition{
+		Provider:    "prepared",
+		DisplayName: "Prepared Provider",
+		Description: "Prepared description",
+		Auth: provider.AuthDef{
+			Type: "manual",
+		},
+		Operations: map[string]provider.OperationDef{
+			"delete_user": {
+				Method:      "DELETE",
+				Path:        "/users/{id}",
+				Description: "Delete user",
+				Transport:   "rest",
+			},
+			"list_users": {
+				Method:      "GET",
+				Path:        "/users",
+				Description: "List users",
+				Transport:   "rest",
+			},
+		},
+	})
+
+	built, err := BuildProvider(context.Background(), "prepared", config.IntegrationDef{
+		DisplayName: "Runtime Provider",
+		Description: "Runtime description",
+	}, config.UpstreamDef{
+		Type: config.UpstreamTypeREST,
+		AllowedOperations: config.AllowedOps{
+			"list_users": "List only active users",
+		},
+	}, map[string]string{
+		"prepared": preparedPath,
+	})
+	if err != nil {
+		t.Fatalf("BuildProvider: %v", err)
+	}
+
+	cp, ok := built.(core.CatalogProvider)
+	if !ok {
+		t.Fatal("expected built provider to expose a catalog")
+	}
+	cat := cp.Catalog()
+	if cat == nil {
+		t.Fatal("expected non-nil catalog")
+	}
+	if cat.DisplayName != "Runtime Provider" {
+		t.Fatalf("Catalog.DisplayName = %q, want %q", cat.DisplayName, "Runtime Provider")
+	}
+	if cat.Description != "Runtime description" {
+		t.Fatalf("Catalog.Description = %q, want %q", cat.Description, "Runtime description")
+	}
+	if len(cat.Operations) != 1 {
+		t.Fatalf("len(Catalog.Operations) = %d, want %d", len(cat.Operations), 1)
+	}
+	if cat.Operations[0].ID != "list_users" {
+		t.Fatalf("Catalog.Operations[0].ID = %q, want %q", cat.Operations[0].ID, "list_users")
+	}
+	if cat.Operations[0].Description != "List only active users" {
+		t.Fatalf("Catalog.Operations[0].Description = %q, want %q", cat.Operations[0].Description, "List only active users")
+	}
+}
+
+func writePreparedDefinition(t *testing.T, def provider.Definition) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prepared.json")
+	data, err := json.Marshal(def)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}


### PR DESCRIPTION
## Summary
- add a compiler boundary package that owns `prepared artifact or remote spec -> definition/catalog`
- move REST/GraphQL provider compilation out of `cmd/gestaltd` orchestration and into that boundary
- keep `cmd/gestaltd` as thin adapters over the compiler boundary

## Testing
- go test ./internal/openapi ./internal/graphql ./internal/provider ./core/catalog ./core/integration
- go test ./cmd/gestaltd -run 'Test(PrepareConfig|LoadConfigForExecution|ValidatePrefersPreparedProviders)'