### PR TITLE
Add Go doc comments to the Gestalt SDK

### DIFF
--- a/sdk/go/doc.go
+++ b/sdk/go/doc.go
@@ -1,0 +1,46 @@
+// Package gestalt provides a Go SDK for building Gestalt plugins.
+//
+// Gestalt plugins extend the platform with new integrations and automations.
+// There are two plugin types:
+//
+//   - A [Provider] exposes a set of named operations (e.g. "list_issues",
+//     "send_message") that callers can invoke. Providers are short-lived:
+//     they start, handle requests, and stop when the host is done.
+//
+//   - A [Runtime] is a long-lived sidecar that receives a set of available
+//     [Capability] values on startup and uses a [RuntimeHost] to invoke
+//     operations on other providers in response to external events.
+//
+// # Implementing a Provider
+//
+// Implement the [Provider] interface and call [ServeProvider]:
+//
+//	type MyProvider struct{}
+//
+//	func (p *MyProvider) Name() string            { return "my_provider" }
+//	func (p *MyProvider) DisplayName() string     { return "My Provider" }
+//	func (p *MyProvider) Description() string     { return "Does useful things." }
+//	func (p *MyProvider) ConnectionMode() gestalt.ConnectionMode {
+//		return gestalt.ConnectionModeNone
+//	}
+//
+//	func (p *MyProvider) ListOperations() []gestalt.Operation {
+//		return []gestalt.Operation{{
+//			Name:        "hello",
+//			Description: "Says hello",
+//			Method:      "GET",
+//		}}
+//	}
+//
+//	func (p *MyProvider) Execute(ctx context.Context, op string, params map[string]any, token string) (*gestalt.OperationResult, error) {
+//		return &gestalt.OperationResult{Status: 200, Body: `{"message":"hello"}`}, nil
+//	}
+//
+//	func main() {
+//		ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+//		defer cancel()
+//		if err := gestalt.ServeProvider(ctx, &MyProvider{}); err != nil {
+//			log.Fatal(err)
+//		}
+//	}
+package gestalt

--- a/sdk/go/plugin.go
+++ b/sdk/go/plugin.go
@@ -11,12 +11,20 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+// ServeProvider starts a gRPC server for the given [Provider] on the Unix
+// socket specified by the GESTALT_PLUGIN_SOCKET environment variable. It
+// blocks until ctx is cancelled, at which point it drains in-flight requests
+// and returns nil. This is the main entry point for provider plugins.
 func ServeProvider(ctx context.Context, provider Provider) error {
 	return servePlugin(ctx, func(srv *grpc.Server) {
 		proto.RegisterProviderPluginServer(srv, NewProviderServer(provider))
 	})
 }
 
