### PR TITLE
[codex] Filter release notes by artifact path

### DIFF
--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <artifact> <current-tag> <output-file>" >&2
+  exit 1
+}
+
+join_by() {
+  local separator=$1
+  shift
+  local first=1
+  for value in "$@"; do
+    if [[ $first -eq 1 ]]; then
+      printf '%s' "$value"
+      first=0
+    else
+      printf '%s%s' "$separator" "$value"
+    fi
+  done
+}
+
+artifact=${1:-}
+current_tag=${2:-}
+output_file=${3:-}
+
+[[ -n "$artifact" && -n "$current_tag" && -n "$output_file" ]] || usage
+
+case "$artifact" in
+  gestalt)
+    pathspecs=("gestalt")
+    ;;
+  gestaltd)
+    pathspecs=("gestaltd")
+    ;;
+  *)
+    echo "unsupported artifact: $artifact" >&2
+    exit 1
+    ;;
+esac
+
+if ! git rev-parse --verify --quiet "refs/tags/$current_tag" >/dev/null; then
+  echo "tag not found: $current_tag" >&2
+  exit 1
+fi
+
+previous_tag=""
+if previous_tag=$(git describe --tags --abbrev=0 --match "${artifact}/v*" "${current_tag}^" 2>/dev/null); then
+  range="${previous_tag}..${current_tag}"
+else
+  previous_tag=""
+  range="$current_tag"
+fi
+
+path_filter_label=$(join_by ', ' "${pathspecs[@]}")
+commits=()
+while IFS=$'\t' read -r sha subject; do
+  [[ -n "$sha" ]] || continue
+  commits+=("${sha}"$'\t'"${subject}")
+done < <(git log --reverse --first-parent --format='%H%x09%s' "$range" -- "${pathspecs[@]}")
+
+{
+  printf '## Changes\n\n'
+
+  if [[ -n "$previous_tag" ]]; then
+    printf 'Scoped to `%s` changes since `%s`.\n\n' "$path_filter_label" "$previous_tag"
+  else
+    printf 'Scoped to `%s` changes in the first `%s` release.\n\n' "$path_filter_label" "$artifact"
+  fi
+
+  if [[ ${#commits[@]} -eq 0 ]]; then
+    printf -- '- No commits matched the `%s` path filter in this release range.\n' "$path_filter_label"
+  else
+    for entry in "${commits[@]}"; do
+      sha=${entry%%$'\t'*}
+      subject=${entry#*$'\t'}
+      short_sha=${sha:0:7}
+      if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
+        printf -- '- %s ([`%s`](https://github.com/%s/commit/%s))\n' "$subject" "$short_sha" "$GITHUB_REPOSITORY" "$sha"
+      else
+        printf -- '- %s (`%s`)\n' "$subject" "$short_sha"
+      fi
+    done
+  fi
+} >"$output_file"

--- a/.github/workflows/release-gestalt-cli.yml
+++ b/.github/workflows/release-gestalt-cli.yml
@@ -28,6 +28,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - name: Generate scoped release notes
+        run: .github/scripts/generate-release-notes.sh gestalt "${{ github.ref_name }}" release-notes.md
       - name: Download all artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -42,7 +47,7 @@ jobs:
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           files: release/*
-          generate_release_notes: true
+          body_path: release-notes.md
           draft: false
           prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
 

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -95,6 +95,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - name: Generate scoped release notes
+        run: .github/scripts/generate-release-notes.sh gestaltd "${{ github.ref_name }}" release-notes.md
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
@@ -106,7 +111,7 @@ jobs:
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           files: release/*
-          generate_release_notes: true
+          body_path: release-notes.md
           draft: false
           prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
 


### PR DESCRIPTION
## Summary
Filter `gestaltd` and `gestalt` GitHub release notes by artifact-owned paths instead of relying on GitHub's repo-wide auto-generated notes.

## What changed
- add a shared `.github/scripts/generate-release-notes.sh` helper that finds the previous tag for the same artifact
- scope `gestaltd` release notes to commits touching `gestaltd`
- scope `gestalt` release notes to commits touching `gestalt`
- switch both release workflows to use the generated release body instead of `generate_release_notes: true`

## Why
The repo is a monorepo, and the current release workflows were using repo-wide auto-generated notes. That can mix unrelated CLI and daemon commits into each other's releases.

## Validation
- `bash -n .github/scripts/generate-release-notes.sh`
- `git diff --check`
- generated notes locally for `gestaltd/v0.0.1-alpha.3`
- generated notes locally for `gestalt/v0.0.1-alpha.1`