### PR TITLE
Resolve local upstream URLs relative to config directory

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -440,6 +440,9 @@ func resolveRelativePaths(configPath string, cfg *Config) {
 		if intg.IconFile != "" {
 			intg.IconFile = resolveRelativePath(baseDir, intg.IconFile)
 		}
+		for i := range intg.Upstreams {
+			intg.Upstreams[i].URL = resolveUpstreamURL(baseDir, intg.Upstreams[i].URL)
+		}
 		if intg.Plugin != nil {
 			intg.Plugin.Command = resolveExecutablePath(baseDir, intg.Plugin.Command)
 			intg.Plugin.Package = resolvePackagePath(baseDir, intg.Plugin.Package)
@@ -472,6 +475,13 @@ func resolveExecutablePath(baseDir, value string) string {
 		return filepath.Clean(filepath.Join(baseDir, value))
 	}
 	return value
+}
+
+func resolveUpstreamURL(baseDir, value string) string {
+	if value == "" || filepath.IsAbs(value) || strings.HasPrefix(value, "https://") || strings.HasPrefix(value, "http://") {
+		return value
+	}
+	return filepath.Clean(filepath.Join(baseDir, value))
 }
 
 func resolvePackagePath(baseDir, value string) string {


### PR DESCRIPTION
Local upstream URLs like `../providers/extend.yaml` were resolved
relative to the working directory, not the config file's directory.
This worked when the CWD matched the config location but broke when
running `gestaltd bundle` from a different directory, since the
bundled config tree lives in a new output path. This adds upstream
URL resolution to `resolveRelativePaths`, matching the existing
behavior for `icon_file` and `plugin.package`.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>