### PR TITLE
Fix egress credential grant precedence and validation

### DIFF
--- a/internal/bootstrap/egress.go
+++ b/internal/bootstrap/egress.go
@@ -71,6 +71,16 @@ func (a *denyRuleStoreAdapter) LoadDenyRules(ctx context.Context) ([]egress.Deny
 func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, providers *registry.PluginMap[core.Provider], ds core.Datastore, sm core.SecretManager) {
 	var sources []egress.CredentialResolver
 
+	// Saved grants first: control-plane overlay takes precedence over config defaults.
+	if grantStore, ok := ds.(core.EgressCredentialGrantStore); ok {
+		sources = append(sources, &egress.SavedGrantCredentialResolver{
+			Store:          &credentialGrantStoreAdapter{store: grantStore},
+			TokenResolver:  &brokerTokenResolver{broker: broker},
+			Materializer:   &registryMaterializer{providers: providers},
+			SecretResolver: sm,
+		})
+	}
+
 	if len(deps.CredentialGrants) > 0 {
 		grants := make([]egress.CredentialGrant, len(deps.CredentialGrants))
 		for i := range deps.CredentialGrants {
@@ -95,15 +105,6 @@ func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, provide
 			Materializer:   &registryMaterializer{providers: providers},
 			SecretResolver: sm,
 			Grants:         grants,
-		})
-	}
-
-	if grantStore, ok := ds.(core.EgressCredentialGrantStore); ok {
-		sources = append(sources, &egress.SavedGrantCredentialResolver{
-			Store:          &credentialGrantStoreAdapter{store: grantStore},
-			TokenResolver:  &brokerTokenResolver{broker: broker},
-			Materializer:   &registryMaterializer{providers: providers},
-			SecretResolver: sm,
 		})
 	}
 

