### PR TITLE
Fix compiled plugin release to produce single multi-platform tarball

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -93,19 +93,15 @@ jobs:
           - name: macOS-ARM64
             goos: darwin
             goarch: arm64
-            suffix: macos-arm64
           - name: macOS-x86_64
             goos: darwin
             goarch: amd64
-            suffix: macos-x86_64
           - name: Linux-x86_64
             goos: linux
             goarch: amd64
-            suffix: linux-x86_64
           - name: Linux-ARM64
             goos: linux
             goarch: arm64
-            suffix: linux-arm64
     env:
       PLUGIN_NAME: ${{ needs.prepare.outputs.plugin-name }}
       PLUGIN_VERSION: ${{ needs.prepare.outputs.plugin-version }}
@@ -123,22 +119,78 @@ jobs:
         run: |
           cd "plugins/${PLUGIN_NAME}"
           go build -o "../../gestalt-plugin-${PLUGIN_NAME}" ./cmd
-      - name: Package
+      - uses: actions/upload-artifact@v4
+        with:
+          name: binary-${{ matrix.platform.goos }}-${{ matrix.platform.goarch }}
+          path: gestalt-plugin-${{ env.PLUGIN_NAME }}
+          if-no-files-found: error
+
+  assemble-compiled:
+    name: Assemble Compiled Plugin
+    needs: [prepare, build-compiled]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PLUGIN_NAME: ${{ needs.prepare.outputs.plugin-name }}
+      PLUGIN_VERSION: ${{ needs.prepare.outputs.plugin-version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: binary-*
+          path: binaries
+      - name: Assemble multi-platform package
         run: |
-          ASSET="gestalt-plugin-${PLUGIN_NAME}_v${PLUGIN_VERSION}_${{ matrix.platform.suffix }}"
-          mkdir staging
-          cp "gestalt-plugin-${PLUGIN_NAME}" staging/
-          cp "plugins/${PLUGIN_NAME}/plugin.yaml" staging/
-          if [ -d "plugins/${PLUGIN_NAME}/assets" ]; then
-            cp -r "plugins/${PLUGIN_NAME}/assets" staging/
+          ASSET="gestalt-plugin-${PLUGIN_NAME}_v${PLUGIN_VERSION}"
+          PLUGIN_DIR="plugins/${PLUGIN_NAME}"
+          BINARY_NAME="gestalt-plugin-${PLUGIN_NAME}"
+
+          MANIFEST=$(yq -o json "${PLUGIN_DIR}/plugin.yaml")
+
+          ARTIFACTS="[]"
+          for platform_dir in binaries/binary-*; do
+            PLATFORM=$(basename "$platform_dir" | sed 's/^binary-//')
+            GOOS=$(echo "$PLATFORM" | cut -d- -f1)
+            GOARCH=$(echo "$PLATFORM" | cut -d- -f2)
+            ARTIFACT_PATH="artifacts/${GOOS}/${GOARCH}/${BINARY_NAME}"
+
+            mkdir -p "staging/artifacts/${GOOS}/${GOARCH}"
+            cp "${platform_dir}/${BINARY_NAME}" "staging/${ARTIFACT_PATH}"
+            chmod +x "staging/${ARTIFACT_PATH}"
+
+            DIGEST=$(shasum -a 256 "staging/${ARTIFACT_PATH}" | cut -d' ' -f1)
+            ARTIFACTS=$(echo "$ARTIFACTS" | jq \
+              --arg os "$GOOS" --arg arch "$GOARCH" \
+              --arg path "$ARTIFACT_PATH" --arg sha256 "$DIGEST" \
+              '. + [{"os": $os, "arch": $arch, "path": $path, "sha256": $sha256}]')
+          done
+
+          ENTRYPOINT_PATH="artifacts/linux/amd64/${BINARY_NAME}"
+          if [ ! -f "staging/${ENTRYPOINT_PATH}" ]; then
+            echo "ERROR: entrypoint artifact ${ENTRYPOINT_PATH} not found in staging"
+            exit 1
           fi
+
+          echo "$MANIFEST" | jq \
+            --argjson artifacts "$ARTIFACTS" \
+            --arg entrypoint "$ENTRYPOINT_PATH" \
+            '. + {"artifacts": $artifacts, "entrypoints": {"provider": {"artifact_path": $entrypoint}}}' \
+            > staging/plugin.json
+
+          TAR_ARGS="plugin.json"
+          if [ -d "${PLUGIN_DIR}/assets" ]; then
+            cp -r "${PLUGIN_DIR}/assets" staging/
+            TAR_ARGS="${TAR_ARGS} assets/"
+          fi
+          TAR_ARGS="${TAR_ARGS} artifacts/"
+
           cd staging
-          tar -czvf "../${ASSET}.tar.gz" .
+          tar -czvf "../${ASSET}.tar.gz" ${TAR_ARGS}
           cd ..
           shasum -a 256 "${ASSET}.tar.gz" > "${ASSET}.tar.gz.sha256"
       - uses: actions/upload-artifact@v4
         with:
-          name: gestalt-plugin-${{ env.PLUGIN_NAME }}-${{ matrix.platform.suffix }}
+          name: gestalt-plugin-${{ env.PLUGIN_NAME }}
           path: |
             gestalt-plugin-*.tar.gz
             gestalt-plugin-*.sha256
@@ -146,8 +198,8 @@ jobs:
 
   release:
     name: Create Release
-    needs: [prepare, build-declarative, build-compiled]
-    if: always() && needs.prepare.result == 'success' && (needs.build-declarative.result == 'success' || needs.build-compiled.result == 'success')
+    needs: [prepare, build-declarative, assemble-compiled]
+    if: always() && needs.prepare.result == 'success' && (needs.build-declarative.result == 'success' || needs.assemble-compiled.result == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
The plugin resolver expects a single platform-neutral asset named
`gestalt-plugin-{name}_v{version}.tar.gz`, but the compiled plugin
workflow was producing separate per-platform tarballs with platform
suffixes that the resolver could not find. The tarballs were also
created with `tar ... .` which adds a `./` directory entry that fails
archive path validation.

This restructures the compiled plugin release into a build step that
uploads raw binaries as artifacts and a new assembly step that combines
all platform binaries into a single tarball under
`artifacts/{os}/{arch}/`, generates a `plugin.json` with the `artifacts`
array and `entrypoints` metadata, and lists files explicitly to avoid
the `./` entry.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>