### PR TITLE
Add `api: + plugin:` hybrid integration support

### DIFF
--- a/docs/pages/concepts/integrations.mdx
+++ b/docs/pages/concepts/integrations.mdx
@@ -37,15 +37,17 @@ This one block answers four questions:
 
 ## Integration Patterns
 
-Every integration follows one of three patterns:
+Every integration follows one of these patterns:
 
 | Pattern | Structure | When to use |
 | --- | --- | --- |
 | **Declarative** | `connections` + one or both of `api` and `mcp` | The upstream has an OpenAPI spec, GraphQL endpoint, or MCP server. |
 | **Plugin-only** | Just a `plugin` block | Custom execution logic that cannot be expressed declaratively. |
-| **Hybrid** | `plugin` + `mcp` | A plugin provider combined with an upstream MCP surface. |
+| **Plugin + API** | `plugin` + `api` + `connections` | A plugin for custom operations combined with an API surface for REST/GraphQL operations. |
+| **Plugin + MCP** | `plugin` + `mcp` | A plugin provider combined with an upstream MCP surface. |
+| **Plugin + API + MCP** | `plugin` + `api` + `mcp` + `connections` | All three surfaces composed together. |
 
-Plugin integrations cannot declare an `api` surface. Only plugin + `mcp` composition is supported.
+When composing a plugin with `api` or `connections`, the plugin must specify `plugin.connection` to reference a connection from the shared pool.
 
 ## Connections
 
@@ -202,7 +204,43 @@ See the [Config File](/reference/config-file) reference for the full `plugin` fi
 
 ## Hybrid Integrations
 
