### PR TITLE
Add packaged Notion plugin with OpenAPI and MCP support

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -76,22 +76,24 @@ jobs:
       PLUGIN_VERSION: ${{ needs.prepare.outputs.plugin-version }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: server/go.mod
+          cache-dependency-path: server/go.sum
+      - name: Build gestaltd
+        run: cd server && go build -o ../gestaltd ./cmd/gestaltd
       - name: Package
         run: |
-          ASSET="gestalt-plugin-${PLUGIN_NAME}_v${PLUGIN_VERSION}"
-          cd "plugins/${PLUGIN_NAME}"
-          TAR_ARGS=(plugin.yaml)
-          if [ -d assets ]; then
-            TAR_ARGS+=(assets/)
-          fi
-          tar -czvf "${ASSET}.tar.gz" "${TAR_ARGS[@]}"
-          shasum -a 256 "${ASSET}.tar.gz" > "${ASSET}.tar.gz.sha256"
+          ASSET="gestalt-plugin-${PLUGIN_NAME}_v${PLUGIN_VERSION}.tar.gz"
+          mkdir -p dist
+          ./gestaltd plugin package --input "plugins/${PLUGIN_NAME}" --output "dist/${ASSET}"
+          shasum -a 256 "dist/${ASSET}" > "dist/${ASSET}.sha256"
       - uses: actions/upload-artifact@v4
         with:
           name: gestalt-plugin-${{ env.PLUGIN_NAME }}
           path: |
-            plugins/${{ env.PLUGIN_NAME }}/gestalt-plugin-*.tar.gz
-            plugins/${{ env.PLUGIN_NAME }}/gestalt-plugin-*.sha256
+            dist/gestalt-plugin-*.tar.gz
+            dist/gestalt-plugin-*.sha256
           if-no-files-found: error
 
   release-compiled:

--- a/plugins/notion/assets/icon.svg
+++ b/plugins/notion/assets/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect x="8" y="8" width="48" height="48" rx="6" fill="#111111"/>
+  <path d="M22 18.5 39.5 20.5V46L26 43.5V28.5L38 43V24L42 24.5V50L25 46.5V31.5L38 47V43.5L22 20.5V18.5Z" fill="#ffffff"/>
+</svg>

--- a/plugins/notion/openapi.yaml
+++ b/plugins/notion/openapi.yaml
@@ -1,0 +1,711 @@
+openapi: 3.0.3
+info:
+  title: Notion REST API
+  version: 2026-03-11
+  description: Curated Notion REST operations from the official Notion API reference.
+servers:
+  - url: https://api.notion.com
+security:
+  - bearerAuth: []
+paths:
+  /v1/search:
+    post:
+      operationId: api_search
+      summary: Search pages and data sources
+      description: Search across pages and data sources that the integration can access.
+      tags: [Search]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+
+  /v1/pages:
+    post:
+      operationId: api_create_page
+      summary: Create a page
+      description: Create a new page in a page, database, or data source parent.
+      tags: [Pages]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePageRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+
+  /v1/pages/{page_id}:
+    get:
+      operationId: api_retrieve_page
+      summary: Retrieve a page
+      description: Retrieve a page object by page ID.
+      tags: [Pages]
+      parameters:
+        - $ref: '#/components/parameters/PageID'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+    patch:
+      operationId: api_update_page
+      summary: Update a page
+      description: Update page properties or archive state.
+      tags: [Pages]
+      parameters:
+        - $ref: '#/components/parameters/PageID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdatePageRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+
+  /v1/pages/{page_id}/properties/{property_id}:
+    get:
+      operationId: api_retrieve_page_property_item
+      summary: Retrieve a page property item
+      description: Retrieve a single page property value, including paginated property items.
+      tags: [Pages]
+      parameters:
+        - $ref: '#/components/parameters/PageID'
+        - $ref: '#/components/parameters/PropertyID'
+        - $ref: '#/components/parameters/StartCursor'
+        - $ref: '#/components/parameters/PageSize'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+
+  /v1/pages/{page_id}/markdown:
+    get:
+      operationId: api_retrieve_page_markdown
+      summary: Retrieve a page as markdown
+      description: Retrieve enhanced Markdown for a page.
+      tags: [Pages]
+      parameters:
+        - $ref: '#/components/parameters/PageID'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+    patch:
+      operationId: api_update_page_markdown
+      summary: Update a page's content as markdown
+      description: Insert or replace page content using Notion's enhanced Markdown commands.
+      tags: [Pages]
+      parameters:
+        - $ref: '#/components/parameters/PageID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PageMarkdownUpdateRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+
+  /v1/blocks/{block_id}:
+    get:
+      operationId: api_retrieve_block
+      summary: Retrieve a block
+      description: Retrieve a block object by block ID.
+      tags: [Blocks]
+      parameters:
+        - $ref: '#/components/parameters/BlockID'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+    patch:
+      operationId: api_update_block
+      summary: Update a block
+      description: Update a supported block type or its archived state.
+      tags: [Blocks]
+      parameters:
+        - $ref: '#/components/parameters/BlockID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateBlockRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+    delete:
+      operationId: api_delete_block
+      summary: Delete a block
+      description: Archive a block by block ID.
+      tags: [Blocks]
+      parameters:
+        - $ref: '#/components/parameters/BlockID'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+
+  /v1/blocks/{block_id}/children:
+    get:
+      operationId: api_retrieve_block_children
+      summary: Retrieve block children
+      description: Retrieve the child blocks for a block or page.
+      tags: [Blocks]
+      parameters:
+        - $ref: '#/components/parameters/BlockID'
+        - $ref: '#/components/parameters/StartCursor'
+        - $ref: '#/components/parameters/PageSize'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+    patch:
+      operationId: api_append_block_children
+      summary: Append block children
+      description: Append new child blocks after an existing block or at the end of the children list.
+      tags: [Blocks]
+      parameters:
+        - $ref: '#/components/parameters/BlockID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AppendBlockChildrenRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+
+  /v1/comments:
+    get:
+      operationId: api_retrieve_comments
+      summary: Retrieve comments
+      description: Retrieve comments, optionally filtered to a specific block or page discussion.
+      tags: [Comments]
+      parameters:
+        - $ref: '#/components/parameters/CommentBlockID'
+        - $ref: '#/components/parameters/StartCursor'
+        - $ref: '#/components/parameters/PageSize'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+    post:
+      operationId: api_create_comment
+      summary: Create a comment
+      description: Create a comment on a page, block, or existing discussion thread.
+      tags: [Comments]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCommentRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+
+  /v1/databases:
+    post:
+      operationId: api_create_database
+      summary: Create a database
+      description: Create a database and its initial data source.
+      tags: [Databases]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDatabaseRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+
+  /v1/databases/{database_id}:
+    get:
+      operationId: api_retrieve_database
+      summary: Retrieve a database
+      description: Retrieve a database object by database ID.
+      tags: [Databases]
+      parameters:
+        - $ref: '#/components/parameters/DatabaseID'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+    patch:
+      operationId: api_update_database
+      summary: Update a database
+      description: Update database title, description, cover, or trash state.
+      tags: [Databases]
+      parameters:
+        - $ref: '#/components/parameters/DatabaseID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateDatabaseRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+
+  /v1/data_sources:
+    post:
+      operationId: api_create_data_source
+      summary: Create a data source
+      description: Create an additional data source under an existing database.
+      tags: [Data sources]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDataSourceRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+
+  /v1/data_sources/{data_source_id}:
+    get:
+      operationId: api_retrieve_data_source
+      summary: Retrieve a data source
+      description: Retrieve a data source object by data source ID.
+      tags: [Data sources]
+      parameters:
+        - $ref: '#/components/parameters/DataSourceID'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+    patch:
+      operationId: api_update_data_source
+      summary: Update a data source
+      description: Update a data source schema, name, description, or icon.
+      tags: [Data sources]
+      parameters:
+        - $ref: '#/components/parameters/DataSourceID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateDataSourceRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+
+  /v1/data_sources/{data_source_id}/query:
+    post:
+      operationId: api_query_data_source
+      summary: Query a data source
+      description: Query rows in a data source with filter, sort, and pagination options.
+      tags: [Data sources]
+      parameters:
+        - $ref: '#/components/parameters/DataSourceID'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QueryDataSourceRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+
+  /v1/data_sources/{data_source_id}/templates:
+    get:
+      operationId: api_list_data_source_templates
+      summary: List data source templates
+      description: List templates available for a data source.
+      tags: [Data sources]
+      parameters:
+        - $ref: '#/components/parameters/DataSourceID'
+        - $ref: '#/components/parameters/TemplateName'
+        - $ref: '#/components/parameters/StartCursor'
+        - $ref: '#/components/parameters/PageSize'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+
+  /v1/users:
+    get:
+      operationId: api_list_users
+      summary: List all users
+      description: List users visible to the authenticated integration.
+      tags: [Users]
+      parameters:
+        - $ref: '#/components/parameters/StartCursor'
+        - $ref: '#/components/parameters/PageSize'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+
+  /v1/users/me:
+    get:
+      operationId: api_get_self
+      summary: Retrieve your token's bot user
+      description: Retrieve the bot user associated with the current token.
+      tags: [Users]
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+
+  /v1/users/{user_id}:
+    get:
+      operationId: api_retrieve_user
+      summary: Retrieve a user
+      description: Retrieve a user by user ID.
+      tags: [Users]
+      parameters:
+        - $ref: '#/components/parameters/UserID'
+      responses:
+        '200':
+          $ref: '#/components/responses/GenericObject'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+
+  parameters:
+    PageID:
+      name: page_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: ID of a Notion page.
+    BlockID:
+      name: block_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: ID of a Notion block.
+    DatabaseID:
+      name: database_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: ID of a Notion database.
+    DataSourceID:
+      name: data_source_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: ID of a Notion data source.
+    PropertyID:
+      name: property_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: ID of a page property.
+    UserID:
+      name: user_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: ID of a Notion user.
+    StartCursor:
+      name: start_cursor
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Cursor used to fetch the next page of results.
+    PageSize:
+      name: page_size
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+      description: Maximum number of results to return.
+    CommentBlockID:
+      name: block_id
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Restrict comment results to a specific block or page discussion.
+    TemplateName:
+      name: name
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Filter templates by case-insensitive substring match on name.
+
+  responses:
+    GenericObject:
+      description: Successful response.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GenericObject'
+
+  schemas:
+    GenericObject:
+      type: object
+      additionalProperties: true
+
+    RichTextArray:
+      type: array
+      items:
+        type: object
+        additionalProperties: true
+
+    BlockArray:
+      type: array
+      items:
+        type: object
+        additionalProperties: true
+
+    SearchRequest:
+      type: object
+      additionalProperties: true
+      properties:
+        query:
+          type: string
+          description: Free-text search query.
+        sort:
+          type: object
+          additionalProperties: true
+          description: Sort descriptor for search results.
+        filter:
+          type: object
+          additionalProperties: true
+          description: Filter descriptor for object or property constraints.
+        start_cursor:
+          type: string
+        page_size:
+          type: integer
+          minimum: 1
+          maximum: 100
+
+    CreatePageRequest:
+      type: object
+      additionalProperties: true
+      required: [parent]
+      properties:
+        parent:
+          type: object
+          additionalProperties: true
+          description: Page, database, or data source parent descriptor.
+        properties:
+          type: object
+          additionalProperties: true
+          description: Page property values.
+        children:
+          $ref: '#/components/schemas/BlockArray'
+        icon:
+          type: object
+          additionalProperties: true
+        cover:
+          type: object
+          additionalProperties: true
+        content:
+          type: string
+          description: Enhanced Markdown content to create in the page.
+        template:
+          type: object
+          additionalProperties: true
+          description: Template configuration when creating from a data source template.
+
+    UpdatePageRequest:
+      type: object
+      additionalProperties: true
+      properties:
+        properties:
+          type: object
+          additionalProperties: true
+          description: Updated page property values.
+        archived:
+          type: boolean
+        in_trash:
+          type: boolean
+        icon:
+          type: object
+          additionalProperties: true
+        cover:
+          type: object
+          additionalProperties: true
+        is_locked:
+          type: boolean
+        erase_content:
+          type: boolean
+          description: Remove page content before applying other changes.
+
+    PageMarkdownUpdateRequest:
+      type: object
+      additionalProperties: true
+      required: [type]
+      properties:
+        type:
+          type: string
+          enum:
+            - update_content
+            - replace_content
+            - insert_content
+            - replace_content_range
+          description: Markdown update command type.
+        update_content:
+          type: object
+          additionalProperties: true
+          description: Search-and-replace operations.
+        replace_content:
+          type: object
+          additionalProperties: true
+          description: Full-content replacement payload.
+        insert_content:
+          type: object
+          additionalProperties: true
+          description: Legacy insert payload.
+        replace_content_range:
+          type: object
+          additionalProperties: true
+          description: Legacy targeted replacement payload.
+
+    AppendBlockChildrenRequest:
+      type: object
+      additionalProperties: true
+      required: [children]
+      properties:
+        children:
+          $ref: '#/components/schemas/BlockArray'
+        after:
+          type: string
+          description: Existing child block ID after which new children should be inserted.
+
+    UpdateBlockRequest:
+      type: object
+      additionalProperties: true
+      properties:
+        archived:
+          type: boolean
+        in_trash:
+          type: boolean
+        payload:
+          type: object
+          additionalProperties: true
+          description: Block-type payload keyed by the block type, for example paragraph or heading_1.
+
+    CreateCommentRequest:
+      type: object
+      additionalProperties: true
+      properties:
+        parent:
+          type: object
+          additionalProperties: true
+          description: Page or block parent.
+        discussion_id:
+          type: string
+          description: Existing discussion thread ID.
+        rich_text:
+          $ref: '#/components/schemas/RichTextArray'
+
+    CreateDatabaseRequest:
+      type: object
+      additionalProperties: true
+      required: [parent]
+      properties:
+        parent:
+          type: object
+          additionalProperties: true
+          description: Parent page or workspace descriptor.
+        title:
+          $ref: '#/components/schemas/RichTextArray'
+        description:
+          $ref: '#/components/schemas/RichTextArray'
+        icon:
+          type: object
+          additionalProperties: true
+        cover:
+          type: object
+          additionalProperties: true
+        initial_data_source:
+          type: object
+          additionalProperties: true
+          description: Initial data source schema and default view settings.
+
+    UpdateDatabaseRequest:
+      type: object
+      additionalProperties: true
+      properties:
+        title:
+          $ref: '#/components/schemas/RichTextArray'
+        description:
+          $ref: '#/components/schemas/RichTextArray'
+        icon:
+          type: object
+          additionalProperties: true
+        cover:
+          type: object
+          additionalProperties: true
+        in_trash:
+          type: boolean
+
+    CreateDataSourceRequest:
+      type: object
+      additionalProperties: true
+      required: [parent]
+      properties:
+        parent:
+          type: object
+          additionalProperties: true
+          description: Parent database descriptor.
+        name:
+          type: string
+        description:
+          $ref: '#/components/schemas/RichTextArray'
+        icon:
+          type: object
+          additionalProperties: true
+        properties:
+          type: object
+          additionalProperties: true
+
+    UpdateDataSourceRequest:
+      type: object
+      additionalProperties: true
+      properties:
+        name:
+          type: string
+        description:
+          $ref: '#/components/schemas/RichTextArray'
+        icon:
+          type: object
+          additionalProperties: true
+        properties:
+          type: object
+          additionalProperties: true
+
+    QueryDataSourceRequest:
+      type: object
+      additionalProperties: true
+      properties:
+        filter:
+          type: object
+          additionalProperties: true
+        filter_properties:
+          type: array
+          items:
+            type: string
+        sorts:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        start_cursor:
+          type: string
+        page_size:
+          type: integer
+          minimum: 1
+          maximum: 100

--- a/plugins/notion/plugin.yaml
+++ b/plugins/notion/plugin.yaml
@@ -1,0 +1,18 @@
+source: github.com/valon-technologies/gestalt/notion
+version: 0.0.1-alpha.1
+display_name: Notion
+description: Current Notion REST operations plus the official Notion MCP tool surface.
+icon_file: assets/icon.svg
+kinds:
+  - provider
+provider:
+  openapi: openapi.yaml
+  mcp_url: https://mcp.notion.com/mcp
+  mcp_connection: MCP
+  headers:
+    Notion-Version: "2026-03-11"
+  connections:
+    MCP:
+      mode: user
+      auth:
+        type: mcp_oauth

--- a/server/cmd/gestaltd/plugin_test.go
+++ b/server/cmd/gestaltd/plugin_test.go
@@ -136,6 +136,9 @@ func TestRun_PluginPackageCreatesDirectory(t *testing.T) {
 	if _, err := os.Stat(manifestPath); err != nil {
 		t.Fatalf("expected manifest in output directory: %v", err)
 	}
+	if _, err := os.Stat(filepath.Join(outPath, "openapi.yaml")); err != nil {
+		t.Fatalf("expected support file in output directory: %v", err)
+	}
 	artifactPath := filepath.Join(outPath, "artifacts", runtime.GOOS, runtime.GOARCH, "provider")
 	data, err := os.ReadFile(artifactPath)
 	if err != nil {
@@ -159,6 +162,22 @@ func TestRun_PluginPackageRejectsOutputInsideInput(t *testing.T) {
 	err := run([]string{"plugin", "package", "--input", src, "--output", outPath})
 	if err == nil {
 		t.Fatal("expected error when output is inside input")
+	}
+	if !strings.Contains(err.Error(), "must not be inside source") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_PluginPackageRejectsArchiveOutputInsideInput(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := newPluginPackageFixture(t, dir)
+	outPath := filepath.Join(src, "testowner-provider-0.1.0.tar.gz")
+
+	err := run([]string{"plugin", "package", "--input", src, "--output", outPath})
+	if err == nil {
+		t.Fatal("expected error when archive output is inside input")
 	}
 	if !strings.Contains(err.Error(), "must not be inside source") {
 		t.Fatalf("unexpected error: %v", err)
@@ -789,6 +808,9 @@ func newPluginPackageFixture(t *testing.T, dir string) string {
 	}
 	if err := os.WriteFile(filepath.Join(src, "schemas", "config.schema.json"), []byte(`{"type":"object"}`), 0644); err != nil {
 		t.Fatalf("WriteFile(schema): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "openapi.yaml"), []byte("openapi: 3.0.0\ninfo:\n  title: Test\n  version: 1.0.0\npaths: {}\n"), 0644); err != nil {
+		t.Fatalf("WriteFile(openapi.yaml): %v", err)
 	}
 
 	manifest := `{

--- a/server/internal/bootstrap/bootstrap.go
+++ b/server/internal/bootstrap/bootstrap.go
@@ -990,24 +990,7 @@ func buildManifestProvider(ctx context.Context, name string, intg config.Integra
 		return newProviderBuildResult(name, intg, manifest, pluginConfig, prov, deps, regStore)
 	}
 
-	resolved, ok := resolveConfiguredSpecSurface(intg.Plugin, manifest.Provider)
-	if !ok {
-		return nil, fmt.Errorf("build spec-loaded provider %q: no spec URL", name)
-	}
-	prov, err := buildConfiguredSpecProvider(ctx, name, resolved, meta, specProviderConfig{
-		plugin:               intg.Plugin,
-		manifestProvider:     manifest.Provider,
-		allowedOperations:    allowedOperations,
-		baseURL:              manifest.Provider.BaseURL,
-		applyResponseMapping: true,
-		providerBuildOptions: func(conn config.ConnectionDef) []provider.BuildOption {
-			return mcpOAuthBuildOpts(conn, manifest.Provider, regStore, deps)
-		},
-	}, deps)
-	if err != nil {
-		return nil, fmt.Errorf("build spec-loaded provider %q: %w", name, err)
-	}
-	return newProviderBuildResult(name, intg, manifest, pluginConfig, prov, deps, regStore)
+	return buildSpecLoadedProvider(ctx, name, intg, manifest, pluginConfig, meta, deps, regStore, allowedOperations)
 }
 
 func mcpOAuthBuildOpts(conn config.ConnectionDef, mp *pluginmanifestv1.Provider, regStore *lazyRegStore, deps Deps) []provider.BuildOption {
@@ -1017,7 +1000,92 @@ func mcpOAuthBuildOpts(conn config.ConnectionDef, mp *pluginmanifestv1.Provider,
 	handler := buildMCPOAuthHandler(conn, mp.MCPURL, regStore.get(), deps)
 	return []provider.BuildOption{provider.WithAuthHandler(handler)}
 }
+func buildSpecLoadedProvider(ctx context.Context, name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, pluginConfig map[string]any, meta providerMetadata, deps Deps, regStore *lazyRegStore, allowedOperations map[string]*config.OperationOverride) (*ProviderBuildResult, error) {
+	mp := manifest.Provider
+	apiResolved, hasAPI := resolveConfiguredAPISurface(intg.Plugin, mp)
+	mcpResolved, hasMCP := resolveSpecSurface(intg.Plugin, mp, specSurfaceMCP)
+	if !hasAPI && !hasMCP {
+		return nil, fmt.Errorf("build spec-loaded provider %q: no spec URL", name)
+	}
 
+	buildSpec := func(resolved resolvedSpecSurface, allowed map[string]*config.OperationOverride) (core.Provider, error) {
+		return buildConfiguredSpecProvider(ctx, name, resolved, meta, specProviderConfig{
+			plugin:               intg.Plugin,
+			manifestProvider:     mp,
+			allowedOperations:    allowed,
+			baseURL:              mp.BaseURL,
+			applyResponseMapping: true,
+			providerBuildOptions: func(conn config.ConnectionDef) []provider.BuildOption {
+				return mcpOAuthBuildOpts(conn, mp, regStore, deps)
+			},
+		}, deps)
+	}
+
+	var (
+		prov core.Provider
+		err  error
+	)
+	switch {
+	case hasAPI && hasMCP:
+		apiProv, err := buildSpec(apiResolved, allowedOperations)
+		if err != nil {
+			return nil, fmt.Errorf("build spec-loaded provider %q: %w", name, err)
+		}
+
+		mcpProv, err := buildSpec(mcpResolved, nil)
+		if err != nil {
+			if c, ok := apiProv.(interface{ Close() error }); ok {
+				_ = c.Close()
+			}
+			return nil, fmt.Errorf("build spec-loaded provider %q: %w", name, err)
+		}
+		mcpUp, ok := mcpProv.(composite.MCPUpstream)
+		if !ok {
+			if c, ok := mcpProv.(interface{ Close() error }); ok {
+				_ = c.Close()
+			}
+			if c, ok := apiProv.(interface{ Close() error }); ok {
+				_ = c.Close()
+			}
+			return nil, fmt.Errorf("build spec-loaded provider %q: unexpected mcp provider type %T", name, mcpProv)
+		}
+		type operationFilter interface {
+			FilterOperations(map[string]*config.OperationOverride) error
+		}
+		if filtered := matchingAllowedOperations(allowedOperations, mcpProv.ListOperations()); len(filtered) > 0 {
+			filterable, ok := mcpProv.(operationFilter)
+			if !ok {
+				_ = mcpUp.Close()
+				if c, ok := apiProv.(interface{ Close() error }); ok {
+					_ = c.Close()
+				}
+				return nil, fmt.Errorf("build spec-loaded provider %q: unexpected non-filterable mcp provider type %T", name, mcpProv)
+			}
+			if err := filterable.FilterOperations(filtered); err != nil {
+				_ = mcpUp.Close()
+				if c, ok := apiProv.(interface{ Close() error }); ok {
+					_ = c.Close()
+				}
+				return nil, fmt.Errorf("build spec-loaded provider %q: filter mcp operations: %w", name, err)
+			}
+		}
+		prov = composite.New(name, apiProv, mcpUp)
+
+	case hasAPI:
+		prov, err = buildSpec(apiResolved, allowedOperations)
+		if err != nil {
+			return nil, fmt.Errorf("build spec-loaded provider %q: %w", name, err)
+		}
+
+	case hasMCP:
+		prov, err = buildSpec(mcpResolved, allowedOperations)
+		if err != nil {
+			return nil, fmt.Errorf("build spec-loaded provider %q: %w", name, err)
+		}
+	}
+
+	return newProviderBuildResult(name, intg, manifest, pluginConfig, prov, deps, regStore)
+}
 func applyPluginHeaders(def *provider.Definition, plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider) {
 	if def == nil {
 		return
@@ -1088,6 +1156,26 @@ func manifestAllowedOperations(provider *pluginmanifestv1.Provider) map[string]*
 		}
 	}
 	return result
+}
+
+func matchingAllowedOperations(allowed map[string]*config.OperationOverride, ops []core.Operation) map[string]*config.OperationOverride {
+	if len(allowed) == 0 || len(ops) == 0 {
+		return nil
+	}
+	available := make(map[string]struct{}, len(ops))
+	for _, op := range ops {
+		available[op.Name] = struct{}{}
+	}
+	filtered := make(map[string]*config.OperationOverride)
+	for name, override := range allowed {
+		if _, ok := available[name]; ok {
+			filtered[name] = override
+		}
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
 }
 
 func pluginSurfaceConnectionName(plugin *config.PluginDef, surface specSurface) string {

--- a/server/internal/bootstrap/connections.go
+++ b/server/internal/bootstrap/connections.go
@@ -2,6 +2,8 @@ package bootstrap
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
@@ -92,7 +94,17 @@ func soleNamedConnection(plugin *config.PluginDef, manifestProvider *pluginmanif
 }
 
 func resolveConfiguredSpecSurface(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider) (resolvedSpecSurface, bool) {
-	for _, surface := range []specSurface{specSurfaceOpenAPI, specSurfaceGraphQL, specSurfaceMCP} {
+	if resolved, ok := resolveConfiguredAPISurface(plugin, manifestProvider); ok {
+		return resolved, true
+	}
+	if resolved, ok := resolveSpecSurface(plugin, manifestProvider, specSurfaceMCP); ok {
+		return resolved, true
+	}
+	return resolvedSpecSurface{}, false
+}
+
+func resolveConfiguredAPISurface(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider) (resolvedSpecSurface, bool) {
+	for _, surface := range []specSurface{specSurfaceOpenAPI, specSurfaceGraphQL} {
 		if resolved, ok := resolveSpecSurface(plugin, manifestProvider, surface); ok {
 			return resolved, true
 		}
@@ -102,6 +114,7 @@ func resolveConfiguredSpecSurface(plugin *config.PluginDef, manifestProvider *pl
 
 func resolveSpecSurface(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider, surface specSurface) (resolvedSpecSurface, bool) {
 	var url string
+	fromManifest := false
 	if plugin != nil {
 		switch surface {
 		case specSurfaceOpenAPI:
@@ -127,9 +140,13 @@ func resolveSpecSurface(plugin *config.PluginDef, manifestProvider *pluginmanife
 		case specSurfaceMCP:
 			url = manifestProvider.MCPURL
 		}
+		fromManifest = url != ""
 	}
 	if url == "" {
 		return resolvedSpecSurface{}, false
+	}
+	if fromManifest {
+		url = resolveManifestRelativeSpecURL(plugin, url)
 	}
 	name := config.ResolveConnectionAlias(pluginSurfaceConnectionName(plugin, surface))
 	if name == "" {
@@ -151,6 +168,22 @@ func resolveSpecSurface(plugin *config.PluginDef, manifestProvider *pluginmanife
 	return resolved, true
 }
 
+func resolveManifestRelativeSpecURL(plugin *config.PluginDef, raw string) string {
+	if plugin == nil || plugin.ResolvedManifestPath == "" || raw == "" {
+		return raw
+	}
+	if filepath.IsAbs(raw) || strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://") {
+		return raw
+	}
+	if strings.HasPrefix(raw, "file://") {
+		path := strings.TrimPrefix(raw, "file://")
+		if filepath.IsAbs(path) {
+			return raw
+		}
+		return "file://" + filepath.Clean(filepath.Join(filepath.Dir(plugin.ResolvedManifestPath), path))
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(plugin.ResolvedManifestPath), raw))
+}
 func manifestSurfaceConnectionName(provider *pluginmanifestv1.Provider, surface specSurface) string {
 	if provider == nil {
 		return ""

--- a/server/internal/bootstrap/connections_test.go
+++ b/server/internal/bootstrap/connections_test.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -111,5 +112,26 @@ func TestResolvedNamedConnectionDefMergesNamedDefsWithoutTopLevelInheritance(t *
 	}
 	if got.Auth.ClientID != "" {
 		t.Fatalf("client_id = %q, want empty", got.Auth.ClientID)
+	}
+}
+
+func TestResolveSpecSurfaceResolvesManifestRelativeSpecPath(t *testing.T) {
+	t.Parallel()
+
+	plugin := &config.PluginDef{
+		ResolvedManifestPath: filepath.Join("/tmp", "plugins", "notion", "plugin.yaml"),
+	}
+	manifestProvider := &pluginmanifestv1.Provider{
+		OpenAPI: "openapi.yaml",
+	}
+
+	resolved, ok := resolveSpecSurface(plugin, manifestProvider, specSurfaceOpenAPI)
+	if !ok {
+		t.Fatal("expected openapi surface to resolve")
+	}
+
+	want := filepath.Join("/tmp", "plugins", "notion", "openapi.yaml")
+	if resolved.url != want {
+		t.Fatalf("url = %q, want %q", resolved.url, want)
 	}
 }

--- a/server/internal/bootstrap/inline_gaps_test.go
+++ b/server/internal/bootstrap/inline_gaps_test.go
@@ -11,12 +11,17 @@ import (
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
 	"gopkg.in/yaml.v3"
 )
 
@@ -127,6 +132,26 @@ func serveOpenAPIBackend(t *testing.T, wantToken string) *httptest.Server {
 	return srv
 }
 
+func serveMCPToolServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	srv := mcpserver.NewMCPServer("test-remote", "1.0.0")
+	srv.AddTool(
+		mcpgo.NewTool("search", mcpgo.WithDescription("Search workspace")),
+		func(_ context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+			return mcpgo.NewToolResultText("ok"), nil
+		},
+	)
+
+	httpSrv := mcpserver.NewStreamableHTTPServer(
+		srv,
+		mcpserver.WithStateLess(true),
+	)
+	ts := httptest.NewServer(httpSrv)
+	testutil.CloseOnCleanup(t, ts)
+	return ts
+}
+
 func TestInlineMCPOAuth_ConnectionAuthWired(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -225,6 +250,127 @@ func TestInlineMCPOAuth_SpecLoadedOpenAPI(t *testing.T) {
 	authURL, _ := handler.StartOAuth("s1", nil)
 	if authURL == "" {
 		t.Fatal("expected non-empty authorization URL from mcp_oauth handler for spec-loaded provider")
+	}
+}
+
+func TestBootstrap_SpecLoadedManifestCombinesOpenAPIAndMCP(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mcpSrv := serveMCPToolServer(t)
+
+	pluginDir := t.TempDir()
+	openapiPath := filepath.Join(pluginDir, "openapi.json")
+	if err := os.WriteFile(openapiPath, []byte(`{
+  "openapi": "3.0.0",
+  "info": { "title": "Hybrid Test API" },
+  "servers": [{ "url": "https://api.test.example" }],
+  "paths": {
+    "/items": {
+      "get": {
+        "operationId": "api_list_items",
+        "summary": "List items"
+      }
+    }
+  }
+}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(openapi.json): %v", err)
+	}
+
+	manifest := &pluginmanifestv1.Manifest{
+		Source:      "github.com/acme/plugins/hybrid",
+		Version:     "0.1.0",
+		DisplayName: "Hybrid",
+		Kinds:       []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			OpenAPI:       "openapi.json",
+			MCPURL:        mcpSrv.URL,
+			MCPConnection: "MCP",
+			Connections: map[string]*pluginmanifestv1.ManifestConnectionDef{
+				"MCP": {
+					Auth: &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeMCPOAuth},
+				},
+			},
+		},
+	}
+	manifestData, err := pluginpkg.EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	manifestPath := filepath.Join(pluginDir, "plugin.json")
+	if err := os.WriteFile(manifestPath, manifestData, 0o644); err != nil {
+		t.Fatalf("WriteFile(plugin.json): %v", err)
+	}
+
+	cfg := validConfig()
+	cfg.Integrations = map[string]config.IntegrationDef{
+		"hybrid": {
+			Plugin: &config.PluginDef{
+				IsDeclarative:        true,
+				ResolvedManifestPath: manifestPath,
+				ResolvedManifest:     manifest,
+			},
+		},
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	prov, err := result.Providers.Get("hybrid")
+	if err != nil {
+		t.Fatalf("Providers.Get: %v", err)
+	}
+	cp, ok := prov.(core.CatalogProvider)
+	if !ok {
+		t.Fatalf("provider does not implement CatalogProvider: %T", prov)
+	}
+	cat := cp.Catalog()
+	if cat == nil {
+		t.Fatal("expected non-nil catalog")
+	}
+
+	staticOps := make(map[string]catalog.CatalogOperation, len(cat.Operations))
+	staticIDs := make([]string, 0, len(cat.Operations))
+	for _, op := range cat.Operations {
+		staticOps[op.ID] = op
+		staticIDs = append(staticIDs, fmt.Sprintf("%s:%s", op.ID, op.Transport))
+	}
+	if _, ok := staticOps["api_list_items"]; !ok {
+		t.Fatalf("expected REST operation from packaged openapi spec, got %v", staticIDs)
+	}
+
+	scp, ok := prov.(core.SessionCatalogProvider)
+	if !ok {
+		t.Fatalf("provider does not implement SessionCatalogProvider: %T", prov)
+	}
+	sessionCat, err := scp.CatalogForRequest(ctx, "")
+	if err != nil {
+		t.Fatalf("CatalogForRequest: %v", err)
+	}
+	if sessionCat == nil {
+		t.Fatal("expected non-nil session catalog")
+	}
+	sessionOps := make(map[string]catalog.CatalogOperation, len(sessionCat.Operations))
+	sessionIDs := make([]string, 0, len(sessionCat.Operations))
+	for _, op := range sessionCat.Operations {
+		sessionOps[op.ID] = op
+		sessionIDs = append(sessionIDs, fmt.Sprintf("%s:%s", op.ID, op.Transport))
+	}
+	if op, ok := sessionOps["search"]; !ok {
+		t.Fatalf("expected MCP operation from upstream mcp server, got %v", sessionIDs)
+	} else if op.Transport != catalog.TransportMCPPassthrough {
+		t.Fatalf("search transport = %q, want %q", op.Transport, catalog.TransportMCPPassthrough)
+	}
+
+	maps := bootstrap.BuildConnectionMaps(cfg)
+	if got := maps.APIConnection["hybrid"]; got != config.PluginConnectionName {
+		t.Fatalf("api connection = %q, want %q", got, config.PluginConnectionName)
+	}
+	if got := maps.MCPConnection["hybrid"]; got != "MCP" {
+		t.Fatalf("mcp connection = %q, want %q", got, "MCP")
 	}
 }
 

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -123,10 +123,11 @@ type PluginDef struct {
 	MCP               bool                          `yaml:"mcp"`
 	AllowedOperations map[string]*OperationOverride `yaml:"allowed_operations"`
 
-	ResolvedManifest *pluginmanifestv1.Manifest `yaml:"-"`
-	ResolvedIconFile string                     `yaml:"-"`
-	IsDeclarative    bool                       `yaml:"-"`
-	HostBinary       string                     `yaml:"-"`
+	ResolvedManifestPath string                     `yaml:"-"`
+	ResolvedManifest     *pluginmanifestv1.Manifest `yaml:"-"`
+	ResolvedIconFile     string                     `yaml:"-"`
+	IsDeclarative        bool                       `yaml:"-"`
+	HostBinary           string                     `yaml:"-"`
 }
 
 func (p *PluginDef) IsInline() bool {

--- a/server/internal/operator/lifecycle.go
+++ b/server/internal/operator/lifecycle.go
@@ -746,6 +746,7 @@ func applyLockedPluginEntry(paths initPaths, lock *Lockfile, kind, name string, 
 
 	resolvePluginIcon(manifest, manifestPath, plugin)
 
+	plugin.ResolvedManifestPath = manifestPath
 	plugin.ResolvedManifest = manifest
 	if kind == "integration" && manifest.IsDeclarativeOnlyProvider() {
 		plugin.IsDeclarative = true

--- a/server/internal/pluginpkg/archive.go
+++ b/server/internal/pluginpkg/archive.go
@@ -85,7 +85,7 @@ func CopyPackageDir(sourceDir, destDir string) error {
 		return err
 	}
 	destDir = filepath.Clean(destDir)
-	if rel, err := filepath.Rel(sourceDir, destDir); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	if isPathWithinDir(sourceDir, destDir) {
 		return fmt.Errorf("output directory %q must not be inside source directory %q", destDir, sourceDir)
 	}
 	if err := os.MkdirAll(destDir, 0755); err != nil {
@@ -128,6 +128,10 @@ func CreatePackageFromDir(sourceDir, outputPath string) (err error) {
 	sourceDir = filepath.Clean(sourceDir)
 	if _, err := ValidatePackageDir(sourceDir); err != nil {
 		return err
+	}
+	outputPath = filepath.Clean(outputPath)
+	if isPathWithinDir(sourceDir, outputPath) {
+		return fmt.Errorf("output archive %q must not be inside source directory %q", outputPath, sourceDir)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
@@ -193,6 +197,14 @@ func CreatePackageFromDir(sourceDir, outputPath string) (err error) {
 	}
 
 	return nil
+}
+
+func isPathWithinDir(root, target string) bool {
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 func ExtractPackage(packagePath, destDir string) (err error) {

--- a/server/internal/pluginpkg/archive_boundary_test.go
+++ b/server/internal/pluginpkg/archive_boundary_test.go
@@ -60,6 +60,22 @@ func TestLoadManifestFromPath_DirectoryManifestFileAndArchive(t *testing.T) {
 	}
 }
 
+func TestCreatePackageFromDirRejectsOutputInsideSource(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sourceDir, _ := mustWriteProviderPackageDir(t, dir, "github.com/acme/plugins/provider", "0.1.0", "provider")
+	archivePath := filepath.Join(sourceDir, "provider.tar.gz")
+
+	err := CreatePackageFromDir(sourceDir, archivePath)
+	if err == nil {
+		t.Fatal("expected output-inside-source error")
+	}
+	if !strings.Contains(err.Error(), "must not be inside source directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestValidatePackageDirRejectsMissingProviderSchema(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/pluginpkg/manifest.go
+++ b/server/internal/pluginpkg/manifest.go
@@ -133,10 +133,12 @@ func ValidateManifest(manifest *pluginmanifestv1.Manifest) error {
 	}
 
 	isDeclarative := manifest.Provider.IsDeclarative()
+	isSpecLoaded := manifest.Provider.IsSpecLoaded()
+	isManifestBackedProvider := isDeclarative || isSpecLoaded
 
 	needsArtifacts := false
 	for _, kind := range manifest.Kinds {
-		if kind == pluginmanifestv1.KindRuntime || (kind == pluginmanifestv1.KindProvider && (!isDeclarative || manifest.IsHybridProvider())) {
+		if kind == pluginmanifestv1.KindRuntime || (kind == pluginmanifestv1.KindProvider && (!isManifestBackedProvider || manifest.IsHybridProvider())) {
 			needsArtifacts = true
 			break
 		}
@@ -182,7 +184,7 @@ func ValidateManifest(manifest *pluginmanifestv1.Manifest) error {
 					return err
 				}
 			}
-			if !isDeclarative || manifest.IsHybridProvider() {
+			if !isManifestBackedProvider || manifest.IsHybridProvider() {
 				if err := validateEntrypoint(kind, manifest.Entrypoints.Provider, artifactPaths); err != nil {
 					return err
 				}

--- a/server/internal/pluginpkg/manifest_test.go
+++ b/server/internal/pluginpkg/manifest_test.go
@@ -108,6 +108,32 @@ func TestEncodeManifest_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestEncodeManifest_SpecLoadedProviderDoesNotRequireEntrypoint(t *testing.T) {
+	t.Parallel()
+
+	manifest := &pluginmanifestv1.Manifest{
+		Source:  "github.com/acme/plugins/notion",
+		Version: "0.1.0",
+		Kinds:   []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			OpenAPI: "openapi.yaml",
+			MCPURL:  "https://mcp.example.com/mcp",
+		},
+	}
+
+	data, err := EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	got, err := DecodeManifest(data)
+	if err != nil {
+		t.Fatalf("DecodeManifest: %v", err)
+	}
+	if got.Provider == nil || got.Provider.OpenAPI != "openapi.yaml" {
+		t.Fatalf("unexpected provider after round trip: %#v", got.Provider)
+	}
+}
+
 func validV2JSON() []byte {
 	return []byte(`{
   "source": "github.com/acme/plugins/echo",

--- a/server/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/server/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -223,6 +223,29 @@
             }
           },
           {
+            "properties": {
+              "provider": {
+                "anyOf": [
+                  {
+                    "required": [
+                      "openapi"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "graphql_url"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "mcp_url"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
             "required": [
               "artifacts",
               "entrypoints"


### PR DESCRIPTION
## Summary
- add a packaged `plugins/notion` provider at `0.0.1-alpha.1` with a curated current Notion REST OpenAPI spec and official Notion MCP configuration
- support packaged spec-backed providers that combine OpenAPI/GraphQL catalogs with MCP catalogs, including manifest-relative spec paths
- package declarative plugins through `gestaltd plugin package`, include support files like `openapi.yaml`, and prevent archive outputs from being written inside the source tree

## Testing
- go test ./internal/bootstrap ./internal/pluginpkg ./cmd/gestaltd
- ./gestaltd plugin package --input plugins/notion --output /tmp/notion-dist/gestalt-plugin-notion_v0.0.1-alpha.1.tar.gz
- tar -tzf /tmp/notion-dist/gestalt-plugin-notion_v0.0.1-alpha.1.tar.gz