### PR TITLE
[codex] Audit and fix docs regressions after #463

### DIFF
--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -20,7 +20,8 @@
 
 - Default config path: `/etc/gestalt/config.yaml`
 - This image is not zero-config. Mount or bake a config file before starting it.
-- Locked startup is the default. If your config uses packaged integrations, runtimes, or a packaged UI, run `init` first.
+- Locked startup is the default. If your config uses `plugin.package`,
+  `plugin.source`, or a packaged UI, run `init` first.
 
 ## Supported tags
 
@@ -68,7 +69,8 @@ integrations: {}
 
 ## Run a prepared production image
 
-If your config uses packaged integrations, runtimes, or a packaged UI, prepare it during the image build:
+If your config uses `plugin.package`, `plugin.source`, or a packaged UI,
+prepare it during the image build:
 
 ```dockerfile
 FROM valontechnologies/gestaltd:latest AS init

--- a/docs/pages/concepts/integrations.mdx
+++ b/docs/pages/concepts/integrations.mdx
@@ -1,280 +1,241 @@
 # Integrations
 
-Every integration becomes a provider at startup. Every provider exposes operations that callers invoke through the API, UI, bindings, or MCP.
+Every integration becomes a provider. The provider can be built from inline
+YAML, from a packaged plugin, or from a hybrid of both.
 
-## Shape of an Integration
+## Integration Shape
 
 ```yaml
 integrations:
-  github:
-    display_name: GitHub
-    description: GitHub REST API
-    mcp_tool_prefix: github_
-    connections:
-      default:
-        mode: user
-        auth:
-          type: oauth2
-          client_id: ${GITHUB_CLIENT_ID}
-          client_secret: ${GITHUB_CLIENT_SECRET}
-          authorization_url: https://github.com/login/oauth/authorize
-          token_url: https://github.com/login/oauth/access_token
-    api:
-      type: rest
-      openapi: https://raw.githubusercontent.com/.../api.github.com.json
-      connection: default
-      allowed_operations:
-        repos/list-for-authenticated-user:
-        issues/list-for-authenticated-user:
+  gmail:
+    display_name: Gmail
+    description: Read and send Gmail messages
+    mcp_tool_prefix: gmail_
+    plugin:
+      package: ./dist/gmail-plugin.tar.gz
 ```
 
-This one block answers what the provider should be called, how credentials are resolved (connections), where operations come from (api/mcp surfaces), and which operations should be exposed.
+At the top level, an integration has presentation metadata plus a single
+`plugin` block. That `plugin` block is where the actual behavior lives.
 
-## Integration Patterns
+## The Four Main Patterns
 
-Every integration follows one of these patterns:
+| Pattern | Use it for |
+| --- | --- |
+| Inline declarative provider | Small custom REST APIs where writing a binary would be overkill. |
+| Inline spec-backed provider | OpenAPI, GraphQL, or upstream MCP surfaces that Gestalt can load directly. |
+| Packaged provider plugin | Custom logic that belongs in code or ships as a reusable package. |
+| Hybrid provider | A packaged plugin combined with OpenAPI, GraphQL, or MCP surfaces. |
 
-| Pattern | Structure | When to use |
-| --- | --- | --- |
-| **Declarative** | `connections` + one or both of `api` and `mcp` | The upstream has an OpenAPI spec, GraphQL endpoint, or MCP server. |
-| **Plugin-only** | Just a `plugin` block | Custom execution logic that cannot be expressed declaratively. |
-| **Plugin + API** | `plugin` + `api` + `connections` | A plugin for custom operations combined with an API surface for REST/GraphQL operations. |
-| **Plugin + MCP** | `plugin` + `mcp` | A plugin provider combined with an upstream MCP surface. |
-| **Plugin + API + MCP** | `plugin` + `api` + `mcp` + `connections` | All three surfaces composed together. |
+## Inline Declarative Providers
 
-When composing a plugin with `api` or `connections`, the plugin must specify `plugin.connection` to reference a connection from the shared pool.
-
-## Connections
-
-Connections own credential resolution for an integration. Each named connection declares a mode, optional auth, and optional params.
+Inline declarative providers use `base_url` plus `operations`.
 
 ```yaml
-connections:
-  default:
-    mode: user
-    params:
-      subdomain:
-        required: true
-    auth:
-      type: oauth2
-      authorization_url: https://accounts.example.com/oauth/authorize
-      token_url: https://accounts.example.com/oauth/token
-      client_id: ${CLIENT_ID}
-      client_secret: ${CLIENT_SECRET}
+integrations:
+  support:
+    plugin:
+      auth:
+        type: bearer
+        credentials:
+          - name: token
+            label: API Token
+      base_url: https://api.support.example.com
+      operations:
+        - name: list_tickets
+          description: Return open support tickets
+          method: GET
+          path: /tickets
 ```
 
-All connections within a single integration must share the same mode.
+This is the simplest path when you already know the exact operations you want.
+
+## Inline Spec-Backed Providers
+
+Inline spec-backed providers load operations from OpenAPI, GraphQL, or upstream
+MCP.
+
+```yaml
+integrations:
+  httpbin:
+    mcp_tool_prefix: httpbin_
+    plugin:
+      openapi: ./openapi/httpbin.yaml
+      openapi_connection: public
+      default_connection: public
+      connections:
+        public:
+          mode: none
+          auth:
+            type: none
+      allowed_operations:
+        get_ip:
+          alias: get_ip
+```
+
+`allowed_operations` narrows the exposed surface and can rename operations with
+`alias`.
+
+## Packaged Provider Plugins
+
+Packaged providers come from one of three sources:
+
+- `command`: run an executable directly
+- `package`: load a local directory, local archive, or HTTPS archive
+- `source` plus `version`: resolve a published plugin package during `init`
+
+```yaml
+integrations:
+  support:
+    display_name: Support
+    plugin:
+      package: ./dist/support-plugin.tar.gz
+```
+
+Packaged providers carry their own manifest, auth model, and operation catalog.
+
+If a packaged provider needs named connections, declare them in the plugin
+manifest, not in `config.yaml`.
+
+## Hybrid Providers
+
+A packaged plugin can also layer in spec-backed surfaces.
+
+Assume `./dist/support-plugin.tar.gz` and `./openapi/support.yaml` already
+exist.
+
+```yaml
+integrations:
+  support:
+    display_name: Support
+    mcp_tool_prefix: support_
+    plugin:
+      package: ./dist/support-plugin.tar.gz
+      openapi: ./openapi/support.yaml
+      openapi_connection: plugin
+      mcp_url: https://mcp.support.example.com/mcp
+      mcp_connection: plugin
+      default_connection: plugin
+      allowed_operations:
+        tickets.list:
+          alias: list_tickets
+```
+
+This is useful when a plugin provides custom code while the API or MCP surface
+still comes from a spec or upstream server.
+
+## The Implicit Plugin Connection
+
+When you use top-level `plugin.auth` and `plugin.params`, Gestalt creates an
+implicit connection internally. In API responses and UI flows this connection is
+exposed as `plugin`.
+
+```yaml
+plugin:
+  auth:
+    type: oauth2
+    authorization_url: https://accounts.example.com/oauth/authorize
+    token_url: https://accounts.example.com/oauth/token
+    client_id: ${CLIENT_ID}
+    client_secret: ${CLIENT_SECRET}
+  params:
+    tenant:
+      required: true
+```
+
+## Named Connections
+
+Use `plugin.connections` when different inline surfaces need different auth
+flows.
+
+These next blocks are `plugin:` fragments, not complete integration files.
+
+```yaml
+plugin:
+  openapi: ./openapi/workspace.yaml
+  mcp_url: https://mcp.example.com/mcp
+  openapi_connection: api
+  mcp_connection: mcp
+  default_connection: api
+  connections:
+    api:
+      mode: user
+      auth:
+        type: oauth2
+        authorization_url: https://accounts.example.com/oauth/authorize
+        token_url: https://accounts.example.com/oauth/token
+        client_id: ${CLIENT_ID}
+        client_secret: ${CLIENT_SECRET}
+    mcp:
+      mode: user
+      auth:
+        type: mcp_oauth
+```
+
+The connection names referenced by `openapi_connection`, `graphql_connection`,
+`mcp_connection`, and `default_connection` must exist.
 
 ### Connection Modes
 
-| Value | Behavior |
+| Mode | Meaning |
 | --- | --- |
-| `user` | Use the authenticated caller's token. Default when `mode` is omitted. |
-| `identity` | Use a shared identity token. |
-| `either` | Try the caller's token first, then fall back to the shared identity token. |
-| `none` | No credential. |
+| `none` | No stored credential is needed. |
+| `user` | Use a user-scoped stored connection. |
+| `identity` | Use a shared service identity. |
+| `either` | Prefer user auth and fall back to the shared identity. |
 
-### Params
+## Managed Parameters
 
-Connections can declare named parameters that callers supply when connecting. Required params are used for URL template expansion in surface URLs and auth URLs.
-
-```yaml
-params:
-  subdomain:
-    required: true
-```
-
-A URL like `https://{subdomain}.example.com/api` expands using the connection's params at request time.
-
-## Surfaces: `api` and `mcp`
-
-Surfaces define where operations come from. A declarative integration can declare one `api` surface, one `mcp` surface, or both.
-
-All declarative API operations are automatically projected as MCP tools on `/mcp`. Any integration with an `api` surface has its operations available to MCP clients.
-
-### `api`
+`managed_parameters` inject fixed values into headers or path placeholders
+before an operation is exposed.
 
 ```yaml
-api:
-  type: rest
-  openapi: https://example.com/openapi.json
-  connection: default
-  allowed_operations:
-    listThings:
+plugin:
+  openapi: ./openapi/workspace.yaml
+  managed_parameters:
+    - in: header
+      name: X-API-Version
+      value: "2026-04-01"
+    - in: path
+      name: account_id
+      value: primary
 ```
 
