### PR TITLE
Add `access_token_path` for non-standard OAuth token responses

### DIFF
--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -190,6 +190,7 @@ type ConnectionAuthDef struct {
 	RefreshParams       map[string]string    `yaml:"refresh_params"`
 	AcceptHeader        string               `yaml:"accept_header"`
 	TokenMetadata       []string             `yaml:"token_metadata"`
+	AccessTokenPath     string               `yaml:"access_token_path"`
 	Credentials         []CredentialFieldDef `yaml:"credentials"`
 	AuthMapping         *AuthMappingDef      `yaml:"auth_mapping"`
 }

--- a/server/internal/oauth/upstream.go
+++ b/server/internal/oauth/upstream.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/apiexec"
 )
 
 const defaultTimeout = 10 * time.Second
@@ -52,8 +53,9 @@ type UpstreamConfig struct {
 	TokenParams         map[string]string
 	RefreshParams       map[string]string
 
-	TokenExchange TokenExchangeFormat
-	AcceptHeader  string
+	TokenExchange   TokenExchangeFormat
+	AcceptHeader    string
+	AccessTokenPath string
 }
 
 type ResponseHook func(body []byte) error
@@ -295,7 +297,14 @@ func (h *UpstreamHandler) tokenRequest(ctx context.Context, data url.Values, tok
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return nil, fmt.Errorf("decoding token response: %w", err)
 	}
-	accessToken, _ := raw["access_token"].(string)
+	var accessToken string
+	if h.cfg.AccessTokenPath != "" {
+		if v, ok := apiexec.ExtractJSONPath(raw, h.cfg.AccessTokenPath); ok {
+			accessToken, _ = v.(string)
+		}
+	} else {
+		accessToken, _ = raw["access_token"].(string)
+	}
 	if accessToken == "" {
 		return nil, fmt.Errorf("token response missing access_token")
 	}

--- a/server/internal/oauth/upstream_test.go
+++ b/server/internal/oauth/upstream_test.go
@@ -763,3 +763,64 @@ func TestTokenResponseExtra(t *testing.T) {
 		t.Errorf("Extra[custom_field] = %v, want custom_value", resp.Extra["custom_field"])
 	}
 }
+
+func TestAccessTokenPathExtractsNestedToken(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"ok": true,
+			"access_token": "xoxb-bot-token",
+			"token_type": "bot",
+			"authed_user": {
+				"id": "U12345",
+				"access_token": "xoxp-user-token",
+				"token_type": "user",
+				"scope": "chat:write"
+			}
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	h := NewUpstream(UpstreamConfig{
+		ClientID:        "cid",
+		ClientSecret:    "csec",
+		TokenURL:        srv.URL + "/token",
+		RedirectURL:     "http://localhost/cb",
+		AccessTokenPath: "authed_user.access_token",
+	})
+
+	resp, err := h.ExchangeCode(context.Background(), "code")
+	if err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if resp.AccessToken != "xoxp-user-token" {
+		t.Errorf("AccessToken = %q, want xoxp-user-token", resp.AccessToken)
+	}
+}
+
+func TestAccessTokenPathFallsBackToTopLevel(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token": "standard-token", "token_type": "Bearer"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	h := NewUpstream(UpstreamConfig{
+		ClientID:     "cid",
+		ClientSecret: "csec",
+		TokenURL:     srv.URL + "/token",
+		RedirectURL:  "http://localhost/cb",
+	})
+
+	resp, err := h.ExchangeCode(context.Background(), "code")
+	if err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if resp.AccessToken != "standard-token" {
+		t.Errorf("AccessToken = %q, want standard-token", resp.AccessToken)
+	}
+}

--- a/server/internal/provider/build.go
+++ b/server/internal/provider/build.go
@@ -312,6 +312,7 @@ func ApplyConnectionAuth(def *Definition, conn config.ConnectionDef) {
 	setStr(&def.Auth.ScopeParam, o.ScopeParam)
 	setStr(&def.Auth.ScopeSeparator, o.ScopeSeparator)
 	setStr(&def.Auth.AcceptHeader, o.AcceptHeader)
+	setStr(&def.Auth.AccessTokenPath, o.AccessTokenPath)
 	if o.PKCE {
 		def.Auth.PKCE = true
 	}
@@ -395,6 +396,7 @@ func BuildOAuthUpstream(def *Definition, conn config.ConnectionDef, baseURL stri
 		RefreshParams:       def.Auth.RefreshParams,
 		TokenExchange:       tokenExchange,
 		AcceptHeader:        def.Auth.AcceptHeader,
+		AccessTokenPath:     def.Auth.AccessTokenPath,
 	}
 
 	if def.Auth.ClientAuth == "header" {

--- a/server/internal/provider/definition.go
+++ b/server/internal/provider/definition.go
@@ -78,6 +78,7 @@ type AuthDef struct {
 	RefreshParams       map[string]string `yaml:"refresh_params" json:"refresh_params"`
 	AcceptHeader        string            `yaml:"accept_header" json:"accept_header"`
 	TokenMetadata       []string          `yaml:"token_metadata" json:"token_metadata"`
+	AccessTokenPath     string            `yaml:"access_token_path" json:"access_token_path,omitempty"`
 	ResponseCheck       *ResponseCheckDef `yaml:"response_check" json:"response_check,omitempty"`
 }
 


### PR DESCRIPTION
Some providers (notably Slack) return the access token nested inside the OAuth token response instead of at the standard top-level `access_token` field. Slack's v2 OAuth returns user tokens under `authed_user.access_token`. This adds an `access_token_path` config on connection auth that tells gestaltd where to find the token using dot-separated JSON path traversal, falling back to the standard top-level field when unset.