### PR TITLE
Add declarative plugins and YAML manifest support

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -686,6 +686,9 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 
 func buildProvider(ctx context.Context, name string, intg config.IntegrationDef, factories *FactoryRegistry, deps Deps) (*ProviderBuildResult, error) {
 	if intg.Plugin != nil {
+		if intg.Plugin.IsDeclarative {
+			return buildDeclarativeProvider(name, intg, deps)
+		}
 		pluginProv, pluginConfig, err := buildPluginProvider(ctx, name, intg)
 		if err != nil {
 			return nil, err
@@ -713,6 +716,40 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 		return nil, err
 	}
 	return factory(ctx, name, intg, deps)
+}
+
+func buildDeclarativeProvider(name string, intg config.IntegrationDef, deps Deps) (*ProviderBuildResult, error) {
+	if intg.Plugin == nil || intg.Plugin.ResolvedManifestPath == "" {
+		return nil, fmt.Errorf("declarative provider %q has no resolved manifest path", name)
+	}
+	_, manifest, err := pluginpkg.ReadManifestFile(intg.Plugin.ResolvedManifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest for declarative provider %q: %w", name, err)
+	}
+	prov, err := pluginapi.NewDeclarativeProvider(manifest, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create declarative provider %q: %w", name, err)
+	}
+
+	restricted, err := applyAllowedOperations(name, intg, prov)
+	if err != nil {
+		return nil, err
+	}
+	result := &ProviderBuildResult{Provider: restricted}
+
+	pluginConfig, err := config.NodeToMap(intg.Plugin.Config)
+	if err != nil {
+		return nil, fmt.Errorf("decode plugin config for %q: %w", name, err)
+	}
+	authHandler, err := buildOAuthHandlerFromManifest(manifest, pluginConfig, deps)
+	if err != nil {
+		slog.Warn("cannot build oauth handler from manifest", "provider", name, "error", err)
+	} else if authHandler != nil {
+		result.ConnectionAuth = map[string]OAuthHandler{
+			config.PluginConnectionName: authHandler,
+		}
+	}
+	return result, nil
 }
 
 func applyAllowedOperations(name string, intg config.IntegrationDef, pluginProv core.Provider) (core.Provider, error) {
@@ -841,6 +878,10 @@ func buildPluginOAuthHandler(intg config.IntegrationDef, pluginConfig map[string
 	if err != nil {
 		return nil, err
 	}
+	return buildOAuthHandlerFromManifest(manifest, pluginConfig, deps)
+}
+
+func buildOAuthHandlerFromManifest(manifest *pluginmanifestv1.Manifest, pluginConfig map[string]any, deps Deps) (OAuthHandler, error) {
 	if manifest.Provider == nil || manifest.Provider.Auth == nil || manifest.Provider.Auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
 		return nil, nil
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,6 +105,7 @@ type ExecutablePluginDef struct {
 	AllowedOperations map[string]*OperationOverride `yaml:"allowed_operations"`
 
 	ResolvedManifestPath string `yaml:"-"`
+	IsDeclarative        bool   `yaml:"-"`
 }
 
 func (p *ExecutablePluginDef) HasManagedArtifacts() bool {

--- a/internal/operator/lifecycle.go
+++ b/internal/operator/lifecycle.go
@@ -478,12 +478,14 @@ func pluginEntryMatches(paths initPaths, name string, plugin *config.ExecutableP
 		return false
 	}
 	manifestPath := resolveLockPath(paths.configDir, entry.Manifest)
-	executablePath := resolveLockPath(paths.configDir, entry.Executable)
 	if _, err := os.Stat(manifestPath); err != nil {
 		return false
 	}
-	if _, err := os.Stat(executablePath); err != nil {
-		return false
+	if entry.Executable != "" {
+		executablePath := resolveLockPath(paths.configDir, entry.Executable)
+		if _, err := os.Stat(executablePath); err != nil {
+			return false
+		}
 	}
 	if entry.Source == "" && entry.SourceDigest != "" && !strings.HasPrefix(plugin.Package, "https://") {
 		digest, err := sourceDigestForPackage(plugin.Package)
@@ -617,16 +619,20 @@ func lockEntryForPackage(ctx context.Context, paths initPaths, store *pluginstor
 	if err != nil {
 		return LockPluginEntry{}, fmt.Errorf("compute manifest path for %s %q: %w", kind, name, err)
 	}
-	executablePath, err := filepath.Rel(paths.configDir, installed.ExecutablePath)
-	if err != nil {
-		return LockPluginEntry{}, fmt.Errorf("compute executable path for %s %q: %w", kind, name, err)
+	var executableRel string
+	if installed.ExecutablePath != "" {
+		executablePath, err := filepath.Rel(paths.configDir, installed.ExecutablePath)
+		if err != nil {
+			return LockPluginEntry{}, fmt.Errorf("compute executable path for %s %q: %w", kind, name, err)
+		}
+		executableRel = filepath.ToSlash(executablePath)
 	}
 	return LockPluginEntry{
 		Fingerprint:  fingerprint,
 		Package:      plugin.Package,
 		SourceDigest: sourceDigest,
 		Manifest:     filepath.ToSlash(manifestPath),
-		Executable:   filepath.ToSlash(executablePath),
+		Executable:   executableRel,
 	}, nil
 }
 
@@ -667,9 +673,13 @@ func (l *Lifecycle) lockEntryForSource(ctx context.Context, paths initPaths, sto
 	if err != nil {
 		return LockPluginEntry{}, fmt.Errorf("compute manifest path for %s %q: %w", kind, name, err)
 	}
-	executablePath, err := filepath.Rel(paths.configDir, installed.ExecutablePath)
-	if err != nil {
-		return LockPluginEntry{}, fmt.Errorf("compute executable path for %s %q: %w", kind, name, err)
+	var executableRel string
+	if installed.ExecutablePath != "" {
+		ep, err := filepath.Rel(paths.configDir, installed.ExecutablePath)
+		if err != nil {
+			return LockPluginEntry{}, fmt.Errorf("compute executable path for %s %q: %w", kind, name, err)
+		}
+		executableRel = filepath.ToSlash(ep)
 	}
 	return LockPluginEntry{
 		Fingerprint:   fingerprint,
@@ -678,7 +688,7 @@ func (l *Lifecycle) lockEntryForSource(ctx context.Context, paths initPaths, sto
 		ResolvedURL:   resolved.ResolvedURL,
 		ArchiveSHA256: resolved.ArchiveSHA256,
 		Manifest:      filepath.ToSlash(manifestPath),
-		Executable:    filepath.ToSlash(executablePath),
+		Executable:    executableRel,
 	}, nil
 }
 
@@ -867,12 +877,8 @@ func applyLockedPluginEntry(paths initPaths, lock *Lockfile, kind, name string, 
 	}
 
 	manifestPath := resolveLockPath(paths.configDir, entry.Manifest)
-	executablePath := resolveLockPath(paths.configDir, entry.Executable)
 	if _, err := os.Stat(manifestPath); err != nil {
 		return fmt.Errorf("prepared manifest for %s %q not found at %s; run `gestaltd bundle --config %s --output DIR`", kind, name, manifestPath, paths.configPath)
-	}
-	if _, err := os.Stat(executablePath); err != nil {
-		return fmt.Errorf("prepared executable for %s %q not found at %s; run `gestaltd bundle --config %s --output DIR`", kind, name, executablePath, paths.configPath)
 	}
 
 	_, manifest, err := pluginpkg.ReadManifestFile(manifestPath)
@@ -882,6 +888,18 @@ func applyLockedPluginEntry(paths initPaths, lock *Lockfile, kind, name string, 
 	if err := pluginpkg.ValidateConfigForManifest(manifestPath, manifest, manifestKind(kind), configMap); err != nil {
 		return fmt.Errorf("plugin config validation for %s %q: %w", kind, name, err)
 	}
+
+	if kind == "integration" && manifest.Provider.IsDeclarative() {
+		plugin.ResolvedManifestPath = manifestPath
+		plugin.IsDeclarative = true
+		return nil
+	}
+
+	executablePath := resolveLockPath(paths.configDir, entry.Executable)
+	if _, err := os.Stat(executablePath); err != nil {
+		return fmt.Errorf("prepared executable for %s %q not found at %s; run `gestaltd bundle --config %s --output DIR`", kind, name, executablePath, paths.configPath)
+	}
+
 	args, err := entrypointArgs(kind, manifest)
 	if err != nil {
 		return fmt.Errorf("resolve entrypoint for %s %q: %w", kind, name, err)

--- a/internal/pluginapi/declarative.go
+++ b/internal/pluginapi/declarative.go
@@ -1,0 +1,193 @@
+package pluginapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/apiexec"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
+)
+
+const declarativeHTTPTimeout = 30 * time.Second
+
+type declarativeOp struct {
+	method    string
+	path      string
+	paramLocs map[string]string
+}
+
+type DeclarativeProvider struct {
+	name        string
+	displayName string
+	description string
+	baseURL     string
+	auth        *pluginmanifestv1.ProviderAuth
+	operations  []core.Operation
+	opDefs      map[string]*declarativeOp
+	httpClient  *http.Client
+}
+
+func NewDeclarativeProvider(manifest *pluginmanifestv1.Manifest, httpClient *http.Client) (*DeclarativeProvider, error) {
+	if manifest == nil {
+		return nil, fmt.Errorf("manifest is required")
+	}
+	if manifest.Provider == nil || !manifest.Provider.IsDeclarative() {
+		return nil, fmt.Errorf("manifest is not a declarative provider")
+	}
+
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: declarativeHTTPTimeout}
+	}
+
+	p := &DeclarativeProvider{
+		name:        nameFromManifest(manifest),
+		displayName: manifest.DisplayName,
+		description: manifest.Description,
+		baseURL:     manifest.Provider.BaseURL,
+		auth:        manifest.Provider.Auth,
+		opDefs:      make(map[string]*declarativeOp, len(manifest.Provider.Operations)),
+		httpClient:  httpClient,
+	}
+
+	for i := range manifest.Provider.Operations {
+		mop := &manifest.Provider.Operations[i]
+		locs := make(map[string]string, len(mop.Parameters))
+		for _, mp := range mop.Parameters {
+			locs[mp.Name] = mp.In
+		}
+		p.opDefs[mop.Name] = &declarativeOp{
+			method:    mop.Method,
+			path:      mop.Path,
+			paramLocs: locs,
+		}
+		coreOp := core.Operation{
+			Name:        mop.Name,
+			Description: mop.Description,
+			Method:      mop.Method,
+		}
+		for _, mp := range mop.Parameters {
+			coreOp.Parameters = append(coreOp.Parameters, core.Parameter{
+				Name:        mp.Name,
+				Type:        mp.Type,
+				Description: mp.Description,
+				Required:    mp.Required,
+			})
+		}
+		p.operations = append(p.operations, coreOp)
+	}
+
+	return p, nil
+}
+
+func nameFromManifest(m *pluginmanifestv1.Manifest) string {
+	if m.Source != "" {
+		return m.Source
+	}
+	return m.ID
+}
+
+func (p *DeclarativeProvider) Name() string        { return p.name }
+func (p *DeclarativeProvider) DisplayName() string { return p.displayName }
+func (p *DeclarativeProvider) Description() string { return p.description }
+
+func (p *DeclarativeProvider) ConnectionMode() core.ConnectionMode {
+	return core.ConnectionModeUser
+}
+
+func (p *DeclarativeProvider) ListOperations() []core.Operation {
+	out := make([]core.Operation, len(p.operations))
+	copy(out, p.operations)
+	return out
+}
+
+func (p *DeclarativeProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
+	op, ok := p.opDefs[operation]
+	if !ok {
+		return &core.OperationResult{
+			Status: http.StatusNotFound,
+			Body:   `{"error":"unknown operation"}`,
+		}, nil
+	}
+
+	queryParams := make(map[string]any)
+	bodyParams := make(map[string]any)
+
+	isBodyMethod := op.method == http.MethodPost || op.method == http.MethodPut || op.method == http.MethodPatch
+
+	for k, v := range params {
+		loc, declared := op.paramLocs[k]
+		if !declared {
+			if isBodyMethod {
+				loc = "body"
+			} else {
+				loc = "query"
+			}
+		}
+		switch loc {
+		case "query":
+			queryParams[k] = v
+		case "body", "path":
+			bodyParams[k] = v
+		}
+	}
+
+	req := apiexec.Request{
+		Method:      op.method,
+		BaseURL:     p.baseURL,
+		Path:        op.path,
+		Params:      bodyParams,
+		QueryParams: queryParams,
+		Token:       token,
+		NoRetry:     true,
+	}
+
+	return apiexec.Do(ctx, p.httpClient, req)
+}
+
+func (p *DeclarativeProvider) SupportsManualAuth() bool {
+	if p.auth == nil {
+		return false
+	}
+	return p.auth.Type == pluginmanifestv1.AuthTypeManual || p.auth.Type == pluginmanifestv1.AuthTypeBearer
+}
+
+func (p *DeclarativeProvider) AuthTypes() []string {
+	if p.auth == nil {
+		return nil
+	}
+	switch p.auth.Type {
+	case pluginmanifestv1.AuthTypeOAuth2:
+		return []string{"oauth2"}
+	case pluginmanifestv1.AuthTypeBearer:
+		return []string{"manual"}
+	case pluginmanifestv1.AuthTypeManual:
+		return []string{"manual"}
+	case pluginmanifestv1.AuthTypeNone:
+		return nil
+	}
+	return nil
+}
+
+func (p *DeclarativeProvider) AuthorizationURL(state string, scopes []string) string {
+	if p.auth == nil || p.auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
+		return ""
+	}
+	return p.auth.AuthorizationURL
+}
+
+func (p *DeclarativeProvider) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	if p.auth == nil || p.auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
+		return nil, fmt.Errorf("provider does not support OAuth")
+	}
+	return nil, fmt.Errorf("declarative OAuth code exchange not yet implemented")
+}
+
+func (p *DeclarativeProvider) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	if p.auth == nil || p.auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
+		return nil, fmt.Errorf("provider does not support OAuth")
+	}
+	return nil, fmt.Errorf("declarative OAuth token refresh not yet implemented")
+}

--- a/internal/pluginapi/declarative_test.go
+++ b/internal/pluginapi/declarative_test.go
@@ -1,0 +1,356 @@
+package pluginapi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
+)
+
+func testManifest(baseURL string) *pluginmanifestv1.Manifest {
+	return &pluginmanifestv1.Manifest{
+		SchemaVersion: pluginmanifestv1.SchemaVersion2,
+		Source:        "github.com/acme/plugins/testapi",
+		Version:       "1.0.0",
+		DisplayName:   "Test API",
+		Description:   "A test API provider",
+		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			BaseURL: baseURL,
+			Auth:    &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeBearer},
+			Operations: []pluginmanifestv1.ProviderOperation{
+				{
+					Name:        "list_items",
+					Description: "List all items",
+					Method:      "GET",
+					Path:        "/items",
+					Parameters: []pluginmanifestv1.ProviderParameter{
+						{Name: "limit", Type: "int", In: "query"},
+						{Name: "cursor", Type: "string", In: "query"},
+					},
+				},
+				{
+					Name:        "create_item",
+					Description: "Create a new item",
+					Method:      "POST",
+					Path:        "/items",
+					Parameters: []pluginmanifestv1.ProviderParameter{
+						{Name: "name", Type: "string", In: "body", Required: true},
+						{Name: "value", Type: "string", In: "body"},
+					},
+				},
+				{
+					Name:        "get_item",
+					Description: "Get item by ID",
+					Method:      "GET",
+					Path:        "/items/{id}",
+					Parameters: []pluginmanifestv1.ProviderParameter{
+						{Name: "id", Type: "string", In: "path", Required: true},
+					},
+				},
+				{
+					Name:        "update_item",
+					Description: "Update an item with query filter",
+					Method:      "POST",
+					Path:        "/items/{id}",
+					Parameters: []pluginmanifestv1.ProviderParameter{
+						{Name: "id", Type: "string", In: "path", Required: true},
+						{Name: "name", Type: "string", In: "body"},
+						{Name: "dry_run", Type: "bool", In: "query"},
+					},
+				},
+			},
+		},
+	}
+}
+
+type capturedRequest struct {
+	method      string
+	path        string
+	query       map[string]string
+	body        map[string]any
+	authHeader  string
+	contentType string
+}
+
+func captureHandler(t *testing.T, captured *capturedRequest, respond map[string]any) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		captured.authHeader = r.Header.Get("Authorization")
+		captured.contentType = r.Header.Get("Content-Type")
+		captured.query = make(map[string]string)
+		for k, v := range r.URL.Query() {
+			captured.query[k] = v[0]
+		}
+		if r.Body != nil {
+			data, _ := io.ReadAll(r.Body)
+			if len(data) > 0 {
+				captured.body = make(map[string]any)
+				_ = json.Unmarshal(data, &captured.body)
+			}
+		}
+		_ = json.NewEncoder(w).Encode(respond)
+	}
+}
+
+func TestDeclarativeProvider_GETWithQueryParams(t *testing.T) {
+	t.Parallel()
+
+	var req capturedRequest
+	srv := httptest.NewServer(captureHandler(t, &req, map[string]any{"ok": true}))
+	defer srv.Close()
+
+	p, err := NewDeclarativeProvider(testManifest(srv.URL), srv.Client())
+	if err != nil {
+		t.Fatalf("NewDeclarativeProvider: %v", err)
+	}
+
+	result, err := p.Execute(context.Background(), "list_items", map[string]any{
+		"limit":  float64(10),
+		"cursor": "abc123",
+	}, "test-token-000")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if req.method != "GET" {
+		t.Errorf("method = %s, want GET", req.method)
+	}
+	if req.path != "/items" {
+		t.Errorf("path = %s, want /items", req.path)
+	}
+	if req.query["limit"] != "10" {
+		t.Errorf("query limit = %s, want 10", req.query["limit"])
+	}
+	if req.query["cursor"] != "abc123" {
+		t.Errorf("query cursor = %s, want abc123", req.query["cursor"])
+	}
+	if req.authHeader != "Bearer test-token-000" {
+		t.Errorf("auth = %s, want Bearer test-token-000", req.authHeader)
+	}
+	if result.Status != http.StatusOK {
+		t.Errorf("status = %d, want 200", result.Status)
+	}
+}
+
+func TestDeclarativeProvider_POSTWithBodyParams(t *testing.T) {
+	t.Parallel()
+
+	var req capturedRequest
+	srv := httptest.NewServer(captureHandler(t, &req, map[string]any{"ok": true, "id": "new-1"}))
+	defer srv.Close()
+
+	p, err := NewDeclarativeProvider(testManifest(srv.URL), srv.Client())
+	if err != nil {
+		t.Fatalf("NewDeclarativeProvider: %v", err)
+	}
+
+	result, err := p.Execute(context.Background(), "create_item", map[string]any{
+		"name":  "widget",
+		"value": "42",
+	}, "test-token-000")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if req.method != "POST" {
+		t.Errorf("method = %s, want POST", req.method)
+	}
+	if req.path != "/items" {
+		t.Errorf("path = %s, want /items", req.path)
+	}
+	if req.body["name"] != "widget" {
+		t.Errorf("body name = %v, want widget", req.body["name"])
+	}
+	if req.body["value"] != "42" {
+		t.Errorf("body value = %v, want 42", req.body["value"])
+	}
+	if req.authHeader != "Bearer test-token-000" {
+		t.Errorf("auth = %s, want Bearer test-token-000", req.authHeader)
+	}
+	if result.Status != http.StatusOK {
+		t.Errorf("status = %d, want 200", result.Status)
+	}
+}
+
+func TestDeclarativeProvider_PathParamSubstitution(t *testing.T) {
+	t.Parallel()
+
+	var req capturedRequest
+	srv := httptest.NewServer(captureHandler(t, &req, map[string]any{"id": "item-42", "name": "thing"}))
+	defer srv.Close()
+
+	p, err := NewDeclarativeProvider(testManifest(srv.URL), srv.Client())
+	if err != nil {
+		t.Fatalf("NewDeclarativeProvider: %v", err)
+	}
+
+	_, err = p.Execute(context.Background(), "get_item", map[string]any{
+		"id": "item-42",
+	}, "tok")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if req.method != "GET" {
+		t.Errorf("method = %s, want GET", req.method)
+	}
+	if req.path != "/items/item-42" {
+		t.Errorf("path = %s, want /items/item-42", req.path)
+	}
+}
+
+func TestDeclarativeProvider_MixedQueryAndBodyParams(t *testing.T) {
+	t.Parallel()
+
+	var req capturedRequest
+	srv := httptest.NewServer(captureHandler(t, &req, map[string]any{"ok": true}))
+	defer srv.Close()
+
+	p, err := NewDeclarativeProvider(testManifest(srv.URL), srv.Client())
+	if err != nil {
+		t.Fatalf("NewDeclarativeProvider: %v", err)
+	}
+
+	_, err = p.Execute(context.Background(), "update_item", map[string]any{
+		"id":      "item-7",
+		"name":    "updated",
+		"dry_run": true,
+	}, "tok")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if req.method != "POST" {
+		t.Errorf("method = %s, want POST", req.method)
+	}
+	if req.path != "/items/item-7" {
+		t.Errorf("path = %s, want /items/item-7", req.path)
+	}
+	if req.query["dry_run"] != "true" {
+		t.Errorf("query dry_run = %s, want true", req.query["dry_run"])
+	}
+	if req.body["name"] != "updated" {
+		t.Errorf("body name = %v, want updated", req.body["name"])
+	}
+	if _, has := req.body["id"]; has {
+		t.Error("body should not contain path param 'id'")
+	}
+	if _, has := req.body["dry_run"]; has {
+		t.Error("body should not contain query param 'dry_run'")
+	}
+}
+
+func TestDeclarativeProvider_UnknownOperation(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewDeclarativeProvider(testManifest("http://localhost:0"), nil)
+	if err != nil {
+		t.Fatalf("NewDeclarativeProvider: %v", err)
+	}
+
+	result, err := p.Execute(context.Background(), "nonexistent", nil, "tok")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.Status != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", result.Status)
+	}
+}
+
+func TestDeclarativeProvider_Metadata(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewDeclarativeProvider(testManifest("http://example.com"), nil)
+	if err != nil {
+		t.Fatalf("NewDeclarativeProvider: %v", err)
+	}
+
+	if p.Name() != "github.com/acme/plugins/testapi" {
+		t.Errorf("Name = %s, want github.com/acme/plugins/testapi", p.Name())
+	}
+	if p.DisplayName() != "Test API" {
+		t.Errorf("DisplayName = %s, want Test API", p.DisplayName())
+	}
+	if p.Description() != "A test API provider" {
+		t.Errorf("Description = %s, want A test API provider", p.Description())
+	}
+	if p.ConnectionMode() != "user" {
+		t.Errorf("ConnectionMode = %s, want user", p.ConnectionMode())
+	}
+
+	ops := p.ListOperations()
+	if len(ops) != 4 {
+		t.Fatalf("ListOperations returned %d ops, want 4", len(ops))
+	}
+	if ops[0].Name != "list_items" {
+		t.Errorf("ops[0].Name = %s, want list_items", ops[0].Name)
+	}
+}
+
+func TestDeclarativeProvider_AuthTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		authType string
+		want     []string
+	}{
+		{"oauth2", pluginmanifestv1.AuthTypeOAuth2, []string{"oauth2"}},
+		{"bearer", pluginmanifestv1.AuthTypeBearer, []string{"manual"}},
+		{"manual", pluginmanifestv1.AuthTypeManual, []string{"manual"}},
+		{"none", pluginmanifestv1.AuthTypeNone, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m := testManifest("http://example.com")
+			m.Provider.Auth = &pluginmanifestv1.ProviderAuth{Type: tc.authType}
+			if tc.authType == pluginmanifestv1.AuthTypeOAuth2 {
+				m.Provider.Auth.AuthorizationURL = "https://example.com/auth"
+				m.Provider.Auth.TokenURL = "https://example.com/token"
+			}
+			p, err := NewDeclarativeProvider(m, nil)
+			if err != nil {
+				t.Fatalf("NewDeclarativeProvider: %v", err)
+			}
+			got := p.AuthTypes()
+			if len(got) != len(tc.want) {
+				t.Fatalf("AuthTypes = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("AuthTypes[%d] = %s, want %s", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDeclarativeProvider_OAuthAuthorizationURL(t *testing.T) {
+	t.Parallel()
+
+	m := testManifest("http://example.com")
+	m.Provider.Auth = &pluginmanifestv1.ProviderAuth{
+		Type:             pluginmanifestv1.AuthTypeOAuth2,
+		AuthorizationURL: "https://example.com/oauth/authorize",
+		TokenURL:         "https://example.com/oauth/token",
+		Scopes:           []string{"read", "write"},
+	}
+
+	p, err := NewDeclarativeProvider(m, nil)
+	if err != nil {
+		t.Fatalf("NewDeclarativeProvider: %v", err)
+	}
+
+	url := p.AuthorizationURL("state123", []string{"read"})
+	if url != "https://example.com/oauth/authorize" {
+		t.Errorf("AuthorizationURL = %s, want https://example.com/oauth/authorize", url)
+	}
+}

--- a/internal/pluginpkg/archive.go
+++ b/internal/pluginpkg/archive.go
@@ -19,23 +19,38 @@ import (
 )
 
 func ReadPackageManifest(packagePath string) (_ []byte, _ *pluginmanifestv1.Manifest, err error) {
-	data, err := ReadArchiveEntry(packagePath, ManifestFile)
-	if err != nil {
-		return nil, nil, err
+	var firstErr error
+	for _, name := range ManifestFiles {
+		data, err := ReadArchiveEntry(packagePath, name)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		format := "json"
+		if isYAMLFile(name) {
+			format = "yaml"
+		}
+		manifest, err := DecodeManifestFormat(data, format)
+		if err != nil {
+			return nil, nil, err
+		}
+		return data, manifest, nil
 	}
-	manifest, err := DecodeManifest(data)
-	if err != nil {
-		return nil, nil, err
-	}
-	return data, manifest, nil
+	return nil, nil, firstErr
 }
 
-func ReadManifestFile(path string) ([]byte, *pluginmanifestv1.Manifest, error) {
-	data, err := os.ReadFile(path)
+func ReadManifestFile(p string) ([]byte, *pluginmanifestv1.Manifest, error) {
+	data, err := os.ReadFile(p)
 	if err != nil {
-		return nil, nil, fmt.Errorf("read manifest %q: %w", path, err)
+		return nil, nil, fmt.Errorf("read manifest %q: %w", p, err)
 	}
-	manifest, err := DecodeManifest(data)
+	format := "json"
+	if isYAMLFile(p) {
+		format = "yaml"
+	}
+	manifest, err := DecodeManifestFormat(data, format)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -48,11 +63,15 @@ func LoadManifestFromPath(inputPath string) ([]byte, *pluginmanifestv1.Manifest,
 		return nil, nil, "", fmt.Errorf("stat %q: %w", inputPath, err)
 	}
 	if info.IsDir() {
-		manifestPath := filepath.Join(inputPath, ManifestFile)
+		manifestPath, err := FindManifestFile(inputPath)
+		if err != nil {
+			return nil, nil, "", err
+		}
 		data, manifest, err := ReadManifestFile(manifestPath)
 		return data, manifest, manifestPath, err
 	}
-	if filepath.Base(inputPath) == ManifestFile {
+	base := filepath.Base(inputPath)
+	if base == "plugin.json" || base == "plugin.yaml" || base == "plugin.yml" {
 		data, manifest, err := ReadManifestFile(inputPath)
 		return data, manifest, inputPath, err
 	}
@@ -266,7 +285,11 @@ func ValidatePackageDir(sourceDir string) (*pluginmanifestv1.Manifest, error) {
 }
 
 func loadManifestFromDir(sourceDir string) ([]byte, *pluginmanifestv1.Manifest, error) {
-	return ReadManifestFile(filepath.Join(sourceDir, ManifestFile))
+	p, err := FindManifestFile(sourceDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ReadManifestFile(p)
 }
 
 func archiveEntryPath(name string) (string, error) {

--- a/internal/pluginpkg/digest.go
+++ b/internal/pluginpkg/digest.go
@@ -26,7 +26,11 @@ func DirectoryDigest(dirPath string, manifest *pluginmanifestv1.Manifest) (strin
 
 	var digests []string
 
-	manifestSum, err := fileSHA256(filepath.Join(dirPath, ManifestFile))
+	manifestPath, err := FindManifestFile(dirPath)
+	if err != nil {
+		return "", fmt.Errorf("digest manifest: %w", err)
+	}
+	manifestSum, err := fileSHA256(manifestPath)
 	if err != nil {
 		return "", fmt.Errorf("digest manifest: %w", err)
 	}

--- a/internal/pluginpkg/manifest.go
+++ b/internal/pluginpkg/manifest.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 	"slices"
 	"strings"
@@ -12,11 +14,73 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/valon-technologies/gestalt/internal/pluginsource"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
+	"gopkg.in/yaml.v3"
 )
 
 const ManifestFile = "plugin.json"
 
+var ManifestFiles = []string{"plugin.json", "plugin.yaml", "plugin.yml"}
+
+func FindManifestFile(dir string) (string, error) {
+	for _, name := range ManifestFiles {
+		p := filepath.Join(dir, name)
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf("no manifest file found in %s (tried %s)", dir, strings.Join(ManifestFiles, ", "))
+}
+
+func isYAMLFile(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	return ext == ".yaml" || ext == ".yml"
+}
+
+func yamlToJSON(data []byte) ([]byte, error) {
+	var doc any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse manifest YAML: %w", err)
+	}
+	doc = normalizeYAML(doc)
+	return json.Marshal(doc)
+}
+
+func normalizeYAML(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, v := range val {
+			out[k] = normalizeYAML(v)
+		}
+		return out
+	case []any:
+		out := make([]any, len(val))
+		for i, v := range val {
+			out[i] = normalizeYAML(v)
+		}
+		return out
+	default:
+		return val
+	}
+}
+
 func DecodeManifest(data []byte) (*pluginmanifestv1.Manifest, error) {
+	return DecodeManifestFormat(data, "json")
+}
+
+func DecodeManifestFormat(data []byte, format string) (*pluginmanifestv1.Manifest, error) {
+	jsonData := data
+	if format == "yaml" {
+		var err error
+		jsonData, err = yamlToJSON(data)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return decodeManifestJSON(jsonData)
+}
+
+func decodeManifestJSON(data []byte) (*pluginmanifestv1.Manifest, error) {
 	var header struct {
 		SchemaVersion int `json:"schema_version"`
 	}
@@ -95,16 +159,18 @@ func ValidateManifest(manifest *pluginmanifestv1.Manifest) error {
 		return fmt.Errorf("unsupported manifest schema_version %d", manifest.SchemaVersion)
 	}
 
-	hasExecutableKinds := false
+	isDeclarative := manifest.Provider.IsDeclarative()
+
+	needsArtifacts := false
 	for _, kind := range manifest.Kinds {
-		if kind == pluginmanifestv1.KindProvider || kind == pluginmanifestv1.KindRuntime {
-			hasExecutableKinds = true
+		if kind == pluginmanifestv1.KindRuntime || (kind == pluginmanifestv1.KindProvider && !isDeclarative) {
+			needsArtifacts = true
 			break
 		}
 	}
 
 	var artifactPaths map[string]struct{}
-	if hasExecutableKinds {
+	if needsArtifacts {
 		artifactPaths = make(map[string]struct{}, len(manifest.Artifacts))
 		artifactPlatforms := make(map[string]struct{}, len(manifest.Artifacts))
 		for _, artifact := range manifest.Artifacts {
@@ -130,19 +196,25 @@ func ValidateManifest(manifest *pluginmanifestv1.Manifest) error {
 			if manifest.Provider == nil {
 				return fmt.Errorf("provider metadata is required when kind %q is present", pluginmanifestv1.KindProvider)
 			}
-			if manifest.Provider.Protocol.Min > manifest.Provider.Protocol.Max {
-				return fmt.Errorf("provider.protocol.min must be <= provider.protocol.max")
+			if err := validateProviderAuth(manifest.Provider.Auth); err != nil {
+				return err
 			}
 			if manifest.Provider.ConfigSchemaPath != "" {
 				if err := validateRelativePackagePath(manifest.Provider.ConfigSchemaPath, "provider config schema path"); err != nil {
 					return err
 				}
 			}
-			if err := validateProviderAuth(manifest.Provider.Auth); err != nil {
-				return err
-			}
-			if err := validateEntrypoint(kind, manifest.Entrypoints.Provider, artifactPaths); err != nil {
-				return err
+			if isDeclarative {
+				if err := validateDeclarativeProvider(manifest.Provider); err != nil {
+					return err
+				}
+			} else {
+				if manifest.Provider.Protocol.Min > manifest.Provider.Protocol.Max {
+					return fmt.Errorf("provider.protocol.min must be <= provider.protocol.max")
+				}
+				if err := validateEntrypoint(kind, manifest.Entrypoints.Provider, artifactPaths); err != nil {
+					return err
+				}
 			}
 		case pluginmanifestv1.KindRuntime:
 			if err := validateEntrypoint(kind, manifest.Entrypoints.Runtime, artifactPaths); err != nil {
@@ -229,9 +301,62 @@ func validateProviderAuth(auth *pluginmanifestv1.ProviderAuth) error {
 		if auth.TokenURL == "" {
 			return fmt.Errorf("provider.auth.token_url is required for oauth2")
 		}
-	case pluginmanifestv1.AuthTypeManual, pluginmanifestv1.AuthTypeNone:
+	case pluginmanifestv1.AuthTypeBearer, pluginmanifestv1.AuthTypeManual, pluginmanifestv1.AuthTypeNone:
 	default:
 		return fmt.Errorf("unsupported provider.auth.type %q", auth.Type)
+	}
+	return nil
+}
+
+var validParamIn = map[string]bool{
+	"query": true,
+	"body":  true,
+	"path":  true,
+}
+
+var validHTTPMethods = map[string]bool{
+	"GET":    true,
+	"POST":   true,
+	"PUT":    true,
+	"PATCH":  true,
+	"DELETE": true,
+}
+
+func validateDeclarativeProvider(provider *pluginmanifestv1.Provider) error {
+	if provider.BaseURL == "" {
+		return fmt.Errorf("provider.base_url is required for declarative providers")
+	}
+	seen := make(map[string]struct{}, len(provider.Operations))
+	for i, op := range provider.Operations {
+		if op.Name == "" {
+			return fmt.Errorf("provider.operations[%d].name is required", i)
+		}
+		if _, exists := seen[op.Name]; exists {
+			return fmt.Errorf("duplicate operation name %q", op.Name)
+		}
+		seen[op.Name] = struct{}{}
+		if !validHTTPMethods[op.Method] {
+			return fmt.Errorf("provider.operations[%d].method %q is not a valid HTTP method", i, op.Method)
+		}
+		if op.Path == "" {
+			return fmt.Errorf("provider.operations[%d].path is required", i)
+		}
+		seenParams := make(map[string]struct{}, len(op.Parameters))
+		for j, param := range op.Parameters {
+			if param.Name == "" {
+				return fmt.Errorf("provider.operations[%d].parameters[%d].name is required", i, j)
+			}
+			if _, dup := seenParams[param.Name]; dup {
+				return fmt.Errorf("provider.operations[%d] has duplicate parameter name %q", i, param.Name)
+			}
+			seenParams[param.Name] = struct{}{}
+			if !validParamIn[param.In] {
+				return fmt.Errorf("provider.operations[%d].parameters[%d].in %q must be query, body, or path", i, j, param.In)
+			}
+			if param.In == "path" && !strings.Contains(op.Path, "{"+param.Name+"}") {
+				return fmt.Errorf("provider.operations[%d].parameters[%d] %q declared as path param but %q has no {%s} placeholder", i, j, param.Name, op.Path, param.Name)
+			}
+		}
 	}
 	return nil
 }

--- a/internal/pluginpkg/manifest_test.go
+++ b/internal/pluginpkg/manifest_test.go
@@ -1,6 +1,8 @@
 package pluginpkg
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
@@ -724,7 +726,7 @@ func TestDecodeManifest_V2InvalidAuthType(t *testing.T) {
   "provider": {
     "protocol": { "min": 1, "max": 1 },
     "auth": {
-      "type": "bearer"
+      "type": "bogus"
     }
   },
   "artifacts": [
@@ -805,5 +807,257 @@ func TestDecodeManifest_V2AuthRoundTrip(t *testing.T) {
 	}
 	if got.Provider.Auth.AuthorizationURL != "https://example.com/authorize" {
 		t.Fatalf("auth lost authorization_url across round trip")
+	}
+}
+
+func TestDecodeManifestFormat_YAML(t *testing.T) {
+	t.Parallel()
+
+	yamlData := []byte(`
+schema_version: 2
+source: github.com/acme/plugins/echo
+version: "1.0.0"
+kinds:
+  - provider
+provider:
+  protocol:
+    min: 1
+    max: 1
+artifacts:
+  - os: darwin
+    arch: arm64
+    path: artifacts/darwin/arm64/provider
+    sha256: ` + sha256Hex("provider") + `
+entrypoints:
+  provider:
+    artifact_path: artifacts/darwin/arm64/provider
+`)
+
+	manifest, err := DecodeManifestFormat(yamlData, "yaml")
+	if err != nil {
+		t.Fatalf("DecodeManifestFormat: %v", err)
+	}
+	if manifest.Source != "github.com/acme/plugins/echo" {
+		t.Fatalf("unexpected source %q", manifest.Source)
+	}
+	if manifest.SchemaVersion != pluginmanifestv1.SchemaVersion2 {
+		t.Fatalf("unexpected schema_version %d", manifest.SchemaVersion)
+	}
+}
+
+func TestDecodeManifestFormat_YAMLDeclarative(t *testing.T) {
+	t.Parallel()
+
+	yamlData := []byte(`
+schema_version: 2
+source: github.com/acme/plugins/testapi
+version: "0.1.0"
+display_name: Test API
+description: A test declarative provider
+kinds:
+  - provider
+provider:
+  base_url: https://api.example.com/v1
+  auth:
+    type: bearer
+  operations:
+    - name: list_items
+      description: List all items
+      method: GET
+      path: /items
+      parameters:
+        - name: limit
+          type: int
+          in: query
+    - name: create_item
+      description: Create an item
+      method: POST
+      path: /items
+      parameters:
+        - name: name
+          type: string
+          in: body
+          required: true
+`)
+
+	manifest, err := DecodeManifestFormat(yamlData, "yaml")
+	if err != nil {
+		t.Fatalf("DecodeManifestFormat: %v", err)
+	}
+	if manifest.Provider == nil {
+		t.Fatal("expected provider")
+	}
+	if !manifest.Provider.IsDeclarative() {
+		t.Fatal("expected declarative provider")
+	}
+	if manifest.Provider.BaseURL != "https://api.example.com/v1" {
+		t.Fatalf("unexpected base_url %q", manifest.Provider.BaseURL)
+	}
+	if len(manifest.Provider.Operations) != 2 {
+		t.Fatalf("expected 2 operations, got %d", len(manifest.Provider.Operations))
+	}
+	if manifest.Provider.Operations[0].Name != "list_items" {
+		t.Fatalf("unexpected operation name %q", manifest.Provider.Operations[0].Name)
+	}
+	if manifest.Provider.Operations[1].Parameters[0].Required != true {
+		t.Fatal("expected required param")
+	}
+}
+
+func TestDecodeManifest_DeclarativeProviderJSON(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+  "schema_version": 2,
+  "source": "github.com/acme/plugins/myapi",
+  "version": "1.0.0",
+  "kinds": ["provider"],
+  "provider": {
+    "base_url": "https://api.example.com",
+    "auth": { "type": "bearer" },
+    "operations": [
+      {
+        "name": "get_stuff",
+        "method": "GET",
+        "path": "/stuff",
+        "parameters": [
+          { "name": "q", "type": "string", "in": "query" }
+        ]
+      }
+    ]
+  }
+}`)
+
+	manifest, err := DecodeManifest(data)
+	if err != nil {
+		t.Fatalf("DecodeManifest: %v", err)
+	}
+	if !manifest.Provider.IsDeclarative() {
+		t.Fatal("expected declarative provider")
+	}
+	if len(manifest.Artifacts) != 0 {
+		t.Fatal("declarative provider should have no artifacts")
+	}
+}
+
+func TestDecodeManifest_DeclarativeRejectsMissingBaseURL(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+  "schema_version": 2,
+  "source": "github.com/acme/plugins/myapi",
+  "version": "1.0.0",
+  "kinds": ["provider"],
+  "provider": {
+    "operations": [
+      {
+        "name": "get_stuff",
+        "method": "GET",
+        "path": "/stuff"
+      }
+    ]
+  }
+}`)
+
+	_, err := DecodeManifest(data)
+	if err == nil {
+		t.Fatal("expected error for missing base_url")
+	}
+}
+
+func TestDecodeManifest_DeclarativeRejectsDuplicateOpNames(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+  "schema_version": 2,
+  "source": "github.com/acme/plugins/myapi",
+  "version": "1.0.0",
+  "kinds": ["provider"],
+  "provider": {
+    "base_url": "https://api.example.com",
+    "operations": [
+      { "name": "do_thing", "method": "GET", "path": "/a" },
+      { "name": "do_thing", "method": "POST", "path": "/b" }
+    ]
+  }
+}`)
+
+	_, err := DecodeManifest(data)
+	if err == nil {
+		t.Fatal("expected error for duplicate operation names")
+	}
+}
+
+func TestDecodeManifest_DeclarativeRejectsOrphanPathParam(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+  "schema_version": 2,
+  "source": "github.com/acme/plugins/myapi",
+  "version": "1.0.0",
+  "kinds": ["provider"],
+  "provider": {
+    "base_url": "https://api.example.com",
+    "operations": [
+      {
+        "name": "get_item",
+        "method": "GET",
+        "path": "/items",
+        "parameters": [
+          { "name": "id", "type": "string", "in": "path" }
+        ]
+      }
+    ]
+  }
+}`)
+
+	_, err := DecodeManifest(data)
+	if err == nil {
+		t.Fatal("expected error for path param without matching placeholder")
+	}
+}
+
+func TestFindManifestFile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		files    []string
+		wantBase string
+	}{
+		{"json only", []string{"plugin.json"}, "plugin.json"},
+		{"yaml only", []string{"plugin.yaml"}, "plugin.yaml"},
+		{"yml only", []string{"plugin.yml"}, "plugin.yml"},
+		{"json takes priority", []string{"plugin.json", "plugin.yaml"}, "plugin.json"},
+		{"yaml before yml", []string{"plugin.yaml", "plugin.yml"}, "plugin.yaml"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			for _, f := range tc.files {
+				if err := os.WriteFile(filepath.Join(dir, f), []byte("{}"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := FindManifestFile(dir)
+			if err != nil {
+				t.Fatalf("FindManifestFile: %v", err)
+			}
+			if filepath.Base(got) != tc.wantBase {
+				t.Errorf("FindManifestFile = %s, want %s", filepath.Base(got), tc.wantBase)
+			}
+		})
+	}
+}
+
+func TestFindManifestFile_NotFound(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	_, err := FindManifestFile(dir)
+	if err == nil {
+		t.Fatal("expected error when no manifest found")
 	}
 }

--- a/internal/pluginstore/store.go
+++ b/internal/pluginstore/store.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strings"
 
+	"slices"
+
 	pluginpkg "github.com/valon-technologies/gestalt/internal/pluginpkg"
 	"github.com/valon-technologies/gestalt/internal/pluginsource"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1"
@@ -107,9 +109,27 @@ func (s *Store) Install(packagePath string) (*InstalledPlugin, error) {
 		if err := pluginpkg.ExtractPackage(packagePath, destDir); err != nil {
 			return nil, err
 		}
-		manifestPath := filepath.Join(destDir, pluginpkg.ManifestFile)
+		manifestPath, _ := pluginpkg.FindManifestFile(destDir)
+		if manifestPath == "" {
+			manifestPath = filepath.Join(destDir, pluginpkg.ManifestFile)
+		}
 		assetRoot := filepath.Join(destDir, filepath.FromSlash(manifest.WebUI.AssetRoot))
 		installed := buildInstalledPlugin(manifest, destDir, manifestPath, "", nil, assetRoot)
+		return installed, nil
+	}
+
+	if manifest.Provider.IsDeclarative() && !slices.Contains(manifest.Kinds, pluginmanifestv1.KindRuntime) {
+		if err := os.MkdirAll(destDir, 0755); err != nil {
+			return nil, fmt.Errorf("create plugin directory: %w", err)
+		}
+		if err := pluginpkg.ExtractPackage(packagePath, destDir); err != nil {
+			return nil, err
+		}
+		manifestPath, err := pluginpkg.FindManifestFile(destDir)
+		if err != nil {
+			manifestPath = filepath.Join(destDir, pluginpkg.ManifestFile)
+		}
+		installed := buildInstalledPlugin(manifest, destDir, manifestPath, "", nil, "")
 		return installed, nil
 	}
 
@@ -133,7 +153,10 @@ func (s *Store) Install(packagePath string) (*InstalledPlugin, error) {
 		return nil, err
 	}
 
-	manifestPath := filepath.Join(destDir, pluginpkg.ManifestFile)
+	manifestPath, _ := pluginpkg.FindManifestFile(destDir)
+	if manifestPath == "" {
+		manifestPath = filepath.Join(destDir, pluginpkg.ManifestFile)
+	}
 	executablePath, err := executablePathForManifest(destDir, manifest)
 	if err != nil {
 		return nil, err
@@ -164,9 +187,38 @@ func (s *Store) InstallFromDir(dirPath string) (*InstalledPlugin, error) {
 		if err := copyDir(dirPath, destDir); err != nil {
 			return nil, fmt.Errorf("copy plugin directory: %w", err)
 		}
-		manifestPath := filepath.Join(destDir, pluginpkg.ManifestFile)
+		mfPath, _ := pluginpkg.FindManifestFile(destDir)
+		if mfPath == "" {
+			mfPath = filepath.Join(destDir, pluginpkg.ManifestFile)
+		}
 		assetRoot := filepath.Join(destDir, filepath.FromSlash(manifest.WebUI.AssetRoot))
-		installed := buildInstalledPlugin(manifest, destDir, manifestPath, "", nil, assetRoot)
+		installed := buildInstalledPlugin(manifest, destDir, mfPath, "", nil, assetRoot)
+		return installed, nil
+	}
+
+	if manifest.Provider.IsDeclarative() && !slices.Contains(manifest.Kinds, pluginmanifestv1.KindRuntime) {
+		if err := os.MkdirAll(destDir, 0755); err != nil {
+			return nil, fmt.Errorf("create plugin directory: %w", err)
+		}
+		manifestSrc, err := pluginpkg.FindManifestFile(dirPath)
+		if err != nil {
+			return nil, fmt.Errorf("find manifest: %w", err)
+		}
+		manifestDest := filepath.Join(destDir, filepath.Base(manifestSrc))
+		if err := copyFile(manifestSrc, manifestDest); err != nil {
+			return nil, fmt.Errorf("copy manifest: %w", err)
+		}
+		for _, schemaRel := range configSchemaPaths(manifest, dirPath) {
+			schemaSrc := filepath.Join(dirPath, filepath.FromSlash(schemaRel))
+			schemaDest := filepath.Join(destDir, filepath.FromSlash(schemaRel))
+			if err := os.MkdirAll(filepath.Dir(schemaDest), 0755); err != nil {
+				return nil, fmt.Errorf("create schema directory: %w", err)
+			}
+			if err := copyFile(schemaSrc, schemaDest); err != nil {
+				return nil, fmt.Errorf("copy config schema %s: %w", schemaRel, err)
+			}
+		}
+		installed := buildInstalledPlugin(manifest, destDir, manifestDest, "", nil, "")
 		return installed, nil
 	}
 
@@ -193,8 +245,12 @@ func (s *Store) InstallFromDir(dirPath string) (*InstalledPlugin, error) {
 		return nil, fmt.Errorf("create plugin directory: %w", err)
 	}
 
-	manifestSrc := filepath.Join(dirPath, pluginpkg.ManifestFile)
-	if err := copyFile(manifestSrc, filepath.Join(destDir, pluginpkg.ManifestFile)); err != nil {
+	manifestSrc, err := pluginpkg.FindManifestFile(dirPath)
+	if err != nil {
+		return nil, fmt.Errorf("find manifest: %w", err)
+	}
+	manifestDest := filepath.Join(destDir, filepath.Base(manifestSrc))
+	if err := copyFile(manifestSrc, manifestDest); err != nil {
 		return nil, fmt.Errorf("copy manifest: %w", err)
 	}
 
@@ -222,8 +278,7 @@ func (s *Store) InstallFromDir(dirPath string) (*InstalledPlugin, error) {
 		return nil, err
 	}
 
-	manifestPath := filepath.Join(destDir, pluginpkg.ManifestFile)
-	installed := buildInstalledPlugin(manifest, destDir, manifestPath, executablePath, artifact, "")
+	installed := buildInstalledPlugin(manifest, destDir, manifestDest, executablePath, artifact, "")
 	return installed, nil
 }
 
@@ -292,6 +347,9 @@ func executablePathForManifest(root string, manifest *pluginmanifestv1.Manifest)
 		return "", fmt.Errorf("manifest is required")
 	}
 	if isWebUIOnly(manifest) {
+		return "", nil
+	}
+	if manifest.Provider.IsDeclarative() && !slices.Contains(manifest.Kinds, pluginmanifestv1.KindRuntime) {
 		return "", nil
 	}
 	var entry *pluginmanifestv1.Entrypoint

--- a/sdk/pluginmanifest/v1/manifest.v2.jsonschema.json
+++ b/sdk/pluginmanifest/v1/manifest.v2.jsonschema.json
@@ -42,9 +42,6 @@
     "provider": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "protocol"
-      ],
       "properties": {
         "protocol": {
           "type": "object",
@@ -73,6 +70,17 @@
         },
         "mcp": {
           "type": "boolean"
+        },
+        "base_url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operations": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/provider_operation"
+          }
         }
       }
     },
@@ -119,17 +127,38 @@
       },
       "then": {
         "required": [
-          "artifacts",
-          "entrypoints",
           "provider"
         ],
-        "properties": {
-          "entrypoints": {
+        "anyOf": [
+          {
             "required": [
-              "provider"
-            ]
+              "artifacts",
+              "entrypoints"
+            ],
+            "properties": {
+              "entrypoints": {
+                "required": [
+                  "provider"
+                ]
+              },
+              "provider": {
+                "required": [
+                  "protocol"
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "provider": {
+                "required": [
+                  "base_url",
+                  "operations"
+                ]
+              }
+            }
           }
-        }
+        ]
       }
     },
     {
@@ -181,7 +210,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["oauth2", "manual", "none"]
+          "enum": ["oauth2", "bearer", "manual", "none"]
         },
         "authorization_url": {
           "type": "string",
@@ -224,6 +253,59 @@
           }
         }
       ]
+    },
+    "provider_operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "method", "path"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string"
+        },
+        "method": {
+          "type": "string",
+          "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/provider_parameter"
+          }
+        }
+      }
+    },
+    "provider_parameter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "type", "in"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "enum": ["string", "int", "bool"]
+        },
+        "in": {
+          "type": "string",
+          "enum": ["query", "body", "path"]
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        }
+      }
     },
     "artifact": {
       "type": "object",

--- a/sdk/pluginmanifest/v1/types.go
+++ b/sdk/pluginmanifest/v1/types.go
@@ -30,14 +30,37 @@ type WebUIMetadata struct {
 }
 
 type Provider struct {
-	Protocol         ProtocolRange `json:"protocol"`
-	ConfigSchemaPath string        `json:"config_schema_path,omitempty"`
-	Auth             *ProviderAuth `json:"auth,omitempty"`
-	MCP              bool          `json:"mcp,omitempty"`
+	Protocol         ProtocolRange       `json:"protocol,omitzero"`
+	ConfigSchemaPath string              `json:"config_schema_path,omitempty"`
+	Auth             *ProviderAuth       `json:"auth,omitempty"`
+	MCP              bool                `json:"mcp,omitempty"`
+	BaseURL          string              `json:"base_url,omitempty"`
+	Operations       []ProviderOperation `json:"operations,omitempty"`
+}
+
+func (p *Provider) IsDeclarative() bool {
+	return p != nil && len(p.Operations) > 0
+}
+
+type ProviderOperation struct {
+	Name        string              `json:"name"`
+	Description string              `json:"description,omitempty"`
+	Method      string              `json:"method"`
+	Path        string              `json:"path"`
+	Parameters  []ProviderParameter `json:"parameters,omitempty"`
+}
+
+type ProviderParameter struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	In          string `json:"in"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required,omitempty"`
 }
 
 const (
 	AuthTypeOAuth2 = "oauth2"
+	AuthTypeBearer = "bearer"
 	AuthTypeManual = "manual"
 	AuthTypeNone   = "none"
 )


### PR DESCRIPTION
## Summary
- **Declarative plugins**: Plugin authors can now define REST API operations directly in the manifest (`provider.base_url` + `provider.operations`), eliminating the need to write Go code for straightforward API wrappers. When operations are declared, Gestalt creates an in-process provider using `apiexec.Do` instead of launching a subprocess.
- **YAML manifests**: Manifests can now be `plugin.yaml` or `plugin.yml` in addition to `plugin.json`. YAML is normalized to JSON before schema validation.
- **Schema extension**: The v2 JSON schema is extended with `anyOf` so provider kind accepts either binary plugin fields (artifacts/entrypoints/protocol) or declarative fields (base_url/operations).

## Test plan
- [ ] `go test ./internal/pluginpkg/...` — YAML parsing, declarative manifest validation, FindManifestFile
- [ ] `go test ./internal/pluginapi/...` — DeclarativeProvider Execute with GET/POST/path params/mixed params
- [ ] `go test ./internal/pluginstore/...` — InstallFromDir with declarative manifests
- [ ] `go test ./internal/operator/...` — Lifecycle handles declarative plugins without executables
- [ ] `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)