### PR TITLE
Consolidate Docker images into a single Alpine-based image

### DIFF
--- a/.github/workflows/publish-gestaltd-image.yml
+++ b/.github/workflows/publish-gestaltd-image.yml
@@ -27,12 +27,11 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
-      - name: Build and push runtime image
+      - name: Build and push image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile
-          target: runtime
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
@@ -49,70 +48,10 @@ jobs:
           cache-to: type=gha,mode=min
           sbom: true
           provenance: mode=max
-      - name: Build and push builder image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: Dockerfile
-          target: builder
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.IMAGE_NAME }}:builder
-            ${{ env.IMAGE_NAME }}:builder-${{ github.sha }}
-          build-args: |
-            GESTALT_VERSION=${{ github.sha }}
-            GESTALT_REVISION=${{ github.sha }}
-            GESTALT_CREATED=${{ steps.meta.outputs.created }}
-            GESTALT_SOURCE=${{ env.IMAGE_SOURCE }}
-            GESTALT_DOCUMENTATION=${{ env.IMAGE_DOCUMENTATION }}
-            GESTALT_URL=${{ env.IMAGE_URL }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
-          sbom: true
-          provenance: mode=max
-      - name: Build and push debug image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: Dockerfile
-          target: debug
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.IMAGE_NAME }}:debug
-            ${{ env.IMAGE_NAME }}:debug-${{ github.sha }}
-          build-args: |
-            GESTALT_VERSION=${{ github.sha }}
-            GESTALT_REVISION=${{ github.sha }}
-            GESTALT_CREATED=${{ steps.meta.outputs.created }}
-            GESTALT_SOURCE=${{ env.IMAGE_SOURCE }}
-            GESTALT_DOCUMENTATION=${{ env.IMAGE_DOCUMENTATION }}
-            GESTALT_URL=${{ env.IMAGE_URL }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
-          sbom: true
-          provenance: mode=max
-      - name: Scan runtime image for vulnerabilities
+      - name: Scan image for vulnerabilities
         uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ env.IMAGE_NAME }}:${{ github.sha }}
-          format: table
-          exit-code: '1'
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-      - name: Scan builder image for vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
-        with:
-          image-ref: ${{ env.IMAGE_NAME }}:builder-${{ github.sha }}
-          format: table
-          exit-code: '0'
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-      - name: Scan debug image for vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
-        with:
-          image-ref: ${{ env.IMAGE_NAME }}:debug-${{ github.sha }}
           format: table
           exit-code: '1'
           severity: CRITICAL,HIGH

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -127,12 +127,11 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
-      - name: Build and push runtime image
+      - name: Build and push image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile
-          target: runtime
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
@@ -149,70 +148,10 @@ jobs:
           cache-to: type=gha,mode=min
           sbom: true
           provenance: mode=max
