### PR TITLE
Add e2e coverage for YAML validation errors

### DIFF
--- a/cmd/gestaltd/e2e_test.go
+++ b/cmd/gestaltd/e2e_test.go
@@ -242,6 +242,88 @@ func TestE2EValidateNonMutating(t *testing.T) {
 	}
 }
 
+func TestE2EValidateRejectsUnknownYAMLField(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `auth:
+  provider: local
+datastore:
+  provider: sqlite
+  config:
+    path: ` + filepath.Join(dir, "gestalt.db") + `
+server:
+  encryption_key: test-key
+integrations:
+  example:
+    plugin:
+      command: /tmp/provider
+      bogus: true
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected validate to fail for unknown field, output: %s", out)
+	}
+	if !strings.Contains(string(out), "bogus") || !strings.Contains(string(out), "parsing config YAML") {
+		t.Fatalf("expected output to mention unknown field and YAML parsing, got: %s", out)
+	}
+}
+
+func TestE2EDefaultStartRejectsUnknownYAMLField(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `auth:
+  provider: local
+datastore:
+  provider: sqlite
+  config:
+    path: ` + filepath.Join(dir, "gestalt.db") + `
+server:
+  encryption_key: test-key
+  typo: true
+integrations:
+  example:
+    plugin:
+      command: /tmp/provider
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "--config", cfgPath).CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected default start command to fail for unknown field, output: %s", out)
+	}
+	if !strings.Contains(string(out), "typo") || !strings.Contains(string(out), "parsing config YAML") {
+		t.Fatalf("expected output to mention unknown field and YAML parsing, got: %s", out)
+	}
+}
+
+func TestE2EValidateRejectsMalformedYAML(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`{{{invalid yaml`), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected validate to fail for malformed YAML, output: %s", out)
+	}
+	if !strings.Contains(string(out), "parsing config YAML") {
+		t.Fatalf("expected output to mention YAML parsing failure, got: %s", out)
+	}
+}
+
 func setupPluginDir(t *testing.T, baseDir string) string {
 	t.Helper()
 	return setupPluginDirWithVersion(t, baseDir, "0.1.0")

--- a/cmd/gestaltd/e2e_test.go
+++ b/cmd/gestaltd/e2e_test.go
@@ -243,8 +243,6 @@ func TestE2EValidateNonMutating(t *testing.T) {
 }
 
 func TestE2EValidateRejectsUnknownYAMLField(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := `auth:
@@ -275,8 +273,6 @@ integrations:
 }
 
 func TestE2EDefaultStartRejectsUnknownYAMLField(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := `auth:
@@ -307,8 +303,6 @@ integrations:
 }
 
 func TestE2EValidateRejectsMalformedYAML(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte(`{{{invalid yaml`), 0o644); err != nil {

--- a/cmd/gestaltd/e2e_test.go
+++ b/cmd/gestaltd/e2e_test.go
@@ -242,6 +242,7 @@ func TestE2EValidateNonMutating(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // Spawns the CLI binary; keeping it serial avoids package-level e2e flake.
 func TestE2EValidateRejectsUnknownYAMLField(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
@@ -272,6 +273,7 @@ integrations:
 	}
 }
 
+//nolint:paralleltest // Spawns the CLI binary; keeping it serial avoids package-level e2e flake.
 func TestE2EDefaultStartRejectsUnknownYAMLField(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
@@ -302,6 +304,7 @@ integrations:
 	}
 }
 
+//nolint:paralleltest // Spawns the CLI binary; keeping it serial avoids package-level e2e flake.
 func TestE2EValidateRejectsMalformedYAML(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")


### PR DESCRIPTION
## Summary
- add binary-level `gestaltd` integration coverage for unknown YAML fields during `validate`
- add binary-level coverage that plain `gestaltd --config ...` also rejects unknown YAML fields on startup
- add malformed-YAML coverage at the same integration layer
- keep the new binary-spawning tests non-parallel to avoid introducing package-level test flake

## Notes
- this stays at the CLI/e2e layer rather than adding more unit tests
- no new YAML validation library was needed; the code already uses `gopkg.in/yaml.v3` with `KnownFields(true)`, and these tests harden the user-facing behavior around that strict decoding path
- this PR supersedes #266, which was accidentally branched from a non-`main` branch

## Verification
- `go test ./cmd/gestaltd -run 'TestE2EValidateRejectsUnknownYAMLField|TestE2EDefaultStartRejectsUnknownYAMLField|TestE2EValidateRejectsMalformedYAML'`
- `go test ./cmd/gestaltd`
