### PR TITLE
Include operations in catalog for declarative and remote plugins

### DIFF
--- a/server/core/integration/schema.go
+++ b/server/core/integration/schema.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 )
 
@@ -102,6 +103,31 @@ func CompileSchemas(c *catalog.Catalog) {
 			op.Annotations = AnnotationsFromMethod(op.Method)
 		}
 	}
+}
+
+// CoreOperationsToCatalogOps converts core.Operation values into catalog equivalents.
+func CoreOperationsToCatalogOps(ops []core.Operation) []catalog.CatalogOperation {
+	out := make([]catalog.CatalogOperation, 0, len(ops))
+	for _, op := range ops {
+		params := make([]catalog.CatalogParameter, 0, len(op.Parameters))
+		for _, p := range op.Parameters {
+			params = append(params, catalog.CatalogParameter{
+				Name:        p.Name,
+				Type:        p.Type,
+				Description: p.Description,
+				Required:    p.Required,
+				Default:     p.Default,
+			})
+		}
+		out = append(out, catalog.CatalogOperation{
+			ID:          op.Name,
+			Method:      op.Method,
+			Description: op.Description,
+			Parameters:  params,
+			Transport:   catalog.TransportREST,
+		})
+	}
+	return out
 }
 
 func boolPtr(v bool) *bool { return &v }

--- a/server/internal/pluginhost/declarative.go
+++ b/server/internal/pluginhost/declarative.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/core/integration"
 	"github.com/valon-technologies/gestalt/server/internal/apiexec"
 	"github.com/valon-technologies/gestalt/server/internal/paraminterp"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
@@ -29,6 +30,7 @@ type DeclarativeProvider struct {
 	baseURL              string
 	auth                 *pluginmanifestv1.ProviderAuth
 	operations           []core.Operation
+	catalogOps           []catalog.CatalogOperation
 	opDefs               map[string]*declarativeOp
 	httpClient           *http.Client
 	postConnectDiscovery *pluginmanifestv1.ProviderPostConnectDiscovery
@@ -86,6 +88,8 @@ func NewDeclarativeProvider(manifest *pluginmanifestv1.Manifest, httpClient *htt
 		p.operations = append(p.operations, coreOp)
 	}
 
+	p.catalogOps = integration.CoreOperationsToCatalogOps(p.operations)
+
 	return p, nil
 }
 
