### PR TITLE
[codex] Simplify secret reference handling

### DIFF
--- a/docs/pages/concepts/configuration.mdx
+++ b/docs/pages/concepts/configuration.mdx
@@ -23,7 +23,7 @@ Loading a config is more than YAML parsing:
 4. Connection auth is validated against surface references.
 5. Relative paths are resolved against the directory that contains the config file.
 6. Validation runs.
-7. During bootstrap, `secret://...` values are resolved through the configured secret manager.
+7. During bootstrap, `secret://...` values in bootstrap-managed config sections are resolved through the configured secret manager.
 
 `secret://...` resolution is intentionally later than basic config parsing. That keeps the config loader simple and lets the secret manager itself be configured normally.
 
@@ -118,7 +118,7 @@ That makes configs portable across local runs, Docker mounts, and Kubernetes vol
 
 ## Secret References
 
-Any string value outside `secrets.config` may use the `secret://` scheme:
+Bootstrap-managed string values in `server`, `auth`, `datastore`, `telemetry`, `providers`, and `bindings` may use the `secret://` scheme:
 
 ```yaml
 auth:
@@ -135,6 +135,8 @@ The secret manager resolves the part after `secret://`:
 - `aws_secrets_manager` reads it from AWS Secrets Manager
 - `vault` reads it from HashiCorp Vault
 - `azure_key_vault` reads it from Azure Key Vault
+
+`egress.credentials[].secret_ref` is a different mechanism. It uses a bare secret name and resolves it at request time rather than during bootstrap.
 
 ## The Smallest Explicit Config
 

--- a/docs/pages/concepts/configuration.mdx
+++ b/docs/pages/concepts/configuration.mdx
@@ -23,7 +23,7 @@ Loading a config is more than YAML parsing:
 4. Connection auth is validated against surface references.
 5. Relative paths are resolved against the directory that contains the config file.
 6. Validation runs.
-7. During bootstrap, `secret://...` values in bootstrap-managed config sections are resolved through the configured secret manager.
+7. During bootstrap, `secret://...` values are resolved through the configured secret manager.
 
 `secret://...` resolution is intentionally later than basic config parsing. That keeps the config loader simple and lets the secret manager itself be configured normally.
 
@@ -115,28 +115,6 @@ Paths in config are resolved relative to the config file directory, not the proc
 - local `providers.<name>.from.package` paths
 
 That makes configs portable across local runs, Docker mounts, and Kubernetes volumes.
-
-## Secret References
-
-Bootstrap-managed string values in `server`, `auth`, `datastore`, `telemetry`, `providers`, and `bindings` may use the `secret://` scheme:
-
-```yaml
-auth:
-  provider: oidc
-  config:
-    client_secret: secret://oidc-client-secret
-```
-
-The secret manager resolves the part after `secret://`:
-
-- `env` reads it from an environment variable name
-- `file` reads it from a file inside a configured directory
-- `google_secret_manager` reads it from Google Cloud Secret Manager
-- `aws_secrets_manager` reads it from AWS Secrets Manager
-- `vault` reads it from HashiCorp Vault
-- `azure_key_vault` reads it from Azure Key Vault
-
-`egress.credentials[].secret_ref` is a different mechanism. It uses a bare secret name and resolves it at request time rather than during bootstrap.
 
 ## The Smallest Explicit Config
 

--- a/docs/pages/concepts/platform-model.mdx
+++ b/docs/pages/concepts/platform-model.mdx
@@ -33,7 +33,7 @@ This is the actual shape of startup:
 6. Resolve relative paths against the config file directory.
 7. Validate the config.
 8. Build the secret manager.
-9. Resolve `secret://...` references in bootstrap-managed config sections (`server`, `auth`, `datastore`, `telemetry`, `providers`, and `bindings`).
+9. Resolve `secret://...` references.
 10. Build the platform auth provider.
 11. Build the datastore.
 12. Build providers from `providers`.

--- a/docs/pages/concepts/platform-model.mdx
+++ b/docs/pages/concepts/platform-model.mdx
@@ -33,7 +33,7 @@ This is the actual shape of startup:
 6. Resolve relative paths against the config file directory.
 7. Validate the config.
 8. Build the secret manager.
