### PR TITLE
Add `response_mapping` to declarative API integrations

### DIFF
--- a/server/core/integration/base.go
+++ b/server/core/integration/base.go
@@ -108,10 +108,11 @@ type Base struct {
 	HTTPClient         *http.Client
 	Pagination         map[string]apiexec.PaginationConfig
 
-	TokenParser    func(token string) (authHeader string, extraHeaders map[string]string, err error)
-	CheckResponse  apiexec.ResponseChecker
-	ExecuteFunc    func(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error)
-	EgressResolver *egress.Resolver
+	TokenParser     func(token string) (authHeader string, extraHeaders map[string]string, err error)
+	CheckResponse   apiexec.ResponseChecker
+	ExecuteFunc     func(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error)
+	EgressResolver  *egress.Resolver
+	ResponseMapping *ResponseMappingConfig
 
 	ConnectionDefs      map[string]core.ConnectionParamDef
 	DiscoveryDef        *core.DiscoveryConfig

--- a/server/core/integration/egress_adapter.go
+++ b/server/core/integration/egress_adapter.go
@@ -54,7 +54,16 @@ func (b *Base) executeREST(ctx context.Context, operation string, params map[str
 		return apiexec.DoPaginatedWithExecutor(ctx, b.httpClient(), req, pgn, executeEgressHTTP)
 	}
 
-	return executeEgressHTTP(ctx, b.httpClient(), req)
+	result, err := executeEgressHTTP(ctx, b.httpClient(), req)
+	if err != nil {
+		return nil, err
+	}
+
+	if b.ResponseMapping != nil {
+		result = applyResponseMapping(result, b.ResponseMapping)
+	}
+
+	return result, nil
 }
 
 func (b *Base) resolveEgress(ctx context.Context, operation string, req apiexec.Request) (egress.Resolution, error) {

--- a/server/core/integration/response_mapping.go
+++ b/server/core/integration/response_mapping.go
@@ -1,0 +1,64 @@
+package integration
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/apiexec"
+)
+
+type ResponseMappingConfig struct {
+	DataPath              string
+	PaginationHasMorePath string
+	PaginationCursorPath  string
+}
+
+func applyResponseMapping(result *core.OperationResult, cfg *ResponseMappingConfig) *core.OperationResult {
+	if result == nil || cfg == nil || result.Status >= http.StatusBadRequest {
+		return result
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &raw); err != nil {
+		return result
+	}
+
+	output := make(map[string]any)
+
+	if cfg.DataPath != "" {
+		if data, ok := apiexec.ExtractJSONPath(raw, cfg.DataPath); ok {
+			output["data"] = data
+		} else {
+			return result
+		}
+	}
+
+	if cfg.PaginationHasMorePath != "" || cfg.PaginationCursorPath != "" {
+		pgn := make(map[string]any)
+		if cfg.PaginationHasMorePath != "" {
+			if v, ok := apiexec.ExtractJSONPath(raw, cfg.PaginationHasMorePath); ok {
+				pgn["has_more"] = v
+			}
+		}
+		if cfg.PaginationCursorPath != "" {
+			if v, ok := apiexec.ExtractJSONPath(raw, cfg.PaginationCursorPath); ok {
+				pgn["cursor"] = v
+			}
+		}
+		if len(pgn) > 0 {
+			output["pagination"] = pgn
+		}
+	}
+
+	body, err := json.Marshal(output)
+	if err != nil {
+		return result
+	}
+
+	return &core.OperationResult{
+		Status:  result.Status,
+		Headers: result.Headers,
+		Body:    string(body),
+	}
+}

--- a/server/core/integration/response_mapping_test.go
+++ b/server/core/integration/response_mapping_test.go
@@ -1,0 +1,171 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestResponseMappingExtractsDataAndPagination(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success":           true,
+			"results":           []any{map[string]any{"id": "1", "name": "Alice"}, map[string]any{"id": "2", "name": "Bob"}},
+			"moreDataAvailable": true,
+			"nextCursor":        "cursor-abc",
+		})
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL,
+		Endpoints: map[string]Endpoint{
+			"list": {Method: http.MethodPost, Path: "/list"},
+		},
+		ResponseMapping: &ResponseMappingConfig{
+			DataPath:              "results",
+			PaginationHasMorePath: "moreDataAvailable",
+			PaginationCursorPath:  "nextCursor",
+		},
+	}
+
+	result, err := b.Execute(context.Background(), "list", nil, "test-token")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &parsed); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	data, ok := parsed["data"].([]any)
+	if !ok {
+		t.Fatalf("data is not array: %v", parsed["data"])
+	}
+	if len(data) != 2 {
+		t.Fatalf("data length = %d, want 2", len(data))
+	}
+	if data[0].(map[string]any)["name"] != "Alice" {
+		t.Fatalf("first item name = %v, want Alice", data[0])
+	}
+
+	pgn := parsed["pagination"].(map[string]any)
+	if pgn["has_more"] != true {
+		t.Fatalf("has_more = %v, want true", pgn["has_more"])
+	}
+	if pgn["cursor"] != "cursor-abc" {
+		t.Fatalf("cursor = %v, want cursor-abc", pgn["cursor"])
+	}
+
+	if _, exists := parsed["success"]; exists {
+		t.Fatal("original envelope fields should be stripped")
+	}
+}
+
+func TestResponseMappingNestedDataPath(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"response": map[string]any{
+				"items": []any{map[string]any{"id": "1"}},
+			},
+		})
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL,
+		Endpoints: map[string]Endpoint{
+			"list": {Method: http.MethodGet, Path: "/list"},
+		},
+		ResponseMapping: &ResponseMappingConfig{DataPath: "response.items"},
+	}
+
+	result, err := b.Execute(context.Background(), "list", nil, "tok")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &parsed); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	data := parsed["data"].([]any)
+	if len(data) != 1 {
+		t.Fatalf("data length = %d, want 1", len(data))
+	}
+}
+
+func TestResponseMappingPassesThroughErrors(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"bad request"}`))
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL,
+		Endpoints: map[string]Endpoint{
+			"op": {Method: http.MethodGet, Path: "/op"},
+		},
+		CheckResponse: func(status int, body []byte) error {
+			return nil
+		},
+		ResponseMapping: &ResponseMappingConfig{DataPath: "results"},
+	}
+
+	result, err := b.Execute(context.Background(), "op", nil, "tok")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.Status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", result.Status)
+	}
+	if result.Body != `{"error":"bad request"}` {
+		t.Fatalf("error body should pass through unchanged, got %s", result.Body)
+	}
+}
+
+func TestResponseMappingWithoutConfig(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"raw":"passthrough"}`))
+	}))
+	t.Cleanup(func() { srv.Close() })
+
+	b := &Base{
+		Auth:    mockAuth{},
+		BaseURL: srv.URL,
+		Endpoints: map[string]Endpoint{
+			"op": {Method: http.MethodGet, Path: "/op"},
+		},
+	}
+
+	result, err := b.Execute(context.Background(), "op", nil, "tok")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &parsed); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if parsed["raw"] != "passthrough" {
+		t.Fatalf("without config, response should pass through unchanged")
+	}
+}

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -247,6 +247,17 @@ type APIDef struct {
 	URL               string                        `yaml:"url"`
 	Connection        string                        `yaml:"connection"`
 	AllowedOperations map[string]*OperationOverride `yaml:"allowed_operations"`
+	ResponseMapping   *ResponseMappingDef           `yaml:"response_mapping"`
+}
+
+type ResponseMappingDef struct {
+	DataPath   string                `yaml:"data_path"`
+	Pagination *PaginationMappingDef `yaml:"pagination"`
+}
+
+type PaginationMappingDef struct {
+	HasMorePath string `yaml:"has_more_path"`
+	CursorPath  string `yaml:"cursor_path"`
 }
 
 type MCPDef struct {

--- a/server/internal/provider/build.go
+++ b/server/internal/provider/build.go
@@ -167,6 +167,17 @@ func Build(def *Definition, conn config.ConnectionDef, allowedOperations map[str
 
 	base.ManualAuthEnabled = def.ManualAuth
 
+	if def.ResponseMapping != nil {
+		rm := &coreintegration.ResponseMappingConfig{
+			DataPath: def.ResponseMapping.DataPath,
+		}
+		if def.ResponseMapping.Pagination != nil {
+			rm.PaginationHasMorePath = def.ResponseMapping.Pagination.HasMorePath
+			rm.PaginationCursorPath = def.ResponseMapping.Pagination.CursorPath
+		}
+		base.ResponseMapping = rm
+	}
+
 	if len(def.CredentialFields) > 0 {
 		base.CredentialFieldDefs = make([]core.CredentialFieldDef, len(def.CredentialFields))
 		for i, cf := range def.CredentialFields {
@@ -270,6 +281,21 @@ func ReadIconFile(path string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(data)), nil
+}
+
+func ApplyResponseMapping(def *Definition, api config.APIDef) {
+	if api.ResponseMapping != nil {
+		rm := &ResponseMappingDef{
+			DataPath: api.ResponseMapping.DataPath,
+		}
+		if api.ResponseMapping.Pagination != nil {
+			rm.Pagination = &PaginationMappingDef{
+				HasMorePath: api.ResponseMapping.Pagination.HasMorePath,
+				CursorPath:  api.ResponseMapping.Pagination.CursorPath,
+			}
+		}
+		def.ResponseMapping = rm
+	}
 }
 
 // ApplyConnectionAuth merges connection auth overrides into the Definition.

--- a/server/internal/provider/compiler/compiler.go
+++ b/server/internal/provider/compiler/compiler.go
@@ -38,6 +38,7 @@ func BuildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 		return nil, err
 	}
 	provider.ApplyDisplayOverrides(def, intg)
+	provider.ApplyResponseMapping(def, api)
 	return provider.Build(def, conn, allowedOps, opts...)
 }
 

--- a/server/internal/provider/definition.go
+++ b/server/internal/provider/definition.go
@@ -26,6 +26,7 @@ type Definition struct {
 	CredentialFields []CredentialFieldDef `yaml:"credential_fields" json:"credential_fields,omitempty"`
 
 	PostConnectDiscovery *PostConnectDiscoveryDef `yaml:"post_connect_discovery" json:"post_connect_discovery,omitempty"`
+	ResponseMapping      *ResponseMappingDef      `yaml:"response_mapping" json:"response_mapping,omitempty"`
 
 	Connection map[string]ConnectionParamDef `yaml:"connection" json:"connection"`
 	Operations map[string]OperationDef       `yaml:"operations" json:"operations"`
@@ -110,6 +111,16 @@ type CredentialFieldDef struct {
 	Label       string `yaml:"label" json:"label,omitempty"`
 	Description string `yaml:"description" json:"description,omitempty"`
 	HelpURL     string `yaml:"help_url" json:"help_url,omitempty"`
+}
+
+type ResponseMappingDef struct {
+	DataPath   string                `yaml:"data_path" json:"data_path"`
+	Pagination *PaginationMappingDef `yaml:"pagination" json:"pagination,omitempty"`
+}
+
+type PaginationMappingDef struct {
+	HasMorePath string `yaml:"has_more_path" json:"has_more_path"`
+	CursorPath  string `yaml:"cursor_path" json:"cursor_path"`
 }
 
 type ParameterDef struct {


### PR DESCRIPTION
Declarative integrations can now normalize upstream JSON responses into
a standard `{data, pagination}` envelope via a `response_mapping` config
on the `api` surface. This lets APIs with non-standard response shapes
(like Ashby's `{success, results, moreDataAvailable, nextCursor}`) be
consumed declaratively without writing a Go plugin just for response
transformation.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>