### PR TITLE
Add typed params, input-file, describe, and select to CLI invoke

### DIFF
--- a/client/cli/src/api.rs
+++ b/client/cli/src/api.rs
@@ -139,20 +139,6 @@ impl ApiClient {
         self.handle_response(resp)
     }
 
-    pub fn post_params(
-        &self,
-        path: &str,
-        params: &[(String, String)],
-    ) -> Result<serde_json::Value> {
-        let body: serde_json::Value = params
-            .iter()
-            .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
-            .collect::<serde_json::Map<String, serde_json::Value>>()
-            .into();
-
-        self.post(path, &body)
-    }
-
     pub fn delete(&self, path: &str) -> Result<serde_json::Value> {
         let url = format!("{}{}", self.base_url, path);
         let resp = self

--- a/client/cli/src/catalog.rs
+++ b/client/cli/src/catalog.rs
@@ -1,0 +1,68 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::api::ApiClient;
+
+fn default_type() -> String {
+    "string".to_string()
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogOperation {
+    pub id: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub method: String,
+    #[serde(default)]
+    pub parameters: Vec<CatalogParameter>,
+    #[serde(default)]
+    pub input_schema: Option<serde_json::Value>,
+    #[serde(default)]
+    pub transport: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogParameter {
+    pub name: String,
+    #[serde(default = "default_type")]
+    pub r#type: String,
+    #[serde(default)]
+    pub location: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub required: bool,
+}
+
+pub struct OperationsCatalog {
+    operations: Vec<CatalogOperation>,
+}
+
+impl OperationsCatalog {
+    pub fn find_operation(&self, name: &str) -> Option<&CatalogOperation> {
+        self.operations.iter().find(|op| op.id == name)
+    }
+
+    pub fn is_array_param(&self, operation: &str, param_name: &str) -> Option<bool> {
+        let op = self.find_operation(operation)?;
+        let param = op.parameters.iter().find(|p| p.name == param_name)?;
+        Some(param.r#type == "array")
+    }
+
+    pub fn operations(&self) -> &[CatalogOperation] {
+        &self.operations
+    }
+}
+
+pub fn fetch_catalog(client: &ApiClient, integration: &str) -> Result<OperationsCatalog> {
+    let path = format!("/api/v1/integrations/{}/operations", integration);
+    let resp = client.get(&path)?;
+    let operations: Vec<CatalogOperation> =
+        serde_json::from_value(resp).context("failed to parse operations response")?;
+    Ok(OperationsCatalog { operations })
+}

--- a/client/cli/src/catalog.rs
+++ b/client/cli/src/catalog.rs
@@ -7,7 +7,7 @@ fn default_type() -> String {
     "string".to_string()
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CatalogOperation {
     pub id: String,
@@ -25,7 +25,7 @@ pub struct CatalogOperation {
     pub transport: String,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CatalogParameter {
     pub name: String,
@@ -44,6 +44,10 @@ pub struct OperationsCatalog {
 }
 
 impl OperationsCatalog {
+    pub fn new(operations: Vec<CatalogOperation>) -> Self {
+        Self { operations }
+    }
+
     pub fn find_operation(&self, name: &str) -> Option<&CatalogOperation> {
         self.operations.iter().find(|op| op.id == name)
     }

--- a/client/cli/src/commands/describe.rs
+++ b/client/cli/src/commands/describe.rs
@@ -1,0 +1,78 @@
+use anyhow::{bail, Result};
+
+use crate::api::ApiClient;
+use crate::catalog;
+use crate::output::{self, Format};
+
+pub fn describe(
+    url_override: Option<&str>,
+    integration: &str,
+    operation: &str,
+    format: Format,
+) -> Result<()> {
+    let client = ApiClient::from_env(url_override)?;
+    let cat = catalog::fetch_catalog(&client, integration)?;
+
+    let op = match cat.find_operation(operation) {
+        Some(op) => op,
+        None => {
+            let available: Vec<&str> = cat.operations().iter().map(|o| o.id.as_str()).collect();
+            bail!(
+                "operation '{}' not found; available operations: {}",
+                operation,
+                available.join(", ")
+            );
+        }
+    };
+
+    match format {
+        Format::Json => {
+            let val = serde_json::to_value(op)?;
+            output::print_json(&val);
+        }
+        Format::Table => {
+            println!("Operation:   {}", op.id);
+            if !op.method.is_empty() {
+                println!("Method:      {}", op.method);
+            }
+            if !op.title.is_empty() {
+                println!("Title:       {}", op.title);
+            }
+            if !op.description.is_empty() {
+                println!("Description: {}", op.description);
+            }
+            println!();
+
+            if op.parameters.is_empty() {
+                println!("Parameters:  (none)");
+            } else {
+                println!("Parameters:");
+                let headers = &["Name", "Type", "Location", "Required"];
+                let rows: Vec<Vec<String>> = op
+                    .parameters
+                    .iter()
+                    .map(|p| {
+                        vec![
+                            p.name.clone(),
+                            p.r#type.clone(),
+                            p.location.clone(),
+                            if p.required { "yes" } else { "no" }.to_string(),
+                        ]
+                    })
+                    .collect();
+                output::print_table(headers, &rows);
+            }
+            println!();
+            println!(
+                "Has structured input schema: {}",
+                if op.input_schema.is_some() {
+                    "yes"
+                } else {
+                    "no"
+                }
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/client/cli/src/commands/invoke.rs
+++ b/client/cli/src/commands/invoke.rs
@@ -65,7 +65,12 @@ pub fn list_operations(
                 .iter()
                 .map(|op| {
                     let params = format_parameters(&op.parameters);
-                    vec![op.id.clone(), op.description.clone(), op.method.clone(), params]
+                    vec![
+                        op.id.clone(),
+                        op.description.clone(),
+                        op.method.clone(),
+                        params,
+                    ]
                 })
                 .collect();
             output::print_table(&["Name", "Description", "Method", "Parameters"], &rows);

--- a/client/cli/src/commands/invoke.rs
+++ b/client/cli/src/commands/invoke.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 
 use crate::api::ApiClient;
-use crate::catalog::{self, CatalogOperation};
+use crate::catalog;
 use crate::output::{self, Format};
 use crate::params::{self, ParamEntry};
 
@@ -53,21 +53,19 @@ pub fn list_operations(
     format: Format,
 ) -> Result<()> {
     let client = ApiClient::from_env(url_override)?;
-    let path = format!("/api/v1/integrations/{}/operations", integration);
-    let resp = client
-        .get(&path)
-        .with_context(|| format!("failed to list operations for {}", integration))?;
+    let cat = catalog::fetch_catalog(&client, integration)?;
 
     match format {
-        Format::Json => output::print_json(&resp),
+        Format::Json => {
+            output::print_json(&serde_json::to_value(cat.operations()).unwrap());
+        }
         Format::Table => {
-            let operations: Vec<CatalogOperation> =
-                serde_json::from_value(resp).context("failed to parse operations response")?;
-            let rows: Vec<Vec<String>> = operations
-                .into_iter()
+            let rows: Vec<Vec<String>> = cat
+                .operations()
+                .iter()
                 .map(|op| {
                     let params = format_parameters(&op.parameters);
-                    vec![op.id, op.description, op.method, params]
+                    vec![op.id.clone(), op.description.clone(), op.method.clone(), params]
                 })
                 .collect();
             output::print_table(&["Name", "Description", "Method", "Parameters"], &rows);

--- a/client/cli/src/commands/invoke.rs
+++ b/client/cli/src/commands/invoke.rs
@@ -1,55 +1,47 @@
 use anyhow::{Context, Result};
-use serde::Deserialize;
 
 use crate::api::ApiClient;
+use crate::catalog::{self, CatalogOperation};
 use crate::output::{self, Format};
-
-#[derive(Deserialize)]
-#[serde(rename_all = "PascalCase")]
-struct Operation {
-    name: String,
-    description: String,
-    method: String,
-    parameters: Vec<Parameter>,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "PascalCase")]
-struct Parameter {
-    name: String,
-    #[serde(default = "default_type")]
-    r#type: String,
-    #[serde(default)]
-    required: bool,
-}
-
-fn default_type() -> String {
-    "string".to_string()
-}
+use crate::params::{self, ParamEntry};
 
 pub fn invoke(
     url_override: Option<&str>,
     integration: &str,
     operation: &str,
-    params: &[(String, String)],
+    params: &[ParamEntry],
+    select: Option<&str>,
+    input_file: Option<&str>,
     format: Format,
 ) -> Result<()> {
     let client = ApiClient::from_env(url_override)?;
-    let path = format!("/api/v1/{}/{}", integration, operation);
+    let cat = catalog::fetch_catalog(&client, integration)?;
+    let mut param_map = params::assemble_params(params, Some(&cat), operation)?;
 
-    let resp = if params.is_empty() {
+    if let Some(file_path) = input_file {
+        let file_map = params::load_input_file(file_path)?;
+        param_map = params::merge_params(file_map, param_map);
+    }
+
+    let path = format!("/api/v1/{}/{}", integration, operation);
+    let resp = if param_map.is_empty() {
         client
             .get(&path)
             .with_context(|| format!("failed to invoke {}.{}", integration, operation))?
     } else {
         client
-            .post_params(&path, params)
+            .post(&path, &serde_json::Value::Object(param_map))
             .with_context(|| format!("failed to invoke {}.{}", integration, operation))?
     };
 
+    let output_value = match select {
+        Some(sel_path) => output::select_path(&resp, sel_path)?,
+        None => resp,
+    };
+
     match format {
-        Format::Json => output::print_json(&resp),
-        Format::Table => output::print_json_table(&resp),
+        Format::Json => output::print_json(&output_value),
+        Format::Table => output::print_json_table(&output_value),
     }
 
     Ok(())
@@ -69,13 +61,13 @@ pub fn list_operations(
     match format {
         Format::Json => output::print_json(&resp),
         Format::Table => {
-            let operations: Vec<Operation> =
+            let operations: Vec<CatalogOperation> =
                 serde_json::from_value(resp).context("failed to parse operations response")?;
             let rows: Vec<Vec<String>> = operations
                 .into_iter()
                 .map(|op| {
                     let params = format_parameters(&op.parameters);
-                    vec![op.name, op.description, op.method, params]
+                    vec![op.id, op.description, op.method, params]
                 })
                 .collect();
             output::print_table(&["Name", "Description", "Method", "Parameters"], &rows);
@@ -85,11 +77,16 @@ pub fn list_operations(
     Ok(())
 }
 
-fn format_parameters(params: &[Parameter]) -> String {
+fn format_parameters(params: &[catalog::CatalogParameter]) -> String {
     params
         .iter()
         .map(|p| {
-            let mut s = format!("-p {}=<{}>", p.name, p.r#type);
+            let location_hint = if p.location.is_empty() {
+                String::new()
+            } else {
+                format!(" [{}]", p.location)
+            };
+            let mut s = format!("-p {}=<{}>{}", p.name, p.r#type, location_hint);
             if p.required {
                 s.push_str(" (required)");
             }

--- a/client/cli/src/commands/mod.rs
+++ b/client/cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod config;
+pub mod describe;
 pub mod init;
 pub mod integrations;
 pub mod invoke;

--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod api;
+pub mod catalog;
 pub mod commands;
 pub mod config;
 pub mod credentials;
 pub mod output;
+pub mod params;

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -50,9 +50,25 @@ enum Commands {
         /// Operation name (e.g., search_code, list_channels). Omit to list available operations.
         operation: Option<String>,
 
-        /// Parameters as key=value pairs
-        #[arg(short = 'p', long = "param", value_parser = parse_key_val)]
-        params: Vec<(String, String)>,
+        /// Parameters as key=value or key:=json pairs
+        #[arg(short = 'p', long = "param", value_parser = gestalt::params::parse_param_entry)]
+        params: Vec<gestalt::params::ParamEntry>,
+
+        /// Select a sub-path from the response (e.g., "data.items")
+        #[arg(long = "select")]
+        select: Option<String>,
+
+        /// Load parameters from a JSON file (use "-" for stdin)
+        #[arg(long = "input-file")]
+        input_file: Option<String>,
+    },
+
+    /// Describe an integration operation
+    Describe {
+        /// Integration name
+        integration: String,
+        /// Operation name
+        operation: String,
     },
 
     /// Manage API tokens
@@ -123,13 +139,6 @@ enum TokenCommands {
     },
 }
 
-fn parse_key_val(s: &str) -> Result<(String, String), String> {
-    let pos = s
-        .find('=')
-        .ok_or_else(|| format!("invalid KEY=VALUE: no '=' found in '{s}'"))?;
-    Ok((s[..pos].to_string(), s[pos + 1..].to_string()))
-}
-
 fn main() {
     let cli = Cli::parse();
     let format = cli.format;
@@ -156,8 +165,18 @@ fn main() {
             integration,
             operation,
             params,
+            select,
+            input_file,
         } => match operation {
-            Some(op) => commands::invoke::invoke(url, &integration, &op, &params, format),
+            Some(op) => commands::invoke::invoke(
+                url,
+                &integration,
+                &op,
+                &params,
+                select.as_deref(),
+                input_file.as_deref(),
+                format,
+            ),
             None => {
                 if !params.is_empty() {
                     output::print_warning("parameters ignored; no operation specified");
@@ -165,6 +184,10 @@ fn main() {
                 commands::invoke::list_operations(url, &integration, format)
             }
         },
+        Commands::Describe {
+            integration,
+            operation,
+        } => commands::describe::describe(url, &integration, &operation, format),
         Commands::Tokens { command } => match command {
             TokenCommands::Create { name } => {
                 commands::tokens::create(url, name.as_deref(), format)

--- a/client/cli/src/output.rs
+++ b/client/cli/src/output.rs
@@ -251,11 +251,9 @@ pub fn select_path(value: &serde_json::Value, path: &str) -> anyhow::Result<serd
             continue;
         }
         current = match current {
-            serde_json::Value::Object(map) => {
-                map.get(segment).ok_or_else(|| {
-                    anyhow::anyhow!("key '{}' not found in response", segment)
-                })?
-            }
+            serde_json::Value::Object(map) => map
+                .get(segment)
+                .ok_or_else(|| anyhow::anyhow!("key '{}' not found in response", segment))?,
             serde_json::Value::Array(arr) => {
                 let idx: usize = segment.parse().map_err(|_| {
                     anyhow::anyhow!("expected numeric index for array, got '{}'", segment)

--- a/client/cli/src/output.rs
+++ b/client/cli/src/output.rs
@@ -244,6 +244,31 @@ fn wrap_text(text: &str, width: usize) -> Vec<String> {
     }
 }
 
+pub fn select_path(value: &serde_json::Value, path: &str) -> anyhow::Result<serde_json::Value> {
+    let mut current = value;
+    for segment in path.split('.') {
+        if segment.is_empty() {
+            continue;
+        }
+        current = match current {
+            serde_json::Value::Object(map) => {
+                map.get(segment).ok_or_else(|| {
+                    anyhow::anyhow!("key '{}' not found in response", segment)
+                })?
+            }
+            serde_json::Value::Array(arr) => {
+                let idx: usize = segment.parse().map_err(|_| {
+                    anyhow::anyhow!("expected numeric index for array, got '{}'", segment)
+                })?;
+                arr.get(idx)
+                    .ok_or_else(|| anyhow::anyhow!("index {} out of bounds", idx))?
+            }
+            _ => anyhow::bail!("cannot traverse into non-object/non-array value"),
+        };
+    }
+    Ok(current.clone())
+}
+
 pub fn print_success(msg: &str) {
     if std::io::stderr().is_terminal() {
         eprintln!("{}", msg.green());
@@ -388,5 +413,40 @@ mod tests {
                 "continuation lines should align with column start"
             );
         }
+    }
+
+    #[test]
+    fn test_select_simple_key() {
+        let val = serde_json::json!({"a": 1});
+        let result = select_path(&val, "a").unwrap();
+        assert_eq!(result, serde_json::json!(1));
+    }
+
+    #[test]
+    fn test_select_nested() {
+        let val = serde_json::json!({"a": {"b": 2}});
+        let result = select_path(&val, "a.b").unwrap();
+        assert_eq!(result, serde_json::json!(2));
+    }
+
+    #[test]
+    fn test_select_array_index() {
+        let val = serde_json::json!({"a": [10, 20]});
+        let result = select_path(&val, "a.0").unwrap();
+        assert_eq!(result, serde_json::json!(10));
+    }
+
+    #[test]
+    fn test_select_missing_key() {
+        let val = serde_json::json!({"a": 1});
+        let result = select_path(&val, "b");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_select_empty_path() {
+        let val = serde_json::json!({"a": 1});
+        let result = select_path(&val, "").unwrap();
+        assert_eq!(result, val);
     }
 }

--- a/client/cli/src/params.rs
+++ b/client/cli/src/params.rs
@@ -16,7 +16,16 @@ pub struct ParamEntry {
 }
 
 pub fn parse_param_entry(s: &str) -> Result<ParamEntry, String> {
-    if let Some(pos) = s.find(":=") {
+    let eq_pos = s.find('=');
+    let colon_eq_pos = s.find(":=");
+
+    let use_json = match (eq_pos, colon_eq_pos) {
+        (_, Some(ce)) if eq_pos.is_none() || ce < eq_pos.unwrap() => true,
+        _ => false,
+    };
+
+    if use_json {
+        let pos = colon_eq_pos.unwrap();
         let key = &s[..pos];
         let raw_json = &s[pos + 2..];
         if key.is_empty() {
@@ -30,9 +39,7 @@ pub fn parse_param_entry(s: &str) -> Result<ParamEntry, String> {
         });
     }
 
-    let pos = s
-        .find('=')
-        .ok_or_else(|| format!("invalid param: no '=' or ':=' found in '{s}'"))?;
+    let pos = eq_pos.ok_or_else(|| format!("invalid param: no '=' or ':=' found in '{s}'"))?;
     let key = &s[..pos];
     if key.is_empty() {
         return Err(format!("invalid KEY=VALUE: empty key in '{s}'"));
@@ -204,5 +211,15 @@ mod tests {
     fn test_parse_no_delimiter() {
         let result = parse_param_entry("nodelimiter");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_value_containing_colon_equals() {
+        let entry = parse_param_entry("query=SELECT @a:=1").unwrap();
+        assert_eq!(entry.key, "query");
+        assert_eq!(
+            entry.value,
+            ParamValue::StringVal("SELECT @a:=1".to_string())
+        );
     }
 }

--- a/client/cli/src/params.rs
+++ b/client/cli/src/params.rs
@@ -80,7 +80,9 @@ pub fn assemble_params(
         if vals.len() == 1 {
             let val = vals.into_iter().next().unwrap();
             match is_array {
-                Some(true) => map.insert(key, serde_json::Value::Array(vec![val])),
+                Some(true) if !val.is_array() => {
+                    map.insert(key, serde_json::Value::Array(vec![val]))
+                }
                 _ => map.insert(key, val),
             };
         } else {
@@ -208,6 +210,29 @@ mod tests {
     fn test_parse_no_delimiter() {
         let result = parse_param_entry("nodelimiter");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_json_array_not_double_wrapped() {
+        use crate::catalog::{CatalogOperation, CatalogParameter, OperationsCatalog};
+
+        let cat = OperationsCatalog::new(vec![CatalogOperation {
+            id: "op".to_string(),
+            parameters: vec![CatalogParameter {
+                name: "tags".to_string(),
+                r#type: "array".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }]);
+
+        let entries = vec![ParamEntry {
+            key: "tags".to_string(),
+            value: ParamValue::JsonVal(serde_json::json!(["a", "b"])),
+        }];
+
+        let result = assemble_params(&entries, Some(&cat), "op").unwrap();
+        assert_eq!(result["tags"], serde_json::json!(["a", "b"]));
     }
 
     #[test]

--- a/client/cli/src/params.rs
+++ b/client/cli/src/params.rs
@@ -19,10 +19,10 @@ pub fn parse_param_entry(s: &str) -> Result<ParamEntry, String> {
     let eq_pos = s.find('=');
     let colon_eq_pos = s.find(":=");
 
-    let use_json = match (eq_pos, colon_eq_pos) {
-        (_, Some(ce)) if eq_pos.is_none() || ce < eq_pos.unwrap() => true,
-        _ => false,
-    };
+    let use_json = matches!(
+        (eq_pos, colon_eq_pos),
+        (_, Some(ce)) if eq_pos.is_none() || ce < eq_pos.unwrap()
+    );
 
     if use_json {
         let pos = colon_eq_pos.unwrap();

--- a/client/cli/src/params.rs
+++ b/client/cli/src/params.rs
@@ -1,0 +1,208 @@
+use anyhow::{bail, Context, Result};
+use std::io::Read;
+
+use crate::catalog::OperationsCatalog;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParamValue {
+    StringVal(String),
+    JsonVal(serde_json::Value),
+}
+
+#[derive(Debug, Clone)]
+pub struct ParamEntry {
+    pub key: String,
+    pub value: ParamValue,
+}
+
+pub fn parse_param_entry(s: &str) -> Result<ParamEntry, String> {
+    if let Some(pos) = s.find(":=") {
+        let key = &s[..pos];
+        let raw_json = &s[pos + 2..];
+        if key.is_empty() {
+            return Err(format!("invalid KEY:=JSON: empty key in '{s}'"));
+        }
+        let value: serde_json::Value = serde_json::from_str(raw_json)
+            .map_err(|e| format!("invalid JSON in '{key}:={raw_json}': {e}"))?;
+        return Ok(ParamEntry {
+            key: key.to_string(),
+            value: ParamValue::JsonVal(value),
+        });
+    }
+
+    let pos = s
+        .find('=')
+        .ok_or_else(|| format!("invalid param: no '=' or ':=' found in '{s}'"))?;
+    let key = &s[..pos];
+    if key.is_empty() {
+        return Err(format!("invalid KEY=VALUE: empty key in '{s}'"));
+    }
+    Ok(ParamEntry {
+        key: key.to_string(),
+        value: ParamValue::StringVal(s[pos + 1..].to_string()),
+    })
+}
+
+fn param_to_json(value: &ParamValue) -> serde_json::Value {
+    match value {
+        ParamValue::StringVal(s) => serde_json::Value::String(s.clone()),
+        ParamValue::JsonVal(v) => v.clone(),
+    }
+}
+
+pub fn assemble_params(
+    entries: &[ParamEntry],
+    catalog: Option<&OperationsCatalog>,
+    operation: &str,
+) -> Result<serde_json::Map<String, serde_json::Value>> {
+    let mut grouped: Vec<(String, Vec<serde_json::Value>)> = Vec::new();
+
+    for entry in entries {
+        let json_val = param_to_json(&entry.value);
+        if let Some((_, vals)) = grouped.iter_mut().find(|(k, _)| k == &entry.key) {
+            vals.push(json_val);
+        } else {
+            grouped.push((entry.key.clone(), vec![json_val]));
+        }
+    }
+
+    let mut map = serde_json::Map::new();
+    for (key, vals) in grouped {
+        let is_array = catalog.and_then(|c| c.is_array_param(operation, &key));
+
+        if vals.len() == 1 {
+            let val = vals.into_iter().next().unwrap();
+            match is_array {
+                Some(true) => map.insert(key, serde_json::Value::Array(vec![val])),
+                _ => map.insert(key, val),
+            };
+        } else {
+            match is_array {
+                Some(false) => {
+                    bail!(
+                        "parameter '{}' is not an array type but was specified multiple times",
+                        key
+                    );
+                }
+                _ => {
+                    map.insert(key, serde_json::Value::Array(vals));
+                }
+            }
+        }
+    }
+
+    Ok(map)
+}
+
+pub fn load_input_file(path: &str) -> Result<serde_json::Map<String, serde_json::Value>> {
+    let contents = if path == "-" {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .context("failed to read from stdin")?;
+        buf
+    } else {
+        std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read input file '{}'", path))?
+    };
+
+    let value: serde_json::Value =
+        serde_json::from_str(&contents).context("failed to parse input file as JSON")?;
+
+    match value {
+        serde_json::Value::Object(map) => Ok(map),
+        _ => bail!("input file must contain a JSON object"),
+    }
+}
+
+pub fn merge_params(
+    file_map: serde_json::Map<String, serde_json::Value>,
+    param_map: serde_json::Map<String, serde_json::Value>,
+) -> serde_json::Map<String, serde_json::Value> {
+    let mut result = file_map;
+    for (k, v) in param_map {
+        result.insert(k, v);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_string_param() {
+        let entry = parse_param_entry("key=value").unwrap();
+        assert_eq!(entry.key, "key");
+        assert_eq!(entry.value, ParamValue::StringVal("value".to_string()));
+    }
+
+    #[test]
+    fn test_parse_json_number() {
+        let entry = parse_param_entry("key:=42").unwrap();
+        assert_eq!(entry.key, "key");
+        assert_eq!(entry.value, ParamValue::JsonVal(serde_json::json!(42)));
+    }
+
+    #[test]
+    fn test_parse_json_bool() {
+        let entry = parse_param_entry("key:=true").unwrap();
+        assert_eq!(entry.key, "key");
+        assert_eq!(entry.value, ParamValue::JsonVal(serde_json::json!(true)));
+    }
+
+    #[test]
+    fn test_parse_json_array() {
+        let entry = parse_param_entry("key:=[1,2]").unwrap();
+        assert_eq!(entry.key, "key");
+        assert_eq!(entry.value, ParamValue::JsonVal(serde_json::json!([1, 2])));
+    }
+
+    #[test]
+    fn test_parse_json_object() {
+        let entry = parse_param_entry(r#"key:={"a":1}"#).unwrap();
+        assert_eq!(entry.key, "key");
+        assert_eq!(
+            entry.value,
+            ParamValue::JsonVal(serde_json::json!({"a": 1}))
+        );
+    }
+
+    #[test]
+    fn test_parse_json_null() {
+        let entry = parse_param_entry("key:=null").unwrap();
+        assert_eq!(entry.key, "key");
+        assert_eq!(
+            entry.value,
+            ParamValue::JsonVal(serde_json::Value::Null)
+        );
+    }
+
+    #[test]
+    fn test_parse_invalid_json() {
+        let result = parse_param_entry("key:=invalid");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_value_with_equals() {
+        let entry = parse_param_entry("url=http://x.com?a=1").unwrap();
+        assert_eq!(entry.key, "url");
+        assert_eq!(
+            entry.value,
+            ParamValue::StringVal("http://x.com?a=1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_empty_key() {
+        let result = parse_param_entry("=value");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_no_delimiter() {
+        let result = parse_param_entry("nodelimiter");
+        assert!(result.is_err());
+    }
+}

--- a/client/cli/src/params.rs
+++ b/client/cli/src/params.rs
@@ -179,10 +179,7 @@ mod tests {
     fn test_parse_json_null() {
         let entry = parse_param_entry("key:=null").unwrap();
         assert_eq!(entry.key, "key");
-        assert_eq!(
-            entry.value,
-            ParamValue::JsonVal(serde_json::Value::Null)
-        );
+        assert_eq!(entry.value, ParamValue::JsonVal(serde_json::Value::Null));
     }
 
     #[test]

--- a/client/cli/tests/integration.rs
+++ b/client/cli/tests/integration.rs
@@ -159,12 +159,12 @@ fn test_list_operations_formats_parameters() {
         .with_header("Content-Type", "application/json")
         .with_body(
             r#"[{
-                "Name": "do_thing",
-                "Description": "Does a thing",
-                "Method": "POST",
-                "Parameters": [
-                    {"Name": "id", "Type": "string", "Required": true, "Default": null, "Description": "The ID"},
-                    {"Name": "mode", "Type": "string", "Required": false, "Default": null, "Description": "Mode"}
+                "id": "do_thing",
+                "description": "Does a thing",
+                "method": "POST",
+                "parameters": [
+                    {"name": "id", "type": "string", "location": "path", "required": true, "description": "The ID"},
+                    {"name": "mode", "type": "string", "location": "query", "required": false, "description": "Mode"}
                 ]
             }]"#,
         )
@@ -188,11 +188,11 @@ fn test_list_operations_json_format() {
         .with_header("Content-Type", "application/json")
         .with_body(
             r#"[{
-                "Name": "do_thing",
-                "Description": "Does a thing",
-                "Method": "POST",
-                "Parameters": [
-                    {"Name": "id", "Type": "string", "Required": true, "Default": null, "Description": "The ID"}
+                "id": "do_thing",
+                "description": "Does a thing",
+                "method": "POST",
+                "parameters": [
+                    {"name": "id", "type": "string", "location": "path", "required": true, "description": "The ID"}
                 ]
             }]"#,
         )
@@ -214,7 +214,7 @@ fn test_list_operations_empty_parameters() {
         .mock("GET", "/api/v1/integrations/test_svc/operations")
         .with_status(200)
         .with_header("Content-Type", "application/json")
-        .with_body(r#"[{"Name": "list_items", "Description": "Lists items", "Method": "GET", "Parameters": []}]"#)
+        .with_body(r#"[{"id": "list_items", "description": "Lists items", "method": "GET", "parameters": []}]"#)
         .create();
 
     std::env::set_var("GESTALT_API_KEY", "test-token");
@@ -244,4 +244,91 @@ fn test_start_oauth() {
     mock.assert();
     assert_eq!(resp["url"], "https://example.com/oauth");
     assert_eq!(resp["state"], "abc123");
+}
+
+fn catalog_body() -> &'static str {
+    r#"[{
+        "id": "do_thing",
+        "title": "Do Thing",
+        "description": "Does a thing",
+        "method": "POST",
+        "parameters": [
+            {"name": "name", "type": "string", "location": "query", "required": true},
+            {"name": "count", "type": "integer", "location": "query"}
+        ],
+        "transport": "rest"
+    }]"#
+}
+
+#[test]
+fn test_invoke_typed_params() {
+    let mut server = Server::new();
+
+    let _catalog_mock = server
+        .mock("GET", "/api/v1/integrations/test_svc/operations")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(catalog_body())
+        .create();
+
+    let invoke_mock = server
+        .mock("POST", "/api/v1/test_svc/do_thing")
+        .match_header("Content-Type", "application/json")
+        .match_body(Matcher::JsonString(
+            r#"{"count":42,"name":"test"}"#.to_string(),
+        ))
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(r#"{"ok": true}"#)
+        .create();
+
+    let params = vec![
+        gestalt::params::ParamEntry {
+            key: "count".to_string(),
+            value: gestalt::params::ParamValue::JsonVal(serde_json::json!(42)),
+        },
+        gestalt::params::ParamEntry {
+            key: "name".to_string(),
+            value: gestalt::params::ParamValue::StringVal("test".to_string()),
+        },
+    ];
+
+    std::env::set_var("GESTALT_API_KEY", "test-token");
+    let result = gestalt::commands::invoke::invoke(
+        Some(&server.url()),
+        "test_svc",
+        "do_thing",
+        &params,
+        None,
+        None,
+        Format::Json,
+    );
+    std::env::remove_var("GESTALT_API_KEY");
+
+    invoke_mock.assert();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_describe_operation() {
+    let mut server = Server::new();
+
+    let mock = server
+        .mock("GET", "/api/v1/integrations/test_svc/operations")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(catalog_body())
+        .create();
+
+    std::env::set_var("GESTALT_API_KEY", "test-token");
+    let result = gestalt::commands::describe::describe(
+        Some(&server.url()),
+        "test_svc",
+        "do_thing",
+        Format::Table,
+    );
+    std::env::remove_var("GESTALT_API_KEY");
+
+    mock.assert();
+    assert!(result.is_ok());
 }


### PR DESCRIPTION
The CLI now consumes the rich camelCase `/operations` catalog from the
server to support `:=` typed JSON parameter parsing, automatic array
wrapping for repeated keys, `--input-file` for loading parameters from
a JSON file or stdin, and `--select` for extracting a sub-path from the
response. A new `gestalt describe` command prints operation metadata
including parameter types, locations, and whether a structured input
schema is available.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>