### PR TITLE
Use `net/http` constants instead of magic strings and ints

### DIFF
--- a/core/http.go
+++ b/core/http.go
@@ -1,0 +1,3 @@
+package core
+
+const ContentTypeJSON = "application/json"

--- a/core/integration/catalog.go
+++ b/core/integration/catalog.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/core"
@@ -27,7 +28,7 @@ func OperationsList(c *catalog.Catalog) []core.Operation {
 		}
 		method := strings.ToUpper(strings.TrimSpace(op.Method))
 		if method == "" && op.Query != "" {
-			method = "POST"
+			method = http.MethodPost
 		}
 		ops = append(ops, core.Operation{
 			Name:        op.ID,

--- a/core/integration/catalog_test.go
+++ b/core/integration/catalog_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/core/catalog"
@@ -15,7 +16,7 @@ func TestCompileSchemasFillsInputSchema(t *testing.T) {
 		Operations: []catalog.CatalogOperation{
 			{
 				ID:     "op1",
-				Method: "GET",
+				Method: http.MethodGet,
 				Path:   "/test",
 				Parameters: []catalog.CatalogParameter{
 					{Name: "q", Type: "string", Description: "Query", Required: true},
@@ -54,7 +55,7 @@ func TestCompileSchemasPreservesExistingInputSchema(t *testing.T) {
 		Operations: []catalog.CatalogOperation{
 			{
 				ID:          "op1",
-				Method:      "POST",
+				Method:      http.MethodPost,
 				Path:        "/test",
 				InputSchema: existing,
 				Parameters: []catalog.CatalogParameter{
@@ -77,9 +78,9 @@ func TestCompileSchemasFillsAnnotations(t *testing.T) {
 	cat := &catalog.Catalog{
 		Name: "test",
 		Operations: []catalog.CatalogOperation{
-			{ID: "read", Method: "GET", Path: "/read"},
-			{ID: "write", Method: "POST", Path: "/write"},
-			{ID: "remove", Method: "DELETE", Path: "/remove"},
+			{ID: "read", Method: http.MethodGet, Path: "/read"},
+			{ID: "write", Method: http.MethodPost, Path: "/write"},
+			{ID: "remove", Method: http.MethodDelete, Path: "/remove"},
 		},
 	}
 
@@ -104,7 +105,7 @@ func TestCompileSchemasPreservesExistingAnnotations(t *testing.T) {
 		Operations: []catalog.CatalogOperation{
 			{
 				ID:     "op1",
-				Method: "GET",
+				Method: http.MethodGet,
 				Path:   "/test",
 				Annotations: catalog.OperationAnnotations{
 					ReadOnlyHint:  boolPtr(false),

--- a/core/integration/param_routing_test.go
+++ b/core/integration/param_routing_test.go
@@ -116,8 +116,8 @@ func TestFindCatalogOp_Found(t *testing.T) {
 	cat := &catalog.Catalog{
 		Name: "test",
 		Operations: []catalog.CatalogOperation{
-			{ID: "op_alpha", Method: "GET", Path: "/alpha"},
-			{ID: "op_beta", Method: "POST", Path: "/beta"},
+			{ID: "op_alpha", Method: http.MethodGet, Path: "/alpha"},
+			{ID: "op_beta", Method: http.MethodPost, Path: "/beta"},
 		},
 	}
 	got := findCatalogOp(cat, "op_beta")
@@ -141,7 +141,7 @@ func TestFindCatalogOp_NotFound(t *testing.T) {
 	cat := &catalog.Catalog{
 		Name: "test",
 		Operations: []catalog.CatalogOperation{
-			{ID: "op_alpha", Method: "GET", Path: "/alpha"},
+			{ID: "op_alpha", Method: http.MethodGet, Path: "/alpha"},
 		},
 	}
 	got := findCatalogOp(cat, "nonexistent")
@@ -173,7 +173,7 @@ func TestExecuteREST_CatalogQueryParam(t *testing.T) {
 		Operations: []catalog.CatalogOperation{
 			{
 				ID:     "create_item",
-				Method: "POST",
+				Method: http.MethodPost,
 				Path:   "/items",
 				Parameters: []catalog.CatalogParameter{
 					{Name: "name", Type: "string", Location: "body"},
@@ -359,7 +359,7 @@ func TestExecuteREST_CatalogHeaderParam(t *testing.T) {
 		Operations: []catalog.CatalogOperation{
 			{
 				ID:     "create_item",
-				Method: "POST",
+				Method: http.MethodPost,
 				Path:   "/items",
 				Parameters: []catalog.CatalogParameter{
 					{Name: "name", Type: "string", Location: "body"},

--- a/core/integration/schema.go
+++ b/core/integration/schema.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"encoding/json"
+	"net/http"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/core/catalog"
@@ -77,11 +78,11 @@ func AnnotationsFromMethod(method string) catalog.OperationAnnotations {
 		OpenWorldHint: boolPtr(true),
 	}
 	switch strings.ToUpper(method) {
-	case "GET", "HEAD":
+	case http.MethodGet, http.MethodHead:
 		a.ReadOnlyHint = boolPtr(true)
-	case "PUT":
+	case http.MethodPut:
 		a.IdempotentHint = boolPtr(true)
-	case "DELETE":
+	case http.MethodDelete:
 		a.DestructiveHint = boolPtr(true)
 	}
 	return a

--- a/core/integration/schema_test.go
+++ b/core/integration/schema_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/core/catalog"
@@ -130,12 +131,12 @@ func TestAnnotationsFromMethod(t *testing.T) {
 		wantIdempotent  *bool
 		wantDestructive *bool
 	}{
-		{"GET", boolPtr(true), nil, nil},
-		{"HEAD", boolPtr(true), nil, nil},
-		{"POST", nil, nil, nil},
-		{"PUT", nil, boolPtr(true), nil},
-		{"DELETE", nil, nil, boolPtr(true)},
-		{"PATCH", nil, nil, nil},
+		{http.MethodGet, boolPtr(true), nil, nil},
+		{http.MethodHead, boolPtr(true), nil, nil},
+		{http.MethodPost, nil, nil, nil},
+		{http.MethodPut, nil, boolPtr(true), nil},
+		{http.MethodDelete, nil, nil, boolPtr(true)},
+		{http.MethodPatch, nil, nil, nil},
 	}
 
 	for _, tc := range cases {

--- a/examples/plugins/provider-go/main.go
+++ b/examples/plugins/provider-go/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -30,7 +31,7 @@ func (p *exampleProvider) ListOperations() []pluginsdk.Operation {
 		{
 			Name:        "greet",
 			Description: "Return a greeting message",
-			Method:      "GET",
+			Method:      http.MethodGet,
 			Parameters: []pluginsdk.Parameter{
 				{Name: "name", Type: "string", Description: "Name to greet", Required: true},
 			},
@@ -38,7 +39,7 @@ func (p *exampleProvider) ListOperations() []pluginsdk.Operation {
 		{
 			Name:        "echo",
 			Description: "Echo back the input",
-			Method:      "POST",
+			Method:      http.MethodPost,
 			Parameters: []pluginsdk.Parameter{
 				{Name: "message", Type: "string", Description: "Message to echo", Required: true},
 			},
@@ -46,7 +47,7 @@ func (p *exampleProvider) ListOperations() []pluginsdk.Operation {
 		{
 			Name:        "status",
 			Description: "Return provider startup state",
-			Method:      "GET",
+			Method:      http.MethodGet,
 		},
 	}
 }
@@ -63,19 +64,19 @@ func (p *exampleProvider) Execute(_ context.Context, operation string, params ma
 			greeting = "Hello"
 		}
 		body, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("%s, %s!", greeting, name)})
-		return &pluginsdk.OperationResult{Status: 200, Body: string(body)}, nil
+		return &pluginsdk.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
 	case "echo":
 		msg, _ := params["message"].(string)
 		body, _ := json.Marshal(map[string]string{"echo": msg})
-		return &pluginsdk.OperationResult{Status: 200, Body: string(body)}, nil
+		return &pluginsdk.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
 	case "status":
 		body, _ := json.Marshal(map[string]string{
 			"name":     p.startedName,
 			"greeting": p.greeting,
 		})
-		return &pluginsdk.OperationResult{Status: 200, Body: string(body)}, nil
+		return &pluginsdk.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
 	default:
-		return &pluginsdk.OperationResult{Status: 404, Body: `{"error":"unknown operation"}`}, nil
+		return &pluginsdk.OperationResult{Status: http.StatusNotFound, Body: `{"error":"unknown operation"}`}, nil
 	}
 }
 

--- a/internal/apiexec/apiexec.go
+++ b/internal/apiexec/apiexec.go
@@ -111,7 +111,7 @@ func Do(ctx context.Context, client *http.Client, req Request) (*core.OperationR
 		}
 		contentType = req.ContentType
 		if contentType == "" {
-			contentType = "application/json"
+			contentType = core.ContentTypeJSON
 		}
 	}
 
@@ -213,7 +213,7 @@ func doOnce(
 		if err := req.CheckResponse(resp.StatusCode, respBody); err != nil {
 			return nil, resp.StatusCode, retryAfter, retryableStatusCodes[resp.StatusCode], err
 		}
-	} else if resp.StatusCode >= 400 {
+	} else if resp.StatusCode >= http.StatusBadRequest {
 		retryable := retryableStatusCodes[resp.StatusCode]
 		return nil, resp.StatusCode, retryAfter, retryable, fmt.Errorf("HTTP %d: %s", resp.StatusCode, respBody)
 	}
@@ -277,7 +277,7 @@ func DoGraphQL(ctx context.Context, client *http.Client, req GraphQLRequest) (*c
 	if err != nil {
 		return nil, fmt.Errorf("creating graphql request: %w", err)
 	}
-	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Content-Type", core.ContentTypeJSON)
 
 	if req.AuthHeader != "" {
 		httpReq.Header.Set("Authorization", req.AuthHeader)
@@ -300,7 +300,7 @@ func DoGraphQL(ctx context.Context, client *http.Client, req GraphQLRequest) (*c
 		return nil, fmt.Errorf("reading graphql response: %w", err)
 	}
 
-	if resp.StatusCode >= 400 {
+	if resp.StatusCode >= http.StatusBadRequest {
 		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, respBody)
 	}
 

--- a/internal/bootstrap/regression_test.go
+++ b/internal/bootstrap/regression_test.go
@@ -204,7 +204,7 @@ func TestEgressPolicyWiredThroughBootstrap(t *testing.T) {
 
 	resolve := func(path string) error {
 		_, err := receivedEgress.Resolver.Resolve(ctx, egress.ResolutionInput{
-			Target: egress.Target{Provider: "alpha", Method: "GET", Host: "api.test", Path: path},
+			Target: egress.Target{Provider: "alpha", Method: http.MethodGet, Host: "api.test", Path: path},
 		})
 		return err
 	}
@@ -302,7 +302,7 @@ func TestSecretBackedCredentialGrant_ConfigGrant(t *testing.T) {
 
 	agentCtx := egress.WithSubject(ctx, egress.Subject{Kind: egress.SubjectUser, ID: "user-1"})
 	resolution, err := receivedEgress.Resolver.Resolve(agentCtx, egress.ResolutionInput{
-		Target: egress.Target{Method: "GET", Host: "api.vendor.test", Path: "/v1/data"},
+		Target: egress.Target{Method: http.MethodGet, Host: "api.vendor.test", Path: "/v1/data"},
 	})
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
@@ -365,7 +365,7 @@ func TestSecretBackedCredentialGrant_MultiTenantHostMatching(t *testing.T) {
 	resolve := func(host string) string {
 		t.Helper()
 		res, err := receivedEgress.Resolver.Resolve(agentCtx, egress.ResolutionInput{
-			Target: egress.Target{Method: "GET", Host: host, Path: "/api/orders"},
+			Target: egress.Target{Method: http.MethodGet, Host: host, Path: "/api/orders"},
 		})
 		if err != nil {
 			t.Fatalf("Resolve(%s): %v", host, err)
@@ -451,7 +451,7 @@ func TestSecretBackedGrant_SecretURIPrefixStripped(t *testing.T) {
 
 	agentCtx := egress.WithSubject(ctx, egress.Subject{Kind: egress.SubjectUser, ID: "user-1"})
 	resolution, err := receivedEgress.Resolver.Resolve(agentCtx, egress.ResolutionInput{
-		Target: egress.Target{Method: "GET", Host: "api.prefix.test", Path: "/v1"},
+		Target: egress.Target{Method: http.MethodGet, Host: "api.prefix.test", Path: "/v1"},
 	})
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -24,7 +24,7 @@ func Run(ctx context.Context, cfg *core.DiscoveryConfig, client *http.Client) ([
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode >= 400 {
+	if resp.StatusCode >= http.StatusBadRequest {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return nil, fmt.Errorf("discovery request failed: HTTP %d: %s", resp.StatusCode, body)
 	}

--- a/internal/egress/credential_grant_validation_test.go
+++ b/internal/egress/credential_grant_validation_test.go
@@ -1,6 +1,7 @@
 package egress
 
 import (
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -41,7 +42,7 @@ func TestValidateCredentialGrant_EachMatchCriterionSufficient(t *testing.T) {
 		{"subject_kind", CredentialGrantValidationInput{SubjectKind: "agent"}},
 		{"subject_id", CredentialGrantValidationInput{SubjectID: "agent-1"}},
 		{"operation", CredentialGrantValidationInput{Operation: "chat"}},
-		{"method", CredentialGrantValidationInput{Method: "POST"}},
+		{"method", CredentialGrantValidationInput{Method: http.MethodPost}},
 		{"host", CredentialGrantValidationInput{Host: "api.vendor.test"}},
 		{"path_prefix", CredentialGrantValidationInput{PathPrefix: "/v1"}},
 	}

--- a/internal/invocation/guarded_test.go
+++ b/internal/invocation/guarded_test.go
@@ -39,7 +39,7 @@ func guardTestProvider(name string) *stubProviderWithOps {
 				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
 			},
 		},
-		ops: []core.Operation{{Name: "ping", Method: "GET"}},
+		ops: []core.Operation{{Name: "ping", Method: http.MethodGet}},
 	}
 }
 

--- a/internal/mcp/binding.go
+++ b/internal/mcp/binding.go
@@ -16,7 +16,6 @@ const (
 	serverName    = "gestalt"
 	serverVersion = "0.1.0"
 	toolNameSep   = "_"
-	httpErrorMin  = 400
 )
 
 type TokenResolver interface {

--- a/internal/mcp/binding_test.go
+++ b/internal/mcp/binding_test.go
@@ -186,7 +186,7 @@ func TestNewServer_ListsToolsFromCatalogProvider(t *testing.T) {
 		Operations: []catalog.CatalogOperation{
 			{
 				ID:          "search_issues",
-				Method:      "GET",
+				Method:      http.MethodGet,
 				Path:        "/issues",
 				Title:       "Search Issues",
 				Description: "Search for issues",
@@ -197,7 +197,7 @@ func TestNewServer_ListsToolsFromCatalogProvider(t *testing.T) {
 			},
 			{
 				ID:          "create_issue",
-				Method:      "POST",
+				Method:      http.MethodPost,
 				Path:        "/issues",
 				Title:       "Create Issue",
 				Description: "Create a new issue",
@@ -253,10 +253,10 @@ func TestNewServer_ListsToolsFromFlatProvider(t *testing.T) {
 	prov := &flatProvider{
 		StubIntegration: coretesting.StubIntegration{N: "github"},
 		ops: []core.Operation{
-			{Name: "list_repos", Description: "List repositories", Method: "GET", Parameters: []core.Parameter{
+			{Name: "list_repos", Description: "List repositories", Method: http.MethodGet, Parameters: []core.Parameter{
 				{Name: "org", Type: "string", Description: "Organization name", Required: true},
 			}},
-			{Name: "delete_repo", Description: "Delete a repository", Method: "DELETE"},
+			{Name: "delete_repo", Description: "Delete a repository", Method: http.MethodDelete},
 		},
 	}
 
@@ -296,7 +296,7 @@ func TestNewServer_ToolNameConvention(t *testing.T) {
 
 	prov := &flatProvider{
 		StubIntegration: coretesting.StubIntegration{N: "slack"},
-		ops:             []core.Operation{{Name: "send_message", Method: "POST"}},
+		ops:             []core.Operation{{Name: "send_message", Method: http.MethodPost}},
 	}
 
 	providers := testutil.NewProviderRegistry(t, prov)
@@ -337,7 +337,7 @@ func TestNewServer_ToolCallRoutesThrough(t *testing.T) {
 				}, nil
 			},
 		},
-		ops: []core.Operation{{Name: "do_thing", Method: "POST"}},
+		ops: []core.Operation{{Name: "do_thing", Method: http.MethodPost}},
 	}
 
 	providers := testutil.NewProviderRegistry(t, prov)
@@ -384,7 +384,7 @@ func TestNewServer_ToolCallUsesInjectedInvoker(t *testing.T) {
 
 	prov := &flatProvider{
 		StubIntegration: coretesting.StubIntegration{N: "test"},
-		ops:             []core.Operation{{Name: "op", Method: "GET"}},
+		ops:             []core.Operation{{Name: "op", Method: http.MethodGet}},
 	}
 
 	providers := testutil.NewProviderRegistry(t, prov)
@@ -448,7 +448,7 @@ func TestNewServer_ErrorResultSetsIsError(t *testing.T) {
 				}, nil
 			},
 		},
-		ops: []core.Operation{{Name: "forbidden_op", Method: "GET"}},
+		ops: []core.Operation{{Name: "forbidden_op", Method: http.MethodGet}},
 	}
 
 	providers := testutil.NewProviderRegistry(t, prov)
@@ -484,7 +484,7 @@ func TestNewServer_BrokerErrorReturnsToolError(t *testing.T) {
 				return nil, fmt.Errorf("connection timeout")
 			},
 		},
-		ops: []core.Operation{{Name: "flaky_op", Method: "GET"}},
+		ops: []core.Operation{{Name: "flaky_op", Method: http.MethodGet}},
 	}
 
 	providers := testutil.NewProviderRegistry(t, prov)
@@ -515,7 +515,7 @@ func TestNewServer_NoPrincipalReturnsToolError(t *testing.T) {
 
 	prov := &flatProvider{
 		StubIntegration: coretesting.StubIntegration{N: "test"},
-		ops:             []core.Operation{{Name: "op", Method: "GET"}},
+		ops:             []core.Operation{{Name: "op", Method: http.MethodGet}},
 	}
 
 	providers := testutil.NewProviderRegistry(t, prov)
@@ -545,11 +545,11 @@ func TestNewServer_AllowedProvidersFilter(t *testing.T) {
 
 	prov1 := &flatProvider{
 		StubIntegration: coretesting.StubIntegration{N: "allowed"},
-		ops:             []core.Operation{{Name: "op1", Method: "GET"}},
+		ops:             []core.Operation{{Name: "op1", Method: http.MethodGet}},
 	}
 	prov2 := &flatProvider{
 		StubIntegration: coretesting.StubIntegration{N: "excluded"},
-		ops:             []core.Operation{{Name: "op2", Method: "GET"}},
+		ops:             []core.Operation{{Name: "op2", Method: http.MethodGet}},
 	}
 
 	providers := testutil.NewProviderRegistry(t, prov1, prov2)
@@ -578,8 +578,8 @@ func TestNewServer_HiddenOperationsFiltered(t *testing.T) {
 	cat := &catalog.Catalog{
 		Name: "test",
 		Operations: []catalog.CatalogOperation{
-			{ID: "visible_op", Method: "GET", Path: "/v"},
-			{ID: "hidden_op", Method: "GET", Path: "/h", Visible: &hidden},
+			{ID: "visible_op", Method: http.MethodGet, Path: "/v"},
+			{ID: "hidden_op", Method: http.MethodGet, Path: "/h", Visible: &hidden},
 		},
 	}
 
@@ -1035,7 +1035,7 @@ func TestNewServer_IncludeRESTFiltering(t *testing.T) {
 			cat := &catalog.Catalog{
 				Name: "acme",
 				Operations: []catalog.CatalogOperation{
-					{ID: "api_op", Method: "GET", Path: "/api", Transport: catalog.TransportREST},
+					{ID: "api_op", Method: http.MethodGet, Path: "/api", Transport: catalog.TransportREST},
 					{ID: "mcp_op", Description: "passthrough", Transport: catalog.TransportMCPPassthrough},
 				},
 			}

--- a/internal/mcp/composite_test.go
+++ b/internal/mcp/composite_test.go
@@ -46,7 +46,7 @@ func TestComposite_MCPPassthroughRouting(t *testing.T) {
 	apiCat := &catalog.Catalog{
 		Name: "notion",
 		Operations: []catalog.CatalogOperation{
-			{ID: "list_pages", Method: "GET", Path: "/pages", Description: "List pages"},
+			{ID: "list_pages", Method: http.MethodGet, Path: "/pages", Description: "List pages"},
 		},
 	}
 	apiProv := &catalogProvider{
@@ -119,7 +119,7 @@ func TestComposite_MCPFromAPIExposesBothToolSets(t *testing.T) {
 	apiCat := &catalog.Catalog{
 		Name: "notion",
 		Operations: []catalog.CatalogOperation{
-			{ID: "list_pages", Method: "GET", Path: "/pages", Description: "List pages"},
+			{ID: "list_pages", Method: http.MethodGet, Path: "/pages", Description: "List pages"},
 		},
 	}
 	apiProv := &catalogProvider{
@@ -198,7 +198,7 @@ func TestComposite_ExecuteDelegatesToAPI(t *testing.T) {
 	apiCat := &catalog.Catalog{
 		Name: "notion",
 		Operations: []catalog.CatalogOperation{
-			{ID: "get_page", Method: "GET", Path: "/pages/{id}", Description: "Get page"},
+			{ID: "get_page", Method: http.MethodGet, Path: "/pages/{id}", Description: "Get page"},
 		},
 	}
 	var executedOp string
@@ -241,7 +241,7 @@ func TestComposite_IncludeRESTFalseExcludesAPITools(t *testing.T) {
 	apiCat := &catalog.Catalog{
 		Name: "alpha",
 		Operations: []catalog.CatalogOperation{
-			{ID: "list_items", Method: "GET", Path: "/items", Description: "List items"},
+			{ID: "list_items", Method: http.MethodGet, Path: "/items", Description: "List items"},
 		},
 	}
 	apiProv := &catalogProvider{

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/valon-technologies/gestalt/internal/egress"
 	"github.com/valon-technologies/gestalt/internal/invocation"
@@ -31,7 +32,7 @@ func makeHandler(invoker invocation.Invoker, provName, opName, connection string
 			return mcpgo.NewToolResultError(err.Error()), nil
 		}
 
-		if result.Status >= httpErrorMin {
+		if result.Status >= http.StatusBadRequest {
 			return mcpgo.NewToolResultError(result.Body), nil
 		}
 

--- a/internal/mcpoauth/discovery.go
+++ b/internal/mcpoauth/discovery.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/valon-technologies/gestalt/core"
 )
 
 const discoveryTimeout = 10 * time.Second
@@ -87,7 +89,7 @@ func probeForResourceMetadata(ctx context.Context, client *http.Client, mcpURL s
 	if err != nil {
 		return "", fmt.Errorf("creating probe request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", core.ContentTypeJSON)
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -227,7 +229,7 @@ func fetchJSON(ctx context.Context, client *http.Client, rawURL string) (map[str
 	if err != nil {
 		return nil, fmt.Errorf("creating request for %s: %w", rawURL, err)
 	}
-	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Accept", core.ContentTypeJSON)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/mcpoauth/registration.go
+++ b/internal/mcpoauth/registration.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/valon-technologies/gestalt/core"
 )
 
 type Registration struct {
@@ -42,7 +44,7 @@ func RegisterClient(ctx context.Context, endpoint, redirectURI, clientName, toke
 	if err != nil {
 		return nil, fmt.Errorf("creating DCR request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", core.ContentTypeJSON)
 
 	client := &http.Client{Timeout: discoveryTimeout}
 	resp, err := client.Do(req)

--- a/internal/oauth/upstream.go
+++ b/internal/oauth/upstream.go
@@ -237,7 +237,7 @@ func (h *UpstreamHandler) tokenRequest(ctx context.Context, data url.Values, tok
 			return nil, fmt.Errorf("encoding token request as JSON: %w", err)
 		}
 		reader = bytes.NewReader(b)
-		contentType = "application/json"
+		contentType = core.ContentTypeJSON
 	} else {
 		reader = strings.NewReader(data.Encode())
 		contentType = "application/x-www-form-urlencoded"

--- a/internal/openapi/catalog_test.go
+++ b/internal/openapi/catalog_test.go
@@ -3,6 +3,7 @@ package openapi
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/internal/config"
@@ -178,15 +179,15 @@ func TestLoadCatalogAnnotationsFromMethod(t *testing.T) {
 		}
 
 		switch op.Method {
-		case "GET":
+		case http.MethodGet:
 			if op.Annotations.ReadOnlyHint == nil || !*op.Annotations.ReadOnlyHint {
 				t.Errorf("%s: GET should have readOnlyHint=true", op.ID)
 			}
-		case "DELETE":
+		case http.MethodDelete:
 			if op.Annotations.DestructiveHint == nil || !*op.Annotations.DestructiveHint {
 				t.Errorf("%s: DELETE should have destructiveHint=true", op.ID)
 			}
-		case "PUT":
+		case http.MethodPut:
 			if op.Annotations.IdempotentHint == nil || !*op.Annotations.IdempotentHint {
 				t.Errorf("%s: PUT should have idempotentHint=true", op.ID)
 			}

--- a/internal/pluginapi/provider_test.go
+++ b/internal/pluginapi/provider_test.go
@@ -3,6 +3,7 @@ package pluginapi
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/core"
@@ -24,7 +25,7 @@ func (p *roundTripProvider) ListOperations() []core.Operation {
 		{
 			Name:        "echo",
 			Description: "Echo input",
-			Method:      "POST",
+			Method:      http.MethodPost,
 			Parameters: []core.Parameter{
 				{Name: "message", Type: "string", Description: "message", Required: true, Default: "hello"},
 			},
@@ -68,7 +69,7 @@ func (p *roundTripProvider) Catalog() *catalog.Catalog {
 		DisplayName: "Round Trip",
 		Description: "test provider",
 		Operations: []catalog.CatalogOperation{
-			{ID: "echo", Method: "POST", Path: "/echo", Transport: catalog.TransportREST},
+			{ID: "echo", Method: http.MethodPost, Path: "/echo", Transport: catalog.TransportREST},
 		},
 	}
 }
@@ -79,7 +80,7 @@ func (p *roundTripProvider) CatalogForRequest(_ context.Context, token string) (
 		DisplayName: token,
 		Description: "session catalog",
 		Operations: []catalog.CatalogOperation{
-			{ID: "echo", Method: "POST", Path: "/echo", Transport: catalog.TransportREST},
+			{ID: "echo", Method: http.MethodPost, Path: "/echo", Transport: catalog.TransportREST},
 		},
 	}, nil
 }

--- a/internal/pluginsource/github/resolver.go
+++ b/internal/pluginsource/github/resolver.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/pluginpkg"
 	"github.com/valon-technologies/gestalt/internal/pluginsource"
 )
@@ -17,7 +18,6 @@ const (
 	DefaultBaseURL      = "https://api.github.com"
 	headerAccept        = "Accept"
 	headerAuthorization = "Authorization"
-	acceptJSON          = "application/json"
 	acceptOctetStream   = "application/octet-stream"
 	envGitHubToken      = "GITHUB_TOKEN"
 	authTokenPrefix     = "token "
@@ -85,7 +85,7 @@ func (r *GitHubResolver) fetchRelease(ctx context.Context, client *http.Client, 
 	if err != nil {
 		return nil, fmt.Errorf("create release request: %w", err)
 	}
-	req.Header.Set(headerAccept, acceptJSON)
+	req.Header.Set(headerAccept, core.ContentTypeJSON)
 	if token != "" {
 		req.Header.Set(headerAuthorization, authTokenPrefix+token)
 	}

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -118,7 +118,7 @@ func Build(def *Definition, conn config.ConnectionDef, allowedOperations map[str
 	case def.ErrorMessagePath != "":
 		msgPath := def.ErrorMessagePath
 		base.CheckResponse = func(status int, body []byte) error {
-			if status < 400 {
+			if status < http.StatusBadRequest {
 				return nil
 			}
 			var data map[string]any
@@ -371,7 +371,7 @@ func buildResponseChecker(rcd *ResponseCheckDef) apiexec.ResponseChecker {
 	return func(status int, body []byte) error {
 		var data map[string]any
 		if err := json.Unmarshal(body, &data); err != nil {
-			if status >= 400 {
+			if status >= http.StatusBadRequest {
 				return fmt.Errorf("HTTP %d: %s", status, body)
 			}
 			return nil
@@ -382,7 +382,7 @@ func buildResponseChecker(rcd *ResponseCheckDef) apiexec.ResponseChecker {
 			}
 			return nil
 		}
-		if status >= 400 && rcd.ErrorMessagePath != "" {
+		if status >= http.StatusBadRequest && rcd.ErrorMessagePath != "" {
 			if msg, ok := extractJSONPath(data, rcd.ErrorMessagePath); ok {
 				return fmt.Errorf("HTTP %d: %s", status, msg)
 			}

--- a/internal/provider/build_test.go
+++ b/internal/provider/build_test.go
@@ -26,8 +26,8 @@ func testDefinition(name string) *Definition {
 			TokenURL:         "/oauth/token",
 		},
 		Operations: map[string]OperationDef{
-			"list_items": {Description: "List items", Method: "GET", Path: "/items"},
-			"get_item":   {Description: "Get item", Method: "GET", Path: "/items/{id}"},
+			"list_items": {Description: "List items", Method: http.MethodGet, Path: "/items"},
+			"get_item":   {Description: "Get item", Method: http.MethodGet, Path: "/items/{id}"},
 		},
 	}
 }
@@ -65,7 +65,7 @@ func TestBuildManualAuth(t *testing.T) {
 		BaseURL:     "https://api.example.com",
 		Auth:        AuthDef{Type: "manual"},
 		Operations: map[string]OperationDef{
-			"list": {Description: "List", Method: "GET", Path: "/list"},
+			"list": {Description: "List", Method: http.MethodGet, Path: "/list"},
 		},
 	}
 	intg, err := Build(def, config.ConnectionDef{}, nil)
@@ -145,8 +145,8 @@ func TestBuildWithAlias(t *testing.T) {
 		BaseURL:     srv.URL,
 		Auth:        AuthDef{Type: "manual"},
 		Operations: map[string]OperationDef{
-			"op_alpha": {Description: "Alpha op", Method: "GET", Path: "/alpha"},
-			"op_beta":  {Description: "Beta op", Method: "GET", Path: "/beta"},
+			"op_alpha": {Description: "Alpha op", Method: http.MethodGet, Path: "/alpha"},
+			"op_beta":  {Description: "Beta op", Method: http.MethodGet, Path: "/beta"},
 		},
 	}
 
@@ -196,7 +196,7 @@ func TestBuildWithAliasAndDescription(t *testing.T) {
 		BaseURL:     "https://api.example.com",
 		Auth:        AuthDef{Type: "manual"},
 		Operations: map[string]OperationDef{
-			"op_gamma": {Description: "Gamma op", Method: "GET", Path: "/gamma"},
+			"op_gamma": {Description: "Gamma op", Method: http.MethodGet, Path: "/gamma"},
 		},
 	}
 
@@ -315,7 +315,7 @@ func TestBuildBasicAuthStyle(t *testing.T) {
 		Auth:        AuthDef{Type: "manual"},
 		AuthStyle:   "basic",
 		Operations: map[string]OperationDef{
-			"list": {Description: "List", Method: "GET", Path: "/list"},
+			"list": {Description: "List", Method: http.MethodGet, Path: "/list"},
 		},
 	}
 	intg, err := Build(def, config.ConnectionDef{}, nil)
@@ -339,7 +339,7 @@ func TestBuildSatisfiesCatalogProvider(t *testing.T) {
 		Operations: map[string]OperationDef{
 			"list": {
 				Description: "List things",
-				Method:      "GET",
+				Method:      http.MethodGet,
 				Path:        "/things",
 				Parameters: []ParameterDef{
 					{Name: "limit", Type: "integer", Description: "Max results", Default: 25},
@@ -348,7 +348,7 @@ func TestBuildSatisfiesCatalogProvider(t *testing.T) {
 			},
 			"create": {
 				Description: "Create a thing",
-				Method:      "POST",
+				Method:      http.MethodPost,
 				Path:        "/things",
 				Parameters: []ParameterDef{
 					{Name: "name", Type: "string", Required: true},
@@ -413,7 +413,7 @@ func TestBuildAppliesIconFile(t *testing.T) {
 		BaseURL:     "https://api.example.com",
 		Auth:        AuthDef{Type: "manual"},
 		Operations: map[string]OperationDef{
-			"op": {Description: "An op", Method: "GET", Path: "/op"},
+			"op": {Description: "An op", Method: http.MethodGet, Path: "/op"},
 		},
 	}
 
@@ -445,7 +445,7 @@ func TestBuildIconFileMissing(t *testing.T) {
 		BaseURL:     "https://api.example.com",
 		Auth:        AuthDef{Type: "manual"},
 		Operations: map[string]OperationDef{
-			"op": {Description: "An op", Method: "GET", Path: "/op"},
+			"op": {Description: "An op", Method: http.MethodGet, Path: "/op"},
 		},
 	}
 
@@ -482,7 +482,7 @@ func TestBuildAuthHeader(t *testing.T) {
 		Auth:        AuthDef{Type: "manual"},
 		AuthHeader:  "X-API-Key",
 		Operations: map[string]OperationDef{
-			"list": {Description: "List items", Method: "GET", Path: "/items"},
+			"list": {Description: "List items", Method: http.MethodGet, Path: "/items"},
 		},
 	}
 
@@ -533,7 +533,7 @@ func TestBuildAuthMapping(t *testing.T) {
 			},
 		},
 		Operations: map[string]OperationDef{
-			"list": {Description: "List items", Method: "GET", Path: "/items"},
+			"list": {Description: "List items", Method: http.MethodGet, Path: "/items"},
 		},
 	}
 
@@ -580,7 +580,7 @@ func TestBuildAuthMappingMissingField(t *testing.T) {
 			Headers: map[string]string{"X-Key": "missing_field"},
 		},
 		Operations: map[string]OperationDef{
-			"op": {Description: "Op", Method: "GET", Path: "/op"},
+			"op": {Description: "Op", Method: http.MethodGet, Path: "/op"},
 		},
 	}
 
@@ -619,7 +619,7 @@ func TestBuildErrorMessagePath(t *testing.T) {
 		Auth:             AuthDef{Type: "manual"},
 		ErrorMessagePath: "error.message",
 		Operations: map[string]OperationDef{
-			"list": {Description: "List", Method: "GET", Path: "/list"},
+			"list": {Description: "List", Method: http.MethodGet, Path: "/list"},
 		},
 	}
 
@@ -656,7 +656,7 @@ func TestBuildErrorMessagePathSuccessPassthrough(t *testing.T) {
 		Auth:             AuthDef{Type: "manual"},
 		ErrorMessagePath: "error.message",
 		Operations: map[string]OperationDef{
-			"op": {Description: "Op", Method: "GET", Path: "/op"},
+			"op": {Description: "Op", Method: http.MethodGet, Path: "/op"},
 		},
 	}
 
@@ -693,7 +693,7 @@ func TestBuildConfigOverridesAuthHeader(t *testing.T) {
 		Auth:        AuthDef{Type: "manual"},
 		AuthHeader:  "X-Original-Key",
 		Operations: map[string]OperationDef{
-			"op": {Description: "Op", Method: "GET", Path: "/op"},
+			"op": {Description: "Op", Method: http.MethodGet, Path: "/op"},
 		},
 	}
 
@@ -737,7 +737,7 @@ func TestBuildConnectionParams(t *testing.T) {
 			},
 		},
 		Operations: map[string]OperationDef{
-			"list_products": {Description: "List products", Method: "GET", Path: "/products"},
+			"list_products": {Description: "List products", Method: http.MethodGet, Path: "/products"},
 		},
 	}
 
@@ -781,7 +781,7 @@ func TestBuildConnectionParamsBaseURLInterpolation(t *testing.T) {
 			"subdomain": {Required: true},
 		},
 		Operations: map[string]OperationDef{
-			"op": {Description: "Op", Method: "GET", Path: "/items"},
+			"op": {Description: "Op", Method: http.MethodGet, Path: "/items"},
 		},
 	}
 
@@ -821,7 +821,7 @@ func TestBuildResponseCheck_SuccessMatch(t *testing.T) {
 			ErrorMessagePath: "error",
 		},
 		Operations: map[string]OperationDef{
-			"op": {Description: "Op", Method: "GET", Path: "/op"},
+			"op": {Description: "Op", Method: http.MethodGet, Path: "/op"},
 		},
 	}
 
@@ -864,7 +864,7 @@ func TestBuildResponseCheck_FailureMatch(t *testing.T) {
 			ErrorMessagePath: errorKey,
 		},
 		Operations: map[string]OperationDef{
-			"op": {Description: "Op", Method: "GET", Path: "/op"},
+			"op": {Description: "Op", Method: http.MethodGet, Path: "/op"},
 		},
 	}
 
@@ -902,7 +902,7 @@ func TestBuildResponseCheck_NonJSON200(t *testing.T) {
 			ErrorMessagePath: "error",
 		},
 		Operations: map[string]OperationDef{
-			"op": {Description: "Op", Method: "GET", Path: "/op"},
+			"op": {Description: "Op", Method: http.MethodGet, Path: "/op"},
 		},
 	}
 
@@ -939,7 +939,7 @@ func TestBuildResponseCheck_NonJSON500(t *testing.T) {
 			ErrorMessagePath: "error",
 		},
 		Operations: map[string]OperationDef{
-			"op": {Description: "Op", Method: "GET", Path: "/op"},
+			"op": {Description: "Op", Method: http.MethodGet, Path: "/op"},
 		},
 	}
 
@@ -966,7 +966,7 @@ func TestBuildResponseCheck_SuccessMatchOnly(t *testing.T) {
 			SuccessBodyMatch: map[string]any{"ok": true},
 		},
 		Operations: map[string]OperationDef{
-			"op": {Description: "Op", Method: "GET", Path: "/op"},
+			"op": {Description: "Op", Method: http.MethodGet, Path: "/op"},
 		},
 	}
 
@@ -1000,7 +1000,7 @@ func TestBuildResponseCheck_ErrorMessagePathOnly(t *testing.T) {
 			ErrorMessagePath: msgKey,
 		},
 		Operations: map[string]OperationDef{
-			"op": {Description: "Op", Method: "GET", Path: "/op"},
+			"op": {Description: "Op", Method: http.MethodGet, Path: "/op"},
 		},
 	}
 

--- a/internal/provider/compiler/compiler_test.go
+++ b/internal/provider/compiler/compiler_test.go
@@ -3,6 +3,7 @@ package compiler
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,7 +21,7 @@ func TestCompileUsesPreparedArtifact(t *testing.T) {
 		DisplayName: "Prepared Provider",
 		Operations: map[string]provider.OperationDef{
 			"list_users": {
-				Method:      "GET",
+				Method:      http.MethodGet,
 				Path:        "/users",
 				Description: "List users",
 				Transport:   "rest",
@@ -69,13 +70,13 @@ func TestBuildProviderAppliesRuntimeOverrides(t *testing.T) {
 		},
 		Operations: map[string]provider.OperationDef{
 			"delete_user": {
-				Method:      "DELETE",
+				Method:      http.MethodDelete,
 				Path:        "/users/{id}",
 				Description: "Delete user",
 				Transport:   "rest",
 			},
 			"list_users": {
-				Method:      "GET",
+				Method:      http.MethodGet,
 				Path:        "/users",
 				Description: "List users",
 				Transport:   "rest",

--- a/internal/server/catalog_resolution_test.go
+++ b/internal/server/catalog_resolution_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/core"
@@ -70,7 +71,7 @@ func TestResolveCatalog_StaticCatalog(t *testing.T) {
 			Operations: []catalog.CatalogOperation{
 				{
 					ID:     "list_widgets",
-					Method: "GET",
+					Method: http.MethodGet,
 					Path:   "/widgets",
 					Parameters: []catalog.CatalogParameter{
 						{Name: "page", Type: "integer", Location: "query", Required: false},
@@ -122,7 +123,7 @@ func TestResolveCatalog_FlatProvider(t *testing.T) {
 		ops: []core.Operation{
 			{
 				Name:        "create_gadget",
-				Method:      "POST",
+				Method:      http.MethodPost,
 				Description: "Creates a gadget",
 				Parameters: []core.Parameter{
 					{Name: "label", Type: "string", Required: true},
@@ -131,7 +132,7 @@ func TestResolveCatalog_FlatProvider(t *testing.T) {
 			},
 			{
 				Name:        "get_gadget",
-				Method:      "GET",
+				Method:      http.MethodGet,
 				Description: "Gets a gadget",
 			},
 		},
@@ -149,7 +150,7 @@ func TestResolveCatalog_FlatProvider(t *testing.T) {
 	if create.ID != "create_gadget" {
 		t.Fatalf("expected id %q, got %q", "create_gadget", create.ID)
 	}
-	if create.Method != "POST" {
+	if create.Method != http.MethodPost {
 		t.Fatalf("expected method POST, got %q", create.Method)
 	}
 	if create.Transport != catalog.TransportREST {
@@ -180,14 +181,14 @@ func TestResolveCatalog_SessionAndStaticMerge(t *testing.T) {
 			cat: &catalog.Catalog{
 				Name: "combo-api",
 				Operations: []catalog.CatalogOperation{
-					{ID: "rest_op", Method: "GET", Transport: catalog.TransportREST},
+					{ID: "rest_op", Method: http.MethodGet, Transport: catalog.TransportREST},
 				},
 			},
 		},
 		sessionCat: &catalog.Catalog{
 			Name: "combo-api",
 			Operations: []catalog.CatalogOperation{
-				{ID: "mcp_op", Method: "POST", Transport: catalog.TransportMCPPassthrough},
+				{ID: "mcp_op", Method: http.MethodPost, Transport: catalog.TransportMCPPassthrough},
 			},
 		},
 	}
@@ -227,14 +228,14 @@ func TestResolveCatalog_SameIDCollision_StaticWins(t *testing.T) {
 			cat: &catalog.Catalog{
 				Name: "clash-api",
 				Operations: []catalog.CatalogOperation{
-					{ID: "shared_op", Method: "GET", Transport: catalog.TransportREST, Description: "static version"},
+					{ID: "shared_op", Method: http.MethodGet, Transport: catalog.TransportREST, Description: "static version"},
 				},
 			},
 		},
 		sessionCat: &catalog.Catalog{
 			Name: "clash-api",
 			Operations: []catalog.CatalogOperation{
-				{ID: "shared_op", Method: "POST", Transport: catalog.TransportMCPPassthrough, Description: "session version"},
+				{ID: "shared_op", Method: http.MethodPost, Transport: catalog.TransportMCPPassthrough, Description: "session version"},
 			},
 		},
 	}
@@ -252,7 +253,7 @@ func TestResolveCatalog_SameIDCollision_StaticWins(t *testing.T) {
 	if cat.Operations[0].Description != "static version" {
 		t.Fatalf("expected static version to win, got %q", cat.Operations[0].Description)
 	}
-	if cat.Operations[0].Method != "GET" {
+	if cat.Operations[0].Method != http.MethodGet {
 		t.Fatalf("expected GET from static, got %q", cat.Operations[0].Method)
 	}
 }
@@ -269,14 +270,14 @@ func TestResolveCatalog_TokenResolutionFailure_NonFatal(t *testing.T) {
 			cat: &catalog.Catalog{
 				Name: "auth-api",
 				Operations: []catalog.CatalogOperation{
-					{ID: "static_op", Method: "GET"},
+					{ID: "static_op", Method: http.MethodGet},
 				},
 			},
 		},
 		sessionCat: &catalog.Catalog{
 			Name: "auth-api",
 			Operations: []catalog.CatalogOperation{
-				{ID: "session_only", Method: "POST"},
+				{ID: "session_only", Method: http.MethodPost},
 			},
 		},
 	}
@@ -308,14 +309,14 @@ func TestResolveCatalog_NilResolver(t *testing.T) {
 			cat: &catalog.Catalog{
 				Name: "noauth-api",
 				Operations: []catalog.CatalogOperation{
-					{ID: "the_op", Method: "PUT"},
+					{ID: "the_op", Method: http.MethodPut},
 				},
 			},
 		},
 		sessionCat: &catalog.Catalog{
 			Name: "noauth-api",
 			Operations: []catalog.CatalogOperation{
-				{ID: "hidden_op", Method: "POST"},
+				{ID: "hidden_op", Method: http.MethodPost},
 			},
 		},
 	}
@@ -340,7 +341,7 @@ func TestResolveCatalog_CloneSafety(t *testing.T) {
 		Operations: []catalog.CatalogOperation{
 			{
 				ID:     "safe_op",
-				Method: "POST",
+				Method: http.MethodPost,
 				Parameters: []catalog.CatalogParameter{
 					{Name: "data", Type: "string", Required: true},
 				},

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -387,7 +387,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", core.ContentTypeJSON)
 	w.WriteHeader(result.Status)
 	_, _ = fmt.Fprint(w, result.Body)
 }

--- a/internal/server/response.go
+++ b/internal/server/response.go
@@ -3,10 +3,12 @@ package server
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/valon-technologies/gestalt/core"
 )
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", core.ContentTypeJSON)
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(v)
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -664,7 +664,7 @@ func TestListIntegrationsWithIcon(t *testing.T) {
 		BaseURL:     "https://api.example.com",
 		Auth:        provider.AuthDef{Type: "manual"},
 		Operations: map[string]provider.OperationDef{
-			"op": {Description: "An op", Method: "GET", Path: "/op"},
+			"op": {Description: "An op", Method: http.MethodGet, Path: "/op"},
 		},
 	}
 	prov, err := provider.Build(def, config.ConnectionDef{}, nil)
@@ -900,7 +900,7 @@ func TestListOperations(t *testing.T) {
 	stub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{N: "test-int"},
 		ops: []core.Operation{
-			{Name: "do_thing", Description: "Do a thing", Method: "GET"},
+			{Name: "do_thing", Description: "Do a thing", Method: http.MethodGet},
 		},
 	}
 	ts := newTestServer(t, func(cfg *server.Config) {
@@ -974,8 +974,8 @@ func TestExecuteOperation(t *testing.T) {
 			},
 		},
 		ops: []core.Operation{
-			{Name: "do_thing", Description: "Do a thing", Method: "GET"},
-			{Name: "create_thing", Description: "Create a thing", Method: "POST"},
+			{Name: "do_thing", Description: "Do a thing", Method: http.MethodGet},
+			{Name: "create_thing", Description: "Create a thing", Method: http.MethodPost},
 		},
 	}
 
@@ -1089,7 +1089,7 @@ func TestExecuteOperation_UnknownOperation(t *testing.T) {
 	fullStub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{N: "test-int"},
 		ops: []core.Operation{
-			{Name: "do_thing", Description: "Do a thing", Method: "GET"},
+			{Name: "do_thing", Description: "Do a thing", Method: http.MethodGet},
 		},
 	}
 
@@ -1121,7 +1121,7 @@ func TestExecuteOperation_NoStoredToken(t *testing.T) {
 	fullStub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{N: "test-int"},
 		ops: []core.Operation{
-			{Name: "do_thing", Description: "Do a thing", Method: "GET"},
+			{Name: "do_thing", Description: "Do a thing", Method: http.MethodGet},
 		},
 	}
 
@@ -1781,7 +1781,7 @@ func TestExecuteOperation_POST(t *testing.T) {
 			},
 		},
 		ops: []core.Operation{
-			{Name: "send", Description: "Send", Method: "POST"},
+			{Name: "send", Description: "Send", Method: http.MethodPost},
 		},
 	}
 
@@ -2092,7 +2092,7 @@ func TestExecuteOperation_RefreshesExpiredToken(t *testing.T) {
 					return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
 				},
 			},
-			ops: []core.Operation{{Name: "list", Description: "List", Method: "GET"}},
+			ops: []core.Operation{{Name: "list", Description: "List", Method: http.MethodGet}},
 		},
 		refreshTokenFn: func(_ context.Context, rt string) (*core.TokenResponse, error) {
 			if rt == "old-refresh-token" {
@@ -2168,7 +2168,7 @@ func TestExecuteOperation_RefreshFailsButTokenStillValid(t *testing.T) {
 					return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
 				},
 			},
-			ops: []core.Operation{{Name: "list", Description: "List", Method: "GET"}},
+			ops: []core.Operation{{Name: "list", Description: "List", Method: http.MethodGet}},
 		},
 		refreshTokenFn: func(context.Context, string) (*core.TokenResponse, error) {
 			return nil, fmt.Errorf("upstream error")
@@ -2227,7 +2227,7 @@ func TestExecuteOperation_RefreshFailsAndTokenExpired(t *testing.T) {
 	stub := &stubOAuthIntegration{
 		stubIntegrationWithOps: stubIntegrationWithOps{
 			StubIntegration: coretesting.StubIntegration{N: "fake"},
-			ops:             []core.Operation{{Name: "list", Description: "List", Method: "GET"}},
+			ops:             []core.Operation{{Name: "list", Description: "List", Method: http.MethodGet}},
 		},
 		refreshTokenFn: func(context.Context, string) (*core.TokenResponse, error) {
 			return nil, fmt.Errorf("refresh token revoked")
@@ -2279,7 +2279,7 @@ func TestExecuteOperation_NoRefreshTokenSkipsRefresh(t *testing.T) {
 					return &core.OperationResult{Status: http.StatusOK, Body: `{}`}, nil
 				},
 			},
-			ops: []core.Operation{{Name: "list", Description: "List", Method: "GET"}},
+			ops: []core.Operation{{Name: "list", Description: "List", Method: http.MethodGet}},
 		},
 		refreshTokenFn: func(context.Context, string) (*core.TokenResponse, error) {
 			t.Fatal("RefreshToken should not be called when no refresh token stored")
@@ -2334,7 +2334,7 @@ func TestExecuteOperation_NoExpiresAtSkipsRefresh(t *testing.T) {
 					return &core.OperationResult{Status: http.StatusOK, Body: `{}`}, nil
 				},
 			},
-			ops: []core.Operation{{Name: "list", Description: "List", Method: "GET"}},
+			ops: []core.Operation{{Name: "list", Description: "List", Method: http.MethodGet}},
 		},
 		refreshTokenFn: func(context.Context, string) (*core.TokenResponse, error) {
 			t.Fatal("RefreshToken should not be called when no expiry info")
@@ -2381,7 +2381,7 @@ func TestExecuteOperation_NonOAuthProviderSkipsRefresh(t *testing.T) {
 	var usedToken string
 	stub := &stubNonOAuthProvider{
 		name: "manual-api",
-		ops:  []core.Operation{{Name: "get", Description: "Get", Method: "GET"}},
+		ops:  []core.Operation{{Name: "get", Description: "Get", Method: http.MethodGet}},
 		execFn: func(_ context.Context, _ string, _ map[string]any, token string) (*core.OperationResult, error) {
 			usedToken = token
 			return &core.OperationResult{Status: http.StatusOK, Body: `{}`}, nil
@@ -2432,7 +2432,7 @@ func TestExecuteOperation_RefreshTokenRotation(t *testing.T) {
 					return &core.OperationResult{Status: http.StatusOK, Body: `{}`}, nil
 				},
 			},
-			ops: []core.Operation{{Name: "list", Description: "List", Method: "GET"}},
+			ops: []core.Operation{{Name: "list", Description: "List", Method: http.MethodGet}},
 		},
 		refreshTokenFn: func(_ context.Context, _ string) (*core.TokenResponse, error) {
 			return &core.TokenResponse{
@@ -2500,7 +2500,7 @@ func TestExecuteOperation_RefreshClearsExpiresAtWhenOmitted(t *testing.T) {
 					return &core.OperationResult{Status: http.StatusOK, Body: `{}`}, nil
 				},
 			},
-			ops: []core.Operation{{Name: "list", Description: "List", Method: "GET"}},
+			ops: []core.Operation{{Name: "list", Description: "List", Method: http.MethodGet}},
 		},
 		refreshTokenFn: func(_ context.Context, _ string) (*core.TokenResponse, error) {
 			return &core.TokenResponse{AccessToken: "new-access", ExpiresIn: 0}, nil
@@ -2566,7 +2566,7 @@ func TestExecuteOperation_RefreshErrorSkipsStoreOnConcurrentRefresh(t *testing.T
 					return &core.OperationResult{Status: http.StatusOK, Body: `{}`}, nil
 				},
 			},
-			ops: []core.Operation{{Name: "list", Description: "List", Method: "GET"}},
+			ops: []core.Operation{{Name: "list", Description: "List", Method: http.MethodGet}},
 		},
 		refreshTokenFn: func(context.Context, string) (*core.TokenResponse, error) {
 			return nil, fmt.Errorf("upstream error")
@@ -2631,7 +2631,7 @@ func TestExecuteOperation_StoreTokenFailureReturnsError(t *testing.T) {
 	stub := &stubOAuthIntegration{
 		stubIntegrationWithOps: stubIntegrationWithOps{
 			StubIntegration: coretesting.StubIntegration{N: "fake"},
-			ops:             []core.Operation{{Name: "list", Description: "List", Method: "GET"}},
+			ops:             []core.Operation{{Name: "list", Description: "List", Method: http.MethodGet}},
 		},
 		refreshTokenFn: func(_ context.Context, _ string) (*core.TokenResponse, error) {
 			return &core.TokenResponse{
@@ -2688,7 +2688,7 @@ func TestExecuteOperation_RefreshErrorHandlesDeletedToken(t *testing.T) {
 					return &core.OperationResult{Status: http.StatusOK, Body: `{}`}, nil
 				},
 			},
-			ops: []core.Operation{{Name: "list", Description: "List", Method: "GET"}},
+			ops: []core.Operation{{Name: "list", Description: "List", Method: http.MethodGet}},
 		},
 		refreshTokenFn: func(context.Context, string) (*core.TokenResponse, error) {
 			return nil, fmt.Errorf("upstream error")
@@ -2763,7 +2763,7 @@ func TestExecuteOperation_ConnectionModeNone(t *testing.T) {
 			},
 		},
 		ops: []core.Operation{
-			{Name: "ping", Method: "GET"},
+			{Name: "ping", Method: http.MethodGet},
 		},
 	}
 
@@ -2809,7 +2809,7 @@ func TestExecuteOperation_EchoProvider(t *testing.T) {
 			},
 		},
 		ops: []core.Operation{
-			{Name: "echo", Method: "POST"},
+			{Name: "echo", Method: http.MethodPost},
 		},
 	}
 
@@ -2861,7 +2861,7 @@ func TestExecuteOperation_HTTPAndMCPEquivalent(t *testing.T) {
 				return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
 			},
 		},
-		ops: []core.Operation{{Name: "search", Method: "GET"}},
+		ops: []core.Operation{{Name: "search", Method: http.MethodGet}},
 	}
 
 	providers := testutil.NewProviderRegistry(t, echoProvider)
@@ -3338,7 +3338,7 @@ func TestRefresh_UsesConnectionAuth(t *testing.T) {
 					return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
 				},
 			},
-			ops: []core.Operation{{Name: "list", Description: "List", Method: "GET"}},
+			ops: []core.Operation{{Name: "list", Description: "List", Method: http.MethodGet}},
 		},
 		refreshTokenFn: func(_ context.Context, rt string) (*core.TokenResponse, error) {
 			refreshedVia = "connection-handler"
@@ -3835,7 +3835,7 @@ func TestMCPEndpoint_InitializeAndListTools(t *testing.T) {
 	stub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{N: "linear"},
 		ops: []core.Operation{
-			{Name: "search_issues", Description: "Search issues", Method: "GET"},
+			{Name: "search_issues", Description: "Search issues", Method: http.MethodGet},
 		},
 	}
 	ds := &coretesting.StubDatastore{
@@ -4089,7 +4089,7 @@ func TestMaxBodySize(t *testing.T) {
 			},
 		},
 		ops: []core.Operation{
-			{Name: "do_thing", Description: "Do a thing", Method: "POST"},
+			{Name: "do_thing", Description: "Do a thing", Method: http.MethodPost},
 		},
 	}
 
@@ -4133,7 +4133,7 @@ func TestErrorSanitization(t *testing.T) {
 			},
 		},
 		ops: []core.Operation{
-			{Name: "do_thing", Description: "Do a thing", Method: "GET"},
+			{Name: "do_thing", Description: "Do a thing", Method: http.MethodGet},
 		},
 	}
 
@@ -4202,7 +4202,7 @@ func TestCookieAuth(t *testing.T) {
 	testutil.CloseOnCleanup(t, ts)
 
 	// Request without cookie should be rejected.
-	reqNoCookie, _ := http.NewRequest("GET", ts.URL+"/api/v1/integrations", nil)
+	reqNoCookie, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
 	noAuthResp, err := http.DefaultClient.Do(reqNoCookie)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -4213,7 +4213,7 @@ func TestCookieAuth(t *testing.T) {
 	}
 
 	// Request with cookie should pass auth middleware.
-	req, _ := http.NewRequest("GET", ts.URL+"/api/v1/integrations", nil)
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "valid-cookie-token"})
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -4232,7 +4232,7 @@ func TestLogout(t *testing.T) {
 	ts := newTestServer(t, func(cfg *server.Config) {})
 	testutil.CloseOnCleanup(t, ts)
 
-	req, _ := http.NewRequest("POST", ts.URL+"/api/v1/auth/logout", nil)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/logout", nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -4532,7 +4532,7 @@ func TestExecuteOperation_ConnectionModeIdentity(t *testing.T) {
 				return &core.OperationResult{Status: http.StatusOK, Body: fmt.Sprintf(`{"token":%q}`, token)}, nil
 			},
 		},
-		ops: []core.Operation{{Name: "do", Method: "GET"}},
+		ops: []core.Operation{{Name: "do", Method: http.MethodGet}},
 	}
 
 	ts := newTestServer(t, func(cfg *server.Config) {
@@ -4583,7 +4583,7 @@ func TestExecuteOperation_ConnectionModeEither(t *testing.T) {
 				return &core.OperationResult{Status: http.StatusOK, Body: fmt.Sprintf(`{"token":%q}`, token)}, nil
 			},
 		},
-		ops: []core.Operation{{Name: "do", Method: "GET"}},
+		ops: []core.Operation{{Name: "do", Method: http.MethodGet}},
 	}
 
 	t.Run("prefers user token", func(t *testing.T) {

--- a/internal/testplugins/min_protocol_provider/main.go
+++ b/internal/testplugins/min_protocol_provider/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -44,7 +45,7 @@ func (s *minProtocolProviderServer) ListOperations(context.Context, *emptypb.Emp
 			{
 				Name:        "ping",
 				Description: "Ping",
-				Method:      "GET",
+				Method:      http.MethodGet,
 			},
 		},
 	}, nil

--- a/plugins/bindings/internal/httpjson/httpjson.go
+++ b/plugins/bindings/internal/httpjson/httpjson.go
@@ -3,10 +3,12 @@ package httpjson
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/valon-technologies/gestalt/core"
 )
 
 func WriteJSON(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", core.ContentTypeJSON)
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(v)
 }

--- a/plugins/bindings/webhook/webhook.go
+++ b/plugins/bindings/webhook/webhook.go
@@ -137,7 +137,7 @@ func (b *Binding) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", core.ContentTypeJSON)
 	w.WriteHeader(result.Status)
 	_, _ = fmt.Fprint(w, result.Body)
 }

--- a/plugins/slack/provider_test.go
+++ b/plugins/slack/provider_test.go
@@ -77,7 +77,7 @@ func TestListChannels(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if log.method != "GET" {
+	if log.method != http.MethodGet {
 		t.Errorf("method = %s, want GET", log.method)
 	}
 	if log.path != "/api/"+methodConversationsList {
@@ -113,7 +113,7 @@ func TestSendMessage(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if log.method != "POST" {
+	if log.method != http.MethodPost {
 		t.Errorf("method = %s, want POST", log.method)
 	}
 	if log.path != "/api/"+methodChatPostMessage {
@@ -148,7 +148,7 @@ func TestListUsers(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if log.method != "GET" {
+	if log.method != http.MethodGet {
 		t.Errorf("method = %s, want GET", log.method)
 	}
 	if log.path != "/api/"+methodUsersList {
@@ -180,7 +180,7 @@ func TestReadHistory(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if log.method != "GET" {
+	if log.method != http.MethodGet {
 		t.Errorf("method = %s, want GET", log.method)
 	}
 	if log.path != "/api/"+methodConversationsHistory {
@@ -214,7 +214,7 @@ func TestSearchMessages(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if log.method != "GET" {
+	if log.method != http.MethodGet {
 		t.Errorf("method = %s, want GET", log.method)
 	}
 	if log.path != "/api/"+methodSearchMessages {

--- a/sdk/pluginsdk/plugin_test.go
+++ b/sdk/pluginsdk/plugin_test.go
@@ -3,6 +3,7 @@ package pluginsdk_test
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	pluginsdk "github.com/valon-technologies/gestalt/sdk/pluginsdk"
@@ -185,7 +186,7 @@ func TestProviderServerListOperations(t *testing.T) {
 			{
 				Name:        "list_items",
 				Description: "List all items",
-				Method:      "GET",
+				Method:      http.MethodGet,
 				Parameters: []pluginsdk.Parameter{
 					{Name: "limit", Type: "integer", Description: "Max results", Required: false, Default: 10},
 				},
@@ -193,7 +194,7 @@ func TestProviderServerListOperations(t *testing.T) {
 			{
 				Name:        "create_item",
 				Description: "Create a new item",
-				Method:      "POST",
+				Method:      http.MethodPost,
 				Parameters: []pluginsdk.Parameter{
 					{Name: "name", Type: "string", Description: "Item name", Required: true},
 				},


### PR DESCRIPTION
Replace HTTP method string literals with `http.Method*` constants, status
code integers with `http.Status*` constants, and the magic `>= 400` error
threshold with `>= http.StatusBadRequest` throughout the codebase. Add a
shared `core.ContentTypeJSON` constant to replace the repeated
`"application/json"` string literal and remove redundant local definitions
of the same constant.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>