### PR TITLE
docs: rewrite Concepts pages and add Plugins section

### DIFF
--- a/docs/pages/_meta.ts
+++ b/docs/pages/_meta.ts
@@ -3,6 +3,7 @@ export default {
   introduction: "Introduction",
   "getting-started": "Getting Started",
   concepts: "Concepts",
+  plugins: "Plugins",
   deploy: "Deploy",
   reference: "Reference",
   troubleshooting: "Troubleshooting",

--- a/docs/pages/concepts/authentication-and-tokens.mdx
+++ b/docs/pages/concepts/authentication-and-tokens.mdx
@@ -1,14 +1,10 @@
-# Authentication And Tokens
+# Authentication and Tokens
 
-Gestalt has three separate credential layers:
+Gestalt manages three separate credential layers: platform authentication for users of Gestalt itself, integration authentication for outbound calls to upstream APIs, and API tokens for programmatic access.
 
-- platform auth for the human caller of the server
-- integration auth for outbound calls to upstream systems
-- API tokens for programmatic access to Gestalt itself
+## Platform authentication
 
-## Platform Auth
-
-Platform auth is configured under `auth`.
+Platform auth controls who can log into the Gestalt web UI, call the HTTP API, and connect to `/mcp`. It is configured under the `auth` block:
 
 ```yaml
 auth:
@@ -19,53 +15,38 @@ auth:
     client_secret: ${OIDC_CLIENT_SECRET}
 ```
 
-Built-in platform auth providers are:
+Available providers:
 
-- `none`
-- `local`
-- `google`
-- `oidc`
+| Provider | Description |
+| --- | --- |
+| `none` | Disables authentication. Suitable for local development only. |
+| `local` | Single-user auth for development. No external identity provider required. |
+| `google` | Google OAuth 2.0. Supports `allowed_domains` to restrict access by email domain. |
+| `oidc` | Generic OpenID Connect. Works with Okta, Auth0, Azure AD, Keycloak, and others. |
 
-The platform auth provider controls login to the UI, authenticated HTTP routes,
-and `/mcp`.
+## Integration authentication
 
-## Integration Auth
+Integration auth defines how Gestalt connects to upstream APIs on behalf of users. It is configured per-provider under `connections`:
 
-Integration auth lives inside `providers.*.connections`.
+| Auth type | Description |
+| --- | --- |
+| `none` | No credential is needed. Used with `mode: none` connections. |
+| `oauth2` | User-scoped or shared OAuth 2.0 flows. |
+| `bearer` | User-provided bearer tokens. |
+| `manual` | User-provided credentials with custom field definitions. |
+| `mcp_oauth` | OAuth for upstream MCP servers that implement the MCP OAuth specification. |
 
-Examples:
+OAuth flows are initiated through the HTTP API (`POST /api/v1/auth/start-oauth`) and completed via callback (`GET /api/v1/auth/callback`). Manual connections are created through `POST /api/v1/auth/connect-manual`.
 
-- `type: none` for public spec-backed surfaces that use a `mode: none`
-  connection
-- `type: oauth2` for user-scoped or shared OAuth flows
-- `type: manual` or `type: bearer` for manually entered credentials
-- `type: mcp_oauth` for upstream MCP servers that implement MCP OAuth
+## Stored connections
 
-OAuth connections are started through `POST /api/v1/auth/start-oauth` and
-completed by `GET /api/v1/auth/callback`.
+Gestalt stores integration credentials keyed by user, integration, connection name, and instance. This allows a single user to maintain multiple connections to the same integration, for example to connect to separate Jira sites or different tenant environments.
 
-Manual connections are created through `POST /api/v1/auth/connect-manual`.
+## API tokens
 
-## Stored Connections
+API tokens provide programmatic access to Gestalt. They authenticate requests to the HTTP API and `/mcp` without requiring a browser session.
 
-Gestalt stores integration credentials by:
-
-- user
-- integration
-- connection name
-- instance
-
-This lets one user keep multiple instances of the same integration, such as:
-
-- separate Jira sites
-- different tenant parameters
-- multiple named auth flows on one integration
-
-## API Tokens
-
-API tokens authenticate callers to Gestalt itself.
-
-Create them with:
+Create a token with the CLI:
 
 ```sh
 gestalt tokens create --name automation
@@ -79,29 +60,18 @@ Authorization: Bearer <session-or-api-token>
 Content-Type: application/json
 ```
 
-They can be scoped to specific integrations and are accepted through:
+Tokens are prefixed with `gst_api_` and accepted via the `Authorization: Bearer` header. The token lifetime is controlled by `server.api_token_ttl` (default: 30 days). Tokens can be scoped to specific integrations and revoked individually or in bulk.
 
-- `Authorization: Bearer gst_api_...`
-- the `gestalt` client CLI
-- authenticated calls to `/mcp`
+## Session cookies
 
-`server.api_token_ttl` controls the token lifetime.
+When platform auth is enabled, browser sessions are stored in a `session_token` cookie with `HttpOnly`, `SameSite=Lax`, and `Secure` (when `server.base_url` uses HTTPS).
 
-## Session Cookies
+## Choosing an auth strategy
 
-When platform auth is enabled, the browser session is stored in a
-`session_token` cookie.
-
-- Cookies are `HttpOnly`.
-- Cookies use `SameSite=Lax`.
-- Cookies are marked `Secure` when `server.base_url` uses `https://`.
-
-## Choosing An Auth Strategy
-
-- Use `auth.provider: none` for local development and trusted internal
-  environments.
-- Use `local` for a single-user dev server that still exercises login flows.
-- Use `google` or `oidc` for normal multi-user deployments.
-- Use OAuth integration auth when each user should bring their own account.
-- Use `identity` mode when the server should call upstreams with one shared
-  service credential.
+| Scenario | Recommended configuration |
+| --- | --- |
+| Local development | `auth.provider: none` |
+| Single-user dev server with login flows | `auth.provider: local` |
+| Multi-user deployment | `auth.provider: google` or `auth.provider: oidc` |
+| Per-user upstream access | `mode: user` on integration connections |
+| Shared service credential | `mode: identity` on integration connections |

--- a/docs/pages/concepts/configuration.mdx
+++ b/docs/pages/concepts/configuration.mdx
@@ -1,108 +1,86 @@
 # Configuration
 
-The Gestalt config file is the platform's control plane. `gestaltd` does not have a large imperative setup process; instead, it reads one YAML document and derives the running system from it.
+Gestalt is configured with a single YAML file. The file declares which platform components to use, which providers to enable, and how they connect to upstream services. `gestaltd` reads this file at startup and derives the entire running system from it.
 
-## Config Discovery
+## Config discovery
 
-When you do not pass `--config`, `gestaltd` resolves the config path in this order:
+When `--config` is not specified, `gestaltd` searches for a config file in the following order:
 
-1. `GESTALT_CONFIG`
+1. The `GESTALT_CONFIG` environment variable
 2. `./config.yaml`
 3. `~/.gestalt/config.yaml`
 4. `/etc/gestalt/config.yaml`
 
-The default command `gestaltd` has one extra behavior: if no config exists anywhere in that search path, it generates `~/.gestalt/config.yaml` and starts with a local-only configuration that uses `auth.provider: none` and SQLite.
+If no config file is found, `gestaltd` generates a default local config at `~/.gestalt/config.yaml` with anonymous auth and SQLite storage.
 
-## Config Loading
+## Config loading
 
-When Gestalt loads a config file, it expands `${ENV_VAR}` placeholders, applies defaults, validates the result, and resolves relative paths against the config file's directory. Later during bootstrap, `secret://...` values are resolved through the configured secret manager.
+During loading, Gestalt expands `${ENV_VAR}` placeholders, applies defaults, validates the result, and resolves file paths relative to the config file's directory. After the platform's secret manager is initialized, `secret://` references are resolved.
 
-## The Top-Level Feature Sets
-
-This is the complete top-level shape of the config:
+## Top-level blocks
 
 ```yaml
+server: {}
 auth: {}
 datastore: {}
 secrets: {}
 telemetry: {}
 providers: {}
-server: {}
 ui: {}
 ```
 
-Each block controls a distinct part of the runtime:
-
-| Block | What it defines |
+| Block | Role |
 | --- | --- |
 | `server` | Port, base URL, encryption key, and API token TTL. |
-| `auth` | How users authenticate to Gestalt itself. |
-| `datastore` | Where Gestalt stores users, tokens, and related runtime state. |
-| `secrets` | How `secret://...` values are resolved. |
-| `telemetry` | Observability: traces, metrics, and structured logs. |
-| `providers` | The provider graph users call. |
+| `auth` | Platform authentication provider. |
+| `datastore` | Storage backend for users, tokens, and runtime state. |
+| `secrets` | Secret resolution backend for `secret://` references. |
+| `telemetry` | Structured logging, traces, and metrics. |
+| `providers` | Integration definitions. |
 | `ui` | Optional custom web UI plugin. |
 
-## Defaults And Required Fields
+## Defaults and required fields
 
-The loader applies a small number of defaults:
+Gestalt applies these defaults:
 
-- `server.port` defaults to `8080`
-- `secrets.provider` defaults to `env`
-- `telemetry.provider` defaults to `stdout`
+- `server.port`: `8080`
+- `secrets.provider`: `env`
+- `telemetry.provider`: `stdout`
 
-Some fields are effectively mandatory:
+These fields are required:
 
 - `auth.provider`
 - `datastore.provider`
 - `server.encryption_key`
 
-`server.encryption_key` is the root secret for the deployment. Gestalt derives other cryptographic material from it, including session-related secrets for some auth providers.
+The encryption key is the root secret for the deployment. Gestalt derives all cryptographic material from it, including keys for token encryption and session signing.
 
-## Prepared State: `init`, `validate`, And `serve --locked`
+## Prepared state
 
-Gestalt supports both mutable startup and deterministic startup.
+Gestalt supports two startup modes: mutable and deterministic.
 
-### Mutable Startup
+In **mutable mode** (`gestaltd serve`), Gestalt may fetch remote specs, prepare plugins, and regenerate lock state at startup. This is convenient for development.
 
-`gestaltd` or `gestaltd serve` without `--locked` may mutate local state at startup:
-
-- remote REST or GraphQL API sources can be fetched and compiled
-- packaged plugins can be prepared locally
-- missing or stale lock state can be regenerated
-
-This is convenient for development.
-
-### Deterministic Startup
-
-`gestaltd init --config PATH` resolves remote dependencies and writes lock state next to the config:
+In **deterministic mode**, you first run `gestaltd init` to resolve all remote dependencies and write lock state:
 
 - `gestalt.lock.json`
-- `.gestaltd/providers/*.json`
-- `.gestaltd/plugins/...`
+- `.gestalt/providers/`
+- `.gestalt/plugins/`
 
-After that, `gestaltd serve --locked --config PATH` starts only if the prepared state exactly matches the config.
+Then `gestaltd serve --locked` starts the server only if the lock state matches the config exactly. This is the recommended mode for production.
 
-### Validation
-
-`gestaltd validate --config PATH` is non-mutating and expects existing lock state. Init first, then validate:
+To validate a config without starting the server:
 
 ```sh
 gestaltd init --config ./config.yaml
 gestaltd validate --config ./config.yaml
 ```
 
-## Relative Paths
+## Path resolution
 
-Paths in config are resolved relative to the config file directory, not the process working directory. This matters for:
+All file paths in the config are resolved relative to the directory containing the config file, not the working directory of the process. This makes configs portable across local development, Docker mounts, and Kubernetes volumes.
 
-- `providers.<name>.icon_file`
-- `providers.<name>.from.command`
-- local `providers.<name>.from.package` paths
-
-That makes configs portable across local runs, Docker mounts, and Kubernetes volumes.
-
-## The Smallest Explicit Config
+## Minimal config
 
 ```yaml
 server:
@@ -121,4 +99,4 @@ datastore:
 providers: {}
 ```
 
-That is enough to boot a real server. Everything else is additive.
+This is sufficient to start a working server. All other configuration is additive.

--- a/docs/pages/concepts/integrations.mdx
+++ b/docs/pages/concepts/integrations.mdx
@@ -1,43 +1,19 @@
 # Integrations
 
-Gestalt still talks about integrations in the API and UI, but config now
-declares them under `providers:`. Each configured provider becomes one runtime
-provider that callers invoke through the shared broker.
+Each entry under `providers:` in the config defines an integration. At startup, Gestalt builds each entry into a runtime provider that can be invoked through the HTTP API, the web UI, or `/mcp`.
 
-## Provider Shape
+## Provider structure
 
-```yaml
-providers:
-  gmail:
-    display_name: Gmail
-    description: Read and send Gmail messages
-    from:
-      package: ./dist/gmail-plugin.tar.gz
-    mcp:
-      enabled: true
-      tool_prefix: gmail_
-```
+A provider entry can include any combination of the following:
 
-Each entry can combine:
+- A `from` block that references an executable plugin or packaged provider
+- One or more `connections` that define upstream authentication
+- An API surface (`surfaces.rest`, `surfaces.openapi`, `surfaces.graphql`, or `surfaces.mcp`)
+- Optional `managed_parameters`, `response_mapping`, `allowed_operations`, and `headers`
 
-- an optional `from` block for executable or packaged behavior
-- `connections`
-- one API surface under `surfaces.rest`, `surfaces.openapi`, or `surfaces.graphql`
-- an optional `surfaces.mcp`
-- optional `headers`, `managed_parameters`, `response_mapping`, and `allowed_operations`
+## Examples
 
-## The Four Main Patterns
-
-| Pattern | Use it for |
-| --- | --- |
-| Inline declarative provider | Small custom REST APIs where writing a binary would be overkill. |
-| Inline spec-backed provider | OpenAPI, GraphQL, or upstream MCP surfaces that Gestalt can load directly. |
-| Packaged provider plugin | Custom logic that belongs in code or ships as a reusable package. |
-| Hybrid provider | A packaged plugin combined with OpenAPI, GraphQL, or MCP surfaces. |
-
-## Inline Declarative Providers
-
-Inline declarative providers use `surfaces.rest`.
+### REST operations defined in YAML
 
 ```yaml
 providers:
@@ -59,12 +35,7 @@ providers:
             path: /tickets
 ```
 
-This is the simplest path when you already know the exact operations you want.
-
-## Inline Spec-Backed Providers
-
-Inline spec-backed providers load operations from OpenAPI, GraphQL, or upstream
-MCP.
+### Operations loaded from an OpenAPI spec
 
 ```yaml
 providers:
@@ -86,31 +57,31 @@ providers:
       tool_prefix: httpbin_
 ```
 
-`allowed_operations` narrows the exposed surface and can rename operations with
-`alias`.
+Use `allowed_operations` to restrict which operations are exposed and to rename them with `alias`.
 
-## Packaged Provider Plugins
-
-Packaged providers come from one of three sources:
-
-- `command`: run an executable directly
-- `package`: load a local directory, local archive, or HTTPS archive
-- `source` plus `version`: resolve a published plugin package during `init`
+### Packaged plugin
 
 ```yaml
 providers:
-  support:
-    display_name: Support
+  gmail:
+    display_name: Gmail
+    description: Read and send Gmail messages
     from:
-      package: ./dist/support-plugin.tar.gz
+      package: ./dist/gmail-plugin.tar.gz
+    mcp:
+      enabled: true
+      tool_prefix: gmail_
 ```
 
-Packaged providers carry their own manifests, auth model, and operation
-catalog.
+The three ways to reference a plugin are:
 
-## Hybrid Providers
+- `from.command`: run an executable directly (best for local development)
+- `from.package`: load a local directory, local archive, or HTTPS archive
+- `from.source` with `from.version`: resolve a published plugin during `gestaltd init`
 
-A packaged provider can also layer in spec-backed surfaces.
+### Plugin with additional API surfaces
+
+A packaged plugin can also expose spec-backed surfaces alongside its own operations:
 
 ```yaml
 providers:
@@ -137,13 +108,9 @@ providers:
       tool_prefix: support_
 ```
 
-This is useful when a plugin provides custom code while the API or MCP surface
-still comes from a spec or upstream server.
-
 ## Connections
 
-Gestalt resolves credentials through `connections.default` plus any optional
-named connections.
+Each provider defines one or more connections that control how Gestalt authenticates with the upstream API.
 
 ```yaml
 connections:
@@ -164,76 +131,46 @@ connections:
       type: mcp_oauth
 ```
 
-Rules:
+`connections.default` is the primary connection and is the only connection that may define `params` and `discovery`. Named connections (like `mcp` above) are used when different surfaces require different authentication. Each surface specifies which connection it uses via the `connection` field.
 
-- `connections.default` is the primary connection
-- only `connections.default` may define `params` and `discovery`
-- if you omit `connections.default` and keep only named connections, each
-  configured surface must set `connection`
+### Connection modes
 
-### Connection Modes
-
-| Mode | Meaning |
+| Mode | Description |
 | --- | --- |
-| `none` | No stored credential is needed. |
-| `user` | Use a user-scoped stored connection. |
-| `identity` | Use a shared service identity. |
-| `either` | Prefer user auth and fall back to the shared identity. |
+| `none` | No credential is needed. |
+| `user` | Each user authenticates individually. |
+| `identity` | A single shared service credential is used. |
+| `either` | User credentials are preferred, with fallback to the shared identity. |
 
-## Managed Parameters
+## Managed parameters
 
-`managed_parameters` inject fixed values into headers or path placeholders
-before an operation is exposed.
-
-```yaml
-providers:
-  workspace:
-    connections:
-      default:
-        mode: none
-        auth:
-          type: none
-    surfaces:
-      openapi:
-        document: ./openapi/workspace.yaml
-    managed_parameters:
-      - in: header
-        name: X-API-Version
-        value: "2026-04-01"
-      - in: path
-        name: account_id
-        value: primary
-```
-
-Path managed parameters remove the corresponding user parameter from the
-exposed operation signature.
-
-## Response Mapping
-
-`response_mapping` is available for OpenAPI and GraphQL providers when the
-upstream response needs a stable data path or pagination hints.
+`managed_parameters` inject fixed values into headers or path placeholders before an operation is exposed to callers. Path parameters that are managed are removed from the operation's input signature.
 
 ```yaml
-providers:
-  catalog:
-    connections:
-      default:
-        auth:
-          type: bearer
-    surfaces:
-      graphql:
-        url: https://api.example.com/graphql
-    response_mapping:
-      data_path: data.items
-      pagination:
-        has_more_path: pageInfo.hasNextPage
-        cursor_path: pageInfo.endCursor
+managed_parameters:
+  - in: header
+    name: X-API-Version
+    value: "2026-04-01"
+  - in: path
+    name: account_id
+    value: primary
 ```
 
-## Tool Naming On `/mcp`
+## Response mapping
 
-Use `mcp.tool_prefix` to keep tool names stable and collision-free when
-several providers expose operations with similar names.
+`response_mapping` controls how Gestalt extracts data and pagination metadata from upstream responses:
+
+```yaml
+response_mapping:
+  data_path: data.items
+  pagination:
+    has_more_path: pageInfo.hasNextPage
+    cursor_path: pageInfo.endCursor
+```
+
+## MCP tool naming
+
+Use `mcp.tool_prefix` to namespace tool names and prevent collisions when multiple providers expose operations with similar names:
 
 ```yaml
 providers:
@@ -242,12 +179,3 @@ providers:
       enabled: true
       tool_prefix: slack_
 ```
-
-## Choosing The Right Pattern
-
-- Start with inline declarative YAML for a tiny REST surface.
-- Use OpenAPI, GraphQL, or `surfaces.mcp` when the upstream already publishes a
-  discoverable surface.
-- Use packaged providers when behavior belongs in code or needs to be
-  versioned.
-- Use a hybrid provider when you want packaged logic plus spec-backed coverage.

--- a/docs/pages/concepts/mcp-binding.mdx
+++ b/docs/pages/concepts/mcp-binding.mdx
@@ -1,35 +1,20 @@
 # MCP
 
-Gestalt exposes one MCP endpoint at `/mcp`.
+Gestalt exposes a single MCP endpoint at `/mcp`. AI agents, coding assistants, and other MCP clients can use this endpoint to discover and invoke any provider that has MCP enabled.
 
-## When `/mcp` Exists
+## Availability
 
-The endpoint is mounted when at least one integration declares an MCP-capable
-surface. In practice that includes:
+The `/mcp` endpoint is mounted when at least one provider declares an MCP-capable surface. This includes providers with inline declarative operations, OpenAPI or GraphQL surfaces, upstream MCP connections, and packaged plugins with an operation catalog.
 
-- inline declarative operations
-- OpenAPI-backed integrations
-- GraphQL-backed integrations
-- integrations with `mcp_url`
-- packaged providers whose catalog should be available through MCP
+## Tool discovery
 
-## How Tool Discovery Works
+Gestalt converts provider operation catalogs into MCP tools. HTTP-backed operations become tools that route through the invocation broker. Upstream MCP tools from `surfaces.mcp` are passed through directly. Hybrid providers expose both sets under a single integration.
 
-Gestalt turns provider catalogs into MCP tools.
+Providers that support request-scoped catalogs have their tool lists refreshed at discovery and call time, so the available tools reflect the caller's current connection state.
 
-- HTTP-backed operations become normal tools that route through the invocation
-  broker.
-- Upstream MCP tools can be passed through directly.
-- Hybrid providers expose both sets in one integration catalog.
+## Tool naming
 
-If a provider supports request-scoped catalogs, Gestalt refreshes those tools at
- MCP list or call time so the tool surface reflects the caller's current
- connection.
-
-## Tool Naming
-
-Tool names come from the provider operation IDs. Use `mcp.tool_prefix` on a
-provider to keep names stable across providers.
+Tool names are derived from provider operation IDs. Use `mcp.tool_prefix` to namespace tools and prevent collisions across providers:
 
 ```yaml
 providers:
@@ -41,29 +26,17 @@ providers:
 
 ## Authentication
 
-`/mcp` uses the same auth middleware as the rest of the authenticated API.
+The `/mcp` endpoint uses the same authentication as the rest of the HTTP API. Callers authenticate with a platform session cookie or an API token (`Authorization: Bearer gst_api_...`).
 
-Callers can authenticate with:
+## Connection selection
 
-- a platform session cookie
-- `Authorization: Bearer <gst_api_...>`
+MCP requests follow the same connection resolution logic as the HTTP API. The server resolves the provider's default connection, honors surface-specific connection names, and fails the request if multiple stored instances exist without a unique match.
 
-The endpoint does not have a separate auth model.
-
-## Connection Selection
-
-The same connection logic used by the HTTP API also applies to MCP:
-
-- the server resolves the integration's default connection
-- surface-specific connection names are honored
-- if there are multiple stored instances and no unique match, the call fails
-
-For hybrid providers this means the API-backed and MCP-backed parts of the same
-integration can use different named connections.
+For hybrid providers, the API-backed and MCP-backed surfaces can use different named connections.
 
 ## Example
 
-Assume you already have a local OpenAPI file such as `./openapi/notion.yaml`.
+This configuration exposes a provider with both OpenAPI operations and upstream MCP tools:
 
 ```yaml
 providers:
@@ -92,8 +65,4 @@ providers:
               label: API Token
 ```
 
-With this config:
-
-- the HTTP API exposes the OpenAPI-backed operations
-- `/mcp` exposes the same REST operations plus the upstream Notion MCP tools
-- the upstream MCP tools authenticate through the `MCP` named connection
+With this configuration, the HTTP API exposes the OpenAPI-backed operations, and `/mcp` exposes both the REST operations and the upstream Notion MCP tools. Each surface authenticates through its own named connection.

--- a/docs/pages/concepts/platform-model.mdx
+++ b/docs/pages/concepts/platform-model.mdx
@@ -1,102 +1,55 @@
 # Platform Model
 
-Gestalt has a small number of primitives, but they compose into a full
-integration platform. The easiest way to understand `gestaltd` is to follow the
-startup path from configuration to invocation.
+Gestalt is built on a small set of composable primitives. A single YAML configuration file defines which primitives to use, and `gestaltd` assembles them into a running integration platform at startup.
 
-## The Core Model
+## Primitives
 
-At the highest level, `gestaltd` loads a declarative config file, bootstraps the
-platform components that config names, builds providers from `providers:`, and
-exposes those providers through shared request surfaces.
-
-## The Main Primitives
-
-| Primitive | Purpose |
+| Primitive | Role |
 | --- | --- |
-| `auth` | Authenticates users to Gestalt itself and issues platform sessions. |
-| `datastore` | Persists users, API tokens, integration tokens, and related runtime state. |
-| `secrets` | Resolves `secret://...` references during bootstrap. |
-| `providers` | Define the provider graph users call. Each named entry is provider-shaped directly. |
+| `auth` | Authenticates users to Gestalt and issues platform sessions. |
+| `datastore` | Stores users, API tokens, OAuth credentials, and runtime state. |
+| `secrets` | Resolves `secret://` references in the config at boot time. |
+| `providers` | The integrations that users interact with. Each entry under `providers:` becomes a callable provider. |
 
-## Bootstrap
+## Startup
 
-At startup, `gestaltd` loads the config, expands environment variables and secrets, builds the platform components (auth, datastore, secret manager), builds providers, and starts the HTTP server. See [Configuration](/concepts/configuration) for the full config lifecycle.
+When `gestaltd` starts, it loads the config file, expands environment variables and secret references, builds each platform primitive, builds providers, and starts the HTTP server. See [Configuration](/concepts/configuration) for the full config lifecycle.
 
-## Integrations Become Providers
+## Providers
 
-An integration is a declarative definition. A provider is the executable object
-built from it.
+Each entry under `providers:` in the config becomes a runtime provider. Providers can be built from three sources:
 
-That distinction matters:
-
-- you edit `providers.<name>` in YAML
-- `gestaltd` turns that entry into a provider at startup
-- every request surface invokes the provider, not the raw YAML
-
-Providers come from three sources:
-
-| Source | How it works |
+| Source | Description |
 | --- | --- |
-| Inline declarative provider | Built from `surfaces.rest`. |
-| Inline spec-backed provider | Built from `surfaces.openapi`, `surfaces.graphql`, or `surfaces.mcp`. |
-| Packaged provider plugin | Spawned as a separate process and connected over the plugin protocol. |
+| Inline declarative | Defined entirely in YAML using `surfaces.rest`. |
+| Inline spec-backed | Generated from an OpenAPI spec, GraphQL endpoint, or upstream MCP server. |
+| Packaged plugin | A separate process that communicates with `gestaltd` over gRPC. See [Plugins](/plugins). |
 
-A packaged plugin can also layer in spec-backed surfaces, which is how hybrid
-providers work.
+A packaged plugin can also expose spec-backed surfaces alongside its own operations. This is referred to as a hybrid provider.
 
-## Connection Resolution
+## Connections
 
-Gestalt resolves credentials through `connections.default` plus any optional
-named connections.
+Connections define how a provider authenticates with upstream APIs. Each provider has a `connections.default` entry and may define additional named connections.
 
-- `connections.default` is the primary connection
-- `connections.<name>` defines additional named connections
-- only `connections.default` can carry `params` and `discovery`
-- each configured surface chooses its connection explicitly when needed
-
-Each connection has one mode:
-
-| Mode | Meaning |
+| Mode | Description |
 | --- | --- |
-| `none` | No stored credential is needed. |
-| `user` | Use a user-scoped stored connection. |
-| `identity` | Use a shared service identity. |
-| `either` | Prefer user auth and fall back to the shared identity. |
+| `none` | No credential is needed. |
+| `user` | Each user authenticates individually. |
+| `identity` | A single shared service credential is used. |
+| `either` | User credentials are preferred, with fallback to the shared identity. |
 
-If an integration has more than one stored connection for the chosen subject,
-callers must specify an instance. If there is exactly one, Gestalt selects it
-automatically.
+When a user has multiple stored connections for the same provider, callers must specify which instance to use. When only one exists, Gestalt selects it automatically.
 
-## The Shared Invocation Broker
+## Invocation
 
-Every execution path in Gestalt goes through the same invocation broker.
+All execution paths go through a shared invocation broker. The broker resolves the target provider and operation, selects and refreshes credentials, and returns normalized results. Because the broker is shared, the same authorization and credential behavior applies whether the request comes from the HTTP API, the web UI, or an MCP client.
 
-The broker is responsible for:
+## Surfaces
 
-- locating the target provider and operation
-- resolving credentials based on connection mode
-- choosing an instance when multiple connections exist
-- refreshing expiring OAuth tokens
-- injecting connection metadata into execution context
-- returning normalized operation results
+Providers are accessible through three surfaces, all served from the same `gestaltd` process:
 
-Because this broker is shared, the same token and policy behavior applies
-whether the caller is the web UI, a direct HTTP client, or an MCP client
-hitting `/mcp`.
-
-## Surfaces Built On Top
-
-Once providers exist, `gestaltd` projects them into several surfaces:
-
-| Surface | What it exposes |
+| Surface | Endpoint |
 | --- | --- |
-| HTTP API | `/api/v1/...` for integration listing, auth flows, invocation, and token management. |
-| Embedded web UI | Served by the same server process and port as the API. |
-| MCP endpoint | `/mcp`, mounted when at least one integration exposes tools. |
-
-## What You Actually Program Against
-
-As a Gestalt operator, you compose top-level config blocks, provider
-definitions, connection definitions, surface definitions, and optional plugin
-manifests and packages. Everything else is a consequence of those inputs.
+| HTTP API | `/api/v1/` |
+| Web UI | `/` |
+| MCP | `/mcp` (mounted when at least one provider exposes MCP tools) |

--- a/docs/pages/concepts/plugin-protocol.mdx
+++ b/docs/pages/concepts/plugin-protocol.mdx
@@ -1,48 +1,28 @@
 # Plugin Protocol
 
-Executable plugins let `gestaltd` extend integrations without compiling new code into the host binary.
+Gestalt plugins are separate processes that extend `gestaltd` with custom provider logic. The host and plugin communicate over a local Unix socket using gRPC. See [Writing a Plugin](/plugins/writing-a-plugin) for a practical guide to building one.
 
-## What A Plugin Is
+## How plugins work
 
-A plugin is a separate process started by `gestaltd`. The host and plugin communicate over a local Unix socket using the Gestalt plugin gRPC protocol.
+When `gestaltd` starts a plugin, it creates a temporary Unix socket, sets the `GESTALT_PLUGIN_SOCKET` environment variable, and launches the plugin binary as a child process. The plugin connects to the socket and registers itself over gRPC. The host then sends the plugin its configured name and config block.
 
-One plugin kind is supported:
+## Provider plugin contract
 
-| Kind | Purpose |
-| --- | --- |
-| Provider plugin | Adds a provider for `providers:`. |
+A provider plugin must:
 
-## Startup Model
+- Report metadata (name, display name, description, connection mode)
+- Expose an operation catalog
+- Execute operations when invoked
 
-When `gestaltd` starts a plugin process, it:
+A plugin may optionally:
 
-1. creates a temporary Unix socket
-2. sets `GESTALT_PLUGIN_SOCKET` for the child process
-3. launches the plugin executable
-4. dials the plugin and validates protocol compatibility
-5. sends the plugin its name and config
+- Expose a request-scoped catalog that varies based on the caller's credentials
+- Provide a JSON Schema for its config block
+- Run initialization logic at startup
 
-The public Go SDK in `sdk/go` handles this for you.
+## Config placement
 
-## Provider Plugin Contract
-
-A provider plugin is expected to:
-
-- report provider metadata such as name, display name, description, and connection mode
-- expose its discovery catalog
-- execute operations
-- optionally expose a request-scoped catalog
-- optionally expose a config schema
-- optionally run startup logic when the host sends `StartProvider`
-
-The SDK's `ProviderStarter` path receives:
-
-- the configured integration name
-- the plugin config block as a map
-
-## Config Placement
-
-Provider plugin config lives here:
+Plugin config is passed from the `config` block under the provider entry:
 
 ```yaml
 providers:
@@ -52,3 +32,9 @@ providers:
     config:
       greeting: hello
 ```
+
+The plugin receives this as a key-value map during startup.
+
+## Language support
+
+Gestalt currently provides a Go SDK for writing plugins (`sdk/go`). Support for additional languages is planned. The underlying protocol is gRPC, so plugins can be implemented in any language that supports gRPC by implementing the `ProviderPlugin` service contract defined in `sdk/proto/v1/plugin.proto`.

--- a/docs/pages/concepts/security.mdx
+++ b/docs/pages/concepts/security.mdx
@@ -1,8 +1,8 @@
-# Security Model
+# Security
 
-Gestalt sits between callers and upstream APIs. It authenticates users, stores encrypted credentials, and isolates plugin processes. This page describes the trust boundaries, cryptographic primitives, and security-relevant configuration.
+Gestalt sits between callers and upstream APIs. It authenticates users, stores encrypted credentials, and isolates plugin processes. This page describes the trust boundaries, cryptographic design, and security-relevant configuration.
 
-## Trust Boundaries
+## Trust boundaries
 
 ```
 ┌─────────────────────────────────────────────────────────┐
@@ -31,164 +31,48 @@ Gestalt sits between callers and upstream APIs. It authenticates users, stores e
          └────────────┘  └───────────────┘
 ```
 
-Four trust boundaries:
-
 | Boundary | What crosses it | Protection |
 | --- | --- | --- |
-| Internet → Gestalt | User requests | Platform auth (session or API token) |
-| Gestalt → upstream APIs | OAuth tokens, API keys | Credential encryption, TLS |
-| Gestalt → plugins | Config, operation requests, access tokens | Process isolation, Unix socket, scoped capabilities |
-| Operator → Gestalt | Config, encryption key, secrets | Secret manager, env var expansion, `secret://` refs |
+| Internet to Gestalt | User requests | Platform auth (session or API token) |
+| Gestalt to upstream APIs | OAuth tokens, API keys | Credential encryption, TLS |
+| Gestalt to plugins | Config, operation requests, access tokens | Process isolation, Unix socket, scoped capabilities |
+| Operator to Gestalt | Config, encryption key, secrets | Secret manager, env var expansion, `secret://` refs |
 
-## Encryption at Rest
+## Encryption at rest
 
-All integration tokens (OAuth access tokens, refresh tokens) are encrypted before storage using AES-256-GCM.
+All integration tokens are encrypted before storage using AES-256-GCM.
 
-```
-server.encryption_key
-        │
-        ▼
-   ┌─────────┐
-   │ Argon2id │  (3 iterations, 64 MiB, 4 threads)
-   │  or hex  │  (64-char hex string used directly)
-   └────┬────┘
-        │
-        ▼
-  32-byte AES key
-        │
-        ▼
-   ┌─────────┐
-   │ AES-256 │  random 12-byte nonce per encryption
-   │   GCM   │  authenticated encryption (AEAD)
-   └─────────┘
-```
+The `server.encryption_key` is the root deployment secret. If the key is a 64-character hex string, it is decoded directly as a 32-byte AES key. Otherwise, Argon2id derives a 32-byte key from the string (3 iterations, 64 MiB, 4 threads).
 
-The `server.encryption_key` is the root deployment secret. Gestalt derives all cryptographic material from it:
+Every encryption operation generates a fresh 12-byte nonce using `crypto/rand`. GCM provides authenticated encryption, so tampering with stored ciphertexts is detected at decryption time.
 
-- **AES-256-GCM key** for encrypting integration tokens and pending connection continuations
-- **State secret** for encrypting OAuth state parameters and PKCE verifiers
-
-If the encryption key is a 64-character hex string, it is decoded directly as a 32-byte key. Otherwise, Argon2id derives a 32-byte key from the string.
-
-Every encryption operation generates a fresh random nonce using `crypto/rand`. Ciphertexts are base64-encoded for storage. GCM provides authenticated encryption, so tampering with stored ciphertexts is detected at decryption time.
-
-### What is encrypted
-
-| Data | Storage |
+| Data | Storage method |
 | --- | --- |
 | OAuth access tokens | AES-256-GCM encrypted |
 | OAuth refresh tokens | AES-256-GCM encrypted |
 | Pending connection continuations | AES-256-GCM encrypted |
-| OAuth state parameters | AES-256-GCM encrypted (URL-safe encoding, 10-minute TTL) |
-| API tokens | SHA-256 hashed (one-way, not reversible) |
+| OAuth state parameters | AES-256-GCM encrypted (10-minute TTL) |
+| API tokens | SHA-256 hashed (one-way) |
 | User emails, display names | Plaintext |
-| Token metadata JSON | Plaintext |
 
-## Token Lifecycle
+## Token lifecycle
 
-### Platform Sessions
+**Platform sessions.** Users log in through the configured identity provider. Gestalt validates the callback, checks `email_verified`, and issues a session cookie. Sessions expire based on the auth provider's TTL (default 24 hours).
 
-```
-Browser ──POST /auth/login──▶ Gestalt ──redirect──▶ Identity Provider
-                                                          │
-Browser ◀──set session_token cookie──── Gestalt ◀──callback──┘
-```
+**API tokens.** Generated with 32 random bytes from `crypto/rand` and prefixed with `gst_api_`. The plaintext is returned once at creation time. Only the SHA-256 hash is stored. Default TTL is 30 days, configurable via `server.api_token_ttl`.
 
-1. User initiates login via `POST /api/v1/auth/login`
-2. Gestalt redirects to the identity provider (Google, OIDC)
-3. Identity provider redirects back to `/api/v1/auth/login/callback`
-4. Gestalt validates the callback, checks `email_verified`, and issues a session token
-5. Session token is set as an HTTP cookie (`session_token`)
+**Integration tokens (OAuth).** OAuth state is encrypted with a 10-minute TTL to prevent state injection. After the authorization code exchange, access and refresh tokens are encrypted separately and stored. Gestalt automatically refreshes tokens that expire within 5 minutes.
 
-Session tokens are validated by the platform auth provider on every request.
+## Request authentication
 
-Cookie properties:
+Requests are authenticated in the following order:
 
-| Property | Value |
-| --- | --- |
-| `HttpOnly` | `true` (prevents JavaScript access) |
-| `Secure` | `true` when `server.base_url` starts with `https://`, `false` otherwise |
-| `SameSite` | `Lax` (prevents cross-site form submission, allows top-level navigation) |
-| `Path` | `/` |
-| `MaxAge` | 24 hours (configurable per auth provider) |
+1. Check for a `session_token` cookie
+2. Check for an `Authorization: Bearer` header with a `gst_api_` prefix (API token lookup via SHA-256 hash)
+3. Check for an `Authorization: Bearer` header with a provider-issued token
+4. If no valid credentials are found, return 401
 
-### API Tokens
-
-```
-POST /api/v1/tokens
-        │
-        ▼
-  Generate 32 random bytes (crypto/rand)
-  Prefix with gst_api_
-        │
-        ├──▶ Return plaintext to caller (once, never stored)
-        │
-        └──▶ SHA-256 hash → store in datastore
-```
-
-- Plaintext is returned exactly once at creation time
-- Only the SHA-256 hash is stored. Tokens cannot be recovered from the datastore
-- Default TTL: 30 days (configurable via `server.api_token_ttl`)
-- Revocable individually (`DELETE /api/v1/tokens/{id}`) or in bulk (`DELETE /api/v1/tokens`)
-
-### Integration Tokens (OAuth)
-
-```
-POST /auth/start-oauth
-        │
-        ▼
-  Build OAuth state (user ID, integration, connection, PKCE verifier)
-  Encrypt state with AES-256-GCM (10-minute TTL)
-        │
-        ▼
-  Gestalt ──redirect with encrypted state──▶ Upstream OAuth Provider
-                                                    │
-  Gestalt ◀──callback with code + encrypted state────┘
-        │
-        ▼
-  Decrypt and validate state (TTL, user ID, integration match)
-  Exchange authorization code for tokens (+ PKCE verifier if applicable)
-        │
-        ▼
-  Encrypt access + refresh tokens separately (AES-256-GCM)
-        │
-        ▼
-  Store encrypted tokens in datastore
-```
-
-- OAuth state is encrypted and time-limited (10-minute expiry) to prevent state injection attacks
-- Access and refresh tokens are encrypted separately before storage
-- Automatic refresh when the access token expires within 5 minutes
-- Refresh errors are tracked; repeated failures do not retry indefinitely
-- Tokens are keyed by `(user_id, integration, connection, instance)`
-- Plaintext tokens are held in memory only during credential resolution
-
-## Request Authentication Flow
-
-```
-Request arrives
-      │
-      ├─ Check session_token cookie
-      │      │
-      │      ├─ Valid session? ──▶ Authenticated (SourceSession)
-      │      └─ Invalid/missing
-      │
-      ├─ Check Authorization: Bearer header
-      │      │
-      │      ├─ gst_api_ prefix? ──▶ SHA-256 hash → lookup in datastore
-      │      │                              │
-      │      │                     ──▶ Authenticated (SourceAPIToken)
-      │      │
-      │      └─ Other token? ──▶ Validate with auth provider
-      │                                │
-      │                       ──▶ Authenticated (SourceSession)
-      │
-      └─ No credentials ──▶ 401 Unauthorized
-```
-
-## Security Headers
-
-Gestalt sets the following headers on every response:
+## Security headers
 
 | Header | Value |
 | --- | --- |
@@ -196,36 +80,15 @@ Gestalt sets the following headers on every response:
 | `X-Frame-Options` | `DENY` |
 | `Strict-Transport-Security` | `max-age=63072000; includeSubDomains` (HTTPS only) |
 
-## Plugin Isolation
+## Plugin isolation
 
-Plugins run as separate OS processes. Communication happens over temporary Unix sockets using gRPC.
+Plugins run as separate OS processes with communication over temporary Unix sockets. Plugins cannot access the datastore, other users' credentials, or the host process memory. Only sanitized environment variables are passed to plugin processes.
 
-```
-gestaltd process
-      │
-      ├── creates /tmp/gestalt-*.sock
-      ├── sets GESTALT_PLUGIN_SOCKET env var
-      ├── launches plugin binary as child process
-      │
-      ▼
- Plugin process
-      │
-      ├── connects to socket
-      ├── receives name + config via gRPC
-      └── serves ProviderPlugin service
-```
-
-Isolation properties:
-
-- **No shared memory**: communication is message-passing over a socket
-- **No direct datastore access**: plugins cannot query the datastore or access other users' credentials
-- **Sanitized environment**: only safe variables are passed to plugin processes (`PATH`, `HOME`, `TMPDIR`, `LANG`, `TZ`, `SSL_CERT_*`, plus user-configured `env`)
-- **Token passthrough**: the host resolves the caller's access token and passes it directly to the plugin in the gRPC request. Plugins receive only the token for the current invocation, not the full credential store.
-- **Process lifecycle**: plugins are terminated when `gestaltd` shuts down (SIGTERM, then SIGKILL after timeout)
+The host resolves the caller's access token and passes it to the plugin in each gRPC request. Plugins receive only the token for the current invocation.
 
 ### OS-level sandbox
 
-Plugins are automatically sandboxed when `allowed_hosts` is configured. No additional configuration is needed:
+When `allowed_hosts` is configured on a provider, the plugin is automatically sandboxed:
 
 ```yaml
 providers:
@@ -238,44 +101,26 @@ providers:
         - "*.slack.com"
 ```
 
-Without `allowed_hosts`, the plugin runs unrestricted:
+**Filesystem.** On Linux, [Landlock](https://docs.kernel.org/userspace-api/landlock.html) restricts file access to system libraries, SSL certificates, and DNS configuration. Writes are limited to the socket directory and an isolated temp directory. On macOS, equivalent restrictions are applied via `sandbox-exec`.
 
-```yaml
-providers:
-  trusted-plugin:
-    from:
-      command: ./my-trusted-plugin
-```
+**Network.** `gestaltd` starts a local HTTP proxy and sets `HTTP_PROXY`/`HTTPS_PROXY` in the plugin's environment. The proxy checks each request's hostname against the allowlist before forwarding. Wildcards are supported (`*.example.com` matches `api.example.com`).
 
-**Filesystem restrictions:**
+**Process group.** Sandboxed plugins run in their own process group. On shutdown, `gestaltd` signals the entire group to ensure child processes are also cleaned up.
 
-On Linux, the sandbox uses [Landlock](https://docs.kernel.org/userspace-api/landlock.html) to restrict file access. Plugins can only read system libraries, SSL certificates, and DNS configuration. Writes are limited to the plugin's socket directory and its isolated temp directory. On macOS, equivalent restrictions are applied via `sandbox-exec` with a generated Seatbelt profile.
-
-**Network restrictions:**
-
-When `allowed_hosts` is configured, `gestaltd` starts a local HTTP proxy and sets `HTTP_PROXY`/`HTTPS_PROXY` in the plugin's environment. Plugins use standard HTTP libraries unchanged. The proxy checks each request's target hostname against the allowlist before forwarding. Wildcards are supported (`*.example.com` matches `api.example.com`). On Linux, Landlock additionally restricts TCP connections to only the proxy port.
-
-**Process group isolation:**
-
-Sandboxed plugins run in their own process group. On shutdown, `gestaltd` signals the entire group, ensuring child processes spawned by the plugin are also cleaned up.
-
-## Operator Responsibilities
-
-These configuration choices directly affect the security posture of a deployment:
+## Operator responsibilities
 
 | Setting | Impact |
 | --- | --- |
-| `server.encryption_key` | Protect this value. If compromised, all stored integration tokens can be decrypted. Use a strong random string or a 64-character hex key. Must be the same across all instances in a cluster. |
-| `auth.provider` | `none` disables all authentication. Never use in production. |
-| `server.base_url` | Must match the public URL exactly. OAuth callback URLs are derived from it. A mismatch can break auth flows or create open-redirect risks. |
-| TLS termination | Gestalt does not terminate TLS itself. Deploy behind a reverse proxy (Nginx, Envoy, cloud load balancer) that handles TLS. |
-| `secrets.provider` | Use a dedicated secret manager (`google_secret_manager`, `aws_secrets_manager`, `vault`, `azure_key_vault`) or `file` in production. `env` is acceptable but secrets may appear in process listings. |
-| `datastore.provider` | Use Postgres or another SQL datastore in production. SQLite is single-writer and not suitable for multi-replica deployments. |
+| `server.encryption_key` | Root deployment secret. If compromised, all stored tokens can be decrypted. Use a strong random string or 64-character hex key. Must be the same across all instances in a cluster. |
+| `auth.provider` | `none` disables all authentication. Do not use in production. |
+| `server.base_url` | Must match the public URL exactly. OAuth callbacks are derived from it. |
+| TLS termination | Gestalt does not terminate TLS. Deploy behind a reverse proxy that handles TLS. |
+| `secrets.provider` | Use a dedicated secret manager in production. `env` is acceptable but secrets may appear in process listings. |
+| `datastore.provider` | Use Postgres or another production-grade datastore. SQLite is single-writer and not suitable for multi-replica deployments. |
 
-## Known Limitations
+## Known limitations
 
-- **No built-in key rotation**: changing `server.encryption_key` requires re-encrypting all stored tokens. There is no automated migration.
-- **No session revocation**: platform sessions cannot be explicitly invalidated. They expire based on the auth provider's TTL (default 24 hours).
-- **No built-in rate limiting**: configure rate limiting at the load balancer or reverse proxy layer.
-- **No CORS configuration**: Gestalt does not set CORS headers. Configure CORS at the reverse proxy if cross-origin browser access is needed.
-- **Database encryption is application-level**: Gestalt encrypts tokens before storage, but the database itself may store metadata in plaintext. Ensure the database has appropriate access controls and encrypted backups.
+- Changing `server.encryption_key` requires re-encrypting all stored tokens. There is no automated key rotation.
+- Platform sessions cannot be explicitly revoked. They expire based on the configured TTL.
+- Rate limiting and CORS must be configured at the reverse proxy layer.
+- Gestalt encrypts tokens at the application level, but the database may store metadata in plaintext. Ensure appropriate database access controls.

--- a/docs/pages/plugins/_meta.ts
+++ b/docs/pages/plugins/_meta.ts
@@ -1,0 +1,5 @@
+export default {
+  index: "Overview",
+  "writing-a-plugin": "Writing a Plugin",
+  "packaging-and-releasing": "Packaging and Releasing",
+};

--- a/docs/pages/plugins/index.mdx
+++ b/docs/pages/plugins/index.mdx
@@ -1,0 +1,20 @@
+# Plugins
+
+Gestalt plugins are standalone processes that add custom provider logic to `gestaltd`. Plugins communicate with the host over gRPC on a local Unix socket, and they are started and managed automatically by the server.
+
+Plugins are the right choice when a provider needs logic that cannot be expressed with declarative YAML or a spec-backed surface, such as custom data transformations, multi-step workflows, or proprietary API protocols.
+
+## Language support
+
+Gestalt currently provides a first-party SDK for **Go** (`sdk/go`). The underlying protocol is gRPC, so plugins can be implemented in any language that supports gRPC by implementing the `ProviderPlugin` service contract defined in `sdk/proto/v1/plugin.proto`. First-party SDKs for additional languages are planned.
+
+## How plugins work
+
+When a provider entry includes a `from` block, `gestaltd` starts the plugin as a child process at boot time. The host creates a temporary Unix socket, passes the socket path to the plugin via the `GESTALT_PLUGIN_SOCKET` environment variable, and the plugin connects back to register itself. Once connected, the plugin receives its name and config, exposes its operation catalog, and begins handling invocation requests.
+
+Plugins run in process isolation. They cannot access the datastore, other users' credentials, or the host process memory. The host resolves credentials and passes only the current caller's access token to the plugin for each request.
+
+## Next steps
+
+- [Writing a Plugin](/plugins/writing-a-plugin) walks through building a provider plugin with the Go SDK.
+- [Packaging and Releasing](/plugins/packaging-and-releasing) covers how to package, version, and distribute plugins.

--- a/docs/pages/plugins/packaging-and-releasing.mdx
+++ b/docs/pages/plugins/packaging-and-releasing.mdx
@@ -1,0 +1,124 @@
+# Packaging and Releasing
+
+Once a plugin is working locally with `from.command`, you can package it for distribution. Packaged plugins are self-contained archives that include a manifest, compiled binaries, and optional assets.
+
+## Plugin manifest
+
+Every package requires a manifest file named `plugin.yaml` (or `plugin.yml` or `plugin.json`). The manifest declares the plugin's metadata, supported platforms, and entry points.
+
+A minimal manifest for an executable provider:
+
+```yaml
+name: my-plugin
+version: 0.1.0
+kinds:
+  - provider
+entrypoints:
+  provider:
+    artifact_path: artifacts/my-plugin
+artifacts:
+  - os: linux
+    arch: amd64
+    path: artifacts/my-plugin-linux-amd64
+  - os: darwin
+    arch: arm64
+    path: artifacts/my-plugin-darwin-arm64
+```
+
+### Declarative-only packages
+
+A manifest can describe a declarative provider that requires no compiled binary. This is useful for distributing reusable REST providers, OpenAPI-backed integrations, or web UI bundles:
+
+```yaml
+name: my-rest-provider
+version: 0.1.0
+kinds:
+  - provider
+```
+
+## Package a plugin
+
+Use `gestaltd plugin package` to create a distributable archive from a plugin directory:
+
+```sh
+gestaltd plugin package --input ./my-plugin --output ./dist/my-plugin.tar.gz
+```
+
+The input directory should contain the manifest and any referenced artifacts.
+
+## Build a cross-platform release
+
+Use `gestaltd plugin release` to compile the plugin for multiple platforms and produce release archives:
+
+```sh
+gestaltd plugin release --version 0.1.0
+```
+
+Run this from the plugin source directory. It compiles the binary for each target platform, produces release archives, and writes a checksums file.
+
+## Reference a packaged plugin
+
+There are three ways to reference a packaged plugin from the Gestalt config:
+
+### Local path
+
+Point to a directory or archive on disk:
+
+```yaml
+providers:
+  my-plugin:
+    from:
+      package: ./dist/my-plugin.tar.gz
+```
+
+### HTTPS URL
+
+Reference a remote archive:
+
+```yaml
+providers:
+  my-plugin:
+    from:
+      package: https://releases.example.com/my-plugin-0.1.0.tar.gz
+```
+
+### Versioned source
+
+Reference a published plugin by source and version. `gestaltd init` resolves the package and writes it to lock state:
+
+```yaml
+providers:
+  my-plugin:
+    from:
+      source: github.com/your-org/your-plugins/my-plugin
+      version: 0.1.0
+```
+
+This is the recommended approach for production deployments.
+
+## Prepared state
+
+When a config references packaged or remote plugins, run `gestaltd init` to resolve and prepare them:
+
+```sh
+gestaltd init --config ./config.yaml
+```
+
+This writes lock state (`gestalt.lock.json`) and extracts prepared artifacts under `.gestalt/`. After init, `gestaltd serve --locked` starts the server using only the prepared state, without fetching or resolving anything at runtime.
+
+## Package layout
+
+A typical plugin package contains:
+
+```
+plugin.yaml
+artifacts/
+  my-plugin-linux-amd64
+  my-plugin-darwin-arm64
+schemas/
+  config.schema.json
+assets/
+  icon.svg
+```
+
+The exact structure is determined by the manifest. The `schemas/` directory is optional and used for config validation. The `assets/` directory is optional and used for icons or other static files.

--- a/docs/pages/plugins/writing-a-plugin.mdx
+++ b/docs/pages/plugins/writing-a-plugin.mdx
@@ -1,0 +1,199 @@
+# Writing a Plugin
+
+This guide walks through building a provider plugin using the Go SDK.
+
+## Prerequisites
+
+- Go 1.22 or later
+- A running `gestaltd` instance for testing
+
+## Create the project
+
+```sh
+mkdir my-plugin && cd my-plugin
+go mod init example.com/my-plugin
+go get github.com/valon-technologies/gestalt/sdk/go
+```
+
+## Implement the provider
+
+A provider plugin implements the `gestalt.Provider` interface:
+
+```go
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+)
+
+type myProvider struct {
+	greeting string
+}
+
+func (p *myProvider) Name() string           { return "my-plugin" }
+func (p *myProvider) DisplayName() string    { return "My Plugin" }
+func (p *myProvider) Description() string    { return "A custom provider plugin" }
+func (p *myProvider) ConnectionMode() gestalt.ConnectionMode {
+	return gestalt.ConnectionModeNone
+}
+
+func (p *myProvider) Catalog() *gestalt.Catalog {
+	return &gestalt.Catalog{
+		Name:        p.Name(),
+		DisplayName: p.DisplayName(),
+		Description: p.Description(),
+		Operations: []gestalt.CatalogOperation{
+			{
+				ID:          "greet",
+				Description: "Return a greeting",
+				Method:      http.MethodGet,
+				Parameters: []gestalt.CatalogParameter{
+					{
+						Name:        "name",
+						Type:        "string",
+						Description: "Name to greet",
+						Required:    true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (p *myProvider) Execute(
+	ctx context.Context,
+	operation string,
+	params map[string]any,
+	token string,
+) (*gestalt.OperationResult, error) {
+	switch operation {
+	case "greet":
+		name, _ := params["name"].(string)
+		if name == "" {
+			name = "World"
+		}
+		body, _ := json.Marshal(map[string]string{
+			"message": fmt.Sprintf("%s, %s!", p.greeting, name),
+		})
+		return &gestalt.OperationResult{
+			Status: http.StatusOK,
+			Body:   string(body),
+		}, nil
+	default:
+		return &gestalt.OperationResult{
+			Status: http.StatusNotFound,
+			Body:   `{"error":"unknown operation"}`,
+		}, nil
+	}
+}
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(),
+		syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	provider := &myProvider{greeting: "Hello"}
+	if err := gestalt.ServeProvider(ctx, provider); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+```
+
+## The Provider interface
+
+Every plugin must implement these methods:
+
+| Method | Purpose |
+| --- | --- |
+| `Name()` | Internal identifier for the provider. |
+| `DisplayName()` | Human-readable name shown in the UI and API. |
+| `Description()` | Brief description of what the provider does. |
+| `ConnectionMode()` | How the provider authenticates with upstream APIs. |
+| `Catalog()` | Returns the list of operations the provider supports. |
+| `Execute()` | Handles an operation invocation. Receives the operation ID, input parameters, and the caller's access token. |
+
+### Connection modes
+
+| Mode | Constant | Description |
+| --- | --- | --- |
+| None | `ConnectionModeNone` | No credential needed. |
+| User | `ConnectionModeUser` | Each user provides their own credential. |
+| Identity | `ConnectionModeIdentity` | A shared service credential is used. |
+| Either | `ConnectionModeEither` | Prefer user credentials, fall back to shared. |
+
+When the connection mode is `user` or `either`, the `token` parameter in `Execute` contains the caller's OAuth access token.
+
+## Optional interfaces
+
+Plugins can implement additional interfaces for advanced behavior:
+
+| Interface | Method | Purpose |
+| --- | --- | --- |
+| `ProviderStarter` | `Start(ctx, name, config)` | One-time initialization. Receives the provider name and the `config` block from the YAML. |
+| `SessionCatalogProvider` | `CatalogForRequest(ctx, token)` | Return a different operation catalog based on the caller's credentials. |
+| `ConfigSchemaProvider` | `ConfigSchema()` | Return a JSON Schema string for validating the provider's config block. |
+
+### Using ProviderStarter
+
+Implement `Start` to receive configuration at boot time:
+
+```go
+func (p *myProvider) Start(
+	ctx context.Context,
+	name string,
+	config map[string]any,
+) error {
+	if g, ok := config["greeting"].(string); ok {
+		p.greeting = g
+	}
+	return nil
+}
+```
+
+The corresponding config:
+
+```yaml
+providers:
+  my-plugin:
+    from:
+      command: ./my-plugin
+    config:
+      greeting: Howdy
+```
+
+## Test locally
+
+Build the plugin and reference it from a Gestalt config:
+
+```sh
+go build -o my-plugin .
+```
+
+```yaml
+providers:
+  my-plugin:
+    display_name: My Plugin
+    from:
+      command: ./my-plugin
+    config:
+      greeting: Hello
+    mcp:
+      enabled: true
+      tool_prefix: my_
+```
+
+Start the server and invoke the plugin:
+
+```sh
+gestaltd serve --config ./config.yaml
+gestalt invoke my-plugin greet -p name=Gestalt
+```


### PR DESCRIPTION
## Summary
- Rewrite all 7 Concepts pages in a professional, direct tone
- Remove pattern classification from Integrations, jump straight to examples
- Add new top-level **Plugins** section with 3 pages:
  - Overview: what plugins are, how they work, language support (Go now, more planned)
  - Writing a Plugin: complete Go SDK guide with working example (cross-validated against real plugins in gestalt-plugins repo)
  - Packaging and Releasing: manifest format, build commands, distribution

## Test plan
- [ ] Verify all pages render correctly
- [ ] Verify internal links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)