### PR TITLE
[codex] Dedupe datastore integration coverage and config schema validation

### DIFF
--- a/server/core/testing/datastore_driver_suite.go
+++ b/server/core/testing/datastore_driver_suite.go
@@ -15,9 +15,7 @@ type DatastoreDriverHooks struct {
 	AssertRejectsOrphanTokenInsert func(t *testing.T, ctx context.Context, ds core.Datastore)
 }
 
-// RunDatastoreDriverTests extends the base datastore conformance suite with
-// integration tests that have historically been duplicated across concrete
-// datastore backends.
+// RunDatastoreDriverTests adds shared driver-level integration coverage.
 func RunDatastoreDriverTests(t *testing.T, newStore func(t *testing.T) core.Datastore, hooks DatastoreDriverHooks) {
 	t.Helper()
 

--- a/server/core/testing/datastore_driver_suite.go
+++ b/server/core/testing/datastore_driver_suite.go
@@ -1,0 +1,206 @@
+package coretesting
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/server/core"
+)
+
+type DatastoreDriverHooks struct {
+	AssertTokenEncryptedAtRest     func(t *testing.T, ctx context.Context, ds core.Datastore, token *core.IntegrationToken)
+	AssertRejectsOrphanTokenInsert func(t *testing.T, ctx context.Context, ds core.Datastore)
+}
+
+// RunDatastoreDriverTests extends the base datastore conformance suite with
+// integration tests that have historically been duplicated across concrete
+// datastore backends.
+func RunDatastoreDriverTests(t *testing.T, newStore func(t *testing.T) core.Datastore, hooks DatastoreDriverHooks) {
+	t.Helper()
+
+	RunDatastoreTests(t, newStore)
+
+	t.Run("ConcurrentTokenWrites", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { _ = ds.Close() })
+		ctx := context.Background()
+
+		user := mustCreateUser(t, ctx, ds, "concurrent@example.com")
+		now := time.Now().UTC().Truncate(time.Second)
+
+		var wg sync.WaitGroup
+		errs := make([]error, 10)
+
+		for i := range errs {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				errs[idx] = ds.StoreToken(ctx, &core.IntegrationToken{
+					ID:          uuid.NewString(),
+					UserID:      user.ID,
+					Integration: "svc",
+					Instance:    uuid.NewString(),
+					AccessToken: "tok",
+					CreatedAt:   now,
+					UpdatedAt:   now,
+				})
+			}(i)
+		}
+		wg.Wait()
+
+		for i, err := range errs {
+			if err != nil {
+				t.Errorf("concurrent write %d: %v", i, err)
+			}
+		}
+
+		tokens, err := ds.ListTokens(ctx, user.ID)
+		if err != nil {
+			t.Fatalf("ListTokens: %v", err)
+		}
+		if len(tokens) != len(errs) {
+			t.Fatalf("ListTokens: got %d tokens, want %d", len(tokens), len(errs))
+		}
+	})
+
+	t.Run("FindOrCreateUserRace", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { _ = ds.Close() })
+		ctx := context.Background()
+
+		const goroutines = 20
+		email := "race@example.com"
+
+		var wg sync.WaitGroup
+		users := make([]*core.User, goroutines)
+		errs := make([]error, goroutines)
+
+		for i := range goroutines {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				users[idx], errs[idx] = ds.FindOrCreateUser(ctx, email)
+			}(i)
+		}
+		wg.Wait()
+
+		for i, err := range errs {
+			if err != nil {
+				t.Fatalf("goroutine %d: %v", i, err)
+			}
+		}
+
+		firstID := users[0].ID
+		for i, user := range users[1:] {
+			if user == nil {
+				t.Fatalf("goroutine %d returned nil user", i+1)
+			}
+			if user.ID != firstID {
+				t.Errorf("goroutine %d returned ID %q, want %q", i+1, user.ID, firstID)
+			}
+		}
+	})
+
+	t.Run("StoreTokenUpsert", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { _ = ds.Close() })
+		ctx := context.Background()
+
+		user := mustCreateUser(t, ctx, ds, "upsert@example.com")
+		now := time.Now().UTC().Truncate(time.Second)
+		token := &core.IntegrationToken{
+			ID:          "upsert-tok",
+			UserID:      user.ID,
+			Integration: "svc",
+			Instance:    "i1",
+			AccessToken: "first",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+
+		mustStoreToken(t, ctx, ds, token)
+
+		token.AccessToken = "second"
+		token.UpdatedAt = now.Add(time.Minute)
+		mustStoreToken(t, ctx, ds, token)
+
+		got, err := ds.Token(ctx, user.ID, "svc", "", "i1")
+		if err != nil {
+			t.Fatalf("Token: %v", err)
+		}
+		if got == nil {
+			t.Fatal("Token returned nil")
+		}
+		if got.AccessToken != "second" {
+			t.Errorf("AccessToken after upsert: got %q, want %q", got.AccessToken, "second")
+		}
+	})
+
+	t.Run("DeleteNonexistentTokenNoError", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { _ = ds.Close() })
+
+		if err := ds.DeleteToken(context.Background(), "does-not-exist"); err != nil {
+			t.Fatalf("DeleteToken for nonexistent: %v", err)
+		}
+	})
+
+	t.Run("RevokeNonexistentAPITokenReturnsNotFound", func(t *testing.T) {
+		ds := newStore(t)
+		t.Cleanup(func() { _ = ds.Close() })
+
+		err := ds.RevokeAPIToken(context.Background(), "no-user", "does-not-exist")
+		if err != core.ErrNotFound {
+			t.Fatalf("RevokeAPIToken for nonexistent: expected ErrNotFound, got %v", err)
+		}
+	})
+
+	if hooks.AssertTokenEncryptedAtRest != nil {
+		t.Run("EncryptsTokensAtRest", func(t *testing.T) {
+			ds := newStore(t)
+			t.Cleanup(func() { _ = ds.Close() })
+			ctx := context.Background()
+
+			user := mustCreateUser(t, ctx, ds, "enc@example.com")
+			now := time.Now().UTC().Truncate(time.Second)
+			token := &core.IntegrationToken{
+				ID:           "enc-tok-1",
+				UserID:       user.ID,
+				Integration:  "test",
+				Instance:     "i1",
+				AccessToken:  "secret-access-token",
+				RefreshToken: "secret-refresh-token",
+				CreatedAt:    now,
+				UpdatedAt:    now,
+			}
+
+			mustStoreToken(t, ctx, ds, token)
+			hooks.AssertTokenEncryptedAtRest(t, ctx, ds, token)
+
+			got, err := ds.Token(ctx, user.ID, "test", "", "i1")
+			if err != nil {
+				t.Fatalf("Token: %v", err)
+			}
+			if got == nil {
+				t.Fatal("Token returned nil")
+			}
+			if got.AccessToken != token.AccessToken {
+				t.Errorf("AccessToken: got %q, want %q", got.AccessToken, token.AccessToken)
+			}
+			if got.RefreshToken != token.RefreshToken {
+				t.Errorf("RefreshToken: got %q, want %q", got.RefreshToken, token.RefreshToken)
+			}
+		})
+	}
+
+	if hooks.AssertRejectsOrphanTokenInsert != nil {
+		t.Run("RejectsOrphanTokenInsert", func(t *testing.T) {
+			ds := newStore(t)
+			t.Cleanup(func() { _ = ds.Close() })
+			hooks.AssertRejectsOrphanTokenInsert(t, context.Background(), ds)
+		})
+	}
+}

