### PR TITLE
Require credentials for manual auth connections

### DIFF
--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -445,7 +445,7 @@ connections:
 | `credentials[].help_url` | Link displayed next to the label for where to find the credential. |
 | `auth_mapping.headers` | Maps credential field names to HTTP headers. Required when multiple credentials are declared. |
 
-When no `credentials` are declared, the UI shows the default single "API Token" field.
+`credentials` is required when `auth.type` is `manual`.
 
 ### `plugin`
 

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -637,8 +637,11 @@ func resolveConnectionRef(intgName, surface, connName string, connections map[st
 }
 
 func validateCredentialFields(intgName, connName string, auth ConnectionAuthDef) error {
-	if len(auth.Credentials) == 0 {
+	if auth.Type != "manual" && auth.Type != "api_key" {
 		return nil
+	}
+	if len(auth.Credentials) == 0 {
+		return fmt.Errorf("config validation: integration %q connection %q requires credentials when auth type is %q", intgName, connName, auth.Type)
 	}
 	names := make(map[string]bool, len(auth.Credentials))
 	for i, cf := range auth.Credentials {

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -1883,6 +1883,29 @@ func TestCredentialFieldValidation(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			name:    "manual auth without credentials",
+			wantErr: true,
+			yaml: `
+auth:
+  provider: ap
+datastore:
+  provider: ds
+server:
+  encryption_key: ek
+integrations:
+  svc:
+    connections:
+      default:
+        mode: user
+        auth:
+          type: manual
+    api:
+      type: rest
+      openapi: https://example.test/spec.json
+      connection: default
+`,
+		},
+		{
 			name: "single credential field is valid",
 			yaml: `
 auth:

--- a/web/e2e/integrations.spec.ts
+++ b/web/e2e/integrations.spec.ts
@@ -7,6 +7,7 @@ const OAUTH_INTEGRATION: Integration = {
 
 const MANUAL_INTEGRATION: Integration = {
   name: "manual-svc", display_name: "Manual Service", description: "Example manual integration", auth_types: ["manual"],
+  credential_fields: [{ name: "token", label: "API Token" }],
 };
 
 const sampleIntegrations: Integration[] = [

--- a/web/src/components/IntegrationSettingsModal.tsx
+++ b/web/src/components/IntegrationSettingsModal.tsx
@@ -104,8 +104,14 @@ export default function IntegrationSettingsModal({
     const fd = new FormData(e.currentTarget);
     const fields = resolveCredentialFields();
 
+    if (!fields?.length) return;
+
     let credential: string | Record<string, string>;
-    if (fields && fields.length > 1) {
+    if (fields.length === 1) {
+      const val = (fd.get(`cred_${fields[0].name}`) as string)?.trim();
+      if (!val) return;
+      credential = val;
+    } else {
       const creds: Record<string, string> = {};
       for (const field of fields) {
         const val = (fd.get(`cred_${field.name}`) as string)?.trim();
@@ -113,12 +119,7 @@ export default function IntegrationSettingsModal({
         creds[field.name] = val;
       }
       credential = creds;
-    } else if (fields && fields.length === 1) {
-      credential = (fd.get(`cred_${fields[0].name}`) as string)?.trim() ?? "";
-    } else {
-      credential = (fd.get("credential") as string)?.trim() ?? "";
     }
-    if (!credential) return;
 
     let params: Record<string, string> | undefined;
     if (integration.connection_params) {
@@ -364,10 +365,8 @@ function TokenForm({
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   onCancel: () => void;
 }) {
-  const fields = credentialFields;
-  const heading = !fields?.length ? "API Token"
-    : fields.length === 1 ? (fields[0].label || "API Token")
-    : "Enter Credentials";
+  const fields = credentialFields ?? [];
+  const heading = fields.length === 1 ? (fields[0].label || fields[0].name) : "Enter Credentials";
 
   return (
     <form onSubmit={onSubmit}>
@@ -396,58 +395,38 @@ function TokenForm({
           />
         </div>
       ))}
-      {fields && fields.length > 0 ? (
-        fields.map((field, idx) => (
-          <div key={field.name} className="mt-4">
-            <label
-              htmlFor={`cred_${field.name}-${integrationName}`}
-              className="block text-sm font-medium text-stone-700"
-            >
-              {field.label || field.name}
-              {field.help_url && (
-                <a
-                  href={field.help_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="ml-1 text-xs text-timber-500 hover:underline"
-                >
-                  (where to find this)
-                </a>
-              )}
-            </label>
-            {field.description && (
-              <p className="mt-0.5 text-xs text-stone-400">{field.description}</p>
-            )}
-            <input
-              id={`cred_${field.name}-${integrationName}`}
-              name={`cred_${field.name}`}
-              type="password"
-              required
-              placeholder={field.label || field.name}
-              autoFocus={idx === 0}
-              className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
-            />
-          </div>
-        ))
-      ) : (
-        <>
+      {fields.map((field, idx) => (
+        <div key={field.name} className="mt-4">
           <label
-            htmlFor={`credential-${integrationName}`}
-            className="mt-4 block text-sm font-medium text-stone-700"
+            htmlFor={`cred_${field.name}-${integrationName}`}
+            className="block text-sm font-medium text-stone-700"
           >
-            Paste your API token
+            {field.label || field.name}
+            {field.help_url && (
+              <a
+                href={field.help_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="ml-1 text-xs text-timber-500 hover:underline"
+              >
+                (where to find this)
+              </a>
+            )}
           </label>
+          {field.description && (
+            <p className="mt-0.5 text-xs text-stone-400">{field.description}</p>
+          )}
           <input
-            id={`credential-${integrationName}`}
-            name="credential"
+            id={`cred_${field.name}-${integrationName}`}
+            name={`cred_${field.name}`}
             type="password"
             required
-            placeholder="Paste your API token"
-            autoFocus
+            placeholder={field.label || field.name}
+            autoFocus={idx === 0}
             className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
           />
-        </>
-      )}
+        </div>
+      ))}
       {error && <p className="mt-3 text-sm text-ember-500">{error}</p>}
       <div className="mt-6 flex gap-3">
         <Button


### PR DESCRIPTION
Manual auth connections previously fell back to a hardcoded "API Token" label when no `credentials` were declared, making the field name and help context invisible to users. This removes the fallback and requires every manual-auth connection to explicitly declare its credential fields via the `credentials` config property. The UI now renders exclusively from declared fields with no hardcoded strings.