### PR TITLE
Add light/dark/system mode toggle to web UI

### DIFF
--- a/web/src/app/auth/callback/page.tsx
+++ b/web/src/app/auth/callback/page.tsx
@@ -60,7 +60,7 @@ function CallbackHandler() {
       <div className="flex min-h-screen items-center justify-center">
         <div className="w-full max-w-sm rounded-lg border border-border bg-surface p-8 shadow-warm text-center">
           <p className="text-sm text-ember-500">{error}</p>
-          <a href="/login" className="mt-4 inline-block text-sm text-timber-600 hover:underline">
+          <a href="/login" className="mt-4 inline-block text-sm text-timber-600 hover:underline dark:text-timber-400">
             Back to login
           </a>
         </div>
@@ -70,14 +70,14 @@ function CallbackHandler() {
 
   return (
     <div className="flex min-h-screen items-center justify-center">
-      <p className="text-sm text-stone-400">Completing login...</p>
+      <p className="text-sm text-stone-400 dark:text-stone-500">Completing login...</p>
     </div>
   );
 }
 
 export default function AuthCallbackPage() {
   return (
-    <Suspense fallback={<div className="flex min-h-screen items-center justify-center"><p className="text-sm text-stone-400">Loading...</p></div>}>
+    <Suspense fallback={<div className="flex min-h-screen items-center justify-center"><p className="text-sm text-stone-400 dark:text-stone-500">Loading...</p></div>}>
       <CallbackHandler />
     </Suspense>
   );

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -12,6 +12,14 @@
     --radius: 0.5rem;
   }
 
+  .dark {
+    --background: 30 15% 7%;
+    --surface: 30 12% 10%;
+    --surface-raised: 30 10% 14%;
+    --border: 30 8% 22%;
+    --foreground: 36 20% 88%;
+  }
+
   html {
     scroll-behavior: smooth;
   }

--- a/web/src/app/integrations/page.tsx
+++ b/web/src/app/integrations/page.tsx
@@ -39,11 +39,11 @@ function IntegrationsContent() {
       <Nav />
       <main className="mx-auto max-w-5xl px-6 py-8">
         {toast && (
-          <div className="mb-6 flex items-center justify-between rounded-lg border border-grove-200 bg-grove-50 px-4 py-3 text-sm text-grove-700">
+          <div className="mb-6 flex items-center justify-between rounded-lg border border-grove-200 bg-grove-50 px-4 py-3 text-sm text-grove-700 dark:border-grove-600 dark:bg-grove-700/20 dark:text-grove-200">
             <span>{toast}</span>
             <button
               onClick={() => setToast(null)}
-              className="ml-4 text-grove-400 hover:text-grove-600"
+              className="ml-4 text-grove-400 hover:text-grove-600 dark:text-grove-500 dark:hover:text-grove-200"
               aria-label="Dismiss"
             >
               &times;
@@ -51,10 +51,10 @@ function IntegrationsContent() {
           </div>
         )}
 
-        <h1 className="text-2xl font-heading font-bold text-stone-900">
+        <h1 className="text-2xl font-heading font-bold text-stone-900 dark:text-stone-100">
           Integrations
         </h1>
-        <p className="mt-1 text-sm text-stone-500">
+        <p className="mt-1 text-sm text-stone-500 dark:text-stone-400">
           Browse and connect third-party services.
         </p>
 
@@ -95,7 +95,7 @@ export default function IntegrationsPage() {
           <div className="min-h-screen">
             <Nav />
             <main className="mx-auto max-w-5xl px-6 py-8">
-              <p className="text-sm text-stone-400">Loading...</p>
+              <p className="text-sm text-stone-400 dark:text-stone-500">Loading...</p>
             </main>
           </div>
         }

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -25,13 +25,38 @@ export const metadata: Metadata = {
   description: "Integration management for Gestalt",
 };
 
+const themeScript = `
+  (function() {
+    const stored = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+    if (stored === 'dark' || (stored !== 'light' && prefersDark)) {
+      document.documentElement.classList.add('dark');
+    }
+
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+      const current = localStorage.getItem('theme');
+      if (!current || current === 'system') {
+        if (e.matches) {
+          document.documentElement.classList.add('dark');
+        } else {
+          document.documentElement.classList.remove('dark');
+        }
+      }
+    });
+  })();
+`;
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+      </head>
       <body className={`${bitter.variable} ${ibmPlexSans.variable} ${ibmPlexMono.variable} font-sans antialiased`}>
         {children}
       </body>

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -48,17 +48,17 @@ export default function LoginPage() {
   return (
     <div className="flex min-h-screen items-center justify-center">
       <div className="w-full max-w-sm rounded-lg border border-border bg-surface p-8 shadow-warm">
-        <h1 className="text-center text-2xl font-heading font-bold text-timber-800">
+        <h1 className="text-center text-2xl font-heading font-bold text-timber-800 dark:text-timber-200">
           Gestalt
         </h1>
-        <p className="mt-2 text-center text-sm text-stone-500">
+        <p className="mt-2 text-center text-sm text-stone-500 dark:text-stone-400">
           Sign in to manage your integrations.
         </p>
-        <p className="mt-2 text-center text-sm text-stone-500">
+        <p className="mt-2 text-center text-sm text-stone-500 dark:text-stone-400">
           Or read the{" "}
           <a
             href="/docs"
-            className="font-medium text-timber-600 hover:text-timber-700"
+            className="font-medium text-timber-600 hover:text-timber-700 dark:text-timber-400 dark:hover:text-timber-300"
           >
             documentation
           </a>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -35,10 +35,10 @@ export default function DashboardPage() {
       <div className="min-h-screen">
         <Nav />
         <main className="mx-auto max-w-5xl px-6 py-8">
-          <h1 className="text-2xl font-heading font-bold text-stone-900">
+          <h1 className="text-2xl font-heading font-bold text-stone-900 dark:text-stone-100">
             Dashboard
           </h1>
-          <p className="mt-1 text-sm text-stone-500">
+          <p className="mt-1 text-sm text-stone-500 dark:text-stone-400">
             Your Gestalt overview at a glance.
           </p>
 
@@ -49,27 +49,27 @@ export default function DashboardPage() {
           <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
             <Link
               href="/integrations"
-              className="rounded-lg border border-border bg-surface p-6 shadow-warm transition-all hover:shadow-md hover:border-timber-300"
+              className="rounded-lg border border-border bg-surface p-6 shadow-warm transition-all hover:shadow-md hover:border-timber-300 dark:hover:border-timber-600"
             >
-              <p className="text-sm font-medium text-stone-500">
+              <p className="text-sm font-medium text-stone-500 dark:text-stone-400">
                 Integrations
               </p>
-              <p className="mt-2 text-3xl font-heading font-bold text-stone-900">
+              <p className="mt-2 text-3xl font-heading font-bold text-stone-900 dark:text-stone-100">
                 {data.integrations ?? "--"}
               </p>
-              <p className="mt-1 text-sm font-medium text-timber-600">
+              <p className="mt-1 text-sm font-medium text-timber-600 dark:text-timber-400">
                 Manage integrations &rarr;
               </p>
             </Link>
             <Link
               href="/tokens"
-              className="rounded-lg border border-border bg-surface p-6 shadow-warm transition-all hover:shadow-md hover:border-timber-300"
+              className="rounded-lg border border-border bg-surface p-6 shadow-warm transition-all hover:shadow-md hover:border-timber-300 dark:hover:border-timber-600"
             >
-              <p className="text-sm font-medium text-stone-500">API Tokens</p>
-              <p className="mt-2 text-3xl font-heading font-bold text-stone-900">
+              <p className="text-sm font-medium text-stone-500 dark:text-stone-400">API Tokens</p>
+              <p className="mt-2 text-3xl font-heading font-bold text-stone-900 dark:text-stone-100">
                 {data.tokens ?? "--"}
               </p>
-              <p className="mt-1 text-sm font-medium text-timber-600">
+              <p className="mt-1 text-sm font-medium text-timber-600 dark:text-timber-400">
                 Manage tokens &rarr;
               </p>
             </Link>

--- a/web/src/app/tokens/page.tsx
+++ b/web/src/app/tokens/page.tsx
@@ -29,10 +29,10 @@ export default function TokensPage() {
       <div className="min-h-screen">
         <Nav />
         <main className="mx-auto max-w-5xl px-6 py-8">
-          <h1 className="text-2xl font-heading font-bold text-stone-900">
+          <h1 className="text-2xl font-heading font-bold text-stone-900 dark:text-stone-100">
             API Tokens
           </h1>
-          <p className="mt-1 text-sm text-stone-500">
+          <p className="mt-1 text-sm text-stone-500 dark:text-stone-400">
             Manage tokens for programmatic access to the Gestalt API.
           </p>
 
@@ -41,7 +41,7 @@ export default function TokensPage() {
           {error && <p className="mt-4 text-sm text-ember-500">{error}</p>}
 
           {loading ? (
-            <p className="mt-8 text-sm text-stone-400">Loading...</p>
+            <p className="mt-8 text-sm text-stone-400 dark:text-stone-500">Loading...</p>
           ) : !error ? (
             <div className="mt-6">
               <TokenTable tokens={tokens} onRevoked={loadTokens} />

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -3,9 +3,9 @@ import { ButtonHTMLAttributes } from "react";
 type Variant = "primary" | "secondary" | "danger";
 
 const variantStyles: Record<Variant, string> = {
-  primary: "bg-timber-600 text-white hover:bg-timber-700",
-  secondary: "bg-stone-200 text-stone-800 hover:bg-stone-300",
-  danger: "bg-ember-600 text-white hover:bg-ember-700",
+  primary: "bg-timber-600 text-white hover:bg-timber-700 dark:bg-timber-500 dark:hover:bg-timber-400",
+  secondary: "bg-stone-200 text-stone-800 hover:bg-stone-300 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600",
+  danger: "bg-ember-600 text-white hover:bg-ember-700 dark:bg-ember-500 dark:hover:bg-ember-600",
 };
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {

--- a/web/src/components/IntegrationCard.tsx
+++ b/web/src/components/IntegrationCard.tsx
@@ -180,7 +180,7 @@ export default function IntegrationCard({
       <div key={name} className="mt-2">
         <label
           htmlFor={`cp_${name}-${integration.name}`}
-          className="block text-sm font-medium text-stone-700"
+          className="block text-sm font-medium text-stone-700 dark:text-stone-300"
         >
           {def.description || name}
         </label>
@@ -191,7 +191,7 @@ export default function IntegrationCard({
           required={def.required}
           defaultValue={def.default}
           placeholder={name}
-          className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
+          className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25 dark:text-stone-100 dark:placeholder:text-stone-500 dark:focus:border-timber-500 dark:focus:ring-timber-500/25"
         />
       </div>
     ));
@@ -201,7 +201,7 @@ export default function IntegrationCard({
     <div className="rounded-lg border border-border bg-surface p-5 shadow-warm">
       <div className="flex items-start justify-between">
         <div className="flex items-start gap-3">
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-stone-100 text-stone-500 [&>svg]:h-5 [&>svg]:w-5">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-stone-100 text-stone-500 [&>svg]:h-5 [&>svg]:w-5 dark:bg-stone-800 dark:text-stone-400">
             {safeIconSVG ? (
               <div
                 dangerouslySetInnerHTML={{ __html: safeIconSVG }}
@@ -212,11 +212,11 @@ export default function IntegrationCard({
             )}
           </div>
           <div>
-            <h3 className="text-base font-heading font-semibold text-stone-900">
+            <h3 className="text-base font-heading font-semibold text-stone-900 dark:text-stone-100">
               {integration.display_name || integration.name}
             </h3>
             {integration.description && (
-              <p className="mt-1 line-clamp-2 text-sm text-stone-500">
+              <p className="mt-1 line-clamp-2 text-sm text-stone-500 dark:text-stone-400">
                 {integration.description}
               </p>
             )}
@@ -228,7 +228,7 @@ export default function IntegrationCard({
           )}
           <button
             onClick={() => setSettingsOpen(true)}
-            className="flex h-8 w-8 items-center justify-center rounded text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-600"
+            className="flex h-8 w-8 items-center justify-center rounded text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-600 dark:text-stone-500 dark:hover:bg-stone-800 dark:hover:text-stone-300"
             aria-label={`${integration.display_name || integration.name} settings`}
           >
             <GearIcon className="h-4 w-4" />

--- a/web/src/components/IntegrationSettingsModal.tsx
+++ b/web/src/components/IntegrationSettingsModal.tsx
@@ -212,11 +212,11 @@ export default function IntegrationSettingsModal({
           <>
             <h2
               id={headingId}
-              className="text-lg font-heading font-semibold text-stone-900"
+              className="text-lg font-heading font-semibold text-stone-900 dark:text-stone-100"
             >
               Disconnect {displayName}?
             </h2>
-            <p className="mt-2 text-sm text-stone-500">
+            <p className="mt-2 text-sm text-stone-500 dark:text-stone-400">
               This will remove your {displayName} integration. You can reconnect
               at any time.
             </p>
@@ -244,14 +244,14 @@ export default function IntegrationSettingsModal({
           <form onSubmit={handleInstanceSubmit}>
             <h2
               id={headingId}
-              className="text-lg font-heading font-semibold text-stone-900"
+              className="text-lg font-heading font-semibold text-stone-900 dark:text-stone-100"
             >
               Add Connection
             </h2>
             {error && <p className="mt-3 text-sm text-ember-500">{error}</p>}
             <label
               htmlFor={`instance-name-${integration.name}`}
-              className="mt-4 block text-sm font-medium text-stone-700"
+              className="mt-4 block text-sm font-medium text-stone-700 dark:text-stone-300"
             >
               Connection name
             </label>
@@ -262,7 +262,7 @@ export default function IntegrationSettingsModal({
               required
               placeholder="e.g. my-store, acme-workspace"
               autoFocus
-              className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
+              className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25 dark:text-stone-100 dark:placeholder:text-stone-500 dark:focus:border-timber-500 dark:focus:ring-timber-500/25"
             />
             <div className="mt-6 flex gap-3">
               <Button
@@ -294,13 +294,13 @@ export default function IntegrationSettingsModal({
             <div className="flex items-start justify-between">
               <h2
                 id={headingId}
-                className="text-lg font-heading font-semibold text-stone-900"
+                className="text-lg font-heading font-semibold text-stone-900 dark:text-stone-100"
               >
                 {displayName}
               </h2>
               <button
                 onClick={closeDialog}
-                className="rounded p-1 text-stone-400 hover:text-stone-600 transition-colors"
+                className="rounded p-1 text-stone-400 hover:text-stone-600 transition-colors dark:text-stone-500 dark:hover:text-stone-300"
                 aria-label="Close"
               >
                 <CloseIcon className="h-4 w-4" />
@@ -315,7 +315,7 @@ export default function IntegrationSettingsModal({
                       <div key={inst.name} className="flex items-center justify-between rounded border border-border px-3 py-2">
                         <div className="flex items-center gap-2">
                           <CheckCircleIcon className="h-4 w-4 text-grove-500" />
-                          <span className="text-sm text-stone-700">{inst.name}</span>
+                          <span className="text-sm text-stone-700 dark:text-stone-300">{inst.name}</span>
                         </div>
                         <button
                           onClick={() => { setDisconnectInstance(inst.name); setView("disconnect"); }}
@@ -334,7 +334,7 @@ export default function IntegrationSettingsModal({
               </>
             ) : (
               <>
-                <p className="mt-4 text-sm text-stone-500">Not connected</p>
+                <p className="mt-4 text-sm text-stone-500 dark:text-stone-400">Not connected</p>
                 {error && <p className="mt-3 text-sm text-ember-500">{error}</p>}
                 {renderConnectionButtons()}
               </>
@@ -353,7 +353,7 @@ function renderLinkedText(text: string): (string | JSX.Element)[] {
   return text.split(LINK_RE).map((seg, i) => {
     const m = seg.match(LINK_MATCH_RE);
     if (!m) return seg;
-    return <a key={i} href={m[2]} target="_blank" rel="noopener noreferrer" className="text-timber-500 hover:underline">{m[1]}</a>;
+    return <a key={i} href={m[2]} target="_blank" rel="noopener noreferrer" className="text-timber-500 hover:underline dark:text-timber-400">{m[1]}</a>;
   });
 }
 
@@ -383,7 +383,7 @@ function TokenForm({
     <form onSubmit={onSubmit}>
       <h2
         id={headingId}
-        className="text-lg font-heading font-semibold text-stone-900"
+        className="text-lg font-heading font-semibold text-stone-900 dark:text-stone-100"
       >
         {heading}
       </h2>
@@ -391,7 +391,7 @@ function TokenForm({
         <div key={name} className="mt-2">
           <label
             htmlFor={`cp_${name}-${integrationName}`}
-            className="block text-sm font-medium text-stone-700"
+            className="block text-sm font-medium text-stone-700 dark:text-stone-300"
           >
             {def.description || name}
           </label>
@@ -402,7 +402,7 @@ function TokenForm({
             required={def.required}
             defaultValue={def.default}
             placeholder={name}
-            className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
+            className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25 dark:text-stone-100 dark:placeholder:text-stone-500 dark:focus:border-timber-500 dark:focus:ring-timber-500/25"
           />
         </div>
       ))}
@@ -410,7 +410,7 @@ function TokenForm({
         <div key={field.name} className="mt-4">
           <label
             htmlFor={`cred_${field.name}-${integrationName}`}
-            className="block text-sm font-medium text-stone-700"
+            className="block text-sm font-medium text-stone-700 dark:text-stone-300"
           >
             {field.label || field.name}
             {field.help_url && (
@@ -418,14 +418,14 @@ function TokenForm({
                 href={field.help_url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="ml-1 text-xs text-timber-500 hover:underline"
+                className="ml-1 text-xs text-timber-500 hover:underline dark:text-timber-400"
               >
                 (where to find this)
               </a>
             )}
           </label>
           {field.description && (
-            <p className="mt-0.5 text-xs text-stone-400">{renderLinkedText(field.description)}</p>
+            <p className="mt-0.5 text-xs text-stone-400 dark:text-stone-500">{renderLinkedText(field.description)}</p>
           )}
           <input
             id={`cred_${field.name}-${integrationName}`}
@@ -434,7 +434,7 @@ function TokenForm({
             required
             placeholder={field.label || field.name}
             autoFocus={idx === 0}
-            className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
+            className="mt-1 w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25 dark:text-stone-100 dark:placeholder:text-stone-500 dark:focus:border-timber-500 dark:focus:ring-timber-500/25"
           />
         </div>
       ))}

--- a/web/src/components/Nav.tsx
+++ b/web/src/components/Nav.tsx
@@ -5,6 +5,8 @@ import { usePathname } from "next/navigation";
 import { clearSession, getUserEmail } from "@/lib/auth";
 import { logout } from "@/lib/api";
 import { LOGIN_PATH } from "@/lib/constants";
+import { useTheme } from "@/hooks/use-theme";
+import { SunIcon, MoonIcon, SunMoonIcon } from "./icons";
 
 const links = [
   { href: "/", label: "Dashboard" },
@@ -16,6 +18,9 @@ const links = [
 export default function Nav() {
   const pathname = usePathname();
   const email = getUserEmail();
+  const { theme, setTheme } = useTheme();
+
+  const ThemeIcon = theme === "light" ? SunIcon : theme === "dark" ? MoonIcon : SunMoonIcon;
 
   async function handleLogout() {
     await logout().catch(() => {});
@@ -27,15 +32,15 @@ export default function Nav() {
     <nav className="border-b border-border bg-surface px-6 py-3">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-8">
-          <Link href="/" className="text-lg font-heading font-bold text-timber-800">
+          <Link href="/" className="text-lg font-heading font-bold text-timber-800 dark:text-timber-200">
             Gestalt
           </Link>
           <div className="flex gap-4">
             {links.map((link) => {
               const className = `text-sm ${
                 pathname === link.href
-                  ? "font-medium text-timber-600"
-                  : "text-stone-500 hover:text-stone-800"
+                  ? "font-medium text-timber-600 dark:text-timber-400"
+                  : "text-stone-500 hover:text-stone-800 dark:text-stone-400 dark:hover:text-stone-200"
               }`;
               if (link.href === "/docs") {
                 return (
@@ -52,17 +57,30 @@ export default function Nav() {
             })}
           </div>
         </div>
-        {email && (
-          <div className="flex items-center gap-4">
-            <span className="text-sm text-stone-400">{email}</span>
-            <button
-              onClick={handleLogout}
-              className="text-sm text-stone-400 hover:text-stone-600"
-            >
-              Logout
-            </button>
-          </div>
-        )}
+        <div className="flex items-center gap-4">
+          <button
+            onClick={() => {
+              if (theme === "light") setTheme("dark");
+              else if (theme === "dark") setTheme("system");
+              else setTheme("light");
+            }}
+            className="flex h-8 w-8 items-center justify-center rounded text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-600 dark:text-stone-500 dark:hover:bg-stone-800 dark:hover:text-stone-300"
+            title={theme === "light" ? "Light mode" : theme === "dark" ? "Dark mode" : "System preference"}
+          >
+            <ThemeIcon className="h-5 w-5" />
+          </button>
+          {email && (
+            <>
+              <span className="text-sm text-stone-400 dark:text-stone-500">{email}</span>
+              <button
+                onClick={handleLogout}
+                className="text-sm text-stone-400 hover:text-stone-600 dark:text-stone-500 dark:hover:text-stone-300"
+              >
+                Logout
+              </button>
+            </>
+          )}
+        </div>
       </div>
     </nav>
   );

--- a/web/src/components/TokenCreateForm.tsx
+++ b/web/src/components/TokenCreateForm.tsx
@@ -41,7 +41,7 @@ export default function TokenCreateForm({ onCreated }: TokenCreateFormProps) {
         <div>
           <label
             htmlFor="token-name"
-            className="block text-sm font-medium text-stone-700"
+            className="block text-sm font-medium text-stone-700 dark:text-stone-300"
           >
             Token name
           </label>
@@ -51,7 +51,7 @@ export default function TokenCreateForm({ onCreated }: TokenCreateFormProps) {
             type="text"
             required
             placeholder="e.g. ci-pipeline"
-            className="mt-1 rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25"
+            className="mt-1 rounded-md border border-border bg-surface px-3 py-2 text-sm text-stone-900 placeholder:text-stone-400 focus:border-timber-400 focus:outline-none focus:ring-2 focus:ring-timber-400/25 dark:text-stone-100 dark:placeholder:text-stone-500 dark:focus:border-timber-500 dark:focus:ring-timber-500/25"
           />
         </div>
         <Button type="submit" disabled={creating}>
@@ -60,11 +60,11 @@ export default function TokenCreateForm({ onCreated }: TokenCreateFormProps) {
       </form>
 
       {plaintext && (
-        <div className="mt-4 rounded-lg border border-harvest-300 bg-harvest-50 p-4">
-          <p className="text-sm font-medium text-harvest-700">
+        <div className="mt-4 rounded-lg border border-harvest-300 bg-harvest-50 p-4 dark:border-harvest-600 dark:bg-harvest-700/20">
+          <p className="text-sm font-medium text-harvest-700 dark:text-harvest-300">
             Copy this token now. It will not be shown again.
           </p>
-          <code className="mt-2 block break-all rounded-md bg-stone-100 p-2 font-mono text-sm text-stone-900">
+          <code className="mt-2 block break-all rounded-md bg-stone-100 p-2 font-mono text-sm text-stone-900 dark:bg-stone-800 dark:text-stone-100">
             {plaintext}
           </code>
         </div>

--- a/web/src/components/TokenTable.tsx
+++ b/web/src/components/TokenTable.tsx
@@ -28,7 +28,7 @@ export default function TokenTable({ tokens, onRevoked }: TokenTableProps) {
 
   if (tokens.length === 0) {
     return (
-      <p className="py-8 text-center text-sm text-stone-400">
+      <p className="py-8 text-center text-sm text-stone-400 dark:text-stone-500">
         No API tokens yet.
       </p>
     );
@@ -39,7 +39,7 @@ export default function TokenTable({ tokens, onRevoked }: TokenTableProps) {
       {error && <p className="mb-4 px-4 pt-3 text-sm text-ember-500">{error}</p>}
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b border-border bg-surface-raised text-left text-stone-500">
+          <tr className="border-b border-border bg-surface-raised text-left text-stone-500 dark:text-stone-400">
             <th className="px-4 pb-3 pt-3 text-xs font-medium uppercase tracking-wide">Name</th>
             <th className="px-4 pb-3 pt-3 text-xs font-medium uppercase tracking-wide">Scopes</th>
             <th className="px-4 pb-3 pt-3 text-xs font-medium uppercase tracking-wide">Created</th>
@@ -49,13 +49,13 @@ export default function TokenTable({ tokens, onRevoked }: TokenTableProps) {
         </thead>
         <tbody>
           {tokens.map((token) => (
-            <tr key={token.id} className="border-b border-stone-200 last:border-b-0">
-              <td className="px-4 py-3 text-stone-900">{token.name}</td>
-              <td className="px-4 py-3 text-stone-500">{token.scopes || "all"}</td>
-              <td className="px-4 py-3 text-stone-500">
+            <tr key={token.id} className="border-b border-stone-200 last:border-b-0 dark:border-stone-700">
+              <td className="px-4 py-3 text-stone-900 dark:text-stone-100">{token.name}</td>
+              <td className="px-4 py-3 text-stone-500 dark:text-stone-400">{token.scopes || "all"}</td>
+              <td className="px-4 py-3 text-stone-500 dark:text-stone-400">
                 {new Date(token.created_at).toLocaleDateString()}
               </td>
-              <td className="px-4 py-3 text-stone-500">
+              <td className="px-4 py-3 text-stone-500 dark:text-stone-400">
                 {token.expires_at
                   ? new Date(token.expires_at).toLocaleDateString()
                   : "Never"}

--- a/web/src/components/icons.tsx
+++ b/web/src/components/icons.tsx
@@ -25,6 +25,47 @@ export function CloseIcon({ className }: { className?: string }) {
   );
 }
 
+export function SunIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="5" />
+      <line x1="12" y1="1" x2="12" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="23" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="1" y1="12" x2="3" y2="12" />
+      <line x1="21" y1="12" x2="23" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+  );
+}
+
+export function MoonIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+export function SunMoonIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="8" cy="8" r="2.5" />
+      <line x1="8" y1="2" x2="8" y2="3.5" />
+      <line x1="8" y1="12.5" x2="8" y2="14" />
+      <line x1="3.76" y1="3.76" x2="4.82" y2="4.82" />
+      <line x1="11.18" y1="11.18" x2="12.24" y2="12.24" />
+      <line x1="2" y1="8" x2="3.5" y2="8" />
+      <line x1="12.5" y1="8" x2="14" y2="8" />
+      <line x1="3.76" y1="12.24" x2="4.82" y2="11.18" />
+      <line x1="11.18" y1="4.82" x2="12.24" y2="3.76" />
+      <path d="M22 16.73A7 7 0 1 1 13.27 8a5.5 5.5 0 0 0 8.73 8.73z" />
+    </svg>
+  );
+}
+
 export function DefaultIcon() {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/web/src/hooks/use-theme.ts
+++ b/web/src/hooks/use-theme.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+type Theme = "light" | "dark" | "system";
+
+function getStoredTheme(): Theme {
+  if (typeof window === "undefined") return "system";
+  const stored = localStorage.getItem("theme");
+  if (stored === "light" || stored === "dark" || stored === "system") {
+    return stored;
+  }
+  return "system";
+}
+
+function subscribe(callback: () => void) {
+  window.addEventListener("storage", callback);
+  return () => window.removeEventListener("storage", callback);
+}
+
+export function useTheme() {
+  const theme = useSyncExternalStore(subscribe, getStoredTheme, () => "system");
+
+  const setTheme = (newTheme: Theme) => {
+    localStorage.setItem("theme", newTheme);
+    window.dispatchEvent(new Event("storage"));
+
+    if (newTheme === "system") {
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      if (prefersDark) {
+        document.documentElement.classList.add("dark");
+      } else {
+        document.documentElement.classList.remove("dark");
+      }
+    } else if (newTheme === "dark") {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+  };
+
+  return { theme, setTheme };
+}

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  darkMode: ["class"],
   content: ["./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {


### PR DESCRIPTION
Add theme support using Tailwind's class-based dark mode with a custom `useTheme` hook backed by localStorage and `useSyncExternalStore`. An inline script in the root layout prevents flash of unstyled content by applying the `dark` class before React hydration, and a system preference listener keeps the UI in sync when set to "system" mode.

The toggle cycles light, dark, system on each click and lives in the nav bar alongside the user controls. All components and pages have been updated with `dark:` variant classes that map the warm earthy palette (timber, stone, harvest, grove, ember) to complementary dark tones. CSS variables for background, surface, border, and foreground switch automatically via a `.dark` selector in `globals.css`.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>