### PR TITLE
docs: strengthen Docker image reference and simplify deploy overview

### DIFF
--- a/docs/pages/deploy/index.mdx
+++ b/docs/pages/deploy/index.mdx
@@ -1,7 +1,7 @@
 # Deploy
 
 Gestalt runs anywhere you can run a Docker container. The published image is
-`valontechnologies/gestaltd`. See the
+`valontechnologies/gestaltd:latest`. See the
 [Docker Image](/reference/docker-image) reference for image details,
 environment variables, and a Docker Compose example.
 
@@ -10,10 +10,3 @@ For Kubernetes, Gestalt publishes a [Helm chart](/deploy/helm).
 Any container platform that can run a Docker image on port `8080` with
 environment variables will work, including Google Cloud Run, AWS App Runner
 or ECS, Fly.io, Render, Railway, and others.
-
-## Production checklist
-
-- Set `server.base_url` to your public HTTPS URL.
-- Use an external database (Postgres) instead of SQLite.
-- Store secrets (encryption key, OIDC credentials) in your platform's secret manager.
-- Run `gestaltd init` before `gestaltd serve --locked` for deterministic startup.

--- a/docs/pages/deploy/index.mdx
+++ b/docs/pages/deploy/index.mdx
@@ -1,18 +1,19 @@
 # Deploy
 
-## Recommended Production Pattern
+Gestalt runs anywhere you can run a Docker container. The published image is
+`valontechnologies/gestaltd`. See the
+[Docker Image](/reference/docker-image) reference for image details,
+environment variables, and a Docker Compose example.
 
-1. Prepare artifacts with `gestaltd init`.
-2. Start the server with `gestaltd serve --locked`.
-3. Persist the datastore appropriately for your chosen backend.
-4. Set `server.base_url` to the public HTTPS URL.
+For Kubernetes, Gestalt publishes a [Helm chart](/deploy/helm).
 
-## Deployment Options
+Any container platform that can run a Docker image on port `8080` with
+environment variables will work, including Google Cloud Run, AWS App Runner
+or ECS, Fly.io, Render, Railway, and others.
 
-| Path | Use it for |
-| --- | --- |
-| [Helm](/deploy/helm) | Helm chart for Kubernetes deployments. |
+## Production checklist
 
-The published Docker image (`valontechnologies/gestaltd`) can be used directly
-on any container platform. See the [Docker Image](/reference/docker-image)
-reference for image layout and mount expectations.
+- Set `server.base_url` to your public HTTPS URL.
+- Use an external database (Postgres) instead of SQLite.
+- Store secrets (encryption key, OIDC credentials) in your platform's secret manager.
+- Run `gestaltd init` before `gestaltd serve --locked` for deterministic startup.

--- a/docs/pages/reference/docker-image.mdx
+++ b/docs/pages/reference/docker-image.mdx
@@ -1,6 +1,6 @@
 # Docker Image
 
-The published image is `valontechnologies/gestaltd`.
+The published image is `valontechnologies/gestaltd:latest`.
 
 ## Quick start
 
@@ -12,7 +12,7 @@ docker run -p 8080:8080 valontechnologies/gestaltd
 
 | Property | Value |
 | --- | --- |
-| Image | `valontechnologies/gestaltd` |
+| Image | `valontechnologies/gestaltd:latest` |
 | Port | `8080` |
 | Entrypoint | `/gestaltd` |
 | Default command | `serve --locked --config /etc/gestalt/config.yaml` |
@@ -21,17 +21,8 @@ docker run -p 8080:8080 valontechnologies/gestaltd
 ## Environment variables
 
 Gestalt config supports `${VAR}` placeholders that are resolved from
-environment variables at startup. Common variables:
-
-| Variable | Purpose |
-| --- | --- |
-| `GESTALT_BASE_URL` | Public HTTPS URL of the server. |
-| `GESTALT_ENCRYPTION_KEY` | Key used to encrypt stored tokens. |
-| `DATABASE_URL` | Connection string when using Postgres. |
-| `OIDC_ISSUER_URL` | OIDC provider issuer URL. |
-| `OIDC_CLIENT_ID` | OIDC client ID. |
-| `OIDC_CLIENT_SECRET` | OIDC client secret. |
-| `OIDC_REDIRECT_URL` | OIDC redirect URL. |
+environment variables at startup. See the [Config File](/reference/config-file)
+reference for the full list of configuration options.
 
 ## Docker Compose
 
