### PR TITLE
Sanitize MCP tool schema keys for OpenAI compatibility

### DIFF
--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -12,7 +12,7 @@ import (
 	mcpserver "github.com/mark3labs/mcp-go/server"
 )
 
-func makeHandler(invoker invocation.Invoker, provName, opName, connection string) mcpserver.ToolHandlerFunc {
+func makeHandler(invoker invocation.Invoker, provName, opName, connection string, mapper *argMapper) mcpserver.ToolHandlerFunc {
 	return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 		p := principal.FromContext(ctx)
 		if p == nil {
@@ -22,6 +22,7 @@ func makeHandler(invoker invocation.Invoker, provName, opName, connection string
 		args := req.GetArguments()
 		instance, _ := args["_instance"].(string)
 		delete(args, "_instance")
+		args = remapArguments(args, mapper)
 
 		if connection != "" {
 			ctx = invocation.WithConnection(ctx, connection)
@@ -39,7 +40,7 @@ func makeHandler(invoker invocation.Invoker, provName, opName, connection string
 	}
 }
 
-func makeDirectHandler(cfg Config, provName, opName, connection string, caller directToolCaller) mcpserver.ToolHandlerFunc {
+func makeDirectHandler(cfg Config, provName, opName, connection string, caller directToolCaller, mapper *argMapper) mcpserver.ToolHandlerFunc {
 	return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 		p := principal.FromContext(ctx)
 		if p == nil {
@@ -50,6 +51,7 @@ func makeDirectHandler(cfg Config, provName, opName, connection string, caller d
 		args := req.GetArguments()
 		instance, _ := args["_instance"].(string)
 		delete(args, "_instance")
+		args = remapArguments(args, mapper)
 
 		token, err := cfg.TokenResolver.ResolveToken(ctx, p, provName, connection, instance)
 		if err != nil {

--- a/internal/mcp/projection.go
+++ b/internal/mcp/projection.go
@@ -21,18 +21,19 @@ func addCatalogTools(srv *mcpserver.MCPServer, cfg Config, provName string, cat 
 func addFlatTools(srv *mcpserver.MCPServer, cfg Config, provName string, prov core.Provider) {
 	for _, op := range prov.ListOperations() {
 		name := toolName(cfg.ToolPrefixes, provName, op.Name)
+		sanitizedParams, mapper := sanitizeFlatParams(op.Parameters)
 
 		opts := []mcpgo.ToolOption{mcpgo.WithDescription(op.Description)}
 		annot := mapAnnotations(coreintegration.AnnotationsFromMethod(op.Method))
 		annot.Title = op.Name
 		opts = append(opts, mcpgo.WithToolAnnotation(annot))
 
-		for _, param := range op.Parameters {
+		for _, param := range sanitizedParams {
 			opts = append(opts, paramToOption(param))
 		}
 
 		tool := mcpgo.NewTool(name, opts...)
-		handler := makeHandler(cfg.Invoker, provName, op.Name, cfg.APIConnection[provName])
+		handler := makeHandler(cfg.Invoker, provName, op.Name, cfg.APIConnection[provName], mapper)
 		srv.AddTool(tool, handler)
 	}
 }
@@ -54,10 +55,11 @@ func buildToolMap(cfg Config, provName string, prov core.Provider, cat *catalog.
 		}
 
 		name := toolName(cfg.ToolPrefixes, provName, op.ID)
+		sanitizedSchema, mapper := sanitizeInputSchema(op.InputSchema)
 
 		var tool mcpgo.Tool
-		if len(op.InputSchema) > 0 {
-			tool = mcpgo.NewToolWithRawSchema(name, op.Description, op.InputSchema)
+		if len(sanitizedSchema) > 0 {
+			tool = mcpgo.NewToolWithRawSchema(name, op.Description, sanitizedSchema)
 		} else {
 			tool = mcpgo.NewTool(name, mcpgo.WithDescription(op.Description))
 		}
@@ -83,9 +85,9 @@ func buildToolMap(cfg Config, provName string, prov core.Provider, cat *catalog.
 
 		var handler mcpserver.ToolHandlerFunc
 		if isDirect && op.Transport != catalog.TransportREST && op.Transport != catalog.TransportPlugin {
-			handler = makeDirectHandler(cfg, provName, op.ID, conn, caller)
+			handler = makeDirectHandler(cfg, provName, op.ID, conn, caller, mapper)
 		} else {
-			handler = makeHandler(cfg.Invoker, provName, op.ID, conn)
+			handler = makeHandler(cfg.Invoker, provName, op.ID, conn, mapper)
 		}
 		tools[name] = mcpserver.ServerTool{Tool: tool, Handler: handler}
 	}

--- a/internal/mcp/schema_keys.go
+++ b/internal/mcp/schema_keys.go
@@ -1,0 +1,284 @@
+package mcp
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/core"
+)
+
+var openAIToolKeyPattern = regexp.MustCompile(`^[a-zA-Z0-9_.-]{1,64}$`)
+
+type argMapper struct {
+	originalName string
+	props        map[string]*argMapper
+	items        *argMapper
+}
+
+func sanitizeFlatParams(params []core.Parameter) ([]core.Parameter, *argMapper) {
+	if len(params) == 0 {
+		return params, nil
+	}
+
+	sanitized := make([]core.Parameter, len(params))
+	used := make(map[string]struct{}, len(params))
+	props := make(map[string]*argMapper, len(params))
+	changed := false
+
+	for i, param := range params {
+		safeName := uniqueSanitizedKey(param.Name, used)
+		sanitized[i] = param
+		sanitized[i].Name = safeName
+
+		if safeName != param.Name {
+			changed = true
+		}
+		props[safeName] = &argMapper{originalName: param.Name}
+	}
+
+	if !changed {
+		return params, nil
+	}
+
+	return sanitized, &argMapper{props: props}
+}
+
+func sanitizeInputSchema(raw json.RawMessage) (json.RawMessage, *argMapper) {
+	if len(raw) == 0 {
+		return raw, nil
+	}
+
+	var doc any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return raw, nil
+	}
+
+	sanitized, mapper := sanitizeSchemaValue(doc)
+	if mapper == nil || mapper.empty() {
+		return raw, nil
+	}
+
+	encoded, err := json.Marshal(sanitized)
+	if err != nil {
+		return raw, nil
+	}
+
+	return encoded, mapper
+}
+
+func sanitizeSchemaValue(v any) (any, *argMapper) {
+	switch val := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		mapper := &argMapper{}
+		var rawToSafe map[string]string
+
+		if props, ok := val["properties"].(map[string]any); ok {
+			keys := make([]string, 0, len(props))
+			for key := range props {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+
+			newProps := make(map[string]any, len(props))
+			propMap := make(map[string]*argMapper, len(props))
+			used := make(map[string]struct{}, len(props))
+			rawToSafe = make(map[string]string, len(props))
+
+			for _, rawName := range keys {
+				safeName := uniqueSanitizedKey(rawName, used)
+				rawToSafe[rawName] = safeName
+
+				propValue, childMapper := sanitizeSchemaValue(props[rawName])
+				newProps[safeName] = propValue
+
+				if childMapper == nil {
+					childMapper = &argMapper{}
+				}
+				childMapper.originalName = rawName
+				propMap[safeName] = childMapper
+			}
+
+			out["properties"] = newProps
+			if len(propMap) > 0 {
+				mapper.props = propMap
+			}
+		}
+
+		for key, child := range val {
+			if key == "properties" {
+				continue
+			}
+			if key == "required" && rawToSafe != nil {
+				out[key] = rewriteRequired(child, rawToSafe)
+				continue
+			}
+			sanitizedChild, childMapper := sanitizeSchemaValue(child)
+			out[key] = sanitizedChild
+			if key == "items" && childMapper != nil && !childMapper.empty() {
+				mapper.items = childMapper
+			}
+		}
+
+		if mapper.empty() {
+			return out, nil
+		}
+		return out, mapper
+	case []any:
+		out := make([]any, len(val))
+		for i := range val {
+			sanitizedChild, _ := sanitizeSchemaValue(val[i])
+			out[i] = sanitizedChild
+		}
+		return out, nil
+	default:
+		return v, nil
+	}
+}
+
+func rewriteRequired(v any, rawToSafe map[string]string) any {
+	req, ok := v.([]any)
+	if !ok {
+		return v
+	}
+	out := make([]any, len(req))
+	for i, item := range req {
+		if rawName, ok := item.(string); ok {
+			if safeName, exists := rawToSafe[rawName]; exists {
+				out[i] = safeName
+				continue
+			}
+		}
+		out[i] = item
+	}
+	return out
+}
+
+func remapArguments(args map[string]any, mapper *argMapper) map[string]any {
+	if mapper == nil || mapper.empty() || len(args) == 0 {
+		return args
+	}
+	remapped, ok := remapArgumentValue(args, mapper).(map[string]any)
+	if !ok {
+		return args
+	}
+	return remapped
+}
+
+func remapArgumentValue(v any, mapper *argMapper) any {
+	if mapper == nil || mapper.empty() {
+		return v
+	}
+
+	switch val := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for key, child := range val {
+			nextMapper := mapper.props[key]
+			outKey := key
+			if nextMapper != nil && nextMapper.originalName != "" {
+				outKey = nextMapper.originalName
+			}
+			out[outKey] = remapArgumentValue(child, nextMapper)
+		}
+		return out
+	case []any:
+		if mapper.items == nil || mapper.items.empty() {
+			return v
+		}
+		out := make([]any, len(val))
+		for i := range val {
+			out[i] = remapArgumentValue(val[i], mapper.items)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func (m *argMapper) empty() bool {
+	return m == nil || (m.originalName == "" && len(m.props) == 0 && (m.items == nil || m.items.empty()))
+}
+
+func uniqueSanitizedKey(raw string, used map[string]struct{}) string {
+	candidate := sanitizeSchemaKey(raw)
+	if _, exists := used[candidate]; !exists {
+		used[candidate] = struct{}{}
+		return candidate
+	}
+
+	suffix := "." + shortKeyHash(raw)
+	unique := truncateWithSuffix(candidate, suffix)
+	for {
+		if _, exists := used[unique]; !exists {
+			used[unique] = struct{}{}
+			return unique
+		}
+		suffix += "x"
+		if len(suffix) > 16 {
+			suffix = "." + shortKeyHash(unique)
+		}
+		unique = truncateWithSuffix(candidate, suffix)
+	}
+}
+
+func sanitizeSchemaKey(raw string) string {
+	if openAIToolKeyPattern.MatchString(raw) {
+		return raw
+	}
+
+	var b strings.Builder
+	lastSep := false
+	for _, r := range raw {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '.' || r == '_' || r == '-':
+			b.WriteRune(r)
+			lastSep = false
+		case r == '[':
+			if b.Len() > 0 && !lastSep {
+				b.WriteByte('.')
+				lastSep = true
+			}
+		case r == ']':
+			continue
+		default:
+			if b.Len() > 0 && !lastSep {
+				b.WriteByte('.')
+				lastSep = true
+			}
+		}
+	}
+
+	safe := strings.Trim(b.String(), "._-")
+	if safe == "" {
+		safe = "arg"
+	}
+
+	if len(safe) > 64 {
+		safe = truncateWithSuffix(safe, "."+shortKeyHash(raw))
+	}
+
+	return safe
+}
+
+const maxKeyLen = 64
+
+func truncateWithSuffix(base, suffix string) string {
+	maxBase := maxKeyLen - len(suffix)
+	if maxBase < 1 {
+		maxBase = 1
+	}
+	if len(base) > maxBase {
+		base = base[:maxBase]
+	}
+	return base + suffix
+}
+
+func shortKeyHash(raw string) string {
+	sum := sha1.Sum([]byte(raw))
+	return hex.EncodeToString(sum[:])[:8]
+}

--- a/internal/mcp/schema_keys_test.go
+++ b/internal/mcp/schema_keys_test.go
@@ -1,0 +1,339 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"slices"
+	"sort"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/core/catalog"
+	coreintegration "github.com/valon-technologies/gestalt/core/integration"
+	coretesting "github.com/valon-technologies/gestalt/core/testing"
+	gestaltmcp "github.com/valon-technologies/gestalt/internal/mcp"
+	"github.com/valon-technologies/gestalt/internal/principal"
+	"github.com/valon-technologies/gestalt/internal/testutil"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestNewServer_FlatToolsSanitizeInvalidParameterNames(t *testing.T) {
+	t.Parallel()
+
+	var gotParams map[string]any
+
+	prov := &flatProvider{
+		StubIntegration: coretesting.StubIntegration{N: "datadog"},
+		ops: []core.Operation{
+			{
+				Name:        "search_logs",
+				Description: "Search logs",
+				Method:      http.MethodGet,
+				Parameters: []core.Parameter{
+					{Name: "filter[from]", Type: "string", Required: true},
+					{Name: "page[size]", Type: "integer"},
+				},
+			},
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, prov)
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker: &testutil.StubInvoker{
+			InvokeFn: func(_ context.Context, p *principal.Principal, providerName, _, operation string, params map[string]any) (*core.OperationResult, error) {
+				if p == nil || p.UserID == "" {
+					t.Fatal("expected authenticated principal")
+				}
+				if providerName != "datadog" {
+					t.Fatalf("expected provider datadog, got %q", providerName)
+				}
+				if operation != "search_logs" {
+					t.Fatalf("expected operation search_logs, got %q", operation)
+				}
+				gotParams = params
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		Providers: providers,
+	})
+
+	schema := toolInputSchema(t, srv.ListTools()["datadog_search_logs"].Tool)
+	assertSchemaKeys(t, schema, []string{"filter.from", "page.size"}, []string{"filter.from"})
+
+	tool := srv.GetTool("datadog_search_logs")
+	if tool == nil {
+		t.Fatal("tool not found")
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Name = "datadog_search_logs"
+	req.Params.Arguments = map[string]any{
+		"filter.from": "now-15m",
+		"page.size":   25,
+	}
+
+	result, err := tool.Handler(ctxWithPrincipal(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+	if gotParams["filter[from]"] != "now-15m" {
+		t.Fatalf("expected raw filter[from] param, got %v", gotParams)
+	}
+	if gotParams["page[size]"] != 25 {
+		t.Fatalf("expected raw page[size] param, got %v", gotParams)
+	}
+}
+
+func TestNewServer_CatalogToolsSanitizeInvalidSchemaPropertyNames(t *testing.T) {
+	t.Parallel()
+
+	var gotParams map[string]any
+
+	cat := &catalog.Catalog{
+		Name: "datadog",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:          "search_logs",
+				Method:      http.MethodPost,
+				Path:        "/logs/events/search",
+				Description: "Search logs",
+				InputSchema: json.RawMessage(`{
+					"type":"object",
+					"properties":{
+						"filter[from]":{"type":"string"},
+						"filter[to]":{"type":"string"},
+						"page[size]":{"type":"integer"}
+					},
+					"required":["filter[from]"]
+				}`),
+			},
+		},
+	}
+
+	prov := &catalogProvider{
+		StubIntegration: coretesting.StubIntegration{N: "datadog"},
+		ops:             coreintegration.OperationsList(cat),
+		catalog:         cat,
+	}
+
+	providers := testutil.NewProviderRegistry(t, prov)
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker: &testutil.StubInvoker{
+			InvokeFn: func(_ context.Context, _ *principal.Principal, _, _, _ string, params map[string]any) (*core.OperationResult, error) {
+				gotParams = params
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		Providers: providers,
+	})
+
+	schema := toolInputSchema(t, srv.ListTools()["datadog_search_logs"].Tool)
+	assertSchemaKeys(t, schema, []string{"filter.from", "filter.to", "page.size"}, []string{"filter.from"})
+
+	tool := srv.GetTool("datadog_search_logs")
+	if tool == nil {
+		t.Fatal("tool not found")
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Name = "datadog_search_logs"
+	req.Params.Arguments = map[string]any{
+		"filter.from": "now-15m",
+		"filter.to":   "now",
+		"page.size":   50,
+	}
+
+	result, err := tool.Handler(ctxWithPrincipal(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+	if gotParams["filter[from]"] != "now-15m" || gotParams["filter[to]"] != "now" || gotParams["page[size]"] != 50 {
+		t.Fatalf("expected remapped raw params, got %v", gotParams)
+	}
+}
+
+func TestNewServer_MCPPassthroughSanitizesArrayItemSchemaKeys(t *testing.T) {
+	t.Parallel()
+
+	var gotArgs map[string]any
+
+	cat := &catalog.Catalog{
+		Name: "svc",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:          "search_logs",
+				Description: "Search logs",
+				Transport:   catalog.TransportMCPPassthrough,
+				InputSchema: json.RawMessage(`{
+					"type":"object",
+					"properties":{
+						"filters":{
+							"type":"array",
+							"items":{
+								"type":"object",
+								"properties":{
+									"filter[from]":{"type":"string"},
+									"filter[to]":{"type":"string"}
+								},
+								"required":["filter[from]"]
+							}
+						}
+					},
+					"required":["filters"]
+				}`),
+			},
+		},
+	}
+
+	prov := &directCallerProvider{
+		StubIntegration: coretesting.StubIntegration{N: "svc"},
+		ops:             []core.Operation{{Name: "search_logs", Description: "Search logs"}},
+		cat:             cat,
+		callFn: func(_ context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
+			if name != "search_logs" {
+				t.Fatalf("expected upstream name search_logs, got %q", name)
+			}
+			gotArgs = args
+			return &mcpgo.CallToolResult{
+				Content:           []mcpgo.Content{mcpgo.NewTextContent(`{"ok":true}`)},
+				StructuredContent: map[string]any{"ok": true},
+			}, nil
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, prov)
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker:       &testutil.StubInvoker{},
+		TokenResolver: &stubTokenResolver{token: "test-token"},
+		Providers:     providers,
+	})
+
+	schema := toolInputSchema(t, srv.ListTools()["svc_search_logs"].Tool)
+	filters := nestedMap(t, schema, "properties", "filters")
+	items := nestedMap(t, filters, "items")
+	assertSchemaKeys(t, items, []string{"filter.from", "filter.to"}, []string{"filter.from"})
+
+	tool := srv.GetTool("svc_search_logs")
+	if tool == nil {
+		t.Fatal("tool not found")
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Name = "svc_search_logs"
+	req.Params.Arguments = map[string]any{
+		"filters": []any{
+			map[string]any{
+				"filter.from": "now-1h",
+				"filter.to":   "now",
+			},
+		},
+	}
+
+	result, err := tool.Handler(ctxWithPrincipal(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+
+	filtersArg, ok := gotArgs["filters"].([]any)
+	if !ok || len(filtersArg) != 1 {
+		t.Fatalf("expected one upstream filter item, got %v", gotArgs["filters"])
+	}
+	filterItem, ok := filtersArg[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected upstream filter item map, got %T", filtersArg[0])
+	}
+	if filterItem["filter[from]"] != "now-1h" || filterItem["filter[to]"] != "now" {
+		t.Fatalf("expected remapped array item args, got %v", filterItem)
+	}
+}
+
+func toolInputSchema(t *testing.T, tool mcpgo.Tool) map[string]any {
+	t.Helper()
+
+	raw, err := json.Marshal(tool)
+	if err != nil {
+		t.Fatalf("marshal tool: %v", err)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal tool: %v", err)
+	}
+
+	schema, ok := doc["inputSchema"].(map[string]any)
+	if !ok {
+		t.Fatalf("tool missing inputSchema: %v", doc)
+	}
+	return schema
+}
+
+func nestedMap(t *testing.T, root map[string]any, keys ...string) map[string]any {
+	t.Helper()
+
+	current := root
+	for _, key := range keys {
+		next, ok := current[key].(map[string]any)
+		if !ok {
+			t.Fatalf("expected map at key %q, got %T", key, current[key])
+		}
+		current = next
+	}
+	return current
+}
+
+func assertSchemaKeys(t *testing.T, schema map[string]any, wantProps, wantRequired []string) {
+	t.Helper()
+
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema missing properties: %v", schema)
+	}
+
+	gotProps := make([]string, 0, len(props))
+	for key := range props {
+		gotProps = append(gotProps, key)
+	}
+	sort.Strings(gotProps)
+	sort.Strings(wantProps)
+	if !slices.Equal(gotProps, wantProps) {
+		t.Fatalf("unexpected properties: got %v want %v", gotProps, wantProps)
+	}
+
+	gotRequired := stringSlice(schema["required"])
+	sort.Strings(gotRequired)
+	sort.Strings(wantRequired)
+	if !slices.Equal(gotRequired, wantRequired) {
+		t.Fatalf("unexpected required fields: got %v want %v", gotRequired, wantRequired)
+	}
+}
+
+func stringSlice(v any) []string {
+	switch vals := v.(type) {
+	case nil:
+		return nil
+	case []string:
+		return append([]string(nil), vals...)
+	case []any:
+		out := make([]string, 0, len(vals))
+		for _, item := range vals {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+


### PR DESCRIPTION
## Summary
- sanitize MCP tool input schema property names so OpenAI-compatible tool schemas never expose invalid keys like `page[size]`
- remap sanitized MCP arguments back to the provider's original parameter names before invocation
- add regression coverage for flat REST tools, catalog-backed tools, and MCP passthrough tools with nested array item schemas

## Problem
OpenAI rejects tool schemas whose property names do not match `^[a-zA-Z0-9_.-]{1,64}$`.

Our MCP projection was forwarding upstream parameter names directly into tool schemas. Declarative integrations can legitimately contain names like `page[size]` and `filter[from]`, which caused errors like:

```
tools.11.custom.input_schema.properties: Property keys should match pattern '^[a-zA-Z0-9_.-]{1,64}$'
```

## Fix
- sanitize invalid property names when projecting flat operation params into MCP tools
- sanitize invalid property names recursively when projecting raw JSON schemas into MCP tools
- preserve a mapper so sanitized arguments are converted back to the provider's original keys before broker or direct upstream invocation
- keep already-valid keys unchanged and add collision handling for sanitized aliases

## Validation
- `go test ./internal/mcp/...`
- `go test -run '^$' ./cmd/gestaltd`

## Notes
A broader `go test ./cmd/gestaltd ./internal/mcp/...` run hit an existing unrelated failure in `TestE2EBundleServeLockedGoldenPath` (`integration "example" not found`), so I used a compile-only pass for `cmd/gestaltd` in this branch.