### PR TITLE
fix: surface missing path parameter errors as HTTP 400

### DIFF
--- a/internal/apiexec/apiexec.go
+++ b/internal/apiexec/apiexec.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,8 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 )
+
+var ErrMissingPathParam = errors.New("missing required path parameter")
 
 const (
 	defaultMaxRetries   = 3
@@ -351,7 +354,7 @@ func substitutePath(path string, params map[string]any) (string, error) {
 		key := match[1 : len(match)-1]
 		v, ok := params[key]
 		if !ok {
-			missingErr = fmt.Errorf("missing required path parameter: %s", key)
+			missingErr = fmt.Errorf("%w: %s", ErrMissingPathParam, key)
 			return match
 		}
 		delete(params, key)

--- a/internal/apiexec/apiexec_test.go
+++ b/internal/apiexec/apiexec_test.go
@@ -3,6 +3,7 @@ package apiexec
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,31 @@ import (
 
 	"github.com/valon-technologies/gestalt/internal/testutil"
 )
+
+func TestSubstitutePath_MissingParam(t *testing.T) {
+	t.Parallel()
+	_, err := substitutePath("/users/{userId}/messages", map[string]any{})
+	if err == nil {
+		t.Fatal("expected error for missing path parameter")
+	}
+	if !errors.Is(err, ErrMissingPathParam) {
+		t.Errorf("expected ErrMissingPathParam, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "userId") {
+		t.Errorf("error should mention the missing param name, got: %v", err)
+	}
+}
+
+func TestSubstitutePath_Success(t *testing.T) {
+	t.Parallel()
+	result, err := substitutePath("/users/{userId}/messages", map[string]any{"userId": "me"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "/users/me/messages" {
+		t.Errorf("expected /users/me/messages, got: %s", result)
+	}
+}
 
 func TestDoGETWithQueryAndPathParams(t *testing.T) {
 	t.Parallel()

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/apiexec"
 	"github.com/valon-technologies/gestalt/internal/discovery"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	"github.com/valon-technologies/gestalt/internal/oauth"
@@ -332,6 +333,8 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusInternalServerError, "internal error")
 		case errors.Is(err, core.ErrMCPOnly):
 			writeError(w, http.StatusBadRequest, "this integration is accessible only via MCP")
+		case errors.Is(err, apiexec.ErrMissingPathParam):
+			writeError(w, http.StatusBadRequest, err.Error())
 		default:
 			log.Printf("operation %s/%s failed: %v", providerName, operationName, err)
 			writeError(w, http.StatusBadGateway, "operation failed")


### PR DESCRIPTION
## Summary
- Introduce `ErrMissingPathParam` sentinel error in apiexec package
- Catch it in the server handler and return HTTP 400 with the actual error message instead of generic 502 "operation failed"
- Add tests for path parameter substitution

## Test plan
- Run `go test ./internal/apiexec/... ./internal/server/...`
- Deploy and verify `gestalt invoke gmail gmail.users.messages.list` returns "missing required path parameter: userId" (400) instead of "operation failed" (502)

🤖 Generated with [Claude Code](https://claude.com/claude-code)