@@ -48,25 +39,23 @@ services:
       GESTALT_ENCRYPTION_KEY: dev-only-change-me
 ```
 
-## Mount a prepared config directory
+## Production image
 
-If you ran `gestaltd init` locally, mount the entire config directory at
-`/etc/gestalt`. It should contain:
+For production, run `gestaltd init` locally to resolve plugins and generate
+a lock file, then commit both the config and lock file to your repo. At
+build time, copy them into a derived image:
 
-- `config.yaml`
-- `gestalt.lock.json`
-- `.gestalt/` (when packaged plugins or prepared specs are present)
-
-## Bake prepared state into a derived image
-
-Run `gestaltd init` in a build stage, copy the prepared config directory
-into the final image, and keep the default locked command:
+```
+deploy/
+  config.yaml
+  gestalt.lock.json
+```
 
 ```dockerfile
-FROM valontechnologies/gestaltd AS init
-COPY config.yaml /etc/gestalt/config.yaml
-RUN /gestaltd init --config /etc/gestalt/config.yaml
-
 FROM valontechnologies/gestaltd
-COPY --from=init /etc/gestalt /etc/gestalt
+COPY deploy/ /etc/gestalt/
 ```
+
+The image starts with `serve --locked` by default, so it will use the
+committed lock file without fetching anything at runtime. This gives you a
+fully self-contained, deterministic image.

--- a/docs/pages/reference/docker-image.mdx
+++ b/docs/pages/reference/docker-image.mdx
@@ -1,32 +1,72 @@
-# Docker
+# Docker Image
 
 The published image is `valontechnologies/gestaltd`.
 
-## What The Image Does
+## Quick start
 
-- exposes port `8080`
-- uses `/gestaltd` as the entrypoint
-- defaults to `serve --locked --config /etc/gestalt/config.yaml`
+```sh
+docker run -p 8080:8080 valontechnologies/gestaltd
+```
 
-## Mount A Prepared Config Directory
+## Image details
 
-If you already ran `gestaltd init`, mount the whole config directory at
-`/etc/gestalt`.
+| Property | Value |
+| --- | --- |
+| Image | `valontechnologies/gestaltd` |
+| Port | `8080` |
+| Entrypoint | `/gestaltd` |
+| Default command | `serve --locked --config /etc/gestalt/config.yaml` |
+| Config path | `/etc/gestalt/config.yaml` |
 
-That directory should contain:
+## Environment variables
+
+Gestalt config supports `${VAR}` placeholders that are resolved from
+environment variables at startup. Common variables:
+
+| Variable | Purpose |
+| --- | --- |
+| `GESTALT_BASE_URL` | Public HTTPS URL of the server. |
+| `GESTALT_ENCRYPTION_KEY` | Key used to encrypt stored tokens. |
+| `DATABASE_URL` | Connection string when using Postgres. |
+| `OIDC_ISSUER_URL` | OIDC provider issuer URL. |
+| `OIDC_CLIENT_ID` | OIDC client ID. |
+| `OIDC_CLIENT_SECRET` | OIDC client secret. |
+| `OIDC_REDIRECT_URL` | OIDC redirect URL. |
+
+## Docker Compose
+
+```yaml
+services:
+  gestalt:
+    image: valontechnologies/gestaltd:latest
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./config.yaml:/etc/gestalt/config.yaml:ro
+    environment:
+      GESTALT_BASE_URL: http://localhost:8080
+      GESTALT_ENCRYPTION_KEY: dev-only-change-me
+```
+
+## Mount a prepared config directory
+
+If you ran `gestaltd init` locally, mount the entire config directory at
+`/etc/gestalt`. It should contain:
 
 - `config.yaml`
 - `gestalt.lock.json`
-- `.gestalt/` when packaged plugins, prepared OpenAPI definitions, or a UI
-  plugin were prepared
+- `.gestalt/` (when packaged plugins or prepared specs are present)
 
-## Mutable Local Startup In Docker
+## Bake prepared state into a derived image
 
-For local development, override the default command and start the container with
-`serve --config /etc/gestalt/config.yaml`.
+Run `gestaltd init` in a build stage, copy the prepared config directory
+into the final image, and keep the default locked command:
 
-## Bake Prepared State Into A Derived Image
+```dockerfile
+FROM valontechnologies/gestaltd AS init
+COPY config.yaml /etc/gestalt/config.yaml
+RUN /gestaltd init --config /etc/gestalt/config.yaml
 
-If you want an immutable runtime image, run `gestaltd init` in a build stage,
-copy the prepared config directory plus `.gestalt/` into the final image, and
-keep the runtime container on the default locked command.
+FROM valontechnologies/gestaltd
+COPY --from=init /etc/gestalt /etc/gestalt
+```


### PR DESCRIPTION
## Summary
- Expand Docker image reference with env var table, docker-compose example, quick start, and multi-stage Dockerfile example
- Simplify deploy overview to list compatible platforms without per-platform guides
- Add production checklist to deploy overview

## Test plan
- [ ] Verify docker-compose example works
- [ ] Verify multi-stage Dockerfile example builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)