### PR TITLE
Fix CSS cascade for code blocks in lists and tables

### DIFF
--- a/docs/globals.css
+++ b/docs/globals.css
@@ -171,6 +171,16 @@ pre {
   box-shadow: none !important;
 }
 
+:not(pre) > code.nextra-code,
+p code,
+li code,
+td code {
+  border: 1px solid rgba(35, 24, 16, 0.08);
+  border-radius: 6px;
+  background: rgba(248, 246, 243, 0.9) !important;
+  color: rgba(var(--valon-ink), 1) !important;
+}
+
 pre code {
   display: flex !important;
   flex-direction: column !important;
@@ -182,16 +192,6 @@ pre code {
 
 pre code > span {
   white-space: pre !important;
-}
-
-:not(pre) > code.nextra-code,
-p code,
-li code,
-td code {
-  border: 1px solid rgba(35, 24, 16, 0.08);
-  border-radius: 6px;
-  background: rgba(248, 246, 243, 0.9) !important;
-  color: rgba(var(--valon-ink), 1) !important;
 }
 
 .nextra-nav-container {


### PR DESCRIPTION
## Summary
- Follow-up to #541. The `pre code` background reset (`transparent !important`) and the inline code rules (`li code`, `td code` with `!important`) share specificity 0,0,2. When a `<pre><code>` appears inside a `<li>` or `<td>`, both rules match, and the later one in the file wins — so the inline code background was defeating the reset.
- Fix: move the inline code rule above the `pre code` reset so the reset appears later and wins the cascade.

## Test plan
- [ ] Verify code blocks inside list items (e.g. on `/troubleshooting`) have no inner background leak
- [ ] Verify code blocks inside table cells (e.g. on `/reference/cli`) render with a single border
- [ ] Verify inline code in `<li>` and `<td>` still has its styled background

🤖 Generated with [Claude Code](https://claude.com/claude-code)