### PR TITLE
Add MCP-aware validation for duplicate normalized param names

### DIFF
--- a/core/catalog/catalog.go
+++ b/core/catalog/catalog.go
@@ -109,6 +109,20 @@ func isValidAuthStyle(s string) bool {
 	return ok
 }
 
+func (c *Catalog) ValidateMCPCompat() error {
+	for i := range c.Operations {
+		op := &c.Operations[i]
+		seen := make(map[string]struct{}, len(op.Parameters))
+		for _, param := range op.Parameters {
+			if _, dup := seen[param.Name]; dup {
+				return fmt.Errorf("catalog %q operation %q has duplicate parameter name %q (likely from bracket normalization; rename one in the OpenAPI spec)", c.Name, op.ID, param.Name)
+			}
+			seen[param.Name] = struct{}{}
+		}
+	}
+	return nil
+}
+
 func (c *Catalog) Validate() error {
 	if c == nil {
 		return fmt.Errorf("catalog is nil")

--- a/internal/bootstrap/validate.go
+++ b/internal/bootstrap/validate.go
@@ -58,6 +58,10 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 	}
 	defer func() { _ = CloseProviders(providers) }()
 
+	if err := validateMCPCatalogs(providers); err != nil {
+		return warnings, err
+	}
+
 	sharedInvoker := invocation.NewBroker(providers, ds)
 	wireCredentialResolver(&deps.Egress, sm)
 	audit := core.AuditSink(invocation.LogAuditSink{})
@@ -73,6 +77,27 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 	}
 
 	return warnings, nil
+}
+
+func validateMCPCatalogs(providers *registry.PluginMap[core.Provider]) error {
+	for _, name := range providers.List() {
+		prov, err := providers.Get(name)
+		if err != nil {
+			continue
+		}
+		cp, ok := prov.(core.CatalogProvider)
+		if !ok {
+			continue
+		}
+		cat := cp.Catalog()
+		if cat == nil {
+			continue
+		}
+		if err := cat.ValidateMCPCompat(); err != nil {
+			return fmt.Errorf("integration %q: %w", name, err)
+		}
+	}
+	return nil
 }
 
 func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.PluginMap[core.Provider], map[string]map[string]OAuthHandler, error) {

--- a/internal/openapi/catalog_test.go
+++ b/internal/openapi/catalog_test.go
@@ -407,6 +407,55 @@ func TestLoadCatalogNormalizesBracketParams(t *testing.T) {
 	}
 }
 
+func TestValidateMCPCompatRejectsDuplicateNormalizedParams(t *testing.T) {
+	t.Parallel()
+
+	const (
+		bracketName = "page[size]"
+		plainName   = "page_size"
+	)
+
+	spec := map[string]any{
+		"openapi": "3.0.0",
+		"info":    map[string]string{"title": "Collision API"},
+		"servers": []any{map[string]string{"url": "https://api.example.com"}},
+		"paths": map[string]any{
+			"/records": map[string]any{
+				"get": map[string]any{
+					"operationId": "list_records",
+					"summary":     "List records",
+					"parameters": []any{
+						map[string]any{
+							"name": bracketName, "in": "query",
+							"schema": map[string]any{"type": "integer"},
+						},
+						map[string]any{
+							"name": plainName, "in": "query",
+							"schema": map[string]any{"type": "integer"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	srv := serveJSON(t, spec)
+	testutil.CloseOnCleanup(t, srv)
+
+	cat, err := LoadCatalog(context.Background(), "test", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+
+	if err := cat.Validate(); err != nil {
+		t.Fatalf("Validate() should pass (duplicates are an MCP concern, not a general one): %v", err)
+	}
+
+	if err := cat.ValidateMCPCompat(); err == nil {
+		t.Fatal("ValidateMCPCompat() should reject duplicate normalized param names")
+	}
+}
+
 func TestLoadCatalogYAMLSpec(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When bracket-style OpenAPI params like `page[size]` get normalized to
`page_size`, a collision can occur if the spec also has a literal
`page_size` param. This adds `ValidateMCPCompat()` to Catalog, which
detects duplicate parameter names that would corrupt MCP tool schemas.
The check runs during `gestaltd validate` for all catalog-backed
providers, since all providers get MCP-projected.

Follow-up to #275. Addresses Bugbot feedback about silent name collisions.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>