### PR TITLE
Add webui plugin support to store, lifecycle, and bundle

### DIFF
--- a/cmd/gestaltd/bundle.go
+++ b/cmd/gestaltd/bundle.go
@@ -87,6 +87,11 @@ func collectLocalRefs(configPath string) ([]string, error) {
 				Package string `yaml:"package"`
 			} `yaml:"plugin"`
 		} `yaml:"runtimes"`
+		UI struct {
+			Plugin *struct {
+				Package string `yaml:"package"`
+			} `yaml:"plugin"`
+		} `yaml:"ui"`
 	}
 	if err := yaml.Unmarshal(data, &raw); err != nil {
 		return nil, fmt.Errorf("parsing config for local refs: %w", err)
@@ -136,6 +141,17 @@ func collectLocalRefs(configPath string) ([]string, error) {
 				}
 				refs = append(refs, resolved)
 			}
+		}
+	}
+
+	if raw.UI.Plugin != nil && raw.UI.Plugin.Package != "" {
+		pkg := raw.UI.Plugin.Package
+		if !strings.HasPrefix(pkg, "https://") && !filepath.IsAbs(pkg) {
+			resolved := filepath.Clean(filepath.Join(baseDir, pkg))
+			if _, err := os.Stat(resolved); err != nil {
+				return nil, fmt.Errorf("ui plugin.package %q: %w", pkg, err)
+			}
+			refs = append(refs, resolved)
 		}
 	}
 

--- a/cmd/gestaltd/init.go
+++ b/cmd/gestaltd/init.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/operator"
+	github "github.com/valon-technologies/gestalt/internal/pluginsource/github"
 	"github.com/valon-technologies/gestalt/internal/provider"
 	providercompiler "github.com/valon-technologies/gestalt/internal/provider/compiler"
 )
@@ -22,7 +23,7 @@ type lockPluginEntry = operator.LockPluginEntry
 func operatorLifecycle() *operator.Lifecycle {
 	return operator.NewLifecycle(func(ctx context.Context, name string, api config.APIDef) (*provider.Definition, error) {
 		return providercompiler.LoadDefinition(ctx, name, api, nil)
-	}, nil)
+	}, &github.GitHubResolver{})
 }
 
 func initConfig(configFlag string) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -301,6 +301,10 @@ func resolveRelativePaths(configPath string, cfg *Config) {
 		}
 		cfg.Runtimes[name] = rt
 	}
