### PR TITLE
[codex] Delete unused ExpandedPath wrapper

### DIFF
--- a/server/internal/apiexec/apiexec.go
+++ b/server/internal/apiexec/apiexec.go
@@ -332,10 +332,6 @@ func DoGraphQL(ctx context.Context, client *http.Client, req GraphQLRequest) (*c
 	}, nil
 }
 
-func ExpandedPath(method, path string, params map[string]any) string {
-	return ExpandedPathWithQuery(method, path, params, nil)
-}
-
 func ExpandedPathWithQuery(method, path string, params map[string]any, queryParams map[string]any) string {
 	params = maps.Clone(params)
 	expanded, err := substitutePath(path, params)


### PR DESCRIPTION
## What changed

This deletes the unused `ExpandedPath` wrapper from `server/internal/apiexec/apiexec.go`.

`ExpandedPathWithQuery` is the active implementation and the simple wrapper no longer has any callers in the repo.

## Why

This is pure dead-code removal. Keeping the wrapper around adds API surface without any usage.

## Validation

- `go test ./internal/apiexec ./core/integration`
