### PR TITLE
[codex] simplify dockerfiles and align docker docs

### DIFF
--- a/.github/workflows/publish-gestaltd-image.yml
+++ b/.github/workflows/publish-gestaltd-image.yml
@@ -62,5 +62,5 @@ jobs:
           username: ${{ secrets.DOCKERHUB_DESCRIPTION_USERNAME }}
           password: ${{ secrets.DOCKERHUB_DESCRIPTION_PASSWORD }}
           repository: ${{ env.IMAGE_NAME }}
-          short-description: Self-hosted integration runtime for REST, GraphQL, MCP, and plugins.
+          short-description: Platform for self-hostable, configurable integrations and tooling
           readme-filepath: docs/dockerhub/gestaltd.md

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -168,7 +168,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_DESCRIPTION_USERNAME }}
           password: ${{ secrets.DOCKERHUB_DESCRIPTION_PASSWORD }}
           repository: ${{ env.IMAGE_NAME }}
-          short-description: Self-hosted integration runtime for REST, GraphQL, MCP, and plugins.
+          short-description: Platform for self-hostable, configurable integrations and tooling
           readme-filepath: docs/dockerhub/gestaltd.md
 
   update-formula:

--- a/docs/dockerhub/gestalt.md
+++ b/docs/dockerhub/gestalt.md
@@ -12,7 +12,7 @@
 
 - Image: `valontechnologies/gestalt`
 - Entrypoint: `/gestalt`
-- This image contains a statically linked binary on a distroless base. There is no shell.
+- This image runs the `gestalt` CLI on a distroless base. There is no shell.
 
 ## Supported tags
 
@@ -23,8 +23,9 @@ The image is published for `linux/amd64` and `linux/arm64`.
 
 ## What the image includes
 
-The image uses `gcr.io/distroless/static-debian12` as its base and contains
-only the `gestalt` binary and CA certificates. It runs as `nobody:nobody`.
+The image uses `gcr.io/distroless/cc-debian12` as its base and contains the
+`gestalt` binary on a minimal distroless runtime with CA certificates. It runs
+as `nonroot:nonroot`.
 
 ## Usage
 
@@ -57,13 +58,13 @@ binary is inconvenient:
 jobs:
   check-integrations:
     runs-on: ubuntu-latest
-    container:
-      image: valontechnologies/gestalt:latest
     steps:
-      - run: gestalt integrations list --format json
-        env:
-          GESTALT_URL: ${{ vars.GESTALT_URL }}
-          GESTALT_API_KEY: ${{ secrets.GESTALT_API_KEY }}
+      - run: |
+          docker run --rm \
+            -e GESTALT_URL="${{ vars.GESTALT_URL }}" \
+            -e GESTALT_API_KEY="${{ secrets.GESTALT_API_KEY }}" \
+            valontechnologies/gestalt:latest \
+            integrations list --format json
 ```
 
 ## Available commands

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -1,6 +1,6 @@
 # gestaltd Docker image
 
-`gestaltd` is a self-hosted integration gateway. You describe your platform in one YAML file, and `gestaltd` turns that file into a running server with:
+`gestaltd` is a platform for self-hostable, configurable integrations and tooling. You describe your platform in one YAML file, and `gestaltd` turns that file into a running server with:
 
 - an HTTP API
 - an embedded web UI
@@ -15,10 +15,11 @@
 - Default command:
 
   ```sh
-  /gestaltd serve --locked --config /etc/gestalt/config.yaml
+  /gestaltd serve --locked --config /etc/gestalt/config.yaml --artifacts-dir /data
   ```
 
 - Default config path: `/etc/gestalt/config.yaml`
+- Default writable data and artifacts dir: `/data`
 - This image is not zero-config. Mount or bake a config file before starting it.
 - Locked startup is the default. If your config uses `providers.*.from.package`,
   `providers.*.from.source`, or a packaged UI, run `init` first.
@@ -35,7 +36,9 @@ The image is published for `linux/amd64` and `linux/arm64`.
 
 ## What the image includes
 
-The image is Alpine-based and includes `gestaltd`, a shell, and `ca-certificates`. It runs as `nobody:nobody` by default.
+The image is Alpine-based and includes `gestaltd`, a shell, and
+`ca-certificates`. It runs as `nobody:nobody` by default and pre-creates
+`/data` as a writable directory for SQLite and prepared artifacts.
 
 ## Run a simple static config
 
@@ -44,10 +47,15 @@ If your config does not need prepared artifacts, mount it directly:
 ```sh
 docker run --rm \
   -p 8080:8080 \