+
+	if cfg.UI.Plugin != nil {
+		cfg.UI.Plugin.Package = resolvePackagePath(baseDir, cfg.UI.Plugin.Package)
+	}
 }
 
 func resolveRelativePath(baseDir, value string) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,24 @@ type Config struct {
 	Bindings     map[string]BindingDef     `yaml:"bindings"`
 	Server       ServerConfig              `yaml:"server"`
 	Egress       EgressConfig              `yaml:"egress"`
+	UI           UIConfig                  `yaml:"ui"`
+}
+
+type UIConfig struct {
+	Plugin *UIPluginDef `yaml:"plugin"`
+}
+
+type UIPluginDef struct {
+	Package string `yaml:"package"`
+	Source  string `yaml:"source"`
+	Version string `yaml:"version"`
+
+	ResolvedAssetRoot    string `yaml:"-"`
+	ResolvedManifestPath string `yaml:"-"`
+}
+
+func (p *UIPluginDef) HasManagedArtifacts() bool {
+	return p != nil && (p.Package != "" || p.Source != "")
 }
 
 type EgressConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -348,6 +348,9 @@ func ValidateStructure(cfg *Config) error {
 	if err := validateEgress(&cfg.Egress); err != nil {
 		return err
 	}
+	if err := validateUIPlugin(cfg.UI.Plugin); err != nil {
+		return err
+	}
 	for name := range cfg.Integrations {
 		intg := cfg.Integrations[name]
 		if err := validateIntegration(name, intg); err != nil {
@@ -585,6 +588,45 @@ func validateExecutablePlugin(kind, name string, plugin *ExecutablePluginDef) er
 	}
 	if strings.HasPrefix(plugin.Package, "http://") {
 		return fmt.Errorf("config validation: %s %q plugin.package requires HTTPS; plain HTTP is not supported", kind, name)
+	}
+	return nil
+}
+
+func validateUIPlugin(plugin *UIPluginDef) error {
+	if plugin == nil {
+		return nil
+	}
+	sourceCount := 0
+	if plugin.Package != "" {
+		sourceCount++
+	}
+	if plugin.Source != "" {
+		sourceCount++
+	}
+	switch {
+	case sourceCount == 0:
+		return fmt.Errorf("config validation: ui plugin.package or plugin.source is required")
+	case sourceCount > 1:
+		return fmt.Errorf("config validation: ui plugin.package and plugin.source are mutually exclusive")
+	}
+
+	if plugin.Source != "" {
+		if _, err := pluginsource.Parse(plugin.Source); err != nil {
+			return fmt.Errorf("config validation: ui plugin.source: %w", err)
+		}
+		if plugin.Version == "" {
+			return fmt.Errorf("config validation: ui plugin.version is required when plugin.source is set")
+		}
+		if err := pluginsource.ValidateVersion(plugin.Version); err != nil {
+			return fmt.Errorf("config validation: ui plugin.version: %w", err)
+		}
+	}
+
+	if plugin.Package != "" && plugin.Version != "" {
+		return fmt.Errorf("config validation: ui plugin.version is only valid with plugin.source")
+	}
+	if strings.HasPrefix(plugin.Package, "http://") {
+		return fmt.Errorf("config validation: ui plugin.package requires HTTPS; plain HTTP is not supported")
 	}
 	return nil
 }

--- a/internal/operator/lifecycle.go
+++ b/internal/operator/lifecycle.go
@@ -709,6 +709,12 @@ func (l *Lifecycle) writeUIPluginArtifact(ctx context.Context, cfg *config.Confi
 		if err != nil {
 			return LockPluginEntry{}, fmt.Errorf("ui plugin install source: %w", err)
 		}
+		if installed.Manifest.Source != plugin.Source {
+			return LockPluginEntry{}, fmt.Errorf("ui plugin manifest source %q does not match config source %q", installed.Manifest.Source, plugin.Source)
+		}
+		if installed.Manifest.Version != plugin.Version {
+			return LockPluginEntry{}, fmt.Errorf("ui plugin manifest version %q does not match config version %q", installed.Manifest.Version, plugin.Version)
+		}
 		manifestPath, err := filepath.Rel(paths.configDir, installed.ManifestPath)
 		if err != nil {
 			return LockPluginEntry{}, fmt.Errorf("compute manifest path for ui plugin: %w", err)

--- a/internal/operator/lifecycle.go
+++ b/internal/operator/lifecycle.go
@@ -284,10 +284,7 @@ func configHasPlugins(cfg *config.Config) bool {
 			return true
 		}
 	}
-	if cfg.UI.Plugin.HasManagedArtifacts() {
-		return true
-	}
-	return false
+	return cfg.UI.Plugin.HasManagedArtifacts()
 }
 
 func resolveLockPath(baseDir, provider string) string {
@@ -406,6 +403,12 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 		assetRootPath := resolveLockPath(paths.configDir, entry.AssetRoot)
 		if _, err := os.Stat(assetRootPath); err != nil {
 			return false
+		}
+		if entry.SourceDigest != "" && cfg.UI.Plugin.Package != "" && !strings.HasPrefix(cfg.UI.Plugin.Package, "https://") {
+			digest, err := sourceDigestForPackage(cfg.UI.Plugin.Package)
+			if err != nil || digest != entry.SourceDigest {
+				return false
+			}
 		}
 	}
 	return true

--- a/internal/operator/lifecycle.go
+++ b/internal/operator/lifecycle.go
@@ -49,7 +49,8 @@ type LockPluginEntry struct {
 	ResolvedURL   string `json:"resolved_url,omitempty"`
 	ArchiveSHA256 string `json:"archive_sha256,omitempty"`
 	Manifest      string `json:"manifest"`
-	Executable    string `json:"executable"`
+	Executable    string `json:"executable,omitempty"`
+	AssetRoot     string `json:"asset_root,omitempty"`
 }
 
 type UpstreamLoader func(ctx context.Context, name string, api config.APIDef) (*provider.Definition, error)
@@ -283,6 +284,9 @@ func configHasPlugins(cfg *config.Config) bool {
 			return true
 		}
 	}
