### PR TITLE
Make plugin package output directories by default

### DIFF
--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -174,7 +174,7 @@ COPY --from=gestaltd /gestaltd /usr/local/bin/gestaltd
 WORKDIR /src
 COPY . .
 RUN go build -o /tmp/myplugin ./plugins/cmd/myplugin && \
-    gestaltd plugin package --binary /tmp/myplugin --id example/myplugin --output ./deploy/plugins/myplugin.tar.gz && \
+    gestaltd plugin package --binary /tmp/myplugin --source github.com/example/myrepo/myplugin --output ./deploy/plugins/myplugin && \
     gestaltd bundle --config ./deploy/config.yaml --output /app
 ```
 

--- a/docs/pages/concepts/integrations.mdx
+++ b/docs/pages/concepts/integrations.mdx
@@ -192,7 +192,7 @@ A plugin-only integration delegates execution to an external binary:
 integrations:
   custom_tool:
     plugin:
-      package: ./custom-tool.tar.gz
+      package: ./custom-tool
 ```
 
 See the [Config File](/reference/config-file) reference for the full `plugin` field specification.

--- a/docs/pages/concepts/plugin-packaging.mdx
+++ b/docs/pages/concepts/plugin-packaging.mdx
@@ -62,18 +62,21 @@ Web UI manifests have no `artifacts` or `entrypoints` and cannot be combined wit
 Build a directory that contains `plugin.json` plus the referenced artifacts, then run:
 
 ```sh
-gestaltd plugin package --input ./build/example-provider --output ./dist/example-provider.tar.gz
+gestaltd plugin package --input ./build/example-provider --output ./dist/example-provider
 ```
 
-That creates a distributable archive.
+That copies the validated plugin directory to the output path. If you need an archive for remote distribution, use a `.tar.gz` output path:
+
+```sh
+gestaltd plugin package --input ./build/example-provider --output ./dist/example-provider.tar.gz
+```
 
 ## Using A Package In Config
 
 Packages can come from:
 
-- a local `.tar.gz`
 - a local directory
-- an HTTPS URL
+- an HTTPS URL (`.tar.gz`)
 
 Example:
 
@@ -81,18 +84,18 @@ Example:
 integrations:
   example:
     plugin:
-      package: https://example.com/example-provider.tar.gz
+      package: ./dist/example-provider
       config:
         greeting: hello
 ```
 
-or:
+or from a remote archive:
 
 ```yaml
 integrations:
   example:
     plugin:
-      package: ./dist/example-provider.tar.gz
+      package: https://example.com/example-provider.tar.gz
 ```
 
 Plain `http://` is rejected. Remote packages must use HTTPS.

--- a/docs/pages/concepts/ui-plugins.mdx
+++ b/docs/pages/concepts/ui-plugins.mdx
@@ -80,7 +80,7 @@ Then configure `ui.plugin.package: ./my-ui` with `asset_root: "out"` in the mani
 
 ## Publishing
 
-Package the plugin directory into an archive:
+Package the plugin directory into an archive for GitHub release:
 
 ```sh
 gestaltd plugin package --input ./my-ui-plugin --output gestalt-plugin-console_v1.0.0.tar.gz

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -258,7 +258,7 @@ gestaltd version
 | `gestaltd serve --locked` | Start the server. Fail if prepared state is missing or stale. |
 | `gestaltd bundle` | Resolve remote artifacts and packaged plugins into a self-contained output directory. |
 | `gestaltd validate` | Load and validate config without starting the server. |
-| `gestaltd plugin package` | Build a distributable plugin archive. |
+| `gestaltd plugin package` | Package a plugin directory or binary. |
 | `gestaltd version` | Print the binary version and exit. |
 
 ## Default Command Behavior
@@ -336,7 +336,7 @@ Two packaging flows:
 Package an existing plugin directory that already contains a `plugin.json` manifest:
 
 ```sh
-gestaltd plugin package --input ./build/my-plugin --output ./dist/my-plugin.tar.gz
+gestaltd plugin package --input ./build/my-plugin --output ./dist/my-plugin
 ```
 
 ### From a pre-built binary
@@ -347,14 +347,16 @@ Scaffold a manifest and package a binary in one step:
 gestaltd plugin package \
   --binary ./my-plugin \
   --source github.com/myorg/my-repo/my-plugin \
-  --output ./my-plugin.tar.gz
+  --output ./dist/my-plugin
 ```
+
+Output format is determined by the `--output` path: paths ending in `.tar.gz` produce an archive for remote distribution, all other paths produce a directory.
 
 | Flag | Default | Purpose |
 | --- | --- | --- |
 | `--binary` | — | Path to pre-built binary. |
 | `--source` | — | Plugin source identifier (`github.com/owner/repo/plugin`). Required with `--binary`. |
