### PR TITLE
[codex] Align alpha.1 release versioning

### DIFF
--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -101,9 +101,13 @@ jobs:
         run: |
           mkdir release
           find artifacts -type f \( -name "*.tar.gz" -o -name "*.sha256" \) -exec mv {} release/ \;
-      - uses: softprops/action-gh-release@v2
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
         with:
           files: release/*
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
 
   publish-image:
     name: Publish Docker Image

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli", "xtask"]
 
 [workspace.package]
-version = "0.0.1-alpha.33"
+version = "0.0.1-alpha.1"
 edition = "2024"


### PR DESCRIPTION
## What changed
- mark `gestaltd` alpha, beta, and rc GitHub releases as prereleases in the release workflow
- update the Rust CLI workspace version to `0.0.1-alpha.1` so local/source builds report the same version line we reset the releases to

## Why
- GitHub does not infer the `Pre-release` flag from tags like `gestaltd/v0.0.1-alpha.1`; the workflow has to set it explicitly
- the checked-in Rust workspace version was still `0.0.1-alpha.33`, which made `gestalt --version` disagree with the reset release line

## Impact
- future `gestaltd` prerelease tags will render correctly as GitHub prereleases
- local and source-built `gestalt` binaries now report `0.0.1-alpha.1`

## Validation
- ran `cargo run --manifest-path client/Cargo.toml -p gestalt -- --version`
- verified output: `gestalt 0.0.1-alpha.1`
