### PR TITLE
Fix Helm chart image default and add OCI publishing

### DIFF
--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   build-frontend:
@@ -166,8 +167,8 @@ jobs:
           readme-filepath: docs/dockerhub/gestaltd.md
 
   update-formula:
-    name: Update Homebrew Formula
-    needs: release
+    name: Update Homebrew Formula, Chart & OCI Publish
+    needs: [release, publish-image]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -230,12 +231,27 @@ jobs:
         run: |
           grep -q "version \"${VERSION}\"" Formula/gestaltd.rb
           echo "Formula verified"
+      - name: Update Helm chart version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          CHART="server/deploy/helm/gestalt/Chart.yaml"
+          sed -i "s/^version:.*/version: ${VERSION}/" "$CHART"
+          sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" "$CHART"
+      - uses: azure/setup-helm@v4
+      - name: Package and push Helm chart to GHCR
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          helm package server/deploy/helm/gestalt --destination /tmp/charts
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+          helm push /tmp/charts/gestalt-${VERSION}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
       - name: Commit and push
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Formula/gestaltd.rb
-          git diff --cached --quiet && { echo "No formula changes"; exit 0; }
-          git commit -m "Update gestaltd formula to v${{ steps.version.outputs.version }}"
+          git add Formula/gestaltd.rb server/deploy/helm/gestalt/Chart.yaml
+          git diff --cached --quiet && { echo "No changes"; exit 0; }
+          git commit -m "Update gestaltd formula and chart to v${{ steps.version.outputs.version }}"
           git pull --rebase origin main
           git push

--- a/docs/pages/deploy/kubernetes.mdx
+++ b/docs/pages/deploy/kubernetes.mdx
@@ -106,9 +106,21 @@ pluginInit:
 
 ## Install
 
+From the OCI registry (recommended):
+
+```sh
+helm upgrade --install gestalt oci://ghcr.io/valon-technologies/charts/gestalt \
+  --version 0.0.1-alpha.16 \
+  -f values.yaml
+```
+
+Or from a local checkout of the repo:
+
 ```sh
 helm upgrade --install gestalt ./server/deploy/helm/gestalt -f values.yaml
 ```
+
+The GHCR registry inherits the visibility of the GitHub repository. Authenticate with `helm registry login ghcr.io` if the repo is private.
 
 If you use ingress, make sure `config.server.base_url` matches the public URL exactly. That is what Gestalt uses for callback derivation.
 

--- a/server/deploy/helm/gestalt/values.yaml
+++ b/server/deploy/helm/gestalt/values.yaml
@@ -3,7 +3,7 @@
 replicaCount: 1
 
 image:
-  repository: gestaltd
+  repository: valontechnologies/gestaltd
   pullPolicy: IfNotPresent
   tag: ""
 


### PR DESCRIPTION
The Helm chart's default image repository was `gestaltd`, which resolves to a nonexistent Docker Hub library image. This fixes it to `valontechnologies/gestaltd`. The release workflow now also packages and pushes the chart to GHCR as a private OCI artifact, and the formula-update job bumps `Chart.yaml` in the same commit so the chart version stays in sync with server releases going forward.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>