### PR TITLE
Record request metadata in audit log entries

### DIFF
--- a/core/audit.go
+++ b/core/audit.go
@@ -6,15 +6,18 @@ import (
 )
 
 type AuditEntry struct {
-	Timestamp time.Time
-	RequestID string
-	Source    string
-	UserID    string
-	Provider  string
-	Operation string
-	Depth     int
-	Allowed   bool
-	Error     string
+	Timestamp  time.Time
+	RequestID  string
+	Source     string
+	UserID     string
+	Provider   string
+	Operation  string
+	Depth      int
+	Allowed    bool
+	Error      string
+	ClientIP   string
+	RemoteAddr string
+	UserAgent  string
 }
 
 type AuditSink interface {

--- a/internal/invocation/audit.go
+++ b/internal/invocation/audit.go
@@ -44,6 +44,16 @@ func (s *SlogAuditSink) Log(ctx context.Context, entry core.AuditEntry) {
 		attrs = append(attrs, slog.String("error", entry.Error))
 	}
 
+	if entry.ClientIP != "" {
+		attrs = append(attrs, slog.String("client_ip", entry.ClientIP))
+	}
+	if entry.RemoteAddr != "" {
+		attrs = append(attrs, slog.String("remote_addr", entry.RemoteAddr))
+	}
+	if entry.UserAgent != "" {
+		attrs = append(attrs, slog.String("user_agent", entry.UserAgent))
+	}
+
 	spanCtx := trace.SpanContextFromContext(ctx)
 	if spanCtx.IsValid() {
 		attrs = append(attrs,

--- a/internal/invocation/context.go
+++ b/internal/invocation/context.go
@@ -2,6 +2,9 @@ package invocation
 
 import (
 	"context"
+	"net"
+	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
 )
@@ -30,4 +33,40 @@ func ensureMeta(ctx context.Context) (context.Context, *InvocationMeta) {
 	}
 	meta = &InvocationMeta{RequestID: uuid.NewString()}
 	return ContextWithMeta(ctx, meta), meta
+}
+
+type requestMetaCtxKey struct{}
+
+type RequestMeta struct {
+	ClientIP   string
+	RemoteAddr string
+	UserAgent  string
+}
+
+func WithRequestMeta(ctx context.Context, meta RequestMeta) context.Context {
+	return context.WithValue(ctx, requestMetaCtxKey{}, meta)
+}
+
+func RequestMetaFromContext(ctx context.Context) RequestMeta {
+	m, _ := ctx.Value(requestMetaCtxKey{}).(RequestMeta)
+	return m
+}
+
+const xForwardedForHeader = "X-Forwarded-For"
+
+func ClientIP(r *http.Request) string {
+	if xff := r.Header.Get(xForwardedForHeader); xff != "" {
+		if ip := strings.TrimSpace(strings.SplitN(xff, ",", 2)[0]); ip != "" {
+			return ip
+		}
+	}
+	return RemoteAddrIP(r)
+}
+
+func RemoteAddrIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
 }

--- a/internal/invocation/guarded.go
+++ b/internal/invocation/guarded.go
@@ -78,13 +78,17 @@ func (g *GuardedInvoker) Invoke(ctx context.Context, p *principal.Principal, pro
 		p = &principal.Principal{}
 	}
 
+	reqMeta := RequestMetaFromContext(ctx)
 	entry := core.AuditEntry{
-		Timestamp: time.Now(),
-		RequestID: meta.RequestID,
-		Source:    g.source,
-		Provider:  providerName,
-		Operation: operation,
-		Depth:     meta.Depth,
+		Timestamp:  time.Now(),
+		RequestID:  meta.RequestID,
+		Source:     g.source,
+		Provider:   providerName,
+		Operation:  operation,
+		Depth:      meta.Depth,
+		ClientIP:   reqMeta.ClientIP,
+		RemoteAddr: reqMeta.RemoteAddr,
+		UserAgent:  reqMeta.UserAgent,
 	}
 	if p != nil {
 		entry.UserID = p.UserID

--- a/internal/server/audit_metadata_test.go
+++ b/internal/server/audit_metadata_test.go
@@ -1,0 +1,194 @@
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/core"
+	coretesting "github.com/valon-technologies/gestalt/core/testing"
+	"github.com/valon-technologies/gestalt/internal/invocation"
+	"github.com/valon-technologies/gestalt/internal/server"
+	"github.com/valon-technologies/gestalt/internal/testutil"
+)
+
+func TestAuditMetadata_IPAndUserAgent(t *testing.T) {
+	t.Parallel()
+
+	var auditBuf bytes.Buffer
+	auditSink := invocation.NewSlogAuditSink(&auditBuf)
+
+	stub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "audit-prov",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "ping", Method: http.MethodPost}},
+	}
+
+	providers := testutil.NewProviderRegistry(t, stub)
+	ds := &coretesting.StubDatastore{}
+	broker := invocation.NewBroker(providers, ds)
+	guarded := invocation.NewGuarded(broker, broker, "http", auditSink, invocation.WithoutRateLimit())
+
+	srv, err := server.New(server.Config{
+		Auth:        &coretesting.StubAuthProvider{N: "none"},
+		Datastore:   ds,
+		Providers:   providers,
+		Invoker:     guarded,
+		StateSecret: []byte("0123456789abcdef0123456789abcdef"),
+	})
+	if err != nil {
+		t.Fatalf("creating server: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/audit-prov/ping", bytes.NewBufferString(`{}`))
+	req.Header.Set("X-Forwarded-For", "203.0.113.42, 10.0.0.1")
+	req.Header.Set("User-Agent", "test-client/1.0")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var record map[string]any
+	if err := json.Unmarshal(auditBuf.Bytes(), &record); err != nil {
+		t.Fatalf("failed to parse audit JSON: %v\nraw: %s", err, auditBuf.String())
+	}
+
+	if record["client_ip"] != "203.0.113.42" {
+		t.Errorf("expected client_ip=203.0.113.42, got %v", record["client_ip"])
+	}
+	remoteAddr, _ := record["remote_addr"].(string)
+	if remoteAddr == "" {
+		t.Error("expected non-empty remote_addr for direct connection address")
+	}
+	if remoteAddr == "203.0.113.42" {
+		t.Error("remote_addr should be the actual connection address, not the XFF value")
+	}
+	if record["user_agent"] != "test-client/1.0" {
+		t.Errorf("expected user_agent=test-client/1.0, got %v", record["user_agent"])
+	}
+	if record["provider"] != "audit-prov" {
+		t.Errorf("expected provider=audit-prov, got %v", record["provider"])
+	}
+	if record["allowed"] != true {
+		t.Errorf("expected allowed=true, got %v", record["allowed"])
+	}
+}
+
+func TestAuditMetadata_FallbackToRemoteAddr(t *testing.T) {
+	t.Parallel()
+
+	var auditBuf bytes.Buffer
+	auditSink := invocation.NewSlogAuditSink(&auditBuf)
+
+	stub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "audit-fallback-prov",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "ping", Method: http.MethodPost}},
+	}
+
+	providers := testutil.NewProviderRegistry(t, stub)
+	ds := &coretesting.StubDatastore{}
+	broker := invocation.NewBroker(providers, ds)
+	guarded := invocation.NewGuarded(broker, broker, "http", auditSink, invocation.WithoutRateLimit())
+
+	srv, err := server.New(server.Config{
+		Auth:        &coretesting.StubAuthProvider{N: "none"},
+		Datastore:   ds,
+		Providers:   providers,
+		Invoker:     guarded,
+		StateSecret: []byte("0123456789abcdef0123456789abcdef"),
+	})
+	if err != nil {
+		t.Fatalf("creating server: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/audit-fallback-prov/ping", bytes.NewBufferString(`{}`))
+	req.Header.Set("User-Agent", "fallback-agent/2.0")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var record map[string]any
+	if err := json.Unmarshal(auditBuf.Bytes(), &record); err != nil {
+		t.Fatalf("failed to parse audit JSON: %v\nraw: %s", err, auditBuf.String())
+	}
+
+	clientIP, ok := record["client_ip"].(string)
+	if !ok || clientIP == "" {
+		t.Errorf("expected non-empty client_ip from RemoteAddr fallback, got %v", record["client_ip"])
+	}
+	remoteAddr, ok := record["remote_addr"].(string)
+	if !ok || remoteAddr == "" {
+		t.Errorf("expected non-empty remote_addr, got %v", record["remote_addr"])
+	}
+	if clientIP != remoteAddr {
+		t.Errorf("without XFF, client_ip and remote_addr should match: client_ip=%v, remote_addr=%v", clientIP, remoteAddr)
+	}
+	if record["user_agent"] != "fallback-agent/2.0" {
+		t.Errorf("expected user_agent=fallback-agent/2.0, got %v", record["user_agent"])
+	}
+}
+
+func TestAuditMetadata_OmittedWithoutHTTPContext(t *testing.T) {
+	t.Parallel()
+
+	var auditBuf bytes.Buffer
+	auditSink := invocation.NewSlogAuditSink(&auditBuf)
+
+	entry := core.AuditEntry{
+		RequestID: "req-no-http",
+		Source:    "runtime:test",
+		Provider:  "alpha",
+		Operation: "fetch",
+		Allowed:   true,
+	}
+	auditSink.Log(t.Context(), entry)
+
+	var record map[string]any
+	if err := json.Unmarshal(auditBuf.Bytes(), &record); err != nil {
+		t.Fatalf("failed to parse audit JSON: %v", err)
+	}
+
+	if _, has := record["client_ip"]; has {
+		t.Errorf("expected no client_ip for non-HTTP invocation, got %v", record["client_ip"])
+	}
+	if _, has := record["remote_addr"]; has {
+		t.Errorf("expected no remote_addr for non-HTTP invocation, got %v", record["remote_addr"])
+	}
+	if _, has := record["user_agent"]; has {
+		t.Errorf("expected no user_agent for non-HTTP invocation, got %v", record["user_agent"])
+	}
+}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/valon-technologies/gestalt/core"
+	"github.com/valon-technologies/gestalt/internal/invocation"
 	"github.com/valon-technologies/gestalt/internal/principal"
 )
 
