### PR TITLE
[codex] Check SDK proto-generated Go stubs in CI

### DIFF
--- a/.github/workflows/build-sdk-go.yml
+++ b/.github/workflows/build-sdk-go.yml
@@ -1,0 +1,55 @@
+name: Build Go SDK
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'sdk/go/**'
+      - 'sdk/proto/**'
+      - '.github/workflows/build-sdk-go.yml'
+      - '.github/workflows/release-sdk.yml'
+  pull_request:
+    paths:
+      - 'sdk/go/**'
+      - 'sdk/proto/**'
+      - '.github/workflows/build-sdk-go.yml'
+      - '.github/workflows/release-sdk.yml'
+
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Go SDK Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: sdk/go
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: sdk/go/go.mod
+          cache-dependency-path: sdk/go/go.sum
+      - name: Run Go SDK tests
+        run: go test ./...
+
+  proto-sync:
+    name: Go SDK Proto Sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: sdk/go/go.mod
+          cache-dependency-path: sdk/go/go.sum
+      - name: Install Buf
+        run: |
+          GOBIN="$RUNNER_TEMP/bin" go install github.com/bufbuild/buf/cmd/buf@v1.66.1
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+      - name: Verify generated Go SDK stubs
+        run: sdk/proto/check-go-sdk-sync.sh

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -22,6 +22,14 @@ jobs:
         with:
           go-version-file: sdk/go/go.mod
           cache-dependency-path: sdk/go/go.sum
+      - name: Install Buf
+        working-directory: .
+        run: |
+          GOBIN="$RUNNER_TEMP/bin" go install github.com/bufbuild/buf/cmd/buf@v1.66.1
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+      - name: Verify generated Go SDK stubs
+        working-directory: .
+        run: sdk/proto/check-go-sdk-sync.sh
       - name: Run Go SDK tests
         run: go test ./...
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,13 @@ go test ./...
 cd ../gestalt
 cargo test
 
+cd ../sdk/go
+go test ./...
+
+cd ../proto
+./update-go-sdk.sh
+./check-go-sdk-sync.sh
+
 cd ../gestaltd/ui
 npm ci
 npm run typecheck
@@ -54,6 +61,14 @@ Release workflows use scoped tags:
 - Plugins: `plugin/<plugin>/v<version>`
 
 Keep the bare semantic version aligned across artifacts when they are meant to ship together.
+
+If you change `sdk/proto`, regenerate and verify the checked-in Go stubs before sending a PR:
+
+```sh
+cd sdk/proto
+./update-go-sdk.sh
+./check-go-sdk-sync.sh
+```
 
 ## Adding New Built-Ins
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ cd ../proto
 ./update-go-sdk.sh
 ./check-go-sdk-sync.sh
 
-cd ../gestaltd/ui
+cd ../../gestaltd/ui
 npm ci
 npm run typecheck
 npm run build

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -103,6 +103,25 @@ func extractHiddenInputValue(t *testing.T, html, name string) string {
 	return html[start : start+end]
 }
 
+func newNoRedirectClient(t *testing.T, jar http.CookieJar) *http.Client {
+	t.Helper()
+
+	baseTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		t.Fatalf("default transport has unexpected type %T", http.DefaultTransport)
+	}
+	transport := baseTransport.Clone()
+	t.Cleanup(transport.CloseIdleConnections)
+
+	return &http.Client{
+		Jar:       jar,
+		Transport: transport,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
 // testOAuthHandler adapts a test stub into bootstrap.OAuthHandler for use in
 // server tests. Only the methods actually exercised by each test need non-nil
 // implementations.
@@ -2408,11 +2427,7 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 			t.Fatalf("decoding start response: %v", err)
 		}
 
