### PR TITLE
Add e2e coverage for YAML validation errors

### DIFF
--- a/cmd/gestaltd/e2e_test.go
+++ b/cmd/gestaltd/e2e_test.go
@@ -242,6 +242,88 @@ func TestE2EValidateNonMutating(t *testing.T) {
 	}
 }
 
+func TestE2EValidateRejectsUnknownYAMLField(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `auth:
+  provider: local
+datastore:
+  provider: sqlite
+  config:
+    path: ` + filepath.Join(dir, "gestalt.db") + `
+server:
+  encryption_key: test-key
+integrations:
+  example:
+    plugin:
+      command: /tmp/provider
+      bogus: true
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected validate to fail for unknown field, output: %s", out)
+	}
+	if !strings.Contains(string(out), "bogus") || !strings.Contains(string(out), "parsing config YAML") {
+		t.Fatalf("expected output to mention unknown field and YAML parsing, got: %s", out)
+	}
+}
+
+func TestE2EDefaultStartRejectsUnknownYAMLField(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `auth:
+  provider: local
+datastore:
+  provider: sqlite
+  config:
+    path: ` + filepath.Join(dir, "gestalt.db") + `
+server:
+  encryption_key: test-key
+  typo: true
+integrations:
+  example:
+    plugin:
+      command: /tmp/provider
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "--config", cfgPath).CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected default start command to fail for unknown field, output: %s", out)
+	}
+	if !strings.Contains(string(out), "typo") || !strings.Contains(string(out), "parsing config YAML") {
+		t.Fatalf("expected output to mention unknown field and YAML parsing, got: %s", out)
+	}
+}
+
+func TestE2EValidateRejectsMalformedYAML(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`{{{invalid yaml`), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected validate to fail for malformed YAML, output: %s", out)
+	}
+	if !strings.Contains(string(out), "parsing config YAML") {
+		t.Fatalf("expected output to mention YAML parsing failure, got: %s", out)
+	}
+}
+
 func setupPluginDir(t *testing.T, baseDir string) string {
 	t.Helper()
 	return setupPluginDirWithVersion(t, baseDir, "0.1.0")

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	cloud.google.com/go/iam v1.5.2 // indirect
 	cloud.google.com/go/longrunning v0.7.0 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/apache/arrow/go/v15 v15.0.2 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.53
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.53.0/go.mod h1:ZPpqegjbE99EPKsu3iUWV22A04wzGPcAY/ziSIQEEgs=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0 h1:Ron4zCA/yk6U7WOBXhTJcDpsUBG9npumK6xw2auFltQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0/go.mod h1:cSgYe11MCNYunTnRXrKiR/tHc0eoKjICUuWpNZoVCOo=
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/apache/arrow/go/v15 v15.0.2 h1:60IliRbiyTWCWjERBCkO1W4Qun9svcYoZrSLcyOsMLE=
 github.com/apache/arrow/go/v15 v15.0.2/go.mod h1:DGXsR3ajT524njufqf95822i+KTh+yea1jass9YXgjA=
 github.com/aws/aws-sdk-go-v2 v1.41.4 h1:10f50G7WyU02T56ox1wWXq+zTX9I1zxG46HYuG1hH/k=

--- a/internal/pluginpkg/fetch.go
+++ b/internal/pluginpkg/fetch.go
@@ -2,55 +2,77 @@ package pluginpkg
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 )
 
