### PR TITLE
Align docs and examples to gestaltd bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# Gestalt
+
+Gestalt is a unified API gateway for integrations. It loads a YAML config, connects to REST, GraphQL, and MCP upstreams, manages OAuth and manual credentials, and serves a single API and MCP endpoint for all configured integrations.
+
+## Local Quickstart
+
+```sh
+gestaltd
+```
+
+Bare `gestaltd` auto-generates a local config, boots with local auth and SQLite, and starts serving. No setup needed.
+
+## Production Deployment
+
+```sh
+gestaltd bundle --config ./config.yaml --output ./bundle
+gestaltd serve --locked --config ./bundle/config.yaml
+```
+
+`bundle` resolves remote provider specs, installs plugin packages, writes a lockfile, and produces a self-contained output directory. `serve --locked` starts the server from that prepared state without fetching or mutating anything.
+
+## Commands
+
+| Command | Purpose |
+|---|---|
+| `gestaltd` | Local dev: auto-prepares and serves. |
+| `gestaltd bundle --config PATH --output DIR` | Production prep: produces a self-contained deployable bundle. |
+| `gestaltd serve --locked --config PATH` | Production runtime: serves from prepared state only. |
+| `gestaltd validate --config PATH` | CI: validates config without starting the server. |
+| `gestaltd plugin package --input DIR --output FILE` | Authoring: packages a plugin for distribution. |
+| `gestaltd plugin init --id ID --kind KIND --output DIR` | Authoring: scaffolds a plugin package directory. |
+
+## Docker
+
+```dockerfile
+FROM valontechnologies/gestalt:latest AS build
+COPY config.yaml /src/config.yaml
+RUN ["/gestaltd", "bundle", "--config", "/src/config.yaml", "--output", "/app"]
+
+FROM valontechnologies/gestalt:latest
+COPY --from=build /app/ /app/
+CMD ["serve", "--locked", "--config", "/app/config.yaml"]
+```
+
+## Documentation
+
+Full documentation is available at [gestalt.run](https://gestalt.run).
+
+- [Getting Started](/getting-started)
+- [Configuration](/concepts/configuration)
+- [CLI Reference](/reference/cli)
+- [Deployment](/deploy)
+- [Write a Plugin](/tasks/write-a-plugin)

--- a/docs/pages/concepts/configuration.mdx
+++ b/docs/pages/concepts/configuration.mdx
@@ -73,7 +73,7 @@ Some fields are effectively mandatory:
 
 `server.encryption_key` is the root secret for the deployment. Gestalt derives other cryptographic material from it, including session-related secrets for some auth providers.
 
-## Prepared State: `init`, `validate`, And `serve --locked`
+## Prepared State: `bundle`, `validate`, And `serve --locked`
 
 Gestalt supports both mutable startup and deterministic startup.
 
@@ -89,19 +89,22 @@ This is convenient for development.
 
 ### Deterministic Startup
 
-`gestaltd init` writes prepared artifacts next to the config:
+`gestaltd bundle --config PATH --output DIR` resolves remote dependencies into a self-contained output directory containing:
 
 - `gestalt.lock.json`
 - `.gestalt/providers/*.json`
 - `.gestalt/plugins/...`
 
-After that, `gestaltd serve --locked` starts only if the prepared state exactly matches the config.
+After that, `gestaltd serve --locked --config <output>/PATH` starts only if the prepared state exactly matches the config.
 
 ### Validation
 
-`gestaltd validate --config PATH` is non-mutating and expects existing lock state.
+`gestaltd validate --config PATH` is non-mutating and expects existing lock state. Bundle first, then validate the bundled output:
 
-`gestaltd validate --init --config PATH` first prepares remote dependencies, then validates the resulting locked deployment.
+```sh
+gestaltd bundle --config ./gestalt.yaml --output ./bundle
+gestaltd validate --config ./bundle/gestalt.yaml
+```
 
 ## Relative Paths
 

--- a/docs/pages/concepts/integrations.mdx
+++ b/docs/pages/concepts/integrations.mdx
@@ -160,7 +160,7 @@ These fields only affect how the provider is presented, not how it executes:
 - `icon_file`
 - `mcp_tool_prefix`
 
-`icon_file` is resolved relative to the config file and embedded into the prepared provider artifact during `init`.
+`icon_file` is resolved relative to the config file and embedded into the prepared provider artifact during `bundle`.
 
 ## Instances
 

--- a/docs/pages/concepts/plugin-packaging.mdx
+++ b/docs/pages/concepts/plugin-packaging.mdx
@@ -1,6 +1,6 @@
 # Plugin Packaging
 
-Gestalt can run plugins directly from a local executable, but it can also install and lock packaged plugins. Packaged plugins are the better fit for deployment because they give `gestaltd init` something explicit to verify and install.
+Gestalt can run plugins directly from a local executable, but it can also install and lock packaged plugins. Packaged plugins are the better fit for deployment because they give `gestaltd bundle` something explicit to verify and install.
 
 ## The Manifest
 
@@ -86,16 +86,16 @@ integrations:
 
 Plain `http://` is rejected. Remote packages must use HTTPS.
 
-## What `init` Does
+## What `bundle` Does
 
-`gestaltd init` installs packaged plugins into local prepared state and records them in `gestalt.lock.json`.
+`gestaltd bundle` installs packaged plugins into the output directory and records them in `gestalt.lock.json`.
 
-That prepared state lives under:
+The bundled state includes:
 
 - `.gestalt/plugins/...`
 - `gestalt.lock.json`
 
-When you later run `gestaltd serve --locked`, startup succeeds only if those prepared artifacts still match the config.
+When you later run `gestaltd serve --locked` against the bundled config, startup succeeds only if those prepared artifacts still match the config.
 
 ## Why Packaging Matters
 
@@ -107,4 +107,4 @@ Packaging gives you:
 - optional config schema validation
 - deterministic production startup
 
-For development, `plugin.command` is usually simpler. For deployment, `plugin.package` plus `gestaltd init` is the stronger model.
+For development, `plugin.command` is usually simpler. For deployment, `plugin.package` plus `gestaltd bundle` is the stronger model.

--- a/docs/pages/concepts/plugin-protocol.mdx
+++ b/docs/pages/concepts/plugin-protocol.mdx
@@ -55,7 +55,7 @@ That is how a runtime plugin participates in the same execution model as built-i
 
 The host and plugin speak an explicit protocol version. Provider metadata includes a supported range, and startup fails if the current host version is outside that range.
 
-That check is what allows packaged plugins to be validated before or during `init`.
+That check is what allows packaged plugins to be validated during `bundle`.
 
 ## Config Placement
 

--- a/docs/pages/contributing.mdx
+++ b/docs/pages/contributing.mdx
@@ -29,7 +29,8 @@ The easiest way to make docs drift is to copy previous prose instead of reading 
 ```sh
 go test ./...
 
-gestaltd validate --init --config ./gestalt.dev.yaml
+gestaltd bundle --config ./gestalt.dev.yaml --output ./bundle
+gestaltd validate --config ./bundle/gestalt.dev.yaml
 
 cd docs
 npm ci

--- a/docs/pages/deploy/fly-io.mdx
+++ b/docs/pages/deploy/fly-io.mdx
@@ -36,7 +36,7 @@ This allows mutable startup.
 
 ### Preferred Production Shape
 
-Run `gestaltd init` before the main process starts, then run:
+Run `gestaltd bundle` before the main process starts, then run:
 
 ```sh
 /gestaltd serve --locked --config /etc/gestalt/config.yaml

--- a/docs/pages/deploy/gateway-only.mdx
+++ b/docs/pages/deploy/gateway-only.mdx
@@ -184,7 +184,7 @@ egress:
 
 ## Startup
 
-Gateway-only configs have no remote upstreams to fetch, so locked startup works without `gestaltd init`:
+Gateway-only configs have no remote upstreams to fetch, so locked startup works without `gestaltd bundle`:
 
 ```sh
 gestaltd serve --config ./gateway.yaml
@@ -193,8 +193,8 @@ gestaltd serve --config ./gateway.yaml
 For production, you can still use the locked flow:
 
 ```sh
-gestaltd validate --init --config ./gateway.yaml
-gestaltd serve --locked --config ./gateway.yaml
+gestaltd bundle --config ./gateway.yaml --output ./bundle
+gestaltd serve --locked --config ./bundle/gateway.yaml
 ```
 
 See [Deploy Overview](/deploy) for Docker, Kubernetes, and other deployment targets.

--- a/docs/pages/deploy/index.mdx
+++ b/docs/pages/deploy/index.mdx
@@ -19,7 +19,7 @@ Every deployment needs the same inputs:
 | Mode | Command | When to use it |
 | --- | --- | --- |
 | Mutable | `gestaltd --config ...` or `gestaltd serve --config ...` | Local development or simple single-node deployments. |
-| Locked | `gestaltd init --config ...` then `gestaltd serve --locked --config ...` | Production deployments that should not fetch remote specs or mutate local state at boot. |
+| Locked | `gestaltd bundle --config ... --output DIR` then `gestaltd serve --locked --config DIR/...` | Production deployments that should not fetch remote specs or mutate local state at boot. |
 
 If your config depends on remote REST or GraphQL upstreams, or packaged plugins, the locked flow is the safer deployment model.
 
@@ -66,15 +66,15 @@ It mounts:
 The bare-binary model is straightforward:
 
 ```sh
-gestaltd validate --init --config ./gestalt.yaml
-gestaltd serve --locked --config ./gestalt.yaml
+gestaltd bundle --config ./gestalt.yaml --output ./bundle
+gestaltd serve --locked --config ./bundle/gestalt.yaml
 ```
 
 That is often the cleanest way to run Gestalt on a VM, inside systemd, or in a custom container build.
 
 ## Kubernetes
 
-The bundled Helm chart is the most complete production deployment path in the repo. It uses one Deployment for `gestaltd` and can optionally add an init container that runs `gestaltd init` before the main container starts.
+The bundled Helm chart is the most complete production deployment path in the repo. It uses one Deployment for `gestaltd` and can optionally add an init container that runs `gestaltd bundle` before the main container starts.
 
 See [Kubernetes](/deploy/kubernetes) for the exact chart behavior.
 

--- a/docs/pages/deploy/kubernetes.mdx
+++ b/docs/pages/deploy/kubernetes.mdx
@@ -10,7 +10,7 @@ The chart creates:
 - one `Service`
 - an optional `Ingress`
 - an optional persistent volume claim for `/data`
-- an optional init container for `gestaltd init`
+- an optional init container for `gestaltd bundle`
 
 There is no separate web Deployment. The web UI is served by the same `gestaltd` container as the API.
 
@@ -30,9 +30,8 @@ The chart supports an init container behind `pluginInit.enabled`.
 
 When enabled, the init container:
 
-1. copies the rendered config into a writable directory
-2. runs `gestaltd init --config /etc/gestalt/config.yaml`
-3. leaves `gestalt.lock.json` and `.gestalt/` in a shared volume
+1. runs `gestaltd bundle --config /etc/gestalt/config.yaml --output /data/bundle`
+2. leaves the bundled config, `gestalt.lock.json`, and `.gestalt/` in a shared volume
 
 The main container then reads from that prepared state.
 

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -24,7 +24,7 @@ The generated local config uses:
 The server listens on `http://localhost:8080`. The web UI is served from that same port.
 
 <Callout>
-  The default command `gestaltd` is intentionally local-friendly. It can auto-generate config and auto-prepare remote artifacts. Production deployments should usually use `gestaltd init` followed by `gestaltd serve --locked`.
+  The default command `gestaltd` is intentionally local-friendly. It can auto-generate config and auto-prepare remote artifacts. Production deployments should usually use `gestaltd bundle` followed by `gestaltd serve --locked`.
 </Callout>
 
 ## 2. Open The UI And Sign In
@@ -84,13 +84,14 @@ This is the smallest useful production-shaped config:
 - an explicit integration `base_url` for live requests
 - no per-user credential requirement because `connection_mode: none`
 
-## 4. Prepare And Validate It
+## 4. Bundle And Validate It
 
 ```sh
-gestaltd validate --init --config ./gestalt.yaml
+gestaltd bundle --config ./gestalt.yaml --output ./bundle
+gestaltd validate --config ./bundle/gestalt.yaml
 ```
 
-`--init` resolves remote provider inputs first, then validates the final locked state. For the config above, that writes:
+`bundle` resolves remote provider inputs into a self-contained output directory. For the config above, the bundle contains:
 
 - `gestalt.lock.json`
 - `.gestalt/providers/petstore.json`
@@ -98,7 +99,7 @@ gestaltd validate --init --config ./gestalt.yaml
 ## 5. Start From Locked State
 
 ```sh
-gestaltd serve --locked --config ./gestalt.yaml
+gestaltd serve --locked --config ./bundle/gestalt.yaml
 ```
 
 This is the deployment path to model in Docker, Kubernetes, or any other production target. Startup becomes deterministic because `gestaltd` no longer needs to mutate local state or fetch remote specs.

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -10,7 +10,7 @@ import { Cards, Steps } from 'nextra/components'
 | --- | --- |
 | `gestaltd` | The server binary. It loads config, bootstraps plugins, serves the HTTP API, serves the web UI, and mounts `/mcp` when MCP is enabled. |
 | `config.yaml` | The declarative control plane. This is where you define auth, datastore, secrets, integrations, runtimes, bindings, and egress policy. |
-| `gestalt.lock.json` and `.gestalt/` | Optional prepared state written by `gestaltd init`. Use it for deterministic startup when you depend on remote OpenAPI, GraphQL, or packaged plugins. |
+| `gestalt.lock.json` and `.gestalt/` | Optional prepared state written by `gestaltd bundle`. Use it for deterministic startup when you depend on remote OpenAPI, GraphQL, or packaged plugins. |
 | Deploy assets | A Dockerfile, `docker-compose.yml`, and a Helm chart for the bundled deployment paths. |
 
 ## The Four Foundations
@@ -22,7 +22,7 @@ Your YAML file declares the feature sets that make up a Gestalt deployment: plat
 
 ### Prepared State
 
-If your config points at remote OpenAPI specs, GraphQL endpoints, or packaged plugins, `gestaltd init` resolves them into local artifacts. Production deployments normally start from that prepared state with `gestaltd serve --locked`.
+If your config points at remote OpenAPI specs, GraphQL endpoints, or packaged plugins, `gestaltd bundle` resolves them into a self-contained output directory. Production deployments normally start from that bundled state with `gestaltd serve --locked`.
 
 ### Providers And Invocation
 
@@ -40,7 +40,7 @@ There are four real deployment modes to think about:
 1. `gestaltd` with no config: local-only, auto-generated config, local auth, SQLite, dev mode on.
 2. Docker or Docker Compose: single container, single HTTP port, config mounted into `/etc/gestalt/config.yaml`.
 3. Helm on Kubernetes: one Deployment for `gestaltd`, optional init container for locked startup.
-4. Bare binary: `gestaltd`, `gestaltd serve`, `gestaltd init`, and `gestaltd validate`.
+4. Bare binary: `gestaltd`, `gestaltd serve`, `gestaltd bundle`, and `gestaltd validate`.
 
 ## Start Here
 
@@ -52,7 +52,7 @@ There are four real deployment modes to think about:
     See how config, providers, the invocation broker, bindings, runtimes, and MCP fit together.
   </Cards.Card>
   <Cards.Card title="Configuration" href="/concepts/configuration">
-    Learn the top-level primitives and the lifecycle of `validate`, `init`, and `serve --locked`.
+    Learn the top-level primitives and the lifecycle of `bundle`, `validate`, and `serve --locked`.
   </Cards.Card>
   <Cards.Card title="Deploy" href="/deploy">
     Use the shipped Docker and Helm paths, then adapt the same model to Fly.io, Railway, Render, or Lambda.

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -10,20 +10,19 @@ The most important CLI surface in this repo is the `gestaltd` server binary.
 gestaltd [--config PATH]
 gestaltd plugin <command> [flags]
 gestaltd serve [--config PATH] [--locked]
-gestaltd init [--config PATH]
-gestaltd validate [--config PATH] [--init]
+gestaltd bundle --config PATH --output DIR
+gestaltd validate [--config PATH]
 ```
 
 ## Command Meanings
 
 | Command | What it does |
 | --- | --- |
-| `gestaltd` | Default start command. Can auto-generate a local config and can auto-init missing prepared state. |
+| `gestaltd` | Default start command. Can auto-generate a local config and can auto-prepare missing state. |
 | `gestaltd serve` | Start the server from an explicit config path. |
-| `gestaltd serve --locked` | Require exact prepared state. Do not auto-init. |
-| `gestaltd init` | Prepare remote provider artifacts and packaged plugins into locked local state. |
+| `gestaltd serve --locked` | Require exact prepared state. Do not auto-prepare. |
+| `gestaltd bundle` | Resolve remote provider artifacts and packaged plugins into a self-contained output directory. |
 | `gestaltd validate` | Load and validate config without starting the server. |
-| `gestaltd validate --init` | Prepare locked state first, then validate it. |
 | `gestaltd plugin package` | Build a distributable plugin archive from a manifest directory. |
 
 ## Default Command Behavior
@@ -51,10 +50,11 @@ When a command needs a config path, Gestalt resolves it in this order:
 4. `~/.gestalt/config.yaml`
 5. `/etc/gestalt/config.yaml`
 
-## `init`
+## `bundle`
 
-`gestaltd init --config ./gestalt.yaml` writes:
+`gestaltd bundle --config ./gestalt.yaml --output ./bundle` produces a self-contained output directory containing:
 
+- the bundled config
 - `gestalt.lock.json`
 - `.gestalt/providers/*.json`
 - `.gestalt/plugins/...`
@@ -70,17 +70,20 @@ Use it whenever your config contains:
 Use locked mode in production:
 
 ```sh
-gestaltd init --config ./gestalt.yaml
-gestaltd serve --locked --config ./gestalt.yaml
+gestaltd bundle --config ./gestalt.yaml --output ./bundle
+gestaltd serve --locked --config ./bundle/gestalt.yaml
 ```
 
 If prepared state is missing or stale, startup fails instead of mutating local state.
 
 ## `validate`
 
-`gestaltd validate` is non-mutating by default. It expects lock state to already exist when the config depends on prepared artifacts.
+`gestaltd validate` is non-mutating. It expects lock state to already exist when the config depends on prepared artifacts. Bundle first, then validate the bundled output:
 
-`gestaltd validate --init` is the most useful CI command for production-shaped configs.
+```sh
+gestaltd bundle --config ./gestalt.yaml --output ./bundle
+gestaltd validate --config ./bundle/gestalt.yaml
+```
 
 ## `plugin package`
 

--- a/docs/pages/tasks/add-an-integration.mdx
+++ b/docs/pages/tasks/add-an-integration.mdx
@@ -70,18 +70,19 @@ You can refine the integration with:
 - `mcp_tool_prefix` to avoid MCP tool-name collisions
 - `manual_auth: true` if the provider supports both OAuth and manual auth
 
-## 5. Validate And Prepare
+## 5. Bundle And Validate
 
 ```sh
-gestaltd validate --init --config ./gestalt.yaml
+gestaltd bundle --config ./gestalt.yaml --output ./bundle
+gestaltd validate --config ./bundle/gestalt.yaml
 ```
 
-That catches config errors and prepares any remote provider artifacts.
+That prepares remote provider artifacts and catches config errors.
 
 ## 6. Run It
 
 ```sh
-gestaltd serve --locked --config ./gestalt.yaml
+gestaltd serve --locked --config ./bundle/gestalt.yaml
 ```
 
 Then:

--- a/docs/pages/tasks/run-locally.mdx
+++ b/docs/pages/tasks/run-locally.mdx
@@ -35,11 +35,12 @@ Use this when you want to control:
 
 ## Locked Local Startup
 
-If your config includes remote REST or GraphQL upstreams, or packaged plugins, validate and prepare first:
+If your config includes remote REST or GraphQL upstreams, or packaged plugins, bundle and validate first:
 
 ```sh
-gestaltd validate --init --config ./gestalt.yaml
-gestaltd serve --locked --config ./gestalt.yaml
+gestaltd bundle --config ./gestalt.yaml --output ./bundle
+gestaltd validate --config ./bundle/gestalt.yaml
+gestaltd serve --locked --config ./bundle/gestalt.yaml
 ```
 
 This is the closest local approximation to a production deployment.

--- a/docs/pages/tasks/use-a-plugin-package.mdx
+++ b/docs/pages/tasks/use-a-plugin-package.mdx
@@ -19,26 +19,26 @@ integrations:
 - a local `.tar.gz`
 - an HTTPS URL
 
-## 2. Prepare It
+## 2. Bundle It
 
 ```sh
-gestaltd init --config ./gestalt.yaml
+gestaltd bundle --config ./gestalt.yaml --output ./bundle
 ```
 
-This validates the manifest, selects the current platform artifact, installs the package into `.gestalt/plugins/`, and records the prepared result in `gestalt.lock.json`.
+This validates the manifest, selects the current platform artifact, installs the package into the output directory, and records the prepared result in `gestalt.lock.json`.
 
-## 3. Validate The Locked Deployment
+## 3. Validate The Bundled Deployment
 
 ```sh
-gestaltd validate --config ./gestalt.yaml
+gestaltd validate --config ./bundle/gestalt.yaml
 ```
 
-Validation now uses the prepared plugin state instead of re-resolving the package every time.
+Validation uses the prepared plugin state instead of re-resolving the package every time.
 
 ## 4. Start From Locked State
 
 ```sh
-gestaltd serve --locked --config ./gestalt.yaml
+gestaltd serve --locked --config ./bundle/gestalt.yaml
 ```
 
 That is the normal production path for packaged plugins.
@@ -48,7 +48,7 @@ That is the normal production path for packaged plugins.
 If `plugin.package` points at an HTTPS URL and the remote archive changes, rerun:
 
 ```sh
-gestaltd init --config ./gestalt.yaml
+gestaltd bundle --config ./gestalt.yaml --output ./bundle
 ```
 
-Remote packages are intentionally refreshed during explicit `init`.
+Remote packages are intentionally refreshed during explicit `bundle`.

--- a/docs/pages/tasks/write-a-plugin.mdx
+++ b/docs/pages/tasks/write-a-plugin.mdx
@@ -107,11 +107,11 @@ integrations:
       package: ./my-tool.tar.gz
 ```
 
-Then hydrate and serve:
+Then bundle and serve:
 
 ```sh
-gestaltd init --config config.yaml
-gestaltd serve --locked --config config.yaml
+gestaltd bundle --config config.yaml --output ./bundle
+gestaltd serve --locked --config ./bundle/config.yaml
 ```
 
 ## Overlay plugins

--- a/docs/pages/troubleshooting.mdx
+++ b/docs/pages/troubleshooting.mdx
@@ -15,10 +15,10 @@ Your config references something that must be prepared first, usually:
 Run:
 
 ```sh
-gestaltd init --config ./gestalt.yaml
+gestaltd bundle --config ./gestalt.yaml --output ./bundle
 ```
 
-and then start again with `serve --locked`.
+and then start again with `gestaltd serve --locked --config ./bundle/gestalt.yaml`.
 
 ## OAuth Redirects Are Wrong
 

--- a/examples/deploy/Dockerfile
+++ b/examples/deploy/Dockerfile
@@ -1,0 +1,7 @@
+FROM valontechnologies/gestalt:latest AS build
+COPY config.yaml /src/config.yaml
+RUN ["/gestaltd", "bundle", "--config", "/src/config.yaml", "--output", "/app"]
+
+FROM valontechnologies/gestalt:latest
+COPY --from=build /app/ /app/
+CMD ["serve", "--locked", "--config", "/app/config.yaml"]


### PR DESCRIPTION
The repo still described the old `gestaltd init` lifecycle as the
primary production path across 17 documentation files. This replaces
all user-facing `init` references with `bundle`, removes
`validate --init`, adds a root README with the new command model, and
adds a canonical deployment Dockerfile example. The story is now
consistent: `gestaltd` for local dev, `bundle` for production prep,
`serve --locked` for runtime.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>