### PR TITLE
Set LastRefreshedAt when storing new integration tokens

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1022,16 +1022,17 @@ type postConnectResult struct {
 func (s *Server) storeTokenFromMaterial(ctx context.Context, tm tokenMaterial) (*core.IntegrationToken, error) {
 	now := s.now().UTC().Truncate(time.Second)
 	tok := &core.IntegrationToken{
-		ID:           uuid.NewString(),
-		UserID:       tm.UserID,
-		Integration:  tm.Integration,
-		Instance:     tm.Instance,
-		AccessToken:  tm.AccessToken,
-		RefreshToken: tm.RefreshToken,
-		ExpiresAt:    tm.TokenExpiresAt,
-		MetadataJSON: tm.MetadataJSON,
-		CreatedAt:    now,
-		UpdatedAt:    now,
+		ID:              uuid.NewString(),
+		UserID:          tm.UserID,
+		Integration:     tm.Integration,
+		Instance:        tm.Instance,
+		AccessToken:     tm.AccessToken,
+		RefreshToken:    tm.RefreshToken,
+		ExpiresAt:       tm.TokenExpiresAt,
+		LastRefreshedAt: &now,
+		MetadataJSON:    tm.MetadataJSON,
+		CreatedAt:       now,
+		UpdatedAt:       now,
 	}
 	if err := s.datastore.StoreToken(ctx, tok); err != nil {
 		return nil, err


### PR DESCRIPTION
The OAuth callback and manual connect flows create integration tokens
without setting LastRefreshedAt. On MySQL deployments where the column
has a NOT NULL constraint, this causes the token upsert to fail with
"Column 'last_refreshed_at' cannot be null", breaking the connection
flow with a 502 "connection setup failed" error.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>