### PR TITLE
Forward _meta and preserve outputSchema in MCP passthrough

### DIFF
--- a/core/catalog/catalog.go
+++ b/core/catalog/catalog.go
@@ -36,6 +36,7 @@ type CatalogOperation struct {
 	Title          string               `yaml:"title,omitempty"          json:"title,omitempty"`
 	Description    string               `yaml:"description,omitempty"    json:"description,omitempty"`
 	InputSchema    json.RawMessage      `yaml:"-"                        json:"inputSchema,omitempty"`
+	OutputSchema   json.RawMessage      `yaml:"-"                        json:"outputSchema,omitempty"`
 	Annotations    OperationAnnotations `yaml:"annotations,omitempty"    json:"annotations,omitempty"`
 	Parameters     []CatalogParameter   `yaml:"parameters,omitempty"     json:"parameters,omitempty"`
 	RequiredScopes []string             `yaml:"required_scopes,omitempty" json:"requiredScopes,omitempty"`

--- a/internal/mcp/binding_test.go
+++ b/internal/mcp/binding_test.go
@@ -1067,4 +1067,121 @@ func TestNewServer_IncludeRESTFiltering(t *testing.T) {
 	}
 }
 
+func TestNewServer_DirectCallerForwardsMeta(t *testing.T) {
+	t.Parallel()
+
+	var gotMeta *mcpgo.Meta
+
+	cat := &catalog.Catalog{
+		Name: "upstream",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:          "do_thing",
+				Description: "Do a thing",
+				Transport:   catalog.TransportMCPPassthrough,
+			},
+		},
+	}
+
+	prov := &directCallerProvider{
+		StubIntegration: coretesting.StubIntegration{N: "upstream"},
+		ops:             []core.Operation{{Name: "do_thing", Description: "Do a thing"}},
+		cat:             cat,
+		callFn: func(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
+			gotMeta = mcpupstream.CallToolMetaFromContext(ctx)
+			return mcpgo.NewToolResultText("ok"), nil
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, prov)
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker:       &testutil.StubInvoker{},
+		TokenResolver: &stubTokenResolver{token: "t"},
+		Providers:     providers,
+	})
+
+	tool := srv.GetTool("upstream_do_thing")
+	if tool == nil {
+		t.Fatal("tool not found")
+	}
+
+	ctx := ctxWithPrincipal()
+	req := mcpgo.CallToolRequest{}
+	req.Params.Name = "upstream_do_thing"
+	req.Params.Meta = &mcpgo.Meta{ProgressToken: mcpgo.ProgressToken("prog-1")}
+
+	result, err := tool.Handler(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+	if gotMeta == nil {
+		t.Fatal("expected meta to be forwarded via context")
+	}
+	if gotMeta.ProgressToken != mcpgo.ProgressToken("prog-1") {
+		t.Fatalf("expected progress token prog-1, got %v", gotMeta.ProgressToken)
+	}
+}
+
+func TestNewServer_OutputSchemaPreserved(t *testing.T) {
+	t.Parallel()
+
+	cat := &catalog.Catalog{
+		Name: "upstream",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:           "typed_op",
+				Description:  "Has output schema",
+				Transport:    catalog.TransportMCPPassthrough,
+				InputSchema:  json.RawMessage(`{"type":"object","properties":{"q":{"type":"string"}}}`),
+				OutputSchema: json.RawMessage(`{"type":"object","properties":{"count":{"type":"integer"}}}`),
+			},
+		},
+	}
+
+	prov := &catalogProvider{
+		StubIntegration: coretesting.StubIntegration{N: "upstream"},
+		ops:             coreintegration.OperationsList(cat),
+		catalog:         cat,
+	}
+
+	providers := testutil.NewProviderRegistry(t, prov)
+	ds := stubDatastoreWithToken()
+	broker := invocation.NewBroker(providers, ds)
+
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker:   broker,
+		Providers: providers,
+	})
+
+	tools := srv.ListTools()
+	st := tools["upstream_typed_op"]
+	if st == nil {
+		t.Fatal("expected upstream_typed_op tool")
+	}
+
+	raw, err := json.Marshal(st.Tool)
+	if err != nil {
+		t.Fatalf("marshal tool: %v", err)
+	}
+
+	var toolJSON map[string]any
+	if err := json.Unmarshal(raw, &toolJSON); err != nil {
+		t.Fatalf("unmarshal tool JSON: %v", err)
+	}
+	os, ok := toolJSON["outputSchema"]
+	if !ok {
+		t.Fatal("expected outputSchema in tool JSON")
+	}
+	osMap, ok := os.(map[string]any)
+	if !ok {
+		t.Fatalf("expected outputSchema to be a map, got %T", os)
+	}
+	if osMap["type"] != "object" {
+		t.Fatalf("expected outputSchema type=object, got %v", osMap["type"])
+	}
+}
+
 func boolPtr(v bool) *bool { return &v }

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -57,6 +57,7 @@ func makeDirectHandler(cfg Config, provName, opName, connection string, caller d
 		}
 
 		ctx = mcpupstream.WithUpstreamToken(ctx, token)