-A hybrid integration composes a plugin provider with an upstream MCP surface. The plugin handles execution logic while the MCP surface exposes additional tools.
+A hybrid integration composes a plugin with other surfaces. The plugin handles custom execution logic while the other surfaces provide REST, GraphQL, or MCP operations.
+
+### Plugin + API
+
+Compose a plugin binary with an API surface when the upstream has an OpenAPI spec for most operations but a few operations need custom code (SDK calls, data transformation, etc.).
+
+```yaml
+integrations:
+  bigquery:
+    display_name: BigQuery
+    connections:
+      default:
+        mode: user
+        auth:
+          type: oauth2
+          client_id: ${GOOGLE_CLIENT_ID}
+          client_secret: ${GOOGLE_CLIENT_SECRET}
+          authorization_url: https://accounts.google.com/o/oauth2/v2/auth
+          token_url: https://oauth2.googleapis.com/token
+          scopes: [https://www.googleapis.com/auth/bigquery]
+    api:
+      type: rest
+      openapi: https://bigquery.googleapis.com/bigquery/v2/openapi.json
+      connection: default
+      allowed_operations:
+        list_datasets: {}
+        get_dataset: {}
+    plugin:
+      source: github.com/valon-technologies/gestalt/bigquery
+      connection: default
+```
+
+Both surfaces must share the same connection (`plugin.connection` and `api.connection` must reference the same name), so the user authenticates once. The API surface provides REST operations and the plugin binary provides custom operations like SQL query execution.
+
+Operation names must be unique across all surfaces. If an API operation and a plugin operation share a name, the server rejects the configuration at startup.
+
+### Plugin + MCP
 
 ```yaml
 integrations:
@@ -217,7 +255,11 @@ integrations:
 
 Setting `mcp.connection` to `plugin` reuses the plugin's OAuth token for the MCP surface. Alternatively, declare explicit `connections` and reference one from `mcp.connection`.
 
-Hybrid integrations cannot declare an `api` surface. If `connections` are declared, they must be paired with an `mcp` surface.
+### Shared Connections
+
+When `plugin.connection` is set, the plugin uses a connection from the integration's shared pool instead of building a separate connection from the plugin manifest's auth config. This enables single-auth-flow integrations where all surfaces share one token.
+
+When `plugin.connection` is omitted, the plugin falls back to its manifest's auth config (the default behavior for plugin-only integrations).
 
 ## Metadata
 

--- a/server/cmd/gestaltd/e2e_test.go
+++ b/server/cmd/gestaltd/e2e_test.go
@@ -486,3 +486,105 @@ func waitForEndpoint(t *testing.T, url string, timeout time.Duration) {
 	}
 	t.Fatalf("%s did not return 200 within %s", url, timeout)
 }
+
+func TestE2EHybridAPIPluginIntegration(t *testing.T) {
+	t.Parallel()
+
+	upstreamAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"id":"1","name":"test"}]}`))
+	}))
+	t.Cleanup(upstreamAPI.Close)
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+	archivePath := filepath.Join(dir, "plugin.tar.gz")
+	if err := pluginpkg.CreatePackageFromDir(pluginDir, archivePath); err != nil {
+		t.Fatalf("CreatePackageFromDir: %v", err)
+	}
+
+	port := allocateTestPort(t)
+	cfgPath := writeHybridAPIPluginConfig(t, dir, archivePath, upstreamAPI.URL, port)
+
+	bundleDir := filepath.Join(dir, "bundle")
+	out, err := exec.Command(gestaltdBin, "bundle", "--config", cfgPath, "--output", bundleDir).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd bundle: %v\n%s", err, out)
+	}
+
+	bundledCfg := filepath.Join(bundleDir, "config.yaml")
+	out, err = exec.Command(gestaltdBin, "validate", "--config", bundledCfg).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd validate failed for hybrid api+plugin config: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "config ok") {
+		t.Fatalf("expected 'config ok' in validate output, got: %s", out)
+	}
+
+	cmd := exec.Command(gestaltdBin, "serve", "--locked", "--config", bundledCfg)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start serve: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(os.Interrupt)
+		_ = cmd.Wait()
+	})
+
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	waitForReady(t, baseURL, 30*time.Second)
+}
+
+func writeHybridAPIPluginConfig(t *testing.T, dir, packageRef, upstreamURL string, port int) string {
+	t.Helper()
+
+	openapiSpec := fmt.Sprintf(`{
+  "openapi": "3.0.0",
+  "info": {"title": "Test API", "version": "1.0"},
+  "servers": [{"url": %q}],
+  "paths": {
+    "/items": {
+      "get": {
+        "operationId": "list_items",
+        "summary": "List items",
+        "responses": {"200": {"description": "OK"}}
+      }
+    }
+  }
+}`, upstreamURL)
+	specPath := filepath.Join(dir, "openapi.json")
+	if err := os.WriteFile(specPath, []byte(openapiSpec), 0644); err != nil {
+		t.Fatalf("write openapi spec: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := fmt.Sprintf(`auth:
+  provider: none
+datastore:
+  provider: sqlite
+  config:
+    path: %s
+server:
+  port: %d
+  encryption_key: test-hybrid-key
+integrations:
+  hybrid:
+    display_name: Hybrid Test
+    connections:
+      default:
+        mode: none
+    api:
+      type: rest
+      openapi: %s
+      connection: default
+    plugin:
+      package: %s
+      connection: default
+`, filepath.Join(dir, "gestalt.db"), port, specPath, packageRef)
+
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return cfgPath
+}

--- a/server/cmd/gestaltd/init_test.go
+++ b/server/cmd/gestaltd/init_test.go
@@ -253,7 +253,7 @@ func TestValidateConfigRejectsPluginHybridMisconfiguration(t *testing.T) {
 		wantContain string
 	}{
 		{
-			name: "plugin with api is rejected",
+			name: "plugin with api requires plugin.connection",
 			body: `integrations:
   sample:
     plugin:
@@ -263,7 +263,7 @@ func TestValidateConfigRejectsPluginHybridMisconfiguration(t *testing.T) {
       openapi: https://example.com/spec.json
       connection: default
 `,
-			wantContain: "cannot compose plugin with api",
+			wantContain: "plugin.connection is required when composing plugin with api",
 		},
 	}
 

--- a/server/internal/bootstrap/bootstrap.go
+++ b/server/internal/bootstrap/bootstrap.go
@@ -704,12 +704,19 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 			return nil, err
 		}
 
+		if intg.API != nil {
+			return buildAPIPluginProvider(ctx, name, intg, restricted, pluginConfig, factories, deps)
+		}
 		if intg.MCP != nil {
 			return buildPluginMCPProvider(ctx, name, intg, restricted, pluginConfig, factories, deps)
 		}
 
 		buildResult := &ProviderBuildResult{Provider: restricted}
-		attachPluginOAuth(name, intg, pluginConfig, deps, buildResult)
+		if intg.Plugin.Connection == "" {
+			attachPluginOAuth(name, intg, pluginConfig, deps, buildResult)
+		} else {
+			attachPluginOAuthForConnection(name, intg, pluginConfig, deps, buildResult)
+		}
 		return buildResult, nil
 	}
 
@@ -718,6 +725,55 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 		return nil, err
 	}
 	return factory(ctx, name, intg, deps)
+}
+
+func buildAPIPluginProvider(ctx context.Context, name string, intg config.IntegrationDef, pluginProv core.Provider, pluginConfig map[string]any, factories *FactoryRegistry, deps Deps) (_ *ProviderBuildResult, err error) {
+	cleanupPlugin := true
+	defer func() {
+		if cleanupPlugin {
+			if c, ok := pluginProv.(interface{ Close() error }); ok {
+				_ = c.Close()
+			}
+		}
+	}()
+
+	factory, err := providerFactoryForName(name, factories)
+	if err != nil {
+		return nil, err
+	}
+	apiResult, err := factory(ctx, name, intg, deps)
+	if err != nil {
+		return nil, fmt.Errorf("building api surface for %q: %w", name, err)
+	}
+
+	displayName := intg.DisplayName
+	if displayName == "" {
+		displayName = name
+	}
+	merged, err := composite.NewMerged(name, displayName, intg.Description, apiResult.Provider, pluginProv)
+	if err != nil {
+		if c, ok := apiResult.Provider.(interface{ Close() error }); ok {
+			_ = c.Close()
+		}
+		return nil, fmt.Errorf("merging api and plugin for %q: %w", name, err)
+	}
+	cleanupPlugin = false
+
+	var prov core.Provider = merged
+	if intg.MCP != nil {
+		mcpUp, ok := apiResult.Provider.(composite.MCPUpstream)
+		if !ok {
+			_ = merged.Close()
+			return nil, fmt.Errorf("integration %q has mcp surface but api factory did not return MCPUpstream", name)
+		}
+		merged.DisownProvider(apiResult.Provider)
+		prov = composite.New(name, merged, mcpUp)
+	}
+
+	return &ProviderBuildResult{
+		Provider:       prov,
+		ConnectionAuth: apiResult.ConnectionAuth,
+	}, nil
 }
 
 func buildDeclarativeProvider(name string, intg config.IntegrationDef, deps Deps) (*ProviderBuildResult, error) {
@@ -868,10 +924,36 @@ func buildPluginMCPProvider(ctx context.Context, name string, intg config.Integr
 		Provider:       composed,
 		ConnectionAuth: mcpResult.ConnectionAuth,
 	}
-	attachPluginOAuth(name, intg, pluginConfig, deps, result)
+	if intg.Plugin.Connection == "" {
+		attachPluginOAuth(name, intg, pluginConfig, deps, result)
+	} else {
+		attachPluginOAuthForConnection(name, intg, pluginConfig, deps, result)
+	}
 
 	cleanupPlugin = false
 	return result, nil
+}
+
+func attachPluginOAuthForConnection(name string, intg config.IntegrationDef, pluginConfig map[string]any, deps Deps, result *ProviderBuildResult) {
+	if intg.Plugin == nil || intg.Plugin.Connection == "" {
+		return
+	}
+	conn, ok := intg.Connections[intg.Plugin.Connection]
+	if !ok || conn.Auth.Type != "oauth2" {
+		return
+	}
+	authHandler, err := buildPluginOAuthHandler(intg, pluginConfig, deps)
+	if err != nil {
+		slog.Warn("cannot build oauth handler for shared connection", "provider", name, "connection", intg.Plugin.Connection, "error", err)
+		return
+	}
+	if authHandler == nil {
+		return
+	}
+	if result.ConnectionAuth == nil {
+		result.ConnectionAuth = make(map[string]OAuthHandler)
+	}
+	result.ConnectionAuth[intg.Plugin.Connection] = authHandler
 }
 
 func attachPluginOAuth(name string, intg config.IntegrationDef, pluginConfig map[string]any, deps Deps, result *ProviderBuildResult) {
@@ -960,7 +1042,7 @@ func providerFactoryForName(name string, factories *FactoryRegistry) (ProviderFa
 }
 
 func validateProviderBuildAvailable(name string, intg config.IntegrationDef, factories *FactoryRegistry) error {
-	if intg.Plugin != nil && intg.MCP == nil {
+	if intg.Plugin != nil && intg.MCP == nil && intg.API == nil {
 		return nil
 	}
 	_, err := providerFactoryForName(name, factories)
@@ -975,6 +1057,8 @@ func BuildConnectionMap(cfg *config.Config) invocation.ConnectionMap {
 	m := make(invocation.ConnectionMap, len(cfg.Integrations))
 	for name, intg := range cfg.Integrations {
 		switch {
+		case intg.Plugin != nil && intg.Plugin.Connection != "":
+			m[name] = intg.Plugin.Connection
 		case intg.Plugin != nil:
 			m[name] = config.PluginConnectionName
 		case intg.API != nil:

--- a/server/internal/composite/merged.go
+++ b/server/internal/composite/merged.go
@@ -1,0 +1,124 @@
+package composite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+)
+
+type MergedProvider struct {
+	name, displayName, desc string
+	connMode                core.ConnectionMode
+	ops                     []core.Operation
+	route                   map[string]core.Provider
+	all                     []core.Provider
+	owned                   []core.Provider
+}
+
+var (
+	_ core.Provider        = (*MergedProvider)(nil)
+	_ core.CatalogProvider = (*MergedProvider)(nil)
+)
+
+func NewMerged(name, displayName, desc string, providers ...core.Provider) (*MergedProvider, error) {
+	all := make([]core.Provider, len(providers))
+	copy(all, providers)
+	m := &MergedProvider{
+		name:        name,
+		displayName: displayName,
+		desc:        desc,
+		route:       make(map[string]core.Provider),
+		all:         all,
+		owned:       providers,
+	}
+	for i, p := range providers {
+		if i == 0 {
+			m.connMode = p.ConnectionMode()
+		} else {
+			m.connMode = stricterConnectionMode(m.connMode, p.ConnectionMode())
+		}
+		for _, op := range p.ListOperations() {
+			if owner, exists := m.route[op.Name]; exists {
+				return nil, fmt.Errorf("operation %q provided by both %q and %q", op.Name, owner.Name(), p.Name())
+			}
+			m.route[op.Name] = p
+			m.ops = append(m.ops, op)
+		}
+	}
+	return m, nil
+}
+
+func (m *MergedProvider) Name() string                        { return m.name }
+func (m *MergedProvider) DisplayName() string                 { return m.displayName }
+func (m *MergedProvider) Description() string                 { return m.desc }
+func (m *MergedProvider) ConnectionMode() core.ConnectionMode { return m.connMode }
+func (m *MergedProvider) ListOperations() []core.Operation    { return m.ops }
+
+func (m *MergedProvider) Catalog() *catalog.Catalog {
+	richOps := make(map[string]catalog.CatalogOperation)
+	for _, p := range m.all {
+		cp, ok := p.(core.CatalogProvider)
+		if !ok {
+			continue
+		}
+		cat := cp.Catalog()
+		if cat == nil {
+			continue
+		}
+		for i := range cat.Operations {
+			if _, ours := m.route[cat.Operations[i].ID]; ours {
+				richOps[cat.Operations[i].ID] = cat.Operations[i]
+			}
+		}
+	}
+
+	cat := &catalog.Catalog{
+		Name:        m.name,
+		DisplayName: m.displayName,
+		Description: m.desc,
+	}
+	for _, op := range m.ops {
+		if rich, ok := richOps[op.Name]; ok {
+			cat.Operations = append(cat.Operations, rich)
+		} else {
+			cat.Operations = append(cat.Operations, catalog.CatalogOperation{
+				ID:          op.Name,
+				Title:       op.Name,
+				Description: op.Description,
+				Transport:   catalog.TransportREST,
+			})
+		}
+	}
+	return cat
+}
+
+func (m *MergedProvider) Execute(ctx context.Context, op string, params map[string]any, token string) (*core.OperationResult, error) {
+	p, ok := m.route[op]
+	if !ok {
+		return nil, fmt.Errorf("unknown operation %q", op)
+	}
+	return p.Execute(ctx, op, params, token)
+}
+
+func (m *MergedProvider) Close() error {
+	var err error
+	for i := len(m.owned) - 1; i >= 0; i-- {
+		if c, ok := m.owned[i].(io.Closer); ok {
+			err = errors.Join(err, c.Close())
+		}
+	}
+	return err
+}
+
+func (m *MergedProvider) DisownProvider(p core.Provider) {
+	for i, owned := range m.owned {
+		if owned == p {
+			m.owned = append(m.owned[:i], m.owned[i+1:]...)
+			return
+		}
+	}
+}

--- a/server/internal/composite/merged_test.go
+++ b/server/internal/composite/merged_test.go
@@ -1,0 +1,132 @@
+package composite_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/composite"
+)
+
+type fakeProvider struct {
+	name     string
+	connMode core.ConnectionMode
+	ops      []core.Operation
+	execFn   func(ctx context.Context, op string, params map[string]any, token string) (*core.OperationResult, error)
+	closed   bool
+}
+
+func (p *fakeProvider) Name() string                        { return p.name }
+func (p *fakeProvider) DisplayName() string                 { return p.name }
+func (p *fakeProvider) Description() string                 { return "" }
+func (p *fakeProvider) ConnectionMode() core.ConnectionMode { return p.connMode }
+func (p *fakeProvider) ListOperations() []core.Operation    { return p.ops }
+
+func (p *fakeProvider) Execute(ctx context.Context, op string, params map[string]any, token string) (*core.OperationResult, error) {
+	if p.execFn != nil {
+		return p.execFn(ctx, op, params, token)
+	}
+	return &core.OperationResult{Status: http.StatusOK, Body: `{"source":"` + p.name + `"}`}, nil
+}
+
+func (p *fakeProvider) Close() error { p.closed = true; return nil }
+
+func TestNewMergedRejectsOperationCollision(t *testing.T) {
+	t.Parallel()
+
+	_, err := composite.NewMerged("test", "Test", "desc",
+		&fakeProvider{name: "api", ops: []core.Operation{{Name: "search"}}},
+		&fakeProvider{name: "plugin", ops: []core.Operation{{Name: "search"}}},
+	)
+	if err == nil {
+		t.Fatal("expected error for duplicate operation name")
+	}
+	want := `operation "search" provided by both "api" and "plugin"`
+	if err.Error() != want {
+		t.Fatalf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestNewMergedRoutesExecuteByOperationName(t *testing.T) {
+	t.Parallel()
+
+	apiHit := false
+	pluginHit := false
+	merged, err := composite.NewMerged("test", "Test", "desc",
+		&fakeProvider{
+			name: "api",
+			ops:  []core.Operation{{Name: "list_items"}},
+			execFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				apiHit = true
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"from":"api"}`}, nil
+			},
+		},
+		&fakeProvider{
+			name: "plugin",
+			ops:  []core.Operation{{Name: "query"}},
+			execFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				pluginHit = true
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"from":"plugin"}`}, nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := merged.Execute(context.Background(), "list_items", nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	if !apiHit {
+		t.Error("expected api provider to handle list_items")
+	}
+
+	if _, err := merged.Execute(context.Background(), "query", nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	if !pluginHit {
+		t.Error("expected plugin provider to handle query")
+	}
+
+	if _, err := merged.Execute(context.Background(), "nonexistent", nil, ""); err == nil {
+		t.Error("expected error for unknown operation")
+	}
+}
+
+func TestNewMergedConnectionModeNone(t *testing.T) {
+	t.Parallel()
+
+	merged, err := composite.NewMerged("test", "Test", "desc",
+		&fakeProvider{name: "a", connMode: core.ConnectionModeNone, ops: []core.Operation{{Name: "a"}}},
+		&fakeProvider{name: "b", connMode: core.ConnectionModeNone, ops: []core.Operation{{Name: "b"}}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if merged.ConnectionMode() != core.ConnectionModeNone {
+		t.Errorf("expected %q, got %q", core.ConnectionModeNone, merged.ConnectionMode())
+	}
+}
+
+func TestMergedDisownProvider(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeProvider{name: "api", ops: []core.Operation{{Name: "a"}}}
+	plugin := &fakeProvider{name: "plugin", ops: []core.Operation{{Name: "b"}}}
+
+	merged, err := composite.NewMerged("test", "Test", "desc", api, plugin)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	merged.DisownProvider(api)
+	_ = merged.Close()
+
+	if api.closed {
+		t.Error("disowned provider should not be closed by merged")
+	}
+	if !plugin.closed {
+		t.Error("owned provider should be closed by merged")
+	}
+}

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -103,6 +103,7 @@ type ExecutablePluginDef struct {
 	AllowedHosts      []string                      `yaml:"allowed_hosts"`
 	Config            yaml.Node                     `yaml:"config"`
 	AllowedOperations map[string]*OperationOverride `yaml:"allowed_operations"`
+	Connection        string                        `yaml:"connection"`
 
 	ResolvedManifestPath string `yaml:"-"`
 	ResolvedIconFile     string `yaml:"-"`
@@ -525,8 +526,25 @@ func validateHybridIntegration(name string, intg IntegrationDef) error {
 		return err
 	}
 
+	if intg.Plugin.Connection != "" {
+		if len(intg.Connections) == 0 {
+			return fmt.Errorf("config validation: integration %q plugin.connection requires connections to be defined", name)
+		}
+		if _, ok := intg.Connections[intg.Plugin.Connection]; !ok {
+			return fmt.Errorf("config validation: integration %q plugin.connection %q not found in connections", name, intg.Plugin.Connection)
+		}
+	}
+
 	if intg.API != nil {
-		return fmt.Errorf("config validation: integration %q cannot compose plugin with api; only plugin + mcp is supported", name)
+		if intg.Plugin.Connection == "" {
+			return fmt.Errorf("config validation: integration %q plugin.connection is required when composing plugin with api", name)
+		}
+		if err := validateAPIDef(name, intg.API, intg.Connections); err != nil {
+			return err
+		}
+		if intg.API.Connection != intg.Plugin.Connection {
+			return fmt.Errorf("config validation: integration %q plugin.connection and api.connection must reference the same connection", name)
+		}
 	}
 
 	if intg.MCP != nil {
@@ -545,8 +563,8 @@ func validateHybridIntegration(name string, intg IntegrationDef) error {
 	}
 
 	if len(intg.Connections) > 0 {
-		if intg.MCP == nil {
-			return fmt.Errorf("config validation: integration %q has connections but no mcp surface; plugin + bare connections is not supported", name)
+		if intg.MCP == nil && intg.API == nil && intg.Plugin.Connection == "" {
+			return fmt.Errorf("config validation: integration %q has connections but no surface references them; use plugin.connection, api, or mcp", name)
 		}
 		if err := validateConnectionModes(name, intg.Connections); err != nil {
 			return err

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -1596,7 +1596,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 			wantErr: "plugin.source",
 		},
 		{
-			name: "plugin with connections but no mcp is rejected",
+			name: "plugin with connections but no surface reference is rejected",
 			cfg: &Config{
 				Integrations: map[string]IntegrationDef{
 					"sample": {
@@ -1605,19 +1605,72 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "plugin + bare connections is not supported",
+			wantErr: "no surface references them",
 		},
 		{
-			name: "plugin with api is rejected",
+			name: "plugin with connection referencing pool is valid",
 			cfg: &Config{
 				Integrations: map[string]IntegrationDef{
 					"sample": {
-						Plugin: &ExecutablePluginDef{Command: "/usr/bin/plugin"},
-						API:    &APIDef{Type: "rest"},
+						Connections: map[string]ConnectionDef{"default": {Mode: "user"}},
+						Plugin:      &ExecutablePluginDef{Command: "/usr/bin/plugin", Connection: "default"},
 					},
 				},
 			},
-			wantErr: "cannot compose plugin with api",
+		},
+		{
+			name: "plugin with api requires plugin.connection",
+			cfg: &Config{
+				Integrations: map[string]IntegrationDef{
+					"sample": {
+						Connections: map[string]ConnectionDef{"default": {Mode: "user"}},
+						Plugin:      &ExecutablePluginDef{Command: "/usr/bin/plugin"},
+						API:         &APIDef{Type: "rest", Connection: "default"},
+					},
+				},
+			},
+			wantErr: "plugin.connection is required when composing plugin with api",
+		},
+		{
+			name: "plugin with api and shared connection is valid",
+			cfg: &Config{
+				Integrations: map[string]IntegrationDef{
+					"sample": {
+						Connections: map[string]ConnectionDef{"default": {Mode: "user"}},
+						Plugin:      &ExecutablePluginDef{Command: "/usr/bin/plugin", Connection: "default"},
+						API:         &APIDef{Type: "rest", OpenAPI: "https://example.com/spec.json", Connection: "default"},
+					},
+				},
+			},
+		},
+		{
+			name: "plugin with api but missing connection rejected",
+			cfg: &Config{
+				Integrations: map[string]IntegrationDef{
+					"sample": {
+						Connections: map[string]ConnectionDef{"default": {Mode: "user"}},
+						Plugin:      &ExecutablePluginDef{Command: "/usr/bin/plugin", Connection: "nonexistent"},
+						API:         &APIDef{Type: "rest", OpenAPI: "https://example.com/spec.json", Connection: "default"},
+					},
+				},
+			},
+			wantErr: `plugin.connection "nonexistent" not found`,
+		},
+		{
+			name: "plugin with api using different connections rejected",
+			cfg: &Config{
+				Integrations: map[string]IntegrationDef{
+					"sample": {
+						Connections: map[string]ConnectionDef{
+							"api_conn":    {Mode: "user"},
+							"plugin_conn": {Mode: "user"},
+						},
+						Plugin: &ExecutablePluginDef{Command: "/usr/bin/plugin", Connection: "plugin_conn"},
+						API:    &APIDef{Type: "rest", OpenAPI: "https://example.com/spec.json", Connection: "api_conn"},
+					},
+				},
+			},
+			wantErr: "plugin.connection and api.connection must reference the same connection",
 		},
 		{
 			name: "runtime plugin with type rejected",


### PR DESCRIPTION
Integrations can now compose an API surface (REST or GraphQL from an
OpenAPI spec) with a plugin binary in a single integration. Both
surfaces share connections from the integration's connection pool via
the new `plugin.connection` field, so users authenticate once for the
entire integration. Operation names must be unique across surfaces;
duplicate names are rejected at startup with a clear error message.

This enables plugin authors to implement only custom operations (like
BigQuery's SQL query execution) while the deployer supplies an OpenAPI
spec for standard REST operations, eliminating boilerplate. The plugin
binary, API surface, and optionally an MCP surface can all be composed
together in a single integration.

Supported composition patterns after this change:

Plugin with shared connection (new):

```yaml
connections:
  default: {mode: user, auth: {type: oauth2, ...}}
plugin:
  source: github.com/org/repo/myplugin
  connection: default
```

API + plugin with shared connection (new):

```yaml
connections:
  default: {mode: user, auth: {type: oauth2, ...}}
api:
  type: rest
  openapi: https://example.com/openapi.json
  connection: default
plugin:
  source: github.com/org/repo/myplugin
  connection: default
```

API + plugin + MCP (new):

```yaml
connections:
  default: {mode: user, auth: {type: oauth2, ...}}
api:
  type: rest
  openapi: https://example.com/openapi.json
  connection: default
plugin:
  source: github.com/org/repo/myplugin
  connection: default
mcp:
  url: https://mcp.example.com/mcp
  connection: default
```

Plugin only without connection (unchanged):

```yaml
plugin:
  source: github.com/org/repo/myplugin
  config: {client_id: ..., client_secret: ...}
```

When `plugin.connection` is omitted, plugin auth falls back to the
manifest's auth config, preserving existing behavior for plugin-only
integrations.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>