### PR TITLE
[codex] Fix docs cert replacement rollout

### DIFF
--- a/docs/terraform/main.tf
+++ b/docs/terraform/main.tf
@@ -19,6 +19,10 @@ provider "google" {
   project = var.dns_project_id
 }
 
+locals {
+  docs_cert_name = "toolshed-docs-cert-${replace(var.domain, ".", "-")}"
+}
+
 # ---------- Cloud Run ----------
 
 resource "google_cloud_run_v2_service" "docs" {
@@ -81,10 +85,14 @@ resource "google_compute_url_map" "docs" {
 }
 
 resource "google_compute_managed_ssl_certificate" "docs" {
-  name = "toolshed-docs-cert"
+  name = local.docs_cert_name
 
   managed {
     domains = [var.domain]
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 


### PR DESCRIPTION
## What changed
- changed the docs managed SSL certificate name to derive from the target domain
- added `create_before_destroy` to the managed SSL certificate resource

## Why
The merged `docs.valon.tools` rollout failed in `Terraform Apply` because Terraform tried to replace `toolshed-docs-cert` in place while that cert was still attached to `toolshed-docs-https-proxy`.

That left the deployment in a partial state:
- `docs.valon.tools` DNS now points at the docs load balancer
- `docs.toolshed.peachstreet.dev` DNS is gone
- the proxy is still serving the old `docs.toolshed.peachstreet.dev` certificate, so browsers show `NET::ERR_CERT_COMMON_NAME_INVALID`

This change makes the certificate replacement non-destructive by creating a new cert with a distinct name first, updating the HTTPS proxy, and only then destroying the old cert.

## Validation
- `terraform fmt -check -diff docs/terraform`
- `terraform init` in `docs/terraform`
- `terraform plan -var='docs_image=us-east4-docker.pkg.dev/gitlab-peach-street/cloud-run-source-deploy/gestalt-docs:dc16a16e1075435f83beb070d21233bc4355d8f6'`

The resulting plan is now:
- `1 to add, 1 to change, 1 to destroy`
- cert replacement is `create replacement and then destroy`
