### PR TITLE
Rewrite plugin release CI to use gestaltd plugin release

### DIFF
--- a/.github/workflows/release-plugin-reusable.yml
+++ b/.github/workflows/release-plugin-reusable.yml
@@ -1,0 +1,40 @@
+name: Release Gestalt Plugin
+
+on:
+  workflow_call:
+    inputs:
+      plugin-dir:
+        description: Path to plugin directory containing plugin.yaml
+        type: string
+        default: '.'
+      version:
+        description: Semantic version for the release
+        type: string
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: ${{ inputs.plugin-dir }}/go.mod
+      - name: Install gestaltd
+        run: go install github.com/valon-technologies/gestalt/server/cmd/gestaltd@latest
+      - name: Release
+        run: |
+          cd "${{ inputs.plugin-dir }}"
+          gestaltd plugin release --version "${{ inputs.version }}"
+      - name: Publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ inputs.version }}"
+          VERSION="${VERSION#v}"
+          gh release create "v${VERSION}" --generate-notes \
+            "${{ inputs.plugin-dir }}"/dist/*

--- a/.github/workflows/release-plugin-reusable.yml
+++ b/.github/workflows/release-plugin-reusable.yml
@@ -30,17 +30,25 @@ jobs:
         run: |
           VERSION="${{ inputs.version }}"
           echo "release=${VERSION#v}" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.0'
       - name: Detect plugin type
         id: plugin
         run: |
-          if [ -f "${{ inputs.plugin-dir }}/go.mod" ] && [ -d "${{ inputs.plugin-dir }}/cmd" ]; then
+          is_main_package() {
+            local package_name
+            package_name="$(cd "$1" && go list -f '{{.Name}}' "$2" 2>/dev/null)" || return 1
+            [ "$package_name" = "main" ]
+          }
+
+          if [ ! -f "${{ inputs.plugin-dir }}/go.mod" ]; then
+            echo "compiled=false" >> "$GITHUB_OUTPUT"
+          elif is_main_package "${{ inputs.plugin-dir }}" ./cmd || is_main_package "${{ inputs.plugin-dir }}" .; then
             echo "compiled=true" >> "$GITHUB_OUTPUT"
           else
             echo "compiled=false" >> "$GITHUB_OUTPUT"
           fi
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.26.0'
       - name: Install gestaltd
         env:
           GOBIN: ${{ runner.temp }}/bin

--- a/.github/workflows/release-plugin-reusable.yml
+++ b/.github/workflows/release-plugin-reusable.yml
@@ -11,6 +11,10 @@ on:
         description: Semantic version for the release
         type: string
         required: true
+      gestaltd-version:
+        description: Pinned Gestalt module version, tag, or commit SHA used to install gestaltd
+        type: string
+        required: true
 
 permissions:
   contents: write
@@ -21,20 +25,40 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+      - name: Normalize version
+        id: version
+        run: |
+          VERSION="${{ inputs.version }}"
+          echo "release=${VERSION#v}" >> "$GITHUB_OUTPUT"
+      - name: Detect plugin type
+        id: plugin
+        run: |
+          if [ -f "${{ inputs.plugin-dir }}/go.mod" ] && [ -d "${{ inputs.plugin-dir }}/cmd" ]; then
+            echo "compiled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "compiled=false" >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/setup-go@v5
         with:
-          go-version-file: ${{ inputs.plugin-dir }}/go.mod
+          go-version: '1.26.0'
       - name: Install gestaltd
-        run: go install github.com/valon-technologies/gestalt/server/cmd/gestaltd@latest
+        env:
+          GOBIN: ${{ runner.temp }}/bin
+        run: |
+          mkdir -p "$GOBIN"
+          echo "$GOBIN" >> "$GITHUB_PATH"
+          go install github.com/valon-technologies/gestalt/server/cmd/gestaltd@${{ inputs.gestaltd-version }}
+      - uses: actions/setup-go@v5
+        if: steps.plugin.outputs.compiled == 'true'
+        with:
+          go-version-file: ${{ inputs.plugin-dir }}/go.mod
       - name: Release
         run: |
           cd "${{ inputs.plugin-dir }}"
-          gestaltd plugin release --version "${{ inputs.version }}"
+          gestaltd plugin release --version "${{ steps.version.outputs.release }}"
       - name: Publish
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION="${{ inputs.version }}"
-          VERSION="${VERSION#v}"
-          gh release create "v${VERSION}" --generate-notes \
+          gh release create "v${{ steps.version.outputs.release }}" --generate-notes \
             "${{ inputs.plugin-dir }}"/dist/*

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -80,28 +80,12 @@ jobs:
             plugins/${{ env.PLUGIN_NAME }}/gestalt-plugin-*.sha256
           if-no-files-found: error
 
-  build-compiled:
-    name: Build - ${{ matrix.platform.name }}
+  release-compiled:
+    name: Release Compiled Plugin
     needs: prepare
     if: needs.prepare.outputs.plugin-type == 'compiled'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - name: macOS-ARM64
-            goos: darwin
-            goarch: arm64
-          - name: macOS-x86_64
-            goos: darwin
-            goarch: amd64
-          - name: Linux-x86_64
-            goos: linux
-            goarch: amd64
-          - name: Linux-ARM64
-            goos: linux
-            goarch: arm64
     env:
       PLUGIN_NAME: ${{ needs.prepare.outputs.plugin-name }}
       PLUGIN_VERSION: ${{ needs.prepare.outputs.plugin-version }}
@@ -111,95 +95,22 @@ jobs:
         with:
           go-version-file: plugins/${{ env.PLUGIN_NAME }}/go.mod
           cache-dependency-path: plugins/${{ env.PLUGIN_NAME }}/go.sum
-      - name: Build
-        env:
-          CGO_ENABLED: '0'
-          GOOS: ${{ matrix.platform.goos }}
-          GOARCH: ${{ matrix.platform.goarch }}
+      - name: Build gestaltd
+        run: cd server && go build -o ../gestaltd ./cmd/gestaltd
+      - name: Release plugin
         run: |
           cd "plugins/${PLUGIN_NAME}"
-          go build -o "../../gestalt-plugin-${PLUGIN_NAME}" ./cmd
-      - uses: actions/upload-artifact@v4
-        with:
-          name: binary-${{ matrix.platform.goos }}-${{ matrix.platform.goarch }}
-          path: gestalt-plugin-${{ env.PLUGIN_NAME }}
-          if-no-files-found: error
-
-  assemble-compiled:
-    name: Assemble Compiled Plugin
-    needs: [prepare, build-compiled]
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    env:
-      PLUGIN_NAME: ${{ needs.prepare.outputs.plugin-name }}
-      PLUGIN_VERSION: ${{ needs.prepare.outputs.plugin-version }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: binary-*
-          path: binaries
-      - name: Assemble multi-platform package
-        run: |
-          ASSET="gestalt-plugin-${PLUGIN_NAME}_v${PLUGIN_VERSION}"
-          PLUGIN_DIR="plugins/${PLUGIN_NAME}"
-          BINARY_NAME="gestalt-plugin-${PLUGIN_NAME}"
-
-          MANIFEST=$(yq -o json "${PLUGIN_DIR}/plugin.yaml")
-
-          ARTIFACTS="[]"
-          for platform_dir in binaries/binary-*; do
-            PLATFORM=$(basename "$platform_dir" | sed 's/^binary-//')
-            GOOS=$(echo "$PLATFORM" | cut -d- -f1)
-            GOARCH=$(echo "$PLATFORM" | cut -d- -f2)
-            ARTIFACT_PATH="artifacts/${GOOS}/${GOARCH}/${BINARY_NAME}"
-
-            mkdir -p "staging/artifacts/${GOOS}/${GOARCH}"
-            cp "${platform_dir}/${BINARY_NAME}" "staging/${ARTIFACT_PATH}"
-            chmod +x "staging/${ARTIFACT_PATH}"
-
-            DIGEST=$(shasum -a 256 "staging/${ARTIFACT_PATH}" | cut -d' ' -f1)
-            ARTIFACTS=$(echo "$ARTIFACTS" | jq \
-              --arg os "$GOOS" --arg arch "$GOARCH" \
-              --arg path "$ARTIFACT_PATH" --arg sha256 "$DIGEST" \
-              '. + [{"os": $os, "arch": $arch, "path": $path, "sha256": $sha256}]')
-          done
-
-          ENTRYPOINT_PATH="artifacts/linux/amd64/${BINARY_NAME}"
-          if [ ! -f "staging/${ENTRYPOINT_PATH}" ]; then
-            echo "ERROR: entrypoint artifact ${ENTRYPOINT_PATH} not found in staging"
-            exit 1
-          fi
-
-          echo "$MANIFEST" | jq \
-            --argjson artifacts "$ARTIFACTS" \
-            --arg entrypoint "$ENTRYPOINT_PATH" \
-            '. + {"artifacts": $artifacts, "entrypoints": {"provider": {"artifact_path": $entrypoint}}}' \
-            > staging/plugin.json
-
-          TAR_ARGS="plugin.json"
-          if [ -d "${PLUGIN_DIR}/assets" ]; then
-            cp -r "${PLUGIN_DIR}/assets" staging/
-            TAR_ARGS="${TAR_ARGS} assets/"
-          fi
-          TAR_ARGS="${TAR_ARGS} artifacts/"
-
-          cd staging
-          tar -czvf "../${ASSET}.tar.gz" ${TAR_ARGS}
-          cd ..
-          shasum -a 256 "${ASSET}.tar.gz" > "${ASSET}.tar.gz.sha256"
+          ../../gestaltd plugin release --version "${PLUGIN_VERSION}"
       - uses: actions/upload-artifact@v4
         with:
           name: gestalt-plugin-${{ env.PLUGIN_NAME }}
-          path: |
-            gestalt-plugin-*.tar.gz
-            gestalt-plugin-*.sha256
+          path: plugins/${{ env.PLUGIN_NAME }}/dist/*
           if-no-files-found: error
 
   release:
     name: Create Release
-    needs: [prepare, build-declarative, assemble-compiled]
-    if: always() && needs.prepare.result == 'success' && (needs.build-declarative.result == 'success' || needs.assemble-compiled.result == 'success')
+    needs: [prepare, build-declarative, release-compiled]
+    if: always() && needs.prepare.result == 'success' && (needs.build-declarative.result == 'success' || needs.release-compiled.result == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -23,8 +23,9 @@ jobs:
         id: parse
         run: |
           TAG="${GITHUB_REF_NAME}"
-          PLUGIN_NAME=$(echo "$TAG" | cut -d'/' -f2)
-          PLUGIN_VERSION=$(echo "$TAG" | sed 's|^plugin/.*/v||')
+          PLUGIN_NAME="${TAG#plugin/}"
+          PLUGIN_NAME="${PLUGIN_NAME%%/*}"
+          PLUGIN_VERSION="${TAG##*/v}"
           echo "plugin-name=${PLUGIN_NAME}" >> "$GITHUB_OUTPUT"
           echo "plugin-version=${PLUGIN_VERSION}" >> "$GITHUB_OUTPUT"
       - name: Validate plugin directory
