### PR TITLE
[codex] pass through upstream HTTP errors

### DIFF
--- a/client/cli/src/api.rs
+++ b/client/cli/src/api.rs
@@ -163,7 +163,10 @@ impl ApiClient {
         let body = resp.text().context("failed to read response body")?;
 
         if status.is_client_error() || status.is_server_error() {
-            let message = format_error_message(status, &body);
+            let message = serde_json::from_str::<serde_json::Value>(&body)
+                .ok()
+                .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(String::from))
+                .unwrap_or_else(|| format!("HTTP {}: {}", status.as_u16(), body));
 
             if status == StatusCode::UNAUTHORIZED && self.token_source == TokenSource::EnvVar {
                 bail!(
@@ -185,27 +188,6 @@ impl ApiClient {
     }
 }
 
-fn format_error_message(status: StatusCode, body: &str) -> String {
-    if body.trim().is_empty() {
-        return format!("HTTP {}", status.as_u16());
-    }
-
-    if let Ok(value) = serde_json::from_str::<serde_json::Value>(body) {
-        if let Some(message) = value
-            .get("error")
-            .and_then(|error| error.as_str())
-            .map(String::from)
-        {
-            return message;
-        }
-
-        let pretty = serde_json::to_string_pretty(&value).unwrap_or_else(|_| body.to_string());
-        return format!("HTTP {}:\n{}", status.as_u16(), pretty);
-    }
-
-    format!("HTTP {}: {}", status.as_u16(), body)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -220,35 +202,5 @@ mod tests {
     fn test_base_url_trailing_slash() {
         let client = ApiClient::new("http://localhost:8080/", "test-token").unwrap();
         assert_eq!(client.base_url, "http://localhost:8080");
-    }
-
-    #[test]
-    fn test_format_error_message_prefers_top_level_error_string() {
-        let message = format_error_message(
-            StatusCode::BAD_REQUEST,
-            r#"{"error":"channel_not_found","details":{"channel":"abc"}}"#,
-        );
-
-        assert_eq!(message, "channel_not_found");
-    }
-
-    #[test]
-    fn test_format_error_message_pretty_prints_json_body() {
-        let message = format_error_message(
-            StatusCode::BAD_REQUEST,
-            r#"{"error":{"message":"invalid parameter: limit"}}"#,
-        );
-
-        assert_eq!(
-            message,
-            "HTTP 400:\n{\n  \"error\": {\n    \"message\": \"invalid parameter: limit\"\n  }\n}"
-        );
-    }
-
-    #[test]
-    fn test_format_error_message_handles_empty_body() {
-        let message = format_error_message(StatusCode::BAD_GATEWAY, "");
-
-        assert_eq!(message, "HTTP 502");
     }
 }

--- a/client/cli/src/api.rs
+++ b/client/cli/src/api.rs
@@ -163,10 +163,7 @@ impl ApiClient {
         let body = resp.text().context("failed to read response body")?;
 
         if status.is_client_error() || status.is_server_error() {
-            let message = serde_json::from_str::<serde_json::Value>(&body)
-                .ok()
-                .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(String::from))
-                .unwrap_or_else(|| format!("HTTP {}: {}", status.as_u16(), body));
+            let message = format_error_message(status, &body);
 
             if status == StatusCode::UNAUTHORIZED && self.token_source == TokenSource::EnvVar {
                 bail!(
@@ -188,6 +185,27 @@ impl ApiClient {
     }
 }
 
+fn format_error_message(status: StatusCode, body: &str) -> String {
+    if body.trim().is_empty() {
+        return format!("HTTP {}", status.as_u16());
+    }
+
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(body) {
+        if let Some(message) = value
+            .get("error")
+            .and_then(|error| error.as_str())
+            .map(String::from)
+        {
+            return message;
+        }
+
+        let pretty = serde_json::to_string_pretty(&value).unwrap_or_else(|_| body.to_string());
+        return format!("HTTP {}:\n{}", status.as_u16(), pretty);
+    }
+
+    format!("HTTP {}: {}", status.as_u16(), body)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -202,5 +220,35 @@ mod tests {
     fn test_base_url_trailing_slash() {
         let client = ApiClient::new("http://localhost:8080/", "test-token").unwrap();
         assert_eq!(client.base_url, "http://localhost:8080");
+    }
+
+    #[test]
+    fn test_format_error_message_prefers_top_level_error_string() {
+        let message = format_error_message(
+            StatusCode::BAD_REQUEST,
+            r#"{"error":"channel_not_found","details":{"channel":"abc"}}"#,
+        );
+
+        assert_eq!(message, "channel_not_found");
+    }
+
+    #[test]
+    fn test_format_error_message_pretty_prints_json_body() {
+        let message = format_error_message(
+            StatusCode::BAD_REQUEST,
+            r#"{"error":{"message":"invalid parameter: limit"}}"#,
+        );
+
+        assert_eq!(
+            message,
+            "HTTP 400:\n{\n  \"error\": {\n    \"message\": \"invalid parameter: limit\"\n  }\n}"
+        );
+    }
+
+    #[test]
+    fn test_format_error_message_handles_empty_body() {
+        let message = format_error_message(StatusCode::BAD_GATEWAY, "");
+
+        assert_eq!(message, "HTTP 502");
     }
 }

--- a/server/internal/apiexec/apiexec.go
+++ b/server/internal/apiexec/apiexec.go
@@ -35,8 +35,6 @@ var retryableStatusCodes = map[int]bool{
 
 var pathParamRe = regexp.MustCompile(`\{([^}]+)\}`)
 
-// UpstreamHTTPError preserves the upstream HTTP response for callers that want
-// to surface the real status/body while still treating the request as failed.
 type UpstreamHTTPError struct {
 	Status  int
 	Headers http.Header

--- a/server/internal/apiexec/apiexec.go
+++ b/server/internal/apiexec/apiexec.go
@@ -35,6 +35,32 @@ var retryableStatusCodes = map[int]bool{
 
 var pathParamRe = regexp.MustCompile(`\{([^}]+)\}`)
 
+// UpstreamHTTPError preserves the upstream HTTP response for callers that want
+// to surface the real status/body while still treating the request as failed.
+type UpstreamHTTPError struct {
+	Status  int
+	Headers http.Header
+	Body    string
+	Cause   error
+}
+
+func (e *UpstreamHTTPError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Cause != nil {
+		return e.Cause.Error()
+	}
+	return fmt.Sprintf("HTTP %d: %s", e.Status, e.Body)
+}
+
+func (e *UpstreamHTTPError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
 // ResponseChecker validates a response body beyond the default HTTP status check.
 // If it returns a non-nil error, Do treats the response as a failure.
 type ResponseChecker func(status int, body []byte) error
@@ -212,11 +238,23 @@ func doOnce(
 
 	if req.CheckResponse != nil {
 		if err := req.CheckResponse(resp.StatusCode, respBody); err != nil {
+			if resp.StatusCode >= http.StatusBadRequest {
+				return nil, resp.StatusCode, retryAfter, retryableStatusCodes[resp.StatusCode], &UpstreamHTTPError{
+					Status:  resp.StatusCode,
+					Headers: resp.Header.Clone(),
+					Body:    string(respBody),
+					Cause:   err,
+				}
+			}
 			return nil, resp.StatusCode, retryAfter, retryableStatusCodes[resp.StatusCode], err
 		}
 	} else if resp.StatusCode >= http.StatusBadRequest {
 		retryable := retryableStatusCodes[resp.StatusCode]
-		return nil, resp.StatusCode, retryAfter, retryable, fmt.Errorf("HTTP %d: %s", resp.StatusCode, respBody)
+		return nil, resp.StatusCode, retryAfter, retryable, &UpstreamHTTPError{
+			Status:  resp.StatusCode,
+			Headers: resp.Header.Clone(),
+			Body:    string(respBody),
+		}
 	}
 
 	return &core.OperationResult{

--- a/server/internal/apiexec/apiexec_test.go
+++ b/server/internal/apiexec/apiexec_test.go
@@ -153,6 +153,40 @@ func TestDoUsesCustomAuthHeaderAndBodyOverride(t *testing.T) {
 	}
 }
 
+func TestDoReturnsUpstreamHTTPError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid parameter: limit"}}`))
+	}))
+	testutil.CloseOnCleanup(t, srv)
+
+	_, err := Do(context.Background(), srv.Client(), Request{
+		Method:  http.MethodGet,
+		BaseURL: srv.URL,
+		Path:    "/items",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var upstreamErr *UpstreamHTTPError
+	if !errors.As(err, &upstreamErr) {
+		t.Fatalf("expected UpstreamHTTPError, got %T", err)
+	}
+	if upstreamErr.Status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", upstreamErr.Status, http.StatusBadRequest)
+	}
+	if upstreamErr.Body != `{"error":{"message":"invalid parameter: limit"}}` {
+		t.Fatalf("body = %q", upstreamErr.Body)
+	}
+	if got := upstreamErr.Headers.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", got)
+	}
+}
+
 func TestDoGraphQLBasicQuery(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/server/handlers.go
+++ b/server/internal/server/handlers.go
@@ -369,6 +369,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 
 	result, err := s.invoker.Invoke(r.Context(), p, providerName, instance, operationName, params)
 	if err != nil {
+		var upstreamErr *apiexec.UpstreamHTTPError
 		switch {
 		case errors.Is(err, invocation.ErrProviderNotFound):
 			writeError(w, http.StatusNotFound, fmt.Sprintf("integration %q not found", providerName))
@@ -390,6 +391,12 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, "this integration is accessible only via MCP")
 		case errors.Is(err, apiexec.ErrMissingPathParam):
 			writeError(w, http.StatusBadRequest, err.Error())
+		case errors.As(err, &upstreamErr):
+			writeOperationResult(w, &core.OperationResult{
+				Status:  upstreamErr.Status,
+				Headers: upstreamErr.Headers,
+				Body:    upstreamErr.Body,
+			})
 		default:
 			slog.ErrorContext(r.Context(), "operation failed", "provider", providerName, "operation", operationName, "error", err)
 			writeError(w, http.StatusBadGateway, "operation failed")
@@ -397,9 +404,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", core.ContentTypeJSON)
-	w.WriteHeader(result.Status)
-	_, _ = fmt.Fprint(w, result.Body)
+	writeOperationResult(w, result)
 }
 
 type loginRequest struct {

--- a/server/internal/server/response.go
+++ b/server/internal/server/response.go
@@ -16,3 +16,21 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 func writeError(w http.ResponseWriter, status int, message string) {
 	writeJSON(w, status, map[string]string{"error": message})
 }
+
+func writeOperationResult(w http.ResponseWriter, result *core.OperationResult) {
+	if result == nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	contentType := core.ContentTypeJSON
+	if result.Headers != nil {
+		if ct := result.Headers.Get("Content-Type"); ct != "" {
+			contentType = ct
+		}
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	w.WriteHeader(result.Status)
+	_, _ = w.Write([]byte(result.Body))
+}

--- a/server/internal/server/server_test.go
+++ b/server/internal/server/server_test.go
@@ -4423,6 +4423,73 @@ func TestErrorSanitization(t *testing.T) {
 	}
 }
 
+func TestUpstreamHTTPErrorPassthrough(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"message": "invalid parameter: limit",
+			},
+		})
+	}))
+	testutil.CloseOnCleanup(t, upstream)
+
+	prov, err := provider.Build(&provider.Definition{
+		Provider:         "test-int",
+		DisplayName:      "Test Integration",
+		BaseURL:          upstream.URL,
+		ConnectionMode:   "none",
+		Auth:             provider.AuthDef{Type: "manual"},
+		ErrorMessagePath: "error.message",
+		Operations: map[string]provider.OperationDef{
+			"do_thing": {Description: "Do a thing", Method: http.MethodGet, Path: "/do_thing"},
+		},
+	}, config.ConnectionDef{})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, prov)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/test-int/do_thing", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, body)
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.Contains(got, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json", got)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(body), `"operation failed"`) {
+		t.Fatalf("expected upstream body, got generic error: %s", body)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("decoding upstream body: %v", err)
+	}
+	errObj, ok := decoded["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected nested error object, got %v", decoded)
+	}
+	if errObj["message"] != "invalid parameter: limit" {
+		t.Fatalf("message = %v, want %q", errObj["message"], "invalid parameter: limit")
+	}
+}
+
 type stubAuthWithToken struct {
 	coretesting.StubAuthProvider
 }


### PR DESCRIPTION
## What changed

This PR stops collapsing upstream REST/OpenAPI HTTP failures into a generic `operation failed` response.

- tag upstream HTTP failures as a typed `UpstreamHTTPError`
- pass upstream status/body through `gestaltd` when the failure came from an upstream HTTP response
- preserve upstream `Content-Type` when returning that response
- keep masking arbitrary internal provider/plugin errors

## Why

Today declarative/OpenAPI providers extract useful upstream error messages, but those failures still flow through the internal `error` path and get flattened to `{"error":"operation failed"}` at the HTTP boundary.

That makes `gestalt invoke` unhelpful for real API validation failures even when the upstream returned a legitimate user-facing error response.

## Impact

- upstream API 4xx/5xx responses now reach clients with their real status/body/content type
- internal execution failures still stay masked behind the generic error response
- the change reuses the existing `OperationResult` response path and only adds a typed upstream HTTP error at the transport boundary

## Validation

Passed:
- `go test ./internal/apiexec ./internal/server ./internal/provider ./internal/pluginhost ./core/integration`