-		noRedirect := &http.Client{
-			CheckRedirect: func(*http.Request, []*http.Request) error {
-				return http.ErrUseLastResponse
-			},
-		}
+		noRedirect := newNoRedirectClient(t, nil)
 		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
 		resp, err := noRedirect.Do(req)
 		if err != nil {
@@ -2515,12 +2530,7 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		if err != nil {
 			t.Fatalf("cookie jar: %v", err)
 		}
-		noRedirect := &http.Client{
-			Jar: jar,
-			CheckRedirect: func(*http.Request, []*http.Request) error {
-				return http.ErrUseLastResponse
-			},
-		}
+		noRedirect := newNoRedirectClient(t, jar)
 		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
 		resp, err := noRedirect.Do(req)
 		if err != nil {
@@ -3164,11 +3174,7 @@ func TestIntegrationOAuthCallback_PKCEUsesVerifier(t *testing.T) {
 		t.Fatalf("decoding start response: %v", err)
 	}
 
-	noRedirect := &http.Client{
-		CheckRedirect: func(*http.Request, []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
+	noRedirect := newNoRedirectClient(t, nil)
 	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
 	resp, err := noRedirect.Do(req)
 	if err != nil {
@@ -4277,11 +4283,7 @@ func TestConnectManual(t *testing.T) {
 		})
 		testutil.CloseOnCleanup(t, ts)
 
-		noRedirect := &http.Client{
-			CheckRedirect: func(*http.Request, []*http.Request) error {
-				return http.ErrUseLastResponse
-			},
-		}
+		noRedirect := newNoRedirectClient(t, nil)
 
 		connectBody := bytes.NewBufferString(`{"integration":"manual-svc","credential":"my-api-key"}`)
 		connectReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", connectBody)
@@ -4722,11 +4724,7 @@ func TestOAuthCallback_UsesStateConnection(t *testing.T) {
 		t.Fatalf("decoding start response: %v", err)
 	}
 
-	noRedirect := &http.Client{
-		CheckRedirect: func(*http.Request, []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
+	noRedirect := newNoRedirectClient(t, nil)
 	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=ok&state="+url.QueryEscape(startResult["state"]), nil)
 	resp, err := noRedirect.Do(req)
 	if err != nil {

--- a/sdk/proto/buf.gen.yaml
+++ b/sdk/proto/buf.gen.yaml
@@ -6,13 +6,13 @@ managed:
       value: github.com/valon-technologies/gestalt/sdk/go/gen/v1;proto
 plugins:
   # Go messages
-  - remote: buf.build/protocolbuffers/go
+  - remote: buf.build/protocolbuffers/go:v1.36.11
     out: ../go/gen
     opt:
       - paths=source_relative
 
   # Go gRPC stubs
-  - remote: buf.build/grpc/go
+  - remote: buf.build/grpc/go:v1.6.1
     out: ../go/gen
     opt:
       - paths=source_relative

--- a/sdk/proto/check-go-sdk-sync.sh
+++ b/sdk/proto/check-go-sdk-sync.sh
@@ -9,14 +9,11 @@ fi
 
 repo_root=$(git rev-parse --show-toplevel)
 
-(
-  cd "$repo_root/sdk/proto"
-  buf generate
-)
+"$repo_root/sdk/proto/update-go-sdk.sh"
 
 if ! git -C "$repo_root" diff --quiet -- sdk/go/gen; then
   echo "Generated Go SDK stubs are out of sync with sdk/proto." >&2
-  echo "Run 'cd sdk/proto && buf generate' and commit the updated files under sdk/go/gen." >&2
+  echo "Run 'sdk/proto/update-go-sdk.sh' and commit the updated files under sdk/go/gen." >&2
   git -C "$repo_root" --no-pager diff -- sdk/go/gen
   exit 1
 fi

--- a/sdk/proto/check-go-sdk-sync.sh
+++ b/sdk/proto/check-go-sdk-sync.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v buf >/dev/null 2>&1; then
+  echo "buf is required to verify generated Go SDK stubs" >&2
+  exit 1
+fi
+
+repo_root=$(git rev-parse --show-toplevel)
+
+(
+  cd "$repo_root/sdk/proto"
+  buf generate
+)
+
+if ! git -C "$repo_root" diff --quiet -- sdk/go/gen; then
+  echo "Generated Go SDK stubs are out of sync with sdk/proto." >&2
+  echo "Run 'cd sdk/proto && buf generate' and commit the updated files under sdk/go/gen." >&2
+  git -C "$repo_root" --no-pager diff -- sdk/go/gen
+  exit 1
+fi

--- a/sdk/proto/check-go-sdk-sync.sh
+++ b/sdk/proto/check-go-sdk-sync.sh
@@ -11,9 +11,12 @@ repo_root=$(git rev-parse --show-toplevel)
 
 "$repo_root/sdk/proto/update-go-sdk.sh"
 
-if ! git -C "$repo_root" diff --quiet -- sdk/go/gen; then
+status_output=$(git -C "$repo_root" status --short --untracked-files=all -- sdk/go/gen)
+
+if [[ -n "$status_output" ]]; then
   echo "Generated Go SDK stubs are out of sync with sdk/proto." >&2
   echo "Run 'sdk/proto/update-go-sdk.sh' and commit the updated files under sdk/go/gen." >&2
+  printf '%s\n' "$status_output" >&2
   git -C "$repo_root" --no-pager diff -- sdk/go/gen
   exit 1
 fi

--- a/sdk/proto/update-go-sdk.sh
+++ b/sdk/proto/update-go-sdk.sh
@@ -9,5 +9,7 @@ fi
 
 repo_root=$(git rev-parse --show-toplevel)
 
+find "$repo_root/sdk/go/gen" -type f -name '*.pb.go' -delete
+
 cd "$repo_root/sdk/proto"
 buf generate

--- a/sdk/proto/update-go-sdk.sh
+++ b/sdk/proto/update-go-sdk.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v buf >/dev/null 2>&1; then
+  echo "buf is required to regenerate Go SDK stubs" >&2
+  exit 1
+fi
+
+repo_root=$(git rev-parse --show-toplevel)
+
+cd "$repo_root/sdk/proto"
+buf generate


### PR DESCRIPTION
## Summary
Add a repo-level SDK guard that fails when `sdk/proto` and the committed generated Go stubs under `sdk/go/gen` drift apart.

## What changed
- add `sdk/proto/check-go-sdk-sync.sh` to regenerate Go stubs with Buf and fail if `sdk/go/gen` changes
- add `.github/workflows/build-sdk-go.yml` so pull requests and `main` pushes validate the Go SDK and the generated stubs
- run the same proto-sync check during `sdk/go` release validation in `.github/workflows/release-sdk.yml`
- pin the remote Buf plugin versions in `sdk/proto/buf.gen.yaml` so generation is deterministic over time

## Why
The SDK release flow now scopes notes to `sdk/go` and `sdk/proto`, but there was still no CI guard ensuring proto changes were reflected in committed generated Go code. That left room for drift and broken SDK releases.

## Validation
- `bash -n sdk/proto/check-go-sdk-sync.sh`
- `sdk/proto/check-go-sdk-sync.sh`
- `cd sdk/go && go test ./...`
- `git diff --check`
- `actionlint .github/workflows/build-sdk-go.yml .github/workflows/release-sdk.yml`