### PR TITLE
[codex] Fix Helm chart smoke profile and ingress rendering

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -232,8 +232,28 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: server/go.mod
+          cache-dependency-path: server/go.sum
+
       - name: Helm lint
         run: helm lint gestaltd/deploy/helm/gestalt
+
+      - name: Helm template (default smoke profile)
+        run: |
+          helm template test-release server/deploy/helm/gestalt \
+            > /tmp/rendered-default.yaml
+
+      - name: Helm template (ingress)
+        run: |
+          helm template test-release server/deploy/helm/gestalt \
+            --set ingress.enabled=true \
+            --set-string ingress.hosts[0].host=gestalt.example.com \
+            --set-string ingress.hosts[0].paths[0].path=/gestalt \
+            --set-string ingress.hosts[0].paths[0].pathType=Prefix \
+            > /tmp/rendered-ingress.yaml
 
       - name: Helm template
         run: |
@@ -263,6 +283,15 @@ jobs:
 
       - name: Validate Kubernetes schemas
         run: kubeconform -strict -summary /tmp/rendered.yaml
+
+      - name: Validate Kubernetes schemas (default smoke profile)
+        run: kubeconform -strict -summary /tmp/rendered-default.yaml
+
+      - name: Validate Kubernetes schemas (ingress)
+        run: kubeconform -strict -summary /tmp/rendered-ingress.yaml
+
+      - name: Run Helm e2e smoke test
+        run: cd server && go test ./cmd/gestaltd -run TestE2EHelmChart -count=1
 
       - name: Helm template (plugin-init)
         run: |

--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -54,6 +54,9 @@ jobs:
           go-version-file: gestaltd/go.mod
           cache-dependency-path: gestaltd/go.sum
 
+      - name: Set up Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+
       - name: Run tests
         run: go test ./...
 
@@ -232,12 +235,6 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
-      - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
-        with:
-          go-version-file: server/go.mod
-          cache-dependency-path: server/go.sum
-
       - name: Helm lint
         run: helm lint gestaltd/deploy/helm/gestalt
 
@@ -289,9 +286,6 @@ jobs:
 
       - name: Validate Kubernetes schemas (ingress)
         run: kubeconform -strict -summary /tmp/rendered-ingress.yaml
-
-      - name: Run Helm e2e validation
-        run: cd server && go test ./cmd/gestaltd -run TestE2EHelmChart -count=1
 
       - name: Helm template (plugin-init)
         run: |

--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -240,12 +240,12 @@ jobs:
 
       - name: Helm template (default chart profile)
         run: |
-          helm template test-release server/deploy/helm/gestalt \
+          helm template test-release gestaltd/deploy/helm/gestalt \
             > /tmp/rendered-default.yaml
 
       - name: Helm template (ingress)
         run: |
-          helm template test-release server/deploy/helm/gestalt \
+          helm template test-release gestaltd/deploy/helm/gestalt \
             --set ingress.enabled=true \
             --set-string ingress.hosts[0].host=gestalt.example.com \
             --set-string ingress.hosts[0].paths[0].path=/gestalt \

--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -241,7 +241,7 @@ jobs:
       - name: Helm lint
         run: helm lint gestaltd/deploy/helm/gestalt
 
-      - name: Helm template (default smoke profile)
+      - name: Helm template (default chart profile)
         run: |
           helm template test-release server/deploy/helm/gestalt \
             > /tmp/rendered-default.yaml
@@ -284,13 +284,13 @@ jobs:
       - name: Validate Kubernetes schemas
         run: kubeconform -strict -summary /tmp/rendered.yaml
 
-      - name: Validate Kubernetes schemas (default smoke profile)
+      - name: Validate Kubernetes schemas (default chart profile)
         run: kubeconform -strict -summary /tmp/rendered-default.yaml
 
       - name: Validate Kubernetes schemas (ingress)
         run: kubeconform -strict -summary /tmp/rendered-ingress.yaml
 
-      - name: Run Helm e2e smoke test
+      - name: Run Helm e2e validation
         run: cd server && go test ./cmd/gestaltd -run TestE2EHelmChart -count=1
 
       - name: Helm template (plugin-init)

--- a/docs/pages/deploy/helm.mdx
+++ b/docs/pages/deploy/helm.mdx
@@ -15,6 +15,66 @@ helm upgrade --install gestalt \
 Provide a `values.yaml` file that sets the required auth, datastore, and server
 settings along with the matching `extraEnv` entries.
 
