### PR TITLE
Fix documentation accuracy across getting-started, CLI, built-in plugins, and contributing pages

### DIFF
--- a/docs/pages/contributing.mdx
+++ b/docs/pages/contributing.mdx
@@ -4,9 +4,9 @@
 
 | Path | Purpose |
 | --- | --- |
-| `cmd/gestaltd` | Server entrypoint, command handling, and built-in registration. |
-| `core` | Public interfaces for auth, datastore, secrets, providers, runtimes, and bindings. |
-| `internal` | Bootstrap, config loading, invocation, server routing, plugin process management, and other runtime internals. |
+| `server/cmd/gestaltd` | Server entrypoint, command handling, and built-in registration. |
+| `server/core` | Public interfaces for auth, datastore, secrets, providers, runtimes, and bindings. |
+| `server/internal` | Bootstrap, config loading, invocation, server routing, plugin process management, and other runtime internals. |
 | `plugins` | Built-in auth providers, datastores, secrets, bindings, runtimes, and named providers. |
 | `sdk` | Public SDKs and plugin manifest definitions. |
 | `web` | Frontend that is embedded into the server build. |
@@ -17,9 +17,9 @@
 
 When you update docs, keep them aligned with:
 
-- config structs in `internal/config`
-- runtime wiring in `cmd/gestaltd` and `internal/bootstrap`
-- HTTP routes in `internal/server`
+- config structs in `server/internal/config`
+- runtime wiring in `server/cmd/gestaltd` and `server/internal/bootstrap`
+- HTTP routes in `server/internal/server`
 - deployment assets in `Dockerfile`, `docker-compose.yml`, and `server/deploy/helm`
 
 The easiest way to make docs drift is to copy previous prose instead of reading the code path that actually implements the feature.
@@ -42,7 +42,7 @@ npm run build
 
 If you add a new built-in auth provider, datastore, secret manager, binding, runtime, or named provider:
 
-1. register it in the relevant `cmd/gestaltd` file
+1. register it in the relevant `server/cmd/gestaltd` file
 2. add or update tests
 3. update [Built-in Plugins](/reference/built-in-plugins)
 4. update any docs or examples that describe the supported inventory

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -12,6 +12,12 @@ This guide starts with the true out-of-the-box flow, then moves to an explicit c
 brew install valon-technologies/gestalt/gestaltd
 ```
 
+The `gestalt` client CLI provides `auth`, `invoke`, and `tokens` commands for interacting with a running server:
+
+```sh
+brew install valon-technologies/gestalt/gestalt
+```
+
 **Binary download**
 
 Download the latest release for your platform from the [Releases page](https://github.com/valon-technologies/gestalt/releases), extract it, and place the `gestaltd` binary on your `PATH`.
@@ -20,11 +26,19 @@ Download the latest release for your platform from the [Releases page](https://g
 
 The `valontechnologies/gestaltd` image ships `gestaltd` and supports both `amd64` and `arm64` (Apple Silicon).
 
+Quick start (mutable mode, fetches remote specs on startup):
+
 ```sh
-docker run -p 8080:8080 -v ./gestalt.yaml:/etc/gestalt/config.yaml valontechnologies/gestaltd:latest
+docker run -p 8080:8080 -v ./config.yaml:/etc/gestalt/config.yaml valontechnologies/gestaltd:latest gestaltd
 ```
 
-The container starts with `serve --locked` by default. That direct mount pattern works for static configs that do not require prepared artifacts. If your config references remote OpenAPI or GraphQL sources, or `plugin.package`, bundle first or bake the prepared state into a derived image.
+The trailing `gestaltd` overrides the default CMD (`serve --locked`) so the server auto-prepares missing state on startup.
+
+For production, bundle first and use the default locked mode:
+
+```sh
+docker run -p 8080:8080 -v ./bundle:/etc/gestalt valontechnologies/gestaltd:latest
+```
 
 ## 1. Run `gestaltd` With No Config
 
@@ -62,7 +76,7 @@ The generated config uses `auth.provider: none`, so no sign-in is required. Add 
 
 ## 3. Switch To An Explicit Config
 
-Save this as `gestalt.yaml`:
+Save this as `config.yaml`:
 
 ```yaml
 server:
@@ -101,8 +115,8 @@ This is the smallest useful production-shaped config:
 ## 4. Bundle And Validate It
 
 ```sh
-gestaltd bundle --config ./gestalt.yaml --output ./bundle
-gestaltd validate --config ./bundle/gestalt.yaml
+gestaltd bundle --config ./config.yaml --output ./bundle
+gestaltd validate --config ./bundle/config.yaml
 ```
 
 `bundle` resolves remote provider inputs into a self-contained output directory. For the config above, the bundle contains:
@@ -113,7 +127,7 @@ gestaltd validate --config ./bundle/gestalt.yaml
 ## 5. Start From Locked State
 
 ```sh
-gestaltd serve --locked --config ./bundle/gestalt.yaml
+gestaltd serve --locked --config ./bundle/config.yaml
 ```
 
 This is the deployment path to model in Docker, Kubernetes, or any other production target. Startup becomes deterministic because `gestaltd` no longer needs to mutate local state or fetch remote specs.

--- a/docs/pages/reference/built-in-plugins.mdx
+++ b/docs/pages/reference/built-in-plugins.mdx
@@ -53,12 +53,7 @@ No built-in runtimes are registered. Define custom runtimes using the `plugin` f
 
 ## Named Providers
 
-| Name | Type | Purpose |
-| --- | --- | --- |
-| `bigquery` | Declarative (YAML) | Google BigQuery data warehouse operations. |
-| `jira` | Declarative (YAML) | Jira Cloud issue management. |
-
-Named providers are pre-registered in the binary and referenced by name in integrations. Declarative providers define their operations, auth, and base URL in YAML manifests under `plugins/providers/`.
+No named providers are currently built into the binary. BigQuery and Jira were migrated to external plugins and are available under `plugins/`.
 
 ## Scope
 

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -1,5 +1,31 @@
 # CLI
 
+## `gestalt` Client CLI
+
+The `gestalt` binary is a client for interacting with a running `gestaltd` server.
+
+```sh
+gestalt auth
+gestalt init
+gestalt config
+gestalt integrations
+gestalt invoke
+gestalt describe
+gestalt tokens
+```
+
+| Command | Purpose |
+| --- | --- |
+| `gestalt auth` | Authenticate with a running server. |
+| `gestalt init` | Initialize a new config file interactively. |
+| `gestalt config` | Display resolved client configuration. |
+| `gestalt integrations` | List integrations available on the server. |
+| `gestalt invoke` | Invoke an integration operation. |
+| `gestalt describe` | Describe an integration or operation. |
+| `gestalt tokens` | Manage API tokens. |
+
+## `gestaltd` Server CLI
+
 The `gestaltd` server binary.
 
 ## Usage


### PR DESCRIPTION
The getting-started guide had an incorrect config filename (gestalt.yaml instead of config.yaml which auto-discovery expects), a Docker command that fails with remote upstreams because the default CMD uses serve --locked, and was missing the gestalt client CLI. This updates the Docker section with a working quick-start command that overrides CMD to use mutable mode, renames config references to config.yaml, and adds an install note for the client CLI.

The CLI reference now documents the gestalt client CLI subcommands. The built-in plugins page removes BigQuery and Jira which were migrated to external plugins in PR #331. The contributing guide updates Go code directory paths from cmd/gestaltd, core, and internal to their current locations under server/.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>