### PR TITLE
Use Season Serif headings and warm gradient in web UI

### DIFF
--- a/gestaltd/ui/src/app/layout.tsx
+++ b/gestaltd/ui/src/app/layout.tsx
@@ -64,7 +64,7 @@ export default function RootLayout({
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
-      <body className={`${seasonSerif.variable} ${melangeGrotesk.variable} ${geistMono.variable} font-sans antialiased`}>
+      <body className={`${seasonSerif.variable} ${melangeGrotesk.variable} ${geistMono.variable} font-sans antialiased gradient-warm`}>
         {children}
       </body>
     </html>

--- a/gestaltd/ui/src/app/login/page.tsx
+++ b/gestaltd/ui/src/app/login/page.tsx
@@ -44,7 +44,7 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center gradient-warm">
+    <div className="flex min-h-screen items-center justify-center">
       <div className="w-full max-w-sm animate-fade-in-up">
         <div className="rounded-lg border border-alpha bg-base-white p-10 shadow-dropdown dark:bg-surface">
           <div className="text-center">

--- a/gestaltd/ui/tailwind.config.ts
+++ b/gestaltd/ui/tailwind.config.ts
@@ -69,7 +69,7 @@ const config: Config = {
       },
       fontFamily: {
         sans: ["var(--font-body)", "system-ui", "sans-serif"],
-        heading: ["var(--font-body)", "system-ui", "sans-serif"],
+        heading: ["var(--font-display)", "Georgia", "serif"],
         display: ["var(--font-display)", "Georgia", "serif"],
         mono: ["var(--font-mono)", "monospace"],
       },


### PR DESCRIPTION
## Summary
- Change `font-heading` from Melange Grotesk (body font) to Season Serif (display font) so headings render in the serif typeface
- Apply `gradient-warm` to the body element for warm radial background on all pages
- Remove redundant `gradient-warm` from login page wrapper (body already provides it)

## Test plan
- [ ] Run `cd gestaltd/ui && npm run dev` and verify headings use Season Serif
- [ ] Verify warm gradient background is visible on all pages
- [ ] Check login page still has the gradient (inherited from body)
- [ ] Verify dark mode gradient variant works

🤖 Generated with [Claude Code](https://claude.com/claude-code)