### PR TITLE
Add GitHub release resolver for managed plugin sources

### DIFF
--- a/internal/pluginpkg/fetch.go
+++ b/internal/pluginpkg/fetch.go
@@ -2,55 +2,77 @@ package pluginpkg
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 )
 
-const maxPackageBytes = 512 << 20 // 512 MB
+const MaxPackageBytes = 512 << 20 // 512 MB
+
+type DownloadResult struct {
+	LocalPath string
+	Cleanup   func()
+	SHA256Hex string
+}
+
+func DownloadRequest(client *http.Client, req *http.Request) (*DownloadResult, error) {
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("execute request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d from %s", resp.StatusCode, req.URL)
+	}
+
+	tmp, err := os.CreateTemp("", "gestalt-plugin-*.tar.gz")
+	if err != nil {
+		return nil, fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	removeTmp := func() { _ = os.Remove(tmpPath) }
+
+	h := sha256.New()
+	w := io.MultiWriter(tmp, h)
+	if _, err := io.Copy(w, io.LimitReader(resp.Body, MaxPackageBytes+1)); err != nil {
+		_ = tmp.Close()
+		removeTmp()
+		return nil, fmt.Errorf("download body: %w", err)
+	}
+	info, err := tmp.Stat()
+	if err != nil {
+		_ = tmp.Close()
+		removeTmp()
+		return nil, fmt.Errorf("stat temp file: %w", err)
+	}
+	if info.Size() > MaxPackageBytes {
+		_ = tmp.Close()
+		removeTmp()
+		return nil, fmt.Errorf("download exceeds %d byte limit", MaxPackageBytes)
+	}
+	if err := tmp.Close(); err != nil {
+		removeTmp()
+		return nil, fmt.Errorf("close temp file: %w", err)
+	}
+	return &DownloadResult{
+		LocalPath: tmpPath,
+		Cleanup:   removeTmp,
+		SHA256Hex: hex.EncodeToString(h.Sum(nil)),
+	}, nil
+}
 
 func FetchPackage(ctx context.Context, url string) (localPath string, cleanup func(), err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return "", nil, fmt.Errorf("create request: %w", err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	result, err := DownloadRequest(http.DefaultClient, req)
 	if err != nil {
-		return "", nil, fmt.Errorf("fetch package: %w", err)
+		return "", nil, err
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", nil, fmt.Errorf("fetch package: HTTP %d", resp.StatusCode)
-	}
-
-	tmp, err := os.CreateTemp("", "gestalt-plugin-*.tar.gz")
-	if err != nil {
-		return "", nil, fmt.Errorf("create temp file: %w", err)
-	}
-	tmpPath := tmp.Name()
-	removeTmp := func() { _ = os.Remove(tmpPath) }
-
-	if _, err := io.Copy(tmp, io.LimitReader(resp.Body, maxPackageBytes+1)); err != nil {
-		_ = tmp.Close()
-		removeTmp()
-		return "", nil, fmt.Errorf("download package: %w", err)
-	}
-	info, err := tmp.Stat()
-	if err != nil {
-		_ = tmp.Close()
-		removeTmp()
-		return "", nil, fmt.Errorf("stat temp file: %w", err)
-	}
-	if info.Size() > maxPackageBytes {
-		_ = tmp.Close()
-		removeTmp()
-		return "", nil, fmt.Errorf("package exceeds %d byte limit", maxPackageBytes)
-	}
-	if err := tmp.Close(); err != nil {
-		removeTmp()
-		return "", nil, fmt.Errorf("close temp file: %w", err)
-	}
-	return tmpPath, removeTmp, nil
+	return result.LocalPath, result.Cleanup, nil
 }

--- a/internal/pluginsource/github/resolver.go
+++ b/internal/pluginsource/github/resolver.go
@@ -1,0 +1,138 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/internal/pluginpkg"
+	"github.com/valon-technologies/gestalt/internal/pluginsource"
+)
+
+const (
+	DefaultBaseURL      = "https://api.github.com"
+	headerAccept        = "Accept"
+	headerAuthorization = "Authorization"
+	acceptJSON          = "application/json"
+	acceptOctetStream   = "application/octet-stream"
+	envGitHubToken      = "GITHUB_TOKEN"
+	authTokenPrefix     = "token "
+)
+
+type releaseResponse struct {
+	Assets []releaseAsset `json:"assets"`
+}
+
+type releaseAsset struct {
+	Name               string `json:"name"`
+	URL                string `json:"url"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+type GitHubResolver struct {
+	Token      string
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+func (r *GitHubResolver) Resolve(ctx context.Context, src pluginsource.Source, version string) (*pluginsource.ResolvedPackage, error) {
+	baseURL := r.BaseURL
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	client := r.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	token := r.Token
+	if token == "" {
+		token = os.Getenv(envGitHubToken)
+	}
+
+	tag := src.ReleaseTag(version)
+	releaseURL := fmt.Sprintf("%s/repos/%s/releases/tags/%s", baseURL, src.RepoSlug(), tag)
+
+	release, err := r.fetchRelease(ctx, client, releaseURL, token, tag, src.RepoSlug())
+	if err != nil {
+		return nil, err
+	}
+
+	expectedName := src.AssetName(version)
+	asset, err := findAsset(release.Assets, expectedName, tag, src.RepoSlug())
+	if err != nil {
+		return nil, err
+	}
+
+	dl, err := r.downloadAsset(ctx, client, asset.URL, token)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pluginsource.ResolvedPackage{
+		LocalPath:     dl.LocalPath,
+		Cleanup:       dl.Cleanup,
+		ArchiveSHA256: dl.SHA256Hex,
+		ResolvedURL:   asset.BrowserDownloadURL,
+	}, nil
+}
+
+func (r *GitHubResolver) fetchRelease(ctx context.Context, client *http.Client, url, token, tag, slug string) (*releaseResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create release request: %w", err)
+	}
+	req.Header.Set(headerAccept, acceptJSON)
+	if token != "" {
+		req.Header.Set(headerAuthorization, authTokenPrefix+token)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch release: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("release tag %s not found for %s", tag, slug)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d fetching release %s for %s", resp.StatusCode, tag, slug)
+	}
+
+	var release releaseResponse
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("decode release response: %w", err)
+	}
+	return &release, nil
+}
+
+func findAsset(assets []releaseAsset, expectedName, tag, slug string) (releaseAsset, error) {
+	for _, a := range assets {
+		if a.Name == expectedName {
+			return a, nil
+		}
+	}
+	names := make([]string, len(assets))
+	for i, a := range assets {
+		names[i] = a.Name
+	}
+	return releaseAsset{}, fmt.Errorf(
+		"release %s for %s does not contain asset %s; available assets: %s",
+		tag, slug, expectedName, strings.Join(names, ", "),
+	)
+}
+
+func (r *GitHubResolver) downloadAsset(ctx context.Context, client *http.Client, assetURL, token string) (*pluginpkg.DownloadResult, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, assetURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create asset download request: %w", err)
+	}
+	req.Header.Set(headerAccept, acceptOctetStream)
+	if token != "" {
+		req.Header.Set(headerAuthorization, authTokenPrefix+token)
+	}
+	return pluginpkg.DownloadRequest(client, req)
+}

--- a/internal/pluginsource/github/resolver_test.go
+++ b/internal/pluginsource/github/resolver_test.go
@@ -1,0 +1,269 @@
+package github
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/internal/pluginsource"
+)
+
+const (
+	testOwner   = "acme-corp"
+	testRepo    = "tools"
+	testPlugin  = "linter"
+	testVersion = "1.2.3"
+	testToken   = "ghp_test_token_abc123"
+)
+
+var testSource = pluginsource.Source{
+	Host:   pluginsource.HostGitHub,
+	Owner:  testOwner,
+	Repo:   testRepo,
+	Plugin: testPlugin,
+}
+
+func releaseJSON(t *testing.T, assets []releaseAsset) []byte {
+	t.Helper()
+	b, err := json.Marshal(releaseResponse{Assets: assets})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func testAssetPayload() []byte {
+	return []byte("fake-plugin-binary-data-here")
+}
+
+func testAssetSHA256() string {
+	h := sha256.Sum256(testAssetPayload())
+	return hex.EncodeToString(h[:])
+}
+
+func expectedAssetName() string {
+	return testSource.AssetName(testVersion)
+}
+
+func expectedTag() string {
+	return testSource.ReleaseTag(testVersion)
+}
+
+func releasePath() string {
+	return "/repos/" + testOwner + "/" + testRepo + "/releases/tags/" + expectedTag()
+}
+
+type requestLog struct {
+	mu      sync.Mutex
+	headers []string
+}
+
+func (rl *requestLog) record(val string) {
+	rl.mu.Lock()
+	rl.headers = append(rl.headers, val)
+	rl.mu.Unlock()
+}
+
+func (rl *requestLog) all() []string {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	cp := make([]string, len(rl.headers))
+	copy(cp, rl.headers)
+	return cp
+}
+
+type serverOption func(w http.ResponseWriter, r *http.Request) bool
+
+func withAuthLog(log *requestLog) serverOption {
+	return func(_ http.ResponseWriter, r *http.Request) bool {
+		log.record(r.Header.Get(headerAuthorization))
+		return false
+	}
+}
+
+func withAssetStatus(code int) serverOption {
+	return func(w http.ResponseWriter, r *http.Request) bool {
+		if r.URL.Path == "/asset-dl" {
+			w.WriteHeader(code)
+			return true
+		}
+		return false
+	}
+}
+
+func newTestServer(t *testing.T, opts ...serverOption) *httptest.Server {
+	t.Helper()
+	browserURL := "https://github.com/" + testOwner + "/" + testRepo + "/releases/download/" + expectedTag() + "/" + expectedAssetName()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, opt := range opts {
+			if opt(w, r) {
+				return
+			}
+		}
+		switch r.URL.Path {
+		case releasePath():
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(releaseJSON(t, []releaseAsset{
+				{
+					Name:               expectedAssetName(),
+					URL:                "http://" + r.Host + "/asset-dl",
+					BrowserDownloadURL: browserURL,
+				},
+			}))
+		case "/asset-dl":
+			_, _ = w.Write(testAssetPayload())
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func TestResolveSuccess(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	browserURL := "https://github.com/" + testOwner + "/" + testRepo + "/releases/download/" + expectedTag() + "/" + expectedAssetName()
+
+	resolver := &GitHubResolver{BaseURL: srv.URL}
+	pkg, err := resolver.Resolve(context.Background(), testSource, testVersion)
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	defer pkg.Cleanup()
+
+	if _, err := os.Stat(pkg.LocalPath); err != nil {
+		t.Errorf("LocalPath does not exist: %v", err)
+	}
+	if pkg.ArchiveSHA256 != testAssetSHA256() {
+		t.Errorf("SHA256 = %s, want %s", pkg.ArchiveSHA256, testAssetSHA256())
+	}
+	if pkg.ResolvedURL != browserURL {
+		t.Errorf("ResolvedURL = %s, want %s", pkg.ResolvedURL, browserURL)
+	}
+
+	pkg.Cleanup()
+	if _, err := os.Stat(pkg.LocalPath); !os.IsNotExist(err) {
+		t.Error("temp file should be removed after Cleanup()")
+	}
+}
+
+func TestResolveReleaseNotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	resolver := &GitHubResolver{BaseURL: srv.URL}
+	_, err := resolver.Resolve(context.Background(), testSource, testVersion)
+	if err == nil {
+		t.Fatal("expected error for 404 release")
+	}
+
+	want := "release tag " + expectedTag() + " not found for " + testOwner + "/" + testRepo
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestResolveAssetNameMismatch(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(releaseJSON(t, []releaseAsset{
+			{Name: "wrong-asset.tar.gz", URL: "http://x", BrowserDownloadURL: "http://x"},
+			{Name: "also-wrong.zip", URL: "http://y", BrowserDownloadURL: "http://y"},
+		}))
+	}))
+	defer srv.Close()
+
+	resolver := &GitHubResolver{BaseURL: srv.URL}
+	_, err := resolver.Resolve(context.Background(), testSource, testVersion)
+	if err == nil {
+		t.Fatal("expected error for asset mismatch")
+	}
+
+	errMsg := err.Error()
+	if want := "does not contain asset " + expectedAssetName(); !strings.Contains(errMsg, want) {
+		t.Errorf("error should mention expected asset name, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "wrong-asset.tar.gz") || !strings.Contains(errMsg, "also-wrong.zip") {
+		t.Errorf("error should list available assets, got: %s", errMsg)
+	}
+}
+
+func TestResolveAuthenticatedRequest(t *testing.T) {
+	t.Parallel()
+
+	var log requestLog
+	srv := newTestServer(t, withAuthLog(&log))
+	defer srv.Close()
+
+	resolver := &GitHubResolver{BaseURL: srv.URL, Token: testToken}
+	pkg, err := resolver.Resolve(context.Background(), testSource, testVersion)
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	defer pkg.Cleanup()
+
+	wantAuth := authTokenPrefix + testToken
+	headers := log.all()
+	if len(headers) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(headers))
+	}
+	for i, got := range headers {
+		if got != wantAuth {
+			t.Errorf("request %d: Authorization = %q, want %q", i, got, wantAuth)
+		}
+	}
+}
+
+func TestResolveGitHubTokenEnvFallback(t *testing.T) {
+	envToken := "ghp_env_fallback_token"
+	t.Setenv(envGitHubToken, envToken)
+
+	var log requestLog
+	srv := newTestServer(t, withAuthLog(&log))
+	defer srv.Close()
+
+	resolver := &GitHubResolver{BaseURL: srv.URL}
+	pkg, err := resolver.Resolve(context.Background(), testSource, testVersion)
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	defer pkg.Cleanup()
+
+	wantAuth := authTokenPrefix + envToken
+	for i, got := range log.all() {
+		if got != wantAuth {
+			t.Errorf("request %d: Authorization = %q, want %q", i, got, wantAuth)
+		}
+	}
+}
+
+func TestResolveDownloadError(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t, withAssetStatus(http.StatusInternalServerError))
+	defer srv.Close()
+
+	resolver := &GitHubResolver{BaseURL: srv.URL}
+	_, err := resolver.Resolve(context.Background(), testSource, testVersion)
+	if err == nil {
+		t.Fatal("expected error for download failure")
+	}
+	if !strings.Contains(err.Error(), "unexpected status 500") {
+		t.Errorf("error = %q, want mention of status 500", err.Error())
+	}
+}


### PR DESCRIPTION
Managed plugins need to be fetched from GitHub Releases before they can
be installed. This adds a resolver that downloads plugin archives by
release tag, verifies their SHA256 checksum, and supports both explicit
tokens and the `GITHUB_TOKEN` environment variable for private repo
access. A shared download helper in `pluginpkg` was extracted to
deduplicate the HTTP fetch and checksum logic between the existing
`FetchPackage` path and the new resolver.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>