### PR TITLE
Fix packaged hybrid providers and prep alpha.29

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli", "xtask"]
 
 [workspace.package]
-version = "0.0.1-alpha.23"
+version = "0.0.1-alpha.29"
 edition = "2024"

--- a/server/cmd/gestaltd/e2e_test.go
+++ b/server/cmd/gestaltd/e2e_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -509,6 +510,86 @@ func TestE2EHybridAPIPluginIntegration(t *testing.T) {
 	waitForReady(t, baseURL, 30*time.Second)
 }
 
+func TestE2EHybridSpecLoadedPackageKeepsExecutableAndAllowedOperations(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupHybridSpecLoadedPluginDir(t, dir)
+	archivePath := filepath.Join(dir, "plugin.tar.gz")
+
+	out, err := exec.Command(gestaltdBin, "plugin", "package", "--input", pluginDir, "--output", archivePath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd plugin package: %v\n%s", err, out)
+	}
+
+	port := allocateTestPort(t)
+	cfgPath := writeE2EConfig(t, dir, "plugin.tar.gz", port)
+
+	out, err = exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	lockPath := filepath.Join(dir, initLockfileName)
+	lock, err := readLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("readLockfile: %v", err)
+	}
+	entry, ok := lock.Plugins[lockPluginKey("integration", "example")]
+	if !ok {
+		t.Fatalf("lockfile missing plugin entry: %+v", lock.Plugins)
+	}
+	if entry.Executable == "" {
+		t.Fatal("expected packaged hybrid plugin executable to be preserved in lockfile")
+	}
+
+	cmd := exec.Command(gestaltdBin, "serve", "--locked", "--config", cfgPath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start serve: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(os.Interrupt)
+		_ = cmd.Wait()
+	})
+
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	waitForReady(t, baseURL, 30*time.Second)
+
+	resp, err := http.Get(baseURL + "/api/v1/integrations/example/operations")
+	if err != nil {
+		t.Fatalf("list operations: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("list operations returned %d: %s", resp.StatusCode, body)
+	}
+
+	var ops []struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&ops); err != nil {
+		t.Fatalf("decode operations: %v", err)
+	}
+
+	ids := make([]string, 0, len(ops))
+	for _, op := range ops {
+		ids = append(ids, op.ID)
+	}
+	sort.Strings(ids)
+	if !containsString(ids, "echo") {
+		t.Fatalf("operation ids = %v, want echo from the packaged executable", ids)
+	}
+	if !containsString(ids, "messages.list") || !containsString(ids, "getProfile") {
+		t.Fatalf("operation ids = %v, want aliased spec operations", ids)
+	}
+	if containsString(ids, "gmail.users.labels.list") {
+		t.Fatalf("operation ids = %v, did not expect disallowed raw spec operation", ids)
+	}
+}
+
 func writeHybridAPIPluginConfig(t *testing.T, dir, packageRef string, port int) string {
 	t.Helper()
 
@@ -533,4 +614,102 @@ integrations:
 		t.Fatalf("write config: %v", err)
 	}
 	return cfgPath
