### PR TITLE
Replace hand-rolled map cloning and deduplicate JSON path extraction

### DIFF
--- a/core/integration/base.go
+++ b/core/integration/base.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"maps"
 	"net/http"
 	"time"
 
@@ -228,7 +229,7 @@ func (b *Base) ListOperations() []core.Operation { return b.Operations }
 
 func (b *Base) resolvedURLAndHeaders(ctx context.Context) (string, map[string]string) {
 	baseURL := b.BaseURL
-	headers := egress.CopyHeaders(b.Headers)
+	headers := maps.Clone(b.Headers)
 	if cp := core.ConnectionParams(ctx); cp != nil {
 		baseURL = paraminterp.Interpolate(baseURL, cp)
 		for k, v := range headers {

--- a/core/integration/egress_adapter.go
+++ b/core/integration/egress_adapter.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 
@@ -47,7 +48,7 @@ func (b *Base) executeREST(ctx context.Context, operation string, params map[str
 	if err != nil {
 		return nil, err
 	}
-	req.CustomHeaders = egress.CopyHeaders(resolved.Headers)
+	req.CustomHeaders = maps.Clone(resolved.Headers)
 
 	if pgn, ok := b.Pagination[operation]; ok {
 		return apiexec.DoPaginatedWithExecutor(ctx, b.httpClient(), req, pgn, executeEgressHTTP)
@@ -69,7 +70,7 @@ func (b *Base) resolveEgress(ctx context.Context, operation string, req apiexec.
 			Method:    req.Method,
 			Path:      apiexec.ExpandedPathWithQuery(req.Method, req.Path, req.Params, req.QueryParams),
 		},
-		Headers:    egress.CopyHeaders(req.CustomHeaders),
+		Headers:    maps.Clone(req.CustomHeaders),
 		Credential: credentialFromAPIRequest(req),
 	})
 }
@@ -93,7 +94,7 @@ func (b *Base) resolveGraphQLEgress(ctx context.Context, operation string, req a
 			Host:      parsed.Host,
 			Path:      parsed.Path,
 		},
-		Headers:    egress.CopyHeaders(req.CustomHeaders),
+		Headers:    maps.Clone(req.CustomHeaders),
 		Credential: credentialFromGraphQLRequest(req),
 	})
 }
