### PR TITLE
Add Runtime interface to pluginsdk

### DIFF
--- a/examples/plugins/runtime-go/go.mod
+++ b/examples/plugins/runtime-go/go.mod
@@ -2,18 +2,16 @@ module github.com/valon-technologies/gestalt/examples/plugins/runtime-go
 
 go 1.26
 
-require (
-	github.com/valon-technologies/gestalt/sdk/pluginapi v0.0.0-00010101000000-000000000000
-	github.com/valon-technologies/gestalt/sdk/pluginsdk v0.0.0-00010101000000-000000000000
-	google.golang.org/grpc v1.79.3
-	google.golang.org/protobuf v1.36.10
-)
+require github.com/valon-technologies/gestalt/sdk/pluginsdk v0.0.0-00010101000000-000000000000
 
 require (
+	github.com/valon-technologies/gestalt/sdk/pluginapi v0.0.0-00010101000000-000000000000 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
+	google.golang.org/protobuf v1.36.10 // indirect
 )
 
 replace (

--- a/examples/plugins/runtime-go/main.go
+++ b/examples/plugins/runtime-go/main.go
@@ -13,12 +13,8 @@ import (
 
 type exampleRuntime struct{}
 
-func (r *exampleRuntime) Start(ctx context.Context, name string, config map[string]any, host pluginsdk.RuntimeHost) error {
-	caps, err := host.ListCapabilities(ctx)
-	if err != nil {
-		return err
-	}
-	log.Printf("example runtime %q started with %d capabilities", name, len(caps))
+func (r *exampleRuntime) Start(ctx context.Context, name string, config map[string]any, capabilities []pluginsdk.Capability, host pluginsdk.RuntimeHost) error {
+	log.Printf("example runtime %q started with %d initial capabilities", name, len(capabilities))
 	return nil
 }
 

--- a/examples/plugins/runtime-go/main.go
+++ b/examples/plugins/runtime-go/main.go
@@ -8,40 +8,23 @@ import (
 	"os/signal"
 	"syscall"
 
-	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
 	pluginsdk "github.com/valon-technologies/gestalt/sdk/pluginsdk"
-	"google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-type exampleRuntime struct {
-	pluginapiv1.UnimplementedRuntimePluginServer
-	hostConn *grpc.ClientConn
-	host     pluginapiv1.RuntimeHostClient
+type exampleRuntime struct{}
+
+func (r *exampleRuntime) Start(ctx context.Context, name string, config map[string]any, host pluginsdk.RuntimeHost) error {
+	caps, err := host.ListCapabilities(ctx)
+	if err != nil {
+		return err
+	}
+	log.Printf("example runtime %q started with %d capabilities", name, len(caps))
+	return nil
 }
 
-func (r *exampleRuntime) Start(ctx context.Context, req *pluginapiv1.StartRuntimeRequest) (*emptypb.Empty, error) {
-	conn, host, err := pluginsdk.DialRuntimeHost(ctx)
-	if err != nil {
-		return nil, err
-	}
-	r.hostConn = conn
-	r.host = host
-
-	caps, err := host.ListCapabilities(ctx, &emptypb.Empty{})
-	if err != nil {
-		return nil, err
-	}
-	log.Printf("example runtime %q started with %d capabilities", req.GetName(), len(caps.GetCapabilities()))
-	return &emptypb.Empty{}, nil
-}
-
-func (r *exampleRuntime) Stop(_ context.Context, _ *emptypb.Empty) (*emptypb.Empty, error) {
-	if r.hostConn != nil {
-		_ = r.hostConn.Close()
-	}
+func (r *exampleRuntime) Stop(ctx context.Context) error {
 	log.Println("example runtime stopped")
-	return &emptypb.Empty{}, nil
+	return nil
 }
 
 func main() {

--- a/sdk/pluginsdk/convert.go
+++ b/sdk/pluginsdk/convert.go
@@ -79,6 +79,79 @@ func operationsToProto(ops []Operation) ([]*pluginapiv1.Operation, error) {
 	return out, nil
 }
 
+func principalSourceToProto(src PrincipalSource) pluginapiv1.PrincipalSource {
+	switch src {
+	case PrincipalSourceSession:
+		return pluginapiv1.PrincipalSource_PRINCIPAL_SOURCE_SESSION
+	case PrincipalSourceAPIToken:
+		return pluginapiv1.PrincipalSource_PRINCIPAL_SOURCE_API_TOKEN
+	case PrincipalSourceEnv:
+		return pluginapiv1.PrincipalSource_PRINCIPAL_SOURCE_ENV
+	default:
+		return pluginapiv1.PrincipalSource_PRINCIPAL_SOURCE_UNSPECIFIED
+	}
+}
+
+func principalToProto(p Principal) *pluginapiv1.Principal {
+	msg := &pluginapiv1.Principal{
+		UserId: p.UserID,
+		Source: principalSourceToProto(p.Source),
+	}
+	if p.Identity != nil {
+		msg.Identity = &pluginapiv1.UserIdentity{
+			Email:       p.Identity.Email,
+			DisplayName: p.Identity.DisplayName,
+			AvatarUrl:   p.Identity.AvatarURL,
+		}
+	}
+	return msg
+}
+
+func parameterFromProto(msg *pluginapiv1.Parameter) Parameter {
+	if msg == nil {
+		return Parameter{}
+	}
+	var def any
+	if msg.GetDefaultValue() != nil {
+		def = msg.GetDefaultValue().AsInterface()
+	}
+	return Parameter{
+		Name:        msg.GetName(),
+		Type:        msg.GetType(),
+		Description: msg.GetDescription(),
+		Required:    msg.GetRequired(),
+		Default:     def,
+	}
+}
+
+func parametersFromProto(params []*pluginapiv1.Parameter) []Parameter {
+	out := make([]Parameter, 0, len(params))
+	for _, p := range params {
+		out = append(out, parameterFromProto(p))
+	}
+	return out
+}
+
+func capabilityFromProto(msg *pluginapiv1.Capability) Capability {
+	if msg == nil {
+		return Capability{}
+	}
+	return Capability{
+		Provider:    msg.GetProvider(),
+		Operation:   msg.GetOperation(),
+		Description: msg.GetDescription(),
+		Parameters:  parametersFromProto(msg.GetParameters()),
+	}
+}
+
+func capabilitiesFromProto(caps []*pluginapiv1.Capability) []Capability {
+	out := make([]Capability, 0, len(caps))
+	for _, c := range caps {
+		out = append(out, capabilityFromProto(c))
+	}
+	return out
+}
+
 func connectionParamDefsToProto(defs map[string]ConnectionParamDef) map[string]*pluginapiv1.ConnectionParamDef {
 	if len(defs) == 0 {
 		return nil

--- a/sdk/pluginsdk/plugin.go
+++ b/sdk/pluginsdk/plugin.go
@@ -17,22 +17,10 @@ func ServeProvider(ctx context.Context, provider Provider) error {
 	})
 }
 
-func ServeRuntime(ctx context.Context, server pluginapiv1.RuntimePluginServer) error {
+func ServeRuntime(ctx context.Context, runtime Runtime) error {
 	return servePlugin(ctx, func(srv *grpc.Server) {
-		pluginapiv1.RegisterRuntimePluginServer(srv, server)
+		pluginapiv1.RegisterRuntimePluginServer(srv, NewRuntimeServer(runtime))
 	})
-}
-
-func DialRuntimeHost(ctx context.Context) (*grpc.ClientConn, pluginapiv1.RuntimeHostClient, error) {
-	socket := os.Getenv(pluginapiv1.EnvRuntimeHostSocket)
-	if socket == "" {
-		return nil, nil, fmt.Errorf("%s is required", pluginapiv1.EnvRuntimeHostSocket)
-	}
-	conn, err := dialUnixSocket(ctx, socket)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, pluginapiv1.NewRuntimeHostClient(conn), nil
 }
 
 func DialProviderHost(ctx context.Context) (*grpc.ClientConn, pluginapiv1.ProviderHostClient, error) {

--- a/sdk/pluginsdk/plugin_transport_test.go
+++ b/sdk/pluginsdk/plugin_transport_test.go
@@ -15,14 +15,16 @@ import (
 )
 
 type stubRuntime struct {
-	started  int
-	stopped  int
-	lastName string
+	started      int
+	stopped      int
+	lastName     string
+	lastInitCaps []pluginsdk.Capability
 }
 
-func (s *stubRuntime) Start(_ context.Context, name string, _ map[string]any, _ pluginsdk.RuntimeHost) error {
+func (s *stubRuntime) Start(_ context.Context, name string, _ map[string]any, caps []pluginsdk.Capability, _ pluginsdk.RuntimeHost) error {
 	s.started++
 	s.lastName = name
+	s.lastInitCaps = caps
 	return nil
 }
 
@@ -122,7 +124,13 @@ func TestServeRuntimeRoundTrip(t *testing.T) {
 	rpcCtx, rpcCancel := context.WithTimeout(context.Background(), time.Second)
 	defer rpcCancel()
 
-	if _, err := client.Start(rpcCtx, &pluginapiv1.StartRuntimeRequest{Name: "echo"}, grpc.WaitForReady(true)); err != nil {
+	startReq := &pluginapiv1.StartRuntimeRequest{
+		Name: "echo",
+		InitialCapabilities: []*pluginapiv1.Capability{
+			{Provider: "beta", Operation: "write", Description: "test cap"},
+		},
+	}
+	if _, err := client.Start(rpcCtx, startReq, grpc.WaitForReady(true)); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 	if _, err := client.Stop(rpcCtx, &emptypb.Empty{}, grpc.WaitForReady(true)); err != nil {
@@ -130,6 +138,9 @@ func TestServeRuntimeRoundTrip(t *testing.T) {
 	}
 	if rt.started != 1 || rt.stopped != 1 || rt.lastName != "echo" {
 		t.Fatalf("unexpected runtime state: started=%d stopped=%d lastName=%q", rt.started, rt.stopped, rt.lastName)
+	}
+	if len(rt.lastInitCaps) != 1 || rt.lastInitCaps[0].Provider != "beta" || rt.lastInitCaps[0].Operation != "write" {
+		t.Fatalf("unexpected initial capabilities: %+v", rt.lastInitCaps)
 	}
 }
 
@@ -166,7 +177,7 @@ type capturingRuntime struct {
 	host *pluginsdk.RuntimeHost
 }
 
-func (r *capturingRuntime) Start(_ context.Context, _ string, _ map[string]any, host pluginsdk.RuntimeHost) error {
+func (r *capturingRuntime) Start(_ context.Context, _ string, _ map[string]any, _ []pluginsdk.Capability, host pluginsdk.RuntimeHost) error {
 	*r.host = host
 	return nil
 }

--- a/sdk/pluginsdk/plugin_transport_test.go
+++ b/sdk/pluginsdk/plugin_transport_test.go
@@ -3,6 +3,7 @@ package pluginsdk_test
 import (
 	"context"
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -13,22 +14,21 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-type stubRuntimePlugin struct {
-	pluginapiv1.UnimplementedRuntimePluginServer
-	started int
-	stopped int
-	lastReq *pluginapiv1.StartRuntimeRequest
+type stubRuntime struct {
+	started  int
+	stopped  int
+	lastName string
 }
 
-func (s *stubRuntimePlugin) Start(_ context.Context, req *pluginapiv1.StartRuntimeRequest) (*emptypb.Empty, error) {
+func (s *stubRuntime) Start(_ context.Context, name string, _ map[string]any, _ pluginsdk.RuntimeHost) error {
 	s.started++
-	s.lastReq = req
-	return &emptypb.Empty{}, nil
+	s.lastName = name
+	return nil
 }
 
-func (s *stubRuntimePlugin) Stop(context.Context, *emptypb.Empty) (*emptypb.Empty, error) {
+func (s *stubRuntime) Stop(context.Context) error {
 	s.stopped++
-	return &emptypb.Empty{}, nil
+	return nil
 }
 
 type stubRuntimeHost struct {
@@ -76,23 +76,48 @@ func TestServeProviderRoundTrip(t *testing.T) {
 	}
 }
 
-func TestServeRuntimeRoundTrip(t *testing.T) {
-	socket := filepath.Join(t.TempDir(), "runtime.sock")
-	t.Setenv(pluginapiv1.EnvPluginSocket, socket)
+func newRuntimeTestEnv(t *testing.T, rt pluginsdk.Runtime) pluginapiv1.RuntimePluginClient {
+	t.Helper()
 
-	server := &stubRuntimePlugin{}
+	dir, err := os.MkdirTemp("/tmp", "sdk-rt-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	pluginSocket := filepath.Join(dir, "rt.sock")
+	hostSocket := filepath.Join(dir, "host.sock")
+	t.Setenv(pluginapiv1.EnvPluginSocket, pluginSocket)
+	t.Setenv(pluginapiv1.EnvRuntimeHostSocket, hostSocket)
+
+	hostLis, err := net.Listen("unix", hostSocket)
+	if err != nil {
+		t.Fatalf("net.Listen host: %v", err)
+	}
+	t.Cleanup(func() { _ = hostLis.Close() })
+
+	hostSrv := grpc.NewServer()
+	pluginapiv1.RegisterRuntimeHostServer(hostSrv, &stubRuntimeHost{})
+	go func() { _ = hostSrv.Serve(hostLis) }()
+	t.Cleanup(hostSrv.Stop)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- pluginsdk.ServeRuntime(ctx, server)
+		errCh <- pluginsdk.ServeRuntime(ctx, rt)
 	}()
 	t.Cleanup(func() {
 		cancel()
 		waitServeResult(t, errCh)
 	})
 
-	conn := newUnixConn(t, socket)
-	client := pluginapiv1.NewRuntimePluginClient(conn)
+	conn := newUnixConn(t, pluginSocket)
+	return pluginapiv1.NewRuntimePluginClient(conn)
+}
+
+func TestServeRuntimeRoundTrip(t *testing.T) {
+	rt := &stubRuntime{}
+	client := newRuntimeTestEnv(t, rt)
 
 	rpcCtx, rpcCancel := context.WithTimeout(context.Background(), time.Second)
 	defer rpcCancel()
@@ -103,40 +128,49 @@ func TestServeRuntimeRoundTrip(t *testing.T) {
 	if _, err := client.Stop(rpcCtx, &emptypb.Empty{}, grpc.WaitForReady(true)); err != nil {
 		t.Fatalf("Stop: %v", err)
 	}
-	if server.started != 1 || server.stopped != 1 || server.lastReq.GetName() != "echo" {
-		t.Fatalf("unexpected runtime server state: %+v", server)
+	if rt.started != 1 || rt.stopped != 1 || rt.lastName != "echo" {
+		t.Fatalf("unexpected runtime state: started=%d stopped=%d lastName=%q", rt.started, rt.stopped, rt.lastName)
 	}
 }
 
-func TestDialRuntimeHostRoundTrip(t *testing.T) {
-	socket := filepath.Join(t.TempDir(), "host.sock")
-	t.Setenv(pluginapiv1.EnvRuntimeHostSocket, socket)
+func TestServeRuntimeHostIntegration(t *testing.T) {
+	var capturedHost pluginsdk.RuntimeHost
+	capturingRT := &capturingRuntime{host: &capturedHost}
+	client := newRuntimeTestEnv(t, capturingRT)
 
-	lis, err := net.Listen("unix", socket)
-	if err != nil {
-		t.Fatalf("net.Listen: %v", err)
-	}
-	t.Cleanup(func() { _ = lis.Close() })
-
-	srv := grpc.NewServer()
-	pluginapiv1.RegisterRuntimeHostServer(srv, &stubRuntimeHost{})
-	go func() { _ = srv.Serve(lis) }()
-	t.Cleanup(srv.Stop)
-
-	conn, client, err := pluginsdk.DialRuntimeHost(context.Background())
-	if err != nil {
-		t.Fatalf("DialRuntimeHost: %v", err)
-	}
-	t.Cleanup(func() { _ = conn.Close() })
-
-	rpcCtx, rpcCancel := context.WithTimeout(context.Background(), time.Second)
+	rpcCtx, rpcCancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer rpcCancel()
 
-	resp, err := client.ListCapabilities(rpcCtx, &emptypb.Empty{}, grpc.WaitForReady(true))
+	if _, err := client.Start(rpcCtx, &pluginapiv1.StartRuntimeRequest{Name: "test-rt"}, grpc.WaitForReady(true)); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if capturedHost == nil {
+		t.Fatal("RuntimeHost was not passed to Start")
+	}
+
+	caps, err := capturedHost.ListCapabilities(rpcCtx)
 	if err != nil {
-		t.Fatalf("ListCapabilities: %v", err)
+		t.Fatalf("ListCapabilities via SDK host: %v", err)
 	}
-	if len(resp.GetCapabilities()) != 1 || resp.GetCapabilities()[0].GetProvider() != "alpha" {
-		t.Fatalf("unexpected capabilities: %+v", resp.GetCapabilities())
+	if len(caps) != 1 || caps[0].Provider != "alpha" || caps[0].Operation != "read" {
+		t.Fatalf("unexpected capabilities: %+v", caps)
 	}
+
+	if _, err := client.Stop(rpcCtx, &emptypb.Empty{}); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+}
+
+type capturingRuntime struct {
+	host *pluginsdk.RuntimeHost
+}
+
+func (r *capturingRuntime) Start(_ context.Context, _ string, _ map[string]any, host pluginsdk.RuntimeHost) error {
+	*r.host = host
+	return nil
+}
+
+func (r *capturingRuntime) Stop(context.Context) error {
+	return nil
 }

--- a/sdk/pluginsdk/runtime_server.go
+++ b/sdk/pluginsdk/runtime_server.go
@@ -52,7 +52,8 @@ func (s *RuntimeServer) Start(ctx context.Context, req *pluginapiv1.StartRuntime
 		conn:   conn,
 	}
 
-	if err := s.runtime.Start(ctx, req.GetName(), mapFromStruct(req.GetConfig()), s.host); err != nil {
+	caps := capabilitiesFromProto(req.GetInitialCapabilities())
+	if err := s.runtime.Start(ctx, req.GetName(), mapFromStruct(req.GetConfig()), caps, s.host); err != nil {
 		_ = conn.Close()
 		s.host = nil
 		return nil, status.Errorf(codes.Unknown, "start runtime: %v", err)

--- a/sdk/pluginsdk/runtime_server.go
+++ b/sdk/pluginsdk/runtime_server.go
@@ -1,0 +1,114 @@
+package pluginsdk
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type RuntimeServer struct {
+	pluginapiv1.UnimplementedRuntimePluginServer
+	runtime Runtime
+	mu      sync.Mutex
+	host    *runtimeHostClient
+}
+
+func NewRuntimeServer(runtime Runtime) *RuntimeServer {
+	return &RuntimeServer{runtime: runtime}
+}
+
+func (s *RuntimeServer) Start(ctx context.Context, req *pluginapiv1.StartRuntimeRequest) (*emptypb.Empty, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.host != nil {
+		_ = s.host.conn.Close()
+		s.host = nil
+	}
+
+	socket := os.Getenv(pluginapiv1.EnvRuntimeHostSocket)
+	if socket == "" {
+		return nil, status.Errorf(codes.FailedPrecondition, "%s is required", pluginapiv1.EnvRuntimeHostSocket)
+	}
+	conn, err := dialUnixSocket(ctx, socket)
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "dial runtime host: %v", err)
+	}
+
+	s.host = &runtimeHostClient{
+		client: pluginapiv1.NewRuntimeHostClient(conn),
+		conn:   conn,
+	}
+
+	if err := s.runtime.Start(ctx, req.GetName(), mapFromStruct(req.GetConfig()), s.host); err != nil {
+		_ = conn.Close()
+		s.host = nil
+		return nil, status.Errorf(codes.Unknown, "start runtime: %v", err)
+	}
+	return &emptypb.Empty{}, nil
+}
+
+func (s *RuntimeServer) Stop(ctx context.Context, _ *emptypb.Empty) (*emptypb.Empty, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	err := s.runtime.Stop(ctx)
+	if s.host != nil {
+		_ = s.host.conn.Close()
+		s.host = nil
+	}
+	if err != nil {
+		return nil, status.Errorf(codes.Unknown, "stop runtime: %v", err)
+	}
+	return &emptypb.Empty{}, nil
+}
+
+type runtimeHostClient struct {
+	client pluginapiv1.RuntimeHostClient
+	conn   *grpc.ClientConn
+}
+
+func (c *runtimeHostClient) Invoke(ctx context.Context, p Principal, provider, instance, operation string, params map[string]any) (*OperationResult, error) {
+	var pbParams *structpb.Struct
+	if len(params) > 0 {
+		var err error
+		pbParams, err = structpb.NewStruct(params)
+		if err != nil {
+			return nil, fmt.Errorf("encode params: %w", err)
+		}
+	}
+	resp, err := c.client.Invoke(ctx, &pluginapiv1.InvokeRequest{
+		Principal: principalToProto(p),
+		Provider:  provider,
+		Instance:  instance,
+		Operation: operation,
+		Params:    pbParams,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &OperationResult{
+		Status: int(resp.GetStatus()),
+		Body:   resp.GetBody(),
+	}, nil
+}
+
+func (c *runtimeHostClient) ListCapabilities(ctx context.Context) ([]Capability, error) {
+	resp, err := c.client.ListCapabilities(ctx, &emptypb.Empty{})
+	if err != nil {
+		return nil, err
+	}
+	return capabilitiesFromProto(resp.GetCapabilities()), nil
+}

--- a/sdk/pluginsdk/types.go
+++ b/sdk/pluginsdk/types.go
@@ -80,7 +80,7 @@ func ConnectionParams(ctx context.Context) map[string]string {
 }
 
 type Runtime interface {
-	Start(ctx context.Context, name string, config map[string]any, host RuntimeHost) error
+	Start(ctx context.Context, name string, config map[string]any, capabilities []Capability, host RuntimeHost) error
 	Stop(ctx context.Context) error
 }
 

--- a/sdk/pluginsdk/types.go
+++ b/sdk/pluginsdk/types.go
@@ -78,3 +78,40 @@ func ConnectionParams(ctx context.Context) map[string]string {
 	params, _ := ctx.Value(connectionParamsKey{}).(map[string]string)
 	return params
 }
+
+type Runtime interface {
+	Start(ctx context.Context, name string, config map[string]any, host RuntimeHost) error
+	Stop(ctx context.Context) error
+}
+
+type RuntimeHost interface {
+	Invoke(ctx context.Context, principal Principal, provider, instance, operation string, params map[string]any) (*OperationResult, error)
+	ListCapabilities(ctx context.Context) ([]Capability, error)
+}
+
+type Principal struct {
+	UserID   string
+	Identity *UserIdentity
+	Source   PrincipalSource
+}
+
+type UserIdentity struct {
+	Email       string
+	DisplayName string
+	AvatarURL   string
+}
+
+type PrincipalSource string
+
+const (
+	PrincipalSourceSession  PrincipalSource = "session"
+	PrincipalSourceAPIToken PrincipalSource = "api_token"
+	PrincipalSourceEnv      PrincipalSource = "env"
+)
+
+type Capability struct {
+	Provider    string
+	Operation   string
+	Description string
+	Parameters  []Parameter
+}


### PR DESCRIPTION
Runtime plugin authors previously had to import `pluginapi` directly and
work with raw proto types. This wraps the runtime side the same way
providers are already wrapped, so `pluginsdk` is the only package
runtime authors need. `ServeRuntime` now accepts an SDK `Runtime`
interface, and the runtime host client is passed into `Start` rather
than requiring a separate `DialRuntimeHost` call.

The example runtime plugin is updated to use only `pluginsdk` types,
dropping its direct dependency on `pluginapi`.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>