### PR TITLE
build: pin cross to version 0.2.5 in CI

### DIFF
--- a/.github/workflows/rust-build-matrix.yml
+++ b/.github/workflows/rust-build-matrix.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Install cross-compilation tools
         if: matrix.platform.cross
         run: |
-          command -v cross >/dev/null 2>&1 || cargo install cross --git https://github.com/cross-rs/cross
+          command -v cross >/dev/null 2>&1 || cargo install cross --version 0.2.5
 
       - name: Build (native)
         if: ${{ !matrix.platform.cross }}


### PR DESCRIPTION
## Summary
- Pin `cross` to v0.2.5 (latest stable) instead of installing from git HEAD, making the Rust cross-compilation CI build reproducible.

## Test plan
- [ ] Verify the Rust build matrix workflow passes for cross-compiled targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)