### PR TITLE
[codex] Refresh docs and web styling

### DIFF
--- a/docs/globals.css
+++ b/docs/globals.css
@@ -55,59 +55,327 @@
 }
 
 :root {
-  --nextra-primary-hue: 30deg;
-  --nextra-primary-saturation: 50%;
+  --valon-ink: 35, 24, 16;
+  --valon-bg: #ffffff;
+  --valon-surface: #f8f6f3;
+  --valon-surface-strong: #ece4dd;
+  --valon-line: rgba(35, 24, 16, 0.1);
+  --valon-line-strong: rgba(35, 24, 16, 0.2);
+  --valon-muted: rgba(35, 24, 16, 0.6);
+  --valon-secondary: rgba(35, 24, 16, 0.8);
+  --valon-gold: #e19614;
+  --nextra-primary-hue: 37deg;
+  --nextra-primary-saturation: 84%;
 }
 
 html {
   font-family: 'KMR Melange Grotesk', system-ui, sans-serif;
+  background: var(--valon-bg);
 }
 
-h1, article h1 {
+body {
+  color: var(--valon-secondary);
+  background:
+    radial-gradient(
+      200% 80% at 50% 0%,
+      rgba(246, 241, 234, 0.9) 0%,
+      rgba(243, 233, 221, 0.82) 8%,
+      rgba(241, 225, 208, 0.76) 16%,
+      rgba(238, 213, 174, 0.52) 30%,
+      rgba(234, 204, 184, 0.42) 44%,
+      rgba(232, 203, 190, 0.34) 56%,
+      rgba(237, 223, 212, 0.24) 66%,
+      rgba(244, 237, 230, 0.14) 76%,
+      transparent 88%
+    ),
+    linear-gradient(180deg, #ffffff 0%, #fdfcf9 100%);
+}
+
+a {
+  color: inherit;
+  transition:
+    color 150ms ease,
+    opacity 150ms ease,
+    background-color 150ms ease,
+    border-color 150ms ease,
+    transform 150ms ease;
+}
+
+h1,
+article h1 {
   font-family: 'Season Serif', Georgia, serif;
-  letter-spacing: -0.5px;
+  font-weight: 400 !important;
+  font-size: clamp(2.75rem, 6vw, 4.25rem) !important;
+  line-height: 0.98 !important;
+  letter-spacing: -0.03em !important;
+  color: rgba(var(--valon-ink), 1) !important;
 }
 
-h2, h3, h4, h5, h6,
-article h2, article h3, article h4 {
+h2,
+h3,
+h4,
+h5,
+h6,
+article h2,
+article h3,
+article h4 {
   font-family: 'KMR Melange Grotesk', system-ui, sans-serif;
-  letter-spacing: -0.5px;
+  font-weight: 400 !important;
+  letter-spacing: -0.03em !important;
+  color: rgba(var(--valon-ink), 1) !important;
 }
 
-code, pre, kbd, samp {
-  font-family: 'Geist Mono', monospace;
+article h2 {
+  font-size: clamp(1.75rem, 3vw, 2rem) !important;
+  line-height: 1.15 !important;
+  border-bottom-color: var(--valon-line) !important;
+  padding-bottom: 0.75rem !important;
 }
 
-/* Card padding — Nextra only pads the title span, not the description. */
+article h3 {
+  font-size: clamp(1.25rem, 2vw, 1.5rem) !important;
+  line-height: 1.2 !important;
+}
+
+article p,
+article li,
+article td,
+article th {
+  color: var(--valon-secondary);
+}
+
+article p,
+article li {
+  line-height: 1.7;
+}
+
+article a:not(.nextra-card):not(.subheading-anchor) {
+  color: rgba(var(--valon-ink), 1);
+  text-decoration-color: rgba(35, 24, 16, 0.24);
+  text-underline-offset: 0.18em;
+}
+
+article a:not(.nextra-card):not(.subheading-anchor):hover {
+  color: var(--valon-gold);
+  text-decoration-color: rgba(225, 150, 20, 0.5);
+}
+
+code,
+pre,
+kbd,
+samp,
+.nextra-code {
+  font-family: 'Geist Mono', monospace !important;
+}
+
+pre {
+  border: 1px solid var(--valon-line);
+  border-radius: 12px;
+  background: rgba(248, 246, 243, 0.88) !important;
+}
+
+code.nextra-code,
+p code,
+li code,
+td code {
+  border: 1px solid rgba(35, 24, 16, 0.08);
+  border-radius: 6px;
+  background: rgba(248, 246, 243, 0.9) !important;
+  color: rgba(var(--valon-ink), 1) !important;
+}
+
+.nextra-nav-container {
+  background: rgba(255, 255, 255, 0.84) !important;
+  border-bottom: 1px solid var(--valon-line);
+  backdrop-filter: blur(16px);
+}
+
+.nextra-nav-container-blur {
+  display: none;
+}
+
+.nextra-nav-container nav,
+footer > div {
+  width: min(1300px, calc(100% - 2rem)) !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}
+
+.nextra-nav-container nav a,
+.nextra-nav-container nav button {
+  color: var(--valon-secondary) !important;
+}
+
+.nextra-nav-container nav a:hover,
+.nextra-nav-container nav button:hover {
+  color: rgba(var(--valon-ink), 1) !important;
+}
+
+.nextra-nav-container input[type='search'] {
+  border: 1px solid var(--valon-line) !important;
+  border-radius: 8px !important;
+  background: rgba(248, 246, 243, 0.9) !important;
+  color: rgba(var(--valon-ink), 1) !important;
+  box-shadow: none !important;
+}
+
+.nextra-nav-container input[type='search']::placeholder {
+  color: var(--valon-muted) !important;
+}
+
+.nextra-sidebar-container {
+  background: transparent !important;
+}
+
+@media (min-width: 768px) {
+  .nextra-sidebar-container {
+    border-right: 1px solid var(--valon-line);
+  }
+}
+
+.nextra-sidebar-container a,
+.nextra-sidebar-container button,
+.nextra-toc a,
+.nextra-breadcrumb,
+.nextra-breadcrumb span,
+.nextra-toc-footer a {
+  color: var(--valon-muted) !important;
+}
+
+.nextra-sidebar-container a:hover,
+.nextra-sidebar-container button:hover,
+.nextra-toc a:hover,
+.nextra-toc-footer a:hover {
+  color: rgba(var(--valon-ink), 1) !important;
+}
+
+.nextra-menu-desktop li.active > a,
+.nextra-menu-mobile li.active > a {
+  background: rgba(35, 24, 16, 0.08) !important;
+  color: rgba(var(--valon-ink), 1) !important;
+  font-weight: 700 !important;
+}
+
+.nextra-menu-desktop ul::before,
+.nextra-menu-mobile ul::before {
+  background: var(--valon-line) !important;
+}
+
+nav[aria-label='table of contents'] li:has(> a._ms-8),
+nav[aria-label='table of contents'] li:has(> a._ms-12),
+nav[aria-label='table of contents'] li:has(> a._ms-16) {
+  display: none;
+}
+
+.nextra-toc {
+  width: 13rem !important;
+}
+
+.nextra-toc p,
+.nextra-toc strong {
+  color: rgba(var(--valon-ink), 1) !important;
+}
+
+article.nextra-content {
+  padding-bottom: 4rem;
+}
+
+article.nextra-content main {
+  max-width: 1300px !important;
+  padding-top: 1.5rem !important;
+}
+
+.nextra-breadcrumb {
+  font-size: 0.7rem !important;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
 .nextra-card {
-  padding: 1.25rem;
-}
-.nextra-card > span:last-child {
-  padding: 0.75rem 0 0;
+  border: 1px solid var(--valon-line) !important;
+  border-radius: 12px !important;
+  background: rgba(248, 246, 243, 0.9) !important;
+  box-shadow: none !important;
+  padding: 1.5rem !important;
 }
 
-/* Show the TOC at lg (1024px) instead of xl (1280px).
-   Nextra hard-codes max-xl:_hidden on nav.nextra-toc.
-   Higher specificity (element + two classes) overrides the theme rule. */
+.nextra-card:hover {
+  border-color: var(--valon-line-strong) !important;
+  background: rgba(248, 246, 243, 0.98) !important;
+  box-shadow: 0 8px 24px rgba(35, 24, 16, 0.08) !important;
+  transform: translateY(-1px);
+}
+
+.nextra-card p {
+  margin-top: 0 !important;
+  color: var(--valon-secondary) !important;
+  line-height: 1.6;
+}
+
+.nextra-card > span:last-child {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem 0 0 !important;
+  font-weight: 400 !important;
+  color: rgba(var(--valon-ink), 1) !important;
+}
+
+table {
+  border-collapse: separate;
+  border-spacing: 0;
+  width: 100%;
+  overflow: hidden;
+  border: 1px solid var(--valon-line);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.78);
+}
+
+thead tr,
+tbody tr:nth-child(even) {
+  background: rgba(35, 24, 16, 0.03) !important;
+}
+
+th,
+td {
+  border-color: var(--valon-line) !important;
+}
+
+th {
+  color: rgba(var(--valon-ink), 1) !important;
+  font-weight: 700 !important;
+}
+
+hr,
+footer hr {
+  border-color: var(--valon-line) !important;
+}
+
+footer {
+  background: rgba(248, 246, 243, 0.72) !important;
+  border-top: 1px solid var(--valon-line);
+}
+
+button[title='Change theme'],
+.nextra-nav-container [aria-label='Menu'] + div button[title='Change theme'] {
+  display: none !important;
+}
+
+@media (min-width: 768px) {
+  .nextra-nav-container nav,
+  footer > div {
+    width: min(1300px, calc(100% - 4rem)) !important;
+  }
+}
+
 @media (min-width: 1024px) {
-  nav.nextra-toc.max-xl\:_hidden {
-    display: flex;
+  .nextra-nav-container nav,
+  footer > div {
+    width: min(1300px, calc(100% - 8rem)) !important;
+  }
+
+  .nextra-toc {
+    display: flex !important;
     flex-direction: column;
   }
-}
-
-/* Between lg and xl, use a narrower TOC to leave room for content.
-   Default is 256px (_w-64). */
-@media (min-width: 1024px) and (max-width: 1279.98px) {
-  nav.nextra-toc {
-    width: 12rem;
-  }
-}
-
-/* Limit "On this page" TOC to h2–h3 only.
-   Nextra applies _ms-8 / _ms-12 / _ms-16 to depths 4 / 5 / 6. */
-nav[aria-label="table of contents"] li:has(> a._ms-8),
-nav[aria-label="table of contents"] li:has(> a._ms-12),
-nav[aria-label="table of contents"] li:has(> a._ms-16) {
-  display: none;
 }

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -2,12 +2,31 @@ import { useConfig } from "nextra-theme-docs";
 import type { DocsThemeConfig } from "nextra-theme-docs";
 
 const config: DocsThemeConfig = {
-  logo: <strong style={{ fontFamily: "'Season Serif', Georgia, serif" }}>Gestalt</strong>,
+  logo: (
+    <span style={{ fontFamily: "'Season Serif', Georgia, serif", fontSize: "1.7rem", letterSpacing: "-0.03em" }}>
+      Gestalt
+    </span>
+  ),
   project: {
     link: "https://github.com/valon-technologies/gestalt",
   },
   docsRepositoryBase:
     "https://github.com/valon-technologies/gestalt/tree/main/docs",
+  darkMode: false,
+  nextThemes: {
+    defaultTheme: "light",
+    forcedTheme: "light",
+    storageKey: "gestalt-docs-theme",
+  },
+  backgroundColor: {
+    light: "#FFFFFF",
+    dark: "#FFFFFF",
+  },
+  color: {
+    hue: 37,
+    saturation: 84,
+    lightness: 48,
+  },
   head: function Head() {
     const { title } = useConfig();
     const fullTitle = title ? `${title} – Gestalt` : "Gestalt";
@@ -21,6 +40,9 @@ const config: DocsThemeConfig = {
   },
   footer: {
     content: <span>Gestalt, a self-hosted integration platform</span>,
+  },
+  search: {
+    placeholder: "Search documentation",
   },
   sidebar: {
     defaultMenuCollapseLevel: 1,

--- a/web/dev.sh
+++ b/web/dev.sh
@@ -66,6 +66,33 @@ if [[ -n "$CONFIG" ]]; then
     fi
 fi
 
+if [[ -z "$CONFIG" && "$API_PORT" != "8080" ]]; then
+    DEV_STATE_DIR="${HOME}/.gestaltd-dev/api-${API_PORT}"
+    mkdir -p "$DEV_STATE_DIR"
+    KEY_FILE="$DEV_STATE_DIR/encryption_key"
+    if [[ ! -f "$KEY_FILE" ]]; then
+        if ! command -v openssl &>/dev/null; then
+            err "openssl is required for custom API_PORT dev config generation"
+            exit 1
+        fi
+        openssl rand -hex 32 > "$KEY_FILE"
+    fi
+    CONFIG="$DEV_STATE_DIR/config.yaml"
+    cat > "$CONFIG" <<EOF
+auth:
+  provider: none
+datastore:
+  provider: sqlite
+  config:
+    path: "$DEV_STATE_DIR/gestalt.db"
+secrets:
+  provider: env
+server:
+  port: $API_PORT
+  encryption_key: "$(cat "$KEY_FILE")"
+EOF
+fi
+
 if ! command -v go &>/dev/null; then
     err "Go is not installed. Install it from https://go.dev/dl/"
     exit 1
@@ -77,9 +104,9 @@ fi
 info "Starting Go API server on port $API_PORT..."
 warn "Dev mode — use 'Dev Login' on the login page (no Google OAuth needed)."
 if [[ -n "$CONFIG" ]]; then
-    (cd "$GESTALT_DIR" && go run ./cmd/gestaltd --config "$CONFIG") &
+    (cd "$GESTALT_DIR/server" && go run ./cmd/gestaltd --config "$CONFIG") &
 else
-    (cd "$GESTALT_DIR" && go run ./cmd/gestaltd) &
+    (cd "$GESTALT_DIR/server" && go run ./cmd/gestaltd) &
 fi
 API_PID=$!
 

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -4,28 +4,27 @@
 
 @layer base {
   :root {
-    --background: 36 28% 99%;
-    --surface: 36 33% 97%;
-    --surface-raised: 33 22% 93%;
-    --border: 30 18% 87%;
+    --background: 34 60% 99%;
+    --surface: 34 38% 96%;
+    --surface-raised: 28 28% 91%;
+    --border: 28 22% 86%;
     --foreground: 24 30% 11%;
     --radius: 0.75rem;
-
     --alpha-dark: 35, 24, 16;
   }
 
   .dark {
-    --background: 24 18% 8%;
-    --surface: 24 14% 11%;
-    --surface-raised: 24 12% 15%;
-    --border: 24 10% 20%;
-    --foreground: 33 20% 90%;
-
+    --background: 23 19% 9%;
+    --surface: 23 17% 12%;
+    --surface-raised: 24 15% 16%;
+    --border: 24 12% 24%;
+    --foreground: 33 28% 90%;
     --alpha-dark: 232, 222, 212;
   }
 
   html {
     scroll-behavior: smooth;
+    background-color: #ffffff;
   }
 
   * {
@@ -33,47 +32,266 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background font-sans text-foreground antialiased;
+    min-height: 100vh;
+    background-image:
+      radial-gradient(
+        200% 80% at 50% 0%,
+        rgba(246, 241, 234, 0.9) 0%,
+        rgba(243, 233, 221, 0.82) 8%,
+        rgba(241, 225, 208, 0.76) 16%,
+        rgba(238, 213, 174, 0.52) 30%,
+        rgba(234, 204, 184, 0.42) 44%,
+        rgba(232, 203, 190, 0.34) 56%,
+        rgba(237, 223, 212, 0.24) 66%,
+        rgba(244, 237, 230, 0.14) 76%,
+        transparent 88%
+      ),
+      linear-gradient(180deg, #ffffff 0%, #fdfcf9 100%);
+    background-attachment: fixed;
+  }
+
+  .dark body {
+    background-image:
+      radial-gradient(
+        180% 90% at 50% 0%,
+        rgba(92, 60, 12, 0.35) 0%,
+        rgba(61, 40, 8, 0.3) 18%,
+        rgba(35, 24, 16, 0.12) 48%,
+        transparent 72%
+      ),
+      linear-gradient(180deg, #161110 0%, #0f0b09 100%);
+  }
+
+  a {
+    transition:
+      color 150ms ease,
+      opacity 150ms ease,
+      border-color 150ms ease,
+      background-color 150ms ease,
+      transform 150ms ease;
   }
 
   dialog::backdrop {
-    background-color: rgba(35, 24, 16, 0.5);
+    background-color: rgba(35, 24, 16, 0.44);
+    backdrop-filter: blur(8px);
   }
 
   .dark dialog::backdrop {
-    background-color: rgba(10, 8, 6, 0.7);
+    background-color: rgba(10, 8, 6, 0.72);
   }
 }
 
 @layer base {
   @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
+
     .animate-fade-in-up {
       animation: none !important;
       opacity: 1 !important;
+      transform: none !important;
     }
   }
 }
 
 @layer components {
+  .page-shell {
+    @apply min-h-screen;
+  }
+
+  .page-main {
+    width: min(1300px, calc(100% - 2rem));
+    margin: 0 auto;
+    padding: 3.5rem 0 5rem;
+  }
+
+  .page-hero {
+    @apply relative overflow-hidden rounded-lg border border-alpha px-6 py-8 shadow-card backdrop-blur-sm;
+    background-color: rgba(255, 255, 255, 0.7);
+  }
+
+  .page-hero::after {
+    content: "";
+    position: absolute;
+    inset: auto 0 0;
+    height: 1px;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      rgba(35, 24, 16, 0.08) 20%,
+      rgba(35, 24, 16, 0.16) 50%,
+      rgba(35, 24, 16, 0.08) 80%,
+      transparent 100%
+    );
+  }
+
   .label-text {
-    @apply text-[11px] font-medium uppercase tracking-widest text-faint;
+    @apply text-[11px] uppercase tracking-[0.24em] text-faint;
+  }
+
+  .page-title {
+    font-family: var(--font-display), Georgia, serif;
+    font-size: clamp(2.75rem, 6vw, 4.25rem);
+    line-height: 0.98;
+    letter-spacing: -0.03em;
+    color: rgba(var(--alpha-dark), 1);
+  }
+
+  .section-title {
+    font-family: var(--font-body), system-ui, sans-serif;
+    font-size: clamp(1.25rem, 2.6vw, 2rem);
+    line-height: 1.15;
+    letter-spacing: -0.03em;
+    color: rgba(var(--alpha-dark), 1);
+  }
+
+  .page-subtitle {
+    @apply max-w-2xl text-base leading-7 text-secondary md:text-lg;
+  }
+
+  .surface-card {
+    @apply rounded-lg border border-alpha shadow-card backdrop-blur-sm;
+    background-color: rgba(255, 255, 255, 0.8);
+    transition:
+      background-color 150ms ease,
+      border-color 150ms ease,
+      box-shadow 150ms ease,
+      transform 150ms ease;
+  }
+
+  .surface-card:hover {
+    border-color: rgba(var(--alpha-dark), 0.2);
+    background-color: rgba(248, 246, 243, 0.96);
+    box-shadow: 0 8px 24px rgba(35, 24, 16, 0.08);
+    transform: translateY(-1px);
+  }
+
+  .dark .surface-card:hover {
+    background-color: rgba(38, 30, 26, 0.96);
+    box-shadow: 0 10px 26px rgba(0, 0, 0, 0.24);
+  }
+
+  .metric-value {
+    font-family: var(--font-display), Georgia, serif;
+    font-size: clamp(2.6rem, 5vw, 3.75rem);
+    line-height: 0.95;
+    letter-spacing: -0.04em;
+    color: rgba(var(--alpha-dark), 1);
+  }
+
+  .nav-shell {
+    @apply sticky top-0 z-50 border-b border-alpha backdrop-blur-md;
+    background-color: rgba(255, 255, 255, 0.82);
+  }
+
+  .nav-inner {
+    width: min(1300px, calc(100% - 2rem));
+    margin: 0 auto;
+    @apply flex items-center justify-between py-3;
+  }
+
+  .brand-lockup {
+    font-family: var(--font-display), Georgia, serif;
+    font-size: 1.7rem;
+    letter-spacing: -0.03em;
+    color: rgba(var(--alpha-dark), 1);
+  }
+
+  .nav-link {
+    @apply text-sm text-secondary;
+  }
+
+  .nav-link:hover {
+    color: rgba(var(--alpha-dark), 1);
+    opacity: 0.72;
+  }
+
+  .nav-link-active {
+    @apply rounded-md bg-alpha-5 px-3 py-2 text-sm text-primary;
+    font-weight: 700;
+  }
+
+  .icon-button {
+    @apply flex h-10 w-10 items-center justify-center rounded-full bg-base-100 text-muted;
+    transition:
+      background-color 150ms ease,
+      color 150ms ease,
+      transform 150ms ease;
+  }
+
+  .icon-button:hover {
+    background-color: #ece4dd;
+    color: rgba(var(--alpha-dark), 1);
+  }
+
+  .dark .icon-button {
+    @apply bg-surface-raised;
+  }
+
+  .dark .icon-button:hover {
+    background-color: rgba(255, 255, 255, 0.12);
+  }
+
+  .table-surface {
+    @apply overflow-hidden rounded-lg border border-alpha shadow-card backdrop-blur-sm;
+    background-color: rgba(255, 255, 255, 0.82);
+  }
+
+  .table-head {
+    background-color: rgba(var(--alpha-dark), 0.04);
+  }
+
+  .table-row {
+    transition: background-color 150ms ease;
+  }
+
+  .table-row:hover {
+    background-color: rgba(var(--alpha-dark), 0.03);
   }
 
   .gradient-warm {
-    background: radial-gradient(
-      140% 90% at 50% 100%,
-      #EACCB8 0%,
-      #FDFCF9 50%,
-      #F8F6F3 80%
-    );
+    background:
+      radial-gradient(140% 90% at 50% 100%, #eaccb8 0%, #fdfcf9 50%, #f8f6f3 80%);
   }
 
   .dark .gradient-warm {
-    background: radial-gradient(
-      140% 90% at 50% 100%,
-      #3D2808 0%,
-      #1A1410 50%,
-      #161110 80%
-    );
+    background:
+      radial-gradient(140% 90% at 50% 100%, #3d2808 0%, #1a1410 50%, #161110 80%);
+  }
+
+  .dark .page-hero {
+    background-color: rgba(31, 25, 22, 0.8);
+  }
+
+  .dark .surface-card {
+    background-color: rgba(31, 25, 22, 0.82);
+  }
+
+  .dark .nav-shell {
+    background-color: rgba(31, 25, 22, 0.88);
+  }
+
+  .dark .table-surface {
+    background-color: rgba(31, 25, 22, 0.82);
+  }
+
+  @media (min-width: 768px) {
+    .page-main,
+    .nav-inner {
+      width: min(1300px, calc(100% - 4rem));
+    }
+
+    .page-hero {
+      @apply px-8 py-10;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .page-main,
+    .nav-inner {
+      width: min(1300px, calc(100% - 8rem));
+    }
   }
 }

--- a/web/src/app/integrations/page.tsx
+++ b/web/src/app/integrations/page.tsx
@@ -34,11 +34,11 @@ export default function IntegrationsPage() {
 
   return (
     <AuthGuard>
-      <div className="min-h-screen">
+      <div className="page-shell">
         <Nav />
-        <main className="mx-auto max-w-5xl px-6 py-12">
+        <main className="page-main">
           {toast && (
-            <div className="mb-8 flex items-center justify-between rounded-lg border border-grove-200 bg-grove-50 px-5 py-3.5 text-sm text-grove-700 dark:border-grove-600 dark:bg-grove-700/20 dark:text-grove-200">
+            <div className="mb-8 flex items-center justify-between rounded-lg border border-grove-200 bg-grove-50 px-5 py-4 text-sm text-grove-700 dark:border-grove-600 dark:bg-grove-700/20 dark:text-grove-200">
               <span>{toast}</span>
               <button
                 onClick={() => setToast(null)}
@@ -50,30 +50,29 @@ export default function IntegrationsPage() {
             </div>
           )}
 
-          <div className="animate-fade-in-up">
+          <div className="page-hero animate-fade-in-up">
             <span className="label-text">Catalog</span>
-            <h1 className="mt-2 text-2xl font-heading font-bold text-primary">
-              Integrations
-            </h1>
-            <p className="mt-2 text-sm text-muted">
-              Browse and connect third-party services.
+            <h1 className="page-title mt-4">Integrations</h1>
+            <p className="page-subtitle mt-4">
+              Browse and connect third-party services with a warmer, quieter
+              surface that lets the provider states do the talking.
             </p>
           </div>
 
           {loading && (
-            <p className="mt-10 text-sm text-faint">Loading...</p>
+            <p className="mt-10 text-sm text-faint">Loading integrations...</p>
           )}
 
           {error && <p className="mt-10 text-sm text-ember-500">{error}</p>}
 
           {!loading && !error && integrations.length === 0 && (
-            <p className="mt-10 text-sm text-faint">
+            <div className="surface-card mt-10 p-6 text-sm text-muted">
               No integrations registered.
-            </p>
+            </div>
           )}
 
           {!loading && !error && integrations.length > 0 && (
-            <div className="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 animate-fade-in-up [animation-delay:60ms]">
+            <div className="mt-10 grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3 animate-fade-in-up [animation-delay:60ms]">
               {integrations.map((integration) => (
                 <IntegrationCard
                   key={integration.name}

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -44,21 +44,23 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center gradient-warm">
-      <div className="w-full max-w-sm animate-fade-in-up">
-        <div className="rounded-lg border border-alpha bg-base-white p-10 shadow-dropdown dark:bg-surface">
+    <div className="page-shell gradient-warm flex min-h-screen items-center justify-center px-4 py-12">
+      <div className="w-full max-w-md animate-fade-in-up">
+        <div className="surface-card p-8 md:p-10">
           <div className="text-center">
-            <h1 className="text-2xl font-heading font-bold text-primary">
+            <span className="label-text">Client Portal</span>
+            <h1 className="page-title mt-4 text-[clamp(2.5rem,8vw,3.5rem)]">
               Gestalt
             </h1>
-            <p className="mt-3 text-sm text-muted">
-              Sign in to manage your integrations.
+            <p className="mt-4 text-base leading-7 text-secondary">
+              Sign in to manage integrations, credentials, and the operational
+              surface around them.
             </p>
-            <p className="mt-2 text-sm text-muted">
+            <p className="mt-3 text-sm text-muted">
               Or read the{" "}
               <a
                 href="/docs"
-                className="font-medium text-muted hover:text-primary transition-colors duration-150 underline underline-offset-2 decoration-base-300 dark:decoration-base-600"
+                className="font-bold text-primary underline underline-offset-4 decoration-base-300"
               >
                 documentation
               </a>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -32,16 +32,15 @@ export default function DashboardPage() {
 
   return (
     <AuthGuard>
-      <div className="min-h-screen">
+      <div className="page-shell">
         <Nav />
-        <main className="mx-auto max-w-5xl px-6 py-12">
-          <div className="animate-fade-in-up">
+        <main className="page-main">
+          <div className="page-hero animate-fade-in-up">
             <span className="label-text">Overview</span>
-            <h1 className="mt-2 text-2xl font-heading font-bold text-primary">
-              Dashboard
-            </h1>
-            <p className="mt-2 text-sm text-muted">
-              Your Gestalt overview at a glance.
+            <h1 className="page-title mt-4">Dashboard</h1>
+            <p className="page-subtitle mt-4">
+              A warm, readable control surface for integrations, tokens, and
+              the operational details that matter most.
             </p>
           </div>
 
@@ -49,31 +48,43 @@ export default function DashboardPage() {
             <p className="mt-8 text-sm text-ember-500">{data.error}</p>
           )}
 
-          <div className="mt-10 grid grid-cols-1 gap-5 sm:grid-cols-2 animate-fade-in-up [animation-delay:60ms]">
+          <div className="mt-8 grid grid-cols-1 gap-6 md:mt-10 md:grid-cols-2 animate-fade-in-up [animation-delay:60ms]">
             <Link
               href="/integrations"
-              className="group rounded-lg border border-alpha bg-base-100 p-8 transition-all duration-150 hover:border-alpha-strong hover:shadow-card dark:bg-surface"
+              className="surface-card group p-6 md:p-8"
             >
               <span className="label-text">Integrations</span>
-              <p className="mt-3 text-3xl font-heading font-bold text-primary">
+              <p className="metric-value mt-5">
                 {data.integrations ?? "--"}
               </p>
-              <p className="mt-3 text-sm text-muted group-hover:text-primary transition-colors duration-150">
+              <p className="mt-5 max-w-xs text-sm leading-6 text-muted group-hover:text-secondary">
+                Browse providers, establish new connections, and keep the
+                catalog in good shape.
+              </p>
+              <p className="mt-6 inline-flex items-center gap-2 text-sm font-bold text-primary">
                 Manage integrations
-                <span className="inline-block ml-1 transition-transform duration-150 group-hover:translate-x-0.5">&rarr;</span>
+                <span className="inline-block transition-transform duration-150 group-hover:translate-x-0.5">
+                  &rarr;
+                </span>
               </p>
             </Link>
             <Link
               href="/tokens"
-              className="group rounded-lg border border-alpha bg-base-100 p-8 transition-all duration-150 hover:border-alpha-strong hover:shadow-card dark:bg-surface"
+              className="surface-card group p-6 md:p-8"
             >
               <span className="label-text">API Tokens</span>
-              <p className="mt-3 text-3xl font-heading font-bold text-primary">
+              <p className="metric-value mt-5">
                 {data.tokens ?? "--"}
               </p>
-              <p className="mt-3 text-sm text-muted group-hover:text-primary transition-colors duration-150">
+              <p className="mt-5 max-w-xs text-sm leading-6 text-muted group-hover:text-secondary">
+                Create, rotate, and retire credentials without losing visual
+                clarity in the process.
+              </p>
+              <p className="mt-6 inline-flex items-center gap-2 text-sm font-bold text-primary">
                 Manage tokens
-                <span className="inline-block ml-1 transition-transform duration-150 group-hover:translate-x-0.5">&rarr;</span>
+                <span className="inline-block transition-transform duration-150 group-hover:translate-x-0.5">
+                  &rarr;
+                </span>
               </p>
             </Link>
           </div>

--- a/web/src/app/tokens/page.tsx
+++ b/web/src/app/tokens/page.tsx
@@ -26,16 +26,15 @@ export default function TokensPage() {
 
   return (
     <AuthGuard>
-      <div className="min-h-screen">
+      <div className="page-shell">
         <Nav />
-        <main className="mx-auto max-w-5xl px-6 py-12">
-          <div className="animate-fade-in-up">
+        <main className="page-main">
+          <div className="page-hero animate-fade-in-up">
             <span className="label-text">Security</span>
-            <h1 className="mt-2 text-2xl font-heading font-bold text-primary">
-              API Tokens
-            </h1>
-            <p className="mt-2 text-sm text-muted">
-              Manage tokens for programmatic access to the Gestalt API.
+            <h1 className="page-title mt-4">API Tokens</h1>
+            <p className="page-subtitle mt-4">
+              Manage programmatic access with clearer hierarchy, more space, and
+              less of the generic dashboard feel.
             </p>
           </div>
 

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -4,9 +4,9 @@ type Variant = "primary" | "secondary" | "danger";
 
 const variantStyles: Record<Variant, string> = {
   primary:
-    "bg-base-950 text-white hover:bg-base-900 dark:bg-base-100 dark:text-base-950 dark:hover:bg-base-200",
+    "bg-base-950 text-base-white hover:bg-[rgba(35,24,16,0.9)] dark:bg-base-100 dark:text-base-950 dark:hover:bg-base-200",
   secondary:
-    "bg-alpha-10 text-primary hover:bg-base-200 dark:hover:bg-base-800",
+    "bg-alpha-10 text-primary hover:bg-[rgba(35,24,16,0.18)] dark:hover:bg-base-800",
   danger:
     "bg-ember-600 text-white hover:bg-ember-700 dark:bg-ember-500 dark:hover:bg-ember-600",
 };
@@ -24,7 +24,7 @@ export default function Button({
 }: ButtonProps) {
   return (
     <button
-      className={`rounded-md px-6 py-2.5 text-sm font-medium transition-all duration-150 ease-out disabled:opacity-50 disabled:cursor-not-allowed active:translate-y-px ${variantStyles[variant]} ${className}`}
+      className={`inline-flex min-h-12 items-center justify-center rounded-md px-6 py-3 text-sm font-bold tracking-[0.01em] transition-all duration-150 ease-out focus:outline-none focus:ring-2 focus:ring-base-950/15 focus:ring-offset-2 focus:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 active:translate-y-px dark:focus:ring-base-100/20 ${variantStyles[variant]} ${className}`}
       disabled={disabled}
       {...props}
     >

--- a/web/src/components/IntegrationCard.tsx
+++ b/web/src/components/IntegrationCard.tsx
@@ -220,7 +220,7 @@ export default function IntegrationCard({
   }
 
   return (
-    <div className="rounded-lg border border-alpha bg-base-white p-6 transition-all duration-150 hover:border-alpha-strong hover:shadow-card dark:bg-surface">
+    <div className="surface-card h-full p-6 md:p-7">
       {pendingSelection && (
         <form
           ref={pendingSelectionFormRef}
@@ -235,9 +235,9 @@ export default function IntegrationCard({
           />
         </form>
       )}
-      <div className="flex items-start justify-between">
-        <div className="flex items-start gap-3">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-base-100 text-muted [&>svg]:h-5 [&>svg]:w-5 dark:bg-surface-raised">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-4">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-base-100 text-muted [&>svg]:h-5 [&>svg]:w-5 dark:bg-surface-raised">
             {safeIconSVG ? (
               <div
                 dangerouslySetInnerHTML={{ __html: safeIconSVG }}
@@ -247,12 +247,15 @@ export default function IntegrationCard({
               <DefaultIcon />
             )}
           </div>
-          <div>
-            <h3 className="text-base font-heading font-semibold text-primary">
+          <div className="min-w-0">
+            <p className="label-text">
+              {integration.connected ? "Connected" : "Available"}
+            </p>
+            <h3 className="section-title mt-3 text-[1.25rem]">
               {integration.display_name || integration.name}
             </h3>
             {integration.description && (
-              <p className="mt-1 line-clamp-2 text-sm text-muted">
+              <p className="mt-3 line-clamp-3 text-sm leading-6 text-muted">
                 {integration.description}
               </p>
             )}
@@ -264,18 +267,34 @@ export default function IntegrationCard({
           )}
           <button
             onClick={() => setSettingsOpen(true)}
-            className="flex h-8 w-8 items-center justify-center rounded-md text-faint transition-all duration-150 hover:bg-alpha-5 hover:text-muted"
+            className="icon-button h-9 w-9"
             aria-label={`${integration.display_name || integration.name} settings`}
           >
             <GearIcon className="h-4 w-4" />
           </button>
         </div>
       </div>
+      <div className="mt-6 flex items-center justify-between gap-3 text-sm">
+        <span
+          className={`rounded-full border px-3 py-1.5 ${
+            integration.connected
+              ? "border-grove-200 bg-grove-50 text-grove-700 dark:border-grove-600 dark:bg-grove-700/15 dark:text-grove-200"
+              : "border-alpha bg-alpha-5 text-muted"
+          }`}
+        >
+          {integration.connected ? "Ready to use" : "Ready to connect"}
+        </span>
+        <span className="text-faint">
+          {integration.instances?.length
+            ? `${integration.instances.length} connection${integration.instances.length === 1 ? "" : "s"}`
+            : "No saved connections"}
+        </span>
+      </div>
       {error && !settingsOpen && (
         <p className="mt-3 text-sm text-ember-500">{error}</p>
       )}
       {showParamForm && (
-        <form onSubmit={handleParamSubmit} className="mt-4">
+        <form onSubmit={handleParamSubmit} className="mt-6 border-t border-alpha pt-6">
           {renderConnectionParamFields()}
           <div className="mt-4 flex gap-2">
             <Button type="submit" disabled={loading}>

--- a/web/src/components/IntegrationSettingsModal.tsx
+++ b/web/src/components/IntegrationSettingsModal.tsx
@@ -278,14 +278,14 @@ export default function IntegrationSettingsModal({
       onCancel={handleCancel}
       onClose={onClose}
       onClick={handleBackdropClick}
-      className="m-auto w-full max-w-sm rounded-lg border border-alpha bg-base-white p-0 shadow-dropdown dark:bg-surface"
+      className="m-auto w-full max-w-md rounded-lg border border-alpha bg-base-white p-0 shadow-dropdown dark:bg-surface"
     >
-      <div className="p-7">
+      <div className="p-7 md:p-8">
         {view === "disconnect" ? (
           <>
             <h2
               id={headingId}
-              className="text-lg font-heading font-semibold text-primary"
+              className="section-title text-[1.5rem]"
             >
               Disconnect {displayName}?
             </h2>
@@ -320,7 +320,7 @@ export default function IntegrationSettingsModal({
           <form onSubmit={handleInstanceSubmit}>
             <h2
               id={headingId}
-              className="text-lg font-heading font-semibold text-primary"
+              className="section-title text-[1.5rem]"
             >
               Add Connection
             </h2>
@@ -368,12 +368,12 @@ export default function IntegrationSettingsModal({
         ) : (
           <>
             <div className="flex items-start justify-between">
-              <h2
-                id={headingId}
-                className="text-lg font-heading font-semibold text-primary"
-              >
-                {displayName}
-              </h2>
+            <h2
+              id={headingId}
+              className="section-title text-[1.5rem]"
+            >
+              {displayName}
+            </h2>
               <button
                 onClick={closeDialog}
                 className="rounded-md p-1.5 text-faint hover:text-muted transition-colors duration-150 hover:bg-alpha-5"
@@ -388,7 +388,10 @@ export default function IntegrationSettingsModal({
                 {integration.instances && integration.instances.length > 0 && (
                   <div className="mt-5 space-y-2">
                     {integration.instances.map((inst) => (
-                      <div key={inst.name} className="flex items-center justify-between rounded-md border border-alpha px-4 py-3">
+                      <div
+                        key={inst.name}
+                        className="flex items-center justify-between rounded-md border border-alpha bg-alpha-5 px-4 py-3"
+                      >
                         <div className="flex items-center gap-2.5">
                           <CheckCircleIcon className="h-4 w-4 text-grove-500" />
                           <div>
@@ -467,7 +470,7 @@ function TokenForm({
     <form onSubmit={onSubmit}>
       <h2
         id={headingId}
-        className="text-lg font-heading font-semibold text-primary"
+        className="section-title text-[1.5rem]"
       >
         {heading}
       </h2>

--- a/web/src/components/Nav.tsx
+++ b/web/src/components/Nav.tsx
@@ -19,7 +19,8 @@ export default function Nav() {
   const pathname = usePathname();
   const email = getUserEmail();
   const { theme, setTheme } = useTheme();
-  const ThemeIcon = theme === "light" ? SunIcon : theme === "dark" ? MoonIcon : SunMoonIcon;
+  const ThemeIcon =
+    theme === "light" ? SunIcon : theme === "dark" ? MoonIcon : SunMoonIcon;
 
   async function handleLogout() {
     await logout().catch(() => {});
@@ -28,20 +29,18 @@ export default function Nav() {
   }
 
   return (
-    <nav className="border-b border-alpha px-6 py-3 bg-background/80 backdrop-blur-sm sticky top-0 z-50">
-      <div className="mx-auto max-w-5xl flex items-center justify-between">
-        <div className="flex items-center gap-8">
-          <Link href="/" className="text-lg font-heading font-bold text-primary">
+    <nav className="nav-shell">
+      <div className="nav-inner gap-4">
+        <div className="flex min-w-0 items-center gap-4 md:gap-8">
+          <Link href="/" className="brand-lockup shrink-0">
             Gestalt
           </Link>
-          <div className="flex gap-5">
+          <div className="hidden items-center gap-1 md:flex">
             {links.map((link) => {
               const isActive = pathname === link.href;
-              const className = `text-sm transition-colors duration-150 ${
-                isActive
-                  ? "text-primary font-medium"
-                  : "text-muted hover:text-secondary"
-              }`;
+              const className = isActive
+                ? "nav-link-active"
+                : "nav-link px-3 py-2";
               if (link.href === "/docs") {
                 return (
                   <a key={link.href} href={link.href} className={className}>
@@ -57,30 +56,55 @@ export default function Nav() {
             })}
           </div>
         </div>
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2 md:gap-4">
           <button
             onClick={() => {
               if (theme === "light") setTheme("dark");
               else if (theme === "dark") setTheme("system");
               else setTheme("light");
             }}
-            className="flex h-8 w-8 items-center justify-center rounded-md text-muted transition-all duration-150 hover:bg-alpha-5"
-            title={theme === "light" ? "Light mode" : theme === "dark" ? "Dark mode" : "System preference"}
+            className="icon-button"
+            title={
+              theme === "light"
+                ? "Light mode"
+                : theme === "dark"
+                  ? "Dark mode"
+                  : "System preference"
+            }
             aria-label="Toggle theme"
           >
             <ThemeIcon className="h-[18px] w-[18px]" />
           </button>
           {email && (
             <>
-              <span className="text-sm text-faint">{email}</span>
-              <button
-                onClick={handleLogout}
-                className="text-sm text-muted hover:text-primary transition-colors duration-150"
-              >
+              <span className="hidden text-sm text-faint lg:block">{email}</span>
+              <button onClick={handleLogout} className="nav-link px-3 py-2">
                 Logout
               </button>
             </>
           )}
+        </div>
+      </div>
+      <div className="mx-auto flex w-full justify-center pb-3 md:hidden">
+        <div className="flex w-[min(100%,1300px)] gap-1 overflow-x-auto px-4">
+          {links.map((link) => {
+            const isActive = pathname === link.href;
+            const className = isActive
+              ? "nav-link-active"
+              : "nav-link px-3 py-2";
+            if (link.href === "/docs") {
+              return (
+                <a key={link.href} href={link.href} className={className}>
+                  {link.label}
+                </a>
+              );
+            }
+            return (
+              <Link key={link.href} href={link.href} className={className}>
+                {link.label}
+              </Link>
+            );
+          })}
         </div>
       </div>
     </nav>

--- a/web/src/components/TokenCreateForm.tsx
+++ b/web/src/components/TokenCreateForm.tsx
@@ -38,8 +38,11 @@ export default function TokenCreateForm({ onCreated }: TokenCreateFormProps) {
 
   return (
     <>
-      <form onSubmit={handleSubmit} className="mt-8 flex items-end gap-3">
-        <div>
+      <form
+        onSubmit={handleSubmit}
+        className="surface-card mt-8 flex flex-col gap-4 p-6 md:flex-row md:items-end md:justify-between"
+      >
+        <div className="w-full max-w-xl">
           <label
             htmlFor="token-name"
             className="label-text block"
@@ -55,14 +58,14 @@ export default function TokenCreateForm({ onCreated }: TokenCreateFormProps) {
             className={`mt-2 ${INPUT_CLASSES}`}
           />
         </div>
-        <Button type="submit" disabled={creating}>
+        <Button type="submit" disabled={creating} className="w-full md:w-auto">
           {creating ? "Creating..." : "Create Token"}
         </Button>
       </form>
 
       {plaintext && (
         <div className="mt-6 rounded-lg border border-gold-300 bg-gold-50 p-5 dark:border-gold-700 dark:bg-gold-950/30">
-          <p className="text-sm font-medium text-gold-800 dark:text-gold-300">
+          <p className="text-sm font-bold text-gold-800 dark:text-gold-300">
             Copy this token now. It will not be shown again.
           </p>
           <code className="mt-3 block break-all rounded-sm bg-base-white p-3 font-mono text-sm text-primary border border-alpha dark:bg-surface">

--- a/web/src/components/TokenTable.tsx
+++ b/web/src/components/TokenTable.tsx
@@ -28,17 +28,17 @@ export default function TokenTable({ tokens, onRevoked }: TokenTableProps) {
 
   if (tokens.length === 0) {
     return (
-      <p className="py-12 text-center text-sm text-faint">
+      <div className="surface-card py-12 text-center text-sm text-faint">
         No API tokens yet.
-      </p>
+      </div>
     );
   }
 
   return (
-    <div className="rounded-lg border border-alpha bg-base-white overflow-x-auto dark:bg-surface">
-      {error && <p className="mb-4 px-5 pt-4 text-sm text-ember-500">{error}</p>}
+    <div className="table-surface overflow-x-auto">
+      {error && <p className="px-6 pt-5 text-sm text-ember-500">{error}</p>}
       <table className="w-full text-sm">
-        <thead>
+        <thead className="table-head">
           <tr className="border-b border-alpha text-left">
             <th className="px-5 py-3.5 label-text">Name</th>
             <th className="px-5 py-3.5 label-text">Scopes</th>
@@ -49,8 +49,8 @@ export default function TokenTable({ tokens, onRevoked }: TokenTableProps) {
         </thead>
         <tbody>
           {tokens.map((token) => (
-            <tr key={token.id} className="border-b border-alpha last:border-b-0">
-              <td className="px-5 py-4 text-primary font-medium">{token.name}</td>
+            <tr key={token.id} className="table-row border-b border-alpha last:border-b-0">
+              <td className="px-5 py-4 text-primary">{token.name}</td>
               <td className="px-5 py-4 text-muted">{token.scopes || "all"}</td>
               <td className="px-5 py-4 text-muted font-mono text-xs">
                 {new Date(token.created_at).toLocaleDateString()}

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -4,4 +4,4 @@ export const NONE_PROVIDER = "none";
 export const DEFAULT_LOCAL_EMAIL = "anonymous@gestalt";
 
 export const INPUT_CLASSES =
-  "rounded-sm border border-alpha bg-base-white px-3 py-2 text-sm text-primary placeholder:text-faint focus:border-base-950 focus:outline-none focus:ring-2 focus:ring-base-950/10 dark:bg-surface dark:focus:border-base-200 dark:focus:ring-base-200/10";
+  "min-h-12 rounded-md border border-alpha bg-base-white px-4 py-3 text-sm text-primary placeholder:text-faint transition-colors duration-150 focus:border-alpha-strong focus:outline-none focus:ring-2 focus:ring-base-950/10 dark:bg-surface dark:focus:border-base-300 dark:focus:ring-base-200/10";


### PR DESCRIPTION
## What changed
- restyled the embedded `web/` app around the Valon style guide with warmer surfaces, proper display hierarchy, improved spacing, and cleaner navigation/card/table/form states
- restyled `docs/` beyond font overrides so the Nextra site uses the same warm palette and typography direction instead of the default gray theme
- fixed `web/dev.sh` so it starts `gestaltd` from `server/` and correctly supports custom `API_PORT` values during local frontend development

## Why it changed
The frontend looked off because the fonts were only one piece of the problem. `web/` was still using a generic dashboard system, and `docs/` was still mostly default Nextra with minimal overrides. That left both surfaces visually misaligned with the Valon guide and made local iteration harder than it should be.

## Impact
- `web/` now has a stronger visual hierarchy and more intentional spacing across dashboard, integrations, tokens, login, and shared components
- `docs/` now feels materially closer to the Valon style language while keeping the existing information architecture intact
- local frontend work is easier because `web/dev.sh` now boots reliably, including on non-default ports

## Root cause
The styling work had stopped at font loading, while the actual design mismatch was coming from the underlying layout, color, spacing, and component primitives. Separately, the dev script assumed the Go module lived at repo root and never propagated custom API ports into the generated config.

## Validation
- `cd web && npm run check`
- `cd web && npm run build`
- `cd docs && npm run build`
- `API_PORT=8081 WEB_PORT=3002 ./web/dev.sh`
