### PR TITLE
Redesign provider YAML around connections and surfaces

### DIFF
--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -5,7 +5,7 @@
 - an HTTP API
 - an embedded web UI
 - `/health` and `/ready` endpoints
-- an `/mcp` endpoint when integrations expose tools
+- an `/mcp` endpoint when providers expose tools
 - support for REST, GraphQL, MCP, and packaged plugins
 
 ## Quick reference
@@ -20,8 +20,8 @@
 
 - Default config path: `/etc/gestalt/config.yaml`
 - This image is not zero-config. Mount or bake a config file before starting it.
-- Locked startup is the default. If your config uses `plugin.package`,
-  `plugin.source`, or a packaged UI, run `init` first.
+- Locked startup is the default. If your config uses `providers.*.from.package`,
+  `providers.*.from.source`, or a packaged UI, run `init` first.
 
 ## Supported tags
 
@@ -64,12 +64,12 @@ datastore:
   config:
     path: /data/gestalt.db
 
-integrations: {}
+providers: {}
 ```
 
 ## Run a prepared production image
 
-If your config uses `plugin.package`, `plugin.source`, or a packaged UI,
+If your config uses `providers.*.from.package`, `providers.*.from.source`, or a packaged UI,
 prepare it during the image build:
 
 ```dockerfile

--- a/docs/pages/concepts/authentication-and-tokens.mdx
+++ b/docs/pages/concepts/authentication-and-tokens.mdx
@@ -31,7 +31,7 @@ and `/mcp`.
 
 ## Integration Auth
 
-Integration auth lives inside `integrations.*.plugin`.
+Integration auth lives inside `providers.*.connections`.
 
 Examples:
 

--- a/docs/pages/concepts/configuration.mdx
+++ b/docs/pages/concepts/configuration.mdx
@@ -36,7 +36,7 @@ auth: {}
 datastore: {}
 secrets: {}
 telemetry: {}
-integrations: {}
+providers: {}
 bindings: {}
 server: {}
 egress: {}
@@ -52,7 +52,7 @@ Each block controls a distinct part of the runtime:
 | `datastore` | Where Gestalt stores users, tokens, and related runtime state. |
 | `secrets` | How `secret://...` values are resolved. |
 | `telemetry` | Observability: traces, metrics, and structured logs. |
-| `integrations` | The provider graph users call. |
+| `providers` | The provider graph users call. |
 | `bindings` | Additional inbound surfaces. |
 | `egress` | Outbound allow or deny policy plus credential grants. |
 | `ui` | Optional custom web UI plugin. |
@@ -110,9 +110,9 @@ gestaltd validate --config ./config.yaml
 
 Paths in config are resolved relative to the config file directory, not the process working directory. This matters for:
 
-- `integrations.<name>.icon_file`
-- `plugin.command`
-- local `plugin.package` paths
+- `providers.<name>.icon_file`
+- `providers.<name>.from.command`
+- local `providers.<name>.from.package` paths
 
 That makes configs portable across local runs, Docker mounts, and Kubernetes volumes.
 
@@ -152,7 +152,7 @@ datastore:
   config:
     path: ./gestalt.db
 
-integrations: {}
+providers: {}
 ```
 
 That is enough to boot a real server. Everything else is additive.

--- a/docs/pages/concepts/integrations.mdx
+++ b/docs/pages/concepts/integrations.mdx
@@ -1,22 +1,30 @@
 # Integrations
 
-Every integration becomes a provider. The provider can be built from inline
-YAML, from a packaged plugin, or from a hybrid of both.
+Gestalt still talks about integrations in the API and UI, but config now
+declares them under `providers:`. Each configured provider becomes one runtime
+provider that callers invoke through the shared broker.
 
-## Integration Shape
+## Provider Shape
 
 ```yaml
-integrations:
+providers:
   gmail:
     display_name: Gmail
     description: Read and send Gmail messages
-    mcp_tool_prefix: gmail_
-    plugin:
+    from:
       package: ./dist/gmail-plugin.tar.gz
+    mcp:
+      enabled: true
+      tool_prefix: gmail_
 ```
 
-At the top level, an integration has presentation metadata plus a single
-`plugin` block. That `plugin` block is where the actual behavior lives.
+Each entry can combine:
+
+- an optional `from` block for executable or packaged behavior
+- `connections`
+- one API surface under `surfaces.rest`, `surfaces.openapi`, or `surfaces.graphql`
+- an optional `surfaces.mcp`
+- optional `headers`, `managed_parameters`, `response_mapping`, and `allowed_operations`
 
 ## The Four Main Patterns
 
@@ -29,23 +37,26 @@ At the top level, an integration has presentation metadata plus a single
 
 ## Inline Declarative Providers
 
-Inline declarative providers use `base_url` plus `operations`.
+Inline declarative providers use `surfaces.rest`.
 
 ```yaml
-integrations:
+providers:
   support:
-    plugin:
-      auth:
-        type: bearer
-        credentials:
-          - name: token
-            label: API Token
-      base_url: https://api.support.example.com
-      operations:
-        - name: list_tickets
-          description: Return open support tickets
-          method: GET
-          path: /tickets
+    connections:
+      default:
+        auth:
+          type: bearer
+          credentials:
+            - name: token
+              label: API Token
+    surfaces:
+      rest:
+        base_url: https://api.support.example.com
+        operations:
+          - name: list_tickets
+            description: Return open support tickets
+            method: GET
+            path: /tickets
 ```
 
 This is the simplest path when you already know the exact operations you want.
@@ -56,21 +67,23 @@ Inline spec-backed providers load operations from OpenAPI, GraphQL, or upstream
 MCP.
 
 ```yaml
-integrations:
+providers:
   httpbin:
-    mcp_tool_prefix: httpbin_
-    plugin:
-      openapi: ./openapi/httpbin.yaml
-      openapi_connection: public
-      default_connection: public
-      connections:
-        public:
-          mode: none
-          auth:
-            type: none
-      allowed_operations:
-        get_ip:
-          alias: get_ip
+    connections:
+      public:
+        mode: none
+        auth:
+          type: none
+    surfaces:
+      openapi:
+        document: ./openapi/httpbin.yaml
+        connection: public
+    allowed_operations:
+      get_ip:
+        alias: get_ip
+    mcp:
+      enabled: true
+      tool_prefix: httpbin_
 ```
 
 `allowed_operations` narrows the exposed surface and can rename operations with
@@ -85,98 +98,78 @@ Packaged providers come from one of three sources:
 - `source` plus `version`: resolve a published plugin package during `init`
 
 ```yaml
-integrations:
+providers:
   support:
     display_name: Support
-    plugin:
+    from:
       package: ./dist/support-plugin.tar.gz
 ```
 
-Packaged providers carry their own manifest, auth model, and operation catalog.
-
-If a packaged provider needs named connections, declare them in the plugin
-manifest, not in `config.yaml`.
+Packaged providers carry their own manifests, auth model, and operation
+catalog.
 
 ## Hybrid Providers
 
-A packaged plugin can also layer in spec-backed surfaces.
-
-Assume `./dist/support-plugin.tar.gz` and `./openapi/support.yaml` already
-exist.
+A packaged provider can also layer in spec-backed surfaces.
 
 ```yaml
-integrations:
+providers:
   support:
     display_name: Support
-    mcp_tool_prefix: support_
-    plugin:
+    from:
       package: ./dist/support-plugin.tar.gz
-      openapi: ./openapi/support.yaml
-      openapi_connection: plugin
-      mcp_url: https://mcp.support.example.com/mcp
-      mcp_connection: plugin
-      default_connection: plugin
-      allowed_operations:
-        tickets.list:
-          alias: list_tickets
+    connections:
+      mcp:
+        mode: user
+        auth:
+          type: mcp_oauth
+    surfaces:
+      openapi:
+        document: ./openapi/support.yaml
+      mcp:
+        url: https://mcp.support.example.com/mcp
+        connection: mcp
+    allowed_operations:
+      tickets.list:
+        alias: list_tickets
+    mcp:
+      enabled: true
+      tool_prefix: support_
 ```
 
 This is useful when a plugin provides custom code while the API or MCP surface
 still comes from a spec or upstream server.
 
-## The Implicit Plugin Connection
+## Connections
 
-When you use top-level `plugin.auth` and `plugin.connection_params`, Gestalt creates an
-implicit connection internally. In API responses and UI flows this connection is
-exposed as `plugin`.
-
-```yaml
-plugin:
-  auth:
-    type: oauth2
-    authorization_url: https://accounts.example.com/oauth/authorize
-    token_url: https://accounts.example.com/oauth/token
-    client_id: ${CLIENT_ID}
-    client_secret: ${CLIENT_SECRET}
-  connection_params:
-    tenant:
-      required: true
-```
-
-## Named Connections
-
-Use `plugin.connections` when different inline surfaces need different auth
-flows.
-
-These next blocks are `plugin:` fragments, not complete integration files.
+Gestalt resolves credentials through `connections.default` plus any optional
+named connections.
 
 ```yaml
-plugin:
-  openapi: ./openapi/workspace.yaml
-  mcp_url: https://mcp.example.com/mcp
-  openapi_connection: api
-  mcp_connection: mcp
-  default_connection: api
-  connections:
-    api:
-      mode: user
-      auth:
-        type: oauth2
-        authorization_url: https://accounts.example.com/oauth/authorize
-        token_url: https://accounts.example.com/oauth/token
-        client_id: ${CLIENT_ID}
-        client_secret: ${CLIENT_SECRET}
-      params:
-        tenant:
-          required: true
-    mcp:
-      mode: user
-      auth:
-        type: mcp_oauth
+connections:
+  default:
+    mode: user
+    auth:
+      type: oauth2
+      authorization_url: https://accounts.example.com/oauth/authorize
+      token_url: https://accounts.example.com/oauth/token
+      client_id: ${CLIENT_ID}
+      client_secret: ${CLIENT_SECRET}
+    params:
+      tenant:
+        required: true
+  mcp:
+    mode: user
+    auth:
+      type: mcp_oauth
 ```
 
-The connection names referenced by `openapi_connection`, `graphql_connection`,
-`mcp_connection`, and `default_connection` must exist.
+Rules:
+
+- `connections.default` is the primary connection
+- only `connections.default` may define `params` and `discovery`
+- if you omit `connections.default` and keep only named connections, each
+  configured surface must set `connection`
 
 ### Connection Modes
 
@@ -193,52 +186,68 @@ The connection names referenced by `openapi_connection`, `graphql_connection`,
 before an operation is exposed.
 
 ```yaml
-plugin:
-  openapi: ./openapi/workspace.yaml
-  managed_parameters:
-    - in: header
-      name: X-API-Version
-      value: "2026-04-01"
-    - in: path
-      name: account_id
-      value: primary
+providers:
+  workspace:
+    connections:
+      default:
+        mode: none
+        auth:
+          type: none
+    surfaces:
+      openapi:
+        document: ./openapi/workspace.yaml
+    managed_parameters:
+      - in: header
+        name: X-API-Version
+        value: "2026-04-01"
+      - in: path
+        name: account_id
+        value: primary
 ```
 
-Path managed parameters remove the corresponding user parameter from the exposed
-operation signature.
+Path managed parameters remove the corresponding user parameter from the
+exposed operation signature.
 
 ## Response Mapping
 
-`response_mapping` is available for spec-backed providers when the upstream
-response needs a stable data path or pagination hints.
+`response_mapping` is available for OpenAPI and GraphQL providers when the
+upstream response needs a stable data path or pagination hints.
 
 ```yaml
-plugin:
-  graphql_url: https://api.example.com/graphql
-  auth:
-    type: bearer
-  response_mapping:
-    data_path: data.items
-    pagination:
-      has_more_path: pageInfo.hasNextPage
-      cursor_path: pageInfo.endCursor
+providers:
+  catalog:
+    connections:
+      default:
+        auth:
+          type: bearer
+    surfaces:
+      graphql:
+        url: https://api.example.com/graphql
+    response_mapping:
+      data_path: data.items
+      pagination:
+        has_more_path: pageInfo.hasNextPage
+        cursor_path: pageInfo.endCursor
 ```
 
 ## Tool Naming On `/mcp`
 
-Use `mcp_tool_prefix` on the integration to keep tool names stable and
-collision-free when several integrations expose operations with similar names.
+Use `mcp.tool_prefix` to keep tool names stable and collision-free when
+several providers expose operations with similar names.
 
 ```yaml
-integrations:
+providers:
   slack:
-    mcp_tool_prefix: slack_
+    mcp:
+      enabled: true
+      tool_prefix: slack_
 ```
 
 ## Choosing The Right Pattern
 
 - Start with inline declarative YAML for a tiny REST surface.
-- Use OpenAPI, GraphQL, or `mcp_url` when the upstream already publishes a
+- Use OpenAPI, GraphQL, or `surfaces.mcp` when the upstream already publishes a
   discoverable surface.
-- Use packaged plugins when behavior belongs in code or needs to be versioned.
+- Use packaged providers when behavior belongs in code or needs to be
+  versioned.
 - Use a hybrid provider when you want packaged logic plus spec-backed coverage.

--- a/docs/pages/concepts/mcp-binding.mdx
+++ b/docs/pages/concepts/mcp-binding.mdx
@@ -28,13 +28,15 @@ If a provider supports request-scoped catalogs, Gestalt refreshes those tools at
 
 ## Tool Naming
 
-Tool names come from the provider operation IDs. Use `mcp_tool_prefix` on an
-integration to keep names stable across providers.
+Tool names come from the provider operation IDs. Use `mcp.tool_prefix` on a
+provider to keep names stable across providers.
 
 ```yaml
-integrations:
+providers:
   slack:
-    mcp_tool_prefix: slack_
+    mcp:
+      enabled: true
+      tool_prefix: slack_
 ```
 
 ## Authentication
@@ -64,27 +66,30 @@ integration can use different named connections.
 Assume you already have a local OpenAPI file such as `./openapi/notion.yaml`.
 
 ```yaml
-integrations:
+providers:
   notion:
-    mcp_tool_prefix: notion_
-    plugin:
-      openapi: ./openapi/notion.yaml
-      openapi_connection: REST
-      mcp_url: https://mcp.notion.com/mcp
-      mcp_connection: MCP
-      default_connection: REST
-      connections:
-        REST:
-          mode: user
-          auth:
-            type: bearer
-            credentials:
-              - name: token
-                label: API Token
-        MCP:
-          mode: user
-          auth:
-            type: mcp_oauth
+    mcp:
+      enabled: true
+      tool_prefix: notion_
+    surfaces:
+      openapi:
+        document: ./openapi/notion.yaml
+        connection: REST
+      mcp:
+        url: https://mcp.notion.com/mcp
+        connection: MCP
+    connections:
+      MCP:
+        mode: user
+        auth:
+          type: mcp_oauth
+      REST:
+        mode: user
+        auth:
+          type: bearer
+          credentials:
+            - name: token
+              label: API Token
 ```
 
 With this config:

--- a/docs/pages/concepts/platform-model.mdx
+++ b/docs/pages/concepts/platform-model.mdx
@@ -7,7 +7,7 @@ startup path from configuration to invocation.
 ## The Core Model
 
 At the highest level, `gestaltd` loads a declarative config file, bootstraps the
-platform components that config names, builds providers from integrations, and
+platform components that config names, builds providers from `providers:`, and
 exposes those providers through shared request surfaces.
 
 ## The Main Primitives
@@ -17,7 +17,7 @@ exposes those providers through shared request surfaces.
 | `auth` | Authenticates users to Gestalt itself and issues platform sessions. |
 | `datastore` | Persists users, API tokens, integration tokens, and some egress data. |
 | `secrets` | Resolves `secret://...` references during bootstrap. |
-| `integrations` | Define the provider graph users call. Each integration has one `plugin` block plus optional metadata. |
+| `providers` | Define the provider graph users call. Each named entry is provider-shaped directly. |
 | `bindings` | Extra entry points, such as inbound webhooks or HTTP proxy routes. |
 | `egress` | Policy and credential rules for outbound traffic. |
 
@@ -36,7 +36,7 @@ This is the actual shape of startup:
 9. Resolve `secret://...` references across the rest of the config.
 10. Build the platform auth provider.
 11. Build the datastore.
-12. Build providers from `integrations`.
+12. Build providers from `providers`.
 13. Build the shared invocation broker.
 14. Build bindings.
 15. Start the HTTP server, then start bindings once providers are ready.
@@ -48,7 +48,7 @@ built from it.
 
 That distinction matters:
 
-- you edit `integrations.<name>` in YAML
+- you edit `providers.<name>` in YAML
 - `gestaltd` turns that entry into a provider at startup
 - every request surface invokes the provider, not the raw YAML
 
@@ -56,8 +56,8 @@ Providers come from three sources:
 
 | Source | How it works |
 | --- | --- |
-| Inline declarative provider | Built from `plugin.base_url` plus `plugin.operations`. |
-| Inline spec-backed provider | Built from `plugin.openapi`, `plugin.graphql_url`, or `plugin.mcp_url`. |
+| Inline declarative provider | Built from `surfaces.rest`. |
+| Inline spec-backed provider | Built from `surfaces.openapi`, `surfaces.graphql`, or `surfaces.mcp`. |
 | Packaged provider plugin | Spawned as a separate process and connected over the plugin protocol. |
 
 A packaged plugin can also layer in spec-backed surfaces, which is how hybrid
@@ -65,14 +65,13 @@ providers work.
 
 ## Connection Resolution
 
-Gestalt resolves credentials through either the implicit plugin connection or a
-set of named connections.
+Gestalt resolves credentials through `connections.default` plus any optional
+named connections.
 
-- `plugin.auth` and `plugin.connection_params` define the implicit `plugin` connection
-- `plugin.connections` defines named connections for inline providers
-- packaged providers define their own named connections in the manifest
-- `openapi_connection`, `graphql_connection`, `mcp_connection`, and
-  `default_connection` decide which connection each surface uses
+- `connections.default` is the primary connection
+- `connections.<name>` defines additional named connections
+- only `connections.default` can carry `params` and `discovery`
+- each configured surface chooses its connection explicitly when needed
 
 Each connection has one mode:
 
@@ -117,7 +116,7 @@ Once providers exist, `gestaltd` projects them into several surfaces:
 
 ## What You Actually Program Against
 
-As a Gestalt operator, you compose top-level config blocks, integration
-definitions, plugin definitions, connection definitions, binding definitions,
+As a Gestalt operator, you compose top-level config blocks, provider
+definitions, connection definitions, surface definitions, binding definitions,
 egress rules, and optional plugin manifests and packages. Everything else is a
 consequence of those inputs.

--- a/docs/pages/concepts/plugin-protocol.mdx
+++ b/docs/pages/concepts/plugin-protocol.mdx
@@ -10,7 +10,7 @@ One plugin kind is supported:
 
 | Kind | Purpose |
 | --- | --- |
-| Provider plugin | Adds a provider for `integrations:`. |
+| Provider plugin | Adds a provider for `providers:`. |
 
 ## Startup Model
 
@@ -45,10 +45,10 @@ The SDK's `ProviderStarter` path receives:
 Provider plugin config lives here:
 
 ```yaml
-integrations:
+providers:
   example:
-    plugin:
+    from:
       command: ./provider
-      config:
-        greeting: hello
+    config:
+      greeting: hello
 ```

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -94,20 +94,22 @@ datastore:
   config:
     path: ./gestalt.db
 
-integrations:
+providers:
   httpbin:
     display_name: HTTPBin
     description: Public request and response inspection API
-    mcp_tool_prefix: httpbin_
-    plugin:
-      openapi: ./openapi/httpbin.yaml
-      openapi_connection: public
-      default_connection: public
-      connections:
-        public:
-          mode: none
-          auth:
-            type: none
+    connections:
+      public:
+        mode: none
+        auth:
+          type: none
+    surfaces:
+      openapi:
+        document: ./openapi/httpbin.yaml
+        connection: public
+    mcp:
+      enabled: true
+      tool_prefix: httpbin_
 ```
 
 This is the smallest useful Gestalt config:
@@ -115,7 +117,7 @@ This is the smallest useful Gestalt config:
 - one explicit server block
 - no platform auth
 - SQLite storage
-- one inline OpenAPI integration
+- one inline OpenAPI provider
 
 ## Validate And Start It
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -9,7 +9,7 @@ import { Cards } from 'nextra/components'
 | Piece | What it does |
 | --- | --- |
 | `gestaltd` | The server binary. It loads config, bootstraps plugins, serves the HTTP API, serves the web UI, and mounts `/mcp` when MCP is enabled. |
-| `config.yaml` | The declarative control plane. This is where you define auth, datastore, secrets, integrations, bindings, and egress policy. |
+| `config.yaml` | The declarative control plane. This is where you define auth, datastore, secrets, providers, bindings, and egress policy. |
 | `gestalt.lock.json` and `.gestalt/` | Optional prepared state written by `gestaltd init`. Use it for deterministic startup when you depend on remote OpenAPI, GraphQL, or packaged plugins. |
 | Deploy assets | `server/Dockerfile`, `client/Dockerfile`, and a Helm chart for production deployment paths. |
 
@@ -17,7 +17,7 @@ import { Cards } from 'nextra/components'
 
 ### Configuration
 
-Your YAML file declares the feature sets that make up a Gestalt deployment: platform auth, token storage, secret resolution, integrations, bindings, and egress rules.
+Your YAML file declares the feature sets that make up a Gestalt deployment: platform auth, token storage, secret resolution, providers, bindings, and egress rules.
 
 ### Prepared State
 
@@ -25,7 +25,7 @@ If your config points at remote OpenAPI specs, GraphQL endpoints, or packaged pl
 
 ### Providers And Invocation
 
-Each integration becomes a provider. All request surfaces share the same invocation broker, so token lookup, refresh, connection mode, instance selection, and auditing work the same way everywhere.
+Each configured provider becomes a runtime provider. All request surfaces share the same invocation broker, so token lookup, refresh, connection mode, instance selection, and auditing work the same way everywhere.
 
 ### Surfaces
 

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -9,7 +9,7 @@ auth: {}
 datastore: {}
 secrets: {}
 telemetry: {}
-integrations: {}
+providers: {}
 bindings: {}
 server: {}
 egress: {}
@@ -250,49 +250,66 @@ Disables all telemetry. Instrumentation points remain but produce zero overhead.
 
 Audit records are emitted as structured log entries with `log.type=audit`. Route them to a dedicated audit backend using OTel Collector attribute-based filtering. See [Observability](/concepts/observability) for details.
 
-## `integrations`
+## `providers`
 
-Every integration has one `plugin` block plus optional presentation metadata.
-That `plugin` block can define an inline provider, point at a packaged plugin,
-or combine a packaged plugin with spec-backed surfaces.
+Config uses a top-level `providers:` map. Each provider entry is provider-shaped
+directly: there is no nested `plugin:` block anymore.
 
 ```yaml
-integrations:
+providers:
   github:
     display_name: GitHub
     description: Public GitHub operations
     icon_file: ./icons/github.svg
-    mcp_tool_prefix: github_
-    plugin:
-      openapi: ./openapi/github.yaml
-      openapi_connection: public
-      default_connection: public
-      connections:
-        public:
-          mode: none
-          auth:
-            type: none
-      allowed_operations:
-        repos.get:
-          alias: get_repo
+    connections:
+      public:
+        mode: none
+        auth:
+          type: none
+    surfaces:
+      openapi:
+        document: ./openapi/github.yaml
+        connection: public
+    allowed_operations:
+      repos.get:
+        alias: get_repo
+    mcp:
+      enabled: true
+      tool_prefix: github_
 ```
 
-### Integration fields
+The config key is `providers`, but the HTTP API and client CLI still refer to
+these named entries as integrations.
+
+### Provider fields
 
 | Field | Purpose |
 | --- | --- |
 | `display_name` | UI and API display name override. |
 | `description` | UI and API description override. |
 | `icon_file` | SVG icon path resolved from the config directory. |
-| `mcp_tool_prefix` | Prefix for tools exposed on `/mcp`. |
-| `plugin` | The actual provider definition. Required. |
+| `config` | Provider-specific config passed into packaged providers. |
+| `from` | Optional packaged/executable source. Omit it for fully inline providers. |
+| `connections` | Named connections. `default` is the primary connection entry. |
+| `headers` | Static headers applied to declarative or spec-backed requests. |
+| `managed_parameters` | Fixed header or path values injected before exposure. |
+| `response_mapping` | Data and pagination mapping for OpenAPI or GraphQL providers. |
+| `allowed_operations` | Surface allowlist plus `alias` and `description` overrides. |
+| `surfaces` | Declarative REST, OpenAPI, GraphQL, and MCP surfaces. |
+| `expose` | MCP exposure settings such as tool prefix. |
 
-### `integrations.*.plugin`
+### `providers.*.from`
 
-The same `plugin` block supports inline providers, packaged providers, and
-hybrid providers.
+Use `from` when the provider is backed by an executable or packaged plugin.
 
-#### External plugin source fields
+```yaml
+from:
+  command: ./bin/provider
+  args:
+    - --debug
+  env:
+    LOG_LEVEL: debug
+```
 
 | Field | Purpose |
 | --- | --- |
@@ -301,70 +318,45 @@ hybrid providers.
 | `source` | Resolve a versioned plugin source during `init`. Format: `github.com/<org>/<repo>/<plugin>`. |
 | `version` | Required with `source`. Invalid with `command` or `package`. |
 | `args` | Extra process arguments for `command`. |
-| `env` | Extra environment variables for external plugins. |
-| `config` | Provider-specific config passed into packaged providers. |
+| `env` | Extra environment variables for executable providers. |
 | `allowed_hosts` | Optional network allowlist for sandboxed plugin processes. |
-| `allowed_operations` | Surface allowlist plus `alias` and `description` overrides. |
 
 `command`, `package`, and `source` are mutually exclusive.
 
-#### Inline provider fields
+### Auth shapes inside `connections`
 
-| Field | Purpose |
-| --- | --- |
-| `auth` | Auth definition for the implicit plugin connection. |
-| `connection_params` | Connection parameters for the implicit plugin connection. |
-| `connections` | Named connections for inline integrations. |
-| `openapi` | OpenAPI document URL or local file path. |
-| `graphql_url` | GraphQL endpoint. |
-| `mcp_url` | Upstream MCP endpoint. |
-| `base_url` | Base URL for declarative REST operations. |
-| `headers` | Static headers applied to spec-backed or declarative requests. |
-| `managed_parameters` | Fixed header or path values injected before exposure. |
-| `operations` | Inline declarative REST operations. |
-| `response_mapping` | Data and pagination mapping for spec-backed providers. |
-| `openapi_connection` | Named connection to use for OpenAPI. |
-| `graphql_connection` | Named connection to use for GraphQL. |
-| `mcp_connection` | Named connection to use for upstream MCP. |
-| `default_connection` | Default connection used when the caller does not specify one. |
-| `mcp` | Expose packaged provider operations on `/mcp`. |
-
-Packaged providers can add `openapi`, `graphql_url`, or `mcp_url` in config,
-but inline `plugin.connections` only applies to inline providers. Packaged
-providers define named connections in their manifests.
-
-### Auth shapes inside `plugin`
-
-Top-level `plugin.auth` and named connection auth blocks use the same shape:
+Every connection auth block uses the same shape:
 
 ```yaml
