### PR TITLE
[codex] Relax hybrid source manifests

### DIFF
--- a/plugins/gmail/plugin.yaml
+++ b/plugins/gmail/plugin.yaml
@@ -5,13 +5,6 @@ description: Read, send, and manage Gmail messages, threads, drafts, and labels.
 icon_file: assets/icon.svg
 kinds:
   - provider
-artifacts:
-  - os: darwin
-    arch: arm64
-    path: artifacts/darwin/arm64/provider
-entrypoints:
-  provider:
-    artifact_path: artifacts/darwin/arm64/provider
 provider:
   config_schema_path: schemas/config.schema.json
   auth:

--- a/plugins/slack/plugin.yaml
+++ b/plugins/slack/plugin.yaml
@@ -5,13 +5,6 @@ description: Send messages, search conversations, and manage channels.
 icon_file: assets/icon.svg
 kinds:
   - provider
-artifacts:
-  - os: darwin
-    arch: arm64
-    path: artifacts/darwin/arm64/provider
-entrypoints:
-  provider:
-    artifact_path: artifacts/darwin/arm64/provider
 provider:
   mcp: true
   base_url: https://slack.com

--- a/server/cmd/gestaltd/plugin_test.go
+++ b/server/cmd/gestaltd/plugin_test.go
@@ -551,6 +551,36 @@ func TestRun_PluginReleasePreservesHybridProviderManifest(t *testing.T) {
 	}
 }
 
+func TestRun_PluginReleaseCompilesManifestBackedProviderWithoutSourceArtifacts(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newCompiledManifestBackedProviderReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.4-source.1"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-" + releaseTestPluginName + "_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+
+	if manifest.IsDeclarativeOnlyProvider() {
+		t.Fatal("expected released manifest to remain executable for compiled manifest-backed provider")
+	}
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != releaseBinaryName(releaseTestPluginName, runtime.GOOS) {
+		t.Fatalf("artifacts = %+v", manifest.Artifacts)
+	}
+	if manifest.Entrypoints.Provider == nil || manifest.Entrypoints.Provider.ArtifactPath != releaseBinaryName(releaseTestPluginName, runtime.GOOS) {
+		t.Fatalf("provider entrypoint = %+v", manifest.Entrypoints.Provider)
+	}
+	if manifest.Provider == nil || manifest.Provider.BaseURL != releaseHybridBaseURL {
+		t.Fatalf("provider base_url = %#v, want %q", manifest.Provider, releaseHybridBaseURL)
+	}
+}
+
 func TestRun_PluginReleasePreservesPrebuiltHybridProvider(t *testing.T) {
 	t.Parallel()
 
@@ -1065,6 +1095,31 @@ func newHybridReleaseFixture(t *testing.T, dir string) string {
 			Provider: &pluginmanifestv1.Entrypoint{
 				ArtifactPath: releaseSourceArtifactPath,
 				Args:         []string{releaseHybridArg},
+			},
+		},
+	})
+
+	return pluginDir
+}
+
+func newCompiledManifestBackedProviderReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := newCompiledReleaseFixture(t, dir)
+	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
+		Source:      releaseTestSource,
+		Version:     "0.0.1",
+		DisplayName: "Release Test",
+		IconFile:    releaseTestIconPath,
+		Kinds:       []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			BaseURL: releaseHybridBaseURL,
+			Operations: []pluginmanifestv1.ProviderOperation{
+				{
+					Name:   releaseHybridOperationName,
+					Method: "GET",
+					Path:   "/items",
+				},
 			},
 		},
 	})


### PR DESCRIPTION
## Summary
- remove source-level `artifacts` and `entrypoints` from the Gmail and Slack plugin manifests
- add a release regression test showing that a compiled manifest-backed provider still releases with concrete per-platform artifacts and entrypoints

## Why
`gestaltd plugin release` already detects compiled plugins and synthesizes the released manifest for each target platform. Gmail and Slack were still carrying source-manifest scaffolding for `darwin/arm64`, which made them look single-platform even though release output is multi-platform.

This keeps the source manifests platform-agnostic and leans on the existing release primitives instead of adding more validation or packaging code.

This also subsumes the narrower Slack placeholder-digest cleanup, since the Slack source manifest no longer carries an `artifacts` block at all.

## Validation
- `go test ./cmd/gestaltd ./internal/pluginpkg` from `server/`
- built `gestaltd` from this branch and ran real releases:
  - `plugins/gmail`: `plugin release --version 0.0.1-alpha.99 --platform $(go env GOOS)/$(go env GOARCH)`
  - `plugins/slack`: `plugin release --version 0.0.1-alpha.99 --platform $(go env GOOS)/$(go env GOARCH)`
- inspected the generated archive manifests to confirm release output still includes concrete per-platform `artifacts` and `entrypoints`
