### PR TITLE
Default Gmail userId to me

### DIFF
--- a/plugins/gmail/plugin.yaml
+++ b/plugins/gmail/plugin.yaml
@@ -26,6 +26,10 @@ provider:
       access_type: offline
       prompt: consent
   openapi: https://api.apis.guru/v2/specs/googleapis.com/gmail/v1/openapi.json
+  managed_parameters:
+    - in: path
+      name: userId
+      value: me
   allowed_operations:
     gmail.users.messages.list:
       alias: messages.list


### PR DESCRIPTION
## Summary
- add a managed Gmail path parameter so spec-backed operations always use `userId=me`
- keep the existing curated `allowed_operations` surface and aliases unchanged
- make the packaged Gmail integration work without requiring an inline `managed_parameters` override

## Validation
- `cd server && go test ./internal/pluginpkg ./internal/bootstrap`