### PR TITLE
Merge credential field overrides by name

### DIFF
--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -336,10 +336,55 @@ func MergeConnectionAuth(dst *ConnectionAuthDef, src ConnectionAuthDef) {
 		dst.TokenMetadata = src.TokenMetadata
 	}
 	if len(src.Credentials) > 0 {
-		dst.Credentials = src.Credentials
+		dst.Credentials = mergeCredentialFields(dst.Credentials, src.Credentials)
 	}
 	if src.AuthMapping != nil {
 		dst.AuthMapping = src.AuthMapping
+	}
+}
+
+func mergeCredentialFields(base, override []CredentialFieldDef) []CredentialFieldDef {
+	if len(base) == 0 {
+		return append([]CredentialFieldDef(nil), override...)
+	}
+
+	merged := append([]CredentialFieldDef(nil), base...)
+	indexByName := make(map[string]int, len(merged))
+	for i, field := range merged {
+		if field.Name != "" {
+			indexByName[field.Name] = i
+		}
+	}
+
+	for _, field := range override {
+		if idx, ok := indexByName[field.Name]; ok {
+			mergeCredentialField(&merged[idx], field)
+			continue
+		}
+		merged = append(merged, field)
+		if field.Name != "" {
+			indexByName[field.Name] = len(merged) - 1
+		}
+	}
+
+	return merged
+}
+
+func mergeCredentialField(dst *CredentialFieldDef, src CredentialFieldDef) {
+	if dst == nil {
+		return
+	}
+	if dst.Name == "" {
+		dst.Name = src.Name
+	}
+	if src.Label != "" {
+		dst.Label = src.Label
+	}
+	if src.Description != "" {
+		dst.Description = src.Description
+	}
+	if src.HelpURL != "" {
+		dst.HelpURL = src.HelpURL
 	}
 }
 

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -3,9 +3,11 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 	"gopkg.in/yaml.v3"
 )
 
@@ -843,5 +845,63 @@ func TestExternalPluginAllowsSpecURL(t *testing.T) {
 	}
 	if err := ValidateStructure(cfg); err != nil {
 		t.Fatalf("unexpected validation error: %v", err)
+	}
+}
+
+func TestMergeConnectionAuth_MergesCredentialFieldsByName(t *testing.T) {
+	t.Parallel()
+
+	dst := ConnectionAuthDef{
+		Credentials: []CredentialFieldDef{
+			{Name: "api_key", Label: "API Key", Description: "Package API key"},
+			{Name: "app_key", Label: "Application Key", Description: "Package app key"},
+		},
+	}
+	src := ConnectionAuthDef{
+		Credentials: []CredentialFieldDef{
+			{Name: "api_key", Description: "Local API key copy"},
+			{Name: "new_key", Label: "New Key", Description: "Local-only credential"},
+		},
+	}
+
+	MergeConnectionAuth(&dst, src)
+
+	want := []CredentialFieldDef{
+		{Name: "api_key", Label: "API Key", Description: "Local API key copy"},
+		{Name: "app_key", Label: "Application Key", Description: "Package app key"},
+		{Name: "new_key", Label: "New Key", Description: "Local-only credential"},
+	}
+	if !reflect.DeepEqual(dst.Credentials, want) {
+		t.Fatalf("Credentials = %#v, want %#v", dst.Credentials, want)
+	}
+}
+
+func TestEffectivePluginConnectionDef_MergesManifestCredentialFieldOverrides(t *testing.T) {
+	t.Parallel()
+
+	plugin := &PluginDef{
+		Auth: &ConnectionAuthDef{
+			Credentials: []CredentialFieldDef{
+				{Name: "api_key", Description: "Local API key copy"},
+			},
+		},
+	}
+	manifestProvider := &pluginmanifestv1.Provider{
+		Auth: &pluginmanifestv1.ProviderAuth{
+			Type: pluginmanifestv1.AuthTypeManual,
+			Credentials: []pluginmanifestv1.CredentialField{
+				{Name: "api_key", Label: "API Key", Description: "Package API key"},
+				{Name: "app_key", Label: "Application Key", Description: "Package app key"},
+			},
+		},
+	}
+
+	got := EffectivePluginConnectionDef(plugin, manifestProvider)
+	want := []CredentialFieldDef{
+		{Name: "api_key", Label: "API Key", Description: "Local API key copy"},
+		{Name: "app_key", Label: "Application Key", Description: "Package app key"},
+	}
+	if !reflect.DeepEqual(got.Auth.Credentials, want) {
+		t.Fatalf("Credentials = %#v, want %#v", got.Auth.Credentials, want)
 	}
 }

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -3,11 +3,9 @@ package config
 import (
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
-	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 	"gopkg.in/yaml.v3"
 )
 