-| Field | Purpose |
-| --- | --- |
-| `type` | `rest` or `graphql`. |
-| `openapi` | Required when `type: rest`. URL or local path to an OpenAPI document. |
-| `url` | Required when `type: graphql`. The GraphQL endpoint URL. |
-| `connection` | Name of a connection defined in the same integration. |
-| `allowed_operations` | Narrows exposed operations. Bare key keeps the upstream description. Object with `alias` and/or `description` overrides it. |
+Path managed parameters remove the corresponding user parameter from the exposed
+operation signature.
 
-### `mcp`
+## Response Mapping
+
+`response_mapping` is available for spec-backed providers when the upstream
+response needs a stable data path or pagination hints.
 
 ```yaml
-mcp:
-  url: https://mcp.example.com
-  connection: mcp_conn
-  allowed_operations:
-    search:
+plugin:
+  graphql_url: https://api.example.com/graphql
+  auth:
+    type: bearer
+  response_mapping:
+    data_path: data.items
+    pagination:
+      has_more_path: pageInfo.hasNextPage
+      cursor_path: pageInfo.endCursor
 ```
 
-| Field | Purpose |
-| --- | --- |
-| `url` | Required. The upstream MCP server URL. |
-| `connection` | Name of a connection defined in the same integration. |
-| `allowed_operations` | Optional. Narrows exposed tools. Same override syntax as `api`. |
+## Tool Naming On `/mcp`
 
-### Multiple Connections
-
-An integration can define separate connections for its API and MCP surfaces when the two surfaces authenticate through different providers.
-
-```yaml
-integrations:
-  shop:
-    connections:
-      api_conn:
-        mode: user
-        auth:
-          type: oauth2
-          authorization_url: https://accounts.shopify.com/oauth/authorize
-          token_url: https://accounts.shopify.com/oauth/token
-          client_id: ${SHOP_CLIENT_ID}
-          client_secret: ${SHOP_SECRET}
-      mcp_conn:
-        mode: user
-        auth:
-          type: oauth2
-          authorization_url: https://mcp-auth.example.com/authorize
-          token_url: https://mcp-auth.example.com/token
-          client_id: ${MCP_CLIENT_ID}
-          client_secret: ${MCP_SECRET}
-    api:
-      type: graphql
-      url: https://{subdomain}.myshopify.com/admin/api/graphql.json
-      connection: api_conn
-    mcp:
-      url: https://tenant-{subdomain}.mcp.example.com
-      connection: mcp_conn
-```
-
-## Operation Exposure
-
-`allowed_operations` on `api` and `mcp` narrows what a provider exposes.
-
-Two forms:
-
-```yaml
-allowed_operations:
-  repos/list-for-authenticated-user:
-  issues/list-for-authenticated-user:
-```
-
-```yaml
-allowed_operations:
-  repos/list-for-authenticated-user:
-    description: List repositories
-  issues/list-for-authenticated-user:
-    description: List assigned issues
-```
-
-The bare-key form keeps upstream descriptions. The object form overrides descriptions or aliases.
-
-Omitting `allowed_operations` exposes every operation from the source.
-
-## Plugins
-
-A plugin-only integration delegates execution to an external binary:
-
-```yaml
-integrations:
-  custom_tool:
-    plugin:
-      package: ./custom-tool
-```
-
-See the [Config File](/reference/config-file) reference for the full `plugin` field specification.
-
-## Hybrid Integrations
-
-A hybrid integration composes a plugin with other surfaces. The plugin handles custom execution logic while the other surfaces provide REST, GraphQL, or MCP operations.
-
-### Plugin + API
-
-Compose a plugin binary with an API surface when the upstream has an OpenAPI spec for most operations but a few operations need custom code (SDK calls, data transformation, etc.).
-
-```yaml
-integrations:
-  bigquery:
-    display_name: BigQuery
-    connections:
-      default:
-        mode: user
-        auth:
-          type: oauth2
-          client_id: ${GOOGLE_CLIENT_ID}
-          client_secret: ${GOOGLE_CLIENT_SECRET}
-          authorization_url: https://accounts.google.com/o/oauth2/v2/auth
-          token_url: https://oauth2.googleapis.com/token
-          scopes: [https://www.googleapis.com/auth/bigquery]
-    api:
-      type: rest
-      openapi: https://bigquery.googleapis.com/bigquery/v2/openapi.json
-      connection: default
-      allowed_operations:
-        list_datasets: {}
-        get_dataset: {}
-    plugin:
-      source: github.com/valon-technologies/gestalt/bigquery
-      connection: default
-```
-
-Both surfaces must share the same connection (`plugin.connection` and `api.connection` must reference the same name), so the user authenticates once. The API surface provides REST operations and the plugin binary provides custom operations like SQL query execution.
-
-Operation names must be unique across all surfaces. If an API operation and a plugin operation share a name, the server rejects the configuration at startup.
-
-### Plugin + MCP
+Use `mcp_tool_prefix` on the integration to keep tool names stable and
+collision-free when several integrations expose operations with similar names.
 
 ```yaml
 integrations:
   slack:
-    plugin:
-      source: github.com/valon-technologies/gestalt/slack
-      version: 0.0.1-alpha.3
-    mcp:
-      url: https://mcp.slack.com
-      connection: plugin
+    mcp_tool_prefix: slack_
 ```
 
-Setting `mcp.connection` to `plugin` reuses the plugin's OAuth token for the MCP surface. Alternatively, declare explicit `connections` and reference one from `mcp.connection`.
+## Choosing The Right Pattern
 
-### Shared Connections
-
-When `plugin.connection` is set, the plugin uses a connection from the integration's shared pool instead of building a separate connection from the plugin manifest's auth config. This enables single-auth-flow integrations where all surfaces share one token.
-
-When `plugin.connection` is omitted, the plugin falls back to its manifest's auth config (the default behavior for plugin-only integrations).
-
-## Metadata
-
-These fields affect presentation only:
-
-| Field | Purpose |
-| --- | --- |
-| `display_name` | Provider name shown in the UI and API responses. |
-| `description` | Provider description. |
-| `icon_file` | SVG path, resolved relative to the config file. Embedded during `init`. |
-| `mcp_tool_prefix` | Prefix applied to tool names on the `/mcp` endpoint. |
-
-## Instances
-
-Gestalt stores connection state by `(subject, integration, instance)`.
-
-One integration can support:
-
-- one default connection
-- multiple named connections for the same user
-- a shared identity connection
-
-When there is exactly one matching connection, Gestalt auto-selects it. When there are multiple, callers must name the instance explicitly.
+- Start with inline declarative YAML for a tiny REST surface.
+- Use OpenAPI, GraphQL, or `mcp_url` when the upstream already publishes a
+  discoverable surface.
+- Use packaged plugins when behavior belongs in code or needs to be versioned.
+- Use a hybrid provider when you want packaged logic plus spec-backed coverage.

