### PR TITLE
Use omitzero for struct-typed Entrypoints field

### DIFF
--- a/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -8,8 +8,7 @@
     "id",
     "version",
     "kinds",
-    "artifacts",
-    "entrypoints"
+    "artifacts"
   ],
   "properties": {
     "schema_version": {
@@ -104,7 +103,8 @@
       },
       "then": {
         "required": [
-          "provider"
+          "provider",
+          "entrypoints"
         ],
         "properties": {
           "entrypoints": {
@@ -126,6 +126,9 @@
         }
       },
       "then": {
+        "required": [
+          "entrypoints"
+        ],
         "properties": {
           "entrypoints": {
             "required": [

--- a/sdk/pluginmanifest/v1/types.go
+++ b/sdk/pluginmanifest/v1/types.go
@@ -22,7 +22,7 @@ type Manifest struct {
 	Provider      *Provider      `json:"provider,omitempty"`
 	WebUI         *WebUIMetadata `json:"webui,omitempty"`
 	Artifacts     []Artifact     `json:"artifacts,omitempty"`
-	Entrypoints   Entrypoints    `json:"entrypoints,omitempty"`
+	Entrypoints   Entrypoints    `json:"entrypoints,omitzero"`
 }
 
 type WebUIMetadata struct {


### PR DESCRIPTION
The `Entrypoints` field on `Manifest` is a value type, not a pointer,
so the `omitempty` JSON tag was a no-op: zero-value structs are never
considered empty by `encoding/json`. This meant webui-only manifests
would always serialize `"entrypoints": {}` instead of omitting the key.
Replacing `omitempty` with `omitzero` (available since Go 1.24) gives
the intended behavior, omitting the field when both sub-fields are nil.

The v1 JSON schema is also updated to make `entrypoints` conditionally
required (only when provider or runtime kinds are present), matching the
v2 schema which already had this structure.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>