### PR TITLE
Add manifest v2, source-based store layout, and --source flag

### DIFF
--- a/cmd/gestaltd/plugin.go
+++ b/cmd/gestaltd/plugin.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/valon-technologies/gestalt/internal/pluginpkg"
+	"github.com/valon-technologies/gestalt/internal/pluginsource"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
 )
 
@@ -38,7 +39,8 @@ func runPluginPackage(args []string) error {
 	input := fs.String("input", "", "path to plugin manifest or build directory")
 	output := fs.String("output", "", "path to write the packaged archive")
 	binary := fs.String("binary", "", "path to pre-built binary (scaffolds manifest automatically)")
-	id := fs.String("id", "", "plugin ID (publisher/name), required with --binary")
+	id := fs.String("id", "", "(deprecated) plugin ID (publisher/name), required with --binary")
+	source := fs.String("source", "", "plugin source (github.com/owner/repo/plugin), used with --binary")
 	kind := fs.String("kind", "provider", "plugin kind (provider or runtime), used with --binary")
 	targetOS := fs.String("os", runtime.GOOS, "target OS for the artifact, used with --binary")
 	targetArch := fs.String("arch", runtime.GOARCH, "target architecture, used with --binary")
@@ -50,8 +52,12 @@ func runPluginPackage(args []string) error {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
 	}
 
+	if *id != "" && *source != "" {
+		return fmt.Errorf("--id and --source are mutually exclusive")
+	}
+
 	if *binary != "" {
-		return packageFromBinary(*binary, *id, *kind, *version, *targetOS, *targetArch, *output)
+		return packageFromBinary(*binary, *id, *source, *kind, *version, *targetOS, *targetArch, *output)
 	}
 	return packageFromDir(*input, *output)
 }
@@ -78,12 +84,27 @@ func packageFromDir(input, output string) error {
 	return nil
 }
 
