### PR TITLE
Overhaul docs for accuracy and completeness

### DIFF
--- a/docs/pages/concepts/_meta.ts
+++ b/docs/pages/concepts/_meta.ts
@@ -1,6 +1,7 @@
 export default {
   "platform-model": "Platform Model",
   configuration: "Configuration",
+  security: "Security Model",
   observability: "Observability",
   integrations: "Integrations",
   "authentication-and-tokens": "Authentication and Tokens",

--- a/docs/pages/concepts/authentication-and-tokens.mdx
+++ b/docs/pages/concepts/authentication-and-tokens.mdx
@@ -2,25 +2,19 @@
 
 Gestalt has two separate auth layers:
 
-1. platform auth: who is allowed to use Gestalt
-2. integration auth: which upstream credentials Gestalt should use on behalf of that subject
-
-Keeping those layers separate is one of the core design choices in `gestaltd`.
+1. **Platform auth** -- who is allowed to use Gestalt
+2. **Integration auth** -- which upstream credentials Gestalt uses on behalf of that subject
 
 ## Platform Auth Providers
 
-Gestalt currently ships four platform auth providers:
-
-| Provider | When to use it |
+| Provider | When to use |
 | --- | --- |
-| `none` | Local development, demos, or simple single-user deployments with no sign-in. |
-| `local` | Local development, no external identity provider required. |
+| `none` | Local development, demos, or single-user deployments with no sign-in. |
+| `local` | Local development without an external identity provider. |
 | `google` | Google Workspace or Google account login. |
-| `oidc` | Any OIDC-compatible provider such as Okta, Auth0, Azure AD, or Keycloak. |
+| `oidc` | Any OIDC-compatible provider: Okta, Auth0, Azure AD, Keycloak, Firebase. |
 
 ### `none`
-
-`none` is the auth provider used by the auto-generated out-of-the-box config.
 
 ```yaml
 auth:
@@ -31,8 +25,6 @@ All requests are treated as coming from a single anonymous user.
 
 ### `local`
 
-`local` is the simplest built-in authenticated provider.
-
 ```yaml
 auth:
   provider: local
@@ -40,7 +32,7 @@ auth:
     email: you@example.com
 ```
 
-`email` is optional. If omitted, Gestalt uses `local@gestalt.local`.
+`email` is optional. Defaults to `local@gestalt.local`.
 
 ### `google`
 
@@ -54,7 +46,7 @@ auth:
       - example.com
 ```
 
-If `redirect_url` is omitted and `server.base_url` is set, Gestalt derives the login callback automatically.
+If `redirect_url` is omitted and `server.base_url` is set, Gestalt derives the login callback automatically. Google checks `email_verified` on every login and rejects unverified accounts.
 
 ### `oidc`
 
@@ -76,69 +68,75 @@ auth:
     display_name: Company SSO
 ```
 
-OIDC exposes more knobs because the host identity provider can vary.
+OIDC checks `email_verified` when the claim is present and rejects unverified accounts.
 
 ## Session Tokens
 
-Successful platform login produces a Gestalt session token:
+Successful platform login produces a session token:
 
-- stored in the `session_token` cookie for browser flows
-- validated by the platform auth provider
-- used by the API when no bearer token is provided
+- Stored in the `session_token` cookie for browser flows
+- Validated by the platform auth provider on each request
+- Used by the API when no bearer token is provided
 
 The auth middleware checks the session cookie first, then the `Authorization: Bearer ...` header.
 
 ## API Tokens
 
-Users can mint long-lived API tokens for direct HTTP access.
+Users mint long-lived API tokens for programmatic access.
 
-These tokens:
+```
+POST /api/v1/tokens     Create a token. Plaintext is returned once.
+GET  /api/v1/tokens      List tokens for the current user.
+DELETE /api/v1/tokens/{id}  Revoke a single token.
+DELETE /api/v1/tokens       Revoke all tokens for the current user.
+```
 
-- are created through `POST /api/v1/tokens`
-- are stored hashed, not in plaintext
-- use the prefix `gst_api_`
-- resolve back to the owning user at request time
+Properties:
 
-API tokens authenticate to the same HTTP API as browser sessions.
+- Prefixed with `gst_api_`
+- Stored as a SHA-256 hash, not in plaintext
+- Resolve back to the owning user at request time
+- Default lifetime: 30 days, configurable via `server.api_token_ttl`
+- Authenticate to the same HTTP API as browser sessions
 
 ## Integration Tokens
 
-Integration tokens are the credentials Gestalt stores for upstream providers. These are different from platform sessions and API tokens.
+Integration tokens are the credentials Gestalt stores for upstream providers. They are separate from platform sessions and API tokens.
 
-They are keyed by:
+Keyed by:
 
-- subject
-- integration name
-- instance
+- Subject (user or identity)
+- Integration name
+- Instance
 
 The invocation broker resolves them based on the connection's `mode`:
 
 | Mode | Token lookup |
 | --- | --- |
-| `user` | Find the calling user's token |
-| `identity` | Find the shared identity token |
-| `either` | Try user, then identity |
-| `none` | Do not look up a token |
+| `user` | Find the calling user's token. |
+| `identity` | Find the shared identity token. |
+| `either` | Try user first, then fall back to identity. |
+| `none` | No token lookup. |
 
 If an OAuth access token is near expiry and a refresh token exists, Gestalt refreshes it automatically and persists the new token.
 
 ## Manual Auth
 
-Not every integration uses OAuth. Gestalt also supports manual connection flows, where a user pastes a token or key directly.
+Not every integration uses OAuth. Gestalt supports manual connection flows where a user provides a token or key directly.
 
-At the config layer, that is controlled by the integration auth model:
+At the config layer:
 
-- auth type `manual`
-- or `manual_auth: true` when a provider exposes both OAuth and manual auth
+- Auth type `manual` on the connection
+- Or a plugin that implements `ManualAuthProvider`
 
-Manual auth still ends with a stored integration token. The difference is only how the token enters the system.
+Manual auth still produces a stored integration token. The difference is how the token enters the system.
 
-## Instances And Ambiguity
+## Instances and Ambiguity
 
 If there is exactly one stored connection for an integration, Gestalt uses it automatically.
 
-If there are multiple stored instances and the caller does not specify which one to use, invocation fails with an ambiguity error. That is a deliberate safeguard; Gestalt does not guess when more than one upstream account could apply.
+If there are multiple stored instances and the caller does not specify which one to use, invocation fails with an ambiguity error. Gestalt does not guess when more than one upstream account could apply.
 
 ## No-Auth Mode
 
-When `auth.provider: none`, Gestalt skips authentication entirely. All requests are treated as coming from a single anonymous user. This is useful for local development and testing.
+When `auth.provider: none`, Gestalt skips authentication entirely. All requests are treated as coming from a single anonymous user.

--- a/docs/pages/concepts/configuration.mdx
+++ b/docs/pages/concepts/configuration.mdx
@@ -41,13 +41,14 @@ runtimes: {}
 bindings: {}
 server: {}
 egress: {}
+ui: {}
 ```
 
 Each block controls a distinct part of the runtime:
 
 | Block | What it defines |
 | --- | --- |
-| `server` | Port, base URL, and encryption key. |
+| `server` | Port, base URL, encryption key, and API token TTL. |
 | `auth` | How users authenticate to Gestalt itself. |
 | `datastore` | Where Gestalt stores users, tokens, and related runtime state. |
 | `secrets` | How `secret://...` values are resolved. |
@@ -56,6 +57,7 @@ Each block controls a distinct part of the runtime:
 | `runtimes` | Background workers. |
 | `bindings` | Additional inbound surfaces. |
 | `egress` | Outbound allow or deny policy plus credential grants. |
+| `ui` | Optional custom web UI plugin. |
 
 ## Defaults And Required Fields
 

--- a/docs/pages/concepts/integrations.mdx
+++ b/docs/pages/concepts/integrations.mdx
@@ -1,8 +1,8 @@
 # Integrations
 
-Integrations are the main user-facing primitive in Gestalt. Every integration becomes a provider at runtime, and every provider exposes operations that callers can invoke through the API, UI, bindings, runtimes, or MCP.
+Every integration becomes a provider at runtime. Every provider exposes operations that callers invoke through the API, UI, bindings, runtimes, or MCP.
 
-## The Shape Of An Integration
+## Shape of an Integration
 
 ```yaml
 integrations:
@@ -35,14 +35,17 @@ This one block answers four questions:
 3. Where do its operations come from (api/mcp surfaces)
 4. Which operations should be exposed
 
-## Two Lanes
+## Integration Patterns
 
-Every integration follows one of two patterns:
+Every integration follows one of three patterns:
 
-- **Declarative**: `connections` + one or both of `api` and `mcp`
-- **Plugin-only**: just a `plugin` block
+| Pattern | Structure | When to use |
+| --- | --- | --- |
+| **Declarative** | `connections` + one or both of `api` and `mcp` | The upstream has an OpenAPI spec, GraphQL endpoint, or MCP server. |
+| **Plugin-only** | Just a `plugin` block | Custom execution logic that cannot be expressed declaratively. |
+| **Hybrid** | `plugin` + `mcp` | A plugin provider combined with an upstream MCP surface. |
 
-You cannot mix plugin and declarative surfaces.
+Plugin integrations cannot declare an `api` surface. Only plugin + `mcp` composition is supported.
 
 ## Connections
 
@@ -69,9 +72,10 @@ All connections within a single integration must share the same mode.
 
 | Value | Behavior |
 | --- | --- |
-| `user` | Use the authenticated caller's token. |
+| `user` | Use the authenticated caller's token. Default when `mode` is omitted. |
 | `identity` | Use a shared identity token. |
-| `none` | Use no credential. |
+| `either` | Try the caller's token first, then fall back to the shared identity token. |
+| `none` | No credential. |
 
 ### Params
 
@@ -83,13 +87,13 @@ params:
     required: true
 ```
 
-A URL like `https://{subdomain}.example.com/api` is expanded using the connection's params at request time.
+A URL like `https://{subdomain}.example.com/api` expands using the connection's params at request time.
 
-## Surfaces: `api` And `mcp`
+## Surfaces: `api` and `mcp`
 
-Surfaces define where operations come from. An integration can declare one `api` surface, one `mcp` surface, or both.
+Surfaces define where operations come from. A declarative integration can declare one `api` surface, one `mcp` surface, or both.
 
-All declarative API operations are automatically projected as MCP tools on `/mcp`. There is no opt-in flag; any integration with an `api` surface has its operations available to MCP clients.
+All declarative API operations are automatically projected as MCP tools on `/mcp`. Any integration with an `api` surface has its operations available to MCP clients.
 
 ### `api`
 
@@ -102,13 +106,13 @@ api:
     listThings:
 ```
 
-| Field | Notes |
+| Field | Purpose |
 | --- | --- |
 | `type` | `rest` or `graphql`. |
 | `openapi` | Required when `type: rest`. URL or local path to an OpenAPI document. |
 | `url` | Required when `type: graphql`. The GraphQL endpoint URL. |
 | `connection` | Name of a connection defined in the same integration. |
-| `allowed_operations` | Narrows exposed operations. Use a YAML map where each key is an operation name. Set the value to nothing to keep the upstream description, or provide an object with `alias` and/or `description`. |
+| `allowed_operations` | Narrows exposed operations. Bare key keeps the upstream description. Object with `alias` and/or `description` overrides it. |
 
 ### `mcp`
 
@@ -116,16 +120,19 @@ api:
 mcp:
   url: https://mcp.example.com
   connection: mcp_conn
+  allowed_operations:
+    search:
 ```
 
-| Field | Notes |
+| Field | Purpose |
 | --- | --- |
 | `url` | Required. The upstream MCP server URL. |
 | `connection` | Name of a connection defined in the same integration. |
+| `allowed_operations` | Optional. Narrows exposed tools. Same override syntax as `api`. |
 
 ### Multiple Connections
 
-An integration can define separate connections for its API and MCP surfaces. This is useful when the two surfaces authenticate through different providers.
+An integration can define separate connections for its API and MCP surfaces when the two surfaces authenticate through different providers.
 
 ```yaml
 integrations:
@@ -158,17 +165,15 @@ integrations:
 
 ## Operation Exposure
 
-`allowed_operations` on `api` narrows what a provider exposes.
+`allowed_operations` on `api` and `mcp` narrows what a provider exposes.
 
-It supports two forms:
+Two forms:
 
 ```yaml
 allowed_operations:
   repos/list-for-authenticated-user:
   issues/list-for-authenticated-user:
 ```
-
-or:
 
 ```yaml
 allowed_operations:
@@ -178,13 +183,13 @@ allowed_operations:
     description: List assigned issues
 ```
 
-The bare-key form keeps upstream descriptions. The object form lets you override descriptions or aliases.
+The bare-key form keeps upstream descriptions. The object form overrides descriptions or aliases.
 
-If you omit `allowed_operations`, Gestalt exposes every operation from the source.
+Omitting `allowed_operations` exposes every operation from the source.
 
 ## Plugins
 
-An integration can be backed by an executable provider plugin instead of declarative surfaces:
+A plugin-only integration delegates execution to an external binary:
 
 ```yaml
 integrations:
@@ -193,24 +198,43 @@ integrations:
       package: ./custom-tool.tar.gz
 ```
 
-Plugin integrations cannot also declare `connections`, `api`, or `mcp`.
+See the [Config File](/reference/config-file) reference for the full `plugin` field specification.
 
-## Metadata And Presentation
+## Hybrid Integrations
 
-These fields only affect how the provider is presented, not how it executes:
+A hybrid integration composes a plugin provider with an upstream MCP surface. The plugin handles execution logic while the MCP surface exposes additional tools.
 
-- `display_name`
-- `description`
-- `icon_file`
-- `mcp_tool_prefix`
+```yaml
+integrations:
+  slack:
+    plugin:
+      source: github.com/valon-technologies/gestalt/slack
+      version: 0.0.1-alpha.3
+    mcp:
+      url: https://mcp.slack.com
+      connection: plugin
+```
 
-`icon_file` is resolved relative to the config file and embedded into the prepared provider artifact during `bundle`.
+Setting `mcp.connection` to `plugin` reuses the plugin's OAuth token for the MCP surface. Alternatively, declare explicit `connections` and reference one from `mcp.connection`.
+
+Hybrid integrations cannot declare an `api` surface. If `connections` are declared, they must be paired with an `mcp` surface.
+
+## Metadata
+
+These fields affect presentation only:
+
+| Field | Purpose |
+| --- | --- |
+| `display_name` | Provider name shown in the UI and API responses. |
+| `description` | Provider description. |
+| `icon_file` | SVG path, resolved relative to the config file. Embedded during `bundle`. |
+| `mcp_tool_prefix` | Prefix applied to tool names on the `/mcp` endpoint. |
 
 ## Instances
 
 Gestalt stores connection state by `(subject, integration, instance)`.
 
-That means one integration can support:
+One integration can support:
 
 - one default connection
 - multiple named connections for the same user

--- a/docs/pages/concepts/mcp-binding.mdx
+++ b/docs/pages/concepts/mcp-binding.mdx
@@ -49,11 +49,13 @@ An integration may combine:
 
 - one `api` surface (REST or GraphQL)
 - one `mcp` surface
+- a `plugin` block with an `mcp` surface (hybrid pattern)
 
 That gives you one provider namespace that can contain:
 
 - generated HTTP operations (automatically projected as MCP tools)
 - imported MCP tools
+- plugin-provided operations (including plugin catalogs)
 
 `mcp_tool_prefix` exists to avoid tool-name collisions when multiple integrations export similarly named operations.
 

--- a/docs/pages/concepts/platform-model.mdx
+++ b/docs/pages/concepts/platform-model.mdx
@@ -68,7 +68,7 @@ The composition rules are intentionally narrow:
 - an integration may have at most one `api` surface (REST or GraphQL)
 - an integration may have at most one `mcp` surface
 - one `api` surface plus one `mcp` surface is valid
-- a `plugin` block replaces declarative surfaces entirely
+- a `plugin` block may compose with `mcp` (hybrid) but not with `api`
 
 That gives you a predictable composition model:
 
@@ -78,6 +78,7 @@ That gives you a predictable composition model:
 - REST plus MCP
 - GraphQL plus MCP
 - plugin only
+- plugin plus MCP (hybrid)
 
 ## The Shared Invocation Broker
 

--- a/docs/pages/concepts/plugin-packaging.mdx
+++ b/docs/pages/concepts/plugin-packaging.mdx
@@ -10,8 +10,7 @@ A minimal provider package manifest looks like this:
 
 ```json
 {
-  "schema_version": 1,
-  "id": "example-provider",
+  "source": "github.com/your-org/your-repo/example-provider",
   "version": "1.0.0",
   "display_name": "Example Provider",
   "description": "Minimal packaged provider",
@@ -41,6 +40,7 @@ A minimal provider package manifest looks like this:
 
 The important ideas are:
 
+- `source` identifies the plugin in the managed artifact system
 - the package declares which kinds it supports
 - the manifest names platform-specific artifacts
 - entrypoints point at one of those packaged artifacts
@@ -52,7 +52,6 @@ UI plugins use the `webui` kind. They contain static assets instead of executabl
 
 ```json
 {
-  "schema_version": 2,
   "source": "github.com/your-org/your-repo/console",
   "version": "1.0.0",
   "kinds": ["webui"],
@@ -62,7 +61,7 @@ UI plugins use the `webui` kind. They contain static assets instead of executabl
 }
 ```
 
-Web UI manifests require schema version 2, have no `artifacts` or `entrypoints`, and cannot be combined with `provider` or `runtime` kinds. See [UI Plugins](/concepts/ui-plugins) for the full workflow.
+Web UI manifests have no `artifacts` or `entrypoints` and cannot be combined with `provider` or `runtime` kinds. See [UI Plugins](/concepts/ui-plugins) for the full workflow.
 
 ## Creating A Package
 

--- a/docs/pages/concepts/security.mdx
+++ b/docs/pages/concepts/security.mdx
@@ -1,0 +1,326 @@
+# Security Model
+
+Gestalt sits between callers and upstream APIs. It authenticates users, stores encrypted credentials, enforces egress policy, and isolates plugin processes. This page describes the trust boundaries, cryptographic primitives, and security-relevant configuration.
+
+## Trust Boundaries
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                      INTERNET                           │
+└────────────────────────┬────────────────────────────────┘
+                         │
+                    ┌────▼────┐
+                    │ Platform │  session_token cookie
+                    │   Auth   │  or Authorization: Bearer
+                    └────┬────┘
+                         │
+           ┌─────────────▼─────────────┐
+           │         gestaltd          │
+           │                           │
+           │  ┌─────────┐ ┌─────────┐  │
+           │  │ Invoker │ │  MCP    │  │
+           │  │ (Broker)│ │ Server  │  │
+           │  └────┬────┘ └────┬────┘  │
+           │       │           │       │
+           │  ┌────▼───────────▼────┐  │
+           │  │   Egress Policy     │  │
+           │  │   Enforcement       │  │
+           │  └────┬───────────┬────┘  │
+           └───────┼───────────┼───────┘
+                   │           │
+         ┌─────────▼──┐  ┌────▼──────────┐
+         │  Upstream   │  │   Plugin      │
+         │  APIs       │  │   Processes   │
+         │ (REST/GQL/  │  │  (gRPC over   │
+         │  MCP)       │  │  Unix socket) │
+         └────────────┘  └───────────────┘
+```
+
+Four trust boundaries:
+
+| Boundary | What crosses it | Protection |
+| --- | --- | --- |
+| Internet → Gestalt | User requests | Platform auth (session or API token) |
+| Gestalt → upstream APIs | OAuth tokens, API keys | Egress policy, credential encryption, TLS |
+| Gestalt → plugins | Config, operation requests | Process isolation, Unix socket, scoped capabilities |
+| Operator → Gestalt | Config, encryption key, secrets | Secret manager, env var expansion, `secret://` refs |
+
+## Encryption at Rest
+
+All integration tokens (OAuth access tokens, refresh tokens) are encrypted before storage using AES-256-GCM.
+
+```
+server.encryption_key
+        │
+        ▼
+   ┌─────────┐
+   │ Argon2id │  (3 iterations, 64 MiB, 4 threads)
+   │  or hex  │  (64-char hex string used directly)
+   └────┬────┘
+        │
+        ▼
+  32-byte AES key
+        │
+        ▼
+   ┌─────────┐
+   │ AES-256 │  random 12-byte nonce per encryption
+   │   GCM   │  authenticated encryption (AEAD)
+   └─────────┘
+```
+
+The `server.encryption_key` is the root deployment secret. Gestalt derives all cryptographic material from it:
+
+- **AES-256-GCM key** for encrypting integration tokens and staged connections
+- **State secret** for encrypting OAuth state parameters and PKCE verifiers
+
+If the encryption key is a 64-character hex string, it is decoded directly as a 32-byte key. Otherwise, Argon2id derives a 32-byte key from the string.
+
+Every encryption operation generates a fresh random nonce using `crypto/rand`. Ciphertexts are base64-encoded for storage. GCM provides authenticated encryption -- tampering with stored ciphertexts is detected at decryption time.
+
+### What is encrypted
+
+| Data | Storage |
+| --- | --- |
+| OAuth access tokens | AES-256-GCM encrypted |
+| OAuth refresh tokens | AES-256-GCM encrypted |
+| Staged connection tokens | AES-256-GCM encrypted |
+| OAuth state parameters | AES-256-GCM encrypted (URL-safe encoding, 10-minute TTL) |
+| API tokens | SHA-256 hashed (one-way, not reversible) |
+| User emails, display names | Plaintext |
+| Token metadata JSON | Plaintext |
+
+## Token Lifecycle
+
+### Platform Sessions
+
+```
+Browser ──POST /auth/login──▶ Gestalt ──redirect──▶ Identity Provider
+                                                          │
+Browser ◀──set session_token cookie──── Gestalt ◀──callback──┘
+```
+
+1. User initiates login via `POST /api/v1/auth/login`
+2. Gestalt redirects to the identity provider (Google, OIDC)
+3. Identity provider redirects back to `/api/v1/auth/login/callback`
+4. Gestalt validates the callback, checks `email_verified`, and issues a session token
+5. Session token is set as an HTTP cookie (`session_token`)
+
+Session tokens are validated by the platform auth provider on every request.
+
+Cookie properties:
+
+| Property | Value |
+| --- | --- |
+| `HttpOnly` | `true` (prevents JavaScript access) |
+| `Secure` | `true` when `server.base_url` starts with `https://`, `false` otherwise |
+| `SameSite` | `Lax` (prevents cross-site form submission, allows top-level navigation) |
+| `Path` | `/` |
+| `MaxAge` | 24 hours (configurable per auth provider) |
+
+### API Tokens
+
+```
+POST /api/v1/tokens
+        │
+        ▼
+  Generate 32 random bytes (crypto/rand)
+  Prefix with gst_api_
+        │
+        ├──▶ Return plaintext to caller (once, never stored)
+        │
+        └──▶ SHA-256 hash → store in datastore
+```
+
+- Plaintext is returned exactly once at creation time
+- Only the SHA-256 hash is stored -- tokens cannot be recovered from the datastore
+- Default TTL: 30 days (configurable via `server.api_token_ttl`)
+- Revocable individually (`DELETE /api/v1/tokens/{id}`) or in bulk (`DELETE /api/v1/tokens`)
+
+### Integration Tokens (OAuth)
+
+```
+POST /auth/start-oauth
+        │
+        ▼
+  Build OAuth state (user ID, integration, connection, PKCE verifier)
+  Encrypt state with AES-256-GCM (10-minute TTL)
+        │
+        ▼
+  Gestalt ──redirect with encrypted state──▶ Upstream OAuth Provider
+                                                    │
+  Gestalt ◀──callback with code + encrypted state────┘
+        │
+        ▼
+  Decrypt and validate state (TTL, user ID, integration match)
+  Exchange authorization code for tokens (+ PKCE verifier if applicable)
+        │
+        ▼
+  Encrypt access + refresh tokens separately (AES-256-GCM)
+        │
+        ▼
+  Store encrypted tokens in datastore
+```
+
+- OAuth state is encrypted and time-limited (10-minute expiry) to prevent state injection attacks
+- Access and refresh tokens are encrypted separately before storage
+- Automatic refresh when the access token expires within 5 minutes
+- Refresh errors are tracked; repeated failures do not retry indefinitely
+- Tokens are keyed by `(user_id, integration, connection, instance)`
+- Plaintext tokens are held in memory only during credential resolution
+
+## Request Authentication Flow
+
+```
+Request arrives
+      │
+      ├─ Check session_token cookie
+      │      │
+      │      ├─ Valid session? ──▶ Authenticated (SourceSession)
+      │      └─ Invalid/missing
+      │
+      ├─ Check Authorization: Bearer header
+      │      │
+      │      ├─ gst_api_ prefix? ──▶ SHA-256 hash → lookup in datastore
+      │      │                              │
+      │      │                     ──▶ Authenticated (SourceAPIToken)
+      │      │
+      │      └─ Other token? ──▶ Validate with auth provider
+      │                                │
+      │                       ──▶ Authenticated (SourceSession)
+      │
+      └─ No credentials ──▶ 401 Unauthorized
+```
+
+For proxy bindings, `Proxy-Authorization: Bearer` is checked first, then `Authorization: Bearer`. A `407 Proxy Authentication Required` is returned instead of `401`.
+
+## Egress Policy Enforcement
+
+Egress policies control what outbound requests Gestalt makes on behalf of callers. Policy evaluation happens **before** credential resolution -- denied requests never trigger secret fetches or token decryption.
+
+```
+Invocation request
+        │
+        ▼
+  Build PolicyInput:
+    subject (user/identity/system)
+    target  (provider, operation, method, host, path)
+        │
+        ▼
+  Evaluate rules (first match wins)
+        │
+        ├─ Rule matches with action: allow ──▶ Resolve credentials ──▶ Execute
+        ├─ Rule matches with action: deny  ──▶ Block (no credential fetch)
+        └─ No rule matches ──▶ Apply default_action
+```
+
+Policy rules match on any combination of:
+
+| Field | Matches against |
+| --- | --- |
+| `subject_kind` | `user`, `identity`, or `system` |
+| `subject_id` | Specific user email or token ID |
+| `provider` | Integration provider name |
+| `operation` | Operation name |
+| `method` | HTTP method |
+| `host` | Outbound hostname |
+| `path_prefix` | Outbound URL path prefix |
+
+Empty fields are wildcards. The first matching rule wins. If no rule matches, `egress.default_action` applies (default: `allow`).
+
+### Credential Injection
+
+Egress credential grants inject secrets into outbound requests. Credentials are resolved from the secret manager at request time, not at config load time.
+
+| `auth_style` | Behavior |
+| --- | --- |
+| `bearer` | Sets `Authorization: Bearer <secret>` |
+| `basic` | Sets `Authorization: Basic <secret>` |
+| `raw` | Sets `Authorization: <secret>` |
+
+## Security Headers
+
+Gestalt sets the following headers on every response:
+
+| Header | Value |
+| --- | --- |
+| `X-Content-Type-Options` | `nosniff` |
+| `X-Frame-Options` | `DENY` |
+| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains` (HTTPS only) |
+
+## Plugin Isolation
+
+Plugins run as separate OS processes. Communication happens over temporary Unix sockets using gRPC.
+
+```
+gestaltd process
+      │
+      ├── creates /tmp/gestalt-*.sock
+      ├── sets GESTALT_PLUGIN_SOCKET env var
+      ├── launches plugin binary as child process
+      │
+      ▼
+ Plugin process
+      │
+      ├── connects to socket
+      ├── receives name + config via gRPC
+      └── serves ProviderPlugin or RuntimePlugin service
+```
+
+Isolation properties:
+
+- **No shared memory**: communication is message-passing over a socket
+- **No direct datastore access**: plugins cannot read or write tokens
+- **No direct network access**: all plugin HTTP requests go through the host's `ProxyHTTP` callback, which validates URLs (blocks private IPs unless `allowed_hosts` is set) and strips sensitive headers
+- **Sanitized environment**: only safe variables are passed to plugin processes (`PATH`, `HOME`, `TMPDIR`, `LANG`, `TZ`, `SSL_CERT_*`, plus user-configured `env`)
+- **Scoped capabilities**: runtime plugins can only invoke providers listed in `runtimes.<name>.providers`
+- **Credential passthrough**: the host passes a single access token per invocation, not the full credential store
+- **Process lifecycle**: plugins are terminated when `gestaltd` shuts down (SIGTERM, then SIGKILL after timeout)
+
+## Webhook Signature Verification
+
+Webhook bindings with `auth_mode: signed` verify request authenticity using HMAC-SHA256:
+
+```
+expected = HMAC-SHA256(signing_secret, request_body)
+provided = hex-decode(signature_header)
+
+Verification: constant-time comparison (hmac.Equal)
+```
+
+Constant-time comparison prevents timing side-channel attacks.
+
+## Proxy Header Sanitization
+
+The proxy binding strips the following headers before forwarding requests upstream:
+
+- `Authorization` (replaced by egress credential injection)
+- `Cookie`
+- `Host`
+- `Proxy-Authorization`
+- `X-Forwarded-*` headers
+- Hop-by-hop headers (`TE`, `Trailer`, `Transfer-Encoding`, `Upgrade`)
+
+Request bodies are limited to 1 MB through the proxy.
+
+## Operator Responsibilities
+
+These configuration choices directly affect the security posture of a deployment:
+
+| Setting | Impact |
+| --- | --- |
+| `server.encryption_key` | Protect this value. If compromised, all stored integration tokens can be decrypted. Use a strong random string or a 64-character hex key. Must be the same across all instances in a cluster. |
+| `auth.provider` | `none` disables all authentication. Never use in production. |
+| `server.base_url` | Must match the public URL exactly. OAuth callback URLs are derived from it. A mismatch can break auth flows or create open-redirect risks. |
+| `egress.default_action` | Set to `deny` in production and explicitly allow required paths. |
+| TLS termination | Gestalt does not terminate TLS itself. Deploy behind a reverse proxy (Nginx, Envoy, cloud load balancer) that handles TLS. |
+| `secrets.provider` | Use `gcp_secret_manager` or `file` in production. `env` is acceptable but secrets may appear in process listings. |
+| `datastore.provider` | Use Postgres or another SQL datastore in production. SQLite is single-writer and not suitable for multi-replica deployments. |
+
+## Known Limitations
+
+- **No built-in key rotation**: changing `server.encryption_key` requires re-encrypting all stored tokens. There is no automated migration.
+- **No session revocation**: platform sessions cannot be explicitly invalidated. They expire based on the auth provider's TTL (default 24 hours).
+- **No built-in rate limiting**: configure rate limiting at the load balancer or reverse proxy layer.
+- **No CORS configuration**: Gestalt does not set CORS headers. Configure CORS at the reverse proxy if cross-origin browser access is needed.
+- **Plugin DNS rebinding**: the host blocks obvious private IPs for plugin HTTP requests, but DNS rebinding or HTTP redirects could potentially bypass this check. Use `allowed_hosts` to restrict plugin network access to specific domains.
+- **Database encryption is application-level**: Gestalt encrypts tokens before storage, but the database itself may store metadata in plaintext. Ensure the database has appropriate access controls and encrypted backups.

--- a/docs/pages/concepts/ui-plugins.mdx
+++ b/docs/pages/concepts/ui-plugins.mdx
@@ -36,7 +36,6 @@ my-ui-plugin/
 
 ```json
 {
-  "schema_version": 2,
   "source": "github.com/your-org/your-repo/console",
   "version": "1.0.0",
   "display_name": "Custom Console",

--- a/docs/pages/deploy/kubernetes.mdx
+++ b/docs/pages/deploy/kubernetes.mdx
@@ -131,6 +131,6 @@ Enable `pluginInit.enabled` when any of these are true:
 
 - an integration uses a remote OpenAPI spec
 - an integration uses a remote GraphQL schema
-- an integration or runtime uses `plugin.package`
+- an integration or runtime uses `plugin.package` or `plugin.source`
 
 If none of those apply, you can keep it off and still use locked startup.

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -57,7 +57,7 @@ Visit `http://localhost:8080`.
 
 ### Inspect the default environment
 
-The generated config uses `auth.provider: none`, so no sign-in is required. The built-in `echo` provider is available for local experimentation.
+The generated config uses `auth.provider: none`, so no sign-in is required. Add an integration to start building.
 </Steps>
 
 ## 3. Switch To An Explicit Config

--- a/docs/pages/reference/built-in-plugins.mdx
+++ b/docs/pages/reference/built-in-plugins.mdx
@@ -1,21 +1,21 @@
 # Built-in Plugins
 
-This page lists the components that the `gestaltd` binary actually registers today.
+Components registered by the `gestaltd` binary at startup.
 
 ## Auth Providers
 
-| Name | Notes |
+| Name | Purpose |
 | --- | --- |
-| `none` | No-auth mode used by the generated no-config startup path. |
-| `google` | Google OAuth login for the Gestalt platform. |
-| `local` | Built-in authenticated provider for local development without an external identity system. |
-| `oidc` | Generic OIDC platform auth provider. |
+| `none` | Disables platform authentication. Every request is treated as anonymous. |
+| `local` | Single-user auth for local development. No external identity provider required. |
+| `google` | Google OAuth 2.0 platform login. Supports `allowed_domains` restriction. |
+| `oidc` | Generic OpenID Connect. Works with Okta, Auth0, Azure AD, Keycloak, and others. |
 
 ## Datastores
 
-| Name | Notes |
+| Name | Purpose |
 | --- | --- |
-| `sqlite` | File-backed datastore. Best for local or single-node deployments. |
+| `sqlite` | File-backed. Best for local or single-node deployments. |
 | `postgres` | Recommended production datastore. |
 | `mysql` | SQL-backed production datastore. |
 | `dynamodb` | DynamoDB-backed datastore. |
@@ -26,33 +26,40 @@ This page lists the components that the `gestaltd` binary actually registers tod
 
 ## Secret Managers
 
-| Name | Notes |
+| Name | Purpose |
 | --- | --- |
-| `env` | Resolve secrets from environment variables. |
-| `file` | Resolve secrets from files in a configured directory. |
-| `gcp_secret_manager` | Resolve secrets from Google Secret Manager. |
+| `env` | Resolves secrets from environment variables. Default when `secrets` is omitted. |
+| `file` | Resolves secrets from files in a configured directory. |
+| `gcp_secret_manager` | Resolves secrets from Google Cloud Secret Manager. |
+
+## Telemetry Providers
+
+| Name | Purpose |
+| --- | --- |
+| `stdout` | Prints traces and logs to standard output. Default when `telemetry` is omitted. |
+| `otlp` | Exports traces, metrics, and logs via OpenTelemetry Protocol. |
+| `noop` | Disables all telemetry collection. |
 
 ## Bindings
 
-| Name | Notes |
+| Name | Purpose |
 | --- | --- |
-| `webhook` | Inbound HTTP route that can optionally forward into a provider operation. |
-| `proxy` | HTTP proxy surface with egress policy and credential resolution. |
+| `webhook` | Inbound HTTP endpoint with optional HMAC signature verification and provider forwarding. |
+| `proxy` | HTTP proxy surface with egress policy enforcement and credential injection. |
 
 ## Runtimes
 
-| Name | Notes |
-| --- | --- |
-| `echo` | Built-in runtime always registered by the server binary. |
+No built-in runtimes are registered. Define custom runtimes using the `plugin` field under `runtimes` in the config file. See [Plugin Protocol](/concepts/plugin-protocol) for the runtime plugin contract.
 
-## Built-In Named Providers
+## Named Providers
 
-| Name | Notes |
-| --- | --- |
-| `bigquery` | Built-in named provider registered by the server binary. |
-| `jira` | Built-in named provider registered by the server binary. |
-| `echo` | Built-in provider always registered by the server binary. |
+| Name | Type | Purpose |
+| --- | --- | --- |
+| `bigquery` | Declarative (YAML) | Google BigQuery data warehouse operations. |
+| `jira` | Declarative (YAML) | Jira Cloud issue management. |
 
-## What This Page Does Not Mean
+Named providers are pre-registered in the binary and referenced by name in integrations. Declarative providers define their operations, auth, and base URL in YAML manifests under `plugins/providers/`.
 
-This page only lists components that are actually wired into `cmd/gestaltd`. Test fixtures, examples, and helper packages elsewhere in the repo are not runtime registration.
+## Scope
+
+This page lists only components wired into `cmd/gestaltd`. Test fixtures, examples, and the Slack plugin manifest (`plugins/slack/plugin.yaml`) ship in the repository but are not compiled into the binary.

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -1,73 +1,71 @@
 # CLI
 
-The most important CLI surface in this repo is the `gestaltd` server binary.
+The `gestaltd` server binary.
 
-## `gestaltd`
-
-### Usage
+## Usage
 
 ```sh
 gestaltd [--config PATH]
-gestaltd plugin <command> [flags]
 gestaltd serve [--config PATH] [--locked]
 gestaltd bundle --config PATH --output DIR
 gestaltd validate [--config PATH] [--init]
+gestaltd plugin package [flags]
+gestaltd version
 ```
 
-## Command Meanings
+## Commands
 
-| Command | What it does |
+| Command | Purpose |
 | --- | --- |
-| `gestaltd` | Default start command. Can auto-generate a local config and can auto-prepare missing state. |
+| `gestaltd` | Default start. Auto-generates a local config if none exists. Auto-prepares missing state. |
 | `gestaltd serve` | Start the server from an explicit config path. |
-| `gestaltd serve --locked` | Require exact prepared state. Do not auto-prepare. |
-| `gestaltd bundle` | Resolve remote provider artifacts and packaged plugins into a self-contained output directory. |
+| `gestaltd serve --locked` | Start the server. Fail if prepared state is missing or stale. |
+| `gestaltd bundle` | Resolve remote artifacts and packaged plugins into a self-contained output directory. |
 | `gestaltd validate` | Load and validate config without starting the server. |
-| `gestaltd plugin package` | Build a distributable plugin archive from a manifest directory. |
+| `gestaltd plugin package` | Build a distributable plugin archive. |
+| `gestaltd version` | Print the binary version and exit. |
 
 ## Default Command Behavior
 
-The plain `gestaltd` command has one extra convenience feature:
+The plain `gestaltd` command has one extra convenience:
 
-- if you do not pass `--config`
-- and no config file can be found in the normal search path
-- it generates `~/.gestalt/config.yaml`
+- If you do not pass `--config` and no config file exists in the search path, it generates `~/.gestalt/config.yaml`
 
-That generated config is intentionally local-only:
+That generated config is local-only:
 
 - `none` auth
-- SQLite
+- SQLite datastore
 - `env` secrets
-- a generated `server.encryption_key`
+- A generated `server.encryption_key`
 
 ## Config Path Resolution
 
-When a command needs a config path, Gestalt resolves it in this order:
+When a command needs a config path:
 
-1. `--config`
-2. `GESTALT_CONFIG`
+1. `--config` flag
+2. `GESTALT_CONFIG` environment variable
 3. `./config.yaml`
 4. `~/.gestalt/config.yaml`
 5. `/etc/gestalt/config.yaml`
 
 ## `bundle`
 
-`gestaltd bundle --config ./gestalt.yaml --output ./bundle` produces a self-contained output directory containing:
+```sh
+gestaltd bundle --config ./gestalt.yaml --output ./bundle
+```
 
-- the bundled config
+Produces a self-contained output directory:
+
+- The bundled config
 - `gestalt.lock.json`
-- `.gestalt/providers/*.json`
-- `.gestalt/plugins/...`
+- `.gestalt/providers/*.json` (prepared provider artifacts)
+- `.gestalt/plugins/...` (installed plugin packages)
 
-Use it whenever your config contains:
-
-- remote REST upstreams
-- remote GraphQL upstreams
-- `plugin.package`
+Run `bundle` whenever your config contains remote REST upstreams, remote GraphQL upstreams, `plugin.package`, or `plugin.source`.
 
 ## `serve --locked`
 
-Use locked mode in production:
+Production startup:
 
 ```sh
 gestaltd bundle --config ./gestalt.yaml --output ./bundle
@@ -78,21 +76,61 @@ If prepared state is missing or stale, startup fails instead of mutating local s
 
 ## `validate`
 
-`gestaltd validate` is non-mutating. It expects lock state to already exist when the config depends on prepared artifacts. Bundle first, then validate the bundled output:
+Non-mutating config validation. Expects lock state to already exist when the config depends on prepared artifacts.
 
 ```sh
 gestaltd bundle --config ./gestalt.yaml --output ./bundle
 gestaltd validate --config ./bundle/gestalt.yaml
 ```
 
+### `validate --init`
+
+Run initialization before validating. Useful when you want to validate a config that has not been bundled yet:
+
+```sh
+gestaltd validate --init --config ./gestalt.yaml
+```
+
 ## `plugin package`
 
-Build a plugin archive from a manifest directory:
+Two packaging flows:
+
+### From a manifest directory
+
+Package an existing plugin directory that already contains a `plugin.json` manifest:
 
 ```sh
 gestaltd plugin package --input ./build/my-plugin --output ./dist/my-plugin.tar.gz
 ```
 
-## Companion Client
+### From a pre-built binary
 
-The repo also contains a separate `gestalt` client binary, but the deployment and platform model documented here are centered on `gestaltd`.
+Scaffold a manifest and package a binary in one step:
+
+```sh
+gestaltd plugin package \
+  --binary ./my-plugin \
+  --source github.com/myorg/my-repo/my-plugin \
+  --output ./my-plugin.tar.gz
+```
+
+| Flag | Default | Purpose |
+| --- | --- | --- |
+| `--binary` | — | Path to pre-built binary. |
+| `--source` | — | Plugin source identifier (`github.com/owner/repo/plugin`). Required with `--binary`. |
+| `--output` | — | Path to write the `.tar.gz` archive. |
+| `--kind` | `provider` | Plugin kind: `provider` or `runtime`. |
+| `--os` | Current platform | Target OS for the artifact. |
+| `--arch` | Current platform | Target architecture. |
+| `--version` | `0.0.0-alpha.1` | Manifest version. Must be valid SemVer. |
+
+Cross-compilation example:
+
+```sh
+GOOS=linux GOARCH=amd64 go build -o ./my-plugin-linux .
+gestaltd plugin package \
+  --binary ./my-plugin-linux \
+  --source github.com/myorg/my-repo/my-plugin \
+  --os linux --arch amd64 \
+  --output ./my-plugin.tar.gz
+```

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -1,6 +1,6 @@
 # Config File
 
-This page is the authoritative reference for `gestaltd` configuration.
+Authoritative reference for `gestaltd` configuration.
 
 ## Top-Level Shape
 
@@ -19,16 +19,14 @@ ui: {}
 
 ## Load Semantics
 
-Before you get into individual fields, these global rules matter:
-
 - `${ENV_VAR}` expansion happens before YAML decode
-- if `${ENV_VAR}` is unset and `ENV_VAR_FILE` exists, Gestalt reads the value from that file
-- unknown YAML fields are rejected
+- If `${ENV_VAR}` is unset and `ENV_VAR_FILE` is set, Gestalt reads the value from that file path
+- Unknown YAML fields are rejected
 - `server.port` defaults to `8080`
 - `secrets.provider` defaults to `env`
 - `telemetry.provider` defaults to `stdout`
-- relative paths resolve relative to the config file directory
-- `secret://...` values are resolved later during bootstrap, not during raw YAML parsing
+- Relative paths resolve relative to the config file directory
+- `secret://...` values are resolved during bootstrap, not during YAML parsing
 
 ## `server`
 
@@ -37,13 +35,15 @@ server:
   port: 8080
   base_url: https://gestalt.example.com
   encryption_key: secret://gestalt-encryption-key
+  api_token_ttl: 30d
 ```
 
-| Field | Required | Notes |
-| --- | --- | --- |
-| `port` | no | Defaults to `8080`. |
-| `base_url` | no, but strongly recommended | Used to derive OAuth callback URLs when explicit redirect URLs are missing. |
-| `encryption_key` | yes | Root deployment secret used for encryption and derived session material. |
+| Field | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `port` | No | `8080` | HTTP listen port. |
+| `base_url` | No | — | Derives OAuth callback URLs when explicit redirect URLs are omitted. |
+| `encryption_key` | Yes | — | Root deployment secret. Used for encryption and derived session material. |
+| `api_token_ttl` | No | `30d` | Lifetime of newly issued API tokens. Accepts Go duration strings (`1h`, `720h`) and day suffixes (`30d`). |
 
 ## `auth`
 
@@ -54,7 +54,7 @@ auth:
   provider: none
 ```
 
-`none` disables platform authentication entirely. Every request is treated as coming from a single anonymous user. That is useful for local development, demos, and simple single-user setups.
+Disables platform authentication. Every request is treated as a single anonymous user.
 
 ### `local`
 
@@ -65,9 +65,9 @@ auth:
     email: local@example.com
 ```
 
-| Field | Required | Notes |
-| --- | --- | --- |
-| `email` | no | Defaults to `local@gestalt.local`. |
+| Field | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `email` | No | `local@gestalt.local` | Identity of the single local user. |
 
 ### `google`
 
@@ -82,12 +82,14 @@ auth:
       - example.com
 ```
 
-| Field | Required | Notes |
-| --- | --- | --- |
-| `client_id` | yes | Google OAuth client ID. |
-| `client_secret` | yes | Google OAuth client secret. |
-| `redirect_url` | no | If omitted and `server.base_url` is set, Gestalt derives the login callback. |
-| `allowed_domains` | no | Restrict login to selected email domains. |
+| Field | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `client_id` | Yes | — | Google OAuth client ID. |
+| `client_secret` | Yes | — | Google OAuth client secret. |
+| `redirect_url` | No | Derived from `server.base_url` | Login callback URL. |
+| `allowed_domains` | No | — | Restrict login to specific email domains. |
+
+Google checks `email_verified` on every login. Unverified accounts are rejected.
 
 ### `oidc`
 
@@ -111,18 +113,20 @@ auth:
     display_name: Company SSO
 ```
 
-| Field | Required | Notes |
-| --- | --- | --- |
-| `issuer_url` | yes | OIDC discovery base URL. |
-| `client_id` | yes | OIDC client ID. |
-| `client_secret` | no in some PKCE setups, but commonly set | OIDC client secret. |
-| `redirect_url` | no | Derived from `server.base_url` when omitted. |
-| `allowed_domains` | no | Optional email-domain allowlist. |
-| `scopes` | no | Defaults to `openid`, `email`, `profile`. |
-| `session_secret` | yes | Secret used to sign OIDC-backed session tokens. |
-| `session_ttl` | no | Defaults to `24h`. |
-| `pkce` | no | Enables PKCE for the platform login flow. |
-| `display_name` | no | Defaults to `SSO`. |
+| Field | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `issuer_url` | Yes | — | OIDC discovery base URL. |
+| `client_id` | Yes | — | OIDC client ID. |
+| `client_secret` | Conditional | — | OIDC client secret. May be omitted for PKCE-only public clients. |
+| `redirect_url` | No | Derived from `server.base_url` | Login callback URL. |
+| `allowed_domains` | No | — | Email-domain allowlist. |
+| `scopes` | No | `openid`, `email`, `profile` | OIDC scopes to request. |
+| `session_secret` | Yes | — | Secret for signing session tokens. |
+| `session_ttl` | No | `24h` | Session token lifetime. |
+| `pkce` | No | `false` | Enable PKCE for the login flow. |
+| `display_name` | No | `SSO` | Name shown in the login UI. |
+
+OIDC checks `email_verified` when the claim is present. Unverified accounts are rejected.
 
 ## `datastore`
 
@@ -133,14 +137,14 @@ datastore:
     dsn: ${DATABASE_URL}
 ```
 
-| Provider | Config fields | Notes |
+| Provider | Config fields | Purpose |
 | --- | --- | --- |
-| `sqlite` | `path` | Defaults to `./gestalt.db` if the provider itself applies its default. Good for local or single-node use. |
-| `postgres` | `dsn` | Recommended production choice. |
+| `sqlite` | `path` | Defaults to `./gestalt.db`. Single-node deployments. |
+| `postgres` | `dsn` | Recommended production datastore. |
 | `mysql` | `dsn` | SQL-backed production option. |
 | `dynamodb` | `table`, `region`, `endpoint` | `table` defaults to `gestalt`. |
 | `mongodb` | `uri`, `database` | `database` defaults to `gestalt`. |
-| `oracle` | `dsn` | SQL-backed enterprise option. |
+| `oracle` | `dsn` | Enterprise SQL option. |
 | `firestore` | `project_id`, `database` | Firestore-backed deployment. |
 | `sqlserver` | `dsn` | SQL Server-backed deployment. |
 
@@ -155,21 +159,21 @@ secrets:
     dir: /etc/gestalt-secrets
 ```
 
-| Provider | Config fields | Notes |
+| Provider | Config fields | Purpose |
 | --- | --- | --- |
 | `env` | `prefix` | Reads secrets from environment variables. |
 | `file` | `dir` | Reads one secret per file from a base directory. |
 | `gcp_secret_manager` | `project`, `version` | `version` defaults to `latest`. |
 
-Any string value outside `secrets.config` may use:
+Any string value outside `secrets.config` may use the `secret://` prefix:
 
 ```yaml
-secret://name-of-secret
+encryption_key: secret://name-of-secret
 ```
 
 ## `telemetry`
 
-Controls observability: distributed traces, metrics, and structured logs. Gestalt uses [OpenTelemetry](https://opentelemetry.io) under the hood. Every HTTP request, broker invocation, and plugin gRPC call is automatically traced.
+Controls distributed traces, metrics, and structured logs. Gestalt uses [OpenTelemetry](https://opentelemetry.io) under the hood. Every HTTP request, broker invocation, and plugin gRPC call is automatically traced.
 
 ### `stdout`
 
@@ -181,12 +185,12 @@ telemetry:
     level: info
 ```
 
-| Field | Required | Notes |
-| --- | --- | --- |
-| `format` | no | `text` (default) or `json`. |
-| `level` | no | `debug`, `info` (default), `warn`, or `error`. |
+| Field | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `format` | No | `text` | `text` or `json`. |
+| `level` | No | `info` | `debug`, `info`, `warn`, or `error`. |
 
-`stdout` prints traces and metrics to standard output. Good for local development and debugging. This is the default provider when `telemetry` is omitted.
+Prints traces and metrics to standard output. Default provider when `telemetry` is omitted.
 
 ### `otlp`
 
@@ -211,19 +215,19 @@ telemetry:
       level: info
 ```
 
-| Field | Required | Notes |
-| --- | --- | --- |
-| `endpoint` | no | OTLP collector address. Uses the SDK default when omitted. |
-| `protocol` | no | `grpc` (default) or `http`. |
-| `service_name` | no | OpenTelemetry service name. Defaults to `gestaltd`. |
-| `insecure` | no | Skip TLS verification. Defaults to `false`. |
-| `headers` | no | Extra headers sent with every export request. Useful for auth tokens. |
-| `resource_attributes` | no | Arbitrary key-value pairs attached to every signal as resource attributes. |
-| `traces.sampling_ratio` | no | Fraction of traces to sample, `0.0` to `1.0`. Defaults to `1.0` (all traces). |
-| `metrics.interval` | no | How often metrics are exported. Defaults to `60s`. |
-| `logs.level` | no | Minimum log level exported. Defaults to `info`. |
+| Field | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `endpoint` | No | SDK default | OTLP collector address. |
+| `protocol` | No | `grpc` | `grpc` or `http`. |
+| `service_name` | No | `gestaltd` | OpenTelemetry service name. |
+| `insecure` | No | `false` | Skip TLS verification. |
+| `headers` | No | — | Extra headers on every export request. |
+| `resource_attributes` | No | — | Key-value pairs attached as resource attributes. |
+| `traces.sampling_ratio` | No | `1.0` | Fraction of traces to sample, `0.0` to `1.0`. |
+| `metrics.interval` | No | `60s` | Metric export interval. |
+| `logs.level` | No | `info` | Minimum exported log level. |
 
-`otlp` exports traces, metrics, and logs to any OpenTelemetry-compatible collector (Jaeger, Grafana Alloy, Datadog Agent, etc.) using the OTLP protocol.
+Exports to any OpenTelemetry-compatible collector (Jaeger, Grafana Alloy, Datadog Agent).
 
 ### `noop`
 
@@ -232,27 +236,23 @@ telemetry:
   provider: noop
 ```
 
-Disables all telemetry. No traces, metrics, or logs are collected or exported. The instrumentation points remain in the code but produce zero overhead.
+Disables all telemetry. Instrumentation points remain but produce zero overhead.
 
-### What gets traced
-
-Gestalt automatically creates distributed trace spans at three levels:
+### Trace spans
 
 | Layer | Span name | Key attributes |
 | --- | --- | --- |
-| HTTP | `gestaltd: {method} {route}` | Standard HTTP semantic conventions (method, route, status code) |
+| HTTP | `gestaltd: {method} {route}` | Standard HTTP semantic conventions |
 | Broker | `broker.invoke` | `gestalt.provider`, `gestalt.operation`, `gestalt.user_id`, `gestalt.connection_mode` |
-| gRPC plugin | Per-RPC spans | Standard gRPC semantic conventions (service, method, status) |
-
-Child spans are linked to their parent, so a single trace shows the full request lifecycle from HTTP through broker to plugin.
+| gRPC plugin | Per-RPC spans | Standard gRPC semantic conventions |
 
 ### Audit logs
 
-Audit log records are emitted as structured log entries with a `log.type=audit` attribute. When using the `otlp` provider, these can be routed to a dedicated audit backend by the OTel Collector using attribute-based filtering. See [Observability](/concepts/observability) for details.
+Audit records are emitted as structured log entries with `log.type=audit`. Route them to a dedicated audit backend using OTel Collector attribute-based filtering. See [Observability](/concepts/observability) for details.
 
 ## `integrations`
 
-Integrations are the main user-facing primitive. Each integration follows one of two patterns: declarative (`connections` + `api`/`mcp`) or plugin-only.
+Each integration follows one of three patterns: declarative (`connections` + `api`/`mcp`), plugin-only, or hybrid (plugin + `mcp`). See [Integrations](/concepts/integrations) for the conceptual model.
 
 ### Declarative integration
 
@@ -281,10 +281,10 @@ integrations:
         issues/list-for-authenticated-user:
 ```
 
-| Field | Notes |
+| Field | Purpose |
 | --- | --- |
 | `display_name`, `description` | Presentation metadata. |
-| `mcp_tool_prefix` | Prefix tool names when exposing this integration over MCP. |
+| `mcp_tool_prefix` | Prefix tool names on the MCP endpoint. |
 | `icon_file` | SVG path, resolved relative to the config file. |
 | `connections` | Named connections that own mode, auth, and params. |
 | `api` | REST or GraphQL surface. |
@@ -307,9 +307,9 @@ connections:
       client_secret: ${CLIENT_SECRET}
 ```
 
-| Field | Notes |
+| Field | Purpose |
 | --- | --- |
-| `mode` | `user`, `identity`, or `none`. All connections in an integration must share the same mode. |
+| `mode` | `user` (default), `identity`, `either`, or `none`. All connections in an integration must share the same mode. |
 | `params` | Named parameters callers supply when connecting. Used for URL template expansion. |
 | `auth` | Auth configuration for this connection. |
 
@@ -324,13 +324,13 @@ api:
     listThings:
 ```
 
-| Field | Notes |
+| Field | Purpose |
 | --- | --- |
 | `type` | `rest` or `graphql`. |
 | `openapi` | Required when `type: rest`. URL or local path to an OpenAPI document. |
 | `url` | Required when `type: graphql`. The GraphQL endpoint URL. |
 | `connection` | References a named connection in the same integration. |
-| `allowed_operations` | YAML map of operation name to an optional override object. Use a bare key to keep the upstream description. |
+| `allowed_operations` | Narrows exposed operations. Bare key keeps the upstream description. Object with `alias` and/or `description` overrides it. |
 
 ### `mcp`
 
@@ -338,16 +338,19 @@ api:
 mcp:
   url: https://mcp.example.com
   connection: mcp_conn
+  allowed_operations:
+    search:
 ```
 
-| Field | Notes |
+| Field | Purpose |
 | --- | --- |
 | `url` | Required. The upstream MCP server URL. |
 | `connection` | References a named connection in the same integration. |
+| `allowed_operations` | Optional. Narrows exposed tools. Same override syntax as `api`. |
 
 ### `auth`
 
-This block is used inside a connection.
+Auth configuration for a connection.
 
 ```yaml
 auth:
@@ -374,75 +377,76 @@ auth:
     - workspace_id
 ```
 
-Supported or notable fields:
+| Field | Purpose |
+| --- | --- |
+| `type` | `oauth2`, `manual`, or `mcp_oauth`. |
+| `authorization_url` | OAuth authorization endpoint. |
+| `token_url` | OAuth token endpoint. |
+| `client_id`, `client_secret` | OAuth client credentials. |
+| `redirect_url` | Override the derived callback URL. |
+| `client_auth` | How client credentials are sent: `body` (default) or `header`. |
+| `token_exchange` | Token request encoding: `form` (default) or `json`. |
+| `scopes` | OAuth scopes to request. |
+| `scope_param` | Query parameter name for scopes. Defaults to `scope`. Set to `user_scope` for Slack and other providers that use a non-standard parameter. |
+| `scope_separator` | Separator between scope values. Defaults to space. |
+| `pkce` | Enable Proof Key for Code Exchange. |
+| `authorization_params` | Extra query parameters on the authorization request. |
+| `token_params` | Extra parameters on the token exchange request. |
+| `refresh_params` | Extra parameters on the token refresh request. |
+| `accept_header` | `Accept` header for the token endpoint. |
+| `token_metadata` | Fields to extract from the token response and store as connection metadata. |
 
-- `type`
-- `authorization_url`
-- `token_url`
-- `client_id`, `client_secret`
-- `client_auth`
-- `token_exchange`
-- `scopes`
-- `scope_param` -- query parameter name for scopes (defaults to `scope`). Set to `user_scope` for Slack and other providers that use a non-standard parameter.
-- `scope_separator`
-- `pkce`
-- `authorization_params`
-- `token_params`
-- `refresh_params`
-- `accept_header`
-- `token_metadata`
-
-The normal auth types are `oauth2` and `manual`. `mcp_oauth` also exists as an advanced mode for MCP-driven OAuth discovery.
+`mcp_oauth` is an advanced mode for MCP-driven OAuth discovery. It delegates authorization URL and token URL resolution to the upstream MCP server.
 
 ### `plugin`
 
-Plugin-only integrations cannot also declare `connections`, `api`, or `mcp`.
+Plugin integrations delegate execution to an external binary. A plugin integration may optionally compose with an `mcp` surface (hybrid pattern) but cannot declare an `api` surface.
 
 ```yaml
 integrations:
   custom_tool:
     plugin:
-      package: ./custom-tool.tar.gz
+      command: ./my-plugin
 ```
 
 ```yaml
-plugin:
-  command: ./my-plugin
-  package: https://example.com/my-plugin.tar.gz
-  args:
-    - --verbose
-  env:
-    LOG_LEVEL: debug
-  config:
-    greeting: hello
+integrations:
+  custom_tool:
+    plugin:
+      source: github.com/your-org/your-repo/custom-tool
+      version: 1.0.0
+      config:
+        greeting: hello
 ```
 
-| Field | Notes |
+| Field | Purpose |
 | --- | --- |
-| `command` | Local executable path. Mutually exclusive with `package`. |
-| `package` | Local directory, local archive, or HTTPS URL. Mutually exclusive with `command`. |
-| `args` | Only valid with `command`. |
-| `env` | Extra plugin environment variables. |
-| `config` | Arbitrary plugin config payload. |
+| `command` | Local executable path. Mutually exclusive with `package` and `source`. |
+| `package` | Local directory, local archive, or HTTPS URL. Mutually exclusive with `command` and `source`. |
+| `source` | Managed plugin source address (`github.com/owner/repo/plugin`). Mutually exclusive with `command` and `package`. Requires `version`. |
+| `version` | Required with `source`. Must be valid SemVer. |
+| `args` | Command-line arguments. Only valid with `command`. |
+| `env` | Extra environment variables passed to the plugin process. |
+| `allowed_hosts` | Host allowlist for plugin network access. |
+| `config` | Arbitrary plugin config payload, validated against the plugin's config schema if one exists. |
+| `allowed_operations` | Narrows exposed operations. Same override syntax as `api.allowed_operations`. |
 
-Validation rules:
+### Hybrid integration (plugin + MCP)
 
-- exactly one of `command` or `package`
-- plain `http://` package URLs are rejected
-- plugin integrations cannot declare `connections`, `api`, or `mcp`
+```yaml
+integrations:
+  slack:
+    plugin:
+      source: github.com/valon-technologies/gestalt/slack
+      version: 0.0.1-alpha.3
+    mcp:
+      url: https://mcp.slack.com
+      connection: plugin
+```
+
+Setting `mcp.connection` to `plugin` reuses the plugin's OAuth token for the MCP surface. Declare explicit `connections` and reference one from `mcp.connection` for separate credentials.
 
 ## `runtimes`
-
-```yaml
-runtimes:
-  syncer:
-    type: echo
-    providers:
-      - github
-    config: {}
-```
-
-or:
 
 ```yaml
 runtimes:
@@ -455,12 +459,14 @@ runtimes:
       interval: 30s
 ```
 
-| Field | Notes |
+| Field | Purpose |
 | --- | --- |
-| `type` | Built-in runtime type. Currently only `echo`, and only in dev mode. |
-| `providers` | Allowlist of providers the runtime can access. |
-| `config` | Runtime config payload. |
-| `plugin` | Executable runtime plugin. |
+| `type` | Built-in runtime type. See [Built-in Plugins](/reference/built-in-plugins) for available types. |
+| `providers` | Allowlist of providers the runtime can invoke. |
+| `config` | Runtime config payload. Must be at `runtimes.<name>.config`, not `runtimes.<name>.plugin.config`. |
+| `plugin` | Executable runtime plugin. Same fields as integration `plugin` (`command`, `package`, `source`, `version`). |
+
+A runtime must set either `type` or `plugin`, not both.
 
 ## `bindings`
 
@@ -478,8 +484,6 @@ bindings:
       signing_secret: secret://webhook-secret
 ```
 
-or:
-
 ```yaml
 bindings:
   outbound_proxy:
@@ -493,7 +497,7 @@ bindings:
 
 ### Common binding fields
 
-| Field | Notes |
+| Field | Purpose |
 | --- | --- |
 | `type` | `webhook` or `proxy`. |
 | `providers` | Allowlist of providers the binding can access. |
@@ -501,7 +505,7 @@ bindings:
 
 ### Webhook binding config
 
-| Field | Notes |
+| Field | Purpose |
 | --- | --- |
 | `path` | Required. Must start with `/`. |
 | `provider` | Optional target provider for forwarding. |
@@ -509,20 +513,17 @@ bindings:
 | `operation` | Optional target operation. |
 | `auth_mode` | `public`, `signed`, or `trusted_user_header`. |
 | `signing_secret` | Required for `signed`. |
-| `signature_header` | Header carrying the signature. Defaults to `X-Signature`. |
+| `signature_header` | Header carrying the HMAC signature. Defaults to `X-Signature`. |
 | `user_header` | Required for `trusted_user_header`. |
-| `trusted_sources` | Optional source IP allowlist for `trusted_user_header`. |
+| `trusted_sources` | Source IP allowlist for `trusted_user_header`. |
 
 ### Proxy binding config
 
-| Field | Notes |
+| Field | Purpose |
 | --- | --- |
 | `path` | Required. Must start with `/`. |
 
-Rules:
-
-- proxy bindings may declare zero or one provider in `bindings.<name>.providers`
-- webhook forwarding requires the forwarded provider to be present in the binding allowlist
+Proxy bindings may declare zero or one provider in `bindings.<name>.providers`. Webhook forwarding requires the forwarded provider to be present in the binding allowlist.
 
 ## `egress`
 
@@ -547,7 +548,7 @@ egress:
 
 ### `policies`
 
-| Field | Notes |
+| Field | Purpose |
 | --- | --- |
 | `action` | `allow` or `deny`. |
 | `subject_kind` | Match a subject kind. |
@@ -560,7 +561,7 @@ egress:
 
 ### `credentials`
 
-| Field | Notes |
+| Field | Purpose |
 | --- | --- |
 | `secret_ref` | Required. Secret manager key resolved at request time. |
 | `auth_style` | How the resolved secret is injected: `bearer`, `basic`, or `raw`. Defaults to `bearer`. |
@@ -579,8 +580,6 @@ ui:
     package: ./my-ui-plugin
 ```
 
-or:
-
 ```yaml
 ui:
   plugin:
@@ -588,29 +587,37 @@ ui:
     version: 1.0.0
 ```
 
-| Field | Notes |
+| Field | Purpose |
 | --- | --- |
 | `plugin.package` | Local directory, local archive, or HTTPS URL. Mutually exclusive with `source`. |
 | `plugin.source` | Managed plugin source address. Requires `version`. |
 | `plugin.version` | Required with `source`. Must be valid SemVer without leading `v`. |
 
-When `ui` is omitted, `gestaltd` serves the embedded frontend. When `ui.plugin` is configured, the plugin's assets are served instead.
+When `ui` is omitted, `gestaltd` serves the embedded frontend. When `ui.plugin` is configured, the plugin's assets are served instead. See [UI Plugins](/concepts/ui-plugins) for the full workflow.
 
-See [UI Plugins](/concepts/ui-plugins) for the full workflow.
+## Validation Rules
 
-## Validation Rules Worth Remembering
+Structural validation runs at config load time (`bundle`, `validate`, `serve`). Runtime validation runs only at `serve` time.
 
-- `auth.provider` is required
-- `datastore.provider` is required
-- `server.encryption_key` is required outside dev mode
-- integrations are either declarative (`connections` + `api`/`mcp`) or plugin-only
-- all connections in an integration must share the same mode
-- `api` surfaces reference connections by name; `api.connection` must exist in `connections`
-- `mcp` surfaces reference connections by name; `mcp.connection` must exist in `connections`
+### Structural
+
+- Integrations are declarative (`connections` + `api`/`mcp`), plugin-only, or hybrid (plugin + `mcp`)
+- Plugin integrations cannot declare `api`
+- Exactly one of `command`, `package`, or `source` per plugin
+- `plugin.version` is required with `source` and invalid with `command` or `package`
+- `plugin.args` are only valid with `command`
+- Plain `http://` package URLs are rejected
+- All connections in an integration must share the same mode
+- `api.connection` and `mcp.connection` must reference a declared connection
 - REST API surfaces require `api.openapi`; GraphQL surfaces require `api.url`
 - URL templates in surface URLs and auth URLs must reference required params
-- runtime plugins must use `runtimes.<name>.config`, not `runtimes.<name>.plugin.config`
+- Runtime plugins must use `runtimes.<name>.config`, not `runtimes.<name>.plugin.config`
 - `egress.default_action` and policy `action` must be `allow` or `deny`
 - `ui.plugin` requires exactly one of `package` or `source`
 - `ui.plugin.version` is required with `source` and invalid with `package`
-- `ui.plugin.package` rejects plain `http://`
+
+### Runtime
+
+- `auth.provider` is required
+- `datastore.provider` is required
+- `server.encryption_key` is required

--- a/docs/pages/reference/http-api.mdx
+++ b/docs/pages/reference/http-api.mdx
@@ -58,6 +58,7 @@ Valid bearer tokens are:
 | `POST` | `/api/v1/tokens` | Create an API token. Plaintext is returned once. |
 | `GET` | `/api/v1/tokens` | List API tokens for the current user. |
 | `DELETE` | `/api/v1/tokens/{id}` | Revoke an API token. |
+| `DELETE` | `/api/v1/tokens` | Revoke all API tokens for the current user. |
 
 ### Runtime And Binding Discovery
 

--- a/docs/pages/tasks/add-an-integration.mdx
+++ b/docs/pages/tasks/add-an-integration.mdx
@@ -1,19 +1,17 @@
 # Add an Integration
 
-Most integrations in Gestalt are pure configuration. Start with a declarative integration and only reach for a plugin when the upstream behavior cannot be expressed declaratively.
+Most integrations are pure configuration. Start with a declarative integration and reach for a plugin only when the upstream behavior cannot be expressed declaratively.
 
-## 1. Pick The Surface Type
+## 1. Pick the Surface Type
 
-Choose one or both:
-
-| Surface | Use when |
+| Surface | When to use |
 | --- | --- |
 | `api` (REST) | You have an OpenAPI document. |
 | `api` (GraphQL) | You have a GraphQL endpoint. |
 | `mcp` | The upstream already exposes MCP tools. |
-| `plugin` | You need custom execution logic. Plugin-only; cannot combine with declarative surfaces. |
+| `plugin` | You need custom execution logic. Can compose with `mcp` (hybrid). Cannot combine with `api`. |
 
-## 2. Start With The Smallest Useful Definition
+## 2. Start with the Smallest Useful Definition
 
 Public REST example with no auth:
 
@@ -30,9 +28,9 @@ integrations:
       connection: default
 ```
 
-That is enough to build a real provider and invoke the public API.
+That is enough to build a provider and invoke the public API.
 
-## 3. Add Auth If The Upstream Needs It
+## 3. Add Auth
 
 OAuth-backed example:
 
@@ -57,11 +55,11 @@ integrations:
         issues/list-for-authenticated-user:
 ```
 
-Auth lives inside the connection, not at the integration level or in a separate profile.
+Auth lives inside the connection, not at the integration level.
 
-## 4. Add An MCP Surface
+## 4. Add an MCP Surface
 
-You can add an `mcp` surface alongside `api`, or use it standalone:
+Add `mcp` alongside `api`, or use it standalone:
 
 ```yaml
 integrations:
@@ -80,18 +78,18 @@ integrations:
       connection: default
 ```
 
-Use `mcp_tool_prefix` at the integration level to avoid tool-name collisions across integrations.
+Set `mcp_tool_prefix` at the integration level to avoid tool-name collisions across integrations.
 
-## 5. Bundle And Validate
+## 5. Bundle and Validate
 
 ```sh
 gestaltd bundle --config ./gestalt.yaml --output ./bundle
 gestaltd validate --config ./bundle/gestalt.yaml
 ```
 
-That prepares remote provider artifacts and catches config errors.
+This prepares remote provider artifacts and catches config errors.
 
-## 6. Run It
+## 6. Run
 
 ```sh
 gestaltd serve --locked --config ./bundle/gestalt.yaml
@@ -99,17 +97,17 @@ gestaltd serve --locked --config ./bundle/gestalt.yaml
 
 Then:
 
-- connect the integration through the UI or API
-- list operations with `GET /api/v1/integrations/{name}/operations`
-- invoke operations over HTTP or MCP
+- Connect the integration through the UI or API
+- List operations with `GET /api/v1/integrations/{name}/operations`
+- Invoke operations over HTTP or MCP
 
-## 7. Reach For A Plugin Only When Needed
+## 7. Reach for a Plugin Only When Needed
 
-Write a provider plugin when you need one of these:
+Write a provider plugin when you need:
 
-- request or response shaping that config cannot express
-- nonstandard auth behavior
-- multi-step execution
-- custom operation semantics that do not come from an upstream spec
+- Request or response shaping that config cannot express
+- Nonstandard auth behavior
+- Multi-step execution
+- Custom operation semantics that do not come from an upstream spec
 
-Plugin integrations use only the `plugin` block and cannot declare `connections`, `api`, or `mcp`.
+Plugin integrations use the `plugin` block. They can optionally compose with an `mcp` surface (hybrid pattern) but cannot declare an `api` surface. See [Integrations](/concepts/integrations) for the hybrid pattern.

--- a/docs/pages/tasks/write-a-plugin.mdx
+++ b/docs/pages/tasks/write-a-plugin.mdx
@@ -83,15 +83,21 @@ go build -o ./my-tool .
 Package the binary directly into a distributable archive:
 
 ```sh
-gestaltd plugin package --binary ./my-tool --id myorg/my-tool --output ./my-tool.tar.gz
+gestaltd plugin package \
+  --binary ./my-tool \
+  --source github.com/myorg/my-repo/my-tool \
+  --output ./my-tool.tar.gz
 ```
 
 The `--os` and `--arch` flags default to your current platform. For cross-compilation:
 
 ```sh
 GOOS=linux GOARCH=amd64 go build -o ./my-tool-linux .
-gestaltd plugin package --binary ./my-tool-linux --id myorg/my-tool \
-  --os linux --arch amd64 --output ./my-tool.tar.gz
+gestaltd plugin package \
+  --binary ./my-tool-linux \
+  --source github.com/myorg/my-repo/my-tool \
+  --os linux --arch amd64 \
+  --output ./my-tool.tar.gz
 ```
 
 ## Configure and run


### PR DESCRIPTION
The documentation had drifted from the codebase across several recent
changes. Plugin manifest examples still referenced the removed
`schema_version` and `id` fields (replaced by `source` in PR #322), the
CLI reference showed a non-existent `--id` flag instead of `--source`,
the built-in plugins page listed an "echo" provider and runtime that
only exist in test fixtures, and the `either` connection mode was missing
from every page that enumerated connection modes. The config reference
was also missing `server.api_token_ttl`, `plugin.source`/`version`/
`allowed_operations`/`allowed_hosts`, the `DELETE /api/v1/tokens`
revoke-all endpoint, and the hybrid integration pattern (plugin + MCP)
that has been valid since `validateHybridIntegration` was added.

This fixes all confirmed inaccuracies across 16 files and adds a new
Security Model page covering trust boundaries, AES-256-GCM encryption at
rest, token lifecycle, request authentication flow, egress policy
enforcement, plugin process isolation, webhook HMAC verification, and
operator configuration responsibilities. All 38 pages build cleanly and
every claim has been cross-referenced against source code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)