@@ -45,7 +46,7 @@ jobs:
         env:
           PLUGIN_NAME: ${{ steps.parse.outputs.plugin-name }}
         run: |
-          if [ -f "plugins/${PLUGIN_NAME}/go.mod" ]; then
+          if [ -f "plugins/${PLUGIN_NAME}/go.mod" ] && [ -d "plugins/${PLUGIN_NAME}/cmd" ]; then
             echo "plugin-type=compiled" >> "$GITHUB_OUTPUT"
           else
             echo "plugin-type=declarative" >> "$GITHUB_OUTPUT"
@@ -66,11 +67,11 @@ jobs:
         run: |
           ASSET="gestalt-plugin-${PLUGIN_NAME}_v${PLUGIN_VERSION}"
           cd "plugins/${PLUGIN_NAME}"
-          TAR_ARGS="plugin.yaml"
+          TAR_ARGS=(plugin.yaml)
           if [ -d assets ]; then
-            TAR_ARGS="${TAR_ARGS} assets/"
+            TAR_ARGS+=(assets/)
           fi
-          tar -czvf "${ASSET}.tar.gz" ${TAR_ARGS}
+          tar -czvf "${ASSET}.tar.gz" "${TAR_ARGS[@]}"
           shasum -a 256 "${ASSET}.tar.gz" > "${ASSET}.tar.gz.sha256"
       - uses: actions/upload-artifact@v4
         with:
