### PR TITLE
Wrap provider host in pluginsdk interface

### DIFF
--- a/plugins/bigquery/provider.go
+++ b/plugins/bigquery/provider.go
@@ -19,8 +19,8 @@ const (
 )
 
 type Provider struct {
-	runner     queryRunner
-	httpClient *pluginsdk.ProxiedHTTPClient
+	runner queryRunner
+	host   pluginsdk.ProviderHost
 }
 
 var _ pluginsdk.Provider = (*Provider)(nil)
@@ -35,11 +35,11 @@ func (p *Provider) Description() string                       { return providerD
 func (p *Provider) ConnectionMode() pluginsdk.ConnectionMode { return pluginsdk.ConnectionModeUser }
 
 func (p *Provider) Start(ctx context.Context, name string, config map[string]any) error {
-	_, hostClient, err := pluginsdk.DialProviderHost(ctx)
+	host, err := pluginsdk.DialProviderHost(ctx)
 	if err != nil {
 		return fmt.Errorf("dialing provider host: %w", err)
 	}
-	p.httpClient = pluginsdk.NewProxiedHTTPClient(hostClient)
+	p.host = host
 	return nil
 }
 
@@ -116,7 +116,7 @@ func (p *Provider) Execute(ctx context.Context, operation string, params map[str
 }
 
 func (p *Provider) executeREST(ctx context.Context, operation string, params map[string]any) (*pluginsdk.OperationResult, error) {
-	if p.httpClient == nil {
+	if p.host == nil {
 		return nil, fmt.Errorf("provider not started: no HTTP client available")
 	}
 
@@ -171,7 +171,7 @@ func (p *Provider) executeREST(ctx context.Context, operation string, params map
 	}
 
 	invocationID := pluginsdk.InvocationID(ctx)
-	resp, err := p.httpClient.Do(ctx, invocationID, http.MethodGet, url, nil, nil)
+	resp, err := p.host.ProxyHTTP(ctx, invocationID, http.MethodGet, url, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("executing REST request: %w", err)
 	}

--- a/sdk/pluginsdk/http_client.go
+++ b/sdk/pluginsdk/http_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
+	"google.golang.org/grpc"
 )
 
 type invocationIDKey struct{}
@@ -23,16 +24,13 @@ type HTTPResponse struct {
 	Body       []byte
 }
 
-type ProxiedHTTPClient struct {
-	host pluginapiv1.ProviderHostClient
+type providerHostClient struct {
+	client pluginapiv1.ProviderHostClient
+	conn   *grpc.ClientConn
 }
 
-func NewProxiedHTTPClient(host pluginapiv1.ProviderHostClient) *ProxiedHTTPClient {
-	return &ProxiedHTTPClient{host: host}
-}
-
-func (c *ProxiedHTTPClient) Do(ctx context.Context, invocationID, method, url string, headers map[string]string, body []byte) (*HTTPResponse, error) {
-	resp, err := c.host.ProxyHTTP(ctx, &pluginapiv1.ProxyHTTPRequest{
+func (c *providerHostClient) ProxyHTTP(ctx context.Context, invocationID, method, url string, headers map[string]string, body []byte) (*HTTPResponse, error) {
+	resp, err := c.client.ProxyHTTP(ctx, &pluginapiv1.ProxyHTTPRequest{
 		InvocationId: invocationID,
 		Method:       method,
 		Url:          url,
@@ -47,4 +45,8 @@ func (c *ProxiedHTTPClient) Do(ctx context.Context, invocationID, method, url st
 		Headers:    resp.GetHeaders(),
 		Body:       resp.GetBody(),
 	}, nil
+}
+
+func (c *providerHostClient) Close() error {
+	return c.conn.Close()
 }

--- a/sdk/pluginsdk/plugin.go
+++ b/sdk/pluginsdk/plugin.go
@@ -23,16 +23,19 @@ func ServeRuntime(ctx context.Context, runtime Runtime) error {
 	})
 }
 
-func DialProviderHost(ctx context.Context) (*grpc.ClientConn, pluginapiv1.ProviderHostClient, error) {
+func DialProviderHost(ctx context.Context) (ProviderHost, error) {
 	socket := os.Getenv(pluginapiv1.EnvProviderHostSocket)
 	if socket == "" {
-		return nil, nil, fmt.Errorf("%s is required", pluginapiv1.EnvProviderHostSocket)
+		return nil, fmt.Errorf("%s is required", pluginapiv1.EnvProviderHostSocket)
 	}
 	conn, err := dialUnixSocket(ctx, socket)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return conn, pluginapiv1.NewProviderHostClient(conn), nil
+	return &providerHostClient{
+		client: pluginapiv1.NewProviderHostClient(conn),
+		conn:   conn,
+	}, nil
 }
 
 func servePlugin(ctx context.Context, register func(*grpc.Server)) error {

--- a/sdk/pluginsdk/plugin_transport_test.go
+++ b/sdk/pluginsdk/plugin_transport_test.go
@@ -3,6 +3,7 @@ package pluginsdk_test
 import (
 	"context"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -184,4 +185,69 @@ func (r *capturingRuntime) Start(_ context.Context, _ string, _ map[string]any, 
 
 func (r *capturingRuntime) Stop(context.Context) error {
 	return nil
+}
+
+type stubProviderHost struct {
+	pluginapiv1.UnimplementedProviderHostServer
+}
+
+const (
+	stubStatusCode  = 418
+	stubHeaderKey   = "X-Stub"
+	stubHeaderValue = "dummy"
+	stubBodyContent = "response-body-bytes"
+)
+
+func (s *stubProviderHost) ProxyHTTP(_ context.Context, req *pluginapiv1.ProxyHTTPRequest) (*pluginapiv1.ProxyHTTPResponse, error) {
+	return &pluginapiv1.ProxyHTTPResponse{
+		StatusCode: int32(stubStatusCode),
+		Headers:    map[string]string{stubHeaderKey: stubHeaderValue},
+		Body:       []byte(stubBodyContent),
+	}, nil
+}
+
+func TestDialProviderHostIntegration(t *testing.T) {
+	dir, err := os.MkdirTemp("/tmp", "sdk-ph-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	socket := filepath.Join(dir, "ph.sock")
+
+	lis, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = lis.Close() })
+
+	srv := grpc.NewServer()
+	pluginapiv1.RegisterProviderHostServer(srv, &stubProviderHost{})
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	t.Setenv(pluginapiv1.EnvProviderHostSocket, socket)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	host, err := pluginsdk.DialProviderHost(ctx)
+	if err != nil {
+		t.Fatalf("DialProviderHost: %v", err)
+	}
+	defer func() { _ = host.Close() }()
+
+	resp, err := host.ProxyHTTP(ctx, "inv-123", http.MethodGet, "https://dummy.example.com/items", nil, nil)
+	if err != nil {
+		t.Fatalf("ProxyHTTP: %v", err)
+	}
+	if resp.StatusCode != stubStatusCode {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, stubStatusCode)
+	}
+	if resp.Headers[stubHeaderKey] != stubHeaderValue {
+		t.Errorf("Headers[%q] = %q, want %q", stubHeaderKey, resp.Headers[stubHeaderKey], stubHeaderValue)
+	}
+	if string(resp.Body) != stubBodyContent {
+		t.Errorf("Body = %q, want %q", string(resp.Body), stubBodyContent)
+	}
 }

--- a/sdk/pluginsdk/types.go
+++ b/sdk/pluginsdk/types.go
@@ -115,3 +115,8 @@ type Capability struct {
 	Description string
 	Parameters  []Parameter
 }
+
+type ProviderHost interface {
+	ProxyHTTP(ctx context.Context, invocationID, method, url string, headers map[string]string, body []byte) (*HTTPResponse, error)
+	Close() error
+}


### PR DESCRIPTION
External provider plugins previously had to import proto types directly
to use `DialProviderHost` and `ProxiedHTTPClient`. This wraps the
provider host behind a `ProviderHost` interface so plugins only depend
on SDK types, keeping proto details internal to the SDK.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>