### PR TITLE
Add gestaltd audit logging coverage for MCP and auth flows

### DIFF
--- a/docs/pages/reference/_meta.ts
+++ b/docs/pages/reference/_meta.ts
@@ -7,5 +7,6 @@ export default {
   cli: "CLI",
   "docker-images": "Docker Images",
   observability: "Observability",
+  "audit-logging": "Audit Logging",
   "built-in-providers": "Built-in Providers",
 };

--- a/docs/pages/reference/audit-logging.mdx
+++ b/docs/pages/reference/audit-logging.mdx
@@ -1,0 +1,118 @@
+# Audit Logging
+
+`gestaltd` emits audit records as structured logs with `log.type=audit`.
+
+Audit logging covers both invocation traffic and security-sensitive management
+actions, so you can forward one stream to a SIEM, warehouse, or compliance
+backend without having to reconstruct behavior from mixed application logs.
+
+## Coverage
+
+Audit events are emitted for:
+
+- HTTP operation invocations with `source: http`
+- MCP operation invocations with `source: mcp`
+- Other guarded runtime surfaces that use the invocation guard, such as binding
+  hooks, with a surface-specific `source`
+- Login and logout flows
+- Integration connect and disconnect flows
+- API token create and revoke flows
+
+`gestaltd` resolves the authenticated user ID before emitting session-backed
+audit events, so session requests and API-token requests both produce stable
+`user_id` values when a user identity exists.
+
+## Fields
+
+Every audit record includes:
+
+| Field | Meaning |
+| --- | --- |
+| `log.type` | Always `audit` |
+| `event_time` | Event timestamp |
+| `request_id` | Request-scoped correlation ID |
+| `source` | Surface that emitted the event, such as `http`, `mcp`, or `binding:...` |
+| `provider` | Integration key for provider-scoped events |
+| `operation` | Operation or event name |
+| `depth` | Invocation depth for guarded invocation events |
+| `allowed` | Whether `gestaltd` allowed or completed the audited action |
+
+These fields are emitted when available:
+
+| Field | Meaning |
+| --- | --- |
+| `auth_source` | Auth mechanism for the caller: `session`, `api_token`, or `env` |
+| `user_id` | Stable internal user ID |
+| `error` | Denial or failure reason |
+| `client_ip` | Client IP, preferring `X-Forwarded-For` |
+| `remote_addr` | Immediate peer address |
+| `user_agent` | HTTP user agent |
+| `trace_id` | Active OpenTelemetry trace ID |
+| `span_id` | Active OpenTelemetry span ID |
+
+For platform-level events such as API-token CRUD, `provider` is empty because
+the event is not tied to a specific integration.
+
+## Event Names
+
+Invocation events use the catalog operation ID in `operation`.
+
+Non-invocation HTTP audit events use explicit operation names:
+
+- `auth.login.start`
+- `auth.login.complete`
+- `auth.logout`
+- `connection.oauth.start`
+- `connection.oauth.complete`
+- `connection.manual.connect`
+- `connection.pending.select`
+- `connection.disconnect`
+- `api_token.create`
+- `api_token.revoke`
+- `api_token.revoke_all`
+
+## Example
+
+```json
+{
+  "log.type": "audit",
+  "event_time": "2026-04-06T18:23:11.842Z",
+  "request_id": "2a7c1d7f-2b25-4b7a-8ae8-02f4d8f6f2b2",
+  "source": "mcp",
+  "auth_source": "api_token",
+  "user_id": "usr_123",
+  "provider": "github",
+  "operation": "issues_list",
+  "depth": 0,
+  "allowed": true,
+  "trace_id": "0af7651916cd43dd8448eb211c80319c",
+  "span_id": "b7ad6b7169203331"
+}
+```
+
+## Routing
+
+Audit records are standard structured logs, so you route them the same way as
+the rest of `gestaltd` telemetry:
+
+- `telemetry.provider: stdout` writes them to local structured logs
+- `telemetry.provider: otlp` exports them through the OTLP log pipeline
+
+If you need a dedicated sink, route on `log.type=audit` in your collector.
+
+## Metrics Notes
+
+Audit logs are a good source for invocation-based activity metrics. In
+particular, `source`, `auth_source`, `user_id`, `provider`, `operation`, and
+`allowed` are enough to derive distinct-user activity over guarded invocations.
+
+For DAU, WAU, or MAU built from tool usage, filter to successful top-level
+invocations, for example:
+
+- `allowed = true`
+- `depth = 0`
+- non-empty `user_id`
+
+This produces a clean “users who actually invoked a tool” metric. If you need a
+broader product-activity definition, treat the non-invocation audit events as a
+separate metric family rather than mixing them into invocation counts.

--- a/docs/pages/reference/config-file.mdx
+++ b/docs/pages/reference/config-file.mdx
@@ -289,7 +289,11 @@ response, and the built-in admin UI shows that metrics are unavailable.
 
 ### Audit logs
 
-Audit records are emitted as structured log entries with `log.type=audit`. Route them to a dedicated audit backend using OTel Collector attribute-based filtering. See [Observability](/reference/observability) for details.
+Audit records are emitted as structured log entries with `log.type=audit`.
+Route them to a dedicated audit backend using OTel Collector attribute-based
+filtering. See [Audit Logging](/reference/audit-logging) for the event schema
+and coverage details, and [Observability](/reference/observability) for export
+options.
 
 ## `providers`
 

--- a/docs/pages/reference/observability.mdx
+++ b/docs/pages/reference/observability.mdx
@@ -3,6 +3,9 @@
 Gestalt ships with structured logging, health endpoints, readiness checks, a
 Prometheus scrape endpoint, and optional OpenTelemetry export.
 
+For the audit-specific log schema and event coverage, see
+[Audit Logging](/reference/audit-logging).
+
 ## Health Endpoints
 
 | Path | Meaning |
@@ -222,7 +225,9 @@ Gestalt logs:
 - provider readiness
 - auth and connection flow failures
 - invocation failures
+- audit records with `log.type=audit`
 - datastore warnings
 
 When OTLP is enabled, the server routes structured logs through the OpenTelemetry
