### PR TITLE
Use pattern-based asset discovery for plugin resolution

### DIFF
--- a/server/internal/pluginsource/github/resolver.go
+++ b/server/internal/pluginsource/github/resolver.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -21,6 +22,29 @@ const (
 	acceptOctetStream   = "application/octet-stream"
 	envGitHubToken      = "GITHUB_TOKEN"
 	authTokenPrefix     = "token "
+	platformAssetPrefix = "gestalt-plugin-"
+)
+
+type platformAssetMatch int
+
+const (
+	noPlatformAssetMatch platformAssetMatch = iota
+	pluginOnlyPlatformAssetMatch
+	versionedPlatformAssetMatch
+)
+
+var (
+	platformSeparators = []string{"_", "-", "."}
+	platformOSAliases  = map[string][]string{
+		"darwin":  {"darwin", "macos"},
+		"linux":   {"linux"},
+		"windows": {"windows", "win32"},
+	}
+	platformArchAliases = map[string][]string{
+		"386":   {"386", "x86"},
+		"amd64": {"amd64", "x86_64"},
+		"arm64": {"arm64", "aarch64"},
+	}
 )
 
 type releaseResponse struct {
@@ -61,8 +85,7 @@ func (r *GitHubResolver) Resolve(ctx context.Context, src pluginsource.Source, v
 		return nil, err
 	}
 
-	expectedName := src.AssetName(version)
-	asset, err := findAsset(release.Assets, expectedName, tag, src.RepoSlug())
+	asset, err := findAsset(release.Assets, src.Plugin, version)
 	if err != nil {
 		return nil, err
 	}
@@ -110,20 +133,153 @@ func (r *GitHubResolver) fetchRelease(ctx context.Context, client *http.Client, 
 	return &release, nil
 }
 
-func findAsset(assets []releaseAsset, expectedName, tag, slug string) (releaseAsset, error) {
+func findAsset(assets []releaseAsset, plugin, version string) (releaseAsset, error) {
+	if plugin == "" {
+		return releaseAsset{}, fmt.Errorf("plugin name is required")
+	}
+
+	expectedName := platformAssetName(plugin, version)
+	oldName := pluginsource.Source{Plugin: plugin}.AssetName(version)
+
+	if asset, ok := findAssetByName(assets, expectedName); ok {
+		return asset, nil
+	}
+
+	oldAsset, hasOldAsset := findAssetByName(assets, oldName)
+
+	versionedMatches := make([]releaseAsset, 0, 1)
+	pluginOnlyMatches := make([]releaseAsset, 0, 1)
 	for _, a := range assets {
-		if a.Name == expectedName {
-			return a, nil
+		switch matchesPlatformAsset(a.Name, plugin, version) {
+		case versionedPlatformAssetMatch:
+			versionedMatches = append(versionedMatches, a)
+		case pluginOnlyPlatformAssetMatch:
+			pluginOnlyMatches = append(pluginOnlyMatches, a)
 		}
+	}
+
+	switch len(versionedMatches) {
+	case 1:
+		return versionedMatches[0], nil
+	case 0:
+	default:
+		if hasOldAsset {
+			return oldAsset, nil
+		}
+		return releaseAsset{}, fmt.Errorf(
+			"multiple %s/%s assets found for plugin %q version %q: %s",
+			runtime.GOOS, runtime.GOARCH, plugin, version, joinAssetNames(versionedMatches),
+		)
+	}
+
+	switch len(pluginOnlyMatches) {
+	case 1:
+		return pluginOnlyMatches[0], nil
+	case 0:
+	default:
+		if hasOldAsset {
+			return oldAsset, nil
+		}
+		return releaseAsset{}, fmt.Errorf(
+			"multiple %s/%s assets found for plugin %q version %q: %s",
+			runtime.GOOS, runtime.GOARCH, plugin, version, joinAssetNames(pluginOnlyMatches),
+		)
+	}
+
+	if hasOldAsset {
+		return oldAsset, nil
+	}
+
+	return releaseAsset{}, fmt.Errorf(
+		"no %s/%s asset found for plugin %q in release v%s; available: %s",
+		runtime.GOOS, runtime.GOARCH, plugin, version, joinAssetNames(assets),
+	)
+}
+
+func platformAssetName(plugin, version string) string {
+	return fmt.Sprintf("%s%s_v%s_%s_%s.tar.gz", platformAssetPrefix, plugin, version, runtime.GOOS, runtime.GOARCH)
+}
+
+func findAssetByName(assets []releaseAsset, name string) (releaseAsset, bool) {
+	for _, a := range assets {
+		if a.Name == name {
+			return a, true
+		}
+	}
+	return releaseAsset{}, false
+}
+
+func matchesPlatformAsset(name, plugin, version string) platformAssetMatch {
+	stem, ok := trimPlatformArchive(name)
+	if !ok {
+		return noPlatformAssetMatch
+	}
+	if !strings.HasPrefix(stem, platformAssetPrefix) {
+		return noPlatformAssetMatch
+	}
+
+	rest := strings.TrimPrefix(stem, platformAssetPrefix)
+	if rest == plugin {
+		return pluginOnlyPlatformAssetMatch
+	}
+
+	for _, sep := range platformSeparators {
+		for _, versionToken := range []string{"v" + version, version} {
+			if rest == plugin+sep+versionToken || rest == versionToken+sep+plugin {
+				return versionedPlatformAssetMatch
+			}
+		}
+	}
+
+	return noPlatformAssetMatch
+}
+
+func trimPlatformArchive(name string) (string, bool) {
+	base, ok := trimPackageArchiveExtension(name)
+	if !ok {
+		return "", false
+	}
+	for _, goos := range platformAliases(platformOSAliases, runtime.GOOS) {
+		for _, goarch := range platformAliases(platformArchAliases, runtime.GOARCH) {
+			for _, leadSep := range platformSeparators {
+				for _, midSep := range platformSeparators {
+					suffix := leadSep + goos + midSep + goarch
+					if strings.HasSuffix(base, suffix) {
+						return strings.TrimSuffix(base, suffix), true
+					}
+				}
+			}
+		}
+	}
+	return "", false
+}
+
+func platformAliases(aliasMap map[string][]string, name string) []string {
+	if aliases, ok := aliasMap[name]; ok {
+		return aliases
+	}
+	return []string{name}
+}
+
+// Remote plugin packages are tarball archives today; pluginpkg only reads gzip-compressed tar packages.
+func trimPackageArchiveExtension(name string) (string, bool) {
+	for _, ext := range []string{".tar.gz", ".tgz"} {
+		if strings.HasSuffix(name, ext) {
+			return strings.TrimSuffix(name, ext), true
+		}
+	}
+	return "", false
+}
+
+func joinAssetNames(assets []releaseAsset) string {
+	if len(assets) == 0 {
+		return "(none)"
 	}
 	names := make([]string, len(assets))
 	for i, a := range assets {
 		names[i] = a.Name
 	}
-	return releaseAsset{}, fmt.Errorf(
-		"release %s for %s does not contain asset %s; available assets: %s",
-		tag, slug, expectedName, strings.Join(names, ", "),
-	)
+	return strings.Join(names, ", ")
 }
 
 func (r *GitHubResolver) downloadAsset(ctx context.Context, client *http.Client, assetURL, token string) (*pluginpkg.DownloadResult, error) {

--- a/server/internal/pluginsource/github/resolver_test.go
+++ b/server/internal/pluginsource/github/resolver_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -30,6 +31,39 @@ var testSource = pluginsource.Source{
 	Plugin: testPlugin,
 }
 
+func currentPlatformAssetName() string {
+	return platformAssetNameFor(testPlugin, testVersion)
+}
+
+func platformAssetNameFor(plugin, version string, extras ...string) string {
+	base := platformAssetPrefix + plugin + "_v" + version
+	for _, extra := range extras {
+		if extra != "" {
+			base += "_" + extra
+		}
+	}
+	return base + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+}
+
+func variantPlatformAssetName(stem, leadSep, midSep, ext string) string {
+	return aliasedPlatformAssetName(stem, leadSep, midSep, ext, runtime.GOOS, runtime.GOARCH)
+}
+
+func aliasedPlatformAssetName(stem, leadSep, midSep, ext, goos, goarch string) string {
+	return stem + leadSep + goos + midSep + goarch + ext
+}
+
+func secondaryPlatformName(aliases []string) string {
+	if len(aliases) > 1 {
+		return aliases[1]
+	}
+	return aliases[0]
+}
+
+func oldStyleAssetName() string {
+	return testSource.AssetName(testVersion)
+}
+
 func releaseJSON(t *testing.T, assets []releaseAsset) []byte {
 	t.Helper()
 	b, err := json.Marshal(releaseResponse{Assets: assets})
@@ -46,10 +80,6 @@ func testAssetPayload() []byte {
 func testAssetSHA256() string {
 	h := sha256.Sum256(testAssetPayload())
 	return hex.EncodeToString(h[:])
-}
-
-func expectedAssetName() string {
-	return testSource.AssetName(testVersion)
 }
 
 func expectedTag() string {
@@ -98,9 +128,9 @@ func withAssetStatus(code int) serverOption {
 	}
 }
 
-func newTestServer(t *testing.T, opts ...serverOption) *httptest.Server {
+func newTestServer(t *testing.T, assetName string, opts ...serverOption) *httptest.Server {
 	t.Helper()
-	browserURL := "https://github.com/" + testOwner + "/" + testRepo + "/releases/download/" + expectedTag() + "/" + expectedAssetName()
+	browserURL := "https://github.com/" + testOwner + "/" + testRepo + "/releases/download/" + expectedTag() + "/" + assetName
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		for _, opt := range opts {
 			if opt(w, r) {
@@ -112,7 +142,7 @@ func newTestServer(t *testing.T, opts ...serverOption) *httptest.Server {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write(releaseJSON(t, []releaseAsset{
 				{
-					Name:               expectedAssetName(),
+					Name:               assetName,
 					URL:                "http://" + r.Host + "/asset-dl",
 					BrowserDownloadURL: browserURL,
 				},
@@ -125,13 +155,285 @@ func newTestServer(t *testing.T, opts ...serverOption) *httptest.Server {
 	}))
 }
 
+func TestFindAssetPlatformMatch(t *testing.T) {
+	t.Parallel()
+
+	want := aliasedPlatformAssetName(
+		platformAssetPrefix+testPlugin+".v"+testVersion,
+		".",
+		"-",
+		".tgz",
+		secondaryPlatformName(platformAliases(platformOSAliases, runtime.GOOS)),
+		secondaryPlatformName(platformAliases(platformArchAliases, runtime.GOARCH)),
+	)
+	assets := []releaseAsset{
+		{Name: variantPlatformAssetName(platformAssetPrefix+"my-"+testPlugin, "_", "_", ".tar.gz"), URL: "http://z", BrowserDownloadURL: "http://z"},
+		{Name: want, URL: "http://x", BrowserDownloadURL: "http://x"},
+		{Name: platformAssetNameFor(testPlugin, "1.2.2"), URL: "http://y", BrowserDownloadURL: "http://y"},
+	}
+	got, err := findAsset(assets, testPlugin, testVersion)
+	if err != nil {
+		t.Fatalf("findAsset() error: %v", err)
+	}
+	if got.Name != want {
+		t.Errorf("findAsset() = %q, want %q", got.Name, want)
+	}
+}
+
+func TestFindAssetBackwardCompat(t *testing.T) {
+	t.Parallel()
+
+	assets := []releaseAsset{
+		{Name: oldStyleAssetName(), URL: "http://x", BrowserDownloadURL: "http://x"},
+	}
+	got, err := findAsset(assets, testPlugin, testVersion)
+	if err != nil {
+		t.Fatalf("findAsset() error: %v", err)
+	}
+	if got.Name != oldStyleAssetName() {
+		t.Errorf("findAsset() = %q, want %q", got.Name, oldStyleAssetName())
+	}
+}
+
+func TestFindAssetNoMatch(t *testing.T) {
+	t.Parallel()
+
+	assets := []releaseAsset{
+		{Name: "gestalt-plugin-linter_v1.2.3_fakeos_fakearch.tar.gz", URL: "http://x", BrowserDownloadURL: "http://x"},
+		{Name: "unrelated.zip", URL: "http://y", BrowserDownloadURL: "http://y"},
+	}
+	_, err := findAsset(assets, testPlugin, testVersion)
+	if err == nil {
+		t.Fatal("expected error for no matching asset")
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, runtime.GOOS+"/"+runtime.GOARCH) {
+		t.Errorf("error should mention current platform, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "gestalt-plugin-linter_v1.2.3_fakeos_fakearch.tar.gz") || !strings.Contains(errMsg, "unrelated.zip") {
+		t.Errorf("error should list available assets, got: %s", errMsg)
+	}
+}
+
+func TestFindAssetRejectsWrongVersion(t *testing.T) {
+	t.Parallel()
+
+	assets := []releaseAsset{
+		{Name: platformAssetNameFor(testPlugin, "1.2.2"), URL: "http://x", BrowserDownloadURL: "http://x"},
+	}
+	_, err := findAsset(assets, testPlugin, testVersion)
+	if err == nil {
+		t.Fatal("expected error for wrong-version asset")
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, testVersion) {
+		t.Errorf("error should mention requested version, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, platformAssetNameFor(testPlugin, "1.2.2")) {
+		t.Errorf("error should list available assets, got: %s", errMsg)
+	}
+}
+
+func TestFindAssetRejectsAmbiguousMatches(t *testing.T) {
+	t.Parallel()
+
+	goos := secondaryPlatformName(platformAliases(platformOSAliases, runtime.GOOS))
+	goarch := secondaryPlatformName(platformAliases(platformArchAliases, runtime.GOARCH))
+	assets := []releaseAsset{
+		{Name: aliasedPlatformAssetName(platformAssetPrefix+testPlugin+".v"+testVersion, ".", "-", ".tar.gz", goos, goarch), URL: "http://x", BrowserDownloadURL: "http://x"},
+		{Name: aliasedPlatformAssetName(platformAssetPrefix+"v"+testVersion+"-"+testPlugin, "-", ".", ".tgz", goos, goarch), URL: "http://y", BrowserDownloadURL: "http://y"},
+	}
+	_, err := findAsset(assets, testPlugin, testVersion)
+	if err == nil {
+		t.Fatal("expected error for ambiguous platform assets")
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "multiple") {
+		t.Errorf("error should mention multiple matches, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, aliasedPlatformAssetName(platformAssetPrefix+testPlugin+".v"+testVersion, ".", "-", ".tar.gz", goos, goarch)) || !strings.Contains(errMsg, aliasedPlatformAssetName(platformAssetPrefix+"v"+testVersion+"-"+testPlugin, "-", ".", ".tgz", goos, goarch)) {
+		t.Errorf("error should list matching assets, got: %s", errMsg)
+	}
+}
+
+func TestFindAssetAmbiguousPatternFallsBackToLegacyName(t *testing.T) {
+	t.Parallel()
+
+	goos := secondaryPlatformName(platformAliases(platformOSAliases, runtime.GOOS))
+	goarch := secondaryPlatformName(platformAliases(platformArchAliases, runtime.GOARCH))
+	assets := []releaseAsset{
+		{Name: aliasedPlatformAssetName(platformAssetPrefix+testPlugin+".v"+testVersion, ".", "-", ".tar.gz", goos, goarch), URL: "http://x", BrowserDownloadURL: "http://x"},
+		{Name: aliasedPlatformAssetName(platformAssetPrefix+"v"+testVersion+"-"+testPlugin, "-", ".", ".tgz", goos, goarch), URL: "http://y", BrowserDownloadURL: "http://y"},
+		{Name: oldStyleAssetName(), URL: "http://z", BrowserDownloadURL: "http://z"},
+	}
+	got, err := findAsset(assets, testPlugin, testVersion)
+	if err != nil {
+		t.Fatalf("findAsset() error: %v", err)
+	}
+	if got.Name != oldStyleAssetName() {
+		t.Errorf("findAsset() = %q, want %q", got.Name, oldStyleAssetName())
+	}
+}
+
+func TestFindAssetAmbiguousPluginOnlyPatternFallsBackToLegacyName(t *testing.T) {
+	t.Parallel()
+
+	goos := secondaryPlatformName(platformAliases(platformOSAliases, runtime.GOOS))
+	goarch := secondaryPlatformName(platformAliases(platformArchAliases, runtime.GOARCH))
+	assets := []releaseAsset{
+		{Name: aliasedPlatformAssetName(platformAssetPrefix+testPlugin, ".", "-", ".tar.gz", goos, goarch), URL: "http://x", BrowserDownloadURL: "http://x"},
+		{Name: aliasedPlatformAssetName(platformAssetPrefix+testPlugin, "-", ".", ".tgz", goos, goarch), URL: "http://y", BrowserDownloadURL: "http://y"},
+		{Name: oldStyleAssetName(), URL: "http://z", BrowserDownloadURL: "http://z"},
+	}
+	got, err := findAsset(assets, testPlugin, testVersion)
+	if err != nil {
+		t.Fatalf("findAsset() error: %v", err)
+	}
+	if got.Name != oldStyleAssetName() {
+		t.Errorf("findAsset() = %q, want %q", got.Name, oldStyleAssetName())
+	}
+}
+
+func TestFindAssetVersionBeforePluginMatch(t *testing.T) {
+	t.Parallel()
+
+	want := variantPlatformAssetName(platformAssetPrefix+"v"+testVersion+"-"+testPlugin, ".", "-", ".tgz")
+	assets := []releaseAsset{
+		{Name: want, URL: "http://x", BrowserDownloadURL: "http://x"},
+	}
+	got, err := findAsset(assets, testPlugin, testVersion)
+	if err != nil {
+		t.Fatalf("findAsset() error: %v", err)
+	}
+	if got.Name != want {
+		t.Errorf("findAsset() = %q, want %q", got.Name, want)
+	}
+}
+
+func TestFindAssetPrefersPatternMatchOverLegacyFallback(t *testing.T) {
+	t.Parallel()
+
+	want := variantPlatformAssetName(platformAssetPrefix+testPlugin+".v"+testVersion, ".", "-", ".tgz")
+	assets := []releaseAsset{
+		{Name: want, URL: "http://x", BrowserDownloadURL: "http://x"},
+		{Name: oldStyleAssetName(), URL: "http://y", BrowserDownloadURL: "http://y"},
+	}
+	got, err := findAsset(assets, testPlugin, testVersion)
+	if err != nil {
+		t.Fatalf("findAsset() error: %v", err)
+	}
+	if got.Name != want {
+		t.Errorf("findAsset() = %q, want %q", got.Name, want)
+	}
+}
+
+func TestFindAssetDoesNotMatchPluginSuffixOfDifferentPlugin(t *testing.T) {
+	t.Parallel()
+
+	assets := []releaseAsset{
+		{Name: variantPlatformAssetName(platformAssetPrefix+"my-"+testPlugin+"_v"+testVersion, "_", "_", ".tar.gz"), URL: "http://x", BrowserDownloadURL: "http://x"},
+		{Name: variantPlatformAssetName(platformAssetPrefix+"my_"+testPlugin+"_v"+testVersion, "_", "_", ".tar.gz"), URL: "http://y", BrowserDownloadURL: "http://y"},
+	}
+	_, err := findAsset(assets, testPlugin, testVersion)
+	if err == nil {
+		t.Fatal("expected error for mismatched plugin suffix")
+	}
+	if !strings.Contains(err.Error(), "my-"+testPlugin) || !strings.Contains(err.Error(), "my_"+testPlugin) {
+		t.Errorf("error should list mismatched asset, got: %s", err.Error())
+	}
+}
+
+func TestFindAssetDoesNotMatchPluginOnlySuffixOfDifferentPlugin(t *testing.T) {
+	t.Parallel()
+
+	assets := []releaseAsset{
+		{Name: variantPlatformAssetName(platformAssetPrefix+"my-"+testPlugin, "_", "_", ".tar.gz"), URL: "http://x", BrowserDownloadURL: "http://x"},
+		{Name: variantPlatformAssetName(platformAssetPrefix+"my_"+testPlugin, "_", "_", ".tgz"), URL: "http://y", BrowserDownloadURL: "http://y"},
+	}
+	_, err := findAsset(assets, testPlugin, testVersion)
+	if err == nil {
+		t.Fatal("expected error for mismatched plugin-only suffix")
+	}
+	if !strings.Contains(err.Error(), "my-"+testPlugin) || !strings.Contains(err.Error(), "my_"+testPlugin) {
+		t.Errorf("error should list mismatched asset, got: %s", err.Error())
+	}
+}
+
+func TestFindAssetMatchesOfficialPluginOnlyArchive(t *testing.T) {
+	t.Parallel()
+
+	want := aliasedPlatformAssetName(
+		platformAssetPrefix+testPlugin,
+		"-",
+		"-",
+		".tar.gz",
+		secondaryPlatformName(platformAliases(platformOSAliases, runtime.GOOS)),
+		secondaryPlatformName(platformAliases(platformArchAliases, runtime.GOARCH)),
+	)
+	assets := []releaseAsset{
+		{Name: want, URL: "http://x", BrowserDownloadURL: "http://x"},
+	}
+	got, err := findAsset(assets, testPlugin, testVersion)
+	if err != nil {
+		t.Fatalf("findAsset() error: %v", err)
+	}
+	if got.Name != want {
+		t.Errorf("findAsset() = %q, want %q", got.Name, want)
+	}
+}
+
+func TestFindAssetPrefersVersionedPatternOverPluginOnlyPattern(t *testing.T) {
+	t.Parallel()
+
+	want := variantPlatformAssetName(platformAssetPrefix+testPlugin+"-"+testVersion, "-", "-", ".tgz")
+	assets := []releaseAsset{
+		{Name: variantPlatformAssetName(platformAssetPrefix+testPlugin, "_", "_", ".tar.gz"), URL: "http://y", BrowserDownloadURL: "http://y"},
+		{Name: want, URL: "http://x", BrowserDownloadURL: "http://x"},
+	}
+	got, err := findAsset(assets, testPlugin, testVersion)
+	if err != nil {
+		t.Fatalf("findAsset() error: %v", err)
+	}
+	if got.Name != want {
+		t.Errorf("findAsset() = %q, want %q", got.Name, want)
+	}
+}
+
+func TestFindAssetRejectsUnofficialPlatformArchive(t *testing.T) {
+	t.Parallel()
+
+	assets := []releaseAsset{
+		{Name: variantPlatformAssetName(testPlugin+".v"+testVersion, ".", "-", ".tgz"), URL: "http://x", BrowserDownloadURL: "http://x"},
+	}
+	_, err := findAsset(assets, testPlugin, testVersion)
+	if err == nil {
+		t.Fatal("expected error for unofficial platform archive")
+	}
+	if !strings.Contains(err.Error(), testPlugin+".v"+testVersion) {
+		t.Errorf("error should list unofficial asset, got: %s", err.Error())
+	}
+}
+
+func TestFindAssetRejectsEmptyPlugin(t *testing.T) {
+	t.Parallel()
+
+	_, err := findAsset([]releaseAsset{{Name: currentPlatformAssetName(), URL: "http://x", BrowserDownloadURL: "http://x"}}, "", testVersion)
+	if err == nil {
+		t.Fatal("expected error for empty plugin name")
+	}
+	if !strings.Contains(err.Error(), "plugin name is required") {
+		t.Errorf("error = %q, want mention of missing plugin name", err.Error())
+	}
+}
+
 func TestResolveSuccess(t *testing.T) {
 	t.Parallel()
 
-	srv := newTestServer(t)
+	assetName := currentPlatformAssetName()
+	srv := newTestServer(t, assetName)
 	defer srv.Close()
 
-	browserURL := "https://github.com/" + testOwner + "/" + testRepo + "/releases/download/" + expectedTag() + "/" + expectedAssetName()
+	browserURL := "https://github.com/" + testOwner + "/" + testRepo + "/releases/download/" + expectedTag() + "/" + assetName
 
 	resolver := &GitHubResolver{BaseURL: srv.URL}
 	pkg, err := resolver.Resolve(context.Background(), testSource, testVersion)
@@ -153,6 +455,25 @@ func TestResolveSuccess(t *testing.T) {
 	pkg.Cleanup()
 	if _, err := os.Stat(pkg.LocalPath); !os.IsNotExist(err) {
 		t.Error("temp file should be removed after Cleanup()")
+	}
+}
+
+func TestResolveBackwardCompatAsset(t *testing.T) {
+	t.Parallel()
+
+	assetName := oldStyleAssetName()
+	srv := newTestServer(t, assetName)
+	defer srv.Close()
+
+	resolver := &GitHubResolver{BaseURL: srv.URL}
+	pkg, err := resolver.Resolve(context.Background(), testSource, testVersion)
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	defer pkg.Cleanup()
+
+	if pkg.ArchiveSHA256 != testAssetSHA256() {
+		t.Errorf("SHA256 = %s, want %s", pkg.ArchiveSHA256, testAssetSHA256())
 	}
 }
 
@@ -195,8 +516,8 @@ func TestResolveAssetNameMismatch(t *testing.T) {
 	}
 
 	errMsg := err.Error()
-	if want := "does not contain asset " + expectedAssetName(); !strings.Contains(errMsg, want) {
-		t.Errorf("error should mention expected asset name, got: %s", errMsg)
+	if !strings.Contains(errMsg, runtime.GOOS+"/"+runtime.GOARCH) {
+		t.Errorf("error should mention current platform, got: %s", errMsg)
 	}
 	if !strings.Contains(errMsg, "wrong-asset.tar.gz") || !strings.Contains(errMsg, "also-wrong.zip") {
 		t.Errorf("error should list available assets, got: %s", errMsg)
@@ -207,7 +528,7 @@ func TestResolveAuthenticatedRequest(t *testing.T) {
 	t.Parallel()
 
 	var log requestLog
-	srv := newTestServer(t, withAuthLog(&log))
+	srv := newTestServer(t, currentPlatformAssetName(), withAuthLog(&log))
 	defer srv.Close()
 
 	resolver := &GitHubResolver{BaseURL: srv.URL, Token: testToken}
@@ -234,7 +555,7 @@ func TestResolveGitHubTokenEnvFallback(t *testing.T) {
 	t.Setenv(envGitHubToken, envToken)
 
 	var log requestLog
-	srv := newTestServer(t, withAuthLog(&log))
+	srv := newTestServer(t, currentPlatformAssetName(), withAuthLog(&log))
 	defer srv.Close()
 
 	resolver := &GitHubResolver{BaseURL: srv.URL}
@@ -255,7 +576,7 @@ func TestResolveGitHubTokenEnvFallback(t *testing.T) {
 func TestResolveDownloadError(t *testing.T) {
 	t.Parallel()
 
-	srv := newTestServer(t, withAssetStatus(http.StatusInternalServerError))
+	srv := newTestServer(t, currentPlatformAssetName(), withAssetStatus(http.StatusInternalServerError))
 	defer srv.Close()
 
 	resolver := &GitHubResolver{BaseURL: srv.URL}


### PR DESCRIPTION
The GitHub resolver previously constructed an exact expected filename
and matched it against release assets. This duplicated the naming
convention between the release command and the resolver, meaning any
naming change had to be coordinated in both places. Following the
approach used by cargo-binstall and Python pip, the resolver now uses
pattern matching (plugin name plus platform suffix) to find the right
asset. A fallback to the old single-archive naming preserves backward
compatibility with existing releases.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>