### PR TITLE
Add spec-loading and multi-connection support to plugin manifests

### DIFF
--- a/server/internal/bootstrap/bootstrap.go
+++ b/server/internal/bootstrap/bootstrap.go
@@ -14,8 +14,11 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/integration"
 	"github.com/valon-technologies/gestalt/server/internal/composite"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	graphqlupstream "github.com/valon-technologies/gestalt/server/internal/graphql"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/mcpupstream"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
+	"github.com/valon-technologies/gestalt/server/internal/openapi"
 	"github.com/valon-technologies/gestalt/server/internal/pluginhost"
 	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
@@ -692,7 +695,14 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 func buildProvider(ctx context.Context, name string, intg config.IntegrationDef, factories *FactoryRegistry, deps Deps) (*ProviderBuildResult, error) {
 	if intg.Plugin != nil {
 		if intg.Plugin.IsDeclarative {
-			return buildDeclarativeProvider(name, intg, deps)
+			_, manifest, err := pluginpkg.ReadManifestFile(intg.Plugin.ResolvedManifestPath)
+			if err != nil {
+				return nil, fmt.Errorf("read manifest for %q: %w", name, err)
+			}
+			if manifest.Provider.IsSpecLoaded() {
+				return buildSpecLoadedProvider(ctx, name, intg, manifest, deps)
+			}
+			return buildDeclarativeProvider(name, intg, manifest, deps)
 		}
 		pluginProv, pluginConfig, err := buildPluginProvider(ctx, name, intg)
 		if err != nil {
@@ -780,14 +790,7 @@ func buildAPIPluginProvider(ctx context.Context, name string, intg config.Integr
 	}, nil
 }
 
-func buildDeclarativeProvider(name string, intg config.IntegrationDef, deps Deps) (*ProviderBuildResult, error) {
-	if intg.Plugin == nil || intg.Plugin.ResolvedManifestPath == "" {
-		return nil, fmt.Errorf("declarative provider %q has no resolved manifest path", name)
-	}
-	_, manifest, err := pluginpkg.ReadManifestFile(intg.Plugin.ResolvedManifestPath)
-	if err != nil {
-		return nil, fmt.Errorf("read manifest for declarative provider %q: %w", name, err)
-	}
+func buildDeclarativeProvider(name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, deps Deps) (*ProviderBuildResult, error) {
 	prov, err := pluginhost.NewDeclarativeProvider(manifest, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create declarative provider %q: %w", name, err)
@@ -813,6 +816,225 @@ func buildDeclarativeProvider(name string, intg config.IntegrationDef, deps Deps
 		}
 	}
 	return result, nil
+}
+
+func buildSpecLoadedProvider(ctx context.Context, name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, deps Deps) (_ *ProviderBuildResult, err error) {
+	mp := manifest.Provider
+
+	pluginConfig, err := config.NodeToMap(intg.Plugin.Config)
+	if err != nil {
+		return nil, fmt.Errorf("decode plugin config for %q: %w", name, err)
+	}
+
+	connName := config.PluginConnectionName
+	conn := buildSpecLoadedConnection(mp, connName, pluginConfig)
+
+	var allowedOps map[string]*config.OperationOverride
+	if mp.AllowedOperations != nil {
+		allowedOps = make(map[string]*config.OperationOverride, len(mp.AllowedOperations))
+		for opName, override := range mp.AllowedOperations {
+			if override != nil {
+				allowedOps[opName] = &config.OperationOverride{
+					Alias:       override.Alias,
+					Description: override.Description,
+				}
+			} else {
+				allowedOps[opName] = nil
+			}
+		}
+	}
+
+	var apiProv core.Provider
+	var mcpUp *mcpupstream.Upstream
+
+	defer func() {
+		if err != nil && mcpUp != nil {
+			_ = mcpUp.Close()
+		}
+	}()
+
+	loadAndBuild := func(def *provider.Definition, loadErr error) (core.Provider, error) {
+		if loadErr != nil {
+			return nil, loadErr
+		}
+		provider.ApplyDisplayOverrides(def, intg)
+		if def.DisplayName == "" {
+			def.DisplayName = manifest.DisplayName
+		}
+		if def.Description == "" {
+			def.Description = manifest.Description
+		}
+		return provider.Build(def, conn, allowedOps, provider.WithEgressResolver(deps.Egress.Resolver))
+	}
+
+	switch {
+	case mp.OpenAPI != "":
+		p, buildErr := loadAndBuild(openapi.LoadDefinition(ctx, name, mp.OpenAPI, allowedOps))
+		if buildErr != nil {
+			return nil, fmt.Errorf("openapi provider %q: %w", name, buildErr)
+		}
+		apiProv = p
+	case mp.GraphQLURL != "":
+		p, buildErr := loadAndBuild(graphqlupstream.LoadDefinition(ctx, name, mp.GraphQLURL, allowedOps))
+		if buildErr != nil {
+			return nil, fmt.Errorf("graphql provider %q: %w", name, buildErr)
+		}
+		apiProv = p
+	}
+
+	if mp.MCPURL != "" {
+		connMode := core.ConnectionMode(conn.Mode)
+		if connMode == "" {
+			connMode = core.ConnectionModeUser
+		}
+		up, mcpErr := mcpupstream.New(ctx, name, mp.MCPURL, connMode, deps.Egress.Resolver)
+		if mcpErr != nil {
+			return nil, fmt.Errorf("creating mcp upstream for %q: %w", name, mcpErr)
+		}
+		mcpUp = up
+	}
+
+	var prov core.Provider
+	switch {
+	case apiProv != nil && mcpUp != nil:
+		prov = composite.New(name, apiProv, mcpUp)
+	case apiProv != nil:
+		prov = apiProv
+	case mcpUp != nil:
+		prov = mcpUp
+	default:
+		return nil, fmt.Errorf("spec-loaded provider %q has no surfaces", name)
+	}
+
+	applyPluginIcon(prov, intg)
+
+	result := &ProviderBuildResult{Provider: prov}
+
+	authHandler, err := buildOAuthHandlerFromManifest(manifest, pluginConfig, deps)
+	if err != nil {
+		slog.Warn("cannot build oauth handler from manifest", "provider", name, "error", err)
+	} else if authHandler != nil {
+		result.ConnectionAuth = map[string]OAuthHandler{
+			connName: authHandler,
+		}
+	}
+
+	if len(mp.Connections) > 0 {
+		if result.ConnectionAuth == nil {
+			result.ConnectionAuth = make(map[string]OAuthHandler)
+		}
+		for cName, cDef := range mp.Connections {
+			if cDef.Auth == nil || cDef.Auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
+				continue
+			}
+			clientID, clientSecret := resolveConnectionCredentials(cName, pluginConfig)
+			if clientID == "" || clientSecret == "" {
+				continue
+			}
+			handler, err := buildOAuthHandlerFromAuth(cDef.Auth, clientID, clientSecret, deps)
+			if err != nil {
+				slog.Warn("cannot build oauth handler for connection", "provider", name, "connection", cName, "error", err)
+				continue
+			}
+			result.ConnectionAuth[cName] = handler
+		}
+	}
+
+	return result, nil
+}
+
+func buildSpecLoadedConnection(mp *pluginmanifestv1.Provider, connName string, pluginConfig map[string]any) config.ConnectionDef {
+	conn := config.ConnectionDef{Mode: string(core.ConnectionModeUser)}
+	if mp.Auth != nil {
+		conn.Auth = config.ConnectionAuthDef{
+			Type:                mp.Auth.Type,
+			AuthorizationURL:    mp.Auth.AuthorizationURL,
+			TokenURL:            mp.Auth.TokenURL,
+			Scopes:              mp.Auth.Scopes,
+			PKCE:                mp.Auth.PKCE,
+			ClientAuth:          mp.Auth.ClientAuth,
+			TokenExchange:       mp.Auth.TokenExchange,
+			ScopeParam:          mp.Auth.ScopeParam,
+			ScopeSeparator:      mp.Auth.ScopeSeparator,
+			AuthorizationParams: mp.Auth.AuthorizationParams,
+			TokenParams:         mp.Auth.TokenParams,
+			RefreshParams:       mp.Auth.RefreshParams,
+			AcceptHeader:        mp.Auth.AcceptHeader,
+			TokenMetadata:       mp.Auth.TokenMetadata,
+		}
+		if mp.Auth.ClientID != "" {
+			conn.Auth.ClientID = mp.Auth.ClientID
+		}
+		if mp.Auth.ClientSecret != "" {
+			conn.Auth.ClientSecret = mp.Auth.ClientSecret
+		}
+		if mp.Auth.RedirectURL != "" {
+			conn.Auth.RedirectURL = mp.Auth.RedirectURL
+		}
+	}
+	clientID, clientSecret := resolveConnectionCredentials(connName, pluginConfig)
+	if clientID != "" {
+		conn.Auth.ClientID = clientID
+	}
+	if clientSecret != "" {
+		conn.Auth.ClientSecret = clientSecret
+	}
+	return conn
+}
+
+func resolveConnectionCredentials(connName string, pluginConfig map[string]any) (clientID, clientSecret string) {
+	if conns, ok := pluginConfig["connections"].(map[string]any); ok {
+		if conn, ok := conns[connName].(map[string]any); ok {
+			clientID, _ = conn["client_id"].(string)
+			clientSecret, _ = conn["client_secret"].(string)
+		}
+	}
+	if clientID == "" {
+		clientID, _ = pluginConfig["client_id"].(string)
+		clientSecret, _ = pluginConfig["client_secret"].(string)
+	}
+	return
+}
+
+func buildOAuthHandlerFromAuth(auth *pluginmanifestv1.ProviderAuth, clientID, clientSecret string, deps Deps) (OAuthHandler, error) {
+	if auth == nil || auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
+		return nil, nil
+	}
+
+	redirectURL := deps.BaseURL + config.IntegrationCallbackPath
+
+	var tokenExchange oauth.TokenExchangeFormat
+	switch auth.TokenExchange {
+	case "", "form":
+		tokenExchange = oauth.TokenExchangeForm
+	case "json":
+		tokenExchange = oauth.TokenExchangeJSON
+	default:
+		return nil, fmt.Errorf("unknown token_exchange %q", auth.TokenExchange)
+	}
+
+	oauthCfg := oauth.UpstreamConfig{
+		ClientID:            clientID,
+		ClientSecret:        clientSecret,
+		AuthorizationURL:    auth.AuthorizationURL,
+		TokenURL:            auth.TokenURL,
+		RedirectURL:         redirectURL,
+		PKCE:                auth.PKCE,
+		DefaultScopes:       auth.Scopes,
+		ScopeParam:          auth.ScopeParam,
+		ScopeSeparator:      auth.ScopeSeparator,
+		TokenExchange:       tokenExchange,
+		AuthorizationParams: auth.AuthorizationParams,
+		TokenParams:         auth.TokenParams,
+		RefreshParams:       auth.RefreshParams,
+		AcceptHeader:        auth.AcceptHeader,
+	}
+	if auth.ClientAuth == "header" {
+		oauthCfg.ClientAuthMethod = oauth.ClientAuthHeader
+	}
+
+	handler := oauth.NewUpstream(oauthCfg)
+	return WrapUpstreamHandler(handler), nil
 }
 
 func applyAllowedOperations(name string, intg config.IntegrationDef, pluginProv core.Provider) (core.Provider, error) {
@@ -991,7 +1213,6 @@ func buildOAuthHandlerFromManifest(manifest *pluginmanifestv1.Manifest, pluginCo
 	if manifest.Provider == nil || manifest.Provider.Auth == nil || manifest.Provider.Auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
 		return nil, nil
 	}
-	auth := manifest.Provider.Auth
 
 	clientID, _ := pluginConfig["client_id"].(string)
 	clientSecret, _ := pluginConfig["client_secret"].(string)
@@ -999,37 +1220,7 @@ func buildOAuthHandlerFromManifest(manifest *pluginmanifestv1.Manifest, pluginCo
 		return nil, fmt.Errorf("plugin.config must provide client_id and client_secret for oauth2 auth")
 	}
 
-	redirectURL := deps.BaseURL + config.IntegrationCallbackPath
-
-	var tokenExchange oauth.TokenExchangeFormat
-	switch auth.TokenExchange {
-	case "", "form":
-		tokenExchange = oauth.TokenExchangeForm
-	case "json":
-		tokenExchange = oauth.TokenExchangeJSON
-	default:
-		return nil, fmt.Errorf("unknown token_exchange %q", auth.TokenExchange)
-	}
-
-	oauthCfg := oauth.UpstreamConfig{
-		ClientID:            clientID,
-		ClientSecret:        clientSecret,
-		AuthorizationURL:    auth.AuthorizationURL,
-		TokenURL:            auth.TokenURL,
-		RedirectURL:         redirectURL,
-		PKCE:                auth.PKCE,
-		DefaultScopes:       auth.Scopes,
-		ScopeParam:          auth.ScopeParam,
-		ScopeSeparator:      auth.ScopeSeparator,
-		TokenExchange:       tokenExchange,
-		AuthorizationParams: auth.AuthorizationParams,
-	}
-	if auth.ClientAuth == "header" {
-		oauthCfg.ClientAuthMethod = oauth.ClientAuthHeader
-	}
-
-	handler := oauth.NewUpstream(oauthCfg)
-	return WrapUpstreamHandler(handler), nil
+	return buildOAuthHandlerFromAuth(manifest.Provider.Auth, clientID, clientSecret, deps)
 }
 
 func providerFactoryForName(name string, factories *FactoryRegistry) (ProviderFactory, error) {

--- a/server/internal/bootstrap/bootstrap_test.go
+++ b/server/internal/bootstrap/bootstrap_test.go
@@ -3,7 +3,10 @@ package bootstrap_test
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1069,4 +1072,257 @@ func TestBootstrapBindingWithProviders(t *testing.T) {
 	if receivedDeps.Invoker == result.Invoker {
 		t.Fatal("expected binding deps to be scoped rather than reusing the shared bootstrap invoker directly")
 	}
+}
+
+func serveOpenAPISpec(t *testing.T) *httptest.Server {
+	t.Helper()
+	spec := map[string]any{
+		"openapi": "3.0.0",
+		"info":    map[string]string{"title": "Test Spec API", "description": "A test API"},
+		"servers": []any{map[string]string{"url": "https://api.test-spec.example.com/v1"}},
+		"paths": map[string]any{
+			"/widgets": map[string]any{
+				"get": map[string]any{
+					"operationId": "list_widgets",
+					"summary":     "List all widgets",
+					"parameters": []any{
+						map[string]any{
+							"name": "limit", "in": "query",
+							"schema": map[string]any{"type": "integer"},
+						},
+					},
+				},
+			},
+			"/widgets/{id}": map[string]any{
+				"get": map[string]any{
+					"operationId": "get_widget",
+					"summary":     "Get a widget by ID",
+					"parameters": []any{
+						map[string]any{
+							"name": "id", "in": "path", "required": true,
+							"schema": map[string]any{"type": "string"},
+						},
+					},
+				},
+			},
+		},
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(spec)
+	}))
+}
+
+func writeSpecLoadedManifest(t *testing.T, specURL string) string {
+	t.Helper()
+	manifest := map[string]any{
+		"source":  "github.com/test-org/test-repo/test-plugin",
+		"version": "0.1.0",
+		"kinds":   []string{"provider"},
+		"provider": map[string]any{
+			"openapi": specURL,
+			"auth": map[string]any{
+				"type":              "oauth2",
+				"authorization_url": "https://auth.example.com/authorize",
+				"token_url":         "https://auth.example.com/token",
+			},
+		},
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plugin.json")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestBootstrapSpecLoadedProvider(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	specSrv := serveOpenAPISpec(t)
+	t.Cleanup(specSrv.Close)
+
+	manifestPath := writeSpecLoadedManifest(t, specSrv.URL)
+
+	cfg := validConfig()
+	cfg.Integrations["alpha"] = config.IntegrationDef{
+		Plugin: &config.ExecutablePluginDef{
+			Command:              "unused",
+			IsDeclarative:        true,
+			ResolvedManifestPath: manifestPath,
+			Config: yamlNode(map[string]any{
+				"client_id":     "test-client-id",
+				"client_secret": "test-client-secret",
+			}),
+		},
+	}
+
+	factories := validFactories()
+	delete(factories.Providers, "alpha")
+	factories.DefaultProvider = nil
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	prov, err := result.Providers.Get("alpha")
+	if err != nil {
+		t.Fatalf("provider 'alpha' not found: %v", err)
+	}
+
+	ops := prov.ListOperations()
+	if len(ops) != 2 {
+		t.Fatalf("expected 2 operations, got %d", len(ops))
+	}
+
+	opNames := make(map[string]bool, len(ops))
+	for _, op := range ops {
+		opNames[op.Name] = true
+	}
+	if !opNames["list_widgets"] {
+		t.Error("expected list_widgets operation")
+	}
+	if !opNames["get_widget"] {
+		t.Error("expected get_widget operation")
+	}
+
+	connAuth := result.ConnectionAuth()
+	if connAuth == nil {
+		t.Fatal("expected ConnectionAuth to be non-nil")
+	}
+	alphaConns, ok := connAuth["alpha"]
+	if !ok {
+		t.Fatal("expected connection auth for alpha")
+	}
+	if _, ok := alphaConns[config.PluginConnectionName]; !ok {
+		t.Errorf("expected oauth handler for connection %q", config.PluginConnectionName)
+	}
+}
+
+func TestBootstrapSpecLoadedProviderMultiConnection(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	specSrv := serveOpenAPISpec(t)
+	t.Cleanup(specSrv.Close)
+
+	manifest := map[string]any{
+		"source":  "github.com/test-org/test-repo/test-multiconn",
+		"version": "0.1.0",
+		"kinds":   []string{"provider"},
+		"provider": map[string]any{
+			"openapi": specSrv.URL,
+			"auth": map[string]any{
+				"type":              "oauth2",
+				"authorization_url": "https://auth.example.com/authorize",
+				"token_url":         "https://auth.example.com/token",
+			},
+			"connections": map[string]any{
+				"primary": map[string]any{
+					"mode": "user",
+					"auth": map[string]any{
+						"type":              "oauth2",
+						"authorization_url": "https://auth1.example.com/authorize",
+						"token_url":         "https://auth1.example.com/token",
+					},
+				},
+				"secondary": map[string]any{
+					"mode": "user",
+					"auth": map[string]any{
+						"type":              "oauth2",
+						"authorization_url": "https://auth2.example.com/authorize",
+						"token_url":         "https://auth2.example.com/token",
+					},
+				},
+			},
+			"openapi_connection": "primary",
+		},
+	}
+
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "plugin.json")
+	if err := os.WriteFile(manifestPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := validConfig()
+	cfg.Integrations["alpha"] = config.IntegrationDef{
+		Plugin: &config.ExecutablePluginDef{
+			Command:              "unused",
+			IsDeclarative:        true,
+			ResolvedManifestPath: manifestPath,
+			Config: yamlNode(map[string]any{
+				"client_id":     "top-level-id",
+				"client_secret": "top-level-secret",
+				"connections": map[string]any{
+					"primary": map[string]any{
+						"client_id":     "primary-id",
+						"client_secret": "primary-secret",
+					},
+					"secondary": map[string]any{
+						"client_id":     "secondary-id",
+						"client_secret": "secondary-secret",
+					},
+				},
+			}),
+		},
+	}
+
+	factories := validFactories()
+	delete(factories.Providers, "alpha")
+	factories.DefaultProvider = nil
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	prov, err := result.Providers.Get("alpha")
+	if err != nil {
+		t.Fatalf("provider 'alpha' not found: %v", err)
+	}
+	if len(prov.ListOperations()) != 2 {
+		t.Fatalf("expected 2 operations, got %d", len(prov.ListOperations()))
+	}
+
+	connAuth := result.ConnectionAuth()
+	if connAuth == nil {
+		t.Fatal("expected ConnectionAuth to be non-nil")
+	}
+	alphaConns, ok := connAuth["alpha"]
+	if !ok {
+		t.Fatal("expected connection auth for alpha")
+	}
+	if _, ok := alphaConns["primary"]; !ok {
+		t.Error("expected oauth handler for primary connection")
+	}
+	if _, ok := alphaConns["secondary"]; !ok {
+		t.Error("expected oauth handler for secondary connection")
+	}
+}
+
+func yamlNode(v any) yaml.Node {
+	data, err := yaml.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	var node yaml.Node
+	if err := yaml.Unmarshal(data, &node); err != nil {
+		panic(err)
+	}
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		return *node.Content[0]
+	}
+	return node
 }

