### PR TITLE
Add gestaltd bundle as the canonical deploy-prep command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ FROM gcr.io/distroless/static-debian12
 COPY --from=builder /gestaltd /gestaltd
 EXPOSE 8080
 ENTRYPOINT ["/gestaltd"]
-CMD ["--config", "/etc/gestalt/config.yaml"]
+CMD ["serve", "--locked", "--config", "/etc/gestalt/config.yaml"]

--- a/cmd/gestaltd/bundle.go
+++ b/cmd/gestaltd/bundle.go
@@ -1,0 +1,466 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/internal/pluginpkg"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
+	"gopkg.in/yaml.v3"
+)
+
+const bundleScheme = "bundle://"
+
+type pluginMapping struct {
+	id     string
+	binary string
+}
+
+type pluginMappingList []pluginMapping
+
+func (l *pluginMappingList) String() string { return "" }
+func (l *pluginMappingList) Set(value string) error {
+	parts := strings.SplitN(value, "=", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return fmt.Errorf("plugin flag must be id=path, got %q", value)
+	}
+	*l = append(*l, pluginMapping{id: parts[0], binary: parts[1]})
+	return nil
+}
+
+func runBundle(args []string) error {
+	fs := flag.NewFlagSet("gestaltd bundle", flag.ContinueOnError)
+	fs.Usage = func() { printBundleUsage(fs.Output()) }
+	configPath := fs.String("config", "", "path to config file")
+	outputDir := fs.String("output", "", "output directory for bundled artifacts")
+	var plugins pluginMappingList
+	fs.Var(&plugins, "plugin", "plugin binary: id=path (repeatable)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if *configPath == "" || *outputDir == "" {
+		return fmt.Errorf("usage: gestaltd bundle --config PATH --output DIR")
+	}
+
+	absConfig, err := filepath.Abs(*configPath)
+	if err != nil {
+		return fmt.Errorf("resolving config path: %w", err)
+	}
+	absOutput, err := filepath.Abs(*outputDir)
+	if err != nil {
+		return fmt.Errorf("resolving output path: %w", err)
+	}
+
+	refs, err := collectLocalRefs(absConfig)
+	if err != nil {
+		return fmt.Errorf("collecting local references: %w", err)
+	}
+
+	sourceRoot, err := computeSourceRoot(absConfig, refs)
+	if err != nil {
+		return err
+	}
+
+	if err := copySourceTree(sourceRoot, absOutput, absOutput); err != nil {
+		return fmt.Errorf("copying source tree: %w", err)
+	}
+
+	bundledConfig, err := filepath.Rel(sourceRoot, absConfig)
+	if err != nil {
+		return fmt.Errorf("computing bundled config path: %w", err)
+	}
+	bundledConfigPath := filepath.Join(absOutput, bundledConfig)
+
+	if len(plugins) > 0 {
+		if err := resolveBundlePlugins(bundledConfigPath, plugins); err != nil {
+			return fmt.Errorf("resolving bundle plugins: %w", err)
+		}
+	}
+
+	if err := initConfig(bundledConfigPath); err != nil {
+		return fmt.Errorf("hydrating bundle: %w", err)
+	}
+
+	log.Printf("bundle written to %s", absOutput)
+	log.Printf("serve with: gestaltd serve --locked --config %s", bundledConfigPath)
+	return nil
+}
+
+func collectLocalRefs(configPath string) ([]string, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var raw struct {
+		Integrations map[string]struct {
+			IconFile  string `yaml:"icon_file"`
+			Upstreams []struct {
+				URL string `yaml:"url"`
+			} `yaml:"upstreams"`
+			Plugin *struct {
+				Package string `yaml:"package"`
+			} `yaml:"plugin"`
+		} `yaml:"integrations"`
+		Runtimes map[string]struct {
+			Plugin *struct {
+				Package string `yaml:"package"`
+			} `yaml:"plugin"`
+		} `yaml:"runtimes"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing config for local refs: %w", err)
+	}
+
+	baseDir := filepath.Dir(configPath)
+	var refs []string
+
+	for name, intg := range raw.Integrations {
+		if intg.IconFile != "" && !filepath.IsAbs(intg.IconFile) {
+			resolved := filepath.Clean(filepath.Join(baseDir, intg.IconFile))
+			if _, err := os.Stat(resolved); err != nil {
+				return nil, fmt.Errorf("integration %q icon_file %q: %w", name, intg.IconFile, err)
+			}
+			refs = append(refs, resolved)
+		}
+
+		for _, us := range intg.Upstreams {
+			if us.URL != "" && !isRemoteURL(us.URL) && !filepath.IsAbs(us.URL) {
+				resolved := filepath.Clean(filepath.Join(baseDir, us.URL))
+				if _, err := os.Stat(resolved); err != nil {
+					return nil, fmt.Errorf("integration %q upstream url %q: %w", name, us.URL, err)
+				}
+				refs = append(refs, resolved)
+			}
+		}
+
+		if intg.Plugin != nil && intg.Plugin.Package != "" {
+			pkg := intg.Plugin.Package
+			if !strings.HasPrefix(pkg, bundleScheme) && !strings.HasPrefix(pkg, "https://") && !filepath.IsAbs(pkg) {
+				resolved := filepath.Clean(filepath.Join(baseDir, pkg))
+				if _, err := os.Stat(resolved); err != nil {
+					return nil, fmt.Errorf("integration %q plugin.package %q: %w", name, pkg, err)
+				}
+				refs = append(refs, resolved)
+			}
+		}
+	}
+
+	for name, rt := range raw.Runtimes {
+		if rt.Plugin != nil && rt.Plugin.Package != "" {
+			pkg := rt.Plugin.Package
+			if !strings.HasPrefix(pkg, bundleScheme) && !strings.HasPrefix(pkg, "https://") && !filepath.IsAbs(pkg) {
+				resolved := filepath.Clean(filepath.Join(baseDir, pkg))
+				if _, err := os.Stat(resolved); err != nil {
+					return nil, fmt.Errorf("runtime %q plugin.package %q: %w", name, pkg, err)
+				}
+				refs = append(refs, resolved)
+			}
+		}
+	}
+
+	return refs, nil
+}
+
+func computeSourceRoot(configPath string, refs []string) (string, error) {
+	all := append([]string{configPath}, refs...)
+	root := filepath.Dir(all[0])
+	for _, p := range all[1:] {
+		for !strings.HasPrefix(p, root+string(filepath.Separator)) && p != root {
+			parent := filepath.Dir(root)
+			if parent == root {
+				return "", fmt.Errorf("cannot compute common ancestor for paths: config and referenced files have no common directory")
+			}
+			root = parent
+		}
+	}
+
+	for _, p := range refs {
+		if !strings.HasPrefix(p, root) {
+			return "", fmt.Errorf("local reference %q is outside the source tree rooted at %q", p, root)
+		}
+	}
+
+	return root, nil
+}
+
+func copySourceTree(src, dst, excludeDir string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		absPath, _ := filepath.Abs(path)
+		if absPath == excludeDir || strings.HasPrefix(absPath, excludeDir+string(filepath.Separator)) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		if rel == ".gestalt" || strings.HasPrefix(rel, ".gestalt"+string(filepath.Separator)) {
+			return filepath.SkipDir
+		}
+		if filepath.Base(rel) == "gestalt.lock.json" {
+			return nil
+		}
+
+		target := filepath.Join(dst, rel)
+
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+
+		return bundleCopyFile(path, target)
+	})
+}
+
+func bundleCopyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+func resolveBundlePlugins(bundledConfigPath string, plugins pluginMappingList) error {
+	data, err := os.ReadFile(bundledConfigPath)
+	if err != nil {
+		return err
+	}
+
+	bundledDir := filepath.Dir(bundledConfigPath)
+	pluginMap := make(map[string]string, len(plugins))
+	for _, p := range plugins {
+		pluginMap[p.id] = p.binary
+	}
+
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("parsing config: %w", err)
+	}
+
+	integrations, _ := raw["integrations"].(map[string]any)
+	for name, v := range integrations {
+		intg, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		plugin, ok := intg["plugin"].(map[string]any)
+		if !ok {
+			continue
+		}
+		pkg, _ := plugin["package"].(string)
+		if !strings.HasPrefix(pkg, bundleScheme) {
+			continue
+		}
+
+		pluginID := strings.TrimPrefix(pkg, bundleScheme)
+		binaryPath, ok := pluginMap[pluginID]
+		if !ok {
+			return fmt.Errorf("integration %q references %s but no --plugin %s=... flag was provided", name, pkg, pluginID)
+		}
+
+		archivePath, err := packageBinaryForBundle(bundledDir, pluginID, binaryPath)
+		if err != nil {
+			return fmt.Errorf("packaging plugin %q for integration %q: %w", pluginID, name, err)
+		}
+
+		relArchive, err := filepath.Rel(bundledDir, archivePath)
+		if err != nil {
+			return err
+		}
+		plugin["package"] = relArchive
+		intg["plugin"] = plugin
+		integrations[name] = intg
+	}
+
+	runtimes, _ := raw["runtimes"].(map[string]any)
+	for name, v := range runtimes {
+		rt, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		plugin, ok := rt["plugin"].(map[string]any)
+		if !ok {
+			continue
+		}
+		pkg, _ := plugin["package"].(string)
+		if !strings.HasPrefix(pkg, bundleScheme) {
+			continue
+		}
+
+		pluginID := strings.TrimPrefix(pkg, bundleScheme)
+		binaryPath, ok := pluginMap[pluginID]
+		if !ok {
+			return fmt.Errorf("runtime %q references %s but no --plugin %s=... flag was provided", name, pkg, pluginID)
+		}
+
+		archivePath, err := packageBinaryForBundle(bundledDir, pluginID, binaryPath)
+		if err != nil {
+			return fmt.Errorf("packaging plugin %q for runtime %q: %w", pluginID, name, err)
+		}
+
+		relArchive, err := filepath.Rel(bundledDir, archivePath)
+		if err != nil {
+			return err
+		}
+		plugin["package"] = relArchive
+		rt["plugin"] = plugin
+		runtimes[name] = rt
+	}
+
+	if integrations != nil {
+		raw["integrations"] = integrations
+	}
+	if runtimes != nil {
+		raw["runtimes"] = runtimes
+	}
+
+	out, err := yaml.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("marshaling rewritten config: %w", err)
+	}
+	return os.WriteFile(bundledConfigPath, out, 0o644)
+}
+
+func packageBinaryForBundle(bundledDir, pluginID, binaryPath string) (string, error) {
+	absBinary, err := filepath.Abs(binaryPath)
+	if err != nil {
+		return "", err
+	}
+
+	targetOS := runtime.GOOS
+	targetArch := runtime.GOARCH
+
+	artifactRel := filepath.ToSlash(filepath.Join("artifacts", targetOS, targetArch, "provider"))
+
+	workDir, err := os.MkdirTemp("", "gestalt-bundle-plugin-*")
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = os.RemoveAll(workDir) }()
+
+	artifactAbs := filepath.Join(workDir, filepath.FromSlash(artifactRel))
+	if err := os.MkdirAll(filepath.Dir(artifactAbs), 0o755); err != nil {
+		return "", err
+	}
+	if err := bundleCopyFile(absBinary, artifactAbs); err != nil {
+		return "", fmt.Errorf("copying binary: %w", err)
+	}
+
+	digest, err := bundleFileSHA256(artifactAbs)
+	if err != nil {
+		return "", err
+	}
+
+	manifest := &pluginmanifestv1.Manifest{
+		SchemaVersion: pluginmanifestv1.SchemaVersion,
+		ID:            pluginID,
+		Version:       "0.0.0-bundle",
+		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     targetOS,
+				Arch:   targetArch,
+				Path:   artifactRel,
+				SHA256: digest,
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{
+				ArtifactPath: artifactRel,
+			},
+		},
+	}
+	data, err := pluginpkg.EncodeManifest(manifest)
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(filepath.Join(workDir, pluginpkg.ManifestFile), data, 0o644); err != nil {
+		return "", err
+	}
+
+	pluginsDir := filepath.Join(bundledDir, ".gestalt", "bundle-packages")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		return "", err
+	}
+
+	safeName := strings.ReplaceAll(pluginID, "/", "-")
+	archivePath := filepath.Join(pluginsDir, safeName+".tar.gz")
+	if err := pluginpkg.CreatePackageFromDir(workDir, archivePath); err != nil {
+		return "", err
+	}
+
+	return archivePath, nil
+}
+
+func bundleFileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func isRemoteURL(s string) bool {
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
+}
+
+func printBundleUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd bundle --config PATH --output DIR [--plugin ID=PATH ...]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Prepare a self-contained bundle for production deployment.")
+	writeUsageLine(w, "Copies the config tree, resolves providers and plugins, and writes")
+	writeUsageLine(w, "lock state. The output is runnable with gestaltd serve --locked.")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Flags:")
+	writeUsageLine(w, "  --config    Path to the config file")
+	writeUsageLine(w, "  --output    Output directory for the bundle")
+	writeUsageLine(w, "  --plugin    Plugin binary mapping: id=path (repeatable)")
+}

--- a/cmd/gestaltd/e2e_test.go
+++ b/cmd/gestaltd/e2e_test.go
@@ -21,7 +21,7 @@ import (
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
 )
 
-func TestE2EPluginPackageArchiveInitAndValidate(t *testing.T) {
+func TestE2EBundleArchiveAndValidate(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -34,12 +34,14 @@ func TestE2EPluginPackageArchiveInitAndValidate(t *testing.T) {
 	}
 
 	cfgPath := writeE2EConfig(t, dir, "plugin.tar.gz", 0)
-	out, err = exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	bundleDir := filepath.Join(dir, "bundle")
+	out, err = exec.Command(gestaltdBin, "bundle", "--config", cfgPath, "--output", bundleDir).CombinedOutput()
 	if err != nil {
-		t.Fatalf("gestaltd init: %v\n%s", err, out)
+		t.Fatalf("gestaltd bundle: %v\n%s", err, out)
 	}
 
-	lockPath := filepath.Join(dir, initLockfileName)
+	bundledCfg := filepath.Join(bundleDir, "config.yaml")
+	lockPath := filepath.Join(bundleDir, initLockfileName)
 	lock, err := readLockfile(lockPath)
 	if err != nil {
 		t.Fatalf("readLockfile: %v", err)
@@ -55,25 +57,26 @@ func TestE2EPluginPackageArchiveInitAndValidate(t *testing.T) {
 		t.Fatal("expected non-empty Package in lockfile entry")
 	}
 
-	out, err = exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	out, err = exec.Command(gestaltdBin, "validate", "--config", bundledCfg).CombinedOutput()
 	if err != nil {
 		t.Fatalf("gestaltd validate: %v\n%s", err, out)
 	}
 }
 
-func TestE2EPluginPackageDirectoryInit(t *testing.T) {
+func TestE2EBundleDirectoryPackage(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
 	pluginDir := setupPluginDir(t, dir)
 	cfgPath := writeE2EConfigForDir(t, dir, pluginDir)
+	bundleDir := filepath.Join(dir, "bundle")
 
-	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	out, err := exec.Command(gestaltdBin, "bundle", "--config", cfgPath, "--output", bundleDir).CombinedOutput()
 	if err != nil {
-		t.Fatalf("gestaltd init: %v\n%s", err, out)
+		t.Fatalf("gestaltd bundle: %v\n%s", err, out)
 	}
 
-	lockPath := filepath.Join(dir, initLockfileName)
+	lockPath := filepath.Join(bundleDir, initLockfileName)
 	lock, err := readLockfile(lockPath)
 	if err != nil {
 		t.Fatalf("readLockfile: %v", err)
@@ -87,7 +90,7 @@ func TestE2EPluginPackageDirectoryInit(t *testing.T) {
 	}
 }
 
-func TestE2EPluginPackageHTTPSInit(t *testing.T) { //nolint:paralleltest // mutates http.DefaultTransport
+func TestE2EBundleHTTPSPackage(t *testing.T) { //nolint:paralleltest // mutates http.DefaultTransport
 
 	dir := t.TempDir()
 	pluginDir := setupPluginDir(t, dir)
@@ -106,11 +109,12 @@ func TestE2EPluginPackageHTTPSInit(t *testing.T) { //nolint:paralleltest // muta
 	t.Cleanup(func() { http.DefaultTransport = savedTransport })
 
 	cfgPath := writeE2EConfig(t, dir, ts.URL+"/plugin.tar.gz", 0)
-	if err := run([]string{"init", "--config", cfgPath}); err != nil {
-		t.Fatalf("run init: %v", err)
+	bundleDir := filepath.Join(dir, "bundle")
+	if err := run([]string{"bundle", "--config", cfgPath, "--output", bundleDir}); err != nil {
+		t.Fatalf("run bundle: %v", err)
 	}
 
-	lockPath := filepath.Join(dir, initLockfileName)
+	lockPath := filepath.Join(bundleDir, initLockfileName)
 	lock, err := readLockfile(lockPath)
 	if err != nil {
 		t.Fatalf("readLockfile: %v", err)
@@ -124,7 +128,7 @@ func TestE2EPluginPackageHTTPSInit(t *testing.T) { //nolint:paralleltest // muta
 	}
 }
 
-func TestE2EPluginServeLockedGoldenPath(t *testing.T) {
+func TestE2EBundleServeLockedGoldenPath(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -138,13 +142,15 @@ func TestE2EPluginServeLockedGoldenPath(t *testing.T) {
 
 	port := allocateTestPort(t)
 	cfgPath := writeE2EConfig(t, dir, "plugin.tar.gz", port)
+	bundleDir := filepath.Join(dir, "bundle")
 
-	out, err = exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	out, err = exec.Command(gestaltdBin, "bundle", "--config", cfgPath, "--output", bundleDir).CombinedOutput()
 	if err != nil {
-		t.Fatalf("gestaltd init: %v\n%s", err, out)
+		t.Fatalf("gestaltd bundle: %v\n%s", err, out)
 	}
 
-	cmd := exec.Command(gestaltdBin, "serve", "--locked", "--config", cfgPath)
+	bundledCfg := filepath.Join(bundleDir, "config.yaml")
+	cmd := exec.Command(gestaltdBin, "serve", "--locked", "--config", bundledCfg)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
@@ -179,7 +185,7 @@ func TestE2EPluginServeLockedGoldenPath(t *testing.T) {
 	}
 }
 
-func TestE2EPluginStaleArchiveAutoReinit(t *testing.T) {
+func TestE2EBareGestaltdAutoInit(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -191,23 +197,6 @@ func TestE2EPluginStaleArchiveAutoReinit(t *testing.T) {
 
 	port := allocateTestPort(t)
 	cfgPath := writeE2EConfig(t, dir, "plugin.tar.gz", port)
-
-	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
-	if err != nil {
-		t.Fatalf("gestaltd init: %v\n%s", err, out)
-	}
-
-	lockPath := filepath.Join(dir, initLockfileName)
-	lockBefore, err := readLockfile(lockPath)
-	if err != nil {
-		t.Fatalf("readLockfile before: %v", err)
-	}
-	digestBefore := lockBefore.Plugins[lockPluginKey("integration", "example")].SourceDigest
-
-	writeManifest(t, pluginDir, "0.2.0")
-	if err := pluginpkg.CreatePackageFromDir(pluginDir, archivePath); err != nil {
-		t.Fatalf("rebuild CreatePackageFromDir: %v", err)
-	}
 
 	cmd := exec.Command(gestaltdBin, "--config", cfgPath)
 	cmd.Stdout = os.Stdout
@@ -222,15 +211,6 @@ func TestE2EPluginStaleArchiveAutoReinit(t *testing.T) {
 
 	baseURL := fmt.Sprintf("http://localhost:%d", port)
 	waitForHealth(t, baseURL, 20*time.Second)
-
-	lockAfter, err := readLockfile(lockPath)
-	if err != nil {
-		t.Fatalf("readLockfile after: %v", err)
-	}
-	digestAfter := lockAfter.Plugins[lockPluginKey("integration", "example")].SourceDigest
-	if digestAfter == digestBefore {
-		t.Fatal("expected SourceDigest to change after stale archive reinit")
-	}
 }
 
 func TestE2EValidateNonMutating(t *testing.T) {
@@ -248,7 +228,7 @@ func TestE2EValidateNonMutating(t *testing.T) {
 
 	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
 	if err == nil {
-		t.Fatalf("expected validate to fail without init, output: %s", out)
+		t.Fatalf("expected validate to fail without bundle, output: %s", out)
 	}
 	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
 		t.Fatal("expected no lockfile after non-mutating validate")

--- a/cmd/gestaltd/init.go
+++ b/cmd/gestaltd/init.go
@@ -2,9 +2,6 @@ package main
 
 import (
 	"context"
-	"flag"
-	"fmt"
-	"strings"
 
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/operator"
@@ -21,20 +18,6 @@ const (
 type initLockfile = operator.Lockfile
 type lockProviderEntry = operator.LockProviderEntry
 type lockPluginEntry = operator.LockPluginEntry
-
-func runInit(args []string) error {
-	fs := flag.NewFlagSet("gestaltd init", flag.ContinueOnError)
-	fs.Usage = func() { printInitUsage(fs.Output()) }
-	configPath := fs.String("config", "", "path to config file")
-	if err := fs.Parse(args); err != nil {
-		return err
-	}
-	if fs.NArg() > 0 {
-		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
-	}
-
-	return initConfig(*configPath)
-}
 
 func operatorLifecycle() *operator.Lifecycle {
 	return operator.NewLifecycle(func(ctx context.Context, name string, upstream config.UpstreamDef) (*provider.Definition, error) {

--- a/cmd/gestaltd/init_test.go
+++ b/cmd/gestaltd/init_test.go
@@ -102,7 +102,7 @@ func TestLoadConfigForExecutionRequirePreparedRejectsUnpreparedRemote(t *testing
 	if err == nil {
 		t.Fatal("expected strict serve to reject unprepared remote upstream")
 	}
-	if !strings.Contains(err.Error(), "gestaltd init") {
+	if !strings.Contains(err.Error(), "gestaltd bundle") {
 		t.Fatalf("expected init guidance, got: %v", err)
 	}
 }
@@ -444,7 +444,7 @@ func TestLoadConfigForExecutionPreferRejectsUnpreparedPluginPackage(t *testing.T
 	if err == nil {
 		t.Fatal("expected unprepared plugin package to fail")
 	}
-	if !strings.Contains(err.Error(), "gestaltd init") {
+	if !strings.Contains(err.Error(), "gestaltd bundle") {
 		t.Fatalf("expected init guidance, got: %v", err)
 	}
 }

--- a/cmd/gestaltd/main_test.go
+++ b/cmd/gestaltd/main_test.go
@@ -36,8 +36,11 @@ func TestGestaltd_HelpExitsCleanly(t *testing.T) {
 	if !strings.Contains(string(out), "gestaltd validate") {
 		t.Fatalf("expected usage output containing 'gestaltd validate', got: %s", out)
 	}
-	if !strings.Contains(string(out), "gestaltd init") {
-		t.Fatalf("expected usage output containing 'gestaltd init', got: %s", out)
+	if !strings.Contains(string(out), "gestaltd bundle") {
+		t.Fatalf("expected usage output containing 'gestaltd bundle', got: %s", out)
+	}
+	if strings.Contains(string(out), "gestaltd init") {
+		t.Fatalf("expected init to be removed from usage, got: %s", out)
 	}
 	if !strings.Contains(string(out), "gestaltd plugin <command> [flags]") {
 		t.Fatalf("expected usage output containing 'gestaltd plugin <command> [flags]', got: %s", out)
@@ -65,15 +68,15 @@ func TestGestaltdValidateHelpExitsCleanly(t *testing.T) {
 	}
 }
 
-func TestGestaltdInitHelpExitsCleanly(t *testing.T) {
+func TestGestaltdBundleHelpExitsCleanly(t *testing.T) {
 	t.Parallel()
-	cmd := exec.Command("go", "run", ".", "init", "--help")
+	cmd := exec.Command("go", "run", ".", "bundle", "--help")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("expected exit 0 for 'init --help', got error: %v\noutput: %s", err, out)
+		t.Fatalf("expected exit 0 for 'bundle --help', got error: %v\noutput: %s", err, out)
 	}
-	if !strings.Contains(string(out), "gestaltd init") {
-		t.Fatalf("expected usage output containing 'gestaltd init', got: %s", out)
+	if !strings.Contains(string(out), "gestaltd bundle") {
+		t.Fatalf("expected usage output containing 'gestaltd bundle', got: %s", out)
 	}
 }
 

--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -35,8 +35,8 @@ func run(args []string) error {
 			return runPlugin(args[1:])
 		case "serve":
 			return runServe(args[1:])
-		case "init":
-			return runInit(args[1:])
+		case "bundle":
+			return runBundle(args[1:])
 		case "validate":
 			return runValidate(args[1:])
 		}
@@ -358,15 +358,15 @@ func maskEmpty(s string) string {
 func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
 	writeUsageLine(w, "  gestaltd [--config PATH]")
-	writeUsageLine(w, "  gestaltd plugin <command> [flags]")
+	writeUsageLine(w, "  gestaltd bundle --config PATH --output DIR [--plugin ID=PATH ...]")
 	writeUsageLine(w, "  gestaltd serve [--config PATH] [--locked]")
-	writeUsageLine(w, "  gestaltd init [--config PATH]")
+	writeUsageLine(w, "  gestaltd plugin <command> [flags]")
 	writeUsageLine(w, "  gestaltd validate [--config PATH] [--init]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
-	writeUsageLine(w, "  plugin      Package plugins for distribution")
+	writeUsageLine(w, "  bundle      Prepare a self-contained bundle for production deployment")
 	writeUsageLine(w, "  serve       Start the server (use --locked for production)")
-	writeUsageLine(w, "  init        Hydrate plugin packages and provider artifacts into locked local state")
+	writeUsageLine(w, "  plugin      Package plugins for distribution")
 	writeUsageLine(w, "  validate    Load and validate configuration without starting the server")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
@@ -379,20 +379,7 @@ func printServeUsage(w io.Writer) {
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Start the server. Auto-inits if lock state is missing or stale.")
 	writeUsageLine(w, "Use --locked for production deployments to prevent automatic mutation")
-	writeUsageLine(w, "at startup. When locked, run `gestaltd init` first to hydrate state.")
-}
-
-func printInitUsage(w io.Writer) {
-	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd init [--config PATH]")
-	writeUsageLine(w, "")
-	writeUsageLine(w, "Hydrate plugin packages and remote provider specs into locked local state:")
-	writeUsageLine(w, "  - gestalt.lock.json")
-	writeUsageLine(w, "  - .gestalt/providers/*.json")
-	writeUsageLine(w, "  - .gestalt/plugins/...")
-	writeUsageLine(w, "")
-	writeUsageLine(w, "HTTPS URL packages are always re-fetched. Run init explicitly to pick")
-	writeUsageLine(w, "up remote content changes.")
+	writeUsageLine(w, "at startup. When locked, run `gestaltd bundle` first to prepare state.")
 }
 
 func printValidateUsage(w io.Writer) {

--- a/internal/operator/lifecycle.go
+++ b/internal/operator/lifecycle.go
@@ -155,7 +155,7 @@ func (l *Lifecycle) providersForConfig(configPath string, cfg *config.Config, lo
 	}
 	if err != nil {
 		if locked {
-			return nil, fmt.Errorf("remote REST/GraphQL upstreams require prepared artifacts; run `gestaltd init --config %s`: %w", configPath, err)
+			return nil, fmt.Errorf("remote REST/GraphQL upstreams require prepared artifacts; run `gestaltd bundle --config %s --output DIR`: %w", configPath, err)
 		}
 		return nil, nil
 	}
@@ -176,7 +176,7 @@ func (l *Lifecycle) providersForConfig(configPath string, cfg *config.Config, lo
 		entry, ok := lock.Providers[name]
 		if !ok || entry.Fingerprint != fingerprint {
 			if locked {
-				return nil, fmt.Errorf("prepared artifact for integration %q is missing or stale; run `gestaltd init --config %s`", name, configPath)
+				return nil, fmt.Errorf("prepared artifact for integration %q is missing or stale; run `gestaltd bundle --config %s --output DIR`", name, configPath)
 			}
 			continue
 		}
@@ -184,7 +184,7 @@ func (l *Lifecycle) providersForConfig(configPath string, cfg *config.Config, lo
 		absPath := resolveLockPath(paths.configDir, entry.Provider)
 		if _, statErr := os.Stat(absPath); statErr != nil {
 			if locked {
-				return nil, fmt.Errorf("prepared artifact for integration %q not found at %s; run `gestaltd init --config %s`", name, absPath, configPath)
+				return nil, fmt.Errorf("prepared artifact for integration %q not found at %s; run `gestaltd bundle --config %s --output DIR`", name, absPath, configPath)
 			}
 			continue
 		}
@@ -554,7 +554,7 @@ func (l *Lifecycle) applyLockedPlugins(configPath string, cfg *config.Config, lo
 		lock, err = l.InitAtPath(configPath)
 	}
 	if err != nil {
-		return fmt.Errorf("plugin packages require prepared artifacts; run `gestaltd init --config %s`: %w", configPath, err)
+		return fmt.Errorf("plugin packages require prepared artifacts; run `gestaltd bundle --config %s --output DIR`: %w", configPath, err)
 	}
 
 	for name := range cfg.Integrations {
@@ -590,23 +590,23 @@ func applyLockedPluginEntry(paths initPaths, lock *Lockfile, kind, name string, 
 	key := LockPluginKey(kind, name)
 	entry, ok := lock.Plugins[key]
 	if !ok {
-		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", kind, name, paths.configPath)
+		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd bundle --config %s --output DIR`", kind, name, paths.configPath)
 	}
 	fingerprint, err := PluginFingerprint(name, plugin, configMap)
 	if err != nil {
 		return fmt.Errorf("fingerprinting %s %q plugin: %w", kind, name, err)
 	}
 	if entry.Fingerprint != fingerprint || entry.Package != plugin.Package {
-		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", kind, name, paths.configPath)
+		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd bundle --config %s --output DIR`", kind, name, paths.configPath)
 	}
 
 	manifestPath := resolveLockPath(paths.configDir, entry.Manifest)
 	executablePath := resolveLockPath(paths.configDir, entry.Executable)
 	if _, err := os.Stat(manifestPath); err != nil {
-		return fmt.Errorf("prepared manifest for %s %q not found at %s; run `gestaltd init --config %s`", kind, name, manifestPath, paths.configPath)
+		return fmt.Errorf("prepared manifest for %s %q not found at %s; run `gestaltd bundle --config %s --output DIR`", kind, name, manifestPath, paths.configPath)
 	}
 	if _, err := os.Stat(executablePath); err != nil {
-		return fmt.Errorf("prepared executable for %s %q not found at %s; run `gestaltd init --config %s`", kind, name, executablePath, paths.configPath)
+		return fmt.Errorf("prepared executable for %s %q not found at %s; run `gestaltd bundle --config %s --output DIR`", kind, name, executablePath, paths.configPath)
 	}
 
 	_, manifest, err := pluginpkg.ReadManifestFile(manifestPath)


### PR DESCRIPTION
Downstream consumers like valon-tools had to re-implement plugin
packaging, config preparation, and locked-state bootstrapping across
multi-stage Dockerfiles. This adds `gestaltd bundle --config ...
--output ...` as a single command that copies the config tree into an
output directory, resolves remote providers and plugin packages, writes
the lockfile and .gestalt/ artifacts, and produces a self-contained
directory runnable with `serve --locked`. For Docker builds with
compiled plugins, the `--plugin id=path` flag accepts binaries and
packages them inline using the `bundle://` config scheme.

The `init` command is removed from the user-facing surface. The image
default CMD changes to `serve --locked` to make the production path
the container default.

WIP: E2E tests need to be updated from `init` to `bundle`. Core
functionality is working and manually verified.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>