### PR TITLE
Make documentation more readable

### DIFF
--- a/docs/pages/concepts/authentication-and-tokens.mdx
+++ b/docs/pages/concepts/authentication-and-tokens.mdx
@@ -1,9 +1,6 @@
 # Authentication and Tokens
 
-Gestalt has two separate auth layers:
-
-1. **Platform auth** -- who is allowed to use Gestalt
-2. **Integration auth** -- which upstream credentials Gestalt uses on behalf of that subject
+Gestalt has two separate auth layers. **Platform auth** controls who is allowed to use Gestalt. **Integration auth** controls which upstream credentials Gestalt uses on behalf of that subject.
 
 ## Platform Auth Providers
 

--- a/docs/pages/concepts/integrations.mdx
+++ b/docs/pages/concepts/integrations.mdx
@@ -28,12 +28,7 @@ integrations:
         issues/list-for-authenticated-user:
 ```
 
-This one block answers four questions:
-
-1. What should the provider be called
-2. How should credentials be resolved (connections)
-3. Where do its operations come from (api/mcp surfaces)
-4. Which operations should be exposed
+This one block answers what the provider should be called, how credentials are resolved (connections), where operations come from (api/mcp surfaces), and which operations should be exposed.
 
 ## Integration Patterns
 

--- a/docs/pages/concepts/mcp-binding.mdx
+++ b/docs/pages/concepts/mcp-binding.mdx
@@ -61,15 +61,7 @@ That gives you one provider namespace that can contain:
 
 ## What The MCP Client Sees
 
-The MCP client does not talk directly to your upstream APIs. It talks to Gestalt:
-
-1. the client connects to `/mcp`
-2. Gestalt advertises tools from all integrations that expose operations
-3. tool invocations flow through the same invocation broker as HTTP requests
-4. the broker resolves credentials, instances, refresh, and connection metadata
-5. Gestalt executes the underlying provider operation
-
-This means MCP inherits the same auth and connection behavior as the rest of the platform.
+The MCP client does not talk directly to your upstream APIs. It connects to `/mcp`, where Gestalt advertises tools from all integrations that expose operations. Tool invocations flow through the same invocation broker as HTTP requests, so the broker resolves credentials, instances, refresh, and connection metadata before Gestalt executes the underlying provider operation. MCP inherits the same auth and connection behavior as the rest of the platform.
 
 ## Auth Behavior
 

--- a/docs/pages/concepts/observability.mdx
+++ b/docs/pages/concepts/observability.mdx
@@ -2,25 +2,21 @@
 
 Gestalt uses [OpenTelemetry](https://opentelemetry.io) for observability. The `telemetry` block in your config file selects a provider that controls what signals are exported:
 
-- **`otlp`** — Exports traces, metrics, and structured logs to an OpenTelemetry collector.
-- **`stdout`** — Outputs structured logs only. Traces and metrics use noop providers to keep terminal output clean during development.
-- **`noop`** — Disables all telemetry.
+- **`otlp`**: exports traces, metrics, and structured logs to an OpenTelemetry collector.
+- **`stdout`**: outputs structured logs only. Traces and metrics use noop providers to keep terminal output clean during development.
+- **`noop`**: disables all telemetry.
 
 ## Traces
 
 Trace export requires the `otlp` telemetry provider. The `stdout` provider silences traces to avoid noisy output during local development.
 
-When using `otlp`, every request is automatically traced across three layers:
-
-1. **HTTP** — `otelhttp` middleware on the chi router creates a root span for each inbound request with standard HTTP semantic conventions (method, route, status code, latency).
-2. **Broker** — `Broker.Invoke()` creates a child span with attributes for the provider, operation, user, and connection mode.
-3. **gRPC plugins** — `otelgrpc` interceptors on plugin connections propagate trace context across process boundaries, so plugin spans appear as children of the broker span.
+When using `otlp`, every request is automatically traced across three layers. At the **HTTP** layer, `otelhttp` middleware on the chi router creates a root span for each inbound request with standard HTTP semantic conventions (method, route, status code, latency). At the **broker** layer, `Broker.Invoke()` creates a child span with attributes for the provider, operation, user, and connection mode. At the **gRPC plugin** layer, `otelgrpc` interceptors on plugin connections propagate trace context across process boundaries, so plugin spans appear as children of the broker span.
 
 A single trace shows the full lifecycle: HTTP request → broker invocation → plugin RPC. When a provider invocation is slow, the trace shows whether the bottleneck was token refresh, the provider's execution, or network latency.
 
 ### Sampling (`otlp` only)
 
-The `otlp` provider supports configurable trace sampling via `traces.sampling_ratio` (default `1.0`, meaning all traces). At low to moderate scale, sample everything. When volume demands it, reduce the ratio — but note that the OTel Collector's [spanmetrics connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/README.md) can derive accurate RED metrics from 100% of spans _before_ the sampling decision, so metrics remain accurate even with aggressive trace sampling.
+The `otlp` provider supports configurable trace sampling via `traces.sampling_ratio` (default `1.0`, meaning all traces). At low to moderate scale, sample everything. When volume demands it, reduce the ratio, but note that the OTel Collector's [spanmetrics connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/README.md) can derive accurate RED metrics from 100% of spans _before_ the sampling decision, so metrics remain accurate even with aggressive trace sampling.
 
 ## Metrics
 

--- a/docs/pages/concepts/platform-model.mdx
+++ b/docs/pages/concepts/platform-model.mdx
@@ -4,12 +4,7 @@ Gestalt has a small number of primitives, but they compose into a full integrati
 
 ## The Core Model
 
-At the highest level, `gestaltd` does four things:
-
-1. Load and validate a declarative config file.
-2. Bootstrap the platform components that config names.
-3. Build providers from integrations.
-4. Expose those providers through shared request surfaces.
+At the highest level, `gestaltd` loads and validates a declarative config file, bootstraps the platform components that config names, builds providers from integrations, and exposes those providers through shared request surfaces.
 
 ## The Main Primitives
 
@@ -93,14 +88,7 @@ The broker is responsible for:
 - injecting connection metadata into execution context
 - returning normalized operation results
 
-Because this broker is shared, the same token and policy behavior applies whether the caller is:
-
-- the web UI
-- a direct HTTP client
-- an MCP client hitting `/mcp`
-- a webhook binding
-- a proxy binding
-- a background runtime
+Because this broker is shared, the same token and policy behavior applies whether the caller is the web UI, a direct HTTP client, an MCP client hitting `/mcp`, a webhook binding, a proxy binding, or a background runtime.
 
 ## Connection Modes
 
@@ -129,15 +117,4 @@ Once providers exist, `gestaltd` projects them into several surfaces:
 
 ## What The User Actually Programs Against
 
-As a Gestalt operator, the main primitives you compose are:
-
-- top-level config blocks
-- integration definitions
-- connection definitions
-- API and MCP surface definitions
-- runtime definitions
-- binding definitions
-- egress rules
-- optional plugin manifests and packages
-
-Everything else is a consequence of those inputs.
+As a Gestalt operator, you compose top-level config blocks, integration definitions, connection definitions, API and MCP surface definitions, runtime and binding definitions, egress rules, and optional plugin manifests and packages. Everything else is a consequence of those inputs.

--- a/docs/pages/concepts/plugin-packaging.mdx
+++ b/docs/pages/concepts/plugin-packaging.mdx
@@ -38,13 +38,7 @@ A minimal provider package manifest looks like this:
 }
 ```
 
