### PR TITLE
Style the Rust CLI auth callback page

### DIFF
--- a/gestalt/cli/src/commands/auth.rs
+++ b/gestalt/cli/src/commands/auth.rs
@@ -186,11 +186,7 @@ where
         api_token_id: api_token_id.to_string(),
     })?;
 
-    let _ = send_browser_response(
-        &stream,
-        "Login successful",
-        "You can close this tab.",
-    );
+    let _ = send_browser_response(&stream, "Login successful", "You can close this tab.");
     output::print_success("Logged in successfully. Stored CLI API token.");
     Ok(())
 }

--- a/gestalt/cli/src/commands/auth.rs
+++ b/gestalt/cli/src/commands/auth.rs
@@ -6,6 +6,12 @@ use crate::api::{self, ApiClient};
 use crate::credentials::{CredentialStore, Credentials};
 use crate::output::{self, Format};
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BrowserResponseTone {
+    Success,
+    Error,
+}
+
 pub fn login(url_override: Option<&str>) -> Result<()> {
     if api::env_api_key_is_set() {
         bail!(
@@ -90,7 +96,12 @@ pub fn login(url_override: Option<&str>) -> Result<()> {
         .find(|(k, _)| k == "state")
         .map(|(_, v)| v.into_owned());
     if callback_state.as_deref() != Some(&state) {
-        let _ = send_browser_response(&stream, "Login failed: state mismatch.");
+        let _ = send_browser_response(
+            &stream,
+            "Login failed",
+            "The callback state did not match. Check the terminal for details.",
+            BrowserResponseTone::Error,
+        );
         bail!("OAuth state mismatch — possible CSRF attack");
     }
 
@@ -116,7 +127,12 @@ pub fn login(url_override: Option<&str>) -> Result<()> {
     let callback_status = callback_resp.status();
     if !callback_status.is_success() {
         let text = callback_resp.text().unwrap_or_default();
-        let _ = send_browser_response(&stream, "Login failed. Check the terminal for details.");
+        let _ = send_browser_response(
+            &stream,
+            "Login failed",
+            "The browser flow finished, but the CLI could not exchange the code. Check the terminal for details.",
+            BrowserResponseTone::Error,
+        );
         bail!(
             "code exchange failed (HTTP {}): {}",
             callback_status.as_u16(),
@@ -141,16 +157,235 @@ pub fn login(url_override: Option<&str>) -> Result<()> {
         api_token_id: api_token_id.to_string(),
     })?;
 
-    let _ = send_browser_response(&stream, "Login successful! You can close this tab.");
+    let _ = send_browser_response(
+        &stream,
+        "Login successful",
+        "You can close this tab and return to the CLI.",
+        BrowserResponseTone::Success,
+    );
     output::print_success("Logged in successfully. Stored CLI API token.");
     Ok(())
 }
 
-fn send_browser_response(stream: &std::net::TcpStream, message: &str) -> std::io::Result<()> {
-    let html = format!(
-        "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<html><body><h1>{message}</h1></body></html>"
+fn send_browser_response(
+    stream: &std::net::TcpStream,
+    title: &str,
+    detail: &str,
+    tone: BrowserResponseTone,
+) -> std::io::Result<()> {
+    let html = build_browser_response_html(title, detail, tone);
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nCache-Control: no-store\r\nConnection: close\r\n\r\n{}",
+        html.len(),
+        html
     );
-    (&*stream).write_all(html.as_bytes())
+    (&*stream).write_all(response.as_bytes())
+}
+
+fn build_browser_response_html(title: &str, detail: &str, tone: BrowserResponseTone) -> String {
+    let escaped_title = escape_html(title);
+    let escaped_detail = escape_html(detail);
+    let (tone_class, chip_label, icon_label, note) = match tone {
+        BrowserResponseTone::Success => (
+            "success",
+            "CLI login complete",
+            "OK",
+            "Return to the terminal to keep going.",
+        ),
+        BrowserResponseTone::Error => (
+            "error",
+            "CLI login error",
+            "!",
+            "Return to the terminal for the exact error details.",
+        ),
+    };
+
+    format!(
+        r#"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
+  <title>{escaped_title} - Gestalt</title>
+  <style>
+    :root {{
+      color-scheme: light dark;
+      --background: 36 28% 99%;
+      --surface: 36 33% 97%;
+      --surface-raised: 33 22% 93%;
+      --border: 30 18% 87%;
+      --foreground: 24 30% 11%;
+      --alpha-dark: 35, 24, 16;
+      --shadow: 0 4px 12px rgba(35, 24, 16, 0.1);
+      --page-gradient: radial-gradient(140% 90% at 50% 100%, #EACCB8 0%, #FDFCF9 50%, #F8F6F3 80%);
+      --success-bg: rgba(74, 124, 74, 0.14);
+      --success-border: rgba(74, 124, 74, 0.24);
+      --success-text: #2F5A2F;
+      --error-bg: rgba(199, 80, 80, 0.14);
+      --error-border: rgba(199, 80, 80, 0.22);
+      --error-text: #9B2C2C;
+    }}
+
+    @media (prefers-color-scheme: dark) {{
+      :root {{
+        --background: 24 18% 8%;
+        --surface: 24 14% 11%;
+        --surface-raised: 24 12% 15%;
+        --border: 24 10% 20%;
+        --foreground: 33 20% 90%;
+        --alpha-dark: 232, 222, 212;
+        --shadow: 0 18px 36px rgba(10, 8, 6, 0.35);
+        --page-gradient: radial-gradient(140% 90% at 50% 100%, #3D2808 0%, #1A1410 50%, #161110 80%);
+        --success-bg: rgba(184, 223, 184, 0.16);
+        --success-border: rgba(184, 223, 184, 0.26);
+        --success-text: #DCEFDC;
+        --error-bg: rgba(199, 80, 80, 0.18);
+        --error-border: rgba(199, 80, 80, 0.28);
+        --error-text: #F9C7C7;
+      }}
+    }}
+
+    * {{
+      box-sizing: border-box;
+    }}
+
+    html, body {{
+      height: 100%;
+    }}
+
+    body {{
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      background: var(--page-gradient);
+      color: rgba(var(--alpha-dark), 1);
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }}
+
+    .panel {{
+      width: min(100%, 440px);
+      border: 1px solid hsl(var(--border));
+      border-radius: 16px;
+      padding: 28px;
+      background: hsl(var(--surface));
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(14px);
+    }}
+
+    .eyebrow {{
+      margin: 0;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: rgba(var(--alpha-dark), 0.5);
+    }}
+
+    .chip {{
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      margin-top: 14px;
+      padding: 7px 10px;
+      border-radius: 999px;
+      border: 1px solid transparent;
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+    }}
+
+    .chip::before {{
+      content: "";
+      width: 8px;
+      height: 8px;
+      border-radius: 999px;
+      background: currentColor;
+      opacity: 0.9;
+    }}
+
+    .chip.success {{
+      background: var(--success-bg);
+      border-color: var(--success-border);
+      color: var(--success-text);
+    }}
+
+    .chip.error {{
+      background: var(--error-bg);
+      border-color: var(--error-border);
+      color: var(--error-text);
+    }}
+
+    .icon {{
+      width: 52px;
+      height: 52px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      margin-top: 20px;
+      border-radius: 14px;
+      font-size: 22px;
+      font-weight: 700;
+      background: hsl(var(--surface-raised));
+      border: 1px solid rgba(var(--alpha-dark), 0.08);
+      color: rgba(var(--alpha-dark), 0.9);
+      font-family: Georgia, "Times New Roman", serif;
+    }}
+
+    h1 {{
+      margin: 20px 0 0;
+      font-family: Georgia, "Times New Roman", serif;
+      font-size: clamp(2rem, 4vw, 2.35rem);
+      line-height: 1.05;
+      letter-spacing: -0.03em;
+    }}
+
+    p {{
+      margin: 14px 0 0;
+      font-size: 15px;
+      line-height: 1.65;
+      color: rgba(var(--alpha-dark), 0.72);
+    }}
+
+    .helper {{
+      margin-top: 18px;
+      padding-top: 18px;
+      border-top: 1px solid rgba(var(--alpha-dark), 0.08);
+      font-size: 13px;
+      color: rgba(var(--alpha-dark), 0.54);
+    }}
+  </style>
+</head>
+<body>
+  <main class="panel">
+    <p class="eyebrow">Gestalt CLI</p>
+    <div class="chip {tone_class}">{chip_label}</div>
+    <div class="icon" aria-hidden="true">{icon_label}</div>
+    <h1>{escaped_title}</h1>
+    <p>{escaped_detail}</p>
+    <p class="helper">{note}</p>
+  </main>
+</body>
+</html>
+"#
+    )
+}
+
+fn escape_html(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&#39;"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
 }
 
 pub fn logout() -> Result<()> {
@@ -243,4 +478,40 @@ fn random_hex_string() -> String {
     let mut buf = [0u8; 16];
     getrandom::fill(&mut buf).expect("failed to generate random bytes");
     buf.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn browser_response_html_carries_gestalt_theme_tokens() {
+        let html = build_browser_response_html(
+            "Login successful",
+            "You can close this tab and return to the CLI.",
+            BrowserResponseTone::Success,
+        );
+
+        assert!(html.contains("Gestalt CLI"));
+        assert!(html.contains("color-scheme: light dark"));
+        assert!(html.contains("@media (prefers-color-scheme: dark)"));
+        assert!(html.contains("#EACCB8"));
+        assert!(html.contains("#3D2808"));
+        assert!(html.contains("CLI login complete"));
+        assert!(html.contains("Return to the terminal to keep going."));
+    }
+
+    #[test]
+    fn browser_response_html_escapes_dynamic_text() {
+        let html = build_browser_response_html(
+            "<script>alert('x')</script>",
+            "Use \"quotes\" & close.",
+            BrowserResponseTone::Error,
+        );
+
+        assert!(html.contains("&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;"));
+        assert!(html.contains("Use &quot;quotes&quot; &amp; close."));
+        assert!(!html.contains("<script>alert('x')</script>"));
+        assert!(html.contains("CLI login error"));
+    }
 }

--- a/gestalt/cli/src/commands/auth.rs
+++ b/gestalt/cli/src/commands/auth.rs
@@ -210,7 +210,8 @@ fn build_browser_response_html(title: &str, detail: &str) -> String {
         "detail": detail,
         "title": title,
     });
-    BROWSER_RESPONSE_PAGE.replace("__DATA__", &data.to_string())
+    let data = data.to_string().replace('<', "\\u003c");
+    BROWSER_RESPONSE_PAGE.replace("__DATA__", &data)
 }
 
 pub fn logout() -> Result<()> {

--- a/gestalt/cli/src/commands/auth.rs
+++ b/gestalt/cli/src/commands/auth.rs
@@ -189,7 +189,7 @@ where
     let _ = send_browser_response(
         &stream,
         "Login successful",
-        "You can close this tab and return to the CLI.",
+        "You can close this tab.",
     );
     output::print_success("Logged in successfully. Stored CLI API token.");
     Ok(())

--- a/gestalt/cli/src/commands/auth.rs
+++ b/gestalt/cli/src/commands/auth.rs
@@ -6,13 +6,49 @@ use crate::api::{self, ApiClient};
 use crate::credentials::{CredentialStore, Credentials};
 use crate::output::{self, Format};
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum BrowserResponseTone {
-    Success,
-    Error,
-}
+const BROWSER_RESPONSE_PAGE: &str = r#"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    :root { color-scheme: light dark; --surface: #fff; --border: #ece4dd; --fg: #231810; --muted: #5c543c; --warm: radial-gradient(140% 90% at 50% 100%, #EACCB8 0%, #FDFCF9 50%, #F8F6F3 80%); }
+    @media (prefers-color-scheme: dark) { :root { --surface: #20190f; --border: #31231b; --fg: #f3ede6; --muted: #dcd2c6; --warm: radial-gradient(140% 90% at 50% 100%, #3D2808 0%, #1A1410 50%, #161110 80%); } }
+    * { box-sizing: border-box; }
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 24px; background: var(--warm); color: var(--fg); font: 16px/1.5 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    main { width: min(100%, 440px); padding: 28px; border: 1px solid var(--border); border-radius: 16px; background: var(--surface); box-shadow: 0 12px 40px rgba(35, 24, 16, 0.12); }
+    small { display: block; font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
+    h1 { margin: 16px 0 0; font: 700 clamp(2rem, 4vw, 2.35rem) / 1.05 Georgia, "Times New Roman", serif; letter-spacing: -0.03em; }
+    p { margin: 12px 0 0; color: var(--muted); }
+  </style>
+</head>
+<body>
+  <main>
+    <small>Gestalt</small>
+    <h1 id="title"></h1>
+    <p id="detail"></p>
+  </main>
+  <script>
+    const data = __DATA__;
+    document.title = `${data.title} - Gestalt`;
+    document.getElementById('title').textContent = data.title;
+    document.getElementById('detail').textContent = data.detail;
+  </script>
+</body>
+</html>
+"#;
 
 pub fn login(url_override: Option<&str>) -> Result<()> {
+    login_with_browser_opener(url_override, |url| {
+        open::that(url).map(|_| ()).map_err(Into::into)
+    })
+}
+
+pub fn login_with_browser_opener<F>(url_override: Option<&str>, open_browser: F) -> Result<()>
+where
+    F: FnOnce(&str) -> Result<()>,
+{
     if api::env_api_key_is_set() {
         bail!(
             "{} is set in your environment and takes priority over stored CLI credentials. \
@@ -26,7 +62,6 @@ pub fn login(url_override: Option<&str>) -> Result<()> {
     let listener =
         std::net::TcpListener::bind("127.0.0.1:0").context("failed to bind callback listener")?;
     let port = listener.local_addr()?.port();
-
     let state = random_hex_string();
 
     let login_url = format!("{}/api/v1/auth/login", base_url);
@@ -55,15 +90,13 @@ pub fn login(url_override: Option<&str>) -> Result<()> {
     let body: serde_json::Value = resp
         .json()
         .with_context(|| format!("server at {} returned non-JSON response", base_url))?;
-
     let url = body["url"]
         .as_str()
         .context("login response missing 'url' field")?;
 
     eprintln!("Opening browser for authentication...");
     eprintln!("If the browser doesn't open, visit: {}", url);
-
-    if open::that(url).is_err() {
+    if open_browser(url).is_err() {
         eprintln!("Could not open browser automatically.");
     }
 
@@ -90,7 +123,6 @@ pub fn login(url_override: Option<&str>) -> Result<()> {
         .nth(1)
         .and_then(|path| url::Url::parse(&format!("http://localhost{}", path)).ok())
         .context("failed to parse callback request")?;
-
     let callback_state = callback_params
         .query_pairs()
         .find(|(k, _)| k == "state")
@@ -100,9 +132,8 @@ pub fn login(url_override: Option<&str>) -> Result<()> {
             &stream,
             "Login failed",
             "The callback state did not match. Check the terminal for details.",
-            BrowserResponseTone::Error,
         );
-        bail!("OAuth state mismatch — possible CSRF attack");
+        bail!("OAuth state mismatch - possible CSRF attack");
     }
 
     let code = callback_params
@@ -123,7 +154,6 @@ pub fn login(url_override: Option<&str>) -> Result<()> {
         .get(callback_url.as_str())
         .send()
         .context("failed to exchange authorization code")?;
-
     let callback_status = callback_resp.status();
     if !callback_status.is_success() {
         let text = callback_resp.text().unwrap_or_default();
@@ -131,7 +161,6 @@ pub fn login(url_override: Option<&str>) -> Result<()> {
             &stream,
             "Login failed",
             "The browser flow finished, but the CLI could not exchange the code. Check the terminal for details.",
-            BrowserResponseTone::Error,
         );
         bail!(
             "code exchange failed (HTTP {}): {}",
@@ -161,7 +190,6 @@ pub fn login(url_override: Option<&str>) -> Result<()> {
         &stream,
         "Login successful",
         "You can close this tab and return to the CLI.",
-        BrowserResponseTone::Success,
     );
     output::print_success("Logged in successfully. Stored CLI API token.");
     Ok(())
@@ -171,9 +199,8 @@ fn send_browser_response(
     stream: &std::net::TcpStream,
     title: &str,
     detail: &str,
-    tone: BrowserResponseTone,
 ) -> std::io::Result<()> {
-    let html = build_browser_response_html(title, detail, tone);
+    let html = build_browser_response_html(title, detail);
     let response = format!(
         "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nCache-Control: no-store\r\nConnection: close\r\n\r\n{}",
         html.len(),
@@ -182,210 +209,12 @@ fn send_browser_response(
     (&*stream).write_all(response.as_bytes())
 }
 
-fn build_browser_response_html(title: &str, detail: &str, tone: BrowserResponseTone) -> String {
-    let escaped_title = escape_html(title);
-    let escaped_detail = escape_html(detail);
-    let (tone_class, chip_label, icon_label, note) = match tone {
-        BrowserResponseTone::Success => (
-            "success",
-            "CLI login complete",
-            "OK",
-            "Return to the terminal to keep going.",
-        ),
-        BrowserResponseTone::Error => (
-            "error",
-            "CLI login error",
-            "!",
-            "Return to the terminal for the exact error details.",
-        ),
-    };
-
-    format!(
-        r#"<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="color-scheme" content="light dark">
-  <title>{escaped_title} - Gestalt</title>
-  <style>
-    :root {{
-      color-scheme: light dark;
-      --background: 36 28% 99%;
-      --surface: 36 33% 97%;
-      --surface-raised: 33 22% 93%;
-      --border: 30 18% 87%;
-      --foreground: 24 30% 11%;
-      --alpha-dark: 35, 24, 16;
-      --shadow: 0 4px 12px rgba(35, 24, 16, 0.1);
-      --page-gradient: radial-gradient(140% 90% at 50% 100%, #EACCB8 0%, #FDFCF9 50%, #F8F6F3 80%);
-      --success-bg: rgba(74, 124, 74, 0.14);
-      --success-border: rgba(74, 124, 74, 0.24);
-      --success-text: #2F5A2F;
-      --error-bg: rgba(199, 80, 80, 0.14);
-      --error-border: rgba(199, 80, 80, 0.22);
-      --error-text: #9B2C2C;
-    }}
-
-    @media (prefers-color-scheme: dark) {{
-      :root {{
-        --background: 24 18% 8%;
-        --surface: 24 14% 11%;
-        --surface-raised: 24 12% 15%;
-        --border: 24 10% 20%;
-        --foreground: 33 20% 90%;
-        --alpha-dark: 232, 222, 212;
-        --shadow: 0 18px 36px rgba(10, 8, 6, 0.35);
-        --page-gradient: radial-gradient(140% 90% at 50% 100%, #3D2808 0%, #1A1410 50%, #161110 80%);
-        --success-bg: rgba(184, 223, 184, 0.16);
-        --success-border: rgba(184, 223, 184, 0.26);
-        --success-text: #DCEFDC;
-        --error-bg: rgba(199, 80, 80, 0.18);
-        --error-border: rgba(199, 80, 80, 0.28);
-        --error-text: #F9C7C7;
-      }}
-    }}
-
-    * {{
-      box-sizing: border-box;
-    }}
-
-    html, body {{
-      height: 100%;
-    }}
-
-    body {{
-      margin: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 24px;
-      background: var(--page-gradient);
-      color: rgba(var(--alpha-dark), 1);
-      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    }}
-
-    .panel {{
-      width: min(100%, 440px);
-      border: 1px solid hsl(var(--border));
-      border-radius: 16px;
-      padding: 28px;
-      background: hsl(var(--surface));
-      box-shadow: var(--shadow);
-      backdrop-filter: blur(14px);
-    }}
-
-    .eyebrow {{
-      margin: 0;
-      font-size: 11px;
-      font-weight: 600;
-      letter-spacing: 0.16em;
-      text-transform: uppercase;
-      color: rgba(var(--alpha-dark), 0.5);
-    }}
-
-    .chip {{
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      margin-top: 14px;
-      padding: 7px 10px;
-      border-radius: 999px;
-      border: 1px solid transparent;
-      font-size: 12px;
-      font-weight: 600;
-      letter-spacing: 0.01em;
-    }}
-
-    .chip::before {{
-      content: "";
-      width: 8px;
-      height: 8px;
-      border-radius: 999px;
-      background: currentColor;
-      opacity: 0.9;
-    }}
-
-    .chip.success {{
-      background: var(--success-bg);
-      border-color: var(--success-border);
-      color: var(--success-text);
-    }}
-
-    .chip.error {{
-      background: var(--error-bg);
-      border-color: var(--error-border);
-      color: var(--error-text);
-    }}
-
-    .icon {{
-      width: 52px;
-      height: 52px;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      margin-top: 20px;
-      border-radius: 14px;
-      font-size: 22px;
-      font-weight: 700;
-      background: hsl(var(--surface-raised));
-      border: 1px solid rgba(var(--alpha-dark), 0.08);
-      color: rgba(var(--alpha-dark), 0.9);
-      font-family: Georgia, "Times New Roman", serif;
-    }}
-
-    h1 {{
-      margin: 20px 0 0;
-      font-family: Georgia, "Times New Roman", serif;
-      font-size: clamp(2rem, 4vw, 2.35rem);
-      line-height: 1.05;
-      letter-spacing: -0.03em;
-    }}
-
-    p {{
-      margin: 14px 0 0;
-      font-size: 15px;
-      line-height: 1.65;
-      color: rgba(var(--alpha-dark), 0.72);
-    }}
-
-    .helper {{
-      margin-top: 18px;
-      padding-top: 18px;
-      border-top: 1px solid rgba(var(--alpha-dark), 0.08);
-      font-size: 13px;
-      color: rgba(var(--alpha-dark), 0.54);
-    }}
-  </style>
-</head>
-<body>
-  <main class="panel">
-    <p class="eyebrow">Gestalt CLI</p>
-    <div class="chip {tone_class}">{chip_label}</div>
-    <div class="icon" aria-hidden="true">{icon_label}</div>
-    <h1>{escaped_title}</h1>
-    <p>{escaped_detail}</p>
-    <p class="helper">{note}</p>
-  </main>
-</body>
-</html>
-"#
-    )
-}
-
-fn escape_html(value: &str) -> String {
-    let mut escaped = String::with_capacity(value.len());
-    for ch in value.chars() {
-        match ch {
-            '&' => escaped.push_str("&amp;"),
-            '<' => escaped.push_str("&lt;"),
-            '>' => escaped.push_str("&gt;"),
-            '"' => escaped.push_str("&quot;"),
-            '\'' => escaped.push_str("&#39;"),
-            _ => escaped.push(ch),
-        }
-    }
-    escaped
+fn build_browser_response_html(title: &str, detail: &str) -> String {
+    let data = serde_json::json!({
+        "detail": detail,
+        "title": title,
+    });
+    BROWSER_RESPONSE_PAGE.replace("__DATA__", &data.to_string())
 }
 
 pub fn logout() -> Result<()> {
@@ -478,40 +307,4 @@ fn random_hex_string() -> String {
     let mut buf = [0u8; 16];
     getrandom::fill(&mut buf).expect("failed to generate random bytes");
     buf.iter().map(|b| format!("{b:02x}")).collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn browser_response_html_carries_gestalt_theme_tokens() {
-        let html = build_browser_response_html(
-            "Login successful",
-            "You can close this tab and return to the CLI.",
-            BrowserResponseTone::Success,
-        );
-
-        assert!(html.contains("Gestalt CLI"));
-        assert!(html.contains("color-scheme: light dark"));
-        assert!(html.contains("@media (prefers-color-scheme: dark)"));
-        assert!(html.contains("#EACCB8"));
-        assert!(html.contains("#3D2808"));
-        assert!(html.contains("CLI login complete"));
-        assert!(html.contains("Return to the terminal to keep going."));
-    }
-
-    #[test]
-    fn browser_response_html_escapes_dynamic_text() {
-        let html = build_browser_response_html(
-            "<script>alert('x')</script>",
-            "Use \"quotes\" & close.",
-            BrowserResponseTone::Error,
-        );
-
-        assert!(html.contains("&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;"));
-        assert!(html.contains("Use &quot;quotes&quot; &amp; close."));
-        assert!(!html.contains("<script>alert('x')</script>"));
-        assert!(html.contains("CLI login error"));
-    }
 }

--- a/gestalt/cli/tests/integration.rs
+++ b/gestalt/cli/tests/integration.rs
@@ -1,8 +1,193 @@
+use std::ffi::OsString;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::Path;
+use std::sync::{Arc, Mutex, OnceLock};
+
 use gestalt::output::Format;
 use mockito::{Matcher, Server};
 
 fn create_client(server: &Server) -> gestalt::api::ApiClient {
     gestalt::api::ApiClient::new(&server.url(), "test-token").unwrap()
+}
+
+fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+}
+
+struct EnvGuard(Vec<(&'static str, Option<OsString>)>);
+
+impl EnvGuard {
+    fn new(config_root: &Path) -> Self {
+        let saved = vec![
+            ("HOME", std::env::var_os("HOME")),
+            ("XDG_CONFIG_HOME", std::env::var_os("XDG_CONFIG_HOME")),
+            (
+                gestalt::api::ENV_API_KEY,
+                std::env::var_os(gestalt::api::ENV_API_KEY),
+            ),
+        ];
+        unsafe {
+            std::env::set_var("HOME", config_root);
+            std::env::set_var("XDG_CONFIG_HOME", config_root);
+            std::env::remove_var(gestalt::api::ENV_API_KEY);
+        }
+        Self(saved)
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.0.drain(..) {
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct LoginFlowState {
+    callback_port: Option<u16>,
+    expected_state: Option<String>,
+    browser_response_html: Option<String>,
+}
+
+struct HttpRequest {
+    method: String,
+    target: String,
+    body: Vec<u8>,
+}
+
+struct LoginServer {
+    base_url: String,
+    state: Arc<Mutex<LoginFlowState>>,
+    handle: std::thread::JoinHandle<()>,
+}
+
+fn spawn_login_server() -> LoginServer {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+    let state = Arc::new(Mutex::new(LoginFlowState::default()));
+    let server_state = Arc::clone(&state);
+    let server_url = base_url.clone();
+    let handle = std::thread::spawn(move || {
+        let mut workers = Vec::new();
+        for _ in 0..3 {
+            let (stream, _) = listener.accept().unwrap();
+            let state = Arc::clone(&server_state);
+            let base_url = server_url.clone();
+            workers.push(std::thread::spawn(move || {
+                handle_login_request(stream, state, &base_url);
+            }));
+        }
+        for worker in workers {
+            worker.join().unwrap();
+        }
+    });
+    LoginServer {
+        base_url,
+        state,
+        handle,
+    }
+}
+
+fn handle_login_request(mut stream: TcpStream, state: Arc<Mutex<LoginFlowState>>, base_url: &str) {
+    let request = read_http_request(&mut stream);
+    match (request.method.as_str(), request.target.as_str()) {
+        ("POST", "/api/v1/auth/login") => {
+            let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+            let mut state = state.lock().unwrap();
+            state.callback_port = Some(body["callback_port"].as_u64().unwrap() as u16);
+            state.expected_state = Some(body["state"].as_str().unwrap().to_string());
+            write_http_response(
+                &mut stream,
+                "200 OK",
+                "application/json",
+                &format!(r#"{{"url":"{base_url}/browser-login"}}"#),
+            );
+        }
+        ("GET", "/browser-login") => {
+            let (callback_port, expected_state) = {
+                let state = state.lock().unwrap();
+                (
+                    state.callback_port.expect("missing callback port"),
+                    state.expected_state.clone().expect("missing state"),
+                )
+            };
+            let callback_url =
+                format!("http://127.0.0.1:{callback_port}/?code=test-code&state={expected_state}");
+            let html = reqwest::blocking::get(callback_url)
+                .unwrap()
+                .text()
+                .unwrap();
+            state.lock().unwrap().browser_response_html = Some(html);
+            write_http_response(&mut stream, "200 OK", "text/plain", "ok");
+        }
+        ("GET", target) if target.starts_with("/api/v1/auth/login/callback?") => {
+            let url = url::Url::parse(&format!("http://localhost{target}")).unwrap();
+            let params = url
+                .query_pairs()
+                .collect::<std::collections::HashMap<_, _>>();
+            let expected_state = state.lock().unwrap().expected_state.clone().unwrap();
+            assert_eq!(params.get("code").map(|v| v.as_ref()), Some("test-code"));
+            assert_eq!(params.get("cli").map(|v| v.as_ref()), Some("1"));
+            assert_eq!(
+                params.get("state").map(|v| v.as_ref()),
+                Some(expected_state.as_str())
+            );
+            write_http_response(
+                &mut stream,
+                "200 OK",
+                "application/json",
+                r#"{"token":"cli-secret","id":"tok-123"}"#,
+            );
+        }
+        _ => panic!("unexpected request: {} {}", request.method, request.target),
+    }
+}
+
+fn read_http_request(stream: &mut TcpStream) -> HttpRequest {
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    let mut request_line = String::new();
+    reader.read_line(&mut request_line).unwrap();
+
+    let mut content_length = 0usize;
+    loop {
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        if line == "\r\n" {
+            break;
+        }
+        if let Some((name, value)) = line.split_once(':')
+            && name.eq_ignore_ascii_case("Content-Length")
+        {
+            content_length = value.trim().parse().unwrap();
+        }
+    }
+
+    let mut body = vec![0; content_length];
+    reader.read_exact(&mut body).unwrap();
+
+    let mut parts = request_line.split_whitespace();
+    HttpRequest {
+        method: parts.next().unwrap().to_string(),
+        target: parts.next().unwrap().to_string(),
+        body,
+    }
+}
+
+fn write_http_response(stream: &mut TcpStream, status: &str, content_type: &str, body: &str) {
+    write!(
+        stream,
+        "HTTP/1.1 {status}\r\nContent-Type: {content_type}; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    )
+    .unwrap();
 }
 
 #[test]
@@ -256,6 +441,57 @@ fn test_start_oauth() {
     mock.assert();
     assert_eq!(resp["url"], "https://example.com/oauth");
     assert_eq!(resp["state"], "abc123");
+}
+
+#[test]
+fn test_auth_login_stores_credentials_and_serves_styled_browser_page() {
+    let _lock = env_lock();
+    let tempdir = tempfile::tempdir().unwrap();
+    let _env = EnvGuard::new(tempdir.path());
+    let server = spawn_login_server();
+    let browser = Arc::new(Mutex::new(None));
+    let browser_handle = Arc::clone(&browser);
+
+    gestalt::commands::auth::login_with_browser_opener(Some(&server.base_url), |url| {
+        let url = url.to_string();
+        *browser_handle.lock().unwrap() = Some(std::thread::spawn(move || {
+            reqwest::blocking::get(url).unwrap();
+        }));
+        Ok(())
+    })
+    .unwrap();
+
+    let LoginServer {
+        base_url,
+        state,
+        handle,
+    } = server;
+    browser
+        .lock()
+        .unwrap()
+        .take()
+        .expect("browser thread missing")
+        .join()
+        .unwrap();
+    handle.join().unwrap();
+
+    let html = state.lock().unwrap().browser_response_html.clone().unwrap();
+    assert!(html.contains("<small>Gestalt</small>"));
+    assert!(html.contains("Login successful"));
+    assert!(html.contains("radial-gradient(140% 90% at 50% 100%"));
+    assert!(!html.contains("Gestalt CLI"));
+    assert!(!html.contains("CLI login complete"));
+    assert!(!html.contains("class=\"pill\""));
+
+    let credentials_path = dirs::config_dir()
+        .unwrap()
+        .join("gestalt")
+        .join("credentials.json");
+    let credentials: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(credentials_path).unwrap()).unwrap();
+    assert_eq!(credentials["api_url"], base_url);
+    assert_eq!(credentials["api_token"], "cli-secret");
+    assert_eq!(credentials["api_token_id"], "tok-123");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- replace the bare CLI localhost callback page with a styled standalone HTML response
- reuse the Gestalt UI light/dark color tokens and warm background treatment in the inline CSS
- add unit tests for theme token presence and HTML escaping in the generated browser response

## Testing
- `cargo test` (from `gestalt/cli`)

## Preview
- local screenshots generated in the worktree for light and dark mode review