--- a/server/internal/configschema/validate.go
+++ b/server/internal/configschema/validate.go
@@ -1,0 +1,30 @@
+package configschema
+
+import (
+	"fmt"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"gopkg.in/yaml.v3"
+)
+
+func Validate(config map[string]any, schemaText string) error {
+	var schemaDoc any
+	if err := yaml.Unmarshal([]byte(schemaText), &schemaDoc); err != nil {
+		return fmt.Errorf("invalid config schema: %w", err)
+	}
+
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("config.schema", schemaDoc); err != nil {
+		return fmt.Errorf("invalid config schema: %w", err)
+	}
+
+	schema, err := compiler.Compile("config.schema")
+	if err != nil {
+		return fmt.Errorf("compile config schema: %w", err)
+	}
+
+	if err := schema.Validate(config); err != nil {
+		return fmt.Errorf("config validation failed: %w", err)
+	}
+	return nil
+}

--- a/server/internal/drivers/datastore/firestore/firestore_test.go
+++ b/server/internal/drivers/datastore/firestore/firestore_test.go
@@ -46,65 +46,31 @@ func newTestStore(t *testing.T) *Store {
 
 func TestFirestoreDatastoreConformance(t *testing.T) {
 	t.Parallel()
-	coretesting.RunDatastoreTests(t, func(t *testing.T) core.Datastore {
+	coretesting.RunDatastoreDriverTests(t, func(t *testing.T) core.Datastore {
 		return newTestStore(t)
+	}, coretesting.DatastoreDriverHooks{
+		AssertTokenEncryptedAtRest: func(t *testing.T, ctx context.Context, ds core.Datastore, token *core.IntegrationToken) {
+			store := ds.(*Store)
+
+			snap, err := store.client.Collection(datastore.IntegrationTokensCollection).Doc(token.ID).Get(ctx)
+			if err != nil {
+				t.Fatalf("raw Get: %v", err)
+			}
+			var doc integrationTokenDoc
+			if err := snap.DataTo(&doc); err != nil {
+				t.Fatalf("DataTo: %v", err)
+			}
+			if doc.AccessTokenEncrypted == token.AccessToken {
+				t.Error("access token stored in plaintext")
+			}
+			if doc.RefreshTokenEncrypted == token.RefreshToken {
+				t.Error("refresh token stored in plaintext")
+			}
+			if doc.AccessTokenEncrypted == "" {
+				t.Error("access_token_encrypted is empty")
+			}
+		},
 	})
-}
-
-func TestEncryptionRoundTrip(t *testing.T) {
-	t.Parallel()
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	user, err := store.FindOrCreateUser(ctx, "enc@example.com")
-	if err != nil {
-		t.Fatalf("FindOrCreateUser: %v", err)
-	}
-
-	now := time.Now().Truncate(time.Second)
-	token := &core.IntegrationToken{
-		ID:           fmt.Sprintf("enc-tok-%s", uuid.NewString()),
-		UserID:       user.ID,
-		Integration:  "test",
-		Instance:     "i1",
-		AccessToken:  "secret-access-token",
-		RefreshToken: "secret-refresh-token",
-		CreatedAt:    now,
-		UpdatedAt:    now,
-	}
-	if err := store.StoreToken(ctx, token); err != nil {
-		t.Fatalf("StoreToken: %v", err)
-	}
-
-	// Verify the raw document stores encrypted values.
-	snap, err := store.client.Collection(datastore.IntegrationTokensCollection).Doc(token.ID).Get(ctx)
-	if err != nil {
-		t.Fatalf("raw Get: %v", err)
-	}
-	var doc integrationTokenDoc
-	if err := snap.DataTo(&doc); err != nil {
-		t.Fatalf("DataTo: %v", err)
-	}
-	if doc.AccessTokenEncrypted == "secret-access-token" {
-		t.Error("access token stored in plaintext")
-	}
-	if doc.RefreshTokenEncrypted == "secret-refresh-token" {
-		t.Error("refresh token stored in plaintext")
-	}
-	if doc.AccessTokenEncrypted == "" {
-		t.Error("access_token_encrypted is empty")
-	}
-
-	got, err := store.Token(ctx, user.ID, "test", "", "i1")
-	if err != nil {
-		t.Fatalf("Token: %v", err)
-	}
-	if got.AccessToken != "secret-access-token" {
-		t.Errorf("AccessToken: got %q, want %q", got.AccessToken, "secret-access-token")
-	}
-	if got.RefreshToken != "secret-refresh-token" {
-		t.Errorf("RefreshToken: got %q, want %q", got.RefreshToken, "secret-refresh-token")
-	}
 }
 
 func TestFindOrCreateUserHonorsLegacyEmailLookupKey(t *testing.T) {

--- a/server/internal/drivers/datastore/mysql/mysql_test.go
+++ b/server/internal/drivers/datastore/mysql/mysql_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -80,227 +79,48 @@ func newTestStore(t *testing.T) *Store {
 
 func TestMySQLDatastoreConformance(t *testing.T) {
 	t.Parallel()
-	coretesting.RunDatastoreTests(t, func(t *testing.T) core.Datastore {
+	coretesting.RunDatastoreDriverTests(t, func(t *testing.T) core.Datastore {
 		return newTestStore(t)
-	})
-}
+	}, coretesting.DatastoreDriverHooks{
+		AssertTokenEncryptedAtRest: func(t *testing.T, ctx context.Context, ds core.Datastore, token *core.IntegrationToken) {
+			store := ds.(*Store)
 
-func TestEncryptionRoundTrip(t *testing.T) {
-	t.Parallel()
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	user, err := store.FindOrCreateUser(ctx, "enc@example.com")
-	if err != nil {
-		t.Fatalf("FindOrCreateUser: %v", err)
-	}
-
-	now := time.Now().Truncate(time.Second)
-	token := &core.IntegrationToken{
-		ID:           "enc-tok-1",
-		UserID:       user.ID,
-		Integration:  "test",
-		Instance:     "i1",
-		AccessToken:  "secret-access-token",
-		RefreshToken: "secret-refresh-token",
-		CreatedAt:    now,
-		UpdatedAt:    now,
-	}
-	if err := store.StoreToken(ctx, token); err != nil {
-		t.Fatalf("StoreToken: %v", err)
-	}
-
-	// Verify tokens are encrypted at rest.
-	var accessEnc, refreshEnc string
-	err = store.DB.QueryRowContext(ctx,
-		"SELECT access_token_encrypted, refresh_token_encrypted FROM integration_tokens WHERE id = ?",
-		"enc-tok-1",
-	).Scan(&accessEnc, &refreshEnc)
-	if err != nil {
-		t.Fatalf("raw query: %v", err)
-	}
-	if accessEnc == "secret-access-token" {
-		t.Error("access token stored in plaintext")
-	}
-	if refreshEnc == "secret-refresh-token" {
-		t.Error("refresh token stored in plaintext")
-	}
-	if accessEnc == "" {
-		t.Error("access_token_encrypted is empty")
-	}
-
-	// Verify round-trip decryption.
-	got, err := store.Token(ctx, user.ID, "test", "", "i1")
-	if err != nil {
-		t.Fatalf("Token: %v", err)
-	}
-	if got.AccessToken != "secret-access-token" {
-		t.Errorf("AccessToken: got %q, want %q", got.AccessToken, "secret-access-token")
-	}
-	if got.RefreshToken != "secret-refresh-token" {
-		t.Errorf("RefreshToken: got %q, want %q", got.RefreshToken, "secret-refresh-token")
-	}
-}
-
-func TestConcurrentReadWrite(t *testing.T) {
-	t.Parallel()
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	user, err := store.FindOrCreateUser(ctx, "concurrent@example.com")
-	if err != nil {
-		t.Fatalf("FindOrCreateUser: %v", err)
-	}
-
-	now := time.Now().Truncate(time.Second)
-	var wg sync.WaitGroup
-	errs := make([]error, 10)
-
-	for i := range 10 {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			tok := &core.IntegrationToken{
-				ID:          uuid.NewString(),
-				UserID:      user.ID,
-				Integration: "svc",
-				Instance:    uuid.NewString(),
-				AccessToken: "tok",
-				CreatedAt:   now,
-				UpdatedAt:   now,
+			var accessEnc, refreshEnc string
+			err := store.DB.QueryRowContext(ctx,
+				"SELECT access_token_encrypted, refresh_token_encrypted FROM integration_tokens WHERE id = ?",
+				token.ID,
+			).Scan(&accessEnc, &refreshEnc)
+			if err != nil {
+				t.Fatalf("raw query: %v", err)
 			}
-			errs[idx] = store.StoreToken(ctx, tok)
-		}(i)
-	}
-	wg.Wait()
+			if accessEnc == token.AccessToken {
+				t.Error("access token stored in plaintext")
+			}
+			if refreshEnc == token.RefreshToken {
+				t.Error("refresh token stored in plaintext")
+			}
+			if accessEnc == "" {
+				t.Error("access_token_encrypted is empty")
+			}
+		},
+		AssertRejectsOrphanTokenInsert: func(t *testing.T, ctx context.Context, ds core.Datastore) {
+			store := ds.(*Store)
+			now := time.Now().UTC().Truncate(time.Second)
 
-	for i, err := range errs {
-		if err != nil {
-			t.Errorf("concurrent write %d: %v", i, err)
-		}
-	}
+			_, err := store.DB.ExecContext(ctx,
+				"INSERT INTO integration_tokens (id, user_id, integration, instance, access_token_encrypted, refresh_token_encrypted, scopes, metadata_json, created_at, updated_at, last_refreshed_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+				"fk-tok", "nonexistent-user", "svc", "i1", "enc", "", "", "", now, now, now,
+			)
+			if err == nil {
+				t.Fatal("expected foreign key violation, got nil error")
+			}
 
-	tokens, err := store.ListTokens(ctx, user.ID)
-	if err != nil {
-		t.Fatalf("ListTokens: %v", err)
-	}
-	if len(tokens) != 10 {
-		t.Errorf("expected 10 tokens, got %d", len(tokens))
-	}
-}
-
-func TestFindOrCreateUserRace(t *testing.T) {
-	t.Parallel()
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	const goroutines = 20
-	email := "race@example.com"
-
-	var wg sync.WaitGroup
-	users := make([]*core.User, goroutines)
-	errs := make([]error, goroutines)
-
-	for i := range goroutines {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			users[idx], errs[idx] = store.FindOrCreateUser(ctx, email)
-		}(i)
-	}
-	wg.Wait()
-
-	for i, err := range errs {
-		if err != nil {
-			t.Fatalf("goroutine %d: %v", i, err)
-		}
-	}
-
-	// All goroutines must return the same user ID.
-	firstID := users[0].ID
-	for i, u := range users[1:] {
-		if u.ID != firstID {
-			t.Errorf("goroutine %d returned ID %q, want %q", i+1, u.ID, firstID)
-		}
-	}
-}
-
-func TestStoreTokenUpsert(t *testing.T) {
-	t.Parallel()
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	user, err := store.FindOrCreateUser(ctx, "upsert@example.com")
-	if err != nil {
-		t.Fatalf("FindOrCreateUser: %v", err)
-	}
-
-	now := time.Now().Truncate(time.Second)
-	token := &core.IntegrationToken{
-		ID:          "upsert-tok",
-		UserID:      user.ID,
-		Integration: "svc",
-		Instance:    "i1",
-		AccessToken: "first",
-		CreatedAt:   now,
-		UpdatedAt:   now,
-	}
-	if err := store.StoreToken(ctx, token); err != nil {
-		t.Fatalf("first StoreToken: %v", err)
-	}
-
-	token.AccessToken = "second"
-	token.UpdatedAt = now.Add(time.Minute)
-	if err := store.StoreToken(ctx, token); err != nil {
-		t.Fatalf("second StoreToken: %v", err)
-	}
-
-	got, err := store.Token(ctx, user.ID, "svc", "", "i1")
-	if err != nil {
-		t.Fatalf("Token: %v", err)
-	}
-	if got.AccessToken != "second" {
-		t.Errorf("AccessToken after upsert: got %q, want %q", got.AccessToken, "second")
-	}
-}
-
-func TestDeleteNonexistentTokenNoError(t *testing.T) {
-	t.Parallel()
-	store := newTestStore(t)
-
-	if err := store.DeleteToken(context.Background(), "does-not-exist"); err != nil {
-		t.Fatalf("DeleteToken for nonexistent: %v", err)
-	}
-}
-
-func TestRevokeNonexistentAPITokenReturnsNotFound(t *testing.T) {
-	t.Parallel()
-	store := newTestStore(t)
-
-	if err := store.RevokeAPIToken(context.Background(), "no-user", "does-not-exist"); err != core.ErrNotFound {
-		t.Fatalf("RevokeAPIToken for nonexistent: expected ErrNotFound, got %v", err)
-	}
-}
-
-func TestForeignKeyEnforcement(t *testing.T) {
-	t.Parallel()
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	now := time.Now().Truncate(time.Second)
-	_, err := store.DB.ExecContext(ctx,
-		"INSERT INTO integration_tokens (id, user_id, integration, instance, access_token_encrypted, refresh_token_encrypted, scopes, metadata_json, created_at, updated_at, last_refreshed_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-		"fk-tok", "nonexistent-user", "svc", "i1", "enc", "", "", "", now, now, now,
-	)
-	if err == nil {
-		t.Fatal("expected foreign key violation, got nil error")
-	}
-
-	// MySQL error 1452: Cannot add or update a child row: a foreign key constraint fails
-	var mysqlErr *mysqldriver.MySQLError
-	if !errors.As(err, &mysqlErr) || mysqlErr.Number != 1452 {
-		t.Errorf("expected MySQL error 1452 (FK violation), got: %v", err)
-	}
+			var mysqlErr *mysqldriver.MySQLError
+			if !errors.As(err, &mysqlErr) || mysqlErr.Number != 1452 {
+				t.Errorf("expected MySQL error 1452 (FK violation), got: %v", err)
+			}
+		},
+	})
 }
 
 func shortUUID() string {

--- a/server/internal/drivers/datastore/postgres/postgres_test.go
+++ b/server/internal/drivers/datastore/postgres/postgres_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -80,124 +79,41 @@ func uuidNoDashes(t *testing.T) string {
 
 func TestPostgresDatastoreConformance(t *testing.T) {
 	t.Parallel()
-	coretesting.RunDatastoreTests(t, func(t *testing.T) core.Datastore {
+	coretesting.RunDatastoreDriverTests(t, func(t *testing.T) core.Datastore {
 		return newTestStore(t)
-	})
-}
+	}, coretesting.DatastoreDriverHooks{
+		AssertTokenEncryptedAtRest: func(t *testing.T, ctx context.Context, ds core.Datastore, token *core.IntegrationToken) {
+			store := ds.(*Store)
 
-func TestEncryptionRoundTrip(t *testing.T) {
-	t.Parallel()
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	user, err := store.FindOrCreateUser(ctx, "enc@example.com")
-	if err != nil {
-		t.Fatalf("FindOrCreateUser: %v", err)
-	}
-
-	now := time.Now().Truncate(time.Second)
-	token := &core.IntegrationToken{
-		ID:           "enc-tok-1",
-		UserID:       user.ID,
-		Integration:  "test",
-		Instance:     "i1",
-		AccessToken:  "secret-access-token",
-		RefreshToken: "secret-refresh-token",
-		CreatedAt:    now,
-		UpdatedAt:    now,
-	}
-	if err := store.StoreToken(ctx, token); err != nil {
-		t.Fatalf("StoreToken: %v", err)
-	}
-
-	var accessEnc, refreshEnc string
-	err = store.DB.QueryRowContext(ctx,
-		"SELECT access_token_encrypted, refresh_token_encrypted FROM integration_tokens WHERE id = $1",
-		"enc-tok-1",
-	).Scan(&accessEnc, &refreshEnc)
-	if err != nil {
-		t.Fatalf("raw query: %v", err)
-	}
-	if accessEnc == "secret-access-token" {
-		t.Error("access token stored in plaintext")
-	}
-	if refreshEnc == "secret-refresh-token" {
-		t.Error("refresh token stored in plaintext")
-	}
-	if accessEnc == "" {
-		t.Error("access_token_encrypted is empty")
-	}
-
-	got, err := store.Token(ctx, user.ID, "test", "", "i1")
-	if err != nil {
-		t.Fatalf("Token: %v", err)
-	}
-	if got.AccessToken != "secret-access-token" {
-		t.Errorf("AccessToken: got %q, want %q", got.AccessToken, "secret-access-token")
-	}
-	if got.RefreshToken != "secret-refresh-token" {
-		t.Errorf("RefreshToken: got %q, want %q", got.RefreshToken, "secret-refresh-token")
-	}
-}
-
-func TestConcurrentReadWrite(t *testing.T) {
-	t.Parallel()
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	user, err := store.FindOrCreateUser(ctx, "concurrent@example.com")
-	if err != nil {
-		t.Fatalf("FindOrCreateUser: %v", err)
-	}
-
-	now := time.Now().Truncate(time.Second)
-	var wg sync.WaitGroup
-	errs := make([]error, 10)
-
-	for i := range 10 {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			tok := &core.IntegrationToken{
-				ID:          uuid.NewString(),
-				UserID:      user.ID,
-				Integration: "svc",
-				Instance:    uuid.NewString(),
-				AccessToken: "tok",
-				CreatedAt:   now,
-				UpdatedAt:   now,
+			var accessEnc, refreshEnc string
+			err := store.DB.QueryRowContext(ctx,
+				"SELECT access_token_encrypted, refresh_token_encrypted FROM integration_tokens WHERE id = $1",
+				token.ID,
+			).Scan(&accessEnc, &refreshEnc)
+			if err != nil {
+				t.Fatalf("raw query: %v", err)
 			}
-			errs[idx] = store.StoreToken(ctx, tok)
-		}(i)
-	}
-	wg.Wait()
+			if accessEnc == token.AccessToken {
+				t.Error("access token stored in plaintext")
+			}
+			if refreshEnc == token.RefreshToken {
+				t.Error("refresh token stored in plaintext")
+			}
+			if accessEnc == "" {
+				t.Error("access_token_encrypted is empty")
+			}
+		},
+		AssertRejectsOrphanTokenInsert: func(t *testing.T, ctx context.Context, ds core.Datastore) {
+			store := ds.(*Store)
+			now := time.Now().UTC().Truncate(time.Second)
 
-	for i, err := range errs {
-		if err != nil {
-			t.Errorf("concurrent write %d: %v", i, err)
-		}
-	}
-
-	tokens, err := store.ListTokens(ctx, user.ID)
-	if err != nil {
-		t.Fatalf("ListTokens: %v", err)
-	}
-	if len(tokens) != 10 {
-		t.Errorf("expected 10 tokens, got %d", len(tokens))
-	}
-}
-
-func TestForeignKeyEnforcement(t *testing.T) {
-	t.Parallel()
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	now := time.Now().Truncate(time.Second)
-	_, err := store.DB.ExecContext(ctx,
-		"INSERT INTO integration_tokens (id, user_id, integration, instance, access_token_encrypted, created_at, updated_at, last_refreshed_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
-		"fk-tok", "nonexistent-user", "svc", "i1", "enc", now, now, now,
-	)
-	if err == nil {
-		t.Error("expected foreign key violation, got nil error")
-	}
+			_, err := store.DB.ExecContext(ctx,
+				"INSERT INTO integration_tokens (id, user_id, integration, instance, access_token_encrypted, created_at, updated_at, last_refreshed_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+				"fk-tok", "nonexistent-user", "svc", "i1", "enc", now, now, now,
+			)
+			if err == nil {
+				t.Error("expected foreign key violation, got nil error")
+			}
+		},
+	})
 }

--- a/server/internal/drivers/datastore/sqlite/sqlite_test.go
+++ b/server/internal/drivers/datastore/sqlite/sqlite_test.go
@@ -3,11 +3,9 @@ package sqlite
 import (
 	"context"
 	"path/filepath"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/server/core"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 )
@@ -27,65 +25,43 @@ func newTestStore(t *testing.T) *Store {
 
 func TestSQLiteDatastoreConformance(t *testing.T) {
 	t.Parallel()
-	coretesting.RunDatastoreTests(t, func(t *testing.T) core.Datastore {
+	coretesting.RunDatastoreDriverTests(t, func(t *testing.T) core.Datastore {
 		return newTestStore(t)
+	}, coretesting.DatastoreDriverHooks{
+		AssertTokenEncryptedAtRest: func(t *testing.T, ctx context.Context, ds core.Datastore, token *core.IntegrationToken) {
+			store := ds.(*Store)
+
+			var accessEnc, refreshEnc string
+			err := store.DB.QueryRowContext(ctx,
+				"SELECT access_token_encrypted, refresh_token_encrypted FROM integration_tokens WHERE id = ?",
+				token.ID,
+			).Scan(&accessEnc, &refreshEnc)
+			if err != nil {
+				t.Fatalf("raw query: %v", err)
+			}
+			if accessEnc == token.AccessToken {
+				t.Error("access token stored in plaintext")
+			}
+			if refreshEnc == token.RefreshToken {
+				t.Error("refresh token stored in plaintext")
+			}
+			if accessEnc == "" {
+				t.Error("access_token_encrypted is empty")
+			}
+		},
+		AssertRejectsOrphanTokenInsert: func(t *testing.T, ctx context.Context, ds core.Datastore) {
+			store := ds.(*Store)
+			now := time.Now().UTC().Truncate(time.Second)
+
+			_, err := store.DB.ExecContext(ctx,
+				"INSERT INTO integration_tokens (id, user_id, integration, instance, access_token_encrypted, created_at, updated_at, last_refreshed_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+				"fk-tok", "nonexistent-user", "svc", "i1", "enc", now, now, now,
+			)
+			if err == nil {
+				t.Error("expected foreign key violation, got nil error")
+			}
+		},
 	})
-}
-
-func TestEncryptionRoundTrip(t *testing.T) {
-	t.Parallel()
-	store := newTestStore(t)
-	t.Cleanup(func() { _ = store.Close() })
-	ctx := context.Background()
-
-	user, err := store.FindOrCreateUser(ctx, "enc@example.com")
-	if err != nil {
-		t.Fatalf("FindOrCreateUser: %v", err)
-	}
-
-	now := time.Now().Truncate(time.Second)
-	token := &core.IntegrationToken{
-		ID:           "enc-tok-1",
-		UserID:       user.ID,
-		Integration:  "test",
-		Instance:     "i1",
-		AccessToken:  "secret-access-token",
-		RefreshToken: "secret-refresh-token",
-		CreatedAt:    now,
-		UpdatedAt:    now,
-	}
-	if err := store.StoreToken(ctx, token); err != nil {
-		t.Fatalf("StoreToken: %v", err)
-	}
-
-	var accessEnc, refreshEnc string
-	err = store.DB.QueryRowContext(ctx,
-		"SELECT access_token_encrypted, refresh_token_encrypted FROM integration_tokens WHERE id = ?",
-		"enc-tok-1",
-	).Scan(&accessEnc, &refreshEnc)
-	if err != nil {
-		t.Fatalf("raw query: %v", err)
-	}
-	if accessEnc == "secret-access-token" {
-		t.Error("access token stored in plaintext")
-	}
-	if refreshEnc == "secret-refresh-token" {
-		t.Error("refresh token stored in plaintext")
-	}
-	if accessEnc == "" {
-		t.Error("access_token_encrypted is empty")
-	}
-
-	got, err := store.Token(ctx, user.ID, "test", "", "i1")
-	if err != nil {
-		t.Fatalf("Token: %v", err)
-	}
-	if got.AccessToken != "secret-access-token" {
-		t.Errorf("AccessToken: got %q, want %q", got.AccessToken, "secret-access-token")
-	}
-	if got.RefreshToken != "secret-refresh-token" {
-		t.Errorf("RefreshToken: got %q, want %q", got.RefreshToken, "secret-refresh-token")
-	}
 }
 
 func TestWALMode(t *testing.T) {
@@ -100,129 +76,5 @@ func TestWALMode(t *testing.T) {
 	}
 	if mode != "wal" {
 		t.Errorf("journal_mode: got %q, want %q", mode, "wal")
-	}
-}
-
-func TestConcurrentReadWrite(t *testing.T) {
-	t.Parallel()
-	store := newTestStore(t)
-	t.Cleanup(func() { _ = store.Close() })
-	ctx := context.Background()
-
-	user, err := store.FindOrCreateUser(ctx, "concurrent@example.com")
-	if err != nil {
-		t.Fatalf("FindOrCreateUser: %v", err)
-	}
-
-	now := time.Now().Truncate(time.Second)
-	var wg sync.WaitGroup
-	errs := make([]error, 10)
-
-	for i := range 10 {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			tok := &core.IntegrationToken{
-				ID:          uuid.NewString(),
-				UserID:      user.ID,
-				Integration: "svc",
-				Instance:    uuid.NewString(),
-				AccessToken: "tok",
-				CreatedAt:   now,
-				UpdatedAt:   now,
-			}
-			errs[idx] = store.StoreToken(ctx, tok)
-		}(i)
-	}
-	wg.Wait()
-
-	for i, err := range errs {
-		if err != nil {
-			t.Errorf("concurrent write %d: %v", i, err)
-		}
-	}
-
-	tokens, err := store.ListTokens(ctx, user.ID)
-	if err != nil {
-		t.Fatalf("ListTokens: %v", err)
-	}
-	if len(tokens) != 10 {
-		t.Errorf("expected 10 tokens, got %d", len(tokens))
-	}
-}
-
-func TestStoreTokenUpsert(t *testing.T) {
-	t.Parallel()
-	store := newTestStore(t)
-	t.Cleanup(func() { _ = store.Close() })
-	ctx := context.Background()
-
-	user, err := store.FindOrCreateUser(ctx, "upsert@example.com")
-	if err != nil {
-		t.Fatalf("FindOrCreateUser: %v", err)
-	}
-
-	now := time.Now().Truncate(time.Second)
-	token := &core.IntegrationToken{
-		ID:          "upsert-tok",
-		UserID:      user.ID,
-		Integration: "svc",
-		Instance:    "i1",
-		AccessToken: "first",
-		CreatedAt:   now,
-		UpdatedAt:   now,
-	}
-	if err := store.StoreToken(ctx, token); err != nil {
-		t.Fatalf("first StoreToken: %v", err)
-	}
-
-	token.AccessToken = "second"
-	token.UpdatedAt = now.Add(time.Minute)
-	if err := store.StoreToken(ctx, token); err != nil {
-		t.Fatalf("second StoreToken: %v", err)
-	}
-
-	got, err := store.Token(ctx, user.ID, "svc", "", "i1")
-	if err != nil {
-		t.Fatalf("Token: %v", err)
-	}
-	if got.AccessToken != "second" {
-		t.Errorf("AccessToken after upsert: got %q, want %q", got.AccessToken, "second")
-	}
-}
-
-func TestDeleteNonexistentTokenNoError(t *testing.T) {
-	t.Parallel()
-	store := newTestStore(t)
-	t.Cleanup(func() { _ = store.Close() })
-
-	if err := store.DeleteToken(context.Background(), "does-not-exist"); err != nil {
-		t.Fatalf("DeleteToken for nonexistent: %v", err)
-	}
-}
-
-func TestRevokeNonexistentAPITokenReturnsNotFound(t *testing.T) {
-	t.Parallel()
-	store := newTestStore(t)
-	t.Cleanup(func() { _ = store.Close() })
-
-	if err := store.RevokeAPIToken(context.Background(), "no-user", "does-not-exist"); err != core.ErrNotFound {
-		t.Fatalf("RevokeAPIToken for nonexistent: expected ErrNotFound, got %v", err)
-	}
-}
-
-func TestForeignKeyEnforcement(t *testing.T) {
-	t.Parallel()
-	store := newTestStore(t)
-	t.Cleanup(func() { _ = store.Close() })
-	ctx := context.Background()
-
-	now := time.Now().Truncate(time.Second)
-	_, err := store.DB.ExecContext(ctx,
-		"INSERT INTO integration_tokens (id, user_id, integration, instance, access_token_encrypted, created_at, updated_at, last_refreshed_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-		"fk-tok", "nonexistent-user", "svc", "i1", "enc", now, now, now,
-	)
-	if err == nil {
-		t.Error("expected foreign key violation, got nil error")
 	}
 }

--- a/server/internal/pluginhost/validate.go
+++ b/server/internal/pluginhost/validate.go
@@ -1,27 +1,9 @@
 package pluginhost
 
 import (
-	"fmt"
-
-	"github.com/santhosh-tekuri/jsonschema/v6"
-	"gopkg.in/yaml.v3"
+	"github.com/valon-technologies/gestalt/server/internal/configschema"
 )
 
 func validateConfigSchema(config map[string]any, schemaText string) error {
-	var schemaDoc any
-	if err := yaml.Unmarshal([]byte(schemaText), &schemaDoc); err != nil {
-		return fmt.Errorf("invalid config schema: %w", err)
-	}
-	compiler := jsonschema.NewCompiler()
-	if err := compiler.AddResource("config.schema", schemaDoc); err != nil {
-		return fmt.Errorf("invalid config schema: %w", err)
-	}
-	schema, err := compiler.Compile("config.schema")
-	if err != nil {
-		return fmt.Errorf("compile config schema: %w", err)
-	}
-	if err := schema.Validate(config); err != nil {
-		return fmt.Errorf("config validation failed: %w", err)
-	}
-	return nil
+	return configschema.Validate(config, schemaText)
 }

--- a/server/internal/pluginpkg/config.go
+++ b/server/internal/pluginpkg/config.go
@@ -5,9 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/valon-technologies/gestalt/server/internal/configschema"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
-	"gopkg.in/yaml.v3"
 )
 
 func ValidateConfigForManifest(manifestPath string, manifest *pluginmanifestv1.Manifest, kind string, config map[string]any) error {
@@ -23,27 +22,10 @@ func ValidateConfigForManifest(manifestPath string, manifest *pluginmanifestv1.M
 		return fmt.Errorf("read config schema %q: %w", schemaName, err)
 	}
 
-	var schemaDoc any
-	if err := yaml.Unmarshal(data, &schemaDoc); err != nil {
-		return fmt.Errorf("invalid config schema: %w", err)
-	}
-
-	compiler := jsonschema.NewCompiler()
-	if err := compiler.AddResource("config.schema", schemaDoc); err != nil {
-		return fmt.Errorf("invalid config schema: %w", err)
-	}
-	schema, err := compiler.Compile("config.schema")
-	if err != nil {
-		return fmt.Errorf("compile config schema: %w", err)
-	}
-
 	if config == nil {
 		config = map[string]any{}
 	}
-	if err := schema.Validate(config); err != nil {
-		return fmt.Errorf("config validation failed: %w", err)
-	}
-	return nil
+	return configschema.Validate(config, string(data))
 }
 
 func configSchemaForManifest(manifestPath string, manifest *pluginmanifestv1.Manifest, kind string) (path string, name string, ok bool, err error) {


### PR DESCRIPTION
## Summary
- share duplicated datastore driver integration coverage across sqlite, postgres, mysql, and firestore
- keep backend-specific raw-storage checks only where they differ
- share config schema validation between pluginhost and pluginpkg

## Validation
- `go test ./core/testing ./internal/drivers/datastore/sqlite ./internal/drivers/datastore/postgres ./internal/drivers/datastore/mysql ./internal/drivers/datastore/firestore -run 'Test(SQLiteDatastoreConformance|PostgresDatastoreConformance|MySQLDatastoreConformance|FirestoreDatastoreConformance)$'`\n- `go test ./internal/configschema ./internal/pluginhost ./internal/pluginpkg -run '^$'`