### PR TITLE
Support locked rehydration for private GitHub plugins

### DIFF
--- a/server/internal/operator/lifecycle.go
+++ b/server/internal/operator/lifecycle.go
@@ -16,6 +16,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
+	ghresolver "github.com/valon-technologies/gestalt/server/internal/pluginsource/github"
 	"github.com/valon-technologies/gestalt/server/internal/pluginstore"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
@@ -741,11 +742,20 @@ func (l *Lifecycle) materializeLockedSourcePlugin(ctx context.Context, paths ini
 		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", kind, name, paths.configPath)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, entry.ResolvedURL, nil)
-	if err != nil {
-		return fmt.Errorf("create locked source plugin request for %s %q: %w", kind, name, err)
+	src, parseErr := pluginsource.Parse(entry.Source)
+	var (
+		download *pluginpkg.DownloadResult
+		err      error
+	)
+	if parseErr == nil && src.Host == pluginsource.HostGitHub {
+		download, err = ghresolver.DownloadResolvedAsset(ctx, http.DefaultClient, entry.ResolvedURL, "")
+	} else {
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, entry.ResolvedURL, nil)
+		if reqErr != nil {
+			return fmt.Errorf("create locked source plugin request for %s %q: %w", kind, name, reqErr)
+		}
+		download, err = pluginpkg.DownloadRequest(http.DefaultClient, req)
 	}
-	download, err := pluginpkg.DownloadRequest(http.DefaultClient, req)
 	if err != nil {
 		return fmt.Errorf("download locked source plugin for %s %q: %w", kind, name, err)
 	}

--- a/server/internal/operator/lifecycle_source_test.go
+++ b/server/internal/operator/lifecycle_source_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -386,7 +387,7 @@ func TestSourcePluginLoadForExecution(t *testing.T) {
 		t.Fatalf("ReadLockfile: %v", err)
 	}
 	entry := lock.Plugins[LockPluginKey("integration", "gadget")]
-	pluginRoot := filepath.Join(filepath.Dir(configPath), ".gestalt", "plugins", "integration_gadget")
+	pluginRoot := filepath.Join(filepath.Dir(configPath), ".gestaltd", "plugins", "integration_gadget")
 	if err := os.RemoveAll(pluginRoot); err != nil {
 		t.Fatalf("RemoveAll plugin root: %v", err)
 	}
@@ -418,7 +419,7 @@ func TestSourcePluginLoadForExecution(t *testing.T) {
 }
 
 func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
-	t.Parallel()
+	t.Setenv("GITHUB_TOKEN", "test-token")
 
 	dir := t.TempDir()
 
@@ -437,11 +438,27 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 		t.Fatalf("read archive: %v", err)
 	}
 
