### PR TITLE
[codex] Pin Docker base image digests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: /server
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: build
+
+  - package-ecosystem: docker
+    directory: /client
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: build
+
+  - package-ecosystem: docker
+    directory: /docs
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: build

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -5,7 +5,7 @@ ARG GESTALT_SOURCE=https://github.com/valon-technologies/gestalt
 ARG GESTALT_DOCUMENTATION=https://docs.valon.tools
 ARG GESTALT_URL=https://hub.docker.com/r/valontechnologies/gestalt
 
-FROM --platform=$BUILDPLATFORM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS unpack
+FROM --platform=$BUILDPLATFORM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS unpack
 ARG TARGETARCH
 WORKDIR /dist
 COPY dist/ /dist/

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -5,7 +5,7 @@ ARG GESTALT_SOURCE=https://github.com/valon-technologies/gestalt
 ARG GESTALT_DOCUMENTATION=https://docs.valon.tools
 ARG GESTALT_URL=https://hub.docker.com/r/valontechnologies/gestalt
 
-FROM --platform=$BUILDPLATFORM alpine:3.23 AS unpack
+FROM --platform=$BUILDPLATFORM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS unpack
 ARG TARGETARCH
 WORKDIR /dist
 COPY dist/ /dist/
@@ -18,7 +18,7 @@ RUN case "$TARGETARCH" in \
     tar -xzf "/dist/$archive" -C /out && \
     test -x /out/gestalt
 
-FROM gcr.io/distroless/cc-debian12
+FROM gcr.io/distroless/cc-debian12@sha256:329e54034ce498f9c6b345044e8f530c6691f99e94a92446f68c0adf9baa8464
 ARG GESTALT_VERSION
 ARG GESTALT_REVISION
 ARG GESTALT_CREATED

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:20-alpine@sha256:f598378b5240225e6beab68fa9f356db1fb8efe55173e6d4d8153113bb8f333c AS builder
+FROM node:20.20.2-alpine3.23@sha256:f598378b5240225e6beab68fa9f356db1fb8efe55173e6d4d8153113bb8f333c AS builder
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
 RUN npm run build
 
-FROM nginx:alpine@sha256:e7257f1ef28ba17cf7c248cb8ccf6f0c6e0228ab9c315c152f9c203cd34cf6d1
+FROM nginx:1.29.7-alpine@sha256:e7257f1ef28ba17cf7c248cb8ccf6f0c6e0228ab9c315c152f9c203cd34cf6d1
 COPY --from=builder /app/out /usr/share/nginx/html
 COPY <<'EOF' /etc/nginx/conf.d/default.conf
 server {

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:20-alpine AS builder
+FROM node:20-alpine@sha256:f598378b5240225e6beab68fa9f356db1fb8efe55173e6d4d8153113bb8f333c AS builder
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
 RUN npm run build
 
-FROM nginx:alpine
+FROM nginx:alpine@sha256:e7257f1ef28ba17cf7c248cb8ccf6f0c6e0228ab9c315c152f9c203cd34cf6d1
 COPY --from=builder /app/out /usr/share/nginx/html
 COPY <<'EOF' /etc/nginx/conf.d/default.conf
 server {

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,14 +5,14 @@ ARG GESTALT_SOURCE=https://github.com/valon-technologies/gestalt
 ARG GESTALT_DOCUMENTATION=https://docs.valon.tools
 ARG GESTALT_URL=https://hub.docker.com/r/valontechnologies/gestaltd
 
-FROM --platform=$BUILDPLATFORM node:20-alpine AS frontend
+FROM --platform=$BUILDPLATFORM node:20-alpine@sha256:f598378b5240225e6beab68fa9f356db1fb8efe55173e6d4d8153113bb8f333c AS frontend
 WORKDIR /web
 COPY web/package.json web/package-lock.json ./
 RUN npm ci
 COPY web/ .
 RUN npm run build
 
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build-binary
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:2389ebfa5b7f43eeafbd6be0c3700cc46690ef842ad962f6c5bd6be49ed82039 AS build-binary
 WORKDIR /build
 COPY server/go.mod server/go.sum server/
 COPY sdk/go/go.mod sdk/go/go.sum sdk/go/
@@ -23,7 +23,7 @@ ARG TARGETARCH
 RUN cd server && CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /gestaltd ./cmd/gestaltd
 RUN mkdir /data
 
-FROM alpine:3.23
+FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 ARG GESTALT_VERSION
 ARG GESTALT_REVISION
 ARG GESTALT_CREATED

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,14 +5,14 @@ ARG GESTALT_SOURCE=https://github.com/valon-technologies/gestalt
 ARG GESTALT_DOCUMENTATION=https://docs.valon.tools
 ARG GESTALT_URL=https://hub.docker.com/r/valontechnologies/gestaltd
 
-FROM --platform=$BUILDPLATFORM node:20-alpine@sha256:f598378b5240225e6beab68fa9f356db1fb8efe55173e6d4d8153113bb8f333c AS frontend
+FROM --platform=$BUILDPLATFORM node:20.20.2-alpine3.23@sha256:f598378b5240225e6beab68fa9f356db1fb8efe55173e6d4d8153113bb8f333c AS frontend
 WORKDIR /web
 COPY web/package.json web/package-lock.json ./
 RUN npm ci
 COPY web/ .
 RUN npm run build
 
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:2389ebfa5b7f43eeafbd6be0c3700cc46690ef842ad962f6c5bd6be49ed82039 AS build-binary
+FROM --platform=$BUILDPLATFORM golang:1.26.1-alpine3.23@sha256:2389ebfa5b7f43eeafbd6be0c3700cc46690ef842ad962f6c5bd6be49ed82039 AS build-binary
 WORKDIR /build
 COPY server/go.mod server/go.sum server/
 COPY sdk/go/go.mod sdk/go/go.sum sdk/go/
@@ -23,7 +23,7 @@ ARG TARGETARCH
 RUN cd server && CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /gestaltd ./cmd/gestaltd
 RUN mkdir /data
 
-FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 ARG GESTALT_VERSION
 ARG GESTALT_REVISION
 ARG GESTALT_CREATED


### PR DESCRIPTION
## Summary
- pin external base images in `server/Dockerfile`, `client/Dockerfile`, and `docs/Dockerfile` to immutable digest hashes
- add `.github/dependabot.yml` entries for `/server`, `/client`, and `/docs` so Docker digest updates stay automated

## Why
Tag-only image references are mutable and leave the build pipeline exposed to unexpected upstream image changes or a compromised republish. Pinning to digests makes the resolved base image immutable while keeping the current tags readable.

## Root Cause
The Dockerfiles referenced upstream images by tag only (`node:20-alpine`, `golang:1.26-alpine`, `alpine:3.23`, `nginx:alpine`, `gcr.io/distroless/cc-debian12`) without digest locks.

## Impact
Builds for the server, client, and docs images now resolve to fixed upstream images. Future digest refreshes can be proposed automatically by Dependabot.

## Validation
- `git diff --check`
- resolved each pinned image reference with `docker buildx imagetools inspect`
