### PR TITLE
Add top-level ui: config and refactor webui handler

### DIFF
--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -114,6 +114,11 @@ func runServer(env *bootstrapEnv) error {
 		log.Printf("  integration callback: %s%s", env.Config.Server.BaseURL, config.IntegrationCallbackPath)
 	}
 
+	uiHandler, err := resolveUIHandler(env.Config)
+	if err != nil {
+		return fmt.Errorf("resolving ui handler: %w", err)
+	}
+
 	mcpSlot := &lateHandler{}
 	var mcpHandler http.Handler = mcpSlot
 
@@ -134,7 +139,7 @@ func runServer(env *bootstrapEnv) error {
 			datastoreReadiness(result.Datastore),
 		),
 		MCPHandler: mcpHandler,
-		WebUI:      webui.Handler(),
+		WebUI:      uiHandler,
 	})
 	if err != nil {
 		return fmt.Errorf("creating server: %w", err)
@@ -190,6 +195,16 @@ func runServer(env *bootstrapEnv) error {
 	}
 
 	return nil
+}
+
+func resolveUIHandler(cfg *config.Config) (http.Handler, error) {
+	if cfg.UI.Plugin == nil {
+		return webui.EmbeddedHandler(), nil
+	}
+	if cfg.UI.Plugin.ResolvedAssetRoot != "" {
+		return webui.DirHandler(cfg.UI.Plugin.ResolvedAssetRoot)
+	}
+	return nil, fmt.Errorf("ui plugin configured but asset root not resolved")
 }
 
 type mcpSurface struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,20 @@ type Config struct {
 	Bindings     map[string]BindingDef     `yaml:"bindings"`
 	Server       ServerConfig              `yaml:"server"`
 	Egress       EgressConfig              `yaml:"egress"`
+	UI           UIConfig                  `yaml:"ui"`
+}
+
+type UIConfig struct {
+	Plugin *UIPluginDef `yaml:"plugin"`
+}
+
+type UIPluginDef struct {
+	Package string `yaml:"package"`
+	Source  string `yaml:"source"`
+	Version string `yaml:"version"`
+
+	ResolvedAssetRoot    string `yaml:"-"`
+	ResolvedManifestPath string `yaml:"-"`
 }
 
 type EgressConfig struct {
@@ -283,6 +297,10 @@ func resolveRelativePaths(configPath string, cfg *Config) {
 		}
 		cfg.Runtimes[name] = rt
 	}
