### PR TITLE
Improve gestaltd Docker image docs and packaging

### DIFF
--- a/.github/dockerhub-gestaltd-description.md
+++ b/.github/dockerhub-gestaltd-description.md
@@ -1,0 +1,199 @@
+# gestaltd Docker image
+
+`gestaltd` is a self-hosted integration runtime. You describe your platform in one YAML file, and `gestaltd` turns that file into a running server with:
+
+- an HTTP API
+- an embedded web UI
+- `/health` and `/ready` endpoints
+- an `/mcp` endpoint when integrations expose tools
+- support for REST, GraphQL, MCP, and packaged plugins
+
+## Quick reference
+
+- Image: `valontechnologies/gestaltd`
+- Default port: `8080`
+- Default command:
+
+  ```sh
+  /gestaltd serve --locked --config /etc/gestalt/config.yaml
+  ```
+
+- Default config path: `/etc/gestalt/config.yaml`
+- This image is not zero-config. Mount or bake a config file before starting it.
+- Locked startup is the default. If your config depends on remote OpenAPI or GraphQL specs, or on `plugin.package`, bundle the config first and run from the prepared output.
+
+## Supported tags
+
+The publish workflows maintain these tag shapes:
+
+- `latest`
+- `<version>`
+- `<sha>`
+- `builder`
+- `builder-<version>`
+- `builder-<sha>`
+- `debug`
+- `debug-<version>`
+- `debug-<sha>`
+
+The image is published for `linux/amd64` and `linux/arm64`.
+
+## What each tag is for
+
+- `valontechnologies/gestaltd:latest`
+  The production runtime image. Distroless, no shell, smallest surface area.
+- `valontechnologies/gestaltd:builder`
+  A Go-based build image with `gestaltd`, `git`, and the Go toolchain. Use it when compiling plugins and bundling a deployment in a multi-stage Docker build.
+- `valontechnologies/gestaltd:debug`
+  A shell-enabled image for troubleshooting. Same `gestaltd` entrypoint, plus a shell and `curl`.
+
+## Run a simple static config
+
+If your config does not need prepared artifacts, mount it directly:
+
+```sh
+docker run --rm \
+  -p 8080:8080 \
+  -v "$(pwd)/gestalt.yaml:/etc/gestalt/config.yaml:ro" \
+  -v gestalt-data:/data \
+  valontechnologies/gestaltd:latest
+```
+
+Example minimal config:
+
+```yaml
+server:
+  port: 8080
+  encryption_key: ${GESTALT_ENCRYPTION_KEY}
+
+auth:
+  provider: none
+
+datastore:
+  provider: sqlite
+  config:
+    path: /data/gestalt.db
+
+integrations: {}
+```
+
+## Run a bundled production image
+
+If your config references remote OpenAPI or GraphQL sources, or `plugin.package`, prepare it during the image build:
+
+```dockerfile
+FROM valontechnologies/gestaltd:builder AS bundle
+COPY config.yaml /src/config.yaml
+RUN ["/gestaltd", "bundle", "--config", "/src/config.yaml", "--output", "/app"]
+
+FROM valontechnologies/gestaltd:latest
+COPY --from=bundle /app/ /app/
+CMD ["serve", "--locked", "--config", "/app/config.yaml"]
+```
+
+This is the recommended production pattern.
+
+## Compose example
+
+```yaml
+services:
+  gestaltd:
+    image: valontechnologies/gestaltd:latest
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./config.yaml:/etc/gestalt/config.yaml:ro
+      - gestalt-data:/data
+    environment:
+      GESTALT_ENCRYPTION_KEY: change-me
+
+volumes:
+  gestalt-data:
+```
+
+## Configuration and environment variables
+
+Gestalt expands `${VAR}` placeholders before YAML decode. The image also supports the common `*_FILE` convention for those placeholders:
+
+- if `VAR` is set, `${VAR}` resolves to that value
+- otherwise, if `VAR_FILE` is set, `${VAR}` resolves to the contents of that file
+
+That means this works well with Docker secrets:
+
+```yaml
+server:
+  encryption_key: ${GESTALT_ENCRYPTION_KEY}
+```
+
+```sh
+docker run --rm \
+  -p 8080:8080 \
+  -v "$(pwd)/gestalt.yaml:/etc/gestalt/config.yaml:ro" \
+  -v /run/secrets/gestalt-encryption-key:/run/secrets/gestalt-encryption-key:ro \
+  -e GESTALT_ENCRYPTION_KEY_FILE=/run/secrets/gestalt-encryption-key \
+  valontechnologies/gestaltd:latest
+```
+
+For more advanced setups, Gestalt also supports `secret://...` references with `env`, `file`, and `gcp_secret_manager` secret providers.
+
+## Health endpoints
+
+The container exposes:
+
+- `GET /health` for liveness
+- `GET /ready` for readiness
+
+The embedded web UI is served from `/` on the same port.
+
+## SQLite and `/data`
+
+SQLite works well for:
+
+- local development
+- demos
+- single-instance deployments with persistent storage
+
+If you choose SQLite, store the database on mounted durable storage such as `/data/gestalt.db`.
+
+For horizontally scaled deployments, prefer Postgres or MySQL.
+
+## Debugging
+
+The default runtime image is distroless, so it does not include a shell. Use the `debug` tag when you need interactive troubleshooting:
+
+```sh
+docker run --rm -it --entrypoint sh valontechnologies/gestaltd:debug
+```
+
+You can also use it to check startup behavior directly:
+
+```sh
+docker run --rm valontechnologies/gestaltd:debug --help
+```
+
+## Building plugins and bundles
+
+Use the `builder` tag when you want to compile plugins and run `gestaltd bundle` in the same build stage:
+
+```dockerfile
+FROM valontechnologies/gestaltd:builder AS build
+WORKDIR /src
+COPY . .
+RUN go build -o /tmp/myplugin ./plugins/cmd/myplugin && \
+    gestaltd plugin package --binary /tmp/myplugin --id example/myplugin --output ./deploy/plugins/myplugin.tar.gz && \
+    gestaltd bundle --config ./deploy/config.yaml --output /app
+```
+
+## Caveats
+
+- The published image defaults to locked startup. A missing config file or missing prepared state causes startup to fail fast.
+- `docker run valontechnologies/gestaltd:latest` by itself is expected to fail because the image does not auto-generate config in-container.
+- The runtime image has no shell. Use `:debug` if you need one.
+- If you use SQLite, do not scale to multiple replicas.
+
+## Learn more
+
+- Docs: https://gestalt.run
+- CLI reference: https://gestalt.run/reference/cli
+- Deployment docs: https://gestalt.run/deploy
+- Source: https://github.com/valon-technologies/gestalt

