### PR TITLE
Use catalogs as the canonical provider operation model

### DIFF
--- a/server/core/integration/base.go
+++ b/server/core/integration/base.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"net/http"
 	"time"
@@ -79,11 +80,6 @@ func (u UpstreamAuth) StartOAuthWithOverride(authBaseURL, state string, scopes [
 	return u.Handler.AuthorizationURLWithOverride(authBaseURL, state, scopes)
 }
 
-type Endpoint struct {
-	Method string
-	Path   string
-}
-
 type AuthStyle int
 
 const (
@@ -100,9 +96,6 @@ type Base struct {
 	ConnMode           core.ConnectionMode
 	Auth               AuthHandler
 	BaseURL            string
-	Operations         []core.Operation
-	Endpoints          map[string]Endpoint
-	Queries            map[string]string // operation_name -> graphql query
 	Headers            map[string]string
 	AuthStyle          AuthStyle
 	HTTPClient         *http.Client
@@ -251,7 +244,7 @@ func (b *Base) RefreshTokenWithURL(ctx context.Context, refreshToken, tokenURL s
 	return b.Auth.RefreshToken(ctx, refreshToken)
 }
 
-func (b *Base) ListOperations() []core.Operation { return b.Operations }
+func (b *Base) ListOperations() []core.Operation { return OperationsList(b.catalog) }
 
 func (b *Base) resolvedURLAndHeaders(ctx context.Context) (string, map[string]string) {
 	baseURL := b.BaseURL
@@ -277,11 +270,14 @@ func (b *Base) Execute(ctx context.Context, operation string, params map[string]
 		return b.ExecuteFunc(ctx, operation, params, token)
 	}
 
-	if query, ok := b.Queries[operation]; ok {
-		return b.executeGraphQL(ctx, operation, query, params, token)
+	catOp := findCatalogOp(b.catalog, operation)
+	if catOp == nil {
+		return nil, fmt.Errorf("unknown operation: %s", operation)
 	}
-
-	return b.executeREST(ctx, operation, params, token)
+	if catOp.Query != "" {
+		return b.executeGraphQL(ctx, operation, catOp.Query, params, token)
+	}
+	return b.executeREST(ctx, operation, catOp, params, token)
 }
 
 func (b *Base) executeGraphQL(ctx context.Context, operation string, query string, params map[string]any, token string) (*core.OperationResult, error) {

--- a/server/core/integration/base_test.go
+++ b/server/core/integration/base_test.go
@@ -43,10 +43,8 @@ func TestBaseExecuteDispatchesToEndpoint(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			"list_items": {Method: http.MethodGet, Path: "/api/items"},
-		},
 	}
+	setTestCatalog(b, restCatalogOp("list_items", http.MethodGet, "/api/items"))
 
 	result, err := b.Execute(context.Background(), "list_items", nil, "test-token")
 	if err != nil {
@@ -80,13 +78,11 @@ func TestBaseTokenParserOverridesAuthorization(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			"op": {Method: http.MethodGet, Path: "/test"},
-		},
 		TokenParser: func(token string) (string, map[string]string, error) {
 			return "Token " + token, map[string]string{"X-Custom": "value"}, nil
 		},
 	}
+	setTestCatalog(b, restCatalogOp("op", http.MethodGet, "/test"))
 
 	result, err := b.Execute(context.Background(), "op", nil, "abc123")
 	if err != nil {
@@ -125,10 +121,8 @@ func TestBaseExecuteStaticHeadersReachUpstream(t *testing.T) {
 		Headers: map[string]string{
 			headerName: headerValue,
 		},
-		Endpoints: map[string]Endpoint{
-			"list_items": {Method: http.MethodGet, Path: "/items"},
-		},
 	}
+	setTestCatalog(b, restCatalogOp("list_items", http.MethodGet, "/items"))
 
 	result, err := b.Execute(context.Background(), "list_items", nil, "")
 	if err != nil {
@@ -168,10 +162,8 @@ func TestBaseExecuteRequestAuthOverridesStaticAuthorizationHeader(t *testing.T) 
 			"Authorization": "Bearer wrong-token",
 			headerName:      headerValue,
 		},
-		Endpoints: map[string]Endpoint{
-			"list_items": {Method: http.MethodGet, Path: "/items"},
-		},
 	}
+	setTestCatalog(b, restCatalogOp("list_items", http.MethodGet, "/items"))
 
 	result, err := b.Execute(context.Background(), "list_items", nil, "secret-token")
 	if err != nil {
@@ -207,9 +199,6 @@ func TestBaseExecuteRESTRunsEgressResolutionOnFinalRequest(t *testing.T) {
 		Auth:            mockAuth{},
 		IntegrationName: "test-provider",
 		BaseURL:         srv.URL,
-		Endpoints: map[string]Endpoint{
-			"op": {Method: http.MethodGet, Path: "/test"},
-		},
 		EgressResolver: &egress.Resolver{
 			Subjects: egress.StaticSubjectResolver{
 				Subject: egress.Subject{Kind: egress.SubjectUser, ID: "user-1"},
@@ -220,6 +209,7 @@ func TestBaseExecuteRESTRunsEgressResolutionOnFinalRequest(t *testing.T) {
 			}),
 		},
 	}
+	setTestCatalog(b, restCatalogOp("op", http.MethodGet, "/test"))
 
 	if _, err := b.Execute(context.Background(), "op", nil, "test-token"); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -279,13 +269,11 @@ func TestBaseExecuteRoutesGraphQLOperations(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Queries: map[string]string{
-			"get_viewer": "{ viewer { login } }",
-		},
-		Endpoints: map[string]Endpoint{
-			"list_items": {Method: http.MethodGet, Path: "/api/items"},
-		},
 	}
+	setTestCatalog(b,
+		graphQLCatalogOp("get_viewer", "{ viewer { login } }"),
+		restCatalogOp("list_items", http.MethodGet, "/api/items"),
+	)
 
 	result, err := b.Execute(context.Background(), "get_viewer", nil, "gql-token")
 	if err != nil {
@@ -326,10 +314,8 @@ func TestBaseExecuteGraphQLWithVariables(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Queries: map[string]string{
-			"list_repos": "query($first: Int) { viewer { repositories(first: $first) { nodes { name } } } }",
-		},
 	}
+	setTestCatalog(b, graphQLCatalogOp("list_repos", "query($first: Int) { viewer { repositories(first: $first) { nodes { name } } } }"))
 
 	result, err := b.Execute(context.Background(), "list_repos", map[string]any{"first": 5}, "tok")
 	if err != nil {
@@ -366,9 +352,6 @@ func TestBaseExecuteGraphQLRunsEgressResolutionOnFinalRequest(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL + "/graphql",
-		Queries: map[string]string{
-			"get_viewer": "{ viewer { login } }",
-		},
 		TokenParser: func(token string) (string, map[string]string, error) {
 			return "Token " + token, map[string]string{"X-Org": "acme"}, nil
 		},
@@ -381,6 +364,7 @@ func TestBaseExecuteGraphQLRunsEgressResolutionOnFinalRequest(t *testing.T) {
 			}),
 		},
 	}
+	setTestCatalog(b, graphQLCatalogOp("get_viewer", "{ viewer { login } }"))
 
 	ctx := egress.WithSubject(context.Background(), egress.Subject{Kind: egress.SubjectUser, ID: "user-graphql"})
 	result, err := b.Execute(ctx, "get_viewer", nil, "gql-token")
@@ -434,13 +418,11 @@ func TestBaseExecuteGraphQLWithTokenParser(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Queries: map[string]string{
-			"get_viewer": "{ viewer { login } }",
-		},
 		TokenParser: func(token string) (string, map[string]string, error) {
 			return "Token " + token, map[string]string{"X-Org": "acme"}, nil
 		},
 	}
+	setTestCatalog(b, graphQLCatalogOp("get_viewer", "{ viewer { login } }"))
 
 	result, err := b.Execute(context.Background(), "get_viewer", nil, "my-token")
 	if err != nil {
@@ -471,10 +453,8 @@ func TestBaseExecuteGraphQLErrorsReturned(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Queries: map[string]string{
-			"get_viewer": "{ viewer { login } }",
-		},
 	}
+	setTestCatalog(b, graphQLCatalogOp("get_viewer", "{ viewer { login } }"))
 
 	_, err := b.Execute(context.Background(), "get_viewer", nil, "tok")
 	if err == nil {
@@ -500,10 +480,8 @@ func TestBaseExecuteBasicAuthStyle(t *testing.T) {
 		Auth:      mockAuth{},
 		BaseURL:   srv.URL,
 		AuthStyle: AuthStyleBasic,
-		Endpoints: map[string]Endpoint{
-			"op": {Method: http.MethodGet, Path: "/test"},
-		},
 	}
+	setTestCatalog(b, restCatalogOp("op", http.MethodGet, "/test"))
 
 	result, err := b.Execute(context.Background(), "op", nil, "user:pass")
 	if err != nil {
@@ -524,12 +502,7 @@ func TestBaseExecuteBasicAuthStyle(t *testing.T) {
 func TestBaseExecuteUnknownOperationFallsThrough(t *testing.T) {
 	t.Parallel()
 
-	b := &Base{
-		Auth: mockAuth{},
-		Queries: map[string]string{
-			"get_viewer": "{ viewer { login } }",
-		},
-	}
+	b := &Base{Auth: mockAuth{}}
 
 	_, err := b.Execute(context.Background(), "nonexistent", nil, "tok")
 	if err == nil {

--- a/server/core/integration/catalog.go
+++ b/server/core/integration/catalog.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -10,6 +9,9 @@ import (
 )
 
 func OperationsList(c *catalog.Catalog) []core.Operation {
+	if c == nil {
+		return nil
+	}
 	ops := make([]core.Operation, 0, len(c.Operations))
 	for i := range c.Operations {
 		op := &c.Operations[i]
@@ -40,39 +42,4 @@ func OperationsList(c *catalog.Catalog) []core.Operation {
 	return ops
 }
 
-func EndpointsMap(c *catalog.Catalog) (map[string]Endpoint, error) {
-	endpoints := make(map[string]Endpoint, len(c.Operations))
-	for i := range c.Operations {
-		op := &c.Operations[i]
-		if op.Transport == transportGraphQL || op.Query != "" {
-			continue
-		}
-		if strings.TrimSpace(op.Method) == "" {
-			return nil, fmt.Errorf("catalog %q operation %q is missing method", c.Name, op.ID)
-		}
-		if strings.TrimSpace(op.Path) == "" {
-			return nil, fmt.Errorf("catalog %q operation %q is missing path", c.Name, op.ID)
-		}
-		endpoints[op.ID] = Endpoint{
-			Method: strings.ToUpper(strings.TrimSpace(op.Method)),
-			Path:   op.Path,
-		}
-	}
-	return endpoints, nil
-}
-
 const transportGraphQL = "graphql"
-
-func QueriesMap(c *catalog.Catalog) map[string]string {
-	queries := make(map[string]string)
-	for i := range c.Operations {
-		op := &c.Operations[i]
-		if op.Query != "" {
-			queries[op.ID] = op.Query
-		}
-	}
-	if len(queries) == 0 {
-		return nil
-	}
-	return queries
-}

--- a/server/core/integration/egress_adapter.go
+++ b/server/core/integration/egress_adapter.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
@@ -13,13 +14,17 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/egress"
 )
 
-func (b *Base) executeREST(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
-	ep, ok := b.Endpoints[operation]
-	if !ok {
+func (b *Base) executeREST(ctx context.Context, operation string, catOp *catalog.CatalogOperation, params map[string]any, token string) (*core.OperationResult, error) {
+	if catOp == nil {
 		return nil, fmt.Errorf("unknown operation: %s", operation)
 	}
-
-	catOp := findCatalogOp(b.catalog, operation)
+	method := strings.ToUpper(strings.TrimSpace(catOp.Method))
+	if method == "" {
+		return nil, fmt.Errorf("operation %q is missing method", operation)
+	}
+	if strings.TrimSpace(catOp.Path) == "" {
+		return nil, fmt.Errorf("operation %q is missing path", operation)
+	}
 	bodyParams, queryParams, headerParams := partitionParams(catOp, params)
 
 	baseURL, headers := b.resolvedURLAndHeaders(ctx)
@@ -31,9 +36,9 @@ func (b *Base) executeREST(ctx context.Context, operation string, params map[str
 	}
 
 	req := apiexec.Request{
-		Method:        ep.Method,
+		Method:        method,
 		BaseURL:       baseURL,
-		Path:          ep.Path,
+		Path:          catOp.Path,
 		Params:        bodyParams,
 		QueryParams:   queryParams,
 		CustomHeaders: headers,

--- a/server/core/integration/param_routing_test.go
+++ b/server/core/integration/param_routing_test.go
@@ -186,9 +186,6 @@ func TestExecuteREST_CatalogQueryParam(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			"create_item": {Method: http.MethodPost, Path: "/items"},
-		},
 	}
 	b.SetCatalog(cat)
 
@@ -220,56 +217,6 @@ func TestExecuteREST_CatalogQueryParam(t *testing.T) {
 	}
 	if _, hasPage := body["page"]; hasPage {
 		t.Fatalf("body should not contain page (it should be in query)")
-	}
-}
-
-func TestExecuteREST_NoCatalog_PreservesLegacy(t *testing.T) {
-	t.Parallel()
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		bodyBytes, _ := io.ReadAll(r.Body)
-		var body map[string]any
-		_ = json.Unmarshal(bodyBytes, &body)
-
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"query": r.URL.RawQuery,
-			"body":  body,
-		})
-	}))
-	t.Cleanup(func() { srv.Close() })
-
-	b := &Base{
-		Auth:    mockAuth{},
-		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			"create_item": {Method: http.MethodPost, Path: "/items"},
-		},
-	}
-
-	result, err := b.Execute(context.Background(), "create_item", map[string]any{
-		"name": "widget",
-		"page": 2,
-	}, "test-token")
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-
-	var resp map[string]any
-	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
-		t.Fatalf("json.Unmarshal: %v", err)
-	}
-
-	if resp["query"] != "" {
-		t.Fatalf("query = %q, want empty (legacy POST puts everything in body)", resp["query"])
-	}
-
-	body := resp["body"].(map[string]any)
-	if body["name"] != "widget" {
-		t.Fatalf("body[name] = %v, want widget", body["name"])
-	}
-	if body["page"] != float64(2) {
-		t.Fatalf("body[page] = %v, want 2", body["page"])
 	}
 }
 
@@ -309,9 +256,6 @@ func TestExecuteREST_WireNameQueryParam(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			opID: {Method: http.MethodGet, Path: opPath},
-		},
 	}
 	b.SetCatalog(cat)
 
@@ -372,9 +316,6 @@ func TestExecuteREST_CatalogHeaderParam(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			"create_item": {Method: http.MethodPost, Path: "/items"},
-		},
 	}
 	b.SetCatalog(cat)
 

--- a/server/core/integration/response_mapping_test.go
+++ b/server/core/integration/response_mapping_test.go
@@ -25,15 +25,13 @@ func TestResponseMappingExtractsDataAndPagination(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			"list": {Method: http.MethodPost, Path: "/list"},
-		},
 		ResponseMapping: &ResponseMappingConfig{
 			DataPath:              "results",
 			PaginationHasMorePath: "moreDataAvailable",
 			PaginationCursorPath:  "nextCursor",
 		},
 	}
+	setTestCatalog(b, restCatalogOp("list", http.MethodPost, "/list"))
 
 	result, err := b.Execute(context.Background(), "list", nil, "test-token")
 	if err != nil {
@@ -83,13 +81,11 @@ func TestResponseMappingNestedDataPath(t *testing.T) {
 	t.Cleanup(func() { srv.Close() })
 
 	b := &Base{
-		Auth:    mockAuth{},
-		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			"list": {Method: http.MethodGet, Path: "/list"},
-		},
+		Auth:            mockAuth{},
+		BaseURL:         srv.URL,
 		ResponseMapping: &ResponseMappingConfig{DataPath: "response.items"},
 	}
+	setTestCatalog(b, restCatalogOp("list", http.MethodGet, "/list"))
 
 	result, err := b.Execute(context.Background(), "list", nil, "tok")
 	if err != nil {
@@ -118,14 +114,12 @@ func TestResponseMappingPassesThroughErrors(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			"op": {Method: http.MethodGet, Path: "/op"},
-		},
 		CheckResponse: func(status int, body []byte) error {
 			return nil
 		},
 		ResponseMapping: &ResponseMappingConfig{DataPath: "results"},
 	}
+	setTestCatalog(b, restCatalogOp("op", http.MethodGet, "/op"))
 
 	result, err := b.Execute(context.Background(), "op", nil, "tok")
 	if err != nil {
@@ -151,10 +145,8 @@ func TestResponseMappingWithoutConfig(t *testing.T) {
 	b := &Base{
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
-		Endpoints: map[string]Endpoint{
-			"op": {Method: http.MethodGet, Path: "/op"},
-		},
 	}
+	setTestCatalog(b, restCatalogOp("op", http.MethodGet, "/op"))
 
 	result, err := b.Execute(context.Background(), "op", nil, "tok")
 	if err != nil {

--- a/server/core/integration/schema.go
+++ b/server/core/integration/schema.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 )
 
@@ -103,31 +102,6 @@ func CompileSchemas(c *catalog.Catalog) {
 			op.Annotations = AnnotationsFromMethod(op.Method)
 		}
 	}
-}
-
-// CoreOperationsToCatalogOps converts core.Operation values into catalog equivalents.
-func CoreOperationsToCatalogOps(ops []core.Operation) []catalog.CatalogOperation {
-	out := make([]catalog.CatalogOperation, 0, len(ops))
-	for _, op := range ops {
-		params := make([]catalog.CatalogParameter, 0, len(op.Parameters))
-		for _, p := range op.Parameters {
-			params = append(params, catalog.CatalogParameter{
-				Name:        p.Name,
-				Type:        p.Type,
-				Description: p.Description,
-				Required:    p.Required,
-				Default:     p.Default,
-			})
-		}
-		out = append(out, catalog.CatalogOperation{
-			ID:          op.Name,
-			Method:      op.Method,
-			Description: op.Description,
-			Parameters:  params,
-			Transport:   catalog.TransportREST,
-		})
-	}
-	return out
 }
 
 func boolPtr(v bool) *bool { return &v }

--- a/server/core/integration/test_helpers_test.go
+++ b/server/core/integration/test_helpers_test.go
@@ -1,0 +1,27 @@
+package integration
+
+import "github.com/valon-technologies/gestalt/server/core/catalog"
+
+func setTestCatalog(b *Base, ops ...catalog.CatalogOperation) {
+	b.SetCatalog(&catalog.Catalog{
+		Name:       "test",
+		Operations: ops,
+	})
+}
+
+func restCatalogOp(id, method, path string, params ...catalog.CatalogParameter) catalog.CatalogOperation {
+	return catalog.CatalogOperation{
+		ID:         id,
+		Method:     method,
+		Path:       path,
+		Parameters: params,
+	}
+}
+
+func graphQLCatalogOp(id, query string) catalog.CatalogOperation {
+	return catalog.CatalogOperation{
+		ID:        id,
+		Query:     query,
+		Transport: transportGraphQL,
+	}
+}

--- a/server/internal/composite/merged.go
+++ b/server/internal/composite/merged.go
@@ -8,17 +8,15 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/core/integration"
 )
 
 type MergedProvider struct {
-	name, displayName, desc string
-	iconSVG                 string
-	connMode                core.ConnectionMode
-	ops                     []core.Operation
-	opConn                  map[string]string
-	route                   map[string]core.Provider
-	all                     []core.Provider
-	owned                   []core.Provider
+	catalog  *catalog.Catalog
+	connMode core.ConnectionMode
+	opConn   map[string]string
+	route    map[string]core.Provider
+	owned    []core.Provider
 }
 
 type BoundProvider struct {
@@ -41,20 +39,20 @@ func NewMerged(name, displayName, desc string, providers ...core.Provider) (*Mer
 }
 
 func NewMergedWithConnections(name, displayName, desc string, providers ...BoundProvider) (*MergedProvider, error) {
-	all := make([]core.Provider, len(providers))
 	owned := make([]core.Provider, len(providers))
 	for i, p := range providers {
-		all[i] = p.Provider
 		owned[i] = p.Provider
 	}
 	m := &MergedProvider{
-		name:        name,
-		displayName: displayName,
-		desc:        desc,
-		opConn:      make(map[string]string),
-		route:       make(map[string]core.Provider),
-		all:         all,
-		owned:       owned,
+		catalog: &catalog.Catalog{
+			Name:        name,
+			DisplayName: displayName,
+			Description: desc,
+			Operations:  make([]catalog.CatalogOperation, 0),
+		},
+		opConn: make(map[string]string),
+		route:  make(map[string]core.Provider),
+		owned:  owned,
 	}
 	for i, bound := range providers {
 		p := bound.Provider
@@ -68,66 +66,32 @@ func NewMergedWithConnections(name, displayName, desc string, providers ...Bound
 				return nil, fmt.Errorf("operation %q provided by both %q and %q", op.Name, owner.Name(), p.Name())
 			}
 			m.route[op.Name] = p
-			m.ops = append(m.ops, op)
+			m.catalog.Operations = append(m.catalog.Operations, mergedCatalogOperation(p, op))
 			if bound.Connection != "" {
 				m.opConn[op.Name] = bound.Connection
 			}
 		}
 	}
+	integration.CompileSchemas(m.catalog)
 	return m, nil
 }
 
-func (m *MergedProvider) Name() string                        { return m.name }
-func (m *MergedProvider) DisplayName() string                 { return m.displayName }
-func (m *MergedProvider) Description() string                 { return m.desc }
+func (m *MergedProvider) Name() string                        { return m.catalog.Name }
+func (m *MergedProvider) DisplayName() string                 { return m.catalog.DisplayName }
+func (m *MergedProvider) Description() string                 { return m.catalog.Description }
 func (m *MergedProvider) ConnectionMode() core.ConnectionMode { return m.connMode }
-func (m *MergedProvider) ListOperations() []core.Operation    { return m.ops }
+func (m *MergedProvider) ListOperations() []core.Operation {
+	return integration.OperationsList(m.catalog)
+}
 func (m *MergedProvider) ConnectionForOperation(op string) string {
 	return m.opConn[op]
 }
 
-func (m *MergedProvider) SetDisplayName(s string) { m.displayName = s }
-func (m *MergedProvider) SetDescription(s string) { m.desc = s }
-func (m *MergedProvider) SetIconSVG(svg string)   { m.iconSVG = svg }
+func (m *MergedProvider) SetDisplayName(s string) { m.catalog.DisplayName = s }
+func (m *MergedProvider) SetDescription(s string) { m.catalog.Description = s }
+func (m *MergedProvider) SetIconSVG(svg string)   { m.catalog.IconSVG = svg }
 
-func (m *MergedProvider) Catalog() *catalog.Catalog {
-	richOps := make(map[string]catalog.CatalogOperation)
-	for _, p := range m.all {
-		cp, ok := p.(core.CatalogProvider)
-		if !ok {
-			continue
-		}
-		cat := cp.Catalog()
-		if cat == nil {
-			continue
-		}
-		for i := range cat.Operations {
-			if _, ours := m.route[cat.Operations[i].ID]; ours {
-				richOps[cat.Operations[i].ID] = cat.Operations[i]
-			}
-		}
-	}
-
-	cat := &catalog.Catalog{
-		Name:        m.name,
-		DisplayName: m.displayName,
-		Description: m.desc,
-		IconSVG:     m.iconSVG,
-	}
-	for _, op := range m.ops {
-		if rich, ok := richOps[op.Name]; ok {
-			cat.Operations = append(cat.Operations, rich)
-		} else {
-			cat.Operations = append(cat.Operations, catalog.CatalogOperation{
-				ID:          op.Name,
-				Title:       op.Name,
-				Description: op.Description,
-				Transport:   catalog.TransportREST,
-			})
-		}
-	}
-	return cat
-}
+func (m *MergedProvider) Catalog() *catalog.Catalog { return m.catalog.Clone() }
 
 func (m *MergedProvider) Execute(ctx context.Context, op string, params map[string]any, token string) (*core.OperationResult, error) {
 	p, ok := m.route[op]
@@ -153,5 +117,37 @@ func (m *MergedProvider) DisownProvider(p core.Provider) {
 			m.owned = append(m.owned[:i], m.owned[i+1:]...)
 			return
 		}
+	}
+}
+
+func mergedCatalogOperation(p core.Provider, op core.Operation) catalog.CatalogOperation {
+	if cp, ok := p.(core.CatalogProvider); ok {
+		if cat := cp.Catalog(); cat != nil {
+			for i := range cat.Operations {
+				if cat.Operations[i].ID == op.Name {
+					return cat.Operations[i]
+				}
+			}
+		}
+	}
+
+	params := make([]catalog.CatalogParameter, 0, len(op.Parameters))
+	for _, param := range op.Parameters {
+		params = append(params, catalog.CatalogParameter{
+			Name:        param.Name,
+			Type:        param.Type,
+			Description: param.Description,
+			Required:    param.Required,
+			Default:     param.Default,
+		})
+	}
+
+	return catalog.CatalogOperation{
+		ID:          op.Name,
+		Method:      op.Method,
+		Title:       op.Name,
+		Description: op.Description,
+		Parameters:  params,
+		Transport:   catalog.TransportREST,
 	}
 }

--- a/server/internal/mcpupstream/upstream.go
+++ b/server/internal/mcpupstream/upstream.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"slices"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/core/integration"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"github.com/valon-technologies/gestalt/server/internal/operationexposure"
@@ -36,7 +36,6 @@ type Upstream struct {
 	connMode core.ConnectionMode
 	headers  map[string]string
 	cat      *catalog.Catalog
-	ops      []core.Operation
 	client   mcpclient.MCPClient
 	exposure *operationexposure.Policy
 	resolver *egress.Resolver
@@ -59,14 +58,13 @@ func New(_ context.Context, name string, url string, connMode core.ConnectionMod
 }
 
 func newFromClient(name string, client mcpclient.MCPClient, connMode core.ConnectionMode, tools []mcpgo.Tool) *Upstream {
-	cat, ops := buildCatalog(name, tools)
+	cat := buildCatalog(name, tools)
 	return &Upstream{
 		name:     name,
 		display:  name,
 		desc:     fmt.Sprintf("MCP upstream: %s", name),
 		connMode: connMode,
 		cat:      cat,
-		ops:      ops,
 		client:   client,
 	}
 }
@@ -75,9 +73,14 @@ func (u *Upstream) Name() string                        { return u.name }
 func (u *Upstream) DisplayName() string                 { return u.display }
 func (u *Upstream) Description() string                 { return u.desc }
 func (u *Upstream) ConnectionMode() core.ConnectionMode { return u.connMode }
-func (u *Upstream) ListOperations() []core.Operation    { return slices.Clone(u.ops) }
-func (u *Upstream) Catalog() *catalog.Catalog           { return u.cat }
-func (u *Upstream) SupportsManualAuth() bool            { return true }
+func (u *Upstream) ListOperations() []core.Operation    { return integration.OperationsList(u.cat) }
+func (u *Upstream) Catalog() *catalog.Catalog {
+	if u.cat == nil {
+		return nil
+	}
+	return u.cat.Clone()
+}
+func (u *Upstream) SupportsManualAuth() bool { return true }
 
 func (u *Upstream) SetDisplayName(s string) { u.display = s }
 func (u *Upstream) SetDescription(s string) { u.desc = s }
@@ -92,7 +95,7 @@ func (u *Upstream) Execute(_ context.Context, _ string, _ map[string]any, _ stri
 }
 
 func (u *Upstream) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
-	cat, _, err := u.discover(ctx, token)
+	cat, err := u.discover(ctx, token)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +138,7 @@ func (u *Upstream) FilterOperations(allowed map[string]*config.OperationOverride
 		return err
 	}
 	if u.cat != nil {
-		if err := policy.Validate(u.ops); err != nil {
+		if err := policy.Validate(integration.OperationsList(u.cat)); err != nil {
 			return err
 		}
 	}
@@ -145,7 +148,6 @@ func (u *Upstream) FilterOperations(allowed map[string]*config.OperationOverride
 		return nil
 	}
 
-	u.ops = policy.ApplyOperations(u.ops)
 	u.cat = policy.ApplyCatalog(u.cat)
 	return nil
 }
@@ -190,41 +192,40 @@ func (u *Upstream) connect(ctx context.Context, token string) (mcpclient.MCPClie
 	return client, nil
 }
 
-func (u *Upstream) discover(ctx context.Context, token string) (*catalog.Catalog, []core.Operation, error) {
+func (u *Upstream) discover(ctx context.Context, token string) (*catalog.Catalog, error) {
 	if u.client != nil && u.cat != nil {
-		return u.cat.Clone(), slices.Clone(u.ops), nil
+		return u.cat.Clone(), nil
 	}
 
 	client, err := u.connect(ctx, token)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	defer func() { _ = client.Close() }()
 
 	toolsResult, err := client.ListTools(ctx, mcpgo.ListToolsRequest{})
 	if err != nil {
-		return nil, nil, fmt.Errorf("mcpupstream %s: listing tools: %w", u.name, err)
+		return nil, fmt.Errorf("mcpupstream %s: listing tools: %w", u.name, err)
 	}
 
-	cat, ops := buildCatalog(u.name, toolsResult.Tools)
+	cat := buildCatalog(u.name, toolsResult.Tools)
+	ops := integration.OperationsList(cat)
 	if err := u.exposure.Validate(ops); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	ops = u.exposure.ApplyOperations(ops)
 	cat = u.exposure.ApplyCatalog(cat)
-	return cat, ops, nil
+	return cat, nil
 }
 
 func (u *Upstream) resolveInnerName(name string) (string, bool) {
 	return u.exposure.Resolve(name)
 }
 
-func buildCatalog(name string, tools []mcpgo.Tool) (*catalog.Catalog, []core.Operation) {
+func buildCatalog(name string, tools []mcpgo.Tool) *catalog.Catalog {
 	cat := &catalog.Catalog{
 		Name:       name,
 		Operations: make([]catalog.CatalogOperation, 0, len(tools)),
 	}
-	ops := make([]core.Operation, 0, len(tools))
 
 	for i := range tools {
 		schema, _ := json.Marshal(tools[i].InputSchema)
@@ -249,12 +250,7 @@ func buildCatalog(name string, tools []mcpgo.Tool) (*catalog.Catalog, []core.Ope
 			OpenWorldHint:   tools[i].Annotations.OpenWorldHint,
 		}
 		cat.Operations = append(cat.Operations, catOp)
-
-		ops = append(ops, core.Operation{
-			Name:        tools[i].Name,
-			Description: tools[i].Description,
-		})
 	}
 
-	return cat, ops
+	return cat
 }

--- a/server/internal/mcpupstream/upstream_test.go
+++ b/server/internal/mcpupstream/upstream_test.go
@@ -268,7 +268,7 @@ func TestUpstream_DiscoverAfterFilterWithAlias(t *testing.T) {
 		t.Fatalf("FilterOperations: %v", err)
 	}
 
-	cat, _, err := u.discover(context.Background(), "")
+	cat, err := u.discover(context.Background(), "")
 	if err != nil {
 		t.Fatalf("discover after filter with alias: %v", err)
 	}

--- a/server/internal/pluginhost/declarative.go
+++ b/server/internal/pluginhost/declarative.go
@@ -17,23 +17,11 @@ import (
 
 const declarativeHTTPTimeout = 30 * time.Second
 
-type declarativeOp struct {
-	method    string
-	path      string
-	paramLocs map[string]string
-}
-
 type DeclarativeProvider struct {
-	name                 string
-	displayName          string
-	description          string
-	iconSVG              string
+	catalog              *catalog.Catalog
+	opsByName            map[string]*catalog.CatalogOperation
 	baseURL              string
-	headers              map[string]string
 	auth                 *pluginmanifestv1.ProviderAuth
-	operations           []core.Operation
-	catalogOps           []catalog.CatalogOperation
-	opDefs               map[string]*declarativeOp
 	httpClient           *http.Client
 	postConnectDiscovery *pluginmanifestv1.ProviderPostConnectDiscovery
 	connectionDefs       map[string]pluginmanifestv1.ProviderConnectionParam
@@ -52,13 +40,16 @@ func NewDeclarativeProvider(manifest *pluginmanifestv1.Manifest, httpClient *htt
 	}
 
 	p := &DeclarativeProvider{
-		name:                 manifest.Source,
-		displayName:          manifest.DisplayName,
-		description:          manifest.Description,
+		catalog: &catalog.Catalog{
+			Name:        manifest.Source,
+			DisplayName: manifest.DisplayName,
+			Description: manifest.Description,
+			Headers:     maps.Clone(manifest.Provider.Headers),
+			Operations:  make([]catalog.CatalogOperation, 0, len(manifest.Provider.Operations)),
+		},
+		opsByName:            make(map[string]*catalog.CatalogOperation, len(manifest.Provider.Operations)),
 		baseURL:              manifest.Provider.BaseURL,
-		headers:              maps.Clone(manifest.Provider.Headers),
 		auth:                 manifest.Provider.Auth,
-		opDefs:               make(map[string]*declarativeOp, len(manifest.Provider.Operations)),
 		httpClient:           httpClient,
 		postConnectDiscovery: manifest.Provider.PostConnectDiscovery,
 		connectionDefs:       manifest.Provider.Connection,
@@ -66,67 +57,55 @@ func NewDeclarativeProvider(manifest *pluginmanifestv1.Manifest, httpClient *htt
 
 	for i := range manifest.Provider.Operations {
 		mop := &manifest.Provider.Operations[i]
-		locs := make(map[string]string, len(mop.Parameters))
-		for _, mp := range mop.Parameters {
-			locs[mp.Name] = mp.In
-		}
-		p.opDefs[mop.Name] = &declarativeOp{
-			method:    mop.Method,
-			path:      mop.Path,
-			paramLocs: locs,
-		}
-		coreOp := core.Operation{
-			Name:        mop.Name,
-			Description: mop.Description,
+		catOp := catalog.CatalogOperation{
+			ID:          mop.Name,
 			Method:      mop.Method,
+			Path:        mop.Path,
+			Description: mop.Description,
+			Transport:   catalog.TransportREST,
+			Parameters:  make([]catalog.CatalogParameter, 0, len(mop.Parameters)),
 		}
 		for _, mp := range mop.Parameters {
-			coreOp.Parameters = append(coreOp.Parameters, core.Parameter{
+			catOp.Parameters = append(catOp.Parameters, catalog.CatalogParameter{
 				Name:        mp.Name,
 				Type:        mp.Type,
+				Location:    mp.In,
 				Description: mp.Description,
 				Required:    mp.Required,
 			})
 		}
-		p.operations = append(p.operations, coreOp)
+		p.catalog.Operations = append(p.catalog.Operations, catOp)
 	}
 
-	p.catalogOps = integration.CoreOperationsToCatalogOps(p.operations)
+	integration.CompileSchemas(p.catalog)
+	for i := range p.catalog.Operations {
+		op := &p.catalog.Operations[i]
+		p.opsByName[op.ID] = op
+	}
 
 	return p, nil
 }
 
-func (p *DeclarativeProvider) Name() string        { return p.name }
-func (p *DeclarativeProvider) DisplayName() string { return p.displayName }
-func (p *DeclarativeProvider) Description() string { return p.description }
+func (p *DeclarativeProvider) Name() string        { return p.catalog.Name }
+func (p *DeclarativeProvider) DisplayName() string { return p.catalog.DisplayName }
+func (p *DeclarativeProvider) Description() string { return p.catalog.Description }
 
-func (p *DeclarativeProvider) SetDisplayName(s string) { p.displayName = s }
-func (p *DeclarativeProvider) SetDescription(s string) { p.description = s }
-func (p *DeclarativeProvider) SetIconSVG(svg string)   { p.iconSVG = svg }
+func (p *DeclarativeProvider) SetDisplayName(s string) { p.catalog.DisplayName = s }
+func (p *DeclarativeProvider) SetDescription(s string) { p.catalog.Description = s }
+func (p *DeclarativeProvider) SetIconSVG(svg string)   { p.catalog.IconSVG = svg }
 
-func (p *DeclarativeProvider) Catalog() *catalog.Catalog {
-	return &catalog.Catalog{
-		Name:        p.name,
-		DisplayName: p.displayName,
-		Description: p.description,
-		IconSVG:     p.iconSVG,
-		Headers:     maps.Clone(p.headers),
-		Operations:  p.catalogOps,
-	}
-}
+func (p *DeclarativeProvider) Catalog() *catalog.Catalog { return p.catalog.Clone() }
 
 func (p *DeclarativeProvider) ConnectionMode() core.ConnectionMode {
 	return core.ConnectionModeUser
 }
 
 func (p *DeclarativeProvider) ListOperations() []core.Operation {
-	out := make([]core.Operation, len(p.operations))
-	copy(out, p.operations)
-	return out
+	return integration.OperationsList(p.catalog)
 }
 
 func (p *DeclarativeProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
-	op, ok := p.opDefs[operation]
+	op, ok := p.opsByName[operation]
 	if !ok {
 		return &core.OperationResult{
 			Status: http.StatusNotFound,
@@ -137,10 +116,10 @@ func (p *DeclarativeProvider) Execute(ctx context.Context, operation string, par
 	queryParams := make(map[string]any)
 	bodyParams := make(map[string]any)
 
-	isBodyMethod := op.method == http.MethodPost || op.method == http.MethodPut || op.method == http.MethodPatch
+	isBodyMethod := op.Method == http.MethodPost || op.Method == http.MethodPut || op.Method == http.MethodPatch
 
 	for k, v := range params {
-		loc, declared := op.paramLocs[k]
+		loc, declared := declarativeParamLocation(op, k)
 		if !declared {
 			if isBodyMethod {
 				loc = "body"
@@ -157,7 +136,7 @@ func (p *DeclarativeProvider) Execute(ctx context.Context, operation string, par
 	}
 
 	baseURL := p.baseURL
-	headers := maps.Clone(p.headers)
+	headers := maps.Clone(p.catalog.Headers)
 	if cp := core.ConnectionParams(ctx); cp != nil {
 		baseURL = paraminterp.Interpolate(baseURL, cp)
 		for k, v := range headers {
@@ -166,9 +145,9 @@ func (p *DeclarativeProvider) Execute(ctx context.Context, operation string, par
 	}
 
 	req := apiexec.Request{
-		Method:        op.method,
+		Method:        op.Method,
 		BaseURL:       baseURL,
-		Path:          op.path,
+		Path:          op.Path,
 		Params:        bodyParams,
 		QueryParams:   queryParams,
 		CustomHeaders: headers,
@@ -177,6 +156,15 @@ func (p *DeclarativeProvider) Execute(ctx context.Context, operation string, par
 	}
 
 	return apiexec.Do(ctx, p.httpClient, req)
+}
+
+func declarativeParamLocation(op *catalog.CatalogOperation, name string) (string, bool) {
+	for _, param := range op.Parameters {
+		if param.Name == name {
+			return param.Location, true
+		}
+	}
+	return "", false
 }
 
 func (p *DeclarativeProvider) SupportsManualAuth() bool {

--- a/server/internal/pluginhost/declarative_test.go
+++ b/server/internal/pluginhost/declarative_test.go
@@ -366,6 +366,15 @@ func TestDeclarativeProviderCatalog(t *testing.T) {
 			t.Fatalf("Operations[%d].ID = %q, want %q", i, cat.Operations[i].ID, want)
 		}
 	}
+	if got := cat.Operations[0].Parameters[0].Location; got != "query" {
+		t.Fatalf("list_items first param location = %q, want query", got)
+	}
+	if got := cat.Operations[1].Parameters[0].Location; got != "body" {
+		t.Fatalf("create_item first param location = %q, want body", got)
+	}
+	if cat.Operations[3].InputSchema == nil {
+		t.Fatal("expected compiled input schema on update_item")
+	}
 
 	const testSVG = `<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>`
 	p.SetIconSVG(testSVG)

--- a/server/internal/pluginhost/provider_client.go
+++ b/server/internal/pluginhost/provider_client.go
@@ -19,7 +19,6 @@ import (
 type remoteProviderBase struct {
 	client      proto.ProviderPluginClient
 	metadata    *proto.ProviderMetadata
-	ops         []core.Operation
 	catalog     *catalog.Catalog
 	iconSVG     string
 	displayOver string
@@ -69,12 +68,12 @@ func NewRemoteProvider(ctx context.Context, client proto.ProviderPluginClient, n
 	if err != nil {
 		return nil, err
 	}
+	ops := operationsFromProto(opsResp.GetOperations())
 
 	base := &remoteProviderBase{
 		client:   client,
 		metadata: meta,
-		ops:      operationsFromProto(opsResp.GetOperations()),
-		catalog:  staticCatalog,
+		catalog:  buildRemoteCatalog(meta, staticCatalog, ops),
 	}
 	for _, opt := range opts {
 		opt(base)
@@ -110,9 +109,7 @@ func (p *remoteProviderBase) ConnectionMode() core.ConnectionMode {
 }
 
 func (p *remoteProviderBase) ListOperations() []core.Operation {
-	out := make([]core.Operation, len(p.ops))
-	copy(out, p.ops)
-	return out
+	return integration.OperationsList(p.catalog)
 }
 
 func (p *remoteProviderBase) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
@@ -143,7 +140,7 @@ func (p *remoteProviderBase) SetIconSVG(svg string) { p.iconSVG = svg }
 
 func (p *remoteProviderBase) Catalog() *catalog.Catalog {
 	if p.catalog == nil {
-		if len(p.ops) == 0 && p.iconSVG == "" {
+		if p.iconSVG == "" {
 			return nil
 		}
 		return &catalog.Catalog{
@@ -151,7 +148,6 @@ func (p *remoteProviderBase) Catalog() *catalog.Catalog {
 			DisplayName: p.DisplayName(),
 			Description: p.Description(),
 			IconSVG:     p.iconSVG,
-			Operations:  integration.CoreOperationsToCatalogOps(p.ops),
 		}
 	}
 	cat := p.catalog.Clone()
@@ -190,6 +186,120 @@ type remoteProviderWithSessionCatalog struct{ *remoteProviderBase }
 
 func (p *remoteProviderWithSessionCatalog) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
 	return p.sessionCatalog(ctx, token)
+}
+
+func buildRemoteCatalog(meta *proto.ProviderMetadata, staticCatalog *catalog.Catalog, ops []core.Operation) *catalog.Catalog {
+	if staticCatalog == nil && len(ops) == 0 {
+		return nil
+	}
+
+	var cat *catalog.Catalog
+	if staticCatalog != nil {
+		cat = staticCatalog.Clone()
+	} else {
+		cat = &catalog.Catalog{
+			Name:        meta.GetName(),
+			DisplayName: meta.GetDisplayName(),
+			Description: meta.GetDescription(),
+			Operations:  make([]catalog.CatalogOperation, 0, len(ops)),
+		}
+	}
+	if cat.Name == "" {
+		cat.Name = meta.GetName()
+	}
+	if cat.DisplayName == "" {
+		cat.DisplayName = meta.GetDisplayName()
+	}
+	if cat.Description == "" {
+		cat.Description = meta.GetDescription()
+	}
+
+	for _, op := range ops {
+		catOp := ensureCatalogOperation(cat, op)
+		if catOp.Description == "" {
+			catOp.Description = op.Description
+		}
+		if catOp.Method == "" {
+			catOp.Method = op.Method
+		}
+		if catOp.Transport == "" {
+			catOp.Transport = catalog.TransportPlugin
+		}
+		catOp.Parameters = mergeCatalogParameters(catOp.Parameters, op.Parameters)
+	}
+
+	integration.CompileSchemas(cat)
+	return cat
+}
+
+func ensureCatalogOperation(cat *catalog.Catalog, op core.Operation) *catalog.CatalogOperation {
+	for i := range cat.Operations {
+		if cat.Operations[i].ID == op.Name {
+			return &cat.Operations[i]
+		}
+	}
+	cat.Operations = append(cat.Operations, catalog.CatalogOperation{
+		ID:          op.Name,
+		Method:      op.Method,
+		Description: op.Description,
+		Transport:   catalog.TransportPlugin,
+	})
+	return &cat.Operations[len(cat.Operations)-1]
+}
+
+func mergeCatalogParameters(existing []catalog.CatalogParameter, params []core.Parameter) []catalog.CatalogParameter {
+	if len(params) == 0 {
+		return existing
+	}
+	if len(existing) == 0 {
+		return catalogParametersFromCore(params)
+	}
+
+	indexByName := make(map[string]int, len(existing))
+	for i := range existing {
+		indexByName[existing[i].Name] = i
+	}
+
+	for _, param := range params {
+		if idx, ok := indexByName[param.Name]; ok {
+			if existing[idx].Type == "" {
+				existing[idx].Type = param.Type
+			}
+			if existing[idx].Description == "" {
+				existing[idx].Description = param.Description
+			}
+			if !existing[idx].Required {
+				existing[idx].Required = param.Required
+			}
+			if existing[idx].Default == nil && param.Default != nil {
+				existing[idx].Default = param.Default
+			}
+			continue
+		}
+		existing = append(existing, catalog.CatalogParameter{
+			Name:        param.Name,
+			Type:        param.Type,
+			Description: param.Description,
+			Required:    param.Required,
+			Default:     param.Default,
+		})
+	}
+
+	return existing
+}
+
+func catalogParametersFromCore(params []core.Parameter) []catalog.CatalogParameter {
+	out := make([]catalog.CatalogParameter, 0, len(params))
+	for _, param := range params {
+		out = append(out, catalog.CatalogParameter{
+			Name:        param.Name,
+			Type:        param.Type,
+			Description: param.Description,
+			Required:    param.Required,
+			Default:     param.Default,
+		})
+	}
+	return out
 }
 
 func callStartProvider(ctx context.Context, client proto.ProviderPluginClient, name string, config map[string]any) error {

--- a/server/internal/pluginhost/provider_test.go
+++ b/server/internal/pluginhost/provider_test.go
@@ -95,6 +95,35 @@ func (p *manualOnlySDKProvider) Execute(_ context.Context, _ string, _ map[strin
 
 func (p *manualOnlySDKProvider) SupportsManualAuth() bool { return true }
 
+type opsOnlySDKProvider struct{}
+
+func (p *opsOnlySDKProvider) Name() string { return "ops-only" }
+
+func (p *opsOnlySDKProvider) DisplayName() string { return "Ops Only" }
+
+func (p *opsOnlySDKProvider) Description() string { return "ops-only provider" }
+
+func (p *opsOnlySDKProvider) ConnectionMode() sdkgestalt.ConnectionMode {
+	return sdkgestalt.ConnectionModeUser
+}
+
+func (p *opsOnlySDKProvider) ListOperations() []sdkgestalt.Operation {
+	return []sdkgestalt.Operation{
+		{
+			Name:        "echo",
+			Description: "Echo input",
+			Method:      http.MethodPost,
+			Parameters: []sdkgestalt.Parameter{
+				{Name: "message", Type: "string", Description: "message", Required: true, Default: "hello"},
+			},
+		},
+	}
+}
+
+func (p *opsOnlySDKProvider) Execute(_ context.Context, _ string, _ map[string]any, _ string) (*sdkgestalt.OperationResult, error) {
+	return &sdkgestalt.OperationResult{Status: 200, Body: `{}`}, nil
+}
+
 func TestRemoteProviderRoundTrip(t *testing.T) {
 	t.Parallel()
 
@@ -128,6 +157,9 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 	}
 	if _, ok := prov.(core.AuthTypeLister); !ok {
 		t.Fatal("expected remote provider to implement AuthTypeLister")
+	}
+	if ops := prov.ListOperations(); len(ops) != 1 || len(ops[0].Parameters) != 1 || ops[0].Parameters[0].Name != "message" {
+		t.Fatalf("unexpected ListOperations result: %+v", ops)
 	}
 
 	ctx := core.WithConnectionParams(context.Background(), map[string]string{"tenant": "acme"})
@@ -206,13 +238,12 @@ func TestRemoteProviderIconSVG(t *testing.T) {
 	t.Run("ops included in catalog when no static catalog", func(t *testing.T) {
 		t.Parallel()
 
-		client := newProviderPluginClient(t, NewProviderServer(&roundTripProvider{}))
+		client := newProviderPluginClient(t, sdkgestalt.NewProviderServer(&opsOnlySDKProvider{}))
 		prov, err := NewRemoteProvider(context.Background(), client, "roundtrip", nil)
 		if err != nil {
 			t.Fatalf("NewRemoteProvider: %v", err)
 		}
-		base := prov.(*remoteProviderWithSessionCatalog).remoteProviderBase
-		base.catalog = nil
+		base := prov.(*remoteProviderBase)
 		base.SetIconSVG(testSVG)
 
 		cp := prov.(core.CatalogProvider)
@@ -228,6 +259,12 @@ func TestRemoteProviderIconSVG(t *testing.T) {
 		}
 		if cat.Operations[0].ID != "echo" {
 			t.Fatalf("Operations[0].ID = %q, want echo", cat.Operations[0].ID)
+		}
+		if cat.Operations[0].Transport != catalog.TransportPlugin {
+			t.Fatalf("Transport = %q, want %q", cat.Operations[0].Transport, catalog.TransportPlugin)
+		}
+		if len(cat.Operations[0].Parameters) != 1 || cat.Operations[0].Parameters[0].Name != "message" {
+			t.Fatalf("unexpected synthesized parameters: %+v", cat.Operations[0].Parameters)
 		}
 	})
 

--- a/server/internal/provider/build.go
+++ b/server/internal/provider/build.go
@@ -67,11 +67,6 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 	cat.BaseURL = baseURL
 	coreintegration.CompileSchemas(cat)
 
-	endpoints, err := coreintegration.EndpointsMap(cat)
-	if err != nil {
-		return nil, fmt.Errorf("%s: %w", def.Provider, err)
-	}
-
 	base := &coreintegration.Base{
 		IntegrationName:    def.Provider,
 		IntegrationDisplay: def.DisplayName,
@@ -79,9 +74,6 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 		Auth:               auth,
 		BaseURL:            baseURL,
 		HTTPClient:         client,
-		Operations:         coreintegration.OperationsList(cat),
-		Endpoints:          endpoints,
-		Queries:            coreintegration.QueriesMap(cat),
 		Headers:            def.Headers,
 		Pagination:         buildPaginationConfigs(def),
 		EgressResolver:     bo.egress,

--- a/server/internal/server/catalog_resolution.go
+++ b/server/internal/server/catalog_resolution.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -59,20 +60,9 @@ func resolveCatalog(ctx context.Context, prov core.Provider, provName string, re
 	}
 
 	if merged == nil {
-		merged = synthesizeCatalog(prov, provName)
-	} else if len(merged.Operations) == 0 {
-		merged.Operations = integration.CoreOperationsToCatalogOps(prov.ListOperations())
+		return nil, fmt.Errorf("provider %q does not expose a catalog", provName)
 	}
 
 	integration.CompileSchemas(merged)
 	return merged, nil
-}
-
-func synthesizeCatalog(prov core.Provider, provName string) *catalog.Catalog {
-	return &catalog.Catalog{
-		Name:        provName,
-		DisplayName: prov.DisplayName(),
-		Description: prov.Description(),
-		Operations:  integration.CoreOperationsToCatalogOps(prov.ListOperations()),
-	}
 }

--- a/server/internal/server/catalog_resolution_test.go
+++ b/server/internal/server/catalog_resolution_test.go
@@ -112,7 +112,7 @@ func TestResolveCatalog_StaticCatalog(t *testing.T) {
 	}
 }
 
-func TestResolveCatalog_FlatProvider(t *testing.T) {
+func TestResolveCatalog_FlatProviderErrors(t *testing.T) {
 	t.Parallel()
 
 	prov := &stubProvider{
@@ -139,33 +139,11 @@ func TestResolveCatalog_FlatProvider(t *testing.T) {
 	}
 
 	cat, err := resolveCatalog(context.Background(), prov, "gadget-svc", nil, nil, "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err == nil {
+		t.Fatalf("expected error for provider without catalog, got catalog %+v", cat)
 	}
-	if len(cat.Operations) != 2 {
-		t.Fatalf("expected 2 operations, got %d", len(cat.Operations))
-	}
-
-	create := cat.Operations[0]
-	if create.ID != "create_gadget" {
-		t.Fatalf("expected id %q, got %q", "create_gadget", create.ID)
-	}
-	if create.Method != http.MethodPost {
-		t.Fatalf("expected method POST, got %q", create.Method)
-	}
-	if create.Transport != catalog.TransportREST {
-		t.Fatalf("expected transport %q, got %q", catalog.TransportREST, create.Transport)
-	}
-	if create.InputSchema == nil {
-		t.Fatal("expected inputSchema for operation with parameters")
-	}
-
-	get := cat.Operations[1]
-	if get.ID != "get_gadget" {
-		t.Fatalf("expected id %q, got %q", "get_gadget", get.ID)
-	}
-	if get.Annotations.ReadOnlyHint == nil || !*get.Annotations.ReadOnlyHint {
-		t.Fatal("expected readOnlyHint=true for GET method")
+	if got, want := err.Error(), `provider "gadget-svc" does not expose a catalog`; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
 	}
 }
 
@@ -333,7 +311,7 @@ func TestResolveCatalog_NilResolver(t *testing.T) {
 	}
 }
 
-func TestResolveCatalog_IconOnlyCatalogStillHasOperations(t *testing.T) {
+func TestResolveCatalog_IconOnlyCatalogPreserved(t *testing.T) {
 	t.Parallel()
 
 	prov := &stubCatalogProvider{
@@ -366,21 +344,8 @@ func TestResolveCatalog_IconOnlyCatalogStillHasOperations(t *testing.T) {
 	if cat.IconSVG != `<svg/>` {
 		t.Fatalf("IconSVG = %q, want %q", cat.IconSVG, `<svg/>`)
 	}
-	if len(cat.Operations) != 1 {
-		t.Fatalf("got %d operations, want 1", len(cat.Operations))
-	}
-	op := cat.Operations[0]
-	if op.ID != "do_thing" {
-		t.Fatalf("Operations[0].ID = %q, want do_thing", op.ID)
-	}
-	if op.Method != http.MethodPost {
-		t.Fatalf("Operations[0].Method = %q, want POST", op.Method)
-	}
-	if op.Description != "Does a thing" {
-		t.Fatalf("Operations[0].Description = %q, want %q", op.Description, "Does a thing")
-	}
-	if len(op.Parameters) != 1 || op.Parameters[0].Name != "input" {
-		t.Fatalf("Operations[0].Parameters = %+v, want [{Name:input}]", op.Parameters)
+	if len(cat.Operations) != 0 {
+		t.Fatalf("got %d operations, want 0", len(cat.Operations))
 	}
 }
 

--- a/server/internal/server/server_test.go
+++ b/server/internal/server/server_test.go
@@ -923,10 +923,15 @@ func TestDisconnectIntegration_NotConnected(t *testing.T) {
 func TestListOperations(t *testing.T) {
 	t.Parallel()
 
-	stub := &stubIntegrationWithOps{
-		StubIntegration: coretesting.StubIntegration{N: "test-int"},
-		ops: []core.Operation{
-			{Name: "do_thing", Description: "Do a thing", Method: http.MethodGet},
+	stub := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "test-int"},
+		},
+		catalog: &catalog.Catalog{
+			Name: "test-int",
+			Operations: []catalog.CatalogOperation{
+				{ID: "do_thing", Description: "Do a thing", Method: http.MethodGet, Path: "/do-thing"},
+			},
 		},
 	}
 	ts := newTestServer(t, func(cfg *server.Config) {


### PR DESCRIPTION
## Summary
- make `core/integration.Base` execute directly from catalog operations instead of keeping duplicate operation maps
- collapse duplicate flat operation state in declarative providers, remote plugin providers, merged providers, and MCP upstreams
- remove server-side catalog synthesis fallback so providers must expose a real catalog
- delete the now-unused `CoreOperationsToCatalogOps` conversion helper

## Why
We were still representing the same provider surface in multiple shapes at once and rebuilding one from another:
- `Base` kept catalog operations plus duplicated `Operations` / `Endpoints` / `Queries`
- pluginhost providers kept both flat `[]core.Operation` and catalog operations
- composite and MCP upstream providers kept both catalogs and flat op slices
- server catalog resolution still synthesized catalogs from flat ops

This PR makes catalog metadata the canonical source in those paths and derives `ListOperations()` from it when needed.

## Validation
```bash
go test ./internal/bootstrap ./internal/openapi ./internal/graphql ./internal/mcp ./internal/composite ./internal/mcpupstream ./internal/pluginhost ./internal/server ./core/integration ./internal/provider ./internal/provider/compiler
```