### PR TITLE
[codex] Add manual CLI integration connect flow

### DIFF
--- a/docs/dockerhub/gestalt.md
+++ b/docs/dockerhub/gestalt.md
@@ -77,7 +77,7 @@ jobs:
 | `init`                      | Interactive setup wizard               |
 | `config get/set/unset/list` | Manage persistent configuration        |
 | `integrations list`         | List available integrations            |
-| `integrations connect`      | Connect an integration via OAuth       |
+| `integrations connect`      | Connect an integration via OAuth or interactive manual auth |
 | `invoke <integ> <op>`       | Execute an integration operation       |
 | `describe <integ> <op>`     | Describe an integration operation      |
 | `tokens create/list/revoke` | Manage API tokens                      |

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -57,7 +57,7 @@ See [Configuration](/concepts/configuration) for the relationship between `init`
 | `gestalt init` | Run the interactive setup wizard. |
 | `gestalt config get|set|unset|list` | Manage the local client config. |
 | `gestalt integrations list` | List integrations from the server. |
-| `gestalt integrations connect NAME` | Start an integration OAuth flow. |
+| `gestalt integrations connect NAME` | Connect an integration through OAuth or interactive manual auth. |
 | `gestalt invoke INTEGRATION [OPERATION]` | Invoke an operation or list operations when omitted. |
 | `gestalt describe INTEGRATION OPERATION` | Show one operation's parameter contract. |
 | `gestalt tokens create|list|revoke` | Manage Gestalt API tokens. |
@@ -97,6 +97,10 @@ directories until it finds the nearest `.gestalt.json`.
 
 - `--connection`
 - `--instance`
+
+When the selected integration or connection uses manual auth instead of OAuth,
+the CLI now prompts for the required credential fields and connection
+parameters using the same metadata surfaced in the web UI.
 
 ### Invoke Flags
 

--- a/gestalt/cli/Cargo.toml
+++ b/gestalt/cli/Cargo.toml
@@ -13,6 +13,7 @@ clap = { version = "4", features = ["derive"] }
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "cookies", "json", "rustls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_urlencoded = "0.7"
 dirs = "6"
 colored = "3"
 anyhow = "1"
@@ -21,6 +22,7 @@ terminal_size = "0.4.4"
 url = "2"
 getrandom = "0.4"
 comfy-table = { version = "7.2.1", default-features = false }
+rpassword = "7"
 
 [dev-dependencies]
 tempfile = "3"

--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -209,32 +209,7 @@ impl ApiClient {
         }
 
         let body = resp.text().context("failed to read response body")?;