--- a/docs/pages/concepts/platform-model.mdx
+++ b/docs/pages/concepts/platform-model.mdx
@@ -1,10 +1,14 @@
 # Platform Model
 
-Gestalt has a small number of primitives, but they compose into a full integration platform. The easiest way to understand `gestaltd` is to follow the startup path from configuration to invocation.
+Gestalt has a small number of primitives, but they compose into a full
+integration platform. The easiest way to understand `gestaltd` is to follow the
+startup path from configuration to invocation.
 
 ## The Core Model
 
-At the highest level, `gestaltd` loads and validates a declarative config file, bootstraps the platform components that config names, builds providers from integrations, and exposes those providers through shared request surfaces.
+At the highest level, `gestaltd` loads a declarative config file, bootstraps the
+platform components that config names, builds providers from integrations, and
+exposes those providers through shared request surfaces.
 
 ## The Main Primitives
 
@@ -13,7 +17,7 @@ At the highest level, `gestaltd` loads and validates a declarative config file, 
 | `auth` | Authenticates users to Gestalt itself and issues platform sessions. |
 | `datastore` | Persists users, API tokens, integration tokens, staged connections, and some egress data. |
 | `secrets` | Resolves `secret://...` references during bootstrap. |
-| `integrations` | Define the user-facing provider graph: connections, API/MCP surfaces, plugins, and metadata. |
+| `integrations` | Define the provider graph users call. Each integration has one `plugin` block plus optional metadata. |
 | `bindings` | Extra entry points, such as inbound webhooks or HTTP proxy routes. |
 | `egress` | Policy and credential rules for outbound traffic. |
 
@@ -39,7 +43,8 @@ This is the actual shape of startup:
 
 ## Integrations Become Providers
 
-An integration is a declarative definition. A provider is the executable object built from it.
+An integration is a declarative definition. A provider is the executable object
+built from it.
 
 That distinction matters:
 
@@ -47,36 +52,44 @@ That distinction matters:
 - `gestaltd` turns that entry into a provider at startup
 - every request surface invokes the provider, not the raw YAML
 
-Providers can come from three sources:
+Providers come from three sources:
 
 | Source | How it works |
 | --- | --- |
-| Built-in named provider | A registered provider name such as `bigquery` or `jira`. |
-| Surface-defined provider | Built from a REST, GraphQL, or MCP surface in config. |
-| Executable plugin | Spawned as a separate process and connected over the plugin protocol. |
+| Inline declarative provider | Built from `plugin.base_url` plus `plugin.operations`. |
+| Inline spec-backed provider | Built from `plugin.openapi`, `plugin.graphql_url`, or `plugin.mcp_url`. |
+| Packaged provider plugin | Spawned as a separate process and connected over the plugin protocol. |
 
-## Composition Rules
+A packaged plugin can also layer in spec-backed surfaces, which is how hybrid
+providers work.
 
-The composition rules are intentionally narrow:
+## Connection Resolution
 
-- an integration may have at most one `api` surface (REST or GraphQL)
-- an integration may have at most one `mcp` surface
-- one `api` surface plus one `mcp` surface is valid
-- a `plugin` block may compose with `mcp` (hybrid) but not with `api`
+Gestalt resolves credentials through either the implicit plugin connection or a
+set of named connections.
 
-That gives you a predictable composition model:
+- `plugin.auth` and `plugin.params` define the implicit `plugin` connection
+- `plugin.connections` defines named connections for inline providers
+- packaged providers define their own named connections in the manifest
+- `openapi_connection`, `graphql_connection`, `mcp_connection`, and
+  `default_connection` decide which connection each surface uses
 
-- REST only
-- GraphQL only
-- MCP only
-- REST plus MCP
-- GraphQL plus MCP
-- plugin only
-- plugin plus MCP (hybrid)
+Each connection has one mode:
+
+| Mode | Meaning |
+| --- | --- |
+| `none` | No stored credential is needed. |
+| `user` | Use a user-scoped stored connection. |
+| `identity` | Use a shared service identity. |
+| `either` | Prefer user auth and fall back to the shared identity. |
+
+If an integration has more than one stored connection for the chosen subject,
+callers must specify an instance. If there is exactly one, Gestalt selects it
+automatically.
 
 ## The Shared Invocation Broker
 
-Every execution path in Gestalt goes through the same invocation broker. That is the mechanism that makes the platform feel uniform.
+Every execution path in Gestalt goes through the same invocation broker.
 
 The broker is responsible for:
 
@@ -87,20 +100,9 @@ The broker is responsible for:
 - injecting connection metadata into execution context
 - returning normalized operation results
 
-Because this broker is shared, the same token and policy behavior applies whether the caller is the web UI, a direct HTTP client, an MCP client hitting `/mcp`, a webhook binding, or a proxy binding.
-
-## Connection Modes
-
-Each integration declares how credentials are resolved:
-
-| Mode | Meaning |
-| --- | --- |
-| `user` | Use the authenticated caller's token. This is the default. |
-| `identity` | Use a shared platform-level token. |
-| `either` | Try the user's token first, then fall back to the identity token. |
-| `none` | Invoke with no credential at all. |
-
-If an integration has more than one stored connection for the chosen subject, callers must specify an instance. If there is exactly one, Gestalt selects it automatically.
+Because this broker is shared, the same token and policy behavior applies
+whether the caller is the web UI, a direct HTTP client, an MCP client hitting
+`/mcp`, a webhook binding, or a proxy binding.
 
 ## Surfaces Built On Top
 
@@ -113,6 +115,9 @@ Once providers exist, `gestaltd` projects them into several surfaces:
 | MCP endpoint | `/mcp`, mounted when at least one integration exposes tools. |
 | Bindings | Additional routes and triggers declared under `bindings:`. |
 
-## What The User Actually Programs Against
+## What You Actually Program Against
 
-As a Gestalt operator, you compose top-level config blocks, integration definitions, connection definitions, API and MCP surface definitions, binding definitions, egress rules, and optional plugin manifests and packages. Everything else is a consequence of those inputs.
+As a Gestalt operator, you compose top-level config blocks, integration
+definitions, plugin definitions, connection definitions, binding definitions,
+egress rules, and optional plugin manifests and packages. Everything else is a
+consequence of those inputs.

--- a/docs/pages/concepts/plugin-packaging.mdx
+++ b/docs/pages/concepts/plugin-packaging.mdx
@@ -3,7 +3,6 @@
 Gestalt uses one package format for:
 
 - provider plugins
-- runtime plugins
 - web UI bundles
 
 Each package is described by a manifest file named one of:
@@ -37,16 +36,16 @@ Load a local directory, local archive, or HTTPS archive.
 
 ```yaml
 integrations:
-  slack:
+  example:
     plugin:
-      package: ./dist/slack
+      package: ./dist/example-provider.tar.gz
 ```
 
 ### `source`
 
 Resolve a versioned plugin source during `init`.
 
-In config, that looks like `source: github.com/acme/plugins/gmail` plus
+In config, that looks like `source: github.com/acme/plugins/example` plus
 `version: 1.2.3`.
 
 This is the cleanest path for reusable, versioned packages.
@@ -55,10 +54,10 @@ This is the cleanest path for reusable, versioned packages.
 
 `gestaltd init` resolves and prepares:
 
-- `plugin.source`
 - `plugin.package`
-- runtime plugins
-- UI plugins
+- `plugin.source`
+- `ui.plugin.package`
+- `ui.plugin.source`
 
 It writes lock state and extracts the prepared artifacts under `.gestalt/`.
 
