### PR TITLE
Enforce API token scopes during invocation

### DIFF
--- a/server/internal/invocation/broker.go
+++ b/server/internal/invocation/broker.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -149,8 +150,16 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 
 	span.SetAttributes(attrConnectionMode.String(string(prov.ConnectionMode())))
 
-	if p != nil && p.UserID != "" {
+	if p == nil {
+		return fail(ErrNotAuthenticated)
+	}
+
+	if p.UserID != "" {
 		span.SetAttributes(attrUserID.String(p.UserID))
+	}
+
+	if p.Scopes != nil && !slices.Contains(p.Scopes, providerName) {
+		return fail(fmt.Errorf("%w: %s", ErrScopeDenied, providerName))
 	}
 
 	ops := prov.ListOperations()
@@ -163,10 +172,6 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	}
 	if !found {
 		return fail(fmt.Errorf("%w: %q on provider %q", ErrOperationNotFound, operation, providerName))
-	}
-
-	if p == nil {
-		return fail(ErrNotAuthenticated)
 	}
 
 	conn := ConnectionFromContext(ctx)
@@ -190,6 +195,9 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 }
 
 func (b *Broker) ResolveToken(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (string, error) {
+	if p != nil && p.Scopes != nil && !slices.Contains(p.Scopes, providerName) {
+		return "", fmt.Errorf("%w: %s", ErrScopeDenied, providerName)
+	}
 	prov, err := b.providers.Get(providerName)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {

--- a/server/internal/invocation/errors.go
+++ b/server/internal/invocation/errors.go
@@ -10,4 +10,5 @@ var (
 	ErrAmbiguousInstance = errors.New("ambiguous instance")
 	ErrUserResolution    = errors.New("user resolution failed")
 	ErrInternal          = errors.New("internal error")
+	ErrScopeDenied       = errors.New("token scope denied")
 )

--- a/server/internal/principal/principal.go
+++ b/server/internal/principal/principal.go
@@ -20,6 +20,7 @@ type Principal struct {
 	Identity *core.UserIdentity
 	UserID   string
 	Source   Source
+	Scopes   []string
 }
 
 type contextKey struct{}

--- a/server/internal/principal/resolver.go
+++ b/server/internal/principal/resolver.go
@@ -94,14 +94,18 @@ func (r *Resolver) resolveAPIToken(ctx context.Context, token string) (*Principa
 		return nil, err
 	}
 
-	return &Principal{
+	p := &Principal{
 		Identity: &core.UserIdentity{
 			Email:       user.Email,
 			DisplayName: user.DisplayName,
 		},
 		UserID: user.ID,
 		Source: SourceAPIToken,
-	}, nil
+	}
+	if scopes := strings.Fields(apiToken.Scopes); len(scopes) > 0 {
+		p.Scopes = scopes
+	}
+	return p, nil
 }
 
 func (r *Resolver) ResolveEmail(email string) *Principal {

--- a/server/internal/server/handlers.go
+++ b/server/internal/server/handlers.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -404,6 +405,8 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusNotFound, fmt.Sprintf("operation %q not found on integration %q", operationName, providerName))
 		case errors.Is(err, invocation.ErrNotAuthenticated):
 			writeError(w, http.StatusUnauthorized, "not authenticated")
+		case errors.Is(err, invocation.ErrScopeDenied):
+			writeError(w, http.StatusForbidden, err.Error())
 		case errors.Is(err, invocation.ErrNoToken):
 			writeError(w, http.StatusPreconditionFailed, fmt.Sprintf("no token stored for integration %q; connect via OAuth first", providerName))
 		case errors.Is(err, invocation.ErrAmbiguousInstance):
@@ -902,6 +905,15 @@ func (s *Server) createAPIToken(w http.ResponseWriter, r *http.Request) {
 	if req.Name == "" {
 		writeError(w, http.StatusBadRequest, "name is required")
 		return
+	}
+
+	if req.Scopes != "" {
+		for _, scope := range strings.Fields(req.Scopes) {
+			if _, err := s.providers.Get(scope); err != nil {
+				writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown scope %q", scope))
+				return
+			}
+		}
 	}
 
 	issued, err := s.issueToken()

--- a/server/internal/server/server_test.go
+++ b/server/internal/server/server_test.go
@@ -1497,7 +1497,7 @@ func TestCreateAndListAPITokens(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	body := bytes.NewBufferString(`{"name":"my-token","scopes":"read"}`)
+	body := bytes.NewBufferString(`{"name":"my-token"}`)
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/tokens", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
@@ -1608,7 +1608,7 @@ func TestCreateAPIToken_DefaultExpiry(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	body := bytes.NewBufferString(`{"name":"expiry-test","scopes":"read"}`)
+	body := bytes.NewBufferString(`{"name":"expiry-test"}`)
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/tokens", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
@@ -1661,7 +1661,7 @@ func TestCreateAPIToken_ConfigurableTTL(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	body := bytes.NewBufferString(`{"name":"ttl-test","scopes":"read"}`)
+	body := bytes.NewBufferString(`{"name":"ttl-test"}`)
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/tokens", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
@@ -4714,5 +4714,169 @@ func TestConnectManual_MultiCredential(t *testing.T) {
 	}
 	if tokenData["app_key"] != "k2" {
 		t.Errorf("app_key = %q, want k2", tokenData["app_key"])
+	}
+}
+
+func TestAPITokenScopes_EnforcedDuringInvocation(t *testing.T) {
+	t.Parallel()
+
+	alphaStub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "alpha",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "do_thing", Method: http.MethodGet}},
+	}
+	betaStub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "beta",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "do_thing", Method: http.MethodGet}},
+	}
+
+	plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, _ string) (*core.UserIdentity, error) {
+				return nil, fmt.Errorf("not a session token")
+			},
+		}
+		cfg.Providers = testutil.NewProviderRegistry(t, alphaStub, betaStub)
+		cfg.Datastore = &coretesting.StubDatastore{
+			ValidateAPITokenFn: func(_ context.Context, h string) (*core.APIToken, error) {
+				if h == hashed {
+					return &core.APIToken{UserID: "u1", Name: "scoped-key", Scopes: "alpha"}, nil
+				}
+				return nil, core.ErrNotFound
+			},
+			GetUserFn: func(_ context.Context, id string) (*core.User, error) {
+				return &core.User{ID: id, Email: "user@test.com"}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	t.Run("allowed provider succeeds", func(t *testing.T) {
+		t.Parallel()
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/alpha/do_thing", nil)
+		req.Header.Set("Authorization", "Bearer "+plaintext)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("denied provider returns 403", func(t *testing.T) {
+		t.Parallel()
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/beta/do_thing", nil)
+		req.Header.Set("Authorization", "Bearer "+plaintext)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d", resp.StatusCode)
+		}
+	})
+}
+
+func TestAPITokenScopes_EmptyScopesAllowAll(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "any-provider",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "do_thing", Method: http.MethodGet}},
+	}
+
+	plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, _ string) (*core.UserIdentity, error) {
+				return nil, fmt.Errorf("not a session token")
+			},
+		}
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Datastore = &coretesting.StubDatastore{
+			ValidateAPITokenFn: func(_ context.Context, h string) (*core.APIToken, error) {
+				if h == hashed {
+					return &core.APIToken{UserID: "u1", Name: "unscoped-key", Scopes: ""}, nil
+				}
+				return nil, core.ErrNotFound
+			},
+			GetUserFn: func(_ context.Context, id string) (*core.User, error) {
+				return &core.User{ID: id, Email: "user@test.com"}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/any-provider/do_thing", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestCreateAPIToken_InvalidScope(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{N: "real-provider"},
+		ops:             []core.Operation{{Name: "op", Method: http.MethodGet}},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"name":"test-token","scopes":"nonexistent"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/tokens", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
 	}
 }


### PR DESCRIPTION
API tokens carried a `Scopes` field in the database but it was never
enforced, so all tokens had full access regardless of declared scopes.
Scopes are now checked on every invocation and token resolution,
returning 403 when a token attempts to access a provider outside its
allowed set. Empty scopes continue to grant full access for backwards
compatibility, and token creation now validates that requested scopes
name real providers.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>