@@ -845,63 +843,5 @@ func TestExternalPluginAllowsSpecURL(t *testing.T) {
 	}
 	if err := ValidateStructure(cfg); err != nil {
 		t.Fatalf("unexpected validation error: %v", err)
-	}
-}
-
-func TestMergeConnectionAuth_MergesCredentialFieldsByName(t *testing.T) {
-	t.Parallel()
-
-	dst := ConnectionAuthDef{
-		Credentials: []CredentialFieldDef{
-			{Name: "api_key", Label: "API Key", Description: "Package API key"},
-			{Name: "app_key", Label: "Application Key", Description: "Package app key"},
-		},
-	}
-	src := ConnectionAuthDef{
-		Credentials: []CredentialFieldDef{
-			{Name: "api_key", Description: "Local API key copy"},
-			{Name: "new_key", Label: "New Key", Description: "Local-only credential"},
-		},
-	}
-
-	MergeConnectionAuth(&dst, src)
-
-	want := []CredentialFieldDef{
-		{Name: "api_key", Label: "API Key", Description: "Local API key copy"},
-		{Name: "app_key", Label: "Application Key", Description: "Package app key"},
-		{Name: "new_key", Label: "New Key", Description: "Local-only credential"},
-	}
-	if !reflect.DeepEqual(dst.Credentials, want) {
-		t.Fatalf("Credentials = %#v, want %#v", dst.Credentials, want)
-	}
-}
-
-func TestEffectivePluginConnectionDef_MergesManifestCredentialFieldOverrides(t *testing.T) {
-	t.Parallel()
-
-	plugin := &PluginDef{
-		Auth: &ConnectionAuthDef{
-			Credentials: []CredentialFieldDef{
-				{Name: "api_key", Description: "Local API key copy"},
-			},
-		},
-	}
-	manifestProvider := &pluginmanifestv1.Provider{
-		Auth: &pluginmanifestv1.ProviderAuth{
-			Type: pluginmanifestv1.AuthTypeManual,
-			Credentials: []pluginmanifestv1.CredentialField{
-				{Name: "api_key", Label: "API Key", Description: "Package API key"},
-				{Name: "app_key", Label: "Application Key", Description: "Package app key"},
-			},
-		},
-	}
-
-	got := EffectivePluginConnectionDef(plugin, manifestProvider)
-	want := []CredentialFieldDef{
-		{Name: "api_key", Label: "API Key", Description: "Local API key copy"},
-		{Name: "app_key", Label: "Application Key", Description: "Package app key"},
-	}
-	if !reflect.DeepEqual(got.Auth.Credentials, want) {
-		t.Fatalf("Credentials = %#v, want %#v", got.Auth.Credentials, want)
 	}
 }

--- a/server/internal/server/server_test.go
+++ b/server/internal/server/server_test.go
@@ -692,7 +692,8 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		Auth: &config.ConnectionAuthDef{
 			Type: pluginmanifestv1.AuthTypeManual,
 			Credentials: []config.CredentialFieldDef{
-				{Name: "plugin_config_token", Label: "Plugin Config Token"},
+				{Name: "plugin_token", Description: "Plugin Config Description"},
+				{Name: "plugin_local_only", Label: "Plugin Local Only", Description: "Plugin Local Only Description"},
 			},
 		},
 		Connections: map[string]*config.ConnectionDef{
@@ -700,7 +701,8 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 				Auth: config.ConnectionAuthDef{
 					Type: pluginmanifestv1.AuthTypeManual,
 					Credentials: []config.CredentialFieldDef{
-						{Name: "workspace_config_token", Label: "Workspace Config Token"},
+						{Name: "workspace_token", Label: "Workspace Config Token"},
+						{Name: "workspace_local_only", Label: "Workspace Local Only", Description: "Workspace Local Only Description"},
 					},
 				},
 			},
@@ -710,7 +712,8 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 				Auth: &pluginmanifestv1.ProviderAuth{
 					Type: pluginmanifestv1.AuthTypeManual,
 					Credentials: []pluginmanifestv1.CredentialField{
-						{Name: "plugin_manifest_token", Label: "Plugin Manifest Token"},
+						{Name: "plugin_token", Label: "Plugin Manifest Token", Description: "Plugin Manifest Description"},
+						{Name: "plugin_manifest_only", Label: "Plugin Manifest Only", Description: "Plugin Manifest Only Description"},
 					},
 				},
 				Connections: map[string]*pluginmanifestv1.ManifestConnectionDef{
@@ -718,7 +721,8 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 						Auth: &pluginmanifestv1.ProviderAuth{
 							Type: pluginmanifestv1.AuthTypeManual,
 							Credentials: []pluginmanifestv1.CredentialField{
-								{Name: "workspace_manifest_token", Label: "Workspace Manifest Token"},
+								{Name: "workspace_token", Label: "Workspace Manifest Token", Description: "Workspace Manifest Description"},
+								{Name: "workspace_manifest_only", Label: "Workspace Manifest Only", Description: "Workspace Manifest Only Description"},
 							},
 						},
 					},
