### PR TITLE
Share theme assets between client and admin UIs

### DIFF
--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -416,6 +416,9 @@ func TestE2EInitServeLockedOTLPExportsTracesAndMetricsButKeepsLogsOnStdout(t *te
 		if !bytes.Contains(adminBody, []byte("echarts.simple.min.js")) {
 			t.Fatalf("expected admin ui to include echarts asset: %s", adminBody)
 		}
+		if !bytes.Contains(adminBody, []byte("theme.css")) {
+			t.Fatalf("expected admin ui to include shared theme asset: %s", adminBody)
+		}
 	})
 
 	if traceRequests.Load() == 0 {
@@ -516,6 +519,9 @@ func TestE2EInitServeLockedStdoutExposesPrometheusAndEmbeddedAdminUIByDefault(t 
 		if !bytes.Contains(adminBody, []byte("echarts.simple.min.js")) {
 			t.Fatalf("expected admin ui to include echarts asset: %s", adminBody)
 		}
+		if !bytes.Contains(adminBody, []byte("theme.css")) {
+			t.Fatalf("expected admin ui to include shared theme asset: %s", adminBody)
+		}
 	})
 
 	if !strings.Contains(stdout, `"msg":"audit"`) {
@@ -565,6 +571,9 @@ func TestE2EInitServeLockedNoopKeepsAdminUIAndReturnsMetricsUnavailable(t *testi
 		}
 		if !bytes.Contains(adminBody, []byte("echarts.simple.min.js")) {
 			t.Fatalf("expected admin ui to include echarts asset: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("theme.css")) {
+			t.Fatalf("expected admin ui to include shared theme asset: %s", adminBody)
 		}
 	})
 }
@@ -625,6 +634,9 @@ ui:
 		}
 		if !bytes.Contains(adminBody, []byte("echarts.simple.min.js")) {
 			t.Fatalf("expected built-in admin UI to include echarts asset: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("theme.css")) {
+			t.Fatalf("expected built-in admin UI to include shared theme asset: %s", adminBody)
 		}
 	})
 }

--- a/gestaltd/internal/adminui/out/index.html
+++ b/gestaltd/internal/adminui/out/index.html
@@ -537,20 +537,36 @@
           return charts[id];
         }
 
+        let themeProbe = null;
+
+        function resolveThemeColor(value) {
+          if (!themeProbe) {
+            themeProbe = document.createElement("span");
+            themeProbe.setAttribute("aria-hidden", "true");
+            themeProbe.style.cssText =
+              "position:absolute;visibility:hidden;pointer-events:none;inset:auto;top:-9999px;";
+            document.body.appendChild(themeProbe);
+          }
+
+          themeProbe.style.color = value;
+          return window.getComputedStyle(themeProbe).color;
+        }
+
         function theme() {
-          const styles = window.getComputedStyle(document.documentElement);
           return {
-            brand: styles.getPropertyValue("--brand").trim(),
-            brandSoft: styles.getPropertyValue("--brand-soft").trim(),
-            border: `hsl(${styles.getPropertyValue("--border").trim()} / 1)`,
-            foreground: `hsl(${styles.getPropertyValue("--foreground").trim()} / 1)`,
-            muted: `rgba(${styles.getPropertyValue("--alpha-dark").trim()}, 0.6)`,
-            faint: `rgba(${styles.getPropertyValue("--alpha-dark").trim()}, 0.42)`,
-            danger: styles.getPropertyValue("--danger").trim(),
-            success: styles.getPropertyValue("--success").trim(),
-            surfaceRaised: `hsl(${styles.getPropertyValue("--surface-raised").trim()} / 1)`,
+            brand: resolveThemeColor("var(--brand)"),
+            brandSoft: resolveThemeColor("var(--brand-soft)"),
+            border: resolveThemeColor("hsl(var(--border) / 1)"),
+            foreground: resolveThemeColor("hsl(var(--foreground) / 1)"),
+            muted: resolveThemeColor("rgba(var(--alpha-dark), 0.6)"),
+            faint: resolveThemeColor("rgba(var(--alpha-dark), 0.42)"),
+            danger: resolveThemeColor("var(--danger)"),
+            success: resolveThemeColor("var(--success)"),
+            surfaceRaised: resolveThemeColor("hsl(var(--surface-raised) / 1)"),
           };
         }