+The default chart profile is intentionally minimal:
+
+- `auth.provider: none`
+- SQLite on a PVC mounted at `/data`
+- a static dev-only `server.encryption_key`
+- one replica
+- no ingress
+
+That profile is suitable for smoke tests, local development, and trusted
+internal clusters. It is not a production-ready security posture.
+
+## Production Install Pattern
+
+For production, override the default auth and datastore settings and provide
+the required environment variables through `extraEnv`.
+
+```yaml
+config:
+  server:
+    base_url: "${GESTALT_BASE_URL}"
+    encryption_key: "${GESTALT_ENCRYPTION_KEY}"
+  auth:
+    provider: oidc
+    config:
+      issuer_url: "${OIDC_ISSUER_URL}"
+      client_id: "${OIDC_CLIENT_ID}"
+      client_secret: "${OIDC_CLIENT_SECRET}"
+  datastore:
+    provider: postgres
+    config:
+      dsn: "${DATABASE_URL}"
+
+extraEnv:
+  - name: GESTALT_BASE_URL
+    value: "https://gestalt.example.com"
+  - name: GESTALT_ENCRYPTION_KEY
+    valueFrom:
+      secretKeyRef:
+        name: gestalt-secrets
+        key: encryption-key
+  - name: DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: gestalt-secrets
+        key: database-url
+
+pluginInit:
+  enabled: true
+```
+
+Apply that with:
+
+```sh
+helm upgrade --install gestalt \
+  oci://ghcr.io/valon-technologies/gestalt/charts/gestalt \
+  --namespace gestalt \
+  --set image.tag=<version> \
+  -f values-production.yaml
+```
+
 ## Important Chart Values
 
 | Value | Purpose |
@@ -24,6 +84,7 @@ settings along with the matching `extraEnv` entries.
 | `persistence` | PVC settings for SQLite or other local state. |
 | `pluginInit.enabled` | Runs `gestaltd init` in an init container before the main server starts. |
 | `ingress` | Standard ingress settings. |
+| `ingress.hosts[].paths` | Per-host ingress paths and path types. |
 
 ## Example Values
 

--- a/docs/pages/deploy/helm.mdx
+++ b/docs/pages/deploy/helm.mdx
@@ -23,8 +23,8 @@ The default chart profile is intentionally minimal:
 - one replica
 - no ingress
 