+  -e GESTALT_ENCRYPTION_KEY=change-me \
   -v "$(pwd)/gestalt.yaml:/etc/gestalt/config.yaml:ro" \
   -v gestalt-data:/data \
   valontechnologies/gestaltd:latest
 ```
+
+The default image command still points `--artifacts-dir` at `/data`, so keeping
+that volume mounted is the safe default even when your current config does not
+need prepared plugins.
 
 Example minimal config:
 
@@ -69,21 +77,32 @@ providers: {}
 
 ## Run a prepared production image
 
-If your config uses `providers.*.from.package`, `providers.*.from.source`, or a packaged UI,
-prepare it during the image build:
+For deterministic production images, run `gestaltd init` before `docker build`
+and copy the prepared state into the image.
+
+For a config at `deploy/config.yaml`, `init` writes:
+
+```text
+deploy/
+  config.yaml
+  gestalt.lock.json
+  .gestaltd/providers/...
+  .gestaltd/plugins/...
+```
+
+Build the image from that prepared directory:
 
 ```dockerfile
-FROM valontechnologies/gestaltd:latest AS init
-USER root
-COPY config.yaml /app/config.yaml
-RUN ["/gestaltd", "init", "--config", "/app/config.yaml"]
-
 FROM valontechnologies/gestaltd:latest
