### PR TITLE
Simplify manifest and connection parameter surfaces

### DIFF
--- a/docs/pages/concepts/integrations.mdx
+++ b/docs/pages/concepts/integrations.mdx
@@ -166,6 +166,9 @@ plugin:
         token_url: https://accounts.example.com/oauth/token
         client_id: ${CLIENT_ID}
         client_secret: ${CLIENT_SECRET}
+      params:
+        tenant:
+          required: true
     mcp:
       mode: user
       auth:

--- a/docs/pages/concepts/integrations.mdx
+++ b/docs/pages/concepts/integrations.mdx
@@ -126,7 +126,7 @@ still comes from a spec or upstream server.
 
 ## The Implicit Plugin Connection
 
-When you use top-level `plugin.auth` and `plugin.params`, Gestalt creates an
+When you use top-level `plugin.auth` and `plugin.connection_params`, Gestalt creates an
 implicit connection internally. In API responses and UI flows this connection is
 exposed as `plugin`.
 
@@ -138,7 +138,7 @@ plugin:
     token_url: https://accounts.example.com/oauth/token
     client_id: ${CLIENT_ID}
     client_secret: ${CLIENT_SECRET}
-  params:
+  connection_params:
     tenant:
       required: true
 ```

--- a/docs/pages/concepts/platform-model.mdx
+++ b/docs/pages/concepts/platform-model.mdx
@@ -68,7 +68,7 @@ providers work.
 Gestalt resolves credentials through either the implicit plugin connection or a
 set of named connections.
 
-- `plugin.auth` and `plugin.params` define the implicit `plugin` connection
+- `plugin.auth` and `plugin.connection_params` define the implicit `plugin` connection
 - `plugin.connections` defines named connections for inline providers
 - packaged providers define their own named connections in the manifest
 - `openapi_connection`, `graphql_connection`, `mcp_connection`, and

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -313,7 +313,7 @@ hybrid providers.
 | Field | Purpose |
 | --- | --- |
 | `auth` | Auth definition for the implicit plugin connection. |
-| `params` | Connection parameters for the implicit plugin connection. |
+| `connection_params` | Connection parameters for the implicit plugin connection. |
 | `connections` | Named connections for inline integrations. |
 | `openapi` | OpenAPI document URL or local file path. |
 | `graphql_url` | GraphQL endpoint. |

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -450,6 +450,9 @@ plugin:
         token_url: https://accounts.example.com/oauth/token
         client_id: ${CLIENT_ID}
         client_secret: ${CLIENT_SECRET}
+      params:
+        tenant:
+          required: true
     mcp:
       mode: user
       auth:

--- a/docs/pages/reference/plugin-manifests.mdx
+++ b/docs/pages/reference/plugin-manifests.mdx
@@ -214,7 +214,7 @@ webui:
 - Executable provider packages do require `artifacts` plus
   `entrypoints.provider`.
 - `config_schema_path` validates `integrations.*.plugin.config`.
-- Connection parameters discovered after auth live under `provider.connection`.
+- Connection parameters discovered after auth live under `provider.connection_params`.
 
 ## Packaging And Release
 
@@ -229,3 +229,6 @@ Build a release from a plugin source directory:
 ```sh
 gestaltd plugin release --version 1.2.3
 ```
+
+`gestaltd plugin release` preserves the source manifest format, so
+`plugin.yaml` stays YAML and `plugin.json` stays JSON in the release package.

--- a/plugins/jira/plugin.yaml
+++ b/plugins/jira/plugin.yaml
@@ -25,7 +25,7 @@ provider:
     name_path: name
     metadata_mapping:
       cloud_id: id
-  connection:
+  connection_params:
     cloud_id:
       required: true
       description: Jira Cloud site identifier (discovered automatically)

--- a/server/cmd/gestaltd/e2e_test.go
+++ b/server/cmd/gestaltd/e2e_test.go
@@ -391,32 +391,67 @@ func TestE2EValidateNonMutating(t *testing.T) {
 
 //nolint:paralleltest // Spawns the CLI binary; keeping it serial avoids package-level e2e flake.
 func TestE2EValidateRejectsUnknownYAMLField(t *testing.T) {
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := `auth:
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		pluginYAML string
+		wantError  string
+	}{
+		{
+			name: "bogus field",
+			pluginYAML: `command: /tmp/provider
+bogus: true`,
+			wantError: "bogus",
+		},
+		{
+			name: "removed plugin connection field",
+			pluginYAML: `command: /tmp/provider
+connection: default`,
+			wantError: "connection",
+		},
+		{
+			name: "removed plugin params field",
+			pluginYAML: `command: /tmp/provider
+params:
+  tenant:
+    required: true`,
+			wantError: "params",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "config.yaml")
+			cfg := fmt.Sprintf(`auth:
   provider: local
 datastore:
   provider: sqlite
   config:
-    path: ` + filepath.Join(dir, "gestalt.db") + `
+    path: %s
 server:
   encryption_key: test-key
 integrations:
   example:
     plugin:
-      command: /tmp/provider
-      bogus: true
-`
-	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
-		t.Fatalf("WriteFile config: %v", err)
-	}
+      %s
+`, filepath.Join(dir, "gestalt.db"), strings.ReplaceAll(tc.pluginYAML, "\n", "\n      "))
+			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+				t.Fatalf("WriteFile config: %v", err)
+			}
 
-	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
-	if err == nil {
-		t.Fatalf("expected validate to fail for unknown field, output: %s", out)
-	}
-	if !strings.Contains(string(out), "bogus") || !strings.Contains(string(out), "parsing config YAML") {
-		t.Fatalf("expected output to mention unknown field and YAML parsing, got: %s", out)
+			out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+			if err == nil {
+				t.Fatalf("expected validate to fail for unknown field, output: %s", out)
+			}
+			if !strings.Contains(string(out), tc.wantError) || !strings.Contains(string(out), "parsing config YAML") {
+				t.Fatalf("expected output to mention %q and YAML parsing, got: %s", tc.wantError, out)
+			}
+		})
 	}
 }
 
@@ -428,12 +463,6 @@ func TestE2EValidateRejectsUnsupportedPluginFields(t *testing.T) {
 		pluginYAML string
 		wantError  string
 	}{
-		{
-			name: "plugin connection unsupported",
-			pluginYAML: `command: /tmp/provider
-connection: default`,
-			wantError: "plugin.connection is not supported; remove plugin.connection and use plugin.default_connection or a surface-specific *_connection field instead",
-		},
 		{
 			name: "env unsupported for inline plugin",
 			pluginYAML: `openapi: https://api.example.test/openapi.json

--- a/server/cmd/gestaltd/e2e_test.go
+++ b/server/cmd/gestaltd/e2e_test.go
@@ -112,7 +112,10 @@ default_connection: missing
 connections:
   workspace:
     auth:
-      type: manual`,
+      type: manual
+    params:
+      tenant:
+        required: true`,
 			wantError: "plugin.default_connection references undeclared connection",
 		},
 	}