@@ -93,10 +94,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: plugins/${{ env.PLUGIN_NAME }}/go.mod
-          cache-dependency-path: plugins/${{ env.PLUGIN_NAME }}/go.sum
+          go-version-file: server/go.mod
+          cache-dependency-path: server/go.sum
       - name: Build gestaltd
         run: cd server && go build -o ../gestaltd ./cmd/gestaltd
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: plugins/${{ env.PLUGIN_NAME }}/go.mod
+          cache-dependency-path: plugins/${{ env.PLUGIN_NAME }}/go.sum
       - name: Release plugin
         run: |
           cd "plugins/${PLUGIN_NAME}"
@@ -121,7 +126,7 @@ jobs:
       - name: Flatten artifacts
         run: |
           mkdir release
-          find artifacts -type f \( -name "*.tar.gz" -o -name "*.sha256" \) -exec mv {} release/ \;
+          find artifacts -type f -exec mv {} release/ \;
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -41,12 +41,25 @@ jobs:
             echo "ERROR: ${PLUGIN_DIR}/plugin.yaml not found"
             exit 1
           fi
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: server/go.mod
+          cache: false
       - name: Detect plugin type
         id: detect
         env:
           PLUGIN_NAME: ${{ steps.parse.outputs.plugin-name }}
         run: |
