### PR TITLE
Fix docs site rendering: code blocks, header gradient, sidebar, and TOC

### DIFF
--- a/docs/globals.css
+++ b/docs/globals.css
@@ -141,6 +141,7 @@ article th {
 article p,
 article li {
   line-height: 1.7;
+  margin-top: 0.75rem !important;
 }
 
 article a:not(.nextra-card):not(.subheading-anchor) {
@@ -166,6 +167,18 @@ pre {
   border: 1px solid var(--valon-line);
   border-radius: 12px;
   background: rgba(248, 246, 243, 0.88) !important;
+  padding: 6px 0 !important;
+  box-shadow: none !important;
+}
+
+pre code {
+  display: flex !important;
+  flex-direction: column !important;
+  white-space: normal !important;
+}
+
+pre code > span {
+  white-space: pre !important;
 }
 
 code.nextra-code,
@@ -228,9 +241,7 @@ footer > div {
 
   .nextra-sidebar-container > div {
     border-right: 1px solid var(--valon-line);
-    background:
-      linear-gradient(180deg, rgba(248, 246, 243, 0.7) 0%, rgba(255, 255, 255, 0.7) 100%),
-      radial-gradient(180% 80% at 50% 0%, rgba(238, 213, 174, 0.24) 0%, transparent 72%);
+    background: transparent;
   }
 }
 
@@ -292,20 +303,15 @@ article.nextra-content main::before {
   content: '';
   position: absolute;
   top: -1rem;
-  left: -2rem;
-  right: -2rem;
-  height: 18rem;
-  border-radius: 24px;
-  background:
-    radial-gradient(
-      200% 80% at 50% 100%,
-      rgba(246, 241, 234, 0.72) 0%,
-      rgba(243, 233, 221, 0.66) 10%,
-      rgba(241, 225, 208, 0.56) 20%,
-      rgba(238, 213, 174, 0.34) 36%,
-      rgba(237, 223, 212, 0.18) 58%,
-      transparent 86%
-    );
+  left: 0;
+  right: 0;
+  height: 7rem;
+  background: linear-gradient(
+    to bottom,
+    rgba(243, 233, 221, 0.45) 0%,
+    rgba(238, 213, 174, 0.15) 50%,
+    transparent 100%
+  );
   z-index: -1;
   pointer-events: none;
 }
@@ -421,17 +427,14 @@ button[title='Change theme'],
   footer > div {
     width: min(1300px, calc(100% - 8rem)) !important;
   }
+}
 
+@media (min-width: 1280px) {
   .nextra-toc {
     display: flex !important;
     flex-direction: column;
     padding-left: 1.5rem;
     border-left: 1px solid var(--valon-line);
-  }
-
-  article.nextra-content main::before {
-    left: -3rem;
-    right: -3rem;
   }
 }
 
@@ -442,8 +445,6 @@ button[title='Change theme'],
   }
 
   article.nextra-content main::before {
-    left: -1rem;
-    right: -1rem;
-    height: 14rem;
+    height: 6rem;
   }
 }


### PR DESCRIPTION
Fix several visual issues in the docs site CSS. Code blocks had a double border from Nextra's ring shadow stacking with our custom border, and extra line spacing from \n text nodes creating anonymous grid items inside display:grid code elements. Switch pre code to display:flex with white-space:normal to collapse those text nodes, and add box-shadow:none to eliminate the duplicate ring. Tighten pre padding from 16px to 6px.

Replace the oversized header gradient (18rem radial, origin at bottom) with a contained 7rem linear gradient that fades before reaching content. Remove the sidebar gradient and align the TOC breakpoint to 1280px to match Nextra's xl breakpoint and avoid !important conflicts between dev and production CSS ordering. Reduce paragraph spacing for tighter layout.