### PR TITLE
Add multi-architecture Docker image support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.claude
+.github
+node_modules
+web/node_modules
+web/out
+web/.next
+docs
+thoughts
+deploy
+**/.DS_Store

--- a/.github/workflows/publish-gestaltd-image.yml
+++ b/.github/workflows/publish-gestaltd-image.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -17,11 +17,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             valontechnologies/gestalt:latest
             valontechnologies/gestalt:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:20-alpine AS frontend
+FROM --platform=$BUILDPLATFORM node:20-alpine AS frontend
 WORKDIR /web
 COPY web/package.json web/package-lock.json ./
 RUN npm ci
 COPY web/ .
 RUN npm run build
 
-FROM golang:1.26-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 WORKDIR /build
 COPY go.mod go.sum ./
 COPY sdk/pluginapi/go.mod sdk/pluginapi/go.sum sdk/pluginapi/
@@ -15,7 +15,8 @@ COPY examples/plugins/runtime-go/go.mod examples/plugins/runtime-go/go.sum examp
 RUN go mod download
 COPY . .
 COPY --from=frontend /web/out/ internal/webui/out/
-RUN CGO_ENABLED=0 GOOS=linux go build -o /gestaltd ./cmd/gestaltd
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /gestaltd ./cmd/gestaltd
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=builder /gestaltd /gestaltd


### PR DESCRIPTION
## Summary
- Publish Docker images for both `linux/amd64` and `linux/arm64` using Docker buildx with Go native cross-compilation
- Pin build stages to `--platform=$BUILDPLATFORM` so npm/Go run at native speed; pass `TARGETARCH` to `GOARCH` for cross-compilation
- Add `.dockerignore` to exclude `.git`, `.claude`, `docs`, and other non-build directories from the build context

## Test plan
- [ ] Merge and verify the publish workflow succeeds in CI
- [ ] Run `docker manifest inspect valontechnologies/gestalt:latest` and confirm entries for both amd64 and arm64
- [ ] Pull and run on Apple Silicon without platform mismatch warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)