### PR TITLE
Support inline links in credential field descriptions

### DIFF
--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -444,7 +444,7 @@ connections:
 | --- | --- |
 | `credentials[].name` | Internal identifier for the field. Must be unique, lowercase with underscores. |
 | `credentials[].label` | Display label shown in the UI. Falls back to `name` if omitted. |
-| `credentials[].description` | Hint text shown below the label. |
+| `credentials[].description` | Hint text shown below the label. Supports inline links via `[text](url)`. |
 | `credentials[].help_url` | Link displayed next to the label for where to find the credential. |
 | `auth_mapping.headers` | Maps credential field names to HTTP headers. Required when multiple credentials are declared. |
 

--- a/web/e2e/integrations.spec.ts
+++ b/web/e2e/integrations.spec.ts
@@ -10,6 +10,11 @@ const MANUAL_INTEGRATION: Integration = {
   credential_fields: [{ name: "token", label: "API Token" }],
 };
 
+const MANUAL_WITH_LINKED_DESC: Integration = {
+  name: "linked-svc", display_name: "Linked Service", auth_types: ["manual"],
+  credential_fields: [{ name: "api_key", label: "API Key", description: "Find yours in [Account Settings](https://example.com/settings)" }],
+};
+
 const sampleIntegrations: Integration[] = [
   OAUTH_INTEGRATION,
   MANUAL_INTEGRATION,
@@ -287,5 +292,22 @@ test.describe("Integrations", () => {
     await dialog.getByLabel("Connection name").fill("second");
     await dialog.getByRole("button", { name: "Continue" }).click();
     await expect(dialog.getByLabel(/API token/i)).toBeVisible();
+  });
+
+  test("credential field description renders inline links", async ({ authenticatedPage }) => {
+    const page = authenticatedPage;
+    await mockIntegrations(page, [MANUAL_WITH_LINKED_DESC]);
+    await mockTokens(page, []);
+
+    await page.goto("/integrations");
+    await page.getByRole("button", { name: "Linked Service settings" }).click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByRole("button", { name: "Connect" }).click();
+
+    const link = dialog.getByRole("link", { name: "Account Settings" });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", "https://example.com/settings");
+    await expect(link).toHaveAttribute("target", "_blank");
+    await expect(dialog.getByText("Find yours in")).toBeVisible();
   });
 });

--- a/web/src/components/IntegrationSettingsModal.tsx
+++ b/web/src/components/IntegrationSettingsModal.tsx
@@ -346,6 +346,17 @@ export default function IntegrationSettingsModal({
   );
 }
 
+const LINK_RE = /(\[[^\]]+\]\(https?:\/\/[^)]+\))/;
+const LINK_MATCH_RE = /^\[([^\]]+)\]\((https?:\/\/[^)]+)\)$/;
+
+function renderLinkedText(text: string): (string | JSX.Element)[] {
+  return text.split(LINK_RE).map((seg, i) => {
+    const m = seg.match(LINK_MATCH_RE);
+    if (!m) return seg;
+    return <a key={i} href={m[2]} target="_blank" rel="noopener noreferrer" className="text-timber-500 hover:underline">{m[1]}</a>;
+  });
+}
+
 function TokenForm({
   integrationName,
   headingId,
@@ -414,7 +425,7 @@ function TokenForm({
             )}
           </label>
           {field.description && (
-            <p className="mt-0.5 text-xs text-stone-400">{field.description}</p>
+            <p className="mt-0.5 text-xs text-stone-400">{renderLinkedText(field.description)}</p>
           )}
           <input
             id={`cred_${field.name}-${integrationName}`}


### PR DESCRIPTION
Credential field descriptions now render markdown-style `[text](url)`
as clickable links. This lets integration authors embed contextual
links directly in help text, for example pointing users to the exact
settings page where they can find a credential.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>