### PR TITLE
[codex] Fix declarative plugin releases

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -66,7 +66,7 @@ jobs:
           fi
 
   build-declarative:
-    name: Package Declarative Plugin
+    name: Release Declarative Plugin
     needs: prepare
     if: needs.prepare.outputs.plugin-type == 'declarative'
     runs-on: ubuntu-latest
@@ -82,18 +82,14 @@ jobs:
           cache-dependency-path: server/go.sum
       - name: Build gestaltd
         run: cd server && go build -o ../gestaltd ./cmd/gestaltd
-      - name: Package
+      - name: Release plugin
         run: |
-          ASSET="gestalt-plugin-${PLUGIN_NAME}_v${PLUGIN_VERSION}.tar.gz"
-          mkdir -p dist
-          ./gestaltd plugin package --input "plugins/${PLUGIN_NAME}" --output "dist/${ASSET}"
-          shasum -a 256 "dist/${ASSET}" > "dist/${ASSET}.sha256"
+          cd "plugins/${PLUGIN_NAME}"
+          ../../gestaltd plugin release --version "${PLUGIN_VERSION}"
       - uses: actions/upload-artifact@v4
         with:
           name: gestalt-plugin-${{ env.PLUGIN_NAME }}
-          path: |
-            dist/gestalt-plugin-*.tar.gz
-            dist/gestalt-plugin-*.sha256
+          path: plugins/${{ env.PLUGIN_NAME }}/dist/*
           if-no-files-found: error
 
   release-compiled:

--- a/server/cmd/gestaltd/init_test.go
+++ b/server/cmd/gestaltd/init_test.go
@@ -320,6 +320,36 @@ func TestPrepareConfigAcceptsPluginPackageSurfaceConnectionAliases(t *testing.T)
 	}
 }
 
+func TestValidateConfigUsesPreparedManifestForSpecLoadedPluginPackage(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	packagePath := buildPreparedSpecLoadedPluginPackage(t, dir, "github.com/acme/plugins/spec-loaded", "0.1.0")
+	cfgPath := writePreparedPluginPackageConfig(t, dir, packagePath)
+
+	if err := initConfig(cfgPath); err != nil {
+		t.Fatalf("initConfig: %v", err)
+	}
+	if err := validateConfig(cfgPath); err != nil {
+		t.Fatalf("validateConfig: %v", err)
+	}
+
+	_, cfg, err := loadConfigForExecution(cfgPath, true)
+	if err != nil {
+		t.Fatalf("loadConfigForExecution: %v", err)
+	}
+	plugin := cfg.Integrations["example"].Plugin
+	if plugin.ResolvedManifest == nil || plugin.ResolvedManifest.Provider == nil {
+		t.Fatal("expected resolved manifest provider to be set after prepare")
+	}
+	if !filepath.IsAbs(plugin.ResolvedManifest.Provider.OpenAPI) {
+		t.Fatalf("resolved openapi path = %q, want absolute path", plugin.ResolvedManifest.Provider.OpenAPI)
+	}
+	if _, err := os.Stat(plugin.ResolvedManifest.Provider.OpenAPI); err != nil {
+		t.Fatalf("resolved openapi path missing: %v", err)
+	}
+}
+
 func TestValidateConfigUsesPreparedManifestForRuntimePluginPackage(t *testing.T) {
 	t.Parallel()
 
@@ -495,6 +525,40 @@ func buildPreparedTestPluginPackageWithManifestProvider(t *testing.T, dir, sourc
 	}
 
 	archivePath := filepath.Join(dir, "plugin.tar.gz")
+	if err := pluginpkg.CreatePackageFromDir(srcDir, archivePath); err != nil {
+		t.Fatalf("CreatePackageFromDir: %v", err)
+	}
+	return archivePath
+}
+
+func buildPreparedSpecLoadedPluginPackage(t *testing.T, dir, source, version string) string {
+	t.Helper()
+
+	srcDir := filepath.Join(dir, "spec-plugin-src")
+	if err := os.MkdirAll(filepath.Join(srcDir, "specs"), 0755); err != nil {
+		t.Fatalf("MkdirAll specs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "specs", "openapi.yaml"), []byte("openapi: 3.0.0\ninfo:\n  title: Test\n  version: 1.0.0\npaths: {}\n"), 0644); err != nil {
+		t.Fatalf("WriteFile spec: %v", err)
+	}
+
+	manifest := &pluginmanifestv1.Manifest{
+		Source:  source,
+		Version: version,
+		Kinds:   []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			OpenAPI: filepath.ToSlash(filepath.Join("specs", "openapi.yaml")),
+		},
+	}
+	data, err := pluginpkg.EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, pluginpkg.ManifestFile), data, 0644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	archivePath := filepath.Join(dir, "spec-plugin.tar.gz")
 	if err := pluginpkg.CreatePackageFromDir(srcDir, archivePath); err != nil {
 		t.Fatalf("CreatePackageFromDir: %v", err)
 	}

--- a/server/cmd/gestaltd/plugin.go
+++ b/server/cmd/gestaltd/plugin.go
@@ -305,7 +305,7 @@ func releaseRequiresBuildTarget(manifest *pluginmanifestv1.Manifest) bool {
 		case pluginmanifestv1.KindRuntime:
 			return true
 		case pluginmanifestv1.KindProvider:
-			if manifest.Provider == nil || !manifest.Provider.IsDeclarative() {
+			if manifest.Provider == nil || !manifest.Provider.IsManifestBacked() {
 				return true
 			}
 		}
@@ -541,11 +541,27 @@ func copyReleasePackageFiles(manifest *pluginmanifestv1.Manifest, sourceDir, sta
 		return nil
 	}
 
+	copyMaybeLocalPath := func(value string, optional bool) error {
+		if value == "" || filepath.IsAbs(value) || strings.Contains(value, "://") {
+			return nil
+		}
+		return copyPath(value, optional)
+	}
+
 	if err := copyPath(manifest.IconFile, false); err != nil {
 		return err
 	}
 	if manifest.Provider != nil {
 		if err := copyPath(manifest.Provider.ConfigSchemaPath, false); err != nil {
+			return err
+		}
+		if err := copyMaybeLocalPath(manifest.Provider.OpenAPI, false); err != nil {
+			return err
+		}
+		if err := copyMaybeLocalPath(manifest.Provider.GraphQLURL, false); err != nil {
+			return err
+		}
+		if err := copyMaybeLocalPath(manifest.Provider.MCPURL, false); err != nil {
 			return err
 		}
 	}

--- a/server/cmd/gestaltd/plugin_test.go
+++ b/server/cmd/gestaltd/plugin_test.go
@@ -792,6 +792,38 @@ func TestRun_PluginReleaseCopiesDeclarativeProviderSupportFiles(t *testing.T) {
 	}
 }
 
+func TestRun_PluginReleaseCopiesSpecLoadedProviderSupportFiles(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newSpecLoadedProviderReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.11-test"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-spec-loaded-provider_v" + testVersion + ".tar.gz"
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+
+	if manifest.Version != testVersion {
+		t.Fatalf("manifest version = %q, want %q", manifest.Version, testVersion)
+	}
+	if len(manifest.Artifacts) != 0 {
+		t.Fatalf("expected spec-loaded release to omit artifacts, got %+v", manifest.Artifacts)
+	}
+	if manifest.Provider == nil || manifest.Provider.OpenAPI != "specs/openapi.yaml" {
+		t.Fatalf("provider openapi = %#v, want specs/openapi.yaml", manifest.Provider)
+	}
+	for _, rel := range []string{releaseTestIconPath, "specs/openapi.yaml"} {
+		if _, err := os.Stat(filepath.Join(extractDir, filepath.FromSlash(rel))); err != nil {
+			t.Fatalf("expected %s in archive: %v", rel, err)
+		}
+	}
+}
+
 func newPluginPackageFixture(t *testing.T, dir string) string {
 	t.Helper()
 
@@ -908,6 +940,28 @@ func newDeclarativeProviderReleaseFixture(t *testing.T, dir string) string {
 	})
 	writeTestFile(t, pluginDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0644)
 	writeTestFile(t, pluginDir, releaseProviderSchemaPath, []byte(`{"type":"object"}`), 0644)
+	return pluginDir
+}
+
+func newSpecLoadedProviderReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(dir, "spec-loaded-provider")
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatalf("MkdirAll(pluginDir): %v", err)
+	}
+	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
+		Source:      "github.com/testowner/plugins/spec-loaded-provider",
+		Version:     "0.0.1",
+		DisplayName: "Spec Loaded Provider",
+		IconFile:    releaseTestIconPath,
+		Kinds:       []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			OpenAPI: "specs/openapi.yaml",
+		},
+	})
+	writeTestFile(t, pluginDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0644)
+	writeTestFile(t, pluginDir, "specs/openapi.yaml", []byte("openapi: 3.0.0\ninfo:\n  title: Test\n  version: 1.0.0\npaths: {}\n"), 0644)
 	return pluginDir
 }
 

--- a/server/internal/operator/lifecycle.go
+++ b/server/internal/operator/lifecycle.go
@@ -740,6 +740,7 @@ func applyLockedPluginEntry(paths initPaths, lock *Lockfile, kind, name string, 
 	if err != nil {
 		return fmt.Errorf("read prepared manifest for %s %q: %w", kind, name, err)
 	}
+	manifest = pluginpkg.ResolveManifestLocalReferences(manifest, manifestPath)
 	if err := pluginpkg.ValidateConfigForManifest(manifestPath, manifest, manifestKind(kind), configMap); err != nil {
 		return fmt.Errorf("plugin config validation for %s %q: %w", kind, name, err)
 	}

--- a/server/internal/pluginpkg/references.go
+++ b/server/internal/pluginpkg/references.go
@@ -1,0 +1,47 @@
+package pluginpkg
+
+import (
+	"path/filepath"
+	"strings"
+
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+)
+
+// ResolveManifestLocalReferences rewrites local spec references so extracted
+// plugin manifests can be used directly at runtime.
+func ResolveManifestLocalReferences(manifest *pluginmanifestv1.Manifest, manifestPath string) *pluginmanifestv1.Manifest {
+	if manifest == nil || manifest.Provider == nil || manifestPath == "" {
+		return manifest
+	}
+
+	resolve := func(value string) string {
+		if value == "" || filepath.IsAbs(value) || strings.Contains(value, "://") {
+			return value
+		}
+		return filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(value))
+	}
+
+	provider := *manifest.Provider
+	changed := false
+
+	if resolved := resolve(provider.OpenAPI); resolved != provider.OpenAPI {
+		provider.OpenAPI = resolved
+		changed = true
+	}
+	if resolved := resolve(provider.GraphQLURL); resolved != provider.GraphQLURL {
+		provider.GraphQLURL = resolved
+		changed = true
+	}
+	if resolved := resolve(provider.MCPURL); resolved != provider.MCPURL {
+		provider.MCPURL = resolved
+		changed = true
+	}
+
+	if !changed {
+		return manifest
+	}
+
+	cloned := *manifest
+	cloned.Provider = &provider
+	return &cloned
+}

--- a/server/internal/pluginpkg/references.go
+++ b/server/internal/pluginpkg/references.go
@@ -7,8 +7,6 @@ import (
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
 
-// ResolveManifestLocalReferences rewrites local spec references so extracted
-// plugin manifests can be used directly at runtime.
 func ResolveManifestLocalReferences(manifest *pluginmanifestv1.Manifest, manifestPath string) *pluginmanifestv1.Manifest {
 	if manifest == nil || manifest.Provider == nil || manifestPath == "" {
 		return manifest

--- a/server/internal/pluginstore/store.go
+++ b/server/internal/pluginstore/store.go
@@ -61,6 +61,7 @@ func Install(packagePath, destDir string) (*InstalledPlugin, error) {
 		if err != nil {
 			manifestPath = filepath.Join(destDir, pluginpkg.ManifestFile)
 		}
+		manifest = pluginpkg.ResolveManifestLocalReferences(manifest, manifestPath)
 		installed := buildInstalledPlugin(manifest, destDir, manifestPath, "", nil, "")
 		return installed, nil
 	}
@@ -89,6 +90,7 @@ func Install(packagePath, destDir string) (*InstalledPlugin, error) {
 	if manifestPath == "" {
 		manifestPath = filepath.Join(destDir, pluginpkg.ManifestFile)
 	}
+	manifest = pluginpkg.ResolveManifestLocalReferences(manifest, manifestPath)
 	executablePath, err := executablePathForManifest(destDir, manifest)
 	if err != nil {
 		return nil, err
@@ -132,6 +134,7 @@ func InstallFromDir(dirPath, destDir string) (*InstalledPlugin, error) {
 		if err := copyFile(manifestSrc, manifestDest); err != nil {
 			return nil, fmt.Errorf("copy manifest: %w", err)
 		}
+		manifest = pluginpkg.ResolveManifestLocalReferences(manifest, manifestDest)
 		for _, schemaRel := range configSchemaPaths(manifest, dirPath) {
 			schemaSrc := filepath.Join(dirPath, filepath.FromSlash(schemaRel))
 			schemaDest := filepath.Join(destDir, filepath.FromSlash(schemaRel))
@@ -177,6 +180,7 @@ func InstallFromDir(dirPath, destDir string) (*InstalledPlugin, error) {
 	if err := copyFile(manifestSrc, manifestDest); err != nil {
 		return nil, fmt.Errorf("copy manifest: %w", err)
 	}
+	manifest = pluginpkg.ResolveManifestLocalReferences(manifest, manifestDest)
 
 	artifactDest := filepath.Join(destDir, filepath.FromSlash(artifact.Path))
 	if err := os.MkdirAll(filepath.Dir(artifactDest), 0755); err != nil {

--- a/server/sdk/pluginmanifest/v1/types.go
+++ b/server/sdk/pluginmanifest/v1/types.go
@@ -80,12 +80,16 @@ func (p *Provider) IsSpecLoaded() bool {
 	return p != nil && (p.OpenAPI != "" || p.GraphQLURL != "" || p.MCPURL != "")
 }
 
+func (p *Provider) IsManifestBacked() bool {
+	return p != nil && (p.IsDeclarative() || p.IsSpecLoaded())
+}
+
 func (m *Manifest) IsHybridProvider() bool {
 	return m != nil && m.Provider != nil && len(m.Provider.Operations) > 0 && m.Entrypoints.Provider != nil
 }
 
 func (m *Manifest) IsDeclarativeOnlyProvider() bool {
-	return m != nil && m.Provider != nil && m.Provider.IsDeclarative() && !m.IsHybridProvider() && !slices.Contains(m.Kinds, KindRuntime)
+	return m != nil && m.Provider != nil && m.Provider.IsManifestBacked() && !m.IsHybridProvider() && !slices.Contains(m.Kinds, KindRuntime)
 }
 
 type ManifestOperationOverride struct {


### PR DESCRIPTION
## What changed
- treat spec-backed provider manifests as installable declarative packages when they have no executable artifact
- resolve local packaged spec paths like `openapi.yaml` after extraction so prepared plugins can load bundled specs at runtime
- use `gestaltd plugin release` for declarative plugin releases instead of raw `plugin package`
- include bundled spec files in source releases and add regressions for spec-backed plugin release and init flows

## Root cause
The current Notion release artifact is a raw tarball of the plugin directory. That left two problems:
- the packaged manifest still had the old version from source instead of the release tag version
- `gestaltd init` classified the spec-backed provider as needing a platform artifact, so install failed with `no artifact for current platform linux/amd64`

There was also a latent follow-on issue: once extracted, local spec references like `openapi.yaml` were not being rewritten relative to the prepared manifest path.

## Impact
Declarative/spec-backed plugins such as Notion can now be released as real versioned plugin artifacts and then installed from GitHub releases without requiring a fake linux binary artifact.

## Validation
- `go test ./cmd/gestaltd ./internal/pluginstore ./internal/operator`
- built `gestaltd` locally and ran `plugin release --version 0.0.1-alpha.4` in `plugins/notion`
- verified the generated archive contains `plugin.json`, `openapi.yaml`, and `assets/icon.svg`
- verified the generated manifest version is `0.0.1-alpha.4`
