### PR TITLE
Restore plugin release recovery fixes

### DIFF
--- a/.github/workflows/release-plugin-reusable.yml
+++ b/.github/workflows/release-plugin-reusable.yml
@@ -25,6 +25,11 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: valon-technologies/gestalt
+          ref: ${{ inputs.gestaltd-version }}
+          path: .gestalt-toolchain
       - name: Normalize version
         id: version
         run: |
@@ -32,22 +37,30 @@ jobs:
           echo "release=${VERSION#v}" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26.0'
-      - name: Detect plugin type
+          go-version-file: .gestalt-toolchain/server/go.mod
+      - name: Resolve plugin metadata
         id: plugin
         run: |
-          is_main_package() {
-            local package_name
-            package_name="$(cd "$1" && go list -f '{{.Name}}' "$2" 2>/dev/null)" || return 1
-            [ "$package_name" = "main" ]
-          }
+          PLUGIN_DIR="${{ inputs.plugin-dir }}"
+          MANIFEST_PATH="${PLUGIN_DIR}/plugin.yaml"
+          if [ ! -f "$MANIFEST_PATH" ]; then
+            echo "ERROR: ${MANIFEST_PATH} not found"
+            exit 1
+          fi
 
-          if [ ! -f "${{ inputs.plugin-dir }}/go.mod" ]; then
-            echo "compiled=false" >> "$GITHUB_OUTPUT"
-          elif is_main_package "${{ inputs.plugin-dir }}" ./cmd || is_main_package "${{ inputs.plugin-dir }}" .; then
-            echo "compiled=true" >> "$GITHUB_OUTPUT"
+          SOURCE="$(sed -nE "s/^[[:space:]]*source:[[:space:]]*['\"]?([^'\"[:space:]]+)['\"]?[[:space:]]*$/\\1/p" "$MANIFEST_PATH" | head -n1)"
+          if [ -z "$SOURCE" ]; then
+            echo "ERROR: unable to parse source from ${MANIFEST_PATH}"
+            exit 1
+          fi
+
+          PLUGIN_NAME="${SOURCE##*/}"
+          echo "name=${PLUGIN_NAME}" >> "$GITHUB_OUTPUT"
+          echo "tag=plugin/${PLUGIN_NAME}/v${{ steps.version.outputs.release }}" >> "$GITHUB_OUTPUT"
+          if [ -f "${PLUGIN_DIR}/go.mod" ]; then
+            echo "has-go-mod=true" >> "$GITHUB_OUTPUT"
           else
-            echo "compiled=false" >> "$GITHUB_OUTPUT"
+            echo "has-go-mod=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Install gestaltd
         env:
@@ -57,7 +70,7 @@ jobs:
           echo "$GOBIN" >> "$GITHUB_PATH"
           go install github.com/valon-technologies/gestalt/server/cmd/gestaltd@${{ inputs.gestaltd-version }}
       - uses: actions/setup-go@v5
-        if: steps.plugin.outputs.compiled == 'true'
+        if: steps.plugin.outputs.has-go-mod == 'true'
         with:
           go-version-file: ${{ inputs.plugin-dir }}/go.mod
       - name: Release