+// ServeRuntime starts a gRPC server for the given [Runtime] on the Unix
+// socket specified by the GESTALT_PLUGIN_SOCKET environment variable. It
+// blocks until ctx is cancelled, at which point it drains in-flight requests
+// and returns nil. This is the main entry point for runtime plugins.
 func ServeRuntime(ctx context.Context, runtime Runtime) error {
 	return servePlugin(ctx, func(srv *grpc.Server) {
 		proto.RegisterRuntimePluginServer(srv, NewRuntimeServer(runtime))

--- a/sdk/go/provider_server.go
+++ b/sdk/go/provider_server.go
@@ -10,19 +10,30 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
+// ConfigSchemaProvider is an optional interface a [Provider] can implement
+// to declare a JSON Schema for the provider-level configuration it accepts.
+// The host uses this schema to validate configuration before starting the plugin.
 type ConfigSchemaProvider interface {
 	ConfigSchemaJSON() string
 }
 
+// ProtocolVersionProvider is an optional interface a [Provider] can implement
+// to advertise the range of protocol versions it supports. If not implemented,
+// the server reports the current protocol version as both min and max.
 type ProtocolVersionProvider interface {
 	ProtocolVersionRange() (min, max int32)
 }
 
+// ProviderServer adapts a [Provider] implementation to the gRPC
+// ProviderPlugin service. Most plugin authors should use [ServeProvider]
+// instead of constructing this directly.
 type ProviderServer struct {
 	proto.UnimplementedProviderPluginServer
 	provider Provider
 }
 
+// NewProviderServer wraps a [Provider] in a [ProviderServer] ready to be
+// registered on a gRPC server.
 func NewProviderServer(provider Provider) *ProviderServer {
 	return &ProviderServer{provider: provider}
 }

--- a/sdk/go/runtime_server.go
+++ b/sdk/go/runtime_server.go
@@ -14,6 +14,9 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+// RuntimeServer adapts a [Runtime] implementation to the gRPC
+// RuntimePlugin service. Most plugin authors should use [ServeRuntime]
+// instead of constructing this directly.
 type RuntimeServer struct {
 	proto.UnimplementedRuntimePluginServer
 	runtime Runtime
@@ -21,6 +24,8 @@ type RuntimeServer struct {
 	host    *runtimeHostClient
 }
 
+// NewRuntimeServer wraps a [Runtime] in a [RuntimeServer] ready to be
+// registered on a gRPC server.
 func NewRuntimeServer(runtime Runtime) *RuntimeServer {
 	return &RuntimeServer{runtime: runtime}
 }

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -4,15 +4,29 @@ import (
 	"context"
 )
 
+// ConnectionMode controls how a provider authenticates with its upstream
+// service. The mode is declared as provider metadata and tells the host
+// whether a user-supplied OAuth token, a service-level identity, both,
+// or neither is required.
 type ConnectionMode string
 
 const (
-	ConnectionModeNone     ConnectionMode = "none"
-	ConnectionModeUser     ConnectionMode = "user"
+	// ConnectionModeNone means the provider needs no credentials.
+	ConnectionModeNone ConnectionMode = "none"
+	// ConnectionModeUser requires per-user OAuth tokens supplied by the host.
+	ConnectionModeUser ConnectionMode = "user"
+	// ConnectionModeIdentity uses a shared service identity configured on the host.
 	ConnectionModeIdentity ConnectionMode = "identity"
-	ConnectionModeEither   ConnectionMode = "either"
+	// ConnectionModeEither accepts either a user token or a service identity.
+	ConnectionModeEither ConnectionMode = "either"
 )
 
+// Provider is the core interface that every provider plugin must implement.
+// It declares metadata about the provider, lists the operations it supports,
+// and executes individual operations when called by the host.
+//
+// The token argument to Execute is a user OAuth token supplied by the host
+// when [ConnectionMode] is [ConnectionModeUser] or [ConnectionModeEither].
 type Provider interface {
 	Name() string
 	DisplayName() string
@@ -22,10 +36,15 @@ type Provider interface {
 	Execute(ctx context.Context, operation string, params map[string]any, token string) (*OperationResult, error)
 }
 
+// ProviderStarter is an optional interface that a [Provider] can implement
+// to receive one-time initialization when the host starts the plugin. The
+// config map contains provider-level configuration set in the plugin manifest.
 type ProviderStarter interface {
 	Start(ctx context.Context, name string, config map[string]any) error
 }
 
+// Operation describes a single invocable action exposed by a [Provider].
+// Method is an HTTP-like verb (GET, POST, etc.) used for categorization.
 type Operation struct {
 	Name        string
 	Description string
@@ -33,6 +52,7 @@ type Operation struct {
 	Parameters  []Parameter
 }
 
+// Parameter describes a single input to an [Operation].
 type Parameter struct {
 	Name        string
 	Type        string
@@ -41,11 +61,16 @@ type Parameter struct {
 	Default     any
 }
 
+// OperationResult holds the response from a [Provider.Execute] call.
+// Status is an HTTP-like status code; Body is the response payload, typically JSON.
 type OperationResult struct {
 	Status int
 	Body   string
 }
 
+// ConnectionParamDef describes a single credential or configuration value that
+// a provider needs from the host's connection store. From and Field control
+// where the value is sourced (e.g. from an OAuth token field).
 type ConnectionParamDef struct {
 	Required    bool
 	Description string
@@ -54,63 +79,96 @@ type ConnectionParamDef struct {
 	Field       string
 }
 
+// ConnectionParamProvider is an optional interface a [Provider] can implement
+// to declare the connection parameters it needs. The host resolves these
+// parameters and delivers them via [WithConnectionParams] on each Execute call.
 type ConnectionParamProvider interface {
 	ConnectionParamDefs() map[string]ConnectionParamDef
 }
 
+// ManualAuthProvider is an optional interface a [Provider] can implement to
+// indicate it accepts manually-entered credentials instead of OAuth.
 type ManualAuthProvider interface {
 	SupportsManualAuth() bool
 }
 
+// AuthTypeLister is an optional interface a [Provider] can implement to
+// advertise the authentication methods it supports (e.g. "oauth", "manual").
 type AuthTypeLister interface {
 	AuthTypes() []string
 }
 
 type connectionParamsKey struct{}
 
+// WithConnectionParams returns a child context carrying the given connection
+// parameters. The host calls this before invoking [Provider.Execute] so that
+// providers implementing [ConnectionParamProvider] can retrieve their
+// resolved credentials via [ConnectionParams].
 func WithConnectionParams(ctx context.Context, params map[string]string) context.Context {
 	return context.WithValue(ctx, connectionParamsKey{}, params)
 }
 
+// ConnectionParams extracts the connection parameters stored by
+// [WithConnectionParams]. Returns nil if none are present.
 func ConnectionParams(ctx context.Context) map[string]string {
 	params, _ := ctx.Value(connectionParamsKey{}).(map[string]string)
 	return params
 }
 
+// Runtime is the interface that every runtime plugin must implement. Unlike
+// providers, runtimes are long-lived processes that react to external events
+// and call back into the platform via a [RuntimeHost].
+//
+// Start is called once with the plugin's configuration, the set of available
+// capabilities, and a host handle for making callbacks. Stop signals the
+// runtime to shut down gracefully.
 type Runtime interface {
 	Start(ctx context.Context, name string, config map[string]any, capabilities []Capability, host RuntimeHost) error
 	Stop(ctx context.Context) error
 }
 
+// RuntimeHost gives a [Runtime] the ability to call back into the Gestalt
+// platform. Invoke executes an operation on another provider instance, and
+// ListCapabilities returns the currently available operations across all
+// connected providers.
 type RuntimeHost interface {
 	Invoke(ctx context.Context, principal Principal, provider, instance, operation string, params map[string]any) (*OperationResult, error)
 	ListCapabilities(ctx context.Context) ([]Capability, error)
 }
 
+// Principal identifies the user on whose behalf a runtime invokes an
+// operation. Source indicates how the user was authenticated.
 type Principal struct {
 	UserID   string
 	Identity *UserIdentity
 	Source   PrincipalSource
 }
 
+// UserIdentity holds display information about a user.
 type UserIdentity struct {
 	Email       string
 	DisplayName string
 	AvatarURL   string
 }
 
+// PrincipalSource indicates how a [Principal] was authenticated.
 type PrincipalSource string
 
 const (
-	PrincipalSourceSession  PrincipalSource = "session"
+	// PrincipalSourceSession identifies a user authenticated via a browser session.
+	PrincipalSourceSession PrincipalSource = "session"
+	// PrincipalSourceAPIToken identifies a user authenticated via an API token.
 	PrincipalSourceAPIToken PrincipalSource = "api_token"
-	PrincipalSourceEnv      PrincipalSource = "env"
+	// PrincipalSourceEnv identifies a system-level principal from the environment.
+	PrincipalSourceEnv PrincipalSource = "env"
 )
 
+// Capability describes a single operation available through the platform,
+// including which provider exposes it. Runtimes receive these on startup and
+// can refresh them via [RuntimeHost.ListCapabilities].
 type Capability struct {
 	Provider    string
 	Operation   string
 	Description string
 	Parameters  []Parameter
 }
-


### PR DESCRIPTION
The sdk/go package had no doc comments on any exported symbol. This adds
a package overview in doc.go and documents all exported types, interfaces,
functions, and constants following Go doc conventions. The package doc
explains the two plugin types (Provider and Runtime) and includes a
runnable example showing how to implement and serve a Provider.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>