### PR TITLE
[codex] document .gestalt.json CLI config

### DIFF
--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -104,7 +104,10 @@ gestalt init
 ```
 
 The interactive wizard prompts for the server URL (default `http://localhost:8080`)
-and saves it to your local client config. You can also set it directly:
+and saves it to your local client config. It can also create a project-local
+`.gestalt.json` file with the same URL so a specific checkout or deployment
+directory keeps using that server without changing your machine-wide default.
+You can also set the global URL directly:
 
 ```sh
 gestalt config set url http://localhost:8080

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -64,6 +64,35 @@ See [Configuration](/concepts/configuration) for the relationship between `init`
 | `gestalt describe INTEGRATION OPERATION` | Show one operation's parameter contract. |
 | `gestalt tokens create|list|revoke` | Manage Gestalt API tokens. |
 
+### URL Resolution
+
+The `gestalt` client resolves the server URL in this order:
+
+1. `--url`
+2. `GESTALT_URL`
+3. project-local `.gestalt.json`
+4. global CLI config from `gestalt config set url ...`
+5. the saved server URL from stored login credentials
+6. `http://localhost:8080`
+
+### Project Config File
+
+`gestalt init` can create a `.gestalt.json` file in the current directory.
+This file is a project-local override for the server URL. It is intended for
+cases where one checkout or deployment directory should always point to a
+specific Gestalt server without changing your machine-wide default.
+
+The file currently stores only the URL:
+
+```json
+{
+  "url": "https://gestalt.example.com"
+}
+```
+
+When present, the CLI searches the current directory and then parent
+directories until it finds the nearest `.gestalt.json`.
+
 ### Integration Connect Flags
 
 `gestalt integrations connect NAME` supports:

--- a/gestaltd/ui/src/app/docs/DocsClient.tsx
+++ b/gestaltd/ui/src/app/docs/DocsClient.tsx
@@ -197,11 +197,15 @@ export GESTALT_URL=${origin}`}
                 rows={[
                   [
                     "gestalt init",
-                    "Interactive setup that stores the URL and can start browser login.",
+                    "Interactive setup that stores the URL, can create a project-local .gestalt.json, and can start browser login.",
                   ],
                   [
                     "gestalt config set url ...",
                     "Persistent global config for your user account on this machine.",
+                  ],
+                  [
+                    ".gestalt.json",
+                    "Project-local URL override for one checkout or deployment directory.",
                   ],
                   [
                     "GESTALT_URL",
@@ -210,12 +214,19 @@ export GESTALT_URL=${origin}`}
                 ]}
               />
               <p className="doc-copy">
+                The optional{" "}
+                <code className="font-mono text-sm text-primary">.gestalt.json</code>{" "}
+                file stores only the deployment URL. The CLI searches the
+                current directory and then parent directories until it finds the
+                nearest project config.
+              </p>
+              <p className="doc-copy">
                 Resolution order is{" "}
                 <code className="font-mono text-sm text-primary">--url</code>,{" "}
                 <code className="font-mono text-sm text-primary">GESTALT_URL</code>,
                 project-local{" "}
                 <code className="font-mono text-sm text-primary">.gestalt.json</code>,
-                global CLI config, then{" "}
+                global CLI config, stored login credentials, then{" "}
                 <code className="font-mono text-sm text-primary">
                   http://localhost:8080
                 </code>


### PR DESCRIPTION
## What changed
- document that `gestalt init` can create a project-local `.gestalt.json`
- explain that `.gestalt.json` stores only the server URL for one checkout or deployment directory
- add the actual `gestalt` URL resolution order to both the public docs and the in-product docs
- note that the CLI searches the current directory and then parent directories for the nearest `.gestalt.json`

## Why
The CLI behavior was implemented but only partially documented. The public MDX docs said `gestalt init` saved the URL to local client config, while the in-product docs mentioned `.gestalt.json` without fully explaining its scope or the full precedence order.

## Impact
This is a docs-only change. It makes the project-local URL override behavior discoverable and aligns the external docs with the in-product docs.

## Validation
- `cd gestaltd/ui && npm run check`
- `cd docs && npm ci && npm run build` could not complete because the local machine hit `ENOSPC` while installing Next.js dependencies
