### PR TITLE
Remove schema_version field from plugin manifests

### DIFF
--- a/cmd/gestaltd/e2e_test.go
+++ b/cmd/gestaltd/e2e_test.go
@@ -357,10 +357,9 @@ func writeManifest(t *testing.T, pluginDir, version string) {
 	}
 
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        "github.com/test/plugins/provider",
-		Version:       version,
-		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Source:  "github.com/test/plugins/provider",
+		Version: version,
+		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
 			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
 		},

--- a/cmd/gestaltd/init_test.go
+++ b/cmd/gestaltd/init_test.go
@@ -675,10 +675,9 @@ func buildPreparedTestPluginPackageWithSchema(t *testing.T, dir, source, version
 	}
 
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        source,
-		Version:       version,
-		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Source:  source,
+		Version: version,
+		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
 			Protocol:         pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
 			ConfigSchemaPath: schemaPath,
@@ -734,10 +733,9 @@ func buildPreparedTestRuntimePackageWithSchema(t *testing.T, dir, source, versio
 	}
 
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        source,
-		Version:       version,
-		Kinds:         []string{pluginmanifestv1.KindRuntime},
+		Source:  source,
+		Version: version,
+		Kinds:   []string{pluginmanifestv1.KindRuntime},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
 				OS:     runtime.GOOS,

