### PR TITLE
Delete server-side flat operation fallbacks

### DIFF
--- a/server/core/integration/restricted.go
+++ b/server/core/integration/restricted.go
@@ -104,20 +104,7 @@ func (r *Restricted) SetIconSVG(s string) {
 }
 
 func (r *Restricted) ListOperations() []core.Operation {
-	all := r.inner.ListOperations()
-	filtered := make([]core.Operation, 0, len(r.allowed))
-	for _, op := range all {
-		if _, ok := r.allowedInner[op.Name]; ok {
-			if exposed, ok := r.reverseAlias[op.Name]; ok {
-				op.Name = exposed
-			}
-			if desc, ok := r.descriptions[op.Name]; ok {
-				op.Description = desc
-			}
-			filtered = append(filtered, op)
-		}
-	}
-	return filtered
+	return OperationsList(r.Catalog())
 }
 
 func (r *Restricted) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {

--- a/server/core/integration/restricted_test.go
+++ b/server/core/integration/restricted_test.go
@@ -20,12 +20,33 @@ func (s *stubWithOps) ListOperations() []core.Operation {
 	return s.ops
 }
 
+func (s *stubWithOps) Catalog() *catalog.Catalog {
+	return restrictedTestCatalog(s.StubIntegration.N, s.ops)
+}
+
 func sampleOps() []core.Operation {
 	return []core.Operation{
 		{Name: "list_channels", Description: "List channels"},
 		{Name: "send_message", Description: "Send a message"},
 		{Name: "delete_message", Description: "Delete a message"},
 	}
+}
+
+func restrictedTestCatalog(name string, ops []core.Operation) *catalog.Catalog {
+	cat := &catalog.Catalog{
+		Name:       name,
+		Operations: make([]catalog.CatalogOperation, 0, len(ops)),
+	}
+	for _, op := range ops {
+		cat.Operations = append(cat.Operations, catalog.CatalogOperation{
+			ID:          op.Name,
+			Method:      op.Method,
+			Path:        "/" + op.Name,
+			Description: op.Description,
+		})
+	}
+	coreintegration.CompileSchemas(cat)
+	return cat
 }
 
 func TestListOperationsFilters(t *testing.T) {

--- a/server/internal/invocation/broker.go
+++ b/server/internal/invocation/broker.go
@@ -164,15 +164,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		return fail(fmt.Errorf("%w: %s", ErrScopeDenied, providerName))
 	}
 
-	ops := prov.ListOperations()
-	found := false
-	for _, op := range ops {
-		if op.Name == operation {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !catalogHasOperation(providerCatalog(prov), operation) {
 		return fail(fmt.Errorf("%w: %q on provider %q", ErrOperationNotFound, operation, providerName))
 	}
 

--- a/server/internal/invocation/capabilities.go
+++ b/server/internal/invocation/capabilities.go
@@ -9,12 +9,10 @@ import (
 )
 
 func capabilitiesForProvider(name string, prov core.Provider) []core.Capability {
-	if cp, ok := prov.(core.CatalogProvider); ok {
-		if cat := cp.Catalog(); cat != nil {
-			return capabilitiesFromCatalog(name, cat)
-		}
+	if cat := providerCatalog(prov); cat != nil {
+		return capabilitiesFromCatalog(name, cat)
 	}
-	return capabilitiesFromOperations(name, prov.ListOperations())
+	return nil
 }
 
 func capabilitiesFromCatalog(name string, cat *catalog.Catalog) []core.Capability {
@@ -62,27 +60,22 @@ func capabilitiesFromCatalog(name string, cat *catalog.Catalog) []core.Capabilit
 	return caps
 }
 
-func capabilitiesFromOperations(name string, ops []core.Operation) []core.Capability {
-	caps := make([]core.Capability, 0, len(ops))
-	for _, op := range ops {
-		if strings.TrimSpace(op.Name) == "" {
-			continue
-		}
-
-		method := strings.ToUpper(strings.TrimSpace(op.Method))
-		transport := ""
-		if method != "" {
-			transport = catalog.TransportREST
-		}
-
-		caps = append(caps, core.Capability{
-			Provider:    name,
-			Operation:   op.Name,
-			Description: op.Description,
-			Parameters:  op.Parameters,
-			Method:      method,
-			Transport:   transport,
-		})
+func providerCatalog(prov core.Provider) *catalog.Catalog {
+	cp, ok := prov.(core.CatalogProvider)
+	if !ok {
+		return nil
 	}
-	return caps
+	return cp.Catalog()
+}
+
+func catalogHasOperation(cat *catalog.Catalog, operation string) bool {
+	if cat == nil || strings.TrimSpace(operation) == "" {
+		return false
+	}
+	for i := range cat.Operations {
+		if cat.Operations[i].ID == operation {
+			return true
+		}
+	}
+	return false
 }

--- a/server/internal/invocation/guarded_test.go
+++ b/server/internal/invocation/guarded_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coreintegration "github.com/valon-technologies/gestalt/server/core/integration"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
@@ -20,6 +22,34 @@ type stubProviderWithOps struct {
 
 func (s *stubProviderWithOps) ListOperations() []core.Operation {
 	return s.ops
+}
+
+func (s *stubProviderWithOps) Catalog() *catalog.Catalog {
+	cat := &catalog.Catalog{
+		Name:       s.StubIntegration.N,
+		Operations: make([]catalog.CatalogOperation, 0, len(s.ops)),
+	}
+	for _, op := range s.ops {
+		params := make([]catalog.CatalogParameter, 0, len(op.Parameters))
+		for _, param := range op.Parameters {
+			params = append(params, catalog.CatalogParameter{
+				Name:        param.Name,
+				Type:        param.Type,
+				Description: param.Description,
+				Required:    param.Required,
+				Default:     param.Default,
+			})
+		}
+		cat.Operations = append(cat.Operations, catalog.CatalogOperation{
+			ID:          op.Name,
+			Method:      op.Method,
+			Path:        "/" + op.Name,
+			Description: op.Description,
+			Parameters:  params,
+		})
+	}
+	coreintegration.CompileSchemas(cat)
+	return cat
 }
 
 type capturingSink struct {

--- a/server/internal/mcp/binding.go
+++ b/server/internal/mcp/binding.go
@@ -71,11 +71,8 @@ func NewServer(cfg Config) *mcpserver.MCPServer {
 		if cp, ok := prov.(core.CatalogProvider); ok {
 			if cat := cp.Catalog(); cat != nil {
 				addCatalogTools(srv, cfg, provName, cat, prov)
-				continue
 			}
 		}
-
-		addFlatTools(srv, cfg, provName, prov)
 	}
 
 	if len(dynamicProviders) > 0 {

--- a/server/internal/mcp/binding_test.go
+++ b/server/internal/mcp/binding_test.go
@@ -37,8 +37,13 @@ type catalogProvider struct {
 	catalog *catalog.Catalog
 }
 
-func (p *catalogProvider) ListOperations() []core.Operation { return p.ops }
-func (p *catalogProvider) Catalog() *catalog.Catalog        { return p.catalog }
+func (p *catalogProvider) ListOperations() []core.Operation {
+	if p.ops != nil {
+		return p.ops
+	}
+	return coreintegration.OperationsList(p.catalog)
+}
+func (p *catalogProvider) Catalog() *catalog.Catalog { return p.catalog }
 
 type flatProvider struct {
 	coretesting.StubIntegration
@@ -46,6 +51,43 @@ type flatProvider struct {
 }
 
 func (p *flatProvider) ListOperations() []core.Operation { return p.ops }
+
+func testCatalogFromOperations(name string, ops []core.Operation) *catalog.Catalog {
+	cat := &catalog.Catalog{
+		Name:       name,
+		Operations: make([]catalog.CatalogOperation, 0, len(ops)),
+	}
+	for _, op := range ops {
+		params := make([]catalog.CatalogParameter, 0, len(op.Parameters))
+		for _, param := range op.Parameters {
+			params = append(params, catalog.CatalogParameter{
+				Name:        param.Name,
+				Type:        param.Type,
+				Description: param.Description,
+				Required:    param.Required,
+				Default:     param.Default,
+			})
+		}
+		cat.Operations = append(cat.Operations, catalog.CatalogOperation{
+			ID:          op.Name,
+			Method:      op.Method,
+			Path:        "/" + op.Name,
+			Title:       op.Name,
+			Description: op.Description,
+			Parameters:  params,
+			Transport:   catalog.TransportREST,
+		})
+	}
+	coreintegration.CompileSchemas(cat)
+	return cat
+}
+
+func newCatalogBackedProvider(stub coretesting.StubIntegration, ops []core.Operation) *catalogProvider {
+	return &catalogProvider{
+		StubIntegration: stub,
+		catalog:         testCatalogFromOperations(stub.N, ops),
+	}
+}
 
 func stubDatastoreWithToken() *coretesting.StubDatastore {
 	return &coretesting.StubDatastore{
@@ -255,7 +297,7 @@ func TestNewServer_ListsToolsFromCatalogProvider(t *testing.T) {
 	}
 }
 
-func TestNewServer_ListsToolsFromFlatProvider(t *testing.T) {
+func TestNewServer_SkipsFlatOnlyProvider(t *testing.T) {
 	t.Parallel()
 
 	prov := &flatProvider{
@@ -278,34 +320,18 @@ func TestNewServer_ListsToolsFromFlatProvider(t *testing.T) {
 	})
 
 	tools := srv.ListTools()
-	if len(tools) != 2 {
-		t.Fatalf("expected 2 tools, got %d", len(tools))
-	}
-
-	listTool := tools["github_list_repos"]
-	if listTool == nil {
-		t.Fatal("expected github_list_repos tool")
-	}
-	if listTool.Tool.Annotations.ReadOnlyHint == nil || !*listTool.Tool.Annotations.ReadOnlyHint {
-		t.Fatal("expected ReadOnlyHint for GET method")
-	}
-
-	deleteTool := tools["github_delete_repo"]
-	if deleteTool == nil {
-		t.Fatal("expected github_delete_repo tool")
-	}
-	if deleteTool.Tool.Annotations.DestructiveHint == nil || !*deleteTool.Tool.Annotations.DestructiveHint {
-		t.Fatal("expected DestructiveHint for DELETE method")
+	if len(tools) != 0 {
+		t.Fatalf("expected 0 tools for flat-only provider, got %d", len(tools))
 	}
 }
 
 func TestNewServer_ToolNameConvention(t *testing.T) {
 	t.Parallel()
 
-	prov := &flatProvider{
-		StubIntegration: coretesting.StubIntegration{N: "slack"},
-		ops:             []core.Operation{{Name: "send_message", Method: http.MethodPost}},
-	}
+	prov := newCatalogBackedProvider(
+		coretesting.StubIntegration{N: "slack"},
+		[]core.Operation{{Name: "send_message", Method: http.MethodPost}},
+	)
 
 	providers := testutil.NewProviderRegistry(t, prov)
 	ds := stubDatastoreWithToken()
@@ -333,8 +359,8 @@ func TestNewServer_ToolCallRoutesThrough(t *testing.T) {
 	var invokedOp string
 	var invokedParams map[string]any
 
-	prov := &flatProvider{
-		StubIntegration: coretesting.StubIntegration{
+	prov := newCatalogBackedProvider(
+		coretesting.StubIntegration{
 			N: "test",
 			ExecuteFn: func(_ context.Context, op string, params map[string]any, _ string) (*core.OperationResult, error) {
 				invokedOp = op
@@ -345,8 +371,8 @@ func TestNewServer_ToolCallRoutesThrough(t *testing.T) {
 				}, nil
 			},
 		},
-		ops: []core.Operation{{Name: "do_thing", Method: http.MethodPost}},
-	}
+		[]core.Operation{{Name: "do_thing", Method: http.MethodPost}},
+	)
 
 	providers := testutil.NewProviderRegistry(t, prov)
 	ds := stubDatastoreWithToken()
@@ -390,10 +416,10 @@ func TestNewServer_ToolCallUsesInjectedInvoker(t *testing.T) {
 	var gotOperation string
 	var gotParams map[string]any
 
-	prov := &flatProvider{
-		StubIntegration: coretesting.StubIntegration{N: "test"},
-		ops:             []core.Operation{{Name: "op", Method: http.MethodGet}},
-	}
+	prov := newCatalogBackedProvider(
+		coretesting.StubIntegration{N: "test"},
+		[]core.Operation{{Name: "op", Method: http.MethodGet}},
+	)
 
 	providers := testutil.NewProviderRegistry(t, prov)
 	srv := gestaltmcp.NewServer(gestaltmcp.Config{
@@ -446,8 +472,8 @@ func TestNewServer_ToolCallUsesInjectedInvoker(t *testing.T) {
 func TestNewServer_ErrorResultSetsIsError(t *testing.T) {
 	t.Parallel()
 
-	prov := &flatProvider{
-		StubIntegration: coretesting.StubIntegration{
+	prov := newCatalogBackedProvider(
+		coretesting.StubIntegration{
 			N: "test",
 			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
 				return &core.OperationResult{
@@ -456,8 +482,8 @@ func TestNewServer_ErrorResultSetsIsError(t *testing.T) {
 				}, nil
 			},
 		},
-		ops: []core.Operation{{Name: "forbidden_op", Method: http.MethodGet}},
-	}
+		[]core.Operation{{Name: "forbidden_op", Method: http.MethodGet}},
+	)
 
 	providers := testutil.NewProviderRegistry(t, prov)
 	ds := stubDatastoreWithToken()
@@ -485,15 +511,15 @@ func TestNewServer_ErrorResultSetsIsError(t *testing.T) {
 func TestNewServer_BrokerErrorReturnsToolError(t *testing.T) {
 	t.Parallel()
 
-	prov := &flatProvider{
-		StubIntegration: coretesting.StubIntegration{
+	prov := newCatalogBackedProvider(
+		coretesting.StubIntegration{
 			N: "test",
 			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
 				return nil, fmt.Errorf("connection timeout")
 			},
 		},
-		ops: []core.Operation{{Name: "flaky_op", Method: http.MethodGet}},
-	}
+		[]core.Operation{{Name: "flaky_op", Method: http.MethodGet}},
+	)
 
 	providers := testutil.NewProviderRegistry(t, prov)
 	ds := stubDatastoreWithToken()
@@ -521,10 +547,10 @@ func TestNewServer_BrokerErrorReturnsToolError(t *testing.T) {
 func TestNewServer_NoPrincipalReturnsToolError(t *testing.T) {
 	t.Parallel()
 
-	prov := &flatProvider{
-		StubIntegration: coretesting.StubIntegration{N: "test"},
-		ops:             []core.Operation{{Name: "op", Method: http.MethodGet}},
-	}
+	prov := newCatalogBackedProvider(
+		coretesting.StubIntegration{N: "test"},
+		[]core.Operation{{Name: "op", Method: http.MethodGet}},
+	)
 
 	providers := testutil.NewProviderRegistry(t, prov)
 	ds := stubDatastoreWithToken()
@@ -551,14 +577,14 @@ func TestNewServer_NoPrincipalReturnsToolError(t *testing.T) {
 func TestNewServer_AllowedProvidersFilter(t *testing.T) {
 	t.Parallel()
 
-	prov1 := &flatProvider{
-		StubIntegration: coretesting.StubIntegration{N: "allowed"},
-		ops:             []core.Operation{{Name: "op1", Method: http.MethodGet}},
-	}
-	prov2 := &flatProvider{
-		StubIntegration: coretesting.StubIntegration{N: "excluded"},
-		ops:             []core.Operation{{Name: "op2", Method: http.MethodGet}},
-	}
+	prov1 := newCatalogBackedProvider(
+		coretesting.StubIntegration{N: "allowed"},
+		[]core.Operation{{Name: "op1", Method: http.MethodGet}},
+	)
+	prov2 := newCatalogBackedProvider(
+		coretesting.StubIntegration{N: "excluded"},
+		[]core.Operation{{Name: "op2", Method: http.MethodGet}},
+	)
 
 	providers := testutil.NewProviderRegistry(t, prov1, prov2)
 	ds := stubDatastoreWithToken()
@@ -623,8 +649,13 @@ type directCallerProvider struct {
 	callFn           func(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error)
 }
 
-func (p *directCallerProvider) ListOperations() []core.Operation { return p.ops }
-func (p *directCallerProvider) Catalog() *catalog.Catalog        { return p.cat }
+func (p *directCallerProvider) ListOperations() []core.Operation {
+	if p.ops != nil {
+		return p.ops
+	}
+	return coreintegration.OperationsList(p.cat)
+}
+func (p *directCallerProvider) Catalog() *catalog.Catalog { return p.cat }
 func (p *directCallerProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
 	if p.sessionCatalogFn != nil {
 		return p.sessionCatalogFn(ctx, token)

--- a/server/internal/mcp/projection.go
+++ b/server/internal/mcp/projection.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
-	coreintegration "github.com/valon-technologies/gestalt/server/core/integration"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -15,25 +14,6 @@ func addCatalogTools(srv *mcpserver.MCPServer, cfg Config, provName string, cat 
 	m := buildToolMap(cfg, provName, prov, cat)
 	for name := range m {
 		srv.AddTool(m[name].Tool, m[name].Handler)
-	}
-}
-
-func addFlatTools(srv *mcpserver.MCPServer, cfg Config, provName string, prov core.Provider) {
-	for _, op := range prov.ListOperations() {
-		name := toolName(cfg.ToolPrefixes, provName, op.Name)
-
-		opts := []mcpgo.ToolOption{mcpgo.WithDescription(op.Description)}
-		annot := mapAnnotations(coreintegration.AnnotationsFromMethod(op.Method))
-		annot.Title = op.Name
-		opts = append(opts, mcpgo.WithToolAnnotation(annot))
-
-		for _, param := range op.Parameters {
-			opts = append(opts, paramToOption(param))
-		}
-
-		tool := mcpgo.NewTool(name, opts...)
-		handler := makeHandler(cfg.Invoker, provName, op.Name, "")
-		srv.AddTool(tool, handler)
 	}
 }
 
@@ -129,28 +109,5 @@ func mapAnnotations(a catalog.OperationAnnotations) mcpgo.ToolAnnotation {
 		DestructiveHint: a.DestructiveHint,
 		IdempotentHint:  a.IdempotentHint,
 		OpenWorldHint:   a.OpenWorldHint,
-	}
-}
-
-func buildPropertyOpts(param core.Parameter) []mcpgo.PropertyOption {
-	opts := []mcpgo.PropertyOption{mcpgo.Description(param.Description)}
-	if param.Required {
-		opts = append(opts, mcpgo.Required())
-	}
-	return opts
-}
-
-func paramToOption(param core.Parameter) mcpgo.ToolOption {
-	switch coreintegration.NormalizeType(param.Type) {
-	case "integer", "number":
-		return mcpgo.WithNumber(param.Name, buildPropertyOpts(param)...)
-	case "boolean":
-		return mcpgo.WithBoolean(param.Name, buildPropertyOpts(param)...)
-	case "array":
-		return mcpgo.WithArray(param.Name, buildPropertyOpts(param)...)
-	case "object":
-		return mcpgo.WithObject(param.Name, buildPropertyOpts(param)...)
-	default:
-		return mcpgo.WithString(param.Name, buildPropertyOpts(param)...)
 	}
 }

--- a/server/internal/server/server_test.go
+++ b/server/internal/server/server_test.go
@@ -19,6 +19,7 @@ import (
 	mcpserver "github.com/mark3labs/mcp-go/server"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coreintegration "github.com/valon-technologies/gestalt/server/core/integration"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -2106,6 +2107,10 @@ func (s *stubIntegrationWithOps) ListOperations() []core.Operation {
 	return s.ops
 }
 
+func (s *stubIntegrationWithOps) Catalog() *catalog.Catalog {
+	return serverTestCatalogFromOperations(s.StubIntegration.N, s.ops)
+}
+
 type stubIntegrationWithSessionCatalog struct {
 	stubIntegrationWithOps
 	catalog             *catalog.Catalog
@@ -2293,11 +2298,43 @@ func (s *stubNonOAuthProvider) DisplayName() string                 { return s.n
 func (s *stubNonOAuthProvider) Description() string                 { return "" }
 func (s *stubNonOAuthProvider) ConnectionMode() core.ConnectionMode { return core.ConnectionModeUser }
 func (s *stubNonOAuthProvider) ListOperations() []core.Operation    { return s.ops }
+func (s *stubNonOAuthProvider) Catalog() *catalog.Catalog {
+	return serverTestCatalogFromOperations(s.name, s.ops)
+}
 func (s *stubNonOAuthProvider) Execute(ctx context.Context, op string, params map[string]any, token string) (*core.OperationResult, error) {
 	if s.execFn != nil {
 		return s.execFn(ctx, op, params, token)
 	}
 	return &core.OperationResult{Status: http.StatusOK, Body: `{}`}, nil
+}
+
+func serverTestCatalogFromOperations(name string, ops []core.Operation) *catalog.Catalog {
+	cat := &catalog.Catalog{
+		Name:       name,
+		Operations: make([]catalog.CatalogOperation, 0, len(ops)),
+	}
+	for _, op := range ops {
+		params := make([]catalog.CatalogParameter, 0, len(op.Parameters))
+		for _, param := range op.Parameters {
+			params = append(params, catalog.CatalogParameter{
+				Name:        param.Name,
+				Type:        param.Type,
+				Description: param.Description,
+				Required:    param.Required,
+				Default:     param.Default,
+			})
+		}
+		cat.Operations = append(cat.Operations, catalog.CatalogOperation{
+			ID:          op.Name,
+			Method:      op.Method,
+			Path:        "/" + op.Name,
+			Description: op.Description,
+			Parameters:  params,
+			Transport:   catalog.TransportREST,
+		})
+	}
+	coreintegration.CompileSchemas(cat)
+	return cat
 }
 
 func TestExecuteOperation_RefreshesExpiredToken(t *testing.T) {


### PR DESCRIPTION
## Summary
- remove the MCP flat-tool fallback so server tool projection only uses provider catalogs
- remove invocation fallback paths that projected capabilities or checked operation existence from flat ops
- make `Restricted` derive `ListOperations()` from its filtered catalog instead of re-filtering the inner flat op list
- update server and MCP tests to use catalog-backed stubs, and add coverage that flat-only providers are skipped

## Why
After #429, real providers on the server side already expose catalogs. The remaining flat-op branches were just defensive compatibility code inside the server itself:
- `internal/mcp` still had `addFlatTools`
- `internal/invocation` still fell back to `ListOperations()` for capabilities and operation existence
- `core/integration/Restricted` still re-filtered flat ops even though it already filtered catalogs

This PR deletes those server-side fallbacks without removing the `ListOperations()` interface itself.

## Validation
```bash
go test ./internal/bootstrap ./internal/openapi ./internal/graphql ./internal/mcp ./internal/composite ./internal/mcpupstream ./internal/pluginhost ./internal/server ./internal/invocation ./core/integration ./internal/provider ./internal/provider/compiler
```