-auth:
-  type: oauth2
-  authorization_url: https://provider.example.com/oauth/authorize
-  token_url: https://provider.example.com/oauth/token
-  client_id: ${CLIENT_ID}
-  client_secret: ${CLIENT_SECRET}
-  client_auth: body
-  token_exchange: form
-  scopes:
-    - read
-    - write
-  scope_param: user_scope
-  scope_separator: ","
-  pkce: true
-  authorization_params:
-    audience: https://api.example.com
-  token_params:
-    resource: api
-  refresh_params: {}
-  accept_header: application/json
-  token_metadata:
-    - workspace_id
+connections:
+  default:
+    auth:
+      type: oauth2
+      authorization_url: https://provider.example.com/oauth/authorize
+      token_url: https://provider.example.com/oauth/token
+      client_id: ${CLIENT_ID}
+      client_secret: ${CLIENT_SECRET}
+      client_auth: body
+      token_exchange: form
+      scopes:
+        - read
+        - write
+      scope_param: user_scope
+      scope_separator: ","
+      pkce: true
+      authorization_params:
+        audience: https://api.example.com
+      token_params:
+        resource: api
+      refresh_params: {}
+      accept_header: application/json
+      token_metadata:
+        - workspace_id
 ```
 
 | Field | Purpose |
 | --- | --- |
-| `type` | `oauth2`, `manual`, or `mcp_oauth`. |
+| `type` | `oauth2`, `manual`, `bearer`, `none`, or `mcp_oauth`. |
 | `authorization_url` | OAuth authorization endpoint. |
 | `token_url` | OAuth token endpoint. |
 | `client_id`, `client_secret` | OAuth client credentials. |
@@ -393,33 +385,35 @@ optional label, description, and help URL.
 Single credential with a custom label:
 
 ```yaml
-plugin:
-  auth:
-    type: manual
-    credentials:
-      - name: token
-        label: API Access Token
-        help_url: https://app.example.com/settings/tokens
+connections:
+  default:
+    auth:
+      type: manual
+      credentials:
+        - name: token
+          label: API Access Token
+          help_url: https://app.example.com/settings/tokens
 ```
 
 Multiple credentials require `auth_mapping` to map each field to an HTTP
 header:
 
 ```yaml
-plugin:
-  auth:
-    type: manual
-    credentials:
-      - name: api_key
-        label: API Key
-        help_url: https://us5.datadoghq.com/organization-settings/api-keys
-      - name: app_key
-        label: Application Key
-        help_url: https://us5.datadoghq.com/organization-settings/application-keys
-    auth_mapping:
-      headers:
-        DD-API-KEY: api_key
-        DD-APPLICATION-KEY: app_key
+connections:
+  default:
+    auth:
+      type: manual
+      credentials:
+        - name: api_key
+          label: API Key
+          help_url: https://us5.datadoghq.com/organization-settings/api-keys
+        - name: app_key
+          label: Application Key
+          help_url: https://us5.datadoghq.com/organization-settings/application-keys
+      auth_mapping:
+        headers:
+          DD-API-KEY: api_key
+          DD-APPLICATION-KEY: app_key
 ```
 
 | Field | Notes |
@@ -432,32 +426,32 @@ plugin:
 
 `credentials` is required when `auth.type` is `manual`.
 
-### Named connections
+### `connections`
 
 ```yaml
-plugin:
-  openapi: https://api.example.com/openapi.json
-  mcp_url: https://mcp.example.com/mcp
-  openapi_connection: api
-  mcp_connection: mcp
-  default_connection: api
-  connections:
-    api:
-      mode: user
-      auth:
-        type: oauth2
-        authorization_url: https://accounts.example.com/oauth/authorize
-        token_url: https://accounts.example.com/oauth/token
-        client_id: ${CLIENT_ID}
-        client_secret: ${CLIENT_SECRET}
-      params:
-        tenant:
-          required: true
-    mcp:
-      mode: user
-      auth:
-        type: mcp_oauth
+connections:
+  default:
+    mode: user
+    auth:
+      type: oauth2
+      authorization_url: https://accounts.example.com/oauth/authorize
+      token_url: https://accounts.example.com/oauth/token
+      client_id: ${CLIENT_ID}
+      client_secret: ${CLIENT_SECRET}
+    params:
+      tenant:
+        required: true
+        description: Tenant identifier
+  mcp:
+    mode: user
+    auth:
+      type: mcp_oauth
 ```
+
+Only `connections.default` may define:
+
+- `params`
+- `discovery`
 
 Connection modes:
 
@@ -466,26 +460,53 @@ Connection modes:
 - `identity`
 - `either`
 
-### Declarative operations
+If you omit `connections.default` and use only named connections, every
+configured surface must set its own `connection`.
+
+#### Post-connect discovery
 
 ```yaml
-plugin:
-  auth:
-    type: bearer
-    credentials:
-      - name: token
-        label: API Token
-  base_url: https://api.support.example.com
-  operations:
-    - name: list_tickets
-      method: GET
-      path: /tickets
-    - name: get_ticket
-      method: GET
-      path: /tickets/{ticket_id}
+connections:
+  default:
+    mode: user
+    auth:
+      type: oauth2
+      authorization_url: https://accounts.example.com/oauth/authorize
+      token_url: https://accounts.example.com/oauth/token
+    params:
+      workspace_id:
+        required: true
+        description: Workspace chosen after connect
+        from: discovery
+    discovery:
+      url: https://api.example.com/workspaces
+      id_path: id
+      name_path: name
+      metadata:
+        workspace_id: id
 ```
 
-Each operation accepts:
+### `surfaces`
+
+`surfaces.rest`, `surfaces.openapi`, and `surfaces.graphql` are mutually
+exclusive. `surfaces.mcp` can be added alongside any of them.
+
+#### Declarative REST
+
+```yaml
+surfaces:
+  rest:
+    base_url: https://api.support.example.com
+    operations:
+      - name: list_tickets
+        method: GET
+        path: /tickets
+      - name: get_ticket
+        method: GET
+        path: /tickets/{ticket_id}
+```
+
+Each declarative operation accepts:
 
 - `name`
 - `description`
@@ -495,25 +516,46 @@ Each operation accepts:
 
 Parameter locations can be `query`, `body`, or `path`.
 
+#### OpenAPI, GraphQL, and MCP
+
+```yaml
+surfaces:
+  openapi:
+    document: ./openapi/workspace.yaml
+    connection: default
+  mcp:
+    url: https://mcp.example.com/mcp
+    connection: mcp
+```
+
+| Surface field | Purpose |
+| --- | --- |
+| `surfaces.rest.base_url` | Base URL for declarative REST operations. |
+| `surfaces.rest.operations` | Inline declarative REST operations. |
+| `surfaces.openapi.document` | OpenAPI document URL or local file path. |
+| `surfaces.openapi.base_url` | Optional runtime base URL override for OpenAPI. |
+| `surfaces.graphql.url` | GraphQL endpoint URL. |
+| `surfaces.mcp.url` | Upstream MCP endpoint URL. |
+| `surfaces.*.connection` | Connection name for that surface. |
+
 ### Managed parameters
 
 ```yaml
-plugin:
-  openapi: https://api.example.com/openapi.json
-  openapi_connection: public
-  default_connection: public
-  connections:
-    public:
-      mode: none
-      auth:
-        type: none
-  managed_parameters:
-    - in: header
-      name: X-API-Version
-      value: "2026-04-01"
-    - in: path
-      name: account_id
-      value: primary
+connections:
+  default:
+    mode: none
+    auth:
+      type: none
+surfaces:
+  openapi:
+    document: https://api.example.com/openapi.json
+managed_parameters:
+  - in: header
+    name: X-API-Version
+    value: "2026-04-01"
+  - in: path
+    name: account_id
+    value: primary
 ```
 
 Managed parameter locations can be `header` or `path`.
@@ -521,18 +563,29 @@ Managed parameter locations can be `header` or `path`.
 ### Response mapping
 
 ```yaml
-plugin:
-  graphql_url: https://api.example.com/graphql
-  auth:
-    type: bearer
-    credentials:
-      - name: token
-        label: API Token
-  response_mapping:
-    data_path: data.items
-    pagination:
-      has_more_path: pageInfo.hasNextPage
-      cursor_path: pageInfo.endCursor
+connections:
+  default:
+    auth:
+      type: bearer
+      credentials:
+        - name: token
+          label: API Token
+surfaces:
+  graphql:
+    url: https://api.example.com/graphql
+response_mapping:
+  data_path: data.items
+  pagination:
+    has_more_path: pageInfo.hasNextPage
+    cursor_path: pageInfo.endCursor
+```
+
+### `mcp`
+
+```yaml
+mcp:
+  enabled: true
+  tool_prefix: github_
 ```
 
 ## `bindings`
@@ -668,15 +721,15 @@ Structural validation runs at config load time (`init`, `validate`, `serve`). Ru
 
 ### Structural
 
-- Every integration requires a `plugin` block
-- Exactly one of `command`, `package`, or `source` per plugin
-- `plugin.version` is required with `source` and invalid with `command` or `package`
-- `plugin.args` are only valid with `command`
+- Provider entries are decoded directly; there is no nested `plugin` block
+- Exactly one of `from.command`, `from.package`, or `from.source` per packaged provider
+- `from.version` is required with `from.source` and invalid with `from.command` or `from.package`
+- `from.args` are only valid with `from.command`
 - Plain `http://` package URLs are rejected
-- External plugins cannot use inline `operations`
-- External plugins cannot use inline `connections`; named connections belong in the plugin manifest
-- All connections in an integration must share the same mode
-- `openapi_connection`, `graphql_connection`, `mcp_connection`, and `default_connection` must reference a declared connection when named connections are used
+- `surfaces.rest`, `surfaces.openapi`, and `surfaces.graphql` are mutually exclusive
+- Only `connections.default` may define `params` or `discovery`
+- All connections in a provider must share the same mode
+- `surfaces.*.connection` must reference a declared connection when present
 - URL templates in spec surfaces and auth URLs must reference required params
 - `egress.default_action` and policy `action` must be `allow` or `deny`
 - `ui.plugin` requires exactly one of `package` or `source`

--- a/docs/pages/reference/plugin-manifests.mdx
+++ b/docs/pages/reference/plugin-manifests.mdx
@@ -8,17 +8,12 @@ Gestalt plugin packages are described by a manifest file named one of:
 
 YAML is the easiest format to author by hand.
 
-## Manifest Kinds
+## Top-Level Shape
 
-Supported manifest kinds are:
+A manifest can define exactly one of:
 
 - `provider`
 - `webui`
-
-A package can contain:
-
-- a provider only
-- a UI bundle only
 
 ## Common Fields
 
@@ -29,11 +24,9 @@ A package can contain:
 | `display_name` | Human-readable label. |
 | `description` | Human-readable description. |
 | `icon_file` | Relative path to an SVG icon bundled with the package. |
-| `kinds` | The plugin kinds contained in the package. |
 | `provider` | Provider metadata and optional declarative surfaces. |
-| `webui` | UI metadata for `webui` packages. |
+| `webui` | UI metadata for UI-only packages. |
 | `artifacts` | Packaged executable artifacts keyed by platform. |
-| `entrypoints` | Which packaged executable should be started for the provider. |
 
 ## Basic YAML Manifest
 
@@ -45,24 +38,26 @@ version: 0.1.0
 display_name: Support API
 description: Small ticket API
 icon_file: assets/icon.svg
-kinds:
-  - provider
 provider:
-  base_url: https://api.support.example.com
-  auth:
-    type: bearer
-    credentials:
-      - name: token
-        label: API Token
-  operations:
-    - name: list_tickets
-      description: Return open tickets
-      method: GET
-      path: /tickets
-    - name: get_ticket
-      description: Return one ticket
-      method: GET
-      path: /tickets/{ticket_id}
+  connections:
+    default:
+      auth:
+        type: bearer
+        credentials:
+          - name: token
+            label: API Token
+  surfaces:
+    rest:
+      base_url: https://api.support.example.com
+      operations:
+        - name: list_tickets
+          description: Return open tickets
+          method: GET
+          path: /tickets
+        - name: get_ticket
+          description: Return one ticket
+          method: GET
+          path: /tickets/{ticket_id}
 ```
 
 Use this style when:
@@ -76,10 +71,11 @@ Use this style when:
 This example shows a provider package with:
 
 - a config schema
+- an executable entrypoint
 - OpenAPI and upstream MCP surfaces
-- multiple named connections
 - managed parameters
 - allowed operation aliases
+- multiple connections
 
 ```yaml
 source: github.com/acme/plugins/support
@@ -87,15 +83,10 @@ version: 1.2.3
 display_name: Support
 description: Tickets, knowledge base, and MCP workspace tools
 icon_file: assets/icon.svg
-kinds:
-  - provider
 provider:
   config_schema_path: schemas/config.schema.json
-  openapi: openapi.yaml
-  mcp_url: https://mcp.support.example.com/mcp
-  openapi_connection: api
-  mcp_connection: mcp
-  default_connection: api
+  exec:
+    artifact_path: artifacts/linux/amd64/provider
   headers:
     X-App-Version: "2026-04-01"
   managed_parameters:
@@ -103,7 +94,7 @@ provider:
       name: workspace_id
       value: primary
   connections:
-    api:
+    default:
       mode: user
       auth:
         type: oauth2
@@ -114,26 +105,47 @@ provider:
         scopes:
           - tickets.read
           - tickets.write
+      params:
+        workspace_id:
+          required: true
+          from: discovery
+      discovery:
+        url: https://api.support.example.com/workspaces
+        id_path: id
+        name_path: name
+        metadata:
+          workspace_id: id
     mcp:
       mode: user
       auth:
         type: mcp_oauth
+  surfaces:
+    openapi:
+      document: openapi.yaml
+    mcp:
+      url: https://mcp.support.example.com/mcp
+      connection: mcp
   allowed_operations:
     tickets.list:
       alias: list_tickets
     tickets.get:
       alias: get_ticket
+artifacts:
+  - os: linux
+    arch: amd64
+    path: artifacts/linux/amd64/provider
+    sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 ```
 
 Use this style when:
 
 - the provider includes executable logic
-- a reusable package should ship its own auth and connection model
+- a reusable package should ship its own connection model
 - you want packaged custom code plus spec-backed operations
 
 ## Post-Connect Discovery
 
-Declarative providers can define `provider.post_connect_discovery` to perform one
+Providers can define `provider.connections.default.discovery` to perform one
 extra authenticated lookup immediately after OAuth or manual connect succeeds.
 Gestalt calls the configured URL with the freshly acquired access token, parses
 the returned items, and turns them into candidate connections.
@@ -144,22 +156,23 @@ workspace.
 
 ```yaml
 provider:
-  auth:
-    type: oauth2
-    authorization_url: https://auth.example.com/authorize
-    token_url: https://auth.example.com/token
-  post_connect_discovery:
-    url: https://api.example.com/me/workspaces
-    items_path: data
-    id_path: id
-    name_path: display_name
-    metadata_mapping:
-      workspace_id: id
-  connection:
-    workspace_id:
-      required: true
-      description: Workspace identifier discovered after connect
-      from: discovery
+  connections:
+    default:
+      auth:
+        type: oauth2
+        authorization_url: https://auth.example.com/authorize
+        token_url: https://auth.example.com/token
+      params:
+        workspace_id:
+          required: true
+          description: Workspace identifier discovered after connect
+          from: discovery
+      discovery:
+        url: https://api.example.com/me/workspaces
+        id_path: id
+        name_path: display_name
+        metadata:
+          workspace_id: id
 ```
 
 Behavior:
@@ -169,29 +182,8 @@ Behavior:
 - if discovery returns multiple items, Gestalt asks the user to choose one
 - if discovery returns zero items, connect fails
 
-`metadata_mapping` populates connection metadata, and connection fields marked
+`metadata` populates connection metadata, and connection fields marked
 with `from: discovery` are satisfied from that metadata instead of user input.
-
-## Runtime Manifest Example
-
-```yaml
-source: github.com/acme/plugins/notifier-runtime
-version: 0.4.0
-display_name: Notifier Runtime
-kinds:
-  - runtime
-artifacts:
-  - os: linux
-    arch: amd64
-    path: artifacts/linux/amd64/runtime
-    sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-entrypoints:
-  runtime:
-    artifact_path: artifacts/linux/amd64/runtime
-```
-
-If you include `schemas/config.schema.json` in the package root, Gestalt uses it
-to validate `runtimes.*.config`.
 
 ## Web UI Manifest Example
 
@@ -199,8 +191,6 @@ to validate `runtimes.*.config`.
 source: github.com/acme/plugins/gestalt-ui
 version: 1.0.0
 display_name: Custom UI
-kinds:
-  - webui
 webui:
   asset_root: ui/out
 ```
@@ -209,12 +199,12 @@ webui:
 
 - Manifest paths must stay inside the package.
 - `source` and `version` are required.
-- Declarative-only provider packages do not require `artifacts` or
-  `entrypoints`.
-- Executable provider packages do require `artifacts` plus
-  `entrypoints.provider`.
-- `config_schema_path` validates `integrations.*.plugin.config`.
-- Connection parameters discovered after auth live under `provider.connection_params`.
+- A manifest defines either `provider` or `webui`, not both.
+- Declarative-only provider packages do not require `artifacts`.
+- Executable provider packages do require `artifacts` plus `provider.exec.artifact_path`.
+- `config_schema_path` validates `providers.*.config`.
+- Only `provider.connections.default` may define `params` and `discovery`.
+- `provider.surfaces.rest`, `provider.surfaces.openapi`, and `provider.surfaces.graphql` are mutually exclusive. `provider.surfaces.mcp` may be added alongside any of them.
 
 ## Packaging And Release
 

--- a/docs/pages/tasks/add-an-integration.mdx
+++ b/docs/pages/tasks/add-an-integration.mdx
@@ -30,24 +30,26 @@ Use this when the upstream already publishes a spec.
 Assume you already have a local OpenAPI file such as `./openapi/httpbin.yaml`.
 
 ```yaml
-integrations:
+providers:
   httpbin:
     display_name: HTTPBin
-    mcp_tool_prefix: httpbin_
-    plugin:
-      openapi: ./openapi/httpbin.yaml
-      openapi_connection: public
-      default_connection: public
-      connections:
-        public:
-          mode: none
-          auth:
-            type: none
-      allowed_operations:
-        get_ip:
-          alias: get_ip
-        get_headers:
-          alias: get_headers
+    mcp:
+      enabled: true
+      tool_prefix: httpbin_
+    connections:
+      public:
+        mode: none
+        auth:
+          type: none
+    surfaces:
+      openapi:
+        document: ./openapi/httpbin.yaml
+        connection: public
+    allowed_operations:
+      get_ip:
+        alias: get_ip
+      get_headers:
+        alias: get_headers
 ```
 
 ## Packaged Plugin
@@ -55,10 +57,10 @@ integrations:
 Use this when the logic belongs in code or should be versioned independently.
 
 ```yaml
-integrations:
+providers:
   support:
     display_name: Support
-    plugin:
+    from:
       package: ./dist/support-plugin.tar.gz
 ```
 
@@ -77,20 +79,24 @@ Assume you already have a local package such as `./dist/support-plugin.tar.gz`
 and a local OpenAPI file such as `./openapi/support.yaml`.
 
 ```yaml
-integrations:
+providers:
   support:
     display_name: Support
-    mcp_tool_prefix: support_
-    plugin:
+    mcp:
+      enabled: true
+      tool_prefix: support_
+    from:
       package: ./dist/support-plugin.tar.gz
-      openapi: ./openapi/support.yaml
-      openapi_connection: plugin
-      mcp_url: https://mcp.support.example.com/mcp
-      mcp_connection: plugin
-      default_connection: plugin
-      allowed_operations:
-        tickets.list:
-          alias: list_tickets
+    surfaces:
+      openapi:
+        document: ./openapi/support.yaml
+        connection: default
+      mcp:
+        url: https://mcp.support.example.com/mcp
+        connection: default
+    allowed_operations:
+      tickets.list:
+        alias: list_tickets
 ```
 
 ## Named Connections

--- a/docs/pages/tasks/use-with-mcp.mdx
+++ b/docs/pages/tasks/use-with-mcp.mdx
@@ -23,18 +23,20 @@ paths:
 ```
 
 ```yaml
-integrations:
+providers:
   httpbin:
-    mcp_tool_prefix: httpbin_
-    plugin:
-      openapi: ./openapi/httpbin.yaml
-      openapi_connection: public
-      default_connection: public
-      connections:
-        public:
-          mode: none
-          auth:
-            type: none
+    mcp:
+      enabled: true
+      tool_prefix: httpbin_
+    connections:
+      public:
+        mode: none
+        auth:
+          type: none
+    surfaces:
+      openapi:
+        document: ./openapi/httpbin.yaml
+        connection: public
 ```
 
 Start the server and `/mcp` is mounted automatically.
@@ -44,27 +46,30 @@ Start the server and `/mcp` is mounted automatically.
 Assume you already have a local OpenAPI file such as `./openapi/notion.yaml`.
 
 ```yaml
-integrations:
+providers:
   notion:
