### PR TITLE
Add manifest-declared auth for plugins

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -15,8 +15,10 @@ import (
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	"github.com/valon-technologies/gestalt/internal/oauth"
 	"github.com/valon-technologies/gestalt/internal/pluginapi"
+	"github.com/valon-technologies/gestalt/internal/pluginpkg"
 	"github.com/valon-technologies/gestalt/internal/provider"
 	"github.com/valon-technologies/gestalt/internal/registry"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
 	"gopkg.in/yaml.v3"
 )
 
@@ -661,7 +663,18 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 		if err != nil {
 			return nil, err
 		}
-		return &ProviderBuildResult{Provider: prov}, nil
+		result := &ProviderBuildResult{Provider: prov}
+		if intg.Plugin.ResolvedManifestPath != "" {
+			authHandler, err := buildPluginOAuthHandler(intg, deps)
+			if err != nil {
+				log.Printf("WARNING: %s: cannot build oauth handler from manifest: %v", name, err)
+			} else if authHandler != nil {
+				result.ConnectionAuth = map[string]OAuthHandler{
+					config.PluginConnectionName: authHandler,
+				}
+			}
+		}
+		return result, nil
 	}
 
 	factory, err := providerFactoryForName(name, factories)
@@ -669,6 +682,60 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 		return nil, err
 	}
 	return factory(ctx, name, intg, deps)
