### PR TITLE
Add gestaltd plugin release command

### DIFF
--- a/server/cmd/gestaltd/e2e_test.go
+++ b/server/cmd/gestaltd/e2e_test.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -400,16 +398,7 @@ func copyFile(src, dst string) error {
 }
 
 func fileSHA256(path string) (string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = f.Close() }()
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(h.Sum(nil)), nil
+	return fileSHA256Hex(path)
 }
 
 func writeE2EConfig(t *testing.T, dir, packageRef string, port int) string {

--- a/server/cmd/gestaltd/plugin.go
+++ b/server/cmd/gestaltd/plugin.go
@@ -3,12 +3,15 @@ package main
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
+	"os/exec"
+	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
@@ -28,6 +31,8 @@ func runPlugin(args []string) error {
 		return flag.ErrHelp
 	case "package":
 		return runPluginPackage(args[1:])
+	case "release":
+		return runPluginRelease(args[1:])
 	default:
 		return fmt.Errorf("unknown plugin command %q", args[0])
 	}
@@ -38,21 +43,11 @@ func runPluginPackage(args []string) error {
 	fs.Usage = func() { printPluginPackageUsage(fs.Output()) }
 	input := fs.String("input", "", "path to plugin manifest or build directory")
 	output := fs.String("output", "", "output path (directory, or .tar.gz for archive)")
-	binary := fs.String("binary", "", "path to pre-built binary (scaffolds manifest automatically)")
-	source := fs.String("source", "", "plugin source (github.com/owner/repo/plugin), required with --binary")
-	kind := fs.String("kind", "provider", "plugin kind (provider or runtime), used with --binary")
-	targetOS := fs.String("os", runtime.GOOS, "target OS for the artifact, used with --binary")
-	targetArch := fs.String("arch", runtime.GOARCH, "target architecture, used with --binary")
-	version := fs.String("version", "0.0.0-alpha.1", "manifest version, used with --binary")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if fs.NArg() > 0 {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
-	}
-
-	if *binary != "" {
-		return packageFromBinary(*binary, *source, *kind, *version, *targetOS, *targetArch, *output)
 	}
 	return packageFromDir(*input, *output)
 }
@@ -85,128 +80,541 @@ func packageFromDir(input, output string) error {
 	return nil
 }
 
-func packageFromBinary(binaryPath, source, kind, version, targetOS, targetArch, output string) error {
-	if source == "" {
-		return fmt.Errorf("usage: gestaltd plugin package --binary PATH --source SOURCE --output PATH")
+const defaultPlatforms = "darwin/amd64,darwin/arm64,linux/amd64,linux/arm64"
+const defaultReleaseOutputDir = "dist/"
+const releaseCmdBuildTarget = "./cmd"
+const releaseRootBuildTarget = "."
+const releaseBinaryPrefix = "gestalt-plugin-"
+const windowsOS = "windows"
+const windowsExecutableSuffix = ".exe"
+
+type releasePlatform struct {
+	GOOS   string
+	GOARCH string
+}
+
+func runPluginRelease(args []string) error {
+	fs := flag.NewFlagSet("gestaltd plugin release", flag.ContinueOnError)
+	fs.Usage = func() { printPluginReleaseUsage(fs.Output()) }
+	version := fs.String("version", "", "semantic version string (required)")
+	outputDir := fs.String("output", defaultReleaseOutputDir, "output directory")
+	platforms := fs.String("platform", defaultPlatforms, "comma-separated platforms (os/arch)")
+	if err := fs.Parse(args); err != nil {
+		return err
 	}
-	if output == "" {
-		return fmt.Errorf("--output is required")
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
 	}
-	if kind != pluginmanifestv1.KindProvider && kind != pluginmanifestv1.KindRuntime {
-		return fmt.Errorf("kind must be %q or %q", pluginmanifestv1.KindProvider, pluginmanifestv1.KindRuntime)
+	if *version == "" {
+		return fmt.Errorf("--version is required")
 	}
 
-	if _, err := pluginsource.Parse(source); err != nil {
-		return fmt.Errorf("invalid --source: %w", err)
-	}
-	if err := pluginsource.ValidateVersion(version); err != nil {
-		return fmt.Errorf("invalid --version for source plugin: %w", err)
+	if err := pluginsource.ValidateVersion(*version); err != nil {
+		return fmt.Errorf("invalid --version: %w", err)
 	}
 
-	scaffoldDir := output
-	var cleanup func()
-	if isArchiveOutput(output) {
-		tmp, err := os.MkdirTemp("", "gestalt-plugin-pkg-*")
+	manifestPath, err := pluginpkg.FindManifestFile(".")
+	if err != nil {
+		return err
+	}
+	_, srcManifest, err := pluginpkg.ReadManifestFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("decode %s: %w", manifestPath, err)
+	}
+
+	src, err := pluginsource.Parse(srcManifest.Source)
+	if err != nil {
+		return fmt.Errorf("invalid source in manifest: %w", err)
+	}
+	pluginName := src.Plugin
+
+	if err := validateReleaseOutputDir(srcManifest, ".", *outputDir); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(*outputDir, 0755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+
+	buildTarget, compiled, err := findReleaseBuildTarget(".")
+	if err != nil {
+		return fmt.Errorf("detect build target: %w", err)
+	}
+	var archivePaths []string
+
+	if compiled {
+		platList, err := parseReleasePlatforms(*platforms)
 		if err != nil {
 			return err
 		}
-		cleanup = func() { _ = os.RemoveAll(tmp) }
-		defer cleanup()
-		scaffoldDir = tmp
-	} else {
-		if err := os.MkdirAll(output, 0755); err != nil {
-			return fmt.Errorf("create output dir: %w", err)
+		for _, plat := range platList {
+			archivePath, err := buildPlatformArchive(srcManifest, pluginName, *version, buildTarget, plat, *outputDir)
+			if err != nil {
+				return fmt.Errorf("build %s/%s: %w", plat.GOOS, plat.GOARCH, err)
+			}
+			archivePaths = append(archivePaths, archivePath)
 		}
-	}
-
-	artifactRel := filepath.ToSlash(filepath.Join("artifacts", targetOS, targetArch, kind))
-	artifactAbs := filepath.Join(scaffoldDir, filepath.FromSlash(artifactRel))
-
-	if err := os.MkdirAll(filepath.Dir(artifactAbs), 0755); err != nil {
-		return err
-	}
-
-	digest, err := copyAndDigest(binaryPath, artifactAbs)
-	if err != nil {
-		return fmt.Errorf("copying binary: %w", err)
-	}
-
-	manifest := buildManifest(source, kind, version, targetOS, targetArch, artifactRel, digest)
-	data, err := pluginpkg.EncodeManifest(manifest)
-	if err != nil {
-		return fmt.Errorf("encoding manifest: %w", err)
-	}
-	if err := os.WriteFile(filepath.Join(scaffoldDir, pluginpkg.ManifestFile), data, 0644); err != nil {
-		return fmt.Errorf("writing manifest: %w", err)
-	}
-
-	if isArchiveOutput(output) {
-		if err := pluginpkg.CreatePackageFromDir(scaffoldDir, output); err != nil {
+	} else {
+		archivePath, err := buildSourceArchive(srcManifest, pluginName, *version, *outputDir)
+		if err != nil {
 			return err
 		}
+		archivePaths = append(archivePaths, archivePath)
 	}
-	_, _ = fmt.Fprintf(os.Stdout, "packaged %s (%s) -> %s\n", source, binaryPath, output)
+
+	if err := writeChecksums(*outputDir, archivePaths); err != nil {
+		return fmt.Errorf("write checksums: %w", err)
+	}
+
 	return nil
 }
 
-func buildManifest(source, kind, version, targetOS, targetArch, artifactRel, digest string) *pluginmanifestv1.Manifest {
-	m := newManifestSkeleton(kind, version, targetOS, targetArch, artifactRel, digest)
-	m.Source = source
-	return m
-}
-
-func newManifestSkeleton(kind, version, targetOS, targetArch, artifactRel, digest string) *pluginmanifestv1.Manifest {
-	m := &pluginmanifestv1.Manifest{
-		Version: version,
-		Kinds:   []string{kind},
-		Artifacts: []pluginmanifestv1.Artifact{
-			{
-				OS:     targetOS,
-				Arch:   targetArch,
-				Path:   artifactRel,
-				SHA256: digest,
-			},
-		},
-	}
-
-	switch kind {
-	case pluginmanifestv1.KindProvider:
-		m.Provider = &pluginmanifestv1.Provider{}
-		m.Entrypoints.Provider = &pluginmanifestv1.Entrypoint{
-			ArtifactPath: artifactRel,
-		}
-	case pluginmanifestv1.KindRuntime:
-		m.Entrypoints.Runtime = &pluginmanifestv1.Entrypoint{
-			ArtifactPath: artifactRel,
-		}
-	}
-
-	return m
-}
-
-func copyAndDigest(src, dst string) (string, error) {
-	in, err := os.Open(src)
+func buildPlatformArchive(srcManifest *pluginmanifestv1.Manifest, pluginName, version, buildTarget string, plat releasePlatform, outputDir string) (string, error) {
+	stagingDir, err := os.MkdirTemp("", "gestalt-release-*")
 	if err != nil {
 		return "", err
+	}
+	defer func() { _ = os.RemoveAll(stagingDir) }()
+
+	binaryName := releaseBinaryName(pluginName, plat.GOOS)
+	binaryPath := filepath.Join(stagingDir, binaryName)
+
+	cmd := exec.Command("go", "build", "-trimpath", "-ldflags", "-s -w", "-o", binaryPath, buildTarget)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS="+plat.GOOS, "GOARCH="+plat.GOARCH)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("go build: %w", err)
+	}
+
+	digest, err := fileSHA256Hex(binaryPath)
+	if err != nil {
+		return "", fmt.Errorf("hash binary: %w", err)
+	}
+
+	manifest, err := buildReleaseManifest(srcManifest, version, binaryName, plat, digest)
+	if err != nil {
+		return "", err
+	}
+
+	data, err := pluginpkg.EncodeManifest(manifest)
+	if err != nil {
+		return "", fmt.Errorf("encode manifest: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(stagingDir, pluginpkg.ManifestFile), data, 0644); err != nil {
+		return "", err
+	}
+
+	if err := copyReleasePackageFiles(srcManifest, ".", stagingDir, false); err != nil {
+		return "", err
+	}
+
+	archiveName := fmt.Sprintf("gestalt-plugin-%s_v%s_%s_%s.tar.gz", pluginName, version, plat.GOOS, plat.GOARCH)
+	archivePath := filepath.Join(outputDir, archiveName)
+	if err := pluginpkg.CreatePackageFromDir(stagingDir, archivePath); err != nil {
+		return "", err
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "created %s\n", archivePath)
+	return archivePath, nil
+}
+
+func findReleaseBuildTarget(root string) (string, bool, error) {
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+
+	cmdDirHasGoFiles, err := dirHasGoFiles(filepath.Join(root, "cmd"))
+	if err != nil {
+		return "", false, err
+	}
+	if cmdDirHasGoFiles {
+		isMain, err := isMainPackage(root, releaseCmdBuildTarget)
+		if err != nil {
+			return "", false, err
+		}
+		if isMain {
+			return releaseCmdBuildTarget, true, nil
+		}
+	}
+
+	rootHasGoFiles, err := dirHasGoFiles(root)
+	if err != nil {
+		return "", false, err
+	}
+	if rootHasGoFiles {
+		isMain, err := isMainPackage(root, releaseRootBuildTarget)
+		if err != nil {
+			return "", false, err
+		}
+		if isMain {
+			return releaseRootBuildTarget, true, nil
+		}
+	}
+
+	return "", false, nil
+}
+
+func dirHasGoFiles(dir string) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(entry.Name(), ".go") && !strings.HasSuffix(entry.Name(), "_test.go") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func isMainPackage(root, buildTarget string) (bool, error) {
+	cmd := exec.Command("go", "list", "-f", "{{.Name}}", buildTarget)
+	cmd.Dir = root
+	out, err := cmd.Output()
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(out)) == "main", nil
+}
+
+func parseReleasePlatforms(value string) ([]releasePlatform, error) {
+	parts := strings.Split(value, ",")
+	platforms := make([]releasePlatform, 0, len(parts))
+	for _, part := range parts {
+		plat := strings.TrimSpace(part)
+		pieces := strings.SplitN(plat, "/", 2)
+		if len(pieces) != 2 || pieces[0] == "" || pieces[1] == "" {
+			return nil, fmt.Errorf("invalid platform %q, expected os/arch", plat)
+		}
+		platforms = append(platforms, releasePlatform{
+			GOOS:   pieces[0],
+			GOARCH: pieces[1],
+		})
+	}
+	return platforms, nil
+}
+
+func buildSourceArchive(srcManifest *pluginmanifestv1.Manifest, pluginName, version, outputDir string) (string, error) {
+	stagingDir, err := os.MkdirTemp("", "gestalt-release-*")
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = os.RemoveAll(stagingDir) }()
+
+	manifest, err := cloneManifest(srcManifest)
+	if err != nil {
+		return "", fmt.Errorf("clone manifest: %w", err)
+	}
+	manifest.Version = version
+
+	data, err := pluginpkg.EncodeManifest(manifest)
+	if err != nil {
+		return "", fmt.Errorf("encode manifest: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(stagingDir, pluginpkg.ManifestFile), data, 0644); err != nil {
+		return "", err
+	}
+
+	if err := validateReleaseArtifactDigests(srcManifest, "."); err != nil {
+		return "", err
+	}
+	if err := copyReleasePackageFiles(srcManifest, ".", stagingDir, true); err != nil {
+		return "", err
+	}
+
+	archiveName := fmt.Sprintf("gestalt-plugin-%s_v%s.tar.gz", pluginName, version)
+	archivePath := filepath.Join(outputDir, archiveName)
+	if err := pluginpkg.CreatePackageFromDir(stagingDir, archivePath); err != nil {
+		return "", err
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "created %s\n", archivePath)
+	return archivePath, nil
+}
+
+func buildReleaseManifest(srcManifest *pluginmanifestv1.Manifest, version, binaryName string, plat releasePlatform, digest string) (*pluginmanifestv1.Manifest, error) {
+	manifest, err := cloneManifest(srcManifest)
+	if err != nil {
+		return nil, fmt.Errorf("clone manifest: %w", err)
+	}
+	manifest.Version = version
+	manifest.Artifacts = []pluginmanifestv1.Artifact{
+		{OS: plat.GOOS, Arch: plat.GOARCH, Path: binaryName, SHA256: digest},
+	}
+
+	for _, kind := range manifest.Kinds {
+		switch kind {
+		case pluginmanifestv1.KindProvider:
+			if manifest.Entrypoints.Provider == nil {
+				manifest.Entrypoints.Provider = &pluginmanifestv1.Entrypoint{}
+			}
+			manifest.Entrypoints.Provider.ArtifactPath = binaryName
+		case pluginmanifestv1.KindRuntime:
+			if manifest.Entrypoints.Runtime == nil {
+				manifest.Entrypoints.Runtime = &pluginmanifestv1.Entrypoint{}
+			}
+			manifest.Entrypoints.Runtime.ArtifactPath = binaryName
+		}
+	}
+
+	return manifest, nil
+}
+
+func releaseBinaryName(pluginName, goos string) string {
+	binaryName := releaseBinaryPrefix + pluginName
+	if goos == windowsOS {
+		return binaryName + windowsExecutableSuffix
+	}
+	return binaryName
+}
+
+func writeChecksums(dir string, archivePaths []string) error {
+	var lines []string
+	for _, archivePath := range archivePaths {
+		digest, err := fileSHA256Hex(archivePath)
+		if err != nil {
+			return err
+		}
+		lines = append(lines, fmt.Sprintf("%s  %s", digest, filepath.Base(archivePath)))
+	}
+
+	if len(lines) == 0 {
+		return nil
+	}
+
+	checksumPath := filepath.Join(dir, "checksums.txt")
+	content := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(checksumPath, []byte(content), 0644); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(os.Stdout, "created %s\n", checksumPath)
+	return nil
+}
+
+func fileSHA256Hex(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func cloneManifest(manifest *pluginmanifestv1.Manifest) (*pluginmanifestv1.Manifest, error) {
+	if manifest == nil {
+		return nil, nil
+	}
+
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	var cloned pluginmanifestv1.Manifest
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		return nil, err
+	}
+	return &cloned, nil
+}
+
+func copyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, p)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+		return copyReleaseFile(p, target)
+	})
+}
+
+func copyReleaseFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
 	}
 	defer func() { _ = in.Close() }()
 
-	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	info, err := in.Stat()
 	if err != nil {
-		return "", err
+		return err
 	}
-
-	h := sha256.New()
-	w := io.MultiWriter(out, h)
-	if _, err := io.Copy(w, in); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
 		_ = out.Close()
-		return "", err
+		return err
 	}
-	if err := out.Close(); err != nil {
-		return "", err
+	return out.Close()
+}
+
+func copyReleasePackageFiles(manifest *pluginmanifestv1.Manifest, sourceDir, stagingDir string, includeArtifacts bool) error {
+	if manifest == nil {
+		return nil
 	}
 
-	return hex.EncodeToString(h.Sum(nil)), nil
+	copied := make(map[string]struct{})
+	copyPath := func(rel string, optional bool) error {
+		if rel == "" {
+			return nil
+		}
+
+		cleanRel, err := normalizeReleasePath(rel)
+		if err != nil {
+			return err
+		}
+		if _, seen := copied[cleanRel]; seen {
+			return nil
+		}
+		copied[cleanRel] = struct{}{}
+
+		srcPath := filepath.Join(sourceDir, filepath.FromSlash(cleanRel))
+		info, err := os.Stat(srcPath)
+		if err != nil {
+			if optional && os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("stat support path %s: %w", rel, err)
+		}
+
+		dstPath := filepath.Join(stagingDir, filepath.FromSlash(cleanRel))
+		if info.IsDir() {
+			if err := copyDir(srcPath, dstPath); err != nil {
+				return fmt.Errorf("copy support directory %s: %w", rel, err)
+			}
+			return nil
+		}
+		if err := copyReleaseFile(srcPath, dstPath); err != nil {
+			return fmt.Errorf("copy support file %s: %w", rel, err)
+		}
+		return nil
+	}
+
+	if err := copyPath(manifest.IconFile, false); err != nil {
+		return err
+	}
+	if manifest.Provider != nil {
+		if err := copyPath(manifest.Provider.ConfigSchemaPath, false); err != nil {
+			return err
+		}
+	}
+	if manifest.WebUI != nil {
+		if err := copyPath(manifest.WebUI.AssetRoot, false); err != nil {
+			return err
+		}
+	}
+	if includeArtifacts {
+		for _, artifact := range manifest.Artifacts {
+			if err := copyPath(artifact.Path, false); err != nil {
+				return err
+			}
+		}
+	}
+	if err := copyPath(pluginpkg.RuntimeConfigSchemaPath, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateReleaseArtifactDigests(manifest *pluginmanifestv1.Manifest, sourceDir string) error {
+	if manifest == nil {
+		return nil
+	}
+
+	for _, artifact := range manifest.Artifacts {
+		cleanPath, err := normalizeReleasePath(artifact.Path)
+		if err != nil {
+			return err
+		}
+
+		digest, err := fileSHA256Hex(filepath.Join(sourceDir, filepath.FromSlash(cleanPath)))
+		if err != nil {
+			return fmt.Errorf("hash artifact %s: %w", artifact.Path, err)
+		}
+		if digest != artifact.SHA256 {
+			return fmt.Errorf("artifact %s sha256 mismatch: manifest=%s actual=%s", artifact.Path, artifact.SHA256, digest)
+		}
+	}
+
+	return nil
+}
+
+func validateReleaseOutputDir(manifest *pluginmanifestv1.Manifest, sourceDir, outputDir string) error {
+	if manifest == nil || manifest.WebUI == nil || manifest.WebUI.AssetRoot == "" {
+		return nil
+	}
+
+	assetRoot, err := normalizeReleasePath(manifest.WebUI.AssetRoot)
+	if err != nil {
+		return err
+	}
+
+	sourceAbs, err := filepath.Abs(sourceDir)
+	if err != nil {
+		return fmt.Errorf("resolve plugin root: %w", err)
+	}
+
+	assetRootAbs := filepath.Join(sourceAbs, filepath.FromSlash(assetRoot))
+	outputDirAbs := outputDir
+	if !filepath.IsAbs(outputDirAbs) {
+		outputDirAbs = filepath.Join(sourceAbs, outputDirAbs)
+	}
+	outputDirAbs = filepath.Clean(outputDirAbs)
+
+	insideAssetRoot, err := pathWithinBase(outputDirAbs, assetRootAbs)
+	if err != nil {
+		return fmt.Errorf("compare output dir to webui asset_root: %w", err)
+	}
+	if insideAssetRoot {
+		return fmt.Errorf("--output %q must not be inside webui.asset_root %q", outputDir, manifest.WebUI.AssetRoot)
+	}
+
+	return nil
+}
+
+func pathWithinBase(path, base string) (bool, error) {
+	rel, err := filepath.Rel(base, path)
+	if err != nil {
+		return false, err
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))), nil
+}
+
+func normalizeReleasePath(rel string) (string, error) {
+	if rel == "" {
+		return "", nil
+	}
+
+	cleanPath := path.Clean(strings.ReplaceAll(rel, "\\", "/"))
+	if path.IsAbs(cleanPath) || cleanPath == ".." || strings.HasPrefix(cleanPath, "../") {
+		return "", fmt.Errorf("release path %q must stay within plugin root", rel)
+	}
+	return cleanPath, nil
 }
 
 func isArchiveOutput(path string) bool {
@@ -219,16 +627,14 @@ func printPluginUsage(w io.Writer) {
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
 	writeUsageLine(w, "  package     Package a plugin for distribution")
+	writeUsageLine(w, "  release     Cross-compile and package a plugin for release")
 }
 
 func printPluginPackageUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
 	writeUsageLine(w, "  gestaltd plugin package --input PATH --output PATH")
-	writeUsageLine(w, "  gestaltd plugin package --binary PATH --source SOURCE --output PATH")
 	writeUsageLine(w, "")
-	writeUsageLine(w, "Package a plugin for distribution. Use --input with an existing plugin")
-	writeUsageLine(w, "directory containing a manifest, or --binary to scaffold and package")
-	writeUsageLine(w, "a pre-built binary in one step.")
+	writeUsageLine(w, "Package an existing plugin directory for distribution.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Output format is determined by the --output path: paths ending in")
 	writeUsageLine(w, ".tar.gz produce an archive, all other paths produce a directory.")
@@ -236,10 +642,17 @@ func printPluginPackageUsage(w io.Writer) {
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --input     Path to plugin manifest or build directory")
 	writeUsageLine(w, "  --output    Output path (directory, or .tar.gz for archive)")
-	writeUsageLine(w, "  --binary    Path to pre-built binary (scaffolds manifest automatically)")
-	writeUsageLine(w, "  --source    Plugin source (github.com/owner/repo/plugin), required with --binary")
-	writeUsageLine(w, "  --kind      Plugin kind: provider or runtime (default: provider)")
-	writeUsageLine(w, "  --os        Target OS (default: current platform)")
-	writeUsageLine(w, "  --arch      Target architecture (default: current platform)")
-	writeUsageLine(w, "  --version   Manifest version (default: 0.0.0-alpha.1)")
+}
+
+func printPluginReleaseUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd plugin release --version VERSION [--output DIR] [--platform PLATFORMS]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Cross-compile a plugin for multiple platforms and produce per-platform")
+	writeUsageLine(w, "tar.gz archives and a checksums file. Run from the plugin source directory.")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Flags:")
+	writeUsageLine(w, "  --version    Semantic version string (required)")
+	writeUsageLine(w, "  --output     Output directory (default: dist/)")
+	writeUsageLine(w, "  --platform   Comma-separated platforms (default: darwin/amd64,darwin/arm64,linux/amd64,linux/arm64)")
 }

--- a/server/cmd/gestaltd/plugin_test.go
+++ b/server/cmd/gestaltd/plugin_test.go
@@ -2,8 +2,7 @@ package main
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"flag"
 	"io"
@@ -14,9 +13,30 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
 
 var stdoutMu sync.Mutex
+
+const (
+	releaseTestPluginName      = "release-test"
+	releaseTestSource          = "github.com/testowner/plugins/release-test"
+	releaseTestModule          = "example.com/release-test"
+	releaseTestIconPath        = "branding/icon.svg"
+	releaseProviderSchemaPath  = "schemas/provider.schema.json"
+	releaseHybridArg           = "--serve-provider"
+	releaseHybridBaseURL       = "https://api.example.com"
+	releaseHybridOperationName = "list_items"
+	releaseSourceArtifactPath  = "artifacts/source-plugin"
+	webUITestPluginName        = "webui-test"
+	webUITestSource            = "github.com/testowner/plugins/webui-test"
+	webUITestAssetRoot         = "out"
+	prebuiltHybridPluginName   = "prebuilt-hybrid"
+	prebuiltHybridSource       = "github.com/testowner/plugins/prebuilt-hybrid"
+	prebuiltHybridArtifactPath = "bin/provider"
+)
 
 func TestRun_PluginHelpExitsCleanly(t *testing.T) {
 	t.Parallel()
@@ -28,6 +48,9 @@ func TestRun_PluginHelpExitsCleanly(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "gestaltd plugin <command> [flags]") {
 		t.Fatalf("expected plugin usage output, got: %s", out)
+	}
+	if !strings.Contains(string(out), "release") {
+		t.Fatalf("expected release in help output, got: %s", out)
 	}
 	for _, removed := range []string{"install", "inspect", "list", "init"} {
 		if strings.Contains(string(out), removed) {
@@ -46,6 +69,22 @@ func TestRun_PluginPackageHelpExitsCleanly(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "gestaltd plugin package --input PATH --output PATH") {
 		t.Fatalf("expected package usage output, got: %s", out)
+	}
+	if strings.Contains(string(out), "--binary") {
+		t.Fatalf("expected --binary removed from help, got: %s", out)
+	}
+}
+
+func TestRun_PluginReleaseHelpExitsCleanly(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command("go", "run", ".", "plugin", "release", "--help")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected exit 0 for 'plugin release --help', got error: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(string(out), "--version") {
+		t.Fatalf("expected --version in release help, got: %s", out)
 	}
 }
 
@@ -73,33 +112,6 @@ func TestRun_PluginPackageCreatesArchive(t *testing.T) {
 	}
 	if !strings.Contains(output, "packaged") {
 		t.Fatalf("expected package output, got: %q", output)
-	}
-}
-
-//nolint:paralleltest // Swaps os.Stdout via captureStdout.
-func TestRun_PluginPackageFromBinaryWithSource(t *testing.T) {
-	dir := t.TempDir()
-	binaryPath := filepath.Join(dir, "my-provider")
-	if err := os.WriteFile(binaryPath, []byte("fake-binary-content"), 0755); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-	outPath := filepath.Join(dir, "my-provider-v2.tar.gz")
-
-	output := captureStdout(t, func() error {
-		return run([]string{
-			"plugin", "package",
-			"--binary", binaryPath,
-			"--source", "github.com/testorg/testrepo/testplugin",
-			"--version", "1.0.0",
-			"--output", outPath,
-		})
-	})
-
-	if _, err := os.Stat(outPath); err != nil {
-		t.Fatalf("expected archive to exist: %v", err)
-	}
-	if !strings.Contains(output, "packaged") {
-		t.Fatalf("expected packaged output, got: %q", output)
 	}
 }
 
@@ -137,49 +149,6 @@ func TestRun_PluginPackageCreatesDirectory(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // Swaps os.Stdout via captureStdout.
-func TestRun_PluginPackageFromBinaryCreatesDirectory(t *testing.T) {
-	dir := t.TempDir()
-	binaryPath := filepath.Join(dir, "my-provider")
-	if err := os.WriteFile(binaryPath, []byte("fake-binary-content"), 0755); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-	outPath := filepath.Join(dir, "my-plugin-dir")
-
-	output := captureStdout(t, func() error {
-		return run([]string{
-			"plugin", "package",
-			"--binary", binaryPath,
-			"--source", "github.com/testorg/testrepo/testplugin",
-			"--version", "1.0.0",
-			"--output", outPath,
-		})
-	})
-
-	info, err := os.Stat(outPath)
-	if err != nil {
-		t.Fatalf("expected output directory to exist: %v", err)
-	}
-	if !info.IsDir() {
-		t.Fatal("expected output to be a directory")
-	}
-	manifestPath := filepath.Join(outPath, "plugin.json")
-	if _, err := os.Stat(manifestPath); err != nil {
-		t.Fatalf("expected manifest in output directory: %v", err)
-	}
-	artifactPath := filepath.Join(outPath, "artifacts", runtime.GOOS, runtime.GOARCH, "provider")
-	data, err := os.ReadFile(artifactPath)
-	if err != nil {
-		t.Fatalf("expected artifact in output directory: %v", err)
-	}
-	if string(data) != "fake-binary-content" {
-		t.Fatalf("unexpected artifact content: %q", data)
-	}
-	if !strings.Contains(output, "packaged") {
-		t.Fatalf("expected packaged output, got: %q", output)
-	}
-}
-
 func TestRun_PluginPackageRejectsOutputInsideInput(t *testing.T) {
 	t.Parallel()
 
@@ -205,6 +174,408 @@ func TestRun_PluginRejectsUnknownSubcommand(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `unknown plugin command "bogus"`) {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_PluginReleaseRequiresVersion(t *testing.T) {
+	t.Parallel()
+
+	err := run([]string{"plugin", "release"})
+	if err == nil {
+		t.Fatal("expected error when --version missing")
+	}
+	if !strings.Contains(err.Error(), "--version is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_PluginReleaseRejectsInvalidManifest(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := filepath.Join(t.TempDir(), "invalid-plugin")
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatalf("MkdirAll(pluginDir): %v", err)
+	}
+	writeTestFile(t, pluginDir, "plugin.yaml", []byte(`
+source: github.com/testowner/plugins/invalid
+version: 0.1.0
+kinds:
+  - provider
+provider:
+  operations:
+    - name: list_items
+      method: GET
+      path: /items
+`), 0644)
+
+	out, err := runPluginReleaseCommandResult(pluginDir, "--version", "0.0.1-test")
+	if err == nil {
+		t.Fatal("expected invalid manifest error")
+	}
+	if !strings.Contains(string(out), "base_url") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
+func TestE2EPluginReleaseBigquery(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := filepath.Join("..", "..", "..")
+	bigqueryDir := filepath.Join(repoRoot, "plugins", "bigquery")
+	if _, err := os.Stat(filepath.Join(bigqueryDir, "go.mod")); err != nil {
+		t.Skipf("bigquery plugin not found: %v", err)
+	}
+
+	outputDir := t.TempDir()
+	const testVersion = "0.0.1-test"
+	const testPlatform = "linux/amd64"
+
+	cmd := exec.Command(gestaltdBin, "plugin", "release",
+		"--version", testVersion,
+		"--platform", testPlatform,
+		"--output", outputDir,
+	)
+	cmd.Dir = bigqueryDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("plugin release failed: %v\n%s", err, out)
+	}
+
+	archiveName := "gestalt-plugin-bigquery_v" + testVersion + "_linux_amd64.tar.gz"
+	archivePath := filepath.Join(outputDir, archiveName)
+	if _, err := os.Stat(archivePath); err != nil {
+		t.Fatalf("expected archive %s to exist: %v", archiveName, err)
+	}
+
+	extractDir := filepath.Join(outputDir, "extracted")
+	if err := pluginpkg.ExtractPackage(archivePath, extractDir); err != nil {
+		t.Fatalf("extract archive: %v", err)
+	}
+
+	manifestData, err := os.ReadFile(filepath.Join(extractDir, pluginpkg.ManifestFile))
+	if err != nil {
+		t.Fatalf("read plugin.json: %v", err)
+	}
+	var manifest pluginmanifestv1.Manifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	if manifest.Version != testVersion {
+		t.Fatalf("manifest version = %q, want %q", manifest.Version, testVersion)
+	}
+	if len(manifest.Artifacts) != 1 {
+		t.Fatalf("expected 1 artifact, got %d", len(manifest.Artifacts))
+	}
+	artifact := manifest.Artifacts[0]
+	if artifact.OS != "linux" || artifact.Arch != "amd64" {
+		t.Fatalf("artifact platform = %s/%s, want linux/amd64", artifact.OS, artifact.Arch)
+	}
+	if artifact.Path != "gestalt-plugin-bigquery" {
+		t.Fatalf("artifact path = %q, want %q", artifact.Path, "gestalt-plugin-bigquery")
+	}
+
+	binaryPath := filepath.Join(extractDir, artifact.Path)
+	if _, err := os.Stat(binaryPath); err != nil {
+		t.Fatalf("binary not in archive: %v", err)
+	}
+	digest, err := fileSHA256(binaryPath)
+	if err != nil {
+		t.Fatalf("hash binary: %v", err)
+	}
+	if digest != artifact.SHA256 {
+		t.Fatalf("binary sha256 = %s, manifest says %s", digest, artifact.SHA256)
+	}
+
+	checksumPath := filepath.Join(outputDir, "checksums.txt")
+	checksumData, err := os.ReadFile(checksumPath)
+	if err != nil {
+		t.Fatalf("read checksums.txt: %v", err)
+	}
+	if !strings.Contains(string(checksumData), archiveName) {
+		t.Fatalf("checksums.txt does not reference %s: %s", archiveName, checksumData)
+	}
+
+	iconPath := filepath.Join(extractDir, "assets", "icon.svg")
+	if _, err := os.Stat(iconPath); err != nil {
+		t.Fatalf("expected assets/icon.svg in archive: %v", err)
+	}
+}
+
+func TestRun_PluginReleaseCopiesCompiledSupportFiles(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newCompiledReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	testVersion := "0.0.2-test"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-release-test_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+
+	if _, err := pluginpkg.ValidatePackageDir(extractDir); err != nil {
+		t.Fatalf("validate extracted package: %v", err)
+	}
+	for _, rel := range []string{
+		"branding/icon.svg",
+		"schemas/provider.schema.json",
+		"schemas/config.schema.json",
+		"gestalt-plugin-release-test",
+	} {
+		if _, err := os.Stat(filepath.Join(extractDir, filepath.FromSlash(rel))); err != nil {
+			t.Fatalf("expected %s in archive: %v", rel, err)
+		}
+	}
+}
+
+func TestRun_PluginReleaseCopiesWebUISupportFiles(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newWebUIReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	testVersion := "0.0.3-test"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-webui-test_v" + testVersion + ".tar.gz"
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+
+	for _, rel := range []string{
+		"branding/icon.svg",
+		"out/index.html",
+		"out/static/app.js",
+	} {
+		if _, err := os.Stat(filepath.Join(extractDir, filepath.FromSlash(rel))); err != nil {
+			t.Fatalf("expected %s in archive: %v", rel, err)
+		}
+	}
+}
+
+func TestRun_PluginReleaseChecksumsOnlyCurrentArchives(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newWebUIReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", "1.0.0",
+		"--output", outputDir,
+	)
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", "1.0.1",
+		"--output", outputDir,
+	)
+
+	checksumPath := filepath.Join(outputDir, "checksums.txt")
+	checksumData, err := os.ReadFile(checksumPath)
+	if err != nil {
+		t.Fatalf("read checksums.txt: %v", err)
+	}
+	if got := string(checksumData); strings.Contains(got, "gestalt-plugin-webui-test_v1.0.0.tar.gz") {
+		t.Fatalf("checksums.txt unexpectedly included stale archive: %s", got)
+	} else if !strings.Contains(got, "gestalt-plugin-webui-test_v1.0.1.tar.gz") {
+		t.Fatalf("checksums.txt missing current archive: %s", got)
+	}
+}
+
+func TestRun_PluginReleaseRejectsOutputInsideWebUIAssetRoot(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newWebUIReleaseFixtureWithAssetRoot(t, t.TempDir(), "release-output")
+	outputDir := filepath.Join(pluginDir, "release-output", "nested")
+
+	out, err := runPluginReleaseCommandResult(pluginDir, "--version", "1.0.0", "--output", outputDir)
+	if err == nil {
+		t.Fatalf("expected plugin release to fail, got output: %s", out)
+	}
+	if !strings.Contains(string(out), "must not be inside webui.asset_root") {
+		t.Fatalf("expected overlap error, got: %s", out)
+	}
+}
+
+func TestRun_PluginReleasePreservesHybridProviderManifest(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newHybridReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.4-test"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-" + releaseTestPluginName + "_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+
+	if manifest.IsDeclarativeOnlyProvider() {
+		t.Fatal("expected released manifest to remain executable for hybrid provider")
+	}
+	if manifest.Entrypoints.Provider == nil {
+		t.Fatal("expected provider entrypoint")
+	}
+	if manifest.Entrypoints.Provider.ArtifactPath != "gestalt-plugin-"+releaseTestPluginName {
+		t.Fatalf("provider artifact path = %q", manifest.Entrypoints.Provider.ArtifactPath)
+	}
+	if len(manifest.Entrypoints.Provider.Args) != 1 || manifest.Entrypoints.Provider.Args[0] != releaseHybridArg {
+		t.Fatalf("provider entrypoint args = %v, want [%q]", manifest.Entrypoints.Provider.Args, releaseHybridArg)
+	}
+	if manifest.Provider == nil {
+		t.Fatal("expected provider metadata")
+	}
+	if manifest.Provider.BaseURL != releaseHybridBaseURL {
+		t.Fatalf("provider base_url = %q, want %q", manifest.Provider.BaseURL, releaseHybridBaseURL)
+	}
+	if len(manifest.Provider.Operations) != 1 || manifest.Provider.Operations[0].Name != releaseHybridOperationName {
+		t.Fatalf("provider operations = %+v", manifest.Provider.Operations)
+	}
+}
+
+func TestRun_PluginReleasePreservesPrebuiltHybridProvider(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newPrebuiltHybridReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.5-test"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-" + prebuiltHybridPluginName + "_v" + testVersion + ".tar.gz"
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+
+	if manifest.IsDeclarativeOnlyProvider() {
+		t.Fatal("expected prebuilt hybrid provider to remain executable")
+	}
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != prebuiltHybridArtifactPath {
+		t.Fatalf("artifacts = %+v", manifest.Artifacts)
+	}
+	if manifest.Entrypoints.Provider == nil {
+		t.Fatal("expected provider entrypoint")
+	}
+	if manifest.Entrypoints.Provider.ArtifactPath != prebuiltHybridArtifactPath {
+		t.Fatalf("provider artifact path = %q", manifest.Entrypoints.Provider.ArtifactPath)
+	}
+	if len(manifest.Entrypoints.Provider.Args) != 1 || manifest.Entrypoints.Provider.Args[0] != releaseHybridArg {
+		t.Fatalf("provider entrypoint args = %v", manifest.Entrypoints.Provider.Args)
+	}
+	if _, err := os.Stat(filepath.Join(extractDir, filepath.FromSlash(prebuiltHybridArtifactPath))); err != nil {
+		t.Fatalf("expected prebuilt artifact in archive: %v", err)
+	}
+}
+
+func TestRun_PluginReleasePackagesGoModuleWithoutCmdAsSource(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newPrebuiltHybridReleaseFixture(t, t.TempDir())
+	writeTestFile(t, pluginDir, "go.mod", []byte("module example.com/prebuilt-hybrid\n\ngo 1.22\n"), 0644)
+
+	outputDir := t.TempDir()
+	const testVersion = "0.0.6-test"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-" + prebuiltHybridPluginName + "_v" + testVersion + ".tar.gz"
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != prebuiltHybridArtifactPath {
+		t.Fatalf("artifacts = %+v", manifest.Artifacts)
+	}
+	if manifest.Entrypoints.Provider == nil || manifest.Entrypoints.Provider.ArtifactPath != prebuiltHybridArtifactPath {
+		t.Fatalf("provider entrypoint = %+v", manifest.Entrypoints.Provider)
+	}
+	if _, err := os.Stat(filepath.Join(extractDir, filepath.FromSlash(prebuiltHybridArtifactPath))); err != nil {
+		t.Fatalf("expected prebuilt artifact in archive: %v", err)
+	}
+}
+
+func TestRun_PluginReleasePackagesRootMainBuildTarget(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newRootMainReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.7-test"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-" + releaseTestPluginName + "_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != releaseBinaryName(releaseTestPluginName, runtime.GOOS) {
+		t.Fatalf("artifacts = %+v", manifest.Artifacts)
+	}
+}
+
+func TestRun_PluginReleaseRejectsStaleSourceArtifactDigest(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newPrebuiltHybridReleaseFixture(t, t.TempDir())
+
+	_, manifest, err := pluginpkg.ReadManifestFile(filepath.Join(pluginDir, pluginpkg.ManifestFile))
+	if err != nil {
+		t.Fatalf("ReadManifestFile(plugin.json): %v", err)
+	}
+	manifest.Artifacts[0].SHA256 = sha256HexForTest("different-content")
+	writeReleaseTestManifest(t, pluginDir, manifest)
+
+	out, err := runPluginReleaseCommandResult(pluginDir, "--version", "0.0.8-test")
+	if err == nil {
+		t.Fatal("expected stale digest error")
+	}
+	if !strings.Contains(string(out), "sha256 mismatch") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
+func TestRun_PluginReleaseWindowsArtifactUsesExe(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newCompiledReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.9-test"
+	const windowsPlatform = "windows/amd64"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", windowsPlatform,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-" + releaseTestPluginName + "_v" + testVersion + "_windows_amd64.tar.gz"
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+	binaryName := releaseBinaryName(releaseTestPluginName, "windows")
+
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != binaryName {
+		t.Fatalf("artifacts = %+v, want path %q", manifest.Artifacts, binaryName)
+	}
+	if manifest.Entrypoints.Provider == nil || manifest.Entrypoints.Provider.ArtifactPath != binaryName {
+		t.Fatalf("provider entrypoint = %+v, want artifact path %q", manifest.Entrypoints.Provider, binaryName)
+	}
+	if manifest.Entrypoints.Runtime == nil || manifest.Entrypoints.Runtime.ArtifactPath != binaryName {
+		t.Fatalf("runtime entrypoint = %+v, want artifact path %q", manifest.Entrypoints.Runtime, binaryName)
+	}
+	if _, err := os.Stat(filepath.Join(extractDir, binaryName)); err != nil {
+		t.Fatalf("expected %s in archive: %v", binaryName, err)
 	}
 }
 
@@ -253,6 +624,234 @@ func newPluginPackageFixture(t *testing.T, dir string) string {
 	return src
 }
 
+func newCompiledReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(dir, releaseTestPluginName)
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatalf("MkdirAll(pluginDir): %v", err)
+	}
+	writeTestFile(t, pluginDir, "go.mod", []byte("module "+releaseTestModule+"\n\ngo 1.22\n"), 0644)
+	writeTestFile(t, pluginDir, "cmd/main.go", []byte("package main\n\nfunc main() {}\n"), 0644)
+	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
+		Source:      releaseTestSource,
+		Version:     "0.0.1",
+		DisplayName: "Release Test",
+		IconFile:    releaseTestIconPath,
+		Kinds:       []string{pluginmanifestv1.KindProvider, pluginmanifestv1.KindRuntime},
+		Provider: &pluginmanifestv1.Provider{
+			BaseURL:          releaseHybridBaseURL,
+			ConfigSchemaPath: releaseProviderSchemaPath,
+			Operations: []pluginmanifestv1.ProviderOperation{
+				{
+					Name:   releaseHybridOperationName,
+					Method: "GET",
+					Path:   "/items",
+				},
+			},
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				Path:   releaseSourceArtifactPath,
+				SHA256: sha256HexForTest("source-plugin"),
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{ArtifactPath: releaseSourceArtifactPath},
+			Runtime:  &pluginmanifestv1.Entrypoint{ArtifactPath: releaseSourceArtifactPath},
+		},
+	})
+	writeTestFile(t, pluginDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0644)
+	writeTestFile(t, pluginDir, releaseProviderSchemaPath, []byte(`{"type":"object"}`), 0644)
+	writeTestFile(t, pluginDir, "schemas/config.schema.json", []byte(`{"type":"object"}`), 0644)
+	return pluginDir
+}
+
+func newRootMainReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := newCompiledReleaseFixture(t, dir)
+	if err := os.RemoveAll(filepath.Join(pluginDir, "cmd")); err != nil {
+		t.Fatalf("RemoveAll(cmd): %v", err)
+	}
+	writeTestFile(t, pluginDir, "main.go", []byte("package main\n\nfunc main() {}\n"), 0644)
+	return pluginDir
+}
+
+func newHybridReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := newCompiledReleaseFixture(t, dir)
+	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
+		Source:      releaseTestSource,
+		Version:     "0.0.1",
+		DisplayName: "Release Test",
+		IconFile:    releaseTestIconPath,
+		Kinds:       []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			BaseURL: releaseHybridBaseURL,
+			Operations: []pluginmanifestv1.ProviderOperation{
+				{
+					Name:   releaseHybridOperationName,
+					Method: "GET",
+					Path:   "/items",
+				},
+			},
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				Path:   releaseSourceArtifactPath,
+				SHA256: sha256HexForTest("source-plugin"),
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{
+				ArtifactPath: releaseSourceArtifactPath,
+				Args:         []string{releaseHybridArg},
+			},
+		},
+	})
+	return pluginDir
+}
+
+func newPrebuiltHybridReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(dir, prebuiltHybridPluginName)
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatalf("MkdirAll(pluginDir): %v", err)
+	}
+	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
+		Source:      prebuiltHybridSource,
+		Version:     "0.0.1",
+		DisplayName: "Prebuilt Hybrid",
+		IconFile:    releaseTestIconPath,
+		Kinds:       []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			BaseURL: releaseHybridBaseURL,
+			Operations: []pluginmanifestv1.ProviderOperation{
+				{
+					Name:   releaseHybridOperationName,
+					Method: "GET",
+					Path:   "/items",
+				},
+			},
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				Path:   prebuiltHybridArtifactPath,
+				SHA256: sha256HexForTest("prebuilt-provider"),
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{
+				ArtifactPath: prebuiltHybridArtifactPath,
+				Args:         []string{releaseHybridArg},
+			},
+		},
+	})
+	writeTestFile(t, pluginDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0644)
+	writeTestFile(t, pluginDir, prebuiltHybridArtifactPath, []byte("prebuilt-provider"), 0755)
+	return pluginDir
+}
+
+func newWebUIReleaseFixture(t *testing.T, dir string) string {
+	return newWebUIReleaseFixtureWithAssetRoot(t, dir, webUITestAssetRoot)
+}
+
+func newWebUIReleaseFixtureWithAssetRoot(t *testing.T, dir, assetRoot string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(dir, webUITestPluginName)
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatalf("MkdirAll(pluginDir): %v", err)
+	}
+	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
+		Source:      webUITestSource,
+		Version:     "0.0.1",
+		DisplayName: "WebUI Test",
+		IconFile:    releaseTestIconPath,
+		Kinds:       []string{pluginmanifestv1.KindWebUI},
+		WebUI: &pluginmanifestv1.WebUIMetadata{
+			AssetRoot: assetRoot,
+		},
+	})
+	writeTestFile(t, pluginDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0644)
+	writeTestFile(t, pluginDir, assetRoot+"/index.html", []byte("<html></html>\n"), 0644)
+	writeTestFile(t, pluginDir, assetRoot+"/static/app.js", []byte("console.log('ok')\n"), 0644)
+	return pluginDir
+}
+
+func runPluginReleaseCommand(t *testing.T, pluginDir string, args ...string) string {
+	t.Helper()
+
+	out, err := runPluginReleaseCommandResult(pluginDir, args...)
+	if err != nil {
+		t.Fatalf("plugin release failed: %v\n%s", err, out)
+	}
+	return string(out)
+}
+
+func runPluginReleaseCommandResult(pluginDir string, args ...string) ([]byte, error) {
+	cmdArgs := append([]string{"plugin", "release"}, args...)
+	cmd := exec.Command(gestaltdBin, cmdArgs...)
+	cmd.Dir = pluginDir
+	return cmd.CombinedOutput()
+}
+
+func extractReleasedArchive(t *testing.T, outputDir, archiveName string) string {
+	t.Helper()
+
+	archivePath := filepath.Join(outputDir, archiveName)
+	if _, err := os.Stat(archivePath); err != nil {
+		t.Fatalf("expected archive %s to exist: %v", archiveName, err)
+	}
+	extractDir := filepath.Join(outputDir, strings.TrimSuffix(archiveName, ".tar.gz"))
+	if err := pluginpkg.ExtractPackage(archivePath, extractDir); err != nil {
+		t.Fatalf("extract archive: %v", err)
+	}
+	return extractDir
+}
+
+func readReleasedManifest(t *testing.T, outputDir, archiveName string) *pluginmanifestv1.Manifest {
+	t.Helper()
+
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	_, manifest, err := pluginpkg.ReadManifestFile(filepath.Join(extractDir, pluginpkg.ManifestFile))
+	if err != nil {
+		t.Fatalf("read released manifest: %v", err)
+	}
+	return manifest
+}
+
+func writeReleaseTestManifest(t *testing.T, dir string, manifest *pluginmanifestv1.Manifest) {
+	t.Helper()
+
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent(plugin.json): %v", err)
+	}
+	writeTestFile(t, dir, "plugin.json", append(data, '\n'), 0644)
+}
+
+func writeTestFile(t *testing.T, dir, rel string, data []byte, mode os.FileMode) {
+	t.Helper()
+
+	path := filepath.Join(dir, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", rel, err)
+	}
+	if err := os.WriteFile(path, data, mode); err != nil {
+		t.Fatalf("WriteFile(%s): %v", rel, err)
+	}
+}
+
 func captureStdout(t *testing.T, fn func() error) string {
 	t.Helper()
 
@@ -284,6 +883,5 @@ func captureStdout(t *testing.T, fn func() error) string {
 }
 
 func sha256HexForTest(value string) string {
-	sum := sha256.Sum256([]byte(value))
-	return hex.EncodeToString(sum[:])
+	return sha256HexForPrepareTest(value)
 }

--- a/server/internal/operator/lifecycle.go
+++ b/server/internal/operator/lifecycle.go
@@ -748,7 +748,7 @@ func applyLockedPluginEntry(paths initPaths, lock *Lockfile, kind, name string, 
 	resolvePluginIcon(manifest, manifestPath, plugin)
 
 	plugin.ResolvedManifestPath = manifestPath
-	if kind == "integration" && manifest.Provider.IsDeclarative() {
+	if kind == "integration" && manifest.IsDeclarativeOnlyProvider() {
 		plugin.IsDeclarative = true
 		return nil
 	}

--- a/server/internal/pluginpkg/config.go
+++ b/server/internal/pluginpkg/config.go
@@ -10,7 +10,7 @@ import (
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
 
-const runtimeConfigSchemaPath = "schemas/config.schema.json"
+const RuntimeConfigSchemaPath = "schemas/config.schema.json"
 
 func ValidateConfigForManifest(manifestPath string, manifest *pluginmanifestv1.Manifest, kind string, config map[string]any) error {
 	schemaPath, schemaName, ok, err := configSchemaForManifest(manifestPath, manifest, kind)
@@ -60,11 +60,11 @@ func configSchemaForManifest(manifestPath string, manifest *pluginmanifestv1.Man
 		}
 		return filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(manifest.Provider.ConfigSchemaPath)), manifest.Provider.ConfigSchemaPath, true, nil
 	case pluginmanifestv1.KindRuntime:
-		schemaPath := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(runtimeConfigSchemaPath))
+		schemaPath := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(RuntimeConfigSchemaPath))
 		if _, statErr := os.Stat(schemaPath); statErr == nil {
-			return schemaPath, runtimeConfigSchemaPath, true, nil
+			return schemaPath, RuntimeConfigSchemaPath, true, nil
 		} else if !os.IsNotExist(statErr) {
-			return "", "", false, fmt.Errorf("stat runtime config schema %q: %w", runtimeConfigSchemaPath, statErr)
+			return "", "", false, fmt.Errorf("stat runtime config schema %q: %w", RuntimeConfigSchemaPath, statErr)
 		}
 		return "", "", false, nil
 	default:

--- a/server/internal/pluginpkg/config_test.go
+++ b/server/internal/pluginpkg/config_test.go
@@ -68,7 +68,7 @@ func TestValidateConfigForManifestRuntimeFallback(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(dir, "schemas"), 0755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, filepath.FromSlash(runtimeConfigSchemaPath)), []byte(`{
+	if err := os.WriteFile(filepath.Join(dir, filepath.FromSlash(RuntimeConfigSchemaPath)), []byte(`{
   "type": "object",
   "required": ["runtime_key"],
   "properties": {

--- a/server/internal/pluginpkg/digest.go
+++ b/server/internal/pluginpkg/digest.go
@@ -52,7 +52,7 @@ func DirectoryDigest(dirPath string, manifest *pluginmanifestv1.Manifest) (strin
 		digests = append(digests, sum)
 	}
 
-	runtimeSchema := filepath.Join(dirPath, filepath.FromSlash(runtimeConfigSchemaPath))
+	runtimeSchema := filepath.Join(dirPath, filepath.FromSlash(RuntimeConfigSchemaPath))
 	if _, err := os.Stat(runtimeSchema); err == nil {
 		sum, err := fileSHA256(runtimeSchema)
 		if err != nil {

--- a/server/internal/pluginstore/store.go
+++ b/server/internal/pluginstore/store.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"slices"
-
 	pluginpkg "github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
@@ -52,7 +50,7 @@ func Install(packagePath, destDir string) (*InstalledPlugin, error) {
 		return installed, nil
 	}
 
-	if manifest.Provider.IsDeclarative() && !slices.Contains(manifest.Kinds, pluginmanifestv1.KindRuntime) {
+	if manifest.IsDeclarativeOnlyProvider() {
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return nil, fmt.Errorf("create plugin directory: %w", err)
 		}
@@ -122,7 +120,7 @@ func InstallFromDir(dirPath, destDir string) (*InstalledPlugin, error) {
 		return installed, nil
 	}
 
-	if manifest.Provider.IsDeclarative() && !slices.Contains(manifest.Kinds, pluginmanifestv1.KindRuntime) {
+	if manifest.IsDeclarativeOnlyProvider() {
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return nil, fmt.Errorf("create plugin directory: %w", err)
 		}
@@ -232,7 +230,7 @@ func executablePathForManifest(root string, manifest *pluginmanifestv1.Manifest)
 	if isWebUIOnly(manifest) {
 		return "", nil
 	}
-	if manifest.Provider.IsDeclarative() && !slices.Contains(manifest.Kinds, pluginmanifestv1.KindRuntime) {
+	if manifest.IsDeclarativeOnlyProvider() {
 		return "", nil
 	}
 	var entry *pluginmanifestv1.Entrypoint
@@ -258,16 +256,14 @@ func executablePathForManifest(root string, manifest *pluginmanifestv1.Manifest)
 	return filepath.Join(root, filepath.FromSlash(entry.ArtifactPath)), nil
 }
 
-const runtimeConfigSchemaPath = "schemas/config.schema.json"
-
 func configSchemaPaths(manifest *pluginmanifestv1.Manifest, dirPath string) []string {
 	var paths []string
 	if manifest.Provider != nil && manifest.Provider.ConfigSchemaPath != "" {
 		paths = append(paths, manifest.Provider.ConfigSchemaPath)
 	}
-	runtimeSchema := filepath.Join(dirPath, filepath.FromSlash(runtimeConfigSchemaPath))
+	runtimeSchema := filepath.Join(dirPath, filepath.FromSlash(pluginpkg.RuntimeConfigSchemaPath))
 	if _, err := os.Stat(runtimeSchema); err == nil {
-		paths = append(paths, runtimeConfigSchemaPath)
+		paths = append(paths, pluginpkg.RuntimeConfigSchemaPath)
 	}
 	return paths
 }

--- a/server/internal/pluginstore/store_test.go
+++ b/server/internal/pluginstore/store_test.go
@@ -18,6 +18,12 @@ import (
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
 
+const (
+	hybridProviderArg     = "--serve-provider"
+	hybridProviderBaseURL = "https://api.example.com"
+	hybridOperationName   = "list_items"
+)
+
 func TestInstall(t *testing.T) {
 	t.Parallel()
 
@@ -238,6 +244,34 @@ func TestInstallFromDirCopiesManifestAndArtifact(t *testing.T) {
 	}
 }
 
+func TestInstallFromDirKeepsExecutableForHybridProvider(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	srcDir := mustBuildHybridPluginDir(t, dir, "github.com/testowner/plugins/hybrid", "0.1.0", "hybrid-binary")
+
+	dest := filepath.Join(dir, "plugins", "integration_hybrid")
+	installed, err := InstallFromDir(srcDir, dest)
+	if err != nil {
+		t.Fatalf("InstallFromDir: %v", err)
+	}
+	if installed.ExecutablePath == "" {
+		t.Fatal("ExecutablePath is empty")
+	}
+	if installed.Manifest == nil {
+		t.Fatal("Manifest is nil")
+	}
+	if installed.Manifest.IsDeclarativeOnlyProvider() {
+		t.Fatal("expected hybrid provider manifest to remain executable")
+	}
+	if installed.Manifest.Entrypoints.Provider == nil {
+		t.Fatal("expected provider entrypoint")
+	}
+	if len(installed.Manifest.Entrypoints.Provider.Args) != 1 || installed.Manifest.Entrypoints.Provider.Args[0] != hybridProviderArg {
+		t.Fatalf("provider args = %v", installed.Manifest.Entrypoints.Provider.Args)
+	}
+}
+
 func TestInstallFromDirSetsSource(t *testing.T) {
 	t.Parallel()
 
@@ -327,6 +361,32 @@ func mustBuildPluginDir(t *testing.T, dir, source, version, content, schema stri
 		t.Fatalf("EncodeManifest: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, pluginpkg.ManifestFile), manifestBytes, 0644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+	return srcDir
+}
+
+func mustBuildHybridPluginDir(t *testing.T, dir, source, version, content string) string {
+	t.Helper()
+
+	srcDir := mustBuildPluginDir(t, dir, source, version, content, "")
+	manifestPath := filepath.Join(srcDir, pluginpkg.ManifestFile)
+	_, manifest, err := pluginpkg.ReadManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadManifestFile: %v", err)
+	}
+
+	manifest.Provider.BaseURL = hybridProviderBaseURL
+	manifest.Provider.Operations = []pluginmanifestv1.ProviderOperation{
+		{Name: hybridOperationName, Method: "GET", Path: "/items"},
+	}
+	manifest.Entrypoints.Provider.Args = []string{hybridProviderArg}
+
+	manifestBytes, err := pluginpkg.EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(manifestPath, manifestBytes, 0644); err != nil {
 		t.Fatalf("WriteFile manifest: %v", err)
 	}
 	return srcDir

--- a/server/sdk/pluginmanifest/v1/types.go
+++ b/server/sdk/pluginmanifest/v1/types.go
@@ -1,6 +1,9 @@
 package pluginmanifestv1
 
-import _ "embed"
+import (
+	_ "embed"
+	"slices"
+)
 
 const (
 	KindProvider = "provider"
@@ -78,6 +81,10 @@ func (p *Provider) IsSpecLoaded() bool {
 
 func (m *Manifest) IsHybridProvider() bool {
 	return m != nil && m.Provider != nil && len(m.Provider.Operations) > 0 && m.Entrypoints.Provider != nil
+}
+
+func (m *Manifest) IsDeclarativeOnlyProvider() bool {
+	return m != nil && m.Provider != nil && m.Provider.IsDeclarative() && !m.IsHybridProvider() && !slices.Contains(m.Kinds, KindRuntime)
 }
 
 type ManifestOperationOverride struct {


### PR DESCRIPTION
## Summary

- Adds `gestaltd plugin release --version VERSION` command that cross-compiles a Go plugin for all platforms and produces per-platform tar.gz archives + checksums file
- Each archive contains `plugin.json` (with single-platform artifact metadata), the binary, and assets — structurally identical to existing archives so the server install path is unchanged
- For declarative plugins (no `go.mod`), produces a single archive with `plugin.yaml` + assets
- Removes the old `--binary` packaging mode (`packageFromBinary`, `buildManifest`, `newManifestSkeleton`) which is superseded by this command
- Built entirely on Go stdlib (`os/exec`, `archive/tar`, `compress/gzip`, `crypto/sha256`) — no external dependencies

This replaces the 50-line bash/yq/jq `assemble-compiled` CI job with a single command that works identically on local dev machines and CI, for both internal and third-party plugin developers.

## Test plan

- [x] `TestE2EPluginReleaseBigquery` — builds gestaltd, runs release against the real BigQuery plugin, verifies archive contents (plugin.json, binary SHA256, checksums, assets)
- [x] `go test ./cmd/gestaltd/` — all 35 tests pass
- [x] Manual test: `cd plugins/bigquery && gestaltd plugin release --version 0.0.1-test --platform linux/amd64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)