-          if [ -f "plugins/${PLUGIN_NAME}/go.mod" ] && [ -d "plugins/${PLUGIN_NAME}/cmd" ]; then
+          is_main_package() {
+            local package_name
+            package_name="$(cd "$1" && go list -f '{{.Name}}' "$2" 2>/dev/null)" || return 1
+            [ "$package_name" = "main" ]
+          }
+
+          PLUGIN_DIR="plugins/${PLUGIN_NAME}"
+          if [ ! -f "${PLUGIN_DIR}/go.mod" ]; then
+            echo "plugin-type=declarative" >> "$GITHUB_OUTPUT"
+          elif is_main_package "${PLUGIN_DIR}" ./cmd || is_main_package "${PLUGIN_DIR}" .; then
             echo "plugin-type=compiled" >> "$GITHUB_OUTPUT"
           else
             echo "plugin-type=declarative" >> "$GITHUB_OUTPUT"

--- a/docs/pages/concepts/plugin-packaging.mdx
+++ b/docs/pages/concepts/plugin-packaging.mdx
@@ -65,6 +65,31 @@ That copies the validated plugin directory to the output path. If you need an ar
 gestaltd plugin package --input ./build/example-provider --output ./dist/example-provider.tar.gz
 ```
 
+## Releasing A Compiled Plugin
+
+For compiled plugins, `gestaltd plugin release` handles cross-compilation, packaging, and checksum generation in one step:
+
+```sh
+cd my-plugin
+gestaltd plugin release --version 1.0.0
+```
+
+This produces per-platform archives in `dist/`:
+
+- `gestalt-plugin-my-plugin_v1.0.0_darwin_amd64.tar.gz`
+- `gestalt-plugin-my-plugin_v1.0.0_darwin_arm64.tar.gz`
+- `gestalt-plugin-my-plugin_v1.0.0_linux_amd64.tar.gz`
+- `gestalt-plugin-my-plugin_v1.0.0_linux_arm64.tar.gz`
+- `gestalt-plugin-my-plugin_v1.0.0_checksums.txt`
+
+Each archive contains a `plugin.json` manifest, the platform-specific binary, and any assets. Upload the contents of `dist/` to a GitHub release and reference the plugin via `plugin.source` in your config.
+
+Use `--platform` to restrict to specific platforms:
+
+```sh
+gestaltd plugin release --version 1.0.0 --platform linux/amd64,linux/arm64
+```
+
 ## Using A Package In Config
 
 Packages can come from:

--- a/docs/pages/tasks/write-a-plugin.mdx
+++ b/docs/pages/tasks/write-a-plugin.mdx
@@ -78,29 +78,39 @@ func main() {
 go build -o ./my-tool .
 ```
 
-## Package
+## Release
 
-Package the binary into a plugin directory:
-
-```sh
-gestaltd plugin package \
-  --binary ./my-tool \
-  --source github.com/myorg/my-repo/my-tool \
-  --output ./dist/my-tool
-```
-
-The `--os` and `--arch` flags default to your current platform. For cross-compilation:
+Release the plugin for all platforms:
 
 ```sh
-GOOS=linux GOARCH=amd64 go build -o ./my-tool-linux .
-gestaltd plugin package \
-  --binary ./my-tool-linux \
-  --source github.com/myorg/my-repo/my-tool \
-  --os linux --arch amd64 \
-  --output ./dist/my-tool
+gestaltd plugin release --version 0.1.0
 ```
 
-For remote distribution, use a `.tar.gz` output path to produce an archive instead.
+This cross-compiles for macOS and Linux (amd64 and arm64), creates per-platform archives, and generates a checksums file in `dist/`.
+
+Upload the release artifacts to GitHub:
+
+```sh
+gh release create v0.1.0 dist/*
+```
+
+For CI automation, use the reusable workflow:
+
+```yaml
+# .github/workflows/release.yml
+name: Release
+on:
+  push:
+    tags: ['v*']
+jobs:
+  release:
+    uses: valon-technologies/gestalt/.github/workflows/release-plugin-reusable.yml@<pinned-ref>
+    with:
+      version: ${{ github.ref_name }}
+      gestaltd-version: <same-pinned-ref>
+```
+
+Use the same tag or commit SHA for both `<pinned-ref>` values so the workflow and installed `gestaltd` stay in lockstep.
 
 ## Configure and run
 

