### PR TITLE
Add IdleTimeout and MaxHeaderBytes to HTTP server

### DIFF
--- a/server/cmd/gestaltd/run.go
+++ b/server/cmd/gestaltd/run.go
@@ -164,6 +164,8 @@ func runServer(env *bootstrapEnv) error {
 		Addr:              addr,
 		Handler:           srv,
 		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		MaxHeaderBytes:    1 << 20,
 	}
 
 	listenErr := make(chan error, 1)


### PR DESCRIPTION
The gestaltd `http.Server` only set `ReadHeaderTimeout`, leaving idle keep-alive connections open indefinitely. This allows connection exhaustion by accumulating idle connections. Adding `IdleTimeout: 120s` closes connections idle for two minutes between requests. `MaxHeaderBytes` is set to 1 MB to make the limit explicit alongside the existing body size middleware.

`WriteTimeout` is intentionally omitted because it covers handler processing time in Go, not just write time. The MCP endpoint holds long-lived SSE streams, and all API routes invoke external integrations with unbounded latency, so any safe `WriteTimeout` value would need to be too large to provide meaningful protection. The Kubernetes ingress handles slow-reader protection on the client-facing side.