### PR TITLE
Simplify plugin store to plain extraction functions

### DIFF
--- a/server/cmd/gestaltd/init_test.go
+++ b/server/cmd/gestaltd/init_test.go
@@ -71,8 +71,8 @@ func TestPreparedLockfileRoundTripPreservesPluginsSection(t *testing.T) {
 			"integration:external": {
 				Fingerprint: "plugin-fingerprint",
 				Package:     "./plugins/dummy.tar.gz",
-				Manifest:    ".gestalt/plugins/acme/provider/0.1.0/plugin.json",
-				Executable:  ".gestalt/plugins/acme/provider/0.1.0/artifacts/linux/amd64/provider",
+				Manifest:    ".gestalt/plugins/integration_external/plugin.json",
+				Executable:  ".gestalt/plugins/integration_external/artifacts/linux/amd64/provider",
 			},
 		},
 	}

--- a/server/internal/operator/lifecycle.go
+++ b/server/internal/operator/lifecycle.go
@@ -21,6 +21,7 @@ import (
 const (
 	InitLockfileName     = "gestalt.lock.json"
 	PreparedProvidersDir = ".gestalt/providers"
+	PluginsDir           = ".gestalt/plugins"
 	LockVersion          = 4
 	LockVersionCompat    = 3
 )
@@ -74,7 +75,7 @@ func (l *Lifecycle) InitAtPath(configPath string) (*Lockfile, error) {
 		Plugins:   make(map[string]LockPluginEntry),
 	}
 
-	resolvedPlugins, err := l.writePluginArtifacts(context.Background(), configPath, cfg, paths)
+	resolvedPlugins, err := l.writePluginArtifacts(context.Background(), cfg, paths)
 	if err != nil {
 		return nil, err
 	}
@@ -112,6 +113,7 @@ type initPaths struct {
 	configDir    string
 	lockfilePath string
 	providersDir string
+	pluginsDir   string
 }
 
 type pluginFingerprintInput struct {
@@ -153,7 +155,12 @@ func initPathsForConfig(configPath string) initPaths {
 		configDir:    configDir,
 		lockfilePath: filepath.Join(configDir, InitLockfileName),
 		providersDir: filepath.Join(configDir, filepath.FromSlash(PreparedProvidersDir)),
+		pluginsDir:   filepath.Join(configDir, filepath.FromSlash(PluginsDir)),
 	}
+}
+
+func pluginDestDir(paths initPaths, kind, name string) string {
+	return filepath.Join(paths.pluginsDir, kind+"_"+name)
 }
 
 func writeJSONFile(path string, v any) error {
@@ -329,8 +336,7 @@ func pluginEntryMatches(paths initPaths, name string, plugin *config.PluginDef, 
 	return true
 }
 
-func (l *Lifecycle) writePluginArtifacts(ctx context.Context, configPath string, cfg *config.Config, paths initPaths) (map[string]LockPluginEntry, error) {
-	store := pluginstore.New(configPath)
+func (l *Lifecycle) writePluginArtifacts(ctx context.Context, cfg *config.Config, paths initPaths) (map[string]LockPluginEntry, error) {
 	written := make(map[string]LockPluginEntry)
 	for name := range cfg.Integrations {
 		intg := cfg.Integrations[name]
@@ -344,9 +350,9 @@ func (l *Lifecycle) writePluginArtifacts(ctx context.Context, configPath string,
 		var entry LockPluginEntry
 		switch {
 		case intg.Plugin.Source != "":
-			entry, err = l.lockEntryForSource(ctx, paths, store, "integration", name, intg.Plugin, configMap)
+			entry, err = l.lockEntryForSource(ctx, paths, "integration", name, intg.Plugin, configMap)
 		case intg.Plugin.Package != "":
-			entry, err = lockEntryForPackage(ctx, paths, store, "integration", name, intg.Plugin, configMap)
+			entry, err = lockEntryForPackage(ctx, paths, "integration", name, intg.Plugin, configMap)
 		default:
 			continue
 		}
@@ -367,9 +373,9 @@ func (l *Lifecycle) writePluginArtifacts(ctx context.Context, configPath string,
 		var entry LockPluginEntry
 		switch {
 		case rt.Plugin.Source != "":
-			entry, err = l.lockEntryForSource(ctx, paths, store, "runtime", name, rt.Plugin, configMap)
+			entry, err = l.lockEntryForSource(ctx, paths, "runtime", name, rt.Plugin, configMap)
 		case rt.Plugin.Package != "":
-			entry, err = lockEntryForPackage(ctx, paths, store, "runtime", name, rt.Plugin, configMap)
+			entry, err = lockEntryForPackage(ctx, paths, "runtime", name, rt.Plugin, configMap)
 		default:
 			continue
 		}
@@ -380,7 +386,7 @@ func (l *Lifecycle) writePluginArtifacts(ctx context.Context, configPath string,
 	}
 
 	if cfg.UI.Plugin.HasManagedArtifacts() {
-		entry, err := l.writeUIPluginArtifact(ctx, cfg, paths, store)
+		entry, err := l.writeUIPluginArtifact(ctx, cfg, paths)
 		if err != nil {
 			return nil, err
 		}
@@ -405,7 +411,7 @@ func sourceDigestForPackage(packagePath string) (string, error) {
 	return pluginpkg.ArchiveDigest(packagePath)
 }
 
-func lockEntryForPackage(ctx context.Context, paths initPaths, store *pluginstore.Store, kind, name string, plugin *config.PluginDef, configMap map[string]any) (LockPluginEntry, error) {
+func lockEntryForPackage(ctx context.Context, paths initPaths, kind, name string, plugin *config.PluginDef, configMap map[string]any) (LockPluginEntry, error) {
 	packagePath := plugin.Package
 	isURL := strings.HasPrefix(packagePath, "https://")
 
@@ -424,11 +430,12 @@ func lockEntryForPackage(ctx context.Context, paths initPaths, store *pluginstor
 		return LockPluginEntry{}, fmt.Errorf("%s %q plugin.package %q: %w", kind, name, plugin.Package, err)
 	}
 
+	destDir := pluginDestDir(paths, kind, name)
 	var installed *pluginstore.InstalledPlugin
 	if info.IsDir() {
-		installed, err = store.InstallFromDir(packagePath)
+		installed, err = pluginstore.InstallFromDir(packagePath, destDir)
 	} else {
-		installed, err = store.Install(packagePath)
+		installed, err = pluginstore.Install(packagePath, destDir)
 	}
 	if err != nil {
 		return LockPluginEntry{}, fmt.Errorf("%s %q plugin.package %q: %w", kind, name, plugin.Package, err)
@@ -469,7 +476,7 @@ func lockEntryForPackage(ctx context.Context, paths initPaths, store *pluginstor
 	}, nil
 }
 
-func (l *Lifecycle) lockEntryForSource(ctx context.Context, paths initPaths, store *pluginstore.Store, kind, name string, plugin *config.PluginDef, configMap map[string]any) (LockPluginEntry, error) {
+func (l *Lifecycle) lockEntryForSource(ctx context.Context, paths initPaths, kind, name string, plugin *config.PluginDef, configMap map[string]any) (LockPluginEntry, error) {
 	src, err := pluginsource.Parse(plugin.Source)
 	if err != nil {
 		return LockPluginEntry{}, fmt.Errorf("%s %q plugin.source %q: %w", kind, name, plugin.Source, err)
@@ -483,7 +490,8 @@ func (l *Lifecycle) lockEntryForSource(ctx context.Context, paths initPaths, sto
 	}
 	defer resolved.Cleanup()
 
-	installed, err := store.Install(resolved.LocalPath)
+	destDir := pluginDestDir(paths, kind, name)
+	installed, err := pluginstore.Install(resolved.LocalPath, destDir)
 	if err != nil {
 		return LockPluginEntry{}, fmt.Errorf("%s %q install source plugin: %w", kind, name, err)
 	}
@@ -525,13 +533,14 @@ func (l *Lifecycle) lockEntryForSource(ctx context.Context, paths initPaths, sto
 	}, nil
 }
 
-func (l *Lifecycle) writeUIPluginArtifact(ctx context.Context, cfg *config.Config, paths initPaths, store *pluginstore.Store) (LockPluginEntry, error) {
+func (l *Lifecycle) writeUIPluginArtifact(ctx context.Context, cfg *config.Config, paths initPaths) (LockPluginEntry, error) {
 	plugin := cfg.UI.Plugin
 	fingerprint, err := UIPluginFingerprint(plugin)
 	if err != nil {
 		return LockPluginEntry{}, fmt.Errorf("fingerprinting ui plugin: %w", err)
 	}
 
+	destDir := pluginDestDir(paths, "ui", "default")
 	var installed *pluginstore.InstalledPlugin
 	var sourceDigest string
 	switch {
@@ -548,7 +557,7 @@ func (l *Lifecycle) writeUIPluginArtifact(ctx context.Context, cfg *config.Confi
 			return LockPluginEntry{}, fmt.Errorf("ui plugin resolve source %q@%s: %w", plugin.Source, plugin.Version, err)
 		}
 		defer resolved.Cleanup()
-		installed, err = store.Install(resolved.LocalPath)
+		installed, err = pluginstore.Install(resolved.LocalPath, destDir)
 		if err != nil {
 			return LockPluginEntry{}, fmt.Errorf("ui plugin install source: %w", err)
 		}
@@ -592,9 +601,9 @@ func (l *Lifecycle) writeUIPluginArtifact(ctx context.Context, cfg *config.Confi
 			return LockPluginEntry{}, fmt.Errorf("ui plugin.package %q: %w", plugin.Package, err)
 		}
 		if info.IsDir() {
-			installed, err = store.InstallFromDir(packagePath)
+			installed, err = pluginstore.InstallFromDir(packagePath, destDir)
 		} else {
-			installed, err = store.Install(packagePath)
+			installed, err = pluginstore.Install(packagePath, destDir)
 		}
 		if err != nil {
 			return LockPluginEntry{}, fmt.Errorf("ui plugin.package %q: %w", plugin.Package, err)

--- a/server/internal/operator/lifecycle_source_test.go
+++ b/server/internal/operator/lifecycle_source_test.go
@@ -203,8 +203,9 @@ func TestSourcePluginEndToEnd(t *testing.T) {
 		t.Errorf("executable not found at %s: %v", executablePath, err)
 	}
 
-	if !strings.Contains(entry.Manifest, source) {
-		t.Errorf("manifest path %q does not contain source path %q", entry.Manifest, source)
+	wantPrefix := ".gestalt/plugins/integration_alpha/"
+	if !strings.HasPrefix(entry.Manifest, wantPrefix) {
+		t.Errorf("manifest path %q does not start with %q", entry.Manifest, wantPrefix)
 	}
 
 	if resolver.calls != 1 {
@@ -245,8 +246,8 @@ func TestReadLockfileV3Compat(t *testing.T) {
 			"integration:beta": {
 				Fingerprint: "abc123",
 				Package:     "/tmp/beta.tar.gz",
-				Manifest:    ".gestalt/plugins/acme/beta/1.0.0/plugin.json",
-				Executable:  ".gestalt/plugins/acme/beta/1.0.0/artifacts/darwin/arm64/provider",
+				Manifest:    ".gestalt/plugins/integration_beta/plugin.json",
+				Executable:  ".gestalt/plugins/integration_beta/artifacts/darwin/arm64/provider",
 			},
 		},
 	}
@@ -500,10 +501,10 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 		t.Errorf("lockfile on disk version = %d, want %d", readBack.Version, LockVersion)
 	}
 
-	wantInstallSuffix := filepath.Join("github.com", testOwner, testRepo, testPlugin, testVersion)
+	wantDirName := "integration_alpha"
 	executablePath := resolveLockPath(configDir, entry.Executable)
-	if !strings.Contains(executablePath, wantInstallSuffix) {
-		t.Errorf("executable path %q does not contain expected store path %q", executablePath, wantInstallSuffix)
+	if !strings.Contains(executablePath, wantDirName) {
+		t.Errorf("executable path %q does not contain expected dir %q", executablePath, wantDirName)
 	}
 	if _, err := os.Stat(executablePath); err != nil {
 		t.Errorf("executable not found at %s: %v", executablePath, err)

--- a/server/internal/operator/lifecycle_test.go
+++ b/server/internal/operator/lifecycle_test.go
@@ -406,8 +406,8 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 			"integration:example": {
 				Fingerprint: "plugin-fp",
 				Package:     "./test-plugin",
-				Manifest:    ".gestalt/plugins/testowner/provider/0.1.0/plugin.json",
-				Executable:  ".gestalt/plugins/testowner/provider/0.1.0/artifacts/darwin/arm64/provider",
+				Manifest:    ".gestalt/plugins/integration_example/plugin.json",
+				Executable:  ".gestalt/plugins/integration_example/artifacts/darwin/arm64/provider",
 			},
 		},
 	}

--- a/server/internal/pluginsource/source.go
+++ b/server/internal/pluginsource/source.go
@@ -53,10 +53,6 @@ func (s Source) String() string {
 	return s.Host + "/" + s.Owner + "/" + s.Repo + "/" + s.Plugin
 }
 
-func (s Source) StorePath() string {
-	return s.String()
-}
-
 func (s Source) AssetName(version string) string {
 	return assetPrefix + s.Plugin + "_" + versionPrefix + version + assetSuffix
 }

--- a/server/internal/pluginsource/source_test.go
+++ b/server/internal/pluginsource/source_test.go
@@ -98,15 +98,6 @@ func TestSourceStringRoundTrip(t *testing.T) {
 	}
 }
 
-func TestSourceStorePath(t *testing.T) {
-	t.Parallel()
-
-	src := Source{Host: HostGitHub, Owner: "testowner", Repo: "testrepo", Plugin: "testplugin"}
-	if got := src.StorePath(); got != src.String() {
-		t.Errorf("StorePath() = %q, want %q", got, src.String())
-	}
-}
-
 func TestSourceAssetName(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/pluginstore/store.go
+++ b/server/internal/pluginstore/store.go
@@ -11,24 +11,8 @@ import (
 	"slices"
 
 	pluginpkg "github.com/valon-technologies/gestalt/server/internal/pluginpkg"
-	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
-
-func storeRootForConfigPath(configPath string) string {
-	if configPath == "" {
-		return filepath.Join(".gestalt", "plugins")
-	}
-	return filepath.Join(filepath.Dir(configPath), ".gestalt", "plugins")
-}
-
-type Store struct {
-	root string
-}
-
-func New(configPath string) *Store {
-	return &Store{root: storeRootForConfigPath(configPath)}
-}
 
 type InstalledPlugin struct {
 	Source         string
@@ -46,16 +30,8 @@ func isWebUIOnly(manifest *pluginmanifestv1.Manifest) bool {
 	return len(manifest.Kinds) == 1 && manifest.Kinds[0] == pluginmanifestv1.KindWebUI
 }
 
-func (s *Store) Install(packagePath string) (*InstalledPlugin, error) {
-	if s == nil {
-		return nil, fmt.Errorf("store is required")
-	}
+func Install(packagePath, destDir string) (*InstalledPlugin, error) {
 	_, manifest, err := pluginpkg.ReadPackageManifest(packagePath)
-	if err != nil {
-		return nil, err
-	}
-
-	destDir, err := s.destDirForManifest(manifest)
 	if err != nil {
 		return nil, err
 	}
@@ -124,16 +100,8 @@ func (s *Store) Install(packagePath string) (*InstalledPlugin, error) {
 	return installed, nil
 }
 
-func (s *Store) InstallFromDir(dirPath string) (*InstalledPlugin, error) {
-	if s == nil {
-		return nil, fmt.Errorf("store is required")
-	}
+func InstallFromDir(dirPath, destDir string) (*InstalledPlugin, error) {
 	_, manifest, _, err := pluginpkg.LoadManifestFromPath(dirPath)
-	if err != nil {
-		return nil, err
-	}
-
-	destDir, err := s.destDirForManifest(manifest)
 	if err != nil {
 		return nil, err
 	}
@@ -238,21 +206,6 @@ func (s *Store) InstallFromDir(dirPath string) (*InstalledPlugin, error) {
 
 	installed := buildInstalledPlugin(manifest, destDir, manifestDest, executablePath, artifact, "")
 	return installed, nil
-}
-
-func (s *Store) destDirForManifest(manifest *pluginmanifestv1.Manifest) (string, error) {
-	if s == nil || s.root == "" {
-		return "", fmt.Errorf("store root is required")
-	}
-	if manifest == nil {
-		return "", fmt.Errorf("manifest is required")
-	}
-	src, err := pluginsource.Parse(manifest.Source)
-	if err != nil {
-		return "", fmt.Errorf("manifest source: %w", err)
-	}
-	destDir := filepath.Join(s.root, filepath.FromSlash(src.StorePath()), manifest.Version)
-	return destDir, nil
 }
 
 func buildInstalledPlugin(manifest *pluginmanifestv1.Manifest, destDir, manifestPath, executablePath string, artifact *pluginmanifestv1.Artifact, assetRoot string) *InstalledPlugin {

--- a/server/internal/pluginstore/store_test.go
+++ b/server/internal/pluginstore/store_test.go
@@ -22,19 +22,11 @@ func TestInstall(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "configs", "gestalt.yaml")
-	if err := os.MkdirAll(filepath.Dir(cfgPath), 0755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
-	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
-		t.Fatalf("WriteFile config: %v", err)
-	}
-
-	store := New(cfgPath)
 	pkg1 := mustBuildPackage(t, dir, "github.com/testowner/plugins/provider", "0.1.0", "hello from testowner")
 	pkg2 := mustBuildPackage(t, dir, "github.com/beta/plugins/provider", "1.2.3", "hello from beta")
 
-	installed1, err := store.Install(pkg1)
+	dest1 := filepath.Join(dir, "plugins", "integration_example")
+	installed1, err := Install(pkg1, dest1)
 	if err != nil {
 		t.Fatalf("Install pkg1: %v", err)
 	}
@@ -44,14 +36,13 @@ func TestInstall(t *testing.T) {
 	if installed1.Manifest == nil || installed1.Manifest.Source != "github.com/testowner/plugins/provider" {
 		t.Fatalf("unexpected installed manifest: %+v", installed1.Manifest)
 	}
-	wantRoot := filepath.Join(installed1.Root, "..")
-	if _, err := os.Stat(wantRoot); err != nil {
-		t.Fatalf("expected install root to exist: %v", err)
+	if installed1.Root != dest1 {
+		t.Fatalf("Root = %q, want %q", installed1.Root, dest1)
 	}
-	if installed1.ManifestPath != filepath.Join(installed1.Root, pluginpkg.ManifestFile) {
+	if installed1.ManifestPath != filepath.Join(dest1, pluginpkg.ManifestFile) {
 		t.Fatalf("ManifestPath = %q", installed1.ManifestPath)
 	}
-	if installed1.ExecutablePath != filepath.Join(installed1.Root, "artifacts", runtime.GOOS, runtime.GOARCH, "provider") {
+	if installed1.ExecutablePath != filepath.Join(dest1, "artifacts", runtime.GOOS, runtime.GOARCH, "provider") {
 		t.Fatalf("ExecutablePath = %q", installed1.ExecutablePath)
 	}
 	data, err := os.ReadFile(installed1.ExecutablePath)
@@ -62,7 +53,8 @@ func TestInstall(t *testing.T) {
 		t.Fatalf("unexpected executable content: %q", data)
 	}
 
-	installed2, err := store.Install(pkg2)
+	dest2 := filepath.Join(dir, "plugins", "integration_beta")
+	installed2, err := Install(pkg2, dest2)
 	if err != nil {
 		t.Fatalf("Install pkg2: %v", err)
 	}
@@ -75,14 +67,9 @@ func TestInstallRejectsDigestMismatch(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "gestalt.yaml")
-	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
-		t.Fatalf("WriteFile config: %v", err)
-	}
-	store := New(cfgPath)
-
 	pkg := mustBuildMismatchPackage(t, dir, "github.com/testowner/plugins/provider", "0.1.0", "hello", strings.Repeat("deadbeef", 8))
-	_, err := store.Install(pkg)
+	dest := filepath.Join(dir, "plugins", "integration_example")
+	_, err := Install(pkg, dest)
 	if err == nil {
 		t.Fatal("expected digest mismatch error")
 	}
@@ -91,38 +78,13 @@ func TestInstallRejectsDigestMismatch(t *testing.T) {
 	}
 }
 
-func TestInstallRejectsInvalidVersion(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "gestalt.yaml")
-	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
-		t.Fatalf("WriteFile config: %v", err)
-	}
-	store := New(cfgPath)
-
-	pkg := mustBuildRawPackage(t, dir, "github.com/testowner/plugins/provider", "../evil", "hello")
-	_, err := store.Install(pkg)
-	if err == nil {
-		t.Fatal("expected invalid manifest version error")
-	}
-	if !strings.Contains(err.Error(), "version") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
 func TestInstallRejectsDuplicateArtifactEntries(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "gestalt.yaml")
-	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
-		t.Fatalf("WriteFile config: %v", err)
-	}
-	store := New(cfgPath)
-
 	pkg := mustBuildPackageWithDuplicateArtifact(t, dir, "github.com/testowner/plugins/provider", "0.1.0", "good", "evil")
-	_, err := store.Install(pkg)
+	dest := filepath.Join(dir, "plugins", "integration_example")
+	_, err := Install(pkg, dest)
 	if err == nil {
 		t.Fatal("expected duplicate artifact entry error")
 	}
@@ -135,14 +97,10 @@ func TestInstallFromDirValidatesAndCopies(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "gestalt.yaml")
-	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
-		t.Fatalf("WriteFile config: %v", err)
-	}
-	store := New(cfgPath)
 	srcDir := mustBuildPluginDir(t, dir, "github.com/testowner/plugins/provider", "0.1.0", "dir-content", "")
 
-	installed, err := store.InstallFromDir(srcDir)
+	dest := filepath.Join(dir, "plugins", "integration_example")
+	installed, err := InstallFromDir(srcDir, dest)
 	if err != nil {
 		t.Fatalf("InstallFromDir: %v", err)
 	}
@@ -165,14 +123,10 @@ func TestInstallFromDirCopiesSchema(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "gestalt.yaml")
-	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
-		t.Fatalf("WriteFile config: %v", err)
-	}
-	store := New(cfgPath)
 	srcDir := mustBuildPluginDir(t, dir, "github.com/testowner/plugins/provider", "0.2.0", "binary", `{"type":"object"}`)
 
-	installed, err := store.InstallFromDir(srcDir)
+	dest := filepath.Join(dir, "plugins", "integration_example")
+	installed, err := InstallFromDir(srcDir, dest)
 	if err != nil {
 		t.Fatalf("InstallFromDir: %v", err)
 	}
@@ -187,14 +141,9 @@ func TestInstallFromDirRejectsDigestMismatch(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "gestalt.yaml")
-	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
-		t.Fatalf("WriteFile config: %v", err)
-	}
-	store := New(cfgPath)
-
 	srcDir := mustBuildPluginDirWithDigest(t, dir, "github.com/testowner/plugins/provider", "0.3.0", "real-content", strings.Repeat("deadbeef", 8))
-	_, err := store.InstallFromDir(srcDir)
+	dest := filepath.Join(dir, "plugins", "integration_example")
+	_, err := InstallFromDir(srcDir, dest)
 	if err == nil {
 		t.Fatal("expected digest mismatch error")
 	}
@@ -203,27 +152,22 @@ func TestInstallFromDirRejectsDigestMismatch(t *testing.T) {
 	}
 }
 
-func TestInstallV2ArchiveUsesSourcePath(t *testing.T) {
+func TestInstallExtractsToDestDir(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "gestalt.yaml")
-	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
-		t.Fatalf("WriteFile config: %v", err)
-	}
-	store := New(cfgPath)
 	pkg := mustBuildV2Package(t, dir, "github.com/testorg/testrepo/testplugin", "1.0.0", "v2-binary")
 
-	installed, err := store.Install(pkg)
+	dest := filepath.Join(dir, "plugins", "integration_beta")
+	installed, err := Install(pkg, dest)
 	if err != nil {
-		t.Fatalf("Install v2: %v", err)
+		t.Fatalf("Install: %v", err)
 	}
 	if installed.Source != "github.com/testorg/testrepo/testplugin" {
 		t.Fatalf("source = %q", installed.Source)
 	}
-	wantSuffix := filepath.Join("github.com", "testorg", "testrepo", "testplugin", "1.0.0")
-	if !strings.HasSuffix(installed.Root, wantSuffix) {
-		t.Fatalf("install root = %q, want suffix %q", installed.Root, wantSuffix)
+	if installed.Root != dest {
+		t.Fatalf("install root = %q, want %q", installed.Root, dest)
 	}
 	data, err := os.ReadFile(installed.ExecutablePath)
 	if err != nil {
@@ -234,27 +178,22 @@ func TestInstallV2ArchiveUsesSourcePath(t *testing.T) {
 	}
 }
 
-func TestInstallV2FromDirUsesSourcePath(t *testing.T) {
+func TestInstallFromDirExtractsToDestDir(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "gestalt.yaml")
-	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
-		t.Fatalf("WriteFile config: %v", err)
-	}
-	store := New(cfgPath)
 	srcDir := mustBuildV2PluginDir(t, dir, "github.com/testorg/testrepo/testplugin", "0.5.0", "dir-v2-binary")
 
-	installed, err := store.InstallFromDir(srcDir)
+	dest := filepath.Join(dir, "plugins", "integration_beta")
+	installed, err := InstallFromDir(srcDir, dest)
 	if err != nil {
-		t.Fatalf("InstallFromDir v2: %v", err)
+		t.Fatalf("InstallFromDir: %v", err)
 	}
 	if installed.Source != "github.com/testorg/testrepo/testplugin" {
 		t.Fatalf("source = %q", installed.Source)
 	}
-	wantSuffix := filepath.Join("github.com", "testorg", "testrepo", "testplugin", "0.5.0")
-	if !strings.HasSuffix(installed.Root, wantSuffix) {
-		t.Fatalf("install root = %q, want suffix %q", installed.Root, wantSuffix)
+	if installed.Root != dest {
+		t.Fatalf("install root = %q, want %q", installed.Root, dest)
 	}
 	data, err := os.ReadFile(installed.ExecutablePath)
 	if err != nil {
@@ -265,35 +204,14 @@ func TestInstallV2FromDirUsesSourcePath(t *testing.T) {
 	}
 }
 
-func TestInstallV2RejectsInvalidSource(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "gestalt.yaml")
-	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
-		t.Fatalf("WriteFile config: %v", err)
-	}
-	store := New(cfgPath)
-	pkg := mustBuildV2PackageRaw(t, dir, "not-a-valid-source", "1.0.0", "binary")
-
-	_, err := store.Install(pkg)
-	if err == nil {
-		t.Fatal("expected error for invalid v2 source")
-	}
-}
-
 func TestInstallFromDirCopiesManifestAndArtifact(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "gestalt.yaml")
-	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
-		t.Fatalf("WriteFile config: %v", err)
-	}
-	store := New(cfgPath)
 	srcDir := mustBuildPluginDir(t, dir, "github.com/testowner/plugins/fullcopy", "0.1.0", "test-binary", "")
 
-	installed, err := store.InstallFromDir(srcDir)
+	dest := filepath.Join(dir, "plugins", "integration_fullcopy")
+	installed, err := InstallFromDir(srcDir, dest)
 	if err != nil {
 		t.Fatalf("InstallFromDir: %v", err)
 	}
@@ -320,18 +238,14 @@ func TestInstallFromDirCopiesManifestAndArtifact(t *testing.T) {
 	}
 }
 
-func TestInstallFromDirV2SetsSource(t *testing.T) {
+func TestInstallFromDirSetsSource(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "gestalt.yaml")
-	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
-		t.Fatalf("WriteFile config: %v", err)
-	}
-	store := New(cfgPath)
 	srcDir := mustBuildV2PluginDir(t, dir, "github.com/test-org/test-repo/test-plugin", "1.0.0", "v2-install-test")
 
-	installed, err := store.InstallFromDir(srcDir)
+	dest := filepath.Join(dir, "plugins", "integration_test")
+	installed, err := InstallFromDir(srcDir, dest)
 	if err != nil {
 		t.Fatalf("InstallFromDir: %v", err)
 	}
@@ -347,14 +261,10 @@ func TestInstall_ArchiveArtifactDigestVerified(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "gestalt.yaml")
-	if err := os.WriteFile(cfgPath, []byte("server:\n  port: 8080\n"), 0644); err != nil {
-		t.Fatalf("WriteFile config: %v", err)
-	}
-	store := New(cfgPath)
 	pkg := mustBuildPackage(t, dir, "github.com/testowner/plugins/digcheck", "0.1.0", "correct-content")
 
-	installed, err := store.Install(pkg)
+	dest := filepath.Join(dir, "plugins", "integration_digcheck")
+	installed, err := Install(pkg, dest)
 	if err != nil {
 		t.Fatalf("Install: %v", err)
 	}
@@ -518,70 +428,6 @@ func mustBuildPackageWithDigest(t *testing.T, dir, source, version, content, dig
 	archivePath := filepath.Join(dir, filepath.Base(srcDir)+".tar.gz")
 	if err := pluginpkg.CreatePackageFromDir(srcDir, archivePath); err != nil {
 		t.Fatalf("CreatePackageFromDir: %v", err)
-	}
-	return archivePath
-}
-
-func mustBuildRawPackage(t *testing.T, dir, source, version, content string) string {
-	t.Helper()
-
-	artifactName := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider"))
-	sum := sha256.Sum256([]byte(content))
-	manifest := map[string]any{
-		"source":  source,
-		"version": version,
-		"kinds":   []string{pluginmanifestv1.KindProvider},
-		"provider": map[string]any{
-			"protocol": map[string]any{"min": 1, "max": 1},
-		},
-		"artifacts": []map[string]any{
-			{
-				"os":     runtime.GOOS,
-				"arch":   runtime.GOARCH,
-				"path":   artifactName,
-				"sha256": hex.EncodeToString(sum[:]),
-			},
-		},
-		"entrypoints": map[string]any{
-			"provider": map[string]any{
-				"artifact_path": artifactName,
-			},
-		},
-	}
-	manifestBytes, err := json.MarshalIndent(manifest, "", "  ")
-	if err != nil {
-		t.Fatalf("MarshalIndent: %v", err)
-	}
-	manifestBytes = append(manifestBytes, '\n')
-
-	archivePath := filepath.Join(dir, "raw-invalid.tar.gz")
-	out, err := os.Create(archivePath)
-	if err != nil {
-		t.Fatalf("Create archive: %v", err)
-	}
-	gzw := gzip.NewWriter(out)
-	tw := tar.NewWriter(gzw)
-
-	writeFile := func(name string, data []byte, mode int64) {
-		hdr := &tar.Header{Name: name, Mode: mode, Size: int64(len(data))}
-		if err := tw.WriteHeader(hdr); err != nil {
-			t.Fatalf("WriteHeader %s: %v", name, err)
-		}
-		if _, err := io.Copy(tw, bytes.NewReader(data)); err != nil {
-			t.Fatalf("Write file %s: %v", name, err)
-		}
-	}
-	writeFile(pluginpkg.ManifestFile, manifestBytes, 0644)
-	writeFile(artifactName, []byte(content), 0755)
-
-	if err := tw.Close(); err != nil {
-		t.Fatalf("close tar: %v", err)
-	}
-	if err := gzw.Close(); err != nil {
-		t.Fatalf("close gzip: %v", err)
-	}
-	if err := out.Close(); err != nil {
-		t.Fatalf("close archive: %v", err)
 	}
 	return archivePath
 }
@@ -763,70 +609,6 @@ func mustBuildV2Package(t *testing.T, dir, source, version, content string) stri
 	archivePath := filepath.Join(dir, safeName+".tar.gz")
 	if err := pluginpkg.CreatePackageFromDir(sourceDir, archivePath); err != nil {
 		t.Fatalf("CreatePackageFromDir: %v", err)
-	}
-	return archivePath
-}
-
-func mustBuildV2PackageRaw(t *testing.T, dir, source, version, content string) string {
-	t.Helper()
-
-	artifactName := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider"))
-	sum := sha256.Sum256([]byte(content))
-	manifest := map[string]any{
-		"source":  source,
-		"version": version,
-		"kinds":   []string{pluginmanifestv1.KindProvider},
-		"provider": map[string]any{
-			"protocol": map[string]any{"min": 1, "max": 1},
-		},
-		"artifacts": []map[string]any{
-			{
-				"os":     runtime.GOOS,
-				"arch":   runtime.GOARCH,
-				"path":   artifactName,
-				"sha256": hex.EncodeToString(sum[:]),
-			},
-		},
-		"entrypoints": map[string]any{
-			"provider": map[string]any{
-				"artifact_path": artifactName,
-			},
-		},
-	}
-	manifestBytes, err := json.MarshalIndent(manifest, "", "  ")
-	if err != nil {
-		t.Fatalf("MarshalIndent: %v", err)
-	}
-	manifestBytes = append(manifestBytes, '\n')
-
-	archivePath := filepath.Join(dir, "raw-v2.tar.gz")
-	out, err := os.Create(archivePath)
-	if err != nil {
-		t.Fatalf("Create archive: %v", err)
-	}
-	gzw := gzip.NewWriter(out)
-	tw := tar.NewWriter(gzw)
-
-	writeFile := func(name string, data []byte, mode int64) {
-		hdr := &tar.Header{Name: name, Mode: mode, Size: int64(len(data))}
-		if err := tw.WriteHeader(hdr); err != nil {
-			t.Fatalf("WriteHeader %s: %v", name, err)
-		}
-		if _, err := io.Copy(tw, bytes.NewReader(data)); err != nil {
-			t.Fatalf("Write file %s: %v", name, err)
-		}
-	}
-	writeFile(pluginpkg.ManifestFile, manifestBytes, 0644)
-	writeFile(artifactName, []byte(content), 0755)
-
-	if err := tw.Close(); err != nil {
-		t.Fatalf("close tar: %v", err)
-	}
-	if err := gzw.Close(); err != nil {
-		t.Fatalf("close gzip: %v", err)
-	}
-	if err := out.Close(); err != nil {
-		t.Fatalf("close archive: %v", err)
 	}
 	return archivePath
 }


### PR DESCRIPTION
The plugin store used a `Store` struct that computed destination
directories from the manifest's source and version fields, producing
deeply nested paths like `.gestalt/plugins/github.com/owner/repo/plugin/1.0.0/`.
This indirection provided no caching, deduplication, or cross-config
sharing, it was just an extraction target whose paths were immediately
written to the lockfile.

This replaces the `Store` struct with plain `Install` and
`InstallFromDir` functions that take an explicit destination directory.
The caller now computes a flat path based on the lock key, e.g.
`.gestalt/plugins/integration_slack/`. This removes the dependency on
manifest source parsing for directory naming and simplifies the overall
plugin lifecycle.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>