### PR TITLE
Use Argon2id instead of SHA-256 for passphrase key derivation

### DIFF
--- a/core/crypto/derivekey.go
+++ b/core/crypto/derivekey.go
@@ -1,13 +1,23 @@
 package crypto
 
 import (
-	"crypto/sha256"
 	"encoding/hex"
+
+	"golang.org/x/crypto/argon2"
 )
+
+const (
+	argonTime    = 3
+	argonMemory  = 64 * 1024 // 64 MiB
+	argonThreads = 4
+	argonKeyLen  = 32
+)
+
+var argonSalt = []byte("gestalt-derivekey-v1")
 
 // DeriveKey converts an encryption key string to a 32-byte key for AES-256-GCM.
 // If the string is 64 hex characters it is hex-decoded directly; otherwise it is
-// SHA-256 hashed. Returns nil for an empty string.
+// derived using Argon2id. Returns nil for an empty string.
 func DeriveKey(s string) []byte {
 	if s == "" {
 		return nil
@@ -15,6 +25,5 @@ func DeriveKey(s string) []byte {
 	if b, err := hex.DecodeString(s); err == nil && len(b) == 32 {
 		return b
 	}
-	h := sha256.Sum256([]byte(s))
-	return h[:]
+	return argon2.IDKey([]byte(s), argonSalt, argonTime, argonMemory, argonThreads, argonKeyLen)
 }

--- a/core/crypto/derivekey_test.go
+++ b/core/crypto/derivekey_test.go
@@ -1,0 +1,114 @@
+package crypto_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core/crypto"
+)
+
+func TestDeriveKeyPassphraseEncryptRoundTrip(t *testing.T) {
+	t.Parallel()
+	key := crypto.DeriveKey("dummy-passphrase-for-testing")
+	enc, err := crypto.NewAESGCM(key)
+	if err != nil {
+		t.Fatalf("NewAESGCM: %v", err)
+	}
+
+	plaintext := "sensitive-token-value"
+	ciphertext, err := enc.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	got, err := enc.Decrypt(ciphertext)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if got != plaintext {
+		t.Fatalf("round-trip failed: got %q, want %q", got, plaintext)
+	}
+}
+
+func TestDeriveKeyHexKeyEncryptRoundTrip(t *testing.T) {
+	t.Parallel()
+	hexKey := "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+	key := crypto.DeriveKey(hexKey)
+	want, _ := hex.DecodeString(hexKey)
+	if !bytes.Equal(key, want) {
+		t.Fatalf("hex key not passed through: got %x, want %x", key, want)
+	}
+
+	enc, err := crypto.NewAESGCM(key)
+	if err != nil {
+		t.Fatalf("NewAESGCM: %v", err)
+	}
+
+	plaintext := "sensitive-token-value"
+	ciphertext, err := enc.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	got, err := enc.Decrypt(ciphertext)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if got != plaintext {
+		t.Fatalf("round-trip failed: got %q, want %q", got, plaintext)
+	}
+}
+
+func TestDeriveKeySamePassphraseProducesSameEncryption(t *testing.T) {
+	t.Parallel()
+	passphrase := "deterministic-dummy-phrase"
+	key1 := crypto.DeriveKey(passphrase)
+	key2 := crypto.DeriveKey(passphrase)
+
+	enc1, err := crypto.NewAESGCM(key1)
+	if err != nil {
+		t.Fatalf("NewAESGCM key1: %v", err)
+	}
+	enc2, err := crypto.NewAESGCM(key2)
+	if err != nil {
+		t.Fatalf("NewAESGCM key2: %v", err)
+	}
+
+	plaintext := "cross-instance-token"
+	ciphertext, err := enc1.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	got, err := enc2.Decrypt(ciphertext)
+	if err != nil {
+		t.Fatalf("Decrypt with second key failed: %v", err)
+	}
+	if got != plaintext {
+		t.Fatalf("cross-key decrypt failed: got %q, want %q", got, plaintext)
+	}
+}
+
+func TestDeriveKeySHA256KeyCannotDecryptArgon2idCiphertext(t *testing.T) {
+	t.Parallel()
+	passphrase := "dummy-phrase-kdf-mismatch"
+
+	key := crypto.DeriveKey(passphrase)
+	enc, err := crypto.NewAESGCM(key)
+	if err != nil {
+		t.Fatalf("NewAESGCM: %v", err)
+	}
+	ciphertext, err := enc.Encrypt("secret-data")
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	sha := sha256.Sum256([]byte(passphrase))
+	shaEnc, err := crypto.NewAESGCM(sha[:])
+	if err != nil {
+		t.Fatalf("NewAESGCM (sha256): %v", err)
+	}
+	_, err = shaEnc.Decrypt(ciphertext)
+	if err == nil {
+		t.Fatal("SHA-256 derived key decrypted Argon2id ciphertext; KDF is not Argon2id")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/valon-technologies/gestalt/sdk/pluginapi v0.0.0-00010101000000-000000000000
 	github.com/valon-technologies/gestalt/sdk/pluginsdk v0.0.0-00010101000000-000000000000
 	go.mongodb.org/mongo-driver/v2 v2.5.0
+	golang.org/x/crypto v0.48.0
 	golang.org/x/mod v0.34.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/time v0.14.0
@@ -100,7 +101,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.37.0 // indirect
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
-	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect


### PR DESCRIPTION
`DeriveKey` previously used bare SHA-256 when the encryption key was not a 64-character hex string, providing no resistance to offline brute force of weak passphrases. This replaces the SHA-256 fallback with Argon2id using OWASP-recommended parameters and a fixed application salt, so passphrase-based keys are now memory-hard to crack. The hex fast path for raw 256-bit keys is unchanged.