### PR TITLE
[codex] Verify kubeconform checksum in CI

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -241,8 +241,23 @@ jobs:
 
       - name: Install kubeconform
         run: |
-          curl -fsSL https://github.com/yannh/kubeconform/releases/download/v0.7.0/kubeconform-linux-amd64.tar.gz \
-            | tar xz -C /usr/local/bin
+          set -euo pipefail
+          version="v0.7.0"
+          archive="kubeconform-linux-amd64.tar.gz"
+          checksum="c31518ddd122663b3f3aa874cfe8178cb0988de944f29c74a0b9260920d115d3"
+          tmp_dir="$(mktemp -d)"
+          archive_path="${tmp_dir}/${archive}"
+
+          trap 'rm -rf "${tmp_dir}"' EXIT
+
+          curl -fsSLo "${archive_path}" \
+            "https://github.com/yannh/kubeconform/releases/download/${version}/${archive}"
+          actual_checksum="$(sha256sum "${archive_path}" | awk '{print $1}')"
+          if [ "${actual_checksum}" != "${checksum}" ]; then
+            echo "Checksum mismatch for ${archive}: ${actual_checksum}" >&2
+            exit 1
+          fi
+          tar xzf "${archive_path}" -C /usr/local/bin kubeconform
 
       - name: Validate Kubernetes schemas
         run: kubeconform -strict -summary /tmp/rendered.yaml


### PR DESCRIPTION
## Summary
- replace the `curl | tar` install step for `kubeconform` with an explicit download to a temporary file
- verify the downloaded `kubeconform-linux-amd64.tar.gz` archive against the pinned SHA-256 for upstream `v0.7.0`
- extract only the `kubeconform` binary after the checksum passes

## Why
The previous workflow trusted the GitHub release download path and extracted the archive directly into `/usr/local/bin` without verifying integrity first. Pinning the expected digest closes that gap and makes the CI install step fail closed on tampering or an unexpected asset change.

## Validation
- ran `git diff --check`
- downloaded the upstream `v0.7.0` tarball, verified its SHA-256, and confirmed the `kubeconform` binary extracts cleanly in a local shell check