@@ -68,5 +81,5 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "v${{ steps.version.outputs.release }}" --generate-notes \
+          gh release create "${{ steps.plugin.outputs.tag }}" --generate-notes \
             "${{ inputs.plugin-dir }}"/dist/*

--- a/server/cmd/gestaltd/plugin.go
+++ b/server/cmd/gestaltd/plugin.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -93,6 +95,8 @@ type releasePlatform struct {
 	GOARCH string
 }
 
+var errNoGoMainPackage = errors.New("no Go main package found")
+
 func runPluginRelease(args []string) error {
 	fs := flag.NewFlagSet("gestaltd plugin release", flag.ContinueOnError)
 	fs.Usage = func() { printPluginReleaseUsage(fs.Output()) }
@@ -135,18 +139,31 @@ func runPluginRelease(args []string) error {
 		return fmt.Errorf("create output dir: %w", err)
 	}
 
-	buildTarget, compiled, err := findReleaseBuildTarget(".")
+	platList, err := parseReleasePlatforms(*platforms)
 	if err != nil {
-		return fmt.Errorf("detect build target: %w", err)
+		return err
 	}
-	var archivePaths []string
 
-	if compiled {
-		platList, err := parseReleasePlatforms(*platforms)
-		if err != nil {
-			return err
+	compiled := false
+	for _, plat := range platList {
+		if _, err := detectGoBuildTarget(".", src.Plugin, plat.GOOS, plat.GOARCH); err == nil {
+			compiled = true
+			break
+		} else if !errors.Is(err, errNoGoMainPackage) {
+			return fmt.Errorf("detect build target for %s/%s: %w", plat.GOOS, plat.GOARCH, err)
 		}
+	}
+	if !compiled && releaseRequiresBuildTarget(srcManifest) {
+		return errNoGoMainPackage
+	}
+
+	var archivePaths []string
+	if compiled {
 		for _, plat := range platList {
+			buildTarget, err := detectGoBuildTarget(".", src.Plugin, plat.GOOS, plat.GOARCH)
+			if err != nil {
+				return fmt.Errorf("detect build target for %s/%s: %w", plat.GOOS, plat.GOARCH, err)
+			}
 			archivePath, err := buildPlatformArchive(srcManifest, pluginName, *version, buildTarget, plat, *outputDir)
 			if err != nil {
 				return fmt.Errorf("build %s/%s: %w", plat.GOOS, plat.GOARCH, err)
@@ -179,6 +196,7 @@ func buildPlatformArchive(srcManifest *pluginmanifestv1.Manifest, pluginName, ve
 	binaryPath := filepath.Join(stagingDir, binaryName)
 
 	cmd := exec.Command("go", "build", "-trimpath", "-ldflags", "-s -w", "-o", binaryPath, buildTarget)
+	cmd.Dir = "."
 	cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS="+plat.GOOS, "GOARCH="+plat.GOARCH)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -218,73 +236,81 @@ func buildPlatformArchive(srcManifest *pluginmanifestv1.Manifest, pluginName, ve
 	return archivePath, nil
 }
 
-func findReleaseBuildTarget(root string) (string, bool, error) {
-	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
-		if os.IsNotExist(err) {
-			return "", false, nil
-		}
-		return "", false, err
+func detectGoBuildTarget(root, pluginName, goos, goarch string) (string, error) {
+	targets := make([]string, 0, 3)
+	if pluginName != "" {
+		targets = append(targets, releaseCmdBuildTarget+"/"+pluginName)
 	}
+	targets = append(targets, releaseCmdBuildTarget, releaseRootBuildTarget)
 
-	cmdDirHasGoFiles, err := dirHasGoFiles(filepath.Join(root, "cmd"))
-	if err != nil {
-		return "", false, err
-	}
-	if cmdDirHasGoFiles {
-		isMain, err := isMainPackage(root, releaseCmdBuildTarget)
+	var fatalErr error
+	for _, target := range targets {
+		name, err := goPackageName(root, target, goos, goarch)
 		if err != nil {
-			return "", false, err
-		}
-		if isMain {
-			return releaseCmdBuildTarget, true, nil
-		}
-	}
-
-	rootHasGoFiles, err := dirHasGoFiles(root)
-	if err != nil {
-		return "", false, err
-	}
-	if rootHasGoFiles {
-		isMain, err := isMainPackage(root, releaseRootBuildTarget)
-		if err != nil {
-			return "", false, err
-		}
-		if isMain {
-			return releaseRootBuildTarget, true, nil
-		}
-	}
-
-	return "", false, nil
-}
-
-func dirHasGoFiles(dir string) (bool, error) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, err
-	}
-
-	for _, entry := range entries {
-		if entry.IsDir() {
+			if isMissingGoPackageError(err) {
+				continue
+			}
+			if fatalErr == nil {
+				fatalErr = fmt.Errorf("%s: %w", target, err)
+			}
 			continue
 		}
-		if strings.HasSuffix(entry.Name(), ".go") && !strings.HasSuffix(entry.Name(), "_test.go") {
-			return true, nil
+		if name == "main" {
+			return target, nil
 		}
 	}
-	return false, nil
+
+	if fatalErr != nil {
+		return "", fatalErr
+	}
+	return "", errNoGoMainPackage
 }
 
-func isMainPackage(root, buildTarget string) (bool, error) {
+func goPackageName(root, buildTarget, goos, goarch string) (string, error) {
 	cmd := exec.Command("go", "list", "-f", "{{.Name}}", buildTarget)
 	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "GOOS="+goos, "GOARCH="+goarch)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
-		return false, err
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", errors.New(msg)
 	}
-	return strings.TrimSpace(string(out)) == "main", nil
+	return strings.TrimSpace(string(out)), nil
+}
+
+func isMissingGoPackageError(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "directory not found") ||
+		strings.Contains(msg, "no such file or directory") ||
+		strings.Contains(msg, "go.mod file not found") ||
+		strings.Contains(msg, "cannot find main module") ||
+		strings.Contains(msg, "does not contain main module or its selected dependencies") ||
+		strings.Contains(msg, "no Go files") ||
+		strings.Contains(msg, "build constraints exclude all Go files") ||
+		strings.Contains(msg, "matched no packages")
+}
+
+func releaseRequiresBuildTarget(manifest *pluginmanifestv1.Manifest) bool {
+	if manifest == nil {
+		return false
+	}
+	for _, kind := range manifest.Kinds {
+		switch kind {
+		case pluginmanifestv1.KindRuntime:
+			return true
+		case pluginmanifestv1.KindProvider:
+			if manifest.Provider == nil || !manifest.Provider.IsDeclarative() {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func parseReleasePlatforms(value string) ([]releasePlatform, error) {

--- a/server/cmd/gestaltd/plugin_test.go
+++ b/server/cmd/gestaltd/plugin_test.go
@@ -417,6 +417,38 @@ func TestRun_PluginReleaseTreatsGoModWithoutCmdAsDeclarative(t *testing.T) {
 	}
 }
 
+func TestRun_PluginReleaseTreatsDeclarativePluginWithHelperMainAsSource(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newDeclarativeProviderReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.4-helper.1"
+
+	writeTestFile(t, pluginDir, "go.mod", []byte("module example.com/declarative-provider\n\ngo 1.22\n"), 0644)
+	writeTestFile(t, pluginDir, "cmd/helper/main.go", []byte("package main\n\nfunc main() {}\n"), 0644)
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-declarative-provider_v" + testVersion + ".tar.gz"
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+
+	if len(manifest.Artifacts) != 0 {
+		t.Fatalf("expected declarative release to omit artifacts, got %+v", manifest.Artifacts)
+	}
+	if manifest.Entrypoints.Provider != nil {
+		t.Fatalf("expected declarative release to omit provider entrypoint, got %+v", manifest.Entrypoints.Provider)
+	}
+
+	compiledArchiveName := "gestalt-plugin-declarative-provider_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	if _, err := os.Stat(filepath.Join(outputDir, compiledArchiveName)); !os.IsNotExist(err) {
+		t.Fatalf("unexpected compiled archive %s: %v", compiledArchiveName, err)
+	}
+}
+
 func TestRun_PluginReleaseChecksumsOnlyCurrentArchives(t *testing.T) {
 	t.Parallel()
 
@@ -584,6 +616,83 @@ func TestRun_PluginReleasePackagesRootMainBuildTarget(t *testing.T) {
 	}
 }
 
+func TestRun_PluginReleasePrefersCmdBuildTargetOverRootMain(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newNestedCmdReleaseFixture(t, t.TempDir())
+	writeTestFile(t, pluginDir, "main.go", []byte("package main\n\nfunc main() { missingSymbol() }\n"), 0644)
+
+	outputDir := t.TempDir()
+	const testVersion = "0.0.7-rc.1"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-" + releaseTestPluginName + "_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != releaseBinaryName(releaseTestPluginName, runtime.GOOS) {
+		t.Fatalf("artifacts = %+v", manifest.Artifacts)
+	}
+}
+
+func TestRun_PluginReleaseBuildsNestedCmdMainPackage(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newNestedCmdReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.7-alpha.1"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-" + releaseTestPluginName + "_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != releaseBinaryName(releaseTestPluginName, runtime.GOOS) {
+		t.Fatalf("artifacts = %+v", manifest.Artifacts)
+	}
+}
+
+func TestRun_PluginReleaseDetectsPlatformTaggedMainPackage(t *testing.T) {
+	t.Parallel()
+
+	targetOS := "linux"
+	switch runtime.GOOS {
+	case "linux":
+		targetOS = "darwin"
+	case "darwin":
+		targetOS = "linux"
+	default:
+		t.Skipf("platform-tagged release test expects darwin or linux host, got %s", runtime.GOOS)
+	}
+
+	pluginDir := newRootMainReleaseFixture(t, t.TempDir())
+	writeTestFile(t, pluginDir, "main.go", []byte("//go:build "+targetOS+"\n\npackage main\n\nfunc main() {}\n"), 0644)
+
+	outputDir := t.TempDir()
+	const testVersion = "0.0.7-beta.1"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", targetOS+"/amd64",
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-" + releaseTestPluginName + "_v" + testVersion + "_" + targetOS + "_amd64.tar.gz"
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].OS != targetOS || manifest.Artifacts[0].Arch != "amd64" {
+		t.Fatalf("artifacts = %+v", manifest.Artifacts)
+	}
+}
+
 func TestRun_PluginReleaseRejectsStaleSourceArtifactDigest(t *testing.T) {
 	t.Parallel()
 
@@ -635,6 +744,32 @@ func TestRun_PluginReleaseWindowsArtifactUsesExe(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(extractDir, binaryName)); err != nil {
 		t.Fatalf("expected %s in archive: %v", binaryName, err)
+	}
+}
+
+func TestRun_PluginReleaseCopiesDeclarativeProviderSupportFiles(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newDeclarativeProviderReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.10-test"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-declarative-provider_v" + testVersion + ".tar.gz"
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+
+	if len(manifest.Artifacts) != 0 {
+		t.Fatalf("expected declarative release to omit artifacts, got %+v", manifest.Artifacts)
+	}
+	for _, rel := range []string{releaseTestIconPath, releaseProviderSchemaPath} {
+		if _, err := os.Stat(filepath.Join(extractDir, filepath.FromSlash(rel))); err != nil {
+			t.Fatalf("expected %s in archive: %v", rel, err)
+		}
 	}
 }
 
@@ -728,6 +863,32 @@ func newCompiledReleaseFixture(t *testing.T, dir string) string {
 	return pluginDir
 }
 
+func newDeclarativeProviderReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(dir, "declarative-provider")
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatalf("MkdirAll(pluginDir): %v", err)
+	}
+	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
+		Source:      "github.com/testowner/plugins/declarative-provider",
+		Version:     "0.0.1",
+		DisplayName: "Declarative Provider",
+		IconFile:    releaseTestIconPath,
+		Kinds:       []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			BaseURL:          releaseHybridBaseURL,
+			ConfigSchemaPath: releaseProviderSchemaPath,
+			Operations: []pluginmanifestv1.ProviderOperation{
+				{Name: releaseHybridOperationName, Method: "GET", Path: "/items"},
+			},
+		},
+	})
+	writeTestFile(t, pluginDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0644)
+	writeTestFile(t, pluginDir, releaseProviderSchemaPath, []byte(`{"type":"object"}`), 0644)
+	return pluginDir
+}
+
 func newRootMainReleaseFixture(t *testing.T, dir string) string {
 	t.Helper()
 
@@ -736,6 +897,17 @@ func newRootMainReleaseFixture(t *testing.T, dir string) string {
 		t.Fatalf("RemoveAll(cmd): %v", err)
 	}
 	writeTestFile(t, pluginDir, "main.go", []byte("package main\n\nfunc main() {}\n"), 0644)
+	return pluginDir
+}
+
+func newNestedCmdReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := newCompiledReleaseFixture(t, dir)
+	if err := os.Remove(filepath.Join(pluginDir, "cmd", "main.go")); err != nil {
+		t.Fatalf("Remove(cmd/main.go): %v", err)
+	}
+	writeTestFile(t, pluginDir, filepath.ToSlash(filepath.Join("cmd", releaseTestPluginName, "main.go")), []byte("package main\n\nfunc main() {}\n"), 0644)
 	return pluginDir
 }
 

--- a/server/cmd/gestaltd/run.go
+++ b/server/cmd/gestaltd/run.go
@@ -267,6 +267,9 @@ func buildMCPSurface(cfg *config.Config, connMaps bootstrap.ConnectionMaps) mcpS
 }
 
 func pluginDeclaresMCP(plugin *config.PluginDef) bool {
+	if plugin == nil {
+		return false
+	}
 	if plugin.MCP || plugin.MCPURL != "" || plugin.OpenAPI != "" || plugin.GraphQLURL != "" || len(plugin.Operations) > 0 {
 		return true
 	}
@@ -278,7 +281,7 @@ func pluginDeclaresMCP(plugin *config.PluginDef) bool {
 		slog.Warn("reading plugin manifest", "path", plugin.ResolvedManifestPath, "error", err)
 		return true
 	}
-	return manifest.Provider != nil && manifest.Provider.MCP
+	return manifest.Provider != nil && (manifest.Provider.MCP || manifest.Provider.IsSpecLoaded() || len(manifest.Provider.Operations) > 0)
 }
 
 func (s mcpSurface) handler(result *bootstrap.Result) (http.Handler, error) {

--- a/server/cmd/gestaltd/run_test.go
+++ b/server/cmd/gestaltd/run_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+)
+
+func TestBuildMCPSurfaceIncludesManifestDeclaredProviders(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		manifest *pluginmanifestv1.Manifest
+	}{
+		{
+			name: "manifest catalog",
+			manifest: &pluginmanifestv1.Manifest{
+				Source:      "github.com/testowner/plugins/example",
+				Version:     "0.0.1",
+				DisplayName: "Example",
+				Kinds:       []string{pluginmanifestv1.KindProvider},
+				Provider: &pluginmanifestv1.Provider{
+					BaseURL: "https://example.com",
+					Operations: []pluginmanifestv1.ProviderOperation{
+						{Name: "search", Method: "GET", Path: "/search"},
+					},
+				},
+			},
+		},
+		{
+			name: "manifest spec surface",
+			manifest: &pluginmanifestv1.Manifest{
+				Source:      "github.com/testowner/plugins/example",
+				Version:     "0.0.1",
+				DisplayName: "Example",
+				Kinds:       []string{pluginmanifestv1.KindProvider},
+				Provider: &pluginmanifestv1.Provider{
+					OpenAPI: "https://example.com/openapi.json",
+				},
+				Artifacts: []pluginmanifestv1.Artifact{
+					{
+						OS:     "darwin",
+						Arch:   "arm64",
+						Path:   "artifacts/darwin/arm64/provider",
+						SHA256: sha256HexForTest("provider"),
+					},
+				},
+				Entrypoints: pluginmanifestv1.Entrypoints{
+					Provider: &pluginmanifestv1.Entrypoint{ArtifactPath: "artifacts/darwin/arm64/provider"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pluginDir := t.TempDir()
+			writeReleaseTestManifest(t, pluginDir, tc.manifest)
+
+			cfg := &config.Config{
+				Integrations: map[string]config.IntegrationDef{
+					"example": {
+						Plugin: &config.PluginDef{
+							Source:               "github.com/testowner/plugins/example",
+							ResolvedManifestPath: pluginDir + "/plugin.json",
+						},
+					},
+				},
+			}
+
+			surface := buildMCPSurface(cfg, bootstrap.BuildConnectionMaps(cfg))
+			if len(surface.providers) != 1 || surface.providers[0] != "example" {
+				t.Fatalf("providers = %v", surface.providers)
+			}
+			if got := surface.toolPrefixes["example"]; got != "example_" {
+				t.Fatalf("tool prefix = %q, want %q", got, "example_")
+			}
+			if got := surface.apiConnection["example"]; got != config.PluginConnectionName {
+				t.Fatalf("api connection = %q, want %q", got, config.PluginConnectionName)
+			}
+			if got := surface.mcpConnection["example"]; got != config.PluginConnectionName {
+				t.Fatalf("mcp connection = %q, want %q", got, config.PluginConnectionName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- restore `plugin release` build-target detection for declarative plugins with `go.mod`, nested `cmd/<plugin>` layouts, and platform-tagged mains
- expose manifest-declared catalog/spec providers in MCP surface discovery
- fix the reusable plugin release workflow to derive the managed release tag from `plugin.yaml` and use the Gestalt ref's `server/go.mod` for the bootstrap Go toolchain

## Test plan

- [x] `TMPDIR=/Users/hugh/src/gestalt/.tmp GOTMPDIR=/Users/hugh/src/gestalt/.tmp go test ./cmd/gestaltd`
- [x] `TMPDIR=/Users/hugh/src/gestalt/.tmp GOTMPDIR=/Users/hugh/src/gestalt/.tmp go test ./...`
- [x] `TMPDIR=/Users/hugh/src/gestalt/.tmp GOTMPDIR=/Users/hugh/src/gestalt/.tmp go test -race -coverprofile=coverage.out -covermode=atomic ./...`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-plugin-reusable.yml")'`