+	if cfg.UI.Plugin.HasManagedArtifacts() {
+		return true
+	}
 	return false
 }
 
@@ -385,6 +389,25 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 			return false
 		}
 	}
+	if cfg.UI.Plugin.HasManagedArtifacts() {
+		key := LockPluginKey("ui", "default")
+		entry, found := lock.Plugins[key]
+		if !found {
+			return false
+		}
+		fingerprint, err := UIPluginFingerprint(cfg.UI.Plugin)
+		if err != nil || entry.Fingerprint != fingerprint {
+			return false
+		}
+		manifestPath := resolveLockPath(paths.configDir, entry.Manifest)
+		if _, err := os.Stat(manifestPath); err != nil {
+			return false
+		}
+		assetRootPath := resolveLockPath(paths.configDir, entry.AssetRoot)
+		if _, err := os.Stat(assetRootPath); err != nil {
+			return false
+		}
+	}
 	return true
 }
 
@@ -406,6 +429,24 @@ func PluginFingerprint(name string, plugin *config.ExecutablePluginDef, configMa
 		input.Config = configMap
 	}
 
+	payload, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func UIPluginFingerprint(plugin *config.UIPluginDef) (string, error) {
+	input := struct {
+		Package string `json:"package,omitempty"`
+		Source  string `json:"source,omitempty"`
+		Version string `json:"version,omitempty"`
+	}{
+		Package: plugin.Package,
+		Source:  plugin.Source,
+		Version: plugin.Version,
+	}
 	payload, err := json.Marshal(input)
 	if err != nil {
 		return "", err
@@ -499,6 +540,15 @@ func (l *Lifecycle) writePluginArtifacts(ctx context.Context, configPath string,
 		}
 		written[LockPluginKey("runtime", name)] = entry
 	}
+
+	if cfg.UI.Plugin.HasManagedArtifacts() {
+		entry, err := l.writeUIPluginArtifact(ctx, cfg, paths, store)
+		if err != nil {
+			return nil, err
+		}
+		written[LockPluginKey("ui", "default")] = entry
+	}
+
 	return written, nil
 }
 
@@ -629,6 +679,100 @@ func (l *Lifecycle) lockEntryForSource(ctx context.Context, paths initPaths, sto
 	}, nil
 }
 
