### PR TITLE
Rename server/internal/pluginapi to pluginhost

### DIFF
--- a/server/internal/bootstrap/bootstrap.go
+++ b/server/internal/bootstrap/bootstrap.go
@@ -16,7 +16,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
-	"github.com/valon-technologies/gestalt/server/internal/pluginapi"
+	"github.com/valon-technologies/gestalt/server/internal/pluginhost"
 	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
@@ -732,7 +732,7 @@ func buildDeclarativeProvider(name string, intg config.IntegrationDef, deps Deps
 	if err != nil {
 		return nil, fmt.Errorf("read manifest for declarative provider %q: %w", name, err)
 	}
-	prov, err := pluginapi.NewDeclarativeProvider(manifest, nil)
+	prov, err := pluginhost.NewDeclarativeProvider(manifest, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create declarative provider %q: %w", name, err)
 	}
@@ -806,7 +806,7 @@ func buildPluginProvider(ctx context.Context, name string, intg config.Integrati
 	if err != nil {
 		return nil, nil, fmt.Errorf("decode plugin config for %q: %w", name, err)
 	}
-	prov, err := pluginapi.NewExecutableProvider(ctx, pluginapi.ExecConfig{
+	prov, err := pluginhost.NewExecutableProvider(ctx, pluginhost.ExecConfig{
 		Command:      intg.Plugin.Command,
 		Args:         intg.Plugin.Args,
 		Env:          intg.Plugin.Env,

--- a/server/internal/bootstrap/runtime_boundary.go
+++ b/server/internal/bootstrap/runtime_boundary.go
@@ -8,7 +8,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
-	"github.com/valon-technologies/gestalt/server/internal/pluginapi"
+	"github.com/valon-technologies/gestalt/server/internal/pluginhost"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 )
 
@@ -59,7 +59,7 @@ func buildRuntime(ctx context.Context, name string, cfg config.RuntimeDef, facto
 		if err != nil {
 			return nil, fmt.Errorf("decode runtime plugin config for %q: %w", name, err)
 		}
-		return pluginapi.NewExecutableRuntime(ctx, name, pluginapi.ExecConfig{
+		return pluginhost.NewExecutableRuntime(ctx, name, pluginhost.ExecConfig{
 			Command: cfg.Plugin.Command,
 			Args:    cfg.Plugin.Args,
 			Env:     cfg.Plugin.Env,

--- a/server/internal/pluginhost/convert.go
+++ b/server/internal/pluginhost/convert.go
@@ -1,4 +1,4 @@
-package pluginapi
+package pluginhost
 
 import (
 	"encoding/json"

--- a/server/internal/pluginhost/declarative.go
+++ b/server/internal/pluginhost/declarative.go
@@ -1,4 +1,4 @@
-package pluginapi
+package pluginhost
 
 import (
 	"context"

--- a/server/internal/pluginhost/declarative_test.go
+++ b/server/internal/pluginhost/declarative_test.go
@@ -1,4 +1,4 @@
-package pluginapi
+package pluginhost
 
 import (
 	"context"

--- a/server/internal/pluginhost/grpc_test.go
+++ b/server/internal/pluginhost/grpc_test.go
@@ -1,4 +1,4 @@
-package pluginapi
+package pluginhost
 
 import (
 	"context"

--- a/server/internal/pluginhost/process.go
+++ b/server/internal/pluginhost/process.go
@@ -1,4 +1,4 @@
-package pluginapi
+package pluginhost
 
 import (
 	"context"

--- a/server/internal/pluginhost/provider_client.go
+++ b/server/internal/pluginhost/provider_client.go
@@ -1,4 +1,4 @@
-package pluginapi
+package pluginhost
 
 import (
 	"context"

--- a/server/internal/pluginhost/provider_host.go
+++ b/server/internal/pluginhost/provider_host.go
@@ -1,4 +1,4 @@
-package pluginapi
+package pluginhost
 
 import (
 	"bytes"

--- a/server/internal/pluginhost/provider_host_test.go
+++ b/server/internal/pluginhost/provider_host_test.go
@@ -1,4 +1,4 @@
-package pluginapi
+package pluginhost
 
 import (
 	"context"

--- a/server/internal/pluginhost/provider_server.go
+++ b/server/internal/pluginhost/provider_server.go
@@ -1,4 +1,4 @@
-package pluginapi
+package pluginhost
 
 import (
 	"context"

--- a/server/internal/pluginhost/provider_test.go
+++ b/server/internal/pluginhost/provider_test.go
@@ -1,4 +1,4 @@
-package pluginapi
+package pluginhost
 
 import (
 	"context"

--- a/server/internal/pluginhost/runtime.go
+++ b/server/internal/pluginhost/runtime.go
@@ -1,4 +1,4 @@
-package pluginapi
+package pluginhost
 
 import (
 	"context"

--- a/server/internal/pluginhost/runtime_test.go
+++ b/server/internal/pluginhost/runtime_test.go
@@ -1,4 +1,4 @@
-package pluginapi
+package pluginhost
 
 import (
 	"context"

--- a/server/internal/pluginhost/validate.go
+++ b/server/internal/pluginhost/validate.go
@@ -1,4 +1,4 @@
-package pluginapi
+package pluginhost
 
 import (
 	"encoding/json"

--- a/server/internal/pluginhost/validate_test.go
+++ b/server/internal/pluginhost/validate_test.go
@@ -1,4 +1,4 @@
-package pluginapi
+package pluginhost
 
 import (
 	"context"

--- a/server/internal/testplugins/echo/main.go
+++ b/server/internal/testplugins/echo/main.go
@@ -13,7 +13,7 @@ import (
 
 	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/pluginapi"
+	"github.com/valon-technologies/gestalt/server/internal/pluginhost"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -36,9 +36,9 @@ func run() error {
 
 	switch os.Args[1] {
 	case "provider":
-		return pluginapi.ServeProvider(ctx, newProxyProvider(&echoProvider{}))
+		return pluginhost.ServeProvider(ctx, newProxyProvider(&echoProvider{}))
 	case "runtime":
-		return pluginapi.ServeRuntime(ctx, &echoRuntimePlugin{})
+		return pluginhost.ServeRuntime(ctx, &echoRuntimePlugin{})
 	default:
 		return fmt.Errorf("unknown mode %q", os.Args[1])
 	}
@@ -83,7 +83,7 @@ func (p *echoRuntimePlugin) Start(ctx context.Context, req *pluginapiv1.StartRun
 	}
 
 	if p.hostConn == nil {
-		conn, host, err := pluginapi.DialRuntimeHost(ctx)
+		conn, host, err := pluginhost.DialRuntimeHost(ctx)
 		if err != nil {
 			return nil, status.Errorf(codes.Unavailable, "dial runtime host: %v", err)
 		}

--- a/server/internal/testplugins/echo/proxy_provider.go
+++ b/server/internal/testplugins/echo/proxy_provider.go
@@ -10,7 +10,7 @@ import (
 
 	pluginapiv1 "github.com/valon-technologies/gestalt/sdk/pluginapi/v1"
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/pluginapi"
+	"github.com/valon-technologies/gestalt/server/internal/pluginhost"
 	"google.golang.org/grpc"
 )
 
@@ -65,7 +65,7 @@ func (p *proxyProvider) Execute(ctx context.Context, operation string, params ma
 			return nil, err
 		}
 		url, _ := params["url"].(string)
-		invocationID := pluginapi.InvocationID(ctx)
+		invocationID := pluginhost.InvocationID(ctx)
 		resp, err := p.host.ProxyHTTP(ctx, &pluginapiv1.ProxyHTTPRequest{
 			InvocationId: invocationID,
 			Method:       http.MethodGet,
@@ -92,7 +92,7 @@ func (p *proxyProvider) ensureHost(ctx context.Context) error {
 	if p.host != nil {
 		return nil
 	}
-	conn, host, err := pluginapi.DialProviderHost(ctx)
+	conn, host, err := pluginhost.DialProviderHost(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The server-side pluginapi package manages plugin processes, gRPC
connections, and type conversions -- it is a host/bridge layer, not an
API definition. Renaming it to pluginhost resolves the naming collision
with sdk/pluginapi and better reflects the package's role.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>