### PR TITLE
[codex] Deploy docs to docs.valon.tools

### DIFF
--- a/.github/workflows/publish-gestaltd-image.yml
+++ b/.github/workflows/publish-gestaltd-image.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       IMAGE_NAME: valontechnologies/gestaltd
       IMAGE_SOURCE: https://github.com/${{ github.repository }}
-      IMAGE_DOCUMENTATION: https://docs.toolshed.peachstreet.dev
+      IMAGE_DOCUMENTATION: https://docs.valon.tools
       IMAGE_URL: https://hub.docker.com/r/valontechnologies/gestaltd
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-gestalt-cli.yml
+++ b/.github/workflows/release-gestalt-cli.yml
@@ -54,7 +54,7 @@ jobs:
     env:
       REGISTRY_IMAGE: valontechnologies/gestalt
       IMAGE_SOURCE: https://github.com/${{ github.repository }}
-      IMAGE_DOCUMENTATION: https://docs.toolshed.peachstreet.dev
+      IMAGE_DOCUMENTATION: https://docs.valon.tools
       IMAGE_URL: https://hub.docker.com/r/valontechnologies/gestalt
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -112,7 +112,7 @@ jobs:
     env:
       IMAGE_NAME: valontechnologies/gestaltd
       IMAGE_SOURCE: https://github.com/${{ github.repository }}
-      IMAGE_DOCUMENTATION: https://docs.toolshed.peachstreet.dev
+      IMAGE_DOCUMENTATION: https://docs.valon.tools
       IMAGE_URL: https://hub.docker.com/r/valontechnologies/gestaltd
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ CMD ["serve", "--locked", "--config", "/app/config.yaml"]
 
 ## Documentation
 
-Full documentation is available at [docs.toolshed.peachstreet.dev](https://docs.toolshed.peachstreet.dev).
+Full documentation is available at [docs.valon.tools](https://docs.valon.tools).
 
-- [Getting Started](https://docs.toolshed.peachstreet.dev/getting-started)
-- [Configuration](https://docs.toolshed.peachstreet.dev/concepts/configuration)
-- [CLI Reference](https://docs.toolshed.peachstreet.dev/reference/cli)
-- [Deployment](https://docs.toolshed.peachstreet.dev/deploy)
-- [Write a Plugin](https://docs.toolshed.peachstreet.dev/tasks/write-a-plugin)
+- [Getting Started](https://docs.valon.tools/getting-started)
+- [Configuration](https://docs.valon.tools/concepts/configuration)
+- [CLI Reference](https://docs.valon.tools/reference/cli)
+- [Deployment](https://docs.valon.tools/deploy)
+- [Write a Plugin](https://docs.valon.tools/tasks/write-a-plugin)

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -2,7 +2,7 @@ ARG GESTALT_VERSION=dev
 ARG GESTALT_REVISION=unknown
 ARG GESTALT_CREATED=unknown
 ARG GESTALT_SOURCE=https://github.com/valon-technologies/gestalt
-ARG GESTALT_DOCUMENTATION=https://docs.toolshed.peachstreet.dev
+ARG GESTALT_DOCUMENTATION=https://docs.valon.tools
 ARG GESTALT_URL=https://hub.docker.com/r/valontechnologies/gestalt
 
 FROM --platform=$BUILDPLATFORM alpine:3.23 AS unpack

--- a/docs/dockerhub/gestalt.md
+++ b/docs/dockerhub/gestalt.md
@@ -105,6 +105,6 @@ of the Docker image.
 
 ## Learn more
 
-- Docs: https://docs.toolshed.peachstreet.dev
-- CLI reference: https://docs.toolshed.peachstreet.dev/reference/cli
+- Docs: https://docs.valon.tools
+- CLI reference: https://docs.valon.tools/reference/cli
 - Source: https://github.com/valon-technologies/gestalt

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -190,7 +190,7 @@ RUN go build -o ./my-plugin/artifacts/linux/amd64/provider ./plugins/cmd/myplugi
 
 ## Learn more
 
-- Docs: https://docs.toolshed.peachstreet.dev
-- CLI reference: https://docs.toolshed.peachstreet.dev/reference/cli
-- Deployment docs: https://docs.toolshed.peachstreet.dev/deploy
+- Docs: https://docs.valon.tools
+- CLI reference: https://docs.valon.tools/reference/cli
+- Deployment docs: https://docs.valon.tools/deploy
 - Source: https://github.com/valon-technologies/gestalt

--- a/docs/terraform/variables.tf
+++ b/docs/terraform/variables.tf
@@ -19,13 +19,13 @@ variable "dns_project_id" {
 variable "dns_zone_name" {
   description = "Cloud DNS managed zone name"
   type        = string
-  default     = "peachstreet-dev"
+  default     = "valon-tools"
 }
 
 variable "domain" {
   description = "Docs site domain"
   type        = string
-  default     = "docs.toolshed.peachstreet.dev"
+  default     = "docs.valon.tools"
 }
 
 variable "docs_image" {

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,7 +2,7 @@ ARG GESTALT_VERSION=dev
 ARG GESTALT_REVISION=unknown
 ARG GESTALT_CREATED=unknown
 ARG GESTALT_SOURCE=https://github.com/valon-technologies/gestalt
-ARG GESTALT_DOCUMENTATION=https://docs.toolshed.peachstreet.dev
+ARG GESTALT_DOCUMENTATION=https://docs.valon.tools
 ARG GESTALT_URL=https://hub.docker.com/r/valontechnologies/gestaltd
 
 FROM --platform=$BUILDPLATFORM node:20-alpine AS frontend

--- a/server/internal/drivers/datastore/sqlite/warnings.go
+++ b/server/internal/drivers/datastore/sqlite/warnings.go
@@ -2,6 +2,6 @@ package sqlite
 
 func (s *Store) Warnings() []string {
 	return []string{
-		"using SQLite for the datastore; this is not recommended for production. See https://docs.toolshed.peachstreet.dev/deploy for alternatives.",
+		"using SQLite for the datastore; this is not recommended for production. See https://docs.valon.tools/deploy for alternatives.",
 	}
 }


### PR DESCRIPTION
## What changed
- switched the docs Terraform default hostname from `docs.toolshed.peachstreet.dev` to `docs.valon.tools`
- switched the default Cloud DNS managed zone from `peachstreet-dev` to `valon-tools`
- updated public-facing documentation URLs and image metadata so released artifacts point at the new docs hostname
- updated the SQLite production warning link to the new deployment docs URL

## Why
The docs deployment should now publish at `https://docs.valon.tools` instead of `https://docs.toolshed.peachstreet.dev`.

I verified the existing `valon-tools` public managed zone is present in the `serviceone` GCP project, so the Terraform defaults now line up with the current DNS location while leaving the docs runtime in `gitlab-peach-street`.

## Validation
- `npm ci` in `docs/`
- `npm run build` in `docs/`
- `terraform fmt -check -diff docs/terraform`
- `terraform init -backend=false` in `docs/terraform`
- `terraform validate` in `docs/terraform`
- repo-wide search confirms no remaining `docs.toolshed.peachstreet.dev` references in tracked files
