### PR TITLE
Remove Go main-package release fallback

### DIFF
--- a/docs/pages/plugins/packaging-and-releasing.mdx
+++ b/docs/pages/plugins/packaging-and-releasing.mdx
@@ -20,6 +20,8 @@ provider:
         type: none
 ```
 
+For Go source plugins, the executable code lives under `provider/`. You do not write `main.go`; Gestalt synthesizes the wrapper during source execution and release packaging.
+
 ### Declarative-only release archives
 
 A manifest can describe a declarative provider that requires no compiled binary. This is useful for distributing reusable REST providers, OpenAPI-backed integrations, or web UI bundles:

--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
@@ -44,11 +43,6 @@ const windowsExecutableSuffix = ".exe"
 type releasePlatform struct {
 	GOOS   string
 	GOARCH string
-}
-
-type releaseBuild struct {
-	platform releasePlatform
-	target   string
 }
 
 func runPluginRelease(args []string) error {
@@ -110,7 +104,7 @@ func runPluginRelease(args []string) error {
 		for _, build := range builds {
 			archivePath, err := buildPlatformArchive(srcManifest, pluginName, *version, build, *outputDir, manifestFile, manifestFormat)
 			if err != nil {
-				return fmt.Errorf("build %s/%s: %w", build.platform.GOOS, build.platform.GOARCH, err)
+				return fmt.Errorf("build %s/%s: %w", build.GOOS, build.GOARCH, err)
 			}
 			archivePaths = append(archivePaths, archivePath)
 		}
@@ -129,8 +123,8 @@ func runPluginRelease(args []string) error {
 	return nil
 }
 
-func detectReleaseBuilds(root string, manifest *pluginmanifestv1.Manifest, platforms []releasePlatform) ([]releaseBuild, error) {
-	builds := make([]releaseBuild, 0, len(platforms))
+func detectReleaseBuilds(root string, manifest *pluginmanifestv1.Manifest, platforms []releasePlatform) ([]releasePlatform, error) {
+	builds := make([]releasePlatform, 0, len(platforms))
 	hasProviderKind := manifestHasKind(manifest, pluginmanifestv1.KindProvider)
 	providerBuildRequired := releaseRequiresBuildTarget(manifest)
 	var missingErr error
@@ -140,7 +134,7 @@ func detectReleaseBuilds(root string, manifest *pluginmanifestv1.Manifest, platf
 			_, err := pluginpkg.DetectGoProviderImportPath(root, plat.GOOS, plat.GOARCH)
 			switch {
 			case err == nil:
-				builds = append(builds, releaseBuild{platform: plat})
+				builds = append(builds, plat)
 				continue
 			case errors.Is(err, pluginpkg.ErrNoGoProviderPackage):
 				if providerBuildRequired && missingErr == nil {
@@ -149,16 +143,6 @@ func detectReleaseBuilds(root string, manifest *pluginmanifestv1.Manifest, platf
 			default:
 				return nil, fmt.Errorf("detect Go provider package for %s/%s: %w", plat.GOOS, plat.GOARCH, err)
 			}
-		}
-
-		target, err := pluginpkg.DetectGoMainBuildTarget(root, plat.GOOS, plat.GOARCH)
-		switch {
-		case err == nil:
-			builds = append(builds, releaseBuild{platform: plat, target: target})
-		case errors.Is(err, pluginpkg.ErrNoGoMainPackage):
-			continue
-		default:
-			return nil, fmt.Errorf("detect Go main package for %s/%s: %w", plat.GOOS, plat.GOARCH, err)
 		}
 	}
 
@@ -174,11 +158,10 @@ func detectReleaseBuilds(root string, manifest *pluginmanifestv1.Manifest, platf
 	return builds, nil
 }
 
-func buildPlatformArchive(srcManifest *pluginmanifestv1.Manifest, pluginName, version string, build releaseBuild, outputDir, manifestFile, manifestFormat string) (string, error) {
-	plat := build.platform
+func buildPlatformArchive(srcManifest *pluginmanifestv1.Manifest, pluginName, version string, plat releasePlatform, outputDir, manifestFile, manifestFormat string) (string, error) {
 	archiveName := fmt.Sprintf("gestalt-plugin-%s_v%s_%s_%s.tar.gz", pluginName, version, plat.GOOS, plat.GOARCH)
 	return createReleaseArchive(outputDir, archiveName, manifestFile, manifestFormat, func(stagingDir string) (*pluginmanifestv1.Manifest, error) {
-		return prepareBuiltPackageDir(stagingDir, ".", srcManifest, version, pluginName, build)
+		return prepareBuiltPackageDir(stagingDir, ".", srcManifest, version, pluginName, plat)
 	})
 }
 
@@ -205,19 +188,8 @@ func createReleaseArchive(outputDir, archiveName, manifestFile, manifestFormat s
 	return archivePath, nil
 }
 
-func buildReleaseBinary(root, buildTarget, binaryPath string, plat releasePlatform) error {
-	if buildTarget == "" {
-		return pluginpkg.BuildGoProviderBinary(root, binaryPath, plat.GOOS, plat.GOARCH)
-	}
-
-	cmd := exec.Command("go", "-C", root, "build", "-mod=readonly", "-trimpath", "-ldflags", "-s -w", "-o", binaryPath, buildTarget)
-	cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS="+plat.GOOS, "GOARCH="+plat.GOARCH)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("go build: %w", err)
-	}
-	return nil
+func buildReleaseBinary(root, binaryPath string, plat releasePlatform) error {
+	return pluginpkg.BuildGoProviderBinary(root, binaryPath, plat.GOOS, plat.GOARCH)
 }
 
 func writeReleaseManifestFile(stagingDir, manifestFile, manifestFormat string, manifest *pluginmanifestv1.Manifest) error {
@@ -275,10 +247,10 @@ func buildSourceArchive(srcManifest *pluginmanifestv1.Manifest, pluginName, vers
 	})
 }
 
-func prepareBuiltPackageDir(stagingDir, sourceDir string, srcManifest *pluginmanifestv1.Manifest, version, pluginName string, build releaseBuild) (*pluginmanifestv1.Manifest, error) {
-	binaryName := releaseBinaryName(pluginName, build.platform.GOOS)
+func prepareBuiltPackageDir(stagingDir, sourceDir string, srcManifest *pluginmanifestv1.Manifest, version, pluginName string, plat releasePlatform) (*pluginmanifestv1.Manifest, error) {
+	binaryName := releaseBinaryName(pluginName, plat.GOOS)
 	binaryPath := filepath.Join(stagingDir, binaryName)
-	if err := buildReleaseBinary(sourceDir, build.target, binaryPath, build.platform); err != nil {
+	if err := buildReleaseBinary(sourceDir, binaryPath, plat); err != nil {
 		return nil, err
 	}
 
@@ -289,7 +261,7 @@ func prepareBuiltPackageDir(stagingDir, sourceDir string, srcManifest *pluginman
 	if err := copyReleasePackageFiles(srcManifest, sourceDir, stagingDir, false); err != nil {
 		return nil, err
 	}
-	return buildReleaseManifest(srcManifest, version, binaryName, build.platform, digest)
+	return buildReleaseManifest(srcManifest, version, binaryName, plat, digest)
 }
 
 func buildSourceReleaseManifest(srcManifest *pluginmanifestv1.Manifest, version, sourceDir string) (*pluginmanifestv1.Manifest, error) {

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -295,32 +295,6 @@ func TestRun_PluginReleaseCopiesCompiledSupportFiles(t *testing.T) {
 	}
 }
 
-func TestRun_PluginReleasePreservesCompiledWebUIMetadata(t *testing.T) {
-	t.Parallel()
-
-	pluginDir := newCompiledWebUIReleaseFixture(t, t.TempDir())
-	outputDir := t.TempDir()
-	testVersion := "0.0.21-test"
-
-	runPluginReleaseCommand(t, pluginDir,
-		"--version", testVersion,
-		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
-		"--output", outputDir,
-	)
-
-	archiveName := "gestalt-plugin-compiled-webui-test_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
-	extractDir := extractReleasedArchive(t, outputDir, archiveName)
-
-	_, manifest := readManifestFromDir(t, extractDir)
-	if manifest.WebUI == nil || manifest.WebUI.AssetRoot != "out" {
-		t.Fatalf("manifest webui = %#v, want asset_root %q", manifest.WebUI, "out")
-	}
-
-	if _, err := os.Stat(filepath.Join(extractDir, "out", "index.html")); err != nil {
-		t.Fatalf("expected webui asset in archive: %v", err)
-	}
-}
-
 func TestRun_PluginReleaseCopiesWebUISupportFiles(t *testing.T) {
 	t.Parallel()
 
@@ -384,7 +358,7 @@ func TestRun_PluginReleaseAllowsOverlappingSupportPaths(t *testing.T) {
 	}
 }
 
-func TestRun_PluginReleaseTreatsGoModWithoutCmdAsDeclarative(t *testing.T) {
+func TestRun_PluginReleaseTreatsGoModWithoutProviderPackageAsDeclarative(t *testing.T) {
 	t.Parallel()
 
 	pluginDir := newWebUIReleaseFixture(t, t.TempDir())
@@ -409,7 +383,7 @@ func TestRun_PluginReleaseTreatsGoModWithoutCmdAsDeclarative(t *testing.T) {
 	}
 }
 
-func TestRun_PluginReleaseTreatsDeclarativePluginWithHelperMainAsSource(t *testing.T) {
+func TestRun_PluginReleaseIgnoresHelperMainPackagesWithoutProviderPackage(t *testing.T) {
 	t.Parallel()
 
 	pluginDir := newDeclarativeProviderReleaseFixture(t, t.TempDir())
@@ -1001,30 +975,6 @@ func writeStaticCatalogProviderMain(t *testing.T, dir string) {
 func writeStaticCatalogProviderMainAt(t *testing.T, dir, rel string) {
 	t.Helper()
 	writeTestFile(t, dir, rel, []byte(testutil.GeneratedProviderPackageSource()), 0644)
-}
-
-func newCompiledWebUIReleaseFixture(t *testing.T, dir string) string {
-	t.Helper()
-
-	pluginDir := filepath.Join(dir, "compiled-webui-test")
-	if err := os.MkdirAll(pluginDir, 0755); err != nil {
-		t.Fatalf("MkdirAll(pluginDir): %v", err)
-	}
-	writeTestFile(t, pluginDir, "go.mod", []byte("module example.com/compiled-webui-test\n\ngo 1.22\n"), 0644)
-	writeTestFile(t, pluginDir, "cmd/main.go", []byte("package main\n\nfunc main() {}\n"), 0644)
-	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
-		Source:      "github.com/testowner/plugins/compiled-webui-test",
-		Version:     "0.0.1",
-		DisplayName: "Compiled WebUI Test",
-		IconFile:    "branding/icon.svg",
-		Kinds:       []string{pluginmanifestv1.KindWebUI},
-		WebUI: &pluginmanifestv1.WebUIMetadata{
-			AssetRoot: "out",
-		},
-	})
-	writeTestFile(t, pluginDir, "branding/icon.svg", []byte("<svg></svg>\n"), 0644)
-	writeTestFile(t, pluginDir, "out/index.html", []byte("<html></html>\n"), 0644)
-	return pluginDir
 }
 
 func newPrebuiltHybridReleaseFixture(t *testing.T, dir string) string {

--- a/gestaltd/internal/pluginpkg/go_provider.go
+++ b/gestaltd/internal/pluginpkg/go_provider.go
@@ -18,7 +18,6 @@ const goProviderPackageTarget = "./provider"
 const goReadonlyFlag = "-mod=readonly"
 
 var ErrNoGoProviderPackage = errors.New("no Go provider package found")
-var ErrNoGoMainPackage = errors.New("no Go main package found")
 
 //go:embed go_provider_wrapper.go.tmpl
 var goProviderWrapperSource string
@@ -123,22 +122,6 @@ func BuildGoProviderBinary(root, outputPath, goos, goarch string) error {
 		return fmt.Errorf("go build: %w", err)
 	}
 	return nil
-}
-
-func DetectGoMainBuildTarget(root, goos, goarch string) (string, error) {
-	for _, target := range []string{"./cmd", "."} {
-		name, err := goPackageField(root, target, "{{.Name}}", goos, goarch)
-		if err != nil {
-			if isMissingGoPackageError(err) {
-				continue
-			}
-			return "", fmt.Errorf("%s: %w", target, err)
-		}
-		if strings.TrimSpace(name) == "main" {
-			return target, nil
-		}
-	}
-	return "", ErrNoGoMainPackage
 }
 
 func goPackageField(root, buildTarget, field, goos, goarch string) (string, error) {


### PR DESCRIPTION
## Summary
- remove the legacy `./cmd` / `.` Go `main` package fallback from `gestaltd plugin release`
- keep the Go authoring contract provider-package-only: `provider/`, `New()`, and `Router`
- update the existing release docs/tests to match the simplified flow

## Why
The typed source-plugin model already standardizes on the provider package. Keeping a second release-only authoring path via a root `main.go` adds complexity without adding useful capability.

## Verification
- `go test ./internal/pluginpkg`
- `GOMODCACHE=$(mktemp -d) GOCACHE=$(mktemp -d) go test ./cmd/gestaltd -run 'TestRun_PluginRelease'