+
+	if cfg.UI.Plugin != nil {
+		cfg.UI.Plugin.Package = resolvePackagePath(baseDir, cfg.UI.Plugin.Package)
+	}
 }
 
 func resolveRelativePath(baseDir, value string) string {
@@ -324,6 +342,9 @@ var templateParamRe = regexp.MustCompile(`\{(\w+)\}`)
 // runtime secrets like encryption_key, auth.provider, or datastore.provider.
 func ValidateStructure(cfg *Config) error {
 	if err := validateEgress(&cfg.Egress); err != nil {
+		return err
+	}
+	if err := validateUIPlugin(cfg.UI.Plugin); err != nil {
 		return err
 	}
 	for name := range cfg.Integrations {
@@ -563,6 +584,45 @@ func validateExecutablePlugin(kind, name string, plugin *ExecutablePluginDef) er
 	}
 	if strings.HasPrefix(plugin.Package, "http://") {
 		return fmt.Errorf("config validation: %s %q plugin.package requires HTTPS; plain HTTP is not supported", kind, name)
+	}
+	return nil
+}
+
+func validateUIPlugin(plugin *UIPluginDef) error {
+	if plugin == nil {
+		return nil
+	}
+	sourceCount := 0
+	if plugin.Package != "" {
+		sourceCount++
+	}
+	if plugin.Source != "" {
+		sourceCount++
+	}
+	switch {
+	case sourceCount == 0:
+		return fmt.Errorf("config validation: ui plugin.package or plugin.source is required")
+	case sourceCount > 1:
+		return fmt.Errorf("config validation: ui plugin.package and plugin.source are mutually exclusive")
+	}
+
+	if plugin.Source != "" {
+		if _, err := pluginsource.Parse(plugin.Source); err != nil {
+			return fmt.Errorf("config validation: ui plugin.source: %w", err)
+		}
+		if plugin.Version == "" {
+			return fmt.Errorf("config validation: ui plugin.version is required when plugin.source is set")
+		}
+		if err := pluginsource.ValidateVersion(plugin.Version); err != nil {
+			return fmt.Errorf("config validation: ui plugin.version: %w", err)
+		}
+	}
+
+	if plugin.Package != "" && plugin.Version != "" {
+		return fmt.Errorf("config validation: ui plugin.version is only valid with plugin.source")
+	}
+	if strings.HasPrefix(plugin.Package, "http://") {
+		return fmt.Errorf("config validation: ui plugin.package requires HTTPS; plain HTTP is not supported")
 	}
 	return nil
 }

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -8,26 +8,18 @@ package webui
 
 import (
 	"embed"
+	"fmt"
 	"io/fs"
 	"net/http"
+	"os"
 	"strings"
 )
 
 //go:embed all:out
 var assets embed.FS
 
-// Handler returns an http.Handler that serves the embedded frontend,
-// or nil if the frontend has not been built.
-func Handler() http.Handler {
-	sub, err := fs.Sub(assets, "out")
-	if err != nil {
-		return nil
-	}
-	if _, err := fs.Stat(sub, "index.html"); err != nil {
-		return nil
-	}
-
-	fileServer := http.FileServer(http.FS(sub))
+func NewHandler(root fs.FS) http.Handler {
+	fileServer := http.FileServer(http.FS(root))
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := strings.TrimPrefix(r.URL.Path, "/")
@@ -35,18 +27,17 @@ func Handler() http.Handler {
 			path = "index.html"
 		}
 
-		if _, err := fs.Stat(sub, path); err == nil {
+		if _, err := fs.Stat(root, path); err == nil {
 			fileServer.ServeHTTP(w, r)
 			return
 		}
 
-		// Try path.html and path/index.html for Next.js static export routes.
 		if !strings.Contains(path, ".") {
-			if _, err := fs.Stat(sub, path+".html"); err == nil {
+			if _, err := fs.Stat(root, path+".html"); err == nil {
 				serve(fileServer, w, r, "/"+path+".html")
 				return
 			}
-			if _, err := fs.Stat(sub, path+"/index.html"); err == nil {
+			if _, err := fs.Stat(root, path+"/index.html"); err == nil {
 				serve(fileServer, w, r, "/"+path+"/index.html")
 				return
 			}
@@ -54,6 +45,25 @@ func Handler() http.Handler {
 
 		serve(fileServer, w, r, "/index.html")
 	})
+}
+
+func EmbeddedHandler() http.Handler {
+	sub, err := fs.Sub(assets, "out")
+	if err != nil {
+		return nil
+	}
+	if _, err := fs.Stat(sub, "index.html"); err != nil {
+		return nil
+	}
+	return NewHandler(sub)
+}
+
+func DirHandler(path string) (http.Handler, error) {
+	root := os.DirFS(path)
+	if _, err := fs.Stat(root, "index.html"); err != nil {
+		return nil, fmt.Errorf("webui asset root %s does not contain index.html", path)
+	}
+	return NewHandler(root), nil
 }
 
 func serve(h http.Handler, w http.ResponseWriter, r *http.Request, path string) {


### PR DESCRIPTION
Gestalt previously had no way to serve a UI other than the embedded
frontend. This adds a `ui:` section to the config file that lets
operators point at a local package directory or a managed plugin source.
When no `ui:` section is present the behavior is unchanged and the
embedded assets are served as before.

The webui package is split into composable entry points so the server
can serve static assets from any `fs.FS`, whether that comes from the
embedded build output or a directory on disk. The server startup now
selects the appropriate handler based on the resolved config.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>