### PR TITLE
Add internal/pluginsource package for managed plugin source addresses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/valon-technologies/gestalt/sdk/pluginapi v0.0.0-00010101000000-000000000000
 	github.com/valon-technologies/gestalt/sdk/pluginsdk v0.0.0-00010101000000-000000000000
 	go.mongodb.org/mongo-driver/v2 v2.5.0
+	golang.org/x/mod v0.34.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/time v0.14.0
 	google.golang.org/api v0.256.0
@@ -101,7 +102,6 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
-	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVo
 golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 h1:mgKeJMpvi0yx/sU5GsxQ7p6s2wtOnGAHZWCHUM4KGzY=
 golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546/go.mod h1:j/pmGrbnkbPtQfxEe5D0VQhZC6qKbfKifgD0oM7sR70=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
-golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=
-golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
+golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
+golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=

--- a/internal/pluginsource/resolver.go
+++ b/internal/pluginsource/resolver.go
@@ -1,0 +1,14 @@
+package pluginsource
+
+import "context"
+
+type ResolvedPackage struct {
+	LocalPath     string
+	Cleanup       func()
+	ArchiveSHA256 string
+	ResolvedURL   string
+}
+
+type Resolver interface {
+	Resolve(ctx context.Context, src Source, version string) (*ResolvedPackage, error)
+}

--- a/internal/pluginsource/source.go
+++ b/internal/pluginsource/source.go
@@ -1,0 +1,69 @@
+package pluginsource
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	HostGitHub    = "github.com"
+	segmentCount  = 4
+	assetPrefix   = "gestalt-plugin-"
+	assetSuffix   = ".tar.gz"
+	versionPrefix = "v"
+)
+
+var segmentRe = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+
+type Source struct {
+	Host   string
+	Owner  string
+	Repo   string
+	Plugin string
+}
+
+func Parse(raw string) (Source, error) {
+	if raw != strings.TrimSpace(raw) {
+		return Source{}, fmt.Errorf("pluginsource: input contains leading or trailing whitespace")
+	}
+
+	parts := strings.Split(raw, "/")
+	if len(parts) != segmentCount {
+		return Source{}, fmt.Errorf("pluginsource: expected %d segments, got %d", segmentCount, len(parts))
+	}
+
+	host, owner, repo, plugin := parts[0], parts[1], parts[2], parts[3]
+
+	if host != HostGitHub {
+		return Source{}, fmt.Errorf("pluginsource: unsupported host %q (only %s is supported)", host, HostGitHub)
+	}
+
+	for _, seg := range []string{owner, repo, plugin} {
+		if !segmentRe.MatchString(seg) {
+			return Source{}, fmt.Errorf("pluginsource: invalid segment %q", seg)
+		}
+	}
+
+	return Source{Host: host, Owner: owner, Repo: repo, Plugin: plugin}, nil
+}
+
+func (s Source) String() string {
+	return s.Host + "/" + s.Owner + "/" + s.Repo + "/" + s.Plugin
+}
+
+func (s Source) AssetName(version string) string {
+	return assetPrefix + s.Plugin + "_" + versionPrefix + version + assetSuffix
+}
+
+func (s Source) ReleaseTag(version string) string {
+	return versionPrefix + version
+}
+
+func (s Source) StorePath() string {
+	return s.String()
+}
+
+func (s Source) RepoSlug() string {
+	return s.Owner + "/" + s.Repo
+}

