### PR TITLE
Add SBOM and provenance attestations to CLI Docker image

### DIFF
--- a/.github/workflows/release-gestalt-cli.yml
+++ b/.github/workflows/release-gestalt-cli.yml
@@ -46,82 +46,38 @@ jobs:
           draft: false
           prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
 
-  build-image:
-    name: Build Docker Image (${{ matrix.platform }})
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
-    env:
-      REGISTRY_IMAGE: valontechnologies/gestalt
-    steps:
-      - uses: actions/checkout@v4
-      - name: Prepare platform pair
-        id: platform
-        run: echo "pair=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: docker/setup-buildx-action@v3
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@v5
-        with:
-          context: client
-          file: client/Dockerfile
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ steps.platform.outputs.pair }}
-          cache-to: type=gha,scope=${{ steps.platform.outputs.pair }},mode=min
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: cli-digests-${{ steps.platform.outputs.pair }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
   publish-image:
     name: Publish Docker Image
-    needs: build-image
+    needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 60
     env:
       REGISTRY_IMAGE: valontechnologies/gestalt
     steps:
+      - uses: actions/checkout@v6
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: cli-digests-*
-          merge-multiple: true
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: docker/setup-buildx-action@v3
-      - name: Create multi-arch manifest and push
-        run: |
-          docker buildx imagetools create \
-            -t "$REGISTRY_IMAGE:${{ steps.version.outputs.version }}" \
-            -t "$REGISTRY_IMAGE:latest" \
-            $(printf "$REGISTRY_IMAGE@sha256:%s " $(ls /tmp/digests/))
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - name: Build and push image
+        uses: docker/build-push-action@v7
+        with:
+          context: client
+          file: client/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.REGISTRY_IMAGE }}:${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY_IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+          sbom: true
+          provenance: mode=max
       - name: Scan CLI image for vulnerabilities
         uses: aquasecurity/trivy-action@v0.35.0
         with:
@@ -139,7 +95,7 @@ jobs:
 
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           token: ${{ secrets.PAT_TOKEN }}

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,10 +1,22 @@
-FROM rust:1-alpine AS builder
-RUN apk add --no-cache musl-dev perl make
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.9.0 AS xx
+
+FROM --platform=$BUILDPLATFORM rust:1-alpine AS builder
+COPY --from=xx / /
+RUN apk add --no-cache perl make
+ARG TARGETPLATFORM
+RUN xx-apk add --no-cache musl-dev gcc
 WORKDIR /build
 COPY . .
-RUN cargo build --release
+RUN RUST_TARGET=$(xx-info rust-target) && \
+    LINKER=$(xx-info triple)-gcc && \
+    rustup target add "$RUST_TARGET" && \
+    mkdir -p .cargo && \
+    printf '[target.%s]\nlinker = "%s"\n' "$RUST_TARGET" "$LINKER" > .cargo/config.toml && \
+    CC="$LINKER" cargo build --release --target "$RUST_TARGET" && \
+    cp "target/$RUST_TARGET/release/gestalt" /gestalt && \
+    xx-verify /gestalt
 
 FROM gcr.io/distroless/static-debian12
-COPY --from=builder /build/target/release/gestalt /gestalt
+COPY --from=builder /gestalt /gestalt
 USER nobody:nobody
 ENTRYPOINT ["/gestalt"]


### PR DESCRIPTION
The gestalt CLI Docker image was missing supply chain attestations
(SBOM and provenance), resulting in a "Not compliant" status on Docker
Hub. The previous digest-based multi-arch build pattern does not
preserve attestations through the `imagetools create` manifest
combination step.

This replaces the two-job build with a single-job multi-platform build
that enables `sbom: true` and `provenance: mode=max`. To avoid the
QEMU timeout that originally motivated the two-job approach (Rust
compilation under CPU emulation is extremely slow), the Dockerfile now
uses cross-compilation via Docker's `xx` project. The builder stage
runs natively on the build platform and cross-compiles for the target
architecture, so QEMU is only needed for the trivial final stage.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>