### PR TITLE
Use `core.BearerScheme` constant instead of raw `"Bearer "` strings

### DIFF
--- a/internal/egress/credentials.go
+++ b/internal/egress/credentials.go
@@ -3,6 +3,8 @@ package egress
 import (
 	"encoding/base64"
 	"fmt"
+
+	"github.com/valon-technologies/gestalt/core"
 )
 
 // AuthStyle determines how a stored credential should be materialized.
@@ -43,7 +45,7 @@ func MaterializeCredential(token string, style AuthStyle, parser TokenParser) (C
 		if token == "" {
 			return CredentialMaterialization{}, nil
 		}
-		return CredentialMaterialization{Authorization: "Bearer " + token}, nil
+		return CredentialMaterialization{Authorization: core.BearerScheme + token}, nil
 	case AuthStyleRaw:
 		return CredentialMaterialization{Authorization: token}, nil
 	case AuthStyleBasic:

--- a/internal/mcpoauth/discovery.go
+++ b/internal/mcpoauth/discovery.go
@@ -111,7 +111,7 @@ func parseResourceMetadataFromWWWAuth(header string) string {
 	if header == "" {
 		return ""
 	}
-	header = strings.TrimPrefix(header, "Bearer ")
+	header = strings.TrimPrefix(header, core.BearerScheme)
 	for _, part := range strings.Split(header, ",") {
 		part = strings.TrimSpace(part)
 		if strings.HasPrefix(part, "resource_metadata=") {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1022,7 +1022,7 @@ type bearerTransport struct {
 func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if req.Header.Get("Authorization") == "" {
 		req = req.Clone(req.Context())
-		req.Header.Set("Authorization", "Bearer "+t.token)
+		req.Header.Set("Authorization", core.BearerScheme+t.token)
 	}
 	return t.base.RoundTrip(req)
 }


### PR DESCRIPTION
Three call sites were still using the literal `"Bearer "` string instead of
the existing `core.BearerScheme` constant. This aligns them with the rest of
the codebase, which already uses the constant in nine other locations.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>