### PR TITLE
feat(pluginsdk): add preliminary plugin OAuth support

### DIFF
--- a/internal/pluginapi/provider_test.go
+++ b/internal/pluginapi/provider_test.go
@@ -115,6 +115,45 @@ func (p *manualOnlySDKProvider) Execute(_ context.Context, _ string, _ map[strin
 
 func (p *manualOnlySDKProvider) SupportsManualAuth() bool { return true }
 
+type oauthOnlySDKProvider struct{}
+
+func (p *oauthOnlySDKProvider) Name() string { return "oauth-only" }
+
+func (p *oauthOnlySDKProvider) DisplayName() string { return "OAuth Only" }
+
+func (p *oauthOnlySDKProvider) Description() string { return "oauth provider" }
+
+func (p *oauthOnlySDKProvider) ConnectionMode() sdkpluginsdk.ConnectionMode {
+	return sdkpluginsdk.ConnectionModeUser
+}
+
+func (p *oauthOnlySDKProvider) ListOperations() []sdkpluginsdk.Operation { return nil }
+
+func (p *oauthOnlySDKProvider) Execute(_ context.Context, _ string, _ map[string]any, _ string) (*sdkpluginsdk.OperationResult, error) {
+	return &sdkpluginsdk.OperationResult{Status: 200, Body: `{}`}, nil
+}
+
+func (p *oauthOnlySDKProvider) AuthorizationURL(state string, scopes []string) string {
+	return fmt.Sprintf("https://example.com/sdk-oauth?state=%s&scope=%d", state, len(scopes))
+}
+
+func (p *oauthOnlySDKProvider) ExchangeCode(_ context.Context, code string) (*sdkpluginsdk.TokenResponse, error) {
+	return &sdkpluginsdk.TokenResponse{
+		AccessToken:  "sdk-access:" + code,
+		RefreshToken: "sdk-refresh:" + code,
+		ExpiresIn:    1800,
+		TokenType:    "Bearer",
+		Extra:        map[string]any{"workspace": "acme"},
+	}, nil
+}
+
+func (p *oauthOnlySDKProvider) RefreshToken(_ context.Context, refreshToken string) (*sdkpluginsdk.TokenResponse, error) {
+	return &sdkpluginsdk.TokenResponse{
+		AccessToken: "sdk-fresh:" + refreshToken,
+		TokenType:   "Bearer",
+	}, nil
+}
+
 func TestRemoteProviderRoundTrip(t *testing.T) {
 	t.Parallel()
 
@@ -214,5 +253,63 @@ func TestRemoteProviderManualAuthOnly(t *testing.T) {
 
 	if _, ok := prov.(core.OAuthProvider); ok {
 		t.Fatal("expected remote provider to NOT implement core.OAuthProvider")
+	}
+}
+
+func TestRemoteProviderOAuthOnlySDK(t *testing.T) {
+	t.Parallel()
+
+	client := newProviderPluginClient(t, sdkpluginsdk.NewProviderServer(&oauthOnlySDKProvider{}))
+	prov, err := NewRemoteProvider(context.Background(), client, "oauth-only", nil)
+	if err != nil {
+		t.Fatalf("NewRemoteProvider: %v", err)
+	}
+
+	if prov.Name() != "oauth-only" {
+		t.Fatalf("unexpected provider name: %q", prov.Name())
+	}
+	if prov.ConnectionMode() != core.ConnectionModeUser {
+		t.Fatalf("unexpected connection mode: %q", prov.ConnectionMode())
+	}
+
+	oauthProv, ok := prov.(core.OAuthProvider)
+	if !ok {
+		t.Fatal("expected remote provider to implement core.OAuthProvider")
+	}
+
+	authTypes, ok := prov.(core.AuthTypeLister)
+	if !ok {
+		t.Fatal("expected remote provider to implement core.AuthTypeLister")
+	}
+	if got := authTypes.AuthTypes(); len(got) != 1 || got[0] != "oauth" {
+		t.Fatalf("unexpected auth types: %v", got)
+	}
+
+	mp, ok := prov.(core.ManualProvider)
+	if !ok {
+		t.Fatal("expected remote provider to implement core.ManualProvider")
+	}
+	if mp.SupportsManualAuth() {
+		t.Fatal("expected SupportsManualAuth() == false")
+	}
+
+	if got := oauthProv.AuthorizationURL("state-xyz", []string{"read", "write"}); got != "https://example.com/sdk-oauth?state=state-xyz&scope=2" {
+		t.Fatalf("unexpected authorization url: %q", got)
+	}
+
+	tok, err := oauthProv.ExchangeCode(context.Background(), "abc")
+	if err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if tok.AccessToken != "sdk-access:abc" || tok.RefreshToken != "sdk-refresh:abc" || tok.Extra["workspace"] != "acme" {
+		t.Fatalf("unexpected exchange token response: %+v", tok)
+	}
+
+	fresh, err := oauthProv.RefreshToken(context.Background(), "sdk-refresh:abc")
+	if err != nil {
+		t.Fatalf("RefreshToken: %v", err)
+	}
+	if fresh.AccessToken != "sdk-fresh:sdk-refresh:abc" {
+		t.Fatalf("unexpected refresh token response: %+v", fresh)
 	}
 }

--- a/sdk/pluginsdk/convert.go
+++ b/sdk/pluginsdk/convert.go
@@ -95,3 +95,22 @@ func connectionParamDefsToProto(defs map[string]ConnectionParamDef) map[string]*
 	}
 	return out
 }
+
+func tokenResponseToProto(resp *TokenResponse) (*pluginapiv1.TokenResponse, error) {
+	var extra *structpb.Struct
+	var err error
+	if len(resp.Extra) > 0 {
+		extra, err = structpb.NewStruct(resp.Extra)
+		if err != nil {
+			return nil, fmt.Errorf("token response extra: %w", err)
+		}
+	}
+
+	return &pluginapiv1.TokenResponse{
+		AccessToken:  resp.AccessToken,
+		RefreshToken: resp.RefreshToken,
+		ExpiresIn:    int32(resp.ExpiresIn),
+		TokenType:    resp.TokenType,
+		Extra:        extra,
+	}, nil
+}

--- a/sdk/pluginsdk/plugin_test.go
+++ b/sdk/pluginsdk/plugin_test.go
@@ -2,6 +2,7 @@ package pluginsdk_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	pluginsdk "github.com/valon-technologies/gestalt/sdk/pluginsdk"
@@ -57,6 +58,37 @@ type manualAuthStubProvider struct {
 
 func (p *manualAuthStubProvider) SupportsManualAuth() bool { return true }
 
+type oauthStubProvider struct {
+	stubProvider
+}
+
+func (p *oauthStubProvider) AuthorizationURL(state string, scopes []string) string {
+	return fmt.Sprintf("https://example.com/oauth?state=%s&scope=%d", state, len(scopes))
+}
+
+func (p *oauthStubProvider) ExchangeCode(_ context.Context, code string) (*pluginsdk.TokenResponse, error) {
+	return &pluginsdk.TokenResponse{
+		AccessToken:  "access:" + code,
+		RefreshToken: "refresh:" + code,
+		ExpiresIn:    3600,
+		TokenType:    "Bearer",
+		Extra:        map[string]any{"team": "eng"},
+	}, nil
+}
+
+func (p *oauthStubProvider) RefreshToken(_ context.Context, refreshToken string) (*pluginsdk.TokenResponse, error) {
+	return &pluginsdk.TokenResponse{
+		AccessToken: "fresh:" + refreshToken,
+		TokenType:   "Bearer",
+	}, nil
+}
+
+type oauthManualStubProvider struct {
+	oauthStubProvider
+}
+
+func (p *oauthManualStubProvider) SupportsManualAuth() bool { return true }
+
 func TestProviderServerGetMetadata(t *testing.T) {
 	t.Parallel()
 
@@ -102,6 +134,44 @@ func TestProviderServerGetMetadata_ManualAuth(t *testing.T) {
 	authTypes := meta.GetAuthTypes()
 	if len(authTypes) != 1 || authTypes[0] != "manual" {
 		t.Fatalf("AuthTypes = %v, want [manual]", authTypes)
+	}
+}
+
+func TestProviderServerGetMetadata_OAuthAuth(t *testing.T) {
+	t.Parallel()
+
+	prov := &oauthStubProvider{
+		stubProvider: stubProvider{name: "oauth-prov"},
+	}
+
+	client := newProviderPluginClient(t, prov)
+	meta, err := client.GetMetadata(context.Background(), &emptypb.Empty{})
+	if err != nil {
+		t.Fatalf("GetMetadata: %v", err)
+	}
+	authTypes := meta.GetAuthTypes()
+	if len(authTypes) != 1 || authTypes[0] != "oauth" {
+		t.Fatalf("AuthTypes = %v, want [oauth]", authTypes)
+	}
+}
+
+func TestProviderServerGetMetadata_OAuthAndManualAuth(t *testing.T) {
+	t.Parallel()
+
+	prov := &oauthManualStubProvider{
+		oauthStubProvider: oauthStubProvider{
+			stubProvider: stubProvider{name: "oauth-manual-prov"},
+		},
+	}
+
+	client := newProviderPluginClient(t, prov)
+	meta, err := client.GetMetadata(context.Background(), &emptypb.Empty{})
+	if err != nil {
+		t.Fatalf("GetMetadata: %v", err)
+	}
+	authTypes := meta.GetAuthTypes()
+	if len(authTypes) != 2 || authTypes[0] != "oauth" || authTypes[1] != "manual" {
+		t.Fatalf("AuthTypes = %v, want [oauth manual]", authTypes)
 	}
 }
 
@@ -288,6 +358,59 @@ func TestProviderServerMetadataProtocolVersions(t *testing.T) {
 	}
 }
 
+func TestProviderServerOAuthRPCs(t *testing.T) {
+	t.Parallel()
+
+	prov := &oauthStubProvider{
+		stubProvider: stubProvider{
+			name:     "oauth-provider",
+			connMode: pluginsdk.ConnectionModeUser,
+		},
+	}
+
+	client := newProviderPluginClient(t, prov)
+	ctx := context.Background()
+
+	authResp, err := client.AuthorizationURL(ctx, &pluginapiv1.AuthorizationURLRequest{
+		State:  "state-123",
+		Scopes: []string{"read", "write"},
+	})
+	if err != nil {
+		t.Fatalf("AuthorizationURL: %v", err)
+	}
+	if authResp.GetUrl() != "https://example.com/oauth?state=state-123&scope=2" {
+		t.Fatalf("AuthorizationURL = %q", authResp.GetUrl())
+	}
+
+	exchangeResp, err := client.ExchangeCode(ctx, &pluginapiv1.ExchangeCodeRequest{Code: "abc"})
+	if err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if exchangeResp.GetAccessToken() != "access:abc" {
+		t.Fatalf("AccessToken = %q", exchangeResp.GetAccessToken())
+	}
+	if exchangeResp.GetRefreshToken() != "refresh:abc" {
+		t.Fatalf("RefreshToken = %q", exchangeResp.GetRefreshToken())
+	}
+	if exchangeResp.GetExpiresIn() != 3600 {
+		t.Fatalf("ExpiresIn = %d", exchangeResp.GetExpiresIn())
+	}
+	if exchangeResp.GetTokenType() != "Bearer" {
+		t.Fatalf("TokenType = %q", exchangeResp.GetTokenType())
+	}
+	if got := exchangeResp.GetExtra().AsMap()["team"]; got != "eng" {
+		t.Fatalf("Extra.team = %v", got)
+	}
+
+	refreshResp, err := client.RefreshToken(ctx, &pluginapiv1.RefreshTokenRequest{RefreshToken: "refresh:abc"})
+	if err != nil {
+		t.Fatalf("RefreshToken: %v", err)
+	}
+	if refreshResp.GetAccessToken() != "fresh:refresh:abc" {
+		t.Fatalf("RefreshToken.AccessToken = %q", refreshResp.GetAccessToken())
+	}
+}
+
 func TestProviderServerUnimplementedRPCs(t *testing.T) {
 	t.Parallel()
 
@@ -307,6 +430,11 @@ func TestProviderServerUnimplementedRPCs(t *testing.T) {
 	_, err = client.ExchangeCode(ctx, &pluginapiv1.ExchangeCodeRequest{Code: "c"})
 	if err == nil {
 		t.Error("ExchangeCode should return UNIMPLEMENTED")
+	}
+
+	_, err = client.RefreshToken(ctx, &pluginapiv1.RefreshTokenRequest{RefreshToken: "r"})
+	if err == nil {
+		t.Error("RefreshToken should return UNIMPLEMENTED")
 	}
 
 	_, err = client.GetSessionCatalog(ctx, &pluginapiv1.GetSessionCatalogRequest{Token: "t"})

--- a/sdk/pluginsdk/provider_server.go
+++ b/sdk/pluginsdk/provider_server.go
@@ -2,6 +2,7 @@ package pluginsdk
 
 import (
 	"context"
+	"slices"
 
 	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
 	"google.golang.org/grpc/codes"
@@ -92,8 +93,69 @@ func (s *ProviderServer) Execute(ctx context.Context, req *pluginapiv1.ExecuteRe
 	}, nil
 }
 
+func (s *ProviderServer) AuthorizationURL(_ context.Context, req *pluginapiv1.AuthorizationURLRequest) (*pluginapiv1.AuthorizationURLResponse, error) {
+	oauthProv, ok := s.provider.(OAuthProvider)
+	if !ok {
+		return nil, status.Error(codes.Unimplemented, "provider does not support OAuth")
+	}
+	return &pluginapiv1.AuthorizationURLResponse{
+		Url: oauthProv.AuthorizationURL(req.GetState(), slices.Clone(req.GetScopes())),
+	}, nil
+}
+
+func (s *ProviderServer) ExchangeCode(ctx context.Context, req *pluginapiv1.ExchangeCodeRequest) (*pluginapiv1.TokenResponse, error) {
+	oauthProv, ok := s.provider.(OAuthProvider)
+	if !ok {
+		return nil, status.Error(codes.Unimplemented, "provider does not support OAuth")
+	}
+	resp, err := oauthProv.ExchangeCode(ctx, req.GetCode())
+	if err != nil {
+		return nil, status.Errorf(codes.Unknown, "exchange code: %v", err)
+	}
+	if resp == nil {
+		return nil, status.Error(codes.Internal, "provider returned nil token response")
+	}
+	msg, err := tokenResponseToProto(resp)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "encode token response: %v", err)
+	}
+	return msg, nil
+}
+
+func (s *ProviderServer) RefreshToken(ctx context.Context, req *pluginapiv1.RefreshTokenRequest) (*pluginapiv1.TokenResponse, error) {
+	oauthProv, ok := s.provider.(OAuthProvider)
+	if !ok {
+		return nil, status.Error(codes.Unimplemented, "provider does not support OAuth")
+	}
+	resp, err := oauthProv.RefreshToken(ctx, req.GetRefreshToken())
+	if err != nil {
+		return nil, status.Errorf(codes.Unknown, "refresh token: %v", err)
+	}
+	if resp == nil {
+		return nil, status.Error(codes.Internal, "provider returned nil token response")
+	}
+	msg, err := tokenResponseToProto(resp)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "encode token response: %v", err)
+	}
+	return msg, nil
+}
+
 func authTypes(p Provider) []string {
-	if mp, ok := p.(ManualAuthProvider); ok && mp.SupportsManualAuth() {
+	if atl, ok := p.(AuthTypeLister); ok {
+		return slices.Clone(atl.AuthTypes())
+	}
+	_, hasOAuth := p.(OAuthProvider)
+	hasManual := false
+	if mp, ok := p.(ManualAuthProvider); ok {
+		hasManual = mp.SupportsManualAuth()
+	}
+	switch {
+	case hasOAuth && hasManual:
+		return []string{"oauth", "manual"}
+	case hasOAuth:
+		return []string{"oauth"}
+	case hasManual:
 		return []string{"manual"}
 	}
 	return nil

--- a/sdk/pluginsdk/types.go
+++ b/sdk/pluginsdk/types.go
@@ -58,8 +58,26 @@ type ConnectionParamProvider interface {
 	ConnectionParamDefs() map[string]ConnectionParamDef
 }
 
+type TokenResponse struct {
+	AccessToken  string
+	RefreshToken string
+	ExpiresIn    int
+	TokenType    string
+	Extra        map[string]any
+}
+
+type OAuthProvider interface {
+	AuthorizationURL(state string, scopes []string) string
+	ExchangeCode(ctx context.Context, code string) (*TokenResponse, error)
+	RefreshToken(ctx context.Context, refreshToken string) (*TokenResponse, error)
+}
+
 type ManualAuthProvider interface {
 	SupportsManualAuth() bool
+}
+
+type AuthTypeLister interface {
+	AuthTypes() []string
 }
 
 type connectionParamsKey struct{}


### PR DESCRIPTION
## Summary
- add an OAuth-capable surface to `sdk/pluginsdk` with SDK token/auth types
- implement the provider RPCs needed for plugin-owned OAuth in the SDK provider server
- advertise plugin auth types from implemented interfaces and add host round-trip coverage

## Testing
- `go test ./...` in `sdk/pluginsdk`
- `go test ./internal/pluginapi`

## Scope
This is the preliminary SDK-side unlock for OAuth-capable plugins over the existing plugin protocol. It does not add host-managed `plugin + connections` config support in the main config model.