### PR TITLE
Reset pending state unconditionally in handleStartOAuth

### DIFF
--- a/web/src/components/IntegrationCard.tsx
+++ b/web/src/components/IntegrationCard.tsx
@@ -90,8 +90,8 @@ export default function IntegrationCard({
   }
 
   async function handleStartOAuth(instance?: string, connection?: string) {
-    if (instance) setPendingInstance(instance);
-    if (connection) setPendingConnection(connection);
+    setPendingInstance(instance || "");
+    setPendingConnection(connection);
     if (needsParams && !showParamForm) {
       setSettingsOpen(false);
       setShowParamForm(true);


### PR DESCRIPTION
When starting a new OAuth flow, `pendingInstance` and
`pendingConnection` were only updated when the new values were truthy.
If a previous failed flow had set these to real values, subsequent
flows with undefined parameters would inherit the stale values, causing
`handleParamSubmit` to send the wrong instance or connection to the
server. Both values are now set unconditionally so each flow starts
clean.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>