### PR TITLE
Deduplicate concurrent OAuth token refresh calls

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -49,6 +49,7 @@ require (
 	golang.org/x/crypto v0.48.0
 	golang.org/x/mod v0.34.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.14.0
 	google.golang.org/api v0.256.0
 	google.golang.org/grpc v1.79.3
@@ -136,7 +137,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
 	golang.org/x/net v0.51.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/genproto v0.0.0-20250603155806-513f23925822 // indirect

--- a/server/internal/invocation/broker.go
+++ b/server/internal/invocation/broker.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -81,6 +82,7 @@ type Broker struct {
 	datastore      core.Datastore
 	connMapper     ConnectionMapper
 	connectionAuth RefresherResolver
+	refreshGroup   singleflight.Group
 }
 
 type BrokerOption func(*Broker)
@@ -320,7 +322,10 @@ func (b *Broker) refreshTokenIfNeeded(ctx context.Context, token *core.Integrati
 		return token.AccessToken, nil
 	}
 
-	resp, err := b.refreshOAuth(ctx, refresher, token.RefreshToken)
+	key := token.UserID + ":" + providerName + ":" + connection + ":" + token.Instance
+	v, err, _ := b.refreshGroup.Do(key, func() (any, error) {
+		return b.refreshOAuth(context.WithoutCancel(ctx), refresher, token.RefreshToken)
+	})
 	if err != nil {
 		fresh, fetchErr := b.datastore.Token(ctx, token.UserID, token.Integration, token.Connection, token.Instance)
 		if fetchErr == nil && fresh != nil && fresh.AccessToken != token.AccessToken {
@@ -337,6 +342,7 @@ func (b *Broker) refreshTokenIfNeeded(ctx context.Context, token *core.Integrati
 		return "", fmt.Errorf("token expired and refresh failed: %w", err)
 	}
 
+	resp := v.(*core.TokenResponse)
 	now := time.Now()
 	token.AccessToken = resp.AccessToken
 	if resp.RefreshToken != "" {


### PR DESCRIPTION
When multiple requests share the same expired integration token, each
independently calls the OAuth provider to refresh it. If the provider
rotates refresh tokens on each grant, the last writer invalidates
earlier refresh tokens. This wraps the refresh call in singleflight so
only one OAuth request is made per token, and all concurrent callers
share the same response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)