### PR TITLE
Add distributed request tracing across HTTP and gRPC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,8 @@ require (
 	github.com/valon-technologies/gestalt/sdk/pluginsdk v0.0.0-00010101000000-000000000000
 	go.mongodb.org/mongo-driver/v2 v2.5.0
 	go.opentelemetry.io/contrib/bridges/otelslog v0.17.0
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.18.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.18.0
@@ -112,8 +114,6 @@ require (
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0 // indirect
 	go.opentelemetry.io/otel/log v0.18.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect

--- a/internal/invocation/broker.go
+++ b/internal/invocation/broker.go
@@ -13,9 +13,21 @@ import (
 	"github.com/valon-technologies/gestalt/internal/paraminterp"
 	"github.com/valon-technologies/gestalt/internal/principal"
 	"github.com/valon-technologies/gestalt/internal/registry"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
-const tokenRefreshThreshold = 5 * time.Minute
+const (
+	tokenRefreshThreshold = 5 * time.Minute
+	tracerName            = "gestaltd"
+
+	attrProvider       = attribute.Key("gestalt.provider")
+	attrOperation      = attribute.Key("gestalt.operation")
+	attrUserID         = attribute.Key("gestalt.user_id")
+	attrConnectionMode = attribute.Key("gestalt.connection_mode")
+)
 
 type connectionCtxKey struct{}
 
@@ -109,12 +121,36 @@ func (b *Broker) ListCapabilities() []core.Capability {
 }
 
 func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "broker.invoke",
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+	defer span.End()
+
+	span.SetAttributes(
+		attrProvider.String(providerName),
+		attrOperation.String(operation),
+	)
+
+	fail := func(err error) (*core.OperationResult, error) {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
 	prov, err := b.providers.Get(providerName)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
-			return nil, fmt.Errorf("%w: %q", ErrProviderNotFound, providerName)
+			err = fmt.Errorf("%w: %q", ErrProviderNotFound, providerName)
+		} else {
+			err = fmt.Errorf("%w: looking up provider: %v", ErrInternal, err)
 		}
-		return nil, fmt.Errorf("%w: looking up provider: %v", ErrInternal, err)
+		return fail(err)
+	}
+
+	span.SetAttributes(attrConnectionMode.String(string(prov.ConnectionMode())))
+
+	if p != nil && p.UserID != "" {
+		span.SetAttributes(attrUserID.String(p.UserID))
 	}
 
 	ops := prov.ListOperations()
@@ -126,11 +162,11 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		}
 	}
 	if !found {
-		return nil, fmt.Errorf("%w: %q on provider %q", ErrOperationNotFound, operation, providerName)
+		return fail(fmt.Errorf("%w: %q on provider %q", ErrOperationNotFound, operation, providerName))
 	}
 
 	if p == nil {
-		return nil, ErrNotAuthenticated
+		return fail(ErrNotAuthenticated)
 	}
 
 	conn := ConnectionFromContext(ctx)
@@ -140,14 +176,14 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 
 	ctx, accessToken, err := b.resolveToken(ctx, prov, p, providerName, conn, instance)
 	if err != nil {
-		return nil, err
+		return fail(err)
 	}
 
 	ctx = b.withSubject(ctx, p)
 
 	result, err := prov.Execute(ctx, operation, params, accessToken)
 	if err != nil {
-		return nil, err
+		return fail(err)
 	}
 
 	return result, nil

--- a/internal/pluginapi/process.go
+++ b/internal/pluginapi/process.go
@@ -15,6 +15,7 @@ import (
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -349,6 +350,7 @@ func dialUnixSocket(ctx context.Context, socket string) (*grpc.ClientConn, error
 			var d net.Dialer
 			return d.DialContext(ctx, "unix", addr)
 		}),
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/valon-technologies/gestalt/internal/invocation"
 	"github.com/valon-technologies/gestalt/internal/principal"
 	"github.com/valon-technologies/gestalt/internal/registry"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // ReadinessChecker reports whether the server is ready to handle requests.
