### PR TITLE
Add UI plugin documentation

### DIFF
--- a/docs/pages/concepts/_meta.ts
+++ b/docs/pages/concepts/_meta.ts
@@ -6,4 +6,5 @@ export default {
   "mcp-binding": "MCP Binding",
   "plugin-protocol": "Plugin Protocol",
   "plugin-packaging": "Plugin Packaging",
+  "ui-plugins": "UI Plugins",
 };

--- a/docs/pages/concepts/plugin-packaging.mdx
+++ b/docs/pages/concepts/plugin-packaging.mdx
@@ -46,6 +46,24 @@ The important ideas are:
 - entrypoints point at one of those packaged artifacts
 - provider packages may also ship a JSON Schema for config validation
 
+### Web UI package
+
+UI plugins use the `webui` kind. They contain static assets instead of executables:
+
+```json
+{
+  "schema_version": 2,
+  "source": "github.com/your-org/your-repo/console",
+  "version": "1.0.0",
+  "kinds": ["webui"],
+  "webui": {
+    "asset_root": "out"
+  }
+}
+```
+
+Web UI manifests require schema version 2, have no `artifacts` or `entrypoints`, and cannot be combined with `provider` or `runtime` kinds. See [UI Plugins](/concepts/ui-plugins) for the full workflow.
+
 ## Creating A Package
 
 Build a directory that contains `plugin.json` plus the referenced artifacts, then run:

--- a/docs/pages/concepts/ui-plugins.mdx
+++ b/docs/pages/concepts/ui-plugins.mdx
@@ -1,0 +1,116 @@
+# UI Plugins
+
+Gestalt serves a web UI alongside its API. By default it uses the embedded frontend compiled into the `gestaltd` binary. UI plugins let you replace that frontend with a custom one without rebuilding `gestaltd`.
+
+## How It Works
+
+A UI plugin is a static asset package (HTML, CSS, JS) with a `plugin.json` manifest. When configured, `gestaltd` serves the plugin's assets instead of the embedded frontend. The browser connects to the same origin and port — there is no separate UI server.
+
+API routes (`/api/v1/*`, `/mcp`, `/health`, `/ready`) always take priority. Unmatched requests fall through to the UI handler, which serves files with SPA fallback behavior:
+
+1. Exact file match
+2. `path.html` fallback (for static export routes)
+3. `path/index.html` fallback (for directory routes)
+4. `index.html` fallback (for client-side routing)
+
+## Creating a UI Plugin
+
+Any static site generator that outputs HTML, CSS, and JS works. The only requirements are:
+
+- an `index.html` at the asset root
+- a `plugin.json` manifest
+
+### Directory Layout
+
+```
+my-ui-plugin/
+├── plugin.json
+└── out/
+    ├── index.html
+    ├── style.css
+    └── assets/
+        └── app.js
+```
+
+### Manifest
+
+```json
+{
+  "schema_version": 2,
+  "source": "github.com/your-org/your-repo/console",
+  "version": "1.0.0",
+  "display_name": "Custom Console",
+  "description": "Custom Gestalt UI",
+  "kinds": ["webui"],
+  "webui": {
+    "asset_root": "out"
+  }
+}
+```
+
+The `webui` kind differs from `provider` and `runtime`:
+
+- no `artifacts` or `entrypoints` — there is no binary
+- no platform-specific builds — static assets are platform-agnostic
+- `asset_root` points to the directory containing `index.html`
+- `webui` cannot be combined with other kinds in the same manifest
+
+The `source` field follows the managed plugin source grammar: `github.com/<owner>/<repo>/<plugin>`.
+
+## Local Development
+
+Point `ui.plugin.package` at your build output:
+
+```yaml
+ui:
+  plugin:
+    package: ./my-ui-plugin
+```
+
+Then run `gestaltd serve --config config.yaml`. Changes to the package directory are detected on restart.
+
+This works with any build tool. For example, with Next.js:
+
+```sh
+cd my-ui && npm run build
+# next.config.js must have output: 'export'
+# output lands in my-ui/out/
+```
+
+Then configure `ui.plugin.package: ./my-ui` with `asset_root: "out"` in the manifest.
+
+## Publishing
+
+Package the plugin directory into an archive:
+
+```sh
+gestaltd plugin package --input ./my-ui-plugin --output gestalt-plugin-console_v1.0.0.tar.gz
+```
+
+Upload the archive to a GitHub release. The release tag must be `v<version>` and the asset name must follow `gestalt-plugin-<plugin>_v<version>.tar.gz`.
+
+Then configure with source and version:
+
+```yaml
+ui:
+  plugin:
+    source: github.com/your-org/your-repo/console
+    version: 1.0.0
+```
+
+`gestaltd` resolves the package from the GitHub release, installs it into `.gestalt/plugins/`, and locks it in `gestalt.lock.json`.
+
+## Bundled Deployment
+
+For production, use `gestaltd bundle` to prepare a self-contained deployment:
+
+```sh
+gestaltd bundle --config config.yaml --output ./deploy
+gestaltd serve --locked --config ./deploy/config.yaml
+```
+
+The bundle includes the resolved UI plugin assets and lock state. `--locked` prevents automatic resolution at startup.
+
+## No UI Plugin
+
+When no `ui:` section is in the config, `gestaltd` serves the embedded frontend. If the embedded frontend was not built into the binary (the `internal/webui/out` directory was empty at compile time), no UI is served and `gestaltd` runs as an API-only server.

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -13,6 +13,7 @@ runtimes: {}
 bindings: {}
 server: {}
 egress: {}
+ui: {}
 ```
 
 ## Load Semantics
@@ -473,6 +474,33 @@ egress:
 | `host` | Optional host filter. |
 | `path_prefix` | Optional path filter. |
 
+## `ui`
+
+```yaml
+ui:
+  plugin:
+    package: ./my-ui-plugin
+```
+
+or:
+
+```yaml
+ui:
+  plugin:
+    source: github.com/your-org/your-repo/console
+    version: 1.0.0
+```
+
+| Field | Notes |
+| --- | --- |
+| `plugin.package` | Local directory, local archive, or HTTPS URL. Mutually exclusive with `source`. |
+| `plugin.source` | Managed plugin source address. Requires `version`. |
+| `plugin.version` | Required with `source`. Must be valid SemVer without leading `v`. |
+
+When `ui` is omitted, `gestaltd` serves the embedded frontend. When `ui.plugin` is configured, the plugin's assets are served instead.
+
+See [UI Plugins](/concepts/ui-plugins) for the full workflow.
+
 ## Validation Rules Worth Remembering
 
 - `auth.provider` is required
@@ -486,3 +514,6 @@ egress:
 - URL templates in surface URLs and auth URLs must reference required params
 - runtime plugins must use `runtimes.<name>.config`, not `runtimes.<name>.plugin.config`
 - `egress.default_action` and policy `action` must be `allow` or `deny`
+- `ui.plugin` requires exactly one of `package` or `source`
+- `ui.plugin.version` is required with `source` and invalid with `package`
+- `ui.plugin.package` rejects plain `http://`


### PR DESCRIPTION
## Summary

- Add concepts page for UI plugins covering creation, local dev, publishing, and bundled deployment
- Update plugin packaging page with webui manifest format
- Add `ui` config section and validation rules to config reference

## Test plan

- [ ] `npm run build` in docs/ succeeds
- [ ] UI plugins concepts page renders correctly
- [ ] Config reference shows `ui` section
- [ ] Plugin packaging page shows webui manifest example

Generated with [Claude Code](https://claude.com/claude-code)