### PR TITLE
docs: add Introduction page and rewrite Getting Started

### DIFF
--- a/docs/globals.css
+++ b/docs/globals.css
@@ -341,19 +341,26 @@ article.nextra-content main::before {
   transform: translateY(-1px);
 }
 
+.nextra-card {
+  display: flex !important;
+  flex-direction: column !important;
+}
+
 .nextra-card p {
   margin-top: 0 !important;
   color: var(--valon-secondary) !important;
   line-height: 1.6;
+  order: 2;
 }
 
 .nextra-card > span:last-child {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 1rem 0 0 !important;
-  font-weight: 400 !important;
-  color: rgba(var(--valon-ink), 1) !important;
+  padding: 0 0 0.75rem !important;
+  font-weight: 600 !important;
+  color: rgba(35, 24, 16, 1) !important;
+  order: 1;
 }
 
 table {

--- a/docs/pages/_meta.ts
+++ b/docs/pages/_meta.ts
@@ -1,5 +1,6 @@
 export default {
   index: "Overview",
+  introduction: "Introduction",
   "getting-started": "Getting Started",
   concepts: "Concepts",
   tasks: "Tasks",

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -1,9 +1,4 @@
-import { Callout } from 'nextra/components'
-
 # Getting Started
-
-This guide starts with the zero-config local path and then switches to an
-explicit `config.yaml`.
 
 ## Install
 
@@ -20,65 +15,23 @@ Download the latest binaries from the
 [GitHub releases page](https://github.com/valon-technologies/gestalt/releases)
 and place them on your `PATH`.
 
-**Docker**
+## Run a local server
 
-The published image is `valontechnologies/gestaltd`. It expects
-`/etc/gestalt/config.yaml` and defaults to
-`serve --locked --config /etc/gestalt/config.yaml`.
-See [Docker](/deploy/gateway-only) for the container layout and mount
-expectations.
-
-## Run A Local Server With No Config
+Start a local Gestalt server with a single command:
 
 ```sh
 gestaltd
 ```
 
-If you do not pass `--config` and no local config exists, Gestalt writes a new
-file at `~/.gestalt/config.yaml` and starts immediately.
+When no configuration file is provided, `gestaltd` generates a default local
+config and starts immediately. The server is now running at
+`http://localhost:8080`.
 
-The generated local config uses:
+## Add a provider
 
-- `auth.provider: none`
-- `datastore.provider: sqlite`
-- `secrets.provider: env`
-- `telemetry.provider: stdout`
-- `server.port: 8080`
-
-The generated SQLite database lives at `~/.gestalt/gestalt.db`.
-
-<Callout>
-  `gestaltd` is intentionally local-friendly. Production deployments should
-  usually use `gestaltd init` followed by `gestaltd serve --locked`.
-</Callout>
-
-## Write An Explicit Config
-
-Save this as `openapi/httpbin.yaml`:
-
-```yaml
-openapi: 3.0.3
-info:
-  title: HTTPBin
-  version: 1.0.0
-servers:
-  - url: https://httpbin.org
-paths:
-  /ip:
-    get:
-      operationId: get_ip
-      responses:
-        "200":
-          description: OK
-  /headers:
-    get:
-      operationId: get_headers
-      responses:
-        "200":
-          description: OK
-```
-
-Save this as `config.yaml`:
+Create a file called `config.yaml` with a provider definition. This example
+adds [HTTPBin](https://httpbin.org), a public API that requires no
+authentication:
 
 ```yaml
 server:
@@ -112,26 +65,46 @@ providers:
       tool_prefix: httpbin_
 ```
 
-This is the smallest useful Gestalt config:
+Save the following OpenAPI spec as `openapi/httpbin.yaml`:
 
-- one explicit server block
-- no platform auth
-- SQLite storage
-- one inline OpenAPI provider
-
-## Validate And Start It
-
-```sh
-gestaltd init --config ./config.yaml
-gestaltd validate --config ./config.yaml
-gestaltd serve --locked --config ./config.yaml
+```yaml
+openapi: 3.0.3
+info:
+  title: HTTPBin
+  version: 1.0.0
+servers:
+  - url: https://httpbin.org
+paths:
+  /ip:
+    get:
+      operationId: get_ip
+      responses:
+        "200":
+          description: OK
+  /headers:
+    get:
+      operationId: get_headers
+      responses:
+        "200":
+          description: OK
 ```
 
-`init` writes `gestalt.lock.json`. With this inline config there are no packaged
-artifacts to fetch, but the same workflow scales to packaged providers and UI
-plugins.
+Start the server with your config:
 
-## Call The Integration
+```sh
+gestaltd serve --config ./config.yaml
+```
+
+## Call an integration
+
+Once the server is running, you can invoke the provider through any surface.
+
+**Client CLI**
+
+```sh
+gestalt invoke httpbin get_ip
+gestalt invoke httpbin get_headers
+```
 
 **HTTP API**
 
@@ -139,21 +112,16 @@ plugins.
 curl http://localhost:8080/api/v1/httpbin/get_ip
 ```
 
-**Client CLI**
+**Web UI**
 
-```sh
-gestalt --url http://localhost:8080 integrations list
-gestalt --url http://localhost:8080 invoke httpbin get_headers
-```
+Open `http://localhost:8080` in a browser to explore and invoke integrations
+interactively.
 
-Because `auth.provider` is `none`, no login step is required.
+## Next steps
 
-## Next Steps
-
-- [Configuration](/concepts/configuration) explains config discovery, defaults,
+- [Configuration](/concepts/configuration) explains the config file format,
   environment expansion, and locked startup.
 - [Integrations](/concepts/integrations) covers inline, packaged, and hybrid
   providers.
-- [Plugin Manifests](/reference/plugin-manifests) shows how YAML manifests work
-  for packaged plugins.
-- [Run Locally](/tasks/run-locally) walks through local development patterns.
+- [Add an Integration](/tasks/add-an-integration) walks through adding a
+  real-world provider with OAuth.

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -8,38 +8,49 @@ Gestalt is a platform for self-hostable, configurable integrations and tooling, 
 
 Gestalt works in three stages:
 
-**Configure.** Define the integrations you need declaratively: which providers to enable, how users authenticate, and where secrets and tokens are stored.
+### Configure
 
-**Connect.** Gestalt handles OAuth flows, token storage, and automatic refresh for every configured provider. Users authenticate once, and Gestalt manages their credentials from that point forward.
+Define the integrations you need declaratively: which providers to enable, how users authenticate, and where secrets and tokens are stored.
 
-**Invoke.** Once connected, every provider is available through a unified gateway. The same authorization rules apply regardless of how a provider is reached.
+### Connect
+
+Gestalt handles OAuth flows, token storage, and automatic refresh for every configured provider. Users authenticate once, and Gestalt manages their credentials from that point forward.
+
+### Invoke
+
+Once connected, every provider is available through a unified gateway. The same authorization rules apply regardless of how a provider is reached.
 
 ## Why Gestalt?
 
-**Self-hosted and private.** Gestalt runs in your infrastructure. Credentials and data never leave your network.
+### Self-hosted and private
 
-**One config, many integrations.** A single YAML file replaces per-integration glue code, token management scripts, and bespoke OAuth callback servers. Cloud agents, local coding assistants, and other harnesses all share the same gateway and authorization platform, so you only configure your integrations once.
+Gestalt runs in your infrastructure. Credentials and data never leave your network.
 
-**Works with AI tooling.** Gestalt exposes every configured integration via an optionally enabled, self-hosted MCP server, so AI agents and coding assistants can use your integrations directly. Gestalt's CLI ships with progressive disclosure, so non-technical users can work with integrations directly and effectively.
+### One config, many integrations
 
-**Extensible.** Write your own plugins or point Gestalt at any OpenAPI spec, MCP server, or GraphQL endpoint to add a new provider in minutes.
+A single YAML file replaces per-integration glue code, token management scripts, and bespoke OAuth callback servers. Cloud agents, local coding assistants, and other harnesses all share the same gateway and authorization platform, so you only configure your integrations once.
+
+### Works with AI tooling
+
+Gestalt exposes every configured integration via an optionally enabled, self-hosted MCP server, so AI agents and coding assistants can use your integrations directly. Gestalt's CLI ships with progressive disclosure, so non-technical users can work with integrations directly and effectively.
+
+### Extensible
+
+Write your own plugins or point Gestalt at any OpenAPI spec, MCP server, or GraphQL endpoint to add a new provider in minutes.
 
 ## Start Here
 
 <Cards>
   <Cards.Card title="Getting Started" href="/getting-started">
-    Run `gestaltd` out of the box, then move to an explicit config and locked startup.
+    Run Gestalt out-of-the-box, then move to custom configurations.
   </Cards.Card>
   <Cards.Card title="Platform Model" href="/concepts/platform-model">
-    See how config, providers, the invocation broker, and MCP fit together.
+    See how the pieces of Gestalt all fit together.
   </Cards.Card>
   <Cards.Card title="Configuration" href="/concepts/configuration">
-    Learn the top-level primitives and the lifecycle of `init`, `validate`, and `serve --locked`.
+    Learn the top-level primitives and lifecycle of Gestalt.
   </Cards.Card>
   <Cards.Card title="Deploy" href="/deploy">
-    Use the shipped Docker and Helm paths, then adapt the same model to Fly.io, Railway, Render, or Lambda.
-  </Cards.Card>
-  <Cards.Card title="Config File" href="/reference/config-file">
-    Full reference for every top-level block and the fields inside them.
+    Ship Gestalt to the cloud provider of your choice.
   </Cards.Card>
 </Cards>

--- a/docs/pages/introduction.mdx
+++ b/docs/pages/introduction.mdx
@@ -1,0 +1,25 @@
+# Introduction
+
+The Gestalt platform comes with two prebuilt binaries: the `gestaltd` server and the `gestalt` client.
+
+## `gestaltd`, the server
+
+`gestaltd` is the Gestalt server. It reads a single YAML configuration file and starts an HTTP server that handles authentication, token management, and integration execution for every provider you configure.
+
+The server exposes three surfaces:
+
+- **HTTP API** for programmatic access to any configured integration.
+- **Web UI** for browser-based authentication, connection management, and interactive invocation.
+- **MCP endpoint** (optional) so AI agents and coding assistants can use your integrations as tools.
+
+All three surfaces share the same authorization rules, token storage, and audit logging.
+
+## `gestalt`, the client CLI
+
+`gestalt` is a command-line client for interacting with a running `gestaltd` server. It handles login, lists available integrations, and invokes provider operations from the terminal.
+
+The CLI is designed with progressive disclosure: common tasks like listing integrations or invoking a tool are simple one-liners, while advanced options are available when you need them.
+
+## How they work together
+
+You run `gestaltd` once to start the server. From there, any number of clients can connect to it: the `gestalt` CLI, the web UI, direct HTTP calls, or AI agents. A single Gestalt deployment serves as a shared gateway for all of these consumers.


### PR DESCRIPTION
## Summary
- Adds new Introduction page explaining `gestaltd` (server) and `gestalt` (CLI), the three surfaces, and how they work together
- Rewrites Getting Started around a progressive narrative: install, run a local server, add a provider, call an integration
- Removes implementation-detail sections (locked startup, init workflow, Docker setup) from the getting started flow

## Test plan
- [ ] Verify docs site renders correctly
- [ ] Review copy for accuracy and tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)