### PR TITLE
Simplify executable plugin static contract

### DIFF
--- a/docs/pages/plugins/writing-a-plugin.mdx
+++ b/docs/pages/plugins/writing-a-plugin.mdx
@@ -17,7 +17,8 @@ go get github.com/valon-technologies/gestalt/sdk/go
 
 ## Implement the provider
 
-A provider plugin implements the `gestalt.Provider` interface:
+A provider plugin implements the runtime `gestalt.Provider` interface. Static
+metadata and static operations live in the manifest:
 
 ```go
 package main
@@ -38,12 +39,6 @@ type myProvider struct {
 	greeting string
 }
 
-func (p *myProvider) Name() string           { return "my-plugin" }
-func (p *myProvider) DisplayName() string    { return "My Plugin" }
-func (p *myProvider) Description() string    { return "A custom provider plugin" }
-func (p *myProvider) ConnectionMode() gestalt.ConnectionMode {
-	return gestalt.ConnectionModeNone
-}
 func (p *myProvider) Configure(
 	ctx context.Context,
 	name string,
@@ -53,29 +48,6 @@ func (p *myProvider) Configure(
 		p.greeting = g
 	}
 	return nil
-}
-
-func (p *myProvider) Catalog() *gestalt.Catalog {
-	return &gestalt.Catalog{
-		Name:        p.Name(),
-		DisplayName: p.DisplayName(),
-		Description: p.Description(),
-		Operations: []gestalt.CatalogOperation{
-			{
-				ID:          "greet",
-				Description: "Return a greeting",
-				Method:      http.MethodGet,
-				Parameters: []gestalt.CatalogParameter{
-					{
-						Name:        "name",
-						Type:        "string",
-						Description: "Name to greet",
-						Required:    true,
-					},
-				},
-			},
-		},
-	}
 }
 
 func (p *myProvider) Execute(
@@ -124,24 +96,8 @@ Every plugin must implement these methods:
 
 | Method | Purpose |
 | --- | --- |
-| `Name()` | Internal identifier for the provider. |
-| `DisplayName()` | Human-readable name shown in the UI and API. |
-| `Description()` | Brief description of what the provider does. |
-| `ConnectionMode()` | How the provider authenticates with upstream APIs. |
 | `Configure()` | One-time startup hook. Receives the provider name and the `config` block from the YAML. |
-| `Catalog()` | Returns the list of operations the provider supports. |
 | `Execute()` | Handles an operation invocation. Receives the operation ID, input parameters, and the caller's access token. |
-
-### Connection modes
-
-| Mode | Constant | Description |
-| --- | --- | --- |
-| None | `ConnectionModeNone` | No credential needed. |
-| User | `ConnectionModeUser` | Each user provides their own credential. |
-| Identity | `ConnectionModeIdentity` | A shared service credential is used. |
-| Either | `ConnectionModeEither` | Prefer user credentials, fall back to shared. |
-
-When the connection mode is `user` or `either`, the `token` parameter in `Execute` contains the caller's OAuth access token.
 
 ## Optional interfaces
 
@@ -152,6 +108,34 @@ Plugins can implement additional interfaces for advanced behavior:
 | `SessionCatalogProvider` | `CatalogForRequest(ctx, token)` | Return a different operation catalog based on the caller's credentials. |
 
 Provider config schemas belong in the manifest via `provider.config_schema_path`, not in the Go provider interface.
+
+Static plugin metadata also belongs in the manifest:
+
+```yaml
+source: example.com/my-plugin
+version: 0.1.0
+display_name: My Plugin
+description: A custom provider plugin
+kinds:
+  - provider
+provider:
+  auth:
+    type: none
+  static_catalog_path: catalog.yaml
+```
+
+```yaml
+name: my-plugin
+operations:
+  - id: greet
+    method: GET
+    description: Return a greeting
+    parameters:
+      - name: name
+        type: string
+        description: Name to greet
+        required: true
+```
 
 ### Using Configure
 
@@ -177,6 +161,7 @@ providers:
   my-plugin:
     from:
       command: ./my-plugin
+      manifest: ./plugin.yaml
     config:
       greeting: Howdy
 ```
@@ -192,9 +177,9 @@ go build -o my-plugin .
 ```yaml
 providers:
   my-plugin:
-    display_name: My Plugin
     from:
       command: ./my-plugin
+      manifest: ./plugin.yaml
     config:
       greeting: Hello
     mcp:

--- a/examples/plugins/provider-go/catalog.yaml
+++ b/examples/plugins/provider-go/catalog.yaml
@@ -1,0 +1,21 @@
+name: example
+operations:
+  - id: greet
+    method: GET
+    description: Return a greeting message
+    parameters:
+      - name: name
+        type: string
+        description: Name to greet
+        required: true
+  - id: echo
+    method: POST
+    description: Echo back the input
+    parameters:
+      - name: message
+        type: string
+        description: Message to echo
+        required: true
+  - id: status
+    method: GET
+    description: Return provider startup state

--- a/examples/plugins/provider-go/config.yaml
+++ b/examples/plugins/provider-go/config.yaml
@@ -16,5 +16,6 @@ integrations:
   example:
     plugin:
       command: ./provider-go
+      manifest: ./plugin.yaml
       config:
         greeting: "Hello from example plugin"

--- a/examples/plugins/provider-go/main.go
+++ b/examples/plugins/provider-go/main.go
@@ -17,51 +17,12 @@ type exampleProvider struct {
 	startedName string
 }
 
-func (p *exampleProvider) Name() string        { return "example" }
-func (p *exampleProvider) DisplayName() string { return "Example Provider" }
-func (p *exampleProvider) Description() string {
-	return "A minimal example provider built with the public SDK"
-}
-func (p *exampleProvider) ConnectionMode() gestalt.ConnectionMode {
-	return gestalt.ConnectionModeNone
-}
 func (p *exampleProvider) Configure(_ context.Context, name string, config map[string]any) error {
 	p.startedName = name
 	if g, ok := config["greeting"].(string); ok {
 		p.greeting = g
 	}
 	return nil
-}
-
-func (p *exampleProvider) Catalog() *gestalt.Catalog {
-	return &gestalt.Catalog{
-		Name:        p.Name(),
-		DisplayName: p.DisplayName(),
-		Description: p.Description(),
-		Operations: []gestalt.CatalogOperation{
-			{
-				ID:          "greet",
-				Description: "Return a greeting message",
-				Method:      http.MethodGet,
-				Parameters: []gestalt.CatalogParameter{
-					{Name: "name", Type: "string", Description: "Name to greet", Required: true},
-				},
-			},
-			{
-				ID:          "echo",
-				Description: "Echo back the input",
-				Method:      http.MethodPost,
-				Parameters: []gestalt.CatalogParameter{
-					{Name: "message", Type: "string", Description: "Message to echo", Required: true},
-				},
-			},
-			{
-				ID:          "status",
-				Description: "Return provider startup state",
-				Method:      http.MethodGet,
-			},
-		},
-	}
 }
 
 func (p *exampleProvider) Execute(_ context.Context, operation string, params map[string]any, _ string) (*gestalt.OperationResult, error) {

--- a/examples/plugins/provider-go/plugin.yaml
+++ b/examples/plugins/provider-go/plugin.yaml
@@ -1,0 +1,10 @@
+source: example.com/provider-go
+version: 0.1.0
+display_name: Example Provider
+description: A minimal example provider built with the public SDK
+kinds:
+  - provider
+provider:
+  auth:
+    type: none
+  static_catalog_path: catalog.yaml

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -172,6 +172,11 @@ func TestE2EInitDirectoryPackage(t *testing.T) {
 	if entry.SourceDigest == "" {
 		t.Fatal("expected non-empty SourceDigest for directory package")
 	}
+
+	out, err = exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd validate: %v\n%s", err, out)
+	}
 }
 
 //nolint:paralleltest // Uses a process-wide HTTP transport override so the TLS package fetch trusts the test server.

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -927,6 +927,7 @@ surfaces:
 			name: "headers unsupported without declarative ops or spec surface",
 			pluginYAML: `from:
   command: /tmp/provider
+  manifest: /tmp/plugin.yaml
 headers:
   x-test: value`,
 			wantError: "plugin.headers are only valid when the plugin exposes declarative operations or a spec surface; remove plugin.headers or configure declarative operations, OpenAPI, GraphQL, or MCP",
@@ -935,6 +936,7 @@ headers:
 			name: "managed parameters unsupported without api surface",
 			pluginYAML: `from:
   command: /tmp/provider
+  manifest: /tmp/plugin.yaml
 managed_parameters:
   - in: header
     name: x-version
@@ -1192,6 +1194,9 @@ func writeManifest(t *testing.T, pluginDir, version string) {
 
 func writeManifestFile(t *testing.T, pluginDir string, manifest *pluginmanifestv1.Manifest) {
 	t.Helper()
+	if manifest.Provider != nil && manifest.Entrypoints.Provider != nil && manifest.Provider.StaticCatalogPath == "" {
+		manifest.Provider.StaticCatalogPath = "catalog.yaml"
+	}
 
 	data, err := pluginpkg.EncodeManifest(manifest)
 	if err != nil {
@@ -1199,6 +1204,11 @@ func writeManifestFile(t *testing.T, pluginDir string, manifest *pluginmanifestv
 	}
 	if err := os.WriteFile(filepath.Join(pluginDir, pluginpkg.ManifestFile), data, 0o644); err != nil {
 		t.Fatalf("write manifest: %v", err)
+	}
+	if manifest.Provider != nil && manifest.Provider.StaticCatalogPath != "" {
+		if err := os.WriteFile(filepath.Join(pluginDir, filepath.FromSlash(manifest.Provider.StaticCatalogPath)), []byte("name: provider\noperations:\n  - id: greet\n    method: GET\n  - id: echo\n    method: POST\n  - id: status\n    method: GET\n"), 0o644); err != nil {
+			t.Fatalf("write catalog: %v", err)
+		}
 	}
 }
 
@@ -1738,13 +1748,7 @@ paths:
 			},
 		},
 	}
-	data, err := pluginpkg.EncodeManifest(manifest)
-	if err != nil {
-		t.Fatalf("EncodeManifest: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(pluginDir, pluginpkg.ManifestFile), data, 0o644); err != nil {
-		t.Fatalf("write manifest: %v", err)
-	}
+	writeManifestFile(t, pluginDir, manifest)
 
 	return pluginDir
 }

