### PR TITLE
Add Docker Hub security compliance: non-root users, SBOMs, and vulnerability scanning

### DIFF
--- a/.github/workflows/publish-gestaltd-image.yml
+++ b/.github/workflows/publish-gestaltd-image.yml
@@ -94,7 +94,7 @@ jobs:
           sbom: true
           provenance: mode=max
       - name: Scan runtime image for vulnerabilities
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ env.IMAGE_NAME }}:${{ github.sha }}
           format: table
@@ -102,7 +102,7 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: true
       - name: Scan builder image for vulnerabilities
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ env.IMAGE_NAME }}:builder-${{ github.sha }}
           format: table
@@ -110,7 +110,7 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: true
       - name: Scan debug image for vulnerabilities
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ env.IMAGE_NAME }}:debug-${{ github.sha }}
           format: table

--- a/.github/workflows/publish-gestaltd-image.yml
+++ b/.github/workflows/publish-gestaltd-image.yml
@@ -47,6 +47,8 @@ jobs:
             GESTALT_URL=${{ env.IMAGE_URL }}
           cache-from: type=gha
           cache-to: type=gha,mode=min
+          sbom: true
+          provenance: mode=max
       - name: Build and push builder image
         uses: docker/build-push-action@v5
         with:
@@ -67,6 +69,8 @@ jobs:
             GESTALT_URL=${{ env.IMAGE_URL }}
           cache-from: type=gha
           cache-to: type=gha,mode=min
+          sbom: true
+          provenance: mode=max
       - name: Build and push debug image
         uses: docker/build-push-action@v5
         with:
@@ -87,6 +91,32 @@ jobs:
             GESTALT_URL=${{ env.IMAGE_URL }}
           cache-from: type=gha
           cache-to: type=gha,mode=min
+          sbom: true
+          provenance: mode=max
+      - name: Scan runtime image for vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          format: table
+          exit-code: '1'
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+      - name: Scan builder image for vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:builder-${{ github.sha }}
+          format: table
+          exit-code: '0'
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+      - name: Scan debug image for vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:debug-${{ github.sha }}
+          format: table
+          exit-code: '1'
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
       - name: Update Docker Hub description
         uses: peter-evans/dockerhub-description@v4
         with:

--- a/.github/workflows/release-gestalt-cli.yml
+++ b/.github/workflows/release-gestalt-cli.yml
@@ -73,6 +73,16 @@ jobs:
             valontechnologies/gestalt:latest
           cache-from: type=gha
           cache-to: type=gha,mode=min
+          sbom: true
+          provenance: mode=max
+      - name: Scan CLI image for vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: valontechnologies/gestalt:${{ steps.version.outputs.version }}
+          format: table
+          exit-code: '1'
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
 
   update-formula:
     name: Update Homebrew Formula

--- a/.github/workflows/release-gestalt-cli.yml
+++ b/.github/workflows/release-gestalt-cli.yml
@@ -76,7 +76,7 @@ jobs:
           sbom: true
           provenance: mode=max
       - name: Scan CLI image for vulnerabilities
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: valontechnologies/gestalt:${{ steps.version.outputs.version }}
           format: table

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -147,6 +147,8 @@ jobs:
             GESTALT_URL=${{ env.IMAGE_URL }}
           cache-from: type=gha
           cache-to: type=gha,mode=min
+          sbom: true
+          provenance: mode=max
       - name: Build and push builder image
         uses: docker/build-push-action@v5
         with:
@@ -167,6 +169,8 @@ jobs:
             GESTALT_URL=${{ env.IMAGE_URL }}
           cache-from: type=gha
           cache-to: type=gha,mode=min
+          sbom: true
+          provenance: mode=max
       - name: Build and push debug image
         uses: docker/build-push-action@v5
         with:
@@ -187,6 +191,32 @@ jobs:
             GESTALT_URL=${{ env.IMAGE_URL }}
           cache-from: type=gha
           cache-to: type=gha,mode=min
+          sbom: true
+          provenance: mode=max
+      - name: Scan runtime image for vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+          format: table
+          exit-code: '1'
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+      - name: Scan builder image for vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:builder-${{ steps.version.outputs.version }}
+          format: table
+          exit-code: '0'
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+      - name: Scan debug image for vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:debug-${{ steps.version.outputs.version }}
+          format: table
+          exit-code: '1'
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
       - name: Update Docker Hub description
         uses: peter-evans/dockerhub-description@v4
         with:

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -194,7 +194,7 @@ jobs:
           sbom: true
           provenance: mode=max
       - name: Scan runtime image for vulnerabilities
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
           format: table
@@ -202,7 +202,7 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: true
       - name: Scan builder image for vulnerabilities
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ env.IMAGE_NAME }}:builder-${{ steps.version.outputs.version }}
           format: table
