### PR TITLE
[codex] Document provider-key impact on stored tokens

### DIFF
--- a/docs/pages/concepts/authentication-and-tokens.mdx
+++ b/docs/pages/concepts/authentication-and-tokens.mdx
@@ -42,6 +42,9 @@ OAuth flows are initiated through the HTTP API (`POST /api/v1/auth/start-oauth`)
 
 Gestalt stores integration credentials keyed by user, integration, connection name, and instance. This allows a single user to maintain multiple connections to the same integration, for example to connect to separate Jira sites or different tenant environments.
 
+Here, `integration` means the entry name under `providers:` in config, not the integration's `display_name`.
+Renaming a provider key changes the stored-connection lookup key, so existing credentials will stop resolving until they are migrated or reconnected.
+
 ## API tokens
 
 API tokens provide programmatic access to Gestalt. They authenticate requests to the HTTP API and `/mcp` without requiring a browser session.

--- a/docs/pages/concepts/authentication-and-tokens.mdx
+++ b/docs/pages/concepts/authentication-and-tokens.mdx
@@ -42,8 +42,7 @@ OAuth flows are initiated through the HTTP API (`POST /api/v1/auth/start-oauth`)
 
 Gestalt stores integration credentials keyed by user, integration, connection name, and instance. This allows a single user to maintain multiple connections to the same integration, for example to connect to separate Jira sites or different tenant environments.
 
-Here, `integration` means the entry name under `providers:` in config, not the integration's `display_name`.
-Renaming a provider key changes the stored-connection lookup key, so existing credentials will stop resolving until they are migrated or reconnected.
+> **Warning:** Renaming a `providers:` entry is a breaking change for stored connections. Existing credentials will stop resolving until they are migrated or reconnected.
 
 ## API tokens
 


### PR DESCRIPTION
## What changed
Added a note to the authentication and tokens docs clarifying that stored integration credentials are keyed by the `providers:` entry name, not by `display_name`.

## Why
Provider-key renames change the stored connection lookup key. Without this note, it is easy to treat a provider rename as cosmetic and accidentally break existing stored credentials.

## Impact
This makes the rename risk explicit in the most relevant docs section for stored connections.

## Validation
Verified the doc location and reviewed the rendered markdown content locally.