### PR TITLE
Simplify provider metadata threading

### DIFF
--- a/server/cmd/gestaltd/init_test.go
+++ b/server/cmd/gestaltd/init_test.go
@@ -315,8 +315,8 @@ func TestPrepareConfigAcceptsPluginPackageSurfaceConnectionAliases(t *testing.T)
 		t.Fatalf("loadConfigForExecution: %v", err)
 	}
 	plugin := cfg.Integrations["example"].Plugin
-	if plugin.ResolvedManifestPath == "" {
-		t.Fatal("expected ResolvedManifestPath to be set after prepare")
+	if plugin.ResolvedManifest == nil {
+		t.Fatal("expected ResolvedManifest to be set after prepare")
 	}
 }
 

--- a/server/cmd/gestaltd/run.go
+++ b/server/cmd/gestaltd/run.go
@@ -19,7 +19,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	gestaltmcp "github.com/valon-technologies/gestalt/server/internal/mcp"
-	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
 	"github.com/valon-technologies/gestalt/server/internal/sandbox"
 	"github.com/valon-technologies/gestalt/server/internal/server"
@@ -247,7 +246,7 @@ func buildMCPSurface(cfg *config.Config, connMaps bootstrap.ConnectionMaps) mcpS
 		if intg.Plugin == nil {
 			continue
 		}
-		if !pluginDeclaresMCP(intg.Plugin) {
+		if !intg.Plugin.DeclaresMCP() {
 			continue
 		}
 		surface.providers = append(surface.providers, name)
@@ -264,24 +263,6 @@ func buildMCPSurface(cfg *config.Config, connMaps bootstrap.ConnectionMaps) mcpS
 	}
 
 	return surface