+func (l *Lifecycle) writeUIPluginArtifact(ctx context.Context, cfg *config.Config, paths initPaths, store *pluginstore.Store) (LockPluginEntry, error) {
+	plugin := cfg.UI.Plugin
+	fingerprint, err := UIPluginFingerprint(plugin)
+	if err != nil {
+		return LockPluginEntry{}, fmt.Errorf("fingerprinting ui plugin: %w", err)
+	}
+
+	var installed *pluginstore.InstalledPlugin
+	var sourceDigest string
+	switch {
+	case plugin.Source != "":
+		src, err := pluginsource.Parse(plugin.Source)
+		if err != nil {
+			return LockPluginEntry{}, fmt.Errorf("ui plugin.source %q: %w", plugin.Source, err)
+		}
+		if l.sourceResolver == nil {
+			return LockPluginEntry{}, fmt.Errorf("ui plugin: source resolution requires a source resolver")
+		}
+		resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.Version)
+		if err != nil {
+			return LockPluginEntry{}, fmt.Errorf("ui plugin resolve source %q@%s: %w", plugin.Source, plugin.Version, err)
+		}
+		defer resolved.Cleanup()
+		installed, err = store.Install(resolved.LocalPath)
+		if err != nil {
+			return LockPluginEntry{}, fmt.Errorf("ui plugin install source: %w", err)
+		}
+		manifestPath, err := filepath.Rel(paths.configDir, installed.ManifestPath)
+		if err != nil {
+			return LockPluginEntry{}, fmt.Errorf("compute manifest path for ui plugin: %w", err)
+		}
+		assetRoot, err := filepath.Rel(paths.configDir, installed.AssetRoot)
+		if err != nil {
+			return LockPluginEntry{}, fmt.Errorf("compute asset root path for ui plugin: %w", err)
+		}
+		return LockPluginEntry{
+			Fingerprint:   fingerprint,
+			Source:        plugin.Source,
+			Version:       plugin.Version,
+			ResolvedURL:   resolved.ResolvedURL,
+			ArchiveSHA256: resolved.ArchiveSHA256,
+			Manifest:      filepath.ToSlash(manifestPath),
+			AssetRoot:     filepath.ToSlash(assetRoot),
+		}, nil
+
+	case plugin.Package != "":
+		packagePath := plugin.Package
+		isURL := strings.HasPrefix(packagePath, "https://")
+		if isURL {
+			tmpPath, cleanup, err := pluginpkg.FetchPackage(ctx, packagePath)
+			if err != nil {
+				return LockPluginEntry{}, fmt.Errorf("ui plugin.package %q: %w", packagePath, err)
+			}
+			defer cleanup()
+			packagePath = tmpPath
+		}
+		info, err := os.Stat(packagePath)
+		if err != nil {
+			return LockPluginEntry{}, fmt.Errorf("ui plugin.package %q: %w", plugin.Package, err)
+		}
+		if info.IsDir() {
+			installed, err = store.InstallFromDir(packagePath)
+		} else {
+			installed, err = store.Install(packagePath)
+		}
+		if err != nil {
+			return LockPluginEntry{}, fmt.Errorf("ui plugin.package %q: %w", plugin.Package, err)
+		}
+		if !isURL {
+			sourceDigest, err = sourceDigestForPackage(packagePath)
+			if err != nil {
+				return LockPluginEntry{}, fmt.Errorf("ui plugin source digest: %w", err)
+			}
+		}
+		manifestPath, err := filepath.Rel(paths.configDir, installed.ManifestPath)
+		if err != nil {
+			return LockPluginEntry{}, fmt.Errorf("compute manifest path for ui plugin: %w", err)
+		}
+		assetRoot, err := filepath.Rel(paths.configDir, installed.AssetRoot)
+		if err != nil {
+			return LockPluginEntry{}, fmt.Errorf("compute asset root path for ui plugin: %w", err)
+		}
+		return LockPluginEntry{
+			Fingerprint:  fingerprint,
+			Package:      plugin.Package,
+			SourceDigest: sourceDigest,
+			Manifest:     filepath.ToSlash(manifestPath),
+			AssetRoot:    filepath.ToSlash(assetRoot),
+		}, nil
+	}
+
+	return LockPluginEntry{}, fmt.Errorf("ui plugin requires package or source")
+}
+
 func (l *Lifecycle) applyLockedPlugins(configPath string, cfg *config.Config, locked bool) error {
 	if !configHasPlugins(cfg) {
 		return nil
@@ -669,6 +813,29 @@ func (l *Lifecycle) applyLockedPlugins(configPath string, cfg *config.Config, lo
 			return err
 		}
 	}
+
+	if cfg.UI.Plugin.HasManagedArtifacts() {
+		key := LockPluginKey("ui", "default")
+		entry, ok := lock.Plugins[key]
+		if !ok {
+			return fmt.Errorf("prepared artifact for ui plugin is missing or stale; run `gestaltd bundle --config %s --output DIR`", paths.configPath)
+		}
+		fingerprint, err := UIPluginFingerprint(cfg.UI.Plugin)
+		if err != nil || entry.Fingerprint != fingerprint {
+			return fmt.Errorf("prepared artifact for ui plugin is missing or stale; run `gestaltd bundle --config %s --output DIR`", paths.configPath)
+		}
+		manifestPath := resolveLockPath(paths.configDir, entry.Manifest)
+		assetRootPath := resolveLockPath(paths.configDir, entry.AssetRoot)
+		if _, err := os.Stat(manifestPath); err != nil {
+			return fmt.Errorf("prepared manifest for ui plugin not found at %s", manifestPath)
+		}
+		if _, err := os.Stat(assetRootPath); err != nil {
+			return fmt.Errorf("prepared asset root for ui plugin not found at %s", assetRootPath)
+		}
+		cfg.UI.Plugin.ResolvedAssetRoot = assetRootPath
+		cfg.UI.Plugin.ResolvedManifestPath = manifestPath
+	}
+
 	return nil
 }
 

