### PR TITLE
Add singleflight deduplication for OAuth token refresh

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -44,6 +44,7 @@ require (
 	golang.org/x/crypto v0.48.0
 	golang.org/x/mod v0.34.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.14.0
 	google.golang.org/api v0.256.0
 	google.golang.org/grpc v1.79.3
@@ -112,7 +113,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
 	golang.org/x/net v0.51.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/genproto v0.0.0-20250603155806-513f23925822 // indirect

--- a/server/internal/invocation/broker.go
+++ b/server/internal/invocation/broker.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -81,6 +82,7 @@ type Broker struct {
 	datastore      core.Datastore
 	connMapper     ConnectionMapper
 	connectionAuth RefresherResolver
+	refreshGroup   singleflight.Group
 }
 
 type BrokerOption func(*Broker)
@@ -320,8 +322,36 @@ func (b *Broker) refreshTokenIfNeeded(ctx context.Context, token *core.Integrati
 		return token.AccessToken, nil
 	}
 
-	resp, err := b.refreshOAuth(ctx, refresher, token.RefreshToken)
+	key := token.UserID + ":" + providerName + ":" + connection + ":" + token.Instance
+	v, err, _ := b.refreshGroup.Do(key, func() (any, error) {
+		resp, err := b.refreshOAuth(ctx, refresher, token.RefreshToken)
+		if err != nil {
+			return nil, err
+		}
+		now := time.Now()
+		token.AccessToken = resp.AccessToken
+		if resp.RefreshToken != "" {
+			token.RefreshToken = resp.RefreshToken
+		}
+		if resp.ExpiresIn > 0 {
+			t := now.Add(time.Duration(resp.ExpiresIn) * time.Second)
+			token.ExpiresAt = &t
+		} else {
+			token.ExpiresAt = nil
+		}
+		token.LastRefreshedAt = &now
+		token.RefreshErrorCount = 0
+		token.UpdatedAt = now
+		if err := b.datastore.StoreToken(ctx, token); err != nil {
+			return nil, fmt.Errorf("%w: %w", errStoreToken, err)
+		}
+		return resp.AccessToken, nil
+	})
+
 	if err != nil {
+		if errors.Is(err, errStoreToken) {
+			return "", err
+		}
 		fresh, fetchErr := b.datastore.Token(ctx, token.UserID, token.Integration, token.Connection, token.Instance)
 		if fetchErr == nil && fresh != nil && fresh.AccessToken != token.AccessToken {
 			return fresh.AccessToken, nil
@@ -335,25 +365,7 @@ func (b *Broker) refreshTokenIfNeeded(ctx context.Context, token *core.Integrati
 		return "", fmt.Errorf("token expired and refresh failed: %w", err)
 	}
 
-	now := time.Now()
-	token.AccessToken = resp.AccessToken
-	if resp.RefreshToken != "" {
-		token.RefreshToken = resp.RefreshToken
-	}
-	if resp.ExpiresIn > 0 {
-		t := now.Add(time.Duration(resp.ExpiresIn) * time.Second)
-		token.ExpiresAt = &t
-	} else {
-		token.ExpiresAt = nil
-	}
-	token.LastRefreshedAt = &now
-	token.RefreshErrorCount = 0
-	token.UpdatedAt = now
-
-	if err := b.datastore.StoreToken(ctx, token); err != nil {
-		return "", fmt.Errorf("persisting refreshed token: %w", err)
-	}
-	return token.AccessToken, nil
+	return v.(string), nil
 }
 
 func (b *Broker) resolveRefresher(integration, connection string) OAuthRefresher {

--- a/server/internal/invocation/errors.go
+++ b/server/internal/invocation/errors.go
@@ -11,4 +11,5 @@ var (
 	ErrUserResolution    = errors.New("user resolution failed")
 	ErrInternal          = errors.New("internal error")
 	ErrScopeDenied       = errors.New("token scope denied")
+	errStoreToken        = errors.New("persisting refreshed token")
 )


### PR DESCRIPTION
When concurrent requests share an expired token, they all attempt to refresh it simultaneously, risking refresh token rotation conflicts with the OAuth provider. This wraps the refresh call in a singleflight.Group keyed on user/provider/connection/instance so only one goroutine performs the actual refresh. Shared callers re-fetch the token from the datastore to pick up the winner's stored result rather than using the response directly.

The error path continues to re-fetch from the store unconditionally (as before) to handle the case where a separate request already refreshed successfully outside the singleflight window.