-
-        if status.is_client_error() || status.is_server_error() {
-            let message = serde_json::from_str::<serde_json::Value>(&body)
-                .ok()
-                .and_then(|v| extract_error_message(&v))
-                .unwrap_or_else(|| format!("HTTP {}: {}", status.as_u16(), body));
-
-            if status == StatusCode::UNAUTHORIZED && self.token_source == TokenSource::EnvVar {
-                bail!(
-                    "{} (using {} from environment; \
-                     unset it to use your stored CLI API token from 'gestalt auth login')",
-                    message,
-                    ENV_API_KEY,
-                );
-            }
-            if status == StatusCode::UNAUTHORIZED
-                && self.token_source == TokenSource::StoredCredentials
-            {
-                bail!(
-                    "{} (stored CLI API token may be expired or revoked; run 'gestalt auth login' to mint a new one)",
-                    message,
-                );
-            }
-
-            bail!("{}", message);
-        }
+        self.bail_on_error_response(status, &body)?;
 
         if body.is_empty() {
             return Ok(serde_json::json!({}));
@@ -246,9 +221,13 @@ impl ApiClient {
     fn handle_text_response(&self, resp: reqwest::blocking::Response) -> Result<String> {
         let status = resp.status();
         let body = resp.text().context("failed to read response body")?;
+        self.bail_on_error_response(status, &body)?;
+        Ok(body)
+    }
 
+    fn bail_on_error_response(&self, status: StatusCode, body: &str) -> Result<()> {
         if status.is_client_error() || status.is_server_error() {
-            let message = serde_json::from_str::<serde_json::Value>(&body)
+            let message = serde_json::from_str::<serde_json::Value>(body)
                 .ok()
                 .and_then(|v| extract_error_message(&v))
                 .unwrap_or_else(|| format!("HTTP {}: {}", status.as_u16(), body));
@@ -272,8 +251,7 @@ impl ApiClient {
 
             bail!("{}", message);
         }
-
-        Ok(body)
+        Ok(())
     }
 }
 

--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -1,9 +1,11 @@
+use std::collections::BTreeMap;
+
 use anyhow::{Context, Result, bail};
 use reqwest::Method;
 use reqwest::StatusCode;
 use reqwest::blocking::Client;
 use reqwest::header::{self, HeaderValue};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::config::ConfigStore;
 use crate::credentials::CredentialStore;
@@ -40,6 +42,104 @@ pub fn resolve_url(url_override: Option<&str>) -> Result<String> {
 }
 
 pub const PROJECT_CONFIG_FILE: &str = ".gestalt.json";
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct IntegrationInfo {
+    pub name: String,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub auth_types: Vec<String>,
+    #[serde(default)]
+    pub connection_params: BTreeMap<String, ConnectionParamDef>,
+    #[serde(default)]
+    pub connections: Vec<ConnectionDefInfo>,
+    #[serde(default)]
+    pub credential_fields: Vec<CredentialFieldInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ConnectionDefInfo {
+    pub name: String,
+    #[serde(default)]
+    pub auth_types: Vec<String>,
+    #[serde(default)]
+    pub credential_fields: Vec<CredentialFieldInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ConnectionParamDef {
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub default: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+pub struct CredentialFieldInfo {
+    pub name: String,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub help_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+pub struct DiscoveryCandidateInfo {
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct StartOAuthResponse {
+    pub url: String,
+    #[serde(default)]
+    pub state: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ConnectIntegrationResult {
+    pub status: String,
+    #[serde(default)]
+    pub integration: Option<String>,
+    #[serde(default)]
+    pub selection_url: Option<String>,
+    #[serde(default)]
+    pub pending_token: Option<String>,
+    #[serde(default)]
+    pub candidates: Vec<DiscoveryCandidateInfo>,
+}
+
+#[derive(Serialize)]
+struct StartOAuthRequest<'a> {
+    integration: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    connection: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    instance: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct ConnectManualRequest<'a> {
+    integration: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    credential: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    credentials: Option<&'a BTreeMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    connection: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    instance: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    connection_params: Option<&'a BTreeMap<String, String>>,
+}
 
 fn find_project_config_value(key: &str) -> Option<String> {
     let mut dir = std::env::current_dir().ok()?;
@@ -147,6 +247,66 @@ impl ApiClient {
 
     pub fn revoke_api_token(&self, id: &str) -> Result<serde_json::Value> {
         self.delete(&format!("/api/v1/tokens/{id}"))
+    }
+
+    pub fn list_integrations_typed(&self) -> Result<Vec<IntegrationInfo>> {
+        let resp = self.get("/api/v1/integrations")?;
+        serde_json::from_value(resp).context("failed to parse integrations")
+    }
+
+    pub fn start_integration_oauth(
+        &self,
+        integration: &str,
+        connection: Option<&str>,
+        instance: Option<&str>,
+    ) -> Result<StartOAuthResponse> {
+        let resp = self.post(
+            "/api/v1/auth/start-oauth",
+            &StartOAuthRequest {
+                integration,
+                connection,
+                instance,
+            },
+        )?;
+        serde_json::from_value(resp).context("failed to parse OAuth response")
+    }
+
+    pub fn connect_manual_integration(
+        &self,
+        integration: &str,
+        credential: Option<&str>,
+        credentials: Option<&BTreeMap<String, String>>,
+        connection_params: Option<&BTreeMap<String, String>>,
+        connection: Option<&str>,
+        instance: Option<&str>,
+    ) -> Result<ConnectIntegrationResult> {
+        let resp = self.post(
+            "/api/v1/auth/connect-manual",
+            &ConnectManualRequest {
+                integration,
+                credential,
+                credentials,
+                connection,
+                instance,
+                connection_params,
+            },
+        )?;
+        serde_json::from_value(resp).context("failed to parse manual connect response")
+    }
+
+    pub fn finalize_pending_connection(
+        &self,
+        selection_url: &str,
+        pending_token: &str,
+        candidate_index: usize,
+    ) -> Result<String> {
+        self.post_form(
+            selection_url,
+            &[
+                ("pending_token", pending_token.to_string()),
+                ("candidate_index", candidate_index.to_string()),
+            ],
+        )
     }
 
     fn send(&self, method: Method, path: &str) -> Result<serde_json::Value> {

--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -1,11 +1,9 @@
-use std::collections::BTreeMap;
-
 use anyhow::{Context, Result, bail};
 use reqwest::Method;
 use reqwest::StatusCode;
 use reqwest::blocking::Client;
 use reqwest::header::{self, HeaderValue};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::config::ConfigStore;
 use crate::credentials::CredentialStore;
@@ -42,104 +40,6 @@ pub fn resolve_url(url_override: Option<&str>) -> Result<String> {
 }
 
 pub const PROJECT_CONFIG_FILE: &str = ".gestalt.json";
-
-#[derive(Debug, Clone, Deserialize, Default)]
-pub struct IntegrationInfo {
-    pub name: String,
-    #[serde(default)]
-    pub display_name: Option<String>,
-    #[serde(default)]
-    pub description: Option<String>,
-    #[serde(default)]
-    pub auth_types: Vec<String>,
-    #[serde(default)]
-    pub connection_params: BTreeMap<String, ConnectionParamDef>,
-    #[serde(default)]
-    pub connections: Vec<ConnectionDefInfo>,
-    #[serde(default)]
-    pub credential_fields: Vec<CredentialFieldInfo>,
-}
-
-#[derive(Debug, Clone, Deserialize, Default)]
-pub struct ConnectionDefInfo {
-    pub name: String,
-    #[serde(default)]
-    pub auth_types: Vec<String>,
-    #[serde(default)]
-    pub credential_fields: Vec<CredentialFieldInfo>,
-}
-
-#[derive(Debug, Clone, Deserialize, Default)]
-pub struct ConnectionParamDef {
-    #[serde(default)]
-    pub required: bool,
-    #[serde(default)]
-    pub description: Option<String>,
-    #[serde(default)]
-    pub default: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
-pub struct CredentialFieldInfo {
-    pub name: String,
-    #[serde(default)]
-    pub label: Option<String>,
-    #[serde(default)]
-    pub description: Option<String>,
-    #[serde(default)]
-    pub help_url: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
-pub struct DiscoveryCandidateInfo {
-    pub id: String,
-    #[serde(default)]
-    pub name: String,
-}
-
-#[derive(Debug, Clone, Deserialize, Default)]
-pub struct StartOAuthResponse {
-    pub url: String,
-    #[serde(default)]
-    pub state: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize, Default)]
-pub struct ConnectIntegrationResult {
-    pub status: String,
-    #[serde(default)]
-    pub integration: Option<String>,
-    #[serde(default)]
-    pub selection_url: Option<String>,
-    #[serde(default)]
-    pub pending_token: Option<String>,
-    #[serde(default)]
-    pub candidates: Vec<DiscoveryCandidateInfo>,
-}
-
-#[derive(Serialize)]
-struct StartOAuthRequest<'a> {
-    integration: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    connection: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    instance: Option<&'a str>,
-}
-
-#[derive(Serialize)]
-struct ConnectManualRequest<'a> {
-    integration: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    credential: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    credentials: Option<&'a BTreeMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    connection: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    instance: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    connection_params: Option<&'a BTreeMap<String, String>>,
-}
 
 fn find_project_config_value(key: &str) -> Option<String> {
     let mut dir = std::env::current_dir().ok()?;
@@ -247,66 +147,6 @@ impl ApiClient {
 
     pub fn revoke_api_token(&self, id: &str) -> Result<serde_json::Value> {
         self.delete(&format!("/api/v1/tokens/{id}"))
-    }
-
-    pub fn list_integrations_typed(&self) -> Result<Vec<IntegrationInfo>> {
-        let resp = self.get("/api/v1/integrations")?;
-        serde_json::from_value(resp).context("failed to parse integrations")
-    }
-
-    pub fn start_integration_oauth(
-        &self,
-        integration: &str,
-        connection: Option<&str>,
-        instance: Option<&str>,
-    ) -> Result<StartOAuthResponse> {
-        let resp = self.post(
-            "/api/v1/auth/start-oauth",
-            &StartOAuthRequest {
-                integration,
-                connection,
-                instance,
-            },
-        )?;
-        serde_json::from_value(resp).context("failed to parse OAuth response")
-    }
-
-    pub fn connect_manual_integration(
-        &self,
-        integration: &str,
-        credential: Option<&str>,
-        credentials: Option<&BTreeMap<String, String>>,
-        connection_params: Option<&BTreeMap<String, String>>,
-        connection: Option<&str>,
-        instance: Option<&str>,
-    ) -> Result<ConnectIntegrationResult> {
-        let resp = self.post(
-            "/api/v1/auth/connect-manual",
-            &ConnectManualRequest {
-                integration,
-                credential,
-                credentials,
-                connection,
-                instance,
-                connection_params,
-            },
-        )?;
-        serde_json::from_value(resp).context("failed to parse manual connect response")
-    }
-
-    pub fn finalize_pending_connection(
-        &self,
-        selection_url: &str,
-        pending_token: &str,
-        candidate_index: usize,
-    ) -> Result<String> {
-        self.post_form(
-            selection_url,
-            &[
-                ("pending_token", pending_token.to_string()),
-                ("candidate_index", candidate_index.to_string()),
-            ],
-        )
     }
 
     fn send(&self, method: Method, path: &str) -> Result<serde_json::Value> {

--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -130,6 +130,13 @@ impl ApiClient {
         self.send_json(Method::POST, path, body)
     }
 
+    pub fn post_form<T>(&self, path: &str, body: &T) -> Result<String>
+    where
+        T: Serialize + ?Sized,
+    {
+        self.send_form(Method::POST, path, body)
+    }
+
     pub fn delete(&self, path: &str) -> Result<serde_json::Value> {
         self.send(Method::DELETE, path)
     }
@@ -151,6 +158,26 @@ impl ApiClient {
         T: Serialize + ?Sized,
     {
         self.send_request(method, path, Some(body))
+    }
+
+    fn send_form<T>(&self, method: Method, path: &str, body: &T) -> Result<String>
+    where
+        T: Serialize + ?Sized,
+    {
+        let url = format!("{}{}", self.base_url, path);
+        let encoded = serde_urlencoded::to_string(body).context("failed to encode form body")?;
+        let resp = self
+            .client
+            .request(method, &url)
+            .bearer_auth(&self.token)
+            .header(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/x-www-form-urlencoded"),
+            )
+            .body(encoded)
+            .send()
+            .with_context(|| format!("request to {} failed", url))?;
+        self.handle_text_response(resp)
     }
 
     fn send_request<T>(
@@ -214,6 +241,39 @@ impl ApiClient {
         }
 
         serde_json::from_str(&body).context("failed to parse response JSON")
+    }
+
+    fn handle_text_response(&self, resp: reqwest::blocking::Response) -> Result<String> {
+        let status = resp.status();
+        let body = resp.text().context("failed to read response body")?;
+
+        if status.is_client_error() || status.is_server_error() {
+            let message = serde_json::from_str::<serde_json::Value>(&body)
+                .ok()
+                .and_then(|v| extract_error_message(&v))
+                .unwrap_or_else(|| format!("HTTP {}: {}", status.as_u16(), body));
+
+            if status == StatusCode::UNAUTHORIZED && self.token_source == TokenSource::EnvVar {
+                bail!(
+                    "{} (using {} from environment; \
+                     unset it to use your stored CLI API token from 'gestalt auth login')",
+                    message,
+                    ENV_API_KEY,
+                );
+            }
+            if status == StatusCode::UNAUTHORIZED
+                && self.token_source == TokenSource::StoredCredentials
+            {
+                bail!(
+                    "{} (stored CLI API token may be expired or revoked; run 'gestalt auth login' to mint a new one)",
+                    message,
+                );
+            }
+
+            bail!("{}", message);
+        }
+
+        Ok(body)
     }
 }
 

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -124,7 +124,7 @@ pub enum ConfigCommands {
 pub enum IntegrationCommands {
     /// List available integrations
     List,
-    /// Connect an integration via OAuth
+    /// Connect an integration via OAuth or interactive manual auth
     Connect {
         /// Integration name (e.g., github, slack)
         name: String,

--- a/gestalt/cli/src/commands/init.rs
+++ b/gestalt/cli/src/commands/init.rs
@@ -3,16 +3,14 @@ use anyhow::{Context, Result};
 use crate::api::{self, PROJECT_CONFIG_FILE};
 use crate::commands::auth;
 use crate::config::ConfigStore;
-use crate::interactive::{InputPrompt, Prompter, StdioPrompter};
+use crate::interactive::{InputPrompt, prompt_confirm, prompt_input};
 use crate::output;
 
 pub fn run(url_override: Option<&str>) -> Result<()> {
-    let mut prompts = StdioPrompter;
-
     eprintln!("Welcome to Gestalt! Let's get you set up.\n");
 
     let current_url = api::resolve_url(url_override).unwrap_or_default();
-    let url = api::normalize_url(&prompts.input(&InputPrompt {
+    let url = api::normalize_url(&prompt_input(&InputPrompt {
         label: "API server URL".to_string(),
         description: None,
         help_url: None,
@@ -25,13 +23,13 @@ pub fn run(url_override: Option<&str>) -> Result<()> {
     store.set("url", &url)?;
     eprintln!("Saved to global config.\n");
 
-    if prompts.confirm("Log in now?", true)? {
+    if prompt_confirm("Log in now?", true)? {
         eprintln!();
         auth::login(Some(&url))?;
         eprintln!();
     }
 
-    if prompts.confirm("Create .gestalt.json in current directory?", false)? {
+    if prompt_confirm("Create .gestalt.json in current directory?", false)? {
         let config = serde_json::json!({"url": url});
         let json = serde_json::to_string_pretty(&config).context("failed to serialize config")?;
         std::fs::write(PROJECT_CONFIG_FILE, format!("{json}\n"))

--- a/gestalt/cli/src/commands/init.rs
+++ b/gestalt/cli/src/commands/init.rs
@@ -1,36 +1,37 @@
-use std::io::{self, BufRead, Write};
-
 use anyhow::{Context, Result};
 
 use crate::api::{self, PROJECT_CONFIG_FILE};
 use crate::commands::auth;
 use crate::config::ConfigStore;
+use crate::interactive::{InputPrompt, Prompter, StdioPrompter};
 use crate::output;
 
 pub fn run(url_override: Option<&str>) -> Result<()> {
-    let stdin = io::stdin();
-    let mut lines = stdin.lock().lines();
+    let mut prompts = StdioPrompter;
 
     eprintln!("Welcome to Gestalt! Let's get you set up.\n");
 
     let current_url = api::resolve_url(url_override).unwrap_or_default();
-    let url = api::normalize_url(&prompt(&mut lines, "API server URL", &current_url)?);
+    let url = api::normalize_url(&prompts.input(&InputPrompt {
+        label: "API server URL".to_string(),
+        description: None,
+        help_url: None,
+        default: Some(current_url),
+        required: true,
+        secret: false,
+    })?);
 
     let store = ConfigStore::new()?;
     store.set("url", &url)?;
     eprintln!("Saved to global config.\n");
 
-    if confirm(&mut lines, "Log in now?", true)? {
+    if prompts.confirm("Log in now?", true)? {
         eprintln!();
         auth::login(Some(&url))?;
         eprintln!();
     }
 
-    if confirm(
-        &mut lines,
-        "Create .gestalt.json in current directory?",
-        false,
-    )? {
+    if prompts.confirm("Create .gestalt.json in current directory?", false)? {
         let config = serde_json::json!({"url": url});
         let json = serde_json::to_string_pretty(&config).context("failed to serialize config")?;
         std::fs::write(PROJECT_CONFIG_FILE, format!("{json}\n"))
@@ -41,43 +42,4 @@ pub fn run(url_override: Option<&str>) -> Result<()> {
     eprintln!();
     output::print_success("You're all set! Run 'gestalt --help' to see available commands.");
     Ok(())
-}
-
-fn prompt(lines: &mut io::Lines<io::StdinLock>, label: &str, default: &str) -> Result<String> {
-    if default.is_empty() {
-        eprint!("{}: ", label);
-    } else {
-        eprint!("{} [{}]: ", label, default);
-    }
-    io::stderr().flush()?;
-
-    let line = lines
-        .next()
-        .unwrap_or(Ok(String::new()))
-        .context("failed to read input")?;
-    let trimmed = line.trim();
-
-    if trimmed.is_empty() {
-        Ok(default.to_string())
-    } else {
-        Ok(trimmed.to_string())
-    }
-}
-
-fn confirm(lines: &mut io::Lines<io::StdinLock>, question: &str, default: bool) -> Result<bool> {
-    let hint = if default { "Y/n" } else { "y/N" };
-    eprint!("{} [{}]: ", question, hint);
-    io::stderr().flush()?;
-
-    let line = lines
-        .next()
-        .unwrap_or(Ok(String::new()))
-        .context("failed to read input")?;
-    let trimmed = line.trim().to_lowercase();
-
-    if trimmed.is_empty() {
-        Ok(default)
-    } else {
-        Ok(trimmed.starts_with('y'))
-    }
 }

--- a/gestalt/cli/src/commands/integrations.rs
+++ b/gestalt/cli/src/commands/integrations.rs
@@ -1,13 +1,105 @@
 use std::collections::BTreeMap;
 
 use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
 
-use crate::api::{ApiClient, CredentialFieldInfo, DiscoveryCandidateInfo, IntegrationInfo};
+use crate::api::ApiClient;
 use crate::interactive::{InputPrompt, PromptOption, prompt_input, prompt_select};
 use crate::output::{self, Format};
 
 const PLUGIN_CONNECTION_NAME: &str = "_plugin";
 const PLUGIN_CONNECTION_ALIAS: &str = "plugin";
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct IntegrationInfo {
+    name: String,
+    #[serde(default)]
+    display_name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    auth_types: Vec<String>,
+    #[serde(default)]
+    connection_params: BTreeMap<String, ConnectionParamDef>,
+    #[serde(default)]
+    connections: Vec<ConnectionDefInfo>,
+    #[serde(default)]
+    credential_fields: Vec<CredentialFieldInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct ConnectionDefInfo {
+    name: String,
+    #[serde(default)]
+    auth_types: Vec<String>,
+    #[serde(default)]
+    credential_fields: Vec<CredentialFieldInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct ConnectionParamDef {
+    #[serde(default)]
+    required: bool,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    default: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct ConnectManualResponse {
+    status: String,
+    #[serde(default)]
+    integration: Option<String>,
+    #[serde(default)]
+    selection_url: Option<String>,
+    #[serde(default)]
+    pending_token: Option<String>,
+    #[serde(default)]
+    candidates: Vec<DiscoveryCandidateInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+struct CredentialFieldInfo {
+    name: String,
+    #[serde(default)]
+    label: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    help_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+struct DiscoveryCandidateInfo {
+    id: String,
+    #[serde(default)]
+    name: String,
+}
+
+#[derive(Serialize)]
+struct StartOAuthRequest<'a> {
+    integration: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    connection: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    instance: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct ConnectManualRequest<'a> {
+    integration: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    credential: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    credentials: Option<&'a BTreeMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    connection: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    instance: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    connection_params: Option<&'a BTreeMap<String, String>>,
+}
 
 #[derive(Debug, Clone)]
 struct ResolvedAuthTarget {
@@ -125,13 +217,23 @@ where
     F: FnOnce(&str) -> Result<()>,
 {
     let resp = client
-        .start_integration_oauth(name, connection, instance)
+        .post(
+            "/api/v1/auth/start-oauth",
+            &StartOAuthRequest {
+                integration: name,
+                connection,
+                instance,
+            },
+        )
         .context("failed to start OAuth flow")?;
+    let url = resp["url"]
+        .as_str()
+        .context("response missing 'url' field")?;
 
     eprintln!("Opening browser to connect {}...", name);
-    eprintln!("If the browser doesn't open, visit: {}", resp.url);
+    eprintln!("If the browser doesn't open, visit: {}", url);
 
-    if open_browser(&resp.url).is_err() {
+    if open_browser(url).is_err() {
         eprintln!("Could not open browser automatically.");
     }
 
@@ -167,16 +269,22 @@ fn connect_manual(
         ManualCredentialPayload::Multiple(values) => (None, Some(values)),
     };
 
-    let response = client
-        .connect_manual_integration(
-            name,
-            credential,
-            credentials,
-            connection_params.as_ref(),
-            connection,
-            instance,
-        )
-        .context("failed to connect integration")?;
+    let response: ConnectManualResponse = serde_json::from_value(
+        client
+            .post(
+                "/api/v1/auth/connect-manual",
+                &ConnectManualRequest {
+                    integration: name,
+                    credential,
+                    credentials,
+                    connection,
+                    instance,
+                    connection_params: connection_params.as_ref(),
+                },
+            )
+            .context("failed to connect integration")?,
+    )
+    .context("failed to parse manual connect response")?;
 
     match response.status.as_str() {
         "connected" => {
@@ -230,7 +338,13 @@ fn complete_pending_selection(
     };
 
     client
-        .finalize_pending_connection(selection_url, pending_token, selected)
+        .post_form(
+            selection_url,
+            &[
+                ("pending_token", pending_token.to_string()),
+                ("candidate_index", selected.to_string()),
+            ],
+        )
         .context("failed to finalize selected connection")?;
 
     output::print_success(&format!(
@@ -242,9 +356,14 @@ fn complete_pending_selection(
 }
 
 fn fetch_integration(client: &ApiClient, name: &str) -> Result<IntegrationInfo> {
-    client
-        .list_integrations_typed()
-        .context("failed to load integrations")?
+    let integrations: Vec<IntegrationInfo> = serde_json::from_value(
+        client
+            .get("/api/v1/integrations")
+            .context("failed to load integrations")?,
+    )
+    .context("failed to parse integrations")?;
+
+    integrations
         .into_iter()
         .find(|integration| integration.name == name)
         .with_context(|| format!("integration '{}' not found", name))
@@ -428,7 +547,7 @@ impl IntegrationInfo {
         non_empty(self.display_name.as_deref()).unwrap_or(&self.name)
     }
 
-    fn connection_by_name(&self, name: &str) -> Option<&crate::api::ConnectionDefInfo> {
+    fn connection_by_name(&self, name: &str) -> Option<&ConnectionDefInfo> {
         let normalized = normalize_connection_name(name);
         self.connections
             .iter()

--- a/gestalt/cli/src/commands/integrations.rs
+++ b/gestalt/cli/src/commands/integrations.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use anyhow::{Context, Result, bail};
 
 use crate::api::{ApiClient, CredentialFieldInfo, DiscoveryCandidateInfo, IntegrationInfo};
-use crate::interactive::{InputPrompt, PromptOption, Prompter, StdioPrompter};
+use crate::interactive::{InputPrompt, PromptOption, prompt_input, prompt_select};
 use crate::output::{self, Format};
 
 const PLUGIN_CONNECTION_NAME: &str = "_plugin";
@@ -68,15 +68,9 @@ pub fn connect(
     connection: Option<&str>,
     instance: Option<&str>,
 ) -> Result<()> {
-    let mut prompts = StdioPrompter;
-    connect_with_browser_opener_and_prompter(
-        client,
-        name,
-        connection,
-        instance,
-        &mut prompts,
-        |url| open::that(url).map(|_| ()).map_err(Into::into),
-    )
+    connect_with_browser_opener(client, name, connection, instance, |url| {
+        open::that(url).map(|_| ()).map_err(Into::into)
+    })
 }
 
 pub fn connect_with_browser_opener<F>(
@@ -89,31 +83,8 @@ pub fn connect_with_browser_opener<F>(
 where
     F: FnOnce(&str) -> Result<()>,
 {
-    let mut prompts = StdioPrompter;
-    connect_with_browser_opener_and_prompter(
-        client,
-        name,
-        connection,
-        instance,
-        &mut prompts,
-        open_browser,
-    )
-}
-
-pub fn connect_with_browser_opener_and_prompter<P, F>(
-    client: &ApiClient,
-    name: &str,
-    connection: Option<&str>,
-    instance: Option<&str>,
-    prompts: &mut P,
-    open_browser: F,
-) -> Result<()>
-where
-    P: Prompter,
-    F: FnOnce(&str) -> Result<()>,
-{
     let integration = fetch_integration(client, name)?;
-    let selected_connection = resolve_connection(&integration, connection, prompts)?;
+    let selected_connection = resolve_connection(&integration, connection)?;
     let auth_target = resolve_auth_target(&integration, selected_connection.as_deref());
 
     if auth_target.supports_oauth() {
@@ -134,7 +105,6 @@ where
             selected_connection.as_deref(),
             instance,
             &auth_target,
-            prompts,
         );
     }
 
@@ -168,18 +138,14 @@ where
     Ok(())
 }
 
-fn connect_manual<P>(
+fn connect_manual(
     client: &ApiClient,
     integration: &IntegrationInfo,
     name: &str,
     connection: Option<&str>,
     instance: Option<&str>,
     auth_target: &ResolvedAuthTarget,
-    prompts: &mut P,
-) -> Result<()>
-where
-    P: Prompter,
-{
+) -> Result<()> {
     eprintln!(
         "Connecting {} with manual auth.",
         integration.display_name()
@@ -194,8 +160,8 @@ where
         );
     }
 
-    let connection_params = prompt_connection_params(integration, prompts)?;
-    let credential_payload = prompt_manual_credentials(&auth_target.credential_fields, prompts)?;
+    let connection_params = prompt_connection_params(integration)?;
+    let credential_payload = prompt_manual_credentials(&auth_target.credential_fields)?;
     let (credential, credentials) = match &credential_payload {
         ManualCredentialPayload::Single(value) => (Some(value.as_str()), None),
         ManualCredentialPayload::Multiple(values) => (None, Some(values)),
@@ -226,23 +192,18 @@ where
             response.selection_url.as_deref(),
             response.pending_token.as_deref(),
             &response.candidates,
-            prompts,
         ),
         other => bail!("unexpected manual connect response status '{}'", other),
     }
 }
 
-fn complete_pending_selection<P>(
+fn complete_pending_selection(
     client: &ApiClient,
     integration: &str,
     selection_url: Option<&str>,
     pending_token: Option<&str>,
     candidates: &[DiscoveryCandidateInfo],
-    prompts: &mut P,
-) -> Result<()>
-where
-    P: Prompter,
-{
+) -> Result<()> {
     let selection_url = selection_url.context("manual connect response missing selection_url")?;
     let pending_token = pending_token.context("manual connect response missing pending_token")?;
     if candidates.is_empty() {
@@ -259,7 +220,7 @@ where
                 detail: Some(candidate.id.clone()),
             })
             .collect();
-        prompts.select(
+        prompt_select(
             &format!(
                 "Gestalt found more than one {} connection. Choose one to save:",
                 integration
@@ -289,14 +250,10 @@ fn fetch_integration(client: &ApiClient, name: &str) -> Result<IntegrationInfo> 
         .with_context(|| format!("integration '{}' not found", name))
 }
 
-fn resolve_connection<P>(
+fn resolve_connection(
     integration: &IntegrationInfo,
     requested_connection: Option<&str>,
-    prompts: &mut P,
-) -> Result<Option<String>>
-where
-    P: Prompter,
-{
+) -> Result<Option<String>> {
     if integration.connections.is_empty() {
         return Ok(requested_connection.map(str::to_string));
     }
@@ -330,7 +287,7 @@ where
             )),
         })
         .collect();
-    let idx = prompts.select(
+    let idx = prompt_select(
         &format!("Select a {} connection:", integration.display_name()),
         &options,
     )?;
@@ -360,20 +317,16 @@ fn resolve_auth_target(
     }
 }
 
-fn prompt_connection_params<P>(
+fn prompt_connection_params(
     integration: &IntegrationInfo,
-    prompts: &mut P,
-) -> Result<Option<BTreeMap<String, String>>>
-where
-    P: Prompter,
-{
+) -> Result<Option<BTreeMap<String, String>>> {
     if integration.connection_params.is_empty() {
         return Ok(None);
     }
 
     let mut values = BTreeMap::new();
     for (name, def) in &integration.connection_params {
-        let value = prompts.input(&InputPrompt {
+        let value = prompt_input(&InputPrompt {
             label: non_empty(def.description.as_deref())
                 .unwrap_or(name)
                 .to_string(),
@@ -395,13 +348,7 @@ where
     }
 }
 
-fn prompt_manual_credentials<P>(
-    fields: &[CredentialFieldInfo],
-    prompts: &mut P,
-) -> Result<ManualCredentialPayload>
-where
-    P: Prompter,
-{
+fn prompt_manual_credentials(fields: &[CredentialFieldInfo]) -> Result<ManualCredentialPayload> {
     let fields = if fields.is_empty() {
         vec![CredentialFieldInfo {
             name: "credential".to_string(),
@@ -415,22 +362,19 @@ where
 
     if fields.len() == 1 {
         return Ok(ManualCredentialPayload::Single(prompt_for_credential(
-            &fields[0], prompts,
+            &fields[0],
         )?));
     }
 
     let mut values = BTreeMap::new();
     for field in &fields {
-        values.insert(field.name.clone(), prompt_for_credential(field, prompts)?);
+        values.insert(field.name.clone(), prompt_for_credential(field)?);
     }
     Ok(ManualCredentialPayload::Multiple(values))
 }
 
-fn prompt_for_credential<P>(field: &CredentialFieldInfo, prompts: &mut P) -> Result<String>
-where
-    P: Prompter,
-{
-    prompts.input(&InputPrompt {
+fn prompt_for_credential(field: &CredentialFieldInfo) -> Result<String> {
+    prompt_input(&InputPrompt {
         label: field.display_label(),
         description: non_empty(field.description.as_deref()).map(str::to_string),
         help_url: non_empty(field.help_url.as_deref()).map(str::to_string),

--- a/gestalt/cli/src/commands/integrations.rs
+++ b/gestalt/cli/src/commands/integrations.rs
@@ -1,224 +1,13 @@
 use std::collections::BTreeMap;
-use std::io::{self, IsTerminal, Write};
 
 use anyhow::{Context, Result, bail};
-use serde::{Deserialize, Serialize};
 
-use crate::api::ApiClient;
+use crate::api::{ApiClient, CredentialFieldInfo, DiscoveryCandidateInfo, IntegrationInfo};
+use crate::interactive::{InputPrompt, PromptOption, Prompter, StdioPrompter};
 use crate::output::{self, Format};
 
 const PLUGIN_CONNECTION_NAME: &str = "_plugin";
 const PLUGIN_CONNECTION_ALIAS: &str = "plugin";
-
-#[derive(Serialize)]
-struct StartOAuthRequest<'a> {
-    integration: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    connection: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    instance: Option<&'a str>,
-}
-
-#[derive(Serialize)]
-struct ConnectManualRequest<'a> {
-    integration: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    credential: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    credentials: Option<&'a BTreeMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    connection: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    instance: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    connection_params: Option<&'a BTreeMap<String, String>>,
-}
-
-#[derive(Debug, Clone, Deserialize, Default)]
-struct IntegrationInfo {
-    name: String,
-    #[serde(default)]
-    display_name: Option<String>,
-    #[serde(default)]
-    description: Option<String>,
-    #[serde(default)]
-    auth_types: Vec<String>,
-    #[serde(default)]
-    connection_params: BTreeMap<String, ConnectionParamDef>,
-    #[serde(default)]
-    connections: Vec<ConnectionDefInfo>,
-    #[serde(default)]
-    credential_fields: Vec<CredentialFieldInfo>,
-}
-
-#[derive(Debug, Clone, Deserialize, Default)]
-struct ConnectionDefInfo {
-    name: String,
-    #[serde(default)]
-    auth_types: Vec<String>,
-    #[serde(default)]
-    credential_fields: Vec<CredentialFieldInfo>,
-}
-
-#[derive(Debug, Clone, Deserialize, Default)]
-struct ConnectionParamDef {
-    #[serde(default)]
-    required: bool,
-    #[serde(default)]
-    description: Option<String>,
-    #[serde(default)]
-    default: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
-struct CredentialFieldInfo {
-    name: String,
-    #[serde(default)]
-    label: Option<String>,
-    #[serde(default)]
-    description: Option<String>,
-    #[serde(default)]
-    help_url: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
-struct DiscoveryCandidateInfo {
-    id: String,
-    #[serde(default)]
-    name: String,
-}
-
-#[derive(Debug, Clone, Deserialize, Default)]
-struct ConnectManualResponse {
-    status: String,
-    #[serde(default)]
-    integration: Option<String>,
-    #[serde(default)]
-    selection_url: Option<String>,
-    #[serde(default)]
-    pending_token: Option<String>,
-    #[serde(default)]
-    candidates: Vec<DiscoveryCandidateInfo>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct PromptOption {
-    label: String,
-    detail: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct PromptInput {
-    label: String,
-    description: Option<String>,
-    help_url: Option<String>,
-    default: Option<String>,
-    required: bool,
-    secret: bool,
-}
-
-trait ConnectPrompter {
-    fn select(&mut self, prompt: &str, options: &[PromptOption]) -> Result<usize>;
-    fn input(&mut self, prompt: &PromptInput) -> Result<String>;
-}
-
-struct StdioPrompter;
-
-impl StdioPrompter {
-    fn ensure_interactive(&self) -> Result<()> {
-        if !io::stdin().is_terminal() || !io::stderr().is_terminal() {
-            bail!(
-                "manual connections require an interactive terminal; rerun this command in a terminal session",
-            );
-        }
-        Ok(())
-    }
-
-    fn read_line(&self) -> Result<String> {
-        let mut input = String::new();
-        io::stdin()
-            .read_line(&mut input)
-            .context("failed to read terminal input")?;
-        Ok(input.trim().to_string())
-    }
-}
-
-impl ConnectPrompter for StdioPrompter {
-    fn select(&mut self, prompt: &str, options: &[PromptOption]) -> Result<usize> {
-        self.ensure_interactive()?;
-        if options.is_empty() {
-            bail!("no options available");
-        }
-
-        let mut stderr = io::stderr();
-        writeln!(stderr, "{prompt}")?;
-        for (idx, option) in options.iter().enumerate() {
-            writeln!(stderr, "  {}. {}", idx + 1, option.label)?;
-            if let Some(detail) = option.detail.as_deref() {
-                writeln!(stderr, "     {detail}")?;
-            }
-        }
-
-        loop {
-            write!(stderr, "Selection [1-{}]: ", options.len())?;
-            stderr.flush()?;
-            let input = self.read_line()?;
-
-            if let Ok(choice) = input.parse::<usize>()
-                && (1..=options.len()).contains(&choice)
-            {
-                return Ok(choice - 1);
-            }
-
-            writeln!(stderr, "Enter a number between 1 and {}.", options.len())?;
-        }
-    }
-
-    fn input(&mut self, prompt: &PromptInput) -> Result<String> {
-        self.ensure_interactive()?;
-
-        let mut stderr = io::stderr();
-        writeln!(stderr)?;
-        writeln!(stderr, "{}", prompt.label)?;
-        if let Some(description) = prompt.description.as_deref() {
-            writeln!(stderr, "  {description}")?;
-        }
-        if let Some(help_url) = prompt.help_url.as_deref() {
-            writeln!(stderr, "  Help: {help_url}")?;
-        }
-
-        loop {
-            let value = if prompt.secret {
-                let prompt_text = match prompt.default.as_deref() {
-                    Some(default) => format!("Value [{default}]: "),
-                    None => "Value: ".to_string(),
-                };
-                rpassword::prompt_password(prompt_text).context("failed to read secret input")?
-            } else {
-                match prompt.default.as_deref() {
-                    Some(default) => write!(stderr, "Value [{default}]: ")?,
-                    None => write!(stderr, "Value: ")?,
-                }
-                stderr.flush()?;
-                self.read_line()?
-            };
-
-            let trimmed = value.trim().to_string();
-            if trimmed.is_empty() {
-                if let Some(default) = prompt.default.clone() {
-                    return Ok(default);
-                }
-                if !prompt.required {
-                    return Ok(String::new());
-                }
-                writeln!(stderr, "A value is required.")?;
-                continue;
-            }
-
-            return Ok(trimmed);
-        }
-    }
-}
 
 #[derive(Debug, Clone)]
 struct ResolvedAuthTarget {
@@ -311,7 +100,7 @@ where
     )
 }
 
-fn connect_with_browser_opener_and_prompter<P, F>(
+pub fn connect_with_browser_opener_and_prompter<P, F>(
     client: &ApiClient,
     name: &str,
     connection: Option<&str>,
@@ -320,12 +109,12 @@ fn connect_with_browser_opener_and_prompter<P, F>(
     open_browser: F,
 ) -> Result<()>
 where
-    P: ConnectPrompter,
+    P: Prompter,
     F: FnOnce(&str) -> Result<()>,
 {
     let integration = fetch_integration(client, name)?;
     let selected_connection = resolve_connection(&integration, connection, prompts)?;
-    let auth_target = resolve_auth_target(&integration, selected_connection.as_deref())?;
+    let auth_target = resolve_auth_target(&integration, selected_connection.as_deref());
 
     if auth_target.supports_oauth() {
         return start_oauth(
@@ -366,24 +155,13 @@ where
     F: FnOnce(&str) -> Result<()>,
 {
     let resp = client
-        .post(
-            "/api/v1/auth/start-oauth",
-            &StartOAuthRequest {
-                integration: name,
-                connection,
-                instance,
-            },
-        )
+        .start_integration_oauth(name, connection, instance)
         .context("failed to start OAuth flow")?;
 
-    let url = resp["url"]
-        .as_str()
-        .context("response missing 'url' field")?;
-
     eprintln!("Opening browser to connect {}...", name);
-    eprintln!("If the browser doesn't open, visit: {}", url);
+    eprintln!("If the browser doesn't open, visit: {}", resp.url);
 
-    if open_browser(url).is_err() {
+    if open_browser(&resp.url).is_err() {
         eprintln!("Could not open browser automatically.");
     }
 
@@ -400,10 +178,12 @@ fn connect_manual<P>(
     prompts: &mut P,
 ) -> Result<()>
 where
-    P: ConnectPrompter,
+    P: Prompter,
 {
-    let display_name = integration.display_name();
-    eprintln!("Connecting {display_name} with manual auth.");
+    eprintln!(
+        "Connecting {} with manual auth.",
+        integration.display_name()
+    );
     if let Some(description) = non_empty(integration.description.as_deref()) {
         eprintln!("{description}");
     }
@@ -414,35 +194,30 @@ where
         );
     }
 
-    let connection_params = prompt_connection_params(&integration.connection_params, prompts)?;
+    let connection_params = prompt_connection_params(integration, prompts)?;
     let credential_payload = prompt_manual_credentials(&auth_target.credential_fields, prompts)?;
-
     let (credential, credentials) = match &credential_payload {
         ManualCredentialPayload::Single(value) => (Some(value.as_str()), None),
         ManualCredentialPayload::Multiple(values) => (None, Some(values)),
     };
 
-    let resp = client
-        .post(
-            "/api/v1/auth/connect-manual",
-            &ConnectManualRequest {
-                integration: name,
-                credential,
-                credentials,
-                connection,
-                instance,
-                connection_params: connection_params.as_ref(),
-            },
+    let response = client
+        .connect_manual_integration(
+            name,
+            credential,
+            credentials,
+            connection_params.as_ref(),
+            connection,
+            instance,
         )
         .context("failed to connect integration")?;
 
-    let response: ConnectManualResponse =
-        serde_json::from_value(resp).context("failed to parse manual connect response")?;
-
     match response.status.as_str() {
         "connected" => {
-            let connected_name = response.integration.as_deref().unwrap_or(name);
-            output::print_success(&format!("Connected {}.", connected_name));
+            output::print_success(&format!(
+                "Connected {}.",
+                response.integration.as_deref().unwrap_or(name)
+            ));
             Ok(())
         }
         "selection_required" => complete_pending_selection(
@@ -466,11 +241,10 @@ fn complete_pending_selection<P>(
     prompts: &mut P,
 ) -> Result<()>
 where
-    P: ConnectPrompter,
+    P: Prompter,
 {
     let selection_url = selection_url.context("manual connect response missing selection_url")?;
     let pending_token = pending_token.context("manual connect response missing pending_token")?;
-
     if candidates.is_empty() {
         bail!("manual connect response missing discovery candidates");
     }
@@ -482,7 +256,7 @@ where
             .iter()
             .map(|candidate| PromptOption {
                 label: candidate.display_name(),
-                detail: non_empty(Some(candidate.id.as_str())).map(str::to_string),
+                detail: Some(candidate.id.clone()),
             })
             .collect();
         prompts.select(
@@ -495,13 +269,7 @@ where
     };
 
     client
-        .post_form(
-            selection_url,
-            &[
-                ("pending_token", pending_token.to_string()),
-                ("candidate_index", selected.to_string()),
-            ],
-        )
+        .finalize_pending_connection(selection_url, pending_token, selected)
         .context("failed to finalize selected connection")?;
 
     output::print_success(&format!(
@@ -513,13 +281,9 @@ where
 }
 
 fn fetch_integration(client: &ApiClient, name: &str) -> Result<IntegrationInfo> {
-    let resp = client
-        .get("/api/v1/integrations")
-        .context("failed to load integrations")?;
-    let integrations: Vec<IntegrationInfo> =
-        serde_json::from_value(resp).context("failed to parse integrations")?;
-
-    integrations
+    client
+        .list_integrations_typed()
+        .context("failed to load integrations")?
         .into_iter()
         .find(|integration| integration.name == name)
         .with_context(|| format!("integration '{}' not found", name))
@@ -531,7 +295,7 @@ fn resolve_connection<P>(
     prompts: &mut P,
 ) -> Result<Option<String>>
 where
-    P: ConnectPrompter,
+    P: Prompter,
 {
     if integration.connections.is_empty() {
         return Ok(requested_connection.map(str::to_string));
@@ -576,41 +340,40 @@ where
 fn resolve_auth_target(
     integration: &IntegrationInfo,
     connection: Option<&str>,
-) -> Result<ResolvedAuthTarget> {
-    if let Some(connection) = connection {
-        if let Some(connection_info) = integration.connection_by_name(connection) {
-            let credential_fields = if connection_info.credential_fields.is_empty() {
+) -> ResolvedAuthTarget {
+    if let Some(connection) = connection
+        && let Some(connection_info) = integration.connection_by_name(connection)
+    {
+        return ResolvedAuthTarget {
+            auth_types: connection_info.auth_types.clone(),
+            credential_fields: if connection_info.credential_fields.is_empty() {
                 integration.credential_fields.clone()
             } else {
                 connection_info.credential_fields.clone()
-            };
-            return Ok(ResolvedAuthTarget {
-                auth_types: connection_info.auth_types.clone(),
-                credential_fields,
-            });
-        }
+            },
+        };
     }
 
-    Ok(ResolvedAuthTarget {
+    ResolvedAuthTarget {
         auth_types: integration.auth_types.clone(),
         credential_fields: integration.credential_fields.clone(),
-    })
+    }
 }
 
 fn prompt_connection_params<P>(
-    connection_params: &BTreeMap<String, ConnectionParamDef>,
+    integration: &IntegrationInfo,
     prompts: &mut P,
 ) -> Result<Option<BTreeMap<String, String>>>
 where
-    P: ConnectPrompter,
+    P: Prompter,
 {
-    if connection_params.is_empty() {
+    if integration.connection_params.is_empty() {
         return Ok(None);
     }
 
     let mut values = BTreeMap::new();
-    for (name, def) in connection_params {
-        let value = prompts.input(&PromptInput {
+    for (name, def) in &integration.connection_params {
+        let value = prompts.input(&InputPrompt {
             label: non_empty(def.description.as_deref())
                 .unwrap_or(name)
                 .to_string(),
@@ -637,7 +400,7 @@ fn prompt_manual_credentials<P>(
     prompts: &mut P,
 ) -> Result<ManualCredentialPayload>
 where
-    P: ConnectPrompter,
+    P: Prompter,
 {
     let fields = if fields.is_empty() {
         vec![CredentialFieldInfo {
@@ -651,32 +414,30 @@ where
     };
 
     if fields.len() == 1 {
-        let field = &fields[0];
-        let value = prompts.input(&PromptInput {
-            label: field.display_label(),
-            description: non_empty(field.description.as_deref()).map(str::to_string),
-            help_url: non_empty(field.help_url.as_deref()).map(str::to_string),
-            default: None,
-            required: true,
-            secret: true,
-        })?;
-        return Ok(ManualCredentialPayload::Single(value));
+        return Ok(ManualCredentialPayload::Single(prompt_for_credential(
+            &fields[0], prompts,
+        )?));
     }
 
     let mut values = BTreeMap::new();
     for field in &fields {
-        let value = prompts.input(&PromptInput {
-            label: field.display_label(),
-            description: non_empty(field.description.as_deref()).map(str::to_string),
-            help_url: non_empty(field.help_url.as_deref()).map(str::to_string),
-            default: None,
-            required: true,
-            secret: true,
-        })?;
-        values.insert(field.name.clone(), value);
+        values.insert(field.name.clone(), prompt_for_credential(field, prompts)?);
     }
-
     Ok(ManualCredentialPayload::Multiple(values))
+}
+
+fn prompt_for_credential<P>(field: &CredentialFieldInfo, prompts: &mut P) -> Result<String>
+where
+    P: Prompter,
+{
+    prompts.input(&InputPrompt {
+        label: field.display_label(),
+        description: non_empty(field.description.as_deref()).map(str::to_string),
+        help_url: non_empty(field.help_url.as_deref()).map(str::to_string),
+        default: None,
+        required: true,
+        secret: true,
+    })
 }
 
 fn normalize_connection_name(name: &str) -> &str {
@@ -707,15 +468,15 @@ fn non_empty(value: Option<&str>) -> Option<&str> {
 }
 
 fn format_auth_types(auth_types: &[String]) -> String {
-    let labels: Vec<&str> = auth_types
+    auth_types
         .iter()
         .map(|auth_type| match auth_type.as_str() {
             "oauth" => "OAuth",
             "manual" => "manual",
             _ => auth_type.as_str(),
         })
-        .collect();
-    labels.join(" / ")
+        .collect::<Vec<_>>()
+        .join(" / ")
 }
 
 impl IntegrationInfo {
@@ -723,7 +484,7 @@ impl IntegrationInfo {
         non_empty(self.display_name.as_deref()).unwrap_or(&self.name)
     }
 
-    fn connection_by_name(&self, name: &str) -> Option<&ConnectionDefInfo> {
+    fn connection_by_name(&self, name: &str) -> Option<&crate::api::ConnectionDefInfo> {
         let normalized = normalize_connection_name(name);
         self.connections
             .iter()
@@ -752,310 +513,5 @@ impl DiscoveryCandidateInfo {
         non_empty(Some(self.name.as_str()))
             .unwrap_or(&self.id)
             .to_string()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use anyhow::{Result, bail};
-    use mockito::{Matcher, Server};
-
-    use super::{
-        ApiClient, ConnectPrompter, CredentialFieldInfo, PromptInput, PromptOption,
-        connect_with_browser_opener_and_prompter,
-    };
-
-    struct MockPrompter {
-        selections: Vec<usize>,
-        inputs: Vec<String>,
-        seen_selects: Vec<(String, Vec<PromptOption>)>,
-        seen_inputs: Vec<PromptInput>,
-    }
-
-    impl MockPrompter {
-        fn new(selections: Vec<usize>, inputs: Vec<&str>) -> Self {
-            Self {
-                selections,
-                inputs: inputs.into_iter().map(str::to_string).collect(),
-                seen_selects: Vec::new(),
-                seen_inputs: Vec::new(),
-            }
-        }
-    }
-
-    impl ConnectPrompter for MockPrompter {
-        fn select(&mut self, prompt: &str, options: &[PromptOption]) -> Result<usize> {
-            self.seen_selects
-                .push((prompt.to_string(), options.to_vec()));
-            Ok(self.selections.remove(0))
-        }
-
-        fn input(&mut self, prompt: &PromptInput) -> Result<String> {
-            self.seen_inputs.push(prompt.clone());
-            Ok(self.inputs.remove(0))
-        }
-    }
-
-    fn create_client(server: &Server) -> ApiClient {
-        ApiClient::new(&server.url(), "test-token").unwrap()
-    }
-
-    #[test]
-    fn manual_connect_uses_prompted_credentials_and_connection_params() {
-        let mut server = Server::new();
-        let _integrations = server
-            .mock("GET", "/api/v1/integrations")
-            .match_header("Authorization", "Bearer test-token")
-            .with_status(200)
-            .with_header("Content-Type", "application/json")
-            .with_body(
-                r#"[{
-                    "name":"datadog",
-                    "display_name":"Datadog",
-                    "description":"Metrics and logs",
-                    "connected":false,
-                    "auth_types":["manual"],
-                    "connection_params":{"site":{"description":"Datadog site","default":"datadoghq.com","required":true}},
-                    "credential_fields":[{"name":"api_key","label":"API key","description":"Use a personal API key","help_url":"https://docs.example.com/datadog"}]
-                }]"#,
-            )
-            .create();
-        let _connect = server
-            .mock("POST", "/api/v1/auth/connect-manual")
-            .match_header("Authorization", "Bearer test-token")
-            .match_header("Content-Type", "application/json")
-            .match_body(Matcher::JsonString(
-                r#"{"connection_params":{"site":"datadoghq.eu"},"credential":"dd-key","integration":"datadog"}"#.to_string(),
-            ))
-            .with_status(200)
-            .with_header("Content-Type", "application/json")
-            .with_body(r#"{"status":"connected","integration":"datadog"}"#)
-            .create();
-
-        let client = create_client(&server);
-        let mut prompts = MockPrompter::new(vec![], vec!["datadoghq.eu", "dd-key"]);
-        let browser_used = std::cell::Cell::new(false);
-
-        let result = connect_with_browser_opener_and_prompter(
-            &client,
-            "datadog",
-            None,
-            None,
-            &mut prompts,
-            |_| {
-                browser_used.set(true);
-                Ok(())
-            },
-        );
-
-        assert!(result.is_ok());
-        assert!(!browser_used.get());
-        assert_eq!(
-            prompts.seen_inputs,
-            vec![
-                PromptInput {
-                    label: "Datadog site".to_string(),
-                    description: None,
-                    help_url: None,
-                    default: Some("datadoghq.com".to_string()),
-                    required: true,
-                    secret: false,
-                },
-                PromptInput {
-                    label: "API key".to_string(),
-                    description: Some("Use a personal API key".to_string()),
-                    help_url: Some("https://docs.example.com/datadog".to_string()),
-                    default: None,
-                    required: true,
-                    secret: true,
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn manual_connect_prompts_for_connection_and_finishes_candidate_selection() {
-        let mut server = Server::new();
-        let _integrations = server
-            .mock("GET", "/api/v1/integrations")
-            .match_header("Authorization", "Bearer test-token")
-            .with_status(200)
-            .with_header("Content-Type", "application/json")
-            .with_body(
-                r#"[{
-                    "name":"manual-svc",
-                    "display_name":"Manual Service",
-                    "connected":false,
-                    "connections":[
-                        {"name":"workspace","auth_types":["manual"],"credential_fields":[{"name":"token","label":"Workspace token"}]},
-                        {"name":"plugin","auth_types":["oauth"]}
-                    ]
-                }]"#,
-            )
-            .create();
-        let _connect = server
-            .mock("POST", "/api/v1/auth/connect-manual")
-            .match_header("Authorization", "Bearer test-token")
-            .match_header("Content-Type", "application/json")
-            .match_body(Matcher::JsonString(
-                r#"{"connection":"workspace","credential":"abc123","integration":"manual-svc"}"#
-                    .to_string(),
-            ))
-            .with_status(200)
-            .with_header("Content-Type", "application/json")
-            .with_body(
-                r#"{
-                    "status":"selection_required",
-                    "integration":"manual-svc",
-                    "selection_url":"/api/v1/auth/pending-connection",
-                    "pending_token":"pending-123",
-                    "candidates":[
-                        {"id":"site-a","name":"Site A"},
-                        {"id":"site-b","name":"Site B"}
-                    ]
-                }"#,
-            )
-            .create();
-        let _select = server
-            .mock("POST", "/api/v1/auth/pending-connection")
-            .match_header("Authorization", "Bearer test-token")
-            .match_header(
-                "content-type",
-                Matcher::Regex("application/x-www-form-urlencoded.*".to_string()),
-            )
-            .match_body(Matcher::Exact(
-                "pending_token=pending-123&candidate_index=1".to_string(),
-            ))
-            .with_status(200)
-            .with_header("Content-Type", "text/html")
-            .with_body("<html>ok</html>")
-            .create();
-
-        let client = create_client(&server);
-        let mut prompts = MockPrompter::new(vec![0, 1], vec!["abc123"]);
-
-        let result = connect_with_browser_opener_and_prompter(
-            &client,
-            "manual-svc",
-            None,
-            None,
-            &mut prompts,
-            |_| bail!("browser should not be used"),
-        );
-
-        assert!(result.is_ok());
-        assert_eq!(prompts.seen_selects.len(), 2);
-        assert_eq!(
-            prompts.seen_selects[0].0,
-            "Select a Manual Service connection:"
-        );
-        assert_eq!(
-            prompts.seen_selects[0].1,
-            vec![
-                PromptOption {
-                    label: "workspace".to_string(),
-                    detail: Some("Auth: manual".to_string()),
-                },
-                PromptOption {
-                    label: "plugin".to_string(),
-                    detail: Some("Auth: OAuth".to_string()),
-                },
-            ]
-        );
-        assert_eq!(
-            prompts.seen_inputs,
-            vec![PromptInput {
-                label: "Workspace token".to_string(),
-                description: None,
-                help_url: None,
-                default: None,
-                required: true,
-                secret: true,
-            }]
-        );
-    }
-
-    #[test]
-    fn oauth_connect_still_prefers_browser_flow() {
-        let mut server = Server::new();
-        let _integrations = server
-            .mock("GET", "/api/v1/integrations")
-            .match_header("Authorization", "Bearer test-token")
-            .with_status(200)
-            .with_header("Content-Type", "application/json")
-            .with_body(
-                r#"[{
-                    "name":"github",
-                    "display_name":"GitHub",
-                    "connected":false,
-                    "auth_types":["oauth","manual"],
-                    "credential_fields":[{"name":"token","label":"Token"}]
-                }]"#,
-            )
-            .create();
-        let _oauth = server
-            .mock("POST", "/api/v1/auth/start-oauth")
-            .match_header("Authorization", "Bearer test-token")
-            .match_header("Content-Type", "application/json")
-            .match_body(Matcher::JsonString(
-                r#"{"integration":"github"}"#.to_string(),
-            ))
-            .with_status(200)
-            .with_header("Content-Type", "application/json")
-            .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
-            .create();
-
-        let client = create_client(&server);
-        let mut prompts = MockPrompter::new(vec![], vec![]);
-        let opened = std::cell::Cell::new(String::new());
-
-        let result = connect_with_browser_opener_and_prompter(
-            &client,
-            "github",
-            None,
-            None,
-            &mut prompts,
-            |url| {
-                opened.set(url.to_string());
-                Ok(())
-            },
-        );
-
-        assert!(result.is_ok());
-        assert_eq!(opened.take(), "https://example.com/oauth");
-        assert!(prompts.seen_inputs.is_empty());
-        assert!(prompts.seen_selects.is_empty());
-    }
-
-    #[test]
-    fn prompt_manual_credentials_uses_generic_field_when_metadata_missing() {
-        let mut prompts = MockPrompter::new(vec![], vec!["secret"]);
-        let result = super::prompt_manual_credentials(&[], &mut prompts).unwrap();
-
-        assert_eq!(
-            prompts.seen_inputs,
-            vec![PromptInput {
-                label: "Credential".to_string(),
-                description: None,
-                help_url: None,
-                default: None,
-                required: true,
-                secret: true,
-            }]
-        );
-        match result {
-            super::ManualCredentialPayload::Single(value) => assert_eq!(value, "secret"),
-            super::ManualCredentialPayload::Multiple(_) => panic!("expected single credential"),
-        }
-        assert_eq!(
-            CredentialFieldInfo {
-                name: "token".to_string(),
-                label: Some("API token".to_string()),
-                description: None,
-                help_url: None,
-            }
-            .display_label(),
-            "API token"
-        );
     }
 }

--- a/gestalt/cli/src/commands/integrations.rs
+++ b/gestalt/cli/src/commands/integrations.rs
@@ -1,8 +1,14 @@
-use anyhow::{Context, Result};
-use serde::Serialize;
+use std::collections::BTreeMap;
+use std::io::{self, IsTerminal, Write};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
 
 use crate::api::ApiClient;
 use crate::output::{self, Format};
+
+const PLUGIN_CONNECTION_NAME: &str = "_plugin";
+const PLUGIN_CONNECTION_ALIAS: &str = "plugin";
 
 #[derive(Serialize)]
 struct StartOAuthRequest<'a> {
@@ -11,6 +17,230 @@ struct StartOAuthRequest<'a> {
     connection: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     instance: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct ConnectManualRequest<'a> {
+    integration: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    credential: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    credentials: Option<&'a BTreeMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    connection: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    instance: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    connection_params: Option<&'a BTreeMap<String, String>>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct IntegrationInfo {
+    name: String,
+    #[serde(default)]
+    display_name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    auth_types: Vec<String>,
+    #[serde(default)]
+    connection_params: BTreeMap<String, ConnectionParamDef>,
+    #[serde(default)]
+    connections: Vec<ConnectionDefInfo>,
+    #[serde(default)]
+    credential_fields: Vec<CredentialFieldInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct ConnectionDefInfo {
+    name: String,
+    #[serde(default)]
+    auth_types: Vec<String>,
+    #[serde(default)]
+    credential_fields: Vec<CredentialFieldInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct ConnectionParamDef {
+    #[serde(default)]
+    required: bool,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    default: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+struct CredentialFieldInfo {
+    name: String,
+    #[serde(default)]
+    label: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    help_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+struct DiscoveryCandidateInfo {
+    id: String,
+    #[serde(default)]
+    name: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct ConnectManualResponse {
+    status: String,
+    #[serde(default)]
+    integration: Option<String>,
+    #[serde(default)]
+    selection_url: Option<String>,
+    #[serde(default)]
+    pending_token: Option<String>,
+    #[serde(default)]
+    candidates: Vec<DiscoveryCandidateInfo>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PromptOption {
+    label: String,
+    detail: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PromptInput {
+    label: String,
+    description: Option<String>,
+    help_url: Option<String>,
+    default: Option<String>,
+    required: bool,
+    secret: bool,
+}
+
+trait ConnectPrompter {
+    fn select(&mut self, prompt: &str, options: &[PromptOption]) -> Result<usize>;
+    fn input(&mut self, prompt: &PromptInput) -> Result<String>;
+}
+
+struct StdioPrompter;
+
+impl StdioPrompter {
+    fn ensure_interactive(&self) -> Result<()> {
+        if !io::stdin().is_terminal() || !io::stderr().is_terminal() {
+            bail!(
+                "manual connections require an interactive terminal; rerun this command in a terminal session",
+            );
+        }
+        Ok(())
+    }
+
+    fn read_line(&self) -> Result<String> {
+        let mut input = String::new();
+        io::stdin()
+            .read_line(&mut input)
+            .context("failed to read terminal input")?;
+        Ok(input.trim().to_string())
+    }
+}
+
+impl ConnectPrompter for StdioPrompter {
+    fn select(&mut self, prompt: &str, options: &[PromptOption]) -> Result<usize> {
+        self.ensure_interactive()?;
+        if options.is_empty() {
+            bail!("no options available");
+        }
+
+        let mut stderr = io::stderr();
+        writeln!(stderr, "{prompt}")?;
+        for (idx, option) in options.iter().enumerate() {
+            writeln!(stderr, "  {}. {}", idx + 1, option.label)?;
+            if let Some(detail) = option.detail.as_deref() {
+                writeln!(stderr, "     {detail}")?;
+            }
+        }
+
+        loop {
+            write!(stderr, "Selection [1-{}]: ", options.len())?;
+            stderr.flush()?;
+            let input = self.read_line()?;
+
+            if let Ok(choice) = input.parse::<usize>()
+                && (1..=options.len()).contains(&choice)
+            {
+                return Ok(choice - 1);
+            }
+
+            writeln!(stderr, "Enter a number between 1 and {}.", options.len())?;
+        }
+    }
+
+    fn input(&mut self, prompt: &PromptInput) -> Result<String> {
+        self.ensure_interactive()?;
+
+        let mut stderr = io::stderr();
+        writeln!(stderr)?;
+        writeln!(stderr, "{}", prompt.label)?;
+        if let Some(description) = prompt.description.as_deref() {
+            writeln!(stderr, "  {description}")?;
+        }
+        if let Some(help_url) = prompt.help_url.as_deref() {
+            writeln!(stderr, "  Help: {help_url}")?;
+        }
+
+        loop {
+            let value = if prompt.secret {
+                let prompt_text = match prompt.default.as_deref() {
+                    Some(default) => format!("Value [{default}]: "),
+                    None => "Value: ".to_string(),
+                };
+                rpassword::prompt_password(prompt_text).context("failed to read secret input")?
+            } else {
+                match prompt.default.as_deref() {
+                    Some(default) => write!(stderr, "Value [{default}]: ")?,
+                    None => write!(stderr, "Value: ")?,
+                }
+                stderr.flush()?;
+                self.read_line()?
+            };
+
+            let trimmed = value.trim().to_string();
+            if trimmed.is_empty() {
+                if let Some(default) = prompt.default.clone() {
+                    return Ok(default);
+                }
+                if !prompt.required {
+                    return Ok(String::new());
+                }
+                writeln!(stderr, "A value is required.")?;
+                continue;
+            }
+
+            return Ok(trimmed);
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedAuthTarget {
+    auth_types: Vec<String>,
+    credential_fields: Vec<CredentialFieldInfo>,
+}
+
+impl ResolvedAuthTarget {
+    fn supports_oauth(&self) -> bool {
+        self.auth_types.iter().any(|auth_type| auth_type == "oauth")
+    }
+
+    fn supports_manual(&self) -> bool {
+        self.auth_types
+            .iter()
+            .any(|auth_type| auth_type == "manual")
+    }
+}
+
+enum ManualCredentialPayload {
+    Single(String),
+    Multiple(BTreeMap<String, String>),
 }
 
 pub fn list(client: &ApiClient, format: Format) -> Result<()> {
@@ -49,12 +279,83 @@ pub fn connect(
     connection: Option<&str>,
     instance: Option<&str>,
 ) -> Result<()> {
-    connect_with_browser_opener(client, name, connection, instance, |url| {
-        open::that(url).map(|_| ()).map_err(Into::into)
-    })
+    let mut prompts = StdioPrompter;
+    connect_with_browser_opener_and_prompter(
+        client,
+        name,
+        connection,
+        instance,
+        &mut prompts,
+        |url| open::that(url).map(|_| ()).map_err(Into::into),
+    )
 }
 
 pub fn connect_with_browser_opener<F>(
+    client: &ApiClient,
+    name: &str,
+    connection: Option<&str>,
+    instance: Option<&str>,
+    open_browser: F,
+) -> Result<()>
+where
+    F: FnOnce(&str) -> Result<()>,
+{
+    let mut prompts = StdioPrompter;
+    connect_with_browser_opener_and_prompter(
+        client,
+        name,
+        connection,
+        instance,
+        &mut prompts,
+        open_browser,
+    )
+}
+
+fn connect_with_browser_opener_and_prompter<P, F>(
+    client: &ApiClient,
+    name: &str,
+    connection: Option<&str>,
+    instance: Option<&str>,
+    prompts: &mut P,
+    open_browser: F,
+) -> Result<()>
+where
+    P: ConnectPrompter,
+    F: FnOnce(&str) -> Result<()>,
+{
+    let integration = fetch_integration(client, name)?;
+    let selected_connection = resolve_connection(&integration, connection, prompts)?;
+    let auth_target = resolve_auth_target(&integration, selected_connection.as_deref())?;
+
+    if auth_target.supports_oauth() {
+        return start_oauth(
+            client,
+            name,
+            selected_connection.as_deref(),
+            instance,
+            open_browser,
+        );
+    }
+
+    if auth_target.supports_manual() {
+        return connect_manual(
+            client,
+            &integration,
+            name,
+            selected_connection.as_deref(),
+            instance,
+            &auth_target,
+            prompts,
+        );
+    }
+
+    bail!(
+        "integration '{}' does not expose a supported connection flow in the CLI",
+        name
+    );
+}
+
+fn start_oauth<F>(
     client: &ApiClient,
     name: &str,
     connection: Option<&str>,
@@ -87,4 +388,674 @@ where
     }
 
     Ok(())
+}
+
+fn connect_manual<P>(
+    client: &ApiClient,
+    integration: &IntegrationInfo,
+    name: &str,
+    connection: Option<&str>,
+    instance: Option<&str>,
+    auth_target: &ResolvedAuthTarget,
+    prompts: &mut P,
+) -> Result<()>
+where
+    P: ConnectPrompter,
+{
+    let display_name = integration.display_name();
+    eprintln!("Connecting {display_name} with manual auth.");
+    if let Some(description) = non_empty(integration.description.as_deref()) {
+        eprintln!("{description}");
+    }
+    if let Some(connection_name) = connection {
+        eprintln!(
+            "Connection: {}",
+            user_facing_connection_name(connection_name)
+        );
+    }
+
+    let connection_params = prompt_connection_params(&integration.connection_params, prompts)?;
+    let credential_payload = prompt_manual_credentials(&auth_target.credential_fields, prompts)?;
+
+    let (credential, credentials) = match &credential_payload {
+        ManualCredentialPayload::Single(value) => (Some(value.as_str()), None),
+        ManualCredentialPayload::Multiple(values) => (None, Some(values)),
+    };
+
+    let resp = client
+        .post(
+            "/api/v1/auth/connect-manual",
+            &ConnectManualRequest {
+                integration: name,
+                credential,
+                credentials,
+                connection,
+                instance,
+                connection_params: connection_params.as_ref(),
+            },
+        )
+        .context("failed to connect integration")?;
+
+    let response: ConnectManualResponse =
+        serde_json::from_value(resp).context("failed to parse manual connect response")?;
+
+    match response.status.as_str() {
+        "connected" => {
+            let connected_name = response.integration.as_deref().unwrap_or(name);
+            output::print_success(&format!("Connected {}.", connected_name));
+            Ok(())
+        }
+        "selection_required" => complete_pending_selection(
+            client,
+            response.integration.as_deref().unwrap_or(name),
+            response.selection_url.as_deref(),
+            response.pending_token.as_deref(),
+            &response.candidates,
+            prompts,
+        ),
+        other => bail!("unexpected manual connect response status '{}'", other),
+    }
+}
+
+fn complete_pending_selection<P>(
+    client: &ApiClient,
+    integration: &str,
+    selection_url: Option<&str>,
+    pending_token: Option<&str>,
+    candidates: &[DiscoveryCandidateInfo],
+    prompts: &mut P,
+) -> Result<()>
+where
+    P: ConnectPrompter,
+{
+    let selection_url = selection_url.context("manual connect response missing selection_url")?;
+    let pending_token = pending_token.context("manual connect response missing pending_token")?;
+
+    if candidates.is_empty() {
+        bail!("manual connect response missing discovery candidates");
+    }
+
+    let selected = if candidates.len() == 1 {
+        0
+    } else {
+        let options: Vec<PromptOption> = candidates
+            .iter()
+            .map(|candidate| PromptOption {
+                label: candidate.display_name(),
+                detail: non_empty(Some(candidate.id.as_str())).map(str::to_string),
+            })
+            .collect();
+        prompts.select(
+            &format!(
+                "Gestalt found more than one {} connection. Choose one to save:",
+                integration
+            ),
+            &options,
+        )?
+    };
+
+    client
+        .post_form(
+            selection_url,
+            &[
+                ("pending_token", pending_token.to_string()),
+                ("candidate_index", selected.to_string()),
+            ],
+        )
+        .context("failed to finalize selected connection")?;
+
+    output::print_success(&format!(
+        "Connected {} ({})",
+        integration,
+        candidates[selected].display_name()
+    ));
+    Ok(())
+}
+
+fn fetch_integration(client: &ApiClient, name: &str) -> Result<IntegrationInfo> {
+    let resp = client
+        .get("/api/v1/integrations")
+        .context("failed to load integrations")?;
+    let integrations: Vec<IntegrationInfo> =
+        serde_json::from_value(resp).context("failed to parse integrations")?;
+
+    integrations
+        .into_iter()
+        .find(|integration| integration.name == name)
+        .with_context(|| format!("integration '{}' not found", name))
+}
+
+fn resolve_connection<P>(
+    integration: &IntegrationInfo,
+    requested_connection: Option<&str>,
+    prompts: &mut P,
+) -> Result<Option<String>>
+where
+    P: ConnectPrompter,
+{
+    if integration.connections.is_empty() {
+        return Ok(requested_connection.map(str::to_string));
+    }
+
+    if let Some(requested_connection) = requested_connection {
+        return integration
+            .connection_by_name(requested_connection)
+            .map(|connection| Some(connection.name.clone()))
+            .with_context(|| {
+                format!(
+                    "unknown connection '{}' for integration '{}'; available connections: {}",
+                    requested_connection,
+                    integration.name,
+                    integration.available_connections()
+                )
+            });
+    }
+
+    if integration.connections.len() == 1 {
+        return Ok(Some(integration.connections[0].name.clone()));
+    }
+
+    let options: Vec<PromptOption> = integration
+        .connections
+        .iter()
+        .map(|connection| PromptOption {
+            label: user_facing_connection_name(&connection.name).to_string(),
+            detail: Some(format!(
+                "Auth: {}",
+                format_auth_types(&connection.auth_types)
+            )),
+        })
+        .collect();
+    let idx = prompts.select(
+        &format!("Select a {} connection:", integration.display_name()),
+        &options,
+    )?;
+    Ok(Some(integration.connections[idx].name.clone()))
+}
+
+fn resolve_auth_target(
+    integration: &IntegrationInfo,
+    connection: Option<&str>,
+) -> Result<ResolvedAuthTarget> {
+    if let Some(connection) = connection {
+        if let Some(connection_info) = integration.connection_by_name(connection) {
+            let credential_fields = if connection_info.credential_fields.is_empty() {
+                integration.credential_fields.clone()
+            } else {
+                connection_info.credential_fields.clone()
+            };
+            return Ok(ResolvedAuthTarget {
+                auth_types: connection_info.auth_types.clone(),
+                credential_fields,
+            });
+        }
+    }
+
+    Ok(ResolvedAuthTarget {
+        auth_types: integration.auth_types.clone(),
+        credential_fields: integration.credential_fields.clone(),
+    })
+}
+
+fn prompt_connection_params<P>(
+    connection_params: &BTreeMap<String, ConnectionParamDef>,
+    prompts: &mut P,
+) -> Result<Option<BTreeMap<String, String>>>
+where
+    P: ConnectPrompter,
+{
+    if connection_params.is_empty() {
+        return Ok(None);
+    }
+
+    let mut values = BTreeMap::new();
+    for (name, def) in connection_params {
+        let value = prompts.input(&PromptInput {
+            label: non_empty(def.description.as_deref())
+                .unwrap_or(name)
+                .to_string(),
+            description: None,
+            help_url: None,
+            default: non_empty(def.default.as_deref()).map(str::to_string),
+            required: def.required,
+            secret: false,
+        })?;
+        if !value.is_empty() {
+            values.insert(name.clone(), value);
+        }
+    }
+
+    if values.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(values))
+    }
+}
+
+fn prompt_manual_credentials<P>(
+    fields: &[CredentialFieldInfo],
+    prompts: &mut P,
+) -> Result<ManualCredentialPayload>
+where
+    P: ConnectPrompter,
+{
+    let fields = if fields.is_empty() {
+        vec![CredentialFieldInfo {
+            name: "credential".to_string(),
+            label: Some("Credential".to_string()),
+            description: None,
+            help_url: None,
+        }]
+    } else {
+        fields.to_vec()
+    };
+
+    if fields.len() == 1 {
+        let field = &fields[0];
+        let value = prompts.input(&PromptInput {
+            label: field.display_label(),
+            description: non_empty(field.description.as_deref()).map(str::to_string),
+            help_url: non_empty(field.help_url.as_deref()).map(str::to_string),
+            default: None,
+            required: true,
+            secret: true,
+        })?;
+        return Ok(ManualCredentialPayload::Single(value));
+    }
+
+    let mut values = BTreeMap::new();
+    for field in &fields {
+        let value = prompts.input(&PromptInput {
+            label: field.display_label(),
+            description: non_empty(field.description.as_deref()).map(str::to_string),
+            help_url: non_empty(field.help_url.as_deref()).map(str::to_string),
+            default: None,
+            required: true,
+            secret: true,
+        })?;
+        values.insert(field.name.clone(), value);
+    }
+
+    Ok(ManualCredentialPayload::Multiple(values))
+}
+
+fn normalize_connection_name(name: &str) -> &str {
+    if name == PLUGIN_CONNECTION_ALIAS {
+        PLUGIN_CONNECTION_NAME
+    } else {
+        name
+    }
+}
+
+fn user_facing_connection_name(name: &str) -> &str {
+    if name == PLUGIN_CONNECTION_NAME {
+        PLUGIN_CONNECTION_ALIAS
+    } else {
+        name
+    }
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    })
+}
+
+fn format_auth_types(auth_types: &[String]) -> String {
+    let labels: Vec<&str> = auth_types
+        .iter()
+        .map(|auth_type| match auth_type.as_str() {
+            "oauth" => "OAuth",
+            "manual" => "manual",
+            _ => auth_type.as_str(),
+        })
+        .collect();
+    labels.join(" / ")
+}
+
+impl IntegrationInfo {
+    fn display_name(&self) -> &str {
+        non_empty(self.display_name.as_deref()).unwrap_or(&self.name)
+    }
+
+    fn connection_by_name(&self, name: &str) -> Option<&ConnectionDefInfo> {
+        let normalized = normalize_connection_name(name);
+        self.connections
+            .iter()
+            .find(|connection| normalize_connection_name(&connection.name) == normalized)
+    }
+
+    fn available_connections(&self) -> String {
+        self.connections
+            .iter()
+            .map(|connection| user_facing_connection_name(&connection.name).to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+impl CredentialFieldInfo {
+    fn display_label(&self) -> String {
+        non_empty(self.label.as_deref())
+            .unwrap_or(&self.name)
+            .to_string()
+    }
+}
+
+impl DiscoveryCandidateInfo {
+    fn display_name(&self) -> String {
+        non_empty(Some(self.name.as_str()))
+            .unwrap_or(&self.id)
+            .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::{Result, bail};
+    use mockito::{Matcher, Server};
+
+    use super::{
+        ApiClient, ConnectPrompter, CredentialFieldInfo, PromptInput, PromptOption,
+        connect_with_browser_opener_and_prompter,
+    };
+
+    struct MockPrompter {
+        selections: Vec<usize>,
+        inputs: Vec<String>,
+        seen_selects: Vec<(String, Vec<PromptOption>)>,
+        seen_inputs: Vec<PromptInput>,
+    }
+
+    impl MockPrompter {
+        fn new(selections: Vec<usize>, inputs: Vec<&str>) -> Self {
+            Self {
+                selections,
+                inputs: inputs.into_iter().map(str::to_string).collect(),
+                seen_selects: Vec::new(),
+                seen_inputs: Vec::new(),
+            }
+        }
+    }
+
+    impl ConnectPrompter for MockPrompter {
+        fn select(&mut self, prompt: &str, options: &[PromptOption]) -> Result<usize> {
+            self.seen_selects
+                .push((prompt.to_string(), options.to_vec()));
+            Ok(self.selections.remove(0))
+        }
+
+        fn input(&mut self, prompt: &PromptInput) -> Result<String> {
+            self.seen_inputs.push(prompt.clone());
+            Ok(self.inputs.remove(0))
+        }
+    }
+
+    fn create_client(server: &Server) -> ApiClient {
+        ApiClient::new(&server.url(), "test-token").unwrap()
+    }
+
+    #[test]
+    fn manual_connect_uses_prompted_credentials_and_connection_params() {
+        let mut server = Server::new();
+        let _integrations = server
+            .mock("GET", "/api/v1/integrations")
+            .match_header("Authorization", "Bearer test-token")
+            .with_status(200)
+            .with_header("Content-Type", "application/json")
+            .with_body(
+                r#"[{
+                    "name":"datadog",
+                    "display_name":"Datadog",
+                    "description":"Metrics and logs",
+                    "connected":false,
+                    "auth_types":["manual"],
+                    "connection_params":{"site":{"description":"Datadog site","default":"datadoghq.com","required":true}},
+                    "credential_fields":[{"name":"api_key","label":"API key","description":"Use a personal API key","help_url":"https://docs.example.com/datadog"}]
+                }]"#,
+            )
+            .create();
+        let _connect = server
+            .mock("POST", "/api/v1/auth/connect-manual")
+            .match_header("Authorization", "Bearer test-token")
+            .match_header("Content-Type", "application/json")
+            .match_body(Matcher::JsonString(
+                r#"{"connection_params":{"site":"datadoghq.eu"},"credential":"dd-key","integration":"datadog"}"#.to_string(),
+            ))
+            .with_status(200)
+            .with_header("Content-Type", "application/json")
+            .with_body(r#"{"status":"connected","integration":"datadog"}"#)
+            .create();
+
+        let client = create_client(&server);
+        let mut prompts = MockPrompter::new(vec![], vec!["datadoghq.eu", "dd-key"]);
+        let browser_used = std::cell::Cell::new(false);
+
+        let result = connect_with_browser_opener_and_prompter(
+            &client,
+            "datadog",
+            None,
+            None,
+            &mut prompts,
+            |_| {
+                browser_used.set(true);
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok());
+        assert!(!browser_used.get());
+        assert_eq!(
+            prompts.seen_inputs,
+            vec![
+                PromptInput {
+                    label: "Datadog site".to_string(),
+                    description: None,
+                    help_url: None,
+                    default: Some("datadoghq.com".to_string()),
+                    required: true,
+                    secret: false,
+                },
+                PromptInput {
+                    label: "API key".to_string(),
+                    description: Some("Use a personal API key".to_string()),
+                    help_url: Some("https://docs.example.com/datadog".to_string()),
+                    default: None,
+                    required: true,
+                    secret: true,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn manual_connect_prompts_for_connection_and_finishes_candidate_selection() {
+        let mut server = Server::new();
+        let _integrations = server
+            .mock("GET", "/api/v1/integrations")
+            .match_header("Authorization", "Bearer test-token")
+            .with_status(200)
+            .with_header("Content-Type", "application/json")
+            .with_body(
+                r#"[{
+                    "name":"manual-svc",
+                    "display_name":"Manual Service",
+                    "connected":false,
+                    "connections":[
+                        {"name":"workspace","auth_types":["manual"],"credential_fields":[{"name":"token","label":"Workspace token"}]},
+                        {"name":"plugin","auth_types":["oauth"]}
+                    ]
+                }]"#,
+            )
+            .create();
+        let _connect = server
+            .mock("POST", "/api/v1/auth/connect-manual")
+            .match_header("Authorization", "Bearer test-token")
+            .match_header("Content-Type", "application/json")
+            .match_body(Matcher::JsonString(
+                r#"{"connection":"workspace","credential":"abc123","integration":"manual-svc"}"#
+                    .to_string(),
+            ))
+            .with_status(200)
+            .with_header("Content-Type", "application/json")
+            .with_body(
+                r#"{
+                    "status":"selection_required",
+                    "integration":"manual-svc",
+                    "selection_url":"/api/v1/auth/pending-connection",
+                    "pending_token":"pending-123",
+                    "candidates":[
+                        {"id":"site-a","name":"Site A"},
+                        {"id":"site-b","name":"Site B"}
+                    ]
+                }"#,
+            )
+            .create();
+        let _select = server
+            .mock("POST", "/api/v1/auth/pending-connection")
+            .match_header("Authorization", "Bearer test-token")
+            .match_header(
+                "content-type",
+                Matcher::Regex("application/x-www-form-urlencoded.*".to_string()),
+            )
+            .match_body(Matcher::Exact(
+                "pending_token=pending-123&candidate_index=1".to_string(),
+            ))
+            .with_status(200)
+            .with_header("Content-Type", "text/html")
+            .with_body("<html>ok</html>")
+            .create();
+
+        let client = create_client(&server);
+        let mut prompts = MockPrompter::new(vec![0, 1], vec!["abc123"]);
+
+        let result = connect_with_browser_opener_and_prompter(
+            &client,
+            "manual-svc",
+            None,
+            None,
+            &mut prompts,
+            |_| bail!("browser should not be used"),
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(prompts.seen_selects.len(), 2);
+        assert_eq!(
+            prompts.seen_selects[0].0,
+            "Select a Manual Service connection:"
+        );
+        assert_eq!(
+            prompts.seen_selects[0].1,
+            vec![
+                PromptOption {
+                    label: "workspace".to_string(),
+                    detail: Some("Auth: manual".to_string()),
+                },
+                PromptOption {
+                    label: "plugin".to_string(),
+                    detail: Some("Auth: OAuth".to_string()),
+                },
+            ]
+        );
+        assert_eq!(
+            prompts.seen_inputs,
+            vec![PromptInput {
+                label: "Workspace token".to_string(),
+                description: None,
+                help_url: None,
+                default: None,
+                required: true,
+                secret: true,
+            }]
+        );
+    }
+
+    #[test]
+    fn oauth_connect_still_prefers_browser_flow() {
+        let mut server = Server::new();
+        let _integrations = server
+            .mock("GET", "/api/v1/integrations")
+            .match_header("Authorization", "Bearer test-token")
+            .with_status(200)
+            .with_header("Content-Type", "application/json")
+            .with_body(
+                r#"[{
+                    "name":"github",
+                    "display_name":"GitHub",
+                    "connected":false,
+                    "auth_types":["oauth","manual"],
+                    "credential_fields":[{"name":"token","label":"Token"}]
+                }]"#,
+            )
+            .create();
+        let _oauth = server
+            .mock("POST", "/api/v1/auth/start-oauth")
+            .match_header("Authorization", "Bearer test-token")
+            .match_header("Content-Type", "application/json")
+            .match_body(Matcher::JsonString(
+                r#"{"integration":"github"}"#.to_string(),
+            ))
+            .with_status(200)
+            .with_header("Content-Type", "application/json")
+            .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
+            .create();
+
+        let client = create_client(&server);
+        let mut prompts = MockPrompter::new(vec![], vec![]);
+        let opened = std::cell::Cell::new(String::new());
+
+        let result = connect_with_browser_opener_and_prompter(
+            &client,
+            "github",
+            None,
+            None,
+            &mut prompts,
+            |url| {
+                opened.set(url.to_string());
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(opened.take(), "https://example.com/oauth");
+        assert!(prompts.seen_inputs.is_empty());
+        assert!(prompts.seen_selects.is_empty());
+    }
+
+    #[test]
+    fn prompt_manual_credentials_uses_generic_field_when_metadata_missing() {
+        let mut prompts = MockPrompter::new(vec![], vec!["secret"]);
+        let result = super::prompt_manual_credentials(&[], &mut prompts).unwrap();
+
+        assert_eq!(
+            prompts.seen_inputs,
+            vec![PromptInput {
+                label: "Credential".to_string(),
+                description: None,
+                help_url: None,
+                default: None,
+                required: true,
+                secret: true,
+            }]
+        );
+        match result {
+            super::ManualCredentialPayload::Single(value) => assert_eq!(value, "secret"),
+            super::ManualCredentialPayload::Multiple(_) => panic!("expected single credential"),
+        }
+        assert_eq!(
+            CredentialFieldInfo {
+                name: "token".to_string(),
+                label: Some("API token".to_string()),
+                description: None,
+                help_url: None,
+            }
+            .display_label(),
+            "API token"
+        );
+    }
 }

--- a/gestalt/cli/src/commands/integrations.rs
+++ b/gestalt/cli/src/commands/integrations.rs
@@ -84,6 +84,8 @@ struct StartOAuthRequest<'a> {
     connection: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     instance: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    connection_params: Option<&'a BTreeMap<String, String>>,
 }
 
 #[derive(Serialize)]
@@ -180,11 +182,13 @@ where
     let auth_target = resolve_auth_target(&integration, selected_connection.as_deref());
 
     if auth_target.supports_oauth() {
+        let connection_params = prompt_connection_params(&integration)?;
         return start_oauth(
             client,
             name,
             selected_connection.as_deref(),
             instance,
+            connection_params.as_ref(),
             open_browser,
         );
     }
@@ -211,6 +215,7 @@ fn start_oauth<F>(
     name: &str,
     connection: Option<&str>,
     instance: Option<&str>,
+    connection_params: Option<&BTreeMap<String, String>>,
     open_browser: F,
 ) -> Result<()>
 where
@@ -223,6 +228,7 @@ where
                 integration: name,
                 connection,
                 instance,
+                connection_params,
             },
         )
         .context("failed to start OAuth flow")?;
@@ -421,7 +427,11 @@ fn resolve_auth_target(
         && let Some(connection_info) = integration.connection_by_name(connection)
     {
         return ResolvedAuthTarget {
-            auth_types: connection_info.auth_types.clone(),
+            auth_types: if connection_info.auth_types.is_empty() {
+                integration.auth_types.clone()
+            } else {
+                connection_info.auth_types.clone()
+            },
             credential_fields: if connection_info.credential_fields.is_empty() {
                 integration.credential_fields.clone()
             } else {

--- a/gestalt/cli/src/interactive.rs
+++ b/gestalt/cli/src/interactive.rs
@@ -1,0 +1,140 @@
+use std::io::{self, BufRead, IsTerminal, Write};
+
+use anyhow::{Context, Result, bail};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromptOption {
+    pub label: String,
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InputPrompt {
+    pub label: String,
+    pub description: Option<String>,
+    pub help_url: Option<String>,
+    pub default: Option<String>,
+    pub required: bool,
+    pub secret: bool,
+}
+
+pub trait Prompter {
+    fn select(&mut self, prompt: &str, options: &[PromptOption]) -> Result<usize>;
+    fn input(&mut self, prompt: &InputPrompt) -> Result<String>;
+    fn confirm(&mut self, question: &str, default: bool) -> Result<bool>;
+}
+
+pub struct StdioPrompter;
+
+impl StdioPrompter {
+    fn ensure_interactive(&self) -> Result<()> {
+        if !io::stdin().is_terminal() || !io::stderr().is_terminal() {
+            bail!("interactive prompts require a terminal session");
+        }
+        Ok(())
+    }
+
+    fn read_line(&self) -> Result<String> {
+        let stdin = io::stdin();
+        let mut lines = stdin.lock().lines();
+        Ok(lines
+            .next()
+            .unwrap_or(Ok(String::new()))
+            .context("failed to read input")?
+            .trim()
+            .to_string())
+    }
+}
+
+impl Prompter for StdioPrompter {
+    fn select(&mut self, prompt: &str, options: &[PromptOption]) -> Result<usize> {
+        self.ensure_interactive()?;
+        if options.is_empty() {
+            bail!("no options available");
+        }
+
+        let mut stderr = io::stderr();
+        writeln!(stderr, "{prompt}")?;
+        for (idx, option) in options.iter().enumerate() {
+            writeln!(stderr, "  {}. {}", idx + 1, option.label)?;
+            if let Some(detail) = option.detail.as_deref() {
+                writeln!(stderr, "     {detail}")?;
+            }
+        }
+
+        loop {
+            write!(stderr, "Selection [1-{}]: ", options.len())?;
+            stderr.flush()?;
+            let input = self.read_line()?;
+
+            if let Ok(choice) = input.parse::<usize>()
+                && (1..=options.len()).contains(&choice)
+            {
+                return Ok(choice - 1);
+            }
+
+            writeln!(stderr, "Enter a number between 1 and {}.", options.len())?;
+        }
+    }
+
+    fn input(&mut self, prompt: &InputPrompt) -> Result<String> {
+        self.ensure_interactive()?;
+
+        let mut stderr = io::stderr();
+        writeln!(stderr)?;
+        writeln!(stderr, "{}", prompt.label)?;
+        if let Some(description) = prompt.description.as_deref() {
+            writeln!(stderr, "  {description}")?;
+        }
+        if let Some(help_url) = prompt.help_url.as_deref() {
+            writeln!(stderr, "  Help: {help_url}")?;
+        }
+
+        loop {
+            let value = if prompt.secret {
+                let prompt_text = match prompt.default.as_deref() {
+                    Some(default) => format!("Value [{default}]: "),
+                    None => "Value: ".to_string(),
+                };
+                rpassword::prompt_password(prompt_text).context("failed to read secret input")?
+            } else {
+                match prompt.default.as_deref() {
+                    Some(default) => write!(stderr, "Value [{default}]: ")?,
+                    None => write!(stderr, "Value: ")?,
+                }
+                stderr.flush()?;
+                self.read_line()?
+            };
+
+            let trimmed = value.trim().to_string();
+            if trimmed.is_empty() {
+                if let Some(default) = prompt.default.clone() {
+                    return Ok(default);
+                }
+                if !prompt.required {
+                    return Ok(String::new());
+                }
+                writeln!(stderr, "A value is required.")?;
+                continue;
+            }
+
+            return Ok(trimmed);
+        }
+    }
+
+    fn confirm(&mut self, question: &str, default: bool) -> Result<bool> {
+        self.ensure_interactive()?;
+
+        let hint = if default { "Y/n" } else { "y/N" };
+        let mut stderr = io::stderr();
+        write!(stderr, "{} [{}]: ", question, hint)?;
+        stderr.flush()?;
+
+        let input = self.read_line()?.to_lowercase();
+        if input.is_empty() {
+            Ok(default)
+        } else {
+            Ok(input.starts_with('y'))
+        }
+    }
+}

--- a/gestalt/cli/src/interactive.rs
+++ b/gestalt/cli/src/interactive.rs
@@ -18,15 +18,15 @@ pub struct InputPrompt {
     pub secret: bool,
 }
 
-fn read_line() -> Result<String> {
+fn read_line() -> Result<Option<String>> {
     let stdin = io::stdin();
     let mut lines = stdin.lock().lines();
-    Ok(lines
-        .next()
-        .unwrap_or(Ok(String::new()))
-        .context("failed to read input")?
-        .trim()
-        .to_string())
+    match lines.next() {
+        Some(line) => Ok(Some(
+            line.context("failed to read input")?.trim().to_string(),
+        )),
+        None => Ok(None),
+    }
 }
 
 pub fn prompt_select(prompt: &str, options: &[PromptOption]) -> Result<usize> {
@@ -46,7 +46,7 @@ pub fn prompt_select(prompt: &str, options: &[PromptOption]) -> Result<usize> {
     loop {
         write!(stderr, "Selection [1-{}]: ", options.len())?;
         stderr.flush()?;
-        let input = read_line()?;
+        let input = read_line()?.context("stdin closed while waiting for selection")?;
 
         if let Ok(choice) = input.parse::<usize>()
             && (1..=options.len()).contains(&choice)
@@ -82,7 +82,7 @@ pub fn prompt_input(prompt: &InputPrompt) -> Result<String> {
                 None => write!(stderr, "Value: ")?,
             }
             stderr.flush()?;
-            read_line()?
+            read_line()?.context("stdin closed while waiting for input")?
         };
 
         let trimmed = value.trim().to_string();
@@ -107,7 +107,9 @@ pub fn prompt_confirm(question: &str, default: bool) -> Result<bool> {
     write!(stderr, "{} [{}]: ", question, hint)?;
     stderr.flush()?;
 
-    let input = read_line()?.to_lowercase();
+    let input = read_line()?
+        .context("stdin closed while waiting for confirmation")?
+        .to_lowercase();
     if input.is_empty() {
         Ok(default)
     } else {

--- a/gestalt/cli/src/interactive.rs
+++ b/gestalt/cli/src/interactive.rs
@@ -18,123 +18,99 @@ pub struct InputPrompt {
     pub secret: bool,
 }
 
-pub trait Prompter {
-    fn select(&mut self, prompt: &str, options: &[PromptOption]) -> Result<usize>;
-    fn input(&mut self, prompt: &InputPrompt) -> Result<String>;
-    fn confirm(&mut self, question: &str, default: bool) -> Result<bool>;
+fn read_line() -> Result<String> {
+    let stdin = io::stdin();
+    let mut lines = stdin.lock().lines();
+    Ok(lines
+        .next()
+        .unwrap_or(Ok(String::new()))
+        .context("failed to read input")?
+        .trim()
+        .to_string())
 }
 
-pub struct StdioPrompter;
-
-impl StdioPrompter {
-    fn ensure_interactive(&self) -> Result<()> {
-        if !io::stdin().is_terminal() || !io::stderr().is_terminal() {
-            bail!("interactive prompts require a terminal session");
-        }
-        Ok(())
+pub fn prompt_select(prompt: &str, options: &[PromptOption]) -> Result<usize> {
+    if options.is_empty() {
+        bail!("no options available");
     }
 
-    fn read_line(&self) -> Result<String> {
-        let stdin = io::stdin();
-        let mut lines = stdin.lock().lines();
-        Ok(lines
-            .next()
-            .unwrap_or(Ok(String::new()))
-            .context("failed to read input")?
-            .trim()
-            .to_string())
-    }
-}
-
-impl Prompter for StdioPrompter {
-    fn select(&mut self, prompt: &str, options: &[PromptOption]) -> Result<usize> {
-        self.ensure_interactive()?;
-        if options.is_empty() {
-            bail!("no options available");
-        }
-
-        let mut stderr = io::stderr();
-        writeln!(stderr, "{prompt}")?;
-        for (idx, option) in options.iter().enumerate() {
-            writeln!(stderr, "  {}. {}", idx + 1, option.label)?;
-            if let Some(detail) = option.detail.as_deref() {
-                writeln!(stderr, "     {detail}")?;
-            }
-        }
-
-        loop {
-            write!(stderr, "Selection [1-{}]: ", options.len())?;
-            stderr.flush()?;
-            let input = self.read_line()?;
-
-            if let Ok(choice) = input.parse::<usize>()
-                && (1..=options.len()).contains(&choice)
-            {
-                return Ok(choice - 1);
-            }
-
-            writeln!(stderr, "Enter a number between 1 and {}.", options.len())?;
+    let mut stderr = io::stderr();
+    writeln!(stderr, "{prompt}")?;
+    for (idx, option) in options.iter().enumerate() {
+        writeln!(stderr, "  {}. {}", idx + 1, option.label)?;
+        if let Some(detail) = option.detail.as_deref() {
+            writeln!(stderr, "     {detail}")?;
         }
     }
 
-    fn input(&mut self, prompt: &InputPrompt) -> Result<String> {
-        self.ensure_interactive()?;
-
-        let mut stderr = io::stderr();
-        writeln!(stderr)?;
-        writeln!(stderr, "{}", prompt.label)?;
-        if let Some(description) = prompt.description.as_deref() {
-            writeln!(stderr, "  {description}")?;
-        }
-        if let Some(help_url) = prompt.help_url.as_deref() {
-            writeln!(stderr, "  Help: {help_url}")?;
-        }
-
-        loop {
-            let value = if prompt.secret {
-                let prompt_text = match prompt.default.as_deref() {
-                    Some(default) => format!("Value [{default}]: "),
-                    None => "Value: ".to_string(),
-                };
-                rpassword::prompt_password(prompt_text).context("failed to read secret input")?
-            } else {
-                match prompt.default.as_deref() {
-                    Some(default) => write!(stderr, "Value [{default}]: ")?,
-                    None => write!(stderr, "Value: ")?,
-                }
-                stderr.flush()?;
-                self.read_line()?
-            };
-
-            let trimmed = value.trim().to_string();
-            if trimmed.is_empty() {
-                if let Some(default) = prompt.default.clone() {
-                    return Ok(default);
-                }
-                if !prompt.required {
-                    return Ok(String::new());
-                }
-                writeln!(stderr, "A value is required.")?;
-                continue;
-            }
-
-            return Ok(trimmed);
-        }
-    }
-
-    fn confirm(&mut self, question: &str, default: bool) -> Result<bool> {
-        self.ensure_interactive()?;
-
-        let hint = if default { "Y/n" } else { "y/N" };
-        let mut stderr = io::stderr();
-        write!(stderr, "{} [{}]: ", question, hint)?;
+    loop {
+        write!(stderr, "Selection [1-{}]: ", options.len())?;
         stderr.flush()?;
+        let input = read_line()?;
 
-        let input = self.read_line()?.to_lowercase();
-        if input.is_empty() {
-            Ok(default)
-        } else {
-            Ok(input.starts_with('y'))
+        if let Ok(choice) = input.parse::<usize>()
+            && (1..=options.len()).contains(&choice)
+        {
+            return Ok(choice - 1);
         }
+
+        writeln!(stderr, "Enter a number between 1 and {}.", options.len())?;
+    }
+}
+
+pub fn prompt_input(prompt: &InputPrompt) -> Result<String> {
+    let mut stderr = io::stderr();
+    writeln!(stderr)?;
+    writeln!(stderr, "{}", prompt.label)?;
+    if let Some(description) = prompt.description.as_deref() {
+        writeln!(stderr, "  {description}")?;
+    }
+    if let Some(help_url) = prompt.help_url.as_deref() {
+        writeln!(stderr, "  Help: {help_url}")?;
+    }
+
+    loop {
+        let value = if prompt.secret && io::stdin().is_terminal() && io::stderr().is_terminal() {
+            let prompt_text = match prompt.default.as_deref() {
+                Some(default) => format!("Value [{default}]: "),
+                None => "Value: ".to_string(),
+            };
+            rpassword::prompt_password(prompt_text).context("failed to read secret input")?
+        } else {
+            match prompt.default.as_deref() {
+                Some(default) => write!(stderr, "Value [{default}]: ")?,
+                None => write!(stderr, "Value: ")?,
+            }
+            stderr.flush()?;
+            read_line()?
+        };
+
+        let trimmed = value.trim().to_string();
+        if trimmed.is_empty() {
+            if let Some(default) = prompt.default.clone() {
+                return Ok(default);
+            }
+            if !prompt.required {
+                return Ok(String::new());
+            }
+            writeln!(stderr, "A value is required.")?;
+            continue;
+        }
+
+        return Ok(trimmed);
+    }
+}
+
+pub fn prompt_confirm(question: &str, default: bool) -> Result<bool> {
+    let hint = if default { "Y/n" } else { "y/N" };
+    let mut stderr = io::stderr();
+    write!(stderr, "{} [{}]: ", question, hint)?;
+    stderr.flush()?;
+
+    let input = read_line()?.to_lowercase();
+    if input.is_empty() {
+        Ok(default)
+    } else {
+        Ok(input.starts_with('y'))
     }
 }

--- a/gestalt/cli/src/lib.rs
+++ b/gestalt/cli/src/lib.rs
@@ -4,5 +4,6 @@ pub mod cli;
 pub mod commands;
 pub mod config;
 pub mod credentials;
+pub mod interactive;
 pub mod output;
 pub mod params;

--- a/gestalt/cli/tests/integration.rs
+++ b/gestalt/cli/tests/integration.rs
@@ -659,8 +659,9 @@ fn test_manual_connect_prompts_for_connection_and_finishes_candidate_selection()
             r#"[{
                 "name":"manual-svc",
                 "display_name":"Manual Service",
+                "auth_types":["manual"],
                 "connections":[
-                    {"name":"workspace","auth_types":["manual"],"credential_fields":[{"name":"token","label":"Workspace token"}]},
+                    {"name":"workspace","credential_fields":[{"name":"token","label":"Workspace token"}]},
                     {"name":"plugin","auth_types":["oauth"]}
                 ]
             }]"#,
@@ -733,6 +734,7 @@ fn test_oauth_connect_still_prefers_browser_flow_when_manual_also_exists() {
                 "name":"github",
                 "display_name":"GitHub",
                 "auth_types":["oauth","manual"],
+                "connection_params":{"site":{"description":"GitHub site","required":true}},
                 "credential_fields":[{"name":"token","label":"Token"}]
             }]"#,
         )
@@ -742,32 +744,51 @@ fn test_oauth_connect_still_prefers_browser_flow_when_manual_also_exists() {
         .match_header("Authorization", "Bearer test-token")
         .match_header("Content-Type", "application/json")
         .match_body(Matcher::JsonString(
-            r#"{"integration":"github"}"#.to_string(),
+            r#"{"connection_params":{"site":"github.valon.com"},"integration":"github"}"#
+                .to_string(),
         ))
         .with_status(200)
         .with_header("Content-Type", "application/json")
         .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
         .create();
 
-    let client = create_client(&server);
-    let opened = std::cell::RefCell::new(None::<String>);
+    let home = tempfile::tempdir().unwrap();
+    let browser_bin = tempfile::tempdir().unwrap();
+    for command in ["open", "xdg-open"] {
+        let path = browser_bin.path().join(command);
+        std::fs::write(&path, "#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
 
-    let result = gestalt::commands::integrations::connect_with_browser_opener(
-        &client,
-        "github",
-        None,
-        None,
-        |url| {
-            *opened.borrow_mut() = Some(url.to_string());
-            Ok(())
-        },
-    );
+            let mut perms = std::fs::metadata(&path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&path, perms).unwrap();
+        }
+    }
 
-    assert!(result.is_ok());
-    assert_eq!(
-        opened.into_inner().as_deref(),
-        Some("https://example.com/oauth")
-    );
+    let path = std::env::join_paths(
+        std::iter::once(browser_bin.path().to_path_buf()).chain(
+            std::env::var_os("PATH")
+                .into_iter()
+                .flat_map(|value| std::env::split_paths(&value).collect::<Vec<_>>()),
+        ),
+    )
+    .unwrap();
+
+    cli_command_for_server(home.path(), &server)
+        .env("PATH", path)
+        .args(["integrations", "connect", "github"])
+        .write_stdin("github.valon.com\n")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("GitHub site"))
+        .stderr(predicate::str::contains(
+            "Opening browser to connect github...",
+        ))
+        .stderr(predicate::str::contains(
+            "If the browser doesn't open, visit: https://example.com/oauth",
+        ));
 }
 
 #[test]

--- a/gestalt/cli/tests/integration.rs
+++ b/gestalt/cli/tests/integration.rs
@@ -4,7 +4,9 @@ use std::net::{TcpListener, TcpStream};
 use std::path::Path;
 use std::sync::{Arc, Mutex, OnceLock};
 
+use anyhow::{Result, bail};
 use assert_cmd::Command;
+use gestalt::interactive::{InputPrompt, PromptOption, Prompter};
 use gestalt::output::Format;
 use mockito::{Matcher, Server};
 use predicates::prelude::*;
@@ -213,6 +215,41 @@ fn run_cli(server: &Server, args: &[&str]) -> std::process::Output {
         .args(args)
         .output()
         .unwrap()
+}
+
+struct MockPrompter {
+    selections: Vec<usize>,
+    inputs: Vec<String>,
+    seen_selects: Vec<(String, Vec<PromptOption>)>,
+    seen_inputs: Vec<InputPrompt>,
+}
+
+impl MockPrompter {
+    fn new(selections: Vec<usize>, inputs: Vec<&str>) -> Self {
+        Self {
+            selections,
+            inputs: inputs.into_iter().map(str::to_string).collect(),
+            seen_selects: Vec::new(),
+            seen_inputs: Vec::new(),
+        }
+    }
+}
+
+impl Prompter for MockPrompter {
+    fn select(&mut self, prompt: &str, options: &[PromptOption]) -> Result<usize> {
+        self.seen_selects
+            .push((prompt.to_string(), options.to_vec()));
+        Ok(self.selections.remove(0))
+    }
+
+    fn input(&mut self, prompt: &InputPrompt) -> Result<String> {
+        self.seen_inputs.push(prompt.clone());
+        Ok(self.inputs.remove(0))
+    }
+
+    fn confirm(&mut self, _question: &str, _default: bool) -> Result<bool> {
+        bail!("confirm should not be called in integration connect tests")
+    }
 }
 
 #[test]
@@ -595,6 +632,280 @@ fn test_connect_omits_null_connection_and_instance() {
 
     mock.assert();
     assert!(result.is_ok());
+}
+
+#[test]
+fn test_manual_connect_uses_prompted_credentials_and_connection_params() {
+    let mut server = Server::new();
+    let _integrations = server
+        .mock("GET", "/api/v1/integrations")
+        .match_header("Authorization", "Bearer test-token")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(
+            r#"[{
+                "name":"datadog",
+                "display_name":"Datadog",
+                "description":"Metrics and logs",
+                "auth_types":["manual"],
+                "connection_params":{"site":{"description":"Datadog site","default":"datadoghq.com","required":true}},
+                "credential_fields":[{"name":"api_key","label":"API key","description":"Use a personal API key","help_url":"https://docs.example.com/datadog"}]
+            }]"#,
+        )
+        .create();
+    let _connect = server
+        .mock("POST", "/api/v1/auth/connect-manual")
+        .match_header("Authorization", "Bearer test-token")
+        .match_header("Content-Type", "application/json")
+        .match_body(Matcher::JsonString(
+            r#"{"connection_params":{"site":"datadoghq.eu"},"credential":"dd-key","integration":"datadog"}"#.to_string(),
+        ))
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(r#"{"status":"connected","integration":"datadog"}"#)
+        .create();
+
+    let client = create_client(&server);
+    let mut prompts = MockPrompter::new(vec![], vec!["datadoghq.eu", "dd-key"]);
+    let browser_used = std::cell::Cell::new(false);
+
+    let result = gestalt::commands::integrations::connect_with_browser_opener_and_prompter(
+        &client,
+        "datadog",
+        None,
+        None,
+        &mut prompts,
+        |_| {
+            browser_used.set(true);
+            Ok(())
+        },
+    );
+
+    assert!(result.is_ok());
+    assert!(!browser_used.get());
+    assert_eq!(
+        prompts.seen_inputs,
+        vec![
+            InputPrompt {
+                label: "Datadog site".to_string(),
+                description: None,
+                help_url: None,
+                default: Some("datadoghq.com".to_string()),
+                required: true,
+                secret: false,
+            },
+            InputPrompt {
+                label: "API key".to_string(),
+                description: Some("Use a personal API key".to_string()),
+                help_url: Some("https://docs.example.com/datadog".to_string()),
+                default: None,
+                required: true,
+                secret: true,
+            },
+        ]
+    );
+}
+
+#[test]
+fn test_manual_connect_prompts_for_connection_and_finishes_candidate_selection() {
+    let mut server = Server::new();
+    let _integrations = server
+        .mock("GET", "/api/v1/integrations")
+        .match_header("Authorization", "Bearer test-token")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(
+            r#"[{
+                "name":"manual-svc",
+                "display_name":"Manual Service",
+                "connections":[
+                    {"name":"workspace","auth_types":["manual"],"credential_fields":[{"name":"token","label":"Workspace token"}]},
+                    {"name":"plugin","auth_types":["oauth"]}
+                ]
+            }]"#,
+        )
+        .create();
+    let _connect = server
+        .mock("POST", "/api/v1/auth/connect-manual")
+        .match_header("Authorization", "Bearer test-token")
+        .match_header("Content-Type", "application/json")
+        .match_body(Matcher::JsonString(
+            r#"{"connection":"workspace","credential":"abc123","integration":"manual-svc"}"#
+                .to_string(),
+        ))
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(
+            r#"{
+                "status":"selection_required",
+                "integration":"manual-svc",
+                "selection_url":"/api/v1/auth/pending-connection",
+                "pending_token":"pending-123",
+                "candidates":[
+                    {"id":"site-a","name":"Site A"},
+                    {"id":"site-b","name":"Site B"}
+                ]
+            }"#,
+        )
+        .create();
+    let _select = server
+        .mock("POST", "/api/v1/auth/pending-connection")
+        .match_header("Authorization", "Bearer test-token")
+        .match_header(
+            "content-type",
+            Matcher::Regex("application/x-www-form-urlencoded.*".to_string()),
+        )
+        .match_body(Matcher::Exact(
+            "pending_token=pending-123&candidate_index=1".to_string(),
+        ))
+        .with_status(200)
+        .with_header("Content-Type", "text/html")
+        .with_body("<html>ok</html>")
+        .create();
+
+    let client = create_client(&server);
+    let mut prompts = MockPrompter::new(vec![0, 1], vec!["abc123"]);
+
+    let result = gestalt::commands::integrations::connect_with_browser_opener_and_prompter(
+        &client,
+        "manual-svc",
+        None,
+        None,
+        &mut prompts,
+        |_| bail!("browser should not be used"),
+    );
+
+    assert!(result.is_ok());
+    assert_eq!(prompts.seen_selects.len(), 2);
+    assert_eq!(
+        prompts.seen_selects[0],
+        (
+            "Select a Manual Service connection:".to_string(),
+            vec![
+                PromptOption {
+                    label: "workspace".to_string(),
+                    detail: Some("Auth: manual".to_string()),
+                },
+                PromptOption {
+                    label: "plugin".to_string(),
+                    detail: Some("Auth: OAuth".to_string()),
+                },
+            ]
+        )
+    );
+    assert_eq!(
+        prompts.seen_inputs,
+        vec![InputPrompt {
+            label: "Workspace token".to_string(),
+            description: None,
+            help_url: None,
+            default: None,
+            required: true,
+            secret: true,
+        }]
+    );
+}
+
+#[test]
+fn test_oauth_connect_still_prefers_browser_flow_when_manual_also_exists() {
+    let mut server = Server::new();
+    let _integrations = server
+        .mock("GET", "/api/v1/integrations")
+        .match_header("Authorization", "Bearer test-token")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(
+            r#"[{
+                "name":"github",
+                "display_name":"GitHub",
+                "auth_types":["oauth","manual"],
+                "credential_fields":[{"name":"token","label":"Token"}]
+            }]"#,
+        )
+        .create();
+    let _oauth = server
+        .mock("POST", "/api/v1/auth/start-oauth")
+        .match_header("Authorization", "Bearer test-token")
+        .match_header("Content-Type", "application/json")
+        .match_body(Matcher::JsonString(
+            r#"{"integration":"github"}"#.to_string(),
+        ))
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
+        .create();
+
+    let client = create_client(&server);
+    let mut prompts = MockPrompter::new(vec![], vec![]);
+    let opened = std::cell::RefCell::new(None::<String>);
+
+    let result = gestalt::commands::integrations::connect_with_browser_opener_and_prompter(
+        &client,
+        "github",
+        None,
+        None,
+        &mut prompts,
+        |url| {
+            *opened.borrow_mut() = Some(url.to_string());
+            Ok(())
+        },
+    );
+
+    assert!(result.is_ok());
+    assert_eq!(
+        opened.into_inner().as_deref(),
+        Some("https://example.com/oauth")
+    );
+    assert!(prompts.seen_inputs.is_empty());
+    assert!(prompts.seen_selects.is_empty());
+}
+
+#[test]
+fn test_manual_connect_falls_back_to_generic_credential_prompt() {
+    let mut server = Server::new();
+    let _integrations = server
+        .mock("GET", "/api/v1/integrations")
+        .match_header("Authorization", "Bearer test-token")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(r#"[{"name":"manual-svc","auth_types":["manual"]}]"#)
+        .create();
+    let _connect = server
+        .mock("POST", "/api/v1/auth/connect-manual")
+        .match_header("Authorization", "Bearer test-token")
+        .match_header("Content-Type", "application/json")
+        .match_body(Matcher::JsonString(
+            r#"{"credential":"secret","integration":"manual-svc"}"#.to_string(),
+        ))
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(r#"{"status":"connected","integration":"manual-svc"}"#)
+        .create();
+
+    let client = create_client(&server);
+    let mut prompts = MockPrompter::new(vec![], vec!["secret"]);
+
+    let result = gestalt::commands::integrations::connect_with_browser_opener_and_prompter(
+        &client,
+        "manual-svc",
+        None,
+        None,
+        &mut prompts,
+        |_| bail!("browser should not be used"),
+    );
+
+    assert!(result.is_ok());
+    assert_eq!(
+        prompts.seen_inputs,
+        vec![InputPrompt {
+            label: "Credential".to_string(),
+            description: None,
+            help_url: None,
+            default: None,
+            required: true,
+            secret: true,
+        }]
+    );
 }
 
 fn catalog_body() -> &'static str {

--- a/gestalt/cli/tests/integration.rs
+++ b/gestalt/cli/tests/integration.rs
@@ -4,9 +4,7 @@ use std::net::{TcpListener, TcpStream};
 use std::path::Path;
 use std::sync::{Arc, Mutex, OnceLock};
 
-use anyhow::{Result, bail};
 use assert_cmd::Command;
-use gestalt::interactive::{InputPrompt, PromptOption, Prompter};
 use gestalt::output::Format;
 use mockito::{Matcher, Server};
 use predicates::prelude::*;
@@ -217,39 +215,12 @@ fn run_cli(server: &Server, args: &[&str]) -> std::process::Output {
         .unwrap()
 }
 
-struct MockPrompter {
-    selections: Vec<usize>,
-    inputs: Vec<String>,
-    seen_selects: Vec<(String, Vec<PromptOption>)>,
-    seen_inputs: Vec<InputPrompt>,
-}
-
-impl MockPrompter {
-    fn new(selections: Vec<usize>, inputs: Vec<&str>) -> Self {
-        Self {
-            selections,
-            inputs: inputs.into_iter().map(str::to_string).collect(),
-            seen_selects: Vec::new(),
-            seen_inputs: Vec::new(),
-        }
-    }
-}
-
-impl Prompter for MockPrompter {
-    fn select(&mut self, prompt: &str, options: &[PromptOption]) -> Result<usize> {
-        self.seen_selects
-            .push((prompt.to_string(), options.to_vec()));
-        Ok(self.selections.remove(0))
-    }
-
-    fn input(&mut self, prompt: &InputPrompt) -> Result<String> {
-        self.seen_inputs.push(prompt.clone());
-        Ok(self.inputs.remove(0))
-    }
-
-    fn confirm(&mut self, _question: &str, _default: bool) -> Result<bool> {
-        bail!("confirm should not be called in integration connect tests")
-    }
+fn cli_command_for_server(home: &Path, server: &Server) -> Command {
+    let mut cmd = cli_command(home);
+    cmd.env("GESTALT_API_KEY", "test-token")
+        .arg("--url")
+        .arg(server.url());
+    cmd
 }
 
 #[test]
@@ -665,45 +636,15 @@ fn test_manual_connect_uses_prompted_credentials_and_connection_params() {
         .with_body(r#"{"status":"connected","integration":"datadog"}"#)
         .create();
 
-    let client = create_client(&server);
-    let mut prompts = MockPrompter::new(vec![], vec!["datadoghq.eu", "dd-key"]);
-    let browser_used = std::cell::Cell::new(false);
-
-    let result = gestalt::commands::integrations::connect_with_browser_opener_and_prompter(
-        &client,
-        "datadog",
-        None,
-        None,
-        &mut prompts,
-        |_| {
-            browser_used.set(true);
-            Ok(())
-        },
-    );
-
-    assert!(result.is_ok());
-    assert!(!browser_used.get());
-    assert_eq!(
-        prompts.seen_inputs,
-        vec![
-            InputPrompt {
-                label: "Datadog site".to_string(),
-                description: None,
-                help_url: None,
-                default: Some("datadoghq.com".to_string()),
-                required: true,
-                secret: false,
-            },
-            InputPrompt {
-                label: "API key".to_string(),
-                description: Some("Use a personal API key".to_string()),
-                help_url: Some("https://docs.example.com/datadog".to_string()),
-                default: None,
-                required: true,
-                secret: true,
-            },
-        ]
-    );
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["integrations", "connect", "datadog"])
+        .write_stdin("datadoghq.eu\ndd-key\n")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Datadog site"))
+        .stderr(predicate::str::contains("API key"))
+        .stderr(predicate::str::contains("Connected datadog."));
 }
 
 #[test]
@@ -763,47 +704,20 @@ fn test_manual_connect_prompts_for_connection_and_finishes_candidate_selection()
         .with_body("<html>ok</html>")
         .create();
 
-    let client = create_client(&server);
-    let mut prompts = MockPrompter::new(vec![0, 1], vec!["abc123"]);
-
-    let result = gestalt::commands::integrations::connect_with_browser_opener_and_prompter(
-        &client,
-        "manual-svc",
-        None,
-        None,
-        &mut prompts,
-        |_| bail!("browser should not be used"),
-    );
-
-    assert!(result.is_ok());
-    assert_eq!(prompts.seen_selects.len(), 2);
-    assert_eq!(
-        prompts.seen_selects[0],
-        (
-            "Select a Manual Service connection:".to_string(),
-            vec![
-                PromptOption {
-                    label: "workspace".to_string(),
-                    detail: Some("Auth: manual".to_string()),
-                },
-                PromptOption {
-                    label: "plugin".to_string(),
-                    detail: Some("Auth: OAuth".to_string()),
-                },
-            ]
-        )
-    );
-    assert_eq!(
-        prompts.seen_inputs,
-        vec![InputPrompt {
-            label: "Workspace token".to_string(),
-            description: None,
-            help_url: None,
-            default: None,
-            required: true,
-            secret: true,
-        }]
-    );
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["integrations", "connect", "manual-svc"])
+        .write_stdin("1\nabc123\n2\n")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Select a Manual Service connection:",
+        ))
+        .stderr(predicate::str::contains("Workspace token"))
+        .stderr(predicate::str::contains(
+            "Gestalt found more than one manual-svc connection. Choose one to save:",
+        ))
+        .stderr(predicate::str::contains("Connected manual-svc (Site B)"));
 }
 
 #[test]
@@ -836,15 +750,13 @@ fn test_oauth_connect_still_prefers_browser_flow_when_manual_also_exists() {
         .create();
 
     let client = create_client(&server);
-    let mut prompts = MockPrompter::new(vec![], vec![]);
     let opened = std::cell::RefCell::new(None::<String>);
 
-    let result = gestalt::commands::integrations::connect_with_browser_opener_and_prompter(
+    let result = gestalt::commands::integrations::connect_with_browser_opener(
         &client,
         "github",
         None,
         None,
-        &mut prompts,
         |url| {
             *opened.borrow_mut() = Some(url.to_string());
             Ok(())
@@ -856,8 +768,6 @@ fn test_oauth_connect_still_prefers_browser_flow_when_manual_also_exists() {
         opened.into_inner().as_deref(),
         Some("https://example.com/oauth")
     );
-    assert!(prompts.seen_inputs.is_empty());
-    assert!(prompts.seen_selects.is_empty());
 }
 
 #[test]
@@ -882,30 +792,14 @@ fn test_manual_connect_falls_back_to_generic_credential_prompt() {
         .with_body(r#"{"status":"connected","integration":"manual-svc"}"#)
         .create();
 
-    let client = create_client(&server);
-    let mut prompts = MockPrompter::new(vec![], vec!["secret"]);
-
-    let result = gestalt::commands::integrations::connect_with_browser_opener_and_prompter(
-        &client,
-        "manual-svc",
-        None,
-        None,
-        &mut prompts,
-        |_| bail!("browser should not be used"),
-    );
-
-    assert!(result.is_ok());
-    assert_eq!(
-        prompts.seen_inputs,
-        vec![InputPrompt {
-            label: "Credential".to_string(),
-            description: None,
-            help_url: None,
-            default: None,
-            required: true,
-            secret: true,
-        }]
-    );
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["integrations", "connect", "manual-svc"])
+        .write_stdin("secret\n")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("\nCredential\n"))
+        .stderr(predicate::str::contains("Connected manual-svc."));
 }
 
 fn catalog_body() -> &'static str {

--- a/gestalt/cli/tests/integration.rs
+++ b/gestalt/cli/tests/integration.rs
@@ -802,6 +802,28 @@ fn test_manual_connect_falls_back_to_generic_credential_prompt() {
         .stderr(predicate::str::contains("Connected manual-svc."));
 }
 
+#[test]
+fn test_manual_connect_fails_when_stdin_closes_during_prompt() {
+    let mut server = Server::new();
+    let _integrations = server
+        .mock("GET", "/api/v1/integrations")
+        .match_header("Authorization", "Bearer test-token")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(r#"[{"name":"manual-svc","auth_types":["manual"]}]"#)
+        .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["integrations", "connect", "manual-svc"])
+        .write_stdin("")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "stdin closed while waiting for input",
+        ));
+}
+
 fn catalog_body() -> &'static str {
     r#"[{
         "id": "do_thing",

--- a/gestalt/cli/tests/integration.rs
+++ b/gestalt/cli/tests/integration.rs
@@ -530,6 +530,13 @@ fn test_auth_login_stores_credentials_and_serves_styled_browser_page() {
 #[test]
 fn test_connect_includes_connection_and_instance() {
     let mut server = Server::new();
+    let _integrations = server
+        .mock("GET", "/api/v1/integrations")
+        .match_header("Authorization", "Bearer test-token")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(r#"[{"name":"github","auth_types":["oauth"],"connected":false}]"#)
+        .create();
     let mock = server
         .mock("POST", "/api/v1/auth/start-oauth")
         .match_header("Authorization", "Bearer test-token")
@@ -558,6 +565,13 @@ fn test_connect_includes_connection_and_instance() {
 #[test]
 fn test_connect_omits_null_connection_and_instance() {
     let mut server = Server::new();
+    let _integrations = server
+        .mock("GET", "/api/v1/integrations")
+        .match_header("Authorization", "Bearer test-token")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(r#"[{"name":"github","auth_types":["oauth"],"connected":false}]"#)
+        .create();
     let mock = server
         .mock("POST", "/api/v1/auth/start-oauth")
         .match_header("Authorization", "Bearer test-token")

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -1640,10 +1640,16 @@ type tokenMaterial struct {
 }
 
 type postConnectResult struct {
-	Status       string `json:"status"`
-	Integration  string `json:"integration,omitempty"`
-	SelectionURL string `json:"selection_url,omitempty"`
-	PendingToken string `json:"pending_token,omitempty"`
+	Status       string                   `json:"status"`
+	Integration  string                   `json:"integration,omitempty"`
+	SelectionURL string                   `json:"selection_url,omitempty"`
+	PendingToken string                   `json:"pending_token,omitempty"`
+	Candidates   []discoveryCandidateInfo `json:"candidates,omitempty"`
+}
+
+type discoveryCandidateInfo struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
 }
 
 func (s *Server) storeTokenFromMaterial(ctx context.Context, tm tokenMaterial) (*core.IntegrationToken, error) {
@@ -1731,6 +1737,7 @@ func (s *Server) runPostConnect(ctx context.Context, prov core.Provider, tm toke
 				Integration:  tm.Integration,
 				SelectionURL: pendingConnectionPath,
 				PendingToken: pendingToken,
+				Candidates:   discoveryCandidateInfos(candidates),
 			}, nil
 		}
 	}
@@ -1739,4 +1746,18 @@ func (s *Server) runPostConnect(ctx context.Context, prov core.Provider, tm toke
 		return nil, err
 	}
 	return &postConnectResult{Status: "connected", Integration: tm.Integration}, nil
+}
+
+func discoveryCandidateInfos(candidates []core.DiscoveryCandidate) []discoveryCandidateInfo {
+	if len(candidates) == 0 {
+		return nil
+	}
+	out := make([]discoveryCandidateInfo, len(candidates))
+	for i, candidate := range candidates {
+		out[i] = discoveryCandidateInfo{
+			ID:   candidate.ID,
+			Name: candidate.Name,
+		}
+	}
+	return out
 }

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -4613,8 +4613,13 @@ func TestConnectManual(t *testing.T) {
 
 		var connectResult struct {
 			Status       string `json:"status"`
+			Integration  string `json:"integration"`
 			SelectionURL string `json:"selection_url"`
 			PendingToken string `json:"pending_token"`
+			Candidates   []struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"candidates"`
 		}
 		if err := json.NewDecoder(connectResp.Body).Decode(&connectResult); err != nil {
 			t.Fatalf("decode connect result: %v", err)
@@ -4622,11 +4627,20 @@ func TestConnectManual(t *testing.T) {
 		if connectResult.Status != "selection_required" {
 			t.Fatalf("expected selection_required, got %q", connectResult.Status)
 		}
+		if connectResult.Integration != "manual-svc" {
+			t.Fatalf("expected integration %q, got %q", "manual-svc", connectResult.Integration)
+		}
 		if connectResult.SelectionURL != pendingSelectionPath {
 			t.Fatalf("expected selection URL %q, got %q", pendingSelectionPath, connectResult.SelectionURL)
 		}
 		if connectResult.PendingToken == "" {
 			t.Fatal("expected pending token")
+		}
+		if len(connectResult.Candidates) != 2 {
+			t.Fatalf("expected 2 candidates, got %d", len(connectResult.Candidates))
+		}
+		if connectResult.Candidates[0].Name != "Site A" || connectResult.Candidates[1].ID != "site-b" {
+			t.Fatalf("unexpected candidates: %+v", connectResult.Candidates)
 		}
 		if stored != nil {
 			t.Fatal("did not expect final token to be stored before selection")

--- a/gestaltd/ui/src/lib/api.ts
+++ b/gestaltd/ui/src/lib/api.ts
@@ -57,6 +57,7 @@ export interface ConnectIntegrationResult {
   integration?: string;
   selection_url?: string;
   pending_token?: string;
+  candidates?: { id: string; name?: string }[];
 }
 
 export class APIError extends Error {


### PR DESCRIPTION
## Summary
- add metadata-aware `gestalt integrations connect` behavior so the CLI can choose OAuth when available and fall back to interactive manual auth when it is not
- prompt for connection selection, manual credential fields, connection params, and follow-up discovery candidate selection using the same server metadata the web UI already consumes
- return discovery candidates from the post-connect server response so non-web clients can finish manual connection setup without bouncing through HTML
- update CLI docs and tests for the new manual-connect flow

## Why
`gestalt integrations connect` always posted to `start-oauth`, which meant non-OAuth integrations like manual Datadog setups had no usable CLI path. Even when manual auth succeeded server-side, discovery-based follow-up selection was only exposed through the web selection page.

## Impact
Manual-only integrations can now be connected end-to-end from the Rust CLI, while existing OAuth flows keep their current browser behavior.

## Validation
- `cargo test --manifest-path gestalt/Cargo.toml -p gestalt`
- `go test ./internal/server -run 'TestConnectManual|TestConnectManual_OAuthProviderRejected|TestConnectManual_MissingFields|TestConnectManual_UnknownIntegration|TestConnectManual_MultiCredential'`
- `go test ./internal/server -run TestCustomAuthMetrics`

Note: `go test ./internal/server` still shows an existing order-dependent failure in `TestCustomAuthMetrics`, but that test passes in isolation and is outside this change.