### PR TITLE
Add Content-Security-Policy header

### DIFF
--- a/server/internal/server/middleware.go
+++ b/server/internal/server/middleware.go
@@ -62,8 +62,24 @@ func maxBodyMiddleware(limit int64) func(http.Handler) http.Handler {
 	}
 }
 
+// contentSecurityPolicy is the CSP applied to all responses. script-src and
+// style-src require 'unsafe-inline' because the Next.js static export embeds
+// inline <script> tags for RSC flight data that change with every build,
+// making hash-based policies impractical.
+const contentSecurityPolicy = "default-src 'self'; " +
+	"script-src 'self' 'unsafe-inline'; " +
+	"style-src 'self' 'unsafe-inline'; " +
+	"img-src 'self' data:; " +
+	"font-src 'self'; " +
+	"connect-src 'self'; " +
+	"object-src 'none'; " +
+	"base-uri 'self'; " +
+	"form-action 'self'; " +
+	"frame-ancestors 'none'"
+
 func (s *Server) securityHeadersMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-Frame-Options", "DENY")
 		if s.secureCookies {

--- a/server/internal/server/server_test.go
+++ b/server/internal/server/server_test.go
@@ -253,6 +253,18 @@ func TestSecurityHeaders(t *testing.T) {
 		if got := resp.Header.Get("Strict-Transport-Security"); got != "" {
 			t.Errorf("Strict-Transport-Security = %q, want empty (secureCookies=false)", got)
 		}
+		csp := resp.Header.Get("Content-Security-Policy")
+		for _, directive := range []string{
+			"default-src 'self'",
+			"script-src 'self' 'unsafe-inline'",
+			"style-src 'self' 'unsafe-inline'",
+			"object-src 'none'",
+			"frame-ancestors 'none'",
+		} {
+			if !strings.Contains(csp, directive) {
+				t.Errorf("Content-Security-Policy missing directive %q; got %q", directive, csp)
+			}
+		}
 	})
 
 	t.Run("secure_cookies", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds a `Content-Security-Policy` header to the security headers middleware, restricting resource loading to same-origin and blocking plugin content, framing, base-tag hijacking, and form-action hijacking.
- `script-src` and `style-src` use `'unsafe-inline'` because the Next.js static export embeds inline `<script>` tags for RSC flight data that change per build, making hash/nonce-based policies impractical with embedded-FS serving.
- Adds test coverage for the new CSP directives in `TestSecurityHeaders`.

## Test plan
- [x] `TestSecurityHeaders/default` passes — verifies key CSP directives are present
- [x] `TestSecurityHeaders/secure_cookies` passes — existing HSTS behavior unchanged
- [ ] Manual: load the web UI and confirm no CSP violations in the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)