### PR TITLE
Deduplicate body properties that collide with path/query params

### DIFF
--- a/server/internal/openapi/loader.go
+++ b/server/internal/openapi/loader.go
@@ -257,6 +257,10 @@ func extractOperations(model *v3high.Document, def *provider.Definition, allowed
 			}
 
 			if op.RequestBody != nil && op.RequestBody.Content != nil {
+				seen := make(map[string]struct{}, len(params))
+				for _, p := range params {
+					seen[p.Name] = struct{}{}
+				}
 				for contentPair := op.RequestBody.Content.First(); contentPair != nil; contentPair = contentPair.Next() {
 					mt := contentPair.Value()
 					if mt.Schema == nil || mt.Schema.Schema() == nil {
@@ -271,6 +275,9 @@ func extractOperations(model *v3high.Document, def *provider.Definition, allowed
 						requiredSet[r] = true
 					}
 					for propPair := schema.Properties.First(); propPair != nil; propPair = propPair.Next() {
+						if _, exists := seen[propPair.Key()]; exists {
+							continue
+						}
 						propSchema := propPair.Value().Schema()
 						if propSchema == nil {
 							continue

--- a/server/internal/openapi/loader_test.go
+++ b/server/internal/openapi/loader_test.go
@@ -554,6 +554,74 @@ func TestLoadDefinitionRelativeServerURL(t *testing.T) {
 	}
 }
 
+func TestLoadDefinitionBodyParamDedup(t *testing.T) {
+	t.Parallel()
+
+	spec := map[string]any{
+		"openapi": "3.0.0",
+		"info":    map[string]string{"title": "Test"},
+		"servers": []any{map[string]string{"url": "https://api.example.com"}},
+		"paths": map[string]any{
+			"/variables/{name}": map[string]any{
+				"patch": map[string]any{
+					"operationId": "update_variable",
+					"summary":     "Update a variable",
+					"parameters": []any{
+						map[string]any{
+							"name": "name", "in": "path", "required": true,
+							"schema": map[string]any{"type": "string"},
+						},
+					},
+					"requestBody": map[string]any{
+						"content": map[string]any{
+							"application/json": map[string]any{
+								"schema": map[string]any{
+									"type":     "object",
+									"required": []string{"name", "value"},
+									"properties": map[string]any{
+										"name":  map[string]any{"type": "string", "description": "Variable name"},
+										"value": map[string]any{"type": "string", "description": "Variable value"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	srv := serveJSON(t, spec)
+	testutil.CloseOnCleanup(t, srv)
+
+	def, err := LoadDefinition(context.Background(), "test", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("LoadDefinition: %v", err)
+	}
+
+	op, ok := def.Operations["update_variable"]
+	if !ok {
+		t.Fatal("missing update_variable operation")
+	}
+
+	nameCount := 0
+	hasValue := false
+	for _, p := range op.Parameters {
+		if p.Name == "name" {
+			nameCount++
+		}
+		if p.Name == "value" {
+			hasValue = true
+		}
+	}
+	if nameCount != 1 {
+		t.Errorf("expected 1 'name' parameter, got %d", nameCount)
+	}
+	if !hasValue {
+		t.Error("expected 'value' body property to be included")
+	}
+}
+
 func TestLoadDefinitionYAML(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When an OpenAPI spec defines a request body property with the same name
as an existing path or query parameter (e.g. GitHub's PATCH
/variables/{name}), LoadDefinition was adding both to the flat
Parameters array. This caused the MCP compatibility validator to reject
the operation as having duplicate parameter names.

The body property is skipped when its name already exists in the
path/query parameter list. The body content remains accessible via the
full request body JSON, so the path/query param takes precedence for the
flat parameter list without any loss of functionality.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>