--- a/server/internal/pluginpkg/manifest.go
+++ b/server/internal/pluginpkg/manifest.go
@@ -293,6 +293,10 @@ var validHTTPMethods = map[string]bool{
 }
 
 func validateDeclarativeProvider(provider *pluginmanifestv1.Provider) error {
+	if provider.IsSpecLoaded() {
+		return validateSpecLoadedProvider(provider)
+	}
+
 	if provider.BaseURL == "" {
 		return fmt.Errorf("provider.base_url is required for declarative providers")
 	}
@@ -328,6 +332,50 @@ func validateDeclarativeProvider(provider *pluginmanifestv1.Provider) error {
 			}
 		}
 	}
+	return nil
+}
+
+func validateSpecLoadedProvider(provider *pluginmanifestv1.Provider) error {
+	if len(provider.Operations) > 0 {
+		return fmt.Errorf("spec-loaded providers cannot also declare hand-written operations")
+	}
+	if provider.OpenAPI != "" && provider.GraphQLURL != "" {
+		return fmt.Errorf("openapi and graphql_url are mutually exclusive")
+	}
+
+	if len(provider.Connections) > 0 {
+		var firstMode string
+		var firstName string
+		for cname, conn := range provider.Connections {
+			mode := conn.Mode
+			if mode == "" {
+				mode = "user"
+			}
+			if firstName == "" {
+				firstName = cname
+				firstMode = mode
+			} else if mode != firstMode {
+				return fmt.Errorf("all connections must share the same mode (%q=%q, %q=%q)", firstName, firstMode, cname, mode)
+			}
+		}
+
+		if provider.OpenAPIConnection != "" {
+			if _, ok := provider.Connections[provider.OpenAPIConnection]; !ok {
+				return fmt.Errorf("openapi_connection references unknown connection %q", provider.OpenAPIConnection)
+			}
+		}
+		if provider.GraphQLConnection != "" {
+			if _, ok := provider.Connections[provider.GraphQLConnection]; !ok {
+				return fmt.Errorf("graphql_connection references unknown connection %q", provider.GraphQLConnection)
+			}
+		}
+		if provider.MCPConnection != "" {
+			if _, ok := provider.Connections[provider.MCPConnection]; !ok {
+				return fmt.Errorf("mcp_connection references unknown connection %q", provider.MCPConnection)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/server/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/server/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -113,6 +113,47 @@
               "from": { "type": "string", "enum": ["discovery"] }
             }
           }
+        },
+        "openapi": {
+          "type": "string",
+          "minLength": 1
+        },
+        "graphql_url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mcp_url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "allowed_operations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": ["object", "null"],
+            "properties": {
+              "alias": { "type": "string" },
+              "description": { "type": "string" }
+            },
+            "additionalProperties": false
+          }
+        },
+        "connections": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/manifest_connection_def"
+          }
+        },
+        "openapi_connection": {
+          "type": "string",
+          "minLength": 1
+        },
+        "graphql_connection": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mcp_connection": {
+          "type": "string",
+          "minLength": 1
         }
       }
     },
