### PR TITLE
[codex] Support managed path parameters

### DIFF
--- a/server/internal/bootstrap/bootstrap.go
+++ b/server/internal/bootstrap/bootstrap.go
@@ -1136,6 +1136,7 @@ func applyManagedParameters(def *provider.Definition, plugin *config.PluginDef, 
 				return fmt.Errorf("managed parameter %q conflicts with configured header", param.Name)
 			}
 			def.Headers[param.Name] = param.Value
+		case config.ManagedParameterInPath:
 		default:
 			return fmt.Errorf("unsupported managed parameter location %q", param.In)
 		}
@@ -1143,6 +1144,12 @@ func applyManagedParameters(def *provider.Definition, plugin *config.PluginDef, 
 
 	for opName := range def.Operations {
 		op := def.Operations[opName]
+		for _, param := range params {
+			if param.In != config.ManagedParameterInPath {
+				continue
+			}
+			op.Path = strings.ReplaceAll(op.Path, "{"+param.Name+"}", param.Value)
+		}
 		filtered := op.Parameters[:0]
 		for _, param := range op.Parameters {
 			if isManagedOperationParameter(param, params) {

--- a/server/internal/bootstrap/bootstrap_test.go
+++ b/server/internal/bootstrap/bootstrap_test.go
@@ -155,7 +155,7 @@ func TestValidateRejectsInvalidManagedParameters(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected invalid managed parameters")
 	}
-	if !strings.Contains(err.Error(), `managed_parameters[0].in "query" must be "header"`) {
+	if !strings.Contains(err.Error(), `managed_parameters[0].in "query" must be "header" or "path"`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/server/internal/bootstrap/executable_plugin_test.go
+++ b/server/internal/bootstrap/executable_plugin_test.go
@@ -739,3 +739,151 @@ func TestHybridPluginUsesManifestManagedParametersForSpecSurface(t *testing.T) {
 		t.Fatal("timed out waiting for upstream request")
 	}
 }
+
+func TestHybridPluginUsesManifestManagedPathParametersForSpecSurface(t *testing.T) {
+	t.Parallel()
+
+	const managedAccountID = "acct-managed"
+
+	bin := buildEchoPluginBinary(t)
+
+	gotPath := make(chan string, 1)
+	gotPageSize := make(chan string, 1)
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath <- r.URL.Path
+		gotPageSize <- r.URL.Query().Get("page_size")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	}))
+	testutil.CloseOnCleanup(t, apiSrv)
+
+	specSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"openapi": "3.0.0",
+			"info":    map[string]string{"title": "Hybrid Managed Path Parameters Test API"},
+			"servers": []any{map[string]string{"url": apiSrv.URL}},
+			"paths": map[string]any{
+				"/accounts/{account_id}/items": map[string]any{
+					"get": map[string]any{
+						"operationId": "list_items",
+						"summary":     "List items",
+						"parameters": []any{
+							map[string]any{
+								"name":     "account_id",
+								"in":       "path",
+								"required": true,
+								"schema":   map[string]any{"type": "string"},
+							},
+							map[string]any{
+								"name":   "page_size",
+								"in":     "query",
+								"schema": map[string]any{"type": "integer"},
+							},
+						},
+					},
+				},
+			},
+		})
+	}))
+	testutil.CloseOnCleanup(t, specSrv)
+
+	manifest := &pluginmanifestv1.Manifest{
+		Source:  "github.com/acme/plugins/hybrid",
+		Version: "1.0.0",
+		Kinds:   []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			OpenAPI: specSrv.URL,
+			ManagedParameters: []pluginmanifestv1.ManagedParameter{
+				{
+					In:    "path",
+					Name:  "account_id",
+					Value: managedAccountID,
+				},
+			},
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				Path:   "artifacts/" + runtime.GOOS + "/" + runtime.GOARCH + "/provider",
+				SHA256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{
+				ArtifactPath: "artifacts/" + runtime.GOOS + "/" + runtime.GOARCH + "/provider",
+			},
+		},
+	}
+	cfg := &config.Config{
+		Integrations: map[string]config.IntegrationDef{
+			"hybrid": {
+				Plugin: &config.PluginDef{
+					Command:          bin,
+					Args:             []string{"provider"},
+					ResolvedManifest: manifest,
+				},
+			},
+		},
+	}
+
+	factories := NewFactoryRegistry()
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	prov, err := providers.Get("hybrid")
+	if err != nil {
+		t.Fatalf("providers.Get(hybrid): %v", err)
+	}
+
+	cat := prov.Catalog()
+	if cat == nil {
+		t.Fatalf("unexpected catalog: %+v", cat)
+	}
+	foundListItems := false
+	for i := range cat.Operations {
+		if cat.Operations[i].ID == "list_items" {
+			foundListItems = true
+			if got := cat.Operations[i].Path; got != "/accounts/acct-managed/items" {
+				t.Fatalf("catalog path = %q, want %q", got, "/accounts/acct-managed/items")
+			}
+			if got := cat.Operations[i].Parameters; len(got) != 1 || got[0].Name != "page_size" {
+				t.Fatalf("catalog params = %+v, want only page_size", got)
+			}
+			break
+		}
+	}
+	if !foundListItems {
+		t.Fatalf("expected list_items operation in catalog: %+v", cat.Operations)
+	}
+
+	result, err := prov.Execute(context.Background(), "list_items", map[string]any{"page_size": 25}, "")
+	if err != nil {
+		t.Fatalf("Execute(list_items): %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", result.Status, http.StatusOK)
+	}
+
+	select {
+	case got := <-gotPath:
+		if got != "/accounts/acct-managed/items" {
+			t.Fatalf("path = %q, want %q", got, "/accounts/acct-managed/items")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for upstream request")
+	}
+
+	select {
+	case got := <-gotPageSize:
+		if got != "25" {
+			t.Fatalf("page_size = %q, want %q", got, "25")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for upstream query param")
+	}
+}

--- a/server/internal/bootstrap/headers_test.go
+++ b/server/internal/bootstrap/headers_test.go
@@ -202,3 +202,115 @@ func TestBootstrap_ManagedParametersInjectHeadersAndHideOpenAPIParams(t *testing
 		t.Fatal("timed out waiting for upstream query param")
 	}
 }