-    mcp_tool_prefix: notion_
-    plugin:
-      openapi: ./openapi/notion.yaml
-      openapi_connection: REST
-      mcp_url: https://mcp.notion.com/mcp
-      mcp_connection: MCP
-      default_connection: REST
-      connections:
-        REST:
-          mode: user
-          auth:
-            type: bearer
-            credentials:
-              - name: token
-                label: API Token
-        MCP:
-          mode: user
-          auth:
-            type: mcp_oauth
+    mcp:
+      enabled: true
+      tool_prefix: notion_
+    connections:
+      REST:
+        mode: user
+        auth:
+          type: bearer
+          credentials:
+            - name: token
+              label: API Token
+      MCP:
+        mode: user
+        auth:
+          type: mcp_oauth
+    surfaces:
+      openapi:
+        document: ./openapi/notion.yaml
+        connection: REST
+      mcp:
+        url: https://mcp.notion.com/mcp
+        connection: MCP
 ```
 
 This gives you:

--- a/plugins/ashby/plugin.yaml
+++ b/plugins/ashby/plugin.yaml
@@ -3,12 +3,12 @@ version: 0.0.1-alpha.5
 display_name: Ashby
 description: Candidates, applications, jobs, offers, interviews, departments, locations, and users.
 icon_file: assets/icon.svg
-kinds:
-  - provider
 provider:
-  openapi: openapi.yaml
   response_mapping:
     data_path: results
     pagination:
       has_more_path: moreDataAvailable
       cursor_path: nextCursor
+  surfaces:
+    openapi:
+      document: openapi.yaml

--- a/plugins/bigquery/plugin.yaml
+++ b/plugins/bigquery/plugin.yaml
@@ -3,91 +3,93 @@ version: 0.0.1-alpha.2
 display_name: BigQuery
 description: Google BigQuery data warehouse
 icon_file: assets/icon.svg
-kinds:
-  - provider
 provider:
-  base_url: "https://bigquery.googleapis.com/bigquery/v2"
-  auth:
-    type: oauth2
-    authorization_url: https://accounts.google.com/o/oauth2/v2/auth
-    token_url: https://oauth2.googleapis.com/token
-    scopes:
-      - https://www.googleapis.com/auth/bigquery
-    authorization_params:
-      access_type: offline
-      prompt: consent
-  operations:
-    - name: list_datasets
-      description: List datasets in a project
-      method: GET
-      path: "/projects/{project_id}/datasets"
-      parameters:
-        - name: project_id
-          type: string
-          in: path
-          required: true
-        - name: maxResults
-          type: int
-          in: query
-    - name: get_dataset
-      description: Get dataset metadata
-      method: GET
-      path: "/projects/{project_id}/datasets/{dataset_id}"
-      parameters:
-        - name: project_id
-          type: string
-          in: path
-          required: true
-        - name: dataset_id
-          type: string
-          in: path
-          required: true
-    - name: list_tables
-      description: List tables in a dataset
-      method: GET
-      path: "/projects/{project_id}/datasets/{dataset_id}/tables"
-      parameters:
-        - name: project_id
-          type: string
-          in: path
-          required: true
-        - name: dataset_id
-          type: string
-          in: path
-          required: true
-        - name: maxResults
-          type: int
-          in: query
-    - name: get_table
-      description: Get table metadata
-      method: GET
-      path: "/projects/{project_id}/datasets/{dataset_id}/tables/{table_id}"
-      parameters:
-        - name: project_id
-          type: string
-          in: path
-          required: true
-        - name: dataset_id
-          type: string
-          in: path
-          required: true
-        - name: table_id
-          type: string
-          in: path
-          required: true
-    - name: list_routines
-      description: List routines in a dataset
-      method: GET
-      path: "/projects/{project_id}/datasets/{dataset_id}/routines"
-      parameters:
-        - name: project_id
-          type: string
-          in: path
-          required: true
-        - name: dataset_id
-          type: string
-          in: path
-          required: true
-        - name: maxResults
-          type: int
-          in: query
+  connections:
+    default:
+      auth:
+        type: oauth2
+        authorization_url: https://accounts.google.com/o/oauth2/v2/auth
+        token_url: https://oauth2.googleapis.com/token
+        scopes:
+          - https://www.googleapis.com/auth/bigquery
+        authorization_params:
+          access_type: offline
+          prompt: consent
+  surfaces:
+    rest:
+      base_url: "https://bigquery.googleapis.com/bigquery/v2"
+      operations:
+        - name: list_datasets
+          description: List datasets in a project
+          method: GET
+          path: "/projects/{project_id}/datasets"
+          parameters:
+            - name: project_id
+              type: string
+              in: path
+              required: true
+            - name: maxResults
+              type: int
+              in: query
+        - name: get_dataset
+          description: Get dataset metadata
+          method: GET
+          path: "/projects/{project_id}/datasets/{dataset_id}"
+          parameters:
+            - name: project_id
+              type: string
+              in: path
+              required: true
+            - name: dataset_id
+              type: string
+              in: path
+              required: true
+        - name: list_tables
+          description: List tables in a dataset
+          method: GET
+          path: "/projects/{project_id}/datasets/{dataset_id}/tables"
+          parameters:
+            - name: project_id
+              type: string
+              in: path
+              required: true
+            - name: dataset_id
+              type: string
+              in: path
+              required: true
+            - name: maxResults
+              type: int
+              in: query
+        - name: get_table
+          description: Get table metadata
+          method: GET
+          path: "/projects/{project_id}/datasets/{dataset_id}/tables/{table_id}"
+          parameters:
+            - name: project_id
+              type: string
+              in: path
+              required: true
+            - name: dataset_id
+              type: string
+              in: path
+              required: true
+            - name: table_id
+              type: string
+              in: path
+              required: true
+        - name: list_routines
+          description: List routines in a dataset
+          method: GET
+          path: "/projects/{project_id}/datasets/{dataset_id}/routines"
+          parameters:
+            - name: project_id
+              type: string
+              in: path
+              required: true
+            - name: dataset_id
+              type: string
+              in: path
+              required: true
+            - name: maxResults
+              type: int
+              in: query

--- a/plugins/datadog/plugin.yaml
+++ b/plugins/datadog/plugin.yaml
@@ -3,7 +3,7 @@ version: 0.0.1-alpha.5
 display_name: Datadog
 description: Manage dashboards, monitors, incidents, logs, and RUM.
 icon_file: assets/icon.svg
-kinds:
-  - provider
 provider:
-  openapi: openapi.yaml
+  surfaces:
+    openapi:
+      document: openapi.yaml

--- a/plugins/extend/plugin.yaml
+++ b/plugins/extend/plugin.yaml
@@ -3,9 +3,9 @@ version: 0.0.1-alpha.3
 display_name: Extend
 description: Document processing and extraction with Extend.
 icon_file: assets/icon.svg
-kinds:
-  - provider
 provider:
-  openapi: openapi.yaml
   headers:
     x-extend-api-version: "2026-02-09"
+  surfaces:
+    openapi:
+      document: openapi.yaml

--- a/plugins/gitlab/plugin.yaml
+++ b/plugins/gitlab/plugin.yaml
@@ -3,7 +3,7 @@ version: 0.0.1-alpha.3
 display_name: GitLab
 description: Repository, issue, merge request, and pipeline operations.
 icon_file: assets/icon.svg
-kinds:
-  - provider
 provider:
-  openapi: openapi.yaml
+  surfaces:
+    openapi:
+      document: openapi.yaml

--- a/plugins/gmail/plugin.yaml
+++ b/plugins/gmail/plugin.yaml
@@ -3,21 +3,20 @@ version: 0.0.1-alpha.4
 display_name: Gmail
 description: Read, send, and manage Gmail messages, threads, drafts, and labels.
 icon_file: assets/icon.svg
-kinds:
-  - provider
 provider:
   config_schema_path: schemas/config.schema.json
-  auth:
-    type: oauth2
-    authorization_url: https://accounts.google.com/o/oauth2/v2/auth
-    token_url: https://oauth2.googleapis.com/token
-    scopes:
-      - https://www.googleapis.com/auth/gmail.modify
-      - https://www.googleapis.com/auth/gmail.compose
-    authorization_params:
-      access_type: offline
-      prompt: consent
-  openapi: https://api.apis.guru/v2/specs/googleapis.com/gmail/v1/openapi.json
+  connections:
+    default:
+      auth:
+        type: oauth2
+        authorization_url: https://accounts.google.com/o/oauth2/v2/auth
+        token_url: https://oauth2.googleapis.com/token
+        scopes:
+          - https://www.googleapis.com/auth/gmail.modify
+          - https://www.googleapis.com/auth/gmail.compose
+        authorization_params:
+          access_type: offline
+          prompt: consent
   managed_parameters:
     - in: path
       name: userId
@@ -39,3 +38,6 @@ provider:
       alias: threads.get
     gmail.users.getProfile:
       alias: getProfile
+  surfaces:
+    openapi:
+      document: https://api.apis.guru/v2/specs/googleapis.com/gmail/v1/openapi.json

--- a/plugins/google_calendar/plugin.yaml
+++ b/plugins/google_calendar/plugin.yaml
@@ -3,20 +3,19 @@ version: 0.0.1-alpha.1
 display_name: Google Calendar
 description: Read and manage Google calendars and events.
 icon_file: assets/icon.svg
-kinds:
-  - provider
 provider:
   config_schema_path: schemas/config.schema.json
-  auth:
-    type: oauth2
-    authorization_url: https://accounts.google.com/o/oauth2/v2/auth
-    token_url: https://oauth2.googleapis.com/token
-    scopes:
-      - https://www.googleapis.com/auth/calendar
-    authorization_params:
-      access_type: offline
-      prompt: consent
-  openapi: https://api.apis.guru/v2/specs/googleapis.com/calendar/v3/openapi.json
+  connections:
+    default:
+      auth:
+        type: oauth2
+        authorization_url: https://accounts.google.com/o/oauth2/v2/auth
+        token_url: https://oauth2.googleapis.com/token
+        scopes:
+          - https://www.googleapis.com/auth/calendar
+        authorization_params:
+          access_type: offline
+          prompt: consent
   allowed_operations:
     calendar.calendarList.list:
       alias: calendarList.list
@@ -34,3 +33,6 @@ provider:
       alias: events.delete
     calendar.events.quickAdd:
       alias: events.quickAdd
+  surfaces:
+    openapi:
+      document: https://api.apis.guru/v2/specs/googleapis.com/calendar/v3/openapi.json

--- a/plugins/google_docs/plugin.yaml
+++ b/plugins/google_docs/plugin.yaml
@@ -3,20 +3,19 @@ version: 0.0.1-alpha.1
 display_name: Google Docs
 description: Read, create, and edit Google Docs documents.
 icon_file: assets/icon.svg
-kinds:
-  - provider
 provider:
   config_schema_path: schemas/config.schema.json
-  auth:
-    type: oauth2
-    authorization_url: https://accounts.google.com/o/oauth2/v2/auth
-    token_url: https://oauth2.googleapis.com/token
-    scopes:
-      - https://www.googleapis.com/auth/documents
-    authorization_params:
-      access_type: offline
-      prompt: consent
-  openapi: https://api.apis.guru/v2/specs/googleapis.com/docs/v1/openapi.json
+  connections:
+    default:
+      auth:
+        type: oauth2
+        authorization_url: https://accounts.google.com/o/oauth2/v2/auth
+        token_url: https://oauth2.googleapis.com/token
+        scopes:
+          - https://www.googleapis.com/auth/documents
+        authorization_params:
+          access_type: offline
+          prompt: consent
   allowed_operations:
     docs.documents.get:
       alias: get
@@ -24,3 +23,6 @@ provider:
       alias: create
     docs.documents.batchUpdate:
       alias: batchUpdate
+  surfaces:
+    openapi:
+      document: https://api.apis.guru/v2/specs/googleapis.com/docs/v1/openapi.json

--- a/plugins/google_drive/plugin.yaml
+++ b/plugins/google_drive/plugin.yaml
@@ -3,20 +3,19 @@ version: 0.0.1-alpha.1
 display_name: Google Drive
 description: Read, create, update, and share files in Google Drive.
 icon_file: assets/icon.svg
-kinds:
-  - provider
 provider:
   config_schema_path: schemas/config.schema.json
-  auth:
-    type: oauth2
-    authorization_url: https://accounts.google.com/o/oauth2/v2/auth
-    token_url: https://oauth2.googleapis.com/token
-    scopes:
-      - https://www.googleapis.com/auth/drive
-    authorization_params:
-      access_type: offline
-      prompt: consent
-  openapi: https://api.apis.guru/v2/specs/googleapis.com/drive/v3/openapi.json
+  connections:
+    default:
+      auth:
+        type: oauth2
+        authorization_url: https://accounts.google.com/o/oauth2/v2/auth
+        token_url: https://oauth2.googleapis.com/token
+        scopes:
+          - https://www.googleapis.com/auth/drive
+        authorization_params:
+          access_type: offline
+          prompt: consent
   allowed_operations:
     drive.files.list:
       alias: files.list
@@ -42,3 +41,6 @@ provider:
       alias: permissions.delete
     drive.about.get:
       alias: about.get
+  surfaces:
+    openapi:
+      document: https://api.apis.guru/v2/specs/googleapis.com/drive/v3/openapi.json

--- a/plugins/google_sheets/plugin.yaml
+++ b/plugins/google_sheets/plugin.yaml
@@ -3,20 +3,19 @@ version: 0.0.1-alpha.1
 display_name: Google Sheets
 description: Read and update Google Sheets spreadsheets and values.
 icon_file: assets/icon.svg
-kinds:
-  - provider
 provider:
   config_schema_path: schemas/config.schema.json
-  auth:
-    type: oauth2
-    authorization_url: https://accounts.google.com/o/oauth2/v2/auth
-    token_url: https://oauth2.googleapis.com/token
-    scopes:
-      - https://www.googleapis.com/auth/spreadsheets
-    authorization_params:
-      access_type: offline
-      prompt: consent
-  openapi: https://api.apis.guru/v2/specs/googleapis.com/sheets/v4/openapi.json
+  connections:
+    default:
+      auth:
+        type: oauth2
+        authorization_url: https://accounts.google.com/o/oauth2/v2/auth
+        token_url: https://oauth2.googleapis.com/token
+        scopes:
+          - https://www.googleapis.com/auth/spreadsheets
+        authorization_params:
+          access_type: offline
+          prompt: consent
   allowed_operations:
     sheets.spreadsheets.create:
       alias: create
@@ -36,3 +35,6 @@ provider:
       alias: values.clear
     sheets.spreadsheets.batchUpdate:
       alias: batchUpdate
+  surfaces:
+    openapi:
+      document: https://api.apis.guru/v2/specs/googleapis.com/sheets/v4/openapi.json

--- a/plugins/google_slides/plugin.yaml
+++ b/plugins/google_slides/plugin.yaml
@@ -3,20 +3,19 @@ version: 0.0.1-alpha.1
 display_name: Google Slides
 description: Create and update Google Slides presentations.
 icon_file: assets/icon.svg
-kinds:
-  - provider
 provider:
   config_schema_path: schemas/config.schema.json
-  auth:
-    type: oauth2
-    authorization_url: https://accounts.google.com/o/oauth2/v2/auth
-    token_url: https://oauth2.googleapis.com/token
-    scopes:
-      - https://www.googleapis.com/auth/presentations
-    authorization_params:
-      access_type: offline
-      prompt: consent
-  openapi: https://api.apis.guru/v2/specs/googleapis.com/slides/v1/openapi.json
+  connections:
+    default:
+      auth:
+        type: oauth2
+        authorization_url: https://accounts.google.com/o/oauth2/v2/auth
+        token_url: https://oauth2.googleapis.com/token
+        scopes:
+          - https://www.googleapis.com/auth/presentations
+        authorization_params:
+          access_type: offline
+          prompt: consent
   allowed_operations:
     slides.presentations.create:
       alias: presentations.create
@@ -28,3 +27,6 @@ provider:
       alias: pages.get
     slides.presentations.pages.getThumbnail:
       alias: pages.getThumbnail
+  surfaces:
+    openapi:
+      document: https://api.apis.guru/v2/specs/googleapis.com/slides/v1/openapi.json

--- a/plugins/jira/plugin.yaml
+++ b/plugins/jira/plugin.yaml
@@ -3,113 +3,115 @@ version: 0.0.1-alpha.2
 display_name: Jira Cloud
 description: Atlassian Jira Cloud project and issue management
 icon_file: assets/icon.svg
-kinds:
-  - provider
 provider:
-  base_url: "https://api.atlassian.com/ex/jira/{cloud_id}/rest/api/3"
-  auth:
-    type: oauth2
-    authorization_url: https://auth.atlassian.com/authorize
-    token_url: https://auth.atlassian.com/oauth/token
-    scopes:
-      - read:me
-      - read:jira-work
-      - write:jira-work
-      - offline_access
-    authorization_params:
-      audience: api.atlassian.com
-      prompt: consent
-  post_connect_discovery:
-    url: https://api.atlassian.com/oauth/token/accessible-resources
-    id_path: id
-    name_path: name
-    metadata_mapping:
-      cloud_id: id
-  connection_params:
-    cloud_id:
-      required: true
-      description: Jira Cloud site identifier (discovered automatically)
-      from: discovery
-  operations:
-    - name: list_projects
-      description: List all accessible projects
-      method: GET
-      path: /project
-      parameters:
-        - name: maxResults
-          type: int
-          in: query
-    - name: get_issue
-      description: Get a Jira issue by key
-      method: GET
-      path: "/issue/{issueIdOrKey}"
-      parameters:
-        - name: issueIdOrKey
-          type: string
-          in: path
+  connections:
+    default:
+      auth:
+        type: oauth2
+        authorization_url: https://auth.atlassian.com/authorize
+        token_url: https://auth.atlassian.com/oauth/token
+        scopes:
+          - read:me
+          - read:jira-work
+          - write:jira-work
+          - offline_access
+        authorization_params:
+          audience: api.atlassian.com
+          prompt: consent
+      params:
+        cloud_id:
           required: true
-        - name: fields
-          type: string
-          in: query
-    - name: search_issues
-      description: Search issues using JQL
-      method: POST
-      path: /search
-      parameters:
-        - name: jql
-          type: string
-          in: body
-          required: true
-        - name: maxResults
-          type: int
-          in: body
-        - name: startAt
-          type: int
-          in: body
-        - name: fields
-          type: array
-          in: body
-    - name: create_issue
-      description: Create a new issue
-      method: POST
-      path: /issue
-      parameters:
-        - name: fields
-          type: object
-          in: body
-          required: true
-    - name: add_comment
-      description: Add a comment to an issue
-      method: POST
-      path: "/issue/{issueIdOrKey}/comment"
-      parameters:
-        - name: issueIdOrKey
-          type: string
-          in: path
-          required: true
-        - name: body
-          type: object
-          in: body
-          required: true
-    - name: get_transitions
-      description: Get available transitions for an issue
-      method: GET
-      path: "/issue/{issueIdOrKey}/transitions"
-      parameters:
-        - name: issueIdOrKey
-          type: string
-          in: path
-          required: true
-    - name: transition_issue
-      description: Transition an issue to a new status
-      method: POST
-      path: "/issue/{issueIdOrKey}/transitions"
-      parameters:
-        - name: issueIdOrKey
-          type: string
-          in: path
-          required: true
-        - name: transition
-          type: object
-          in: body
-          required: true
+          description: Jira Cloud site identifier (discovered automatically)
+          from: discovery
+      discovery:
+        url: https://api.atlassian.com/oauth/token/accessible-resources
+        id_path: id
+        name_path: name
+        metadata:
+          cloud_id: id
+  surfaces:
+    rest:
+      base_url: "https://api.atlassian.com/ex/jira/{cloud_id}/rest/api/3"
+      operations:
+        - name: list_projects
+          description: List all accessible projects
+          method: GET
+          path: /project
+          parameters:
+            - name: maxResults
+              type: int
+              in: query
+        - name: get_issue
+          description: Get a Jira issue by key
+          method: GET
+          path: "/issue/{issueIdOrKey}"
+          parameters:
+            - name: issueIdOrKey
+              type: string
+              in: path
+              required: true
+            - name: fields
+              type: string
+              in: query
+        - name: search_issues
+          description: Search issues using JQL
+          method: POST
+          path: /search
+          parameters:
+            - name: jql
+              type: string
+              in: body
+              required: true
+            - name: maxResults
+              type: int
+              in: body
+            - name: startAt
+              type: int
+              in: body
+            - name: fields
+              type: array
+              in: body
+        - name: create_issue
+          description: Create a new issue
+          method: POST
+          path: /issue
+          parameters:
+            - name: fields
+              type: object
+              in: body
+              required: true
+        - name: add_comment
+          description: Add a comment to an issue
+          method: POST
+          path: "/issue/{issueIdOrKey}/comment"
+          parameters:
+            - name: issueIdOrKey
+              type: string
+              in: path
+              required: true
+            - name: body
+              type: object
+              in: body
+              required: true
+        - name: get_transitions
+          description: Get available transitions for an issue
+          method: GET
+          path: "/issue/{issueIdOrKey}/transitions"
+          parameters:
+            - name: issueIdOrKey
+              type: string
+              in: path
+              required: true
+        - name: transition_issue
+          description: Transition an issue to a new status
+          method: POST
+          path: "/issue/{issueIdOrKey}/transitions"
+          parameters:
+            - name: issueIdOrKey
+              type: string
+              in: path
+              required: true
+            - name: transition
+              type: object
+              in: body
+              required: true

--- a/plugins/notion/plugin.yaml
+++ b/plugins/notion/plugin.yaml
@@ -3,16 +3,17 @@ version: 0.0.1-alpha.1
 display_name: Notion
 description: Current Notion REST operations plus the official Notion MCP tool surface.
 icon_file: assets/icon.svg
-kinds:
-  - provider
 provider:
-  openapi: openapi.yaml
-  mcp_url: https://mcp.notion.com/mcp
-  mcp_connection: MCP
   headers:
     Notion-Version: "2026-03-11"
   connections:
-    MCP:
+    mcp:
       mode: user
       auth:
         type: mcp_oauth
+  surfaces:
+    openapi:
+      document: openapi.yaml
+    mcp:
+      url: https://mcp.notion.com/mcp
+      connection: mcp

--- a/plugins/rippling/plugin.yaml
+++ b/plugins/rippling/plugin.yaml
@@ -3,245 +3,247 @@ version: 0.0.1-alpha.3
 display_name: Rippling
 description: Access company, employee, org structure, and leave data from Rippling.
 icon_file: assets/icon.svg
-kinds:
-  - provider
 provider:
-  base_url: https://api.rippling.com/platform/api
-  auth:
-    type: bearer
-    credentials:
-      - name: token
-        label: API Token
-        description: "Create one in [Rippling API Tokens](https://app.rippling.com/developer/api-tokens)"
-  operations:
-    - name: get_company
-      description: Get current company information for the connected Rippling token
-      method: GET
-      path: /companies/current
-    - name: list_departments
-      description: List departments for the current company
-      method: GET
-      path: /departments
-      parameters:
-        - name: limit
-          type: int
-          in: query
-          description: Maximum number of departments to return
-        - name: offset
-          type: int
-          in: query
-          description: Pagination offset
-    - name: list_bank_accounts
-      description: List bank accounts for the current company
-      method: GET
-      path: /bank_accounts
-    - name: list_employees
-      description: List active employees for the current company
-      method: GET
-      path: /employees
-      parameters:
-        - name: limit
-          type: int
-          in: query
-          description: Maximum number of employees to return
-        - name: offset
-          type: int
-          in: query
-          description: Pagination offset
-        - name: countryCode
-          type: string
-          in: query
-          description: Two-letter company entity country code filter
-    - name: list_employees_including_terminated
-      description: List active and terminated employees for the current company
-      method: GET
-      path: /employees/include_terminated
-      parameters:
-        - name: limit
-          type: int
-          in: query
-          description: Maximum number of employees to return
-        - name: offset
-          type: int
-          in: query
-          description: Pagination offset
-        - name: EIN
-          type: int
-          in: query
-          description: Employer identification number filter
-        - name: send_all_roles
-          type: bool
-          in: query
-          description: Return all roles, including non-provisioned roles
-    - name: get_employee
-      description: Get a single employee by ID
-      method: GET
-      path: /employees/{employee_id}
-      parameters:
-        - name: employee_id
-          type: string
-          in: path
-          required: true
-          description: Unique identifier for the employee within Rippling
-    - name: get_current_user
-      description: Get basic information about the Rippling user tied to the token
-      method: GET
-      path: /me
-    - name: list_work_locations
-      description: List work locations for the current company
-      method: GET
-      path: /work_locations
-      parameters:
-        - name: limit
-          type: int
-          in: query
-          description: Maximum number of work locations to return
-        - name: offset
-          type: int
-          in: query
-          description: Pagination offset
-    - name: list_custom_fields
-      description: List custom fields for the current company
-      method: GET
-      path: /custom_fields
-      parameters:
-        - name: limit
-          type: int
-          in: query
-          description: Maximum number of custom fields to return
-        - name: offset
-          type: int
-          in: query
-          description: Pagination offset
-    - name: list_teams
-      description: List teams for the current company
-      method: GET
-      path: /teams
-      parameters:
-        - name: limit
-          type: int
-          in: query
-          description: Maximum number of teams to return
-        - name: offset
-          type: int
-          in: query
-          description: Pagination offset
-    - name: list_levels
-      description: List levels for the current company
-      method: GET
-      path: /levels
-      parameters:
-        - name: limit
-          type: int
-          in: query
-          description: Maximum number of levels to return
-        - name: offset
-          type: int
-          in: query
-          description: Pagination offset
-    - name: list_company_activity
-      description: List company activity events with optional cursor/date filtering
-      method: GET
-      path: /company_activity
-      parameters:
-        - name: startDate
-          type: string
-          in: query
-          description: Start date for activity retrieval (inclusive)
-        - name: endDate
-          type: string
-          in: query
-          description: End date for activity retrieval (inclusive)
-        - name: next
-          type: string
-          in: query
-          description: Pagination cursor returned by a previous activity response
-        - name: limit
-          type: int
-          in: query
-          description: Maximum number of events to return
-    - name: list_leave_requests
-      description: List leave requests with optional filtering
-      method: GET
-      path: /leave_requests
-      parameters:
-        - name: id
-          type: string
-          in: query
-          description: Leave request ID
-        - name: role
-          type: string
-          in: query
-          description: Employee role ID
-        - name: requestedBy
-          type: string
-          in: query
-          description: Requesting employee ID
-        - name: status
-          type: string
-          in: query
-          description: Leave request status
-        - name: startDate
-          type: string
-          in: query
-          description: Start date of leave
-        - name: endDate
-          type: string
-          in: query
-          description: End date of leave
-        - name: leavePolicy
-          type: string
-          in: query
-          description: Leave policy ID
-        - name: processedBy
-          type: string
-          in: query
-          description: Employee ID that processed the request
-        - name: from
-          type: string
-          in: query
-          description: Start of overlapping date-range filter
-        - name: to
-          type: string
-          in: query
-          description: End of overlapping date-range filter
-        - name: limit
-          type: int
-          in: query
-          description: Maximum number of leave requests to return
-        - name: offset
-          type: int
-          in: query
-          description: Pagination offset
-    - name: list_company_leave_types
-      description: List company leave types with optional managed-by filtering
-      method: GET
-      path: /company_leave_types
-      parameters:
-        - name: managedBy
-          type: string
-          in: query
-          description: Filter leave types by managing system identifier
-    - name: list_leave_balances
-      description: List leave balances for employees
-      method: GET
-      path: /leave_balances
-      parameters:
-        - name: limit
-          type: int
-          in: query
-          description: Maximum number of balance records to return
-        - name: offset
-          type: int
-          in: query
-          description: Pagination offset
-    - name: get_leave_balance
-      description: Get leave balances for a single employee role
-      method: GET
-      path: /leave_balances/{role}
-      parameters:
-        - name: role
-          type: string
-          in: path
-          required: true
-          description: Employee role ID returned by Rippling employee endpoints
+  connections:
+    default:
+      auth:
+        type: bearer
+        credentials:
+          - name: token
+            label: API Token
+            description: "Create one in [Rippling API Tokens](https://app.rippling.com/developer/api-tokens)"
+  surfaces:
+    rest:
+      base_url: https://api.rippling.com/platform/api
+      operations:
+        - name: get_company
+          description: Get current company information for the connected Rippling token
+          method: GET
+          path: /companies/current
+        - name: list_departments
+          description: List departments for the current company
+          method: GET
+          path: /departments
+          parameters:
+            - name: limit
+              type: int
+              in: query
+              description: Maximum number of departments to return
+            - name: offset
+              type: int
+              in: query
+              description: Pagination offset
+        - name: list_bank_accounts
+          description: List bank accounts for the current company
+          method: GET
+          path: /bank_accounts
+        - name: list_employees
+          description: List active employees for the current company
+          method: GET
+          path: /employees
+          parameters:
+            - name: limit
+              type: int
+              in: query
+              description: Maximum number of employees to return
+            - name: offset
+              type: int
+              in: query
+              description: Pagination offset
+            - name: countryCode
+              type: string
+              in: query
+              description: Two-letter company entity country code filter
+        - name: list_employees_including_terminated
+          description: List active and terminated employees for the current company
+          method: GET
+          path: /employees/include_terminated
+          parameters:
+            - name: limit
+              type: int
+              in: query
+              description: Maximum number of employees to return
+            - name: offset
+              type: int
+              in: query
+              description: Pagination offset
+            - name: EIN
+              type: int
+              in: query
+              description: Employer identification number filter
+            - name: send_all_roles
+              type: bool
+              in: query
+              description: Return all roles, including non-provisioned roles
+        - name: get_employee
+          description: Get a single employee by ID
+          method: GET
+          path: /employees/{employee_id}
+          parameters:
+            - name: employee_id
+              type: string
+              in: path
+              required: true
+              description: Unique identifier for the employee within Rippling
+        - name: get_current_user
+          description: Get basic information about the Rippling user tied to the token
+          method: GET
+          path: /me
+        - name: list_work_locations
+          description: List work locations for the current company
+          method: GET
+          path: /work_locations
+          parameters:
+            - name: limit
+              type: int
+              in: query
+              description: Maximum number of work locations to return
+            - name: offset
+              type: int
+              in: query
+              description: Pagination offset
+        - name: list_custom_fields
+          description: List custom fields for the current company
+          method: GET
+          path: /custom_fields
+          parameters:
+            - name: limit
+              type: int
+              in: query
+              description: Maximum number of custom fields to return
+            - name: offset
+              type: int
+              in: query
+              description: Pagination offset
+        - name: list_teams
+          description: List teams for the current company
+          method: GET
+          path: /teams
+          parameters:
+            - name: limit
+              type: int
+              in: query
+              description: Maximum number of teams to return
+            - name: offset
+              type: int
+              in: query
+              description: Pagination offset
+        - name: list_levels
+          description: List levels for the current company
+          method: GET
+          path: /levels
+          parameters:
+            - name: limit
+              type: int
+              in: query
+              description: Maximum number of levels to return
+            - name: offset
+              type: int
+              in: query
+              description: Pagination offset
+        - name: list_company_activity
+          description: List company activity events with optional cursor/date filtering
+          method: GET
+          path: /company_activity
+          parameters:
+            - name: startDate
+              type: string
+              in: query
+              description: Start date for activity retrieval (inclusive)
+            - name: endDate
+              type: string
+              in: query
+              description: End date for activity retrieval (inclusive)
+            - name: next
+              type: string
+              in: query
+              description: Pagination cursor returned by a previous activity response
+            - name: limit
+              type: int
+              in: query
+              description: Maximum number of events to return
+        - name: list_leave_requests
+          description: List leave requests with optional filtering
+          method: GET
+          path: /leave_requests
+          parameters:
+            - name: id
+              type: string
+              in: query
+              description: Leave request ID
+            - name: role
+              type: string
+              in: query
+              description: Employee role ID
+            - name: requestedBy
+              type: string
+              in: query
+              description: Requesting employee ID
+            - name: status
+              type: string
+              in: query
+              description: Leave request status
+            - name: startDate
+              type: string
+              in: query
+              description: Start date of leave
+            - name: endDate
+              type: string
+              in: query
+              description: End date of leave
+            - name: leavePolicy
+              type: string
+              in: query
+              description: Leave policy ID
+            - name: processedBy
+              type: string
+              in: query
+              description: Employee ID that processed the request
+            - name: from
+              type: string
+              in: query
+              description: Start of overlapping date-range filter
+            - name: to
+              type: string
+              in: query
+              description: End of overlapping date-range filter
+            - name: limit
+              type: int
+              in: query
+              description: Maximum number of leave requests to return
+            - name: offset
+              type: int
+              in: query
+              description: Pagination offset
+        - name: list_company_leave_types
+          description: List company leave types with optional managed-by filtering
+          method: GET
+          path: /company_leave_types
+          parameters:
+            - name: managedBy
+              type: string
+              in: query
+              description: Filter leave types by managing system identifier
+        - name: list_leave_balances
+          description: List leave balances for employees
+          method: GET
+          path: /leave_balances
+          parameters:
+            - name: limit
+              type: int
+              in: query
+              description: Maximum number of balance records to return
+            - name: offset
+              type: int
+              in: query
+              description: Pagination offset
+        - name: get_leave_balance
+          description: Get leave balances for a single employee role
+          method: GET
+          path: /leave_balances/{role}
+          parameters:
+            - name: role
+              type: string
+              in: path
+              required: true
+              description: Employee role ID returned by Rippling employee endpoints

--- a/plugins/slack/plugin.yaml
+++ b/plugins/slack/plugin.yaml
@@ -3,262 +3,265 @@ version: 0.0.1-alpha.7
 display_name: Slack
 description: Send messages, search conversations, and manage channels.
 icon_file: assets/icon.svg
-kinds:
-  - provider
 provider:
-  mcp: true
-  base_url: https://slack.com
-  auth:
-    type: oauth2
-    authorization_url: https://slack.com/oauth/v2/authorize
-    token_url: https://slack.com/api/oauth.v2.access
-    access_token_path: authed_user.access_token
-    scope_param: user_scope
-    scope_separator: ","
-    scopes:
-      - channels:read
-      - channels:history
-      - groups:read
-      - groups:history
-      - im:read
-      - im:history
-      - mpim:read
-      - mpim:history
-      - search:read
-      - users:read
-      - chat:write
-      - reactions:write
-      - channels:write
-      - groups:write
-      - canvases:write
-  operations:
-    - name: conversations.list
-      description: List conversations/channels
-      method: GET
-      path: /api/conversations.list
-      parameters:
-        - name: limit
-          type: int
-          in: query
-        - name: cursor
-          type: string
-          in: query
-        - name: types
-          type: string
-          in: query
-    - name: chat.postMessage
-      description: Send a message to a channel
-      method: POST
-      path: /api/chat.postMessage
-      parameters:
-        - name: channel
-          type: string
-          in: body
-          required: true
-        - name: text
-          type: string
-          in: body
-          required: true
-        - name: thread_ts
-          type: string
-          in: body
-        - name: unfurl_links
-          type: bool
-          in: body
-        - name: unfurl_media
-          type: bool
-          in: body
-    - name: users.list
-      description: List workspace users
-      method: GET
-      path: /api/users.list
-      parameters:
-        - name: limit
-          type: int
-          in: query
-        - name: cursor
-          type: string
-          in: query
-    - name: conversations.history
-      description: Read message history for a channel
-      method: GET
-      path: /api/conversations.history
-      parameters:
-        - name: channel
-          type: string
-          in: query
-          required: true
-        - name: limit
-          type: int
-          in: query
-        - name: cursor
-          type: string
-          in: query
-        - name: oldest
-          type: string
-          in: query
-        - name: latest
-          type: string
-          in: query
-        - name: inclusive
-          type: bool
-          in: query
-    - name: search.messages
-      description: Search messages across the workspace
-      method: GET
-      path: /api/search.messages
-      parameters:
-        - name: query
-          type: string
-          in: query
-          required: true
-        - name: count
-          type: int
-          in: query
-        - name: page
-          type: int
-          in: query
-    - name: users.info
-      description: Get profile information for a Slack user
-      method: GET
-      path: /api/users.info
-      parameters:
-        - name: user
-          type: string
-          in: query
-          required: true
-    - name: conversations.replies
-      description: Read replies for a thread
-      method: GET
-      path: /api/conversations.replies
-      parameters:
-        - name: channel
-          type: string
-          in: query
-          required: true
-        - name: ts
-          type: string
-          in: query
-          required: true
-        - name: limit
-          type: int
-          in: query
-        - name: cursor
-          type: string
-          in: query
-        - name: oldest
-          type: string
-          in: query
-        - name: latest
-          type: string
-          in: query
-        - name: inclusive
-          type: bool
-          in: query
-    - name: chat.scheduleMessage
-      description: Schedule a message to be sent later
-      method: POST
-      path: /api/chat.scheduleMessage
-      parameters:
-        - name: channel
-          type: string
-          in: body
-          required: true
-        - name: text
-          type: string
-          in: body
-          required: true
-        - name: post_at
-          type: int
-          in: body
-          required: true
-        - name: thread_ts
-          type: string
-          in: body
-    - name: reactions.add
-      description: Add an emoji reaction to a message
-      method: POST
-      path: /api/reactions.add
-      parameters:
-        - name: channel
-          type: string
-          in: body
-          required: true
-        - name: timestamp
-          type: string
-          in: body
-          required: true
-        - name: name
-          type: string
-          in: body
-          required: true
-    - name: conversations.setTopic
-      description: Set a channel topic
-      method: POST
-      path: /api/conversations.setTopic
-      parameters:
-        - name: channel
-          type: string
-          in: body
-          required: true
-        - name: topic
-          type: string
-          in: body
-          required: true
-    - name: conversations.create
-      description: Create a new Slack channel
-      method: POST
-      path: /api/conversations.create
-      parameters:
-        - name: name
-          type: string
-          in: body
-          required: true
-        - name: is_private
-          type: bool
-          in: body
-    - name: conversations.invite
-      description: Invite users to a channel
-      method: POST
-      path: /api/conversations.invite
-      parameters:
-        - name: channel
-          type: string
-          in: body
-          required: true
-        - name: users
-          type: string
-          in: body
-          required: true
-    - name: chat.postEphemeral
-      description: Send an ephemeral message visible only to a specific user
-      method: POST
-      path: /api/chat.postEphemeral
-      parameters:
-        - name: channel
-          type: string
-          in: body
-          required: true
-        - name: text
-          type: string
-          in: body
-          required: true
-        - name: user
-          type: string
-          in: body
-          required: true
-        - name: thread_ts
-          type: string
-          in: body
-    - name: canvases.create
-      description: Create a Slack canvas
-      method: POST
-      path: /api/canvases.create
-      parameters:
-        - name: title
-          type: string
-          in: body
-          required: true
-        - name: document_content
-          type: object
-          in: body
+  connections:
+    default:
+      auth:
+        type: oauth2
+        authorization_url: https://slack.com/oauth/v2/authorize
+        token_url: https://slack.com/api/oauth.v2.access
+        access_token_path: authed_user.access_token
+        scope_param: user_scope
+        scope_separator: ","
+        scopes:
+          - channels:read
+          - channels:history
+          - groups:read
+          - groups:history
+          - im:read
+          - im:history
+          - mpim:read
+          - mpim:history
+          - search:read
+          - users:read
+          - chat:write
+          - reactions:write
+          - channels:write
+          - groups:write
+          - canvases:write
+  surfaces:
+    rest:
+      base_url: https://slack.com
+      operations:
+        - name: conversations.list
+          description: List conversations/channels
+          method: GET
+          path: /api/conversations.list
+          parameters:
+            - name: limit
+              type: int
+              in: query
+            - name: cursor
+              type: string
+              in: query
+            - name: types
+              type: string
+              in: query
+        - name: chat.postMessage
+          description: Send a message to a channel
+          method: POST
+          path: /api/chat.postMessage
+          parameters:
+            - name: channel
+              type: string
+              in: body
+              required: true
+            - name: text
+              type: string
+              in: body
+              required: true
+            - name: thread_ts
+              type: string
+              in: body
+            - name: unfurl_links
+              type: bool
+              in: body
+            - name: unfurl_media
+              type: bool
+              in: body
+        - name: users.list
+          description: List workspace users
+          method: GET
+          path: /api/users.list
+          parameters:
+            - name: limit
+              type: int
+              in: query
+            - name: cursor
+              type: string
+              in: query
+        - name: conversations.history
+          description: Read message history for a channel
+          method: GET
+          path: /api/conversations.history
+          parameters:
+            - name: channel
+              type: string
+              in: query
+              required: true
+            - name: limit
+              type: int
+              in: query
+            - name: cursor
+              type: string
+              in: query
+            - name: oldest
+              type: string
+              in: query
+            - name: latest
+              type: string
+              in: query
+            - name: inclusive
+              type: bool
+              in: query
+        - name: search.messages
+          description: Search messages across the workspace
+          method: GET
+          path: /api/search.messages
+          parameters:
+            - name: query
+              type: string
+              in: query
+              required: true
+            - name: count
+              type: int
+              in: query
+            - name: page
+              type: int
+              in: query
+        - name: users.info
+          description: Get profile information for a Slack user
+          method: GET
+          path: /api/users.info
+          parameters:
+            - name: user
+              type: string
+              in: query
+              required: true
+        - name: conversations.replies
+          description: Read replies for a thread
+          method: GET
+          path: /api/conversations.replies
+          parameters:
+            - name: channel
+              type: string
+              in: query
+              required: true
+            - name: ts
+              type: string
+              in: query
+              required: true
+            - name: limit
+              type: int
+              in: query
+            - name: cursor
+              type: string
+              in: query
+            - name: oldest
+              type: string
+              in: query
+            - name: latest
+              type: string
+              in: query
+            - name: inclusive
+              type: bool
+              in: query
+        - name: chat.scheduleMessage
+          description: Schedule a message to be sent later
+          method: POST
+          path: /api/chat.scheduleMessage
+          parameters:
+            - name: channel
+              type: string
+              in: body
+              required: true
+            - name: text
+              type: string
+              in: body
+              required: true
+            - name: post_at
+              type: int
+              in: body
+              required: true
+            - name: thread_ts
+              type: string
+              in: body
+        - name: reactions.add
+          description: Add an emoji reaction to a message
+          method: POST
+          path: /api/reactions.add
+          parameters:
+            - name: channel
+              type: string
+              in: body
+              required: true
+            - name: timestamp
+              type: string
+              in: body
+              required: true
+            - name: name
+              type: string
+              in: body
+              required: true
+        - name: conversations.setTopic
+          description: Set a channel topic
+          method: POST
+          path: /api/conversations.setTopic
+          parameters:
+            - name: channel
+              type: string
+              in: body
+              required: true
+            - name: topic
+              type: string
+              in: body
+              required: true
+        - name: conversations.create
+          description: Create a new Slack channel
+          method: POST
+          path: /api/conversations.create
+          parameters:
+            - name: name
+              type: string
+              in: body
+              required: true
+            - name: is_private
+              type: bool
+              in: body
+        - name: conversations.invite
+          description: Invite users to a channel
+          method: POST
+          path: /api/conversations.invite
+          parameters:
+            - name: channel
+              type: string
+              in: body
+              required: true
+            - name: users
+              type: string
+              in: body
+              required: true
+        - name: chat.postEphemeral
+          description: Send an ephemeral message visible only to a specific user
+          method: POST
+          path: /api/chat.postEphemeral
+          parameters:
+            - name: channel
+              type: string
+              in: body
+              required: true
+            - name: text
+              type: string
+              in: body
+              required: true
+            - name: user
+              type: string
+              in: body
+              required: true
+            - name: thread_ts
+              type: string
+              in: body
+        - name: canvases.create
+          description: Create a Slack canvas
+          method: POST
+          path: /api/canvases.create
+          parameters:
+            - name: title
+              type: string
+              in: body
+              required: true
+            - name: document_content
+              type: object
+              in: body
+  mcp:
+    enabled: true

--- a/server/cmd/gestaltd/e2e_test.go
+++ b/server/cmd/gestaltd/e2e_test.go
@@ -70,53 +70,42 @@ func TestE2EValidateRejectsInvalidInlineConnectionConfigs(t *testing.T) {
 		wantError  string
 	}{
 		{
-			name: "operations require default connection",
-			pluginYAML: `base_url: https://api.example.test
-auth:
-  type: manual
-connections:
+			name: "openapi requires explicit surface connection",
+			pluginYAML: `connections:
   workspace:
     auth:
       type: manual
-operations:
-  - name: list_items
-    method: GET
-    path: /items`,
-			wantError: "plugin.default_connection is required when using inline operations with named connections",
+surfaces:
+  openapi:
+    document: https://api.example.test/openapi.json`,
+			wantError: "surfaces.openapi.connection is required when using named connections without connections.default",
 		},
 		{
-			name: "openapi requires explicit surface connection",
-			pluginYAML: `openapi: https://api.example.test/openapi.json
-connections:
+			name: "graphql requires explicit surface connection",
+			pluginYAML: `connections:
   workspace:
     auth:
-      type: manual`,
-			wantError: "plugin.openapi_connection is required when using openapi with named connections and no top-level auth",
-		},
-		{
-			name: "graphql still requires surface connection when openapi also exists",
-			pluginYAML: `openapi: https://api.example.test/openapi.json
-openapi_connection: workspace
-graphql_url: https://api.example.test/graphql
-connections:
-  workspace:
-    auth:
-      type: manual`,
-			wantError: "plugin.graphql_connection is required when using graphql_url with named connections and no top-level auth",
+      type: manual
+surfaces:
+  graphql:
+    url: https://api.example.test/graphql`,
+			wantError: "surfaces.graphql.connection is required when using named connections without connections.default",
 		},
 		{
 			name: "default connection reference must exist",
-			pluginYAML: `openapi: https://api.example.test/openapi.json
-openapi_connection: workspace
-default_connection: missing
-connections:
+			pluginYAML: `connections:
   workspace:
     auth:
       type: manual
-    params:
-      tenant:
-        required: true`,
-			wantError: "plugin.default_connection references undeclared connection",
+surfaces:
+  rest:
+    connection: missing
+    base_url: https://api.example.test
+    operations:
+      - name: list_items
+        method: GET
+        path: /items`,
+			wantError: "surfaces.rest.connection references undeclared connection",
 		},
 	}
 
