### PR TITLE
Expire stale MCP OAuth dynamic client registrations

### DIFF
--- a/server/internal/drivers/datastore/oracle/oracle.go
+++ b/server/internal/drivers/datastore/oracle/oracle.go
@@ -53,6 +53,7 @@ func (dialect) RegistrationDDL() string {
 				redirect_uri VARCHAR2(255) NOT NULL,
 				client_id VARCHAR2(255) NOT NULL,
 				client_secret_encrypted CLOB,
+				expires_at TIMESTAMP WITH TIME ZONE,
 				authorization_endpoint VARCHAR2(500) NOT NULL,
 				token_endpoint VARCHAR2(500) NOT NULL,
 				scopes_supported CLOB,

--- a/server/internal/drivers/datastore/postgres/postgres.go
+++ b/server/internal/drivers/datastore/postgres/postgres.go
@@ -41,6 +41,7 @@ func (dialect) RegistrationDDL() string {
 		redirect_uri TEXT NOT NULL,
 		client_id TEXT NOT NULL,
 		client_secret_encrypted TEXT,
+		expires_at TIMESTAMPTZ,
 		authorization_endpoint TEXT NOT NULL,
 		token_endpoint TEXT NOT NULL,
 		scopes_supported TEXT,

--- a/server/internal/drivers/datastore/sqlserver/sqlserver.go
+++ b/server/internal/drivers/datastore/sqlserver/sqlserver.go
@@ -53,6 +53,7 @@ func (dialect) RegistrationDDL() string {
 			redirect_uri NVARCHAR(255) NOT NULL,
 			client_id NVARCHAR(255) NOT NULL,
 			client_secret_encrypted NVARCHAR(MAX),
+			expires_at DATETIME2(6),
 			authorization_endpoint NVARCHAR(500) NOT NULL,
 			token_endpoint NVARCHAR(500) NOT NULL,
 			scopes_supported NVARCHAR(MAX),

--- a/server/internal/mcpoauth/handler.go
+++ b/server/internal/mcpoauth/handler.go
@@ -124,16 +124,28 @@ func (h *Handler) resolveRegistration(ctx context.Context, md *DiscoveredMetadat
 	if err != nil {
 		slog.Warn("mcpoauth: reading registration failed", "auth_server", authServerURL, "error", err)
 	}
-	if existing != nil {
+
+	if existing != nil && !existing.Expired() {
 		return existing, nil
 	}
 
 	if md.RegistrationEndpoint == "" {
+		if existing != nil {
+			return existing, nil
+		}
 		return nil, nil
+	}
+
+	if existing != nil {
+		slog.Info("mcpoauth: re-registering (expired)", "auth_server", authServerURL)
 	}
 
 	reg, err := RegisterClient(ctx, md.RegistrationEndpoint, h.cfg.RedirectURL, "Gestalt", md.PreferredAuthMethod())
 	if err != nil {
+		if existing != nil {
+			slog.Warn("mcpoauth: re-registration failed, using existing", "auth_server", authServerURL, "error", err)
+			return existing, nil
+		}
 		return nil, fmt.Errorf("mcp oauth DCR for %s: %w", h.cfg.MCPURL, err)
 	}
 
@@ -151,6 +163,30 @@ func (h *Handler) resolveRegistration(ctx context.Context, md *DiscoveredMetadat
 	}
 
 	return reg, nil
+}
+
+func (h *Handler) ClearRegistration() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	var authServerURL string
+	if h.metadata != nil {
+		authServerURL = h.metadata.AuthServerURL
+	}
+	h.upstream = nil
+	h.metadata = nil
+	h.discoveredAt = time.Time{}
+
+	if h.cfg.Store == nil || authServerURL == "" {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := h.cfg.Store.DeleteRegistration(ctx, authServerURL, h.cfg.RedirectURL); err != nil {
+		slog.Warn("mcpoauth: deleting registration failed", "auth_server", authServerURL, "error", err)
+	}
 }
 
 // AuthorizationURL discards the PKCE verifier. Use StartOAuth when the

--- a/server/internal/mcpoauth/mcpoauth_test.go
+++ b/server/internal/mcpoauth/mcpoauth_test.go
@@ -33,6 +33,13 @@ func (s *memStore) StoreRegistration(_ context.Context, reg *mcpoauth.Registrati
 	return nil
 }
 
+func (s *memStore) DeleteRegistration(_ context.Context, authServerURL, redirectURI string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.regs, authServerURL+"|"+redirectURI)
+	return nil
+}
+
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	if status != 0 {
@@ -232,6 +239,76 @@ func TestMCPOAuthFlow(t *testing.T) {
 		}
 		if tokenResp.AccessToken != "direct-access-tok" {
 			t.Errorf("access_token = %q, want direct-access-tok", tokenResp.AccessToken)
+		}
+	})
+
+	t.Run("ClearRegistration", func(t *testing.T) {
+		t.Parallel()
+
+		var dcrCount int
+		var mu sync.Mutex
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("POST /mcp", func(w http.ResponseWriter, r *http.Request) {
+			baseURL := "http://" + r.Host
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf(
+				`Bearer resource_metadata="%s/.well-known/oauth-protected-resource/mcp"`, baseURL))
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+		mux.HandleFunc("GET /.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
+			baseURL := "http://" + r.Host
+			writeJSON(w, 0, map[string]any{
+				"resource":              baseURL + "/mcp",
+				"authorization_servers": []string{baseURL},
+			})
+		})
+		mux.HandleFunc("GET /.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+			baseURL := "http://" + r.Host
+			writeJSON(w, 0, map[string]any{
+				"issuer":                                baseURL,
+				"authorization_endpoint":                baseURL + "/oauth/authorize",
+				"token_endpoint":                        baseURL + "/oauth/token",
+				"registration_endpoint":                 baseURL + "/oauth/register",
+				"code_challenge_methods_supported":      []string{"S256"},
+				"token_endpoint_auth_methods_supported": []string{"none"},
+			})
+		})
+		mux.HandleFunc("POST /oauth/register", func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			dcrCount++
+			id := fmt.Sprintf("client-%03d", dcrCount)
+			mu.Unlock()
+			writeJSON(w, http.StatusCreated, map[string]any{"client_id": id})
+		})
+
+		srv := httptest.NewServer(mux)
+		testutil.CloseOnCleanup(t, srv)
+
+		store := &memStore{regs: make(map[string]*mcpoauth.Registration)}
+		handler := mcpoauth.NewHandler(mcpoauth.HandlerConfig{
+			MCPURL:      srv.URL + "/mcp",
+			Store:       store,
+			RedirectURL: "http://localhost:9999/callback",
+		})
+
+		authURL1, _ := handler.StartOAuth("s1", nil)
+		parsed1, _ := url.Parse(authURL1)
+		if parsed1.Query().Get("client_id") != "client-001" {
+			t.Fatalf("first client_id = %q, want client-001", parsed1.Query().Get("client_id"))
+		}
+
+		authURL2, _ := handler.StartOAuth("s2", nil)
+		parsed2, _ := url.Parse(authURL2)
+		if parsed2.Query().Get("client_id") != "client-001" {
+			t.Fatalf("cached client_id = %q, want client-001", parsed2.Query().Get("client_id"))
+		}
+
+		handler.ClearRegistration()
+
+		authURL3, _ := handler.StartOAuth("s3", nil)
+		parsed3, _ := url.Parse(authURL3)
+		if parsed3.Query().Get("client_id") != "client-002" {
+			t.Fatalf("re-registered client_id = %q, want client-002", parsed3.Query().Get("client_id"))
 		}
 	})
 }

