### PR TITLE
Add icon_file support to plugin manifests

### DIFF
--- a/server/internal/bootstrap/bootstrap.go
+++ b/server/internal/bootstrap/bootstrap.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -820,12 +819,11 @@ func applyPluginIcon(prov core.Provider, intg config.IntegrationDef) {
 	if intg.IconFile == "" {
 		return
 	}
-	data, err := os.ReadFile(intg.IconFile)
+	svg, err := provider.ReadIconFile(intg.IconFile)
 	if err != nil {
 		slog.Warn("could not read plugin icon_file", "path", intg.IconFile, "error", err)
 		return
 	}
-	svg := strings.TrimSpace(string(data))
 	if svg == "" {
 		return
 	}

--- a/server/internal/provider/build.go
+++ b/server/internal/provider/build.go
@@ -256,13 +256,20 @@ func ApplyDisplayOverrides(def *Definition, intg config.IntegrationDef) {
 	setStr(&def.DisplayName, intg.DisplayName)
 	setStr(&def.Description, intg.Description)
 	if intg.IconFile != "" {
-		data, err := os.ReadFile(intg.IconFile)
-		if err != nil {
+		if svg, err := ReadIconFile(intg.IconFile); err != nil {
 			slog.Warn("could not read icon_file", "path", intg.IconFile, "error", err)
 		} else {
-			def.IconSVG = strings.TrimSpace(string(data))
+			def.IconSVG = svg
 		}
 	}
+}
+
+func ReadIconFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
 }
 
 // ApplyConnectionAuth merges connection auth overrides into the Definition.


### PR DESCRIPTION
Plugins can now declare an icon by setting `icon_file` in their
manifest (plugin.yaml), pointing to an SVG file within the plugin
package. Deployers no longer need to specify `icon_file` in their
integration config when using a plugin that ships its own icon.
The deployer's `icon_file` still takes precedence as an override if
both are present. The bigquery, jira, and slack plugins now ship
their own icons.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>