### PR TITLE
Use Valon typography in docs site

### DIFF
--- a/docs/globals.css
+++ b/docs/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Bitter:ital,wght@0,400;0,600;0,700;1,400&family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Instrument+Serif&family=Outfit:wght@300;400;500;600&family=JetBrains+Mono&display=swap');
 
 :root {
   --nextra-primary-hue: 30deg;
@@ -6,16 +6,16 @@
 }
 
 html {
-  font-family: 'IBM Plex Sans', system-ui, sans-serif;
+  font-family: 'Outfit', system-ui, sans-serif;
 }
 
 h1, h2, h3, h4, h5, h6,
 article h1, article h2, article h3, article h4 {
-  font-family: 'Bitter', Georgia, serif;
+  font-family: 'Instrument Serif', Georgia, serif;
 }
 
 code, pre, kbd, samp {
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'JetBrains Mono', monospace;
 }
 
 /* Show the TOC at lg (1024px) instead of xl (1280px).

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -2,7 +2,7 @@ import { useConfig } from "nextra-theme-docs";
 import type { DocsThemeConfig } from "nextra-theme-docs";
 
 const config: DocsThemeConfig = {
-  logo: <strong style={{ fontFamily: "'Bitter', Georgia, serif" }}>Gestalt</strong>,
+  logo: <strong style={{ fontFamily: "'Instrument Serif', Georgia, serif" }}>Gestalt</strong>,
   project: {
     link: "https://github.com/valon-technologies/gestalt",
   },


### PR DESCRIPTION
## Summary
- Switch docs fonts from Bitter/IBM Plex to the Valon font stack: Instrument Serif (headings), Outfit (body), JetBrains Mono (code)
- Matches the typography from valon.ai/style

## Test plan
- [ ] Verify docs headings render in Instrument Serif
- [ ] Verify body text renders in Outfit
- [ ] Verify code blocks render in JetBrains Mono
- [ ] Check logo in sidebar uses Instrument Serif

🤖 Generated with [Claude Code](https://claude.com/claude-code)