+		ctx = mcpupstream.WithCallToolMeta(ctx, req.Params.Meta)
 		return caller.CallTool(ctx, opName, args)
 	}
 }

--- a/internal/mcp/projection.go
+++ b/internal/mcp/projection.go
@@ -69,6 +69,10 @@ func buildToolMap(cfg Config, provName string, prov core.Provider, cat *catalog.
 			tool.Annotations.Title = op.ID
 		}
 
+		if len(op.OutputSchema) > 0 {
+			tool.RawOutputSchema = op.OutputSchema
+		}
+
 		var conn string
 		switch op.Transport {
 		case catalog.TransportMCPPassthrough:

--- a/internal/mcpupstream/context.go
+++ b/internal/mcpupstream/context.go
@@ -1,8 +1,14 @@
 package mcpupstream
 
-import "context"
+import (
+	"context"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
 
 type contextKey struct{}
+
+type metaKey struct{}
 
 func WithUpstreamToken(ctx context.Context, token string) context.Context {
 	return context.WithValue(ctx, contextKey{}, token)
@@ -10,5 +16,17 @@ func WithUpstreamToken(ctx context.Context, token string) context.Context {
 
 func UpstreamTokenFromContext(ctx context.Context) string {
 	v, _ := ctx.Value(contextKey{}).(string)
+	return v
+}
+
+func WithCallToolMeta(ctx context.Context, meta *mcpgo.Meta) context.Context {
+	if meta == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, metaKey{}, meta)
+}
+
+func CallToolMetaFromContext(ctx context.Context) *mcpgo.Meta {
+	v, _ := ctx.Value(metaKey{}).(*mcpgo.Meta)
 	return v
 }

--- a/internal/mcpupstream/upstream.go
+++ b/internal/mcpupstream/upstream.go
@@ -95,6 +95,7 @@ func (u *Upstream) CallTool(ctx context.Context, name string, args map[string]an
 	req := mcpgo.CallToolRequest{}
 	req.Params.Name = name
 	req.Params.Arguments = args
+	req.Params.Meta = CallToolMetaFromContext(ctx)
 
 	if u.client != nil {
 		return u.client.CallTool(ctx, req)
@@ -218,12 +219,18 @@ func buildCatalog(name string, tools []mcpgo.Tool) (*catalog.Catalog, []core.Ope
 	for i := range tools {
 		schema, _ := json.Marshal(tools[i].InputSchema)
 
+		var outputSchema json.RawMessage
+		if tools[i].OutputSchema.Type != "" {
+			outputSchema, _ = json.Marshal(tools[i].OutputSchema)
+		}
+
 		catOp := catalog.CatalogOperation{
-			ID:          tools[i].Name,
-			Title:       tools[i].Annotations.Title,
-			Description: tools[i].Description,
-			InputSchema: schema,
-			Transport:   catalog.TransportMCPPassthrough,
+			ID:           tools[i].Name,
+			Title:        tools[i].Annotations.Title,
+			Description:  tools[i].Description,
+			InputSchema:  schema,
+			OutputSchema: outputSchema,
+			Transport:    catalog.TransportMCPPassthrough,
 		}
 		catOp.Annotations = catalog.OperationAnnotations{
 			ReadOnlyHint:    tools[i].Annotations.ReadOnlyHint,

--- a/internal/mcpupstream/upstream_test.go
+++ b/internal/mcpupstream/upstream_test.go
@@ -2,6 +2,8 @@ package mcpupstream
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -37,8 +39,12 @@ func newTestServer() *mcpserver.MCPServer {
 
 func newTestUpstream(t *testing.T) *Upstream {
 	t.Helper()
+	return newTestUpstreamFromServer(t, "clickhouse", newTestServer())
+}
 
-	srv := newTestServer()
+func newTestUpstreamFromServer(t *testing.T, name string, srv *mcpserver.MCPServer) *Upstream {
+	t.Helper()
+
 	client, err := mcpclient.NewInProcessClient(srv)
 	if err != nil {
 		t.Fatalf("creating in-process client: %v", err)
@@ -61,7 +67,7 @@ func newTestUpstream(t *testing.T) *Upstream {
 		t.Fatalf("listing tools: %v", err)
 	}
 
-	return newFromClient("clickhouse", client, core.ConnectionModeUser, toolsResult.Tools)
+	return newFromClient(name, client, core.ConnectionModeUser, toolsResult.Tools)
 }
 
 func newAuthenticatedHTTPTestServer(t *testing.T, expectedAuth string) *httptest.Server {
@@ -330,5 +336,68 @@ func TestUpstream_UsesSharedEgressResolver(t *testing.T) {
 	}
 	if result.IsError {
 		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+}
+
+func TestUpstream_CallToolForwardsMeta(t *testing.T) {
+	t.Parallel()
+
+	srv := mcpserver.NewMCPServer("meta-test", "1.0.0")
+	srv.AddTool(
+		mcpgo.NewTool("check_meta", mcpgo.WithDescription("checks meta")),
+		func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+			if req.Params.Meta == nil {
+				return nil, fmt.Errorf("expected _meta to be forwarded")
+			}
+			return mcpgo.NewToolResultText("ok"), nil
+		},
+	)
+
+	u := newTestUpstreamFromServer(t, "meta-upstream", srv)
+	t.Cleanup(func() { _ = u.Close() })
+
+	ctx := WithCallToolMeta(context.Background(), &mcpgo.Meta{ProgressToken: mcpgo.ProgressToken("tok-1")})
+	result, err := u.CallTool(ctx, "check_meta", nil)
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+}
+
+func TestUpstream_DiscoverToolsPreservesOutputSchema(t *testing.T) {
+	t.Parallel()
+
+	outputSchema := json.RawMessage(`{"type":"object","properties":{"count":{"type":"integer"}}}`)
+
+	srv := mcpserver.NewMCPServer("output-test", "1.0.0")
+	srv.AddTool(
+		mcpgo.NewTool("typed_op", mcpgo.WithDescription("has output schema"), mcpgo.WithRawOutputSchema(outputSchema)),
+		func(_ context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+			return mcpgo.NewToolResultText("ok"), nil
+		},
+	)
+
+	u := newTestUpstreamFromServer(t, "output-upstream", srv)
+	t.Cleanup(func() { _ = u.Close() })
+
+	cat := u.Catalog()
+	if cat == nil {
+		t.Fatal("expected non-nil catalog")
+	}
+	if len(cat.Operations) != 1 {
+		t.Fatalf("expected 1 catalog operation, got %d", len(cat.Operations))
+	}
+	if len(cat.Operations[0].OutputSchema) == 0 {
+		t.Fatal("expected OutputSchema to be preserved")
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(cat.Operations[0].OutputSchema, &parsed); err != nil {
+		t.Fatalf("unmarshal OutputSchema: %v", err)
+	}
+	if parsed["type"] != "object" {
+		t.Fatalf("expected type=object, got %v", parsed["type"])
 	}
 }


### PR DESCRIPTION
The MCP passthrough layer was dropping the `_meta` field from client
tool call requests and stripping `outputSchema` from upstream tool
definitions. This caused upstream servers that require structured content
negotiation (like ClickHouse Cloud) to reject calls with a protocol
error, and prevented clients from knowing which tools support structured
output.

Both fields are now faithfully proxied end-to-end. Upstream tools that
declare an `outputSchema` will surface it to clients in `tools/list`,
and client-supplied `_meta` (progress tokens, structured content
preferences) will reach the upstream server on `tools/call`.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>