### PR TITLE
Add manual auth support to the public plugin SDK

### DIFF
--- a/docs/pages/tasks/write-a-plugin.mdx
+++ b/docs/pages/tasks/write-a-plugin.mdx
@@ -139,6 +139,18 @@ Overlay plugins inherit auth and connection behavior from the base declarative i
 
 For overlays on OAuth-protected APIs (Gmail, Slack, etc.), keep the normal auth configuration. The resolved token is passed to `Execute` so the plugin can make its own authenticated API calls.
 
+## Manual auth plugins
+
+Plugins that need operator-provided credentials (API keys, tokens) can opt into the manual auth flow by implementing `ManualAuthProvider`:
+
+```go
+func (p *myProvider) SupportsManualAuth() bool { return true }
+```
+
+With this, operators can connect credentials through `gestalt auth connect-manual` or the web UI. The token is passed to `Execute` on each invocation. No-auth plugins (the default) do not need this interface.
+
+OAuth provider authoring is not yet part of the public SDK contract.
+
 ## Optional interfaces
 
 The SDK supports several optional interfaces beyond the core `Provider`:
@@ -146,6 +158,7 @@ The SDK supports several optional interfaces beyond the core `Provider`:
 | Interface | Purpose |
 |---|---|
 | `ProviderStarter` | Receive integration name, config, and mode at startup. |
+| `ManualAuthProvider` | Opt into manual credential connection. |
 | `ConfigSchemaProvider` | Advertise a JSON Schema for the `plugin.config` block. |
 | `ConnectionParamProvider` | Define parameters required to connect (shown in the UI). |
 | `ProtocolVersionProvider` | Declare supported protocol version range. |

--- a/internal/pluginapi/provider_test.go
+++ b/internal/pluginapi/provider_test.go
@@ -7,6 +7,10 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
+	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type roundTripProvider struct{}
@@ -172,4 +176,57 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 		t.Fatalf("unexpected connection param defs: %+v", defs)
 	}
 
+}
+
+type manualOnlyProviderServer struct {
+	pluginapiv1.UnimplementedProviderPluginServer
+}
+
+func (s *manualOnlyProviderServer) StartProvider(_ context.Context, _ *pluginapiv1.StartProviderRequest) (*pluginapiv1.StartProviderResponse, error) {
+	return &pluginapiv1.StartProviderResponse{ProtocolVersion: pluginapiv1.CurrentProtocolVersion}, nil
+}
+
+func (s *manualOnlyProviderServer) GetMetadata(_ context.Context, _ *emptypb.Empty) (*pluginapiv1.ProviderMetadata, error) {
+	return &pluginapiv1.ProviderMetadata{
+		Name:               "manual-only",
+		DisplayName:        "Manual Only",
+		ConnectionMode:     pluginapiv1.ConnectionMode_CONNECTION_MODE_IDENTITY,
+		AuthTypes:          []string{"manual"},
+		MinProtocolVersion: pluginapiv1.CurrentProtocolVersion,
+		MaxProtocolVersion: pluginapiv1.CurrentProtocolVersion,
+	}, nil
+}
+
+func (s *manualOnlyProviderServer) ListOperations(_ context.Context, _ *emptypb.Empty) (*pluginapiv1.ListOperationsResponse, error) {
+	return &pluginapiv1.ListOperationsResponse{}, nil
+}
+
+func (s *manualOnlyProviderServer) Execute(_ context.Context, _ *pluginapiv1.ExecuteRequest) (*pluginapiv1.OperationResult, error) {
+	return &pluginapiv1.OperationResult{Status: 200, Body: `{}`}, nil
+}
+
+func (s *manualOnlyProviderServer) AuthorizationURL(_ context.Context, _ *pluginapiv1.AuthorizationURLRequest) (*pluginapiv1.AuthorizationURLResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not supported")
+}
+
+func TestRemoteProviderManualAuthOnly(t *testing.T) {
+	t.Parallel()
+
+	client := newProviderPluginClient(t, &manualOnlyProviderServer{})
+	prov, err := NewRemoteProvider(context.Background(), client, "manual-only", nil, "")
+	if err != nil {
+		t.Fatalf("NewRemoteProvider: %v", err)
+	}
+
+	mp, ok := prov.(core.ManualProvider)
+	if !ok {
+		t.Fatal("expected remote provider to implement core.ManualProvider")
+	}
+	if !mp.SupportsManualAuth() {
+		t.Fatal("expected SupportsManualAuth() == true")
+	}
+
+	if _, ok := prov.(core.OAuthProvider); ok {
+		t.Fatal("expected remote provider to NOT implement core.OAuthProvider")
+	}
 }

