### PR TITLE
Fix admin ECharts theme color resolution

### DIFF
--- a/gestaltd/internal/adminui/out/index.html
+++ b/gestaltd/internal/adminui/out/index.html
@@ -576,20 +576,36 @@
           return charts[id];
         }
 
+        let themeProbe = null;
+
+        function resolveThemeColor(name) {
+          if (!themeProbe) {
+            themeProbe = document.createElement("span");
+            themeProbe.setAttribute("aria-hidden", "true");
+            themeProbe.style.cssText =
+              "position:absolute;visibility:hidden;pointer-events:none;inset:auto;top:-9999px;";
+            document.body.appendChild(themeProbe);
+          }
+
+          themeProbe.style.color = `var(${name})`;
+          return window.getComputedStyle(themeProbe).color;
+        }
+
         function theme() {
-          const styles = window.getComputedStyle(document.documentElement);
           return {
-            brand: styles.getPropertyValue("--brand").trim(),
-            brandSoft: styles.getPropertyValue("--brand-soft").trim(),
-            border: styles.getPropertyValue("--border").trim(),
-            foreground: styles.getPropertyValue("--foreground").trim(),
-            muted: styles.getPropertyValue("--muted").trim(),
-            faint: styles.getPropertyValue("--faint").trim(),
-            danger: styles.getPropertyValue("--danger").trim(),
-            success: styles.getPropertyValue("--success").trim(),
-            surfaceRaised: styles.getPropertyValue("--surface-raised").trim(),
+            brand: resolveThemeColor("--brand"),
+            brandSoft: resolveThemeColor("--brand-soft"),
+            border: resolveThemeColor("--border"),
+            foreground: resolveThemeColor("--foreground"),
+            muted: resolveThemeColor("--muted"),
+            faint: resolveThemeColor("--faint"),
+            danger: resolveThemeColor("--danger"),
+            success: resolveThemeColor("--success"),
+            surfaceRaised: resolveThemeColor("--surface-raised"),
           };
         }
+
+        window.__gestaltAdminTheme = theme;
 
         function positiveDelta(current, previous) {
           if (!Number.isFinite(current)) return 0;

--- a/gestaltd/ui/e2e/auth.spec.ts
+++ b/gestaltd/ui/e2e/auth.spec.ts
@@ -127,6 +127,20 @@ gestaltd_operation_duration_seconds_count{gestalt_provider="slack",gestalt_opera
     await expect(page.locator("#activity-chart canvas")).toHaveCount(1);
     await expect(page.locator("#latency-chart canvas")).toHaveCount(1);
     await expect(page.locator("#provider-chart canvas")).toHaveCount(1);
+    const chartColors = await page.evaluate(() => {
+      const scope = window as Window & {
+        __gestaltAdminTheme?: () => {
+          border: string;
+          foreground: string;
+          surfaceRaised: string;
+        };
+      };
+      return scope.__gestaltAdminTheme ? scope.__gestaltAdminTheme() : null;
+    });
+    expect(chartColors).not.toBeNull();
+    expect(chartColors?.surfaceRaised).toMatch(/^rgba?\(/);
+    expect(chartColors?.border).toMatch(/^rgba?\(/);
+    expect(chartColors?.foreground).toMatch(/^rgba?\(/);
     await expect(page.getByText("Top providers")).toBeVisible();
     await expect(page.locator("#provider-bars")).toContainText("slash\\nname");
     await expect(page.locator("#provider-bars .bar-name").first()).toHaveText("slash\\nname");


### PR DESCRIPTION
## Summary
- resolve admin chart theme colors through the browser before passing them to ECharts
- keep the fix local to the embedded admin page instead of changing shared theme tokens
- extend the existing admin Playwright flow to verify the page exposes ECharts-safe rgb/rgba colors

## Testing
- go test -ldflags='-w -s' ./cmd/gestaltd -run 'TestE2EInitServeLockedStdoutExposesPrometheusAndEmbeddedAdminUIByDefault'
- npm run check
- CI=1 npx playwright test e2e/auth.spec.ts