### PR TITLE
Update Rust client to 2024 edition

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -4,4 +4,4 @@ members = ["cli"]
 
 [workspace.package]
 version = "0.0.1-alpha.9"
-edition = "2021"
+edition = "2024"

--- a/client/cli/src/api.rs
+++ b/client/cli/src/api.rs
@@ -1,6 +1,6 @@
-use anyhow::{bail, Context, Result};
-use reqwest::blocking::Client;
+use anyhow::{Context, Result, bail};
 use reqwest::StatusCode;
+use reqwest::blocking::Client;
 
 use crate::config::ConfigStore;
 use crate::credentials::CredentialStore;

--- a/client/cli/src/commands/auth.rs
+++ b/client/cli/src/commands/auth.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 
 use crate::api::{self, ApiClient};
 use crate::credentials::{CredentialStore, Credentials};

--- a/client/cli/src/commands/config.rs
+++ b/client/cli/src/commands/config.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 
 use crate::config::ConfigStore;
 use crate::output::{self, Format};

--- a/client/cli/src/commands/describe.rs
+++ b/client/cli/src/commands/describe.rs
@@ -1,17 +1,16 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 
 use crate::api::ApiClient;
 use crate::catalog;
 use crate::output::{self, Format};
 
 pub fn describe(
-    url_override: Option<&str>,
+    client: &ApiClient,
     integration: &str,
     operation: &str,
     format: Format,
 ) -> Result<()> {
-    let client = ApiClient::from_env(url_override)?;
-    let cat = catalog::fetch_catalog(&client, integration)?;
+    let cat = catalog::fetch_catalog(client, integration)?;
 
     let op = match cat.find_operation(operation) {
         Some(op) => op,

--- a/client/cli/src/commands/integrations.rs
+++ b/client/cli/src/commands/integrations.rs
@@ -3,8 +3,7 @@ use anyhow::{Context, Result};
 use crate::api::ApiClient;
 use crate::output::{self, Format};
 
-pub fn list(url_override: Option<&str>, format: Format) -> Result<()> {
-    let client = ApiClient::from_env(url_override)?;
+pub fn list(client: &ApiClient, format: Format) -> Result<()> {
     let resp = client
         .get("/api/v1/integrations")
         .context("failed to list integrations")?;
@@ -34,8 +33,7 @@ pub fn list(url_override: Option<&str>, format: Format) -> Result<()> {
     Ok(())
 }
 
-pub fn connect(url_override: Option<&str>, name: &str) -> Result<()> {
-    let client = ApiClient::from_env(url_override)?;
+pub fn connect(client: &ApiClient, name: &str) -> Result<()> {
     let body = serde_json::json!({"integration": name});
     let resp = client
         .post("/api/v1/auth/start-oauth", &body)

--- a/client/cli/src/commands/invoke.rs
+++ b/client/cli/src/commands/invoke.rs
@@ -6,7 +6,7 @@ use crate::output::{self, Format};
 use crate::params::{self, ParamEntry};
 
 pub fn invoke(
-    url_override: Option<&str>,
+    client: &ApiClient,
     integration: &str,
     operation: &str,
     params: &[ParamEntry],
@@ -14,8 +14,7 @@ pub fn invoke(
     input_file: Option<&str>,
     format: Format,
 ) -> Result<()> {
-    let client = ApiClient::from_env(url_override)?;
-    let cat = catalog::fetch_catalog(&client, integration)?;
+    let cat = catalog::fetch_catalog(client, integration)?;
     let mut param_map = params::assemble_params(params, Some(&cat), operation)?;
 
     if let Some(file_path) = input_file {
@@ -47,13 +46,8 @@ pub fn invoke(
     Ok(())
 }
 
-pub fn list_operations(
-    url_override: Option<&str>,
-    integration: &str,
-    format: Format,
-) -> Result<()> {
-    let client = ApiClient::from_env(url_override)?;
-    let cat = catalog::fetch_catalog(&client, integration)?;
+pub fn list_operations(client: &ApiClient, integration: &str, format: Format) -> Result<()> {
+    let cat = catalog::fetch_catalog(client, integration)?;
 
     match format {
         Format::Json => {

--- a/client/cli/src/commands/tokens.rs
+++ b/client/cli/src/commands/tokens.rs
@@ -3,8 +3,7 @@ use anyhow::{Context, Result};
 use crate::api::ApiClient;
 use crate::output::{self, Format};
 
-pub fn create(url_override: Option<&str>, name: Option<&str>, format: Format) -> Result<()> {
-    let client = ApiClient::from_env(url_override)?;
+pub fn create(client: &ApiClient, name: Option<&str>, format: Format) -> Result<()> {
     let token_name = name.unwrap_or("cli-token");
     let body = serde_json::json!({"name": token_name});
     let resp = client
@@ -26,8 +25,7 @@ pub fn create(url_override: Option<&str>, name: Option<&str>, format: Format) ->
     Ok(())
 }
 
-pub fn list(url_override: Option<&str>, format: Format) -> Result<()> {
-    let client = ApiClient::from_env(url_override)?;
+pub fn list(client: &ApiClient, format: Format) -> Result<()> {
     let resp = client
         .get("/api/v1/tokens")
         .context("failed to list tokens")?;
@@ -54,8 +52,7 @@ pub fn list(url_override: Option<&str>, format: Format) -> Result<()> {
     Ok(())
 }
 
-pub fn revoke(url_override: Option<&str>, id: &str, format: Format) -> Result<()> {
-    let client = ApiClient::from_env(url_override)?;
+pub fn revoke(client: &ApiClient, id: &str, format: Format) -> Result<()> {
     let path = format!("/api/v1/tokens/{}", id);
     let resp = client.delete(&path).context("failed to revoke token")?;
 

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use gestalt::api::ApiClient;
 use gestalt::commands;
 use gestalt::output::{self, Format};
 
@@ -139,12 +140,12 @@ enum TokenCommands {
     },
 }
 
-fn main() {
+fn run() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let format = cli.format;
     let url = cli.url.as_deref();
 
-    let result = match cli.command {
+    match cli.command {
         Commands::Auth { command } => match command {
             AuthCommands::Login => commands::auth::login(url),
             AuthCommands::Logout => commands::auth::logout(),
@@ -157,47 +158,63 @@ fn main() {
             ConfigCommands::Unset { key } => commands::config::unset(&key),
             ConfigCommands::List => commands::config::list(format),
         },
-        Commands::Integrations { command } => match command {
-            IntegrationCommands::List => commands::integrations::list(url, format),
-            IntegrationCommands::Connect { name } => commands::integrations::connect(url, &name),
-        },
+        Commands::Integrations { command } => {
+            let client = ApiClient::from_env(url)?;
+            match command {
+                IntegrationCommands::List => commands::integrations::list(&client, format),
+                IntegrationCommands::Connect { name } => {
+                    commands::integrations::connect(&client, &name)
+                }
+            }
+        }
         Commands::Invoke {
             integration,
             operation,
             params,
             select,
             input_file,
-        } => match operation {
-            Some(op) => commands::invoke::invoke(
-                url,
-                &integration,
-                &op,
-                &params,
-                select.as_deref(),
-                input_file.as_deref(),
-                format,
-            ),
-            None => {
-                if !params.is_empty() {
-                    output::print_warning("parameters ignored; no operation specified");
+        } => {
+            let client = ApiClient::from_env(url)?;
+            match operation {
+                Some(op) => commands::invoke::invoke(
+                    &client,
+                    &integration,
+                    &op,
+                    &params,
+                    select.as_deref(),
+                    input_file.as_deref(),
+                    format,
+                ),
+                None => {
+                    if !params.is_empty() {
+                        output::print_warning("parameters ignored; no operation specified");
+                    }
+                    commands::invoke::list_operations(&client, &integration, format)
                 }
-                commands::invoke::list_operations(url, &integration, format)
             }
-        },
+        }
         Commands::Describe {
             integration,
             operation,
-        } => commands::describe::describe(url, &integration, &operation, format),
-        Commands::Tokens { command } => match command {
-            TokenCommands::Create { name } => {
-                commands::tokens::create(url, name.as_deref(), format)
+        } => {
+            let client = ApiClient::from_env(url)?;
+            commands::describe::describe(&client, &integration, &operation, format)
+        }
+        Commands::Tokens { command } => {
+            let client = ApiClient::from_env(url)?;
+            match command {
+                TokenCommands::Create { name } => {
+                    commands::tokens::create(&client, name.as_deref(), format)
+                }
+                TokenCommands::List => commands::tokens::list(&client, format),
+                TokenCommands::Revoke { id } => commands::tokens::revoke(&client, &id, format),
             }
-            TokenCommands::List => commands::tokens::list(url, format),
-            TokenCommands::Revoke { id } => commands::tokens::revoke(url, &id, format),
-        },
-    };
+        }
+    }
+}
 
-    if let Err(e) = result {
+fn main() {
+    if let Err(e) = run() {
         output::print_error(&format!("{:#}", e));
         std::process::exit(1);
     }

--- a/client/cli/src/params.rs
+++ b/client/cli/src/params.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use std::io::Read;
 
 use crate::catalog::OperationsCatalog;

--- a/client/cli/tests/integration.rs
+++ b/client/cli/tests/integration.rs
@@ -123,9 +123,8 @@ fn test_list_integrations_table_format() {
         )
         .create();
 
-    std::env::set_var("GESTALT_API_KEY", "test-token");
-    let result = gestalt::commands::integrations::list(Some(&server.url()), Format::Table);
-    std::env::remove_var("GESTALT_API_KEY");
+    let client = create_client(&server);
+    let result = gestalt::commands::integrations::list(&client, Format::Table);
 
     mock.assert();
     assert!(result.is_ok());
@@ -170,10 +169,8 @@ fn test_list_operations_formats_parameters() {
         )
         .create();
 
-    std::env::set_var("GESTALT_API_KEY", "test-token");
-    let result =
-        gestalt::commands::invoke::list_operations(Some(&server.url()), "test_svc", Format::Table);
-    std::env::remove_var("GESTALT_API_KEY");
+    let client = create_client(&server);
+    let result = gestalt::commands::invoke::list_operations(&client, "test_svc", Format::Table);
 
     mock.assert();
     assert!(result.is_ok());
@@ -198,10 +195,8 @@ fn test_list_operations_json_format() {
         )
         .create();
 
-    std::env::set_var("GESTALT_API_KEY", "test-token");
-    let result =
-        gestalt::commands::invoke::list_operations(Some(&server.url()), "test_svc", Format::Json);
-    std::env::remove_var("GESTALT_API_KEY");
+    let client = create_client(&server);
+    let result = gestalt::commands::invoke::list_operations(&client, "test_svc", Format::Json);
 
     mock.assert();
     assert!(result.is_ok());
@@ -217,10 +212,8 @@ fn test_list_operations_empty_parameters() {
         .with_body(r#"[{"id": "list_items", "description": "Lists items", "method": "GET", "parameters": []}]"#)
         .create();
 
-    std::env::set_var("GESTALT_API_KEY", "test-token");
-    let result =
-        gestalt::commands::invoke::list_operations(Some(&server.url()), "test_svc", Format::Table);
-    std::env::remove_var("GESTALT_API_KEY");
+    let client = create_client(&server);
+    let result = gestalt::commands::invoke::list_operations(&client, "test_svc", Format::Table);
 
     mock.assert();
     assert!(result.is_ok());
@@ -293,9 +286,9 @@ fn test_invoke_typed_params() {
         },
     ];
 
-    std::env::set_var("GESTALT_API_KEY", "test-token");
+    let client = create_client(&server);
     let result = gestalt::commands::invoke::invoke(
-        Some(&server.url()),
+        &client,
         "test_svc",
         "do_thing",
         &params,
@@ -303,7 +296,6 @@ fn test_invoke_typed_params() {
         None,
         Format::Json,
     );
-    std::env::remove_var("GESTALT_API_KEY");
 
     invoke_mock.assert();
     assert!(result.is_ok());
@@ -320,14 +312,9 @@ fn test_describe_operation() {
         .with_body(catalog_body())
         .create();
 
-    std::env::set_var("GESTALT_API_KEY", "test-token");
-    let result = gestalt::commands::describe::describe(
-        Some(&server.url()),
-        "test_svc",
-        "do_thing",
-        Format::Table,
-    );
-    std::env::remove_var("GESTALT_API_KEY");
+    let client = create_client(&server);
+    let result =
+        gestalt::commands::describe::describe(&client, "test_svc", "do_thing", Format::Table);
 
     mock.assert();
     assert!(result.is_ok());


### PR DESCRIPTION
The workspace edition is bumped from 2021 to 2024. In edition 2024, `std::env::set_var` and `std::env::remove_var` became unsafe functions. Rather than sprinkling unsafe blocks throughout the test suite, this refactors command functions to accept an `&ApiClient` parameter directly, so tests construct clients via `ApiClient::new` and never mutate the process environment.