### PR TITLE
Resolve named connections for auth_mapping injection

### DIFF
--- a/server/internal/bootstrap/bootstrap.go
+++ b/server/internal/bootstrap/bootstrap.go
@@ -779,11 +779,11 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 }
 
 func buildHybridSpecProvider(ctx context.Context, name string, intg config.IntegrationDef, deps Deps) (core.Provider, error) {
-	conn := pluginConnectionDef(intg.Plugin)
 	allowedOps := intg.Plugin.AllowedOperations
 
 	switch {
 	case intg.Plugin.OpenAPI != "":
+		conn := pluginConnectionDef(intg.Plugin, intg.Plugin.OpenAPIConnection)
 		def, err := openapi.LoadDefinition(ctx, name, intg.Plugin.OpenAPI, allowedOps)
 		if err != nil {
 			return nil, fmt.Errorf("load hybrid openapi spec for %q: %w", name, err)
@@ -795,6 +795,7 @@ func buildHybridSpecProvider(ctx context.Context, name string, intg config.Integ
 		return provider.Build(def, conn, nil, provider.WithEgressResolver(deps.Egress.Resolver))
 
 	case intg.Plugin.GraphQLURL != "":
+		conn := pluginConnectionDef(intg.Plugin, intg.Plugin.GraphQLConnection)
 		def, err := graphqlupstream.LoadDefinition(ctx, name, intg.Plugin.GraphQLURL, allowedOps)
 		if err != nil {
 			return nil, fmt.Errorf("load hybrid graphql schema for %q: %w", name, err)
@@ -806,6 +807,7 @@ func buildHybridSpecProvider(ctx context.Context, name string, intg config.Integ
 		return provider.Build(def, conn, nil, provider.WithEgressResolver(deps.Egress.Resolver))
 
 	case intg.Plugin.MCPURL != "":
+		conn := pluginConnectionDef(intg.Plugin, intg.Plugin.MCPConnection)
 		connMode := core.ConnectionMode(conn.Mode)
 		if connMode == "" {
 			connMode = core.ConnectionModeUser
@@ -871,10 +873,10 @@ func buildSpecLoadedProvider(ctx context.Context, name string, intg config.Integ
 	mp := manifest.Provider
 
 	allowedOps := convertAllowedOperations(mp.AllowedOperations)
-	conn := pluginConnectionDef(intg.Plugin)
 
 	switch {
 	case mp.OpenAPI != "":
+		conn := pluginConnectionDef(intg.Plugin, mp.OpenAPIConnection)
 		def, err := openapi.LoadDefinition(ctx, name, mp.OpenAPI, allowedOps)
 		if err != nil {
 			return nil, fmt.Errorf("load openapi spec for %q: %w", name, err)
@@ -891,6 +893,7 @@ func buildSpecLoadedProvider(ctx context.Context, name string, intg config.Integ
 		return specLoadedResult(name, intg, manifest, prov, deps, regStore)
 
 	case mp.GraphQLURL != "":
+		conn := pluginConnectionDef(intg.Plugin, mp.GraphQLConnection)
 		def, err := graphqlupstream.LoadDefinition(ctx, name, mp.GraphQLURL, allowedOps)
 		if err != nil {
 			return nil, fmt.Errorf("load graphql schema for %q: %w", name, err)
@@ -907,6 +910,7 @@ func buildSpecLoadedProvider(ctx context.Context, name string, intg config.Integ
 		return specLoadedResult(name, intg, manifest, prov, deps, regStore)
 
 	case mp.MCPURL != "":
+		conn := pluginConnectionDef(intg.Plugin, mp.MCPConnection)
 		connMode := core.ConnectionMode(conn.Mode)
 		if connMode == "" {
 			connMode = core.ConnectionModeUser
@@ -960,10 +964,16 @@ func convertAllowedOperations(ops map[string]*pluginmanifestv1.ManifestOperation
 	return result
 }
 
-func pluginConnectionDef(plugin *config.PluginDef) config.ConnectionDef {
+func pluginConnectionDef(plugin *config.PluginDef, connName string) config.ConnectionDef {
 	conn := config.ConnectionDef{}
 	if plugin == nil {
 		return conn
+	}
+	if connName != "" {
+		if named, ok := plugin.Connections[connName]; ok && named != nil {
+			return *named
+		}
+		slog.Warn("named connection not found, falling back to top-level auth", "connection", connName)
 	}
 	if plugin.Auth != nil {
 		conn.Auth = *plugin.Auth
@@ -1108,7 +1118,7 @@ func attachManifestOAuth(name string, intg config.IntegrationDef, manifest *plug
 			slog.Warn("mcp_oauth auth requires mcp_url", "provider", name)
 			return nil
 		}
-		conn := pluginConnectionDef(intg.Plugin)
+		conn := pluginConnectionDef(intg.Plugin, manifest.Provider.MCPConnection)
 		handler := buildMCPOAuthHandler(conn, mcpURL, regStore.get(), deps)
 		result.ConnectionAuth = map[string]OAuthHandler{
 			config.PluginConnectionName: handler,

--- a/server/internal/bootstrap/inline_gaps_test.go
+++ b/server/internal/bootstrap/inline_gaps_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
 
 func serveMCPOAuthEndpoints(t *testing.T) *httptest.Server {
@@ -300,5 +301,87 @@ func TestInlineResponseMapping_NilDoesNotBreak(t *testing.T) {
 	}
 	if len(prov.ListOperations()) == 0 {
 		t.Fatal("expected at least one operation even without response_mapping")
+	}
+}
+
+func TestInlineOpenAPI_NamedConnectionAuthMapping(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeTestJSON(w, map[string]string{
+			"api_key": r.Header.Get("DD-API-KEY"),
+			"app_key": r.Header.Get("DD-APPLICATION-KEY"),
+		})
+	}))
+	testutil.CloseOnCleanup(t, apiSrv)
+
+	specSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeTestJSON(w, map[string]any{
+			"openapi": "3.0.0",
+			"info":    map[string]string{"title": "Test API"},
+			"servers": []any{map[string]string{"url": apiSrv.URL}},
+			"paths": map[string]any{
+				"/items": map[string]any{
+					"get": map[string]any{
+						"operationId": "list_items",
+						"summary":     "List items",
+					},
+				},
+			},
+		})
+	}))
+	testutil.CloseOnCleanup(t, specSrv)
+
+	const connName = "api"
+	cfg := validConfig()
+	cfg.Integrations = map[string]config.IntegrationDef{
+		"datadog": {
+			Plugin: &config.PluginDef{
+				OpenAPI:           specSrv.URL,
+				OpenAPIConnection: connName,
+				Connections: map[string]*config.ConnectionDef{
+					connName: {
+						Auth: config.ConnectionAuthDef{
+							Type: pluginmanifestv1.AuthTypeManual,
+							AuthMapping: &config.AuthMappingDef{
+								Headers: map[string]string{
+									"DD-API-KEY":         "api_key",
+									"DD-APPLICATION-KEY": "app_key",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	prov, err := result.Providers.Get("datadog")
+	if err != nil {
+		t.Fatalf("Get provider: %v", err)
+	}
+
+	token := `{"api_key":"k1","app_key":"k2"}`
+	opResult, err := prov.Execute(ctx, "list_items", nil, token)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var resp map[string]string
+	if err := json.Unmarshal([]byte(opResult.Body), &resp); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if resp["api_key"] != "k1" {
+		t.Errorf("DD-API-KEY = %q, want %q", resp["api_key"], "k1")
+	}
+	if resp["app_key"] != "k2" {
+		t.Errorf("DD-APPLICATION-KEY = %q, want %q", resp["app_key"], "k2")
 	}
 }


### PR DESCRIPTION
Integrations that use `openapi_connection` or `mcp_connection` to
reference a named connection with `auth_mapping` were silently falling
back to the top-level `auth` config, which has no mapping. This caused
credentials like Datadog's application key to appear as a required
CLI parameter instead of being injected server-side from the stored
token.

Named connections are now resolved for each provider type (OpenAPI,
GraphQL, MCP), so `auth_mapping` configured on a named connection flows
through to the upstream request as intended.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>