### PR TITLE
Use separate credentials for Docker Hub description updates

### DIFF
--- a/.github/workflows/publish-gestaltd-image.yml
+++ b/.github/workflows/publish-gestaltd-image.yml
@@ -120,8 +120,8 @@ jobs:
       - name: Update Docker Hub description
         uses: peter-evans/dockerhub-description@v5
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_DESCRIPTION_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_DESCRIPTION_PASSWORD }}
           repository: ${{ env.IMAGE_NAME }}
           short-description: Self-hosted integration runtime for REST, GraphQL, MCP, and plugins.
           readme-filepath: docs/dockerhub/gestaltd.md

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -220,8 +220,8 @@ jobs:
       - name: Update Docker Hub description
         uses: peter-evans/dockerhub-description@v5
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_DESCRIPTION_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_DESCRIPTION_PASSWORD }}
           repository: ${{ env.IMAGE_NAME }}
           short-description: Self-hosted integration runtime for REST, GraphQL, MCP, and plugins.
           readme-filepath: docs/dockerhub/gestaltd.md


### PR DESCRIPTION
The Docker Hub registry API accepts the org name (valontechnologies) as a username for image push, but the Hub API's description endpoint requires a personal username and password. This splits the description step to use dedicated DOCKERHUB_DESCRIPTION_USERNAME and DOCKERHUB_DESCRIPTION_PASSWORD secrets so image push and description update can authenticate independently.