### PR TITLE
Add scope_param to OAuth config for non-standard providers

### DIFF
--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -361,6 +361,7 @@ auth:
   scopes:
     - read
     - write
+  scope_param: user_scope
   scope_separator: ","
   pkce: true
   authorization_params:
@@ -382,6 +383,7 @@ Supported or notable fields:
 - `client_auth`
 - `token_exchange`
 - `scopes`
+- `scope_param` -- query parameter name for scopes (defaults to `scope`). Set to `user_scope` for Slack and other providers that use a non-standard parameter.
 - `scope_separator`
 - `pkce`
 - `authorization_params`

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -88,6 +88,13 @@ func (a *upstreamHandlerAdapter) RefreshTokenWithURL(ctx context.Context, refres
 func (a *upstreamHandlerAdapter) AuthorizationBaseURL() string { return a.h.AuthorizationBaseURL() }
 func (a *upstreamHandlerAdapter) TokenURL() string             { return a.h.TokenURL() }
 
+// RegistrationClearer is an optional interface that OAuthHandler
+// implementations can satisfy to support clearing cached dynamic client
+// registrations. mcpoauth.Handler implements this.
+type RegistrationClearer interface {
+	ClearRegistration()
+}
+
 // ProviderBuildResult is the return value of a ProviderFactory. It carries
 // the constructed provider and an OAuth handler for each named connection
 // that uses oauth2 or mcp_oauth auth.
@@ -913,6 +920,7 @@ func buildOAuthHandlerFromManifest(manifest *pluginmanifestv1.Manifest, pluginCo
 		RedirectURL:         redirectURL,
 		PKCE:                auth.PKCE,
 		DefaultScopes:       auth.Scopes,
+		ScopeParam:          auth.ScopeParam,
 		ScopeSeparator:      auth.ScopeSeparator,
 		TokenExchange:       tokenExchange,
 		AuthorizationParams: auth.AuthorizationParams,

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -88,13 +88,6 @@ func (a *upstreamHandlerAdapter) RefreshTokenWithURL(ctx context.Context, refres
 func (a *upstreamHandlerAdapter) AuthorizationBaseURL() string { return a.h.AuthorizationBaseURL() }
 func (a *upstreamHandlerAdapter) TokenURL() string             { return a.h.TokenURL() }
 
-// RegistrationClearer is an optional interface that OAuthHandler
-// implementations can satisfy to support clearing cached dynamic client
-// registrations. mcpoauth.Handler implements this.
-type RegistrationClearer interface {
-	ClearRegistration()
-}
-
 // ProviderBuildResult is the return value of a ProviderFactory. It carries
 // the constructed provider and an OAuth handler for each named connection
 // that uses oauth2 or mcp_oauth auth.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -179,6 +179,7 @@ type ConnectionAuthDef struct {
 	ClientAuth          string            `yaml:"client_auth"`
 	TokenExchange       string            `yaml:"token_exchange"`
 	Scopes              []string          `yaml:"scopes"`
+	ScopeParam          string            `yaml:"scope_param"`
 	ScopeSeparator      string            `yaml:"scope_separator"`
 	PKCE                bool              `yaml:"pkce"`
 	AuthorizationParams map[string]string `yaml:"authorization_params"`

--- a/internal/oauth/upstream.go
+++ b/internal/oauth/upstream.go
@@ -46,6 +46,7 @@ type UpstreamConfig struct {
 	PKCE             bool
 
 	DefaultScopes       []string
+	ScopeParam          string
 	ScopeSeparator      string
 	AuthorizationParams map[string]string
 	TokenParams         map[string]string
@@ -147,7 +148,11 @@ func (h *UpstreamHandler) authorizationURL(baseURL, state string, scopes []strin
 		if h.cfg.ScopeSeparator != "" {
 			sep = h.cfg.ScopeSeparator
 		}
-		q.Set("scope", strings.Join(effective, sep))
+		param := "scope"
+		if h.cfg.ScopeParam != "" {
+			param = h.cfg.ScopeParam
+		}
+		q.Set(param, strings.Join(effective, sep))
 	}
 
 	for k, v := range h.cfg.AuthorizationParams {

--- a/internal/provider/build.go
+++ b/internal/provider/build.go
@@ -264,6 +264,7 @@ func ApplyConnectionAuth(def *Definition, conn config.ConnectionDef) {
 	if o.Scopes != nil {
 		def.Auth.Scopes = o.Scopes
 	}
+	setStr(&def.Auth.ScopeParam, o.ScopeParam)
 	setStr(&def.Auth.ScopeSeparator, o.ScopeSeparator)
 	setStr(&def.Auth.AcceptHeader, o.AcceptHeader)
 	if o.PKCE {
@@ -328,6 +329,7 @@ func BuildOAuthUpstream(def *Definition, conn config.ConnectionDef, baseURL stri
 		RedirectURL:         conn.Auth.RedirectURL,
 		PKCE:                def.Auth.PKCE,
 		DefaultScopes:       def.Auth.Scopes,
+		ScopeParam:          def.Auth.ScopeParam,
 		ScopeSeparator:      def.Auth.ScopeSeparator,
 		AuthorizationParams: def.Auth.AuthorizationParams,
 		TokenParams:         def.Auth.TokenParams,

--- a/internal/provider/definition.go
+++ b/internal/provider/definition.go
@@ -68,6 +68,7 @@ type AuthDef struct {
 	ClientAuth          string            `yaml:"client_auth" json:"client_auth"`       // body (default), header
 	TokenExchange       string            `yaml:"token_exchange" json:"token_exchange"` // form (default), json
 	Scopes              []string          `yaml:"scopes" json:"scopes"`
+	ScopeParam          string            `yaml:"scope_param" json:"scope_param"`
 	ScopeSeparator      string            `yaml:"scope_separator" json:"scope_separator"`
 	PKCE                bool              `yaml:"pkce" json:"pkce"`
 	AuthorizationParams map[string]string `yaml:"authorization_params" json:"authorization_params"`

--- a/plugins/slack/plugin.yaml
+++ b/plugins/slack/plugin.yaml
@@ -12,12 +12,24 @@ provider:
     type: oauth2
     authorization_url: https://slack.com/oauth/v2/authorize
     token_url: https://slack.com/api/oauth.v2.access
+    scope_param: user_scope
+    scope_separator: ","
     scopes:
       - channels:read
       - channels:history
-      - chat:write
-      - users:read
+      - groups:read
+      - groups:history
+      - im:read
+      - im:history
+      - mpim:read
+      - mpim:history
       - search:read
+      - users:read
+      - chat:write
+      - reactions:write
+      - channels:write
+      - groups:write
+      - canvases:write
   operations:
     - name: slack_list_channels
       description: List conversations/channels

--- a/sdk/pluginmanifest/v1/manifest.v2.jsonschema.json
+++ b/sdk/pluginmanifest/v1/manifest.v2.jsonschema.json
@@ -235,6 +235,10 @@
           "type": "string",
           "enum": ["form", "json"]
         },
+        "scope_param": {
+          "type": "string",
+          "description": "Query parameter name for scopes (default: scope)"
+        },
         "scope_separator": {
           "type": "string"
         },

--- a/sdk/pluginmanifest/v1/types.go
+++ b/sdk/pluginmanifest/v1/types.go
@@ -71,6 +71,7 @@ type ProviderAuth struct {
 	PKCE                bool              `json:"pkce,omitempty"`
 	ClientAuth          string            `json:"client_auth,omitempty"`
 	TokenExchange       string            `json:"token_exchange,omitempty"`
+	ScopeParam          string            `json:"scope_param,omitempty"`
 	ScopeSeparator      string            `json:"scope_separator,omitempty"`
 	AuthorizationParams map[string]string `json:"authorization_params,omitempty"`
 }


### PR DESCRIPTION
## Summary
- Adds `scope_param` field to the OAuth config chain so integrations can override the default `scope` query parameter name
- Fixes Slack OAuth failing with `invalid_scope` because the server sent user scopes as `scope` (bot scopes) instead of `user_scope`
- Updates Slack plugin manifest to v0.0.1-alpha.3 with `scope_param: "user_scope"`, comma separator, and full scope list

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/oauth/... ./internal/bootstrap/... ./internal/provider/...` all pass
- [ ] Deploy and verify Slack OAuth flow completes without `invalid_scope` error
- [ ] Verify existing OAuth integrations (Google, Figma, PagerDuty, etc.) are unaffected (scope_param defaults to "scope" when unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)