--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -563,6 +563,9 @@ func copyReleasePackageFiles(manifest *pluginmanifestv1.Manifest, sourceDir, sta
 		if err := copyPath(manifest.Provider.ConfigSchemaPath, false); err != nil {
 			return err
 		}
+		if err := copyPath(manifest.Provider.StaticCatalogPath, false); err != nil {
+			return err
+		}
 		if err := copyMaybeLocalPath(manifest.Provider.OpenAPI, false); err != nil {
 			return err
 		}

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -1075,7 +1075,8 @@ func newPluginPackageFixture(t *testing.T, dir string) string {
 		Version: "0.1.0",
 		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
-			ConfigSchemaPath: "schemas/config.schema.json",
+			StaticCatalogPath: "catalog.yaml",
+			ConfigSchemaPath:  "schemas/config.schema.json",
 		},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
@@ -1097,6 +1098,9 @@ func newPluginPackageFixture(t *testing.T, dir string) string {
 	}
 	if err := os.WriteFile(filepath.Join(src, "plugin.json"), manifestData, 0644); err != nil {
 		t.Fatalf("WriteFile(plugin.json): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "catalog.yaml"), []byte("name: provider\noperations:\n  - id: echo\n    method: POST\n"), 0644); err != nil {
+		t.Fatalf("WriteFile(catalog.yaml): %v", err)
 	}
 	return src
 }
@@ -1480,6 +1484,9 @@ func writeReleaseTestManifest(t *testing.T, dir string, manifest *pluginmanifest
 
 func writeReleaseTestManifestFormat(t *testing.T, dir, manifestFile string, manifest *pluginmanifestv1.Manifest) {
 	t.Helper()
+	if manifest.Provider != nil && manifest.Entrypoints.Provider != nil && manifest.Provider.StaticCatalogPath == "" {
+		manifest.Provider.StaticCatalogPath = "catalog.yaml"
+	}
 
 	populateMissingArtifactDigests(t, dir, manifest)
 	data, err := encodeTestManifestFormat(manifest, pluginpkg.ManifestFormatFromPath(manifestFile))
@@ -1487,6 +1494,9 @@ func writeReleaseTestManifestFormat(t *testing.T, dir, manifestFile string, mani
 		t.Fatalf("encodeTestManifestFormat(%s): %v", manifestFile, err)
 	}
 	writeTestFile(t, dir, manifestFile, data, 0644)
+	if manifest.Provider != nil && manifest.Provider.StaticCatalogPath != "" {
+		writeTestFile(t, dir, manifest.Provider.StaticCatalogPath, []byte("name: provider\noperations:\n  - id: echo\n    method: POST\n"), 0644)
+	}
 }
 
 func populateMissingArtifactDigests(t *testing.T, dir string, manifest *pluginmanifestv1.Manifest) {

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -129,6 +129,20 @@ func (m providerMetadata) applyToDefinition(def *provider.Definition) {
 	}
 }
 
+func (m providerMetadata) displayNameOr(v string) string {
+	if m.displayName != "" {
+		return m.displayName
+	}
+	return v
+}
+
+func (m providerMetadata) descriptionOr(v string) string {
+	if m.description != "" {
+		return m.description
+	}
+	return v
+}
+
 type Deps struct {
 	EncryptionKey []byte
 	BaseURL       string
@@ -1177,22 +1191,22 @@ func buildPluginProvider(ctx context.Context, intg config.IntegrationDef, plugin
 	return prov, nil
 }
 
-func buildPluginStaticSpec(name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, _ providerMetadata) (pluginhost.StaticProviderSpec, error) {
+func buildPluginStaticSpec(name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, meta providerMetadata) (pluginhost.StaticProviderSpec, error) {
 	if manifest == nil || manifest.Provider == nil {
 		return pluginhost.StaticProviderSpec{}, fmt.Errorf("resolved manifest is required")
 	}
 
-	displayName := manifest.DisplayName
+	displayName := meta.displayNameOr(manifest.DisplayName)
 	if displayName == "" {
 		displayName = name
 	}
-	description := manifest.Description
-	iconSVG := ""
+	description := meta.descriptionOr(manifest.Description)
+	iconSVG := meta.iconSVG
 	if iconPath := intg.Plugin.ResolvedIconFile; iconPath != "" {
 		svg, err := provider.ReadIconFile(iconPath)
 		if err != nil {
 			slog.Warn("could not read manifest icon_file", "path", iconPath, "error", err)
-		} else {
+		} else if iconSVG == "" {
 			iconSVG = svg
 		}
 	}
@@ -1214,6 +1228,17 @@ func buildPluginStaticSpec(name string, intg config.IntegrationDef, manifest *pl
 	}
 	if staticCatalog == nil && !manifest.Provider.IsManifestBacked() {
 		return pluginhost.StaticProviderSpec{}, fmt.Errorf("executable providers without declarative or spec surfaces must define provider.static_catalog_path")
+	}
+	if staticCatalog != nil {
+		if displayName != "" {
+			staticCatalog.DisplayName = displayName
+		}
+		if description != "" {
+			staticCatalog.Description = description
+		}
+		if iconSVG != "" {
+			staticCatalog.IconSVG = iconSVG
+		}
 	}
 
 	return pluginhost.StaticProviderSpec{

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -23,6 +23,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/openapi"
 	"github.com/valon-technologies/gestalt/server/internal/operationexposure"
 	"github.com/valon-technologies/gestalt/server/internal/pluginhost"
+	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
@@ -126,27 +127,6 @@ func (m providerMetadata) applyToDefinition(def *provider.Definition) {
 	if m.iconSVG != "" {
 		def.IconSVG = m.iconSVG
 	}
-}
-
-func (m providerMetadata) displayNameOr(v string) string {
-	if m.displayName != "" {
-		return m.displayName
-	}
-	return v
-}
-
-func (m providerMetadata) descriptionOr(v string) string {
-	if m.description != "" {
-		return m.description
-	}
-	return v
-}
-
-func (m providerMetadata) iconSVGOr(v string) string {
-	if m.iconSVG != "" {
-		return m.iconSVG
-	}
-	return v
 }
 
 type Deps struct {
@@ -746,10 +726,6 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 }
 
 func buildExternalPluginProvider(ctx context.Context, name string, intg config.IntegrationDef, pluginConfig map[string]any, meta providerMetadata, deps Deps, regStore *lazyRegStore) (*ProviderBuildResult, error) {
-	pluginProv, err := buildPluginProvider(ctx, name, intg, pluginConfig, meta)
-	if err != nil {
-		return nil, err
-	}
 	manifest := intg.Plugin.ResolvedManifest
 	manifestProvider := intg.Plugin.ManifestProvider()
 	allowedOperations := intg.Plugin.AllowedOperations
@@ -757,7 +733,6 @@ func buildExternalPluginProvider(ctx context.Context, name string, intg config.I
 	if intg.Plugin.HasResolvedManifest() {
 		resolvedManifest, resolvedAllowedOperations, err := config.EffectiveManifestBackedInputs(name, intg.Plugin)
 		if err != nil {
-			closeIfPossible(pluginProv)
 			return nil, err
 		}
 		manifest = resolvedManifest
@@ -766,6 +741,18 @@ func buildExternalPluginProvider(ctx context.Context, name string, intg config.I
 		}
 		allowedOperations = resolvedAllowedOperations
 		specPlugin = nil
+	}
+	if manifest == nil || manifestProvider == nil {
+		return nil, fmt.Errorf("build external plugin provider %q: executable plugins must be manifest-backed", name)
+	}
+
+	staticSpec, err := buildPluginStaticSpec(name, intg, manifest, meta)
+	if err != nil {
+		return nil, fmt.Errorf("build external plugin provider %q: %w", name, err)
+	}
+	pluginProv, err := buildPluginProvider(ctx, intg, pluginConfig, staticSpec)
+	if err != nil {
+		return nil, err
 	}
 	plan, err := buildPluginConnectionPlan(intg.Plugin, manifestProvider)
 	if err != nil {
@@ -790,9 +777,9 @@ func buildExternalPluginProvider(ctx context.Context, name string, intg config.I
 		}
 		merged, err := composite.NewMergedWithConnections(
 			name,
-			meta.displayNameOr(pluginProv.DisplayName()),
-			meta.descriptionOr(pluginProv.Description()),
-			meta.iconSVGOr(firstProviderIconSVG(pluginProv, apiProv)),
+			pluginProv.DisplayName(),
+			pluginProv.Description(),
+			firstProviderIconSVG(pluginProv, apiProv),
 			composite.BoundProvider{Provider: pluginProv, Connection: config.PluginConnectionName},
 			composite.BoundProvider{Provider: apiProv, Connection: plan.apiConnection()},
 		)
@@ -834,9 +821,9 @@ func buildExternalPluginProvider(ctx context.Context, name string, intg config.I
 	}
 	merged, err := composite.NewMergedWithConnections(
 		name,
-		meta.displayNameOr(pluginProv.DisplayName()),
-		meta.descriptionOr(pluginProv.Description()),
-		meta.iconSVGOr(firstProviderIconSVG(pluginProv, specProv)),
+		pluginProv.DisplayName(),
+		pluginProv.Description(),
+		firstProviderIconSVG(pluginProv, specProv),
 		composite.BoundProvider{Provider: pluginProv, Connection: config.PluginConnectionName},
 		composite.BoundProvider{Provider: specProv, Connection: resolved.connectionName},
 	)
@@ -1174,15 +1161,12 @@ func catalogOperationCount(cat *catalog.Catalog) int {
 	return len(cat.Operations)
 }
 
-func buildPluginProvider(ctx context.Context, name string, intg config.IntegrationDef, pluginConfig map[string]any, meta providerMetadata) (core.Provider, error) {
+func buildPluginProvider(ctx context.Context, intg config.IntegrationDef, pluginConfig map[string]any, spec pluginhost.StaticProviderSpec) (core.Provider, error) {
 	prov, err := pluginhost.NewExecutableProvider(ctx, pluginhost.ExecConfig{
 		Command:      intg.Plugin.Command,
 		Args:         intg.Plugin.Args,
 		Env:          intg.Plugin.Env,
-		Name:         name,
-		DisplayName:  meta.displayName,
-		Description:  meta.description,
-		IconSVG:      meta.iconSVG,
+		StaticSpec:   spec,
 		Config:       pluginConfig,
 		AllowedHosts: intg.Plugin.AllowedHosts,
 		HostBinary:   intg.Plugin.HostBinary,
@@ -1191,6 +1175,70 @@ func buildPluginProvider(ctx context.Context, name string, intg config.Integrati
 		return nil, err
 	}
 	return prov, nil
+}
+
+func buildPluginStaticSpec(name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, _ providerMetadata) (pluginhost.StaticProviderSpec, error) {
+	if manifest == nil || manifest.Provider == nil {
+		return pluginhost.StaticProviderSpec{}, fmt.Errorf("resolved manifest is required")
+	}
+
+	displayName := manifest.DisplayName
+	if displayName == "" {
+		displayName = name
+	}
+	description := manifest.Description
+	iconSVG := ""
+	if iconPath := intg.Plugin.ResolvedIconFile; iconPath != "" {
+		svg, err := provider.ReadIconFile(iconPath)
+		if err != nil {
+			slog.Warn("could not read manifest icon_file", "path", iconPath, "error", err)
+		} else {
+			iconSVG = svg
+		}
+	}
+
+	conn := config.EffectivePluginConnectionDef(intg.Plugin, manifest.Provider)
+	connMode := core.ConnectionMode(conn.Mode)
+	if connMode == "" {
+		switch conn.Auth.Type {
+		case "", pluginmanifestv1.AuthTypeNone:
+			connMode = core.ConnectionModeNone
+		default:
+			connMode = core.ConnectionModeUser
+		}
+	}
+
+	staticCatalog, err := pluginpkg.ReadStaticCatalog(manifest.Provider.StaticCatalogPath, name)
+	if err != nil {
+		return pluginhost.StaticProviderSpec{}, err
+	}
+	if staticCatalog == nil && !manifest.Provider.IsManifestBacked() {
+		return pluginhost.StaticProviderSpec{}, fmt.Errorf("executable providers without declarative or spec surfaces must define provider.static_catalog_path")
+	}
+
+	return pluginhost.StaticProviderSpec{
+		Name:             name,
+		DisplayName:      displayName,
+		Description:      description,
+		IconSVG:          iconSVG,
+		ConnectionMode:   connMode,
+		Catalog:          staticCatalog,
+		AuthTypes:        staticAuthTypes(conn.Auth.Type),
+		ConnectionParams: pluginhost.ConnectionParamDefsFromManifest(conn.ConnectionParams),
+		CredentialFields: pluginhost.CredentialFieldsFromManifest(conn.Auth.Credentials),
+		DiscoveryConfig:  pluginhost.DiscoveryConfigFromManifest(manifest.Provider.PostConnectDiscovery),
+	}, nil
+}
+
+func staticAuthTypes(authType string) []string {
+	switch authType {
+	case "", pluginmanifestv1.AuthTypeNone:
+		return nil
+	case pluginmanifestv1.AuthTypeManual, pluginmanifestv1.AuthTypeBearer:
+		return []string{"manual"}
+	default:
+		return []string{"oauth"}
+	}
 }
 
 func buildOAuthHandlerFromAuth(auth *config.ConnectionAuthDef, pluginConfig map[string]any, deps Deps) (OAuthHandler, error) {

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -106,6 +106,77 @@ func TestExecutableSDKExampleProviderReceivesStartConfig(t *testing.T) {
 	}
 }
 
+func TestExecutableSDKExampleProviderAppliesConfigMetadataOverrides(t *testing.T) {
+	t.Parallel()
+
+	const iconSVG = `<svg viewBox="0 0 10 10"><rect x="1" y="1" width="8" height="8"/></svg>`
+
+	bin := buildExampleProviderBinary(t)
+	iconPath := t.TempDir() + "/override.svg"
+	if err := os.WriteFile(iconPath, []byte(iconSVG), 0o644); err != nil {
+		t.Fatalf("WriteFile(icon): %v", err)
+	}
+
+	manifest := newExecutableManifest(
+		"Manifest Display",
+		"Manifest Description",
+		writeStaticCatalog(t, &catalog.Catalog{
+			Name:        "example",
+			DisplayName: "Catalog Display",
+			Description: "Catalog Description",
+			Operations: []catalog.CatalogOperation{
+				{ID: "status", Method: http.MethodGet},
+			},
+		}),
+	)
+
+	cfg := &config.Config{
+		Integrations: map[string]config.IntegrationDef{
+			"example": {
+				DisplayName: "Config Display",
+				Description: "Config Description",
+				IconFile:    iconPath,
+				Plugin: &config.PluginDef{
+					Command:          bin,
+					ResolvedManifest: manifest,
+				},
+			},
+		},
+	}
+
+	factories := NewFactoryRegistry()
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	prov, err := providers.Get("example")
+	if err != nil {
+		t.Fatalf("providers.Get(example): %v", err)
+	}
+	if prov.DisplayName() != "Config Display" {
+		t.Fatalf("DisplayName = %q, want %q", prov.DisplayName(), "Config Display")
+	}
+	if prov.Description() != "Config Description" {
+		t.Fatalf("Description = %q, want %q", prov.Description(), "Config Description")
+	}
+
+	cat := prov.Catalog()
+	if cat == nil {
+		t.Fatal("expected non-nil catalog")
+	}
+	if cat.DisplayName != "Config Display" {
+		t.Fatalf("catalog DisplayName = %q, want %q", cat.DisplayName, "Config Display")
+	}
+	if cat.Description != "Config Description" {
+		t.Fatalf("catalog Description = %q, want %q", cat.Description, "Config Description")
+	}
+	if cat.IconSVG != iconSVG {
+		t.Fatalf("catalog IconSVG = %q, want %q", cat.IconSVG, iconSVG)
+	}
+}
+
 func buildEchoPluginBinary(t *testing.T) string {
 	t.Helper()
 	if sharedEchoPluginBin == "" {

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"runtime"
 	"testing"
 	"time"
@@ -20,11 +21,24 @@ func TestExecutableSDKExampleProviderReceivesStartConfig(t *testing.T) {
 	t.Parallel()
 
 	bin := buildExampleProviderBinary(t)
+	manifest := newExecutableManifest(
+		"Example Provider",
+		"A minimal example provider built with the public SDK",
+		writeStaticCatalog(t, &catalog.Catalog{
+			Name: "example",
+			Operations: []catalog.CatalogOperation{
+				{ID: "greet", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+				{ID: "echo", Method: http.MethodPost, Parameters: []catalog.CatalogParameter{{Name: "message", Type: "string", Required: true}}},
+				{ID: "status", Method: http.MethodGet},
+			},
+		}),
+	)
 	cfg := &config.Config{
 		Integrations: map[string]config.IntegrationDef{
 			"example": {
 				Plugin: &config.PluginDef{
-					Command: bin,
+					Command:          bin,
+					ResolvedManifest: manifest,
 					Config: mustNode(t, map[string]any{
 						"greeting": "Hello from config",
 					}),
@@ -43,6 +57,22 @@ func TestExecutableSDKExampleProviderReceivesStartConfig(t *testing.T) {
 	prov, err := providers.Get("example")
 	if err != nil {
 		t.Fatalf("providers.Get(example): %v", err)
+	}
+	if prov.DisplayName() != "Example Provider" {
+		t.Fatalf("DisplayName = %q", prov.DisplayName())
+	}
+	if prov.Description() != "A minimal example provider built with the public SDK" {
+		t.Fatalf("Description = %q", prov.Description())
+	}
+	cat := prov.Catalog()
+	if cat == nil || len(cat.Operations) != 3 {
+		t.Fatalf("unexpected catalog: %+v", cat)
+	}
+	if cat.DisplayName != "Example Provider" || cat.Description != "A minimal example provider built with the public SDK" {
+		t.Fatalf("unexpected catalog metadata: %+v", cat)
+	}
+	if cat.Operations[0].Transport != catalog.TransportPlugin {
+		t.Fatalf("unexpected catalog transport: %+v", cat.Operations[0])
 	}
 
 	result, err := prov.Execute(context.Background(), "greet", map[string]any{"name": "Gestalt"}, "")
@@ -101,29 +131,48 @@ func mustNode(t *testing.T, value any) yaml.Node {
 	return node
 }
 
+func writeStaticCatalog(t *testing.T, cat *catalog.Catalog) string {
+	t.Helper()
+	data, err := yaml.Marshal(cat)
+	if err != nil {
+		t.Fatalf("yaml.Marshal(catalog): %v", err)
+	}
+	path := t.TempDir() + "/catalog.yaml"
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile(catalog): %v", err)
+	}
+	return path
+}
+
+func newExecutableManifest(displayName, description, staticCatalogPath string) *pluginmanifestv1.Manifest {
+	return &pluginmanifestv1.Manifest{
+		Source:      "github.com/acme/plugins/test",
+		Version:     "1.0.0",
+		Kinds:       []string{pluginmanifestv1.KindProvider},
+		DisplayName: displayName,
+		Description: description,
+		Provider: &pluginmanifestv1.Provider{
+			StaticCatalogPath: staticCatalogPath,
+		},
+	}
+}
+
 func TestPluginManifestOAuthWiresConnectionAuth(t *testing.T) {
 	t.Parallel()
 
 	bin := buildEchoPluginBinary(t)
 
-	manifest := &pluginmanifestv1.Manifest{
-		Source:  "github.com/acme/plugins/echo",
-		Version: "1.0.0",
-		Kinds:   []string{pluginmanifestv1.KindProvider},
-		Provider: &pluginmanifestv1.Provider{
-			Auth: &pluginmanifestv1.ProviderAuth{
-				Type:             pluginmanifestv1.AuthTypeOAuth2,
-				AuthorizationURL: "https://example.com/authorize",
-				TokenURL:         "https://example.com/token",
-				Scopes:           []string{"read", "write"},
-			},
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters", writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoauth",
+		Operations: []catalog.CatalogOperation{
+			{ID: "echo", Method: http.MethodPost},
 		},
-		Artifacts: []pluginmanifestv1.Artifact{
-			{OS: runtime.GOOS, Arch: runtime.GOARCH, Path: "artifacts/" + runtime.GOOS + "/" + runtime.GOARCH + "/provider", SHA256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
-		},
-		Entrypoints: pluginmanifestv1.Entrypoints{
-			Provider: &pluginmanifestv1.Entrypoint{ArtifactPath: "artifacts/" + runtime.GOOS + "/" + runtime.GOARCH + "/provider"},
-		},
+	}))
+	manifest.Provider.Auth = &pluginmanifestv1.ProviderAuth{
+		Type:             pluginmanifestv1.AuthTypeOAuth2,
+		AuthorizationURL: "https://example.com/authorize",
+		TokenURL:         "https://example.com/token",
+		Scopes:           []string{"read", "write"},
 	}
 	cfg := &config.Config{
 		Integrations: map[string]config.IntegrationDef{
@@ -180,18 +229,12 @@ func TestPluginManifestNoAuthSkipsConnectionAuth(t *testing.T) {
 
 	bin := buildEchoPluginBinary(t)
 
-	manifest := &pluginmanifestv1.Manifest{
-		Source:   "github.com/acme/plugins/echo",
-		Version:  "1.0.0",
-		Kinds:    []string{pluginmanifestv1.KindProvider},
-		Provider: &pluginmanifestv1.Provider{},
-		Artifacts: []pluginmanifestv1.Artifact{
-			{OS: runtime.GOOS, Arch: runtime.GOARCH, Path: "artifacts/" + runtime.GOOS + "/" + runtime.GOARCH + "/provider", SHA256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters", writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echonoauth",
+		Operations: []catalog.CatalogOperation{
+			{ID: "echo", Method: http.MethodPost},
 		},
-		Entrypoints: pluginmanifestv1.Entrypoints{
-			Provider: &pluginmanifestv1.Entrypoint{ArtifactPath: "artifacts/" + runtime.GOOS + "/" + runtime.GOARCH + "/provider"},
-		},
-	}
+	}))
 	cfg := &config.Config{
 		Integrations: map[string]config.IntegrationDef{
 			"echonoauth": {
@@ -219,13 +262,21 @@ func TestPluginManifestNoAuthSkipsConnectionAuth(t *testing.T) {
 func TestPluginProcessEnvIsolation(t *testing.T) {
 	t.Parallel()
 	bin := buildEchoPluginBinary(t)
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters", writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "echo", Method: http.MethodPost},
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	}))
 
 	cfg := &config.Config{
 		Integrations: map[string]config.IntegrationDef{
 			"echoext": {
 				Plugin: &config.PluginDef{
-					Command: bin,
-					Args:    []string{"provider"},
+					Command:          bin,
+					Args:             []string{"provider"},
+					ResolvedManifest: manifest,
 				},
 			},
 		},
@@ -271,6 +322,31 @@ func TestPluginProcessEnvIsolation(t *testing.T) {
 	}
 }
 
+func TestExecutablePluginRequiresManifest(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	cfg := &config.Config{
+		Integrations: map[string]config.IntegrationDef{
+			"echoext": {
+				Plugin: &config.PluginDef{
+					Command: bin,
+					Args:    []string{"provider"},
+				},
+			},
+		},
+	}
+
+	factories := NewFactoryRegistry()
+	_, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	if err == nil {
+		t.Fatal("expected buildProvidersStrict to reject executable plugin without manifest")
+	}
+	if got := err.Error(); got != `bootstrap: provider validation failed: integration "echoext": build external plugin provider "echoext": executable plugins must be manifest-backed` {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestHybridPluginMergesCommandAndOpenAPI(t *testing.T) {
 	t.Parallel()
 
@@ -309,13 +385,21 @@ func TestHybridPluginMergesCommandAndOpenAPI(t *testing.T) {
 	}))
 	testutil.CloseOnCleanup(t, specSrv)
 
+	manifest := newExecutableManifest("Hybrid", "", writeStaticCatalog(t, &catalog.Catalog{
+		Name: "hybrid",
+		Operations: []catalog.CatalogOperation{
+			{ID: "echo", Method: http.MethodPost},
+		},
+	}))
+	manifest.Provider.OpenAPI = specSrv.URL
+
 	cfg := &config.Config{
 		Integrations: map[string]config.IntegrationDef{
 			"hybrid": {
 				Plugin: &config.PluginDef{
-					Command: bin,
-					Args:    []string{"provider"},
-					OpenAPI: specSrv.URL,
+					Command:          bin,
+					Args:             []string{"provider"},
+					ResolvedManifest: manifest,
 				},
 			},
 		},
@@ -379,6 +463,12 @@ func TestHybridPluginMergesCommandAndDeclarativeREST(t *testing.T) {
 		Version: "1.0.0",
 		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
+			StaticCatalogPath: writeStaticCatalog(t, &catalog.Catalog{
+				Name: "hybrid",
+				Operations: []catalog.CatalogOperation{
+					{ID: "echo", Method: http.MethodPost},
+				},
+			}),
 			BaseURL: apiSrv.URL,
 			Operations: []pluginmanifestv1.ProviderOperation{
 				{

--- a/gestaltd/internal/bootstrap/sandbox_test.go
+++ b/gestaltd/internal/bootstrap/sandbox_test.go
@@ -14,7 +14,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
 
 func buildGestaltdBinary(t *testing.T) string {
@@ -34,6 +36,14 @@ func hostFromTestServer(t *testing.T, ts *httptest.Server) string {
 	return host
 }
 
+func echoExecutableManifest(t *testing.T, name string, ops ...catalog.CatalogOperation) *pluginmanifestv1.Manifest {
+	t.Helper()
+	return newExecutableManifest("Echo", "Echoes back the input parameters", writeStaticCatalog(t, &catalog.Catalog{
+		Name:       name,
+		Operations: ops,
+	}))
+}
+
 func TestSandboxedPluginCannotReadUnauthorizedFile(t *testing.T) {
 	t.Parallel()
 
@@ -44,15 +54,20 @@ func TestSandboxedPluginCannotReadUnauthorizedFile(t *testing.T) {
 
 	bin := buildEchoPluginBinary(t)
 	hostBin := buildGestaltdBinary(t)
+	manifest := echoExecutableManifest(t, "sandboxed",
+		catalog.CatalogOperation{ID: "echo", Method: http.MethodPost},
+		catalog.CatalogOperation{ID: "read_file", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "path", Type: "string", Required: true}}},
+	)
 
 	cfg := &config.Config{
 		Integrations: map[string]config.IntegrationDef{
 			"sandboxed": {
 				Plugin: &config.PluginDef{
-					Command:      bin,
-					Args:         []string{"provider"},
-					AllowedHosts: []string{"localhost"},
-					HostBinary:   hostBin,
+					Command:          bin,
+					Args:             []string{"provider"},
+					AllowedHosts:     []string{"localhost"},
+					HostBinary:       hostBin,
+					ResolvedManifest: manifest,
 				},
 			},
 		},
@@ -85,15 +100,19 @@ func TestSandboxedPluginCanCommunicateViaGRPC(t *testing.T) {
 
 	bin := buildEchoPluginBinary(t)
 	hostBin := buildGestaltdBinary(t)
+	manifest := echoExecutableManifest(t, "sandboxed",
+		catalog.CatalogOperation{ID: "echo", Method: http.MethodPost},
+	)
 
 	cfg := &config.Config{
 		Integrations: map[string]config.IntegrationDef{
 			"sandboxed": {
 				Plugin: &config.PluginDef{
-					Command:      bin,
-					Args:         []string{"provider"},
-					AllowedHosts: []string{"localhost"},
-					HostBinary:   hostBin,
+					Command:          bin,
+					Args:             []string{"provider"},
+					AllowedHosts:     []string{"localhost"},
+					HostBinary:       hostBin,
+					ResolvedManifest: manifest,
 				},
 			},
 		},
@@ -132,13 +151,18 @@ func TestSandboxDisabledByDefault(t *testing.T) {
 	}
 
 	bin := buildEchoPluginBinary(t)
+	manifest := echoExecutableManifest(t, "nosandbox",
+		catalog.CatalogOperation{ID: "echo", Method: http.MethodPost},
+		catalog.CatalogOperation{ID: "read_file", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "path", Type: "string", Required: true}}},
+	)
 
 	cfg := &config.Config{
 		Integrations: map[string]config.IntegrationDef{
 			"nosandbox": {
 				Plugin: &config.PluginDef{
-					Command: bin,
-					Args:    []string{"provider"},
+					Command:          bin,
+					Args:             []string{"provider"},
+					ResolvedManifest: manifest,
 				},
 			},
 		},
@@ -176,15 +200,19 @@ func TestSandboxedPluginHTTPProxyAllowsConfiguredHosts(t *testing.T) {
 	host := hostFromTestServer(t, ts)
 	bin := buildEchoPluginBinary(t)
 	hostBin := buildGestaltdBinary(t)
+	manifest := echoExecutableManifest(t, "proxied",
+		catalog.CatalogOperation{ID: "make_http_request", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "url", Type: "string", Required: true}}},
+	)
 
 	cfg := &config.Config{
 		Integrations: map[string]config.IntegrationDef{
 			"proxied": {
 				Plugin: &config.PluginDef{
-					Command:      bin,
-					Args:         []string{"provider"},
-					AllowedHosts: []string{host},
-					HostBinary:   hostBin,
+					Command:          bin,
+					Args:             []string{"provider"},
+					AllowedHosts:     []string{host},
+					HostBinary:       hostBin,
+					ResolvedManifest: manifest,
 				},
 			},
 		},
@@ -229,15 +257,19 @@ func TestSandboxedPluginHTTPProxyBlocksUnconfiguredHosts(t *testing.T) {
 
 	bin := buildEchoPluginBinary(t)
 	hostBin := buildGestaltdBinary(t)
+	manifest := echoExecutableManifest(t, "blocked",
+		catalog.CatalogOperation{ID: "make_http_request", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "url", Type: "string", Required: true}}},
+	)
 
 	cfg := &config.Config{
 		Integrations: map[string]config.IntegrationDef{
 			"blocked": {
 				Plugin: &config.PluginDef{
-					Command:      bin,
-					Args:         []string{"provider"},
-					AllowedHosts: []string{"not-a-real-host.example.com"},
-					HostBinary:   hostBin,
+					Command:          bin,
+					Args:             []string{"provider"},
+					AllowedHosts:     []string{"not-a-real-host.example.com"},
+					HostBinary:       hostBin,
+					ResolvedManifest: manifest,
 				},
 			},
 		},

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -93,12 +93,13 @@ type EgressCredentialGrant struct {
 }
 
 type PluginDef struct {
-	Command string            `yaml:"command"`
-	Package string            `yaml:"package"`
-	Source  string            `yaml:"source"`
-	Version string            `yaml:"version"`
-	Args    []string          `yaml:"args"`
-	Env     map[string]string `yaml:"env"`
+	Command  string            `yaml:"command"`
+	Manifest string            `yaml:"manifest"`
+	Package  string            `yaml:"package"`
+	Source   string            `yaml:"source"`
+	Version  string            `yaml:"version"`
+	Args     []string          `yaml:"args"`
+	Env      map[string]string `yaml:"env"`
 
 	Config       yaml.Node `yaml:"config"`
 	AllowedHosts []string  `yaml:"allowed_hosts"`
@@ -137,7 +138,7 @@ func (p *PluginDef) IsInline() bool {
 	if p == nil {
 		return false
 	}
-	if p.Source != "" || p.Package != "" || p.Command != "" {
+	if p.Source != "" || p.Package != "" || p.Command != "" || p.Manifest != "" {
 		return false
 	}
 	return p.OpenAPI != "" || p.GraphQLURL != "" || p.MCPURL != "" || len(p.Operations) > 0 ||
@@ -402,6 +403,9 @@ func EffectivePluginConnectionDef(plugin *PluginDef, manifestProvider *pluginman
 	conn := ConnectionDef{}
 	if manifestProvider != nil {
 		conn.Mode = manifestProvider.ConnectionMode
+		if len(manifestProvider.ConnectionParams) > 0 {
+			conn.ConnectionParams = maps.Clone(manifestProvider.ConnectionParams)
+		}
 		if manifestProvider.Auth != nil {
 			MergeConnectionAuth(&conn.Auth, ManifestAuthToConnectionAuthDef(manifestProvider.Auth))
 		}
@@ -1015,6 +1019,15 @@ func validateExternalPlugin(kind, name string, plugin *PluginDef) error {
 	if plugin.Command == "" && len(plugin.Args) > 0 {
 		return fmt.Errorf("config validation: %s %q plugin.args are only valid with plugin.command", kind, name)
 	}
+	if plugin.Command != "" && plugin.Manifest == "" && !plugin.HasResolvedManifest() {
+		return fmt.Errorf("config validation: %s %q plugin.manifest is required when plugin.command is set", kind, name)
+	}
+	if plugin.Manifest != "" && plugin.Command == "" {
+		return fmt.Errorf("config validation: %s %q plugin.manifest is only valid with plugin.command", kind, name)
+	}
+	if plugin.Manifest != "" && (plugin.Package != "" || plugin.Source != "") {
+		return fmt.Errorf("config validation: %s %q plugin.manifest cannot be combined with plugin.package or plugin.source", kind, name)
+	}
 	if strings.HasPrefix(plugin.Package, "http://") {
 		return fmt.Errorf("config validation: %s %q plugin.package requires HTTPS; plain HTTP is not supported", kind, name)
 	}
@@ -1076,6 +1089,12 @@ func validateSupportedPluginFields(name string, plugin *PluginDef) error {
 		supported bool
 		reason    string
 	}{
+		{
+			field:     "plugin.manifest",
+			present:   plugin.Manifest != "",
+			supported: plugin.Command != "",
+			reason:    "is only valid when the plugin runs from a local command; remove plugin.manifest or configure plugin.command",
+		},
 		{
 			field:     "plugin.env",
 			present:   len(plugin.Env) > 0,

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -47,6 +47,7 @@ providers:
     display_name: Service A
     from:
       command: /tmp/provider
+      manifest: /tmp/plugin.yaml
 `)
 
 	cfg, err := Load(path)
@@ -94,6 +95,7 @@ providers:
   service-a:
     from:
       command: /tmp/provider
+      manifest: /tmp/plugin.yaml
 `)
 
 	cfg, err := LoadWithMapping(path, getenv)
@@ -299,6 +301,7 @@ providers:
   service:
     from:
       command: /usr/bin/provider
+      manifest: /usr/bin/provider.yaml
 `,
 		},
 		{
@@ -370,6 +373,7 @@ providers:
   external:
     from:
       command: /tmp/plugin
+      manifest: /tmp/plugin.yaml
       package: ./plugins/dummy.tar.gz
 `,
 			wantErr: true,
@@ -642,6 +646,7 @@ providers:
     icon_file: ../assets/service.svg
     from:
       command: ../bin/provider
+      manifest: ../bin/plugin.yaml
   service-b:
     from:
       package: ../plugins/dummy.tar.gz
@@ -827,7 +832,8 @@ func TestExternalPluginRejectsInlineOperations(t *testing.T) {
 		Integrations: map[string]IntegrationDef{
 			"bad": {
 				Plugin: &PluginDef{
-					Command: "echo",
+					Command:  "echo",
+					Manifest: "plugin.yaml",
 					Operations: []InlineOperationDef{
 						{Name: "op", Method: "GET", Path: "/op"},
 					},
@@ -850,8 +856,9 @@ func TestExternalPluginAllowsSpecURL(t *testing.T) {
 		Integrations: map[string]IntegrationDef{
 			"ok": {
 				Plugin: &PluginDef{
-					Command: "echo",
-					OpenAPI: "https://example.com/spec.json",
+					Command:  "echo",
+					Manifest: "plugin.yaml",
+					OpenAPI:  "https://example.com/spec.json",
 				},
 			},
 		},

--- a/gestaltd/internal/config/provider_wire.go
+++ b/gestaltd/internal/config/provider_wire.go
@@ -26,6 +26,7 @@ type providerWire struct {
 
 type providerSourceWire struct {
 	Command      string            `yaml:"command"`
+	Manifest     string            `yaml:"manifest"`
 	Package      string            `yaml:"package"`
 	Source       string            `yaml:"source"`
 	Version      string            `yaml:"version"`
@@ -101,6 +102,7 @@ func (i *IntegrationDef) UnmarshalYAML(value *yaml.Node) error {
 
 	plugin := &PluginDef{
 		Command:           wire.From.Command,
+		Manifest:          wire.From.Manifest,
 		Package:           wire.From.Package,
 		Source:            wire.From.Source,
 		Version:           wire.From.Version,

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -656,15 +656,21 @@ func (l *Lifecycle) applyLockedPlugins(configPath, artifactsDir string, cfg *con
 
 	for name := range cfg.Integrations {
 		intg := cfg.Integrations[name]
-		if !intg.Plugin.HasManagedArtifacts() {
-			continue
-		}
 		configMap, err := config.NodeToMap(intg.Plugin.Config)
 		if err != nil {
 			return fmt.Errorf("decode plugin config for integration %q: %w", name, err)
 		}
-		if err := l.applyLockedPluginEntry(paths, lock, "integration", name, intg.Plugin, configMap); err != nil {
-			return err
+		switch {
+		case intg.Plugin.HasManagedArtifacts():
+			if err := l.applyLockedPluginEntry(paths, lock, "integration", name, intg.Plugin, configMap); err != nil {
+				return err
+			}
+		case intg.Plugin.Manifest != "":
+			if err := applyLocalPluginManifest(paths, "integration", name, intg.Plugin, configMap); err != nil {
+				return err
+			}
+		default:
+			continue
 		}
 		if manifest := intg.Plugin.ResolvedManifest; manifest != nil {
 			intg.DisplayName = cmp.Or(intg.DisplayName, manifest.DisplayName)
@@ -695,6 +701,26 @@ func (l *Lifecycle) applyLockedPlugins(configPath, artifactsDir string, cfg *con
 	}
 
 	return nil
+}
+
+func applyLocalPluginManifest(paths initPaths, kind, name string, plugin *config.PluginDef, configMap map[string]any) error {
+	if plugin == nil || plugin.Manifest == "" {
+		return nil
+	}
+
+	manifestPath := plugin.Manifest
+	if !filepath.IsAbs(manifestPath) {
+		manifestPath = filepath.Join(paths.configDir, plugin.Manifest)
+	}
+	if _, err := os.Stat(manifestPath); err != nil {
+		return fmt.Errorf("manifest for %s %q not found at %s: %w", kind, name, manifestPath, err)
+	}
+
+	_, manifest, err := pluginpkg.ReadManifestFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("read manifest for %s %q: %w", kind, name, err)
+	}
+	return bindResolvedManifest(kind, name, plugin, manifestPath, manifest, configMap)
 }
 
 func (l *Lifecycle) applyLockedPluginEntry(paths initPaths, lock *Lockfile, kind, name string, plugin *config.PluginDef, configMap map[string]any) error {
@@ -741,17 +767,10 @@ func (l *Lifecycle) applyLockedPluginEntry(paths initPaths, lock *Lockfile, kind
 	if err != nil {
 		return fmt.Errorf("read prepared manifest for %s %q: %w", kind, name, err)
 	}
-	manifest = pluginpkg.ResolveManifestLocalReferences(manifest, manifestPath)
-	if err := pluginpkg.ValidateConfigForManifest(manifestPath, manifest, manifestKind(kind), configMap); err != nil {
-		return fmt.Errorf("plugin config validation for %s %q: %w", kind, name, err)
+	if err := bindResolvedManifest(kind, name, plugin, manifestPath, manifest, configMap); err != nil {
+		return err
 	}
-
-	resolvePluginIcon(manifest, manifestPath, plugin)
-
-	plugin.ResolvedManifestPath = manifestPath
-	plugin.ResolvedManifest = manifest
-	if kind == "integration" && manifest.IsDeclarativeOnlyProvider() {
-		plugin.IsDeclarative = true
+	if kind == "integration" && plugin.IsDeclarative {
 		return nil
 	}
 
@@ -766,6 +785,18 @@ func (l *Lifecycle) applyLockedPluginEntry(paths initPaths, lock *Lockfile, kind
 
 	plugin.Command = executablePath
 	plugin.Args = append([]string(nil), args...)
+	return nil
+}
+
+func bindResolvedManifest(kind, name string, plugin *config.PluginDef, manifestPath string, manifest *pluginmanifestv1.Manifest, configMap map[string]any) error {
+	manifest = pluginpkg.ResolveManifestLocalReferences(manifest, manifestPath)
+	if err := pluginpkg.ValidateConfigForManifest(manifestPath, manifest, manifestKind(kind), configMap); err != nil {
+		return fmt.Errorf("plugin config validation for %s %q: %w", kind, name, err)
+	}
+	resolvePluginIcon(manifest, manifestPath, plugin)
+	plugin.ResolvedManifestPath = manifestPath
+	plugin.ResolvedManifest = manifest
+	plugin.IsDeclarative = kind == "integration" && manifest.IsDeclarativeOnlyProvider()
 	return nil
 }
 

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -146,7 +146,17 @@ type pluginFingerprintInput struct {
 	Version string `json:"version,omitempty"`
 }
 
-func configHasPlugins(cfg *config.Config) bool {
+func configHasPluginLoading(cfg *config.Config) bool {
+	for name := range cfg.Integrations {
+		plugin := cfg.Integrations[name].Plugin
+		if plugin.HasManagedArtifacts() || (plugin != nil && plugin.Manifest != "") {
+			return true
+		}
+	}
+	return cfg.UI.Plugin.HasManagedArtifacts()
+}
+
+func configHasManagedPlugins(cfg *config.Config) bool {
 	for name := range cfg.Integrations {
 		if cfg.Integrations[name].Plugin.HasManagedArtifacts() {
 			return true
@@ -641,21 +651,28 @@ func (l *Lifecycle) writeUIPluginArtifact(ctx context.Context, cfg *config.Confi
 }
 
 func (l *Lifecycle) applyLockedPlugins(configPath, artifactsDir string, cfg *config.Config, locked bool) error {
-	if !configHasPlugins(cfg) {
+	if !configHasPluginLoading(cfg) {
 		return nil
 	}
 
 	paths := initPathsForConfigWithArtifactsDir(configPath, resolveArtifactsDir(configPath, cfg, artifactsDir))
-	lock, err := ReadLockfile(paths.lockfilePath)
-	if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock)) {
-		lock, err = l.InitAtPathWithArtifactsDir(configPath, artifactsDir)
-	}
-	if err != nil {
-		return fmt.Errorf("plugin packages require prepared artifacts; run `gestaltd init --config %s`: %w", configPath, err)
+	var lock *Lockfile
+	var err error
+	if configHasManagedPlugins(cfg) {
+		lock, err = ReadLockfile(paths.lockfilePath)
+		if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock)) {
+			lock, err = l.InitAtPathWithArtifactsDir(configPath, artifactsDir)
+		}
+		if err != nil {
+			return fmt.Errorf("plugin packages require prepared artifacts; run `gestaltd init --config %s`: %w", configPath, err)
+		}
 	}
 
 	for name := range cfg.Integrations {
 		intg := cfg.Integrations[name]
+		if intg.Plugin == nil {
+			continue
+		}
 		configMap, err := config.NodeToMap(intg.Plugin.Config)
 		if err != nil {
 			return fmt.Errorf("decode plugin config for integration %q: %w", name, err)
@@ -665,7 +682,7 @@ func (l *Lifecycle) applyLockedPlugins(configPath, artifactsDir string, cfg *con
 			if err := l.applyLockedPluginEntry(paths, lock, "integration", name, intg.Plugin, configMap); err != nil {
 				return err
 			}
-		case intg.Plugin.Manifest != "":
+		case intg.Plugin != nil && intg.Plugin.Manifest != "":
 			if err := applyLocalPluginManifest(paths, "integration", name, intg.Plugin, configMap); err != nil {
 				return err
 			}

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -68,7 +68,7 @@ func buildV2Archive(t *testing.T, dir, source, version, binaryContent string) st
 		Source:   source,
 		Version:  version,
 		Kinds:    []string{pluginmanifestv1.KindProvider},
-		Provider: &pluginmanifestv1.Provider{},
+		Provider: &pluginmanifestv1.Provider{StaticCatalogPath: "catalog.yaml"},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
 				OS:     runtime.GOOS,
@@ -88,6 +88,9 @@ func buildV2Archive(t *testing.T, dir, source, version, binaryContent string) st
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "plugin.json"), manifestBytes, 0644); err != nil {
 		t.Fatalf("write provider manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "catalog.yaml"), []byte("name: provider\noperations:\n  - id: echo\n    method: POST\n"), 0644); err != nil {
+		t.Fatalf("write provider catalog: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, filepath.FromSlash(artPath)), []byte(binaryContent), 0755); err != nil {
 		t.Fatalf("write provider artifact: %v", err)

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -27,7 +27,7 @@ func mustBuildTestPluginDir(t *testing.T, dir, source, version, content string) 
 		Source:   source,
 		Version:  version,
 		Kinds:    []string{pluginmanifestv1.KindProvider},
-		Provider: &pluginmanifestv1.Provider{},
+		Provider: &pluginmanifestv1.Provider{StaticCatalogPath: "catalog.yaml"},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
 				OS:     runtime.GOOS,
@@ -46,6 +46,9 @@ func mustBuildTestPluginDir(t *testing.T, dir, source, version, content string) 
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, pluginpkg.ManifestFile), data, 0644); err != nil {
 		t.Fatalf("WriteFile manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "catalog.yaml"), []byte("name: provider\noperations:\n  - id: echo\n    method: POST\n"), 0644); err != nil {
+		t.Fatalf("WriteFile catalog: %v", err)
 	}
 	return srcDir
 }

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -68,6 +68,137 @@ func writeTestConfig(t *testing.T, dir, packagePath string) string {
 	return cfgPath
 }
 
+func TestLoadForExecutionAtPath_ResolvesLocalManifestCommandPluginWithoutLockfile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "plugin.yaml")
+	manifest, err := pluginpkg.EncodeManifest(&pluginmanifestv1.Manifest{
+		Source:      "github.com/testowner/plugins/local-provider",
+		Version:     "0.1.0",
+		DisplayName: "Local Provider",
+		Description: "Local manifest-backed provider",
+		Kinds:       []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			Auth:    &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeNone},
+			BaseURL: "https://example.com",
+			Operations: []pluginmanifestv1.ProviderOperation{
+				{
+					Name:   "ping",
+					Method: "GET",
+					Path:   "/ping",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(manifestPath, manifest, 0o644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `auth:
+  provider: none
+datastore:
+  provider: sqlite
+  config:
+    path: ./gestalt.db
+providers:
+  example:
+    from:
+      command: /tmp/provider
+      manifest: ./plugin.yaml
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	lc := NewLifecycle(nil)
+	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath: %v", err)
+	}
+
+	intg := loaded.Integrations["example"]
+	if intg.DisplayName != "Local Provider" {
+		t.Fatalf("DisplayName = %q", intg.DisplayName)
+	}
+	if intg.Description != "Local manifest-backed provider" {
+		t.Fatalf("Description = %q", intg.Description)
+	}
+	if intg.Plugin == nil || intg.Plugin.ResolvedManifest == nil {
+		t.Fatalf("ResolvedManifest = %+v", intg.Plugin)
+	}
+	if intg.Plugin.ResolvedManifestPath != manifestPath {
+		t.Fatalf("ResolvedManifestPath = %q, want %q", intg.Plugin.ResolvedManifestPath, manifestPath)
+	}
+	if !intg.Plugin.IsDeclarative {
+		t.Fatal("expected manifest-backed command plugin to resolve as declarative")
+	}
+	if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); !os.IsNotExist(err) {
+		t.Fatalf("lockfile should not be created, got err=%v", err)
+	}
+}
+
+func TestApplyLockedPlugins_SkipsNilIntegrationPlugins(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "plugin.yaml")
+	manifest, err := pluginpkg.EncodeManifest(&pluginmanifestv1.Manifest{
+		Source:      "github.com/testowner/plugins/local-provider",
+		Version:     "0.1.0",
+		DisplayName: "Local Provider",
+		Kinds:       []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			Auth:    &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeNone},
+			BaseURL: "https://example.com",
+			Operations: []pluginmanifestv1.ProviderOperation{
+				{Name: "ping", Method: "GET", Path: "/ping"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(manifestPath, manifest, 0o644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `auth:
+  provider: none
+datastore:
+  provider: sqlite
+  config:
+    path: ./gestalt.db
+providers:
+  example:
+    from:
+      command: /tmp/provider
+      manifest: ./plugin.yaml
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	loaded, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load config: %v", err)
+	}
+	loaded.Integrations["missing"] = config.IntegrationDef{}
+
+	lc := NewLifecycle(nil)
+	if err := lc.applyLockedPlugins(cfgPath, "", loaded, false); err != nil {
+		t.Fatalf("applyLockedPlugins: %v", err)
+	}
+	if loaded.Integrations["example"].Plugin == nil || loaded.Integrations["example"].Plugin.ResolvedManifest == nil {
+		t.Fatalf("ResolvedManifest = %+v", loaded.Integrations["example"].Plugin)
+	}
+}
+
 func TestInitAtPath_WritesLockfileWithPluginEntry(t *testing.T) {
 	t.Parallel()
 
@@ -277,6 +408,37 @@ func TestLockMatchesConfig_FalseWhenFingerprintChanged(t *testing.T) {
 	}
 	if lockMatchesConfig(cfg, paths, lock2) {
 		t.Fatal("lockMatchesConfig returned true after fingerprint was corrupted")
+	}
+}
+
+func TestLockMatchesConfig_FalseWhenStaticCatalogChanged(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := mustBuildTestPluginDir(t, dir, "github.com/testowner/plugins/provider", "0.1.0", "catalog-test-binary")
+	cfgPath := writeTestConfig(t, dir, pluginDir)
+
+	lc := NewLifecycle(nil)
+	if _, err := lc.InitAtPath(cfgPath); err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(pluginDir, "catalog.yaml"), []byte("name: provider\noperations:\n  - id: greet\n    method: GET\n"), 0644); err != nil {
+		t.Fatalf("WriteFile catalog: %v", err)
+	}
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load config: %v", err)
+	}
+	paths := initPathsForConfig(cfgPath)
+	lock, err := ReadLockfile(paths.lockfilePath)
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+
+	if lockMatchesConfig(cfg, paths, lock) {
+		t.Fatal("lockMatchesConfig returned true after static catalog changed")
 	}
 }
 

--- a/gestaltd/internal/pluginhost/convert.go
+++ b/gestaltd/internal/pluginhost/convert.go
@@ -3,42 +3,10 @@ package pluginhost
 import (
 	"encoding/json"
 
-	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 
-	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"google.golang.org/protobuf/types/known/structpb"
 )
-
-func coreConnectionModeToProto(mode core.ConnectionMode) proto.ConnectionMode {
-	switch mode {
-	case core.ConnectionModeNone:
-		return proto.ConnectionMode_CONNECTION_MODE_NONE
-	case core.ConnectionModeUser, "":
-		return proto.ConnectionMode_CONNECTION_MODE_USER
-	case core.ConnectionModeIdentity:
-		return proto.ConnectionMode_CONNECTION_MODE_IDENTITY
-	case core.ConnectionModeEither:
-		return proto.ConnectionMode_CONNECTION_MODE_EITHER
-	default:
-		return proto.ConnectionMode_CONNECTION_MODE_UNSPECIFIED
-	}
-}
-
-func protoConnectionModeToCore(mode proto.ConnectionMode) core.ConnectionMode {
-	switch mode {
-	case proto.ConnectionMode_CONNECTION_MODE_NONE:
-		return core.ConnectionModeNone
-	case proto.ConnectionMode_CONNECTION_MODE_USER, proto.ConnectionMode_CONNECTION_MODE_UNSPECIFIED:
-		return core.ConnectionModeUser
-	case proto.ConnectionMode_CONNECTION_MODE_IDENTITY:
-		return core.ConnectionModeIdentity
-	case proto.ConnectionMode_CONNECTION_MODE_EITHER:
-		return core.ConnectionModeEither
-	default:
-		return core.ConnectionModeUser
-	}
-}
 
 func structFromMap(values map[string]any) (*structpb.Struct, error) {
 	if len(values) == 0 {
@@ -52,40 +20,6 @@ func mapFromStruct(s *structpb.Struct) map[string]any {
 		return nil
 	}
 	return s.AsMap()
-}
-
-func connectionParamDefsToProto(defs map[string]core.ConnectionParamDef) map[string]*proto.ConnectionParamDef {
-	if len(defs) == 0 {
-		return nil
-	}
-	out := make(map[string]*proto.ConnectionParamDef, len(defs))
-	for name, def := range defs {
-		out[name] = &proto.ConnectionParamDef{
-			Required:     def.Required,
-			Description:  def.Description,
-			DefaultValue: def.Default,
-			From:         def.From,
-			Field:        def.Field,
-		}
-	}
-	return out
-}
-
-func connectionParamDefsFromProto(defs map[string]*proto.ConnectionParamDef) map[string]core.ConnectionParamDef {
-	if len(defs) == 0 {
-		return nil
-	}
-	out := make(map[string]core.ConnectionParamDef, len(defs))
-	for name, def := range defs {
-		out[name] = core.ConnectionParamDef{
-			Required:    def.GetRequired(),
-			Description: def.GetDescription(),
-			Default:     def.GetDefaultValue(),
-			From:        def.GetFrom(),
-			Field:       def.GetField(),
-		}
-	}
-	return out
 }
 
 func catalogToJSON(cat *catalog.Catalog) (string, error) {

--- a/gestaltd/internal/pluginhost/declarative.go
+++ b/gestaltd/internal/pluginhost/declarative.go
@@ -186,19 +186,10 @@ func (p *DeclarativeProvider) SupportsManualAuth() bool {
 }
 
 func (p *DeclarativeProvider) CredentialFields() []core.CredentialFieldDef {
-	if p.auth == nil || len(p.auth.Credentials) == 0 {
+	if p.auth == nil {
 		return nil
 	}
-	fields := make([]core.CredentialFieldDef, len(p.auth.Credentials))
-	for i, cf := range p.auth.Credentials {
-		fields[i] = core.CredentialFieldDef{
-			Name:        cf.Name,
-			Label:       cf.Label,
-			Description: cf.Description,
-			HelpURL:     cf.HelpURL,
-		}
-	}
-	return fields
+	return CredentialFieldsFromManifest(p.auth.Credentials)
 }
 
 func (p *DeclarativeProvider) AuthTypes() []string {
@@ -242,28 +233,9 @@ func (p *DeclarativeProvider) RefreshToken(ctx context.Context, refreshToken str
 }
 
 func (p *DeclarativeProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
-	if len(p.connectionDefs) == 0 {
-		return nil
-	}
-	defs := make(map[string]core.ConnectionParamDef, len(p.connectionDefs))
-	for name, cp := range p.connectionDefs {
-		defs[name] = core.ConnectionParamDef{
-			Required:    cp.Required,
-			Description: cp.Description,
-			From:        cp.From,
-		}
-	}
-	return defs
+	return ConnectionParamDefsFromManifest(p.connectionDefs)
 }
 
 func (p *DeclarativeProvider) DiscoveryConfig() *core.DiscoveryConfig {
-	if p.postConnectDiscovery == nil {
-		return nil
-	}
-	return &core.DiscoveryConfig{
-		URL:             p.postConnectDiscovery.URL,
-		IDPath:          p.postConnectDiscovery.IDPath,
-		NamePath:        p.postConnectDiscovery.NamePath,
-		MetadataMapping: p.postConnectDiscovery.MetadataMapping,
-	}
+	return DiscoveryConfigFromManifest(p.postConnectDiscovery)
 }

--- a/gestaltd/internal/pluginhost/manifest_core.go
+++ b/gestaltd/internal/pluginhost/manifest_core.go
@@ -1,0 +1,51 @@
+package pluginhost
+
+import (
+	"maps"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+)
+
+func ConnectionParamDefsFromManifest(defs map[string]pluginmanifestv1.ProviderConnectionParam) map[string]core.ConnectionParamDef {
+	if len(defs) == 0 {
+		return nil
+	}
+	out := make(map[string]core.ConnectionParamDef, len(defs))
+	for name, def := range defs {
+		out[name] = core.ConnectionParamDef{
+			Required:    def.Required,
+			Description: def.Description,
+			From:        def.From,
+		}
+	}
+	return out
+}
+
+func CredentialFieldsFromManifest(fields []pluginmanifestv1.CredentialField) []core.CredentialFieldDef {
+	if len(fields) == 0 {
+		return nil
+	}
+	out := make([]core.CredentialFieldDef, len(fields))
+	for i, field := range fields {
+		out[i] = core.CredentialFieldDef{
+			Name:        field.Name,
+			Label:       field.Label,
+			Description: field.Description,
+			HelpURL:     field.HelpURL,
+		}
+	}
+	return out
+}
+
+func DiscoveryConfigFromManifest(discovery *pluginmanifestv1.ProviderPostConnectDiscovery) *core.DiscoveryConfig {
+	if discovery == nil {
+		return nil
+	}
+	return &core.DiscoveryConfig{
+		URL:             discovery.URL,
+		IDPath:          discovery.IDPath,
+		NamePath:        discovery.NamePath,
+		MetadataMapping: maps.Clone(discovery.MetadataMapping),
+	}
+}

--- a/gestaltd/internal/pluginhost/process.go
+++ b/gestaltd/internal/pluginhost/process.go
@@ -30,10 +30,7 @@ type ExecConfig struct {
 	Command      string
 	Args         []string
 	Env          map[string]string
-	Name         string
-	DisplayName  string
-	Description  string
-	IconSVG      string
+	StaticSpec   StaticProviderSpec
 	Config       map[string]any
 	AllowedHosts []string
 	HostBinary   string
@@ -63,10 +60,9 @@ func NewExecutableProvider(ctx context.Context, cfg ExecConfig) (core.Provider, 
 	prov, err := NewRemoteProvider(
 		ctx,
 		client,
-		cfg.Name,
+		cfg.StaticSpec,
 		cfg.Config,
 		WithCloser(proc),
-		WithMetadataOverrides(cfg.DisplayName, cfg.Description, cfg.IconSVG),
 	)
 	if err != nil {
 		_ = proc.Close()

--- a/gestaltd/internal/pluginhost/provider_client.go
+++ b/gestaltd/internal/pluginhost/provider_client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"slices"
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
@@ -15,13 +14,31 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
+type StaticProviderSpec struct {
+	Name             string
+	DisplayName      string
+	Description      string
+	IconSVG          string
+	ConnectionMode   core.ConnectionMode
+	Catalog          *catalog.Catalog
+	AuthTypes        []string
+	ConnectionParams map[string]core.ConnectionParamDef
+	CredentialFields []core.CredentialFieldDef
+	DiscoveryConfig  *core.DiscoveryConfig
+}
+
 type remoteProviderBase struct {
 	client      proto.ProviderPluginClient
-	metadata    *proto.ProviderMetadata
+	name        string
+	displayName string
+	description string
+	connection  core.ConnectionMode
 	catalog     *catalog.Catalog
 	iconSVG     string
-	displayOver string
-	descOver    string
+	authTypes   []string
+	connParams  map[string]core.ConnectionParamDef
+	credFields  []core.CredentialFieldDef
+	discovery   *core.DiscoveryConfig
 	closer      io.Closer
 }
 
@@ -34,16 +51,58 @@ func WithCloser(c io.Closer) RemoteProviderOption {
 	return func(b *remoteProviderBase) { b.closer = c }
 }
 
-func WithMetadataOverrides(displayName, description, iconSVG string) RemoteProviderOption {
-	return func(b *remoteProviderBase) {
-		if displayName != "" {
-			b.displayOver = displayName
+func NewRemoteProvider(ctx context.Context, client proto.ProviderPluginClient, spec StaticProviderSpec, config map[string]any, opts ...RemoteProviderOption) (core.Provider, error) {
+	supportsSessionCatalog, err := getSessionCatalogSupportWithRetry(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	if err := callStartProvider(ctx, client, spec.Name, config); err != nil {
+		return nil, err
+	}
+
+	base := &remoteProviderBase{
+		client:      client,
+		name:        spec.Name,
+		displayName: spec.DisplayName,
+		description: spec.Description,
+		connection:  spec.ConnectionMode,
+		catalog:     spec.Catalog,
+		iconSVG:     spec.IconSVG,
+		authTypes:   spec.AuthTypes,
+		connParams:  spec.ConnectionParams,
+		credFields:  spec.CredentialFields,
+		discovery:   spec.DiscoveryConfig,
+	}
+	for _, opt := range opts {
+		opt(base)
+	}
+
+	if supportsSessionCatalog {
+		return &remoteProviderWithSessionCatalog{remoteProviderBase: base}, nil
+	}
+	return base, nil
+}
+
+func getSessionCatalogSupportWithRetry(ctx context.Context, client proto.ProviderPluginClient) (bool, error) {
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		meta, err := client.GetMetadata(ctx, &emptypb.Empty{})
+		if err == nil {
+			return meta.GetSupportsSessionCatalog(), nil
 		}
-		if description != "" {
-			b.descOver = description
+		if status.Code(err) == codes.Unimplemented {
+			return false, nil
 		}
-		if iconSVG != "" {
-			b.iconSVG = iconSVG
+		if status.Code(err) != codes.Unavailable {
+			return false, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return false, err
+		case <-ticker.C:
 		}
 	}
 }
@@ -55,73 +114,15 @@ func (p *remoteProviderBase) Close() error {
 	return nil
 }
 
-func NewRemoteProvider(ctx context.Context, client proto.ProviderPluginClient, name string, config map[string]any, opts ...RemoteProviderOption) (core.Provider, error) {
-	meta, err := getMetadataWithRetry(ctx, client)
-	if err != nil {
-		return nil, err
-	}
-	if err := callStartProvider(ctx, client, name, config); err != nil {
-		return nil, err
-	}
-	staticCatalog, err := catalogFromJSON(meta.GetStaticCatalogJson())
-	if err != nil {
-		return nil, err
-	}
-
-	base := &remoteProviderBase{
-		client:   client,
-		metadata: meta,
-		catalog:  buildRemoteCatalog(meta, staticCatalog),
-	}
-	for _, opt := range opts {
-		opt(base)
-	}
-
-	if meta.GetSupportsSessionCatalog() {
-		return &remoteProviderWithSessionCatalog{remoteProviderBase: base}, nil
-	}
-	return base, nil
-}
-
-func getMetadataWithRetry(ctx context.Context, client proto.ProviderPluginClient) (*proto.ProviderMetadata, error) {
-	ticker := time.NewTicker(25 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		meta, err := client.GetMetadata(ctx, &emptypb.Empty{})
-		if err == nil {
-			return meta, nil
-		}
-		if status.Code(err) != codes.Unavailable {
-			return nil, err
-		}
-
-		select {
-		case <-ctx.Done():
-			return nil, err
-		case <-ticker.C:
-		}
-	}
-}
-
-func (p *remoteProviderBase) Name() string { return p.metadata.GetName() }
-
-func (p *remoteProviderBase) DisplayName() string {
-	if p.displayOver != "" {
-		return p.displayOver
-	}
-	return p.metadata.GetDisplayName()
-}
-
-func (p *remoteProviderBase) Description() string {
-	if p.descOver != "" {
-		return p.descOver
-	}
-	return p.metadata.GetDescription()
-}
+func (p *remoteProviderBase) Name() string        { return p.name }
+func (p *remoteProviderBase) DisplayName() string { return p.displayName }
+func (p *remoteProviderBase) Description() string { return p.description }
 
 func (p *remoteProviderBase) ConnectionMode() core.ConnectionMode {
-	return protoConnectionModeToCore(p.metadata.GetConnectionMode())
+	if p.connection == "" {
+		return core.ConnectionModeUser
+	}
+	return p.connection
 }
 
 func (p *remoteProviderBase) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
@@ -145,22 +146,32 @@ func (p *remoteProviderBase) Execute(ctx context.Context, operation string, para
 }
 
 func (p *remoteProviderBase) SupportsManualAuth() bool {
-	return slices.Contains(p.metadata.GetAuthTypes(), "manual")
+	for _, authType := range p.authTypes {
+		if authType == "manual" {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *remoteProviderBase) Catalog() *catalog.Catalog {
-	if p.catalog == nil {
-		return nil
-	}
 	return p.decorateCatalog(p.catalog)
 }
 
 func (p *remoteProviderBase) ConnectionParamDefs() map[string]core.ConnectionParamDef {
-	return connectionParamDefsFromProto(p.metadata.GetConnectionParams())
+	return p.connParams
 }
 
 func (p *remoteProviderBase) AuthTypes() []string {
-	return slices.Clone(p.metadata.GetAuthTypes())
+	return p.authTypes
+}
+
+func (p *remoteProviderBase) CredentialFields() []core.CredentialFieldDef {
+	return p.credFields
+}
+
+func (p *remoteProviderBase) DiscoveryConfig() *core.DiscoveryConfig {
+	return p.discovery
 }
 
 func (p *remoteProviderBase) sessionCatalog(ctx context.Context, token string) (*catalog.Catalog, error) {
@@ -184,42 +195,27 @@ func (p *remoteProviderWithSessionCatalog) CatalogForRequest(ctx context.Context
 	return p.sessionCatalog(ctx, token)
 }
 
-func buildRemoteCatalog(meta *proto.ProviderMetadata, staticCatalog *catalog.Catalog) *catalog.Catalog {
-	if staticCatalog == nil {
-		return nil
-	}
-
-	cat := staticCatalog.Clone()
-	if cat.Name == "" {
-		cat.Name = meta.GetName()
-	}
-	if cat.DisplayName == "" {
-		cat.DisplayName = meta.GetDisplayName()
-	}
-	if cat.Description == "" {
-		cat.Description = meta.GetDescription()
-	}
-	for i := range cat.Operations {
-		if cat.Operations[i].Transport == "" {
-			cat.Operations[i].Transport = catalog.TransportPlugin
-		}
-	}
-	return cat
-}
-
 func (p *remoteProviderBase) decorateCatalog(cat *catalog.Catalog) *catalog.Catalog {
 	if cat == nil {
 		return nil
 	}
 	decorated := cat.Clone()
-	if decorated.DisplayName == "" || p.displayOver != "" {
-		decorated.DisplayName = p.DisplayName()
+	if decorated.Name == "" {
+		decorated.Name = p.name
 	}
-	if decorated.Description == "" || p.descOver != "" {
-		decorated.Description = p.Description()
+	if decorated.DisplayName == "" {
+		decorated.DisplayName = p.displayName
+	}
+	if decorated.Description == "" {
+		decorated.Description = p.description
 	}
 	if p.iconSVG != "" {
 		decorated.IconSVG = p.iconSVG
+	}
+	for i := range decorated.Operations {
+		if decorated.Operations[i].Transport == "" {
+			decorated.Operations[i].Transport = catalog.TransportPlugin
+		}
 	}
 	return decorated
 }

--- a/gestaltd/internal/pluginhost/provider_server.go
+++ b/gestaltd/internal/pluginhost/provider_server.go
@@ -2,11 +2,9 @@ package pluginhost
 
 import (
 	"context"
-	"slices"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -22,24 +20,7 @@ func NewProviderServer(provider core.Provider) *ProviderServer {
 }
 
 func (s *ProviderServer) GetMetadata(_ context.Context, _ *emptypb.Empty) (*proto.ProviderMetadata, error) {
-	var defs map[string]core.ConnectionParamDef
-	if cpp, ok := s.provider.(core.ConnectionParamProvider); ok {
-		defs = cpp.ConnectionParamDefs()
-	}
-
-	staticCatalog, err := catalogToJSON(staticCatalogForProvider(s.provider))
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "encode static catalog: %v", err)
-	}
-
 	return &proto.ProviderMetadata{
-		Name:                   s.provider.Name(),
-		DisplayName:            s.provider.DisplayName(),
-		Description:            s.provider.Description(),
-		ConnectionMode:         coreConnectionModeToProto(s.provider.ConnectionMode()),
-		AuthTypes:              authTypesForProvider(s.provider),
-		ConnectionParams:       connectionParamDefsToProto(defs),
-		StaticCatalogJson:      staticCatalog,
 		SupportsSessionCatalog: supportsSessionCatalog(s.provider),
 	}, nil
 }
@@ -78,29 +59,6 @@ func (s *ProviderServer) GetSessionCatalog(ctx context.Context, req *proto.GetSe
 		return nil, status.Errorf(codes.Internal, "encode session catalog: %v", err)
 	}
 	return &proto.GetSessionCatalogResponse{CatalogJson: raw}, nil
-}
-
-func authTypesForProvider(prov core.Provider) []string {
-	if atl, ok := prov.(core.AuthTypeLister); ok {
-		return slices.Clone(atl.AuthTypes())
-	}
-	_, hasOAuth := prov.(core.OAuthProvider)
-	hasManual := false
-	if mp, ok := prov.(core.ManualProvider); ok {
-		hasManual = mp.SupportsManualAuth()
-	}
-	switch {
-	case hasOAuth && hasManual:
-		return []string{"oauth", "manual"}
-	case hasManual:
-		return []string{"manual"}
-	default:
-		return []string{"oauth"}
-	}
-}
-
-func staticCatalogForProvider(prov core.Provider) *catalog.Catalog {
-	return prov.Catalog()
 }
 
 func supportsSessionCatalog(prov core.Provider) bool {

--- a/gestaltd/internal/pluginhost/provider_test.go
+++ b/gestaltd/internal/pluginhost/provider_test.go
@@ -13,12 +13,13 @@ import (
 
 type roundTripProvider struct{}
 
-func (p *roundTripProvider) Name() string        { return "roundtrip" }
-func (p *roundTripProvider) DisplayName() string { return "Round Trip" }
-func (p *roundTripProvider) Description() string { return "test provider" }
-func (p *roundTripProvider) ConnectionMode() core.ConnectionMode {
-	return core.ConnectionModeEither
+func (p *roundTripProvider) Configure(_ context.Context, _ string, _ map[string]any) error {
+	return nil
 }
+func (p *roundTripProvider) Name() string                        { return "roundtrip" }
+func (p *roundTripProvider) DisplayName() string                 { return "Round Trip" }
+func (p *roundTripProvider) Description() string                 { return "test provider" }
+func (p *roundTripProvider) ConnectionMode() core.ConnectionMode { return core.ConnectionModeEither }
 
 func (p *roundTripProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
 	return &core.OperationResult{
@@ -26,8 +27,6 @@ func (p *roundTripProvider) Execute(ctx context.Context, operation string, param
 		Body:   fmt.Sprintf("%s|%s|%s|%s", operation, token, params["message"], core.ConnectionParams(ctx)["tenant"]),
 	}, nil
 }
-
-func (p *roundTripProvider) SupportsManualAuth() bool { return true }
 
 func (p *roundTripProvider) Catalog() *catalog.Catalog {
 	return &catalog.Catalog{
@@ -51,62 +50,68 @@ func (p *roundTripProvider) CatalogForRequest(_ context.Context, token string) (
 	}, nil
 }
 
-func (p *roundTripProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
-	return map[string]core.ConnectionParamDef{
-		"tenant":  {Required: true, Description: "Tenant slug"},
-		"team_id": {From: "token_response", Field: "team_id"},
-	}
-}
-
-func (p *roundTripProvider) AuthTypes() []string {
-	return []string{"manual"}
-}
-
 type manualOnlySDKProvider struct{}
-
-func (p *manualOnlySDKProvider) Name() string { return "manual-only" }
-
-func (p *manualOnlySDKProvider) DisplayName() string { return "Manual Only" }
-
-func (p *manualOnlySDKProvider) Description() string { return "manual auth provider" }
-
-func (p *manualOnlySDKProvider) ConnectionMode() sdkgestalt.ConnectionMode {
-	return sdkgestalt.ConnectionModeIdentity
-}
 
 func (p *manualOnlySDKProvider) Configure(_ context.Context, _ string, _ map[string]any) error {
 	return nil
-}
-
-func (p *manualOnlySDKProvider) Catalog() *sdkgestalt.Catalog {
-	return &sdkgestalt.Catalog{
-		Name:        "manual-only",
-		DisplayName: "Manual Only",
-		Description: "manual auth provider",
-		Operations: []sdkgestalt.CatalogOperation{
-			{
-				ID:          "echo",
-				Description: "Echo input",
-				Method:      http.MethodPost,
-				Parameters: []sdkgestalt.CatalogParameter{
-					{Name: "message", Type: "string", Description: "message", Required: true, Default: "hello"},
-				},
-			},
-		},
-	}
 }
 
 func (p *manualOnlySDKProvider) Execute(_ context.Context, _ string, _ map[string]any, _ string) (*sdkgestalt.OperationResult, error) {
 	return &sdkgestalt.OperationResult{Status: 200, Body: `{}`}, nil
 }
 
-func (p *manualOnlySDKProvider) SupportsManualAuth() bool { return true }
+func roundTripStaticSpec() StaticProviderSpec {
+	return StaticProviderSpec{
+		Name:           "roundtrip",
+		DisplayName:    "Round Trip",
+		Description:    "test provider",
+		ConnectionMode: core.ConnectionModeEither,
+		Catalog: &catalog.Catalog{
+			Name:        "roundtrip",
+			DisplayName: "Round Trip",
+			Description: "test provider",
+			Operations: []catalog.CatalogOperation{
+				{ID: "echo", Method: http.MethodPost},
+			},
+		},
+		AuthTypes: []string{"manual"},
+		ConnectionParams: map[string]core.ConnectionParamDef{
+			"tenant":  {Required: true, Description: "Tenant slug"},
+			"team_id": {From: "token_response", Field: "team_id"},
+		},
+	}
+}
+
+func manualOnlyStaticSpec() StaticProviderSpec {
+	return StaticProviderSpec{
+		Name:           "manual-only",
+		DisplayName:    "Manual Only",
+		Description:    "manual auth provider",
+		ConnectionMode: core.ConnectionModeIdentity,
+		Catalog: &catalog.Catalog{
+			Name:        "manual-only",
+			DisplayName: "Manual Only",
+			Description: "manual auth provider",
+			Operations: []catalog.CatalogOperation{
+				{
+					ID:          "echo",
+					Description: "Echo input",
+					Method:      http.MethodPost,
+					Parameters: []catalog.CatalogParameter{
+						{Name: "message", Type: "string", Description: "message", Required: true, Default: "hello"},
+					},
+				},
+			},
+		},
+		AuthTypes: []string{"manual"},
+	}
+}
 
 func TestRemoteProviderRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	client := newProviderPluginClient(t, NewProviderServer(&roundTripProvider{}))
-	prov, err := NewRemoteProvider(context.Background(), client, "roundtrip", nil)
+	prov, err := NewRemoteProvider(context.Background(), client, roundTripStaticSpec(), nil)
 	if err != nil {
 		t.Fatalf("NewRemoteProvider: %v", err)
 	}
@@ -163,82 +168,13 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 	if defs := cpp.ConnectionParamDefs(); defs["tenant"].Description != "Tenant slug" || defs["team_id"].Field != "team_id" {
 		t.Fatalf("unexpected connection param defs: %+v", defs)
 	}
-
-}
-
-func TestRemoteProviderIconSVG(t *testing.T) {
-	t.Parallel()
-
-	const testSVG = `<svg xmlns="http://www.w3.org/2000/svg"><rect width="16" height="16"/></svg>`
-
-	t.Run("metadata override fills empty icon on existing catalog", func(t *testing.T) {
-		t.Parallel()
-
-		client := newProviderPluginClient(t, NewProviderServer(&roundTripProvider{}))
-		prov, err := NewRemoteProvider(context.Background(), client, "roundtrip", nil, WithMetadataOverrides("", "", testSVG))
-		if err != nil {
-			t.Fatalf("NewRemoteProvider: %v", err)
-		}
-		cat := prov.Catalog()
-		if cat.IconSVG != testSVG {
-			t.Fatalf("IconSVG = %q, want %q", cat.IconSVG, testSVG)
-		}
-	})
-
-	t.Run("metadata override replaces existing catalog icon", func(t *testing.T) {
-		t.Parallel()
-
-		const existingIcon = `<svg><circle/></svg>`
-		client := newProviderPluginClient(t, NewProviderServer(&roundTripProvider{}))
-		prov, err := NewRemoteProvider(context.Background(), client, "roundtrip", nil, WithMetadataOverrides("", "", testSVG))
-		if err != nil {
-			t.Fatalf("NewRemoteProvider: %v", err)
-		}
-		base := prov.(*remoteProviderWithSessionCatalog).remoteProviderBase
-		base.catalog.IconSVG = existingIcon
-
-		cat := prov.Catalog()
-		if cat.IconSVG != testSVG {
-			t.Fatalf("IconSVG = %q, want override %q", cat.IconSVG, testSVG)
-		}
-	})
-}
-
-func TestRemoteProviderMetadataOverridesApplyToSessionCatalog(t *testing.T) {
-	t.Parallel()
-
-	client := newProviderPluginClient(t, NewProviderServer(&roundTripProvider{}))
-	prov, err := NewRemoteProvider(
-		context.Background(),
-		client,
-		"roundtrip",
-		nil,
-		WithMetadataOverrides("Override", "Override description", "<svg/>"),
-	)
-	if err != nil {
-		t.Fatalf("NewRemoteProvider: %v", err)
-	}
-
-	cat, err := prov.(core.SessionCatalogProvider).CatalogForRequest(context.Background(), "token-123")
-	if err != nil {
-		t.Fatalf("CatalogForRequest: %v", err)
-	}
-	if cat.DisplayName != "Override" {
-		t.Fatalf("DisplayName = %q, want %q", cat.DisplayName, "Override")
-	}
-	if cat.Description != "Override description" {
-		t.Fatalf("Description = %q, want %q", cat.Description, "Override description")
-	}
-	if cat.IconSVG != "<svg/>" {
-		t.Fatalf("IconSVG = %q, want %q", cat.IconSVG, "<svg/>")
-	}
 }
 
 func TestRemoteProviderManualAuthOnly(t *testing.T) {
 	t.Parallel()
 
 	client := newProviderPluginClient(t, sdkgestalt.NewProviderServer(&manualOnlySDKProvider{}))
-	prov, err := NewRemoteProvider(context.Background(), client, "manual-only", nil)
+	prov, err := NewRemoteProvider(context.Background(), client, manualOnlyStaticSpec(), nil)
 	if err != nil {
 		t.Fatalf("NewRemoteProvider: %v", err)
 	}

--- a/gestaltd/internal/pluginpkg/archive.go
+++ b/gestaltd/internal/pluginpkg/archive.go
@@ -338,16 +338,10 @@ func ValidatePackageDir(sourceDir string) (*pluginmanifestv1.Manifest, error) {
 			return nil, fmt.Errorf("artifact %s sha256 %s does not match manifest %s", artifact.Path, sum, artifact.SHA256)
 		}
 	}
-	if manifest.Provider != nil && manifest.Provider.ConfigSchemaPath != "" {
-		schemaPath := filepath.Join(sourceDir, filepath.FromSlash(manifest.Provider.ConfigSchemaPath))
-		if _, err := os.Stat(schemaPath); err != nil {
-			return nil, fmt.Errorf("validate provider config schema %s: %w", manifest.Provider.ConfigSchemaPath, err)
-		}
-	}
-	if manifest.IconFile != "" {
-		iconPath := filepath.Join(sourceDir, filepath.FromSlash(manifest.IconFile))
-		if _, err := os.Stat(iconPath); err != nil {
-			return nil, fmt.Errorf("validate icon_file %s: %w", manifest.IconFile, err)
+	for _, ref := range LocalPackageReferences(manifest) {
+		refPath := filepath.Join(sourceDir, filepath.FromSlash(ref.Path))
+		if _, err := os.Stat(refPath); err != nil {
+			return nil, fmt.Errorf("validate %s %s: %w", ref.Description, ref.Path, err)
 		}
 	}
 	return manifest, nil

--- a/gestaltd/internal/pluginpkg/archive_test.go
+++ b/gestaltd/internal/pluginpkg/archive_test.go
@@ -78,6 +78,7 @@ func TestCreatePackageFromDirAndReadManifest(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(src, ManifestFile), manifest, 0644); err != nil {
 		t.Fatalf("WriteFile(plugin.json): %v", err)
 	}
+	mustWriteFile(t, filepath.Join(src, "catalog.yaml"), []byte("name: provider\noperations:\n  - id: echo\n    method: POST\n"), 0644)
 
 	archivePath := filepath.Join(dir, "acme-provider-0.1.0.tar.gz")
 	if err := CreatePackageFromDir(src, archivePath); err != nil {

--- a/gestaltd/internal/pluginpkg/catalog.go
+++ b/gestaltd/internal/pluginpkg/catalog.go
@@ -1,0 +1,40 @@
+package pluginpkg
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"gopkg.in/yaml.v3"
+)
+
+func ReadStaticCatalog(catalogPath, name string) (*catalog.Catalog, error) {
+	if catalogPath == "" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(catalogPath)
+	if err != nil {
+		return nil, fmt.Errorf("read static catalog %q: %w", catalogPath, err)
+	}
+
+	var cat catalog.Catalog
+	if isYAMLFile(catalogPath) {
+		if err := yaml.Unmarshal(data, &cat); err != nil {
+			return nil, fmt.Errorf("parse static catalog YAML %q: %w", catalogPath, err)
+		}
+	} else {
+		if err := json.Unmarshal(data, &cat); err != nil {
+			return nil, fmt.Errorf("parse static catalog JSON %q: %w", catalogPath, err)
+		}
+	}
+
+	if cat.Name == "" && name != "" {
+		cat.Name = name
+	}
+	if err := cat.Validate(); err != nil {
+		return nil, fmt.Errorf("validate static catalog %q: %w", catalogPath, err)
+	}
+	return &cat, nil
+}

--- a/gestaltd/internal/pluginpkg/config_test.go
+++ b/gestaltd/internal/pluginpkg/config_test.go
@@ -58,7 +58,8 @@ properties:
 				Version: "0.1.0",
 				Kinds:   []string{pluginmanifestv1.KindProvider},
 				Provider: &pluginmanifestv1.Provider{
-					ConfigSchemaPath: tc.schemaPath,
+					StaticCatalogPath: "catalog.yaml",
+					ConfigSchemaPath:  tc.schemaPath,
 				},
 				Artifacts: []pluginmanifestv1.Artifact{
 					{
@@ -78,6 +79,9 @@ properties:
 			}
 			if err := os.WriteFile(manifestPath, data, 0644); err != nil {
 				t.Fatalf("WriteFile(manifest): %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "catalog.yaml"), []byte("name: provider\noperations:\n  - id: echo\n    method: POST\n"), 0644); err != nil {
+				t.Fatalf("WriteFile(catalog): %v", err)
 			}
 
 			if err := ValidateConfigForManifest(manifestPath, manifest, pluginmanifestv1.KindProvider, map[string]any{"api_key": "sk-test"}); err != nil {

--- a/gestaltd/internal/pluginpkg/digest.go
+++ b/gestaltd/internal/pluginpkg/digest.go
@@ -48,10 +48,10 @@ func DirectoryDigest(dirPath string, manifest *pluginmanifestv1.Manifest) (strin
 		digests = append(digests, sum)
 	}
 
-	if manifest.Provider != nil && manifest.Provider.ConfigSchemaPath != "" {
-		sum, err := FileSHA256(filepath.Join(dirPath, filepath.FromSlash(manifest.Provider.ConfigSchemaPath)))
+	for _, ref := range LocalPackageReferences(manifest) {
+		sum, err := FileSHA256(filepath.Join(dirPath, filepath.FromSlash(ref.Path)))
 		if err != nil {
-			return "", fmt.Errorf("digest provider config schema: %w", err)
+			return "", fmt.Errorf("digest %s: %w", ref.Description, err)
 		}
 		digests = append(digests, sum)
 	}

--- a/gestaltd/internal/pluginpkg/manifest.go
+++ b/gestaltd/internal/pluginpkg/manifest.go
@@ -185,6 +185,11 @@ func validateManifest(manifest *pluginmanifestv1.Manifest, allowMissingArtifactD
 					return err
 				}
 			}
+			if manifest.Provider.StaticCatalogPath != "" {
+				if err := validateRelativePackagePath(manifest.Provider.StaticCatalogPath, "provider static catalog path"); err != nil {
+					return err
+				}
+			}
 			if isDeclarative {
 				if err := validateDeclarativeProvider(manifest.Provider); err != nil {
 					return err
@@ -194,6 +199,9 @@ func validateManifest(manifest *pluginmanifestv1.Manifest, allowMissingArtifactD
 				if err := validateEntrypoint(kind, manifest.Entrypoints.Provider, artifactPaths); err != nil {
 					return err
 				}
+			}
+			if manifest.Entrypoints.Provider != nil && !isManifestBackedProvider && !manifest.Provider.HasStaticCatalog() {
+				return fmt.Errorf("provider static_catalog_path is required for executable providers without declarative or spec surfaces")
 			}
 		case pluginmanifestv1.KindWebUI:
 			if manifest.WebUI == nil {

--- a/gestaltd/internal/pluginpkg/manifest_wire.go
+++ b/gestaltd/internal/pluginpkg/manifest_wire.go
@@ -23,6 +23,7 @@ type manifestWire struct {
 
 type providerManifestWire struct {
 	ConfigSchemaPath  string                                                 `json:"config_schema_path,omitempty" yaml:"config_schema_path,omitempty"`
+	StaticCatalogPath string                                                 `json:"static_catalog_path,omitempty" yaml:"static_catalog_path,omitempty"`
 	Exec              *providerExecWire                                      `json:"exec,omitempty" yaml:"exec,omitempty"`
 	Connections       map[string]*providerManifestConnectionWire             `json:"connections,omitempty" yaml:"connections,omitempty"`
 	Headers           map[string]string                                      `json:"headers,omitempty" yaml:"headers,omitempty"`
@@ -126,6 +127,7 @@ func wireManifestToInternal(wire *manifestWire) *pluginmanifestv1.Manifest {
 		manifest.Kinds = append(manifest.Kinds, pluginmanifestv1.KindProvider)
 		manifest.Provider = &pluginmanifestv1.Provider{
 			ConfigSchemaPath:  wire.Provider.ConfigSchemaPath,
+			StaticCatalogPath: wire.Provider.StaticCatalogPath,
 			Headers:           wire.Provider.Headers,
 			ManagedParameters: wire.Provider.ManagedParameters,
 			ResponseMapping:   wire.Provider.ResponseMapping,
@@ -217,6 +219,7 @@ func internalManifestToWire(manifest *pluginmanifestv1.Manifest) *manifestWire {
 
 	provider := &providerManifestWire{
 		ConfigSchemaPath:  manifest.Provider.ConfigSchemaPath,
+		StaticCatalogPath: manifest.Provider.StaticCatalogPath,
 		Headers:           manifest.Provider.Headers,
 		ManagedParameters: manifest.Provider.ManagedParameters,
 		ResponseMapping:   manifest.Provider.ResponseMapping,

--- a/gestaltd/internal/pluginpkg/references.go
+++ b/gestaltd/internal/pluginpkg/references.go
@@ -7,6 +7,40 @@ import (
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
 
+type LocalPackageReference struct {
+	Path        string
+	Description string
+}
+
+func LocalPackageReferences(manifest *pluginmanifestv1.Manifest) []LocalPackageReference {
+	if manifest == nil {
+		return nil
+	}
+
+	refs := make([]LocalPackageReference, 0, 3)
+	seen := make(map[string]struct{}, 3)
+	add := func(path, description string) {
+		if path == "" {
+			return
+		}
+		if _, ok := seen[path]; ok {
+			return
+		}
+		seen[path] = struct{}{}
+		refs = append(refs, LocalPackageReference{
+			Path:        path,
+			Description: description,
+		})
+	}
+
+	if manifest.Provider != nil {
+		add(manifest.Provider.ConfigSchemaPath, "provider config schema")
+		add(manifest.Provider.StaticCatalogPath, "provider static catalog")
+	}
+	add(manifest.IconFile, "icon_file")
+	return refs
+}
+
 func ResolveManifestLocalReferences(manifest *pluginmanifestv1.Manifest, manifestPath string) *pluginmanifestv1.Manifest {
 	if manifest == nil || manifest.Provider == nil || manifestPath == "" {
 		return manifest

--- a/gestaltd/internal/pluginpkg/references.go
+++ b/gestaltd/internal/pluginpkg/references.go
@@ -26,6 +26,10 @@ func ResolveManifestLocalReferences(manifest *pluginmanifestv1.Manifest, manifes
 		provider.OpenAPI = resolved
 		changed = true
 	}
+	if resolved := resolve(provider.StaticCatalogPath); resolved != provider.StaticCatalogPath {
+		provider.StaticCatalogPath = resolved
+		changed = true
+	}
 	if resolved := resolve(provider.GraphQLURL); resolved != provider.GraphQLURL {
 		provider.GraphQLURL = resolved
 		changed = true

--- a/gestaltd/internal/pluginpkg/test_helpers_test.go
+++ b/gestaltd/internal/pluginpkg/test_helpers_test.go
@@ -52,7 +52,7 @@ func newProviderManifest(source, version, artifactPath, digest string) *pluginma
 		Source:   source,
 		Version:  version,
 		Kinds:    []string{pluginmanifestv1.KindProvider},
-		Provider: &pluginmanifestv1.Provider{},
+		Provider: &pluginmanifestv1.Provider{StaticCatalogPath: "catalog.yaml"},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
 				OS:     testArtifactOS,
@@ -86,6 +86,7 @@ func mustWriteManifest(t *testing.T, dir string, manifest *pluginmanifestv1.Mani
 		t.Fatalf("EncodeManifest: %v", err)
 	}
 	mustWriteFile(t, filepath.Join(dir, ManifestFile), data, 0644)
+	mustWriteStaticCatalog(t, dir, manifest)
 	return data
 }
 
@@ -94,8 +95,9 @@ func mustProviderManifest(source, version, osName, arch, artifactPath, sha strin
 		Source:  source,
 		Version: version,
 		Provider: &providerManifestWire{
-			Exec:     &providerExecWire{ArtifactPath: artifactPath},
-			Surfaces: providerManifestSurfacesWire{},
+			Exec:              &providerExecWire{ArtifactPath: artifactPath},
+			StaticCatalogPath: "catalog.yaml",
+			Surfaces:          providerManifestSurfacesWire{},
 		},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
@@ -135,7 +137,24 @@ func mustWriteManifestData(t *testing.T, dir, name string, data []byte) string {
 
 	path := filepath.Join(dir, name)
 	mustWriteFile(t, path, data, 0644)
+	format := ManifestFormatJSON
+	if strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml") {
+		format = ManifestFormatYAML
+	}
+	manifest, err := DecodeManifestFormat(data, format)
+	if err != nil {
+		return path
+	}
+	mustWriteStaticCatalog(t, dir, manifest)
 	return path
+}
+
+func mustWriteStaticCatalog(t *testing.T, dir string, manifest *pluginmanifestv1.Manifest) {
+	t.Helper()
+	if manifest == nil || manifest.Provider == nil || manifest.Provider.StaticCatalogPath == "" {
+		return
+	}
+	mustWriteFile(t, filepath.Join(dir, filepath.FromSlash(manifest.Provider.StaticCatalogPath)), []byte("name: provider\noperations:\n  - id: echo\n    method: POST\n"), 0644)
 }
 
 func mustCreateArchive(t *testing.T, archivePath string, files ...archiveTestFile) {

--- a/gestaltd/internal/pluginstore/store.go
+++ b/gestaltd/internal/pluginstore/store.go
@@ -134,17 +134,10 @@ func InstallFromDir(dirPath, destDir string) (*InstalledPlugin, error) {
 		if err := copyFile(manifestSrc, manifestDest); err != nil {
 			return nil, fmt.Errorf("copy manifest: %w", err)
 		}
-		manifest = pluginpkg.ResolveManifestLocalReferences(manifest, manifestDest)
-		for _, schemaRel := range configSchemaPaths(manifest, dirPath) {
-			schemaSrc := filepath.Join(dirPath, filepath.FromSlash(schemaRel))
-			schemaDest := filepath.Join(destDir, filepath.FromSlash(schemaRel))
-			if err := os.MkdirAll(filepath.Dir(schemaDest), 0755); err != nil {
-				return nil, fmt.Errorf("create schema directory: %w", err)
-			}
-			if err := copyFile(schemaSrc, schemaDest); err != nil {
-				return nil, fmt.Errorf("copy config schema %s: %w", schemaRel, err)
-			}
+		if err := copyManifestReferencedFiles(dirPath, destDir, manifest); err != nil {
+			return nil, err
 		}
+		manifest = pluginpkg.ResolveManifestLocalReferences(manifest, manifestDest)
 		installed := buildInstalledPlugin(manifest, destDir, manifestDest, "", nil, "")
 		return installed, nil
 	}
@@ -180,7 +173,6 @@ func InstallFromDir(dirPath, destDir string) (*InstalledPlugin, error) {
 	if err := copyFile(manifestSrc, manifestDest); err != nil {
 		return nil, fmt.Errorf("copy manifest: %w", err)
 	}
-	manifest = pluginpkg.ResolveManifestLocalReferences(manifest, manifestDest)
 
 	artifactDest := filepath.Join(destDir, filepath.FromSlash(artifact.Path))
 	if err := os.MkdirAll(filepath.Dir(artifactDest), 0755); err != nil {
@@ -190,16 +182,10 @@ func InstallFromDir(dirPath, destDir string) (*InstalledPlugin, error) {
 		return nil, fmt.Errorf("copy artifact: %w", err)
 	}
 
-	for _, schemaRel := range configSchemaPaths(manifest, dirPath) {
-		schemaSrc := filepath.Join(dirPath, filepath.FromSlash(schemaRel))
-		schemaDest := filepath.Join(destDir, filepath.FromSlash(schemaRel))
-		if err := os.MkdirAll(filepath.Dir(schemaDest), 0755); err != nil {
-			return nil, fmt.Errorf("create schema directory: %w", err)
-		}
-		if err := copyFile(schemaSrc, schemaDest); err != nil {
-			return nil, fmt.Errorf("copy config schema %s: %w", schemaRel, err)
-		}
+	if err := copyManifestReferencedFiles(dirPath, destDir, manifest); err != nil {
+		return nil, err
 	}
+	manifest = pluginpkg.ResolveManifestLocalReferences(manifest, manifestDest)
 
 	executablePath, err := executablePathForManifest(destDir, manifest)
 	if err != nil {
@@ -258,12 +244,18 @@ func executablePathForManifest(root string, manifest *pluginmanifestv1.Manifest)
 	return filepath.Join(root, filepath.FromSlash(entry.ArtifactPath)), nil
 }
 
-func configSchemaPaths(manifest *pluginmanifestv1.Manifest, dirPath string) []string {
-	var paths []string
-	if manifest.Provider != nil && manifest.Provider.ConfigSchemaPath != "" {
-		paths = append(paths, manifest.Provider.ConfigSchemaPath)
+func copyManifestReferencedFiles(srcDir, destDir string, manifest *pluginmanifestv1.Manifest) error {
+	for _, ref := range pluginpkg.LocalPackageReferences(manifest) {
+		src := filepath.Join(srcDir, filepath.FromSlash(ref.Path))
+		dest := filepath.Join(destDir, filepath.FromSlash(ref.Path))
+		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+			return fmt.Errorf("create %s directory: %w", ref.Description, err)
+		}
+		if err := copyFile(src, dest); err != nil {
+			return fmt.Errorf("copy %s %s: %w", ref.Description, ref.Path, err)
+		}
 	}
-	return paths
+	return nil
 }
 
 func copyDir(src, dst string) error {

--- a/gestaltd/internal/pluginstore/store_test.go
+++ b/gestaltd/internal/pluginstore/store_test.go
@@ -21,6 +21,7 @@ const (
 	hybridProviderArg     = "--serve-provider"
 	hybridProviderBaseURL = "https://api.example.com"
 	hybridOperationName   = "list_items"
+	testCatalogYAML       = "name: provider\noperations:\n  - id: echo\n    method: POST\n"
 )
 
 func TestInstall(t *testing.T) {
@@ -339,7 +340,8 @@ func mustBuildPluginDir(t *testing.T, dir, source, version, content, schema stri
 		Version: version,
 		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &pluginmanifestv1.Provider{
-			ConfigSchemaPath: schemaPath,
+			StaticCatalogPath: "catalog.yaml",
+			ConfigSchemaPath:  schemaPath,
 		},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
@@ -361,6 +363,9 @@ func mustBuildPluginDir(t *testing.T, dir, source, version, content, schema stri
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, pluginpkg.ManifestFile), manifestBytes, 0644); err != nil {
 		t.Fatalf("WriteFile manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "catalog.yaml"), []byte(testCatalogYAML), 0644); err != nil {
+		t.Fatalf("WriteFile catalog: %v", err)
 	}
 	return srcDir
 }
@@ -406,7 +411,7 @@ func mustBuildPluginDirWithDigest(t *testing.T, dir, source, version, content, d
 		Source:   source,
 		Version:  version,
 		Kinds:    []string{pluginmanifestv1.KindProvider},
-		Provider: &pluginmanifestv1.Provider{},
+		Provider: &pluginmanifestv1.Provider{StaticCatalogPath: "catalog.yaml"},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
 				OS:     runtime.GOOS,
@@ -427,6 +432,9 @@ func mustBuildPluginDirWithDigest(t *testing.T, dir, source, version, content, d
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, pluginpkg.ManifestFile), manifestBytes, 0644); err != nil {
 		t.Fatalf("WriteFile manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "catalog.yaml"), []byte(testCatalogYAML), 0644); err != nil {
+		t.Fatalf("WriteFile catalog: %v", err)
 	}
 	return srcDir
 }
@@ -456,7 +464,7 @@ func mustBuildPackageWithDigest(t *testing.T, dir, source, version, content, dig
 		Source:   source,
 		Version:  version,
 		Kinds:    []string{pluginmanifestv1.KindProvider},
-		Provider: &pluginmanifestv1.Provider{},
+		Provider: &pluginmanifestv1.Provider{StaticCatalogPath: "catalog.yaml"},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
 				OS:     runtime.GOOS,
@@ -478,6 +486,9 @@ func mustBuildPackageWithDigest(t *testing.T, dir, source, version, content, dig
 	if err := os.WriteFile(filepath.Join(srcDir, pluginpkg.ManifestFile), manifestBytes, 0644); err != nil {
 		t.Fatalf("WriteFile manifest: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(srcDir, "catalog.yaml"), []byte(testCatalogYAML), 0644); err != nil {
+		t.Fatalf("WriteFile catalog: %v", err)
+	}
 
 	archivePath := filepath.Join(dir, filepath.Base(srcDir)+".tar.gz")
 	if err := pluginpkg.CreatePackageFromDir(srcDir, archivePath); err != nil {
@@ -493,7 +504,7 @@ func mustBuildMismatchPackage(t *testing.T, dir, source, version, content, diges
 		Source:   source,
 		Version:  version,
 		Kinds:    []string{pluginmanifestv1.KindProvider},
-		Provider: &pluginmanifestv1.Provider{},
+		Provider: &pluginmanifestv1.Provider{StaticCatalogPath: "catalog.yaml"},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
 				OS:     runtime.GOOS,
@@ -531,6 +542,7 @@ func mustBuildMismatchPackage(t *testing.T, dir, source, version, content, diges
 		}
 	}
 	writeFile(pluginpkg.ManifestFile, manifestBytes, 0644)
+	writeFile("catalog.yaml", []byte(testCatalogYAML), 0644)
 	writeFile(filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider")), []byte(content), 0755)
 
 	if err := tw.Close(); err != nil {
@@ -554,7 +566,7 @@ func mustBuildPackageWithDuplicateArtifact(t *testing.T, dir, source, version, f
 		Source:   source,
 		Version:  version,
 		Kinds:    []string{pluginmanifestv1.KindProvider},
-		Provider: &pluginmanifestv1.Provider{},
+		Provider: &pluginmanifestv1.Provider{StaticCatalogPath: "catalog.yaml"},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
 				OS:     runtime.GOOS,
@@ -592,6 +604,7 @@ func mustBuildPackageWithDuplicateArtifact(t *testing.T, dir, source, version, f
 		}
 	}
 	writeFile(pluginpkg.ManifestFile, manifestBytes, 0644)
+	writeFile("catalog.yaml", []byte(testCatalogYAML), 0644)
 	writeFile(artifactName, []byte(firstContent), 0755)
 	writeFile(artifactName, []byte(secondContent), 0755)
 
@@ -614,7 +627,7 @@ func newV2Manifest(source, version, content string) *pluginmanifestv1.Manifest {
 		Source:   source,
 		Version:  version,
 		Kinds:    []string{pluginmanifestv1.KindProvider},
-		Provider: &pluginmanifestv1.Provider{},
+		Provider: &pluginmanifestv1.Provider{StaticCatalogPath: "catalog.yaml"},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
 				OS:     runtime.GOOS,
@@ -652,6 +665,9 @@ func mustBuildV2Package(t *testing.T, dir, source, version, content string) stri
 	if err := os.WriteFile(filepath.Join(sourceDir, pluginpkg.ManifestFile), manifestBytes, 0644); err != nil {
 		t.Fatalf("WriteFile manifest: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "catalog.yaml"), []byte(testCatalogYAML), 0644); err != nil {
+		t.Fatalf("WriteFile catalog: %v", err)
+	}
 
 	archivePath := filepath.Join(dir, safeName+".tar.gz")
 	if err := pluginpkg.CreatePackageFromDir(sourceDir, archivePath); err != nil {
@@ -680,6 +696,9 @@ func mustBuildV2PluginDir(t *testing.T, dir, source, version, content string) st
 	}
 	if err := os.WriteFile(filepath.Join(sourceDir, pluginpkg.ManifestFile), manifestBytes, 0644); err != nil {
 		t.Fatalf("WriteFile manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "catalog.yaml"), []byte(testCatalogYAML), 0644); err != nil {
+		t.Fatalf("WriteFile catalog: %v", err)
 	}
 	return sourceDir
 }

--- a/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -54,11 +54,12 @@
     "provider": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "surfaces"
-      ],
       "properties": {
         "config_schema_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "static_catalog_path": {
           "type": "string",
           "minLength": 1
         },

--- a/gestaltd/sdk/pluginmanifest/v1/types.go
+++ b/gestaltd/sdk/pluginmanifest/v1/types.go
@@ -28,6 +28,7 @@ type WebUIMetadata struct {
 
 type Provider struct {
 	ConfigSchemaPath     string                             `json:"config_schema_path,omitempty" yaml:"config_schema_path,omitempty"`
+	StaticCatalogPath    string                             `json:"static_catalog_path,omitempty" yaml:"static_catalog_path,omitempty"`
 	Auth                 *ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
 	ConnectionMode       string                             `json:"connection_mode,omitempty" yaml:"connection_mode,omitempty"`
 	MCP                  bool                               `json:"mcp,omitempty" yaml:"mcp,omitempty"`
@@ -75,6 +76,10 @@ type ProviderConnectionParam struct {
 
 func (p *Provider) IsDeclarative() bool {
 	return p != nil && len(p.Operations) > 0
+}
+
+func (p *Provider) HasStaticCatalog() bool {
+	return p != nil && p.StaticCatalogPath != ""
 }
 
 func (p *Provider) IsSpecLoaded() bool {

--- a/sdk/go/doc.go
+++ b/sdk/go/doc.go
@@ -7,29 +7,13 @@
 //
 // # Implementing a Provider
 //
-// Implement the [Provider] interface and call [ServeProvider]:
+// Implement the [Provider] interface and call [ServeProvider]. Static metadata
+// and the static catalog belong in the plugin manifest, not in the Go type:
 //
 //	type MyProvider struct{}
 //
-//	func (p *MyProvider) Name() string            { return "my_provider" }
-//	func (p *MyProvider) DisplayName() string     { return "My Provider" }
-//	func (p *MyProvider) Description() string     { return "Does useful things." }
-//	func (p *MyProvider) ConnectionMode() gestalt.ConnectionMode {
-//		return gestalt.ConnectionModeNone
-//	}
 //	func (p *MyProvider) Configure(ctx context.Context, name string, config map[string]any) error {
 //		return nil
-//	}
-//
-//	func (p *MyProvider) Catalog() *gestalt.Catalog {
-//		return &gestalt.Catalog{
-//			Name: "my_provider",
-//			Operations: []gestalt.CatalogOperation{{
-//				ID:          "hello",
-//				Description: "Says hello",
-//				Method:      "GET",
-//			}},
-//		}
 //	}
 //
 //	func (p *MyProvider) Execute(ctx context.Context, op string, params map[string]any, token string) (*gestalt.OperationResult, error) {
@@ -43,4 +27,7 @@
 //			log.Fatal(err)
 //		}
 //	}
+//
+// The corresponding manifest would define fields like display_name,
+// description, auth, and provider.static_catalog_path.
 package gestalt

--- a/sdk/go/plugin_test.go
+++ b/sdk/go/plugin_test.go
@@ -2,35 +2,22 @@ package gestalt_test
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"testing"
 
 	gestalt "github.com/valon-technologies/gestalt/sdk/go"
-
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-type stubProvider struct {
-	name        string
-	displayName string
-	description string
-	connMode    gestalt.ConnectionMode
-	catalog     *gestalt.Catalog
-}
+type stubProvider struct{}
 
-func (p *stubProvider) Name() string                           { return p.name }
-func (p *stubProvider) DisplayName() string                    { return p.displayName }
-func (p *stubProvider) Description() string                    { return p.description }
-func (p *stubProvider) ConnectionMode() gestalt.ConnectionMode { return p.connMode }
 func (p *stubProvider) Configure(_ context.Context, _ string, _ map[string]any) error {
 	return nil
 }
-func (p *stubProvider) Catalog() *gestalt.Catalog { return p.catalog }
 
-func (p *stubProvider) Execute(_ context.Context, operation string, params map[string]any, _ string) (*gestalt.OperationResult, error) {
+func (p *stubProvider) Execute(_ context.Context, operation string, _ map[string]any, _ string) (*gestalt.OperationResult, error) {
 	return &gestalt.OperationResult{
 		Status: 200,
 		Body:   `{"operation":"` + operation + `"}`,
@@ -49,12 +36,6 @@ func (p *startableStubProvider) Configure(_ context.Context, name string, config
 	return nil
 }
 
-type manualAuthStubProvider struct {
-	stubProvider
-}
-
-func (p *manualAuthStubProvider) SupportsManualAuth() bool { return true }
-
 type sessionCatalogStubProvider struct {
 	stubProvider
 	sessionCatalog *gestalt.Catalog
@@ -67,96 +48,33 @@ func (p *sessionCatalogStubProvider) CatalogForRequest(_ context.Context, _ stri
 func TestProviderServerGetMetadata(t *testing.T) {
 	t.Parallel()
 
-	prov := &stubProvider{
-		name:        "test-provider",
-		displayName: "Test Provider",
-		description: "A test provider for SDK validation",
-	}
-
-	client := newProviderPluginClient(t, prov)
-	ctx := context.Background()
-
-	meta, err := client.GetMetadata(ctx, &emptypb.Empty{})
-	if err != nil {
-		t.Fatalf("GetMetadata: %v", err)
-	}
-	if meta.GetName() != "test-provider" {
-		t.Errorf("Name = %q, want %q", meta.GetName(), "test-provider")
-	}
-	if meta.GetDisplayName() != "Test Provider" {
-		t.Errorf("DisplayName = %q, want %q", meta.GetDisplayName(), "Test Provider")
-	}
-	if meta.GetConnectionMode() != proto.ConnectionMode_CONNECTION_MODE_NONE {
-		t.Errorf("ConnectionMode = %v, want CONNECTION_MODE_NONE", meta.GetConnectionMode())
-	}
-	if len(meta.GetAuthTypes()) != 0 {
-		t.Errorf("AuthTypes = %v, want empty for plain provider", meta.GetAuthTypes())
-	}
-}
-
-func TestProviderServerGetMetadata_ManualAuth(t *testing.T) {
-	t.Parallel()
-
-	prov := &manualAuthStubProvider{
-		stubProvider: stubProvider{name: "manual-prov"},
-	}
-
-	client := newProviderPluginClient(t, prov)
+	client := newProviderPluginClient(t, &stubProvider{})
 	meta, err := client.GetMetadata(context.Background(), &emptypb.Empty{})
 	if err != nil {
 		t.Fatalf("GetMetadata: %v", err)
 	}
-	authTypes := meta.GetAuthTypes()
-	if len(authTypes) != 1 || authTypes[0] != "manual" {
-		t.Fatalf("AuthTypes = %v, want [manual]", authTypes)
+	if meta.GetSupportsSessionCatalog() {
+		t.Fatal("SupportsSessionCatalog = true, want false")
 	}
 }
 
-func TestProviderServerGetMetadata_StaticCatalog(t *testing.T) {
+func TestProviderServerGetMetadata_SessionCatalogCapability(t *testing.T) {
 	t.Parallel()
 
-	prov := &stubProvider{
-		name:     "test-provider",
-		connMode: gestalt.ConnectionModeNone,
-		catalog: &gestalt.Catalog{
+	client := newProviderPluginClient(t, &sessionCatalogStubProvider{
+		sessionCatalog: &gestalt.Catalog{
 			Name: "test-provider",
 			Operations: []gestalt.CatalogOperation{
-				{
-					ID:          "list_items",
-					Description: "List all items",
-					Method:      http.MethodGet,
-					Parameters: []gestalt.CatalogParameter{
-						{Name: "limit", Type: "integer", Description: "Max results", Default: 10},
-					},
-				},
+				{ID: "session_op", Method: http.MethodGet},
 			},
 		},
-	}
-
-	client := newProviderPluginClient(t, prov)
-	ctx := context.Background()
-
-	meta, err := client.GetMetadata(ctx, &emptypb.Empty{})
+	})
+	meta, err := client.GetMetadata(context.Background(), &emptypb.Empty{})
 	if err != nil {
 		t.Fatalf("GetMetadata: %v", err)
 	}
-	if meta.GetStaticCatalogJson() == "" {
-		t.Fatal("expected static catalog json")
-	}
-	var cat map[string]any
-	if err := json.Unmarshal([]byte(meta.GetStaticCatalogJson()), &cat); err != nil {
-		t.Fatalf("unmarshal static catalog: %v", err)
-	}
-	ops, ok := cat["operations"].([]any)
-	if !ok || len(ops) != 1 {
-		t.Fatalf("unexpected operations payload: %+v", cat["operations"])
-	}
-	first, ok := ops[0].(map[string]any)
-	if !ok || first["id"] != "list_items" {
-		t.Fatalf("unexpected first operation: %+v", ops[0])
-	}
-	if first["transport"] != "plugin" {
-		t.Fatalf("unexpected first operation transport: %+v", ops[0])
+	if !meta.GetSupportsSessionCatalog() {
+		t.Fatal("SupportsSessionCatalog = false, want true")
 	}
 }
 
@@ -164,16 +82,6 @@ func TestProviderServerGetSessionCatalog(t *testing.T) {
 	t.Parallel()
 
 	prov := &sessionCatalogStubProvider{
-		stubProvider: stubProvider{
-			name:     "test-provider",
-			connMode: gestalt.ConnectionModeUser,
-			catalog: &gestalt.Catalog{
-				Name: "test-provider",
-				Operations: []gestalt.CatalogOperation{
-					{ID: "static_op", Method: http.MethodGet},
-				},
-			},
-		},
 		sessionCatalog: &gestalt.Catalog{
 			Name: "test-provider",
 			Operations: []gestalt.CatalogOperation{
@@ -195,12 +103,7 @@ func TestProviderServerGetSessionCatalog(t *testing.T) {
 func TestProviderServerExecute(t *testing.T) {
 	t.Parallel()
 
-	prov := &stubProvider{
-		name:     "test-provider",
-		connMode: gestalt.ConnectionModeNone,
-	}
-
-	client := newProviderPluginClient(t, prov)
+	client := newProviderPluginClient(t, &stubProvider{})
 	ctx := context.Background()
 
 	params, _ := structpb.NewStruct(map[string]any{"key": "value"})
@@ -223,13 +126,7 @@ func TestProviderServerExecute(t *testing.T) {
 func TestProviderServerStartProvider(t *testing.T) {
 	t.Parallel()
 
-	prov := &startableStubProvider{
-		stubProvider: stubProvider{
-			name:     "test-provider",
-			connMode: gestalt.ConnectionModeNone,
-		},
-	}
-
+	prov := &startableStubProvider{}
 	client := newProviderPluginClient(t, prov)
 	ctx := context.Background()
 
@@ -256,12 +153,7 @@ func TestProviderServerStartProvider(t *testing.T) {
 func TestProviderServerUnimplementedRPCs(t *testing.T) {
 	t.Parallel()
 
-	prov := &stubProvider{
-		name:     "test-provider",
-		connMode: gestalt.ConnectionModeNone,
-	}
-
-	client := newProviderPluginClient(t, prov)
+	client := newProviderPluginClient(t, &stubProvider{})
 	ctx := context.Background()
 
 	_, err := client.GetSessionCatalog(ctx, &proto.GetSessionCatalogRequest{Token: "t"})

--- a/sdk/go/plugin_transport_test.go
+++ b/sdk/go/plugin_transport_test.go
@@ -19,11 +19,7 @@ func TestServeProviderRoundTrip(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- gestalt.ServeProvider(ctx, &stubProvider{
-			name:        "test-provider",
-			displayName: "Test Provider",
-			connMode:    gestalt.ConnectionModeEither,
-		})
+		errCh <- gestalt.ServeProvider(ctx, &stubProvider{})
 	}()
 	t.Cleanup(func() {
 		cancel()
@@ -40,7 +36,7 @@ func TestServeProviderRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetMetadata: %v", err)
 	}
-	if meta.GetName() != "test-provider" || meta.GetConnectionMode() != proto.ConnectionMode_CONNECTION_MODE_EITHER {
+	if meta.GetSupportsSessionCatalog() {
 		t.Fatalf("unexpected metadata: %+v", meta)
 	}
 }

--- a/sdk/go/provider_server.go
+++ b/sdk/go/provider_server.go
@@ -2,7 +2,6 @@ package gestalt
 
 import (
 	"context"
-	"slices"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"google.golang.org/grpc/codes"
@@ -41,23 +40,8 @@ func (s *ProviderServer) StartProvider(ctx context.Context, req *proto.StartProv
 }
 
 func (s *ProviderServer) GetMetadata(_ context.Context, _ *emptypb.Empty) (*proto.ProviderMetadata, error) {
-	var connParams map[string]*proto.ConnectionParamDef
-	if cpp, ok := s.provider.(ConnectionParamProvider); ok {
-		connParams = connectionParamDefsToProto(cpp.ConnectionParamDefs())
-	}
-	staticCatalog, err := catalogToJSON(s.provider.Catalog())
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "encode static catalog: %v", err)
-	}
 	return &proto.ProviderMetadata{
-		Name:                   s.provider.Name(),
-		DisplayName:            s.provider.DisplayName(),
-		Description:            s.provider.Description(),
-		ConnectionMode:         coreConnectionModeToProto(s.provider.ConnectionMode()),
-		ConnectionParams:       connParams,
-		StaticCatalogJson:      staticCatalog,
 		SupportsSessionCatalog: supportsSessionCatalog(s.provider),
-		AuthTypes:              authTypes(s.provider),
 	}, nil
 }
 
@@ -98,16 +82,6 @@ func (s *ProviderServer) GetSessionCatalog(ctx context.Context, req *proto.GetSe
 		return nil, status.Errorf(codes.Internal, "encode session catalog: %v", err)
 	}
 	return &proto.GetSessionCatalogResponse{CatalogJson: raw}, nil
-}
-
-func authTypes(p Provider) []string {
-	if atl, ok := p.(AuthTypeLister); ok {
-		return slices.Clone(atl.AuthTypes())
-	}
-	if mp, ok := p.(ManualAuthProvider); ok && mp.SupportsManualAuth() {
-		return []string{"manual"}
-	}
-	return nil
 }
 
 func supportsSessionCatalog(p Provider) bool {

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 )
 
-// ConnectionMode controls how a provider authenticates with its upstream
-// service. The mode is declared as provider metadata and tells the host
-// whether a user-supplied OAuth token, a service-level identity, both,
-// or neither is required.
+// ConnectionMode describes how a provider authenticates with its upstream
+// service. Static connection behavior belongs in the plugin manifest rather
+// than the Go provider interface, but the type remains available for
+// compatibility and for session-catalog related code.
 type ConnectionMode string
 
 const (
@@ -22,20 +22,15 @@ const (
 	ConnectionModeEither ConnectionMode = "either"
 )
 
-// Provider is the core interface that every provider plugin must implement.
-// It declares metadata about the provider, receives provider-level startup
-// configuration, provides the discovery catalog, and executes individual
-// operations when called by the host.
+// Provider is the core interface that every executable provider plugin must
+// implement. Static metadata and the static operation catalog are supplied by
+// the plugin manifest; the provider only receives startup configuration and
+// executes operations when called by the host.
 //
 // The token argument to Execute is a user OAuth token supplied by the host
-// when [ConnectionMode] is [ConnectionModeUser] or [ConnectionModeEither].
+// when the manifest declares a user or either connection mode.
 type Provider interface {
-	Name() string
-	DisplayName() string
-	Description() string
-	ConnectionMode() ConnectionMode
 	Configure(ctx context.Context, name string, config map[string]any) error
-	Catalog() *Catalog
 	Execute(ctx context.Context, operation string, params map[string]any, token string) (*OperationResult, error)
 }
 
@@ -102,21 +97,21 @@ type ConnectionParamDef struct {
 	Field       string
 }
 
-// ConnectionParamProvider is an optional interface a [Provider] can implement
-// to declare the connection parameters it needs. The host resolves these
-// parameters and delivers them via [WithConnectionParams] on each Execute call.
+// ConnectionParamProvider previously declared static connection parameters from
+// code. Static connection metadata now belongs in manifests, but the interface
+// remains for compatibility and is ignored by the executable plugin host.
 type ConnectionParamProvider interface {
 	ConnectionParamDefs() map[string]ConnectionParamDef
 }
 
-// ManualAuthProvider is an optional interface a [Provider] can implement to
-// indicate it accepts manually-entered credentials instead of OAuth.
+// ManualAuthProvider is retained for compatibility and is ignored by the
+// executable plugin host, which reads auth behavior from manifests.
 type ManualAuthProvider interface {
 	SupportsManualAuth() bool
 }
 
-// AuthTypeLister is an optional interface a [Provider] can implement to
-// advertise the authentication methods it supports (e.g. "oauth", "manual").
+// AuthTypeLister is retained for compatibility and is ignored by the
+// executable plugin host, which reads auth behavior from manifests.
 type AuthTypeLister interface {
 	AuthTypes() []string
 }


### PR DESCRIPTION
## Summary
- require executable plugins to be manifest-backed and derive their static contract from the manifest
- remove static metadata and static catalog as authoritative runtime SDK/provider-server data
- add manifest-backed static catalog loading for executable plugins and update examples/docs/tests accordingly

## What changed
- `sdk/go` executable providers now only need `Configure` and `Execute`, with optional session catalog support
- `plugin.manifest` is supported for local command plugins and command-only configs are rejected without a manifest
- static provider metadata and static operations now come from manifest data plus `provider.static_catalog_path`
- packaged/local executable plugin loading now builds `StaticProviderSpec` from manifest data instead of runtime plugin metadata
- packaging/operator/bootstrap paths and existing integration/e2e tests were updated to carry static catalogs through

## Verification
- `go test ./...` in `gestaltd`
- `go test ./...` in `sdk/go`
- `go test ./...` in `examples/plugins/provider-go`
