### PR TITLE
Add operation aliasing to allowed_operations

### DIFF
--- a/cmd/gestaltd/provider_factory.go
+++ b/cmd/gestaltd/provider_factory.go
@@ -84,7 +84,7 @@ func (a *providerAssembly) build() (_ core.Provider, err error) {
 			buildOpts = append(buildOpts, provider.WithAuthHandler(buildMCPOAuthHandler(conn, mcpURL, a.regStore, a.deps)))
 		}
 
-		p, err := providercompiler.BuildProvider(a.ctx, a.name, a.intg, *a.intg.API, conn, a.preparedProviders, buildOpts...)
+		p, err := providercompiler.BuildProvider(a.ctx, a.name, a.intg, *a.intg.API, conn, a.preparedProviders, nil, buildOpts...)
 		if err != nil {
 			return nil, err
 		}

--- a/core/integration/restricted.go
+++ b/core/integration/restricted.go
@@ -9,10 +9,14 @@ import (
 	"github.com/valon-technologies/gestalt/internal/oauth"
 )
 
-// Restricted wraps a Provider to expose only a subset of its operations.
+// Restricted wraps a Provider to expose only a subset of its operations,
+// optionally renaming them via aliases.
 type Restricted struct {
-	inner   core.Provider
-	allowed map[string]struct{}
+	inner        core.Provider
+	allowed      map[string]struct{}
+	aliases      map[string]string
+	reverseAlias map[string]string
+	allowedInner map[string]struct{}
 }
 
 // Compile-time interface checks.
@@ -26,13 +30,31 @@ var (
 )
 
 // NewRestricted returns a Provider that gates operations to the allowed set.