--- a/server/cmd/gestaltd/plugin_test.go
+++ b/server/cmd/gestaltd/plugin_test.go
@@ -332,6 +332,40 @@ func TestRun_PluginReleaseCopiesCompiledSupportFiles(t *testing.T) {
 	}
 }
 
+func TestRun_PluginReleasePreservesCompiledWebUIMetadata(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newCompiledWebUIReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	testVersion := "0.0.21-test"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-compiled-webui-test_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+
+	manifestData, err := os.ReadFile(filepath.Join(extractDir, pluginpkg.ManifestFile))
+	if err != nil {
+		t.Fatalf("read plugin.json: %v", err)
+	}
+
+	var manifest pluginmanifestv1.Manifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	if manifest.WebUI == nil || manifest.WebUI.AssetRoot != "out" {
+		t.Fatalf("manifest webui = %#v, want asset_root %q", manifest.WebUI, "out")
+	}
+
+	if _, err := os.Stat(filepath.Join(extractDir, "out", "index.html")); err != nil {
+		t.Fatalf("expected webui asset in archive: %v", err)
+	}
+}
+
 func TestRun_PluginReleaseCopiesWebUISupportFiles(t *testing.T) {
 	t.Parallel()
 
@@ -355,6 +389,31 @@ func TestRun_PluginReleaseCopiesWebUISupportFiles(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(extractDir, filepath.FromSlash(rel))); err != nil {
 			t.Fatalf("expected %s in archive: %v", rel, err)
 		}
+	}
+}
+
+func TestRun_PluginReleaseTreatsGoModWithoutCmdAsDeclarative(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newWebUIReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	testVersion := "0.0.4-test"
+
+	writeTestFile(t, pluginDir, "go.mod", []byte("module example.com/webui-test\n\ngo 1.22\n"), 0644)
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-webui-test_v" + testVersion + ".tar.gz"
+	if _, err := os.Stat(filepath.Join(outputDir, archiveName)); err != nil {
+		t.Fatalf("expected declarative archive %s to exist: %v", archiveName, err)
+	}
+
+	compiledArchiveName := "gestalt-plugin-webui-test_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	if _, err := os.Stat(filepath.Join(outputDir, compiledArchiveName)); !os.IsNotExist(err) {
+		t.Fatalf("unexpected compiled archive %s: %v", compiledArchiveName, err)
 	}
 }
 
@@ -715,6 +774,31 @@ func newHybridReleaseFixture(t *testing.T, dir string) string {
 			},
 		},
 	})
+
+	return pluginDir
+}
+
+func newCompiledWebUIReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(dir, "compiled-webui-test")
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatalf("MkdirAll(pluginDir): %v", err)
+	}
+	writeTestFile(t, pluginDir, "go.mod", []byte("module example.com/compiled-webui-test\n\ngo 1.22\n"), 0644)
+	writeTestFile(t, pluginDir, "cmd/main.go", []byte("package main\n\nfunc main() {}\n"), 0644)
+	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
+		Source:      "github.com/testowner/plugins/compiled-webui-test",
+		Version:     "0.0.1",
+		DisplayName: "Compiled WebUI Test",
+		IconFile:    "branding/icon.svg",
+		Kinds:       []string{pluginmanifestv1.KindWebUI},
+		WebUI: &pluginmanifestv1.WebUIMetadata{
+			AssetRoot: "out",
+		},
+	})
+	writeTestFile(t, pluginDir, "branding/icon.svg", []byte("<svg></svg>\n"), 0644)
+	writeTestFile(t, pluginDir, "out/index.html", []byte("<html></html>\n"), 0644)
 	return pluginDir
 }
 


### PR DESCRIPTION
## Summary

- Replaces the `build-compiled` matrix job (4 parallel runners) and `assemble-compiled` job (50 lines of bash/yq/jq) with a single `release-compiled` job that runs `gestaltd plugin release`
- Creates `.github/workflows/release-plugin-reusable.yml` — a reusable workflow that third-party plugin developers can call from their own repos with a 10-line workflow file
- Net deletion: ~50 lines of shell scripting removed

Stacked on #408.

## Test plan

- [ ] Workflow YAML is valid (no syntax errors)
- [ ] Reusable workflow has correct input parameters
- [ ] `release-compiled` job correctly builds gestaltd and runs the release command

🤖 Generated with [Claude Code](https://claude.com/claude-code)