### PR TITLE
Add manifest v2 schema with source-based plugin identity

### DIFF
--- a/internal/pluginpkg/manifest.go
+++ b/internal/pluginpkg/manifest.go
@@ -17,21 +17,21 @@ import (
 const ManifestFile = "plugin.json"
 
 func DecodeManifest(data []byte) (*pluginmanifestv1.Manifest, error) {
-	var ver struct {
+	var header struct {
 		SchemaVersion int `json:"schema_version"`
 	}
-	if err := json.Unmarshal(data, &ver); err != nil {
+	if err := json.Unmarshal(data, &header); err != nil {
 		return nil, fmt.Errorf("parse manifest JSON: %w", err)
 	}
 
-	var schemaBytes []byte
-	switch ver.SchemaVersion {
+	var rawSchema []byte
+	switch header.SchemaVersion {
 	case pluginmanifestv1.SchemaVersion:
-		schemaBytes = pluginmanifestv1.ManifestJSONSchema
+		rawSchema = pluginmanifestv1.ManifestJSONSchema
 	case pluginmanifestv1.SchemaVersion2:
-		schemaBytes = pluginmanifestv1.ManifestV2JSONSchema
+		rawSchema = pluginmanifestv1.ManifestV2JSONSchema
 	default:
-		return nil, fmt.Errorf("unsupported manifest schema_version %d", ver.SchemaVersion)
+		return nil, fmt.Errorf("unsupported manifest schema_version %d", header.SchemaVersion)
 	}
 
 	var doc any
@@ -39,7 +39,7 @@ func DecodeManifest(data []byte) (*pluginmanifestv1.Manifest, error) {
 		return nil, fmt.Errorf("parse manifest JSON: %w", err)
 	}
 	var schemaDoc any
-	if err := json.Unmarshal(schemaBytes, &schemaDoc); err != nil {
+	if err := json.Unmarshal(rawSchema, &schemaDoc); err != nil {
 		return nil, fmt.Errorf("parse embedded manifest schema: %w", err)
 	}
 
@@ -82,11 +82,14 @@ func ValidateManifest(manifest *pluginmanifestv1.Manifest) error {
 		if manifest.ID != "" {
 			return fmt.Errorf("manifest id must not be set for schema_version %d", pluginmanifestv1.SchemaVersion2)
 		}
+		if manifest.Source == "" {
+			return fmt.Errorf("manifest source is required for schema_version %d", pluginmanifestv1.SchemaVersion2)
+		}
 		if _, err := pluginsource.Parse(manifest.Source); err != nil {
-			return fmt.Errorf("manifest source is invalid: %w", err)
+			return fmt.Errorf("manifest source: %w", err)
 		}
 		if err := pluginsource.ValidateVersion(manifest.Version); err != nil {
-			return fmt.Errorf("manifest version is invalid: %w", err)
+			return fmt.Errorf("manifest version: %w", err)
 		}
 	default:
 		return fmt.Errorf("unsupported manifest schema_version %d", manifest.SchemaVersion)

--- a/internal/pluginpkg/manifest_test.go
+++ b/internal/pluginpkg/manifest_test.go
@@ -113,3 +113,264 @@ func TestEncodeManifest_RoundTrip(t *testing.T) {
 		t.Fatal("manifest changed across round trip")
 	}
 }
+
+func validV2JSON() []byte {
+	return []byte(`{
+  "schema_version": 2,
+  "source": "github.com/acme/plugins/echo",
+  "version": "1.0.0",
+  "kinds": ["provider"],
+  "provider": {
+    "protocol": { "min": 1, "max": 1 }
+  },
+  "artifacts": [
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "path": "artifacts/darwin/arm64/provider",
+      "sha256": "` + sha256Hex("provider") + `"
+    }
+  ],
+  "entrypoints": {
+    "provider": {
+      "artifact_path": "artifacts/darwin/arm64/provider"
+    }
+  }
+}`)
+}
+
+func TestDecodeManifest_V2ValidSource(t *testing.T) {
+	t.Parallel()
+
+	manifest, err := DecodeManifest(validV2JSON())
+	if err != nil {
+		t.Fatalf("DecodeManifest: %v", err)
+	}
+	if manifest.Source != "github.com/acme/plugins/echo" {
+		t.Fatalf("unexpected source %q", manifest.Source)
+	}
+	if manifest.SchemaVersion != pluginmanifestv1.SchemaVersion2 {
+		t.Fatalf("unexpected schema_version %d", manifest.SchemaVersion)
+	}
+}
+
+func TestEncodeManifest_V2RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	manifest := &pluginmanifestv1.Manifest{
+		SchemaVersion: pluginmanifestv1.SchemaVersion2,
+		Source:        "github.com/acme/plugins/echo",
+		Version:       "1.0.0",
+		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     "darwin",
+				Arch:   "arm64",
+				Path:   "artifacts/darwin/arm64/provider",
+				SHA256: sha256Hex("provider"),
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{
+				ArtifactPath: "artifacts/darwin/arm64/provider",
+			},
+		},
+	}
+
+	data, err := EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	got, err := DecodeManifest(data)
+	if err != nil {
+		t.Fatalf("DecodeManifest: %v", err)
+	}
+	if !ManifestEqual(manifest, got) {
+		t.Fatal("manifest changed across round trip")
+	}
+}
+
+func TestDecodeManifest_V2RejectsID(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+  "schema_version": 2,
+  "source": "github.com/acme/plugins/echo",
+  "id": "acme/echo",
+  "version": "1.0.0",
+  "kinds": ["provider"],
+  "provider": {
+    "protocol": { "min": 1, "max": 1 }
+  },
+  "artifacts": [
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "path": "artifacts/darwin/arm64/provider",
+      "sha256": "` + sha256Hex("provider") + `"
+    }
+  ],
+  "entrypoints": {
+    "provider": {
+      "artifact_path": "artifacts/darwin/arm64/provider"
+    }
+  }
+}`)
+
+	_, err := DecodeManifest(data)
+	if err == nil {
+		t.Fatal("expected error for v2 manifest with id set")
+	}
+}
+
+func TestDecodeManifest_V2RejectsInvalidSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{"uppercase", "github.com/Acme/plugins/echo"},
+		{"missing segment", "github.com/acme/plugins"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			data := []byte(`{
+  "schema_version": 2,
+  "source": "` + tc.source + `",
+  "version": "1.0.0",
+  "kinds": ["provider"],
+  "provider": {
+    "protocol": { "min": 1, "max": 1 }
+  },
+  "artifacts": [
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "path": "artifacts/darwin/arm64/provider",
+      "sha256": "` + sha256Hex("provider") + `"
+    }
+  ],
+  "entrypoints": {
+    "provider": {
+      "artifact_path": "artifacts/darwin/arm64/provider"
+    }
+  }
+}`)
+
+			_, err := DecodeManifest(data)
+			if err == nil {
+				t.Fatalf("expected error for source %q", tc.source)
+			}
+		})
+	}
+}
+
+func TestDecodeManifest_V2RejectsLeadingVVersion(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+  "schema_version": 2,
+  "source": "github.com/acme/plugins/echo",
+  "version": "v1.0.0",
+  "kinds": ["provider"],
+  "provider": {
+    "protocol": { "min": 1, "max": 1 }
+  },
+  "artifacts": [
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "path": "artifacts/darwin/arm64/provider",
+      "sha256": "` + sha256Hex("provider") + `"
+    }
+  ],
+  "entrypoints": {
+    "provider": {
+      "artifact_path": "artifacts/darwin/arm64/provider"
+    }
+  }
+}`)
+
+	_, err := DecodeManifest(data)
+	if err == nil {
+		t.Fatal("expected error for version with leading v")
+	}
+}
+
+func TestDecodeManifest_V1StillWorks(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+  "schema_version": 1,
+  "id": "acme/provider",
+  "version": "0.1.0",
+  "kinds": ["provider"],
+  "provider": {
+    "protocol": { "min": 1, "max": 1 }
+  },
+  "artifacts": [
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "path": "artifacts/darwin/arm64/provider",
+      "sha256": "` + sha256Hex("provider") + `"
+    }
+  ],
+  "entrypoints": {
+    "provider": {
+      "artifact_path": "artifacts/darwin/arm64/provider"
+    }
+  }
+}`)
+
+	manifest, err := DecodeManifest(data)
+	if err != nil {
+		t.Fatalf("DecodeManifest: %v", err)
+	}
+	if manifest.ID != "acme/provider" {
+		t.Fatalf("unexpected id %q", manifest.ID)
+	}
+	if manifest.SchemaVersion != pluginmanifestv1.SchemaVersion {
+		t.Fatalf("unexpected schema_version %d", manifest.SchemaVersion)
+	}
+}
+
+func TestDecodeManifest_V1RejectsSource(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+  "schema_version": 1,
+  "id": "acme/provider",
+  "source": "github.com/acme/plugins/echo",
+  "version": "0.1.0",
+  "kinds": ["provider"],
+  "provider": {
+    "protocol": { "min": 1, "max": 1 }
+  },
+  "artifacts": [
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "path": "artifacts/darwin/arm64/provider",
+      "sha256": "` + sha256Hex("provider") + `"
+    }
+  ],
+  "entrypoints": {
+    "provider": {
+      "artifact_path": "artifacts/darwin/arm64/provider"
+    }
+  }
+}`)
+
+	_, err := DecodeManifest(data)
+	if err == nil {
+		t.Fatal("expected error for v1 manifest with source set")
+	}
+}


### PR DESCRIPTION
Plugin manifests can now use schema_version 2, which replaces the
free-form id field with a structured source address pointing to a
GitHub-hosted plugin repository. The v2 schema also enforces strict
SemVer for the version field. Existing v1 manifests continue to work
unchanged, with each version enforcing its own invariants: v1 requires
id and forbids source, while v2 requires source and forbids id.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>