### PR TITLE
Add gestaltd operation metrics

### DIFF
--- a/docs/pages/reference/observability.mdx
+++ b/docs/pages/reference/observability.mdx
@@ -67,6 +67,24 @@ telemetry:
       level: info
 ```
 
+## Built-In Operation Metrics
+
+`gestaltd` emits broker-level OTEL metrics for operation execution:
+
+- `gestaltd.operation.count`
+- `gestaltd.operation.error_count`
+- `gestaltd.operation.duration`
+
+These metrics use low-cardinality attributes:
+
+- `gestalt.provider`: the integration key
+- `gestalt.operation`: the catalog operation id
+- `gestalt.transport`: how the operation is implemented: `plugin`, `rest`, or `mcp-passthrough`
+- `gestalt.connection_mode`: the provider auth mode: `none`, `user`, `identity`, or `either`
+
+When a request references an unknown provider or operation, `gestaltd` records
+`unknown` for the missing metric attributes instead of using raw user input.
+
 ## What Gets Logged
 
 Gestalt logs:

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -13,12 +13,17 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	"google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
 )
 
@@ -320,7 +325,12 @@ func TestE2EInitServeLockedOTLPExportsTracesAndMetricsButKeepsLogsOnStdout(t *te
 	}
 
 	var logRequests, traceRequests, metricRequests atomic.Int32
+	metricObserver := newOTLPMetricObserver()
+	var metricDecodeErr atomic.Value
 	otlpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+
 		switch r.URL.Path {
 		case "/v1/logs":
 			logRequests.Add(1)
@@ -328,10 +338,11 @@ func TestE2EInitServeLockedOTLPExportsTracesAndMetricsButKeepsLogsOnStdout(t *te
 			traceRequests.Add(1)
 		case "/v1/metrics":
 			metricRequests.Add(1)
+			if err := metricObserver.recordExport(body); err != nil && metricDecodeErr.Load() == nil {
+				metricDecodeErr.Store(err.Error())
+			}
 		}
 
-		_, _ = io.Copy(io.Discard, r.Body)
-		_ = r.Body.Close()
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(otlpServer.Close)
@@ -366,7 +377,19 @@ func TestE2EInitServeLockedOTLPExportsTracesAndMetricsButKeepsLogsOnStdout(t *te
 		t.Fatalf("gestaltd init: %v\n%s", err, out)
 	}
 
-	stdout, stderr := serveLockedAndInvokeExampleEcho(t, cfgPath, port, "")
+	stdout, stderr := serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
+		body := invokeExampleOperation(t, baseURL, "echo", `{"message":"hello"}`, http.StatusOK)
+
+		var result map[string]any
+		if err := json.Unmarshal(body, &result); err != nil {
+			t.Fatalf("unmarshal success response: %v\nbody: %s", err, body)
+		}
+		if result["echo"] != "hello" {
+			t.Fatalf("expected echo=hello, got %v", result)
+		}
+
+		invokeExampleOperation(t, baseURL, "nope", `{}`, http.StatusNotFound)
+	})
 
 	if traceRequests.Load() == 0 {
 		t.Fatalf("expected OTLP trace export\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
@@ -376,6 +399,34 @@ func TestE2EInitServeLockedOTLPExportsTracesAndMetricsButKeepsLogsOnStdout(t *te
 	}
 	if logRequests.Load() != 0 {
 		t.Fatalf("expected logs to stay on stdout, saw %d OTLP log exports\nstdout:\n%s\nstderr:\n%s", logRequests.Load(), stdout, stderr)
+	}
+	if v := metricDecodeErr.Load(); v != nil {
+		t.Fatalf("decode OTLP metrics: %s\nstdout:\n%s\nstderr:\n%s", v.(string), stdout, stderr)
+	}
+	if !metricObserver.hasMetric("gestaltd.operation.count") {
+		t.Fatalf("expected gestaltd.operation.count in OTLP export\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if !metricObserver.hasMetric("gestaltd.operation.duration") {
+		t.Fatalf("expected gestaltd.operation.duration in OTLP export\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if !metricObserver.hasMetric("gestaltd.operation.error_count") {
+		t.Fatalf("expected gestaltd.operation.error_count in OTLP export\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if !metricObserver.hasMetricAttributes("gestaltd.operation.count", map[string]string{
+		"gestalt.connection_mode": "none",
+		"gestalt.operation":       "echo",
+		"gestalt.provider":        "example",
+		"gestalt.transport":       "plugin",
+	}) {
+		t.Fatalf("expected gestaltd.operation.count attrs for plugin echo invoke\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if !metricObserver.hasMetricAttributes("gestaltd.operation.error_count", map[string]string{
+		"gestalt.connection_mode": "none",
+		"gestalt.operation":       "unknown",
+		"gestalt.provider":        "example",
+		"gestalt.transport":       "unknown",
+	}) {
+		t.Fatalf("expected gestaltd.operation.error_count attrs for unknown operation invoke\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
 	}
 	if !strings.Contains(stdout, `"msg":"audit"`) {
 		t.Fatalf("expected audit log in stdout\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
@@ -1046,7 +1097,7 @@ func writeE2EConfigForDir(t *testing.T, dir, pluginDir string) string {
 	return writeE2EConfig(t, dir, pluginDir, 0)
 }
 
-func serveLockedAndInvokeExampleEcho(t *testing.T, cfgPath string, port int, artifactsDir string) (string, string) {
+func serveLockedAndExerciseExample(t *testing.T, cfgPath string, port int, artifactsDir string, exercise func(t *testing.T, baseURL string)) (string, string) {
 	t.Helper()
 
 	args := []string{"serve", "--locked", "--config", cfgPath}
@@ -1073,30 +1124,185 @@ func serveLockedAndInvokeExampleEcho(t *testing.T, cfgPath string, port int, art
 	baseURL := fmt.Sprintf("http://localhost:%d", port)
 	waitForReady(t, baseURL, 30*time.Second)
 
-	req, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/example/echo", strings.NewReader(`{"message":"hello"}`))
+	exercise(t, baseURL)
+
+	stopped = true
+	_ = cmd.Process.Signal(os.Interrupt)
+	_ = cmd.Wait()
+	return stdout.String(), stderr.String()
+}
+
+func serveLockedAndInvokeExampleEcho(t *testing.T, cfgPath string, port int, artifactsDir string) (string, string) {
+	t.Helper()
+
+	return serveLockedAndExerciseExample(t, cfgPath, port, artifactsDir, func(t *testing.T, baseURL string) {
+		body := invokeExampleOperation(t, baseURL, "echo", `{"message":"hello"}`, http.StatusOK)
+
+		var result map[string]any
+		if err := json.Unmarshal(body, &result); err != nil {
+			t.Fatalf("unmarshal: %v\nbody: %s", err, body)
+		}
+		if result["echo"] != "hello" {
+			t.Fatalf("expected echo=hello, got %v", result)
+		}
+	})
+}
+
+func invokeExampleOperation(t *testing.T, baseURL, operation, requestBody string, wantStatus int) []byte {
+	t.Helper()
+
+	req, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/example/"+operation, strings.NewReader(requestBody))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("invoke: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	body, _ := io.ReadAll(resp.Body)
+	respBody, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("invoke returned %d: %s", resp.StatusCode, body)
+		if resp.StatusCode != wantStatus {
+			t.Fatalf("invoke %q returned %d, want %d: %s", operation, resp.StatusCode, wantStatus, respBody)
+		}
+	}
+	return respBody
+}
+
+type otlpMetricObserver struct {
+	mu       sync.Mutex
+	names    map[string]struct{}
+	attrSets map[string]map[string]struct{}
+}
+
+func newOTLPMetricObserver() *otlpMetricObserver {
+	return &otlpMetricObserver{
+		names:    make(map[string]struct{}),
+		attrSets: make(map[string]map[string]struct{}),
+	}
+}
+
+func (o *otlpMetricObserver) recordExport(body []byte) error {
+	var req colmetricspb.ExportMetricsServiceRequest
+	if err := proto.Unmarshal(body, &req); err != nil {
+		return err
 	}
 
-	var result map[string]any
-	if err := json.Unmarshal(body, &result); err != nil {
-		t.Fatalf("unmarshal: %v\nbody: %s", err, body)
-	}
-	if result["echo"] != "hello" {
-		t.Fatalf("expected echo=hello, got %v", result)
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	for _, rm := range req.GetResourceMetrics() {
+		for _, sm := range rm.GetScopeMetrics() {
+			for _, metric := range sm.GetMetrics() {
+				o.names[metric.GetName()] = struct{}{}
+				if o.attrSets[metric.GetName()] == nil {
+					o.attrSets[metric.GetName()] = make(map[string]struct{})
+				}
+				for _, attrSet := range otlpMetricAttributeSets(metric) {
+					o.attrSets[metric.GetName()][attrSet] = struct{}{}
+				}
+			}
+		}
 	}
 
-	stopped = true
-	_ = cmd.Process.Signal(os.Interrupt)
-	_ = cmd.Wait()
-	return stdout.String(), stderr.String()
+	return nil
+}
+
+func (o *otlpMetricObserver) hasMetric(name string) bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	_, ok := o.names[name]
+	return ok
+}
+
+func (o *otlpMetricObserver) hasMetricAttributes(name string, attrs map[string]string) bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	sets := o.attrSets[name]
+	if len(sets) == 0 {
+		return false
+	}
+	_, ok := sets[serializeMetricAttributes(attrs)]
+	return ok
+}
+
+func otlpMetricAttributeSets(metric *metricspb.Metric) []string {
+	switch {
+	case metric.GetGauge() != nil:
+		return otlpNumberDataPointAttributeSets(metric.GetGauge().GetDataPoints())
+	case metric.GetSum() != nil:
+		return otlpNumberDataPointAttributeSets(metric.GetSum().GetDataPoints())
+	case metric.GetHistogram() != nil:
+		out := make([]string, 0, len(metric.GetHistogram().GetDataPoints()))
+		for _, point := range metric.GetHistogram().GetDataPoints() {
+			out = append(out, serializeOTLPAttributes(point.GetAttributes()))
+		}
+		return out
+	case metric.GetExponentialHistogram() != nil:
+		out := make([]string, 0, len(metric.GetExponentialHistogram().GetDataPoints()))
+		for _, point := range metric.GetExponentialHistogram().GetDataPoints() {
+			out = append(out, serializeOTLPAttributes(point.GetAttributes()))
+		}
+		return out
+	case metric.GetSummary() != nil:
+		out := make([]string, 0, len(metric.GetSummary().GetDataPoints()))
+		for _, point := range metric.GetSummary().GetDataPoints() {
+			out = append(out, serializeOTLPAttributes(point.GetAttributes()))
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func otlpNumberDataPointAttributeSets[T interface{ GetAttributes() []*commonv1.KeyValue }](points []T) []string {
+	out := make([]string, 0, len(points))
+	for _, point := range points {
+		out = append(out, serializeOTLPAttributes(point.GetAttributes()))
+	}
+	return out
+}
+
+func serializeOTLPAttributes(attrs []*commonv1.KeyValue) string {
+	parts := make([]string, 0, len(attrs))
+	for _, attr := range attrs {
+		parts = append(parts, attr.GetKey()+"="+otlpAnyValueString(attr.GetValue()))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
+}
+
+func serializeMetricAttributes(attrs map[string]string) string {
+	parts := make([]string, 0, len(attrs))
+	for key, value := range attrs {
+		parts = append(parts, key+"="+value)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
+}
+
+func otlpAnyValueString(value *commonv1.AnyValue) string {
+	if value == nil {
+		return ""
+	}
+
+	switch v := value.Value.(type) {
+	case *commonv1.AnyValue_StringValue:
+		return v.StringValue
+	case *commonv1.AnyValue_BoolValue:
+		if v.BoolValue {
+			return "true"
+		}
+		return "false"
+	case *commonv1.AnyValue_IntValue:
+		return fmt.Sprintf("%d", v.IntValue)
+	case *commonv1.AnyValue_DoubleValue:
+		return fmt.Sprintf("%g", v.DoubleValue)
+	case *commonv1.AnyValue_BytesValue:
+		return string(v.BytesValue)
+	default:
+		return ""
+	}
 }
 
 var nextTestPort atomic.Int32 // zero value; first allocation returns 19100

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -1159,10 +1159,8 @@ func invokeExampleOperation(t *testing.T, baseURL, operation, requestBody string
 	}
 	defer func() { _ = resp.Body.Close() }()
 	respBody, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		if resp.StatusCode != wantStatus {
-			t.Fatalf("invoke %q returned %d, want %d: %s", operation, resp.StatusCode, wantStatus, respBody)
-		}
+	if resp.StatusCode != wantStatus {
+		t.Fatalf("invoke %q returned %d, want %d: %s", operation, resp.StatusCode, wantStatus, respBody)
 	}
 	return respBody
 }
@@ -1228,25 +1226,15 @@ func (o *otlpMetricObserver) hasMetricAttributes(name string, attrs map[string]s
 
 func otlpMetricAttributeSets(metric *metricspb.Metric) []string {
 	switch {
-	case metric.GetGauge() != nil:
-		return otlpNumberDataPointAttributeSets(metric.GetGauge().GetDataPoints())
 	case metric.GetSum() != nil:
-		return otlpNumberDataPointAttributeSets(metric.GetSum().GetDataPoints())
+		out := make([]string, 0, len(metric.GetSum().GetDataPoints()))
+		for _, point := range metric.GetSum().GetDataPoints() {
+			out = append(out, serializeOTLPAttributes(point.GetAttributes()))
+		}
+		return out
 	case metric.GetHistogram() != nil:
 		out := make([]string, 0, len(metric.GetHistogram().GetDataPoints()))
 		for _, point := range metric.GetHistogram().GetDataPoints() {
-			out = append(out, serializeOTLPAttributes(point.GetAttributes()))
-		}
-		return out
-	case metric.GetExponentialHistogram() != nil:
-		out := make([]string, 0, len(metric.GetExponentialHistogram().GetDataPoints()))
-		for _, point := range metric.GetExponentialHistogram().GetDataPoints() {
-			out = append(out, serializeOTLPAttributes(point.GetAttributes()))
-		}
-		return out
-	case metric.GetSummary() != nil:
-		out := make([]string, 0, len(metric.GetSummary().GetDataPoints()))
-		for _, point := range metric.GetSummary().GetDataPoints() {
 			out = append(out, serializeOTLPAttributes(point.GetAttributes()))
 		}
 		return out
@@ -1255,18 +1243,10 @@ func otlpMetricAttributeSets(metric *metricspb.Metric) []string {
 	}
 }
 
-func otlpNumberDataPointAttributeSets[T interface{ GetAttributes() []*commonv1.KeyValue }](points []T) []string {
-	out := make([]string, 0, len(points))
-	for _, point := range points {
-		out = append(out, serializeOTLPAttributes(point.GetAttributes()))
-	}
-	return out
-}
-
 func serializeOTLPAttributes(attrs []*commonv1.KeyValue) string {
 	parts := make([]string, 0, len(attrs))
 	for _, attr := range attrs {
-		parts = append(parts, attr.GetKey()+"="+otlpAnyValueString(attr.GetValue()))
+		parts = append(parts, attr.GetKey()+"="+attr.GetValue().GetStringValue())
 	}
 	sort.Strings(parts)
 	return strings.Join(parts, ",")
@@ -1279,30 +1259,6 @@ func serializeMetricAttributes(attrs map[string]string) string {
 	}
 	sort.Strings(parts)
 	return strings.Join(parts, ",")
-}
-
-func otlpAnyValueString(value *commonv1.AnyValue) string {
-	if value == nil {
-		return ""
-	}
-
-	switch v := value.Value.(type) {
-	case *commonv1.AnyValue_StringValue:
-		return v.StringValue
-	case *commonv1.AnyValue_BoolValue:
-		if v.BoolValue {
-			return "true"
-		}
-		return "false"
-	case *commonv1.AnyValue_IntValue:
-		return fmt.Sprintf("%d", v.IntValue)
-	case *commonv1.AnyValue_DoubleValue:
-		return fmt.Sprintf("%g", v.DoubleValue)
-	case *commonv1.AnyValue_BytesValue:
-		return string(v.BytesValue)
-	default:
-		return ""
-	}
 }
 
 var nextTestPort atomic.Int32 // zero value; first allocation returns 19100

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -325,8 +325,8 @@ func TestE2EInitServeLockedOTLPExportsTracesAndMetricsButKeepsLogsOnStdout(t *te
 	}
 
 	var logRequests, traceRequests, metricRequests atomic.Int32
-	metricObserver := newOTLPMetricObserver()
-	var metricDecodeErr atomic.Value
+	var metricBodiesMu sync.Mutex
+	var metricBodies [][]byte
 	otlpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		_ = r.Body.Close()
@@ -338,9 +338,9 @@ func TestE2EInitServeLockedOTLPExportsTracesAndMetricsButKeepsLogsOnStdout(t *te
 			traceRequests.Add(1)
 		case "/v1/metrics":
 			metricRequests.Add(1)
-			if err := metricObserver.recordExport(body); err != nil && metricDecodeErr.Load() == nil {
-				metricDecodeErr.Store(err.Error())
-			}
+			metricBodiesMu.Lock()
+			metricBodies = append(metricBodies, bytes.Clone(body))
+			metricBodiesMu.Unlock()
 		}
 
 		w.WriteHeader(http.StatusOK)
@@ -400,34 +400,24 @@ func TestE2EInitServeLockedOTLPExportsTracesAndMetricsButKeepsLogsOnStdout(t *te
 	if logRequests.Load() != 0 {
 		t.Fatalf("expected logs to stay on stdout, saw %d OTLP log exports\nstdout:\n%s\nstderr:\n%s", logRequests.Load(), stdout, stderr)
 	}
-	if v := metricDecodeErr.Load(); v != nil {
-		t.Fatalf("decode OTLP metrics: %s\nstdout:\n%s\nstderr:\n%s", v.(string), stdout, stderr)
-	}
-	if !metricObserver.hasMetric("gestaltd.operation.count") {
-		t.Fatalf("expected gestaltd.operation.count in OTLP export\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
-	}
-	if !metricObserver.hasMetric("gestaltd.operation.duration") {
-		t.Fatalf("expected gestaltd.operation.duration in OTLP export\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
-	}
-	if !metricObserver.hasMetric("gestaltd.operation.error_count") {
-		t.Fatalf("expected gestaltd.operation.error_count in OTLP export\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
-	}
-	if !metricObserver.hasMetricAttributes("gestaltd.operation.count", map[string]string{
+	metricBodiesMu.Lock()
+	exports := append([][]byte(nil), metricBodies...)
+	metricBodiesMu.Unlock()
+	requireExportedMetric(t, exports, "gestaltd.operation.count", nil, stdout, stderr)
+	requireExportedMetric(t, exports, "gestaltd.operation.duration", nil, stdout, stderr)
+	requireExportedMetric(t, exports, "gestaltd.operation.error_count", nil, stdout, stderr)
+	requireExportedMetric(t, exports, "gestaltd.operation.count", map[string]string{
 		"gestalt.connection_mode": "none",
 		"gestalt.operation":       "echo",
 		"gestalt.provider":        "example",
 		"gestalt.transport":       "plugin",
-	}) {
-		t.Fatalf("expected gestaltd.operation.count attrs for plugin echo invoke\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
-	}
-	if !metricObserver.hasMetricAttributes("gestaltd.operation.error_count", map[string]string{
+	}, stdout, stderr)
+	requireExportedMetric(t, exports, "gestaltd.operation.error_count", map[string]string{
 		"gestalt.connection_mode": "none",
 		"gestalt.operation":       "unknown",
 		"gestalt.provider":        "example",
 		"gestalt.transport":       "unknown",
-	}) {
-		t.Fatalf("expected gestaltd.operation.error_count attrs for unknown operation invoke\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
-	}
+	}, stdout, stderr)
 	if !strings.Contains(stdout, `"msg":"audit"`) {
 		t.Fatalf("expected audit log in stdout\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
 	}
@@ -1165,82 +1155,65 @@ func invokeExampleOperation(t *testing.T, baseURL, operation, requestBody string
 	return respBody
 }
 
-type otlpMetricObserver struct {
-	mu       sync.Mutex
-	names    map[string]struct{}
-	attrSets map[string]map[string]struct{}
+func requireExportedMetric(t *testing.T, exports [][]byte, name string, attrs map[string]string, stdout, stderr string) {
+	t.Helper()
+
+	found, err := hasExportedMetric(exports, name, attrs)
+	if err != nil {
+		t.Fatalf("decode OTLP metrics: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	if found {
+		return
+	}
+	if attrs == nil {
+		t.Fatalf("expected %s in OTLP export\nstdout:\n%s\nstderr:\n%s", name, stdout, stderr)
+	}
+	t.Fatalf("expected %s attrs %s in OTLP export\nstdout:\n%s\nstderr:\n%s", name, serializeMetricAttributes(attrs), stdout, stderr)
 }
 
-func newOTLPMetricObserver() *otlpMetricObserver {
-	return &otlpMetricObserver{
-		names:    make(map[string]struct{}),
-		attrSets: make(map[string]map[string]struct{}),
-	}
-}
-
-func (o *otlpMetricObserver) recordExport(body []byte) error {
-	var req colmetricspb.ExportMetricsServiceRequest
-	if err := proto.Unmarshal(body, &req); err != nil {
-		return err
-	}
-
-	o.mu.Lock()
-	defer o.mu.Unlock()
-
-	for _, rm := range req.GetResourceMetrics() {
-		for _, sm := range rm.GetScopeMetrics() {
-			for _, metric := range sm.GetMetrics() {
-				o.names[metric.GetName()] = struct{}{}
-				if o.attrSets[metric.GetName()] == nil {
-					o.attrSets[metric.GetName()] = make(map[string]struct{})
-				}
-				for _, attrSet := range otlpMetricAttributeSets(metric) {
-					o.attrSets[metric.GetName()][attrSet] = struct{}{}
+func hasExportedMetric(exports [][]byte, name string, attrs map[string]string) (bool, error) {
+	wantAttrs := serializeMetricAttributes(attrs)
+	for _, body := range exports {
+		var req colmetricspb.ExportMetricsServiceRequest
+		if err := proto.Unmarshal(body, &req); err != nil {
+			return false, err
+		}
+		for _, rm := range req.GetResourceMetrics() {
+			for _, sm := range rm.GetScopeMetrics() {
+				for _, metric := range sm.GetMetrics() {
+					if metric.GetName() != name {
+						continue
+					}
+					if attrs == nil || metricHasAttributes(metric, wantAttrs) {
+						return true, nil
+					}
 				}
 			}
 		}
 	}
-
-	return nil
+	return false, nil
 }
 
-func (o *otlpMetricObserver) hasMetric(name string) bool {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-
-	_, ok := o.names[name]
-	return ok
-}
-
-func (o *otlpMetricObserver) hasMetricAttributes(name string, attrs map[string]string) bool {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-
-	sets := o.attrSets[name]
-	if len(sets) == 0 {
-		return false
-	}
-	_, ok := sets[serializeMetricAttributes(attrs)]
-	return ok
-}
-
-func otlpMetricAttributeSets(metric *metricspb.Metric) []string {
+func metricHasAttributes(metric *metricspb.Metric, want string) bool {
+	var points [][]*commonv1.KeyValue
 	switch {
 	case metric.GetSum() != nil:
-		out := make([]string, 0, len(metric.GetSum().GetDataPoints()))
 		for _, point := range metric.GetSum().GetDataPoints() {
-			out = append(out, serializeOTLPAttributes(point.GetAttributes()))
+			points = append(points, point.GetAttributes())
 		}
-		return out
 	case metric.GetHistogram() != nil:
-		out := make([]string, 0, len(metric.GetHistogram().GetDataPoints()))
 		for _, point := range metric.GetHistogram().GetDataPoints() {
-			out = append(out, serializeOTLPAttributes(point.GetAttributes()))
+			points = append(points, point.GetAttributes())
 		}
-		return out
 	default:
-		return nil
+		return false
 	}
+	for _, attrs := range points {
+		if serializeOTLPAttributes(attrs) == want {
+			return true
+		}
+	}
+	return false
 }
 
 func serializeOTLPAttributes(attrs []*commonv1.KeyValue) string {

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -20,10 +20,6 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
-	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
-	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
-	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
-	"google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
 )
 
@@ -403,21 +399,31 @@ func TestE2EInitServeLockedOTLPExportsTracesAndMetricsButKeepsLogsOnStdout(t *te
 	metricBodiesMu.Lock()
 	exports := append([][]byte(nil), metricBodies...)
 	metricBodiesMu.Unlock()
-	requireExportedMetric(t, exports, "gestaltd.operation.count", nil, stdout, stderr)
-	requireExportedMetric(t, exports, "gestaltd.operation.duration", nil, stdout, stderr)
-	requireExportedMetric(t, exports, "gestaltd.operation.error_count", nil, stdout, stderr)
-	requireExportedMetric(t, exports, "gestaltd.operation.count", map[string]string{
-		"gestalt.connection_mode": "none",
-		"gestalt.operation":       "echo",
-		"gestalt.provider":        "example",
-		"gestalt.transport":       "plugin",
-	}, stdout, stderr)
-	requireExportedMetric(t, exports, "gestaltd.operation.error_count", map[string]string{
-		"gestalt.connection_mode": "none",
-		"gestalt.operation":       "unknown",
-		"gestalt.provider":        "example",
-		"gestalt.transport":       "unknown",
-	}, stdout, stderr)
+	requireMetricPayload(t, exports, stdout, stderr, "gestaltd.operation.count")
+	requireMetricPayload(t, exports, stdout, stderr, "gestaltd.operation.duration")
+	requireMetricPayload(t, exports, stdout, stderr, "gestaltd.operation.error_count")
+	requireMetricPayload(t, exports, stdout, stderr,
+		"gestaltd.operation.count",
+		"gestalt.connection_mode",
+		"none",
+		"gestalt.operation",
+		"echo",
+		"gestalt.provider",
+		"example",
+		"gestalt.transport",
+		"plugin",
+	)
+	requireMetricPayload(t, exports, stdout, stderr,
+		"gestaltd.operation.error_count",
+		"gestalt.connection_mode",
+		"none",
+		"gestalt.operation",
+		"unknown",
+		"gestalt.provider",
+		"example",
+		"gestalt.transport",
+		"unknown",
+	)
 	if !strings.Contains(stdout, `"msg":"audit"`) {
 		t.Fatalf("expected audit log in stdout\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
 	}
@@ -1155,83 +1161,25 @@ func invokeExampleOperation(t *testing.T, baseURL, operation, requestBody string
 	return respBody
 }
 
-func requireExportedMetric(t *testing.T, exports [][]byte, name string, attrs map[string]string, stdout, stderr string) {
+func requireMetricPayload(t *testing.T, exports [][]byte, stdout, stderr string, parts ...string) {
 	t.Helper()
 
-	found, err := hasExportedMetric(exports, name, attrs)
-	if err != nil {
-		t.Fatalf("decode OTLP metrics: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
-	}
-	if found {
-		return
-	}
-	if attrs == nil {
-		t.Fatalf("expected %s in OTLP export\nstdout:\n%s\nstderr:\n%s", name, stdout, stderr)
-	}
-	t.Fatalf("expected %s attrs %s in OTLP export\nstdout:\n%s\nstderr:\n%s", name, serializeMetricAttributes(attrs), stdout, stderr)
-}
-
-func hasExportedMetric(exports [][]byte, name string, attrs map[string]string) (bool, error) {
-	wantAttrs := serializeMetricAttributes(attrs)
 	for _, body := range exports {
-		var req colmetricspb.ExportMetricsServiceRequest
-		if err := proto.Unmarshal(body, &req); err != nil {
-			return false, err
-		}
-		for _, rm := range req.GetResourceMetrics() {
-			for _, sm := range rm.GetScopeMetrics() {
-				for _, metric := range sm.GetMetrics() {
-					if metric.GetName() != name {
-						continue
-					}
-					if attrs == nil || metricHasAttributes(metric, wantAttrs) {
-						return true, nil
-					}
-				}
-			}
+		if payloadContainsAll(body, parts...) {
+			return
 		}
 	}
-	return false, nil
+
+	t.Fatalf("expected OTLP metric payload to contain %q\nstdout:\n%s\nstderr:\n%s", parts, stdout, stderr)
 }
 
-func metricHasAttributes(metric *metricspb.Metric, want string) bool {
-	var points [][]*commonv1.KeyValue
-	switch {
-	case metric.GetSum() != nil:
-		for _, point := range metric.GetSum().GetDataPoints() {
-			points = append(points, point.GetAttributes())
-		}
-	case metric.GetHistogram() != nil:
-		for _, point := range metric.GetHistogram().GetDataPoints() {
-			points = append(points, point.GetAttributes())
-		}
-	default:
-		return false
-	}
-	for _, attrs := range points {
-		if serializeOTLPAttributes(attrs) == want {
-			return true
+func payloadContainsAll(body []byte, parts ...string) bool {
+	for _, part := range parts {
+		if !bytes.Contains(body, []byte(part)) {
+			return false
 		}
 	}
-	return false
-}
-
-func serializeOTLPAttributes(attrs []*commonv1.KeyValue) string {
-	parts := make([]string, 0, len(attrs))
-	for _, attr := range attrs {
-		parts = append(parts, attr.GetKey()+"="+attr.GetValue().GetStringValue())
-	}
-	sort.Strings(parts)
-	return strings.Join(parts, ",")
-}
-
-func serializeMetricAttributes(attrs map[string]string) string {
-	parts := make([]string, 0, len(attrs))
-	for key, value := range attrs {
-		parts = append(parts, key+"="+value)
-	}
-	sort.Strings(parts)
-	return strings.Join(parts, ",")
+	return true
 }
 
 var nextTestPort atomic.Int32 // zero value; first allocation returns 19100

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -27,6 +27,7 @@ const (
 
 	attrProvider       = attribute.Key("gestalt.provider")
 	attrOperation      = attribute.Key("gestalt.operation")
+	attrTransport      = attribute.Key("gestalt.transport")
 	attrUserID         = attribute.Key("gestalt.user_id")
 	attrConnectionMode = attribute.Key("gestalt.connection_mode")
 )
@@ -123,11 +124,28 @@ func (b *Broker) ListCapabilities() []core.Capability {
 	return caps
 }
 
-func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
+func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (_ *core.OperationResult, err error) {
+	startedAt := time.Now()
+	metricProvider := unknownMetricAttrValue
+	metricOperation := unknownMetricAttrValue
+	metricTransport := unknownMetricAttrValue
+	metricConnectionMode := unknownMetricAttrValue
+
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "broker.invoke",
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	defer span.End()
+	defer func() {
+		recordOperationMetrics(
+			ctx,
+			startedAt,
+			metricProvider,
+			metricOperation,
+			metricTransport,
+			metricConnectionMode,
+			err != nil,
+		)
+	}()
 
 	span.SetAttributes(
 		attrProvider.String(providerName),
@@ -150,7 +168,9 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		return fail(err)
 	}
 
-	span.SetAttributes(attrConnectionMode.String(string(prov.ConnectionMode())))
+	metricProvider = providerName
+	metricConnectionMode = normalizeConnectionMode(prov.ConnectionMode())
+	span.SetAttributes(attrConnectionMode.String(metricConnectionMode))
 
 	if p == nil {
 		return fail(ErrNotAuthenticated)
@@ -164,7 +184,11 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		return fail(fmt.Errorf("%w: %s", ErrScopeDenied, providerName))
 	}
 
-	if !catalogHasOperation(providerCatalog(prov), operation) {
+	if transport, ok := catalogOperationTransport(providerCatalog(prov), operation); ok {
+		metricOperation = operation
+		metricTransport = metricAttrValue(transport)
+		span.SetAttributes(attrTransport.String(metricTransport))
+	} else {
 		return fail(fmt.Errorf("%w: %q on provider %q", ErrOperationNotFound, operation, providerName))
 	}
 

--- a/gestaltd/internal/invocation/capabilities.go
+++ b/gestaltd/internal/invocation/capabilities.go
@@ -64,14 +64,18 @@ func providerCatalog(prov core.Provider) *catalog.Catalog {
 	return prov.Catalog()
 }
 
-func catalogHasOperation(cat *catalog.Catalog, operation string) bool {
+func catalogOperationTransport(cat *catalog.Catalog, operation string) (string, bool) {
 	if cat == nil || strings.TrimSpace(operation) == "" {
-		return false
+		return "", false
 	}
 	for i := range cat.Operations {
 		if cat.Operations[i].ID == operation {
-			return true
+			transport := strings.TrimSpace(cat.Operations[i].Transport)
+			if transport == "" && strings.TrimSpace(cat.Operations[i].Method) != "" {
+				transport = catalog.TransportREST
+			}
+			return transport, true
 		}
 	}
-	return false
+	return "", false
 }

--- a/gestaltd/internal/invocation/metrics.go
+++ b/gestaltd/internal/invocation/metrics.go
@@ -1,0 +1,107 @@
+package invocation
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	noopmetric "go.opentelemetry.io/otel/metric/noop"
+)
+
+const unknownMetricAttrValue = "unknown"
+
+type operationMetrics struct {
+	count      metric.Int64Counter
+	errorCount metric.Int64Counter
+	duration   metric.Float64Histogram
+}
+
+var (
+	operationMetricsOnce sync.Once
+	operationMetricState operationMetrics
+)
+
+func recordOperationMetrics(
+	ctx context.Context,
+	startedAt time.Time,
+	provider string,
+	operation string,
+	transport string,
+	connectionMode string,
+	failed bool,
+) {
+	metrics := loadOperationMetrics()
+	attrs := []attribute.KeyValue{
+		attrProvider.String(metricAttrValue(provider)),
+		attrOperation.String(metricAttrValue(operation)),
+		attrTransport.String(metricAttrValue(transport)),
+		attrConnectionMode.String(metricAttrValue(connectionMode)),
+	}
+
+	metrics.count.Add(ctx, 1, metric.WithAttributes(attrs...))
+	metrics.duration.Record(ctx, time.Since(startedAt).Seconds(), metric.WithAttributes(attrs...))
+	if failed {
+		metrics.errorCount.Add(ctx, 1, metric.WithAttributes(attrs...))
+	}
+}
+
+func loadOperationMetrics() operationMetrics {
+	operationMetricsOnce.Do(func() {
+		meter := otel.Meter(tracerName)
+
+		count, err := meter.Int64Counter(
+			"gestaltd.operation.count",
+			metric.WithDescription("Counts gestaltd operation invocations."),
+		)
+		if err != nil {
+			otel.Handle(err)
+			count = noopmetric.Int64Counter{}
+		}
+
+		errorCount, err := meter.Int64Counter(
+			"gestaltd.operation.error_count",
+			metric.WithDescription("Counts gestaltd operation invocations that fail."),
+		)
+		if err != nil {
+			otel.Handle(err)
+			errorCount = noopmetric.Int64Counter{}
+		}
+
+		duration, err := meter.Float64Histogram(
+			"gestaltd.operation.duration",
+			metric.WithDescription("Measures gestaltd operation invocation duration."),
+			metric.WithUnit("s"),
+		)
+		if err != nil {
+			otel.Handle(err)
+			duration = noopmetric.Float64Histogram{}
+		}
+
+		operationMetricState = operationMetrics{
+			count:      count,
+			errorCount: errorCount,
+			duration:   duration,
+		}
+	})
+
+	return operationMetricState
+}
+
+func metricAttrValue(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return unknownMetricAttrValue
+	}
+	return value
+}
+
+func normalizeConnectionMode(mode core.ConnectionMode) string {
+	if mode == "" {
+		return string(core.ConnectionModeUser)
+	}
+	return string(mode)
+}

--- a/gestaltd/internal/invocation/metrics.go
+++ b/gestaltd/internal/invocation/metrics.go
@@ -21,10 +21,28 @@ type operationMetrics struct {
 	duration   metric.Float64Histogram
 }
 
-var (
-	operationMetricsOnce sync.Once
-	operationMetricState operationMetrics
-)
+var operationMetricsOnce = sync.OnceValue(func() operationMetrics {
+	meter := otel.Meter(tracerName)
+
+	return operationMetrics{
+		count: newInt64Counter(
+			meter,
+			"gestaltd.operation.count",
+			"Counts gestaltd operation invocations.",
+		),
+		errorCount: newInt64Counter(
+			meter,
+			"gestaltd.operation.error_count",
+			"Counts gestaltd operation invocations that fail.",
+		),
+		duration: newFloat64Histogram(
+			meter,
+			"gestaltd.operation.duration",
+			"Measures gestaltd operation invocation duration.",
+			"s",
+		),
+	}
+})
 
 func recordOperationMetrics(
 	ctx context.Context,
@@ -35,7 +53,7 @@ func recordOperationMetrics(
 	connectionMode string,
 	failed bool,
 ) {
-	metrics := loadOperationMetrics()
+	metrics := operationMetricsOnce()
 	attrs := []attribute.KeyValue{
 		attrProvider.String(metricAttrValue(provider)),
 		attrOperation.String(metricAttrValue(operation)),
@@ -50,46 +68,26 @@ func recordOperationMetrics(
 	}
 }
 
-func loadOperationMetrics() operationMetrics {
-	operationMetricsOnce.Do(func() {
-		meter := otel.Meter(tracerName)
+func newInt64Counter(meter metric.Meter, name, desc string) metric.Int64Counter {
+	counter, err := meter.Int64Counter(name, metric.WithDescription(desc))
+	if err != nil {
+		otel.Handle(err)
+		return noopmetric.Int64Counter{}
+	}
+	return counter
+}
 
-		count, err := meter.Int64Counter(
-			"gestaltd.operation.count",
-			metric.WithDescription("Counts gestaltd operation invocations."),
-		)
-		if err != nil {
-			otel.Handle(err)
-			count = noopmetric.Int64Counter{}
-		}
-
-		errorCount, err := meter.Int64Counter(
-			"gestaltd.operation.error_count",
-			metric.WithDescription("Counts gestaltd operation invocations that fail."),
-		)
-		if err != nil {
-			otel.Handle(err)
-			errorCount = noopmetric.Int64Counter{}
-		}
-
-		duration, err := meter.Float64Histogram(
-			"gestaltd.operation.duration",
-			metric.WithDescription("Measures gestaltd operation invocation duration."),
-			metric.WithUnit("s"),
-		)
-		if err != nil {
-			otel.Handle(err)
-			duration = noopmetric.Float64Histogram{}
-		}
-
-		operationMetricState = operationMetrics{
-			count:      count,
-			errorCount: errorCount,
-			duration:   duration,
-		}
-	})
-
-	return operationMetricState
+func newFloat64Histogram(meter metric.Meter, name, desc, unit string) metric.Float64Histogram {
+	histogram, err := meter.Float64Histogram(
+		name,
+		metric.WithDescription(desc),
+		metric.WithUnit(unit),
+	)
+	if err != nil {
+		otel.Handle(err)
+		return noopmetric.Float64Histogram{}
+	}
+	return histogram
 }
 
 func metricAttrValue(value string) string {


### PR DESCRIPTION
## Summary
- add custom broker-level OTEL metrics for gestaltd operation count, error count, and duration
- tag those metrics with normalized provider, operation, transport, and connection mode dimensions
- extend the existing OTLP end-to-end test to assert the emitted metric names and tag sets, including an error path

## Metric dimensions
- `gestalt.provider`: the integration key when the provider exists, otherwise `unknown`
- `gestalt.operation`: the catalog operation id when it exists, otherwise `unknown`
- `gestalt.transport`: the operation transport from the catalog (`plugin`, `rest`, or `mcp-passthrough`), otherwise `unknown`
- `gestalt.connection_mode`: the provider auth mode (`none`, `user`, `identity`, or `either`); empty mode is normalized to `user`

## Notes
- this intentionally does not add egress metrics yet
- unknown provider or operation inputs are normalized to `unknown` in metrics to avoid unbounded cardinality from user-supplied route params

## Validation
- `go test ./cmd/gestaltd`
- `go test ./internal/invocation`
- `golangci-lint run ./cmd/gestaltd ./internal/invocation`