### PR TITLE
Add connection-aware token storage and invocation

### DIFF
--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -119,14 +119,15 @@ func runServer(env *bootstrapEnv) error {
 	}
 
 	srv, err := server.New(server.Config{
-		Auth:        result.Auth,
-		Datastore:   result.Datastore,
-		Providers:   result.Providers,
-		Runtimes:    result.Runtimes,
-		Bindings:    result.Bindings,
-		Invoker:     result.Invoker,
-		DevMode:     result.DevMode,
-		StateSecret: crypto.DeriveKey(env.Config.Server.EncryptionKey),
+		Auth:              result.Auth,
+		Datastore:         result.Datastore,
+		Providers:         result.Providers,
+		Runtimes:          result.Runtimes,
+		Bindings:          result.Bindings,
+		Invoker:           result.Invoker,
+		DefaultConnection: bootstrap.BuildConnectionMap(env.Config),
+		DevMode:           result.DevMode,
+		StateSecret:       crypto.DeriveKey(env.Config.Server.EncryptionKey),
 		Readiness: composeReadiness(
 			readinessFromChannel(result.ProvidersReady, "providers loading"),
 			datastoreReadiness(result.Datastore),
@@ -193,24 +194,34 @@ func runServer(env *bootstrapEnv) error {
 }
 
 type mcpSurface struct {
-	providers    []string
-	toolPrefixes map[string]string
-	includeREST  map[string]bool
+	providers     []string
+	toolPrefixes  map[string]string
+	includeREST   map[string]bool
+	apiConnection map[string]string
+	mcpConnection map[string]string
 }
 
 func buildMCPSurface(cfg *config.Config) mcpSurface {
 	surface := mcpSurface{
-		toolPrefixes: make(map[string]string),
-		includeREST:  make(map[string]bool),
+		toolPrefixes:  make(map[string]string),
+		includeREST:   make(map[string]bool),
+		apiConnection: make(map[string]string),
+		mcpConnection: make(map[string]string),
 	}
 
 	for name, intg := range cfg.Integrations {
 		if intg.Plugin != nil {
 			surface.providers = append(surface.providers, name)
+			surface.apiConnection[name] = config.PluginConnectionName
+			surface.mcpConnection[name] = config.PluginConnectionName
 		} else if intg.API != nil || intg.MCP != nil {
 			surface.providers = append(surface.providers, name)
 			if intg.API != nil {
 				surface.includeREST[name] = true
+				surface.apiConnection[name] = intg.API.Connection
+			}
+			if intg.MCP != nil {
+				surface.mcpConnection[name] = intg.MCP.Connection
 			}
 		}
 		if intg.MCPToolPrefix != "" {
@@ -238,6 +249,8 @@ func (s mcpSurface) handler(result *bootstrap.Result) (http.Handler, error) {
 			AllowedProviders: s.providers,
 			ToolPrefixes:     s.toolPrefixes,
 			IncludeREST:      s.includeREST,
+			APIConnection:    s.apiConnection,
+			MCPConnection:    s.mcpConnection,
 		}),
 		mcpserver.WithStateLess(true),
 	), nil

--- a/core/datastore.go
+++ b/core/datastore.go
@@ -8,9 +8,10 @@ type Datastore interface {
 	FindOrCreateUser(ctx context.Context, email string) (*User, error)
 
 	StoreToken(ctx context.Context, token *IntegrationToken) error
-	Token(ctx context.Context, userID, integration, instance string) (*IntegrationToken, error)
+	Token(ctx context.Context, userID, integration, connection, instance string) (*IntegrationToken, error)
 	ListTokens(ctx context.Context, userID string) ([]*IntegrationToken, error)
 	ListTokensForIntegration(ctx context.Context, userID, integration string) ([]*IntegrationToken, error)
+	ListTokensForConnection(ctx context.Context, userID, integration, connection string) ([]*IntegrationToken, error)
 	DeleteToken(ctx context.Context, id string) error
 
 	StoreAPIToken(ctx context.Context, token *APIToken) error

--- a/core/testing/datastore_suite.go
+++ b/core/testing/datastore_suite.go
@@ -161,7 +161,7 @@ func testDatastoreIntegrationTokens(t *testing.T, newStore func(t *testing.T) co
 
 		mustStoreToken(t, ctx, ds, token)
 
-		got, err := ds.Token(ctx, user.ID, "test-service", "instance-1")
+		got, err := ds.Token(ctx, user.ID, "test-service", "", "instance-1")
 		if err != nil {
 			t.Fatalf("Token: %v", err)
 		}
@@ -222,7 +222,7 @@ func testDatastoreIntegrationTokens(t *testing.T, newStore func(t *testing.T) co
 			t.Fatalf("DeleteToken: %v", err)
 		}
 
-		got, err := ds.Token(ctx, user.ID, "svc", "i1")
+		got, err := ds.Token(ctx, user.ID, "svc", "", "i1")
 		if err != nil {
 			t.Fatalf("Token after delete: unexpected error: %v", err)
 		}
@@ -236,7 +236,7 @@ func testDatastoreIntegrationTokens(t *testing.T, newStore func(t *testing.T) co
 		t.Cleanup(func() { ds.Close() })
 		ctx := context.Background()
 
-		got, err := ds.Token(ctx, "no-user", "no-svc", "no-instance")
+		got, err := ds.Token(ctx, "no-user", "no-svc", "", "no-instance")
 		if err != nil {
 			t.Fatalf("Token for nonexistent: unexpected error: %v", err)
 		}

--- a/core/testing/stubs.go
+++ b/core/testing/stubs.go
@@ -26,9 +26,10 @@ type StubDatastore struct {
 	GetUserFn                  func(context.Context, string) (*core.User, error)
 	FindOrCreateUserFn         func(context.Context, string) (*core.User, error)
 	StoreTokenFn               func(context.Context, *core.IntegrationToken) error
-	TokenFn                    func(context.Context, string, string, string) (*core.IntegrationToken, error)
+	TokenFn                    func(context.Context, string, string, string, string) (*core.IntegrationToken, error)
 	ListTokensFn               func(context.Context, string) ([]*core.IntegrationToken, error)
 	ListTokensForIntegrationFn func(context.Context, string, string) ([]*core.IntegrationToken, error)
+	ListTokensForConnectionFn  func(context.Context, string, string, string) ([]*core.IntegrationToken, error)
 	DeleteTokenFn              func(context.Context, string) error
 	ValidateAPITokenFn         func(context.Context, string) (*core.APIToken, error)
 	RevokeAPITokenFn           func(context.Context, string, string) error
@@ -63,9 +64,9 @@ func (s *StubDatastore) StoreToken(ctx context.Context, token *core.IntegrationT
 	}
 	return nil
 }
-func (s *StubDatastore) Token(ctx context.Context, userID, integration, instance string) (*core.IntegrationToken, error) {
+func (s *StubDatastore) Token(ctx context.Context, userID, integration, connection, instance string) (*core.IntegrationToken, error) {
 	if s.TokenFn != nil {
-		return s.TokenFn(ctx, userID, integration, instance)
+		return s.TokenFn(ctx, userID, integration, connection, instance)
 	}
 	return nil, nil
 }
@@ -80,7 +81,26 @@ func (s *StubDatastore) ListTokensForIntegration(ctx context.Context, userID, in
 		return s.ListTokensForIntegrationFn(ctx, userID, integration)
 	}
 	if s.TokenFn != nil {
-		tok, err := s.TokenFn(ctx, userID, integration, "default")
+		tok, err := s.TokenFn(ctx, userID, integration, "", "default")
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		if tok == nil {
+			return nil, nil
+		}
+		return []*core.IntegrationToken{tok}, nil
+	}
+	return nil, nil
+}
+func (s *StubDatastore) ListTokensForConnection(ctx context.Context, userID, integration, connection string) ([]*core.IntegrationToken, error) {
+	if s.ListTokensForConnectionFn != nil {
+		return s.ListTokensForConnectionFn(ctx, userID, integration, connection)
+	}
+	if s.TokenFn != nil {
+		tok, err := s.TokenFn(ctx, userID, integration, connection, "default")
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) {
 				return nil, nil

--- a/core/types.go
+++ b/core/types.go
@@ -17,6 +17,7 @@ type IntegrationToken struct {
 	ID                string
 	UserID            string
 	Integration       string
+	Connection        string
 	Instance          string
 	AccessToken       string
 	RefreshToken      string
@@ -73,6 +74,7 @@ type StagedConnection struct {
 	ID             string
 	UserID         string
 	Integration    string
+	Connection     string
 	Instance       string
 	AccessToken    string
 	RefreshToken   string

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -182,7 +182,8 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		}
 	}()
 
-	sharedInvoker := invocation.NewBroker(providers, ds)
+	connMap := BuildConnectionMap(cfg)
+	sharedInvoker := invocation.NewBroker(providers, ds, invocation.WithConnectionMapper(connMap))
 	wireCredentialResolver(&deps.Egress, sm)
 	audit := core.AuditSink(invocation.LogAuditSink{})
 
@@ -594,6 +595,23 @@ func validateProviderBuildAvailable(name string, intg config.IntegrationDef, fac
 	}
 	_, err := providerFactoryForName(name, factories)
 	return err
+}
+
+// BuildConnectionMap returns a map from integration name to its default
+// connection name. Used by the broker and server to resolve connections.
+func BuildConnectionMap(cfg *config.Config) invocation.ConnectionMap {
+	m := make(invocation.ConnectionMap, len(cfg.Integrations))
+	for name, intg := range cfg.Integrations {
+		switch {
+		case intg.Plugin != nil:
+			m[name] = config.PluginConnectionName
+		case intg.API != nil:
+			m[name] = intg.API.Connection
+		case intg.MCP != nil:
+			m[name] = intg.MCP.Connection
+		}
+	}
+	return m
 }
 
 // ResolveAPIConnection returns the ConnectionDef referenced by the

--- a/internal/invocation/broker.go
+++ b/internal/invocation/broker.go
@@ -17,6 +17,17 @@ import (
 
 const tokenRefreshThreshold = 5 * time.Minute
 
+type connectionCtxKey struct{}
+
+func WithConnection(ctx context.Context, connection string) context.Context {
+	return context.WithValue(ctx, connectionCtxKey{}, connection)
+}
+
+func ConnectionFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(connectionCtxKey{}).(string)
+	return v
+}
+
 type Invoker interface {
 	Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error)
 }
@@ -30,13 +41,34 @@ var (
 	_ CapabilityLister = (*Broker)(nil)
 )
 
-type Broker struct {
-	providers *registry.PluginMap[core.Provider]
-	datastore core.Datastore
+type ConnectionMapper interface {
+	ConnectionForProvider(provider string) string
 }
 
-func NewBroker(providers *registry.PluginMap[core.Provider], ds core.Datastore) *Broker {
-	return &Broker{providers: providers, datastore: ds}
+type ConnectionMap map[string]string
+
+func (m ConnectionMap) ConnectionForProvider(provider string) string {
+	return m[provider]
+}
+
+type Broker struct {
+	providers  *registry.PluginMap[core.Provider]
+	datastore  core.Datastore
+	connMapper ConnectionMapper
+}
+
+type BrokerOption func(*Broker)
+
+func WithConnectionMapper(m ConnectionMapper) BrokerOption {
+	return func(b *Broker) { b.connMapper = m }
+}
+
+func NewBroker(providers *registry.PluginMap[core.Provider], ds core.Datastore, opts ...BrokerOption) *Broker {
+	b := &Broker{providers: providers, datastore: ds}
+	for _, o := range opts {
+		o(b)
+	}
+	return b
 }
 
 func (b *Broker) ListProviders() []string {
@@ -84,7 +116,12 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		return nil, ErrNotAuthenticated
 	}
 
-	ctx, accessToken, err := b.resolveToken(ctx, prov, p, providerName, instance)
+	conn := ConnectionFromContext(ctx)
+	if conn == "" && b.connMapper != nil {
+		conn = b.connMapper.ConnectionForProvider(providerName)
+	}
+
+	ctx, accessToken, err := b.resolveToken(ctx, prov, p, providerName, conn, instance)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +136,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	return result, nil
 }
 
-func (b *Broker) ResolveToken(ctx context.Context, p *principal.Principal, providerName, instance string) (string, error) {
+func (b *Broker) ResolveToken(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (string, error) {
 	prov, err := b.providers.Get(providerName)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
@@ -107,7 +144,7 @@ func (b *Broker) ResolveToken(ctx context.Context, p *principal.Principal, provi
 		}
 		return "", fmt.Errorf("%w: looking up provider: %v", ErrInternal, err)
 	}
-	_, tok, resolveErr := b.resolveToken(ctx, prov, p, providerName, instance)
+	_, tok, resolveErr := b.resolveToken(ctx, prov, p, providerName, connection, instance)
 	return tok, resolveErr
 }
 
@@ -115,7 +152,7 @@ func (b *Broker) withSubject(ctx context.Context, p *principal.Principal) contex
 	return egress.WithSubjectFromPrincipal(ctx, p)
 }
 
-func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *principal.Principal, providerName, instance string) (context.Context, string, error) {
+func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error) {
 	mode := prov.ConnectionMode()
 	switch mode {
 	case core.ConnectionModeNone:
@@ -135,14 +172,14 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 			}
 			p.UserID = dbUser.ID
 		}
-		return b.resolveUserToken(ctx, prov, p.UserID, providerName, instance)
+		return b.resolveUserToken(ctx, prov, p.UserID, providerName, connection, instance)
 
 	case core.ConnectionModeIdentity:
-		return b.resolveUserToken(ctx, prov, principal.IdentityPrincipal, providerName, instance)
+		return b.resolveUserToken(ctx, prov, principal.IdentityPrincipal, providerName, connection, instance)
 
 	case core.ConnectionModeEither:
 		if p.UserID != "" {
-			enrichedCtx, tok, err := b.resolveUserToken(ctx, prov, p.UserID, providerName, instance)
+			enrichedCtx, tok, err := b.resolveUserToken(ctx, prov, p.UserID, providerName, connection, instance)
 			if err == nil {
 				return enrichedCtx, tok, nil
 			}
@@ -153,19 +190,19 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 				return ctx, "", err
 			}
 		}
-		return b.resolveUserToken(ctx, prov, principal.IdentityPrincipal, providerName, instance)
+		return b.resolveUserToken(ctx, prov, principal.IdentityPrincipal, providerName, connection, instance)
 
 	default:
 		return ctx, "", fmt.Errorf("%w: unknown connection mode %q", ErrInternal, mode)
 	}
 }
 
-func (b *Broker) resolveUserToken(ctx context.Context, prov core.Provider, userID, providerName, instance string) (context.Context, string, error) {
+func (b *Broker) resolveUserToken(ctx context.Context, prov core.Provider, userID, providerName, connection, instance string) (context.Context, string, error) {
 	var storedToken *core.IntegrationToken
 	var err error
 
 	if instance != "" {
-		storedToken, err = b.datastore.Token(ctx, userID, providerName, instance)
+		storedToken, err = b.datastore.Token(ctx, userID, providerName, connection, instance)
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) {
 				return ctx, "", fmt.Errorf("%w: no token stored for integration %q instance %q", ErrNoToken, providerName, instance)
@@ -173,7 +210,7 @@ func (b *Broker) resolveUserToken(ctx context.Context, prov core.Provider, userI
 			return ctx, "", fmt.Errorf("%w: retrieving integration token: %v", ErrInternal, err)
 		}
 	} else {
-		tokens, listErr := b.datastore.ListTokensForIntegration(ctx, userID, providerName)
+		tokens, listErr := b.datastore.ListTokensForConnection(ctx, userID, providerName, connection)
 		if listErr != nil {
 			return ctx, "", fmt.Errorf("%w: listing tokens: %v", ErrInternal, listErr)
 		}
@@ -224,7 +261,7 @@ func (b *Broker) refreshTokenIfNeeded(ctx context.Context, prov core.Provider, t
 
 	resp, err := b.refreshOAuth(ctx, oauthProv, prov, token.RefreshToken)
 	if err != nil {
-		fresh, fetchErr := b.datastore.Token(ctx, token.UserID, token.Integration, token.Instance)
+		fresh, fetchErr := b.datastore.Token(ctx, token.UserID, token.Integration, token.Connection, token.Instance)
 		if fetchErr == nil && fresh != nil && fresh.AccessToken != token.AccessToken {
 			return fresh.AccessToken, nil
 		}

--- a/internal/mcp/binding.go
+++ b/internal/mcp/binding.go
@@ -20,7 +20,7 @@ const (
 )
 
 type TokenResolver interface {
-	ResolveToken(ctx context.Context, p *principal.Principal, providerName, instance string) (string, error)
+	ResolveToken(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (string, error)
 }
 
 type directToolCaller interface {
@@ -34,6 +34,8 @@ type Config struct {
 	AllowedProviders []string
 	ToolPrefixes     map[string]string
 	IncludeREST      map[string]bool
+	APIConnection    map[string]string
+	MCPConnection    map[string]string
 }
 
 func NewServer(cfg Config) *mcpserver.MCPServer {

--- a/internal/mcp/binding_test.go
+++ b/internal/mcp/binding_test.go
@@ -41,7 +41,7 @@ func (p *flatProvider) ListOperations() []core.Operation { return p.ops }
 
 func stubDatastoreWithToken() *coretesting.StubDatastore {
 	return &coretesting.StubDatastore{
-		TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+		TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 			return &core.IntegrationToken{AccessToken: "test-token"}, nil
 		},
 	}
@@ -636,7 +636,7 @@ type stubTokenResolver struct {
 	err   error
 }
 
-func (r *stubTokenResolver) ResolveToken(_ context.Context, _ *principal.Principal, _, _ string) (string, error) {
+func (r *stubTokenResolver) ResolveToken(_ context.Context, _ *principal.Principal, _, _, _ string) (string, error) {
 	return r.token, r.err
 }
 

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -12,7 +12,7 @@ import (
 	mcpserver "github.com/mark3labs/mcp-go/server"
 )
 
-func makeHandler(invoker invocation.Invoker, provName, opName string) mcpserver.ToolHandlerFunc {
+func makeHandler(invoker invocation.Invoker, provName, opName, connection string) mcpserver.ToolHandlerFunc {
 	return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 		p := principal.FromContext(ctx)
 		if p == nil {
@@ -23,6 +23,9 @@ func makeHandler(invoker invocation.Invoker, provName, opName string) mcpserver.
 		instance, _ := args["_instance"].(string)
 		delete(args, "_instance")
 
+		if connection != "" {
+			ctx = invocation.WithConnection(ctx, connection)
+		}
 		result, err := invoker.Invoke(ctx, p, provName, instance, opName, args)
 		if err != nil {
 			return mcpgo.NewToolResultError(err.Error()), nil
@@ -36,7 +39,7 @@ func makeHandler(invoker invocation.Invoker, provName, opName string) mcpserver.
 	}
 }
 
-func makeDirectHandler(cfg Config, provName, opName string, caller directToolCaller) mcpserver.ToolHandlerFunc {
+func makeDirectHandler(cfg Config, provName, opName, connection string, caller directToolCaller) mcpserver.ToolHandlerFunc {
 	return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 		p := principal.FromContext(ctx)
 		if p == nil {
@@ -48,7 +51,7 @@ func makeDirectHandler(cfg Config, provName, opName string, caller directToolCal
 		instance, _ := args["_instance"].(string)
 		delete(args, "_instance")
 
-		token, err := cfg.TokenResolver.ResolveToken(ctx, p, provName, instance)
+		token, err := cfg.TokenResolver.ResolveToken(ctx, p, provName, connection, instance)
 		if err != nil {
 			return mcpgo.NewToolResultError(err.Error()), nil
 		}

--- a/internal/mcp/projection.go
+++ b/internal/mcp/projection.go
@@ -32,7 +32,7 @@ func addFlatTools(srv *mcpserver.MCPServer, cfg Config, provName string, prov co
 		}
 
 		tool := mcpgo.NewTool(name, opts...)
-		handler := makeHandler(cfg.Invoker, provName, op.Name)
+		handler := makeHandler(cfg.Invoker, provName, op.Name, cfg.APIConnection[provName])
 		srv.AddTool(tool, handler)
 	}
 }
@@ -69,11 +69,19 @@ func buildToolMap(cfg Config, provName string, prov core.Provider, cat *catalog.
 			tool.Annotations.Title = op.ID
 		}
 
+		var conn string
+		switch op.Transport {
+		case catalog.TransportMCPPassthrough:
+			conn = cfg.MCPConnection[provName]
+		default:
+			conn = cfg.APIConnection[provName]
+		}
+
 		var handler mcpserver.ToolHandlerFunc
 		if isDirect && op.Transport != catalog.TransportREST && op.Transport != catalog.TransportPlugin {
-			handler = makeDirectHandler(cfg, provName, op.ID, caller)
+			handler = makeDirectHandler(cfg, provName, op.ID, conn, caller)
 		} else {
-			handler = makeHandler(cfg.Invoker, provName, op.ID)
+			handler = makeHandler(cfg.Invoker, provName, op.ID, conn)
 		}
 		tools[name] = mcpserver.ServerTool{Tool: tool, Handler: handler}
 	}

--- a/internal/mcp/session_tools.go
+++ b/internal/mcp/session_tools.go
@@ -86,5 +86,5 @@ func resolveSessionToken(ctx context.Context, cfg Config, provName string, prov 
 	if p == nil {
 		return "", fmt.Errorf("not authenticated")
 	}
-	return cfg.TokenResolver.ResolveToken(ctx, p, provName, "")
+	return cfg.TokenResolver.ResolveToken(ctx, p, provName, cfg.MCPConnection[provName], "")
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/apiexec"
+	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/discovery"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	"github.com/valon-technologies/gestalt/internal/oauth"
@@ -61,7 +62,8 @@ func (s *Server) readinessCheck(w http.ResponseWriter, _ *http.Request) {
 }
 
 type instanceInfo struct {
-	Name string `json:"name"`
+	Name       string `json:"name"`
+	Connection string `json:"connection,omitempty"`
 }
 
 type integrationInfo struct {
@@ -161,7 +163,7 @@ func (s *Server) userConnectedIntegrations(r *http.Request) (map[string][]instan
 	}
 	m := make(map[string][]instanceInfo, len(tokens))
 	for _, tok := range tokens {
-		m[tok.Integration] = append(m[tok.Integration], instanceInfo{Name: tok.Instance})
+		m[tok.Integration] = append(m[tok.Integration], instanceInfo{Name: tok.Instance, Connection: tok.Connection})
 	}
 	return m, nil
 }
@@ -178,6 +180,7 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 	}
 
 	requestedInstance := r.URL.Query().Get("instance")
+	requestedConnection := r.URL.Query().Get("connection")
 
 	tokens, err := s.datastore.ListTokensForIntegration(r.Context(), userID, name)
 	if err != nil {
@@ -185,30 +188,49 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(tokens) == 0 {
+	var matched []*core.IntegrationToken
+	for _, tok := range tokens {
+		if requestedConnection != "" && tok.Connection != requestedConnection {
+			continue
+		}
+		matched = append(matched, tok)
+	}
+
+	if len(matched) == 0 {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("no connection found for integration %q", name))
 		return
 	}
 
-	if requestedInstance == "" && len(tokens) > 1 {
-		instances := make([]string, len(tokens))
-		for i, t := range tokens {
-			instances[i] = t.Instance
+	if requestedInstance != "" {
+		var instanceMatched []*core.IntegrationToken
+		for _, tok := range matched {
+			if tok.Instance == requestedInstance {
+				instanceMatched = append(instanceMatched, tok)
+			}
 		}
-		writeError(w, http.StatusConflict, fmt.Sprintf("multiple connections exist for %q (%v); specify ?instance=NAME", name, instances))
+		matched = instanceMatched
+	}
+
+	if len(matched) == 0 {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("no connection found for integration %q instance %q", name, requestedInstance))
+		return
+	}
+	if len(matched) > 1 {
+		labels := make([]string, len(matched))
+		for i, t := range matched {
+			labels[i] = fmt.Sprintf("%s/%s", t.Connection, t.Instance)
+		}
+		hint := "?instance=NAME"
+		if requestedInstance != "" {
+			hint = "?connection=NAME"
+		}
+		writeError(w, http.StatusConflict, fmt.Sprintf("multiple connections exist for %q (%v); specify %s", name, labels, hint))
 		return
 	}
 
-	var tokenID string
-	for _, tok := range tokens {
-		if requestedInstance == "" || tok.Instance == requestedInstance {
-			tokenID = tok.ID
-			break
-		}
-	}
-
+	tokenID := matched[0].ID
 	if tokenID == "" {
-		writeError(w, http.StatusNotFound, fmt.Sprintf("no connection found for integration %q instance %q", name, requestedInstance))
+		writeError(w, http.StatusNotFound, fmt.Sprintf("no connection found for integration %q", name))
 		return
 	}
 
@@ -485,6 +507,7 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 
 type startOAuthRequest struct {
 	Integration      string            `json:"integration"`
+	Connection       string            `json:"connection"`
 	Instance         string            `json:"instance"`
 	Scopes           []string          `json:"scopes"`
 	ConnectionParams map[string]string `json:"connection_params"`
@@ -531,6 +554,18 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	connection := req.Connection
+	if connection == "" {
+		connection = s.defaultConnection[req.Integration]
+	}
+	if connection == "" {
+		connection = config.PluginConnectionName
+	}
+	if !safeParamValue.MatchString(connection) {
+		writeError(w, http.StatusBadRequest, "connection name contains invalid characters")
+		return
+	}
+
 	var connParams map[string]string
 	if cpp, ok := prov.(core.ConnectionParamProvider); ok {
 		var valErr error
@@ -573,6 +608,7 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 	state, err := s.stateCodec.Encode(integrationOAuthState{
 		UserID:           dbUserID,
 		Integration:      req.Integration,
+		Connection:       connection,
 		Instance:         instance,
 		Verifier:         verifier,
 		ConnectionParams: connParams,
@@ -668,6 +704,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	tm := tokenMaterial{
 		UserID:         state.UserID,
 		Integration:    providerName,
+		Connection:     state.Connection,
 		Instance:       callbackInstance,
 		AccessToken:    tokenResp.AccessToken,
 		RefreshToken:   tokenResp.RefreshToken,
@@ -692,6 +729,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 
 type connectManualRequest struct {
 	Integration      string            `json:"integration"`
+	Connection       string            `json:"connection"`
 	Instance         string            `json:"instance"`
 	Credential       string            `json:"credential"`
 	ConnectionParams map[string]string `json:"connection_params"`
@@ -740,6 +778,18 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	manualConnection := req.Connection
+	if manualConnection == "" {
+		manualConnection = s.defaultConnection[req.Integration]
+	}
+	if manualConnection == "" {
+		manualConnection = config.PluginConnectionName
+	}
+	if !safeParamValue.MatchString(manualConnection) {
+		writeError(w, http.StatusBadRequest, "connection name contains invalid characters")
+		return
+	}
+
 	var connParams map[string]string
 	if cpp, ok := prov.(core.ConnectionParamProvider); ok {
 		var valErr error
@@ -759,6 +809,7 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 	tm := tokenMaterial{
 		UserID:       dbUser.ID,
 		Integration:  req.Integration,
+		Connection:   manualConnection,
 		Instance:     manualInstance,
 		AccessToken:  req.Credential,
 		MetadataJSON: manualMeta,
@@ -1009,6 +1060,7 @@ const stagedConnectionTTL = 30 * time.Minute
 type tokenMaterial struct {
 	UserID         string
 	Integration    string
+	Connection     string
 	Instance       string
 	AccessToken    string
 	RefreshToken   string
@@ -1028,6 +1080,7 @@ func (s *Server) storeTokenFromMaterial(ctx context.Context, tm tokenMaterial) (
 		ID:              uuid.NewString(),
 		UserID:          tm.UserID,
 		Integration:     tm.Integration,
+		Connection:      tm.Connection,
 		Instance:        tm.Instance,
 		AccessToken:     tm.AccessToken,
 		RefreshToken:    tm.RefreshToken,
@@ -1104,6 +1157,7 @@ func (s *Server) runPostConnect(ctx context.Context, prov core.Provider, tm toke
 				ID:             uuid.NewString(),
 				UserID:         tm.UserID,
 				Integration:    tm.Integration,
+				Connection:     tm.Connection,
 				Instance:       tm.Instance,
 				AccessToken:    tm.AccessToken,
 				RefreshToken:   tm.RefreshToken,
@@ -1241,6 +1295,7 @@ func (s *Server) selectStagedConnection(w http.ResponseWriter, r *http.Request) 
 	tm := tokenMaterial{
 		UserID:         sc.UserID,
 		Integration:    sc.Integration,
+		Connection:     sc.Connection,
 		Instance:       sc.Instance,
 		AccessToken:    sc.AccessToken,
 		RefreshToken:   sc.RefreshToken,

--- a/internal/server/oauth_state.go
+++ b/internal/server/oauth_state.go
@@ -14,6 +14,7 @@ const integrationOAuthStateTTL = 10 * time.Minute
 type integrationOAuthState struct {
 	UserID           string            `json:"uid"`
 	Integration      string            `json:"int"`
+	Connection       string            `json:"con,omitempty"`
 	Instance         string            `json:"ins,omitempty"`
 	Verifier         string            `json:"ver,omitempty"`
 	ConnectionParams map[string]string `json:"cp,omitempty"`

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,35 +18,37 @@ import (
 type ReadinessChecker func() string
 
 type Server struct {
-	router     chi.Router
-	auth       core.AuthProvider
-	datastore  core.Datastore
-	providers  *registry.PluginMap[core.Provider]
-	runtimes   *registry.PluginMap[core.Runtime]
-	bindings   *registry.PluginMap[core.Binding]
-	resolver   *principal.Resolver
-	invoker    invocation.Invoker
-	devMode    bool
-	stateCodec *integrationOAuthStateCodec
-	now        func() time.Time
-	readiness  ReadinessChecker
-	mcpHandler http.Handler
-	webUI      http.Handler
+	router            chi.Router
+	auth              core.AuthProvider
+	datastore         core.Datastore
+	providers         *registry.PluginMap[core.Provider]
+	runtimes          *registry.PluginMap[core.Runtime]
+	bindings          *registry.PluginMap[core.Binding]
+	resolver          *principal.Resolver
+	invoker           invocation.Invoker
+	defaultConnection map[string]string
+	devMode           bool
+	stateCodec        *integrationOAuthStateCodec
+	now               func() time.Time
+	readiness         ReadinessChecker
+	mcpHandler        http.Handler
+	webUI             http.Handler
 }
 
 type Config struct {
-	Auth        core.AuthProvider
-	Datastore   core.Datastore
-	Providers   *registry.PluginMap[core.Provider]
-	Runtimes    *registry.PluginMap[core.Runtime]
-	Bindings    *registry.PluginMap[core.Binding]
-	Invoker     invocation.Invoker
-	DevMode     bool
-	StateSecret []byte
-	Now         func() time.Time
-	Readiness   ReadinessChecker
-	MCPHandler  http.Handler
-	WebUI       http.Handler
+	Auth              core.AuthProvider
+	Datastore         core.Datastore
+	Providers         *registry.PluginMap[core.Provider]
+	Runtimes          *registry.PluginMap[core.Runtime]
+	Bindings          *registry.PluginMap[core.Binding]
+	Invoker           invocation.Invoker
+	DefaultConnection map[string]string // integration name -> default connection name
+	DevMode           bool
+	StateSecret       []byte
+	Now               func() time.Time
+	Readiness         ReadinessChecker
+	MCPHandler        http.Handler
+	WebUI             http.Handler
 }
 
 func New(cfg Config) (*Server, error) {
@@ -67,20 +69,21 @@ func New(cfg Config) (*Server, error) {
 	}
 
 	s := &Server{
-		router:     chi.NewRouter(),
-		auth:       cfg.Auth,
-		datastore:  cfg.Datastore,
-		providers:  cfg.Providers,
-		runtimes:   cfg.Runtimes,
-		bindings:   cfg.Bindings,
-		resolver:   principal.NewResolver(cfg.Auth, cfg.Datastore),
-		invoker:    cfg.Invoker,
-		devMode:    cfg.DevMode,
-		stateCodec: stateCodec,
-		now:        now,
-		readiness:  cfg.Readiness,
-		mcpHandler: cfg.MCPHandler,
-		webUI:      cfg.WebUI,
+		router:            chi.NewRouter(),
+		auth:              cfg.Auth,
+		datastore:         cfg.Datastore,
+		providers:         cfg.Providers,
+		runtimes:          cfg.Runtimes,
+		bindings:          cfg.Bindings,
+		resolver:          principal.NewResolver(cfg.Auth, cfg.Datastore),
+		invoker:           cfg.Invoker,
+		defaultConnection: cfg.DefaultConnection,
+		devMode:           cfg.DevMode,
+		stateCodec:        stateCodec,
+		now:               now,
+		readiness:         cfg.Readiness,
+		mcpHandler:        cfg.MCPHandler,
+		webUI:             cfg.WebUI,
 	}
 
 	s.routes()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -859,7 +859,7 @@ func TestExecuteOperation(t *testing.T) {
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
 			},
-			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 				return &core.IntegrationToken{AccessToken: "stored-token"}, nil
 			},
 		}
@@ -1013,7 +1013,7 @@ func TestExecuteOperation_NoStoredToken(t *testing.T) {
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
 			},
-			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 				return nil, core.ErrNotFound
 			},
 		}
@@ -1555,7 +1555,7 @@ func TestExecuteOperation_POST(t *testing.T) {
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
 			},
-			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 				return &core.IntegrationToken{AccessToken: "tok"}, nil
 			},
 		}
@@ -1863,7 +1863,7 @@ func TestExecuteOperation_RefreshesExpiredToken(t *testing.T) {
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
 			},
-			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 				return &core.IntegrationToken{
 					AccessToken:  "stale-access-token",
 					RefreshToken: "old-refresh-token",
@@ -1936,7 +1936,7 @@ func TestExecuteOperation_RefreshFailsButTokenStillValid(t *testing.T) {
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
 			},
-			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 				return &core.IntegrationToken{
 					AccessToken:  "still-valid-token",
 					RefreshToken: "rf",
@@ -1994,7 +1994,7 @@ func TestExecuteOperation_RefreshFailsAndTokenExpired(t *testing.T) {
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
 			},
-			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 				return &core.IntegrationToken{
 					AccessToken:  "expired-token",
 					RefreshToken: "rf",
@@ -2047,7 +2047,7 @@ func TestExecuteOperation_NoRefreshTokenSkipsRefresh(t *testing.T) {
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
 			},
-			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 				return &core.IntegrationToken{
 					AccessToken: "no-refresh-token",
 					ExpiresAt:   &expiresSoon,
@@ -2101,7 +2101,7 @@ func TestExecuteOperation_NoExpiresAtSkipsRefresh(t *testing.T) {
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
 			},
-			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 				return &core.IntegrationToken{
 					AccessToken:  "no-expiry-token",
 					RefreshToken: "rf",
@@ -2148,7 +2148,7 @@ func TestExecuteOperation_NonOAuthProviderSkipsRefresh(t *testing.T) {
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
 			},
-			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 				return &core.IntegrationToken{
 					AccessToken:  "manual-token",
 					RefreshToken: "rf",
@@ -2206,7 +2206,7 @@ func TestExecuteOperation_RefreshTokenRotation(t *testing.T) {
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
 			},
-			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 				return &core.IntegrationToken{
 					AccessToken:  "old-access",
 					RefreshToken: "old-refresh",
@@ -2270,7 +2270,7 @@ func TestExecuteOperation_RefreshClearsExpiresAtWhenOmitted(t *testing.T) {
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
 			},
-			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 				return &core.IntegrationToken{
 					AccessToken:  "old-access",
 					RefreshToken: "rf",
@@ -2337,7 +2337,7 @@ func TestExecuteOperation_RefreshErrorSkipsStoreOnConcurrentRefresh(t *testing.T
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
 			},
-			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 				tokenCallCount++
 				if tokenCallCount == 1 {
 					return &core.IntegrationToken{
@@ -2404,7 +2404,7 @@ func TestExecuteOperation_StoreTokenFailureReturnsError(t *testing.T) {
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
 			},
-			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 				return &core.IntegrationToken{
 					AccessToken:  "old-access",
 					RefreshToken: "old-refresh",
@@ -2458,7 +2458,7 @@ func TestExecuteOperation_RefreshErrorHandlesDeletedToken(t *testing.T) {
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
 			},
-			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 				tokenCallCount++
 				if tokenCallCount == 1 {
 					return &core.IntegrationToken{
@@ -2528,7 +2528,7 @@ func TestExecuteOperation_ConnectionModeNone(t *testing.T) {
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
 			},
-			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 				tokenCalled = true
 				return nil, core.ErrNotFound
 			},
@@ -3649,7 +3649,7 @@ func TestMaxBodySize(t *testing.T) {
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
 			},
-			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 				return &core.IntegrationToken{AccessToken: "tok"}, nil
 			},
 		}
@@ -3695,7 +3695,7 @@ func TestErrorSanitization(t *testing.T) {
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
 			},
-			TokenFn: func(_ context.Context, _, _, _ string) (*core.IntegrationToken, error) {
+			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 				return &core.IntegrationToken{AccessToken: "tok"}, nil
 			},
 		}
@@ -4190,7 +4190,7 @@ func TestExecuteOperation_ConnectionModeIdentity(t *testing.T) {
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
 			},
-			TokenFn: func(_ context.Context, userID, integration, _ string) (*core.IntegrationToken, error) {
+			TokenFn: func(_ context.Context, userID, integration, _, _ string) (*core.IntegrationToken, error) {
 				if userID == principal.IdentityPrincipal && integration == "svc" {
 					return &core.IntegrationToken{AccessToken: "identity-tok"}, nil
 				}
@@ -4257,7 +4257,7 @@ func TestExecuteOperation_ConnectionModeEither(t *testing.T) {
 				GetUserFn: func(_ context.Context, id string) (*core.User, error) {
 					return &core.User{ID: id, Email: "dev@example.com"}, nil
 				},
-				TokenFn: func(_ context.Context, userID, _, _ string) (*core.IntegrationToken, error) {
+				TokenFn: func(_ context.Context, userID, _, _, _ string) (*core.IntegrationToken, error) {
 					switch userID {
 					case "u1":
 						return &core.IntegrationToken{AccessToken: "user-tok"}, nil
@@ -4295,7 +4295,7 @@ func TestExecuteOperation_ConnectionModeEither(t *testing.T) {
 				FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 					return &core.User{ID: "u1", Email: email}, nil
 				},
-				TokenFn: func(_ context.Context, userID, _, _ string) (*core.IntegrationToken, error) {
+				TokenFn: func(_ context.Context, userID, _, _, _ string) (*core.IntegrationToken, error) {
 					if userID == principal.IdentityPrincipal {
 						return &core.IntegrationToken{AccessToken: "identity-tok"}, nil
 					}

--- a/plugins/datastore/dynamodb/dynamodb.go
+++ b/plugins/datastore/dynamodb/dynamodb.go
@@ -37,6 +37,7 @@ const (
 	attrUpdatedAt         = "updated_at"
 	attrUserID            = "user_id"
 	attrIntegration       = "integration"
+	attrConnection        = "connection"
 	attrInstance          = "instance"
 	attrAccessTokenEnc    = "access_token_enc"
 	attrRefreshTokenEnc   = "refresh_token_enc"
@@ -250,10 +251,10 @@ func (s *Store) StoreToken(ctx context.Context, token *core.IntegrationToken) er
 	return nil
 }
 
-func (s *Store) Token(ctx context.Context, userID, integration, instance string) (*core.IntegrationToken, error) {
+func (s *Store) Token(ctx context.Context, userID, integration, connection, instance string) (*core.IntegrationToken, error) {
 	out, err := s.client.GetItem(ctx, &dynamodb.GetItemInput{
 		TableName: &s.tableName,
-		Key:       tokenKey(userID, integration, instance),
+		Key:       tokenKey(userID, integration, connection, instance),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("dynamodb: getting token: %w", err)
@@ -313,6 +314,41 @@ func (s *Store) ListTokensForIntegration(ctx context.Context, userID, integratio
 	})
 	if err != nil {
 		return nil, fmt.Errorf("dynamodb: listing tokens for integration: %w", err)
+	}
+
+	tokens := make([]*core.IntegrationToken, 0, len(out.Items))
+	for _, item := range out.Items {
+		t, err := s.unmarshalIntegrationToken(item)
+		if err != nil {
+			return nil, err
+		}
+		tokens = append(tokens, t)
+	}
+	return tokens, nil
+}
+
+func (s *Store) ListTokensForConnection(ctx context.Context, userID, integration, connection string) ([]*core.IntegrationToken, error) {
+	keyCond := expression.KeyAnd(
+		expression.Key(attrPK).Equal(expression.Value(userPKPrefix+userID)),
+		expression.KeyBeginsWith(expression.Key(attrSK), tokenSKPrefix),
+	)
+	filt := expression.And(
+		expression.Name(attrIntegration).Equal(expression.Value(integration)),
+		expression.Name(attrConnection).Equal(expression.Value(connection)),
+	)
+	expr, err := expression.NewBuilder().WithKeyCondition(keyCond).WithFilter(filt).Build()
+	if err != nil {
+		return nil, fmt.Errorf("dynamodb: building expression: %w", err)
+	}
+	out, err := s.client.Query(ctx, &dynamodb.QueryInput{
+		TableName:                 &s.tableName,
+		KeyConditionExpression:    expr.KeyCondition(),
+		FilterExpression:          expr.Filter(),
+		ExpressionAttributeNames:  expr.Names(),
+		ExpressionAttributeValues: expr.Values(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("dynamodb: listing tokens for connection: %w", err)
 	}
 
 	tokens := make([]*core.IntegrationToken, 0, len(out.Items))
@@ -530,10 +566,10 @@ func userKey(id string) map[string]ddbtypes.AttributeValue {
 	}
 }
 
-func tokenKey(userID, integration, instance string) map[string]ddbtypes.AttributeValue {
+func tokenKey(userID, integration, connection, instance string) map[string]ddbtypes.AttributeValue {
 	return map[string]ddbtypes.AttributeValue{
 		attrPK: &ddbtypes.AttributeValueMemberS{Value: userPKPrefix + userID},
-		attrSK: &ddbtypes.AttributeValueMemberS{Value: tokenSKPrefix + integration + "#" + instance},
+		attrSK: &ddbtypes.AttributeValueMemberS{Value: tokenSKPrefix + integration + "#" + connection + "#" + instance},
 	}
 }
 
@@ -583,10 +619,11 @@ func unmarshalUser(item map[string]ddbtypes.AttributeValue) (*core.User, error) 
 func marshalIntegrationToken(t *core.IntegrationToken, accessEnc, refreshEnc string) map[string]ddbtypes.AttributeValue {
 	item := map[string]ddbtypes.AttributeValue{
 		attrPK:                &ddbtypes.AttributeValueMemberS{Value: userPKPrefix + t.UserID},
-		attrSK:                &ddbtypes.AttributeValueMemberS{Value: tokenSKPrefix + t.Integration + "#" + t.Instance},
+		attrSK:                &ddbtypes.AttributeValueMemberS{Value: tokenSKPrefix + t.Integration + "#" + t.Connection + "#" + t.Instance},
 		attrID:                &ddbtypes.AttributeValueMemberS{Value: t.ID},
 		attrUserID:            &ddbtypes.AttributeValueMemberS{Value: t.UserID},
 		attrIntegration:       &ddbtypes.AttributeValueMemberS{Value: t.Integration},
+		attrConnection:        &ddbtypes.AttributeValueMemberS{Value: t.Connection},
 		attrInstance:          &ddbtypes.AttributeValueMemberS{Value: t.Instance},
 		attrAccessTokenEnc:    &ddbtypes.AttributeValueMemberS{Value: accessEnc},
 		attrRefreshTokenEnc:   &ddbtypes.AttributeValueMemberS{Value: refreshEnc},
@@ -617,6 +654,9 @@ func (s *Store) unmarshalIntegrationToken(item map[string]ddbtypes.AttributeValu
 		return nil, err
 	}
 	if err := unmarshalS(item, attrIntegration, &t.Integration); err != nil {
+		return nil, err
+	}
+	if err := unmarshalS(item, attrConnection, &t.Connection); err != nil {
 		return nil, err
 	}
 	if err := unmarshalS(item, attrInstance, &t.Instance); err != nil {

--- a/plugins/datastore/firestore/firestore.go
+++ b/plugins/datastore/firestore/firestore.go
@@ -191,6 +191,7 @@ func snapToUser(snap *gcpfirestore.DocumentSnapshot) (*core.User, error) {
 type integrationTokenDoc struct {
 	UserID                string     `firestore:"user_id"`
 	Integration           string     `firestore:"integration"`
+	Connection            string     `firestore:"connection"`
 	Instance              string     `firestore:"instance"`
 	AccessTokenEncrypted  string     `firestore:"access_token_encrypted"`
 	RefreshTokenEncrypted string     `firestore:"refresh_token_encrypted"`
@@ -212,6 +213,7 @@ func (s *Store) StoreToken(ctx context.Context, token *core.IntegrationToken) er
 	doc := integrationTokenDoc{
 		UserID:                token.UserID,
 		Integration:           token.Integration,
+		Connection:            token.Connection,
 		Instance:              token.Instance,
 		AccessTokenEncrypted:  accessEnc,
 		RefreshTokenEncrypted: refreshEnc,
@@ -231,6 +233,7 @@ func (s *Store) StoreToken(ctx context.Context, token *core.IntegrationToken) er
 		query := s.client.Collection(datastore.IntegrationTokensCollection).
 			Where("user_id", "==", token.UserID).
 			Where("integration", "==", token.Integration).
+			Where("connection", "==", token.Connection).
 			Where("instance", "==", token.Instance).
 			Limit(1)
 		iter := tx.Documents(query)
@@ -249,10 +252,11 @@ func (s *Store) StoreToken(ctx context.Context, token *core.IntegrationToken) er
 	})
 }
 
-func (s *Store) Token(ctx context.Context, userID, integration, instance string) (*core.IntegrationToken, error) {
+func (s *Store) Token(ctx context.Context, userID, integration, connection, instance string) (*core.IntegrationToken, error) {
 	iter := s.client.Collection(datastore.IntegrationTokensCollection).
 		Where("user_id", "==", userID).
 		Where("integration", "==", integration).
+		Where("connection", "==", connection).
 		Where("instance", "==", instance).
 		Limit(1).
 		Documents(ctx)
@@ -317,6 +321,32 @@ func (s *Store) ListTokensForIntegration(ctx context.Context, userID, integratio
 	return tokens, nil
 }
 
+func (s *Store) ListTokensForConnection(ctx context.Context, userID, integration, connection string) ([]*core.IntegrationToken, error) {
+	iter := s.client.Collection(datastore.IntegrationTokensCollection).
+		Where("user_id", "==", userID).
+		Where("integration", "==", integration).
+		Where("connection", "==", connection).
+		Documents(ctx)
+	defer iter.Stop()
+
+	var tokens []*core.IntegrationToken
+	for {
+		snap, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("firestore: listing tokens for connection: %w", err)
+		}
+		t, err := s.snapToIntegrationToken(snap)
+		if err != nil {
+			return nil, err
+		}
+		tokens = append(tokens, t)
+	}
+	return tokens, nil
+}
+
 func (s *Store) DeleteToken(ctx context.Context, id string) error {
 	_, err := s.client.Collection(datastore.IntegrationTokensCollection).Doc(id).Delete(ctx)
 	if err != nil {
@@ -340,6 +370,7 @@ func (s *Store) snapToIntegrationToken(snap *gcpfirestore.DocumentSnapshot) (*co
 		ID:                snap.Ref.ID,
 		UserID:            doc.UserID,
 		Integration:       doc.Integration,
+		Connection:        doc.Connection,
 		Instance:          doc.Instance,
 		AccessToken:       access,
 		RefreshToken:      refresh,

--- a/plugins/datastore/firestore/firestore_test.go
+++ b/plugins/datastore/firestore/firestore_test.go
@@ -118,7 +118,7 @@ func TestEncryptionRoundTrip(t *testing.T) {
 		t.Error("access_token_encrypted is empty")
 	}
 
-	got, err := store.Token(ctx, user.ID, "test", "i1")
+	got, err := store.Token(ctx, user.ID, "test", "", "i1")
 	if err != nil {
 		t.Fatalf("Token: %v", err)
 	}

--- a/plugins/datastore/mongodb/mongodb.go
+++ b/plugins/datastore/mongodb/mongodb.go
@@ -33,6 +33,7 @@ type integrationTokenDoc struct {
 	ID                    string     `bson:"_id"`
 	UserID                string     `bson:"user_id"`
 	Integration           string     `bson:"integration"`
+	Connection            string     `bson:"connection"`
 	Instance              string     `bson:"instance"`
 	AccessTokenEncrypted  string     `bson:"access_token_encrypted"`
 	RefreshTokenEncrypted string     `bson:"refresh_token_encrypted"`
@@ -93,7 +94,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 	}
 
 	_, err = s.db.Collection(datastore.IntegrationTokensCollection).Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys:    bson.D{{Key: "user_id", Value: 1}, {Key: "integration", Value: 1}, {Key: "instance", Value: 1}},
+		Keys:    bson.D{{Key: "user_id", Value: 1}, {Key: "integration", Value: 1}, {Key: "connection", Value: 1}, {Key: "instance", Value: 1}},
 		Options: options.Index().SetUnique(true),
 	})
 	if err != nil {
@@ -165,7 +166,7 @@ func (s *Store) StoreToken(ctx context.Context, token *core.IntegrationToken) er
 		return fmt.Errorf("mongodb: %w", err)
 	}
 
-	filter := bson.M{"user_id": token.UserID, "integration": token.Integration, "instance": token.Instance}
+	filter := bson.M{"user_id": token.UserID, "integration": token.Integration, "connection": token.Connection, "instance": token.Instance}
 	update := bson.M{
 		"$set": bson.M{
 			"access_token_encrypted":  accessEnc,
@@ -181,6 +182,7 @@ func (s *Store) StoreToken(ctx context.Context, token *core.IntegrationToken) er
 			"_id":         token.ID,
 			"user_id":     token.UserID,
 			"integration": token.Integration,
+			"connection":  token.Connection,
 			"instance":    token.Instance,
 			"created_at":  token.CreatedAt,
 		},
@@ -193,8 +195,8 @@ func (s *Store) StoreToken(ctx context.Context, token *core.IntegrationToken) er
 	return nil
 }
 
-func (s *Store) Token(ctx context.Context, userID, integration, instance string) (*core.IntegrationToken, error) {
-	filter := bson.M{"user_id": userID, "integration": integration, "instance": instance}
+func (s *Store) Token(ctx context.Context, userID, integration, connection, instance string) (*core.IntegrationToken, error) {
+	filter := bson.M{"user_id": userID, "integration": integration, "connection": connection, "instance": instance}
 	var doc integrationTokenDoc
 	err := s.db.Collection(datastore.IntegrationTokensCollection).FindOne(ctx, filter).Decode(&doc)
 	if errors.Is(err, mongo.ErrNoDocuments) {
@@ -232,6 +234,28 @@ func (s *Store) ListTokensForIntegration(ctx context.Context, userID, integratio
 	cursor, err := s.db.Collection(datastore.IntegrationTokensCollection).Find(ctx, bson.M{"user_id": userID, "integration": integration})
 	if err != nil {
 		return nil, fmt.Errorf("mongodb: listing tokens for integration: %w", err)
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	var tokens []*core.IntegrationToken
+	for cursor.Next(ctx) {
+		var doc integrationTokenDoc
+		if err := cursor.Decode(&doc); err != nil {
+			return nil, fmt.Errorf("mongodb: decoding token: %w", err)
+		}
+		t, err := s.integrationTokenFromDoc(&doc)
+		if err != nil {
+			return nil, err
+		}
+		tokens = append(tokens, t)
+	}
+	return tokens, cursor.Err()
+}
+
+func (s *Store) ListTokensForConnection(ctx context.Context, userID, integration, connection string) ([]*core.IntegrationToken, error) {
+	cursor, err := s.db.Collection(datastore.IntegrationTokensCollection).Find(ctx, bson.M{"user_id": userID, "integration": integration, "connection": connection})
+	if err != nil {
+		return nil, fmt.Errorf("mongodb: listing tokens for connection: %w", err)
 	}
 	defer func() { _ = cursor.Close(ctx) }()
 
@@ -344,6 +368,7 @@ func (s *Store) integrationTokenFromDoc(doc *integrationTokenDoc) (*core.Integra
 		ID:                doc.ID,
 		UserID:            doc.UserID,
 		Integration:       doc.Integration,
+		Connection:        doc.Connection,
 		Instance:          doc.Instance,
 		AccessToken:       access,
 		RefreshToken:      refresh,

--- a/plugins/datastore/mysql/mysql.go
+++ b/plugins/datastore/mysql/mysql.go
@@ -20,9 +20,9 @@ func (dialect) Placeholder(int) string { return "?" }
 func (dialect) UpsertTokenSQL() string {
 	return `
 		INSERT INTO integration_tokens
-			(id, user_id, integration, instance, access_token_encrypted, refresh_token_encrypted,
+			(id, user_id, integration, connection, instance, access_token_encrypted, refresh_token_encrypted,
 			 scopes, expires_at, last_refreshed_at, refresh_error_count, metadata_json, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON DUPLICATE KEY UPDATE
 			access_token_encrypted = VALUES(access_token_encrypted),
 			refresh_token_encrypted = VALUES(refresh_token_encrypted),
@@ -81,6 +81,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 			id VARCHAR(36) NOT NULL PRIMARY KEY,
 			user_id VARCHAR(36) NOT NULL,
 			integration VARCHAR(255) NOT NULL,
+			connection VARCHAR(255) NOT NULL DEFAULT '',
 			instance VARCHAR(255) NOT NULL,
 			access_token_encrypted TEXT NOT NULL,
 			refresh_token_encrypted TEXT NOT NULL,
@@ -91,7 +92,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 			metadata_json TEXT NOT NULL,
 			created_at DATETIME(6) NOT NULL,
 			updated_at DATETIME(6) NOT NULL,
-			UNIQUE KEY idx_integration_tokens_user_integ_inst (user_id, integration, instance),
+			UNIQUE KEY idx_integration_tokens_user_integ_conn_inst (user_id, integration, connection, instance),
 			CONSTRAINT fk_integration_tokens_user FOREIGN KEY (user_id) REFERENCES users(id)
 		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`,
 
@@ -112,6 +113,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 			id VARCHAR(36) NOT NULL PRIMARY KEY,
 			user_id VARCHAR(36) NOT NULL,
 			integration VARCHAR(255) NOT NULL,
+			connection VARCHAR(255) NOT NULL DEFAULT '',
 			instance VARCHAR(255) NOT NULL,
 			access_token_encrypted TEXT NOT NULL,
 			refresh_token_encrypted TEXT NOT NULL,

--- a/plugins/datastore/mysql/mysql_test.go
+++ b/plugins/datastore/mysql/mysql_test.go
@@ -130,7 +130,7 @@ func TestEncryptionRoundTrip(t *testing.T) {
 	}
 
 	// Verify round-trip decryption.
-	got, err := store.Token(ctx, user.ID, "test", "i1")
+	got, err := store.Token(ctx, user.ID, "test", "", "i1")
 	if err != nil {
 		t.Fatalf("Token: %v", err)
 	}
@@ -255,7 +255,7 @@ func TestStoreTokenUpsert(t *testing.T) {
 		t.Fatalf("second StoreToken: %v", err)
 	}
 
-	got, err := store.Token(ctx, user.ID, "svc", "i1")
+	got, err := store.Token(ctx, user.ID, "svc", "", "i1")
 	if err != nil {
 		t.Fatalf("Token: %v", err)
 	}

--- a/plugins/datastore/oracle/oracle.go
+++ b/plugins/datastore/oracle/oracle.go
@@ -20,12 +20,12 @@ func (dialect) Placeholder(n int) string { return fmt.Sprintf(":%d", n) }
 
 func (dialect) UpsertTokenSQL() string {
 	return `MERGE INTO integration_tokens tgt
-USING (SELECT :1 AS id, :2 AS user_id, :3 AS integration, :4 AS instance,
-              :5 AS access_token_encrypted, :6 AS refresh_token_encrypted,
-              :7 AS scopes, :8 AS expires_at, :9 AS last_refreshed_at,
-              :10 AS refresh_error_count, :11 AS metadata_json,
-              :12 AS created_at, :13 AS updated_at FROM DUAL) src
-ON (tgt.user_id = src.user_id AND tgt.integration = src.integration AND tgt.instance = src.instance)
+USING (SELECT :1 AS id, :2 AS user_id, :3 AS integration, :4 AS connection,
+              :5 AS instance, :6 AS access_token_encrypted, :7 AS refresh_token_encrypted,
+              :8 AS scopes, :9 AS expires_at, :10 AS last_refreshed_at,
+              :11 AS refresh_error_count, :12 AS metadata_json,
+              :13 AS created_at, :14 AS updated_at FROM DUAL) src
+ON (tgt.user_id = src.user_id AND tgt.integration = src.integration AND tgt.connection = src.connection AND tgt.instance = src.instance)
 WHEN MATCHED THEN UPDATE SET
     tgt.access_token_encrypted = src.access_token_encrypted,
     tgt.refresh_token_encrypted = src.refresh_token_encrypted,
@@ -34,9 +34,9 @@ WHEN MATCHED THEN UPDATE SET
     tgt.refresh_error_count = src.refresh_error_count,
     tgt.metadata_json = src.metadata_json, tgt.updated_at = src.updated_at
 WHEN NOT MATCHED THEN INSERT
-    (id, user_id, integration, instance, access_token_encrypted, refresh_token_encrypted,
+    (id, user_id, integration, connection, instance, access_token_encrypted, refresh_token_encrypted,
      scopes, expires_at, last_refreshed_at, refresh_error_count, metadata_json, created_at, updated_at)
-VALUES (src.id, src.user_id, src.integration, src.instance, src.access_token_encrypted,
+VALUES (src.id, src.user_id, src.integration, src.connection, src.instance, src.access_token_encrypted,
         src.refresh_token_encrypted, src.scopes, src.expires_at, src.last_refreshed_at,
         src.refresh_error_count, src.metadata_json, src.created_at, src.updated_at)`
 }
@@ -109,6 +109,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 				id VARCHAR2(36) PRIMARY KEY,
 				user_id VARCHAR2(36) NOT NULL,
 				integration VARCHAR2(255) NOT NULL,
+				connection VARCHAR2(255) DEFAULT '' NOT NULL,
 				instance VARCHAR2(255) NOT NULL,
 				access_token_encrypted CLOB NOT NULL,
 				refresh_token_encrypted CLOB,
@@ -140,6 +141,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 				id VARCHAR2(36) PRIMARY KEY,
 				user_id VARCHAR2(36) NOT NULL,
 				integration VARCHAR2(255) NOT NULL,
+				connection VARCHAR2(255) DEFAULT '' NOT NULL,
 				instance VARCHAR2(255) NOT NULL,
 				access_token_encrypted CLOB NOT NULL,
 				refresh_token_encrypted CLOB,
@@ -173,8 +175,8 @@ func (s *Store) Migrate(ctx context.Context) error {
 			ddl:  "ALTER TABLE users ADD CONSTRAINT uq_users_email UNIQUE (email)",
 		},
 		{
-			name: "UQ_IT_USER_INTEG_INST",
-			ddl:  "ALTER TABLE integration_tokens ADD CONSTRAINT uq_it_user_integ_inst UNIQUE (user_id, integration, instance)",
+			name: "UQ_IT_USER_INTEG_CONN_INST",
+			ddl:  "ALTER TABLE integration_tokens ADD CONSTRAINT uq_it_user_integ_conn_inst UNIQUE (user_id, integration, connection, instance)",
 		},
 		{
 			name: "FK_IT_USER",

--- a/plugins/datastore/postgres/postgres.go
+++ b/plugins/datastore/postgres/postgres.go
@@ -20,10 +20,10 @@ func (dialect) Placeholder(n int) string { return fmt.Sprintf("$%d", n) }
 func (dialect) UpsertTokenSQL() string {
 	return `
 		INSERT INTO integration_tokens
-			(id, user_id, integration, instance, access_token_encrypted, refresh_token_encrypted,
+			(id, user_id, integration, connection, instance, access_token_encrypted, refresh_token_encrypted,
 			 scopes, expires_at, last_refreshed_at, refresh_error_count, metadata_json, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-		ON CONFLICT(user_id, integration, instance) DO UPDATE SET
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+		ON CONFLICT(user_id, integration, connection, instance) DO UPDATE SET
 			access_token_encrypted = EXCLUDED.access_token_encrypted,
 			refresh_token_encrypted = EXCLUDED.refresh_token_encrypted,
 			scopes = EXCLUDED.scopes,
@@ -94,6 +94,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id),
 			integration TEXT NOT NULL,
+			connection TEXT NOT NULL DEFAULT '',
 			instance TEXT NOT NULL,
 			access_token_encrypted TEXT NOT NULL,
 			refresh_token_encrypted TEXT NOT NULL DEFAULT '',
@@ -104,7 +105,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 			metadata_json TEXT NOT NULL DEFAULT '',
 			created_at TIMESTAMPTZ NOT NULL,
 			updated_at TIMESTAMPTZ NOT NULL,
-			UNIQUE(user_id, integration, instance)
+			UNIQUE(user_id, integration, connection, instance)
 		)`); err != nil {
 		return fmt.Errorf("creating integration_tokens table: %w", err)
 	}
@@ -126,6 +127,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id),
 			integration TEXT NOT NULL,
+			connection TEXT NOT NULL DEFAULT '',
 			instance TEXT NOT NULL,
 			access_token_encrypted TEXT NOT NULL,
 			refresh_token_encrypted TEXT NOT NULL DEFAULT '',

--- a/plugins/datastore/postgres/postgres_test.go
+++ b/plugins/datastore/postgres/postgres_test.go
@@ -128,7 +128,7 @@ func TestEncryptionRoundTrip(t *testing.T) {
 		t.Error("access_token_encrypted is empty")
 	}
 
-	got, err := store.Token(ctx, user.ID, "test", "i1")
+	got, err := store.Token(ctx, user.ID, "test", "", "i1")
 	if err != nil {
 		t.Fatalf("Token: %v", err)
 	}

--- a/plugins/datastore/sqlite/sqlite.go
+++ b/plugins/datastore/sqlite/sqlite.go
@@ -21,10 +21,10 @@ func (dialect) Placeholder(int) string { return "?" }
 func (dialect) UpsertTokenSQL() string {
 	return `
 		INSERT INTO integration_tokens
-			(id, user_id, integration, instance, access_token_encrypted, refresh_token_encrypted,
+			(id, user_id, integration, connection, instance, access_token_encrypted, refresh_token_encrypted,
 			 scopes, expires_at, last_refreshed_at, refresh_error_count, metadata_json, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(user_id, integration, instance) DO UPDATE SET
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(user_id, integration, connection, instance) DO UPDATE SET
 			access_token_encrypted = excluded.access_token_encrypted,
 			refresh_token_encrypted = excluded.refresh_token_encrypted,
 			scopes = excluded.scopes,
@@ -80,6 +80,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id),
 			integration TEXT NOT NULL,
+			connection TEXT NOT NULL DEFAULT '',
 			instance TEXT NOT NULL,
 			access_token_encrypted TEXT NOT NULL,
 			refresh_token_encrypted TEXT NOT NULL DEFAULT '',
@@ -90,7 +91,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 			metadata_json TEXT NOT NULL DEFAULT '',
 			created_at DATETIME NOT NULL,
 			updated_at DATETIME NOT NULL,
-			UNIQUE(user_id, integration, instance)
+			UNIQUE(user_id, integration, connection, instance)
 		);
 		CREATE TABLE IF NOT EXISTS api_tokens (
 			id TEXT PRIMARY KEY,
@@ -106,6 +107,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 			id TEXT PRIMARY KEY,
 			user_id TEXT NOT NULL REFERENCES users(id),
 			integration TEXT NOT NULL,
+			connection TEXT NOT NULL DEFAULT '',
 			instance TEXT NOT NULL,
 			access_token_encrypted TEXT NOT NULL,
 			refresh_token_encrypted TEXT NOT NULL DEFAULT '',

--- a/plugins/datastore/sqlite/sqlite_test.go
+++ b/plugins/datastore/sqlite/sqlite_test.go
@@ -76,7 +76,7 @@ func TestEncryptionRoundTrip(t *testing.T) {
 		t.Error("access_token_encrypted is empty")
 	}
 
-	got, err := store.Token(ctx, user.ID, "test", "i1")
+	got, err := store.Token(ctx, user.ID, "test", "", "i1")
 	if err != nil {
 		t.Fatalf("Token: %v", err)
 	}
@@ -182,7 +182,7 @@ func TestStoreTokenUpsert(t *testing.T) {
 		t.Fatalf("second StoreToken: %v", err)
 	}
 
-	got, err := store.Token(ctx, user.ID, "svc", "i1")
+	got, err := store.Token(ctx, user.ID, "svc", "", "i1")
 	if err != nil {
 		t.Fatalf("Token: %v", err)
 	}

--- a/plugins/datastore/sqlserver/sqlserver.go
+++ b/plugins/datastore/sqlserver/sqlserver.go
@@ -26,10 +26,10 @@ func (dialect) Placeholder(n int) string { return fmt.Sprintf("@p%d", n) }
 func (dialect) UpsertTokenSQL() string {
 	return `
 		MERGE integration_tokens WITH (HOLDLOCK) AS tgt
-		USING (VALUES (@p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10, @p11, @p12, @p13))
-			AS src (id, user_id, integration, instance, access_token_encrypted, refresh_token_encrypted,
+		USING (VALUES (@p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10, @p11, @p12, @p13, @p14))
+			AS src (id, user_id, integration, connection, instance, access_token_encrypted, refresh_token_encrypted,
 					scopes, expires_at, last_refreshed_at, refresh_error_count, metadata_json, created_at, updated_at)
-		ON tgt.user_id = src.user_id AND tgt.integration = src.integration AND tgt.instance = src.instance
+		ON tgt.user_id = src.user_id AND tgt.integration = src.integration AND tgt.connection = src.connection AND tgt.instance = src.instance
 		WHEN MATCHED THEN UPDATE SET
 			tgt.access_token_encrypted = src.access_token_encrypted,
 			tgt.refresh_token_encrypted = src.refresh_token_encrypted,
@@ -38,9 +38,9 @@ func (dialect) UpsertTokenSQL() string {
 			tgt.refresh_error_count = src.refresh_error_count,
 			tgt.metadata_json = src.metadata_json, tgt.updated_at = src.updated_at
 		WHEN NOT MATCHED THEN INSERT
-			(id, user_id, integration, instance, access_token_encrypted, refresh_token_encrypted,
+			(id, user_id, integration, connection, instance, access_token_encrypted, refresh_token_encrypted,
 			 scopes, expires_at, last_refreshed_at, refresh_error_count, metadata_json, created_at, updated_at)
-		VALUES (src.id, src.user_id, src.integration, src.instance, src.access_token_encrypted,
+		VALUES (src.id, src.user_id, src.integration, src.connection, src.instance, src.access_token_encrypted,
 				src.refresh_token_encrypted, src.scopes, src.expires_at, src.last_refreshed_at,
 				src.refresh_error_count, src.metadata_json, src.created_at, src.updated_at);`
 }
@@ -113,6 +113,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 				id NVARCHAR(36) NOT NULL PRIMARY KEY,
 				user_id NVARCHAR(36) NOT NULL REFERENCES users(id),
 				integration NVARCHAR(255) NOT NULL,
+				connection NVARCHAR(255) NOT NULL DEFAULT '',
 				instance NVARCHAR(255) NOT NULL,
 				access_token_encrypted NVARCHAR(MAX) NOT NULL,
 				refresh_token_encrypted NVARCHAR(MAX) NOT NULL DEFAULT '',
@@ -123,7 +124,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 				metadata_json NVARCHAR(MAX) NOT NULL DEFAULT '',
 				created_at DATETIME2(6) NOT NULL,
 				updated_at DATETIME2(6) NOT NULL,
-				UNIQUE(user_id, integration, instance)
+				UNIQUE(user_id, integration, connection, instance)
 			)`},
 		{"api_tokens", `
 			IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'api_tokens')
@@ -143,6 +144,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 				id NVARCHAR(36) NOT NULL PRIMARY KEY,
 				user_id NVARCHAR(36) NOT NULL REFERENCES users(id),
 				integration NVARCHAR(255) NOT NULL,
+				connection NVARCHAR(255) NOT NULL DEFAULT '',
 				instance NVARCHAR(255) NOT NULL,
 				access_token_encrypted NVARCHAR(MAX) NOT NULL,
 				refresh_token_encrypted NVARCHAR(MAX) NOT NULL DEFAULT '',

--- a/plugins/datastore/sqlstore/sqlstore.go
+++ b/plugins/datastore/sqlstore/sqlstore.go
@@ -25,7 +25,7 @@ type Dialect interface {
 
 	// UpsertTokenSQL returns the full INSERT ... ON CONFLICT / ON
 	// DUPLICATE KEY UPDATE statement for integration_tokens. The
-	// statement must accept 13 bind parameters.
+	// statement must accept 14 bind parameters.
 	UpsertTokenSQL() string
 
 	// IsDuplicateKeyError reports whether err is a driver-specific
@@ -80,7 +80,7 @@ func (s *Store) scanIntegrationToken(row Scanner) (*core.IntegrationToken, error
 	var scopes, metadataJSON sql.NullString
 	var expiresAt, lastRefreshedAt sql.NullTime
 
-	if err := row.Scan(&t.ID, &t.UserID, &t.Integration, &t.Instance,
+	if err := row.Scan(&t.ID, &t.UserID, &t.Integration, &t.Connection, &t.Instance,
 		&accessEnc, &refreshEnc,
 		&scopes, &expiresAt, &lastRefreshedAt, &t.RefreshErrorCount,
 		&metadataJSON, &t.CreatedAt, &t.UpdatedAt); err != nil {
@@ -221,7 +221,7 @@ func (s *Store) StoreToken(ctx context.Context, token *core.IntegrationToken) er
 	}
 
 	_, err = s.DB.ExecContext(ctx, s.Dialect.UpsertTokenSQL(),
-		token.ID, token.UserID, token.Integration, token.Instance,
+		token.ID, token.UserID, token.Integration, token.Connection, token.Instance,
 		accessEnc, refreshEnc,
 		token.Scopes, NullableTime(token.ExpiresAt), NullableTime(token.LastRefreshedAt),
 		token.RefreshErrorCount, token.MetadataJSON, token.CreatedAt, token.UpdatedAt,
@@ -232,13 +232,13 @@ func (s *Store) StoreToken(ctx context.Context, token *core.IntegrationToken) er
 	return nil
 }
 
-func (s *Store) Token(ctx context.Context, userID, integration, instance string) (*core.IntegrationToken, error) {
+func (s *Store) Token(ctx context.Context, userID, integration, connection, instance string) (*core.IntegrationToken, error) {
 	row := s.DB.QueryRowContext(ctx, `
-		SELECT id, user_id, integration, instance, access_token_encrypted, refresh_token_encrypted,
+		SELECT id, user_id, integration, connection, instance, access_token_encrypted, refresh_token_encrypted,
 		       scopes, expires_at, last_refreshed_at, refresh_error_count, metadata_json, created_at, updated_at
 		FROM integration_tokens
-		WHERE user_id = `+s.ph(1)+` AND integration = `+s.ph(2)+` AND instance = `+s.ph(3),
-		userID, integration, instance,
+		WHERE user_id = `+s.ph(1)+` AND integration = `+s.ph(2)+` AND connection = `+s.ph(3)+` AND instance = `+s.ph(4),
+		userID, integration, connection, instance,
 	)
 	t, err := s.scanIntegrationToken(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -252,7 +252,7 @@ func (s *Store) Token(ctx context.Context, userID, integration, instance string)
 
 func (s *Store) ListTokens(ctx context.Context, userID string) ([]*core.IntegrationToken, error) {
 	rows, err := s.DB.QueryContext(ctx, `
-		SELECT id, user_id, integration, instance, access_token_encrypted, refresh_token_encrypted,
+		SELECT id, user_id, integration, connection, instance, access_token_encrypted, refresh_token_encrypted,
 		       scopes, expires_at, last_refreshed_at, refresh_error_count, metadata_json, created_at, updated_at
 		FROM integration_tokens WHERE user_id = `+s.ph(1), userID)
 	if err != nil {
@@ -273,11 +273,32 @@ func (s *Store) ListTokens(ctx context.Context, userID string) ([]*core.Integrat
 
 func (s *Store) ListTokensForIntegration(ctx context.Context, userID, integration string) ([]*core.IntegrationToken, error) {
 	rows, err := s.DB.QueryContext(ctx, `
-		SELECT id, user_id, integration, instance, access_token_encrypted, refresh_token_encrypted,
+		SELECT id, user_id, integration, connection, instance, access_token_encrypted, refresh_token_encrypted,
 		       scopes, expires_at, last_refreshed_at, refresh_error_count, metadata_json, created_at, updated_at
 		FROM integration_tokens WHERE user_id = `+s.ph(1)+` AND integration = `+s.ph(2), userID, integration)
 	if err != nil {
 		return nil, fmt.Errorf("listing tokens for integration: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tokens []*core.IntegrationToken
+	for rows.Next() {
+		t, err := s.scanIntegrationToken(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning token row: %w", err)
+		}
+		tokens = append(tokens, t)
+	}
+	return tokens, rows.Err()
+}
+
+func (s *Store) ListTokensForConnection(ctx context.Context, userID, integration, connection string) ([]*core.IntegrationToken, error) {
+	rows, err := s.DB.QueryContext(ctx, `
+		SELECT id, user_id, integration, connection, instance, access_token_encrypted, refresh_token_encrypted,
+		       scopes, expires_at, last_refreshed_at, refresh_error_count, metadata_json, created_at, updated_at
+		FROM integration_tokens WHERE user_id = `+s.ph(1)+` AND integration = `+s.ph(2)+` AND connection = `+s.ph(3), userID, integration, connection)
+	if err != nil {
+		return nil, fmt.Errorf("listing tokens for connection: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
@@ -375,11 +396,11 @@ func (s *Store) StoreStagedConnection(ctx context.Context, sc *core.StagedConnec
 
 	_, err = s.DB.ExecContext(ctx, `
 		INSERT INTO staged_connections
-			(id, user_id, integration, instance, access_token_encrypted, refresh_token_encrypted,
+			(id, user_id, integration, connection, instance, access_token_encrypted, refresh_token_encrypted,
 			 token_expires_at, metadata_json, candidates_json, created_at, expires_at)
-		VALUES (`+s.ph(1)+`, `+s.ph(2)+`, `+s.ph(3)+`, `+s.ph(4)+`, `+s.ph(5)+`, `+s.ph(6)+`,
-				`+s.ph(7)+`, `+s.ph(8)+`, `+s.ph(9)+`, `+s.ph(10)+`, `+s.ph(11)+`)`,
-		sc.ID, sc.UserID, sc.Integration, sc.Instance,
+		VALUES (`+s.ph(1)+`, `+s.ph(2)+`, `+s.ph(3)+`, `+s.ph(4)+`, `+s.ph(5)+`, `+s.ph(6)+`, `+s.ph(7)+`,
+				`+s.ph(8)+`, `+s.ph(9)+`, `+s.ph(10)+`, `+s.ph(11)+`, `+s.ph(12)+`)`,
+		sc.ID, sc.UserID, sc.Integration, sc.Connection, sc.Instance,
 		accessEnc, refreshEnc,
 		NullableTime(sc.TokenExpiresAt), sc.MetadataJSON, sc.CandidatesJSON,
 		sc.CreatedAt, sc.ExpiresAt,
@@ -392,7 +413,7 @@ func (s *Store) StoreStagedConnection(ctx context.Context, sc *core.StagedConnec
 
 func (s *Store) GetStagedConnection(ctx context.Context, id string) (*core.StagedConnection, error) {
 	row := s.DB.QueryRowContext(ctx, `
-		SELECT id, user_id, integration, instance, access_token_encrypted, refresh_token_encrypted,
+		SELECT id, user_id, integration, connection, instance, access_token_encrypted, refresh_token_encrypted,
 		       token_expires_at, metadata_json, candidates_json, created_at, expires_at
 		FROM staged_connections WHERE id = `+s.ph(1), id)
 
@@ -401,7 +422,7 @@ func (s *Store) GetStagedConnection(ctx context.Context, id string) (*core.Stage
 	var metadataJSON sql.NullString
 	var tokenExpiresAt sql.NullTime
 
-	if err := row.Scan(&sc.ID, &sc.UserID, &sc.Integration, &sc.Instance,
+	if err := row.Scan(&sc.ID, &sc.UserID, &sc.Integration, &sc.Connection, &sc.Instance,
 		&accessEnc, &refreshEnc,
 		&tokenExpiresAt, &metadataJSON, &sc.CandidatesJSON,
 		&sc.CreatedAt, &sc.ExpiresAt); err != nil {


### PR DESCRIPTION
Token storage was previously keyed by (user, integration, instance),
which cannot distinguish credentials for different connections within
the same integration. This adds a `Connection` field to
`IntegrationToken` and threads it through the entire stack: all eight
datastore implementations (SQL and NoSQL), the invocation broker, the
MCP tool handlers, the OAuth and manual connect flows, and the
disconnect API. Tokens are now keyed by (user, integration, connection,
instance).

The broker derives the connection name automatically from a
`ConnectionMapper` built at bootstrap time, so callers of `Invoke` do
not need to pass it explicitly. MCP tool handlers capture the correct
connection name (API or MCP) per tool at registration time based on the
catalog transport field. The connect flow accepts an explicit connection
name in the request and defaults to `_plugin` for plugin-only
integrations. The disconnect endpoint accepts a `?connection=` query
parameter for targeted credential removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)