--- a/server/internal/mcpoauth/registration.go
+++ b/server/internal/mcpoauth/registration.go
@@ -17,10 +17,18 @@ type Registration struct {
 	RedirectURI           string
 	ClientID              string
 	ClientSecret          string // empty for public clients
+	ExpiresAt             *time.Time
 	AuthorizationEndpoint string
 	TokenEndpoint         string
 	ScopesSupported       string // JSON array
 	DiscoveredAt          time.Time
+}
+
+func (r *Registration) Expired() bool {
+	if r.ExpiresAt != nil {
+		return time.Now().After(*r.ExpiresAt)
+	}
+	return false
 }
 
 func RegisterClient(ctx context.Context, endpoint, redirectURI, clientName, tokenAuthMethod string) (*Registration, error) {
@@ -73,9 +81,16 @@ func RegisterClient(ctx context.Context, endpoint, redirectURI, clientName, toke
 	}
 	clientSecret, _ := result["client_secret"].(string)
 
-	return &Registration{
+	reg := &Registration{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		DiscoveredAt: time.Now(),
-	}, nil
+	}
+
+	if expiresAt, ok := result["client_secret_expires_at"].(float64); ok && expiresAt > 0 {
+		t := time.Unix(int64(expiresAt), 0)
+		reg.ExpiresAt = &t
+	}
+
+	return reg, nil
 }

