### PR TITLE
Replace raw log.Printf audit sink with structured slog records

### DIFF
--- a/core/audit.go
+++ b/core/audit.go
@@ -1,6 +1,9 @@
 package core
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 type AuditEntry struct {
 	Timestamp time.Time
@@ -15,5 +18,5 @@ type AuditEntry struct {
 }
 
 type AuditSink interface {
-	Log(entry AuditEntry)
+	Log(ctx context.Context, entry AuditEntry)
 }

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -284,7 +284,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		invocation.WithConnectionAuth(lazyRefreshers(providersReady, connAuthResolver)),
 	)
 	wireCredentialResolver(&deps.Egress, sm)
-	audit := core.AuditSink(invocation.LogAuditSink{})
+	audit := core.AuditSink(invocation.NewSlogAuditSink(nil))
 
 	extensions, err := buildExtensions(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress)
 	if err != nil {

--- a/internal/bootstrap/executable_plugin_test.go
+++ b/internal/bootstrap/executable_plugin_test.go
@@ -90,7 +90,7 @@ func TestExecutableProviderAndRuntimePlugins(t *testing.T) {
 	defer func() { _ = CloseProviders(providers) }()
 
 	broker := invocation.NewBroker(providers, nil)
-	runtimes, err := buildRuntimes(context.Background(), cfg, factories, broker, broker, core.AuditSink(invocation.LogAuditSink{}), EgressDeps{})
+	runtimes, err := buildRuntimes(context.Background(), cfg, factories, broker, broker, core.AuditSink(invocation.NewSlogAuditSink(nil)), EgressDeps{})
 	if err != nil {
 		t.Fatalf("buildRuntimes: %v", err)
 	}
@@ -174,7 +174,7 @@ func TestExecutableRuntimeCapabilities_OmitsMCPPassthroughOnlyCatalogOperations(
 	defer func() { _ = CloseProviders(providers) }()
 
 	broker := invocation.NewBroker(providers, nil)
-	runtimes, err := buildRuntimes(context.Background(), cfg, factories, broker, broker, core.AuditSink(invocation.LogAuditSink{}), EgressDeps{})
+	runtimes, err := buildRuntimes(context.Background(), cfg, factories, broker, broker, core.AuditSink(invocation.NewSlogAuditSink(nil)), EgressDeps{})
 	if err != nil {
 		t.Fatalf("buildRuntimes: %v", err)
 	}
@@ -274,7 +274,7 @@ func TestExecutableRuntimeCapabilities_ExposeOnlyInvokableCatalogOperations(t *t
 	defer func() { _ = CloseProviders(providers) }()
 
 	broker := invocation.NewBroker(providers, nil)
-	runtimes, err := buildRuntimes(context.Background(), cfg, factories, broker, broker, core.AuditSink(invocation.LogAuditSink{}), EgressDeps{})
+	runtimes, err := buildRuntimes(context.Background(), cfg, factories, broker, broker, core.AuditSink(invocation.NewSlogAuditSink(nil)), EgressDeps{})
 	if err != nil {
 		t.Fatalf("buildRuntimes: %v", err)
 	}
@@ -348,7 +348,7 @@ func TestExecutableRuntimeCapabilities_FilterMethodlessFallbackOperations(t *tes
 	defer func() { _ = CloseProviders(providers) }()
 
 	broker := invocation.NewBroker(providers, nil)
-	runtimes, err := buildRuntimes(context.Background(), cfg, factories, broker, broker, core.AuditSink(invocation.LogAuditSink{}), EgressDeps{})
+	runtimes, err := buildRuntimes(context.Background(), cfg, factories, broker, broker, core.AuditSink(invocation.NewSlogAuditSink(nil)), EgressDeps{})
 	if err != nil {
 		t.Fatalf("buildRuntimes: %v", err)
 	}
@@ -395,7 +395,7 @@ func TestExecutableRuntimeReceivesPluginConfig(t *testing.T) {
 
 	factories := NewFactoryRegistry()
 	broker := invocation.NewBroker(nil, nil)
-	runtimes, err := buildRuntimes(context.Background(), cfg, factories, broker, broker, core.AuditSink(invocation.LogAuditSink{}), EgressDeps{})
+	runtimes, err := buildRuntimes(context.Background(), cfg, factories, broker, broker, core.AuditSink(invocation.NewSlogAuditSink(nil)), EgressDeps{})
 	if err != nil {
 		t.Fatalf("buildRuntimes: %v", err)
 	}

--- a/internal/bootstrap/validate.go
+++ b/internal/bootstrap/validate.go
@@ -70,7 +70,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 
 	sharedInvoker := invocation.NewBroker(providers, ds)
 	wireCredentialResolver(&deps.Egress, sm)
-	audit := core.AuditSink(invocation.LogAuditSink{})
+	audit := core.AuditSink(invocation.NewSlogAuditSink(nil))
 
 	extensions, err := buildExtensionsWith(ctx, cfg, factories, sharedInvoker, sharedInvoker, audit, deps.Egress, buildRuntimeForValidation)
 	if err != nil {

--- a/internal/invocation/audit.go
+++ b/internal/invocation/audit.go
@@ -1,21 +1,58 @@
 package invocation
 
 import (
-	"log"
+	"context"
+	"io"
+	"log/slog"
+	"os"
 
 	"github.com/valon-technologies/gestalt/core"
+	"go.opentelemetry.io/otel/trace"
 )
 
-var _ core.AuditSink = LogAuditSink{}
+const auditLogType = "audit"
 
-type LogAuditSink struct{}
+var _ core.AuditSink = (*SlogAuditSink)(nil)
 
-func (LogAuditSink) Log(entry core.AuditEntry) {
-	if entry.Allowed {
-		log.Printf("audit: %s src=%s user=%s %s/%s depth=%d",
-			entry.RequestID, entry.Source, entry.UserID, entry.Provider, entry.Operation, entry.Depth)
-		return
+type SlogAuditSink struct {
+	logger *slog.Logger
+}
+
+func NewSlogAuditSink(w io.Writer) *SlogAuditSink {
+	if w == nil {
+		w = os.Stderr
 	}
-	log.Printf("audit: %s src=%s user=%s %s/%s depth=%d DENIED: %s",
-		entry.RequestID, entry.Source, entry.UserID, entry.Provider, entry.Operation, entry.Depth, entry.Error)
+	return &SlogAuditSink{
+		logger: slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	}
+}
+
+func (s *SlogAuditSink) Log(ctx context.Context, entry core.AuditEntry) {
+	attrs := []slog.Attr{
+		slog.String("log.type", auditLogType),
+		slog.Time("event_time", entry.Timestamp),
+		slog.String("request_id", entry.RequestID),
+		slog.String("source", entry.Source),
+		slog.String("user_id", entry.UserID),
+		slog.String("provider", entry.Provider),
+		slog.String("operation", entry.Operation),
+		slog.Int("depth", entry.Depth),
+		slog.Bool("allowed", entry.Allowed),
+	}
+
+	if entry.Error != "" {
+		attrs = append(attrs, slog.String("error", entry.Error))
+	}
+
+	spanCtx := trace.SpanContextFromContext(ctx)
+	if spanCtx.IsValid() {
+		attrs = append(attrs, slog.String("trace_id", spanCtx.TraceID().String()))
+		attrs = append(attrs, slog.String("span_id", spanCtx.SpanID().String()))
+	}
+
+	level := slog.LevelInfo
+	if !entry.Allowed {
+		level = slog.LevelWarn
+	}
+	s.logger.LogAttrs(ctx, level, auditLogType, attrs...)
 }

--- a/internal/invocation/audit.go
+++ b/internal/invocation/audit.go
@@ -46,8 +46,10 @@ func (s *SlogAuditSink) Log(ctx context.Context, entry core.AuditEntry) {
 
 	spanCtx := trace.SpanContextFromContext(ctx)
 	if spanCtx.IsValid() {
-		attrs = append(attrs, slog.String("trace_id", spanCtx.TraceID().String()))
-		attrs = append(attrs, slog.String("span_id", spanCtx.SpanID().String()))
+		attrs = append(attrs,
+			slog.String("trace_id", spanCtx.TraceID().String()),
+			slog.String("span_id", spanCtx.SpanID().String()),
+		)
 	}
 
 	level := slog.LevelInfo

--- a/internal/invocation/audit_test.go
+++ b/internal/invocation/audit_test.go
@@ -1,0 +1,263 @@
+package invocation_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/invocation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestSlogAuditSink_AllowedEntry(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	sink := invocation.NewSlogAuditSink(&buf)
+
+	eventTime := time.Date(2026, 3, 15, 12, 30, 0, 0, time.UTC)
+	entry := core.AuditEntry{
+		Timestamp: eventTime,
+		RequestID: "req-abc-123",
+		Source:    "binding:test-hook",
+		UserID:    "user-42",
+		Provider:  "alpha",
+		Operation: "fetch",
+		Depth:     1,
+		Allowed:   true,
+	}
+
+	sink.Log(context.Background(), entry)
+
+	var record map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
+		t.Fatalf("failed to parse JSON log output: %v", err)
+	}
+
+	if record["log.type"] != "audit" {
+		t.Errorf("expected log.type=audit, got %v", record["log.type"])
+	}
+	if record["level"] != "INFO" {
+		t.Errorf("expected level=INFO for allowed entry, got %v", record["level"])
+	}
+	parsedEventTime, err := time.Parse(time.RFC3339Nano, record["event_time"].(string))
+	if err != nil {
+		t.Fatalf("failed to parse event_time: %v", err)
+	}
+	if !parsedEventTime.Equal(eventTime) {
+		t.Errorf("expected event_time=%v, got %v", eventTime, parsedEventTime)
+	}
+	if record["request_id"] != "req-abc-123" {
+		t.Errorf("expected request_id=req-abc-123, got %v", record["request_id"])
+	}
+	if record["source"] != "binding:test-hook" {
+		t.Errorf("expected source=binding:test-hook, got %v", record["source"])
+	}
+	if record["user_id"] != "user-42" {
+		t.Errorf("expected user_id=user-42, got %v", record["user_id"])
+	}
+	if record["provider"] != "alpha" {
+		t.Errorf("expected provider=alpha, got %v", record["provider"])
+	}
+	if record["operation"] != "fetch" {
+		t.Errorf("expected operation=fetch, got %v", record["operation"])
+	}
+	if record["depth"] != float64(1) {
+		t.Errorf("expected depth=1, got %v", record["depth"])
+	}
+	if record["allowed"] != true {
+		t.Errorf("expected allowed=true, got %v", record["allowed"])
+	}
+	if _, hasError := record["error"]; hasError {
+		t.Errorf("expected no error field for allowed entry, got %v", record["error"])
+	}
+}
+
+func TestSlogAuditSink_DeniedEntry(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	sink := invocation.NewSlogAuditSink(&buf)
+
+	entry := core.AuditEntry{
+		Timestamp: time.Now(),
+		RequestID: "req-deny-456",
+		Source:    "binding:test-hook",
+		UserID:    "user-99",
+		Provider:  "beta",
+		Operation: "write",
+		Depth:     2,
+		Allowed:   false,
+		Error:     "provider \"beta\" is not available in this scope",
+	}
+
+	sink.Log(context.Background(), entry)
+
+	var record map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
+		t.Fatalf("failed to parse JSON log output: %v", err)
+	}
+
+	if record["log.type"] != "audit" {
+		t.Errorf("expected log.type=audit, got %v", record["log.type"])
+	}
+	if record["level"] != "WARN" {
+		t.Errorf("expected level=WARN for denied entry, got %v", record["level"])
+	}
+	if record["allowed"] != false {
+		t.Errorf("expected allowed=false, got %v", record["allowed"])
+	}
+	if record["error"] != entry.Error {
+		t.Errorf("expected error=%q, got %v", entry.Error, record["error"])
+	}
+}
+
+func TestSlogAuditSink_WithSpanContext(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	sink := invocation.NewSlogAuditSink(&buf)
+
+	traceID, _ := trace.TraceIDFromHex("0af7651916cd43dd8448eb211c80319c")
+	spanID, _ := trace.SpanIDFromHex("b7ad6b7169203331")
+	spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), spanCtx)
+
+	entry := core.AuditEntry{
+		Timestamp: time.Now(),
+		RequestID: "req-trace-789",
+		Source:    "binding:traced",
+		UserID:    "user-1",
+		Provider:  "gamma",
+		Operation: "read",
+		Depth:     0,
+		Allowed:   true,
+	}
+
+	sink.Log(ctx, entry)
+
+	var record map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
+		t.Fatalf("failed to parse JSON log output: %v", err)
+	}
+
+	if record["log.type"] != "audit" {
+		t.Errorf("expected log.type=audit, got %v", record["log.type"])
+	}
+	if record["request_id"] != "req-trace-789" {
+		t.Errorf("expected request_id=req-trace-789, got %v", record["request_id"])
+	}
+	if record["trace_id"] != "0af7651916cd43dd8448eb211c80319c" {
+		t.Errorf("expected trace_id=0af7651916cd43dd8448eb211c80319c, got %v", record["trace_id"])
+	}
+	if record["span_id"] != "b7ad6b7169203331" {
+		t.Errorf("expected span_id=b7ad6b7169203331, got %v", record["span_id"])
+	}
+}
+
+func TestSlogAuditSink_NoTraceContext(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	sink := invocation.NewSlogAuditSink(&buf)
+
+	entry := core.AuditEntry{
+		Timestamp: time.Now(),
+		RequestID: "req-no-trace",
+		Source:    "binding:test-hook",
+		UserID:    "user-1",
+		Provider:  "delta",
+		Operation: "read",
+		Depth:     0,
+		Allowed:   true,
+	}
+
+	sink.Log(context.Background(), entry)
+
+	var record map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
+		t.Fatalf("failed to parse JSON log output: %v", err)
+	}
+
+	if _, has := record["trace_id"]; has {
+		t.Errorf("expected no trace_id without span context, got %v", record["trace_id"])
+	}
+	if _, has := record["span_id"]; has {
+		t.Errorf("expected no span_id without span context, got %v", record["span_id"])
+	}
+}
+
+func TestSlogAuditSink_GuaranteedDelivery(t *testing.T) {
+	t.Parallel()
+
+	// Verify that the audit sink emits both INFO-level (allowed) and WARN-level
+	// (denied) entries. A typical application logger configured at WARN would
+	// suppress the allowed entries, but the audit sink's internal logger is set
+	// to LevelDebug so nothing is filtered.
+	warnOnly := slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	if warnOnly.Enabled(context.Background(), slog.LevelInfo) {
+		t.Fatal("expected warn-level logger to filter INFO")
+	}
+
+	var buf bytes.Buffer
+	sink := invocation.NewSlogAuditSink(&buf)
+
+	entries := []core.AuditEntry{
+		{
+			Timestamp: time.Now(),
+			RequestID: "req-allowed",
+			Source:    "binding:test-hook",
+			UserID:    "user-1",
+			Provider:  "epsilon",
+			Operation: "read",
+			Allowed:   true,
+		},
+		{
+			Timestamp: time.Now(),
+			RequestID: "req-denied",
+			Source:    "binding:test-hook",
+			UserID:    "user-2",
+			Provider:  "zeta",
+			Operation: "write",
+			Allowed:   false,
+			Error:     "access denied",
+		},
+	}
+
+	for _, entry := range entries {
+		sink.Log(context.Background(), entry)
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n"))
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 audit log lines, got %d", len(lines))
+	}
+
+	var first map[string]any
+	if err := json.Unmarshal(lines[0], &first); err != nil {
+		t.Fatalf("failed to parse first log line: %v", err)
+	}
+	if first["request_id"] != "req-allowed" {
+		t.Errorf("expected first entry request_id=req-allowed, got %v", first["request_id"])
+	}
+	if first["level"] != "INFO" {
+		t.Errorf("expected first entry level=INFO, got %v", first["level"])
+	}
+
+	var second map[string]any
+	if err := json.Unmarshal(lines[1], &second); err != nil {
+		t.Fatalf("failed to parse second log line: %v", err)
+	}
+	if second["request_id"] != "req-denied" {
+		t.Errorf("expected second entry request_id=req-denied, got %v", second["request_id"])
+	}
+}

--- a/internal/invocation/guarded.go
+++ b/internal/invocation/guarded.go
@@ -93,12 +93,12 @@ func (g *GuardedInvoker) Invoke(ctx context.Context, p *principal.Principal, pro
 	if err := g.check(meta, providerName, instance, operation); err != nil {
 		entry.Allowed = false
 		entry.Error = err.Error()
-		g.logAudit(entry)
+		g.logAudit(ctx, entry)
 		return nil, err
 	}
 
 	entry.Allowed = true
-	g.logAudit(entry)
+	g.logAudit(ctx, entry)
 
 	chainInstance := instance
 	if chainInstance == "" {
@@ -173,8 +173,8 @@ func (g *GuardedInvoker) ResolveToken(ctx context.Context, p *principal.Principa
 	return "", fmt.Errorf("token resolution not supported")
 }
 
-func (g *GuardedInvoker) logAudit(entry core.AuditEntry) {
+func (g *GuardedInvoker) logAudit(ctx context.Context, entry core.AuditEntry) {
 	if g.audit != nil {
-		g.audit.Log(entry)
+		g.audit.Log(ctx, entry)
 	}
 }

--- a/internal/invocation/guarded_test.go
+++ b/internal/invocation/guarded_test.go
@@ -26,7 +26,7 @@ type capturingSink struct {
 	entries []core.AuditEntry
 }
 
-func (s *capturingSink) Log(entry core.AuditEntry) {
+func (s *capturingSink) Log(_ context.Context, entry core.AuditEntry) {
 	s.entries = append(s.entries, entry)
 }
 


### PR DESCRIPTION
Audit entries are now emitted as structured JSON slog records with a
`log.type=audit` attribute, replacing the previous `log.Printf` output.
This enables OTel Collector-side routing so audit logs can be directed
to dedicated compliance backends (S3, CloudWatch, etc.) separately from
operational logs. The `AuditSink.Log` method now accepts a `context.Context`,
allowing audit records to carry trace and span IDs from the request
context for automatic correlation with distributed traces.

The audit sink owns its own JSON handler writing to stderr, decoupled
from the telemetry provider's logger. This ensures audit records are
never silently dropped by the noop provider or filtered by log-level
configuration, since compliance audit output must be unconditional.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>