### PR TITLE
Update docs to reflect stdout telemetry noop change

### DIFF
--- a/docs/pages/concepts/observability.mdx
+++ b/docs/pages/concepts/observability.mdx
@@ -1,10 +1,16 @@
 # Observability
 
-Gestalt uses [OpenTelemetry](https://opentelemetry.io) for observability. Traces, metrics, and structured logs are exported through a pluggable telemetry provider configured in the `telemetry` block of your config file.
+Gestalt uses [OpenTelemetry](https://opentelemetry.io) for observability. The `telemetry` block in your config file selects a provider that controls what signals are exported:
+
+- **`otlp`** — Exports traces, metrics, and structured logs to an OpenTelemetry collector.
+- **`stdout`** — Outputs structured logs only. Traces and metrics use noop providers to keep terminal output clean during development.
+- **`noop`** — Disables all telemetry.
 
 ## Traces
 
-Every request is automatically traced across three layers:
+Trace export requires the `otlp` telemetry provider. The `stdout` provider silences traces to avoid noisy output during local development.
+
+When using `otlp`, every request is automatically traced across three layers:
 
 1. **HTTP** — `otelhttp` middleware on the chi router creates a root span for each inbound request with standard HTTP semantic conventions (method, route, status code, latency).
 2. **Broker** — `Broker.Invoke()` creates a child span with attributes for the provider, operation, user, and connection mode.
@@ -12,13 +18,15 @@ Every request is automatically traced across three layers:
 
 A single trace shows the full lifecycle: HTTP request → broker invocation → plugin RPC. When a provider invocation is slow, the trace shows whether the bottleneck was token refresh, the provider's execution, or network latency.
 
-### Sampling
+### Sampling (`otlp` only)
 
 The `otlp` provider supports configurable trace sampling via `traces.sampling_ratio` (default `1.0`, meaning all traces). At low to moderate scale, sample everything. When volume demands it, reduce the ratio — but note that the OTel Collector's [spanmetrics connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/README.md) can derive accurate RED metrics from 100% of spans _before_ the sampling decision, so metrics remain accurate even with aggressive trace sampling.
 
 ## Metrics
 
-Gestalt does not maintain separate application-level metric instrumentation for request rates, error rates, or latency. Instead, these are derived from traces:
+Metric export requires the `otlp` telemetry provider. The `stdout` provider uses a noop meter to avoid cluttering terminal output.
+
+When using `otlp`, Gestalt does not maintain separate application-level metric instrumentation for request rates, error rates, or latency. Instead, these are derived from traces:
 
 - Use the OTel Collector's **spanmetrics connector** to automatically generate RED metrics (Rate, Errors, Duration) from trace spans.
 - This eliminates double-instrumentation and gives you per-provider, per-operation breakdowns without declaring metric labels upfront.
@@ -29,7 +37,7 @@ Infrastructure metrics (CPU, memory, goroutines) should come from your runtime e
 
 All log output from Gestalt uses Go's `slog` for structured logging. When using the `otlp` provider, logs are exported via the [otelslog bridge](https://pkg.go.dev/go.opentelemetry.io/contrib/bridges/otelslog) and include trace correlation fields (`trace_id`, `span_id`) so logs can be linked to their parent request trace.
 
-With the `stdout` provider, logs are written to stdout in either `text` (default) or `json` format.
+With the `stdout` provider, logs are written to stdout in either `text` (default) or `json` format. This is the only signal the `stdout` provider emits; traces and metrics are silenced.
 
 ## Audit Logs
 
@@ -128,7 +136,7 @@ telemetry:
     level: debug
 ```
 
-Prints all traces, metrics, and logs to stdout in JSON format. Useful for inspecting request flow during development.
+Outputs structured logs to stdout in JSON format. Traces and metrics are silenced. Useful for inspecting request flow during development without noisy span or metric output.
 
 ## Disabling Telemetry
 

--- a/docs/pages/reference/built-in-plugins.mdx
+++ b/docs/pages/reference/built-in-plugins.mdx
@@ -39,7 +39,7 @@ Components registered by the `gestaltd` binary at startup.
 
 | Name | Purpose |
 | --- | --- |
-| `stdout` | Prints traces and logs to standard output. Default when `telemetry` is omitted. |
+| `stdout` | Outputs structured logs to standard output. Traces and metrics use noop providers. Default when `telemetry` is omitted. |
 | `otlp` | Exports traces, metrics, and logs via OpenTelemetry Protocol. |
 | `noop` | Disables all telemetry collection. |
 

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -193,7 +193,7 @@ telemetry:
 | `format` | No | `text` | `text` or `json`. |
 | `level` | No | `info` | `debug`, `info`, `warn`, or `error`. |
 
-Prints traces and metrics to standard output. Default provider when `telemetry` is omitted.
+Outputs structured logs to standard output. Traces and metrics use noop providers to keep terminal output clean. Default provider when `telemetry` is omitted.
 
 ### `otlp`
 


### PR DESCRIPTION
Following the switch to noop trace and metric providers for the stdout telemetry provider (PR #359), update the observability page, built-in plugins reference, and config file reference to clarify that trace and metric export only applies to the otlp provider. The stdout provider now outputs structured slog logs only, with traces and metrics silenced to keep terminal output clean during development.