--- a/server/internal/mcpoauth/sqlstore.go
+++ b/server/internal/mcpoauth/sqlstore.go
@@ -42,6 +42,7 @@ const defaultRegistrationDDL = `CREATE TABLE IF NOT EXISTS oauth_registrations (
 	redirect_uri VARCHAR(255) NOT NULL,
 	client_id VARCHAR(255) NOT NULL,
 	client_secret_encrypted TEXT,
+	expires_at DATETIME NULL,
 	authorization_endpoint VARCHAR(500) NOT NULL,
 	token_endpoint VARCHAR(500) NOT NULL,
 	scopes_supported TEXT,
@@ -56,13 +57,16 @@ func (s *SQLStore) Migrate(ctx context.Context) error {
 	if p, ok := s.dialect.(RegistrationDDLProvider); ok {
 		ddl = p.RegistrationDDL()
 	}
-	_, err := s.db.ExecContext(ctx, ddl)
-	return err
+	if _, err := s.db.ExecContext(ctx, ddl); err != nil {
+		return err
+	}
+	_, _ = s.db.ExecContext(ctx, `ALTER TABLE oauth_registrations ADD COLUMN expires_at DATETIME NULL`)
+	return nil
 }
 
 func (s *SQLStore) GetRegistration(ctx context.Context, authServerURL, redirectURI string) (*Registration, error) {
 	query := `SELECT id, auth_server_url, redirect_uri, client_id, client_secret_encrypted,
-	       authorization_endpoint, token_endpoint, scopes_supported, discovered_at
+	       expires_at, authorization_endpoint, token_endpoint, scopes_supported, discovered_at
 	FROM oauth_registrations
 	WHERE auth_server_url = ` + s.ph(1) + ` AND redirect_uri = ` + s.ph(2)
 
@@ -71,9 +75,10 @@ func (s *SQLStore) GetRegistration(ctx context.Context, authServerURL, redirectU
 	var reg Registration
 	var secretEnc sql.NullString
 	var scopes sql.NullString
+	var expiresAt sql.NullTime
 	var id string
 	err := row.Scan(&id, &reg.AuthServerURL, &reg.RedirectURI, &reg.ClientID,
-		&secretEnc, &reg.AuthorizationEndpoint, &reg.TokenEndpoint,
+		&secretEnc, &expiresAt, &reg.AuthorizationEndpoint, &reg.TokenEndpoint,
 		&scopes, &reg.DiscoveredAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -89,9 +94,20 @@ func (s *SQLStore) GetRegistration(ctx context.Context, authServerURL, redirectU
 		}
 		reg.ClientSecret = decrypted
 	}
+	if expiresAt.Valid {
+		reg.ExpiresAt = &expiresAt.Time
+	}
 	reg.ScopesSupported = scopes.String
 
 	return &reg, nil
+}
+
+func (s *SQLStore) DeleteRegistration(ctx context.Context, authServerURL, redirectURI string) error {
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM oauth_registrations WHERE auth_server_url = `+s.ph(1)+` AND redirect_uri = `+s.ph(2),
+		authServerURL, redirectURI,
+	)
+	return err
 }
 
 func (s *SQLStore) StoreRegistration(ctx context.Context, reg *Registration) error {
@@ -104,6 +120,11 @@ func (s *SQLStore) StoreRegistration(ctx context.Context, reg *Registration) err
 		secretEnc = sql.NullString{String: encrypted, Valid: true}
 	}
 
