### PR TITLE
Add plugin.source and plugin.version config fields

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/valon-technologies/gestalt/internal/egress"
+	"github.com/valon-technologies/gestalt/internal/pluginsource"
 	"gopkg.in/yaml.v3"
 )
 
@@ -64,6 +65,8 @@ type EgressCredentialGrant struct {
 type ExecutablePluginDef struct {
 	Command string            `yaml:"command"`
 	Package string            `yaml:"package"`
+	Source  string            `yaml:"source"`
+	Version string            `yaml:"version"`
 	Args    []string          `yaml:"args"`
 	Env     map[string]string `yaml:"env"`
 	Config  yaml.Node         `yaml:"config"`
@@ -526,14 +529,35 @@ func validateExecutablePlugin(kind, name string, plugin *ExecutablePluginDef) er
 	if plugin.Package != "" {
 		sourceCount++
 	}
+	if plugin.Source != "" {
+		sourceCount++
+	}
 	switch {
 	case sourceCount == 0:
-		return fmt.Errorf("config validation: %s %q plugin.command or plugin.package is required", kind, name)
+		return fmt.Errorf("config validation: %s %q plugin.command, plugin.package, or plugin.source is required", kind, name)
 	case sourceCount > 1:
-		return fmt.Errorf("config validation: %s %q plugin.command and plugin.package are mutually exclusive", kind, name)
-	case plugin.Command == "" && len(plugin.Args) > 0:
+		return fmt.Errorf("config validation: %s %q plugin.command, plugin.package, and plugin.source are mutually exclusive", kind, name)
+	}
+
+	if plugin.Source != "" {
+		if _, err := pluginsource.Parse(plugin.Source); err != nil {
+			return fmt.Errorf("config validation: %s %q plugin.source: %w", kind, name, err)
+		}
+		if plugin.Version == "" {
+			return fmt.Errorf("config validation: %s %q plugin.version is required when plugin.source is set", kind, name)
+		}
+		if err := pluginsource.ValidateVersion(plugin.Version); err != nil {
+			return fmt.Errorf("config validation: %s %q plugin.version: %w", kind, name, err)
+		}
+	}
+
+	if (plugin.Command != "" || plugin.Package != "") && plugin.Version != "" {
+		return fmt.Errorf("config validation: %s %q plugin.version is only valid with plugin.source", kind, name)
+	}
+	if plugin.Command == "" && len(plugin.Args) > 0 {
 		return fmt.Errorf("config validation: %s %q plugin.args are only valid with plugin.command", kind, name)
-	case strings.HasPrefix(plugin.Package, "http://"):
+	}
+	if strings.HasPrefix(plugin.Package, "http://") {
 		return fmt.Errorf("config validation: %s %q plugin.package requires HTTPS; plain HTTP is not supported", kind, name)
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1056,6 +1056,118 @@ egress:
 `,
 			wantErr: true,
 		},
+		{
+			name: "plugin source with version is valid",
+			yaml: `
+integrations:
+  external:
+    plugin:
+      source: github.com/acme-corp/tools/widget
+      version: 1.2.3
+`,
+		},
+		{
+			name: "plugin source without version is rejected",
+			yaml: `
+integrations:
+  external:
+    plugin:
+      source: github.com/acme-corp/tools/widget
+`,
+			wantErr: true,
+		},
+		{
+			name: "plugin source with command is rejected",
+			yaml: `
+integrations:
+  external:
+    plugin:
+      source: github.com/acme-corp/tools/widget
+      version: 1.0.0
+      command: /tmp/plugin
+`,
+			wantErr: true,
+		},
+		{
+			name: "plugin source with package is rejected",
+			yaml: `
+integrations:
+  external:
+    plugin:
+      source: github.com/acme-corp/tools/widget
+      version: 1.0.0
+      package: ./plugins/dummy.tar.gz
+`,
+			wantErr: true,
+		},
+		{
+			name: "plugin command with version is rejected",
+			yaml: `
+integrations:
+  external:
+    plugin:
+      command: /tmp/plugin
+      version: 1.0.0
+`,
+			wantErr: true,
+		},
+		{
+			name: "plugin package with version is rejected",
+			yaml: `
+integrations:
+  external:
+    plugin:
+      package: ./plugins/dummy.tar.gz
+      version: 1.0.0
+`,
+			wantErr: true,
+		},
+		{
+			name: "plugin source missing plugin segment is rejected",
+			yaml: `
+integrations:
+  external:
+    plugin:
+      source: github.com/acme-corp/tools
+      version: 1.0.0
+`,
+			wantErr: true,
+		},
+		{
+			name: "plugin source with uppercase is rejected",
+			yaml: `
+integrations:
+  external:
+    plugin:
+      source: github.com/Acme-Corp/tools/widget
+      version: 1.0.0
+`,
+			wantErr: true,
+		},
+		{
+			name: "plugin source with leading v in version is rejected",
+			yaml: `
+integrations:
+  external:
+    plugin:
+      source: github.com/acme-corp/tools/widget
+      version: v1.0.0
+`,
+			wantErr: true,
+		},
+		{
+			name: "plugin source with args is rejected",
+			yaml: `
+integrations:
+  external:
+    plugin:
+      source: github.com/acme-corp/tools/widget
+      version: 1.0.0
+      args:
+        - --verbose
+`,
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Plugins can now be declared with a managed source address
(`plugin.source: github.com/org/repo/name`) and a pinned semver
version, as a third option alongside `plugin.command` and
`plugin.package`. The three are mutually exclusive, and `plugin.version`
is only accepted alongside `plugin.source`. Source addresses are
validated against the grammar from Wave A's `pluginsource.Parse`, and
versions must be strict semver without a leading "v".

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>