### PR TITLE
Add configurable credential fields for manual token auth

### DIFF
--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -394,6 +394,55 @@ Supported or notable fields:
 
 The normal auth types are `oauth2` and `manual`. `mcp_oauth` also exists as an advanced mode for MCP-driven OAuth discovery.
 
+#### Manual auth with custom credential fields
+
+For manual-auth connections, you can customize the credential input form with `credentials`. Each entry defines a field the user must fill in, with an optional label, description, and help URL.
+
+Single credential with a custom label:
+
+```yaml
+connections:
+  default:
+    mode: user
+    auth:
+      type: manual
+      credentials:
+        - name: token
+          label: API Access Token
+          help_url: https://app.example.com/settings/tokens
+```
+
+Multiple credentials (requires `auth_mapping` to map each field to an HTTP header):
+
+```yaml
+connections:
+  default:
+    mode: user
+    auth:
+      type: manual
+      credentials:
+        - name: api_key
+          label: API Key
+          help_url: https://us5.datadoghq.com/organization-settings/api-keys
+        - name: app_key
+          label: Application Key
+          help_url: https://us5.datadoghq.com/organization-settings/application-keys
+      auth_mapping:
+        headers:
+          DD-API-KEY: api_key
+          DD-APPLICATION-KEY: app_key
+```
+
+| Field | Notes |
+| --- | --- |
+| `credentials[].name` | Internal identifier for the field. Must be unique, lowercase with underscores. |
+| `credentials[].label` | Display label shown in the UI. Falls back to `name` if omitted. |
+| `credentials[].description` | Hint text shown below the label. |
+| `credentials[].help_url` | Link displayed next to the label for where to find the credential. |
+| `auth_mapping.headers` | Maps credential field names to HTTP headers. Required when multiple credentials are declared. |
+
+When no `credentials` are declared, the UI shows the default single "API Token" field.
+
 ### `plugin`
 
 Plugin-only integrations cannot also declare `connections`, `api`, or `mcp`.

--- a/server/core/integration/base.go
+++ b/server/core/integration/base.go
@@ -113,9 +113,10 @@ type Base struct {
 	ExecuteFunc    func(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error)
 	EgressResolver *egress.Resolver
 
-	ConnectionDefs    map[string]core.ConnectionParamDef
-	DiscoveryDef      *core.DiscoveryConfig
-	ManualAuthEnabled bool
+	ConnectionDefs      map[string]core.ConnectionParamDef
+	DiscoveryDef        *core.DiscoveryConfig
+	ManualAuthEnabled   bool
+	CredentialFieldDefs []core.CredentialFieldDef
 
 	catalog *catalog.Catalog
 }
