### PR TITLE
Update Slack plugin manifest to v0.0.1-alpha.2 with mcp and auth

### DIFF
--- a/plugins/slack/plugin.json
+++ b/plugins/slack/plugin.json
@@ -1,12 +1,13 @@
 {
   "schema_version": 2,
   "source": "github.com/valon-technologies/gestalt/slack",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "display_name": "Slack",
   "description": "Send messages, search conversations, and manage channels.",
   "kinds": ["provider"],
   "provider": {
     "protocol": { "min": 1, "max": 1 },
+    "mcp": true,
     "auth": {
       "type": "oauth2",
       "authorization_url": "https://slack.com/oauth/v2/authorize",


### PR DESCRIPTION
## Summary

- Adds `mcp: true` to the Slack plugin manifest for MCP tool exposure
- Bumps version to `0.0.1-alpha.2` to match the published GitHub Release

The `plugin/slack/v0.0.1-alpha.2` release has already been published with the auth declaration and MCP opt-in.

## Test plan

- [ ] `cd plugins/slack && go test ./...` passes
- [ ] Manifest validates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)