### PR TITLE
[codex] Remove Slack placeholder artifact digest

### DIFF
--- a/plugins/slack/plugin.yaml
+++ b/plugins/slack/plugin.yaml
@@ -9,7 +9,6 @@ artifacts:
   - os: darwin
     arch: arm64
     path: artifacts/darwin/arm64/provider
-    sha256: "0000000000000000000000000000000000000000000000000000000000000000"
 entrypoints:
   provider:
     artifact_path: artifacts/darwin/arm64/provider


### PR DESCRIPTION
## Summary
- remove the placeholder `artifacts[].sha256` value from the Slack source manifest
- rely on the post-#456 source-manifest packaging flow to compute the artifact digest at release time

## Why
`#456` made source manifests tolerant of missing artifact digests while still writing concrete digests into release manifests. The Slack manifest was still carrying the all-zero placeholder, so this follow-up removes that stale value.

## Validation
- `go test ./internal/pluginpkg ./cmd/gestaltd` (run from `server/`)
