### PR TITLE
Migrate log.Printf calls to structured slog

### DIFF
--- a/cmd/gestaltd/bundle.go
+++ b/cmd/gestaltd/bundle.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -61,8 +61,7 @@ func runBundle(args []string) error {
 		return fmt.Errorf("hydrating bundle: %w", err)
 	}
 
-	log.Printf("bundle written to %s", absOutput)
-	log.Printf("serve with: gestaltd serve --locked --config %s", bundledConfigPath)
+	slog.Info("bundle written", "output", absOutput, "serve_command", "gestaltd serve --locked --config "+bundledConfigPath)
 	return nil
 }
 

--- a/cmd/gestaltd/factories.go
+++ b/cmd/gestaltd/factories.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -137,7 +137,7 @@ func logDatastoreWarnings(ds core.Datastore) {
 	}
 	if w, ok := ds.(warner); ok {
 		for _, msg := range w.Warnings() {
-			log.Printf("WARNING: %s", msg)
+			slog.Warn(msg)
 		}
 	}
 }

--- a/cmd/gestaltd/provider_factory.go
+++ b/cmd/gestaltd/provider_factory.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log"
+	"log/slog"
 	"sync"
 
 	"github.com/valon-technologies/gestalt/core"
@@ -168,7 +168,7 @@ func (a *providerAssembly) buildOAuth2Handler(connName string, conn config.Conne
 	}
 	def, err := providercompiler.LoadDefinition(a.ctx, a.name, *a.intg.API, a.preparedProviders)
 	if err != nil {
-		log.Printf("WARNING: %s: cannot load definition for connection %q oauth handler: %v", a.name, connName, err)
+		slog.Warn("cannot load definition for connection oauth handler", "provider", a.name, "connection", connName, "error", err)
 		return nil
 	}
 
@@ -177,7 +177,7 @@ func (a *providerAssembly) buildOAuth2Handler(connName string, conn config.Conne
 
 	upstream, err := provider.BuildOAuthUpstream(&defCopy, conn, defCopy.BaseURL, nil)
 	if err != nil {
-		log.Printf("WARNING: %s: cannot build oauth handler for connection %q: %v", a.name, connName, err)
+		slog.Warn("cannot build oauth handler for connection", "provider", a.name, "connection", connName, "error", err)
 		return nil
 	}
 	return bootstrap.WrapUpstreamHandler(upstream)
@@ -204,12 +204,12 @@ func buildRegistrationStore(deps bootstrap.Deps) mcpoauth.RegistrationStore {
 	}
 	enc, err := crypto.NewAESGCM(deps.EncryptionKey)
 	if err != nil {
-		log.Printf("WARNING: mcpoauth: cannot create encryptor for registration store: %v", err)
+		slog.Warn("cannot create encryptor for registration store", "component", "mcpoauth", "error", err)
 		return nil
 	}
 	store := mcpoauth.NewSQLStore(db, enc, dialect)
 	if err := store.Migrate(context.Background()); err != nil {
-		log.Printf("WARNING: mcpoauth: migrating registration store: %v", err)
+		slog.Warn("registration store migration failed", "component", "mcpoauth", "error", err)
 	}
 	return store
 }

