### PR TITLE
Update docs for plugin token passthrough and hybrid composition

### DIFF
--- a/docs/pages/concepts/mcp-binding.mdx
+++ b/docs/pages/concepts/mcp-binding.mdx
@@ -45,17 +45,7 @@ integrations:
 
 ## Composition Rules
 
-An integration may combine:
-
-- one `api` surface (REST or GraphQL)
-- one `mcp` surface
-- a `plugin` block with an `mcp` surface (hybrid pattern)
-
-That gives you one provider namespace that can contain:
-
-- generated HTTP operations (automatically projected as MCP tools)
-- imported MCP tools
-- plugin-provided operations (including plugin catalogs)
+An integration may combine one `api` surface (REST or GraphQL), one `mcp` surface, and a `plugin` block. All three can coexist in a single integration, giving you one provider namespace that contains generated HTTP operations (automatically projected as MCP tools), imported MCP tools, and plugin-provided operations.
 
 `mcp_tool_prefix` exists to avoid tool-name collisions when multiple integrations export similarly named operations.
 

--- a/docs/pages/concepts/security.mdx
+++ b/docs/pages/concepts/security.mdx
@@ -42,7 +42,7 @@ Four trust boundaries:
 | --- | --- | --- |
 | Internet → Gestalt | User requests | Platform auth (session or API token) |
 | Gestalt → upstream APIs | OAuth tokens, API keys | Egress policy, credential encryption, TLS |
-| Gestalt → plugins | Config, operation requests | Process isolation, Unix socket, scoped capabilities |
+| Gestalt → plugins | Config, operation requests, access tokens | Process isolation, Unix socket, scoped capabilities |
 | Operator → Gestalt | Config, encryption key, secrets | Secret manager, env var expansion, `secret://` refs |
 
 ## Encryption at Rest
@@ -269,10 +269,10 @@ gestaltd process
 Isolation properties:
 
 - **No shared memory**: communication is message-passing over a socket
-- **No direct datastore access**: plugins cannot read or write tokens
+- **No direct datastore access**: plugins cannot query the datastore or access other users' credentials
 - **Sanitized environment**: only safe variables are passed to plugin processes (`PATH`, `HOME`, `TMPDIR`, `LANG`, `TZ`, `SSL_CERT_*`, plus user-configured `env`)
 - **Scoped capabilities**: runtime plugins can only invoke providers listed in `runtimes.<name>.providers`
-- **Credential passthrough**: the host passes the access token directly to the plugin via the gRPC request, not the full credential store
+- **Token passthrough**: the host resolves the caller's access token and passes it directly to the plugin in the gRPC request. Plugins receive only the token for the current invocation, not the full credential store.
 - **Process lifecycle**: plugins are terminated when `gestaltd` shuts down (SIGTERM, then SIGKILL after timeout)
 
 ## Webhook Signature Verification

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -452,7 +452,7 @@ connections:
 
 ### `plugin`
 
-Plugin integrations delegate execution to an external binary. A plugin integration may optionally compose with an `mcp` surface (hybrid pattern) but cannot declare an `api` surface.
+Plugin integrations delegate execution to an external binary. A plugin can compose with `api`, `mcp`, or both.
 
 ```yaml
 integrations:
@@ -653,8 +653,7 @@ Structural validation runs at config load time (`bundle`, `validate`, `serve`). 
 
 ### Structural
 
-- Integrations are declarative (`connections` + `api`/`mcp`), plugin-only, or hybrid (plugin + `mcp`)
-- Plugin integrations cannot declare `api`
+- Integrations are declarative (`connections` + `api`/`mcp`), plugin-only, or hybrid (plugin + `api`, `mcp`, or both)
 - Exactly one of `command`, `package`, or `source` per plugin
 - `plugin.version` is required with `source` and invalid with `command` or `package`
 - `plugin.args` are only valid with `command`


### PR DESCRIPTION
The security model, config-file reference, and MCP binding docs still
described the old plugin model where plugins could not compose with
`api` surfaces and did not receive tokens directly. PR #344 added
hybrid plugin+api support and PR #360 changed the host to pass access
tokens directly to plugins in the gRPC request. This updates the trust
boundary table, plugin isolation properties, config-file validation
rules, and MCP composition rules to match.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>