### PR TITLE
Add `allowed_operations` to V0 config format

### DIFF
--- a/cmd/gestaltd/provider_factory.go
+++ b/cmd/gestaltd/provider_factory.go
@@ -84,7 +84,7 @@ func (a *providerAssembly) build() (_ core.Provider, err error) {
 			buildOpts = append(buildOpts, provider.WithAuthHandler(buildMCPOAuthHandler(conn, mcpURL, a.regStore, a.deps)))
 		}
 
-		p, err := providercompiler.BuildProvider(a.ctx, a.name, a.intg, *a.intg.API, conn, a.preparedProviders, nil, buildOpts...)
+		p, err := providercompiler.BuildProvider(a.ctx, a.name, a.intg, *a.intg.API, conn, a.preparedProviders, a.intg.API.AllowedOperations, buildOpts...)
 		if err != nil {
 			return nil, err
 		}
@@ -96,6 +96,11 @@ func (a *providerAssembly) build() (_ core.Provider, err error) {
 		up, err := mcpupstream.New(a.ctx, a.name, a.intg.MCP.URL, connMode, a.deps.Egress.Resolver)
 		if err != nil {
 			return nil, err
+		}
+		if a.intg.MCP.AllowedOperations != nil {
+			if err := up.FilterOperations(a.intg.MCP.AllowedOperations); err != nil {
+				return nil, fmt.Errorf("integration %q mcp: %w", a.name, err)
+			}
 		}
 		a.mcpUp = up
 		a.mcpConn = &conn

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -168,16 +168,24 @@ func ConnectionMode(connections map[string]ConnectionDef) string {
 	return "user"
 }
 
+// OperationOverride holds optional alias and description for an allowed operation.
+type OperationOverride struct {
+	Alias       string `yaml:"alias" json:"alias,omitempty"`
+	Description string `yaml:"description" json:"description,omitempty"`
+}
+
 type APIDef struct {
-	Type       string `yaml:"type"`
-	OpenAPI    string `yaml:"openapi"`
-	URL        string `yaml:"url"`
-	Connection string `yaml:"connection"`
+	Type              string                        `yaml:"type"`
+	OpenAPI           string                        `yaml:"openapi"`
+	URL               string                        `yaml:"url"`
+	Connection        string                        `yaml:"connection"`
+	AllowedOperations map[string]*OperationOverride `yaml:"allowed_operations"`
 }
 
 type MCPDef struct {
-	URL        string `yaml:"url"`
-	Connection string `yaml:"connection"`
+	URL               string                        `yaml:"url"`
+	Connection        string                        `yaml:"connection"`
+	AllowedOperations map[string]*OperationOverride `yaml:"allowed_operations"`
 }
 
 func Load(path string) (*Config, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1131,3 +1131,97 @@ func TestLoadErrors(t *testing.T) {
 		}
 	})
 }
