### PR TITLE
Return rich catalog operations from list-operations endpoint

### DIFF
--- a/internal/invocation/guarded.go
+++ b/internal/invocation/guarded.go
@@ -163,6 +163,16 @@ func (g *GuardedInvoker) check(meta *InvocationMeta, providerName, instance, ope
 	return nil
 }
 
+func (g *GuardedInvoker) ResolveToken(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (string, error) {
+	type resolver interface {
+		ResolveToken(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (string, error)
+	}
+	if r, ok := g.inner.(resolver); ok {
+		return r.ResolveToken(ctx, p, providerName, connection, instance)
+	}
+	return "", fmt.Errorf("token resolution not supported")
+}
+
 func (g *GuardedInvoker) logAudit(entry core.AuditEntry) {
 	if g.audit != nil {
 		g.audit.Log(entry)

--- a/internal/server/catalog_resolution.go
+++ b/internal/server/catalog_resolution.go
@@ -1,0 +1,97 @@
+package server
+
+import (
+	"context"
+	"log"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+	"github.com/valon-technologies/gestalt/core/integration"
+	"github.com/valon-technologies/gestalt/internal/principal"
+)
+
+type tokenResolver interface {
+	ResolveToken(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (string, error)
+}
+
+func resolveCatalog(ctx context.Context, prov core.Provider, provName string, resolver tokenResolver, p *principal.Principal, defaultConnection string) (*catalog.Catalog, error) {
+	var staticCat *catalog.Catalog
+	if cp, ok := prov.(core.CatalogProvider); ok {
+		staticCat = cp.Catalog()
+	}
+
+	var sessionCat *catalog.Catalog
+	if scp, ok := prov.(core.SessionCatalogProvider); ok {
+		if resolver != nil && prov.ConnectionMode() != core.ConnectionModeNone && p != nil {
+			token, err := resolver.ResolveToken(ctx, p, provName, defaultConnection, "")
+			if err != nil {
+				log.Printf("catalog: token resolution for %q: %v", provName, err)
+			} else {
+				cat, err := scp.CatalogForRequest(ctx, token)
+				if err != nil {
+					log.Printf("catalog: session catalog for %q: %v", provName, err)
+				} else {
+					sessionCat = cat
+				}
+			}
+		}
+	}
+
+	var merged *catalog.Catalog
+	switch {
+	case staticCat == nil && sessionCat == nil:
+		// fall through to synthesis
+	case staticCat != nil && sessionCat == nil:
+		merged = staticCat.Clone()
+	case staticCat == nil && sessionCat != nil:
+		merged = sessionCat.Clone()
+	default:
+		merged = staticCat.Clone()
+		staticIDs := make(map[string]struct{}, len(merged.Operations))
+		for i := range merged.Operations {
+			staticIDs[merged.Operations[i].ID] = struct{}{}
+		}
+		for i := range sessionCat.Operations {
+			if _, exists := staticIDs[sessionCat.Operations[i].ID]; !exists {
+				merged.Operations = append(merged.Operations, sessionCat.Operations[i])
+			}
+		}
+	}
+
+	if merged == nil {
+		merged = synthesizeCatalog(prov, provName)
+	}
+
+	integration.CompileSchemas(merged)
+	return merged, nil
+}
+
+func synthesizeCatalog(prov core.Provider, provName string) *catalog.Catalog {
+	ops := prov.ListOperations()
+	cat := &catalog.Catalog{
+		Name:        provName,
+		DisplayName: prov.DisplayName(),
+		Description: prov.Description(),
+		Operations:  make([]catalog.CatalogOperation, 0, len(ops)),
+	}
+	for _, op := range ops {
+		params := make([]catalog.CatalogParameter, 0, len(op.Parameters))
+		for _, p := range op.Parameters {
+			params = append(params, catalog.CatalogParameter{
+				Name:        p.Name,
+				Type:        p.Type,
+				Description: p.Description,
+				Required:    p.Required,
+				Default:     p.Default,
+			})
+		}
+		cat.Operations = append(cat.Operations, catalog.CatalogOperation{
+			ID:          op.Name,
+			Method:      op.Method,
+			Description: op.Description,
+			Parameters:  params,
+			Transport:   catalog.TransportREST,
+		})
+	}
+	return cat
+}

--- a/internal/server/catalog_resolution_test.go
+++ b/internal/server/catalog_resolution_test.go
@@ -1,0 +1,367 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+	"github.com/valon-technologies/gestalt/internal/principal"
+)
+
+type stubProvider struct {
+	name        string
+	displayName string
+	description string
+	connMode    core.ConnectionMode
+	ops         []core.Operation
+}
+
+func (s *stubProvider) Name() string                        { return s.name }
+func (s *stubProvider) DisplayName() string                 { return s.displayName }
+func (s *stubProvider) Description() string                 { return s.description }
+func (s *stubProvider) ConnectionMode() core.ConnectionMode { return s.connMode }
+func (s *stubProvider) ListOperations() []core.Operation    { return s.ops }
+func (s *stubProvider) Execute(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
+	return nil, nil
+}
+
+type stubCatalogProvider struct {
+	stubProvider
+	cat *catalog.Catalog
+}
+
+func (s *stubCatalogProvider) Catalog() *catalog.Catalog { return s.cat }
+
+type stubSessionProvider struct {
+	stubCatalogProvider
+	sessionCat *catalog.Catalog
+	sessionErr error
+}
+
+func (s *stubSessionProvider) CatalogForRequest(_ context.Context, _ string) (*catalog.Catalog, error) {
+	return s.sessionCat, s.sessionErr
+}
+
+type stubTokenResolver struct {
+	token string
+	err   error
+}
+
+func (s *stubTokenResolver) ResolveToken(context.Context, *principal.Principal, string, string, string) (string, error) {
+	return s.token, s.err
+}
+
+func TestResolveCatalog_StaticCatalog(t *testing.T) {
+	t.Parallel()
+
+	prov := &stubCatalogProvider{
+		stubProvider: stubProvider{
+			name:        "widget-api",
+			displayName: "Widget API",
+			description: "Manages widgets",
+			connMode:    core.ConnectionModeUser,
+		},
+		cat: &catalog.Catalog{
+			Name:        "widget-api",
+			DisplayName: "Widget API",
+			Operations: []catalog.CatalogOperation{
+				{
+					ID:     "list_widgets",
+					Method: "GET",
+					Path:   "/widgets",
+					Parameters: []catalog.CatalogParameter{
+						{Name: "page", Type: "integer", Location: "query", Required: false},
+						{Name: "limit", Type: "integer", Location: "query", Required: true},
+					},
+				},
+			},
+		},
+	}
+
+	cat, err := resolveCatalog(context.Background(), prov, "widget-api", nil, nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cat.Operations) != 1 {
+		t.Fatalf("expected 1 operation, got %d", len(cat.Operations))
+	}
+	op := cat.Operations[0]
+	if op.ID != "list_widgets" {
+		t.Fatalf("expected id %q, got %q", "list_widgets", op.ID)
+	}
+	if op.InputSchema == nil {
+		t.Fatal("expected inputSchema to be synthesized")
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(op.InputSchema, &schema); err != nil {
+		t.Fatalf("invalid inputSchema JSON: %v", err)
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("expected properties in schema")
+	}
+	if _, ok := props["page"]; !ok {
+		t.Fatal("expected page in schema properties")
+	}
+	if _, ok := props["limit"]; !ok {
+		t.Fatal("expected limit in schema properties")
+	}
+}
+
+func TestResolveCatalog_FlatProvider(t *testing.T) {
+	t.Parallel()
+
+	prov := &stubProvider{
+		name:        "gadget-svc",
+		displayName: "Gadget Service",
+		description: "Gadget operations",
+		connMode:    core.ConnectionModeNone,
+		ops: []core.Operation{
+			{
+				Name:        "create_gadget",
+				Method:      "POST",
+				Description: "Creates a gadget",
+				Parameters: []core.Parameter{
+					{Name: "label", Type: "string", Required: true},
+					{Name: "count", Type: "integer", Required: false, Default: 1},
+				},
+			},
+			{
+				Name:        "get_gadget",
+				Method:      "GET",
+				Description: "Gets a gadget",
+			},
+		},
+	}
+
+	cat, err := resolveCatalog(context.Background(), prov, "gadget-svc", nil, nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cat.Operations) != 2 {
+		t.Fatalf("expected 2 operations, got %d", len(cat.Operations))
+	}
+
+	create := cat.Operations[0]
+	if create.ID != "create_gadget" {
+		t.Fatalf("expected id %q, got %q", "create_gadget", create.ID)
+	}
+	if create.Method != "POST" {
+		t.Fatalf("expected method POST, got %q", create.Method)
+	}
+	if create.Transport != catalog.TransportREST {
+		t.Fatalf("expected transport %q, got %q", catalog.TransportREST, create.Transport)
+	}
+	if create.InputSchema == nil {
+		t.Fatal("expected inputSchema for operation with parameters")
+	}
+
+	get := cat.Operations[1]
+	if get.ID != "get_gadget" {
+		t.Fatalf("expected id %q, got %q", "get_gadget", get.ID)
+	}
+	if get.Annotations.ReadOnlyHint == nil || !*get.Annotations.ReadOnlyHint {
+		t.Fatal("expected readOnlyHint=true for GET method")
+	}
+}
+
+func TestResolveCatalog_SessionAndStaticMerge(t *testing.T) {
+	t.Parallel()
+
+	prov := &stubSessionProvider{
+		stubCatalogProvider: stubCatalogProvider{
+			stubProvider: stubProvider{
+				name:     "combo-api",
+				connMode: core.ConnectionModeUser,
+			},
+			cat: &catalog.Catalog{
+				Name: "combo-api",
+				Operations: []catalog.CatalogOperation{
+					{ID: "rest_op", Method: "GET", Transport: catalog.TransportREST},
+				},
+			},
+		},
+		sessionCat: &catalog.Catalog{
+			Name: "combo-api",
+			Operations: []catalog.CatalogOperation{
+				{ID: "mcp_op", Method: "POST", Transport: catalog.TransportMCPPassthrough},
+			},
+		},
+	}
+
+	resolver := &stubTokenResolver{token: "tok_123"}
+	p := &principal.Principal{UserID: "u1"}
+
+	cat, err := resolveCatalog(context.Background(), prov, "combo-api", resolver, p, "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cat.Operations) != 2 {
+		t.Fatalf("expected 2 operations, got %d", len(cat.Operations))
+	}
+
+	ids := map[string]bool{}
+	for _, op := range cat.Operations {
+		ids[op.ID] = true
+	}
+	if !ids["rest_op"] {
+		t.Fatal("expected rest_op in merged catalog")
+	}
+	if !ids["mcp_op"] {
+		t.Fatal("expected mcp_op in merged catalog")
+	}
+}
+
+func TestResolveCatalog_SameIDCollision_StaticWins(t *testing.T) {
+	t.Parallel()
+
+	prov := &stubSessionProvider{
+		stubCatalogProvider: stubCatalogProvider{
+			stubProvider: stubProvider{
+				name:     "clash-api",
+				connMode: core.ConnectionModeUser,
+			},
+			cat: &catalog.Catalog{
+				Name: "clash-api",
+				Operations: []catalog.CatalogOperation{
+					{ID: "shared_op", Method: "GET", Transport: catalog.TransportREST, Description: "static version"},
+				},
+			},
+		},
+		sessionCat: &catalog.Catalog{
+			Name: "clash-api",
+			Operations: []catalog.CatalogOperation{
+				{ID: "shared_op", Method: "POST", Transport: catalog.TransportMCPPassthrough, Description: "session version"},
+			},
+		},
+	}
+
+	resolver := &stubTokenResolver{token: "tok_456"}
+	p := &principal.Principal{UserID: "u1"}
+
+	cat, err := resolveCatalog(context.Background(), prov, "clash-api", resolver, p, "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cat.Operations) != 1 {
+		t.Fatalf("expected 1 operation after collision, got %d", len(cat.Operations))
+	}
+	if cat.Operations[0].Description != "static version" {
+		t.Fatalf("expected static version to win, got %q", cat.Operations[0].Description)
+	}
+	if cat.Operations[0].Method != "GET" {
+		t.Fatalf("expected GET from static, got %q", cat.Operations[0].Method)
+	}
+}
+
+func TestResolveCatalog_TokenResolutionFailure_NonFatal(t *testing.T) {
+	t.Parallel()
+
+	prov := &stubSessionProvider{
+		stubCatalogProvider: stubCatalogProvider{
+			stubProvider: stubProvider{
+				name:     "auth-api",
+				connMode: core.ConnectionModeUser,
+			},
+			cat: &catalog.Catalog{
+				Name: "auth-api",
+				Operations: []catalog.CatalogOperation{
+					{ID: "static_op", Method: "GET"},
+				},
+			},
+		},
+		sessionCat: &catalog.Catalog{
+			Name: "auth-api",
+			Operations: []catalog.CatalogOperation{
+				{ID: "session_only", Method: "POST"},
+			},
+		},
+	}
+
+	resolver := &stubTokenResolver{err: fmt.Errorf("token expired")}
+	p := &principal.Principal{UserID: "u1"}
+
+	cat, err := resolveCatalog(context.Background(), prov, "auth-api", resolver, p, "default")
+	if err != nil {
+		t.Fatalf("expected no error on token failure, got: %v", err)
+	}
+	if len(cat.Operations) != 1 {
+		t.Fatalf("expected 1 operation (static only), got %d", len(cat.Operations))
+	}
+	if cat.Operations[0].ID != "static_op" {
+		t.Fatalf("expected static_op, got %q", cat.Operations[0].ID)
+	}
+}
+
+func TestResolveCatalog_NilResolver(t *testing.T) {
+	t.Parallel()
+
+	prov := &stubSessionProvider{
+		stubCatalogProvider: stubCatalogProvider{
+			stubProvider: stubProvider{
+				name:     "noauth-api",
+				connMode: core.ConnectionModeUser,
+			},
+			cat: &catalog.Catalog{
+				Name: "noauth-api",
+				Operations: []catalog.CatalogOperation{
+					{ID: "the_op", Method: "PUT"},
+				},
+			},
+		},
+		sessionCat: &catalog.Catalog{
+			Name: "noauth-api",
+			Operations: []catalog.CatalogOperation{
+				{ID: "hidden_op", Method: "POST"},
+			},
+		},
+	}
+
+	cat, err := resolveCatalog(context.Background(), prov, "noauth-api", nil, &principal.Principal{UserID: "u1"}, "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cat.Operations) != 1 {
+		t.Fatalf("expected 1 operation (static only), got %d", len(cat.Operations))
+	}
+	if cat.Operations[0].ID != "the_op" {
+		t.Fatalf("expected the_op, got %q", cat.Operations[0].ID)
+	}
+}
+
+func TestResolveCatalog_CloneSafety(t *testing.T) {
+	t.Parallel()
+
+	original := &catalog.Catalog{
+		Name: "clone-api",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:     "safe_op",
+				Method: "POST",
+				Parameters: []catalog.CatalogParameter{
+					{Name: "data", Type: "string", Required: true},
+				},
+			},
+		},
+	}
+
+	prov := &stubCatalogProvider{
+		stubProvider: stubProvider{
+			name:     "clone-api",
+			connMode: core.ConnectionModeNone,
+		},
+		cat: original,
+	}
+
+	_, err := resolveCatalog(context.Background(), prov, "clone-api", nil, nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if original.Operations[0].InputSchema != nil {
+		t.Fatal("CompileSchemas mutated the provider's original catalog")
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -287,11 +287,22 @@ func (s *Server) requireOAuthProvider(w http.ResponseWriter, name string) (core.
 }
 
 func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
-	prov, ok := s.getProvider(w, chi.URLParam(r, "name"))
+	name := chi.URLParam(r, "name")
+	prov, ok := s.getProvider(w, name)
 	if !ok {
 		return
 	}
-	writeJSON(w, http.StatusOK, prov.ListOperations())
+	p := PrincipalFromContext(r.Context())
+	var resolver tokenResolver
+	if tr, ok := s.invoker.(tokenResolver); ok {
+		resolver = tr
+	}
+	cat, err := resolveCatalog(r.Context(), prov, name, resolver, p, s.defaultConnection[name])
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to resolve catalog")
+		return
+	}
+	writeJSON(w, http.StatusOK, cat.Operations)
 }
 
 func (s *Server) listRuntimes(w http.ResponseWriter, _ *http.Request) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -788,7 +788,12 @@ func TestDisconnectIntegration_NotConnected(t *testing.T) {
 func TestListOperations(t *testing.T) {
 	t.Parallel()
 
-	stub := &coretesting.StubIntegration{N: "test-int"}
+	stub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{N: "test-int"},
+		ops: []core.Operation{
+			{Name: "do_thing", Description: "Do a thing", Method: "GET"},
+		},
+	}
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.DevMode = true
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
@@ -810,6 +815,23 @@ func TestListOperations(t *testing.T) {
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var ops []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&ops); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if len(ops) != 1 {
+		t.Fatalf("expected 1 operation, got %d", len(ops))
+	}
+	if _, ok := ops[0]["id"]; !ok {
+		t.Fatal("expected camelCase 'id' key in response")
+	}
+	if _, ok := ops[0]["Name"]; ok {
+		t.Fatal("expected camelCase keys, found PascalCase 'Name'")
+	}
+	if ops[0]["id"] != "do_thing" {
+		t.Fatalf("expected id 'do_thing', got %v", ops[0]["id"])
 	}
 }
 


### PR DESCRIPTION
The `GET /api/v1/integrations/{name}/operations` endpoint now returns
`[]catalog.CatalogOperation` with camelCase JSON keys instead of the
flat `[]core.Operation` with PascalCase keys. The response is derived
from the effective catalog for the authenticated request, merging
static provider catalogs with session catalogs when available, and
falling back to synthesized metadata from flat operation lists. Token
resolution failures during session catalog lookup are non-fatal,
gracefully degrading to the static catalog alone.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>