### PR TITLE
Harden API token security with shorter expiry and bulk revocation

### DIFF
--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -122,6 +122,15 @@ func runServer(env *bootstrapEnv) error {
 	mcpSlot := &lateHandler{}
 	var mcpHandler http.Handler = mcpSlot
 
+	var apiTokenTTL time.Duration
+	if env.Config.Server.APITokenTTL != "" {
+		var err error
+		apiTokenTTL, err = config.ParseDuration(env.Config.Server.APITokenTTL)
+		if err != nil {
+			return fmt.Errorf("parsing server.api_token_ttl: %w", err)
+		}
+	}
+
 	srv, err := server.New(server.Config{
 		Auth:              result.Auth,
 		Datastore:         result.Datastore,
@@ -134,6 +143,7 @@ func runServer(env *bootstrapEnv) error {
 		IntegrationDefs:   env.Config.Integrations,
 		SecureCookies:     strings.HasPrefix(env.Config.Server.BaseURL, "https://"),
 		StateSecret:       crypto.DeriveKey(env.Config.Server.EncryptionKey),
+		APITokenTTL:       apiTokenTTL,
 		Readiness: composeReadiness(
 			readinessFromChannel(result.ProvidersReady, "providers loading"),
 			datastoreReadiness(result.Datastore),

--- a/core/datastore.go
+++ b/core/datastore.go
@@ -18,6 +18,7 @@ type Datastore interface {
 	ValidateAPIToken(ctx context.Context, hashedToken string) (*APIToken, error)
 	ListAPITokens(ctx context.Context, userID string) ([]*APIToken, error)
 	RevokeAPIToken(ctx context.Context, userID, id string) error
+	RevokeAllAPITokens(ctx context.Context, userID string) (int64, error)
 
 	Ping(ctx context.Context) error
 	Migrate(ctx context.Context) error

--- a/core/testing/datastore_suite.go
+++ b/core/testing/datastore_suite.go
@@ -399,6 +399,68 @@ func testDatastoreAPITokens(t *testing.T, newStore func(t *testing.T) core.Datas
 			t.Errorf("ValidateAPIToken for expired: expected nil, got %+v", got)
 		}
 	})
+
+	t.Run("revoke all tokens for user", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+		ctx := context.Background()
+
+		userA := mustCreateUser(t, ctx, ds, "revoke-all-a@example.com")
+		userB := mustCreateUser(t, ctx, ds, "revoke-all-b@example.com")
+		now := time.Now().Truncate(time.Second)
+
+		mustStoreAPIToken(t, ctx, ds, &core.APIToken{
+			ID: "rall-1", UserID: userA.ID, Name: "a-tok-1",
+			HashedToken: "sha256:rall1", CreatedAt: now, UpdatedAt: now,
+		})
+		mustStoreAPIToken(t, ctx, ds, &core.APIToken{
+			ID: "rall-2", UserID: userA.ID, Name: "a-tok-2",
+			HashedToken: "sha256:rall2", CreatedAt: now, UpdatedAt: now,
+		})
+		mustStoreAPIToken(t, ctx, ds, &core.APIToken{
+			ID: "rall-3", UserID: userB.ID, Name: "b-tok-1",
+			HashedToken: "sha256:rall3", CreatedAt: now, UpdatedAt: now,
+		})
+
+		count, err := ds.RevokeAllAPITokens(ctx, userA.ID)
+		if err != nil {
+			t.Fatalf("RevokeAllAPITokens: %v", err)
+		}
+		if count != 2 {
+			t.Fatalf("RevokeAllAPITokens: got count %d, want 2", count)
+		}
+
+		tokensA, err := ds.ListAPITokens(ctx, userA.ID)
+		if err != nil {
+			t.Fatalf("ListAPITokens after revoke-all: %v", err)
+		}
+		if len(tokensA) != 0 {
+			t.Errorf("expected 0 tokens for userA, got %d", len(tokensA))
+		}
+
+		tokensB, err := ds.ListAPITokens(ctx, userB.ID)
+		if err != nil {
+			t.Fatalf("ListAPITokens for userB: %v", err)
+		}
+		if len(tokensB) != 1 {
+			t.Errorf("expected 1 token for userB, got %d", len(tokensB))
+		}
+	})
+
+	t.Run("revoke all tokens returns zero when none exist", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { ds.Close() })
+		ctx := context.Background()
+
+		user := mustCreateUser(t, ctx, ds, "revoke-all-empty@example.com")
+		count, err := ds.RevokeAllAPITokens(ctx, user.ID)
+		if err != nil {
+			t.Fatalf("RevokeAllAPITokens: %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("RevokeAllAPITokens: got count %d, want 0", count)
+		}
+	})
 }
 
 func testDatastoreStagedConnections(t *testing.T, newStore func(t *testing.T) core.Datastore) {

--- a/core/testing/stubs.go
+++ b/core/testing/stubs.go
@@ -33,6 +33,7 @@ type StubDatastore struct {
 	DeleteTokenFn              func(context.Context, string) error
 	ValidateAPITokenFn         func(context.Context, string) (*core.APIToken, error)
 	RevokeAPITokenFn           func(context.Context, string, string) error
+	RevokeAllAPITokensFn       func(context.Context, string) (int64, error)
 	StoreStagedConnectionFn    func(context.Context, *core.StagedConnection) error
 	GetStagedConnectionFn      func(context.Context, string) (*core.StagedConnection, error)
 	DeleteStagedConnectionFn   func(context.Context, string) error
@@ -135,6 +136,12 @@ func (s *StubDatastore) RevokeAPIToken(ctx context.Context, userID, id string) e
 		return s.RevokeAPITokenFn(ctx, userID, id)
 	}
 	return nil
+}
+func (s *StubDatastore) RevokeAllAPITokens(ctx context.Context, userID string) (int64, error) {
+	if s.RevokeAllAPITokensFn != nil {
+		return s.RevokeAllAPITokensFn(ctx, userID)
+	}
+	return 0, nil
 }
 func (s *StubDatastore) StoreStagedConnection(ctx context.Context, sc *core.StagedConnection) error {
 	if s.StoreStagedConnectionFn != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/valon-technologies/gestalt/internal/egress"
 	"github.com/valon-technologies/gestalt/internal/pluginsource"
@@ -128,6 +130,7 @@ type ServerConfig struct {
 	Port          int    `yaml:"port"`
 	BaseURL       string `yaml:"base_url"`
 	EncryptionKey string `yaml:"encryption_key"`
+	APITokenTTL   string `yaml:"api_token_ttl"`
 }
 
 // IntegrationDef represents either a declarative integration (connections +
@@ -345,6 +348,11 @@ var templateParamRe = regexp.MustCompile(`\{(\w+)\}`)
 // Called by Load (and therefore by bundle and validate). Does not require
 // runtime secrets like encryption_key, auth.provider, or datastore.provider.
 func ValidateStructure(cfg *Config) error {
+	if cfg.Server.APITokenTTL != "" {
+		if _, err := ParseDuration(cfg.Server.APITokenTTL); err != nil {
+			return fmt.Errorf("config validation: server.api_token_ttl: %w", err)
+		}
+	}
 	if err := validateEgress(&cfg.Egress); err != nil {
 		return err
 	}
@@ -629,6 +637,30 @@ func validateUIPlugin(plugin *UIPluginDef) error {
 		return fmt.Errorf("config validation: ui plugin.package requires HTTPS; plain HTTP is not supported")
 	}
 	return nil
+}
+
+func ParseDuration(s string) (time.Duration, error) {
+	if s == "" {
+		return 0, fmt.Errorf("empty duration string")
+	}
+	if strings.HasSuffix(s, "d") {
+		days, err := strconv.Atoi(strings.TrimSuffix(s, "d"))
+		if err != nil {
+			return 0, fmt.Errorf("invalid day duration %q: %w", s, err)
+		}
+		if days <= 0 {
+			return 0, fmt.Errorf("duration must be positive, got %q", s)
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, err
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("duration must be positive, got %q", s)
+	}
+	return d, nil
 }
 
 func NodeToMap(node yaml.Node) (map[string]any, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1251,6 +1251,113 @@ server:
 	}
 }
 
+func TestLoadConfig_APITokenTTL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid day duration", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+server:
+  api_token_ttl: "14d"
+`)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.Server.APITokenTTL != "14d" {
+			t.Fatalf("APITokenTTL = %q, want %q", cfg.Server.APITokenTTL, "14d")
+		}
+	})
+
+	t.Run("valid hour duration", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+server:
+  api_token_ttl: "48h"
+`)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.Server.APITokenTTL != "48h" {
+			t.Fatalf("APITokenTTL = %q, want %q", cfg.Server.APITokenTTL, "48h")
+		}
+	})
+
+	t.Run("valid minute duration", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+server:
+  api_token_ttl: "30m"
+`)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.Server.APITokenTTL != "30m" {
+			t.Fatalf("APITokenTTL = %q, want %q", cfg.Server.APITokenTTL, "30m")
+		}
+	})
+
+	t.Run("invalid duration rejected", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+server:
+  api_token_ttl: "not-a-duration"
+`)
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("expected error for invalid api_token_ttl")
+		}
+	})
+
+	t.Run("zero day duration rejected", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+server:
+  api_token_ttl: "0d"
+`)
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("expected error for zero api_token_ttl")
+		}
+	})
+
+	t.Run("negative duration rejected", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+server:
+  api_token_ttl: "-1d"
+`)
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("expected error for negative api_token_ttl")
+		}
+	})
+
+	t.Run("omitted uses default", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+server:
+  port: 9090
+`)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.Server.APITokenTTL != "" {
+			t.Fatalf("APITokenTTL = %q, want empty", cfg.Server.APITokenTTL)
+		}
+	})
+}
+
 func TestLoadErrors(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -923,6 +923,20 @@ func (s *Server) revokeAPIToken(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "revoked"})
 }
 
+func (s *Server) revokeAllAPITokens(w http.ResponseWriter, r *http.Request) {
+	userID, ok := s.resolveUserID(w, r)
+	if !ok {
+		return
+	}
+
+	count, err := s.datastore.RevokeAllAPITokens(r.Context(), userID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to revoke tokens")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"status": "revoked", "count": count})
+}
+
 func (s *Server) logout(w http.ResponseWriter, r *http.Request) {
 	s.clearSessionCookie(w)
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})

--- a/internal/server/routes_user.go
+++ b/internal/server/routes_user.go
@@ -24,6 +24,7 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 
 		r.Post("/tokens", s.createAPIToken)
 		r.Get("/tokens", s.listAPITokens)
+		r.Delete("/tokens", s.revokeAllAPITokens)
 		r.Delete("/tokens/{id}", s.revokeAPIToken)
 
 	})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -35,6 +35,7 @@ type Server struct {
 	anonymousPrincipal *principal.Principal
 	secureCookies      bool
 	stateCodec         *integrationOAuthStateCodec
+	apiTokenTTL        time.Duration
 	now                func() time.Time
 	readiness          ReadinessChecker
 	mcpHandler         http.Handler
@@ -53,6 +54,7 @@ type Config struct {
 	IntegrationDefs   map[string]config.IntegrationDef
 	SecureCookies     bool
 	StateSecret       []byte
+	APITokenTTL       time.Duration
 	Now               func() time.Time
 	Readiness         ReadinessChecker
 	MCPHandler        http.Handler
@@ -94,6 +96,7 @@ func New(cfg Config) (*Server, error) {
 		noAuth:            noAuth,
 		secureCookies:     cfg.SecureCookies,
 		stateCodec:        stateCodec,
+		apiTokenTTL:       cfg.APITokenTTL,
 		now:               now,
 		readiness:         cfg.Readiness,
 		mcpHandler:        cfg.MCPHandler,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1587,9 +1587,131 @@ func TestCreateAPIToken_DefaultExpiry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parsing expires_at: %v", err)
 	}
-	expected := fixedNow.Add(90 * 24 * time.Hour).UTC().Truncate(time.Second)
+	expected := fixedNow.Add(30 * 24 * time.Hour).UTC().Truncate(time.Second)
 	if !expiresAt.Equal(expected) {
 		t.Fatalf("expected expires_at %v, got %v", expected, expiresAt)
+	}
+}
+
+func TestCreateAPIToken_ConfigurableTTL(t *testing.T) {
+	t.Parallel()
+
+	fixedNow := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	customTTL := 7 * 24 * time.Hour
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Now = func() time.Time { return fixedNow }
+		cfg.APITokenTTL = customTTL
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"name":"ttl-test","scopes":"read"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/tokens", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 201, got %d: %s", resp.StatusCode, respBody)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	expiresAtStr, ok := result["expires_at"].(string)
+	if !ok {
+		t.Fatal("expected expires_at string in response")
+	}
+	expiresAt, err := time.Parse(time.RFC3339, expiresAtStr)
+	if err != nil {
+		t.Fatalf("parsing expires_at: %v", err)
+	}
+	expected := fixedNow.Add(customTTL).UTC().Truncate(time.Second)
+	if !expiresAt.Equal(expected) {
+		t.Fatalf("expected expires_at %v, got %v", expected, expiresAt)
+	}
+}
+
+func TestRevokeAllAPITokens(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			RevokeAllAPITokensFn: func(_ context.Context, userID string) (int64, error) {
+				if userID == "u1" {
+					return 3, nil
+				}
+				return 0, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/tokens", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if result["status"] != "revoked" {
+		t.Fatalf("expected status revoked, got %q", result["status"])
+	}
+	if count, ok := result["count"].(float64); !ok || count != 3 {
+		t.Fatalf("expected count 3, got %v", result["count"])
+	}
+}
+
+func TestRevokeAllAPITokens_NoneExist(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/tokens", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if count, ok := result["count"].(float64); !ok || count != 0 {
+		t.Fatalf("expected count 0, got %v", result["count"])
 	}
 }
 

--- a/internal/server/token_helpers.go
+++ b/internal/server/token_helpers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/valon-technologies/gestalt/internal/principal"
 )
 
-const defaultIssuedTokenExpiry = 90 * 24 * time.Hour
+const defaultIssuedTokenExpiry = 30 * 24 * time.Hour
 
 type issuedToken struct {
 	Plaintext string
@@ -32,7 +32,11 @@ func (s *Server) issueTokenWithType(typ principal.TokenType) (*issuedToken, erro
 	}
 
 	now := s.nowUTCSecond()
-	expiry := now.Add(defaultIssuedTokenExpiry)
+	ttl := s.apiTokenTTL
+	if ttl == 0 {
+		ttl = defaultIssuedTokenExpiry
+	}
+	expiry := now.Add(ttl)
 	return &issuedToken{
 		Plaintext: plaintext,
 		Hashed:    hashed,

--- a/plugins/datastore/dynamodb/dynamodb.go
+++ b/plugins/datastore/dynamodb/dynamodb.go
@@ -484,6 +484,84 @@ func (s *Store) RevokeAPIToken(ctx context.Context, userID, id string) error {
 	return nil
 }
 
+func (s *Store) RevokeAllAPITokens(ctx context.Context, userID string) (int64, error) {
+	pk := userPKPrefix + userID
+	keyCond := expression.KeyAnd(
+		expression.Key(attrPK).Equal(expression.Value(pk)),
+		expression.KeyBeginsWith(expression.Key(attrSK), apiTokenSKPrefix),
+	)
+	proj := expression.NamesList(expression.Name(attrPK), expression.Name(attrSK))
+	expr, err := expression.NewBuilder().WithKeyCondition(keyCond).WithProjection(proj).Build()
+	if err != nil {
+		return 0, fmt.Errorf("dynamodb: building expression: %w", err)
+	}
+
+	var items []map[string]ddbtypes.AttributeValue
+	var exclusiveStartKey map[string]ddbtypes.AttributeValue
+	for {
+		input := &dynamodb.QueryInput{
+			TableName:                 &s.tableName,
+			KeyConditionExpression:    expr.KeyCondition(),
+			ProjectionExpression:      expr.Projection(),
+			ExpressionAttributeNames:  expr.Names(),
+			ExpressionAttributeValues: expr.Values(),
+			ExclusiveStartKey:         exclusiveStartKey,
+		}
+		out, err := s.client.Query(ctx, input)
+		if err != nil {
+			return 0, fmt.Errorf("dynamodb: querying api tokens for revoke-all: %w", err)
+		}
+		items = append(items, out.Items...)
+		if out.LastEvaluatedKey == nil {
+			break
+		}
+		exclusiveStartKey = out.LastEvaluatedKey
+	}
+
+	if len(items) == 0 {
+		return 0, nil
+	}
+
+	const batchSize = 25
+	const maxRetries = 3
+	var count int64
+	for i := 0; i < len(items); i += batchSize {
+		end := i + batchSize
+		if end > len(items) {
+			end = len(items)
+		}
+		requests := make([]ddbtypes.WriteRequest, 0, end-i)
+		for _, item := range items[i:end] {
+			requests = append(requests, ddbtypes.WriteRequest{
+				DeleteRequest: &ddbtypes.DeleteRequest{
+					Key: map[string]ddbtypes.AttributeValue{
+						attrPK: item[attrPK],
+						attrSK: item[attrSK],
+					},
+				},
+			})
+		}
+		pending := requests
+		for attempt := 0; attempt <= maxRetries && len(pending) > 0; attempt++ {
+			batchOut, err := s.client.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
+				RequestItems: map[string][]ddbtypes.WriteRequest{
+					s.tableName: pending,
+				},
+			})
+			if err != nil {
+				return count, fmt.Errorf("dynamodb: batch deleting api tokens: %w", err)
+			}
+			unprocessed := batchOut.UnprocessedItems[s.tableName]
+			count += int64(len(pending) - len(unprocessed))
+			pending = unprocessed
+		}
+		if len(pending) > 0 {
+			return count, fmt.Errorf("dynamodb: %d api token deletions failed after retries", len(pending))
+		}
+	}
+	return count, nil
+}
+
 func (s *Store) lookupKeysByGSI(ctx context.Context, indexName, keyAttr, keyValue, skPrefix string) (pk, sk string, err error) {
 	keyCond := expression.KeyAnd(
 		expression.Key(keyAttr).Equal(expression.Value(keyValue)),

--- a/plugins/datastore/firestore/firestore.go
+++ b/plugins/datastore/firestore/firestore.go
@@ -483,6 +483,40 @@ func (s *Store) RevokeAPIToken(ctx context.Context, userID, id string) error {
 	return nil
 }
 
+func (s *Store) RevokeAllAPITokens(ctx context.Context, userID string) (int64, error) {
+	iter := s.client.Collection(datastore.APITokensCollection).
+		Where("user_id", "==", userID).
+		Documents(ctx)
+	defer iter.Stop()
+
+	bw := s.client.BulkWriter(ctx)
+	var jobs []*gcpfirestore.BulkWriterJob
+	for {
+		snap, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return 0, fmt.Errorf("firestore: iterating api tokens for revoke-all: %w", err)
+		}
+		job, err := bw.Delete(snap.Ref)
+		if err != nil {
+			return 0, fmt.Errorf("firestore: queuing delete for revoke-all: %w", err)
+		}
+		jobs = append(jobs, job)
+	}
+	bw.End()
+
+	var count int64
+	for _, job := range jobs {
+		if _, err := job.Results(); err != nil {
+			return count, fmt.Errorf("firestore: deleting api token in revoke-all: %w", err)
+		}
+		count++
+	}
+	return count, nil
+}
+
 func snapToAPIToken(snap *gcpfirestore.DocumentSnapshot) (*core.APIToken, error) {
 	var doc apiTokenDoc
 	if err := snap.DataTo(&doc); err != nil {

--- a/plugins/datastore/mongodb/mongodb.go
+++ b/plugins/datastore/mongodb/mongodb.go
@@ -349,6 +349,14 @@ func (s *Store) RevokeAPIToken(ctx context.Context, userID, id string) error {
 	return nil
 }
 
+func (s *Store) RevokeAllAPITokens(ctx context.Context, userID string) (int64, error) {
+	result, err := s.db.Collection(datastore.APITokensCollection).DeleteMany(ctx, bson.M{"user_id": userID})
+	if err != nil {
+		return 0, fmt.Errorf("mongodb: revoking all api tokens: %w", err)
+	}
+	return result.DeletedCount, nil
+}
+
 func userFromDoc(doc *userDoc) *core.User {
 	return &core.User{
 		ID:          doc.ID,

--- a/plugins/datastore/sqlstore/sqlstore.go
+++ b/plugins/datastore/sqlstore/sqlstore.go
@@ -388,6 +388,18 @@ func (s *Store) RevokeAPIToken(ctx context.Context, userID, id string) error {
 	return nil
 }
 
+func (s *Store) RevokeAllAPITokens(ctx context.Context, userID string) (int64, error) {
+	result, err := s.DB.ExecContext(ctx, "DELETE FROM api_tokens WHERE user_id = "+s.ph(1), userID)
+	if err != nil {
+		return 0, fmt.Errorf("revoking all api tokens: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("revoking all api tokens: %w", err)
+	}
+	return n, nil
+}
+
 func (s *Store) StoreStagedConnection(ctx context.Context, sc *core.StagedConnection) error {
 	accessEnc, refreshEnc, err := s.Enc.EncryptTokenPair(sc.AccessToken, sc.RefreshToken)
 	if err != nil {


### PR DESCRIPTION
API tokens previously expired after 90 days with no way to adjust that
window or revoke all tokens at once if a credential was compromised.
The default expiry is now 30 days, and operators can tune it at deploy
time via a new `server.api_token_ttl` config field that accepts
durations like "14d" or "72h".

A new `DELETE /api/v1/tokens` endpoint lets users revoke every API
token on their account in a single call, returning the number of tokens
removed. This covers all datastore backends.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>