### PR TITLE
Remove dead proxy Instance field from Target and config

### DIFF
--- a/docs/adr/002-gateway-composition.md
+++ b/docs/adr/002-gateway-composition.md
@@ -6,26 +6,24 @@ Accepted
 
 ## Context
 
-Gestalt currently assumes every proxy binding has exactly one provider configured. However, a gateway-only deployment (auth + datastore + secret manager + proxy binding + saved deny rules) is a useful shape that does not require any provider. We need to clarify which components are required, which are optional, and how the gateway relates to the full Gestalt deployment.
+Gestalt currently assumes every proxy binding has exactly one provider configured. However, a gateway-only deployment (auth + datastore + secret manager + proxy binding + static egress policy) is a useful shape that does not require any provider. We need to clarify which components are required, which are optional, and how the gateway relates to the full Gestalt deployment.
 
 ## Decision
 
-1. **Gateway-only is a valid deployment shape.** A deployment with auth, datastore, secret manager, proxy binding, and saved deny rules is a supported composition of existing parts. It does not require providers.
+1. **Gateway-only is a valid deployment shape.** A deployment with auth, datastore, secret manager, proxy binding, and static egress policy is a supported composition of existing parts. It does not require providers.
 
 2. **Full Gestalt reuses the same substrate.** The full deployment uses the exact same auth and egress infrastructure as the gateway-only shape. Providers are additive.
 
 3. **Providers are optional capability adapters.** Providers supply credentials and policy for specific upstream services. A proxy binding with zero providers forwards requests without injecting provider credentials. A proxy binding with one provider resolves credentials through that provider. Two or more providers on a single binding are rejected.
 
-4. **v1 saved rules are deny-only.** The first version of saved rules supports deny rules only. Allow rules are deferred.
+4. **Egress policy is config-defined.** Policy rules are declared in the `egress:` config block and evaluated at request time. There is no runtime API for creating or mutating rules.
 
-5. **v1 admin control uses `admin_emails`.** Administrative access is governed by the `admin_emails` configuration field.
+5. **Proxy credentials are secret-backed.** Credential grants reference secrets via `secret_ref` and are resolved through the configured secret manager at request time.
 
-6. **Shared/workload EgressClient scope is deferred.** Scoping EgressClient to shared or per-workload contexts is out of scope for v1.
-
-7. **Gateway-only is a composition, not a separate runtime.** A later gateway-service step can improve listener and routing ergonomics, but the gateway is not a separately optimized runtime surface.
+6. **Gateway-only is a composition, not a separate runtime.** A later gateway-service step can improve listener and routing ergonomics, but the gateway is not a separately optimized runtime surface.
 
 ## Consequences
 
 - The proxy factory must accept zero providers (not just exactly one).
 - Tests must cover the zero-provider path.
-- Future PRs can layer provider-backed and gateway-service capabilities on this foundation without restructuring.
+- Future PRs can layer additional gateway capabilities on this foundation without restructuring.

--- a/docs/pages/concepts/platform-model.mdx
+++ b/docs/pages/concepts/platform-model.mdx
@@ -121,7 +121,7 @@ Once providers exist, `gestaltd` projects them into several surfaces:
 
 | Surface | What it exposes |
 | --- | --- |
-| HTTP API | `/api/v1/...` for integration listing, auth flows, invocation, token management, egress clients, and admin egress rules. |
+| HTTP API | `/api/v1/...` for integration listing, auth flows, invocation, and token management. |
 | Embedded web UI | Served by the same server process and port as the API. |
 | MCP endpoint | `/mcp`, mounted only when at least one integration is MCP-enabled. |
 | Bindings | Additional routes and triggers declared under `bindings:`. |

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -428,7 +428,6 @@ bindings:
 | Field | Notes |
 | --- | --- |
 | `path` | Required. Must start with `/`. |
-| `instance` | Optional provider instance to use for credential resolution. |
 
 Rules:
 

--- a/internal/egress/types.go
+++ b/internal/egress/types.go
@@ -18,7 +18,6 @@ type Subject struct {
 // Target describes the destination and logical source for an outbound request.
 type Target struct {
 	Provider  string
-	Instance  string
 	Operation string
 	Method    string
 	Host      string

--- a/plugins/bindings/proxy/binding.go
+++ b/plugins/bindings/proxy/binding.go
@@ -134,7 +134,6 @@ func (b *Binding) resolve(r *http.Request) (egress.Resolution, []byte, error) {
 	headers := sanitizeForwardHeaders(normalizeHeaders(r.Header))
 	target := egress.Target{
 		Provider: b.provider,
-		Instance: b.cfg.Instance,
 		Method:   r.Method,
 		Host:     resolveHost(r),
 		Path:     resolvePath(r, b.cfg.normalizedPath()),

--- a/plugins/bindings/proxy/config.go
+++ b/plugins/bindings/proxy/config.go
@@ -7,8 +7,7 @@ import (
 )
 
 type proxyConfig struct {
-	Path     string `yaml:"path"`
-	Instance string `yaml:"instance"`
+	Path string `yaml:"path"`
 }
 
 func (c proxyConfig) validate(name string) error {

--- a/plugins/bindings/proxy/connect.go
+++ b/plugins/bindings/proxy/connect.go
@@ -33,7 +33,6 @@ func (b *Binding) handleConnect(w http.ResponseWriter, r *http.Request) {
 
 	target := egress.Target{
 		Provider: b.provider,
-		Instance: b.cfg.Instance,
 		Method:   http.MethodConnect,
 		Host:     targetHost,
 	}


### PR DESCRIPTION
The proxy binding populated `Instance` on every outbound `Target` but
no consumer ever read it. Matching, policy evaluation, credential
resolution, and HTTP execution all ignore the field. Integration
invocation never populated it either. Removing it eliminates dead state
that could mislead readers into thinking instance selection still
matters for proxy credential resolution.