--- a/cmd/gestaltd/run.go
+++ b/cmd/gestaltd/run.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -111,9 +111,11 @@ func runServer(env *bootstrapEnv) error {
 	mcpSurface := buildMCPSurface(env.Config)
 
 	if env.Config.Server.BaseURL != "" {
-		log.Printf("gestaltd base URL: %s", env.Config.Server.BaseURL)
-		log.Printf("  auth callback:        %s%s", env.Config.Server.BaseURL, config.AuthCallbackPath)
-		log.Printf("  integration callback: %s%s", env.Config.Server.BaseURL, config.IntegrationCallbackPath)
+		slog.Info("gestaltd base URL configured",
+			"base_url", env.Config.Server.BaseURL,
+			"auth_callback", env.Config.Server.BaseURL+config.AuthCallbackPath,
+			"integration_callback", env.Config.Server.BaseURL+config.IntegrationCallbackPath,
+		)
 	}
 
 	uiHandler, err := resolveUIHandler(env.Config)
@@ -166,7 +168,7 @@ func runServer(env *bootstrapEnv) error {
 
 	listenErr := make(chan error, 1)
 	go func() {
-		log.Printf("gestaltd listening on %s", addr)
+		slog.Info("gestaltd listening", "addr", addr)
 		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			listenErr <- err
 		}
@@ -176,13 +178,13 @@ func runServer(env *bootstrapEnv) error {
 		drainCtx, drainCancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
 		defer drainCancel()
 		if err := httpServer.Shutdown(drainCtx); err != nil {
-			log.Printf("server shutdown: %v", err)
+			slog.Warn("server shutdown", "error", err)
 		}
 	}()
 
 	select {
 	case <-result.ProvidersReady:
-		log.Printf("all providers ready (%d loaded)", len(result.Providers.List()))
+		slog.Info("all providers ready", "count", len(result.Providers.List()))
 	case err := <-listenErr:
 		return fmt.Errorf("http server: %v", err)
 	case <-env.Ctx.Done():
@@ -198,7 +200,7 @@ func runServer(env *bootstrapEnv) error {
 		return err
 	}
 	mcpSlot.Set(mcpInner)
-	log.Println("MCP endpoint enabled at /mcp")
+	slog.Info("MCP endpoint enabled", "path", "/mcp")
 
 	select {
 	case err := <-listenErr:
@@ -278,7 +280,7 @@ func pluginDeclaresMCP(plugin *config.ExecutablePluginDef) bool {
 	}
 	_, manifest, err := pluginpkg.ReadManifestFile(plugin.ResolvedManifestPath)
 	if err != nil {
-		log.Printf("WARNING: reading plugin manifest %s: %v", plugin.ResolvedManifestPath, err)
+		slog.Warn("reading plugin manifest", "path", plugin.ResolvedManifestPath, "error", err)
 		return true
 	}
 	return manifest.Provider != nil && manifest.Provider.MCP
@@ -338,62 +340,50 @@ func validateConfig(configFlag string) error {
 
 	logConfigSummary(path, cfg)
 	for _, w := range warnings {
-		log.Printf("WARNING: %s", w)
+		slog.Warn(w)
 	}
-	log.Printf("config ok")
+	slog.Info("config ok")
 	return nil
 }
 
 func logConfigSummary(path string, cfg *config.Config) {
-	log.Printf("config file: %s", path)
-	log.Printf("server:")
-	log.Printf("  port:       %d", cfg.Server.Port)
-	log.Printf("  base_url:   %s", maskEmpty(cfg.Server.BaseURL))
-	log.Printf("  encryption: %s", maskSecret(cfg.Server.EncryptionKey))
-	log.Printf("auth:")
-	log.Printf("  provider:   %s", cfg.Auth.Provider)
-	log.Printf("datastore:")
-	log.Printf("  provider:   %s", cfg.Datastore.Provider)
-	log.Printf("secrets:")
-	log.Printf("  provider:   %s", cfg.Secrets.Provider)
-	log.Printf("telemetry:")
-	log.Printf("  provider:   %s", cfg.Telemetry.Provider)
+	slog.Info("config loaded",
+		"config_file", path,
+		"server_port", cfg.Server.Port,
+		"server_base_url", maskEmpty(cfg.Server.BaseURL),
+		"server_encryption", maskSecret(cfg.Server.EncryptionKey),
+		"auth_provider", cfg.Auth.Provider,
+		"datastore_provider", cfg.Datastore.Provider,
+		"secrets_provider", cfg.Secrets.Provider,
+		"telemetry_provider", cfg.Telemetry.Provider,
+	)
 
-	if len(cfg.Integrations) > 0 {
-		log.Printf("integrations: %d", len(cfg.Integrations))
-		for name, intg := range cfg.Integrations {
-			switch {
-			case intg.Plugin != nil && intg.MCP == nil:
-				log.Printf("  %s: plugin", name)
-			case intg.Plugin != nil:
-				log.Printf("  %s: hybrid surfaces=[plugin,mcp]", name)
-			default:
-				var surfaces []string
-				if intg.API != nil {
-					surfaces = append(surfaces, intg.API.Type)
-				}
-				if intg.MCP != nil {
-					surfaces = append(surfaces, "mcp")
-				}
-				log.Printf("  %s: surfaces=[%s] connections=%d", name, strings.Join(surfaces, ","), len(intg.Connections))
+	for name, intg := range cfg.Integrations {
+		switch {
+		case intg.Plugin != nil && intg.MCP == nil:
+			slog.Info("integration configured", "integration", name, "type", "plugin")
+		case intg.Plugin != nil:
+			slog.Info("integration configured", "integration", name, "type", "hybrid", "surfaces", []string{"plugin", "mcp"})
+		default:
+			var surfaces []string
+			if intg.API != nil {
+				surfaces = append(surfaces, intg.API.Type)
 			}
+			if intg.MCP != nil {
+				surfaces = append(surfaces, "mcp")
+			}
+			slog.Info("integration configured", "integration", name, "surfaces", surfaces, "connections", len(intg.Connections))
 		}
 	}
 
-	if len(cfg.Runtimes) > 0 {
-		log.Printf("runtimes: %d", len(cfg.Runtimes))
-		for name := range cfg.Runtimes {
-			rt := cfg.Runtimes[name]
-			log.Printf("  %s: type=%s providers=%s", name, rt.Type, strings.Join(rt.Providers, ","))
-		}
+	for name := range cfg.Runtimes {
+		rt := cfg.Runtimes[name]
+		slog.Info("runtime configured", "runtime", name, "type", rt.Type, "providers", rt.Providers)
 	}
 
-	if len(cfg.Bindings) > 0 {
-		log.Printf("bindings: %d", len(cfg.Bindings))
-		for name := range cfg.Bindings {
-			b := cfg.Bindings[name]
-			log.Printf("  %s: type=%s", name, b.Type)
-		}
+	for name := range cfg.Bindings {
+		b := cfg.Bindings[name]
+		slog.Info("binding configured", "binding", name, "type", b.Type)
 	}
 }
 

--- a/internal/bootstrap/binding_boundary.go
+++ b/internal/bootstrap/binding_boundary.go
@@ -3,7 +3,7 @@ package bootstrap
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/config"
@@ -45,7 +45,7 @@ func buildBindings(ctx context.Context, cfg *config.Config, factories *FactoryRe
 			_ = CloseBindings(bindings, bindingNames(bindings))
 			return nil, fmt.Errorf("bootstrap: registering binding %q: %w", name, err)
 		}
-		log.Printf("loaded binding %s (type=%s, providers=%v)", name, def.Type, def.Providers)
+		slog.Info("loaded binding", "binding", name, "type", def.Type, "providers", def.Providers)
 	}
 
 	return bindings, nil

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"reflect"
 	"strings"
 	"sync"
@@ -632,7 +632,7 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 		} else if err != nil {
 			return nil, nil, nil, fmt.Errorf("bootstrap: registering builtin %q: %w", builtin.Name(), err)
 		}
-		log.Printf("loaded builtin provider %s (%d operations)", builtin.Name(), len(builtin.ListOperations()))
+		slog.Info("loaded builtin provider", "provider", builtin.Name(), "operations", len(builtin.ListOperations()))
 	}
 
 	ready := make(chan struct{})
@@ -653,14 +653,14 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 			defer wg.Done()
 			result, err := buildProvider(ctx, name, intgDef, factories, deps)
 			if err != nil {
-				log.Printf("WARNING: skipping provider %q: %v", name, err)
+				slog.Warn("skipping provider", "provider", name, "error", err)
 				return
 			}
 			if err := reg.Providers.Register(name, result.Provider); err != nil {
 				if c, ok := result.Provider.(interface{ Close() error }); ok {
 					_ = c.Close()
 				}
-				log.Printf("WARNING: registering provider %q: %v", name, err)
+				slog.Warn("registering provider failed", "provider", name, "error", err)
 				return
 			}
 			if len(result.ConnectionAuth) > 0 {
@@ -668,7 +668,7 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 				connAuth[name] = result.ConnectionAuth
 				connMu.Unlock()
 			}
-			log.Printf("loaded provider %s (%d operations)", name, len(result.Provider.ListOperations()))
+			slog.Info("loaded provider", "provider", name, "operations", len(result.Provider.ListOperations()))
 		}()
 	}
 
@@ -820,7 +820,7 @@ func attachPluginOAuth(name string, intg config.IntegrationDef, pluginConfig map
 	}
 	authHandler, err := buildPluginOAuthHandler(intg, pluginConfig, deps)
 	if err != nil {
-		log.Printf("WARNING: %s: cannot build oauth handler from manifest: %v", name, err)
+		slog.Warn("cannot build oauth handler from manifest", "provider", name, "error", err)
 		return
 	}
 	if authHandler == nil {
@@ -967,7 +967,7 @@ func BuildResultWithOAuth(prov core.Provider, def *provider.Definition, intg con
 	}
 	upstream, err := provider.BuildOAuthUpstream(def, conn, def.BaseURL, nil)
 	if err != nil {
-		log.Printf("WARNING: %s: cannot build oauth handler for connection %q: %v", prov.Name(), intg.API.Connection, err)
+		slog.Warn("cannot build oauth handler for connection", "provider", prov.Name(), "connection", intg.API.Connection, "error", err)
 		return result
 	}
 	result.ConnectionAuth = map[string]OAuthHandler{

--- a/internal/bootstrap/runtime_boundary.go
+++ b/internal/bootstrap/runtime_boundary.go
@@ -3,7 +3,7 @@ package bootstrap
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/internal/config"
@@ -47,7 +47,7 @@ func buildRuntimesWith(ctx context.Context, cfg *config.Config, factories *Facto
 			_ = StopRuntimes(context.Background(), runtimes, runtimeNames(runtimes))
 			return nil, fmt.Errorf("bootstrap: registering runtime %q: %w", name, err)
 		}
-		log.Printf("loaded runtime %s (type=%s, providers=%v)", name, def.Type, def.Providers)
+		slog.Info("loaded runtime", "runtime", name, "type", def.Type, "providers", def.Providers)
 	}
 
 	return runtimes, nil

--- a/internal/bootstrap/structured_logging_test.go
+++ b/internal/bootstrap/structured_logging_test.go
@@ -1,0 +1,112 @@
+package bootstrap_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/internal/config"
+)
+
+func TestBootstrapProducesStructuredLogs(t *testing.T) { //nolint:paralleltest // mutates slog.Default
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	result, err := bootstrap.Bootstrap(context.Background(), validConfig(), validFactories())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	output := buf.String()
+	if output == "" {
+		t.Fatal("expected structured log output from bootstrap, got empty string")
+	}
+
+	var foundProviderLog bool
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("log line is not valid JSON: %q: %v", line, err)
+		}
+
+		if _, ok := record["time"]; !ok {
+			t.Errorf("log record missing 'time' field: %v", record)
+		}
+		if _, ok := record["level"]; !ok {
+			t.Errorf("log record missing 'level' field: %v", record)
+		}
+		if _, ok := record["msg"]; !ok {
+			t.Errorf("log record missing 'msg' field: %v", record)
+		}
+
+		if record["msg"] == "loaded provider" {
+			foundProviderLog = true
+			if record["provider"] != "alpha" {
+				t.Errorf("expected provider=alpha, got provider=%v", record["provider"])
+			}
+			if _, ok := record["operations"]; !ok {
+				t.Error("loaded provider log missing 'operations' field")
+			}
+		}
+	}
+
+	if !foundProviderLog {
+		t.Errorf("did not find 'loaded provider' log line in output:\n%s", output)
+	}
+}
+
+func TestBootstrapSkippedProviderLogsWarning(t *testing.T) { //nolint:paralleltest // mutates slog.Default
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	cfg := validConfig()
+	cfg.Integrations = map[string]config.IntegrationDef{
+		"broken": {},
+	}
+	factories := validFactories()
+	factories.Providers = map[string]bootstrap.ProviderFactory{
+		"broken": func(_ context.Context, _ string, _ config.IntegrationDef, _ bootstrap.Deps) (*bootstrap.ProviderBuildResult, error) {
+			return nil, context.DeadlineExceeded
+		},
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	output := buf.String()
+	var foundWarning bool
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("log line is not valid JSON: %q: %v", line, err)
+		}
+
+		if record["msg"] == "skipping provider" && record["level"] == "WARN" {
+			foundWarning = true
+			if record["provider"] != "broken" {
+				t.Errorf("expected provider=broken, got provider=%v", record["provider"])
+			}
+			if _, ok := record["error"]; !ok {
+				t.Error("skipping provider log missing 'error' field")
+			}
+		}
+	}
+
+	if !foundWarning {
+		t.Errorf("did not find 'skipping provider' WARN log line in output:\n%s", output)
+	}
+}

--- a/internal/invocation/broker.go
+++ b/internal/invocation/broker.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 
 	"github.com/valon-technologies/gestalt/core"
@@ -253,7 +253,7 @@ func (b *Broker) resolveUserToken(ctx context.Context, prov core.Provider, userI
 	if storedToken.MetadataJSON != "" {
 		var connParams map[string]string
 		if err := json.Unmarshal([]byte(storedToken.MetadataJSON), &connParams); err != nil {
-			log.Printf("WARNING: malformed MetadataJSON for %s: %v", providerName, err)
+			slog.WarnContext(ctx, "malformed metadata JSON", "provider", providerName, "error", err)
 		} else if len(connParams) > 0 {
 			ctx = core.WithConnectionParams(ctx, connParams)
 		}

--- a/internal/invocation/structured_logging_test.go
+++ b/internal/invocation/structured_logging_test.go
@@ -1,0 +1,94 @@
+package invocation_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	coretesting "github.com/valon-technologies/gestalt/core/testing"
+	"github.com/valon-technologies/gestalt/internal/invocation"
+	"github.com/valon-technologies/gestalt/internal/principal"
+	"github.com/valon-technologies/gestalt/internal/testutil"
+)
+
+func TestBrokerMalformedMetadataJSON_StructuredLog(t *testing.T) { //nolint:paralleltest // mutates slog.Default
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	prov := &stubProviderWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "myservice",
+			ConnMode: core.ConnectionModeUser,
+			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "do_thing", Method: http.MethodGet}},
+	}
+
+	ds := &coretesting.StubDatastore{
+		FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+			return &core.User{ID: "u-1", Email: email}, nil
+		},
+		ListTokensForConnectionFn: func(_ context.Context, _, _, _ string) ([]*core.IntegrationToken, error) {
+			return []*core.IntegrationToken{{
+				UserID:       "u-1",
+				Integration:  "myservice",
+				Instance:     "default",
+				AccessToken:  "tok-123",
+				MetadataJSON: `{{{not json`,
+			}}, nil
+		},
+	}
+
+	broker := invocation.NewBroker(testutil.NewProviderRegistry(t, prov), ds)
+	p := &principal.Principal{
+		Identity: &core.UserIdentity{Email: "test@example.com"},
+	}
+
+	result, err := broker.Invoke(context.Background(), p, "myservice", "", "do_thing", nil)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", result.Status)
+	}
+
+	output := buf.String()
+	if output == "" {
+		t.Fatal("expected structured log output for malformed MetadataJSON, got empty")
+	}
+
+	var foundWarning bool
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("log line is not valid JSON: %q: %v", line, err)
+		}
+
+		if record["msg"] == "malformed metadata JSON" {
+			foundWarning = true
+			if record["level"] != "WARN" {
+				t.Errorf("expected level=WARN, got level=%v", record["level"])
+			}
+			if record["provider"] != "myservice" {
+				t.Errorf("expected provider=myservice, got provider=%v", record["provider"])
+			}
+			if _, ok := record["error"]; !ok {
+				t.Error("malformed metadata JSON log missing 'error' field")
+			}
+		}
+	}
+
+	if !foundWarning {
+		t.Errorf("did not find 'malformed metadata JSON' warning in output:\n%s", output)
+	}
+}

