### PR TITLE
[codex] Fix CVE-2026-34986 in gestaltd

### DIFF
--- a/gestaltd/go.mod
+++ b/gestaltd/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect

--- a/gestaltd/go.sum
+++ b/gestaltd/go.sum
@@ -106,8 +106,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
-github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
-github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
## Summary
- bump `github.com/go-jose/go-jose/v4` in `gestaltd` from `v4.1.3` to `v4.1.4`
- refresh `gestaltd/go.sum` to remove the vulnerable checksum entry

## Why
This addresses CVE-2026-34986 in `go-jose`, where JWE decryption can panic when a key wrapping algorithm is used with an empty `encrypted_key` field. In this repo, `gestaltd` pulls `go-jose` through `github.com/hashicorp/vault/api`.

## Impact
Upgrading to `v4.1.4` pulls in the upstream fix for the panic path and removes the vulnerable `v4.1.3` module from the resolved dependency set for `gestaltd`.

## Root Cause
`gestaltd` was resolving `github.com/go-jose/go-jose/v4 v4.1.3`, which is below the fixed version listed in the advisory.

## Validation
- `go list -m all | rg "github.com/go-jose/go-jose/v4"`
- `go test ./...` in `gestaltd`
- verified there are no remaining `v4.1.3` references in the worktree
