### PR TITLE
Make OAuth handler lookup connection-aware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ internal/webui/out/
 # Exceptions
 !internal/manifest/
 .claude/scheduled_tasks.lock
+.claude/worktrees/

--- a/cmd/gestaltd/provider_factory.go
+++ b/cmd/gestaltd/provider_factory.go
@@ -14,7 +14,6 @@ import (
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/mcpoauth"
 	"github.com/valon-technologies/gestalt/internal/mcpupstream"
-	"github.com/valon-technologies/gestalt/internal/oauth"
 	"github.com/valon-technologies/gestalt/internal/provider"
 	providercompiler "github.com/valon-technologies/gestalt/internal/provider/compiler"
 )
@@ -114,7 +113,7 @@ func (a *providerAssembly) build() (_ *bootstrap.ProviderBuildResult, err error)
 		prov = a.apiProv
 	case a.mcpUp != nil:
 		if a.mcpConn != nil && a.mcpConn.Auth.Type == "mcp_oauth" {
-			p, buildErr := buildMCPOAuthProvider(a.name, a.intg, *a.mcpConn, a.mcpUp, a.regStore, a.deps, connMode)
+			p, buildErr := buildMCPOAuthProvider(a.name, a.intg, a.mcpUp, connMode)
 			if buildErr != nil {
 				return nil, buildErr
 			}
@@ -230,19 +229,12 @@ func buildMCPOAuthHandler(conn config.ConnectionDef, mcpURL string, store mcpoau
 	})
 }
 
-func buildMCPOAuthProvider(name string, intg config.IntegrationDef, conn config.ConnectionDef, mcpUp *mcpupstream.Upstream, store mcpoauth.RegistrationStore, deps bootstrap.Deps, connMode core.ConnectionMode) (core.Provider, error) {
-	mcpURL := ""
-	if intg.MCP != nil {
-		mcpURL = intg.MCP.URL
-	}
-	handler := buildMCPOAuthHandler(conn, mcpURL, store, deps)
-
+func buildMCPOAuthProvider(name string, intg config.IntegrationDef, mcpUp *mcpupstream.Upstream, connMode core.ConnectionMode) (core.Provider, error) {
 	baseProv := &mcpOAuthMetadataProvider{
 		name:        name,
 		displayName: intg.DisplayName,
 		description: intg.Description,
 		connMode:    connMode,
-		auth:        handler,
 	}
 
 	return composite.New(name, baseProv, mcpUp), nil
@@ -253,7 +245,6 @@ type mcpOAuthMetadataProvider struct {
 	displayName string
 	description string
 	connMode    core.ConnectionMode
-	auth        *mcpoauth.Handler
 }
 
 func (p *mcpOAuthMetadataProvider) Name() string        { return p.name }
@@ -280,38 +271,3 @@ func (p *mcpOAuthMetadataProvider) AuthTypes() []string {
 	return []string{"oauth", "manual"}
 }
 
-func (p *mcpOAuthMetadataProvider) AuthorizationURL(state string, scopes []string) string {
-	return p.auth.AuthorizationURL(state, scopes)
-}
-
-func (p *mcpOAuthMetadataProvider) StartOAuth(state string, scopes []string) (string, string) {
-	return p.auth.StartOAuth(state, scopes)
-}
-
-func (p *mcpOAuthMetadataProvider) StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string) {
-	return p.auth.StartOAuthWithOverride(authBaseURL, state, scopes)
-}
-
-func (p *mcpOAuthMetadataProvider) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
-	return p.auth.ExchangeCode(ctx, code)
-}
-
-func (p *mcpOAuthMetadataProvider) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error) {
-	return p.auth.ExchangeCodeWithVerifier(ctx, code, verifier, extraOpts...)
-}
-
-func (p *mcpOAuthMetadataProvider) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
-	return p.auth.RefreshToken(ctx, refreshToken)
-}
-
-func (p *mcpOAuthMetadataProvider) RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error) {
-	return p.auth.RefreshTokenWithURL(ctx, refreshToken, tokenURL)
-}
-
-func (p *mcpOAuthMetadataProvider) TokenURL() string {
-	return p.auth.TokenURL()
-}
-
-func (p *mcpOAuthMetadataProvider) AuthorizationBaseURL() string {
-	return p.auth.AuthorizationBaseURL()
-}