@@ -76,8 +75,8 @@ gestaltd plugin package --input ./my-plugin --output ./dist/my-plugin.tar.gz
 gestaltd plugin release --version 0.1.0
 ```
 
-Run `plugin release` from the plugin source directory. It cross-compiles the
-plugin, produces per-platform archives, and writes a checksums file.
+Run `plugin release` from the plugin source directory. It compiles the plugin,
+produces release archives, and writes a checksums file.
 
 ## Declarative-Only Packages
 
@@ -89,6 +88,12 @@ That is useful when you want to ship:
 - a reusable declarative REST provider
 - a reusable OpenAPI-backed integration
 - a reusable web UI bundle
+
+## Executable Packages
+
+Executable provider packages add `artifacts` plus
+`entrypoints.provider.artifact_path` to the manifest. `gestaltd plugin release`
+builds that structure for you.
 
 ## Package Layout
 

--- a/docs/pages/deploy/gateway-only.mdx
+++ b/docs/pages/deploy/gateway-only.mdx
@@ -1,198 +1,32 @@
-import { Callout } from 'nextra/components'
+# Docker
 
-# Gateway-Only Deployment
+The published image is `valontechnologies/gestaltd`.
 
-A gateway-only deployment runs Gestalt as an HTTP proxy with centralized auth, egress policy, and credential injection. It does not load any providers, integrations, or MCP surfaces.
+## What The Image Does
 
-This is useful when you want to mediate outbound API calls (injecting secrets, enforcing deny rules, and authenticating callers) without building a capability catalog.
+- exposes port `8080`
+- uses `/gestaltd` as the entrypoint
+- defaults to `serve --locked --config /etc/gestalt/config.yaml`
 
-## What You Get
+## Mount A Prepared Config Directory
 
-- Inbound auth via session tokens or API keys (`gst_api_`)
-- A proxy binding that forwards requests to arbitrary upstream hosts
-- Egress policy rules that deny or allow requests by host, path, method, or subject
-- Secret-backed credential injection via `secret_ref`
+If you already ran `gestaltd init`, mount the whole config directory at
+`/etc/gestalt`.
 
-## What You Do Not Get
+That directory should contain:
 
-- No capability catalog or operation discovery
-- No provider integrations, API/MCP surfaces, or MCP endpoints
+- `config.yaml`
+- `gestalt.lock.json`
+- `.gestalt/` when packaged plugins, prepared OpenAPI definitions, or a UI
+  plugin were prepared
 
-## Minimal Config
+## Mutable Local Startup In Docker
 
-```yaml
-server:
-  port: 8080
-  base_url: https://gateway.example.com
-  encryption_key: secret://gestalt-encryption-key
+For local development, override the default command and start the container with
+`serve --config /etc/gestalt/config.yaml`.
 
-auth:
-  provider: oidc
-  config:
-    issuer_url: https://login.example.com
-    client_id: ${OIDC_CLIENT_ID}
-    client_secret: secret://oidc-client-secret
-    session_secret: secret://oidc-session-secret
+## Bake Prepared State Into A Derived Image
 
-datastore:
-  provider: sqlite
-  config:
-    path: /data/gestalt.db
-
-secrets:
-  provider: file
-  config:
-    dir: /etc/gestalt-secrets
-
-bindings:
-  proxy:
-    type: proxy
-    config:
-      path: /proxy
-
-egress:
-  default_action: deny
-  policies:
-    - action: allow
-      host: api.openai.com
-    - action: allow
-      host: api.anthropic.com
-  credentials:
-    - host: api.openai.com
-      secret_ref: openai-api-key
-      auth_style: bearer
-    - host: api.anthropic.com
-      secret_ref: anthropic-api-key
-      auth_style: bearer
-```
-
-Key points:
-
-- The `bindings.proxy` section declares zero providers. This is the providerless proxy mode.
-- `egress.default_action: deny` blocks all outbound traffic except hosts explicitly allowed.
-- Each credential grant uses `secret_ref` to pull a secret at request time and `auth_style: bearer` to inject it as a `Bearer` token.
-<Callout>
-  `secret_ref` values are resolved at request time through the configured secret manager, not during config loading. This means the proxy always fetches the current secret value.
-</Callout>
-
-## Secret-Backed Credentials
-
-The `secret_ref` and `auth_style` fields on credential grants control how secrets are resolved and injected.
-
-```yaml
-egress:
-  credentials:
-    - host: api.openai.com
-      secret_ref: openai-api-key
-      auth_style: bearer
-```
-
-When a proxied request matches this grant's host, Gestalt resolves `openai-api-key` through the secret manager and sets the `Authorization: Bearer <value>` header.
-
-Supported `auth_style` values:
-
-| Style | Header |
-| --- | --- |
-| `bearer` | `Authorization: Bearer <secret>` |
-| `basic` | `Authorization: Basic <secret>` |
-| `raw` | `Authorization: <secret>` |
-
-## Multi-Tenant Host Credentials
-
-When different hosts need different secrets, add one credential grant per host:
-
-```yaml
-egress:
-  credentials:
-    - host: shop-1.myshopify.com
-      secret_ref: shop-1-token
-      auth_style: bearer
-    - host: shop-2.myshopify.com
-      secret_ref: shop-2-token
-      auth_style: bearer
-```
-
-Host matching is exact. Each request resolves credentials from the first grant whose host matches.
-
-## Full Platform With Egress
-
-The same egress substrate works in a full-platform deployment alongside providers and integrations. The proxy uses secret-backed credential grants for outbound auth while integrations use their own OAuth connections:
-
-```yaml
-server:
-  port: 8080
-  base_url: https://gestalt.example.com
-  encryption_key: secret://gestalt-encryption-key
-
-auth:
-  provider: oidc
-  config:
-    issuer_url: https://login.example.com
-    client_id: ${OIDC_CLIENT_ID}
-    client_secret: secret://oidc-client-secret
-    session_secret: secret://oidc-session-secret
-
-datastore:
-  provider: postgres
-  config:
-    dsn: ${DATABASE_URL}
-
-secrets:
-  provider: google_secret_manager
-  config:
-    project: my-project
-
-integrations:
-  github:
-    display_name: GitHub
-    connections:
-      default:
-        mode: user
-        auth:
-          type: oauth2
-          client_id: ${GITHUB_CLIENT_ID}
-          client_secret: secret://github-client-secret
-          authorization_url: https://github.com/login/oauth/authorize
-          token_url: https://github.com/login/oauth/access_token
-    api:
-      type: rest
-      openapi: https://api.github.com/openapi.json
-      connection: default
-
-bindings:
-  proxy:
-    type: proxy
-    providers:
-      - github
-    config:
-      path: /proxy
-
-egress:
-  default_action: deny
-  policies:
-    - action: allow
-      host: api.github.com
-    - action: allow
-      host: api.openai.com
-  credentials:
-    - host: api.openai.com
-      secret_ref: openai-api-key
-      auth_style: bearer
-```
-
-## Startup
-
-Gateway-only configs have no remote API specs to fetch, so locked startup works without `gestaltd init`:
-
-```sh
-gestaltd serve --config ./gateway.yaml
-```
-
-For production, you can still use the locked flow:
-
-```sh
-gestaltd init --config ./gateway.yaml
-gestaltd serve --locked --config ./gateway.yaml
-```
-
-See [Deploy Overview](/deploy) for Docker, Kubernetes, and other deployment targets.
+If you want an immutable runtime image, run `gestaltd init` in a build stage,
+copy the prepared config directory plus `.gestalt/` into the final image, and
+keep the runtime container on the default locked command.

--- a/docs/pages/deploy/kubernetes.mdx
+++ b/docs/pages/deploy/kubernetes.mdx
@@ -57,8 +57,8 @@ Enable the init container when your config uses:
 
 - `plugin.package`
 - `plugin.source`
-- runtime plugins
-- UI plugins
+- `ui.plugin.package`
+- `ui.plugin.source`
 
 The init container copies the rendered config and runs:
 

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -2,73 +2,81 @@ import { Callout } from 'nextra/components'
 
 # Getting Started
 
-This guide starts with the true out-of-the-box flow, then moves to an explicit config and a production-style startup path.
+This guide starts with the zero-config local path and then switches to an
+explicit `config.yaml`.
 
 ## Install
 
-**Homebrew** (macOS and Linux)
+**Homebrew**
 
 ```sh
 brew install valon-technologies/gestalt/gestaltd
