### PR TITLE
Add parameter location routing for REST execution

### DIFF
--- a/core/integration/egress_adapter.go
+++ b/core/integration/egress_adapter.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 
 	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
 	"github.com/valon-technologies/gestalt/internal/apiexec"
 	"github.com/valon-technologies/gestalt/internal/egress"
 )
@@ -17,12 +18,23 @@ func (b *Base) executeREST(ctx context.Context, operation string, params map[str
 		return nil, fmt.Errorf("unknown operation: %s", operation)
 	}
 
+	catOp := findCatalogOp(b.catalog, operation)
+	bodyParams, queryParams, headerParams := partitionParams(catOp, params)
+
 	baseURL, headers := b.resolvedURLAndHeaders(ctx)
+	for k, v := range headerParams {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
+		headers[k] = v
+	}
+
 	req := apiexec.Request{
 		Method:        ep.Method,
 		BaseURL:       baseURL,
 		Path:          ep.Path,
-		Params:        params,
+		Params:        bodyParams,
+		QueryParams:   queryParams,
 		CustomHeaders: headers,
 		CheckResponse: b.CheckResponse,
 	}
@@ -55,7 +67,7 @@ func (b *Base) resolveEgress(ctx context.Context, operation string, req apiexec.
 			Provider:  b.IntegrationName,
 			Operation: operation,
 			Method:    req.Method,
-			Path:      apiexec.ExpandedPath(req.Method, req.Path, req.Params),
+			Path:      apiexec.ExpandedPathWithQuery(req.Method, req.Path, req.Params, req.QueryParams),
 		},
 		Headers:    egress.CopyHeaders(req.CustomHeaders),
 		Credential: credentialFromAPIRequest(req),
@@ -117,6 +129,7 @@ func egressRequestFromAPIExec(req apiexec.Request) egress.HTTPRequestSpec {
 		},
 		BaseURL:     req.BaseURL,
 		Params:      req.Params,
+		QueryParams: req.QueryParams,
 		Headers:     egress.CopyHeaders(req.CustomHeaders),
 		Body:        req.Body,
 		ContentType: req.ContentType,
@@ -125,4 +138,49 @@ func egressRequestFromAPIExec(req apiexec.Request) egress.HTTPRequestSpec {
 		NoRetry:     req.NoRetry,
 		Credential:  credentialFromAPIRequest(req),
 	}
+}
+
+func findCatalogOp(cat *catalog.Catalog, id string) *catalog.CatalogOperation {
+	if cat == nil {
+		return nil
+	}
+	for i := range cat.Operations {
+		if cat.Operations[i].ID == id {
+			return &cat.Operations[i]
+		}
+	}
+	return nil
+}
+
+func partitionParams(catOp *catalog.CatalogOperation, params map[string]any) (body map[string]any, query map[string]any, headers map[string]string) {
+	if catOp == nil || len(catOp.Parameters) == 0 {
+		return params, nil, nil
+	}
+
+	locations := make(map[string]string, len(catOp.Parameters))
+	for _, p := range catOp.Parameters {
+		if p.Location != "" {
+			locations[p.Name] = p.Location
+		}
+	}
+	if len(locations) == 0 {
+		return params, nil, nil
+	}
+
+	body = make(map[string]any)
+	query = make(map[string]any)
+	headers = make(map[string]string)
+	for k, v := range params {
+		switch locations[k] {
+		case "query":
+			query[k] = v
+		case "header":
+			headers[k] = fmt.Sprintf("%v", v)
+		case "path":
+			body[k] = v
+		default:
+			body[k] = v
+		}
+	}
+	return body, query, headers
 }

