### PR TITLE
Show docs TOC at narrower viewport widths

### DIFF
--- a/docs/globals.css
+++ b/docs/globals.css
@@ -1,0 +1,17 @@
+/* Show the TOC at lg (1024px) instead of xl (1280px).
+   Nextra hard-codes max-xl:_hidden on nav.nextra-toc.
+   Higher specificity (element + two classes) overrides the theme rule. */
+@media (min-width: 1024px) {
+  nav.nextra-toc.max-xl\:_hidden {
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+/* Between lg and xl, use a narrower TOC to leave room for content.
+   Default is 256px (_w-64). */
+@media (min-width: 1024px) and (max-width: 1279.98px) {
+  nav.nextra-toc {
+    width: 12rem;
+  }
+}

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -1,4 +1,5 @@
 import type { AppProps } from "next/app";
+import "../globals.css";
 
 export default function App({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />;


### PR DESCRIPTION
The right-side "On This Page" table of contents in the docs site was only visible at viewport widths of 1280px and above, which meant it disappeared on many laptop screens and non-maximized browser windows. This adds a CSS override that lowers the breakpoint to 1024px, with a slightly narrower TOC column at intermediate widths to keep the main content readable.