-```
-
-The `gestalt` client CLI provides `auth`, `invoke`, and `tokens` commands for interacting with a running server:
-
-```sh
 brew install valon-technologies/gestalt/gestalt
 ```
 
-**Binary download**
+**Binary releases**
 
-Download the latest release for your platform from the [Releases page](https://github.com/valon-technologies/gestalt/releases), extract it, and place the `gestaltd` binary on your `PATH`.
+Download the latest binaries from the
+[GitHub releases page](https://github.com/valon-technologies/gestalt/releases)
+and place them on your `PATH`.
 
 **Docker**
 
-The `valontechnologies/gestaltd` image ships `gestaltd` and supports both `amd64` and `arm64` (Apple Silicon).
+The published image is `valontechnologies/gestaltd`. It expects
+`/etc/gestalt/config.yaml` and defaults to
+`serve --locked --config /etc/gestalt/config.yaml`.
+See [Docker](/deploy/gateway-only) for the container layout and mount
+expectations.
 
-Quick start (mutable mode, fetches remote specs on startup):
-
-```sh
-docker run -p 8080:8080 -v ./config.yaml:/etc/gestalt/config.yaml valontechnologies/gestaltd:latest gestaltd
-```
-
-The trailing `gestaltd` overrides the default CMD (`serve --locked`) so the server auto-prepares missing state on startup.
-
-For production, init first and use the default locked mode:
-
-```sh
-docker run -p 8080:8080 -v ./config:/etc/gestalt valontechnologies/gestaltd:latest
-```
-
-## Run `gestaltd` With No Config
+## Run A Local Server With No Config
 
 ```sh
 gestaltd
 ```
 
-If no config file exists and you did not pass `--config`, `gestaltd` creates `~/.gestalt/config.yaml` for you and starts immediately.
+If you do not pass `--config` and no local config exists, Gestalt writes a new
+file at `~/.gestalt/config.yaml` and starts immediately.
 
-The generated local config uses `auth.provider: none`, SQLite as the datastore at `~/.gestalt/gestalt.db`, `env` for secrets, and a generated `server.encryption_key`.
+The generated local config uses:
 
-The server listens on `http://localhost:8080`. The web UI is served from that same port.
+- `auth.provider: none`
+- `datastore.provider: sqlite`
+- `secrets.provider: env`
+- `telemetry.provider: stdout`
+- `server.port: 8080`
+
+The generated SQLite database lives at `~/.gestalt/gestalt.db`.
 
 <Callout>
-  The default command `gestaltd` is intentionally local-friendly. It can auto-generate config and auto-prepare remote artifacts. Production deployments should usually use `gestaltd init` followed by `gestaltd serve --locked`.
+  `gestaltd` is intentionally local-friendly. Production deployments should
+  usually use `gestaltd init` followed by `gestaltd serve --locked`.
 </Callout>
 
-## Open The UI
+## Write An Explicit Config
 
-Visit `http://localhost:8080`. The generated config uses `auth.provider: none`, so no sign-in is required. Add an integration to start building.
+Save this as `openapi/httpbin.yaml`:
 
-## Or: Generate A Config With `gestalt init`
-
-Instead of writing `config.yaml` by hand, run `gestalt init` for an interactive setup wizard that walks you through creating one.
-
-```sh
-gestalt init
+```yaml
+openapi: 3.0.3
+info:
+  title: HTTPBin
+  version: 1.0.0
+servers:
+  - url: https://httpbin.org
+paths:
+  /ip:
+    get:
+      operationId: get_ip
+      responses:
+        "200":
+          description: OK
+  /headers:
+    get:
+      operationId: get_headers
+      responses:
+        "200":
+          description: OK
 ```
-
-## Switch To An Explicit Config
 
 Save this as `config.yaml`:
 
@@ -76,7 +84,7 @@ Save this as `config.yaml`:
 server:
   port: 8080
   base_url: http://localhost:8080
-  encryption_key: change-me
+  encryption_key: dev-only-change-me
 
 auth:
   provider: none
@@ -87,51 +95,63 @@ datastore:
     path: ./gestalt.db
 
 integrations:
-  github:
-    display_name: GitHub REST API
-    description: Public GitHub REST surface
-    connections:
-      default:
-        mode: none
-    api:
-      type: rest
-      openapi: https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json
-      connection: default
+  httpbin:
+    display_name: HTTPBin
+    description: Public request and response inspection API
+    mcp_tool_prefix: httpbin_
+    plugin:
+      openapi: ./openapi/httpbin.yaml
+      openapi_connection: public
+      default_connection: public
+      connections:
+        public:
+          mode: none
+          auth:
+            type: none
 ```
 
-This is the smallest useful production-shaped config: explicit `server`, `auth`, and `datastore` blocks, one named integration, one connection with `mode: none`, and one REST API surface pointing at an OpenAPI spec.
+This is the smallest useful Gestalt config:
 
-## Init And Validate It
+- one explicit server block
+- no platform auth
+- SQLite storage
+- one inline OpenAPI integration
+
+## Validate And Start It
 
 ```sh
 gestaltd init --config ./config.yaml
 gestaltd validate --config ./config.yaml
-```
-
-`init` resolves remote provider inputs in-place. For the config above, init creates:
-
-- `gestalt.lock.json`
-- `.gestalt/providers/github.json`
-
-## Start From Locked State
-
-```sh
 gestaltd serve --locked --config ./config.yaml
 ```
 
-This is the deployment path to model in Docker, Kubernetes, or any other production target. Startup becomes deterministic because `gestaltd` no longer needs to mutate local state or fetch remote specs.
+`init` writes `gestalt.lock.json`. With this inline config there are no packaged
+artifacts to fetch, but the same workflow scales to packaged providers and UI
+plugins.
 
-## What To Learn Next
+## Call The Integration
 
-- [Platform Model](/concepts/platform-model): how config turns into providers, bindings, and MCP.
-- [Configuration](/concepts/configuration): config discovery, defaults, secret resolution, and lock state.
-- [Add an Integration](/tasks/add-an-integration): build a real integration from REST, GraphQL, MCP, or plugins.
-- [Deploy](/deploy): move the same config into Docker or Kubernetes.
-
-## Explore Operations With `gestalt describe`
-
-Once the server is running, use `gestalt describe` to inspect what operations an integration exposes and what parameters they accept:
+**HTTP API**
 
 ```sh
-gestalt describe github repos/list-for-authenticated-user
+curl http://localhost:8080/api/v1/httpbin/get_ip
 ```
+
+**Client CLI**
+
+```sh
+gestalt --url http://localhost:8080 integrations list
+gestalt --url http://localhost:8080 invoke httpbin get_headers
+```
+
+Because `auth.provider` is `none`, no login step is required.
+
+## Next Steps
+
+- [Configuration](/concepts/configuration) explains config discovery, defaults,
+  environment expansion, and locked startup.
+- [Integrations](/concepts/integrations) covers inline, packaged, and hybrid
+  providers.
+- [Plugin Manifests](/reference/plugin-manifests) shows how YAML manifests work
+  for packaged plugins.
+- [Run Locally](/tasks/run-locally) walks through local development patterns.

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -254,105 +254,90 @@ Audit records are emitted as structured log entries with `log.type=audit`. Route
 
 ## `integrations`
 
-Each integration follows one of three patterns: declarative (`connections` + `api`/`mcp`), plugin-only, or hybrid (plugin + `mcp`). See [Integrations](/concepts/integrations) for the conceptual model.
-
-### Declarative integration
+Every integration has one `plugin` block plus optional presentation metadata.
+That `plugin` block can define an inline provider, point at a packaged plugin,
+or combine a packaged plugin with spec-backed surfaces.
 
 ```yaml
 integrations:
   github:
     display_name: GitHub
-    description: GitHub REST API
-    mcp_tool_prefix: github_
+    description: Public GitHub operations
     icon_file: ./icons/github.svg
-    connections:
-      default:
-        mode: user
-        auth:
-          type: oauth2
-          client_id: ${GITHUB_CLIENT_ID}
-          client_secret: ${GITHUB_CLIENT_SECRET}
-          authorization_url: https://github.com/login/oauth/authorize
-          token_url: https://github.com/login/oauth/access_token
-    api:
-      type: rest
-      openapi: https://raw.githubusercontent.com/.../api.github.com.json
-      connection: default
+    mcp_tool_prefix: github_
+    plugin:
+      openapi: ./openapi/github.yaml
+      openapi_connection: public
+      default_connection: public
+      connections:
+        public:
+          mode: none
+          auth:
+            type: none
       allowed_operations:
-        repos/list-for-authenticated-user:
-        issues/list-for-authenticated-user:
+        repos.get:
+          alias: get_repo
 ```