-That profile is suitable for smoke tests, local development, and trusted
-internal clusters. It is not a production-ready security posture.
+That profile is suitable for local development and trusted internal clusters.
+It is not a production-ready security posture.
 
 ## Production Install Pattern
 

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -460,7 +460,7 @@ func TestE2EHelmChart(t *testing.T) {
 
 	chartDir := filepath.Join("..", "..", "deploy", "helm", "gestalt")
 
-	t.Run("default smoke profile boots", func(t *testing.T) {
+	t.Run("default chart profile boots", func(t *testing.T) {
 		t.Parallel()
 
 		dir := t.TempDir()

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+	"gopkg.in/yaml.v3"
 )
 
 func TestE2EInitArchiveAndValidate(t *testing.T) {
@@ -449,6 +450,75 @@ func TestE2EValidateNonMutating(t *testing.T) {
 	}
 }
 
+func TestE2EHelmChart(t *testing.T) {
+	t.Parallel()
+
+	helmPath, err := exec.LookPath("helm")
+	if err != nil {
+		t.Skip("helm not installed")
+	}
+
+	chartDir := filepath.Join("..", "..", "deploy", "helm", "gestalt")
+
+	t.Run("default smoke profile boots", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		port := allocateTestPort(t)
+		dbPath := filepath.Join(dir, "gestalt.db")
+		rendered := renderHelmChart(t, helmPath, chartDir,
+			"--set", fmt.Sprintf("config.server.port=%d", port),
+			"--set-string", "config.datastore.config.path="+dbPath,
+		)
+
+		cfgPath := filepath.Join(dir, "config.yaml")
+		if err := os.WriteFile(cfgPath, []byte(extractRenderedConfig(t, rendered)), 0o644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+		if err != nil {
+			t.Fatalf("gestaltd validate: %v\n%s", err, out)
+		}
+
+		cmd := exec.Command(gestaltdBin, "serve", "--locked", "--config", cfgPath)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start serve: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = cmd.Process.Signal(os.Interrupt)
+			_ = cmd.Wait()
+		})
+
+		baseURL := fmt.Sprintf("http://localhost:%d", port)
+		waitForHealth(t, baseURL, 20*time.Second)
+		waitForReady(t, baseURL, 20*time.Second)
+	})
+
+	t.Run("ingress paths render from values", func(t *testing.T) {
+		t.Parallel()
+
+		rendered := renderHelmChart(t, helmPath, chartDir,
+			"--set", "ingress.enabled=true",
+			"--set-string", "ingress.hosts[0].host=gestalt.example.com",
+			"--set-string", "ingress.hosts[0].paths[0].path=/gestalt",
+			"--set-string", "ingress.hosts[0].paths[0].pathType=Prefix",
+		)
+
+		for _, want := range []string{
+			`host: "gestalt.example.com"`,
+			`path: "/gestalt"`,
+			`pathType: Prefix`,
+		} {
+			if !strings.Contains(rendered, want) {
+				t.Fatalf("expected rendered manifest to contain %q\n%s", want, rendered)
+			}
+		}
+	})
+}
+
 func withoutEnvVar(env []string, name string) []string {
 	prefix := name + "="
 	filtered := env[:0]
@@ -459,6 +529,45 @@ func withoutEnvVar(env []string, name string) []string {
 		filtered = append(filtered, entry)
 	}
 	return filtered
+}
+
+func renderHelmChart(t *testing.T, helmPath, chartDir string, extraArgs ...string) string {
+	t.Helper()
+	args := append([]string{"template", "test-release", chartDir}, extraArgs...)
+	out, err := exec.Command(helmPath, args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	return string(out)
+}
+
+func extractRenderedConfig(t *testing.T, rendered string) string {
+	t.Helper()
+
+	var doc struct {
+		Kind string            `yaml:"kind"`
+		Data map[string]string `yaml:"data"`
+	}
+
+	dec := yaml.NewDecoder(strings.NewReader(rendered))
+	for {
+		doc = struct {
+			Kind string            `yaml:"kind"`
+			Data map[string]string `yaml:"data"`
+		}{}
+		if err := dec.Decode(&doc); err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatalf("decode rendered manifest: %v", err)
+		}
+		if doc.Kind == "ConfigMap" && doc.Data["config.yaml"] != "" {
+			return doc.Data["config.yaml"]
+		}
+	}
+
+	t.Fatal("rendered chart missing config.yaml ConfigMap")
+	return ""
 }
 
 //nolint:paralleltest // Spawns the CLI binary; keeping it serial avoids package-level e2e flake.

--- a/gestaltd/deploy/helm/gestalt/ci-values.yaml
+++ b/gestaltd/deploy/helm/gestalt/ci-values.yaml
@@ -9,7 +9,3 @@ config:
 
 image:
   tag: "ci-test"
-
-web:
-  image:
-    tag: "ci-test"

--- a/gestaltd/deploy/helm/gestalt/templates/NOTES.txt
+++ b/gestaltd/deploy/helm/gestalt/templates/NOTES.txt
@@ -40,7 +40,7 @@ Health check:
 Default chart profile:
   auth.provider=none, SQLite on /data, single replica
   static dev-only encryption key
-  Suitable for smoke tests, local development, or trusted internal clusters
+  Suitable for local development or trusted internal clusters
   Replace server.encryption_key and auth settings before production use
 
 If you enable OAuth/OIDC or other ${VAR} placeholders, provide the matching

--- a/gestaltd/deploy/helm/gestalt/templates/NOTES.txt
+++ b/gestaltd/deploy/helm/gestalt/templates/NOTES.txt
@@ -37,11 +37,20 @@ Verify the deployment:
 Health check:
   curl http://127.0.0.1:{{ .Values.service.port }}/health
 
-Required environment variables (provide via extraEnv):
-  GESTALT_BASE_URL        Public URL of this Gestalt instance
-  GESTALT_ENCRYPTION_KEY  Encryption key for token storage
+Default chart profile:
+  auth.provider=none, SQLite on /data, single replica
+  static dev-only encryption key
+  Suitable for smoke tests, local development, or trusted internal clusters
+  Replace server.encryption_key and auth settings before production use
 
-The default auth provider is Google. Provide these for Google OAuth:
+If you enable OAuth/OIDC or other ${VAR} placeholders, provide the matching
+environment variables via extraEnv.
+
+Common env vars:
+  GESTALT_BASE_URL         Public URL of this Gestalt instance
+  GESTALT_ENCRYPTION_KEY   Required when auth.provider is not "none"
+
+For Google OAuth:
   GOOGLE_CLIENT_ID         Google OAuth client ID
   GOOGLE_CLIENT_SECRET     Google OAuth client secret
 

--- a/gestaltd/deploy/helm/gestalt/templates/ingress.yaml
+++ b/gestaltd/deploy/helm/gestalt/templates/ingress.yaml
@@ -28,12 +28,14 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          - path: /
-            pathType: Prefix
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType | default "ImplementationSpecific" }}
             backend:
               service:
                 name: {{ include "gestalt.fullname" $ }}
                 port:
                   name: http
+          {{- end }}
     {{- end }}
 {{- end }}

--- a/gestaltd/deploy/helm/gestalt/values.yaml
+++ b/gestaltd/deploy/helm/gestalt/values.yaml
@@ -1,6 +1,6 @@
-# The default chart profile is for smoke tests, local development, or
-# trusted internal clusters. It uses auth.provider=none, SQLite, and a
-# single replica so the chart boots without extra secrets.
+# The default chart profile is for local development or trusted internal
+# clusters. It uses auth.provider=none, SQLite, and a single replica so
+# the chart boots without extra secrets.
 #
 # Configure OAuth/OIDC, server.encryption_key, and a networked datastore
 # before using this chart in production.