-}
-
-func pluginDeclaresMCP(plugin *config.PluginDef) bool {
-	if plugin == nil {
-		return false
-	}
-	if plugin.MCP || plugin.MCPURL != "" || plugin.OpenAPI != "" || plugin.GraphQLURL != "" || len(plugin.Operations) > 0 {
-		return true
-	}
-	if plugin.ResolvedManifestPath == "" {
-		return true
-	}
-	_, manifest, err := pluginpkg.ReadManifestFile(plugin.ResolvedManifestPath)
-	if err != nil {
-		slog.Warn("reading plugin manifest", "path", plugin.ResolvedManifestPath, "error", err)
-		return true
-	}
-	return manifest.Provider != nil && (manifest.Provider.MCP || manifest.Provider.IsSpecLoaded() || len(manifest.Provider.Operations) > 0)
 }
 
 func (s mcpSurface) handler(result *bootstrap.Result) (http.Handler, error) {

--- a/server/cmd/gestaltd/run_test.go
+++ b/server/cmd/gestaltd/run_test.go
@@ -87,3 +87,27 @@ func TestBuildMCPSurfaceIncludesManifestDeclaredProviders(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildMCPSurfaceExcludesResolvedManifestWithoutProvider(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Integrations: map[string]config.IntegrationDef{
+			"example": {
+				Plugin: &config.PluginDef{
+					Source: "github.com/testowner/plugins/example",
+					ResolvedManifest: &pluginmanifestv1.Manifest{
+						Source:  "github.com/testowner/plugins/example",
+						Version: "0.0.1",
+						Kinds:   []string{pluginmanifestv1.KindProvider},
+					},
+				},
+			},
+		},
+	}
+
+	surface := buildMCPSurface(cfg, bootstrap.BuildConnectionMaps(cfg))
+	if len(surface.providers) != 0 {
+		t.Fatalf("providers = %v, want none", surface.providers)
+	}
+}

--- a/server/cmd/gestaltd/run_test.go
+++ b/server/cmd/gestaltd/run_test.go
@@ -60,15 +60,12 @@ func TestBuildMCPSurfaceIncludesManifestDeclaredProviders(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			pluginDir := t.TempDir()
-			writeReleaseTestManifest(t, pluginDir, tc.manifest)
-
 			cfg := &config.Config{
 				Integrations: map[string]config.IntegrationDef{
 					"example": {
 						Plugin: &config.PluginDef{
-							Source:               "github.com/testowner/plugins/example",
-							ResolvedManifestPath: pluginDir + "/plugin.json",
+							Source:           "github.com/testowner/plugins/example",
+							ResolvedManifest: tc.manifest,
 						},
 					},
 				},

--- a/server/core/integration/base.go
+++ b/server/core/integration/base.go
@@ -119,26 +119,6 @@ func (b *Base) Name() string        { return b.IntegrationName }
 func (b *Base) DisplayName() string { return b.IntegrationDisplay }
 func (b *Base) Description() string { return b.IntegrationDesc }
 
-func (b *Base) SetDisplayName(s string) {
-	b.IntegrationDisplay = s
-	if b.catalog != nil {
-		b.catalog.DisplayName = s
-	}
-}
-
-func (b *Base) SetDescription(s string) {
-	b.IntegrationDesc = s
-	if b.catalog != nil {
-		b.catalog.Description = s
-	}
-}
-
-func (b *Base) SetIconSVG(svg string) {
-	if b.catalog != nil {
-		b.catalog.IconSVG = svg
-	}
-}
-
 func (b *Base) ConnectionMode() core.ConnectionMode {
 	if b.ConnMode == "" {
 		return core.ConnectionModeUser

--- a/server/core/integration/restricted.go
+++ b/server/core/integration/restricted.go
@@ -85,24 +85,6 @@ func (r *Restricted) DisplayName() string                 { return r.inner.Displ
 func (r *Restricted) Description() string                 { return r.inner.Description() }
 func (r *Restricted) ConnectionMode() core.ConnectionMode { return r.inner.ConnectionMode() }
 
-func (r *Restricted) SetDisplayName(s string) {
-	if v, ok := r.inner.(interface{ SetDisplayName(string) }); ok {
-		v.SetDisplayName(s)
-	}
-}
-
-func (r *Restricted) SetDescription(s string) {
-	if v, ok := r.inner.(interface{ SetDescription(string) }); ok {
-		v.SetDescription(s)
-	}
-}
-
-func (r *Restricted) SetIconSVG(s string) {
-	if v, ok := r.inner.(interface{ SetIconSVG(string) }); ok {
-		v.SetIconSVG(s)
-	}
-}
-
 func (r *Restricted) ListOperations() []core.Operation {
 	all := r.inner.ListOperations()
 	filtered := make([]core.Operation, 0, len(r.allowed))

--- a/server/internal/bootstrap/bootstrap.go
+++ b/server/internal/bootstrap/bootstrap.go
@@ -100,6 +100,66 @@ type ProviderBuildResult struct {
 	ConnectionAuth map[string]OAuthHandler
 }
 
+type providerMetadata struct {
+	displayName string
+	description string
+	iconSVG     string
+}
+
+func resolveProviderMetadata(intg config.IntegrationDef) providerMetadata {
+	meta := providerMetadata{
+		displayName: intg.DisplayName,
+		description: intg.Description,
+	}
+	if intg.IconFile == "" {
+		return meta
+	}
+
+	svg, err := provider.ReadIconFile(intg.IconFile)
+	if err != nil {
+		slog.Warn("could not read icon_file", "path", intg.IconFile, "error", err)
+		return meta
+	}
+	meta.iconSVG = svg
+	return meta
+}
+
+func (m providerMetadata) applyToDefinition(def *provider.Definition) {
+	if def == nil {
+		return
+	}
+	if m.displayName != "" {
+		def.DisplayName = m.displayName
+	}
+	if m.description != "" {
+		def.Description = m.description
+	}
+	if m.iconSVG != "" {
+		def.IconSVG = m.iconSVG
+	}
+}
+
+func (m providerMetadata) displayNameOr(v string) string {
+	if m.displayName != "" {
+		return m.displayName
+	}
+	return v
+}
+
+func (m providerMetadata) descriptionOr(v string) string {
+	if m.description != "" {
+		return m.description
+	}
+	return v
+}
+
+func (m providerMetadata) iconSVGOr(v string) string {
+	if m.iconSVG != "" {
+		return m.iconSVG
+	}
+	return v
+}
+
 type Deps struct {
 	EncryptionKey []byte
 	BaseURL       string
@@ -718,44 +778,37 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 		return nil, fmt.Errorf("integration %q has no plugin defined", name)
 	}
 
+	meta := resolveProviderMetadata(intg)
 	var result *ProviderBuildResult
 	var err error
 
 	switch {
 	case intg.Plugin.IsInline():
-		result, err = buildInlineProvider(ctx, name, intg, deps, regStore)
+		result, err = buildInlineProvider(ctx, name, intg, meta, deps, regStore)
 	case intg.Plugin.IsDeclarative:
-		result, err = buildDeclarativeProvider(ctx, name, intg, deps, regStore)
+		result, err = buildDeclarativeProvider(ctx, name, intg, meta, deps, regStore)
 	default:
-		result, err = buildExternalPluginProvider(ctx, name, intg, deps, regStore)
+		result, err = buildExternalPluginProvider(ctx, name, intg, meta, deps, regStore)
 	}
 	if err != nil {
 		return nil, err
 	}
-
-	applyConfigDisplayOverrides(result.Provider, intg)
 	return result, nil
 }
 
-func buildExternalPluginProvider(ctx context.Context, name string, intg config.IntegrationDef, deps Deps, regStore *lazyRegStore) (*ProviderBuildResult, error) {
-	pluginProv, pluginConfig, err := buildPluginProvider(ctx, name, intg)
+func buildExternalPluginProvider(ctx context.Context, name string, intg config.IntegrationDef, meta providerMetadata, deps Deps, regStore *lazyRegStore) (*ProviderBuildResult, error) {
+	pluginProv, pluginConfig, err := buildPluginProvider(ctx, name, intg, meta)
 	if err != nil {
 		return nil, err
 	}
-	var manifest *pluginmanifestv1.Manifest
-	var manifestProvider *pluginmanifestv1.Provider
-	if intg.Plugin != nil && intg.Plugin.ResolvedManifestPath != "" {
-		_, manifest, err = pluginpkg.ReadManifestFile(intg.Plugin.ResolvedManifestPath)
-		if err != nil {
-			if c, ok := pluginProv.(interface{ Close() error }); ok {
-				_ = c.Close()
-			}
-			return nil, fmt.Errorf("read manifest for external provider %q: %w", name, err)
+	manifest, err := readResolvedManifest(intg.Plugin)
+	if err != nil {
+		if c, ok := pluginProv.(interface{ Close() error }); ok {
+			_ = c.Close()
 		}
-		if manifest != nil {
-			manifestProvider = manifest.Provider
-		}
+		return nil, fmt.Errorf("read manifest for external provider %q: %w", name, err)
 	}
+	manifestProvider := providerFromManifest(manifest)
 
 	resolved, hasSpecSurface := resolveConfiguredSpecSurface(intg.Plugin, manifestProvider)
 
@@ -770,7 +823,7 @@ func buildExternalPluginProvider(ctx context.Context, name string, intg config.I
 		}
 		finalProv = restricted
 	} else {
-		specProv, err := buildConfiguredSpecProvider(ctx, name, resolved, specProviderConfig{
+		specProv, err := buildConfiguredSpecProvider(ctx, name, resolved, meta, specProviderConfig{
 			plugin:            intg.Plugin,
 			manifestProvider:  manifestProvider,
 			allowedOperations: intg.Plugin.AllowedOperations,
@@ -787,8 +840,9 @@ func buildExternalPluginProvider(ctx context.Context, name string, intg config.I
 		}
 		merged, err := composite.NewMergedWithConnections(
 			name,
-			pluginProv.DisplayName(),
-			pluginProv.Description(),
+			meta.displayNameOr(pluginProv.DisplayName()),
+			meta.descriptionOr(pluginProv.Description()),
+			meta.iconSVGOr(firstProviderIconSVG(pluginProv, specProv)),
 			composite.BoundProvider{Provider: pluginProv, Connection: config.PluginConnectionName},
 			composite.BoundProvider{Provider: specProv, Connection: resolved.connectionName},
 		)
@@ -824,7 +878,7 @@ type specProviderConfig struct {
 	applyResponseMapping bool
 }
 
-func buildConfiguredSpecProvider(ctx context.Context, name string, resolved resolvedSpecSurface, cfg specProviderConfig, deps Deps) (core.Provider, error) {
+func buildConfiguredSpecProvider(ctx context.Context, name string, resolved resolvedSpecSurface, meta providerMetadata, cfg specProviderConfig, deps Deps) (core.Provider, error) {
 	var buildOpts []provider.BuildOption
 	if cfg.providerBuildOptions != nil {
 		buildOpts = cfg.providerBuildOptions(resolved.connection)
@@ -843,6 +897,7 @@ func buildConfiguredSpecProvider(ctx context.Context, name string, resolved reso
 		if cfg.applyResponseMapping {
 			applyManifestResponseMapping(def, cfg.manifestProvider)
 		}
+		meta.applyToDefinition(def)
 		prov, err := provider.Build(def, resolved.connection, buildOpts...)
 		if err != nil {
 			return nil, err
@@ -861,6 +916,7 @@ func buildConfiguredSpecProvider(ctx context.Context, name string, resolved reso
 		if cfg.applyResponseMapping {
 			applyManifestResponseMapping(def, cfg.manifestProvider)
 		}
+		meta.applyToDefinition(def)
 		prov, err := provider.Build(def, resolved.connection, buildOpts...)
 		if err != nil {
 			return nil, err
@@ -872,7 +928,15 @@ func buildConfiguredSpecProvider(ctx context.Context, name string, resolved reso
 		if connMode == "" {
 			connMode = core.ConnectionModeUser
 		}
-		up, err := mcpupstream.New(ctx, name, resolved.url, connMode, mergedHeaders(cfg.manifestProvider, cfg.plugin), deps.Egress.Resolver)
+		up, err := mcpupstream.New(
+			ctx,
+			name,
+			resolved.url,
+			connMode,
+			mergedHeaders(cfg.manifestProvider, cfg.plugin),
+			deps.Egress.Resolver,
+			mcpupstream.WithMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
+		)
 		if err != nil {
 			return nil, fmt.Errorf("create mcp upstream: %w", err)
 		}
@@ -902,8 +966,12 @@ func newProviderBuildResult(name string, intg config.IntegrationDef, manifest *p
 	return result, nil
 }
 
-func buildRestrictedDeclarativeProvider(kind, name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest) (core.Provider, error) {
-	prov, err := pluginhost.NewDeclarativeProvider(manifest, nil)
+func buildRestrictedDeclarativeProvider(kind, name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, meta providerMetadata) (core.Provider, error) {
+	prov, err := pluginhost.NewDeclarativeProvider(
+		manifest,
+		nil,
+		pluginhost.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("create %s provider %q: %w", kind, name, err)
 	}
@@ -915,19 +983,19 @@ func buildRestrictedDeclarativeProvider(kind, name string, intg config.Integrati
 	return restricted, nil
 }
 
-func buildManifestBackedProvider(ctx context.Context, kind, name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, pluginConfig map[string]any, deps Deps, regStore *lazyRegStore, allowedOperations map[string]*config.OperationOverride) (*ProviderBuildResult, error) {
+func buildManifestBackedProvider(ctx context.Context, kind, name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, pluginConfig map[string]any, meta providerMetadata, deps Deps, regStore *lazyRegStore, allowedOperations map[string]*config.OperationOverride) (*ProviderBuildResult, error) {
 	if manifest.Provider.IsSpecLoaded() {
-		return buildSpecLoadedProvider(ctx, name, intg, manifest, pluginConfig, deps, regStore, allowedOperations)
+		return buildSpecLoadedProvider(ctx, name, intg, manifest, pluginConfig, meta, deps, regStore, allowedOperations)
 	}
 
-	prov, err := buildRestrictedDeclarativeProvider(kind, name, intg, manifest)
+	prov, err := buildRestrictedDeclarativeProvider(kind, name, intg, manifest, meta)
 	if err != nil {
 		return nil, err
 	}
 	return newProviderBuildResult(name, intg, manifest, pluginConfig, prov, deps, regStore)
 }
 
-func buildInlineProvider(ctx context.Context, name string, intg config.IntegrationDef, deps Deps, regStore *lazyRegStore) (*ProviderBuildResult, error) {
+func buildInlineProvider(ctx context.Context, name string, intg config.IntegrationDef, meta providerMetadata, deps Deps, regStore *lazyRegStore) (*ProviderBuildResult, error) {
 	manifest, err := config.InlineToManifest(name, intg.Plugin)
 	if err != nil {
 		return nil, fmt.Errorf("convert inline plugin %q to manifest: %w", name, err)
@@ -936,7 +1004,7 @@ func buildInlineProvider(ctx context.Context, name string, intg config.Integrati
 	if err != nil {
 		return nil, fmt.Errorf("decode plugin config for %q: %w", name, err)
 	}
-	return buildManifestBackedProvider(ctx, "inline", name, intg, manifest, pluginConfig, deps, regStore, intg.Plugin.AllowedOperations)
+	return buildManifestBackedProvider(ctx, "inline", name, intg, manifest, pluginConfig, meta, deps, regStore, intg.Plugin.AllowedOperations)
 }
 
 func mcpOAuthBuildOpts(conn config.ConnectionDef, mp *pluginmanifestv1.Provider, regStore *lazyRegStore, deps Deps) []provider.BuildOption {
@@ -947,13 +1015,13 @@ func mcpOAuthBuildOpts(conn config.ConnectionDef, mp *pluginmanifestv1.Provider,
 	return []provider.BuildOption{provider.WithAuthHandler(handler)}
 }
 
-func buildSpecLoadedProvider(ctx context.Context, name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, pluginConfig map[string]any, deps Deps, regStore *lazyRegStore, allowedOperations map[string]*config.OperationOverride) (*ProviderBuildResult, error) {
+func buildSpecLoadedProvider(ctx context.Context, name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, pluginConfig map[string]any, meta providerMetadata, deps Deps, regStore *lazyRegStore, allowedOperations map[string]*config.OperationOverride) (*ProviderBuildResult, error) {
 	mp := manifest.Provider
 	resolved, ok := resolveConfiguredSpecSurface(intg.Plugin, mp)
 	if !ok {
 		return nil, fmt.Errorf("build spec-loaded provider %q: no spec URL", name)
 	}
-	prov, err := buildConfiguredSpecProvider(ctx, name, resolved, specProviderConfig{
+	prov, err := buildConfiguredSpecProvider(ctx, name, resolved, meta, specProviderConfig{
 		plugin:               intg.Plugin,
 		manifestProvider:     mp,
 		allowedOperations:    allowedOperations,
@@ -1007,6 +1075,42 @@ func mergedHeaders(manifestProvider *pluginmanifestv1.Provider, plugin *config.P
 	}
 
 	return config.MergeHeaders(manifestHeaders, pluginHeaders)
+}
+
+func readManifest(path string) (*pluginmanifestv1.Manifest, error) {
+	if path == "" {
+		return nil, nil
+	}
+	_, manifest, err := pluginpkg.ReadManifestFile(path)
+	return manifest, err
+}
+
+func readResolvedManifest(plugin *config.PluginDef) (*pluginmanifestv1.Manifest, error) {
+	if plugin == nil {
+		return nil, nil
+	}
+	return readManifest(plugin.ResolvedManifestPath)
+}
+
+func providerFromManifest(manifest *pluginmanifestv1.Manifest) *pluginmanifestv1.Provider {
+	if manifest == nil {
+		return nil
+	}
+	return manifest.Provider
+}
+
+func firstProviderIconSVG(providers ...core.Provider) string {
+	for _, prov := range providers {
+		cp, ok := prov.(core.CatalogProvider)
+		if !ok {
+			continue
+		}
+		cat := cp.Catalog()
+		if cat != nil && cat.IconSVG != "" {
+			return cat.IconSVG
+		}
+	}
+	return ""
 }
 
 func manifestAllowedOperations(provider *pluginmanifestv1.Provider) map[string]*config.OperationOverride {
@@ -1106,11 +1210,11 @@ func mergeConnectionAuth(dst *config.ConnectionAuthDef, src config.ConnectionAut
 	}
 }
 
-func buildDeclarativeProvider(ctx context.Context, name string, intg config.IntegrationDef, deps Deps, regStore *lazyRegStore) (*ProviderBuildResult, error) {
+func buildDeclarativeProvider(ctx context.Context, name string, intg config.IntegrationDef, meta providerMetadata, deps Deps, regStore *lazyRegStore) (*ProviderBuildResult, error) {
 	if intg.Plugin == nil || intg.Plugin.ResolvedManifestPath == "" {
 		return nil, fmt.Errorf("declarative provider %q has no resolved manifest path", name)
 	}
-	_, manifest, err := pluginpkg.ReadManifestFile(intg.Plugin.ResolvedManifestPath)
+	manifest, err := readResolvedManifest(intg.Plugin)
 	if err != nil {
 		return nil, fmt.Errorf("read manifest for declarative provider %q: %w", name, err)
 	}
@@ -1119,7 +1223,7 @@ func buildDeclarativeProvider(ctx context.Context, name string, intg config.Inte
 	if err != nil {
 		return nil, fmt.Errorf("decode plugin config for %q: %w", name, err)
 	}
-	return buildManifestBackedProvider(ctx, "declarative", name, intg, manifest, pluginConfig, deps, regStore, manifestAllowedOperations(manifest.Provider))
+	return buildManifestBackedProvider(ctx, "declarative", name, intg, manifest, pluginConfig, meta, deps, regStore, manifestAllowedOperations(manifest.Provider))
 }
 
 func applyAllowedOperations(name string, intg config.IntegrationDef, pluginProv core.Provider) (core.Provider, error) {
@@ -1136,7 +1240,7 @@ func applyAllowedOperations(name string, intg config.IntegrationDef, pluginProv 
 	return policy.Wrap(pluginProv), nil
 }
 
-func buildPluginProvider(ctx context.Context, name string, intg config.IntegrationDef) (core.Provider, map[string]any, error) {
+func buildPluginProvider(ctx context.Context, name string, intg config.IntegrationDef, meta providerMetadata) (core.Provider, map[string]any, error) {
 	pluginConfig, err := config.NodeToMap(intg.Plugin.Config)
 	if err != nil {
 		return nil, nil, fmt.Errorf("decode plugin config for %q: %w", name, err)
@@ -1146,6 +1250,9 @@ func buildPluginProvider(ctx context.Context, name string, intg config.Integrati
 		Args:         intg.Plugin.Args,
 		Env:          intg.Plugin.Env,
 		Name:         name,
+		DisplayName:  meta.displayName,
+		Description:  meta.description,
+		IconSVG:      meta.iconSVG,
 		Config:       pluginConfig,
 		AllowedHosts: intg.Plugin.AllowedHosts,
 		HostBinary:   intg.Plugin.HostBinary,
@@ -1154,39 +1261,6 @@ func buildPluginProvider(ctx context.Context, name string, intg config.Integrati
 		return nil, nil, err
 	}
 	return prov, pluginConfig, nil
-}
-
-// applyConfigDisplayOverrides applies display_name, description, and icon_file
-// from the integration config onto the final provider. Called once at the end of
-// buildProvider so every provider type (MCP, OpenAPI, plugin, composite) gets
-// consistent treatment.
-func applyConfigDisplayOverrides(prov core.Provider, intg config.IntegrationDef) {
-	type displayNameSetter interface{ SetDisplayName(string) }
-	type descriptionSetter interface{ SetDescription(string) }
-	type iconSetter interface{ SetIconSVG(string) }
-
-	if intg.DisplayName != "" {
-		if s, ok := prov.(displayNameSetter); ok {
-			s.SetDisplayName(intg.DisplayName)
-		}
-	}
-	if intg.Description != "" {
-		if s, ok := prov.(descriptionSetter); ok {
-			s.SetDescription(intg.Description)
-		}
-	}
-	if intg.IconFile != "" {
-		svg, err := provider.ReadIconFile(intg.IconFile)
-		if err != nil {
-			slog.Warn("could not read icon_file", "path", intg.IconFile, "error", err)
-			return
-		}
-		if svg != "" {
-			if s, ok := prov.(iconSetter); ok {
-				s.SetIconSVG(svg)
-			}
-		}
-	}
 }
 
 func buildOAuthHandlerFromAuth(auth *config.ConnectionAuthDef, pluginConfig map[string]any, deps Deps) (OAuthHandler, error) {

--- a/server/internal/bootstrap/bootstrap.go
+++ b/server/internal/bootstrap/bootstrap.go
@@ -22,7 +22,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/openapi"
 	"github.com/valon-technologies/gestalt/server/internal/operationexposure"
 	"github.com/valon-technologies/gestalt/server/internal/pluginhost"
-	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
@@ -801,14 +800,8 @@ func buildExternalPluginProvider(ctx context.Context, name string, intg config.I
 	if err != nil {
 		return nil, err
 	}
-	manifest, err := readResolvedManifest(intg.Plugin)
-	if err != nil {
-		if c, ok := pluginProv.(interface{ Close() error }); ok {
-			_ = c.Close()
-		}
-		return nil, fmt.Errorf("read manifest for external provider %q: %w", name, err)
-	}
-	manifestProvider := providerFromManifest(manifest)
+	manifest := intg.Plugin.ResolvedManifest
+	manifestProvider := intg.Plugin.ManifestProvider()
 
 	resolved, hasSpecSurface := resolveConfiguredSpecSurface(intg.Plugin, manifestProvider)
 
@@ -1077,28 +1070,6 @@ func mergedHeaders(manifestProvider *pluginmanifestv1.Provider, plugin *config.P
 	return config.MergeHeaders(manifestHeaders, pluginHeaders)
 }
 
-func readManifest(path string) (*pluginmanifestv1.Manifest, error) {
-	if path == "" {
-		return nil, nil
-	}
-	_, manifest, err := pluginpkg.ReadManifestFile(path)
-	return manifest, err
-}
-
-func readResolvedManifest(plugin *config.PluginDef) (*pluginmanifestv1.Manifest, error) {
-	if plugin == nil {
-		return nil, nil
-	}
-	return readManifest(plugin.ResolvedManifestPath)
-}
-
-func providerFromManifest(manifest *pluginmanifestv1.Manifest) *pluginmanifestv1.Provider {
-	if manifest == nil {
-		return nil
-	}
-	return manifest.Provider
-}
-
 func firstProviderIconSVG(providers ...core.Provider) string {
 	for _, prov := range providers {
 		cp, ok := prov.(core.CatalogProvider)
@@ -1211,13 +1182,10 @@ func mergeConnectionAuth(dst *config.ConnectionAuthDef, src config.ConnectionAut
 }
 
 func buildDeclarativeProvider(ctx context.Context, name string, intg config.IntegrationDef, meta providerMetadata, deps Deps, regStore *lazyRegStore) (*ProviderBuildResult, error) {
-	if intg.Plugin == nil || intg.Plugin.ResolvedManifestPath == "" {
-		return nil, fmt.Errorf("declarative provider %q has no resolved manifest path", name)
+	if intg.Plugin == nil || !intg.Plugin.HasResolvedManifest() {
+		return nil, fmt.Errorf("declarative provider %q has no resolved manifest", name)
 	}
-	manifest, err := readResolvedManifest(intg.Plugin)
-	if err != nil {
-		return nil, fmt.Errorf("read manifest for declarative provider %q: %w", name, err)
-	}
+	manifest := intg.Plugin.ResolvedManifest
 	manifest = mergedManifestHeaders(manifest, intg.Plugin)
 	pluginConfig, err := config.NodeToMap(intg.Plugin.Config)
 	if err != nil {

--- a/server/internal/bootstrap/connections.go
+++ b/server/internal/bootstrap/connections.go
@@ -2,7 +2,6 @@ package bootstrap
 
 import (
 	"fmt"
-	"log/slog"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
@@ -54,7 +53,7 @@ func describeIntegrationConnections(intg config.IntegrationDef) integrationConne
 		return meta
 	}
 
-	manifestProvider := resolvedManifestProvider(intg.Plugin)
+	manifestProvider := intg.Plugin.ManifestProvider()
 	if resolved, ok := resolveConfiguredSpecSurface(intg.Plugin, manifestProvider); ok {
 		meta.defaultConnection = resolved.connectionName
 		meta.apiConnection = resolved.connectionName
@@ -150,15 +149,6 @@ func resolveSpecSurface(plugin *config.PluginDef, manifestProvider *pluginmanife
 		resolved.connection = resolvedNamedConnectionDef(plugin, manifestProvider, name)
 	}
 	return resolved, true
-}
-
-func resolvedManifestProvider(plugin *config.PluginDef) *pluginmanifestv1.Provider {
-	manifest, err := readResolvedManifest(plugin)
-	if err != nil {
-		slog.Warn("reading plugin manifest for connection metadata", "path", plugin.ResolvedManifestPath, "error", err)
-		return nil
-	}
-	return providerFromManifest(manifest)
 }
 
 func manifestSurfaceConnectionName(provider *pluginmanifestv1.Provider, surface specSurface) string {

--- a/server/internal/bootstrap/connections.go
+++ b/server/internal/bootstrap/connections.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
 
@@ -154,18 +153,12 @@ func resolveSpecSurface(plugin *config.PluginDef, manifestProvider *pluginmanife
 }
 
 func resolvedManifestProvider(plugin *config.PluginDef) *pluginmanifestv1.Provider {
-	if plugin == nil || plugin.ResolvedManifestPath == "" {
-		return nil
-	}
-	_, manifest, err := pluginpkg.ReadManifestFile(plugin.ResolvedManifestPath)
+	manifest, err := readResolvedManifest(plugin)
 	if err != nil {
 		slog.Warn("reading plugin manifest for connection metadata", "path", plugin.ResolvedManifestPath, "error", err)
 		return nil
 	}
-	if manifest == nil {
-		return nil
-	}
-	return manifest.Provider
+	return providerFromManifest(manifest)
 }
 
 func manifestSurfaceConnectionName(provider *pluginmanifestv1.Provider, surface specSurface) string {

--- a/server/internal/bootstrap/executable_plugin_test.go
+++ b/server/internal/bootstrap/executable_plugin_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
-	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 	"gopkg.in/yaml.v3"
@@ -271,15 +270,6 @@ func TestPluginManifestOAuthWiresConnectionAuth(t *testing.T) {
 			Provider: &pluginmanifestv1.Entrypoint{ArtifactPath: "artifacts/" + runtime.GOOS + "/" + runtime.GOARCH + "/provider"},
 		},
 	}
-	manifestData, err := pluginpkg.EncodeManifest(manifest)
-	if err != nil {
-		t.Fatalf("EncodeManifest: %v", err)
-	}
-	manifestPath := filepath.Join(t.TempDir(), "plugin.json")
-	if err := os.WriteFile(manifestPath, manifestData, 0644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
 	cfg := &config.Config{
 		Integrations: map[string]config.IntegrationDef{
 			"echoauth": {
@@ -290,7 +280,7 @@ func TestPluginManifestOAuthWiresConnectionAuth(t *testing.T) {
 						"client_id":     "test-client-id",
 						"client_secret": "test-client-secret",
 					}),
-					ResolvedManifestPath: manifestPath,
+					ResolvedManifest: manifest,
 				},
 			},
 		},
@@ -347,22 +337,13 @@ func TestPluginManifestNoAuthSkipsConnectionAuth(t *testing.T) {
 			Provider: &pluginmanifestv1.Entrypoint{ArtifactPath: "artifacts/" + runtime.GOOS + "/" + runtime.GOARCH + "/provider"},
 		},
 	}
-	manifestData, err := pluginpkg.EncodeManifest(manifest)
-	if err != nil {
-		t.Fatalf("EncodeManifest: %v", err)
-	}
-	manifestPath := filepath.Join(t.TempDir(), "plugin.json")
-	if err := os.WriteFile(manifestPath, manifestData, 0644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
 	cfg := &config.Config{
 		Integrations: map[string]config.IntegrationDef{
 			"echonoauth": {
 				Plugin: &config.PluginDef{
-					Command:              bin,
-					Args:                 []string{"provider"},
-					ResolvedManifestPath: manifestPath,
+					Command:          bin,
+					Args:             []string{"provider"},
+					ResolvedManifest: manifest,
 				},
 			},
 		},
@@ -582,22 +563,13 @@ func TestHybridPluginUsesManifestStaticHeadersForSpecSurface(t *testing.T) {
 			},
 		},
 	}
-	manifestData, err := pluginpkg.EncodeManifest(manifest)
-	if err != nil {
-		t.Fatalf("EncodeManifest: %v", err)
-	}
-	manifestPath := filepath.Join(t.TempDir(), "plugin.json")
-	if err := os.WriteFile(manifestPath, manifestData, 0644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
 	cfg := &config.Config{
 		Integrations: map[string]config.IntegrationDef{
 			"hybrid": {
 				Plugin: &config.PluginDef{
-					Command:              bin,
-					Args:                 []string{"provider"},
-					ResolvedManifestPath: manifestPath,
+					Command:          bin,
+					Args:             []string{"provider"},
+					ResolvedManifest: manifest,
 				},
 			},
 		},

--- a/server/internal/bootstrap/headers_test.go
+++ b/server/internal/bootstrap/headers_test.go
@@ -4,14 +4,11 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
@@ -51,21 +48,12 @@ func TestBootstrap_ConfigHeadersOverrideManifestHeaders(t *testing.T) {
 			},
 		},
 	}
-	manifestData, err := pluginpkg.EncodeManifest(manifest)
-	if err != nil {
-		t.Fatalf("EncodeManifest: %v", err)
-	}
-	manifestPath := filepath.Join(t.TempDir(), "plugin.json")
-	if err := os.WriteFile(manifestPath, manifestData, 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
 	cfg := validConfig()
 	cfg.Integrations = map[string]config.IntegrationDef{
 		"sample": {
 			Plugin: &config.PluginDef{
-				IsDeclarative:        true,
-				ResolvedManifestPath: manifestPath,
+				IsDeclarative:    true,
+				ResolvedManifest: manifest,
 				Headers: map[string]string{
 					headerName: configValue,
 				},

--- a/server/internal/bootstrap/validate.go
+++ b/server/internal/bootstrap/validate.go
@@ -149,10 +149,10 @@ func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *Fa
 }
 
 func buildProviderForValidation(ctx context.Context, name string, intg config.IntegrationDef, factories *FactoryRegistry, deps Deps, regStore *lazyRegStore) (*ProviderBuildResult, error) {
-	if intg.Plugin == nil || intg.Plugin.Package == "" || intg.Plugin.ResolvedManifestPath == "" {
+	if intg.Plugin == nil || intg.Plugin.Package == "" || !intg.Plugin.HasResolvedManifest() {
 		return buildProvider(ctx, name, intg, factories, deps, regStore)
 	}
-	prov, err := newPreparedProviderStub(name, intg, intg.Plugin.ResolvedManifestPath)
+	prov, err := newPreparedProviderStub(name, intg)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func buildProviderForValidation(ctx context.Context, name string, intg config.In
 }
 
 func buildRuntimeForValidation(ctx context.Context, name string, cfg config.RuntimeDef, factories *FactoryRegistry, deps RuntimeDeps) (core.Runtime, error) {
-	if cfg.Plugin != nil && cfg.Plugin.Package != "" && cfg.Plugin.ResolvedManifestPath != "" {
+	if cfg.Plugin != nil && cfg.Plugin.Package != "" && cfg.Plugin.HasResolvedManifest() {
 		return &preparedRuntimeStub{name: name}, nil
 	}
 	return buildRuntime(ctx, name, cfg, factories, deps)
@@ -173,11 +173,11 @@ type preparedProviderStub struct {
 	connectionMode core.ConnectionMode
 }
 
-func newPreparedProviderStub(name string, intg config.IntegrationDef, manifestPath string) (core.Provider, error) {
-	manifest, err := readManifest(manifestPath)
-	if err != nil {
-		return nil, fmt.Errorf("read prepared manifest: %w", err)
+func newPreparedProviderStub(name string, intg config.IntegrationDef) (core.Provider, error) {
+	if intg.Plugin == nil || intg.Plugin.ResolvedManifest == nil {
+		return nil, fmt.Errorf("prepared manifest is not resolved")
 	}
+	manifest := intg.Plugin.ResolvedManifest
 	displayName := manifest.DisplayName
 	if displayName == "" {
 		displayName = name

--- a/server/internal/bootstrap/validate.go
+++ b/server/internal/bootstrap/validate.go
@@ -12,7 +12,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/crypto"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
-	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 )
 
@@ -175,7 +174,7 @@ type preparedProviderStub struct {
 }
 
 func newPreparedProviderStub(name string, intg config.IntegrationDef, manifestPath string) (core.Provider, error) {
-	_, manifest, err := pluginpkg.ReadManifestFile(manifestPath)
+	manifest, err := readManifest(manifestPath)
 	if err != nil {
 		return nil, fmt.Errorf("read prepared manifest: %w", err)
 	}

--- a/server/internal/composite/merged.go
+++ b/server/internal/composite/merged.go
@@ -30,15 +30,15 @@ var (
 	_ core.OperationConnectionProvider = (*MergedProvider)(nil)
 )
 
-func NewMerged(name, displayName, desc string, providers ...core.Provider) (*MergedProvider, error) {
+func NewMerged(name, displayName, desc, iconSVG string, providers ...core.Provider) (*MergedProvider, error) {
 	bound := make([]BoundProvider, len(providers))
 	for i, p := range providers {
 		bound[i] = BoundProvider{Provider: p}
 	}
-	return NewMergedWithConnections(name, displayName, desc, bound...)
+	return NewMergedWithConnections(name, displayName, desc, iconSVG, bound...)
 }
 
-func NewMergedWithConnections(name, displayName, desc string, providers ...BoundProvider) (*MergedProvider, error) {
+func NewMergedWithConnections(name, displayName, desc, iconSVG string, providers ...BoundProvider) (*MergedProvider, error) {
 	owned := make([]core.Provider, len(providers))
 	for i, p := range providers {
 		owned[i] = p.Provider
@@ -48,6 +48,7 @@ func NewMergedWithConnections(name, displayName, desc string, providers ...Bound
 			Name:        name,
 			DisplayName: displayName,
 			Description: desc,
+			IconSVG:     iconSVG,
 			Operations:  make([]catalog.CatalogOperation, 0),
 		},
 		opConn: make(map[string]string),
@@ -86,10 +87,6 @@ func (m *MergedProvider) ListOperations() []core.Operation {
 func (m *MergedProvider) ConnectionForOperation(op string) string {
 	return m.opConn[op]
 }
-
-func (m *MergedProvider) SetDisplayName(s string) { m.catalog.DisplayName = s }
-func (m *MergedProvider) SetDescription(s string) { m.catalog.Description = s }
-func (m *MergedProvider) SetIconSVG(svg string)   { m.catalog.IconSVG = svg }
 
 func (m *MergedProvider) Catalog() *catalog.Catalog { return m.catalog.Clone() }
 

--- a/server/internal/composite/merged_test.go
+++ b/server/internal/composite/merged_test.go
@@ -35,7 +35,7 @@ func (p *fakeProvider) Close() error { p.closed = true; return nil }
 func TestNewMergedRejectsOperationCollision(t *testing.T) {
 	t.Parallel()
 
-	_, err := composite.NewMerged("test", "Test", "desc",
+	_, err := composite.NewMerged("test", "Test", "desc", "",
 		&fakeProvider{name: "api", ops: []core.Operation{{Name: "search"}}},
 		&fakeProvider{name: "plugin", ops: []core.Operation{{Name: "search"}}},
 	)
@@ -53,7 +53,7 @@ func TestNewMergedRoutesExecuteByOperationName(t *testing.T) {
 
 	apiHit := false
 	pluginHit := false
-	merged, err := composite.NewMerged("test", "Test", "desc",
+	merged, err := composite.NewMerged("test", "Test", "desc", "",
 		&fakeProvider{
 			name: "api",
 			ops:  []core.Operation{{Name: "list_items"}},
@@ -97,7 +97,7 @@ func TestNewMergedRoutesExecuteByOperationName(t *testing.T) {
 func TestNewMergedConnectionModeNone(t *testing.T) {
 	t.Parallel()
 
-	merged, err := composite.NewMerged("test", "Test", "desc",
+	merged, err := composite.NewMerged("test", "Test", "desc", "",
 		&fakeProvider{name: "a", connMode: core.ConnectionModeNone, ops: []core.Operation{{Name: "a"}}},
 		&fakeProvider{name: "b", connMode: core.ConnectionModeNone, ops: []core.Operation{{Name: "b"}}},
 	)
@@ -115,7 +115,7 @@ func TestMergedDisownProvider(t *testing.T) {
 	api := &fakeProvider{name: "api", ops: []core.Operation{{Name: "a"}}}
 	plugin := &fakeProvider{name: "plugin", ops: []core.Operation{{Name: "b"}}}
 
-	merged, err := composite.NewMerged("test", "Test", "desc", api, plugin)
+	merged, err := composite.NewMerged("test", "Test", "desc", "", api, plugin)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,20 +131,16 @@ func TestMergedDisownProvider(t *testing.T) {
 	}
 }
 
-func TestMergedSettersUpdateCatalogMetadata(t *testing.T) {
+func TestMergedCatalogIncludesConstructorMetadata(t *testing.T) {
 	t.Parallel()
 
-	merged, err := composite.NewMerged("test", "Test", "desc",
+	merged, err := composite.NewMerged("test", "Override", "Override description", "<svg/>",
 		&fakeProvider{name: "api", ops: []core.Operation{{Name: "list_items"}}},
 		&fakeProvider{name: "plugin", ops: []core.Operation{{Name: "query"}}},
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	merged.SetDisplayName("Override")
-	merged.SetDescription("Override description")
-	merged.SetIconSVG("<svg/>")
 
 	cat := merged.Catalog()
 	if cat == nil {

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 	"gopkg.in/yaml.v3"
 )
 
@@ -56,8 +57,7 @@ type UIPluginDef struct {
 	Source  string `yaml:"source"`
 	Version string `yaml:"version"`
 
-	ResolvedAssetRoot    string `yaml:"-"`
-	ResolvedManifestPath string `yaml:"-"`
+	ResolvedAssetRoot string `yaml:"-"`
 }
 
 func (p *UIPluginDef) HasManagedArtifacts() bool {
@@ -123,10 +123,10 @@ type PluginDef struct {
 	MCP               bool                          `yaml:"mcp"`
 	AllowedOperations map[string]*OperationOverride `yaml:"allowed_operations"`
 
-	ResolvedManifestPath string `yaml:"-"`
-	ResolvedIconFile     string `yaml:"-"`
-	IsDeclarative        bool   `yaml:"-"`
-	HostBinary           string `yaml:"-"`
+	ResolvedManifest *pluginmanifestv1.Manifest `yaml:"-"`
+	ResolvedIconFile string                     `yaml:"-"`
+	IsDeclarative    bool                       `yaml:"-"`
+	HostBinary       string                     `yaml:"-"`
 }
 
 func (p *PluginDef) IsInline() bool {
@@ -142,6 +142,31 @@ func (p *PluginDef) IsInline() bool {
 
 func (p *PluginDef) HasManagedArtifacts() bool {
 	return p != nil && (p.Package != "" || p.Source != "")
+}
+
+func (p *PluginDef) HasResolvedManifest() bool {
+	return p != nil && p.ResolvedManifest != nil
+}
+
+func (p *PluginDef) ManifestProvider() *pluginmanifestv1.Provider {
+	if p == nil || p.ResolvedManifest == nil {
+		return nil
+	}
+	return p.ResolvedManifest.Provider
+}
+
+func (p *PluginDef) DeclaresMCP() bool {
+	if p == nil {
+		return false
+	}
+	if p.MCP || p.MCPURL != "" || p.OpenAPI != "" || p.GraphQLURL != "" || len(p.Operations) > 0 {
+		return true
+	}
+	provider := p.ManifestProvider()
+	if provider == nil {
+		return true
+	}
+	return provider.MCP || provider.IsSpecLoaded() || len(provider.Operations) > 0
 }
 
 type InlineOperationDef struct {

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -162,9 +162,12 @@ func (p *PluginDef) DeclaresMCP() bool {
 	if p.MCP || p.MCPURL != "" || p.OpenAPI != "" || p.GraphQLURL != "" || len(p.Operations) > 0 {
 		return true
 	}
+	if !p.HasResolvedManifest() {
+		return true
+	}
 	provider := p.ManifestProvider()
 	if provider == nil {
-		return true
+		return false
 	}
 	return provider.MCP || provider.IsSpecLoaded() || len(provider.Operations) > 0
 }

--- a/server/internal/mcp/binding_test.go
+++ b/server/internal/mcp/binding_test.go
@@ -770,6 +770,7 @@ func TestNewServer_RESTCatalogToolsUseOperationConnections(t *testing.T) {
 		"hybrid",
 		"Hybrid",
 		"Hybrid provider",
+		"",
 		composite.BoundProvider{Provider: pluginProv, Connection: config.PluginConnectionName},
 		composite.BoundProvider{Provider: apiProv, Connection: testAPIConnectionName},
 	)

--- a/server/internal/mcpupstream/upstream.go
+++ b/server/internal/mcpupstream/upstream.go
@@ -32,6 +32,7 @@ type Upstream struct {
 	name     string
 	display  string
 	desc     string
+	iconSVG  string
 	url      string
 	connMode core.ConnectionMode
 	headers  map[string]string
@@ -41,12 +42,28 @@ type Upstream struct {
 	resolver *egress.Resolver
 }
 
-func New(_ context.Context, name string, url string, connMode core.ConnectionMode, headers map[string]string, resolver *egress.Resolver) (*Upstream, error) {
+type Option func(*Upstream)
+
+func WithMetadataOverrides(displayName, description, iconSVG string) Option {
+	return func(u *Upstream) {
+		if displayName != "" {
+			u.display = displayName
+		}
+		if description != "" {
+			u.desc = description
+		}
+		if iconSVG != "" {
+			u.iconSVG = iconSVG
+		}
+	}
+}
+
+func New(_ context.Context, name string, url string, connMode core.ConnectionMode, headers map[string]string, resolver *egress.Resolver, opts ...Option) (*Upstream, error) {
 	if url == "" {
 		return nil, fmt.Errorf("mcpupstream %s: url is required", name)
 	}
 
-	return &Upstream{
+	u := &Upstream{
 		name:     name,
 		display:  name,
 		desc:     fmt.Sprintf("MCP upstream: %s", url),
@@ -54,7 +71,11 @@ func New(_ context.Context, name string, url string, connMode core.ConnectionMod
 		connMode: connMode,
 		headers:  config.NormalizeHeaders(headers),
 		resolver: resolver,
-	}, nil
+	}
+	for _, opt := range opts {
+		opt(u)
+	}
+	return u, nil
 }
 
 func newFromClient(name string, client mcpclient.MCPClient, connMode core.ConnectionMode, tools []mcpgo.Tool) *Upstream {
@@ -74,32 +95,15 @@ func (u *Upstream) DisplayName() string                 { return u.display }
 func (u *Upstream) Description() string                 { return u.desc }
 func (u *Upstream) ConnectionMode() core.ConnectionMode { return u.connMode }
 func (u *Upstream) ListOperations() []core.Operation    { return integration.OperationsList(u.cat) }
-func (u *Upstream) Catalog() *catalog.Catalog {
-	if u.cat == nil {
-		return nil
-	}
-	return u.cat.Clone()
-}
-func (u *Upstream) SupportsManualAuth() bool { return true }
-
-func (u *Upstream) SetDisplayName(s string) { u.display = s }
-func (u *Upstream) SetDescription(s string) { u.desc = s }
-func (u *Upstream) SetIconSVG(svg string) {
-	if u.cat != nil {
-		u.cat.IconSVG = svg
-	}
-}
+func (u *Upstream) Catalog() *catalog.Catalog           { return u.decorateCatalog(u.cat) }
+func (u *Upstream) SupportsManualAuth() bool            { return true }
 
 func (u *Upstream) Execute(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
 	return nil, core.ErrMCPOnly
 }
 
 func (u *Upstream) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
-	cat, err := u.discover(ctx, token)
-	if err != nil {
-		return nil, err
-	}
-	return cat, nil
+	return u.discover(ctx, token)
 }
 
 func (u *Upstream) CallTool(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
@@ -194,7 +198,7 @@ func (u *Upstream) connect(ctx context.Context, token string) (mcpclient.MCPClie
 
 func (u *Upstream) discover(ctx context.Context, token string) (*catalog.Catalog, error) {
 	if u.client != nil && u.cat != nil {
-		return u.cat.Clone(), nil
+		return u.decorateCatalog(u.cat), nil
 	}
 
 	client, err := u.connect(ctx, token)
@@ -209,12 +213,10 @@ func (u *Upstream) discover(ctx context.Context, token string) (*catalog.Catalog
 	}
 
 	cat := buildCatalog(u.name, toolsResult.Tools)
-	ops := integration.OperationsList(cat)
-	if err := u.exposure.Validate(ops); err != nil {
+	if err := u.exposure.Validate(integration.OperationsList(cat)); err != nil {
 		return nil, err
 	}
-	cat = u.exposure.ApplyCatalog(cat)
-	return cat, nil
+	return u.decorateCatalog(u.exposure.ApplyCatalog(cat)), nil
 }
 
 func (u *Upstream) resolveInnerName(name string) (string, bool) {
@@ -253,4 +255,25 @@ func buildCatalog(name string, tools []mcpgo.Tool) *catalog.Catalog {
 	}
 
 	return cat
+}
+
+func (u *Upstream) decorateCatalog(cat *catalog.Catalog) *catalog.Catalog {
+	if cat == nil {
+		if u.iconSVG == "" {
+			return nil
+		}
+		return &catalog.Catalog{
+			Name:        u.name,
+			DisplayName: u.display,
+			Description: u.desc,
+			IconSVG:     u.iconSVG,
+		}
+	}
+	decorated := cat.Clone()
+	decorated.DisplayName = u.display
+	decorated.Description = u.desc
+	if u.iconSVG != "" {
+		decorated.IconSVG = u.iconSVG
+	}
+	return decorated
 }

--- a/server/internal/mcpupstream/upstream_test.go
+++ b/server/internal/mcpupstream/upstream_test.go
@@ -297,6 +297,54 @@ func TestUpstream_ProviderMetadata(t *testing.T) {
 	}
 }
 
+func TestUpstream_MetadataOverridesDecorateCatalogs(t *testing.T) {
+	t.Parallel()
+
+	ts := newAuthenticatedHTTPTestServer(t, "Bearer secret-token")
+	t.Cleanup(ts.Close)
+
+	u, err := New(
+		context.Background(),
+		"clickhouse",
+		ts.URL,
+		core.ConnectionModeUser,
+		nil,
+		nil,
+		WithMetadataOverrides("Override", "Override description", "<svg/>"),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	staticCat := u.Catalog()
+	if staticCat == nil {
+		t.Fatal("expected static catalog")
+	}
+	if staticCat.DisplayName != "Override" {
+		t.Fatalf("DisplayName = %q, want %q", staticCat.DisplayName, "Override")
+	}
+	if staticCat.Description != "Override description" {
+		t.Fatalf("Description = %q, want %q", staticCat.Description, "Override description")
+	}
+	if staticCat.IconSVG != "<svg/>" {
+		t.Fatalf("IconSVG = %q, want %q", staticCat.IconSVG, "<svg/>")
+	}
+
+	sessionCat, err := u.CatalogForRequest(context.Background(), "secret-token")
+	if err != nil {
+		t.Fatalf("CatalogForRequest: %v", err)
+	}
+	if sessionCat.DisplayName != "Override" {
+		t.Fatalf("session DisplayName = %q, want %q", sessionCat.DisplayName, "Override")
+	}
+	if sessionCat.Description != "Override description" {
+		t.Fatalf("session Description = %q, want %q", sessionCat.Description, "Override description")
+	}
+	if sessionCat.IconSVG != "<svg/>" {
+		t.Fatalf("session IconSVG = %q, want %q", sessionCat.IconSVG, "<svg/>")
+	}
+}
+
 func TestUpstream_LazyDiscoveryUsesRequestToken(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/operator/lifecycle.go
+++ b/server/internal/operator/lifecycle.go
@@ -708,7 +708,6 @@ func (l *Lifecycle) applyLockedPlugins(configPath string, cfg *config.Config, lo
 			return fmt.Errorf("prepared asset root for ui plugin not found at %s", assetRootPath)
 		}
 		cfg.UI.Plugin.ResolvedAssetRoot = assetRootPath
-		cfg.UI.Plugin.ResolvedManifestPath = manifestPath
 	}
 
 	return nil
@@ -747,7 +746,7 @@ func applyLockedPluginEntry(paths initPaths, lock *Lockfile, kind, name string, 
 
 	resolvePluginIcon(manifest, manifestPath, plugin)
 
-	plugin.ResolvedManifestPath = manifestPath
+	plugin.ResolvedManifest = manifest
 	if kind == "integration" && manifest.IsDeclarativeOnlyProvider() {
 		plugin.IsDeclarative = true
 		return nil
@@ -765,7 +764,7 @@ func applyLockedPluginEntry(paths initPaths, lock *Lockfile, kind, name string, 
 
 	plugin.Command = executablePath
 	plugin.Args = append([]string(nil), args...)
-	plugin.ResolvedManifestPath = manifestPath
+	plugin.ResolvedManifest = manifest
 	return nil
 }
 

--- a/server/internal/operator/lifecycle.go
+++ b/server/internal/operator/lifecycle.go
@@ -764,7 +764,6 @@ func applyLockedPluginEntry(paths initPaths, lock *Lockfile, kind, name string, 
 
 	plugin.Command = executablePath
 	plugin.Args = append([]string(nil), args...)
-	plugin.ResolvedManifest = manifest
 	return nil
 }
 

--- a/server/internal/pluginhost/declarative.go
+++ b/server/internal/pluginhost/declarative.go
@@ -17,6 +17,22 @@ import (
 
 const declarativeHTTPTimeout = 30 * time.Second
 
+type DeclarativeProviderOption func(*DeclarativeProvider)
+
+func WithDeclarativeMetadataOverrides(displayName, description, iconSVG string) DeclarativeProviderOption {
+	return func(p *DeclarativeProvider) {
+		if displayName != "" {
+			p.catalog.DisplayName = displayName
+		}
+		if description != "" {
+			p.catalog.Description = description
+		}
+		if iconSVG != "" {
+			p.catalog.IconSVG = iconSVG
+		}
+	}
+}
+
 type DeclarativeProvider struct {
 	catalog              *catalog.Catalog
 	opsByName            map[string]*catalog.CatalogOperation
@@ -27,7 +43,7 @@ type DeclarativeProvider struct {
 	connectionDefs       map[string]pluginmanifestv1.ProviderConnectionParam
 }
 
-func NewDeclarativeProvider(manifest *pluginmanifestv1.Manifest, httpClient *http.Client) (*DeclarativeProvider, error) {
+func NewDeclarativeProvider(manifest *pluginmanifestv1.Manifest, httpClient *http.Client, opts ...DeclarativeProviderOption) (*DeclarativeProvider, error) {
 	if manifest == nil {
 		return nil, fmt.Errorf("manifest is required")
 	}
@@ -82,6 +98,9 @@ func NewDeclarativeProvider(manifest *pluginmanifestv1.Manifest, httpClient *htt
 		op := &p.catalog.Operations[i]
 		p.opsByName[op.ID] = op
 	}
+	for _, opt := range opts {
+		opt(p)
+	}
 
 	return p, nil
 }
@@ -89,10 +108,6 @@ func NewDeclarativeProvider(manifest *pluginmanifestv1.Manifest, httpClient *htt
 func (p *DeclarativeProvider) Name() string        { return p.catalog.Name }
 func (p *DeclarativeProvider) DisplayName() string { return p.catalog.DisplayName }
 func (p *DeclarativeProvider) Description() string { return p.catalog.Description }
-
-func (p *DeclarativeProvider) SetDisplayName(s string) { p.catalog.DisplayName = s }
-func (p *DeclarativeProvider) SetDescription(s string) { p.catalog.Description = s }
-func (p *DeclarativeProvider) SetIconSVG(svg string)   { p.catalog.IconSVG = svg }
 
 func (p *DeclarativeProvider) Catalog() *catalog.Catalog { return p.catalog.Clone() }
 
@@ -218,14 +233,16 @@ func (p *DeclarativeProvider) ExchangeCode(ctx context.Context, code string) (*c
 	if p.auth == nil || p.auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
 		return nil, fmt.Errorf("provider does not support OAuth")
 	}
-	return nil, fmt.Errorf("declarative OAuth code exchange not yet implemented")
+
+	return nil, fmt.Errorf("declarative provider OAuth exchange not implemented")
 }
 
 func (p *DeclarativeProvider) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
 	if p.auth == nil || p.auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
 		return nil, fmt.Errorf("provider does not support OAuth")
 	}
-	return nil, fmt.Errorf("declarative OAuth token refresh not yet implemented")
+
+	return nil, fmt.Errorf("declarative provider OAuth refresh not implemented")
 }
 
 func (p *DeclarativeProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
@@ -233,11 +250,11 @@ func (p *DeclarativeProvider) ConnectionParamDefs() map[string]core.ConnectionPa
 		return nil
 	}
 	defs := make(map[string]core.ConnectionParamDef, len(p.connectionDefs))
-	for name, def := range p.connectionDefs {
+	for name, cp := range p.connectionDefs {
 		defs[name] = core.ConnectionParamDef{
-			Required:    def.Required,
-			Description: def.Description,
-			From:        def.From,
+			Required:    cp.Required,
+			Description: cp.Description,
+			From:        cp.From,
 		}
 	}
 	return defs

--- a/server/internal/pluginhost/declarative_test.go
+++ b/server/internal/pluginhost/declarative_test.go
@@ -354,7 +354,7 @@ func TestDeclarativeProviderCatalog(t *testing.T) {
 		t.Fatalf("DisplayName = %q, want Test API", cat.DisplayName)
 	}
 	if cat.IconSVG != "" {
-		t.Fatalf("IconSVG = %q, want empty before SetIconSVG", cat.IconSVG)
+		t.Fatalf("IconSVG = %q, want empty", cat.IconSVG)
 	}
 
 	wantIDs := []string{"list_items", "create_item", "get_item", "update_item"}
@@ -377,9 +377,22 @@ func TestDeclarativeProviderCatalog(t *testing.T) {
 	}
 
 	const testSVG = `<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>`
-	p.SetIconSVG(testSVG)
+	p, err = NewDeclarativeProvider(
+		testManifest("http://example.com"),
+		nil,
+		WithDeclarativeMetadataOverrides("Override", "Override description", testSVG),
+	)
+	if err != nil {
+		t.Fatalf("NewDeclarativeProvider with overrides: %v", err)
+	}
 
 	cat = p.Catalog()
+	if cat.DisplayName != "Override" {
+		t.Fatalf("DisplayName = %q, want %q", cat.DisplayName, "Override")
+	}
+	if cat.Description != "Override description" {
+		t.Fatalf("Description = %q, want %q", cat.Description, "Override description")
+	}
 	if cat.IconSVG != testSVG {
 		t.Fatalf("IconSVG = %q, want %q", cat.IconSVG, testSVG)
 	}

--- a/server/internal/pluginhost/declarative_test.go
+++ b/server/internal/pluginhost/declarative_test.go
@@ -397,7 +397,7 @@ func TestDeclarativeProviderCatalog(t *testing.T) {
 		t.Fatalf("IconSVG = %q, want %q", cat.IconSVG, testSVG)
 	}
 	if len(cat.Operations) != len(wantIDs) {
-		t.Fatalf("got %d operations after SetIconSVG, want %d", len(cat.Operations), len(wantIDs))
+		t.Fatalf("got %d operations after metadata overrides, want %d", len(cat.Operations), len(wantIDs))
 	}
 }
 

--- a/server/internal/pluginhost/process.go
+++ b/server/internal/pluginhost/process.go
@@ -32,6 +32,9 @@ type ExecConfig struct {
 	Args         []string
 	Env          map[string]string
 	Name         string
+	DisplayName  string
+	Description  string
+	IconSVG      string
 	Config       map[string]any
 	AllowedHosts []string
 	HostBinary   string
@@ -83,7 +86,14 @@ func NewExecutableProvider(ctx context.Context, cfg ExecConfig) (core.Provider, 
 	}
 
 	client := proto.NewProviderPluginClient(proc.conn)
-	prov, err := NewRemoteProvider(ctx, client, cfg.Name, cfg.Config, WithCloser(proc))
+	prov, err := NewRemoteProvider(
+		ctx,
+		client,
+		cfg.Name,
+		cfg.Config,
+		WithCloser(proc),
+		WithMetadataOverrides(cfg.DisplayName, cfg.Description, cfg.IconSVG),
+	)
 	if err != nil {
 		_ = proc.Close()
 		return nil, err

--- a/server/internal/pluginhost/provider_client.go
+++ b/server/internal/pluginhost/provider_client.go
@@ -35,6 +35,20 @@ func WithCloser(c io.Closer) RemoteProviderOption {
 	return func(b *remoteProviderBase) { b.closer = c }
 }
 
+func WithMetadataOverrides(displayName, description, iconSVG string) RemoteProviderOption {
+	return func(b *remoteProviderBase) {
+		if displayName != "" {
+			b.displayOver = displayName
+		}
+		if description != "" {
+			b.descOver = description
+		}
+		if iconSVG != "" {
+			b.iconSVG = iconSVG
+		}
+	}
+}
+
 func (p *remoteProviderBase) Close() error {
 	if p.closer != nil {
 		return p.closer.Close()
@@ -101,9 +115,6 @@ func (p *remoteProviderBase) Description() string {
 	return p.metadata.GetDescription()
 }
 
-func (p *remoteProviderBase) SetDisplayName(s string) { p.displayOver = s }
-func (p *remoteProviderBase) SetDescription(s string) { p.descOver = s }
-
 func (p *remoteProviderBase) ConnectionMode() core.ConnectionMode {
 	return protoConnectionModeToCore(p.metadata.GetConnectionMode())
 }
@@ -136,31 +147,14 @@ func (p *remoteProviderBase) SupportsManualAuth() bool {
 	return slices.Contains(p.metadata.GetAuthTypes(), "manual")
 }
 
-func (p *remoteProviderBase) SetIconSVG(svg string) { p.iconSVG = svg }
-
 func (p *remoteProviderBase) Catalog() *catalog.Catalog {
 	if p.catalog == nil {
 		if p.iconSVG == "" {
 			return nil
 		}
-		return &catalog.Catalog{
-			Name:        p.metadata.GetName(),
-			DisplayName: p.DisplayName(),
-			Description: p.Description(),
-			IconSVG:     p.iconSVG,
-		}
+		return p.decorateCatalog(&catalog.Catalog{Name: p.metadata.GetName()})
 	}
-	cat := p.catalog.Clone()
-	if p.displayOver != "" {
-		cat.DisplayName = p.displayOver
-	}
-	if p.descOver != "" {
-		cat.Description = p.descOver
-	}
-	if cat.IconSVG == "" && p.iconSVG != "" {
-		cat.IconSVG = p.iconSVG
-	}
-	return cat
+	return p.decorateCatalog(p.catalog)
 }
 
 func (p *remoteProviderBase) ConnectionParamDefs() map[string]core.ConnectionParamDef {
@@ -179,7 +173,11 @@ func (p *remoteProviderBase) sessionCatalog(ctx context.Context, token string) (
 	if err != nil {
 		return nil, err
 	}
-	return catalogFromJSON(resp.GetCatalogJson())
+	cat, err := catalogFromJSON(resp.GetCatalogJson())
+	if err != nil {
+		return nil, err
+	}
+	return p.decorateCatalog(cat), nil
 }
 
 type remoteProviderWithSessionCatalog struct{ *remoteProviderBase }
@@ -300,6 +298,23 @@ func catalogParametersFromCore(params []core.Parameter) []catalog.CatalogParamet
 		})
 	}
 	return out
+}
+
+func (p *remoteProviderBase) decorateCatalog(cat *catalog.Catalog) *catalog.Catalog {
+	if cat == nil {
+		return nil
+	}
+	decorated := cat.Clone()
+	if decorated.DisplayName == "" || p.displayOver != "" {
+		decorated.DisplayName = p.DisplayName()
+	}
+	if decorated.Description == "" || p.descOver != "" {
+		decorated.Description = p.Description()
+	}
+	if p.iconSVG != "" {
+		decorated.IconSVG = p.iconSVG
+	}
+	return decorated
 }
 
 func callStartProvider(ctx context.Context, client proto.ProviderPluginClient, name string, config map[string]any) error {

--- a/server/internal/pluginhost/provider_test.go
+++ b/server/internal/pluginhost/provider_test.go
@@ -214,21 +214,19 @@ func TestRemoteProviderIconSVG(t *testing.T) {
 		}
 	})
 
-	t.Run("SetIconSVG injects icon when no static catalog", func(t *testing.T) {
+	t.Run("metadata override injects icon when no static catalog", func(t *testing.T) {
 		t.Parallel()
 
 		client := newProviderPluginClient(t, sdkgestalt.NewProviderServer(&manualOnlySDKProvider{}))
-		prov, err := NewRemoteProvider(context.Background(), client, "manual-only", nil)
+		prov, err := NewRemoteProvider(context.Background(), client, "manual-only", nil, WithMetadataOverrides("", "", testSVG))
 		if err != nil {
 			t.Fatalf("NewRemoteProvider: %v", err)
 		}
-		base := prov.(*remoteProviderBase)
-		base.SetIconSVG(testSVG)
 
 		cp := prov.(core.CatalogProvider)
 		cat := cp.Catalog()
 		if cat == nil {
-			t.Fatal("expected non-nil catalog after SetIconSVG")
+			t.Fatal("expected non-nil catalog after metadata override")
 		}
 		if cat.IconSVG != testSVG {
 			t.Fatalf("IconSVG = %q, want %q", cat.IconSVG, testSVG)
@@ -239,12 +237,10 @@ func TestRemoteProviderIconSVG(t *testing.T) {
 		t.Parallel()
 
 		client := newProviderPluginClient(t, sdkgestalt.NewProviderServer(&opsOnlySDKProvider{}))
-		prov, err := NewRemoteProvider(context.Background(), client, "roundtrip", nil)
+		prov, err := NewRemoteProvider(context.Background(), client, "roundtrip", nil, WithMetadataOverrides("", "", testSVG))
 		if err != nil {
 			t.Fatalf("NewRemoteProvider: %v", err)
 		}
-		base := prov.(*remoteProviderBase)
-		base.SetIconSVG(testSVG)
 
 		cp := prov.(core.CatalogProvider)
 		cat := cp.Catalog()
@@ -268,47 +264,68 @@ func TestRemoteProviderIconSVG(t *testing.T) {
 		}
 	})
 
-	t.Run("SetIconSVG fills empty icon on existing catalog", func(t *testing.T) {
+	t.Run("metadata override fills empty icon on existing catalog", func(t *testing.T) {
 		t.Parallel()
 
 		client := newProviderPluginClient(t, NewProviderServer(&roundTripProvider{}))
-		prov, err := NewRemoteProvider(context.Background(), client, "roundtrip", nil)
+		prov, err := NewRemoteProvider(context.Background(), client, "roundtrip", nil, WithMetadataOverrides("", "", testSVG))
 		if err != nil {
 			t.Fatalf("NewRemoteProvider: %v", err)
 		}
-		cp := prov.(core.CatalogProvider)
-		if cp.Catalog().IconSVG != "" {
-			t.Fatal("expected empty icon before SetIconSVG")
-		}
-
-		base := prov.(*remoteProviderWithSessionCatalog).remoteProviderBase
-		base.SetIconSVG(testSVG)
-
-		cat := cp.Catalog()
+		cat := prov.(core.CatalogProvider).Catalog()
 		if cat.IconSVG != testSVG {
 			t.Fatalf("IconSVG = %q, want %q", cat.IconSVG, testSVG)
 		}
 	})
 
-	t.Run("existing catalog icon is preserved", func(t *testing.T) {
+	t.Run("metadata override replaces existing catalog icon", func(t *testing.T) {
 		t.Parallel()
 
 		const existingIcon = `<svg><circle/></svg>`
 		client := newProviderPluginClient(t, NewProviderServer(&roundTripProvider{}))
-		prov, err := NewRemoteProvider(context.Background(), client, "roundtrip", nil)
+		prov, err := NewRemoteProvider(context.Background(), client, "roundtrip", nil, WithMetadataOverrides("", "", testSVG))
 		if err != nil {
 			t.Fatalf("NewRemoteProvider: %v", err)
 		}
 		base := prov.(*remoteProviderWithSessionCatalog).remoteProviderBase
 		base.catalog.IconSVG = existingIcon
-		base.SetIconSVG(testSVG)
 
 		cp := prov.(core.CatalogProvider)
 		cat := cp.Catalog()
-		if cat.IconSVG != existingIcon {
-			t.Fatalf("IconSVG = %q, want preserved %q", cat.IconSVG, existingIcon)
+		if cat.IconSVG != testSVG {
+			t.Fatalf("IconSVG = %q, want override %q", cat.IconSVG, testSVG)
 		}
 	})
+}
+
+func TestRemoteProviderMetadataOverridesApplyToSessionCatalog(t *testing.T) {
+	t.Parallel()
+
+	client := newProviderPluginClient(t, NewProviderServer(&roundTripProvider{}))
+	prov, err := NewRemoteProvider(
+		context.Background(),
+		client,
+		"roundtrip",
+		nil,
+		WithMetadataOverrides("Override", "Override description", "<svg/>"),
+	)
+	if err != nil {
+		t.Fatalf("NewRemoteProvider: %v", err)
+	}
+
+	cat, err := prov.(core.SessionCatalogProvider).CatalogForRequest(context.Background(), "token-123")
+	if err != nil {
+		t.Fatalf("CatalogForRequest: %v", err)
+	}
+	if cat.DisplayName != "Override" {
+		t.Fatalf("DisplayName = %q, want %q", cat.DisplayName, "Override")
+	}
+	if cat.Description != "Override description" {
+		t.Fatalf("Description = %q, want %q", cat.Description, "Override description")
+	}
+	if cat.IconSVG != "<svg/>" {
+		t.Fatalf("IconSVG = %q, want %q", cat.IconSVG, "<svg/>")
+	}
 }
 
 func TestRemoteProviderManualAuthOnly(t *testing.T) {

--- a/server/internal/provider/build.go
+++ b/server/internal/provider/build.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -35,9 +34,7 @@ func WithEgressResolver(r *egress.Resolver) BuildOption {
 }
 
 // Build constructs a provider from a spec Definition and a ConnectionDef that
-// owns auth configuration. Display metadata (display_name, description, icon)
-// should be applied to the Definition before calling Build via
-// ApplyDisplayOverrides.
+// owns auth configuration.
 func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (core.Provider, error) {
 	var bo buildOptions
 	for _, opt := range opts {
@@ -204,21 +201,6 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 
 	base.SetCatalog(cat)
 	return base, nil
-}
-
-// ApplyDisplayOverrides merges display metadata from an IntegrationDef into a
-// provider Definition. Call this before Build to set display_name, description,
-// and icon from the integration config.
-func ApplyDisplayOverrides(def *Definition, intg config.IntegrationDef) {
-	setStr(&def.DisplayName, intg.DisplayName)
-	setStr(&def.Description, intg.Description)
-	if intg.IconFile != "" {
-		if svg, err := ReadIconFile(intg.IconFile); err != nil {
-			slog.Warn("could not read icon_file", "path", intg.IconFile, "error", err)
-		} else {
-			def.IconSVG = svg
-		}
-	}
 }
 
 func ReadIconFile(path string) (string, error) {

--- a/server/internal/provider/build_test.go
+++ b/server/internal/provider/build_test.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -281,71 +279,6 @@ func TestBuildExecuteRoutesQueryParamsUsingCatalogMetadata(t *testing.T) {
 	}
 	if _, ok := body["page_size"]; ok {
 		t.Fatalf("body should not contain page_size when parameter is routed to query")
-	}
-}
-
-func TestBuildAppliesIconFile(t *testing.T) {
-	t.Parallel()
-
-	const svg = `<svg viewBox="0 0 24 24"><rect width="24" height="24"/></svg>`
-	iconPath := filepath.Join(t.TempDir(), "test.svg")
-	if err := os.WriteFile(iconPath, []byte(svg+"\n"), 0644); err != nil {
-		t.Fatalf("writing icon file: %v", err)
-	}
-
-	def := &Definition{
-		Provider:    "fileicon",
-		DisplayName: "File Icon Test",
-		BaseURL:     "https://api.example.com",
-		Auth:        AuthDef{Type: "manual"},
-		Operations: map[string]OperationDef{
-			"op": {Description: "An op", Method: http.MethodGet, Path: "/op"},
-		},
-	}
-
-	ApplyDisplayOverrides(def, config.IntegrationDef{IconFile: iconPath})
-	prov, err := Build(def, config.ConnectionDef{})
-	if err != nil {
-		t.Fatalf("Build: %v", err)
-	}
-
-	cp, ok := prov.(core.CatalogProvider)
-	if !ok {
-		t.Fatal("expected CatalogProvider")
-	}
-	cat := cp.Catalog()
-	if cat == nil {
-		t.Fatal("expected non-nil Catalog")
-	}
-	if cat.IconSVG != svg {
-		t.Fatalf("expected icon from file, got %q", cat.IconSVG)
-	}
-}
-
-func TestBuildIconFileMissing(t *testing.T) {
-	t.Parallel()
-
-	def := &Definition{
-		Provider:    "badicon",
-		DisplayName: "Bad Icon Test",
-		BaseURL:     "https://api.example.com",
-		Auth:        AuthDef{Type: "manual"},
-		Operations: map[string]OperationDef{
-			"op": {Description: "An op", Method: http.MethodGet, Path: "/op"},
-		},
-	}
-
-	ApplyDisplayOverrides(def, config.IntegrationDef{IconFile: "/nonexistent/icon.svg"})
-	prov, err := Build(def, config.ConnectionDef{})
-	if err != nil {
-		t.Fatalf("Build should succeed with missing icon: %v", err)
-	}
-	cp, ok := prov.(core.CatalogProvider)
-	if !ok {
-		t.Fatal("expected CatalogProvider")
-	}
-	if cat := cp.Catalog(); cat != nil && cat.IconSVG != "" {
-		t.Errorf("expected empty IconSVG, got %q", cat.IconSVG)
 	}
 }
 


### PR DESCRIPTION
## Summary
- thread integration metadata through provider construction instead of patching providers after build
- make lazy MCP upstream catalogs consistently expose display metadata before and after discovery
- remove dead setter-based metadata plumbing and the unused spec-definition metadata helper
- reuse bootstrap manifest reads through a single helper instead of re-reading ad hoc in multiple spots

## Testing
- `go test ./internal/server ./internal/mcp ./internal/bootstrap/... ./internal/pluginhost ./internal/mcpupstream ./internal/composite ./core/integration ./internal/provider`
- `golangci-lint run ./internal/server ./internal/mcp ./internal/bootstrap/... ./internal/pluginhost ./internal/mcpupstream ./internal/composite ./core/integration ./internal/provider`