--- a/.github/workflows/publish-gestaltd-image.yml
+++ b/.github/workflows/publish-gestaltd-image.yml
@@ -51,7 +51,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: Dockerfile.gestaltd
+          file: Dockerfile
           target: builder
           push: true
           platforms: linux/amd64,linux/arm64
@@ -71,7 +71,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: Dockerfile.gestaltd
+          file: Dockerfile
           target: debug
           push: true
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-gestaltd-image.yml
+++ b/.github/workflows/publish-gestaltd-image.yml
@@ -11,22 +11,87 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
+    env:
+      IMAGE_NAME: valontechnologies/gestaltd
+      IMAGE_SOURCE: https://github.com/${{ github.repository }}
+      IMAGE_DOCUMENTATION: https://gestalt.run
+      IMAGE_URL: https://hub.docker.com/r/valontechnologies/gestaltd
     steps:
       - uses: actions/checkout@v4
+      - name: Compute image metadata
+        id: meta
+        run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v5
+      - name: Build and push runtime image
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile
+          target: runtime
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            valontechnologies/gestaltd:latest
-            valontechnologies/gestaltd:${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          build-args: |
+            GESTALT_VERSION=${{ github.sha }}
+            GESTALT_REVISION=${{ github.sha }}
+            GESTALT_CREATED=${{ steps.meta.outputs.created }}
+            GESTALT_SOURCE=${{ env.IMAGE_SOURCE }}
+            GESTALT_DOCUMENTATION=${{ env.IMAGE_DOCUMENTATION }}
+            GESTALT_URL=${{ env.IMAGE_URL }}
           cache-from: type=gha
           cache-to: type=gha,mode=min
+      - name: Build and push builder image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.gestaltd
+          target: builder
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.IMAGE_NAME }}:builder
+            ${{ env.IMAGE_NAME }}:builder-${{ github.sha }}
+          build-args: |
+            GESTALT_VERSION=${{ github.sha }}
+            GESTALT_REVISION=${{ github.sha }}
+            GESTALT_CREATED=${{ steps.meta.outputs.created }}
+            GESTALT_SOURCE=${{ env.IMAGE_SOURCE }}
+            GESTALT_DOCUMENTATION=${{ env.IMAGE_DOCUMENTATION }}
+            GESTALT_URL=${{ env.IMAGE_URL }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+      - name: Build and push debug image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.gestaltd
+          target: debug
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.IMAGE_NAME }}:debug
+            ${{ env.IMAGE_NAME }}:debug-${{ github.sha }}
+          build-args: |
+            GESTALT_VERSION=${{ github.sha }}
+            GESTALT_REVISION=${{ github.sha }}
+            GESTALT_CREATED=${{ steps.meta.outputs.created }}
+            GESTALT_SOURCE=${{ env.IMAGE_SOURCE }}
+            GESTALT_DOCUMENTATION=${{ env.IMAGE_DOCUMENTATION }}
+            GESTALT_URL=${{ env.IMAGE_URL }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAME }}
+          short-description: Self-hosted integration runtime for REST, GraphQL, MCP, and plugins.
+          readme-filepath: .github/dockerhub-gestaltd-description.md

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -151,7 +151,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: Dockerfile.gestaltd
+          file: Dockerfile
           target: builder
           push: true
           platforms: linux/amd64,linux/arm64
@@ -171,7 +171,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: Dockerfile.gestaltd
+          file: Dockerfile
           target: debug
           push: true
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -108,28 +108,93 @@ jobs:
     name: Publish Docker Image
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      IMAGE_NAME: valontechnologies/gestaltd
+      IMAGE_SOURCE: https://github.com/${{ github.repository }}
+      IMAGE_DOCUMENTATION: https://gestalt.run
+      IMAGE_URL: https://hub.docker.com/r/valontechnologies/gestaltd
     steps:
       - uses: actions/checkout@v4
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Compute image metadata
+        id: meta
+        run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v5
+      - name: Build and push runtime image
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile
+          target: runtime
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            valontechnologies/gestaltd:${{ steps.version.outputs.version }}
-            valontechnologies/gestaltd:latest
+            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+            ${{ env.IMAGE_NAME }}:latest
+          build-args: |
+            GESTALT_VERSION=${{ steps.version.outputs.version }}
+            GESTALT_REVISION=${{ github.sha }}
+            GESTALT_CREATED=${{ steps.meta.outputs.created }}
+            GESTALT_SOURCE=${{ env.IMAGE_SOURCE }}
+            GESTALT_DOCUMENTATION=${{ env.IMAGE_DOCUMENTATION }}
+            GESTALT_URL=${{ env.IMAGE_URL }}
           cache-from: type=gha
           cache-to: type=gha,mode=min
+      - name: Build and push builder image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.gestaltd
+          target: builder
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.IMAGE_NAME }}:builder
+            ${{ env.IMAGE_NAME }}:builder-${{ steps.version.outputs.version }}
+          build-args: |
+            GESTALT_VERSION=${{ steps.version.outputs.version }}
+            GESTALT_REVISION=${{ github.sha }}
+            GESTALT_CREATED=${{ steps.meta.outputs.created }}
+            GESTALT_SOURCE=${{ env.IMAGE_SOURCE }}
+            GESTALT_DOCUMENTATION=${{ env.IMAGE_DOCUMENTATION }}
+            GESTALT_URL=${{ env.IMAGE_URL }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+      - name: Build and push debug image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.gestaltd
+          target: debug
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.IMAGE_NAME }}:debug
+            ${{ env.IMAGE_NAME }}:debug-${{ steps.version.outputs.version }}
+          build-args: |
+            GESTALT_VERSION=${{ steps.version.outputs.version }}
+            GESTALT_REVISION=${{ github.sha }}
+            GESTALT_CREATED=${{ steps.meta.outputs.created }}
+            GESTALT_SOURCE=${{ env.IMAGE_SOURCE }}
+            GESTALT_DOCUMENTATION=${{ env.IMAGE_DOCUMENTATION }}
+            GESTALT_URL=${{ env.IMAGE_URL }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAME }}
+          short-description: Self-hosted integration runtime for REST, GraphQL, MCP, and plugins.
+          readme-filepath: .github/dockerhub-gestaltd-description.md
 
   update-formula:
     name: Update Homebrew Formula

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+ARG GESTALT_VERSION=dev
+ARG GESTALT_REVISION=unknown
+ARG GESTALT_CREATED=unknown
+ARG GESTALT_SOURCE=https://github.com/valon-technologies/gestalt
+ARG GESTALT_DOCUMENTATION=https://gestalt.run
+ARG GESTALT_URL=https://hub.docker.com/r/valontechnologies/gestaltd
+
 FROM --platform=$BUILDPLATFORM node:20-alpine AS frontend
 WORKDIR /web
 COPY web/package.json web/package-lock.json ./