@@ -186,6 +227,17 @@
                 "required": [
                   "base_url",
                   "operations"
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "provider": {
+                "anyOf": [
+                  { "required": ["openapi"] },
+                  { "required": ["graphql_url"] },
+                  { "required": ["mcp_url"] }
                 ]
               }
             }
@@ -291,6 +343,30 @@
               "help_url": { "type": "string", "format": "uri" }
             }
           }
+        },
+        "client_id": {
+          "type": "string"
+        },
+        "client_secret": {
+          "type": "string"
+        },
+        "redirect_url": {
+          "type": "string"
+        },
+        "token_params": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "refresh_params": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "accept_header": {
+          "type": "string"
+        },
+        "token_metadata": {
+          "type": "array",
+          "items": { "type": "string" }
         }
       },
       "allOf": [
@@ -382,6 +458,31 @@
         "sha256": {
           "type": "string",
           "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "manifest_connection_def": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["user", "identity", "either", "none"]
+        },
+        "auth": {
+          "$ref": "#/$defs/provider_auth"
+        },
+        "params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "required": { "type": "boolean" },
+              "description": { "type": "string" },
+              "from": { "type": "string", "enum": ["discovery"] }
+            }
+          }
         }
       }
     },

--- a/server/sdk/pluginmanifest/v1/types.go
+++ b/server/sdk/pluginmanifest/v1/types.go
@@ -34,6 +34,18 @@ type Provider struct {
 	Operations           []ProviderOperation                `json:"operations,omitempty"`
 	PostConnectDiscovery *ProviderPostConnectDiscovery      `json:"post_connect_discovery,omitempty"`
 	Connection           map[string]ProviderConnectionParam `json:"connection,omitempty"`
+
+	OpenAPI    string `json:"openapi,omitempty"`
+	GraphQLURL string `json:"graphql_url,omitempty"`
+	MCPURL     string `json:"mcp_url,omitempty"`
+
+	AllowedOperations map[string]*ManifestOperationOverride `json:"allowed_operations,omitempty"`
+
+	Connections map[string]*ManifestConnectionDef `json:"connections,omitempty"`
+
+	OpenAPIConnection  string `json:"openapi_connection,omitempty"`
+	GraphQLConnection  string `json:"graphql_connection,omitempty"`
+	MCPConnection      string `json:"mcp_connection,omitempty"`
 }
 
 type ProviderPostConnectDiscovery struct {
@@ -50,7 +62,22 @@ type ProviderConnectionParam struct {
 }
 
 func (p *Provider) IsDeclarative() bool {
-	return p != nil && len(p.Operations) > 0
+	return p != nil && (len(p.Operations) > 0 || p.OpenAPI != "" || p.GraphQLURL != "" || p.MCPURL != "")
+}
+
+func (p *Provider) IsSpecLoaded() bool {
+	return p != nil && (p.OpenAPI != "" || p.GraphQLURL != "" || p.MCPURL != "")
+}
+
+type ManifestConnectionDef struct {
+	Mode   string                             `json:"mode,omitempty"`
+	Auth   *ProviderAuth                      `json:"auth,omitempty"`
+	Params map[string]ProviderConnectionParam `json:"params,omitempty"`
+}
+
+type ManifestOperationOverride struct {
+	Alias       string `json:"alias,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 type ProviderOperation struct {
@@ -88,6 +115,13 @@ type ProviderAuth struct {
 	ScopeSeparator      string            `json:"scope_separator,omitempty"`
 	AuthorizationParams map[string]string `json:"authorization_params,omitempty"`
 	Credentials         []CredentialField `json:"credentials,omitempty"`
+	ClientID            string            `json:"client_id,omitempty"`
+	ClientSecret        string            `json:"client_secret,omitempty"`
+	RedirectURL         string            `json:"redirect_url,omitempty"`
+	TokenParams         map[string]string `json:"token_params,omitempty"`
+	RefreshParams       map[string]string `json:"refresh_params,omitempty"`
+	AcceptHeader        string            `json:"accept_header,omitempty"`
+	TokenMetadata       []string          `json:"token_metadata,omitempty"`
 }
 
 type CredentialField struct {


### PR DESCRIPTION
Plugin manifests can now declare `openapi`, `graphql_url`, and `mcp_url` fields instead of hand-writing operations. When a spec URL is set, the server loads and processes the spec at bootstrap time and builds a full provider from it, including composite assembly when both API and MCP URLs are present. An `allowed_operations` map lets manifests filter and override the operations exposed by the loaded spec.

Multi-connection support lets a single plugin declare multiple named auth endpoints via a `connections` map, with `openapi_connection`, `graphql_connection`, and `mcp_connection` bindings to route each surface to its connection. Per-connection OAuth credentials are resolved from plugin config, falling back to top-level `client_id`/`client_secret`. Validation ensures all connections share the same mode and that binding references are valid.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>