### PR TITLE
Fix double border on docs code blocks

### DIFF
--- a/docs/globals.css
+++ b/docs/globals.css
@@ -165,7 +165,7 @@ samp,
 
 pre {
   border: 1px solid var(--valon-line);
-  border-radius: 12px;
+  border-radius: 12px !important;
   background: rgba(248, 246, 243, 0.88) !important;
   padding: 6px 0 !important;
   box-shadow: none !important;
@@ -175,13 +175,16 @@ pre code {
   display: flex !important;
   flex-direction: column !important;
   white-space: normal !important;
+  border: none !important;
+  border-radius: 0 !important;
+  background: transparent !important;
 }
 
 pre code > span {
   white-space: pre !important;
 }
 
-code.nextra-code,
+:not(pre) > code.nextra-code,
 p code,
 li code,
 td code {


### PR DESCRIPTION
## Summary
- Nextra wraps syntax-highlighted code in `<pre><code class="nextra-code">`. The `code.nextra-code` CSS selector matched both inline code and code inside `pre` blocks, giving the inner `<code>` its own border that stacked with the `<pre>` border — producing a visible double border on every code block.
- Changed the selector to `:not(pre) > code.nextra-code` so inline code styles only apply to inline code, and added explicit border/background resets on `pre code`.
- Also fixed `border-radius: 12px` being overridden by Nextra's `._rounded-md` (6px) due to class specificity.

## Test plan
- [ ] Verify code blocks on `/getting-started` and `/tasks/write-a-plugin` show a single border with 12px radius
- [ ] Verify inline code in prose (e.g. `config.yaml`, `PATH`) retains its styled border and background
- [ ] Spot-check other docs pages with code blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)