-      - name: Build and push builder image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: Dockerfile
-          target: builder
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.IMAGE_NAME }}:builder
-            ${{ env.IMAGE_NAME }}:builder-${{ steps.version.outputs.version }}
-          build-args: |
-            GESTALT_VERSION=${{ steps.version.outputs.version }}
-            GESTALT_REVISION=${{ github.sha }}
-            GESTALT_CREATED=${{ steps.meta.outputs.created }}
-            GESTALT_SOURCE=${{ env.IMAGE_SOURCE }}
-            GESTALT_DOCUMENTATION=${{ env.IMAGE_DOCUMENTATION }}
-            GESTALT_URL=${{ env.IMAGE_URL }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
-          sbom: true
-          provenance: mode=max
-      - name: Build and push debug image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: Dockerfile
-          target: debug
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.IMAGE_NAME }}:debug
-            ${{ env.IMAGE_NAME }}:debug-${{ steps.version.outputs.version }}
-          build-args: |
-            GESTALT_VERSION=${{ steps.version.outputs.version }}
-            GESTALT_REVISION=${{ github.sha }}
-            GESTALT_CREATED=${{ steps.meta.outputs.created }}
-            GESTALT_SOURCE=${{ env.IMAGE_SOURCE }}
-            GESTALT_DOCUMENTATION=${{ env.IMAGE_DOCUMENTATION }}
-            GESTALT_URL=${{ env.IMAGE_URL }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
-          sbom: true
-          provenance: mode=max
-      - name: Scan runtime image for vulnerabilities
+      - name: Scan image for vulnerabilities
         uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-          format: table
-          exit-code: '1'
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-      - name: Scan builder image for vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
-        with:
-          image-ref: ${{ env.IMAGE_NAME }}:builder-${{ steps.version.outputs.version }}
-          format: table
-          exit-code: '0'
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-      - name: Scan debug image for vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
-        with:
-          image-ref: ${{ env.IMAGE_NAME }}:debug-${{ steps.version.outputs.version }}
           format: table
           exit-code: '1'
           severity: CRITICAL,HIGH

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,27 +26,7 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /gestaltd ./cmd/gestaltd
 RUN mkdir /data
 
-FROM golang:1.26-alpine AS builder
-ARG GESTALT_VERSION
-ARG GESTALT_REVISION
-ARG GESTALT_CREATED
-ARG GESTALT_SOURCE
-ARG GESTALT_DOCUMENTATION
-ARG GESTALT_URL
-RUN apk upgrade --no-cache && apk add --no-cache ca-certificates git
-COPY --from=build-binary /gestaltd /gestaltd
-RUN ln -sf /gestaltd /usr/local/bin/gestaltd
-WORKDIR /src
-LABEL org.opencontainers.image.title="gestaltd builder" \
-      org.opencontainers.image.description="Build image for packaging plugins and bundling Gestalt deployments." \
-      org.opencontainers.image.source="${GESTALT_SOURCE}" \
-      org.opencontainers.image.documentation="${GESTALT_DOCUMENTATION}" \
-      org.opencontainers.image.url="${GESTALT_URL}" \
-      org.opencontainers.image.version="${GESTALT_VERSION}" \
-      org.opencontainers.image.revision="${GESTALT_REVISION}" \
-      org.opencontainers.image.created="${GESTALT_CREATED}"
-
-FROM alpine:3.21 AS debug
+FROM alpine:3.21
 ARG GESTALT_VERSION
 ARG GESTALT_REVISION
 ARG GESTALT_CREATED
@@ -56,28 +36,6 @@ ARG GESTALT_URL
 RUN apk upgrade --no-cache && apk add --no-cache ca-certificates curl
 COPY --from=build-binary /gestaltd /gestaltd
 RUN mkdir -p /data && chown nobody:nobody /data
-USER nobody:nobody
-LABEL org.opencontainers.image.title="gestaltd debug" \
-      org.opencontainers.image.description="Debug image for gestaltd with a shell and troubleshooting tools." \
-      org.opencontainers.image.source="${GESTALT_SOURCE}" \
-      org.opencontainers.image.documentation="${GESTALT_DOCUMENTATION}" \
-      org.opencontainers.image.url="${GESTALT_URL}" \
-      org.opencontainers.image.version="${GESTALT_VERSION}" \
-      org.opencontainers.image.revision="${GESTALT_REVISION}" \
-      org.opencontainers.image.created="${GESTALT_CREATED}"
-EXPOSE 8080
-ENTRYPOINT ["/gestaltd"]
-CMD ["serve", "--locked", "--config", "/etc/gestalt/config.yaml"]
-
-FROM gcr.io/distroless/static-debian12 AS runtime
-ARG GESTALT_VERSION
-ARG GESTALT_REVISION
-ARG GESTALT_CREATED
-ARG GESTALT_SOURCE
-ARG GESTALT_DOCUMENTATION
-ARG GESTALT_URL
-COPY --from=build-binary /gestaltd /gestaltd
-COPY --from=build-binary --chown=nobody:nobody /data /data
 LABEL org.opencontainers.image.title="gestaltd" \
       org.opencontainers.image.description="Self-hosted integration runtime for REST, GraphQL, MCP, and plugins." \
       org.opencontainers.image.source="${GESTALT_SOURCE}" \

--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ The published `valontechnologies/gestaltd` image:
 - serves the API, embedded UI, `/health`, `/ready`, and `/mcp`
 - defaults to `serve --locked --config /etc/gestalt/config.yaml`
 - expects you to mount or bake a config file before startup
-- also publishes `:builder` and `:debug` variants
+- includes a shell, `ca-certificates`, and `curl`
 
 ```dockerfile
-FROM valontechnologies/gestaltd:builder AS bundle
+FROM valontechnologies/gestaltd:latest AS bundle
+USER root
 COPY config.yaml /src/config.yaml
 RUN ["/gestaltd", "bundle", "--config", "/src/config.yaml", "--output", "/app"]
 

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -29,23 +29,12 @@ The publish workflows maintain these tag shapes:
 - `latest`
 - `<version>`
 - `<sha>`
-- `builder`
-- `builder-<version>`
-- `builder-<sha>`
-- `debug`
-- `debug-<version>`
-- `debug-<sha>`
 
 The image is published for `linux/amd64` and `linux/arm64`.
 
-## What each tag is for
+## What the image includes
 
-- `valontechnologies/gestaltd:latest`
-  The production runtime image. Distroless, no shell, smallest surface area.
-- `valontechnologies/gestaltd:builder`
-  A Go-based build image with `gestaltd`, `git`, and the Go toolchain. Use it when compiling plugins and bundling a deployment in a multi-stage Docker build.
-- `valontechnologies/gestaltd:debug`
-  A shell-enabled image for troubleshooting. Same `gestaltd` entrypoint, plus a shell and `curl`.
+The image is Alpine-based and includes `gestaltd`, a shell, `ca-certificates`, and `curl`. It runs as `nobody:nobody` by default.
 
 ## Run a simple static config
 
@@ -82,7 +71,8 @@ integrations: {}
 If your config references remote OpenAPI or GraphQL sources, or `plugin.package`, prepare it during the image build:
 
 ```dockerfile
-FROM valontechnologies/gestaltd:builder AS bundle
+FROM valontechnologies/gestaltd:latest AS bundle
+USER root
 COPY config.yaml /src/config.yaml
 RUN ["/gestaltd", "bundle", "--config", "/src/config.yaml", "--output", "/app"]
 
@@ -159,24 +149,28 @@ For horizontally scaled deployments, prefer Postgres or MySQL.
 
 ## Debugging
 
-The default runtime image is distroless, so it does not include a shell. Use the `debug` tag when you need interactive troubleshooting:
+The image includes a shell, so you can exec into a running container or start an interactive session:
 
 ```sh
-docker run --rm -it --entrypoint sh valontechnologies/gestaltd:debug
+docker run --rm -it --entrypoint sh valontechnologies/gestaltd:latest
 ```
 
 You can also use it to check startup behavior directly:
 
 ```sh
-docker run --rm valontechnologies/gestaltd:debug --help
+docker run --rm valontechnologies/gestaltd:latest --help
 ```
 
 ## Building plugins and bundles
 
-Use the `builder` tag when you want to compile plugins and run `gestaltd bundle` in the same build stage:
+To compile Go plugins, use a standard `golang:` image and copy `gestaltd` from the runtime image:
 
 ```dockerfile
-FROM valontechnologies/gestaltd:builder AS build
+FROM valontechnologies/gestaltd:latest AS gestaltd
+
+FROM golang:1.26-alpine AS build
+RUN apk add --no-cache git
+COPY --from=gestaltd /gestaltd /usr/local/bin/gestaltd
 WORKDIR /src
 COPY . .
 RUN go build -o /tmp/myplugin ./plugins/cmd/myplugin && \
@@ -188,7 +182,7 @@ RUN go build -o /tmp/myplugin ./plugins/cmd/myplugin && \
 
 - The published image defaults to locked startup. A missing config file or missing prepared state causes startup to fail fast.
 - `docker run valontechnologies/gestaltd:latest` by itself is expected to fail because the image does not auto-generate config in-container.
-- The runtime image has no shell. Use `:debug` if you need one.
+- The image includes a shell and `curl` for debugging.
 - If you use SQLite, do not scale to multiple replicas.
 
 ## Learn more

--- a/examples/deploy/Dockerfile
+++ b/examples/deploy/Dockerfile
@@ -1,4 +1,5 @@
-FROM valontechnologies/gestaltd:builder AS bundle
+FROM valontechnologies/gestaltd:latest AS bundle
+USER root
 COPY config.yaml /src/config.yaml
 RUN ["/gestaltd", "bundle", "--config", "/src/config.yaml", "--output", "/app"]
 

--- a/examples/deploy/Dockerfile.plugins
+++ b/examples/deploy/Dockerfile.plugins
@@ -12,11 +12,14 @@
 # Build:
 #   docker build -f Dockerfile.plugins --secret id=github_token,src=token.txt .
 
-FROM valontechnologies/gestaltd:builder AS build
+FROM valontechnologies/gestaltd:latest AS gestaltd
+
+FROM golang:1.26-alpine AS build
+RUN apk add --no-cache git
+COPY --from=gestaltd /gestaltd /usr/local/bin/gestaltd
 WORKDIR /src
 COPY . .
 
-# Build plugin binaries, package them as archives, and bundle everything.
 RUN --mount=type=secret,id=github_token \
     if [ -f /run/secrets/github_token ]; then \
       git config --global url."https://x-access-token:$(cat /run/secrets/github_token)@github.com/".insteadOf "https://github.com/"; \

--- a/examples/deploy/README.md
+++ b/examples/deploy/README.md
@@ -5,4 +5,4 @@ This directory contains published-image examples for `valontechnologies/gestaltd
 - `config.yaml`: minimal static config that works with the default image command
 - `compose.yaml`: simplest `docker compose` example using the published image
 - `Dockerfile`: multi-stage example that bundles config during the image build
-- `Dockerfile.plugins`: multi-stage example that compiles Go plugins with `valontechnologies/gestaltd:builder`, packages them, and bundles the deployment
+- `Dockerfile.plugins`: multi-stage example that compiles Go plugins with a standard `golang:` image, packages them, and bundles the deployment


### PR DESCRIPTION
Replace the three separate Docker image stages (builder, debug, runtime)
with a single Alpine-based image. The builder image existed to provide a
Go toolchain for compiling plugins, but since Gestalt plugins are
separate binaries, users can bring their own golang image and copy
gestaltd from the runtime image. The debug image existed to provide a
shell for docker exec, which Alpine gives us by default.

This drops from three published tags to one and simplifies the deployment
examples. Plugin authors now use a standard golang: image with gestaltd
copied in, which also lets them control their own Go version.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>