--- a/internal/bootstrap/regression_test.go
+++ b/internal/bootstrap/regression_test.go
@@ -2,6 +2,7 @@ package bootstrap_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -664,5 +665,246 @@ func TestSecretBackedGrant_SecretURIPrefixStripped(t *testing.T) {
 	const wantAuth = "Bearer " + secretValue
 	if resolution.Credential.Authorization != wantAuth {
 		t.Fatalf("got Authorization %q, want %q", resolution.Credential.Authorization, wantAuth)
+	}
+}
+
+func TestSavedGrantOverridesConfigGrant(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const (
+		configSecret = "config-key"
+		savedSecret  = "saved-key"
+		targetHost   = "api.precedence.test"
+	)
+
+	cfg := validConfig()
+	cfg.Egress = config.EgressConfig{
+		Credentials: []config.EgressCredentialGrant{
+			{Host: targetHost, SecretRef: configSecret, AuthStyle: "raw"},
+		},
+	}
+	cfg.Bindings = map[string]config.BindingDef{
+		"my-binding": {Type: "test-binding"},
+	}
+
+	factories := validFactories()
+	factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+		return &coretesting.StubSecretManager{
+			Secrets: map[string]string{
+				configSecret: "val-from-config",
+				savedSecret:  "val-from-saved",
+			},
+		}, nil
+	}
+	factories.Datastores["test-store"] = func(_ yaml.Node, _ bootstrap.Deps) (core.Datastore, error) {
+		return &coretesting.StubDatastore{
+			ListEgressCredentialGrantsFn: func(_ context.Context, _ core.EgressCredentialGrantFilter) ([]*core.EgressCredentialGrant, error) {
+				return []*core.EgressCredentialGrant{
+					{ID: "ecg-saved", Host: targetHost, SecretRef: savedSecret, AuthStyle: "raw"},
+				}, nil
+			},
+		}, nil
+	}
+
+	var receivedEgress bootstrap.EgressDeps
+	factories.Bindings["test-binding"] = func(_ context.Context, name string, _ config.BindingDef, deps bootstrap.BindingDeps) (core.Binding, error) {
+		receivedEgress = deps.Egress
+		return &coretesting.StubBinding{N: name}, nil
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	agentCtx := egress.WithSubject(ctx, egress.Subject{Kind: egress.SubjectAgent, ID: "ec-agent-1"})
+	resolution, err := receivedEgress.Resolver.Resolve(agentCtx, egress.ResolutionInput{
+		Target: egress.Target{Method: "GET", Host: targetHost, Path: "/v1"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if resolution.Credential.Authorization != "val-from-saved" {
+		t.Fatalf("expected saved grant to win, got Authorization %q", resolution.Credential.Authorization)
+	}
+}
+
+func TestConfigGrantFallbackWhenNoSavedGrantMatches(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const (
+		configSecret = "fallback-key"
+		targetHost   = "api.fallback.test"
+	)
+
+	cfg := validConfig()
+	cfg.Egress = config.EgressConfig{
+		Credentials: []config.EgressCredentialGrant{
+			{Host: targetHost, SecretRef: configSecret, AuthStyle: "raw"},
+		},
+	}
+	cfg.Bindings = map[string]config.BindingDef{
+		"my-binding": {Type: "test-binding"},
+	}
+
+	factories := validFactories()
+	factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+		return &coretesting.StubSecretManager{
+			Secrets: map[string]string{configSecret: "val-from-config"},
+		}, nil
+	}
+	factories.Datastores["test-store"] = func(_ yaml.Node, _ bootstrap.Deps) (core.Datastore, error) {
+		return &coretesting.StubDatastore{
+			ListEgressCredentialGrantsFn: func(_ context.Context, _ core.EgressCredentialGrantFilter) ([]*core.EgressCredentialGrant, error) {
+				return []*core.EgressCredentialGrant{
+					{ID: "ecg-other", Host: "other.host.test", SecretRef: "other-key", AuthStyle: "raw"},
+				}, nil
+			},
+		}, nil
+	}
+
+	var receivedEgress bootstrap.EgressDeps
+	factories.Bindings["test-binding"] = func(_ context.Context, name string, _ config.BindingDef, deps bootstrap.BindingDeps) (core.Binding, error) {
+		receivedEgress = deps.Egress
+		return &coretesting.StubBinding{N: name}, nil
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	agentCtx := egress.WithSubject(ctx, egress.Subject{Kind: egress.SubjectAgent, ID: "ec-agent-1"})
+	resolution, err := receivedEgress.Resolver.Resolve(agentCtx, egress.ResolutionInput{
+		Target: egress.Target{Method: "GET", Host: targetHost, Path: "/v1"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if resolution.Credential.Authorization != "val-from-config" {
+		t.Fatalf("expected config grant fallback, got Authorization %q", resolution.Credential.Authorization)
+	}
+}
+
+func TestSavedGrantStoreErrorBlocksConfigFallback(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const targetHost = "api.storeerr.test"
+
+	cfg := validConfig()
+	cfg.Egress = config.EgressConfig{
+		Credentials: []config.EgressCredentialGrant{
+			{Host: targetHost, SecretRef: "config-key", AuthStyle: "raw"},
+		},
+	}
+	cfg.Bindings = map[string]config.BindingDef{
+		"my-binding": {Type: "test-binding"},
+	}
+
+	factories := validFactories()
+	factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+		return &coretesting.StubSecretManager{
+			Secrets: map[string]string{"config-key": "val-from-config"},
+		}, nil
+	}
+	storeErr := fmt.Errorf("datastore unavailable")
+	factories.Datastores["test-store"] = func(_ yaml.Node, _ bootstrap.Deps) (core.Datastore, error) {
+		return &coretesting.StubDatastore{
+			ListEgressCredentialGrantsFn: func(_ context.Context, _ core.EgressCredentialGrantFilter) ([]*core.EgressCredentialGrant, error) {
+				return nil, storeErr
+			},
+		}, nil
+	}
+
+	var receivedEgress bootstrap.EgressDeps
+	factories.Bindings["test-binding"] = func(_ context.Context, name string, _ config.BindingDef, deps bootstrap.BindingDeps) (core.Binding, error) {
+		receivedEgress = deps.Egress
+		return &coretesting.StubBinding{N: name}, nil
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	agentCtx := egress.WithSubject(ctx, egress.Subject{Kind: egress.SubjectAgent, ID: "ec-agent-1"})
+	_, err = receivedEgress.Resolver.Resolve(agentCtx, egress.ResolutionInput{
+		Target: egress.Target{Method: "GET", Host: targetHost, Path: "/v1"},
+	})
+	if err == nil {
+		t.Fatal("expected store error to propagate, got nil")
+	}
+	if !strings.Contains(err.Error(), "datastore unavailable") {
+		t.Fatalf("expected store error in message, got: %v", err)
+	}
+}
+
+func TestInvalidSavedGrantAuthStyleBlocksConfigFallback(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const (
+		targetHost  = "api.badstyle.test"
+		savedSecret = "saved-key"
+	)
+
+	cfg := validConfig()
+	cfg.Egress = config.EgressConfig{
+		Credentials: []config.EgressCredentialGrant{
+			{Host: targetHost, SecretRef: "config-key", AuthStyle: "raw"},
+		},
+	}
+	cfg.Bindings = map[string]config.BindingDef{
+		"my-binding": {Type: "test-binding"},
+	}
+
+	factories := validFactories()
+	factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+		return &coretesting.StubSecretManager{
+			Secrets: map[string]string{
+				"config-key": "val-from-config",
+				savedSecret:  "val-from-saved",
+			},
+		}, nil
+	}
+	factories.Datastores["test-store"] = func(_ yaml.Node, _ bootstrap.Deps) (core.Datastore, error) {
+		return &coretesting.StubDatastore{
+			ListEgressCredentialGrantsFn: func(_ context.Context, _ core.EgressCredentialGrantFilter) ([]*core.EgressCredentialGrant, error) {
+				return []*core.EgressCredentialGrant{
+					{ID: "ecg-bad", Host: targetHost, SecretRef: savedSecret, AuthStyle: "oauth2"},
+				}, nil
+			},
+		}, nil
+	}
+
+	var receivedEgress bootstrap.EgressDeps
+	factories.Bindings["test-binding"] = func(_ context.Context, name string, _ config.BindingDef, deps bootstrap.BindingDeps) (core.Binding, error) {
+		receivedEgress = deps.Egress
+		return &coretesting.StubBinding{N: name}, nil
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	agentCtx := egress.WithSubject(ctx, egress.Subject{Kind: egress.SubjectAgent, ID: "ec-agent-1"})
+	_, err = receivedEgress.Resolver.Resolve(agentCtx, egress.ResolutionInput{
+		Target: egress.Target{Method: "GET", Host: targetHost, Path: "/v1"},
+	})
+	if err == nil {
+		t.Fatal("expected invalid auth_style error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown auth style") {
+		t.Fatalf("expected auth style error, got: %v", err)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/valon-technologies/gestalt/internal/egress"
 	"gopkg.in/yaml.v3"
 )
 
@@ -628,12 +629,19 @@ func validateEgress(cfg *EgressConfig) error {
 		}
 	}
 	for i := range cfg.Credentials {
-		if style := cfg.Credentials[i].AuthStyle; style != "" {
-			switch style {
-			case "bearer", "raw", "basic", "none":
-			default:
-				return fmt.Errorf("config validation: egress.credentials[%d].auth_style must be one of \"bearer\", \"raw\", \"basic\", \"none\", got %q", i, style)
-			}
+		c := &cfg.Credentials[i]
+		if err := egress.ValidateCredentialGrant(egress.CredentialGrantValidationInput{
+			SubjectKind: c.SubjectKind,
+			SubjectID:   c.SubjectID,
+			Provider:    c.Provider,
+			Instance:    c.Instance,
+			Operation:   c.Operation,
+			Method:      c.Method,
+			Host:        c.Host,
+			PathPrefix:  c.PathPrefix,
+			AuthStyle:   c.AuthStyle,
+		}); err != nil {
+			return fmt.Errorf("config validation: egress.credentials[%d]: %w", i, err)
 		}
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -757,6 +757,38 @@ egress:
 `,
 		},
 		{
+			name: "egress credential with no match criterion rejected",
+			yaml: `
+auth:
+  provider: auth-provider
+datastore:
+  provider: data-store
+server:
+  encryption_key: server-key
+egress:
+  credentials:
+    - secret_ref: vendor-key
+      auth_style: bearer
+`,
+			wantErr: true,
+		},
+		{
+			name: "egress credential with only instance rejected",
+			yaml: `
+auth:
+  provider: auth-provider
+datastore:
+  provider: data-store
+server:
+  encryption_key: server-key
+egress:
+  credentials:
+    - instance: vendor-prod
+      secret_ref: vendor-key
+`,
+			wantErr: true,
+		},
+		{
 			name: "egress credential invalid auth_style rejected",
 			yaml: `
 auth:

--- a/internal/egress/credential_grant_validation.go
+++ b/internal/egress/credential_grant_validation.go
@@ -1,0 +1,37 @@
+package egress
+
+import "fmt"
+
+type CredentialGrantValidationInput struct {
+	SubjectKind string
+	SubjectID   string
+	Provider    string
+	Instance    string
+	Operation   string
+	Method      string
+	Host        string
+	PathPrefix  string
+	AuthStyle   string
+}
+
+// ValidateCredentialGrant checks that a credential grant has at least one match
+// criterion and a valid auth_style. Instance is not a match criterion because it
+// only affects provider-token resolution, not request matching.
+func ValidateCredentialGrant(g CredentialGrantValidationInput) error {
+	if g.SubjectKind == "" && g.SubjectID == "" && g.Provider == "" &&
+		g.Operation == "" && g.Method == "" &&
+		g.Host == "" && g.PathPrefix == "" {
+		return fmt.Errorf("at least one match criterion is required")
+	}
+	if g.AuthStyle != "" {
+		switch AuthStyle(g.AuthStyle) {
+		case AuthStyleBearer, AuthStyleRaw, AuthStyleBasic, AuthStyleNone:
+		default:
+			return fmt.Errorf(
+				"auth_style must be one of %q, %q, %q, %q, got %q",
+				AuthStyleBearer, AuthStyleRaw, AuthStyleBasic, AuthStyleNone, g.AuthStyle,
+			)
+		}
+	}
+	return nil
+}

--- a/internal/egress/credential_grant_validation_test.go
+++ b/internal/egress/credential_grant_validation_test.go
@@ -1,0 +1,110 @@
+package egress
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateCredentialGrant_RequiresMatchCriterion(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateCredentialGrant(CredentialGrantValidationInput{})
+	if err == nil {
+		t.Fatal("expected error for empty input")
+	}
+	if !strings.Contains(err.Error(), "at least one match criterion") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateCredentialGrant_InstanceOnlyIsNotSufficient(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateCredentialGrant(CredentialGrantValidationInput{
+		Instance: "vendor-prod",
+	})
+	if err == nil {
+		t.Fatal("expected error when only instance is set")
+	}
+	if !strings.Contains(err.Error(), "at least one match criterion") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateCredentialGrant_EachMatchCriterionSufficient(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input CredentialGrantValidationInput
+	}{
+		{"subject_kind", CredentialGrantValidationInput{SubjectKind: "agent"}},
+		{"subject_id", CredentialGrantValidationInput{SubjectID: "agent-1"}},
+		{"provider", CredentialGrantValidationInput{Provider: "vendorx"}},
+		{"operation", CredentialGrantValidationInput{Operation: "chat"}},
+		{"method", CredentialGrantValidationInput{Method: "POST"}},
+		{"host", CredentialGrantValidationInput{Host: "api.vendor.test"}},
+		{"path_prefix", CredentialGrantValidationInput{PathPrefix: "/v1"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if err := ValidateCredentialGrant(tc.input); err != nil {
+				t.Fatalf("expected no error for %s, got: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+func TestValidateCredentialGrant_AuthStyleValidation(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{"bearer", "raw", "basic", "none", ""}
+	for _, style := range valid {
+		t.Run("valid_"+style, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateCredentialGrant(CredentialGrantValidationInput{
+				Host:      "api.vendor.test",
+				AuthStyle: style,
+			})
+			if err != nil {
+				t.Fatalf("expected no error for auth_style %q, got: %v", style, err)
+			}
+		})
+	}
+
+	invalid := []string{"oauth2", "BEARER", "Bearer", "token"}
+	for _, style := range invalid {
+		t.Run("invalid_"+style, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateCredentialGrant(CredentialGrantValidationInput{
+				Host:      "api.vendor.test",
+				AuthStyle: style,
+			})
+			if err == nil {
+				t.Fatalf("expected error for auth_style %q", style)
+			}
+			if !strings.Contains(err.Error(), "auth_style must be one of") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateCredentialGrant_InvalidAuthStyleWithValidCriterion(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateCredentialGrant(CredentialGrantValidationInput{
+		Host:      "api.vendor.test",
+		AuthStyle: "oauth2",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "auth_style") {
+		t.Fatalf("expected auth_style error, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "match criterion") {
+		t.Fatalf("should not report match criterion error when host is set: %v", err)
+	}
+}

--- a/internal/server/egress_credential_grants.go
+++ b/internal/server/egress_credential_grants.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/egress"
 )
 
 func (s *Server) egressCredentialGrantStore() (core.EgressCredentialGrantStore, error) {
@@ -87,9 +88,18 @@ func (s *Server) createEgressCredentialGrant(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	if req.Provider == "" && req.Host == "" && req.SubjectKind == "" && req.SubjectID == "" &&
-		req.Operation == "" && req.Method == "" && req.PathPrefix == "" && req.Instance == "" {
-		writeError(w, http.StatusBadRequest, "at least one match criterion is required")
+	if err := egress.ValidateCredentialGrant(egress.CredentialGrantValidationInput{
+		SubjectKind: req.SubjectKind,
+		SubjectID:   req.SubjectID,
+		Provider:    req.Provider,
+		Instance:    req.Instance,
+		Operation:   req.Operation,
+		Method:      req.Method,
+		Host:        req.Host,
+		PathPrefix:  req.PathPrefix,
+		AuthStyle:   req.AuthStyle,
+	}); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -5284,6 +5284,68 @@ func TestAdminCredentialGrants_RequiresMatchCriterion(t *testing.T) {
 	}
 }
 
+func TestAdminCredentialGrants_RejectsInvalidAuthStyle(t *testing.T) {
+	t.Parallel()
+
+	const adminEmail = "admin@testcorp.example"
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.AdminEmails = []string{adminEmail}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u-admin", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"host":"api.vendor.test","auth_style":"oauth2"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/egress/credential-grants", body)
+	req.Header.Set("X-Dev-User-Email", adminEmail)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid auth_style, got %d", resp.StatusCode)
+	}
+}
+
+func TestAdminCredentialGrants_InstanceOnlyRejected(t *testing.T) {
+	t.Parallel()
+
+	const adminEmail = "admin@testcorp.example"
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.AdminEmails = []string{adminEmail}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u-admin", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"instance":"vendor-prod","secret_ref":"vendor-key"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/egress/credential-grants", body)
+	req.Header.Set("X-Dev-User-Email", adminEmail)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for instance-only grant, got %d", resp.StatusCode)
+	}
+}
+
 func TestAdminCredentialGrants_ListFilterByProvider(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Saved grants are now evaluated before config grants, making them the
control-plane overlay rather than an unreachable backfill. Both config
loading and the admin API now share a single `ValidateCredentialGrant`
helper that rejects grants with no match criterion and grants with an
invalid `auth_style`. This closes the gap where empty config grants
silently matched everything and the API accepted arbitrary auth_style
strings that would fail at request time.

The precedence change is intentionally fail-closed: a saved-grant store
error or a corrupt persisted grant blocks config-grant fallback rather
than silently serving stale credentials. Operators should audit existing
`egress_credential_grants` rows for invalid `auth_style` values before
deploying this change.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>