### PR TITLE
[codex] Rename Gmail message write operations

### DIFF
--- a/plugins/gmail/plugin.yaml
+++ b/plugins/gmail/plugin.yaml
@@ -1,5 +1,5 @@
 source: github.com/valon-technologies/gestalt/gmail
-version: 0.0.1-alpha.2
+version: 0.0.1-alpha.4
 display_name: Gmail
 description: Read, send, and manage Gmail messages, threads, drafts, and labels.
 icon_file: assets/icon.svg

--- a/plugins/gmail/provider.go
+++ b/plugins/gmail/provider.go
@@ -40,7 +40,7 @@ func (p *Provider) Catalog() *gestalt.Catalog {
 		Description: p.Description(),
 		Operations: []gestalt.CatalogOperation{
 			{
-				ID:          "send_message",
+				ID:          "messages.send",
 				Description: "Send an email message",
 				Method:      http.MethodPost,
 				Parameters: []gestalt.CatalogParameter{
@@ -53,7 +53,7 @@ func (p *Provider) Catalog() *gestalt.Catalog {
 				},
 			},
 			{
-				ID:          "create_draft",
+				ID:          "messages.createDraft",
 				Description: "Create an email draft",
 				Method:      http.MethodPost,
 				Parameters: []gestalt.CatalogParameter{
@@ -66,7 +66,7 @@ func (p *Provider) Catalog() *gestalt.Catalog {
 				},
 			},
 			{
-				ID:          "reply_to_message",
+				ID:          "messages.reply",
 				Description: "Reply to an existing message",
 				Method:      http.MethodPost,
 				Parameters: []gestalt.CatalogParameter{
@@ -78,7 +78,7 @@ func (p *Provider) Catalog() *gestalt.Catalog {
 				},
 			},
 			{
-				ID:          "forward_message",
+				ID:          "messages.forward",
 				Description: "Forward a message to new recipients",
 				Method:      http.MethodPost,
 				Parameters: []gestalt.CatalogParameter{
@@ -98,13 +98,13 @@ func (p *Provider) Execute(ctx context.Context, operation string, params map[str
 	}
 
 	switch operation {
-	case "send_message":
+	case "messages.send":
 		return p.sendMessage(ctx, params, token)
-	case "create_draft":
+	case "messages.createDraft":
 		return p.createDraft(ctx, params, token)
-	case "reply_to_message":
+	case "messages.reply":
 		return p.replyToMessage(ctx, params, token)
-	case "forward_message":
+	case "messages.forward":
 		return p.forwardMessage(ctx, params, token)
 	default:
 		return nil, fmt.Errorf("unknown operation: %s", operation)

--- a/plugins/gmail/provider_test.go
+++ b/plugins/gmail/provider_test.go
@@ -25,11 +25,22 @@ func TestProviderMetadata(t *testing.T) {
 	if len(catalog.Operations) != 4 {
 		t.Fatalf("Catalog().Operations returned %d ops, want 4", len(catalog.Operations))
 	}
+	wantIDs := []string{
+		"messages.send",
+		"messages.createDraft",
+		"messages.reply",
+		"messages.forward",
+	}
+	for i, want := range wantIDs {
+		if got := catalog.Operations[i].ID; got != want {
+			t.Fatalf("Catalog().Operations[%d].ID = %q, want %q", i, got, want)
+		}
+	}
 }
 
 func TestExecuteRequiresToken(t *testing.T) {
 	p := NewProvider()
-	_, err := p.Execute(context.Background(), "send_message", map[string]any{
+	_, err := p.Execute(context.Background(), "messages.send", map[string]any{
 		"to": "a@b.com", "subject": "Hi", "body": "Hi",
 	}, "")
 	if err == nil {
@@ -68,7 +79,7 @@ func TestSendMessage(t *testing.T) {
 		}, nil
 	})
 
-	result, err := p.Execute(context.Background(), "send_message", map[string]any{
+	result, err := p.Execute(context.Background(), "messages.send", map[string]any{
 		"to":      "bob@example.com",
 		"subject": "Hello",
 		"body":    "Hi Bob",
@@ -100,7 +111,7 @@ func TestSendMessageWithHTML(t *testing.T) {
 		}, nil
 	})
 
-	_, err := p.Execute(context.Background(), "send_message", map[string]any{
+	_, err := p.Execute(context.Background(), "messages.send", map[string]any{
 		"to":        "bob@example.com",
 		"subject":   "Hello",
 		"body":      "Hi Bob",
@@ -129,7 +140,7 @@ func TestCreateDraft(t *testing.T) {
 		}, nil
 	})
 
-	result, err := p.Execute(context.Background(), "create_draft", map[string]any{
+	result, err := p.Execute(context.Background(), "messages.createDraft", map[string]any{
 		"to":      "bob@example.com",
 		"subject": "Draft",
 		"body":    "Draft body",
@@ -190,7 +201,7 @@ func TestReplyToMessage(t *testing.T) {
 		}, nil
 	})
 
-	_, err := p.Execute(context.Background(), "reply_to_message", map[string]any{
+	_, err := p.Execute(context.Background(), "messages.reply", map[string]any{
 		"message_id": "orig-1",
 		"body":       "Thanks!",
 	}, "test-token")


### PR DESCRIPTION
## Summary
Rename the Gmail plugin's custom write operations to use the `messages.*` namespace so they surface consistently alongside the existing Gmail REST aliases.

## What changed
- Renamed the custom provider operation IDs from underscore names to:
  - `messages.send`
  - `messages.createDraft`
  - `messages.reply`
  - `messages.forward`
- Updated the provider dispatch switch to handle the renamed operations.
- Updated provider tests to call the new operation IDs and assert the surfaced catalog names.

## Why
The Gmail plugin already exposes read/manage operations under names like `messages.list` and `messages.get`. Renaming the custom send/draft/reply/forward operations makes the operation surface consistent and easier to discover.

## Validation
- `go test ./...` in `plugins/gmail`
