### PR TITLE
docs: reorganize Concepts, rename built-in-providers, fix table width

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,5 +61,5 @@ If you add a new built-in auth provider, datastore, secret manager, or named pro
 
 1. Register it in the relevant `gestaltd/cmd/gestaltd` file.
 2. Add or update tests.
-3. Update [Built-in Plugins](https://docs.valon.tools/reference/built-in-plugins).
+3. Update [Built-in Providers](https://docs.valon.tools/reference/built-in-providers).
 4. Update any docs or examples that describe the supported inventory.

--- a/README.md
+++ b/README.md
@@ -6,32 +6,48 @@ Gestalt is a platform for self-hostable, configurable integrations and tooling, 
 
 Gestalt works in three stages:
 
-**Configure.** Define the integrations you need declaratively: which providers to enable, how users authenticate, and where secrets and tokens are stored.
+### Configure
 
-**Connect.** Gestalt handles OAuth flows, token storage, and automatic refresh for every configured provider. Users authenticate once, and Gestalt manages their credentials from that point forward.
+Define the integrations you need declaratively: which providers to enable, how users authenticate, and where secrets and tokens are stored.
 
-**Invoke.** Once connected, every provider is available through a unified gateway. The same authorization rules apply regardless of how a provider is reached.
+### Connect
+
+Gestalt handles OAuth flows, token storage, and automatic refresh for every configured provider. Users authenticate once, and Gestalt manages their credentials from that point forward.
+
+### Invoke
+
+Once connected, every provider is available through a unified gateway. The same authorization rules apply regardless of how a provider is reached.
 
 ## Why Gestalt?
 
-**Self-hosted and private.** Gestalt runs in your infrastructure. Credentials and data never leave your network.
+### Self-hosted and private
 
-**One config, many integrations.** A single YAML file replaces per-integration glue code, token management scripts, and bespoke OAuth callback servers. Cloud agents, local coding assistants, and other harnesses all share the same gateway and authorization platform, so you only configure your integrations once.
+Gestalt runs in your infrastructure. Credentials and data never leave your network.
 
-**Works with AI tooling.** Gestalt exposes every configured integration via an optionally enabled, self-hosted MCP server, so AI agents and coding assistants can use your integrations directly. Gestalt's CLI ships with progressive disclosure, so non-technical users can work with integrations directly and effectively.
+### One config, many integrations
 
-**Extensible.** Write your own plugins or point Gestalt at any OpenAPI spec, MCP server, or GraphQL endpoint to add a new provider in minutes.
+A single YAML file replaces per-integration glue code, token management scripts, and bespoke OAuth callback servers. Cloud agents, local coding assistants, and other harnesses all share the same gateway and authorization platform, so you only configure your integrations once.
 
-## Repository
+### Works with AI tooling
+
+Gestalt exposes every configured integration via an optionally enabled, self-hosted MCP server, so AI agents and coding assistants can use your integrations directly. Gestalt's CLI ships with progressive disclosure, so non-technical users can work with integrations directly and effectively.
+
+### Extensible
+
+Write your own plugins or point Gestalt at any OpenAPI spec, MCP server, or GraphQL endpoint to add a new provider in minutes.
+
+## Project layout
 
 | Path | Description |
 | --- | --- |
 | [`gestaltd`](./gestaltd) | The Go server daemon. Loads config, serves the HTTP API, MCP surface, and embedded web UI. |
 | [`gestalt`](./gestalt) | The Rust CLI client. Connects to a running `gestaltd` instance for authentication and operations. |
-| [`gestaltd/ui`](./gestaltd/ui) | The Next.js web UI embedded into `gestaltd`. |
-| [`plugins`](./plugins) | Built-in and example plugin packages. |
 | [`sdk`](./sdk) | Shared SDKs and plugin manifest definitions. |
 | [`docs`](./docs) | The documentation site. |
+
+## Getting started
+
+See the [Getting Started](https://docs.valon.tools/getting-started) guide.
 
 ## Documentation
 

--- a/docs/globals.css
+++ b/docs/globals.css
@@ -372,7 +372,11 @@ article.nextra-content main::before {
   order: 1;
 }
 
-table {
+article div:has(> table) {
+  width: 100%;
+}
+
+article table {
   border-collapse: separate;
   border-spacing: 0;
   width: 100%;

--- a/docs/pages/reference/_meta.ts
+++ b/docs/pages/reference/_meta.ts
@@ -7,5 +7,5 @@ export default {
   cli: "CLI",
   "docker-image": "Docker Image",
   observability: "Observability",
-  "built-in-plugins": "Built-in Plugins",
+  "built-in-providers": "Built-in Providers",
 };

--- a/docs/pages/reference/built-in-providers.mdx
+++ b/docs/pages/reference/built-in-providers.mdx
@@ -1,4 +1,4 @@
-# Built-in Plugins
+# Built-in Providers
 
 Components registered by the `gestaltd` binary at startup.
 


### PR DESCRIPTION
## Summary
- Move Plugin Packaging, UI Plugins, and Observability from Concepts to Reference
- Trim Platform Model bootstrap sequence and Configuration loading steps to concise summaries
- Fix outdated YAML in Plugin Packaging and Security (`integrations:/plugin:` to `providers:/from:`)
- Rename built-in-plugins to built-in-providers
- Fix tables not stretching to full container width
- Update README with h3 headers, remove stale paths, add Getting Started link
- Fix internal links in Config File reference

## Test plan
- [ ] Verify tables render full width on built-in-providers page
- [ ] Verify no broken links across docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)