-| `--output` | — | Path to write the `.tar.gz` archive. |
+| `--output` | — | Output path (directory, or `.tar.gz` for archive). |
 | `--kind` | `provider` | Plugin kind: `provider` or `runtime`. |
 | `--os` | Current platform | Target OS for the artifact. |
 | `--arch` | Current platform | Target architecture. |
@@ -368,5 +370,5 @@ gestaltd plugin package \
   --binary ./my-plugin-linux \
   --source github.com/myorg/my-repo/my-plugin \
   --os linux --arch amd64 \
-  --output ./my-plugin.tar.gz
+  --output ./dist/my-plugin
 ```

--- a/docs/pages/tasks/use-a-plugin-package.mdx
+++ b/docs/pages/tasks/use-a-plugin-package.mdx
@@ -8,7 +8,7 @@ Packaged plugins are the deployment-oriented way to run executable providers and
 integrations:
   acme:
     plugin:
-      package: ./plugins/acme-provider.tar.gz
+      package: ./plugins/acme-provider
       config:
         endpoint: https://api.example.com
 ```
@@ -16,8 +16,7 @@ integrations:
 `plugin.package` accepts:
 
 - a local directory
-- a local `.tar.gz`
-- an HTTPS URL
+- an HTTPS URL (`.tar.gz`)
 
 ## Bundle It
 

--- a/docs/pages/tasks/write-a-plugin.mdx
+++ b/docs/pages/tasks/write-a-plugin.mdx
@@ -80,13 +80,13 @@ go build -o ./my-tool .
 
 ## Package
 
-Package the binary directly into a distributable archive:
+Package the binary into a plugin directory:
 
 ```sh
 gestaltd plugin package \
   --binary ./my-tool \
   --source github.com/myorg/my-repo/my-tool \
-  --output ./my-tool.tar.gz
+  --output ./dist/my-tool
 ```
 
 The `--os` and `--arch` flags default to your current platform. For cross-compilation:
@@ -97,8 +97,10 @@ gestaltd plugin package \
   --binary ./my-tool-linux \
   --source github.com/myorg/my-repo/my-tool \
   --os linux --arch amd64 \
-  --output ./my-tool.tar.gz
+  --output ./dist/my-tool
 ```
+
+For remote distribution, use a `.tar.gz` output path to produce an archive instead.
 
 ## Configure and run
 
@@ -108,7 +110,7 @@ Reference the package in your Gestalt config:
 integrations:
   my-tool:
     plugin:
-      package: ./my-tool.tar.gz
+      package: ./dist/my-tool
 ```
 
 Then bundle and serve:

--- a/examples/deploy/Dockerfile.plugins
+++ b/examples/deploy/Dockerfile.plugins
@@ -1,12 +1,12 @@
 # Example: deploying Gestalt with custom Go plugins.
 #
 # This demonstrates the full plugin deployment pipeline: compile Go plugin
-# binaries, package them as Gestalt plugin archives, and bundle everything
+# binaries, package them into plugin directories, and bundle everything
 # into a locked, self-contained deployment artifact.
 #
 # Prerequisites:
 #   - Plugin source code in ./plugins/cmd/<name>/
-#   - Deployment config at ./deploy/config.yaml referencing plugin archives
+#   - Deployment config at ./deploy/config.yaml referencing plugin directories
 #   - For private repos: a GitHub token in token.txt
 #
 # Build:
@@ -25,7 +25,7 @@ RUN --mount=type=secret,id=github_token \
       git config --global url."https://x-access-token:$(cat /run/secrets/github_token)@github.com/".insteadOf "https://github.com/"; \
     fi && \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /tmp/myplugin ./plugins/cmd/myplugin && \
-    gestaltd plugin package --binary /tmp/myplugin --id example/myplugin --output ./deploy/plugins/myplugin.tar.gz && \
+    gestaltd plugin package --binary /tmp/myplugin --source github.com/example/myrepo/myplugin --output ./deploy/plugins/myplugin && \
     gestaltd bundle --config ./deploy/config.yaml --output /app
 
 FROM valontechnologies/gestaltd:latest

