### PR TITLE
[codex] Fix published Helm docs

### DIFF
--- a/docs/pages/deploy/kubernetes.mdx
+++ b/docs/pages/deploy/kubernetes.mdx
@@ -6,12 +6,13 @@ The repository includes a Helm chart under `gestaltd/deploy/helm/gestalt`.
 
 ```sh
 helm upgrade --install gestalt ./gestaltd/deploy/helm/gestalt \
+  --namespace gestalt \
   --set image.tag=<version> \
-  --dry-run --debug
+  -f values.yaml
 ```
 
-Remove `--dry-run --debug` when you are ready to apply the release to a real
-cluster.
+Provide a `values.yaml` file that sets the required auth, datastore, and server
+settings along with the matching `extraEnv` entries.
 
 ## Important Chart Values
 
@@ -46,6 +47,30 @@ config:
 extraEnv:
   - name: GESTALT_BASE_URL
     value: "https://gestalt.example.com"
+  - name: GESTALT_ENCRYPTION_KEY
+    valueFrom:
+      secretKeyRef:
+        name: gestalt-secrets
+        key: encryption-key
+  - name: OIDC_ISSUER_URL
+    value: "https://login.example.com"
+  - name: OIDC_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: gestalt-secrets
+        key: oidc-client-id
+  - name: OIDC_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: gestalt-secrets
+        key: oidc-client-secret
+  - name: OIDC_REDIRECT_URL
+    value: "https://gestalt.example.com/auth/callback"
+  - name: DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: gestalt-secrets
+        key: database-url
 
 pluginInit:
   enabled: true


### PR DESCRIPTION
## Summary

This updates the published Kubernetes Helm docs to match the current chart usage.

## What changed

- switched the install example to a real `helm upgrade --install` flow that targets the namespace and uses a `values.yaml` file
- made it explicit that the chart requires `config` and matching `extraEnv` values for auth, datastore, and server settings
- expanded the example values file so the required environment variables are visible in the docs

## Why

The existing page implied a dry-run-first path and did not clearly show the required values wiring, which made the published Helm instructions incomplete.

## Impact

Users following the Kubernetes page should now have a clearer path to a working Helm deployment.

## Validation

- `cd docs && npm run build`
