### PR TITLE
Replace stdout trace/metric exporters with noop providers

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -39,8 +39,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.42.0
-	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.42.0
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.42.0
 	go.opentelemetry.io/otel/metric v1.42.0
 	go.opentelemetry.io/otel/sdk v1.42.0
 	go.opentelemetry.io/otel/sdk/log v0.18.0

--- a/server/go.sum
+++ b/server/go.sum
@@ -271,10 +271,6 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0 h1:zWWrB
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0/go.mod h1:2qXPNBX1OVRC0IwOnfo1ljoid+RD0QK3443EaqVlsOU=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.42.0 h1:uLXP+3mghfMf7XmV4PkGfFhFKuNWoCvvx5wP/wOXo0o=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.42.0/go.mod h1:v0Tj04armyT59mnURNUJf7RCKcKzq+lgJs6QSjHjaTc=
-go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.42.0 h1:lSZHgNHfbmQTPfuTmWVkEu8J8qXaQwuV30pjCcAUvP8=
-go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.42.0/go.mod h1:so9ounLcuoRDu033MW/E0AD4hhUjVqswrMF5FoZlBcw=
-go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.42.0 h1:s/1iRkCKDfhlh1JF26knRneorus8aOwVIDhvYx9WoDw=
-go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.42.0/go.mod h1:UI3wi0FXg1Pofb8ZBiBLhtMzgoTm1TYkMvn71fAqDzs=
 go.opentelemetry.io/otel/log v0.18.0 h1:XgeQIIBjZZrliksMEbcwMZefoOSMI1hdjiLEiiB0bAg=
 go.opentelemetry.io/otel/log v0.18.0/go.mod h1:KEV1kad0NofR3ycsiDH4Yjcoj0+8206I6Ox2QYFSNgI=
 go.opentelemetry.io/otel/metric v1.42.0 h1:2jXG+3oZLNXEPfNmnpxKDeZsFI5o4J+nz6xUlaFdF/4=

--- a/server/internal/drivers/telemetry/stdout/stdout.go
+++ b/server/internal/drivers/telemetry/stdout/stdout.go
@@ -2,7 +2,6 @@ package stdout
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -10,12 +9,10 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/internal/drivers/telemetry/telemetryutil"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
-	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/metric"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	noopmetric "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace"
+	nooptrace "go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
@@ -31,8 +28,8 @@ type yamlConfig struct {
 
 type Provider struct {
 	logger *slog.Logger
-	tp     *sdktrace.TracerProvider
-	mp     *sdkmetric.MeterProvider
+	tp     trace.TracerProvider
+	mp     metric.MeterProvider
 }
 
 func New(cfg yamlConfig) (*Provider, error) {
@@ -47,18 +44,8 @@ func New(cfg yamlConfig) (*Provider, error) {
 		handler = slog.NewTextHandler(os.Stdout, opts)
 	}
 
-	traceExporter, err := stdouttrace.New()
-	if err != nil {
-		return nil, fmt.Errorf("stdout telemetry: creating trace exporter: %w", err)
-	}
-
-	metricExporter, err := stdoutmetric.New()
-	if err != nil {
-		return nil, fmt.Errorf("stdout telemetry: creating metric exporter: %w", err)
-	}
-
-	tp := sdktrace.NewTracerProvider(sdktrace.WithBatcher(traceExporter))
-	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(sdkmetric.NewPeriodicReader(metricExporter)))
+	tp := nooptrace.NewTracerProvider()
+	mp := noopmetric.NewMeterProvider()
 
 	otel.SetTracerProvider(tp)
 	otel.SetMeterProvider(mp)
@@ -74,12 +61,7 @@ func (p *Provider) Logger() *slog.Logger                 { return p.logger }
 func (p *Provider) TracerProvider() trace.TracerProvider { return p.tp }
 func (p *Provider) MeterProvider() metric.MeterProvider  { return p.mp }
 
-func (p *Provider) Shutdown(ctx context.Context) error {
-	return errors.Join(
-		p.tp.Shutdown(ctx),
-		p.mp.Shutdown(ctx),
-	)
-}
+func (p *Provider) Shutdown(context.Context) error { return nil }
 
 var Factory bootstrap.TelemetryFactory = func(node yaml.Node) (core.TelemetryProvider, error) {
 	var cfg yamlConfig


### PR DESCRIPTION
## Summary

- Replace `stdouttrace` and `stdoutmetric` exporters in the stdout telemetry driver with noop trace/metric providers, eliminating verbose JSON blobs dumped to the terminal on every HTTP request during local development.
- The stdout provider now means "structured slog output only" while the otlp provider remains the path for full observability (traces + metrics + logs to a collector).
- The noop provider continues to mean "nothing at all."

## Test plan

- Verified `go vet ./...` passes with no unused imports
- Verified `go test ./internal/drivers/telemetry/... -v` compiles cleanly
- Built gestaltd, started it with the default stdout provider, curled `/health`, and confirmed only clean slog INFO/WARN lines appear with no JSON trace/metric output

🤖 Generated with [Claude Code](https://claude.com/claude-code)