### PR TITLE
Clean up Rust CLI: use stdlib constants and secure RNG

### DIFF
--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -19,6 +19,7 @@ anyhow = "1"
 open = "5"
 terminal_size = "0.4.4"
 url = "2"
+getrandom = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/client/cli/src/api.rs
+++ b/client/cli/src/api.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result, bail};
 use reqwest::StatusCode;
 use reqwest::blocking::Client;
+use reqwest::header::{self, HeaderValue};
 
 use crate::config::ConfigStore;
 use crate::credentials::CredentialStore;
@@ -98,8 +99,12 @@ impl ApiClient {
     }
 
     pub fn new(base_url: &str, token: &str) -> Result<Self> {
+        let mut default_headers = header::HeaderMap::new();
+        default_headers.insert(header::ACCEPT, HeaderValue::from_static("application/json"));
+
         let client = Client::builder()
             .timeout(std::time::Duration::from_secs(30))
+            .default_headers(default_headers)
             .build()
             .context("failed to build HTTP client")?;
 
@@ -117,7 +122,6 @@ impl ApiClient {
             .client
             .get(&url)
             .bearer_auth(&self.token)
-            .header("Accept", "application/json")
             .send()
             .with_context(|| format!("request to {} failed", url))?;
 
@@ -130,8 +134,6 @@ impl ApiClient {
             .client
             .post(&url)
             .bearer_auth(&self.token)
-            .header("Content-Type", "application/json")
-            .header("Accept", "application/json")
             .json(body)
             .send()
             .with_context(|| format!("request to {} failed", url))?;
@@ -145,7 +147,6 @@ impl ApiClient {
             .client
             .delete(&url)
             .bearer_auth(&self.token)
-            .header("Accept", "application/json")
             .send()
             .with_context(|| format!("request to {} failed", url))?;
 

--- a/client/cli/src/commands/auth.rs
+++ b/client/cli/src/commands/auth.rs
@@ -6,6 +6,8 @@ use crate::api::{self, ApiClient};
 use crate::credentials::{CredentialStore, Credentials};
 use crate::output::{self, Format};
 
+const SESSION_COOKIE_PREFIX: &str = "session_token=";
+
 pub fn login(url_override: Option<&str>) -> Result<()> {
     if api::env_api_key_is_set() {
         bail!(
@@ -21,7 +23,7 @@ pub fn login(url_override: Option<&str>) -> Result<()> {
         std::net::TcpListener::bind("127.0.0.1:0").context("failed to bind callback listener")?;
     let port = listener.local_addr()?.port();
 
-    let state = format!("{:x}", rand_u64());
+    let state = random_hex_string();
 
     let login_url = format!("{}/api/v1/auth/login", base_url);
     let client = reqwest::blocking::Client::builder()
@@ -117,7 +119,7 @@ pub fn login(url_override: Option<&str>) -> Result<()> {
         .iter()
         .filter_map(|v| v.to_str().ok())
         .find_map(|v| {
-            v.strip_prefix("session_token=")
+            v.strip_prefix(SESSION_COOKIE_PREFIX)
                 .map(|rest| rest.split(';').next().unwrap_or(rest).to_string())
         })
         .context("callback response missing session cookie")?;
@@ -205,8 +207,8 @@ pub fn status(url_override: Option<&str>, format: Format) -> Result<()> {
     Ok(())
 }
 
-fn rand_u64() -> u64 {
-    use std::collections::hash_map::RandomState;
-    use std::hash::{BuildHasher, Hasher};
-    RandomState::new().build_hasher().finish()
+fn random_hex_string() -> String {
+    let mut buf = [0u8; 16];
+    getrandom::fill(&mut buf).expect("failed to generate random bytes");
+    buf.iter().map(|b| format!("{b:02x}")).collect()
 }


### PR DESCRIPTION
Replace the `RandomState` hasher trick for OAuth state generation with
`getrandom`, which provides cryptographically secure random bytes. Use
`reqwest::header` constants and default headers instead of repeating raw
`"Accept"/"Content-Type"` strings on every request, and remove the
redundant `Content-Type` header that reqwest already sets via `.json()`.
Extract the session cookie name into a constant.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>