+
+func TestAllowedOperations(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+integrations:
+  service-a:
+    connections:
+      default:
+        mode: user
+        auth:
+          type: oauth2
+          authorization_url: https://example.test/auth
+          token_url: https://example.test/token
+    api:
+      type: rest
+      openapi: https://example.test/spec.json
+      connection: default
+      allowed_operations:
+        list_records:
+          alias: fetch_records
+          description: Retrieve all records
+        get_record:
+        delete_record:
+          alias: remove_record
+    mcp:
+      url: https://example.test/mcp
+      connection: default
+      allowed_operations:
+        run_query:
+          alias: execute_query
+          description: Run a database query
+        list_tables:
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	api := cfg.Integrations["service-a"].API
+	if api.AllowedOperations == nil {
+		t.Fatal("API.AllowedOperations is nil")
+	}
+	if len(api.AllowedOperations) != 3 {
+		t.Fatalf("API.AllowedOperations length = %d, want 3", len(api.AllowedOperations))
+	}
+
+	listOp := api.AllowedOperations["list_records"]
+	if listOp == nil {
+		t.Fatal("list_records override is nil")
+	}
+	if listOp.Alias != "fetch_records" {
+		t.Errorf("list_records alias = %q, want fetch_records", listOp.Alias)
+	}
+	if listOp.Description != "Retrieve all records" {
+		t.Errorf("list_records description = %q", listOp.Description)
+	}
+
+	if api.AllowedOperations["get_record"] != nil {
+		t.Error("get_record override should be nil for bare key")
+	}
+
+	deleteOp := api.AllowedOperations["delete_record"]
+	if deleteOp == nil {
+		t.Fatal("delete_record override is nil")
+	}
+	if deleteOp.Alias != "remove_record" {
+		t.Errorf("delete_record alias = %q, want remove_record", deleteOp.Alias)
+	}
+
+	mcp := cfg.Integrations["service-a"].MCP
+	if mcp.AllowedOperations == nil {
+		t.Fatal("MCP.AllowedOperations is nil")
+	}
+	if len(mcp.AllowedOperations) != 2 {
+		t.Fatalf("MCP.AllowedOperations length = %d, want 2", len(mcp.AllowedOperations))
+	}
+
+	runOp := mcp.AllowedOperations["run_query"]
+	if runOp == nil {
+		t.Fatal("run_query override is nil")
+	}
+	if runOp.Alias != "execute_query" {
+		t.Errorf("run_query alias = %q, want execute_query", runOp.Alias)
+	}
+	if runOp.Description != "Run a database query" {
+		t.Errorf("run_query description = %q", runOp.Description)
+	}
+
+	if mcp.AllowedOperations["list_tables"] != nil {
+		t.Error("list_tables override should be nil for bare key")
+	}
+}

--- a/internal/graphql/loader.go
+++ b/internal/graphql/loader.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/provider"
 )
 