+
+func TestBootstrap_ManagedParametersRewritePathParamsAndHideOpenAPIParams(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const managedAccountID = "acct-managed"
+
+	gotPath := make(chan string, 1)
+	gotPageSize := make(chan string, 1)
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath <- r.URL.Path
+		gotPageSize <- r.URL.Query().Get("page_size")
+		writeTestJSON(w, map[string]any{"messages": []any{}})
+	}))
+	testutil.CloseOnCleanup(t, apiSrv)
+
+	specSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"openapi": "3.0.0",
+			"info":    map[string]string{"title": "Managed Path Parameters Test API"},
+			"servers": []any{map[string]string{"url": apiSrv.URL}},
+			"paths": map[string]any{
+				"/accounts/{account_id}/items": map[string]any{
+					"get": map[string]any{
+						"operationId": "list_items",
+						"summary":     "List items",
+						"parameters": []any{
+							map[string]any{
+								"name":     "account_id",
+								"in":       "path",
+								"required": true,
+								"schema":   map[string]any{"type": "string"},
+							},
+							map[string]any{
+								"name":   "page_size",
+								"in":     "query",
+								"schema": map[string]any{"type": "integer"},
+							},
+						},
+					},
+				},
+			},
+		})
+	}))
+	testutil.CloseOnCleanup(t, specSrv)
+
+	cfg := validConfig()
+	cfg.Integrations = map[string]config.IntegrationDef{
+		"sample": {
+			Plugin: &config.PluginDef{
+				OpenAPI: specSrv.URL,
+				ManagedParameters: []config.ManagedParameterDef{
+					{
+						In:    "path",
+						Name:  "account_id",
+						Value: managedAccountID,
+					},
+				},
+			},
+		},
+	}
+
+	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	prov, err := result.Providers.Get("sample")
+	if err != nil {
+		t.Fatalf("Providers.Get: %v", err)
+	}
+
+	cat := prov.Catalog()
+	if cat == nil || len(cat.Operations) != 1 {
+		t.Fatalf("unexpected catalog: %+v", cat)
+	}
+	if got := cat.Operations[0].Path; got != "/accounts/acct-managed/items" {
+		t.Fatalf("catalog path = %q, want %q", got, "/accounts/acct-managed/items")
+	}
+	params := cat.Operations[0].Parameters
+	if len(params) != 1 || params[0].Name != "page_size" {
+		t.Fatalf("catalog params = %+v, want only page_size", params)
+	}
+
+	execResult, err := prov.Execute(ctx, "list_items", map[string]any{"page_size": 25}, "")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if execResult.Status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", execResult.Status, http.StatusOK)
+	}
+
+	select {
+	case got := <-gotPath:
+		if got != "/accounts/acct-managed/items" {
+			t.Fatalf("path = %q, want %q", got, "/accounts/acct-managed/items")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for upstream path")
+	}
+
+	select {
+	case got := <-gotPageSize:
+		if got != "25" {
+			t.Fatalf("page_size = %q, want %q", got, "25")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for upstream query param")
+	}
+}

--- a/server/internal/config/managed_parameters.go
+++ b/server/internal/config/managed_parameters.go
@@ -6,7 +6,10 @@ import (
 	"strings"
 )
 
-const ManagedParameterInHeader = "header"
+const (
+	ManagedParameterInHeader = "header"
+	ManagedParameterInPath   = "path"
+)
 
 func NormalizeManagedParameter(param ManagedParameterDef) ManagedParameterDef {
 	param.In = strings.ToLower(strings.TrimSpace(param.In))
@@ -60,8 +63,8 @@ func ValidateManagedParameters(params []ManagedParameterDef) error {
 		if param.In == "" {
 			return fmt.Errorf("managed_parameters[%d].in is required", i)
 		}
-		if param.In != ManagedParameterInHeader {
-			return fmt.Errorf("managed_parameters[%d].in %q must be %q", i, param.In, ManagedParameterInHeader)
+		if param.In != ManagedParameterInHeader && param.In != ManagedParameterInPath {
+			return fmt.Errorf("managed_parameters[%d].in %q must be %q or %q", i, param.In, ManagedParameterInHeader, ManagedParameterInPath)
 		}
 		if param.Name == "" {
 			return fmt.Errorf("managed_parameters[%d].name is required", i)

--- a/server/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/server/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -475,7 +475,7 @@
       "properties": {
         "in": {
           "type": "string",
-          "enum": ["header"]
+          "enum": ["header", "path"]
         },
         "name": {
           "type": "string",


### PR DESCRIPTION
## Summary
Support `managed_parameters` with `in: path` for manifest-backed providers.

## What changed
- allow `path` alongside `header` in managed parameter validation and manifest schema
- rewrite matching path placeholders to managed literals during bootstrap
- continue hiding managed params from the surfaced catalog
- add functional bootstrap coverage for inline OpenAPI and hybrid manifest-backed providers

## Why
This lets integrations hide fixed path segments such as account or user identifiers without forcing callers to pass them explicitly.

## Validation
- `go test ./...` in `server/`
