### PR TITLE
Simplify bootstrap connection planning

### DIFF
--- a/server/internal/bootstrap/bootstrap.go
+++ b/server/internal/bootstrap/bootstrap.go
@@ -269,6 +269,14 @@ func (r *Result) Close(ctx context.Context) error {
 	return errors.Join(errs...)
 }
 
+func closeIfPossible(values ...any) {
+	for _, value := range values {
+		if c, ok := value.(interface{ Close() error }); ok {
+			_ = c.Close()
+		}
+	}
+}
+
 func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) (*Result, error) {
 	sm, err := buildSecretManager(cfg, factories)
 	if err != nil {
@@ -277,9 +285,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	closeSM := true
 	defer func() {
 		if closeSM {
-			if c, ok := sm.(interface{ Close() error }); ok {
-				_ = c.Close()
-			}
+			closeIfPossible(sm)
 		}
 	}()
 
@@ -746,9 +752,7 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 				return
 			}
 			if err := reg.Providers.Register(name, result.Provider); err != nil {
-				if c, ok := result.Provider.(interface{ Close() error }); ok {
-					_ = c.Close()
-				}
+				closeIfPossible(result.Provider)
 				slog.Warn("registering provider failed", "provider", name, "error", err)
 				return
 			}
@@ -826,16 +830,14 @@ func buildExternalPluginProvider(ctx context.Context, name string, intg config.I
 	}
 	manifest := intg.Plugin.ResolvedManifest
 	manifestProvider := intg.Plugin.ManifestProvider()
-
-	resolved, hasSpecSurface := resolveConfiguredSpecSurface(intg.Plugin, manifestProvider)
+	plan := buildPluginConnectionPlan(intg.Plugin, manifestProvider)
+	resolved, hasSpecSurface := plan.configuredSpecSurface()
 
 	var finalProv core.Provider
 	if !hasSpecSurface {
 		restricted, err := applyAllowedOperations(name, intg, pluginProv)
 		if err != nil {
-			if c, ok := pluginProv.(interface{ Close() error }); ok {
-				_ = c.Close()
-			}
+			closeIfPossible(pluginProv)
 			return nil, err
 		}
 		finalProv = restricted
@@ -850,9 +852,7 @@ func buildExternalPluginProvider(ctx context.Context, name string, intg config.I
 			},
 		}, deps)
 		if err != nil {
-			if c, ok := pluginProv.(interface{ Close() error }); ok {
-				_ = c.Close()
-			}
+			closeIfPossible(pluginProv)
 			return nil, fmt.Errorf("build hybrid spec provider %q: %w", name, err)
 		}
 		merged, err := composite.NewMergedWithConnections(
@@ -864,12 +864,7 @@ func buildExternalPluginProvider(ctx context.Context, name string, intg config.I
 			composite.BoundProvider{Provider: specProv, Connection: resolved.connectionName},
 		)
 		if err != nil {
-			if c, ok := specProv.(interface{ Close() error }); ok {
-				_ = c.Close()
-			}
-			if c, ok := pluginProv.(interface{ Close() error }); ok {
-				_ = c.Close()
-			}
+			closeIfPossible(specProv, pluginProv)
 			return nil, err
 		}
 		finalProv = merged
@@ -967,9 +962,7 @@ func newProviderBuildResult(name string, intg config.IntegrationDef, manifest *p
 	var err error
 	result.ConnectionAuth, err = buildConnectionAuthMap(name, intg, manifest, pluginConfig, deps, regStore)
 	if err != nil {
-		if c, ok := prov.(interface{ Close() error }); ok {
-			_ = c.Close()
-		}
+		closeIfPossible(prov)
 		return nil, err
 	}
 	return result, nil
@@ -1008,8 +1001,9 @@ func mcpOAuthBuildOpts(conn config.ConnectionDef, mp *pluginmanifestv1.Provider,
 }
 func buildSpecLoadedProvider(ctx context.Context, name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, pluginConfig map[string]any, meta providerMetadata, deps Deps, regStore *lazyRegStore, allowedOperations map[string]*config.OperationOverride) (*ProviderBuildResult, error) {
 	mp := manifest.Provider
-	apiResolved, hasAPI := resolveConfiguredAPISurface(intg.Plugin, mp)
-	mcpResolved, hasMCP := resolveSpecSurface(intg.Plugin, mp, specSurfaceMCP)
+	plan := buildPluginConnectionPlan(intg.Plugin, mp)
+	apiResolved, hasAPI := plan.configuredAPISurface()
+	mcpResolved, hasMCP := plan.resolvedSurface(specSurfaceMCP)
 	if !hasAPI && !hasMCP {
 		return nil, fmt.Errorf("build spec-loaded provider %q: no spec URL", name)
 	}
@@ -1040,19 +1034,12 @@ func buildSpecLoadedProvider(ctx context.Context, name string, intg config.Integ
 
 		mcpProv, err := buildSpec(mcpResolved, nil)
 		if err != nil {
-			if c, ok := apiProv.(interface{ Close() error }); ok {
-				_ = c.Close()
-			}
+			closeIfPossible(apiProv)
 			return nil, fmt.Errorf("build spec-loaded provider %q: %w", name, err)
 		}
 		mcpUp, ok := mcpProv.(composite.MCPUpstream)
 		if !ok {
-			if c, ok := mcpProv.(interface{ Close() error }); ok {
-				_ = c.Close()
-			}
-			if c, ok := apiProv.(interface{ Close() error }); ok {
-				_ = c.Close()
-			}
+			closeIfPossible(mcpProv, apiProv)
 			return nil, fmt.Errorf("build spec-loaded provider %q: unexpected mcp provider type %T", name, mcpProv)
 		}
 		type operationFilter interface {
@@ -1061,17 +1048,11 @@ func buildSpecLoadedProvider(ctx context.Context, name string, intg config.Integ
 		if filtered := matchingAllowedOperations(allowedOperations, mcpProv.Catalog()); len(filtered) > 0 {
 			filterable, ok := mcpProv.(operationFilter)
 			if !ok {
-				_ = mcpUp.Close()
-				if c, ok := apiProv.(interface{ Close() error }); ok {
-					_ = c.Close()
-				}
+				closeIfPossible(mcpUp, apiProv)
 				return nil, fmt.Errorf("build spec-loaded provider %q: unexpected non-filterable mcp provider type %T", name, mcpProv)
 			}
 			if err := filterable.FilterOperations(filtered); err != nil {
-				_ = mcpUp.Close()
-				if c, ok := apiProv.(interface{ Close() error }); ok {
-					_ = c.Close()
-				}
+				closeIfPossible(mcpUp, apiProv)
 				return nil, fmt.Errorf("build spec-loaded provider %q: filter mcp operations: %w", name, err)
 			}
 		}

--- a/server/internal/bootstrap/connections.go
+++ b/server/internal/bootstrap/connections.go
@@ -23,19 +23,34 @@ func BuildConnectionMaps(cfg *config.Config) ConnectionMaps {
 	}
 
 	for name, intg := range cfg.Integrations {
-		meta := describeIntegrationConnections(intg)
-		maps.DefaultConnection[name] = meta.defaultConnection
-		maps.APIConnection[name] = meta.apiConnection
-		maps.MCPConnection[name] = meta.mcpConnection
+		defaultConnection := config.PluginConnectionName
+		apiConnection := config.PluginConnectionName
+		mcpConnection := config.PluginConnectionName
+
+		if intg.Plugin != nil {
+			plan := buildPluginConnectionPlan(intg.Plugin, intg.Plugin.ManifestProvider())
+			if resolved, ok := plan.configuredSpecSurface(); ok {
+				defaultConnection = resolved.connectionName
+				apiConnection = resolved.connectionName
+			} else if plan.pluginConnection.Auth.Type == "" {
+				if name, ok := plan.soleNamedConnection(); ok {
+					defaultConnection = name
+					apiConnection = name
+				}
+			}
+			if resolved, ok := plan.resolvedSurface(specSurfaceMCP); ok {
+				mcpConnection = resolved.connectionName
+			} else {
+				mcpConnection = defaultConnection
+			}
+		}
+
+		maps.DefaultConnection[name] = defaultConnection
+		maps.APIConnection[name] = apiConnection
+		maps.MCPConnection[name] = mcpConnection
 	}
 
 	return maps
-}
-
-type integrationConnectionMeta struct {
-	defaultConnection string
-	apiConnection     string
-	mcpConnection     string
 }
 
 type resolvedSpecSurface struct {
@@ -118,42 +133,6 @@ func (plan pluginConnectionPlan) soleNamedConnection() (string, bool) {
 		return name, true
 	}
 	return "", false
-}
-
-func describeIntegrationConnections(intg config.IntegrationDef) integrationConnectionMeta {
-	meta := integrationConnectionMeta{
-		defaultConnection: config.PluginConnectionName,
-		apiConnection:     config.PluginConnectionName,
-		mcpConnection:     config.PluginConnectionName,
-	}
-
-	if intg.Plugin == nil {
-		return meta
-	}
-
-	plan := buildPluginConnectionPlan(intg.Plugin, intg.Plugin.ManifestProvider())
-	if resolved, ok := plan.configuredSpecSurface(); ok {
-		meta.defaultConnection = resolved.connectionName
-		meta.apiConnection = resolved.connectionName
-	} else if plan.pluginConnection.Auth.Type == "" {
-		if name, ok := plan.soleNamedConnection(); ok {
-			meta.defaultConnection = name
-			meta.apiConnection = name
-		}
-	}
-
-	if resolved, ok := plan.resolvedSurface(specSurfaceMCP); ok {
-		meta.mcpConnection = resolved.connectionName
-	} else {
-		meta.mcpConnection = meta.defaultConnection
-	}
-	if meta.apiConnection == "" {
-		meta.apiConnection = meta.defaultConnection
-	}
-	if meta.mcpConnection == "" {
-		meta.mcpConnection = meta.defaultConnection
-	}
-	return meta
 }
 
 func surfaceURL(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider, surface specSurface) string {
@@ -243,27 +222,24 @@ func basePluginConnectionDef(plugin *config.PluginDef, manifestProvider *pluginm
 		conn.Params = plugin.ConnectionParams
 	}
 	if manifestProvider != nil && manifestProvider.Auth != nil {
-		mergeConnectionDef(&conn, manifestTopLevelConnectionDef(manifestProvider))
+		mergeConnectionAuth(&conn.Auth, manifestAuthToConfig(manifestProvider.Auth))
 	}
 	return conn
 }
 
 func resolvedNamedConnectionDef(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider, name string) config.ConnectionDef {
-	conn, ok := explicitNamedConnectionDef(plugin, manifestProvider, name)
-	if ok {
-		return conn
-	}
-	return basePluginConnectionDef(plugin, manifestProvider)
-}
-
-func explicitNamedConnectionDef(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider, name string) (config.ConnectionDef, bool) {
 	conn := config.ConnectionDef{}
 	found := false
 
-	if manifestProvider != nil {
-		if _, ok := manifestProvider.Connections[name]; ok {
+	if manifestProvider != nil && manifestProvider.Connections != nil {
+		if def, ok := manifestProvider.Connections[name]; ok && def != nil {
 			found = true
-			mergeConnectionDef(&conn, manifestNamedConnectionDef(manifestProvider, name))
+			if def.Mode != "" {
+				conn.Mode = def.Mode
+			}
+			if def.Auth != nil {
+				mergeConnectionAuth(&conn.Auth, manifestAuthToConfig(def.Auth))
+			}
 		}
 	}
 	if plugin != nil {
@@ -273,29 +249,10 @@ func explicitNamedConnectionDef(plugin *config.PluginDef, manifestProvider *plug
 		}
 	}
 
-	return conn, found
-}
-
-func manifestTopLevelConnectionDef(provider *pluginmanifestv1.Provider) *config.ConnectionDef {
-	if provider == nil || provider.Auth == nil {
-		return nil
+	if found {
+		return conn
 	}
-	return &config.ConnectionDef{Auth: manifestAuthToConfig(provider.Auth)}
-}
-
-func manifestNamedConnectionDef(provider *pluginmanifestv1.Provider, name string) *config.ConnectionDef {
-	if provider == nil || provider.Connections == nil {
-		return nil
-	}
-	def, ok := provider.Connections[name]
-	if !ok || def == nil {
-		return nil
-	}
-	out := &config.ConnectionDef{Mode: def.Mode}
-	if def.Auth != nil {
-		out.Auth = manifestAuthToConfig(def.Auth)
-	}
-	return out
+	return basePluginConnectionDef(plugin, manifestProvider)
 }
 
 func manifestAuthToConfig(auth *pluginmanifestv1.ProviderAuth) config.ConnectionAuthDef {

--- a/server/internal/bootstrap/connections.go
+++ b/server/internal/bootstrap/connections.go
@@ -156,21 +156,6 @@ func describeIntegrationConnections(intg config.IntegrationDef) integrationConne
 	return meta
 }
 
-func resolveConfiguredSpecSurface(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider) (resolvedSpecSurface, bool) {
-	plan := buildPluginConnectionPlan(plugin, manifestProvider)
-	return plan.configuredSpecSurface()
-}
-
-func resolveConfiguredAPISurface(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider) (resolvedSpecSurface, bool) {
-	plan := buildPluginConnectionPlan(plugin, manifestProvider)
-	return plan.configuredAPISurface()
-}
-
-func resolveSpecSurface(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider, surface specSurface) (resolvedSpecSurface, bool) {
-	plan := buildPluginConnectionPlan(plugin, manifestProvider)
-	return plan.resolvedSurface(surface)
-}
-
 func surfaceURL(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider, surface specSurface) string {
 	if plugin != nil {
 		switch surface {

--- a/server/internal/bootstrap/connections.go
+++ b/server/internal/bootstrap/connections.go
@@ -45,27 +45,104 @@ type resolvedSpecSurface struct {
 	connection     config.ConnectionDef
 }
 
+type pluginConnectionPlan struct {
+	pluginConnection config.ConnectionDef
+	namedConnections map[string]config.ConnectionDef
+	surfaces         map[specSurface]resolvedSpecSurface
+}
+
+func buildPluginConnectionPlan(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider) pluginConnectionPlan {
+	plan := pluginConnectionPlan{
+		pluginConnection: basePluginConnectionDef(plugin, manifestProvider),
+		namedConnections: make(map[string]config.ConnectionDef),
+		surfaces:         make(map[specSurface]resolvedSpecSurface),
+	}
+
+	for name := range namedConnectionNames(plugin, manifestProvider) {
+		if name == "" || name == config.PluginConnectionName {
+			continue
+		}
+		plan.namedConnections[name] = resolvedNamedConnectionDef(plugin, manifestProvider, name)
+	}
+
+	for _, surface := range []specSurface{specSurfaceOpenAPI, specSurfaceGraphQL, specSurfaceMCP} {
+		url := surfaceURL(plugin, manifestProvider, surface)
+		if url == "" {
+			continue
+		}
+		resolved := resolvedSpecSurface{
+			surface:        surface,
+			url:            url,
+			connectionName: resolveSurfaceConnectionName(plugin, manifestProvider, surface),
+		}
+		if resolved.connectionName == config.PluginConnectionName {
+			resolved.connection = plan.pluginConnection
+		} else {
+			resolved.connection = plan.namedConnections[resolved.connectionName]
+		}
+		plan.surfaces[surface] = resolved
+	}
+
+	return plan
+}
+
+func (plan pluginConnectionPlan) configuredAPISurface() (resolvedSpecSurface, bool) {
+	for _, surface := range []specSurface{specSurfaceOpenAPI, specSurfaceGraphQL} {
+		if resolved, ok := plan.resolvedSurface(surface); ok {
+			return resolved, true
+		}
+	}
+	return resolvedSpecSurface{}, false
+}
+
+func (plan pluginConnectionPlan) configuredSpecSurface() (resolvedSpecSurface, bool) {
+	if resolved, ok := plan.configuredAPISurface(); ok {
+		return resolved, true
+	}
+	return plan.resolvedSurface(specSurfaceMCP)
+}
+
+func (plan pluginConnectionPlan) resolvedSurface(surface specSurface) (resolvedSpecSurface, bool) {
+	resolved, ok := plan.surfaces[surface]
+	return resolved, ok
+}
+
+func (plan pluginConnectionPlan) soleNamedConnection() (string, bool) {
+	if len(plan.namedConnections) != 1 {
+		return "", false
+	}
+	for name := range plan.namedConnections {
+		if name == "" || name == config.PluginConnectionName {
+			return "", false
+		}
+		return name, true
+	}
+	return "", false
+}
+
 func describeIntegrationConnections(intg config.IntegrationDef) integrationConnectionMeta {
 	meta := integrationConnectionMeta{
 		defaultConnection: config.PluginConnectionName,
 		apiConnection:     config.PluginConnectionName,
 		mcpConnection:     config.PluginConnectionName,
 	}
+
 	if intg.Plugin == nil {
 		return meta
 	}
 
-	manifestProvider := intg.Plugin.ManifestProvider()
-	if resolved, ok := resolveConfiguredSpecSurface(intg.Plugin, manifestProvider); ok {
+	plan := buildPluginConnectionPlan(intg.Plugin, intg.Plugin.ManifestProvider())
+	if resolved, ok := plan.configuredSpecSurface(); ok {
 		meta.defaultConnection = resolved.connectionName
 		meta.apiConnection = resolved.connectionName
-	} else if basePluginConnectionDef(intg.Plugin, manifestProvider).Auth.Type == "" {
-		if name, ok := soleNamedConnection(intg.Plugin, manifestProvider); ok {
+	} else if plan.pluginConnection.Auth.Type == "" {
+		if name, ok := plan.soleNamedConnection(); ok {
 			meta.defaultConnection = name
 			meta.apiConnection = name
 		}
 	}
-	if resolved, ok := resolveSpecSurface(intg.Plugin, manifestProvider, specSurfaceMCP); ok {
+
+	if resolved, ok := plan.resolvedSurface(specSurfaceMCP); ok {
 		meta.mcpConnection = resolved.connectionName
 	} else {
 		meta.mcpConnection = meta.defaultConnection
@@ -79,93 +156,64 @@ func describeIntegrationConnections(intg config.IntegrationDef) integrationConne
 	return meta
 }
 
-func soleNamedConnection(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider) (string, bool) {
-	names := namedConnectionNames(plugin, manifestProvider)
-	if len(names) != 1 {
-		return "", false
-	}
-	for name := range names {
-		if name == "" || name == config.PluginConnectionName {
-			return "", false
-		}
-		return name, true
-	}
-	return "", false
-}
-
 func resolveConfiguredSpecSurface(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider) (resolvedSpecSurface, bool) {
-	if resolved, ok := resolveConfiguredAPISurface(plugin, manifestProvider); ok {
-		return resolved, true
-	}
-	if resolved, ok := resolveSpecSurface(plugin, manifestProvider, specSurfaceMCP); ok {
-		return resolved, true
-	}
-	return resolvedSpecSurface{}, false
+	plan := buildPluginConnectionPlan(plugin, manifestProvider)
+	return plan.configuredSpecSurface()
 }
 
 func resolveConfiguredAPISurface(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider) (resolvedSpecSurface, bool) {
-	for _, surface := range []specSurface{specSurfaceOpenAPI, specSurfaceGraphQL} {
-		if resolved, ok := resolveSpecSurface(plugin, manifestProvider, surface); ok {
-			return resolved, true
-		}
-	}
-	return resolvedSpecSurface{}, false
+	plan := buildPluginConnectionPlan(plugin, manifestProvider)
+	return plan.configuredAPISurface()
 }
 
 func resolveSpecSurface(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider, surface specSurface) (resolvedSpecSurface, bool) {
-	var url string
-	fromManifest := false
+	plan := buildPluginConnectionPlan(plugin, manifestProvider)
+	return plan.resolvedSurface(surface)
+}
+
+func surfaceURL(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider, surface specSurface) string {
 	if plugin != nil {
 		switch surface {
 		case specSurfaceOpenAPI:
 			if plugin.OpenAPI != "" {
-				url = plugin.OpenAPI
+				return plugin.OpenAPI
 			}
 		case specSurfaceGraphQL:
 			if plugin.GraphQLURL != "" {
-				url = plugin.GraphQLURL
+				return plugin.GraphQLURL
 			}
 		case specSurfaceMCP:
 			if plugin.MCPURL != "" {
-				url = plugin.MCPURL
+				return plugin.MCPURL
 			}
 		}
 	}
-	if url == "" && manifestProvider != nil {
-		switch surface {
-		case specSurfaceOpenAPI:
-			url = manifestProvider.OpenAPI
-		case specSurfaceGraphQL:
-			url = manifestProvider.GraphQLURL
-		case specSurfaceMCP:
-			url = manifestProvider.MCPURL
-		}
-		fromManifest = url != ""
+	if manifestProvider == nil {
+		return ""
 	}
-	if url == "" {
-		return resolvedSpecSurface{}, false
+	var url string
+	switch surface {
+	case specSurfaceOpenAPI:
+		url = manifestProvider.OpenAPI
+	case specSurfaceGraphQL:
+		url = manifestProvider.GraphQLURL
+	case specSurfaceMCP:
+		url = manifestProvider.MCPURL
+	default:
+		return ""
 	}
-	if fromManifest {
-		url = resolveManifestRelativeSpecURL(plugin, url)
-	}
+	return resolveManifestRelativeSpecURL(plugin, url)
+}
+
+func resolveSurfaceConnectionName(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider, surface specSurface) string {
 	name := config.ResolveConnectionAlias(pluginSurfaceConnectionName(plugin, surface))
 	if name == "" {
 		name = config.ResolveConnectionAlias(manifestSurfaceConnectionName(manifestProvider, surface))
 	}
 	if name == "" {
-		name = config.PluginConnectionName
+		return config.PluginConnectionName
 	}
-	resolved := resolvedSpecSurface{
-		surface:        surface,
-		url:            url,
-		connectionName: name,
-	}
-	if name == config.PluginConnectionName {
-		resolved.connection = basePluginConnectionDef(plugin, manifestProvider)
-	} else {
-		resolved.connection = resolvedNamedConnectionDef(plugin, manifestProvider, name)
-	}
-	return resolved, true
+	return name
 }
 
 func resolveManifestRelativeSpecURL(plugin *config.PluginDef, raw string) string {
@@ -184,6 +232,7 @@ func resolveManifestRelativeSpecURL(plugin *config.PluginDef, raw string) string
 	}
 	return filepath.Clean(filepath.Join(filepath.Dir(plugin.ResolvedManifestPath), raw))
 }
+
 func manifestSurfaceConnectionName(provider *pluginmanifestv1.Provider, surface specSurface) string {
 	if provider == nil {
 		return ""
@@ -306,24 +355,21 @@ func buildConnectionAuthMap(name string, intg config.IntegrationDef, manifest *p
 	if manifest != nil {
 		manifestProvider = manifest.Provider
 	}
+	plan := buildPluginConnectionPlan(intg.Plugin, manifestProvider)
 	mcpURL := ""
-	if resolved, ok := resolveSpecSurface(intg.Plugin, manifestProvider, specSurfaceMCP); ok {
+	if resolved, ok := plan.resolvedSurface(specSurfaceMCP); ok {
 		mcpURL = resolved.url
 	}
 
 	handlers := make(map[string]OAuthHandler)
-	if handler, err := buildConnectionHandler(basePluginConnectionDef(intg.Plugin, manifestProvider), mcpURL, pluginConfig, deps, regStore); err != nil {
+	if handler, err := buildConnectionHandler(plan.pluginConnection, mcpURL, pluginConfig, deps, regStore); err != nil {
 		return nil, fmt.Errorf("build plugin connection auth for %q: %w", name, err)
 	} else if handler != nil {
 		handlers[config.PluginConnectionName] = handler
 	}
 
-	for connName := range namedConnectionNames(intg.Plugin, manifestProvider) {
-		resolvedName := config.ResolveConnectionAlias(connName)
-		if resolvedName == "" || resolvedName == config.PluginConnectionName {
-			continue
-		}
-		conn := resolvedNamedConnectionDef(intg.Plugin, manifestProvider, resolvedName)
+	for resolvedName := range plan.namedConnections {
+		conn := plan.namedConnections[resolvedName]
 		handler, err := buildConnectionHandler(conn, mcpURL, pluginConfig, deps, regStore)
 		if err != nil {
 			return nil, fmt.Errorf("build named connection auth for %q/%q: %w", name, resolvedName, err)

--- a/server/internal/bootstrap/connections.go
+++ b/server/internal/bootstrap/connections.go
@@ -62,18 +62,21 @@ type resolvedSpecSurface struct {
 
 type pluginConnectionPlan struct {
 	pluginConnection config.ConnectionDef
+	connectionNames  map[string]struct{}
 	namedConnections map[string]config.ConnectionDef
 	surfaces         map[specSurface]resolvedSpecSurface
 }
 
 func buildPluginConnectionPlan(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider) pluginConnectionPlan {
+	connectionNames := namedConnectionNames(plugin, manifestProvider)
 	plan := pluginConnectionPlan{
 		pluginConnection: basePluginConnectionDef(plugin, manifestProvider),
+		connectionNames:  connectionNames,
 		namedConnections: make(map[string]config.ConnectionDef),
 		surfaces:         make(map[specSurface]resolvedSpecSurface),
 	}
 
-	for name := range namedConnectionNames(plugin, manifestProvider) {
+	for name := range connectionNames {
 		if name == "" || name == config.PluginConnectionName {
 			continue
 		}
@@ -123,10 +126,10 @@ func (plan pluginConnectionPlan) resolvedSurface(surface specSurface) (resolvedS
 }
 
 func (plan pluginConnectionPlan) soleNamedConnection() (string, bool) {
-	if len(plan.namedConnections) != 1 {
+	if len(plan.connectionNames) != 1 {
 		return "", false
 	}
-	for name := range plan.namedConnections {
+	for name := range plan.connectionNames {
 		if name == "" || name == config.PluginConnectionName {
 			return "", false
 		}

--- a/server/internal/bootstrap/connections_test.go
+++ b/server/internal/bootstrap/connections_test.go
@@ -114,7 +114,6 @@ func TestResolvedNamedConnectionDefMergesNamedDefsWithoutTopLevelInheritance(t *
 		t.Fatalf("client_id = %q, want empty", got.Auth.ClientID)
 	}
 }
-
 func TestResolveSpecSurfaceResolvesManifestRelativeSpecPath(t *testing.T) {
 	t.Parallel()
 
@@ -133,81 +132,5 @@ func TestResolveSpecSurfaceResolvesManifestRelativeSpecPath(t *testing.T) {
 	want := filepath.Join("/tmp", "plugins", "notion", "openapi.yaml")
 	if resolved.url != want {
 		t.Fatalf("url = %q, want %q", resolved.url, want)
-	}
-}
-
-func TestBuildConnectionMaps(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name              string
-		plugin            *config.PluginDef
-		wantDefault       string
-		wantAPIConnection string
-		wantMCPConnection string
-	}{
-		{
-			name: "uses primary and mcp surface connections",
-			plugin: &config.PluginDef{
-				OpenAPI:           "https://example.com/openapi.json",
-				OpenAPIConnection: "api",
-				MCPURL:            "https://example.com/mcp",
-				MCPConnection:     "mcp",
-				Connections: map[string]*config.ConnectionDef{
-					"api": {},
-					"mcp": {},
-				},
-			},
-			wantDefault:       "api",
-			wantAPIConnection: "api",
-			wantMCPConnection: "mcp",
-		},
-		{
-			name: "falls back to sole named connection without base auth",
-			plugin: &config.PluginDef{
-				Connections: map[string]*config.ConnectionDef{
-					"api": {},
-				},
-			},
-			wantDefault:       "api",
-			wantAPIConnection: "api",
-			wantMCPConnection: "api",
-		},
-		{
-			name: "does not fall back to sole named connection with base auth",
-			plugin: &config.PluginDef{
-				Auth: &config.ConnectionAuthDef{Type: pluginmanifestv1.AuthTypeOAuth2},
-				Connections: map[string]*config.ConnectionDef{
-					"api": {},
-				},
-			},
-			wantDefault:       config.PluginConnectionName,
-			wantAPIConnection: config.PluginConnectionName,
-			wantMCPConnection: config.PluginConnectionName,
-		},
-	}
-
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			cfg := &config.Config{
-				Integrations: map[string]config.IntegrationDef{
-					"example": {Plugin: tc.plugin},
-				},
-			}
-
-			maps := BuildConnectionMaps(cfg)
-			if got := maps.DefaultConnection["example"]; got != tc.wantDefault {
-				t.Fatalf("default connection = %q, want %q", got, tc.wantDefault)
-			}
-			if got := maps.APIConnection["example"]; got != tc.wantAPIConnection {
-				t.Fatalf("api connection = %q, want %q", got, tc.wantAPIConnection)
-			}
-			if got := maps.MCPConnection["example"]; got != tc.wantMCPConnection {
-				t.Fatalf("mcp connection = %q, want %q", got, tc.wantMCPConnection)
-			}
-		})
 	}
 }

--- a/server/internal/bootstrap/connections_test.go
+++ b/server/internal/bootstrap/connections_test.go
@@ -8,112 +8,127 @@ import (
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
 
-func TestResolvedNamedConnectionDefFallsBackToBaseForSurfaceAlias(t *testing.T) {
+func TestResolvedNamedConnectionDef(t *testing.T) {
 	t.Parallel()
 
-	plugin := &config.PluginDef{
-		Auth: &config.ConnectionAuthDef{
-			Type:     pluginmanifestv1.AuthTypeOAuth2,
-			ClientID: "base-client-id",
-		},
-		ConnectionParams: map[string]config.ConnectionParamDef{
-			"tenant": {Required: true},
-		},
-	}
-
-	got := resolvedNamedConnectionDef(plugin, nil, "api")
-
-	if got.Auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
-		t.Fatalf("auth type = %q, want %q", got.Auth.Type, pluginmanifestv1.AuthTypeOAuth2)
-	}
-	if got.Auth.ClientID != "base-client-id" {
-		t.Fatalf("client_id = %q, want %q", got.Auth.ClientID, "base-client-id")
-	}
-	if len(got.Params) != 1 || !got.Params["tenant"].Required {
-		t.Fatalf("params = %#v, want tenant required", got.Params)
-	}
-}
-
-func TestResolvedNamedConnectionDefDoesNotInheritTopLevelConfig(t *testing.T) {
-	t.Parallel()
-
-	plugin := &config.PluginDef{
-		Auth: &config.ConnectionAuthDef{
-			Type:         pluginmanifestv1.AuthTypeOAuth2,
-			ClientID:     "base-client-id",
-			ClientSecret: "base-client-secret",
-		},
-		ConnectionParams: map[string]config.ConnectionParamDef{
-			"tenant": {Required: true},
-		},
-		Connections: map[string]*config.ConnectionDef{
-			"api": {},
-		},
-	}
-
-	got := resolvedNamedConnectionDef(plugin, nil, "api")
-
-	if got.Auth.Type != "" {
-		t.Fatalf("auth type = %q, want empty", got.Auth.Type)
-	}
-	if got.Auth.ClientID != "" || got.Auth.ClientSecret != "" {
-		t.Fatalf("auth = %#v, want empty auth", got.Auth)
-	}
-	if len(got.Params) != 0 {
-		t.Fatalf("params = %#v, want none", got.Params)
-	}
-}
-
-func TestResolvedNamedConnectionDefMergesNamedDefsWithoutTopLevelInheritance(t *testing.T) {
-	t.Parallel()
-
-	plugin := &config.PluginDef{
-		Auth: &config.ConnectionAuthDef{
-			Type:     pluginmanifestv1.AuthTypeOAuth2,
-			ClientID: "base-client-id",
-		},
-		Connections: map[string]*config.ConnectionDef{
-			"api": {
-				Auth: config.ConnectionAuthDef{
-					ClientSecret: "named-client-secret",
+	testCases := []struct {
+		name             string
+		plugin           *config.PluginDef
+		manifestProvider *pluginmanifestv1.Provider
+		assert           func(*testing.T, config.ConnectionDef)
+	}{
+		{
+			name: "falls back to base for surface alias",
+			plugin: &config.PluginDef{
+				Auth: &config.ConnectionAuthDef{
+					Type:     pluginmanifestv1.AuthTypeOAuth2,
+					ClientID: "base-client-id",
+				},
+				ConnectionParams: map[string]config.ConnectionParamDef{
+					"tenant": {Required: true},
 				},
 			},
+			assert: func(t *testing.T, got config.ConnectionDef) {
+				t.Helper()
+				if got.Auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
+					t.Fatalf("auth type = %q, want %q", got.Auth.Type, pluginmanifestv1.AuthTypeOAuth2)
+				}
+				if got.Auth.ClientID != "base-client-id" {
+					t.Fatalf("client_id = %q, want %q", got.Auth.ClientID, "base-client-id")
+				}
+				if len(got.Params) != 1 || !got.Params["tenant"].Required {
+					t.Fatalf("params = %#v, want tenant required", got.Params)
+				}
+			},
 		},
-	}
-	manifestProvider := &pluginmanifestv1.Provider{
-		Auth: &pluginmanifestv1.ProviderAuth{
-			Type:     pluginmanifestv1.AuthTypeOAuth2,
-			ClientID: "manifest-base-client-id",
+		{
+			name: "does not inherit top level config",
+			plugin: &config.PluginDef{
+				Auth: &config.ConnectionAuthDef{
+					Type:         pluginmanifestv1.AuthTypeOAuth2,
+					ClientID:     "base-client-id",
+					ClientSecret: "base-client-secret",
+				},
+				ConnectionParams: map[string]config.ConnectionParamDef{
+					"tenant": {Required: true},
+				},
+				Connections: map[string]*config.ConnectionDef{
+					"api": {},
+				},
+			},
+			assert: func(t *testing.T, got config.ConnectionDef) {
+				t.Helper()
+				if got.Auth.Type != "" {
+					t.Fatalf("auth type = %q, want empty", got.Auth.Type)
+				}
+				if got.Auth.ClientID != "" || got.Auth.ClientSecret != "" {
+					t.Fatalf("auth = %#v, want empty auth", got.Auth)
+				}
+				if len(got.Params) != 0 {
+					t.Fatalf("params = %#v, want none", got.Params)
+				}
+			},
 		},
-		Connections: map[string]*pluginmanifestv1.ManifestConnectionDef{
-			"api": {
+		{
+			name: "merges named defs without top level inheritance",
+			plugin: &config.PluginDef{
+				Auth: &config.ConnectionAuthDef{
+					Type:     pluginmanifestv1.AuthTypeOAuth2,
+					ClientID: "base-client-id",
+				},
+				Connections: map[string]*config.ConnectionDef{
+					"api": {
+						Auth: config.ConnectionAuthDef{
+							ClientSecret: "named-client-secret",
+						},
+					},
+				},
+			},
+			manifestProvider: &pluginmanifestv1.Provider{
 				Auth: &pluginmanifestv1.ProviderAuth{
-					Type:             pluginmanifestv1.AuthTypeOAuth2,
-					AuthorizationURL: "https://example.com/authorize",
-					TokenURL:         "https://example.com/token",
+					Type:     pluginmanifestv1.AuthTypeOAuth2,
+					ClientID: "manifest-base-client-id",
 				},
+				Connections: map[string]*pluginmanifestv1.ManifestConnectionDef{
+					"api": {
+						Auth: &pluginmanifestv1.ProviderAuth{
+							Type:             pluginmanifestv1.AuthTypeOAuth2,
+							AuthorizationURL: "https://example.com/authorize",
+							TokenURL:         "https://example.com/token",
+						},
+					},
+				},
+			},
+			assert: func(t *testing.T, got config.ConnectionDef) {
+				t.Helper()
+				if got.Auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
+					t.Fatalf("auth type = %q, want %q", got.Auth.Type, pluginmanifestv1.AuthTypeOAuth2)
+				}
+				if got.Auth.AuthorizationURL != "https://example.com/authorize" {
+					t.Fatalf("authorization_url = %q, want %q", got.Auth.AuthorizationURL, "https://example.com/authorize")
+				}
+				if got.Auth.TokenURL != "https://example.com/token" {
+					t.Fatalf("token_url = %q, want %q", got.Auth.TokenURL, "https://example.com/token")
+				}
+				if got.Auth.ClientSecret != "named-client-secret" {
+					t.Fatalf("client_secret = %q, want %q", got.Auth.ClientSecret, "named-client-secret")
+				}
+				if got.Auth.ClientID != "" {
+					t.Fatalf("client_id = %q, want empty", got.Auth.ClientID)
+				}
 			},
 		},
 	}
 
-	got := resolvedNamedConnectionDef(plugin, manifestProvider, "api")
-
-	if got.Auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
-		t.Fatalf("auth type = %q, want %q", got.Auth.Type, pluginmanifestv1.AuthTypeOAuth2)
-	}
-	if got.Auth.AuthorizationURL != "https://example.com/authorize" {
-		t.Fatalf("authorization_url = %q, want %q", got.Auth.AuthorizationURL, "https://example.com/authorize")
-	}
-	if got.Auth.TokenURL != "https://example.com/token" {
-		t.Fatalf("token_url = %q, want %q", got.Auth.TokenURL, "https://example.com/token")
-	}
-	if got.Auth.ClientSecret != "named-client-secret" {
-		t.Fatalf("client_secret = %q, want %q", got.Auth.ClientSecret, "named-client-secret")
-	}
-	if got.Auth.ClientID != "" {
-		t.Fatalf("client_id = %q, want empty", got.Auth.ClientID)
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.assert(t, resolvedNamedConnectionDef(tc.plugin, tc.manifestProvider, "api"))
+		})
 	}
 }
+
 func TestResolveSpecSurfaceResolvesManifestRelativeSpecPath(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/bootstrap/connections_test.go
+++ b/server/internal/bootstrap/connections_test.go
@@ -135,3 +135,79 @@ func TestResolveSpecSurfaceResolvesManifestRelativeSpecPath(t *testing.T) {
 		t.Fatalf("url = %q, want %q", resolved.url, want)
 	}
 }
+
+func TestBuildConnectionMaps(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name              string
+		plugin            *config.PluginDef
+		wantDefault       string
+		wantAPIConnection string
+		wantMCPConnection string
+	}{
+		{
+			name: "uses primary and mcp surface connections",
+			plugin: &config.PluginDef{
+				OpenAPI:           "https://example.com/openapi.json",
+				OpenAPIConnection: "api",
+				MCPURL:            "https://example.com/mcp",
+				MCPConnection:     "mcp",
+				Connections: map[string]*config.ConnectionDef{
+					"api": {},
+					"mcp": {},
+				},
+			},
+			wantDefault:       "api",
+			wantAPIConnection: "api",
+			wantMCPConnection: "mcp",
+		},
+		{
+			name: "falls back to sole named connection without base auth",
+			plugin: &config.PluginDef{
+				Connections: map[string]*config.ConnectionDef{
+					"api": {},
+				},
+			},
+			wantDefault:       "api",
+			wantAPIConnection: "api",
+			wantMCPConnection: "api",
+		},
+		{
+			name: "does not fall back to sole named connection with base auth",
+			plugin: &config.PluginDef{
+				Auth: &config.ConnectionAuthDef{Type: pluginmanifestv1.AuthTypeOAuth2},
+				Connections: map[string]*config.ConnectionDef{
+					"api": {},
+				},
+			},
+			wantDefault:       config.PluginConnectionName,
+			wantAPIConnection: config.PluginConnectionName,
+			wantMCPConnection: config.PluginConnectionName,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &config.Config{
+				Integrations: map[string]config.IntegrationDef{
+					"example": {Plugin: tc.plugin},
+				},
+			}
+
+			maps := BuildConnectionMaps(cfg)
+			if got := maps.DefaultConnection["example"]; got != tc.wantDefault {
+				t.Fatalf("default connection = %q, want %q", got, tc.wantDefault)
+			}
+			if got := maps.APIConnection["example"]; got != tc.wantAPIConnection {
+				t.Fatalf("api connection = %q, want %q", got, tc.wantAPIConnection)
+			}
+			if got := maps.MCPConnection["example"]; got != tc.wantMCPConnection {
+				t.Fatalf("mcp connection = %q, want %q", got, tc.wantMCPConnection)
+			}
+		})
+	}
+}

--- a/server/internal/bootstrap/connections_test.go
+++ b/server/internal/bootstrap/connections_test.go
@@ -124,7 +124,7 @@ func TestResolveSpecSurfaceResolvesManifestRelativeSpecPath(t *testing.T) {
 		OpenAPI: "openapi.yaml",
 	}
 
-	resolved, ok := resolveSpecSurface(plugin, manifestProvider, specSurfaceOpenAPI)
+	resolved, ok := buildPluginConnectionPlan(plugin, manifestProvider).resolvedSurface(specSurfaceOpenAPI)
 	if !ok {
 		t.Fatal("expected openapi surface to resolve")
 	}

--- a/server/internal/bootstrap/inline_gaps_test.go
+++ b/server/internal/bootstrap/inline_gaps_test.go
@@ -525,6 +525,24 @@ func TestBootstrapInvoke_ConnectionSelection(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:           "does not treat plugin surface alias as absent",
+			wantConnection: config.PluginConnectionName,
+			buildPlugin: func(apiBase string) *config.PluginDef {
+				return &config.PluginDef{
+					BaseURL:       apiBase,
+					MCPConnection: config.PluginConnectionAlias,
+					Connections: map[string]*config.ConnectionDef{
+						testOpenAPIConnectionName: {
+							Auth: config.ConnectionAuthDef{Type: pluginmanifestv1.AuthTypeManual},
+						},
+					},
+					Operations: []config.InlineOperationDef{
+						{Name: "list_items", Method: http.MethodGet, Path: "/items"},
+					},
+				}
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/server/internal/bootstrap/inline_gaps_test.go
+++ b/server/internal/bootstrap/inline_gaps_test.go
@@ -132,6 +132,28 @@ func serveOpenAPIBackend(t *testing.T, wantToken string) *httptest.Server {
 	return srv
 }
 
+func mustBootstrapResult(t *testing.T, cfg *config.Config, factories *bootstrap.FactoryRegistry) *bootstrap.Result {
+	t.Helper()
+	if factories == nil {
+		factories = validFactories()
+	}
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+	return result
+}
+
+func mustGetProvider(t *testing.T, result *bootstrap.Result, name string) core.Provider {
+	t.Helper()
+	prov, err := result.Providers.Get(name)
+	if err != nil {
+		t.Fatalf("Get %s provider: %v", name, err)
+	}
+	return prov
+}
+
 func serveMCPToolServer(t *testing.T) *httptest.Server {
 	t.Helper()
 
@@ -154,7 +176,6 @@ func serveMCPToolServer(t *testing.T) *httptest.Server {
 
 func TestInlineMCPOAuth_ConnectionAuthWired(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	mcpSrv := serveMCPOAuthEndpoints(t)
 
@@ -176,11 +197,7 @@ func TestInlineMCPOAuth_ConnectionAuthWired(t *testing.T) {
 		},
 	}
 
-	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
-	if err != nil {
-		t.Fatalf("Bootstrap: %v", err)
-	}
-	<-result.ProvidersReady
+	result := mustBootstrapResult(t, cfg, nil)
 
 	connAuth := result.ConnectionAuth()
 	alphaAuth, ok := connAuth["alpha"]
@@ -203,7 +220,6 @@ func TestInlineMCPOAuth_ConnectionAuthWired(t *testing.T) {
 
 func TestInlineMCPOAuth_SpecLoadedOpenAPI(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	mcpSrv := serveMCPOAuthEndpoints(t)
 	specSrv := serveOpenAPISpec(t)
@@ -223,16 +239,8 @@ func TestInlineMCPOAuth_SpecLoadedOpenAPI(t *testing.T) {
 		},
 	}
 
-	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
-	if err != nil {
-		t.Fatalf("Bootstrap: %v", err)
-	}
-	<-result.ProvidersReady
-
-	prov, err := result.Providers.Get("vendor")
-	if err != nil {
-		t.Fatalf("Get vendor provider: %v", err)
-	}
+	result := mustBootstrapResult(t, cfg, nil)
+	prov := mustGetProvider(t, result, "vendor")
 	cat := prov.Catalog()
 	if cat == nil || len(cat.Operations) == 0 {
 		t.Fatal("expected at least one operation from the openapi spec")
@@ -313,16 +321,8 @@ func TestBootstrap_SpecLoadedManifestCombinesOpenAPIAndMCP(t *testing.T) {
 		},
 	}
 
-	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
-	if err != nil {
-		t.Fatalf("Bootstrap: %v", err)
-	}
-	<-result.ProvidersReady
-
-	prov, err := result.Providers.Get("hybrid")
-	if err != nil {
-		t.Fatalf("Providers.Get: %v", err)
-	}
+	result := mustBootstrapResult(t, cfg, nil)
+	prov := mustGetProvider(t, result, "hybrid")
 	cat := prov.Catalog()
 	if cat == nil {
 		t.Fatal("expected non-nil catalog")
@@ -373,7 +373,6 @@ func TestBootstrap_SpecLoadedManifestCombinesOpenAPIAndMCP(t *testing.T) {
 func TestInlineOAuth_NamedOpenAPIConnectionAuthWired(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
 	specSrv := serveOpenAPISpec(t)
 	var pluginConfig yaml.Node
 	if err := pluginConfig.Encode(map[string]any{
@@ -400,11 +399,7 @@ func TestInlineOAuth_NamedOpenAPIConnectionAuthWired(t *testing.T) {
 		},
 	}
 
-	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
-	if err != nil {
-		t.Fatalf("Bootstrap: %v", err)
-	}
-	<-result.ProvidersReady
+	result := mustBootstrapResult(t, cfg, nil)
 
 	connAuth := result.ConnectionAuth()
 	vendorAuth, ok := connAuth["vendor"]
@@ -423,23 +418,15 @@ func TestInlineOAuth_NamedOpenAPIConnectionAuthWired(t *testing.T) {
 	}
 }
 
-func TestBootstrapInvoke_UsesNamedOpenAPIConnection(t *testing.T) {
-	t.Parallel()
+func invokeListItemsConnection(t *testing.T, buildPlugin func(apiBase string) *config.PluginDef) string {
+	t.Helper()
 
 	ctx := context.Background()
 	apiSrv := serveOpenAPIBackend(t, testOpenAPIAccessToken)
 
 	cfg := validConfig()
 	cfg.Integrations = map[string]config.IntegrationDef{
-		"vendor": {
-			Plugin: &config.PluginDef{
-				OpenAPI:           apiSrv.URL + "/openapi.json",
-				OpenAPIConnection: testOpenAPIConnectionName,
-				Auth: &config.ConnectionAuthDef{
-					Type: pluginmanifestv1.AuthTypeManual,
-				},
-			},
-		},
+		"vendor": {Plugin: buildPlugin(apiSrv.URL)},
 	}
 
 	var gotConnection string
@@ -459,11 +446,7 @@ func TestBootstrapInvoke_UsesNamedOpenAPIConnection(t *testing.T) {
 		}, nil
 	}
 
-	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
-	if err != nil {
-		t.Fatalf("Bootstrap: %v", err)
-	}
-	<-result.ProvidersReady
+	result := mustBootstrapResult(t, cfg, factories)
 
 	resp, err := result.Invoker.Invoke(ctx, &principal.Principal{UserID: "u1"}, "vendor", "", "list_items", nil)
 	if err != nil {
@@ -472,133 +455,82 @@ func TestBootstrapInvoke_UsesNamedOpenAPIConnection(t *testing.T) {
 	if resp.Status != http.StatusOK {
 		t.Fatalf("status = %d, want %d", resp.Status, http.StatusOK)
 	}
-	if gotConnection != testOpenAPIConnectionName {
-		t.Fatalf("connection = %q, want %q", gotConnection, testOpenAPIConnectionName)
-	}
+	return gotConnection
 }
 
-func TestBootstrapInvoke_FallsBackToSoleNamedConnectionWithoutBaseAuth(t *testing.T) {
+func TestBootstrapInvoke_ConnectionSelection(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	apiSrv := serveOpenAPIBackend(t, testOpenAPIAccessToken)
-
-	cfg := validConfig()
-	cfg.Integrations = map[string]config.IntegrationDef{
-		"vendor": {
-			Plugin: &config.PluginDef{
-				BaseURL: apiSrv.URL,
-				Connections: map[string]*config.ConnectionDef{
-					testOpenAPIConnectionName: {
-						Auth: config.ConnectionAuthDef{Type: pluginmanifestv1.AuthTypeManual},
+	testCases := []struct {
+		name           string
+		wantConnection string
+		buildPlugin    func(apiBase string) *config.PluginDef
+	}{
+		{
+			name:           "uses named openapi connection",
+			wantConnection: testOpenAPIConnectionName,
+			buildPlugin: func(apiBase string) *config.PluginDef {
+				return &config.PluginDef{
+					OpenAPI:           apiBase + "/openapi.json",
+					OpenAPIConnection: testOpenAPIConnectionName,
+					Auth: &config.ConnectionAuthDef{
+						Type: pluginmanifestv1.AuthTypeManual,
 					},
-				},
-				Operations: []config.InlineOperationDef{
-					{Name: "list_items", Method: http.MethodGet, Path: "/items"},
-				},
+				}
+			},
+		},
+		{
+			name:           "falls back to sole named connection without base auth",
+			wantConnection: testOpenAPIConnectionName,
+			buildPlugin: func(apiBase string) *config.PluginDef {
+				return &config.PluginDef{
+					BaseURL: apiBase,
+					Connections: map[string]*config.ConnectionDef{
+						testOpenAPIConnectionName: {
+							Auth: config.ConnectionAuthDef{Type: pluginmanifestv1.AuthTypeManual},
+						},
+					},
+					Operations: []config.InlineOperationDef{
+						{Name: "list_items", Method: http.MethodGet, Path: "/items"},
+					},
+				}
+			},
+		},
+		{
+			name:           "does not fall back to sole named connection with base auth",
+			wantConnection: config.PluginConnectionName,
+			buildPlugin: func(apiBase string) *config.PluginDef {
+				return &config.PluginDef{
+					BaseURL: apiBase,
+					Auth: &config.ConnectionAuthDef{
+						Type: pluginmanifestv1.AuthTypeManual,
+					},
+					Connections: map[string]*config.ConnectionDef{
+						testOpenAPIConnectionName: {
+							Auth: config.ConnectionAuthDef{Type: pluginmanifestv1.AuthTypeManual},
+						},
+					},
+					Operations: []config.InlineOperationDef{
+						{Name: "list_items", Method: http.MethodGet, Path: "/items"},
+					},
+				}
 			},
 		},
 	}
 
-	var gotConnection string
-	factories := validFactories()
-	factories.Datastores["test-store"] = func(yaml.Node, bootstrap.Deps) (core.Datastore, error) {
-		return &coretesting.StubDatastore{
-			TokenFn: func(_ context.Context, userID, integration, connection, instance string) (*core.IntegrationToken, error) {
-				gotConnection = connection
-				return &core.IntegrationToken{
-					UserID:      userID,
-					Integration: integration,
-					Connection:  connection,
-					Instance:    instance,
-					AccessToken: testOpenAPIAccessToken,
-				}, nil
-			},
-		}, nil
-	}
-
-	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
-	if err != nil {
-		t.Fatalf("Bootstrap: %v", err)
-	}
-	<-result.ProvidersReady
-
-	resp, err := result.Invoker.Invoke(ctx, &principal.Principal{UserID: "u1"}, "vendor", "", "list_items", nil)
-	if err != nil {
-		t.Fatalf("Invoke: %v", err)
-	}
-	if resp.Status != http.StatusOK {
-		t.Fatalf("status = %d, want %d", resp.Status, http.StatusOK)
-	}
-	if gotConnection != testOpenAPIConnectionName {
-		t.Fatalf("connection = %q, want %q", gotConnection, testOpenAPIConnectionName)
-	}
-}
-
-func TestBootstrapInvoke_DoesNotFallBackToSoleNamedConnectionWithBaseAuth(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	apiSrv := serveOpenAPIBackend(t, testOpenAPIAccessToken)
-
-	cfg := validConfig()
-	cfg.Integrations = map[string]config.IntegrationDef{
-		"vendor": {
-			Plugin: &config.PluginDef{
-				BaseURL: apiSrv.URL,
-				Auth: &config.ConnectionAuthDef{
-					Type: pluginmanifestv1.AuthTypeManual,
-				},
-				Connections: map[string]*config.ConnectionDef{
-					testOpenAPIConnectionName: {
-						Auth: config.ConnectionAuthDef{Type: pluginmanifestv1.AuthTypeManual},
-					},
-				},
-				Operations: []config.InlineOperationDef{
-					{Name: "list_items", Method: http.MethodGet, Path: "/items"},
-				},
-			},
-		},
-	}
-
-	var gotConnection string
-	factories := validFactories()
-	factories.Datastores["test-store"] = func(yaml.Node, bootstrap.Deps) (core.Datastore, error) {
-		return &coretesting.StubDatastore{
-			TokenFn: func(_ context.Context, userID, integration, connection, instance string) (*core.IntegrationToken, error) {
-				gotConnection = connection
-				return &core.IntegrationToken{
-					UserID:      userID,
-					Integration: integration,
-					Connection:  connection,
-					Instance:    instance,
-					AccessToken: testOpenAPIAccessToken,
-				}, nil
-			},
-		}, nil
-	}
-
-	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
-	if err != nil {
-		t.Fatalf("Bootstrap: %v", err)
-	}
-	<-result.ProvidersReady
-
-	resp, err := result.Invoker.Invoke(ctx, &principal.Principal{UserID: "u1"}, "vendor", "", "list_items", nil)
-	if err != nil {
-		t.Fatalf("Invoke: %v", err)
-	}
-	if resp.Status != http.StatusOK {
-		t.Fatalf("status = %d, want %d", resp.Status, http.StatusOK)
-	}
-	if gotConnection != config.PluginConnectionName {
-		t.Fatalf("connection = %q, want %q", gotConnection, config.PluginConnectionName)
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := invokeListItemsConnection(t, tc.buildPlugin); got != tc.wantConnection {
+				t.Fatalf("connection = %q, want %q", got, tc.wantConnection)
+			}
+		})
 	}
 }
 
 func TestInlineResponseMapping_AppliedToOpenAPIProvider(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	specSrv := serveOpenAPISpec(t)
 
@@ -621,16 +553,8 @@ func TestInlineResponseMapping_AppliedToOpenAPIProvider(t *testing.T) {
 		},
 	}
 
-	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
-	if err != nil {
-		t.Fatalf("Bootstrap: %v", err)
-	}
-	<-result.ProvidersReady
-
-	prov, err := result.Providers.Get("mapped")
-	if err != nil {
-		t.Fatalf("Get mapped provider: %v", err)
-	}
+	result := mustBootstrapResult(t, cfg, nil)
+	prov := mustGetProvider(t, result, "mapped")
 	cat := prov.Catalog()
 	if cat == nil || len(cat.Operations) == 0 {
 		t.Fatal("expected at least one operation from the openapi spec")
@@ -649,7 +573,6 @@ func TestInlineResponseMapping_AppliedToOpenAPIProvider(t *testing.T) {
 
 func TestInlineResponseMapping_DataPathOnly(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	specSrv := serveOpenAPISpec(t)
 
@@ -668,16 +591,8 @@ func TestInlineResponseMapping_DataPathOnly(t *testing.T) {
 		},
 	}
 
-	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
-	if err != nil {
-		t.Fatalf("Bootstrap: %v", err)
-	}
-	<-result.ProvidersReady
-
-	prov, err := result.Providers.Get("simple")
-	if err != nil {
-		t.Fatalf("Get simple provider: %v", err)
-	}
+	result := mustBootstrapResult(t, cfg, nil)
+	prov := mustGetProvider(t, result, "simple")
 	if cat := prov.Catalog(); cat == nil || len(cat.Operations) == 0 {
 		t.Fatal("expected at least one operation")
 	}
@@ -685,7 +600,6 @@ func TestInlineResponseMapping_DataPathOnly(t *testing.T) {
 
 func TestInlineResponseMapping_NilDoesNotBreak(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	specSrv := serveOpenAPISpec(t)
 
@@ -701,16 +615,8 @@ func TestInlineResponseMapping_NilDoesNotBreak(t *testing.T) {
 		},
 	}
 
-	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
-	if err != nil {
-		t.Fatalf("Bootstrap: %v", err)
-	}
-	<-result.ProvidersReady
-
-	prov, err := result.Providers.Get("noop")
-	if err != nil {
-		t.Fatalf("Get noop provider: %v", err)
-	}
+	result := mustBootstrapResult(t, cfg, nil)
+	prov := mustGetProvider(t, result, "noop")
 	if cat := prov.Catalog(); cat == nil || len(cat.Operations) == 0 {
 		t.Fatal("expected at least one operation even without response_mapping")
 	}
@@ -769,16 +675,8 @@ func TestInlineOpenAPI_NamedConnectionAuthMapping(t *testing.T) {
 		},
 	}
 
-	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
-	if err != nil {
-		t.Fatalf("Bootstrap: %v", err)
-	}
-	<-result.ProvidersReady
-
-	prov, err := result.Providers.Get("datadog")
-	if err != nil {
-		t.Fatalf("Get provider: %v", err)
-	}
+	result := mustBootstrapResult(t, cfg, nil)
+	prov := mustGetProvider(t, result, "datadog")
 
 	token := `{"api_key":"k1","app_key":"k2"}`
 	opResult, err := prov.Execute(ctx, "list_items", nil, token)
@@ -800,7 +698,6 @@ func TestInlineOpenAPI_NamedConnectionAuthMapping(t *testing.T) {
 
 func TestInlineDeclarative_ConfigDisplayOverridesAppliedAfterRestriction(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	const iconSVG = `<svg viewBox="0 0 10 10"><circle cx="5" cy="5" r="4"/></svg>`
 	iconPath := filepath.Join(t.TempDir(), "icon.svg")
@@ -826,16 +723,8 @@ func TestInlineDeclarative_ConfigDisplayOverridesAppliedAfterRestriction(t *test
 		},
 	}
 
-	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
-	if err != nil {
-		t.Fatalf("Bootstrap: %v", err)
-	}
-	<-result.ProvidersReady
-
-	prov, err := result.Providers.Get("alpha")
-	if err != nil {
-		t.Fatalf("Get provider: %v", err)
-	}
+	result := mustBootstrapResult(t, cfg, nil)
+	prov := mustGetProvider(t, result, "alpha")
 	if prov.DisplayName() != "Alpha Display" {
 		t.Fatalf("DisplayName = %q, want %q", prov.DisplayName(), "Alpha Display")
 	}

--- a/server/internal/bootstrap/inline_gaps_test.go
+++ b/server/internal/bootstrap/inline_gaps_test.go
@@ -477,6 +477,125 @@ func TestBootstrapInvoke_UsesNamedOpenAPIConnection(t *testing.T) {
 	}
 }
 
+func TestBootstrapInvoke_FallsBackToSoleNamedConnectionWithoutBaseAuth(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	apiSrv := serveOpenAPIBackend(t, testOpenAPIAccessToken)
+
+	cfg := validConfig()
+	cfg.Integrations = map[string]config.IntegrationDef{
+		"vendor": {
+			Plugin: &config.PluginDef{
+				BaseURL: apiSrv.URL,
+				Connections: map[string]*config.ConnectionDef{
+					testOpenAPIConnectionName: {
+						Auth: config.ConnectionAuthDef{Type: pluginmanifestv1.AuthTypeManual},
+					},
+				},
+				Operations: []config.InlineOperationDef{
+					{Name: "list_items", Method: http.MethodGet, Path: "/items"},
+				},
+			},
+		},
+	}
+
+	var gotConnection string
+	factories := validFactories()
+	factories.Datastores["test-store"] = func(yaml.Node, bootstrap.Deps) (core.Datastore, error) {
+		return &coretesting.StubDatastore{
+			TokenFn: func(_ context.Context, userID, integration, connection, instance string) (*core.IntegrationToken, error) {
+				gotConnection = connection
+				return &core.IntegrationToken{
+					UserID:      userID,
+					Integration: integration,
+					Connection:  connection,
+					Instance:    instance,
+					AccessToken: testOpenAPIAccessToken,
+				}, nil
+			},
+		}, nil
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	resp, err := result.Invoker.Invoke(ctx, &principal.Principal{UserID: "u1"}, "vendor", "", "list_items", nil)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.Status, http.StatusOK)
+	}
+	if gotConnection != testOpenAPIConnectionName {
+		t.Fatalf("connection = %q, want %q", gotConnection, testOpenAPIConnectionName)
+	}
+}
+
+func TestBootstrapInvoke_DoesNotFallBackToSoleNamedConnectionWithBaseAuth(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	apiSrv := serveOpenAPIBackend(t, testOpenAPIAccessToken)
+
+	cfg := validConfig()
+	cfg.Integrations = map[string]config.IntegrationDef{
+		"vendor": {
+			Plugin: &config.PluginDef{
+				BaseURL: apiSrv.URL,
+				Auth: &config.ConnectionAuthDef{
+					Type: pluginmanifestv1.AuthTypeManual,
+				},
+				Connections: map[string]*config.ConnectionDef{
+					testOpenAPIConnectionName: {
+						Auth: config.ConnectionAuthDef{Type: pluginmanifestv1.AuthTypeManual},
+					},
+				},
+				Operations: []config.InlineOperationDef{
+					{Name: "list_items", Method: http.MethodGet, Path: "/items"},
+				},
+			},
+		},
+	}
+
+	var gotConnection string
+	factories := validFactories()
+	factories.Datastores["test-store"] = func(yaml.Node, bootstrap.Deps) (core.Datastore, error) {
+		return &coretesting.StubDatastore{
+			TokenFn: func(_ context.Context, userID, integration, connection, instance string) (*core.IntegrationToken, error) {
+				gotConnection = connection
+				return &core.IntegrationToken{
+					UserID:      userID,
+					Integration: integration,
+					Connection:  connection,
+					Instance:    instance,
+					AccessToken: testOpenAPIAccessToken,
+				}, nil
+			},
+		}, nil
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	resp, err := result.Invoker.Invoke(ctx, &principal.Principal{UserID: "u1"}, "vendor", "", "list_items", nil)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.Status, http.StatusOK)
+	}
+	if gotConnection != config.PluginConnectionName {
+		t.Fatalf("connection = %q, want %q", gotConnection, config.PluginConnectionName)
+	}
+}
+
 func TestInlineResponseMapping_AppliedToOpenAPIProvider(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/server/internal/bootstrap/inline_gaps_test.go
+++ b/server/internal/bootstrap/inline_gaps_test.go
@@ -154,6 +154,15 @@ func mustGetProvider(t *testing.T, result *bootstrap.Result, name string) core.P
 	return prov
 }
 
+func bootstrapInlineProvider(t *testing.T, name string, plugin *config.PluginDef) core.Provider {
+	t.Helper()
+	cfg := validConfig()
+	cfg.Integrations = map[string]config.IntegrationDef{
+		name: {Plugin: plugin},
+	}
+	return mustGetProvider(t, mustBootstrapResult(t, cfg, nil), name)
+}
+
 func serveMCPToolServer(t *testing.T) *httptest.Server {
 	t.Helper()
 
@@ -529,96 +538,67 @@ func TestBootstrapInvoke_ConnectionSelection(t *testing.T) {
 	}
 }
 
-func TestInlineResponseMapping_AppliedToOpenAPIProvider(t *testing.T) {
+func TestInlineResponseMapping(t *testing.T) {
 	t.Parallel()
 
 	specSrv := serveOpenAPISpec(t)
+	testCases := []struct {
+		name            string
+		integrationName string
+		responseMapping *config.ResponseMappingDef
+		wantOperationID string
+	}{
+		{
+			name:            "applied to openapi provider",
+			integrationName: "mapped",
+			responseMapping: &config.ResponseMappingDef{
+				DataPath: "results",
+				Pagination: &config.PaginationMapping{
+					HasMorePath: "moreDataAvailable",
+					CursorPath:  "nextCursor",
+				},
+			},
+			wantOperationID: "list_items",
+		},
+		{
+			name:            "data path only",
+			integrationName: "simple",
+			responseMapping: &config.ResponseMappingDef{
+				DataPath: "data.items",
+			},
+		},
+		{
+			name:            "nil does not break",
+			integrationName: "noop",
+		},
+	}
 
-	cfg := validConfig()
-	cfg.Integrations = map[string]config.IntegrationDef{
-		"mapped": {
-			Plugin: &config.PluginDef{
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			prov := bootstrapInlineProvider(t, tc.integrationName, &config.PluginDef{
 				OpenAPI: specSrv.URL,
 				Auth: &config.ConnectionAuthDef{
 					Type: "none",
 				},
-				ResponseMapping: &config.ResponseMappingDef{
-					DataPath: "results",
-					Pagination: &config.PaginationMapping{
-						HasMorePath: "moreDataAvailable",
-						CursorPath:  "nextCursor",
-					},
-				},
-			},
-		},
-	}
-
-	result := mustBootstrapResult(t, cfg, nil)
-	prov := mustGetProvider(t, result, "mapped")
-	cat := prov.Catalog()
-	if cat == nil || len(cat.Operations) == 0 {
-		t.Fatal("expected at least one operation from the openapi spec")
-	}
-	found := false
-	for _, op := range cat.Operations {
-		if op.ID == "list_items" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatal("expected list_items operation to be present")
-	}
-}
-
-func TestInlineResponseMapping_DataPathOnly(t *testing.T) {
-	t.Parallel()
-
-	specSrv := serveOpenAPISpec(t)
-
-	cfg := validConfig()
-	cfg.Integrations = map[string]config.IntegrationDef{
-		"simple": {
-			Plugin: &config.PluginDef{
-				OpenAPI: specSrv.URL,
-				Auth: &config.ConnectionAuthDef{
-					Type: "none",
-				},
-				ResponseMapping: &config.ResponseMappingDef{
-					DataPath: "data.items",
-				},
-			},
-		},
-	}
-
-	result := mustBootstrapResult(t, cfg, nil)
-	prov := mustGetProvider(t, result, "simple")
-	if cat := prov.Catalog(); cat == nil || len(cat.Operations) == 0 {
-		t.Fatal("expected at least one operation")
-	}
-}
-
-func TestInlineResponseMapping_NilDoesNotBreak(t *testing.T) {
-	t.Parallel()
-
-	specSrv := serveOpenAPISpec(t)
-
-	cfg := validConfig()
-	cfg.Integrations = map[string]config.IntegrationDef{
-		"noop": {
-			Plugin: &config.PluginDef{
-				OpenAPI: specSrv.URL,
-				Auth: &config.ConnectionAuthDef{
-					Type: "none",
-				},
-			},
-		},
-	}
-
-	result := mustBootstrapResult(t, cfg, nil)
-	prov := mustGetProvider(t, result, "noop")
-	if cat := prov.Catalog(); cat == nil || len(cat.Operations) == 0 {
-		t.Fatal("expected at least one operation even without response_mapping")
+				ResponseMapping: tc.responseMapping,
+			})
+			cat := prov.Catalog()
+			if cat == nil || len(cat.Operations) == 0 {
+				t.Fatal("expected at least one operation")
+			}
+			if tc.wantOperationID == "" {
+				return
+			}
+			for _, op := range cat.Operations {
+				if op.ID == tc.wantOperationID {
+					return
+				}
+			}
+			t.Fatalf("expected %q operation to be present", tc.wantOperationID)
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- centralize plugin connection planning in `connections.go` so default/API/MCP connection selection and auth handler wiring use the same resolved shape
- resolve plugin and named connections once, then reuse the primary spec surface and MCP surface instead of recomputing them in separate paths
- add focused bootstrap tests for surface selection and sole-named-connection fallback behavior

## Testing
- go test ./internal/bootstrap/... ./cmd/gestaltd
- golangci-lint run ./internal/bootstrap/... ./cmd/gestaltd