### PR TITLE
Fix Docker image security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,14 +26,14 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /gestaltd ./cmd/gestaltd
 RUN mkdir /data
 
-FROM alpine:3.21
+FROM alpine:3.23
 ARG GESTALT_VERSION
 ARG GESTALT_REVISION
 ARG GESTALT_CREATED
 ARG GESTALT_SOURCE
 ARG GESTALT_DOCUMENTATION
 ARG GESTALT_URL
-RUN apk upgrade --no-cache && apk add --no-cache ca-certificates curl
+RUN apk upgrade --no-cache && apk add --no-cache ca-certificates
 COPY --from=build-binary /gestaltd /gestaltd
 RUN mkdir -p /data && chown nobody:nobody /data
 LABEL org.opencontainers.image.title="gestaltd" \

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -34,7 +34,7 @@ The image is published for `linux/amd64` and `linux/arm64`.
 
 ## What the image includes
 
-The image is Alpine-based and includes `gestaltd`, a shell, `ca-certificates`, and `curl`. It runs as `nobody:nobody` by default.
+The image is Alpine-based and includes `gestaltd`, a shell, and `ca-certificates`. It runs as `nobody:nobody` by default.
 
 ## Run a simple static config
 
@@ -182,7 +182,7 @@ RUN go build -o /tmp/myplugin ./plugins/cmd/myplugin && \
 
 - The published image defaults to locked startup. A missing config file or missing prepared state causes startup to fail fast.
 - `docker run valontechnologies/gestaltd:latest` by itself is expected to fail because the image does not auto-generate config in-container.
-- The image includes a shell and `curl` for debugging.
+- The image includes a shell for debugging.
 - If you use SQLite, do not scale to multiple replicas.
 
 ## Learn more


### PR DESCRIPTION
The gestaltd Docker image had 15 CVEs across system packages, primarily
in `curl` and its dependencies. Since `curl` was only included for ad-hoc
debugging and Kubernetes health probes use native `httpGet`, removing it
eliminates 12 of the 15 CVEs. Bumping the base image from `alpine:3.21`
to `alpine:3.23` (current latest stable) addresses the remaining `zlib`
and BusyBox vulnerabilities through newer packages and backported fixes.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>