### PR TITLE
Thin top-level composition and demote faux-public integration surface

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -14,12 +14,12 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/crypto"
-	ci "github.com/valon-technologies/gestalt/core/integration"
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/internal/composite"
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/mcpoauth"
 	"github.com/valon-technologies/gestalt/internal/mcpupstream"
+	"github.com/valon-technologies/gestalt/internal/oauth"
 	"github.com/valon-technologies/gestalt/internal/provider"
 	providercompiler "github.com/valon-technologies/gestalt/internal/provider/compiler"
 	"github.com/valon-technologies/gestalt/plugins/auth/google"
@@ -85,10 +85,9 @@ func setupBootstrap(configFlag string, locked bool) (*bootstrapEnv, error) {
 
 func (e *bootstrapEnv) Close() {
 	e.Stop()
-	_ = e.Result.Datastore.Close()
-	if closer, ok := e.Result.SecretManager.(interface{ Close() error }); ok {
-		_ = closer.Close()
-	}
+	ctx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
+	defer cancel()
+	_ = e.Result.Close(ctx)
 }
 
 func buildFactories(preparedProviders map[string]string, devMode bool) *bootstrap.FactoryRegistry {
@@ -148,72 +147,6 @@ func logDatastoreWarnings(ds core.Datastore) {
 }
 
 const gracefulShutdownTimeout = 15 * time.Second
-
-func startPlugins(env *bootstrapEnv) error {
-	result := env.Result
-	if result.Runtimes != nil {
-		var started []string
-		for _, name := range result.Runtimes.List() {
-			rt, err := result.Runtimes.Get(name)
-			if err != nil {
-				return fmt.Errorf("getting runtime %q: %v", name, err)
-			}
-			if err := rt.Start(env.Ctx); err != nil {
-				if stopErr := bootstrap.StopRuntimes(env.Ctx, result.Runtimes, started); stopErr != nil {
-					log.Printf("stopping runtimes after startup failure: %v", stopErr)
-				}
-				return fmt.Errorf("starting runtime %q: %v", name, err)
-			}
-			started = append(started, name)
-		}
-	}
-	if result.Bindings != nil {
-		var started []string
-		for _, name := range result.Bindings.List() {
-			binding, err := result.Bindings.Get(name)
-			if err != nil {
-				if closeErr := bootstrap.CloseBindings(result.Bindings, started); closeErr != nil {
-					log.Printf("closing bindings after startup failure: %v", closeErr)
-				}
-				if result.Runtimes != nil {
-					if stopErr := bootstrap.StopRuntimes(env.Ctx, result.Runtimes, result.Runtimes.List()); stopErr != nil {
-						log.Printf("stopping runtimes after startup failure: %v", stopErr)
-					}
-				}
-				return fmt.Errorf("getting binding %q: %v", name, err)
-			}
-			if err := binding.Start(env.Ctx); err != nil {
-				if closeErr := bootstrap.CloseBindings(result.Bindings, started); closeErr != nil {
-					log.Printf("closing bindings after startup failure: %v", closeErr)
-				}
-				if result.Runtimes != nil {
-					if stopErr := bootstrap.StopRuntimes(env.Ctx, result.Runtimes, result.Runtimes.List()); stopErr != nil {
-						log.Printf("stopping runtimes after startup failure: %v", stopErr)
-					}
-				}
-				return fmt.Errorf("starting binding %q: %v", name, err)
-			}
-			started = append(started, name)
-		}
-	}
-	return nil
-}
-
-func shutdownPlugins(ctx context.Context, env *bootstrapEnv) {
-	if env.Result.Bindings != nil {
-		if err := bootstrap.CloseBindings(env.Result.Bindings, env.Result.Bindings.List()); err != nil {
-			log.Printf("closing bindings: %v", err)
-		}
-	}
-	if env.Result.Runtimes != nil {
-		if err := bootstrap.StopRuntimes(ctx, env.Result.Runtimes, env.Result.Runtimes.List()); err != nil {
-			log.Printf("stopping runtimes: %v", err)
-		}
-	}
-	if err := bootstrap.CloseProviders(env.Result.Providers); err != nil {
-		log.Printf("closing providers: %v", err)
-	}
-}
 
 func defaultProviderFactory(preparedProviders map[string]string) bootstrap.ProviderFactory {
 	var regStoreOnce sync.Once
@@ -350,15 +283,81 @@ func buildMCPOAuthProvider(name string, intg config.IntegrationDef, us config.Up
 		connMode = core.ConnectionMode(intg.ConnectionMode)
 	}
 
-	baseProv := &ci.Base{
-		IntegrationName:    name,
-		IntegrationDisplay: intg.DisplayName,
-		IntegrationDesc:    intg.Description,
-		ConnMode:           connMode,
-		Auth:               handler,
-		ManualAuthEnabled:  true,
-		EgressResolver:     deps.Egress.Resolver,
+	baseProv := &mcpOAuthMetadataProvider{
+		name:        name,
+		displayName: intg.DisplayName,
+		description: intg.Description,
+		connMode:    connMode,
+		auth:        handler,
 	}
 
 	return composite.New(name, baseProv, mcpUp), nil
+}
+
+type mcpOAuthMetadataProvider struct {
+	name        string
+	displayName string
+	description string
+	connMode    core.ConnectionMode
+	auth        *mcpoauth.Handler
+}
+
+func (p *mcpOAuthMetadataProvider) Name() string        { return p.name }
+func (p *mcpOAuthMetadataProvider) DisplayName() string { return p.displayName }
+func (p *mcpOAuthMetadataProvider) Description() string { return p.description }
+func (p *mcpOAuthMetadataProvider) ListOperations() []core.Operation {
+	return nil
+}
+
+func (p *mcpOAuthMetadataProvider) ConnectionMode() core.ConnectionMode {
+	if p.connMode == "" {
+		return core.ConnectionModeUser
+	}
+	return p.connMode
+}
+
+func (p *mcpOAuthMetadataProvider) Execute(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
+	return nil, fmt.Errorf("integration %q does not expose executable api operations", p.name)
+}
+
+func (p *mcpOAuthMetadataProvider) SupportsManualAuth() bool { return true }
+
+func (p *mcpOAuthMetadataProvider) AuthTypes() []string {
+	return []string{"oauth", "manual"}
+}
+
+func (p *mcpOAuthMetadataProvider) AuthorizationURL(state string, scopes []string) string {
+	return p.auth.AuthorizationURL(state, scopes)
+}
+
+func (p *mcpOAuthMetadataProvider) StartOAuth(state string, scopes []string) (string, string) {
+	return p.auth.StartOAuth(state, scopes)
+}
+
+func (p *mcpOAuthMetadataProvider) StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string) {
+	return p.auth.StartOAuthWithOverride(authBaseURL, state, scopes)
+}
+
+func (p *mcpOAuthMetadataProvider) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	return p.auth.ExchangeCode(ctx, code)
+}
+
+func (p *mcpOAuthMetadataProvider) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error) {
+	return p.auth.ExchangeCodeWithVerifier(ctx, code, verifier, extraOpts...)
+}
+
+func (p *mcpOAuthMetadataProvider) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	return p.auth.RefreshToken(ctx, refreshToken)
+}
+
+func (p *mcpOAuthMetadataProvider) RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error) {
+	return p.auth.RefreshTokenWithURL(ctx, refreshToken, tokenURL)
+}
+
+func (p *mcpOAuthMetadataProvider) TokenURL() string {
+	return p.auth.TokenURL()
+}
+
+func (p *mcpOAuthMetadataProvider) AuthorizationBaseURL() string {
+	return p.auth.AuthorizationBaseURL()
 }