-The important ideas are:
-
-- `source` identifies the plugin in the managed artifact system
-- the package declares which kinds it supports
-- the manifest names platform-specific artifacts
-- entrypoints point at one of those packaged artifacts
-- provider packages may also ship a JSON Schema for config validation
+`source` identifies the plugin in the managed artifact system. The package declares which kinds it supports, names platform-specific artifacts, and defines entrypoints that point at those artifacts. Provider packages may also ship a JSON Schema for config validation.
 
 ### Web UI package
 
@@ -116,12 +110,4 @@ When you later run `gestaltd serve --locked` against the bundled config, startup
 
 ## Why Packaging Matters
 
-Packaging gives you:
-
-- repeatable installs
-- artifact digest verification
-- platform-specific binaries in one archive
-- optional config schema validation
-- deterministic production startup
-
-For development, `plugin.command` is usually simpler. For deployment, `plugin.package` plus `gestaltd bundle` is the stronger model.
+Packaging gives you repeatable installs, artifact digest verification, platform-specific binaries in one archive, optional config schema validation, and deterministic production startup. For development, `plugin.command` is usually simpler. For deployment, `plugin.package` plus `gestaltd bundle` is the stronger model.

--- a/docs/pages/concepts/security.mdx
+++ b/docs/pages/concepts/security.mdx
@@ -75,7 +75,7 @@ The `server.encryption_key` is the root deployment secret. Gestalt derives all c
 
 If the encryption key is a 64-character hex string, it is decoded directly as a 32-byte key. Otherwise, Argon2id derives a 32-byte key from the string.
 
