### PR TITLE
Restrict plugin socket temp directory permissions

### DIFF
--- a/server/internal/pluginhost/process.go
+++ b/server/internal/pluginhost/process.go
@@ -294,6 +294,10 @@ func newSocketDir() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("create plugin temp dir: %w", err)
 	}
+	if err := os.Chmod(dir, 0700); err != nil {
+		os.Remove(dir)
+		return "", fmt.Errorf("restrict plugin temp dir permissions: %w", err)
+	}
 	return dir, nil
 }
 


### PR DESCRIPTION
## Summary
- Plugin gRPC sockets in `/tmp` were created with default umask permissions (typically 0022), making the directory world-readable on multi-tenant hosts.
- Adds `os.Chmod(dir, 0700)` after `os.MkdirTemp` to restrict access to the owning user only.

## Test plan
- [x] `go build ./internal/pluginhost/` passes
- [ ] Verify on Linux that `ls -la /tmp | grep gstp` shows `drwx------` after starting a plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)