### PR TITLE
Add supply chain metadata and Docker Hub description for gestalt image

### DIFF
--- a/.github/workflows/release-gestalt-cli.yml
+++ b/.github/workflows/release-gestalt-cli.yml
@@ -53,11 +53,17 @@ jobs:
     timeout-minutes: 60
     env:
       REGISTRY_IMAGE: valontechnologies/gestalt
+      IMAGE_SOURCE: https://github.com/${{ github.repository }}
+      IMAGE_DOCUMENTATION: https://docs.toolshed.peachstreet.dev
+      IMAGE_URL: https://hub.docker.com/r/valontechnologies/gestalt
     steps:
       - uses: actions/checkout@v6
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Compute image metadata
+        id: meta
+        run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
       - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -74,6 +80,13 @@ jobs:
           tags: |
             ${{ env.REGISTRY_IMAGE }}:${{ steps.version.outputs.version }}
             ${{ env.REGISTRY_IMAGE }}:latest
+          build-args: |
+            GESTALT_VERSION=${{ steps.version.outputs.version }}
+            GESTALT_REVISION=${{ github.sha }}
+            GESTALT_CREATED=${{ steps.meta.outputs.created }}
+            GESTALT_SOURCE=${{ env.IMAGE_SOURCE }}
+            GESTALT_DOCUMENTATION=${{ env.IMAGE_DOCUMENTATION }}
+            GESTALT_URL=${{ env.IMAGE_URL }}
           cache-from: type=gha
           cache-to: type=gha,mode=min
           sbom: true
@@ -86,6 +99,14 @@ jobs:
           exit-code: '1'
           severity: CRITICAL,HIGH
           ignore-unfixed: true
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_DESCRIPTION_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_DESCRIPTION_PASSWORD }}
+          repository: ${{ env.REGISTRY_IMAGE }}
+          short-description: CLI client for managing Gestalt integrations, authentication, and operations.
+          readme-filepath: docs/dockerhub/gestalt.md
 
   update-formula:
     name: Update Homebrew Formula

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,3 +1,10 @@
+ARG GESTALT_VERSION=dev
+ARG GESTALT_REVISION=unknown
+ARG GESTALT_CREATED=unknown
+ARG GESTALT_SOURCE=https://github.com/valon-technologies/gestalt
+ARG GESTALT_DOCUMENTATION=https://docs.toolshed.peachstreet.dev
+ARG GESTALT_URL=https://hub.docker.com/r/valontechnologies/gestalt
+
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.9.0 AS xx
 
 FROM --platform=$BUILDPLATFORM rust:1-alpine AS builder
@@ -17,6 +24,20 @@ RUN RUST_TARGET=$(xx-info rust-target) && \
     xx-verify /gestalt
 
 FROM gcr.io/distroless/static-debian12
+ARG GESTALT_VERSION
+ARG GESTALT_REVISION
+ARG GESTALT_CREATED
+ARG GESTALT_SOURCE
+ARG GESTALT_DOCUMENTATION
+ARG GESTALT_URL
 COPY --from=builder /gestalt /gestalt
+LABEL org.opencontainers.image.title="gestalt" \
+      org.opencontainers.image.description="CLI client for managing Gestalt integrations, authentication, and operations." \
+      org.opencontainers.image.source="${GESTALT_SOURCE}" \
+      org.opencontainers.image.documentation="${GESTALT_DOCUMENTATION}" \
+      org.opencontainers.image.url="${GESTALT_URL}" \
+      org.opencontainers.image.version="${GESTALT_VERSION}" \
+      org.opencontainers.image.revision="${GESTALT_REVISION}" \
+      org.opencontainers.image.created="${GESTALT_CREATED}"
 USER nobody:nobody
 ENTRYPOINT ["/gestalt"]

