### PR TITLE
Fix docs heading fonts and card padding

### DIFF
--- a/docs/globals.css
+++ b/docs/globals.css
@@ -63,9 +63,14 @@ html {
   font-family: 'KMR Melange Grotesk', system-ui, sans-serif;
 }
 
-h1, h2, h3, h4, h5, h6,
-article h1, article h2, article h3, article h4 {
+h1, article h1 {
   font-family: 'Season Serif', Georgia, serif;
+  letter-spacing: -0.5px;
+}
+
+h2, h3, h4, h5, h6,
+article h2, article h3, article h4 {
+  font-family: 'KMR Melange Grotesk', system-ui, sans-serif;
   letter-spacing: -0.5px;
 }
 

--- a/docs/globals.css
+++ b/docs/globals.css
@@ -78,6 +78,14 @@ code, pre, kbd, samp {
   font-family: 'Geist Mono', monospace;
 }
 
+/* Card padding — Nextra only pads the title span, not the description. */
+.nextra-card {
+  padding: 1.25rem;
+}
+.nextra-card > span:last-child {
+  padding: 0.75rem 0 0;
+}
+
 /* Show the TOC at lg (1024px) instead of xl (1280px).
    Nextra hard-codes max-xl:_hidden on nav.nextra-toc.
    Higher specificity (element + two classes) overrides the theme rule. */

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -7,7 +7,7 @@ const seasonSerif = localFont({
     { path: "../../public/fonts/SeasonSerif_Regular.woff", weight: "400", style: "normal" },
     { path: "../../public/fonts/SeasonSerif_RegularItalic.woff", weight: "400", style: "italic" },
   ],
-  variable: "--font-heading",
+  variable: "--font-display",
 });
 
 const melangeGrotesk = localFont({
@@ -18,6 +18,7 @@ const melangeGrotesk = localFont({
     { path: "../../public/fonts/KMRMelangeGrotesk_BoldItalic.woff", weight: "700", style: "italic" },
   ],
   variable: "--font-body",
+  adjustFontFallback: false,
 });
 
 const geistMono = localFont({

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -69,7 +69,8 @@ const config: Config = {
       },
       fontFamily: {
         sans: ["var(--font-body)", "system-ui", "sans-serif"],
-        heading: ["var(--font-heading)", "Georgia", "serif"],
+        heading: ["var(--font-body)", "system-ui", "sans-serif"],
+        display: ["var(--font-display)", "Georgia", "serif"],
         mono: ["var(--font-mono)", "monospace"],
       },
       boxShadow: {


### PR DESCRIPTION
## Summary
- Fix heading font assignments per Valon style guide: Season Serif only for h1 (44px+ display), h2-h6 use KMR Melange Grotesk
- Remap web UI `font-heading` to Melange Grotesk since all usages are 18-30px; Season Serif available as `font-display`
- Fix card padding in docs — Nextra only pads the title span, leaving description text flush against card edges

## Test plan
- [ ] Verify docs h2+ headings render in KMR Melange Grotesk (sans), not Season Serif (thin serif)
- [ ] Verify docs h1 page titles still render in Season Serif
- [ ] Verify docs cards have consistent internal padding
- [ ] Verify web UI headings render in Melange Grotesk

🤖 Generated with [Claude Code](https://claude.com/claude-code)