+}
+
+func buildPluginOAuthHandler(intg config.IntegrationDef, deps Deps) (OAuthHandler, error) {
+	if intg.Plugin == nil || intg.Plugin.ResolvedManifestPath == "" {
+		return nil, nil
+	}
+	_, manifest, err := pluginpkg.ReadManifestFile(intg.Plugin.ResolvedManifestPath)
+	if err != nil {
+		return nil, err
+	}
+	if manifest.Provider == nil || manifest.Provider.Auth == nil || manifest.Provider.Auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
+		return nil, nil
+	}
+	auth := manifest.Provider.Auth
+
+	pluginConfig, err := config.NodeToMap(intg.Plugin.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	clientID, _ := pluginConfig["client_id"].(string)
+	clientSecret, _ := pluginConfig["client_secret"].(string)
+	if clientID == "" || clientSecret == "" {
+		return nil, fmt.Errorf("plugin.config must provide client_id and client_secret for oauth2 auth")
+	}
+
+	redirectURL := deps.BaseURL + config.IntegrationCallbackPath
+
+	var tokenExchange oauth.TokenExchangeFormat
+	switch auth.TokenExchange {
+	case "", "form":
+		tokenExchange = oauth.TokenExchangeForm
+	case "json":
+		tokenExchange = oauth.TokenExchangeJSON
+	}
+
+	oauthCfg := oauth.UpstreamConfig{
+		ClientID:            clientID,
+		ClientSecret:        clientSecret,
+		AuthorizationURL:    auth.AuthorizationURL,
+		TokenURL:            auth.TokenURL,
+		RedirectURL:         redirectURL,
+		PKCE:                auth.PKCE,
+		DefaultScopes:       auth.Scopes,
+		ScopeSeparator:      auth.ScopeSeparator,
+		TokenExchange:       tokenExchange,
+		AuthorizationParams: auth.AuthorizationParams,
+	}
+	if auth.ClientAuth == "header" {
+		oauthCfg.ClientAuthMethod = oauth.ClientAuthHeader
+	}
+
+	handler := oauth.NewUpstream(oauthCfg)
+	return WrapUpstreamHandler(handler), nil
 }
 
 func providerFactoryForName(name string, factories *FactoryRegistry) (ProviderFactory, error) {

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -711,6 +711,8 @@ func buildPluginOAuthHandler(intg config.IntegrationDef, pluginConfig map[string
 		tokenExchange = oauth.TokenExchangeForm
 	case "json":
 		tokenExchange = oauth.TokenExchangeJSON
+	default:
+		return nil, fmt.Errorf("unknown token_exchange %q", auth.TokenExchange)
 	}
 
 	oauthCfg := oauth.UpstreamConfig{

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -665,7 +665,7 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 		}
 		result := &ProviderBuildResult{Provider: prov}
 		if intg.Plugin.ResolvedManifestPath != "" {
-			authHandler, err := buildPluginOAuthHandler(intg, deps)
+			authHandler, err := buildPluginOAuthHandler(intg, pluginConfig, deps)
 			if err != nil {
 				log.Printf("WARNING: %s: cannot build oauth handler from manifest: %v", name, err)
 			} else if authHandler != nil {
@@ -684,7 +684,7 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 	return factory(ctx, name, intg, deps)
 }
 
-func buildPluginOAuthHandler(intg config.IntegrationDef, deps Deps) (OAuthHandler, error) {
+func buildPluginOAuthHandler(intg config.IntegrationDef, pluginConfig map[string]any, deps Deps) (OAuthHandler, error) {
 	if intg.Plugin == nil || intg.Plugin.ResolvedManifestPath == "" {
 		return nil, nil
 	}
@@ -696,11 +696,6 @@ func buildPluginOAuthHandler(intg config.IntegrationDef, deps Deps) (OAuthHandle
 		return nil, nil
 	}
 	auth := manifest.Provider.Auth
-
-	pluginConfig, err := config.NodeToMap(intg.Plugin.Config)
-	if err != nil {
-		return nil, err
-	}
 
 	clientID, _ := pluginConfig["client_id"].(string)
 	clientSecret, _ := pluginConfig["client_secret"].(string)

--- a/internal/pluginpkg/manifest.go
+++ b/internal/pluginpkg/manifest.go
@@ -138,6 +138,9 @@ func ValidateManifest(manifest *pluginmanifestv1.Manifest) error {
 					return err
 				}
 			}
+			if err := validateProviderAuth(manifest.Provider.Auth); err != nil {
+				return err
+			}
 			if err := validateEntrypoint(kind, manifest.Entrypoints.Provider, artifactPaths); err != nil {
 				return err
 			}
@@ -210,6 +213,25 @@ func validateRelativePackagePath(value, label string) error {
 	}
 	if cleaned != value {
 		return fmt.Errorf("%s must be normalized", label)
+	}
+	return nil
+}
+
+func validateProviderAuth(auth *pluginmanifestv1.ProviderAuth) error {
+	if auth == nil {
+		return nil
+	}
+	switch auth.Type {
+	case pluginmanifestv1.AuthTypeOAuth2:
+		if auth.AuthorizationURL == "" {
+			return fmt.Errorf("provider.auth.authorization_url is required for oauth2")
+		}
+		if auth.TokenURL == "" {
+			return fmt.Errorf("provider.auth.token_url is required for oauth2")
+		}
+	case pluginmanifestv1.AuthTypeManual, pluginmanifestv1.AuthTypeNone:
+	default:
+		return fmt.Errorf("unsupported provider.auth.type %q", auth.Type)
 	}
 	return nil
 }

--- a/internal/pluginpkg/manifest_test.go
+++ b/internal/pluginpkg/manifest_test.go
@@ -374,3 +374,233 @@ func TestDecodeManifest_V1RejectsSource(t *testing.T) {
 		t.Fatal("expected error for v1 manifest with source set")
 	}
 }
+
+func TestDecodeManifest_V2WithOAuth2Auth(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+  "schema_version": 2,
+  "source": "github.com/acme/plugins/echo",
+  "version": "1.0.0",
+  "kinds": ["provider"],
+  "provider": {
+    "protocol": { "min": 1, "max": 1 },
+    "auth": {
+      "type": "oauth2",
+      "authorization_url": "https://example.com/authorize",
+      "token_url": "https://example.com/token",
+      "scopes": ["read", "write"],
+      "pkce": true,
+      "client_auth": "header"
+    }
+  },
+  "artifacts": [
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "path": "artifacts/darwin/arm64/provider",
+      "sha256": "` + sha256Hex("provider") + `"
+    }
+  ],
+  "entrypoints": {
+    "provider": {
+      "artifact_path": "artifacts/darwin/arm64/provider"
+    }
+  }
+}`)
+
+	manifest, err := DecodeManifest(data)
+	if err != nil {
+		t.Fatalf("DecodeManifest: %v", err)
+	}
+	if manifest.Provider.Auth == nil {
+		t.Fatal("expected provider auth to be set")
+	}
+	if manifest.Provider.Auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
+		t.Fatalf("unexpected auth type %q", manifest.Provider.Auth.Type)
+	}
+	if manifest.Provider.Auth.AuthorizationURL != "https://example.com/authorize" {
+		t.Fatalf("unexpected authorization_url %q", manifest.Provider.Auth.AuthorizationURL)
+	}
+	if manifest.Provider.Auth.TokenURL != "https://example.com/token" {
+		t.Fatalf("unexpected token_url %q", manifest.Provider.Auth.TokenURL)
+	}
+	if !manifest.Provider.Auth.PKCE {
+		t.Fatal("expected pkce to be true")
+	}
+	if manifest.Provider.Auth.ClientAuth != "header" {
+		t.Fatalf("unexpected client_auth %q", manifest.Provider.Auth.ClientAuth)
+	}
+	if len(manifest.Provider.Auth.Scopes) != 2 {
+		t.Fatalf("expected 2 scopes, got %d", len(manifest.Provider.Auth.Scopes))
+	}
+}
+
+func TestDecodeManifest_V2OAuth2MissingTokenURL(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+  "schema_version": 2,
+  "source": "github.com/acme/plugins/echo",
+  "version": "1.0.0",
+  "kinds": ["provider"],
+  "provider": {
+    "protocol": { "min": 1, "max": 1 },
+    "auth": {
+      "type": "oauth2",
+      "authorization_url": "https://example.com/authorize"
+    }
+  },
+  "artifacts": [
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "path": "artifacts/darwin/arm64/provider",
+      "sha256": "` + sha256Hex("provider") + `"
+    }
+  ],
+  "entrypoints": {
+    "provider": {
+      "artifact_path": "artifacts/darwin/arm64/provider"
+    }
+  }
+}`)
+
+	_, err := DecodeManifest(data)
+	if err == nil {
+		t.Fatal("expected error for oauth2 auth without token_url")
+	}
+}
+
+func TestDecodeManifest_V2ManualAuth(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+  "schema_version": 2,
+  "source": "github.com/acme/plugins/echo",
+  "version": "1.0.0",
+  "kinds": ["provider"],
+  "provider": {
+    "protocol": { "min": 1, "max": 1 },
+    "auth": {
+      "type": "manual"
+    }
+  },
+  "artifacts": [
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "path": "artifacts/darwin/arm64/provider",
+      "sha256": "` + sha256Hex("provider") + `"
+    }
+  ],
+  "entrypoints": {
+    "provider": {
+      "artifact_path": "artifacts/darwin/arm64/provider"
+    }
+  }
+}`)
+
+	manifest, err := DecodeManifest(data)
+	if err != nil {
+		t.Fatalf("DecodeManifest: %v", err)
+	}
+	if manifest.Provider.Auth.Type != pluginmanifestv1.AuthTypeManual {
+		t.Fatalf("unexpected auth type %q", manifest.Provider.Auth.Type)
+	}
+}
+
+func TestDecodeManifest_V2InvalidAuthType(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+  "schema_version": 2,
+  "source": "github.com/acme/plugins/echo",
+  "version": "1.0.0",
+  "kinds": ["provider"],
+  "provider": {
+    "protocol": { "min": 1, "max": 1 },
+    "auth": {
+      "type": "bearer"
+    }
+  },
+  "artifacts": [
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "path": "artifacts/darwin/arm64/provider",
+      "sha256": "` + sha256Hex("provider") + `"
+    }
+  ],
+  "entrypoints": {
+    "provider": {
+      "artifact_path": "artifacts/darwin/arm64/provider"
+    }
+  }
+}`)
+
+	_, err := DecodeManifest(data)
+	if err == nil {
+		t.Fatal("expected error for invalid auth type")
+	}
+}
+
+func TestDecodeManifest_V2NoAuthStillValid(t *testing.T) {
+	t.Parallel()
+
+	manifest, err := DecodeManifest(validV2JSON())
+	if err != nil {
+		t.Fatalf("DecodeManifest: %v", err)
+	}
+	if manifest.Provider.Auth != nil {
+		t.Fatal("expected nil auth for manifest without auth block")
+	}
+}
+
+func TestDecodeManifest_V2AuthRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	manifest := &pluginmanifestv1.Manifest{
+		SchemaVersion: pluginmanifestv1.SchemaVersion2,
+		Source:        "github.com/acme/plugins/echo",
+		Version:       "1.0.0",
+		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
+			Auth: &pluginmanifestv1.ProviderAuth{
+				Type:             pluginmanifestv1.AuthTypeOAuth2,
+				AuthorizationURL: "https://example.com/authorize",
+				TokenURL:         "https://example.com/token",
+				Scopes:           []string{"read"},
+			},
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     "darwin",
+				Arch:   "arm64",
+				Path:   "artifacts/darwin/arm64/provider",
+				SHA256: sha256Hex("provider"),
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{
+				ArtifactPath: "artifacts/darwin/arm64/provider",
+			},
+		},
+	}
+
+	data, err := EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	got, err := DecodeManifest(data)
+	if err != nil {
+		t.Fatalf("DecodeManifest: %v", err)
+	}
+	if got.Provider.Auth == nil {
+		t.Fatal("expected auth after round trip")
+	}
+	if got.Provider.Auth.AuthorizationURL != "https://example.com/authorize" {
+		t.Fatalf("auth lost authorization_url across round trip")
+	}
+}

