### PR TITLE
Normalize bracket-style OpenAPI parameter names

### DIFF
--- a/core/catalog/catalog.go
+++ b/core/catalog/catalog.go
@@ -55,12 +55,13 @@ type OperationAnnotations struct {
 }
 
 type CatalogParameter struct {
-	Name        string `yaml:"name"                 json:"name"`
-	Type        string `yaml:"type"                 json:"type"`
-	Location    string `yaml:"location,omitempty"   json:"location,omitempty"`
-	Description string `yaml:"description,omitempty" json:"description,omitempty"`
-	Required    bool   `yaml:"required,omitempty"   json:"required,omitempty"`
-	Default     any    `yaml:"default,omitempty"    json:"default,omitempty"`
+	Name        string `yaml:"name"                  json:"name"`
+	WireName    string `yaml:"wire_name,omitempty"    json:"wireName,omitempty"`
+	Type        string `yaml:"type"                  json:"type"`
+	Location    string `yaml:"location,omitempty"    json:"location,omitempty"`
+	Description string `yaml:"description,omitempty"  json:"description,omitempty"`
+	Required    bool   `yaml:"required,omitempty"    json:"required,omitempty"`
+	Default     any    `yaml:"default,omitempty"     json:"default,omitempty"`
 }
 
 func (c *Catalog) Clone() *Catalog {

--- a/core/integration/egress_adapter.go
+++ b/core/integration/egress_adapter.go
@@ -158,9 +158,16 @@ func partitionParams(catOp *catalog.CatalogOperation, params map[string]any) (bo
 	}
 
 	locations := make(map[string]string, len(catOp.Parameters))
+	var wireNames map[string]string
 	for _, p := range catOp.Parameters {
 		if p.Location != "" {
 			locations[p.Name] = p.Location
+		}
+		if p.WireName != "" {
+			if wireNames == nil {
+				wireNames = make(map[string]string)
+			}
+			wireNames[p.Name] = p.WireName
 		}
 	}
 	if len(locations) == 0 {
@@ -171,13 +178,17 @@ func partitionParams(catOp *catalog.CatalogOperation, params map[string]any) (bo
 	query = make(map[string]any)
 	headers = make(map[string]string)
 	for k, v := range params {
+		httpKey := k
+		if wn, ok := wireNames[k]; ok {
+			httpKey = wn
+		}
 		switch locations[k] {
 		case "query":
-			query[k] = v
+			query[httpKey] = v
 		case "header":
-			headers[k] = fmt.Sprintf("%v", v)
+			headers[httpKey] = fmt.Sprintf("%v", v)
 		case "path":
-			body[k] = v
+			body[httpKey] = v
 		default:
 			body[k] = v
 		}

--- a/core/integration/param_routing_test.go
+++ b/core/integration/param_routing_test.go
@@ -273,6 +273,70 @@ func TestExecuteREST_NoCatalog_PreservesLegacy(t *testing.T) {
 	}
 }
 
+func TestExecuteREST_WireNameQueryParam(t *testing.T) {
+	t.Parallel()
+
+	const (
+		opID          = "list_records"
+		opPath        = "/api/v2/records"
+		schemaName    = "page_size"
+		wireName      = "page[size]"
+		pageSizeValue = "25"
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"raw_query": r.URL.RawQuery,
+		})
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	cat := &catalog.Catalog{
+		Name: "test-svc",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:     opID,
+				Method: http.MethodGet,
+				Path:   opPath,
+				Parameters: []catalog.CatalogParameter{
+					{Name: schemaName, WireName: wireName, Type: "integer", Location: "query"},
+				},
+			},
+		},
+	}
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL,
+		Endpoints: map[string]Endpoint{
+			opID: {Method: http.MethodGet, Path: opPath},
+		},
+	}
+	b.SetCatalog(cat)
+
+	result, err := b.Execute(context.Background(), opID, map[string]any{
+		schemaName: 25,
+	}, "test-token")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	rawQuery := resp["raw_query"].(string)
+	parsed, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		t.Fatalf("url.ParseQuery: %v", err)
+	}
+	if parsed.Get(wireName) != pageSizeValue {
+		t.Fatalf("query %s = %q, want %s; raw = %s", wireName, parsed.Get(wireName), pageSizeValue, rawQuery)
+	}
+}
+
 func TestExecuteREST_CatalogHeaderParam(t *testing.T) {
 	t.Parallel()
 

--- a/internal/openapi/catalog.go
+++ b/internal/openapi/catalog.go
@@ -143,8 +143,10 @@ func catalogExtractOperations(model *v3high.Document, cat *catalog.Catalog, allo
 				if p.In != "" {
 					loc = p.In
 				}
+				name, wireName := normalizeParamName(p.Name)
 				catOp.Parameters = append(catOp.Parameters, catalog.CatalogParameter{
-					Name:        p.Name,
+					Name:        name,
+					WireName:    wireName,
 					Type:        pType,
 					Location:    loc,
 					Description: p.Description,
@@ -185,6 +187,14 @@ func extractRequestBodySchema(rb *v3high.RequestBody) json.RawMessage {
 	}
 
 	return schemaToJSON(schema)
+}
+
+func normalizeParamName(raw string) (name, wireName string) {
+	if !strings.ContainsAny(raw, "[]") {
+		return raw, ""
+	}
+	normalized := strings.ReplaceAll(strings.ReplaceAll(raw, "[", "_"), "]", "")
+	return normalized, raw
 }
 
 func schemaToJSON(s *highbase.Schema) json.RawMessage {

--- a/internal/openapi/catalog_test.go
+++ b/internal/openapi/catalog_test.go
@@ -326,6 +326,87 @@ func TestCatalogExtractAuthHTTPBasic(t *testing.T) {
 	}
 }
 
+func TestLoadCatalogNormalizesBracketParams(t *testing.T) {
+	t.Parallel()
+
+	type paramExpectation struct {
+		rawName        string
+		normalizedName string
+		hasWireName    bool
+	}
+
+	expectations := []paramExpectation{
+		{rawName: "page[size]", normalizedName: "page_size", hasWireName: true},
+		{rawName: "filter[from]", normalizedName: "filter_from", hasWireName: true},
+		{rawName: "status", normalizedName: "status", hasWireName: false},
+	}
+
+	params := make([]any, len(expectations))
+	for i, e := range expectations {
+		params[i] = map[string]any{
+			"name": e.rawName, "in": "query",
+			"schema": map[string]any{"type": "string"},
+		}
+	}
+
+	spec := map[string]any{
+		"openapi": "3.0.0",
+		"info":    map[string]string{"title": "Bracket API"},
+		"servers": []any{map[string]string{"url": "https://api.example.com"}},
+		"paths": map[string]any{
+			"/records": map[string]any{
+				"get": map[string]any{
+					"operationId": "list_records",
+					"summary":     "List records",
+					"parameters":  params,
+				},
+			},
+		},
+	}
+
+	srv := serveJSON(t, spec)
+	testutil.CloseOnCleanup(t, srv)
+
+	cat, err := LoadCatalog(context.Background(), "test", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+
+	op := cat.Operations[0]
+	if len(op.Parameters) != len(expectations) {
+		t.Fatalf("got %d params, want %d", len(op.Parameters), len(expectations))
+	}
+
+	type paramResult struct {
+		Name, WireName string
+	}
+	byWire := make(map[string]paramResult, len(op.Parameters))
+	for _, p := range op.Parameters {
+		key := p.WireName
+		if key == "" {
+			key = p.Name
+		}
+		byWire[key] = paramResult{Name: p.Name, WireName: p.WireName}
+	}
+
+	for _, e := range expectations {
+		p, ok := byWire[e.rawName]
+		if !ok {
+			t.Errorf("missing param for raw name %q", e.rawName)
+			continue
+		}
+		if p.Name != e.normalizedName {
+			t.Errorf("%q normalized to %q, want %q", e.rawName, p.Name, e.normalizedName)
+		}
+		if e.hasWireName && p.WireName != e.rawName {
+			t.Errorf("%q wire name = %q, want %q", e.rawName, p.WireName, e.rawName)
+		}
+		if !e.hasWireName && p.WireName != "" {
+			t.Errorf("%q should have no wire name, got %q", e.rawName, p.WireName)
+		}
+	}
+}
+
 func TestLoadCatalogYAMLSpec(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
OpenAPI specs from providers like Datadog use bracket notation for
query parameters (e.g. `page[size]`, `filter[from]`). These are valid
OpenAPI but incompatible with downstream consumers like OpenAI, which
rejects tool schema property keys containing brackets. This normalizes
bracket params to underscore form at OpenAPI extraction time and
preserves the original name as a wire name so HTTP requests still send
the correct query parameters.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>