### PR TITLE
Migrate remaining log.Printf calls to structured slog

### DIFF
--- a/internal/mcpoauth/handler.go
+++ b/internal/mcpoauth/handler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -122,7 +122,7 @@ func (h *Handler) resolveRegistration(ctx context.Context, md *DiscoveredMetadat
 	authServerURL := md.AuthServerURL
 	existing, err := h.cfg.Store.GetRegistration(ctx, authServerURL, h.cfg.RedirectURL)
 	if err != nil {
-		log.Printf("WARNING: mcpoauth: reading registration for %s: %v", authServerURL, err)
+		slog.Warn("mcpoauth: reading registration failed", "auth_server", authServerURL, "error", err)
 	}
 	if existing != nil {
 		return existing, nil
@@ -147,7 +147,7 @@ func (h *Handler) resolveRegistration(ctx context.Context, md *DiscoveredMetadat
 	}
 
 	if err := h.cfg.Store.StoreRegistration(ctx, reg); err != nil {
-		log.Printf("WARNING: mcpoauth: storing registration for %s: %v", authServerURL, err)
+		slog.Warn("mcpoauth: storing registration failed", "auth_server", authServerURL, "error", err)
 	}
 
 	return reg, nil
@@ -158,7 +158,7 @@ func (h *Handler) resolveRegistration(ctx context.Context, md *DiscoveredMetadat
 func (h *Handler) AuthorizationURL(state string, scopes []string) string {
 	upstream, err := h.ensure()
 	if err != nil {
-		log.Printf("ERROR: mcpoauth: ensure failed in AuthorizationURL: %v", err)
+		slog.Error("mcpoauth: ensure failed", "method", "AuthorizationURL", "error", err)
 		return ""
 	}
 	authURL, _ := upstream.AuthorizationURLWithPKCE(state, scopes)
@@ -168,7 +168,7 @@ func (h *Handler) AuthorizationURL(state string, scopes []string) string {
 func (h *Handler) StartOAuth(state string, scopes []string) (string, string) {
 	upstream, err := h.ensure()
 	if err != nil {
-		log.Printf("ERROR: mcpoauth: ensure failed in StartOAuth: %v", err)
+		slog.Error("mcpoauth: ensure failed", "method", "StartOAuth", "error", err)
 		return "", ""
 	}
 	return upstream.AuthorizationURLWithPKCE(state, scopes)
@@ -177,7 +177,7 @@ func (h *Handler) StartOAuth(state string, scopes []string) (string, string) {
 func (h *Handler) StartOAuthWithOverride(authBaseURL, state string, scopes []string) (string, string) {
 	upstream, err := h.ensure()
 	if err != nil {
-		log.Printf("ERROR: mcpoauth: ensure failed in StartOAuthWithOverride: %v", err)
+		slog.Error("mcpoauth: ensure failed", "method", "StartOAuthWithOverride", "error", err)
 		return "", ""
 	}
 	return upstream.AuthorizationURLWithOverride(authBaseURL, state, scopes)

--- a/internal/operator/lifecycle.go
+++ b/internal/operator/lifecycle.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"maps"
 	"os"
 	"path/filepath"
@@ -101,8 +101,8 @@ func (l *Lifecycle) InitAtPath(configPath string) (*Lockfile, error) {
 		return nil, err
 	}
 
-	log.Printf("prepared providers: %d", len(lock.Providers))
-	log.Printf("wrote lockfile %s", paths.lockfilePath)
+	slog.Info("prepared providers", "count", len(lock.Providers))
+	slog.Info("wrote lockfile", "path", paths.lockfilePath)
 	return lock, nil
 }
 
@@ -241,7 +241,7 @@ func (l *Lifecycle) writeProviderArtifacts(ctx context.Context, cfg *config.Conf
 			Fingerprint: fingerprint,
 			Provider:    filepath.ToSlash(relPath),
 		}
-		log.Printf("wrote prepared provider %s", outPath)
+		slog.Info("wrote prepared provider", "path", outPath)
 	}
 	return written, nil
 }

--- a/internal/operator/localconfig.go
+++ b/internal/operator/localconfig.go
@@ -4,7 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 )
@@ -45,6 +45,6 @@ server:
 	if err := os.WriteFile(configPath, []byte(cfg), 0o600); err != nil {
 		return "", fmt.Errorf("write config: %w", err)
 	}
-	log.Printf("generated default config at %s", configPath)
+	slog.Info("generated default config", "path", configPath)
 	return configPath, nil
 }

--- a/internal/pluginapi/provider_client.go
+++ b/internal/pluginapi/provider_client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"slices"
 	"sync"
 
@@ -55,7 +55,7 @@ func NewRemoteProvider(ctx context.Context, client pluginapiv1.ProviderPluginCli
 		return nil, err
 	}
 	if schemaJSON := meta.GetConfigSchemaJson(); schemaJSON != "" {
-		log.Printf("WARNING: validating plugin %q config requires executing plugin binary; use manifests for static validation (Phase 3)", name)
+		slog.Warn("validating plugin config requires executing plugin binary", "plugin", name)
 		validationTarget := config
 		if validationTarget == nil {
 			validationTarget = map[string]any{}

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -246,7 +246,7 @@ func ApplyDisplayOverrides(def *Definition, intg config.IntegrationDef) {
 	if intg.IconFile != "" {
 		data, err := os.ReadFile(intg.IconFile)
 		if err != nil {
-			log.Printf("WARNING: could not read icon_file %q: %v", intg.IconFile, err)
+			slog.Warn("could not read icon_file", "path", intg.IconFile, "error", err)
 		} else {
 			def.IconSVG = strings.TrimSpace(string(data))
 		}

--- a/plugins/bindings/webhook/webhook.go
+++ b/plugins/bindings/webhook/webhook.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 
@@ -37,7 +37,7 @@ type Binding struct {
 
 func New(name string, cfg webhookConfig, invoker invocation.Invoker) *Binding {
 	if cfg.AuthMode == AuthModeTrustedUserHeader && len(cfg.TrustedSources) == 0 {
-		log.Printf("warning: webhook binding %q uses trusted_user_header auth without trusted_sources; any client can set the user header", name)
+		slog.Warn("webhook binding uses trusted_user_header without trusted_sources", "binding", name)
 	}
 	return &Binding{name: name, cfg: cfg, invoker: invoker}
 }


### PR DESCRIPTION
The codebase had already adopted slog in most places, but a handful of
log.Printf calls remained in mcpoauth, provider build, pluginapi, operator
lifecycle, and the webhook binding. This replaces all of them with the
appropriate slog.Info, slog.Warn, or slog.Error calls using structured
key-value pairs, completing the migration to structured logging throughout
the non-test production code.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>