### PR TITLE
Add security response headers to HTTP server

### DIFF
--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -48,6 +48,17 @@ func maxBodyMiddleware(limit int64) func(http.Handler) http.Handler {
 	}
 }
 
+func (s *Server) securityHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
+		if s.secureCookies {
+			w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if s.noAuth {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -4,6 +4,7 @@ import "github.com/go-chi/chi/v5"
 
 func (s *Server) routes() {
 	r := s.router
+	r.Use(s.securityHeadersMiddleware)
 	r.Use(maxBodyMiddleware(1 << 20)) // 1 MB
 
 	s.mountCoreRoutes(r)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -183,6 +183,57 @@ func TestHealthCheck(t *testing.T) {
 	}
 }
 
+func TestSecurityHeaders(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default", func(t *testing.T) {
+		t.Parallel()
+		ts := newTestServer(t)
+		testutil.CloseOnCleanup(t, ts)
+
+		resp, err := http.Get(ts.URL + "/health")
+		if err != nil {
+			t.Fatalf("GET /health: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if got := resp.Header.Get("X-Content-Type-Options"); got != "nosniff" {
+			t.Errorf("X-Content-Type-Options = %q, want %q", got, "nosniff")
+		}
+		if got := resp.Header.Get("X-Frame-Options"); got != "DENY" {
+			t.Errorf("X-Frame-Options = %q, want %q", got, "DENY")
+		}
+		if got := resp.Header.Get("Strict-Transport-Security"); got != "" {
+			t.Errorf("Strict-Transport-Security = %q, want empty (secureCookies=false)", got)
+		}
+	})
+
+	t.Run("secure_cookies", func(t *testing.T) {
+		t.Parallel()
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.SecureCookies = true
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		resp, err := http.Get(ts.URL + "/health")
+		if err != nil {
+			t.Fatalf("GET /health: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if got := resp.Header.Get("X-Content-Type-Options"); got != "nosniff" {
+			t.Errorf("X-Content-Type-Options = %q, want %q", got, "nosniff")
+		}
+		if got := resp.Header.Get("X-Frame-Options"); got != "DENY" {
+			t.Errorf("X-Frame-Options = %q, want %q", got, "DENY")
+		}
+		const wantHSTS = "max-age=63072000; includeSubDomains"
+		if got := resp.Header.Get("Strict-Transport-Security"); got != wantHSTS {
+			t.Errorf("Strict-Transport-Security = %q, want %q", got, wantHSTS)
+		}
+	})
+}
+
 func TestReadinessCheck(t *testing.T) {
 	t.Parallel()
 	ts := newTestServer(t)


### PR DESCRIPTION
The server previously set no security headers on responses, leaving the
web UI vulnerable to clickjacking and MIME type confusion attacks. All
responses now include `X-Content-Type-Options: nosniff` and
`X-Frame-Options: DENY`, and HTTPS deployments additionally receive a
`Strict-Transport-Security` header with a two-year max-age.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>