--- a/core/integration/param_routing_test.go
+++ b/core/integration/param_routing_test.go
@@ -1,0 +1,341 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core/catalog"
+)
+
+func TestPartitionParams_NilCatalogOp(t *testing.T) {
+	t.Parallel()
+
+	params := map[string]any{"name": "x", "page": 2}
+	body, query, headers := partitionParams(nil, params)
+
+	if body["name"] != "x" || body["page"] != 2 {
+		t.Fatalf("body = %v, want all params", body)
+	}
+	if query != nil {
+		t.Fatalf("query = %v, want nil", query)
+	}
+	if headers != nil {
+		t.Fatalf("headers = %v, want nil", headers)
+	}
+}
+
+func TestPartitionParams_NoLocations(t *testing.T) {
+	t.Parallel()
+
+	catOp := &catalog.CatalogOperation{
+		ID: "op1",
+		Parameters: []catalog.CatalogParameter{
+			{Name: "name", Type: "string"},
+			{Name: "count", Type: "integer"},
+		},
+	}
+	params := map[string]any{"name": "x", "count": 5}
+	body, query, headers := partitionParams(catOp, params)
+
+	if body["name"] != "x" || body["count"] != 5 {
+		t.Fatalf("body = %v, want all params", body)
+	}
+	if query != nil {
+		t.Fatalf("query = %v, want nil", query)
+	}
+	if headers != nil {
+		t.Fatalf("headers = %v, want nil", headers)
+	}
+}
+
+func TestPartitionParams_MixedLocations(t *testing.T) {
+	t.Parallel()
+
+	catOp := &catalog.CatalogOperation{
+		ID: "op1",
+		Parameters: []catalog.CatalogParameter{
+			{Name: "name", Type: "string", Location: "body"},
+			{Name: "page", Type: "integer", Location: "query"},
+			{Name: "x_api_key", Type: "string", Location: "header"},
+			{Name: "item_id", Type: "string", Location: "path"},
+		},
+	}
+	params := map[string]any{
+		"name":      "widget",
+		"page":      3,
+		"x_api_key": "secret",
+		"item_id":   "abc",
+	}
+	body, query, headers := partitionParams(catOp, params)
+
+	if body["name"] != "widget" {
+		t.Fatalf("body[name] = %v, want widget", body["name"])
+	}
+	if body["item_id"] != "abc" {
+		t.Fatalf("body[item_id] = %v, want abc (path params stay in body for substitutePath)", body["item_id"])
+	}
+	if query["page"] != 3 {
+		t.Fatalf("query[page] = %v, want 3", query["page"])
+	}
+	if headers["x_api_key"] != "secret" {
+		t.Fatalf("headers[x_api_key] = %v, want secret", headers["x_api_key"])
+	}
+}
+
+func TestPartitionParams_UnknownParam(t *testing.T) {
+	t.Parallel()
+
+	catOp := &catalog.CatalogOperation{
+		ID: "op1",
+		Parameters: []catalog.CatalogParameter{
+			{Name: "page", Type: "integer", Location: "query"},
+		},
+	}
+	params := map[string]any{
+		"page":    1,
+		"unknown": "extra",
+	}
+	body, query, _ := partitionParams(catOp, params)
+
+	if query["page"] != 1 {
+		t.Fatalf("query[page] = %v, want 1", query["page"])
+	}
+	if body["unknown"] != "extra" {
+		t.Fatalf("body[unknown] = %v, want extra (unknown params default to body)", body["unknown"])
+	}
+}
+
+func TestFindCatalogOp_Found(t *testing.T) {
+	t.Parallel()
+
+	cat := &catalog.Catalog{
+		Name: "test",
+		Operations: []catalog.CatalogOperation{
+			{ID: "op_alpha", Method: "GET", Path: "/alpha"},
+			{ID: "op_beta", Method: "POST", Path: "/beta"},
+		},
+	}
+	got := findCatalogOp(cat, "op_beta")
+	if got == nil || got.ID != "op_beta" {
+		t.Fatalf("findCatalogOp = %v, want op_beta", got)
+	}
+}
+
+func TestFindCatalogOp_NilCatalog(t *testing.T) {
+	t.Parallel()
+
+	got := findCatalogOp(nil, "anything")
+	if got != nil {
+		t.Fatalf("findCatalogOp(nil) = %v, want nil", got)
+	}
+}
+
+func TestFindCatalogOp_NotFound(t *testing.T) {
+	t.Parallel()
+
+	cat := &catalog.Catalog{
+		Name: "test",
+		Operations: []catalog.CatalogOperation{
+			{ID: "op_alpha", Method: "GET", Path: "/alpha"},
+		},
+	}
+	got := findCatalogOp(cat, "nonexistent")
+	if got != nil {
+		t.Fatalf("findCatalogOp = %v, want nil", got)
+	}
+}
+
+func TestExecuteREST_CatalogQueryParam(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		var body map[string]any
+		_ = json.Unmarshal(bodyBytes, &body)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"query":  r.URL.RawQuery,
+			"body":   body,
+			"method": r.Method,
+			"path":   r.URL.Path,
+		})
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	cat := &catalog.Catalog{
+		Name: "test-svc",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:     "create_item",
+				Method: "POST",
+				Path:   "/items",
+				Parameters: []catalog.CatalogParameter{
+					{Name: "name", Type: "string", Location: "body"},
+					{Name: "page", Type: "integer", Location: "query"},
+				},
+			},
+		},
+	}
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL,
+		Endpoints: map[string]Endpoint{
+			"create_item": {Method: http.MethodPost, Path: "/items"},
+		},
+	}
+	b.SetCatalog(cat)
+
+	result, err := b.Execute(context.Background(), "create_item", map[string]any{
+		"name": "widget",
+		"page": 2,
+	}, "test-token")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	query := resp["query"].(string)
+	parsed, err := url.ParseQuery(query)
+	if err != nil {
+		t.Fatalf("url.ParseQuery: %v", err)
+	}
+	if parsed.Get("page") != "2" {
+		t.Fatalf("query page = %q, want 2", parsed.Get("page"))
+	}
+
+	body := resp["body"].(map[string]any)
+	if body["name"] != "widget" {
+		t.Fatalf("body[name] = %v, want widget", body["name"])
+	}
+	if _, hasPage := body["page"]; hasPage {
+		t.Fatalf("body should not contain page (it should be in query)")
+	}
+}
+
+func TestExecuteREST_NoCatalog_PreservesLegacy(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		var body map[string]any
+		_ = json.Unmarshal(bodyBytes, &body)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"query": r.URL.RawQuery,
+			"body":  body,
+		})
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL,
+		Endpoints: map[string]Endpoint{
+			"create_item": {Method: http.MethodPost, Path: "/items"},
+		},
+	}
+
+	result, err := b.Execute(context.Background(), "create_item", map[string]any{
+		"name": "widget",
+		"page": 2,
+	}, "test-token")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	if resp["query"] != "" {
+		t.Fatalf("query = %q, want empty (legacy POST puts everything in body)", resp["query"])
+	}
+
+	body := resp["body"].(map[string]any)
+	if body["name"] != "widget" {
+		t.Fatalf("body[name] = %v, want widget", body["name"])
+	}
+	if body["page"] != float64(2) {
+		t.Fatalf("body[page] = %v, want 2", body["page"])
+	}
+}
+
+func TestExecuteREST_CatalogHeaderParam(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		var body map[string]any
+		_ = json.Unmarshal(bodyBytes, &body)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"body":     body,
+			"x_org_id": r.Header.Get("X-Org-Id"),
+			"query":    r.URL.RawQuery,
+		})
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	cat := &catalog.Catalog{
+		Name: "test-svc",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:     "create_item",
+				Method: "POST",
+				Path:   "/items",
+				Parameters: []catalog.CatalogParameter{
+					{Name: "name", Type: "string", Location: "body"},
+					{Name: "X-Org-Id", Type: "string", Location: "header"},
+				},
+			},
+		},
+	}
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL,
+		Endpoints: map[string]Endpoint{
+			"create_item": {Method: http.MethodPost, Path: "/items"},
+		},
+	}
+	b.SetCatalog(cat)
+
+	result, err := b.Execute(context.Background(), "create_item", map[string]any{
+		"name":     "widget",
+		"X-Org-Id": "org-123",
+	}, "test-token")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	if resp["x_org_id"] != "org-123" {
+		t.Fatalf("X-Org-Id header = %v, want org-123", resp["x_org_id"])
+	}
+
+	body := resp["body"].(map[string]any)
+	if body["name"] != "widget" {
+		t.Fatalf("body[name] = %v, want widget", body["name"])
+	}
+	if _, hasHeader := body["X-Org-Id"]; hasHeader {
+		t.Fatalf("body should not contain X-Org-Id (it should be in headers)")
+	}
+}