-	var requestCount atomic.Int64
+	var releaseCount atomic.Int64
+	var assetCount atomic.Int64
+	handlerErrs := make(chan error, 3)
+	nextHandlerErr := func() error {
+		t.Helper()
+		select {
+		case err := <-handlerErrs:
+			return err
+		default:
+			return nil
+		}
+	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount.Add(1)
 		switch r.URL.Path {
 		case releasePath:
+			releaseCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "token test-token" {
+				handlerErrs <- fmt.Errorf("release authorization = %q, want %q", got, "token test-token")
+				http.Error(w, "bad release authorization", http.StatusBadRequest)
+				return
+			}
 			browserURL := "https://github.com/" + testOwner + "/" + testRepo + "/releases/download/" + expectedTag + "/" + expectedAssetName
 			w.Header().Set("Content-Type", "application/json")
 			resp := map[string]any{
@@ -455,6 +472,17 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 			}
 			_ = json.NewEncoder(w).Encode(resp)
 		case "/asset-dl":
+			assetCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "token test-token" {
+				handlerErrs <- fmt.Errorf("asset authorization = %q, want %q", got, "token test-token")
+				http.Error(w, "bad asset authorization", http.StatusBadRequest)
+				return
+			}
+			if got := r.Header.Get("Accept"); got != "application/octet-stream" {
+				handlerErrs <- fmt.Errorf("asset accept = %q, want %q", got, "application/octet-stream")
+				http.Error(w, "bad asset accept", http.StatusBadRequest)
+				return
+			}
 			w.Header().Set("Content-Type", "application/octet-stream")
 			_, _ = w.Write(archiveData)
 		default:
@@ -488,7 +516,13 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 
 	lock, err := lc.InitAtPath(configPath)
 	if err != nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
 		t.Fatalf("InitAtPath: %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
 	}
 
 	if lock.Version != LockVersion {
@@ -507,6 +541,9 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 	}
 	if entry.ResolvedURL == "" {
 		t.Error("entry.ResolvedURL is empty")
+	}
+	if entry.ResolvedURL != srv.URL+"/asset-dl" {
+		t.Errorf("entry.ResolvedURL = %q, want %q", entry.ResolvedURL, srv.URL+"/asset-dl")
 	}
 	if entry.ArchiveSHA256 == "" {
 		t.Error("entry.ArchiveSHA256 is empty")
@@ -550,12 +587,30 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 		t.Errorf("executable content = %q, want %q", execData, testBinary)
 	}
 
-	requestsBefore := requestCount.Load()
-	_, _, err = lc.LoadForExecutionAtPath(configPath, true)
+	pluginRoot := filepath.Join(configDir, ".gestaltd", "plugins", "integration_alpha")
+	if err := os.RemoveAll(pluginRoot); err != nil {
+		t.Fatalf("RemoveAll plugin root: %v", err)
+	}
+
+	releasesBefore := releaseCount.Load()
+	assetsBefore := assetCount.Load()
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
 	if err != nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
 		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 	}
-	if got := requestCount.Load(); got != requestsBefore {
-		t.Errorf("server received %d requests during locked load, want 0", got-requestsBefore)
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if got := releaseCount.Load(); got != releasesBefore {
+		t.Errorf("release request count during locked load = %d, want %d", got, releasesBefore)
+	}
+	if got := assetCount.Load() - assetsBefore; got != 1 {
+		t.Errorf("asset request count during locked load = %d, want 1", got)
+	}
+	if cfg.Integrations["alpha"].Plugin.Command != executablePath {
+		t.Errorf("plugin command = %q, want %q", cfg.Integrations["alpha"].Plugin.Command, executablePath)
 	}
 }

--- a/server/internal/pluginsource/github/resolver.go
+++ b/server/internal/pluginsource/github/resolver.go
@@ -72,10 +72,7 @@ func (r *GitHubResolver) Resolve(ctx context.Context, src pluginsource.Source, v
 	if client == nil {
 		client = http.DefaultClient
 	}
-	token := r.Token
-	if token == "" {
-		token = os.Getenv(envGitHubToken)
-	}
+	token := resolveToken(r.Token)
 
 	tag := src.ReleaseTag(version)
 	releaseURL := fmt.Sprintf("%s/repos/%s/releases/tags/%s", baseURL, src.RepoSlug(), url.PathEscape(tag))
@@ -99,8 +96,15 @@ func (r *GitHubResolver) Resolve(ctx context.Context, src pluginsource.Source, v
 		LocalPath:     dl.LocalPath,
 		Cleanup:       dl.Cleanup,
 		ArchiveSHA256: dl.SHA256Hex,
-		ResolvedURL:   asset.BrowserDownloadURL,
+		ResolvedURL:   asset.URL,
 	}, nil
+}
+
+func resolveToken(explicit string) string {
+	if explicit != "" {
+		return explicit
+	}
+	return os.Getenv(envGitHubToken)
 }
 
 func (r *GitHubResolver) fetchRelease(ctx context.Context, client *http.Client, url, token, tag, slug string) (*releaseResponse, error) {
@@ -282,7 +286,11 @@ func joinAssetNames(assets []releaseAsset) string {
 	return strings.Join(names, ", ")
 }
 
-func (r *GitHubResolver) downloadAsset(ctx context.Context, client *http.Client, assetURL, token string) (*pluginpkg.DownloadResult, error) {
+func DownloadResolvedAsset(ctx context.Context, client *http.Client, assetURL, token string) (*pluginpkg.DownloadResult, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	token = resolveToken(token)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, assetURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create asset download request: %w", err)
@@ -292,4 +300,8 @@ func (r *GitHubResolver) downloadAsset(ctx context.Context, client *http.Client,
 		req.Header.Set(headerAuthorization, authTokenPrefix+token)
 	}
 	return pluginpkg.DownloadRequest(client, req)
+}
+
+func (r *GitHubResolver) downloadAsset(ctx context.Context, client *http.Client, assetURL, token string) (*pluginpkg.DownloadResult, error) {
+	return DownloadResolvedAsset(ctx, client, assetURL, token)
 }

--- a/server/internal/pluginsource/github/resolver_test.go
+++ b/server/internal/pluginsource/github/resolver_test.go
@@ -433,8 +433,6 @@ func TestResolveSuccess(t *testing.T) {
 	srv := newTestServer(t, assetName)
 	defer srv.Close()
 
-	browserURL := "https://github.com/" + testOwner + "/" + testRepo + "/releases/download/" + expectedTag() + "/" + assetName
-
 	resolver := &GitHubResolver{BaseURL: srv.URL}
 	pkg, err := resolver.Resolve(context.Background(), testSource, testVersion)
 	if err != nil {
@@ -448,8 +446,9 @@ func TestResolveSuccess(t *testing.T) {
 	if pkg.ArchiveSHA256 != testAssetSHA256() {
 		t.Errorf("SHA256 = %s, want %s", pkg.ArchiveSHA256, testAssetSHA256())
 	}
-	if pkg.ResolvedURL != browserURL {
-		t.Errorf("ResolvedURL = %s, want %s", pkg.ResolvedURL, browserURL)
+	wantURL := srv.URL + "/asset-dl"
+	if pkg.ResolvedURL != wantURL {
+		t.Errorf("ResolvedURL = %s, want %s", pkg.ResolvedURL, wantURL)
 	}
 
 	pkg.Cleanup()


### PR DESCRIPTION
## Summary
- store the GitHub asset API URL in source-plugin lock entries so locked rehydration can reuse the exact asset
- reuse the GitHub asset download path for locked rehydration, including `GITHUB_TOKEN`, so private plugin repos work
- fix and extend the existing source-plugin integration tests around `.gestaltd` cache deletion and locked reloads

## Testing
- `TMPDIR=/Users/hugh/src/tmp-go go test ./internal/pluginsource/github ./internal/operator -run 'TestResolveSuccess|TestSourcePluginLoadForExecution|TestSourcePluginGitHubResolverEndToEnd|TestSourcePluginEndToEnd' -count=1`