@@ -5,7 +12,7 @@ RUN npm ci
 COPY web/ .
 RUN npm run build
 
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build-binary
 WORKDIR /build
 COPY go.mod go.sum ./
 COPY sdk/pluginapi/go.mod sdk/pluginapi/go.sum sdk/pluginapi/
@@ -18,8 +25,63 @@ COPY --from=frontend /web/out/ internal/webui/out/
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /gestaltd ./cmd/gestaltd
 
-FROM gcr.io/distroless/static-debian12
-COPY --from=builder /gestaltd /gestaltd
+FROM golang:1.26-alpine AS builder
+ARG GESTALT_VERSION
+ARG GESTALT_REVISION
+ARG GESTALT_CREATED
+ARG GESTALT_SOURCE
+ARG GESTALT_DOCUMENTATION
+ARG GESTALT_URL
+RUN apk add --no-cache ca-certificates git
+COPY --from=build-binary /gestaltd /gestaltd
+RUN ln -sf /gestaltd /usr/local/bin/gestaltd
+WORKDIR /src
+LABEL org.opencontainers.image.title="gestaltd builder" \
+      org.opencontainers.image.description="Build image for packaging plugins and bundling Gestalt deployments." \
+      org.opencontainers.image.source="${GESTALT_SOURCE}" \
+      org.opencontainers.image.documentation="${GESTALT_DOCUMENTATION}" \
+      org.opencontainers.image.url="${GESTALT_URL}" \
+      org.opencontainers.image.version="${GESTALT_VERSION}" \
+      org.opencontainers.image.revision="${GESTALT_REVISION}" \
+      org.opencontainers.image.created="${GESTALT_CREATED}"
+
+FROM alpine:3.21 AS debug
+ARG GESTALT_VERSION
+ARG GESTALT_REVISION
+ARG GESTALT_CREATED
+ARG GESTALT_SOURCE
+ARG GESTALT_DOCUMENTATION
+ARG GESTALT_URL
+RUN apk add --no-cache ca-certificates curl
+COPY --from=build-binary /gestaltd /gestaltd
+LABEL org.opencontainers.image.title="gestaltd debug" \
+      org.opencontainers.image.description="Debug image for gestaltd with a shell and troubleshooting tools." \
+      org.opencontainers.image.source="${GESTALT_SOURCE}" \
+      org.opencontainers.image.documentation="${GESTALT_DOCUMENTATION}" \
+      org.opencontainers.image.url="${GESTALT_URL}" \
+      org.opencontainers.image.version="${GESTALT_VERSION}" \
+      org.opencontainers.image.revision="${GESTALT_REVISION}" \
+      org.opencontainers.image.created="${GESTALT_CREATED}"
+EXPOSE 8080
+ENTRYPOINT ["/gestaltd"]
+CMD ["serve", "--locked", "--config", "/etc/gestalt/config.yaml"]
+
+FROM gcr.io/distroless/static-debian12 AS runtime
+ARG GESTALT_VERSION
+ARG GESTALT_REVISION
+ARG GESTALT_CREATED
+ARG GESTALT_SOURCE
+ARG GESTALT_DOCUMENTATION
+ARG GESTALT_URL
+COPY --from=build-binary /gestaltd /gestaltd
+LABEL org.opencontainers.image.title="gestaltd" \
+      org.opencontainers.image.description="Self-hosted integration runtime for REST, GraphQL, MCP, and plugins." \
+      org.opencontainers.image.source="${GESTALT_SOURCE}" \
+      org.opencontainers.image.documentation="${GESTALT_DOCUMENTATION}" \
+      org.opencontainers.image.url="${GESTALT_URL}" \
+      org.opencontainers.image.version="${GESTALT_VERSION}" \
+      org.opencontainers.image.revision="${GESTALT_REVISION}" \
+      org.opencontainers.image.created="${GESTALT_CREATED}"
 EXPOSE 8080
 ENTRYPOINT ["/gestaltd"]
 CMD ["serve", "--locked", "--config", "/etc/gestalt/config.yaml"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Gestalt is a unified API gateway for integrations. It loads a YAML config, conne
 gestaltd
 ```
 
-Bare `gestaltd` auto-generates a local config, boots with local auth and SQLite, and starts serving. No setup needed.
+Bare `gestaltd` auto-generates a local config, boots with `auth.provider: none` and SQLite, and starts serving. No setup needed.
 
 ## Production Deployment
 
@@ -31,13 +31,21 @@ gestaltd serve --locked --config ./bundle/config.yaml
 
 ## Docker
 
+The published `valontechnologies/gestaltd` image:
+
+- exposes port `8080`
+- serves the API, embedded UI, `/health`, `/ready`, and `/mcp`
+- defaults to `serve --locked --config /etc/gestalt/config.yaml`
+- expects you to mount or bake a config file before startup
+- also publishes `:builder` and `:debug` variants
+
 ```dockerfile
-FROM valontechnologies/gestaltd:latest AS build
+FROM valontechnologies/gestaltd:builder AS bundle
 COPY config.yaml /src/config.yaml
 RUN ["/gestaltd", "bundle", "--config", "/src/config.yaml", "--output", "/app"]
 
 FROM valontechnologies/gestaltd:latest
-COPY --from=build /app/ /app/
+COPY --from=bundle /app/ /app/
 CMD ["serve", "--locked", "--config", "/app/config.yaml"]
 ```
 

--- a/deploy/helm/gestalt/templates/NOTES.txt
+++ b/deploy/helm/gestalt/templates/NOTES.txt
@@ -48,7 +48,7 @@ The default auth provider is Google. Provide these for Google OAuth:
 For OIDC, override config.auth.provider and config.auth.config in your values file.
 {{- if .Values.pluginInit.enabled }}
 
-Plugin init is enabled. An init container runs `gestaltd init` before
-the main server starts, hydrating plugin packages into a shared cache.
+Plugin init is enabled. An init container runs `gestaltd bundle` before
+the main server starts, preparing locked state in a shared volume.
 The main container runs with --locked to prevent mutation at startup.
 {{- end }}

--- a/deploy/helm/gestalt/templates/deployment.yaml
+++ b/deploy/helm/gestalt/templates/deployment.yaml
@@ -49,11 +49,13 @@ spec:
               type: RuntimeDefault
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["/bin/sh", "-c"]
+          command: ["/gestaltd"]
           args:
-            - |
-              cp /etc/gestalt-config/config.yaml /etc/gestalt/config.yaml
-              /gestaltd init --config /etc/gestalt/config.yaml
+            - bundle
+            - --config
+            - /etc/gestalt-config/config.yaml
+            - --output
+            - /etc/gestalt
           {{- with .Values.extraEnv }}
           env:
             {{- toYaml . | nindent 12 }}

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -4,9 +4,20 @@ Gestalt has pluggable platform authentication. Configure it under `auth:` in `co
 
 ## Available Providers
 
+### `none`
+
+Use `none` when you want Gestalt to skip platform authentication entirely.
+
+```yaml
+auth:
+  provider: none
+```
+
+Every request is treated as coming from a single anonymous user.
+
 ### `local`
 
-The built-in local provider is the simplest way to run Gestalt without any external identity system.
+The built-in local provider is the simplest authenticated way to run Gestalt without any external identity system.
 
 ```yaml
 auth:
@@ -63,6 +74,7 @@ auth:
 
 | Field | Provider | Notes |
 | --- | --- | --- |
+| none | `none` | No provider-specific config. |
 | `email` | `local` | Optional local-login email. |
 | `client_id` | `google`, `oidc` | OAuth client ID. |
 | `client_secret` | `google`, `oidc` | OAuth client secret. |

--- a/docs/pages/concepts/authentication-and-tokens.mdx
+++ b/docs/pages/concepts/authentication-and-tokens.mdx
@@ -9,17 +9,29 @@ Keeping those layers separate is one of the core design choices in `gestaltd`.
 
 ## Platform Auth Providers
 
-Gestalt currently ships three platform auth providers:
+Gestalt currently ships four platform auth providers:
 
 | Provider | When to use it |
 | --- | --- |
+| `none` | Local development, demos, or simple single-user deployments with no sign-in. |
 | `local` | Local development, no external identity provider required. |
 | `google` | Google Workspace or Google account login. |
 | `oidc` | Any OIDC-compatible provider such as Okta, Auth0, Azure AD, or Keycloak. |
 
+### `none`
+
+`none` is the auth provider used by the auto-generated out-of-the-box config.
+
+```yaml
+auth:
+  provider: none
+```
+
+All requests are treated as coming from a single anonymous user.
+
 ### `local`
 
-`local` is the auth provider used by the auto-generated out-of-the-box config.
+`local` is the simplest built-in authenticated provider.
 
 ```yaml
 auth:

--- a/docs/pages/concepts/configuration.mdx
+++ b/docs/pages/concepts/configuration.mdx
@@ -11,7 +11,7 @@ When you do not pass `--config`, `gestaltd` resolves the config path in this ord
 3. `~/.gestalt/config.yaml`
 4. `/etc/gestalt/config.yaml`
 
-The default command `gestaltd` has one extra behavior: if no config exists anywhere in that search path, it generates `~/.gestalt/config.yaml` and starts with a local-only configuration.
+The default command `gestaltd` has one extra behavior: if no config exists anywhere in that search path, it generates `~/.gestalt/config.yaml` and starts with a local-only configuration that uses `auth.provider: none` and SQLite.
 
 ## What Happens During Load
 
@@ -46,7 +46,7 @@ Each block controls a distinct part of the runtime:
 
 | Block | What it defines |
 | --- | --- |
-| `server` | Port, base URL, encryption key, dev mode, and admin email allowlist. |
+| `server` | Port, base URL, and encryption key. |
 | `auth` | How users authenticate to Gestalt itself. |
 | `datastore` | Where Gestalt stores users, tokens, and related runtime state. |
 | `secrets` | How `secret://...` values are resolved. |

--- a/docs/pages/concepts/integrations.mdx
+++ b/docs/pages/concepts/integrations.mdx
@@ -24,8 +24,8 @@ integrations:
       openapi: https://raw.githubusercontent.com/.../api.github.com.json
       connection: default
       allowed_operations:
-        repos_listForAuthenticatedUser: List repositories
-        issues_listForAuthenticatedUser: List assigned issues
+        repos/list-for-authenticated-user:
+        issues/list-for-authenticated-user:
 ```
 
 This one block answers four questions:
@@ -99,7 +99,7 @@ api:
   openapi: https://example.com/openapi.json
   connection: default
   allowed_operations:
-    listThings: List things
+    listThings:
 ```
 
 | Field | Notes |
@@ -108,7 +108,7 @@ api:
 | `openapi` | Required when `type: rest`. URL or local path to an OpenAPI document. |
 | `url` | Required when `type: graphql`. The GraphQL endpoint URL. |
 | `connection` | Name of a connection defined in the same integration. |
-| `allowed_operations` | Narrows exposed operations. List of names or map of name to description override. |
+| `allowed_operations` | Narrows exposed operations. Use a YAML map where each key is an operation name. Set the value to nothing to keep the upstream description, or provide an object with `alias` and/or `description`. |
 
 ### `mcp`
 
@@ -164,19 +164,21 @@ It supports two forms:
 
 ```yaml
 allowed_operations:
-  - repos_listForAuthenticatedUser
-  - issues_listForAuthenticatedUser
+  repos/list-for-authenticated-user:
+  issues/list-for-authenticated-user:
 ```
 
 or:
 
 ```yaml
 allowed_operations:
-  repos_listForAuthenticatedUser: List repositories
-  issues_listForAuthenticatedUser: List assigned issues
+  repos/list-for-authenticated-user:
+    description: List repositories
+  issues/list-for-authenticated-user:
+    description: List assigned issues
 ```
 
-The list form keeps upstream descriptions. The map form lets you override descriptions.
+The bare-key form keeps upstream descriptions. The object form lets you override descriptions or aliases.
 
 If you omit `allowed_operations`, Gestalt exposes every operation from the source.
 

--- a/docs/pages/concepts/mcp-binding.mdx
+++ b/docs/pages/concepts/mcp-binding.mdx
@@ -24,8 +24,8 @@ integrations:
       openapi: https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json
       connection: default
       allowed_operations:
-        - repos_listForAuthenticatedUser
-        - issues_listForAuthenticatedUser
+        repos/list-for-authenticated-user:
+        issues/list-for-authenticated-user:
 ```
 
 ## Import Tools From An Upstream MCP Server

--- a/docs/pages/deploy/index.mdx
+++ b/docs/pages/deploy/index.mdx
@@ -30,13 +30,13 @@ The repository ships these deployment assets:
 | Path | What it gives you |
 | --- | --- |
 | `gestaltd` with no config | True out-of-the-box local startup. |
-| `Dockerfile` | Single-container image with `gestaltd` as the entrypoint. |
+| `Dockerfile.gestaltd` | Single-container server image with `gestaltd` as the entrypoint. |
 | `docker-compose.yml` | Single-container local deployment with mounted config and SQLite volume. |
 | `deploy/helm/gestalt` | Helm chart for Kubernetes. |
 
 ## Docker And Compose
 
-The root `Dockerfile` builds:
+`Dockerfile.gestaltd` builds:
 
 - the frontend static export
 - the `gestaltd` binary
@@ -45,12 +45,19 @@ The root `Dockerfile` builds:
 The image defaults to:
 
 ```sh
-/gestaltd --config /etc/gestalt/config.yaml
+/gestaltd serve --locked --config /etc/gestalt/config.yaml
 ```
 
-That is a mutable-startup path. If you want locked startup, override the command and make sure the lockfile and prepared artifacts exist next to the mounted config.
+That means the published image expects a config mounted or baked at `/etc/gestalt/config.yaml` and starts in locked mode by default.
 
-The bundled `docker-compose.yml` is the quickest containerized path:
+If your config is static and does not require prepared artifacts, that works directly.
+
+If your config depends on remote REST or GraphQL upstreams, or packaged plugins, run `gestaltd bundle` ahead of time and either:
+
+- bake the bundled output into a derived image
+- or prepare it in a separate init or release step and point `serve --locked` at that bundled config
+
+The bundled `docker-compose.yml` is the quickest repo-local containerized path:
 
 ```sh
 docker compose up --build
@@ -60,6 +67,8 @@ It mounts:
 
 - `./deploy/docker/config.yaml` to `/etc/gestalt/config.yaml`
 - a named volume at `/data` for SQLite
+
+For published-image examples rather than repo-local source builds, see `examples/deploy/`.
 
 ## Bare Binary
 

--- a/docs/pages/deploy/index.mdx
+++ b/docs/pages/deploy/index.mdx
@@ -30,13 +30,13 @@ The repository ships these deployment assets:
 | Path | What it gives you |
 | --- | --- |
 | `gestaltd` with no config | True out-of-the-box local startup. |
-| `Dockerfile.gestaltd` | Single-container server image with `gestaltd` as the entrypoint. |
+| `Dockerfile` | Single-container server image with `gestaltd` as the entrypoint. |
 | `docker-compose.yml` | Single-container local deployment with mounted config and SQLite volume. |
 | `deploy/helm/gestalt` | Helm chart for Kubernetes. |
 
 ## Docker And Compose
 
-`Dockerfile.gestaltd` builds:
+`Dockerfile` builds:
 
 - the frontend static export
 - the `gestaltd` binary

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -24,6 +24,8 @@ The `valontechnologies/gestaltd` image ships `gestaltd` and supports both `amd64
 docker run -p 8080:8080 -v ./gestalt.yaml:/etc/gestalt/config.yaml valontechnologies/gestaltd:latest
 ```
 
+The container starts with `serve --locked` by default. That direct mount pattern works for static configs that do not require prepared artifacts. If your config references remote OpenAPI or GraphQL sources, or `plugin.package`, bundle first or bake the prepared state into a derived image.
+
 ## 1. Run `gestaltd` With No Config
 
 ```sh
@@ -77,19 +79,16 @@ datastore:
     path: ./gestalt.db
 
 integrations:
-  petstore:
-    display_name: Swagger Petstore
-    description: Public example API
+  github:
+    display_name: GitHub REST API
+    description: Public GitHub REST surface
     connections:
       default:
         mode: none
     api:
       type: rest
-      openapi: https://petstore3.swagger.io/api/v3/openapi.json
+      openapi: https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json
       connection: default
-      allowed_operations:
-        findPetsByStatus: List pets by status
-        getPetById: Fetch a pet by id
 ```
 
 This is the smallest useful production-shaped config:
@@ -109,7 +108,7 @@ gestaltd validate --config ./bundle/gestalt.yaml
 `bundle` resolves remote provider inputs into a self-contained output directory. For the config above, the bundle contains:
 
 - `gestalt.lock.json`
-- `.gestalt/providers/petstore.json`
+- `.gestalt/providers/github.json`
 
 ## 5. Start From Locked State
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -11,7 +11,7 @@ import { Cards, Steps } from 'nextra/components'
 | `gestaltd` | The server binary. It loads config, bootstraps plugins, serves the HTTP API, serves the web UI, and mounts `/mcp` when MCP is enabled. |
 | `config.yaml` | The declarative control plane. This is where you define auth, datastore, secrets, integrations, runtimes, bindings, and egress policy. |
 | `gestalt.lock.json` and `.gestalt/` | Optional prepared state written by `gestaltd bundle`. Use it for deterministic startup when you depend on remote OpenAPI, GraphQL, or packaged plugins. |
-| Deploy assets | A Dockerfile, `docker-compose.yml`, and a Helm chart for the bundled deployment paths. |
+| Deploy assets | `Dockerfile.gestaltd`, `Dockerfile.gestalt`, `docker-compose.yml`, and a Helm chart for the bundled deployment paths. |
 
 ## The Four Foundations
 
@@ -37,7 +37,7 @@ The same provider graph can be reached through the HTTP API, the embedded web UI
 
 There are four real deployment modes to think about:
 
-1. `gestaltd` with no config: local-only, auto-generated config, local auth, SQLite, dev mode on.
+1. `gestaltd` with no config: local-only, auto-generated config, `auth.provider: none`, SQLite, and a generated encryption key.
 2. Docker or Docker Compose: single container, single HTTP port, config mounted into `/etc/gestalt/config.yaml`.
 3. Helm on Kubernetes: one Deployment for `gestaltd`, optional init container for locked startup.
 4. Bare binary: `gestaltd`, `gestaltd serve`, `gestaltd bundle`, and `gestaltd validate`.

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -11,7 +11,7 @@ import { Cards, Steps } from 'nextra/components'
 | `gestaltd` | The server binary. It loads config, bootstraps plugins, serves the HTTP API, serves the web UI, and mounts `/mcp` when MCP is enabled. |
 | `config.yaml` | The declarative control plane. This is where you define auth, datastore, secrets, integrations, runtimes, bindings, and egress policy. |
 | `gestalt.lock.json` and `.gestalt/` | Optional prepared state written by `gestaltd bundle`. Use it for deterministic startup when you depend on remote OpenAPI, GraphQL, or packaged plugins. |
-| Deploy assets | `Dockerfile.gestaltd`, `Dockerfile.gestalt`, `docker-compose.yml`, and a Helm chart for the bundled deployment paths. |
+| Deploy assets | `Dockerfile`, `client/Dockerfile`, `docker-compose.yml`, and a Helm chart for the bundled deployment paths. |
 
 ## The Four Foundations
 

--- a/docs/pages/reference/built-in-plugins.mdx
+++ b/docs/pages/reference/built-in-plugins.mdx
@@ -6,8 +6,9 @@ This page lists the components that the `gestaltd` binary actually registers tod
 
 | Name | Notes |
 | --- | --- |
+| `none` | No-auth mode used by the generated no-config startup path. |
 | `google` | Google OAuth login for the Gestalt platform. |
-| `local` | Local-only auth provider used by the generated no-config startup path. |
+| `local` | Built-in authenticated provider for local development without an external identity system. |
 | `oidc` | Generic OIDC platform auth provider. |
 
 ## Datastores

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -11,7 +11,7 @@ gestaltd [--config PATH]
 gestaltd plugin <command> [flags]
 gestaltd serve [--config PATH] [--locked]
 gestaltd bundle --config PATH --output DIR
-gestaltd validate [--config PATH]
+gestaltd validate [--config PATH] [--init]
 ```
 
 ## Command Meanings
@@ -35,10 +35,10 @@ The plain `gestaltd` command has one extra convenience feature:
 
 That generated config is intentionally local-only:
 
-- `local` auth
+- `none` auth
 - SQLite
 - `env` secrets
-- dev mode enabled
+- a generated `server.encryption_key`
 
 ## Config Path Resolution
 

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -21,6 +21,7 @@ ui: {}
 Before you get into individual fields, these global rules matter:
 
 - `${ENV_VAR}` expansion happens before YAML decode
+- if `${ENV_VAR}` is unset and `ENV_VAR_FILE` exists, Gestalt reads the value from that file
 - unknown YAML fields are rejected
 - `server.port` defaults to `8080`
 - `secrets.provider` defaults to `env`
@@ -43,6 +44,15 @@ server:
 | `encryption_key` | yes | Root deployment secret used for encryption and derived session material. |
 
 ## `auth`
+
+### `none`
+
+```yaml
+auth:
+  provider: none
+```
+
+`none` disables platform authentication entirely. Every request is treated as coming from a single anonymous user. That is useful for local development, demos, and simple single-user setups.
 
 ### `local`
 
@@ -182,8 +192,8 @@ integrations:
       openapi: https://raw.githubusercontent.com/.../api.github.com.json
       connection: default
       allowed_operations:
-        repos_listForAuthenticatedUser: List repositories
-        issues_listForAuthenticatedUser: List issues
+        repos/list-for-authenticated-user:
+        issues/list-for-authenticated-user:
 ```
 
 | Field | Notes |
@@ -226,7 +236,7 @@ api:
   openapi: https://example.com/openapi.json
   connection: default
   allowed_operations:
-    listThings: List things
+    listThings:
 ```
 
 | Field | Notes |
@@ -235,7 +245,7 @@ api:
 | `openapi` | Required when `type: rest`. URL or local path to an OpenAPI document. |
 | `url` | Required when `type: graphql`. The GraphQL endpoint URL. |
 | `connection` | References a named connection in the same integration. |
-| `allowed_operations` | Either a YAML list of names or a YAML map of name to description override. |
+| `allowed_operations` | YAML map of operation name to an optional override object. Use a bare key to keep the upstream description. |
 
 ### `mcp`
 

--- a/docs/pages/tasks/add-an-integration.mdx
+++ b/docs/pages/tasks/add-an-integration.mdx
@@ -19,18 +19,15 @@ Public REST example with no auth:
 
 ```yaml
 integrations:
-  petstore:
-    display_name: Swagger Petstore
+  github:
+    display_name: GitHub
     connections:
       default:
         mode: none
     api:
       type: rest
-      openapi: https://petstore3.swagger.io/api/v3/openapi.json
+      openapi: https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json
       connection: default
-      allowed_operations:
-        findPetsByStatus: List pets by status
-        getPetById: Fetch a pet by id
 ```
 
 That is enough to build a real provider and invoke the public API.
@@ -56,8 +53,8 @@ integrations:
       openapi: https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json
       connection: default
       allowed_operations:
-        repos_listForAuthenticatedUser: List repositories
-        issues_listForAuthenticatedUser: List issues
+        repos/list-for-authenticated-user:
+        issues/list-for-authenticated-user:
 ```
 
 Auth lives inside the connection, not at the integration level or in a separate profile.

--- a/docs/pages/tasks/run-locally.mdx
+++ b/docs/pages/tasks/run-locally.mdx
@@ -12,10 +12,10 @@ gestaltd
 
 If no config exists, `gestaltd` generates `~/.gestalt/config.yaml` and starts a local environment with:
 
-- `local` auth
+- `none` auth
 - SQLite
 - `env` secrets
-- dev mode on
+- a generated `server.encryption_key`
 
 The server and embedded UI are both available at `http://localhost:8080`.
 

--- a/docs/pages/tasks/use-with-mcp.mdx
+++ b/docs/pages/tasks/use-with-mcp.mdx
@@ -24,8 +24,8 @@ integrations:
       openapi: https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json
       connection: default
       allowed_operations:
-        repos_listForAuthenticatedUser: List repositories
-        issues_listForAuthenticatedUser: List assigned issues
+        repos/list-for-authenticated-user:
+        issues/list-for-authenticated-user:
 ```
 
 `mcp_tool_prefix` controls tool naming so that tools from different integrations do not collide.

--- a/examples/deploy/Dockerfile
+++ b/examples/deploy/Dockerfile
@@ -1,7 +1,7 @@
-FROM valontechnologies/gestaltd:latest AS build
+FROM valontechnologies/gestaltd:builder AS bundle
 COPY config.yaml /src/config.yaml
 RUN ["/gestaltd", "bundle", "--config", "/src/config.yaml", "--output", "/app"]
 
 FROM valontechnologies/gestaltd:latest
-COPY --from=build /app/ /app/
+COPY --from=bundle /app/ /app/
 CMD ["serve", "--locked", "--config", "/app/config.yaml"]

--- a/examples/deploy/Dockerfile.plugins
+++ b/examples/deploy/Dockerfile.plugins
@@ -11,17 +11,10 @@
 #
 # Build:
 #   docker build -f Dockerfile.plugins --secret id=github_token,src=token.txt .
-#
-# Once a gestalt:builder image is available, the first stage simplifies to:
-#   FROM valontechnologies/gestalt:builder AS build
 
-FROM golang:1.26-alpine AS build
-RUN apk add --no-cache git
+FROM valontechnologies/gestaltd:builder AS build
 WORKDIR /src
 COPY . .
-
-# Copy gestaltd from the runtime image so we can run plugin package + bundle.
-COPY --from=valontechnologies/gestaltd:latest /gestaltd /usr/local/bin/gestaltd
 
 # Build plugin binaries, package them as archives, and bundle everything.
 RUN --mount=type=secret,id=github_token \

--- a/examples/deploy/README.md
+++ b/examples/deploy/README.md
@@ -1,0 +1,8 @@
+# Docker deployment examples
+
+This directory contains published-image examples for `valontechnologies/gestaltd`.
+
+- `config.yaml`: minimal static config that works with the default image command
+- `compose.yaml`: simplest `docker compose` example using the published image
+- `Dockerfile`: multi-stage example that bundles config during the image build
+- `Dockerfile.plugins`: multi-stage example that compiles Go plugins with `valontechnologies/gestaltd:builder`, packages them, and bundles the deployment

--- a/examples/deploy/compose.yaml
+++ b/examples/deploy/compose.yaml
@@ -1,0 +1,11 @@
+services:
+  gestaltd:
+    image: valontechnologies/gestaltd:latest
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./config.yaml:/etc/gestalt/config.yaml:ro
+      - gestalt-data:/data
+
+volumes:
+  gestalt-data:

--- a/examples/deploy/config-plugins.yaml
+++ b/examples/deploy/config-plugins.yaml
@@ -1,7 +1,7 @@
 server:
   port: 8080
   base_url: ${GESTALT_BASE_URL}
-  encryption_key: ${ENCRYPTION_KEY}
+  encryption_key: ${GESTALT_ENCRYPTION_KEY}
 
 auth:
   provider: google

--- a/examples/deploy/config.yaml
+++ b/examples/deploy/config.yaml
@@ -1,0 +1,13 @@
+server:
+  port: 8080
+  encryption_key: example-not-for-production
+
+auth:
+  provider: none
+
+datastore:
+  provider: sqlite
+  config:
+    path: /data/gestalt.db
+
+integrations: {}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -217,16 +217,26 @@ type MCPDef struct {
 }
 
 func Load(path string) (*Config, error) {
-	return LoadWithMapping(path, os.Getenv)
+	return LoadWithLookup(path, os.LookupEnv)
 }
 
 func LoadWithMapping(path string, getenv func(string) string) (*Config, error) {
+	return LoadWithLookup(path, func(key string) (string, bool) {
+		val := getenv(key)
+		return val, val != ""
+	})
+}
+
+func LoadWithLookup(path string, lookup func(string) (string, bool)) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading config file: %w", err)
 	}
 
-	resolved := os.Expand(string(data), getenv)
+	resolved, err := expandEnvVariables(string(data), lookup)
+	if err != nil {
+		return nil, err
+	}
 
 	var cfg Config
 	dec := yaml.NewDecoder(strings.NewReader(resolved))
@@ -244,6 +254,32 @@ func LoadWithMapping(path string, getenv func(string) string) (*Config, error) {
 	}
 
 	return &cfg, nil
+}
+
+func expandEnvVariables(input string, lookup func(string) (string, bool)) (string, error) {
+	var expandErr error
+	resolved := os.Expand(input, func(key string) string {
+		if expandErr != nil {
+			return ""
+		}
+		if val, ok := lookup(key); ok {
+			return val
+		}
+		filePath, ok := lookup(key + "_FILE")
+		if !ok || filePath == "" {
+			return ""
+		}
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			expandErr = fmt.Errorf("resolving %s_FILE: %w", key, err)
+			return ""
+		}
+		return strings.TrimRight(string(data), "\r\n")
+	})
+	if expandErr != nil {
+		return "", fmt.Errorf("expanding config environment variables: %w", expandErr)
+	}
+	return resolved, nil
 }
 
 func applyDefaults(cfg *Config) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -222,8 +222,9 @@ func Load(path string) (*Config, error) {
 
 func LoadWithMapping(path string, getenv func(string) string) (*Config, error) {
 	return LoadWithLookup(path, func(key string) (string, bool) {
-		val := getenv(key)
-		return val, val != ""
+		// Preserve the legacy os.Expand-style contract for callers that only
+		// provide a string mapping: the mapped value wins even when it is empty.
+		return getenv(key), true
 	})
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -149,6 +149,106 @@ integrations:
 	}
 }
 
+func TestLoadConfigEnvFileFallback(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	secretPath := filepath.Join(dir, "encryption-key")
+	if err := os.WriteFile(secretPath, []byte("file-based-secret\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile secret: %v", err)
+	}
+
+	path := mustWriteConfigFile(t, `
+auth:
+  provider: auth-provider
+datastore:
+  provider: data-store
+server:
+  encryption_key: ${TEST_ENCRYPTION}
+`)
+
+	cfg, err := LoadWithLookup(path, func(key string) (string, bool) {
+		switch key {
+		case "TEST_ENCRYPTION_FILE":
+			return secretPath, true
+		default:
+			return "", false
+		}
+	})
+	if err != nil {
+		t.Fatalf("LoadWithLookup: %v", err)
+	}
+
+	if cfg.Server.EncryptionKey != "file-based-secret" {
+		t.Fatalf("Server.EncryptionKey = %q, want file-based-secret", cfg.Server.EncryptionKey)
+	}
+}
+
+func TestLoadConfigEnvValueOverridesFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	secretPath := filepath.Join(dir, "encryption-key")
+	if err := os.WriteFile(secretPath, []byte("file-based-secret\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile secret: %v", err)
+	}
+
+	path := mustWriteConfigFile(t, `
+auth:
+  provider: auth-provider
+datastore:
+  provider: data-store
+server:
+  encryption_key: ${TEST_ENCRYPTION}
+`)
+
+	cfg, err := LoadWithLookup(path, func(key string) (string, bool) {
+		switch key {
+		case "TEST_ENCRYPTION":
+			return "env-secret", true
+		case "TEST_ENCRYPTION_FILE":
+			return secretPath, true
+		default:
+			return "", false
+		}
+	})
+	if err != nil {
+		t.Fatalf("LoadWithLookup: %v", err)
+	}
+
+	if cfg.Server.EncryptionKey != "env-secret" {
+		t.Fatalf("Server.EncryptionKey = %q, want env-secret", cfg.Server.EncryptionKey)
+	}
+}
+
+func TestLoadConfigEnvFileReadError(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+auth:
+  provider: auth-provider
+datastore:
+  provider: data-store
+server:
+  encryption_key: ${TEST_ENCRYPTION}
+`)
+
+	_, err := LoadWithLookup(path, func(key string) (string, bool) {
+		switch key {
+		case "TEST_ENCRYPTION_FILE":
+			return "/does/not/exist", true
+		default:
+			return "", false
+		}
+	})
+	if err == nil {
+		t.Fatal("expected error for unreadable *_FILE path")
+	}
+	if !strings.Contains(err.Error(), "TEST_ENCRYPTION_FILE") {
+		t.Fatalf("expected *_FILE context in error, got: %v", err)
+	}
+}
+
 func TestLoadConfigBaseURLResolvesRedirectURL(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -249,6 +249,37 @@ server:
 	}
 }
 