@@ -210,7 +210,7 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: true
       - name: Scan debug image for vulnerabilities
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ env.IMAGE_NAME }}:debug-${{ steps.version.outputs.version }}
           format: table

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ LABEL org.opencontainers.image.title="gestaltd" \
       org.opencontainers.image.version="${GESTALT_VERSION}" \
       org.opencontainers.image.revision="${GESTALT_REVISION}" \
       org.opencontainers.image.created="${GESTALT_CREATED}"
-USER nonroot:nonroot
+USER nobody:nobody
 EXPOSE 8080
 ENTRYPOINT ["/gestaltd"]
 CMD ["serve", "--locked", "--config", "/etc/gestalt/config.yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,9 @@ ARG GESTALT_SOURCE
 ARG GESTALT_DOCUMENTATION
 ARG GESTALT_URL
 RUN apk add --no-cache ca-certificates curl
+RUN addgroup -g 65534 -S nonroot && adduser -u 65534 -S -G nonroot -H nonroot
 COPY --from=build-binary /gestaltd /gestaltd
+USER nonroot:nonroot
 LABEL org.opencontainers.image.title="gestaltd debug" \
       org.opencontainers.image.description="Debug image for gestaltd with a shell and troubleshooting tools." \
       org.opencontainers.image.source="${GESTALT_SOURCE}" \
@@ -82,6 +84,7 @@ LABEL org.opencontainers.image.title="gestaltd" \
       org.opencontainers.image.version="${GESTALT_VERSION}" \
       org.opencontainers.image.revision="${GESTALT_REVISION}" \
       org.opencontainers.image.created="${GESTALT_CREATED}"
+USER nonroot:nonroot
 EXPOSE 8080
 ENTRYPOINT ["/gestaltd"]
 CMD ["serve", "--locked", "--config", "/etc/gestalt/config.yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,9 +53,8 @@ ARG GESTALT_SOURCE
 ARG GESTALT_DOCUMENTATION
 ARG GESTALT_URL
 RUN apk add --no-cache ca-certificates curl
-RUN addgroup -g 65534 -S nonroot && adduser -u 65534 -S -G nonroot -H nonroot
 COPY --from=build-binary /gestaltd /gestaltd
-USER nonroot:nonroot
+USER nobody:nobody
 LABEL org.opencontainers.image.title="gestaltd debug" \
       org.opencontainers.image.description="Debug image for gestaltd with a shell and troubleshooting tools." \
       org.opencontainers.image.source="${GESTALT_SOURCE}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ COPY . .
 COPY --from=frontend /web/out/ internal/webui/out/
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /gestaltd ./cmd/gestaltd
+RUN mkdir /data
 
 FROM golang:1.26-alpine AS builder
 ARG GESTALT_VERSION
@@ -54,6 +55,7 @@ ARG GESTALT_DOCUMENTATION
 ARG GESTALT_URL
 RUN apk add --no-cache ca-certificates curl
 COPY --from=build-binary /gestaltd /gestaltd
+RUN mkdir -p /data && chown nobody:nobody /data
 USER nobody:nobody
 LABEL org.opencontainers.image.title="gestaltd debug" \
       org.opencontainers.image.description="Debug image for gestaltd with a shell and troubleshooting tools." \
@@ -75,6 +77,7 @@ ARG GESTALT_SOURCE
 ARG GESTALT_DOCUMENTATION
 ARG GESTALT_URL
 COPY --from=build-binary /gestaltd /gestaltd
+COPY --from=build-binary --chown=nobody:nobody /data /data
 LABEL org.opencontainers.image.title="gestaltd" \
       org.opencontainers.image.description="Self-hosted integration runtime for REST, GraphQL, MCP, and plugins." \
       org.opencontainers.image.source="${GESTALT_SOURCE}" \

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -6,4 +6,5 @@ RUN cargo build --release
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=builder /build/target/release/gestalt /gestalt
+USER nonroot:nonroot
 ENTRYPOINT ["/gestalt"]

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -6,5 +6,5 @@ RUN cargo build --release
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=builder /build/target/release/gestalt /gestalt
-USER nonroot:nonroot
+USER nobody:nobody
 ENTRYPOINT ["/gestalt"]


### PR DESCRIPTION
Run all runtime and debug containers as the non-root user (UID 65534) to
satisfy Docker Hub's security best practices. The distroless base already
ships this user; the Alpine-based debug stage creates it explicitly. The
builder stage is left as root since downstream consumers need write access.

Enable SBOM generation and max-mode provenance attestations on every
build-push-action step across all three publish/release workflows, and add
Trivy vulnerability scanning (CRITICAL+HIGH, ignore-unfixed) after each
image push. The builder image scan is non-blocking since it intentionally
carries a larger tool surface.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>