+	var expiresAt sql.NullTime
+	if reg.ExpiresAt != nil {
+		expiresAt = sql.NullTime{Time: *reg.ExpiresAt, Valid: true}
+	}
+
 	now := time.Now()
 
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -112,18 +133,17 @@ func (s *SQLStore) StoreRegistration(ctx context.Context, reg *Registration) err
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Try UPDATE first, then INSERT if no rows affected. This avoids
-	// database-specific upsert syntax (ON DUPLICATE KEY / ON CONFLICT).
 	res, err := tx.ExecContext(ctx, `UPDATE oauth_registrations SET
 		client_id = `+s.ph(1)+`,
 		client_secret_encrypted = `+s.ph(2)+`,
-		authorization_endpoint = `+s.ph(3)+`,
-		token_endpoint = `+s.ph(4)+`,
-		scopes_supported = `+s.ph(5)+`,
-		discovered_at = `+s.ph(6)+`,
-		updated_at = `+s.ph(7)+`
-		WHERE auth_server_url = `+s.ph(8)+` AND redirect_uri = `+s.ph(9),
-		reg.ClientID, secretEnc, reg.AuthorizationEndpoint, reg.TokenEndpoint,
+		expires_at = `+s.ph(3)+`,
+		authorization_endpoint = `+s.ph(4)+`,
+		token_endpoint = `+s.ph(5)+`,
+		scopes_supported = `+s.ph(6)+`,
+		discovered_at = `+s.ph(7)+`,
+		updated_at = `+s.ph(8)+`
+		WHERE auth_server_url = `+s.ph(9)+` AND redirect_uri = `+s.ph(10),
+		reg.ClientID, secretEnc, expiresAt, reg.AuthorizationEndpoint, reg.TokenEndpoint,
 		reg.ScopesSupported, reg.DiscoveredAt, now,
 		reg.AuthServerURL, reg.RedirectURI,
 	)
@@ -135,10 +155,10 @@ func (s *SQLStore) StoreRegistration(ctx context.Context, reg *Registration) err
 	if affected == 0 {
 		_, err = tx.ExecContext(ctx, `INSERT INTO oauth_registrations
 			(id, auth_server_url, redirect_uri, client_id, client_secret_encrypted,
-			 authorization_endpoint, token_endpoint, scopes_supported, discovered_at, created_at, updated_at)
-			VALUES (`+s.ph(1)+`, `+s.ph(2)+`, `+s.ph(3)+`, `+s.ph(4)+`, `+s.ph(5)+`, `+s.ph(6)+`, `+s.ph(7)+`, `+s.ph(8)+`, `+s.ph(9)+`, `+s.ph(10)+`, `+s.ph(11)+`)`,
+			 expires_at, authorization_endpoint, token_endpoint, scopes_supported, discovered_at, created_at, updated_at)
+			VALUES (`+s.ph(1)+`, `+s.ph(2)+`, `+s.ph(3)+`, `+s.ph(4)+`, `+s.ph(5)+`, `+s.ph(6)+`, `+s.ph(7)+`, `+s.ph(8)+`, `+s.ph(9)+`, `+s.ph(10)+`, `+s.ph(11)+`, `+s.ph(12)+`)`,
 			uuid.NewString(), reg.AuthServerURL, reg.RedirectURI, reg.ClientID,
-			secretEnc, reg.AuthorizationEndpoint, reg.TokenEndpoint,
+			secretEnc, expiresAt, reg.AuthorizationEndpoint, reg.TokenEndpoint,
 			reg.ScopesSupported, reg.DiscoveredAt, now, now,
 		)
 		if err != nil {

--- a/server/internal/mcpoauth/store.go
+++ b/server/internal/mcpoauth/store.go
@@ -7,4 +7,5 @@ import "context"
 type RegistrationStore interface {
 	GetRegistration(ctx context.Context, authServerURL, redirectURI string) (*Registration, error)
 	StoreRegistration(ctx context.Context, reg *Registration) error
+	DeleteRegistration(ctx context.Context, authServerURL, redirectURI string) error
 }


### PR DESCRIPTION
MCP OAuth connections to providers like Datadog use dynamic client
registration (RFC 7591) to obtain credentials. These registrations were
cached indefinitely, so if the remote server expired or revoked them,
gestaltd kept using the stale client_id, causing "Invalid redirect_uri"
errors on the authorize page.

Registrations now respect `client_secret_expires_at` from the DCR
response per RFC 7591. When a provider signals expiry, the cached
registration is automatically refreshed on the next OAuth attempt. A
`ClearRegistration` method is also exposed for manual recovery.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>