--- a/server/cmd/gestaltd/plugin.go
+++ b/server/cmd/gestaltd/plugin.go
@@ -63,8 +63,8 @@ func packageFromDir(input, output string) error {
 	if info, err := os.Stat(input); err != nil {
 		return err
 	} else if !info.IsDir() {
-		if filepath.Base(input) != pluginpkg.ManifestFile {
-			return fmt.Errorf("plugin package input must be a directory or %s, got %q", pluginpkg.ManifestFile, input)
+		if !pluginpkg.IsManifestFile(input) {
+			return fmt.Errorf("plugin package input must be a directory or one of %s, got %q", strings.Join(pluginpkg.ManifestFiles, ", "), input)
 		}
 		sourceDir = filepath.Dir(input)
 	}
@@ -125,6 +125,8 @@ func runPluginRelease(args []string) error {
 	if err != nil {
 		return fmt.Errorf("decode %s: %w", manifestPath, err)
 	}
+	manifestFormat := pluginpkg.ManifestFormatFromPath(manifestPath)
+	manifestFile := filepath.Base(manifestPath)
 
 	src, err := pluginsource.Parse(srcManifest.Source)
 	if err != nil {
@@ -164,14 +166,14 @@ func runPluginRelease(args []string) error {
 			if err != nil {
 				return fmt.Errorf("detect build target for %s/%s: %w", plat.GOOS, plat.GOARCH, err)
 			}
-			archivePath, err := buildPlatformArchive(srcManifest, pluginName, *version, buildTarget, plat, *outputDir)
+			archivePath, err := buildPlatformArchive(srcManifest, pluginName, *version, buildTarget, plat, *outputDir, manifestFile, manifestFormat)
 			if err != nil {
 				return fmt.Errorf("build %s/%s: %w", plat.GOOS, plat.GOARCH, err)
 			}
 			archivePaths = append(archivePaths, archivePath)
 		}
 	} else {
-		archivePath, err := buildSourceArchive(srcManifest, pluginName, *version, *outputDir)
+		archivePath, err := buildSourceArchive(srcManifest, pluginName, *version, *outputDir, manifestFile, manifestFormat)
 		if err != nil {
 			return err
 		}
@@ -185,7 +187,7 @@ func runPluginRelease(args []string) error {
 	return nil
 }
 
-func buildPlatformArchive(srcManifest *pluginmanifestv1.Manifest, pluginName, version, buildTarget string, plat releasePlatform, outputDir string) (string, error) {
+func buildPlatformArchive(srcManifest *pluginmanifestv1.Manifest, pluginName, version, buildTarget string, plat releasePlatform, outputDir, manifestFile, manifestFormat string) (string, error) {
 	stagingDir, err := os.MkdirTemp("", "gestalt-release-*")
 	if err != nil {
 		return "", err
@@ -214,11 +216,11 @@ func buildPlatformArchive(srcManifest *pluginmanifestv1.Manifest, pluginName, ve
 		return "", err
 	}
 
-	data, err := pluginpkg.EncodeManifest(manifest)
+	data, err := pluginpkg.EncodeManifestFormat(manifest, manifestFormat)
 	if err != nil {
 		return "", fmt.Errorf("encode manifest: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(stagingDir, pluginpkg.ManifestFile), data, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(stagingDir, manifestFile), data, 0644); err != nil {
 		return "", err
 	}
 
@@ -325,7 +327,7 @@ func parseReleasePlatforms(value string) ([]releasePlatform, error) {
 	return platforms, nil
 }
 
-func buildSourceArchive(srcManifest *pluginmanifestv1.Manifest, pluginName, version, outputDir string) (string, error) {
+func buildSourceArchive(srcManifest *pluginmanifestv1.Manifest, pluginName, version, outputDir, manifestFile, manifestFormat string) (string, error) {
 	stagingDir, err := os.MkdirTemp("", "gestalt-release-*")
 	if err != nil {
 		return "", err
@@ -337,11 +339,11 @@ func buildSourceArchive(srcManifest *pluginmanifestv1.Manifest, pluginName, vers
 		return "", err
 	}
 
-	data, err := pluginpkg.EncodeManifest(manifest)
+	data, err := pluginpkg.EncodeManifestFormat(manifest, manifestFormat)
 	if err != nil {
 		return "", fmt.Errorf("encode manifest: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(stagingDir, pluginpkg.ManifestFile), data, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(stagingDir, manifestFile), data, 0644); err != nil {
 		return "", err
 	}
 

--- a/server/cmd/gestaltd/plugin_test.go
+++ b/server/cmd/gestaltd/plugin_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+	"gopkg.in/yaml.v3"
 )
 
 var stdoutMu sync.Mutex
@@ -154,6 +155,32 @@ func TestRun_PluginPackageCreatesDirectory(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // Swaps os.Stdout via captureStdout.
+func TestRun_PluginPackageAcceptsYAMLManifestInput(t *testing.T) {
+	dir := t.TempDir()
+	src := newPluginPackageFixture(t, dir)
+	manifestPath, manifest := readManifestFromDir(t, src)
+	if err := os.Remove(manifestPath); err != nil {
+		t.Fatalf("remove %s: %v", manifestPath, err)
+	}
+	writeReleaseTestManifestFormat(t, src, "plugin.yaml", manifest)
+
+	inputPath := filepath.Join(src, "plugin.yaml")
+	outPath := filepath.Join(dir, "output-dir")
+
+	output := captureStdout(t, func() error {
+		return run([]string{"plugin", "package", "--input", inputPath, "--output", outPath})
+	})
+
+	packagedManifestPath, _ := readManifestFromDir(t, outPath)
+	if filepath.Base(packagedManifestPath) != "plugin.yaml" {
+		t.Fatalf("packaged manifest = %q, want plugin.yaml", filepath.Base(packagedManifestPath))
+	}
+	if !strings.Contains(output, "packaged") {
+		t.Fatalf("expected packaged output, got: %q", output)
+	}
+}
+
 func TestRun_PluginPackageRejectsOutputInsideInput(t *testing.T) {
 	t.Parallel()
 
@@ -223,17 +250,21 @@ version: 0.1.0
 kinds:
   - provider
 provider:
+  base_url: https://api.example.com
   operations:
     - name: list_items
       method: GET
       path: /items
+  connection:
+    tenant:
+      required: true
 `), 0644)
 
 	out, err := runPluginReleaseCommandResult(pluginDir, "--version", "0.0.1-test")
 	if err == nil {
 		t.Fatal("expected invalid manifest error")
 	}
-	if !strings.Contains(string(out), "base_url") {
+	if !strings.Contains(string(out), "connection") {
 		t.Fatalf("unexpected output: %s", out)
 	}
 }
@@ -273,14 +304,7 @@ func TestE2EPluginReleaseBigquery(t *testing.T) {
 		t.Fatalf("extract archive: %v", err)
 	}
 
-	manifestData, err := os.ReadFile(filepath.Join(extractDir, pluginpkg.ManifestFile))
-	if err != nil {
-		t.Fatalf("read plugin.json: %v", err)
-	}
-	var manifest pluginmanifestv1.Manifest
-	if err := json.Unmarshal(manifestData, &manifest); err != nil {
-		t.Fatalf("unmarshal manifest: %v", err)
-	}
+	_, manifest := readManifestFromDir(t, extractDir)
 	if manifest.Version != testVersion {
 		t.Fatalf("manifest version = %q, want %q", manifest.Version, testVersion)
 	}
@@ -368,15 +392,7 @@ func TestRun_PluginReleasePreservesCompiledWebUIMetadata(t *testing.T) {
 	archiveName := "gestalt-plugin-compiled-webui-test_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
 	extractDir := extractReleasedArchive(t, outputDir, archiveName)
 
-	manifestData, err := os.ReadFile(filepath.Join(extractDir, pluginpkg.ManifestFile))
-	if err != nil {
-		t.Fatalf("read plugin.json: %v", err)
-	}
-
-	var manifest pluginmanifestv1.Manifest
-	if err := json.Unmarshal(manifestData, &manifest); err != nil {
-		t.Fatalf("unmarshal manifest: %v", err)
-	}
+	_, manifest := readManifestFromDir(t, extractDir)
 	if manifest.WebUI == nil || manifest.WebUI.AssetRoot != "out" {
 		t.Fatalf("manifest webui = %#v, want asset_root %q", manifest.WebUI, "out")
 	}
@@ -466,6 +482,56 @@ func TestRun_PluginReleaseTreatsDeclarativePluginWithHelperMainAsSource(t *testi
 	compiledArchiveName := "gestalt-plugin-declarative-provider_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
 	if _, err := os.Stat(filepath.Join(outputDir, compiledArchiveName)); !os.IsNotExist(err) {
 		t.Fatalf("unexpected compiled archive %s: %v", compiledArchiveName, err)
+	}
+}
+
+func TestRun_PluginReleasePreservesYAMLManifestFormatAndConnectionParams(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := filepath.Join(t.TempDir(), "declarative-provider")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(pluginDir): %v", err)
+	}
+	writeTestFile(t, pluginDir, "plugin.yaml", []byte(`
+source: github.com/testowner/plugins/declarative-provider
+version: 0.0.1
+kinds:
+  - provider
+provider:
+  base_url: https://api.example.com
+  operations:
+    - name: list_items
+      method: GET
+      path: /items
+  connection_params:
+    tenant:
+      required: true
+`), 0o644)
+
+	outputDir := t.TempDir()
+	const testVersion = "0.0.4-yaml.1"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-declarative-provider_v" + testVersion + ".tar.gz"
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifestPath, manifest := readManifestFromDir(t, extractDir)
+	if filepath.Base(manifestPath) != "plugin.yaml" {
+		t.Fatalf("released manifest = %q, want plugin.yaml", filepath.Base(manifestPath))
+	}
+	if manifest.Provider == nil || len(manifest.Provider.ConnectionParams) != 1 || !manifest.Provider.ConnectionParams["tenant"].Required {
+		t.Fatalf("provider connection_params = %+v", manifest.Provider)
+	}
+
+	manifestData, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read released manifest: %v", err)
+	}
+	if !strings.Contains(string(manifestData), "connection_params:") {
+		t.Fatalf("expected released manifest to use connection_params, got: %s", manifestData)
 	}
 }
 
@@ -1289,21 +1355,59 @@ func readReleasedManifest(t *testing.T, outputDir, archiveName string) *pluginma
 	t.Helper()
 
 	extractDir := extractReleasedArchive(t, outputDir, archiveName)
-	_, manifest, err := pluginpkg.ReadManifestFile(filepath.Join(extractDir, pluginpkg.ManifestFile))
+	manifestPath, err := pluginpkg.FindManifestFile(extractDir)
+	if err != nil {
+		t.Fatalf("find released manifest: %v", err)
+	}
+	_, manifest, err := pluginpkg.ReadManifestFile(manifestPath)
 	if err != nil {
 		t.Fatalf("read released manifest: %v", err)
 	}
 	return manifest
 }
 
-func writeReleaseTestManifest(t *testing.T, dir string, manifest *pluginmanifestv1.Manifest) {
+func readManifestFromDir(t *testing.T, dir string) (string, *pluginmanifestv1.Manifest) {
 	t.Helper()
 
-	data, err := json.MarshalIndent(manifest, "", "  ")
+	manifestPath, err := pluginpkg.FindManifestFile(dir)
 	if err != nil {
-		t.Fatalf("MarshalIndent(plugin.json): %v", err)
+		t.Fatalf("find manifest: %v", err)
 	}
-	writeTestFile(t, dir, "plugin.json", append(data, '\n'), 0644)
+	_, manifest, err := pluginpkg.ReadManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	return manifestPath, manifest
+}
+
+func writeReleaseTestManifest(t *testing.T, dir string, manifest *pluginmanifestv1.Manifest) {
+	t.Helper()
+	writeReleaseTestManifestFormat(t, dir, pluginpkg.ManifestFile, manifest)
+}
+
+func writeReleaseTestManifestFormat(t *testing.T, dir, manifestFile string, manifest *pluginmanifestv1.Manifest) {
+	t.Helper()
+
+	data, err := encodeTestManifestFormat(manifest, pluginpkg.ManifestFormatFromPath(manifestFile))
+	if err != nil {
+		t.Fatalf("encodeTestManifestFormat(%s): %v", manifestFile, err)
+	}
+	writeTestFile(t, dir, manifestFile, data, 0644)
+}
+
+func encodeTestManifestFormat(manifest *pluginmanifestv1.Manifest, format string) ([]byte, error) {
+	switch format {
+	case pluginpkg.ManifestFormatJSON:
+		data, err := json.MarshalIndent(manifest, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return append(data, '\n'), nil
+	case pluginpkg.ManifestFormatYAML:
+		return yaml.Marshal(manifest)
+	default:
+		return nil, errors.New("unsupported manifest format")
+	}
 }
 
 func writeTestFile(t *testing.T, dir, rel string, data []byte, mode os.FileMode) {

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -92,13 +92,12 @@ type EgressCredentialGrant struct {
 }
 
 type PluginDef struct {
-	Command    string            `yaml:"command"`
-	Package    string            `yaml:"package"`
-	Source     string            `yaml:"source"`
-	Version    string            `yaml:"version"`
-	Args       []string          `yaml:"args"`
-	Env        map[string]string `yaml:"env"`
-	Connection string            `yaml:"connection"`
+	Command string            `yaml:"command"`
+	Package string            `yaml:"package"`
+	Source  string            `yaml:"source"`
+	Version string            `yaml:"version"`
+	Args    []string          `yaml:"args"`
+	Env     map[string]string `yaml:"env"`
 
 	Config       yaml.Node `yaml:"config"`
 	AllowedHosts []string  `yaml:"allowed_hosts"`
@@ -120,7 +119,7 @@ type PluginDef struct {
 	MCPConnection     string `yaml:"mcp_connection"`
 	DefaultConnection string `yaml:"default_connection"`
 
-	ConnectionParams  map[string]ConnectionParamDef `yaml:"params"`
+	ConnectionParams  map[string]ConnectionParamDef `yaml:"connection_params"`
 	MCP               bool                          `yaml:"mcp"`
 	AllowedOperations map[string]*OperationOverride `yaml:"allowed_operations"`
 
@@ -241,9 +240,9 @@ type IntegrationDef struct {
 // ConnectionDef owns authentication and connection parameters for a named
 // connection. All connections in a single integration must share the same Mode.
 type ConnectionDef struct {
-	Mode   string                        `yaml:"mode"`
-	Auth   ConnectionAuthDef             `yaml:"auth"`
-	Params map[string]ConnectionParamDef `yaml:"params"`
+	Mode             string                        `yaml:"mode"`
+	Auth             ConnectionAuthDef             `yaml:"auth"`
+	ConnectionParams map[string]ConnectionParamDef `yaml:"connection_params"`
 }
 
 type ConnectionAuthDef struct {
@@ -396,8 +395,8 @@ func MergeConnectionDef(dst *ConnectionDef, src *ConnectionDef) {
 		dst.Mode = src.Mode
 	}
 	MergeConnectionAuth(&dst.Auth, src.Auth)
-	if len(src.Params) > 0 {
-		dst.Params = src.Params
+	if len(src.ConnectionParams) > 0 {
+		dst.ConnectionParams = src.ConnectionParams
 	}
 }
 
@@ -444,7 +443,7 @@ func EffectivePluginConnectionDef(plugin *PluginDef, manifestProvider *pluginman
 		MergeConnectionAuth(&conn.Auth, ManifestAuthToConnectionAuthDef(manifestProvider.Auth))
 	}
 	if plugin != nil {
-		override := &ConnectionDef{Params: plugin.ConnectionParams}
+		override := &ConnectionDef{ConnectionParams: plugin.ConnectionParams}
 		if plugin.Auth != nil {
 			override.Auth = *plugin.Auth
 		}
@@ -960,12 +959,6 @@ func validateSupportedPluginFields(name string, plugin *PluginDef) error {
 		supported bool
 		reason    string
 	}{
-		{
-			field:     "plugin.connection",
-			present:   plugin.Connection != "",
-			supported: false,
-			reason:    "is not supported; remove plugin.connection and use plugin.default_connection or a surface-specific *_connection field instead",
-		},
 		{
 			field:     "plugin.env",
 			present:   len(plugin.Env) > 0,

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -242,7 +242,7 @@ type IntegrationDef struct {
 type ConnectionDef struct {
 	Mode             string                        `yaml:"mode"`
 	Auth             ConnectionAuthDef             `yaml:"auth"`
-	ConnectionParams map[string]ConnectionParamDef `yaml:"connection_params"`
+	ConnectionParams map[string]ConnectionParamDef `yaml:"params"`
 }
 
 type ConnectionAuthDef struct {

--- a/server/internal/config/inline_manifest.go
+++ b/server/internal/config/inline_manifest.go
@@ -87,9 +87,9 @@ func InlineToManifest(name string, p *PluginDef) (*pluginmanifestv1.Manifest, er
 	}
 
 	if len(p.ConnectionParams) > 0 {
-		manifest.Provider.Connection = make(map[string]pluginmanifestv1.ProviderConnectionParam, len(p.ConnectionParams))
+		manifest.Provider.ConnectionParams = make(map[string]pluginmanifestv1.ProviderConnectionParam, len(p.ConnectionParams))
 		for k, v := range p.ConnectionParams {
-			manifest.Provider.Connection[k] = pluginmanifestv1.ProviderConnectionParam{
+			manifest.Provider.ConnectionParams[k] = pluginmanifestv1.ProviderConnectionParam{
 				Required: v.Required,
 			}
 		}

--- a/server/internal/pluginhost/declarative.go
+++ b/server/internal/pluginhost/declarative.go
@@ -68,7 +68,7 @@ func NewDeclarativeProvider(manifest *pluginmanifestv1.Manifest, httpClient *htt
 		auth:                 manifest.Provider.Auth,
 		httpClient:           httpClient,
 		postConnectDiscovery: manifest.Provider.PostConnectDiscovery,
-		connectionDefs:       manifest.Provider.Connection,
+		connectionDefs:       manifest.Provider.ConnectionParams,
 	}
 
 	for i := range manifest.Provider.Operations {

--- a/server/internal/pluginpkg/archive.go
+++ b/server/internal/pluginpkg/archive.go
@@ -28,10 +28,7 @@ func ReadPackageManifest(packagePath string) (_ []byte, _ *pluginmanifestv1.Mani
 			}
 			continue
 		}
-		format := "json"
-		if isYAMLFile(name) {
-			format = "yaml"
-		}
+		format := ManifestFormatFromPath(name)
 		manifest, err := DecodeManifestFormat(data, format)
 		if err != nil {
 			return nil, nil, err
@@ -46,10 +43,7 @@ func ReadManifestFile(p string) ([]byte, *pluginmanifestv1.Manifest, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("read manifest %q: %w", p, err)
 	}
-	format := "json"
-	if isYAMLFile(p) {
-		format = "yaml"
-	}
+	format := ManifestFormatFromPath(p)
 	manifest, err := DecodeManifestFormat(data, format)
 	if err != nil {
 		return nil, nil, err
@@ -62,10 +56,7 @@ func ReadSourceManifestFile(p string) ([]byte, *pluginmanifestv1.Manifest, error
 	if err != nil {
 		return nil, nil, fmt.Errorf("read manifest %q: %w", p, err)
 	}
-	format := "json"
-	if isYAMLFile(p) {
-		format = "yaml"
-	}
+	format := ManifestFormatFromPath(p)
 	manifest, err := DecodeSourceManifestFormat(data, format)
 	if err != nil {
 		return nil, nil, err
@@ -86,8 +77,7 @@ func LoadManifestFromPath(inputPath string) ([]byte, *pluginmanifestv1.Manifest,
 		data, manifest, err := ReadManifestFile(manifestPath)
 		return data, manifest, manifestPath, err
 	}
-	base := filepath.Base(inputPath)
-	if base == "plugin.json" || base == "plugin.yaml" || base == "plugin.yml" {
+	if IsManifestFile(inputPath) {
 		data, manifest, err := ReadManifestFile(inputPath)
 		return data, manifest, inputPath, err
 	}

--- a/server/internal/pluginpkg/manifest.go
+++ b/server/internal/pluginpkg/manifest.go
@@ -22,6 +22,11 @@ const ManifestFile = "plugin.json"
 
 var ManifestFiles = []string{"plugin.json", "plugin.yaml", "plugin.yml"}
 
+const (
+	ManifestFormatJSON = "json"
+	ManifestFormatYAML = "yaml"
+)
+
 func FindManifestFile(dir string) (string, error) {
 	for _, name := range ManifestFiles {
 		p := filepath.Join(dir, name)
@@ -30,6 +35,18 @@ func FindManifestFile(dir string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("no manifest file found in %s (tried %s)", dir, strings.Join(ManifestFiles, ", "))
+}
+
+func IsManifestFile(path string) bool {
+	base := filepath.Base(path)
+	return slices.Contains(ManifestFiles, base)
+}
+
+func ManifestFormatFromPath(path string) string {
+	if isYAMLFile(path) {
+		return ManifestFormatYAML
+	}
+	return ManifestFormatJSON
 }
 
 func isYAMLFile(path string) bool {
@@ -66,12 +83,12 @@ func normalizeYAML(v any) any {
 }
 
 func DecodeManifest(data []byte) (*pluginmanifestv1.Manifest, error) {
-	return DecodeManifestFormat(data, "json")
+	return DecodeManifestFormat(data, ManifestFormatJSON)
 }
 
 func DecodeSourceManifestFormat(data []byte, format string) (*pluginmanifestv1.Manifest, error) {
 	jsonData := data
-	if format == "yaml" {
+	if format == ManifestFormatYAML {
 		var err error
 		jsonData, err = yamlToJSON(data)
 		if err != nil {
@@ -83,7 +100,7 @@ func DecodeSourceManifestFormat(data []byte, format string) (*pluginmanifestv1.M
 
 func DecodeManifestFormat(data []byte, format string) (*pluginmanifestv1.Manifest, error) {
 	jsonData := data
-	if format == "yaml" {
+	if format == ManifestFormatYAML {
 		var err error
 		jsonData, err = yamlToJSON(data)
 		if err != nil {
@@ -360,18 +377,37 @@ func validateDeclarativeProvider(provider *pluginmanifestv1.Provider) error {
 }
 
 func EncodeManifest(manifest *pluginmanifestv1.Manifest) ([]byte, error) {
+	return EncodeManifestFormat(manifest, ManifestFormatJSON)
+}
+
+func EncodeManifestFormat(manifest *pluginmanifestv1.Manifest, format string) ([]byte, error) {
 	if err := ValidateManifest(manifest); err != nil {
 		return nil, err
 	}
-	return encodeManifest(manifest)
+	switch format {
+	case ManifestFormatJSON:
+		return encodeManifestJSON(manifest)
+	case ManifestFormatYAML:
+		return encodeManifestYAML(manifest)
+	default:
+		return nil, fmt.Errorf("unsupported manifest format %q", format)
+	}
 }
 
-func encodeManifest(manifest *pluginmanifestv1.Manifest) ([]byte, error) {
+func encodeManifestJSON(manifest *pluginmanifestv1.Manifest) ([]byte, error) {
 	data, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("marshal manifest: %w", err)
 	}
 	return append(data, '\n'), nil
+}
+
+func encodeManifestYAML(manifest *pluginmanifestv1.Manifest) ([]byte, error) {
+	data, err := yaml.Marshal(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("marshal manifest YAML: %w", err)
+	}
+	return data, nil
 }
 
 func Kinds(manifest *pluginmanifestv1.Manifest) []string {

--- a/server/internal/provider/build.go
+++ b/server/internal/provider/build.go
@@ -179,9 +179,9 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 		}
 	}
 
-	if len(conn.Params) > 0 {
-		base.ConnectionDefs = make(map[string]core.ConnectionParamDef, len(conn.Params))
-		for name, cpd := range conn.Params {
+	if len(conn.ConnectionParams) > 0 {
+		base.ConnectionDefs = make(map[string]core.ConnectionParamDef, len(conn.ConnectionParams))
+		for name, cpd := range conn.ConnectionParams {
 			base.ConnectionDefs[name] = core.ConnectionParamDef{
 				Required: cpd.Required,
 			}

--- a/server/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/server/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -135,7 +135,7 @@
             }
           }
         },
-        "connection": {
+        "connection_params": {
           "type": "object",
           "additionalProperties": {
             "type": "object",

--- a/server/sdk/pluginmanifest/v1/types.go
+++ b/server/sdk/pluginmanifest/v1/types.go
@@ -10,66 +10,66 @@ const (
 )
 
 type Manifest struct {
-	Source      string         `json:"source,omitempty"`
-	Version     string         `json:"version"`
-	DisplayName string         `json:"display_name,omitempty"`
-	Description string         `json:"description,omitempty"`
-	IconFile    string         `json:"icon_file,omitempty"`
-	Kinds       []string       `json:"kinds"`
-	Provider    *Provider      `json:"provider,omitempty"`
-	WebUI       *WebUIMetadata `json:"webui,omitempty"`
-	Artifacts   []Artifact     `json:"artifacts,omitempty"`
-	Entrypoints Entrypoints    `json:"entrypoints,omitzero"`
+	Source      string         `json:"source,omitempty" yaml:"source,omitempty"`
+	Version     string         `json:"version" yaml:"version"`
+	DisplayName string         `json:"display_name,omitempty" yaml:"display_name,omitempty"`
+	Description string         `json:"description,omitempty" yaml:"description,omitempty"`
+	IconFile    string         `json:"icon_file,omitempty" yaml:"icon_file,omitempty"`
+	Kinds       []string       `json:"kinds" yaml:"kinds"`
+	Provider    *Provider      `json:"provider,omitempty" yaml:"provider,omitempty"`
+	WebUI       *WebUIMetadata `json:"webui,omitempty" yaml:"webui,omitempty"`
+	Artifacts   []Artifact     `json:"artifacts,omitempty" yaml:"artifacts,omitempty"`
+	Entrypoints Entrypoints    `json:"entrypoints,omitzero" yaml:"entrypoints,omitempty"`
 }
 
 type WebUIMetadata struct {
-	AssetRoot string `json:"asset_root"`
+	AssetRoot string `json:"asset_root" yaml:"asset_root"`
 }
 
 type Provider struct {
-	ConfigSchemaPath     string                             `json:"config_schema_path,omitempty"`
-	Auth                 *ProviderAuth                      `json:"auth,omitempty"`
-	MCP                  bool                               `json:"mcp,omitempty"`
-	BaseURL              string                             `json:"base_url,omitempty"`
-	Headers              map[string]string                  `json:"headers,omitempty"`
-	ManagedParameters    []ManagedParameter                 `json:"managed_parameters,omitempty"`
-	Operations           []ProviderOperation                `json:"operations,omitempty"`
-	PostConnectDiscovery *ProviderPostConnectDiscovery      `json:"post_connect_discovery,omitempty"`
-	Connection           map[string]ProviderConnectionParam `json:"connection,omitempty"`
+	ConfigSchemaPath     string                             `json:"config_schema_path,omitempty" yaml:"config_schema_path,omitempty"`
+	Auth                 *ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
+	MCP                  bool                               `json:"mcp,omitempty" yaml:"mcp,omitempty"`
+	BaseURL              string                             `json:"base_url,omitempty" yaml:"base_url,omitempty"`
+	Headers              map[string]string                  `json:"headers,omitempty" yaml:"headers,omitempty"`
+	ManagedParameters    []ManagedParameter                 `json:"managed_parameters,omitempty" yaml:"managed_parameters,omitempty"`
+	Operations           []ProviderOperation                `json:"operations,omitempty" yaml:"operations,omitempty"`
+	PostConnectDiscovery *ProviderPostConnectDiscovery      `json:"post_connect_discovery,omitempty" yaml:"post_connect_discovery,omitempty"`
+	ConnectionParams     map[string]ProviderConnectionParam `json:"connection_params,omitempty" yaml:"connection_params,omitempty"`
 
-	OpenAPI           string                                `json:"openapi,omitempty"`
-	GraphQLURL        string                                `json:"graphql_url,omitempty"`
-	MCPURL            string                                `json:"mcp_url,omitempty"`
-	AllowedOperations map[string]*ManifestOperationOverride `json:"allowed_operations,omitempty"`
-	OpenAPIConnection string                                `json:"openapi_connection,omitempty"`
-	GraphQLConnection string                                `json:"graphql_connection,omitempty"`
-	MCPConnection     string                                `json:"mcp_connection,omitempty"`
-	DefaultConnection string                                `json:"default_connection,omitempty"`
-	Connections       map[string]*ManifestConnectionDef     `json:"connections,omitempty"`
-	ResponseMapping   *ManifestResponseMapping              `json:"response_mapping,omitempty"`
+	OpenAPI           string                                `json:"openapi,omitempty" yaml:"openapi,omitempty"`
+	GraphQLURL        string                                `json:"graphql_url,omitempty" yaml:"graphql_url,omitempty"`
+	MCPURL            string                                `json:"mcp_url,omitempty" yaml:"mcp_url,omitempty"`
+	AllowedOperations map[string]*ManifestOperationOverride `json:"allowed_operations,omitempty" yaml:"allowed_operations,omitempty"`
+	OpenAPIConnection string                                `json:"openapi_connection,omitempty" yaml:"openapi_connection,omitempty"`
+	GraphQLConnection string                                `json:"graphql_connection,omitempty" yaml:"graphql_connection,omitempty"`
+	MCPConnection     string                                `json:"mcp_connection,omitempty" yaml:"mcp_connection,omitempty"`
+	DefaultConnection string                                `json:"default_connection,omitempty" yaml:"default_connection,omitempty"`
+	Connections       map[string]*ManifestConnectionDef     `json:"connections,omitempty" yaml:"connections,omitempty"`
+	ResponseMapping   *ManifestResponseMapping              `json:"response_mapping,omitempty" yaml:"response_mapping,omitempty"`
 }
 
 type ManifestResponseMapping struct {
-	DataPath   string                     `json:"data_path"`
-	Pagination *ManifestPaginationMapping `json:"pagination,omitempty"`
+	DataPath   string                     `json:"data_path" yaml:"data_path"`
+	Pagination *ManifestPaginationMapping `json:"pagination,omitempty" yaml:"pagination,omitempty"`
 }
 
 type ManifestPaginationMapping struct {
-	HasMorePath string `json:"has_more_path"`
-	CursorPath  string `json:"cursor_path"`
+	HasMorePath string `json:"has_more_path" yaml:"has_more_path"`
+	CursorPath  string `json:"cursor_path" yaml:"cursor_path"`
 }
 
 type ProviderPostConnectDiscovery struct {
-	URL             string            `json:"url"`
-	IDPath          string            `json:"id_path,omitempty"`
-	NamePath        string            `json:"name_path,omitempty"`
-	MetadataMapping map[string]string `json:"metadata_mapping,omitempty"`
+	URL             string            `json:"url" yaml:"url"`
+	IDPath          string            `json:"id_path,omitempty" yaml:"id_path,omitempty"`
+	NamePath        string            `json:"name_path,omitempty" yaml:"name_path,omitempty"`
+	MetadataMapping map[string]string `json:"metadata_mapping,omitempty" yaml:"metadata_mapping,omitempty"`
 }
 
 type ProviderConnectionParam struct {
-	Required    bool   `json:"required,omitempty"`
-	Description string `json:"description,omitempty"`
-	From        string `json:"from,omitempty"`
+	Required    bool   `json:"required,omitempty" yaml:"required,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	From        string `json:"from,omitempty" yaml:"from,omitempty"`
 }
 
 func (p *Provider) IsDeclarative() bool {
@@ -93,35 +93,35 @@ func (m *Manifest) IsDeclarativeOnlyProvider() bool {
 }
 
 type ManifestOperationOverride struct {
-	Alias       string `json:"alias,omitempty"`
-	Description string `json:"description,omitempty"`
+	Alias       string `json:"alias,omitempty" yaml:"alias,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 type ManifestConnectionDef struct {
-	Mode string        `json:"mode,omitempty"`
-	Auth *ProviderAuth `json:"auth,omitempty"`
+	Mode string        `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Auth *ProviderAuth `json:"auth,omitempty" yaml:"auth,omitempty"`
 }
 
 type ProviderOperation struct {
-	Name        string              `json:"name"`
-	Description string              `json:"description,omitempty"`
-	Method      string              `json:"method"`
-	Path        string              `json:"path"`
-	Parameters  []ProviderParameter `json:"parameters,omitempty"`
+	Name        string              `json:"name" yaml:"name"`
+	Description string              `json:"description,omitempty" yaml:"description,omitempty"`
+	Method      string              `json:"method" yaml:"method"`
+	Path        string              `json:"path" yaml:"path"`
+	Parameters  []ProviderParameter `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 }
 
 type ProviderParameter struct {
-	Name        string `json:"name"`
-	Type        string `json:"type"`
-	In          string `json:"in"`
-	Description string `json:"description,omitempty"`
-	Required    bool   `json:"required,omitempty"`
+	Name        string `json:"name" yaml:"name"`
+	Type        string `json:"type" yaml:"type"`
+	In          string `json:"in" yaml:"in"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Required    bool   `json:"required,omitempty" yaml:"required,omitempty"`
 }
 
 type ManagedParameter struct {
-	In    string `json:"in"`
-	Name  string `json:"name"`
-	Value string `json:"value"`
+	In    string `json:"in" yaml:"in"`
+	Name  string `json:"name" yaml:"name"`
+	Value string `json:"value" yaml:"value"`
 }
 
 const (
@@ -133,47 +133,47 @@ const (
 )
 
 type ProviderAuth struct {
-	Type                string            `json:"type"`
-	AuthorizationURL    string            `json:"authorization_url,omitempty"`
-	TokenURL            string            `json:"token_url,omitempty"`
-	ClientID            string            `json:"client_id,omitempty"`
-	ClientSecret        string            `json:"client_secret,omitempty"`
-	Scopes              []string          `json:"scopes,omitempty"`
-	PKCE                bool              `json:"pkce,omitempty"`
-	ClientAuth          string            `json:"client_auth,omitempty"`
-	TokenExchange       string            `json:"token_exchange,omitempty"`
-	AccessTokenPath     string            `json:"access_token_path,omitempty"`
-	ScopeParam          string            `json:"scope_param,omitempty"`
-	ScopeSeparator      string            `json:"scope_separator,omitempty"`
-	AuthorizationParams map[string]string `json:"authorization_params,omitempty"`
-	TokenParams         map[string]string `json:"token_params,omitempty"`
-	RefreshParams       map[string]string `json:"refresh_params,omitempty"`
-	AcceptHeader        string            `json:"accept_header,omitempty"`
-	TokenMetadata       []string          `json:"token_metadata,omitempty"`
-	Credentials         []CredentialField `json:"credentials,omitempty"`
+	Type                string            `json:"type" yaml:"type"`
+	AuthorizationURL    string            `json:"authorization_url,omitempty" yaml:"authorization_url,omitempty"`
+	TokenURL            string            `json:"token_url,omitempty" yaml:"token_url,omitempty"`
+	ClientID            string            `json:"client_id,omitempty" yaml:"client_id,omitempty"`
+	ClientSecret        string            `json:"client_secret,omitempty" yaml:"client_secret,omitempty"`
+	Scopes              []string          `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+	PKCE                bool              `json:"pkce,omitempty" yaml:"pkce,omitempty"`
+	ClientAuth          string            `json:"client_auth,omitempty" yaml:"client_auth,omitempty"`
+	TokenExchange       string            `json:"token_exchange,omitempty" yaml:"token_exchange,omitempty"`
+	AccessTokenPath     string            `json:"access_token_path,omitempty" yaml:"access_token_path,omitempty"`
+	ScopeParam          string            `json:"scope_param,omitempty" yaml:"scope_param,omitempty"`
+	ScopeSeparator      string            `json:"scope_separator,omitempty" yaml:"scope_separator,omitempty"`
+	AuthorizationParams map[string]string `json:"authorization_params,omitempty" yaml:"authorization_params,omitempty"`
+	TokenParams         map[string]string `json:"token_params,omitempty" yaml:"token_params,omitempty"`
+	RefreshParams       map[string]string `json:"refresh_params,omitempty" yaml:"refresh_params,omitempty"`
+	AcceptHeader        string            `json:"accept_header,omitempty" yaml:"accept_header,omitempty"`
+	TokenMetadata       []string          `json:"token_metadata,omitempty" yaml:"token_metadata,omitempty"`
+	Credentials         []CredentialField `json:"credentials,omitempty" yaml:"credentials,omitempty"`
 }
 
 type CredentialField struct {
-	Name        string `json:"name"`
-	Label       string `json:"label,omitempty"`
-	Description string `json:"description,omitempty"`
-	HelpURL     string `json:"help_url,omitempty"`
+	Name        string `json:"name" yaml:"name"`
+	Label       string `json:"label,omitempty" yaml:"label,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	HelpURL     string `json:"help_url,omitempty" yaml:"help_url,omitempty"`
 }
 
 type Artifact struct {
-	OS     string `json:"os"`
-	Arch   string `json:"arch"`
-	Path   string `json:"path"`
-	SHA256 string `json:"sha256,omitempty"`
+	OS     string `json:"os" yaml:"os"`
+	Arch   string `json:"arch" yaml:"arch"`
+	Path   string `json:"path" yaml:"path"`
+	SHA256 string `json:"sha256,omitempty" yaml:"sha256,omitempty"`
 }
 
 type Entrypoints struct {
-	Provider *Entrypoint `json:"provider,omitempty"`
+	Provider *Entrypoint `json:"provider,omitempty" yaml:"provider,omitempty"`
 }
 
 type Entrypoint struct {
-	ArtifactPath string   `json:"artifact_path"`
-	Args         []string `json:"args,omitempty"`
+	ArtifactPath string   `json:"artifact_path" yaml:"artifact_path"`
+	Args         []string `json:"args,omitempty" yaml:"args,omitempty"`
 }
 
 //go:embed manifest.jsonschema.json


### PR DESCRIPTION
## Summary
- remove dead or misleading YAML fields instead of accepting aliases
- standardize top-level config and manifest connection parameter names on `connection_params`
- keep named connection config concise with `plugin.connections.<name>.params`
- preserve manifest source format through `gestaltd plugin release`
- keep coverage at the existing CLI / command-test layer and update docs to match the smaller YAML surface

## YAML Interface Changes
- config `plugin.connection` is removed
- config `plugin.params` is removed; use `plugin.connection_params`
- named connections still use `plugin.connections.<name>.params`
- manifest `provider.connection` is removed; use `provider.connection_params`
- `gestaltd plugin release` now preserves the source manifest format, so `plugin.yaml` / `plugin.yml` stay YAML and `plugin.json` stays JSON
- `gestaltd plugin package --input` now accepts a plugin directory or a direct `plugin.json` / `plugin.yaml` / `plugin.yml` path

## Testing
- `cd server && go test ./...`
- `cd server && golangci-lint run`
