### PR TITLE
Fix Homebrew formula license to match Apache-2.0

### DIFF
--- a/Formula/gestalt.rb
+++ b/Formula/gestalt.rb
@@ -6,7 +6,7 @@ class Gestalt < Formula
   desc "CLI for Gestalt API - authentication, integration management, and operation invocation"
   homepage "https://github.com/valon-technologies/gestalt"
   version "0.0.1-alpha.1"
-  license "Proprietary"
+  license "Apache-2.0"
 
   on_macos do
     on_arm do

--- a/Formula/gestaltd.rb
+++ b/Formula/gestaltd.rb
@@ -6,7 +6,7 @@ class Gestaltd < Formula
   desc "Gestalt server daemon"
   homepage "https://github.com/valon-technologies/gestalt"
   version "0.0.1-alpha.1"
-  license "Proprietary"
+  license "Apache-2.0"
 
   on_macos do
     on_arm do


### PR DESCRIPTION
## Summary
- Update `license` field in `Formula/gestalt.rb` and `Formula/gestaltd.rb` from `"Proprietary"` to `"Apache-2.0"` to match the repository's LICENSE file.

## Test plan
- [ ] Verify `brew audit --formula Formula/gestalt.rb` passes with the new license
- [ ] Verify `brew audit --formula Formula/gestaltd.rb` passes with the new license

🤖 Generated with [Claude Code](https://claude.com/claude-code)