### PR TITLE
Align docs navbar logo with sidebar and update footer

### DIFF
--- a/docs/globals.css
+++ b/docs/globals.css
@@ -204,11 +204,20 @@ pre code > span {
   display: none;
 }
 
-.nextra-nav-container nav,
 footer > div {
   width: min(1300px, calc(100% - 2rem)) !important;
   padding-left: 0 !important;
   padding-right: 0 !important;
+}
+
+.nextra-nav-container nav {
+  max-width: 90rem !important;
+  width: 100% !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  padding-left: 1rem !important;
+  padding-right: 1rem !important;
+  box-sizing: border-box !important;
 }
 
 .nextra-nav-container nav a,
@@ -423,14 +432,12 @@ button[title='Change theme'],
 }
 
 @media (min-width: 768px) {
-  .nextra-nav-container nav,
   footer > div {
     width: min(1300px, calc(100% - 4rem)) !important;
   }
 }
 
 @media (min-width: 1024px) {
-  .nextra-nav-container nav,
   footer > div {
     width: min(1300px, calc(100% - 8rem)) !important;
   }

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -40,7 +40,19 @@ const config: DocsThemeConfig = {
     );
   },
   footer: {
-    content: <span>Gestalt, a self-hosted integration platform</span>,
+    content: (
+      <span>
+        Gestalt, a self-hosted integration platform by{" "}
+        <a
+          href="https://valon.ai"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ textDecoration: "underline", textUnderlineOffset: "0.18em" }}
+        >
+          Valon Technologies
+        </a>
+      </span>
+    ),
   },
   search: {
     placeholder: "Search documentation",


### PR DESCRIPTION
## Summary
- Aligns the "Gestalt" navbar logo horizontally with the sidebar navigation items at all viewport widths by switching the navbar from a centered width constraint to `max-width: 90rem` with `1rem` left padding (matching the sidebar's internal padding and the main content container's centering)
- Updates the footer to read "Gestalt, a self-hosted integration platform by Valon Technologies" with a link to valon.ai

## Test plan
- [ ] Verify the "Gestalt" logo in the navbar is left-aligned with sidebar items at 1280px, 1440px, and 1920px viewports
- [ ] Verify the footer displays "by Valon Technologies" as a clickable link to valon.ai
- [ ] Verify the search bar and GitHub icon on the right side of the navbar are unaffected


🤖 Generated with [Claude Code](https://claude.com/claude-code)