### PR TITLE
Add lockfile v4 and source plugin lifecycle

### DIFF
--- a/cmd/gestaltd/init.go
+++ b/cmd/gestaltd/init.go
@@ -22,7 +22,7 @@ type lockPluginEntry = operator.LockPluginEntry
 func operatorLifecycle() *operator.Lifecycle {
 	return operator.NewLifecycle(func(ctx context.Context, name string, api config.APIDef) (*provider.Definition, error) {
 		return providercompiler.LoadDefinition(ctx, name, api, nil)
-	})
+	}, nil)
 }
 
 func initConfig(configFlag string) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,6 +74,10 @@ type ExecutablePluginDef struct {
 	ResolvedManifestPath string `yaml:"-"`
 }
 
+func (p *ExecutablePluginDef) HasManagedArtifacts() bool {
+	return p != nil && (p.Package != "" || p.Source != "")
+}
+
 type RuntimeDef struct {
 	Type      string               `yaml:"type"`
 	Providers []string             `yaml:"providers"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -985,6 +985,38 @@ integrations:
 			wantErr: true,
 		},
 		{
+			name: "plugin package with version is rejected",
+			yaml: `
+integrations:
+  external:
+    plugin:
+      package: ./plugins/dummy.tar.gz
+      version: 1.0.0
+`,
+			wantErr: true,
+		},
+		{
+			name: "plugin command with version is rejected",
+			yaml: `
+integrations:
+  external:
+    plugin:
+      command: /tmp/plugin
+      version: 1.0.0
+`,
+			wantErr: true,
+		},
+		{
+			name: "plugin source without version is rejected",
+			yaml: `
+integrations:
+  external:
+    plugin:
+      source: example.com/org/repo/plugin
+`,
+			wantErr: true,
+		},
+		{
 			name: "egress default_action allow is valid",
 			yaml: `
 auth:

--- a/internal/operator/lifecycle.go
+++ b/internal/operator/lifecycle.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/pluginpkg"
+	"github.com/valon-technologies/gestalt/internal/pluginsource"
 	"github.com/valon-technologies/gestalt/internal/pluginstore"
 	"github.com/valon-technologies/gestalt/internal/provider"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
@@ -24,7 +25,8 @@ import (
 const (
 	InitLockfileName     = "gestalt.lock.json"
 	PreparedProvidersDir = ".gestalt/providers"
-	LockVersion          = 3
+	LockVersion          = 4
+	LockVersionCompat    = 3
 )
 
 type Lockfile struct {
@@ -39,21 +41,26 @@ type LockProviderEntry struct {
 }
 
 type LockPluginEntry struct {
-	Fingerprint  string `json:"fingerprint"`
-	Package      string `json:"package,omitempty"`
-	SourceDigest string `json:"source_digest,omitempty"`
-	Manifest     string `json:"manifest"`
-	Executable   string `json:"executable"`
+	Fingerprint   string `json:"fingerprint"`
+	Package       string `json:"package,omitempty"`
+	SourceDigest  string `json:"source_digest,omitempty"`
+	Source        string `json:"source,omitempty"`
+	Version       string `json:"version,omitempty"`
+	ResolvedURL   string `json:"resolved_url,omitempty"`
+	ArchiveSHA256 string `json:"archive_sha256,omitempty"`
+	Manifest      string `json:"manifest"`
+	Executable    string `json:"executable"`
 }
 
 type UpstreamLoader func(ctx context.Context, name string, api config.APIDef) (*provider.Definition, error)
 
 type Lifecycle struct {
 	loadAPIUpstream UpstreamLoader
+	sourceResolver  pluginsource.Resolver
 }
 
-func NewLifecycle(loadAPIUpstream UpstreamLoader) *Lifecycle {
-	return &Lifecycle{loadAPIUpstream: loadAPIUpstream}
+func NewLifecycle(loadAPIUpstream UpstreamLoader, sourceResolver pluginsource.Resolver) *Lifecycle {
+	return &Lifecycle{loadAPIUpstream: loadAPIUpstream, sourceResolver: sourceResolver}
 }
 
 func (l *Lifecycle) InitAtPath(configPath string) (*Lockfile, error) {
@@ -81,12 +88,12 @@ func (l *Lifecycle) InitAtPath(configPath string) (*Lockfile, error) {
 		lock.Providers[name] = entry
 	}
 
-	resolvedPlugins, err := writePluginArtifacts(context.Background(), configPath, cfg, paths)
+	resolvedPlugins, err := l.writePluginArtifacts(context.Background(), configPath, cfg, paths)
 	if err != nil {
 		return nil, err
 	}
-	for key, entry := range resolvedPlugins {
-		lock.Plugins[key] = entry
+	for key := range resolvedPlugins {
+		lock.Plugins[key] = resolvedPlugins[key]
 	}
 
 	if err := WriteLockfile(paths.lockfilePath, lock); err != nil {
@@ -139,6 +146,8 @@ type pluginFingerprintInput struct {
 	Name    string            `json:"name"`
 	Command string            `json:"command,omitempty"`
 	Package string            `json:"package,omitempty"`
+	Source  string            `json:"source,omitempty"`
+	Version string            `json:"version,omitempty"`
 	Args    []string          `json:"args,omitempty"`
 	Env     map[string]string `json:"env,omitempty"`
 	Config  map[string]any    `json:"config,omitempty"`
@@ -263,16 +272,14 @@ func configHasRemoteAPIUpstreams(cfg *config.Config) bool {
 	return false
 }
 
-func configHasPluginPackages(cfg *config.Config) bool {
+func configHasPlugins(cfg *config.Config) bool {
 	for name := range cfg.Integrations {
-		intg := cfg.Integrations[name]
-		if intg.Plugin != nil && intg.Plugin.Package != "" {
+		if cfg.Integrations[name].Plugin.HasManagedArtifacts() {
 			return true
 		}
 	}
 	for name := range cfg.Runtimes {
-		rt := cfg.Runtimes[name]
-		if rt.Plugin != nil && rt.Plugin.Package != "" {
+		if cfg.Runtimes[name].Plugin.HasManagedArtifacts() {
 			return true
 		}
 	}
@@ -314,7 +321,7 @@ func ReadLockfile(path string) (*Lockfile, error) {
 	if err := json.Unmarshal(data, &lock); err != nil {
 		return nil, fmt.Errorf("parsing lockfile %s: %w", path, err)
 	}
-	if lock.Version != LockVersion {
+	if lock.Version != LockVersion && lock.Version != LockVersionCompat {
 		return nil, fmt.Errorf("unsupported lockfile version %d", lock.Version)
 	}
 	if lock.Providers == nil {
@@ -334,7 +341,7 @@ func WriteLockfile(path string, lock *Lockfile) error {
 }
 
 func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool {
-	if lock == nil || lock.Version != LockVersion {
+	if lock == nil || (lock.Version != LockVersion && lock.Version != LockVersionCompat) {
 		return false
 	}
 	for name := range cfg.Integrations {
@@ -358,7 +365,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 	}
 	for name := range cfg.Integrations {
 		intg := cfg.Integrations[name]
-		if intg.Plugin == nil || intg.Plugin.Package == "" {
+		if !intg.Plugin.HasManagedArtifacts() {
 			continue
 		}
 		entry, found := lock.Plugins[LockPluginKey("integration", name)]
@@ -369,7 +376,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 	}
 	for name := range cfg.Runtimes {
 		rt := cfg.Runtimes[name]
-		if rt.Plugin == nil || rt.Plugin.Package == "" {
+		if !rt.Plugin.HasManagedArtifacts() {
 			continue
 		}
 		entry, found := lock.Plugins[LockPluginKey("runtime", name)]
@@ -390,6 +397,8 @@ func PluginFingerprint(name string, plugin *config.ExecutablePluginDef, configMa
 		Name:    name,
 		Command: plugin.Command,
 		Package: plugin.Package,
+		Source:  plugin.Source,
+		Version: plugin.Version,
 		Args:    plugin.Args,
 		Env:     plugin.Env,
 	}
@@ -414,7 +423,14 @@ func pluginEntryMatches(paths initPaths, name string, plugin *config.ExecutableP
 		return false
 	}
 	fingerprint, err := PluginFingerprint(name, plugin, configMap)
-	if err != nil || entry.Fingerprint != fingerprint || entry.Package != plugin.Package {
+	if err != nil || entry.Fingerprint != fingerprint {
+		return false
+	}
+	if entry.Source != "" {
+		if entry.Source != plugin.Source || entry.Version != plugin.Version {
+			return false
+		}
+	} else if entry.Package != plugin.Package {
 		return false
 	}
 	manifestPath := resolveLockPath(paths.configDir, entry.Manifest)
@@ -425,7 +441,7 @@ func pluginEntryMatches(paths initPaths, name string, plugin *config.ExecutableP
 	if _, err := os.Stat(executablePath); err != nil {
 		return false
 	}
-	if entry.SourceDigest != "" && !strings.HasPrefix(plugin.Package, "https://") {
+	if entry.Source == "" && entry.SourceDigest != "" && !strings.HasPrefix(plugin.Package, "https://") {
 		digest, err := sourceDigestForPackage(plugin.Package)
 		if err != nil || digest != entry.SourceDigest {
 			return false
@@ -434,19 +450,27 @@ func pluginEntryMatches(paths initPaths, name string, plugin *config.ExecutableP
 	return true
 }
 
-func writePluginArtifacts(ctx context.Context, configPath string, cfg *config.Config, paths initPaths) (map[string]LockPluginEntry, error) {
+func (l *Lifecycle) writePluginArtifacts(ctx context.Context, configPath string, cfg *config.Config, paths initPaths) (map[string]LockPluginEntry, error) {
 	store := pluginstore.New(configPath)
 	written := make(map[string]LockPluginEntry)
 	for name := range cfg.Integrations {
 		intg := cfg.Integrations[name]
-		if intg.Plugin == nil || intg.Plugin.Package == "" {
+		if intg.Plugin == nil {
 			continue
 		}
 		configMap, err := config.NodeToMap(intg.Plugin.Config)
 		if err != nil {
 			return nil, fmt.Errorf("decode plugin config for integration %q: %w", name, err)
 		}
-		entry, err := lockEntryForPackage(ctx, paths, store, "integration", name, intg.Plugin, configMap)
+		var entry LockPluginEntry
+		switch {
+		case intg.Plugin.Source != "":
+			entry, err = l.lockEntryForSource(ctx, paths, store, "integration", name, intg.Plugin, configMap)
+		case intg.Plugin.Package != "":
+			entry, err = lockEntryForPackage(ctx, paths, store, "integration", name, intg.Plugin, configMap)
+		default:
+			continue
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -454,14 +478,22 @@ func writePluginArtifacts(ctx context.Context, configPath string, cfg *config.Co
 	}
 	for name := range cfg.Runtimes {
 		rt := cfg.Runtimes[name]
-		if rt.Plugin == nil || rt.Plugin.Package == "" {
+		if rt.Plugin == nil {
 			continue
 		}
 		configMap, err := config.NodeToMap(rt.Config)
 		if err != nil {
 			return nil, fmt.Errorf("decode runtime config for runtime %q: %w", name, err)
 		}
-		entry, err := lockEntryForPackage(ctx, paths, store, "runtime", name, rt.Plugin, configMap)
+		var entry LockPluginEntry
+		switch {
+		case rt.Plugin.Source != "":
+			entry, err = l.lockEntryForSource(ctx, paths, store, "runtime", name, rt.Plugin, configMap)
+		case rt.Plugin.Package != "":
+			entry, err = lockEntryForPackage(ctx, paths, store, "runtime", name, rt.Plugin, configMap)
+		default:
+			continue
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -545,8 +577,60 @@ func lockEntryForPackage(ctx context.Context, paths initPaths, store *pluginstor
 	}, nil
 }
 
+func (l *Lifecycle) lockEntryForSource(ctx context.Context, paths initPaths, store *pluginstore.Store, kind, name string, plugin *config.ExecutablePluginDef, configMap map[string]any) (LockPluginEntry, error) {
+	src, err := pluginsource.Parse(plugin.Source)
+	if err != nil {
+		return LockPluginEntry{}, fmt.Errorf("%s %q plugin.source %q: %w", kind, name, plugin.Source, err)
+	}
+	if l.sourceResolver == nil {
+		return LockPluginEntry{}, fmt.Errorf("%s %q: source plugin resolution requires a source resolver", kind, name)
+	}
+	resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.Version)
+	if err != nil {
+		return LockPluginEntry{}, fmt.Errorf("%s %q resolve source %q@%s: %w", kind, name, plugin.Source, plugin.Version, err)
+	}
+	defer resolved.Cleanup()
+
+	installed, err := store.Install(resolved.LocalPath)
+	if err != nil {
+		return LockPluginEntry{}, fmt.Errorf("%s %q install source plugin: %w", kind, name, err)
+	}
+
+	if installed.Manifest.Source != plugin.Source {
+		return LockPluginEntry{}, fmt.Errorf("%s %q: manifest source %q does not match config source %q", kind, name, installed.Manifest.Source, plugin.Source)
+	}
+	if installed.Manifest.Version != plugin.Version {
+		return LockPluginEntry{}, fmt.Errorf("%s %q: manifest version %q does not match config version %q", kind, name, installed.Manifest.Version, plugin.Version)
+	}
+
+	if err := pluginpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, manifestKind(kind), configMap); err != nil {
+		return LockPluginEntry{}, fmt.Errorf("plugin config validation for %s %q: %w", kind, name, err)
+	}
+	fingerprint, err := PluginFingerprint(name, plugin, configMap)
+	if err != nil {
+		return LockPluginEntry{}, fmt.Errorf("fingerprinting %s %q plugin: %w", kind, name, err)
+	}
+	manifestPath, err := filepath.Rel(paths.configDir, installed.ManifestPath)
+	if err != nil {
+		return LockPluginEntry{}, fmt.Errorf("compute manifest path for %s %q: %w", kind, name, err)
+	}
+	executablePath, err := filepath.Rel(paths.configDir, installed.ExecutablePath)
+	if err != nil {
+		return LockPluginEntry{}, fmt.Errorf("compute executable path for %s %q: %w", kind, name, err)
+	}
+	return LockPluginEntry{
+		Fingerprint:   fingerprint,
+		Source:        plugin.Source,
+		Version:       plugin.Version,
+		ResolvedURL:   resolved.ResolvedURL,
+		ArchiveSHA256: resolved.ArchiveSHA256,
+		Manifest:      filepath.ToSlash(manifestPath),
+		Executable:    filepath.ToSlash(executablePath),
+	}, nil
+}
+
 func (l *Lifecycle) applyLockedPlugins(configPath string, cfg *config.Config, locked bool) error {
-	if !configHasPluginPackages(cfg) {
+	if !configHasPlugins(cfg) {
 		return nil
 	}
 
@@ -561,7 +645,7 @@ func (l *Lifecycle) applyLockedPlugins(configPath string, cfg *config.Config, lo
 
 	for name := range cfg.Integrations {
 		intg := cfg.Integrations[name]
-		if intg.Plugin == nil || intg.Plugin.Package == "" {
+		if !intg.Plugin.HasManagedArtifacts() {
 			continue
 		}
 		configMap, err := config.NodeToMap(intg.Plugin.Config)
@@ -574,7 +658,7 @@ func (l *Lifecycle) applyLockedPlugins(configPath string, cfg *config.Config, lo
 	}
 	for name := range cfg.Runtimes {
 		rt := cfg.Runtimes[name]
-		if rt.Plugin == nil || rt.Plugin.Package == "" {
+		if !rt.Plugin.HasManagedArtifacts() {
 			continue
 		}
 		configMap, err := config.NodeToMap(rt.Config)
@@ -598,7 +682,11 @@ func applyLockedPluginEntry(paths initPaths, lock *Lockfile, kind, name string, 
 	if err != nil {
 		return fmt.Errorf("fingerprinting %s %q plugin: %w", kind, name, err)
 	}
-	if entry.Fingerprint != fingerprint || entry.Package != plugin.Package {
+	if entry.Source != "" {
+		if entry.Fingerprint != fingerprint || entry.Source != plugin.Source || entry.Version != plugin.Version {
+			return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd bundle --config %s --output DIR`", kind, name, paths.configPath)
+		}
+	} else if entry.Fingerprint != fingerprint || entry.Package != plugin.Package {
 		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd bundle --config %s --output DIR`", kind, name, paths.configPath)
 	}
 

--- a/internal/operator/lifecycle_source_test.go
+++ b/internal/operator/lifecycle_source_test.go
@@ -1,0 +1,377 @@
+package operator
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/internal/pluginsource"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
+)
+
+type fakeResolver struct {
+	archivePath string
+	resolvedURL string
+	sha256      string
+	calls       int
+}
+
+func (f *fakeResolver) Resolve(_ context.Context, _ pluginsource.Source, _ string) (*pluginsource.ResolvedPackage, error) {
+	f.calls++
+	return &pluginsource.ResolvedPackage{
+		LocalPath:     f.archivePath,
+		Cleanup:       func() {},
+		ArchiveSHA256: f.sha256,
+		ResolvedURL:   f.resolvedURL,
+	}, nil
+}
+
+func sha256hex(data string) string {
+	sum := sha256.Sum256([]byte(data))
+	return hex.EncodeToString(sum[:])
+}
+
+func artifactRelPath(binary string) string {
+	return filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, binary))
+}
+
+func buildV2Archive(t *testing.T, dir, source, version, binaryContent string) string {
+	t.Helper()
+
+	artPath := artifactRelPath("provider")
+	manifest := &pluginmanifestv1.Manifest{
+		SchemaVersion: pluginmanifestv1.SchemaVersion2,
+		Source:        source,
+		Version:       version,
+		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				Path:   artPath,
+				SHA256: sha256hex(binaryContent),
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{ArtifactPath: artPath},
+		},
+	}
+
+	manifestBytes, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	manifestBytes = append(manifestBytes, '\n')
+
+	archivePath := filepath.Join(dir, "plugin.tar.gz")
+	f, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	gzw := gzip.NewWriter(f)
+	defer func() { _ = gzw.Close() }()
+	tw := tar.NewWriter(gzw)
+	defer func() { _ = tw.Close() }()
+
+	writeEntry := func(name string, data []byte, mode int64) {
+		t.Helper()
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: mode, Size: int64(len(data))}); err != nil {
+			t.Fatalf("write header %s: %v", name, err)
+		}
+		if _, err := tw.Write(data); err != nil {
+			t.Fatalf("write data %s: %v", name, err)
+		}
+	}
+
+	writeEntry("plugin.json", manifestBytes, 0644)
+	writeEntry(artPath, []byte(binaryContent), 0755)
+
+	return archivePath
+}
+
+func writeConfigYAML(t *testing.T, dir, source, version string) string {
+	t.Helper()
+
+	yaml := strings.Join([]string{
+		"integrations:",
+		"  alpha:",
+		"    plugin:",
+		"      source: " + source,
+		"      version: " + version,
+	}, "\n") + "\n"
+
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(configPath, []byte(yaml), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return configPath
+}
+
+func TestSourcePluginEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := "github.com/acme/tools/widget"
+	version := "1.0.0"
+	binaryContent := "fake-binary-v1"
+	resolvedURL := "https://github.com/acme/tools/releases/download/v1.0.0/gestalt-plugin-widget_v1.0.0.tar.gz"
+
+	archivePath := buildV2Archive(t, dir, source, version, binaryContent)
+	archiveData, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	archiveSum := sha256.Sum256(archiveData)
+	archiveSHA := hex.EncodeToString(archiveSum[:])
+
+	resolver := &fakeResolver{
+		archivePath: archivePath,
+		resolvedURL: resolvedURL,
+		sha256:      archiveSHA,
+	}
+
+	configPath := writeConfigYAML(t, dir, source, version)
+
+	lc := NewLifecycle(nil, resolver)
+	lock, err := lc.InitAtPath(configPath)
+	if err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+
+	if lock.Version != LockVersion {
+		t.Errorf("lock version = %d, want %d", lock.Version, LockVersion)
+	}
+
+	entry, ok := lock.Plugins[LockPluginKey("integration", "alpha")]
+	if !ok {
+		t.Fatal("lock entry for integration:alpha not found")
+	}
+	if entry.Source != source {
+		t.Errorf("entry.Source = %q, want %q", entry.Source, source)
+	}
+	if entry.Version != version {
+		t.Errorf("entry.Version = %q, want %q", entry.Version, version)
+	}
+	if entry.ResolvedURL != resolvedURL {
+		t.Errorf("entry.ResolvedURL = %q, want %q", entry.ResolvedURL, resolvedURL)
+	}
+	if entry.ArchiveSHA256 != archiveSHA {
+		t.Errorf("entry.ArchiveSHA256 = %q, want %q", entry.ArchiveSHA256, archiveSHA)
+	}
+	if entry.Manifest == "" {
+		t.Error("entry.Manifest is empty")
+	}
+	if entry.Executable == "" {
+		t.Error("entry.Executable is empty")
+	}
+	if entry.Package != "" {
+		t.Errorf("entry.Package should be empty for source plugins, got %q", entry.Package)
+	}
+
+	configDir := filepath.Dir(configPath)
+	manifestPath := resolveLockPath(configDir, entry.Manifest)
+	executablePath := resolveLockPath(configDir, entry.Executable)
+	if _, err := os.Stat(manifestPath); err != nil {
+		t.Errorf("manifest not found at %s: %v", manifestPath, err)
+	}
+	if _, err := os.Stat(executablePath); err != nil {
+		t.Errorf("executable not found at %s: %v", executablePath, err)
+	}
+
+	if !strings.Contains(entry.Manifest, source) {
+		t.Errorf("manifest path %q does not contain source path %q", entry.Manifest, source)
+	}
+
+	if resolver.calls != 1 {
+		t.Errorf("resolver called %d times during init, want 1", resolver.calls)
+	}
+
+	lockPath := filepath.Join(configDir, InitLockfileName)
+	lockData, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read lockfile: %v", err)
+	}
+	var written Lockfile
+	if err := json.Unmarshal(lockData, &written); err != nil {
+		t.Fatalf("parse lockfile: %v", err)
+	}
+	if written.Version != LockVersion {
+		t.Errorf("written lockfile version = %d, want %d", written.Version, LockVersion)
+	}
+
+	readBack, err := ReadLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	readEntry := readBack.Plugins[LockPluginKey("integration", "alpha")]
+	if readEntry.Source != source {
+		t.Errorf("readback Source = %q, want %q", readEntry.Source, source)
+	}
+}
+
+func TestReadLockfileV3Compat(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	v3Lock := Lockfile{
+		Version:   LockVersionCompat,
+		Providers: map[string]LockProviderEntry{},
+		Plugins: map[string]LockPluginEntry{
+			"integration:beta": {
+				Fingerprint: "abc123",
+				Package:     "/tmp/beta.tar.gz",
+				Manifest:    ".gestalt/plugins/acme/beta/1.0.0/plugin.json",
+				Executable:  ".gestalt/plugins/acme/beta/1.0.0/artifacts/darwin/arm64/provider",
+			},
+		},
+	}
+
+	lockPath := filepath.Join(dir, InitLockfileName)
+	data, err := json.MarshalIndent(v3Lock, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(lockPath, append(data, '\n'), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	lock, err := ReadLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("ReadLockfile v3: %v", err)
+	}
+	if lock.Version != LockVersionCompat {
+		t.Errorf("version = %d, want %d", lock.Version, LockVersionCompat)
+	}
+
+	entry := lock.Plugins["integration:beta"]
+	if entry.Fingerprint != "abc123" {
+		t.Errorf("fingerprint = %q, want %q", entry.Fingerprint, "abc123")
+	}
+	if entry.Package != "/tmp/beta.tar.gz" {
+		t.Errorf("package = %q, want %q", entry.Package, "/tmp/beta.tar.gz")
+	}
+
+	if entry.Source != "" {
+		t.Errorf("v3 source should be empty, got %q", entry.Source)
+	}
+	if entry.Version != "" {
+		t.Errorf("v3 version should be empty, got %q", entry.Version)
+	}
+	if entry.ResolvedURL != "" {
+		t.Errorf("v3 resolved_url should be empty, got %q", entry.ResolvedURL)
+	}
+	if entry.ArchiveSHA256 != "" {
+		t.Errorf("v3 archive_sha256 should be empty, got %q", entry.ArchiveSHA256)
+	}
+}
+
+func TestReadLockfileRejectsV2(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, InitLockfileName)
+	data := []byte(`{"version": 2, "providers": {}, "plugins": {}}`)
+	if err := os.WriteFile(lockPath, data, 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err := ReadLockfile(lockPath)
+	if err == nil {
+		t.Fatal("expected error for version 2 lockfile")
+	}
+	if !strings.Contains(err.Error(), "unsupported lockfile version") {
+		t.Errorf("error = %q, want to contain 'unsupported lockfile version'", err.Error())
+	}
+}
+
+func TestSourcePluginNilResolver(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := "github.com/acme/tools/widget"
+	version := "1.0.0"
+
+	configPath := writeConfigYAML(t, dir, source, version)
+
+	lc := NewLifecycle(nil, nil)
+	_, err := lc.InitAtPath(configPath)
+	if err == nil {
+		t.Fatal("expected error with nil resolver")
+	}
+	if !strings.Contains(err.Error(), "source resolver") {
+		t.Errorf("error = %q, want to contain 'source resolver'", err.Error())
+	}
+}
+
+func TestSourcePluginLoadForExecution(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := "github.com/acme/tools/gadget"
+	version := "2.0.0"
+	binaryContent := "fake-gadget-binary"
+	resolvedURL := "https://github.com/acme/tools/releases/download/v2.0.0/gestalt-plugin-gadget_v2.0.0.tar.gz"
+
+	archivePath := buildV2Archive(t, dir, source, version, binaryContent)
+	archiveData, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	archiveSum := sha256.Sum256(archiveData)
+	archiveSHA := hex.EncodeToString(archiveSum[:])
+
+	resolver := &fakeResolver{
+		archivePath: archivePath,
+		resolvedURL: resolvedURL,
+		sha256:      archiveSHA,
+	}
+
+	yaml := strings.Join([]string{
+		"auth:",
+		"  provider: noop",
+		"datastore:",
+		"  provider: sqlite",
+		"  config:",
+		"    path: " + filepath.Join(dir, "data.db"),
+		"server:",
+		"  encryption_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"integrations:",
+		"  gadget:",
+		"    plugin:",
+		"      source: " + source,
+		"      version: " + version,
+	}, "\n") + "\n"
+
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(configPath, []byte(yaml), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle(nil, resolver)
+	_, err = lc.InitAtPath(configPath)
+	if err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+
+	callsBefore := resolver.calls
+	_, _, err = lc.LoadForExecutionAtPath(configPath, true)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+	}
+	if resolver.calls != callsBefore {
+		t.Errorf("resolver called during LoadForExecution (locked), want no additional calls")
+	}
+}

--- a/internal/pluginsource/source_test.go
+++ b/internal/pluginsource/source_test.go
@@ -98,6 +98,15 @@ func TestSourceStringRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSourceStorePath(t *testing.T) {
+	t.Parallel()
+
+	src := Source{Host: HostGitHub, Owner: "testowner", Repo: "testrepo", Plugin: "testplugin"}
+	if got := src.StorePath(); got != src.String() {
+		t.Errorf("StorePath() = %q, want %q", got, src.String())
+	}
+}
+
 func TestSourceAssetName(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pluginstore/store.go
+++ b/internal/pluginstore/store.go
@@ -89,6 +89,12 @@ func (s *Store) Install(packagePath string) (*InstalledPlugin, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	destDir, _, err := s.destDirForManifest(manifest)
+	if err != nil {
+		return nil, err
+	}
+
 	artifact, err := pluginpkg.CurrentPlatformArtifact(manifest)
 	if err != nil {
 		return nil, err
@@ -102,14 +108,6 @@ func (s *Store) Install(packagePath string) (*InstalledPlugin, error) {
 		return nil, fmt.Errorf("artifact digest mismatch for %s: package has %s, manifest expects %s", artifact.Path, got, artifact.SHA256)
 	}
 
-	root := s.root
-	if root == "" {
-		return nil, fmt.Errorf("store root is required")
-	}
-	destDir, err := installDirFromManifest(root, manifest)
-	if err != nil {
-		return nil, err
-	}
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return nil, fmt.Errorf("create plugin directory: %w", err)
 	}
@@ -135,6 +133,12 @@ func (s *Store) InstallFromDir(dirPath string) (*InstalledPlugin, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	destDir, _, err := s.destDirForManifest(manifest)
+	if err != nil {
+		return nil, err
+	}
+
 	artifact, err := pluginpkg.CurrentPlatformArtifact(manifest)
 	if err != nil {
 		return nil, err
@@ -153,15 +157,6 @@ func (s *Store) InstallFromDir(dirPath string) (*InstalledPlugin, error) {
 	_ = artifactFile.Close()
 	if got := hex.EncodeToString(sum.Sum(nil)); got != artifact.SHA256 {
 		return nil, fmt.Errorf("artifact digest mismatch for %s: directory has %s, manifest expects %s", artifact.Path, got, artifact.SHA256)
-	}
-
-	root := s.root
-	if root == "" {
-		return nil, fmt.Errorf("store root is required")
-	}
-	destDir, err := installDirFromManifest(root, manifest)
-	if err != nil {
-		return nil, err
 	}
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return nil, fmt.Errorf("create plugin directory: %w", err)
@@ -201,37 +196,41 @@ func (s *Store) InstallFromDir(dirPath string) (*InstalledPlugin, error) {
 	return installed, nil
 }
 
+func (s *Store) destDirForManifest(manifest *pluginmanifestv1.Manifest) (string, PluginID, error) {
+	if s == nil || s.root == "" {
+		return "", PluginID{}, fmt.Errorf("store root is required")
+	}
+	if manifest == nil {
+		return "", PluginID{}, fmt.Errorf("manifest is required")
+	}
+	if manifest.SchemaVersion == pluginmanifestv1.SchemaVersion2 {
+		src, err := pluginsource.Parse(manifest.Source)
+		if err != nil {
+			return "", PluginID{}, fmt.Errorf("manifest source: %w", err)
+		}
+		destDir := filepath.Join(s.root, filepath.FromSlash(src.StorePath()), manifest.Version)
+		return destDir, PluginID{}, nil
+	}
+	id, err := pluginIDFromManifest(manifest)
+	if err != nil {
+		return "", PluginID{}, err
+	}
+	destDir := filepath.Join(s.root, id.Publisher, id.Name, id.Version)
+	return destDir, id, nil
+}
+
 func pluginIDFromManifest(manifest *pluginmanifestv1.Manifest) (PluginID, error) {
 	if manifest == nil {
 		return PluginID{}, fmt.Errorf("manifest is required")
+	}
+	if manifest.ID == "" {
+		return PluginID{}, fmt.Errorf("manifest id is required for v1 plugins")
 	}
 	id, err := ParsePluginID(manifest.ID + "@" + manifest.Version)
 	if err != nil {
 		return PluginID{}, fmt.Errorf("manifest id/version must form a valid plugin identifier: %w", err)
 	}
 	return id, nil
-}
-
-func installDirFromManifest(root string, manifest *pluginmanifestv1.Manifest) (string, error) {
-	switch manifest.SchemaVersion {
-	case pluginmanifestv1.SchemaVersion:
-		id, err := pluginIDFromManifest(manifest)
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(root, id.Publisher, id.Name, id.Version), nil
-	case pluginmanifestv1.SchemaVersion2:
-		src, err := pluginsource.Parse(manifest.Source)
-		if err != nil {
-			return "", fmt.Errorf("manifest source is invalid: %w", err)
-		}
-		if err := pluginsource.ValidateVersion(manifest.Version); err != nil {
-			return "", fmt.Errorf("manifest version is invalid: %w", err)
-		}
-		return filepath.Join(root, filepath.FromSlash(src.StorePath()), manifest.Version), nil
-	default:
-		return "", fmt.Errorf("unsupported manifest schema_version %d", manifest.SchemaVersion)
-	}
 }
 
 func buildInstalledPlugin(manifest *pluginmanifestv1.Manifest, destDir, manifestPath, executablePath string, artifact *pluginmanifestv1.Artifact) *InstalledPlugin {


### PR DESCRIPTION
Plugins can now be addressed by source (e.g. `github.com/acme/tools/widget`) and version instead of requiring a local package path or URL. The lockfile bumps to v4 to track the new source, version, resolved URL, and archive SHA256, while remaining backward-compatible with v3 lockfiles. This also introduces manifest v2 schema support where `source` replaces `id`, and extends config validation so `source`, `package`, and `command` are mutually exclusive with `version` required alongside `source`.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>