### PR TITLE
Fix heading font assignments per Valon style guide

### DIFF
--- a/docs/globals.css
+++ b/docs/globals.css
@@ -63,9 +63,14 @@ html {
   font-family: 'KMR Melange Grotesk', system-ui, sans-serif;
 }
 
-h1, h2, h3, h4, h5, h6,
-article h1, article h2, article h3, article h4 {
+h1, article h1 {
   font-family: 'Season Serif', Georgia, serif;
+  letter-spacing: -0.5px;
+}
+
+h2, h3, h4, h5, h6,
+article h2, article h3, article h4 {
+  font-family: 'KMR Melange Grotesk', system-ui, sans-serif;
   letter-spacing: -0.5px;
 }
 

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -7,7 +7,7 @@ const seasonSerif = localFont({
     { path: "../../public/fonts/SeasonSerif_Regular.woff", weight: "400", style: "normal" },
     { path: "../../public/fonts/SeasonSerif_RegularItalic.woff", weight: "400", style: "italic" },
   ],
-  variable: "--font-heading",
+  variable: "--font-display",
 });
 
 const melangeGrotesk = localFont({
@@ -18,6 +18,7 @@ const melangeGrotesk = localFont({
     { path: "../../public/fonts/KMRMelangeGrotesk_BoldItalic.woff", weight: "700", style: "italic" },
   ],
   variable: "--font-body",
+  adjustFontFallback: false,
 });
 
 const geistMono = localFont({

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -69,7 +69,8 @@ const config: Config = {
       },
       fontFamily: {
         sans: ["var(--font-body)", "system-ui", "sans-serif"],
-        heading: ["var(--font-heading)", "Georgia", "serif"],
+        heading: ["var(--font-body)", "system-ui", "sans-serif"],
+        display: ["var(--font-display)", "Georgia", "serif"],
         mono: ["var(--font-mono)", "monospace"],
       },
       boxShadow: {


### PR DESCRIPTION
Season Serif is only for display headlines at 44px+. Smaller headings (h2-h6) should use KMR Melange Grotesk per the Valon typography scale. In the web app, all font-heading usages are 18-30px so the heading variable now maps to Melange Grotesk, with Season Serif available as font-display for future 44px+ use.