-func LoadDefinition(ctx context.Context, name, endpoint string, allowedOps map[string]*provider.OperationOverride) (*provider.Definition, error) {
+func LoadDefinition(ctx context.Context, name, endpoint string, allowedOps map[string]*config.OperationOverride) (*provider.Definition, error) {
 	schema, err := introspect(ctx, endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("introspecting %s: %w", endpoint, err)
@@ -30,7 +31,7 @@ func LoadDefinition(ctx context.Context, name, endpoint string, allowedOps map[s
 	return def, nil
 }
 
-func addOperations(schema *Schema, def *provider.Definition, root *TypeName, isMutation bool, allowedOps map[string]*provider.OperationOverride) {
+func addOperations(schema *Schema, def *provider.Definition, root *TypeName, isMutation bool, allowedOps map[string]*config.OperationOverride) {
 	if root == nil {
 		return
 	}

--- a/internal/graphql/loader_test.go
+++ b/internal/graphql/loader_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/valon-technologies/gestalt/internal/provider"
+	"github.com/valon-technologies/gestalt/internal/config"
 )
 
 func strPtr(s string) *string { return &s }
@@ -148,7 +148,7 @@ func TestLoadDefinitionWithAllowedOps(t *testing.T) {
 	srv := startIntrospectionServer(t, newTestSchema())
 	defer srv.Close()
 
-	def, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*provider.OperationOverride{
+	def, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*config.OperationOverride{
 		"teams": {Description: "My custom description"},
 	})
 	if err != nil {

--- a/internal/mcpupstream/upstream.go
+++ b/internal/mcpupstream/upstream.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
+	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/egress"
-	"github.com/valon-technologies/gestalt/internal/provider"
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
@@ -37,7 +37,7 @@ type Upstream struct {
 	cat         *catalog.Catalog
 	ops         []core.Operation
 	client      mcpclient.MCPClient
-	allowed     map[string]*provider.OperationOverride
+	allowed     map[string]*config.OperationOverride
 	aliasToOrig map[string]string
 	resolver    *egress.Resolver
 }
@@ -121,12 +121,12 @@ func (u *Upstream) Close() error {
 	return u.client.Close()
 }
 
-func (u *Upstream) FilterOperations(allowed map[string]*provider.OperationOverride) error {
+func (u *Upstream) FilterOperations(allowed map[string]*config.OperationOverride) error {
 	if len(allowed) == 0 {
 		return fmt.Errorf("allowed_operations cannot be empty; omit the field to allow all")
 	}
 
-	u.allowed = make(map[string]*provider.OperationOverride, len(allowed))
+	u.allowed = make(map[string]*config.OperationOverride, len(allowed))
 	u.aliasToOrig = make(map[string]string)
 	exposedNames := make(map[string]string, len(allowed))
 	var collisions []string
@@ -275,7 +275,7 @@ func buildCatalog(name string, tools []mcpgo.Tool) (*catalog.Catalog, []core.Ope
 	return cat, ops
 }
 
-func filterDiscovered(cat *catalog.Catalog, ops *[]core.Operation, allowed map[string]*provider.OperationOverride) error {
+func filterDiscovered(cat *catalog.Catalog, ops *[]core.Operation, allowed map[string]*config.OperationOverride) error {
 	if len(allowed) == 0 {
 		return nil
 	}

--- a/internal/mcpupstream/upstream_test.go
+++ b/internal/mcpupstream/upstream_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 
 	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/egress"
 	"github.com/valon-technologies/gestalt/internal/egress/egresstest"
-	"github.com/valon-technologies/gestalt/internal/provider"
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -166,7 +166,7 @@ func TestUpstream_FilterOperations(t *testing.T) {
 	u := newTestUpstream(t)
 	t.Cleanup(func() { _ = u.Close() })
 
-	err := u.FilterOperations(map[string]*provider.OperationOverride{"run_query": nil})
+	err := u.FilterOperations(map[string]*config.OperationOverride{"run_query": nil})
 	if err != nil {
 		t.Fatalf("FilterOperations: %v", err)
 	}
@@ -197,7 +197,7 @@ func TestUpstream_FilterOperationsWithOverride(t *testing.T) {
 	u := newTestUpstream(t)
 	t.Cleanup(func() { _ = u.Close() })
 
-	err := u.FilterOperations(map[string]*provider.OperationOverride{
+	err := u.FilterOperations(map[string]*config.OperationOverride{
 		"run_query":      {Description: "Custom query description"},
 		"list_databases": nil,
 	})
@@ -230,7 +230,7 @@ func TestUpstream_FilterOperationsUnknown(t *testing.T) {
 	u := newTestUpstream(t)
 	t.Cleanup(func() { _ = u.Close() })
 
-	err := u.FilterOperations(map[string]*provider.OperationOverride{"nonexistent": nil})
+	err := u.FilterOperations(map[string]*config.OperationOverride{"nonexistent": nil})
 	if err == nil {
 		t.Fatal("expected error for unknown operation")
 	}
@@ -242,7 +242,7 @@ func TestUpstream_FilterOperationsEmpty(t *testing.T) {
 	u := newTestUpstream(t)
 	t.Cleanup(func() { _ = u.Close() })
 
-	err := u.FilterOperations(map[string]*provider.OperationOverride{})
+	err := u.FilterOperations(map[string]*config.OperationOverride{})
 	if err == nil {
 		t.Fatal("expected error for empty allowed_operations")
 	}
@@ -254,7 +254,7 @@ func TestUpstream_DiscoverAfterFilterWithAlias(t *testing.T) {
 	u := newTestUpstream(t)
 	t.Cleanup(func() { _ = u.Close() })
 
-	err := u.FilterOperations(map[string]*provider.OperationOverride{
+	err := u.FilterOperations(map[string]*config.OperationOverride{
 		"run_query": {Alias: "query"},
 	})
 	if err != nil {

--- a/internal/openapi/catalog.go
+++ b/internal/openapi/catalog.go
@@ -10,7 +10,7 @@ import (
 	v3high "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/valon-technologies/gestalt/core/catalog"
 	coreintegration "github.com/valon-technologies/gestalt/core/integration"
-	"github.com/valon-technologies/gestalt/internal/provider"
+	"github.com/valon-technologies/gestalt/internal/config"
 
 	"github.com/pb33f/libopenapi"
 )
@@ -21,7 +21,7 @@ const (
 
 // LoadCatalog produces a *Catalog directly from an OpenAPI spec, preserving
 // nested JSON Schema for request bodies instead of flattening to parameters.
-func LoadCatalog(ctx context.Context, name, specURL string, allowedOps map[string]*provider.OperationOverride) (*catalog.Catalog, error) {
+func LoadCatalog(ctx context.Context, name, specURL string, allowedOps map[string]*config.OperationOverride) (*catalog.Catalog, error) {
 	body, err := fetch(ctx, specURL)
 	if err != nil {
 		return nil, fmt.Errorf("fetching %s: %w", specURL, err)
@@ -87,7 +87,7 @@ func catalogExtractAuth(model *v3high.Document, cat *catalog.Catalog) {
 	}
 }
 
-func catalogExtractOperations(model *v3high.Document, cat *catalog.Catalog, allowedOps map[string]*provider.OperationOverride) {
+func catalogExtractOperations(model *v3high.Document, cat *catalog.Catalog, allowedOps map[string]*config.OperationOverride) {
 	if model.Paths == nil || model.Paths.PathItems == nil {
 		return
 	}

--- a/internal/openapi/catalog_test.go
+++ b/internal/openapi/catalog_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/valon-technologies/gestalt/internal/provider"
+	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/testutil"
 )
 
@@ -200,7 +200,7 @@ func TestLoadCatalogAllowedOpsFiltering(t *testing.T) {
 	srv := serveJSON(t, nestedBodySpec())
 	testutil.CloseOnCleanup(t, srv)
 
-	allowed := map[string]*provider.OperationOverride{
+	allowed := map[string]*config.OperationOverride{
 		"list_items":  {Description: "Custom list description"},
 		"create_item": nil,
 	}

--- a/internal/openapi/loader.go
+++ b/internal/openapi/loader.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pb33f/libopenapi/datamodel/high/base"
 	v3high "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/pb33f/libopenapi/orderedmap"
+	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/provider"
 )
 
@@ -21,7 +22,7 @@ const maxSpecSize = 100 << 20 // 100 MB
 
 var defaultClient = &http.Client{Timeout: 30 * time.Second}
 
-func LoadDefinition(ctx context.Context, name, specURL string, allowedOps map[string]*provider.OperationOverride) (*provider.Definition, error) {
+func LoadDefinition(ctx context.Context, name, specURL string, allowedOps map[string]*config.OperationOverride) (*provider.Definition, error) {
 	body, err := fetch(ctx, specURL)
 	if err != nil {
 		return nil, fmt.Errorf("fetching %s: %w", specURL, err)
@@ -160,7 +161,7 @@ func extractScopes(scopes *orderedmap.Map[string, string]) []string {
 	return result
 }
 
-func collectOperationScopes(model *v3high.Document, allowedOps map[string]*provider.OperationOverride) []string {
+func collectOperationScopes(model *v3high.Document, allowedOps map[string]*config.OperationOverride) []string {
 	seen := make(map[string]struct{})
 	collect := func(reqs []*base.SecurityRequirement) {
 		for _, req := range reqs {
@@ -203,7 +204,7 @@ func collectOperationScopes(model *v3high.Document, allowedOps map[string]*provi
 	return result
 }
 
-func extractOperations(model *v3high.Document, def *provider.Definition, allowedOps map[string]*provider.OperationOverride) {
+func extractOperations(model *v3high.Document, def *provider.Definition, allowedOps map[string]*config.OperationOverride) {
 	def.Operations = make(map[string]provider.OperationDef)
 
 	if model.Paths == nil || model.Paths.PathItems == nil {

--- a/internal/openapi/loader_test.go
+++ b/internal/openapi/loader_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/valon-technologies/gestalt/internal/provider"
+	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/testutil"
 )
 
@@ -79,7 +79,7 @@ func TestLoadDefinition(t *testing.T) {
 	srv := serveJSON(t, testSpec())
 	testutil.CloseOnCleanup(t, srv)
 
-	allowed := map[string]*provider.OperationOverride{
+	allowed := map[string]*config.OperationOverride{
 		"list_items": {Description: "List items with pagination"},
 		"get_item":   nil,
 	}
@@ -136,7 +136,7 @@ func TestLoadDefinitionFiltersOperations(t *testing.T) {
 	srv := serveJSON(t, spec)
 	testutil.CloseOnCleanup(t, srv)
 
-	def, err := LoadDefinition(context.Background(), "test", srv.URL, map[string]*provider.OperationOverride{"op_a": nil, "op_c": nil})
+	def, err := LoadDefinition(context.Background(), "test", srv.URL, map[string]*config.OperationOverride{"op_a": nil, "op_c": nil})
 	if err != nil {
 		t.Fatalf("LoadDefinition: %v", err)
 	}
@@ -329,7 +329,7 @@ func TestCollectScopesRespectsAllowedOps(t *testing.T) {
 	srv := serveJSON(t, spec)
 	testutil.CloseOnCleanup(t, srv)
 
-	def, err := LoadDefinition(context.Background(), "test", srv.URL, map[string]*provider.OperationOverride{"read_op": nil})
+	def, err := LoadDefinition(context.Background(), "test", srv.URL, map[string]*config.OperationOverride{"read_op": nil})
 	if err != nil {
 		t.Fatalf("LoadDefinition: %v", err)
 	}

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -17,12 +17,6 @@ import (
 	"github.com/valon-technologies/gestalt/internal/oauth"
 )
 
-// OperationOverride holds optional alias and description for an allowed operation.
-type OperationOverride struct {
-	Alias       string `yaml:"alias" json:"alias,omitempty"`
-	Description string `yaml:"description" json:"description,omitempty"`
-}
-
 // BuildOption configures optional aspects of provider construction.
 type BuildOption func(*buildOptions)
 
@@ -44,7 +38,7 @@ func WithEgressResolver(r *egress.Resolver) BuildOption {
 // owns auth configuration. Display metadata (display_name, description, icon)
 // should be applied to the Definition before calling Build via
 // ApplyDisplayOverrides.
-func Build(def *Definition, conn config.ConnectionDef, allowedOperations map[string]*OperationOverride, opts ...BuildOption) (core.Provider, error) {
+func Build(def *Definition, conn config.ConnectionDef, allowedOperations map[string]*config.OperationOverride, opts ...BuildOption) (core.Provider, error) {
 	var bo buildOptions
 	for _, opt := range opts {
 		opt(&bo)

--- a/internal/provider/build_test.go
+++ b/internal/provider/build_test.go
@@ -101,7 +101,7 @@ func TestBuildAllowedOperations(t *testing.T) {
 		ClientID:     "test",
 		ClientSecret: "test",
 		RedirectURL:  "http://localhost/callback",
-	}}, map[string]*OperationOverride{"list_items": nil})
+	}}, map[string]*config.OperationOverride{"list_items": nil})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestBuildAllowedOperationsUnknown(t *testing.T) {
 	t.Parallel()
 
 	def := testDefinition("bad")
-	_, err := Build(def, config.ConnectionDef{}, map[string]*OperationOverride{"nonexistent": nil})
+	_, err := Build(def, config.ConnectionDef{}, map[string]*config.OperationOverride{"nonexistent": nil})
 	if err == nil {
 		t.Fatal("expected error for unknown allowed operation")
 	}
@@ -124,7 +124,7 @@ func TestBuildAllowedOperationsEmpty(t *testing.T) {
 	t.Parallel()
 
 	def := testDefinition("bad")
-	_, err := Build(def, config.ConnectionDef{}, map[string]*OperationOverride{})
+	_, err := Build(def, config.ConnectionDef{}, map[string]*config.OperationOverride{})
 	if err == nil {
 		t.Fatal("expected error for empty allowed_operations")
 	}
@@ -150,7 +150,7 @@ func TestBuildWithAlias(t *testing.T) {
 		},
 	}
 
-	intg, err := Build(def, config.ConnectionDef{}, map[string]*OperationOverride{
+	intg, err := Build(def, config.ConnectionDef{}, map[string]*config.OperationOverride{
 		"op_alpha": {Alias: "my_alpha"},
 		"op_beta":  nil,
 	})
@@ -200,7 +200,7 @@ func TestBuildWithAliasAndDescription(t *testing.T) {
 		},
 	}
 
-	intg, err := Build(def, config.ConnectionDef{}, map[string]*OperationOverride{
+	intg, err := Build(def, config.ConnectionDef{}, map[string]*config.OperationOverride{
 		"op_gamma": {Alias: "renamed_gamma", Description: "Custom gamma description"},
 	})
 	if err != nil {
@@ -238,7 +238,7 @@ func TestBuildWithNullOverride(t *testing.T) {
 	t.Parallel()
 
 	def := testDefinition("null_override")
-	intg, err := Build(def, testCreds(), map[string]*OperationOverride{
+	intg, err := Build(def, testCreds(), map[string]*config.OperationOverride{
 		"list_items": nil,
 		"get_item":   nil,
 	})
@@ -260,7 +260,7 @@ func TestBuildWithDescriptionOnly(t *testing.T) {
 	t.Parallel()
 
 	def := testDefinition("desc_only")
-	intg, err := Build(def, testCreds(), map[string]*OperationOverride{
+	intg, err := Build(def, testCreds(), map[string]*config.OperationOverride{
 		"list_items": {Description: "Overridden list description"},
 	})
 	if err != nil {
@@ -282,7 +282,7 @@ func TestBuildAliasCollision(t *testing.T) {
 	t.Parallel()
 
 	def := testDefinition("collision")
-	_, err := Build(def, testCreds(), map[string]*OperationOverride{
+	_, err := Build(def, testCreds(), map[string]*config.OperationOverride{
 		"list_items": {Alias: "get_item"},
 		"get_item":   nil,
 	})

--- a/internal/provider/compiler/compiler.go
+++ b/internal/provider/compiler/compiler.go
@@ -32,7 +32,7 @@ func LoadDefinition(ctx context.Context, name string, api config.APIDef, prepare
 	return loadDefinition(ctx, name, api, preparedProviders)
 }
 
-func BuildProvider(ctx context.Context, name string, intg config.IntegrationDef, api config.APIDef, conn config.ConnectionDef, preparedProviders map[string]string, allowedOps map[string]*provider.OperationOverride, opts ...provider.BuildOption) (core.Provider, error) {
+func BuildProvider(ctx context.Context, name string, intg config.IntegrationDef, api config.APIDef, conn config.ConnectionDef, preparedProviders map[string]string, allowedOps map[string]*config.OperationOverride, opts ...provider.BuildOption) (core.Provider, error) {
 	def, err := loadDefinition(ctx, name, api, preparedProviders)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The operation aliasing feature from PR #251 could only be used through
the `Build()` function directly, not through YAML config. This adds
`allowed_operations` fields to both `APIDef` and `MCPDef` in the V0
config format, so users can restrict and rename operations declaratively.
The `OperationOverride` type moves from the provider package to config
where it naturally belongs alongside the structs that reference it.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>