--- a/plugins/slack/plugin.json
+++ b/plugins/slack/plugin.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 2,
+  "source": "github.com/valon-technologies/gestalt/slack",
+  "version": "0.0.1-alpha.1",
+  "display_name": "Slack",
+  "description": "Send messages, search conversations, and manage channels.",
+  "kinds": ["provider"],
+  "provider": {
+    "protocol": { "min": 1, "max": 1 },
+    "auth": {
+      "type": "oauth2",
+      "authorization_url": "https://slack.com/oauth/v2/authorize",
+      "token_url": "https://slack.com/api/oauth.v2.access",
+      "scopes": ["channels:read", "channels:history", "chat:write", "users:read", "search:read"]
+    }
+  },
+  "artifacts": [],
+  "entrypoints": {}
+}

--- a/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -67,6 +67,9 @@
         "config_schema_path": {
           "type": "string",
           "minLength": 1
+        },
+        "auth": {
+          "$ref": "#/$defs/provider_auth"
         }
       }
     },
@@ -140,6 +143,57 @@
     }
   ],
   "$defs": {
+    "provider_auth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["oauth2", "manual", "none"]
+        },
+        "authorization_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "token_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "scopes": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "pkce": {
+          "type": "boolean"
+        },
+        "client_auth": {
+          "type": "string",
+          "enum": ["header", ""]
+        },
+        "token_exchange": {
+          "type": "string",
+          "enum": ["form", "json"]
+        },
+        "scope_separator": {
+          "type": "string"
+        },
+        "authorization_params": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "type": { "const": "oauth2" } }
+          },
+          "then": {
+            "required": ["authorization_url", "token_url"]
+          }
+        }
+      ]
+    },
     "artifact": {
       "type": "object",
       "additionalProperties": false,

--- a/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -169,7 +169,7 @@
         },
         "client_auth": {
           "type": "string",
-          "enum": ["header", ""]
+          "enum": ["header"]
         },
         "token_exchange": {
           "type": "string",

--- a/sdk/pluginmanifest/v1/manifest.v2.jsonschema.json
+++ b/sdk/pluginmanifest/v1/manifest.v2.jsonschema.json
@@ -67,6 +67,9 @@
         "config_schema_path": {
           "type": "string",
           "minLength": 1
+        },
+        "auth": {
+          "$ref": "#/$defs/provider_auth"
         }
       }
     },
