### PR TITLE
Resolve relative OpenAPI server URLs against spec URL

### DIFF
--- a/internal/openapi/loader.go
+++ b/internal/openapi/loader.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -44,7 +45,15 @@ func LoadDefinition(ctx context.Context, name, specURL string, allowedOps map[st
 	}
 
 	if len(model.Model.Servers) > 0 {
-		def.BaseURL = strings.TrimRight(model.Model.Servers[0].URL, "/")
+		serverURL := model.Model.Servers[0].URL
+		if !strings.HasPrefix(serverURL, "http://") && !strings.HasPrefix(serverURL, "https://") {
+			if base, err := url.Parse(specURL); err == nil {
+				if ref, err := url.Parse(serverURL); err == nil {
+					serverURL = base.ResolveReference(ref).String()
+				}
+			}
+		}
+		def.BaseURL = strings.TrimRight(serverURL, "/")
 	}
 
 	extractAuth(&model.Model, def)

--- a/internal/openapi/loader_test.go
+++ b/internal/openapi/loader_test.go
@@ -497,6 +497,62 @@ func TestExtractAuthHTTPBasic(t *testing.T) {
 	}
 }
 
+func TestLoadDefinitionRelativeServerURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		servers []any
+		want    string
+	}{
+		{
+			name:    "absolute URL unchanged",
+			servers: []any{map[string]string{"url": "https://api.example.com/v1"}},
+			want:    "https://api.example.com/v1",
+		},
+		{
+			name:    "relative path resolved against spec URL",
+			servers: []any{map[string]string{"url": "/v1"}},
+		},
+		{
+			name:    "no servers leaves BaseURL empty",
+			servers: nil,
+			want:    "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			spec := map[string]any{
+				"openapi": "3.0.0",
+				"info":    map[string]string{"title": "Test"},
+				"paths":   map[string]any{},
+			}
+			if tc.servers != nil {
+				spec["servers"] = tc.servers
+			}
+
+			srv := serveJSON(t, spec)
+			testutil.CloseOnCleanup(t, srv)
+
+			want := tc.want
+			if tc.name == "relative path resolved against spec URL" {
+				want = srv.URL + "/v1"
+			}
+
+			def, err := LoadDefinition(context.Background(), "test", srv.URL, nil)
+			if err != nil {
+				t.Fatalf("LoadDefinition: %v", err)
+			}
+			if def.BaseURL != want {
+				t.Errorf("BaseURL = %q, want %q", def.BaseURL, want)
+			}
+		})
+	}
+}
+
 func TestLoadDefinitionYAML(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
OpenAPI specs can declare server URLs as relative paths (e.g. `/v1`),
which the loader previously stored as-is. This left the provider with
an unusable base URL since `/v1` alone cannot form a valid HTTP request.
The loader now resolves relative server URLs against the spec retrieval
URL, so a spec fetched from `https://api.example.com/openapi.json` with
a server entry of `/v1` produces the base URL `https://api.example.com/v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)