--- a/sdk/pluginsdk/plugin_test.go
+++ b/sdk/pluginsdk/plugin_test.go
@@ -53,6 +53,12 @@ type schemaStubProvider struct {
 
 func (p *schemaStubProvider) ConfigSchemaJSON() string { return p.schema }
 
+type manualAuthStubProvider struct {
+	stubProvider
+}
+
+func (p *manualAuthStubProvider) SupportsManualAuth() bool { return true }
+
 func TestProviderServerGetMetadata(t *testing.T) {
 	t.Parallel()
 
@@ -77,6 +83,27 @@ func TestProviderServerGetMetadata(t *testing.T) {
 	}
 	if meta.GetConnectionMode() != pluginapiv1.ConnectionMode_CONNECTION_MODE_NONE {
 		t.Errorf("ConnectionMode = %v, want CONNECTION_MODE_NONE", meta.GetConnectionMode())
+	}
+	if len(meta.GetAuthTypes()) != 0 {
+		t.Errorf("AuthTypes = %v, want empty for plain provider", meta.GetAuthTypes())
+	}
+}
+
+func TestProviderServerGetMetadata_ManualAuth(t *testing.T) {
+	t.Parallel()
+
+	prov := &manualAuthStubProvider{
+		stubProvider: stubProvider{name: "manual-prov"},
+	}
+
+	client := newProviderPluginClient(t, prov)
+	meta, err := client.GetMetadata(context.Background(), &emptypb.Empty{})
+	if err != nil {
+		t.Fatalf("GetMetadata: %v", err)
+	}
+	authTypes := meta.GetAuthTypes()
+	if len(authTypes) != 1 || authTypes[0] != "manual" {
+		t.Fatalf("AuthTypes = %v, want [manual]", authTypes)
 	}
 }
 

--- a/sdk/pluginsdk/provider_server.go
+++ b/sdk/pluginsdk/provider_server.go
@@ -60,6 +60,7 @@ func (s *ProviderServer) GetMetadata(_ context.Context, _ *emptypb.Empty) (*plug
 		ConfigSchemaJson:   configSchema,
 		MinProtocolVersion: minPV,
 		MaxProtocolVersion: maxPV,
+		AuthTypes:          authTypes(s.provider),
 	}, nil
 }
 
@@ -89,6 +90,13 @@ func (s *ProviderServer) Execute(ctx context.Context, req *pluginapiv1.ExecuteRe
 		Status: int32(result.Status),
 		Body:   result.Body,
 	}, nil
+}
+
+func authTypes(p Provider) []string {
+	if mp, ok := p.(ManualAuthProvider); ok && mp.SupportsManualAuth() {
+		return []string{"manual"}
+	}
+	return nil
 }
 
 func protocolVersionRange(p Provider) (min, max int32) {

--- a/sdk/pluginsdk/types.go
+++ b/sdk/pluginsdk/types.go
@@ -63,6 +63,10 @@ type ConnectionParamProvider interface {
 	ConnectionParamDefs() map[string]ConnectionParamDef
 }
 
+type ManualAuthProvider interface {
+	SupportsManualAuth() bool
+}
+
 type connectionParamsKey struct{}
 
 func WithConnectionParams(ctx context.Context, params map[string]string) context.Context {


### PR DESCRIPTION
External provider plugins that need operator-provided credentials
(API keys, tokens) had no way to advertise manual auth support through
the public SDK. The host requires providers to satisfy
`core.ManualProvider` for the manual connect flow to work, but
`sdk/pluginsdk` emitted no `auth_types` in plugin metadata. This adds
a `ManualAuthProvider` interface that plugins can implement to opt in.
When enabled, the SDK emits `auth_types=["manual"]` in metadata, which
the host's remote provider adapter already maps to `core.ManualProvider`.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>