-log bridge.
+log bridge. You can split audit records into a dedicated sink by filtering on
+`log.type=audit`.

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -114,6 +114,7 @@ func runServer(env *bootstrapEnv) error {
 
 	result := env.Result
 	httpInvoker := invocation.NewGuarded(result.Invoker, result.CapabilityLister, "http", result.AuditSink, invocation.WithoutRateLimit())
+	mcpInvoker := invocation.NewGuarded(result.Invoker, result.CapabilityLister, "mcp", result.AuditSink, invocation.WithoutRateLimit())
 	connMaps, err := bootstrap.BuildConnectionMaps(env.Config)
 	if err != nil {
 		return err
@@ -148,6 +149,7 @@ func runServer(env *bootstrapEnv) error {
 
 	srv, err := server.New(server.Config{
 		Auth:              result.Auth,
+		AuditSink:         result.AuditSink,
 		Datastore:         result.Datastore,
 		Providers:         result.Providers,
 		Invoker:           httpInvoker,
@@ -209,7 +211,7 @@ func runServer(env *bootstrapEnv) error {
 		return err
 	}
 
-	mcpInner, err := mcpSurface.handler(result)
+	mcpInner, err := mcpSurface.handler(result, mcpInvoker)
 	if err != nil {
 		return err
 	}
@@ -304,15 +306,16 @@ func buildMCPSurface(cfg *config.Config, connMaps bootstrap.ConnectionMaps) mcpS
 	return surface
 }
 
-func (s mcpSurface) handler(result *bootstrap.Result) (http.Handler, error) {
+func (s mcpSurface) handler(result *bootstrap.Result, invoker invocation.Invoker) (http.Handler, error) {
 	broker, ok := result.Invoker.(*invocation.Broker)
 	if !ok {
 		return nil, fmt.Errorf("MCP token resolution requires *invocation.Broker as invoker")
 	}
 	return mcpserver.NewStreamableHTTPServer(
 		gestaltmcp.NewServer(gestaltmcp.Config{
-			Invoker:          result.Invoker,
+			Invoker:          invoker,
 			TokenResolver:    broker,
+			AuditSink:        result.AuditSink,
 			Providers:        result.Providers,
 			AllowedProviders: s.providers,
 			ToolPrefixes:     s.toolPrefixes,

--- a/gestaltd/core/audit.go
+++ b/gestaltd/core/audit.go
@@ -9,6 +9,7 @@ type AuditEntry struct {
 	Timestamp  time.Time
 	RequestID  string
 	Source     string
+	AuthSource string
 	UserID     string
 	Provider   string
 	Operation  string

--- a/gestaltd/internal/invocation/audit.go
+++ b/gestaltd/internal/invocation/audit.go
@@ -5,8 +5,10 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -36,17 +38,51 @@ func NewLoggerAuditSink(logger *slog.Logger) *SlogAuditSink {
 	}
 }
 
+func buildAuditEntry(ctx context.Context, p *principal.Principal, source, providerName, operation string, meta *InvocationMeta) core.AuditEntry {
+	reqMeta := RequestMetaFromContext(ctx)
+	entry := core.AuditEntry{
+		Timestamp:  time.Now(),
+		RequestID:  meta.RequestID,
+		Source:     source,
+		Provider:   providerName,
+		Operation:  operation,
+		Depth:      meta.Depth,
+		ClientIP:   reqMeta.ClientIP,
+		RemoteAddr: reqMeta.RemoteAddr,
+		UserAgent:  reqMeta.UserAgent,
+	}
+	if p != nil {
+		entry.UserID = p.UserID
+		entry.AuthSource = p.AuthSource()
+	}
+	return entry
+}
+
+func BuildAuditEntry(ctx context.Context, p *principal.Principal, source, providerName, operation string) (context.Context, core.AuditEntry) {
+	ctx, meta := ensureMeta(ctx)
+	if p == nil {
+		p = principal.FromContext(ctx)
+	}
+	return ctx, buildAuditEntry(ctx, p, source, providerName, operation, meta)
+}
+
 func (s *SlogAuditSink) Log(ctx context.Context, entry core.AuditEntry) {
 	attrs := []slog.Attr{
 		slog.String("log.type", auditLogType),
 		slog.Time("event_time", entry.Timestamp),
 		slog.String("request_id", entry.RequestID),
 		slog.String("source", entry.Source),
-		slog.String("user_id", entry.UserID),
 		slog.String("provider", entry.Provider),
 		slog.String("operation", entry.Operation),
 		slog.Int("depth", entry.Depth),
 		slog.Bool("allowed", entry.Allowed),
+	}
+
+	if entry.AuthSource != "" {
+		attrs = append(attrs, slog.String("auth_source", entry.AuthSource))
+	}
+	if entry.UserID != "" {
+		attrs = append(attrs, slog.String("user_id", entry.UserID))
 	}
 
 	if entry.Error != "" {

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -290,7 +290,7 @@ func toolResultToOperationResult(result *mcpgo.CallToolResult) (*core.OperationR
 	}
 
 	if result.IsError {
-		return nil, fmt.Errorf("%w: %s", &apiexec.UpstreamOperationError{Message: "operation failed"}, toolErrorMessage(result))
+		return nil, fmt.Errorf("%w: %s", &apiexec.UpstreamOperationError{Message: "operation failed"}, ToolErrorMessage(result))
 	}
 
 	if result.StructuredContent != nil {
@@ -314,7 +314,7 @@ func toolResultToOperationResult(result *mcpgo.CallToolResult) (*core.OperationR
 	return &core.OperationResult{Status: http.StatusOK, Headers: headers, Body: string(body)}, nil
 }
 
-func toolErrorMessage(result *mcpgo.CallToolResult) string {
+func ToolErrorMessage(result *mcpgo.CallToolResult) string {
 	for _, item := range result.Content {
 		if text, ok := mcpgo.AsTextContent(item); ok && strings.TrimSpace(text.Text) != "" {
 			return text.Text

--- a/gestaltd/internal/invocation/guarded.go
+++ b/gestaltd/internal/invocation/guarded.go
@@ -3,7 +3,6 @@ package invocation
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
@@ -78,21 +77,7 @@ func (g *GuardedInvoker) Invoke(ctx context.Context, p *principal.Principal, pro
 		p = &principal.Principal{}
 	}
 
-	reqMeta := RequestMetaFromContext(ctx)
-	entry := core.AuditEntry{
-		Timestamp:  time.Now(),
-		RequestID:  meta.RequestID,
-		Source:     g.source,
-		Provider:   providerName,
-		Operation:  operation,
-		Depth:      meta.Depth,
-		ClientIP:   reqMeta.ClientIP,
-		RemoteAddr: reqMeta.RemoteAddr,
-		UserAgent:  reqMeta.UserAgent,
-	}
-	if p != nil {
-		entry.UserID = p.UserID
-	}
+	entry := buildAuditEntry(ctx, p, g.source, providerName, operation, meta)
 
 	if err := g.check(meta, providerName, instance, operation); err != nil {
 		entry.Allowed = false

--- a/gestaltd/internal/mcp/binding.go
+++ b/gestaltd/internal/mcp/binding.go
@@ -24,6 +24,7 @@ type directToolCaller interface {
 type Config struct {
 	Invoker          invocation.Invoker
 	TokenResolver    invocation.TokenResolver
+	AuditSink        core.AuditSink
 	Providers        *registry.PluginMap[core.Provider]
 	AllowedProviders []string
 	ToolPrefixes     map[string]string

--- a/gestaltd/internal/mcp/handlers.go
+++ b/gestaltd/internal/mcp/handlers.go
@@ -46,9 +46,27 @@ func makeDirectHandler(cfg Config, prov core.Provider, provName, opName, connect
 		instance, _ := args["_instance"].(string)
 		delete(args, "_instance")
 
-		result, err := invocation.CallDirectTool(ctx, cfg.TokenResolver, principal.FromContext(ctx), prov, provName, opName, connection, instance, args, req.Params.Meta)
+		auditCtx, entry := invocation.BuildAuditEntry(ctx, principal.FromContext(ctx), "mcp", provName, opName)
+		result, err := invocation.CallDirectTool(auditCtx, cfg.TokenResolver, principal.FromContext(auditCtx), prov, provName, opName, connection, instance, args, req.Params.Meta)
 		if err != nil {
+			entry.Allowed = false
+			entry.Error = err.Error()
+			if cfg.AuditSink != nil {
+				cfg.AuditSink.Log(auditCtx, entry)
+			}
 			return mcpgo.NewToolResultError(err.Error()), nil
+		}
+		if result != nil && result.IsError {
+			entry.Allowed = false
+			entry.Error = invocation.ToolErrorMessage(result)
+			if cfg.AuditSink != nil {
+				cfg.AuditSink.Log(auditCtx, entry)
+			}
+			return result, nil
+		}
+		entry.Allowed = true
+		if cfg.AuditSink != nil {
+			cfg.AuditSink.Log(auditCtx, entry)
 		}
 		return result, nil
 	}

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -23,6 +23,29 @@ type Principal struct {
 	Scopes   []string
 }
 
+func (s Source) String() string {
+	switch s {
+	case SourceSession:
+		return "session"
+	case SourceAPIToken:
+		return "api_token"
+	case SourceEnv:
+		return "env"
+	default:
+		return ""
+	}
+}
+
+func (p *Principal) AuthSource() string {
+	if p == nil {
+		return ""
+	}
+	if p.Identity == nil && p.UserID == "" && len(p.Scopes) == 0 {
+		return ""
+	}
+	return p.Source.String()
+}
+
 type contextKey struct{}
 
 func WithPrincipal(ctx context.Context, p *Principal) context.Context {

--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Principal) (*principal.Principal, error) {
+	if p == nil || p.UserID != "" || p.Identity == nil || p.Identity.Email == "" {
+		return p, nil
+	}
+
+	dbUser, err := s.datastore.FindOrCreateUser(ctx, p.Identity.Email)
+	if err != nil {
+		return nil, err
+	}
+	if dbUser == nil || dbUser.ID == "" {
+		return nil, fmt.Errorf("authenticated principal missing user ID")
+	}
+
+	clone := *p
+	clone.UserID = dbUser.ID
+	return &clone, nil
+}
+
+func (s *Server) auditHTTPEvent(ctx context.Context, p *principal.Principal, provider, operation string, allowed bool, err error) {
+	if s.auditSink == nil {
+		return
+	}
+
+	ctx, entry := invocation.BuildAuditEntry(ctx, p, "http", provider, operation)
+	entry.Allowed = allowed
+	if err != nil {
+		entry.Error = err.Error()
+	}
+	s.auditSink.Log(ctx, entry)
+}
+
+func (s *Server) auditHTTPEventWithUserID(ctx context.Context, userID, authSource, provider, operation string, allowed bool, err error) {
+	if s.auditSink == nil {
+		return
+	}
+
+	ctx, entry := invocation.BuildAuditEntry(ctx, nil, "http", provider, operation)
+	entry.UserID = userID
+	entry.AuthSource = authSource
+	entry.Allowed = allowed
+	if err != nil {
+		entry.Error = err.Error()
+	}
+	s.auditSink.Log(ctx, entry)
+}

--- a/gestaltd/internal/server/audit_metadata_test.go
+++ b/gestaltd/internal/server/audit_metadata_test.go
@@ -34,12 +34,25 @@ func TestAuditMetadata_IPAndUserAgent(t *testing.T) {
 	}
 
 	providers := testutil.NewProviderRegistry(t, stub)
-	ds := &coretesting.StubDatastore{}
+	ds := &coretesting.StubDatastore{
+		FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+			return &core.User{ID: "user-session", Email: email}, nil
+		},
+	}
 	broker := invocation.NewBroker(providers, ds)
 	guarded := invocation.NewGuarded(broker, broker, "http", auditSink, invocation.WithoutRateLimit())
 
 	srv, err := server.New(server.Config{
-		Auth:        &coretesting.StubAuthProvider{N: "none"},
+		Auth: &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "session@example.com"}, nil
+			},
+		},
+		AuditSink:   auditSink,
 		Datastore:   ds,
 		Providers:   providers,
 		Invoker:     guarded,
@@ -54,6 +67,7 @@ func TestAuditMetadata_IPAndUserAgent(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/audit-prov/ping", bytes.NewBufferString(`{}`))
 	req.Header.Set("X-Forwarded-For", "203.0.113.42, 10.0.0.1")
 	req.Header.Set("User-Agent", "test-client/1.0")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -86,6 +100,12 @@ func TestAuditMetadata_IPAndUserAgent(t *testing.T) {
 	}
 	if record["provider"] != "audit-prov" {
 		t.Errorf("expected provider=audit-prov, got %v", record["provider"])
+	}
+	if record["auth_source"] != "session" {
+		t.Errorf("expected auth_source=session, got %v", record["auth_source"])
+	}
+	if record["user_id"] != "user-session" {
+		t.Errorf("expected user_id=user-session, got %v", record["user_id"])
 	}
 	if record["allowed"] != true {
 		t.Errorf("expected allowed=true, got %v", record["allowed"])

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
 	"github.com/valon-technologies/gestalt/server/internal/paraminterp"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
 
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -37,21 +38,26 @@ const maxPort = 65535
 const sessionCookieName = "session_token"
 const defaultSessionCookieTTL = 24 * time.Hour
 
-func (s *Server) resolveUserID(w http.ResponseWriter, r *http.Request) (string, bool) {
+var (
+	errNotAuthenticated = errors.New("not authenticated")
+	errResolveUser      = errors.New("failed to resolve user")
+)
+
+func (s *Server) resolveUserID(w http.ResponseWriter, r *http.Request) (string, error) {
 	user := UserFromContext(r.Context())
 	if user == nil || user.Email == "" {
 		writeError(w, http.StatusUnauthorized, "not authenticated")
-		return "", false
+		return "", errNotAuthenticated
 	}
 	if id := UserIDFromContext(r.Context()); id != "" {
-		return id, true
+		return id, nil
 	}
 	dbUser, err := s.datastore.FindOrCreateUser(r.Context(), user.Email)
 	if err != nil || dbUser == nil || dbUser.ID == "" {
 		writeError(w, http.StatusInternalServerError, "failed to resolve user")
-		return "", false
+		return "", errResolveUser
 	}
-	return dbUser.ID, true
+	return dbUser.ID, nil
 }
 
 func (s *Server) healthCheck(w http.ResponseWriter, _ *http.Request) {
@@ -191,13 +197,21 @@ func (s *Server) userConnectedIntegrations(r *http.Request) (map[string][]instan
 }
 
 func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
-	userID, ok := s.resolveUserID(w, r)
-	if !ok {
+	name := chi.URLParam(r, "name")
+	auditAllowed := false
+	auditErr := errors.New("connection disconnect failed")
+	defer func() {
+		s.auditHTTPEvent(r.Context(), PrincipalFromContext(r.Context()), name, "connection.disconnect", auditAllowed, auditErr)
+	}()
+
+	userID, err := s.resolveUserID(w, r)
+	if err != nil {
+		auditErr = err
 		return
 	}
 
-	name := chi.URLParam(r, "name")
 	if _, ok := s.getProvider(w, name); !ok {
+		auditErr = errors.New("integration not found")
 		return
 	}
 
@@ -205,6 +219,7 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 	requestedConnection := r.URL.Query().Get("connection")
 	if requestedConnection != "" {
 		if !safeParamValue.MatchString(requestedConnection) {
+			auditErr = errors.New("connection name contains invalid characters")
 			writeError(w, http.StatusBadRequest, "connection name contains invalid characters")
 			return
 		}
@@ -213,6 +228,7 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 
 	tokens, err := s.datastore.ListTokensForIntegration(r.Context(), userID, name)
 	if err != nil {
+		auditErr = errors.New("failed to list tokens")
 		writeError(w, http.StatusInternalServerError, "failed to list tokens")
 		return
 	}
@@ -226,6 +242,7 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(matched) == 0 {
+		auditErr = errors.New("connection not found")
 		writeError(w, http.StatusNotFound, fmt.Sprintf("no connection found for integration %q", name))
 		return
 	}
@@ -241,10 +258,12 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(matched) == 0 {
+		auditErr = errors.New("connection instance not found")
 		writeError(w, http.StatusNotFound, fmt.Sprintf("no connection found for integration %q instance %q", name, requestedInstance))
 		return
 	}
 	if len(matched) > 1 {
+		auditErr = errors.New("multiple matching connections")
 		labels := make([]string, len(matched))
 		for i, t := range matched {
 			labels[i] = fmt.Sprintf("%s/%s", t.Connection, t.Instance)
@@ -259,15 +278,19 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 
 	tokenID := matched[0].ID
 	if tokenID == "" {
+		auditErr = errors.New("connection token is missing an ID")
 		writeError(w, http.StatusNotFound, fmt.Sprintf("no connection found for integration %q", name))
 		return
 	}
 
 	if err := s.datastore.DeleteToken(r.Context(), tokenID); err != nil {
+		auditErr = errors.New("failed to disconnect integration")
 		writeError(w, http.StatusInternalServerError, "failed to disconnect integration")
 		return
 	}
 
+	auditAllowed = true
+	auditErr = nil
 	writeJSON(w, http.StatusOK, map[string]string{"status": "disconnected"})
 }
 
@@ -536,11 +559,24 @@ type authInfoResponse struct {
 	DisplayName string `json:"display_name"`
 }
 
+func (s *Server) authProviderName() string {
+	if s.auth == nil {
+		return "none"
+	}
+	return s.auth.Name()
+}
+
+func (s *Server) authEnabled() bool {
+	return s.auth != nil && !s.noAuth
+}
+
 func (s *Server) authInfo(w http.ResponseWriter, _ *http.Request) {
-	provider := s.auth.Name()
+	provider := s.authProviderName()
 	displayName := provider
-	if dn, ok := s.auth.(AuthProviderDisplayName); ok {
-		displayName = dn.DisplayName()
+	if s.auth != nil {
+		if dn, ok := s.auth.(AuthProviderDisplayName); ok {
+			displayName = dn.DisplayName()
+		}
 	}
 	writeJSON(w, http.StatusOK, authInfoResponse{
 		Provider:    provider,
@@ -549,8 +585,15 @@ func (s *Server) authInfo(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) startLogin(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("login start failed")
+	defer func() {
+		s.auditHTTPEvent(r.Context(), nil, s.authProviderName(), "auth.login.start", auditAllowed, auditErr)
+	}()
+
 	var req loginRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		auditErr = errors.New("invalid JSON body")
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -558,8 +601,14 @@ func (s *Server) startLogin(w http.ResponseWriter, r *http.Request) {
 	if req.CallbackPort > 0 && req.CallbackPort <= maxPort {
 		state = fmt.Sprintf("%s%d:%s", cliStatePrefix, req.CallbackPort, req.State)
 	}
+	if !s.authEnabled() {
+		auditErr = errors.New("auth is disabled")
+		writeError(w, http.StatusNotFound, "auth is disabled")
+		return
+	}
 	url, err := s.auth.LoginURL(state)
 	if err != nil {
+		auditErr = errors.New("failed to generate login URL")
 		writeError(w, http.StatusInternalServerError, "failed to generate login URL")
 		return
 	}
@@ -569,6 +618,7 @@ func (s *Server) startLogin(w http.ResponseWriter, r *http.Request) {
 			ExpiresAt: s.now().Add(loginStateTTL).Unix(),
 		})
 		if encErr != nil {
+			auditErr = errors.New("failed to encode login state")
 			writeError(w, http.StatusInternalServerError, "failed to encode login state")
 			return
 		}
@@ -582,6 +632,8 @@ func (s *Server) startLogin(w http.ResponseWriter, r *http.Request) {
 			SameSite: http.SameSiteLaxMode,
 		})
 	}
+	auditAllowed = true
+	auditErr = nil
 	writeJSON(w, http.StatusOK, map[string]string{"url": url})
 }
 
@@ -638,9 +690,26 @@ type StatefulCallbackHandler interface {
 }
 
 func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("login callback failed")
+	auditUserID := ""
+	defer func() {
+		if auditUserID != "" {
+			s.auditHTTPEventWithUserID(r.Context(), auditUserID, principal.SourceSession.String(), s.authProviderName(), "auth.login.complete", auditAllowed, auditErr)
+			return
+		}
+		s.auditHTTPEvent(r.Context(), nil, s.authProviderName(), "auth.login.complete", auditAllowed, auditErr)
+	}()
+
 	code := r.URL.Query().Get("code")
 	if code == "" {
+		auditErr = errors.New("missing code parameter")
 		writeError(w, http.StatusBadRequest, "missing code parameter")
+		return
+	}
+	if !s.authEnabled() {
+		auditErr = errors.New("auth is disabled")
+		writeError(w, http.StatusNotFound, "auth is disabled")
 		return
 	}
 
@@ -656,12 +725,14 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 		identity, err = s.auth.HandleCallback(r.Context(), code)
 	}
 	if err != nil {
+		auditErr = errors.New("login failed")
 		slog.ErrorContext(r.Context(), "login callback failed", "error", err)
 		writeError(w, http.StatusUnauthorized, "login failed")
 		return
 	}
 
 	if csrfErr := s.validateLoginState(r, originalState); csrfErr != nil {
+		auditErr = errors.New("login state validation failed")
 		slog.ErrorContext(r.Context(), "login state validation failed", "error", csrfErr)
 		writeError(w, http.StatusForbidden, "login state validation failed")
 		return
@@ -673,14 +744,19 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Query().Get("cli") == "1" {
 		dbUser, dbErr := s.datastore.FindOrCreateUser(r.Context(), identity.Email)
 		if dbErr != nil || dbUser == nil || dbUser.ID == "" {
+			auditErr = errors.New("failed to resolve user")
 			writeError(w, http.StatusInternalServerError, "failed to resolve user")
 			return
 		}
+		auditUserID = dbUser.ID
 		apiToken, plaintext, issueErr := s.issueAPIToken(r.Context(), dbUser.ID, cliLoginTokenName, "", true)
 		if issueErr != nil {
+			auditErr = errors.New("failed to issue CLI API token")
 			writeError(w, http.StatusInternalServerError, "failed to issue CLI API token")
 			return
 		}
+		auditAllowed = true
+		auditErr = nil
 		writeJSON(w, http.StatusOK, createTokenResponse{
 			ID:        apiToken.ID,
 			Name:      apiToken.Name,
@@ -690,6 +766,18 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if identity != nil && identity.Email != "" {
+		dbUser, auditPrincipalErr := s.datastore.FindOrCreateUser(r.Context(), identity.Email)
+		switch {
+		case auditPrincipalErr != nil:
+			slog.WarnContext(r.Context(), "login audit user resolution failed", "error", auditPrincipalErr)
+		case dbUser != nil && dbUser.ID != "":
+			auditUserID = dbUser.ID
+		default:
+			slog.WarnContext(r.Context(), "login audit user resolution failed", "error", "authenticated principal missing user ID")
+		}
+	}
+
 	resp := map[string]any{
 		"email":        identity.Email,
 		"display_name": identity.DisplayName,
@@ -697,16 +785,20 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 
 	issuer, ok := s.auth.(SessionTokenIssuer)
 	if !ok {
+		auditErr = errors.New("auth provider does not support session tokens")
 		writeError(w, http.StatusInternalServerError, "auth provider does not support session tokens")
 		return
 	}
 	token, err := issuer.IssueSessionToken(identity)
 	if err != nil {
+		auditErr = errors.New("failed to issue session token")
 		writeError(w, http.StatusInternalServerError, "failed to issue session token")
 		return
 	}
 	s.setSessionCookie(w, token)
 
+	auditAllowed = true
+	auditErr = nil
 	writeJSON(w, http.StatusOK, resp)
 }
 
@@ -749,44 +841,60 @@ type startOAuthRequest struct {
 }
 
 func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("oauth start failed")
+	providerName := ""
+	defer func() {
+		s.auditHTTPEvent(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.oauth.start", auditAllowed, auditErr)
+	}()
+
 	var req startOAuthRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		auditErr = errors.New("invalid JSON body")
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
+	providerName = req.Integration
 
 	prov, ok := s.getProvider(w, req.Integration)
 	if !ok {
+		auditErr = errors.New("integration not found")
 		return
 	}
 
 	connection, ok := s.resolveRequestedConnection(w, req.Integration, req.Connection)
 	if !ok {
+		auditErr = errors.New("invalid connection")
 		return
 	}
 
 	handler, ok := s.requireOAuthHandler(w, req.Integration, connection)
 	if !ok {
+		auditErr = errors.New("oauth is not configured")
 		return
 	}
 
 	if s.stateCodec == nil {
+		auditErr = errors.New("oauth state encryption is not configured")
 		writeError(w, http.StatusInternalServerError, "oauth state encryption is not configured")
 		return
 	}
 
-	dbUserID, ok := s.resolveUserID(w, r)
-	if !ok {
+	dbUserID, err := s.resolveUserID(w, r)
+	if err != nil {
+		auditErr = err
 		return
 	}
 
 	instance, ok := resolveRequestedInstance(w, req.Instance)
 	if !ok {
+		auditErr = errors.New("invalid instance")
 		return
 	}
 
 	connParams, ok := resolveConnectionParams(w, prov, req.ConnectionParams)
 	if !ok {
+		auditErr = errors.New("invalid connection parameters")
 		return
 	}
 
@@ -806,8 +914,13 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		authURL, verifier = handler.StartOAuth("_", req.Scopes)
 	}
 
+	authSource := ""
+	if p := PrincipalFromContext(r.Context()); p != nil {
+		authSource = p.AuthSource()
+	}
 	state, err := s.stateCodec.Encode(integrationOAuthState{
 		UserID:           dbUserID,
+		AuthSource:       authSource,
 		Integration:      req.Integration,
 		Connection:       connection,
 		Instance:         instance,
@@ -816,48 +929,67 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		ExpiresAt:        s.now().Add(integrationOAuthStateTTL).Unix(),
 	})
 	if err != nil {
+		auditErr = errors.New("failed to encode oauth state")
 		writeError(w, http.StatusInternalServerError, "failed to encode oauth state")
 		return
 	}
 
 	authURL, err = setURLQueryParam(authURL, "state", state)
 	if err != nil {
+		auditErr = errors.New("failed to prepare oauth URL")
 		writeError(w, http.StatusInternalServerError, "failed to prepare oauth URL")
 		return
 	}
 
+	auditAllowed = true
+	auditErr = nil
 	writeJSON(w, http.StatusOK, map[string]string{"url": authURL, "state": state})
 }
 
 func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request) {
 	metricProvider := metricutil.UnknownAttrValue
 	callbackFailed := true
+	auditAllowed := false
+	auditErr := errors.New("oauth callback failed")
+	auditUserID := ""
+	stateAuthSource := ""
+	providerName := ""
 	defer func() {
 		recordOAuthCallbackMetric(r.Context(), metricProvider, callbackFailed)
+		if auditUserID != "" {
+			s.auditHTTPEventWithUserID(r.Context(), auditUserID, stateAuthSource, providerName, "connection.oauth.complete", auditAllowed, auditErr)
+			return
+		}
+		s.auditHTTPEvent(r.Context(), nil, providerName, "connection.oauth.complete", auditAllowed, auditErr)
 	}()
 
 	code := r.URL.Query().Get("code")
 	encodedState := r.URL.Query().Get("state")
 	if code == "" || encodedState == "" {
+		auditErr = errors.New("missing code or state parameter")
 		writeError(w, http.StatusBadRequest, "missing code or state parameter")
 		return
 	}
 
 	if s.stateCodec == nil {
+		auditErr = errors.New("oauth state encryption is not configured")
 		writeError(w, http.StatusInternalServerError, "oauth state encryption is not configured")
 		return
 	}
 
 	state, err := s.stateCodec.Decode(encodedState, s.now())
 	if err != nil {
+		auditErr = errors.New("invalid or expired oauth state")
 		writeError(w, http.StatusBadRequest, "invalid or expired oauth state")
 		return
 	}
-
-	providerName := state.Integration
+	providerName = state.Integration
+	auditUserID = state.UserID
+	stateAuthSource = state.AuthSource
 	metricProvider = providerName
 	handler, ok := s.requireOAuthHandler(w, providerName, state.Connection)
 	if !ok {
+		auditErr = errors.New("oauth is not configured")
 		return
 	}
 
@@ -876,6 +1008,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	var tokenResp *core.TokenResponse
 	tokenResp, err = handler.ExchangeCodeWithVerifier(r.Context(), code, state.Verifier, exchangeOpts...)
 	if err != nil {
+		auditErr = errors.New("token exchange failed")
 		slog.ErrorContext(r.Context(), "token exchange failed", "provider", providerName, "error", err)
 		writeError(w, http.StatusBadGateway, "token exchange failed")
 		return
@@ -883,6 +1016,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 
 	metadata, metaErr := buildConnectionMetadata(prov, connParams, tokenResp)
 	if metaErr != nil {
+		auditErr = errors.New("failed to extract connection metadata from token response")
 		slog.ErrorContext(r.Context(), "connection metadata extraction failed", "provider", providerName, "error", metaErr)
 		writeError(w, http.StatusBadGateway, "failed to extract connection metadata from token response")
 		return
@@ -901,6 +1035,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 
 	tm := tokenMaterial{
 		UserID:         state.UserID,
+		AuthSource:     state.AuthSource,
 		Integration:    providerName,
 		Connection:     state.Connection,
 		Instance:       callbackInstance,
@@ -912,6 +1047,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 
 	result, err := s.runPostConnect(r.Context(), prov, tm)
 	if err != nil {
+		auditErr = errors.New("connection setup failed")
 		slog.ErrorContext(r.Context(), "post_connect failed", "provider", providerName, "error", err)
 		writeError(w, http.StatusBadGateway, "connection setup failed")
 		return
@@ -920,15 +1056,19 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	if result.Status == "selection_required" {
 		state, err := s.decodePendingConnectionToken(result.PendingToken)
 		if err != nil {
+			auditErr = errors.New("failed to prepare pending connection")
 			writeError(w, http.StatusInternalServerError, "failed to prepare pending connection")
 			return
 		}
+		auditAllowed = true
+		auditErr = nil
 		s.writePendingConnectionSelectionPage(w, state, result.PendingToken)
 		callbackFailed = false
 		return
 	}
-
 	callbackFailed = false
+	auditAllowed = true
+	auditErr = nil
 	http.Redirect(w, r, "/integrations?connected="+url.QueryEscape(providerName), http.StatusSeeOther)
 }
 
@@ -942,22 +1082,33 @@ type connectManualRequest struct {
 }
 
 func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("manual connection failed")
+	providerName := ""
+	defer func() {
+		s.auditHTTPEvent(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.manual.connect", auditAllowed, auditErr)
+	}()
+
 	var req connectManualRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		auditErr = errors.New("invalid JSON body")
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
+	providerName = req.Integration
 
 	var effectiveCredential string
 	if len(req.Credentials) > 0 {
 		for k, v := range req.Credentials {
 			if v == "" {
+				auditErr = fmt.Errorf("credential %q must not be empty", k)
 				writeError(w, http.StatusBadRequest, fmt.Sprintf("credential %q must not be empty", k))
 				return
 			}
 		}
 		b, err := json.Marshal(req.Credentials)
 		if err != nil {
+			auditErr = errors.New("invalid credentials map")
 			writeError(w, http.StatusBadRequest, "invalid credentials map")
 			return
 		}
@@ -967,49 +1118,62 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.Integration == "" || effectiveCredential == "" {
+		auditErr = errors.New("integration and credential are required")
 		writeError(w, http.StatusBadRequest, "integration and credential are required")
 		return
 	}
 
 	prov, ok := s.getProvider(w, req.Integration)
 	if !ok {
+		auditErr = errors.New("integration not found")
 		return
 	}
 
 	mp, ok := prov.(core.ManualProvider)
 	if !ok || !mp.SupportsManualAuth() {
+		auditErr = errors.New("integration does not support manual auth")
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("integration %q does not support manual auth; use OAuth connect instead", req.Integration))
 		return
 	}
 
-	dbUserID, ok := s.resolveUserID(w, r)
-	if !ok {
+	dbUserID, err := s.resolveUserID(w, r)
+	if err != nil {
+		auditErr = err
 		return
 	}
 
 	manualInstance, ok := resolveRequestedInstance(w, req.Instance)
 	if !ok {
+		auditErr = errors.New("invalid instance")
 		return
 	}
 
 	manualConnection, ok := s.resolveRequestedConnection(w, req.Integration, req.Connection)
 	if !ok {
+		auditErr = errors.New("invalid connection")
 		return
 	}
 
 	connParams, ok := resolveConnectionParams(w, prov, req.ConnectionParams)
 	if !ok {
+		auditErr = errors.New("invalid connection parameters")
 		return
 	}
 
 	manualMeta, metaErr := buildConnectionMetadata(prov, connParams, nil)
 	if metaErr != nil {
+		auditErr = errors.New(metaErr.Error())
 		writeError(w, http.StatusBadRequest, metaErr.Error())
 		return
 	}
 
+	authSource := ""
+	if p := PrincipalFromContext(r.Context()); p != nil {
+		authSource = p.AuthSource()
+	}
 	tm := tokenMaterial{
 		UserID:       dbUserID,
+		AuthSource:   authSource,
 		Integration:  req.Integration,
 		Connection:   manualConnection,
 		Instance:     manualInstance,
@@ -1019,11 +1183,14 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 
 	result, err := s.runPostConnect(r.Context(), prov, tm)
 	if err != nil {
+		auditErr = errors.New("connection setup failed")
 		slog.ErrorContext(r.Context(), "post_connect failed", "provider", req.Integration, "error", err)
 		writeError(w, http.StatusBadGateway, "connection setup failed")
 		return
 	}
 
+	auditAllowed = true
+	auditErr = nil
 	writeJSON(w, http.StatusOK, result)
 }
 
@@ -1040,18 +1207,27 @@ type createTokenResponse struct {
 }
 
 func (s *Server) createAPIToken(w http.ResponseWriter, r *http.Request) {
-	userID, ok := s.resolveUserID(w, r)
-	if !ok {
+	auditAllowed := false
+	auditErr := errors.New("api token creation failed")
+	defer func() {
+		s.auditHTTPEvent(r.Context(), PrincipalFromContext(r.Context()), "", "api_token.create", auditAllowed, auditErr)
+	}()
+
+	userID, err := s.resolveUserID(w, r)
+	if err != nil {
+		auditErr = err
 		return
 	}
 
 	var req createTokenRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		auditErr = errors.New("invalid JSON body")
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
 
 	if req.Name == "" {
+		auditErr = errors.New("name is required")
 		writeError(w, http.StatusBadRequest, "name is required")
 		return
 	}
@@ -1059,6 +1235,7 @@ func (s *Server) createAPIToken(w http.ResponseWriter, r *http.Request) {
 	if req.Scopes != "" {
 		for _, scope := range strings.Fields(req.Scopes) {
 			if _, err := s.providers.Get(scope); err != nil {
+				auditErr = fmt.Errorf("unknown scope %q", scope)
 				writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown scope %q", scope))
 				return
 			}
@@ -1067,10 +1244,13 @@ func (s *Server) createAPIToken(w http.ResponseWriter, r *http.Request) {
 
 	apiToken, plaintext, err := s.issueAPIToken(r.Context(), userID, req.Name, req.Scopes, false)
 	if err != nil {
+		auditErr = errors.New("failed to generate token")
 		writeError(w, http.StatusInternalServerError, "failed to generate token")
 		return
 	}
 
+	auditAllowed = true
+	auditErr = nil
 	writeJSON(w, http.StatusCreated, createTokenResponse{
 		ID:        apiToken.ID,
 		Name:      apiToken.Name,
@@ -1088,8 +1268,8 @@ type apiTokenInfo struct {
 }
 
 func (s *Server) listAPITokens(w http.ResponseWriter, r *http.Request) {
-	userID, ok := s.resolveUserID(w, r)
-	if !ok {
+	userID, err := s.resolveUserID(w, r)
+	if err != nil {
 		return
 	}
 
@@ -1282,39 +1462,80 @@ func userFacingAuthType(authType string) (string, bool) {
 }
 
 func (s *Server) revokeAPIToken(w http.ResponseWriter, r *http.Request) {
-	userID, ok := s.resolveUserID(w, r)
-	if !ok {
+	auditAllowed := false
+	auditErr := errors.New("api token revoke failed")
+	defer func() {
+		s.auditHTTPEvent(r.Context(), PrincipalFromContext(r.Context()), "", "api_token.revoke", auditAllowed, auditErr)
+	}()
+
+	userID, err := s.resolveUserID(w, r)
+	if err != nil {
+		auditErr = err
 		return
 	}
 
 	id := chi.URLParam(r, "id")
 	if err := s.datastore.RevokeAPIToken(r.Context(), userID, id); err != nil {
 		if errors.Is(err, core.ErrNotFound) {
+			auditErr = errors.New("token not found")
 			writeError(w, http.StatusNotFound, "token not found")
 			return
 		}
+		auditErr = errors.New("failed to revoke token")
 		writeError(w, http.StatusInternalServerError, "failed to revoke token")
 		return
 	}
+	auditAllowed = true
+	auditErr = nil
 	writeJSON(w, http.StatusOK, map[string]string{"status": "revoked"})
 }
 
 func (s *Server) revokeAllAPITokens(w http.ResponseWriter, r *http.Request) {
-	userID, ok := s.resolveUserID(w, r)
-	if !ok {
+	auditAllowed := false
+	auditErr := errors.New("api token revoke all failed")
+	defer func() {
+		s.auditHTTPEvent(r.Context(), PrincipalFromContext(r.Context()), "", "api_token.revoke_all", auditAllowed, auditErr)
+	}()
+
+	userID, err := s.resolveUserID(w, r)
+	if err != nil {
+		auditErr = err
 		return
 	}
 
 	count, err := s.datastore.RevokeAllAPITokens(r.Context(), userID)
 	if err != nil {
+		auditErr = errors.New("failed to revoke tokens")
 		writeError(w, http.StatusInternalServerError, "failed to revoke tokens")
 		return
 	}
+	auditAllowed = true
+	auditErr = nil
 	writeJSON(w, http.StatusOK, map[string]any{"status": "revoked", "count": count})
 }
 
 func (s *Server) logout(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("logout failed")
+	var auditPrincipal *principal.Principal
+	if !s.noAuth {
+		p, err := s.resolveRequestPrincipalWithUserID(r)
+		switch {
+		case err == nil:
+			auditPrincipal = p
+		case errors.Is(err, errInvalidAuthorizationHeader), errors.Is(err, principal.ErrInvalidToken):
+			slog.InfoContext(r.Context(), "logout: unable to resolve caller for audit", "error", err)
+		default:
+			slog.WarnContext(r.Context(), "logout: unable to resolve caller for audit", "error", err)
+		}
+	}
+	defer func() {
+		s.auditHTTPEvent(r.Context(), auditPrincipal, s.authProviderName(), "auth.logout", auditAllowed, auditErr)
+	}()
+
 	s.clearSessionCookie(w)
+	auditAllowed = true
+	auditErr = nil
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
@@ -1408,6 +1629,7 @@ func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 type tokenMaterial struct {
 	UserID         string
+	AuthSource     string
 	Integration    string
 	Connection     string
 	Instance       string

--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -88,6 +88,7 @@ func TestCustomAuthMetrics(t *testing.T) {
 	t.Parallel()
 
 	reader := useManualMeterProvider(t)
+	const providerName = "metrics-slack"
 
 	handler := &testOAuthHandler{
 		authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
@@ -101,11 +102,11 @@ func TestCustomAuthMetrics(t *testing.T) {
 
 	oauthServer := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, &stubIntegrationWithAuthURL{
-			StubIntegration: coretesting.StubIntegration{N: "slack"},
+			StubIntegration: coretesting.StubIntegration{N: providerName},
 			authURL:         "https://slack.com/oauth/v2/authorize",
 		})
-		cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
-		cfg.ConnectionAuth = testConnectionAuth("slack", handler)
+		cfg.DefaultConnection = map[string]string{providerName: testDefaultConnection}
+		cfg.ConnectionAuth = testConnectionAuth(providerName, handler)
 		cfg.Datastore = &coretesting.StubDatastore{
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
@@ -117,7 +118,7 @@ func TestCustomAuthMetrics(t *testing.T) {
 	startOAuth := func(code string) int {
 		t.Helper()
 
-		body := bytes.NewBufferString(`{"integration":"slack"}`)
+		body := bytes.NewBufferString(`{"integration":"` + providerName + `"}`)
 		startReq, _ := http.NewRequest(http.MethodPost, oauthServer.URL+"/api/v1/auth/start-oauth", body)
 		startReq.Header.Set("Content-Type", "application/json")
 		startResp, err := http.DefaultClient.Do(startReq)
@@ -156,11 +157,11 @@ func TestCustomAuthMetrics(t *testing.T) {
 
 	rm := collectMetrics(t, reader)
 	requireInt64Sum(t, rm, "gestaltd.oauth.callback.count", 1, map[string]string{
-		"gestalt.provider": "slack",
+		"gestalt.provider": providerName,
 		"gestalt.result":   "success",
 	})
 	requireInt64Sum(t, rm, "gestaltd.oauth.callback.count", 1, map[string]string{
-		"gestalt.provider": "slack",
+		"gestalt.provider": providerName,
 		"gestalt.result":   "error",
 	})
 }
@@ -169,11 +170,12 @@ func TestRefreshAndOperationResultMetrics(t *testing.T) {
 	t.Parallel()
 
 	reader := useManualMeterProvider(t)
+	const providerName = "metrics-fake"
 
 	successStub := &stubOAuthIntegration{
 		stubIntegrationWithOps: stubIntegrationWithOps{
 			StubIntegration: coretesting.StubIntegration{
-				N: "fake",
+				N: providerName,
 				ExecuteFn: func(_ context.Context, _ string, _ map[string]any, token string) (*core.OperationResult, error) {
 					return &core.OperationResult{Status: http.StatusOK, Body: `{"token":"` + token + `"}`}, nil
 				},
@@ -191,8 +193,8 @@ func TestRefreshAndOperationResultMetrics(t *testing.T) {
 	expiresSoon := time.Now().Add(2 * time.Minute)
 	successServer := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, successStub)
-		cfg.DefaultConnection = map[string]string{"fake": testDefaultConnection}
-		cfg.ConnectionAuth = oauthRefreshConnectionAuth("fake", successStub.refreshTokenFn)
+		cfg.DefaultConnection = map[string]string{providerName: testDefaultConnection}
+		cfg.ConnectionAuth = oauthRefreshConnectionAuth(providerName, successStub.refreshTokenFn)
 		cfg.Datastore = &coretesting.StubDatastore{
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
@@ -200,7 +202,7 @@ func TestRefreshAndOperationResultMetrics(t *testing.T) {
 			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 				return &core.IntegrationToken{
 					UserID:       "u1",
-					Integration:  "fake",
+					Integration:  providerName,
 					AccessToken:  "stale-access-token",
 					RefreshToken: "old-refresh-token",
 					ExpiresAt:    &expiresSoon,
@@ -210,7 +212,7 @@ func TestRefreshAndOperationResultMetrics(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, successServer)
 
-	successReq, _ := http.NewRequest(http.MethodGet, successServer.URL+"/api/v1/fake/list", nil)
+	successReq, _ := http.NewRequest(http.MethodGet, successServer.URL+"/api/v1/"+providerName+"/list", nil)
 	successResp, err := http.DefaultClient.Do(successReq)
 	if err != nil {
 		t.Fatalf("refresh success request: %v", err)
@@ -222,7 +224,7 @@ func TestRefreshAndOperationResultMetrics(t *testing.T) {
 
 	errorStub := &stubOAuthIntegration{
 		stubIntegrationWithOps: stubIntegrationWithOps{
-			StubIntegration: coretesting.StubIntegration{N: "fake"},
+			StubIntegration: coretesting.StubIntegration{N: providerName},
 			ops:             []core.Operation{{Name: "list", Description: "List", Method: http.MethodGet}},
 		},
 		refreshTokenFn: func(_ context.Context, refreshToken string) (*core.TokenResponse, error) {
@@ -236,8 +238,8 @@ func TestRefreshAndOperationResultMetrics(t *testing.T) {
 	alreadyExpired := time.Now().Add(-10 * time.Minute)
 	errorServer := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, errorStub)
-		cfg.DefaultConnection = map[string]string{"fake": testDefaultConnection}
-		cfg.ConnectionAuth = oauthRefreshConnectionAuth("fake", errorStub.refreshTokenFn)
+		cfg.DefaultConnection = map[string]string{providerName: testDefaultConnection}
+		cfg.ConnectionAuth = oauthRefreshConnectionAuth(providerName, errorStub.refreshTokenFn)
 		cfg.Datastore = &coretesting.StubDatastore{
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
@@ -245,7 +247,7 @@ func TestRefreshAndOperationResultMetrics(t *testing.T) {
 			TokenFn: func(_ context.Context, _, _, _, _ string) (*core.IntegrationToken, error) {
 				return &core.IntegrationToken{
 					UserID:       "u1",
-					Integration:  "fake",
+					Integration:  providerName,
 					AccessToken:  "expired-token",
 					RefreshToken: "expired-refresh-token",
 					ExpiresAt:    &alreadyExpired,
@@ -255,7 +257,7 @@ func TestRefreshAndOperationResultMetrics(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, errorServer)
 
-	errorReq, _ := http.NewRequest(http.MethodGet, errorServer.URL+"/api/v1/fake/list", nil)
+	errorReq, _ := http.NewRequest(http.MethodGet, errorServer.URL+"/api/v1/"+providerName+"/list", nil)
 	errorResp, err := http.DefaultClient.Do(errorReq)
 	if err != nil {
 		t.Fatalf("refresh error request: %v", err)
@@ -267,23 +269,23 @@ func TestRefreshAndOperationResultMetrics(t *testing.T) {
 
 	rm := collectMetrics(t, reader)
 	requireInt64Sum(t, rm, "gestaltd.oauth.token_refresh.count", 1, map[string]string{
-		"gestalt.provider":        "fake",
+		"gestalt.provider":        providerName,
 		"gestalt.connection_mode": "user",
 		"gestalt.result":          "success",
 	})
 	requireInt64Sum(t, rm, "gestaltd.oauth.token_refresh.count", 1, map[string]string{
-		"gestalt.provider":        "fake",
+		"gestalt.provider":        providerName,
 		"gestalt.connection_mode": "user",
 		"gestalt.result":          "error",
 	})
 	requireInt64Sum(t, rm, "gestaltd.operation.count", 2, map[string]string{
-		"gestalt.provider":        "fake",
+		"gestalt.provider":        providerName,
 		"gestalt.operation":       "list",
 		"gestalt.transport":       "rest",
 		"gestalt.connection_mode": "user",
 	})
 	requireInt64Sum(t, rm, "gestaltd.operation.error_count", 1, map[string]string{
-		"gestalt.provider":        "fake",
+		"gestalt.provider":        providerName,
 		"gestalt.operation":       "list",
 		"gestalt.transport":       "rest",
 		"gestalt.connection_mode": "user",

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -89,6 +89,57 @@ func (s *Server) securityHeadersMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+var errInvalidAuthorizationHeader = errors.New("invalid authorization header format")
+
+func requestBearerToken(r *http.Request) (string, error) {
+	header := r.Header.Get("Authorization")
+	if header == "" {
+		return "", nil
+	}
+	bearer := strings.TrimPrefix(header, core.BearerScheme)
+	if bearer == header {
+		return "", errInvalidAuthorizationHeader
+	}
+	return bearer, nil
+}
+
+func (s *Server) resolveRequestPrincipal(r *http.Request) (*principal.Principal, error) {
+	var lastErr error
+
+	if c, err := r.Cookie(sessionCookieName); err == nil && c.Value != "" {
+		p, err := s.resolver.ResolveToken(r.Context(), c.Value)
+		if p != nil {
+			return p, nil
+		}
+		lastErr = err
+	}
+
+	token, err := requestBearerToken(r)
+	if err != nil {
+		return nil, err
+	}
+	if token == "" {
+		return nil, lastErr
+	}
+
+	p, err := s.resolver.ResolveToken(r.Context(), token)
+	if p != nil {
+		return p, nil
+	}
+	if err != nil {
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+func (s *Server) resolveRequestPrincipalWithUserID(r *http.Request) (*principal.Principal, error) {
+	p, err := s.resolveRequestPrincipal(r)
+	if err != nil || p == nil {
+		return p, err
+	}
+	return s.resolvePrincipalUserID(r.Context(), p)
+}
+
 func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if s.noAuth {
@@ -97,40 +148,35 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		var p *principal.Principal
-		var lastErr error
-
-		if c, err := r.Cookie(sessionCookieName); err == nil && c.Value != "" {
-			p, lastErr = s.resolver.ResolveToken(r.Context(), c.Value)
-		}
-
-		if p == nil {
-			if header := r.Header.Get("Authorization"); header != "" {
-				bearer := strings.TrimPrefix(header, core.BearerScheme)
-				if bearer == header {
-					writeError(w, http.StatusUnauthorized, "invalid authorization header format")
-					return
-				}
-				p, lastErr = s.resolver.ResolveToken(r.Context(), bearer)
+		p, err := s.resolveRequestPrincipal(r)
+		if err == nil && p != nil {
+			enriched, enrichErr := s.resolvePrincipalUserID(r.Context(), p)
+			switch {
+			case enrichErr == nil && enriched != nil:
+				p = enriched
+			case enrichErr != nil:
+				slog.WarnContext(r.Context(), "auth: unable to resolve user ID", "error", enrichErr)
 			}
-		}
-
-		if p == nil {
-			if lastErr == nil {
-				writeError(w, http.StatusUnauthorized, "missing authorization")
-				return
-			}
-			if errors.Is(lastErr, principal.ErrInvalidToken) {
-				slog.InfoContext(r.Context(), "auth: invalid token", "remote_addr", r.RemoteAddr)
-				writeError(w, http.StatusUnauthorized, "invalid token")
-				return
-			}
-			slog.ErrorContext(r.Context(), "auth: token validation failed", "remote_addr", r.RemoteAddr, "error", lastErr)
-			writeError(w, http.StatusInternalServerError, "token validation failed")
+			ctx := principal.WithPrincipal(r.Context(), p)
+			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}
 
-		ctx := principal.WithPrincipal(r.Context(), p)
-		next.ServeHTTP(w, r.WithContext(ctx))
+		switch {
+		case err == nil:
+			writeError(w, http.StatusUnauthorized, "missing authorization")
+			return
+		case errors.Is(err, errInvalidAuthorizationHeader):
+			writeError(w, http.StatusUnauthorized, "invalid authorization header format")
+			return
+		case errors.Is(err, principal.ErrInvalidToken):
+			slog.InfoContext(r.Context(), "auth: invalid token", "remote_addr", r.RemoteAddr)
+			writeError(w, http.StatusUnauthorized, "invalid token")
+			return
+		default:
+			slog.ErrorContext(r.Context(), "auth: token validation failed", "remote_addr", r.RemoteAddr, "error", err)
+			writeError(w, http.StatusInternalServerError, "token validation failed")
+			return
+		}
 	})
 }

--- a/gestaltd/internal/server/oauth_state.go
+++ b/gestaltd/internal/server/oauth_state.go
@@ -18,6 +18,7 @@ var errPendingConnectionExpired = errors.New("pending connection expired")
 
 type integrationOAuthState struct {
 	UserID           string            `json:"uid"`
+	AuthSource       string            `json:"src,omitempty"`
 	Integration      string            `json:"int"`
 	Connection       string            `json:"con,omitempty"`
 	Instance         string            `json:"ins,omitempty"`

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -6,7 +6,6 @@ import (
 	"html/template"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -242,39 +241,20 @@ func (s *Server) resolvePendingConnectionUserID(r *http.Request) (string, bool, 
 	if s.noAuth {
 		return "", false, nil
 	}
-
-	var token string
-	if c, err := r.Cookie(sessionCookieName); err == nil && c.Value != "" {
-		token = c.Value
-	} else if header := r.Header.Get("Authorization"); header != "" {
-		bearer := strings.TrimPrefix(header, core.BearerScheme)
-		if bearer == header {
+	p, err := s.resolveRequestPrincipalWithUserID(r)
+	if err != nil {
+		if errors.Is(err, errInvalidAuthorizationHeader) {
 			return "", true, principal.ErrInvalidToken
 		}
-		token = bearer
+		return "", true, err
 	}
-	if token == "" {
+	if p == nil {
 		return "", false, nil
 	}
-
-	p, err := s.resolver.ResolveToken(r.Context(), token)
-	if err != nil {
-		return "", true, err
-	}
-	if p.UserID != "" {
-		return p.UserID, true, nil
-	}
-	if p.Identity == nil || p.Identity.Email == "" {
-		return "", true, fmt.Errorf("authenticated principal missing email")
-	}
-	dbUser, err := s.datastore.FindOrCreateUser(r.Context(), p.Identity.Email)
-	if err != nil {
-		return "", true, err
-	}
-	if dbUser == nil || dbUser.ID == "" {
+	if p.UserID == "" {
 		return "", true, fmt.Errorf("authenticated principal missing user ID")
 	}
-	return dbUser.ID, true, nil
+	return p.UserID, true, nil
 }
 
 func (s *Server) authorizePendingConnectionByCookie(r *http.Request, state *pendingConnectionState) error {
@@ -322,12 +302,27 @@ func (s *Server) authorizePendingConnection(w http.ResponseWriter, r *http.Reque
 }
 
 func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("pending connection selection failed")
+	auditUserID := ""
+	auditAuthSource := ""
+	providerName := ""
+	defer func() {
+		if auditUserID != "" {
+			s.auditHTTPEventWithUserID(r.Context(), auditUserID, auditAuthSource, providerName, "connection.pending.select", auditAllowed, auditErr)
+			return
+		}
+		s.auditHTTPEvent(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.pending.select", auditAllowed, auditErr)
+	}()
+
 	if err := r.ParseForm(); err != nil {
+		auditErr = errors.New("invalid form body")
 		writeError(w, http.StatusBadRequest, "invalid form body")
 		return
 	}
 	pendingToken := r.Form.Get("pending_token")
 	if pendingToken == "" {
+		auditErr = errors.New("pending_token is required")
 		writeError(w, http.StatusBadRequest, "pending_token is required")
 		return
 	}
@@ -341,13 +336,20 @@ func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request)
 			status = http.StatusGone
 			s.clearPendingConnectionCookie(w)
 		}
+		auditErr = errors.New("invalid or expired pending connection")
 		writeError(w, status, "invalid or expired pending connection")
 		return
 	}
+	providerName = state.Token.Integration
 	if !s.authorizePendingConnection(w, r, state) {
+		auditErr = errors.New("pending connection authorization required")
 		return
 	}
+	auditUserID = state.Token.UserID
+	auditAuthSource = state.Token.AuthSource
 	if candidateIndex == "" && candidateID == "" {
+		auditAllowed = true
+		auditErr = nil
 		s.writePendingConnectionSelectionPage(w, state, pendingToken)
 		return
 	}
@@ -356,26 +358,31 @@ func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request)
 	if candidateIndex != "" {
 		selected, err = findDiscoveryCandidateByIndex(state.Candidates, candidateIndex)
 		if err != nil {
+			auditErr = errors.New(err.Error())
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
 		}
 	} else {
 		selected = findDiscoveryCandidate(state.Candidates, candidateID)
 		if selected == nil {
+			auditErr = errors.New("candidate not found")
 			writeError(w, http.StatusBadRequest, "candidate not found")
 			return
 		}
 	}
 	if selected == nil {
+		auditErr = errors.New("candidate not found")
 		writeError(w, http.StatusBadRequest, "candidate not found")
 		return
 	}
 	if err := validateDiscoveryMetadata(selected.Metadata); err != nil {
+		auditErr = errors.New(err.Error())
 		writeError(w, http.StatusBadGateway, err.Error())
 		return
 	}
 	merged, err := mergeMetadataJSON(state.Token.MetadataJSON, selected.Metadata)
 	if err != nil {
+		auditErr = errors.New("failed to merge metadata")
 		writeError(w, http.StatusInternalServerError, "failed to merge metadata")
 		return
 	}
@@ -383,6 +390,7 @@ func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request)
 	tm := state.Token
 	tm.MetadataJSON = merged
 	if _, err := s.storeTokenFromMaterial(r.Context(), tm); err != nil {
+		auditErr = errors.New("failed to store connection")
 		writeError(w, http.StatusInternalServerError, "failed to store connection")
 		return
 	}
@@ -393,9 +401,13 @@ func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request)
 		if nextURL, err := setURLQueryParam(connectedURL, "connected", state.Token.Integration); err == nil {
 			connectedURL = nextURL
 		}
+		auditAllowed = true
+		auditErr = nil
 		http.Redirect(w, r, connectedURL, http.StatusSeeOther)
 		return
 	}
 
+	auditAllowed = true
+	auditErr = nil
 	s.writePendingConnectionSuccessPage(w, state.Token.Integration)
 }

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -25,6 +25,7 @@ type Server struct {
 	router             chi.Router
 	handler            http.Handler
 	auth               core.AuthProvider
+	auditSink          core.AuditSink
 	datastore          core.Datastore
 	providers          *registry.PluginMap[core.Provider]
 	resolver           *principal.Resolver
@@ -49,6 +50,7 @@ type Server struct {
 
 type Config struct {
 	Auth              core.AuthProvider
+	AuditSink         core.AuditSink
 	Datastore         core.Datastore
 	Providers         *registry.PluginMap[core.Provider]
 	Invoker           invocation.Invoker
@@ -71,7 +73,7 @@ func New(cfg Config) (*Server, error) {
 	if cfg.Invoker == nil {
 		return nil, fmt.Errorf("invoker is required")
 	}
-	noAuth := cfg.Auth.Name() == "none"
+	noAuth := cfg.Auth == nil || cfg.Auth.Name() == "none"
 	var stateCodec *integrationOAuthStateCodec
 	var encryptor *cryptoutil.AESGCMEncryptor
 	if len(cfg.StateSecret) > 0 {
@@ -100,6 +102,7 @@ func New(cfg Config) (*Server, error) {
 		router:            router,
 		handler:           otelhttp.NewHandler(router, "gestaltd"),
 		auth:              cfg.Auth,
+		auditSink:         cfg.AuditSink,
 		datastore:         cfg.Datastore,
 		providers:         cfg.Providers,
 		resolver:          resolver,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -628,6 +628,47 @@ func TestMetricsEndpointsRequireAuth(t *testing.T) {
 	}
 }
 
+func TestMetricsSessionAuthDoesNotRequireUserLookup(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, fmt.Errorf("invalid token")
+				}
+				return &core.UserIdentity{Email: "metrics@example.test"}, nil
+			},
+		}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, _ string) (*core.User, error) {
+				return nil, fmt.Errorf("datastore unavailable")
+			},
+		}
+		cfg.PrometheusMetrics = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+			_, _ = w.Write([]byte("gestaltd_operation_count_total 1\n"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/metrics", nil)
+	req.Header.Set("Authorization", "Bearer session-token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("authenticated GET /metrics with session token: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for session-authenticated /metrics, got %d: %s", resp.StatusCode, body)
+	}
+	if !bytes.Contains(body, []byte("gestaltd_operation_count_total")) {
+		t.Fatalf("expected prometheus metric in body, got %s", body)
+	}
+}
+
 func TestListIntegrations(t *testing.T) {
 	t.Parallel()
 
@@ -2056,9 +2097,47 @@ func TestStartLoginWithInvalidCallbackPort(t *testing.T) {
 	}
 }
 
+func TestStartLogin_NoAuthInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	var auditBuf bytes.Buffer
+	auditSink := invocation.NewSlogAuditSink(&auditBuf)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = nil
+		cfg.AuditSink = auditSink
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Post(ts.URL+"/api/v1/auth/login", "application/json", strings.NewReader("{"))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+
+	var auditRecord map[string]any
+	if err := json.Unmarshal(auditBuf.Bytes(), &auditRecord); err != nil {
+		t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["operation"] != "auth.login.start" {
+		t.Fatalf("expected audit operation auth.login.start, got %v", auditRecord["operation"])
+	}
+	if auditRecord["provider"] != "none" {
+		t.Fatalf("expected audit provider none, got %v", auditRecord["provider"])
+	}
+	if auditRecord["allowed"] != false {
+		t.Fatalf("expected audit allowed=false, got %v", auditRecord["allowed"])
+	}
+}
+
 func TestLoginCallback(t *testing.T) {
 	t.Parallel()
 
+	var auditBuf bytes.Buffer
+	auditSink := invocation.NewSlogAuditSink(&auditBuf)
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &stubAuthWithToken{
 			StubAuthProvider: coretesting.StubAuthProvider{
@@ -2071,6 +2150,12 @@ func TestLoginCallback(t *testing.T) {
 				},
 			},
 		}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+		cfg.AuditSink = auditSink
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -2100,6 +2185,24 @@ func TestLoginCallback(t *testing.T) {
 	}
 	if result["email"] != "user@example.com" {
 		t.Fatalf("unexpected email: %v", result["email"])
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+	if len(lines) == 0 {
+		t.Fatal("expected login audit record")
+	}
+	var auditRecord map[string]any
+	if err := json.Unmarshal(lines[len(lines)-1], &auditRecord); err != nil {
+		t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["operation"] != "auth.login.complete" {
+		t.Fatalf("expected audit operation auth.login.complete, got %v", auditRecord["operation"])
+	}
+	if auditRecord["auth_source"] != "session" {
+		t.Fatalf("expected audit auth_source session, got %v", auditRecord["auth_source"])
+	}
+	if auditRecord["user_id"] != "u1" {
+		t.Fatalf("expected audit user_id u1, got %v", auditRecord["user_id"])
 	}
 }
 
@@ -2229,6 +2332,42 @@ func TestLoginCallbackMissingStateCookie(t *testing.T) {
 
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestLoginCallback_NoAuthMissingCode(t *testing.T) {
+	t.Parallel()
+
+	var auditBuf bytes.Buffer
+	auditSink := invocation.NewSlogAuditSink(&auditBuf)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = nil
+		cfg.AuditSink = auditSink
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/api/v1/auth/login/callback?state=anything")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+
+	var auditRecord map[string]any
+	if err := json.Unmarshal(auditBuf.Bytes(), &auditRecord); err != nil {
+		t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["operation"] != "auth.login.complete" {
+		t.Fatalf("expected audit operation auth.login.complete, got %v", auditRecord["operation"])
+	}
+	if auditRecord["provider"] != "none" {
+		t.Fatalf("expected audit provider none, got %v", auditRecord["provider"])
+	}
+	if auditRecord["allowed"] != false {
+		t.Fatalf("expected audit allowed=false, got %v", auditRecord["allowed"])
 	}
 }
 
@@ -2380,6 +2519,7 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		t.Parallel()
 
 		var stored *core.IntegrationToken
+		var auditBuf bytes.Buffer
 
 		handler := &testOAuthHandler{
 			authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
@@ -2397,6 +2537,15 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		}
 
 		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					if token != "session-token" {
+						return nil, fmt.Errorf("bad token")
+					}
+					return &core.UserIdentity{Email: "user@example.com"}, nil
+				},
+			}
 			cfg.Providers = testutil.NewProviderRegistry(t, stub)
 			cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
 			cfg.ConnectionAuth = testConnectionAuth("slack", handler)
@@ -2409,12 +2558,14 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 					return nil
 				},
 			}
+			cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
 		})
 		testutil.CloseOnCleanup(t, ts)
 
 		startBody := bytes.NewBufferString(`{"integration":"slack"}`)
 		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
 		startReq.Header.Set("Content-Type", "application/json")
+		startReq.Header.Set("Authorization", "Bearer session-token")
 		startResp, err := http.DefaultClient.Do(startReq)
 		if err != nil {
 			t.Fatalf("start request: %v", err)
@@ -2460,6 +2611,24 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		}
 		if stored.AccessToken != "slack-token" {
 			t.Fatalf("stored access token = %q, want %q", stored.AccessToken, "slack-token")
+		}
+
+		lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+		if len(lines) == 0 {
+			t.Fatal("expected oauth callback audit record")
+		}
+		var auditRecord map[string]any
+		if err := json.Unmarshal(lines[len(lines)-1], &auditRecord); err != nil {
+			t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+		}
+		if auditRecord["operation"] != "connection.oauth.complete" {
+			t.Fatalf("expected audit operation connection.oauth.complete, got %v", auditRecord["operation"])
+		}
+		if auditRecord["auth_source"] != "session" {
+			t.Fatalf("expected audit auth_source session, got %v", auditRecord["auth_source"])
+		}
+		if auditRecord["user_id"] != "u1" {
+			t.Fatalf("expected audit user_id u1, got %v", auditRecord["user_id"])
 		}
 	})
 
@@ -2759,8 +2928,20 @@ func TestCreateAPIToken_DefaultExpiry(t *testing.T) {
 	t.Parallel()
 
 	fixedNow := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	var auditBuf bytes.Buffer
+	auditSink := invocation.NewSlogAuditSink(&auditBuf)
 	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "user@example.com"}, nil
+			},
+		}
 		cfg.Now = func() time.Time { return fixedNow }
+		cfg.AuditSink = auditSink
 		cfg.Datastore = &coretesting.StubDatastore{
 			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 				return &core.User{ID: "u1", Email: email}, nil
@@ -2772,6 +2953,7 @@ func TestCreateAPIToken_DefaultExpiry(t *testing.T) {
 	body := bytes.NewBufferString(`{"name":"expiry-test"}`)
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/tokens", body)
 	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -2802,6 +2984,83 @@ func TestCreateAPIToken_DefaultExpiry(t *testing.T) {
 	expected := fixedNow.Add(30 * 24 * time.Hour).UTC().Truncate(time.Second)
 	if !expiresAt.Equal(expected) {
 		t.Fatalf("expected expires_at %v, got %v", expected, expiresAt)
+	}
+
+	var auditRecord map[string]any
+	if err := json.Unmarshal(auditBuf.Bytes(), &auditRecord); err != nil {
+		t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["operation"] != "api_token.create" {
+		t.Fatalf("expected audit operation api_token.create, got %v", auditRecord["operation"])
+	}
+	if auditRecord["source"] != "http" {
+		t.Fatalf("expected audit source http, got %v", auditRecord["source"])
+	}
+	if auditRecord["auth_source"] != "session" {
+		t.Fatalf("expected audit auth_source session, got %v", auditRecord["auth_source"])
+	}
+	if auditRecord["user_id"] != "u1" {
+		t.Fatalf("expected audit user_id u1, got %v", auditRecord["user_id"])
+	}
+	if auditRecord["allowed"] != true {
+		t.Fatalf("expected audit allowed=true, got %v", auditRecord["allowed"])
+	}
+}
+
+func TestCreateAPIToken_AuditResolveUserFailure(t *testing.T) {
+	t.Parallel()
+
+	var auditBuf bytes.Buffer
+	auditSink := invocation.NewSlogAuditSink(&auditBuf)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "user@example.com"}, nil
+			},
+		}
+		cfg.AuditSink = auditSink
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, _ string) (*core.User, error) {
+				return nil, fmt.Errorf("datastore unavailable")
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"name":"failure-test"}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/tokens", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 500, got %d: %s", resp.StatusCode, respBody)
+	}
+
+	var auditRecord map[string]any
+	if err := json.Unmarshal(auditBuf.Bytes(), &auditRecord); err != nil {
+		t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["operation"] != "api_token.create" {
+		t.Fatalf("expected audit operation api_token.create, got %v", auditRecord["operation"])
+	}
+	if auditRecord["auth_source"] != "session" {
+		t.Fatalf("expected audit auth_source session, got %v", auditRecord["auth_source"])
+	}
+	if auditRecord["allowed"] != false {
+		t.Fatalf("expected audit allowed=false, got %v", auditRecord["allowed"])
+	}
+	if auditRecord["error"] != "failed to resolve user" {
+		t.Fatalf("expected audit error failed to resolve user, got %v", auditRecord["error"])
 	}
 }
 
@@ -3042,6 +3301,36 @@ func TestAuthInfoFallback(t *testing.T) {
 	}
 	if body["display_name"] != "custom" {
 		t.Fatalf("expected display_name to fall back to name custom, got %q", body["display_name"])
+	}
+}
+
+func TestAuthInfoNoAuth(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = nil
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/api/v1/auth/info")
+	if err != nil {
+		t.Fatalf("GET /api/v1/auth/info: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if body["provider"] != "none" {
+		t.Fatalf("expected provider none, got %q", body["provider"])
+	}
+	if body["display_name"] != "none" {
+		t.Fatalf("expected display_name none, got %q", body["display_name"])
 	}
 }
 
@@ -4253,6 +4542,8 @@ func TestConnectManual(t *testing.T) {
 		}))
 		testutil.CloseOnCleanup(t, discoverySrv)
 
+		var auditBuf bytes.Buffer
+		auditSink := invocation.NewSlogAuditSink(&auditBuf)
 		var stored *core.IntegrationToken
 		ts := newTestServer(t, func(cfg *server.Config) {
 			cfg.Auth = &coretesting.StubAuthProvider{
@@ -4296,6 +4587,7 @@ func TestConnectManual(t *testing.T) {
 					return nil
 				},
 			}
+			cfg.AuditSink = auditSink
 		})
 		testutil.CloseOnCleanup(t, ts)
 
@@ -4385,6 +4677,23 @@ func TestConnectManual(t *testing.T) {
 		if noAuthResp.StatusCode != http.StatusUnauthorized {
 			t.Fatalf("expected 401 without auth, got %d", noAuthResp.StatusCode)
 		}
+		lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+		if len(lines) == 0 {
+			t.Fatal("expected pending connection audit record")
+		}
+		var noAuthAudit map[string]any
+		if err := json.Unmarshal(lines[len(lines)-1], &noAuthAudit); err != nil {
+			t.Fatalf("parsing pending connection audit record: %v\nraw: %s", err, auditBuf.String())
+		}
+		if noAuthAudit["operation"] != "connection.pending.select" {
+			t.Fatalf("expected pending connection audit operation, got %v", noAuthAudit["operation"])
+		}
+		if noAuthAudit["allowed"] != false {
+			t.Fatalf("expected denied pending connection audit, got %v", noAuthAudit["allowed"])
+		}
+		if userID, ok := noAuthAudit["user_id"]; ok && userID != "" {
+			t.Fatalf("expected unauthenticated denied selection to omit user_id, got %v", userID)
+		}
 
 		mismatchForm := url.Values{
 			"pending_token":   {connectResult.PendingToken},
@@ -4401,6 +4710,23 @@ func TestConnectManual(t *testing.T) {
 
 		if mismatchResp.StatusCode != http.StatusNotFound {
 			t.Fatalf("expected 404 for mismatched user, got %d", mismatchResp.StatusCode)
+		}
+		lines = bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+		if len(lines) == 0 {
+			t.Fatal("expected pending connection audit record")
+		}
+		var mismatchAudit map[string]any
+		if err := json.Unmarshal(lines[len(lines)-1], &mismatchAudit); err != nil {
+			t.Fatalf("parsing mismatched pending connection audit record: %v\nraw: %s", err, auditBuf.String())
+		}
+		if mismatchAudit["operation"] != "connection.pending.select" {
+			t.Fatalf("expected pending connection audit operation, got %v", mismatchAudit["operation"])
+		}
+		if mismatchAudit["allowed"] != false {
+			t.Fatalf("expected denied pending connection audit, got %v", mismatchAudit["allowed"])
+		}
+		if mismatchAudit["user_id"] == "u1" {
+			t.Fatalf("expected denied selection not to be attributed to token owner, got %v", mismatchAudit["user_id"])
 		}
 		if stored != nil {
 			t.Fatal("did not expect token to be stored for mismatched user")
@@ -4823,12 +5149,14 @@ func TestRefresh_UsesConnectionAuth(t *testing.T) {
 	}
 }
 
-func newMCPHandler(t *testing.T, providers *registry.PluginMap[core.Provider], ds core.Datastore) http.Handler {
+func newMCPHandler(t *testing.T, providers *registry.PluginMap[core.Provider], ds core.Datastore, auditSink core.AuditSink) http.Handler {
 	t.Helper()
 	broker := invocation.NewBroker(providers, ds)
+	mcpInvoker := invocation.NewGuarded(broker, broker, "mcp", auditSink, invocation.WithoutRateLimit())
 	srv := gestaltmcp.NewServer(gestaltmcp.Config{
-		Invoker:       broker,
+		Invoker:       mcpInvoker,
 		TokenResolver: broker,
+		AuditSink:     auditSink,
 		Providers:     providers,
 	})
 	return mcpserver.NewStreamableHTTPServer(srv, mcpserver.WithStateLess(true))
@@ -4872,7 +5200,7 @@ func TestMCPEndpoint_InitializeAndListTools(t *testing.T) {
 		},
 	}
 	providers := testutil.NewProviderRegistry(t, stub)
-	mcpHandler := newMCPHandler(t, providers, ds)
+	mcpHandler := newMCPHandler(t, providers, ds, nil)
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = providers
@@ -4932,7 +5260,7 @@ func TestMCPEndpoint_RequiresAuth(t *testing.T) {
 		return &reg.Providers
 	}()
 	ds := &coretesting.StubDatastore{}
-	mcpHandler := newMCPHandler(t, providers, ds)
+	mcpHandler := newMCPHandler(t, providers, ds, nil)
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
@@ -4978,14 +5306,21 @@ func TestMCPEndpoint_DirectPassthrough(t *testing.T) {
 	}
 
 	var calledName string
+	var calledRequestID string
+	var auditBuf bytes.Buffer
+	auditSink := invocation.NewSlogAuditSink(&auditBuf)
 	prov := &stubIntegrationWithSessionCatalog{
 		stubIntegrationWithOps: stubIntegrationWithOps{
 			StubIntegration: coretesting.StubIntegration{N: "clickhouse", ConnMode: core.ConnectionModeNone},
 			ops:             []core.Operation{{Name: "run_query", Description: "Execute a SQL query"}},
 		},
 		catalog: cat,
-		callFn: func(_ context.Context, name string, _ map[string]any) (*mcpgo.CallToolResult, error) {
+		callFn: func(ctx context.Context, name string, _ map[string]any) (*mcpgo.CallToolResult, error) {
 			calledName = name
+			meta := invocation.MetaFromContext(ctx)
+			if meta != nil {
+				calledRequestID = meta.RequestID
+			}
 			return mcpgo.NewToolResultText("query executed"), nil
 		},
 	}
@@ -4996,16 +5331,27 @@ func TestMCPEndpoint_DirectPassthrough(t *testing.T) {
 		},
 	}
 	providers := testutil.NewProviderRegistry(t, prov)
-	mcpHandler := newMCPHandler(t, providers, ds)
+	mcpHandler := newMCPHandler(t, providers, ds, auditSink)
 
 	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "user@example.com"}, nil
+			},
+		}
 		cfg.Providers = providers
 		cfg.Datastore = ds
 		cfg.MCPHandler = mcpHandler
 	})
 	defer ts.Close()
 
-	mcpJSONRPC(t, ts, nil, map[string]any{
+	headers := map[string]string{"Authorization": "Bearer session-token"}
+
+	mcpJSONRPC(t, ts, headers, map[string]any{
 		"jsonrpc": "2.0",
 		"id":      1,
 		"method":  "initialize",
@@ -5016,7 +5362,7 @@ func TestMCPEndpoint_DirectPassthrough(t *testing.T) {
 		},
 	})
 
-	status, resp := mcpJSONRPC(t, ts, nil, map[string]any{
+	status, resp := mcpJSONRPC(t, ts, headers, map[string]any{
 		"jsonrpc": "2.0",
 		"id":      2,
 		"method":  "tools/list",
@@ -5037,7 +5383,7 @@ func TestMCPEndpoint_DirectPassthrough(t *testing.T) {
 		t.Fatalf("expected clickhouse_run_query, got %v", firstTool["name"])
 	}
 
-	status, resp = mcpJSONRPC(t, ts, nil, map[string]any{
+	status, resp = mcpJSONRPC(t, ts, headers, map[string]any{
 		"jsonrpc": "2.0",
 		"id":      3,
 		"method":  "tools/call",
@@ -5056,6 +5402,9 @@ func TestMCPEndpoint_DirectPassthrough(t *testing.T) {
 	if calledName != "run_query" {
 		t.Fatalf("expected direct CallTool with run_query, got %q", calledName)
 	}
+	if calledRequestID == "" {
+		t.Fatal("expected direct CallTool context to include request ID")
+	}
 	content, ok := result["content"].([]any)
 	if !ok || len(content) == 0 {
 		t.Fatalf("expected content in result, got %v", result)
@@ -5063,6 +5412,74 @@ func TestMCPEndpoint_DirectPassthrough(t *testing.T) {
 	textBlock := content[0].(map[string]any)
 	if textBlock["text"] != "query executed" {
 		t.Fatalf("expected passthrough result, got %v", textBlock)
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+	if len(lines) == 0 {
+		t.Fatal("expected MCP audit record")
+	}
+	var auditRecord map[string]any
+	if err := json.Unmarshal(lines[len(lines)-1], &auditRecord); err != nil {
+		t.Fatalf("parsing MCP audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["source"] != "mcp" {
+		t.Fatalf("expected audit source mcp, got %v", auditRecord["source"])
+	}
+	if auditRecord["provider"] != "clickhouse" {
+		t.Fatalf("expected audit provider clickhouse, got %v", auditRecord["provider"])
+	}
+	if auditRecord["operation"] != "run_query" {
+		t.Fatalf("expected audit operation run_query, got %v", auditRecord["operation"])
+	}
+	if auditRecord["request_id"] != calledRequestID {
+		t.Fatalf("expected audit request_id %q, got %v", calledRequestID, auditRecord["request_id"])
+	}
+	if auditRecord["auth_source"] != "session" {
+		t.Fatalf("expected audit auth_source session, got %v", auditRecord["auth_source"])
+	}
+	if auditRecord["user_id"] != "u1" {
+		t.Fatalf("expected audit user_id u1, got %v", auditRecord["user_id"])
+	}
+	if auditRecord["allowed"] != true {
+		t.Fatalf("expected audit allowed=true, got %v", auditRecord["allowed"])
+	}
+
+	prov.callFn = func(_ context.Context, _ string, _ map[string]any) (*mcpgo.CallToolResult, error) {
+		return mcpgo.NewToolResultError("query failed"), nil
+	}
+
+	status, resp = mcpJSONRPC(t, ts, headers, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      4,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "clickhouse_run_query",
+			"arguments": map[string]any{"sql": "SELECT broken"},
+		},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("tools/call error result: expected 200, got %d", status)
+	}
+	result, ok = resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("tools/call error result: expected result, got %v", resp)
+	}
+	if result["isError"] != true {
+		t.Fatalf("expected MCP direct error result, got %v", result["isError"])
+	}
+
+	lines = bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+	if len(lines) == 0 {
+		t.Fatal("expected MCP audit record")
+	}
+	if err := json.Unmarshal(lines[len(lines)-1], &auditRecord); err != nil {
+		t.Fatalf("parsing MCP error audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["allowed"] != false {
+		t.Fatalf("expected audit allowed=false for MCP error result, got %v", auditRecord["allowed"])
+	}
+	if auditRecord["error"] != "query failed" {
+		t.Fatalf("expected audit error query failed, got %v", auditRecord["error"])
 	}
 }
 
@@ -5476,10 +5893,14 @@ func TestCookieAuth(t *testing.T) {
 	stub := &coretesting.StubAuthProvider{
 		N: "test",
 		ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
-			if token == "valid-cookie-token" {
+			switch token {
+			case "valid-cookie-token":
 				return &core.UserIdentity{Email: "cookie@test.local"}, nil
+			case "valid-header-token":
+				return &core.UserIdentity{Email: "header@test.local"}, nil
+			default:
+				return nil, fmt.Errorf("invalid token")
 			}
-			return nil, fmt.Errorf("invalid token")
 		},
 	}
 
@@ -5511,15 +5932,48 @@ func TestCookieAuth(t *testing.T) {
 	if resp.StatusCode == http.StatusUnauthorized {
 		t.Fatal("cookie auth should have passed middleware, got 401")
 	}
+
+	// An invalid cookie should still fall back to a valid Authorization header.
+	reqWithFallback, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	reqWithFallback.AddCookie(&http.Cookie{Name: "session_token", Value: "invalid-cookie-token"})
+	reqWithFallback.Header.Set("Authorization", "Bearer valid-header-token")
+	fallbackResp, err := http.DefaultClient.Do(reqWithFallback)
+	if err != nil {
+		t.Fatalf("request with header fallback: %v", err)
+	}
+	defer func() { _ = fallbackResp.Body.Close() }()
+
+	if fallbackResp.StatusCode == http.StatusUnauthorized {
+		t.Fatal("valid Authorization header should have passed middleware after invalid cookie")
+	}
 }
 
 func TestLogout(t *testing.T) {
 	t.Parallel()
 
-	ts := newTestServer(t, func(cfg *server.Config) {})
+	var auditBuf bytes.Buffer
+	auditSink := invocation.NewSlogAuditSink(&auditBuf)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "user@example.com"}, nil
+			},
+		}
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: email}, nil
+			},
+		}
+		cfg.AuditSink = auditSink
+	})
 	testutil.CloseOnCleanup(t, ts)
 
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -5541,6 +5995,63 @@ func TestLogout(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("expected session_token cookie to be cleared")
+	}
+
+	var auditRecord map[string]any
+	if err := json.Unmarshal(auditBuf.Bytes(), &auditRecord); err != nil {
+		t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["operation"] != "auth.logout" {
+		t.Fatalf("expected audit operation auth.logout, got %v", auditRecord["operation"])
+	}
+	if auditRecord["source"] != "http" {
+		t.Fatalf("expected audit source http, got %v", auditRecord["source"])
+	}
+	if auditRecord["auth_source"] != "session" {
+		t.Fatalf("expected audit auth_source session, got %v", auditRecord["auth_source"])
+	}
+	if auditRecord["user_id"] != "u1" {
+		t.Fatalf("expected audit user_id u1, got %v", auditRecord["user_id"])
+	}
+	if auditRecord["allowed"] != true {
+		t.Fatalf("expected audit allowed=true, got %v", auditRecord["allowed"])
+	}
+}
+
+func TestLogout_NoAuthNilProvider(t *testing.T) {
+	t.Parallel()
+
+	var auditBuf bytes.Buffer
+	auditSink := invocation.NewSlogAuditSink(&auditBuf)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = nil
+		cfg.AuditSink = auditSink
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/logout", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var auditRecord map[string]any
+	if err := json.Unmarshal(auditBuf.Bytes(), &auditRecord); err != nil {
+		t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["operation"] != "auth.logout" {
+		t.Fatalf("expected audit operation auth.logout, got %v", auditRecord["operation"])
+	}
+	if auditRecord["provider"] != "none" {
+		t.Fatalf("expected audit provider none, got %v", auditRecord["provider"])
+	}
+	if auditRecord["allowed"] != true {
+		t.Fatalf("expected audit allowed=true, got %v", auditRecord["allowed"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `auth_source` to audit entries and resolve session-backed user IDs before HTTP invocation audit logging
- audit MCP invocations under `source=mcp`, including direct MCP passthrough tools, and add explicit HTTP audit events for login/logout, connection flows, pending connection selection, and API token CRUD
- document audit logging support with a dedicated reference page and updated observability/config docs

## Testing
- `go test ./internal/invocation/...`
- `go test ./internal/mcp/...`
- `go test ./internal/server/...`
- `go test ./...` *(fails in this environment because the MongoDB driver transitively expects missing `github.com/klauspost/compress/...` module packages during setup)*