### PR TITLE
Refactor allowed_operations handling into shared policy

### DIFF
--- a/server/internal/bootstrap/bootstrap.go
+++ b/server/internal/bootstrap/bootstrap.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/crypto"
-	"github.com/valon-technologies/gestalt/server/core/integration"
 	"github.com/valon-technologies/gestalt/server/internal/composite"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	graphqlupstream "github.com/valon-technologies/gestalt/server/internal/graphql"
@@ -21,6 +20,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/mcpupstream"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
 	"github.com/valon-technologies/gestalt/server/internal/openapi"
+	"github.com/valon-technologies/gestalt/server/internal/operationexposure"
 	"github.com/valon-technologies/gestalt/server/internal/pluginhost"
 	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
@@ -1161,45 +1161,17 @@ func buildDeclarativeProvider(name string, intg config.IntegrationDef, deps Deps
 }
 
 func applyAllowedOperations(name string, intg config.IntegrationDef, pluginProv core.Provider) (core.Provider, error) {
-	if intg.Plugin.AllowedOperations != nil && len(intg.Plugin.AllowedOperations) == 0 {
-		return nil, fmt.Errorf("integration %q plugin.allowed_operations cannot be empty; omit the field to allow all", name)
+	policy, err := operationexposure.New(intg.Plugin.AllowedOperations)
+	if err != nil {
+		return nil, fmt.Errorf("integration %q plugin: %w", name, err)
 	}
-	if len(intg.Plugin.AllowedOperations) == 0 {
+	if policy == nil {
 		return pluginProv, nil
 	}
-
-	provOps := make(map[string]struct{}, len(pluginProv.ListOperations()))
-	for _, op := range pluginProv.ListOperations() {
-		provOps[op.Name] = struct{}{}
+	if err := policy.Validate(pluginProv.ListOperations()); err != nil {
+		return nil, fmt.Errorf("integration %q plugin: %w", name, err)
 	}
-
-	opsMap := make(map[string]string, len(intg.Plugin.AllowedOperations))
-	descs := make(map[string]string)
-	exposedNames := make(map[string]string, len(intg.Plugin.AllowedOperations))
-	for opName, override := range intg.Plugin.AllowedOperations {
-		if _, ok := provOps[opName]; !ok {
-			return nil, fmt.Errorf("integration %q plugin.allowed_operations references unknown operation %q", name, opName)
-		}
-		exposed := opName
-		if override != nil && override.Alias != "" {
-			exposed = override.Alias
-			opsMap[exposed] = opName
-		} else {
-			opsMap[opName] = ""
-		}
-		if existing, ok := exposedNames[exposed]; ok {
-			return nil, fmt.Errorf("integration %q plugin: alias collision: %q and %q both resolve to %q", name, existing, opName, exposed)
-		}
-		exposedNames[exposed] = opName
-		if override != nil && override.Description != "" {
-			descs[exposed] = override.Description
-		}
-	}
-	var opts []integration.RestrictedOption
-	if len(descs) > 0 {
-		opts = append(opts, integration.WithDescriptions(descs))
-	}
-	return integration.NewRestricted(pluginProv, opsMap, opts...), nil
+	return policy.Wrap(pluginProv), nil
 }
 
 func buildPluginProvider(ctx context.Context, name string, intg config.IntegrationDef) (core.Provider, map[string]any, error) {

--- a/server/internal/bootstrap/bootstrap.go
+++ b/server/internal/bootstrap/bootstrap.go
@@ -832,7 +832,7 @@ func buildHybridSpecProvider(ctx context.Context, name string, intg config.Integ
 			def.BaseURL = intg.Plugin.BaseURL
 		}
 		applyPluginHeaders(def, intg.Plugin, manifestProvider)
-		prov, err := provider.Build(def, conn, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+		prov, err := provider.Build(def, conn, provider.WithEgressResolver(deps.Egress.Resolver))
 		if err != nil {
 			return nil, "", err
 		}
@@ -848,7 +848,7 @@ func buildHybridSpecProvider(ctx context.Context, name string, intg config.Integ
 			def.BaseURL = intg.Plugin.BaseURL
 		}
 		applyPluginHeaders(def, intg.Plugin, manifestProvider)
-		prov, err := provider.Build(def, conn, nil, provider.WithEgressResolver(deps.Egress.Resolver))
+		prov, err := provider.Build(def, conn, provider.WithEgressResolver(deps.Egress.Resolver))
 		if err != nil {
 			return nil, "", err
 		}
@@ -932,7 +932,7 @@ func buildSpecLoadedProvider(ctx context.Context, name string, intg config.Integ
 		}
 		applyPluginHeaders(def, intg.Plugin, mp)
 		applyManifestResponseMapping(def, mp)
-		prov, err := provider.Build(def, conn, nil, mcpOAuthBuildOpts(conn, mp, regStore, deps)...)
+		prov, err := provider.Build(def, conn, mcpOAuthBuildOpts(conn, mp, regStore, deps)...)
 		if err != nil {
 			return nil, fmt.Errorf("build openapi provider %q: %w", name, err)
 		}
@@ -949,7 +949,7 @@ func buildSpecLoadedProvider(ctx context.Context, name string, intg config.Integ
 		}
 		applyPluginHeaders(def, intg.Plugin, mp)
 		applyManifestResponseMapping(def, mp)
-		prov, err := provider.Build(def, conn, nil, mcpOAuthBuildOpts(conn, mp, regStore, deps)...)
+		prov, err := provider.Build(def, conn, mcpOAuthBuildOpts(conn, mp, regStore, deps)...)
 		if err != nil {
 			return nil, fmt.Errorf("build graphql provider %q: %w", name, err)
 		}

--- a/server/internal/mcpupstream/upstream.go
+++ b/server/internal/mcpupstream/upstream.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/egress"
+	"github.com/valon-technologies/gestalt/server/internal/operationexposure"
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
@@ -29,18 +29,17 @@ var (
 )
 
 type Upstream struct {
-	name        string
-	display     string
-	desc        string
-	url         string
-	connMode    core.ConnectionMode
-	headers     map[string]string
-	cat         *catalog.Catalog
-	ops         []core.Operation
-	client      mcpclient.MCPClient
-	allowed     map[string]*config.OperationOverride
-	aliasToOrig map[string]string
-	resolver    *egress.Resolver
+	name     string
+	display  string
+	desc     string
+	url      string
+	connMode core.ConnectionMode
+	headers  map[string]string
+	cat      *catalog.Catalog
+	ops      []core.Operation
+	client   mcpclient.MCPClient
+	exposure *operationexposure.Policy
+	resolver *egress.Resolver
 }
 
 func New(_ context.Context, name string, url string, connMode core.ConnectionMode, headers map[string]string, resolver *egress.Resolver) (*Upstream, error) {
@@ -101,11 +100,10 @@ func (u *Upstream) CatalogForRequest(ctx context.Context, token string) (*catalo
 }
 
 func (u *Upstream) CallTool(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
-	if !u.isOperationAllowed(name) {
+	innerName, ok := u.resolveInnerName(name)
+	if !ok {
 		return nil, fmt.Errorf("operation %q is not allowed", name)
 	}
-
-	innerName := u.resolveInnerName(name)
 	req := mcpgo.CallToolRequest{}
 	req.Params.Name = innerName
 	req.Params.Arguments = args
@@ -132,35 +130,24 @@ func (u *Upstream) Close() error {
 }
 
 func (u *Upstream) FilterOperations(allowed map[string]*config.OperationOverride) error {
-	if len(allowed) == 0 {
-		return fmt.Errorf("allowed_operations cannot be empty; omit the field to allow all")
+	policy, err := operationexposure.New(allowed)
+	if err != nil {
+		return err
 	}
-
-	u.allowed = make(map[string]*config.OperationOverride, len(allowed))
-	u.aliasToOrig = make(map[string]string)
-	exposedNames := make(map[string]string, len(allowed))
-	var collisions []string
-	for name, override := range allowed {
-		u.allowed[name] = override
-		exposed := name
-		if override != nil && override.Alias != "" {
-			exposed = override.Alias
-			u.aliasToOrig[override.Alias] = name
+	if u.cat != nil {
+		if err := policy.Validate(u.ops); err != nil {
+			return err
 		}
-		if existing, ok := exposedNames[exposed]; ok {
-			collisions = append(collisions, fmt.Sprintf("%q and %q both resolve to %q", existing, name, exposed))
-		}
-		exposedNames[exposed] = name
 	}
-	if len(collisions) > 0 {
-		return fmt.Errorf("alias collisions: %s", strings.Join(collisions, "; "))
-	}
+	u.exposure = policy
 
-	if u.cat == nil {
+	if u.cat == nil || policy == nil {
 		return nil
 	}
 
-	return filterDiscovered(u.cat, &u.ops, u.allowed)
+	u.ops = policy.ApplyOperations(u.ops)
+	u.cat = policy.ApplyCatalog(u.cat)
+	return nil
 }
 
 func (u *Upstream) connect(ctx context.Context, token string) (mcpclient.MCPClient, error) {
@@ -220,30 +207,16 @@ func (u *Upstream) discover(ctx context.Context, token string) (*catalog.Catalog
 	}
 
 	cat, ops := buildCatalog(u.name, toolsResult.Tools)
-	if err := filterDiscovered(cat, &ops, u.allowed); err != nil {
+	if err := u.exposure.Validate(ops); err != nil {
 		return nil, nil, err
 	}
+	ops = u.exposure.ApplyOperations(ops)
+	cat = u.exposure.ApplyCatalog(cat)
 	return cat, ops, nil
 }
 
-func (u *Upstream) resolveInnerName(name string) string {
-	if orig, ok := u.aliasToOrig[name]; ok {
-		return orig
-	}
-	return name
-}
-
-func (u *Upstream) isOperationAllowed(name string) bool {
-	if len(u.allowed) == 0 {
-		return true
-	}
-	if _, ok := u.aliasToOrig[name]; ok {
-		return true
-	}
-	if override, ok := u.allowed[name]; ok && (override == nil || override.Alias == "") {
-		return true
-	}
-	return false
+func (u *Upstream) resolveInnerName(name string) (string, bool) {
+	return u.exposure.Resolve(name)
 }
 
 func buildCatalog(name string, tools []mcpgo.Tool) (*catalog.Catalog, []core.Operation) {
@@ -284,50 +257,4 @@ func buildCatalog(name string, tools []mcpgo.Tool) (*catalog.Catalog, []core.Ope
 	}
 
 	return cat, ops
-}
-
-func filterDiscovered(cat *catalog.Catalog, ops *[]core.Operation, allowed map[string]*config.OperationOverride) error {
-	if len(allowed) == 0 {
-		return nil
-	}
-
-	opSet := make(map[string]struct{}, len(*ops))
-	for _, op := range *ops {
-		opSet[op.Name] = struct{}{}
-	}
-	for name := range allowed {
-		if _, ok := opSet[name]; !ok {
-			return fmt.Errorf("allowed_operations contains unknown operation %q", name)
-		}
-	}
-
-	filteredOps := make([]core.Operation, 0, len(allowed))
-	for _, op := range *ops {
-		if override, ok := allowed[op.Name]; ok {
-			if override != nil && override.Description != "" {
-				op.Description = override.Description
-			}
-			if override != nil && override.Alias != "" {
-				op.Name = override.Alias
-			}
-			filteredOps = append(filteredOps, op)
-		}
-	}
-
-	filteredCatOps := make([]catalog.CatalogOperation, 0, len(allowed))
-	for i := range cat.Operations {
-		if override, ok := allowed[cat.Operations[i].ID]; ok {
-			if override != nil && override.Description != "" {
-				cat.Operations[i].Description = override.Description
-			}
-			if override != nil && override.Alias != "" {
-				cat.Operations[i].ID = override.Alias
-			}
-			filteredCatOps = append(filteredCatOps, cat.Operations[i])
-		}
-	}
-
-	*ops = filteredOps
-	cat.Operations = filteredCatOps
-	return nil
 }

--- a/server/internal/operationexposure/policy.go
+++ b/server/internal/operationexposure/policy.go
@@ -156,7 +156,8 @@ func (p *Policy) ApplyCatalog(cat *catalog.Catalog) *catalog.Catalog {
 
 	filtered := cat.Clone()
 	filtered.Operations = make([]catalog.CatalogOperation, 0, len(p.exposedToOriginal))
-	for _, op := range cat.Operations {
+	for i := range cat.Operations {
+		op := cat.Operations[i]
 		exposed, ok := p.originalToExposed[op.ID]
 		if !ok {
 			continue

--- a/server/internal/operationexposure/policy.go
+++ b/server/internal/operationexposure/policy.go
@@ -1,0 +1,171 @@
+package operationexposure
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coreintegration "github.com/valon-technologies/gestalt/server/core/integration"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+// Policy normalizes allowed_operations handling so every provider type uses the
+// same validation, aliasing, and description override behavior.
+type Policy struct {
+	exposedToOriginal map[string]string
+	originalToExposed map[string]string
+	descriptions      map[string]string
+}
+
+func New(allowed map[string]*config.OperationOverride) (*Policy, error) {
+	if allowed == nil {
+		return nil, nil
+	}
+	if len(allowed) == 0 {
+		return nil, fmt.Errorf("allowed_operations cannot be empty; omit the field to allow all")
+	}
+
+	policy := &Policy{
+		exposedToOriginal: make(map[string]string, len(allowed)),
+		originalToExposed: make(map[string]string, len(allowed)),
+	}
+	exposedNames := make(map[string]string, len(allowed))
+	var collisions []string
+
+	for original, override := range allowed {
+		exposed := original
+		if override != nil && override.Alias != "" {
+			exposed = override.Alias
+		}
+		if existing, ok := exposedNames[exposed]; ok {
+			collisions = append(collisions, fmt.Sprintf("%q and %q both resolve to %q", existing, original, exposed))
+		}
+		exposedNames[exposed] = original
+		policy.exposedToOriginal[exposed] = original
+		policy.originalToExposed[original] = exposed
+		if override != nil && override.Description != "" {
+			if policy.descriptions == nil {
+				policy.descriptions = make(map[string]string)
+			}
+			policy.descriptions[exposed] = override.Description
+		}
+	}
+
+	if len(collisions) > 0 {
+		return nil, fmt.Errorf("alias collisions: %s", strings.Join(collisions, "; "))
+	}
+
+	return policy, nil
+}
+
+func (p *Policy) Validate(ops []core.Operation) error {
+	if p == nil {
+		return nil
+	}
+
+	opSet := make(map[string]struct{}, len(ops))
+	for _, op := range ops {
+		opSet[op.Name] = struct{}{}
+	}
+	for original := range p.originalToExposed {
+		if _, ok := opSet[original]; !ok {
+			return fmt.Errorf("allowed_operations contains unknown operation %q", original)
+		}
+	}
+
+	return nil
+}
+
+func (p *Policy) Resolve(name string) (string, bool) {
+	if p == nil {
+		return name, true
+	}
+	original, ok := p.exposedToOriginal[name]
+	return original, ok
+}
+
+func (p *Policy) Wrap(prov core.Provider) core.Provider {
+	if p == nil {
+		return prov
+	}
+
+	var opts []coreintegration.RestrictedOption
+	if len(p.descriptions) > 0 {
+		opts = append(opts, coreintegration.WithDescriptions(p.DescriptionOverrides()))
+	}
+	return coreintegration.NewRestricted(prov, p.RestrictedMap(), opts...)
+}
+
+func (p *Policy) RestrictedMap() map[string]string {
+	if p == nil {
+		return nil
+	}
+
+	restricted := make(map[string]string, len(p.exposedToOriginal))
+	for exposed, original := range p.exposedToOriginal {
+		if exposed == original {
+			restricted[exposed] = ""
+			continue
+		}
+		restricted[exposed] = original
+	}
+	return restricted
+}
+
+func (p *Policy) DescriptionOverrides() map[string]string {
+	if len(p.descriptions) == 0 {
+		return nil
+	}
+
+	descriptions := make(map[string]string, len(p.descriptions))
+	for exposed, description := range p.descriptions {
+		descriptions[exposed] = description
+	}
+	return descriptions
+}
+
+func (p *Policy) ApplyOperations(ops []core.Operation) []core.Operation {
+	if p == nil {
+		return slices.Clone(ops)
+	}
+
+	filtered := make([]core.Operation, 0, len(p.exposedToOriginal))
+	for _, op := range ops {
+		exposed, ok := p.originalToExposed[op.Name]
+		if !ok {
+			continue
+		}
+		op.Name = exposed
+		if description, ok := p.descriptions[exposed]; ok {
+			op.Description = description
+		}
+		filtered = append(filtered, op)
+	}
+	return filtered
+}
+
+func (p *Policy) ApplyCatalog(cat *catalog.Catalog) *catalog.Catalog {
+	if cat == nil {
+		return nil
+	}
+	if p == nil {
+		return cat.Clone()
+	}
+
+	filtered := cat.Clone()
+	filtered.Operations = make([]catalog.CatalogOperation, 0, len(p.exposedToOriginal))
+	for _, op := range cat.Operations {
+		exposed, ok := p.originalToExposed[op.ID]
+		if !ok {
+			continue
+		}
+		op.ID = exposed
+		if description, ok := p.descriptions[exposed]; ok {
+			op.Description = description
+		}
+		filtered.Operations = append(filtered.Operations, op)
+	}
+	return filtered
+}

--- a/server/internal/operationexposure/policy_test.go
+++ b/server/internal/operationexposure/policy_test.go
@@ -1,0 +1,80 @@
+package operationexposure
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+func TestPolicyNewRejectsEmpty(t *testing.T) {
+	t.Parallel()
+
+	_, err := New(map[string]*config.OperationOverride{})
+	if err == nil {
+		t.Fatal("expected error for empty allowed_operations")
+	}
+}
+
+func TestPolicyNewRejectsAliasCollisions(t *testing.T) {
+	t.Parallel()
+
+	_, err := New(map[string]*config.OperationOverride{
+		"op_a": {Alias: "shared"},
+		"op_b": {Alias: "shared"},
+	})
+	if err == nil {
+		t.Fatal("expected alias collision")
+	}
+	if !strings.Contains(err.Error(), "alias collisions") {
+		t.Fatalf("error = %q, want alias collisions", err)
+	}
+}
+
+func TestPolicyValidateAndApply(t *testing.T) {
+	t.Parallel()
+
+	policy, err := New(map[string]*config.OperationOverride{
+		"list_items": {Alias: "items", Description: "Custom description"},
+		"get_item":   nil,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ops := []core.Operation{
+		{Name: "list_items", Description: "List items"},
+		{Name: "get_item", Description: "Get item"},
+	}
+	if err := policy.Validate(ops); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	filteredOps := policy.ApplyOperations(ops)
+	if len(filteredOps) != 2 {
+		t.Fatalf("got %d operations, want 2", len(filteredOps))
+	}
+	if filteredOps[0].Name != "items" || filteredOps[0].Description != "Custom description" {
+		t.Fatalf("first operation = %+v", filteredOps[0])
+	}
+	if filteredOps[1].Name != "get_item" {
+		t.Fatalf("second operation = %+v", filteredOps[1])
+	}
+
+	cat := &catalog.Catalog{
+		Name: "example",
+		Operations: []catalog.CatalogOperation{
+			{ID: "list_items", Description: "List items"},
+			{ID: "get_item", Description: "Get item"},
+		},
+	}
+	filteredCat := policy.ApplyCatalog(cat)
+	if len(filteredCat.Operations) != 2 {
+		t.Fatalf("got %d catalog operations, want 2", len(filteredCat.Operations))
+	}
+	if filteredCat.Operations[0].ID != "items" || filteredCat.Operations[0].Description != "Custom description" {
+		t.Fatalf("first catalog operation = %+v", filteredCat.Operations[0])
+	}
+}

--- a/server/internal/provider/build.go
+++ b/server/internal/provider/build.go
@@ -15,6 +15,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
+	"github.com/valon-technologies/gestalt/server/internal/operationexposure"
 )
 
 // BuildOption configures optional aspects of provider construction.
@@ -214,48 +215,14 @@ func Build(def *Definition, conn config.ConnectionDef, allowedOperations map[str
 
 	var result core.Provider = base
 
-	if ops := allowedOperations; ops != nil {
-		if len(ops) == 0 {
-			return nil, fmt.Errorf("%s: allowed_operations cannot be empty; omit the field to allow all", def.Provider)
-		}
-		opSet := make(map[string]struct{}, len(base.Operations))
-		for _, op := range base.Operations {
-			opSet[op.Name] = struct{}{}
-		}
-		restrictedOps := make(map[string]string, len(ops))
-		var collisions []string
-		for opName, override := range ops {
-			if _, ok := opSet[opName]; !ok {
-				return nil, fmt.Errorf("%s: allowed_operations contains unknown operation %q", def.Provider, opName)
-			}
-			if override != nil && override.Description != "" {
-				for i := range base.Operations {
-					if base.Operations[i].Name == opName {
-						base.Operations[i].Description = override.Description
-						break
-					}
-				}
-				for i := range cat.Operations {
-					if cat.Operations[i].ID == opName {
-						cat.Operations[i].Description = override.Description
-						break
-					}
-				}
-			}
-			exposedName := opName
-			if override != nil && override.Alias != "" {
-				exposedName = override.Alias
-			}
-			if existing, ok := restrictedOps[exposedName]; ok {
-				collisions = append(collisions, fmt.Sprintf("%q and %q both resolve to %q", existing, opName, exposedName))
-			}
-			restrictedOps[exposedName] = opName
-		}
-		if len(collisions) > 0 {
-			return nil, fmt.Errorf("%s: alias collisions: %s", def.Provider, strings.Join(collisions, "; "))
-		}
-		result = coreintegration.NewRestricted(result, restrictedOps)
+	policy, err := operationexposure.New(allowedOperations)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", def.Provider, err)
 	}
+	if err := policy.Validate(base.Operations); err != nil {
+		return nil, fmt.Errorf("%s: %w", def.Provider, err)
+	}
+	result = policy.Wrap(result)
 
 	return result, nil
 }

--- a/server/internal/provider/build.go
+++ b/server/internal/provider/build.go
@@ -15,7 +15,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
-	"github.com/valon-technologies/gestalt/server/internal/operationexposure"
 )
 
 // BuildOption configures optional aspects of provider construction.
@@ -39,7 +38,7 @@ func WithEgressResolver(r *egress.Resolver) BuildOption {
 // owns auth configuration. Display metadata (display_name, description, icon)
 // should be applied to the Definition before calling Build via
 // ApplyDisplayOverrides.
-func Build(def *Definition, conn config.ConnectionDef, allowedOperations map[string]*config.OperationOverride, opts ...BuildOption) (core.Provider, error) {
+func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (core.Provider, error) {
 	var bo buildOptions
 	for _, opt := range opts {
 		opt(&bo)
@@ -212,19 +211,7 @@ func Build(def *Definition, conn config.ConnectionDef, allowedOperations map[str
 	}
 
 	base.SetCatalog(cat)
-
-	var result core.Provider = base
-
-	policy, err := operationexposure.New(allowedOperations)
-	if err != nil {
-		return nil, fmt.Errorf("%s: %w", def.Provider, err)
-	}
-	if err := policy.Validate(base.Operations); err != nil {
-		return nil, fmt.Errorf("%s: %w", def.Provider, err)
-	}
-	result = policy.Wrap(result)
-
-	return result, nil
+	return base, nil
 }
 
 // ApplyDisplayOverrides merges display metadata from an IntegrationDef into a

--- a/server/internal/provider/build_test.go
+++ b/server/internal/provider/build_test.go
@@ -44,7 +44,7 @@ func TestBuild(t *testing.T) {
 	t.Parallel()
 
 	def := testDefinition("example")
-	intg, err := Build(def, testCreds(), nil)
+	intg, err := Build(def, testCreds())
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestBuildManualAuth(t *testing.T) {
 			"list": {Description: "List", Method: http.MethodGet, Path: "/list"},
 		},
 	}
-	intg, err := Build(def, config.ConnectionDef{}, nil)
+	intg, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestBuildDoesNotMutateDefinition(t *testing.T) {
 	_, err := Build(def, config.ConnectionDef{Auth: config.ConnectionAuthDef{
 		ClientID: "test",
 		TokenURL: "https://override.example.com/token",
-	}}, nil)
+	}})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -93,213 +93,12 @@ func TestBuildDoesNotMutateDefinition(t *testing.T) {
 	}
 }
 
-func TestBuildAllowedOperations(t *testing.T) {
-	t.Parallel()
-
-	def := testDefinition("filtered")
-	intg, err := Build(def, config.ConnectionDef{Auth: config.ConnectionAuthDef{
-		ClientID:     "test",
-		ClientSecret: "test",
-		RedirectURL:  "http://localhost/callback",
-	}}, map[string]*config.OperationOverride{"list_items": nil})
-	if err != nil {
-		t.Fatalf("Build: %v", err)
-	}
-	if len(intg.ListOperations()) != 1 {
-		t.Fatalf("got %d operations, want 1", len(intg.ListOperations()))
-	}
-}
-
-func TestBuildAllowedOperationsUnknown(t *testing.T) {
-	t.Parallel()
-
-	def := testDefinition("bad")
-	_, err := Build(def, config.ConnectionDef{}, map[string]*config.OperationOverride{"nonexistent": nil})
-	if err == nil {
-		t.Fatal("expected error for unknown allowed operation")
-	}
-}
-
-func TestBuildAllowedOperationsEmpty(t *testing.T) {
-	t.Parallel()
-
-	def := testDefinition("bad")
-	_, err := Build(def, config.ConnectionDef{}, map[string]*config.OperationOverride{})
-	if err == nil {
-		t.Fatal("expected error for empty allowed_operations")
-	}
-}
-
-func TestBuildWithAlias(t *testing.T) {
-	t.Parallel()
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
-	}))
-	t.Cleanup(srv.Close)
-
-	def := &Definition{
-		Provider:    "alias_test",
-		DisplayName: "Alias Test",
-		BaseURL:     srv.URL,
-		Auth:        AuthDef{Type: "manual"},
-		Operations: map[string]OperationDef{
-			"op_alpha": {Description: "Alpha op", Method: http.MethodGet, Path: "/alpha"},
-			"op_beta":  {Description: "Beta op", Method: http.MethodGet, Path: "/beta"},
-		},
-	}
-
-	intg, err := Build(def, config.ConnectionDef{}, map[string]*config.OperationOverride{
-		"op_alpha": {Alias: "my_alpha"},
-		"op_beta":  nil,
-	})
-	if err != nil {
-		t.Fatalf("Build: %v", err)
-	}
-
-	ops := intg.ListOperations()
-	if len(ops) != 2 {
-		t.Fatalf("got %d operations, want 2", len(ops))
-	}
-	names := make(map[string]bool, len(ops))
-	for _, op := range ops {
-		names[op.Name] = true
-	}
-	if !names["my_alpha"] {
-		t.Error("expected aliased name my_alpha in ListOperations")
-	}
-	if !names["op_beta"] {
-		t.Error("expected original name op_beta in ListOperations")
-	}
-
-	result, err := intg.Execute(context.Background(), "my_alpha", nil, "tok")
-	if err != nil {
-		t.Fatalf("Execute(my_alpha): %v", err)
-	}
-	if result.Status != http.StatusOK {
-		t.Errorf("status = %d, want 200", result.Status)
-	}
-
-	_, err = intg.Execute(context.Background(), "op_alpha", nil, "tok")
-	if err == nil {
-		t.Fatal("expected error when calling by original name after aliasing")
-	}
-}
-
-func TestBuildWithAliasAndDescription(t *testing.T) {
-	t.Parallel()
-
-	def := &Definition{
-		Provider:    "alias_desc_test",
-		DisplayName: "Alias Desc Test",
-		BaseURL:     "https://api.example.com",
-		Auth:        AuthDef{Type: "manual"},
-		Operations: map[string]OperationDef{
-			"op_gamma": {Description: "Gamma op", Method: http.MethodGet, Path: "/gamma"},
-		},
-	}
-
-	intg, err := Build(def, config.ConnectionDef{}, map[string]*config.OperationOverride{
-		"op_gamma": {Alias: "renamed_gamma", Description: "Custom gamma description"},
-	})
-	if err != nil {
-		t.Fatalf("Build: %v", err)
-	}
-
-	ops := intg.ListOperations()
-	if len(ops) != 1 {
-		t.Fatalf("got %d operations, want 1", len(ops))
-	}
-	if ops[0].Name != "renamed_gamma" {
-		t.Errorf("operation name = %q, want renamed_gamma", ops[0].Name)
-	}
-	if ops[0].Description != "Custom gamma description" {
-		t.Errorf("description = %q, want custom override", ops[0].Description)
-	}
-
-	cp, ok := intg.(core.CatalogProvider)
-	if !ok {
-		t.Fatal("expected CatalogProvider")
-	}
-	cat := cp.Catalog()
-	if len(cat.Operations) != 1 {
-		t.Fatalf("got %d catalog operations, want 1", len(cat.Operations))
-	}
-	if cat.Operations[0].ID != "renamed_gamma" {
-		t.Errorf("catalog operation ID = %q, want renamed_gamma", cat.Operations[0].ID)
-	}
-	if cat.Operations[0].Description != "Custom gamma description" {
-		t.Errorf("catalog description = %q, want custom override", cat.Operations[0].Description)
-	}
-}
-
-func TestBuildWithNullOverride(t *testing.T) {
-	t.Parallel()
-
-	def := testDefinition("null_override")
-	intg, err := Build(def, testCreds(), map[string]*config.OperationOverride{
-		"list_items": nil,
-		"get_item":   nil,
-	})
-	if err != nil {
-		t.Fatalf("Build: %v", err)
-	}
-	ops := intg.ListOperations()
-	if len(ops) != 2 {
-		t.Fatalf("got %d operations, want 2", len(ops))
-	}
-	for _, op := range ops {
-		if op.Name != "list_items" && op.Name != "get_item" {
-			t.Errorf("unexpected operation %q", op.Name)
-		}
-	}
-}
-
-func TestBuildWithDescriptionOnly(t *testing.T) {
-	t.Parallel()
-
-	def := testDefinition("desc_only")
-	intg, err := Build(def, testCreds(), map[string]*config.OperationOverride{
-		"list_items": {Description: "Overridden list description"},
-	})
-	if err != nil {
-		t.Fatalf("Build: %v", err)
-	}
-	ops := intg.ListOperations()
-	if len(ops) != 1 {
-		t.Fatalf("got %d operations, want 1", len(ops))
-	}
-	if ops[0].Name != "list_items" {
-		t.Errorf("name = %q, want list_items", ops[0].Name)
-	}
-	if ops[0].Description != "Overridden list description" {
-		t.Errorf("description = %q, want override", ops[0].Description)
-	}
-}
-
-func TestBuildAliasCollision(t *testing.T) {
-	t.Parallel()
-
-	def := testDefinition("collision")
-	_, err := Build(def, testCreds(), map[string]*config.OperationOverride{
-		"list_items": {Alias: "get_item"},
-		"get_item":   nil,
-	})
-	if err == nil {
-		t.Fatal("expected error for alias collision")
-	}
-	if !strings.Contains(err.Error(), "alias collision") {
-		t.Errorf("error = %q, want alias collision message", err)
-	}
-}
-
 func TestBuildUnknownAuthStyle(t *testing.T) {
 	t.Parallel()
 
 	def := testDefinition("bad")
 	def.AuthStyle = "bogus"
-	_, err := Build(def, testCreds(), nil)
+	_, err := Build(def, testCreds())
 	if err == nil {
 		t.Fatal("expected error for unknown auth_style")
 	}
@@ -318,7 +117,7 @@ func TestBuildBasicAuthStyle(t *testing.T) {
 			"list": {Description: "List", Method: http.MethodGet, Path: "/list"},
 		},
 	}
-	intg, err := Build(def, config.ConnectionDef{}, nil)
+	intg, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -357,7 +156,7 @@ func TestBuildSatisfiesCatalogProvider(t *testing.T) {
 		},
 	}
 
-	provider, err := Build(def, config.ConnectionDef{}, nil)
+	provider, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -418,7 +217,7 @@ func TestBuildAppliesIconFile(t *testing.T) {
 	}
 
 	ApplyDisplayOverrides(def, config.IntegrationDef{IconFile: iconPath})
-	prov, err := Build(def, config.ConnectionDef{}, nil)
+	prov, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -450,7 +249,7 @@ func TestBuildIconFileMissing(t *testing.T) {
 	}
 
 	ApplyDisplayOverrides(def, config.IntegrationDef{IconFile: "/nonexistent/icon.svg"})
-	prov, err := Build(def, config.ConnectionDef{}, nil)
+	prov, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build should succeed with missing icon: %v", err)
 	}
@@ -486,7 +285,7 @@ func TestBuildAuthHeader(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{}, nil)
+	prov, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -537,7 +336,7 @@ func TestBuildAuthMapping(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{}, nil)
+	prov, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -584,7 +383,7 @@ func TestBuildAuthMappingMissingField(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{}, nil)
+	prov, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -623,7 +422,7 @@ func TestBuildErrorMessagePath(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{}, nil)
+	prov, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -660,7 +459,7 @@ func TestBuildErrorMessagePathSuccessPassthrough(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{}, nil)
+	prov, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -699,7 +498,7 @@ func TestBuildConfigOverridesAuthHeader(t *testing.T) {
 
 	def.AuthHeader = "X-Override-Key"
 
-	prov, err := Build(def, config.ConnectionDef{}, nil)
+	prov, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -741,7 +540,7 @@ func TestBuildConnectionParams(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{}, nil)
+	prov, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -785,7 +584,7 @@ func TestBuildConnectionParamsBaseURLInterpolation(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{}, nil)
+	prov, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -825,7 +624,7 @@ func TestBuildResponseCheck_SuccessMatch(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{}, nil)
+	prov, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -868,7 +667,7 @@ func TestBuildResponseCheck_FailureMatch(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{}, nil)
+	prov, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -906,7 +705,7 @@ func TestBuildResponseCheck_NonJSON200(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{}, nil)
+	prov, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -943,7 +742,7 @@ func TestBuildResponseCheck_NonJSON500(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{}, nil)
+	prov, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -970,7 +769,7 @@ func TestBuildResponseCheck_SuccessMatchOnly(t *testing.T) {
 		},
 	}
 
-	_, err := Build(def, config.ConnectionDef{}, nil)
+	_, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build should succeed with structured response check: %v", err)
 	}
@@ -1004,7 +803,7 @@ func TestBuildResponseCheck_ErrorMessagePathOnly(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{}, nil)
+	prov, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -1035,7 +834,7 @@ func TestBuildCredentialFields(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, config.ConnectionDef{}, nil)
+	prov, err := Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -1078,7 +877,7 @@ func TestBuildCredentialFieldsFromConfig(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, conn, nil)
+	prov, err := Build(def, conn)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -1130,7 +929,7 @@ func TestBuildAuthMappingFromConfig(t *testing.T) {
 		},
 	}
 
-	prov, err := Build(def, conn, nil)
+	prov, err := Build(def, conn)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}

--- a/server/internal/sandbox/sandbox_darwin.go
+++ b/server/internal/sandbox/sandbox_darwin.go
@@ -84,9 +84,9 @@ func buildSBPLProfile(policy *Policy) string {
 }
 
 func sbplAllowWrite(b *strings.Builder, p string) {
-	b.WriteString(fmt.Sprintf("(allow file-write* (subpath %s))\n", sbplQuote(p)))
+	fmt.Fprintf(b, "(allow file-write* (subpath %s))\n", sbplQuote(p))
 	if resolved, err := filepath.EvalSymlinks(p); err == nil && resolved != p {
-		b.WriteString(fmt.Sprintf("(allow file-write* (subpath %s))\n", sbplQuote(resolved)))
+		fmt.Fprintf(b, "(allow file-write* (subpath %s))\n", sbplQuote(resolved))
 	}
 }
 

--- a/server/internal/server/server_test.go
+++ b/server/internal/server/server_test.go
@@ -693,7 +693,7 @@ func TestListIntegrationsWithIcon(t *testing.T) {
 			"op": {Description: "An op", Method: http.MethodGet, Path: "/op"},
 		},
 	}
-	prov, err := provider.Build(def, config.ConnectionDef{}, nil)
+	prov, err := provider.Build(def, config.ConnectionDef{})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}


### PR DESCRIPTION
## Summary
- centralize `allowed_operations` validation, aliasing, and description overrides in a shared `operationexposure.Policy`
- reuse that policy from provider build, bootstrap restriction wrapping, and MCP upstream filtering instead of maintaining three separate implementations
- remove provider-side operation/catalog mutation and let the restriction layer project aliases and descriptions consistently

## Testing
- `go test ./internal/bootstrap ./internal/provider ./internal/mcpupstream ./internal/operationexposure ./core/integration`