### PR TITLE
Allow late-bound config for managed plugins

### DIFF
--- a/server/cmd/gestaltd/init.go
+++ b/server/cmd/gestaltd/init.go
@@ -47,8 +47,8 @@ func writeLockfile(path string, lock *initLockfile) error {
 	return operator.WriteLockfile(path, lock)
 }
 
-func pluginFingerprint(name string, plugin *config.PluginDef, configMap map[string]any, configDir string) (string, error) {
-	return operator.PluginFingerprint(name, plugin, configMap, configDir)
+func pluginFingerprint(name string, plugin *config.PluginDef, configDir string) (string, error) {
+	return operator.PluginFingerprint(name, plugin, configDir)
 }
 
 func lockPluginKey(kind, name string) string {

--- a/server/cmd/gestaltd/init_test.go
+++ b/server/cmd/gestaltd/init_test.go
@@ -71,11 +71,11 @@ func TestPluginFingerprintStable(t *testing.T) {
 		Env:     map[string]string{"API_KEY": "abc123"},
 	}
 
-	first, err := pluginFingerprint("external", plugin, nil, ".")
+	first, err := pluginFingerprint("external", plugin, ".")
 	if err != nil {
 		t.Fatalf("pluginFingerprint: %v", err)
 	}
-	second, err := pluginFingerprint("external", plugin, nil, ".")
+	second, err := pluginFingerprint("external", plugin, ".")
 	if err != nil {
 		t.Fatalf("pluginFingerprint second: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestPluginFingerprintStable(t *testing.T) {
 	}
 
 	plugin.Package = "./plugins/dummy.tar.gz"
-	third, err := pluginFingerprint("external", plugin, nil, ".")
+	third, err := pluginFingerprint("external", plugin, ".")
 	if err != nil {
 		t.Fatalf("pluginFingerprint third: %v", err)
 	}
@@ -93,21 +93,103 @@ func TestPluginFingerprintStable(t *testing.T) {
 	}
 }
 
-func TestPluginFingerprintIncludesPreparedConfig(t *testing.T) {
+func TestLoadConfigForExecutionAllowsManagedPluginConfigChangeAfterInit(t *testing.T) {
 	t.Parallel()
 
-	plugin := &config.PluginDef{Package: "./plugins/dummy.tar.gz"}
+	dir := t.TempDir()
+	packagePath := buildPreparedTestPluginPackageRequiringAPIKey(t, dir, "github.com/acme/plugins/provider", "0.1.0", "provider")
+	cfgPath := writePreparedPluginPackageConfigWithConfig(t, dir, packagePath, map[string]any{
+		"api_key": "one",
+	})
 
-	first, err := pluginFingerprint("external", plugin, map[string]any{"runtime_key": "one"}, ".")
-	if err != nil {
-		t.Fatalf("pluginFingerprint first: %v", err)
+	if err := initConfig(cfgPath); err != nil {
+		t.Fatalf("initConfig: %v", err)
 	}
-	second, err := pluginFingerprint("external", plugin, map[string]any{"runtime_key": "two"}, ".")
+
+	writePreparedPluginPackageConfigWithConfig(t, dir, packagePath, map[string]any{
+		"api_key": "two",
+	})
+
+	_, cfg, err := loadConfigForExecution(cfgPath, true)
 	if err != nil {
-		t.Fatalf("pluginFingerprint second: %v", err)
+		t.Fatalf("loadConfigForExecution: %v", err)
 	}
-	if first == second {
-		t.Fatal("expected prepared config to affect fingerprint")
+
+	pluginConfig, err := config.NodeToMap(cfg.Integrations["example"].Plugin.Config)
+	if err != nil {
+		t.Fatalf("NodeToMap: %v", err)
+	}
+	if got := pluginConfig["api_key"]; got != "two" {
+		t.Fatalf("api_key = %v, want %q", got, "two")
+	}
+}
+
+func TestLoadConfigForExecutionResolvesLateBoundManagedPluginEnv(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	envVar := "TEST_API_KEY_" + strings.ToUpper(strings.ReplaceAll(t.Name(), "/", "_"))
+	portEnvVar := envVar + "_PORT"
+	mcpEnvVar := envVar + "_MCP"
+	packagePath := buildPreparedTestPluginPackageRequiringAPIKey(t, dir, "github.com/acme/plugins/provider", "0.1.0", "provider")
+	cfgPath := writePreparedPluginPackageConfigWithConfig(t, dir, packagePath, map[string]any{
+		"api_key": "${" + envVar + "}",
+	})
+	cfgData, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("ReadFile config: %v", err)
+	}
+	updatedCfg := strings.Replace(string(cfgData), "server:\n  encryption_key: test-key\n", "server:\n  port: ${"+portEnvVar+"}\n  encryption_key: test-key\n", 1)
+	if updatedCfg == string(cfgData) {
+		t.Fatal("expected to rewrite server block in config")
+	}
+	updatedCfg += "    mcp:\n      enabled: ${" + mcpEnvVar + "}\n"
+	if err := os.WriteFile(cfgPath, []byte(updatedCfg), 0644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	savedEnv := map[string]*string{}
+	for _, key := range []string{envVar, portEnvVar, mcpEnvVar} {
+		if value, ok := os.LookupEnv(key); ok {
+			value := value
+			savedEnv[key] = &value
+		}
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatalf("Unsetenv %s: %v", key, err)
+		}
+	}
+	t.Cleanup(func() {
+		for _, key := range []string{envVar, portEnvVar, mcpEnvVar} {
+			if value, ok := savedEnv[key]; ok && value != nil {
+				_ = os.Setenv(key, *value)
+				continue
+			}
+			_ = os.Unsetenv(key)
+		}
+	})
+
+	if err := initConfig(cfgPath); err != nil {
+		t.Fatalf("initConfig: %v", err)
+	}
+
+	if err := os.Setenv(envVar, "runtime-value"); err != nil {
+		t.Fatalf("Setenv %s: %v", envVar, err)
+	}
+
+	_, cfg, err := loadConfigForExecution(cfgPath, true)
+	if err != nil {
+		t.Fatalf("loadConfigForExecution: %v", err)
+	}
+
+	pluginConfig, err := config.NodeToMap(cfg.Integrations["example"].Plugin.Config)
+	if err != nil {
+		t.Fatalf("NodeToMap: %v", err)
+	}
+	if got := pluginConfig["api_key"]; got != "runtime-value" {
+		t.Fatalf("api_key = %v, want %q", got, "runtime-value")
+	}
+	if cfg.Server.Port != 8080 {
+		t.Fatalf("server.port = %d, want %d", cfg.Server.Port, 8080)
 	}
 }
 
@@ -164,13 +246,7 @@ func TestValidateConfigUsesPreparedManifestForPluginPackage(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	packagePath := buildPreparedTestPluginPackageWithSchema(t, dir, "github.com/acme/plugins/provider", "0.1.0", "not-an-executable", "schemas/config.schema.json", `{
-  "type": "object",
-  "required": ["api_key"],
-  "properties": {
-    "api_key": { "type": "string" }
-  }
-}`)
+	packagePath := buildPreparedTestPluginPackageRequiringAPIKey(t, dir, "github.com/acme/plugins/provider", "0.1.0", "not-an-executable")
 	cfgPath := writePreparedPluginPackageConfigWithConfig(t, dir, packagePath, map[string]any{
 		"api_key": "sk-test",
 	})
@@ -362,6 +438,17 @@ providers:
 func buildPreparedTestPluginPackage(t *testing.T, dir, source, version, content string) string {
 	t.Helper()
 	return buildPreparedTestPluginPackageWithSchema(t, dir, source, version, content, "", "")
+}
+
+func buildPreparedTestPluginPackageRequiringAPIKey(t *testing.T, dir, source, version, content string) string {
+	t.Helper()
+	return buildPreparedTestPluginPackageWithSchema(t, dir, source, version, content, "schemas/config.schema.json", `{
+  "type": "object",
+  "required": ["api_key"],
+  "properties": {
+    "api_key": { "type": "string" }
+  }
+}`)
 }
 
 func buildPreparedTestPluginPackageWithSchema(t *testing.T, dir, source, version, content, schemaPath, schema string) string {

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -515,24 +515,94 @@ func OperationOverridesFromManifest(overrides map[string]*pluginmanifestv1.Manif
 }
 
 func Load(path string) (*Config, error) {
-	return LoadWithLookup(path, os.LookupEnv)
+	return loadWithLookup(path, os.LookupEnv, false)
 }
 
 func LoadWithMapping(path string, getenv func(string) string) (*Config, error) {
-	return LoadWithLookup(path, func(key string) (string, bool) {
+	return loadWithLookup(path, func(key string) (string, bool) {
 		// Preserve the legacy os.Expand-style contract for callers that only
 		// provide a string mapping: the mapped value wins even when it is empty.
 		return getenv(key), true
-	})
+	}, false)
 }
 
 func LoadWithLookup(path string, lookup func(string) (string, bool)) (*Config, error) {
+	return loadWithLookup(path, lookup, false)
+}
+
+func OverlayManagedPluginConfig(path string, cfg *Config) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading config file: %w", err)
+	}
+
+	var root yaml.Node
+	dec := yaml.NewDecoder(strings.NewReader(string(data)))
+	if err := dec.Decode(&root); err != nil && err != io.EOF {
+		return fmt.Errorf("parsing config YAML: %w", err)
+	}
+	providers := mappingValueNode(documentValueNode(&root), "providers")
+	if providers == nil {
+		return nil
+	}
+
+	for name := range cfg.Integrations {
+		intg := cfg.Integrations[name]
+		if intg.Plugin == nil || !intg.Plugin.HasManagedArtifacts() {
+			continue
+		}
+
+		raw := mappingValueNode(providers, name)
+		if raw == nil {
+			continue
+		}
+		configNode := mappingValueNode(raw, "config")
+		if configNode == nil || configNode.Kind == 0 {
+			continue
+		}
+
+		node, err := overlayEnvIntoNode(*configNode, os.LookupEnv, true)
+		if err != nil {
+			return fmt.Errorf("expanding managed plugin config for integration %q: %w", name, err)
+		}
+
+		intg.Plugin.Config = node
+		cfg.Integrations[name] = intg
+	}
+
+	return nil
+}
+
+func documentValueNode(node *yaml.Node) *yaml.Node {
+	if node == nil {
+		return nil
+	}
+	if node.Kind == yaml.DocumentNode && len(node.Content) == 1 {
+		return node.Content[0]
+	}
+	return node
+}
+
+func mappingValueNode(node *yaml.Node, key string) *yaml.Node {
+	node = documentValueNode(node)
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func loadWithLookup(path string, lookup func(string) (string, bool), preserveMissing bool) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading config file: %w", err)
 	}
 
-	resolved, err := expandEnvVariables(string(data), lookup)
+	resolved, err := expandEnvVariables(string(data), lookup, preserveMissing)
 	if err != nil {
 		return nil, err
 	}
@@ -555,7 +625,7 @@ func LoadWithLookup(path string, lookup func(string) (string, bool)) (*Config, e
 	return &cfg, nil
 }
 
-func expandEnvVariables(input string, lookup func(string) (string, bool)) (string, error) {
+func expandEnvVariables(input string, lookup func(string) (string, bool), preserveMissing bool) (string, error) {
 	var expandErr error
 	resolved := os.Expand(input, func(key string) string {
 		if expandErr != nil {
@@ -566,6 +636,9 @@ func expandEnvVariables(input string, lookup func(string) (string, bool)) (strin
 		}
 		filePath, ok := lookup(key + "_FILE")
 		if !ok || filePath == "" {
+			if preserveMissing {
+				return "${" + key + "}"
+			}
 			return ""
 		}
 		data, err := os.ReadFile(filePath)
@@ -579,6 +652,28 @@ func expandEnvVariables(input string, lookup func(string) (string, bool)) (strin
 		return "", fmt.Errorf("expanding config environment variables: %w", expandErr)
 	}
 	return resolved, nil
+}
+
+func overlayEnvIntoNode(node yaml.Node, lookup func(string) (string, bool), preserveMissing bool) (yaml.Node, error) {
+	data, err := yaml.Marshal(&node)
+	if err != nil {
+		return yaml.Node{}, fmt.Errorf("marshaling config node: %w", err)
+	}
+
+	resolved, err := expandEnvVariables(string(data), lookup, preserveMissing)
+	if err != nil {
+		return yaml.Node{}, err
+	}
+
+	var out yaml.Node
+	dec := yaml.NewDecoder(strings.NewReader(resolved))
+	if err := dec.Decode(&out); err != nil && err != io.EOF {
+		return yaml.Node{}, fmt.Errorf("parsing config YAML: %w", err)
+	}
+	if out.Kind == yaml.DocumentNode && len(out.Content) == 1 {
+		return *out.Content[0], nil
+	}
+	return out, nil
 }
 
 func applyDefaults(cfg *Config) {

--- a/server/internal/operator/lifecycle.go
+++ b/server/internal/operator/lifecycle.go
@@ -63,6 +63,9 @@ func (l *Lifecycle) InitAtPath(configPath string) (*Lockfile, error) {
 	if err != nil {
 		return nil, fmt.Errorf("loading config: %v", err)
 	}
+	if err := config.OverlayManagedPluginConfig(configPath, cfg); err != nil {
+		return nil, fmt.Errorf("loading config: %v", err)
+	}
 
 	paths := initPathsForConfig(configPath)
 	if err := os.MkdirAll(paths.providersDir, 0o755); err != nil {
@@ -126,14 +129,10 @@ type initPaths struct {
 }
 
 type pluginFingerprintInput struct {
-	Name    string            `json:"name"`
-	Command string            `json:"command,omitempty"`
-	Package string            `json:"package,omitempty"`
-	Source  string            `json:"source,omitempty"`
-	Version string            `json:"version,omitempty"`
-	Args    []string          `json:"args,omitempty"`
-	Env     map[string]string `json:"env,omitempty"`
-	Config  map[string]any    `json:"config,omitempty"`
+	Name    string `json:"name"`
+	Package string `json:"package,omitempty"`
+	Source  string `json:"source,omitempty"`
+	Version string `json:"version,omitempty"`
 }
 
 func configHasPlugins(cfg *config.Config) bool {
@@ -214,8 +213,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 			continue
 		}
 		entry, found := lock.Plugins[LockPluginKey("integration", name)]
-		configMap, err := config.NodeToMap(intg.Plugin.Config)
-		if err != nil || !pluginEntryMatches(paths, name, intg.Plugin, configMap, entry, found) {
+		if !pluginEntryMatches(paths, name, intg.Plugin, entry, found) {
 			return false
 		}
 	}
@@ -257,22 +255,16 @@ func relativePackagePath(configDir, pkg string) string {
 	return pkg
 }
 
-func PluginFingerprint(name string, plugin *config.PluginDef, configMap map[string]any, configDir string) (string, error) {
+func PluginFingerprint(name string, plugin *config.PluginDef, configDir string) (string, error) {
 	if plugin == nil {
 		return "", nil
 	}
 
 	input := pluginFingerprintInput{
 		Name:    name,
-		Command: plugin.Command,
 		Package: relativePackagePath(configDir, plugin.Package),
 		Source:  plugin.Source,
 		Version: plugin.Version,
-		Args:    plugin.Args,
-		Env:     plugin.Env,
-	}
-	if configMap != nil {
-		input.Config = configMap
 	}
 
 	payload, err := json.Marshal(input)
@@ -305,11 +297,11 @@ func LockPluginKey(kind, name string) string {
 	return kind + ":" + name
 }
 
-func pluginEntryMatches(paths initPaths, name string, plugin *config.PluginDef, configMap map[string]any, entry LockPluginEntry, found bool) bool {
+func pluginEntryMatches(paths initPaths, name string, plugin *config.PluginDef, entry LockPluginEntry, found bool) bool {
 	if !found {
 		return false
 	}
-	fingerprint, err := PluginFingerprint(name, plugin, configMap, paths.configDir)
+	fingerprint, err := PluginFingerprint(name, plugin, paths.configDir)
 	if err != nil || entry.Fingerprint != fingerprint {
 		return false
 	}
@@ -430,7 +422,7 @@ func lockEntryForPackage(ctx context.Context, paths initPaths, kind, name string
 	if err := pluginpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, manifestKind(kind), configMap); err != nil {
 		return LockPluginEntry{}, fmt.Errorf("plugin config validation for %s %q: %w", kind, name, err)
 	}
-	fingerprint, err := PluginFingerprint(name, plugin, configMap, paths.configDir)
+	fingerprint, err := PluginFingerprint(name, plugin, paths.configDir)
 	if err != nil {
 		return LockPluginEntry{}, fmt.Errorf("fingerprinting %s %q plugin: %w", kind, name, err)
 	}
@@ -485,7 +477,7 @@ func (l *Lifecycle) lockEntryForSource(ctx context.Context, paths initPaths, kin
 	if err := pluginpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, manifestKind(kind), configMap); err != nil {
 		return LockPluginEntry{}, fmt.Errorf("plugin config validation for %s %q: %w", kind, name, err)
 	}
-	fingerprint, err := PluginFingerprint(name, plugin, configMap, paths.configDir)
+	fingerprint, err := PluginFingerprint(name, plugin, paths.configDir)
 	if err != nil {
 		return LockPluginEntry{}, fmt.Errorf("fingerprinting %s %q plugin: %w", kind, name, err)
 	}
@@ -674,7 +666,7 @@ func applyLockedPluginEntry(paths initPaths, lock *Lockfile, kind, name string, 
 	if !ok {
 		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", kind, name, paths.configPath)
 	}
-	fingerprint, err := PluginFingerprint(name, plugin, configMap, paths.configDir)
+	fingerprint, err := PluginFingerprint(name, plugin, paths.configDir)
 	if err != nil {
 		return fmt.Errorf("fingerprinting %s %q plugin: %w", kind, name, err)
 	}

--- a/server/internal/operator/lifecycle_test.go
+++ b/server/internal/operator/lifecycle_test.go
@@ -303,35 +303,16 @@ func TestPluginFingerprint_Stable(t *testing.T) {
 	plugin := &config.PluginDef{
 		Package: "./test-plugin-dir",
 	}
-	first, err := PluginFingerprint("example", plugin, nil, ".")
+	first, err := PluginFingerprint("example", plugin, ".")
 	if err != nil {
 		t.Fatalf("PluginFingerprint: %v", err)
 	}
-	second, err := PluginFingerprint("example", plugin, nil, ".")
+	second, err := PluginFingerprint("example", plugin, ".")
 	if err != nil {
 		t.Fatalf("PluginFingerprint: %v", err)
 	}
 	if first != second {
 		t.Fatalf("fingerprint not stable: %q != %q", first, second)
-	}
-}
-
-func TestPluginFingerprint_ChangesWithConfig(t *testing.T) {
-	t.Parallel()
-
-	plugin := &config.PluginDef{
-		Package: "./test-plugin-dir",
-	}
-	first, err := PluginFingerprint("example", plugin, map[string]any{"key": "one"}, ".")
-	if err != nil {
-		t.Fatalf("PluginFingerprint: %v", err)
-	}
-	second, err := PluginFingerprint("example", plugin, map[string]any{"key": "two"}, ".")
-	if err != nil {
-		t.Fatalf("PluginFingerprint: %v", err)
-	}
-	if first == second {
-		t.Fatal("fingerprint should differ with different config")
 	}
 }
 
@@ -341,11 +322,11 @@ func TestPluginFingerprint_ChangesWithName(t *testing.T) {
 	plugin := &config.PluginDef{
 		Package: "./test-plugin-dir",
 	}
-	first, err := PluginFingerprint("alpha", plugin, nil, ".")
+	first, err := PluginFingerprint("alpha", plugin, ".")
 	if err != nil {
 		t.Fatalf("PluginFingerprint: %v", err)
 	}
-	second, err := PluginFingerprint("beta", plugin, nil, ".")
+	second, err := PluginFingerprint("beta", plugin, ".")
 	if err != nil {
 		t.Fatalf("PluginFingerprint: %v", err)
 	}


### PR DESCRIPTION
## Summary
- preserve missing `${VAR}` placeholders during `gestaltd init` so managed plugins can be prepared before runtime env vars are injected
- key managed-plugin lock freshness off prepared artifact inputs instead of runtime `plugin.config`/`plugin.env` values
- document that late-bound env vars and `secret://...` values for packaged/source plugins do not require re-running `init`

## Testing
- `go test ./internal/config ./internal/operator`
- `go test ./cmd/gestaltd`