### PR TITLE
feat: scope-aware egress client API and authorization

### DIFF
--- a/core/datastore.go
+++ b/core/datastore.go
@@ -30,7 +30,8 @@ type StagedConnectionStore interface {
 }
 
 type EgressClientFilter struct {
-	CreatedByID string // if non-empty, filter by creator
+	CreatedByID string
+	Scope       string
 }
 
 type EgressClientStore interface {

--- a/core/testing/datastore_suite.go
+++ b/core/testing/datastore_suite.go
@@ -499,7 +499,7 @@ func testDatastoreStagedConnections(t *testing.T, newStore func(t *testing.T) co
 }
 
 func testDatastoreEgressClients(t *testing.T, newStore func(t *testing.T) core.Datastore) {
-	t.Run("create get and list lifecycle", func(t *testing.T) {
+	t.Run("create personal default and get", func(t *testing.T) {
 		ds := newStore(t)
 		t.Cleanup(func() { ds.Close() })
 
@@ -537,13 +537,37 @@ func testDatastoreEgressClients(t *testing.T, newStore func(t *testing.T) core.D
 		if got.CreatedByID != user.ID {
 			t.Errorf("CreatedByID: got %q, want %q", got.CreatedByID, user.ID)
 		}
-
-		clients, err := ecs.ListEgressClients(ctx, core.EgressClientFilter{CreatedByID: user.ID})
-		if err != nil {
-			t.Fatalf("ListEgressClients: %v", err)
+		if got.Scope != core.EgressClientScopePersonal {
+			t.Errorf("Scope: got %q, want %q", got.Scope, core.EgressClientScopePersonal)
 		}
-		if len(clients) != 1 {
-			t.Fatalf("ListEgressClients: got %d, want 1", len(clients))
+	})
+
+	t.Run("create global client", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecs, ok := ds.(core.EgressClientStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressClientStore")
+		}
+
+		ctx := context.Background()
+		user := mustCreateUser(t, ctx, ds, "egress-global@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-g1", Name: "shared-bot", Scope: core.EgressClientScopeGlobal,
+			CreatedByID: user.ID, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClient: %v", err)
+		}
+
+		got, err := ecs.GetEgressClient(ctx, "ec-g1")
+		if err != nil {
+			t.Fatalf("GetEgressClient: %v", err)
+		}
+		if got.Scope != core.EgressClientScopeGlobal {
+			t.Errorf("Scope: got %q, want %q", got.Scope, core.EgressClientScopeGlobal)
 		}
 	})
 
@@ -561,8 +585,8 @@ func testDatastoreEgressClients(t *testing.T, newStore func(t *testing.T) core.D
 		now := time.Now().Truncate(time.Second)
 
 		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
-			ID: "ec-del", Name: "deletable", CreatedByID: user.ID,
-			CreatedAt: now, UpdatedAt: now,
+			ID: "ec-del", Name: "deletable", Scope: core.EgressClientScopePersonal,
+			CreatedByID: user.ID, CreatedAt: now, UpdatedAt: now,
 		}); err != nil {
 			t.Fatalf("CreateEgressClient: %v", err)
 		}
@@ -593,7 +617,7 @@ func testDatastoreEgressClients(t *testing.T, newStore func(t *testing.T) core.D
 		}
 	})
 
-	t.Run("duplicate name for same user returns ErrAlreadyRegistered", func(t *testing.T) {
+	t.Run("duplicate personal name same creator returns ErrAlreadyRegistered", func(t *testing.T) {
 		ds := newStore(t)
 		t.Cleanup(func() { ds.Close() })
 
@@ -607,22 +631,22 @@ func testDatastoreEgressClients(t *testing.T, newStore func(t *testing.T) core.D
 		now := time.Now().Truncate(time.Second)
 
 		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
-			ID: "ec-dup-1", Name: "same-name", CreatedByID: user.ID,
-			CreatedAt: now, UpdatedAt: now,
+			ID: "ec-dup-1", Name: "same-name", Scope: core.EgressClientScopePersonal,
+			CreatedByID: user.ID, CreatedAt: now, UpdatedAt: now,
 		}); err != nil {
 			t.Fatalf("first CreateEgressClient: %v", err)
 		}
 
 		err := ecs.CreateEgressClient(ctx, &core.EgressClient{
-			ID: "ec-dup-2", Name: "same-name", CreatedByID: user.ID,
-			CreatedAt: now, UpdatedAt: now,
+			ID: "ec-dup-2", Name: "same-name", Scope: core.EgressClientScopePersonal,
+			CreatedByID: user.ID, CreatedAt: now, UpdatedAt: now,
 		})
 		if !errors.Is(err, core.ErrAlreadyRegistered) {
 			t.Fatalf("expected ErrAlreadyRegistered, got %v", err)
 		}
 	})
 
-	t.Run("same name allowed for different users and list is scoped", func(t *testing.T) {
+	t.Run("same personal name different creators allowed", func(t *testing.T) {
 		ds := newStore(t)
 		t.Cleanup(func() { ds.Close() })
 
@@ -637,40 +661,259 @@ func testDatastoreEgressClients(t *testing.T, newStore func(t *testing.T) core.D
 		now := time.Now().Truncate(time.Second)
 
 		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
-			ID: "ec-a", Name: "shared-name", CreatedByID: userA.ID,
-			CreatedAt: now, UpdatedAt: now,
+			ID: "ec-a", Name: "shared-name", Scope: core.EgressClientScopePersonal,
+			CreatedByID: userA.ID, CreatedAt: now, UpdatedAt: now,
 		}); err != nil {
 			t.Fatalf("CreateEgressClient userA: %v", err)
 		}
 		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
-			ID: "ec-b", Name: "shared-name", CreatedByID: userB.ID,
-			CreatedAt: now, UpdatedAt: now,
+			ID: "ec-b", Name: "shared-name", Scope: core.EgressClientScopePersonal,
+			CreatedByID: userB.ID, CreatedAt: now, UpdatedAt: now,
 		}); err != nil {
 			t.Fatalf("CreateEgressClient userB: %v", err)
 		}
+	})
 
-		clientsA, err := ecs.ListEgressClients(ctx, core.EgressClientFilter{CreatedByID: userA.ID})
-		if err != nil {
-			t.Fatalf("ListEgressClients userA: %v", err)
-		}
-		if len(clientsA) != 1 || clientsA[0].ID != "ec-a" {
-			t.Fatalf("ListEgressClients userA: got %+v, want only ec-a", clientsA)
-		}
+	t.Run("duplicate global name across creators returns ErrAlreadyRegistered", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
 
-		clientsB, err := ecs.ListEgressClients(ctx, core.EgressClientFilter{CreatedByID: userB.ID})
-		if err != nil {
-			t.Fatalf("ListEgressClients userB: %v", err)
-		}
-		if len(clientsB) != 1 || clientsB[0].ID != "ec-b" {
-			t.Fatalf("ListEgressClients userB: got %+v, want only ec-b", clientsB)
+		ecs, ok := ds.(core.EgressClientStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressClientStore")
 		}
 
-		all, err := ecs.ListEgressClients(ctx, core.EgressClientFilter{})
-		if err != nil {
-			t.Fatalf("ListEgressClients unfiltered: %v", err)
+		ctx := context.Background()
+		userA := mustCreateUser(t, ctx, ds, "egress-ga@example.com")
+		userB := mustCreateUser(t, ctx, ds, "egress-gb@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-g-a", Name: "global-bot", Scope: core.EgressClientScopeGlobal,
+			CreatedByID: userA.ID, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("first global CreateEgressClient: %v", err)
 		}
-		if len(all) != 2 {
-			t.Fatalf("ListEgressClients unfiltered: got %d, want 2", len(all))
+
+		err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-g-b", Name: "global-bot", Scope: core.EgressClientScopeGlobal,
+			CreatedByID: userB.ID, CreatedAt: now, UpdatedAt: now,
+		})
+		if !errors.Is(err, core.ErrAlreadyRegistered) {
+			t.Fatalf("expected ErrAlreadyRegistered, got %v", err)
+		}
+	})
+
+	t.Run("same name personal and global allowed for same creator", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecs, ok := ds.(core.EgressClientStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressClientStore")
+		}
+
+		ctx := context.Background()
+		user := mustCreateUser(t, ctx, ds, "egress-both@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-p", Name: "dual-name", Scope: core.EgressClientScopePersonal,
+			CreatedByID: user.ID, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("personal CreateEgressClient: %v", err)
+		}
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-g", Name: "dual-name", Scope: core.EgressClientScopeGlobal,
+			CreatedByID: user.ID, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("global CreateEgressClient: %v", err)
+		}
+
+		p, err := ecs.GetEgressClient(ctx, "ec-p")
+		if err != nil {
+			t.Fatalf("GetEgressClient personal: %v", err)
+		}
+		if p.Scope != core.EgressClientScopePersonal {
+			t.Errorf("personal Scope: got %q", p.Scope)
+		}
+
+		g, err := ecs.GetEgressClient(ctx, "ec-g")
+		if err != nil {
+			t.Fatalf("GetEgressClient global: %v", err)
+		}
+		if g.Scope != core.EgressClientScopeGlobal {
+			t.Errorf("global Scope: got %q", g.Scope)
+		}
+	})
+
+	t.Run("list filter by CreatedByID only", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecs, ok := ds.(core.EgressClientStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressClientStore")
+		}
+
+		ctx := context.Background()
+		userA := mustCreateUser(t, ctx, ds, "egress-la@example.com")
+		userB := mustCreateUser(t, ctx, ds, "egress-lb@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-la", Name: "bot-a", Scope: core.EgressClientScopePersonal,
+			CreatedByID: userA.ID, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClient A: %v", err)
+		}
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-lb", Name: "bot-b", Scope: core.EgressClientScopePersonal,
+			CreatedByID: userB.ID, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClient B: %v", err)
+		}
+
+		got, err := ecs.ListEgressClients(ctx, core.EgressClientFilter{CreatedByID: userA.ID})
+		if err != nil {
+			t.Fatalf("ListEgressClients: %v", err)
+		}
+		if len(got) != 1 || got[0].ID != "ec-la" {
+			t.Fatalf("ListEgressClients: got %d, want 1 (ec-la)", len(got))
+		}
+	})
+
+	t.Run("list filter by Scope only", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecs, ok := ds.(core.EgressClientStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressClientStore")
+		}
+
+		ctx := context.Background()
+		user := mustCreateUser(t, ctx, ds, "egress-ls@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-sp", Name: "personal-bot", Scope: core.EgressClientScopePersonal,
+			CreatedByID: user.ID, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClient personal: %v", err)
+		}
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-sg", Name: "global-bot", Scope: core.EgressClientScopeGlobal,
+			CreatedByID: user.ID, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClient global: %v", err)
+		}
+
+		personal, err := ecs.ListEgressClients(ctx, core.EgressClientFilter{Scope: core.EgressClientScopePersonal})
+		if err != nil {
+			t.Fatalf("ListEgressClients personal: %v", err)
+		}
+		if len(personal) != 1 || personal[0].ID != "ec-sp" {
+			t.Fatalf("ListEgressClients personal: got %d, want 1 (ec-sp)", len(personal))
+		}
+
+		global, err := ecs.ListEgressClients(ctx, core.EgressClientFilter{Scope: core.EgressClientScopeGlobal})
+		if err != nil {
+			t.Fatalf("ListEgressClients global: %v", err)
+		}
+		if len(global) != 1 || global[0].ID != "ec-sg" {
+			t.Fatalf("ListEgressClients global: got %d, want 1 (ec-sg)", len(global))
+		}
+	})
+
+	t.Run("list filter by both CreatedByID and Scope", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecs, ok := ds.(core.EgressClientStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressClientStore")
+		}
+
+		ctx := context.Background()
+		userA := mustCreateUser(t, ctx, ds, "egress-fa@example.com")
+		userB := mustCreateUser(t, ctx, ds, "egress-fb@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-fa-p", Name: "bot-a-p", Scope: core.EgressClientScopePersonal,
+			CreatedByID: userA.ID, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClient: %v", err)
+		}
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-fa-g", Name: "bot-a-g", Scope: core.EgressClientScopeGlobal,
+			CreatedByID: userA.ID, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClient: %v", err)
+		}
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-fb-p", Name: "bot-b-p", Scope: core.EgressClientScopePersonal,
+			CreatedByID: userB.ID, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClient: %v", err)
+		}
+
+		got, err := ecs.ListEgressClients(ctx, core.EgressClientFilter{
+			CreatedByID: userA.ID, Scope: core.EgressClientScopePersonal,
+		})
+		if err != nil {
+			t.Fatalf("ListEgressClients: %v", err)
+		}
+		if len(got) != 1 || got[0].ID != "ec-fa-p" {
+			t.Fatalf("ListEgressClients AND filter: got %d, want 1 (ec-fa-p)", len(got))
+		}
+	})
+
+	t.Run("migration idempotence with scope data", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+
+		ecs, ok := ds.(core.EgressClientStore)
+		if !ok {
+			t.Skip("datastore does not implement EgressClientStore")
+		}
+
+		ctx := context.Background()
+		user := mustCreateUser(t, ctx, ds, "egress-mig@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-mp", Name: "dual-mig", Scope: core.EgressClientScopePersonal,
+			CreatedByID: user.ID, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClient personal: %v", err)
+		}
+		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
+			ID: "ec-mg", Name: "dual-mig", Scope: core.EgressClientScopeGlobal,
+			CreatedByID: user.ID, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("CreateEgressClient global: %v", err)
+		}
+
+		if err := ds.Migrate(ctx); err != nil {
+			t.Fatalf("re-Migrate: %v", err)
+		}
+
+		p, err := ecs.GetEgressClient(ctx, "ec-mp")
+		if err != nil {
+			t.Fatalf("GetEgressClient personal after re-migrate: %v", err)
+		}
+		if p.Scope != core.EgressClientScopePersonal {
+			t.Errorf("personal Scope after re-migrate: got %q", p.Scope)
+		}
+
+		g, err := ecs.GetEgressClient(ctx, "ec-mg")
+		if err != nil {
+			t.Fatalf("GetEgressClient global after re-migrate: %v", err)
+		}
+		if g.Scope != core.EgressClientScopeGlobal {
+			t.Errorf("global Scope after re-migrate: got %q", g.Scope)
 		}
 	})
 }