@@ -37,6 +38,18 @@ func UserIDFromContext(ctx context.Context) string {
 
 func PrincipalFromContext(ctx context.Context) *principal.Principal {
 	return principal.FromContext(ctx)
+}
+
+func requestMetaMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		meta := invocation.RequestMeta{
+			ClientIP:   invocation.ClientIP(r),
+			RemoteAddr: invocation.RemoteAddrIP(r),
+			UserAgent:  r.UserAgent(),
+		}
+		ctx := invocation.WithRequestMeta(r.Context(), meta)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
 }
 
 func maxBodyMiddleware(limit int64) func(http.Handler) http.Handler {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -4,6 +4,7 @@ import "github.com/go-chi/chi/v5"
 
 func (s *Server) routes() {
 	r := s.router
+	r.Use(requestMetaMiddleware)
 	r.Use(s.securityHeadersMiddleware)
 	r.Use(maxBodyMiddleware(1 << 20)) // 1 MB
 


### PR DESCRIPTION
Audit entries now capture IP address, user agent, and the direct connection address for every HTTP request. The middleware extracts the client IP from the `X-Forwarded-For` header when present (for reverse proxy setups) and always records the raw `RemoteAddr` as a separate field. This prevents XFF spoofing from hiding the real connection source, since both values are logged independently.

Integration tests verify that `client_ip` reflects the forwarded header value while `remote_addr` captures the actual connection, and that both fields are omitted for non-HTTP invocations.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>