### PR TITLE
Use per-plugin tag prefixes for plugin releases

### DIFF
--- a/internal/pluginsource/github/resolver.go
+++ b/internal/pluginsource/github/resolver.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -53,7 +54,7 @@ func (r *GitHubResolver) Resolve(ctx context.Context, src pluginsource.Source, v
 	}
 
 	tag := src.ReleaseTag(version)
-	releaseURL := fmt.Sprintf("%s/repos/%s/releases/tags/%s", baseURL, src.RepoSlug(), tag)
+	releaseURL := fmt.Sprintf("%s/repos/%s/releases/tags/%s", baseURL, src.RepoSlug(), url.PathEscape(tag))
 
 	release, err := r.fetchRelease(ctx, client, releaseURL, token, tag, src.RepoSlug())
 	if err != nil {

--- a/internal/pluginsource/source.go
+++ b/internal/pluginsource/source.go
@@ -7,11 +7,12 @@ import (
 )
 
 const (
-	HostGitHub    = "github.com"
-	segmentCount  = 4
-	assetPrefix   = "gestalt-plugin-"
-	assetSuffix   = ".tar.gz"
-	versionPrefix = "v"
+	HostGitHub      = "github.com"
+	segmentCount    = 4
+	assetPrefix     = "gestalt-plugin-"
+	assetSuffix     = ".tar.gz"
+	versionPrefix   = "v"
+	pluginTagPrefix = "plugin/"
 )
 
 var segmentRe = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
@@ -61,7 +62,7 @@ func (s Source) AssetName(version string) string {
 }
 
 func (s Source) ReleaseTag(version string) string {
-	return versionPrefix + version
+	return pluginTagPrefix + s.Plugin + "/" + versionPrefix + version
 }
 
 func (s Source) RepoSlug() string {

--- a/internal/pluginsource/source_test.go
+++ b/internal/pluginsource/source_test.go
@@ -121,7 +121,7 @@ func TestSourceReleaseTag(t *testing.T) {
 	t.Parallel()
 
 	src := Source{Host: HostGitHub, Owner: "testowner", Repo: "testrepo", Plugin: "testplugin"}
-	const want = "v1.2.3"
+	const want = "plugin/testplugin/v1.2.3"
 	if got := src.ReleaseTag("1.2.3"); got != want {
 		t.Errorf("ReleaseTag(1.2.3) = %q, want %q", got, want)
 	}


### PR DESCRIPTION
Change ReleaseTag to produce tags in the format plugin/<name>/v<version>
instead of the previous bare v<version>. This allows multiple plugins in
the same repository to have independent release tags without collisions.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>