### PR TITLE
Make Base execute directly from catalog

### DIFF
--- a/server/core/integration/base.go
+++ b/server/core/integration/base.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"net/http"
 	"time"
@@ -79,11 +80,6 @@ func (u UpstreamAuth) StartOAuthWithOverride(authBaseURL, state string, scopes [
 	return u.Handler.AuthorizationURLWithOverride(authBaseURL, state, scopes)
 }
 
-type Endpoint struct {
-	Method string
-	Path   string
-}
-
 type AuthStyle int
 
 const (
@@ -100,9 +96,6 @@ type Base struct {
 	ConnMode           core.ConnectionMode
 	Auth               AuthHandler
 	BaseURL            string
-	Operations         []core.Operation
-	Endpoints          map[string]Endpoint
-	Queries            map[string]string // operation_name -> graphql query
 	Headers            map[string]string
 	AuthStyle          AuthStyle
 	HTTPClient         *http.Client
@@ -251,7 +244,7 @@ func (b *Base) RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL s
 	return b.Auth.RefreshToken(ctx, refreshToken)
 }
 
-func (b *Base) ListOperations() []core.Operation { return b.Operations }
+func (b *Base) ListOperations() []core.Operation { return OperationsList(b.catalog) }
 
 func (b *Base) resolvedURLAndHeaders(ctx context.Context) (string, map[string]string) {
 	baseURL := b.BaseURL
@@ -277,11 +270,14 @@ func (b *Base) Execute(ctx context.Context, operation string, params map[string]
 		return b.ExecuteFunc(ctx, operation, params, token)
 	}
 
-	if query, ok := b.Queries[operation]; ok {
-		return b.executeGraphQL(ctx, operation, query, params, token)
+	catOp := findCatalogOp(b.catalog, operation)
+	if catOp == nil {
+		return nil, fmt.Errorf("unknown operation: %s", operation)
 	}
-
-	return b.executeREST(ctx, operation, params, token)
+	if catOp.Query != "" {
+		return b.executeGraphQL(ctx, operation, catOp.Query, params, token)
+	}
+	return b.executeREST(ctx, operation, catOp, params, token)
 }
 
 func (b *Base) executeGraphQL(ctx context.Context, operation string, query string, params map[string]any, token string) (*core.OperationResult, error) {

--- a/server/core/integration/base_test.go
+++ b/server/core/integration/base_test.go
@@ -43,10 +43,8 @@ func TestBaseExecuteDispatchesToEndpoint(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			"list_items": {Method: http.MethodGet, Path: "/api/items"},
-		},
 	}
+	setTestCatalog(b, restCatalogOp("list_items", http.MethodGet, "/api/items"))
 
 	result, err := b.Execute(context.Background(), "list_items", nil, "test-token")
 	if err != nil {
@@ -80,13 +78,11 @@ func TestBaseTokenParserOverridesAuthorization(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			"op": {Method: http.MethodGet, Path: "/test"},
-		},
 		TokenParser: func(token string) (string, map[string]string, error) {
 			return "Token " + token, map[string]string{"X-Custom": "value"}, nil
 		},
 	}
+	setTestCatalog(b, restCatalogOp("op", http.MethodGet, "/test"))
 
 	result, err := b.Execute(context.Background(), "op", nil, "abc123")
 	if err != nil {
@@ -125,10 +121,8 @@ func TestBaseExecuteStaticHeadersReachUpstream(t *testing.T) {
 		Headers: map[string]string{
 			headerName: headerValue,
 		},
-		Endpoints: map[string]Endpoint{
-			"list_items": {Method: http.MethodGet, Path: "/items"},
-		},
 	}
+	setTestCatalog(b, restCatalogOp("list_items", http.MethodGet, "/items"))
 
 	result, err := b.Execute(context.Background(), "list_items", nil, "")
 	if err != nil {
@@ -168,10 +162,8 @@ func TestBaseExecuteRequestAuthOverridesStaticAuthorizationHeader(t *testing.T) 
 			"Authorization": "Bearer wrong-token",
 			headerName:      headerValue,
 		},
-		Endpoints: map[string]Endpoint{
-			"list_items": {Method: http.MethodGet, Path: "/items"},
-		},
 	}
+	setTestCatalog(b, restCatalogOp("list_items", http.MethodGet, "/items"))
 
 	result, err := b.Execute(context.Background(), "list_items", nil, "secret-token")
 	if err != nil {
@@ -207,9 +199,6 @@ func TestBaseExecuteRESTRunsEgressResolutionOnFinalRequest(t *testing.T) {
 		Auth:            mockAuth{},
 		IntegrationName: "test-provider",
 		BaseURL:         srv.URL,
-		Endpoints: map[string]Endpoint{
-			"op": {Method: http.MethodGet, Path: "/test"},
-		},
 		EgressResolver: &egress.Resolver{
 			Subjects: egress.StaticSubjectResolver{
 				Subject: egress.Subject{Kind: egress.SubjectUser, ID: "user-1"},
@@ -220,6 +209,7 @@ func TestBaseExecuteRESTRunsEgressResolutionOnFinalRequest(t *testing.T) {
 			}),
 		},
 	}
+	setTestCatalog(b, restCatalogOp("op", http.MethodGet, "/test"))
 
 	if _, err := b.Execute(context.Background(), "op", nil, "test-token"); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -279,13 +269,11 @@ func TestBaseExecuteRoutesGraphQLOperations(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Queries: map[string]string{
-			"get_viewer": "{ viewer { login } }",
-		},
-		Endpoints: map[string]Endpoint{
-			"list_items": {Method: http.MethodGet, Path: "/api/items"},
-		},
 	}
+	setTestCatalog(b,
+		graphQLCatalogOp("get_viewer", "{ viewer { login } }"),
+		restCatalogOp("list_items", http.MethodGet, "/api/items"),
+	)
 
 	result, err := b.Execute(context.Background(), "get_viewer", nil, "gql-token")
 	if err != nil {
@@ -326,10 +314,8 @@ func TestBaseExecuteGraphQLWithVariables(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Queries: map[string]string{
-			"list_repos": "query($first: Int) { viewer { repositories(first: $first) { nodes { name } } } }",
-		},
 	}
+	setTestCatalog(b, graphQLCatalogOp("list_repos", "query($first: Int) { viewer { repositories(first: $first) { nodes { name } } } }"))
 
 	result, err := b.Execute(context.Background(), "list_repos", map[string]any{"first": 5}, "tok")
 	if err != nil {
@@ -366,9 +352,6 @@ func TestBaseExecuteGraphQLRunsEgressResolutionOnFinalRequest(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL + "/graphql",
-		Queries: map[string]string{
-			"get_viewer": "{ viewer { login } }",
-		},
 		TokenParser: func(token string) (string, map[string]string, error) {
 			return "Token " + token, map[string]string{"X-Org": "acme"}, nil
 		},
@@ -381,6 +364,7 @@ func TestBaseExecuteGraphQLRunsEgressResolutionOnFinalRequest(t *testing.T) {
 			}),
 		},
 	}
+	setTestCatalog(b, graphQLCatalogOp("get_viewer", "{ viewer { login } }"))
 
 	ctx := egress.WithSubject(context.Background(), egress.Subject{Kind: egress.SubjectUser, ID: "user-graphql"})
 	result, err := b.Execute(ctx, "get_viewer", nil, "gql-token")
@@ -434,13 +418,11 @@ func TestBaseExecuteGraphQLWithTokenParser(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Queries: map[string]string{
-			"get_viewer": "{ viewer { login } }",
-		},
 		TokenParser: func(token string) (string, map[string]string, error) {
 			return "Token " + token, map[string]string{"X-Org": "acme"}, nil
 		},
 	}
+	setTestCatalog(b, graphQLCatalogOp("get_viewer", "{ viewer { login } }"))
 
 	result, err := b.Execute(context.Background(), "get_viewer", nil, "my-token")
 	if err != nil {
@@ -471,10 +453,8 @@ func TestBaseExecuteGraphQLErrorsReturned(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Queries: map[string]string{
-			"get_viewer": "{ viewer { login } }",
-		},
 	}
+	setTestCatalog(b, graphQLCatalogOp("get_viewer", "{ viewer { login } }"))
 
 	_, err := b.Execute(context.Background(), "get_viewer", nil, "tok")
 	if err == nil {
@@ -500,10 +480,8 @@ func TestBaseExecuteBasicAuthStyle(t *testing.T) {
 		Auth:      mockAuth{},
 		BaseURL:   srv.URL,
 		AuthStyle: AuthStyleBasic,
-		Endpoints: map[string]Endpoint{
-			"op": {Method: http.MethodGet, Path: "/test"},
-		},
 	}
+	setTestCatalog(b, restCatalogOp("op", http.MethodGet, "/test"))
 
 	result, err := b.Execute(context.Background(), "op", nil, "user:pass")
 	if err != nil {
@@ -524,12 +502,7 @@ func TestBaseExecuteBasicAuthStyle(t *testing.T) {
 func TestBaseExecuteUnknownOperationFallsThrough(t *testing.T) {
 	t.Parallel()
 
-	b := &Base{
-		Auth: mockAuth{},
-		Queries: map[string]string{
-			"get_viewer": "{ viewer { login } }",
-		},
-	}
+	b := &Base{Auth: mockAuth{}}
 
 	_, err := b.Execute(context.Background(), "nonexistent", nil, "tok")
 	if err == nil {

--- a/server/core/integration/catalog.go
+++ b/server/core/integration/catalog.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -10,6 +9,9 @@ import (
 )
 
 func OperationsList(c *catalog.Catalog) []core.Operation {
+	if c == nil {
+		return nil
+	}
 	ops := make([]core.Operation, 0, len(c.Operations))
 	for i := range c.Operations {
 		op := &c.Operations[i]
@@ -40,39 +42,4 @@ func OperationsList(c *catalog.Catalog) []core.Operation {
 	return ops
 }
 
-func EndpointsMap(c *catalog.Catalog) (map[string]Endpoint, error) {
-	endpoints := make(map[string]Endpoint, len(c.Operations))
-	for i := range c.Operations {
-		op := &c.Operations[i]
-		if op.Transport == transportGraphQL || op.Query != "" {
-			continue
-		}
-		if strings.TrimSpace(op.Method) == "" {
-			return nil, fmt.Errorf("catalog %q operation %q is missing method", c.Name, op.ID)
-		}
-		if strings.TrimSpace(op.Path) == "" {
-			return nil, fmt.Errorf("catalog %q operation %q is missing path", c.Name, op.ID)
-		}
-		endpoints[op.ID] = Endpoint{
-			Method: strings.ToUpper(strings.TrimSpace(op.Method)),
-			Path:   op.Path,
-		}
-	}
-	return endpoints, nil
-}
-
 const transportGraphQL = "graphql"
-
-func QueriesMap(c *catalog.Catalog) map[string]string {
-	queries := make(map[string]string)
-	for i := range c.Operations {
-		op := &c.Operations[i]
-		if op.Query != "" {
-			queries[op.ID] = op.Query
-		}
-	}
-	if len(queries) == 0 {
-		return nil
-	}
-	return queries
-}

--- a/server/core/integration/egress_adapter.go
+++ b/server/core/integration/egress_adapter.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
@@ -13,13 +14,17 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/egress"
 )
 
-func (b *Base) executeREST(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
-	ep, ok := b.Endpoints[operation]
-	if !ok {
+func (b *Base) executeREST(ctx context.Context, operation string, catOp *catalog.CatalogOperation, params map[string]any, token string) (*core.OperationResult, error) {
+	if catOp == nil {
 		return nil, fmt.Errorf("unknown operation: %s", operation)
 	}
-
-	catOp := findCatalogOp(b.catalog, operation)
+	method := strings.ToUpper(strings.TrimSpace(catOp.Method))
+	if method == "" {
+		return nil, fmt.Errorf("operation %q is missing method", operation)
+	}
+	if strings.TrimSpace(catOp.Path) == "" {
+		return nil, fmt.Errorf("operation %q is missing path", operation)
+	}
 	bodyParams, queryParams, headerParams := partitionParams(catOp, params)
 
 	baseURL, headers := b.resolvedURLAndHeaders(ctx)
@@ -31,9 +36,9 @@ func (b *Base) executeREST(ctx context.Context, operation string, params map[str
 	}
 
 	req := apiexec.Request{
-		Method:        ep.Method,
+		Method:        method,
 		BaseURL:       baseURL,
-		Path:          ep.Path,
+		Path:          catOp.Path,
 		Params:        bodyParams,
 		QueryParams:   queryParams,
 		CustomHeaders: headers,

--- a/server/core/integration/param_routing_test.go
+++ b/server/core/integration/param_routing_test.go
@@ -186,9 +186,6 @@ func TestExecuteREST_CatalogQueryParam(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			"create_item": {Method: http.MethodPost, Path: "/items"},
-		},
 	}
 	b.SetCatalog(cat)
 
@@ -220,56 +217,6 @@ func TestExecuteREST_CatalogQueryParam(t *testing.T) {
 	}
 	if _, hasPage := body["page"]; hasPage {
 		t.Fatalf("body should not contain page (it should be in query)")
-	}
-}
-
-func TestExecuteREST_NoCatalog_PreservesLegacy(t *testing.T) {
-	t.Parallel()
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		bodyBytes, _ := io.ReadAll(r.Body)
-		var body map[string]any
-		_ = json.Unmarshal(bodyBytes, &body)
-
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"query": r.URL.RawQuery,
-			"body":  body,
-		})
-	}))
-	t.Cleanup(func() { srv.Close() })
-
-	b := &Base{
-		Auth:    mockAuth{},
-		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			"create_item": {Method: http.MethodPost, Path: "/items"},
-		},
-	}
-
-	result, err := b.Execute(context.Background(), "create_item", map[string]any{
-		"name": "widget",
-		"page": 2,
-	}, "test-token")
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-
-	var resp map[string]any
-	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
-		t.Fatalf("json.Unmarshal: %v", err)
-	}
-
-	if resp["query"] != "" {
-		t.Fatalf("query = %q, want empty (legacy POST puts everything in body)", resp["query"])
-	}
-
-	body := resp["body"].(map[string]any)
-	if body["name"] != "widget" {
-		t.Fatalf("body[name] = %v, want widget", body["name"])
-	}
-	if body["page"] != float64(2) {
-		t.Fatalf("body[page] = %v, want 2", body["page"])
 	}
 }
 
@@ -309,9 +256,6 @@ func TestExecuteREST_WireNameQueryParam(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			opID: {Method: http.MethodGet, Path: opPath},
-		},
 	}
 	b.SetCatalog(cat)
 
@@ -372,9 +316,6 @@ func TestExecuteREST_CatalogHeaderParam(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			"create_item": {Method: http.MethodPost, Path: "/items"},
-		},
 	}
 	b.SetCatalog(cat)
 

--- a/server/core/integration/response_mapping_test.go
+++ b/server/core/integration/response_mapping_test.go
@@ -25,15 +25,13 @@ func TestResponseMappingExtractsDataAndPagination(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			"list": {Method: http.MethodPost, Path: "/list"},
-		},
 		ResponseMapping: &ResponseMappingConfig{
 			DataPath:              "results",
 			PaginationHasMorePath: "moreDataAvailable",
 			PaginationCursorPath:  "nextCursor",
 		},
 	}
+	setTestCatalog(b, restCatalogOp("list", http.MethodPost, "/list"))
 
 	result, err := b.Execute(context.Background(), "list", nil, "test-token")
 	if err != nil {
@@ -83,13 +81,11 @@ func TestResponseMappingNestedDataPath(t *testing.T) {
 	t.Cleanup(func() { srv.Close() })
 
 	b := &Base{
-		Auth:    mockAuth{},
-		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			"list": {Method: http.MethodGet, Path: "/list"},
-		},
+		Auth:            mockAuth{},
+		BaseURL:         srv.URL,
 		ResponseMapping: &ResponseMappingConfig{DataPath: "response.items"},
 	}
+	setTestCatalog(b, restCatalogOp("list", http.MethodGet, "/list"))
 
 	result, err := b.Execute(context.Background(), "list", nil, "tok")
 	if err != nil {
@@ -118,14 +114,12 @@ func TestResponseMappingPassesThroughErrors(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			"op": {Method: http.MethodGet, Path: "/op"},
-		},
 		CheckResponse: func(status int, body []byte) error {
 			return nil
 		},
 		ResponseMapping: &ResponseMappingConfig{DataPath: "results"},
 	}
+	setTestCatalog(b, restCatalogOp("op", http.MethodGet, "/op"))
 
 	result, err := b.Execute(context.Background(), "op", nil, "tok")
 	if err != nil {
@@ -151,10 +145,8 @@ func TestResponseMappingWithoutConfig(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			"op": {Method: http.MethodGet, Path: "/op"},
-		},
 	}
+	setTestCatalog(b, restCatalogOp("op", http.MethodGet, "/op"))
 
 	result, err := b.Execute(context.Background(), "op", nil, "tok")
 	if err != nil {

--- a/server/core/integration/test_helpers_test.go
+++ b/server/core/integration/test_helpers_test.go
@@ -1,0 +1,27 @@
+package integration
+
+import "github.com/valon-technologies/gestalt/server/core/catalog"
+
+func setTestCatalog(b *Base, ops ...catalog.CatalogOperation) {
+	b.SetCatalog(&catalog.Catalog{
+		Name:       "test",
+		Operations: ops,
+	})
+}
+
+func restCatalogOp(id, method, path string, params ...catalog.CatalogParameter) catalog.CatalogOperation {
+	return catalog.CatalogOperation{
+		ID:         id,
+		Method:     method,
+		Path:       path,
+		Parameters: params,
+	}
+}
+
+func graphQLCatalogOp(id, query string) catalog.CatalogOperation {
+	return catalog.CatalogOperation{
+		ID:        id,
+		Query:     query,
+		Transport: transportGraphQL,
+	}
+}

--- a/server/internal/provider/build.go
+++ b/server/internal/provider/build.go
@@ -67,11 +67,6 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 	cat.BaseURL = baseURL
 	coreintegration.CompileSchemas(cat)
 
-	endpoints, err := coreintegration.EndpointsMap(cat)
-	if err != nil {
-		return nil, fmt.Errorf("%s: %w", def.Provider, err)
-	}
-
 	base := &coreintegration.Base{
 		IntegrationName:    def.Provider,
 		IntegrationDisplay: def.DisplayName,
@@ -79,9 +74,6 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 		Auth:               auth,
 		BaseURL:            baseURL,
 		HTTPClient:         client,
-		Operations:         coreintegration.OperationsList(cat),
-		Endpoints:          endpoints,
-		Queries:            coreintegration.QueriesMap(cat),
 		Headers:            def.Headers,
 		Pagination:         buildPaginationConfigs(def),
 		EgressResolver:     bo.egress,


### PR DESCRIPTION
## Summary
- make `core/integration.Base` use its catalog as the single source of operation metadata
- remove the duplicated `Operations`, `Endpoints`, and `Queries` state from `Base` and `provider.Build`
- delete the no-catalog REST fallback test and move integration tests onto small catalog helpers

## Testing
- `go test ./core/integration ./internal/provider ./internal/server ./internal/mcp ./internal/pluginhost`
- `go test ./internal/bootstrap ./internal/openapi ./internal/graphql ./internal/provider/compiler`