### PR TITLE
Restore mcp_oauth and response_mapping for inline plugins

### DIFF
--- a/server/internal/bootstrap/bootstrap.go
+++ b/server/internal/bootstrap/bootstrap.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -15,6 +16,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	graphqlupstream "github.com/valon-technologies/gestalt/server/internal/graphql"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/mcpoauth"
 	"github.com/valon-technologies/gestalt/server/internal/mcpupstream"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
 	"github.com/valon-technologies/gestalt/server/internal/openapi"
@@ -616,10 +618,45 @@ func buildDatastore(cfg *config.Config, factories *FactoryRegistry, deps Deps) (
 	return ds, nil
 }
 
+func buildRegistrationStore(deps Deps) mcpoauth.RegistrationStore {
+	db, ok := deps.SQLDB.(*sql.DB)
+	if !ok || db == nil {
+		return nil
+	}
+	dialect, ok := deps.SQLDialect.(mcpoauth.SQLDialect)
+	if !ok || dialect == nil {
+		return nil
+	}
+	enc, err := crypto.NewAESGCM(deps.EncryptionKey)
+	if err != nil {
+		slog.Warn("cannot create encryptor for registration store", "component", "mcpoauth", "error", err)
+		return nil
+	}
+	store := mcpoauth.NewSQLStore(db, enc, dialect)
+	if err := store.Migrate(context.Background()); err != nil {
+		slog.Error("registration store migration failed", "component", "mcpoauth", "error", err)
+	}
+	return store
+}
+
+type lazyRegStore struct {
+	once  sync.Once
+	store mcpoauth.RegistrationStore
+	deps  Deps
+}
+
+func (l *lazyRegStore) get() mcpoauth.RegistrationStore {
+	l.once.Do(func() {
+		l.store = buildRegistrationStore(l.deps)
+	})
+	return l.store
+}
+
 func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.PluginMap[core.Provider], <-chan struct{}, func() map[string]map[string]OAuthHandler, error) {
 	reg := registry.New()
 	connAuth := make(map[string]map[string]OAuthHandler)
 	var connMu sync.Mutex
+	regStore := &lazyRegStore{deps: deps}
 
 	for _, builtin := range factories.Builtins {
 		if err := reg.Providers.Register(builtin.Name(), builtin); errors.Is(err, core.ErrAlreadyRegistered) {
@@ -642,7 +679,7 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			result, err := buildProvider(ctx, name, intgDef, factories, deps)
+			result, err := buildProvider(ctx, name, intgDef, factories, deps, regStore)
 			if err != nil {
 				slog.Warn("skipping provider", "provider", name, "error", err)
 				return
@@ -675,17 +712,17 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 	return &reg.Providers, ready, resolver, nil
 }
 
-func buildProvider(ctx context.Context, name string, intg config.IntegrationDef, factories *FactoryRegistry, deps Deps) (*ProviderBuildResult, error) {
+func buildProvider(ctx context.Context, name string, intg config.IntegrationDef, factories *FactoryRegistry, deps Deps, regStore *lazyRegStore) (*ProviderBuildResult, error) {
 	if intg.Plugin == nil {
 		return nil, fmt.Errorf("integration %q has no plugin defined", name)
 	}
 
 	if intg.Plugin.IsInline() {
-		return buildInlineProvider(ctx, name, intg, deps)
+		return buildInlineProvider(ctx, name, intg, deps, regStore)
 	}
 
 	if intg.Plugin.IsDeclarative {
-		return buildDeclarativeProvider(name, intg, deps)
+		return buildDeclarativeProvider(name, intg, deps, regStore)
 	}
 
 	pluginProv, pluginConfig, err := buildPluginProvider(ctx, name, intg)
@@ -707,7 +744,7 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 	return buildResult, nil
 }
 
-func buildInlineProvider(ctx context.Context, name string, intg config.IntegrationDef, deps Deps) (*ProviderBuildResult, error) {
+func buildInlineProvider(ctx context.Context, name string, intg config.IntegrationDef, deps Deps, regStore *lazyRegStore) (*ProviderBuildResult, error) {
 	manifest, err := config.InlineToManifest(name, intg.Plugin)
 	if err != nil {
 		return nil, fmt.Errorf("convert inline plugin %q to manifest: %w", name, err)
@@ -719,7 +756,7 @@ func buildInlineProvider(ctx context.Context, name string, intg config.Integrati
 		manifest.Description = intg.Description
 	}
 	if manifest.Provider.IsSpecLoaded() {
-		return buildSpecLoadedProvider(ctx, name, intg, manifest, deps)
+		return buildSpecLoadedProvider(ctx, name, intg, manifest, deps, regStore)
 	}
 	prov, err := pluginhost.NewDeclarativeProvider(manifest, nil)
 	if err != nil {
@@ -733,13 +770,21 @@ func buildInlineProvider(ctx context.Context, name string, intg config.Integrati
 	}
 
 	result := &ProviderBuildResult{Provider: restricted}
-	if err := attachManifestOAuth(name, intg, manifest, deps, result); err != nil {
+	if err := attachManifestOAuth(name, intg, manifest, deps, regStore, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func buildSpecLoadedProvider(ctx context.Context, name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, deps Deps) (*ProviderBuildResult, error) {
+func mcpOAuthBuildOpts(conn config.ConnectionDef, mp *pluginmanifestv1.Provider, regStore *lazyRegStore, deps Deps) []provider.BuildOption {
+	if conn.Auth.Type != pluginmanifestv1.AuthTypeMCPOAuth || mp.MCPURL == "" {
+		return nil
+	}
+	handler := buildMCPOAuthHandler(conn, mp.MCPURL, regStore.get(), deps)
+	return []provider.BuildOption{provider.WithAuthHandler(handler)}
+}
+
+func buildSpecLoadedProvider(ctx context.Context, name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, deps Deps, regStore *lazyRegStore) (*ProviderBuildResult, error) {
 	mp := manifest.Provider
 
 	allowedOps := convertAllowedOperations(mp.AllowedOperations)
@@ -754,12 +799,13 @@ func buildSpecLoadedProvider(ctx context.Context, name string, intg config.Integ
 		if mp.BaseURL != "" {
 			def.BaseURL = mp.BaseURL
 		}
+		applyManifestResponseMapping(def, mp)
 		provider.ApplyDisplayOverrides(def, intg)
-		prov, err := provider.Build(def, conn, nil)
+		prov, err := provider.Build(def, conn, nil, mcpOAuthBuildOpts(conn, mp, regStore, deps)...)
 		if err != nil {
 			return nil, fmt.Errorf("build openapi provider %q: %w", name, err)
 		}
-		return specLoadedResult(name, intg, manifest, prov, deps)
+		return specLoadedResult(name, intg, manifest, prov, deps, regStore)
 
 	case mp.GraphQLURL != "":
 		def, err := graphqlupstream.LoadDefinition(ctx, name, mp.GraphQLURL, allowedOps)
@@ -769,12 +815,13 @@ func buildSpecLoadedProvider(ctx context.Context, name string, intg config.Integ
 		if mp.BaseURL != "" {
 			def.BaseURL = mp.BaseURL
 		}
+		applyManifestResponseMapping(def, mp)
 		provider.ApplyDisplayOverrides(def, intg)
-		prov, err := provider.Build(def, conn, nil)
+		prov, err := provider.Build(def, conn, nil, mcpOAuthBuildOpts(conn, mp, regStore, deps)...)
 		if err != nil {
 			return nil, fmt.Errorf("build graphql provider %q: %w", name, err)
 		}
-		return specLoadedResult(name, intg, manifest, prov, deps)
+		return specLoadedResult(name, intg, manifest, prov, deps, regStore)
 
 	case mp.MCPURL != "":
 		connMode := core.ConnectionMode(conn.Mode)
@@ -791,7 +838,7 @@ func buildSpecLoadedProvider(ctx context.Context, name string, intg config.Integ
 				return nil, fmt.Errorf("filter mcp operations for %q: %w", name, err)
 			}
 		}
-		result, resultErr := specLoadedResult(name, intg, manifest, up, deps)
+		result, resultErr := specLoadedResult(name, intg, manifest, up, deps, regStore)
 		if resultErr != nil {
 			_ = up.Close()
 			return nil, resultErr
@@ -803,10 +850,10 @@ func buildSpecLoadedProvider(ctx context.Context, name string, intg config.Integ
 	}
 }
 
-func specLoadedResult(name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, prov core.Provider, deps Deps) (*ProviderBuildResult, error) {
+func specLoadedResult(name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, prov core.Provider, deps Deps, regStore *lazyRegStore) (*ProviderBuildResult, error) {
 	applyPluginIcon(prov, intg)
 	result := &ProviderBuildResult{Provider: prov}
-	if err := attachManifestOAuth(name, intg, manifest, deps, result); err != nil {
+	if err := attachManifestOAuth(name, intg, manifest, deps, regStore, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -842,7 +889,7 @@ func pluginConnectionDef(plugin *config.PluginDef) config.ConnectionDef {
 	return conn
 }
 
-func buildDeclarativeProvider(name string, intg config.IntegrationDef, deps Deps) (*ProviderBuildResult, error) {
+func buildDeclarativeProvider(name string, intg config.IntegrationDef, deps Deps, regStore *lazyRegStore) (*ProviderBuildResult, error) {
 	if intg.Plugin == nil || intg.Plugin.ResolvedManifestPath == "" {
 		return nil, fmt.Errorf("declarative provider %q has no resolved manifest path", name)
 	}
@@ -861,7 +908,7 @@ func buildDeclarativeProvider(name string, intg config.IntegrationDef, deps Deps
 		return nil, err
 	}
 	result := &ProviderBuildResult{Provider: restricted}
-	if err := attachManifestOAuth(name, intg, manifest, deps, result); err != nil {
+	if err := attachManifestOAuth(name, intg, manifest, deps, regStore, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -945,25 +992,44 @@ func applyPluginIcon(prov core.Provider, intg config.IntegrationDef) {
 	}
 }
 
-func attachManifestOAuth(name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, deps Deps, result *ProviderBuildResult) error {
-	if manifest.Provider == nil || manifest.Provider.Auth == nil ||
-		manifest.Provider.Auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
+func attachManifestOAuth(name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, deps Deps, regStore *lazyRegStore, result *ProviderBuildResult) error {
+	if manifest.Provider == nil || manifest.Provider.Auth == nil {
 		return nil
 	}
-	pluginConfig, err := config.NodeToMap(intg.Plugin.Config)
-	if err != nil {
-		return fmt.Errorf("decode plugin config for %q: %w", name, err)
-	}
-	authHandler, err := buildOAuthHandlerFromManifest(manifest, pluginConfig, deps)
-	if err != nil {
-		slog.Warn("cannot build oauth handler from manifest", "provider", name, "error", err)
-		return nil
-	}
-	if authHandler != nil {
+
+	switch manifest.Provider.Auth.Type {
+	case pluginmanifestv1.AuthTypeOAuth2:
+		pluginConfig, err := config.NodeToMap(intg.Plugin.Config)
+		if err != nil {
+			return fmt.Errorf("decode plugin config for %q: %w", name, err)
+		}
+		authHandler, err := buildOAuthHandlerFromManifest(manifest, pluginConfig, deps)
+		if err != nil {
+			slog.Warn("cannot build oauth handler from manifest", "provider", name, "error", err)
+			return nil
+		}
+		if authHandler != nil {
+			result.ConnectionAuth = map[string]OAuthHandler{
+				config.PluginConnectionName: authHandler,
+			}
+		}
+
+	case pluginmanifestv1.AuthTypeMCPOAuth:
+		mcpURL := manifest.Provider.MCPURL
+		if mcpURL == "" && intg.Plugin != nil {
+			mcpURL = intg.Plugin.MCPURL
+		}
+		if mcpURL == "" {
+			slog.Warn("mcp_oauth auth requires mcp_url", "provider", name)
+			return nil
+		}
+		conn := pluginConnectionDef(intg.Plugin)
+		handler := buildMCPOAuthHandler(conn, mcpURL, regStore.get(), deps)
 		result.ConnectionAuth = map[string]OAuthHandler{
-			config.PluginConnectionName: authHandler,
+			config.PluginConnectionName: handler,
 		}
 	}
+
 	return nil
 }
 
@@ -1049,6 +1115,36 @@ func buildOAuthHandlerFromManifest(manifest *pluginmanifestv1.Manifest, pluginCo
 
 	handler := oauth.NewUpstream(oauthCfg)
 	return WrapUpstreamHandler(handler), nil
+}
+
+func buildMCPOAuthHandler(conn config.ConnectionDef, mcpURL string, store mcpoauth.RegistrationStore, deps Deps) *mcpoauth.Handler {
+	redirectURL := conn.Auth.RedirectURL
+	if redirectURL == "" {
+		redirectURL = deps.BaseURL + config.IntegrationCallbackPath
+	}
+	return mcpoauth.NewHandler(mcpoauth.HandlerConfig{
+		MCPURL:       mcpURL,
+		Store:        store,
+		RedirectURL:  redirectURL,
+		ClientID:     conn.Auth.ClientID,
+		ClientSecret: conn.Auth.ClientSecret,
+	})
+}
+
+func applyManifestResponseMapping(def *provider.Definition, mp *pluginmanifestv1.Provider) {
+	if mp.ResponseMapping == nil {
+		return
+	}
+	rm := &provider.ResponseMappingDef{
+		DataPath: mp.ResponseMapping.DataPath,
+	}
+	if mp.ResponseMapping.Pagination != nil {
+		rm.Pagination = &provider.PaginationMappingDef{
+			HasMorePath: mp.ResponseMapping.Pagination.HasMorePath,
+			CursorPath:  mp.ResponseMapping.Pagination.CursorPath,
+		}
+	}
+	def.ResponseMapping = rm
 }
 
 func BuildConnectionMap(cfg *config.Config) invocation.ConnectionMap {

--- a/server/internal/bootstrap/inline_gaps_test.go
+++ b/server/internal/bootstrap/inline_gaps_test.go
@@ -1,0 +1,304 @@
+package bootstrap_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+func serveMCPOAuthEndpoints(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /mcp", func(w http.ResponseWriter, r *http.Request) {
+		baseURL := "http://" + r.Host
+		w.Header().Set("WWW-Authenticate", fmt.Sprintf(
+			`Bearer resource_metadata="%s/.well-known/oauth-protected-resource/mcp"`, baseURL))
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	mux.HandleFunc("GET /.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
+		baseURL := "http://" + r.Host
+		writeTestJSON(w, map[string]any{
+			"resource":              baseURL + "/mcp",
+			"authorization_servers": []string{baseURL},
+			"scopes_supported":      []string{"read", "write"},
+		})
+	})
+	mux.HandleFunc("GET /.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		baseURL := "http://" + r.Host
+		writeTestJSON(w, map[string]any{
+			"issuer":                                baseURL,
+			"authorization_endpoint":                baseURL + "/oauth/authorize",
+			"token_endpoint":                        baseURL + "/oauth/token",
+			"registration_endpoint":                 baseURL + "/oauth/register",
+			"scopes_supported":                      []string{"read", "write"},
+			"code_challenge_methods_supported":      []string{"S256"},
+			"token_endpoint_auth_methods_supported": []string{"client_secret_post"},
+		})
+	})
+	mux.HandleFunc("POST /oauth/register", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"client_id": "dcr-test-client",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	testutil.CloseOnCleanup(t, srv)
+	return srv
+}
+
+func writeTestJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func serveOpenAPISpec(t *testing.T) *httptest.Server {
+	t.Helper()
+	spec := map[string]any{
+		"openapi": "3.0.0",
+		"info":    map[string]string{"title": "Test API"},
+		"servers": []any{map[string]string{"url": "https://api.test.example/v1"}},
+		"paths": map[string]any{
+			"/items": map[string]any{
+				"get": map[string]any{
+					"operationId": "list_items",
+					"summary":     "List items",
+				},
+			},
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(spec)
+	}))
+	testutil.CloseOnCleanup(t, srv)
+	return srv
+}
+
+func TestInlineMCPOAuth_ConnectionAuthWired(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	mcpSrv := serveMCPOAuthEndpoints(t)
+
+	cfg := validConfig()
+	cfg.Integrations = map[string]config.IntegrationDef{
+		"alpha": {
+			Plugin: &config.PluginDef{
+				BaseURL: "https://api.test.example",
+				MCPURL:  mcpSrv.URL + "/mcp",
+				Auth: &config.ConnectionAuthDef{
+					Type:         "mcp_oauth",
+					ClientID:     "test-id",
+					ClientSecret: "test-secret",
+				},
+				Operations: []config.InlineOperationDef{
+					{Name: "do_thing", Method: "POST", Path: "/things"},
+				},
+			},
+		},
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	connAuth := result.ConnectionAuth()
+	alphaAuth, ok := connAuth["alpha"]
+	if !ok {
+		t.Fatal("expected connection auth for alpha integration")
+	}
+	handler, ok := alphaAuth[config.PluginConnectionName]
+	if !ok {
+		t.Fatalf("expected handler for connection %q", config.PluginConnectionName)
+	}
+
+	authURL, verifier := handler.StartOAuth("test-state", nil)
+	if authURL == "" {
+		t.Fatal("expected non-empty authorization URL from mcp_oauth handler")
+	}
+	if verifier == "" {
+		t.Fatal("expected non-empty PKCE verifier from mcp_oauth handler")
+	}
+}
+
+func TestInlineMCPOAuth_SpecLoadedOpenAPI(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	mcpSrv := serveMCPOAuthEndpoints(t)
+	specSrv := serveOpenAPISpec(t)
+
+	cfg := validConfig()
+	cfg.Integrations = map[string]config.IntegrationDef{
+		"vendor": {
+			Plugin: &config.PluginDef{
+				OpenAPI: specSrv.URL,
+				MCPURL:  mcpSrv.URL + "/mcp",
+				Auth: &config.ConnectionAuthDef{
+					Type:         "mcp_oauth",
+					ClientID:     "vendor-id",
+					ClientSecret: "vendor-secret",
+				},
+			},
+		},
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	prov, err := result.Providers.Get("vendor")
+	if err != nil {
+		t.Fatalf("Get vendor provider: %v", err)
+	}
+	ops := prov.ListOperations()
+	if len(ops) == 0 {
+		t.Fatal("expected at least one operation from the openapi spec")
+	}
+
+	connAuth := result.ConnectionAuth()
+	vendorAuth, ok := connAuth["vendor"]
+	if !ok {
+		t.Fatal("expected connection auth for vendor integration")
+	}
+	handler, ok := vendorAuth[config.PluginConnectionName]
+	if !ok {
+		t.Fatalf("expected handler for connection %q", config.PluginConnectionName)
+	}
+	authURL, _ := handler.StartOAuth("s1", nil)
+	if authURL == "" {
+		t.Fatal("expected non-empty authorization URL from mcp_oauth handler for spec-loaded provider")
+	}
+}
+
+func TestInlineResponseMapping_AppliedToOpenAPIProvider(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	specSrv := serveOpenAPISpec(t)
+
+	cfg := validConfig()
+	cfg.Integrations = map[string]config.IntegrationDef{
+		"mapped": {
+			Plugin: &config.PluginDef{
+				OpenAPI: specSrv.URL,
+				Auth: &config.ConnectionAuthDef{
+					Type: "none",
+				},
+				ResponseMapping: &config.ResponseMappingDef{
+					DataPath: "results",
+					Pagination: &config.PaginationMapping{
+						HasMorePath: "moreDataAvailable",
+						CursorPath:  "nextCursor",
+					},
+				},
+			},
+		},
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	prov, err := result.Providers.Get("mapped")
+	if err != nil {
+		t.Fatalf("Get mapped provider: %v", err)
+	}
+	ops := prov.ListOperations()
+	if len(ops) == 0 {
+		t.Fatal("expected at least one operation from the openapi spec")
+	}
+	found := false
+	for _, op := range ops {
+		if op.Name == "list_items" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected list_items operation to be present")
+	}
+}
+
+func TestInlineResponseMapping_DataPathOnly(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	specSrv := serveOpenAPISpec(t)
+
+	cfg := validConfig()
+	cfg.Integrations = map[string]config.IntegrationDef{
+		"simple": {
+			Plugin: &config.PluginDef{
+				OpenAPI: specSrv.URL,
+				Auth: &config.ConnectionAuthDef{
+					Type: "none",
+				},
+				ResponseMapping: &config.ResponseMappingDef{
+					DataPath: "data.items",
+				},
+			},
+		},
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	prov, err := result.Providers.Get("simple")
+	if err != nil {
+		t.Fatalf("Get simple provider: %v", err)
+	}
+	if len(prov.ListOperations()) == 0 {
+		t.Fatal("expected at least one operation")
+	}
+}
+
+func TestInlineResponseMapping_NilDoesNotBreak(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	specSrv := serveOpenAPISpec(t)
+
+	cfg := validConfig()
+	cfg.Integrations = map[string]config.IntegrationDef{
+		"noop": {
+			Plugin: &config.PluginDef{
+				OpenAPI: specSrv.URL,
+				Auth: &config.ConnectionAuthDef{
+					Type: "none",
+				},
+			},
+		},
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	prov, err := result.Providers.Get("noop")
+	if err != nil {
+		t.Fatalf("Get noop provider: %v", err)
+	}
+	if len(prov.ListOperations()) == 0 {
+		t.Fatal("expected at least one operation even without response_mapping")
+	}
+}

--- a/server/internal/bootstrap/validate.go
+++ b/server/internal/bootstrap/validate.go
@@ -109,6 +109,7 @@ func validateMCPCatalogs(providers *registry.PluginMap[core.Provider]) error {
 func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.PluginMap[core.Provider], map[string]map[string]OAuthHandler, error) {
 	reg := registry.New()
 	connAuth := make(map[string]map[string]OAuthHandler)
+	regStore := &lazyRegStore{deps: deps}
 
 	for _, builtin := range factories.Builtins {
 		if err := reg.Providers.Register(builtin.Name(), builtin); errors.Is(err, core.ErrAlreadyRegistered) {
@@ -124,7 +125,7 @@ func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *Fa
 	var errs []error
 	for _, name := range names {
 		intgDef := cfg.Integrations[name]
-		result, err := buildProviderForValidation(ctx, name, intgDef, factories, deps)
+		result, err := buildProviderForValidation(ctx, name, intgDef, factories, deps, regStore)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("integration %q: %w", name, err))
 			continue
@@ -148,9 +149,9 @@ func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *Fa
 	return &reg.Providers, connAuth, nil
 }
 
-func buildProviderForValidation(ctx context.Context, name string, intg config.IntegrationDef, factories *FactoryRegistry, deps Deps) (*ProviderBuildResult, error) {
+func buildProviderForValidation(ctx context.Context, name string, intg config.IntegrationDef, factories *FactoryRegistry, deps Deps, regStore *lazyRegStore) (*ProviderBuildResult, error) {
 	if intg.Plugin == nil || intg.Plugin.Package == "" || intg.Plugin.ResolvedManifestPath == "" {
-		return buildProvider(ctx, name, intg, factories, deps)
+		return buildProvider(ctx, name, intg, factories, deps, regStore)
 	}
 	prov, err := newPreparedProviderStub(name, intg, intg.Plugin.ResolvedManifestPath)
 	if err != nil {

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -109,9 +109,10 @@ type PluginDef struct {
 	MCPURL     string `yaml:"mcp_url"`
 	BaseURL    string `yaml:"base_url"`
 
-	Auth        *ConnectionAuthDef        `yaml:"auth"`
-	Connections map[string]*ConnectionDef `yaml:"connections"`
-	Operations  []InlineOperationDef      `yaml:"operations"`
+	Auth            *ConnectionAuthDef        `yaml:"auth"`
+	Connections     map[string]*ConnectionDef `yaml:"connections"`
+	Operations      []InlineOperationDef      `yaml:"operations"`
+	ResponseMapping *ResponseMappingDef       `yaml:"response_mapping"`
 
 	OpenAPIConnection string `yaml:"openapi_connection"`
 	GraphQLConnection string `yaml:"graphql_connection"`
@@ -155,6 +156,16 @@ type InlineOperationParam struct {
 	In          string `yaml:"in"`
 	Description string `yaml:"description"`
 	Required    bool   `yaml:"required"`
+}
+
+type ResponseMappingDef struct {
+	DataPath   string             `yaml:"data_path"`
+	Pagination *PaginationMapping `yaml:"pagination"`
+}
+
+type PaginationMapping struct {
+	HasMorePath string `yaml:"has_more_path"`
+	CursorPath  string `yaml:"cursor_path"`
 }
 
 type RuntimeDef struct {

--- a/server/internal/config/inline_manifest.go
+++ b/server/internal/config/inline_manifest.go
@@ -26,6 +26,19 @@ func InlineToManifest(name string, p *PluginDef) (*pluginmanifestv1.Manifest, er
 		},
 	}
 
+	if p.ResponseMapping != nil {
+		rm := &pluginmanifestv1.ManifestResponseMapping{
+			DataPath: p.ResponseMapping.DataPath,
+		}
+		if p.ResponseMapping.Pagination != nil {
+			rm.Pagination = &pluginmanifestv1.ManifestPaginationMapping{
+				HasMorePath: p.ResponseMapping.Pagination.HasMorePath,
+				CursorPath:  p.ResponseMapping.Pagination.CursorPath,
+			}
+		}
+		manifest.Provider.ResponseMapping = rm
+	}
+
 	if p.AllowedOperations != nil {
 		manifest.Provider.AllowedOperations = make(map[string]*pluginmanifestv1.ManifestOperationOverride, len(p.AllowedOperations))
 		for k, v := range p.AllowedOperations {

--- a/server/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/server/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -113,6 +113,25 @@
               "from": { "type": "string", "enum": ["discovery"] }
             }
           }
+        },
+        "response_mapping": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["data_path"],
+          "properties": {
+            "data_path": {
+              "type": "string",
+              "minLength": 1
+            },
+            "pagination": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "has_more_path": { "type": "string" },
+                "cursor_path": { "type": "string" }
+              }
+            }
+          }
         }
       }
     },
@@ -262,7 +281,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["oauth2", "bearer", "manual", "none"]
+          "enum": ["oauth2", "mcp_oauth", "bearer", "manual", "none"]
         },
         "authorization_url": {
           "type": "string",

--- a/server/sdk/pluginmanifest/v1/types.go
+++ b/server/sdk/pluginmanifest/v1/types.go
@@ -43,6 +43,17 @@ type Provider struct {
 	GraphQLConnection string                                `json:"graphql_connection,omitempty"`
 	MCPConnection     string                                `json:"mcp_connection,omitempty"`
 	Connections       map[string]*ManifestConnectionDef     `json:"connections,omitempty"`
+	ResponseMapping   *ManifestResponseMapping              `json:"response_mapping,omitempty"`
+}
+
+type ManifestResponseMapping struct {
+	DataPath   string                     `json:"data_path"`
+	Pagination *ManifestPaginationMapping `json:"pagination,omitempty"`
+}
+
+type ManifestPaginationMapping struct {
+	HasMorePath string `json:"has_more_path"`
+	CursorPath  string `json:"cursor_path"`
 }
 
 type ProviderPostConnectDiscovery struct {
@@ -97,10 +108,11 @@ type ProviderParameter struct {
 }
 
 const (
-	AuthTypeOAuth2 = "oauth2"
-	AuthTypeBearer = "bearer"
-	AuthTypeManual = "manual"
-	AuthTypeNone   = "none"
+	AuthTypeOAuth2   = "oauth2"
+	AuthTypeMCPOAuth = "mcp_oauth"
+	AuthTypeBearer   = "bearer"
+	AuthTypeManual   = "manual"
+	AuthTypeNone     = "none"
 )
 
 type ProviderAuth struct {


### PR DESCRIPTION
PR #376 simplified `IntegrationDef` to plugin-only but accidentally
dropped `mcp_oauth` auth and `response_mapping` support that existing
integrations depend on. Inline plugins with `auth.type: mcp_oauth` now
perform MCP OAuth discovery and Dynamic Client Registration just as they
did before the refactor, and the `response_mapping` field on `PluginDef`
lets inline integrations extract data from nested response paths and
handle cursor-based pagination.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>