--- a/cmd/gestaltd/plugin.go
+++ b/cmd/gestaltd/plugin.go
@@ -133,7 +133,6 @@ func packageFromBinary(binaryPath, source, kind, version, targetOS, targetArch, 
 
 func buildManifest(source, kind, version, targetOS, targetArch, artifactRel, digest string) *pluginmanifestv1.Manifest {
 	m := newManifestSkeleton(kind, version, targetOS, targetArch, artifactRel, digest)
-	m.SchemaVersion = pluginmanifestv1.SchemaVersion
 	m.Source = source
 	return m
 }

--- a/cmd/gestaltd/plugin_test.go
+++ b/cmd/gestaltd/plugin_test.go
@@ -134,7 +134,6 @@ func newPluginPackageFixture(t *testing.T, dir string) string {
 	}
 
 	manifest := `{
-  "schema_version": 2,
   "source": "github.com/testowner/plugins/provider",
   "version": "0.1.0",
   "kinds": ["provider"],

--- a/internal/bootstrap/executable_plugin_test.go
+++ b/internal/bootstrap/executable_plugin_test.go
@@ -589,10 +589,9 @@ func TestPluginManifestOAuthWiresConnectionAuth(t *testing.T) {
 	bin := buildEchoPluginBinary(t)
 
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        "github.com/acme/plugins/echo",
-		Version:       "1.0.0",
-		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Source:  "github.com/acme/plugins/echo",
+		Version: "1.0.0",
+		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
 			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
 			Auth: &pluginmanifestv1.ProviderAuth{
@@ -674,10 +673,9 @@ func TestPluginManifestNoAuthSkipsConnectionAuth(t *testing.T) {
 	bin := buildEchoPluginBinary(t)
 
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        "github.com/acme/plugins/echo",
-		Version:       "1.0.0",
-		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Source:  "github.com/acme/plugins/echo",
+		Version: "1.0.0",
+		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
 			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
 		},

--- a/internal/operator/lifecycle_source_test.go
+++ b/internal/operator/lifecycle_source_test.go
@@ -61,10 +61,9 @@ func buildV2Archive(t *testing.T, dir, source, version, binaryContent string) st
 
 	artPath := artifactRelPath("provider")
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        source,
-		Version:       version,
-		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Source:  source,
+		Version: version,
+		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
 			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
 		},

--- a/internal/operator/lifecycle_test.go
+++ b/internal/operator/lifecycle_test.go
@@ -24,10 +24,9 @@ func mustBuildTestPluginDir(t *testing.T, dir, source, version, content string) 
 		t.Fatalf("WriteFile artifact: %v", err)
 	}
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        source,
-		Version:       version,
-		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Source:  source,
+		Version: version,
+		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
 			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
 		},
@@ -444,10 +443,9 @@ func TestInitAtPath_RuntimePlugin(t *testing.T) {
 		t.Fatalf("WriteFile artifact: %v", err)
 	}
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        "github.com/testowner/plugins/runtime",
-		Version:       "0.1.0",
-		Kinds:         []string{pluginmanifestv1.KindRuntime},
+		Source:  "github.com/testowner/plugins/runtime",
+		Version: "0.1.0",
+		Kinds:   []string{pluginmanifestv1.KindRuntime},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
 				OS:     runtime.GOOS,

--- a/internal/pluginapi/declarative_test.go
+++ b/internal/pluginapi/declarative_test.go
@@ -13,12 +13,11 @@ import (
 
 func testManifest(baseURL string) *pluginmanifestv1.Manifest {
 	return &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        "github.com/acme/plugins/testapi",
-		Version:       "1.0.0",
-		DisplayName:   "Test API",
-		Description:   "A test API provider",
-		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Source:      "github.com/acme/plugins/testapi",
+		Version:     "1.0.0",
+		DisplayName: "Test API",
+		Description: "A test API provider",
+		Kinds:       []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
 			BaseURL: baseURL,
 			Auth:    &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeBearer},

--- a/internal/pluginpkg/archive_test.go
+++ b/internal/pluginpkg/archive_test.go
@@ -18,7 +18,6 @@ func TestCreatePackageFromDirAndReadManifest(t *testing.T) {
 		t.Fatalf("WriteFile(provider): %v", err)
 	}
 	manifest := `{
-  "schema_version": 2,
   "source": "github.com/acme/plugins/provider",
   "version": "0.1.0",
   "kinds": ["provider"],

--- a/internal/pluginpkg/config_test.go
+++ b/internal/pluginpkg/config_test.go
@@ -26,10 +26,9 @@ func TestValidateConfigForManifest(t *testing.T) {
 		t.Fatalf("WriteFile(schema): %v", err)
 	}
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        "github.com/acme/plugins/provider",
-		Version:       "0.1.0",
-		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Source:  "github.com/acme/plugins/provider",
+		Version: "0.1.0",
+		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
 			Protocol:         pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
 			ConfigSchemaPath: "schemas/config.schema.json",
@@ -80,10 +79,9 @@ func TestValidateConfigForManifestRuntimeFallback(t *testing.T) {
 		t.Fatalf("WriteFile(schema): %v", err)
 	}
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        "github.com/acme/plugins/runtime",
-		Version:       "0.1.0",
-		Kinds:         []string{pluginmanifestv1.KindRuntime},
+		Source:  "github.com/acme/plugins/runtime",
+		Version: "0.1.0",
+		Kinds:   []string{pluginmanifestv1.KindRuntime},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
 				OS:     "darwin",
@@ -118,10 +116,9 @@ func TestValidateConfigForManifestRuntimeDoesNotUseProviderSchema(t *testing.T) 
 	dir := t.TempDir()
 	manifestPath := filepath.Join(dir, ManifestFile)
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        "github.com/acme/plugins/plugin",
-		Version:       "0.1.0",
-		Kinds:         []string{pluginmanifestv1.KindProvider, pluginmanifestv1.KindRuntime},
+		Source:  "github.com/acme/plugins/plugin",
+		Version: "0.1.0",
+		Kinds:   []string{pluginmanifestv1.KindProvider, pluginmanifestv1.KindRuntime},
 		Provider: &pluginmanifestv1.Provider{
 			Protocol:         pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
 			ConfigSchemaPath: "schemas/provider.schema.json",

--- a/internal/pluginpkg/manifest.go
+++ b/internal/pluginpkg/manifest.go
@@ -81,16 +81,6 @@ func DecodeManifestFormat(data []byte, format string) (*pluginmanifestv1.Manifes
 }
 
 func decodeManifestJSON(data []byte) (*pluginmanifestv1.Manifest, error) {
-	var header struct {
-		SchemaVersion int `json:"schema_version"`
-	}
-	if err := json.Unmarshal(data, &header); err != nil {
-		return nil, fmt.Errorf("parse manifest JSON: %w", err)
-	}
-	if header.SchemaVersion != pluginmanifestv1.SchemaVersion {
-		return nil, fmt.Errorf("unsupported manifest schema_version %d", header.SchemaVersion)
-	}
-
 	var doc any
 	if err := json.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("parse manifest JSON: %w", err)
@@ -127,11 +117,8 @@ func ValidateManifest(manifest *pluginmanifestv1.Manifest) error {
 		return fmt.Errorf("manifest is required")
 	}
 
-	if manifest.SchemaVersion != pluginmanifestv1.SchemaVersion {
-		return fmt.Errorf("unsupported manifest schema_version %d", manifest.SchemaVersion)
-	}
 	if manifest.Source == "" {
-		return fmt.Errorf("manifest source is required for schema_version %d", pluginmanifestv1.SchemaVersion)
+		return fmt.Errorf("manifest source is required")
 	}
 	if _, err := pluginsource.Parse(manifest.Source); err != nil {
 		return fmt.Errorf("manifest source: %w", err)

--- a/internal/pluginpkg/manifest_test.go
+++ b/internal/pluginpkg/manifest_test.go
@@ -12,7 +12,6 @@ func TestDecodeManifest_ValidProviderManifest(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-  "schema_version": 2,
   "source": "github.com/acme/plugins/provider",
   "version": "0.1.0",
   "kinds": ["provider"],
@@ -49,7 +48,6 @@ func TestDecodeManifest_RejectsMissingEntrypointArtifact(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-  "schema_version": 2,
   "source": "github.com/acme/plugins/provider",
   "version": "0.1.0",
   "kinds": ["provider"],
@@ -81,10 +79,9 @@ func TestEncodeManifest_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        "github.com/acme/plugins/provider",
-		Version:       "0.1.0",
-		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Source:  "github.com/acme/plugins/provider",
+		Version: "0.1.0",
+		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
 			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
 		},
@@ -118,7 +115,6 @@ func TestEncodeManifest_RoundTrip(t *testing.T) {
 
 func validV2JSON() []byte {
 	return []byte(`{
-  "schema_version": 2,
   "source": "github.com/acme/plugins/echo",
   "version": "1.0.0",
   "kinds": ["provider"],
@@ -151,19 +147,15 @@ func TestDecodeManifest_V2ValidSource(t *testing.T) {
 	if manifest.Source != "github.com/acme/plugins/echo" {
 		t.Fatalf("unexpected source %q", manifest.Source)
 	}
-	if manifest.SchemaVersion != pluginmanifestv1.SchemaVersion {
-		t.Fatalf("unexpected schema_version %d", manifest.SchemaVersion)
-	}
 }
 
 func TestEncodeManifest_V2RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        "github.com/acme/plugins/echo",
-		Version:       "1.0.0",
-		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Source:  "github.com/acme/plugins/echo",
+		Version: "1.0.0",
+		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
 			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
 		},
@@ -199,7 +191,6 @@ func TestDecodeManifest_RejectsUnknownField(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-  "schema_version": 2,
   "source": "github.com/acme/plugins/echo",
   "id": "acme/echo",
   "version": "1.0.0",
@@ -244,7 +235,6 @@ func TestDecodeManifest_V2RejectsInvalidSource(t *testing.T) {
 			t.Parallel()
 
 			data := []byte(`{
-  "schema_version": 2,
   "source": "` + tc.source + `",
   "version": "1.0.0",
   "kinds": ["provider"],
@@ -278,7 +268,6 @@ func TestDecodeManifest_V2RejectsLeadingVVersion(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-  "schema_version": 2,
   "source": "github.com/acme/plugins/echo",
   "version": "v1.0.0",
   "kinds": ["provider"],
@@ -306,43 +295,10 @@ func TestDecodeManifest_V2RejectsLeadingVVersion(t *testing.T) {
 	}
 }
 
-func TestDecodeManifest_RejectsSchemaVersion1(t *testing.T) {
-	t.Parallel()
-
-	data := []byte(`{
-  "schema_version": 1,
-  "id": "acme/provider",
-  "version": "0.1.0",
-  "kinds": ["provider"],
-  "provider": {
-    "protocol": { "min": 1, "max": 1 }
-  },
-  "artifacts": [
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "artifacts/darwin/arm64/provider",
-      "sha256": "` + sha256Hex("provider") + `"
-    }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "artifacts/darwin/arm64/provider"
-    }
-  }
-}`)
-
-	_, err := DecodeManifest(data)
-	if err == nil {
-		t.Fatal("expected error for schema_version 1")
-	}
-}
-
 func TestDecodeManifest_V2RejectsUnsupportedKind(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-  "schema_version": 2,
   "source": "github.com/test-org/test-repo/test-plugin",
   "version": "1.0.0",
   "kinds": ["unknown_kind"],
@@ -367,7 +323,6 @@ func TestDecodeManifest_V2RejectsMissingSource(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-  "schema_version": 2,
   "version": "1.0.0",
   "kinds": ["provider"],
   "provider": {
@@ -394,27 +349,10 @@ func TestDecodeManifest_V2RejectsMissingSource(t *testing.T) {
 	}
 }
 
-func TestDecodeManifest_RejectsSchemaVersion3(t *testing.T) {
-	t.Parallel()
-
-	data := []byte(`{
-  "schema_version": 3,
-  "source": "github.com/test-org/test-repo/test-plugin",
-  "version": "1.0.0",
-  "kinds": ["provider"]
-}`)
-
-	_, err := DecodeManifest(data)
-	if err == nil {
-		t.Fatal("expected error for unsupported schema_version 3")
-	}
-}
-
 func TestDecodeManifest_V2RejectsDuplicateArtifactPlatform(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-  "schema_version": 2,
   "source": "github.com/test-org/test-repo/test-plugin",
   "version": "1.0.0",
   "kinds": ["provider"],
@@ -452,7 +390,6 @@ func TestDecodeManifest_V2RejectsAbsoluteArtifactPath(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-  "schema_version": 2,
   "source": "github.com/test-org/test-repo/test-plugin",
   "version": "1.0.0",
   "kinds": ["provider"],
@@ -484,7 +421,6 @@ func TestDecodeManifest_V2ProviderWithoutMetadataRejected(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-  "schema_version": 2,
   "source": "github.com/test-org/test-repo/test-plugin",
   "version": "1.0.0",
   "kinds": ["provider"],
@@ -513,10 +449,9 @@ func TestValidateManifest_ProtocolMinGreaterThanMax(t *testing.T) {
 	t.Parallel()
 
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        "github.com/acme/plugins/provider",
-		Version:       "0.1.0",
-		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Source:  "github.com/acme/plugins/provider",
+		Version: "0.1.0",
+		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
 			Protocol: pluginmanifestv1.ProtocolRange{Min: 5, Max: 1},
 		},
@@ -545,7 +480,6 @@ func TestDecodeManifest_V2WithOAuth2Auth(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-  "schema_version": 2,
   "source": "github.com/acme/plugins/echo",
   "version": "1.0.0",
   "kinds": ["provider"],
@@ -606,7 +540,6 @@ func TestDecodeManifest_V2OAuth2MissingTokenURL(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-  "schema_version": 2,
   "source": "github.com/acme/plugins/echo",
   "version": "1.0.0",
   "kinds": ["provider"],
@@ -642,7 +575,6 @@ func TestDecodeManifest_V2ManualAuth(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-  "schema_version": 2,
   "source": "github.com/acme/plugins/echo",
   "version": "1.0.0",
   "kinds": ["provider"],
@@ -680,7 +612,6 @@ func TestDecodeManifest_V2InvalidAuthType(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-  "schema_version": 2,
   "source": "github.com/acme/plugins/echo",
   "version": "1.0.0",
   "kinds": ["provider"],
@@ -727,10 +658,9 @@ func TestDecodeManifest_V2AuthRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        "github.com/acme/plugins/echo",
-		Version:       "1.0.0",
-		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Source:  "github.com/acme/plugins/echo",
+		Version: "1.0.0",
+		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
 			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
 			Auth: &pluginmanifestv1.ProviderAuth{
@@ -775,7 +705,6 @@ func TestDecodeManifestFormat_YAML(t *testing.T) {
 	t.Parallel()
 
 	yamlData := []byte(`
-schema_version: 2
 source: github.com/acme/plugins/echo
 version: "1.0.0"
 kinds:
@@ -801,16 +730,12 @@ entrypoints:
 	if manifest.Source != "github.com/acme/plugins/echo" {
 		t.Fatalf("unexpected source %q", manifest.Source)
 	}
-	if manifest.SchemaVersion != pluginmanifestv1.SchemaVersion {
-		t.Fatalf("unexpected schema_version %d", manifest.SchemaVersion)
-	}
 }
 
 func TestDecodeManifestFormat_YAMLDeclarative(t *testing.T) {
 	t.Parallel()
 
 	yamlData := []byte(`
-schema_version: 2
 source: github.com/acme/plugins/testapi
 version: "0.1.0"
 display_name: Test API
@@ -869,7 +794,6 @@ func TestDecodeManifest_DeclarativeProviderJSON(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-  "schema_version": 2,
   "source": "github.com/acme/plugins/myapi",
   "version": "1.0.0",
   "kinds": ["provider"],
@@ -905,7 +829,6 @@ func TestDecodeManifest_DeclarativeRejectsMissingBaseURL(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-  "schema_version": 2,
   "source": "github.com/acme/plugins/myapi",
   "version": "1.0.0",
   "kinds": ["provider"],
@@ -930,7 +853,6 @@ func TestDecodeManifest_DeclarativeRejectsDuplicateOpNames(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-  "schema_version": 2,
   "source": "github.com/acme/plugins/myapi",
   "version": "1.0.0",
   "kinds": ["provider"],
@@ -953,7 +875,6 @@ func TestDecodeManifest_DeclarativeRejectsOrphanPathParam(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-  "schema_version": 2,
   "source": "github.com/acme/plugins/myapi",
   "version": "1.0.0",
   "kinds": ["provider"],

--- a/internal/pluginpkg/test_helpers_test.go
+++ b/internal/pluginpkg/test_helpers_test.go
@@ -30,10 +30,9 @@ func currentArtifactPath(binary string) string {
 
 func newProviderManifest(source, version, artifactPath, digest string) *pluginmanifestv1.Manifest {
 	return &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        source,
-		Version:       version,
-		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Source:  source,
+		Version: version,
+		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
 			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
 		},

--- a/internal/pluginstore/store_test.go
+++ b/internal/pluginstore/store_test.go
@@ -392,10 +392,9 @@ func mustBuildPluginDir(t *testing.T, dir, source, version, content, schema stri
 	}
 
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        source,
-		Version:       version,
-		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Source:  source,
+		Version: version,
+		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
 			Protocol:         pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
 			ConfigSchemaPath: schemaPath,
@@ -436,10 +435,9 @@ func mustBuildPluginDirWithDigest(t *testing.T, dir, source, version, content, d
 	}
 
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        source,
-		Version:       version,
-		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Source:  source,
+		Version: version,
+		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
 			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
 		},
@@ -489,10 +487,9 @@ func mustBuildPackageWithDigest(t *testing.T, dir, source, version, content, dig
 		digest = digestOverride
 	}
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        source,
-		Version:       version,
-		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Source:  source,
+		Version: version,
+		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
 			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
 		},
@@ -531,10 +528,9 @@ func mustBuildRawPackage(t *testing.T, dir, source, version, content string) str
 	artifactName := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider"))
 	sum := sha256.Sum256([]byte(content))
 	manifest := map[string]any{
-		"schema_version": pluginmanifestv1.SchemaVersion,
-		"source":         source,
-		"version":        version,
-		"kinds":          []string{pluginmanifestv1.KindProvider},
+		"source":  source,
+		"version": version,
+		"kinds":   []string{pluginmanifestv1.KindProvider},
 		"provider": map[string]any{
 			"protocol": map[string]any{"min": 1, "max": 1},
 		},
@@ -594,10 +590,9 @@ func mustBuildMismatchPackage(t *testing.T, dir, source, version, content, diges
 	t.Helper()
 
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        source,
-		Version:       version,
-		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Source:  source,
+		Version: version,
+		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
 			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
 		},
@@ -659,10 +654,9 @@ func mustBuildPackageWithDuplicateArtifact(t *testing.T, dir, source, version, f
 	artifactName := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider"))
 	sum := sha256.Sum256([]byte(firstContent))
 	manifest := &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        source,
-		Version:       version,
-		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Source:  source,
+		Version: version,
+		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
 			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
 		},
@@ -722,10 +716,9 @@ func newV2Manifest(source, version, content string) *pluginmanifestv1.Manifest {
 	artifactPath := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider"))
 	sum := sha256.Sum256([]byte(content))
 	return &pluginmanifestv1.Manifest{
-		SchemaVersion: pluginmanifestv1.SchemaVersion,
-		Source:        source,
-		Version:       version,
-		Kinds:         []string{pluginmanifestv1.KindProvider},
+		Source:  source,
+		Version: version,
+		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
 			Protocol: pluginmanifestv1.ProtocolRange{Min: 1, Max: 1},
 		},
@@ -780,10 +773,9 @@ func mustBuildV2PackageRaw(t *testing.T, dir, source, version, content string) s
 	artifactName := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider"))
 	sum := sha256.Sum256([]byte(content))
 	manifest := map[string]any{
-		"schema_version": pluginmanifestv1.SchemaVersion,
-		"source":         source,
-		"version":        version,
-		"kinds":          []string{pluginmanifestv1.KindProvider},
+		"source":  source,
+		"version": version,
+		"kinds":   []string{pluginmanifestv1.KindProvider},
 		"provider": map[string]any{
 			"protocol": map[string]any{"min": 1, "max": 1},
 		},

--- a/plugins/slack/plugin.yaml
+++ b/plugins/slack/plugin.yaml
@@ -1,4 +1,3 @@
-schema_version: 2
 source: github.com/valon-technologies/gestalt/slack
 version: 0.0.1-alpha.3
 display_name: Slack

--- a/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -1,18 +1,14 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1/manifest.v2.jsonschema.json",
+  "$id": "https://github.com/valon-technologies/gestalt/sdk/pluginmanifest/v1/manifest.jsonschema.json",
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "schema_version",
     "source",
     "version",
     "kinds"
   ],
   "properties": {
-    "schema_version": {
-      "const": 2
-    },
     "source": {
       "type": "string",
       "pattern": "^github\\.com/[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._-]*$"

--- a/sdk/pluginmanifest/v1/types.go
+++ b/sdk/pluginmanifest/v1/types.go
@@ -3,24 +3,21 @@ package pluginmanifestv1
 import _ "embed"
 
 const (
-	SchemaVersion = 2
-
 	KindProvider = "provider"
 	KindRuntime  = "runtime"
 	KindWebUI    = "webui"
 )
 
 type Manifest struct {
-	SchemaVersion int            `json:"schema_version"`
-	Source        string         `json:"source,omitempty"`
-	Version       string         `json:"version"`
-	DisplayName   string         `json:"display_name,omitempty"`
-	Description   string         `json:"description,omitempty"`
-	Kinds         []string       `json:"kinds"`
-	Provider      *Provider      `json:"provider,omitempty"`
-	WebUI         *WebUIMetadata `json:"webui,omitempty"`
-	Artifacts     []Artifact     `json:"artifacts,omitempty"`
-	Entrypoints   Entrypoints    `json:"entrypoints,omitzero"`
+	Source      string         `json:"source,omitempty"`
+	Version     string         `json:"version"`
+	DisplayName string         `json:"display_name,omitempty"`
+	Description string         `json:"description,omitempty"`
+	Kinds       []string       `json:"kinds"`
+	Provider    *Provider      `json:"provider,omitempty"`
+	WebUI       *WebUIMetadata `json:"webui,omitempty"`
+	Artifacts   []Artifact     `json:"artifacts,omitempty"`
+	Entrypoints Entrypoints    `json:"entrypoints,omitzero"`
 }
 
 type WebUIMetadata struct {
@@ -98,5 +95,5 @@ type Entrypoint struct {
 	Args         []string `json:"args,omitempty"`
 }
 
-//go:embed manifest.v2.jsonschema.json
+//go:embed manifest.jsonschema.json
 var ManifestJSONSchema []byte


### PR DESCRIPTION
There is only one manifest schema now (v1 was dropped in #319), so the `schema_version` field is vestigial. Removing it simplifies plugin authoring by eliminating a boilerplate field that always had to be set to 2. The JSON schema validation and Go-level pre-checks that enforced the version are also removed since they no longer serve a purpose.