+
+### Integration fields
 
 | Field | Purpose |
 | --- | --- |
-| `display_name`, `description` | Presentation metadata. |
-| `mcp_tool_prefix` | Prefix tool names on the MCP endpoint. |
-| `icon_file` | SVG path, resolved relative to the config file. |
-| `connections` | Named connections that own mode, auth, and params. |
-| `api` | REST or GraphQL surface. |
-| `mcp` | Upstream MCP surface. |
+| `display_name` | UI and API display name override. |
+| `description` | UI and API description override. |
+| `icon_file` | SVG icon path resolved from the config directory. |
+| `mcp_tool_prefix` | Prefix for tools exposed on `/mcp`. |
+| `plugin` | The actual provider definition. Required. |
 
-### `connections`
+### `integrations.*.plugin`
 
-```yaml
-connections:
-  default:
-    mode: user
-    params:
-      subdomain:
-        required: true
-    auth:
-      type: oauth2
-      authorization_url: https://accounts.example.com/oauth/authorize
-      token_url: https://accounts.example.com/oauth/token
-      client_id: ${CLIENT_ID}
-      client_secret: ${CLIENT_SECRET}
-```
+The same `plugin` block supports inline providers, packaged providers, and
+hybrid providers.
+
+#### External plugin source fields
 
 | Field | Purpose |
 | --- | --- |
-| `mode` | `user` (default), `identity`, `either`, or `none`. All connections in an integration must share the same mode. |
-| `params` | Named parameters callers supply when connecting. Used for URL template expansion. |
-| `auth` | Auth configuration for this connection. |
+| `command` | Execute a local binary directly. |
+| `package` | Load a local directory, local archive, or HTTPS archive. |
+| `source` | Resolve a versioned plugin source during `init`. Format: `github.com/<org>/<repo>/<plugin>`. |
+| `version` | Required with `source`. Invalid with `command` or `package`. |
+| `args` | Extra process arguments for `command`. |
+| `env` | Extra environment variables for external plugins. |
+| `config` | Provider-specific config passed into packaged providers. |
+| `allowed_hosts` | Optional network allowlist for sandboxed plugin processes. |
+| `allowed_operations` | Surface allowlist plus `alias` and `description` overrides. |
 
-### `api`
+`command`, `package`, and `source` are mutually exclusive.
 
-```yaml
-api:
-  type: rest
-  openapi: https://example.com/openapi.json
-  connection: default
-  allowed_operations:
-    listThings:
-```
-
-| Field | Purpose |
-| --- | --- |
-| `type` | `rest` or `graphql`. |
-| `openapi` | Required when `type: rest`. URL or local path to an OpenAPI document. |
-| `url` | Required when `type: graphql`. The GraphQL endpoint URL. |
-| `connection` | References a named connection in the same integration. |
-| `allowed_operations` | Narrows exposed operations. Bare key keeps the upstream description. Object with `alias` and/or `description` overrides it. |
-
-### `mcp`
-
-```yaml
-mcp:
-  url: https://mcp.example.com
-  connection: mcp_conn
-  allowed_operations:
-    search:
-```
+#### Inline provider fields
 
 | Field | Purpose |
 | --- | --- |
-| `url` | Required. The upstream MCP server URL. |
-| `connection` | References a named connection in the same integration. |
-| `allowed_operations` | Optional. Narrows exposed tools. Same override syntax as `api`. |
+| `auth` | Auth definition for the implicit plugin connection. |
+| `params` | Connection parameters for the implicit plugin connection. |
+| `connections` | Named connections for inline integrations. |
+| `openapi` | OpenAPI document URL or local file path. |
+| `graphql_url` | GraphQL endpoint. |
+| `mcp_url` | Upstream MCP endpoint. |
+| `base_url` | Base URL for declarative REST operations. |
+| `headers` | Static headers applied to spec-backed or declarative requests. |
+| `managed_parameters` | Fixed header or path values injected before exposure. |
+| `operations` | Inline declarative REST operations. |
+| `response_mapping` | Data and pagination mapping for spec-backed providers. |
+| `openapi_connection` | Named connection to use for OpenAPI. |
+| `graphql_connection` | Named connection to use for GraphQL. |
+| `mcp_connection` | Named connection to use for upstream MCP. |
+| `default_connection` | Default connection used when the caller does not specify one. |
+| `mcp` | Expose packaged provider operations on `/mcp`. |
 
-### `auth`
+Packaged providers can add `openapi`, `graphql_url`, or `mcp_url` in config,
+but inline `plugin.connections` only applies to inline providers. Packaged
+providers define named connections in their manifests.
 
-Auth configuration for a connection.
+### Auth shapes inside `plugin`
+
+Top-level `plugin.auth` and named connection auth blocks use the same shape:
 
 ```yaml
 auth:
@@ -398,45 +383,45 @@ auth:
 | `accept_header` | `Accept` header for the token endpoint. |
 | `token_metadata` | Fields to extract from the token response and store as connection metadata. |
 
-`mcp_oauth` is an advanced mode for MCP-driven OAuth discovery. It delegates authorization URL and token URL resolution to the upstream MCP server.
+`mcp_oauth` is an advanced mode for MCP-driven OAuth discovery. It delegates
+authorization URL and token URL resolution to the upstream MCP server.
 
 #### Manual auth with custom credential fields
 
-For manual-auth connections, you can customize the credential input form with `credentials`. Each entry defines a field the user must fill in, with an optional label, description, and help URL.
+For manual-auth connections, you can customize the credential input form with
+`credentials`. Each entry defines a field the user must fill in, with an
+optional label, description, and help URL.
 
 Single credential with a custom label:
 
 ```yaml
-connections:
-  default:
-    mode: user
-    auth:
-      type: manual
-      credentials:
-        - name: token
-          label: API Access Token
-          help_url: https://app.example.com/settings/tokens
+plugin:
+  auth:
+    type: manual
+    credentials:
+      - name: token
+        label: API Access Token
+        help_url: https://app.example.com/settings/tokens
 ```
 
-Multiple credentials (requires `auth_mapping` to map each field to an HTTP header):
+Multiple credentials require `auth_mapping` to map each field to an HTTP
+header:
 
 ```yaml
-connections:
-  default:
-    mode: user
-    auth:
-      type: manual
-      credentials:
-        - name: api_key
-          label: API Key
-          help_url: https://us5.datadoghq.com/organization-settings/api-keys
-        - name: app_key
-          label: Application Key
-          help_url: https://us5.datadoghq.com/organization-settings/application-keys
-      auth_mapping:
-        headers:
-          DD-API-KEY: api_key
-          DD-APPLICATION-KEY: app_key
+plugin:
+  auth:
+    type: manual
+    credentials:
+      - name: api_key
+        label: API Key
+        help_url: https://us5.datadoghq.com/organization-settings/api-keys
+      - name: app_key
+        label: Application Key
+        help_url: https://us5.datadoghq.com/organization-settings/application-keys
+    auth_mapping:
+      headers:
+        DD-API-KEY: api_key
+        DD-APPLICATION-KEY: app_key
 ```
 
 | Field | Notes |
@@ -449,53 +434,105 @@ connections:
 
 `credentials` is required when `auth.type` is `manual`.
 
-### `plugin`
-
-Plugin integrations delegate execution to an external binary. A plugin can compose with `api`, `mcp`, or both.
+### Named connections
 
 ```yaml