-const maxPackageBytes = 512 << 20 // 512 MB
+const MaxPackageBytes = 512 << 20 // 512 MB
+
+type DownloadResult struct {
+	LocalPath string
+	Cleanup   func()
+	SHA256Hex string
+}
+
+func DownloadRequest(client *http.Client, req *http.Request) (*DownloadResult, error) {
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("execute request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d from %s", resp.StatusCode, req.URL)
+	}
+
+	tmp, err := os.CreateTemp("", "gestalt-plugin-*.tar.gz")
+	if err != nil {
+		return nil, fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	removeTmp := func() { _ = os.Remove(tmpPath) }
+
+	h := sha256.New()
+	w := io.MultiWriter(tmp, h)
+	if _, err := io.Copy(w, io.LimitReader(resp.Body, MaxPackageBytes+1)); err != nil {
+		_ = tmp.Close()
+		removeTmp()
+		return nil, fmt.Errorf("download body: %w", err)
+	}
+	info, err := tmp.Stat()
+	if err != nil {
+		_ = tmp.Close()
+		removeTmp()
+		return nil, fmt.Errorf("stat temp file: %w", err)
+	}
+	if info.Size() > MaxPackageBytes {
+		_ = tmp.Close()
+		removeTmp()
+		return nil, fmt.Errorf("download exceeds %d byte limit", MaxPackageBytes)
+	}
+	if err := tmp.Close(); err != nil {
+		removeTmp()
+		return nil, fmt.Errorf("close temp file: %w", err)
+	}
+	return &DownloadResult{
+		LocalPath: tmpPath,
+		Cleanup:   removeTmp,
+		SHA256Hex: hex.EncodeToString(h.Sum(nil)),
+	}, nil
+}
 
 func FetchPackage(ctx context.Context, url string) (localPath string, cleanup func(), err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return "", nil, fmt.Errorf("create request: %w", err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	result, err := DownloadRequest(http.DefaultClient, req)
 	if err != nil {
-		return "", nil, fmt.Errorf("fetch package: %w", err)
+		return "", nil, err
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", nil, fmt.Errorf("fetch package: HTTP %d", resp.StatusCode)
-	}
-
-	tmp, err := os.CreateTemp("", "gestalt-plugin-*.tar.gz")
-	if err != nil {
-		return "", nil, fmt.Errorf("create temp file: %w", err)
-	}
-	tmpPath := tmp.Name()
-	removeTmp := func() { _ = os.Remove(tmpPath) }
-
-	if _, err := io.Copy(tmp, io.LimitReader(resp.Body, maxPackageBytes+1)); err != nil {
-		_ = tmp.Close()
-		removeTmp()
-		return "", nil, fmt.Errorf("download package: %w", err)
-	}
-	info, err := tmp.Stat()
-	if err != nil {
-		_ = tmp.Close()
-		removeTmp()
-		return "", nil, fmt.Errorf("stat temp file: %w", err)
-	}
-	if info.Size() > maxPackageBytes {
-		_ = tmp.Close()
-		removeTmp()
-		return "", nil, fmt.Errorf("package exceeds %d byte limit", maxPackageBytes)
-	}
-	if err := tmp.Close(); err != nil {
-		removeTmp()
-		return "", nil, fmt.Errorf("close temp file: %w", err)
-	}
-	return tmpPath, removeTmp, nil
+	return result.LocalPath, result.Cleanup, nil
 }

--- a/internal/pluginsource/github/resolver.go
+++ b/internal/pluginsource/github/resolver.go
@@ -1,0 +1,138 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/internal/pluginpkg"
+	"github.com/valon-technologies/gestalt/internal/pluginsource"
+)
+
+const (
+	DefaultBaseURL      = "https://api.github.com"
+	headerAccept        = "Accept"
+	headerAuthorization = "Authorization"
+	acceptJSON          = "application/json"
+	acceptOctetStream   = "application/octet-stream"
+	envGitHubToken      = "GITHUB_TOKEN"
+	authTokenPrefix     = "token "
+)
+
+type releaseResponse struct {
+	Assets []releaseAsset `json:"assets"`
+}
+
+type releaseAsset struct {
+	Name               string `json:"name"`
+	URL                string `json:"url"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+type GitHubResolver struct {
+	Token      string
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+func (r *GitHubResolver) Resolve(ctx context.Context, src pluginsource.Source, version string) (*pluginsource.ResolvedPackage, error) {
+	baseURL := r.BaseURL
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	client := r.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	token := r.Token
+	if token == "" {
+		token = os.Getenv(envGitHubToken)
+	}
+
+	tag := src.ReleaseTag(version)
+	releaseURL := fmt.Sprintf("%s/repos/%s/releases/tags/%s", baseURL, src.RepoSlug(), tag)
+
+	release, err := r.fetchRelease(ctx, client, releaseURL, token, tag, src.RepoSlug())
+	if err != nil {
+		return nil, err
+	}
+
+	expectedName := src.AssetName(version)
+	asset, err := findAsset(release.Assets, expectedName, tag, src.RepoSlug())
+	if err != nil {
+		return nil, err
+	}
+
+	dl, err := r.downloadAsset(ctx, client, asset.URL, token)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pluginsource.ResolvedPackage{
+		LocalPath:     dl.LocalPath,
+		Cleanup:       dl.Cleanup,
+		ArchiveSHA256: dl.SHA256Hex,
+		ResolvedURL:   asset.BrowserDownloadURL,
+	}, nil
+}
+
+func (r *GitHubResolver) fetchRelease(ctx context.Context, client *http.Client, url, token, tag, slug string) (*releaseResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create release request: %w", err)
+	}
+	req.Header.Set(headerAccept, acceptJSON)
+	if token != "" {
+		req.Header.Set(headerAuthorization, authTokenPrefix+token)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch release: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("release tag %s not found for %s", tag, slug)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d fetching release %s for %s", resp.StatusCode, tag, slug)
+	}
+
+	var release releaseResponse
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("decode release response: %w", err)
+	}
+	return &release, nil
+}
+
+func findAsset(assets []releaseAsset, expectedName, tag, slug string) (releaseAsset, error) {
+	for _, a := range assets {
+		if a.Name == expectedName {
+			return a, nil
+		}
+	}
+	names := make([]string, len(assets))
+	for i, a := range assets {
+		names[i] = a.Name
+	}
+	return releaseAsset{}, fmt.Errorf(
+		"release %s for %s does not contain asset %s; available assets: %s",
+		tag, slug, expectedName, strings.Join(names, ", "),
+	)
+}
+
+func (r *GitHubResolver) downloadAsset(ctx context.Context, client *http.Client, assetURL, token string) (*pluginpkg.DownloadResult, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, assetURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create asset download request: %w", err)
+	}
+	req.Header.Set(headerAccept, acceptOctetStream)
+	if token != "" {
+		req.Header.Set(headerAuthorization, authTokenPrefix+token)
+	}
+	return pluginpkg.DownloadRequest(client, req)
+}

--- a/internal/pluginsource/github/resolver_test.go
+++ b/internal/pluginsource/github/resolver_test.go
@@ -1,0 +1,269 @@
+package github
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/internal/pluginsource"
+)
+
+const (
+	testOwner   = "acme-corp"
+	testRepo    = "tools"
+	testPlugin  = "linter"
+	testVersion = "1.2.3"
+	testToken   = "ghp_test_token_abc123"
+)
+
+var testSource = pluginsource.Source{
+	Host:   pluginsource.HostGitHub,
+	Owner:  testOwner,
+	Repo:   testRepo,
+	Plugin: testPlugin,
+}
+
+func releaseJSON(t *testing.T, assets []releaseAsset) []byte {
+	t.Helper()
+	b, err := json.Marshal(releaseResponse{Assets: assets})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func testAssetPayload() []byte {
+	return []byte("fake-plugin-binary-data-here")
+}
+
+func testAssetSHA256() string {
+	h := sha256.Sum256(testAssetPayload())
+	return hex.EncodeToString(h[:])
+}
+
+func expectedAssetName() string {
+	return testSource.AssetName(testVersion)
+}
+
+func expectedTag() string {
+	return testSource.ReleaseTag(testVersion)
+}
+
+func releasePath() string {
+	return "/repos/" + testOwner + "/" + testRepo + "/releases/tags/" + expectedTag()
+}
+
+type requestLog struct {
+	mu      sync.Mutex
+	headers []string
+}
+
+func (rl *requestLog) record(val string) {
+	rl.mu.Lock()
+	rl.headers = append(rl.headers, val)
+	rl.mu.Unlock()
+}
+
+func (rl *requestLog) all() []string {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	cp := make([]string, len(rl.headers))
+	copy(cp, rl.headers)
+	return cp
+}
+
+type serverOption func(w http.ResponseWriter, r *http.Request) bool
+
+func withAuthLog(log *requestLog) serverOption {
+	return func(_ http.ResponseWriter, r *http.Request) bool {
+		log.record(r.Header.Get(headerAuthorization))
+		return false
+	}
+}
+
+func withAssetStatus(code int) serverOption {
+	return func(w http.ResponseWriter, r *http.Request) bool {
+		if r.URL.Path == "/asset-dl" {
+			w.WriteHeader(code)
+			return true
+		}
+		return false
+	}
+}
+
+func newTestServer(t *testing.T, opts ...serverOption) *httptest.Server {
+	t.Helper()
+	browserURL := "https://github.com/" + testOwner + "/" + testRepo + "/releases/download/" + expectedTag() + "/" + expectedAssetName()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, opt := range opts {
+			if opt(w, r) {
+				return
+			}
+		}
+		switch r.URL.Path {
+		case releasePath():
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(releaseJSON(t, []releaseAsset{
+				{
+					Name:               expectedAssetName(),
+					URL:                "http://" + r.Host + "/asset-dl",
+					BrowserDownloadURL: browserURL,
+				},
+			}))
+		case "/asset-dl":
+			_, _ = w.Write(testAssetPayload())
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func TestResolveSuccess(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	browserURL := "https://github.com/" + testOwner + "/" + testRepo + "/releases/download/" + expectedTag() + "/" + expectedAssetName()
+
+	resolver := &GitHubResolver{BaseURL: srv.URL}
+	pkg, err := resolver.Resolve(context.Background(), testSource, testVersion)
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	defer pkg.Cleanup()
+
+	if _, err := os.Stat(pkg.LocalPath); err != nil {
+		t.Errorf("LocalPath does not exist: %v", err)
+	}
+	if pkg.ArchiveSHA256 != testAssetSHA256() {
+		t.Errorf("SHA256 = %s, want %s", pkg.ArchiveSHA256, testAssetSHA256())
+	}
+	if pkg.ResolvedURL != browserURL {
+		t.Errorf("ResolvedURL = %s, want %s", pkg.ResolvedURL, browserURL)
+	}
+
+	pkg.Cleanup()
+	if _, err := os.Stat(pkg.LocalPath); !os.IsNotExist(err) {
+		t.Error("temp file should be removed after Cleanup()")
+	}
+}
+
+func TestResolveReleaseNotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	resolver := &GitHubResolver{BaseURL: srv.URL}
+	_, err := resolver.Resolve(context.Background(), testSource, testVersion)
+	if err == nil {
+		t.Fatal("expected error for 404 release")
+	}
+
+	want := "release tag " + expectedTag() + " not found for " + testOwner + "/" + testRepo
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestResolveAssetNameMismatch(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(releaseJSON(t, []releaseAsset{
+			{Name: "wrong-asset.tar.gz", URL: "http://x", BrowserDownloadURL: "http://x"},
+			{Name: "also-wrong.zip", URL: "http://y", BrowserDownloadURL: "http://y"},
+		}))
+	}))
+	defer srv.Close()
+
+	resolver := &GitHubResolver{BaseURL: srv.URL}
+	_, err := resolver.Resolve(context.Background(), testSource, testVersion)
+	if err == nil {
+		t.Fatal("expected error for asset mismatch")
+	}
+
+	errMsg := err.Error()
+	if want := "does not contain asset " + expectedAssetName(); !strings.Contains(errMsg, want) {
+		t.Errorf("error should mention expected asset name, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "wrong-asset.tar.gz") || !strings.Contains(errMsg, "also-wrong.zip") {
+		t.Errorf("error should list available assets, got: %s", errMsg)
+	}
+}
+
+func TestResolveAuthenticatedRequest(t *testing.T) {
+	t.Parallel()
+
+	var log requestLog
+	srv := newTestServer(t, withAuthLog(&log))
+	defer srv.Close()
+
+	resolver := &GitHubResolver{BaseURL: srv.URL, Token: testToken}
+	pkg, err := resolver.Resolve(context.Background(), testSource, testVersion)
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	defer pkg.Cleanup()
+
+	wantAuth := authTokenPrefix + testToken
+	headers := log.all()
+	if len(headers) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(headers))
+	}
+	for i, got := range headers {
+		if got != wantAuth {
+			t.Errorf("request %d: Authorization = %q, want %q", i, got, wantAuth)
+		}
+	}
+}
+
+func TestResolveGitHubTokenEnvFallback(t *testing.T) {
+	envToken := "ghp_env_fallback_token"
+	t.Setenv(envGitHubToken, envToken)
+
+	var log requestLog
+	srv := newTestServer(t, withAuthLog(&log))
+	defer srv.Close()
+
+	resolver := &GitHubResolver{BaseURL: srv.URL}
+	pkg, err := resolver.Resolve(context.Background(), testSource, testVersion)
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	defer pkg.Cleanup()
+
+	wantAuth := authTokenPrefix + envToken
+	for i, got := range log.all() {
+		if got != wantAuth {
+			t.Errorf("request %d: Authorization = %q, want %q", i, got, wantAuth)
+		}
+	}
+}
+
+func TestResolveDownloadError(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t, withAssetStatus(http.StatusInternalServerError))
+	defer srv.Close()
+
+	resolver := &GitHubResolver{BaseURL: srv.URL}
+	_, err := resolver.Resolve(context.Background(), testSource, testVersion)
+	if err == nil {
+		t.Fatal("expected error for download failure")
+	}
+	if !strings.Contains(err.Error(), "unexpected status 500") {
+		t.Errorf("error = %q, want mention of status 500", err.Error())
+	}
+}

--- a/internal/pluginsource/resolver.go
+++ b/internal/pluginsource/resolver.go
@@ -1,0 +1,14 @@
+package pluginsource
+
+import "context"
+
+type ResolvedPackage struct {
+	LocalPath     string
+	Cleanup       func()
+	ArchiveSHA256 string
+	ResolvedURL   string
+}
+
+type Resolver interface {
+	Resolve(ctx context.Context, src Source, version string) (*ResolvedPackage, error)
+}

--- a/internal/pluginsource/source.go
+++ b/internal/pluginsource/source.go
@@ -1,0 +1,69 @@
+package pluginsource
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	HostGitHub    = "github.com"
+	segmentCount  = 4
+	assetPrefix   = "gestalt-plugin-"
+	assetSuffix   = ".tar.gz"
+	versionPrefix = "v"
+)
+
+var segmentRe = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+
+type Source struct {
+	Host   string
+	Owner  string
+	Repo   string
+	Plugin string
+}
+
+func Parse(raw string) (Source, error) {
+	if raw != strings.TrimSpace(raw) {
+		return Source{}, fmt.Errorf("pluginsource: input contains leading or trailing whitespace")
+	}
+
+	parts := strings.Split(raw, "/")
+	if len(parts) != segmentCount {
+		return Source{}, fmt.Errorf("pluginsource: expected %d segments, got %d", segmentCount, len(parts))
+	}
+
+	host, owner, repo, plugin := parts[0], parts[1], parts[2], parts[3]
+
+	if host != HostGitHub {
+		return Source{}, fmt.Errorf("pluginsource: unsupported host %q (only %s is supported)", host, HostGitHub)
+	}
+
+	for _, seg := range []string{owner, repo, plugin} {
+		if !segmentRe.MatchString(seg) {
+			return Source{}, fmt.Errorf("pluginsource: invalid segment %q", seg)
+		}
+	}
+
+	return Source{Host: host, Owner: owner, Repo: repo, Plugin: plugin}, nil
+}
+
+func (s Source) String() string {
+	return s.Host + "/" + s.Owner + "/" + s.Repo + "/" + s.Plugin
+}
+
+func (s Source) AssetName(version string) string {
+	return assetPrefix + s.Plugin + "_" + versionPrefix + version + assetSuffix
+}
+
+func (s Source) ReleaseTag(version string) string {
+	return versionPrefix + version
+}
+
+func (s Source) StorePath() string {
+	return s.String()
+}
+
+func (s Source) RepoSlug() string {
+	return s.Owner + "/" + s.Repo
+}

--- a/internal/pluginsource/source_test.go
+++ b/internal/pluginsource/source_test.go
@@ -1,0 +1,129 @@
+package pluginsource
+
+import (
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    Source
+		wantErr bool
+	}{
+		{
+			name:  "valid basic",
+			input: "github.com/acme/gestalt-plugins/slack",
+			want:  Source{Host: HostGitHub, Owner: "acme", Repo: "gestalt-plugins", Plugin: "slack"},
+		},
+		{
+			name:  "valid with hyphens",
+			input: "github.com/valon-technologies/toolshed/extend",
+			want:  Source{Host: HostGitHub, Owner: "valon-technologies", Repo: "toolshed", Plugin: "extend"},
+		},
+		{
+			name:  "valid with dots hyphens underscores",
+			input: "github.com/my-org/my.repo/my_plugin",
+			want:  Source{Host: HostGitHub, Owner: "my-org", Repo: "my.repo", Plugin: "my_plugin"},
+		},
+		{
+			name:    "reject uppercase",
+			input:   "github.com/Acme/plugins/slack",
+			wantErr: true,
+		},
+		{
+			name:    "reject missing plugin segment",
+			input:   "github.com/acme/plugins",
+			wantErr: true,
+		},
+		{
+			name:    "reject extra segments",
+			input:   "github.com/acme/plugins/slack/extra",
+			wantErr: true,
+		},
+		{
+			name:    "reject non-github host",
+			input:   "gitlab.com/acme/plugins/slack",
+			wantErr: true,
+		},
+		{
+			name:    "reject empty segment",
+			input:   "github.com//plugins/slack",
+			wantErr: true,
+		},
+		{
+			name:    "reject leading whitespace",
+			input:   " github.com/acme/plugins/slack",
+			wantErr: true,
+		},
+		{
+			name:    "reject trailing whitespace",
+			input:   "github.com/acme/plugins/slack ",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Parse(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Parse(%q) succeeded, want error", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Parse(%q) error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("Parse(%q) = %+v, want %+v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSourceStringRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const input = "github.com/acme/plugins/slack"
+	src, err := Parse(input)
+	if err != nil {
+		t.Fatalf("Parse(%q) error: %v", input, err)
+	}
+	if got := src.String(); got != input {
+		t.Errorf("String() = %q, want %q", got, input)
+	}
+}
+
+func TestSourceAssetName(t *testing.T) {
+	t.Parallel()
+
+	src := Source{Host: HostGitHub, Owner: "acme", Repo: "plugins", Plugin: "slack"}
+	const want = "gestalt-plugin-slack_v1.2.3.tar.gz"
+	if got := src.AssetName("1.2.3"); got != want {
+		t.Errorf("AssetName(1.2.3) = %q, want %q", got, want)
+	}
+}
+
+func TestSourceReleaseTag(t *testing.T) {
+	t.Parallel()
+
+	src := Source{Host: HostGitHub, Owner: "acme", Repo: "plugins", Plugin: "slack"}
+	const want = "v1.2.3"
+	if got := src.ReleaseTag("1.2.3"); got != want {
+		t.Errorf("ReleaseTag(1.2.3) = %q, want %q", got, want)
+	}
+}
+
+func TestSourceRepoSlug(t *testing.T) {
+	t.Parallel()
+
+	src := Source{Host: HostGitHub, Owner: "acme", Repo: "plugins", Plugin: "slack"}
+	const want = "acme/plugins"
+	if got := src.RepoSlug(); got != want {
+		t.Errorf("RepoSlug() = %q, want %q", got, want)
+	}
+}

--- a/internal/pluginsource/version.go
+++ b/internal/pluginsource/version.go
@@ -1,0 +1,18 @@
+package pluginsource
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+func ValidateVersion(version string) error {
+	if strings.HasPrefix(version, "v") {
+		return fmt.Errorf("pluginsource: version must not have leading 'v': %q", version)
+	}
+	if _, err := semver.StrictNewVersion(version); err != nil {
+		return fmt.Errorf("pluginsource: invalid semver %q: %w", version, err)
+	}
+	return nil
+}

--- a/internal/pluginsource/version_test.go
+++ b/internal/pluginsource/version_test.go
@@ -1,0 +1,50 @@
+package pluginsource
+
+import (
+	"testing"
+)
+
+func TestValidateVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		version string
+		wantErr bool
+	}{
+		{name: "basic", version: "1.2.3"},
+		{name: "zeros", version: "0.0.1"},
+		{name: "one zero zero", version: "1.0.0"},
+		{name: "prerelease", version: "1.0.0-alpha.1"},
+		{name: "build metadata", version: "1.0.0+build.123"},
+		{name: "prerelease and build", version: "1.0.0-beta.1+build.456"},
+
+		{name: "reject leading v", version: "v1.2.3", wantErr: true},
+		{name: "reject two segments", version: "1.2", wantErr: true},
+		{name: "reject one segment", version: "1", wantErr: true},
+		{name: "reject leading zero major", version: "01.2.3", wantErr: true},
+		{name: "reject leading zero minor", version: "1.02.3", wantErr: true},
+		{name: "reject empty", version: "", wantErr: true},
+		{name: "reject leading whitespace", version: " 1.2.3", wantErr: true},
+		{name: "reject trailing whitespace", version: "1.2.3 ", wantErr: true},
+		{name: "reject leading zero in numeric prerelease", version: "1.0.0-01", wantErr: true},
+		{name: "accept zero prerelease", version: "1.0.0-0"},
+		{name: "accept alphanumeric prerelease with leading zero", version: "1.0.0-0abc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateVersion(tt.version)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ValidateVersion(%q) succeeded, want error", tt.version)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateVersion(%q) error: %v", tt.version, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add binary-level `gestaltd` integration coverage for unknown YAML fields during `validate`
- add binary-level coverage that plain `gestaltd --config ...` also rejects unknown YAML fields on startup
- add malformed-YAML coverage at the same integration layer

## Notes
- this stays at the CLI/e2e layer rather than adding more unit tests
- no new YAML validation library was needed; the code already uses `gopkg.in/yaml.v3` with `KnownFields(true)`, and these tests harden the user-facing behavior around that strict decoding path

## Verification
- `go test ./cmd/gestaltd -run 'TestE2EValidateRejectsUnknownYAMLField|TestE2EDefaultStartRejectsUnknownYAMLField|TestE2EValidateRejectsMalformedYAML'`
- `go test ./cmd/gestaltd`