+func TestLoadWithMappingEmptyValueDoesNotFallbackToFile(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+auth:
+  provider: auth-provider
+datastore:
+  provider: data-store
+server:
+  encryption_key: server-key
+  base_url: ${TEST_BASE_URL}
+`)
+
+	cfg, err := LoadWithMapping(path, func(key string) string {
+		switch key {
+		case "TEST_BASE_URL":
+			return ""
+		case "TEST_BASE_URL_FILE":
+			return "/tmp/should-not-be-used"
+		default:
+			return ""
+		}
+	})
+	if err != nil {
+		t.Fatalf("LoadWithMapping: %v", err)
+	}
+	if cfg.Server.BaseURL != "" {
+		t.Fatalf("Server.BaseURL = %q, want empty string", cfg.Server.BaseURL)
+	}
+}
+
 func TestLoadConfigBaseURLResolvesRedirectURL(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/verify-external-authoring.sh
+++ b/scripts/verify-external-authoring.sh
@@ -112,11 +112,11 @@ integrations:
         prefix: "verified:"
 CFG
 
-echo "=== running init ==="
-"$GESTALTD" init --config "$WORK/config.yaml"
+echo "=== bundling config ==="
+"$GESTALTD" bundle --config "$WORK/config.yaml" --output "$WORK/bundle"
 
 echo "=== starting serve --locked ==="
-"$GESTALTD" serve --locked --config "$WORK/config.yaml" &
+"$GESTALTD" serve --locked --config "$WORK/bundle/config.yaml" &
 SERVER_PID=$!
 
 echo "=== polling health ==="


### PR DESCRIPTION
## Summary
- add a Docker Hub description source for `valontechnologies/gestaltd` and sync it from the publish/release workflows
- add `builder` and `debug` image targets plus OCI labels to `Dockerfile.gestaltd`
- align repo docs, examples, and Helm/plugin-init behavior with the real gestaltd container contract and `_FILE` env expansion support

## Notes
- This PR is intentionally stacked on #286 / `docker-image-split` because it depends on the server image being published as `valontechnologies/gestaltd`.
- I kept the docs codebase-first and verified the command/runtime behavior against the current branch state.

## Verification
- `go test ./internal/config ./cmd/gestaltd`
- `go test ./internal/config -run 'TestLoadConfigEnv(FileFallback|ValueOverridesFile|FileReadError)$'`
- `go run ./cmd/gestaltd --help`
- `go run ./cmd/gestaltd validate --help`
- `go run ./cmd/gestaltd init --help` (fails as expected; `init` is still not a public subcommand)
- manual smoke test: static config starts under `serve --locked` and returns `200` on `/health` and `/ready`
- manual smoke test: remote OpenAPI config fails under `serve --locked` until bundled, then bundled config validates and starts successfully
- `docker version` / `docker build` could not be verified here because the local Docker daemon timed out in this environment

## Observed gap
- The public GitHub REST OpenAPI spec bundles successfully but still fails full validation because the compiler rejects a duplicate normalized parameter name (`actions/update-environment-variable`). That remains a real compatibility gap for large upstream specs.