### PR TITLE
Add version-tagged Docker images to release pipeline

### DIFF
--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -104,6 +104,33 @@ jobs:
         with:
           files: release/*
 
+  publish-image:
+    name: Publish Docker Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            valontechnologies/gestalt:${{ steps.version.outputs.version }}
+            valontechnologies/gestalt:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+
   update-formula:
     name: Update Homebrew Formula
     needs: release


### PR DESCRIPTION
The release workflow now builds and pushes a Docker image tagged with
the release version (e.g. valontechnologies/gestalt:0.0.1-alpha.6) in
addition to the existing latest tag. This lets users pin to a specific
version rather than always pulling latest.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>