### PR TITLE
Allow external plugins to compose with spec surfaces

### DIFF
--- a/server/internal/bootstrap/bootstrap.go
+++ b/server/internal/bootstrap/bootstrap.go
@@ -13,6 +13,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/crypto"
 	"github.com/valon-technologies/gestalt/server/core/integration"
+	"github.com/valon-technologies/gestalt/server/internal/composite"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	graphqlupstream "github.com/valon-technologies/gestalt/server/internal/graphql"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
@@ -731,17 +732,99 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 	}
 	applyPluginIcon(pluginProv, intg)
 
-	restricted, err := applyAllowedOperations(name, intg, pluginProv)
-	if err != nil {
-		if c, ok := pluginProv.(interface{ Close() error }); ok {
-			_ = c.Close()
+	hasSpecSurface := intg.Plugin.OpenAPI != "" || intg.Plugin.GraphQLURL != "" || intg.Plugin.MCPURL != ""
+
+	var finalProv core.Provider
+	if !hasSpecSurface {
+		restricted, err := applyAllowedOperations(name, intg, pluginProv)
+		if err != nil {
+			if c, ok := pluginProv.(interface{ Close() error }); ok {
+				_ = c.Close()
+			}
+			return nil, err
 		}
-		return nil, err
+		finalProv = restricted
+	} else {
+		specProv, err := buildHybridSpecProvider(ctx, name, intg, deps)
+		if err != nil {
+			if c, ok := pluginProv.(interface{ Close() error }); ok {
+				_ = c.Close()
+			}
+			return nil, err
+		}
+		displayName := intg.DisplayName
+		if displayName == "" {
+			displayName = pluginProv.DisplayName()
+		}
+		description := intg.Description
+		if description == "" {
+			description = pluginProv.Description()
+		}
+		merged, err := composite.NewMerged(name, displayName, description, pluginProv, specProv)
+		if err != nil {
+			if c, ok := specProv.(interface{ Close() error }); ok {
+				_ = c.Close()
+			}
+			if c, ok := pluginProv.(interface{ Close() error }); ok {
+				_ = c.Close()
+			}
+			return nil, err
+		}
+		finalProv = merged
 	}
 
-	buildResult := &ProviderBuildResult{Provider: restricted}
+	buildResult := &ProviderBuildResult{Provider: finalProv}
 	attachPluginOAuth(name, intg, pluginConfig, deps, buildResult)
 	return buildResult, nil
+}
+
+func buildHybridSpecProvider(ctx context.Context, name string, intg config.IntegrationDef, deps Deps) (core.Provider, error) {
+	conn := pluginConnectionDef(intg.Plugin)
+	allowedOps := intg.Plugin.AllowedOperations
+
+	switch {
+	case intg.Plugin.OpenAPI != "":
+		def, err := openapi.LoadDefinition(ctx, name, intg.Plugin.OpenAPI, allowedOps)
+		if err != nil {
+			return nil, fmt.Errorf("load hybrid openapi spec for %q: %w", name, err)
+		}
+		if intg.Plugin.BaseURL != "" {
+			def.BaseURL = intg.Plugin.BaseURL
+		}
+		provider.ApplyDisplayOverrides(def, intg)
+		return provider.Build(def, conn, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+
+	case intg.Plugin.GraphQLURL != "":
+		def, err := graphqlupstream.LoadDefinition(ctx, name, intg.Plugin.GraphQLURL, allowedOps)
+		if err != nil {
+			return nil, fmt.Errorf("load hybrid graphql schema for %q: %w", name, err)
+		}
+		if intg.Plugin.BaseURL != "" {
+			def.BaseURL = intg.Plugin.BaseURL
+		}
+		provider.ApplyDisplayOverrides(def, intg)
+		return provider.Build(def, conn, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+
+	case intg.Plugin.MCPURL != "":
+		connMode := core.ConnectionMode(conn.Mode)
+		if connMode == "" {
+			connMode = core.ConnectionModeUser
+		}
+		up, err := mcpupstream.New(ctx, name, intg.Plugin.MCPURL, connMode, deps.Egress.Resolver)
+		if err != nil {
+			return nil, fmt.Errorf("create hybrid mcp upstream for %q: %w", name, err)
+		}
+		if allowedOps != nil {
+			if err := up.FilterOperations(allowedOps); err != nil {
+				_ = up.Close()
+				return nil, fmt.Errorf("filter hybrid mcp operations for %q: %w", name, err)
+			}
+		}
+		return up, nil
+
+	default:
+		return nil, fmt.Errorf("hybrid spec provider %q has no spec URL", name)
+	}
 }
 
 func buildInlineProvider(ctx context.Context, name string, intg config.IntegrationDef, deps Deps, regStore *lazyRegStore) (*ProviderBuildResult, error) {
@@ -1034,13 +1117,22 @@ func attachManifestOAuth(name string, intg config.IntegrationDef, manifest *plug
 }
 
 func attachPluginOAuth(name string, intg config.IntegrationDef, pluginConfig map[string]any, deps Deps, result *ProviderBuildResult) {
-	if intg.Plugin == nil || intg.Plugin.ResolvedManifestPath == "" {
+	if intg.Plugin == nil {
 		return
 	}
-	authHandler, err := buildPluginOAuthHandler(intg, pluginConfig, deps)
-	if err != nil {
-		slog.Warn("cannot build oauth handler from manifest", "provider", name, "error", err)
-		return
+	var authHandler OAuthHandler
+	var err error
+	if intg.Plugin.ResolvedManifestPath != "" {
+		authHandler, err = buildPluginOAuthHandler(intg, pluginConfig, deps)
+		if err != nil {
+			slog.Warn("cannot build oauth handler from manifest", "provider", name, "error", err)
+		}
+	}
+	if authHandler == nil && intg.Plugin.Auth != nil && intg.Plugin.Auth.Type == "oauth2" {
+		authHandler, err = buildOAuthHandlerFromAuth(intg.Plugin.Auth, pluginConfig, deps)
+		if err != nil {
+			slog.Warn("cannot build oauth handler from inline auth", "provider", name, "error", err)
+		}
 	}
 	if authHandler == nil {
 		return
@@ -1066,7 +1158,31 @@ func buildOAuthHandlerFromManifest(manifest *pluginmanifestv1.Manifest, pluginCo
 	if manifest.Provider == nil || manifest.Provider.Auth == nil || manifest.Provider.Auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
 		return nil, nil
 	}
-	auth := manifest.Provider.Auth
+	a := manifest.Provider.Auth
+	return buildOAuthHandlerFromAuth(&config.ConnectionAuthDef{
+		Type:                a.Type,
+		AuthorizationURL:    a.AuthorizationURL,
+		TokenURL:            a.TokenURL,
+		ClientID:            a.ClientID,
+		ClientSecret:        a.ClientSecret,
+		Scopes:              a.Scopes,
+		PKCE:                a.PKCE,
+		ClientAuth:          a.ClientAuth,
+		TokenExchange:       a.TokenExchange,
+		ScopeParam:          a.ScopeParam,
+		ScopeSeparator:      a.ScopeSeparator,
+		AuthorizationParams: a.AuthorizationParams,
+		TokenParams:         a.TokenParams,
+		RefreshParams:       a.RefreshParams,
+		AcceptHeader:        a.AcceptHeader,
+		AccessTokenPath:     a.AccessTokenPath,
+	}, pluginConfig, deps)
+}
+
+func buildOAuthHandlerFromAuth(auth *config.ConnectionAuthDef, pluginConfig map[string]any, deps Deps) (OAuthHandler, error) {
+	if auth == nil || auth.Type != "oauth2" {
+		return nil, nil
+	}
 
 	clientID := auth.ClientID
 	clientSecret := auth.ClientSecret
@@ -1077,10 +1193,8 @@ func buildOAuthHandlerFromManifest(manifest *pluginmanifestv1.Manifest, pluginCo
 		clientSecret = sec
 	}
 	if clientID == "" || clientSecret == "" {
-		return nil, fmt.Errorf("client_id and client_secret are required for oauth2 auth (set in plugin.auth or plugin.config)")
+		return nil, fmt.Errorf("client_id and client_secret are required for oauth2 auth")
 	}
-
-	redirectURL := deps.BaseURL + config.IntegrationCallbackPath
 
 	var tokenExchange oauth.TokenExchangeFormat
 	switch auth.TokenExchange {
@@ -1097,7 +1211,7 @@ func buildOAuthHandlerFromManifest(manifest *pluginmanifestv1.Manifest, pluginCo
 		ClientSecret:        clientSecret,
 		AuthorizationURL:    auth.AuthorizationURL,
 		TokenURL:            auth.TokenURL,
-		RedirectURL:         redirectURL,
+		RedirectURL:         deps.BaseURL + config.IntegrationCallbackPath,
 		PKCE:                auth.PKCE,
 		DefaultScopes:       auth.Scopes,
 		ScopeParam:          auth.ScopeParam,
@@ -1113,8 +1227,7 @@ func buildOAuthHandlerFromManifest(manifest *pluginmanifestv1.Manifest, pluginCo
 		oauthCfg.ClientAuthMethod = oauth.ClientAuthHeader
 	}
 
-	handler := oauth.NewUpstream(oauthCfg)
-	return WrapUpstreamHandler(handler), nil
+	return WrapUpstreamHandler(oauth.NewUpstream(oauthCfg)), nil
 }
 
 func buildMCPOAuthHandler(conn config.ConnectionDef, mcpURL string, store mcpoauth.RegistrationStore, deps Deps) *mcpoauth.Handler {

--- a/server/internal/bootstrap/executable_plugin_test.go
+++ b/server/internal/bootstrap/executable_plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 	"gopkg.in/yaml.v3"
 )
@@ -632,5 +634,92 @@ func TestPluginProcessEnvIsolation(t *testing.T) {
 	}
 	if !env.Found || env.Value == "" {
 		t.Fatal("plugin process should see PATH")
+	}
+}
+
+func TestHybridPluginMergesCommandAndOpenAPI(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+
+	spec := map[string]any{
+		"openapi": "3.0.0",
+		"info":    map[string]string{"title": "Hybrid Test API"},
+		"servers": []any{map[string]string{"url": "https://api.hybrid.example/v1"}},
+		"paths": map[string]any{
+			"/messages": map[string]any{
+				"get": map[string]any{
+					"operationId": "list_messages",
+					"summary":     "List messages",
+				},
+			},
+			"/messages/{id}": map[string]any{
+				"get": map[string]any{
+					"operationId": "get_message",
+					"summary":     "Get a message by ID",
+					"parameters": []any{
+						map[string]any{
+							"name":     "id",
+							"in":       "path",
+							"required": true,
+							"schema":   map[string]string{"type": "string"},
+						},
+					},
+				},
+			},
+		},
+	}
+	specSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(spec)
+	}))
+	testutil.CloseOnCleanup(t, specSrv)
+
+	cfg := &config.Config{
+		Integrations: map[string]config.IntegrationDef{
+			"hybrid": {
+				Plugin: &config.PluginDef{
+					Command: bin,
+					Args:    []string{"provider"},
+					OpenAPI: specSrv.URL,
+				},
+			},
+		},
+	}
+
+	factories := NewFactoryRegistry()
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	prov, err := providers.Get("hybrid")
+	if err != nil {
+		t.Fatalf("providers.Get(hybrid): %v", err)
+	}
+
+	ops := prov.ListOperations()
+	opNames := make(map[string]bool, len(ops))
+	for _, op := range ops {
+		opNames[op.Name] = true
+	}
+
+	if !opNames["echo"] {
+		t.Error("expected plugin operation 'echo' to be present")
+	}
+	if !opNames["list_messages"] {
+		t.Error("expected spec operation 'list_messages' to be present")
+	}
+	if !opNames["get_message"] {
+		t.Error("expected spec operation 'get_message' to be present")
+	}
+
+	result, err := prov.Execute(context.Background(), "echo", map[string]any{"msg": "hello"}, "")
+	if err != nil {
+		t.Fatalf("Execute(echo): %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("echo status = %d, want %d", result.Status, http.StatusOK)
 	}
 }

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -563,10 +563,20 @@ func validateExternalPlugin(kind, name string, plugin *PluginDef) error {
 		return fmt.Errorf("config validation: %s %q plugin.package requires HTTPS; plain HTTP is not supported", kind, name)
 	}
 
-	hasInline := plugin.OpenAPI != "" || plugin.GraphQLURL != "" || plugin.MCPURL != "" ||
-		plugin.BaseURL != "" || len(plugin.Operations) > 0 || plugin.Auth != nil || len(plugin.Connections) > 0
-	if hasInline {
-		return fmt.Errorf("config validation: %s %q external plugin cannot use inline fields (openapi, graphql_url, mcp_url, base_url, operations, auth, connections)", kind, name)
+	if len(plugin.Operations) > 0 {
+		return fmt.Errorf("config validation: %s %q external plugin cannot use inline operations", kind, name)
+	}
+
+	if kind != "integration" {
+		hasInline := plugin.OpenAPI != "" || plugin.GraphQLURL != "" || plugin.MCPURL != "" ||
+			plugin.BaseURL != "" || plugin.Auth != nil || len(plugin.Connections) > 0
+		if hasInline {
+			return fmt.Errorf("config validation: %s %q plugin cannot use inline fields", kind, name)
+		}
+	}
+
+	if kind == "integration" && len(plugin.Connections) > 0 {
+		return fmt.Errorf("config validation: integration %q external plugin cannot use inline connections; declare connections in the plugin manifest instead", name)
 	}
 
 	return nil

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -850,3 +850,43 @@ func TestIsInline(t *testing.T) {
 		})
 	}
 }
+
+func TestExternalPluginRejectsInlineOperations(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{
+		Integrations: map[string]IntegrationDef{
+			"bad": {
+				Plugin: &PluginDef{
+					Command: "echo",
+					Operations: []InlineOperationDef{
+						{Name: "op", Method: "GET", Path: "/op"},
+					},
+				},
+			},
+		},
+	}
+	err := ValidateStructure(cfg)
+	if err == nil {
+		t.Fatal("expected validation error for command + inline operations")
+	}
+	if !strings.Contains(err.Error(), "external plugin cannot use inline operations") {
+		t.Fatalf("error = %q, want to contain 'external plugin cannot use inline operations'", err)
+	}
+}
+
+func TestExternalPluginAllowsSpecURL(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{
+		Integrations: map[string]IntegrationDef{
+			"ok": {
+				Plugin: &PluginDef{
+					Command: "echo",
+					OpenAPI: "https://example.com/spec.json",
+				},
+			},
+		},
+	}
+	if err := ValidateStructure(cfg); err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+}


### PR DESCRIPTION
External plugins can now declare `openapi`, `graphql_url`, or `mcp_url`
alongside their `command`, `package`, or `source` fields. The server
loads the spec at startup and merges its operations with the plugin's
own operations, so a single integration can combine custom plugin logic
with a standard API spec. This is useful when a plugin implements a few
specialized operations (like sending email) while the spec provides the
full read surface (like listing messages).

When a spec URL is present, `allowed_operations` applies only to the
spec surface, leaving plugin operations unfiltered. Inline `auth` on
external plugins is now used as a fallback when the plugin manifest does
not declare its own OAuth configuration.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>