### PR TITLE
Guard against concurrent token refresh overwrites

### DIFF
--- a/server/internal/invocation/broker.go
+++ b/server/internal/invocation/broker.go
@@ -337,6 +337,11 @@ func (b *Broker) refreshTokenIfNeeded(ctx context.Context, token *core.Integrati
 		return "", fmt.Errorf("token expired and refresh failed: %w", err)
 	}
 
+	fresh, fetchErr := b.datastore.Token(ctx, token.UserID, token.Integration, token.Connection, token.Instance)
+	if fetchErr == nil && fresh != nil && fresh.AccessToken != token.AccessToken {
+		return fresh.AccessToken, nil
+	}
+
 	now := time.Now()
 	token.AccessToken = resp.AccessToken
 	if resp.RefreshToken != "" {


### PR DESCRIPTION
When multiple requests share the same expired integration token, each
independently refreshes it with the OAuth provider. If the provider
rotates refresh tokens on each grant, the last writer silently
invalidates the earlier refresh tokens. This adds a re-read from the
store after a successful refresh to detect whether another request
already persisted a new token, avoiding the redundant overwrite.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>