### PR TITLE
Separate locked artifacts from config dir

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -44,4 +44,4 @@ LABEL org.opencontainers.image.title="gestaltd" \
 USER nobody:nobody
 EXPOSE 8080
 ENTRYPOINT ["/gestaltd"]
-CMD ["serve", "--locked", "--config", "/etc/gestalt/config.yaml"]
+CMD ["serve", "--locked", "--config", "/etc/gestalt/config.yaml", "--artifacts-dir", "/data"]

--- a/server/cmd/gestaltd/e2e_test.go
+++ b/server/cmd/gestaltd/e2e_test.go
@@ -212,8 +212,18 @@ func TestE2EInitServeLockedGoldenPath(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
+	deployDir := filepath.Join(dir, "deploy")
+	dataDir := filepath.Join(dir, "data")
+	artifactsDir := filepath.Join(dir, "runtime-artifacts")
+	if err := os.MkdirAll(deployDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll deploy dir: %v", err)
+	}
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll data dir: %v", err)
+	}
+
 	pluginDir := setupPluginDir(t, dir)
-	archivePath := filepath.Join(dir, "plugin.tar.gz")
+	archivePath := filepath.Join(deployDir, "plugin.tar.gz")
 
 	out, err := exec.Command(gestaltdBin, "plugin", "package", "--input", pluginDir, "--output", archivePath).CombinedOutput()
 	if err != nil {
@@ -221,7 +231,7 @@ func TestE2EInitServeLockedGoldenPath(t *testing.T) {
 	}
 
 	port := allocateTestPort(t)
-	cfgPath := writeE2EConfig(t, dir, "plugin.tar.gz", port)
+	cfgPath := writeE2EConfigWithPaths(t, deployDir, "plugin.tar.gz", filepath.Join(dataDir, "gestalt.db"), artifactsDir, port)
 	cfgBytes, err := os.ReadFile(cfgPath)
 	if err != nil {
 		t.Fatalf("read config: %v", err)
@@ -236,14 +246,30 @@ func TestE2EInitServeLockedGoldenPath(t *testing.T) {
 		t.Fatalf("write config telemetry: %v", err)
 	}
 
-	out, err = exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	out, err = exec.Command(gestaltdBin, "init", "--config", cfgPath, "--artifacts-dir", artifactsDir).CombinedOutput()
 	if err != nil {
 		t.Fatalf("gestaltd init: %v\n%s", err, out)
 	}
 
+	lockPath := filepath.Join(deployDir, initLockfileName)
+	t.Cleanup(func() {
+		_ = os.Chmod(deployDir, 0o755)
+		_ = os.Chmod(cfgPath, 0o644)
+		_ = os.Chmod(lockPath, 0o644)
+	})
+	if err := os.Chmod(cfgPath, 0o444); err != nil {
+		t.Fatalf("Chmod config: %v", err)
+	}
+	if err := os.Chmod(lockPath, 0o444); err != nil {
+		t.Fatalf("Chmod lockfile: %v", err)
+	}
+	if err := os.Chmod(deployDir, 0o555); err != nil {
+		t.Fatalf("Chmod deploy dir: %v", err)
+	}
+
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	cmd := exec.Command(gestaltdBin, "serve", "--locked", "--config", cfgPath)
+	cmd := exec.Command(gestaltdBin, "serve", "--locked", "--config", cfgPath, "--artifacts-dir", artifactsDir)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Start(); err != nil {
@@ -837,26 +863,35 @@ func fileSHA256(path string) (string, error) {
 
 func writeE2EConfig(t *testing.T, dir, packageRef string, port int) string {
 	t.Helper()
+	return writeE2EConfigWithPaths(t, dir, packageRef, filepath.Join(dir, "gestalt.db"), "", port)
+}
+
+func writeE2EConfigWithPaths(t *testing.T, dir, packageRef, dbPath, artifactsDir string, port int) string {
+	t.Helper()
 
 	if port == 0 {
 		port = 18080
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
+	serverBlock := fmt.Sprintf(`server:
+  port: %d
+  encryption_key: test-e2e-key
+`, port)
+	if artifactsDir != "" {
+		serverBlock += fmt.Sprintf("  artifacts_dir: %s\n", artifactsDir)
+	}
 	cfg := fmt.Sprintf(`auth:
   provider: none
 datastore:
   provider: sqlite
   config:
     path: %s
-server:
-  port: %d
-  encryption_key: test-e2e-key
-providers:
+%sproviders:
   example:
     from:
       package: %s
-`, filepath.Join(dir, "gestalt.db"), port, packageRef)
+`, dbPath, serverBlock, packageRef)
 
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {
 		t.Fatalf("write config: %v", err)

--- a/server/cmd/gestaltd/factories.go
+++ b/server/cmd/gestaltd/factories.go
@@ -47,7 +47,11 @@ type bootstrapEnv struct {
 }
 
 func setupBootstrap(configFlag string, locked bool) (*bootstrapEnv, error) {
-	_, cfg, err := loadConfigForExecution(configFlag, locked)
+	return setupBootstrapWithArtifactsDir(configFlag, "", locked)
+}
+
+func setupBootstrapWithArtifactsDir(configFlag, artifactsDir string, locked bool) (*bootstrapEnv, error) {
+	_, cfg, err := loadConfigForExecutionWithArtifactsDir(configFlag, artifactsDir, locked)
 	if err != nil {
 		return nil, err
 	}

--- a/server/cmd/gestaltd/init.go
+++ b/server/cmd/gestaltd/init.go
@@ -7,9 +7,8 @@ import (
 )
 
 const (
-	initLockfileName     = operator.InitLockfileName
-	preparedProvidersDir = operator.PreparedProvidersDir
-	lockVersion          = operator.LockVersion
+	initLockfileName = operator.InitLockfileName
+	lockVersion      = operator.LockVersion
 )
 
 type initLockfile = operator.Lockfile
@@ -21,18 +20,22 @@ func operatorLifecycle() *operator.Lifecycle {
 }
 
 func initConfig(configFlag string) error {
+	return initConfigWithArtifactsDir(configFlag, "")
+}
+
+func initConfigWithArtifactsDir(configFlag, artifactsDir string) error {
 	configPath := resolveConfigPath(configFlag)
-	_, err := initConfigAtPath(configPath)
+	_, err := operatorLifecycle().InitAtPathWithArtifactsDir(configPath, artifactsDir)
 	return err
 }
 
-func initConfigAtPath(configPath string) (*initLockfile, error) {
-	return operatorLifecycle().InitAtPath(configPath)
+func loadConfigForExecution(configFlag string, locked bool) (string, *config.Config, error) {
+	return loadConfigForExecutionWithArtifactsDir(configFlag, "", locked)
 }
 
-func loadConfigForExecution(configFlag string, locked bool) (string, *config.Config, error) {
+func loadConfigForExecutionWithArtifactsDir(configFlag, artifactsDir string, locked bool) (string, *config.Config, error) {
 	configPath := resolveConfigPath(configFlag)
-	cfg, _, err := operatorLifecycle().LoadForExecutionAtPath(configPath, locked)
+	cfg, _, err := operatorLifecycle().LoadForExecutionAtPathWithArtifactsDir(configPath, artifactsDir, locked)
 	if err != nil {
 		return "", nil, err
 	}

--- a/server/cmd/gestaltd/run.go
+++ b/server/cmd/gestaltd/run.go
@@ -60,6 +60,7 @@ func runServe(args []string) error {
 	fs := flag.NewFlagSet("gestaltd serve", flag.ContinueOnError)
 	fs.Usage = func() { printServeUsage(fs.Output()) }
 	configPath := fs.String("config", "", "path to config file")
+	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
 	locked := fs.Bool("locked", false, "require exact lock state; do not auto-init")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -68,7 +69,7 @@ func runServe(args []string) error {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
 	}
 
-	env, err := setupBootstrap(*configPath, *locked)
+	env, err := setupBootstrapWithArtifactsDir(*configPath, *artifactsDir, *locked)
 	if err != nil {
 		return err
 	}
@@ -79,6 +80,7 @@ func runStartCommand(name string, usage func(io.Writer), args []string, locked b
 	fs := flag.NewFlagSet(name, flag.ContinueOnError)
 	fs.Usage = func() { usage(fs.Output()) }
 	configPath := fs.String("config", "", "path to config file")
+	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -98,7 +100,7 @@ func runStartCommand(name string, usage func(io.Writer), args []string, locked b
 		}
 	}
 
-	env, err := setupBootstrap(*configPath, locked)
+	env, err := setupBootstrapWithArtifactsDir(*configPath, *artifactsDir, locked)
 	if err != nil {
 		return err
 	}
@@ -291,6 +293,7 @@ func runInit(args []string) error {
 	fs := flag.NewFlagSet("gestaltd init", flag.ContinueOnError)
 	fs.Usage = func() { printInitUsage(fs.Output()) }
 	configPath := fs.String("config", "", "path to config file")
+	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -298,13 +301,14 @@ func runInit(args []string) error {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
 	}
 
-	return initConfig(*configPath)
+	return initConfigWithArtifactsDir(*configPath, *artifactsDir)
 }
 
 func runValidate(args []string) error {
 	fs := flag.NewFlagSet("gestaltd validate", flag.ContinueOnError)
 	fs.Usage = func() { printValidateUsage(fs.Output()) }
 	configPath := fs.String("config", "", "path to config file")
+	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
 	initFirst := fs.Bool("init", false, "run init before validating")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -314,16 +318,20 @@ func runValidate(args []string) error {
 	}
 
 	if *initFirst {
-		if err := initConfig(*configPath); err != nil {
+		if err := initConfigWithArtifactsDir(*configPath, *artifactsDir); err != nil {
 			return err
 		}
 	}
 
-	return validateConfig(*configPath)
+	return validateConfigWithArtifactsDir(*configPath, *artifactsDir)
 }
 
 func validateConfig(configFlag string) error {
-	path, cfg, err := loadConfigForExecution(configFlag, true)
+	return validateConfigWithArtifactsDir(configFlag, "")
+}
+
+func validateConfigWithArtifactsDir(configFlag, artifactsDir string) error {
+	path, cfg, err := loadConfigForExecutionWithArtifactsDir(configFlag, artifactsDir, true)
 	if err != nil {
 		return err
 	}
@@ -383,11 +391,11 @@ func maskEmpty(s string) string {
 
 func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd [--config PATH]")
-	writeUsageLine(w, "  gestaltd init [--config PATH]")
-	writeUsageLine(w, "  gestaltd serve [--config PATH] [--locked]")
+	writeUsageLine(w, "  gestaltd [--config PATH] [--artifacts-dir PATH]")
+	writeUsageLine(w, "  gestaltd init [--config PATH] [--artifacts-dir PATH]")
+	writeUsageLine(w, "  gestaltd serve [--config PATH] [--artifacts-dir PATH] [--locked]")
 	writeUsageLine(w, "  gestaltd plugin <command> [flags]")
-	writeUsageLine(w, "  gestaltd validate [--config PATH] [--init]")
+	writeUsageLine(w, "  gestaltd validate [--config PATH] [--artifacts-dir PATH] [--init]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
 	writeUsageLine(w, "  init        Resolve providers and plugins and write lock state")
@@ -397,33 +405,36 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "  version     Print the version and exit")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
-	writeUsageLine(w, "  --config    Path to the config file")
+	writeUsageLine(w, "  --config          Path to the config file")
+	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory")
 }
 
 func printServeUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd serve [--config PATH] [--locked]")
+	writeUsageLine(w, "  gestaltd serve [--config PATH] [--artifacts-dir PATH] [--locked]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Start the server. Auto-inits if lock state is missing or stale.")
 	writeUsageLine(w, "Use --locked for production deployments to prevent automatic mutation")
-	writeUsageLine(w, "at startup. When locked, run `gestaltd init` first to prepare state.")
+	writeUsageLine(w, "at startup. When locked, run `gestaltd init` first to prepare artifacts.")
 }
 
 func printInitUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd init [--config PATH]")
+	writeUsageLine(w, "  gestaltd init [--config PATH] [--artifacts-dir PATH]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Resolve remote providers and packaged plugins and write lock state.")
-	writeUsageLine(w, "Creates gestalt.lock.json and .gestaltd/ in the config directory.")
+	writeUsageLine(w, "Creates gestalt.lock.json in the config directory and prepared artifacts")
+	writeUsageLine(w, "in the artifacts directory.")
 	writeUsageLine(w, "Use this before `gestaltd serve --locked` for production deployments.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
-	writeUsageLine(w, "  --config    Path to the config file")
+	writeUsageLine(w, "  --config          Path to the config file")
+	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory")
 }
 
 func printValidateUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd validate [--config PATH] [--init]")
+	writeUsageLine(w, "  gestaltd validate [--config PATH] [--artifacts-dir PATH] [--init]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Validate configuration without starting the server or running migrations.")
 	writeUsageLine(w, "Non-mutating by default; requires existing lock state. Use --init to")

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -229,6 +229,7 @@ type ServerConfig struct {
 	BaseURL       string `yaml:"base_url"`
 	EncryptionKey string `yaml:"encryption_key"`
 	APITokenTTL   string `yaml:"api_token_ttl"`
+	ArtifactsDir  string `yaml:"artifacts_dir"`
 }
 
 type IntegrationDef struct {

--- a/server/internal/operator/lifecycle.go
+++ b/server/internal/operator/lifecycle.go
@@ -25,8 +25,7 @@ const (
 	InitLockfileName     = "gestalt.lock.json"
 	PreparedProvidersDir = ".gestaltd/providers"
 	PluginsDir           = ".gestaltd/plugins"
-	LockVersion          = 4
-	LockVersionCompat    = 3
+	LockVersion          = 1
 )
 
 type Lockfile struct {
@@ -62,6 +61,10 @@ func NewLifecycle(sourceResolver pluginsource.Resolver) *Lifecycle {
 }
 
 func (l *Lifecycle) InitAtPath(configPath string) (*Lockfile, error) {
+	return l.InitAtPathWithArtifactsDir(configPath, "")
+}
+
+func (l *Lifecycle) InitAtPathWithArtifactsDir(configPath, artifactsDir string) (*Lockfile, error) {
 	cfg, err := config.Load(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("loading config: %v", err)
@@ -70,7 +73,7 @@ func (l *Lifecycle) InitAtPath(configPath string) (*Lockfile, error) {
 		return nil, fmt.Errorf("loading config: %v", err)
 	}
 
-	paths := initPathsForConfig(configPath)
+	paths := initPathsForConfigWithArtifactsDir(configPath, resolveArtifactsDir(configPath, cfg, artifactsDir))
 	if err := os.MkdirAll(paths.providersDir, 0o755); err != nil {
 		return nil, fmt.Errorf("creating providers dir: %w", err)
 	}
@@ -92,7 +95,7 @@ func (l *Lifecycle) InitAtPath(configPath string) (*Lockfile, error) {
 	if err := WriteLockfile(paths.lockfilePath, lock); err != nil {
 		return nil, err
 	}
-	if err := l.applyLockedPlugins(configPath, cfg, true); err != nil {
+	if err := l.applyLockedPlugins(configPath, artifactsDir, cfg, true); err != nil {
 		return nil, err
 	}
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
@@ -105,6 +108,10 @@ func (l *Lifecycle) InitAtPath(configPath string) (*Lockfile, error) {
 }
 
 func (l *Lifecycle) LoadForExecutionAtPath(configPath string, locked bool) (*config.Config, map[string]string, error) {
+	return l.LoadForExecutionAtPathWithArtifactsDir(configPath, "", locked)
+}
+
+func (l *Lifecycle) LoadForExecutionAtPathWithArtifactsDir(configPath, artifactsDir string, locked bool) (*config.Config, map[string]string, error) {
 	cfg, err := config.Load(configPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading config: %v", err)
@@ -113,7 +120,7 @@ func (l *Lifecycle) LoadForExecutionAtPath(configPath string, locked bool) (*con
 		return nil, nil, err
 	}
 
-	if err := l.applyLockedPlugins(configPath, cfg, locked); err != nil {
+	if err := l.applyLockedPlugins(configPath, artifactsDir, cfg, locked); err != nil {
 		return nil, nil, err
 	}
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
@@ -126,6 +133,7 @@ func (l *Lifecycle) LoadForExecutionAtPath(configPath string, locked bool) (*con
 type initPaths struct {
 	configPath   string
 	configDir    string
+	artifactsDir string
 	lockfilePath string
 	providersDir string
 	pluginsDir   string
@@ -154,14 +162,38 @@ func resolveLockPath(baseDir, provider string) string {
 	return filepath.Join(baseDir, filepath.FromSlash(provider))
 }
 
+func resolveArtifactsDir(configPath string, cfg *config.Config, override string) string {
+	dir := override
+	if dir == "" && cfg != nil {
+		dir = cfg.Server.ArtifactsDir
+	}
+	if dir == "" {
+		return filepath.Dir(configPath)
+	}
+	if filepath.IsAbs(dir) {
+		return dir
+	}
+	return filepath.Join(filepath.Dir(configPath), dir)
+}
+
 func initPathsForConfig(configPath string) initPaths {
+	return initPathsForConfigWithArtifactsDir(configPath, "")
+}
+
+func initPathsForConfigWithArtifactsDir(configPath, artifactsDir string) initPaths {
 	configDir := filepath.Dir(configPath)
+	if artifactsDir == "" {
+		artifactsDir = configDir
+	} else if !filepath.IsAbs(artifactsDir) {
+		artifactsDir = filepath.Join(configDir, artifactsDir)
+	}
 	return initPaths{
 		configPath:   configPath,
 		configDir:    configDir,
+		artifactsDir: artifactsDir,
 		lockfilePath: filepath.Join(configDir, InitLockfileName),
-		providersDir: filepath.Join(configDir, filepath.FromSlash(PreparedProvidersDir)),
-		pluginsDir:   filepath.Join(configDir, filepath.FromSlash(PluginsDir)),
+		providersDir: filepath.Join(artifactsDir, filepath.FromSlash(PreparedProvidersDir)),
+		pluginsDir:   filepath.Join(artifactsDir, filepath.FromSlash(PluginsDir)),
 	}
 }
 
@@ -187,7 +219,7 @@ func ReadLockfile(path string) (*Lockfile, error) {
 	if err := json.Unmarshal(data, &lock); err != nil {
 		return nil, fmt.Errorf("parsing lockfile %s: %w", path, err)
 	}
-	if lock.Version != LockVersion && lock.Version != LockVersionCompat {
+	if lock.Version != LockVersion {
 		return nil, fmt.Errorf("unsupported lockfile version %d", lock.Version)
 	}
 	if lock.Providers == nil {
@@ -207,7 +239,7 @@ func WriteLockfile(path string, lock *Lockfile) error {
 }
 
 func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool {
-	if lock == nil || (lock.Version != LockVersion && lock.Version != LockVersionCompat) {
+	if lock == nil || lock.Version != LockVersion {
 		return false
 	}
 	for name := range cfg.Integrations {
@@ -230,11 +262,11 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 		if err != nil || entry.Fingerprint != fingerprint {
 			return false
 		}
-		manifestPath := resolveLockPath(paths.configDir, entry.Manifest)
+		manifestPath := resolveLockPath(paths.artifactsDir, entry.Manifest)
 		if _, err := os.Stat(manifestPath); err != nil {
 			return false
 		}
-		assetRootPath := resolveLockPath(paths.configDir, entry.AssetRoot)
+		assetRootPath := resolveLockPath(paths.artifactsDir, entry.AssetRoot)
 		if _, err := os.Stat(assetRootPath); err != nil {
 			return false
 		}
@@ -315,12 +347,12 @@ func pluginEntryMatches(paths initPaths, name string, plugin *config.PluginDef, 
 	} else if entry.Package != relativePackagePath(paths.configDir, plugin.Package) {
 		return false
 	}
-	manifestPath := resolveLockPath(paths.configDir, entry.Manifest)
+	manifestPath := resolveLockPath(paths.artifactsDir, entry.Manifest)
 	if _, err := os.Stat(manifestPath); err != nil {
 		return false
 	}
 	if entry.Executable != "" {
-		executablePath := resolveLockPath(paths.configDir, entry.Executable)
+		executablePath := resolveLockPath(paths.artifactsDir, entry.Executable)
 		if _, err := os.Stat(executablePath); err != nil {
 			return false
 		}
@@ -429,13 +461,13 @@ func lockEntryForPackage(ctx context.Context, paths initPaths, kind, name string
 	if err != nil {
 		return LockPluginEntry{}, fmt.Errorf("fingerprinting %s %q plugin: %w", kind, name, err)
 	}
-	manifestPath, err := filepath.Rel(paths.configDir, installed.ManifestPath)
+	manifestPath, err := filepath.Rel(paths.artifactsDir, installed.ManifestPath)
 	if err != nil {
 		return LockPluginEntry{}, fmt.Errorf("compute manifest path for %s %q: %w", kind, name, err)
 	}
 	var executableRel string
 	if installed.ExecutablePath != "" {
-		executablePath, err := filepath.Rel(paths.configDir, installed.ExecutablePath)
+		executablePath, err := filepath.Rel(paths.artifactsDir, installed.ExecutablePath)
 		if err != nil {
 			return LockPluginEntry{}, fmt.Errorf("compute executable path for %s %q: %w", kind, name, err)
 		}
@@ -484,13 +516,13 @@ func (l *Lifecycle) lockEntryForSource(ctx context.Context, paths initPaths, kin
 	if err != nil {
 		return LockPluginEntry{}, fmt.Errorf("fingerprinting %s %q plugin: %w", kind, name, err)
 	}
-	manifestPath, err := filepath.Rel(paths.configDir, installed.ManifestPath)
+	manifestPath, err := filepath.Rel(paths.artifactsDir, installed.ManifestPath)
 	if err != nil {
 		return LockPluginEntry{}, fmt.Errorf("compute manifest path for %s %q: %w", kind, name, err)
 	}
 	var executableRel string
 	if installed.ExecutablePath != "" {
-		ep, err := filepath.Rel(paths.configDir, installed.ExecutablePath)
+		ep, err := filepath.Rel(paths.artifactsDir, installed.ExecutablePath)
 		if err != nil {
 			return LockPluginEntry{}, fmt.Errorf("compute executable path for %s %q: %w", kind, name, err)
 		}
@@ -541,11 +573,11 @@ func (l *Lifecycle) writeUIPluginArtifact(ctx context.Context, cfg *config.Confi
 		if installed.Manifest.Version != plugin.Version {
 			return LockPluginEntry{}, fmt.Errorf("ui plugin manifest version %q does not match config version %q", installed.Manifest.Version, plugin.Version)
 		}
-		manifestPath, err := filepath.Rel(paths.configDir, installed.ManifestPath)
+		manifestPath, err := filepath.Rel(paths.artifactsDir, installed.ManifestPath)
 		if err != nil {
 			return LockPluginEntry{}, fmt.Errorf("compute manifest path for ui plugin: %w", err)
 		}
-		assetRoot, err := filepath.Rel(paths.configDir, installed.AssetRoot)
+		assetRoot, err := filepath.Rel(paths.artifactsDir, installed.AssetRoot)
 		if err != nil {
 			return LockPluginEntry{}, fmt.Errorf("compute asset root path for ui plugin: %w", err)
 		}
@@ -588,11 +620,11 @@ func (l *Lifecycle) writeUIPluginArtifact(ctx context.Context, cfg *config.Confi
 				return LockPluginEntry{}, fmt.Errorf("ui plugin source digest: %w", err)
 			}
 		}
-		manifestPath, err := filepath.Rel(paths.configDir, installed.ManifestPath)
+		manifestPath, err := filepath.Rel(paths.artifactsDir, installed.ManifestPath)
 		if err != nil {
 			return LockPluginEntry{}, fmt.Errorf("compute manifest path for ui plugin: %w", err)
 		}
-		assetRoot, err := filepath.Rel(paths.configDir, installed.AssetRoot)
+		assetRoot, err := filepath.Rel(paths.artifactsDir, installed.AssetRoot)
 		if err != nil {
 			return LockPluginEntry{}, fmt.Errorf("compute asset root path for ui plugin: %w", err)
 		}
@@ -608,15 +640,15 @@ func (l *Lifecycle) writeUIPluginArtifact(ctx context.Context, cfg *config.Confi
 	return LockPluginEntry{}, fmt.Errorf("ui plugin requires package or source")
 }
 
-func (l *Lifecycle) applyLockedPlugins(configPath string, cfg *config.Config, locked bool) error {
+func (l *Lifecycle) applyLockedPlugins(configPath, artifactsDir string, cfg *config.Config, locked bool) error {
 	if !configHasPlugins(cfg) {
 		return nil
 	}
 
-	paths := initPathsForConfig(configPath)
+	paths := initPathsForConfigWithArtifactsDir(configPath, resolveArtifactsDir(configPath, cfg, artifactsDir))
 	lock, err := ReadLockfile(paths.lockfilePath)
 	if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock)) {
-		lock, err = l.InitAtPath(configPath)
+		lock, err = l.InitAtPathWithArtifactsDir(configPath, artifactsDir)
 	}
 	if err != nil {
 		return fmt.Errorf("plugin packages require prepared artifacts; run `gestaltd init --config %s`: %w", configPath, err)
@@ -651,8 +683,8 @@ func (l *Lifecycle) applyLockedPlugins(configPath string, cfg *config.Config, lo
 		if err != nil || entry.Fingerprint != fingerprint {
 			return fmt.Errorf("prepared artifact for ui plugin is missing or stale; run `gestaltd init --config %s`", paths.configPath)
 		}
-		manifestPath := resolveLockPath(paths.configDir, entry.Manifest)
-		assetRootPath := resolveLockPath(paths.configDir, entry.AssetRoot)
+		manifestPath := resolveLockPath(paths.artifactsDir, entry.Manifest)
+		assetRootPath := resolveLockPath(paths.artifactsDir, entry.AssetRoot)
 		if _, err := os.Stat(manifestPath); err != nil {
 			return fmt.Errorf("prepared manifest for ui plugin not found at %s", manifestPath)
 		}
@@ -683,8 +715,8 @@ func (l *Lifecycle) applyLockedPluginEntry(paths initPaths, lock *Lockfile, kind
 		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", kind, name, paths.configPath)
 	}
 
-	manifestPath := resolveLockPath(paths.configDir, entry.Manifest)
-	executablePath := resolveLockPath(paths.configDir, entry.Executable)
+	manifestPath := resolveLockPath(paths.artifactsDir, entry.Manifest)
+	executablePath := resolveLockPath(paths.artifactsDir, entry.Executable)
 	needMaterialize := false
 	if entry.Source != "" {
 		if _, err := os.Stat(manifestPath); err != nil {

--- a/server/internal/operator/lifecycle_source_test.go
+++ b/server/internal/operator/lifecycle_source_test.go
@@ -101,16 +101,20 @@ func buildV2Archive(t *testing.T, dir, source, version, binaryContent string) st
 	return archivePath
 }
 
-func writeConfigYAML(t *testing.T, dir, source, version string) string {
+func writeConfigYAML(t *testing.T, dir, source, version, artifactsDir string) string {
 	t.Helper()
 
-	yaml := strings.Join([]string{
+	lines := []string{
+		"server:",
+		"  artifacts_dir: " + artifactsDir,
 		"providers:",
 		"  alpha:",
 		"    from:",
 		"      source: " + source,
 		"      version: " + version,
-	}, "\n") + "\n"
+	}
+
+	yaml := strings.Join(lines, "\n") + "\n"
 
 	configPath := filepath.Join(dir, "gestalt.yaml")
 	if err := os.WriteFile(configPath, []byte(yaml), 0644); err != nil {
@@ -142,7 +146,8 @@ func TestSourcePluginEndToEnd(t *testing.T) {
 		sha256:      archiveSHA,
 	}
 
-	configPath := writeConfigYAML(t, dir, source, version)
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configPath := writeConfigYAML(t, dir, source, version, artifactsDir)
 
 	lc := NewLifecycle(resolver)
 	lock, err := lc.InitAtPath(configPath)
@@ -181,8 +186,8 @@ func TestSourcePluginEndToEnd(t *testing.T) {
 	}
 
 	configDir := filepath.Dir(configPath)
-	manifestPath := resolveLockPath(configDir, entry.Manifest)
-	executablePath := resolveLockPath(configDir, entry.Executable)
+	manifestPath := resolveLockPath(artifactsDir, entry.Manifest)
+	executablePath := resolveLockPath(artifactsDir, entry.Executable)
 	if _, err := os.Stat(manifestPath); err != nil {
 		t.Errorf("manifest not found at %s: %v", manifestPath, err)
 	}
@@ -222,81 +227,6 @@ func TestSourcePluginEndToEnd(t *testing.T) {
 	}
 }
 
-func TestReadLockfileV3Compat(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	v3Lock := Lockfile{
-		Version:   LockVersionCompat,
-		Providers: map[string]LockProviderEntry{},
-		Plugins: map[string]LockPluginEntry{
-			"integration:beta": {
-				Fingerprint: "abc123",
-				Package:     "/tmp/beta.tar.gz",
-				Manifest:    ".gestalt/plugins/integration_beta/plugin.json",
-				Executable:  ".gestalt/plugins/integration_beta/artifacts/darwin/arm64/provider",
-			},
-		},
-	}
-
-	lockPath := filepath.Join(dir, InitLockfileName)
-	data, err := json.MarshalIndent(v3Lock, "", "  ")
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	if err := os.WriteFile(lockPath, append(data, '\n'), 0644); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-
-	lock, err := ReadLockfile(lockPath)
-	if err != nil {
-		t.Fatalf("ReadLockfile v3: %v", err)
-	}
-	if lock.Version != LockVersionCompat {
-		t.Errorf("version = %d, want %d", lock.Version, LockVersionCompat)
-	}
-
-	entry := lock.Plugins["integration:beta"]
-	if entry.Fingerprint != "abc123" {
-		t.Errorf("fingerprint = %q, want %q", entry.Fingerprint, "abc123")
-	}
-	if entry.Package != "/tmp/beta.tar.gz" {
-		t.Errorf("package = %q, want %q", entry.Package, "/tmp/beta.tar.gz")
-	}
-
-	if entry.Source != "" {
-		t.Errorf("v3 source should be empty, got %q", entry.Source)
-	}
-	if entry.Version != "" {
-		t.Errorf("v3 version should be empty, got %q", entry.Version)
-	}
-	if entry.ResolvedURL != "" {
-		t.Errorf("v3 resolved_url should be empty, got %q", entry.ResolvedURL)
-	}
-	if entry.ArchiveSHA256 != "" {
-		t.Errorf("v3 archive_sha256 should be empty, got %q", entry.ArchiveSHA256)
-	}
-}
-
-func TestReadLockfileRejectsV2(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	lockPath := filepath.Join(dir, InitLockfileName)
-	data := []byte(`{"version": 2, "providers": {}, "plugins": {}}`)
-	if err := os.WriteFile(lockPath, data, 0644); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-
-	_, err := ReadLockfile(lockPath)
-	if err == nil {
-		t.Fatal("expected error for version 2 lockfile")
-	}
-	if !strings.Contains(err.Error(), "unsupported lockfile version") {
-		t.Errorf("error = %q, want to contain 'unsupported lockfile version'", err.Error())
-	}
-}
-
 func TestSourcePluginNilResolver(t *testing.T) {
 	t.Parallel()
 
@@ -304,7 +234,7 @@ func TestSourcePluginNilResolver(t *testing.T) {
 	source := "github.com/acme/tools/widget"
 	version := "1.0.0"
 
-	configPath := writeConfigYAML(t, dir, source, version)
+	configPath := writeConfigYAML(t, dir, source, version, filepath.Join(dir, "prepared-artifacts"))
 
 	lc := NewLifecycle(nil)
 	_, err := lc.InitAtPath(configPath)
@@ -346,6 +276,7 @@ func TestSourcePluginLoadForExecution(t *testing.T) {
 		sha256:      archiveSHA,
 	}
 
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	yaml := strings.Join([]string{
 		"auth:",
 		"  provider: noop",
@@ -354,6 +285,7 @@ func TestSourcePluginLoadForExecution(t *testing.T) {
 		"  config:",
 		"    path: " + filepath.Join(dir, "data.db"),
 		"server:",
+		"  artifacts_dir: " + artifactsDir,
 		"  encryption_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		"providers:",
 		"  gadget:",
@@ -387,7 +319,7 @@ func TestSourcePluginLoadForExecution(t *testing.T) {
 		t.Fatalf("ReadLockfile: %v", err)
 	}
 	entry := lock.Plugins[LockPluginKey("integration", "gadget")]
-	pluginRoot := filepath.Join(filepath.Dir(configPath), ".gestaltd", "plugins", "integration_gadget")
+	pluginRoot := filepath.Join(artifactsDir, ".gestaltd", "plugins", "integration_gadget")
 	if err := os.RemoveAll(pluginRoot); err != nil {
 		t.Fatalf("RemoveAll plugin root: %v", err)
 	}
@@ -405,8 +337,8 @@ func TestSourcePluginLoadForExecution(t *testing.T) {
 		t.Fatalf("download count during locked rehydration = %d, want 1", got)
 	}
 
-	manifestPath := resolveLockPath(filepath.Dir(configPath), entry.Manifest)
-	executablePath := resolveLockPath(filepath.Dir(configPath), entry.Executable)
+	manifestPath := resolveLockPath(artifactsDir, entry.Manifest)
+	executablePath := resolveLockPath(artifactsDir, entry.Executable)
 	if _, err := os.Stat(manifestPath); err != nil {
 		t.Fatalf("manifest not rehydrated at %s: %v", manifestPath, err)
 	}
@@ -491,6 +423,7 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configYAML := strings.Join([]string{
 		"auth:",
 		"  provider: noop",
@@ -499,6 +432,7 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 		"  config:",
 		"    path: " + filepath.Join(dir, "data.db"),
 		"server:",
+		"  artifacts_dir: " + artifactsDir,
 		"  encryption_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		"providers:",
 		"  alpha:",
@@ -567,14 +501,14 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 	}
 
 	wantDirName := "integration_alpha"
-	executablePath := resolveLockPath(configDir, entry.Executable)
+	executablePath := resolveLockPath(artifactsDir, entry.Executable)
 	if !strings.Contains(executablePath, wantDirName) {
 		t.Errorf("executable path %q does not contain expected dir %q", executablePath, wantDirName)
 	}
 	if _, err := os.Stat(executablePath); err != nil {
 		t.Errorf("executable not found at %s: %v", executablePath, err)
 	}
-	manifestPath := resolveLockPath(configDir, entry.Manifest)
+	manifestPath := resolveLockPath(artifactsDir, entry.Manifest)
 	if _, err := os.Stat(manifestPath); err != nil {
 		t.Errorf("manifest not found at %s: %v", manifestPath, err)
 	}
@@ -587,7 +521,7 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 		t.Errorf("executable content = %q, want %q", execData, testBinary)
 	}
 
-	pluginRoot := filepath.Join(configDir, ".gestaltd", "plugins", "integration_alpha")
+	pluginRoot := filepath.Join(artifactsDir, ".gestaltd", "plugins", "integration_alpha")
 	if err := os.RemoveAll(pluginRoot); err != nil {
 		t.Fatalf("RemoveAll plugin root: %v", err)
 	}


### PR DESCRIPTION
## Summary
- separate writable prepared artifacts from the config directory for locked startup
- keep `gestalt.lock.json` beside config while storing prepared plugins/providers under a configurable artifacts directory
- augment the existing locked startup e2e to prove a read-only deploy directory works with a separate writable artifacts directory

## What changed
- add `server.artifacts_dir` and `--artifacts-dir`
- reset lockfile schema to `version: 1` and make lock paths relative to the artifacts root
- default the container runtime to `--artifacts-dir /data/gestaltd-artifacts`

## Validation
- `TMPDIR=/Users/hugh/src/tmp-go go test ./internal/operator -run 'TestSourcePluginEndToEnd|TestSourcePluginLoadForExecution|TestSourcePluginGitHubResolverEndToEnd' -count=1`
- `TMPDIR=/Users/hugh/src/tmp-go go test ./cmd/gestaltd -run 'TestE2EInitServeLockedGoldenPath|TestE2EInitArchiveAndValidate|TestE2EInitDirectoryPackage|TestE2EBareGestaltdAutoInit|TestE2EBareGestaltdUsesDotGestaltdHomeConfig' -count=1`