+}
+
+func setupHybridSpecLoadedPluginDir(t *testing.T, baseDir string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(baseDir, "hybrid-plugin-src")
+	artifactRel := pluginArtifactRel()
+	artifactAbs := filepath.Join(pluginDir, filepath.FromSlash(artifactRel))
+	specRel := filepath.ToSlash(filepath.Join("specs", "openapi.yaml"))
+
+	if err := os.MkdirAll(filepath.Dir(artifactAbs), 0o755); err != nil {
+		t.Fatalf("MkdirAll artifact dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(pluginDir, "specs"), 0o755); err != nil {
+		t.Fatalf("MkdirAll specs dir: %v", err)
+	}
+	if err := copyFile(pluginBin, artifactAbs); err != nil {
+		t.Fatalf("copy plugin binary: %v", err)
+	}
+
+	spec := `openapi: 3.0.0
+info:
+  title: Hybrid Allowed Ops API
+  version: 1.0.0
+servers:
+  - url: https://api.hybrid.example/v1
+paths:
+  /messages:
+    get:
+      operationId: gmail.users.messages.list
+      responses:
+        "200":
+          description: ok
+  /profile:
+    get:
+      operationId: gmail.users.getProfile
+      responses:
+        "200":
+          description: ok
+  /labels:
+    get:
+      operationId: gmail.users.labels.list
+      responses:
+        "200":
+          description: ok
+`
+	if err := os.WriteFile(filepath.Join(pluginDir, filepath.FromSlash(specRel)), []byte(spec), 0o644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+
+	digest, err := fileSHA256(artifactAbs)
+	if err != nil {
+		t.Fatalf("compute artifact digest: %v", err)
+	}
+
+	manifest := &pluginmanifestv1.Manifest{
+		Source:  "github.com/test/plugins/hybrid-spec-loaded",
+		Version: "0.1.0",
+		Kinds:   []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			OpenAPI: specRel,
+			AllowedOperations: map[string]*pluginmanifestv1.ManifestOperationOverride{
+				"gmail.users.messages.list": {Alias: "messages.list"},
+				"gmail.users.getProfile":    {Alias: "getProfile"},
+			},
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				Path:   artifactRel,
+				SHA256: digest,
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{
+				ArtifactPath: artifactRel,
+			},
+		},
+	}
+	data, err := pluginpkg.EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, pluginpkg.ManifestFile), data, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	return pluginDir
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/server/cmd/gestaltd/plugin_test.go
+++ b/server/cmd/gestaltd/plugin_test.go
@@ -36,6 +36,8 @@ const (
 	prebuiltHybridPluginName   = "prebuilt-hybrid"
 	prebuiltHybridSource       = "github.com/testowner/plugins/prebuilt-hybrid"
 	prebuiltHybridArtifactPath = "bin/provider"
+	specLoadedHybridPluginName = "spec-loaded-hybrid"
+	specLoadedHybridSource     = "github.com/testowner/plugins/spec-loaded-hybrid"
 )
 
 func TestRun_PluginHelpExitsCleanly(t *testing.T) {
@@ -585,6 +587,45 @@ func TestRun_PluginReleasePreservesPrebuiltHybridProvider(t *testing.T) {
 	}
 }
 
+func TestRun_PluginReleasePreservesSpecLoadedHybridProvider(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newSpecLoadedHybridReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.5-test"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-" + specLoadedHybridPluginName + "_v" + testVersion + ".tar.gz"
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != prebuiltHybridArtifactPath {
+		t.Fatalf("artifacts = %+v", manifest.Artifacts)
+	}
+	if manifest.Entrypoints.Provider == nil {
+		t.Fatal("expected provider entrypoint")
+	}
+	if manifest.Entrypoints.Provider.ArtifactPath != prebuiltHybridArtifactPath {
+		t.Fatalf("provider artifact path = %q", manifest.Entrypoints.Provider.ArtifactPath)
+	}
+	if manifest.Provider == nil || manifest.Provider.OpenAPI != "specs/openapi.yaml" {
+		t.Fatalf("provider openapi = %#v, want specs/openapi.yaml", manifest.Provider)
+	}
+	if len(manifest.Provider.AllowedOperations) != 2 {
+		t.Fatalf("allowed operations = %+v", manifest.Provider.AllowedOperations)
+	}
+	if _, err := os.Stat(filepath.Join(extractDir, filepath.FromSlash(prebuiltHybridArtifactPath))); err != nil {
+		t.Fatalf("expected prebuilt artifact in archive: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(extractDir, "specs", "openapi.yaml")); err != nil {
+		t.Fatalf("expected spec file in archive: %v", err)
+	}
+}
+
 func TestRun_PluginReleasePackagesGoModuleWithoutCmdAsSource(t *testing.T) {
 	t.Parallel()
 
@@ -1090,6 +1131,47 @@ func newPrebuiltHybridReleaseFixture(t *testing.T, dir string) string {
 	})
 	writeTestFile(t, pluginDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0644)
 	writeTestFile(t, pluginDir, prebuiltHybridArtifactPath, []byte("prebuilt-provider"), 0755)
+	return pluginDir
+}
+
+func newSpecLoadedHybridReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(dir, specLoadedHybridPluginName)
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatalf("MkdirAll(pluginDir): %v", err)
+	}
+	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
+		Source:      specLoadedHybridSource,
+		Version:     "0.0.1",
+		DisplayName: "Spec Loaded Hybrid",
+		IconFile:    releaseTestIconPath,
+		Kinds:       []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			OpenAPI: "specs/openapi.yaml",
+			AllowedOperations: map[string]*pluginmanifestv1.ManifestOperationOverride{
+				"gmail.users.messages.list": {Alias: "messages.list"},
+				"gmail.users.getProfile":    {Alias: "getProfile"},
+			},
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				Path:   prebuiltHybridArtifactPath,
+				SHA256: sha256HexForTest("spec-loaded-hybrid-provider"),
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{
+				ArtifactPath: prebuiltHybridArtifactPath,
+				Args:         []string{releaseHybridArg},
+			},
+		},
+	})
+	writeTestFile(t, pluginDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0644)
+	writeTestFile(t, pluginDir, prebuiltHybridArtifactPath, []byte("spec-loaded-hybrid-provider"), 0755)
+	writeTestFile(t, pluginDir, "specs/openapi.yaml", []byte("openapi: 3.0.0\ninfo:\n  title: Test\n  version: 1.0.0\npaths: {}\n"), 0644)
 	return pluginDir
 }
 

--- a/server/internal/bootstrap/bootstrap.go
+++ b/server/internal/bootstrap/bootstrap.go
@@ -808,7 +808,7 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 	if err != nil {
 		return nil, fmt.Errorf("create provider %q: %w", name, err)
 	}
-	prov, err := applyAllowedOperations(name, intg, declarative)
+	prov, err := applyAllowedOperations(name, allowedOperations, declarative)
 	if err != nil {
 		return nil, err
 	}