-9. Resolve `secret://...` references across the rest of the config.
+9. Resolve `secret://...` references in bootstrap-managed config sections (`server`, `auth`, `datastore`, `telemetry`, `providers`, and `bindings`).
 10. Build the platform auth provider.
 11. Build the datastore.
 12. Build providers from `providers`.

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -165,14 +165,6 @@ secrets:
 | `vault` | `address`, `token`, `mount_path`, `namespace` | HashiCorp Vault KV v2. `mount_path` defaults to `secret`. |
 | `azure_key_vault` | `vault_url`, `version` | Azure Key Vault. `version` defaults to latest. |
 
-Bootstrap-managed string values in `server`, `auth`, `datastore`, `telemetry`, `providers`, and `bindings` may use the `secret://` prefix:
-
-```yaml
-encryption_key: secret://name-of-secret
-```
-
-`egress.credentials[].secret_ref` is separate: it is a bare secret name resolved at request time and must not include `secret://`.
-
 ## `telemetry`
 
 Controls distributed traces, metrics, and structured logs. Gestalt uses [OpenTelemetry](https://opentelemetry.io) under the hood. Every HTTP request, broker invocation, and plugin gRPC call is automatically traced.
@@ -685,7 +677,7 @@ egress:
 
 | Field | Purpose |
 | --- | --- |
-| `secret_ref` | Required. Bare secret manager key resolved at request time. Do not include `secret://`. |
+| `secret_ref` | Required. Secret manager key resolved at request time. |
 | `auth_style` | How the resolved secret is injected: `bearer`, `basic`, or `raw`. Defaults to `bearer`. |
 | `subject_kind` | Optional subject filter. |
 | `subject_id` | Optional subject filter. |

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -165,11 +165,13 @@ secrets:
 | `vault` | `address`, `token`, `mount_path`, `namespace` | HashiCorp Vault KV v2. `mount_path` defaults to `secret`. |
 | `azure_key_vault` | `vault_url`, `version` | Azure Key Vault. `version` defaults to latest. |
 
-Any string value outside `secrets.config` may use the `secret://` prefix:
+Bootstrap-managed string values in `server`, `auth`, `datastore`, `telemetry`, `providers`, and `bindings` may use the `secret://` prefix:
 
 ```yaml
 encryption_key: secret://name-of-secret
 ```
+
+`egress.credentials[].secret_ref` is separate: it is a bare secret name resolved at request time and must not include `secret://`.
 
 ## `telemetry`
 
@@ -683,7 +685,7 @@ egress:
 
 | Field | Purpose |
 | --- | --- |
-| `secret_ref` | Required. Secret manager key resolved at request time. |
+| `secret_ref` | Required. Bare secret manager key resolved at request time. Do not include `secret://`. |
 | `auth_style` | How the resolved secret is injected: `bearer`, `basic`, or `raw`. Defaults to `bearer`. |
 | `subject_kind` | Optional subject filter. |
 | `subject_id` | Optional subject filter. |

--- a/server/internal/bootstrap/egress_test.go
+++ b/server/internal/bootstrap/egress_test.go
@@ -26,7 +26,7 @@ func TestEgressPolicyWiredThroughBootstrap(t *testing.T) {
 		},
 		Credentials: []config.EgressCredentialGrant{
 			{
-				SecretRef:  "secret://alpha-key",
+				SecretRef:  "alpha-key",
 				AuthStyle:  "bearer",
 				Host:       "api.test",
 				PathPrefix: "/v1/private",

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -1316,6 +1316,9 @@ func validateEgress(cfg *EgressConfig) error {
 		if c.SecretRef == "" {
 			return fmt.Errorf("config validation: egress.credentials[%d]: secret_ref is required", i)
 		}
+		if strings.HasPrefix(c.SecretRef, "secret://") {
+			return fmt.Errorf("config validation: egress.credentials[%d]: secret_ref must be a bare secret name without secret://", i)
+		}
 		if err := egress.ValidateCredentialGrant(egress.CredentialGrantValidationInput{
 			SubjectKind: c.SubjectKind,
 			SubjectID:   c.SubjectID,

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -276,25 +276,6 @@ egress:
 	}
 }
 
-func TestLoadConfigRejectsPrefixedEgressSecretRef(t *testing.T) {
-	t.Parallel()
-
-	path := mustWriteConfigFile(t, `
-egress:
-  credentials:
-    - host: api.example.com
-      secret_ref: secret://api-key
-`)
-
-	_, err := Load(path)
-	if err == nil {
-		t.Fatal("Load: expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "bare secret name without secret://") {
-		t.Fatalf("Load: error = %q, want bare secret name guidance", err)
-	}
-}
-
 func TestValidConfigurations(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -276,6 +276,25 @@ egress:
 	}
 }
 
+func TestLoadConfigRejectsPrefixedEgressSecretRef(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+egress:
+  credentials:
+    - host: api.example.com
+      secret_ref: secret://api-key
+`)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "bare secret name without secret://") {
+		t.Fatalf("Load: error = %q, want bare secret name guidance", err)
+	}
+}
+
 func TestValidConfigurations(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/egress/credential_grant_resolver.go
+++ b/server/internal/egress/credential_grant_resolver.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 )
 
-const secretURIPrefix = "secret://"
-
 // CredentialGrantLoader loads credential grants for resolution. Implementations
 // may return static config grants or fetch persisted grants from a store.
 type CredentialGrantLoader interface {
@@ -71,10 +69,12 @@ func resolveSecretGrant(ctx context.Context, sr SecretResolver, grant *Credentia
 	if sr == nil {
 		return CredentialMaterialization{}, fmt.Errorf("egress credentials: no secret resolver configured")
 	}
-	name := strings.TrimPrefix(grant.SecretRef, secretURIPrefix)
-	secret, err := sr.GetSecret(ctx, name)
+	if strings.HasPrefix(grant.SecretRef, "secret://") {
+		return CredentialMaterialization{}, fmt.Errorf("egress credentials: secret_ref %q must be a bare secret name without secret://", grant.SecretRef)
+	}
+	secret, err := sr.GetSecret(ctx, grant.SecretRef)
 	if err != nil {
-		return CredentialMaterialization{}, fmt.Errorf("egress credentials: resolving secret %q: %w", name, err)
+		return CredentialMaterialization{}, fmt.Errorf("egress credentials: resolving secret %q: %w", grant.SecretRef, err)
 	}
 	style := grant.AuthStyle
 	if style == "" {

--- a/server/internal/egress/credential_grant_resolver_test.go
+++ b/server/internal/egress/credential_grant_resolver_test.go
@@ -3,6 +3,7 @@ package egress
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -109,7 +110,7 @@ func TestCredentialGrantResolver_MultiTenantHostMatching(t *testing.T) {
 	}
 }
 
-func TestCredentialGrantResolver_StripsSecretURIPrefix(t *testing.T) {
+func TestCredentialGrantResolver_RejectsSecretURIPrefix(t *testing.T) {
 	t.Parallel()
 
 	secrets := &stubSecretResolver{
@@ -136,15 +137,16 @@ func TestCredentialGrantResolver_StripsSecretURIPrefix(t *testing.T) {
 		Subject{Kind: SubjectUser, ID: "user-1"},
 		Target{Method: http.MethodGet, Host: "api.prefix.test", Path: "/v1"},
 	)
-	if err != nil {
-		t.Fatalf("ResolveCredential: %v", err)
+	if err == nil {
+		t.Fatal("ResolveCredential: expected error, got nil")
 	}
-
-	const wantAuth = "Bearer sk-with-prefix"
-	if materialized.Authorization != wantAuth {
-		t.Fatalf("Authorization = %q, want %q", materialized.Authorization, wantAuth)
+	if materialized.Authorization != "" || len(materialized.Headers) != 0 {
+		t.Fatalf("materialized = %+v, want empty authorization and headers", materialized)
 	}
-	if len(secrets.lookups) != 1 || secrets.lookups[0] != "prefixed-key" {
-		t.Fatalf("secret lookups = %v, want [prefixed-key]", secrets.lookups)
+	if len(secrets.lookups) != 0 {
+		t.Fatalf("secret lookups = %v, want []", secrets.lookups)
+	}
+	if !strings.Contains(err.Error(), "bare secret name") {
+		t.Fatalf("error = %q, want bare secret name guidance", err)
 	}
 }


### PR DESCRIPTION
## Summary
- make `egress.credentials[].secret_ref` accept only bare secret names and reject `secret://...`
- update config validation and tests to enforce the bootstrap-vs-runtime secret split
- tighten docs so `secret://` is documented only for bootstrap-managed config sections

## Why
`secret://` and `secret_ref` had overlapping behavior even though they represent different resolution modes. This change removes the ambiguous overlap without dropping multi-cloud secret backends.

## Validation
- `go test ./...` (from `server/`)
