### PR TITLE
Add telemetry documentation to config reference and concepts

### DIFF
--- a/docs/pages/concepts/_meta.ts
+++ b/docs/pages/concepts/_meta.ts
@@ -1,6 +1,7 @@
 export default {
   "platform-model": "Platform Model",
   configuration: "Configuration",
+  observability: "Observability",
   integrations: "Integrations",
   "authentication-and-tokens": "Authentication and Tokens",
   "mcp-binding": "MCP Binding",

--- a/docs/pages/concepts/configuration.mdx
+++ b/docs/pages/concepts/configuration.mdx
@@ -35,6 +35,7 @@ This is the complete top-level shape of the config:
 auth: {}
 datastore: {}
 secrets: {}
+telemetry: {}
 integrations: {}
 runtimes: {}
 bindings: {}
@@ -50,6 +51,7 @@ Each block controls a distinct part of the runtime:
 | `auth` | How users authenticate to Gestalt itself. |
 | `datastore` | Where Gestalt stores users, tokens, and related runtime state. |
 | `secrets` | How `secret://...` values are resolved. |
+| `telemetry` | Observability: traces, metrics, and structured logs. |
 | `integrations` | The provider graph users call. |
 | `runtimes` | Background workers. |
 | `bindings` | Additional inbound surfaces. |
@@ -61,6 +63,7 @@ The loader applies a small number of defaults:
 
 - `server.port` defaults to `8080`
 - `secrets.provider` defaults to `env`
+- `telemetry.provider` defaults to `stdout`
 
 Some fields are effectively mandatory:
 

--- a/docs/pages/concepts/observability.mdx
+++ b/docs/pages/concepts/observability.mdx
@@ -1,0 +1,140 @@
+# Observability
+
+Gestalt uses [OpenTelemetry](https://opentelemetry.io) for observability. Traces, metrics, and structured logs are exported through a pluggable telemetry provider configured in the `telemetry` block of your config file.
+
+## Traces
+
+Every request is automatically traced across three layers:
+
+1. **HTTP** — `otelhttp` middleware on the chi router creates a root span for each inbound request with standard HTTP semantic conventions (method, route, status code, latency).
+2. **Broker** — `Broker.Invoke()` creates a child span with attributes for the provider, operation, user, and connection mode.
+3. **gRPC plugins** — `otelgrpc` interceptors on plugin connections propagate trace context across process boundaries, so plugin spans appear as children of the broker span.
+
+A single trace shows the full lifecycle: HTTP request → broker invocation → plugin RPC. When a provider invocation is slow, the trace shows whether the bottleneck was token refresh, the provider's execution, or network latency.
+
+### Sampling
+
+The `otlp` provider supports configurable trace sampling via `traces.sampling_ratio` (default `1.0`, meaning all traces). At low to moderate scale, sample everything. When volume demands it, reduce the ratio — but note that the OTel Collector's [spanmetrics connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/README.md) can derive accurate RED metrics from 100% of spans _before_ the sampling decision, so metrics remain accurate even with aggressive trace sampling.
+
+## Metrics
+
+Gestalt does not maintain separate application-level metric instrumentation for request rates, error rates, or latency. Instead, these are derived from traces:
+
+- Use the OTel Collector's **spanmetrics connector** to automatically generate RED metrics (Rate, Errors, Duration) from trace spans.
+- This eliminates double-instrumentation and gives you per-provider, per-operation breakdowns without declaring metric labels upfront.
+
+Infrastructure metrics (CPU, memory, goroutines) should come from your runtime environment (Kubernetes metrics-server, CloudWatch, etc.), not from Gestalt itself.
+
+## Structured Logging
+
+All log output from Gestalt uses Go's `slog` for structured logging. When using the `otlp` provider, logs are exported via the [otelslog bridge](https://pkg.go.dev/go.opentelemetry.io/contrib/bridges/otelslog) and include trace correlation fields (`trace_id`, `span_id`) so logs can be linked to their parent request trace.
+
+With the `stdout` provider, logs are written to stdout in either `text` (default) or `json` format.
+
+## Audit Logs
+
+Audit entries record who invoked what, when, and whether it was allowed. Every provider invocation through the broker produces an audit log entry with these fields:
+
+| Field | Description |
+| --- | --- |
+| `log.type` | Always `audit`. Use this for routing. |
+| `request_id` | Unique request identifier. |
+| `source` | Where the invocation originated (e.g., `binding:webhook`). |
+| `user_id` | Authenticated user. |
+| `provider` | Target provider name. |
+| `operation` | Target operation name. |
+| `depth` | Call depth (prevents infinite recursion in chained invocations). |
+| `allowed` | Whether the operation was permitted. |
+| `error` | Present only for denied operations. |
+
+Allowed operations are logged at `INFO` level; denied operations at `WARN`.
+
+### Routing audit logs separately
+
+Audit logs and operational logs serve different purposes and typically need different retention, access controls, and storage backends. Gestalt tags audit entries with `log.type=audit` so they can be routed independently at the collector level.
+
+Example OTel Collector config that splits audit logs from operational logs:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  filter/audit:
+    logs:
+      include:
+        match_type: strict
+        resource_attributes:
+          - key: log.type
+            value: audit
+  filter/operational:
+    logs:
+      exclude:
+        match_type: strict
+        resource_attributes:
+          - key: log.type
+            value: audit
+
+exporters:
+  otlphttp/audit:
+    endpoint: https://audit-backend.example.com
+  otlphttp/operational:
+    endpoint: https://logs-backend.example.com
+
+service:
+  pipelines:
+    logs/audit:
+      receivers: [otlp]
+      processors: [filter/audit]
+      exporters: [otlphttp/audit]
+    logs/operational:
+      receivers: [otlp]
+      processors: [filter/operational]
+      exporters: [otlphttp/operational]
+```
+
+## Example: Full Production Setup
+
+```yaml
+telemetry:
+  provider: otlp
+  config:
+    endpoint: otel-collector.monitoring:4317
+    protocol: grpc
+    service_name: gestaltd
+    resource_attributes:
+      deployment.environment: production
+      service.version: "1.2.0"
+    traces:
+      sampling_ratio: 1.0
+    metrics:
+      interval: 60s
+    logs:
+      level: info
+```
+
+This sends all signals to an OTel Collector, which can then fan out to your tracing backend (Jaeger, Tempo, Datadog), metrics backend (Prometheus, Datadog), and log backend (Loki, CloudWatch) using its pipeline configuration.
+
+## Example: Local Development
+
+```yaml
+telemetry:
+  provider: stdout
+  config:
+    format: json
+    level: debug
+```
+
+Prints all traces, metrics, and logs to stdout in JSON format. Useful for inspecting request flow during development.
+
+## Disabling Telemetry
+
+```yaml
+telemetry:
+  provider: noop
+```
+
+All instrumentation points remain in the code but produce zero overhead. No traces, metrics, or logs are collected.

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -8,6 +8,7 @@ This page is the authoritative reference for `gestaltd` configuration.
 auth: {}
 datastore: {}
 secrets: {}
+telemetry: {}
 integrations: {}
 runtimes: {}
 bindings: {}
@@ -25,6 +26,7 @@ Before you get into individual fields, these global rules matter:
 - unknown YAML fields are rejected
 - `server.port` defaults to `8080`
 - `secrets.provider` defaults to `env`
+- `telemetry.provider` defaults to `stdout`
 - relative paths resolve relative to the config file directory
 - `secret://...` values are resolved later during bootstrap, not during raw YAML parsing
 
@@ -164,6 +166,89 @@ Any string value outside `secrets.config` may use:
 ```yaml
 secret://name-of-secret
 ```
+
+## `telemetry`
+
+Controls observability: distributed traces, metrics, and structured logs. Gestalt uses [OpenTelemetry](https://opentelemetry.io) under the hood. Every HTTP request, broker invocation, and plugin gRPC call is automatically traced.
+
+### `stdout`
+
+```yaml
+telemetry:
+  provider: stdout
+  config:
+    format: text
+    level: info
+```
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `format` | no | `text` (default) or `json`. |
+| `level` | no | `debug`, `info` (default), `warn`, or `error`. |
+
+`stdout` prints traces and metrics to standard output. Good for local development and debugging. This is the default provider when `telemetry` is omitted.
+
+### `otlp`
+
+```yaml
+telemetry:
+  provider: otlp
+  config:
+    endpoint: otel-collector:4317
+    protocol: grpc
+    service_name: gestaltd
+    insecure: false
+    headers:
+      Authorization: Bearer ${OTEL_TOKEN}
+    resource_attributes:
+      deployment.environment: production
+      service.version: "1.0.0"
+    traces:
+      sampling_ratio: 1.0
+    metrics:
+      interval: 60s
+    logs:
+      level: info
+```
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `endpoint` | no | OTLP collector address. Uses the SDK default when omitted. |
+| `protocol` | no | `grpc` (default) or `http`. |
+| `service_name` | no | OpenTelemetry service name. Defaults to `gestaltd`. |
+| `insecure` | no | Skip TLS verification. Defaults to `false`. |
+| `headers` | no | Extra headers sent with every export request. Useful for auth tokens. |
+| `resource_attributes` | no | Arbitrary key-value pairs attached to every signal as resource attributes. |
+| `traces.sampling_ratio` | no | Fraction of traces to sample, `0.0` to `1.0`. Defaults to `1.0` (all traces). |
+| `metrics.interval` | no | How often metrics are exported. Defaults to `60s`. |
+| `logs.level` | no | Minimum log level exported. Defaults to `info`. |
+
+`otlp` exports traces, metrics, and logs to any OpenTelemetry-compatible collector (Jaeger, Grafana Alloy, Datadog Agent, etc.) using the OTLP protocol.
+
+### `noop`
+
+```yaml
+telemetry:
+  provider: noop
+```
+
+Disables all telemetry. No traces, metrics, or logs are collected or exported. The instrumentation points remain in the code but produce zero overhead.
+
+### What gets traced
+
+Gestalt automatically creates distributed trace spans at three levels:
+
+| Layer | Span name | Key attributes |
+| --- | --- | --- |
+| HTTP | `gestaltd: {method} {route}` | Standard HTTP semantic conventions (method, route, status code) |
+| Broker | `broker.invoke` | `gestalt.provider`, `gestalt.operation`, `gestalt.user_id`, `gestalt.connection_mode` |
+| gRPC plugin | Per-RPC spans | Standard gRPC semantic conventions (service, method, status) |
+
+Child spans are linked to their parent, so a single trace shows the full request lifecycle from HTTP through broker to plugin.
+
+### Audit logs
+
+Audit log records are emitted as structured log entries with a `log.type=audit` attribute. When using the `otlp` provider, these can be routed to a dedicated audit backend by the OTel Collector using attribute-based filtering. See [Observability](/concepts/observability) for details.
 
 ## `integrations`
 


### PR DESCRIPTION
## Summary

- Add `telemetry` section to the config file reference documenting all three providers (stdout, otlp, noop) with config tables and options
- Add new Observability concepts page covering distributed tracing, trace-derived metrics, structured logging, and audit log routing
- Update top-level config shape listings and defaults in both config reference and configuration concepts pages

## Test plan

- [ ] Docs build passes (`npx next build` in docs/)
- [ ] New observability page renders at /concepts/observability
- [ ] Telemetry section appears in config file reference between secrets and integrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)