--- a/docs/dockerhub/gestalt.md
+++ b/docs/dockerhub/gestalt.md
@@ -1,0 +1,110 @@
+# gestalt Docker image
+
+`gestalt` is a CLI client for the Gestalt API. It connects to a running
+`gestaltd` server and provides commands for:
+
+- authenticating via OAuth or API tokens
+- listing and connecting third-party integrations
+- invoking integration operations
+- managing configuration and credentials
+
+## Quick reference
+
+- Image: `valontechnologies/gestalt`
+- Entrypoint: `/gestalt`
+- This image contains a statically linked binary on a distroless base. There is no shell.
+
+## Supported tags
+
+- `latest`
+- `<version>`
+
+The image is published for `linux/amd64` and `linux/arm64`.
+
+## What the image includes
+
+The image uses `gcr.io/distroless/static-debian12` as its base and contains
+only the `gestalt` binary and CA certificates. It runs as `nobody:nobody`.
+
+## Usage
+
+Point the CLI at a running `gestaltd` server:
+
+```sh
+docker run --rm \
+  -e GESTALT_URL=https://gestalt.example.com \
+  -e GESTALT_API_KEY=gst_... \
+  valontechnologies/gestalt:latest \
+  integrations list
+```
+
+### Invoke an operation
+
+```sh
+docker run --rm \
+  -e GESTALT_URL=https://gestalt.example.com \
+  -e GESTALT_API_KEY=gst_... \
+  valontechnologies/gestalt:latest \
+  invoke github search_code -p "query=gestalt org:my-org"
+```
+
+### Use in CI pipelines
+
+The Docker image works well in CI environments where installing the native
+binary is inconvenient:
+
+```yaml
+jobs:
+  check-integrations:
+    runs-on: ubuntu-latest
+    container:
+      image: valontechnologies/gestalt:latest
+    steps:
+      - run: gestalt integrations list --format json
+        env:
+          GESTALT_URL: ${{ vars.GESTALT_URL }}
+          GESTALT_API_KEY: ${{ secrets.GESTALT_API_KEY }}
+```
+
+## Available commands
+
+| Command                     | Description                            |
+|-----------------------------|----------------------------------------|
+| `auth login`                | Log in via browser OAuth flow          |
+| `auth logout`               | Log out and clear stored credentials   |
+| `auth status`               | Show authentication status             |
+| `init`                      | Interactive setup wizard               |
+| `config get/set/unset/list` | Manage persistent configuration        |
+| `integrations list`         | List available integrations            |
+| `integrations connect`      | Connect an integration via OAuth       |
+| `invoke <integ> <op>`       | Execute an integration operation       |
+| `describe <integ> <op>`     | Describe an integration operation      |
+| `tokens create/list/revoke` | Manage API tokens                      |
+
+Use `--format json` or `--format table` to control output format.
+
+## Environment variables
+
+| Variable          | Description                     |
+|-------------------|---------------------------------|
+| `GESTALT_URL`     | Base URL of the gestaltd server |
+| `GESTALT_API_KEY` | API token for authentication    |
+
+## Debugging
+
+The image is distroless and does not include a shell. Use the `--help` flag
+to inspect available commands:
+
+```sh
+docker run --rm valontechnologies/gestalt:latest --help
+docker run --rm valontechnologies/gestalt:latest invoke --help
+```
+
+For an interactive shell, use the native binary or Homebrew install instead
+of the Docker image.
+
+## Learn more
+
+- Docs: https://docs.toolshed.peachstreet.dev
+- CLI reference: https://docs.toolshed.peachstreet.dev/reference/cli
+- Source: https://github.com/valon-technologies/gestalt


### PR DESCRIPTION
The gestaltd Docker image already had OCI labels, build-arg metadata,
and an automated Docker Hub description update, but the gestalt CLI
image was missing all three. This adds the same supply chain metadata
to the CLI image: OCI labels in the Dockerfile for version, source,
and provenance tracking, build-args in the release workflow to populate
those labels at build time, and a `peter-evans/dockerhub-description`
step to keep the Docker Hub page in sync with `docs/dockerhub/gestalt.md`.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>