-// If the inner provider implements OAuthProvider, the returned value does too.
-func NewRestricted(inner core.Provider, allowed []string) core.Provider {
-	m := make(map[string]struct{}, len(allowed))
-	for _, name := range allowed {
-		m[name] = struct{}{}
+// The ops map maps exposedName -> innerName. If innerName is empty, the
+// exposed name equals the inner name (no alias). If the inner provider
+// implements OAuthProvider, the returned value does too.
+func NewRestricted(inner core.Provider, ops map[string]string) core.Provider {
+	m := make(map[string]struct{}, len(ops))
+	aliases := make(map[string]string)
+	reverseAlias := make(map[string]string)
+	allowedInner := make(map[string]struct{}, len(ops))
+	for exposed, innerName := range ops {
+		m[exposed] = struct{}{}
+		if innerName != "" && innerName != exposed {
+			aliases[exposed] = innerName
+			reverseAlias[innerName] = exposed
+			allowedInner[innerName] = struct{}{}
+		} else {
+			allowedInner[exposed] = struct{}{}
+		}
 	}
-	r := &Restricted{inner: inner, allowed: m}
+	r := &Restricted{
+		inner:        inner,
+		allowed:      m,
+		aliases:      aliases,
+		reverseAlias: reverseAlias,
+		allowedInner: allowedInner,
+	}
 	if scp, ok := inner.(core.SessionCatalogProvider); ok {
 		rs := &restrictedSession{Restricted: r, scp: scp}
 		if oauth, ok := inner.(core.OAuthProvider); ok {
@@ -55,7 +77,10 @@ func (r *Restricted) ListOperations() []core.Operation {
 	all := r.inner.ListOperations()
 	filtered := make([]core.Operation, 0, len(r.allowed))
 	for _, op := range all {
-		if _, ok := r.allowed[op.Name]; ok {
+		if _, ok := r.allowedInner[op.Name]; ok {
+			if exposed, ok := r.reverseAlias[op.Name]; ok {
+				op.Name = exposed
+			}
 			filtered = append(filtered, op)
 		}
 	}
@@ -66,7 +91,11 @@ func (r *Restricted) Execute(ctx context.Context, operation string, params map[s
 	if _, ok := r.allowed[operation]; !ok {
 		return nil, fmt.Errorf("operation %q is not allowed", operation)
 	}
-	return r.inner.Execute(ctx, operation, params, token)
+	innerName := operation
+	if alias, ok := r.aliases[operation]; ok {
+		innerName = alias
+	}
+	return r.inner.Execute(ctx, innerName, params, token)
 }
 
 func (r *Restricted) SupportsManualAuth() bool {
@@ -88,8 +117,12 @@ func (r *Restricted) Catalog() *catalog.Catalog {
 	filtered := *cat
 	filtered.Operations = nil
 	for i := range cat.Operations {
-		if _, ok := r.allowed[cat.Operations[i].ID]; ok {
-			filtered.Operations = append(filtered.Operations, cat.Operations[i])
+		if _, ok := r.allowedInner[cat.Operations[i].ID]; ok {
+			op := cat.Operations[i]
+			if exposed, ok := r.reverseAlias[op.ID]; ok {
+				op.ID = exposed
+			}
+			filtered.Operations = append(filtered.Operations, op)
 		}
 	}
 	return &filtered
@@ -115,8 +148,12 @@ func (rs *restrictedSession) CatalogForRequest(ctx context.Context, token string
 	filtered := *cat
 	filtered.Operations = nil
 	for i := range cat.Operations {
-		if _, ok := rs.allowed[cat.Operations[i].ID]; ok {
-			filtered.Operations = append(filtered.Operations, cat.Operations[i])
+		if _, ok := rs.allowedInner[cat.Operations[i].ID]; ok {
+			op := cat.Operations[i]
+			if exposed, ok := rs.reverseAlias[op.ID]; ok {
+				op.ID = exposed
+			}
+			filtered.Operations = append(filtered.Operations, op)
 		}
 	}
 	return &filtered, nil

--- a/core/integration/restricted_test.go
+++ b/core/integration/restricted_test.go
@@ -31,11 +31,11 @@ func TestListOperationsFilters(t *testing.T) {
 	t.Parallel()
 
 	inner := &stubWithOps{
-		StubIntegration: coretesting.StubIntegration{N: "slack"},
+		StubIntegration: coretesting.StubIntegration{N: "test_provider"},
 		ops:             sampleOps(),
 	}
 
-	r := coreintegration.NewRestricted(inner, []string{"list_channels", "send_message"})
+	r := coreintegration.NewRestricted(inner, map[string]string{"list_channels": "", "send_message": ""})
 	ops := r.ListOperations()
 
 	if len(ops) != 2 {
@@ -53,12 +53,11 @@ func TestListOperationsPreservesOrder(t *testing.T) {
 	t.Parallel()
 
 	inner := &stubWithOps{
-		StubIntegration: coretesting.StubIntegration{N: "slack"},
+		StubIntegration: coretesting.StubIntegration{N: "test_provider"},
 		ops:             sampleOps(),
 	}
 
-	// Allowlist in different order from inner; output should follow inner's order.
-	r := coreintegration.NewRestricted(inner, []string{"delete_message", "list_channels"})
+	r := coreintegration.NewRestricted(inner, map[string]string{"delete_message": "", "list_channels": ""})
 	ops := r.ListOperations()
 
 	if len(ops) != 2 {
@@ -78,7 +77,7 @@ func TestExecuteAllowed(t *testing.T) {
 	want := &core.OperationResult{Status: 200, Body: "ok"}
 	inner := &stubWithOps{
 		StubIntegration: coretesting.StubIntegration{
-			N: "slack",
+			N: "test_provider",
 			ExecuteFn: func(_ context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
 				return want, nil
 			},
@@ -86,7 +85,7 @@ func TestExecuteAllowed(t *testing.T) {
 		ops: sampleOps(),
 	}
 
-	r := coreintegration.NewRestricted(inner, []string{"send_message"})
+	r := coreintegration.NewRestricted(inner, map[string]string{"send_message": ""})
 	got, err := r.Execute(context.Background(), "send_message", nil, "tok")
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -100,14 +99,64 @@ func TestExecuteDisallowed(t *testing.T) {
 	t.Parallel()
 
 	inner := &stubWithOps{
-		StubIntegration: coretesting.StubIntegration{N: "slack"},
+		StubIntegration: coretesting.StubIntegration{N: "test_provider"},
 		ops:             sampleOps(),
 	}
 
-	r := coreintegration.NewRestricted(inner, []string{"list_channels"})
+	r := coreintegration.NewRestricted(inner, map[string]string{"list_channels": ""})
 	_, err := r.Execute(context.Background(), "delete_message", nil, "tok")
 	if err == nil {
 		t.Fatal("Execute: expected error for disallowed op, got nil")
+	}
+}
+
+func TestRestrictedWithAliases(t *testing.T) {
+	t.Parallel()
+
+	var executedOp string
+	inner := &stubWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N: "test_provider",
+			ExecuteFn: func(_ context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				executedOp = op
+				return &core.OperationResult{Status: 200, Body: "ok"}, nil
+			},
+		},
+		ops: sampleOps(),
+	}
+
+	r := coreintegration.NewRestricted(inner, map[string]string{
+		"my_channels": "list_channels",
+		"send":        "send_message",
+	})
+
+	ops := r.ListOperations()
+	if len(ops) != 2 {
+		t.Fatalf("ListOperations: got %d ops, want 2", len(ops))
+	}
+
+	names := make(map[string]bool)
+	for _, op := range ops {
+		names[op.Name] = true
+	}
+	if !names["my_channels"] {
+		t.Error("expected aliased name my_channels")
+	}
+	if !names["send"] {
+		t.Error("expected aliased name send")
+	}
+
+	_, err := r.Execute(context.Background(), "my_channels", nil, "tok")
+	if err != nil {
+		t.Fatalf("Execute(my_channels): %v", err)
+	}
+	if executedOp != "list_channels" {
+		t.Errorf("inner received op %q, want list_channels", executedOp)
+	}
+
+	_, err = r.Execute(context.Background(), "list_channels", nil, "tok")
+	if err == nil {
+		t.Fatal("expected error when calling by original name after aliasing")
 	}
 }
 
@@ -127,7 +176,7 @@ func TestDelegationMethods(t *testing.T) {
 		ops: sampleOps(),
 	}
 
-	r := coreintegration.NewRestricted(inner, []string{"list_channels"})
+	r := coreintegration.NewRestricted(inner, map[string]string{"list_channels": ""})
 
 	if got := r.Name(); got != "my-integration" {
 		t.Errorf("Name: got %q, want %q", got, "my-integration")

--- a/internal/graphql/loader.go
+++ b/internal/graphql/loader.go
@@ -8,7 +8,7 @@ import (
 	"github.com/valon-technologies/gestalt/internal/provider"
 )
 
-func LoadDefinition(ctx context.Context, name, endpoint string, allowedOps map[string]string) (*provider.Definition, error) {
+func LoadDefinition(ctx context.Context, name, endpoint string, allowedOps map[string]*provider.OperationOverride) (*provider.Definition, error) {
 	schema, err := introspect(ctx, endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("introspecting %s: %w", endpoint, err)
@@ -30,7 +30,7 @@ func LoadDefinition(ctx context.Context, name, endpoint string, allowedOps map[s
 	return def, nil
 }
 
-func addOperations(schema *Schema, def *provider.Definition, root *TypeName, isMutation bool, allowedOps map[string]string) {
+func addOperations(schema *Schema, def *provider.Definition, root *TypeName, isMutation bool, allowedOps map[string]*provider.OperationOverride) {
 	if root == nil {
 		return
 	}
@@ -51,8 +51,14 @@ func addOperations(schema *Schema, def *provider.Definition, root *TypeName, isM
 		}
 
 		desc := field.Description
-		if override, ok := allowedOps[field.Name]; ok && override != "" {
-			desc = override
+		opName := field.Name
+		if override := allowedOps[field.Name]; override != nil {
+			if override.Description != "" {
+				desc = override.Description
+			}
+			if override.Alias != "" {
+				opName = override.Alias
+			}
 		}
 
 		query := generateQuery(schema, field, isMutation)
@@ -65,7 +71,7 @@ func addOperations(schema *Schema, def *provider.Definition, root *TypeName, isM
 
 		opDef.Parameters = argsToParams(schema, field.Args)
 
-		def.Operations[field.Name] = opDef
+		def.Operations[opName] = opDef
 	}
 }
 

--- a/internal/graphql/loader_test.go
+++ b/internal/graphql/loader_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/valon-technologies/gestalt/internal/provider"
 )
 
 func strPtr(s string) *string { return &s }
@@ -146,8 +148,8 @@ func TestLoadDefinitionWithAllowedOps(t *testing.T) {
 	srv := startIntrospectionServer(t, newTestSchema())
 	defer srv.Close()
 
-	def, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]string{
-		"teams": "My custom description",
+	def, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*provider.OperationOverride{
+		"teams": {Description: "My custom description"},
 	})
 	if err != nil {
 		t.Fatalf("LoadDefinition: %v", err)

--- a/internal/mcpupstream/upstream.go
+++ b/internal/mcpupstream/upstream.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
 	"github.com/valon-technologies/gestalt/internal/egress"
+	"github.com/valon-technologies/gestalt/internal/provider"
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
@@ -27,16 +29,17 @@ var (
 )
 
 type Upstream struct {
-	name     string
-	display  string
-	desc     string
-	url      string
-	connMode core.ConnectionMode
-	cat      *catalog.Catalog
-	ops      []core.Operation
-	client   mcpclient.MCPClient
-	allowed  map[string]string
-	resolver *egress.Resolver
+	name        string
+	display     string
+	desc        string
+	url         string
+	connMode    core.ConnectionMode
+	cat         *catalog.Catalog
+	ops         []core.Operation
+	client      mcpclient.MCPClient
+	allowed     map[string]*provider.OperationOverride
+	aliasToOrig map[string]string
+	resolver    *egress.Resolver
 }
 
 func New(_ context.Context, name string, url string, connMode core.ConnectionMode, resolver *egress.Resolver) (*Upstream, error) {
@@ -92,8 +95,9 @@ func (u *Upstream) CallTool(ctx context.Context, name string, args map[string]an
 		return nil, fmt.Errorf("operation %q is not allowed", name)
 	}
 
+	innerName := u.resolveInnerName(name)
 	req := mcpgo.CallToolRequest{}
-	req.Params.Name = name
+	req.Params.Name = innerName
 	req.Params.Arguments = args
 	req.Params.Meta = CallToolMetaFromContext(ctx)
 
@@ -117,14 +121,29 @@ func (u *Upstream) Close() error {
 	return u.client.Close()
 }
 
-func (u *Upstream) FilterOperations(allowed map[string]string) error {
+func (u *Upstream) FilterOperations(allowed map[string]*provider.OperationOverride) error {
 	if len(allowed) == 0 {
 		return fmt.Errorf("allowed_operations cannot be empty; omit the field to allow all")
 	}
 
-	u.allowed = make(map[string]string, len(allowed))
-	for name, desc := range allowed {
-		u.allowed[name] = desc
+	u.allowed = make(map[string]*provider.OperationOverride, len(allowed))
+	u.aliasToOrig = make(map[string]string)
+	exposedNames := make(map[string]string, len(allowed))
+	var collisions []string
+	for name, override := range allowed {
+		u.allowed[name] = override
+		exposed := name
+		if override != nil && override.Alias != "" {
+			exposed = override.Alias
+			u.aliasToOrig[override.Alias] = name
+		}
+		if existing, ok := exposedNames[exposed]; ok {
+			collisions = append(collisions, fmt.Sprintf("%q and %q both resolve to %q", existing, name, exposed))
+		}
+		exposedNames[exposed] = name
+	}
+	if len(collisions) > 0 {
+		return fmt.Errorf("alias collisions: %s", strings.Join(collisions, "; "))
 	}
 
 	if u.cat == nil {
@@ -175,12 +194,7 @@ func (u *Upstream) connect(ctx context.Context, token string) (mcpclient.MCPClie
 
 func (u *Upstream) discover(ctx context.Context, token string) (*catalog.Catalog, []core.Operation, error) {
 	if u.client != nil && u.cat != nil {
-		cat := u.cat.Clone()
-		ops := slices.Clone(u.ops)
-		if err := filterDiscovered(cat, &ops, u.allowed); err != nil {
-			return nil, nil, err
-		}
-		return cat, ops, nil
+		return u.cat.Clone(), slices.Clone(u.ops), nil
 	}
 
 	client, err := u.connect(ctx, token)
@@ -201,12 +215,24 @@ func (u *Upstream) discover(ctx context.Context, token string) (*catalog.Catalog
 	return cat, ops, nil
 }
 
+func (u *Upstream) resolveInnerName(name string) string {
+	if orig, ok := u.aliasToOrig[name]; ok {
+		return orig
+	}
+	return name
+}
+
 func (u *Upstream) isOperationAllowed(name string) bool {
 	if len(u.allowed) == 0 {
 		return true
 	}
-	_, ok := u.allowed[name]
-	return ok
+	if _, ok := u.aliasToOrig[name]; ok {
+		return true
+	}
+	if override, ok := u.allowed[name]; ok && (override == nil || override.Alias == "") {
+		return true
+	}
+	return false
 }
 
 func buildCatalog(name string, tools []mcpgo.Tool) (*catalog.Catalog, []core.Operation) {
@@ -249,7 +275,7 @@ func buildCatalog(name string, tools []mcpgo.Tool) (*catalog.Catalog, []core.Ope
 	return cat, ops
 }
 
-func filterDiscovered(cat *catalog.Catalog, ops *[]core.Operation, allowed map[string]string) error {
+func filterDiscovered(cat *catalog.Catalog, ops *[]core.Operation, allowed map[string]*provider.OperationOverride) error {
 	if len(allowed) == 0 {
 		return nil
 	}
@@ -266,9 +292,12 @@ func filterDiscovered(cat *catalog.Catalog, ops *[]core.Operation, allowed map[s
 
 	filteredOps := make([]core.Operation, 0, len(allowed))
 	for _, op := range *ops {
-		if desc, ok := allowed[op.Name]; ok {
-			if desc != "" {
-				op.Description = desc
+		if override, ok := allowed[op.Name]; ok {
+			if override != nil && override.Description != "" {
+				op.Description = override.Description
+			}
+			if override != nil && override.Alias != "" {
+				op.Name = override.Alias
 			}
 			filteredOps = append(filteredOps, op)
 		}
@@ -276,9 +305,12 @@ func filterDiscovered(cat *catalog.Catalog, ops *[]core.Operation, allowed map[s
 
 	filteredCatOps := make([]catalog.CatalogOperation, 0, len(allowed))
 	for i := range cat.Operations {
-		if desc, ok := allowed[cat.Operations[i].ID]; ok {
-			if desc != "" {
-				cat.Operations[i].Description = desc
+		if override, ok := allowed[cat.Operations[i].ID]; ok {
+			if override != nil && override.Description != "" {
+				cat.Operations[i].Description = override.Description
+			}
+			if override != nil && override.Alias != "" {
+				cat.Operations[i].ID = override.Alias
 			}
 			filteredCatOps = append(filteredCatOps, cat.Operations[i])
 		}

--- a/internal/mcpupstream/upstream_test.go
+++ b/internal/mcpupstream/upstream_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/egress"
 	"github.com/valon-technologies/gestalt/internal/egress/egresstest"
+	"github.com/valon-technologies/gestalt/internal/provider"
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -165,7 +166,7 @@ func TestUpstream_FilterOperations(t *testing.T) {
 	u := newTestUpstream(t)
 	t.Cleanup(func() { _ = u.Close() })
 
-	err := u.FilterOperations(map[string]string{"run_query": ""})
+	err := u.FilterOperations(map[string]*provider.OperationOverride{"run_query": nil})
 	if err != nil {
 		t.Fatalf("FilterOperations: %v", err)
 	}
@@ -196,9 +197,9 @@ func TestUpstream_FilterOperationsWithOverride(t *testing.T) {
 	u := newTestUpstream(t)
 	t.Cleanup(func() { _ = u.Close() })
 
-	err := u.FilterOperations(map[string]string{
-		"run_query":      "Custom query description",
-		"list_databases": "",
+	err := u.FilterOperations(map[string]*provider.OperationOverride{
+		"run_query":      {Description: "Custom query description"},
+		"list_databases": nil,
 	})
 	if err != nil {
 		t.Fatalf("FilterOperations: %v", err)
@@ -229,7 +230,7 @@ func TestUpstream_FilterOperationsUnknown(t *testing.T) {
 	u := newTestUpstream(t)
 	t.Cleanup(func() { _ = u.Close() })
 
-	err := u.FilterOperations(map[string]string{"nonexistent": ""})
+	err := u.FilterOperations(map[string]*provider.OperationOverride{"nonexistent": nil})
 	if err == nil {
 		t.Fatal("expected error for unknown operation")
 	}
@@ -241,9 +242,34 @@ func TestUpstream_FilterOperationsEmpty(t *testing.T) {
 	u := newTestUpstream(t)
 	t.Cleanup(func() { _ = u.Close() })
 
-	err := u.FilterOperations(map[string]string{})
+	err := u.FilterOperations(map[string]*provider.OperationOverride{})
 	if err == nil {
 		t.Fatal("expected error for empty allowed_operations")
+	}
+}
+
+func TestUpstream_DiscoverAfterFilterWithAlias(t *testing.T) {
+	t.Parallel()
+
+	u := newTestUpstream(t)
+	t.Cleanup(func() { _ = u.Close() })
+
+	err := u.FilterOperations(map[string]*provider.OperationOverride{
+		"run_query": {Alias: "query"},
+	})
+	if err != nil {
+		t.Fatalf("FilterOperations: %v", err)
+	}
+
+	cat, _, err := u.discover(context.Background(), "")
+	if err != nil {
+		t.Fatalf("discover after filter with alias: %v", err)
+	}
+	if len(cat.Operations) != 1 {
+		t.Fatalf("expected 1 operation, got %d", len(cat.Operations))
+	}
+	if cat.Operations[0].ID != "query" {
+		t.Errorf("expected aliased ID %q, got %q", "query", cat.Operations[0].ID)
 	}
 }
 

--- a/internal/openapi/catalog.go
+++ b/internal/openapi/catalog.go
@@ -10,6 +10,7 @@ import (
 	v3high "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/valon-technologies/gestalt/core/catalog"
 	coreintegration "github.com/valon-technologies/gestalt/core/integration"
+	"github.com/valon-technologies/gestalt/internal/provider"
 
 	"github.com/pb33f/libopenapi"
 )
@@ -20,7 +21,7 @@ const (
 
 // LoadCatalog produces a *Catalog directly from an OpenAPI spec, preserving
 // nested JSON Schema for request bodies instead of flattening to parameters.
-func LoadCatalog(ctx context.Context, name, specURL string, allowedOps map[string]string) (*catalog.Catalog, error) {
+func LoadCatalog(ctx context.Context, name, specURL string, allowedOps map[string]*provider.OperationOverride) (*catalog.Catalog, error) {
 	body, err := fetch(ctx, specURL)
 	if err != nil {
 		return nil, fmt.Errorf("fetching %s: %w", specURL, err)
@@ -86,7 +87,7 @@ func catalogExtractAuth(model *v3high.Document, cat *catalog.Catalog) {
 	}
 }
 
-func catalogExtractOperations(model *v3high.Document, cat *catalog.Catalog, allowedOps map[string]string) {
+func catalogExtractOperations(model *v3high.Document, cat *catalog.Catalog, allowedOps map[string]*provider.OperationOverride) {
 	if model.Paths == nil || model.Paths.PathItems == nil {
 		return
 	}
@@ -110,14 +111,20 @@ func catalogExtractOperations(model *v3high.Document, cat *catalog.Catalog, allo
 			if desc == "" {
 				desc = op.Summary
 			}
-			if override, ok := allowedOps[op.OperationId]; ok && override != "" {
-				desc = override
+			opID := op.OperationId
+			if override := allowedOps[op.OperationId]; override != nil {
+				if override.Description != "" {
+					desc = override.Description
+				}
+				if override.Alias != "" {
+					opID = override.Alias
+				}
 			}
 
 			upperMethod := strings.ToUpper(method)
 
 			catOp := catalog.CatalogOperation{
-				ID:          op.OperationId,
+				ID:          opID,
 				Method:      upperMethod,
 				Path:        path,
 				Title:       title,

--- a/internal/openapi/catalog_test.go
+++ b/internal/openapi/catalog_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/valon-technologies/gestalt/internal/provider"
 	"github.com/valon-technologies/gestalt/internal/testutil"
 )
 
@@ -199,9 +200,9 @@ func TestLoadCatalogAllowedOpsFiltering(t *testing.T) {
 	srv := serveJSON(t, nestedBodySpec())
 	testutil.CloseOnCleanup(t, srv)
 
-	allowed := map[string]string{
-		"list_items":  "Custom list description",
-		"create_item": "",
+	allowed := map[string]*provider.OperationOverride{
+		"list_items":  {Description: "Custom list description"},
+		"create_item": nil,
 	}
 	cat, err := LoadCatalog(context.Background(), "filtered", srv.URL, allowed)
 	if err != nil {

--- a/internal/openapi/loader.go
+++ b/internal/openapi/loader.go
@@ -21,7 +21,7 @@ const maxSpecSize = 100 << 20 // 100 MB
 
 var defaultClient = &http.Client{Timeout: 30 * time.Second}
 
-func LoadDefinition(ctx context.Context, name, specURL string, allowedOps map[string]string) (*provider.Definition, error) {
+func LoadDefinition(ctx context.Context, name, specURL string, allowedOps map[string]*provider.OperationOverride) (*provider.Definition, error) {
 	body, err := fetch(ctx, specURL)
 	if err != nil {
 		return nil, fmt.Errorf("fetching %s: %w", specURL, err)
@@ -160,7 +160,7 @@ func extractScopes(scopes *orderedmap.Map[string, string]) []string {
 	return result
 }
 
-func collectOperationScopes(model *v3high.Document, allowedOps map[string]string) []string {
+func collectOperationScopes(model *v3high.Document, allowedOps map[string]*provider.OperationOverride) []string {
 	seen := make(map[string]struct{})
 	collect := func(reqs []*base.SecurityRequirement) {
 		for _, req := range reqs {
@@ -203,7 +203,7 @@ func collectOperationScopes(model *v3high.Document, allowedOps map[string]string
 	return result
 }
 
-func extractOperations(model *v3high.Document, def *provider.Definition, allowedOps map[string]string) {
+func extractOperations(model *v3high.Document, def *provider.Definition, allowedOps map[string]*provider.OperationOverride) {
 	def.Operations = make(map[string]provider.OperationDef)
 
 	if model.Paths == nil || model.Paths.PathItems == nil {
@@ -229,8 +229,14 @@ func extractOperations(model *v3high.Document, def *provider.Definition, allowed
 			if desc == "" {
 				desc = op.Description
 			}
-			if override, ok := allowedOps[op.OperationId]; ok && override != "" {
-				desc = override
+			opID := op.OperationId
+			if override := allowedOps[op.OperationId]; override != nil {
+				if override.Description != "" {
+					desc = override.Description
+				}
+				if override.Alias != "" {
+					opID = override.Alias
+				}
 			}
 
 			var params []provider.ParameterDef
@@ -283,7 +289,7 @@ func extractOperations(model *v3high.Document, def *provider.Definition, allowed
 				}
 			}
 
-			def.Operations[op.OperationId] = provider.OperationDef{
+			def.Operations[opID] = provider.OperationDef{
 				Description: desc,
 				Method:      strings.ToUpper(method),
 				Path:        path,

--- a/internal/openapi/loader_test.go
+++ b/internal/openapi/loader_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/valon-technologies/gestalt/internal/provider"
 	"github.com/valon-technologies/gestalt/internal/testutil"
 )
 
@@ -78,9 +79,9 @@ func TestLoadDefinition(t *testing.T) {
 	srv := serveJSON(t, testSpec())
 	testutil.CloseOnCleanup(t, srv)
 
-	allowed := map[string]string{
-		"list_items": "List items with pagination",
-		"get_item":   "",
+	allowed := map[string]*provider.OperationOverride{
+		"list_items": {Description: "List items with pagination"},
+		"get_item":   nil,
 	}
 
 	def, err := LoadDefinition(context.Background(), "example", srv.URL, allowed)
@@ -135,7 +136,7 @@ func TestLoadDefinitionFiltersOperations(t *testing.T) {
 	srv := serveJSON(t, spec)
 	testutil.CloseOnCleanup(t, srv)
 
-	def, err := LoadDefinition(context.Background(), "test", srv.URL, map[string]string{"op_a": "", "op_c": ""})
+	def, err := LoadDefinition(context.Background(), "test", srv.URL, map[string]*provider.OperationOverride{"op_a": nil, "op_c": nil})
 	if err != nil {
 		t.Fatalf("LoadDefinition: %v", err)
 	}
@@ -328,7 +329,7 @@ func TestCollectScopesRespectsAllowedOps(t *testing.T) {
 	srv := serveJSON(t, spec)
 	testutil.CloseOnCleanup(t, srv)
 
-	def, err := LoadDefinition(context.Background(), "test", srv.URL, map[string]string{"read_op": ""})
+	def, err := LoadDefinition(context.Background(), "test", srv.URL, map[string]*provider.OperationOverride{"read_op": nil})
 	if err != nil {
 		t.Fatalf("LoadDefinition: %v", err)
 	}

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -17,6 +17,12 @@ import (
 	"github.com/valon-technologies/gestalt/internal/oauth"
 )
 
+// OperationOverride holds optional alias and description for an allowed operation.
+type OperationOverride struct {
+	Alias       string `yaml:"alias" json:"alias,omitempty"`
+	Description string `yaml:"description" json:"description,omitempty"`
+}
+
 // BuildOption configures optional aspects of provider construction.
 type BuildOption func(*buildOptions)
 
@@ -38,7 +44,7 @@ func WithEgressResolver(r *egress.Resolver) BuildOption {
 // owns auth configuration. Display metadata (display_name, description, icon)
 // should be applied to the Definition before calling Build via
 // ApplyDisplayOverrides.
-func Build(def *Definition, conn config.ConnectionDef, allowedOperations map[string]string, opts ...BuildOption) (core.Provider, error) {
+func Build(def *Definition, conn config.ConnectionDef, allowedOperations map[string]*OperationOverride, opts ...BuildOption) (core.Provider, error) {
 	var bo buildOptions
 	for _, opt := range opts {
 		opt(&bo)
@@ -199,28 +205,39 @@ func Build(def *Definition, conn config.ConnectionDef, allowedOperations map[str
 		for _, op := range base.Operations {
 			opSet[op.Name] = struct{}{}
 		}
-		allowed := make([]string, 0, len(ops))
-		for opName, desc := range ops {
+		restrictedOps := make(map[string]string, len(ops))
+		var collisions []string
+		for opName, override := range ops {
 			if _, ok := opSet[opName]; !ok {
 				return nil, fmt.Errorf("%s: allowed_operations contains unknown operation %q", def.Provider, opName)
 			}
-			if desc != "" {
+			if override != nil && override.Description != "" {
 				for i := range base.Operations {
 					if base.Operations[i].Name == opName {
-						base.Operations[i].Description = desc
+						base.Operations[i].Description = override.Description
 						break
 					}
 				}
 				for i := range cat.Operations {
 					if cat.Operations[i].ID == opName {
-						cat.Operations[i].Description = desc
+						cat.Operations[i].Description = override.Description
 						break
 					}
 				}
 			}
-			allowed = append(allowed, opName)
+			exposedName := opName
+			if override != nil && override.Alias != "" {
+				exposedName = override.Alias
+			}
+			if existing, ok := restrictedOps[exposedName]; ok {
+				collisions = append(collisions, fmt.Sprintf("%q and %q both resolve to %q", existing, opName, exposedName))
+			}
+			restrictedOps[exposedName] = opName
 		}
-		result = coreintegration.NewRestricted(result, allowed)
+		if len(collisions) > 0 {
+			return nil, fmt.Errorf("%s: alias collisions: %s", def.Provider, strings.Join(collisions, "; "))
+		}
+		result = coreintegration.NewRestricted(result, restrictedOps)
 	}
 
 	return result, nil

--- a/internal/provider/build_test.go
+++ b/internal/provider/build_test.go
@@ -101,7 +101,7 @@ func TestBuildAllowedOperations(t *testing.T) {
 		ClientID:     "test",
 		ClientSecret: "test",
 		RedirectURL:  "http://localhost/callback",
-	}}, map[string]string{"list_items": ""})
+	}}, map[string]*OperationOverride{"list_items": nil})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestBuildAllowedOperationsUnknown(t *testing.T) {
 	t.Parallel()
 
 	def := testDefinition("bad")
-	_, err := Build(def, config.ConnectionDef{}, map[string]string{"nonexistent": ""})
+	_, err := Build(def, config.ConnectionDef{}, map[string]*OperationOverride{"nonexistent": nil})
 	if err == nil {
 		t.Fatal("expected error for unknown allowed operation")
 	}
@@ -124,9 +124,173 @@ func TestBuildAllowedOperationsEmpty(t *testing.T) {
 	t.Parallel()
 
 	def := testDefinition("bad")
-	_, err := Build(def, config.ConnectionDef{}, map[string]string{})
+	_, err := Build(def, config.ConnectionDef{}, map[string]*OperationOverride{})
 	if err == nil {
 		t.Fatal("expected error for empty allowed_operations")
+	}
+}
+
+func TestBuildWithAlias(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	t.Cleanup(srv.Close)
+
+	def := &Definition{
+		Provider:    "alias_test",
+		DisplayName: "Alias Test",
+		BaseURL:     srv.URL,
+		Auth:        AuthDef{Type: "manual"},
+		Operations: map[string]OperationDef{
+			"op_alpha": {Description: "Alpha op", Method: "GET", Path: "/alpha"},
+			"op_beta":  {Description: "Beta op", Method: "GET", Path: "/beta"},
+		},
+	}
+
+	intg, err := Build(def, config.ConnectionDef{}, map[string]*OperationOverride{
+		"op_alpha": {Alias: "my_alpha"},
+		"op_beta":  nil,
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	ops := intg.ListOperations()
+	if len(ops) != 2 {
+		t.Fatalf("got %d operations, want 2", len(ops))
+	}
+	names := make(map[string]bool, len(ops))
+	for _, op := range ops {
+		names[op.Name] = true
+	}
+	if !names["my_alpha"] {
+		t.Error("expected aliased name my_alpha in ListOperations")
+	}
+	if !names["op_beta"] {
+		t.Error("expected original name op_beta in ListOperations")
+	}
+
+	result, err := intg.Execute(context.Background(), "my_alpha", nil, "tok")
+	if err != nil {
+		t.Fatalf("Execute(my_alpha): %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Errorf("status = %d, want 200", result.Status)
+	}
+
+	_, err = intg.Execute(context.Background(), "op_alpha", nil, "tok")
+	if err == nil {
+		t.Fatal("expected error when calling by original name after aliasing")
+	}
+}
+
+func TestBuildWithAliasAndDescription(t *testing.T) {
+	t.Parallel()
+
+	def := &Definition{
+		Provider:    "alias_desc_test",
+		DisplayName: "Alias Desc Test",
+		BaseURL:     "https://api.example.com",
+		Auth:        AuthDef{Type: "manual"},
+		Operations: map[string]OperationDef{
+			"op_gamma": {Description: "Gamma op", Method: "GET", Path: "/gamma"},
+		},
+	}
+
+	intg, err := Build(def, config.ConnectionDef{}, map[string]*OperationOverride{
+		"op_gamma": {Alias: "renamed_gamma", Description: "Custom gamma description"},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	ops := intg.ListOperations()
+	if len(ops) != 1 {
+		t.Fatalf("got %d operations, want 1", len(ops))
+	}
+	if ops[0].Name != "renamed_gamma" {
+		t.Errorf("operation name = %q, want renamed_gamma", ops[0].Name)
+	}
+	if ops[0].Description != "Custom gamma description" {
+		t.Errorf("description = %q, want custom override", ops[0].Description)
+	}
+
+	cp, ok := intg.(core.CatalogProvider)
+	if !ok {
+		t.Fatal("expected CatalogProvider")
+	}
+	cat := cp.Catalog()
+	if len(cat.Operations) != 1 {
+		t.Fatalf("got %d catalog operations, want 1", len(cat.Operations))
+	}
+	if cat.Operations[0].ID != "renamed_gamma" {
+		t.Errorf("catalog operation ID = %q, want renamed_gamma", cat.Operations[0].ID)
+	}
+	if cat.Operations[0].Description != "Custom gamma description" {
+		t.Errorf("catalog description = %q, want custom override", cat.Operations[0].Description)
+	}
+}
+
+func TestBuildWithNullOverride(t *testing.T) {
+	t.Parallel()
+
+	def := testDefinition("null_override")
+	intg, err := Build(def, testCreds(), map[string]*OperationOverride{
+		"list_items": nil,
+		"get_item":   nil,
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	ops := intg.ListOperations()
+	if len(ops) != 2 {
+		t.Fatalf("got %d operations, want 2", len(ops))
+	}
+	for _, op := range ops {
+		if op.Name != "list_items" && op.Name != "get_item" {
+			t.Errorf("unexpected operation %q", op.Name)
+		}
+	}
+}
+
+func TestBuildWithDescriptionOnly(t *testing.T) {
+	t.Parallel()
+
+	def := testDefinition("desc_only")
+	intg, err := Build(def, testCreds(), map[string]*OperationOverride{
+		"list_items": {Description: "Overridden list description"},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	ops := intg.ListOperations()
+	if len(ops) != 1 {
+		t.Fatalf("got %d operations, want 1", len(ops))
+	}
+	if ops[0].Name != "list_items" {
+		t.Errorf("name = %q, want list_items", ops[0].Name)
+	}
+	if ops[0].Description != "Overridden list description" {
+		t.Errorf("description = %q, want override", ops[0].Description)
+	}
+}
+
+func TestBuildAliasCollision(t *testing.T) {
+	t.Parallel()
+
+	def := testDefinition("collision")
+	_, err := Build(def, testCreds(), map[string]*OperationOverride{
+		"list_items": {Alias: "get_item"},
+		"get_item":   nil,
+	})
+	if err == nil {
+		t.Fatal("expected error for alias collision")
+	}
+	if !strings.Contains(err.Error(), "alias collision") {
+		t.Errorf("error = %q, want alias collision message", err)
 	}
 }
 

--- a/internal/provider/compiler/compiler.go
+++ b/internal/provider/compiler/compiler.go
@@ -32,13 +32,13 @@ func LoadDefinition(ctx context.Context, name string, api config.APIDef, prepare
 	return loadDefinition(ctx, name, api, preparedProviders)
 }
 
-func BuildProvider(ctx context.Context, name string, intg config.IntegrationDef, api config.APIDef, conn config.ConnectionDef, preparedProviders map[string]string, opts ...provider.BuildOption) (core.Provider, error) {
+func BuildProvider(ctx context.Context, name string, intg config.IntegrationDef, api config.APIDef, conn config.ConnectionDef, preparedProviders map[string]string, allowedOps map[string]*provider.OperationOverride, opts ...provider.BuildOption) (core.Provider, error) {
 	def, err := loadDefinition(ctx, name, api, preparedProviders)
 	if err != nil {
 		return nil, err
 	}
 	provider.ApplyDisplayOverrides(def, intg)
-	return provider.Build(def, conn, nil, opts...)
+	return provider.Build(def, conn, allowedOps, opts...)
 }
 
 func loadDefinition(ctx context.Context, name string, api config.APIDef, preparedProviders map[string]string) (*provider.Definition, error) {

--- a/internal/provider/compiler/compiler_test.go
+++ b/internal/provider/compiler/compiler_test.go
@@ -90,7 +90,7 @@ func TestBuildProviderAppliesRuntimeOverrides(t *testing.T) {
 		Type: config.APITypeREST,
 	}, config.ConnectionDef{}, map[string]string{
 		"prepared": preparedPath,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("BuildProvider: %v", err)
 	}


### PR DESCRIPTION
The `allowed_operations` config now accepts an optional map value per
operation with `alias` and `description` fields, letting deployers
rename verbose OpenAPI operationIds (like `calendar.calendarList.list`)
to concise names (like `list_calendars`). Aliases are applied at
provider construction time and work transparently through REST
execution, MCP tool discovery, and the CLI. Collisions where two
operations resolve to the same exposed name are detected and reported
at startup rather than silently dropping operations.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>