-integrations:
-  custom_tool:
-    plugin:
-      command: ./my-plugin
-```
-
-```yaml
-integrations:
-  custom_tool:
-    plugin:
-      source: github.com/your-org/your-repo/custom-tool
-      version: 1.0.0
-      config:
-        greeting: hello
-```
-
-| Field | Purpose |
-| --- | --- |
-| `command` | Local executable path. Mutually exclusive with `package` and `source`. |
-| `package` | Local directory, local archive, or HTTPS URL. Mutually exclusive with `command` and `source`. |
-| `source` | Managed plugin source address (`github.com/owner/repo/plugin`). Mutually exclusive with `command` and `package`. Requires `version`. |
-| `version` | Required with `source`. Must be valid SemVer. |
-| `args` | Command-line arguments. Only valid with `command`. |
-| `env` | Extra environment variables passed to the plugin process. |
-| `allowed_hosts` | Host allowlist for plugin network access. When set, the plugin is automatically sandboxed: filesystem access is restricted via Landlock (Linux) or sandbox-exec (macOS), and outbound HTTP is proxied through a local allowlist enforcer. Supports exact matches and wildcards (`*.example.com`). |
-| `config` | Arbitrary plugin config payload, validated against the plugin's config schema if one exists. |
-| `allowed_operations` | Narrows exposed operations. Same override syntax as `api.allowed_operations`. |
-
-### Hybrid integration (plugin + MCP)
-
-```yaml
-integrations:
-  slack:
-    plugin:
-      source: github.com/valon-technologies/gestalt/slack
-      version: 0.0.1-alpha.3
+plugin:
+  openapi: https://api.example.com/openapi.json
+  mcp_url: https://mcp.example.com/mcp
+  openapi_connection: api
+  mcp_connection: mcp
+  default_connection: api
+  connections:
+    api:
+      mode: user
+      auth:
+        type: oauth2
+        authorization_url: https://accounts.example.com/oauth/authorize
+        token_url: https://accounts.example.com/oauth/token
+        client_id: ${CLIENT_ID}
+        client_secret: ${CLIENT_SECRET}
     mcp:
-      url: https://mcp.slack.com
-      connection: plugin
+      mode: user
+      auth:
+        type: mcp_oauth
 ```
 
-Setting `mcp.connection` to `plugin` reuses the plugin's OAuth token for the MCP surface. Declare explicit `connections` and reference one from `mcp.connection` for separate credentials.
+Connection modes:
+
+- `none`
+- `user`
+- `identity`
+- `either`
+
+### Declarative operations
+
+```yaml
+plugin:
+  auth:
+    type: bearer
+    credentials:
+      - name: token
+        label: API Token
+  base_url: https://api.support.example.com
+  operations:
+    - name: list_tickets
+      method: GET
+      path: /tickets
+    - name: get_ticket
+      method: GET
+      path: /tickets/{ticket_id}
+```
+
+Each operation accepts:
+
+- `name`
+- `description`
+- `method`
+- `path`
+- `parameters`
+
+Parameter locations can be `query`, `body`, or `path`.
+
+### Managed parameters
+
+```yaml
+plugin:
+  openapi: https://api.example.com/openapi.json
+  openapi_connection: public
+  default_connection: public
+  connections:
+    public:
+      mode: none
+      auth:
+        type: none
+  managed_parameters:
+    - in: header
+      name: X-API-Version
+      value: "2026-04-01"
+    - in: path
+      name: account_id
+      value: primary
+```
+
+Managed parameter locations can be `header` or `path`.
+
+### Response mapping
+
+```yaml
+plugin:
+  graphql_url: https://api.example.com/graphql
+  auth:
+    type: bearer
+    credentials:
+      - name: token
+        label: API Token
+  response_mapping:
+    data_path: data.items
+    pagination:
+      has_more_path: pageInfo.hasNextPage
+      cursor_path: pageInfo.endCursor
+```
 
 ## `bindings`
 
@@ -630,15 +667,16 @@ Structural validation runs at config load time (`init`, `validate`, `serve`). Ru
 
 ### Structural
 
-- Integrations are declarative (`connections` + `api`/`mcp`), plugin-only, or hybrid (plugin + `api`, `mcp`, or both)
+- Every integration requires a `plugin` block
 - Exactly one of `command`, `package`, or `source` per plugin
 - `plugin.version` is required with `source` and invalid with `command` or `package`
 - `plugin.args` are only valid with `command`
 - Plain `http://` package URLs are rejected
+- External plugins cannot use inline `operations`
+- External plugins cannot use inline `connections`; named connections belong in the plugin manifest
 - All connections in an integration must share the same mode
-- `api.connection` and `mcp.connection` must reference a declared connection
-- REST API surfaces require `api.openapi`; GraphQL surfaces require `api.url`
-- URL templates in surface URLs and auth URLs must reference required params
+- `openapi_connection`, `graphql_connection`, `mcp_connection`, and `default_connection` must reference a declared connection when named connections are used
+- URL templates in spec surfaces and auth URLs must reference required params
 - `egress.default_action` and policy `action` must be `allow` or `deny`
 - `ui.plugin` requires exactly one of `package` or `source`
 - `ui.plugin.version` is required with `source` and invalid with `package`

--- a/docs/pages/reference/http-api.mdx
+++ b/docs/pages/reference/http-api.mdx
@@ -113,8 +113,5 @@ Gestalt:
 ## Example
 
 ```sh
-curl -X POST http://localhost:8080/api/v1/github/repos_listForAuthenticatedUser \
-  -H "Authorization: Bearer gst_api_..." \
-  -H "Content-Type: application/json" \
-  -d '{}'
+curl http://localhost:8080/api/v1/httpbin/get_headers
 ```

--- a/docs/pages/reference/plugin-manifests.mdx
+++ b/docs/pages/reference/plugin-manifests.mdx
@@ -13,15 +13,12 @@ YAML is the easiest format to author by hand.
 Supported manifest kinds are:
 
 - `provider`
-- `runtime`
 - `webui`
 
 A package can contain:
 
 - a provider only
-- a runtime only
 - a UI bundle only
-- a combined provider and runtime
 
 ## Common Fields
 
@@ -36,7 +33,7 @@ A package can contain:
 | `provider` | Provider metadata and optional declarative surfaces. |
 | `webui` | UI metadata for `webui` packages. |
 | `artifacts` | Packaged executable artifacts keyed by platform. |
-| `entrypoints` | Which artifact should be started for the provider or runtime. |
+| `entrypoints` | Which packaged executable should be started for the provider. |
 
 ## Basic YAML Manifest
 
@@ -76,10 +73,9 @@ Use this style when:
 
 ## Advanced YAML Manifest
 
-This example shows a hybrid packaged provider with:
+This example shows a provider package with:
 
 - a config schema
-- a packaged executable
 - OpenAPI and upstream MCP surfaces
 - multiple named connections
 - managed parameters
@@ -95,7 +91,7 @@ kinds:
   - provider
 provider:
   config_schema_path: schemas/config.schema.json
-  openapi: https://api.support.example.com/openapi.json
+  openapi: openapi.yaml
   mcp_url: https://mcp.support.example.com/mcp
   openapi_connection: api
   mcp_connection: mcp
@@ -127,46 +123,13 @@ provider:
       alias: list_tickets
     tickets.get:
       alias: get_ticket
-artifacts:
-  - os: darwin
-    arch: arm64
-    path: artifacts/darwin/arm64/provider
-    sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-  - os: linux
-    arch: amd64
-    path: artifacts/linux/amd64/provider
-    sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-entrypoints:
-  provider:
-    artifact_path: artifacts/linux/amd64/provider
 ```
 
 Use this style when:
 
-- the provider includes executable logic
-- a reusable package should ship its own auth and connection model
-- you want packaged custom code plus spec-backed operations
-
-## Runtime Manifest Example
-
-```yaml
-source: github.com/acme/plugins/notifier-runtime
-version: 0.4.0
-display_name: Notifier Runtime
-kinds:
-  - runtime
-artifacts:
-  - os: linux
-    arch: amd64
-    path: artifacts/linux/amd64/runtime
-    sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-entrypoints:
-  runtime:
-    artifact_path: artifacts/linux/amd64/runtime
-```
-
-If you include `schemas/config.schema.json` in the package root, Gestalt uses it
-to validate `runtimes.*.config`.
+- the provider should ship its own auth and connection model
+- you want a reusable package with spec-backed operations
+- you want manifest-level config validation
 
 ## Web UI Manifest Example
 
@@ -186,12 +149,10 @@ webui:
 - `source` and `version` are required.
 - Declarative-only provider packages do not require `artifacts` or
   `entrypoints`.
-- Provider or runtime packages that include executable code do require artifacts
-  and entrypoints.
-- `sha256` must match the artifact bytes. Replace the example values with the
-  hash from your own build.
+- Executable provider packages do require `artifacts` plus
+  `entrypoints.provider`.
 - `config_schema_path` validates `integrations.*.plugin.config`.
-- `schemas/config.schema.json` validates `runtimes.*.config`.
+- Connection parameters discovered after auth live under `provider.connection`.
 
 ## Packaging And Release
 
@@ -201,7 +162,7 @@ Package a local plugin directory:
 gestaltd plugin package --input ./my-plugin --output ./dist/my-plugin.tar.gz
 ```
 
