### PR TITLE
Require encryption key only when auth is enabled

### DIFF
--- a/server/internal/bootstrap/bootstrap.go
+++ b/server/internal/bootstrap/bootstrap.go
@@ -239,8 +239,8 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	}()
 
 	encKey := crypto.DeriveKey(cfg.Server.EncryptionKey)
-	if encKey == nil {
-		slog.Warn("no encryption key configured; stored secrets will not be encrypted")
+	if encKey == nil && cfg.Auth.Provider != "none" {
+		return nil, fmt.Errorf("bootstrap: server.encryption_key is required when auth is enabled")
 	}
 
 	deps := Deps{

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -485,8 +485,8 @@ func ValidateRuntime(cfg *Config) error {
 	if cfg.Datastore.Provider == "" {
 		return fmt.Errorf("config validation: datastore.provider is required")
 	}
-	if cfg.Server.EncryptionKey == "" {
-		return fmt.Errorf("config validation: server.encryption_key is required")
+	if cfg.Server.EncryptionKey == "" && cfg.Auth.Provider != "none" {
+		return fmt.Errorf("config validation: server.encryption_key is required when auth is enabled (auth.provider is %q)", cfg.Auth.Provider)
 	}
 	return nil
 }

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -178,7 +178,7 @@ server:
 `,
 		},
 		{
-			name: "missing encryption key",
+			name: "missing encryption key with auth enabled",
 			yaml: `
 auth:
   provider: auth-provider
@@ -200,6 +200,24 @@ datastore:
 				t.Fatal("ValidateRuntime: expected error, got nil")
 			}
 		})
+	}
+}
+
+func TestValidateRuntimeAllowsNoEncryptionKeyWithAuthNone(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+auth:
+  provider: none
+datastore:
+  provider: data-store
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := ValidateRuntime(cfg); err != nil {
+		t.Fatalf("ValidateRuntime: unexpected error: %v", err)
 	}
 }
 

--- a/server/internal/server/server.go
+++ b/server/internal/server/server.go
@@ -69,6 +69,7 @@ func New(cfg Config) (*Server, error) {
 	if cfg.Invoker == nil {
 		return nil, fmt.Errorf("invoker is required")
 	}
+	noAuth := cfg.Auth.Name() == "none"
 	var stateCodec *integrationOAuthStateCodec
 	var encryptor *cryptoutil.AESGCMEncryptor
 	if len(cfg.StateSecret) > 0 {
@@ -82,6 +83,8 @@ func New(cfg Config) (*Server, error) {
 			return nil, fmt.Errorf("init state encryptor: %w", err)
 		}
 		encryptor = enc
+	} else if !noAuth {
+		return nil, fmt.Errorf("state secret is required when auth is enabled")
 	}
 	now := cfg.Now
 	if now == nil {
@@ -89,7 +92,6 @@ func New(cfg Config) (*Server, error) {
 	}
 
 	resolver := principal.NewResolver(cfg.Auth, cfg.Datastore)
-	noAuth := cfg.Auth.Name() == "none"
 
 	router := chi.NewRouter()
 	s := &Server{

--- a/server/internal/server/server_test.go
+++ b/server/internal/server/server_test.go
@@ -160,6 +160,27 @@ func oauthRefreshConnectionAuth(integration string, refreshFn func(context.Conte
 	return testConnectionAuth(integration, &testOAuthHandler{refreshTokenFn: refreshFn})
 }
 
+func TestNewServerRequiresStateSecretWithAuth(t *testing.T) {
+	t.Parallel()
+	ds := &coretesting.StubDatastore{}
+	providers := func() *registry.PluginMap[core.Provider] {
+		reg := registry.New()
+		return &reg.Providers
+	}()
+	_, err := server.New(server.Config{
+		Auth:      &coretesting.StubAuthProvider{N: "google"},
+		Datastore: ds,
+		Providers: providers,
+		Invoker:   invocation.NewBroker(providers, ds),
+	})
+	if err == nil {
+		t.Fatal("expected error when auth is enabled without state secret")
+	}
+	if !strings.Contains(err.Error(), "state secret is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestHealthCheck(t *testing.T) {
 	t.Parallel()
 	ts := newTestServer(t)


### PR DESCRIPTION
The encryption key was previously required unconditionally by
`ValidateRuntime`, even for local development with `auth.provider: none`
where encryption serves no purpose. Simultaneously, `bootstrap.go`
contained a dead warn-and-continue path that suggested the key was
optional, and `server.go` silently disabled CSRF protection and OAuth
state signing when the key was missing.

This makes the requirement conditional: `server.encryption_key` is
required when `auth.provider` is not `none`, and all three layers
(config validation, bootstrap, server construction) now fail fast with
clear errors instead of silently degrading security. The zero-config
developer experience is unaffected since `gestaltd` auto-generates a
config with a random key.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>