### PR TITLE
Improve server error handling and observability

### DIFF
--- a/server/internal/bootstrap/bootstrap.go
+++ b/server/internal/bootstrap/bootstrap.go
@@ -238,13 +238,13 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		}
 	}()
 
-	encKey := crypto.DeriveKey(cfg.Server.EncryptionKey)
-	if encKey == nil {
+	encryptionKey := crypto.DeriveKey(cfg.Server.EncryptionKey)
+	if encryptionKey == nil {
 		slog.Warn("no encryption key configured; stored secrets will not be encrypted")
 	}
 
 	deps := Deps{
-		EncryptionKey: encKey,
+		EncryptionKey: encryptionKey,
 		BaseURL:       cfg.Server.BaseURL,
 		SecretManager: sm,
 	}


### PR DESCRIPTION
Several error paths in the server silently discarded errors or logged
them at inappropriate levels. JSON marshal failures during connection
setup and discovery are now surfaced as proper errors instead of being
ignored. The registration store migration failure is logged at error
level rather than warn, and token refresh persistence failures are now
logged with context. Auth middleware logs authentication failures to
aid debugging, and startup warns when no encryption key is configured.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>