### PR TITLE
Scope CLI and server release tags

### DIFF
--- a/.github/workflows/release-gestalt-cli.yml
+++ b/.github/workflows/release-gestalt-cli.yml
@@ -3,7 +3,7 @@ name: Release Gestalt CLI
 on:
   push:
     tags:
-      - 'v*'
+      - 'gestalt/v*'
 
 permissions:
   contents: write
@@ -66,7 +66,7 @@ jobs:
           merge-multiple: true
       - name: Extract version from tag
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: echo "version=${GITHUB_REF_NAME#gestalt/v}" >> "$GITHUB_OUTPUT"
       - name: Compute image metadata
         id: meta
         run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
@@ -129,7 +129,7 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: echo "version=${GITHUB_REF_NAME#gestalt/v}" >> "$GITHUB_OUTPUT"
 
       - name: Download SHA256 files from release
         env:
@@ -152,6 +152,7 @@ jobs:
       - name: Update formula
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ github.ref_name }}
           SHA_MACOS_ARM64: ${{ steps.checksums.outputs.macos-arm64 }}
           SHA_MACOS_X86: ${{ steps.checksums.outputs.macos-x86_64 }}
           SHA_LINUX_ARM64: ${{ steps.checksums.outputs.linux-arm64 }}
@@ -160,11 +161,8 @@ jobs:
           FORMULA="Formula/gestalt.rb"
           OLD_VERSION=$(grep '^\s*version ' "$FORMULA" | sed 's/.*version "\(.*\)"/\1/')
 
-          # Update version
           sed -i "s/version \"${OLD_VERSION}\"/version \"${VERSION}\"/" "$FORMULA"
-
-          # Update download URLs (version appears in the URL path)
-          sed -i "s|/download/v${OLD_VERSION}/|/download/v${VERSION}/|g" "$FORMULA"
+          perl -0pi -e 's{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-macos-arm64\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-macos-arm64.tar.gz}g; s{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-macos-x86_64\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-macos-x86_64.tar.gz}g; s{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-linux-arm64\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-linux-arm64.tar.gz}g; s{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-linux-x86_64\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-linux-x86_64.tar.gz}g' "$FORMULA"
 
           # Update SHA256 for each platform by matching the URL above it
           awk -v sha_macos_arm64="$SHA_MACOS_ARM64" \

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -3,7 +3,7 @@ name: Release Gestaltd
 on:
   push:
     tags:
-      - 'v*'
+      - 'gestaltd/v*'
 
 permissions:
   contents: write
@@ -65,7 +65,7 @@ jobs:
           path: server/internal/webui/out/
       - name: Extract version from tag
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: echo "version=${GITHUB_REF_NAME#gestaltd/v}" >> "$GITHUB_OUTPUT"
       - name: Build
         env:
           CGO_ENABLED: '0'
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Extract version from tag
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: echo "version=${GITHUB_REF_NAME#gestaltd/v}" >> "$GITHUB_OUTPUT"
       - name: Compute image metadata
         id: meta
         run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
@@ -178,7 +178,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
       - name: Extract version
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: echo "version=${GITHUB_REF_NAME#gestaltd/v}" >> "$GITHUB_OUTPUT"
       - name: Download SHA256 files
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -198,6 +198,7 @@ jobs:
       - name: Update formula
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ github.ref_name }}
           SHA_MACOS_ARM64: ${{ steps.checksums.outputs.macos-arm64 }}
           SHA_MACOS_X86: ${{ steps.checksums.outputs.macos-x86_64 }}
           SHA_LINUX_ARM64: ${{ steps.checksums.outputs.linux-arm64 }}
@@ -206,7 +207,7 @@ jobs:
           FORMULA="Formula/gestaltd.rb"
           OLD_VERSION=$(grep '^\s*version ' "$FORMULA" | sed 's/.*version "\(.*\)"/\1/')
           sed -i "s/version \"${OLD_VERSION}\"/version \"${VERSION}\"/" "$FORMULA"
-          sed -i "s|/download/v${OLD_VERSION}/|/download/v${VERSION}/|g" "$FORMULA"
+          perl -0pi -e 's{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestaltd-macos-arm64\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestaltd-macos-arm64.tar.gz}g; s{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestaltd-macos-x86_64\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestaltd-macos-x86_64.tar.gz}g; s{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestaltd-linux-arm64\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestaltd-linux-arm64.tar.gz}g; s{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestaltd-linux-x86_64\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestaltd-linux-x86_64.tar.gz}g' "$FORMULA"
           awk -v sha_macos_arm64="$SHA_MACOS_ARM64" \
               -v sha_macos_x86="$SHA_MACOS_X86" \
               -v sha_linux_arm64="$SHA_LINUX_ARM64" \

--- a/Formula/lib/private_strategy.rb
+++ b/Formula/lib/private_strategy.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "cgi"
 require "download_strategy"
 
 # Custom download strategy for private GitHub releases.
@@ -12,12 +13,17 @@ class GitHubPrivateRepositoryReleaseDownloadStrategy < CurlDownloadStrategy
   end
 
   def parse_url_pattern
-    url_pattern = %r{https://github\.com/([^/]+)/([^/]+)/releases/download/([^/]+)/(.+)}
+    url_pattern = %r{\Ahttps://github\.com/([^/]+)/([^/]+)/releases/download/(.+)\z}
     unless @url =~ url_pattern
       raise CurlDownloadStrategyError, "URL pattern not supported for private GitHub releases"
     end
 
-    @owner, @repo, @tag, @filename = Regexp.last_match.captures
+    @owner, @repo, release_path = Regexp.last_match.captures
+    @tag, separator, @filename = release_path.rpartition("/")
+
+    if separator.empty? || @tag.empty? || @filename.empty?
+      raise CurlDownloadStrategyError, "URL pattern not supported for private GitHub releases"
+    end
   end
 
   def set_github_token
@@ -58,7 +64,7 @@ class GitHubPrivateRepositoryReleaseDownloadStrategy < CurlDownloadStrategy
   private
 
   def resolve_asset_id
-    release_url = "https://api.github.com/repos/#{@owner}/#{@repo}/releases/tags/#{@tag}"
+    release_url = "https://api.github.com/repos/#{@owner}/#{@repo}/releases/tags/#{CGI.escape(@tag)}"
 
     output, _, status = curl_output(
       "--header", "Authorization: token #{@github_token}",

--- a/docs/pages/contributing.mdx
+++ b/docs/pages/contributing.mdx
@@ -38,6 +38,17 @@ npm run typecheck
 npm run build
 ```
 
+## Release Tags
+
+Release workflows use scoped tags:
+
+- CLI: `gestalt/v<version>`
+- Server: `gestaltd/v<version>`
+- Go SDK: `sdk/go/v<version>`
+- Plugins: `plugin/<plugin>/v<version>`
+
+Keep the bare semantic version aligned across artifacts when they are meant to ship together.
+
 ## Adding New Built-Ins
 
 If you add a new built-in auth provider, datastore, secret manager, binding, runtime, or named provider:


### PR DESCRIPTION
## Summary
- split the CLI release workflow onto `gestalt/v*` tags
- split the server release workflow onto `gestaltd/v*` tags
- document the scoped tag conventions in the contributor docs

## Notes
- formula update steps now rewrite release asset URLs to the scoped tag paths
- this keeps CLI and server releases independent while preserving aligned semantic versions when desired