@@ -96,10 +100,13 @@ func (p *DeclarativeProvider) Description() string { return p.description }
 func (p *DeclarativeProvider) SetIconSVG(svg string) { p.iconSVG = svg }
 
 func (p *DeclarativeProvider) Catalog() *catalog.Catalog {
-	if p.iconSVG == "" {
-		return nil
+	return &catalog.Catalog{
+		Name:        p.name,
+		DisplayName: p.displayName,
+		Description: p.description,
+		IconSVG:     p.iconSVG,
+		Operations:  p.catalogOps,
 	}
-	return &catalog.Catalog{IconSVG: p.iconSVG}
 }
 
 func (p *DeclarativeProvider) ConnectionMode() core.ConnectionMode {

--- a/server/internal/pluginhost/declarative_test.go
+++ b/server/internal/pluginhost/declarative_test.go
@@ -333,7 +333,7 @@ func TestDeclarativeProvider_AuthTypes(t *testing.T) {
 	}
 }
 
-func TestDeclarativeProviderIcon(t *testing.T) {
+func TestDeclarativeProviderCatalog(t *testing.T) {
 	t.Parallel()
 
 	p, err := NewDeclarativeProvider(testManifest("http://example.com"), nil)
@@ -343,19 +343,39 @@ func TestDeclarativeProviderIcon(t *testing.T) {
 
 	var _ core.CatalogProvider = p
 
-	if cat := p.Catalog(); cat != nil {
-		t.Fatalf("expected nil catalog before SetIconSVG, got %+v", cat)
+	cat := p.Catalog()
+	if cat == nil {
+		t.Fatal("expected non-nil catalog")
+	}
+	if cat.Name != "github.com/acme/plugins/testapi" {
+		t.Fatalf("Name = %q, want github.com/acme/plugins/testapi", cat.Name)
+	}
+	if cat.DisplayName != "Test API" {
+		t.Fatalf("DisplayName = %q, want Test API", cat.DisplayName)
+	}
+	if cat.IconSVG != "" {
+		t.Fatalf("IconSVG = %q, want empty before SetIconSVG", cat.IconSVG)
+	}
+
+	wantIDs := []string{"list_items", "create_item", "get_item", "update_item"}
+	if len(cat.Operations) != len(wantIDs) {
+		t.Fatalf("got %d operations, want %d", len(cat.Operations), len(wantIDs))
+	}
+	for i, want := range wantIDs {
+		if cat.Operations[i].ID != want {
+			t.Fatalf("Operations[%d].ID = %q, want %q", i, cat.Operations[i].ID, want)
+		}
 	}
 
 	const testSVG = `<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>`
 	p.SetIconSVG(testSVG)
 
-	cat := p.Catalog()
-	if cat == nil {
-		t.Fatal("expected non-nil catalog after SetIconSVG")
-	}
+	cat = p.Catalog()
 	if cat.IconSVG != testSVG {
 		t.Fatalf("IconSVG = %q, want %q", cat.IconSVG, testSVG)
+	}
+	if len(cat.Operations) != len(wantIDs) {
+		t.Fatalf("got %d operations after SetIconSVG, want %d", len(cat.Operations), len(wantIDs))
 	}
 }
 

--- a/server/internal/pluginhost/provider_client.go
+++ b/server/internal/pluginhost/provider_client.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/core/integration"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -127,10 +128,16 @@ func (p *remoteProviderBase) SetIconSVG(svg string) { p.iconSVG = svg }
 
 func (p *remoteProviderBase) Catalog() *catalog.Catalog {
 	if p.catalog == nil {
-		if p.iconSVG != "" {
-			return &catalog.Catalog{IconSVG: p.iconSVG}
+		if len(p.ops) == 0 && p.iconSVG == "" {
+			return nil
 		}
-		return nil
+		return &catalog.Catalog{
+			Name:        p.metadata.GetName(),
+			DisplayName: p.metadata.GetDisplayName(),
+			Description: p.metadata.GetDescription(),
+			IconSVG:     p.iconSVG,
+			Operations:  integration.CoreOperationsToCatalogOps(p.ops),
+		}
 	}
 	cat := p.catalog.Clone()
 	if cat.IconSVG == "" && p.iconSVG != "" {

--- a/server/internal/pluginhost/provider_test.go
+++ b/server/internal/pluginhost/provider_test.go
@@ -165,7 +165,7 @@ func TestRemoteProviderIconSVG(t *testing.T) {
 
 	const testSVG = `<svg xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16"/></svg>`
 
-	t.Run("no icon and no catalog returns nil", func(t *testing.T) {
+	t.Run("no icon no catalog no ops returns nil", func(t *testing.T) {
 		t.Parallel()
 
 		client := newProviderPluginClient(t, sdkgestalt.NewProviderServer(&manualOnlySDKProvider{}))
@@ -200,6 +200,34 @@ func TestRemoteProviderIconSVG(t *testing.T) {
 		}
 		if cat.IconSVG != testSVG {
 			t.Fatalf("IconSVG = %q, want %q", cat.IconSVG, testSVG)
+		}
+	})
+
+	t.Run("ops included in catalog when no static catalog", func(t *testing.T) {
+		t.Parallel()
+
+		client := newProviderPluginClient(t, NewProviderServer(&roundTripProvider{}))
+		prov, err := NewRemoteProvider(context.Background(), client, "roundtrip", nil)
+		if err != nil {
+			t.Fatalf("NewRemoteProvider: %v", err)
+		}
+		base := prov.(*remoteProviderWithSessionCatalog).remoteProviderBase
+		base.catalog = nil
+		base.SetIconSVG(testSVG)
+
+		cp := prov.(core.CatalogProvider)
+		cat := cp.Catalog()
+		if cat == nil {
+			t.Fatal("expected non-nil catalog")
+		}
+		if cat.IconSVG != testSVG {
+			t.Fatalf("IconSVG = %q, want %q", cat.IconSVG, testSVG)
+		}
+		if len(cat.Operations) != 1 {
+			t.Fatalf("expected 1 operation, got %d", len(cat.Operations))
+		}
+		if cat.Operations[0].ID != "echo" {
+			t.Fatalf("Operations[0].ID = %q, want echo", cat.Operations[0].ID)
 		}
 	})
 

--- a/server/internal/server/catalog_resolution.go
+++ b/server/internal/server/catalog_resolution.go
@@ -60,6 +60,8 @@ func resolveCatalog(ctx context.Context, prov core.Provider, provName string, re
 
 	if merged == nil {
 		merged = synthesizeCatalog(prov, provName)
+	} else if len(merged.Operations) == 0 {
+		merged.Operations = integration.CoreOperationsToCatalogOps(prov.ListOperations())
 	}
 
 	integration.CompileSchemas(merged)
@@ -67,31 +69,10 @@ func resolveCatalog(ctx context.Context, prov core.Provider, provName string, re
 }
 
 func synthesizeCatalog(prov core.Provider, provName string) *catalog.Catalog {
-	ops := prov.ListOperations()
-	cat := &catalog.Catalog{
+	return &catalog.Catalog{
 		Name:        provName,
 		DisplayName: prov.DisplayName(),
 		Description: prov.Description(),
-		Operations:  make([]catalog.CatalogOperation, 0, len(ops)),
+		Operations:  integration.CoreOperationsToCatalogOps(prov.ListOperations()),
 	}
-	for _, op := range ops {
-		params := make([]catalog.CatalogParameter, 0, len(op.Parameters))
-		for _, p := range op.Parameters {
-			params = append(params, catalog.CatalogParameter{
-				Name:        p.Name,
-				Type:        p.Type,
-				Description: p.Description,
-				Required:    p.Required,
-				Default:     p.Default,
-			})
-		}
-		cat.Operations = append(cat.Operations, catalog.CatalogOperation{
-			ID:          op.Name,
-			Method:      op.Method,
-			Description: op.Description,
-			Parameters:  params,
-			Transport:   catalog.TransportREST,
-		})
-	}
-	return cat
 }

--- a/server/internal/server/catalog_resolution_test.go
+++ b/server/internal/server/catalog_resolution_test.go
@@ -333,6 +333,57 @@ func TestResolveCatalog_NilResolver(t *testing.T) {
 	}
 }
 
+func TestResolveCatalog_IconOnlyCatalogStillHasOperations(t *testing.T) {
+	t.Parallel()
+
+	prov := &stubCatalogProvider{
+		stubProvider: stubProvider{
+			name:        "icon-api",
+			displayName: "Icon API",
+			description: "Has icon and operations",
+			connMode:    core.ConnectionModeUser,
+			ops: []core.Operation{
+				{
+					Name:        "do_thing",
+					Method:      http.MethodPost,
+					Description: "Does a thing",
+					Parameters: []core.Parameter{
+						{Name: "input", Type: "string", Required: true},
+					},
+				},
+			},
+		},
+		cat: &catalog.Catalog{
+			Name:    "icon-api",
+			IconSVG: `<svg/>`,
+		},
+	}
+
+	cat, err := resolveCatalog(context.Background(), prov, "icon-api", nil, nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cat.IconSVG != `<svg/>` {
+		t.Fatalf("IconSVG = %q, want %q", cat.IconSVG, `<svg/>`)
+	}
+	if len(cat.Operations) != 1 {
+		t.Fatalf("got %d operations, want 1", len(cat.Operations))
+	}
+	op := cat.Operations[0]
+	if op.ID != "do_thing" {
+		t.Fatalf("Operations[0].ID = %q, want do_thing", op.ID)
+	}
+	if op.Method != http.MethodPost {
+		t.Fatalf("Operations[0].Method = %q, want POST", op.Method)
+	}
+	if op.Description != "Does a thing" {
+		t.Fatalf("Operations[0].Description = %q, want %q", op.Description, "Does a thing")
+	}
+	if len(op.Parameters) != 1 || op.Parameters[0].Name != "input" {
+		t.Fatalf("Operations[0].Parameters = %+v, want [{Name:input}]", op.Parameters)
+	}
+}
+
 func TestResolveCatalog_CloneSafety(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Declarative and remote providers returned catalogs containing only
metadata (icon SVG) with no operations. This caused the listing API
to return an empty operation catalog for source-based plugins like
Slack, even though direct invocation worked fine. The root cause was
that `Catalog()` was originally added to these providers only to carry
the icon, while operations were served by a synthesis fallback that
only ran when no catalog existed at all.

All `Catalog()` implementations now return complete catalogs with
operations, matching the pattern established by the `Base` provider.
A shared `CoreOperationsToCatalogOps` helper in `core/integration`
provides the canonical conversion, replacing the inline logic that
previously lived only in `synthesizeCatalog`.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>