--- a/internal/pluginpkg/digest.go
+++ b/internal/pluginpkg/digest.go
@@ -57,6 +57,24 @@ func DirectoryDigest(dirPath string, manifest *pluginmanifestv1.Manifest) (strin
 		digests = append(digests, sum)
 	}
 
+	if manifest.WebUI != nil && manifest.WebUI.AssetRoot != "" {
+		assetDir := filepath.Join(dirPath, filepath.FromSlash(manifest.WebUI.AssetRoot))
+		if err := filepath.WalkDir(assetDir, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return err
+			}
+			sum, err := fileSHA256(path)
+			if err != nil {
+				return fmt.Errorf("digest asset %s: %w", path, err)
+			}
+			rel, _ := filepath.Rel(assetDir, path)
+			digests = append(digests, rel+"="+sum)
+			return nil
+		}); err != nil {
+			return "", fmt.Errorf("digest webui assets: %w", err)
+		}
+	}
+
 	combined := sha256.Sum256([]byte(strings.Join(digests, "\n")))
 	return hex.EncodeToString(combined[:]), nil
 }

--- a/internal/pluginpkg/manifest.go
+++ b/internal/pluginpkg/manifest.go
@@ -134,6 +134,13 @@ func ValidateManifest(manifest *pluginmanifestv1.Manifest) error {
 			if err := validateEntrypoint(kind, manifest.Entrypoints.Runtime, artifactPaths); err != nil {
 				return err
 			}
+		case pluginmanifestv1.KindWebUI:
+			if manifest.WebUI == nil {
+				return fmt.Errorf("webui metadata is required when kind %q is present", pluginmanifestv1.KindWebUI)
+			}
+			if err := validateRelativePackagePath(manifest.WebUI.AssetRoot, "webui asset_root"); err != nil {
+				return err
+			}
 		default:
 			return fmt.Errorf("unsupported manifest kind %q", kind)
 		}

