### PR TITLE
Document gestalt init, config, and describe CLI commands

### DIFF
--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -74,6 +74,14 @@ Visit `http://localhost:8080`.
 The generated config uses `auth.provider: none`, so no sign-in is required. Add an integration to start building.
 </Steps>
 
+## Or: Generate A Config With `gestalt init`
+
+Instead of writing `config.yaml` by hand, run `gestalt init` for an interactive setup wizard that walks you through creating one.
+
+```sh
+gestalt init
+```
+
 ## 3. Switch To An Explicit Config
 
 Save this as `config.yaml`:
@@ -138,3 +146,11 @@ This is the deployment path to model in Docker, Kubernetes, or any other product
 - [Configuration](/concepts/configuration): config discovery, defaults, secret resolution, and lock state.
 - [Add an Integration](/tasks/add-an-integration): build a real integration from REST, GraphQL, MCP, or plugins.
 - [Deploy](/deploy): move the same config into Docker or Kubernetes.
+
+## Explore Operations With `gestalt describe`
+
+Once the server is running, use `gestalt describe` to inspect what operations an integration exposes and what parameters they accept:
+
+```sh
+gestalt describe github repos/list-for-authenticated-user
+```

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -24,6 +24,39 @@ gestalt tokens
 | `gestalt describe` | Describe an integration or operation. |
 | `gestalt tokens` | Manage API tokens. |
 
+### `gestalt init`
+
+Interactive wizard that walks you through creating a `config.yaml`. This is an alternative to writing the config file by hand.
+
+```sh
+gestalt init
+```
+
+### `gestalt config`
+
+Manage persistent client configuration so you don't need to pass flags on every invocation.
+
+```sh
+gestalt config set url http://localhost:8080
+gestalt config get url
+gestalt config list
+```
+
+| Subcommand | Purpose |
+| --- | --- |
+| `gestalt config set url <value>` | Persist the server URL. Removes the need for `--url` on every command. |
+| `gestalt config get <key>` | Print the current value of a config key. |
+| `gestalt config list` | Show all current client config values. |
+
+### `gestalt describe`
+
+Display detailed information about an integration or a specific operation, including parameters, types, and descriptions.
+
+```sh
+gestalt describe github
+gestalt describe github repos/list-for-authenticated-user
+```
+
 ## `gestaltd` Server CLI
 
 The `gestaltd` server binary.


### PR DESCRIPTION
## Summary

Add documentation for client CLI features that were listed in the reference table but lacked detailed sections. The CLI reference now covers gestalt init (interactive config wizard), gestalt config subcommands (set, get, list for persistent client settings), and gestalt describe (integration/operation inspection). The getting started guide now mentions gestalt init as an alternative to writing config by hand and shows gestalt describe for exploring operations.

## Test plan

- Verify the docs site builds without errors
- Review getting-started.mdx renders the new `gestalt init` and `gestalt describe` sections correctly
- Review reference/cli.mdx renders the new `init`, `config`, and `describe` subsections with their tables and code blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)