### PR TITLE
Extract CredentialSource as a runtime primitive

### DIFF
--- a/internal/bootstrap/egress_credentials.go
+++ b/internal/bootstrap/egress_credentials.go
@@ -11,11 +11,18 @@ import (
 )
 
 func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, providers *registry.PluginMap[core.Provider], ds core.Datastore, sm core.SecretManager) {
+	tokenResolver := &brokerTokenResolver{broker: broker}
+	materializer := &registryMaterializer{providers: providers}
+
 	var loaders []egress.CredentialGrantLoader
 
-	// Saved grants first: control-plane overlay takes precedence over config defaults.
 	if grantStore, ok := ds.(core.EgressCredentialGrantStore); ok {
-		loaders = append(loaders, &credentialGrantStoreLoader{store: grantStore})
+		loaders = append(loaders, &credentialGrantStoreLoader{
+			store:          grantStore,
+			tokenResolver:  tokenResolver,
+			materializer:   materializer,
+			secretResolver: sm,
+		})
 	}
 
 	if len(deps.CredentialGrants) > 0 {
@@ -36,6 +43,7 @@ func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, provide
 					PathPrefix:  g.PathPrefix,
 				},
 			}
+			grants[i].Source = hydrateCredentialSource(grants[i], tokenResolver, materializer, sm)
 		}
 		loaders = append(loaders, &egress.StaticCredentialGrantLoader{Grants: grants})
 	}