--- a/internal/pluginstore/store.go
+++ b/internal/pluginstore/store.go
@@ -75,10 +75,15 @@ type InstalledPlugin struct {
 	Root           string
 	ManifestPath   string
 	ExecutablePath string
+	AssetRoot      string
 	ArtifactPath   string
 	SHA256         string
 	Manifest       *pluginmanifestv1.Manifest
 	Artifact       *pluginmanifestv1.Artifact
+}
+
+func isWebUIOnly(manifest *pluginmanifestv1.Manifest) bool {
+	return len(manifest.Kinds) == 1 && manifest.Kinds[0] == pluginmanifestv1.KindWebUI
 }
 
 func (s *Store) Install(packagePath string) (*InstalledPlugin, error) {
@@ -93,6 +98,19 @@ func (s *Store) Install(packagePath string) (*InstalledPlugin, error) {
 	destDir, _, err := s.destDirForManifest(manifest)
 	if err != nil {
 		return nil, err
+	}
+
+	if isWebUIOnly(manifest) {
+		if err := os.MkdirAll(destDir, 0755); err != nil {
+			return nil, fmt.Errorf("create plugin directory: %w", err)
+		}
+		if err := pluginpkg.ExtractPackage(packagePath, destDir); err != nil {
+			return nil, err
+		}
+		manifestPath := filepath.Join(destDir, pluginpkg.ManifestFile)
+		assetRoot := filepath.Join(destDir, filepath.FromSlash(manifest.WebUI.AssetRoot))
+		installed := buildInstalledPlugin(manifest, destDir, manifestPath, "", nil, assetRoot)
+		return installed, nil
 	}
 
 	artifact, err := pluginpkg.CurrentPlatformArtifact(manifest)
@@ -121,7 +139,7 @@ func (s *Store) Install(packagePath string) (*InstalledPlugin, error) {
 		return nil, err
 	}
 
-	installed := buildInstalledPlugin(manifest, destDir, manifestPath, executablePath, artifact)
+	installed := buildInstalledPlugin(manifest, destDir, manifestPath, executablePath, artifact, "")
 	return installed, nil
 }
 
@@ -137,6 +155,19 @@ func (s *Store) InstallFromDir(dirPath string) (*InstalledPlugin, error) {
 	destDir, _, err := s.destDirForManifest(manifest)
 	if err != nil {
 		return nil, err
+	}
+
+	if isWebUIOnly(manifest) {
+		if err := os.MkdirAll(destDir, 0755); err != nil {
+			return nil, fmt.Errorf("create plugin directory: %w", err)
+		}
+		if err := copyDir(dirPath, destDir); err != nil {
+			return nil, fmt.Errorf("copy plugin directory: %w", err)
+		}
+		manifestPath := filepath.Join(destDir, pluginpkg.ManifestFile)
+		assetRoot := filepath.Join(destDir, filepath.FromSlash(manifest.WebUI.AssetRoot))
+		installed := buildInstalledPlugin(manifest, destDir, manifestPath, "", nil, assetRoot)
+		return installed, nil
 	}
 
 	artifact, err := pluginpkg.CurrentPlatformArtifact(manifest)
@@ -192,7 +223,7 @@ func (s *Store) InstallFromDir(dirPath string) (*InstalledPlugin, error) {
 	}
 
 	manifestPath := filepath.Join(destDir, pluginpkg.ManifestFile)
-	installed := buildInstalledPlugin(manifest, destDir, manifestPath, executablePath, artifact)
+	installed := buildInstalledPlugin(manifest, destDir, manifestPath, executablePath, artifact, "")
 	return installed, nil
 }
 
@@ -233,15 +264,18 @@ func pluginIDFromManifest(manifest *pluginmanifestv1.Manifest) (PluginID, error)
 	return id, nil
 }
 
-func buildInstalledPlugin(manifest *pluginmanifestv1.Manifest, destDir, manifestPath, executablePath string, artifact *pluginmanifestv1.Artifact) *InstalledPlugin {
+func buildInstalledPlugin(manifest *pluginmanifestv1.Manifest, destDir, manifestPath, executablePath string, artifact *pluginmanifestv1.Artifact, assetRoot string) *InstalledPlugin {
 	ip := &InstalledPlugin{
 		Root:           destDir,
 		ManifestPath:   manifestPath,
 		ExecutablePath: executablePath,
-		ArtifactPath:   artifact.Path,
-		SHA256:         artifact.SHA256,
+		AssetRoot:      assetRoot,
 		Manifest:       manifest,
 		Artifact:       artifact,
+	}
+	if artifact != nil {
+		ip.ArtifactPath = artifact.Path
+		ip.SHA256 = artifact.SHA256
 	}
 	switch manifest.SchemaVersion {
 	case pluginmanifestv1.SchemaVersion:
@@ -256,6 +290,9 @@ func buildInstalledPlugin(manifest *pluginmanifestv1.Manifest, destDir, manifest
 func executablePathForManifest(root string, manifest *pluginmanifestv1.Manifest) (string, error) {
 	if manifest == nil {
 		return "", fmt.Errorf("manifest is required")
+	}
+	if isWebUIOnly(manifest) {
+		return "", nil
 	}
 	var entry *pluginmanifestv1.Entrypoint
 	for _, kind := range manifest.Kinds {
@@ -292,6 +329,23 @@ func configSchemaPaths(manifest *pluginmanifestv1.Manifest, dirPath string) []st
 		paths = append(paths, runtimeConfigSchemaPath)
 	}
 	return paths
+}
+
+func copyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+		return copyFile(path, target)
+	})
 }
 
 func copyFile(src, dst string) error {

--- a/sdk/pluginmanifest/v1/manifest.v2.jsonschema.json
+++ b/sdk/pluginmanifest/v1/manifest.v2.jsonschema.json
@@ -7,9 +7,7 @@
     "schema_version",
     "source",
     "version",
-    "kinds",
-    "artifacts",
-    "entrypoints"
+    "kinds"
   ],
   "properties": {
     "schema_version": {
@@ -36,7 +34,8 @@
       "items": {
         "enum": [
           "provider",
-          "runtime"
+          "runtime",
+          "webui"
         ]
       }
     },
@@ -71,9 +70,21 @@
         }
       }
     },