@@ -153,6 +154,10 @@ func (b *Base) AuthTypes() []string {
 
 func (b *Base) ConnectionParamDefs() map[string]core.ConnectionParamDef {
 	return b.ConnectionDefs
+}
+
+func (b *Base) CredentialFields() []core.CredentialFieldDef {
+	return b.CredentialFieldDefs
 }
 
 func (b *Base) DiscoveryConfig() *core.DiscoveryConfig {

--- a/server/core/integration/restricted.go
+++ b/server/core/integration/restricted.go
@@ -274,3 +274,10 @@ func (r *Restricted) ConnectionParamDefs() map[string]core.ConnectionParamDef {
 	}
 	return nil
 }
+
+func (r *Restricted) CredentialFields() []core.CredentialFieldDef {
+	if cfp, ok := r.inner.(core.CredentialFieldsProvider); ok {
+		return cfp.CredentialFields()
+	}
+	return nil
+}

--- a/server/core/provider.go
+++ b/server/core/provider.go
@@ -61,6 +61,17 @@ type ConnectionParamProvider interface {
 	ConnectionParamDefs() map[string]ConnectionParamDef
 }
 
+type CredentialFieldDef struct {
+	Name        string
+	Label       string
+	Description string
+	HelpURL     string
+}
+
+type CredentialFieldsProvider interface {
+	CredentialFields() []CredentialFieldDef
+}
+
 type AuthTypeLister interface {
 	AuthTypes() []string
 }

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -170,23 +170,36 @@ type ConnectionDef struct {
 }
 
 type ConnectionAuthDef struct {
-	Type                string            `yaml:"type"`
-	AuthorizationURL    string            `yaml:"authorization_url"`
-	TokenURL            string            `yaml:"token_url"`
-	ClientID            string            `yaml:"client_id"`
-	ClientSecret        string            `yaml:"client_secret"`
-	RedirectURL         string            `yaml:"redirect_url"`
-	ClientAuth          string            `yaml:"client_auth"`
-	TokenExchange       string            `yaml:"token_exchange"`
-	Scopes              []string          `yaml:"scopes"`
-	ScopeParam          string            `yaml:"scope_param"`
-	ScopeSeparator      string            `yaml:"scope_separator"`
-	PKCE                bool              `yaml:"pkce"`
-	AuthorizationParams map[string]string `yaml:"authorization_params"`
-	TokenParams         map[string]string `yaml:"token_params"`
-	RefreshParams       map[string]string `yaml:"refresh_params"`
-	AcceptHeader        string            `yaml:"accept_header"`
-	TokenMetadata       []string          `yaml:"token_metadata"`
+	Type                string               `yaml:"type"`
+	AuthorizationURL    string               `yaml:"authorization_url"`
+	TokenURL            string               `yaml:"token_url"`
+	ClientID            string               `yaml:"client_id"`
+	ClientSecret        string               `yaml:"client_secret"`
+	RedirectURL         string               `yaml:"redirect_url"`
+	ClientAuth          string               `yaml:"client_auth"`
+	TokenExchange       string               `yaml:"token_exchange"`
+	Scopes              []string             `yaml:"scopes"`
+	ScopeParam          string               `yaml:"scope_param"`
+	ScopeSeparator      string               `yaml:"scope_separator"`
+	PKCE                bool                 `yaml:"pkce"`
+	AuthorizationParams map[string]string    `yaml:"authorization_params"`
+	TokenParams         map[string]string    `yaml:"token_params"`
+	RefreshParams       map[string]string    `yaml:"refresh_params"`
+	AcceptHeader        string               `yaml:"accept_header"`
+	TokenMetadata       []string             `yaml:"token_metadata"`
+	Credentials         []CredentialFieldDef `yaml:"credentials"`
+	AuthMapping         *AuthMappingDef      `yaml:"auth_mapping"`
+}
+
+type CredentialFieldDef struct {
+	Name        string `yaml:"name"`
+	Label       string `yaml:"label"`
+	Description string `yaml:"description"`
+	HelpURL     string `yaml:"help_url"`
+}
+
+type AuthMappingDef struct {
+	Headers map[string]string `yaml:"headers"`
 }
 
 type ConnectionParamDef struct {
@@ -498,6 +511,9 @@ func validateIntegration(name string, intg IntegrationDef) error {
 		if err := validateConnectionAuthURLParams(name, cname, intg.Connections[cname]); err != nil {
 			return err
 		}
+		if err := validateCredentialFields(name, cname, intg.Connections[cname].Auth); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -536,6 +552,9 @@ func validateHybridIntegration(name string, intg IntegrationDef) error {
 		}
 		for cname := range intg.Connections {
 			if err := validateConnectionAuthURLParams(name, cname, intg.Connections[cname]); err != nil {
+				return err
+			}
+			if err := validateCredentialFields(name, cname, intg.Connections[cname].Auth); err != nil {
 				return err
 			}
 		}
@@ -615,6 +634,37 @@ func resolveConnectionRef(intgName, surface, connName string, connections map[st
 		return ConnectionDef{}, fmt.Errorf("config validation: integration %q %s.connection references unknown connection %q", intgName, surface, connName)
 	}
 	return conn, nil
+}
+
+func validateCredentialFields(intgName, connName string, auth ConnectionAuthDef) error {
+	if len(auth.Credentials) == 0 {
+		return nil
+	}
+	names := make(map[string]bool, len(auth.Credentials))
+	for i, cf := range auth.Credentials {
+		if cf.Name == "" {
+			return fmt.Errorf("config validation: integration %q connection %q credentials[%d].name is required", intgName, connName, i)
+		}
+		if names[cf.Name] {
+			return fmt.Errorf("config validation: integration %q connection %q has duplicate credential name %q", intgName, connName, cf.Name)
+		}
+		names[cf.Name] = true
+	}
+	if auth.AuthMapping != nil {
+		for header, field := range auth.AuthMapping.Headers {
+			if !names[field] {
+				return fmt.Errorf("config validation: integration %q connection %q auth_mapping header %q references unknown credential %q", intgName, connName, header, field)
+			}
+		}
+	}
+	hasMapping := auth.AuthMapping != nil && len(auth.AuthMapping.Headers) > 0
+	if len(auth.Credentials) == 1 && hasMapping {
+		return fmt.Errorf("config validation: integration %q connection %q has auth_mapping with a single credential; use auth_header on the provider definition for single-credential header injection", intgName, connName)
+	}
+	if len(auth.Credentials) > 1 && !hasMapping {
+		return fmt.Errorf("config validation: integration %q connection %q has multiple credentials but no auth_mapping", intgName, connName)
+	}
+	return nil
 }
 
 func validateConnectionAuthURLParams(intgName, connName string, conn ConnectionDef) error {

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -1873,3 +1873,220 @@ integrations:
 		})
 	}
 }
