### PR TITLE
fix: validate required parameters before operation execution

### DIFF
--- a/internal/invocation/broker.go
+++ b/internal/invocation/broker.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/valon-technologies/gestalt/core"
@@ -73,6 +74,9 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	for _, op := range ops {
 		if op.Name == operation {
 			found = true
+			if missing := missingRequiredParams(op.Parameters, params); len(missing) > 0 {
+				return nil, fmt.Errorf("%w: %s", ErrMissingRequiredParam, strings.Join(missing, ", "))
+			}
 			break
 		}
 	}
@@ -276,4 +280,16 @@ func (b *Broker) refreshOAuth(ctx context.Context, oauthProv core.OAuthProvider,
 		}
 	}
 	return oauthProv.RefreshToken(ctx, refreshToken)
+}
+
+func missingRequiredParams(defined []core.Parameter, provided map[string]any) []string {
+	var missing []string
+	for _, p := range defined {
+		if p.Required {
+			if _, ok := provided[p.Name]; !ok {
+				missing = append(missing, p.Name)
+			}
+		}
+	}
+	return missing
 }

--- a/internal/invocation/broker_test.go
+++ b/internal/invocation/broker_test.go
@@ -1,0 +1,31 @@
+package invocation
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+)
+
+func TestMissingRequiredParams(t *testing.T) {
+	t.Parallel()
+	params := []core.Parameter{
+		{Name: "userId", Required: true},
+		{Name: "format", Required: false},
+		{Name: "id", Required: true},
+	}
+
+	missing := missingRequiredParams(params, map[string]any{"userId": "me"})
+	if len(missing) != 1 || missing[0] != "id" {
+		t.Errorf("expected [id], got %v", missing)
+	}
+
+	missing = missingRequiredParams(params, map[string]any{"userId": "me", "id": "123"})
+	if len(missing) != 0 {
+		t.Errorf("expected no missing params, got %v", missing)
+	}
+
+	missing = missingRequiredParams(params, map[string]any{})
+	if len(missing) != 2 {
+		t.Errorf("expected 2 missing params, got %v", missing)
+	}
+}

--- a/internal/invocation/errors.go
+++ b/internal/invocation/errors.go
@@ -3,11 +3,12 @@ package invocation
 import "errors"
 
 var (
-	ErrProviderNotFound  = errors.New("provider not found")
-	ErrOperationNotFound = errors.New("operation not found")
-	ErrNotAuthenticated  = errors.New("not authenticated")
-	ErrNoToken           = errors.New("no integration token")
-	ErrAmbiguousInstance = errors.New("ambiguous instance")
-	ErrUserResolution    = errors.New("user resolution failed")
-	ErrInternal          = errors.New("internal error")
+	ErrProviderNotFound     = errors.New("provider not found")
+	ErrOperationNotFound    = errors.New("operation not found")
+	ErrMissingRequiredParam = errors.New("missing required parameter")
+	ErrNotAuthenticated     = errors.New("not authenticated")
+	ErrNoToken              = errors.New("no integration token")
+	ErrAmbiguousInstance    = errors.New("ambiguous instance")
+	ErrUserResolution       = errors.New("user resolution failed")
+	ErrInternal             = errors.New("internal error")
 )

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -328,6 +328,8 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusConflict, err.Error())
 		case errors.Is(err, invocation.ErrUserResolution):
 			writeError(w, http.StatusInternalServerError, "failed to resolve user")
+		case errors.Is(err, invocation.ErrMissingRequiredParam):
+			writeError(w, http.StatusBadRequest, err.Error())
 		case errors.Is(err, invocation.ErrInternal):
 			writeError(w, http.StatusInternalServerError, "internal error")
 		case errors.Is(err, core.ErrMCPOnly):


### PR DESCRIPTION
## Summary
- Add `ErrMissingRequiredParam` sentinel error in invocation package
- Validate required parameters in the broker before calling Execute(), using the operation's parameter metadata
- Return HTTP 400 with specific error listing which required params are missing

## Test plan
- Run `go test ./internal/invocation/... ./internal/server/...`
- Deploy and verify `gestalt invoke gmail gmail.users.messages.list` returns clear error about missing `userId` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)