### PR TITLE
Limit docs "On this page" TOC to h2–h3 headings

### DIFF
--- a/docs/globals.css
+++ b/docs/globals.css
@@ -15,3 +15,11 @@
     width: 12rem;
   }
 }
+
+/* Limit "On this page" TOC to h2–h3 only.
+   Nextra applies _ms-8 / _ms-12 / _ms-16 to depths 4 / 5 / 6. */
+nav[aria-label="table of contents"] li:has(> a._ms-8),
+nav[aria-label="table of contents"] li:has(> a._ms-12),
+nav[aria-label="table of contents"] li:has(> a._ms-16) {
+  display: none;
+}


### PR DESCRIPTION
The auto-generated CLI reference uses h6 headings for subsections like "Subcommands" and "Options", which cluttered the TOC sidebar. This hides h4–h6 entries by targeting the depth-based margin classes Nextra applies to TOC links.