+
+        window.__gestaltAdminTheme = theme;
 
         function positiveDelta(current, previous) {
           if (!Number.isFinite(current)) return 0;

--- a/gestaltd/internal/adminui/out/index.html
+++ b/gestaltd/internal/adminui/out/index.html
@@ -4,57 +4,25 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Gestalt Admin</title>
+    <script>
+      (function () {
+        const media = window.matchMedia("(prefers-color-scheme: dark)");
+        const applyTheme = function () {
+          document.documentElement.classList.toggle("dark", media.matches);
+          window.dispatchEvent(new Event("gestalt-themechange"));
+        };
+
+        applyTheme();
+        media.addEventListener("change", applyTheme);
+      })();
+    </script>
+    <link rel="stylesheet" href="./theme.css" />
     <style>
-      :root {
-        color-scheme: light;
-        --background: hsl(36 28% 99%);
-        --surface: hsl(36 33% 97%);
-        --surface-raised: hsl(33 22% 93%);
-        --foreground: rgba(35, 24, 16, 1);
-        --muted: rgba(35, 24, 16, 0.6);
-        --faint: rgba(35, 24, 16, 0.42);
-        --border: rgba(35, 24, 16, 0.1);
-        --brand: #7a4f10;
-        --brand-soft: #eac59f;
-        --danger: #c75050;
-        --success: #3d6b3d;
-      }
-
-      @media (prefers-color-scheme: dark) {
-        :root {
-          color-scheme: dark;
-          --background: hsl(24 18% 8%);
-          --surface: hsl(24 14% 11%);
-          --surface-raised: hsl(24 12% 15%);
-          --foreground: rgba(232, 222, 212, 1);
-          --muted: rgba(232, 222, 212, 0.6);
-          --faint: rgba(232, 222, 212, 0.42);
-          --border: rgba(232, 222, 212, 0.1);
-          --brand: #f5ca78;
-          --brand-soft: #5c3c0c;
-          --danger: #f0a3a3;
-          --success: #b8dfb8;
-        }
-      }
-
-      * {
-        box-sizing: border-box;
-      }
-
       body {
         margin: 0;
         min-height: 100vh;
         font: 16px/1.5 system-ui, sans-serif;
-        color: var(--foreground);
-        background:
-          radial-gradient(140% 90% at 50% 100%, #eaccb8 0%, #fdfcf9 50%, #f8f6f3 80%);
-      }
-
-      @media (prefers-color-scheme: dark) {
-        body {
-          background:
-            radial-gradient(140% 90% at 50% 100%, #3d2808 0%, #1a1410 50%, #161110 80%);
-        }
+        color: hsl(var(--foreground) / 1);
       }
 
       a {
@@ -68,8 +36,8 @@
       }
 
       .topbar {
-        border-bottom: 1px solid var(--border);
-        background: color-mix(in srgb, var(--background) 88%, transparent);
+        border-bottom: 1px solid hsl(var(--border) / 1);
+        background: color-mix(in srgb, hsl(var(--background)) 88%, transparent);
       }
 
       .topbar .shell {
@@ -90,7 +58,7 @@
         display: flex;
         align-items: center;
         gap: 12px;
-        color: var(--muted);
+        color: rgba(var(--alpha-dark), 0.6);
       }
 
       .links a {
@@ -104,9 +72,9 @@
       .card,
       .status,
       details {
-        border: 1px solid var(--border);
+        border: 1px solid hsl(var(--border) / 1);
         border-radius: 12px;
-        background: color-mix(in srgb, var(--surface) 90%, white);
+        background: color-mix(in srgb, hsl(var(--surface)) 90%, white);
       }
 
       .hero,
@@ -115,14 +83,6 @@
       .status,
       summary {
         padding: 20px;
-      }
-
-      .label-text {
-        font-size: 11px;
-        font-weight: 600;
-        letter-spacing: 0.14em;
-        text-transform: uppercase;
-        color: var(--faint);
       }
 
       h1,
@@ -144,7 +104,7 @@
 
       p {
         margin: 12px 0 0;
-        color: var(--muted);
+        color: rgba(var(--alpha-dark), 0.6);
       }
 
       .status {
@@ -198,9 +158,9 @@
         align-items: center;
         justify-content: center;
         min-height: 240px;
-        border: 1px dashed var(--border);
+        border: 1px dashed hsl(var(--border) / 1);
         border-radius: 12px;
-        background: color-mix(in srgb, var(--surface-raised) 40%, transparent);
+        background: color-mix(in srgb, hsl(var(--surface-raised)) 40%, transparent);
         padding: 20px;
         text-align: center;
       }
@@ -228,14 +188,14 @@
 
       .bar-value,
       .bar-meta {
-        color: var(--muted);
+        color: rgba(var(--alpha-dark), 0.6);
         font-size: 0.92rem;
       }
 
       .bar-track {
         height: 10px;
         border-radius: 999px;
-        background: color-mix(in srgb, var(--surface-raised) 65%, transparent);
+        background: color-mix(in srgb, hsl(var(--surface-raised)) 65%, transparent);
         overflow: hidden;
       }
 
@@ -256,7 +216,7 @@
         overflow: auto;
         white-space: pre-wrap;
         word-break: break-word;
-        color: var(--muted);
+        color: rgba(var(--alpha-dark), 0.6);
         font: 0.84rem/1.5 ui-monospace, monospace;
       }
 
@@ -283,7 +243,7 @@
       }
     </style>
   </head>
-  <body>
+  <body class="gradient-warm">
     <nav class="topbar">
       <div class="shell">
         <a class="brand" href="/">Gestalt</a>
@@ -371,6 +331,7 @@
         const HISTORY_LIMIT = Math.ceil((60 * 60 * 1000) / REFRESH_INTERVAL_MS);
         const charts = {};
         const history = [];
+        let latestSnapshot = null;
 
         function byId(id) {
           return document.getElementById(id);
@@ -581,13 +542,13 @@
           return {
             brand: styles.getPropertyValue("--brand").trim(),
             brandSoft: styles.getPropertyValue("--brand-soft").trim(),
-            border: styles.getPropertyValue("--border").trim(),
-            foreground: styles.getPropertyValue("--foreground").trim(),
-            muted: styles.getPropertyValue("--muted").trim(),
-            faint: styles.getPropertyValue("--faint").trim(),
+            border: `hsl(${styles.getPropertyValue("--border").trim()} / 1)`,
+            foreground: `hsl(${styles.getPropertyValue("--foreground").trim()} / 1)`,
+            muted: `rgba(${styles.getPropertyValue("--alpha-dark").trim()}, 0.6)`,
+            faint: `rgba(${styles.getPropertyValue("--alpha-dark").trim()}, 0.42)`,
             danger: styles.getPropertyValue("--danger").trim(),
             success: styles.getPropertyValue("--success").trim(),
-            surfaceRaised: styles.getPropertyValue("--surface-raised").trim(),
+            surfaceRaised: `hsl(${styles.getPropertyValue("--surface-raised").trim()} / 1)`,
           };
         }
 
@@ -819,6 +780,7 @@
             }
 
             const snapshot = parseMetrics(body);
+            latestSnapshot = snapshot;
             recordHistory(snapshot);
             byId("metrics-output").textContent = body;
             byId("summary-requests").textContent = formatCount(snapshot.requests);
@@ -843,6 +805,11 @@
           Object.values(charts).forEach(function (chart) {
             chart.resize();
           });
+        });
+        window.addEventListener("gestalt-themechange", function () {
+          if (latestSnapshot) {
+            renderCharts(latestSnapshot);
+          }
         });
       })();
     </script>