--- a/internal/server/catalog_resolution.go
+++ b/internal/server/catalog_resolution.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"context"
-	"log"
+	"log/slog"
 
 	"github.com/valon-technologies/gestalt/core"
 	"github.com/valon-technologies/gestalt/core/catalog"
@@ -25,11 +25,11 @@ func resolveCatalog(ctx context.Context, prov core.Provider, provName string, re
 		if resolver != nil && prov.ConnectionMode() != core.ConnectionModeNone && p != nil {
 			token, err := resolver.ResolveToken(ctx, p, provName, defaultConnection, "")
 			if err != nil {
-				log.Printf("catalog: token resolution for %q: %v", provName, err)
+				slog.WarnContext(ctx, "catalog token resolution failed", "provider", provName, "error", err)
 			} else {
 				cat, err := scp.CatalogForRequest(ctx, token)
 				if err != nil {
-					log.Printf("catalog: session catalog for %q: %v", provName, err)
+					slog.WarnContext(ctx, "catalog session resolution failed", "provider", provName, "error", err)
 				} else {
 					sessionCat = cat
 				}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -94,7 +94,7 @@ type connectionParamInfo struct {
 func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 	connected, err := s.userConnectedIntegrations(r)
 	if err != nil {
-		log.Printf("listing integrations: %v", err)
+		slog.ErrorContext(r.Context(), "listing integrations", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to check integration status")
 		return
 	}
@@ -381,7 +381,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, apiexec.ErrMissingPathParam):
 			writeError(w, http.StatusBadRequest, err.Error())
 		default:
-			log.Printf("operation %s/%s failed: %v", providerName, operationName, err)
+			slog.ErrorContext(r.Context(), "operation failed", "provider", providerName, "operation", operationName, "error", err)
 			writeError(w, http.StatusBadGateway, "operation failed")
 		}
 		return
@@ -501,7 +501,7 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 		identity, err = s.auth.HandleCallback(r.Context(), code)
 	}
 	if err != nil {
-		log.Printf("login callback failed: %v", err)
+		slog.ErrorContext(r.Context(), "login callback failed", "error", err)
 		writeError(w, http.StatusUnauthorized, "login failed")
 		return
 	}
@@ -672,14 +672,14 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	var tokenResp *core.TokenResponse
 	tokenResp, err = handler.ExchangeCodeWithVerifier(r.Context(), code, state.Verifier, exchangeOpts...)
 	if err != nil {
-		log.Printf("token exchange failed for %s: %v", providerName, err)
+		slog.ErrorContext(r.Context(), "token exchange failed", "provider", providerName, "error", err)
 		writeError(w, http.StatusBadGateway, "token exchange failed")
 		return
 	}
 
 	metadata, metaErr := buildConnectionMetadata(prov, connParams, tokenResp)
 	if metaErr != nil {
-		log.Printf("connection metadata extraction failed for %s: %v", providerName, metaErr)
+		slog.ErrorContext(r.Context(), "connection metadata extraction failed", "provider", providerName, "error", metaErr)
 		writeError(w, http.StatusBadGateway, "failed to extract connection metadata from token response")
 		return
 	}
@@ -708,7 +708,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 
 	result, err := s.runPostConnect(r.Context(), prov, tm)
 	if err != nil {
-		log.Printf("post_connect failed for %s: %v", providerName, err)
+		slog.ErrorContext(r.Context(), "post_connect failed", "provider", providerName, "error", err)
 		writeError(w, http.StatusBadGateway, "connection setup failed")
 		return
 	}
@@ -811,7 +811,7 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 
 	result, err := s.runPostConnect(r.Context(), prov, tm)
 	if err != nil {
-		log.Printf("post_connect failed for %s: %v", req.Integration, err)
+		slog.ErrorContext(r.Context(), "post_connect failed", "provider", req.Integration, "error", err)
 		writeError(w, http.StatusBadGateway, "connection setup failed")
 		return
 	}
@@ -1280,7 +1280,7 @@ func (s *Server) selectStagedConnection(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := scs.DeleteStagedConnection(r.Context(), sc.ID); err != nil {
-		log.Printf("failed to delete staged connection %s: %v", sc.ID, err)
+		slog.ErrorContext(r.Context(), "failed to delete staged connection", "staged_connection_id", sc.ID, "error", err)
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "connected"})

--- a/internal/server/routes_bindings.go
+++ b/internal/server/routes_bindings.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"log"
+	"log/slog"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -13,7 +13,7 @@ func (s *Server) mountBindingRoutes(r chi.Router) {
 	for _, name := range s.bindings.List() {
 		binding, err := s.bindings.Get(name)
 		if err != nil {
-			log.Printf("warning: skipping binding %q routes: %v", name, err)
+			slog.Warn("skipping binding routes", "binding", name, "error", err)
 			continue
 		}
 		for _, route := range binding.Routes() {


### PR DESCRIPTION
All `log.Printf` calls in the server, bootstrap, and invocation
packages now use `log/slog` with structured key-value pairs instead of
format strings. This makes logs machine-parseable for aggregation tools
while preserving human readability. Request-scoped handlers use
`slog.WarnContext`/`slog.ErrorContext` to propagate context, while
startup code uses plain `slog.Info`/`slog.Warn`.

The config summary output previously used multi-line printf sequences,
which have been consolidated into single structured calls per entity.
Functional tests verify that bootstrap and broker produce valid JSON log
records with the expected fields.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>