### PR TITLE
fix: add list_threads to gmail provider inventory

### DIFF
--- a/plugins/providers/inventory/inventory.yaml
+++ b/plugins/providers/inventory/inventory.yaml
@@ -242,6 +242,7 @@ providers:
       - get_thread
       - list_labels
       - list_messages
+      - list_threads
       - mark_as_read
       - remove_label
       - reply_to_message


### PR DESCRIPTION
## Summary
- Add `list_threads` operation to gmail provider inventory
- Companion change needed in valon-tools to add `gmail.users.threads.list` to `allowed_operations` in deploy config

## Test plan
- Run `go test ./plugins/providers/inventory/...`
- After deploying with corresponding valon-tools config change, verify `gestalt invoke gmail` lists the threads.list operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)