### PR TITLE
Upgrade dockerhub-description action from v4 to v5

### DIFF
--- a/.github/workflows/publish-gestaltd-image.yml
+++ b/.github/workflows/publish-gestaltd-image.yml
@@ -118,7 +118,7 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: true
       - name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -218,7 +218,7 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: true
       - name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Upgrades `peter-evans/dockerhub-description` from v4 to v5 in both `publish-gestaltd-image.yml` and `release-gestaltd.yml`
- Fixes the 401 Unauthorized error on the "Update Docker Hub description" step by using v5's proper PAT authentication support
- The Docker Hub PAT (`DOCKERHUB_TOKEN`) must have **read/write/delete** scope and the associated user needs **Admin** on the `valontechnologies` Docker Hub org

## Test plan
- [ ] Merge and confirm the next `publish-gestaltd-image` run completes the "Update Docker Hub description" step without 401
- [ ] Verify the Docker Hub repo description at hub.docker.com/r/valontechnologies/gestaltd matches `docs/dockerhub/gestaltd.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)