### PR TITLE
Move connection flows into the settings modal

### DIFF
--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -129,6 +129,7 @@ func runServer(env *bootstrapEnv) error {
 		Bindings:          result.Bindings,
 		Invoker:           result.Invoker,
 		DefaultConnection: bootstrap.BuildConnectionMap(env.Config),
+		IntegrationDefs:   env.Config.Integrations,
 		DevMode:           result.DevMode,
 		StateSecret:       crypto.DeriveKey(env.Config.Server.EncryptionKey),
 		Readiness: composeReadiness(

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"sort"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -66,6 +67,11 @@ type instanceInfo struct {
 	Connection string `json:"connection,omitempty"`
 }
 
+type connectionDefInfo struct {
+	Name     string `json:"name"`
+	AuthType string `json:"auth_type"`
+}
+
 type integrationInfo struct {
 	Name             string                         `json:"name"`
 	DisplayName      string                         `json:"display_name,omitempty"`
@@ -75,6 +81,7 @@ type integrationInfo struct {
 	Instances        []instanceInfo                 `json:"instances,omitempty"`
 	AuthTypes        []string                       `json:"auth_types"`
 	ConnectionParams map[string]connectionParamInfo `json:"connection_params,omitempty"`
+	Connections      []connectionDefInfo            `json:"connections,omitempty"`
 }
 
 type connectionParamInfo struct {
@@ -135,6 +142,23 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 			if len(userParams) > 0 {
 				info.ConnectionParams = userParams
 			}
+		}
+		if intg, ok := s.integrationDefs[name]; ok && len(intg.Connections) > 1 {
+			connNames := make([]string, 0, len(intg.Connections))
+			for connName := range intg.Connections {
+				connNames = append(connNames, connName)
+			}
+			sort.Strings(connNames)
+			conns := make([]connectionDefInfo, 0, len(intg.Connections))
+			for _, connName := range connNames {
+				connDef := intg.Connections[connName]
+				authType := "oauth"
+				if connDef.Auth.Type == "manual" || connDef.Auth.Type == "api_key" {
+					authType = "manual"
+				}
+				conns = append(conns, connectionDefInfo{Name: connName, AuthType: authType})
+			}
+			info.Connections = conns
 		}
 		out = append(out, info)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	"github.com/valon-technologies/gestalt/internal/principal"
 	"github.com/valon-technologies/gestalt/internal/registry"
@@ -27,6 +28,7 @@ type Server struct {
 	resolver          *principal.Resolver
 	invoker           invocation.Invoker
 	defaultConnection map[string]string
+	integrationDefs   map[string]config.IntegrationDef
 	devMode           bool
 	stateCodec        *integrationOAuthStateCodec
 	now               func() time.Time
@@ -42,7 +44,8 @@ type Config struct {
 	Runtimes          *registry.PluginMap[core.Runtime]
 	Bindings          *registry.PluginMap[core.Binding]
 	Invoker           invocation.Invoker
-	DefaultConnection map[string]string // integration name -> default connection name
+	DefaultConnection map[string]string
+	IntegrationDefs   map[string]config.IntegrationDef
 	DevMode           bool
 	StateSecret       []byte
 	Now               func() time.Time
@@ -78,6 +81,7 @@ func New(cfg Config) (*Server, error) {
 		resolver:          principal.NewResolver(cfg.Auth, cfg.Datastore),
 		invoker:           cfg.Invoker,
 		defaultConnection: cfg.DefaultConnection,
+		integrationDefs:   cfg.IntegrationDefs,
 		devMode:           cfg.DevMode,
 		stateCodec:        stateCodec,
 		now:               now,

--- a/web/e2e/integrations.spec.ts
+++ b/web/e2e/integrations.spec.ts
@@ -212,11 +212,11 @@ test.describe("Integrations", () => {
 
     await page.goto("/integrations");
     await page.getByRole("button", { name: "Manual Service settings" }).click();
-    await page.getByRole("dialog").getByRole("button", { name: "Connect" }).click();
-    await expect(page.getByRole("dialog")).not.toBeVisible();
-    await expect(page.getByLabel("API Token")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Submit" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Cancel" })).toBeVisible();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByRole("button", { name: "Connect" }).click();
+    await expect(dialog.getByLabel(/API token/i)).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Submit" })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Cancel" })).toBeVisible();
   });
 
   test("manual auth submits credential and refreshes", async ({
@@ -239,9 +239,9 @@ test.describe("Integrations", () => {
 
     await page.goto("/integrations");
     await page.getByRole("button", { name: "Manual Service settings" }).click();
-    await page.getByRole("dialog").getByRole("button", { name: "Connect" }).click();
-    await expect(page.getByRole("dialog")).not.toBeVisible();
-    await page.getByLabel("API Token").fill("test-api-key-123");
+    const dialog = page.getByRole("dialog");
+    await dialog.getByRole("button", { name: "Connect" }).click();
+    await dialog.getByLabel(/API token/i).fill("test-api-key-123");
 
     await page.route("**/api/v1/integrations", (route, request) => {
       if (request.method() === "GET") {
@@ -251,7 +251,7 @@ test.describe("Integrations", () => {
       }
     });
 
-    await page.getByRole("button", { name: "Submit" }).click();
+    await dialog.getByRole("button", { name: "Submit" }).click();
     await expect(page.getByRole("button", { name: "Manual Service settings" })).toBeVisible();
     expect(receivedCredential).toBe("test-api-key-123");
   });
@@ -264,12 +264,11 @@ test.describe("Integrations", () => {
 
     await page.goto("/integrations");
     await page.getByRole("button", { name: "Manual Service settings" }).click();
-    await page.getByRole("dialog").getByRole("button", { name: "Connect" }).click();
-    await expect(page.getByRole("dialog")).not.toBeVisible();
-    await expect(page.getByLabel("API Token")).toBeVisible();
-    await page.getByRole("button", { name: "Cancel" }).click();
-    await expect(page.getByLabel("API Token")).not.toBeVisible();
-    await expect(page.getByRole("button", { name: "Manual Service settings" })).toBeVisible();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByRole("button", { name: "Connect" }).click();
+    await expect(dialog.getByLabel(/API token/i)).toBeVisible();
+    await dialog.getByRole("button", { name: "Cancel" }).click();
+    await expect(dialog.getByText("Not connected")).toBeVisible();
   });
 
   test("manual auth reconnect opens token form via settings modal", async ({
@@ -283,11 +282,9 @@ test.describe("Integrations", () => {
     const dialog = page.getByRole("dialog");
     await expect(dialog.getByText("default")).toBeVisible();
     await dialog.getByRole("button", { name: "Add Connection" }).click();
-    // Modal closes and instance name form appears
-    await expect(page.getByRole("dialog")).not.toBeVisible();
-    await expect(page.getByLabel("Connection name")).toBeVisible();
-    await page.getByLabel("Connection name").fill("second");
-    await page.getByRole("button", { name: "Continue" }).click();
-    await expect(page.getByLabel("API Token")).toBeVisible();
+    await expect(dialog.getByLabel("Connection name")).toBeVisible();
+    await dialog.getByLabel("Connection name").fill("second");
+    await dialog.getByRole("button", { name: "Continue" }).click();
+    await expect(dialog.getByLabel(/API token/i)).toBeVisible();
   });
 });

--- a/web/src/components/IntegrationCard.tsx
+++ b/web/src/components/IntegrationCard.tsx
@@ -67,21 +67,14 @@ export default function IntegrationCard({
   const [disconnecting, setDisconnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [showTokenForm, setShowTokenForm] = useState(false);
   const [showParamForm, setShowParamForm] = useState(false);
-  const [showInstanceForm, setShowInstanceForm] = useState(false);
   const [pendingInstance, setPendingInstance] = useState("");
-  const [pendingAuthMethod, setPendingAuthMethod] = useState<"oauth" | "manual">("oauth");
+  const [pendingConnection, setPendingConnection] = useState<string | undefined>();
   const [submitting, setSubmitting] = useState(false);
 
   const safeIconSVG = integration.icon_svg
     ? sanitizeSVG(integration.icon_svg)
     : "";
-  const authTypes = integration.auth_types ?? ["oauth"];
-  const supportsOAuth = authTypes.includes("oauth");
-  const supportsManual = authTypes.includes("manual");
-  const isDualAuth = supportsOAuth && supportsManual;
-  const isManualOnly = supportsManual && !supportsOAuth;
   const needsParams = hasConnectionParams(integration);
 
   function collectConnectionParams(
@@ -96,24 +89,9 @@ export default function IntegrationCard({
     return params;
   }
 
-  function promptForInstance(method: "oauth" | "manual") {
-    setPendingAuthMethod(method);
-    setSettingsOpen(false);
-    setShowInstanceForm(true);
-    setError(null);
-  }
-
-  function handleConnectManual() {
-    if (integration.connected) {
-      promptForInstance("manual");
-      return;
-    }
-    setSettingsOpen(false);
-    setShowTokenForm(true);
-    setError(null);
-  }
-
-  async function startOAuthFlow(instance?: string) {
+  async function handleStartOAuth(instance?: string, connection?: string) {
+    setPendingInstance(instance || "");
+    setPendingConnection(connection);
     if (needsParams && !showParamForm) {
       setSettingsOpen(false);
       setShowParamForm(true);
@@ -123,7 +101,9 @@ export default function IntegrationCard({
     setLoading(true);
     setError(null);
     try {
-      const { url } = await startIntegrationOAuth(integration.name, undefined, undefined, instance);
+      const { url } = await startIntegrationOAuth(
+        integration.name, undefined, undefined, instance, connection,
+      );
       window.location.href = url;
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to start OAuth");
@@ -132,32 +112,19 @@ export default function IntegrationCard({
     }
   }
 
-  function handleConnectOAuth() {
-    if (integration.connected) {
-      promptForInstance("oauth");
-      return;
-    }
-    startOAuthFlow();
-  }
-
-  function handleConnect() {
-    if (isManualOnly) {
-      handleConnectManual();
-    } else {
-      handleConnectOAuth();
-    }
-  }
-
-  function handleInstanceSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    const name = (new FormData(e.currentTarget).get("instance_name") as string)?.trim();
-    if (!name) return;
-    setPendingInstance(name);
-    setShowInstanceForm(false);
-    if (pendingAuthMethod === "manual") {
-      setShowTokenForm(true);
-    } else {
-      startOAuthFlow(name);
+  async function handleSubmitToken(credential: string, connectionParams?: Record<string, string>, instance?: string, connection?: string) {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await connectManualIntegration(
+        integration.name, credential, connectionParams, instance, connection,
+      );
+      setSettingsOpen(false);
+      onConnected?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to connect");
+    } finally {
+      setSubmitting(false);
     }
   }
 
@@ -172,6 +139,7 @@ export default function IntegrationCard({
         undefined,
         params,
         pendingInstance || undefined,
+        pendingConnection,
       );
       window.location.href = url;
     } catch (err) {
@@ -180,35 +148,10 @@ export default function IntegrationCard({
     }
   }
 
-  async function handleSubmitManual(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    const fd = new FormData(e.currentTarget);
-    const credential = (fd.get("credential") as string)?.trim();
-    if (!credential) return;
-    const params = collectConnectionParams(e.currentTarget);
-    setSubmitting(true);
-    setError(null);
-    try {
-      await connectManualIntegration(
-        integration.name,
-        credential,
-        Object.keys(params).length > 0 ? params : undefined,
-        pendingInstance || undefined,
-      );
-      setShowTokenForm(false);
-      onConnected?.();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to connect");
-    } finally {
-      setSubmitting(false);
-    }
-  }
-
   function handleCancelForm() {
-    setShowTokenForm(false);
     setShowParamForm(false);
-    setShowInstanceForm(false);
     setPendingInstance("");
+    setPendingConnection(undefined);
     setError(null);
   }
 
@@ -295,30 +238,7 @@ export default function IntegrationCard({
       {error && !settingsOpen && (
         <p className="mt-2 text-sm text-ember-500">{error}</p>
       )}
-      {showInstanceForm && (
-        <form onSubmit={handleInstanceSubmit} className="mt-3">
-          <label
-            htmlFor={`instance-name-${integration.name}`}
-            className="block text-sm font-medium text-stone-700"
-          >
-            Connection name
-          </label>
-          <input
-            id={`instance-name-${integration.name}`}
-            name="instance_name"
-            type="text"
-            required
-            placeholder="e.g. my-store, acme-workspace"
-            autoFocus
-            className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
-          />
-          <div className="mt-2 flex gap-2">
-            <Button type="submit">Continue</Button>
-            <Button type="button" variant="secondary" onClick={handleCancelForm}>Cancel</Button>
-          </div>
-        </form>
-      )}
-      {showParamForm && !isManualOnly && (
+      {showParamForm && (
         <form onSubmit={handleParamSubmit} className="mt-3">
           {renderConnectionParamFields()}
           <div className="mt-3 flex gap-2">
@@ -336,48 +256,16 @@ export default function IntegrationCard({
           </div>
         </form>
       )}
-      {showTokenForm && (
-        <form onSubmit={handleSubmitManual} className="mt-3">
-          {needsParams && renderConnectionParamFields()}
-          <label
-            htmlFor={`credential-${integration.name}`}
-            className="mt-2 block text-sm font-medium text-stone-700"
-          >
-            API Token
-          </label>
-          <input
-            id={`credential-${integration.name}`}
-            name="credential"
-            type="password"
-            required
-            placeholder="Paste your API token"
-            autoFocus={!needsParams}
-            className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
-          />
-          <div className="mt-2 flex gap-2">
-            <Button type="submit" disabled={submitting}>
-              {submitting ? "Connecting..." : "Submit"}
-            </Button>
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={handleCancelForm}
-              disabled={submitting}
-            >
-              Cancel
-            </Button>
-          </div>
-        </form>
-      )}
       {settingsOpen && (
         <IntegrationSettingsModal
           integration={integration}
           onClose={handleSettingsClose}
-          onReconnect={isDualAuth ? handleConnectOAuth : handleConnect}
-          onReconnectManual={isDualAuth ? handleConnectManual : undefined}
+          onStartOAuth={handleStartOAuth}
+          onSubmitToken={handleSubmitToken}
           onDisconnect={handleDisconnect}
           reconnecting={loading}
           disconnecting={disconnecting}
+          submitting={submitting}
           error={error}
         />
       )}

--- a/web/src/components/IntegrationSettingsModal.tsx
+++ b/web/src/components/IntegrationSettingsModal.tsx
@@ -5,30 +5,37 @@ import { Integration } from "@/lib/api";
 import Button from "./Button";
 import { CheckCircleIcon, CloseIcon } from "./icons";
 
+type ModalView = "default" | "disconnect" | "instance" | "token";
+
 interface IntegrationSettingsModalProps {
   integration: Integration;
   onClose: () => void;
-  onReconnect: () => void;
-  onReconnectManual?: () => void;
+  onStartOAuth: (instance?: string, connection?: string) => void;
+  onSubmitToken: (credential: string, connectionParams?: Record<string, string>, instance?: string, connection?: string) => void;
   onDisconnect: (instance?: string) => void;
   reconnecting: boolean;
   disconnecting: boolean;
+  submitting: boolean;
   error: string | null;
 }
 
 export default function IntegrationSettingsModal({
   integration,
   onClose,
-  onReconnect,
-  onReconnectManual,
+  onStartOAuth,
+  onSubmitToken,
   onDisconnect,
   reconnecting,
   disconnecting,
+  submitting,
   error,
 }: IntegrationSettingsModalProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
-  const [confirmingDisconnect, setConfirmingDisconnect] = useState(false);
+  const [view, setView] = useState<ModalView>("default");
   const [disconnectInstance, setDisconnectInstance] = useState<string | undefined>();
+  const [pendingConnection, setPendingConnection] = useState<string | undefined>();
+  const [pendingAuthType, setPendingAuthType] = useState<"oauth" | "manual">("oauth");
+  const [pendingInstance, setPendingInstance] = useState<string | undefined>();
 
   useEffect(() => {
     dialogRef.current?.showModal();
@@ -36,21 +43,134 @@ export default function IntegrationSettingsModal({
 
   const displayName = integration.display_name || integration.name;
   const headingId = `settings-modal-heading-${integration.name}`;
+  const authTypes = integration.auth_types ?? ["oauth"];
+  const supportsOAuth = authTypes.includes("oauth");
+  const supportsManual = authTypes.includes("manual");
+  const isDualAuth = supportsOAuth && supportsManual;
+  const isManualOnly = supportsManual && !supportsOAuth;
+  const hasMultipleConnections = (integration.connections?.length ?? 0) > 1;
+  const needsParams = integration.connection_params && Object.keys(integration.connection_params).length > 0;
 
   function handleCancel(e: React.SyntheticEvent<HTMLDialogElement>) {
-    if (disconnecting) {
+    if (disconnecting || submitting) {
       e.preventDefault();
     }
   }
 
   function handleBackdropClick(e: React.MouseEvent<HTMLDialogElement>) {
-    if (e.target === e.currentTarget && !disconnecting) {
+    if (e.target === e.currentTarget && !disconnecting && !submitting) {
       e.currentTarget.close();
     }
   }
 
   function closeDialog() {
     dialogRef.current?.close();
+  }
+
+  function startAddConnection(authType: "oauth" | "manual", connection?: string) {
+    setPendingConnection(connection);
+    setPendingAuthType(authType);
+    if (integration.connected) {
+      setView("instance");
+    } else if (authType === "manual") {
+      setView("token");
+    } else {
+      onStartOAuth(undefined, connection);
+    }
+  }
+
+  function handleInstanceSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const name = (new FormData(e.currentTarget).get("instance_name") as string)?.trim();
+    if (!name) return;
+    setPendingInstance(name);
+    if (pendingAuthType === "manual") {
+      setView("token");
+    } else {
+      onStartOAuth(name, pendingConnection);
+    }
+  }
+
+  function handleTokenSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const credential = (fd.get("credential") as string)?.trim();
+    if (!credential) return;
+    let params: Record<string, string> | undefined;
+    if (integration.connection_params) {
+      const collected: Record<string, string> = {};
+      for (const name of Object.keys(integration.connection_params)) {
+        const val = (fd.get(`cp_${name}`) as string)?.trim();
+        if (val) collected[name] = val;
+      }
+      if (Object.keys(collected).length > 0) params = collected;
+    }
+    onSubmitToken(credential, params, pendingInstance, pendingConnection);
+  }
+
+  function renderConnectionButtons() {
+    if (hasMultipleConnections) {
+      return (
+        <div className="mt-6 flex flex-col gap-2">
+          {integration.connections!.map((conn) => (
+            <Button
+              key={conn.name}
+              className="w-full"
+              onClick={() => startAddConnection(conn.auth_type, conn.name)}
+              disabled={reconnecting || submitting}
+            >
+              {integration.connected ? `Add ${conn.name}` : `Connect with ${conn.name}`}
+            </Button>
+          ))}
+        </div>
+      );
+    }
+
+    if (integration.connected) {
+      return (
+        <div className="mt-6 flex flex-col gap-2">
+          <Button
+            className="w-full"
+            onClick={() => startAddConnection(isDualAuth ? "oauth" : isManualOnly ? "manual" : "oauth")}
+            disabled={reconnecting || submitting}
+          >
+            {reconnecting ? "Connecting..." : "Add Connection"}
+          </Button>
+          {isDualAuth && (
+            <Button
+              variant="secondary"
+              className="w-full"
+              onClick={() => startAddConnection("manual")}
+              disabled={reconnecting || submitting}
+            >
+              Add with API Token
+            </Button>
+          )}
+        </div>
+      );
+    }
+
+    return (
+      <div className="mt-6 flex flex-col gap-2">
+        <Button
+          className="w-full"
+          onClick={() => startAddConnection(isManualOnly ? "manual" : "oauth")}
+          disabled={reconnecting || submitting}
+        >
+          {reconnecting ? "Connecting..." : isDualAuth ? "Connect with OAuth" : "Connect"}
+        </Button>
+        {isDualAuth && (
+          <Button
+            variant="secondary"
+            className="w-full"
+            onClick={() => startAddConnection("manual")}
+            disabled={reconnecting || submitting}
+          >
+            Use API Token
+          </Button>
+        )}
+      </div>
+    );
   }
 
   return (
@@ -63,7 +183,7 @@ export default function IntegrationSettingsModal({
       className="m-auto w-full max-w-sm rounded-lg border border-border bg-surface p-0 shadow-warm"
     >
       <div className="p-6">
-        {confirmingDisconnect ? (
+        {view === "disconnect" ? (
           <>
             <h2
               id={headingId}
@@ -80,7 +200,7 @@ export default function IntegrationSettingsModal({
               <Button
                 variant="secondary"
                 className="flex-1"
-                onClick={() => { setConfirmingDisconnect(false); setDisconnectInstance(undefined); }}
+                onClick={() => { setView("default"); setDisconnectInstance(undefined); }}
                 disabled={disconnecting}
               >
                 Cancel
@@ -95,6 +215,102 @@ export default function IntegrationSettingsModal({
               </Button>
             </div>
           </>
+        ) : view === "instance" ? (
+          <form onSubmit={handleInstanceSubmit}>
+            <h2
+              id={headingId}
+              className="text-lg font-heading font-semibold text-stone-900"
+            >
+              Add Connection
+            </h2>
+            {error && <p className="mt-3 text-sm text-ember-500">{error}</p>}
+            <label
+              htmlFor={`instance-name-${integration.name}`}
+              className="mt-4 block text-sm font-medium text-stone-700"
+            >
+              Connection name
+            </label>
+            <input
+              id={`instance-name-${integration.name}`}
+              name="instance_name"
+              type="text"
+              required
+              placeholder="e.g. my-store, acme-workspace"
+              autoFocus
+              className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
+            />
+            <div className="mt-6 flex gap-3">
+              <Button
+                type="button"
+                variant="secondary"
+                className="flex-1"
+                onClick={() => setView("default")}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" className="flex-1">
+                Continue
+              </Button>
+            </div>
+          </form>
+        ) : view === "token" ? (
+          <form onSubmit={handleTokenSubmit}>
+            <h2
+              id={headingId}
+              className="text-lg font-heading font-semibold text-stone-900"
+            >
+              API Token
+            </h2>
+            {needsParams && integration.connection_params && Object.entries(integration.connection_params).map(([name, def]) => (
+              <div key={name} className="mt-2">
+                <label
+                  htmlFor={`cp_${name}-${integration.name}`}
+                  className="block text-sm font-medium text-stone-700"
+                >
+                  {def.description || name}
+                </label>
+                <input
+                  id={`cp_${name}-${integration.name}`}
+                  name={`cp_${name}`}
+                  type="text"
+                  required={def.required}
+                  defaultValue={def.default}
+                  placeholder={name}
+                  className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
+                />
+              </div>
+            ))}
+            <label
+              htmlFor={`credential-${integration.name}`}
+              className="mt-4 block text-sm font-medium text-stone-700"
+            >
+              Paste your API token
+            </label>
+            <input
+              id={`credential-${integration.name}`}
+              name="credential"
+              type="password"
+              required
+              placeholder="Paste your API token"
+              autoFocus
+              className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
+            />
+            {error && <p className="mt-3 text-sm text-ember-500">{error}</p>}
+            <div className="mt-6 flex gap-3">
+              <Button
+                type="button"
+                variant="secondary"
+                className="flex-1"
+                onClick={() => setView(integration.connected ? "instance" : "default")}
+                disabled={submitting}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" className="flex-1" disabled={submitting}>
+                {submitting ? "Connecting..." : "Submit"}
+              </Button>
+            </div>
+          </form>
         ) : (
           <>
             <div className="flex items-start justify-between">
@@ -124,7 +340,7 @@ export default function IntegrationSettingsModal({
                           <span className="text-sm text-stone-700">{inst.name}</span>
                         </div>
                         <button
-                          onClick={() => { setDisconnectInstance(inst.name); setConfirmingDisconnect(true); }}
+                          onClick={() => { setDisconnectInstance(inst.name); setView("disconnect"); }}
                           disabled={disconnecting}
                           className="text-xs text-ember-500 hover:text-ember-600"
                         >
@@ -136,52 +352,13 @@ export default function IntegrationSettingsModal({
                 )}
 
                 {error && <p className="mt-3 text-sm text-ember-500">{error}</p>}
-
-                <div className="mt-6 flex flex-col gap-2">
-                  <Button
-                    className="w-full"
-                    onClick={onReconnect}
-                    disabled={reconnecting}
-                  >
-                    {reconnecting ? "Connecting..." : "Add Connection"}
-                  </Button>
-                  {onReconnectManual && (
-                    <Button
-                      variant="secondary"
-                      className="w-full"
-                      onClick={onReconnectManual}
-                      disabled={reconnecting}
-                    >
-                      Add with API Token
-                    </Button>
-                  )}
-                </div>
+                {renderConnectionButtons()}
               </>
             ) : (
               <>
                 <p className="mt-4 text-sm text-stone-500">Not connected</p>
-
                 {error && <p className="mt-3 text-sm text-ember-500">{error}</p>}
-
-                <div className="mt-6 flex flex-col gap-2">
-                  <Button
-                    className="w-full"
-                    onClick={onReconnect}
-                    disabled={reconnecting}
-                  >
-                    {reconnecting ? "Connecting..." : onReconnectManual ? "Connect with OAuth" : "Connect"}
-                  </Button>
-                  {onReconnectManual && (
-                    <Button
-                      variant="secondary"
-                      className="w-full"
-                      onClick={onReconnectManual}
-                      disabled={reconnecting}
-                    >
-                      Use API Token
-                    </Button>
-                  )}
-                </div>
+                {renderConnectionButtons()}
               </>
             )}
           </>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -9,6 +9,12 @@ export interface ConnectionParamDef {
 
 export interface InstanceInfo {
   name: string;
+  connection?: string;
+}
+
+export interface ConnectionDefInfo {
+  name: string;
+  auth_type: "oauth" | "manual";
 }
 
 export interface Integration {
@@ -20,6 +26,7 @@ export interface Integration {
   instances?: InstanceInfo[];
   auth_types?: ("oauth" | "manual")[];
   connection_params?: Record<string, ConnectionParamDef>;
+  connections?: ConnectionDefInfo[];
 }
 
 export interface APIToken {
@@ -123,12 +130,14 @@ export async function startIntegrationOAuth(
   scopes?: string[],
   connectionParams?: Record<string, string>,
   instance?: string,
+  connection?: string,
 ): Promise<{ url: string; state: string }> {
   return fetchAPI("/api/v1/auth/start-oauth", {
     method: "POST",
     body: JSON.stringify({
       integration,
       instance,
+      connection,
       scopes: scopes || [],
       connection_params: connectionParams,
     }),
@@ -140,12 +149,14 @@ export async function connectManualIntegration(
   credential: string,
   connectionParams?: Record<string, string>,
   instance?: string,
+  connection?: string,
 ): Promise<{ status: string }> {
   return fetchAPI("/api/v1/auth/connect-manual", {
     method: "POST",
     body: JSON.stringify({
       integration,
       instance,
+      connection,
       credential,
       connection_params: connectionParams,
     }),


### PR DESCRIPTION
The connection name input and API token input now render inside the settings modal instead of closing the modal and falling back to inline forms on the card. When an integration defines multiple connections in its config, the modal shows a "Connect with {name}" button for each one; single-connection integrations keep the generic "Connect" and "Add Connection" buttons.

The integrations API response now includes connection definitions (name and auth type) for multi-connection integrations, and the `startIntegrationOAuth` and `connectManualIntegration` endpoints accept an optional `connection` parameter to target a specific one.