### PR TITLE
feat: add default_params support for upstream integrations

### DIFF
--- a/core/integration/base.go
+++ b/core/integration/base.go
@@ -107,6 +107,8 @@ type Base struct {
 	HTTPClient         *http.Client
 	Pagination         map[string]apiexec.PaginationConfig
 
+	DefaultParams map[string]any
+
 	TokenParser    func(token string) (authHeader string, extraHeaders map[string]string, err error)
 	CheckResponse  apiexec.ResponseChecker
 	ExecuteFunc    func(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error)

--- a/core/integration/default_params_test.go
+++ b/core/integration/default_params_test.go
@@ -1,0 +1,116 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDefaultParamsAppliedWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"path": r.URL.Path,
+		})
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL,
+		Endpoints: map[string]Endpoint{
+			"list_messages": {Method: http.MethodGet, Path: "/v1/users/{userId}/messages"},
+		},
+		DefaultParams: map[string]any{
+			"userId": "me",
+		},
+	}
+
+	result, err := b.Execute(context.Background(), "list_messages", nil, "tok")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if resp["path"] != "/v1/users/me/messages" {
+		t.Fatalf("path = %v, want /v1/users/me/messages", resp["path"])
+	}
+}
+
+func TestDefaultParamsNotOverrideExplicit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"path": r.URL.Path,
+		})
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL,
+		Endpoints: map[string]Endpoint{
+			"list_messages": {Method: http.MethodGet, Path: "/v1/users/{userId}/messages"},
+		},
+		DefaultParams: map[string]any{
+			"userId": "me",
+		},
+	}
+
+	result, err := b.Execute(context.Background(), "list_messages", map[string]any{
+		"userId": "someone-else",
+	}, "tok")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if resp["path"] != "/v1/users/someone-else/messages" {
+		t.Fatalf("path = %v, want /v1/users/someone-else/messages", resp["path"])
+	}
+}
+
+func TestNoDefaultParamsDoesNotInterfere(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"path": r.URL.Path,
+		})
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL,
+		Endpoints: map[string]Endpoint{
+			"list_items": {Method: http.MethodGet, Path: "/api/items"},
+		},
+	}
+
+	result, err := b.Execute(context.Background(), "list_items", nil, "tok")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if resp["path"] != "/api/items" {
+		t.Fatalf("path = %v, want /api/items", resp["path"])
+	}
+}

--- a/core/integration/egress_adapter.go
+++ b/core/integration/egress_adapter.go
@@ -17,6 +17,17 @@ func (b *Base) executeREST(ctx context.Context, operation string, params map[str
 		return nil, fmt.Errorf("unknown operation: %s", operation)
 	}
 
+	if len(b.DefaultParams) > 0 {
+		if params == nil {
+			params = make(map[string]any)
+		}
+		for k, v := range b.DefaultParams {
+			if _, exists := params[k]; !exists {
+				params[k] = v
+			}
+		}
+	}
+
 	baseURL, headers := b.resolvedURLAndHeaders(ctx)
 	req := apiexec.Request{
 		Method:        ep.Method,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -153,10 +153,11 @@ const (
 )
 
 type UpstreamDef struct {
-	Type              string     `yaml:"type"`
-	URL               string     `yaml:"url"`
-	MCP               bool       `yaml:"mcp"`
-	AllowedOperations AllowedOps `yaml:"allowed_operations"`
+	Type              string         `yaml:"type"`
+	URL               string         `yaml:"url"`
+	MCP               bool           `yaml:"mcp"`
+	AllowedOperations AllowedOps     `yaml:"allowed_operations"`
+	DefaultParams     map[string]any `yaml:"default_params"`
 
 	// Per-upstream auth overrides. When set, these take precedence over
 	// integration-level auth for this upstream. When empty, the

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -84,6 +84,7 @@ func Build(def *Definition, intg config.IntegrationDef, allowedOperations map[st
 		Endpoints:          endpoints,
 		Queries:            coreintegration.QueriesMap(cat),
 		Headers:            def.Headers,
+		DefaultParams:      def.DefaultParams,
 		Pagination:         buildPaginationConfigs(def),
 		EgressResolver:     bo.egress,
 	}

--- a/internal/provider/compiler/compiler.go
+++ b/internal/provider/compiler/compiler.go
@@ -22,6 +22,9 @@ func Compile(ctx context.Context, name string, upstream config.UpstreamDef, prep
 	if err != nil {
 		return nil, err
 	}
+	if len(upstream.DefaultParams) > 0 {
+		def.DefaultParams = upstream.DefaultParams
+	}
 	return &Result{
 		Definition: def,
 		Catalog:    provider.CatalogFromDefinition(def),
@@ -36,6 +39,9 @@ func BuildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 	def, err := loadDefinition(ctx, name, upstream, preparedProviders)
 	if err != nil {
 		return nil, err
+	}
+	if len(upstream.DefaultParams) > 0 {
+		def.DefaultParams = upstream.DefaultParams
 	}
 	return provider.Build(def, integrationWithUpstreamAuth(intg, upstream), map[string]string(upstream.AllowedOperations), opts...)
 }

--- a/internal/provider/definition.go
+++ b/internal/provider/definition.go
@@ -26,6 +26,8 @@ type Definition struct {
 
 	PostConnectDiscovery *PostConnectDiscoveryDef `yaml:"post_connect_discovery" json:"post_connect_discovery,omitempty"`
 
+	DefaultParams map[string]any `yaml:"default_params" json:"default_params"`
+
 	Connection map[string]ConnectionParamDef `yaml:"connection" json:"connection"`
 	Operations map[string]OperationDef       `yaml:"operations" json:"operations"`
 }


### PR DESCRIPTION
## Summary
- Add `default_params` config field to `UpstreamDef` for auto-populating missing path/query parameters
- Thread defaults through compiler → definition → provider → REST execution
- Defaults are only applied when the parameter is not explicitly provided by the caller

## Test plan
- Run `go test ./core/integration/... ./internal/provider/... ./internal/apiexec/...`
- Configure `default_params: {userId: me}` on Gmail upstream and verify `gestalt invoke gmail gmail.users.messages.list` works without `-p userId=me`
- Verify explicit `-p userId=other` still overrides the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)