### PR TITLE
Add write timeout middleware to API routes

### DIFF
--- a/server/internal/server/routes.go
+++ b/server/internal/server/routes.go
@@ -1,6 +1,11 @@
 package server
 
-import "github.com/go-chi/chi/v5"
+import (
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
 
 func (s *Server) routes() {
 	r := s.router
@@ -34,6 +39,7 @@ func (s *Server) mountMCPRoutes(r chi.Router) {
 
 func (s *Server) mountAPIRoutes(r chi.Router) {
 	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(middleware.Timeout(60 * time.Second))
 		s.mountAuthRoutes(r)
 		s.mountBindingRoutes(r)
 		s.mountAuthenticatedRoutes(r)


### PR DESCRIPTION
The HTTP server has ReadHeaderTimeout and IdleTimeout configured, but API
routes had no write timeout, leaving them vulnerable to slow-client attacks.
This adds chi's Timeout middleware (60s) to the /api/v1 route group only,
keeping the MCP/SSE endpoint unaffected since it relies on streaming.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>