### PR TITLE
Add hybrid plugin manifests with declarative + executable ops

### DIFF
--- a/plugins/bigquery/plugin.yaml
+++ b/plugins/bigquery/plugin.yaml
@@ -9,6 +9,7 @@ provider:
   protocol:
     min: 1
     max: 1
+  base_url: "https://bigquery.googleapis.com/bigquery/v2"
   auth:
     type: oauth2
     authorization_url: https://accounts.google.com/o/oauth2/v2/auth
@@ -18,3 +19,78 @@ provider:
     authorization_params:
       access_type: offline
       prompt: consent
+  operations:
+    - name: list_datasets
+      description: List datasets in a project
+      method: GET
+      path: "/projects/{project_id}/datasets"
+      parameters:
+        - name: project_id
+          type: string
+          in: path
+          required: true
+        - name: maxResults
+          type: int
+          in: query
+    - name: get_dataset
+      description: Get dataset metadata
+      method: GET
+      path: "/projects/{project_id}/datasets/{dataset_id}"
+      parameters:
+        - name: project_id
+          type: string
+          in: path
+          required: true
+        - name: dataset_id
+          type: string
+          in: path
+          required: true
+    - name: list_tables
+      description: List tables in a dataset
+      method: GET
+      path: "/projects/{project_id}/datasets/{dataset_id}/tables"
+      parameters:
+        - name: project_id
+          type: string
+          in: path
+          required: true
+        - name: dataset_id
+          type: string
+          in: path
+          required: true
+        - name: maxResults
+          type: int
+          in: query
+    - name: get_table
+      description: Get table metadata
+      method: GET
+      path: "/projects/{project_id}/datasets/{dataset_id}/tables/{table_id}"
+      parameters:
+        - name: project_id
+          type: string
+          in: path
+          required: true
+        - name: dataset_id
+          type: string
+          in: path
+          required: true
+        - name: table_id
+          type: string
+          in: path
+          required: true
+    - name: list_routines
+      description: List routines in a dataset
+      method: GET
+      path: "/projects/{project_id}/datasets/{dataset_id}/routines"
+      parameters:
+        - name: project_id
+          type: string
+          in: path
+          required: true
+        - name: dataset_id
+          type: string
+          in: path
+          required: true
+        - name: maxResults
+          type: int
+          in: query

--- a/plugins/bigquery/provider.go
+++ b/plugins/bigquery/provider.go
@@ -4,26 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"net/url"
-	"time"
 
-	"github.com/valon-technologies/gestalt/sdk/go"
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
 )
 
 const (
 	providerName        = "bigquery"
 	providerDisplayName = "BigQuery"
 	providerDescription = "Google BigQuery data warehouse"
-
-	bigqueryBaseURL = "https://bigquery.googleapis.com/bigquery/v2"
-
-	httpTimeout          = 30 * time.Second
-	maxResponseBodyBytes = 50 << 20 // 50 MB
 )
