### PR TITLE
[codex] Polish docs styling and typography

### DIFF
--- a/docs/globals.css
+++ b/docs/globals.css
@@ -292,9 +292,9 @@ article.nextra-content main::before {
   content: '';
   position: absolute;
   top: -1rem;
-  left: -2rem;
-  right: -2rem;
-  height: 18rem;
+  left: 0;
+  width: min(100%, calc(var(--valon-content-width) + 4rem));
+  height: 16rem;
   border-radius: 24px;
   background:
     radial-gradient(
@@ -423,8 +423,7 @@ button[title='Change theme'],
   }
 
   article.nextra-content main::before {
-    left: -3rem;
-    right: -3rem;
+    width: min(100%, calc(var(--valon-content-width) + 5rem));
   }
 }
 
@@ -436,7 +435,7 @@ button[title='Change theme'],
 
   article.nextra-content main::before {
     left: -1rem;
-    right: -1rem;
+    width: calc(100% + 2rem);
     height: 14rem;
   }
 }


### PR DESCRIPTION
## Summary
- polish the docs shell so it feels less like default Nextra while keeping the Valon font stack
- adjust heading typography so h2/h3 read closer to the Valon reference and stop feeling overly narrow
- constrain the warm hero background treatment so it stays inside the intro content column instead of bleeding into the TOC/sidebar

## Validation
- `cd docs && npm run build`
- rendered the exported `out/` locally and checked screenshots for both typography and hero containment

## Why
`docs.valon.tools` is now deploying correctly, but the docs still needed a visual cleanup. This PR fixes the remaining issues the live site showed after deployment: generic shell styling, overly pinched headings, and the hero background overlaying adjacent layout columns.