@@ -751,16 +755,20 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
 
-	var integrations []struct {
+	type credentialField struct {
 		Name        string `json:"name"`
-		Connections []struct {
-			Name             string   `json:"name"`
-			AuthTypes        []string `json:"auth_types"`
-			CredentialFields []struct {
-				Name  string `json:"name"`
-				Label string `json:"label"`
-			} `json:"credential_fields"`
-		} `json:"connections"`
+		Label       string `json:"label"`
+		Description string `json:"description"`
+	}
+	type connectionInfo struct {
+		Name             string            `json:"name"`
+		AuthTypes        []string          `json:"auth_types"`
+		CredentialFields []credentialField `json:"credential_fields"`
+	}
+
+	var integrations []struct {
+		Name        string           `json:"name"`
+		Connections []connectionInfo `json:"connections"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
 		t.Fatalf("decoding: %v", err)
@@ -769,33 +777,23 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		t.Fatalf("expected 1 integration, got %d", len(integrations))
 	}
 
-	got := make(map[string]struct {
-		authTypes []string
-		field     string
-		label     string
-	}, len(integrations[0].Connections))
+	got := make(map[string]connectionInfo, len(integrations[0].Connections))
 	for _, conn := range integrations[0].Connections {
-		fieldName := ""
-		fieldLabel := ""
-		if len(conn.CredentialFields) > 0 {
-			fieldName = conn.CredentialFields[0].Name
-			fieldLabel = conn.CredentialFields[0].Label
-		}
-		got[conn.Name] = struct {
-			authTypes []string
-			field     string
-			label     string
-		}{
-			authTypes: conn.AuthTypes,
-			field:     fieldName,
-			label:     fieldLabel,
-		}
+		got[conn.Name] = conn
 	}
 
-	if len(got[config.PluginConnectionAlias].authTypes) != 1 || got[config.PluginConnectionAlias].authTypes[0] != "manual" || got[config.PluginConnectionAlias].field != "plugin_config_token" || got[config.PluginConnectionAlias].label != "Plugin Config Token" {
+	if !reflect.DeepEqual(got[config.PluginConnectionAlias].AuthTypes, []string{"manual"}) || !reflect.DeepEqual(got[config.PluginConnectionAlias].CredentialFields, []credentialField{
+		{Name: "plugin_token", Label: "Plugin Manifest Token", Description: "Plugin Config Description"},
+		{Name: "plugin_manifest_only", Label: "Plugin Manifest Only", Description: "Plugin Manifest Only Description"},
+		{Name: "plugin_local_only", Label: "Plugin Local Only", Description: "Plugin Local Only Description"},
+	}) {
 		t.Fatalf("plugin connection info = %+v", got[config.PluginConnectionAlias])
 	}
-	if len(got["workspace"].authTypes) != 1 || got["workspace"].authTypes[0] != "manual" || got["workspace"].field != "workspace_config_token" || got["workspace"].label != "Workspace Config Token" {
+	if !reflect.DeepEqual(got["workspace"].AuthTypes, []string{"manual"}) || !reflect.DeepEqual(got["workspace"].CredentialFields, []credentialField{
+		{Name: "workspace_token", Label: "Workspace Config Token", Description: "Workspace Manifest Description"},
+		{Name: "workspace_manifest_only", Label: "Workspace Manifest Only", Description: "Workspace Manifest Only Description"},
+		{Name: "workspace_local_only", Label: "Workspace Local Only", Description: "Workspace Local Only Description"},
+	}) {
 		t.Fatalf("workspace connection info = %+v", got["workspace"])
 	}
 }


### PR DESCRIPTION
## Summary
- merge `plugin.auth.credentials` overrides by credential `name` instead of replacing the entire list
- preserve packaged fields when a local override only sets one field such as `description`
- append local-only credential entries that do not exist in the base auth config

## Testing
- `go test ./internal/config`
- `go test ./internal/provider -run 'TestBuildCredentialFields'`
- `go test ./internal/server -run 'TestListIntegrations_ConnectionInfosIncludeConfigCredentialFields|TestListIntegrations_ConnectionInfosIncludeProviderManualAuth'`