-
-var restClient = &http.Client{Timeout: httpTimeout}
 
 type Provider struct {
 	runner queryRunner
@@ -35,61 +25,13 @@ func NewProvider() *Provider {
 	return &Provider{runner: sdkQueryRunner{}}
 }
 
-func (p *Provider) Name() string                              { return providerName }
-func (p *Provider) DisplayName() string                       { return providerDisplayName }
-func (p *Provider) Description() string                       { return providerDescription }
+func (p *Provider) Name() string                            { return providerName }
+func (p *Provider) DisplayName() string                     { return providerDisplayName }
+func (p *Provider) Description() string                     { return providerDescription }
 func (p *Provider) ConnectionMode() gestalt.ConnectionMode { return gestalt.ConnectionModeUser }
 
 func (p *Provider) ListOperations() []gestalt.Operation {
 	return []gestalt.Operation{
-		{
-			Name:        "list_datasets",
-			Description: "List datasets in a project",
-			Method:      http.MethodGet,
-			Parameters: []gestalt.Parameter{
-				{Name: "project_id", Type: "string", Required: true, Description: "GCP project ID"},
-				{Name: "maxResults", Type: "integer", Description: "Maximum results"},
-			},
-		},
-		{
-			Name:        "get_dataset",
-			Description: "Get dataset metadata",
-			Method:      http.MethodGet,
-			Parameters: []gestalt.Parameter{
-				{Name: "project_id", Type: "string", Required: true, Description: "GCP project ID"},
-				{Name: "dataset_id", Type: "string", Required: true, Description: "Dataset ID"},
-			},
-		},
-		{
-			Name:        "list_tables",
-			Description: "List tables in a dataset",
-			Method:      http.MethodGet,
-			Parameters: []gestalt.Parameter{
-				{Name: "project_id", Type: "string", Required: true, Description: "GCP project ID"},
-				{Name: "dataset_id", Type: "string", Required: true, Description: "Dataset ID"},
-				{Name: "maxResults", Type: "integer", Description: "Maximum results"},
-			},
-		},
-		{
-			Name:        "get_table",
-			Description: "Get table metadata",
-			Method:      http.MethodGet,
-			Parameters: []gestalt.Parameter{
-				{Name: "project_id", Type: "string", Required: true, Description: "GCP project ID"},
-				{Name: "dataset_id", Type: "string", Required: true, Description: "Dataset ID"},
-				{Name: "table_id", Type: "string", Required: true, Description: "Table ID"},
-			},
-		},
-		{
-			Name:        "list_routines",
-			Description: "List routines in a dataset",
-			Method:      http.MethodGet,
-			Parameters: []gestalt.Parameter{
-				{Name: "project_id", Type: "string", Required: true, Description: "GCP project ID"},
-				{Name: "dataset_id", Type: "string", Required: true, Description: "Dataset ID"},
-				{Name: "maxResults", Type: "integer", Description: "Maximum results"},
-			},
-		},
 		{
 			Name:        queryOperationName,
 			Description: "Execute a BigQuery SQL query",
@@ -106,89 +48,10 @@ func (p *Provider) ListOperations() []gestalt.Operation {
 }
 
 func (p *Provider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*gestalt.OperationResult, error) {
-	if operation == queryOperationName {
-		return p.executeQuery(ctx, params, token)
-	}
-	return p.executeREST(ctx, operation, params, token)
-}
-
-func (p *Provider) executeREST(ctx context.Context, operation string, params map[string]any, token string) (*gestalt.OperationResult, error) {
-	projectID, _ := params["project_id"].(string)
-	if projectID == "" {
-		return nil, fmt.Errorf("project_id is required")
+	if operation != queryOperationName {
+		return nil, fmt.Errorf("unknown operation %q", operation)
 	}
 
-	var path string
-	switch operation {
-	case "list_datasets":
-		path = fmt.Sprintf("/projects/%s/datasets", projectID)
-	case "get_dataset":
-		datasetID, _ := params["dataset_id"].(string)
-		if datasetID == "" {
-			return nil, fmt.Errorf("dataset_id is required")
-		}
-		path = fmt.Sprintf("/projects/%s/datasets/%s", projectID, datasetID)
-	case "list_tables":
-		datasetID, _ := params["dataset_id"].(string)
-		if datasetID == "" {
-			return nil, fmt.Errorf("dataset_id is required")
-		}
-		path = fmt.Sprintf("/projects/%s/datasets/%s/tables", projectID, datasetID)
-	case "get_table":
-		datasetID, _ := params["dataset_id"].(string)
-		tableID, _ := params["table_id"].(string)
-		if datasetID == "" || tableID == "" {
-			return nil, fmt.Errorf("dataset_id and table_id are required")
-		}
-		path = fmt.Sprintf("/projects/%s/datasets/%s/tables/%s", projectID, datasetID, tableID)
-	case "list_routines":
-		datasetID, _ := params["dataset_id"].(string)
-		if datasetID == "" {
-			return nil, fmt.Errorf("dataset_id is required")
-		}
-		path = fmt.Sprintf("/projects/%s/datasets/%s/routines", projectID, datasetID)
-	default:
-		return &gestalt.OperationResult{
-			Status: http.StatusNotFound,
-			Body:   `{"error":"unknown operation"}`,
-		}, nil
-	}
-
-	reqURL := bigqueryBaseURL + path
-	query := make(url.Values)
-	if maxResults, ok := params["maxResults"]; ok {
-		query.Set("maxResults", fmt.Sprintf("%v", maxResults))
-	}
-	if len(query) > 0 {
-		reqURL += "?" + query.Encode()
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("building request: %w", err)
-	}
-	if token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-
-	resp, err := restClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("executing REST request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodyBytes))
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	return &gestalt.OperationResult{
-		Status: resp.StatusCode,
-		Body:   string(body),
-	}, nil
-}
-
-func (p *Provider) executeQuery(ctx context.Context, params map[string]any, token string) (*gestalt.OperationResult, error) {
 	projectID, _ := params[queryParamProjectID].(string)
 	if projectID == "" {
 		return nil, fmt.Errorf("%s is required", queryParamProjectID)
@@ -233,4 +96,3 @@ func (p *Provider) executeQuery(ctx context.Context, params map[string]any, toke
 		Body:   string(body),
 	}, nil
 }
-

--- a/plugins/jira/plugin.yaml
+++ b/plugins/jira/plugin.yaml
@@ -36,46 +36,80 @@ provider:
       method: GET
       path: /project
       parameters:
-        - {name: maxResults, type: int, in: query}
+        - name: maxResults
+          type: int
+          in: query
     - name: get_issue
       description: Get a Jira issue by key
       method: GET
       path: "/issue/{issueIdOrKey}"
       parameters:
-        - {name: issueIdOrKey, type: string, in: path, required: true}
-        - {name: fields, type: string, in: query}
+        - name: issueIdOrKey
+          type: string
+          in: path
+          required: true
+        - name: fields
+          type: string
+          in: query
     - name: search_issues
       description: Search issues using JQL
       method: POST
       path: /search
       parameters:
-        - {name: jql, type: string, in: body, required: true}
-        - {name: maxResults, type: int, in: body}
-        - {name: startAt, type: int, in: body}
-        - {name: fields, type: array, in: body}
+        - name: jql
+          type: string
+          in: body
+          required: true
+        - name: maxResults
+          type: int
+          in: body
+        - name: startAt
+          type: int
+          in: body
+        - name: fields
+          type: array
+          in: body
     - name: create_issue
       description: Create a new issue
       method: POST
       path: /issue
       parameters:
-        - {name: fields, type: object, in: body, required: true}
+        - name: fields
+          type: object
+          in: body
+          required: true
     - name: add_comment
       description: Add a comment to an issue
       method: POST
       path: "/issue/{issueIdOrKey}/comment"
       parameters:
-        - {name: issueIdOrKey, type: string, in: path, required: true}
-        - {name: body, type: object, in: body, required: true}
+        - name: issueIdOrKey
+          type: string
+          in: path
+          required: true
+        - name: body
+          type: object
+          in: body
+          required: true
     - name: get_transitions
       description: Get available transitions for an issue
       method: GET
       path: "/issue/{issueIdOrKey}/transitions"
       parameters:
-        - {name: issueIdOrKey, type: string, in: path, required: true}
+        - name: issueIdOrKey
+          type: string
+          in: path
+          required: true
     - name: transition_issue
       description: Transition an issue to a new status
       method: POST
       path: "/issue/{issueIdOrKey}/transitions"
       parameters:
-        - {name: issueIdOrKey, type: string, in: path, required: true}
-        - {name: transition, type: object, in: body, required: true}
+        - name: issueIdOrKey
+          type: string
+          in: path
+          required: true
+        - name: transition
+          type: object
+          in: body
+          required: true

--- a/server/internal/bootstrap/bootstrap.go
+++ b/server/internal/bootstrap/bootstrap.go
@@ -694,6 +694,9 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 		if intg.Plugin.IsDeclarative {
 			return buildDeclarativeProvider(name, intg, deps)
 		}
+		if intg.Plugin.IsHybrid {
+			return buildHybridManifestProvider(ctx, name, intg, deps)
+		}
 		pluginProv, pluginConfig, err := buildPluginProvider(ctx, name, intg)
 		if err != nil {
 			return nil, err
@@ -804,6 +807,63 @@ func buildDeclarativeProvider(name string, intg config.IntegrationDef, deps Deps
 	if err != nil {
 		return nil, fmt.Errorf("decode plugin config for %q: %w", name, err)
 	}
+	authHandler, err := buildOAuthHandlerFromManifest(manifest, pluginConfig, deps)
+	if err != nil {
+		slog.Warn("cannot build oauth handler from manifest", "provider", name, "error", err)
+	} else if authHandler != nil {
+		result.ConnectionAuth = map[string]OAuthHandler{
+			config.PluginConnectionName: authHandler,
+		}
+	}
+	return result, nil
+}
+
+func buildHybridManifestProvider(ctx context.Context, name string, intg config.IntegrationDef, deps Deps) (_ *ProviderBuildResult, err error) {
+	_, manifest, err := pluginpkg.ReadManifestFile(intg.Plugin.ResolvedManifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest for hybrid provider %q: %w", name, err)
+	}
+
+	declProv, err := pluginhost.NewDeclarativeProvider(manifest, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create declarative provider %q: %w", name, err)
+	}
+
+	pluginProv, pluginConfig, err := buildPluginProvider(ctx, name, intg)
+	if err != nil {
+		return nil, err
+	}
+	cleanupPlugin := true
+	defer func() {
+		if cleanupPlugin {
+			if c, ok := pluginProv.(interface{ Close() error }); ok {
+				_ = c.Close()
+			}
+		}
+	}()
+
+	displayName := intg.DisplayName
+	if displayName == "" {
+		displayName = manifest.DisplayName
+	}
+	if displayName == "" {
+		displayName = name
+	}
+	merged, err := composite.NewMerged(name, displayName, manifest.Description, declProv, pluginProv)
+	if err != nil {
+		return nil, fmt.Errorf("merging declarative and executable operations for %q: %w", name, err)
+	}
+	cleanupPlugin = false
+	applyPluginIcon(merged, intg)
+
+	restricted, err := applyAllowedOperations(name, intg, merged)
+	if err != nil {
+		_ = merged.Close()
+		return nil, err
+	}
+
+	result := &ProviderBuildResult{Provider: restricted}
+
 	authHandler, err := buildOAuthHandlerFromManifest(manifest, pluginConfig, deps)
 	if err != nil {
 		slog.Warn("cannot build oauth handler from manifest", "provider", name, "error", err)

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -108,6 +108,7 @@ type ExecutablePluginDef struct {
 	ResolvedManifestPath string `yaml:"-"`
 	ResolvedIconFile     string `yaml:"-"`
 	IsDeclarative        bool   `yaml:"-"`
+	IsHybrid             bool   `yaml:"-"`
 }
 
 func (p *ExecutablePluginDef) HasManagedArtifacts() bool {

--- a/server/internal/operator/lifecycle.go
+++ b/server/internal/operator/lifecycle.go
@@ -895,8 +895,10 @@ func applyLockedPluginEntry(paths initPaths, lock *Lockfile, kind, name string, 
 
 	resolvePluginIcon(manifest, manifestPath, plugin)
 
-	if kind == "integration" && manifest.Provider.IsDeclarative() {
-		plugin.ResolvedManifestPath = manifestPath
+	plugin.ResolvedManifestPath = manifestPath
+	if kind == "integration" && manifest.IsHybridProvider() {
+		plugin.IsHybrid = true
+	} else if kind == "integration" && manifest.Provider.IsDeclarative() {
 		plugin.IsDeclarative = true
 		return nil
 	}

--- a/server/internal/pluginpkg/manifest.go
+++ b/server/internal/pluginpkg/manifest.go
@@ -136,7 +136,7 @@ func ValidateManifest(manifest *pluginmanifestv1.Manifest) error {
 
 	needsArtifacts := false
 	for _, kind := range manifest.Kinds {
-		if kind == pluginmanifestv1.KindRuntime || (kind == pluginmanifestv1.KindProvider && !isDeclarative) {
+		if kind == pluginmanifestv1.KindRuntime || (kind == pluginmanifestv1.KindProvider && (!isDeclarative || manifest.IsHybridProvider())) {
 			needsArtifacts = true
 			break
 		}
@@ -181,7 +181,8 @@ func ValidateManifest(manifest *pluginmanifestv1.Manifest) error {
 				if err := validateDeclarativeProvider(manifest.Provider); err != nil {
 					return err
 				}
-			} else {
+			}
+			if !isDeclarative || manifest.IsHybridProvider() {
 				if manifest.Provider.Protocol.Min > manifest.Provider.Protocol.Max {
 					return fmt.Errorf("provider.protocol.min must be <= provider.protocol.max")
 				}

--- a/server/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/server/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -189,6 +189,26 @@
                 ]
               }
             }
+          },
+          {
+            "required": [
+              "artifacts",
+              "entrypoints"
+            ],
+            "properties": {
+              "entrypoints": {
+                "required": [
+                  "provider"
+                ]
+              },
+              "provider": {
+                "required": [
+                  "protocol",
+                  "base_url",
+                  "operations"
+                ]
+              }
+            }
           }
         ]
       }

--- a/server/sdk/pluginmanifest/v1/types.go
+++ b/server/sdk/pluginmanifest/v1/types.go
@@ -53,6 +53,10 @@ func (p *Provider) IsDeclarative() bool {
 	return p != nil && len(p.Operations) > 0
 }
 
+func (m *Manifest) IsHybridProvider() bool {
+	return m != nil && m.Provider != nil && len(m.Provider.Operations) > 0 && m.Entrypoints.Provider != nil
+}
+
 type ProviderOperation struct {
 	Name        string              `json:"name"`
 	Description string              `json:"description,omitempty"`


### PR DESCRIPTION
Plugin manifests can now declare both declarative REST operations and
an executable binary entrypoint. The server builds a declarative
provider from the manifest's operations and spawns the binary for
custom operations, then merges them into a single provider. Operation
names must be unique across both sources.

This lets plugin authors bundle REST API definitions alongside custom
code in a single self-contained package. The BigQuery plugin now
declares its five REST operations (list_datasets, get_dataset, etc.)
in the manifest YAML while keeping only the custom SQL query operation
in Go, eliminating 140 lines of REST boilerplate from the binary.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>