--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -103,31 +103,7 @@ func runServer(env *bootstrapEnv) error {
 
 	result := env.Result
 
-	var mcpProviders []string
-	mcpPrefixes := make(map[string]string)
-	includeREST := make(map[string]bool)
-	for name := range env.Config.Integrations {
-		intg := env.Config.Integrations[name]
-		hasMCP := false
-		apiMCP := false
-		for i := range intg.Upstreams {
-			us := &intg.Upstreams[i]
-			if us.Type == config.UpstreamTypeMCP {
-				hasMCP = true
-			}
-			if (us.Type == config.UpstreamTypeREST || us.Type == config.UpstreamTypeGraphQL) && us.MCP {
-				hasMCP = true
-				apiMCP = true
-			}
-		}
-		if hasMCP {
-			mcpProviders = append(mcpProviders, name)
-			includeREST[name] = apiMCP
-			if intg.MCPToolPrefix != "" {
-				mcpPrefixes[name] = intg.MCPToolPrefix
-			}
-		}
-	}
+	mcpSurface := buildMCPSurface(env.Config)
 
 	if env.Config.Server.BaseURL != "" {
 		log.Printf("gestaltd base URL: %s", env.Config.Server.BaseURL)
@@ -137,7 +113,7 @@ func runServer(env *bootstrapEnv) error {
 
 	var mcpSlot *lateHandler
 	var mcpHandler http.Handler
-	if len(mcpProviders) > 0 {
+	if mcpSurface.enabled() {
 		mcpSlot = &lateHandler{}
 		mcpHandler = mcpSlot
 	}
@@ -178,17 +154,11 @@ func runServer(env *bootstrapEnv) error {
 		}
 	}()
 
-	pluginsStarted := false
 	defer func() {
 		drainCtx, drainCancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
 		defer drainCancel()
 		if err := httpServer.Shutdown(drainCtx); err != nil {
 			log.Printf("server shutdown: %v", err)
-		}
-		if pluginsStarted {
-			pluginCtx, pluginCancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
-			defer pluginCancel()
-			shutdownPlugins(pluginCtx, env)
 		}
 	}()
 
@@ -201,28 +171,16 @@ func runServer(env *bootstrapEnv) error {
 		return nil
 	}
 
-	if err := startPlugins(env); err != nil {
+	if err := result.Start(env.Ctx); err != nil {
 		return err
 	}
-	pluginsStarted = true
 
 	if mcpSlot != nil {
-		broker, ok := result.Invoker.(*invocation.Broker)
-		if !ok {
-			return fmt.Errorf("MCP token resolution requires *invocation.Broker as invoker")
+		handler, err := mcpSurface.handler(result)
+		if err != nil {
+			return err
 		}
-		mcpCfg := gestaltmcp.Config{
-			Invoker:          result.Invoker,
-			TokenResolver:    broker,
-			Providers:        result.Providers,
-			AllowedProviders: mcpProviders,
-			ToolPrefixes:     mcpPrefixes,
-			IncludeREST:      includeREST,
-		}
-		mcpSlot.Set(mcpserver.NewStreamableHTTPServer(
-			gestaltmcp.NewServer(mcpCfg),
-			mcpserver.WithStateLess(true),
-		))
+		mcpSlot.Set(handler)
 		log.Println("MCP endpoint enabled at /mcp")
 	}
 
@@ -233,6 +191,67 @@ func runServer(env *bootstrapEnv) error {
 	}
 
 	return nil
+}
+
+type mcpSurface struct {
+	providers    []string
+	toolPrefixes map[string]string
+	includeREST  map[string]bool
+}
+
+func buildMCPSurface(cfg *config.Config) mcpSurface {
+	surface := mcpSurface{
+		toolPrefixes: make(map[string]string),
+		includeREST:  make(map[string]bool),
+	}
+
+	for name := range cfg.Integrations {
+		intg := cfg.Integrations[name]
+		hasMCP := false
+		apiMCP := false
+		for i := range intg.Upstreams {
+			us := &intg.Upstreams[i]
+			if us.Type == config.UpstreamTypeMCP {
+				hasMCP = true
+			}
+			if (us.Type == config.UpstreamTypeREST || us.Type == config.UpstreamTypeGraphQL) && us.MCP {
+				hasMCP = true
+				apiMCP = true
+			}
+		}
+		if !hasMCP {
+			continue
+		}
+		surface.providers = append(surface.providers, name)
+		surface.includeREST[name] = apiMCP
+		if intg.MCPToolPrefix != "" {
+			surface.toolPrefixes[name] = intg.MCPToolPrefix
+		}
+	}
+
+	return surface
+}
+
+func (s mcpSurface) enabled() bool {
+	return len(s.providers) > 0
+}
+
+func (s mcpSurface) handler(result *bootstrap.Result) (http.Handler, error) {
+	broker, ok := result.Invoker.(*invocation.Broker)
+	if !ok {
+		return nil, fmt.Errorf("MCP token resolution requires *invocation.Broker as invoker")
+	}
+	return mcpserver.NewStreamableHTTPServer(
+		gestaltmcp.NewServer(gestaltmcp.Config{
+			Invoker:          result.Invoker,
+			TokenResolver:    broker,
+			Providers:        result.Providers,
+			AllowedProviders: s.providers,
+			ToolPrefixes:     s.toolPrefixes,
+			IncludeREST:      s.includeREST,
+		}),
+		mcpserver.WithStateLess(true),
+	), nil
 }
 
 func runValidate(args []string) error {

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -68,10 +68,23 @@ type Result struct {
 	SecretManager    core.SecretManager
 	Egress           EgressDeps
 	DevMode          bool
+
+	mu                sync.Mutex
+	extensionsStarted bool
+	closed            bool
 }
 
 func (r *Result) Start(ctx context.Context) error {
 	if r == nil {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return fmt.Errorf("bootstrap result already closed")
+	}
+	if r.extensionsStarted {
 		return nil
 	}
 	if err := startRuntimes(ctx, r.Runtimes); err != nil {
@@ -80,6 +93,7 @@ func (r *Result) Start(ctx context.Context) error {
 	if err := startBindings(ctx, r.Bindings, r.Runtimes); err != nil {
 		return err
 	}
+	r.extensionsStarted = true
 	return nil
 }
 
@@ -87,13 +101,28 @@ func (r *Result) Close(ctx context.Context) error {
 	if r == nil {
 		return nil
 	}
-	return errors.Join(
-		CloseBindings(r.Bindings, bindingNames(r.Bindings)),
-		StopRuntimes(ctx, r.Runtimes, runtimeNames(r.Runtimes)),
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return nil
+	}
+
+	var errs []error
+	if r.extensionsStarted {
+		errs = append(errs,
+			CloseBindings(r.Bindings, bindingNames(r.Bindings)),
+			StopRuntimes(ctx, r.Runtimes, runtimeNames(r.Runtimes)),
+		)
+		r.extensionsStarted = false
+	}
+	errs = append(errs,
 		CloseProviders(r.Providers),
 		closeDatastore(r.Datastore),
 		closeResultSecretManager(r.SecretManager),
 	)
+	r.closed = true
+	return errors.Join(errs...)
 }
 
 func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) (*Result, error) {
@@ -217,7 +246,6 @@ func startRuntimes(ctx context.Context, runtimes *registry.PluginMap[core.Runtim
 		if err := rt.Start(ctx); err != nil {
 			return errors.Join(
 				fmt.Errorf("starting runtime %q: %w", name, err),
-				stopRuntime(ctx, name, rt),
 				StopRuntimes(ctx, runtimes, started),
 			)
 		}
@@ -245,7 +273,6 @@ func startBindings(ctx context.Context, bindings *registry.PluginMap[core.Bindin
 		if err := binding.Start(ctx); err != nil {
 			return errors.Join(
 				fmt.Errorf("starting binding %q: %w", name, err),
-				closeBinding(name, binding),
 				CloseBindings(bindings, started),
 				StopRuntimes(ctx, runtimes, runtimeNames(runtimes)),
 			)
@@ -269,20 +296,6 @@ func closeResultSecretManager(sm core.SecretManager) error {
 		return nil
 	}
 	return closer.Close()
-}
-
-func stopRuntime(ctx context.Context, name string, rt core.Runtime) error {
-	if err := rt.Stop(ctx); err != nil {
-		return fmt.Errorf("stopping runtime %q: %w", name, err)
-	}
-	return nil
-}
-
-func closeBinding(name string, binding core.Binding) error {
-	if err := binding.Close(); err != nil {
-		return fmt.Errorf("closing binding %q: %w", name, err)
-	}
-	return nil
 }
 
 const secretPrefix = "secret://"

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -70,6 +70,32 @@ type Result struct {
 	DevMode          bool
 }
 
+func (r *Result) Start(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+	if err := startRuntimes(ctx, r.Runtimes); err != nil {
+		return err
+	}
+	if err := startBindings(ctx, r.Bindings, r.Runtimes); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *Result) Close(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+	return errors.Join(
+		CloseBindings(r.Bindings, bindingNames(r.Bindings)),
+		StopRuntimes(ctx, r.Runtimes, runtimeNames(r.Runtimes)),
+		CloseProviders(r.Providers),
+		closeDatastore(r.Datastore),
+		closeResultSecretManager(r.SecretManager),
+	)
+}
+
 func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) (*Result, error) {
 	sm, err := buildSecretManager(cfg, factories)
 	if err != nil {
@@ -172,6 +198,91 @@ func buildSecretManager(cfg *config.Config, factories *FactoryRegistry) (core.Se
 		return nil, fmt.Errorf("bootstrap: secrets provider %q: %w", cfg.Secrets.Provider, err)
 	}
 	return sm, nil
+}
+
+func startRuntimes(ctx context.Context, runtimes *registry.PluginMap[core.Runtime]) error {
+	if runtimes == nil {
+		return nil
+	}
+
+	var started []string
+	for _, name := range runtimeNames(runtimes) {
+		rt, err := runtimes.Get(name)
+		if err != nil {
+			return errors.Join(
+				fmt.Errorf("getting runtime %q: %w", name, err),
+				StopRuntimes(ctx, runtimes, started),
+			)
+		}
+		if err := rt.Start(ctx); err != nil {
+			return errors.Join(
+				fmt.Errorf("starting runtime %q: %w", name, err),
+				stopRuntime(ctx, name, rt),
+				StopRuntimes(ctx, runtimes, started),
+			)
+		}
+		started = append(started, name)
+	}
+
+	return nil
+}
+
+func startBindings(ctx context.Context, bindings *registry.PluginMap[core.Binding], runtimes *registry.PluginMap[core.Runtime]) error {
+	if bindings == nil {
+		return nil
+	}
+
+	var started []string
+	for _, name := range bindingNames(bindings) {
+		binding, err := bindings.Get(name)
+		if err != nil {
+			return errors.Join(
+				fmt.Errorf("getting binding %q: %w", name, err),
+				CloseBindings(bindings, started),
+				StopRuntimes(ctx, runtimes, runtimeNames(runtimes)),
+			)
+		}
+		if err := binding.Start(ctx); err != nil {
+			return errors.Join(
+				fmt.Errorf("starting binding %q: %w", name, err),
+				closeBinding(name, binding),
+				CloseBindings(bindings, started),
+				StopRuntimes(ctx, runtimes, runtimeNames(runtimes)),
+			)
+		}
+		started = append(started, name)
+	}
+
+	return nil
+}
+
+func closeDatastore(ds core.Datastore) error {
+	if ds == nil {
+		return nil
+	}
+	return ds.Close()
+}
+
+func closeResultSecretManager(sm core.SecretManager) error {
+	closer, ok := sm.(interface{ Close() error })
+	if !ok {
+		return nil
+	}
+	return closer.Close()
+}
+
+func stopRuntime(ctx context.Context, name string, rt core.Runtime) error {
+	if err := rt.Stop(ctx); err != nil {
+		return fmt.Errorf("stopping runtime %q: %w", name, err)
+	}
+	return nil
+}
+
+func closeBinding(name string, binding core.Binding) error {
+	if err := binding.Close(); err != nil {
+		return fmt.Errorf("closing binding %q: %w", name, err)
+	}
+	return nil
 }
 
 const secretPrefix = "secret://"

--- a/internal/bootstrap/result_boundary_test.go
+++ b/internal/bootstrap/result_boundary_test.go
@@ -82,44 +82,174 @@ func TestResultStart_StartsRuntimesBeforeBindings(t *testing.T) {
 	}
 }
 
-func TestResultStart_CleansUpFailedBindingAndStartedRuntimes(t *testing.T) {
+func TestResultStart_StopsStartedRuntimesWithoutStoppingFailedRuntime(t *testing.T) {
 	t.Parallel()
 
-	runtimeStopped := false
-	bindingClosed := false
+	startedRuntimeStopped := 0
+	failedRuntimeStopped := 0
 
 	result := &bootstrap.Result{
-		Runtimes: registryWithRuntime(t, "echo", &coretesting.StubRuntime{
-			N: "echo",
-			StopFn: func(context.Context) error {
-				runtimeStopped = true
-				return nil
+		Runtimes: registryWithRuntimes(t,
+			namedRuntime{
+				name: "alpha",
+				runtime: &coretesting.StubRuntime{
+					N: "alpha",
+					StopFn: func(context.Context) error {
+						startedRuntimeStopped++
+						return nil
+					},
+				},
 			},
-		}),
-		Bindings: registryWithBinding(t, "hook", &coretesting.StubBinding{
-			N: "hook",
-			StartFn: func(context.Context) error {
-				return errors.New("boom")
+			namedRuntime{
+				name: "beta",
+				runtime: &coretesting.StubRuntime{
+					N: "beta",
+					StartFn: func(context.Context) error {
+						return errors.New("boom")
+					},
+					StopFn: func(context.Context) error {
+						failedRuntimeStopped++
+						return nil
+					},
+				},
 			},
-			CloseFn: func() error {
-				bindingClosed = true
-				return nil
-			},
-		}),
+		),
 	}
 
 	err := result.Start(context.Background())
 	if err == nil {
 		t.Fatal("expected Start to fail")
 	}
-	if !strings.Contains(err.Error(), `starting binding "hook"`) {
+	if !strings.Contains(err.Error(), `starting runtime "beta"`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !bindingClosed {
-		t.Fatal("expected failed binding to be closed")
+	if startedRuntimeStopped != 1 {
+		t.Fatalf("started runtime Stop count = %d, want 1", startedRuntimeStopped)
 	}
-	if !runtimeStopped {
-		t.Fatal("expected started runtimes to be stopped")
+	if failedRuntimeStopped != 0 {
+		t.Fatalf("failed runtime Stop count = %d, want 0", failedRuntimeStopped)
+	}
+}
+
+func TestResultStart_CleansUpStartedBindingsWithoutClosingFailedBinding(t *testing.T) {
+	t.Parallel()
+
+	runtimeStopped := 0
+	startedBindingClosed := 0
+	failedBindingClosed := 0
+
+	result := &bootstrap.Result{
+		Runtimes: registryWithRuntime(t, "echo", &coretesting.StubRuntime{
+			N: "echo",
+			StopFn: func(context.Context) error {
+				runtimeStopped++
+				return nil
+			},
+		}),
+		Bindings: registryWithBindings(t,
+			namedBinding{
+				name: "alpha",
+				binding: &coretesting.StubBinding{
+					N: "alpha",
+					CloseFn: func() error {
+						startedBindingClosed++
+						return nil
+					},
+				},
+			},
+			namedBinding{
+				name: "beta",
+				binding: &coretesting.StubBinding{
+					N: "beta",
+					StartFn: func(context.Context) error {
+						return errors.New("boom")
+					},
+					CloseFn: func() error {
+						failedBindingClosed++
+						return nil
+					},
+				},
+			},
+		),
+	}
+
+	err := result.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected Start to fail")
+	}
+	if !strings.Contains(err.Error(), `starting binding "beta"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if startedBindingClosed != 1 {
+		t.Fatalf("started binding Close count = %d, want 1", startedBindingClosed)
+	}
+	if failedBindingClosed != 0 {
+		t.Fatalf("failed binding Close count = %d, want 0", failedBindingClosed)
+	}
+	if runtimeStopped != 1 {
+		t.Fatalf("runtime Stop count = %d, want 1", runtimeStopped)
+	}
+}
+
+func TestResultCloseAfterFailedStartDoesNotDoubleCleanUpExtensions(t *testing.T) {
+	t.Parallel()
+
+	runtimeStopped := 0
+	bindingClosed := 0
+	providerClosed := 0
+
+	result := &bootstrap.Result{
+		Runtimes: registryWithRuntime(t, "echo", &coretesting.StubRuntime{
+			N: "echo",
+			StopFn: func(context.Context) error {
+				runtimeStopped++
+				return nil
+			},
+		}),
+		Bindings: registryWithBindings(t,
+			namedBinding{
+				name: "alpha",
+				binding: &coretesting.StubBinding{
+					N: "alpha",
+					CloseFn: func() error {
+						bindingClosed++
+						return nil
+					},
+				},
+			},
+			namedBinding{
+				name: "beta",
+				binding: &coretesting.StubBinding{
+					N: "beta",
+					StartFn: func(context.Context) error {
+						return errors.New("boom")
+					},
+				},
+			},
+		),
+		Providers: registryWithProvider(t, "acme", &closableProvider{
+			StubIntegration: coretesting.StubIntegration{N: "acme"},
+			closeFn: func() error {
+				providerClosed++
+				return nil
+			},
+		}),
+	}
+
+	if err := result.Start(context.Background()); err == nil {
+		t.Fatal("expected Start to fail")
+	}
+	if err := result.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if runtimeStopped != 1 {
+		t.Fatalf("runtime Stop count = %d, want 1", runtimeStopped)
+	}
+	if bindingClosed != 1 {
+		t.Fatalf("binding Close count = %d, want 1", bindingClosed)
+	}
+	if providerClosed != 1 {
+		t.Fatalf("provider Close count = %d, want 1", providerClosed)
 	}
 }
 
@@ -168,6 +298,9 @@ func TestResultClose_ShutsDownConstructedResources(t *testing.T) {
 		},
 	}
 
+	if err := result.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
 	if err := result.Close(context.Background()); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
@@ -216,4 +349,38 @@ func registryWithBinding(t *testing.T, name string, binding core.Binding) *regis
 		t.Fatalf("Register binding %q: %v", name, err)
 	}
 	return bindings
+}
+
+type namedBinding struct {
+	name    string
+	binding core.Binding
+}
+
+func registryWithBindings(t *testing.T, bindingsList ...namedBinding) *registry.PluginMap[core.Binding] {
+	t.Helper()
+
+	bindings := registry.NewBindingMap()
+	for _, entry := range bindingsList {
+		if err := bindings.Register(entry.name, entry.binding); err != nil {
+			t.Fatalf("Register binding %q: %v", entry.name, err)
+		}
+	}
+	return bindings
+}
+
+type namedRuntime struct {
+	name    string
+	runtime core.Runtime
+}
+
+func registryWithRuntimes(t *testing.T, runtimesList ...namedRuntime) *registry.PluginMap[core.Runtime] {
+	t.Helper()
+
+	runtimes := registry.NewRuntimeMap()
+	for _, entry := range runtimesList {
+		if err := runtimes.Register(entry.name, entry.runtime); err != nil {
+			t.Fatalf("Register runtime %q: %v", entry.name, err)
+		}
+	}
+	return runtimes
 }

--- a/internal/bootstrap/result_boundary_test.go
+++ b/internal/bootstrap/result_boundary_test.go
@@ -1,0 +1,219 @@
+package bootstrap_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	coretesting "github.com/valon-technologies/gestalt/core/testing"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/registry"
+)
+
+type closableProvider struct {
+	coretesting.StubIntegration
+	closeFn func() error
+}
+
+func (p *closableProvider) Close() error {
+	if p.closeFn != nil {
+		return p.closeFn()
+	}
+	return nil
+}
+
+type closableDatastore struct {
+	coretesting.StubDatastore
+	closeFn func() error
+}
+
+func (d *closableDatastore) Close() error {
+	if d.closeFn != nil {
+		return d.closeFn()
+	}
+	return nil
+}
+
+type closableSecretManager struct {
+	coretesting.StubSecretManager
+	closeFn func() error
+}
+
+func (s *closableSecretManager) Close() error {
+	if s.closeFn != nil {
+		return s.closeFn()
+	}
+	return nil
+}
+
+func TestResultStart_StartsRuntimesBeforeBindings(t *testing.T) {
+	t.Parallel()
+
+	runtimeStarted := false
+	bindingSawRuntimeStarted := false
+
+	result := &bootstrap.Result{
+		Runtimes: registryWithRuntime(t, "echo", &coretesting.StubRuntime{
+			N: "echo",
+			StartFn: func(context.Context) error {
+				runtimeStarted = true
+				return nil
+			},
+		}),
+		Bindings: registryWithBinding(t, "hook", &coretesting.StubBinding{
+			N: "hook",
+			StartFn: func(context.Context) error {
+				bindingSawRuntimeStarted = runtimeStarted
+				return nil
+			},
+		}),
+	}
+
+	if err := result.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !runtimeStarted {
+		t.Fatal("expected Start to start runtimes")
+	}
+	if !bindingSawRuntimeStarted {
+		t.Fatal("expected bindings to start after runtimes")
+	}
+}
+
+func TestResultStart_CleansUpFailedBindingAndStartedRuntimes(t *testing.T) {
+	t.Parallel()
+
+	runtimeStopped := false
+	bindingClosed := false
+
+	result := &bootstrap.Result{
+		Runtimes: registryWithRuntime(t, "echo", &coretesting.StubRuntime{
+			N: "echo",
+			StopFn: func(context.Context) error {
+				runtimeStopped = true
+				return nil
+			},
+		}),
+		Bindings: registryWithBinding(t, "hook", &coretesting.StubBinding{
+			N: "hook",
+			StartFn: func(context.Context) error {
+				return errors.New("boom")
+			},
+			CloseFn: func() error {
+				bindingClosed = true
+				return nil
+			},
+		}),
+	}
+
+	err := result.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected Start to fail")
+	}
+	if !strings.Contains(err.Error(), `starting binding "hook"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bindingClosed {
+		t.Fatal("expected failed binding to be closed")
+	}
+	if !runtimeStopped {
+		t.Fatal("expected started runtimes to be stopped")
+	}
+}
+
+func TestResultClose_ShutsDownConstructedResources(t *testing.T) {
+	t.Parallel()
+
+	bindingClosed := false
+	runtimeStopped := false
+	providerClosed := false
+	datastoreClosed := false
+	secretManagerClosed := false
+
+	result := &bootstrap.Result{
+		Bindings: registryWithBinding(t, "hook", &coretesting.StubBinding{
+			N: "hook",
+			CloseFn: func() error {
+				bindingClosed = true
+				return nil
+			},
+		}),
+		Runtimes: registryWithRuntime(t, "echo", &coretesting.StubRuntime{
+			N: "echo",
+			StopFn: func(context.Context) error {
+				runtimeStopped = true
+				return nil
+			},
+		}),
+		Providers: registryWithProvider(t, "acme", &closableProvider{
+			StubIntegration: coretesting.StubIntegration{N: "acme"},
+			closeFn: func() error {
+				providerClosed = true
+				return nil
+			},
+		}),
+		Datastore: &closableDatastore{
+			closeFn: func() error {
+				datastoreClosed = true
+				return nil
+			},
+		},
+		SecretManager: &closableSecretManager{
+			closeFn: func() error {
+				secretManagerClosed = true
+				return nil
+			},
+		},
+	}
+
+	if err := result.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !bindingClosed {
+		t.Fatal("expected Close to close bindings")
+	}
+	if !runtimeStopped {
+		t.Fatal("expected Close to stop runtimes")
+	}
+	if !providerClosed {
+		t.Fatal("expected Close to close providers")
+	}
+	if !datastoreClosed {
+		t.Fatal("expected Close to close datastore")
+	}
+	if !secretManagerClosed {
+		t.Fatal("expected Close to close secret manager")
+	}
+}
+
+func registryWithProvider(t *testing.T, name string, provider core.Provider) *registry.PluginMap[core.Provider] {
+	t.Helper()
+
+	reg := registry.New()
+	if err := reg.Providers.Register(name, provider); err != nil {
+		t.Fatalf("Register provider %q: %v", name, err)
+	}
+	return &reg.Providers
+}
+
+func registryWithRuntime(t *testing.T, name string, runtime core.Runtime) *registry.PluginMap[core.Runtime] {
+	t.Helper()
+
+	runtimes := registry.NewRuntimeMap()
+	if err := runtimes.Register(name, runtime); err != nil {
+		t.Fatalf("Register runtime %q: %v", name, err)
+	}
+	return runtimes
+}
+
+func registryWithBinding(t *testing.T, name string, binding core.Binding) *registry.PluginMap[core.Binding] {
+	t.Helper()
+
+	bindings := registry.NewBindingMap()
+	if err := bindings.Register(name, binding); err != nil {
+		t.Fatalf("Register binding %q: %v", name, err)
+	}
+	return bindings
+}

--- a/internal/integration/api.go
+++ b/internal/integration/api.go
@@ -1,8 +1,6 @@
 package integration
 
 import (
-	"encoding/json"
-
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
 	coreintegration "github.com/valon-technologies/gestalt/core/integration"
@@ -31,10 +29,6 @@ func EndpointsMap(c *catalog.Catalog) (map[string]Endpoint, error) {
 
 func QueriesMap(c *catalog.Catalog) map[string]string {
 	return coreintegration.QueriesMap(c)
-}
-
-func SynthesizeInputSchema(params []catalog.CatalogParameter) json.RawMessage {
-	return coreintegration.SynthesizeInputSchema(params)
 }
 
 func NormalizeType(t string) string {

--- a/internal/integration/api.go
+++ b/internal/integration/api.go
@@ -1,0 +1,50 @@
+package integration
+
+import (
+	"encoding/json"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+	coreintegration "github.com/valon-technologies/gestalt/core/integration"
+)
+
+type AuthHandler = coreintegration.AuthHandler
+type UpstreamAuth = coreintegration.UpstreamAuth
+type Endpoint = coreintegration.Endpoint
+type AuthStyle = coreintegration.AuthStyle
+type Base = coreintegration.Base
+
+const (
+	AuthStyleBearer = coreintegration.AuthStyleBearer
+	AuthStyleRaw    = coreintegration.AuthStyleRaw
+	AuthStyleNone   = coreintegration.AuthStyleNone
+	AuthStyleBasic  = coreintegration.AuthStyleBasic
+)
+
+func OperationsList(c *catalog.Catalog) []core.Operation {
+	return coreintegration.OperationsList(c)
+}
+
+func EndpointsMap(c *catalog.Catalog) (map[string]Endpoint, error) {
+	return coreintegration.EndpointsMap(c)
+}
+
+func QueriesMap(c *catalog.Catalog) map[string]string {
+	return coreintegration.QueriesMap(c)
+}
+
+func SynthesizeInputSchema(params []catalog.CatalogParameter) json.RawMessage {
+	return coreintegration.SynthesizeInputSchema(params)
+}
+
+func NormalizeType(t string) string {
+	return coreintegration.NormalizeType(t)
+}
+
+func AnnotationsFromMethod(method string) catalog.OperationAnnotations {
+	return coreintegration.AnnotationsFromMethod(method)
+}
+
+func CompileSchemas(c *catalog.Catalog) {
+	coreintegration.CompileSchemas(c)
+}

--- a/internal/mcp/binding_test.go
+++ b/internal/mcp/binding_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
-	ci "github.com/valon-technologies/gestalt/core/integration"
 	coretesting "github.com/valon-technologies/gestalt/core/testing"
 	"github.com/valon-technologies/gestalt/internal/egress"
+	"github.com/valon-technologies/gestalt/internal/integration"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	gestaltmcp "github.com/valon-technologies/gestalt/internal/mcp"
 	"github.com/valon-technologies/gestalt/internal/mcpupstream"
@@ -207,7 +207,7 @@ func TestNewServer_ListsToolsFromCatalogProvider(t *testing.T) {
 
 	prov := &catalogProvider{
 		StubIntegration: coretesting.StubIntegration{N: "linear"},
-		ops:             ci.OperationsList(cat),
+		ops:             integration.OperationsList(cat),
 		catalog:         cat,
 	}
 
@@ -585,7 +585,7 @@ func TestNewServer_HiddenOperationsFiltered(t *testing.T) {
 
 	prov := &catalogProvider{
 		StubIntegration: coretesting.StubIntegration{N: "test"},
-		ops:             ci.OperationsList(cat),
+		ops:             integration.OperationsList(cat),
 		catalog:         cat,
 	}
 
@@ -1042,7 +1042,7 @@ func TestNewServer_IncludeRESTFiltering(t *testing.T) {
 
 			prov := &catalogProvider{
 				StubIntegration: coretesting.StubIntegration{N: "acme"},
-				ops:             ci.OperationsList(cat),
+				ops:             integration.OperationsList(cat),
 				catalog:         cat,
 			}
 

--- a/internal/mcp/composite_test.go
+++ b/internal/mcp/composite_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
-	ci "github.com/valon-technologies/gestalt/core/integration"
 	coretesting "github.com/valon-technologies/gestalt/core/testing"
 	"github.com/valon-technologies/gestalt/internal/composite"
+	"github.com/valon-technologies/gestalt/internal/integration"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	gestaltmcp "github.com/valon-technologies/gestalt/internal/mcp"
 	"github.com/valon-technologies/gestalt/internal/testutil"
@@ -57,7 +57,7 @@ func TestComposite_MCPPassthroughRouting(t *testing.T) {
 				return &core.OperationResult{Status: http.StatusOK, Body: `{"from":"api"}`}, nil
 			},
 		},
-		ops:     ci.OperationsList(apiCat),
+		ops:     integration.OperationsList(apiCat),
 		catalog: apiCat,
 	}
 
@@ -130,7 +130,7 @@ func TestComposite_MCPFromAPIExposesBothToolSets(t *testing.T) {
 				return &core.OperationResult{Status: http.StatusOK, Body: `{"from":"api"}`}, nil
 			},
 		},
-		ops:     ci.OperationsList(apiCat),
+		ops:     integration.OperationsList(apiCat),
 		catalog: apiCat,
 	}
 
@@ -210,7 +210,7 @@ func TestComposite_ExecuteDelegatesToAPI(t *testing.T) {
 				return &core.OperationResult{Status: http.StatusOK, Body: `{"id":"page1"}`}, nil
 			},
 		},
-		ops:     ci.OperationsList(apiCat),
+		ops:     integration.OperationsList(apiCat),
 		catalog: apiCat,
 	}
 
@@ -246,7 +246,7 @@ func TestComposite_IncludeRESTFalseExcludesAPITools(t *testing.T) {
 	}
 	apiProv := &catalogProvider{
 		StubIntegration: coretesting.StubIntegration{N: "alpha"},
-		ops:             ci.OperationsList(apiCat),
+		ops:             integration.OperationsList(apiCat),
 		catalog:         apiCat,
 	}
 

--- a/internal/mcp/projection.go
+++ b/internal/mcp/projection.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
-	ci "github.com/valon-technologies/gestalt/core/integration"
+	"github.com/valon-technologies/gestalt/internal/integration"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -23,7 +23,7 @@ func addFlatTools(srv *mcpserver.MCPServer, cfg Config, provName string, prov co
 		name := toolName(cfg.ToolPrefixes, provName, op.Name)
 
 		opts := []mcpgo.ToolOption{mcpgo.WithDescription(op.Description)}
-		annot := mapAnnotations(ci.AnnotationsFromMethod(op.Method))
+		annot := mapAnnotations(integration.AnnotationsFromMethod(op.Method))
 		annot.Title = op.Name
 		opts = append(opts, mcpgo.WithToolAnnotation(annot))
 
@@ -130,7 +130,7 @@ func buildPropertyOpts(param core.Parameter) []mcpgo.PropertyOption {
 }
 
 func paramToOption(param core.Parameter) mcpgo.ToolOption {
-	switch ci.NormalizeType(param.Type) {
+	switch integration.NormalizeType(param.Type) {
 	case "integer", "number":
 		return mcpgo.WithNumber(param.Name, buildPropertyOpts(param)...)
 	case "boolean":

--- a/internal/openapi/catalog.go
+++ b/internal/openapi/catalog.go
@@ -9,7 +9,7 @@ import (
 	highbase "github.com/pb33f/libopenapi/datamodel/high/base"
 	v3high "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/valon-technologies/gestalt/core/catalog"
-	ci "github.com/valon-technologies/gestalt/core/integration"
+	"github.com/valon-technologies/gestalt/internal/integration"
 
 	"github.com/pb33f/libopenapi"
 )
@@ -122,7 +122,7 @@ func catalogExtractOperations(model *v3high.Document, cat *catalog.Catalog, allo
 				Path:        path,
 				Title:       title,
 				Description: desc,
-				Annotations: ci.AnnotationsFromMethod(upperMethod),
+				Annotations: integration.AnnotationsFromMethod(upperMethod),
 			}
 
 			for _, p := range op.Parameters {

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/valon-technologies/gestalt/core"
-	ci "github.com/valon-technologies/gestalt/core/integration"
 	"github.com/valon-technologies/gestalt/internal/apiexec"
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/egress"
@@ -22,12 +21,12 @@ import (
 type BuildOption func(*buildOptions)
 
 type buildOptions struct {
-	authOverride ci.AuthHandler
+	authOverride integration.AuthHandler
 	egress       *egress.Resolver
 }
 
 // WithAuthHandler injects a pre-built auth handler, bypassing buildAuth.
-func WithAuthHandler(h ci.AuthHandler) BuildOption {
+func WithAuthHandler(h integration.AuthHandler) BuildOption {
 	return func(o *buildOptions) { o.authOverride = h }
 }
 
@@ -54,7 +53,7 @@ func Build(def *Definition, intg config.IntegrationDef, allowedOperations map[st
 
 	client := &http.Client{Timeout: 10 * time.Second}
 
-	var auth ci.AuthHandler
+	var auth integration.AuthHandler
 	var err error
 	if bo.authOverride != nil {
 		auth = bo.authOverride
@@ -67,23 +66,23 @@ func Build(def *Definition, intg config.IntegrationDef, allowedOperations map[st
 
 	cat := CatalogFromDefinition(def)
 	cat.BaseURL = baseURL
-	ci.CompileSchemas(cat)
+	integration.CompileSchemas(cat)
 
-	endpoints, err := ci.EndpointsMap(cat)
+	endpoints, err := integration.EndpointsMap(cat)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", def.Provider, err)
 	}
 
-	base := &ci.Base{
+	base := &integration.Base{
 		IntegrationName:    def.Provider,
 		IntegrationDisplay: def.DisplayName,
 		IntegrationDesc:    def.Description,
 		Auth:               auth,
 		BaseURL:            baseURL,
 		HTTPClient:         client,
-		Operations:         ci.OperationsList(cat),
+		Operations:         integration.OperationsList(cat),
 		Endpoints:          endpoints,
-		Queries:            ci.QueriesMap(cat),
+		Queries:            integration.QueriesMap(cat),
 		Headers:            def.Headers,
 		Pagination:         buildPaginationConfigs(def),
 		EgressResolver:     bo.egress,
@@ -105,11 +104,11 @@ func Build(def *Definition, intg config.IntegrationDef, allowedOperations map[st
 	switch def.AuthStyle {
 	case "", "bearer":
 	case "raw":
-		base.AuthStyle = ci.AuthStyleRaw
+		base.AuthStyle = integration.AuthStyleRaw
 	case "none":
-		base.AuthStyle = ci.AuthStyleNone
+		base.AuthStyle = integration.AuthStyleNone
 	case "basic":
-		base.AuthStyle = ci.AuthStyleBasic
+		base.AuthStyle = integration.AuthStyleBasic
 	default:
 		return nil, fmt.Errorf("%s: unknown auth_style %q", def.Provider, def.AuthStyle)
 	}
@@ -315,7 +314,7 @@ func setStr(dst *string, val string) {
 	}
 }
 
-func buildAuth(def *Definition, intg config.IntegrationDef, baseURL string, client *http.Client) (ci.AuthHandler, error) {
+func buildAuth(def *Definition, intg config.IntegrationDef, baseURL string, client *http.Client) (integration.AuthHandler, error) {
 	if def.Auth.Type == "manual" || (def.Auth.Type == "" && def.Auth.AuthorizationURL == "") {
 		return oauth.ManualAuthHandler{}, nil
 	}
@@ -376,7 +375,7 @@ func buildAuth(def *Definition, intg config.IntegrationDef, baseURL string, clie
 	}
 
 	upstream := oauth.NewUpstream(oauthCfg, opts...)
-	return ci.UpstreamAuth{Handler: upstream}, nil
+	return integration.UpstreamAuth{Handler: upstream}, nil
 }
 
 func buildResponseChecker(rcd *ResponseCheckDef) apiexec.ResponseChecker {


### PR DESCRIPTION
## Summary
- move extension/provider lifecycle into bootstrap result ownership
- thin gestaltd startup wiring and isolate MCP surface assembly
- route internal integration helpers through an internal seam instead of core/integration

## Testing
- go test ./internal/bootstrap
- go test ./cmd/gestaltd -run 'Test(E2E|LoadConfig|Validate|Prepare|Init)'
- go test ./internal/server ./internal/mcp ./internal/pluginapi ./internal/provider ./internal/bootstrap
- go test ./...