-Every encryption operation generates a fresh random nonce using `crypto/rand`. Ciphertexts are base64-encoded for storage. GCM provides authenticated encryption -- tampering with stored ciphertexts is detected at decryption time.
+Every encryption operation generates a fresh random nonce using `crypto/rand`. Ciphertexts are base64-encoded for storage. GCM provides authenticated encryption, so tampering with stored ciphertexts is detected at decryption time.
 
 ### What is encrypted
 
@@ -132,7 +132,7 @@ POST /api/v1/tokens
 ```
 
 - Plaintext is returned exactly once at creation time
-- Only the SHA-256 hash is stored -- tokens cannot be recovered from the datastore
+- Only the SHA-256 hash is stored. Tokens cannot be recovered from the datastore
 - Default TTL: 30 days (configurable via `server.api_token_ttl`)
 - Revocable individually (`DELETE /api/v1/tokens/{id}`) or in bulk (`DELETE /api/v1/tokens`)
 
@@ -195,7 +195,7 @@ For proxy bindings, `Proxy-Authorization: Bearer` is checked first, then `Author
 
 ## Egress Policy Enforcement
 
-Egress policies control what outbound requests Gestalt makes on behalf of callers. Policy evaluation happens **before** credential resolution -- denied requests never trigger secret fetches or token decryption.
+Egress policies control what outbound requests Gestalt makes on behalf of callers. Policy evaluation happens **before** credential resolution. Denied requests never trigger secret fetches or token decryption.
 
 ```
 Invocation request

--- a/docs/pages/concepts/ui-plugins.mdx
+++ b/docs/pages/concepts/ui-plugins.mdx
@@ -4,7 +4,7 @@ Gestalt serves a web UI alongside its API. By default it uses the embedded front
 
 ## How It Works
 
-A UI plugin is a static asset package (HTML, CSS, JS) with a `plugin.json` manifest. When configured, `gestaltd` serves the plugin's assets instead of the embedded frontend. The browser connects to the same origin and port — there is no separate UI server.
+A UI plugin is a static asset package (HTML, CSS, JS) with a `plugin.json` manifest. When configured, `gestaltd` serves the plugin's assets instead of the embedded frontend. The browser connects to the same origin and port. There is no separate UI server.
 
 API routes (`/api/v1/*`, `/mcp`, `/health`, `/ready`) always take priority. Unmatched requests fall through to the UI handler, which serves files with SPA fallback behavior:
 
@@ -49,8 +49,8 @@ my-ui-plugin/
 
 The `webui` kind differs from `provider` and `runtime`:
 
-- no `artifacts` or `entrypoints` — there is no binary
-- no platform-specific builds — static assets are platform-agnostic
+- no `artifacts` or `entrypoints` (there is no binary)
+- no platform-specific builds (static assets are platform-agnostic)
 - `asset_root` points to the directory containing `index.html`
 - `webui` cannot be combined with other kinds in the same manifest
 

--- a/docs/pages/deploy/aws-lambda.mdx
+++ b/docs/pages/deploy/aws-lambda.mdx
@@ -25,12 +25,7 @@ SQLite is not a realistic Lambda datastore.
 
 ## Practical Model
 
-The practical Lambda shape is:
-
-1. package Gestalt as a Lambda-compatible container image or custom runtime
-2. put an HTTP adapter in front of `gestaltd`
-3. use a managed SQL datastore
-4. keep `server.base_url` aligned with the API Gateway or custom domain URL
+The practical Lambda shape is to package Gestalt as a Lambda-compatible container image or custom runtime, put an HTTP adapter in front of `gestaltd`, use a managed SQL datastore, and keep `server.base_url` aligned with the API Gateway or custom domain URL.
 
 ## Config Shape
 

--- a/docs/pages/deploy/gateway-only.mdx
+++ b/docs/pages/deploy/gateway-only.mdx
@@ -4,7 +4,7 @@ import { Callout } from 'nextra/components'
 
 A gateway-only deployment runs Gestalt as an HTTP proxy with centralized auth, egress policy, and credential injection. It does not load any providers, integrations, runtimes, or MCP surfaces.
 
-This is useful when you want to mediate outbound API calls -- injecting secrets, enforcing deny rules, and authenticating callers -- without building a capability catalog.
+This is useful when you want to mediate outbound API calls (injecting secrets, enforcing deny rules, and authenticating callers) without building a capability catalog.
 
 ## What You Get
 

--- a/docs/pages/deploy/index.mdx
+++ b/docs/pages/deploy/index.mdx
@@ -6,13 +6,7 @@ import { Cards } from 'nextra/components'
 
 ## Deployment Checklist
 
-Every deployment needs the same inputs:
-
-1. A `gestaltd` binary or container image.
-2. A `config.yaml`.
-3. Environment variables or secret-manager entries for sensitive values.
-4. A datastore choice that matches your scaling model.
-5. A clear startup mode: mutable startup or locked startup.
+Every deployment needs the same inputs: a `gestaltd` binary or container image, a `config.yaml`, environment variables or secret-manager entries for sensitive values, a datastore choice that matches your scaling model, and a clear startup mode (mutable or locked).
 
 ## Choose A Startup Mode
 

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -1,10 +1,10 @@
-import { Callout, Steps } from 'nextra/components'
+import { Callout } from 'nextra/components'
 
 # Getting Started
 
 This guide starts with the true out-of-the-box flow, then moves to an explicit config and a production-style startup path.
 
-## 0. Install
+## Install
 
 **Homebrew** (macOS and Linux)
 
@@ -40,7 +40,7 @@ For production, bundle first and use the default locked mode:
 docker run -p 8080:8080 -v ./bundle:/etc/gestalt valontechnologies/gestaltd:latest
 ```
 
-## 1. Run `gestaltd` With No Config
+## Run `gestaltd` With No Config
 
 ```sh
 gestaltd
@@ -48,13 +48,7 @@ gestaltd
 
 If no config file exists and you did not pass `--config`, `gestaltd` creates `~/.gestalt/config.yaml` for you and starts immediately.
 
-The generated local config uses:
-
-- `auth.provider: none`
-- `datastore.provider: sqlite`
-- `secrets.provider: env`
-- a generated `server.encryption_key`
-- `~/.gestalt/gestalt.db` as the SQLite database
+The generated local config uses `auth.provider: none`, SQLite as the datastore at `~/.gestalt/gestalt.db`, `env` for secrets, and a generated `server.encryption_key`.
 
 The server listens on `http://localhost:8080`. The web UI is served from that same port.
 
@@ -62,17 +56,9 @@ The server listens on `http://localhost:8080`. The web UI is served from that sa
   The default command `gestaltd` is intentionally local-friendly. It can auto-generate config and auto-prepare remote artifacts. Production deployments should usually use `gestaltd bundle` followed by `gestaltd serve --locked`.
 </Callout>
 
-## 2. Open The UI
+## Open The UI
 
-<Steps>
-### Open the server
-
-Visit `http://localhost:8080`.
-
-### Inspect the default environment
-
-The generated config uses `auth.provider: none`, so no sign-in is required. Add an integration to start building.
-</Steps>
+Visit `http://localhost:8080`. The generated config uses `auth.provider: none`, so no sign-in is required. Add an integration to start building.
 
 ## Or: Generate A Config With `gestalt init`
 
@@ -82,7 +68,7 @@ Instead of writing `config.yaml` by hand, run `gestalt init` for an interactive 
 gestalt init
 ```
 
-## 3. Switch To An Explicit Config
+## Switch To An Explicit Config
 
 Save this as `config.yaml`:
 
@@ -113,14 +99,9 @@ integrations:
       connection: default
 ```
 
-This is the smallest useful production-shaped config:
+This is the smallest useful production-shaped config: explicit `server`, `auth`, and `datastore` blocks, one named integration, one connection with `mode: none`, and one REST API surface pointing at an OpenAPI spec.
 
-- explicit `server`, `auth`, and `datastore`
-- one named integration
-- one connection with `mode: none` (no per-user credential requirement)
-- one REST API surface pointing at an OpenAPI spec
-
-## 4. Bundle And Validate It
+## Bundle And Validate It
 
 ```sh
 gestaltd bundle --config ./config.yaml --output ./bundle
@@ -132,7 +113,7 @@ gestaltd validate --config ./bundle/config.yaml
 - `gestalt.lock.json`
 - `.gestalt/providers/github.json`
 
-## 5. Start From Locked State
+## Start From Locked State
 
 ```sh
 gestaltd serve --locked --config ./bundle/config.yaml
@@ -140,7 +121,7 @@ gestaltd serve --locked --config ./bundle/config.yaml
 
 This is the deployment path to model in Docker, Kubernetes, or any other production target. Startup becomes deterministic because `gestaltd` no longer needs to mutate local state or fetch remote specs.
 
-## 6. What To Learn Next
+## What To Learn Next
 
 - [Platform Model](/concepts/platform-model): how config turns into providers, runtimes, bindings, and MCP.
 - [Configuration](/concepts/configuration): config discovery, defaults, secret resolution, and lock state.

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -1,4 +1,4 @@
-import { Cards, Steps } from 'nextra/components'
+import { Cards } from 'nextra/components'
 
 # Gestalt
 
@@ -15,7 +15,6 @@ import { Cards, Steps } from 'nextra/components'
 
 ## The Four Foundations
 
-<Steps>
 ### Configuration
 
 Your YAML file declares the feature sets that make up a Gestalt deployment: platform auth, token storage, secret resolution, integrations, runtimes, bindings, and egress rules.
@@ -31,16 +30,15 @@ Each integration becomes a runtime provider. All request surfaces share the same
 ### Surfaces
 
 The same provider graph can be reached through the HTTP API, the embedded web UI, `/mcp`, webhook bindings, proxy bindings, and background runtimes.
-</Steps>
 
 ## Deployment Paths
 
-There are four real deployment modes to think about:
-
-1. `gestaltd` with no config: local-only, auto-generated config, `auth.provider: none`, SQLite, and a generated encryption key.
-2. Docker or Docker Compose: single container, single HTTP port, config mounted into `/etc/gestalt/config.yaml`.
-3. Helm on Kubernetes: one Deployment for `gestaltd`, optional init container for locked startup.
-4. Bare binary: `gestaltd`, `gestaltd serve`, `gestaltd bundle`, and `gestaltd validate`.
+| Mode | Description |
+| --- | --- |
+| No config | Local-only, auto-generated config, `auth.provider: none`, SQLite, and a generated encryption key. |
+| Docker or Docker Compose | Single container, single HTTP port, config mounted into `/etc/gestalt/config.yaml`. |
+| Helm on Kubernetes | One Deployment for `gestaltd`, optional init container for locked startup. |
+| Bare binary | `gestaltd`, `gestaltd serve`, `gestaltd bundle`, and `gestaltd validate`. |
 
 ## Start Here
 

--- a/docs/pages/tasks/add-a-first-party-provider.mdx
+++ b/docs/pages/tasks/add-a-first-party-provider.mdx
@@ -10,7 +10,7 @@ A built-in provider makes sense when:
 - config-defined surfaces are not expressive enough
 - the code needs to ship and test with the host binary
 
-## 1. Implement The Provider Package
+## Implement The Provider Package
 
 Create a package under:
 
@@ -27,7 +27,7 @@ Depending on behavior, the provider may also implement:
 - `core.CatalogProvider`
 - connection-parameter interfaces used by the UI and MCP
 
-## 2. Register It
+## Register It
 
 Built-in named providers are registered in:
 
@@ -37,11 +37,11 @@ cmd/gestaltd/providers.go
 
 If the provider is intended to ship in the binary, it must be added there.
 
-## 3. Decide How Operators Compose It
+## Decide How Operators Compose It
 
 An integration uses the registered provider as its entire implementation by referencing it in the `plugin` block.
 
-## 4. Test It At The Provider Boundary
+## Test It At The Provider Boundary
 
 Tests should validate:
 
@@ -52,7 +52,7 @@ Tests should validate:
 
 The important boundary is the provider contract the rest of Gestalt sees, not just internal helper functions.
 
-## 5. Update The Docs
+## Update The Docs
 
 If you add a new first-party provider, update:
 

--- a/docs/pages/tasks/add-an-integration.mdx
+++ b/docs/pages/tasks/add-an-integration.mdx
@@ -2,16 +2,16 @@
 
 Most integrations are pure configuration. Start with a declarative integration and reach for a plugin only when the upstream behavior cannot be expressed declaratively.
 
-## 1. Pick the Surface Type
+## Pick the Surface Type
 
 | Surface | When to use |
 | --- | --- |
 | `api` (REST) | You have an OpenAPI document. |
 | `api` (GraphQL) | You have a GraphQL endpoint. |
 | `mcp` | The upstream already exposes MCP tools. |
-| `plugin` | You need custom execution logic. Can compose with `mcp` (hybrid). Cannot combine with `api`. |
+| `plugin` | You need custom execution logic. Can compose with `api`, `mcp`, or both. |
 
-## 2. Start with the Smallest Useful Definition
+## Start with the Smallest Useful Definition
 
 Public REST example with no auth:
 
@@ -30,7 +30,7 @@ integrations:
 
 That is enough to build a provider and invoke the public API.
 
-## 3. Add Auth
+## Add Auth
 
 OAuth-backed example:
 
@@ -57,7 +57,7 @@ integrations:
 
 Auth lives inside the connection, not at the integration level.
 
-## 4. Add an MCP Surface
+## Add an MCP Surface
 
 Add `mcp` alongside `api`, or use it standalone:
 
@@ -80,7 +80,7 @@ integrations:
 
 Set `mcp_tool_prefix` at the integration level to avoid tool-name collisions across integrations.
 
-## 5. Bundle and Validate
+## Bundle and Validate
 
 ```sh
 gestaltd bundle --config ./config.yaml --output ./bundle
@@ -89,7 +89,7 @@ gestaltd validate --config ./bundle/config.yaml
 
 This prepares remote provider artifacts and catches config errors.
 
-## 6. Run
+## Run
 
 ```sh
 gestaltd serve --locked --config ./bundle/config.yaml
@@ -101,7 +101,7 @@ Then:
 - List operations with `GET /api/v1/integrations/{name}/operations`
 - Invoke operations over HTTP or MCP
 
-## 7. Reach for a Plugin Only When Needed
+## Reach for a Plugin Only When Needed
 
 Write a provider plugin when you need:
 

--- a/docs/pages/tasks/use-a-plugin-package.mdx
+++ b/docs/pages/tasks/use-a-plugin-package.mdx
@@ -2,7 +2,7 @@
 
 Packaged plugins are the deployment-oriented way to run executable providers and runtimes.
 
-## 1. Reference The Package
+## Reference The Package
 
 ```yaml
 integrations:
@@ -19,7 +19,7 @@ integrations:
 - a local `.tar.gz`
 - an HTTPS URL
 
-## 2. Bundle It
+## Bundle It
 
 ```sh
 gestaltd bundle --config ./config.yaml --output ./bundle
@@ -27,7 +27,7 @@ gestaltd bundle --config ./config.yaml --output ./bundle
 
 This validates the manifest, selects the current platform artifact, installs the package into the output directory, and records the prepared result in `gestalt.lock.json`.
 
-## 3. Validate The Bundled Deployment
+## Validate The Bundled Deployment
 
 ```sh
 gestaltd validate --config ./bundle/config.yaml
@@ -35,7 +35,7 @@ gestaltd validate --config ./bundle/config.yaml
 
 Validation uses the prepared plugin state instead of re-resolving the package every time.
 
-## 4. Start From Locked State
+## Start From Locked State
 
 ```sh
 gestaltd serve --locked --config ./bundle/config.yaml
@@ -43,7 +43,7 @@ gestaltd serve --locked --config ./bundle/config.yaml
 
 That is the normal production path for packaged plugins.
 
-## 5. Refresh A Remote Package
+## Refresh A Remote Package
 
 If `plugin.package` points at an HTTPS URL and the remote archive changes, rerun:
 

--- a/docs/pages/tasks/use-with-mcp.mdx
+++ b/docs/pages/tasks/use-with-mcp.mdx
@@ -2,7 +2,7 @@
 
 Gestalt exposes integrations to any MCP client through `/mcp`.
 
-## 1. Automatic MCP Projection
+## Automatic MCP Projection
 
 All declarative API operations are automatically projected as MCP tools. There is no opt-in flag; if an integration has an `api` surface, its operations appear on `/mcp`.
 
@@ -30,7 +30,7 @@ integrations:
 
 `mcp_tool_prefix` controls tool naming so that tools from different integrations do not collide.
 
-## 2. Connect To A Native MCP Server
+## Connect To A Native MCP Server
 
 Adding an `mcp` surface connects Gestalt to an upstream MCP server and republishes its tools:
 
@@ -47,11 +47,11 @@ integrations:
 
 An integration can declare both `api` and `mcp` surfaces. The resulting provider namespace contains generated HTTP operations and imported MCP tools.
 
-## 3. Plugin-Only Integrations
+## Plugin-Only Integrations
 
 Plugin-only integrations are mounted on `/mcp` if the plugin exposes a catalog.
 
-## 4. Start The Server
+## Start The Server
 
 ```sh
 gestaltd serve --locked --config ./config.yaml
@@ -59,7 +59,7 @@ gestaltd serve --locked --config ./config.yaml
 
 Gestalt mounts `/mcp` on the same HTTP server as the rest of the API.
 
-## 5. Create A Gestalt API Token
+## Create A Gestalt API Token
 
 Use the web UI or the HTTP API:
 
@@ -72,7 +72,7 @@ curl -X POST http://localhost:8080/api/v1/tokens \
 
 The returned token is what the MCP client uses to authenticate to Gestalt.
 
-## 6. Point Your MCP Client At Gestalt
+## Point Your MCP Client At Gestalt
 
 Example client config:
 
@@ -89,13 +89,13 @@ Example client config:
 }
 ```
 
-## 7. Understand The Auth Layers
+## Understand The Auth Layers
 
 The MCP client authenticates to Gestalt with the API token above.
 
 Then Gestalt resolves upstream credentials using the integration's connection mode. That means MCP inherits the same per-user, shared-identity, or no-auth behavior as the regular HTTP API.
 
-## 8. Troubleshoot Missing Tools
+## Troubleshoot Missing Tools
 
 Check these in order:
 


### PR DESCRIPTION
Replace numbered header prefixes, emdashes, and unnecessary bullet
lists with flowing prose across 17 documentation pages. Convert the
homepage deployment modes to a table, remove `<Steps>` component
wrappers, and fix a stale surface type table that incorrectly said
plugins cannot combine with `api` surfaces.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>