@@ -136,11 +125,10 @@ datastore:
 server:
   port: 18080
   encryption_key: test-e2e-key
-integrations:
+providers:
   example:
-    plugin:
-      %s
-`, filepath.Join(dir, "gestalt.db"), strings.ReplaceAll(tc.pluginYAML, "\n", "\n      "))
+    %s
+`, filepath.Join(dir, "gestalt.db"), strings.ReplaceAll(tc.pluginYAML, "\n", "\n    "))
 
 			if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {
 				t.Fatalf("write config: %v", err)
@@ -403,19 +391,22 @@ func TestE2EValidateRejectsUnknownYAMLField(t *testing.T) {
 	}{
 		{
 			name: "bogus field",
-			pluginYAML: `command: /tmp/provider
+			pluginYAML: `from:
+  command: /tmp/provider
 bogus: true`,
 			wantError: "bogus",
 		},
 		{
 			name: "removed plugin connection field",
-			pluginYAML: `command: /tmp/provider
+			pluginYAML: `from:
+  command: /tmp/provider
 connection: default`,
 			wantError: "connection",
 		},
 		{
-			name: "removed plugin params field",
-			pluginYAML: `command: /tmp/provider
+			name: "removed provider params field",
+			pluginYAML: `from:
+  command: /tmp/provider
 params:
   tenant:
     required: true`,
@@ -438,11 +429,10 @@ datastore:
     path: %s
 server:
   encryption_key: test-key
-integrations:
+providers:
   example:
-    plugin:
-      %s
-`, filepath.Join(dir, "gestalt.db"), strings.ReplaceAll(tc.pluginYAML, "\n", "\n      "))
+    %s
+`, filepath.Join(dir, "gestalt.db"), strings.ReplaceAll(tc.pluginYAML, "\n", "\n    "))
 			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 				t.Fatalf("WriteFile config: %v", err)
 			}
@@ -468,28 +458,36 @@ func TestE2EValidateRejectsUnsupportedPluginFields(t *testing.T) {
 	}{
 		{
 			name: "env unsupported for inline plugin",
-			pluginYAML: `openapi: https://api.example.test/openapi.json
-env:
-  API_KEY: secret`,
+			pluginYAML: `from:
+  env:
+    API_KEY: secret
+surfaces:
+  openapi:
+    document: https://api.example.test/openapi.json`,
 			wantError: "plugin.env is only valid when the plugin runs as an executable process; remove plugin.env or switch this integration to plugin.command, plugin.package, or plugin.source",
 		},
 		{
 			name: "allowed hosts unsupported for inline plugin",
-			pluginYAML: `openapi: https://api.example.test/openapi.json
-allowed_hosts:
-  - api.example.test`,
+			pluginYAML: `from:
+  allowed_hosts:
+    - api.example.test
+surfaces:
+  openapi:
+    document: https://api.example.test/openapi.json`,
 			wantError: "plugin.allowed_hosts is only valid when the plugin runs as an executable process; remove plugin.allowed_hosts or switch this integration to plugin.command, plugin.package, or plugin.source",
 		},
 		{
 			name: "headers unsupported without declarative ops or spec surface",
-			pluginYAML: `command: /tmp/provider
+			pluginYAML: `from:
+  command: /tmp/provider
 headers:
   x-test: value`,
 			wantError: "plugin.headers are only valid when the plugin exposes declarative operations or a spec surface; remove plugin.headers or configure declarative operations, OpenAPI, GraphQL, or MCP",
 		},
 		{
 			name: "managed parameters unsupported without api surface",
-			pluginYAML: `command: /tmp/provider
+			pluginYAML: `from:
+  command: /tmp/provider
 managed_parameters:
   - in: header
     name: x-version
@@ -498,29 +496,56 @@ managed_parameters:
 		},
 		{
 			name: "response mapping unsupported for inline operations only",
-			pluginYAML: `base_url: https://api.example.test
-operations:
-  - name: list_items
-    method: GET
-    path: /items
-response_mapping:
-  data_path: items`,
+			pluginYAML: `response_mapping:
+  data_path: items
+surfaces:
+  rest:
+    base_url: https://api.example.test
+    operations:
+      - name: list_items
+        method: GET
+        path: /items`,
 			wantError: "plugin.response_mapping is only valid for openapi/graphql integrations; remove plugin.response_mapping or configure an OpenAPI or GraphQL surface",
 		},
 		{
-			name: "operations unsupported with spec surface",
-			pluginYAML: `openapi: https://api.example.test/openapi.json
-operations:
-  - name: list_items
-    method: GET
-    path: /items`,
-			wantError: "plugin.operations are only valid when no openapi, graphql_url, or mcp_url is configured",
+			name: "multiple api surfaces are rejected",
+			pluginYAML: `surfaces:
+  rest:
+    base_url: https://api.example.test
+    operations:
+      - name: list_items
+        method: GET
+        path: /items
+  openapi:
+    document: https://api.example.test/openapi.json`,
+			wantError: "provider config can define only one of surfaces.rest, surfaces.openapi, or surfaces.graphql",
+		},
+		{
+			name: "rest surface requires operations",
+			pluginYAML: `surfaces:
+  rest:
+    base_url: https://api.example.test`,
+			wantError: "surfaces.rest.operations is required when surfaces.rest is configured",
 		},
 		{
 			name: "mcp connection requires mcp url",
-			pluginYAML: `command: /tmp/provider
-mcp_connection: default`,
-			wantError: "plugin.mcp_connection is only valid when mcp_url is configured; remove plugin.mcp_connection or configure an MCP surface",
+			pluginYAML: `connections:
+  workspace:
+    auth:
+      type: manual
+surfaces:
+  openapi:
+    document: https://api.example.test/openapi.json
+    connection: workspace
+  mcp:
+    connection: workspace`,
+			wantError: "surfaces.mcp.url is required when surfaces.mcp is configured",
+		},
+		{
+			name: "mcp tool prefix requires enabled",
+			pluginYAML: `mcp:
+  tool_prefix: github_`,
+			wantError: "mcp.tool_prefix is only valid when mcp.enabled is true",
 		},
 	}
 
@@ -539,11 +564,10 @@ datastore:
     path: %s
 server:
   encryption_key: test-key
-integrations:
+providers:
   example:
-    plugin:
-      %s
-`, filepath.Join(dir, "gestalt.db"), strings.ReplaceAll(tc.pluginYAML, "\n", "\n      "))
+    %s
+`, filepath.Join(dir, "gestalt.db"), strings.ReplaceAll(tc.pluginYAML, "\n", "\n    "))
 
 			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 				t.Fatalf("WriteFile config: %v", err)
@@ -571,7 +595,9 @@ func TestE2EValidateInitRejectsUnsupportedManagedPluginFields(t *testing.T) {
 		{
 			name:  "config headers unsupported for executable-only package plugin",
 			setup: setupPluginDir,
-			pluginYAML: `headers:
+			pluginYAML: `from:
+  package: %s
+headers:
   x-test: value`,
 			wantError: "plugin.headers are only valid when the plugin exposes declarative operations or a spec surface; remove plugin.headers or configure declarative operations, OpenAPI, GraphQL, or MCP",
 		},
@@ -583,6 +609,7 @@ func TestE2EValidateInitRejectsUnsupportedManagedPluginFields(t *testing.T) {
 			dir := t.TempDir()
 			pluginDir := tc.setup(t, dir)
 			cfgPath := filepath.Join(dir, "config.yaml")
+			pluginYAML := fmt.Sprintf(tc.pluginYAML, pluginDir)
 			cfg := fmt.Sprintf(`auth:
   provider: local
 datastore:
@@ -591,12 +618,10 @@ datastore:
     path: %s
 server:
   encryption_key: test-key
-integrations:
+providers:
   example:
-    plugin:
-      package: %s
-      %s
-`, filepath.Join(dir, "gestalt.db"), pluginDir, strings.ReplaceAll(tc.pluginYAML, "\n", "\n      "))
+    %s
+`, filepath.Join(dir, "gestalt.db"), strings.ReplaceAll(pluginYAML, "\n", "\n    "))
 
 			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 				t.Fatalf("WriteFile config: %v", err)
@@ -626,9 +651,9 @@ datastore:
 server:
   encryption_key: test-key
   typo: true
-integrations:
+providers:
   example:
-    plugin:
+    from:
       command: /tmp/provider
 `
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
@@ -772,9 +797,9 @@ datastore:
 server:
   port: %d
   encryption_key: test-e2e-key
-integrations:
+providers:
   example:
-    plugin:
+    from:
       package: %s
 `, filepath.Join(dir, "gestalt.db"), port, packageRef)
 
@@ -956,10 +981,10 @@ datastore:
 server:
   port: %d
   encryption_key: test-hybrid-key
-integrations:
+providers:
   hybrid:
     display_name: Hybrid Test
-    plugin:
+    from:
       package: %s
 `, filepath.Join(dir, "gestalt.db"), port, packageRef)
 

--- a/server/cmd/gestaltd/init_test.go
+++ b/server/cmd/gestaltd/init_test.go
@@ -323,7 +323,7 @@ func writePreparedPluginPackageConfigWithConfig(t *testing.T, dir, packagePath s
 	cfgPath := filepath.Join(dir, "config.yaml")
 	var configBlock string
 	if pluginConfig != nil {
-		configBlock += "\n      config:"
+		configBlock += "\n    config:"
 		payload, err := json.Marshal(pluginConfig)
 		if err != nil {
 			t.Fatalf("Marshal(pluginConfig): %v", err)
@@ -333,7 +333,7 @@ func writePreparedPluginPackageConfigWithConfig(t *testing.T, dir, packagePath s
 			t.Fatalf("Unmarshal(pluginConfig): %v", err)
 		}
 		for key, value := range decoded {
-			configBlock += fmt.Sprintf("\n        %s: %q", key, value)
+			configBlock += fmt.Sprintf("\n      %s: %q", key, value)
 		}
 	}
 	cfg := `auth:
@@ -348,9 +348,9 @@ datastore:
     path: ` + filepath.Join(dir, "gestalt.db") + `
 server:
   encryption_key: test-key
-integrations:
+providers:
   example:
-    plugin:
+    from:
       package: ` + packagePath + configBlock + `
 `
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {

--- a/server/cmd/gestaltd/main_test.go
+++ b/server/cmd/gestaltd/main_test.go
@@ -134,7 +134,7 @@ datastore:
     path: ` + filepath.Join(dir, "gestalt.db") + `
 server:
   encryption_key: test-key
-integrations:
+providers:
   broken:
     display_name: Broken
 `
@@ -146,7 +146,7 @@ integrations:
 	if err == nil {
 		t.Fatal("expected validation error, got nil")
 	}
-	if !strings.Contains(err.Error(), `requires a plugin`) {
-		t.Fatalf("expected requires-a-plugin error, got: %v", err)
+	if !strings.Contains(err.Error(), `plugin.command, plugin.package, or plugin.source is required`) {
+		t.Fatalf("expected provider-source validation error, got: %v", err)
 	}
 }

--- a/server/cmd/gestaltd/plugin_test.go
+++ b/server/cmd/gestaltd/plugin_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"flag"
 	"io"
@@ -16,7 +15,6 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
-	"gopkg.in/yaml.v3"
 )
 
 var stdoutMu sync.Mutex
@@ -240,32 +238,72 @@ func TestRun_PluginReleaseRequiresVersion(t *testing.T) {
 func TestRun_PluginReleaseRejectsInvalidManifest(t *testing.T) {
 	t.Parallel()
 
-	pluginDir := filepath.Join(t.TempDir(), "invalid-plugin")
-	if err := os.MkdirAll(pluginDir, 0755); err != nil {
-		t.Fatalf("MkdirAll(pluginDir): %v", err)
-	}
-	writeTestFile(t, pluginDir, "plugin.yaml", []byte(`
+	cases := []struct {
+		name         string
+		manifestYAML string
+		wantError    string
+	}{
+		{
+			name: "rest surface requires operations",
+			manifestYAML: `
 source: github.com/testowner/plugins/invalid
 version: 0.1.0
-kinds:
-  - provider
 provider:
-  base_url: https://api.example.com
-  operations:
-    - name: list_items
-      method: GET
-      path: /items
-  connection:
-    tenant:
-      required: true
-`), 0644)
-
-	out, err := runPluginReleaseCommandResult(pluginDir, "--version", "0.0.1-test")
-	if err == nil {
-		t.Fatal("expected invalid manifest error")
+  surfaces:
+    rest:
+      base_url: https://api.example.com
+`,
+			wantError: "missing property 'operations'",
+		},
+		{
+			name: "exec requires artifact path",
+			manifestYAML: `
+source: github.com/testowner/plugins/invalid
+version: 0.1.0
+provider:
+  exec: {}
+  surfaces: {}
+`,
+			wantError: "missing property 'artifact_path'",
+		},
+		{
+			name: "mcp block requires enabled",
+			manifestYAML: `
+source: github.com/testowner/plugins/invalid
+version: 0.1.0
+provider:
+  mcp: {}
+  surfaces:
+    rest:
+      base_url: https://api.example.com
+      operations:
+        - name: list_items
+          method: GET
+          path: /items
+`,
+			wantError: "missing property 'enabled'",
+		},
 	}
-	if !strings.Contains(string(out), "connection") {
-		t.Fatalf("unexpected output: %s", out)
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pluginDir := filepath.Join(t.TempDir(), "invalid-plugin")
+			if err := os.MkdirAll(pluginDir, 0755); err != nil {
+				t.Fatalf("MkdirAll(pluginDir): %v", err)
+			}
+			writeTestFile(t, pluginDir, "plugin.yaml", []byte(tc.manifestYAML), 0644)
+
+			out, err := runPluginReleaseCommandResult(pluginDir, "--version", "0.0.1-test")
+			if err == nil {
+				t.Fatal("expected invalid manifest error")
+			}
+			if !strings.Contains(string(out), tc.wantError) {
+				t.Fatalf("unexpected output: %s", out)
+			}
+		})
 	}
 }
 