--- a/gestaltd/internal/adminui/out/theme.css
+++ b/gestaltd/internal/adminui/out/theme.css
@@ -1,0 +1,62 @@
+:root {
+  color-scheme: light;
+  --background: 36 28% 99%;
+  --surface: 36 33% 97%;
+  --surface-raised: 33 22% 93%;
+  --border: 30 18% 87%;
+  --foreground: 24 30% 11%;
+  --radius: 0.75rem;
+  --alpha-dark: 35, 24, 16;
+  --brand: #7a4f10;
+  --brand-soft: #eac59f;
+  --danger: #c75050;
+  --success: #3d6b3d;
+}
+
+.dark {
+  color-scheme: dark;
+  --background: 24 18% 8%;
+  --surface: 24 14% 11%;
+  --surface-raised: 24 12% 15%;
+  --border: 24 10% 20%;
+  --foreground: 33 20% 90%;
+  --alpha-dark: 232, 222, 212;
+  --brand: #f5ca78;
+  --brand-soft: #5c3c0c;
+  --danger: #f0a3a3;
+  --success: #b8dfb8;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.label-text {
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--alpha-dark), 0.42);
+}
+
+.gradient-warm {
+  background: radial-gradient(
+    140% 90% at 50% 100%,
+    #eaccb8 0%,
+    #fdfcf9 50%,
+    #f8f6f3 80%
+  );
+}
+
+.dark .gradient-warm {
+  background: radial-gradient(
+    140% 90% at 50% 100%,
+    #3d2808 0%,
+    #1a1410 50%,
+    #161110 80%
+  );
+}