@@ -68,10 +68,10 @@ persistence:
 config:
   server:
     port: 8080
-    # Dev-only default so the smoke profile can boot. Override this with
+    # Dev-only default so the default chart profile can boot. Override this with
     # a secret value before production use.
     encryption_key: "dev-only-insecure-key-change-me"
-    # base_url is optional for the default smoke/dev profile.
+    # base_url is optional for the default local/dev profile.
     # Set it to your public HTTPS URL when auth callbacks or external
     # integrations need it.
     # base_url: "${GESTALT_BASE_URL}"

--- a/gestaltd/deploy/helm/gestalt/values.yaml
+++ b/gestaltd/deploy/helm/gestalt/values.yaml
@@ -1,5 +1,9 @@
-# These example values use SQLite with a single replica.
-# Switch to Postgres or MySQL before scaling horizontally.
+# The default chart profile is for smoke tests, local development, or
+# trusted internal clusters. It uses auth.provider=none, SQLite, and a
+# single replica so the chart boots without extra secrets.
+#
+# Configure OAuth/OIDC, server.encryption_key, and a networked datastore
+# before using this chart in production.
 replicaCount: 1
 
 image:
@@ -59,19 +63,28 @@ persistence:
   size: 1Gi
 
 # Mounted as /etc/gestalt/config.yaml. The app expands ${ENV_VAR}
-# placeholders at startup, so secrets can be injected via extraEnv.
+# placeholders at startup, so secrets can be injected via extraEnv when
+# you enable OAuth/OIDC or an external datastore below.
 config:
   server:
     port: 8080
-    base_url: "${GESTALT_BASE_URL}"
-    encryption_key: "${GESTALT_ENCRYPTION_KEY}"
+    # Dev-only default so the smoke profile can boot. Override this with
+    # a secret value before production use.
+    encryption_key: "dev-only-insecure-key-change-me"
+    # base_url is optional for the default smoke/dev profile.
+    # Set it to your public HTTPS URL when auth callbacks or external
+    # integrations need it.
+    # base_url: "${GESTALT_BASE_URL}"
   auth:
-    provider: google
-    config:
-      client_id: "${GOOGLE_CLIENT_ID}"
-      client_secret: "${GOOGLE_CLIENT_SECRET}"
-      # Optional. If omitted, Gestalt derives the callback from server.base_url.
-      # redirect_url: "${GOOGLE_REDIRECT_URL}"
+    provider: none
+    config: {}
+    # For Google OAuth:
+    # provider: google
+    # config:
+    #   client_id: "${GOOGLE_CLIENT_ID}"
+    #   client_secret: "${GOOGLE_CLIENT_SECRET}"
+    #   # Optional. If omitted, Gestalt derives the callback from server.base_url.
+    #   # redirect_url: "${GOOGLE_REDIRECT_URL}"
     # For OIDC (Okta, Azure AD, Auth0, Keycloak, Firebase, etc.):
     # provider: oidc
     # config:
@@ -88,8 +101,9 @@ config:
     config:
       path: /data/gestalt.db
 
-# Extra environment variables for the container. These are required
-# for the ${VAR} placeholders in the config above to resolve.
+# Extra environment variables for the container. These are only required
+# when your config uses ${VAR} placeholders for auth, base_url, or
+# external datastore settings.
 extraEnv: []
 # - name: GESTALT_BASE_URL
 #   value: "https://gestalt.example.com"


### PR DESCRIPTION
## Summary
- make the default Helm chart profile bootable for smoke/dev use instead of rendering a non-starting config
- fix ingress templating so `ingress.hosts[].paths[]` renders from values instead of hardcoding `/`
- move Helm runtime coverage into the existing `server/cmd/gestaltd` e2e suite and keep workflow validation focused on render/schema checks plus that e2e smoke test

## Why
The chart previously passed `helm lint` and schema validation, but the default rendered config did not actually boot. It also ignored configured ingress paths. That left the docs overstating what a default install could do.

## User Impact
- `helm upgrade --install gestalt ./server/deploy/helm/gestalt` now produces a runnable smoke/dev profile
- production guidance is explicit about overriding auth, encryption, and datastore settings
- ingress path overrides now work as declared in chart values

## Root Cause
The default chart values depended on unresolved auth/encryption placeholders, and the ingress template discarded `hosts[].paths[]` from values at render time.

## Validation
- `cd server && go test ./cmd/gestaltd -run TestE2EHelmChart -count=1`
- `helm lint server/deploy/helm/gestalt`
