### PR TITLE
Validate OAuth state parameter in login callback

### DIFF
--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-reqwest = { version = "0.13", features = ["blocking", "json", "native-tls-vendored"] }
+reqwest = { version = "0.13", features = ["blocking", "cookies", "json", "native-tls-vendored"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/client/cli/src/commands/auth.rs
+++ b/client/cli/src/commands/auth.rs
@@ -28,6 +28,7 @@ pub fn login(url_override: Option<&str>) -> Result<()> {
     let login_url = format!("{}/api/v1/auth/login", base_url);
     let client = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
+        .cookie_store(true)
         .build()
         .context("failed to build HTTP client")?;
     let resp = client
@@ -95,7 +96,10 @@ pub fn login(url_override: Option<&str>) -> Result<()> {
 
     let mut callback_url = url::Url::parse(&format!("{}/api/v1/auth/login/callback", base_url))
         .context("failed to build callback URL")?;
-    callback_url.query_pairs_mut().append_pair("code", &code);
+    callback_url
+        .query_pairs_mut()
+        .append_pair("code", &code)
+        .append_pair("state", &state);
 
     let callback_resp = client
         .get(callback_url.as_str())

--- a/server/internal/server/handlers.go
+++ b/server/internal/server/handlers.go
@@ -465,6 +465,25 @@ func (s *Server) startLogin(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to generate login URL")
 		return
 	}
+	if s.encryptor != nil {
+		encoded, encErr := encodeLoginState(s.encryptor, loginState{
+			State:     req.State,
+			ExpiresAt: s.now().Add(loginStateTTL).Unix(),
+		})
+		if encErr != nil {
+			writeError(w, http.StatusInternalServerError, "failed to encode login state")
+			return
+		}
+		http.SetCookie(w, &http.Cookie{
+			Name:     loginStateCookieName,
+			Value:    encoded,
+			Path:     "/",
+			MaxAge:   int(loginStateTTL.Seconds()),
+			HttpOnly: true,
+			Secure:   s.secureCookies,
+			SameSite: http.SameSiteLaxMode,
+		})
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"url": url})
 }
 
@@ -528,18 +547,29 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var identity *core.UserIdentity
+	var originalState string
 	var err error
 
 	if stateful, ok := s.auth.(StatefulCallbackHandler); ok {
 		state := r.URL.Query().Get("state")
-		identity, _, err = stateful.HandleCallbackWithState(r.Context(), code, state)
+		identity, originalState, err = stateful.HandleCallbackWithState(r.Context(), code, state)
 	} else {
+		originalState = r.URL.Query().Get("state")
 		identity, err = s.auth.HandleCallback(r.Context(), code)
 	}
 	if err != nil {
 		slog.ErrorContext(r.Context(), "login callback failed", "error", err)
 		writeError(w, http.StatusUnauthorized, "login failed")
 		return
+	}
+
+	if csrfErr := s.validateLoginState(r, originalState); csrfErr != nil {
+		slog.ErrorContext(r.Context(), "login state validation failed", "error", csrfErr)
+		writeError(w, http.StatusForbidden, "login state validation failed")
+		return
+	}
+	if s.encryptor != nil {
+		s.clearLoginStateCookie(w)
 	}
 
 	resp := map[string]any{
@@ -560,6 +590,36 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 	s.setSessionCookie(w, token)
 
 	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) validateLoginState(r *http.Request, originalState string) error {
+	if s.encryptor == nil {
+		return nil
+	}
+	cookie, err := r.Cookie(loginStateCookieName)
+	if err != nil {
+		return fmt.Errorf("missing login state cookie")
+	}
+	expected, err := decodeLoginState(s.encryptor, cookie.Value, s.now())
+	if err != nil {
+		return fmt.Errorf("invalid login state cookie: %w", err)
+	}
+	if expected.State != originalState {
+		return fmt.Errorf("login state mismatch")
+	}
+	return nil
+}
+
+func (s *Server) clearLoginStateCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     loginStateCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   s.secureCookies,
+		SameSite: http.SameSiteLaxMode,
+	})
 }
 
 type startOAuthRequest struct {

--- a/server/internal/server/oauth_state.go
+++ b/server/internal/server/oauth_state.go
@@ -70,6 +70,40 @@ func (c *integrationOAuthStateCodec) Decode(encoded string, now time.Time) (*int
 	return &state, nil
 }
 
+const loginStateTTL = 10 * time.Minute
+const loginStateCookieName = "login_state"
+
+type loginState struct {
+	State     string `json:"s"`
+	ExpiresAt int64  `json:"exp"`
+}
+
+func encodeLoginState(enc *cryptoutil.AESGCMEncryptor, state loginState) (string, error) {
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return "", fmt.Errorf("marshal login state: %w", err)
+	}
+	return enc.EncryptURLSafe(string(payload))
+}
+
+func decodeLoginState(enc *cryptoutil.AESGCMEncryptor, encoded string, now time.Time) (*loginState, error) {
+	plaintext, err := enc.DecryptURLSafe(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt login state: %w", err)
+	}
+	var state loginState
+	if err := json.Unmarshal([]byte(plaintext), &state); err != nil {
+		return nil, fmt.Errorf("unmarshal login state: %w", err)
+	}
+	if state.State == "" {
+		return nil, fmt.Errorf("login state missing state value")
+	}
+	if now.Unix() > state.ExpiresAt {
+		return nil, fmt.Errorf("login state expired")
+	}
+	return &state, nil
+}
+
 func setURLQueryParam(rawURL, key, value string) (string, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {

--- a/server/internal/server/server.go
+++ b/server/internal/server/server.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/valon-technologies/gestalt/server/core"
+	cryptoutil "github.com/valon-technologies/gestalt/server/core/crypto"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
@@ -36,6 +37,7 @@ type Server struct {
 	noAuth             bool
 	anonymousPrincipal *principal.Principal
 	secureCookies      bool
+	encryptor          *cryptoutil.AESGCMEncryptor
 	stateCodec         *integrationOAuthStateCodec
 	apiTokenTTL        time.Duration
 	now                func() time.Time
@@ -68,12 +70,18 @@ func New(cfg Config) (*Server, error) {
 		return nil, fmt.Errorf("invoker is required")
 	}
 	var stateCodec *integrationOAuthStateCodec
+	var encryptor *cryptoutil.AESGCMEncryptor
 	if len(cfg.StateSecret) > 0 {
 		codec, err := newIntegrationOAuthStateCodec(cfg.StateSecret)
 		if err != nil {
 			return nil, fmt.Errorf("init oauth state codec: %w", err)
 		}
 		stateCodec = codec
+		enc, err := cryptoutil.NewAESGCM(cfg.StateSecret)
+		if err != nil {
+			return nil, fmt.Errorf("init state encryptor: %w", err)
+		}
+		encryptor = enc
 	}
 	now := cfg.Now
 	if now == nil {
@@ -99,6 +107,7 @@ func New(cfg Config) (*Server, error) {
 		integrationDefs:   cfg.IntegrationDefs,
 		noAuth:            noAuth,
 		secureCookies:     cfg.SecureCookies,
+		encryptor:         encryptor,
 		stateCodec:        stateCodec,
 		apiTokenTTL:       cfg.APITokenTTL,
 		now:               now,

--- a/server/internal/server/server_test.go
+++ b/server/internal/server/server_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
 	"strings"
@@ -1255,7 +1256,17 @@ func TestLoginCallback(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	resp, err := http.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code")
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar}
+
+	body := bytes.NewBufferString(`{"state":"test-state"}`)
+	loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
+	if err != nil {
+		t.Fatalf("start login: %v", err)
+	}
+	_ = loginResp.Body.Close()
+
+	resp, err := client.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=test-state")
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}
@@ -1271,6 +1282,93 @@ func TestLoginCallback(t *testing.T) {
 	}
 	if result["email"] != "user@example.com" {
 		t.Fatalf("unexpected email: %v", result["email"])
+	}
+}
+
+func TestLoginCallbackStateMismatch(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &stubAuthWithToken{
+			StubAuthProvider: coretesting.StubAuthProvider{N: "test"},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar}
+
+	body := bytes.NewBufferString(`{"state":"correct-state"}`)
+	loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
+	if err != nil {
+		t.Fatalf("start login: %v", err)
+	}
+	_ = loginResp.Body.Close()
+
+	resp, err := client.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=wrong-state")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestLoginCallbackMissingStateCookie(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &stubAuthWithToken{
+			StubAuthProvider: coretesting.StubAuthProvider{N: "test"},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=anything")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestLoginCallbackExpiredState(t *testing.T) {
+	t.Parallel()
+
+	nowVal := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Now = func() time.Time { return nowVal }
+		cfg.Auth = &stubAuthWithToken{
+			StubAuthProvider: coretesting.StubAuthProvider{N: "test"},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar}
+
+	body := bytes.NewBufferString(`{"state":"test-state"}`)
+	loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
+	if err != nil {
+		t.Fatalf("start login: %v", err)
+	}
+	_ = loginResp.Body.Close()
+
+	nowVal = nowVal.Add(11 * time.Minute)
+
+	resp, err := client.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=test-state")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
 	}
 }
 
@@ -1292,7 +1390,17 @@ func TestLoginCallbackWithStatefulHandler(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	resp, err := http.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=encrypted-state")
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar}
+
+	body := bytes.NewBufferString(`{"state":"original-state"}`)
+	loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
+	if err != nil {
+		t.Fatalf("start login: %v", err)
+	}
+	_ = loginResp.Body.Close()
+
+	resp, err := client.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=encrypted-state")
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}


### PR DESCRIPTION
The `loginCallback` handler did not validate the OAuth state parameter
for non-PKCE auth providers, leaving it vulnerable to CSRF-based session
fixation. An attacker could initiate OAuth with their own account, get a
valid authorization code, then trick a victim into hitting the callback
endpoint, logging the victim in as the attacker.

This adds server-side state validation using an encrypted cookie. The
`startLogin` handler now stores the expected state in a `login_state`
cookie (AES-GCM encrypted, 10-minute TTL), and `loginCallback` validates
the returned state against it for all providers. The CLI client now
enables cookie storage on its HTTP client and forwards the state
parameter to the callback endpoint.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>