@@ -485,7 +523,7 @@ func TestRun_PluginReleaseTreatsDeclarativePluginWithHelperMainAsSource(t *testi
 	}
 }
 
-func TestRun_PluginReleasePreservesYAMLManifestFormatAndConnectionParams(t *testing.T) {
+func TestRun_PluginReleasePreservesYAMLManifestFormatAndDefaultConnectionParams(t *testing.T) {
 	t.Parallel()
 
 	pluginDir := filepath.Join(t.TempDir(), "declarative-provider")
@@ -495,17 +533,22 @@ func TestRun_PluginReleasePreservesYAMLManifestFormatAndConnectionParams(t *test
 	writeTestFile(t, pluginDir, "plugin.yaml", []byte(`
 source: github.com/testowner/plugins/declarative-provider
 version: 0.0.1
-kinds:
-  - provider
 provider:
-  base_url: https://api.example.com
-  operations:
-    - name: list_items
-      method: GET
-      path: /items
-  connection_params:
-    tenant:
-      required: true
+  mcp:
+    enabled: true
+  connections:
+    default:
+      mode: identity
+      params:
+        tenant:
+          required: true
+  surfaces:
+    rest:
+      base_url: https://api.example.com
+      operations:
+        - name: list_items
+          method: GET
+          path: /items
 `), 0o644)
 
 	outputDir := t.TempDir()
@@ -525,13 +568,16 @@ provider:
 	if manifest.Provider == nil || len(manifest.Provider.ConnectionParams) != 1 || !manifest.Provider.ConnectionParams["tenant"].Required {
 		t.Fatalf("provider connection_params = %+v", manifest.Provider)
 	}
+	if manifest.Provider.ConnectionMode != "identity" {
+		t.Fatalf("provider connection_mode = %q, want %q", manifest.Provider.ConnectionMode, "identity")
+	}
 
 	manifestData, err := os.ReadFile(manifestPath)
 	if err != nil {
 		t.Fatalf("read released manifest: %v", err)
 	}
-	if !strings.Contains(string(manifestData), "connection_params:") {
-		t.Fatalf("expected released manifest to use connection_params, got: %s", manifestData)
+	if !strings.Contains(string(manifestData), "mcp:") || !strings.Contains(string(manifestData), "enabled: true") || !strings.Contains(string(manifestData), "connections:") || !strings.Contains(string(manifestData), "params:") || !strings.Contains(string(manifestData), "mode: identity") {
+		t.Fatalf("expected released manifest to use connections.default.params, got: %s", manifestData)
 	}
 }
 
@@ -985,28 +1031,32 @@ func newPluginPackageFixture(t *testing.T, dir string) string {
 		t.Fatalf("WriteFile(openapi.yaml): %v", err)
 	}
 
-	manifest := `{
-  "source": "github.com/testowner/plugins/provider",
-  "version": "0.1.0",
-  "kinds": ["provider"],
-  "provider": {
-    "config_schema_path": "schemas/config.schema.json"
-  },
-  "artifacts": [
-    {
-      "os": "` + runtime.GOOS + `",
-      "arch": "` + runtime.GOARCH + `",
-      "path": "artifacts/` + runtime.GOOS + `/` + runtime.GOARCH + `/provider",
-      "sha256": "` + sha256HexForTest("provider") + `"
-    }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "artifacts/` + runtime.GOOS + `/` + runtime.GOARCH + `/provider"
-    }
-  }
-}`
-	if err := os.WriteFile(filepath.Join(src, "plugin.json"), []byte(manifest), 0644); err != nil {
+	manifest := &pluginmanifestv1.Manifest{
+		Source:  "github.com/testowner/plugins/provider",
+		Version: "0.1.0",
+		Kinds:   []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			ConfigSchemaPath: "schemas/config.schema.json",
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     runtime.GOOS,
+				Arch:   runtime.GOARCH,
+				Path:   filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider")),
+				SHA256: sha256HexForTest("provider"),
+			},
+		},
+		Entrypoints: pluginmanifestv1.Entrypoints{
+			Provider: &pluginmanifestv1.Entrypoint{
+				ArtifactPath: filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider")),
+			},
+		},
+	}
+	manifestData, err := pluginpkg.EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "plugin.json"), manifestData, 0644); err != nil {
 		t.Fatalf("WriteFile(plugin.json): %v", err)
 	}
 	return src
@@ -1218,6 +1268,8 @@ func newPrebuiltHybridReleaseFixture(t *testing.T, dir string) string {
 	if err := os.MkdirAll(pluginDir, 0755); err != nil {
 		t.Fatalf("MkdirAll(pluginDir): %v", err)
 	}
+	writeTestFile(t, pluginDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0644)
+	writeTestFile(t, pluginDir, prebuiltHybridArtifactPath, []byte("prebuilt-provider"), 0755)
 	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
 		Source:      prebuiltHybridSource,
 		Version:     "0.0.1",
@@ -1248,8 +1300,6 @@ func newPrebuiltHybridReleaseFixture(t *testing.T, dir string) string {
 			},
 		},
 	})
-	writeTestFile(t, pluginDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0644)
-	writeTestFile(t, pluginDir, prebuiltHybridArtifactPath, []byte("prebuilt-provider"), 0755)
 	return pluginDir
 }
 
@@ -1260,6 +1310,9 @@ func newSpecLoadedHybridReleaseFixture(t *testing.T, dir string) string {
 	if err := os.MkdirAll(pluginDir, 0755); err != nil {
 		t.Fatalf("MkdirAll(pluginDir): %v", err)
 	}
+	writeTestFile(t, pluginDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0644)
+	writeTestFile(t, pluginDir, prebuiltHybridArtifactPath, []byte("spec-loaded-hybrid-provider"), 0755)
+	writeTestFile(t, pluginDir, "specs/openapi.yaml", []byte("openapi: 3.0.0\ninfo:\n  title: Test\n  version: 1.0.0\npaths: {}\n"), 0644)
 	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
 		Source:      specLoadedHybridSource,
 		Version:     "0.0.1",
@@ -1287,9 +1340,6 @@ func newSpecLoadedHybridReleaseFixture(t *testing.T, dir string) string {
 			},
 		},
 	})
-	writeTestFile(t, pluginDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0644)
-	writeTestFile(t, pluginDir, prebuiltHybridArtifactPath, []byte("spec-loaded-hybrid-provider"), 0755)
-	writeTestFile(t, pluginDir, "specs/openapi.yaml", []byte("openapi: 3.0.0\ninfo:\n  title: Test\n  version: 1.0.0\npaths: {}\n"), 0644)
 	return pluginDir
 }
 
