### PR TITLE
Point documentation URLs to docs.toolshed.peachstreet.dev

### DIFF
--- a/.github/workflows/publish-gestaltd-image.yml
+++ b/.github/workflows/publish-gestaltd-image.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       IMAGE_NAME: valontechnologies/gestaltd
       IMAGE_SOURCE: https://github.com/${{ github.repository }}
-      IMAGE_DOCUMENTATION: https://gestalt.run
+      IMAGE_DOCUMENTATION: https://docs.toolshed.peachstreet.dev
       IMAGE_URL: https://hub.docker.com/r/valontechnologies/gestaltd
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -111,7 +111,7 @@ jobs:
     env:
       IMAGE_NAME: valontechnologies/gestaltd
       IMAGE_SOURCE: https://github.com/${{ github.repository }}
-      IMAGE_DOCUMENTATION: https://gestalt.run
+      IMAGE_DOCUMENTATION: https://docs.toolshed.peachstreet.dev
       IMAGE_URL: https://hub.docker.com/r/valontechnologies/gestaltd
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ CMD ["serve", "--locked", "--config", "/app/config.yaml"]
 
 ## Documentation
 
-Full documentation is available at [gestalt.run](https://gestalt.run).
+Full documentation is available at [docs.toolshed.peachstreet.dev](https://docs.toolshed.peachstreet.dev).
 
-- [Getting Started](/getting-started)
-- [Configuration](/concepts/configuration)
-- [CLI Reference](/reference/cli)
-- [Deployment](/deploy)
-- [Write a Plugin](/tasks/write-a-plugin)
+- [Getting Started](https://docs.toolshed.peachstreet.dev/getting-started)
+- [Configuration](https://docs.toolshed.peachstreet.dev/concepts/configuration)
+- [CLI Reference](https://docs.toolshed.peachstreet.dev/reference/cli)
+- [Deployment](https://docs.toolshed.peachstreet.dev/deploy)
+- [Write a Plugin](https://docs.toolshed.peachstreet.dev/tasks/write-a-plugin)

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -187,7 +187,7 @@ RUN go build -o /tmp/myplugin ./plugins/cmd/myplugin && \
 
 ## Learn more
 
-- Docs: https://gestalt.run
-- CLI reference: https://gestalt.run/reference/cli
-- Deployment docs: https://gestalt.run/deploy
+- Docs: https://docs.toolshed.peachstreet.dev
+- CLI reference: https://docs.toolshed.peachstreet.dev/reference/cli
+- Deployment docs: https://docs.toolshed.peachstreet.dev/deploy
 - Source: https://github.com/valon-technologies/gestalt

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,7 +2,7 @@ ARG GESTALT_VERSION=dev
 ARG GESTALT_REVISION=unknown
 ARG GESTALT_CREATED=unknown
 ARG GESTALT_SOURCE=https://github.com/valon-technologies/gestalt
-ARG GESTALT_DOCUMENTATION=https://gestalt.run
+ARG GESTALT_DOCUMENTATION=https://docs.toolshed.peachstreet.dev
 ARG GESTALT_URL=https://hub.docker.com/r/valontechnologies/gestaltd
 
 FROM --platform=$BUILDPLATFORM node:20-alpine AS frontend

--- a/server/internal/drivers/datastore/sqlite/warnings.go
+++ b/server/internal/drivers/datastore/sqlite/warnings.go
@@ -2,6 +2,6 @@ package sqlite
 
 func (s *Store) Warnings() []string {
 	return []string{
-		"using SQLite for the datastore; this is not recommended for production. See https://gestalt.run/deploy for alternatives.",
+		"using SQLite for the datastore; this is not recommended for production. See https://docs.toolshed.peachstreet.dev/deploy for alternatives.",
 	}
 }


### PR DESCRIPTION
All references to gestalt.run have been replaced with the actual
documentation domain. The gestalt.run domain exists but returns 404 for
all sub-paths like /deploy, which the SQLite startup warning, README,
Dockerfile, DockerHub description, and CI workflows all referenced.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>