### PR TITLE
Add webui manifest kind to v2 plugin manifest schema

### DIFF
--- a/internal/pluginpkg/manifest.go
+++ b/internal/pluginpkg/manifest.go
@@ -95,22 +95,33 @@ func ValidateManifest(manifest *pluginmanifestv1.Manifest) error {
 		return fmt.Errorf("unsupported manifest schema_version %d", manifest.SchemaVersion)
 	}
 
-	artifactPaths := make(map[string]struct{}, len(manifest.Artifacts))
-	artifactPlatforms := make(map[string]struct{}, len(manifest.Artifacts))
-	for _, artifact := range manifest.Artifacts {
-		if err := validateRelativePackagePath(artifact.Path, "artifact path"); err != nil {
-			return err
+	hasExecutableKinds := false
+	for _, kind := range manifest.Kinds {
+		if kind == pluginmanifestv1.KindProvider || kind == pluginmanifestv1.KindRuntime {
+			hasExecutableKinds = true
+			break
 		}
-		if _, exists := artifactPaths[artifact.Path]; exists {
-			return fmt.Errorf("duplicate artifact path %q", artifact.Path)
-		}
-		artifactPaths[artifact.Path] = struct{}{}
+	}
 
-		key := artifact.OS + "/" + artifact.Arch
-		if _, exists := artifactPlatforms[key]; exists {
-			return fmt.Errorf("duplicate artifact platform %q", key)
+	var artifactPaths map[string]struct{}
+	if hasExecutableKinds {
+		artifactPaths = make(map[string]struct{}, len(manifest.Artifacts))
+		artifactPlatforms := make(map[string]struct{}, len(manifest.Artifacts))
+		for _, artifact := range manifest.Artifacts {
+			if err := validateRelativePackagePath(artifact.Path, "artifact path"); err != nil {
+				return err
+			}
+			if _, exists := artifactPaths[artifact.Path]; exists {
+				return fmt.Errorf("duplicate artifact path %q", artifact.Path)
+			}
+			artifactPaths[artifact.Path] = struct{}{}
+
+			key := artifact.OS + "/" + artifact.Arch
+			if _, exists := artifactPlatforms[key]; exists {
+				return fmt.Errorf("duplicate artifact platform %q", key)
+			}
+			artifactPlatforms[key] = struct{}{}
 		}
-		artifactPlatforms[key] = struct{}{}
 	}
 
 	for _, kind := range manifest.Kinds {
@@ -133,6 +144,21 @@ func ValidateManifest(manifest *pluginmanifestv1.Manifest) error {
 		case pluginmanifestv1.KindRuntime:
 			if err := validateEntrypoint(kind, manifest.Entrypoints.Runtime, artifactPaths); err != nil {
 				return err
+			}
+		case pluginmanifestv1.KindWebUI:
+			if manifest.SchemaVersion != pluginmanifestv1.SchemaVersion2 {
+				return fmt.Errorf("webui kind requires schema_version %d", pluginmanifestv1.SchemaVersion2)
+			}
+			if manifest.WebUI == nil {
+				return fmt.Errorf("webui metadata is required when kind %q is present", pluginmanifestv1.KindWebUI)
+			}
+			if err := validateRelativePackagePath(manifest.WebUI.AssetRoot, "webui asset root"); err != nil {
+				return err
+			}
+			for _, other := range manifest.Kinds {
+				if other != pluginmanifestv1.KindWebUI {
+					return fmt.Errorf("webui kind cannot be combined with %q", other)
+				}
 			}
 		default:
 			return fmt.Errorf("unsupported manifest kind %q", kind)

--- a/sdk/pluginmanifest/v1/manifest.v2.jsonschema.json
+++ b/sdk/pluginmanifest/v1/manifest.v2.jsonschema.json
@@ -7,9 +7,7 @@
     "schema_version",
     "source",
     "version",
-    "kinds",
-    "artifacts",
-    "entrypoints"
+    "kinds"
   ],
   "properties": {
     "schema_version": {
@@ -36,7 +34,8 @@
       "items": {
         "enum": [
           "provider",
-          "runtime"
+          "runtime",
+          "webui"
         ]
       }
     },
@@ -66,6 +65,17 @@
           }
         },
         "config_schema_path": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "webui": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["asset_root"],
+      "properties": {
+        "asset_root": {
           "type": "string",
           "minLength": 1
         }
@@ -104,6 +114,8 @@
       },
       "then": {
         "required": [
+          "artifacts",
+          "entrypoints",
           "provider"
         ],
         "properties": {
@@ -126,6 +138,10 @@
         }
       },
       "then": {
+        "required": [
+          "artifacts",
+          "entrypoints"
+        ],
         "properties": {
           "entrypoints": {
             "required": [
@@ -133,6 +149,22 @@
             ]
           }
         }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kinds": {
+            "contains": {
+              "const": "webui"
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "webui"
+        ]
       }
     }
   ],

--- a/sdk/pluginmanifest/v1/types.go
+++ b/sdk/pluginmanifest/v1/types.go
@@ -21,8 +21,8 @@ type Manifest struct {
 	Kinds         []string    `json:"kinds"`
 	Provider      *Provider       `json:"provider,omitempty"`
 	WebUI         *WebUIMetadata `json:"webui,omitempty"`
-	Artifacts     []Artifact     `json:"artifacts"`
-	Entrypoints   Entrypoints    `json:"entrypoints"`
+	Artifacts     []Artifact     `json:"artifacts,omitempty"`
+	Entrypoints   Entrypoints    `json:"entrypoints,omitempty"`
 }
 
 type WebUIMetadata struct {

--- a/sdk/pluginmanifest/v1/types.go
+++ b/sdk/pluginmanifest/v1/types.go
@@ -8,6 +8,7 @@ const (
 
 	KindProvider = "provider"
 	KindRuntime  = "runtime"
+	KindWebUI    = "webui"
 )
 
 type Manifest struct {
@@ -18,9 +19,14 @@ type Manifest struct {
 	DisplayName   string      `json:"display_name,omitempty"`
 	Description   string      `json:"description,omitempty"`
 	Kinds         []string    `json:"kinds"`
-	Provider      *Provider   `json:"provider,omitempty"`
-	Artifacts     []Artifact  `json:"artifacts"`
-	Entrypoints   Entrypoints `json:"entrypoints"`
+	Provider      *Provider       `json:"provider,omitempty"`
+	WebUI         *WebUIMetadata `json:"webui,omitempty"`
+	Artifacts     []Artifact     `json:"artifacts"`
+	Entrypoints   Entrypoints    `json:"entrypoints"`
+}
+
+type WebUIMetadata struct {
+	AssetRoot string `json:"asset_root"`
 }
 
 type Provider struct {

--- a/sdk/pluginmanifest/v1/types.go
+++ b/sdk/pluginmanifest/v1/types.go
@@ -12,14 +12,14 @@ const (
 )
 
 type Manifest struct {
-	SchemaVersion int         `json:"schema_version"`
-	ID            string      `json:"id,omitempty"`
-	Source        string      `json:"source,omitempty"`
-	Version       string      `json:"version"`
-	DisplayName   string      `json:"display_name,omitempty"`
-	Description   string      `json:"description,omitempty"`
-	Kinds         []string    `json:"kinds"`
-	Provider      *Provider       `json:"provider,omitempty"`
+	SchemaVersion int            `json:"schema_version"`
+	ID            string         `json:"id,omitempty"`
+	Source        string         `json:"source,omitempty"`
+	Version       string         `json:"version"`
+	DisplayName   string         `json:"display_name,omitempty"`
+	Description   string         `json:"description,omitempty"`
+	Kinds         []string       `json:"kinds"`
+	Provider      *Provider      `json:"provider,omitempty"`
 	WebUI         *WebUIMetadata `json:"webui,omitempty"`
 	Artifacts     []Artifact     `json:"artifacts,omitempty"`
 	Entrypoints   Entrypoints    `json:"entrypoints,omitempty"`


### PR DESCRIPTION
UI plugins serve static assets rather than running executables, so they
need a different manifest shape. This adds the "webui" kind, which
declares an asset root path and requires neither artifacts nor
entrypoints. The webui kind is exclusive and cannot be combined with
provider or runtime kinds in the same manifest.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>