@@ -690,7 +933,7 @@ func testDatastoreEgressClientTokens(t *testing.T, newStore func(t *testing.T) c
 		now := time.Now().Truncate(time.Second)
 
 		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
-			ID: "ec-tok", Name: "token-client", CreatedByID: user.ID,
+			ID: "ec-tok", Name: "token-client", Scope: core.EgressClientScopePersonal, CreatedByID: user.ID,
 			CreatedAt: now, UpdatedAt: now,
 		}); err != nil {
 			t.Fatalf("CreateEgressClient: %v", err)
@@ -746,7 +989,7 @@ func testDatastoreEgressClientTokens(t *testing.T, newStore func(t *testing.T) c
 		pastExpiry := now.Add(-1 * time.Hour)
 
 		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
-			ID: "ec-exp", Name: "expired-client", CreatedByID: user.ID,
+			ID: "ec-exp", Name: "expired-client", Scope: core.EgressClientScopePersonal, CreatedByID: user.ID,
 			CreatedAt: now, UpdatedAt: now,
 		}); err != nil {
 			t.Fatalf("CreateEgressClient: %v", err)
@@ -783,7 +1026,7 @@ func testDatastoreEgressClientTokens(t *testing.T, newStore func(t *testing.T) c
 		now := time.Now().Truncate(time.Second)
 
 		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
-			ID: "ec-rev", Name: "revoke-client", CreatedByID: user.ID,
+			ID: "ec-rev", Name: "revoke-client", Scope: core.EgressClientScopePersonal, CreatedByID: user.ID,
 			CreatedAt: now, UpdatedAt: now,
 		}); err != nil {
 			t.Fatalf("CreateEgressClient: %v", err)
@@ -823,7 +1066,7 @@ func testDatastoreEgressClientTokens(t *testing.T, newStore func(t *testing.T) c
 		now := time.Now().Truncate(time.Second)
 
 		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
-			ID: "ec-owner", Name: "owner-client", CreatedByID: user.ID,
+			ID: "ec-owner", Name: "owner-client", Scope: core.EgressClientScopePersonal, CreatedByID: user.ID,
 			CreatedAt: now, UpdatedAt: now,
 		}); err != nil {
 			t.Fatalf("CreateEgressClient: %v", err)
@@ -856,7 +1099,7 @@ func testDatastoreEgressClientTokens(t *testing.T, newStore func(t *testing.T) c
 		now := time.Now().Truncate(time.Second)
 
 		if err := ecs.CreateEgressClient(ctx, &core.EgressClient{
-			ID: "ec-cascade", Name: "cascade-client", CreatedByID: user.ID,
+			ID: "ec-cascade", Name: "cascade-client", Scope: core.EgressClientScopePersonal, CreatedByID: user.ID,
 			CreatedAt: now, UpdatedAt: now,
 		}); err != nil {
 			t.Fatalf("CreateEgressClient: %v", err)

--- a/core/types.go
+++ b/core/types.go
@@ -89,10 +89,16 @@ type OperationResult struct {
 	Body    string
 }
 
+const (
+	EgressClientScopePersonal = "personal"
+	EgressClientScopeGlobal   = "global"
+)
+
 type EgressClient struct {
 	ID          string
 	Name        string
 	Description string
+	Scope       string
 	CreatedByID string
 	CreatedAt   time.Time
 	UpdatedAt   time.Time

--- a/internal/server/egress_clients.go
+++ b/internal/server/egress_clients.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/principal"
 )
 
 func (s *Server) egressClientStore() (core.EgressClientStore, error) {
@@ -20,7 +22,7 @@ func (s *Server) egressClientStore() (core.EgressClientStore, error) {
 	return ecs, nil
 }
 
-func (s *Server) resolveOwnedEgressClient(w http.ResponseWriter, r *http.Request, ecs core.EgressClientStore) (*core.EgressClient, bool) {
+func (s *Server) resolveAuthorizedEgressClient(w http.ResponseWriter, r *http.Request, ecs core.EgressClientStore) (*core.EgressClient, bool) {
 	userID, ok := s.resolveUserID(w, r)
 	if !ok {
 		return nil, false
@@ -35,22 +37,37 @@ func (s *Server) resolveOwnedEgressClient(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusInternalServerError, "failed to look up egress client")
 		return nil, false
 	}
-	if client.CreatedByID != userID {
-		writeError(w, http.StatusNotFound, "egress client not found")
-		return nil, false
+	p := principal.FromContext(r.Context())
+	switch client.Scope {
+	case core.EgressClientScopeGlobal:
+		if !s.isAdmin(p) {
+			writeError(w, http.StatusNotFound, "egress client not found")
+			return nil, false
+		}
+	default:
+		if client.CreatedByID != userID {
+			writeError(w, http.StatusNotFound, "egress client not found")
+			return nil, false
+		}
 	}
 	return client, true
+}
+
+func validScope(scope string) bool {
+	return scope == core.EgressClientScopePersonal || scope == core.EgressClientScopeGlobal
 }
 
 type createEgressClientRequest struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
+	Scope       string `json:"scope"`
 }
 
 type egressClientResponse struct {
 	ID          string    `json:"id"`
 	Name        string    `json:"name"`
 	Description string    `json:"description"`
+	Scope       string    `json:"scope"`
 	CreatedByID string    `json:"created_by_id"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
@@ -78,11 +95,27 @@ func (s *Server) createEgressClient(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	scope := req.Scope
+	if scope == "" {
+		scope = core.EgressClientScopePersonal
+	}
+	if !validScope(scope) {
+		writeError(w, http.StatusBadRequest, "invalid scope")
+		return
+	}
+
+	p := principal.FromContext(r.Context())
+	if scope == core.EgressClientScopeGlobal && !s.isAdmin(p) {
+		writeError(w, http.StatusForbidden, adminForbiddenMessage)
+		return
+	}
+
 	now := s.nowUTCSecond()
 	client := &core.EgressClient{
 		ID:          uuid.NewString(),
 		Name:        req.Name,
 		Description: req.Description,
+		Scope:       scope,
 		CreatedByID: userID,
 		CreatedAt:   now,
 		UpdatedAt:   now,
@@ -112,7 +145,55 @@ func (s *Server) listEgressClients(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clients, err := ecs.ListEgressClients(r.Context(), core.EgressClientFilter{CreatedByID: userID})
+	scopeParam := r.URL.Query().Get("scope")
+	p := principal.FromContext(r.Context())
+	admin := s.isAdmin(p)
+
+	if scopeParam != "" && !validScope(scopeParam) {
+		writeError(w, http.StatusBadRequest, "invalid scope")
+		return
+	}
+
+	if scopeParam == core.EgressClientScopeGlobal && !admin {
+		writeError(w, http.StatusForbidden, adminForbiddenMessage)
+		return
+	}
+
+	var clients []*core.EgressClient
+
+	switch {
+	case scopeParam == core.EgressClientScopeGlobal:
+		clients, err = ecs.ListEgressClients(r.Context(), core.EgressClientFilter{
+			Scope: core.EgressClientScopeGlobal,
+		})
+	case admin && scopeParam == "":
+		personal, pErr := ecs.ListEgressClients(r.Context(), core.EgressClientFilter{
+			CreatedByID: userID,
+			Scope:       core.EgressClientScopePersonal,
+		})
+		if pErr != nil {
+			writeError(w, http.StatusInternalServerError, "failed to list egress clients")
+			return
+		}
+		global, gErr := ecs.ListEgressClients(r.Context(), core.EgressClientFilter{
+			Scope: core.EgressClientScopeGlobal,
+		})
+		if gErr != nil {
+			writeError(w, http.StatusInternalServerError, "failed to list egress clients")
+			return
+		}
+		personal = append(personal, global...)
+		clients = personal
+		sort.Slice(clients, func(i, j int) bool {
+			return clients[i].CreatedAt.Before(clients[j].CreatedAt)
+		})
+	default:
+		clients, err = ecs.ListEgressClients(r.Context(), core.EgressClientFilter{
+			CreatedByID: userID,
+			Scope:       core.EgressClientScopePersonal,
+		})
+	}
+
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list egress clients")
 		return
@@ -132,7 +213,7 @@ func (s *Server) deleteEgressClient(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client, ok := s.resolveOwnedEgressClient(w, r, ecs)
+	client, ok := s.resolveAuthorizedEgressClient(w, r, ecs)
 	if !ok {
 		return
 	}
@@ -173,7 +254,7 @@ func (s *Server) createEgressClientToken(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	client, ok := s.resolveOwnedEgressClient(w, r, ecs)
+	client, ok := s.resolveAuthorizedEgressClient(w, r, ecs)
 	if !ok {
 		return
 	}
@@ -225,7 +306,7 @@ func (s *Server) listEgressClientTokens(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	client, ok := s.resolveOwnedEgressClient(w, r, ecs)
+	client, ok := s.resolveAuthorizedEgressClient(w, r, ecs)
 	if !ok {
 		return
 	}
@@ -250,7 +331,7 @@ func (s *Server) revokeEgressClientToken(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	client, ok := s.resolveOwnedEgressClient(w, r, ecs)
+	client, ok := s.resolveAuthorizedEgressClient(w, r, ecs)
 	if !ok {
 		return
 	}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -97,14 +97,17 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+func (s *Server) isAdmin(p *principal.Principal) bool {
+	if p == nil || p.Identity == nil || p.Identity.Email == "" {
+		return false
+	}
+	_, ok := s.adminEmails[strings.ToLower(p.Identity.Email)]
+	return ok
+}
+
 func (s *Server) adminMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		p := principal.FromContext(r.Context())
-		if p == nil || p.Identity == nil || p.Identity.Email == "" {
-			writeError(w, http.StatusForbidden, adminForbiddenMessage)
-			return
-		}
-		if _, ok := s.adminEmails[strings.ToLower(p.Identity.Email)]; !ok {
+		if !s.isAdmin(principal.FromContext(r.Context())) {
 			writeError(w, http.StatusForbidden, adminForbiddenMessage)
 			return
 		}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1587,6 +1587,9 @@ func TestCreateAndListEgressClients(t *testing.T) {
 				if filter.CreatedByID != "u1" {
 					t.Fatalf("expected CreatedByID u1, got %q", filter.CreatedByID)
 				}
+				if filter.Scope != core.EgressClientScopePersonal {
+					t.Fatalf("expected Scope personal, got %q", filter.Scope)
+				}
 				return stored, nil
 			},
 		}
@@ -1617,6 +1620,9 @@ func TestCreateAndListEgressClients(t *testing.T) {
 	}
 	if created["id"] == "" {
 		t.Fatal("expected non-empty id")
+	}
+	if created["scope"] != core.EgressClientScopePersonal {
+		t.Fatalf("expected scope personal, got %q", created["scope"])
 	}
 
 	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/egress-clients", nil)
@@ -5319,5 +5325,651 @@ func TestAdminCredentialGrants_ListFilterByProvider(t *testing.T) {
 	}
 	if lastFilter.Provider != "vendorx" {
 		t.Fatalf("expected provider filter vendorx, got %q", lastFilter.Provider)
+	}
+}
+
+func TestEgressClientScope_NonAdminCreatePersonal(t *testing.T) {
+	t.Parallel()
+
+	var created *core.EgressClient
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			CreateEgressClientFn: func(_ context.Context, c *core.EgressClient) error {
+				created = c
+				return nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"name":"my-client","scope":"personal"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/egress-clients", body)
+	req.Header.Set("X-Dev-User-Email", "user@example.com")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 201, got %d: %s", resp.StatusCode, respBody)
+	}
+	if created.Scope != core.EgressClientScopePersonal {
+		t.Fatalf("expected personal scope, got %q", created.Scope)
+	}
+}
+
+func TestEgressClientScope_NonAdminCreateGlobalForbidden(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"name":"shared-client","scope":"global"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/egress-clients", body)
+	req.Header.Set("X-Dev-User-Email", "user@example.com")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestEgressClientScope_InvalidScopeOnCreate(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"name":"bad-scope","scope":"team"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/egress-clients", body)
+	req.Header.Set("X-Dev-User-Email", "user@example.com")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestEgressClientScope_AdminCreateGlobal(t *testing.T) {
+	t.Parallel()
+
+	const adminEmail = "admin@testcorp.example"
+
+	var created *core.EgressClient
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.AdminEmails = []string{adminEmail}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u-admin", Email: email}, nil
+			},
+			CreateEgressClientFn: func(_ context.Context, c *core.EgressClient) error {
+				created = c
+				return nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"name":"shared-bot","scope":"global"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/egress-clients", body)
+	req.Header.Set("X-Dev-User-Email", adminEmail)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 201, got %d: %s", resp.StatusCode, respBody)
+	}
+	if created.Scope != core.EgressClientScopeGlobal {
+		t.Fatalf("expected global scope, got %q", created.Scope)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if result["scope"] != core.EgressClientScopeGlobal {
+		t.Fatalf("expected scope global in response, got %q", result["scope"])
+	}
+}
+
+func TestEgressClientScope_AdminListDefault(t *testing.T) {
+	t.Parallel()
+
+	const adminEmail = "admin@testcorp.example"
+
+	personalClient := &core.EgressClient{
+		ID: "ec-p1", Name: "my-bot", Scope: core.EgressClientScopePersonal,
+		CreatedByID: "u-admin", CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	globalClient := &core.EgressClient{
+		ID: "ec-g1", Name: "shared-bot", Scope: core.EgressClientScopeGlobal,
+		CreatedByID: "u-admin", CreatedAt: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.AdminEmails = []string{adminEmail}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u-admin", Email: email}, nil
+			},
+			ListEgressClientsFn: func(_ context.Context, filter core.EgressClientFilter) ([]*core.EgressClient, error) {
+				if filter.Scope == core.EgressClientScopePersonal {
+					return []*core.EgressClient{personalClient}, nil
+				}
+				if filter.Scope == core.EgressClientScopeGlobal {
+					return []*core.EgressClient{globalClient}, nil
+				}
+				return nil, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/egress-clients", nil)
+	req.Header.Set("X-Dev-User-Email", adminEmail)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var listed []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if len(listed) != 2 {
+		t.Fatalf("expected 2 clients, got %d", len(listed))
+	}
+	if listed[0]["id"] != "ec-p1" {
+		t.Fatalf("expected first client ec-p1, got %q", listed[0]["id"])
+	}
+	if listed[1]["id"] != "ec-g1" {
+		t.Fatalf("expected second client ec-g1, got %q", listed[1]["id"])
+	}
+}
+
+func TestEgressClientScope_NonAdminListReturnsOnlyPersonal(t *testing.T) {
+	t.Parallel()
+
+	personalClient := &core.EgressClient{
+		ID: "ec-p1", Name: "my-bot", Scope: core.EgressClientScopePersonal, CreatedByID: "u1",
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			ListEgressClientsFn: func(_ context.Context, filter core.EgressClientFilter) ([]*core.EgressClient, error) {
+				if filter.CreatedByID == "u1" && filter.Scope == core.EgressClientScopePersonal {
+					return []*core.EgressClient{personalClient}, nil
+				}
+				return nil, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/egress-clients", nil)
+	req.Header.Set("X-Dev-User-Email", "user@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var listed []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("expected 1 client, got %d", len(listed))
+	}
+	if listed[0]["scope"] != core.EgressClientScopePersonal {
+		t.Fatalf("expected scope personal, got %q", listed[0]["scope"])
+	}
+}
+
+func TestEgressClientScope_NonAdminListGlobalForbidden(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/egress-clients?scope=global", nil)
+	req.Header.Set("X-Dev-User-Email", "user@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestEgressClientScope_InvalidScopeQueryParam(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/egress-clients?scope=team", nil)
+	req.Header.Set("X-Dev-User-Email", "user@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestEgressClientScope_AdminCannotDeleteOtherPersonalClient(t *testing.T) {
+	t.Parallel()
+
+	const adminEmail = "admin@testcorp.example"
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.AdminEmails = []string{adminEmail}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u-admin", Email: email}, nil
+			},
+			GetEgressClientFn: func(_ context.Context, id string) (*core.EgressClient, error) {
+				if id == "ec-other" {
+					return &core.EgressClient{
+						ID: "ec-other", Name: "other-bot",
+						Scope: core.EgressClientScopePersonal, CreatedByID: "u-other",
+					}, nil
+				}
+				return nil, core.ErrNotFound
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/egress-clients/ec-other", nil)
+	req.Header.Set("X-Dev-User-Email", adminEmail)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 404, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+func TestEgressClientScope_AdminCanDeleteGlobalClient(t *testing.T) {
+	t.Parallel()
+
+	const adminEmail = "admin@testcorp.example"
+	deleted := false
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.AdminEmails = []string{adminEmail}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u-admin", Email: email}, nil
+			},
+			GetEgressClientFn: func(_ context.Context, id string) (*core.EgressClient, error) {
+				if id == "ec-global" {
+					return &core.EgressClient{
+						ID: "ec-global", Name: "shared-bot",
+						Scope: core.EgressClientScopeGlobal, CreatedByID: "u-admin",
+					}, nil
+				}
+				return nil, core.ErrNotFound
+			},
+			DeleteEgressClientFn: func(_ context.Context, id string) error {
+				if id == "ec-global" {
+					deleted = true
+					return nil
+				}
+				return core.ErrNotFound
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/egress-clients/ec-global", nil)
+	req.Header.Set("X-Dev-User-Email", adminEmail)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if !deleted {
+		t.Fatal("expected delete to be called")
+	}
+}
+
+func TestEgressClientScope_AdminCanManageGlobalTokens(t *testing.T) {
+	t.Parallel()
+
+	const adminEmail = "admin@testcorp.example"
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.AdminEmails = []string{adminEmail}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u-admin", Email: email}, nil
+			},
+			GetEgressClientFn: func(_ context.Context, id string) (*core.EgressClient, error) {
+				if id == "ec-global" {
+					return &core.EgressClient{
+						ID: "ec-global", Name: "shared-bot",
+						Scope: core.EgressClientScopeGlobal, CreatedByID: "u-admin",
+					}, nil
+				}
+				return nil, core.ErrNotFound
+			},
+			CreateEgressClientTokenFn: func(_ context.Context, _ *core.EgressClientToken) error {
+				return nil
+			},
+			ListEgressClientTokensFn: func(_ context.Context, clientID string) ([]*core.EgressClientToken, error) {
+				return []*core.EgressClientToken{
+					{ID: "tok-1", ClientID: clientID, Name: "deploy"},
+				}, nil
+			},
+			RevokeEgressClientTokenFn: func(_ context.Context, _, _ string) error {
+				return nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"name":"deploy-token"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/egress-clients/ec-global/tokens", body)
+	req.Header.Set("X-Dev-User-Email", adminEmail)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create token request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 201, got %d: %s", resp.StatusCode, respBody)
+	}
+
+	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/egress-clients/ec-global/tokens", nil)
+	listReq.Header.Set("X-Dev-User-Email", adminEmail)
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("list token request: %v", err)
+	}
+	defer func() { _ = listResp.Body.Close() }()
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", listResp.StatusCode)
+	}
+
+	revokeReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/egress-clients/ec-global/tokens/tok-1", nil)
+	revokeReq.Header.Set("X-Dev-User-Email", adminEmail)
+	revokeResp, err := http.DefaultClient.Do(revokeReq)
+	if err != nil {
+		t.Fatalf("revoke token request: %v", err)
+	}
+	defer func() { _ = revokeResp.Body.Close() }()
+	if revokeResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", revokeResp.StatusCode)
+	}
+}
+
+func TestEgressClientScope_NonAdminAccessGlobalByIDReturns404(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			GetEgressClientFn: func(_ context.Context, id string) (*core.EgressClient, error) {
+				if id == "ec-global" {
+					return &core.EgressClient{
+						ID: "ec-global", Name: "shared-bot",
+						Scope: core.EgressClientScopeGlobal, CreatedByID: "u-admin",
+					}, nil
+				}
+				return nil, core.ErrNotFound
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	for _, path := range []string{
+		"/api/v1/egress-clients/ec-global",
+		"/api/v1/egress-clients/ec-global/tokens",
+	} {
+		method := http.MethodDelete
+		if strings.HasSuffix(path, "/tokens") {
+			method = http.MethodGet
+		}
+		req, _ := http.NewRequest(method, ts.URL+path, nil)
+		req.Header.Set("X-Dev-User-Email", "user@example.com")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s %s: %v", method, path, err)
+		}
+		_ = resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("%s %s: expected 404, got %d", method, path, resp.StatusCode)
+		}
+	}
+}
+
+func TestEgressClientScope_GlobalTokenAuth(t *testing.T) {
+	t.Parallel()
+
+	plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeEgressClient)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
+		cfg.Datastore = &coretesting.StubDatastore{
+			ValidateEgressClientTokenFn: func(_ context.Context, h string) (*core.EgressClientToken, error) {
+				if h == hashed {
+					return &core.EgressClientToken{ID: "tok-1", ClientID: "ec-global"}, nil
+				}
+				return nil, core.ErrNotFound
+			},
+			GetEgressClientFn: func(_ context.Context, id string) (*core.EgressClient, error) {
+				if id == "ec-global" {
+					return &core.EgressClient{
+						ID: "ec-global", Name: "shared-bot",
+						Scope: core.EgressClientScopeGlobal, CreatedByID: "u-admin",
+					}, nil
+				}
+				return nil, core.ErrNotFound
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestEgressClientScope_SameNamePersonalAndGlobal(t *testing.T) {
+	t.Parallel()
+
+	const adminEmail = "admin@testcorp.example"
+	var stored []*core.EgressClient
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.AdminEmails = []string{adminEmail}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u-admin", Email: email}, nil
+			},
+			CreateEgressClientFn: func(_ context.Context, c *core.EgressClient) error {
+				stored = append(stored, c)
+				return nil
+			},
+			ListEgressClientsFn: func(_ context.Context, filter core.EgressClientFilter) ([]*core.EgressClient, error) {
+				var result []*core.EgressClient
+				for _, c := range stored {
+					match := true
+					if filter.CreatedByID != "" && c.CreatedByID != filter.CreatedByID {
+						match = false
+					}
+					if filter.Scope != "" && c.Scope != filter.Scope {
+						match = false
+					}
+					if match {
+						result = append(result, c)
+					}
+				}
+				return result, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	personalBody := bytes.NewBufferString(`{"name":"dual-bot","scope":"personal"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/egress-clients", personalBody)
+	req.Header.Set("X-Dev-User-Email", adminEmail)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create personal: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 for personal, got %d", resp.StatusCode)
+	}
+
+	globalBody := bytes.NewBufferString(`{"name":"dual-bot","scope":"global"}`)
+	req2, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/egress-clients", globalBody)
+	req2.Header.Set("X-Dev-User-Email", adminEmail)
+	req2.Header.Set("Content-Type", "application/json")
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatalf("create global: %v", err)
+	}
+	_ = resp2.Body.Close()
+	if resp2.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 for global, got %d", resp2.StatusCode)
+	}
+
+	if len(stored) != 2 {
+		t.Fatalf("expected 2 stored clients, got %d", len(stored))
+	}
+
+	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/egress-clients", nil)
+	listReq.Header.Set("X-Dev-User-Email", adminEmail)
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	defer func() { _ = listResp.Body.Close() }()
+
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", listResp.StatusCode)
+	}
+
+	var listed []map[string]any
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if len(listed) != 2 {
+		t.Fatalf("expected 2 clients in default admin list, got %d", len(listed))
+	}
+
+	scopes := map[string]bool{}
+	for _, c := range listed {
+		scopes[c["scope"].(string)] = true
+	}
+	if !scopes[core.EgressClientScopePersonal] || !scopes[core.EgressClientScopeGlobal] {
+		t.Fatalf("expected both personal and global scopes, got %v", scopes)
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -400,7 +400,7 @@ func TestAuthMiddleware_EgressClientToken(t *testing.T) {
 			},
 			GetEgressClientFn: func(_ context.Context, id string) (*core.EgressClient, error) {
 				if id == "ec-1" {
-					return &core.EgressClient{ID: "ec-1", Name: "ci-bot"}, nil
+					return &core.EgressClient{ID: "ec-1", Name: "ci-bot", Scope: core.EgressClientScopePersonal}, nil
 				}
 				return nil, core.ErrNotFound
 			},
@@ -1651,7 +1651,7 @@ func TestDeleteEgressClient(t *testing.T) {
 			},
 			GetEgressClientFn: func(_ context.Context, id string) (*core.EgressClient, error) {
 				if id == "ec-123" {
-					return &core.EgressClient{ID: "ec-123", Name: "test", CreatedByID: "u1"}, nil
+					return &core.EgressClient{ID: "ec-123", Name: "test", Scope: core.EgressClientScopePersonal, CreatedByID: "u1"}, nil
 				}
 				return nil, core.ErrNotFound
 			},
@@ -1727,7 +1727,7 @@ func TestCreateAndListEgressClientTokens(t *testing.T) {
 			},
 			GetEgressClientFn: func(_ context.Context, id string) (*core.EgressClient, error) {
 				if id == "ec-1" {
-					return &core.EgressClient{ID: "ec-1", Name: "test-client", CreatedByID: "u1"}, nil
+					return &core.EgressClient{ID: "ec-1", Name: "test-client", Scope: core.EgressClientScopePersonal, CreatedByID: "u1"}, nil
 				}
 				return nil, core.ErrNotFound
 			},
@@ -1808,7 +1808,7 @@ func TestCreateEgressClientToken_DefaultExpiry(t *testing.T) {
 			},
 			GetEgressClientFn: func(_ context.Context, id string) (*core.EgressClient, error) {
 				if id == "ec-1" {
-					return &core.EgressClient{ID: "ec-1", Name: "test-client", CreatedByID: "u1"}, nil
+					return &core.EgressClient{ID: "ec-1", Name: "test-client", Scope: core.EgressClientScopePersonal, CreatedByID: "u1"}, nil
 				}
 				return nil, core.ErrNotFound
 			},
@@ -1864,7 +1864,7 @@ func TestRevokeEgressClientToken(t *testing.T) {
 			},
 			GetEgressClientFn: func(_ context.Context, id string) (*core.EgressClient, error) {
 				if id == "ec-1" {
-					return &core.EgressClient{ID: "ec-1", Name: "test", CreatedByID: "u1"}, nil
+					return &core.EgressClient{ID: "ec-1", Name: "test", Scope: core.EgressClientScopePersonal, CreatedByID: "u1"}, nil
 				}
 				return nil, core.ErrNotFound
 			},
@@ -1910,7 +1910,7 @@ func TestDeleteEgressClient_WrongOwner(t *testing.T) {
 			},
 			GetEgressClientFn: func(_ context.Context, id string) (*core.EgressClient, error) {
 				if id == "ec-owned" {
-					return &core.EgressClient{ID: "ec-owned", Name: "owned", CreatedByID: "u-owner"}, nil
+					return &core.EgressClient{ID: "ec-owned", Name: "owned", Scope: core.EgressClientScopePersonal, CreatedByID: "u-owner"}, nil
 				}
 				return nil, core.ErrNotFound
 			},
@@ -5169,6 +5169,7 @@ func TestAdminCredentialGrants_EgressClientPrincipalForbidden(t *testing.T) {
 	ecClient := &core.EgressClient{
 		ID:          "ec-1",
 		Name:        "test-machine",
+		Scope:       core.EgressClientScopePersonal,
 		CreatedByID: "u-owner",
 	}
 

--- a/internal/server/token_helpers.go
+++ b/internal/server/token_helpers.go
@@ -61,6 +61,7 @@ func egressClientResponseFromCore(client *core.EgressClient) egressClientRespons
 		ID:          client.ID,
 		Name:        client.Name,
 		Description: client.Description,
+		Scope:       client.Scope,
 		CreatedByID: client.CreatedByID,
 		CreatedAt:   client.CreatedAt,
 		UpdatedAt:   client.UpdatedAt,

--- a/plugins/datastore/mysql/mysql.go
+++ b/plugins/datastore/mysql/mysql.go
@@ -130,10 +130,12 @@ func (s *Store) Migrate(ctx context.Context) error {
 			id VARCHAR(36) NOT NULL PRIMARY KEY,
 			name VARCHAR(255) NOT NULL,
 			description TEXT NOT NULL,
+			scope VARCHAR(255) NOT NULL DEFAULT 'personal',
+			scope_key VARCHAR(255) NOT NULL DEFAULT '',
 			created_by_id VARCHAR(36) NOT NULL,
 			created_at DATETIME(6) NOT NULL,
 			updated_at DATETIME(6) NOT NULL,
-			UNIQUE KEY idx_egress_clients_owner_name (created_by_id, name),
+			UNIQUE KEY uq_egress_clients_scope_name (scope_key, name),
 			CONSTRAINT fk_egress_clients_user FOREIGN KEY (created_by_id) REFERENCES users(id)
 		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`,
 
@@ -189,5 +191,77 @@ func (s *Store) Migrate(ctx context.Context) error {
 			return fmt.Errorf("migration %d: %w", i, err)
 		}
 	}
+	return s.migrateEgressClientScope(ctx)
+}
+
+func (s *Store) columnExists(ctx context.Context, table, column string) (bool, error) {
+	var count int
+	err := s.DB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM information_schema.columns
+		 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?`,
+		table, column,
+	).Scan(&count)
+	return count > 0, err
+}
+
+func (s *Store) indexExists(ctx context.Context, table, index string) (bool, error) {
+	var count int
+	err := s.DB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM information_schema.statistics
+		 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?`,
+		table, index,
+	).Scan(&count)
+	return count > 0, err
+}
+
+func (s *Store) migrateEgressClientScope(ctx context.Context) error {
+	exists, err := s.columnExists(ctx, "egress_clients", "scope")
+	if err != nil {
+		return fmt.Errorf("checking scope column: %w", err)
+	}
+	if !exists {
+		if _, err := s.DB.ExecContext(ctx,
+			"ALTER TABLE egress_clients ADD COLUMN scope VARCHAR(255) NOT NULL DEFAULT 'personal'"); err != nil {
+			return fmt.Errorf("adding scope column: %w", err)
+		}
+	}
+
+	exists, err = s.columnExists(ctx, "egress_clients", "scope_key")
+	if err != nil {
+		return fmt.Errorf("checking scope_key column: %w", err)
+	}
+	if !exists {
+		if _, err := s.DB.ExecContext(ctx,
+			"ALTER TABLE egress_clients ADD COLUMN scope_key VARCHAR(255) NOT NULL DEFAULT ''"); err != nil {
+			return fmt.Errorf("adding scope_key column: %w", err)
+		}
+	}
+
+	if _, err := s.DB.ExecContext(ctx,
+		"UPDATE egress_clients SET scope_key = created_by_id WHERE scope = 'personal' AND scope_key = ''"); err != nil {
+		return fmt.Errorf("backfilling scope_key: %w", err)
+	}
+
+	exists, err = s.indexExists(ctx, "egress_clients", "idx_egress_clients_owner_name")
+	if err != nil {
+		return fmt.Errorf("checking old key: %w", err)
+	}
+	if exists {
+		if _, err := s.DB.ExecContext(ctx, "ALTER TABLE egress_clients DROP KEY idx_egress_clients_owner_name"); err != nil {
+			return fmt.Errorf("dropping old key: %w", err)
+		}
+	}
+
+	exists, err = s.indexExists(ctx, "egress_clients", "uq_egress_clients_scope_name")
+	if err != nil {
+		return fmt.Errorf("checking new key: %w", err)
+	}
+	if !exists {
+		if _, err := s.DB.ExecContext(ctx,
+			"ALTER TABLE egress_clients ADD UNIQUE KEY uq_egress_clients_scope_name (scope_key, name)"); err != nil {
+			return fmt.Errorf("adding scope key: %w", err)
+		}
+	}
+
 	return nil
 }

--- a/plugins/datastore/oracle/oracle.go
+++ b/plugins/datastore/oracle/oracle.go
@@ -159,6 +159,8 @@ func (s *Store) Migrate(ctx context.Context) error {
 				id VARCHAR2(36) PRIMARY KEY,
 				name VARCHAR2(255) NOT NULL,
 				description CLOB,
+				scope VARCHAR2(255) DEFAULT 'personal' NOT NULL,
+				scope_key VARCHAR2(255) NOT NULL,
 				created_by_id VARCHAR2(36) NOT NULL,
 				created_at TIMESTAMP WITH TIME ZONE NOT NULL,
 				updated_at TIMESTAMP WITH TIME ZONE NOT NULL
@@ -255,10 +257,6 @@ func (s *Store) Migrate(ctx context.Context) error {
 			ddl:  "ALTER TABLE staged_connections ADD CONSTRAINT fk_staged_conn_user FOREIGN KEY (user_id) REFERENCES users(id)",
 		},
 		{
-			name: "UQ_EGRESS_CLIENTS_OWNER_NAME",
-			ddl:  "ALTER TABLE egress_clients ADD CONSTRAINT uq_egress_clients_owner_name UNIQUE (created_by_id, name)",
-		},
-		{
 			name: "FK_EGRESS_CLIENTS_USER",
 			ddl:  "ALTER TABLE egress_clients ADD CONSTRAINT fk_egress_clients_user FOREIGN KEY (created_by_id) REFERENCES users(id)",
 		},
@@ -278,6 +276,10 @@ func (s *Store) Migrate(ctx context.Context) error {
 			name: "FK_ECG_USER",
 			ddl:  "ALTER TABLE egress_credential_grants ADD CONSTRAINT fk_ecg_user FOREIGN KEY (created_by_id) REFERENCES users(id)",
 		},
+	}
+
+	if err := s.migrateEgressClientScope(ctx); err != nil {
+		return err
 	}
 
 	for _, c := range constraints {
@@ -315,4 +317,89 @@ func (s *Store) constraintExists(ctx context.Context, name string) (bool, error)
 		return false, err
 	}
 	return count > 0, nil
+}
+
+func (s *Store) columnExists(ctx context.Context, table, column string) (bool, error) {
+	var count int
+	err := s.DB.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM user_tab_columns WHERE table_name = :1 AND column_name = :2",
+		strings.ToUpper(table), strings.ToUpper(column),
+	).Scan(&count)
+	return count > 0, err
+}
+
+func (s *Store) columnNullable(ctx context.Context, table, column string) (bool, error) {
+	var nullable string
+	err := s.DB.QueryRowContext(ctx,
+		"SELECT nullable FROM user_tab_columns WHERE table_name = :1 AND column_name = :2",
+		strings.ToUpper(table), strings.ToUpper(column),
+	).Scan(&nullable)
+	if err != nil {
+		return false, err
+	}
+	return nullable == "Y", nil
+}
+
+func (s *Store) migrateEgressClientScope(ctx context.Context) error {
+	exists, err := s.columnExists(ctx, "egress_clients", "scope")
+	if err != nil {
+		return fmt.Errorf("checking scope column: %w", err)
+	}
+	if !exists {
+		if _, err := s.DB.ExecContext(ctx,
+			"ALTER TABLE egress_clients ADD scope VARCHAR2(255) DEFAULT 'personal' NOT NULL"); err != nil {
+			return fmt.Errorf("adding scope column: %w", err)
+		}
+	}
+
+	exists, err = s.columnExists(ctx, "egress_clients", "scope_key")
+	if err != nil {
+		return fmt.Errorf("checking scope_key column: %w", err)
+	}
+	if !exists {
+		if _, err := s.DB.ExecContext(ctx,
+			"ALTER TABLE egress_clients ADD scope_key VARCHAR2(255)"); err != nil {
+			return fmt.Errorf("adding scope_key column: %w", err)
+		}
+	}
+
+	if _, err := s.DB.ExecContext(ctx,
+		"UPDATE egress_clients SET scope_key = created_by_id WHERE scope = 'personal' AND scope_key IS NULL"); err != nil {
+		return fmt.Errorf("backfilling scope_key: %w", err)
+	}
+
+	nullable, err := s.columnNullable(ctx, "egress_clients", "scope_key")
+	if err != nil {
+		return fmt.Errorf("checking scope_key nullable: %w", err)
+	}
+	if nullable {
+		if _, err := s.DB.ExecContext(ctx,
+			"ALTER TABLE egress_clients MODIFY scope_key NOT NULL"); err != nil {
+			return fmt.Errorf("setting scope_key NOT NULL: %w", err)
+		}
+	}
+
+	exists, err = s.constraintExists(ctx, "UQ_EGRESS_CLIENTS_OWNER_NAME")
+	if err != nil {
+		return fmt.Errorf("checking old constraint: %w", err)
+	}
+	if exists {
+		if _, err := s.DB.ExecContext(ctx,
+			"ALTER TABLE egress_clients DROP CONSTRAINT uq_egress_clients_owner_name"); err != nil {
+			return fmt.Errorf("dropping old constraint: %w", err)
+		}
+	}
+
+	exists, err = s.constraintExists(ctx, "UQ_EGRESS_CLIENTS_SCOPE_NAME")
+	if err != nil {
+		return fmt.Errorf("checking new constraint: %w", err)
+	}
+	if !exists {
+		if _, err := s.DB.ExecContext(ctx,
+			"ALTER TABLE egress_clients ADD CONSTRAINT uq_egress_clients_scope_name UNIQUE (scope_key, name)"); err != nil {
+			return fmt.Errorf("adding scope constraint: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/plugins/datastore/postgres/postgres.go
+++ b/plugins/datastore/postgres/postgres.go
@@ -145,12 +145,46 @@ func (s *Store) Migrate(ctx context.Context) error {
 			id TEXT PRIMARY KEY,
 			name TEXT NOT NULL,
 			description TEXT NOT NULL DEFAULT '',
+			scope TEXT NOT NULL DEFAULT 'personal',
+			scope_key TEXT NOT NULL DEFAULT '',
 			created_by_id TEXT NOT NULL REFERENCES users(id),
 			created_at TIMESTAMPTZ NOT NULL,
 			updated_at TIMESTAMPTZ NOT NULL,
-			UNIQUE(created_by_id, name)
+			CONSTRAINT uq_egress_clients_scope_name UNIQUE (scope_key, name)
 		)`); err != nil {
 		return fmt.Errorf("creating egress_clients table: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		ALTER TABLE egress_clients ADD COLUMN IF NOT EXISTS scope TEXT NOT NULL DEFAULT 'personal'`); err != nil {
+		return fmt.Errorf("adding scope column: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		ALTER TABLE egress_clients ADD COLUMN IF NOT EXISTS scope_key TEXT NOT NULL DEFAULT ''`); err != nil {
+		return fmt.Errorf("adding scope_key column: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE egress_clients SET scope_key = created_by_id WHERE scope = 'personal' AND scope_key = ''`); err != nil {
+		return fmt.Errorf("backfilling scope_key: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		DO $$ BEGIN
+		  IF EXISTS (SELECT 1 FROM information_schema.table_constraints
+		    WHERE table_schema = current_schema() AND table_name = 'egress_clients'
+		    AND constraint_name = 'egress_clients_created_by_id_name_key')
+		  THEN ALTER TABLE egress_clients DROP CONSTRAINT egress_clients_created_by_id_name_key;
+		  END IF;
+		END $$`); err != nil {
+		return fmt.Errorf("dropping old egress_clients constraint: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		DO $$ BEGIN
+		  IF NOT EXISTS (SELECT 1 FROM information_schema.table_constraints
+		    WHERE table_schema = current_schema() AND table_name = 'egress_clients'
+		    AND constraint_name = 'uq_egress_clients_scope_name')
+		  THEN ALTER TABLE egress_clients ADD CONSTRAINT uq_egress_clients_scope_name UNIQUE (scope_key, name);
+		  END IF;
+		END $$`); err != nil {
+		return fmt.Errorf("adding egress_clients scope constraint: %w", err)
 	}
 	if _, err := tx.ExecContext(ctx, `
 		CREATE TABLE IF NOT EXISTS egress_client_tokens (

--- a/plugins/datastore/sqlite/sqlite.go
+++ b/plugins/datastore/sqlite/sqlite.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-
 	"strings"
 
 	"github.com/valon-technologies/gestalt/core"
@@ -123,10 +122,12 @@ func (s *Store) Migrate(ctx context.Context) error {
 			id TEXT PRIMARY KEY,
 			name TEXT NOT NULL,
 			description TEXT NOT NULL DEFAULT '',
+			scope TEXT NOT NULL DEFAULT 'personal',
+			scope_key TEXT NOT NULL DEFAULT '',
 			created_by_id TEXT NOT NULL REFERENCES users(id),
 			created_at DATETIME NOT NULL,
 			updated_at DATETIME NOT NULL,
-			UNIQUE(created_by_id, name)
+			UNIQUE(scope_key, name)
 		);
 		CREATE TABLE IF NOT EXISTS egress_client_tokens (
 			id TEXT PRIMARY KEY,
@@ -168,5 +169,96 @@ func (s *Store) Migrate(ctx context.Context) error {
 			updated_at DATETIME NOT NULL
 		)
 	`)
-	return err
+	if err != nil {
+		return err
+	}
+	return s.migrateEgressClientScope(ctx)
+}
+
+func (s *Store) egressClientHasScopeColumns(ctx context.Context) (hasScope, hasScopeKey bool, err error) {
+	rows, err := s.DB.QueryContext(ctx, "PRAGMA table_info(egress_clients)")
+	if err != nil {
+		return false, false, fmt.Errorf("checking egress_clients schema: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notnull int
+		var dfltValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notnull, &dfltValue, &pk); err != nil {
+			return false, false, fmt.Errorf("scanning table_info: %w", err)
+		}
+		if name == "scope" {
+			hasScope = true
+		}
+		if name == "scope_key" {
+			hasScopeKey = true
+		}
+	}
+	return hasScope, hasScopeKey, rows.Err()
+}
+
+func (s *Store) migrateEgressClientScope(ctx context.Context) error {
+	hasScope, hasScopeKey, err := s.egressClientHasScopeColumns(ctx)
+	if err != nil {
+		return err
+	}
+	if hasScope && hasScopeKey {
+		return nil
+	}
+
+	if _, err := s.DB.ExecContext(ctx, "PRAGMA foreign_keys = OFF"); err != nil {
+		return fmt.Errorf("disabling foreign keys: %w", err)
+	}
+	defer func() { _, _ = s.DB.ExecContext(ctx, "PRAGMA foreign_keys = ON") }()
+
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning scope migration tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `DROP TABLE IF EXISTS egress_clients_new`); err != nil {
+		return fmt.Errorf("cleaning up prior failed migration: %w", err)
+	}
+
+	stmts := []string{
+		`CREATE TABLE egress_clients_new (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			scope TEXT NOT NULL DEFAULT 'personal',
+			scope_key TEXT NOT NULL DEFAULT '',
+			created_by_id TEXT NOT NULL REFERENCES users(id),
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			UNIQUE(scope_key, name)
+		)`,
+		`INSERT INTO egress_clients_new (id, name, description, scope, scope_key, created_by_id, created_at, updated_at)
+		 SELECT id, name, description, 'personal', created_by_id, created_by_id, created_at, updated_at
+		 FROM egress_clients`,
+		`DROP TABLE egress_clients`,
+		`ALTER TABLE egress_clients_new RENAME TO egress_clients`,
+	}
+	for _, stmt := range stmts {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("migrating egress_clients scope: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing scope migration: %w", err)
+	}
+
+	fkRows, err := s.DB.QueryContext(ctx, "PRAGMA foreign_key_check(egress_client_tokens)")
+	if err != nil {
+		return fmt.Errorf("foreign key check: %w", err)
+	}
+	defer func() { _ = fkRows.Close() }()
+	if fkRows.Next() {
+		return fmt.Errorf("foreign key violations found in egress_client_tokens after migration")
+	}
+	return fkRows.Err()
 }

--- a/plugins/datastore/sqlserver/sqlserver.go
+++ b/plugins/datastore/sqlserver/sqlserver.go
@@ -161,10 +161,12 @@ func (s *Store) Migrate(ctx context.Context) error {
 				id NVARCHAR(36) NOT NULL PRIMARY KEY,
 				name NVARCHAR(255) NOT NULL,
 				description NVARCHAR(MAX) NOT NULL DEFAULT '',
+				scope NVARCHAR(255) NOT NULL DEFAULT 'personal',
+				scope_key NVARCHAR(255) NOT NULL DEFAULT '',
 				created_by_id NVARCHAR(36) NOT NULL REFERENCES users(id),
 				created_at DATETIME2(6) NOT NULL,
 				updated_at DATETIME2(6) NOT NULL,
-				UNIQUE (created_by_id, name)
+				CONSTRAINT uq_egress_clients_scope_name UNIQUE (scope_key, name)
 			)`},
 		{"egress_client_tokens", `
 			IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'egress_client_tokens')
@@ -219,5 +221,48 @@ func (s *Store) Migrate(ctx context.Context) error {
 		}
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	return s.migrateEgressClientScope(ctx)
+}
+
+func (s *Store) migrateEgressClientScope(ctx context.Context) error {
+	if _, err := s.DB.ExecContext(ctx, `
+		IF COL_LENGTH('egress_clients', 'scope') IS NULL
+		  ALTER TABLE egress_clients ADD scope NVARCHAR(255) NOT NULL DEFAULT 'personal'`); err != nil {
+		return fmt.Errorf("adding scope column: %w", err)
+	}
+
+	if _, err := s.DB.ExecContext(ctx, `
+		IF COL_LENGTH('egress_clients', 'scope_key') IS NULL
+		  ALTER TABLE egress_clients ADD scope_key NVARCHAR(255) NOT NULL DEFAULT ''`); err != nil {
+		return fmt.Errorf("adding scope_key column: %w", err)
+	}
+
+	if _, err := s.DB.ExecContext(ctx, `
+		UPDATE egress_clients SET scope_key = created_by_id WHERE scope = 'personal' AND scope_key = ''`); err != nil {
+		return fmt.Errorf("backfilling scope_key: %w", err)
+	}
+
+	if _, err := s.DB.ExecContext(ctx, `
+		DECLARE @old_uq NVARCHAR(255);
+		SELECT @old_uq = kc.name FROM sys.key_constraints kc
+		  JOIN sys.index_columns ic ON kc.unique_index_id = ic.index_id AND kc.parent_object_id = ic.object_id
+		  WHERE kc.parent_object_id = OBJECT_ID('egress_clients') AND kc.type = 'UQ'
+		  GROUP BY kc.name
+		  HAVING COUNT(*) = 2
+		    AND MAX(CASE WHEN COL_NAME(ic.object_id, ic.column_id) = 'created_by_id' THEN 1 ELSE 0 END) = 1
+		    AND MAX(CASE WHEN COL_NAME(ic.object_id, ic.column_id) = 'name' THEN 1 ELSE 0 END) = 1;
+		IF @old_uq IS NOT NULL EXEC('ALTER TABLE egress_clients DROP CONSTRAINT [' + @old_uq + ']')`); err != nil {
+		return fmt.Errorf("dropping old constraint: %w", err)
+	}
+
+	if _, err := s.DB.ExecContext(ctx, `
+		IF NOT EXISTS (SELECT 1 FROM sys.key_constraints WHERE name = 'uq_egress_clients_scope_name')
+		  ALTER TABLE egress_clients ADD CONSTRAINT uq_egress_clients_scope_name UNIQUE (scope_key, name)`); err != nil {
+		return fmt.Errorf("adding scope constraint: %w", err)
+	}
+
+	return nil
 }

--- a/plugins/datastore/sqlstore/sqlstore.go
+++ b/plugins/datastore/sqlstore/sqlstore.go
@@ -436,14 +436,35 @@ func (s *Store) DeleteStagedConnection(ctx context.Context, id string) error {
 // EgressClient methods
 // ---------------------------------------------------------------------------
 
+const egressClientScopeKeyGlobal = "__global__"
+
+func egressClientScopeKey(scope, createdByID string) (string, error) {
+	switch scope {
+	case core.EgressClientScopePersonal, "":
+		if createdByID == "" {
+			return "", fmt.Errorf("personal scope requires created_by_id")
+		}
+		return createdByID, nil
+	case core.EgressClientScopeGlobal:
+		return egressClientScopeKeyGlobal, nil
+	default:
+		return "", fmt.Errorf("unknown egress client scope: %q", scope)
+	}
+}
+
 func scanEgressClient(row Scanner) (*core.EgressClient, error) {
 	var c core.EgressClient
 	var description sql.NullString
-	if err := row.Scan(&c.ID, &c.Name, &description, &c.CreatedByID,
+	var scope sql.NullString
+	if err := row.Scan(&c.ID, &c.Name, &description, &scope, &c.CreatedByID,
 		&c.CreatedAt, &c.UpdatedAt); err != nil {
 		return nil, err
 	}
 	c.Description = description.String
+	c.Scope = scope.String
+	if c.Scope == "" {
+		c.Scope = core.EgressClientScopePersonal
+	}
 	return &c, nil
 }
 
@@ -462,10 +483,17 @@ func scanEgressClientToken(row Scanner) (*core.EgressClientToken, error) {
 
 func (s *Store) CreateEgressClient(ctx context.Context, client *core.EgressClient) error {
 	defaultTimestamps(&client.CreatedAt, &client.UpdatedAt)
-	_, err := s.DB.ExecContext(ctx, `
-		INSERT INTO egress_clients (id, name, description, created_by_id, created_at, updated_at)
-		VALUES (`+s.ph(1)+`, `+s.ph(2)+`, `+s.ph(3)+`, `+s.ph(4)+`, `+s.ph(5)+`, `+s.ph(6)+`)`,
-		client.ID, client.Name, client.Description, client.CreatedByID,
+	if client.Scope == "" {
+		client.Scope = core.EgressClientScopePersonal
+	}
+	scopeKey, err := egressClientScopeKey(client.Scope, client.CreatedByID)
+	if err != nil {
+		return fmt.Errorf("computing scope key: %w", err)
+	}
+	_, err = s.DB.ExecContext(ctx, `
+		INSERT INTO egress_clients (id, name, description, scope, scope_key, created_by_id, created_at, updated_at)
+		VALUES (`+s.ph(1)+`, `+s.ph(2)+`, `+s.ph(3)+`, `+s.ph(4)+`, `+s.ph(5)+`, `+s.ph(6)+`, `+s.ph(7)+`, `+s.ph(8)+`)`,
+		client.ID, client.Name, client.Description, client.Scope, scopeKey, client.CreatedByID,
 		client.CreatedAt, client.UpdatedAt,
 	)
 	if err != nil {
@@ -479,7 +507,7 @@ func (s *Store) CreateEgressClient(ctx context.Context, client *core.EgressClien
 
 func (s *Store) GetEgressClient(ctx context.Context, id string) (*core.EgressClient, error) {
 	row := s.DB.QueryRowContext(ctx, `
-		SELECT id, name, description, created_by_id, created_at, updated_at
+		SELECT id, name, description, scope, created_by_id, created_at, updated_at
 		FROM egress_clients WHERE id = `+s.ph(1), id)
 	c, err := scanEgressClient(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -492,11 +520,24 @@ func (s *Store) GetEgressClient(ctx context.Context, id string) (*core.EgressCli
 }
 
 func (s *Store) ListEgressClients(ctx context.Context, filter core.EgressClientFilter) ([]*core.EgressClient, error) {
-	query := `SELECT id, name, description, created_by_id, created_at, updated_at FROM egress_clients`
+	query := `SELECT id, name, description, scope, created_by_id, created_at, updated_at FROM egress_clients`
 	var args []any
+	var conditions []string
+	argN := 1
 	if filter.CreatedByID != "" {
-		query += ` WHERE created_by_id = ` + s.ph(1)
+		conditions = append(conditions, `created_by_id = `+s.ph(argN))
 		args = append(args, filter.CreatedByID)
+		argN++
+	}
+	if filter.Scope != "" {
+		conditions = append(conditions, `scope = `+s.ph(argN))
+		args = append(args, filter.Scope)
+	}
+	if len(conditions) > 0 {
+		query += ` WHERE ` + conditions[0]
+		for _, c := range conditions[1:] {
+			query += ` AND ` + c
+		}
 	}
 	query += ` ORDER BY created_at`
 	rows, err := s.DB.QueryContext(ctx, query, args...)


### PR DESCRIPTION
EgressClient management is now scope-aware. Personal clients remain creator-managed with the same behavior as before. Global clients are a new admin-managed scope for shared workload identities, gated by the existing admin_emails config. Non-admins see only their personal clients and get 404 for global client access, while admins see both scopes by default and can manage global clients and their tokens.

This keeps the auth substrate composable: deny rules and credential grants continue to target SubjectAgent by client ID regardless of scope, and token authentication is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)