### PR TITLE
Fix swallowed errors and add observability across the server

### DIFF
--- a/server/cmd/gestaltd/provider_factory.go
+++ b/server/cmd/gestaltd/provider_factory.go
@@ -209,7 +209,7 @@ func buildRegistrationStore(deps bootstrap.Deps) mcpoauth.RegistrationStore {
 	}
 	store := mcpoauth.NewSQLStore(db, enc, dialect)
 	if err := store.Migrate(context.Background()); err != nil {
-		slog.Warn("registration store migration failed", "component", "mcpoauth", "error", err)
+		slog.Error("registration store migration failed", "component", "mcpoauth", "error", err)
 	}
 	return store
 }

--- a/server/internal/bootstrap/bootstrap.go
+++ b/server/internal/bootstrap/bootstrap.go
@@ -238,8 +238,13 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		}
 	}()
 
+	encKey := crypto.DeriveKey(cfg.Server.EncryptionKey)
+	if encKey == nil {
+		slog.Warn("no encryption key configured; stored secrets will not be encrypted")
+	}
+
 	deps := Deps{
-		EncryptionKey: crypto.DeriveKey(cfg.Server.EncryptionKey),
+		EncryptionKey: encKey,
 		BaseURL:       cfg.Server.BaseURL,
 		SecretManager: sm,
 	}

--- a/server/internal/invocation/broker.go
+++ b/server/internal/invocation/broker.go
@@ -328,7 +328,9 @@ func (b *Broker) refreshTokenIfNeeded(ctx context.Context, token *core.Integrati
 		}
 		token.RefreshErrorCount++
 		token.UpdatedAt = time.Now()
-		_ = b.datastore.StoreToken(ctx, token)
+		if storeErr := b.datastore.StoreToken(ctx, token); storeErr != nil {
+			slog.WarnContext(ctx, "failed to persist refresh error count", "provider", providerName, "error", storeErr)
+		}
 		if time.Now().Before(*token.ExpiresAt) {
 			return token.AccessToken, nil
 		}

--- a/server/internal/server/handlers.go
+++ b/server/internal/server/handlers.go
@@ -1138,7 +1138,10 @@ func buildConnectionMetadata(prov core.Provider, userParams map[string]string, t
 	if len(metadata) == 0 {
 		return "", nil
 	}
-	b, _ := json.Marshal(metadata)
+	b, err := json.Marshal(metadata)
+	if err != nil {
+		return "", fmt.Errorf("marshal connection metadata: %w", err)
+	}
 	return string(b), nil
 }
 
@@ -1214,7 +1217,10 @@ func mergeMetadataJSON(existing string, extra map[string]string) (string, error)
 	for k, v := range extra {
 		m[k] = v
 	}
-	b, _ := json.Marshal(m)
+	b, err := json.Marshal(m)
+	if err != nil {
+		return "", fmt.Errorf("marshal merged metadata: %w", err)
+	}
 	return string(b), nil
 }
 
@@ -1251,7 +1257,10 @@ func (s *Server) runPostConnect(ctx context.Context, prov core.Provider, tm toke
 			if err != nil {
 				return nil, err
 			}
-			candidatesJSON, _ := json.Marshal(candidates)
+			candidatesJSON, err := json.Marshal(candidates)
+			if err != nil {
+				return nil, fmt.Errorf("marshal discovery candidates: %w", err)
+			}
 			now := s.now().UTC().Truncate(time.Second)
 			sc := &core.StagedConnection{
 				ID:             uuid.NewString(),

--- a/server/internal/server/middleware.go
+++ b/server/internal/server/middleware.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -104,9 +105,11 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 				return
 			}
 			if errors.Is(lastErr, principal.ErrInvalidToken) {
+				slog.InfoContext(r.Context(), "auth: invalid token", "remote_addr", r.RemoteAddr)
 				writeError(w, http.StatusUnauthorized, "invalid token")
 				return
 			}
+			slog.ErrorContext(r.Context(), "auth: token validation failed", "remote_addr", r.RemoteAddr, "error", lastErr)
 			writeError(w, http.StatusInternalServerError, "token validation failed")
 			return
 		}
@@ -146,6 +149,7 @@ func (s *Server) proxyAuthMiddleware(next http.Handler) http.Handler {
 		if p == nil {
 			w.Header().Set("Proxy-Authenticate", "Bearer")
 			if lastErr != nil && !errors.Is(lastErr, principal.ErrInvalidToken) {
+				slog.ErrorContext(r.Context(), "proxy auth: token validation failed", "remote_addr", r.RemoteAddr, "error", lastErr)
 				writeError(w, http.StatusInternalServerError, "token validation failed")
 				return
 			}


### PR DESCRIPTION
Several error paths in the server silently discarded errors from
`json.Marshal`, token storage, and authentication validation. These
are now either returned to callers or logged with structured context
so failures are observable in production. Auth middleware now logs
failed token validations with the remote address for debugging.

The MCP OAuth registration store migration failure is now logged at
Error level since it represents a serious operational issue. A warning
is emitted at startup when no encryption key is configured so operators
are aware that stored secrets will not be encrypted.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>