-func packageFromBinary(binaryPath, id, kind, version, targetOS, targetArch, output string) error {
-	if id == "" || output == "" {
-		return fmt.Errorf("usage: gestaltd plugin package --binary PATH --id ID --output PATH")
+func packageFromBinary(binaryPath, id, source, kind, version, targetOS, targetArch, output string) error {
+	if id == "" && source == "" {
+		return fmt.Errorf("usage: gestaltd plugin package --binary PATH --source SOURCE --output PATH")
+	}
+	if output == "" {
+		return fmt.Errorf("--output is required")
 	}
 	if kind != pluginmanifestv1.KindProvider && kind != pluginmanifestv1.KindRuntime {
 		return fmt.Errorf("kind must be %q or %q", pluginmanifestv1.KindProvider, pluginmanifestv1.KindRuntime)
+	}
+
+	if source != "" {
+		if _, err := pluginsource.Parse(source); err != nil {
+			return fmt.Errorf("invalid --source: %w", err)
+		}
+		if err := pluginsource.ValidateVersion(version); err != nil {
+			return fmt.Errorf("invalid --version for source plugin: %w", err)
+		}
+	}
+	if id != "" {
+		_, _ = fmt.Fprintf(os.Stderr, "warning: --id is deprecated, use --source instead\n")
 	}
 
 	workDir, err := os.MkdirTemp("", "gestalt-plugin-pkg-*")
@@ -104,7 +125,12 @@ func packageFromBinary(binaryPath, id, kind, version, targetOS, targetArch, outp
 		return fmt.Errorf("copying binary: %w", err)
 	}
 
-	manifest := buildManifest(id, kind, version, targetOS, targetArch, artifactRel, digest)
+	var manifest *pluginmanifestv1.Manifest
+	if source != "" {
+		manifest = buildManifestV2(source, kind, version, targetOS, targetArch, artifactRel, digest)
+	} else {
+		manifest = buildManifest(id, kind, version, targetOS, targetArch, artifactRel, digest)
+	}
 	data, err := pluginpkg.EncodeManifest(manifest)
 	if err != nil {
 		return fmt.Errorf("encoding manifest: %w", err)
@@ -116,16 +142,32 @@ func packageFromBinary(binaryPath, id, kind, version, targetOS, targetArch, outp
 	if err := pluginpkg.CreatePackageFromDir(workDir, output); err != nil {
 		return err
 	}
-	_, _ = fmt.Fprintf(os.Stdout, "packaged %s (%s) -> %s\n", id, binaryPath, output)
+	label := id
+	if source != "" {
+		label = source
+	}
+	_, _ = fmt.Fprintf(os.Stdout, "packaged %s (%s) -> %s\n", label, binaryPath, output)
 	return nil
 }
 
 func buildManifest(id, kind, version, targetOS, targetArch, artifactRel, digest string) *pluginmanifestv1.Manifest {
+	m := newManifestSkeleton(kind, version, targetOS, targetArch, artifactRel, digest)
+	m.SchemaVersion = pluginmanifestv1.SchemaVersion
+	m.ID = id
+	return m
+}
+
+func buildManifestV2(source, kind, version, targetOS, targetArch, artifactRel, digest string) *pluginmanifestv1.Manifest {
+	m := newManifestSkeleton(kind, version, targetOS, targetArch, artifactRel, digest)
+	m.SchemaVersion = pluginmanifestv1.SchemaVersion2
+	m.Source = source
+	return m
+}
+
+func newManifestSkeleton(kind, version, targetOS, targetArch, artifactRel, digest string) *pluginmanifestv1.Manifest {
 	m := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		ID:            id,
-		Version:       version,
-		Kinds:         []string{kind},
+		Version: version,
+		Kinds:   []string{kind},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
 				OS:     targetOS,
@@ -189,7 +231,8 @@ func printPluginUsage(w io.Writer) {
 func printPluginPackageUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
 	writeUsageLine(w, "  gestaltd plugin package --input PATH --output PATH")
-	writeUsageLine(w, "  gestaltd plugin package --binary PATH --id ID --output PATH")
+	writeUsageLine(w, "  gestaltd plugin package --binary PATH --source SOURCE --output PATH")
+	writeUsageLine(w, "  gestaltd plugin package --binary PATH --id ID --output PATH  (deprecated)")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Package a plugin for distribution. Use --input with an existing plugin")
 	writeUsageLine(w, "directory containing a manifest, or --binary to scaffold and package")
@@ -199,7 +242,8 @@ func printPluginPackageUsage(w io.Writer) {
 	writeUsageLine(w, "  --input     Path to plugin manifest or build directory")
 	writeUsageLine(w, "  --output    Path to write the packaged archive")
 	writeUsageLine(w, "  --binary    Path to pre-built binary (scaffolds manifest automatically)")
-	writeUsageLine(w, "  --id        Plugin ID (publisher/name), required with --binary")
+	writeUsageLine(w, "  --source    Plugin source (github.com/owner/repo/plugin), used with --binary")
+	writeUsageLine(w, "  --id        (deprecated) Plugin ID (publisher/name), use --source instead")
 	writeUsageLine(w, "  --kind      Plugin kind: provider or runtime (default: provider)")
 	writeUsageLine(w, "  --os        Target OS (default: current platform)")
 	writeUsageLine(w, "  --arch      Target architecture (default: current platform)")

--- a/cmd/gestaltd/plugin_test.go
+++ b/cmd/gestaltd/plugin_test.go
@@ -62,7 +62,7 @@ func TestRun_PluginRootReturnsHelpWhenNoSubcommandProvided(t *testing.T) {
 func TestRun_PluginPackageCreatesArchive(t *testing.T) {
 	dir := t.TempDir()
 	src := newPluginPackageFixture(t, dir)
-	outPath := filepath.Join(dir, "acme-provider-0.1.0.tar.gz")
+	outPath := filepath.Join(dir, "testowner-provider-0.1.0.tar.gz")
 
 	output := captureStdout(t, func() error {
 		return run([]string{"plugin", "package", "--input", src, "--output", outPath})
@@ -94,6 +94,57 @@ func TestRun_PluginPackageFromBinary(t *testing.T) {
 	}
 	if !strings.Contains(output, "packaged") {
 		t.Fatalf("expected packaged output, got: %q", output)
+	}
+}
+
+//nolint:paralleltest // Swaps os.Stdout via captureStdout.
+func TestRun_PluginPackageFromBinaryWithSource(t *testing.T) {
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "my-provider")
+	if err := os.WriteFile(binaryPath, []byte("fake-binary-content"), 0755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	outPath := filepath.Join(dir, "my-provider-v2.tar.gz")
+
+	output := captureStdout(t, func() error {
+		return run([]string{
+			"plugin", "package",
+			"--binary", binaryPath,
+			"--source", "github.com/testorg/testrepo/testplugin",
+			"--version", "1.0.0",
+			"--output", outPath,
+		})
+	})
+
+	if _, err := os.Stat(outPath); err != nil {
+		t.Fatalf("expected archive to exist: %v", err)
+	}
+	if !strings.Contains(output, "packaged") {
+		t.Fatalf("expected packaged output, got: %q", output)
+	}
+}
+
+func TestRun_PluginPackageRejectsMutualExclusiveFlags(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "my-provider")
+	if err := os.WriteFile(binaryPath, []byte("fake-binary-content"), 0755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	err := run([]string{
+		"plugin", "package",
+		"--binary", binaryPath,
+		"--id", "test/myprov",
+		"--source", "github.com/testorg/testrepo/testplugin",
+		"--output", filepath.Join(dir, "out.tar.gz"),
+	})
+	if err == nil {
+		t.Fatal("expected error for mutually exclusive flags")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -129,7 +180,7 @@ func newPluginPackageFixture(t *testing.T, dir string) string {
 
 	manifest := `{
   "schema_version": 1,
-  "id": "acme/provider",
+  "id": "testowner/provider",
   "version": "0.1.0",
   "kinds": ["provider"],
   "provider": {

--- a/internal/pluginpkg/manifest.go
+++ b/internal/pluginpkg/manifest.go
@@ -10,18 +10,36 @@ import (
 	"strings"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/valon-technologies/gestalt/internal/pluginsource"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
 )
 
 const ManifestFile = "plugin.json"
 
 func DecodeManifest(data []byte) (*pluginmanifestv1.Manifest, error) {
+	var ver struct {
+		SchemaVersion int `json:"schema_version"`
+	}
+	if err := json.Unmarshal(data, &ver); err != nil {
+		return nil, fmt.Errorf("parse manifest JSON: %w", err)
+	}
+
+	var schemaBytes []byte
+	switch ver.SchemaVersion {
+	case pluginmanifestv1.SchemaVersion:
+		schemaBytes = pluginmanifestv1.ManifestJSONSchema
+	case pluginmanifestv1.SchemaVersion2:
+		schemaBytes = pluginmanifestv1.ManifestV2JSONSchema
+	default:
+		return nil, fmt.Errorf("unsupported manifest schema_version %d", ver.SchemaVersion)
+	}
+
 	var doc any
 	if err := json.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("parse manifest JSON: %w", err)
 	}
 	var schemaDoc any
-	if err := json.Unmarshal(pluginmanifestv1.ManifestJSONSchema, &schemaDoc); err != nil {
+	if err := json.Unmarshal(schemaBytes, &schemaDoc); err != nil {
 		return nil, fmt.Errorf("parse embedded manifest schema: %w", err)
 	}
 
@@ -51,8 +69,27 @@ func ValidateManifest(manifest *pluginmanifestv1.Manifest) error {
 	if manifest == nil {
 		return fmt.Errorf("manifest is required")
 	}
-	if manifest.SchemaVersion != pluginmanifestv1.SchemaVersion {
-		return fmt.Errorf("manifest schema_version must be %d", pluginmanifestv1.SchemaVersion)
+
+	switch manifest.SchemaVersion {
+	case pluginmanifestv1.SchemaVersion:
+		if manifest.ID == "" {
+			return fmt.Errorf("manifest id is required for schema_version %d", pluginmanifestv1.SchemaVersion)
+		}
+		if manifest.Source != "" {
+			return fmt.Errorf("manifest source must not be set for schema_version %d", pluginmanifestv1.SchemaVersion)
+		}
+	case pluginmanifestv1.SchemaVersion2:
+		if manifest.ID != "" {
+			return fmt.Errorf("manifest id must not be set for schema_version %d", pluginmanifestv1.SchemaVersion2)
+		}
+		if _, err := pluginsource.Parse(manifest.Source); err != nil {
+			return fmt.Errorf("manifest source is invalid: %w", err)
+		}
+		if err := pluginsource.ValidateVersion(manifest.Version); err != nil {
+			return fmt.Errorf("manifest version is invalid: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported manifest schema_version %d", manifest.SchemaVersion)
 	}
 
 	artifactPaths := make(map[string]struct{}, len(manifest.Artifacts))

--- a/internal/pluginsource/source.go
+++ b/internal/pluginsource/source.go
@@ -52,16 +52,16 @@ func (s Source) String() string {
 	return s.Host + "/" + s.Owner + "/" + s.Repo + "/" + s.Plugin
 }
 
+func (s Source) StorePath() string {
+	return s.String()
+}
+
 func (s Source) AssetName(version string) string {
 	return assetPrefix + s.Plugin + "_" + versionPrefix + version + assetSuffix
 }
 
 func (s Source) ReleaseTag(version string) string {
 	return versionPrefix + version
-}
-
-func (s Source) StorePath() string {
-	return s.String()
 }
 
 func (s Source) RepoSlug() string {

--- a/internal/pluginstore/store.go
+++ b/internal/pluginstore/store.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	pluginpkg "github.com/valon-technologies/gestalt/internal/pluginpkg"
+	"github.com/valon-technologies/gestalt/internal/pluginsource"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
 )
 
@@ -70,6 +71,7 @@ func New(configPath string) *Store {
 
 type InstalledPlugin struct {
 	PluginID       PluginID
+	Source         string
 	Root           string
 	ManifestPath   string
 	ExecutablePath string
@@ -84,10 +86,6 @@ func (s *Store) Install(packagePath string) (*InstalledPlugin, error) {
 		return nil, fmt.Errorf("store is required")
 	}
 	_, manifest, err := pluginpkg.ReadPackageManifest(packagePath)
-	if err != nil {
-		return nil, err
-	}
-	id, err := pluginIDFromManifest(manifest)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +106,10 @@ func (s *Store) Install(packagePath string) (*InstalledPlugin, error) {
 	if root == "" {
 		return nil, fmt.Errorf("store root is required")
 	}
-	destDir := filepath.Join(root, id.Publisher, id.Name, id.Version)
+	destDir, err := installDirFromManifest(root, manifest)
+	if err != nil {
+		return nil, err
+	}
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return nil, fmt.Errorf("create plugin directory: %w", err)
 	}
@@ -122,16 +123,7 @@ func (s *Store) Install(packagePath string) (*InstalledPlugin, error) {
 		return nil, err
 	}
 
-	installed := &InstalledPlugin{
-		PluginID:       id,
-		Root:           destDir,
-		ManifestPath:   manifestPath,
-		ExecutablePath: executablePath,
-		ArtifactPath:   artifact.Path,
-		SHA256:         artifact.SHA256,
-		Manifest:       manifest,
-		Artifact:       artifact,
-	}
+	installed := buildInstalledPlugin(manifest, destDir, manifestPath, executablePath, artifact)
 	return installed, nil
 }
 
@@ -140,10 +132,6 @@ func (s *Store) InstallFromDir(dirPath string) (*InstalledPlugin, error) {
 		return nil, fmt.Errorf("store is required")
 	}
 	_, manifest, _, err := pluginpkg.LoadManifestFromPath(dirPath)
-	if err != nil {
-		return nil, err
-	}
-	id, err := pluginIDFromManifest(manifest)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +159,10 @@ func (s *Store) InstallFromDir(dirPath string) (*InstalledPlugin, error) {
 	if root == "" {
 		return nil, fmt.Errorf("store root is required")
 	}
-	destDir := filepath.Join(root, id.Publisher, id.Name, id.Version)
+	destDir, err := installDirFromManifest(root, manifest)
+	if err != nil {
+		return nil, err
+	}
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return nil, fmt.Errorf("create plugin directory: %w", err)
 	}
@@ -205,16 +196,9 @@ func (s *Store) InstallFromDir(dirPath string) (*InstalledPlugin, error) {
 		return nil, err
 	}
 
-	return &InstalledPlugin{
-		PluginID:       id,
-		Root:           destDir,
-		ManifestPath:   filepath.Join(destDir, pluginpkg.ManifestFile),
-		ExecutablePath: executablePath,
-		ArtifactPath:   artifact.Path,
-		SHA256:         artifact.SHA256,
-		Manifest:       manifest,
-		Artifact:       artifact,
-	}, nil
+	manifestPath := filepath.Join(destDir, pluginpkg.ManifestFile)
+	installed := buildInstalledPlugin(manifest, destDir, manifestPath, executablePath, artifact)
+	return installed, nil
 }
 
 func pluginIDFromManifest(manifest *pluginmanifestv1.Manifest) (PluginID, error) {
@@ -226,6 +210,48 @@ func pluginIDFromManifest(manifest *pluginmanifestv1.Manifest) (PluginID, error)
 		return PluginID{}, fmt.Errorf("manifest id/version must form a valid plugin identifier: %w", err)
 	}
 	return id, nil
+}
+
+func installDirFromManifest(root string, manifest *pluginmanifestv1.Manifest) (string, error) {
+	switch manifest.SchemaVersion {
+	case pluginmanifestv1.SchemaVersion:
+		id, err := pluginIDFromManifest(manifest)
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(root, id.Publisher, id.Name, id.Version), nil
+	case pluginmanifestv1.SchemaVersion2:
+		src, err := pluginsource.Parse(manifest.Source)
+		if err != nil {
+			return "", fmt.Errorf("manifest source is invalid: %w", err)
+		}
+		if err := pluginsource.ValidateVersion(manifest.Version); err != nil {
+			return "", fmt.Errorf("manifest version is invalid: %w", err)
+		}
+		return filepath.Join(root, filepath.FromSlash(src.StorePath()), manifest.Version), nil
+	default:
+		return "", fmt.Errorf("unsupported manifest schema_version %d", manifest.SchemaVersion)
+	}
+}
+
+func buildInstalledPlugin(manifest *pluginmanifestv1.Manifest, destDir, manifestPath, executablePath string, artifact *pluginmanifestv1.Artifact) *InstalledPlugin {
+	ip := &InstalledPlugin{
+		Root:           destDir,
+		ManifestPath:   manifestPath,
+		ExecutablePath: executablePath,
+		ArtifactPath:   artifact.Path,
+		SHA256:         artifact.SHA256,
+		Manifest:       manifest,
+		Artifact:       artifact,
+	}
+	switch manifest.SchemaVersion {
+	case pluginmanifestv1.SchemaVersion:
+		id, _ := pluginIDFromManifest(manifest)
+		ip.PluginID = id
+	case pluginmanifestv1.SchemaVersion2:
+		ip.Source = manifest.Source
+	}
+	return ip
 }
 
 func executablePathForManifest(root string, manifest *pluginmanifestv1.Manifest) (string, error) {

--- a/internal/pluginstore/store_test.go
+++ b/internal/pluginstore/store_test.go
@@ -21,15 +21,15 @@ import (
 func TestParsePluginID(t *testing.T) {
 	t.Parallel()
 
-	id, err := ParsePluginID("acme/provider@0.1.0")
+	id, err := ParsePluginID("testowner/provider@0.1.0")
 	if err != nil {
 		t.Fatalf("ParsePluginID: %v", err)
 	}
-	if id.Publisher != "acme" || id.Name != "provider" || id.Version != "0.1.0" {
+	if id.Publisher != "testowner" || id.Name != "provider" || id.Version != "0.1.0" {
 		t.Fatalf("unexpected id: %+v", id)
 	}
 
-	for _, raw := range []string{"", "acme/provider", "acme@0.1.0", " acme/provider@0.1.0 ", "acme/provider@", "acme//provider@0.1.0"} {
+	for _, raw := range []string{"", "testowner/provider", "testowner@0.1.0", " testowner/provider@0.1.0 ", "testowner/provider@", "testowner//provider@0.1.0"} {
 		if _, err := ParsePluginID(raw); err == nil {
 			t.Fatalf("expected ParsePluginID(%q) to fail", raw)
 		}
@@ -49,17 +49,17 @@ func TestInstall(t *testing.T) {
 	}
 
 	store := New(cfgPath)
-	pkg1 := mustBuildPackage(t, dir, "acme/provider", "0.1.0", "hello from acme")
+	pkg1 := mustBuildPackage(t, dir, "testowner/provider", "0.1.0", "hello from testowner")
 	pkg2 := mustBuildPackage(t, dir, "beta/provider", "1.2.3", "hello from beta")
 
 	installed1, err := store.Install(pkg1)
 	if err != nil {
 		t.Fatalf("Install pkg1: %v", err)
 	}
-	if installed1.PluginID.String() != "acme/provider@0.1.0" {
+	if installed1.PluginID.String() != "testowner/provider@0.1.0" {
 		t.Fatalf("installed id = %q", installed1.PluginID.String())
 	}
-	if installed1.Manifest == nil || installed1.Manifest.ID != "acme/provider" {
+	if installed1.Manifest == nil || installed1.Manifest.ID != "testowner/provider" {
 		t.Fatalf("unexpected installed manifest: %+v", installed1.Manifest)
 	}
 	wantRoot := filepath.Join(installed1.Root, "..")
@@ -76,7 +76,7 @@ func TestInstall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile executable: %v", err)
 	}
-	if string(data) != "hello from acme" {
+	if string(data) != "hello from testowner" {
 		t.Fatalf("unexpected executable content: %q", data)
 	}
 
@@ -99,7 +99,7 @@ func TestInstallRejectsDigestMismatch(t *testing.T) {
 	}
 	store := New(cfgPath)
 
-	pkg := mustBuildMismatchPackage(t, dir, "acme/provider", "0.1.0", "hello", strings.Repeat("deadbeef", 8))
+	pkg := mustBuildMismatchPackage(t, dir, "testowner/provider", "0.1.0", "hello", strings.Repeat("deadbeef", 8))
 	_, err := store.Install(pkg)
 	if err == nil {
 		t.Fatal("expected digest mismatch error")
@@ -119,7 +119,7 @@ func TestInstallRejectsUnsafeManifestVersion(t *testing.T) {
 	}
 	store := New(cfgPath)
 
-	pkg := mustBuildPackage(t, dir, "acme/provider", "../evil", "hello")
+	pkg := mustBuildPackage(t, dir, "testowner/provider", "../evil", "hello")
 	_, err := store.Install(pkg)
 	if err == nil {
 		t.Fatal("expected invalid manifest version error")
@@ -139,7 +139,7 @@ func TestInstallRejectsDuplicateArtifactEntries(t *testing.T) {
 	}
 	store := New(cfgPath)
 
-	pkg := mustBuildPackageWithDuplicateArtifact(t, dir, "acme/provider", "0.1.0", "good", "evil")
+	pkg := mustBuildPackageWithDuplicateArtifact(t, dir, "testowner/provider", "0.1.0", "good", "evil")
 	_, err := store.Install(pkg)
 	if err == nil {
 		t.Fatal("expected duplicate artifact entry error")
@@ -158,13 +158,13 @@ func TestInstallFromDirValidatesAndCopies(t *testing.T) {
 		t.Fatalf("WriteFile config: %v", err)
 	}
 	store := New(cfgPath)
-	srcDir := mustBuildPluginDir(t, dir, "acme/provider", "0.1.0", "dir-content", "")
+	srcDir := mustBuildPluginDir(t, dir, "testowner/provider", "0.1.0", "dir-content", "")
 
 	installed, err := store.InstallFromDir(srcDir)
 	if err != nil {
 		t.Fatalf("InstallFromDir: %v", err)
 	}
-	if installed.PluginID.String() != "acme/provider@0.1.0" {
+	if installed.PluginID.String() != "testowner/provider@0.1.0" {
 		t.Fatalf("id = %q", installed.PluginID.String())
 	}
 	data, err := os.ReadFile(installed.ExecutablePath)
@@ -188,7 +188,7 @@ func TestInstallFromDirCopiesSchema(t *testing.T) {
 		t.Fatalf("WriteFile config: %v", err)
 	}
 	store := New(cfgPath)
-	srcDir := mustBuildPluginDir(t, dir, "acme/provider", "0.2.0", "binary", `{"type":"object"}`)
+	srcDir := mustBuildPluginDir(t, dir, "testowner/provider", "0.2.0", "binary", `{"type":"object"}`)
 
 	installed, err := store.InstallFromDir(srcDir)
 	if err != nil {
@@ -211,13 +211,119 @@ func TestInstallFromDirRejectsDigestMismatch(t *testing.T) {
 	}
 	store := New(cfgPath)
 
-	srcDir := mustBuildPluginDirWithDigest(t, dir, "acme/provider", "0.3.0", "real-content", strings.Repeat("deadbeef", 8))
+	srcDir := mustBuildPluginDirWithDigest(t, dir, "testowner/provider", "0.3.0", "real-content", strings.Repeat("deadbeef", 8))
 	_, err := store.InstallFromDir(srcDir)
 	if err == nil {
 		t.Fatal("expected digest mismatch error")
 	}
 	if !strings.Contains(err.Error(), "digest mismatch") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestInstallV2ArchiveUsesSourcePath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	store := New(cfgPath)
+	pkg := mustBuildV2Package(t, dir, "github.com/testorg/testrepo/testplugin", "1.0.0", "v2-binary")
+
+	installed, err := store.Install(pkg)
+	if err != nil {
+		t.Fatalf("Install v2: %v", err)
+	}
+	if installed.Source != "github.com/testorg/testrepo/testplugin" {
+		t.Fatalf("source = %q", installed.Source)
+	}
+	if !installed.PluginID.IsZero() {
+		t.Fatalf("expected zero PluginID for v2, got %q", installed.PluginID)
+	}
+	wantSuffix := filepath.Join("github.com", "testorg", "testrepo", "testplugin", "1.0.0")
+	if !strings.HasSuffix(installed.Root, wantSuffix) {
+		t.Fatalf("install root = %q, want suffix %q", installed.Root, wantSuffix)
+	}
+	data, err := os.ReadFile(installed.ExecutablePath)
+	if err != nil {
+		t.Fatalf("ReadFile executable: %v", err)
+	}
+	if string(data) != "v2-binary" {
+		t.Fatalf("executable content = %q", data)
+	}
+}
+
+func TestInstallV1StillUsesPublisherNamePath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	store := New(cfgPath)
+	pkg := mustBuildPackage(t, dir, "foocorp/myplugin", "2.3.4", "v1-binary")
+
+	installed, err := store.Install(pkg)
+	if err != nil {
+		t.Fatalf("Install v1: %v", err)
+	}
+	if installed.PluginID.String() != "foocorp/myplugin@2.3.4" {
+		t.Fatalf("id = %q", installed.PluginID.String())
+	}
+	wantSuffix := filepath.Join("foocorp", "myplugin", "2.3.4")
+	if !strings.HasSuffix(installed.Root, wantSuffix) {
+		t.Fatalf("install root = %q, want suffix %q", installed.Root, wantSuffix)
+	}
+}
+
+func TestInstallV2FromDirUsesSourcePath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	store := New(cfgPath)
+	srcDir := mustBuildV2PluginDir(t, dir, "github.com/testorg/testrepo/testplugin", "0.5.0", "dir-v2-binary")
+
+	installed, err := store.InstallFromDir(srcDir)
+	if err != nil {
+		t.Fatalf("InstallFromDir v2: %v", err)
+	}
+	if installed.Source != "github.com/testorg/testrepo/testplugin" {
+		t.Fatalf("source = %q", installed.Source)
+	}
+	wantSuffix := filepath.Join("github.com", "testorg", "testrepo", "testplugin", "0.5.0")
+	if !strings.HasSuffix(installed.Root, wantSuffix) {
+		t.Fatalf("install root = %q, want suffix %q", installed.Root, wantSuffix)
+	}
+	data, err := os.ReadFile(installed.ExecutablePath)
+	if err != nil {
+		t.Fatalf("ReadFile executable: %v", err)
+	}
+	if string(data) != "dir-v2-binary" {
+		t.Fatalf("executable content = %q", data)
+	}
+}
+
+func TestInstallV2RejectsInvalidSource(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	store := New(cfgPath)
+	pkg := mustBuildV2PackageRaw(t, dir, "not-a-valid-source", "1.0.0", "binary")
+
+	_, err := store.Install(pkg)
+	if err == nil {
+		t.Fatal("expected error for invalid v2 source")
 	}
 }
 
@@ -505,4 +611,149 @@ func mustBuildPackageWithDuplicateArtifact(t *testing.T, dir, id, version, first
 		t.Fatalf("close archive: %v", err)
 	}
 	return archivePath
+}
+
+func newV2Manifest(source, version, content string) *pluginmanifestv1.Manifest {
+	artifactPath := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider"))
+	sum := sha256.Sum256([]byte(content))
+	return &pluginmanifestv1.Manifest{
+		SchemaVersion: pluginmanifestv1.SchemaVersion2,
+		Source:        source,
+		Version:       version,
+		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				Path:   artifactPath,
+				SHA256: hex.EncodeToString(sum[:]),
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{
+				ArtifactPath: artifactPath,
+			},
+		},
+	}
+}
+
+func mustBuildV2Package(t *testing.T, dir, source, version, content string) string {
+	t.Helper()
+
+	safeName := strings.NewReplacer("/", "-", ".", "_").Replace(source + "-" + version)
+	sourceDir := filepath.Join(dir, safeName)
+	artifactRel := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider"))
+	if err := os.MkdirAll(filepath.Join(sourceDir, filepath.Dir(filepath.FromSlash(artifactRel))), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, filepath.FromSlash(artifactRel)), []byte(content), 0755); err != nil {
+		t.Fatalf("WriteFile artifact: %v", err)
+	}
+
+	manifest := newV2Manifest(source, version, content)
+	manifestBytes, err := pluginpkg.EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, pluginpkg.ManifestFile), manifestBytes, 0644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	archivePath := filepath.Join(dir, safeName+".tar.gz")
+	if err := pluginpkg.CreatePackageFromDir(sourceDir, archivePath); err != nil {
+		t.Fatalf("CreatePackageFromDir: %v", err)
+	}
+	return archivePath
+}
+
+func mustBuildV2PackageRaw(t *testing.T, dir, source, version, content string) string {
+	t.Helper()
+
+	artifactName := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider"))
+	sum := sha256.Sum256([]byte(content))
+	manifest := map[string]any{
+		"schema_version": pluginmanifestv1.SchemaVersion2,
+		"source":         source,
+		"version":        version,
+		"kinds":          []string{pluginmanifestv1.KindProvider},
+		"provider": map[string]any{
+			"protocol": map[string]any{"min": 1, "max": 1},
+		},
+		"artifacts": []map[string]any{
+			{
+				"os":     runtime.GOOS,
+				"arch":   runtime.GOARCH,
+				"path":   artifactName,
+				"sha256": hex.EncodeToString(sum[:]),
+			},
+		},
+		"entrypoints": map[string]any{
+			"provider": map[string]any{
+				"artifact_path": artifactName,
+			},
+		},
+	}
+	manifestBytes, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent: %v", err)
+	}
+	manifestBytes = append(manifestBytes, '\n')
+
+	archivePath := filepath.Join(dir, "raw-v2.tar.gz")
+	out, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("Create archive: %v", err)
+	}
+	gzw := gzip.NewWriter(out)
+	tw := tar.NewWriter(gzw)
+
+	writeFile := func(name string, data []byte, mode int64) {
+		hdr := &tar.Header{Name: name, Mode: mode, Size: int64(len(data))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("WriteHeader %s: %v", name, err)
+		}
+		if _, err := io.Copy(tw, bytes.NewReader(data)); err != nil {
+			t.Fatalf("Write file %s: %v", name, err)
+		}
+	}
+	writeFile(pluginpkg.ManifestFile, manifestBytes, 0644)
+	writeFile(artifactName, []byte(content), 0755)
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatalf("close archive: %v", err)
+	}
+	return archivePath
+}
+
+func mustBuildV2PluginDir(t *testing.T, dir, source, version, content string) string {
+	t.Helper()
+
+	safeName := strings.NewReplacer("/", "-", ".", "_").Replace(source+"-"+version) + "-dir"
+	sourceDir := filepath.Join(dir, safeName)
+	artifactRel := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider"))
+	if err := os.MkdirAll(filepath.Join(sourceDir, filepath.Dir(filepath.FromSlash(artifactRel))), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, filepath.FromSlash(artifactRel)), []byte(content), 0755); err != nil {
+		t.Fatalf("WriteFile artifact: %v", err)
+	}
+
+	manifest := newV2Manifest(source, version, content)
+	manifestBytes, err := pluginpkg.EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, pluginpkg.ManifestFile), manifestBytes, 0644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+	return sourceDir
 }

--- a/sdk/pluginmanifest/v1/manifest.v2.jsonschema.json
+++ b/sdk/pluginmanifest/v1/manifest.v2.jsonschema.json
@@ -1,0 +1,188 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1/manifest.v2.jsonschema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "source",
+    "version",
+    "kinds",
+    "artifacts",
+    "entrypoints"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 2
+    },
+    "source": {
+      "type": "string",
+      "pattern": "^github\\.com/[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._-]*$"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+    },
+    "display_name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "kinds": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "provider",
+          "runtime"
+        ]
+      }
+    },
+    "provider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "protocol"
+      ],
+      "properties": {
+        "protocol": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "min",
+            "max"
+          ],
+          "properties": {
+            "min": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "max": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        },
+        "config_schema_path": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/artifact"
+      }
+    },
+    "entrypoints": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "$ref": "#/$defs/entrypoint"
+        },
+        "runtime": {
+          "$ref": "#/$defs/entrypoint"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "kinds": {
+            "contains": {
+              "const": "provider"
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "provider"
+        ],
+        "properties": {
+          "entrypoints": {
+            "required": [
+              "provider"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kinds": {
+            "contains": {
+              "const": "runtime"
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "entrypoints": {
+            "required": [
+              "runtime"
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "os",
+        "arch",
+        "path",
+        "sha256"
+      ],
+      "properties": {
+        "os": {
+          "type": "string",
+          "minLength": 1
+        },
+        "arch": {
+          "type": "string",
+          "minLength": 1
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "entrypoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_path"
+      ],
+      "properties": {
+        "artifact_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/sdk/pluginmanifest/v1/types.go
+++ b/sdk/pluginmanifest/v1/types.go
@@ -3,7 +3,8 @@ package pluginmanifestv1
 import _ "embed"
 
 const (
-	SchemaVersion = 1
+	SchemaVersion  = 1
+	SchemaVersion2 = 2
 
 	KindProvider = "provider"
 	KindRuntime  = "runtime"
@@ -11,7 +12,8 @@ const (
 
 type Manifest struct {
 	SchemaVersion int         `json:"schema_version"`
-	ID            string      `json:"id"`
+	ID            string      `json:"id,omitempty"`
+	Source        string      `json:"source,omitempty"`
 	Version       string      `json:"version"`
 	DisplayName   string      `json:"display_name,omitempty"`
 	Description   string      `json:"description,omitempty"`
@@ -50,3 +52,6 @@ type Entrypoint struct {
 
 //go:embed manifest.jsonschema.json
 var ManifestJSONSchema []byte
+
+//go:embed manifest.v2.jsonschema.json
+var ManifestV2JSONSchema []byte


### PR DESCRIPTION
Plugins can now declare a source address (e.g.
`github.com/owner/repo/plugin`) instead of a publisher/name ID. A v2
JSON schema enforces the source format and semver versioning at decode
time, while the store installs v2 plugins under a path derived from the
source address rather than the legacy publisher/name layout.

The CLI's `plugin package` command gains a `--source` flag for producing
v2 packages. The existing `--id` flag still works but prints a
deprecation warning. Both flags are mutually exclusive.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>