### PR TITLE
Split config validation into structural and runtime phases

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -203,7 +203,7 @@ func LoadWithMapping(path string, getenv func(string) string) (*Config, error) {
 	resolveBaseURL(&cfg)
 	resolveRelativePaths(path, &cfg)
 
-	if err := validate(&cfg); err != nil {
+	if err := ValidateStructure(&cfg); err != nil {
 		return nil, err
 	}
 
@@ -304,16 +304,11 @@ func resolvePackagePath(baseDir, value string) string {
 
 var templateParamRe = regexp.MustCompile(`\{(\w+)\}`)
 
-func validate(cfg *Config) error {
-	if cfg.Auth.Provider == "" {
-		return fmt.Errorf("config validation: auth.provider is required")
-	}
-	if cfg.Datastore.Provider == "" {
-		return fmt.Errorf("config validation: datastore.provider is required")
-	}
-	if !cfg.Server.DevMode && cfg.Server.EncryptionKey == "" {
-		return fmt.Errorf("config validation: server.encryption_key is required (set server.dev_mode to true to skip)")
-	}
+// ValidateStructure checks config shape: integration references, plugin
+// declarations, connection references, URL template params, egress rules.
+// Called by Load (and therefore by bundle and validate). Does not require
+// runtime secrets like encryption_key, auth.provider, or datastore.provider.
+func ValidateStructure(cfg *Config) error {
 	if err := validateEgress(&cfg.Egress); err != nil {
 		return err
 	}
@@ -340,6 +335,23 @@ func validate(cfg *Config) error {
 		if rt.Type == "" {
 			return fmt.Errorf("config validation: runtime %q requires either type or plugin", name)
 		}
+	}
+	return nil
+}
+
+// ValidateRuntime checks runtime-only requirements: encryption key, auth
+// provider, and datastore provider. Callers that need a fully operational
+// config (serve) should call this after Load. Callers that only need
+// structural correctness (bundle, validate) should not.
+func ValidateRuntime(cfg *Config) error {
+	if cfg.Auth.Provider == "" {
+		return fmt.Errorf("config validation: auth.provider is required")
+	}
+	if cfg.Datastore.Provider == "" {
+		return fmt.Errorf("config validation: datastore.provider is required")
+	}
+	if !cfg.Server.DevMode && cfg.Server.EncryptionKey == "" {
+		return fmt.Errorf("config validation: server.encryption_key is required (set server.dev_mode to true to skip)")
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -266,7 +266,7 @@ runtimes:
 	}
 }
 
-func TestLoadConfigValidation(t *testing.T) {
+func TestValidateRuntime(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -300,6 +300,71 @@ datastore:
   provider: data-store
 `,
 		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := mustWriteConfigFile(t, tc.yaml)
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if err := ValidateRuntime(cfg); err == nil {
+				t.Fatal("ValidateRuntime: expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestLoadSucceedsWithoutRuntimeFields(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+integrations:
+  custom_tool:
+    plugin:
+      package: https://example.com/custom-tool.tar.gz
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Integrations["custom_tool"].Plugin.Package != "https://example.com/custom-tool.tar.gz" {
+		t.Fatalf("unexpected plugin package: %q", cfg.Integrations["custom_tool"].Plugin.Package)
+	}
+}
+
+func TestValidateRuntimeAcceptsDevMode(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+auth:
+  provider: auth-provider
+datastore:
+  provider: data-store
+server:
+  dev_mode: true
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := ValidateRuntime(cfg); err != nil {
+		t.Fatalf("ValidateRuntime: %v", err)
+	}
+}
+
+func TestLoadConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		yaml string
+	}{
 		{
 			name: "declarative integration with no connections",
 			yaml: `

--- a/internal/operator/lifecycle.go
+++ b/internal/operator/lifecycle.go
@@ -103,6 +103,9 @@ func (l *Lifecycle) LoadForExecutionAtPath(configPath string, locked bool) (*con
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading config: %v", err)
 	}
+	if err := config.ValidateRuntime(cfg); err != nil {
+		return nil, nil, err
+	}
 
 	preparedProviders, err := l.providersForConfig(configPath, cfg, locked)
 	if err != nil {


### PR DESCRIPTION
`config.Load` previously required all runtime fields (encryption key, auth provider, datastore provider) even when the caller only needed structural correctness, like `gestaltd bundle` or `gestaltd validate`. This forced downstream Dockerfiles to set placeholder values like `ENCRYPTION_KEY=build-placeholder` at image build time.

This replaces the single `validate` function with two explicit public functions: `ValidateStructure` checks config shape, integration references, plugin declarations, and egress rules. `ValidateRuntime` checks runtime requirements like encryption key, auth provider, and datastore provider. `Load` now calls only `ValidateStructure`, and the serve path calls `ValidateRuntime` separately via `LoadForExecutionAtPath`.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>