### PR TITLE
Drop unnecessary ALTER TABLE migration

### DIFF
--- a/server/internal/mcpoauth/sqlstore.go
+++ b/server/internal/mcpoauth/sqlstore.go
@@ -57,11 +57,8 @@ func (s *SQLStore) Migrate(ctx context.Context) error {
 	if p, ok := s.dialect.(RegistrationDDLProvider); ok {
 		ddl = p.RegistrationDDL()
 	}
-	if _, err := s.db.ExecContext(ctx, ddl); err != nil {
-		return err
-	}
-	_, _ = s.db.ExecContext(ctx, `ALTER TABLE oauth_registrations ADD COLUMN expires_at DATETIME NULL`)
-	return nil
+	_, err := s.db.ExecContext(ctx, ddl)
+	return err
 }
 
 func (s *SQLStore) GetRegistration(ctx context.Context, authServerURL, redirectURI string) (*Registration, error) {


### PR DESCRIPTION
The expires_at column is already in the CREATE TABLE DDL for all dialects, so the ALTER TABLE is redundant. Since this product has not shipped, there are no existing tables that need the column added retroactively.