### PR TITLE
[codex] Allow base URL overrides for sourced providers

### DIFF
--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -439,6 +439,17 @@ providers:
 `,
 		},
 		{
+			name: "plugin source with base_url override is valid",
+			yaml: `
+providers:
+  external:
+    from:
+      source: github.com/acme-corp/tools/widget
+      version: 1.2.3
+    base_url: https://api.example.com
+`,
+		},
+		{
 			name: "plugin source without version is rejected",
 			yaml: `
 providers:

--- a/server/internal/config/provider_wire.go
+++ b/server/internal/config/provider_wire.go
@@ -13,6 +13,7 @@ type providerWire struct {
 	Description       string                             `yaml:"description"`
 	IconFile          string                             `yaml:"icon_file"`
 	Config            yaml.Node                          `yaml:"config"`
+	BaseURL           string                             `yaml:"base_url"`
 	From              providerSourceWire                 `yaml:"from"`
 	Connections       map[string]*providerConnectionWire `yaml:"connections"`
 	Headers           map[string]string                  `yaml:"headers"`
@@ -168,6 +169,9 @@ func (i *IntegrationDef) UnmarshalYAML(value *yaml.Node) error {
 	if wire.Surfaces.MCP != nil {
 		plugin.MCPURL = wire.Surfaces.MCP.URL
 		plugin.MCPConnection = remapWireConnectionName(wire.Surfaces.MCP.Connection)
+	}
+	if wire.BaseURL != "" {
+		plugin.BaseURL = wire.BaseURL
 	}
 
 	*i = IntegrationDef{


### PR DESCRIPTION
## Summary
- accept top-level `base_url` on provider configs that reference packaged plugins via `from.source`
- map that override into the resolved plugin runtime config
- cover the sourced-plugin case in config loading tests

## Testing
- `go test ./internal/config ./cmd/gestaltd`
- patched `gestaltd validate --init` against `valon-tools/deploy/cloudrun-test-config.yaml` with auth + placeholder deploy envs; plugin preparation succeeded and validation proceeded to secret resolution
