### PR TITLE
Add none auth provider for zero-friction local development

### DIFF
--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -14,6 +14,7 @@ import (
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/plugins/auth/google"
 	"github.com/valon-technologies/gestalt/plugins/auth/local"
+	authnone "github.com/valon-technologies/gestalt/plugins/auth/none"
 	"github.com/valon-technologies/gestalt/plugins/auth/oidc"
 	"github.com/valon-technologies/gestalt/plugins/bindings/proxy"
 	"github.com/valon-technologies/gestalt/plugins/bindings/webhook"
@@ -84,6 +85,7 @@ func buildFactories(preparedProviders map[string]string, devMode bool) *bootstra
 	factories := bootstrap.NewFactoryRegistry()
 	factories.Auth["google"] = google.Factory
 	factories.Auth["local"] = local.Factory
+	factories.Auth["none"] = authnone.Factory
 	factories.Auth["oidc"] = oidc.Factory
 	factories.Datastores["sqlite"] = sqlite.Factory
 	factories.Datastores["postgres"] = postgres.Factory

--- a/cmd/gestaltd/localconfig_test.go
+++ b/cmd/gestaltd/localconfig_test.go
@@ -23,8 +23,8 @@ func TestGenerateDefaultConfigProducesValidConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("config.Load on generated config: %v", err)
 	}
