### PR TITLE
Fix stale plugin composition docs

### DIFF
--- a/docs/pages/tasks/add-an-integration.mdx
+++ b/docs/pages/tasks/add-an-integration.mdx
@@ -110,4 +110,4 @@ Write a provider plugin when you need:
 - Multi-step execution
 - Custom operation semantics that do not come from an upstream spec
 
-Plugin integrations use the `plugin` block. They can optionally compose with an `mcp` surface (hybrid pattern) but cannot declare an `api` surface. See [Integrations](/concepts/integrations) for the hybrid pattern.
+Plugin integrations use the `plugin` block and can compose with `api`, `mcp`, or both. See [Integrations](/concepts/integrations) for the composition patterns.


### PR DESCRIPTION
The add-an-integration guide still said plugins cannot declare an
`api` surface. This was true before PR #344 added hybrid plugin+api
support. Update the remaining reference to match.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>