@@ -45,15 +53,15 @@ func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, provide
 	}
 
 	deps.Resolver.Credentials = &egress.CredentialGrantResolver{
-		Loaders:        loaders,
-		TokenResolver:  &brokerTokenResolver{broker: broker},
-		Materializer:   &registryMaterializer{providers: providers},
-		SecretResolver: sm,
+		Loaders: loaders,
 	}
 }
 
 type credentialGrantStoreLoader struct {
-	store core.EgressCredentialGrantStore
+	store          core.EgressCredentialGrantStore
+	tokenResolver  egress.ProviderTokenResolver
+	materializer   egress.CredentialMaterializer
+	secretResolver egress.SecretResolver
 }
 
 func (a *credentialGrantStoreLoader) LoadCredentialGrants(ctx context.Context) ([]egress.CredentialGrant, error) {
@@ -63,6 +71,19 @@ func (a *credentialGrantStoreLoader) LoadCredentialGrants(ctx context.Context) (
 	}
 	out := make([]egress.CredentialGrant, len(grants))
 	for i, g := range grants {
+		if err := egress.ValidateCredentialGrant(egress.CredentialGrantValidationInput{
+			SubjectKind: g.SubjectKind,
+			SubjectID:   g.SubjectID,
+			Provider:    g.Provider,
+			Instance:    g.Instance,
+			Operation:   g.Operation,
+			Method:      g.Method,
+			Host:        g.Host,
+			PathPrefix:  g.PathPrefix,
+			AuthStyle:   g.AuthStyle,
+		}); err != nil {
+			return nil, fmt.Errorf("egress credentials: invalid saved grant %q: %w", g.ID, err)
+		}
 		out[i] = egress.CredentialGrant{
 			Instance:  g.Instance,
 			SecretRef: g.SecretRef,
@@ -77,8 +98,25 @@ func (a *credentialGrantStoreLoader) LoadCredentialGrants(ctx context.Context) (
 				PathPrefix:  g.PathPrefix,
 			},
 		}
+		out[i].Source = hydrateCredentialSource(out[i], a.tokenResolver, a.materializer, a.secretResolver)
 	}
 	return out, nil
+}
+
+func hydrateCredentialSource(grant egress.CredentialGrant, tr egress.ProviderTokenResolver, mat egress.CredentialMaterializer, sr egress.SecretResolver) egress.CredentialSource {
+	if grant.SecretRef != "" {
+		return &egress.SecretCredentialSource{
+			Resolver:  sr,
+			SecretRef: grant.SecretRef,
+			AuthStyle: grant.AuthStyle,
+		}
+	}
+	return &egress.ProviderTokenCredentialSource{
+		TokenResolver: tr,
+		Materializer:  mat,
+		Provider:      grant.Provider,
+		Instance:      grant.Instance,
+	}
 }
 
 type brokerTokenResolver struct {

--- a/internal/bootstrap/regression_test.go
+++ b/internal/bootstrap/regression_test.go
@@ -904,7 +904,7 @@ func TestInvalidSavedGrantAuthStyleBlocksConfigFallback(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected invalid auth_style error, got nil")
 	}
-	if !strings.Contains(err.Error(), "unknown auth style") {
-		t.Fatalf("expected auth style error, got: %v", err)
+	if !strings.Contains(err.Error(), "invalid saved grant") {
+		t.Fatalf("expected invalid saved grant error, got: %v", err)
 	}
 }

--- a/internal/egress/credential_grant_resolver.go
+++ b/internal/egress/credential_grant_resolver.go
@@ -3,10 +3,7 @@ package egress
 import (
 	"context"
 	"fmt"
-	"strings"
 )
-
-const secretURIPrefix = "secret://"
 
 // CredentialGrantLoader loads credential grants for resolution. Implementations
 // may return static config grants or fetch persisted grants from a store.
@@ -24,13 +21,10 @@ func (l *StaticCredentialGrantLoader) LoadCredentialGrants(_ context.Context) ([
 }
 
 // CredentialGrantResolver resolves credentials by iterating ordered loaders,
-// finding the first matching grant, and materializing it. Loaders are evaluated
-// in order; within each loader the first matching grant wins.
+// finding the first matching grant whose source produces a non-empty result.
+// Loaders are evaluated in order; within each loader the first matching grant wins.
 type CredentialGrantResolver struct {
-	Loaders        []CredentialGrantLoader
-	TokenResolver  ProviderTokenResolver
-	Materializer   CredentialMaterializer
-	SecretResolver SecretResolver
+	Loaders []CredentialGrantLoader
 }
 
 func (r *CredentialGrantResolver) ResolveCredential(ctx context.Context, subject Subject, target Target) (CredentialMaterialization, error) {
@@ -40,80 +34,19 @@ func (r *CredentialGrantResolver) ResolveCredential(ctx context.Context, subject
 			return CredentialMaterialization{}, fmt.Errorf("egress credentials: loading grants: %w", err)
 		}
 
-		grant, ok := firstMatchingGrant(grants, subject, target)
-		if !ok {
-			continue
-		}
-
-		mat, err := r.resolveGrantCredential(ctx, subject, target, grant)
-		if err != nil {
-			return CredentialMaterialization{}, err
-		}
-		if mat.Authorization != "" || len(mat.Headers) > 0 {
-			return mat, nil
+		for i := range grants {
+			g := &grants[i]
+			if !g.Matches(subject, target) || g.Source == nil {
+				continue
+			}
+			mat, err := g.Source.ResolveCredential(ctx, subject, target)
+			if err != nil {
+				return CredentialMaterialization{}, err
+			}
+			if mat.Authorization != "" || len(mat.Headers) > 0 {
+				return mat, nil
+			}
 		}
 	}
 	return CredentialMaterialization{}, nil
-}
-
-func firstMatchingGrant(grants []CredentialGrant, subject Subject, target Target) (*CredentialGrant, bool) {
-	for i := range grants {
-		g := &grants[i]
-		if !g.Matches(subject, target) {
-			continue
-		}
-		if g.SecretRef != "" {
-			return g, true
-		}
-		if _, _, ok := g.ResolveProvider(target); !ok {
-			continue
-		}
-		return g, true
-	}
-	return nil, false
-}
-
-func (r *CredentialGrantResolver) resolveGrantCredential(ctx context.Context, subject Subject, target Target, grant *CredentialGrant) (CredentialMaterialization, error) {
-	if grant.SecretRef != "" {
-		return resolveSecretGrant(ctx, r.SecretResolver, grant)
-	}
-
-	if _, canResolve := PrincipalForSubject(subject); !canResolve {
-		return CredentialMaterialization{}, nil
-	}
-
-	provider, instance, ok := grant.ResolveProvider(target)
-	if !ok {
-		return CredentialMaterialization{}, nil
-	}
-
-	if r.TokenResolver == nil {
-		return CredentialMaterialization{}, fmt.Errorf("egress credentials: no token resolver configured")
-	}
-
-	token, err := r.TokenResolver.ResolveProviderToken(ctx, subject, provider, instance)
-	if err != nil {
-		return CredentialMaterialization{}, fmt.Errorf("egress credentials: resolving token for %q: %w", provider, err)
-	}
-
-	if r.Materializer == nil {
-		return MaterializeCredential(token, AuthStyleBearer, nil)
-	}
-	return r.Materializer.MaterializeProviderCredential(provider, token)
-}
-
-func resolveSecretGrant(ctx context.Context, sr SecretResolver, grant *CredentialGrant) (CredentialMaterialization, error) {
-	if sr == nil {
-		return CredentialMaterialization{}, fmt.Errorf("egress credentials: no secret resolver configured")
-	}
-	name := strings.TrimPrefix(grant.SecretRef, secretURIPrefix)
-	secret, err := sr.GetSecret(ctx, name)
-	if err != nil {
-		return CredentialMaterialization{}, fmt.Errorf("egress credentials: resolving secret %q: %w", name, err)
-	}
-	style := grant.AuthStyle
-	if style == "" {
-		style = AuthStyleBearer
-	}
-	return MaterializeCredential(secret, style, nil)
 }

--- a/internal/egress/credential_grant_resolver_test.go
+++ b/internal/egress/credential_grant_resolver_test.go
@@ -30,13 +30,18 @@ func (r *stubTokenResolver) ResolveProviderToken(_ context.Context, _ Subject, _
 func TestCredentialGrantResolver_SecretBackedGrant(t *testing.T) {
 	t.Parallel()
 
+	sr := &stubSecretResolver{secrets: map[string]string{"api-key": "sk-secret"}}
 	r := &CredentialGrantResolver{
 		Loaders: []CredentialGrantLoader{
 			&StaticCredentialGrantLoader{Grants: []CredentialGrant{
-				{SecretRef: "api-key", AuthStyle: AuthStyleRaw, MatchCriteria: MatchCriteria{Host: "api.vendor.test"}},
+				{
+					SecretRef:     "api-key",
+					AuthStyle:     AuthStyleRaw,
+					MatchCriteria: MatchCriteria{Host: "api.vendor.test"},
+					Source:        &SecretCredentialSource{Resolver: sr, SecretRef: "api-key", AuthStyle: AuthStyleRaw},
+				},
 			}},
 		},
-		SecretResolver: &stubSecretResolver{secrets: map[string]string{"api-key": "sk-secret"}},
 	}
 
 	mat, err := r.ResolveCredential(context.Background(), Subject{Kind: SubjectAgent, ID: "a-1"}, Target{Host: "api.vendor.test", Method: "GET"})
@@ -51,13 +56,16 @@ func TestCredentialGrantResolver_SecretBackedGrant(t *testing.T) {
 func TestCredentialGrantResolver_ProviderTokenGrant(t *testing.T) {
 	t.Parallel()
 
+	tr := &stubTokenResolver{token: "tok-abc"}
 	r := &CredentialGrantResolver{
 		Loaders: []CredentialGrantLoader{
 			&StaticCredentialGrantLoader{Grants: []CredentialGrant{
-				{MatchCriteria: MatchCriteria{Provider: "vendorx"}},
+				{
+					MatchCriteria: MatchCriteria{Provider: "vendorx"},
+					Source:        &ProviderTokenCredentialSource{TokenResolver: tr},
+				},
 			}},
 		},
-		TokenResolver: &stubTokenResolver{token: "tok-abc"},
 	}
 
 	mat, err := r.ResolveCredential(context.Background(), Subject{Kind: SubjectUser, ID: "u-1"}, Target{Provider: "vendorx", Host: "api.test"})
@@ -72,13 +80,16 @@ func TestCredentialGrantResolver_ProviderTokenGrant(t *testing.T) {
 func TestCredentialGrantResolver_NonPrincipalSubjectReturnsEmpty(t *testing.T) {
 	t.Parallel()
 
+	tr := &stubTokenResolver{token: "tok-abc"}
 	r := &CredentialGrantResolver{
 		Loaders: []CredentialGrantLoader{
 			&StaticCredentialGrantLoader{Grants: []CredentialGrant{
-				{MatchCriteria: MatchCriteria{Provider: "vendorx"}},
+				{
+					MatchCriteria: MatchCriteria{Provider: "vendorx"},
+					Source:        &ProviderTokenCredentialSource{TokenResolver: tr},
+				},
 			}},
 		},
-		TokenResolver: &stubTokenResolver{token: "tok-abc"},
 	}
 
 	mat, err := r.ResolveCredential(context.Background(), Subject{Kind: SubjectSystem, ID: "sys"}, Target{Provider: "vendorx", Host: "api.test"})
@@ -93,13 +104,18 @@ func TestCredentialGrantResolver_NonPrincipalSubjectReturnsEmpty(t *testing.T) {
 func TestCredentialGrantResolver_SecretGrantWorksForNonPrincipal(t *testing.T) {
 	t.Parallel()
 
+	sr := &stubSecretResolver{secrets: map[string]string{"key": "secret-val"}}
 	r := &CredentialGrantResolver{
 		Loaders: []CredentialGrantLoader{
 			&StaticCredentialGrantLoader{Grants: []CredentialGrant{
-				{SecretRef: "key", AuthStyle: AuthStyleRaw, MatchCriteria: MatchCriteria{Host: "api.test"}},
+				{
+					SecretRef:     "key",
+					AuthStyle:     AuthStyleRaw,
+					MatchCriteria: MatchCriteria{Host: "api.test"},
+					Source:        &SecretCredentialSource{Resolver: sr, SecretRef: "key", AuthStyle: AuthStyleRaw},
+				},
 			}},
 		},
-		SecretResolver: &stubSecretResolver{secrets: map[string]string{"key": "secret-val"}},
 	}
 
 	mat, err := r.ResolveCredential(context.Background(), Subject{Kind: SubjectSystem, ID: "sys"}, Target{Host: "api.test", Method: "GET"})
@@ -115,16 +131,21 @@ func TestCredentialGrantResolver_LoaderErrorFailsClosed(t *testing.T) {
 	t.Parallel()
 
 	loaderErr := fmt.Errorf("store unavailable")
+	sr := &stubSecretResolver{secrets: map[string]string{"key": "val"}}
 	r := &CredentialGrantResolver{
 		Loaders: []CredentialGrantLoader{
 			CredentialGrantLoaderFunc(func(_ context.Context) ([]CredentialGrant, error) {
 				return nil, loaderErr
 			}),
 			&StaticCredentialGrantLoader{Grants: []CredentialGrant{
-				{SecretRef: "key", AuthStyle: AuthStyleRaw, MatchCriteria: MatchCriteria{Host: "api.test"}},
+				{
+					SecretRef:     "key",
+					AuthStyle:     AuthStyleRaw,
+					MatchCriteria: MatchCriteria{Host: "api.test"},
+					Source:        &SecretCredentialSource{Resolver: sr, SecretRef: "key", AuthStyle: AuthStyleRaw},
+				},
 			}},
 		},
-		SecretResolver: &stubSecretResolver{secrets: map[string]string{"key": "val"}},
 	}
 
 	_, err := r.ResolveCredential(context.Background(), Subject{Kind: SubjectAgent, ID: "a-1"}, Target{Host: "api.test", Method: "GET"})
@@ -136,19 +157,29 @@ func TestCredentialGrantResolver_LoaderErrorFailsClosed(t *testing.T) {
 func TestCredentialGrantResolver_FirstLoaderWins(t *testing.T) {
 	t.Parallel()
 
+	sr := &stubSecretResolver{secrets: map[string]string{
+		"first-key":  "first-val",
+		"second-key": "second-val",
+	}}
 	r := &CredentialGrantResolver{
 		Loaders: []CredentialGrantLoader{
 			&StaticCredentialGrantLoader{Grants: []CredentialGrant{
-				{SecretRef: "first-key", AuthStyle: AuthStyleRaw, MatchCriteria: MatchCriteria{Host: "api.test"}},
+				{
+					SecretRef:     "first-key",
+					AuthStyle:     AuthStyleRaw,
+					MatchCriteria: MatchCriteria{Host: "api.test"},
+					Source:        &SecretCredentialSource{Resolver: sr, SecretRef: "first-key", AuthStyle: AuthStyleRaw},
+				},
 			}},
 			&StaticCredentialGrantLoader{Grants: []CredentialGrant{
-				{SecretRef: "second-key", AuthStyle: AuthStyleRaw, MatchCriteria: MatchCriteria{Host: "api.test"}},
+				{
+					SecretRef:     "second-key",
+					AuthStyle:     AuthStyleRaw,
+					MatchCriteria: MatchCriteria{Host: "api.test"},
+					Source:        &SecretCredentialSource{Resolver: sr, SecretRef: "second-key", AuthStyle: AuthStyleRaw},
+				},
 			}},
 		},
-		SecretResolver: &stubSecretResolver{secrets: map[string]string{
-			"first-key":  "first-val",
-			"second-key": "second-val",
-		}},
 	}
 
 	mat, err := r.ResolveCredential(context.Background(), Subject{Kind: SubjectAgent, ID: "a-1"}, Target{Host: "api.test", Method: "GET"})
@@ -163,19 +194,29 @@ func TestCredentialGrantResolver_FirstLoaderWins(t *testing.T) {
 func TestCredentialGrantResolver_FallsToSecondLoader(t *testing.T) {
 	t.Parallel()
 
+	sr := &stubSecretResolver{secrets: map[string]string{
+		"first-key":  "first-val",
+		"second-key": "second-val",
+	}}
 	r := &CredentialGrantResolver{
 		Loaders: []CredentialGrantLoader{
 			&StaticCredentialGrantLoader{Grants: []CredentialGrant{
-				{SecretRef: "first-key", AuthStyle: AuthStyleRaw, MatchCriteria: MatchCriteria{Host: "other.test"}},
+				{
+					SecretRef:     "first-key",
+					AuthStyle:     AuthStyleRaw,
+					MatchCriteria: MatchCriteria{Host: "other.test"},
+					Source:        &SecretCredentialSource{Resolver: sr, SecretRef: "first-key", AuthStyle: AuthStyleRaw},
+				},
 			}},
 			&StaticCredentialGrantLoader{Grants: []CredentialGrant{
-				{SecretRef: "second-key", AuthStyle: AuthStyleRaw, MatchCriteria: MatchCriteria{Host: "api.test"}},
+				{
+					SecretRef:     "second-key",
+					AuthStyle:     AuthStyleRaw,
+					MatchCriteria: MatchCriteria{Host: "api.test"},
+					Source:        &SecretCredentialSource{Resolver: sr, SecretRef: "second-key", AuthStyle: AuthStyleRaw},
+				},
 			}},
 		},
-		SecretResolver: &stubSecretResolver{secrets: map[string]string{
-			"first-key":  "first-val",
-			"second-key": "second-val",
-		}},
 	}
 
 	mat, err := r.ResolveCredential(context.Background(), Subject{Kind: SubjectAgent, ID: "a-1"}, Target{Host: "api.test", Method: "GET"})
@@ -190,17 +231,25 @@ func TestCredentialGrantResolver_FallsToSecondLoader(t *testing.T) {
 func TestCredentialGrantResolver_EmptyResultFallsToNextLoader(t *testing.T) {
 	t.Parallel()
 
+	tr := &stubTokenResolver{token: "tok-abc"}
+	sr := &stubSecretResolver{secrets: map[string]string{"fallback-key": "secret-val"}}
 	r := &CredentialGrantResolver{
 		Loaders: []CredentialGrantLoader{
 			&StaticCredentialGrantLoader{Grants: []CredentialGrant{
-				{MatchCriteria: MatchCriteria{Provider: "vendorx"}},
+				{
+					MatchCriteria: MatchCriteria{Provider: "vendorx"},
+					Source:        &ProviderTokenCredentialSource{TokenResolver: tr},
+				},
 			}},
 			&StaticCredentialGrantLoader{Grants: []CredentialGrant{
-				{SecretRef: "fallback-key", AuthStyle: AuthStyleRaw, MatchCriteria: MatchCriteria{Provider: "vendorx"}},
+				{
+					SecretRef:     "fallback-key",
+					AuthStyle:     AuthStyleRaw,
+					MatchCriteria: MatchCriteria{Provider: "vendorx"},
+					Source:        &SecretCredentialSource{Resolver: sr, SecretRef: "fallback-key", AuthStyle: AuthStyleRaw},
+				},
 			}},
 		},
-		TokenResolver:  &stubTokenResolver{token: "tok-abc"},
-		SecretResolver: &stubSecretResolver{secrets: map[string]string{"fallback-key": "secret-val"}},
 	}
 
 	// Non-principal subject matches the provider-based grant in the first loader

--- a/internal/egress/credential_source.go
+++ b/internal/egress/credential_source.go
@@ -1,0 +1,95 @@
+package egress
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+const secretURIPrefix = "secret://"
+
+// CredentialSource resolves credentials for a matched grant. Implementations
+// short-circuit internally before any I/O when they cannot serve a request.
+// An empty CredentialMaterialization (not an error) signals "cannot resolve"
+// and allows the resolver to fall through to the next grant or loader.
+type CredentialSource interface {
+	ResolveCredential(ctx context.Context, subject Subject, target Target) (CredentialMaterialization, error)
+}
+
+// SecretCredentialSource resolves credentials by fetching a named secret.
+// Works for any subject kind.
+type SecretCredentialSource struct {
+	Resolver  SecretResolver
+	SecretRef string
+	AuthStyle AuthStyle
+}
+
+func (s *SecretCredentialSource) ResolveCredential(ctx context.Context, _ Subject, _ Target) (CredentialMaterialization, error) {
+	if s.Resolver == nil {
+		return CredentialMaterialization{}, fmt.Errorf("egress credentials: no secret resolver configured")
+	}
+	name := strings.TrimPrefix(s.SecretRef, secretURIPrefix)
+	secret, err := s.Resolver.GetSecret(ctx, name)
+	if err != nil {
+		return CredentialMaterialization{}, fmt.Errorf("egress credentials: resolving secret %q: %w", name, err)
+	}
+	style := s.AuthStyle
+	if style == "" {
+		style = AuthStyleBearer
+	}
+	return MaterializeCredential(secret, style, nil)
+}
+
+// ProviderTokenCredentialSource resolves credentials via a provider's token
+// broker and materializer. Only works for principal subjects (user, identity,
+// agent). Returns empty for non-principal subjects or when provider/instance
+// cannot be derived from the target.
+type ProviderTokenCredentialSource struct {
+	TokenResolver ProviderTokenResolver
+	Materializer  CredentialMaterializer
+	Provider      string
+	Instance      string
+}
+
+func (s *ProviderTokenCredentialSource) ResolveCredential(ctx context.Context, subject Subject, target Target) (CredentialMaterialization, error) {
+	if _, ok := PrincipalForSubject(subject); !ok {
+		return CredentialMaterialization{}, nil
+	}
+
+	provider, instance, ok := s.resolveProvider(target)
+	if !ok {
+		return CredentialMaterialization{}, nil
+	}
+
+	if s.TokenResolver == nil {
+		return CredentialMaterialization{}, fmt.Errorf("egress credentials: no token resolver configured")
+	}
+
+	token, err := s.TokenResolver.ResolveProviderToken(ctx, subject, provider, instance)
+	if err != nil {
+		return CredentialMaterialization{}, fmt.Errorf("egress credentials: resolving token for %q: %w", provider, err)
+	}
+
+	if s.Materializer == nil {
+		return MaterializeCredential(token, AuthStyleBearer, nil)
+	}
+	return s.Materializer.MaterializeProviderCredential(provider, token)
+}
+
+func (s *ProviderTokenCredentialSource) resolveProvider(target Target) (provider, instance string, ok bool) {
+	p := s.Provider
+	if p == "" {
+		p = target.Provider
+	}
+	if p == "" {
+		return "", "", false
+	}
+	inst := s.Instance
+	if inst == "" {
+		inst = target.Instance
+	}
+	if inst == "" {
+		inst = p
+	}
+	return p, inst, true
+}

--- a/internal/egress/provider_credentials.go
+++ b/internal/egress/provider_credentials.go
@@ -19,26 +19,9 @@ type SecretResolver interface {
 }
 
 type CredentialGrant struct {
+	Source    CredentialSource
 	Instance  string
 	SecretRef string
 	AuthStyle AuthStyle
 	MatchCriteria
-}
-
-func (g *CredentialGrant) ResolveProvider(target Target) (provider, instance string, ok bool) {
-	p := g.Provider
-	if p == "" {
-		p = target.Provider
-	}
-	if p == "" {
-		return "", "", false
-	}
-	inst := g.Instance
-	if inst == "" {
-		inst = target.Instance
-	}
-	if inst == "" {
-		inst = p
-	}
-	return p, inst, true
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4615,11 +4615,15 @@ func TestProxyBinding_CredentialInjection(t *testing.T) {
 			Loaders: []egress.CredentialGrantLoader{
 				&egress.StaticCredentialGrantLoader{
 					Grants: []egress.CredentialGrant{
-						{MatchCriteria: egress.MatchCriteria{Provider: "test-provider"}},
+						{
+							MatchCriteria: egress.MatchCriteria{Provider: "test-provider"},
+							Source: &egress.ProviderTokenCredentialSource{
+								TokenResolver: staticTokenResolverFunc("injected-token"),
+							},
+						},
 					},
 				},
 			},
-			TokenResolver: staticTokenResolverFunc("injected-token"),
 		},
 	}
 


### PR DESCRIPTION
The egress credential resolver previously branched on `SecretRef != ""`
in two places to distinguish secret-backed from provider-token-backed
grants. This introduces a `CredentialSource` interface so the resolver
simply matches a grant and calls its source, with no special-case logic.
The secret-vs-provider decision now happens once at the bootstrap
hydration boundary when DTOs are converted to runtime objects.

Saved grants are also validated during hydration via
`ValidateCredentialGrant`, making the fail-closed contract explicit
rather than relying on downstream error propagation at resolution time.
All existing semantics are preserved: saved grants before config grants,
fail-closed on store errors, first-match-wins, and cross-loader
fallthrough.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>