@@ -846,11 +846,24 @@ func buildExternalPluginProvider(ctx context.Context, name string, intg config.I
 	}
 	manifest := intg.Plugin.ResolvedManifest
 	manifestProvider := intg.Plugin.ManifestProvider()
+	allowedOperations := intg.Plugin.AllowedOperations
+	if intg.Plugin.HasResolvedManifest() {
+		resolvedManifest, resolvedAllowedOperations, err := resolveManifestBackedInputs(name, intg.Plugin)
+		if err != nil {
+			closeIfPossible(pluginProv)
+			return nil, err
+		}
+		manifest = resolvedManifest
+		if manifest != nil {
+			manifestProvider = manifest.Provider
+		}
+		allowedOperations = resolvedAllowedOperations
+	}
 	plan := buildPluginConnectionPlan(intg.Plugin, manifestProvider)
 	resolved, hasSpecSurface := plan.configuredSpecSurface()
 
 	if !hasSpecSurface {
-		restricted, err := applyAllowedOperations(name, intg, pluginProv)
+		restricted, err := applyAllowedOperations(name, allowedOperations, pluginProv)
 		if err != nil {
 			closeIfPossible(pluginProv)
 			return nil, err
@@ -861,7 +874,7 @@ func buildExternalPluginProvider(ctx context.Context, name string, intg config.I
 	specProv, err := buildConfiguredSpecProvider(ctx, name, resolved, meta, specProviderConfig{
 		plugin:            intg.Plugin,
 		manifestProvider:  manifestProvider,
-		allowedOperations: intg.Plugin.AllowedOperations,
+		allowedOperations: allowedOperations,
 		baseURL:           intg.Plugin.BaseURL,
 		providerBuildOptions: func(config.ConnectionDef) []provider.BuildOption {
 			return []provider.BuildOption{provider.WithEgressResolver(deps.Egress.Resolver)}
@@ -1287,8 +1300,8 @@ func mergeConnectionAuth(dst *config.ConnectionAuthDef, src config.ConnectionAut
 	}
 }
 
-func applyAllowedOperations(name string, intg config.IntegrationDef, pluginProv core.Provider) (core.Provider, error) {
-	policy, err := operationexposure.New(intg.Plugin.AllowedOperations)
+func applyAllowedOperations(name string, allowedOperations map[string]*config.OperationOverride, pluginProv core.Provider) (core.Provider, error) {
+	policy, err := operationexposure.New(allowedOperations)
 	if err != nil {
 		return nil, fmt.Errorf("integration %q plugin: %w", name, err)
 	}

--- a/server/sdk/pluginmanifest/v1/types.go
+++ b/server/sdk/pluginmanifest/v1/types.go
@@ -86,11 +86,11 @@ func (p *Provider) IsManifestBacked() bool {
 }
 
 func (m *Manifest) IsHybridProvider() bool {
-	return m != nil && m.Provider != nil && len(m.Provider.Operations) > 0 && m.Entrypoints.Provider != nil
+	return m != nil && m.Provider != nil && m.Provider.IsManifestBacked() && m.Entrypoints.Provider != nil
 }
 
 func (m *Manifest) IsDeclarativeOnlyProvider() bool {
-	return m != nil && m.Provider != nil && m.Provider.IsManifestBacked() && !m.IsHybridProvider() && !slices.Contains(m.Kinds, KindRuntime)
+	return m != nil && m.Provider != nil && m.Provider.IsManifestBacked() && m.Entrypoints.Provider == nil && !slices.Contains(m.Kinds, KindRuntime)
 }
 
 type ManifestOperationOverride struct {


### PR DESCRIPTION
## Summary
- classify manifest-backed providers with a provider entrypoint as hybrid even when `provider.operations` is empty
- preserve manifest `allowed_operations` when composing packaged hybrid plugin spec surfaces
- cover the regression with command/e2e tests for `plugin release` and `gestaltd init/serve --locked`, and bump the CLI workspace version to `0.0.1-alpha.29`

## Problem
Packaged hybrid plugins like the released Gmail plugin ship an OpenAPI surface plus an executable provider entrypoint, but they do not declare custom operations in `provider.operations`. We were classifying those manifests as declarative-only, so `gestaltd init` omitted the executable from the lockfile and runtime only exposed the REST/OpenAPI operations.

After restoring the executable path, the hybrid bootstrap path still ignored manifest `allowed_operations`, which meant packaged hybrids would expose the full raw OpenAPI catalog instead of the intended aliased subset.

## Testing
- `go test ./internal/bootstrap -run 'TestHybridPluginUsesManifestStaticHeadersForSpecSurface|TestHybridPluginUsesManifestManagedParametersForSpecSurface' -count=1`
- `go test ./cmd/gestaltd -run 'TestRun_PluginReleasePreservesSpecLoadedHybridProvider|TestE2EHybridSpecLoadedPackageKeepsExecutableAndAllowedOperations' -count=1`
- `cargo test -p gestalt`

## Release note
The next release tag should be `v0.0.1-alpha.29` so the server fix ships and the CLI stops reporting the stale `alpha.23` version string.