+
+func TestCredentialFieldValidation(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+	}{
+		{
+			name: "single credential field is valid",
+			yaml: `
+auth:
+  provider: ap
+datastore:
+  provider: ds
+server:
+  encryption_key: ek
+integrations:
+  svc:
+    connections:
+      default:
+        mode: user
+        auth:
+          type: manual
+          credentials:
+            - name: token
+              label: API Token
+    api:
+      type: rest
+      openapi: https://example.test/spec.json
+      connection: default
+`,
+		},
+		{
+			name: "multiple credentials with auth_mapping is valid",
+			yaml: `
+auth:
+  provider: ap
+datastore:
+  provider: ds
+server:
+  encryption_key: ek
+integrations:
+  svc:
+    connections:
+      default:
+        mode: user
+        auth:
+          type: manual
+          credentials:
+            - name: api_key
+              label: API Key
+            - name: app_key
+              label: Application Key
+          auth_mapping:
+            headers:
+              X-Api-Key: api_key
+              X-App-Key: app_key
+    api:
+      type: rest
+      openapi: https://example.test/spec.json
+      connection: default
+`,
+		},
+		{
+			name:    "duplicate credential names",
+			wantErr: true,
+			yaml: `
+auth:
+  provider: ap
+datastore:
+  provider: ds
+server:
+  encryption_key: ek
+integrations:
+  svc:
+    connections:
+      default:
+        mode: user
+        auth:
+          type: manual
+          credentials:
+            - name: token
+            - name: token
+    api:
+      type: rest
+      openapi: https://example.test/spec.json
+      connection: default
+`,
+		},
+		{
+			name:    "empty credential name",
+			wantErr: true,
+			yaml: `
+auth:
+  provider: ap
+datastore:
+  provider: ds
+server:
+  encryption_key: ek
+integrations:
+  svc:
+    connections:
+      default:
+        mode: user
+        auth:
+          type: manual
+          credentials:
+            - name: ""
+    api:
+      type: rest
+      openapi: https://example.test/spec.json
+      connection: default
+`,
+		},
+		{
+			name:    "auth_mapping references unknown credential",
+			wantErr: true,
+			yaml: `
+auth:
+  provider: ap
+datastore:
+  provider: ds
+server:
+  encryption_key: ek
+integrations:
+  svc:
+    connections:
+      default:
+        mode: user
+        auth:
+          type: manual
+          credentials:
+            - name: api_key
+          auth_mapping:
+            headers:
+              X-Api-Key: unknown_field
+    api:
+      type: rest
+      openapi: https://example.test/spec.json
+      connection: default
+`,
+		},
+		{
+			name:    "single credential with auth_mapping",
+			wantErr: true,
+			yaml: `
+auth:
+  provider: ap
+datastore:
+  provider: ds
+server:
+  encryption_key: ek
+integrations:
+  svc:
+    connections:
+      default:
+        mode: user
+        auth:
+          type: manual
+          credentials:
+            - name: token
+          auth_mapping:
+            headers:
+              X-Token: token
+    api:
+      type: rest
+      openapi: https://example.test/spec.json
+      connection: default
+`,
+		},
+		{
+			name:    "multiple credentials without auth_mapping",
+			wantErr: true,
+			yaml: `
+auth:
+  provider: ap
+datastore:
+  provider: ds
+server:
+  encryption_key: ek
+integrations:
+  svc:
+    connections:
+      default:
+        mode: user
+        auth:
+          type: manual
+          credentials:
+            - name: api_key
+            - name: app_key
+    api:
+      type: rest
+      openapi: https://example.test/spec.json
+      connection: default
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := mustWriteConfigFile(t, tc.yaml)
+			_, err := Load(path)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/server/internal/pluginapi/declarative.go
+++ b/server/internal/pluginapi/declarative.go
@@ -147,6 +147,22 @@ func (p *DeclarativeProvider) SupportsManualAuth() bool {
 	return p.auth.Type == pluginmanifestv1.AuthTypeManual || p.auth.Type == pluginmanifestv1.AuthTypeBearer
 }
 
+func (p *DeclarativeProvider) CredentialFields() []core.CredentialFieldDef {
+	if p.auth == nil || len(p.auth.Credentials) == 0 {
+		return nil
+	}
+	fields := make([]core.CredentialFieldDef, len(p.auth.Credentials))
+	for i, cf := range p.auth.Credentials {
+		fields[i] = core.CredentialFieldDef{
+			Name:        cf.Name,
+			Label:       cf.Label,
+			Description: cf.Description,
+			HelpURL:     cf.HelpURL,
+		}
+	}
+	return fields
+}
+
 func (p *DeclarativeProvider) AuthTypes() []string {
 	if p.auth == nil {
 		return nil

--- a/server/internal/provider/build.go
+++ b/server/internal/provider/build.go
@@ -167,6 +167,18 @@ func Build(def *Definition, conn config.ConnectionDef, allowedOperations map[str
 
 	base.ManualAuthEnabled = def.ManualAuth
 
+	if len(def.CredentialFields) > 0 {
+		base.CredentialFieldDefs = make([]core.CredentialFieldDef, len(def.CredentialFields))
+		for i, cf := range def.CredentialFields {
+			base.CredentialFieldDefs[i] = core.CredentialFieldDef{
+				Name:        cf.Name,
+				Label:       cf.Label,
+				Description: cf.Description,
+				HelpURL:     cf.HelpURL,
+			}
+		}
+	}
+
 	if len(conn.Params) > 0 {
 		base.ConnectionDefs = make(map[string]core.ConnectionParamDef, len(conn.Params))
 		for name, cpd := range conn.Params {
@@ -281,6 +293,20 @@ func ApplyConnectionAuth(def *Definition, conn config.ConnectionDef) {
 	}
 	if o.TokenMetadata != nil {
 		def.Auth.TokenMetadata = o.TokenMetadata
+	}
+	if len(o.Credentials) > 0 {
+		def.CredentialFields = make([]CredentialFieldDef, len(o.Credentials))
+		for i, cf := range o.Credentials {
+			def.CredentialFields[i] = CredentialFieldDef{
+				Name:        cf.Name,
+				Label:       cf.Label,
+				Description: cf.Description,
+				HelpURL:     cf.HelpURL,
+			}
+		}
+	}
+	if o.AuthMapping != nil && len(o.AuthMapping.Headers) > 0 {
+		def.AuthMapping = &AuthMappingDef{Headers: o.AuthMapping.Headers}
 	}
 }
 

--- a/server/internal/provider/build_test.go
+++ b/server/internal/provider/build_test.go
@@ -1017,3 +1017,138 @@ func TestBuildResponseCheck_ErrorMessagePathOnly(t *testing.T) {
 		t.Errorf("error should contain %q, got: %v", msgValue, err)
 	}
 }
+
+func TestBuildCredentialFields(t *testing.T) {
+	t.Parallel()
+
+	def := &Definition{
+		Provider:    "cred_test",
+		DisplayName: "Credential Test",
+		BaseURL:     "https://api.example.com",
+		Auth:        AuthDef{Type: "manual"},
+		CredentialFields: []CredentialFieldDef{
+			{Name: "api_key", Label: "API Key", HelpURL: "https://example.com/keys"},
+			{Name: "app_key", Label: "App Key", Description: "Your application key"},
+		},
+		Operations: map[string]OperationDef{
+			"list": {Description: "List", Method: http.MethodGet, Path: "/items"},
+		},
+	}
+
+	prov, err := Build(def, config.ConnectionDef{}, nil)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	cfp, ok := prov.(core.CredentialFieldsProvider)
+	if !ok {
+		t.Fatal("provider does not implement CredentialFieldsProvider")
+	}
+
+	fields := cfp.CredentialFields()
+	if len(fields) != 2 {
+		t.Fatalf("got %d credential fields, want 2", len(fields))
+	}
+	if fields[0].Name != "api_key" || fields[0].Label != "API Key" || fields[0].HelpURL != "https://example.com/keys" {
+		t.Errorf("field[0] = %+v", fields[0])
+	}
+	if fields[1].Name != "app_key" || fields[1].Description != "Your application key" {
+		t.Errorf("field[1] = %+v", fields[1])
+	}
+}
+
+func TestBuildCredentialFieldsFromConfig(t *testing.T) {
+	t.Parallel()
+
+	def := &Definition{
+		Provider:    "cred_cfg_test",
+		DisplayName: "Credential Config Test",
+		BaseURL:     "https://api.example.com",
+		Auth:        AuthDef{Type: "manual"},
+		Operations: map[string]OperationDef{
+			"list": {Description: "List", Method: http.MethodGet, Path: "/items"},
+		},
+	}
+
+	conn := config.ConnectionDef{
+		Auth: config.ConnectionAuthDef{
+			Credentials: []config.CredentialFieldDef{
+				{Name: "token", Label: "Access Token", HelpURL: "https://example.com/tokens"},
+			},
+		},
+	}
+
+	prov, err := Build(def, conn, nil)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	cfp, ok := prov.(core.CredentialFieldsProvider)
+	if !ok {
+		t.Fatal("provider does not implement CredentialFieldsProvider")
+	}
+
+	fields := cfp.CredentialFields()
+	if len(fields) != 1 {
+		t.Fatalf("got %d credential fields, want 1", len(fields))
+	}
+	if fields[0].Name != "token" || fields[0].Label != "Access Token" {
+		t.Errorf("field = %+v", fields[0])
+	}
+}
+
+func TestBuildAuthMappingFromConfig(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"api_key": r.Header.Get("X-Api-Key"),
+			"app_key": r.Header.Get("X-App-Key"),
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	def := &Definition{
+		Provider:    "cfg_mapping_test",
+		DisplayName: "Config Mapping Test",
+		BaseURL:     srv.URL,
+		Auth:        AuthDef{Type: "manual"},
+		Operations: map[string]OperationDef{
+			"list": {Description: "List", Method: http.MethodGet, Path: "/items"},
+		},
+	}
+
+	conn := config.ConnectionDef{
+		Auth: config.ConnectionAuthDef{
+			AuthMapping: &config.AuthMappingDef{
+				Headers: map[string]string{
+					"X-Api-Key": "api_key",
+					"X-App-Key": "app_key",
+				},
+			},
+		},
+	}
+
+	prov, err := Build(def, conn, nil)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	token := `{"api_key":"k1","app_key":"k2"}`
+	result, err := prov.Execute(context.Background(), "list", nil, token)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if resp["api_key"] != "k1" {
+		t.Errorf("X-Api-Key = %v, want k1", resp["api_key"])
+	}
+	if resp["app_key"] != "k2" {
+		t.Errorf("X-App-Key = %v, want k2", resp["app_key"])
+	}
+}

--- a/server/internal/provider/definition.go
+++ b/server/internal/provider/definition.go
@@ -21,8 +21,9 @@ type Definition struct {
 	AuthMapping      *AuthMappingDef   `yaml:"auth_mapping" json:"auth_mapping"`
 	ErrorMessagePath string            `yaml:"error_message_path" json:"error_message_path"`
 
-	ResponseCheck *ResponseCheckDef `yaml:"response_check" json:"response_check,omitempty"`
-	ManualAuth    bool              `yaml:"manual_auth" json:"manual_auth"`
+	ResponseCheck    *ResponseCheckDef    `yaml:"response_check" json:"response_check,omitempty"`
+	ManualAuth       bool                 `yaml:"manual_auth" json:"manual_auth"`
+	CredentialFields []CredentialFieldDef `yaml:"credential_fields" json:"credential_fields,omitempty"`
 
 	PostConnectDiscovery *PostConnectDiscoveryDef `yaml:"post_connect_discovery" json:"post_connect_discovery,omitempty"`
 
@@ -102,6 +103,13 @@ type PaginationDef struct {
 	DefaultLimit int    `yaml:"default_limit" json:"default_limit"`
 	ResultsPath  string `yaml:"results_path" json:"results_path"`
 	MaxPages     int    `yaml:"max_pages" json:"max_pages"`
+}
+
+type CredentialFieldDef struct {
+	Name        string `yaml:"name" json:"name"`
+	Label       string `yaml:"label" json:"label,omitempty"`
+	Description string `yaml:"description" json:"description,omitempty"`
+	HelpURL     string `yaml:"help_url" json:"help_url,omitempty"`
 }
 
 type ParameterDef struct {

--- a/server/internal/server/handlers.go
+++ b/server/internal/server/handlers.go
@@ -68,9 +68,17 @@ type instanceInfo struct {
 	Connection string `json:"connection,omitempty"`
 }
 
+type credentialFieldInfo struct {
+	Name        string `json:"name"`
+	Label       string `json:"label,omitempty"`
+	Description string `json:"description,omitempty"`
+	HelpURL     string `json:"help_url,omitempty"`
+}
+
 type connectionDefInfo struct {
-	Name     string `json:"name"`
-	AuthType string `json:"auth_type"`
+	Name             string                `json:"name"`
+	AuthType         string                `json:"auth_type"`
+	CredentialFields []credentialFieldInfo `json:"credential_fields,omitempty"`
 }
 
 type integrationInfo struct {
@@ -83,6 +91,7 @@ type integrationInfo struct {
 	AuthTypes        []string                       `json:"auth_types"`
 	ConnectionParams map[string]connectionParamInfo `json:"connection_params,omitempty"`
 	Connections      []connectionDefInfo            `json:"connections,omitempty"`
+	CredentialFields []credentialFieldInfo          `json:"credential_fields,omitempty"`
 }
 
 type connectionParamInfo struct {
@@ -144,6 +153,20 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 				info.ConnectionParams = userParams
 			}
 		}
+		if cfp, ok := prov.(core.CredentialFieldsProvider); ok {
+			if fields := cfp.CredentialFields(); len(fields) > 0 {
+				cfInfos := make([]credentialFieldInfo, len(fields))
+				for i, f := range fields {
+					cfInfos[i] = credentialFieldInfo{
+						Name:        f.Name,
+						Label:       f.Label,
+						Description: f.Description,
+						HelpURL:     f.HelpURL,
+					}
+				}
+				info.CredentialFields = cfInfos
+			}
+		}
 		if intg, ok := s.integrationDefs[name]; ok && len(intg.Connections) > 1 {
 			connNames := make([]string, 0, len(intg.Connections))
 			for connName := range intg.Connections {
@@ -157,7 +180,20 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 				if connDef.Auth.Type == "manual" || connDef.Auth.Type == "api_key" {
 					authType = "manual"
 				}
-				conns = append(conns, connectionDefInfo{Name: connName, AuthType: authType})
+				cdi := connectionDefInfo{Name: connName, AuthType: authType}
+				if len(connDef.Auth.Credentials) > 0 {
+					cfInfos := make([]credentialFieldInfo, len(connDef.Auth.Credentials))
+					for i, cf := range connDef.Auth.Credentials {
+						cfInfos[i] = credentialFieldInfo{
+							Name:        cf.Name,
+							Label:       cf.Label,
+							Description: cf.Description,
+							HelpURL:     cf.HelpURL,
+						}
+					}
+					cdi.CredentialFields = cfInfos
+				}
+				conns = append(conns, cdi)
 			}
 			info.Connections = conns
 		}
@@ -726,6 +762,7 @@ type connectManualRequest struct {
 	Connection       string            `json:"connection"`
 	Instance         string            `json:"instance"`
 	Credential       string            `json:"credential"`
+	Credentials      map[string]string `json:"credentials"`
 	ConnectionParams map[string]string `json:"connection_params"`
 }
 
@@ -735,7 +772,26 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	if req.Integration == "" || req.Credential == "" {
+
+	var effectiveCredential string
+	if len(req.Credentials) > 0 {
+		for k, v := range req.Credentials {
+			if v == "" {
+				writeError(w, http.StatusBadRequest, fmt.Sprintf("credential %q must not be empty", k))
+				return
+			}
+		}
+		b, err := json.Marshal(req.Credentials)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid credentials map")
+			return
+		}
+		effectiveCredential = string(b)
+	} else {
+		effectiveCredential = req.Credential
+	}
+
+	if req.Integration == "" || effectiveCredential == "" {
 		writeError(w, http.StatusBadRequest, "integration and credential are required")
 		return
 	}
@@ -805,7 +861,7 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		Integration:  req.Integration,
 		Connection:   manualConnection,
 		Instance:     manualInstance,
-		AccessToken:  req.Credential,
+		AccessToken:  effectiveCredential,
 		MetadataJSON: manualMeta,
 	}
 

--- a/server/internal/server/server_test.go
+++ b/server/internal/server/server_test.go
@@ -4668,3 +4668,51 @@ func TestExecuteOperation_ConnectionModeEither(t *testing.T) {
 		}
 	})
 }
+
+func TestConnectManual_MultiCredential(t *testing.T) {
+	t.Parallel()
+
+	var stored *core.IntegrationToken
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, &stubManualProvider{
+			StubIntegration: coretesting.StubIntegration{N: "multi-key-svc"},
+		})
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+			StoreTokenFn: func(_ context.Context, tok *core.IntegrationToken) error {
+				stored = tok
+				return nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"integration":"multi-key-svc","credentials":{"api_key":"k1","app_key":"k2"}}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if stored == nil {
+		t.Fatal("expected StoreToken to be called")
+	}
+
+	var tokenData map[string]string
+	if err := json.Unmarshal([]byte(stored.AccessToken), &tokenData); err != nil {
+		t.Fatalf("stored token is not valid JSON: %v", err)
+	}
+	if tokenData["api_key"] != "k1" {
+		t.Errorf("api_key = %q, want k1", tokenData["api_key"])
+	}
+	if tokenData["app_key"] != "k2" {
+		t.Errorf("app_key = %q, want k2", tokenData["app_key"])
+	}
+}

--- a/server/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/server/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -241,6 +241,20 @@
         "authorization_params": {
           "type": "object",
           "additionalProperties": { "type": "string" }
+        },
+        "credentials": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1, "pattern": "^[a-z][a-z0-9_]*$" },
+              "label": { "type": "string" },
+              "description": { "type": "string" },
+              "help_url": { "type": "string", "format": "uri" }
+            }
+          }
         }
       },
       "allOf": [

--- a/server/sdk/pluginmanifest/v1/types.go
+++ b/server/sdk/pluginmanifest/v1/types.go
@@ -71,6 +71,14 @@ type ProviderAuth struct {
 	ScopeParam          string            `json:"scope_param,omitempty"`
 	ScopeSeparator      string            `json:"scope_separator,omitempty"`
 	AuthorizationParams map[string]string `json:"authorization_params,omitempty"`
+	Credentials         []CredentialField `json:"credentials,omitempty"`
+}
+
+type CredentialField struct {
+	Name        string `json:"name"`
+	Label       string `json:"label,omitempty"`
+	Description string `json:"description,omitempty"`
+	HelpURL     string `json:"help_url,omitempty"`
 }
 
 type ProtocolRange struct {

--- a/web/src/components/IntegrationCard.tsx
+++ b/web/src/components/IntegrationCard.tsx
@@ -112,7 +112,7 @@ export default function IntegrationCard({
     }
   }
 
-  async function handleSubmitToken(credential: string, connectionParams?: Record<string, string>, instance?: string, connection?: string) {
+  async function handleSubmitToken(credential: string | Record<string, string>, connectionParams?: Record<string, string>, instance?: string, connection?: string) {
     setSubmitting(true);
     setError(null);
     try {

--- a/web/src/components/IntegrationSettingsModal.tsx
+++ b/web/src/components/IntegrationSettingsModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Integration } from "@/lib/api";
+import { ConnectionParamDef, CredentialFieldDef, Integration } from "@/lib/api";
 import Button from "./Button";
 import { CheckCircleIcon, CloseIcon } from "./icons";
 
@@ -11,7 +11,7 @@ interface IntegrationSettingsModalProps {
   integration: Integration;
   onClose: () => void;
   onStartOAuth: (instance?: string, connection?: string) => void;
-  onSubmitToken: (credential: string, connectionParams?: Record<string, string>, instance?: string, connection?: string) => void;
+  onSubmitToken: (credential: string | Record<string, string>, connectionParams?: Record<string, string>, instance?: string, connection?: string) => void;
   onDisconnect: (instance?: string) => void;
   reconnecting: boolean;
   disconnecting: boolean;
@@ -91,11 +91,35 @@ export default function IntegrationSettingsModal({
     }
   }
 
+  function resolveCredentialFields(): CredentialFieldDef[] | undefined {
+    if (pendingConnection && integration.connections) {
+      const conn = integration.connections.find(c => c.name === pendingConnection);
+      return conn?.credential_fields?.length ? conn.credential_fields : undefined;
+    }
+    return integration.credential_fields;
+  }
+
   function handleTokenSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const fd = new FormData(e.currentTarget);
-    const credential = (fd.get("credential") as string)?.trim();
+    const fields = resolveCredentialFields();
+
+    let credential: string | Record<string, string>;
+    if (fields && fields.length > 1) {
+      const creds: Record<string, string> = {};
+      for (const field of fields) {
+        const val = (fd.get(`cred_${field.name}`) as string)?.trim();
+        if (!val) return;
+        creds[field.name] = val;
+      }
+      credential = creds;
+    } else if (fields && fields.length === 1) {
+      credential = (fd.get(`cred_${fields[0].name}`) as string)?.trim() ?? "";
+    } else {
+      credential = (fd.get("credential") as string)?.trim() ?? "";
+    }
     if (!credential) return;
+
     let params: Record<string, string> | undefined;
     if (integration.connection_params) {
       const collected: Record<string, string> = {};
@@ -254,63 +278,16 @@ export default function IntegrationSettingsModal({
             </div>
           </form>
         ) : view === "token" ? (
-          <form onSubmit={handleTokenSubmit}>
-            <h2
-              id={headingId}
-              className="text-lg font-heading font-semibold text-stone-900"
-            >
-              API Token
-            </h2>
-            {needsParams && integration.connection_params && Object.entries(integration.connection_params).map(([name, def]) => (
-              <div key={name} className="mt-2">
-                <label
-                  htmlFor={`cp_${name}-${integration.name}`}
-                  className="block text-sm font-medium text-stone-700"
-                >
-                  {def.description || name}
-                </label>
-                <input
-                  id={`cp_${name}-${integration.name}`}
-                  name={`cp_${name}`}
-                  type="text"
-                  required={def.required}
-                  defaultValue={def.default}
-                  placeholder={name}
-                  className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
-                />
-              </div>
-            ))}
-            <label
-              htmlFor={`credential-${integration.name}`}
-              className="mt-4 block text-sm font-medium text-stone-700"
-            >
-              Paste your API token
-            </label>
-            <input
-              id={`credential-${integration.name}`}
-              name="credential"
-              type="password"
-              required
-              placeholder="Paste your API token"
-              autoFocus
-              className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
-            />
-            {error && <p className="mt-3 text-sm text-ember-500">{error}</p>}
-            <div className="mt-6 flex gap-3">
-              <Button
-                type="button"
-                variant="secondary"
-                className="flex-1"
-                onClick={() => setView(integration.connected ? "instance" : "default")}
-                disabled={submitting}
-              >
-                Cancel
-              </Button>
-              <Button type="submit" className="flex-1" disabled={submitting}>
-                {submitting ? "Connecting..." : "Submit"}
-              </Button>
-            </div>
-          </form>
+          <TokenForm
+            integrationName={integration.name}
+            headingId={headingId}
+            credentialFields={resolveCredentialFields()}
+            connectionParams={needsParams ? integration.connection_params : undefined}
+            error={error}
+            submitting={submitting}
+            onSubmit={handleTokenSubmit}
+            onCancel={() => setView(integration.connected ? "instance" : "default")}
+          />
         ) : (
           <>
             <div className="flex items-start justify-between">
@@ -365,5 +342,127 @@ export default function IntegrationSettingsModal({
         )}
       </div>
     </dialog>
+  );
+}
+
+function TokenForm({
+  integrationName,
+  headingId,
+  credentialFields,
+  connectionParams,
+  error,
+  submitting,
+  onSubmit,
+  onCancel,
+}: {
+  integrationName: string;
+  headingId: string;
+  credentialFields: CredentialFieldDef[] | undefined;
+  connectionParams: Record<string, ConnectionParamDef> | undefined;
+  error: string | null;
+  submitting: boolean;
+  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  onCancel: () => void;
+}) {
+  const fields = credentialFields;
+  const heading = !fields?.length ? "API Token"
+    : fields.length === 1 ? (fields[0].label || "API Token")
+    : "Enter Credentials";
+
+  return (
+    <form onSubmit={onSubmit}>
+      <h2
+        id={headingId}
+        className="text-lg font-heading font-semibold text-stone-900"
+      >
+        {heading}
+      </h2>
+      {connectionParams && Object.entries(connectionParams).map(([name, def]) => (
+        <div key={name} className="mt-2">
+          <label
+            htmlFor={`cp_${name}-${integrationName}`}
+            className="block text-sm font-medium text-stone-700"
+          >
+            {def.description || name}
+          </label>
+          <input
+            id={`cp_${name}-${integrationName}`}
+            name={`cp_${name}`}
+            type="text"
+            required={def.required}
+            defaultValue={def.default}
+            placeholder={name}
+            className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
+          />
+        </div>
+      ))}
+      {fields && fields.length > 0 ? (
+        fields.map((field, idx) => (
+          <div key={field.name} className="mt-4">
+            <label
+              htmlFor={`cred_${field.name}-${integrationName}`}
+              className="block text-sm font-medium text-stone-700"
+            >
+              {field.label || field.name}
+              {field.help_url && (
+                <a
+                  href={field.help_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="ml-1 text-xs text-timber-500 hover:underline"
+                >
+                  (where to find this)
+                </a>
+              )}
+            </label>
+            {field.description && (
+              <p className="mt-0.5 text-xs text-stone-400">{field.description}</p>
+            )}
+            <input
+              id={`cred_${field.name}-${integrationName}`}
+              name={`cred_${field.name}`}
+              type="password"
+              required
+              placeholder={field.label || field.name}
+              autoFocus={idx === 0}
+              className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
+            />
+          </div>
+        ))
+      ) : (
+        <>
+          <label
+            htmlFor={`credential-${integrationName}`}
+            className="mt-4 block text-sm font-medium text-stone-700"
+          >
+            Paste your API token
+          </label>
+          <input
+            id={`credential-${integrationName}`}
+            name="credential"
+            type="password"
+            required
+            placeholder="Paste your API token"
+            autoFocus
+            className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
+          />
+        </>
+      )}
+      {error && <p className="mt-3 text-sm text-ember-500">{error}</p>}
+      <div className="mt-6 flex gap-3">
+        <Button
+          type="button"
+          variant="secondary"
+          className="flex-1"
+          onClick={onCancel}
+          disabled={submitting}
+        >
+          Cancel
+        </Button>
+        <Button type="submit" className="flex-1" disabled={submitting}>
+          {submitting ? "Connecting..." : "Submit"}
+        </Button>
+      </div>
+    </form>
   );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -7,6 +7,13 @@ export interface ConnectionParamDef {
   default?: string;
 }
 
+export interface CredentialFieldDef {
+  name: string;
+  label?: string;
+  description?: string;
+  help_url?: string;
+}
+
 export interface InstanceInfo {
   name: string;
   connection?: string;
@@ -15,6 +22,7 @@ export interface InstanceInfo {
 export interface ConnectionDefInfo {
   name: string;
   auth_type: "oauth" | "manual";
+  credential_fields?: CredentialFieldDef[];
 }
 
 export interface Integration {
@@ -27,6 +35,7 @@ export interface Integration {
   auth_types?: ("oauth" | "manual")[];
   connection_params?: Record<string, ConnectionParamDef>;
   connections?: ConnectionDefInfo[];
+  credential_fields?: CredentialFieldDef[];
 }
 
 export interface APIToken {
@@ -145,20 +154,25 @@ export async function startIntegrationOAuth(
 
 export async function connectManualIntegration(
   integration: string,
-  credential: string,
+  credential: string | Record<string, string>,
   connectionParams?: Record<string, string>,
   instance?: string,
   connection?: string,
 ): Promise<{ status: string }> {
+  const body: Record<string, unknown> = {
+    integration,
+    instance,
+    connection,
+    connection_params: connectionParams,
+  };
+  if (typeof credential === "string") {
+    body.credential = credential;
+  } else {
+    body.credentials = credential;
+  }
   return fetchAPI("/api/v1/auth/connect-manual", {
     method: "POST",
-    body: JSON.stringify({
-      integration,
-      instance,
-      connection,
-      credential,
-      connection_params: connectionParams,
-    }),
+    body: JSON.stringify(body),
   });
 }
 


### PR DESCRIPTION
Manual token auth previously showed a hardcoded "API Token" label with
a single password input, which does not work for services like Datadog
that require multiple credentials (API Key and Application Key). This
adds a `credentials` field to connection auth config and plugin
manifests that lets integrations declare per-field metadata including
custom labels, descriptions, and help URLs. The UI now renders dynamic
credential forms based on these declarations instead of the hardcoded
single field.

For multi-credential integrations, the config also accepts an
`auth_mapping` that maps credential field names to HTTP headers. The
UI combines multiple fields into a JSON object which the existing
`auth_mapping` token parser unpacks into the correct headers at request
time. Integrations that omit `credentials` continue to show the
default single "API Token" field with no changes required.

Single credential with a custom label:

```yaml
auth:
  type: manual
  credentials:
    - name: token
      label: API Access Token
      help_url: https://app.example.com/settings/tokens
```

Multiple credentials with header mapping (e.g. Datadog):

```yaml
auth:
  type: manual
  credentials:
    - name: api_key
      label: API Key
      help_url: https://us5.datadoghq.com/organization-settings/api-keys
    - name: app_key
      label: Application Key
      help_url: https://us5.datadoghq.com/organization-settings/application-keys
  auth_mapping:
    headers:
      DD-API-KEY: api_key
      DD-APPLICATION-KEY: app_key
```

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>