--- a/cmd/gestaltd/provider_factory.go
+++ b/cmd/gestaltd/provider_factory.go
@@ -137,7 +137,8 @@ func (a *providerAssembly) build() (_ *bootstrap.ProviderBuildResult, err error)
 func (a *providerAssembly) buildConnectionAuth() map[string]bootstrap.OAuthHandler {
 	authMap := make(map[string]bootstrap.OAuthHandler)
 
-	for connName, conn := range a.intg.Connections {
+	for connName := range a.intg.Connections {
+		conn := a.intg.Connections[connName]
 		switch conn.Auth.Type {
 		case "oauth2", "":
 			if conn.Auth.AuthorizationURL == "" && conn.Auth.ClientID == "" {

--- a/cmd/gestaltd/provider_factory.go
+++ b/cmd/gestaltd/provider_factory.go
@@ -270,4 +270,3 @@ func (p *mcpOAuthMetadataProvider) SupportsManualAuth() bool { return true }
 func (p *mcpOAuthMetadataProvider) AuthTypes() []string {
 	return []string{"oauth", "manual"}
 }
-

--- a/cmd/gestaltd/provider_factory.go
+++ b/cmd/gestaltd/provider_factory.go
@@ -30,7 +30,7 @@ func defaultProviderFactory(preparedProviders map[string]string) bootstrap.Provi
 	return state.build
 }
 
-func (s *providerFactoryState) build(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+func (s *providerFactoryState) build(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (*bootstrap.ProviderBuildResult, error) {
 	assembly := providerAssembly{
 		ctx:               ctx,
 		name:              name,
@@ -62,7 +62,7 @@ type providerAssembly struct {
 	mcpConn *config.ConnectionDef
 }
 
-func (a *providerAssembly) build() (_ core.Provider, err error) {
+func (a *providerAssembly) build() (_ *bootstrap.ProviderBuildResult, err error) {
 	connMode := connectionModeForIntegration(a.intg)
 
 	defer func() {
@@ -106,19 +106,81 @@ func (a *providerAssembly) build() (_ core.Provider, err error) {
 		a.mcpConn = &conn
 	}
 
+	var prov core.Provider
 	switch {
 	case a.apiProv != nil && a.mcpUp != nil:
-		return composite.New(a.name, a.apiProv, a.mcpUp), nil
+		prov = composite.New(a.name, a.apiProv, a.mcpUp)
 	case a.apiProv != nil:
-		return a.apiProv, nil
+		prov = a.apiProv
 	case a.mcpUp != nil:
 		if a.mcpConn != nil && a.mcpConn.Auth.Type == "mcp_oauth" {
-			return buildMCPOAuthProvider(a.name, a.intg, *a.mcpConn, a.mcpUp, a.regStore, a.deps, connMode)
+			p, buildErr := buildMCPOAuthProvider(a.name, a.intg, *a.mcpConn, a.mcpUp, a.regStore, a.deps, connMode)
+			if buildErr != nil {
+				return nil, buildErr
+			}
+			prov = p
+		} else {
+			prov = a.mcpUp
 		}
-		return a.mcpUp, nil
 	default:
 		return nil, fmt.Errorf("no surfaces configured")
 	}
+
+	connAuth := a.buildConnectionAuth()
+
+	return &bootstrap.ProviderBuildResult{
+		Provider:       prov,
+		ConnectionAuth: connAuth,
+	}, nil
+}
+
+func (a *providerAssembly) buildConnectionAuth() map[string]bootstrap.OAuthHandler {
+	authMap := make(map[string]bootstrap.OAuthHandler)
+
+	for connName, conn := range a.intg.Connections {
+		switch conn.Auth.Type {
+		case "oauth2", "":
+			if conn.Auth.AuthorizationURL == "" && conn.Auth.ClientID == "" {
+				continue
+			}
+			handler := a.buildOAuth2Handler(connName, conn)
+			if handler != nil {
+				authMap[connName] = handler
+			}
+		case "mcp_oauth":
+			mcpURL := ""
+			if a.intg.MCP != nil {
+				mcpURL = a.intg.MCP.URL
+			}
+			authMap[connName] = buildMCPOAuthHandler(conn, mcpURL, a.regStore, a.deps)
+		}
+	}
+
+	if len(authMap) == 0 {
+		return nil
+	}
+	return authMap
+}
+
+func (a *providerAssembly) buildOAuth2Handler(connName string, conn config.ConnectionDef) bootstrap.OAuthHandler {
+	if a.intg.API == nil {
+		return nil
+	}
+	def, err := providercompiler.LoadDefinition(a.ctx, a.name, *a.intg.API, a.preparedProviders)
+	if err != nil {
+		log.Printf("WARNING: %s: cannot load definition for connection %q oauth handler: %v", a.name, connName, err)
+		return nil
+	}
+
+	defCopy := *def
+	provider.ApplyConnectionAuth(&defCopy, conn)
+
+	upstream, err := provider.BuildOAuthUpstream(&defCopy, conn, defCopy.BaseURL, nil)
+	if err != nil {
+		log.Printf("WARNING: %s: cannot build oauth handler for connection %q: %v", a.name, connName, err)
+		return nil
+	}
+	return bootstrap.WrapUpstreamHandler(upstream)
 }
 
 func (a *providerAssembly) cleanup() {

--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -125,6 +125,7 @@ func runServer(env *bootstrapEnv) error {
 		Bindings:          result.Bindings,
 		Invoker:           result.Invoker,
 		DefaultConnection: bootstrap.BuildConnectionMap(env.Config),
+		ConnectionAuth:    result.ConnectionAuth,
 		IntegrationDefs:   env.Config.Integrations,
 		SecureCookies:     strings.HasPrefix(env.Config.Server.BaseURL, "https://"),
 		StateSecret:       crypto.DeriveKey(env.Config.Server.EncryptionKey),

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -15,6 +15,7 @@ import (
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	"github.com/valon-technologies/gestalt/internal/oauth"
 	"github.com/valon-technologies/gestalt/internal/pluginapi"
+	"github.com/valon-technologies/gestalt/internal/provider"
 	"github.com/valon-technologies/gestalt/internal/registry"
 	"gopkg.in/yaml.v3"
 )
@@ -631,10 +632,12 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 			log.Printf("loaded provider %s (%d operations)", name, len(result.Provider.ListOperations()))
 		}()
 	}
-	go func() {
-		wg.Wait()
-		close(ready)
-	}()
+
+	// Wait for all goroutines to finish so connAuth is fully populated
+	// before the caller reads it. The ready channel still signals provider
+	// loading completion for other consumers.
+	wg.Wait()
+	close(ready)
 
 	return &reg.Providers, ready, connAuth, nil
 }
@@ -714,6 +717,26 @@ func connectionAuthToRefreshers(m map[string]map[string]OAuthHandler) map[string
 		out[intg] = inner
 	}
 	return out
+}
+
+// BuildResultWithOAuth wraps a provider in a ProviderBuildResult and builds an
+// OAuth handler for the API connection when applicable. Named provider factories
+// (BigQuery, Jira, etc.) use this to avoid duplicating the connection auth
+// construction logic.
+func BuildResultWithOAuth(prov core.Provider, def *provider.Definition, intg config.IntegrationDef, conn config.ConnectionDef) *ProviderBuildResult {
+	result := &ProviderBuildResult{Provider: prov}
+	if conn.Auth.Type == "manual" || conn.Auth.Type == "api_key" {
+		return result
+	}
+	upstream, err := provider.BuildOAuthUpstream(def, conn, def.BaseURL, nil)
+	if err != nil {
+		log.Printf("WARNING: %s: cannot build oauth handler for connection %q: %v", prov.Name(), intg.API.Connection, err)
+		return result
+	}
+	result.ConnectionAuth = map[string]OAuthHandler{
+		intg.API.Connection: WrapUpstreamHandler(upstream),
+	}
+	return result
 }
 
 // ResolveAPIConnection returns the ConnectionDef referenced by the

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -133,7 +133,7 @@ type Result struct {
 	Datastore        core.Datastore
 	Providers        *registry.PluginMap[core.Provider]
 	ProvidersReady   <-chan struct{}
-	ConnectionAuth   map[string]map[string]OAuthHandler // integration -> connection -> handler
+	ConnectionAuth   func() map[string]map[string]OAuthHandler
 	Runtimes         *registry.PluginMap[core.Runtime]
 	Bindings         *registry.PluginMap[core.Binding]
 	Invoker          invocation.Invoker
@@ -244,7 +244,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		deps.SQLDialect = acc.RawDialect()
 	}
 
-	providers, providersReady, connAuth, err := buildProviders(ctx, cfg, factories, deps)
+	providers, providersReady, connAuthResolver, err := buildProviders(ctx, cfg, factories, deps)
 	if err != nil {
 		return nil, err
 	}
@@ -259,7 +259,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	connMap := BuildConnectionMap(cfg)
 	sharedInvoker := invocation.NewBroker(providers, ds,
 		invocation.WithConnectionMapper(connMap),
-		invocation.WithConnectionAuth(connectionAuthToRefreshers(connAuth)),
+		invocation.WithConnectionAuth(lazyRefreshers(providersReady, connAuthResolver)),
 	)
 	wireCredentialResolver(&deps.Egress, sm)
 	audit := core.AuditSink(invocation.LogAuditSink{})
@@ -283,7 +283,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		Datastore:        ds,
 		Providers:        providers,
 		ProvidersReady:   providersReady,
-		ConnectionAuth:   connAuth,
+		ConnectionAuth:   connAuthResolver,
 		Runtimes:         extensions.Runtimes,
 		Bindings:         extensions.Bindings,
 		Invoker:          sharedInvoker,
@@ -582,7 +582,7 @@ func buildDatastore(cfg *config.Config, factories *FactoryRegistry, deps Deps) (
 	return ds, nil
 }
 
-func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.PluginMap[core.Provider], <-chan struct{}, map[string]map[string]OAuthHandler, error) {
+func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.PluginMap[core.Provider], <-chan struct{}, func() map[string]map[string]OAuthHandler, error) {
 	reg := registry.New()
 	connAuth := make(map[string]map[string]OAuthHandler)
 	var connMu sync.Mutex
@@ -599,7 +599,7 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 	ready := make(chan struct{})
 	if len(cfg.Integrations) == 0 {
 		close(ready)
-		return &reg.Providers, ready, connAuth, nil
+		return &reg.Providers, ready, func() map[string]map[string]OAuthHandler { return connAuth }, nil
 	}
 
 	var wg sync.WaitGroup
@@ -633,13 +633,16 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 		}()
 	}
 
-	// Wait for all goroutines to finish so connAuth is fully populated
-	// before the caller reads it. The ready channel still signals provider
-	// loading completion for other consumers.
-	wg.Wait()
-	close(ready)
+	go func() {
+		wg.Wait()
+		close(ready)
+	}()
 
-	return &reg.Providers, ready, connAuth, nil
+	resolver := func() map[string]map[string]OAuthHandler {
+		<-ready
+		return connAuth
+	}
+	return &reg.Providers, ready, resolver, nil
 }
 
 func buildProvider(ctx context.Context, name string, intg config.IntegrationDef, factories *FactoryRegistry, deps Deps) (*ProviderBuildResult, error) {
@@ -702,6 +705,18 @@ func BuildConnectionMap(cfg *config.Config) invocation.ConnectionMap {
 		}
 	}
 	return m
+}
+
+func lazyRefreshers(ready <-chan struct{}, resolver func() map[string]map[string]OAuthHandler) invocation.RefresherResolver {
+	var once sync.Once
+	var result map[string]map[string]invocation.OAuthRefresher
+	return func() map[string]map[string]invocation.OAuthRefresher {
+		once.Do(func() {
+			<-ready
+			result = connectionAuthToRefreshers(resolver())
+		})
+		return result
+	}
 }
 
 func connectionAuthToRefreshers(m map[string]map[string]OAuthHandler) map[string]map[string]invocation.OAuthRefresher {

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -740,8 +740,16 @@ func connectionAuthToRefreshers(m map[string]map[string]OAuthHandler) map[string
 // construction logic.
 func BuildResultWithOAuth(prov core.Provider, def *provider.Definition, intg config.IntegrationDef, conn config.ConnectionDef) *ProviderBuildResult {
 	result := &ProviderBuildResult{Provider: prov}
-	if conn.Auth.Type == "manual" || conn.Auth.Type == "api_key" {
+	if intg.API == nil {
 		return result
+	}
+	switch conn.Auth.Type {
+	case "manual", "api_key":
+		return result
+	case "":
+		if conn.Auth.AuthorizationURL == "" && conn.Auth.ClientID == "" {
+			return result
+		}
 	}
 	upstream, err := provider.BuildOAuthUpstream(def, conn, def.BaseURL, nil)
 	if err != nil {

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -13,10 +13,83 @@ import (
 	"github.com/valon-technologies/gestalt/core/crypto"
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/invocation"
+	"github.com/valon-technologies/gestalt/internal/oauth"
 	"github.com/valon-technologies/gestalt/internal/pluginapi"
 	"github.com/valon-technologies/gestalt/internal/registry"
 	"gopkg.in/yaml.v3"
 )
+
+// OAuthHandler covers every OAuth method needed by the server (start, exchange,
+// refresh) and the broker (refresh). mcpoauth.Handler satisfies this directly;
+// use WrapUpstreamHandler to adapt an oauth.UpstreamHandler.
+type OAuthHandler interface {
+	AuthorizationURL(state string, scopes []string) string
+	StartOAuth(state string, scopes []string) (authURL string, verifier string)
+	StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string)
+	ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error)
+	ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
+	RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error)
+	RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error)
+	AuthorizationBaseURL() string
+	TokenURL() string
+}
+
+// upstreamHandlerAdapter wraps an oauth.UpstreamHandler to satisfy OAuthHandler.
+type upstreamHandlerAdapter struct {
+	h *oauth.UpstreamHandler
+}
+
+// WrapUpstreamHandler adapts an oauth.UpstreamHandler to the OAuthHandler
+// interface. The adapter maps StartOAuth to AuthorizationURLWithPKCE and
+// ExchangeCodeWithVerifier to ExchangeCode with option injection.
+func WrapUpstreamHandler(h *oauth.UpstreamHandler) OAuthHandler {
+	return &upstreamHandlerAdapter{h: h}
+}
+
+func (a *upstreamHandlerAdapter) AuthorizationURL(state string, scopes []string) string {
+	url, _ := a.h.AuthorizationURLWithPKCE(state, scopes)
+	return url
+}
+
+func (a *upstreamHandlerAdapter) StartOAuth(state string, scopes []string) (string, string) {
+	return a.h.AuthorizationURLWithPKCE(state, scopes)
+}
+
+func (a *upstreamHandlerAdapter) StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string) {
+	return a.h.AuthorizationURLWithOverride(authBaseURL, state, scopes)
+}
+
+func (a *upstreamHandlerAdapter) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	return a.h.ExchangeCode(ctx, code)
+}
+
+func (a *upstreamHandlerAdapter) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error) {
+	var opts []oauth.ExchangeOption
+	if verifier != "" {
+		opts = append(opts, oauth.WithPKCEVerifier(verifier))
+	}
+	opts = append(opts, extraOpts...)
+	return a.h.ExchangeCode(ctx, code, opts...)
+}
+
+func (a *upstreamHandlerAdapter) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	return a.h.RefreshToken(ctx, refreshToken)
+}
+
+func (a *upstreamHandlerAdapter) RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error) {
+	return a.h.RefreshTokenWithURL(ctx, refreshToken, tokenURL)
+}
+
+func (a *upstreamHandlerAdapter) AuthorizationBaseURL() string { return a.h.AuthorizationBaseURL() }
+func (a *upstreamHandlerAdapter) TokenURL() string             { return a.h.TokenURL() }
+
+// ProviderBuildResult is the return value of a ProviderFactory. It carries
+// the constructed provider and an OAuth handler for each named connection
+// that uses oauth2 or mcp_oauth auth.
+type ProviderBuildResult struct {
+	Provider       core.Provider
+	ConnectionAuth map[string]OAuthHandler
+}
 
 type Deps struct {
 	EncryptionKey []byte
@@ -29,7 +102,7 @@ type Deps struct {
 
 type AuthFactory func(node yaml.Node, deps Deps) (core.AuthProvider, error)
 type DatastoreFactory func(node yaml.Node, deps Deps) (core.Datastore, error)
-type ProviderFactory func(ctx context.Context, name string, intg config.IntegrationDef, deps Deps) (core.Provider, error)
+type ProviderFactory func(ctx context.Context, name string, intg config.IntegrationDef, deps Deps) (*ProviderBuildResult, error)
 type SecretManagerFactory func(node yaml.Node) (core.SecretManager, error)
 
 type FactoryRegistry struct {
@@ -59,6 +132,7 @@ type Result struct {
 	Datastore        core.Datastore
 	Providers        *registry.PluginMap[core.Provider]
 	ProvidersReady   <-chan struct{}
+	ConnectionAuth   map[string]map[string]OAuthHandler // integration -> connection -> handler
 	Runtimes         *registry.PluginMap[core.Runtime]
 	Bindings         *registry.PluginMap[core.Binding]
 	Invoker          invocation.Invoker
@@ -169,7 +243,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		deps.SQLDialect = acc.RawDialect()
 	}
 
-	providers, providersReady, err := buildProviders(ctx, cfg, factories, deps)
+	providers, providersReady, connAuth, err := buildProviders(ctx, cfg, factories, deps)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +256,10 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	}()
 
 	connMap := BuildConnectionMap(cfg)
-	sharedInvoker := invocation.NewBroker(providers, ds, invocation.WithConnectionMapper(connMap))
+	sharedInvoker := invocation.NewBroker(providers, ds,
+		invocation.WithConnectionMapper(connMap),
+		invocation.WithConnectionAuth(connectionAuthToRefreshers(connAuth)),
+	)
 	wireCredentialResolver(&deps.Egress, sm)
 	audit := core.AuditSink(invocation.LogAuditSink{})
 
@@ -205,6 +282,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		Datastore:        ds,
 		Providers:        providers,
 		ProvidersReady:   providersReady,
+		ConnectionAuth:   connAuth,
 		Runtimes:         extensions.Runtimes,
 		Bindings:         extensions.Bindings,
 		Invoker:          sharedInvoker,
@@ -503,14 +581,16 @@ func buildDatastore(cfg *config.Config, factories *FactoryRegistry, deps Deps) (
 	return ds, nil
 }
 
-func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.PluginMap[core.Provider], <-chan struct{}, error) {
+func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.PluginMap[core.Provider], <-chan struct{}, map[string]map[string]OAuthHandler, error) {
 	reg := registry.New()
+	connAuth := make(map[string]map[string]OAuthHandler)
+	var connMu sync.Mutex
 
 	for _, builtin := range factories.Builtins {
 		if err := reg.Providers.Register(builtin.Name(), builtin); errors.Is(err, core.ErrAlreadyRegistered) {
 			continue
 		} else if err != nil {
-			return nil, nil, fmt.Errorf("bootstrap: registering builtin %q: %w", builtin.Name(), err)
+			return nil, nil, nil, fmt.Errorf("bootstrap: registering builtin %q: %w", builtin.Name(), err)
 		}
 		log.Printf("loaded builtin provider %s (%d operations)", builtin.Name(), len(builtin.ListOperations()))
 	}
@@ -518,7 +598,7 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 	ready := make(chan struct{})
 	if len(cfg.Integrations) == 0 {
 		close(ready)
-		return &reg.Providers, ready, nil
+		return &reg.Providers, ready, connAuth, nil
 	}
 
 	var wg sync.WaitGroup
@@ -526,24 +606,29 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 		intgDef := cfg.Integrations[name]
 		if err := validateProviderBuildAvailable(name, intgDef, factories); err != nil {
 			close(ready)
-			return nil, nil, fmt.Errorf("bootstrap: %w", err)
+			return nil, nil, nil, fmt.Errorf("bootstrap: %w", err)
 		}
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			prov, err := buildProvider(ctx, name, intgDef, factories, deps)
+			result, err := buildProvider(ctx, name, intgDef, factories, deps)
 			if err != nil {
 				log.Printf("WARNING: skipping provider %q: %v", name, err)
 				return
 			}
-			if err := reg.Providers.Register(name, prov); err != nil {
-				if c, ok := prov.(interface{ Close() error }); ok {
+			if err := reg.Providers.Register(name, result.Provider); err != nil {
+				if c, ok := result.Provider.(interface{ Close() error }); ok {
 					_ = c.Close()
 				}
 				log.Printf("WARNING: registering provider %q: %v", name, err)
 				return
 			}
-			log.Printf("loaded provider %s (%d operations)", name, len(prov.ListOperations()))
+			if len(result.ConnectionAuth) > 0 {
+				connMu.Lock()
+				connAuth[name] = result.ConnectionAuth
+				connMu.Unlock()
+			}
+			log.Printf("loaded provider %s (%d operations)", name, len(result.Provider.ListOperations()))
 		}()
 	}
 	go func() {
@@ -551,22 +636,26 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 		close(ready)
 	}()
 
-	return &reg.Providers, ready, nil
+	return &reg.Providers, ready, connAuth, nil
 }
 
-func buildProvider(ctx context.Context, name string, intg config.IntegrationDef, factories *FactoryRegistry, deps Deps) (core.Provider, error) {
+func buildProvider(ctx context.Context, name string, intg config.IntegrationDef, factories *FactoryRegistry, deps Deps) (*ProviderBuildResult, error) {
 	if intg.Plugin != nil {
 		pluginConfig, err := config.NodeToMap(intg.Plugin.Config)
 		if err != nil {
 			return nil, fmt.Errorf("decode plugin config for %q: %w", name, err)
 		}
-		return pluginapi.NewExecutableProvider(ctx, pluginapi.ExecConfig{
+		prov, err := pluginapi.NewExecutableProvider(ctx, pluginapi.ExecConfig{
 			Command: intg.Plugin.Command,
 			Args:    intg.Plugin.Args,
 			Env:     intg.Plugin.Env,
 			Name:    name,
 			Config:  pluginConfig,
 		})
+		if err != nil {
+			return nil, err
+		}
+		return &ProviderBuildResult{Provider: prov}, nil
 	}
 
 	factory, err := providerFactoryForName(name, factories)
@@ -610,6 +699,21 @@ func BuildConnectionMap(cfg *config.Config) invocation.ConnectionMap {
 		}
 	}
 	return m
+}
+
+func connectionAuthToRefreshers(m map[string]map[string]OAuthHandler) map[string]map[string]invocation.OAuthRefresher {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]map[string]invocation.OAuthRefresher, len(m))
+	for intg, conns := range m {
+		inner := make(map[string]invocation.OAuthRefresher, len(conns))
+		for conn, handler := range conns {
+			inner[conn] = handler
+		}
+		out[intg] = inner
+	}
+	return out
 }
 
 // ResolveAPIConnection returns the ConnectionDef referenced by the

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -31,8 +31,8 @@ func stubDatastoreFactory() bootstrap.DatastoreFactory {
 }
 
 func stubProviderFactory(name string) bootstrap.ProviderFactory {
-	return func(_ context.Context, _ string, _ config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
-		return &coretesting.StubIntegration{N: name}, nil
+	return func(_ context.Context, _ string, _ config.IntegrationDef, _ bootstrap.Deps) (*bootstrap.ProviderBuildResult, error) {
+		return &bootstrap.ProviderBuildResult{Provider: &coretesting.StubIntegration{N: name}}, nil
 	}
 }
 
@@ -52,11 +52,11 @@ func (s *stubIntegrationWithOps) ListOperations() []core.Operation {
 }
 
 func stubProviderFactoryWithOps(name string, ops []core.Operation) bootstrap.ProviderFactory {
-	return func(_ context.Context, _ string, _ config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
-		return &stubIntegrationWithOps{
+	return func(_ context.Context, _ string, _ config.IntegrationDef, _ bootstrap.Deps) (*bootstrap.ProviderBuildResult, error) {
+		return &bootstrap.ProviderBuildResult{Provider: &stubIntegrationWithOps{
 			StubIntegration: coretesting.StubIntegration{N: name},
 			ops:             ops,
-		}, nil
+		}}, nil
 	}
 }
 
@@ -235,7 +235,7 @@ func TestBootstrapNamedOverridesDefault(t *testing.T) {
 	factories := bootstrap.NewFactoryRegistry()
 	factories.Auth["test-auth"] = stubAuthFactory("test-auth")
 	factories.Datastores["test-store"] = stubDatastoreFactory()
-	factories.DefaultProvider = func(_ context.Context, _ string, _ config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
+	factories.DefaultProvider = func(_ context.Context, _ string, _ config.IntegrationDef, _ bootstrap.Deps) (*bootstrap.ProviderBuildResult, error) {
 		return nil, fmt.Errorf("should not be called")
 	}
 	factories.Providers["alpha"] = stubProviderFactory("alpha")
@@ -362,7 +362,7 @@ func TestBootstrapProviderErrorSkipsProvider(t *testing.T) {
 	cfg.Integrations["beta"] = config.IntegrationDef{}
 
 	factories := validFactories()
-	factories.Providers["beta"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
+	factories.Providers["beta"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ bootstrap.Deps) (*bootstrap.ProviderBuildResult, error) {
 		return nil, fmt.Errorf("provider broke")
 	}
 
@@ -386,7 +386,7 @@ func TestValidateProviderErrorFails(t *testing.T) {
 	cfg.Integrations["beta"] = config.IntegrationDef{}
 
 	factories := validFactories()
-	factories.Providers["beta"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
+	factories.Providers["beta"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ bootstrap.Deps) (*bootstrap.ProviderBuildResult, error) {
 		return nil, fmt.Errorf("provider broke")
 	}
 
@@ -489,11 +489,11 @@ func TestBootstrapBaseURL(t *testing.T) {
 		receivedBaseURL = deps.BaseURL
 		return &coretesting.StubAuthProvider{N: "test-auth"}, nil
 	}
-	factories.Providers["alpha"] = func(_ context.Context, _ string, def config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
+	factories.Providers["alpha"] = func(_ context.Context, _ string, def config.IntegrationDef, _ bootstrap.Deps) (*bootstrap.ProviderBuildResult, error) {
 		if conn, ok := def.Connections["default"]; ok {
 			receivedRedirectURL = conn.Auth.RedirectURL
 		}
-		return &coretesting.StubIntegration{N: "alpha"}, nil
+		return &bootstrap.ProviderBuildResult{Provider: &coretesting.StubIntegration{N: "alpha"}}, nil
 	}
 	// config.Load defaults secrets.provider to "env"
 	factories.Secrets["env"] = stubSecretManagerFactory()
@@ -618,9 +618,9 @@ func TestBootstrapSecretResolution(t *testing.T) {
 				Secrets: map[string]string{"slack-secret": "resolved-secret"},
 			}, nil
 		}
-		factories.Providers["alpha"] = func(_ context.Context, _ string, intg config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
+		factories.Providers["alpha"] = func(_ context.Context, _ string, intg config.IntegrationDef, _ bootstrap.Deps) (*bootstrap.ProviderBuildResult, error) {
 			receivedDef = intg
-			return &coretesting.StubIntegration{N: "alpha"}, nil
+			return &bootstrap.ProviderBuildResult{Provider: &coretesting.StubIntegration{N: "alpha"}}, nil
 		}
 
 		cfg := validConfig()
@@ -782,9 +782,9 @@ func TestBootstrapSecretResolution(t *testing.T) {
 				Secrets: map[string]string{"api-key": "resolved-key"},
 			}, nil
 		}
-		factories.Providers["alpha"] = func(_ context.Context, _ string, intg config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
+		factories.Providers["alpha"] = func(_ context.Context, _ string, intg config.IntegrationDef, _ bootstrap.Deps) (*bootstrap.ProviderBuildResult, error) {
 			receivedDef = intg
-			return &coretesting.StubIntegration{N: "alpha"}, nil
+			return &bootstrap.ProviderBuildResult{Provider: &coretesting.StubIntegration{N: "alpha"}}, nil
 		}
 
 		cfg := validConfig()
@@ -821,9 +821,9 @@ func TestBootstrapSecretResolution(t *testing.T) {
 				Secrets: map[string]string{"meta-val": "resolved-meta"},
 			}, nil
 		}
-		factories.Providers["alpha"] = func(_ context.Context, _ string, intg config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
+		factories.Providers["alpha"] = func(_ context.Context, _ string, intg config.IntegrationDef, _ bootstrap.Deps) (*bootstrap.ProviderBuildResult, error) {
 			receivedDef = intg
-			return &coretesting.StubIntegration{N: "alpha"}, nil
+			return &bootstrap.ProviderBuildResult{Provider: &coretesting.StubIntegration{N: "alpha"}}, nil
 		}
 
 		cfg := validConfig()

--- a/internal/bootstrap/executable_plugin_test.go
+++ b/internal/bootstrap/executable_plugin_test.go
@@ -79,7 +79,7 @@ func TestExecutableProviderAndRuntimePlugins(t *testing.T) {
 	}
 
 	factories := NewFactoryRegistry()
-	providers, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -141,8 +141,8 @@ func TestExecutableRuntimeCapabilities_OmitsMCPPassthroughOnlyCatalogOperations(
 	}
 
 	factories := NewFactoryRegistry()
-	factories.Providers["search"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ Deps) (core.Provider, error) {
-		return &catalogProviderWithOps{
+	factories.Providers["search"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ Deps) (*ProviderBuildResult, error) {
+		return &ProviderBuildResult{Provider: &catalogProviderWithOps{
 			StubIntegration: coretesting.StubIntegration{
 				N:        "search",
 				ConnMode: core.ConnectionModeNone,
@@ -160,10 +160,10 @@ func TestExecutableRuntimeCapabilities_OmitsMCPPassthroughOnlyCatalogOperations(
 					},
 				},
 			},
-		}, nil
+		}}, nil
 	}
 
-	providers, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -223,8 +223,8 @@ func TestExecutableRuntimeCapabilities_ExposeOnlyInvokableCatalogOperations(t *t
 	}
 
 	factories := NewFactoryRegistry()
-	factories.Providers["workspace"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ Deps) (core.Provider, error) {
-		return &catalogProviderWithOps{
+	factories.Providers["workspace"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ Deps) (*ProviderBuildResult, error) {
+		return &ProviderBuildResult{Provider: &catalogProviderWithOps{
 			StubIntegration: coretesting.StubIntegration{
 				N:        "workspace",
 				ConnMode: core.ConnectionModeNone,
@@ -260,10 +260,10 @@ func TestExecutableRuntimeCapabilities_ExposeOnlyInvokableCatalogOperations(t *t
 					},
 				},
 			},
-		}, nil
+		}}, nil
 	}
 
-	providers, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -324,8 +324,8 @@ func TestExecutableRuntimeCapabilities_FilterMethodlessFallbackOperations(t *tes
 	}
 
 	factories := NewFactoryRegistry()
-	factories.Providers["alpha"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ Deps) (core.Provider, error) {
-		return &catalogProviderWithOps{
+	factories.Providers["alpha"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ Deps) (*ProviderBuildResult, error) {
+		return &ProviderBuildResult{Provider: &catalogProviderWithOps{
 			StubIntegration: coretesting.StubIntegration{
 				N:        "alpha",
 				ConnMode: core.ConnectionModeNone,
@@ -334,10 +334,10 @@ func TestExecutableRuntimeCapabilities_FilterMethodlessFallbackOperations(t *tes
 				{Name: "rest_op", Description: "REST op", Method: http.MethodPost},
 				{Name: "hidden_op", Description: "Hidden op"},
 			},
-		}, nil
+		}}, nil
 	}
 
-	providers, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -432,7 +432,7 @@ func TestExecutableSDKExampleProviderReceivesStartConfig(t *testing.T) {
 	}
 
 	factories := NewFactoryRegistry()
-	providers, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
@@ -489,7 +489,7 @@ func TestExecutableProviderAcceptsMinOnlyProtocolVersion(t *testing.T) {
 	}
 
 	factories := NewFactoryRegistry()
-	providers, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}

--- a/internal/bootstrap/regression_test.go
+++ b/internal/bootstrap/regression_test.go
@@ -79,8 +79,8 @@ func TestPlatformMode_BindingsAndRuntimesWithSafetyLayer(t *testing.T) {
 	}
 
 	factories := validFactories()
-	factories.Providers["alpha"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
-		return &stubIntegrationWithOps{
+	factories.Providers["alpha"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ bootstrap.Deps) (*bootstrap.ProviderBuildResult, error) {
+		return &bootstrap.ProviderBuildResult{Provider: &stubIntegrationWithOps{
 			StubIntegration: coretesting.StubIntegration{
 				N:        "alpha",
 				ConnMode: core.ConnectionModeNone,
@@ -89,10 +89,10 @@ func TestPlatformMode_BindingsAndRuntimesWithSafetyLayer(t *testing.T) {
 				},
 			},
 			ops: []core.Operation{{Name: "do", Method: http.MethodPost}},
-		}, nil
+		}}, nil
 	}
-	factories.Providers["beta"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ bootstrap.Deps) (core.Provider, error) {
-		return &stubIntegrationWithOps{
+	factories.Providers["beta"] = func(_ context.Context, _ string, _ config.IntegrationDef, _ bootstrap.Deps) (*bootstrap.ProviderBuildResult, error) {
+		return &bootstrap.ProviderBuildResult{Provider: &stubIntegrationWithOps{
 			StubIntegration: coretesting.StubIntegration{
 				N:        "beta",
 				ConnMode: core.ConnectionModeNone,
@@ -101,7 +101,7 @@ func TestPlatformMode_BindingsAndRuntimesWithSafetyLayer(t *testing.T) {
 				},
 			},
 			ops: []core.Operation{{Name: "do", Method: http.MethodPost}},
-		}, nil
+		}}, nil
 	}
 
 	var runtimeDeps bootstrap.RuntimeDeps

--- a/internal/bootstrap/validate.go
+++ b/internal/bootstrap/validate.go
@@ -52,7 +52,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 		warnings = w.Warnings()
 	}
 
-	providers, err := buildProvidersStrict(ctx, cfg, factories, deps)
+	providers, _, err := buildProvidersStrict(ctx, cfg, factories, deps)
 	if err != nil {
 		return warnings, err
 	}
@@ -75,15 +75,16 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 	return warnings, nil
 }
 
-func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.PluginMap[core.Provider], error) {
+func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.PluginMap[core.Provider], map[string]map[string]OAuthHandler, error) {
 	reg := registry.New()
+	connAuth := make(map[string]map[string]OAuthHandler)
 
 	for _, builtin := range factories.Builtins {
 		if err := reg.Providers.Register(builtin.Name(), builtin); errors.Is(err, core.ErrAlreadyRegistered) {
 			continue
 		} else if err != nil {
 			_ = CloseProviders(&reg.Providers)
-			return nil, fmt.Errorf("bootstrap: registering builtin %q: %w", builtin.Name(), err)
+			return nil, nil, fmt.Errorf("bootstrap: registering builtin %q: %w", builtin.Name(), err)
 		}
 	}
 
@@ -92,32 +93,39 @@ func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *Fa
 	var errs []error
 	for _, name := range names {
 		intgDef := cfg.Integrations[name]
-		prov, err := buildProviderForValidation(ctx, name, intgDef, factories, deps)
+		result, err := buildProviderForValidation(ctx, name, intgDef, factories, deps)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("integration %q: %w", name, err))
 			continue
 		}
-		if err := reg.Providers.Register(name, prov); err != nil {
-			if c, ok := prov.(io.Closer); ok {
+		if err := reg.Providers.Register(name, result.Provider); err != nil {
+			if c, ok := result.Provider.(io.Closer); ok {
 				_ = c.Close()
 			}
 			errs = append(errs, fmt.Errorf("bootstrap: registering provider %q: %w", name, err))
+		}
+		if len(result.ConnectionAuth) > 0 {
+			connAuth[name] = result.ConnectionAuth
 		}
 	}
 
 	if len(errs) > 0 {
 		_ = CloseProviders(&reg.Providers)
-		return nil, fmt.Errorf("bootstrap: provider validation failed: %w", errors.Join(errs...))
+		return nil, nil, fmt.Errorf("bootstrap: provider validation failed: %w", errors.Join(errs...))
 	}
 
-	return &reg.Providers, nil
+	return &reg.Providers, connAuth, nil
 }
 
-func buildProviderForValidation(ctx context.Context, name string, intg config.IntegrationDef, factories *FactoryRegistry, deps Deps) (core.Provider, error) {
+func buildProviderForValidation(ctx context.Context, name string, intg config.IntegrationDef, factories *FactoryRegistry, deps Deps) (*ProviderBuildResult, error) {
 	if intg.Plugin == nil || intg.Plugin.Package == "" || intg.Plugin.ResolvedManifestPath == "" {
 		return buildProvider(ctx, name, intg, factories, deps)
 	}
-	return newPreparedProviderStub(name, intg, intg.Plugin.ResolvedManifestPath)
+	prov, err := newPreparedProviderStub(name, intg, intg.Plugin.ResolvedManifestPath)
+	if err != nil {
+		return nil, err
+	}
+	return &ProviderBuildResult{Provider: prov}, nil
 }
 
 func buildRuntimeForValidation(ctx context.Context, name string, cfg config.RuntimeDef, factories *FactoryRegistry, deps RuntimeDeps) (core.Runtime, error) {

--- a/internal/invocation/broker.go
+++ b/internal/invocation/broker.go
@@ -51,16 +51,29 @@ func (m ConnectionMap) ConnectionForProvider(provider string) string {
 	return m[provider]
 }
 
+// OAuthRefresher is the subset of OAuthHandler that the broker needs for
+// token refresh. Defined here to avoid importing the bootstrap package.
+type OAuthRefresher interface {
+	RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error)
+	RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error)
+	TokenURL() string
+}
+
 type Broker struct {
-	providers  *registry.PluginMap[core.Provider]
-	datastore  core.Datastore
-	connMapper ConnectionMapper
+	providers      *registry.PluginMap[core.Provider]
+	datastore      core.Datastore
+	connMapper     ConnectionMapper
+	connectionAuth map[string]map[string]OAuthRefresher
 }
 
 type BrokerOption func(*Broker)
 
 func WithConnectionMapper(m ConnectionMapper) BrokerOption {
 	return func(b *Broker) { b.connMapper = m }
+}
+
+func WithConnectionAuth(m map[string]map[string]OAuthRefresher) BrokerOption {
+	return func(b *Broker) { b.connectionAuth = m }
 }
 
 func NewBroker(providers *registry.PluginMap[core.Provider], ds core.Datastore, opts ...BrokerOption) *Broker {
@@ -242,11 +255,11 @@ func (b *Broker) resolveUserToken(ctx context.Context, prov core.Provider, userI
 		}
 	}
 
-	accessToken, err := b.refreshTokenIfNeeded(ctx, prov, storedToken)
+	accessToken, err := b.refreshTokenIfNeeded(ctx, storedToken, providerName, connection)
 	return ctx, accessToken, err
 }
 
-func (b *Broker) refreshTokenIfNeeded(ctx context.Context, prov core.Provider, token *core.IntegrationToken) (string, error) {
+func (b *Broker) refreshTokenIfNeeded(ctx context.Context, token *core.IntegrationToken, providerName, connection string) (string, error) {
 	if token.RefreshToken == "" || token.ExpiresAt == nil {
 		return token.AccessToken, nil
 	}
@@ -254,12 +267,12 @@ func (b *Broker) refreshTokenIfNeeded(ctx context.Context, prov core.Provider, t
 		return token.AccessToken, nil
 	}
 
-	oauthProv, ok := prov.(core.OAuthProvider)
-	if !ok {
+	refresher := b.resolveRefresher(providerName, connection)
+	if refresher == nil {
 		return token.AccessToken, nil
 	}
 
-	resp, err := b.refreshOAuth(ctx, oauthProv, prov, token.RefreshToken)
+	resp, err := b.refreshOAuth(ctx, refresher, token.RefreshToken)
 	if err != nil {
 		fresh, fetchErr := b.datastore.Token(ctx, token.UserID, token.Integration, token.Connection, token.Instance)
 		if fetchErr == nil && fresh != nil && fresh.AccessToken != token.AccessToken {
@@ -295,22 +308,24 @@ func (b *Broker) refreshTokenIfNeeded(ctx context.Context, prov core.Provider, t
 	return token.AccessToken, nil
 }
 
-func (b *Broker) refreshOAuth(ctx context.Context, oauthProv core.OAuthProvider, prov core.Provider, refreshToken string) (*core.TokenResponse, error) {
-	type refreshWithURL interface {
-		RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error)
+func (b *Broker) resolveRefresher(integration, connection string) OAuthRefresher {
+	if b.connectionAuth == nil {
+		return nil
 	}
-	type tokenURLer interface{ TokenURL() string }
+	connMap := b.connectionAuth[integration]
+	if connMap == nil {
+		return nil
+	}
+	return connMap[connection]
+}
 
+func (b *Broker) refreshOAuth(ctx context.Context, refresher OAuthRefresher, refreshToken string) (*core.TokenResponse, error) {
 	if cp := core.ConnectionParams(ctx); cp != nil {
-		if tu, ok := prov.(tokenURLer); ok {
-			raw := tu.TokenURL()
-			resolved := paraminterp.Interpolate(raw, cp)
-			if resolved != raw {
-				if rw, ok := prov.(refreshWithURL); ok {
-					return rw.RefreshTokenWithURL(ctx, refreshToken, resolved)
-				}
-			}
+		raw := refresher.TokenURL()
+		resolved := paraminterp.Interpolate(raw, cp)
+		if resolved != raw {
+			return refresher.RefreshTokenWithURL(ctx, refreshToken, resolved)
 		}
 	}
-	return oauthProv.RefreshToken(ctx, refreshToken)
+	return refresher.RefreshToken(ctx, refreshToken)
 }

--- a/internal/invocation/broker.go
+++ b/internal/invocation/broker.go
@@ -59,11 +59,15 @@ type OAuthRefresher interface {
 	TokenURL() string
 }
 
+// RefresherResolver returns the connection auth map, blocking until providers
+// finish loading if needed.
+type RefresherResolver func() map[string]map[string]OAuthRefresher
+
 type Broker struct {
 	providers      *registry.PluginMap[core.Provider]
 	datastore      core.Datastore
 	connMapper     ConnectionMapper
-	connectionAuth map[string]map[string]OAuthRefresher
+	connectionAuth RefresherResolver
 }
 
 type BrokerOption func(*Broker)
@@ -72,8 +76,8 @@ func WithConnectionMapper(m ConnectionMapper) BrokerOption {
 	return func(b *Broker) { b.connMapper = m }
 }
 
-func WithConnectionAuth(m map[string]map[string]OAuthRefresher) BrokerOption {
-	return func(b *Broker) { b.connectionAuth = m }
+func WithConnectionAuth(r RefresherResolver) BrokerOption {
+	return func(b *Broker) { b.connectionAuth = r }
 }
 
 func NewBroker(providers *registry.PluginMap[core.Provider], ds core.Datastore, opts ...BrokerOption) *Broker {
@@ -312,11 +316,11 @@ func (b *Broker) resolveRefresher(integration, connection string) OAuthRefresher
 	if b.connectionAuth == nil {
 		return nil
 	}
-	connMap := b.connectionAuth[integration]
-	if connMap == nil {
+	m := b.connectionAuth()
+	if m == nil {
 		return nil
 	}
-	return connMap[connection]
+	return m[integration][connection]
 }
 
 func (b *Broker) refreshOAuth(ctx context.Context, refresher OAuthRefresher, refreshToken string) (*core.TokenResponse, error) {

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -46,7 +46,7 @@ func Build(def *Definition, conn config.ConnectionDef, allowedOperations map[str
 
 	d := *def
 	def = &d
-	applyConnectionAuth(def, conn)
+	ApplyConnectionAuth(def, conn)
 
 	baseURL := def.BaseURL
 
@@ -253,8 +253,8 @@ func ApplyDisplayOverrides(def *Definition, intg config.IntegrationDef) {
 	}
 }
 
-// applyConnectionAuth merges connection auth overrides into the Definition.
-func applyConnectionAuth(def *Definition, conn config.ConnectionDef) {
+// ApplyConnectionAuth merges connection auth overrides into the Definition.
+func ApplyConnectionAuth(def *Definition, conn config.ConnectionDef) {
 	o := conn.Auth
 	setStr(&def.Auth.Type, o.Type)
 	setStr(&def.Auth.AuthorizationURL, o.AuthorizationURL)
@@ -294,6 +294,19 @@ func buildAuth(def *Definition, conn config.ConnectionDef, baseURL string, clien
 		return oauth.ManualAuthHandler{}, nil
 	}
 
+	upstream, err := BuildOAuthUpstream(def, conn, baseURL, client)
+	if err != nil {
+		return nil, err
+	}
+	return coreintegration.UpstreamAuth{Handler: upstream}, nil
+}
+
+// BuildOAuthUpstream creates an oauth.UpstreamHandler from a provider
+// Definition and ConnectionDef. This preserves all fields: token_exchange,
+// token_params, refresh_params, scope_separator, accept_header, and response
+// hooks. Callers outside the provider build pipeline (e.g. the factory building
+// per-connection OAuth handlers) use this to get a standalone handler.
+func BuildOAuthUpstream(def *Definition, conn config.ConnectionDef, baseURL string, client *http.Client) (*oauth.UpstreamHandler, error) {
 	var tokenExchange oauth.TokenExchangeFormat
 	switch def.Auth.TokenExchange {
 	case "", "form":
@@ -328,7 +341,9 @@ func buildAuth(def *Definition, conn config.ConnectionDef, baseURL string, clien
 	}
 
 	var opts []oauth.Option
-	opts = append(opts, oauth.WithHTTPClient(client))
+	if client != nil {
+		opts = append(opts, oauth.WithHTTPClient(client))
+	}
 
 	if def.Auth.ResponseCheck != nil {
 		rcd := def.Auth.ResponseCheck
@@ -349,8 +364,7 @@ func buildAuth(def *Definition, conn config.ConnectionDef, baseURL string, clien
 		}))
 	}
 
-	upstream := oauth.NewUpstream(oauthCfg, opts...)
-	return coreintegration.UpstreamAuth{Handler: upstream}, nil
+	return oauth.NewUpstream(oauthCfg, opts...), nil
 }
 
 func buildResponseChecker(rcd *ResponseCheckDef) apiexec.ResponseChecker {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/apiexec"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/discovery"
 	"github.com/valon-technologies/gestalt/internal/invocation"
@@ -279,35 +280,18 @@ func (s *Server) getProvider(w http.ResponseWriter, name string) (core.Provider,
 	return prov, true
 }
 
-func (s *Server) requireOAuthProvider(w http.ResponseWriter, name string) (core.OAuthProvider, bool) {
-	prov, ok := s.getProvider(w, name)
+func (s *Server) requireOAuthHandler(w http.ResponseWriter, integration, connection string) (bootstrap.OAuthHandler, bool) {
+	connMap := s.connectionAuth[integration]
+	if connMap == nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("integration %q has no OAuth connections configured", integration))
+		return nil, false
+	}
+	handler, ok := connMap[connection]
 	if !ok {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("connection %q on integration %q does not support OAuth", connection, integration))
 		return nil, false
 	}
-	oauthProv, ok := prov.(core.OAuthProvider)
-	if !ok {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("integration %q does not support OAuth", name))
-		return nil, false
-	}
-	if atl, ok := prov.(core.AuthTypeLister); ok {
-		hasOAuth := false
-		for _, t := range atl.AuthTypes() {
-			if t == "oauth" {
-				hasOAuth = true
-				break
-			}
-		}
-		if !hasOAuth {
-			writeError(w, http.StatusBadRequest,
-				fmt.Sprintf("integration %q uses manual auth; use POST /api/v1/auth/connect-manual instead", name))
-			return nil, false
-		}
-	} else if mp, ok := prov.(core.ManualProvider); ok && mp.SupportsManualAuth() {
-		writeError(w, http.StatusBadRequest,
-			fmt.Sprintf("integration %q uses manual auth; use POST /api/v1/auth/connect-manual instead", name))
-		return nil, false
-	}
-	return oauthProv, true
+	return handler, true
 }
 
 func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
@@ -546,14 +530,6 @@ type startOAuthRequest struct {
 	ConnectionParams map[string]string `json:"connection_params"`
 }
 
-type oauthStarter interface {
-	StartOAuth(state string, scopes []string) (authURL string, verifier string)
-}
-
-type oauthVerifierExchanger interface {
-	ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, extraOpts ...oauth.ExchangeOption) (*core.TokenResponse, error)
-}
-
 func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 	var req startOAuthRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -561,12 +537,26 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	oauthProv, ok := s.requireOAuthProvider(w, req.Integration)
-	if !ok {
+	if _, ok := s.getProvider(w, req.Integration); !ok {
 		return
 	}
 
-	prov, _ := s.providers.Get(req.Integration)
+	connection := req.Connection
+	if connection == "" {
+		connection = s.defaultConnection[req.Integration]
+	}
+	if connection == "" {
+		connection = config.PluginConnectionName
+	}
+	if !safeParamValue.MatchString(connection) {
+		writeError(w, http.StatusBadRequest, "connection name contains invalid characters")
+		return
+	}
+
+	handler, ok := s.requireOAuthHandler(w, req.Integration, connection)
+	if !ok {
+		return
+	}
 
 	if s.stateCodec == nil {
 		writeError(w, http.StatusInternalServerError, "oauth state encryption is not configured")
@@ -587,17 +577,7 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	connection := req.Connection
-	if connection == "" {
-		connection = s.defaultConnection[req.Integration]
-	}
-	if connection == "" {
-		connection = config.PluginConnectionName
-	}
-	if !safeParamValue.MatchString(connection) {
-		writeError(w, http.StatusBadRequest, "connection name contains invalid characters")
-		return
-	}
+	prov, _ := s.providers.Get(req.Integration)
 
 	var connParams map[string]string
 	if cpp, ok := prov.(core.ConnectionParamProvider); ok {
@@ -614,28 +594,15 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		verifier string
 	)
 
-	type authURLOverrider interface {
-		StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string)
-	}
-	type authBaseURLer interface{ AuthorizationBaseURL() string }
-
 	if len(connParams) > 0 {
-		if abu, ok := prov.(authBaseURLer); ok {
-			rawAuthURL := abu.AuthorizationBaseURL()
-			resolvedAuthURL := paraminterp.Interpolate(rawAuthURL, connParams)
-			if resolvedAuthURL != rawAuthURL {
-				if ov, ok := prov.(authURLOverrider); ok {
-					authURL, verifier = ov.StartOAuthWithOverride(resolvedAuthURL, "_", req.Scopes)
-				}
-			}
+		rawAuthURL := handler.AuthorizationBaseURL()
+		resolvedAuthURL := paraminterp.Interpolate(rawAuthURL, connParams)
+		if resolvedAuthURL != rawAuthURL {
+			authURL, verifier = handler.StartOAuthWithOverride(resolvedAuthURL, "_", req.Scopes)
 		}
 	}
 	if authURL == "" {
-		if starter, ok := prov.(oauthStarter); ok {
-			authURL, verifier = starter.StartOAuth("_", req.Scopes)
-		} else {
-			authURL = oauthProv.AuthorizationURL("_", req.Scopes)
-		}
+		authURL, verifier = handler.StartOAuth("_", req.Scopes)
 	}
 
 	state, err := s.stateCodec.Encode(integrationOAuthState{
@@ -681,7 +648,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	}
 
 	providerName := state.Integration
-	oauthProv, ok := s.requireOAuthProvider(w, providerName)
+	handler, ok := s.requireOAuthHandler(w, providerName, state.Connection)
 	if !ok {
 		return
 	}
@@ -691,25 +658,15 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	var exchangeOpts []oauth.ExchangeOption
 	connParams := state.ConnectionParams
 	if len(connParams) > 0 {
-		type tokenURLer interface{ TokenURL() string }
-		if tup, ok := prov.(tokenURLer); ok {
-			rawURL := tup.TokenURL()
-			resolved := paraminterp.Interpolate(rawURL, connParams)
-			if resolved != rawURL {
-				exchangeOpts = append(exchangeOpts, oauth.WithTokenURL(resolved))
-			}
+		rawURL := handler.TokenURL()
+		resolved := paraminterp.Interpolate(rawURL, connParams)
+		if resolved != rawURL {
+			exchangeOpts = append(exchangeOpts, oauth.WithTokenURL(resolved))
 		}
 	}
 
 	var tokenResp *core.TokenResponse
-	if exchanger, ok := prov.(oauthVerifierExchanger); ok {
-		tokenResp, err = exchanger.ExchangeCodeWithVerifier(r.Context(), code, state.Verifier, exchangeOpts...)
-	} else {
-		if len(exchangeOpts) > 0 {
-			log.Printf("WARNING: %s does not support exchange options (e.g. token URL override); connection params may not apply to token exchange", providerName)
-		}
-		tokenResp, err = oauthProv.ExchangeCode(r.Context(), code)
-	}
+	tokenResp, err = handler.ExchangeCodeWithVerifier(r.Context(), code, state.Verifier, exchangeOpts...)
 	if err != nil {
 		log.Printf("token exchange failed for %s: %v", providerName, err)
 		writeError(w, http.StatusBadGateway, "token exchange failed")

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -281,7 +281,11 @@ func (s *Server) getProvider(w http.ResponseWriter, name string) (core.Provider,
 }
 
 func (s *Server) requireOAuthHandler(w http.ResponseWriter, integration, connection string) (bootstrap.OAuthHandler, bool) {
-	connMap := s.connectionAuth[integration]
+	if s.connectionAuth == nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("integration %q has no OAuth connections configured", integration))
+		return nil, false
+	}
+	connMap := s.connectionAuth()[integration]
 	if connMap == nil {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("integration %q has no OAuth connections configured", integration))
 		return nil, false

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,7 +29,7 @@ type Server struct {
 	resolver           *principal.Resolver
 	invoker            invocation.Invoker
 	defaultConnection  map[string]string
-	connectionAuth     map[string]map[string]bootstrap.OAuthHandler
+	connectionAuth     func() map[string]map[string]bootstrap.OAuthHandler
 	integrationDefs    map[string]config.IntegrationDef
 	noAuth             bool
 	anonymousPrincipal *principal.Principal
@@ -49,7 +49,7 @@ type Config struct {
 	Bindings          *registry.PluginMap[core.Binding]
 	Invoker           invocation.Invoker
 	DefaultConnection map[string]string
-	ConnectionAuth    map[string]map[string]bootstrap.OAuthHandler
+	ConnectionAuth    func() map[string]map[string]bootstrap.OAuthHandler
 	IntegrationDefs   map[string]config.IntegrationDef
 	SecureCookies     bool
 	StateSecret       []byte

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	"github.com/valon-technologies/gestalt/internal/principal"
@@ -28,6 +29,7 @@ type Server struct {
 	resolver           *principal.Resolver
 	invoker            invocation.Invoker
 	defaultConnection  map[string]string
+	connectionAuth     map[string]map[string]bootstrap.OAuthHandler
 	integrationDefs    map[string]config.IntegrationDef
 	noAuth             bool
 	anonymousPrincipal *principal.Principal
@@ -47,6 +49,7 @@ type Config struct {
 	Bindings          *registry.PluginMap[core.Binding]
 	Invoker           invocation.Invoker
 	DefaultConnection map[string]string
+	ConnectionAuth    map[string]map[string]bootstrap.OAuthHandler
 	IntegrationDefs   map[string]config.IntegrationDef
 	SecureCookies     bool
 	StateSecret       []byte
@@ -86,6 +89,7 @@ func New(cfg Config) (*Server, error) {
 		resolver:          resolver,
 		invoker:           cfg.Invoker,
 		defaultConnection: cfg.DefaultConnection,
+		connectionAuth:    cfg.ConnectionAuth,
 		integrationDefs:   cfg.IntegrationDefs,
 		noAuth:            noAuth,
 		secureCookies:     cfg.SecureCookies,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -78,15 +78,15 @@ func newTestServer(t *testing.T, opts ...func(*server.Config)) *httptest.Server 
 // server tests. Only the methods actually exercised by each test need non-nil
 // implementations.
 type testOAuthHandler struct {
-	authorizationURLFn      func(state string, scopes []string) string
-	startOAuthFn            func(state string, scopes []string) (string, string)
+	authorizationURLFn       func(state string, scopes []string) string
+	startOAuthFn             func(state string, scopes []string) (string, string)
 	startOAuthWithOverrideFn func(authBaseURL, state string, scopes []string) (string, string)
-	exchangeCodeFn          func(ctx context.Context, code string) (*core.TokenResponse, error)
-	exchangeCodeWithVerFn   func(ctx context.Context, code, verifier string, opts ...oauth.ExchangeOption) (*core.TokenResponse, error)
-	refreshTokenFn          func(ctx context.Context, refreshToken string) (*core.TokenResponse, error)
-	refreshTokenWithURLFn   func(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error)
-	authorizationBaseURLVal string
-	tokenURLVal             string
+	exchangeCodeFn           func(ctx context.Context, code string) (*core.TokenResponse, error)
+	exchangeCodeWithVerFn    func(ctx context.Context, code, verifier string, opts ...oauth.ExchangeOption) (*core.TokenResponse, error)
+	refreshTokenFn           func(ctx context.Context, refreshToken string) (*core.TokenResponse, error)
+	refreshTokenWithURLFn    func(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error)
+	authorizationBaseURLVal  string
+	tokenURLVal              string
 }
 
 func (h *testOAuthHandler) AuthorizationURL(state string, scopes []string) string {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -54,15 +54,19 @@ func newTestServer(t *testing.T, opts ...func(*server.Config)) *httptest.Server 
 		brokerOpts = append(brokerOpts, invocation.WithConnectionMapper(invocation.ConnectionMap(cfg.DefaultConnection)))
 	}
 	if cfg.ConnectionAuth != nil {
-		refreshers := make(map[string]map[string]invocation.OAuthRefresher)
-		for intg, conns := range cfg.ConnectionAuth {
-			inner := make(map[string]invocation.OAuthRefresher)
-			for conn, h := range conns {
-				inner[conn] = h
+		authFn := cfg.ConnectionAuth
+		brokerOpts = append(brokerOpts, invocation.WithConnectionAuth(func() map[string]map[string]invocation.OAuthRefresher {
+			m := authFn()
+			refreshers := make(map[string]map[string]invocation.OAuthRefresher, len(m))
+			for intg, conns := range m {
+				inner := make(map[string]invocation.OAuthRefresher, len(conns))
+				for conn, h := range conns {
+					inner[conn] = h
+				}
+				refreshers[intg] = inner
 			}
-			refreshers[intg] = inner
-		}
-		brokerOpts = append(brokerOpts, invocation.WithConnectionAuth(refreshers))
+			return refreshers
+		}))
 	}
 	if cfg.Invoker == nil {
 		cfg.Invoker = invocation.NewBroker(cfg.Providers, cfg.Datastore, brokerOpts...)
@@ -144,13 +148,14 @@ func (h *testOAuthHandler) TokenURL() string             { return h.tokenURLVal 
 
 const testDefaultConnection = "default"
 
-func testConnectionAuth(integration string, handler bootstrap.OAuthHandler) map[string]map[string]bootstrap.OAuthHandler {
-	return map[string]map[string]bootstrap.OAuthHandler{
+func testConnectionAuth(integration string, handler bootstrap.OAuthHandler) func() map[string]map[string]bootstrap.OAuthHandler {
+	m := map[string]map[string]bootstrap.OAuthHandler{
 		integration: {testDefaultConnection: handler},
 	}
+	return func() map[string]map[string]bootstrap.OAuthHandler { return m }
 }
 
-func oauthRefreshConnectionAuth(integration string, refreshFn func(context.Context, string) (*core.TokenResponse, error)) map[string]map[string]bootstrap.OAuthHandler {
+func oauthRefreshConnectionAuth(integration string, refreshFn func(context.Context, string) (*core.TokenResponse, error)) func() map[string]map[string]bootstrap.OAuthHandler {
 	return testConnectionAuth(integration, &testOAuthHandler{refreshTokenFn: refreshFn})
 }
 
@@ -2988,11 +2993,13 @@ func TestStartOAuth_MultiConnection_SelectsByConnectionName(t *testing.T) {
 		cfg.DevMode = true
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
 		cfg.DefaultConnection = map[string]string{"multi": "conn-a"}
-		cfg.ConnectionAuth = map[string]map[string]bootstrap.OAuthHandler{
-			"multi": {
-				"conn-a": connAHandler,
-				"conn-b": connBHandler,
-			},
+		cfg.ConnectionAuth = func() map[string]map[string]bootstrap.OAuthHandler {
+			return map[string]map[string]bootstrap.OAuthHandler{
+				"multi": {
+					"conn-a": connAHandler,
+					"conn-b": connBHandler,
+				},
+			}
 		}
 		cfg.Datastore = &coretesting.StubDatastore{
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
@@ -3093,11 +3100,13 @@ func TestOAuthCallback_UsesStateConnection(t *testing.T) {
 		cfg.DevMode = true
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
 		cfg.DefaultConnection = map[string]string{"multi": "conn-a"}
-		cfg.ConnectionAuth = map[string]map[string]bootstrap.OAuthHandler{
-			"multi": {
-				"conn-a": &testOAuthHandler{authorizationBaseURLVal: "https://provider.example/oauth/a"},
-				"conn-b": handler,
-			},
+		cfg.ConnectionAuth = func() map[string]map[string]bootstrap.OAuthHandler {
+			return map[string]map[string]bootstrap.OAuthHandler{
+				"multi": {
+					"conn-a": &testOAuthHandler{authorizationBaseURLVal: "https://provider.example/oauth/a"},
+					"conn-b": handler,
+				},
+			}
 		}
 		cfg.Datastore = &coretesting.StubDatastore{
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -49,14 +49,109 @@ func newTestServer(t *testing.T, opts ...func(*server.Config)) *httptest.Server 
 	for _, opt := range opts {
 		opt(&cfg)
 	}
+	brokerOpts := []invocation.BrokerOption{}
+	if cfg.DefaultConnection != nil {
+		brokerOpts = append(brokerOpts, invocation.WithConnectionMapper(invocation.ConnectionMap(cfg.DefaultConnection)))
+	}
+	if cfg.ConnectionAuth != nil {
+		refreshers := make(map[string]map[string]invocation.OAuthRefresher)
+		for intg, conns := range cfg.ConnectionAuth {
+			inner := make(map[string]invocation.OAuthRefresher)
+			for conn, h := range conns {
+				inner[conn] = h
+			}
+			refreshers[intg] = inner
+		}
+		brokerOpts = append(brokerOpts, invocation.WithConnectionAuth(refreshers))
+	}
 	if cfg.Invoker == nil {
-		cfg.Invoker = invocation.NewBroker(cfg.Providers, cfg.Datastore)
+		cfg.Invoker = invocation.NewBroker(cfg.Providers, cfg.Datastore, brokerOpts...)
 	}
 	srv, err := server.New(cfg)
 	if err != nil {
 		t.Fatalf("creating server: %v", err)
 	}
 	return httptest.NewServer(srv)
+}
+
+// testOAuthHandler adapts a test stub into bootstrap.OAuthHandler for use in
+// server tests. Only the methods actually exercised by each test need non-nil
+// implementations.
+type testOAuthHandler struct {
+	authorizationURLFn      func(state string, scopes []string) string
+	startOAuthFn            func(state string, scopes []string) (string, string)
+	startOAuthWithOverrideFn func(authBaseURL, state string, scopes []string) (string, string)
+	exchangeCodeFn          func(ctx context.Context, code string) (*core.TokenResponse, error)
+	exchangeCodeWithVerFn   func(ctx context.Context, code, verifier string, opts ...oauth.ExchangeOption) (*core.TokenResponse, error)
+	refreshTokenFn          func(ctx context.Context, refreshToken string) (*core.TokenResponse, error)
+	refreshTokenWithURLFn   func(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error)
+	authorizationBaseURLVal string
+	tokenURLVal             string
+}
+
+func (h *testOAuthHandler) AuthorizationURL(state string, scopes []string) string {
+	if h.authorizationURLFn != nil {
+		return h.authorizationURLFn(state, scopes)
+	}
+	url, _ := h.StartOAuth(state, scopes)
+	return url
+}
+
+func (h *testOAuthHandler) StartOAuth(state string, scopes []string) (string, string) {
+	if h.startOAuthFn != nil {
+		return h.startOAuthFn(state, scopes)
+	}
+	return h.authorizationBaseURLVal + "?state=" + state, ""
+}
+
+func (h *testOAuthHandler) StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string) {
+	if h.startOAuthWithOverrideFn != nil {
+		return h.startOAuthWithOverrideFn(authBaseURL, state, scopes)
+	}
+	return authBaseURL + "?state=" + state, ""
+}
+
+func (h *testOAuthHandler) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	if h.exchangeCodeFn != nil {
+		return h.exchangeCodeFn(ctx, code)
+	}
+	return nil, fmt.Errorf("ExchangeCode not implemented")
+}
+
+func (h *testOAuthHandler) ExchangeCodeWithVerifier(ctx context.Context, code, verifier string, opts ...oauth.ExchangeOption) (*core.TokenResponse, error) {
+	if h.exchangeCodeWithVerFn != nil {
+		return h.exchangeCodeWithVerFn(ctx, code, verifier, opts...)
+	}
+	return h.ExchangeCode(ctx, code)
+}
+
+func (h *testOAuthHandler) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	if h.refreshTokenFn != nil {
+		return h.refreshTokenFn(ctx, refreshToken)
+	}
+	return nil, fmt.Errorf("RefreshToken not implemented")
+}
+
+func (h *testOAuthHandler) RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL string) (*core.TokenResponse, error) {
+	if h.refreshTokenWithURLFn != nil {
+		return h.refreshTokenWithURLFn(ctx, refreshToken, tokenURL)
+	}
+	return h.RefreshToken(ctx, refreshToken)
+}
+
+func (h *testOAuthHandler) AuthorizationBaseURL() string { return h.authorizationBaseURLVal }
+func (h *testOAuthHandler) TokenURL() string             { return h.tokenURLVal }
+
+const testDefaultConnection = "default"
+
+func testConnectionAuth(integration string, handler bootstrap.OAuthHandler) map[string]map[string]bootstrap.OAuthHandler {
+	return map[string]map[string]bootstrap.OAuthHandler{
+		integration: {testDefaultConnection: handler},
+	}
+}
+
+func oauthRefreshConnectionAuth(integration string, refreshFn func(context.Context, string) (*core.TokenResponse, error)) map[string]map[string]bootstrap.OAuthHandler {
+	return testConnectionAuth(integration, &testOAuthHandler{refreshTokenFn: refreshFn})
 }
 
 func TestHealthCheck(t *testing.T) {
@@ -1168,8 +1263,14 @@ func TestStartIntegrationOAuth(t *testing.T) {
 		authURL:         "https://slack.com/oauth/v2/authorize",
 	}
 
+	handler := &testOAuthHandler{
+		authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
+	}
+
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+		cfg.ConnectionAuth = testConnectionAuth("slack", handler)
 		cfg.Datastore = &coretesting.StubDatastore{
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
@@ -1215,21 +1316,26 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 	t.Parallel()
 
 	var stored *core.IntegrationToken
-	stub := &stubIntegrationWithAuthURL{
-		StubIntegration: coretesting.StubIntegration{
-			N: "slack",
-			ExchangeCodeFn: func(_ context.Context, code string) (*core.TokenResponse, error) {
-				if code == "good-code" {
-					return &core.TokenResponse{AccessToken: "slack-token"}, nil
-				}
-				return nil, fmt.Errorf("bad code")
-			},
+
+	handler := &testOAuthHandler{
+		authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
+		exchangeCodeFn: func(_ context.Context, code string) (*core.TokenResponse, error) {
+			if code == "good-code" {
+				return &core.TokenResponse{AccessToken: "slack-token"}, nil
+			}
+			return nil, fmt.Errorf("bad code")
 		},
-		authURL: "https://slack.com/oauth/v2/authorize",
+	}
+
+	stub := &stubIntegrationWithAuthURL{
+		StubIntegration: coretesting.StubIntegration{N: "slack"},
+		authURL:         "https://slack.com/oauth/v2/authorize",
 	}
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+		cfg.ConnectionAuth = testConnectionAuth("slack", handler)
 		cfg.Datastore = &coretesting.StubDatastore{
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
@@ -1670,8 +1776,24 @@ func TestIntegrationOAuthCallback_PKCEUsesVerifier(t *testing.T) {
 		wantVerifier:    "verifier-123",
 	}
 
+	handler := &testOAuthHandler{
+		authorizationBaseURLVal: "https://gitlab.com/oauth/authorize",
+		startOAuthFn: func(state string, _ []string) (string, string) {
+			return "https://gitlab.com/oauth/authorize?state=" + state, "verifier-123"
+		},
+		exchangeCodeWithVerFn: func(_ context.Context, code, verifier string, _ ...oauth.ExchangeOption) (*core.TokenResponse, error) {
+			stub.gotVerifier = verifier
+			if code != "good-code" {
+				return nil, fmt.Errorf("bad code")
+			}
+			return &core.TokenResponse{AccessToken: "pkce-token"}, nil
+		},
+	}
+
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"gitlab": testDefaultConnection}
+		cfg.ConnectionAuth = testConnectionAuth("gitlab", handler)
 		cfg.Datastore = &coretesting.StubDatastore{
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
@@ -1806,6 +1928,8 @@ func TestExecuteOperation_RefreshesExpiredToken(t *testing.T) {
 	var storedToken *core.IntegrationToken
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"fake": testDefaultConnection}
+		cfg.ConnectionAuth = oauthRefreshConnectionAuth("fake", stub.refreshTokenFn)
 		cfg.Datastore = &coretesting.StubDatastore{
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
@@ -1877,6 +2001,8 @@ func TestExecuteOperation_RefreshFailsButTokenStillValid(t *testing.T) {
 	expiresInThree := time.Now().Add(3 * time.Minute)
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"fake": testDefaultConnection}
+		cfg.ConnectionAuth = oauthRefreshConnectionAuth("fake", stub.refreshTokenFn)
 		cfg.Datastore = &coretesting.StubDatastore{
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
@@ -1933,6 +2059,8 @@ func TestExecuteOperation_RefreshFailsAndTokenExpired(t *testing.T) {
 	alreadyExpired := time.Now().Add(-10 * time.Minute)
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"fake": testDefaultConnection}
+		cfg.ConnectionAuth = oauthRefreshConnectionAuth("fake", stub.refreshTokenFn)
 		cfg.Datastore = &coretesting.StubDatastore{
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
@@ -1984,6 +2112,8 @@ func TestExecuteOperation_NoRefreshTokenSkipsRefresh(t *testing.T) {
 	expiresSoon := time.Now().Add(2 * time.Minute)
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"fake": testDefaultConnection}
+		cfg.ConnectionAuth = oauthRefreshConnectionAuth("fake", stub.refreshTokenFn)
 		cfg.Datastore = &coretesting.StubDatastore{
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
@@ -2036,6 +2166,8 @@ func TestExecuteOperation_NoExpiresAtSkipsRefresh(t *testing.T) {
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"fake": testDefaultConnection}
+		cfg.ConnectionAuth = oauthRefreshConnectionAuth("fake", stub.refreshTokenFn)
 		cfg.Datastore = &coretesting.StubDatastore{
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
@@ -2137,6 +2269,8 @@ func TestExecuteOperation_RefreshTokenRotation(t *testing.T) {
 	var storedToken *core.IntegrationToken
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"fake": testDefaultConnection}
+		cfg.ConnectionAuth = oauthRefreshConnectionAuth("fake", stub.refreshTokenFn)
 		cfg.Datastore = &coretesting.StubDatastore{
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
@@ -2199,6 +2333,8 @@ func TestExecuteOperation_RefreshClearsExpiresAtWhenOmitted(t *testing.T) {
 	var storedToken *core.IntegrationToken
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"fake": testDefaultConnection}
+		cfg.ConnectionAuth = oauthRefreshConnectionAuth("fake", stub.refreshTokenFn)
 		cfg.Datastore = &coretesting.StubDatastore{
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
@@ -2264,6 +2400,8 @@ func TestExecuteOperation_RefreshErrorSkipsStoreOnConcurrentRefresh(t *testing.T
 	var storedToken *core.IntegrationToken
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"fake": testDefaultConnection}
+		cfg.ConnectionAuth = oauthRefreshConnectionAuth("fake", stub.refreshTokenFn)
 		cfg.Datastore = &coretesting.StubDatastore{
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
@@ -2329,6 +2467,8 @@ func TestExecuteOperation_StoreTokenFailureReturnsError(t *testing.T) {
 	expiresSoon := time.Now().Add(2 * time.Minute)
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"fake": testDefaultConnection}
+		cfg.ConnectionAuth = oauthRefreshConnectionAuth("fake", stub.refreshTokenFn)
 		cfg.Datastore = &coretesting.StubDatastore{
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
@@ -2381,6 +2521,8 @@ func TestExecuteOperation_RefreshErrorHandlesDeletedToken(t *testing.T) {
 	tokenCallCount := 0
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"fake": testDefaultConnection}
+		cfg.ConnectionAuth = oauthRefreshConnectionAuth("fake", stub.refreshTokenFn)
 		cfg.Datastore = &coretesting.StubDatastore{
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
@@ -2824,6 +2966,244 @@ func TestStartOAuth_ManualProviderRejected(t *testing.T) {
 	}
 	if result["error"] == "" {
 		t.Fatal("expected error message in response")
+	}
+}
+
+func TestStartOAuth_MultiConnection_SelectsByConnectionName(t *testing.T) {
+	t.Parallel()
+
+	connAHandler := &testOAuthHandler{
+		authorizationBaseURLVal: "https://provider.example/oauth/a",
+	}
+	connBHandler := &testOAuthHandler{
+		authorizationBaseURLVal: "https://provider.example/oauth/b",
+	}
+
+	stub := &stubIntegrationWithAuthURL{
+		StubIntegration: coretesting.StubIntegration{N: "multi"},
+		authURL:         "https://provider.example/oauth/a",
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"multi": "conn-a"}
+		cfg.ConnectionAuth = map[string]map[string]bootstrap.OAuthHandler{
+			"multi": {
+				"conn-a": connAHandler,
+				"conn-b": connBHandler,
+			},
+		}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"integration":"multi","connection":"conn-b"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", body)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, bodyBytes)
+	}
+	var result map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if !strings.Contains(result["url"], "provider.example/oauth/b") {
+		t.Fatalf("expected conn-b auth URL, got %q", result["url"])
+	}
+}
+
+func TestStartOAuth_MissingConnection_FailsCleanly(t *testing.T) {
+	t.Parallel()
+
+	handler := &testOAuthHandler{
+		authorizationBaseURLVal: "https://provider.example/oauth",
+	}
+
+	stub := &stubIntegrationWithAuthURL{
+		StubIntegration: coretesting.StubIntegration{N: "myint"},
+		authURL:         "https://provider.example/oauth",
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"myint": "conn-a"}
+		cfg.ConnectionAuth = testConnectionAuth("myint", handler)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"integration":"myint","connection":"nonexistent"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", body)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+	var result map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if !strings.Contains(result["error"], "nonexistent") {
+		t.Fatalf("expected error to mention missing connection, got %q", result["error"])
+	}
+}
+
+func TestOAuthCallback_UsesStateConnection(t *testing.T) {
+	t.Parallel()
+
+	var exchangedConnection string
+	handler := &testOAuthHandler{
+		authorizationBaseURLVal: "https://provider.example/oauth",
+		exchangeCodeFn: func(_ context.Context, code string) (*core.TokenResponse, error) {
+			exchangedConnection = "conn-b"
+			return &core.TokenResponse{AccessToken: "token-for-b"}, nil
+		},
+	}
+
+	stub := &stubIntegrationWithAuthURL{
+		StubIntegration: coretesting.StubIntegration{N: "multi"},
+		authURL:         "https://provider.example/oauth",
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"multi": "conn-a"}
+		cfg.ConnectionAuth = map[string]map[string]bootstrap.OAuthHandler{
+			"multi": {
+				"conn-a": &testOAuthHandler{authorizationBaseURLVal: "https://provider.example/oauth/a"},
+				"conn-b": handler,
+			},
+		}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			StoreTokenFn: func(_ context.Context, _ *core.IntegrationToken) error {
+				return nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	startBody := bytes.NewBufferString(`{"integration":"multi","connection":"conn-b"}`)
+	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
+	startReq.Header.Set("X-Dev-User-Email", "dev@example.com")
+	startReq.Header.Set("Content-Type", "application/json")
+	startResp, err := http.DefaultClient.Do(startReq)
+	if err != nil {
+		t.Fatalf("start request: %v", err)
+	}
+	defer func() { _ = startResp.Body.Close() }()
+	if startResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from start-oauth, got %d", startResp.StatusCode)
+	}
+	var startResult map[string]string
+	if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
+		t.Fatalf("decoding start response: %v", err)
+	}
+
+	noRedirect := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=ok&state="+url.QueryEscape(startResult["state"]), nil)
+	resp, err := noRedirect.Do(req)
+	if err != nil {
+		t.Fatalf("callback request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("expected 303 redirect, got %d", resp.StatusCode)
+	}
+	if exchangedConnection != "conn-b" {
+		t.Fatalf("expected conn-b handler to be used for exchange, got %q", exchangedConnection)
+	}
+}
+
+func TestRefresh_UsesConnectionAuth(t *testing.T) {
+	t.Parallel()
+
+	var refreshedVia string
+	stub := &stubOAuthIntegration{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N: "fake",
+				ExecuteFn: func(_ context.Context, _ string, _ map[string]any, token string) (*core.OperationResult, error) {
+					return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+				},
+			},
+			ops: []core.Operation{{Name: "list", Description: "List", Method: "GET"}},
+		},
+		refreshTokenFn: func(_ context.Context, rt string) (*core.TokenResponse, error) {
+			refreshedVia = "connection-handler"
+			return &core.TokenResponse{AccessToken: "refreshed-token", ExpiresIn: 3600}, nil
+		},
+	}
+
+	expiresSoon := time.Now().Add(2 * time.Minute)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.DevMode = true
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"fake": testDefaultConnection}
+		cfg.ConnectionAuth = oauthRefreshConnectionAuth("fake", stub.refreshTokenFn)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
+				return &core.IntegrationToken{
+					AccessToken:  "stale",
+					RefreshToken: "rf",
+					ExpiresAt:    &expiresSoon,
+				}, nil
+			},
+			StoreTokenFn: func(_ context.Context, _ *core.IntegrationToken) error {
+				return nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/fake/list", nil)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if refreshedVia != "connection-handler" {
+		t.Fatalf("expected refresh via connection handler, got %q", refreshedVia)
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2990,7 +2990,6 @@ func TestStartOAuth_MultiConnection_SelectsByConnectionName(t *testing.T) {
 	}
 
 	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.DevMode = true
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
 		cfg.DefaultConnection = map[string]string{"multi": "conn-a"}
 		cfg.ConnectionAuth = func() map[string]map[string]bootstrap.OAuthHandler {
@@ -3045,7 +3044,6 @@ func TestStartOAuth_MissingConnection_FailsCleanly(t *testing.T) {
 	}
 
 	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.DevMode = true
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
 		cfg.DefaultConnection = map[string]string{"myint": "conn-a"}
 		cfg.ConnectionAuth = testConnectionAuth("myint", handler)
@@ -3097,7 +3095,6 @@ func TestOAuthCallback_UsesStateConnection(t *testing.T) {
 	}
 
 	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.DevMode = true
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
 		cfg.DefaultConnection = map[string]string{"multi": "conn-a"}
 		cfg.ConnectionAuth = func() map[string]map[string]bootstrap.OAuthHandler {
@@ -3178,7 +3175,6 @@ func TestRefresh_UsesConnectionAuth(t *testing.T) {
 
 	expiresSoon := time.Now().Add(2 * time.Minute)
 	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.DevMode = true
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
 		cfg.DefaultConnection = map[string]string{"fake": testDefaultConnection}
 		cfg.ConnectionAuth = oauthRefreshConnectionAuth("fake", stub.refreshTokenFn)

--- a/plugins/providers/bigquery/factory.go
+++ b/plugins/providers/bigquery/factory.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"net/http"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -25,9 +27,20 @@ func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps 
 		return nil, fmt.Errorf("bigquery: %w", err)
 	}
 	provider.ApplyDisplayOverrides(&def, intg)
+	provider.ApplyConnectionAuth(&def, conn)
 	prov, err := provider.Build(&def, conn, nil, provider.WithEgressResolver(deps.Egress.Resolver))
 	if err != nil {
 		return nil, err
 	}
-	return &bootstrap.ProviderBuildResult{Provider: prov}, nil
+	result := &bootstrap.ProviderBuildResult{Provider: prov}
+	if conn.Auth.Type != "manual" && conn.Auth.Type != "api_key" {
+		upstream, err := provider.BuildOAuthUpstream(&def, conn, def.BaseURL, &http.Client{Timeout: 10 * time.Second})
+		if err == nil {
+			connName := intg.API.Connection
+			result.ConnectionAuth = map[string]bootstrap.OAuthHandler{
+				connName: bootstrap.WrapUpstreamHandler(upstream),
+			}
+		}
+	}
+	return result, nil
 }

--- a/plugins/providers/bigquery/factory.go
+++ b/plugins/providers/bigquery/factory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"log"
 	"net/http"
 	"time"
 
@@ -35,10 +36,11 @@ func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps 
 	result := &bootstrap.ProviderBuildResult{Provider: prov}
 	if conn.Auth.Type != "manual" && conn.Auth.Type != "api_key" {
 		upstream, err := provider.BuildOAuthUpstream(&def, conn, def.BaseURL, &http.Client{Timeout: 10 * time.Second})
-		if err == nil {
-			connName := intg.API.Connection
+		if err != nil {
+			log.Printf("WARNING: bigquery: cannot build oauth handler for connection %q: %v", intg.API.Connection, err)
+		} else {
 			result.ConnectionAuth = map[string]bootstrap.OAuthHandler{
-				connName: bootstrap.WrapUpstreamHandler(upstream),
+				intg.API.Connection: bootstrap.WrapUpstreamHandler(upstream),
 			}
 		}
 	}

--- a/plugins/providers/bigquery/factory.go
+++ b/plugins/providers/bigquery/factory.go
@@ -7,7 +7,6 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/provider"
@@ -16,7 +15,7 @@ import (
 //go:embed provider.yaml
 var definitionYAML []byte
 
-func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (*bootstrap.ProviderBuildResult, error) {
 	var def provider.Definition
 	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
 		return nil, fmt.Errorf("bigquery: parsing embedded definition: %w", err)
@@ -26,5 +25,9 @@ func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps 
 		return nil, fmt.Errorf("bigquery: %w", err)
 	}
 	provider.ApplyDisplayOverrides(&def, intg)
-	return provider.Build(&def, conn, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+	prov, err := provider.Build(&def, conn, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+	if err != nil {
+		return nil, err
+	}
+	return &bootstrap.ProviderBuildResult{Provider: prov}, nil
 }

--- a/plugins/providers/bigquery/factory.go
+++ b/plugins/providers/bigquery/factory.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"log"
-	"net/http"
-	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -33,16 +30,5 @@ func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps 
 	if err != nil {
 		return nil, err
 	}
-	result := &bootstrap.ProviderBuildResult{Provider: prov}
-	if conn.Auth.Type != "manual" && conn.Auth.Type != "api_key" {
-		upstream, err := provider.BuildOAuthUpstream(&def, conn, def.BaseURL, &http.Client{Timeout: 10 * time.Second})
-		if err != nil {
-			log.Printf("WARNING: bigquery: cannot build oauth handler for connection %q: %v", intg.API.Connection, err)
-		} else {
-			result.ConnectionAuth = map[string]bootstrap.OAuthHandler{
-				intg.API.Connection: bootstrap.WrapUpstreamHandler(upstream),
-			}
-		}
-	}
-	return result, nil
+	return bootstrap.BuildResultWithOAuth(prov, &def, intg, conn), nil
 }

--- a/plugins/providers/jira/factory.go
+++ b/plugins/providers/jira/factory.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/internal/config"
@@ -24,9 +26,20 @@ func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps 
 		return nil, fmt.Errorf("jira: %w", err)
 	}
 	provider.ApplyDisplayOverrides(&def, intg)
+	provider.ApplyConnectionAuth(&def, conn)
 	prov, err := provider.Build(&def, conn, nil, provider.WithEgressResolver(deps.Egress.Resolver))
 	if err != nil {
 		return nil, err
 	}
-	return &bootstrap.ProviderBuildResult{Provider: prov}, nil
+	result := &bootstrap.ProviderBuildResult{Provider: prov}
+	if conn.Auth.Type != "manual" && conn.Auth.Type != "api_key" {
+		upstream, err := provider.BuildOAuthUpstream(&def, conn, def.BaseURL, &http.Client{Timeout: 10 * time.Second})
+		if err == nil {
+			connName := intg.API.Connection
+			result.ConnectionAuth = map[string]bootstrap.OAuthHandler{
+				connName: bootstrap.WrapUpstreamHandler(upstream),
+			}
+		}
+	}
+	return result, nil
 }

--- a/plugins/providers/jira/factory.go
+++ b/plugins/providers/jira/factory.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"log"
-	"net/http"
-	"time"
 
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/internal/config"
@@ -32,16 +29,5 @@ func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps 
 	if err != nil {
 		return nil, err
 	}
-	result := &bootstrap.ProviderBuildResult{Provider: prov}
-	if conn.Auth.Type != "manual" && conn.Auth.Type != "api_key" {
-		upstream, err := provider.BuildOAuthUpstream(&def, conn, def.BaseURL, &http.Client{Timeout: 10 * time.Second})
-		if err != nil {
-			log.Printf("WARNING: jira: cannot build oauth handler for connection %q: %v", intg.API.Connection, err)
-		} else {
-			result.ConnectionAuth = map[string]bootstrap.OAuthHandler{
-				intg.API.Connection: bootstrap.WrapUpstreamHandler(upstream),
-			}
-		}
-	}
-	return result, nil
+	return bootstrap.BuildResultWithOAuth(prov, &def, intg, conn), nil
 }

--- a/plugins/providers/jira/factory.go
+++ b/plugins/providers/jira/factory.go
@@ -5,7 +5,6 @@ import (
 	_ "embed"
 	"fmt"
 
-	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/provider"
@@ -15,7 +14,7 @@ import (
 //go:embed provider.yaml
 var definitionYAML []byte
 
-func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (core.Provider, error) {
+func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps bootstrap.Deps) (*bootstrap.ProviderBuildResult, error) {
 	var def provider.Definition
 	if err := yaml.Unmarshal(definitionYAML, &def); err != nil {
 		return nil, err
@@ -25,5 +24,9 @@ func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps 
 		return nil, fmt.Errorf("jira: %w", err)
 	}
 	provider.ApplyDisplayOverrides(&def, intg)
-	return provider.Build(&def, conn, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+	prov, err := provider.Build(&def, conn, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+	if err != nil {
+		return nil, err
+	}
+	return &bootstrap.ProviderBuildResult{Provider: prov}, nil
 }

--- a/plugins/providers/jira/factory.go
+++ b/plugins/providers/jira/factory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"log"
 	"net/http"
 	"time"
 
@@ -34,10 +35,11 @@ func Factory(ctx context.Context, name string, intg config.IntegrationDef, deps 
 	result := &bootstrap.ProviderBuildResult{Provider: prov}
 	if conn.Auth.Type != "manual" && conn.Auth.Type != "api_key" {
 		upstream, err := provider.BuildOAuthUpstream(&def, conn, def.BaseURL, &http.Client{Timeout: 10 * time.Second})
-		if err == nil {
-			connName := intg.API.Connection
+		if err != nil {
+			log.Printf("WARNING: jira: cannot build oauth handler for connection %q: %v", intg.API.Connection, err)
+		} else {
 			result.ConnectionAuth = map[string]bootstrap.OAuthHandler{
-				connName: bootstrap.WrapUpstreamHandler(upstream),
+				intg.API.Connection: bootstrap.WrapUpstreamHandler(upstream),
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Replace per-integration OAuth handler with per-connection handlers, so integrations with multiple connections (e.g. Notion with OAuth2 + MCP) use the correct auth flow for each
- Introduce OAuthHandler interface in bootstrap, change ProviderFactory to return ProviderBuildResult{Provider, ConnectionAuth}
- Build auth handlers for all declarative connections at bootstrap (oauth2, mcp_oauth), thread through server and broker
- Server resolves connection before handler lookup; broker refresh uses token.Connection
- No fallback to provider-level OAuthProvider; exact connection match required

## Test plan
- [x] go test ./... passes (all packages)
- [x] go build ./cmd/gestaltd/ succeeds
- [ ] Deploy to toolshed.peachstreet.dev, verify Notion shows two connect buttons with different OAuth URLs
- [ ] Verify Linear (single mcp_oauth) still works
- [ ] Verify Google Calendar (single oauth2) still works