### PR TITLE
Remove provider-token grants from proxy credentials

### DIFF
--- a/docs/pages/deploy/gateway-only.mdx
+++ b/docs/pages/deploy/gateway-only.mdx
@@ -8,11 +8,10 @@ This is useful when you want to mediate outbound API calls -- injecting secrets,
 
 ## What You Get
 
-- Inbound auth via session tokens, API keys (`gst_api_`), or egress-client tokens (`gst_ec_`)
+- Inbound auth via session tokens or API keys (`gst_api_`)
 - A proxy binding that forwards requests to arbitrary upstream hosts
 - Egress policy rules that deny or allow requests by host, path, method, or subject
-- Credential injection from secret-manager references (`secret_ref`) or provider tokens
-- Admin API for managing deny rules and credential grants at runtime
+- Secret-backed credential injection via `secret_ref`
 
 ## What You Do Not Get
 
@@ -27,8 +26,6 @@ server:
   port: 8080
   base_url: https://gateway.example.com
   encryption_key: secret://gestalt-encryption-key
-  admin_emails:
-    - ops@example.com
 
 auth:
   provider: oidc
@@ -75,15 +72,13 @@ Key points:
 - The `bindings.proxy` section declares zero providers. This is the providerless proxy mode.
 - `egress.default_action: deny` blocks all outbound traffic except hosts explicitly allowed.
 - Each credential grant uses `secret_ref` to pull a secret at request time and `auth_style: bearer` to inject it as a `Bearer` token.
-- `admin_emails` grants the listed users access to the deny-rule and credential-grant admin APIs, and to global-scope egress client management.
-
 <Callout>
   `secret_ref` values are resolved at request time through the configured secret manager, not during config loading. This means the proxy always fetches the current secret value.
 </Callout>
 
 ## Secret-Backed Credentials
 
-The `secret_ref` and `auth_style` fields on credential grants replace provider-token resolution with direct secret-manager lookups.
+The `secret_ref` and `auth_style` fields on credential grants control how secrets are resolved and injected.
 
 ```yaml
 egress:
@@ -122,15 +117,13 @@ Host matching is exact. Each request resolves credentials from the first grant w
 
 ## Full Platform With Egress
 
-The same egress substrate works in a full-platform deployment alongside providers and integrations. Provider-token grants and secret-backed grants can coexist:
+The same egress substrate works in a full-platform deployment alongside providers and integrations. The proxy uses secret-backed credential grants for outbound auth while integrations use their own OAuth connections:
 
 ```yaml
 server:
   port: 8080
   base_url: https://gestalt.example.com
   encryption_key: secret://gestalt-encryption-key
-  admin_emails:
-    - ops@example.com
 
 auth:
   provider: oidc
@@ -184,16 +177,10 @@ egress:
     - action: allow
       host: api.openai.com
   credentials:
