### PR TITLE
Refresh metrics and admin UI docs

### DIFF
--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -5,6 +5,7 @@
 - an HTTP API
 - a client UI at `/`
 - a built-in admin UI at `/admin`
+- an authenticated `/metrics` scrape endpoint when telemetry metrics are enabled
 - `/health` and `/ready` endpoints
 - an `/mcp` endpoint when providers expose tools
 - support for REST, GraphQL, MCP, and packaged plugins
@@ -148,15 +149,20 @@ docker run --rm \
 
 For more advanced setups, Gestalt also supports `secret://...` references with `env`, `file`, `google_secret_manager`, `aws_secrets_manager`, `vault`, and `azure_key_vault` secret providers.
 
-## Health endpoints
+## Health and observability endpoints
 
 The container exposes:
 
 - `GET /health` for liveness
 - `GET /ready` for readiness
+- `GET /metrics` for Prometheus scraping when telemetry metrics are enabled
 
 The client UI is served from `/` on the same port, and the built-in admin UI is
 served from `/admin`.
+
+`/metrics` follows the configured platform auth boundary. With `auth.provider:
+none`, it is open. With any configured auth provider, it requires an
+authenticated session or API token.
 
 ## SQLite and `/data`
 

--- a/docs/pages/reference/built-in-providers.mdx
+++ b/docs/pages/reference/built-in-providers.mdx
@@ -39,7 +39,7 @@ Components registered by the `gestaltd` binary at startup.
 
 | Name | Purpose |
 | --- | --- |
-| `stdout` | Outputs structured logs to standard output. Traces and metrics use noop providers. Default when `telemetry` is omitted. |
+| `stdout` | Outputs structured logs to standard output, keeps traces disabled, and exposes local Prometheus metrics plus the built-in admin metrics UI. Default when `telemetry` is omitted. |
 | `otlp` | Exports traces, metrics, and logs via OpenTelemetry Protocol. |
 | `noop` | Disables all telemetry collection. |
 

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -207,7 +207,8 @@ telemetry:
 Outputs structured logs to standard output. Traces remain disabled, but metrics
 are collected locally and exposed through the Prometheus-compatible `/metrics`
 endpoint. The built-in admin UI at `/admin` reads that same scrape surface.
-This is the default provider when `telemetry` is omitted.
+Both `/metrics` and `/admin` use the configured platform auth boundary. This is
+the default provider when `telemetry` is omitted.
 
 ### `otlp`
 
@@ -250,7 +251,8 @@ telemetry:
 
 Exports to any OpenTelemetry-compatible collector (Jaeger, Grafana Alloy,
 Datadog Agent) while still keeping local `/metrics` available by default. The
-built-in admin UI at `/admin` reads that same local scrape surface.
+built-in admin UI at `/admin` reads that same local scrape surface. Both
+surfaces use the configured platform auth boundary.
 
 To keep system logs on stdout while still exporting traces and metrics over OTLP:
 
@@ -277,7 +279,9 @@ telemetry:
 
 Disables all telemetry. Instrumentation points remain but produce zero overhead.
 This disables Prometheus scraping. `/metrics` returns a clear unavailable
-response, and the built-in admin UI shows that metrics are unavailable.
+response, and the built-in admin UI shows that metrics are unavailable. The
+route still exists so operators get a clear disabled-state response instead of a
+404 or a client UI fallback page.
 
 ### Trace spans
 

--- a/docs/pages/reference/http-api.mdx
+++ b/docs/pages/reference/http-api.mdx
@@ -29,6 +29,14 @@ Valid bearer tokens are:
 
 ## Authenticated User Routes
 
+### Observability and Admin Surfaces
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/metrics` | Prometheus scrape endpoint when telemetry metrics are enabled. Returns `503` when telemetry metrics are disabled. |
+| `GET` | `/admin` | Redirects to the built-in admin UI at `/admin/`. |
+| `GET` | `/admin/*` | Built-in admin UI assets. The admin UI reads `/metrics` directly. |
+
 ### Integrations
 
 | Method | Path | Purpose |

--- a/docs/pages/reference/observability.mdx
+++ b/docs/pages/reference/observability.mdx
@@ -106,6 +106,14 @@ directly and derives a few lightweight ECharts views in the browser without
 introducing a second admin JSON API or any custom server-side aggregation
 layer.
 
+`/metrics` uses the same platform auth boundary as the rest of `gestaltd`.
+That means:
+
+- with `auth.provider: none`, `/metrics` is open
+- with `local`, `google`, `oidc`, or other configured auth, `/metrics`
+  requires an authenticated session or API token
+- `/admin` follows the same auth model because it reads `/metrics` directly
+
 The admin UI intentionally stays basic:
 
 - summary cards and lightweight charts derived from `/metrics`


### PR DESCRIPTION
## Summary
- update the built-in provider docs to match the shipped `stdout` metrics behavior
- document that `/metrics` and `/admin` share the configured platform auth boundary
- add the current Prometheus/admin route behavior to the config, observability, HTTP API, and Docker image docs

## Testing
- not run (docs-only changes)