### PR TITLE
Rename gestalt.yaml to config.yaml across documentation

### DIFF
--- a/docs/pages/concepts/configuration.mdx
+++ b/docs/pages/concepts/configuration.mdx
@@ -104,8 +104,8 @@ After that, `gestaltd serve --locked --config <output>/PATH` starts only if the 
 `gestaltd validate --config PATH` is non-mutating and expects existing lock state. Bundle first, then validate the bundled output:
 
 ```sh
-gestaltd bundle --config ./gestalt.yaml --output ./bundle
-gestaltd validate --config ./bundle/gestalt.yaml
+gestaltd bundle --config ./config.yaml --output ./bundle
+gestaltd validate --config ./bundle/config.yaml
 ```
 
 ## Relative Paths

--- a/docs/pages/deploy/index.mdx
+++ b/docs/pages/deploy/index.mdx
@@ -75,8 +75,8 @@ For published-image examples rather than repo-local source builds, see `examples
 The bare-binary model is straightforward:
 
 ```sh
-gestaltd bundle --config ./gestalt.yaml --output ./bundle
-gestaltd serve --locked --config ./bundle/gestalt.yaml
+gestaltd bundle --config ./config.yaml --output ./bundle
+gestaltd serve --locked --config ./bundle/config.yaml
 ```
 
 That is often the cleanest way to run Gestalt on a VM, inside systemd, or in a custom container build.

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -287,7 +287,7 @@ When a command needs a config path:
 ## `bundle`
 
 ```sh
-gestaltd bundle --config ./gestalt.yaml --output ./bundle
+gestaltd bundle --config ./config.yaml --output ./bundle
 ```
 
 Produces a self-contained output directory:
@@ -304,8 +304,8 @@ Run `bundle` whenever your config contains remote REST upstreams, remote GraphQL
 Production startup:
 
 ```sh
-gestaltd bundle --config ./gestalt.yaml --output ./bundle
-gestaltd serve --locked --config ./bundle/gestalt.yaml
+gestaltd bundle --config ./config.yaml --output ./bundle
+gestaltd serve --locked --config ./bundle/config.yaml
 ```
 
 If prepared state is missing or stale, startup fails instead of mutating local state.
@@ -315,8 +315,8 @@ If prepared state is missing or stale, startup fails instead of mutating local s
 Non-mutating config validation. Expects lock state to already exist when the config depends on prepared artifacts.
 
 ```sh
-gestaltd bundle --config ./gestalt.yaml --output ./bundle
-gestaltd validate --config ./bundle/gestalt.yaml
+gestaltd bundle --config ./config.yaml --output ./bundle
+gestaltd validate --config ./bundle/config.yaml
 ```
 
 ### `validate --init`
@@ -324,7 +324,7 @@ gestaltd validate --config ./bundle/gestalt.yaml
 Run initialization before validating. Useful when you want to validate a config that has not been bundled yet:
 
 ```sh
-gestaltd validate --init --config ./gestalt.yaml
+gestaltd validate --init --config ./config.yaml
 ```
 
 ## `plugin package`

--- a/docs/pages/tasks/add-an-integration.mdx
+++ b/docs/pages/tasks/add-an-integration.mdx
@@ -83,8 +83,8 @@ Set `mcp_tool_prefix` at the integration level to avoid tool-name collisions acr
 ## 5. Bundle and Validate
 
 ```sh
-gestaltd bundle --config ./gestalt.yaml --output ./bundle
-gestaltd validate --config ./bundle/gestalt.yaml
+gestaltd bundle --config ./config.yaml --output ./bundle
+gestaltd validate --config ./bundle/config.yaml
 ```
 
 This prepares remote provider artifacts and catches config errors.
@@ -92,7 +92,7 @@ This prepares remote provider artifacts and catches config errors.
 ## 6. Run
 
 ```sh