-COPY --from=init /app/ /app/
+COPY deploy/ /app/
 CMD ["serve", "--locked", "--config", "/app/config.yaml"]
 ```
 
 This is the recommended production pattern.
+
+If you intentionally want the image build itself to generate prepared state,
+`RUN gestaltd init` in a build stage also works, but it is a build-time
+convenience rather than the primary deterministic workflow.
 
 ## Compose example
 

--- a/docs/pages/concepts/configuration.mdx
+++ b/docs/pages/concepts/configuration.mdx
@@ -78,8 +78,8 @@ This is convenient for development.
 `gestaltd init --config PATH` resolves remote dependencies and writes lock state next to the config:
 
 - `gestalt.lock.json`
-- `.gestalt/providers/*.json`
-- `.gestalt/plugins/...`
+- `.gestaltd/providers/*.json`
+- `.gestaltd/plugins/...`
 
 After that, `gestaltd serve --locked --config PATH` starts only if the prepared state exactly matches the config.
 

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -33,6 +33,7 @@ server:
   base_url: https://gestalt.example.com
   encryption_key: secret://gestalt-encryption-key
   api_token_ttl: 30d
+  artifacts_dir: ./state
 ```
 
 | Field | Required | Default | Purpose |
@@ -41,6 +42,7 @@ server:
 | `base_url` | No | — | Derives OAuth callback URLs when explicit redirect URLs are omitted. |
 | `encryption_key` | Yes | — | Root deployment secret. Used for encryption and derived session material. |
 | `api_token_ttl` | No | `30d` | Lifetime of newly issued API tokens. Accepts Go duration strings (`1h`, `720h`) and day suffixes (`30d`). |
+| `artifacts_dir` | No | Config file directory | Writable directory for prepared providers and plugins produced by `init` and consumed by locked startup when no CLI override is supplied. |
 
 ## `auth`
 

--- a/docs/pages/reference/docker-image.mdx
+++ b/docs/pages/reference/docker-image.mdx
@@ -1,12 +1,19 @@
-# Docker Image
+# Server Docker Image
 
 The published image is `valontechnologies/gestaltd:latest`.
 
 ## Quick start
 
 ```sh
-docker run -p 8080:8080 valontechnologies/gestaltd
+docker run --rm \
+  -p 8080:8080 \
+  -e GESTALT_ENCRYPTION_KEY=change-me \
+  -v "$(pwd)/config.yaml:/etc/gestalt/config.yaml:ro" \
+  -v gestalt-data:/data \
+  valontechnologies/gestaltd:latest
 ```
+
+The image is not zero-config. Mount or bake a config file before starting it.
 
 ## Image details
 
@@ -15,8 +22,9 @@ docker run -p 8080:8080 valontechnologies/gestaltd
 | Image | `valontechnologies/gestaltd:latest` |
 | Port | `8080` |
 | Entrypoint | `/gestaltd` |
-| Default command | `serve --locked --config /etc/gestalt/config.yaml` |
+| Default command | `serve --locked --config /etc/gestalt/config.yaml --artifacts-dir /data` |
 | Config path | `/etc/gestalt/config.yaml` |
+| Writable data and artifacts dir | `/data` |
 
 ## Environment variables
 
@@ -34,28 +42,41 @@ services:
       - "8080:8080"
     volumes:
       - ./config.yaml:/etc/gestalt/config.yaml:ro
+      - gestalt-data:/data
     environment:
       GESTALT_BASE_URL: http://localhost:8080
       GESTALT_ENCRYPTION_KEY: dev-only-change-me
+
+volumes:
+  gestalt-data:
 ```
 
 ## Production image
 
-For production, run `gestaltd init` locally to resolve plugins and generate
-a lock file, then commit both the config and lock file to your repo. At
-build time, copy them into a derived image:
+For deterministic production images, run `gestaltd init` before `docker build`
+and copy the prepared state into the image.
 
-```
+For a config at `deploy/config.yaml`, `init` writes:
+
+```text
 deploy/
   config.yaml
   gestalt.lock.json
+  .gestaltd/providers/...
+  .gestaltd/plugins/...
 ```
+
+Build the image from that prepared directory:
 
 ```dockerfile
-FROM valontechnologies/gestaltd
-COPY deploy/ /etc/gestalt/
+FROM valontechnologies/gestaltd:latest
+COPY deploy/ /app/
+CMD ["serve", "--locked", "--config", "/app/config.yaml"]
 ```
 
-The image starts with `serve --locked` by default, so it will use the
-committed lock file without fetching anything at runtime. This gives you a
-fully self-contained, deterministic image.
+This keeps the prepared state next to the config inside the derived image and
+avoids relying on the base image's default `--artifacts-dir /data` override.
+
+If you intentionally want the image build itself to generate prepared state,
+`RUN gestaltd init` in a build stage also works, but it should be treated as a
+build-time convenience rather than the primary deterministic workflow.

--- a/gestalt/Dockerfile
+++ b/gestalt/Dockerfile
@@ -7,15 +7,14 @@ ARG GESTALT_URL=https://hub.docker.com/r/valontechnologies/gestalt
 
 FROM --platform=$BUILDPLATFORM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS unpack
 ARG TARGETARCH
-WORKDIR /dist
-COPY dist/ /dist/
+COPY dist/gestalt-linux-*.tar.gz /dist/
 RUN case "$TARGETARCH" in \
-      amd64) archive=gestalt-linux-x86_64.tar.gz ;; \
-      arm64) archive=gestalt-linux-arm64.tar.gz ;; \
+      amd64) archive=/dist/gestalt-linux-x86_64.tar.gz ;; \
+      arm64) archive=/dist/gestalt-linux-arm64.tar.gz ;; \
       *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
     esac && \
     mkdir -p /out && \
-    tar -xzf "/dist/$archive" -C /out && \
+    tar -xzf "$archive" -C /out && \
     test -x /out/gestalt
 
 FROM gcr.io/distroless/cc-debian12@sha256:329e54034ce498f9c6b345044e8f530c6691f99e94a92446f68c0adf9baa8464

--- a/gestaltd/Dockerfile
+++ b/gestaltd/Dockerfile
@@ -21,7 +21,6 @@ COPY . .
 COPY --from=frontend /ui/out/ gestaltd/internal/webui/out/
 ARG TARGETARCH
 RUN cd gestaltd && CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /gestaltd ./cmd/gestaltd
-RUN mkdir /data
 
 FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 ARG GESTALT_VERSION
@@ -34,7 +33,7 @@ RUN apk upgrade --no-cache && apk add --no-cache ca-certificates
 COPY --from=build-binary /gestaltd /gestaltd
 RUN mkdir -p /data && chown nobody:nobody /data
 LABEL org.opencontainers.image.title="gestaltd" \
-      org.opencontainers.image.description="Self-hosted integration server for REST, GraphQL, MCP, and plugins." \
+      org.opencontainers.image.description="Platform for self-hostable, configurable integrations and tooling" \
       org.opencontainers.image.source="${GESTALT_SOURCE}" \
       org.opencontainers.image.documentation="${GESTALT_DOCUMENTATION}" \
       org.opencontainers.image.url="${GESTALT_URL}" \


### PR DESCRIPTION
## What changed

This PR tightens the two Dockerfiles and brings the Docker image docs back in sync with the code and publish workflows.

It includes:

- a small cleanup in `gestaltd/Dockerfile` by removing an unused build-stage `/data` creation step
- a simplification in `gestalt/Dockerfile` so the unpack stage only copies the Linux tarballs it actually uses
- an updated `gestaltd` OCI/Docker Hub description: `Platform for self-hostable, configurable integrations and tooling`
- fixes to the CLI Docker Hub docs so they match the actual image runtime (`distroless/cc-debian12`, `nonroot:nonroot`, no shell-based CI container example)
- fixes to the `gestaltd` Docker docs and site docs so they reflect the actual default command and `/data` usage
- documentation for `server.artifacts_dir`
- correction of the deterministic production guidance: the recommended flow is to run `gestaltd init` before `docker build` and copy in both the lockfile and prepared `.gestaltd/...` artifacts, rather than treating `RUN gestaltd init` inside the Dockerfile as the primary pattern
- correction of stale `.gestalt/...` paths to `.gestaltd/...`

## Why it changed

The Docker and Docker Hub docs had drifted from the shipped image behavior.

In particular:

- the CLI Docker docs described a different distroless base and runtime user than the actual image
- the server docs omitted the image's default `--artifacts-dir /data` behavior
- the production docs implied that a committed lockfile alone was enough for locked startup, but the code also requires prepared artifacts next to the config or in the configured artifacts dir
- the site docs and Docker Hub docs had duplicated Docker image guidance and had fallen out of sync

## Impact

- Docker Hub will show the updated `gestaltd` description
- users reading the CLI image docs will now see the correct runtime characteristics
- users building deterministic `gestaltd` images will get the correct pre-build `init` workflow and artifact layout
- the Dockerfiles remain functionally equivalent, with a small reduction in accidental complexity

## Validation

- `git diff --check`
- manual audit against the Dockerfiles, GitHub publish workflows, and `gestaltd` locked-startup implementation

## Notes

I did not run a full Docker/docs build locally because the workspace machine is nearly out of disk space.