@@ -1388,6 +1438,7 @@ func writeReleaseTestManifest(t *testing.T, dir string, manifest *pluginmanifest
 func writeReleaseTestManifestFormat(t *testing.T, dir, manifestFile string, manifest *pluginmanifestv1.Manifest) {
 	t.Helper()
 
+	populateMissingArtifactDigests(t, dir, manifest)
 	data, err := encodeTestManifestFormat(manifest, pluginpkg.ManifestFormatFromPath(manifestFile))
 	if err != nil {
 		t.Fatalf("encodeTestManifestFormat(%s): %v", manifestFile, err)
@@ -1395,19 +1446,27 @@ func writeReleaseTestManifestFormat(t *testing.T, dir, manifestFile string, mani
 	writeTestFile(t, dir, manifestFile, data, 0644)
 }
 
-func encodeTestManifestFormat(manifest *pluginmanifestv1.Manifest, format string) ([]byte, error) {
-	switch format {
-	case pluginpkg.ManifestFormatJSON:
-		data, err := json.MarshalIndent(manifest, "", "  ")
-		if err != nil {
-			return nil, err
+func populateMissingArtifactDigests(t *testing.T, dir string, manifest *pluginmanifestv1.Manifest) {
+	t.Helper()
+
+	for i := range manifest.Artifacts {
+		if manifest.Artifacts[i].SHA256 != "" {
+			continue
 		}
-		return append(data, '\n'), nil
-	case pluginpkg.ManifestFormatYAML:
-		return yaml.Marshal(manifest)
-	default:
-		return nil, errors.New("unsupported manifest format")
+
+		path := filepath.Join(dir, filepath.FromSlash(manifest.Artifacts[i].Path))
+		data, err := os.ReadFile(path)
+		if err == nil {
+			manifest.Artifacts[i].SHA256 = sha256HexForTest(string(data))
+			continue
+		}
+
+		manifest.Artifacts[i].SHA256 = sha256HexForTest(manifest.Artifacts[i].Path)
 	}
+}
+
+func encodeTestManifestFormat(manifest *pluginmanifestv1.Manifest, format string) ([]byte, error) {
+	return pluginpkg.EncodeManifestFormat(manifest, format)
 }
 
 func writeTestFile(t *testing.T, dir, rel string, data []byte, mode os.FileMode) {

--- a/server/internal/bootstrap/validate.go
+++ b/server/internal/bootstrap/validate.go
@@ -169,6 +169,9 @@ func connectionModeFromPlugin(intg config.IntegrationDef) core.ConnectionMode {
 	if intg.Plugin == nil {
 		return core.ConnectionModeUser
 	}
+	if intg.Plugin.ConnectionMode != "" {
+		return core.ConnectionMode(intg.Plugin.ConnectionMode)
+	}
 	if intg.Plugin.Auth != nil && intg.Plugin.Auth.Type == "none" {
 		return core.ConnectionModeNone
 	}

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	Datastore    DatastoreConfig           `yaml:"datastore"`
 	Secrets      SecretsConfig             `yaml:"secrets"`
 	Telemetry    TelemetryConfig           `yaml:"telemetry"`
-	Integrations map[string]IntegrationDef `yaml:"integrations"`
+	Integrations map[string]IntegrationDef `yaml:"providers"`
 	Bindings     map[string]BindingDef     `yaml:"bindings"`
 	Server       ServerConfig              `yaml:"server"`
 	Egress       EgressConfig              `yaml:"egress"`
@@ -102,14 +102,16 @@ type PluginDef struct {
 	Config       yaml.Node `yaml:"config"`
 	AllowedHosts []string  `yaml:"allowed_hosts"`
 
-	OpenAPI           string                `yaml:"openapi"`
-	GraphQLURL        string                `yaml:"graphql_url"`
-	MCPURL            string                `yaml:"mcp_url"`
-	BaseURL           string                `yaml:"base_url"`
-	Headers           map[string]string     `yaml:"headers"`
-	ManagedParameters []ManagedParameterDef `yaml:"managed_parameters"`
+	OpenAPI              string                                         `yaml:"openapi"`
+	GraphQLURL           string                                         `yaml:"graphql_url"`
+	MCPURL               string                                         `yaml:"mcp_url"`
+	BaseURL              string                                         `yaml:"base_url"`
+	Headers              map[string]string                              `yaml:"headers"`
+	ManagedParameters    []ManagedParameterDef                          `yaml:"managed_parameters"`
+	PostConnectDiscovery *pluginmanifestv1.ProviderPostConnectDiscovery `yaml:"-"`
 
 	Auth            *ConnectionAuthDef        `yaml:"auth"`
+	ConnectionMode  string                    `yaml:"-"`
 	Connections     map[string]*ConnectionDef `yaml:"connections"`
 	Operations      []InlineOperationDef      `yaml:"operations"`
 	ResponseMapping *ResponseMappingDef       `yaml:"response_mapping"`
@@ -233,7 +235,7 @@ type IntegrationDef struct {
 	Plugin        *PluginDef `yaml:"plugin"`
 	DisplayName   string     `yaml:"display_name"`
 	Description   string     `yaml:"description"`
-	MCPToolPrefix string     `yaml:"mcp_tool_prefix"`
+	MCPToolPrefix string     `yaml:"-"`
 	IconFile      string     `yaml:"icon_file"`
 }
 
@@ -280,7 +282,9 @@ type AuthMappingDef struct {
 }
 
 type ConnectionParamDef struct {
-	Required bool `yaml:"required"`
+	Required    bool   `yaml:"required"`
+	Description string `yaml:"description"`
+	From        string `yaml:"from"`
 }
 
 // ResolveConnectionAlias maps the user-facing "plugin" alias to the
@@ -439,11 +443,17 @@ func ManifestAuthToConnectionAuthDef(auth *pluginmanifestv1.ProviderAuth) Connec
 
 func EffectivePluginConnectionDef(plugin *PluginDef, manifestProvider *pluginmanifestv1.Provider) ConnectionDef {
 	conn := ConnectionDef{}
-	if manifestProvider != nil && manifestProvider.Auth != nil {
-		MergeConnectionAuth(&conn.Auth, ManifestAuthToConnectionAuthDef(manifestProvider.Auth))
+	if manifestProvider != nil {
+		conn.Mode = manifestProvider.ConnectionMode
+		if manifestProvider.Auth != nil {
+			MergeConnectionAuth(&conn.Auth, ManifestAuthToConnectionAuthDef(manifestProvider.Auth))
+		}
 	}
 	if plugin != nil {
-		override := &ConnectionDef{ConnectionParams: plugin.ConnectionParams}
+		override := &ConnectionDef{
+			Mode:             plugin.ConnectionMode,
+			ConnectionParams: plugin.ConnectionParams,
+		}
 		if plugin.Auth != nil {
 			override.Auth = *plugin.Auth
 		}

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -42,10 +42,10 @@ datastore:
 server:
   encryption_key: server-key
   port: 9090
-integrations:
+providers:
   service-a:
     display_name: Service A
-    plugin:
+    from:
       command: /tmp/provider
 `)
 
@@ -90,9 +90,9 @@ datastore:
   provider: data-store
 server:
   encryption_key: ${TEST_ENCRYPTION}
-integrations:
+providers:
   service-a:
-    plugin:
+    from:
       command: /tmp/provider
 `)
 
@@ -225,9 +225,9 @@ func TestLoadSucceedsWithoutRuntimeFields(t *testing.T) {
 	t.Parallel()
 
 	path := mustWriteConfigFile(t, `
-integrations:
+providers:
   custom_tool:
-    plugin:
+    from:
       package: https://example.com/custom-tool.tar.gz
 `)
 
@@ -248,9 +248,9 @@ func TestLoadConfigValidation(t *testing.T) {
 		yaml string
 	}{
 		{
-			name: "integration with no plugin",
+			name: "provider with no source or surfaces",
 			yaml: `
-integrations:
+providers:
   service-a:
     display_name: Service A
 `,
@@ -286,46 +286,50 @@ func TestValidConfigurations(t *testing.T) {
 		{
 			name: "plugin only",
 			yaml: `
-integrations:
+providers:
   custom_tool:
-    plugin:
+    from:
       package: https://example.com/custom-tool.tar.gz
 `,
 		},
 		{
 			name: "plugin with command",
 			yaml: `
-integrations:
+providers:
   service:
-    plugin:
+    from:
       command: /usr/bin/provider
 `,
 		},
 		{
 			name: "inline plugin with openapi",
 			yaml: `
-integrations:
+providers:
   service:
-    plugin:
-      openapi: https://example.test/spec.json
-      base_url: https://api.example.test
-      auth:
-        type: oauth2
-        authorization_url: https://example.test/auth
-        token_url: https://example.test/token
+    connections:
+      default:
+        auth:
+          type: oauth2
+          authorization_url: https://example.test/auth
+          token_url: https://example.test/token
+    surfaces:
+      openapi:
+        document: https://example.test/spec.json
+        base_url: https://api.example.test
 `,
 		},
 		{
 			name: "inline plugin with operations",
 			yaml: `
-integrations:
+providers:
   service:
-    plugin:
-      base_url: https://api.example.test
-      operations:
-        - name: list_users
-          method: GET
-          path: /users
+    surfaces:
+      rest:
+        base_url: https://api.example.test
+        operations:
+          - name: list_users
+            method: GET
+            path: /users
 `,
 		},
 	}
@@ -353,18 +357,18 @@ func TestPluginValidation(t *testing.T) {
 		{
 			name: "integration plugin package is valid",
 			yaml: `
-integrations:
+providers:
   external:
-    plugin:
+    from:
       package: ./plugins/dummy.tar.gz
 `,
 		},
 		{
 			name: "plugin package and command are mutually exclusive",
 			yaml: `
-integrations:
+providers:
   external:
-    plugin:
+    from:
       command: /tmp/plugin
       package: ./plugins/dummy.tar.gz
 `,
@@ -373,9 +377,9 @@ integrations:
 		{
 			name: "plugin args require command not package",
 			yaml: `
-integrations:
+providers:
   external:
-    plugin:
+    from:
       package: ./plugins/dummy.tar.gz
       args:
         - --verbose
@@ -385,9 +389,9 @@ integrations:
 		{
 			name: "plugin env with package is valid",
 			yaml: `
-integrations:
+providers:
   external:
-    plugin:
+    from:
       package: ./plugins/dummy.tar.gz
       env:
         FOO: bar
@@ -396,29 +400,29 @@ integrations:
 		{
 			name: "plugin config with package is valid",
 			yaml: `
-integrations:
+providers:
   external:
-    plugin:
+    from:
       package: ./plugins/dummy.tar.gz
-      config:
-        base_url: https://example.com
+    config:
+      base_url: https://example.com
 `,
 		},
 		{
 			name: "plugin command or package is required for external",
 			yaml: `
-integrations:
+providers:
   external:
-    plugin: {}
+    {}
 `,
 			wantErr: true,
 		},
 		{
 			name: "plugin package with version is rejected",
 			yaml: `
-integrations:
+providers:
   external:
-    plugin:
+    from:
       package: ./plugins/dummy.tar.gz
       version: 1.0.0
 `,
@@ -427,9 +431,9 @@ integrations:
 		{
 			name: "plugin source with version is valid",
 			yaml: `
-integrations:
+providers:
   external:
-    plugin:
+    from:
       source: github.com/acme-corp/tools/widget
       version: 1.2.3
 `,
@@ -437,9 +441,9 @@ integrations:
 		{
 			name: "plugin source without version is rejected",
 			yaml: `
-integrations:
+providers:
   external:
-    plugin:
+    from:
       source: github.com/acme-corp/tools/widget
 `,
 			wantErr: true,
@@ -622,16 +626,16 @@ func TestLoadConfigResolvesRelativePaths(t *testing.T) {
 		t.Fatalf("MkdirAll config dir: %v", err)
 	}
 	if err := os.WriteFile(cfgPath, []byte(`
-integrations:
+providers:
   service-a:
     icon_file: ../assets/service.svg
-    plugin:
+    from:
       command: ../bin/provider
   service-b:
-    plugin:
+    from:
       package: ../plugins/dummy.tar.gz
   service-c:
-    plugin:
+    from:
       package: https://example.com/dummy.tar.gz
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile config: %v", err)
@@ -745,9 +749,9 @@ func TestLoad_ResolvesRelativePluginPackagePath(t *testing.T) {
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := `integrations:
+	cfg := `providers:
   sample:
-    plugin:
+    from:
       package: ./my-plugin
 `
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {

--- a/server/internal/config/inline_manifest.go
+++ b/server/internal/config/inline_manifest.go
@@ -15,17 +15,19 @@ func InlineToManifest(name string, p *PluginDef) (*pluginmanifestv1.Manifest, er
 		DisplayName: name,
 		Kinds:       []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
-			BaseURL:           p.BaseURL,
-			Headers:           NormalizeHeaders(p.Headers),
-			ManagedParameters: NormalizeManagedParameters(p.ManagedParameters),
-			MCP:               p.MCP,
-			OpenAPI:           p.OpenAPI,
-			GraphQLURL:        p.GraphQLURL,
-			MCPURL:            p.MCPURL,
-			OpenAPIConnection: p.OpenAPIConnection,
-			GraphQLConnection: p.GraphQLConnection,
-			MCPConnection:     p.MCPConnection,
-			DefaultConnection: p.DefaultConnection,
+			BaseURL:              p.BaseURL,
+			Headers:              NormalizeHeaders(p.Headers),
+			ManagedParameters:    NormalizeManagedParameters(p.ManagedParameters),
+			ConnectionMode:       p.ConnectionMode,
+			MCP:                  p.MCP,
+			OpenAPI:              p.OpenAPI,
+			GraphQLURL:           p.GraphQLURL,
+			MCPURL:               p.MCPURL,
+			OpenAPIConnection:    p.OpenAPIConnection,
+			GraphQLConnection:    p.GraphQLConnection,
+			MCPConnection:        p.MCPConnection,
+			DefaultConnection:    p.DefaultConnection,
+			PostConnectDiscovery: p.PostConnectDiscovery,
 		},
 	}
 
@@ -90,7 +92,9 @@ func InlineToManifest(name string, p *PluginDef) (*pluginmanifestv1.Manifest, er
 		manifest.Provider.ConnectionParams = make(map[string]pluginmanifestv1.ProviderConnectionParam, len(p.ConnectionParams))
 		for k, v := range p.ConnectionParams {
 			manifest.Provider.ConnectionParams[k] = pluginmanifestv1.ProviderConnectionParam{
-				Required: v.Required,
+				Required:    v.Required,
+				Description: v.Description,
+				From:        v.From,
 			}
 		}
 	}

--- a/server/internal/config/provider_wire.go
+++ b/server/internal/config/provider_wire.go
@@ -1,0 +1,311 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+	"gopkg.in/yaml.v3"
+)
+
+type providerWire struct {
+	DisplayName       string                             `yaml:"display_name"`
+	Description       string                             `yaml:"description"`
+	IconFile          string                             `yaml:"icon_file"`
+	Config            yaml.Node                          `yaml:"config"`
+	From              providerSourceWire                 `yaml:"from"`
+	Connections       map[string]*providerConnectionWire `yaml:"connections"`
+	Headers           map[string]string                  `yaml:"headers"`
+	ManagedParameters []ManagedParameterDef              `yaml:"managed_parameters"`
+	ResponseMapping   *ResponseMappingDef                `yaml:"response_mapping"`
+	AllowedOperations map[string]*OperationOverride      `yaml:"allowed_operations"`
+	Surfaces          providerSurfacesWire               `yaml:"surfaces"`
+	MCP               *providerMCPWire                   `yaml:"mcp"`
+}
+
+type providerSourceWire struct {
+	Command      string            `yaml:"command"`
+	Package      string            `yaml:"package"`
+	Source       string            `yaml:"source"`
+	Version      string            `yaml:"version"`
+	Args         []string          `yaml:"args"`
+	Env          map[string]string `yaml:"env"`
+	AllowedHosts []string          `yaml:"allowed_hosts"`
+}
+
+type providerConnectionWire struct {
+	Mode      string                        `yaml:"mode"`
+	Auth      ConnectionAuthDef             `yaml:"auth"`
+	Params    map[string]ConnectionParamDef `yaml:"params"`
+	Discovery *providerDiscoveryWire        `yaml:"discovery"`
+}
+
+type providerDiscoveryWire struct {
+	URL      string            `yaml:"url"`
+	IDPath   string            `yaml:"id_path"`
+	NamePath string            `yaml:"name_path"`
+	Metadata map[string]string `yaml:"metadata"`
+}
+
+type providerSurfacesWire struct {
+	REST    *providerRESTSurfaceWire    `yaml:"rest"`
+	OpenAPI *providerOpenAPISurfaceWire `yaml:"openapi"`
+	GraphQL *providerGraphQLSurfaceWire `yaml:"graphql"`
+	MCP     *providerMCPSurfaceWire     `yaml:"mcp"`
+}
+
+type providerRESTSurfaceWire struct {
+	Connection string               `yaml:"connection"`
+	BaseURL    string               `yaml:"base_url"`
+	Operations []InlineOperationDef `yaml:"operations"`
+}
+
+type providerOpenAPISurfaceWire struct {
+	Connection string `yaml:"connection"`
+	Document   string `yaml:"document"`
+	BaseURL    string `yaml:"base_url"`
+}
+
+type providerGraphQLSurfaceWire struct {
+	Connection string `yaml:"connection"`
+	URL        string `yaml:"url"`
+}
+
+type providerMCPSurfaceWire struct {
+	Connection string `yaml:"connection"`
+	URL        string `yaml:"url"`
+}
+
+type providerMCPWire struct {
+	Enabled    bool   `yaml:"enabled"`
+	ToolPrefix string `yaml:"tool_prefix"`
+}
+
+func (i *IntegrationDef) UnmarshalYAML(value *yaml.Node) error {
+	data, err := yaml.Marshal(value)
+	if err != nil {
+		return err
+	}
+
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+
+	var wire providerWire
+	if err := dec.Decode(&wire); err != nil {
+		return err
+	}
+	if err := validateProviderWire(&wire); err != nil {
+		return err
+	}
+
+	plugin := &PluginDef{
+		Command:           wire.From.Command,
+		Package:           wire.From.Package,
+		Source:            wire.From.Source,
+		Version:           wire.From.Version,
+		Args:              wire.From.Args,
+		Env:               wire.From.Env,
+		Config:            wire.Config,
+		AllowedHosts:      wire.From.AllowedHosts,
+		Headers:           wire.Headers,
+		ManagedParameters: wire.ManagedParameters,
+		ResponseMapping:   wire.ResponseMapping,
+		AllowedOperations: wire.AllowedOperations,
+	}
+	if wire.MCP != nil {
+		plugin.MCP = wire.MCP.Enabled
+	}
+
+	defaultConn, hasDefault := wire.Connections["default"]
+	if hasDefault && defaultConn != nil {
+		auth := defaultConn.Auth
+		plugin.Auth = &auth
+		plugin.ConnectionMode = defaultConn.Mode
+		plugin.ConnectionParams = defaultConn.Params
+		plugin.PostConnectDiscovery = defaultConn.toManifestDiscovery()
+	}
+
+	if len(wire.Connections) > 0 {
+		plugin.Connections = make(map[string]*ConnectionDef, len(wire.Connections))
+		for name, conn := range wire.Connections {
+			if name == "default" {
+				continue
+			}
+			if conn == nil {
+				plugin.Connections[name] = nil
+				continue
+			}
+			plugin.Connections[name] = &ConnectionDef{
+				Mode: conn.Mode,
+				Auth: conn.Auth,
+			}
+		}
+		if len(plugin.Connections) == 0 {
+			plugin.Connections = nil
+		}
+	}
+
+	if wire.Surfaces.REST != nil {
+		plugin.BaseURL = wire.Surfaces.REST.BaseURL
+		plugin.Operations = wire.Surfaces.REST.Operations
+		if defaultConnection := remapWireConnectionName(wire.Surfaces.REST.Connection); defaultConnection != "" {
+			plugin.DefaultConnection = defaultConnection
+		} else if hasDefault && len(plugin.Connections) > 0 {
+			plugin.DefaultConnection = PluginConnectionAlias
+		}
+	}
+	if wire.Surfaces.OpenAPI != nil {
+		plugin.OpenAPI = wire.Surfaces.OpenAPI.Document
+		if wire.Surfaces.OpenAPI.BaseURL != "" {
+			plugin.BaseURL = wire.Surfaces.OpenAPI.BaseURL
+		}
+		plugin.OpenAPIConnection = remapWireConnectionName(wire.Surfaces.OpenAPI.Connection)
+	}
+	if wire.Surfaces.GraphQL != nil {
+		plugin.GraphQLURL = wire.Surfaces.GraphQL.URL
+		plugin.GraphQLConnection = remapWireConnectionName(wire.Surfaces.GraphQL.Connection)
+	}
+	if wire.Surfaces.MCP != nil {
+		plugin.MCPURL = wire.Surfaces.MCP.URL
+		plugin.MCPConnection = remapWireConnectionName(wire.Surfaces.MCP.Connection)
+	}
+
+	*i = IntegrationDef{
+		Plugin:      plugin,
+		DisplayName: wire.DisplayName,
+		Description: wire.Description,
+		IconFile:    wire.IconFile,
+	}
+	if wire.MCP != nil {
+		i.MCPToolPrefix = wire.MCP.ToolPrefix
+	}
+	return nil
+}
+
+func validateProviderWire(wire *providerWire) error {
+	apiSurfaceCount := 0
+	if wire.Surfaces.REST != nil {
+		apiSurfaceCount++
+	}
+	if wire.Surfaces.OpenAPI != nil {
+		apiSurfaceCount++
+	}
+	if wire.Surfaces.GraphQL != nil {
+		apiSurfaceCount++
+	}
+	if apiSurfaceCount > 1 {
+		return fmt.Errorf("provider config can define only one of surfaces.rest, surfaces.openapi, or surfaces.graphql")
+	}
+	if wire.Surfaces.REST != nil && wire.Surfaces.REST.BaseURL == "" {
+		return fmt.Errorf("surfaces.rest.base_url is required when surfaces.rest is configured")
+	}
+	if wire.Surfaces.REST != nil && len(wire.Surfaces.REST.Operations) == 0 {
+		return fmt.Errorf("surfaces.rest.operations is required when surfaces.rest is configured")
+	}
+	if wire.Surfaces.OpenAPI != nil && wire.Surfaces.OpenAPI.Document == "" {
+		return fmt.Errorf("surfaces.openapi.document is required when surfaces.openapi is configured")
+	}
+	if wire.Surfaces.GraphQL != nil && wire.Surfaces.GraphQL.URL == "" {
+		return fmt.Errorf("surfaces.graphql.url is required when surfaces.graphql is configured")
+	}
+	if wire.Surfaces.MCP != nil && wire.Surfaces.MCP.URL == "" {
+		return fmt.Errorf("surfaces.mcp.url is required when surfaces.mcp is configured")
+	}
+	if wire.MCP != nil && wire.MCP.ToolPrefix != "" && !wire.MCP.Enabled {
+		return fmt.Errorf("mcp.tool_prefix is only valid when mcp.enabled is true")
+	}
+
+	hasDefaultConnection := false
+	hasNamedConnections := false
+	for name, conn := range wire.Connections {
+		if conn == nil {
+			if name == "default" {
+				hasDefaultConnection = true
+			} else {
+				hasNamedConnections = true
+			}
+			continue
+		}
+		if name == "default" {
+			hasDefaultConnection = true
+		} else {
+			hasNamedConnections = true
+		}
+		if name != "default" {
+			if len(conn.Params) > 0 {
+				return fmt.Errorf("connections.%s.params are only supported on connections.default", name)
+			}
+			if conn.Discovery != nil {
+				return fmt.Errorf("connections.%s.discovery is only supported on connections.default", name)
+			}
+		}
+	}
+
+	if hasNamedConnections && !hasDefaultConnection {
+		if wire.Surfaces.REST != nil && wire.Surfaces.REST.Connection == "" {
+			return fmt.Errorf("surfaces.rest.connection is required when using named connections without connections.default")
+		}
+		if wire.Surfaces.OpenAPI != nil && wire.Surfaces.OpenAPI.Connection == "" {
+			return fmt.Errorf("surfaces.openapi.connection is required when using named connections without connections.default")
+		}
+		if wire.Surfaces.GraphQL != nil && wire.Surfaces.GraphQL.Connection == "" {
+			return fmt.Errorf("surfaces.graphql.connection is required when using named connections without connections.default")
+		}
+		if wire.Surfaces.MCP != nil && wire.Surfaces.MCP.Connection == "" {
+			return fmt.Errorf("surfaces.mcp.connection is required when using named connections without connections.default")
+		}
+	}
+
+	checkConnectionRef := func(fieldPath, name string) error {
+		if name == "" {
+			return nil
+		}
+		if _, ok := wire.Connections[name]; !ok {
+			return fmt.Errorf("%s references undeclared connection %q", fieldPath, name)
+		}
+		return nil
+	}
+	if wire.Surfaces.REST != nil {
+		if err := checkConnectionRef("surfaces.rest.connection", wire.Surfaces.REST.Connection); err != nil {
+			return err
+		}
+	}
+	if wire.Surfaces.OpenAPI != nil {
+		if err := checkConnectionRef("surfaces.openapi.connection", wire.Surfaces.OpenAPI.Connection); err != nil {
+			return err
+		}
+	}
+	if wire.Surfaces.GraphQL != nil {
+		if err := checkConnectionRef("surfaces.graphql.connection", wire.Surfaces.GraphQL.Connection); err != nil {
+			return err
+		}
+	}
+	if wire.Surfaces.MCP != nil {
+		if err := checkConnectionRef("surfaces.mcp.connection", wire.Surfaces.MCP.Connection); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (w *providerConnectionWire) toManifestDiscovery() *pluginmanifestv1.ProviderPostConnectDiscovery {
+	if w == nil || w.Discovery == nil {
+		return nil
+	}
+	return &pluginmanifestv1.ProviderPostConnectDiscovery{
+		URL:             w.Discovery.URL,
+		IDPath:          w.Discovery.IDPath,
+		NamePath:        w.Discovery.NamePath,
+		MetadataMapping: w.Discovery.Metadata,
+	}
+}
+
+func remapWireConnectionName(name string) string {
+	switch name {
+	case "", "default":
+		return ""
+	default:
+		return name
+	}
+}

--- a/server/internal/operator/lifecycle_source_test.go
+++ b/server/internal/operator/lifecycle_source_test.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
 	ghresolver "github.com/valon-technologies/gestalt/server/internal/pluginsource/github"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
@@ -78,11 +79,10 @@ func buildV2Archive(t *testing.T, dir, source, version, binaryContent string) st
 		},
 	}
 
-	manifestBytes, err := json.MarshalIndent(manifest, "", "  ")
+	manifestBytes, err := pluginpkg.EncodeManifest(manifest)
 	if err != nil {
-		t.Fatalf("marshal manifest: %v", err)
+		t.Fatalf("encode manifest: %v", err)
 	}
-	manifestBytes = append(manifestBytes, '\n')
 
 	archivePath := filepath.Join(dir, "plugin.tar.gz")
 	f, err := os.Create(archivePath)
@@ -116,9 +116,9 @@ func writeConfigYAML(t *testing.T, dir, source, version string) string {
 	t.Helper()
 
 	yaml := strings.Join([]string{
-		"integrations:",
+		"providers:",
 		"  alpha:",
-		"    plugin:",
+		"    from:",
 		"      source: " + source,
 		"      version: " + version,
 	}, "\n") + "\n"
@@ -359,9 +359,9 @@ func TestSourcePluginLoadForExecution(t *testing.T) {
 		"    path: " + filepath.Join(dir, "data.db"),
 		"server:",
 		"  encryption_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		"integrations:",
+		"providers:",
 		"  gadget:",
-		"    plugin:",
+		"    from:",
 		"      source: " + source,
 		"      version: " + version,
 	}, "\n") + "\n"
@@ -442,9 +442,9 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 		"    path: " + filepath.Join(dir, "data.db"),
 		"server:",
 		"  encryption_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		"integrations:",
+		"providers:",
 		"  alpha:",
-		"    plugin:",
+		"    from:",
 		"      source: " + testSource,
 		"      version: " + testVersion,
 	}, "\n") + "\n"

--- a/server/internal/operator/lifecycle_test.go
+++ b/server/internal/operator/lifecycle_test.go
@@ -54,9 +54,9 @@ func writeTestConfig(t *testing.T, dir, packagePath string) string {
 	t.Helper()
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := `integrations:
+	cfg := `providers:
   example:
-    plugin:
+    from:
       package: ` + packagePath + `
 `
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {
@@ -146,9 +146,9 @@ func TestLockMatchesConfig_FalseWhenPackageChanged(t *testing.T) {
 	if err := os.MkdirAll(altDir, 0755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	cfg := `integrations:
+	cfg := `providers:
   example:
-    plugin:
+    from:
       package: ` + altDir + `
 `
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {

--- a/server/internal/pluginpkg/archive_test.go
+++ b/server/internal/pluginpkg/archive_test.go
@@ -73,26 +73,8 @@ func TestCreatePackageFromDirAndReadManifest(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(src, "artifacts", "darwin", "arm64", "provider"), []byte("provider"), 0755); err != nil {
 		t.Fatalf("WriteFile(provider): %v", err)
 	}
-	manifest := `{
-  "source": "github.com/acme/plugins/provider",
-  "version": "0.1.0",
-  "kinds": ["provider"],
-  "provider": {},
-  "artifacts": [
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "artifacts/darwin/arm64/provider",
-      "sha256": "` + sha256Hex("provider") + `"
-    }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "artifacts/darwin/arm64/provider"
-    }
-  }
-}`
-	if err := os.WriteFile(filepath.Join(src, ManifestFile), []byte(manifest), 0644); err != nil {
+	manifest := mustManifestJSON(t, mustProviderManifest("github.com/acme/plugins/provider", "0.1.0", "darwin", "arm64", "artifacts/darwin/arm64/provider", sha256Hex("provider")))
+	if err := os.WriteFile(filepath.Join(src, ManifestFile), manifest, 0644); err != nil {
 		t.Fatalf("WriteFile(plugin.json): %v", err)
 	}
 

--- a/server/internal/pluginpkg/manifest.go
+++ b/server/internal/pluginpkg/manifest.go
@@ -87,59 +87,56 @@ func DecodeManifest(data []byte) (*pluginmanifestv1.Manifest, error) {
 }
 
 func DecodeSourceManifestFormat(data []byte, format string) (*pluginmanifestv1.Manifest, error) {
-	jsonData := data
-	if format == ManifestFormatYAML {
-		var err error
-		jsonData, err = yamlToJSON(data)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return decodeManifestJSON(jsonData, true)
+	return decodeManifest(data, format, true)
 }
 
 func DecodeManifestFormat(data []byte, format string) (*pluginmanifestv1.Manifest, error) {
+	return decodeManifest(data, format, false)
+}
+
+func decodeManifest(data []byte, format string, allowMissingArtifactDigests bool) (*pluginmanifestv1.Manifest, error) {
+	wire, err := decodeManifestWire(data, format)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateManifestSchema(data, format); err != nil {
+		return nil, fmt.Errorf("manifest validation failed: %w", err)
+	}
+	manifest := wireManifestToInternal(wire)
+	if err := validateManifest(manifest, allowMissingArtifactDigests); err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+func validateManifestSchema(data []byte, format string) error {
 	jsonData := data
 	if format == ManifestFormatYAML {
 		var err error
 		jsonData, err = yamlToJSON(data)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
-	return decodeManifestJSON(jsonData, false)
-}
 
-func decodeManifestJSON(data []byte, allowMissingArtifactDigests bool) (*pluginmanifestv1.Manifest, error) {
 	var doc any
-	if err := json.Unmarshal(data, &doc); err != nil {
-		return nil, fmt.Errorf("parse manifest JSON: %w", err)
+	if err := json.Unmarshal(jsonData, &doc); err != nil {
+		return fmt.Errorf("parse manifest JSON: %w", err)
 	}
 	var schemaDoc any
 	if err := json.Unmarshal(pluginmanifestv1.ManifestJSONSchema, &schemaDoc); err != nil {
-		return nil, fmt.Errorf("parse embedded manifest schema: %w", err)
+		return fmt.Errorf("parse embedded manifest schema: %w", err)
 	}
 
 	compiler := jsonschema.NewCompiler()
 	if err := compiler.AddResource("manifest.schema.json", schemaDoc); err != nil {
-		return nil, fmt.Errorf("load manifest schema: %w", err)
+		return fmt.Errorf("load manifest schema: %w", err)
 	}
 	schema, err := compiler.Compile("manifest.schema.json")
 	if err != nil {
-		return nil, fmt.Errorf("compile manifest schema: %w", err)
+		return fmt.Errorf("compile manifest schema: %w", err)
 	}
-	if err := schema.Validate(doc); err != nil {
-		return nil, fmt.Errorf("manifest validation failed: %w", err)
-	}
-
-	var manifest pluginmanifestv1.Manifest
-	if err := json.Unmarshal(data, &manifest); err != nil {
-		return nil, fmt.Errorf("decode manifest: %w", err)
-	}
-	if err := validateManifest(&manifest, allowMissingArtifactDigests); err != nil {
-		return nil, err
-	}
-	return &manifest, nil
+	return schema.Validate(doc)
 }
 
 func ValidateManifest(manifest *pluginmanifestv1.Manifest) error {
@@ -395,7 +392,8 @@ func EncodeManifestFormat(manifest *pluginmanifestv1.Manifest, format string) ([
 }
 
 func encodeManifestJSON(manifest *pluginmanifestv1.Manifest) ([]byte, error) {
-	data, err := json.MarshalIndent(manifest, "", "  ")
+	wire := internalManifestToWire(manifest)
+	data, err := json.MarshalIndent(wire, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("marshal manifest: %w", err)
 	}
@@ -403,7 +401,8 @@ func encodeManifestJSON(manifest *pluginmanifestv1.Manifest) ([]byte, error) {
 }
 
 func encodeManifestYAML(manifest *pluginmanifestv1.Manifest) ([]byte, error) {
-	data, err := yaml.Marshal(manifest)
+	wire := internalManifestToWire(manifest)
+	data, err := yaml.Marshal(wire)
 	if err != nil {
 		return nil, fmt.Errorf("marshal manifest YAML: %w", err)
 	}

--- a/server/internal/pluginpkg/manifest_test.go
+++ b/server/internal/pluginpkg/manifest_test.go
@@ -1,39 +1,64 @@
 package pluginpkg
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+	"gopkg.in/yaml.v3"
 )
+
+func mustProviderManifest(source, version, osName, arch, artifactPath, sha string) *manifestWire {
+	return &manifestWire{
+		Source:  source,
+		Version: version,
+		Provider: &providerManifestWire{
+			Exec:     &providerExecWire{ArtifactPath: artifactPath},
+			Surfaces: providerManifestSurfacesWire{},
+		},
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     osName,
+				Arch:   arch,
+				Path:   artifactPath,
+				SHA256: sha,
+			},
+		},
+	}
+}
+
+func mustManifestJSON(t *testing.T, wire *manifestWire) []byte {
+	t.Helper()
+	return mustManifestJSONBytes(wire)
+}
+
+func mustManifestYAML(t *testing.T, wire *manifestWire) []byte {
+	t.Helper()
+	data, err := yaml.Marshal(wire)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	return data
+}
+
+func mustManifestJSONBytes(wire *manifestWire) []byte {
+	data, err := json.MarshalIndent(wire, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	return append(data, '\n')
+}
 
 func TestDecodeManifest_ValidProviderManifest(t *testing.T) {
 	t.Parallel()
 
-	data := []byte(`{
-  "source": "github.com/acme/plugins/provider",
-  "version": "0.1.0",
-  "kinds": ["provider"],
-  "provider": {
-    "config_schema_path": "schemas/config.schema.json"
-  },
-  "artifacts": [
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "artifacts/darwin/arm64/provider",
-      "sha256": "` + sha256Hex("provider") + `"
-    }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "artifacts/darwin/arm64/provider",
-      "args": []
-    }
-  }
-}`)
+	wire := mustProviderManifest("github.com/acme/plugins/provider", "0.1.0", "darwin", "arm64", "artifacts/darwin/arm64/provider", sha256Hex("provider"))
+	wire.Provider.ConfigSchemaPath = "schemas/config.schema.json"
+	wire.Provider.Exec.Args = []string{}
+	data := mustManifestJSON(t, wire)
 
 	manifest, err := DecodeManifest(data)
 	if err != nil {
@@ -47,25 +72,9 @@ func TestDecodeManifest_ValidProviderManifest(t *testing.T) {
 func TestDecodeManifest_RejectsMissingEntrypointArtifact(t *testing.T) {
 	t.Parallel()
 
-	data := []byte(`{
-  "source": "github.com/acme/plugins/provider",
-  "version": "0.1.0",
-  "kinds": ["provider"],
-  "provider": {},
-  "artifacts": [
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "artifacts/darwin/arm64/provider",
-      "sha256": "` + sha256Hex("provider") + `"
-    }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "artifacts/linux/amd64/provider"
-    }
-  }
-}`)
+	wire := mustProviderManifest("github.com/acme/plugins/provider", "0.1.0", "darwin", "arm64", "artifacts/darwin/arm64/provider", sha256Hex("provider"))
+	wire.Provider.Exec.ArtifactPath = "artifacts/linux/amd64/provider"
+	data := mustManifestJSON(t, wire)
 
 	_, err := DecodeManifest(data)
 	if err == nil {
@@ -76,24 +85,8 @@ func TestDecodeManifest_RejectsMissingEntrypointArtifact(t *testing.T) {
 func TestDecodeManifest_RejectsMissingArtifactSHA256(t *testing.T) {
 	t.Parallel()
 
-	data := []byte(`{
-  "source": "github.com/acme/plugins/provider",
-  "version": "0.1.0",
-  "kinds": ["provider"],
-  "provider": {},
-  "artifacts": [
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "artifacts/darwin/arm64/provider"
-    }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "artifacts/darwin/arm64/provider"
-    }
-  }
-}`)
+	wire := mustProviderManifest("github.com/acme/plugins/provider", "0.1.0", "darwin", "arm64", "artifacts/darwin/arm64/provider", "")
+	data := mustManifestJSON(t, wire)
 
 	_, err := DecodeManifest(data)
 	if err == nil {
@@ -107,24 +100,8 @@ func TestDecodeManifest_RejectsMissingArtifactSHA256(t *testing.T) {
 func TestDecodeSourceManifest_AllowsMissingArtifactSHA256(t *testing.T) {
 	t.Parallel()
 
-	data := []byte(`{
-  "source": "github.com/acme/plugins/provider",
-  "version": "0.1.0",
-  "kinds": ["provider"],
-  "provider": {},
-  "artifacts": [
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "artifacts/darwin/arm64/provider"
-    }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "artifacts/darwin/arm64/provider"
-    }
-  }
-}`)
+	wire := mustProviderManifest("github.com/acme/plugins/provider", "0.1.0", "darwin", "arm64", "artifacts/darwin/arm64/provider", "")
+	data := mustManifestJSON(t, wire)
 
 	manifest, err := DecodeSourceManifestFormat(data, "json")
 	if err != nil {
@@ -201,25 +178,7 @@ func TestEncodeManifest_SpecLoadedProviderDoesNotRequireEntrypoint(t *testing.T)
 }
 
 func validV2JSON() []byte {
-	return []byte(`{
-  "source": "github.com/acme/plugins/echo",
-  "version": "1.0.0",
-  "kinds": ["provider"],
-  "provider": {},
-  "artifacts": [
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "artifacts/darwin/arm64/provider",
-      "sha256": "` + sha256Hex("provider") + `"
-    }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "artifacts/darwin/arm64/provider"
-    }
-  }
-}`)
+	return mustManifestJSONBytes(mustProviderManifest("github.com/acme/plugins/echo", "1.0.0", "darwin", "arm64", "artifacts/darwin/arm64/provider", sha256Hex("provider")))
 }
 
 func TestDecodeManifest_V2ValidSource(t *testing.T) {
@@ -277,8 +236,11 @@ func TestDecodeManifest_RejectsUnknownField(t *testing.T) {
   "source": "github.com/acme/plugins/echo",
   "id": "acme/echo",
   "version": "1.0.0",
-  "kinds": ["provider"],
-  "provider": {},
+  "provider": {
+    "exec": {
+      "artifact_path": "artifacts/darwin/arm64/provider"
+    }
+  },
   "artifacts": [
     {
       "os": "darwin",
@@ -286,12 +248,7 @@ func TestDecodeManifest_RejectsUnknownField(t *testing.T) {
       "path": "artifacts/darwin/arm64/provider",
       "sha256": "` + sha256Hex("provider") + `"
     }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "artifacts/darwin/arm64/provider"
-    }
-  }
+  ]
 }`)
 
 	_, err := DecodeManifest(data)
@@ -315,25 +272,8 @@ func TestDecodeManifest_V2RejectsInvalidSource(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			data := []byte(`{
-  "source": "` + tc.source + `",
-  "version": "1.0.0",
-  "kinds": ["provider"],
-  "provider": {},
-  "artifacts": [
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "artifacts/darwin/arm64/provider",
-      "sha256": "` + sha256Hex("provider") + `"
-    }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "artifacts/darwin/arm64/provider"
-    }
-  }
-}`)
+			wire := mustProviderManifest(tc.source, "1.0.0", "darwin", "arm64", "artifacts/darwin/arm64/provider", sha256Hex("provider"))
+			data := mustManifestJSON(t, wire)
 
 			_, err := DecodeManifest(data)
 			if err == nil {
@@ -346,25 +286,8 @@ func TestDecodeManifest_V2RejectsInvalidSource(t *testing.T) {
 func TestDecodeManifest_V2RejectsLeadingVVersion(t *testing.T) {
 	t.Parallel()
 
-	data := []byte(`{
-  "source": "github.com/acme/plugins/echo",
-  "version": "v1.0.0",
-  "kinds": ["provider"],
-  "provider": {},
-  "artifacts": [
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "artifacts/darwin/arm64/provider",
-      "sha256": "` + sha256Hex("provider") + `"
-    }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "artifacts/darwin/arm64/provider"
-    }
-  }
-}`)
+	wire := mustProviderManifest("github.com/acme/plugins/echo", "v1.0.0", "darwin", "arm64", "artifacts/darwin/arm64/provider", sha256Hex("provider"))
+	data := mustManifestJSON(t, wire)
 
 	_, err := DecodeManifest(data)
 	if err == nil {
@@ -372,51 +295,24 @@ func TestDecodeManifest_V2RejectsLeadingVVersion(t *testing.T) {
 	}
 }
 
-func TestDecodeManifest_V2RejectsUnsupportedKind(t *testing.T) {
+func TestDecodeManifest_RejectsProviderAndWebUICombination(t *testing.T) {
 	t.Parallel()
 
-	data := []byte(`{
-  "source": "github.com/test-org/test-repo/test-plugin",
-  "version": "1.0.0",
-  "kinds": ["unknown_kind"],
-  "artifacts": [
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "artifacts/darwin/arm64/provider",
-      "sha256": "` + sha256Hex("provider") + `"
-    }
-  ],
-  "entrypoints": {}
-}`)
+	wire := mustProviderManifest("github.com/test-org/test-repo/test-plugin", "1.0.0", "darwin", "arm64", "artifacts/darwin/arm64/provider", sha256Hex("provider"))
+	wire.WebUI = &pluginmanifestv1.WebUIMetadata{AssetRoot: "out"}
+	data := mustManifestJSON(t, wire)
 
 	_, err := DecodeManifest(data)
 	if err == nil {
-		t.Fatal("expected error for unsupported kind")
+		t.Fatal("expected error for provider+webui manifest")
 	}
 }
 
 func TestDecodeManifest_V2RejectsMissingSource(t *testing.T) {
 	t.Parallel()
 
-	data := []byte(`{
-  "version": "1.0.0",
-  "kinds": ["provider"],
-  "provider": {},
-  "artifacts": [
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "artifacts/darwin/arm64/provider",
-      "sha256": "` + sha256Hex("provider") + `"
-    }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "artifacts/darwin/arm64/provider"
-    }
-  }
-}`)
+	wire := mustProviderManifest("", "1.0.0", "darwin", "arm64", "artifacts/darwin/arm64/provider", sha256Hex("provider"))
+	data := mustManifestJSON(t, wire)
 
 	_, err := DecodeManifest(data)
 	if err == nil {
@@ -427,31 +323,14 @@ func TestDecodeManifest_V2RejectsMissingSource(t *testing.T) {
 func TestDecodeManifest_V2RejectsDuplicateArtifactPlatform(t *testing.T) {
 	t.Parallel()
 
-	data := []byte(`{
-  "source": "github.com/test-org/test-repo/test-plugin",
-  "version": "1.0.0",
-  "kinds": ["provider"],
-  "provider": {},
-  "artifacts": [
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "artifacts/darwin/arm64/provider",
-      "sha256": "` + sha256Hex("provider") + `"
-    },
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "artifacts/darwin/arm64/provider2",
-      "sha256": "` + sha256Hex("provider2") + `"
-    }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "artifacts/darwin/arm64/provider"
-    }
-  }
-}`)
+	wire := mustProviderManifest("github.com/test-org/test-repo/test-plugin", "1.0.0", "darwin", "arm64", "artifacts/darwin/arm64/provider", sha256Hex("provider"))
+	wire.Artifacts = append(wire.Artifacts, pluginmanifestv1.Artifact{
+		OS:     "darwin",
+		Arch:   "arm64",
+		Path:   "artifacts/darwin/arm64/provider2",
+		SHA256: sha256Hex("provider2"),
+	})
+	data := mustManifestJSON(t, wire)
 
 	_, err := DecodeManifest(data)
 	if err == nil {
@@ -462,25 +341,8 @@ func TestDecodeManifest_V2RejectsDuplicateArtifactPlatform(t *testing.T) {
 func TestDecodeManifest_V2RejectsAbsoluteArtifactPath(t *testing.T) {
 	t.Parallel()
 
-	data := []byte(`{
-  "source": "github.com/test-org/test-repo/test-plugin",
-  "version": "1.0.0",
-  "kinds": ["provider"],
-  "provider": {},
-  "artifacts": [
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "/absolute/path/provider",
-      "sha256": "` + sha256Hex("provider") + `"
-    }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "/absolute/path/provider"
-    }
-  }
-}`)
+	wire := mustProviderManifest("github.com/test-org/test-repo/test-plugin", "1.0.0", "darwin", "arm64", "/absolute/path/provider", sha256Hex("provider"))
+	data := mustManifestJSON(t, wire)
 
 	_, err := DecodeManifest(data)
 	if err == nil {
@@ -488,65 +350,45 @@ func TestDecodeManifest_V2RejectsAbsoluteArtifactPath(t *testing.T) {
 	}
 }
 
-func TestDecodeManifest_V2ProviderWithoutMetadataRejected(t *testing.T) {
+func TestDecodeManifest_RejectsMissingProviderAndWebUI(t *testing.T) {
 	t.Parallel()
 
-	data := []byte(`{
-  "source": "github.com/test-org/test-repo/test-plugin",
-  "version": "1.0.0",
-  "kinds": ["provider"],
-  "artifacts": [
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "artifacts/darwin/arm64/provider",
-      "sha256": "` + sha256Hex("provider") + `"
-    }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "artifacts/darwin/arm64/provider"
-    }
-  }
-}`)
+	data := mustManifestJSON(t, &manifestWire{
+		Source:  "github.com/test-org/test-repo/test-plugin",
+		Version: "1.0.0",
+		Artifacts: []pluginmanifestv1.Artifact{
+			{
+				OS:     "darwin",
+				Arch:   "arm64",
+				Path:   "artifacts/darwin/arm64/provider",
+				SHA256: sha256Hex("provider"),
+			},
+		},
+	})
 
 	_, err := DecodeManifest(data)
 	if err == nil {
-		t.Fatal("expected error for provider kind without provider metadata")
+		t.Fatal("expected error for manifest without provider or webui")
 	}
 }
 
 func TestDecodeManifest_V2WithOAuth2Auth(t *testing.T) {
 	t.Parallel()
 
-	data := []byte(`{
-  "source": "github.com/acme/plugins/echo",
-  "version": "1.0.0",
-  "kinds": ["provider"],
-  "provider": {
-    "auth": {
-      "type": "oauth2",
-      "authorization_url": "https://example.com/authorize",
-      "token_url": "https://example.com/token",
-      "scopes": ["read", "write"],
-      "pkce": true,
-      "client_auth": "header"
-    }
-  },
-  "artifacts": [
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "artifacts/darwin/arm64/provider",
-      "sha256": "` + sha256Hex("provider") + `"
-    }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "artifacts/darwin/arm64/provider"
-    }
-  }
-}`)
+	wire := mustProviderManifest("github.com/acme/plugins/echo", "1.0.0", "darwin", "arm64", "artifacts/darwin/arm64/provider", sha256Hex("provider"))
+	wire.Provider.Connections = map[string]*providerManifestConnectionWire{
+		"default": {
+			Auth: &pluginmanifestv1.ProviderAuth{
+				Type:             "oauth2",
+				AuthorizationURL: "https://example.com/authorize",
+				TokenURL:         "https://example.com/token",
+				Scopes:           []string{"read", "write"},
+				PKCE:             true,
+				ClientAuth:       "header",
+			},
+		},
+	}
+	data := mustManifestJSON(t, wire)
 
 	manifest, err := DecodeManifest(data)
 	if err != nil {
@@ -578,30 +420,16 @@ func TestDecodeManifest_V2WithOAuth2Auth(t *testing.T) {
 func TestDecodeManifest_V2OAuth2MissingTokenURL(t *testing.T) {
 	t.Parallel()
 
-	data := []byte(`{
-  "source": "github.com/acme/plugins/echo",
-  "version": "1.0.0",
-  "kinds": ["provider"],
-  "provider": {
-    "auth": {
-      "type": "oauth2",
-      "authorization_url": "https://example.com/authorize"
-    }
-  },
-  "artifacts": [
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "artifacts/darwin/arm64/provider",
-      "sha256": "` + sha256Hex("provider") + `"
-    }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "artifacts/darwin/arm64/provider"
-    }
-  }
-}`)
+	wire := mustProviderManifest("github.com/acme/plugins/echo", "1.0.0", "darwin", "arm64", "artifacts/darwin/arm64/provider", sha256Hex("provider"))
+	wire.Provider.Connections = map[string]*providerManifestConnectionWire{
+		"default": {
+			Auth: &pluginmanifestv1.ProviderAuth{
+				Type:             "oauth2",
+				AuthorizationURL: "https://example.com/authorize",
+			},
+		},
+	}
+	data := mustManifestJSON(t, wire)
 
 	_, err := DecodeManifest(data)
 	if err == nil {
@@ -612,29 +440,13 @@ func TestDecodeManifest_V2OAuth2MissingTokenURL(t *testing.T) {
 func TestDecodeManifest_V2ManualAuth(t *testing.T) {
 	t.Parallel()
 
-	data := []byte(`{
-  "source": "github.com/acme/plugins/echo",
-  "version": "1.0.0",
-  "kinds": ["provider"],
-  "provider": {
-    "auth": {
-      "type": "manual"
-    }
-  },
-  "artifacts": [
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "artifacts/darwin/arm64/provider",
-      "sha256": "` + sha256Hex("provider") + `"
-    }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "artifacts/darwin/arm64/provider"
-    }
-  }
-}`)
+	wire := mustProviderManifest("github.com/acme/plugins/echo", "1.0.0", "darwin", "arm64", "artifacts/darwin/arm64/provider", sha256Hex("provider"))
+	wire.Provider.Connections = map[string]*providerManifestConnectionWire{
+		"default": {
+			Auth: &pluginmanifestv1.ProviderAuth{Type: "manual"},
+		},
+	}
+	data := mustManifestJSON(t, wire)
 
 	manifest, err := DecodeManifest(data)
 	if err != nil {
@@ -648,29 +460,13 @@ func TestDecodeManifest_V2ManualAuth(t *testing.T) {
 func TestDecodeManifest_V2InvalidAuthType(t *testing.T) {
 	t.Parallel()
 
-	data := []byte(`{
-  "source": "github.com/acme/plugins/echo",
-  "version": "1.0.0",
-  "kinds": ["provider"],
-  "provider": {
-    "auth": {
-      "type": "bogus"
-    }
-  },
-  "artifacts": [
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "artifacts/darwin/arm64/provider",
-      "sha256": "` + sha256Hex("provider") + `"
-    }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "artifacts/darwin/arm64/provider"
-    }
-  }
-}`)
+	wire := mustProviderManifest("github.com/acme/plugins/echo", "1.0.0", "darwin", "arm64", "artifacts/darwin/arm64/provider", sha256Hex("provider"))
+	wire.Provider.Connections = map[string]*providerManifestConnectionWire{
+		"default": {
+			Auth: &pluginmanifestv1.ProviderAuth{Type: "bogus"},
+		},
+	}
+	data := mustManifestJSON(t, wire)
 
 	_, err := DecodeManifest(data)
 	if err == nil {
@@ -739,21 +535,7 @@ func TestDecodeManifest_V2AuthRoundTrip(t *testing.T) {
 func TestDecodeManifestFormat_YAML(t *testing.T) {
 	t.Parallel()
 
-	yamlData := []byte(`
-source: github.com/acme/plugins/echo
-version: "1.0.0"
-kinds:
-  - provider
-provider: {}
-artifacts:
-  - os: darwin
-    arch: arm64
-    path: artifacts/darwin/arm64/provider
-    sha256: ` + sha256Hex("provider") + `
-entrypoints:
-  provider:
-    artifact_path: artifacts/darwin/arm64/provider
-`)
+	yamlData := mustManifestYAML(t, mustProviderManifest("github.com/acme/plugins/echo", "1.0.0", "darwin", "arm64", "artifacts/darwin/arm64/provider", sha256Hex("provider")))
 
 	manifest, err := DecodeManifestFormat(yamlData, "yaml")
 	if err != nil {
@@ -767,36 +549,42 @@ entrypoints:
 func TestDecodeManifestFormat_YAMLDeclarative(t *testing.T) {
 	t.Parallel()
 
-	yamlData := []byte(`
-source: github.com/acme/plugins/testapi
-version: "0.1.0"
-display_name: Test API
-description: A test declarative provider
-kinds:
-  - provider
-provider:
-  base_url: https://api.example.com/v1
-  auth:
-    type: bearer
-  operations:
-    - name: list_items
-      description: List all items
-      method: GET
-      path: /items
-      parameters:
-        - name: limit
-          type: int
-          in: query
-    - name: create_item
-      description: Create an item
-      method: POST
-      path: /items
-      parameters:
-        - name: name
-          type: string
-          in: body
-          required: true
-`)
+	yamlData := mustManifestYAML(t, &manifestWire{
+		Source:      "github.com/acme/plugins/testapi",
+		Version:     "0.1.0",
+		DisplayName: "Test API",
+		Description: "A test declarative provider",
+		Provider: &providerManifestWire{
+			Connections: map[string]*providerManifestConnectionWire{
+				"default": {Auth: &pluginmanifestv1.ProviderAuth{Type: "bearer"}},
+			},
+			Surfaces: providerManifestSurfacesWire{
+				REST: &providerManifestRESTSurfaceWire{
+					BaseURL: "https://api.example.com/v1",
+					Operations: []pluginmanifestv1.ProviderOperation{
+						{
+							Name:        "list_items",
+							Description: "List all items",
+							Method:      "GET",
+							Path:        "/items",
+							Parameters: []pluginmanifestv1.ProviderParameter{
+								{Name: "limit", Type: "int", In: "query"},
+							},
+						},
+						{
+							Name:        "create_item",
+							Description: "Create an item",
+							Method:      "POST",
+							Path:        "/items",
+							Parameters: []pluginmanifestv1.ProviderParameter{
+								{Name: "name", Type: "string", In: "body", Required: true},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
 
 	manifest, err := DecodeManifestFormat(yamlData, "yaml")
 	if err != nil {
@@ -825,25 +613,12 @@ provider:
 func TestDecodeManifestFormat_YAMLAllowedOperations(t *testing.T) {
 	t.Parallel()
 
-	yamlData := []byte(`
-source: github.com/acme/plugins/testapi
-version: "0.1.0"
-kinds:
-  - provider
-provider:
-  openapi: https://api.example.com/openapi.json
-  allowed_operations:
-    api.items.list:
-      alias: list_items
-artifacts:
-  - os: darwin
-    arch: arm64
-    path: artifacts/darwin/arm64/provider
-    sha256: ` + sha256Hex("provider") + `
-entrypoints:
-  provider:
-    artifact_path: artifacts/darwin/arm64/provider
-`)
+	wire := mustProviderManifest("github.com/acme/plugins/testapi", "0.1.0", "darwin", "arm64", "artifacts/darwin/arm64/provider", sha256Hex("provider"))
+	wire.Provider.Surfaces.OpenAPI = &providerManifestOpenAPISurfaceWire{Document: "https://api.example.com/openapi.json"}
+	wire.Provider.AllowedOperations = map[string]*pluginmanifestv1.ManifestOperationOverride{
+		"api.items.list": {Alias: "list_items"},
+	}
+	yamlData := mustManifestYAML(t, wire)
 
 	manifest, err := DecodeManifestFormat(yamlData, "yaml")
 	if err != nil {
@@ -864,25 +639,30 @@ entrypoints:
 func TestDecodeManifest_DeclarativeProviderJSON(t *testing.T) {
 	t.Parallel()
 
-	data := []byte(`{
-  "source": "github.com/acme/plugins/myapi",
-  "version": "1.0.0",
-  "kinds": ["provider"],
-  "provider": {
-    "base_url": "https://api.example.com",
-    "auth": { "type": "bearer" },
-    "operations": [
-      {
-        "name": "get_stuff",
-        "method": "GET",
-        "path": "/stuff",
-        "parameters": [
-          { "name": "q", "type": "string", "in": "query" }
-        ]
-      }
-    ]
-  }
-}`)
+	data := mustManifestJSON(t, &manifestWire{
+		Source:  "github.com/acme/plugins/myapi",
+		Version: "1.0.0",
+		Provider: &providerManifestWire{
+			Connections: map[string]*providerManifestConnectionWire{
+				"default": {Auth: &pluginmanifestv1.ProviderAuth{Type: "bearer"}},
+			},
+			Surfaces: providerManifestSurfacesWire{
+				REST: &providerManifestRESTSurfaceWire{
+					BaseURL: "https://api.example.com",
+					Operations: []pluginmanifestv1.ProviderOperation{
+						{
+							Name:   "get_stuff",
+							Method: "GET",
+							Path:   "/stuff",
+							Parameters: []pluginmanifestv1.ProviderParameter{
+								{Name: "q", Type: "string", In: "query"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
 
 	manifest, err := DecodeManifest(data)
 	if err != nil {
@@ -899,20 +679,19 @@ func TestDecodeManifest_DeclarativeProviderJSON(t *testing.T) {
 func TestDecodeManifest_DeclarativeRejectsMissingBaseURL(t *testing.T) {
 	t.Parallel()
 
-	data := []byte(`{
-  "source": "github.com/acme/plugins/myapi",
-  "version": "1.0.0",
-  "kinds": ["provider"],
-  "provider": {
-    "operations": [
-      {
-        "name": "get_stuff",
-        "method": "GET",
-        "path": "/stuff"
-      }
-    ]
-  }
-}`)
+	data := mustManifestJSON(t, &manifestWire{
+		Source:  "github.com/acme/plugins/myapi",
+		Version: "1.0.0",
+		Provider: &providerManifestWire{
+			Surfaces: providerManifestSurfacesWire{
+				REST: &providerManifestRESTSurfaceWire{
+					Operations: []pluginmanifestv1.ProviderOperation{
+						{Name: "get_stuff", Method: "GET", Path: "/stuff"},
+					},
+				},
+			},
+		},
+	})
 
 	_, err := DecodeManifest(data)
 	if err == nil {
@@ -923,18 +702,21 @@ func TestDecodeManifest_DeclarativeRejectsMissingBaseURL(t *testing.T) {
 func TestDecodeManifest_DeclarativeRejectsDuplicateOpNames(t *testing.T) {
 	t.Parallel()
 
-	data := []byte(`{
-  "source": "github.com/acme/plugins/myapi",
-  "version": "1.0.0",
-  "kinds": ["provider"],
-  "provider": {
-    "base_url": "https://api.example.com",
-    "operations": [
-      { "name": "do_thing", "method": "GET", "path": "/a" },
-      { "name": "do_thing", "method": "POST", "path": "/b" }
-    ]
-  }
-}`)
+	data := mustManifestJSON(t, &manifestWire{
+		Source:  "github.com/acme/plugins/myapi",
+		Version: "1.0.0",
+		Provider: &providerManifestWire{
+			Surfaces: providerManifestSurfacesWire{
+				REST: &providerManifestRESTSurfaceWire{
+					BaseURL: "https://api.example.com",
+					Operations: []pluginmanifestv1.ProviderOperation{
+						{Name: "do_thing", Method: "GET", Path: "/a"},
+						{Name: "do_thing", Method: "POST", Path: "/b"},
+					},
+				},
+			},
+		},
+	})
 
 	_, err := DecodeManifest(data)
 	if err == nil {
@@ -945,26 +727,12 @@ func TestDecodeManifest_DeclarativeRejectsDuplicateOpNames(t *testing.T) {
 func TestDecodeManifestFormat_YAMLManagedParameters(t *testing.T) {
 	t.Parallel()
 
-	yamlData := []byte(`
-source: github.com/acme/plugins/testapi
-version: "0.1.0"
-kinds:
-  - provider
-provider:
-  openapi: https://api.example.com/openapi.json
-  managed_parameters:
-    - in: header
-      name: intercom-version
-      value: "2.11"
-artifacts:
-  - os: darwin
-    arch: arm64
-    path: artifacts/darwin/arm64/provider
-    sha256: ` + sha256Hex("provider") + `
-entrypoints:
-  provider:
-    artifact_path: artifacts/darwin/arm64/provider
-`)
+	wire := mustProviderManifest("github.com/acme/plugins/testapi", "0.1.0", "darwin", "arm64", "artifacts/darwin/arm64/provider", sha256Hex("provider"))
+	wire.Provider.Surfaces.OpenAPI = &providerManifestOpenAPISurfaceWire{Document: "https://api.example.com/openapi.json"}
+	wire.Provider.ManagedParameters = []pluginmanifestv1.ManagedParameter{
+		{In: "header", Name: "intercom-version", Value: "2.11"},
+	}
+	yamlData := mustManifestYAML(t, wire)
 
 	manifest, err := DecodeManifestFormat(yamlData, "yaml")
 	if err != nil {
@@ -984,37 +752,13 @@ entrypoints:
 func TestDecodeManifest_RejectsManagedParameterHeaderConflict(t *testing.T) {
 	t.Parallel()
 
-	data := []byte(`{
-  "source": "github.com/acme/plugins/myapi",
-  "version": "1.0.0",
-  "kinds": ["provider"],
-  "provider": {
-    "openapi": "https://api.example.com/openapi.json",
-    "headers": {
-      "Intercom-Version": "2.15"
-    },
-    "managed_parameters": [
-      {
-        "in": "header",
-        "name": "intercom-version",
-        "value": "2.11"
-      }
-    ]
-  },
-  "artifacts": [
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "path": "artifacts/darwin/arm64/provider",
-      "sha256": "` + sha256Hex("provider") + `"
-    }
-  ],
-  "entrypoints": {
-    "provider": {
-      "artifact_path": "artifacts/darwin/arm64/provider"
-    }
-  }
-}`)
+	wire := mustProviderManifest("github.com/acme/plugins/myapi", "1.0.0", "darwin", "arm64", "artifacts/darwin/arm64/provider", sha256Hex("provider"))
+	wire.Provider.Surfaces.OpenAPI = &providerManifestOpenAPISurfaceWire{Document: "https://api.example.com/openapi.json"}
+	wire.Provider.Headers = map[string]string{"Intercom-Version": "2.15"}
+	wire.Provider.ManagedParameters = []pluginmanifestv1.ManagedParameter{
+		{In: "header", Name: "intercom-version", Value: "2.11"},
+	}
+	data := mustManifestJSON(t, wire)
 
 	_, err := DecodeManifest(data)
 	if err == nil {
@@ -1028,24 +772,27 @@ func TestDecodeManifest_RejectsManagedParameterHeaderConflict(t *testing.T) {
 func TestDecodeManifest_DeclarativeRejectsOrphanPathParam(t *testing.T) {
 	t.Parallel()
 
-	data := []byte(`{
-  "source": "github.com/acme/plugins/myapi",
-  "version": "1.0.0",
-  "kinds": ["provider"],
-  "provider": {
-    "base_url": "https://api.example.com",
-    "operations": [
-      {
-        "name": "get_item",
-        "method": "GET",
-        "path": "/items",
-        "parameters": [
-          { "name": "id", "type": "string", "in": "path" }
-        ]
-      }
-    ]
-  }
-}`)
+	data := mustManifestJSON(t, &manifestWire{
+		Source:  "github.com/acme/plugins/myapi",
+		Version: "1.0.0",
+		Provider: &providerManifestWire{
+			Surfaces: providerManifestSurfacesWire{
+				REST: &providerManifestRESTSurfaceWire{
+					BaseURL: "https://api.example.com",
+					Operations: []pluginmanifestv1.ProviderOperation{
+						{
+							Name:   "get_item",
+							Method: "GET",
+							Path:   "/items",
+							Parameters: []pluginmanifestv1.ProviderParameter{
+								{Name: "id", Type: "string", In: "path"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
 
 	_, err := DecodeManifest(data)
 	if err == nil {
@@ -1059,18 +806,21 @@ func TestDecodeManifest_IconFile(t *testing.T) {
 	t.Run("valid icon_file decodes and validates", func(t *testing.T) {
 		t.Parallel()
 
-		data := []byte(`{
-  "source": "github.com/acme/plugins/echo",
-  "version": "1.0.0",
-  "icon_file": "assets/icon.svg",
-  "kinds": ["provider"],
-  "provider": {
-    "base_url": "https://api.example.com",
-    "operations": [
-      {"name": "get_thing", "method": "GET", "path": "/thing"}
-    ]
-  }
-}`)
+		data := mustManifestJSON(t, &manifestWire{
+			Source:   "github.com/acme/plugins/echo",
+			Version:  "1.0.0",
+			IconFile: "assets/icon.svg",
+			Provider: &providerManifestWire{
+				Surfaces: providerManifestSurfacesWire{
+					REST: &providerManifestRESTSurfaceWire{
+						BaseURL: "https://api.example.com",
+						Operations: []pluginmanifestv1.ProviderOperation{
+							{Name: "get_thing", Method: "GET", Path: "/thing"},
+						},
+					},
+				},
+			},
+		})
 		manifest, err := DecodeManifest(data)
 		if err != nil {
 			t.Fatalf("DecodeManifest: %v", err)
@@ -1083,17 +833,20 @@ func TestDecodeManifest_IconFile(t *testing.T) {
 	t.Run("omitted icon_file is valid", func(t *testing.T) {
 		t.Parallel()
 
-		data := []byte(`{
-  "source": "github.com/acme/plugins/echo",
-  "version": "1.0.0",
-  "kinds": ["provider"],
-  "provider": {
-    "base_url": "https://api.example.com",
-    "operations": [
-      {"name": "get_thing", "method": "GET", "path": "/thing"}
-    ]
-  }
-}`)
+		data := mustManifestJSON(t, &manifestWire{
+			Source:  "github.com/acme/plugins/echo",
+			Version: "1.0.0",
+			Provider: &providerManifestWire{
+				Surfaces: providerManifestSurfacesWire{
+					REST: &providerManifestRESTSurfaceWire{
+						BaseURL: "https://api.example.com",
+						Operations: []pluginmanifestv1.ProviderOperation{
+							{Name: "get_thing", Method: "GET", Path: "/thing"},
+						},
+					},
+				},
+			},
+		})
 		manifest, err := DecodeManifest(data)
 		if err != nil {
 			t.Fatalf("DecodeManifest: %v", err)

--- a/server/internal/pluginpkg/manifest_wire.go
+++ b/server/internal/pluginpkg/manifest_wire.go
@@ -1,0 +1,332 @@
+package pluginpkg
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+	"gopkg.in/yaml.v3"
+)
+
+type manifestWire struct {
+	Source      string                          `json:"source,omitempty" yaml:"source,omitempty"`
+	Version     string                          `json:"version" yaml:"version"`
+	DisplayName string                          `json:"display_name,omitempty" yaml:"display_name,omitempty"`
+	Description string                          `json:"description,omitempty" yaml:"description,omitempty"`
+	IconFile    string                          `json:"icon_file,omitempty" yaml:"icon_file,omitempty"`
+	Provider    *providerManifestWire           `json:"provider,omitempty" yaml:"provider,omitempty"`
+	WebUI       *pluginmanifestv1.WebUIMetadata `json:"webui,omitempty" yaml:"webui,omitempty"`
+	Artifacts   []pluginmanifestv1.Artifact     `json:"artifacts,omitempty" yaml:"artifacts,omitempty"`
+}
+
+type providerManifestWire struct {
+	ConfigSchemaPath  string                                                 `json:"config_schema_path,omitempty" yaml:"config_schema_path,omitempty"`
+	Exec              *providerExecWire                                      `json:"exec,omitempty" yaml:"exec,omitempty"`
+	Connections       map[string]*providerManifestConnectionWire             `json:"connections,omitempty" yaml:"connections,omitempty"`
+	Headers           map[string]string                                      `json:"headers,omitempty" yaml:"headers,omitempty"`
+	ManagedParameters []pluginmanifestv1.ManagedParameter                    `json:"managed_parameters,omitempty" yaml:"managed_parameters,omitempty"`
+	ResponseMapping   *pluginmanifestv1.ManifestResponseMapping              `json:"response_mapping,omitempty" yaml:"response_mapping,omitempty"`
+	AllowedOperations map[string]*pluginmanifestv1.ManifestOperationOverride `json:"allowed_operations,omitempty" yaml:"allowed_operations,omitempty"`
+	Surfaces          providerManifestSurfacesWire                           `json:"surfaces" yaml:"surfaces"`
+	MCP               *providerManifestMCPWire                               `json:"mcp,omitempty" yaml:"mcp,omitempty"`
+}
+
+type providerExecWire struct {
+	ArtifactPath string   `json:"artifact_path" yaml:"artifact_path"`
+	Args         []string `json:"args,omitempty" yaml:"args,omitempty"`
+}
+
+type providerManifestConnectionWire struct {
+	Mode      string                                              `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Auth      *pluginmanifestv1.ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
+	Params    map[string]pluginmanifestv1.ProviderConnectionParam `json:"params,omitempty" yaml:"params,omitempty"`
+	Discovery *providerManifestDiscoveryWire                      `json:"discovery,omitempty" yaml:"discovery,omitempty"`
+}
+
+type providerManifestDiscoveryWire struct {
+	URL      string            `json:"url" yaml:"url"`
+	IDPath   string            `json:"id_path,omitempty" yaml:"id_path,omitempty"`
+	NamePath string            `json:"name_path,omitempty" yaml:"name_path,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+}
+
+type providerManifestSurfacesWire struct {
+	REST    *providerManifestRESTSurfaceWire    `json:"rest,omitempty" yaml:"rest,omitempty"`
+	OpenAPI *providerManifestOpenAPISurfaceWire `json:"openapi,omitempty" yaml:"openapi,omitempty"`
+	GraphQL *providerManifestGraphQLSurfaceWire `json:"graphql,omitempty" yaml:"graphql,omitempty"`
+	MCP     *providerManifestMCPSurfaceWire     `json:"mcp,omitempty" yaml:"mcp,omitempty"`
+}
+
+type providerManifestRESTSurfaceWire struct {
+	Connection string                               `json:"connection,omitempty" yaml:"connection,omitempty"`
+	BaseURL    string                               `json:"base_url" yaml:"base_url"`
+	Operations []pluginmanifestv1.ProviderOperation `json:"operations" yaml:"operations"`
+}
+
+type providerManifestOpenAPISurfaceWire struct {
+	Connection string `json:"connection,omitempty" yaml:"connection,omitempty"`
+	Document   string `json:"document" yaml:"document"`
+	BaseURL    string `json:"base_url,omitempty" yaml:"base_url,omitempty"`
+}
+
+type providerManifestGraphQLSurfaceWire struct {
+	Connection string `json:"connection,omitempty" yaml:"connection,omitempty"`
+	URL        string `json:"url" yaml:"url"`
+}
+
+type providerManifestMCPSurfaceWire struct {
+	Connection string `json:"connection,omitempty" yaml:"connection,omitempty"`
+	URL        string `json:"url" yaml:"url"`
+}
+
+type providerManifestMCPWire struct {
+	Enabled bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+}
+
+func decodeManifestWire(data []byte, format string) (*manifestWire, error) {
+	switch format {
+	case ManifestFormatJSON:
+		dec := json.NewDecoder(bytes.NewReader(data))
+		dec.DisallowUnknownFields()
+		var wire manifestWire
+		if err := dec.Decode(&wire); err != nil {
+			return nil, fmt.Errorf("parse manifest JSON: %w", err)
+		}
+		return &wire, nil
+	case ManifestFormatYAML:
+		dec := yaml.NewDecoder(bytes.NewReader(data))
+		dec.KnownFields(true)
+		var wire manifestWire
+		if err := dec.Decode(&wire); err != nil {
+			return nil, fmt.Errorf("parse manifest YAML: %w", err)
+		}
+		return &wire, nil
+	default:
+		return nil, fmt.Errorf("unsupported manifest format %q", format)
+	}
+}
+
+func wireManifestToInternal(wire *manifestWire) *pluginmanifestv1.Manifest {
+	if wire == nil {
+		return nil
+	}
+
+	manifest := &pluginmanifestv1.Manifest{
+		Source:      wire.Source,
+		Version:     wire.Version,
+		DisplayName: wire.DisplayName,
+		Description: wire.Description,
+		IconFile:    wire.IconFile,
+		WebUI:       wire.WebUI,
+		Artifacts:   wire.Artifacts,
+	}
+	if wire.Provider != nil {
+		manifest.Kinds = append(manifest.Kinds, pluginmanifestv1.KindProvider)
+		manifest.Provider = &pluginmanifestv1.Provider{
+			ConfigSchemaPath:  wire.Provider.ConfigSchemaPath,
+			Headers:           wire.Provider.Headers,
+			ManagedParameters: wire.Provider.ManagedParameters,
+			ResponseMapping:   wire.Provider.ResponseMapping,
+			AllowedOperations: wire.Provider.AllowedOperations,
+		}
+		if wire.Provider.MCP != nil {
+			manifest.Provider.MCP = wire.Provider.MCP.Enabled
+		}
+		if wire.Provider.Exec != nil {
+			manifest.Entrypoints.Provider = &pluginmanifestv1.Entrypoint{
+				ArtifactPath: wire.Provider.Exec.ArtifactPath,
+				Args:         wire.Provider.Exec.Args,
+			}
+		}
+		if defaultConn, ok := wire.Provider.Connections["default"]; ok && defaultConn != nil {
+			manifest.Provider.Auth = defaultConn.Auth
+			manifest.Provider.ConnectionMode = defaultConn.Mode
+			manifest.Provider.ConnectionParams = defaultConn.Params
+			manifest.Provider.PostConnectDiscovery = defaultConn.toInternalDiscovery()
+		}
+		if len(wire.Provider.Connections) > 0 {
+			manifest.Provider.Connections = make(map[string]*pluginmanifestv1.ManifestConnectionDef, len(wire.Provider.Connections))
+			for name, conn := range wire.Provider.Connections {
+				if name == "default" {
+					continue
+				}
+				if conn == nil {
+					manifest.Provider.Connections[name] = nil
+					continue
+				}
+				manifest.Provider.Connections[name] = &pluginmanifestv1.ManifestConnectionDef{
+					Mode: conn.Mode,
+					Auth: conn.Auth,
+				}
+			}
+			if len(manifest.Provider.Connections) == 0 {
+				manifest.Provider.Connections = nil
+			}
+		}
+		if s := wire.Provider.Surfaces.REST; s != nil {
+			manifest.Provider.BaseURL = s.BaseURL
+			manifest.Provider.Operations = s.Operations
+			if s.Connection == "default" {
+				if len(manifest.Provider.Connections) > 0 {
+					manifest.Provider.DefaultConnection = config.PluginConnectionAlias
+				}
+			} else if s.Connection != "" {
+				manifest.Provider.DefaultConnection = s.Connection
+			}
+		}
+		if s := wire.Provider.Surfaces.OpenAPI; s != nil {
+			manifest.Provider.OpenAPI = s.Document
+			manifest.Provider.BaseURL = s.BaseURL
+			manifest.Provider.OpenAPIConnection = remapManifestWireConnectionName(s.Connection)
+		}
+		if s := wire.Provider.Surfaces.GraphQL; s != nil {
+			manifest.Provider.GraphQLURL = s.URL
+			manifest.Provider.GraphQLConnection = remapManifestWireConnectionName(s.Connection)
+		}
+		if s := wire.Provider.Surfaces.MCP; s != nil {
+			manifest.Provider.MCPURL = s.URL
+			manifest.Provider.MCPConnection = remapManifestWireConnectionName(s.Connection)
+		}
+	}
+	if wire.WebUI != nil {
+		manifest.Kinds = append(manifest.Kinds, pluginmanifestv1.KindWebUI)
+	}
+	return manifest
+}
+
+func internalManifestToWire(manifest *pluginmanifestv1.Manifest) *manifestWire {
+	if manifest == nil {
+		return nil
+	}
+
+	wire := &manifestWire{
+		Source:      manifest.Source,
+		Version:     manifest.Version,
+		DisplayName: manifest.DisplayName,
+		Description: manifest.Description,
+		IconFile:    manifest.IconFile,
+		WebUI:       manifest.WebUI,
+		Artifacts:   manifest.Artifacts,
+	}
+
+	if manifest.Provider == nil {
+		return wire
+	}
+
+	provider := &providerManifestWire{
+		ConfigSchemaPath:  manifest.Provider.ConfigSchemaPath,
+		Headers:           manifest.Provider.Headers,
+		ManagedParameters: manifest.Provider.ManagedParameters,
+		ResponseMapping:   manifest.Provider.ResponseMapping,
+		AllowedOperations: manifest.Provider.AllowedOperations,
+		Surfaces:          providerManifestSurfacesWire{},
+	}
+	if manifest.Entrypoints.Provider != nil {
+		provider.Exec = &providerExecWire{
+			ArtifactPath: manifest.Entrypoints.Provider.ArtifactPath,
+			Args:         manifest.Entrypoints.Provider.Args,
+		}
+	}
+	if manifest.Provider.MCP {
+		provider.MCP = &providerManifestMCPWire{Enabled: true}
+	}
+
+	if manifest.Provider.ConnectionMode != "" || manifest.Provider.Auth != nil || len(manifest.Provider.ConnectionParams) > 0 || manifest.Provider.PostConnectDiscovery != nil {
+		provider.Connections = map[string]*providerManifestConnectionWire{
+			"default": {
+				Mode:      manifest.Provider.ConnectionMode,
+				Auth:      manifest.Provider.Auth,
+				Params:    manifest.Provider.ConnectionParams,
+				Discovery: internalDiscoveryToWire(manifest.Provider.PostConnectDiscovery),
+			},
+		}
+	}
+	if len(manifest.Provider.Connections) > 0 {
+		if provider.Connections == nil {
+			provider.Connections = make(map[string]*providerManifestConnectionWire, len(manifest.Provider.Connections))
+		}
+		for name, conn := range manifest.Provider.Connections {
+			if conn == nil {
+				provider.Connections[name] = nil
+				continue
+			}
+			provider.Connections[name] = &providerManifestConnectionWire{
+				Mode: conn.Mode,
+				Auth: conn.Auth,
+			}
+		}
+	}
+
+	switch {
+	case manifest.Provider.IsDeclarative():
+		provider.Surfaces.REST = &providerManifestRESTSurfaceWire{
+			Connection: manifestDefaultConnectionToWire(manifest.Provider.DefaultConnection),
+			BaseURL:    manifest.Provider.BaseURL,
+			Operations: manifest.Provider.Operations,
+		}
+	case manifest.Provider.OpenAPI != "":
+		provider.Surfaces.OpenAPI = &providerManifestOpenAPISurfaceWire{
+			Connection: manifestDefaultConnectionToWire(manifest.Provider.OpenAPIConnection),
+			Document:   manifest.Provider.OpenAPI,
+			BaseURL:    manifest.Provider.BaseURL,
+		}
+	case manifest.Provider.GraphQLURL != "":
+		provider.Surfaces.GraphQL = &providerManifestGraphQLSurfaceWire{
+			Connection: manifestDefaultConnectionToWire(manifest.Provider.GraphQLConnection),
+			URL:        manifest.Provider.GraphQLURL,
+		}
+	}
+	if manifest.Provider.MCPURL != "" {
+		provider.Surfaces.MCP = &providerManifestMCPSurfaceWire{
+			Connection: manifestDefaultConnectionToWire(manifest.Provider.MCPConnection),
+			URL:        manifest.Provider.MCPURL,
+		}
+	}
+
+	wire.Provider = provider
+	return wire
+}
+
+func (w *providerManifestConnectionWire) toInternalDiscovery() *pluginmanifestv1.ProviderPostConnectDiscovery {
+	if w == nil || w.Discovery == nil {
+		return nil
+	}
+	return &pluginmanifestv1.ProviderPostConnectDiscovery{
+		URL:             w.Discovery.URL,
+		IDPath:          w.Discovery.IDPath,
+		NamePath:        w.Discovery.NamePath,
+		MetadataMapping: w.Discovery.Metadata,
+	}
+}
+
+func internalDiscoveryToWire(discovery *pluginmanifestv1.ProviderPostConnectDiscovery) *providerManifestDiscoveryWire {
+	if discovery == nil {
+		return nil
+	}
+	return &providerManifestDiscoveryWire{
+		URL:      discovery.URL,
+		IDPath:   discovery.IDPath,
+		NamePath: discovery.NamePath,
+		Metadata: discovery.MetadataMapping,
+	}
+}
+
+func remapManifestWireConnectionName(name string) string {
+	switch name {
+	case "", "default":
+		return ""
+	default:
+		return name
+	}
+}
+
+func manifestDefaultConnectionToWire(name string) string {
+	switch name {
+	case "", config.PluginConnectionAlias:
+		return ""
+	default:
+		return name
+	}
+}

--- a/server/internal/pluginstore/store_test.go
+++ b/server/internal/pluginstore/store_test.go
@@ -6,7 +6,6 @@ import (
 	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -509,11 +508,10 @@ func mustBuildMismatchPackage(t *testing.T, dir, source, version, content, diges
 			},
 		},
 	}
-	manifestBytes, err := json.MarshalIndent(manifest, "", "  ")
+	manifestBytes, err := pluginpkg.EncodeManifest(manifest)
 	if err != nil {
-		t.Fatalf("MarshalIndent manifest: %v", err)
+		t.Fatalf("EncodeManifest: %v", err)
 	}
-	manifestBytes = append(manifestBytes, '\n')
 
 	archivePath := filepath.Join(dir, "mismatch.tar.gz")
 	out, err := os.Create(archivePath)

--- a/server/internal/provider/build.go
+++ b/server/internal/provider/build.go
@@ -183,7 +183,9 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 		base.ConnectionDefs = make(map[string]core.ConnectionParamDef, len(conn.ConnectionParams))
 		for name, cpd := range conn.ConnectionParams {
 			base.ConnectionDefs[name] = core.ConnectionParamDef{
-				Required: cpd.Required,
+				Required:    cpd.Required,
+				Description: cpd.Description,
+				From:        cpd.From,
 			}
 		}
 	} else if len(def.Connection) > 0 {

--- a/server/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/server/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -5,8 +5,7 @@
   "additionalProperties": false,
   "required": [
     "source",
-    "version",
-    "kinds"
+    "version"
   ],
   "properties": {
     "source": {
@@ -26,34 +25,59 @@
     "icon_file": {
       "type": "string"
     },
-    "kinds": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "items": {
-        "enum": [
-          "provider",
-          "webui"
-        ]
-      }
+    "provider": {
+      "$ref": "#/$defs/provider"
     },
+    "webui": {
+      "$ref": "#/$defs/webui"
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/artifact"
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "required": [
+        "provider"
+      ]
+    },
+    {
+      "required": [
+        "webui"
+      ]
+    }
+  ],
+  "$defs": {
     "provider": {
       "type": "object",
       "additionalProperties": false,
+      "required": [
+        "surfaces"
+      ],
       "properties": {
         "config_schema_path": {
           "type": "string",
           "minLength": 1
         },
-        "auth": {
-          "$ref": "#/$defs/provider_auth"
+        "exec": {
+          "$ref": "#/$defs/exec"
         },
-        "mcp": {
-          "type": "boolean"
-        },
-        "base_url": {
-          "type": "string",
-          "minLength": 1
+        "connections": {
+          "type": "object",
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/provider_default_connection"
+            }
+          },
+          "propertyNames": {
+            "minLength": 1
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/provider_named_connection"
+          }
         },
         "headers": {
           "type": "object",
@@ -67,16 +91,8 @@
             "$ref": "#/$defs/managed_parameter"
           }
         },
-        "operations": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/provider_operation"
-          }
-        },
-        "openapi": {
-          "type": "string",
-          "minLength": 1
+        "response_mapping": {
+          "$ref": "#/$defs/response_mapping"
         },
         "allowed_operations": {
           "type": "object",
@@ -84,94 +100,55 @@
             "$ref": "#/$defs/manifest_operation_override"
           }
         },
-        "graphql_url": {
-          "type": "string",
-          "minLength": 1
+        "surfaces": {
+          "$ref": "#/$defs/surfaces"
         },
-        "mcp_url": {
-          "type": "string",
-          "minLength": 1
+        "mcp": {
+          "$ref": "#/$defs/mcp_config"
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "exec"
+          ]
         },
-        "openapi_connection": {
-          "type": "string",
-          "minLength": 1
-        },
-        "graphql_connection": {
-          "type": "string",
-          "minLength": 1
-        },
-        "mcp_connection": {
-          "type": "string",
-          "minLength": 1
-        },
-        "default_connection": {
-          "type": "string",
-          "minLength": 1
-        },
-        "connections": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/manifest_connection_def"
-          }
-        },
-        "post_connect_discovery": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["url"],
+        {
           "properties": {
-            "url": {
-              "type": "string",
-              "format": "uri"
-            },
-            "id_path": {
-              "type": "string"
-            },
-            "name_path": {
-              "type": "string"
-            },
-            "metadata_mapping": {
-              "type": "object",
-              "additionalProperties": { "type": "string" }
-            }
-          }
-        },
-        "connection_params": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "required": { "type": "boolean" },
-              "description": { "type": "string" },
-              "from": { "type": "string", "enum": ["discovery"] }
-            }
-          }
-        },
-        "response_mapping": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["data_path"],
-          "properties": {
-            "data_path": {
-              "type": "string",
-              "minLength": 1
-            },
-            "pagination": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "has_more_path": { "type": "string" },
-                "cursor_path": { "type": "string" }
-              }
+            "surfaces": {
+              "anyOf": [
+                {
+                  "required": [
+                    "rest"
+                  ]
+                },
+                {
+                  "required": [
+                    "openapi"
+                  ]
+                },
+                {
+                  "required": [
+                    "graphql"
+                  ]
+                },
+                {
+                  "required": [
+                    "mcp"
+                  ]
+                }
+              ]
             }
           }
         }
-      }
+      ]
     },
     "webui": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["asset_root"],
+      "required": [
+        "asset_root"
+      ],
       "properties": {
         "asset_root": {
           "type": "string",
@@ -179,130 +156,290 @@
         }
       }
     },
-    "artifacts": {
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/artifact"
+    "exec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_path"
+      ],
+      "properties": {
+        "artifact_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       }
     },
-    "entrypoints": {
+    "provider_default_connection": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "provider": {
-          "$ref": "#/$defs/entrypoint"
-        }
-      }
-    }
-  },
-  "allOf": [
-    {
-      "if": {
-        "properties": {
-          "kinds": {
-            "contains": {
-              "const": "provider"
-            }
+        "mode": {
+          "type": "string",
+          "enum": [
+            "none",
+            "user",
+            "identity",
+            "either"
+          ]
+        },
+        "auth": {
+          "$ref": "#/$defs/provider_auth"
+        },
+        "params": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/provider_connection_param"
           }
+        },
+        "discovery": {
+          "$ref": "#/$defs/provider_discovery"
         }
-      },
-      "then": {
-        "required": [
-          "provider"
-        ],
-        "anyOf": [
-          {
-            "required": [
-              "entrypoints"
-            ],
-            "properties": {
-              "entrypoints": {
-                "required": [
-                  "provider"
-                ]
-              }
-            }
-          },
-          {
-            "properties": {
-              "provider": {
-                "required": [
-                  "base_url",
-                  "operations"
-                ]
-              }
-            }
-          },
-          {
-            "properties": {
-              "provider": {
-                "anyOf": [
-                  {
-                    "required": [
-                      "openapi"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "graphql_url"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "mcp_url"
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "required": [
-              "entrypoints"
-            ],
-            "properties": {
-              "entrypoints": {
-                "required": [
-                  "provider"
-                ]
-              },
-              "provider": {
-                "required": [
-                  "base_url",
-                  "operations"
-                ]
-              }
-            }
-          }
-        ]
       }
     },
-    {
-      "if": {
-        "properties": {
-          "kinds": {
-            "contains": {
-              "const": "webui"
+    "provider_named_connection": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "none",
+            "user",
+            "identity",
+            "either"
+          ]
+        },
+        "auth": {
+          "$ref": "#/$defs/provider_auth"
+        }
+      }
+    },
+    "provider_connection_param": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
+        "from": {
+          "type": "string",
+          "enum": [
+            "discovery"
+          ]
+        }
+      }
+    },
+    "provider_discovery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "id_path": {
+          "type": "string"
+        },
+        "name_path": {
+          "type": "string"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "surfaces": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rest": {
+          "$ref": "#/$defs/rest_surface"
+        },
+        "openapi": {
+          "$ref": "#/$defs/openapi_surface"
+        },
+        "graphql": {
+          "$ref": "#/$defs/graphql_surface"
+        },
+        "mcp": {
+          "$ref": "#/$defs/mcp_surface"
+        }
+      },
+      "allOf": [
+        {
+          "not": {
+            "required": [
+              "rest",
+              "openapi"
+            ]
+          }
+        },
+        {
+          "not": {
+            "required": [
+              "rest",
+              "graphql"
+            ]
+          }
+        },
+        {
+          "not": {
+            "required": [
+              "openapi",
+              "graphql"
+            ]
+          }
+        }
+      ]
+    },
+    "rest_surface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "base_url",
+        "operations"
+      ],
+      "properties": {
+        "connection": {
+          "type": "string",
+          "minLength": 1
+        },
+        "base_url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operations": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/provider_operation"
+          }
+        }
+      }
+    },
+    "openapi_surface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "document"
+      ],
+      "properties": {
+        "connection": {
+          "type": "string",
+          "minLength": 1
+        },
+        "document": {
+          "type": "string",
+          "minLength": 1
+        },
+        "base_url": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "graphql_surface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "connection": {
+          "type": "string",
+          "minLength": 1
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "mcp_surface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "connection": {
+          "type": "string",
+          "minLength": 1
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "mcp_config": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "enabled"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "response_mapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "data_path"
+      ],
+      "properties": {
+        "data_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pagination": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "has_more_path": {
+              "type": "string"
+            },
+            "cursor_path": {
+              "type": "string"
             }
           }
         }
-      },
-      "then": {
-        "required": [
-          "webui"
-        ]
       }
-    }
-  ],
-  "$defs": {
+    },
     "provider_auth": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["oauth2", "mcp_oauth", "bearer", "manual", "none"]
+          "enum": [
+            "oauth2",
+            "mcp_oauth",
+            "bearer",
+            "manual",
+            "none"
+          ]
         },
         "authorization_url": {
           "type": "string",
@@ -320,60 +457,86 @@
         },
         "scopes": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "pkce": {
           "type": "boolean"
         },
         "client_auth": {
           "type": "string",
-          "enum": ["header"]
+          "enum": [
+            "header"
+          ]
         },
         "token_exchange": {
           "type": "string",
-          "enum": ["form", "json"]
+          "enum": [
+            "form",
+            "json"
+          ]
         },
         "access_token_path": {
-          "type": "string",
-          "description": "Dot-separated JSON path to extract the access token from the token response"
+          "type": "string"
         },
         "scope_param": {
-          "type": "string",
-          "description": "Query parameter name for scopes (default: scope)"
+          "type": "string"
         },
         "scope_separator": {
           "type": "string"
         },
         "authorization_params": {
           "type": "object",
-          "additionalProperties": { "type": "string" }
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "token_params": {
           "type": "object",
-          "additionalProperties": { "type": "string" }
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "refresh_params": {
           "type": "object",
-          "additionalProperties": { "type": "string" }
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "accept_header": {
           "type": "string"
         },
         "token_metadata": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "credentials": {
           "type": "array",
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["name"],
+            "required": [
+              "name"
+            ],
             "properties": {
-              "name": { "type": "string", "minLength": 1, "pattern": "^[a-z][a-z0-9_]*$" },
-              "label": { "type": "string" },
-              "description": { "type": "string" },
-              "help_url": { "type": "string", "format": "uri" }
+              "name": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^[a-z][a-z0-9_]*$"
+              },
+              "label": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "help_url": {
+                "type": "string",
+                "format": "uri"
+              }
             }
           }
         }
@@ -381,31 +544,29 @@
       "allOf": [
         {
           "if": {
-            "properties": { "type": { "const": "oauth2" } }
+            "properties": {
+              "type": {
+                "const": "oauth2"
+              }
+            }
           },
           "then": {
-            "required": ["authorization_url", "token_url"]
+            "required": [
+              "authorization_url",
+              "token_url"
+            ]
           }
         }
       ]
     },
-    "manifest_connection_def": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "mode": {
-          "type": "string",
-          "enum": ["none", "user", "identity", "either"]
-        },
-        "auth": {
-          "$ref": "#/$defs/provider_auth"
-        }
-      }
-    },
     "provider_operation": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "method", "path"],
+      "required": [
+        "name",
+        "method",
+        "path"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -416,7 +577,13 @@
         },
         "method": {
           "type": "string",
-          "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+          "enum": [
+            "GET",
+            "POST",
+            "PUT",
+            "PATCH",
+            "DELETE"
+          ]
         },
         "path": {
           "type": "string",
@@ -430,26 +597,60 @@
         }
       }
     },
-    "manifest_operation_override": {
+    "provider_parameter": {
       "type": "object",
       "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "in"
+      ],
       "properties": {
-        "alias": {
-          "type": "string"
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "int",
+            "bool",
+            "object",
+            "array"
+          ]
+        },
+        "in": {
+          "type": "string",
+          "enum": [
+            "query",
+            "body",
+            "path"
+          ]
         },
         "description": {
           "type": "string"
+        },
+        "required": {
+          "type": "boolean"
         }
       }
     },
     "managed_parameter": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["in", "name", "value"],
+      "required": [
+        "in",
+        "name",
+        "value"
+      ],
       "properties": {
         "in": {
           "type": "string",
-          "enum": ["header", "path"]
+          "enum": [
+            "header",
+            "path"
+          ]
         },
         "name": {
           "type": "string",
@@ -461,28 +662,15 @@
         }
       }
     },
-    "provider_parameter": {
+    "manifest_operation_override": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "type", "in"],
       "properties": {
-        "name": {
-          "type": "string",
-          "minLength": 1
-        },
-        "type": {
-          "type": "string",
-          "enum": ["string", "int", "bool", "object", "array"]
-        },
-        "in": {
-          "type": "string",
-          "enum": ["query", "body", "path"]
+        "alias": {
+          "type": "string"
         },
         "description": {
           "type": "string"
-        },
-        "required": {
-          "type": "boolean"
         }
       }
     },
@@ -510,25 +698,6 @@
         "sha256": {
           "type": "string",
           "pattern": "^[a-f0-9]{64}$"
-        }
-      }
-    },
-    "entrypoint": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "artifact_path"
-      ],
-      "properties": {
-        "artifact_path": {
-          "type": "string",
-          "minLength": 1
-        },
-        "args": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
         }
       }
     }

--- a/server/sdk/pluginmanifest/v1/types.go
+++ b/server/sdk/pluginmanifest/v1/types.go
@@ -29,6 +29,7 @@ type WebUIMetadata struct {
 type Provider struct {
 	ConfigSchemaPath     string                             `json:"config_schema_path,omitempty" yaml:"config_schema_path,omitempty"`
 	Auth                 *ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
+	ConnectionMode       string                             `json:"connection_mode,omitempty" yaml:"connection_mode,omitempty"`
 	MCP                  bool                               `json:"mcp,omitempty" yaml:"mcp,omitempty"`
 	BaseURL              string                             `json:"base_url,omitempty" yaml:"base_url,omitempty"`
 	Headers              map[string]string                  `json:"headers,omitempty" yaml:"headers,omitempty"`


### PR DESCRIPTION
## Summary
This is a breaking YAML interface redesign for both `gestaltd` config and plugin manifests.

The goal is to make the external interface explicitly structured around four concepts:
- `from`: where a provider comes from
- `connections`: auth and connection-scoped inputs
- `surfaces`: the callable API / MCP shape
- `mcp`: how the provider is exposed on Gestalt's `/mcp` surface

Internally, this still reuses the existing `PluginDef`, manifest-backed merge path, bootstrap plumbing, and shared validation paths wherever possible.

## Before and after
### Config before
```yaml
integrations:
  jira:
    plugin:
      source: github.com/valon-technologies/gestalt/jira
      version: 0.0.1
      auth:
        type: oauth2
      openapi: specs/openapi.yaml
      openapi_connection: workspace
      mcp: true
    mcp_tool_prefix: jira_
```

### Config after
```yaml
providers:
  jira:
    from:
      source: github.com/valon-technologies/gestalt/jira
      version: 0.0.1
    connections:
      default:
        auth:
          type: oauth2
    surfaces:
      openapi:
        document: specs/openapi.yaml
        connection: default
    mcp:
      enabled: true
      tool_prefix: jira_
```

### Manifest before
```yaml
source: github.com/valon-technologies/gestalt/jira
version: 0.0.1
kinds: [provider]
provider:
  openapi: specs/openapi.yaml
  mcp: true
artifacts:
  - os: linux
    arch: amd64
    path: artifacts/linux/amd64/provider
    sha256: ...
entrypoints:
  provider:
    artifact_path: artifacts/linux/amd64/provider
```

### Manifest after
```yaml
source: github.com/valon-technologies/gestalt/jira
version: 0.0.1
provider:
  exec:
    artifact_path: artifacts/linux/amd64/provider
  surfaces:
    openapi:
      document: specs/openapi.yaml
  mcp:
    enabled: true
artifacts:
  - os: linux
    arch: amd64
    path: artifacts/linux/amd64/provider
    sha256: ...
```

## What is allowed now
- top-level `providers` instead of `integrations`
- direct provider config instead of a nested `plugin` block
- `from.command`, `from.package`, and `from.source`
- `connections.default` for auth, params, and discovery
- named non-default `connections` for alternate auth / mode selection
- `surfaces.rest`, `surfaces.openapi`, `surfaces.graphql`, and `surfaces.mcp`
- `mcp.enabled` and `mcp.tool_prefix` in config
- `provider.mcp.enabled` in manifests
- `provider.exec` instead of external `entrypoints`
- JSON and YAML plugin manifests through the same decode/encode path

## What is not allowed now
- top-level `integrations` in config
- nested `providers.<name>.plugin` blocks
- mixed top-level surface fields in the external YAML contract like `openapi`, `graphql_url`, `mcp_url`, `operations`, `base_url`, or `*_connection`
- `expose.mcp` or `expose.tool_prefix`
- `mcp.tool_prefix` without `mcp.enabled: true`
- `params` or `discovery` on non-default named connections
- implicit surface connection selection when only named non-default connections exist
- external manifest `kinds` / `entrypoints`
- `provider` and `webui` together in one external manifest

## Release implications
This is a breaking release.

What needs a release:
- `gestaltd` must be released, because it owns the new config parser and new manifest decoder
- checked-in / packaged plugins must be re-released or re-packaged with the new manifest shape

Compatibility expectations:
- old `gestaltd` will not understand newly packaged plugin manifests from this branch
- new `gestaltd` will not accept old config or old manifest shapes from before this PR
- inline-only providers need config migration but no plugin artifact release
- packaged / source plugins need their manifests rebuilt even if the provider binary itself did not change

Safest rollout:
1. Merge this PR.
2. Release `gestaltd`.
3. Re-release bundled plugins from the new manifest shape.
4. Communicate the config migration from `integrations` / `plugin` to `providers` / `from` / `connections` / `surfaces` / `mcp`.

## Implementation notes
- reuse the existing internal `PluginDef` and manifest-backed merge logic instead of adding a second runtime model
- keep manifest structural validation schema-backed instead of growing a handwritten manifest validator
- keep coverage in existing command / e2e paths by augmenting functional tests instead of adding new unit-test-only cases

## Verification
- `cd server && go test ./...`
- `cd server && golangci-lint run`