--- a/gestaltd/ui/e2e/auth.spec.ts
+++ b/gestaltd/ui/e2e/auth.spec.ts
@@ -127,6 +127,20 @@ gestaltd_operation_duration_seconds_count{gestalt_provider="slack",gestalt_opera
     await expect(page.locator("#activity-chart canvas")).toHaveCount(1);
     await expect(page.locator("#latency-chart canvas")).toHaveCount(1);
     await expect(page.locator("#provider-chart canvas")).toHaveCount(1);
+    const chartColors = await page.evaluate(() => {
+      const scope = window as Window & {
+        __gestaltAdminTheme?: () => {
+          border: string;
+          foreground: string;
+          surfaceRaised: string;
+        };
+      };
+      return scope.__gestaltAdminTheme ? scope.__gestaltAdminTheme() : null;
+    });
+    expect(chartColors).not.toBeNull();
+    expect(chartColors?.surfaceRaised).toMatch(/^rgba?\(/);
+    expect(chartColors?.border).toMatch(/^rgba?\(/);
+    expect(chartColors?.foreground).toMatch(/^rgba?\(/);
     await expect(page.getByText("Top providers")).toBeVisible();
     await expect(page.locator("#provider-bars")).toContainText("slash\\nname");
     await expect(page.locator("#provider-bars .bar-name").first()).toHaveText("slash\\nname");

--- a/gestaltd/ui/package.json
+++ b/gestaltd/ui/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "./dev.sh",
     "dev:next": "next dev",
-    "build": "next build",
+    "sync:theme": "node ./scripts/sync-admin-theme.mjs",
+    "build": "npm run sync:theme && next build",
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",

--- a/gestaltd/ui/scripts/sync-admin-theme.mjs
+++ b/gestaltd/ui/scripts/sync-admin-theme.mjs
@@ -1,0 +1,11 @@
+import { copyFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const uiDir = dirname(scriptDir);
+const source = join(uiDir, "shared", "theme.css");
+const target = join(uiDir, "..", "internal", "adminui", "out", "theme.css");
+
+mkdirSync(dirname(target), { recursive: true });
+copyFileSync(source, target);

--- a/gestaltd/ui/shared/theme.css
+++ b/gestaltd/ui/shared/theme.css
@@ -1,0 +1,62 @@
+:root {
+  color-scheme: light;
+  --background: 36 28% 99%;
+  --surface: 36 33% 97%;
+  --surface-raised: 33 22% 93%;
+  --border: 30 18% 87%;
+  --foreground: 24 30% 11%;
+  --radius: 0.75rem;
+  --alpha-dark: 35, 24, 16;
+  --brand: #7a4f10;
+  --brand-soft: #eac59f;
+  --danger: #c75050;
+  --success: #3d6b3d;
+}
+
+.dark {
+  color-scheme: dark;
+  --background: 24 18% 8%;
+  --surface: 24 14% 11%;
+  --surface-raised: 24 12% 15%;
+  --border: 24 10% 20%;
+  --foreground: 33 20% 90%;
+  --alpha-dark: 232, 222, 212;
+  --brand: #f5ca78;
+  --brand-soft: #5c3c0c;
+  --danger: #f0a3a3;
+  --success: #b8dfb8;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.label-text {
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--alpha-dark), 0.42);
+}
+
+.gradient-warm {
+  background: radial-gradient(
+    140% 90% at 50% 100%,
+    #eaccb8 0%,
+    #fdfcf9 50%,
+    #f8f6f3 80%
+  );
+}
+
+.dark .gradient-warm {
+  background: radial-gradient(
+    140% 90% at 50% 100%,
+    #3d2808 0%,
+    #1a1410 50%,
+    #161110 80%
+  );
+}

--- a/gestaltd/ui/src/app/globals.css
+++ b/gestaltd/ui/src/app/globals.css
@@ -1,33 +1,10 @@
+@import "../../shared/theme.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
-  :root {
-    --background: 36 28% 99%;
-    --surface: 36 33% 97%;
-    --surface-raised: 33 22% 93%;
-    --border: 30 18% 87%;
-    --foreground: 24 30% 11%;
-    --radius: 0.75rem;
-
-    --alpha-dark: 35, 24, 16;
-  }
-
-  .dark {
-    --background: 24 18% 8%;
-    --surface: 24 14% 11%;
-    --surface-raised: 24 12% 15%;
-    --border: 24 10% 20%;
-    --foreground: 33 20% 90%;
-
-    --alpha-dark: 232, 222, 212;
-  }
-
-  html {
-    scroll-behavior: smooth;
-  }
-
   * {
     border-color: hsl(var(--border));
   }
@@ -55,10 +32,6 @@
 }
 
 @layer components {
-  .label-text {
-    @apply text-[11px] font-medium uppercase tracking-widest text-faint;
-  }
-
   .doc-copy {
     @apply text-base leading-7 text-secondary;
   }
@@ -67,21 +40,4 @@
     @apply text-primary underline decoration-base-300 underline-offset-4 transition-colors duration-150 hover:text-gold-600 dark:decoration-base-600;
   }
 
-  .gradient-warm {
-    background: radial-gradient(
-      140% 90% at 50% 100%,
-      #EACCB8 0%,
-      #FDFCF9 50%,
-      #F8F6F3 80%
-    );
-  }
-
-  .dark .gradient-warm {
-    background: radial-gradient(
-      140% 90% at 50% 100%,
-      #3D2808 0%,
-      #1A1410 50%,
-      #161110 80%
-    );
-  }
 }


### PR DESCRIPTION
## Summary
- move shared color tokens, dark-mode values, the warm background treatment, and shared label styling into a common UI theme stylesheet
- have the client UI import that shared stylesheet while the built-in admin UI serves the same generated theme asset
- keep the admin UI embedded and pluggable client UI behavior unchanged while adding integration coverage for the shared theme asset

## Testing
- npm run build
- npm run check
- CI=1 npx playwright test e2e/auth.spec.ts e2e/theme.spec.ts
- go test -ldflags='-w -s' ./cmd/gestaltd -run 'TestE2EInitServeLockedOTLPExportsTracesAndMetricsButKeepsLogsOnStdout|TestE2EInitServeLockedStdoutExposesPrometheusAndEmbeddedAdminUIByDefault|TestE2EInitServeLockedNoopKeepsAdminUIAndReturnsMetricsUnavailable|TestE2EServeLockedUsesUIPluginForClientRootAndKeepsAdminBuiltIn'