### PR TITLE
Rename prepared state directory to .gestaltd

### DIFF
--- a/server/cmd/gestaltd/e2e_test.go
+++ b/server/cmd/gestaltd/e2e_test.go
@@ -350,6 +350,49 @@ func TestE2EBareGestaltdAutoInit(t *testing.T) {
 	waitForHealth(t, baseURL, 20*time.Second)
 }
 
+func TestE2EBareGestaltdUsesDotGestaltdHomeConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	homeDir := filepath.Join(dir, "home")
+	configDir := filepath.Join(homeDir, ".gestaltd")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll config dir: %v", err)
+	}
+
+	port := allocateTestPort(t)
+	cfg := `auth:
+  provider: none
+datastore:
+  provider: sqlite
+  config:
+    path: ` + filepath.Join(configDir, "gestalt.db") + `
+server:
+  port: ` + fmt.Sprintf("%d", port) + `
+  encryption_key: test-key
+`
+	cfgPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	cmd := exec.Command(gestaltdBin)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = withoutEnvVar(os.Environ(), "GESTALT_CONFIG")
+	cmd.Env = append(cmd.Env, "HOME="+homeDir)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start gestaltd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(os.Interrupt)
+		_ = cmd.Wait()
+	})
+
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	waitForHealth(t, baseURL, 20*time.Second)
+}
+
 func TestE2EValidateNonMutating(t *testing.T) {
 	t.Parallel()
 
@@ -378,6 +421,18 @@ func TestE2EValidateNonMutating(t *testing.T) {
 	if _, err := os.Stat(lockPath); err != nil {
 		t.Fatalf("expected lockfile after validate --init: %v", err)
 	}
+}
+
+func withoutEnvVar(env []string, name string) []string {
+	prefix := name + "="
+	filtered := env[:0]
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
 }
 
 //nolint:paralleltest // Spawns the CLI binary; keeping it serial avoids package-level e2e flake.

--- a/server/cmd/gestaltd/factories.go
+++ b/server/cmd/gestaltd/factories.go
@@ -139,7 +139,10 @@ func resolveConfigPath(flagValue string) string {
 	if _, err := os.Stat("config.yaml"); err == nil {
 		return "config.yaml"
 	}
-	if p := defaultLocalConfigPath(); p != "" {
+	for _, p := range localConfigPaths() {
+		if p == "" {
+			continue
+		}
 		if _, err := os.Stat(p); err == nil {
 			return p
 		}

--- a/server/cmd/gestaltd/init_test.go
+++ b/server/cmd/gestaltd/init_test.go
@@ -26,15 +26,15 @@ func TestPreparedLockfileRoundTripPreservesPluginsSection(t *testing.T) {
 		Providers: map[string]lockProviderEntry{
 			"restapi": {
 				Fingerprint: "provider-fingerprint",
-				Provider:    ".gestalt/providers/restapi.json",
+				Provider:    ".gestaltd/providers/restapi.json",
 			},
 		},
 		Plugins: map[string]lockPluginEntry{
 			"integration:external": {
 				Fingerprint: "plugin-fingerprint",
 				Package:     "./plugins/dummy.tar.gz",
-				Manifest:    ".gestalt/plugins/integration_external/plugin.json",
-				Executable:  ".gestalt/plugins/integration_external/artifacts/linux/amd64/provider",
+				Manifest:    ".gestaltd/plugins/integration_external/plugin.json",
+				Executable:  ".gestaltd/plugins/integration_external/artifacts/linux/amd64/provider",
 			},
 		},
 	}

--- a/server/cmd/gestaltd/localconfig.go
+++ b/server/cmd/gestaltd/localconfig.go
@@ -6,6 +6,10 @@ func defaultLocalConfigPath() string {
 	return operator.DefaultLocalConfigPath()
 }
 
+func localConfigPaths() []string {
+	return operator.LocalConfigPaths()
+}
+
 func generateDefaultConfig(configDir string) (string, error) {
 	return operator.GenerateDefaultConfig(configDir)
 }

--- a/server/cmd/gestaltd/run.go
+++ b/server/cmd/gestaltd/run.go
@@ -414,7 +414,7 @@ func printInitUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd init [--config PATH]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Resolve remote providers and packaged plugins and write lock state.")
-	writeUsageLine(w, "Creates gestalt.lock.json and .gestalt/ in the config directory.")
+	writeUsageLine(w, "Creates gestalt.lock.json and .gestaltd/ in the config directory.")
 	writeUsageLine(w, "Use this before `gestaltd serve --locked` for production deployments.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")

--- a/server/internal/operator/lifecycle.go
+++ b/server/internal/operator/lifecycle.go
@@ -21,8 +21,8 @@ import (
 
 const (
 	InitLockfileName     = "gestalt.lock.json"
-	PreparedProvidersDir = ".gestalt/providers"
-	PluginsDir           = ".gestalt/plugins"
+	PreparedProvidersDir = ".gestaltd/providers"
+	PluginsDir           = ".gestaltd/plugins"
 	LockVersion          = 4
 	LockVersionCompat    = 3
 )

--- a/server/internal/operator/lifecycle_source_test.go
+++ b/server/internal/operator/lifecycle_source_test.go
@@ -201,7 +201,7 @@ func TestSourcePluginEndToEnd(t *testing.T) {
 		t.Errorf("executable not found at %s: %v", executablePath, err)
 	}
 
-	wantPrefix := ".gestalt/plugins/integration_alpha/"
+	wantPrefix := ".gestaltd/plugins/integration_alpha/"
 	if !strings.HasPrefix(entry.Manifest, wantPrefix) {
 		t.Errorf("manifest path %q does not start with %q", entry.Manifest, wantPrefix)
 	}

--- a/server/internal/operator/lifecycle_test.go
+++ b/server/internal/operator/lifecycle_test.go
@@ -376,15 +376,15 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 		Providers: map[string]LockProviderEntry{
 			"test-provider": {
 				Fingerprint: "test-fp",
-				Provider:    ".gestalt/providers/test.json",
+				Provider:    ".gestaltd/providers/test.json",
 			},
 		},
 		Plugins: map[string]LockPluginEntry{
 			"integration:example": {
 				Fingerprint: "plugin-fp",
 				Package:     "./test-plugin",
-				Manifest:    ".gestalt/plugins/integration_example/plugin.json",
-				Executable:  ".gestalt/plugins/integration_example/artifacts/darwin/arm64/provider",
+				Manifest:    ".gestaltd/plugins/integration_example/plugin.json",
+				Executable:  ".gestaltd/plugins/integration_example/artifacts/darwin/arm64/provider",
 			},
 		},
 	}

--- a/server/internal/operator/localconfig.go
+++ b/server/internal/operator/localconfig.go
@@ -9,12 +9,28 @@ import (
 	"path/filepath"
 )
 
+const (
+	localConfigDirName       = ".gestaltd"
+	legacyLocalConfigDirName = ".gestalt"
+)
+
 func DefaultLocalConfigPath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return ""
 	}
-	return filepath.Join(home, ".gestalt", "config.yaml")
+	return filepath.Join(home, localConfigDirName, "config.yaml")
+}
+
+func LocalConfigPaths() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	return []string{
+		filepath.Join(home, localConfigDirName, "config.yaml"),
+		filepath.Join(home, legacyLocalConfigDirName, "config.yaml"),
+	}
 }
 
 func GenerateDefaultConfig(configDir string) (string, error) {


### PR DESCRIPTION
## Summary
- rename the canonical prepared-state directory from `.gestalt/` to `.gestaltd/`
- switch the default local config path to `~/.gestaltd/config.yaml` while still discovering an existing legacy `~/.gestalt/config.yaml`
- update docs, CLI text, and existing path expectations, and add a functional CLI test for bare `gestaltd` discovery of the new home config path

## Testing
- `TMPDIR=/Users/hugh/src/tmp-go go test ./internal/operator`
- `TMPDIR=/Users/hugh/src/tmp-go go test ./cmd/gestaltd -run TestE2EBareGestaltdUsesDotGestaltdHomeConfig -count=1`