--- a/internal/apiexec/apiexec.go
+++ b/internal/apiexec/apiexec.go
@@ -63,6 +63,12 @@ type Request struct {
 	// path parameter substitution and query strings on GET/DELETE.
 	Body []byte
 
+	// QueryParams are always applied as URL query parameters, regardless of
+	// HTTP method. When set on a POST/PUT/PATCH, these go on the URL while
+	// Params become the JSON body. When nil, the existing method-based
+	// routing applies (backward compatible).
+	QueryParams map[string]any
+
 	// CheckResponse, when set, replaces the default status >= 400 check.
 	CheckResponse ResponseChecker
 
@@ -83,6 +89,13 @@ func Do(ctx context.Context, client *http.Client, req Request) (*core.OperationR
 	}
 
 	fullURL := req.BaseURL + path
+	if len(req.QueryParams) > 0 {
+		q := url.Values{}
+		for k, v := range req.QueryParams {
+			addQueryValue(q, k, v)
+		}
+		fullURL += "?" + q.Encode()
+	}
 
 	var bodyBytes []byte
 	var contentType string
@@ -168,7 +181,7 @@ func doOnce(
 		if len(params) > 0 {
 			q := httpReq.URL.Query()
 			for k, v := range params {
-				q.Set(k, fmt.Sprintf("%v", v))
+				addQueryValue(q, k, v)
 			}
 			httpReq.URL.RawQuery = q.Encode()
 		}
@@ -319,22 +332,44 @@ func DoGraphQL(ctx context.Context, client *http.Client, req GraphQLRequest) (*c
 }
 
 func ExpandedPath(method, path string, params map[string]any) string {
+	return ExpandedPathWithQuery(method, path, params, nil)
+}
+
+func ExpandedPathWithQuery(method, path string, params map[string]any, queryParams map[string]any) string {
 	params = copyParams(params)
 	expanded, err := substitutePath(path, params)
 	if err != nil {
 		return path
 	}
+	q := url.Values{}
+	for k, v := range queryParams {
+		addQueryValue(q, k, v)
+	}
 	switch method {
 	case http.MethodGet, http.MethodDelete:
-		if len(params) > 0 {
-			q := url.Values{}
-			for k, v := range params {
-				q.Set(k, fmt.Sprintf("%v", v))
-			}
-			return expanded + "?" + q.Encode()
+		for k, v := range params {
+			addQueryValue(q, k, v)
 		}
 	}
+	if len(q) > 0 {
+		return expanded + "?" + q.Encode()
+	}
 	return expanded
+}
+
+func addQueryValue(q url.Values, key string, value any) {
+	switch v := value.(type) {
+	case []any:
+		for _, item := range v {
+			q.Add(key, fmt.Sprintf("%v", item))
+		}
+	case []string:
+		for _, item := range v {
+			q.Add(key, item)
+		}
+	default:
+		q.Add(key, fmt.Sprintf("%v", value))
+	}
 }
 
 func copyParams(params map[string]any) map[string]any {

--- a/internal/apiexec/apiexec_query_test.go
+++ b/internal/apiexec/apiexec_query_test.go
@@ -1,0 +1,259 @@
+package apiexec
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/internal/testutil"
+)
+
+func TestAddQueryValue_Scalar(t *testing.T) {
+	t.Parallel()
+
+	q := url.Values{}
+	addQueryValue(q, "count", 42)
+	addQueryValue(q, "name", "alice")
+
+	if got := q.Get("count"); got != "42" {
+		t.Fatalf("count = %q, want 42", got)
+	}
+	if got := q.Get("name"); got != "alice" {
+		t.Fatalf("name = %q, want alice", got)
+	}
+}
+
+func TestAddQueryValue_SliceAny(t *testing.T) {
+	t.Parallel()
+
+	q := url.Values{}
+	addQueryValue(q, "tag", []any{"a", "b"})
+
+	got := q["tag"]
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("tag = %v, want [a b]", got)
+	}
+}
+
+func TestAddQueryValue_SliceString(t *testing.T) {
+	t.Parallel()
+
+	q := url.Values{}
+	addQueryValue(q, "color", []string{"red", "blue"})
+
+	got := q["color"]
+	if len(got) != 2 || got[0] != "red" || got[1] != "blue" {
+		t.Fatalf("color = %v, want [red blue]", got)
+	}
+}
+
+func TestDo_POSTWithQueryParams(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"query":  r.URL.RawQuery,
+			"body":   body,
+			"method": r.Method,
+		})
+	}))
+	testutil.CloseOnCleanup(t, srv)
+
+	result, err := Do(context.Background(), srv.Client(), Request{
+		Method:  http.MethodPost,
+		BaseURL: srv.URL,
+		Path:    "/items",
+		Params:  map[string]any{"name": "widget"},
+		QueryParams: map[string]any{
+			"page":  2,
+			"limit": 10,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	query := resp["query"].(string)
+	parsed, err := url.ParseQuery(query)
+	if err != nil {
+		t.Fatalf("url.ParseQuery: %v", err)
+	}
+	if parsed.Get("page") != "2" {
+		t.Fatalf("query page = %q, want 2", parsed.Get("page"))
+	}
+	if parsed.Get("limit") != "10" {
+		t.Fatalf("query limit = %q, want 10", parsed.Get("limit"))
+	}
+
+	body := resp["body"].(map[string]any)
+	if body["name"] != "widget" {
+		t.Fatalf("body name = %v, want widget", body["name"])
+	}
+}
+
+func TestDo_GETWithArrayQueryFallback(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"query": r.URL.RawQuery,
+		})
+	}))
+	testutil.CloseOnCleanup(t, srv)
+
+	result, err := Do(context.Background(), srv.Client(), Request{
+		Method:  http.MethodGet,
+		BaseURL: srv.URL,
+		Path:    "/search",
+		Params: map[string]any{
+			"tag": []any{"alpha", "beta"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	query := resp["query"].(string)
+	parsed, err := url.ParseQuery(query)
+	if err != nil {
+		t.Fatalf("url.ParseQuery: %v", err)
+	}
+	tags := parsed["tag"]
+	if len(tags) != 2 || tags[0] != "alpha" || tags[1] != "beta" {
+		t.Fatalf("tag = %v, want [alpha beta]", tags)
+	}
+}
+
+func TestDo_QueryParamsNil_PreservesLegacy(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"query": r.URL.RawQuery,
+			"body":  body,
+		})
+	}))
+	testutil.CloseOnCleanup(t, srv)
+
+	result, err := Do(context.Background(), srv.Client(), Request{
+		Method:  http.MethodPost,
+		BaseURL: srv.URL,
+		Path:    "/items",
+		Params:  map[string]any{"name": "widget", "count": 5},
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	if resp["query"] != "" {
+		t.Fatalf("query = %q, want empty (legacy POST should have no query string)", resp["query"])
+	}
+
+	body := resp["body"].(map[string]any)
+	if body["name"] != "widget" {
+		t.Fatalf("body name = %v, want widget", body["name"])
+	}
+	if body["count"] != float64(5) {
+		t.Fatalf("body count = %v, want 5", body["count"])
+	}
+}
+
+func TestExpandedPathWithQuery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		method      string
+		path        string
+		params      map[string]any
+		queryParams map[string]any
+		wantPrefix  string
+		wantQuery   url.Values
+	}{
+		{
+			name:        "POST with query params",
+			method:      http.MethodPost,
+			path:        "/items",
+			params:      map[string]any{"name": "x"},
+			queryParams: map[string]any{"page": 2},
+			wantPrefix:  "/items",
+			wantQuery:   url.Values{"page": {"2"}},
+		},
+		{
+			name:        "GET merges both",
+			method:      http.MethodGet,
+			path:        "/items/{id}",
+			params:      map[string]any{"id": "abc", "limit": 10},
+			queryParams: map[string]any{"page": 1},
+			wantPrefix:  "/items/abc",
+			wantQuery:   url.Values{"page": {"1"}, "limit": {"10"}},
+		},
+		{
+			name:       "nil query params delegates to legacy",
+			method:     http.MethodGet,
+			path:       "/items",
+			params:     map[string]any{"limit": 5},
+			wantPrefix: "/items",
+			wantQuery:  url.Values{"limit": {"5"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ExpandedPathWithQuery(tt.method, tt.path, tt.params, tt.queryParams)
+			parts := strings.SplitN(got, "?", 2)
+			if parts[0] != tt.wantPrefix {
+				t.Fatalf("path prefix = %q, want %q", parts[0], tt.wantPrefix)
+			}
+			if tt.wantQuery != nil {
+				if len(parts) < 2 {
+					t.Fatalf("expected query string, got none in %q", got)
+				}
+				parsed, err := url.ParseQuery(parts[1])
+				if err != nil {
+					t.Fatalf("url.ParseQuery: %v", err)
+				}
+				for k, want := range tt.wantQuery {
+					gotVals := parsed[k]
+					if len(gotVals) != len(want) {
+						t.Fatalf("query[%s] = %v, want %v", k, gotVals, want)
+					}
+					for i := range want {
+						if gotVals[i] != want[i] {
+							t.Fatalf("query[%s][%d] = %q, want %q", k, i, gotVals[i], want[i])
+						}
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/egress/http.go
+++ b/internal/egress/http.go
@@ -14,6 +14,7 @@ type HTTPRequestSpec struct {
 	Target      Target
 	BaseURL     string
 	Params      map[string]any
+	QueryParams map[string]any
 	Headers     map[string]string
 	Body        []byte
 	ContentType string
@@ -31,6 +32,7 @@ func BuildRequest(spec HTTPRequestSpec) apiexec.Request {
 		BaseURL:       spec.BaseURL,
 		Path:          spec.Target.Path,
 		Params:        spec.Params,
+		QueryParams:   spec.QueryParams,
 		AuthHeader:    spec.Credential.Authorization,
 		CustomHeaders: headers,
 		ContentType:   spec.ContentType,


### PR DESCRIPTION
Generic REST execution now routes parameters to the URL query string,
HTTP headers, or JSON body based on `CatalogParameter.Location` metadata.
Array-valued query parameters are encoded as repeated keys. When no
catalog is attached or no location metadata exists, behavior is unchanged.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>