@@ -21,6 +22,7 @@ type ReadinessChecker func() string
 
 type Server struct {
 	router             chi.Router
+	handler            http.Handler
 	auth               core.AuthProvider
 	datastore          core.Datastore
 	providers          *registry.PluginMap[core.Provider]
@@ -81,8 +83,10 @@ func New(cfg Config) (*Server, error) {
 	resolver := principal.NewResolver(cfg.Auth, cfg.Datastore)
 	noAuth := cfg.Auth.Name() == "none"
 
+	router := chi.NewRouter()
 	s := &Server{
-		router:            chi.NewRouter(),
+		router:            router,
+		handler:           otelhttp.NewHandler(router, "gestaltd"),
 		auth:              cfg.Auth,
 		datastore:         cfg.Datastore,
 		providers:         cfg.Providers,
@@ -119,5 +123,5 @@ func (s *Server) stagedConnectionStore() (core.StagedConnectionStore, error) {
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	s.router.ServeHTTP(w, r)
+	s.handler.ServeHTTP(w, r)
 }

--- a/internal/server/tracing_test.go
+++ b/internal/server/tracing_test.go
@@ -1,0 +1,198 @@
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	coretesting "github.com/valon-technologies/gestalt/core/testing"
+	"github.com/valon-technologies/gestalt/internal/invocation"
+	"github.com/valon-technologies/gestalt/internal/server"
+	"github.com/valon-technologies/gestalt/internal/testutil"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestTracing_HTTPAndBrokerSpans(t *testing.T) { //nolint:paralleltest // mutates global otel.TracerProvider
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+
+	stub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "tracer-prov",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "ping", Method: http.MethodPost}},
+	}
+
+	providers := testutil.NewProviderRegistry(t, stub)
+	ds := &coretesting.StubDatastore{}
+	broker := invocation.NewBroker(providers, ds)
+
+	srv, err := server.New(server.Config{
+		Auth:        &coretesting.StubAuthProvider{N: "none"},
+		Datastore:   ds,
+		Providers:   providers,
+		Invoker:     broker,
+		StateSecret: []byte("0123456789abcdef0123456789abcdef"),
+	})
+	if err != nil {
+		t.Fatalf("creating server: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/tracer-prov/ping", bytes.NewBufferString(`{}`))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	_ = tp.ForceFlush(context.Background())
+	spans := exporter.GetSpans()
+	if len(spans) == 0 {
+		t.Fatal("expected at least one span, got none")
+	}
+
+	httpSpan := findSpanPrefix(spans, "gestaltd")
+	if httpSpan == nil {
+		var names []string
+		for _, s := range spans {
+			names = append(names, s.Name)
+		}
+		t.Fatalf("expected HTTP span with prefix 'gestaltd', got spans: %v", names)
+	}
+
+	brokerSpan := findSpan(spans, "broker.invoke")
+	if brokerSpan == nil {
+		t.Fatal("expected broker span named 'broker.invoke'")
+	}
+	assertSpanHasAttr(t, brokerSpan, "gestalt.provider", "tracer-prov")
+	assertSpanHasAttr(t, brokerSpan, "gestalt.operation", "ping")
+	assertSpanHasAttr(t, brokerSpan, "gestalt.connection_mode", "none")
+
+	if brokerSpan.Parent.TraceID() != httpSpan.SpanContext.TraceID() {
+		t.Errorf("broker span should share trace ID with HTTP span: broker=%s http=%s",
+			brokerSpan.Parent.TraceID(), httpSpan.SpanContext.TraceID())
+	}
+}
+
+func TestTracing_BrokerSpanRecordsErrors(t *testing.T) { //nolint:paralleltest // mutates global otel.TracerProvider
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+
+	stub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "err-prov",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				return nil, fmt.Errorf("provider exploded")
+			},
+		},
+		ops: []core.Operation{{Name: "boom", Method: http.MethodPost}},
+	}
+
+	providers := testutil.NewProviderRegistry(t, stub)
+	ds := &coretesting.StubDatastore{}
+	broker := invocation.NewBroker(providers, ds)
+
+	srv, err := server.New(server.Config{
+		Auth:        &coretesting.StubAuthProvider{N: "none"},
+		Datastore:   ds,
+		Providers:   providers,
+		Invoker:     broker,
+		StateSecret: []byte("0123456789abcdef0123456789abcdef"),
+	})
+	if err != nil {
+		t.Fatalf("creating server: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/err-prov/boom", bytes.NewBufferString(`{}`))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body)
+
+	_ = tp.ForceFlush(context.Background())
+	spans := exporter.GetSpans()
+	brokerSpan := findSpan(spans, "broker.invoke")
+	if brokerSpan == nil {
+		t.Fatal("expected broker span")
+	}
+
+	if len(brokerSpan.Events) == 0 {
+		t.Fatal("expected error event on broker span")
+	}
+
+	foundError := false
+	for _, ev := range brokerSpan.Events {
+		if ev.Name == "exception" {
+			foundError = true
+			break
+		}
+	}
+	if !foundError {
+		t.Error("expected an exception event on the broker span")
+	}
+}
+
+func findSpan(spans tracetest.SpanStubs, name string) *tracetest.SpanStub {
+	for i := range spans {
+		if spans[i].Name == name {
+			return &spans[i]
+		}
+	}
+	return nil
+}
+
+func findSpanPrefix(spans tracetest.SpanStubs, prefix string) *tracetest.SpanStub {
+	for i := range spans {
+		if strings.HasPrefix(spans[i].Name, prefix) {
+			return &spans[i]
+		}
+	}
+	return nil
+}
+
+func assertSpanHasAttr(t *testing.T, span *tracetest.SpanStub, key, expected string) {
+	t.Helper()
+	for _, attr := range span.Attributes {
+		if string(attr.Key) == key {
+			if attr.Value.AsString() != expected {
+				t.Errorf("span %q: attr %q = %q, want %q", span.Name, key, attr.Value.AsString(), expected)
+			}
+			return
+		}
+	}
+	t.Errorf("span %q: missing attribute %q", span.Name, key)
+}


### PR DESCRIPTION
Requests to gestaltd now produce OpenTelemetry spans end-to-end. The
HTTP server wraps the chi router with `otelhttp`, the broker creates an
internal span per invocation with provider, operation, and connection
attributes, and the gRPC plugin client propagates trace context to child
processes via `otelgrpc`. Error paths record exceptions and set span
status so failed requests are visible in any configured trace backend.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>