-    # Provider-token grant: resolves from user's GitHub OAuth token
-    - provider: github
-      host: api.github.com
-    # Secret-backed grant: resolves from secret manager
     - host: api.openai.com
       secret_ref: openai-api-key
       auth_style: bearer
 ```
-
-The credential grant resolver evaluates saved DB grants before config grants, so operator-managed state overrides bootstrap defaults. Within each source, the first matching grant wins.
 
 ## Startup
 

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -448,12 +448,9 @@ egress:
       host: api.github.com
       path_prefix: /repos
   credentials:
-    - provider: github
-      instance: default
-      subject_kind: user
-      method: GET
-      host: api.github.com
-      path_prefix: /repos
+    - host: api.github.com
+      secret_ref: github-api-key
+      auth_style: bearer
     - host: api.openai.com
       secret_ref: openai-api-key
       auth_style: bearer
@@ -476,12 +473,10 @@ egress:
 
 | Field | Notes |
 | --- | --- |
-| `provider` | Credential source provider. Not required when `secret_ref` is set. |
-| `instance` | Credential instance. |
-| `secret_ref` | Secret manager key. When set, the credential is resolved from the secret manager instead of a provider token. |
-| `auth_style` | How the resolved secret is injected: `bearer`, `basic`, or `raw`. Required when `secret_ref` is set. |
-| `subject_kind` | Subject filter. |
-| `subject_id` | Subject filter. |
+| `secret_ref` | Required. Secret manager key resolved at request time. |
+| `auth_style` | How the resolved secret is injected: `bearer`, `basic`, or `raw`. Defaults to `bearer`. |
+| `subject_kind` | Optional subject filter. |
+| `subject_id` | Optional subject filter. |
 | `operation` | Optional operation filter. |
 | `method` | Optional HTTP-method filter. |
 | `host` | Optional host filter. |

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -184,7 +184,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	}()
 
 	sharedInvoker := invocation.NewBroker(providers, ds)
-	wireCredentialResolver(&deps.Egress, sharedInvoker, providers, sm)
+	wireCredentialResolver(&deps.Egress, sm)
 	audit := core.AuditSink(invocation.LogAuditSink{})
 
 	extensions, err := buildExtensions(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress)

--- a/internal/bootstrap/egress_credentials.go
+++ b/internal/bootstrap/egress_credentials.go
@@ -1,16 +1,11 @@
 package bootstrap
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/egress"
-	"github.com/valon-technologies/gestalt/internal/invocation"
-	"github.com/valon-technologies/gestalt/internal/registry"
 )
 
-func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, providers *registry.PluginMap[core.Provider], sm core.SecretManager) {
+func wireCredentialResolver(deps *EgressDeps, sm core.SecretManager) {
 	var loaders []egress.CredentialGrantLoader
 
 	if len(deps.CredentialGrants) > 0 {
@@ -18,13 +13,11 @@ func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, provide
 		for i := range deps.CredentialGrants {
 			g := &deps.CredentialGrants[i]
 			grants[i] = egress.CredentialGrant{
-				Instance:  g.Instance,
 				SecretRef: g.SecretRef,
 				AuthStyle: egress.AuthStyle(g.AuthStyle),
 				MatchCriteria: egress.MatchCriteria{
 					SubjectKind: egress.SubjectKind(g.SubjectKind),
 					SubjectID:   g.SubjectID,
-					Provider:    g.Provider,
 					Operation:   g.Operation,
 					Method:      g.Method,
 					Host:        g.Host,
@@ -41,46 +34,6 @@ func wireCredentialResolver(deps *EgressDeps, broker *invocation.Broker, provide
 
 	deps.Resolver.Credentials = &egress.CredentialGrantResolver{
 		Loaders:        loaders,
-		TokenResolver:  &brokerTokenResolver{broker: broker},
-		Materializer:   &registryMaterializer{providers: providers},
 		SecretResolver: sm,
 	}
-}
-
-type brokerTokenResolver struct {
-	broker *invocation.Broker
-}
-
-func (r *brokerTokenResolver) ResolveProviderToken(ctx context.Context, subject egress.Subject, provider, instance string) (string, error) {
-	p, ok := egress.PrincipalForSubject(subject)
-	if !ok {
-		return "", fmt.Errorf("subject %s/%s cannot resolve provider tokens", subject.Kind, subject.ID)
-	}
-	return r.broker.ResolveToken(ctx, p, provider, instance)
-}
-
-type registryMaterializer struct {
-	providers *registry.PluginMap[core.Provider]
-}
-
-type egressMaterializer interface {
-	EgressMaterializeCredential(token string) (egress.CredentialMaterialization, error)
-}
-
-func (m *registryMaterializer) MaterializeProviderCredential(provider string, token string) (egress.CredentialMaterialization, error) {
-	prov, err := m.providers.Get(provider)
-	if err != nil {
-		return egress.CredentialMaterialization{}, fmt.Errorf("loading provider %q for credential materialization: %w", provider, err)
-	}
-	for prov != nil {
-		if em, ok := prov.(egressMaterializer); ok {
-			return em.EgressMaterializeCredential(token)
-		}
-		unwrapper, ok := prov.(interface{ Inner() core.Provider })
-		if !ok {
-			break
-		}
-		prov = unwrapper.Inner()
-	}
-	return egress.MaterializeCredential(token, egress.AuthStyleBearer, nil)
 }

--- a/internal/bootstrap/regression_test.go
+++ b/internal/bootstrap/regression_test.go
@@ -224,7 +224,7 @@ func TestEgressCredentialGrantWiredThroughBootstrap(t *testing.T) {
 	cfg := validConfig()
 	cfg.Egress = config.EgressConfig{
 		Credentials: []config.EgressCredentialGrant{
-			{Provider: "alpha", Host: "api.test"},
+			{Host: "api.test", SecretRef: "test-key"},
 		},
 	}
 	cfg.Bindings = map[string]config.BindingDef{
@@ -378,76 +378,6 @@ func TestSecretBackedCredentialGrant_MultiTenantHostMatching(t *testing.T) {
 	}
 	if auth := resolve(hostShop2); auth != secretShop2 {
 		t.Fatalf("shop-2: got %q, want %q", auth, secretShop2)
-	}
-}
-
-func TestSecretBackedGrant_CoexistsWithProviderTokenGrant(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-
-	const (
-		secretName  = "ext-api-key"
-		secretValue = "sk-external-key"
-		tokenValue  = "tok-provider-token"
-	)
-
-	cfg := validConfig()
-	cfg.Egress = config.EgressConfig{
-		Credentials: []config.EgressCredentialGrant{
-			{Host: "api.external.test", SecretRef: secretName, AuthStyle: "bearer"},
-			{Provider: "alpha", Host: "api.provider.test"},
-		},
-	}
-	cfg.Bindings = map[string]config.BindingDef{
-		"my-binding": {Type: "test-binding", Providers: []string{"alpha"}},
-	}
-
-	factories := validFactories()
-	factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
-		return &coretesting.StubSecretManager{
-			Secrets: map[string]string{secretName: secretValue},
-		}, nil
-	}
-	factories.Datastores["test-store"] = func(_ yaml.Node, _ bootstrap.Deps) (core.Datastore, error) {
-		return &coretesting.StubDatastore{
-			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
-				return &core.IntegrationToken{AccessToken: tokenValue}, nil
-			},
-		}, nil
-	}
-
-	var receivedEgress bootstrap.EgressDeps
-	factories.Bindings["test-binding"] = func(_ context.Context, name string, _ config.BindingDef, deps bootstrap.BindingDeps) (core.Binding, error) {
-		receivedEgress = deps.Egress
-		return &coretesting.StubBinding{N: name}, nil
-	}
-
-	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
-	if err != nil {
-		t.Fatalf("Bootstrap: %v", err)
-	}
-	<-result.ProvidersReady
-
-	agentCtx := egress.WithSubject(ctx, egress.Subject{Kind: egress.SubjectUser, ID: "user-1"})
-	secretRes, err := receivedEgress.Resolver.Resolve(agentCtx, egress.ResolutionInput{
-		Target: egress.Target{Method: "GET", Host: "api.external.test", Path: "/v1/data"},
-	})
-	if err != nil {
-		t.Fatalf("Resolve secret grant: %v", err)
-	}
-	if secretRes.Credential.Authorization != "Bearer "+secretValue {
-		t.Fatalf("secret grant: got %q, want %q", secretRes.Credential.Authorization, "Bearer "+secretValue)
-	}
-
-	userCtx := egress.WithSubject(ctx, egress.Subject{Kind: egress.SubjectUser, ID: "user-456"})
-	providerRes, err := receivedEgress.Resolver.Resolve(userCtx, egress.ResolutionInput{
-		Target: egress.Target{Provider: "alpha", Method: "GET", Host: "api.provider.test", Path: "/v1/data"},
-	})
-	if err != nil {
-		t.Fatalf("Resolve provider grant: %v", err)
-	}
-	if !strings.Contains(providerRes.Credential.Authorization, tokenValue) {
-		t.Fatalf("provider grant: got %q, want to contain %q", providerRes.Credential.Authorization, tokenValue)
 	}
 }
 

--- a/internal/bootstrap/validate.go
+++ b/internal/bootstrap/validate.go
@@ -60,7 +60,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 	defer func() { _ = CloseProviders(providers) }()
 
 	sharedInvoker := invocation.NewBroker(providers, ds)
-	wireCredentialResolver(&deps.Egress, sharedInvoker, providers, sm)
+	wireCredentialResolver(&deps.Egress, sm)
 	audit := core.AuditSink(invocation.LogAuditSink{})
 
 	extensions, err := buildExtensionsWith(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress, buildRuntimeForValidation)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,8 +47,6 @@ type EgressPolicyRule struct {
 }
 
 type EgressCredentialGrant struct {
-	Provider    string `yaml:"provider"`
-	Instance    string `yaml:"instance"`
 	SecretRef   string `yaml:"secret_ref"`
 	AuthStyle   string `yaml:"auth_style"`
 	SubjectKind string `yaml:"subject_kind"`
@@ -629,11 +627,12 @@ func validateEgress(cfg *EgressConfig) error {
 	}
 	for i := range cfg.Credentials {
 		c := &cfg.Credentials[i]
+		if c.SecretRef == "" {
+			return fmt.Errorf("config validation: egress.credentials[%d]: secret_ref is required", i)
+		}
 		if err := egress.ValidateCredentialGrant(egress.CredentialGrantValidationInput{
 			SubjectKind: c.SubjectKind,
 			SubjectID:   c.SubjectID,
-			Provider:    c.Provider,
-			Instance:    c.Instance,
 			Operation:   c.Operation,
 			Method:      c.Method,
 			Host:        c.Host,

--- a/internal/egress/credential_grant_resolver.go
+++ b/internal/egress/credential_grant_resolver.go
@@ -24,12 +24,10 @@ func (l *StaticCredentialGrantLoader) LoadCredentialGrants(_ context.Context) ([
 }
 
 // CredentialGrantResolver resolves credentials by iterating ordered loaders,
-// finding the first matching grant, and materializing it. Loaders are evaluated
-// in order; within each loader the first matching grant wins.
+// finding the first matching grant, and materializing it via secret lookup.
+// Loaders are evaluated in order; within each loader the first matching grant wins.
 type CredentialGrantResolver struct {
 	Loaders        []CredentialGrantLoader
-	TokenResolver  ProviderTokenResolver
-	Materializer   CredentialMaterializer
 	SecretResolver SecretResolver
 }
 
@@ -45,7 +43,7 @@ func (r *CredentialGrantResolver) ResolveCredential(ctx context.Context, subject
 			continue
 		}
 
-		mat, err := r.resolveGrantCredential(ctx, subject, target, grant)
+		mat, err := resolveSecretGrant(ctx, r.SecretResolver, grant)
 		if err != nil {
 			return CredentialMaterialization{}, err
 		}
@@ -65,41 +63,8 @@ func firstMatchingGrant(grants []CredentialGrant, subject Subject, target Target
 		if g.SecretRef != "" {
 			return g, true
 		}
-		if _, _, ok := g.ResolveProvider(target); !ok {
-			continue
-		}
-		return g, true
 	}
 	return nil, false
-}
-
-func (r *CredentialGrantResolver) resolveGrantCredential(ctx context.Context, subject Subject, target Target, grant *CredentialGrant) (CredentialMaterialization, error) {
-	if grant.SecretRef != "" {
-		return resolveSecretGrant(ctx, r.SecretResolver, grant)
-	}
-
-	if _, canResolve := PrincipalForSubject(subject); !canResolve {
-		return CredentialMaterialization{}, nil
-	}
-
-	provider, instance, ok := grant.ResolveProvider(target)
-	if !ok {
-		return CredentialMaterialization{}, nil
-	}
-
-	if r.TokenResolver == nil {
-		return CredentialMaterialization{}, fmt.Errorf("egress credentials: no token resolver configured")
-	}
-
-	token, err := r.TokenResolver.ResolveProviderToken(ctx, subject, provider, instance)
-	if err != nil {
-		return CredentialMaterialization{}, fmt.Errorf("egress credentials: resolving token for %q: %w", provider, err)
-	}
-
-	if r.Materializer == nil {
-		return MaterializeCredential(token, AuthStyleBearer, nil)
-	}
-	return r.Materializer.MaterializeProviderCredential(provider, token)
 }
 
 func resolveSecretGrant(ctx context.Context, sr SecretResolver, grant *CredentialGrant) (CredentialMaterialization, error) {

--- a/internal/egress/credential_grant_validation.go
+++ b/internal/egress/credential_grant_validation.go
@@ -5,8 +5,6 @@ import "fmt"
 type CredentialGrantValidationInput struct {
 	SubjectKind string
 	SubjectID   string
-	Provider    string
-	Instance    string
 	Operation   string
 	Method      string
 	Host        string
@@ -15,10 +13,9 @@ type CredentialGrantValidationInput struct {
 }
 
 // ValidateCredentialGrant checks that a credential grant has at least one match
-// criterion and a valid auth_style. Instance is not a match criterion because it
-// only affects provider-token resolution, not request matching.
+// criterion and a valid auth_style.
 func ValidateCredentialGrant(g CredentialGrantValidationInput) error {
-	if g.SubjectKind == "" && g.SubjectID == "" && g.Provider == "" &&
+	if g.SubjectKind == "" && g.SubjectID == "" &&
 		g.Operation == "" && g.Method == "" &&
 		g.Host == "" && g.PathPrefix == "" {
 		return fmt.Errorf("at least one match criterion is required")

--- a/internal/egress/credential_grant_validation_test.go
+++ b/internal/egress/credential_grant_validation_test.go
@@ -17,14 +17,14 @@ func TestValidateCredentialGrant_RequiresMatchCriterion(t *testing.T) {
 	}
 }
 
-func TestValidateCredentialGrant_InstanceOnlyIsNotSufficient(t *testing.T) {
+func TestValidateCredentialGrant_AuthStyleOnlyIsNotSufficient(t *testing.T) {
 	t.Parallel()
 
 	err := ValidateCredentialGrant(CredentialGrantValidationInput{
-		Instance: "vendor-prod",
+		AuthStyle: "bearer",
 	})
 	if err == nil {
-		t.Fatal("expected error when only instance is set")
+		t.Fatal("expected error when only auth_style is set")
 	}
 	if !strings.Contains(err.Error(), "at least one match criterion") {
 		t.Fatalf("unexpected error: %v", err)
@@ -40,7 +40,6 @@ func TestValidateCredentialGrant_EachMatchCriterionSufficient(t *testing.T) {
 	}{
 		{"subject_kind", CredentialGrantValidationInput{SubjectKind: "agent"}},
 		{"subject_id", CredentialGrantValidationInput{SubjectID: "agent-1"}},
-		{"provider", CredentialGrantValidationInput{Provider: "vendorx"}},
 		{"operation", CredentialGrantValidationInput{Operation: "chat"}},
 		{"method", CredentialGrantValidationInput{Method: "POST"}},
 		{"host", CredentialGrantValidationInput{Host: "api.vendor.test"}},

--- a/internal/egress/provider_credentials.go
+++ b/internal/egress/provider_credentials.go
@@ -6,39 +6,12 @@ type CredentialResolver interface {
 	ResolveCredential(ctx context.Context, subject Subject, target Target) (CredentialMaterialization, error)
 }
 
-type ProviderTokenResolver interface {
-	ResolveProviderToken(ctx context.Context, subject Subject, provider, instance string) (string, error)
-}
-
-type CredentialMaterializer interface {
-	MaterializeProviderCredential(provider string, token string) (CredentialMaterialization, error)
-}
-
 type SecretResolver interface {
 	GetSecret(ctx context.Context, name string) (string, error)
 }
 
 type CredentialGrant struct {
-	Instance  string
 	SecretRef string
 	AuthStyle AuthStyle
 	MatchCriteria
-}
-
-func (g *CredentialGrant) ResolveProvider(target Target) (provider, instance string, ok bool) {
-	p := g.Provider
-	if p == "" {
-		p = target.Provider
-	}
-	if p == "" {
-		return "", "", false
-	}
-	inst := g.Instance
-	if inst == "" {
-		inst = target.Instance
-	}
-	if inst == "" {
-		inst = p
-	}
-	return p, inst, true
 }

--- a/internal/egress/subject_principal.go
+++ b/internal/egress/subject_principal.go
@@ -3,7 +3,6 @@ package egress
 import (
 	"context"
 
-	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/principal"
 )
 
@@ -21,26 +20,6 @@ func SubjectForPrincipal(p *principal.Principal) (Subject, bool) {
 		return Subject{Kind: SubjectIdentity, ID: principal.IdentityPrincipal}, true
 	}
 	return Subject{}, false
-}
-
-func PrincipalForSubject(s Subject) (*principal.Principal, bool) {
-	switch s.Kind {
-	case SubjectUser:
-		if s.ID == "" {
-			return nil, false
-		}
-		return &principal.Principal{UserID: s.ID}, true
-	case SubjectIdentity:
-		if s.ID == principal.IdentityPrincipal {
-			return &principal.Principal{UserID: principal.IdentityPrincipal}, true
-		}
-		if s.ID == "" {
-			return nil, false
-		}
-		return &principal.Principal{Identity: &core.UserIdentity{Email: s.ID}}, true
-	default:
-		return nil, false
-	}
 }
 
 func WithSubjectFromPrincipal(ctx context.Context, p *principal.Principal) context.Context {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4121,11 +4121,11 @@ func TestProxyBinding_CredentialInjection(t *testing.T) {
 			Loaders: []egress.CredentialGrantLoader{
 				&egress.StaticCredentialGrantLoader{
 					Grants: []egress.CredentialGrant{
-						{MatchCriteria: egress.MatchCriteria{Provider: "test-provider"}},
+						{SecretRef: "inject-key", MatchCriteria: egress.MatchCriteria{Host: upstream.Listener.Addr().String()}},
 					},
 				},
 			},
-			TokenResolver: staticTokenResolverFunc("injected-token"),
+			SecretResolver: &coretesting.StubSecretManager{Secrets: map[string]string{"inject-key": "injected-token"}},
 		},
 	}
 
@@ -4166,18 +4166,6 @@ func TestProxyBinding_CredentialInjection(t *testing.T) {
 	auth, _ := receivedAuth.Load().(string)
 	if auth != "Bearer injected-token" {
 		t.Fatalf("upstream received Authorization = %q, want %q", auth, "Bearer injected-token")
-	}
-}
-
-type tokenResolverFunc func(ctx context.Context, subject egress.Subject, provider, instance string) (string, error)
-
-func (f tokenResolverFunc) ResolveProviderToken(ctx context.Context, subject egress.Subject, provider, instance string) (string, error) {
-	return f(ctx, subject, provider, instance)
-}
-
-func staticTokenResolverFunc(token string) tokenResolverFunc {
-	return func(_ context.Context, _ egress.Subject, _, _ string) (string, error) {
-		return token, nil
 	}
 }
 


### PR DESCRIPTION
Proxy credential injection is now exclusively secret-backed. The
provider-token path let the proxy borrow an integration's OAuth
connection for outbound requests, but neither supported deployment mode
requires this. Removing it eliminates the `ProviderTokenResolver` and
`CredentialMaterializer` interfaces, the bootstrap adapters that bridged
the invocation broker into the credential chain, and the
`PrincipalForSubject` reverse-mapping function that only existed to
serve that path.

Config validation now requires `secret_ref` on every credential grant,
and the `provider` and `instance` fields are removed from the grant
schema. Documentation in the gateway-only guide and config reference is
updated to reflect the secret-only model.

Stacked on #218.