-	if cfg.Auth.Provider != "local" {
-		t.Fatalf("auth.provider = %q, want local", cfg.Auth.Provider)
+	if cfg.Auth.Provider != "none" {
+		t.Fatalf("auth.provider = %q, want none", cfg.Auth.Provider)
 	}
 	if cfg.Datastore.Provider != "sqlite" {
 		t.Fatalf("datastore.provider = %q, want sqlite", cfg.Datastore.Provider)

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -25,6 +25,7 @@ type Deps struct {
 	SQLDB         any // *sql.DB when available, nil otherwise
 	SQLDialect    any // Placeholder(int)string when available, nil otherwise
 	Egress        EgressDeps
+	DevMode       bool
 }
 
 type AuthFactory func(node yaml.Node, deps Deps) (core.AuthProvider, error)
@@ -146,6 +147,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		EncryptionKey: crypto.DeriveKey(cfg.Server.EncryptionKey),
 		BaseURL:       cfg.Server.BaseURL,
 		SecretManager: sm,
+		DevMode:       cfg.Server.DevMode,
 	}
 
 	auth, err := buildAuth(cfg, factories, deps)

--- a/internal/bootstrap/validate.go
+++ b/internal/bootstrap/validate.go
@@ -34,6 +34,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 		EncryptionKey: crypto.DeriveKey(cfg.Server.EncryptionKey),
 		BaseURL:       cfg.Server.BaseURL,
 		SecretManager: sm,
+		DevMode:       cfg.Server.DevMode,
 	}
 
 	if _, err := buildAuth(cfg, factories, deps); err != nil {

--- a/internal/operator/localconfig.go
+++ b/internal/operator/localconfig.go
@@ -30,7 +30,7 @@ func GenerateDefaultConfig(configDir string) (string, error) {
 
 	dbPath := filepath.Join(configDir, "gestalt.db")
 	cfg := fmt.Sprintf(`auth:
-  provider: local
+  provider: none
 datastore:
   provider: sqlite
   config:

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -48,6 +48,12 @@ func maxBodyMiddleware(limit int64) func(http.Handler) http.Handler {
 
 func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.noAuth {
+			ctx := principal.WithPrincipal(r.Context(), s.resolver.ResolveEmail("local@gestalt.local"))
+			next.ServeHTTP(w, r.WithContext(ctx))
+			return
+		}
+
 		if s.devMode {
 			if email := r.Header.Get("X-Dev-User-Email"); email != "" {
 				p := s.resolver.ResolveEmail(email)
@@ -57,8 +63,6 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			}
 		}
 
-		// Try the session cookie first, then the Authorization header.
-		// If either yields a valid principal, use it.
 		var p *principal.Principal
 		var lastErr error
 
@@ -97,6 +101,12 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 
 func (s *Server) proxyAuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.noAuth {
+			ctx := principal.WithPrincipal(r.Context(), s.resolver.ResolveEmail("local@gestalt.local"))
+			next.ServeHTTP(w, r.WithContext(ctx))
+			return
+		}
+
 		if s.devMode {
 			if email := r.Header.Get("X-Dev-User-Email"); email != "" {
 				p := s.resolver.ResolveEmail(email)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,6 +30,7 @@ type Server struct {
 	defaultConnection map[string]string
 	integrationDefs   map[string]config.IntegrationDef
 	devMode           bool
+	noAuth            bool
 	stateCodec        *integrationOAuthStateCodec
 	now               func() time.Time
 	readiness         ReadinessChecker
@@ -83,6 +84,7 @@ func New(cfg Config) (*Server, error) {
 		defaultConnection: cfg.DefaultConnection,
 		integrationDefs:   cfg.IntegrationDefs,
 		devMode:           cfg.DevMode,
+		noAuth:            cfg.Auth.Name() == "none" && cfg.DevMode,
 		stateCodec:        stateCodec,
 		now:               now,
 		readiness:         cfg.Readiness,

--- a/plugins/auth/none/none.go
+++ b/plugins/auth/none/none.go
@@ -1,0 +1,35 @@
+package none
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"gopkg.in/yaml.v3"
+)
+
+const providerName = "none"
+
+type Provider struct{}
+
+func (p *Provider) Name() string { return providerName }
+
+func (p *Provider) LoginURL(_ string) (string, error) {
+	return "", fmt.Errorf("none auth provider does not support login")
+}
+
+func (p *Provider) HandleCallback(_ context.Context, _ string) (*core.UserIdentity, error) {
+	return nil, fmt.Errorf("none auth provider does not support callbacks")
+}
+
+func (p *Provider) ValidateToken(_ context.Context, _ string) (*core.UserIdentity, error) {
+	return nil, fmt.Errorf("none auth provider does not validate tokens")
+}
+
+var Factory bootstrap.AuthFactory = func(_ yaml.Node, deps bootstrap.Deps) (core.AuthProvider, error) {
+	if !deps.DevMode {
+		return nil, fmt.Errorf("none auth provider requires server.dev_mode: true")
+	}
+	return &Provider{}, nil
+}

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { fetchAPI, getAuthInfo, startLogin } from "@/lib/api";
 import { isAuthenticated, setUserEmail } from "@/lib/auth";
+import { NONE_PROVIDER, DEFAULT_LOCAL_EMAIL } from "@/lib/constants";
 import Button from "@/components/Button";
 
 export default function LoginPage() {
@@ -19,6 +20,11 @@ export default function LoginPage() {
   useEffect(() => {
     getAuthInfo()
       .then((info) => {
+        if (info.provider === NONE_PROVIDER) {
+          setUserEmail(DEFAULT_LOCAL_EMAIL);
+          window.location.replace("/");
+          return;
+        }
         setAuthConfig({
           label: "Sign in with " + info.display_name,
           devMode: info.dev_mode,

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -1,2 +1,4 @@
 export const LOGIN_PATH = "/login";
 export const HTTP_UNAUTHORIZED = 401;
+export const NONE_PROVIDER = "none";
+export const DEFAULT_LOCAL_EMAIL = "local@gestalt.local";


### PR DESCRIPTION
When running gestaltd locally, the local auth provider still requires
clicking through a login screen. The new none auth provider skips
authentication entirely, injecting a synthetic principal on every
request so the server is immediately usable without any login flow.

The none provider only activates when dev_mode is true, refusing to
start in production. The auto-generated local config now defaults to
auth.provider: none so the out-of-the-box experience is: run gestaltd,
open localhost:8080, start using it. The web UI detects the none
provider via /api/v1/auth/info and auto-authenticates without showing
the login page.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>