-Build a multi-platform release from a plugin source directory:
+Build a release from a plugin source directory:
 
 ```sh
 gestaltd plugin release --version 1.2.3

--- a/docs/pages/tasks/use-a-plugin-package.mdx
+++ b/docs/pages/tasks/use-a-plugin-package.mdx
@@ -6,16 +6,17 @@ Packaged plugins are the deployment-oriented way to run executable providers.
 
 ```yaml
 integrations:
-  acme:
+  example:
     plugin:
-      package: ./plugins/acme-provider
+      package: ./dist/example-provider.tar.gz
       config:
-        endpoint: https://api.example.com
+        greeting: Hello from packaged plugin
 ```
 
 `plugin.package` accepts:
 
 - a local directory
+- a local `.tar.gz`
 - an HTTPS URL (`.tar.gz`)
 
 ## Init It

--- a/docs/pages/tasks/write-a-plugin.mdx
+++ b/docs/pages/tasks/write-a-plugin.mdx
@@ -1,87 +1,42 @@
 # Write A Plugin
 
-This walkthrough uses the Go SDK because the repository ships working provider
-and runtime examples in Go.
+The repository ships a working Go provider example under
+`examples/plugins/provider-go`.
 
-## Implement A Provider
+Start there when you want a minimal executable provider that speaks the public
+plugin protocol.
 
-Start from a complete provider, not a fragment:
+## Build The Example Provider
 
-```go
-package main
+Run this from `examples/plugins/provider-go`:
 
-import (
-    "context"
-    "encoding/json"
-    "fmt"
-    "net/http"
-    "os"
-    "os/signal"
-
-    gestalt "github.com/valon-technologies/gestalt/sdk/go"
-)
-
-type exampleProvider struct {
-    greeting string
-}
-
-func (p *exampleProvider) Name() string        { return "example" }
-func (p *exampleProvider) DisplayName() string { return "Example Provider" }
-func (p *exampleProvider) Description() string { return "A minimal example provider" }
-func (p *exampleProvider) ConnectionMode() gestalt.ConnectionMode {
-    return gestalt.ConnectionModeNone
-}
-
-func (p *exampleProvider) Catalog() *gestalt.Catalog {
-    return &gestalt.Catalog{
-        Name: "example",
-        Operations: []gestalt.CatalogOperation{
-            {
-                ID:          "greet",
-                Method:      http.MethodGet,
-                Description: "Say hello",
-                Parameters: []gestalt.CatalogParameter{
-                    {Name: "name", Type: "string", Description: "Name to greet"},
-                },
-            },
-        },
-    }
-}
-
-func (p *exampleProvider) Execute(_ context.Context, _ string, params map[string]any, _ string) (*gestalt.OperationResult, error) {
-    name, _ := params["name"].(string)
-    if name == "" {
-        name = "World"
-    }
-    greeting := p.greeting
-    if greeting == "" {
-        greeting = "Hello"
-    }
-    body, _ := json.Marshal(map[string]string{
-        "message": fmt.Sprintf("%s, %s!", greeting, name),
-    })
-    return &gestalt.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
-}
-
-func main() {
-    ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
-    defer cancel()
-    if err := gestalt.ServeProvider(ctx, &exampleProvider{}); err != nil {
-        fmt.Fprintln(os.Stderr, err)
-        os.Exit(1)
-    }
-}
+```sh
+go build -o ./provider-go .
 ```
 
-The repository examples live under:
+## Add A Manifest
 
-- `examples/plugins/provider-go`
-- `examples/plugins/runtime-go`
+Add a `plugin.yaml` or `plugin.json` to the plugin root.
 
-## Add A YAML Manifest
+For a releasable provider package, start with:
 
-Add a `plugin.yaml` or `plugin.json` to the plugin root. For manifest fields
-and worked examples, use [Plugin Manifests](/reference/plugin-manifests).
+```yaml
+source: github.com/acme/plugins/example
+version: 0.1.0
+display_name: Example Provider
+description: Minimal example provider
+kinds:
+  - provider
+provider:
+  base_url: https://example.invalid
+  operations:
+    - name: greet
+      method: GET
+      path: /greet
+```
+
+See [Plugin Manifests](/reference/plugin-manifests) for the full manifest
+model.
 
 ## Package It
 
@@ -99,11 +54,26 @@ gestaltd plugin release --version 0.1.0
 
 ## Use It From `config.yaml`
 
+During local development, point at the binary directly:
+
+```yaml
+integrations:
+  example:
+    plugin:
+      command: ./provider-go
+      config:
+        greeting: Hello from example plugin
+```
+
+For prepared deployments, point at the packaged archive:
+
 ```yaml
 integrations:
   example:
     plugin:
       package: ./dist/my-plugin.tar.gz
+      config:
+        greeting: Hello from example plugin
 ```
 
 Then:
@@ -113,10 +83,8 @@ gestaltd init --config ./config.yaml
 gestaltd serve --locked --config ./config.yaml
 ```
 
-## Add Runtime Or UI Variants
+## Ship A Web UI Instead
 
-- Add a `runtime` kind when the package should run as a long-lived background
-  worker.
-- Add a `webui` kind when the package should ship a replacement UI bundle.
-
-See [Plugin Manifests](/reference/plugin-manifests) for the full manifest model.
+If the package should replace the embedded frontend, add the `webui` kind and
+`webui.asset_root` to the manifest. The package can then be used from
+`ui.plugin`.


### PR DESCRIPTION
## Summary
- restore the docs to the current `integrations.<name>.plugin.*` config model
- remove stale runtime plugin references from manifests, packaging, Kubernetes, and Docker copy
- replace broken or misleading task examples with examples I exercised locally
- turn `/deploy/gateway-only` back into Docker deployment guidance so the route matches the nav again

## What was wrong
- several pages documented a top-level `connections` / `api` / `mcp` integration shape that the current server does not accept
- runtime plugin support was still documented even though it was removed from the code and manifest schema
- a few task and reference examples had drifted away from commands and manifests I could actually run

## Validation
- `go run ./cmd/gestaltd --help`
- `cargo run -p gestalt -- --help`
- local lifecycle pass for:
  - `gestaltd`
  - `gestaltd --config ./config.yaml`
  - `gestaltd init --config ./config.yaml`
  - `gestaltd validate --config ./config.yaml`
  - `gestaltd validate --init --config ./config.yaml`
  - `gestaltd serve --locked --config ./config.yaml`
  - `curl http://127.0.0.1:18080/api/v1/httpbin/get_ip`
  - `curl http://127.0.0.1:18080/api/v1/httpbin/get_headers`
  - `gestalt --url http://127.0.0.1:18080 integrations list`
  - `gestalt --url http://127.0.0.1:18080 describe httpbin get_ip`
  - `gestalt --url http://127.0.0.1:18080 invoke httpbin get_headers`
- plugin flow pass for:
  - `go build -o ./provider-go .` in `examples/plugins/provider-go`
  - `gestaltd plugin package --input ... --output ...` for the basic manifest example
  - `gestaltd plugin package --input ... --output ...` for the advanced manifest example
  - `plugin.command` config using the example provider binary
  - `plugin.package` config using a packaged executable provider archive
  - `gestaltd plugin release --version 0.0.1-test --platform darwin/arm64` in `plugins/bigquery`
- `helm upgrade --install gestalt ./server/deploy/helm/gestalt --set image.tag=test --dry-run --debug`
- `cd docs && npm ci`
- `cd docs && npm run typecheck`
- `cd docs && npm run build`

## Notes
- I did not re-run the long Docker command examples in `docs/dockerhub/gestaltd.md` because the local Docker daemon was not available in this environment. I only corrected the stale runtime wording there.