--- a/internal/pluginsource/source_test.go
+++ b/internal/pluginsource/source_test.go
@@ -1,0 +1,129 @@
+package pluginsource
+
+import (
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    Source
+		wantErr bool
+	}{
+		{
+			name:  "valid basic",
+			input: "github.com/testowner/testrepo/testplugin",
+			want:  Source{Host: HostGitHub, Owner: "testowner", Repo: "testrepo", Plugin: "testplugin"},
+		},
+		{
+			name:  "valid with hyphens",
+			input: "github.com/test-org/test-repo/test-plugin",
+			want:  Source{Host: HostGitHub, Owner: "test-org", Repo: "test-repo", Plugin: "test-plugin"},
+		},
+		{
+			name:  "valid with dots hyphens underscores",
+			input: "github.com/my-org/my.repo/my_plugin",
+			want:  Source{Host: HostGitHub, Owner: "my-org", Repo: "my.repo", Plugin: "my_plugin"},
+		},
+		{
+			name:    "reject uppercase",
+			input:   "github.com/TestOwner/testrepo/testplugin",
+			wantErr: true,
+		},
+		{
+			name:    "reject missing plugin segment",
+			input:   "github.com/testowner/testrepo",
+			wantErr: true,
+		},
+		{
+			name:    "reject extra segments",
+			input:   "github.com/testowner/testrepo/testplugin/extra",
+			wantErr: true,
+		},
+		{
+			name:    "reject non-github host",
+			input:   "gitlab.com/testowner/testrepo/testplugin",
+			wantErr: true,
+		},
+		{
+			name:    "reject empty segment",
+			input:   "github.com//testrepo/testplugin",
+			wantErr: true,
+		},
+		{
+			name:    "reject leading whitespace",
+			input:   " github.com/testowner/testrepo/testplugin",
+			wantErr: true,
+		},
+		{
+			name:    "reject trailing whitespace",
+			input:   "github.com/testowner/testrepo/testplugin ",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Parse(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Parse(%q) succeeded, want error", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Parse(%q) error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("Parse(%q) = %+v, want %+v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSourceStringRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const input = "github.com/testowner/testrepo/testplugin"
+	src, err := Parse(input)
+	if err != nil {
+		t.Fatalf("Parse(%q) error: %v", input, err)
+	}
+	if got := src.String(); got != input {
+		t.Errorf("String() = %q, want %q", got, input)
+	}
+}
+
+func TestSourceAssetName(t *testing.T) {
+	t.Parallel()
+
+	src := Source{Host: HostGitHub, Owner: "testowner", Repo: "testrepo", Plugin: "testplugin"}
+	const want = "gestalt-plugin-testplugin_v1.2.3.tar.gz"
+	if got := src.AssetName("1.2.3"); got != want {
+		t.Errorf("AssetName(1.2.3) = %q, want %q", got, want)
+	}
+}
+
+func TestSourceReleaseTag(t *testing.T) {
+	t.Parallel()
+
+	src := Source{Host: HostGitHub, Owner: "testowner", Repo: "testrepo", Plugin: "testplugin"}
+	const want = "v1.2.3"
+	if got := src.ReleaseTag("1.2.3"); got != want {
+		t.Errorf("ReleaseTag(1.2.3) = %q, want %q", got, want)
+	}
+}
+
+func TestSourceRepoSlug(t *testing.T) {
+	t.Parallel()
+
+	src := Source{Host: HostGitHub, Owner: "testowner", Repo: "testrepo", Plugin: "testplugin"}
+	const want = "testowner/testrepo"
+	if got := src.RepoSlug(); got != want {
+		t.Errorf("RepoSlug() = %q, want %q", got, want)
+	}
+}

--- a/internal/pluginsource/version.go
+++ b/internal/pluginsource/version.go
@@ -1,0 +1,23 @@
+package pluginsource
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+func ValidateVersion(version string) error {
+	canonical := versionPrefix + version
+	if !semver.IsValid(canonical) {
+		return fmt.Errorf("pluginsource: invalid semver %q", version)
+	}
+	base := canonical
+	if i := strings.IndexByte(base, '+'); i != -1 {
+		base = base[:i]
+	}
+	if semver.Canonical(canonical) != base {
+		return fmt.Errorf("pluginsource: invalid semver %q", version)
+	}
+	return nil
+}

--- a/internal/pluginsource/version_test.go
+++ b/internal/pluginsource/version_test.go
@@ -1,0 +1,37 @@
+package pluginsource
+
+import (
+	"testing"
+)
+
+func TestValidateVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		version string
+		wantErr bool
+	}{
+		{name: "valid", version: "1.2.3"},
+		{name: "valid with prerelease", version: "1.0.0-alpha.1"},
+
+		{name: "reject leading v", version: "v1.2.3", wantErr: true},
+		{name: "reject empty", version: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateVersion(tt.version)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ValidateVersion(%q) succeeded, want error", tt.version)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateVersion(%q) error: %v", tt.version, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implement Wave A of ADR 003 (Managed Plugin Sources). This adds the pluginsource
package with Source address parsing for the github.com/<owner>/<repo>/<plugin>
grammar, SemVer 2.0.0 version validation, and the Resolver interface that future
waves will implement to download plugin archives from GitHub releases.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>