@@ -130,7 +131,7 @@ func egressRequestFromAPIExec(req apiexec.Request) egress.HTTPRequestSpec {
 		BaseURL:     req.BaseURL,
 		Params:      req.Params,
 		QueryParams: req.QueryParams,
-		Headers:     egress.CopyHeaders(req.CustomHeaders),
+		Headers:     maps.Clone(req.CustomHeaders),
 		Body:        req.Body,
 		ContentType: req.ContentType,
 		Check:       req.CheckResponse,

--- a/internal/apiexec/apiexec.go
+++ b/internal/apiexec/apiexec.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -81,7 +82,7 @@ type Request struct {
 
 // Do executes the request and returns an OperationResult.
 func Do(ctx context.Context, client *http.Client, req Request) (*core.OperationResult, error) {
-	params := copyParams(req.Params)
+	params := maps.Clone(req.Params)
 
 	path, err := substitutePath(req.Path, params)
 	if err != nil {
@@ -336,7 +337,7 @@ func ExpandedPath(method, path string, params map[string]any) string {
 }
 
 func ExpandedPathWithQuery(method, path string, params map[string]any, queryParams map[string]any) string {
-	params = copyParams(params)
+	params = maps.Clone(params)
 	expanded, err := substitutePath(path, params)
 	if err != nil {
 		return path
@@ -370,17 +371,6 @@ func addQueryValue(q url.Values, key string, value any) {
 	default:
 		q.Add(key, fmt.Sprintf("%v", value))
 	}
-}
-
-func copyParams(params map[string]any) map[string]any {
-	if params == nil {
-		return nil
-	}
-	cp := make(map[string]any, len(params))
-	for k, v := range params {
-		cp[k] = v
-	}
-	return cp
 }
 
 func substitutePath(path string, params map[string]any) (string, error) {

--- a/internal/apiexec/pagination.go
+++ b/internal/apiexec/pagination.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"strconv"
 	"strings"
@@ -54,7 +55,7 @@ func DoPaginatedWithExecutor(ctx context.Context, client *http.Client, req Reque
 }
 
 func doPaginated(ctx context.Context, client *http.Client, req Request, pgn PaginationConfig, exec RequestExecutor) (*core.OperationResult, error) {
-	params := copyParams(req.Params)
+	params := maps.Clone(req.Params)
 	if params == nil {
 		params = make(map[string]any)
 	}
@@ -77,7 +78,7 @@ func doPaginated(ctx context.Context, client *http.Client, req Request, pgn Pagi
 
 	for page := 0; page < maxPages; page++ {
 		pageReq := req
-		pageReq.Params = copyParams(params)
+		pageReq.Params = maps.Clone(params)
 
 		result, err := exec(ctx, client, pageReq)
 		if err != nil {
@@ -90,7 +91,7 @@ func doPaginated(ctx context.Context, client *http.Client, req Request, pgn Pagi
 			return nil, fmt.Errorf("parsing paginated response: %w", err)
 		}
 
-		pageResults, ok := extractJSONPath(parsed, pgn.ResultsPath)
+		pageResults, ok := ExtractJSONPath(parsed, pgn.ResultsPath)
 		if !ok {
 			break
 		}
@@ -102,7 +103,7 @@ func doPaginated(ctx context.Context, client *http.Client, req Request, pgn Pagi
 
 		switch pgn.Style {
 		case PaginationStyleCursor:
-			cursor, ok := extractJSONPath(parsed, pgn.CursorPath)
+			cursor, ok := ExtractJSONPath(parsed, pgn.CursorPath)
 			if !ok || cursor == nil {
 				return combinedResult(lastStatus, allResults)
 			}
@@ -155,8 +156,7 @@ func combinedResult(status int, results []any) (*core.OperationResult, error) {
 	}, nil
 }
 
-// extractJSONPath traverses a parsed JSON value using a dotted path (e.g. "data.items").
-func extractJSONPath(data any, path string) (any, bool) {
+func ExtractJSONPath(data any, path string) (any, bool) {
 	if path == "" {
 		return data, true
 	}

--- a/internal/egress/resolution.go
+++ b/internal/egress/resolution.go
@@ -1,6 +1,9 @@
 package egress
 
-import "context"
+import (
+	"context"
+	"maps"
+)
 
 type ResolutionInput struct {
 	Target     Target
@@ -38,7 +41,7 @@ func (r Resolver) Resolve(ctx context.Context, input ResolutionInput) (Resolutio
 	policy := PolicyInput{
 		Subject: subject,
 		Target:  input.Target,
-		Headers: CopyHeaders(input.Headers),
+		Headers: maps.Clone(input.Headers),
 	}
 	if err := EvaluatePolicy(ctx, r.Policy, policy); err != nil {
 		return Resolution{}, err
@@ -66,15 +69,4 @@ func (r Resolver) Resolve(ctx context.Context, input ResolutionInput) (Resolutio
 		Credential: CredentialMaterialization{Authorization: credential.Authorization},
 		Policy:     policy,
 	}, nil
-}
-
-func CopyHeaders(headers map[string]string) map[string]string {
-	if headers == nil {
-		return nil
-	}
-	out := make(map[string]string, len(headers))
-	for k, v := range headers {
-		out[k] = v
-	}
-	return out
 }

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -428,19 +428,11 @@ func matchValue(actual, expected any) bool {
 }
 
 func extractJSONPath(data map[string]any, path string) (string, bool) {
-	parts := strings.Split(path, ".")
-	var current any = data
-	for _, part := range parts {
-		m, ok := current.(map[string]any)
-		if !ok {
-			return "", false
-		}
-		current, ok = m[part]
-		if !ok {
-			return "", false
-		}
+	v, ok := apiexec.ExtractJSONPath(data, path)
+	if !ok {
+		return "", false
 	}
-	return fmt.Sprintf("%v", current), true
+	return fmt.Sprintf("%v", v), true
 }
 
 func buildPaginationConfigs(def *Definition) map[string]apiexec.PaginationConfig {


### PR DESCRIPTION
Replace `copyParams` and `CopyHeaders` with `maps.Clone` from the Go
stdlib, which does the same shallow clone with nil passthrough. Export
`ExtractJSONPath` from the `apiexec` package and reuse it in
`provider/build.go`, eliminating a duplicate implementation.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>