-gestaltd serve --locked --config ./bundle/gestalt.yaml
+gestaltd serve --locked --config ./bundle/config.yaml
 ```
 
 Then:

--- a/docs/pages/tasks/run-locally.mdx
+++ b/docs/pages/tasks/run-locally.mdx
@@ -22,7 +22,7 @@ The server and embedded UI are both available at `http://localhost:8080`.
 ## Explicit Config
 
 ```sh
-gestaltd --config ./gestalt.yaml
+gestaltd --config ./config.yaml
 ```
 
 Use this when you want to control:
@@ -38,9 +38,9 @@ Use this when you want to control:
 If your config includes remote REST or GraphQL upstreams, or packaged plugins, bundle and validate first:
 
 ```sh
-gestaltd bundle --config ./gestalt.yaml --output ./bundle
-gestaltd validate --config ./bundle/gestalt.yaml
-gestaltd serve --locked --config ./bundle/gestalt.yaml
+gestaltd bundle --config ./config.yaml --output ./bundle
+gestaltd validate --config ./bundle/config.yaml
+gestaltd serve --locked --config ./bundle/config.yaml
 ```
 
 This is the closest local approximation to a production deployment.

--- a/docs/pages/tasks/use-a-plugin-package.mdx
+++ b/docs/pages/tasks/use-a-plugin-package.mdx
@@ -22,7 +22,7 @@ integrations:
 ## 2. Bundle It
 
 ```sh
-gestaltd bundle --config ./gestalt.yaml --output ./bundle
+gestaltd bundle --config ./config.yaml --output ./bundle
 ```
 
 This validates the manifest, selects the current platform artifact, installs the package into the output directory, and records the prepared result in `gestalt.lock.json`.
@@ -30,7 +30,7 @@ This validates the manifest, selects the current platform artifact, installs the
 ## 3. Validate The Bundled Deployment
 
 ```sh
-gestaltd validate --config ./bundle/gestalt.yaml
+gestaltd validate --config ./bundle/config.yaml
 ```
 
 Validation uses the prepared plugin state instead of re-resolving the package every time.
@@ -38,7 +38,7 @@ Validation uses the prepared plugin state instead of re-resolving the package ev
 ## 4. Start From Locked State
 
 ```sh
-gestaltd serve --locked --config ./bundle/gestalt.yaml
+gestaltd serve --locked --config ./bundle/config.yaml
 ```
 
 That is the normal production path for packaged plugins.
@@ -48,7 +48,7 @@ That is the normal production path for packaged plugins.
 If `plugin.package` points at an HTTPS URL and the remote archive changes, rerun:
 
 ```sh
-gestaltd bundle --config ./gestalt.yaml --output ./bundle
+gestaltd bundle --config ./config.yaml --output ./bundle
 ```
 
 Remote packages are intentionally refreshed during explicit `bundle`.

--- a/docs/pages/tasks/use-with-mcp.mdx
+++ b/docs/pages/tasks/use-with-mcp.mdx
@@ -54,7 +54,7 @@ Plugin-only integrations are mounted on `/mcp` if the plugin exposes a catalog.
 ## 4. Start The Server
 
 ```sh
-gestaltd serve --locked --config ./gestalt.yaml
+gestaltd serve --locked --config ./config.yaml
 ```
 
 Gestalt mounts `/mcp` on the same HTTP server as the rest of the API.

--- a/docs/pages/troubleshooting.mdx
+++ b/docs/pages/troubleshooting.mdx
@@ -15,10 +15,10 @@ Your config references something that must be prepared first, usually:
 Run:
 
 ```sh
-gestaltd bundle --config ./gestalt.yaml --output ./bundle
+gestaltd bundle --config ./config.yaml --output ./bundle
 ```
 
-and then start again with `gestaltd serve --locked --config ./bundle/gestalt.yaml`.
+and then start again with `gestaltd serve --locked --config ./bundle/config.yaml`.
 
 ## OAuth Redirects Are Wrong
 


### PR DESCRIPTION
The Getting Started page already used config.yaml to match the auto-discovery search path (./config.yaml), but the remaining docs pages still referenced gestalt.yaml. This renames all user-facing config file references in 8 docs pages so the documentation is internally consistent. References to gestalt.lock.json and gestalt.db are intentionally unchanged since those are separate files.