+    "webui": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "asset_root"
+      ],
+      "properties": {
+        "asset_root": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
     "artifacts": {
       "type": "array",
-      "minItems": 1,
       "items": {
         "$ref": "#/$defs/artifact"
       }
@@ -133,6 +144,22 @@
             ]
           }
         }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kinds": {
+            "contains": {
+              "const": "webui"
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "webui"
+        ]
       }
     }
   ],

--- a/sdk/pluginmanifest/v1/manifest.v2.jsonschema.json
+++ b/sdk/pluginmanifest/v1/manifest.v2.jsonschema.json
@@ -115,6 +115,8 @@
       },
       "then": {
         "required": [
+          "artifacts",
+          "entrypoints",
           "provider"
         ],
         "properties": {
@@ -137,6 +139,10 @@
         }
       },
       "then": {
+        "required": [
+          "artifacts",
+          "entrypoints"
+        ],
         "properties": {
           "entrypoints": {
             "required": [

--- a/sdk/pluginmanifest/v1/types.go
+++ b/sdk/pluginmanifest/v1/types.go
@@ -8,19 +8,25 @@ const (
 
 	KindProvider = "provider"
 	KindRuntime  = "runtime"
+	KindWebUI    = "webui"
 )
 
 type Manifest struct {
-	SchemaVersion int         `json:"schema_version"`
-	ID            string      `json:"id,omitempty"`
-	Source        string      `json:"source,omitempty"`
-	Version       string      `json:"version"`
-	DisplayName   string      `json:"display_name,omitempty"`
-	Description   string      `json:"description,omitempty"`
-	Kinds         []string    `json:"kinds"`
-	Provider      *Provider   `json:"provider,omitempty"`
-	Artifacts     []Artifact  `json:"artifacts"`
-	Entrypoints   Entrypoints `json:"entrypoints"`
+	SchemaVersion int            `json:"schema_version"`
+	ID            string         `json:"id,omitempty"`
+	Source        string         `json:"source,omitempty"`
+	Version       string         `json:"version"`
+	DisplayName   string         `json:"display_name,omitempty"`
+	Description   string         `json:"description,omitempty"`
+	Kinds         []string       `json:"kinds"`
+	Provider      *Provider      `json:"provider,omitempty"`
+	WebUI         *WebUIMetadata `json:"webui,omitempty"`
+	Artifacts     []Artifact     `json:"artifacts"`
+	Entrypoints   Entrypoints    `json:"entrypoints"`
+}
+
+type WebUIMetadata struct {
+	AssetRoot string `json:"asset_root"`
 }
 
 type Provider struct {


### PR DESCRIPTION
UI plugins configured via `ui.plugin.package` or `ui.plugin.source` are
now handled through the full install, lock, apply, serve flow. This
introduces the `webui` manifest kind for plugins that serve static
assets instead of running an executable, enabling custom UI packages to
be installed and resolved the same way provider and runtime plugins are.

The bundle command now collects local references for UI plugin packages,
and the source resolver is wired to the GitHub release resolver so
`ui.plugin.source` can pull packages from GitHub releases.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>