### PR TITLE
Support plugin + MCP composition in integrations

### DIFF
--- a/cmd/gestaltd/init_test.go
+++ b/cmd/gestaltd/init_test.go
@@ -244,7 +244,7 @@ integrations:
 	}
 }
 
-func TestValidateConfigRejectsPluginWithConnectionsOrAPI(t *testing.T) {
+func TestValidateConfigRejectsPluginHybridMisconfiguration(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -253,19 +253,7 @@ func TestValidateConfigRejectsPluginWithConnectionsOrAPI(t *testing.T) {
 		wantContain string
 	}{
 		{
-			name: "plugin with connections",
-			body: `integrations:
-  sample:
-    connections:
-      default:
-        mode: user
-    plugin:
-      command: /tmp/plugin
-`,
-			wantContain: "cannot set both plugin and connections",
-		},
-		{
-			name: "plugin with api",
+			name: "plugin with api is rejected",
 			body: `integrations:
   sample:
     plugin:
@@ -275,7 +263,7 @@ func TestValidateConfigRejectsPluginWithConnectionsOrAPI(t *testing.T) {
       openapi: https://example.com/spec.json
       connection: default
 `,
-			wantContain: "cannot set both plugin and api",
+			wantContain: "cannot compose plugin with api",
 		},
 	}
 

--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -238,12 +238,17 @@ func buildMCPSurface(cfg *config.Config) mcpSurface {
 
 	for name, intg := range cfg.Integrations {
 		if intg.Plugin != nil {
-			if !pluginDeclaresMCP(intg.Plugin) {
+			if intg.MCP == nil && !pluginDeclaresMCP(intg.Plugin) {
 				continue
 			}
 			surface.providers = append(surface.providers, name)
 			surface.apiConnection[name] = config.PluginConnectionName
-			surface.mcpConnection[name] = config.PluginConnectionName
+			if intg.MCP != nil {
+				surface.includeREST[name] = true
+				surface.mcpConnection[name] = config.ResolveConnectionAlias(intg.MCP.Connection)
+			} else {
+				surface.mcpConnection[name] = config.PluginConnectionName
+			}
 			if intg.MCPToolPrefix == "" && intg.Plugin.Source != "" {
 				if src, err := pluginsource.Parse(intg.Plugin.Source); err == nil {
 					surface.toolPrefixes[name] = src.Plugin + "_"
@@ -355,9 +360,12 @@ func logConfigSummary(path string, cfg *config.Config) {
 	if len(cfg.Integrations) > 0 {
 		log.Printf("integrations: %d", len(cfg.Integrations))
 		for name, intg := range cfg.Integrations {
-			if intg.Plugin != nil {
+			switch {
+			case intg.Plugin != nil && intg.MCP == nil:
 				log.Printf("  %s: plugin", name)
-			} else {
+			case intg.Plugin != nil:
+				log.Printf("  %s: hybrid surfaces=[plugin,mcp]", name)
+			default:
 				var surfaces []string
 				if intg.API != nil {
 					surfaces = append(surfaces, intg.API.Type)

--- a/core/integration/restricted.go
+++ b/core/integration/restricted.go
@@ -150,6 +150,13 @@ func (r *Restricted) filterCatalog(cat *catalog.Catalog) *catalog.Catalog {
 	return &filtered
 }
 
+func (r *Restricted) Close() error {
+	if c, ok := r.inner.(interface{ Close() error }); ok {
+		return c.Close()
+	}
+	return nil
+}
+
 // Inner returns the unwrapped provider.
 func (r *Restricted) Inner() core.Provider {
 	return r.inner

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -12,6 +12,7 @@ import (
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/crypto"
 	"github.com/valon-technologies/gestalt/core/integration"
+	"github.com/valon-technologies/gestalt/internal/composite"
 	"github.com/valon-technologies/gestalt/internal/config"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	"github.com/valon-technologies/gestalt/internal/oauth"
@@ -650,68 +651,25 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 
 func buildProvider(ctx context.Context, name string, intg config.IntegrationDef, factories *FactoryRegistry, deps Deps) (*ProviderBuildResult, error) {
 	if intg.Plugin != nil {
-		pluginConfig, err := config.NodeToMap(intg.Plugin.Config)
-		if err != nil {
-			return nil, fmt.Errorf("decode plugin config for %q: %w", name, err)
-		}
-		prov, err := pluginapi.NewExecutableProvider(ctx, pluginapi.ExecConfig{
-			Command: intg.Plugin.Command,
-			Args:    intg.Plugin.Args,
-			Env:     intg.Plugin.Env,
-			Name:    name,
-			Config:  pluginConfig,
-		})
+		pluginProv, pluginConfig, err := buildPluginProvider(ctx, name, intg)
 		if err != nil {
 			return nil, err
 		}
-		buildResult := &ProviderBuildResult{Provider: prov}
-		if intg.Plugin.AllowedOperations != nil && len(intg.Plugin.AllowedOperations) == 0 {
-			return nil, fmt.Errorf("integration %q plugin.allowed_operations cannot be empty; omit the field to allow all", name)
-		}
-		if len(intg.Plugin.AllowedOperations) > 0 {
-			provOps := make(map[string]struct{}, len(prov.ListOperations()))
-			for _, op := range prov.ListOperations() {
-				provOps[op.Name] = struct{}{}
-			}
 
-			opsMap := make(map[string]string, len(intg.Plugin.AllowedOperations))
-			descs := make(map[string]string)
-			exposedNames := make(map[string]string, len(intg.Plugin.AllowedOperations))
-			for opName, override := range intg.Plugin.AllowedOperations {
-				if _, ok := provOps[opName]; !ok {
-					return nil, fmt.Errorf("integration %q plugin.allowed_operations references unknown operation %q", name, opName)
-				}
-				exposed := opName
-				if override != nil && override.Alias != "" {
-					exposed = override.Alias
-					opsMap[exposed] = opName
-				} else {
-					opsMap[opName] = ""
-				}
-				if existing, ok := exposedNames[exposed]; ok {
-					return nil, fmt.Errorf("integration %q plugin: alias collision: %q and %q both resolve to %q", name, existing, opName, exposed)
-				}
-				exposedNames[exposed] = opName
-				if override != nil && override.Description != "" {
-					descs[exposed] = override.Description
-				}
+		restricted, err := applyAllowedOperations(name, intg, pluginProv)
+		if err != nil {
+			if c, ok := pluginProv.(interface{ Close() error }); ok {
+				_ = c.Close()
 			}
-			var opts []integration.RestrictedOption
-			if len(descs) > 0 {
-				opts = append(opts, integration.WithDescriptions(descs))
-			}
-			buildResult.Provider = integration.NewRestricted(prov, opsMap, opts...)
+			return nil, err
 		}
-		if intg.Plugin.ResolvedManifestPath != "" {
-			authHandler, err := buildPluginOAuthHandler(intg, pluginConfig, deps)
-			if err != nil {
-				log.Printf("WARNING: %s: cannot build oauth handler from manifest: %v", name, err)
-			} else if authHandler != nil {
-				buildResult.ConnectionAuth = map[string]OAuthHandler{
-					config.PluginConnectionName: authHandler,
-				}
-			}
+
+		if intg.MCP != nil {
+			return buildPluginMCPProvider(ctx, name, intg, restricted, pluginConfig, factories, deps)
 		}
+
+		buildResult := &ProviderBuildResult{Provider: restricted}
+		attachPluginOAuth(name, intg, pluginConfig, deps, buildResult)
 		return buildResult, nil
 	}
 
@@ -720,6 +678,123 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 		return nil, err
 	}
 	return factory(ctx, name, intg, deps)
+}
+
+func applyAllowedOperations(name string, intg config.IntegrationDef, pluginProv core.Provider) (core.Provider, error) {
+	if intg.Plugin.AllowedOperations != nil && len(intg.Plugin.AllowedOperations) == 0 {
+		return nil, fmt.Errorf("integration %q plugin.allowed_operations cannot be empty; omit the field to allow all", name)
+	}
+	if len(intg.Plugin.AllowedOperations) == 0 {
+		return pluginProv, nil
+	}
+
+	provOps := make(map[string]struct{}, len(pluginProv.ListOperations()))
+	for _, op := range pluginProv.ListOperations() {
+		provOps[op.Name] = struct{}{}
+	}
+
+	opsMap := make(map[string]string, len(intg.Plugin.AllowedOperations))
+	descs := make(map[string]string)
+	exposedNames := make(map[string]string, len(intg.Plugin.AllowedOperations))
+	for opName, override := range intg.Plugin.AllowedOperations {
+		if _, ok := provOps[opName]; !ok {
+			return nil, fmt.Errorf("integration %q plugin.allowed_operations references unknown operation %q", name, opName)
+		}
+		exposed := opName
+		if override != nil && override.Alias != "" {
+			exposed = override.Alias
+			opsMap[exposed] = opName
+		} else {
+			opsMap[opName] = ""
+		}
+		if existing, ok := exposedNames[exposed]; ok {
+			return nil, fmt.Errorf("integration %q plugin: alias collision: %q and %q both resolve to %q", name, existing, opName, exposed)
+		}
+		exposedNames[exposed] = opName
+		if override != nil && override.Description != "" {
+			descs[exposed] = override.Description
+		}
+	}
+	var opts []integration.RestrictedOption
+	if len(descs) > 0 {
+		opts = append(opts, integration.WithDescriptions(descs))
+	}
+	return integration.NewRestricted(pluginProv, opsMap, opts...), nil
+}
+
+func buildPluginProvider(ctx context.Context, name string, intg config.IntegrationDef) (core.Provider, map[string]any, error) {
+	pluginConfig, err := config.NodeToMap(intg.Plugin.Config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("decode plugin config for %q: %w", name, err)
+	}
+	prov, err := pluginapi.NewExecutableProvider(ctx, pluginapi.ExecConfig{
+		Command: intg.Plugin.Command,
+		Args:    intg.Plugin.Args,
+		Env:     intg.Plugin.Env,
+		Name:    name,
+		Config:  pluginConfig,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return prov, pluginConfig, nil
+}
+
+func buildPluginMCPProvider(ctx context.Context, name string, intg config.IntegrationDef, pluginProv core.Provider, pluginConfig map[string]any, factories *FactoryRegistry, deps Deps) (*ProviderBuildResult, error) {
+	cleanupPlugin := true
+	defer func() {
+		if cleanupPlugin {
+			if c, ok := pluginProv.(interface{ Close() error }); ok {
+				_ = c.Close()
+			}
+		}
+	}()
+
+	factory, err := providerFactoryForName(name, factories)
+	if err != nil {
+		return nil, fmt.Errorf("building mcp surface for plugin+mcp %q: %w", name, err)
+	}
+
+	mcpResult, err := factory(ctx, name, intg, deps)
+	if err != nil {
+		return nil, fmt.Errorf("building mcp surface for plugin+mcp %q: %w", name, err)
+	}
+
+	mcpUp, ok := mcpResult.Provider.(composite.MCPUpstream)
+	if !ok {
+		if c, ok := mcpResult.Provider.(interface{ Close() error }); ok {
+			_ = c.Close()
+		}
+		return nil, fmt.Errorf("plugin+mcp %q: provider factory returned %T which does not implement MCPUpstream", name, mcpResult.Provider)
+	}
+	composed := composite.New(name, pluginProv, mcpUp)
+
+	result := &ProviderBuildResult{
+		Provider:       composed,
+		ConnectionAuth: mcpResult.ConnectionAuth,
+	}
+	attachPluginOAuth(name, intg, pluginConfig, deps, result)
+
+	cleanupPlugin = false
+	return result, nil
+}
+
+func attachPluginOAuth(name string, intg config.IntegrationDef, pluginConfig map[string]any, deps Deps, result *ProviderBuildResult) {
+	if intg.Plugin == nil || intg.Plugin.ResolvedManifestPath == "" {
+		return
+	}
+	authHandler, err := buildPluginOAuthHandler(intg, pluginConfig, deps)
+	if err != nil {
+		log.Printf("WARNING: %s: cannot build oauth handler from manifest: %v", name, err)
+		return
+	}
+	if authHandler == nil {
+		return
+	}
+	if result.ConnectionAuth == nil {
+		result.ConnectionAuth = make(map[string]OAuthHandler)
+	}
+	result.ConnectionAuth[config.PluginConnectionName] = authHandler
 }
 
 func buildPluginOAuthHandler(intg config.IntegrationDef, pluginConfig map[string]any, deps Deps) (OAuthHandler, error) {
@@ -785,7 +860,7 @@ func providerFactoryForName(name string, factories *FactoryRegistry) (ProviderFa
 }
 
 func validateProviderBuildAvailable(name string, intg config.IntegrationDef, factories *FactoryRegistry) error {
-	if intg.Plugin != nil {
+	if intg.Plugin != nil && intg.MCP == nil {
 		return nil
 	}
 	_, err := providerFactoryForName(name, factories)
@@ -794,6 +869,8 @@ func validateProviderBuildAvailable(name string, intg config.IntegrationDef, fac
 
 // BuildConnectionMap returns a map from integration name to its default
 // connection name. Used by the broker and server to resolve connections.
+// For hybrid integrations, the default is PluginConnectionName; the MCP and
+// server handlers pass per-tool connection names from the surface config.
 func BuildConnectionMap(cfg *config.Config) invocation.ConnectionMap {
 	m := make(invocation.ConnectionMap, len(cfg.Integrations))
 	for name, intg := range cfg.Integrations {

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -315,6 +315,59 @@ func TestBootstrapNilProviderFactoryFailsFast(t *testing.T) {
 
 }
 
+func TestBootstrapPluginMCPRequiresFactory(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cfg := validConfig()
+	cfg.Integrations["alpha"] = config.IntegrationDef{
+		Plugin: &config.ExecutablePluginDef{
+			Command: "echo",
+		},
+		MCP: &config.MCPDef{
+			URL:        "https://mcp.test/sse",
+			Connection: "default",
+		},
+		Connections: map[string]config.ConnectionDef{
+			"default": {Mode: "none"},
+		},
+	}
+
+	factories := validFactories()
+	delete(factories.Providers, "alpha")
+	factories.DefaultProvider = nil
+
+	_, err := bootstrap.Bootstrap(ctx, cfg, factories)
+	if err == nil {
+		t.Fatal("expected error for plugin+mcp integration with no factory")
+	}
+	if !strings.Contains(err.Error(), "no provider factory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBootstrapPluginOnlySkipsFactory(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cfg := validConfig()
+	cfg.Integrations["alpha"] = config.IntegrationDef{
+		Plugin: &config.ExecutablePluginDef{
+			Command: "echo",
+		},
+	}
+
+	factories := validFactories()
+	delete(factories.Providers, "alpha")
+	factories.DefaultProvider = nil
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap should succeed for plugin-only: %v", err)
+	}
+	<-result.ProvidersReady
+}
+
 func TestBootstrapFactoryError(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/composite/provider.go
+++ b/internal/composite/provider.go
@@ -47,12 +47,36 @@ func New(name string, apiProv core.Provider, mcpUp MCPUpstream) core.Provider {
 	return p
 }
 
-func (p *Provider) Name() string                        { return p.name }
-func (p *Provider) DisplayName() string                 { return p.api.DisplayName() }
-func (p *Provider) Description() string                 { return p.api.Description() }
-func (p *Provider) ConnectionMode() core.ConnectionMode { return p.api.ConnectionMode() }
-func (p *Provider) ListOperations() []core.Operation    { return p.api.ListOperations() }
-func (p *Provider) Catalog() *catalog.Catalog           { return p.buildCatalog() }
+func (p *Provider) Name() string        { return p.name }
+func (p *Provider) DisplayName() string { return p.api.DisplayName() }
+func (p *Provider) Description() string { return p.api.Description() }
+func (p *Provider) ConnectionMode() core.ConnectionMode {
+	return stricterConnectionMode(p.api.ConnectionMode(), p.mcpConnectionMode())
+}
+
+func (p *Provider) mcpConnectionMode() core.ConnectionMode {
+	if cm, ok := p.mcp.(interface{ ConnectionMode() core.ConnectionMode }); ok {
+		return cm.ConnectionMode()
+	}
+	return core.ConnectionModeNone
+}
+
+var connectionModeRank = map[core.ConnectionMode]int{
+	core.ConnectionModeNone:     0,
+	core.ConnectionModeEither:   1,
+	core.ConnectionModeIdentity: 2,
+	core.ConnectionModeUser:     2,
+}
+
+func stricterConnectionMode(a, b core.ConnectionMode) core.ConnectionMode {
+	if connectionModeRank[b] > connectionModeRank[a] {
+		return b
+	}
+	return a
+}
+
+func (p *Provider) ListOperations() []core.Operation { return p.api.ListOperations() }
+func (p *Provider) Catalog() *catalog.Catalog        { return p.buildCatalog() }
 
 func (p *Provider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
 	return p.api.Execute(ctx, operation, params, token)
@@ -143,18 +167,18 @@ func (p *Provider) buildCatalog() *catalog.Catalog {
 	return merged
 }
 
-func tagRESTCatalog(src *catalog.Catalog) *catalog.Catalog {
+func tagCatalog(src *catalog.Catalog, transport string) *catalog.Catalog {
 	out := src.Clone()
 	for i := range out.Operations {
-		out.Operations[i].Transport = catalog.TransportREST
+		out.Operations[i].Transport = transport
 	}
 	return out
 }
 
+func tagRESTCatalog(src *catalog.Catalog) *catalog.Catalog {
+	return tagCatalog(src, catalog.TransportREST)
+}
+
 func tagMCPCatalog(src *catalog.Catalog) *catalog.Catalog {
-	out := src.Clone()
-	for i := range out.Operations {
-		out.Operations[i].Transport = catalog.TransportMCPPassthrough
-	}
-	return out
+	return tagCatalog(src, catalog.TransportMCPPassthrough)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,11 @@ const (
 // tokens for plugin-only integrations that do not declare YAML connections.
 const PluginConnectionName = "_plugin"
 
+// PluginConnectionAlias is the user-facing alias that maps to
+// PluginConnectionName. In hybrid integrations, mcp.connection can be set
+// to "plugin" to reuse the plugin's OAuth token.
+const PluginConnectionAlias = "plugin"
+
 type Config struct {
 	Auth         AuthConfig                `yaml:"auth"`
 	Datastore    DatastoreConfig           `yaml:"datastore"`
@@ -134,9 +139,9 @@ type ServerConfig struct {
 	APITokenTTL   string `yaml:"api_token_ttl"`
 }
 
-// IntegrationDef represents either a declarative integration (connections +
-// api/mcp surfaces) or a plugin-only integration. The two lanes are mutually
-// exclusive: if Plugin is set, Connections/API/MCP must be nil and vice versa.
+// IntegrationDef represents a declarative integration (connections +
+// api/mcp surfaces), a plugin-only integration, or a hybrid that composes
+// a plugin with an MCP surface.
 type IntegrationDef struct {
 	Connections   map[string]ConnectionDef `yaml:"connections"`
 	API           *APIDef                  `yaml:"api"`
@@ -183,6 +188,15 @@ const (
 	APITypeREST    = "rest"
 	APITypeGraphQL = "graphql"
 )
+
+// ResolveConnectionAlias maps the user-facing "plugin" alias to the
+// internal PluginConnectionName. All other names pass through unchanged.
+func ResolveConnectionAlias(name string) string {
+	if name == PluginConnectionAlias {
+		return PluginConnectionName
+	}
+	return name
+}
 
 // ConnectionMode returns the shared connection mode for a set of connections.
 // All connections are validated to have the same mode; this returns the first
@@ -443,19 +457,7 @@ func ValidateRuntime(cfg *Config) error {
 
 func validateIntegration(name string, intg IntegrationDef) error {
 	if intg.Plugin != nil {
-		if err := validateExecutablePlugin("integration", name, intg.Plugin); err != nil {
-			return err
-		}
-		if len(intg.Connections) > 0 {
-			return fmt.Errorf("config validation: integration %q cannot set both plugin and connections", name)
-		}
-		if intg.API != nil {
-			return fmt.Errorf("config validation: integration %q cannot set both plugin and api", name)
-		}
-		if intg.MCP != nil {
-			return fmt.Errorf("config validation: integration %q cannot set both plugin and mcp", name)
-		}
-		return nil
+		return validateHybridIntegration(name, intg)
 	}
 
 	if len(intg.Connections) == 0 {
@@ -483,6 +485,47 @@ func validateIntegration(name string, intg IntegrationDef) error {
 	for cname := range intg.Connections {
 		if err := validateConnectionAuthURLParams(name, cname, intg.Connections[cname]); err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+func validateHybridIntegration(name string, intg IntegrationDef) error {
+	if err := validateExecutablePlugin("integration", name, intg.Plugin); err != nil {
+		return err
+	}
+
+	if intg.API != nil {
+		return fmt.Errorf("config validation: integration %q cannot compose plugin with api; only plugin + mcp is supported", name)
+	}
+
+	if intg.MCP != nil {
+		if intg.MCP.Connection == "" {
+			return fmt.Errorf("config validation: integration %q mcp.connection is required when composing with plugin", name)
+		}
+		if intg.MCP.Connection != PluginConnectionAlias {
+			if err := validateMCPDef(name, intg.MCP, intg.Connections); err != nil {
+				return err
+			}
+		} else {
+			if intg.MCP.URL == "" {
+				return fmt.Errorf("config validation: integration %q mcp.url is required", name)
+			}
+		}
+	}
+
+	if len(intg.Connections) > 0 {
+		if intg.MCP == nil {
+			return fmt.Errorf("config validation: integration %q has connections but no mcp surface; plugin + bare connections is not supported", name)
+		}
+		if err := validateConnectionModes(name, intg.Connections); err != nil {
+			return err
+		}
+		for cname := range intg.Connections {
+			if err := validateConnectionAuthURLParams(name, cname, intg.Connections[cname]); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -533,28 +533,6 @@ integrations:
 `,
 		},
 		{
-			name: "plugin with connections",
-			yaml: `
-auth:
-  provider: auth-provider
-datastore:
-  provider: data-store
-server:
-  encryption_key: server-key
-integrations:
-  service-a:
-    plugin:
-      command: /tmp/provider
-    connections:
-      default:
-        mode: user
-        auth:
-          type: oauth2
-          authorization_url: https://example.test/auth
-          token_url: https://example.test/token
-`,
-		},
-		{
 			name: "plugin with api",
 			yaml: `
 auth:
@@ -1618,7 +1596,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 			wantErr: "plugin.source",
 		},
 		{
-			name: "plugin with connections rejected",
+			name: "plugin with connections but no mcp is rejected",
 			cfg: &Config{
 				Integrations: map[string]IntegrationDef{
 					"sample": {
@@ -1627,10 +1605,10 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "cannot set both plugin and connections",
+			wantErr: "plugin + bare connections is not supported",
 		},
 		{
-			name: "plugin with api rejected",
+			name: "plugin with api is rejected",
 			cfg: &Config{
 				Integrations: map[string]IntegrationDef{
 					"sample": {
@@ -1639,7 +1617,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "cannot set both plugin and api",
+			wantErr: "cannot compose plugin with api",
 		},
 		{
 			name: "runtime plugin with type rejected",
@@ -1799,5 +1777,99 @@ integrations:
 
 	if mcp.AllowedOperations["list_tables"] != nil {
 		t.Error("list_tables override should be nil for bare key")
+	}
+}
+
+func TestHybridPluginComposition(t *testing.T) {
+	t.Parallel()
+
+	const baseConfig = `
+integrations:
+  svc:
+`
+	const connBlock = `    connections:
+      named:
+        mode: user
+        auth:
+          type: oauth2
+          authorization_url: https://example.test/auth
+          token_url: https://example.test/token
+          client_id: cid
+          client_secret: csec
+`
+	cases := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+	}{
+		{
+			name: "plugin only is valid",
+			yaml: baseConfig + `    plugin:
+      command: /tmp/plug
+`,
+		},
+		{
+			name: "plugin plus mcp with connection plugin is valid",
+			yaml: baseConfig + `    plugin:
+      command: /tmp/plug
+    mcp:
+      url: https://mcp.test/sse
+      connection: plugin
+`,
+		},
+		{
+			name: "plugin plus mcp with named connection is valid",
+			yaml: baseConfig + connBlock + `    plugin:
+      command: /tmp/plug
+    mcp:
+      url: https://mcp.test/sse
+      connection: named
+`,
+		},
+		{
+			name: "plugin plus api is rejected",
+			yaml: baseConfig + connBlock + `    plugin:
+      command: /tmp/plug
+    api:
+      type: rest
+      openapi: https://api.test/spec.json
+      connection: named
+`,
+			wantErr: true,
+		},
+		{
+			name: "plugin plus mcp without connection is rejected",
+			yaml: baseConfig + `    plugin:
+      command: /tmp/plug
+    mcp:
+      url: https://mcp.test/sse
+`,
+			wantErr: true,
+		},
+		{
+			name: "declarative only is valid",
+			yaml: baseConfig + connBlock + `    api:
+      type: rest
+      openapi: https://api.test/spec.json
+      connection: named
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := mustWriteConfigFile(t, tc.yaml)
+			_, err := Load(path)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
 	}
 }

--- a/internal/mcp/projection.go
+++ b/internal/mcp/projection.go
@@ -82,7 +82,7 @@ func buildToolMap(cfg Config, provName string, prov core.Provider, cat *catalog.
 		}
 
 		var handler mcpserver.ToolHandlerFunc
-		if isDirect && op.Transport != catalog.TransportREST && op.Transport != catalog.TransportPlugin {
+		if isDirect && op.Transport != catalog.TransportREST {
 			handler = makeDirectHandler(cfg, provName, op.ID, conn, caller)
 		} else {
 			handler = makeHandler(cfg.Invoker, provName, op.ID, conn)


### PR DESCRIPTION
A single integration definition can now combine a plugin provider with
an external MCP upstream. When both `plugin` and `mcp` blocks are
present, the plugin subprocess handles `Execute` while the MCP upstream
handles `CallTool`, and the composite provider reports the stricter of
the two connection modes. The `mcp.connection` field can reference a
named YAML connection or the special `plugin` alias to reuse the
plugin's own OAuth token.

Validation is updated so that `plugin + mcp` is allowed while
`plugin + api` remains rejected. The MCP surface builder in `run.go`
now includes plugins with an explicit `mcp` block without requiring
the plugin manifest to opt in.