### PR TITLE
[codex] Add Dependabot coverage for Go and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,31 @@ updates:
       interval: weekly
     commit-message:
       prefix: build
+
+  - package-ecosystem: gomod
+    directory: /gestaltd
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: build
+
+  - package-ecosystem: gomod
+    directory: /sdk/go
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: build
+
+  - package-ecosystem: npm
+    directory: /gestaltd/ui
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: build
+
+  - package-ecosystem: npm
+    directory: /docs
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: build


### PR DESCRIPTION
## Summary
- add weekly Dependabot coverage for Go modules in `/gestaltd` and `/sdk/go`
- add weekly Dependabot coverage for npm packages in `/gestaltd/ui` and `/docs`
- keep the existing `build` commit-message prefix so dependency PRs stay consistent with current Docker updates

## Why
Docker base image updates were already configured, but application dependencies in the Go and npm workspaces were not. This leaves module and package vulnerabilities undiscovered unless someone checks them manually.

## Validation
- parsed `.github/dependabot.yml` with Ruby YAML loader