--- a/server/cmd/gestaltd/plugin.go
+++ b/server/cmd/gestaltd/plugin.go
@@ -37,7 +37,7 @@ func runPluginPackage(args []string) error {
 	fs := flag.NewFlagSet("gestaltd plugin package", flag.ContinueOnError)
 	fs.Usage = func() { printPluginPackageUsage(fs.Output()) }
 	input := fs.String("input", "", "path to plugin manifest or build directory")
-	output := fs.String("output", "", "path to write the packaged archive")
+	output := fs.String("output", "", "output path (directory, or .tar.gz for archive)")
 	binary := fs.String("binary", "", "path to pre-built binary (scaffolds manifest automatically)")
 	source := fs.String("source", "", "plugin source (github.com/owner/repo/plugin), required with --binary")
 	kind := fs.String("kind", "provider", "plugin kind (provider or runtime), used with --binary")
@@ -72,8 +72,14 @@ func packageFromDir(input, output string) error {
 		sourceDir = filepath.Dir(input)
 	}
 
-	if err := pluginpkg.CreatePackageFromDir(sourceDir, output); err != nil {
-		return err
+	if isArchiveOutput(output) {
+		if err := pluginpkg.CreatePackageFromDir(sourceDir, output); err != nil {
+			return err
+		}
+	} else {
+		if err := pluginpkg.CopyPackageDir(sourceDir, output); err != nil {
+			return err
+		}
 	}
 	_, _ = fmt.Fprintf(os.Stdout, "packaged %s -> %s\n", sourceDir, output)
 	return nil
@@ -97,14 +103,24 @@ func packageFromBinary(binaryPath, source, kind, version, targetOS, targetArch, 
 		return fmt.Errorf("invalid --version for source plugin: %w", err)
 	}
 
-	workDir, err := os.MkdirTemp("", "gestalt-plugin-pkg-*")
-	if err != nil {
-		return err
+	scaffoldDir := output
+	var cleanup func()
+	if isArchiveOutput(output) {
+		tmp, err := os.MkdirTemp("", "gestalt-plugin-pkg-*")
+		if err != nil {
+			return err
+		}
+		cleanup = func() { _ = os.RemoveAll(tmp) }
+		defer cleanup()
+		scaffoldDir = tmp
+	} else {
+		if err := os.MkdirAll(output, 0755); err != nil {
+			return fmt.Errorf("create output dir: %w", err)
+		}
 	}
-	defer func() { _ = os.RemoveAll(workDir) }()
 
 	artifactRel := filepath.ToSlash(filepath.Join("artifacts", targetOS, targetArch, kind))
-	artifactAbs := filepath.Join(workDir, filepath.FromSlash(artifactRel))
+	artifactAbs := filepath.Join(scaffoldDir, filepath.FromSlash(artifactRel))
 
 	if err := os.MkdirAll(filepath.Dir(artifactAbs), 0755); err != nil {
 		return err
@@ -120,12 +136,14 @@ func packageFromBinary(binaryPath, source, kind, version, targetOS, targetArch, 
 	if err != nil {
 		return fmt.Errorf("encoding manifest: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(workDir, pluginpkg.ManifestFile), data, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(scaffoldDir, pluginpkg.ManifestFile), data, 0644); err != nil {
 		return fmt.Errorf("writing manifest: %w", err)
 	}
 
-	if err := pluginpkg.CreatePackageFromDir(workDir, output); err != nil {
-		return err
+	if isArchiveOutput(output) {
+		if err := pluginpkg.CreatePackageFromDir(scaffoldDir, output); err != nil {
+			return err
+		}
 	}
 	_, _ = fmt.Fprintf(os.Stdout, "packaged %s (%s) -> %s\n", source, binaryPath, output)
 	return nil
@@ -193,6 +211,10 @@ func copyAndDigest(src, dst string) (string, error) {
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
+func isArchiveOutput(path string) bool {
+	return strings.HasSuffix(path, ".tar.gz") || strings.HasSuffix(path, ".tgz")
+}
+
 func printPluginUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
 	writeUsageLine(w, "  gestaltd plugin <command> [flags]")
@@ -210,9 +232,12 @@ func printPluginPackageUsage(w io.Writer) {
 	writeUsageLine(w, "directory containing a manifest, or --binary to scaffold and package")
 	writeUsageLine(w, "a pre-built binary in one step.")
 	writeUsageLine(w, "")
+	writeUsageLine(w, "Output format is determined by the --output path: paths ending in")
+	writeUsageLine(w, ".tar.gz produce an archive, all other paths produce a directory.")
+	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --input     Path to plugin manifest or build directory")
-	writeUsageLine(w, "  --output    Path to write the packaged archive")
+	writeUsageLine(w, "  --output    Output path (directory, or .tar.gz for archive)")
 	writeUsageLine(w, "  --binary    Path to pre-built binary (scaffolds manifest automatically)")
 	writeUsageLine(w, "  --source    Plugin source (github.com/owner/repo/plugin), required with --binary")
 	writeUsageLine(w, "  --kind      Plugin kind: provider or runtime (default: provider)")

--- a/server/cmd/gestaltd/plugin_test.go
+++ b/server/cmd/gestaltd/plugin_test.go
@@ -103,6 +103,99 @@ func TestRun_PluginPackageFromBinaryWithSource(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // Swaps os.Stdout via captureStdout.
+func TestRun_PluginPackageCreatesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	src := newPluginPackageFixture(t, dir)
+	outPath := filepath.Join(dir, "output-dir")
+
+	output := captureStdout(t, func() error {
+		return run([]string{"plugin", "package", "--input", src, "--output", outPath})
+	})
+
+	info, err := os.Stat(outPath)
+	if err != nil {
+		t.Fatalf("expected output directory to exist: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("expected output to be a directory")
+	}
+	manifestPath := filepath.Join(outPath, "plugin.json")
+	if _, err := os.Stat(manifestPath); err != nil {
+		t.Fatalf("expected manifest in output directory: %v", err)
+	}
+	artifactPath := filepath.Join(outPath, "artifacts", runtime.GOOS, runtime.GOARCH, "provider")
+	data, err := os.ReadFile(artifactPath)
+	if err != nil {
+		t.Fatalf("expected artifact in output directory: %v", err)
+	}
+	if string(data) != "provider" {
+		t.Fatalf("unexpected artifact content: %q", data)
+	}
+	if !strings.Contains(output, "packaged") {
+		t.Fatalf("expected packaged output, got: %q", output)
+	}
+}
+
+//nolint:paralleltest // Swaps os.Stdout via captureStdout.
+func TestRun_PluginPackageFromBinaryCreatesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "my-provider")
+	if err := os.WriteFile(binaryPath, []byte("fake-binary-content"), 0755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	outPath := filepath.Join(dir, "my-plugin-dir")
+
+	output := captureStdout(t, func() error {
+		return run([]string{
+			"plugin", "package",
+			"--binary", binaryPath,
+			"--source", "github.com/testorg/testrepo/testplugin",
+			"--version", "1.0.0",
+			"--output", outPath,
+		})
+	})
+
+	info, err := os.Stat(outPath)
+	if err != nil {
+		t.Fatalf("expected output directory to exist: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("expected output to be a directory")
+	}
+	manifestPath := filepath.Join(outPath, "plugin.json")
+	if _, err := os.Stat(manifestPath); err != nil {
+		t.Fatalf("expected manifest in output directory: %v", err)
+	}
+	artifactPath := filepath.Join(outPath, "artifacts", runtime.GOOS, runtime.GOARCH, "provider")
+	data, err := os.ReadFile(artifactPath)
+	if err != nil {
+		t.Fatalf("expected artifact in output directory: %v", err)
+	}
+	if string(data) != "fake-binary-content" {
+		t.Fatalf("unexpected artifact content: %q", data)
+	}
+	if !strings.Contains(output, "packaged") {
+		t.Fatalf("expected packaged output, got: %q", output)
+	}
+}
+
+func TestRun_PluginPackageRejectsOutputInsideInput(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := newPluginPackageFixture(t, dir)
+	outPath := filepath.Join(src, "dist")
+
+	err := run([]string{"plugin", "package", "--input", src, "--output", outPath})
+	if err == nil {
+		t.Fatal("expected error when output is inside input")
+	}
+	if !strings.Contains(err.Error(), "must not be inside source") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRun_PluginRejectsUnknownSubcommand(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/pluginpkg/archive.go
+++ b/server/internal/pluginpkg/archive.go
@@ -79,6 +79,51 @@ func LoadManifestFromPath(inputPath string) ([]byte, *pluginmanifestv1.Manifest,
 	return data, manifest, inputPath, err
 }
 
+func CopyPackageDir(sourceDir, destDir string) error {
+	sourceDir = filepath.Clean(sourceDir)
+	if _, err := ValidatePackageDir(sourceDir); err != nil {
+		return err
+	}
+	destDir = filepath.Clean(destDir)
+	if rel, err := filepath.Rel(sourceDir, destDir); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("output directory %q must not be inside source directory %q", destDir, sourceDir)
+	}
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+	return filepath.WalkDir(sourceDir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(sourceDir, p)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(destDir, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		src, err := os.Open(p)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = src.Close() }()
+		dst, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode())
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(dst, src); err != nil {
+			_ = dst.Close()
+			return err
+		}
+		return dst.Close()
+	})
+}
+
 func CreatePackageFromDir(sourceDir, outputPath string) (err error) {
 	sourceDir = filepath.Clean(sourceDir)
 	if _, err := ValidatePackageDir(sourceDir); err != nil {


### PR DESCRIPTION
`gestaltd plugin package` now outputs a directory instead of a tar.gz
archive when the `--output` path does not end in `.tar.gz`. This
eliminates the unnecessary intermediate archive step for local plugins,
where the flow was previously build, archive, then immediately extract.
Plugins can now go straight from directory to the plugin store. Archives
remain supported for remote distribution via GitHub releases or HTTPS.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>