### PR TITLE
[codex] Fix docs deploy Terraform project inputs

### DIFF
--- a/.github/workflows/deploy-gestalt-docs.yml
+++ b/.github/workflows/deploy-gestalt-docs.yml
@@ -65,6 +65,10 @@ jobs:
 
       - name: Terraform Apply
         working-directory: docs/terraform
+        env:
+          TF_VAR_project_id: ${{ env.PROJECT_ID }}
+          TF_VAR_project_number: ${{ secrets.GCP_PROJECT_NUMBER }}
+          TF_VAR_region: ${{ env.REGION }}
         run: |
           terraform apply -auto-approve \
             -var='docs_image=${{ env.IMAGE }}:${{ github.sha }}'

--- a/docs/terraform/main.tf
+++ b/docs/terraform/main.tf
@@ -127,10 +127,8 @@ resource "google_dns_record_set" "docs" {
 
 # ---------- Workload Identity Federation ----------
 
-data "google_project" "current" {}
-
 resource "google_service_account_iam_member" "github_actions_wif" {
   service_account_id = "projects/${var.project_id}/serviceAccounts/github-actions@${var.project_id}.iam.gserviceaccount.com"
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/${var.wif_pool_id}/attribute.repository/${var.github_repository}"
+  member             = "principalSet://iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/${var.wif_pool_id}/attribute.repository/${var.github_repository}"
 }

--- a/docs/terraform/variables.tf
+++ b/docs/terraform/variables.tf
@@ -4,6 +4,11 @@ variable "project_id" {
   default     = "REDACTED_GCP_PROJECT"
 }
 
+variable "project_number" {
+  description = "GCP project number hosting the Cloud Run service"
+  type        = string
+}
+
 variable "region" {
   description = "GCP region for Cloud Run"
   type        = string


### PR DESCRIPTION
## Summary
- pass the real GCP project inputs into the docs Terraform apply step
- stop deriving the workload identity project number from a Terraform data source that was resolving to the placeholder project ID
- keep the fix scoped to the docs deploy workflow and docs Terraform

## Validation
- `terraform -chdir=docs/terraform init -backend=false`
- `terraform -chdir=docs/terraform validate`

## Why
`docs.valon.tools` was still serving the old bundle because the `Deploy Gestalt Docs` workflow failed on merge. The docs image built successfully, but Terraform apply failed while reading project `REDACTED_GCP_PROJECT`, so Cloud Run never updated.