@@ -168,6 +171,57 @@
     }
   ],
   "$defs": {
+    "provider_auth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["oauth2", "manual", "none"]
+        },
+        "authorization_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "token_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "scopes": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "pkce": {
+          "type": "boolean"
+        },
+        "client_auth": {
+          "type": "string",
+          "enum": ["header", ""]
+        },
+        "token_exchange": {
+          "type": "string",
+          "enum": ["form", "json"]
+        },
+        "scope_separator": {
+          "type": "string"
+        },
+        "authorization_params": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "type": { "const": "oauth2" } }
+          },
+          "then": {
+            "required": ["authorization_url", "token_url"]
+          }
+        }
+      ]
+    },
     "artifact": {
       "type": "object",
       "additionalProperties": false,

--- a/sdk/pluginmanifest/v1/manifest.v2.jsonschema.json
+++ b/sdk/pluginmanifest/v1/manifest.v2.jsonschema.json
@@ -197,7 +197,7 @@
         },
         "client_auth": {
           "type": "string",
-          "enum": ["header", ""]
+          "enum": ["header"]
         },
         "token_exchange": {
           "type": "string",

--- a/sdk/pluginmanifest/v1/types.go
+++ b/sdk/pluginmanifest/v1/types.go
@@ -32,6 +32,25 @@ type WebUIMetadata struct {
 type Provider struct {
 	Protocol         ProtocolRange `json:"protocol"`
 	ConfigSchemaPath string        `json:"config_schema_path,omitempty"`
+	Auth             *ProviderAuth `json:"auth,omitempty"`
+}
+
+const (
+	AuthTypeOAuth2 = "oauth2"
+	AuthTypeManual = "manual"
+	AuthTypeNone   = "none"
+)
+
+type ProviderAuth struct {
+	Type                string            `json:"type"`
+	AuthorizationURL    string            `json:"authorization_url,omitempty"`
+	TokenURL            string            `json:"token_url,omitempty"`
+	Scopes              []string          `json:"scopes,omitempty"`
+	PKCE                bool              `json:"pkce,omitempty"`
+	ClientAuth          string            `json:"client_auth,omitempty"`
+	TokenExchange       string            `json:"token_exchange,omitempty"`
+	ScopeSeparator      string            `json:"scope_separator,omitempty"`
+	AuthorizationParams map[string]string `json:"authorization_params,omitempty"`
 }
 
 type ProtocolRange struct {


### PR DESCRIPTION
Plugin integrations can now declare OAuth requirements directly in their
`plugin.json` manifest. When a plugin declares `"type": "oauth2"` auth,
gestaltd automatically handles the OAuth flow on the plugin's behalf,
pulling client credentials from plugin config. Plugins just receive
tokens in `Execute()` without needing YAML-level connection definitions.
This brings plugin integrations to parity with declarative integrations
for OAuth support.

Three auth types are supported: `oauth2`, `manual`, and `none`. The
`oauth2` type accepts the full range of OAuth2 configuration including
PKCE, custom scopes, header-based client auth, and JSON token exchange.
A reference `plugin.json` for the Slack plugin demonstrates the format.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>