### PR TITLE
Add time controls to admin metrics charts

### DIFF
--- a/docs/pages/reference/observability.mdx
+++ b/docs/pages/reference/observability.mdx
@@ -209,9 +209,9 @@ metrics, and exporter metadata described above.
 The admin UI intentionally stays basic:
 
 - summary cards and lightweight charts derived from `/metrics`
-- browser-local chart history with selectable time windows up to 24 hours
+- in-browser time-window and refresh controls for the current page session
 - adjustable browser refresh cadence, including pause
-- no shared history across browsers or replicas
+- no persisted history across page reloads
 - no cross-replica aggregation
 
 It is designed for built-in operator visibility, not as a replacement for a

--- a/docs/pages/reference/observability.mdx
+++ b/docs/pages/reference/observability.mdx
@@ -209,9 +209,9 @@ metrics, and exporter metadata described above.
 The admin UI intentionally stays basic:
 
 - summary cards and lightweight charts derived from `/metrics`
-- raw Prometheus text available in-page for inspection
-- periodic browser refreshes
-- no persisted history
+- browser-local chart history with selectable time windows up to 24 hours
+- adjustable browser refresh cadence, including pause
+- no shared history across browsers or replicas
 - no cross-replica aggregation
 
 It is designed for built-in operator visibility, not as a replacement for a

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -328,6 +328,15 @@ func TestE2EInitServeLockedOTLPExportsTracesAndMetricsButKeepsLogsOnStdout(t *te
 		if !bytes.Contains(adminBody, []byte("Top providers")) {
 			t.Fatalf("expected graph sections in embedded admin UI: %s", adminBody)
 		}
+		if !bytes.Contains(adminBody, []byte("Time window")) {
+			t.Fatalf("expected chart controls in embedded admin UI: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("Refresh cadence")) {
+			t.Fatalf("expected refresh controls in embedded admin UI: %s", adminBody)
+		}
+		if bytes.Contains(adminBody, []byte("Raw Prometheus output")) {
+			t.Fatalf("did not expect raw prometheus section in embedded admin UI: %s", adminBody)
+		}
 		if !bytes.Contains(adminBody, []byte("echarts.simple.min.js")) {
 			t.Fatalf("expected admin ui to include echarts asset: %s", adminBody)
 		}
@@ -426,6 +435,15 @@ func TestE2EInitServeLockedStdoutExposesPrometheusAndEmbeddedAdminUIByDefault(t 
 		}
 		if !bytes.Contains(adminBody, []byte("Top providers")) {
 			t.Fatalf("expected provider chart section in embedded admin UI: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("Time window")) {
+			t.Fatalf("expected chart controls in embedded admin UI: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("Refresh cadence")) {
+			t.Fatalf("expected refresh controls in embedded admin UI: %s", adminBody)
+		}
+		if bytes.Contains(adminBody, []byte("Raw Prometheus output")) {
+			t.Fatalf("did not expect raw prometheus section in embedded admin UI: %s", adminBody)
 		}
 		if !bytes.Contains(adminBody, []byte("echarts.simple.min.js")) {
 			t.Fatalf("expected admin ui to include echarts asset: %s", adminBody)

--- a/gestaltd/internal/adminui/out/index.html
+++ b/gestaltd/internal/adminui/out/index.html
@@ -158,34 +158,12 @@
         gap: 8px;
       }
 
-      .chip-row {
-        display: flex;
-        gap: 8px;
-        flex-wrap: wrap;
-      }
-
-      .control-chip,
       .control-select {
         border: 1px solid hsl(var(--border) / 1);
         border-radius: 999px;
         background: color-mix(in srgb, hsl(var(--surface-raised)) 48%, white);
         color: hsl(var(--foreground) / 1);
         font: inherit;
-      }
-
-      .control-chip {
-        cursor: pointer;
-        padding: 8px 12px;
-        transition:
-          background-color 140ms ease,
-          border-color 140ms ease,
-          color 140ms ease;
-      }
-
-      .control-chip.is-active {
-        border-color: transparent;
-        background: color-mix(in srgb, var(--brand) 82%, black);
-        color: white;
       }
 
       .control-select {
@@ -343,16 +321,16 @@
 
       <section class="card controls">
         <div class="control-cluster">
-          <div class="control-group">
+          <label class="control-group" for="time-window-select">
             <span class="label-text">Time window</span>
-            <div class="chip-row" id="time-window-controls">
-              <button class="control-chip" type="button" data-window-key="15m">15 min</button>
-              <button class="control-chip" type="button" data-window-key="1h">1 hour</button>
-              <button class="control-chip" type="button" data-window-key="6h">6 hours</button>
-              <button class="control-chip" type="button" data-window-key="24h">24 hours</button>
-              <button class="control-chip" type="button" data-window-key="all">All</button>
-            </div>
-          </div>
+            <select class="control-select" id="time-window-select">
+              <option value="15m">15 min</option>
+              <option value="1h">1 hour</option>
+              <option value="6h">6 hours</option>
+              <option value="24h">24 hours</option>
+              <option value="all">All</option>
+            </select>
+          </label>
 
           <label class="control-group" for="refresh-interval-select">
             <span class="label-text">Refresh cadence</span>
@@ -365,7 +343,10 @@
           </label>
         </div>
 
-        <p class="metric-note controls-note" id="history-note">Loading chart controls...</p>
+        <p class="metric-note controls-note">
+          Filters the browser's current chart history from authenticated
+          <code>/metrics</code> scrapes. Provider totals stay cumulative.
+        </p>
       </section>
 
       <section class="panel-grid">
@@ -375,7 +356,7 @@
           <div class="chart" id="activity-chart" data-chart-state="empty"></div>
           <p class="metric-note chart-caption">
             Derived from consecutive authenticated <code>/metrics</code> scrapes
-            stored locally in this browser.
+            captured in this browser session.
           </p>
         </article>
 
@@ -407,54 +388,44 @@
           /^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{[^}]*\})?\s+([+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?|NaN|[+-]?Inf)$/;
         const DEFAULT_REFRESH_INTERVAL_MS = 15000;
         const HISTORY_RETENTION_MS = 24 * 60 * 60 * 1000;
-        const HISTORY_STORAGE_KEY = "gestalt_admin_metrics_history_v1";
-        const PREFERENCES_STORAGE_KEY = "gestalt_admin_metrics_preferences_v1";
         const TIME_WINDOWS = [
           {
             key: "15m",
             label: "15 min",
-            noteLabel: "the last 15 minutes",
             ms: 15 * 60 * 1000,
           },
           {
             key: "1h",
             label: "1 hour",
-            noteLabel: "the last hour",
             ms: 60 * 60 * 1000,
           },
           {
             key: "6h",
             label: "6 hours",
-            noteLabel: "the last 6 hours",
             ms: 6 * 60 * 60 * 1000,
           },
           {
             key: "24h",
             label: "24 hours",
-            noteLabel: "the last 24 hours",
             ms: 24 * 60 * 60 * 1000,
           },
           {
             key: "all",
             label: "All",
-            noteLabel: "all retained local history",
             ms: null,
           },
         ];
         const REFRESH_OPTIONS = [
-          { value: 15000, label: "15 seconds", noteLabel: "15 seconds" },
-          { value: 30000, label: "30 seconds", noteLabel: "30 seconds" },
-          { value: 60000, label: "1 minute", noteLabel: "1 minute" },
-          { value: 0, label: "Paused", noteLabel: "paused" },
+          { value: 15000, label: "15 seconds" },
+          { value: 30000, label: "30 seconds" },
+          { value: 60000, label: "1 minute" },
+          { value: 0, label: "Paused" },
         ];
         const charts = {};
-        const history = loadHistory();
-        const storedPreferences = loadPreferences();
+        const history = [];
         let latestSnapshot = null;
-        let selectedWindowKey = normalizeWindowKey(storedPreferences.windowKey);
-        let refreshIntervalMs = normalizeRefreshIntervalMs(
-          storedPreferences.refreshIntervalMs,
-        );
+        let selectedWindowKey = "1h";
+        let refreshIntervalMs = DEFAULT_REFRESH_INTERVAL_MS;
         let refreshTimer = null;
 
         function byId(id) {
@@ -494,90 +465,6 @@
             : "--";
         }
 
-        function sanitizeMetricValue(value) {
-          if (value == null) return null;
-          const numeric = Number(value);
-          return Number.isFinite(numeric) ? numeric : null;
-        }
-
-        function normalizeHistoryEntry(entry) {
-          if (!entry || typeof entry !== "object") return null;
-          const timestamp = Number(entry.timestamp);
-          if (!Number.isFinite(timestamp)) return null;
-
-          return {
-            timestamp,
-            requests: Number.isFinite(Number(entry.requests)) ? Number(entry.requests) : 0,
-            errors: Number.isFinite(Number(entry.errors)) ? Number(entry.errors) : 0,
-            avgLatencyMs: sanitizeMetricValue(entry.avgLatencyMs),
-            p95LatencyMs: sanitizeMetricValue(entry.p95LatencyMs),
-            requestsTotal: Number.isFinite(Number(entry.requestsTotal))
-              ? Number(entry.requestsTotal)
-              : 0,
-            errorsTotal: Number.isFinite(Number(entry.errorsTotal))
-              ? Number(entry.errorsTotal)
-              : 0,
-          };
-        }
-
-        function pruneHistoryEntries(entries) {
-          const cutoff = Date.now() - HISTORY_RETENTION_MS;
-          return entries
-            .filter(function (entry) {
-              return entry && entry.timestamp >= cutoff;
-            })
-            .sort(function (left, right) {
-              return left.timestamp - right.timestamp;
-            });
-        }
-
-        function loadHistory() {
-          try {
-            const raw = window.localStorage.getItem(HISTORY_STORAGE_KEY);
-            if (!raw) return [];
-            const parsed = JSON.parse(raw);
-            if (!Array.isArray(parsed)) return [];
-            return pruneHistoryEntries(
-              parsed
-                .map(function (entry) {
-                  return normalizeHistoryEntry(entry);
-                })
-                .filter(Boolean),
-            );
-          } catch {
-            return [];
-          }
-        }
-
-        function persistHistory() {
-          try {
-            window.localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(history));
-          } catch {}
-        }
-
-        function loadPreferences() {
-          try {
-            const raw = window.localStorage.getItem(PREFERENCES_STORAGE_KEY);
-            if (!raw) return {};
-            const parsed = JSON.parse(raw);
-            return parsed && typeof parsed === "object" ? parsed : {};
-          } catch {
-            return {};
-          }
-        }
-
-        function persistPreferences() {
-          try {
-            window.localStorage.setItem(
-              PREFERENCES_STORAGE_KEY,
-              JSON.stringify({
-                windowKey: selectedWindowKey,
-                refreshIntervalMs,
-              }),
-            );
-          } catch {}
-        }
-
         function normalizeWindowKey(key) {
           return TIME_WINDOWS.some(function (windowOption) {
             return windowOption.key === key;
@@ -603,29 +490,9 @@
           );
         }
 
-        function selectedRefreshOption() {
-          return (
-            REFRESH_OPTIONS.find(function (option) {
-              return option.value === refreshIntervalMs;
-            }) || REFRESH_OPTIONS[0]
-          );
-        }
-
-        function updateHistoryNote() {
-          byId("history-note").textContent =
-            `Activity and latency charts use ${selectedWindow().noteLabel} stored locally ` +
-            `in this browser for up to 24 hours. Provider totals stay cumulative. ` +
-            `Refresh cadence: ${selectedRefreshOption().noteLabel}.`;
-        }
-
         function syncControlState() {
-          document.querySelectorAll("[data-window-key]").forEach(function (button) {
-            const isActive = button.getAttribute("data-window-key") === selectedWindowKey;
-            button.classList.toggle("is-active", isActive);
-            button.setAttribute("aria-pressed", isActive ? "true" : "false");
-          });
+          byId("time-window-select").value = selectedWindowKey;
           byId("refresh-interval-select").value = String(refreshIntervalMs);
-          updateHistoryNote();
         }
 
         function scheduleRefreshTimer() {
@@ -639,18 +506,16 @@
         }
 
         function bindControls() {
-          document.querySelectorAll("[data-window-key]").forEach(function (button) {
-            button.addEventListener("click", function () {
-              const nextKey = button.getAttribute("data-window-key") || "";
-              const normalized = normalizeWindowKey(nextKey);
-              if (normalized === selectedWindowKey) return;
-              selectedWindowKey = normalized;
-              persistPreferences();
-              syncControlState();
-              if (latestSnapshot) {
-                renderCharts(latestSnapshot);
-              }
-            });
+          byId("time-window-select").addEventListener("change", function (event) {
+            const target = event.target;
+            if (!target || typeof target.value !== "string") return;
+            const nextKey = normalizeWindowKey(target.value);
+            if (nextKey === selectedWindowKey) return;
+            selectedWindowKey = nextKey;
+            syncControlState();
+            if (latestSnapshot) {
+              renderCharts(latestSnapshot);
+            }
           });
 
           byId("refresh-interval-select").addEventListener("change", function (event) {
@@ -659,7 +524,6 @@
             const nextValue = normalizeRefreshIntervalMs(target.value);
             if (nextValue === refreshIntervalMs) return;
             refreshIntervalMs = nextValue;
-            persistPreferences();
             syncControlState();
             scheduleRefreshTimer();
             if (refreshIntervalMs > 0) {
@@ -897,7 +761,6 @@
           while (history.length > 0 && history[0].timestamp < cutoff) {
             history.shift();
           }
-          persistHistory();
         }
 
         function visibleHistory() {
@@ -1129,10 +992,7 @@
             byId("summary-avg-latency").textContent = formatDuration(snapshot.avgLatencySeconds);
             byId("summary-p95-latency").textContent = formatDuration(snapshot.p95LatencySeconds);
             renderCharts(snapshot);
-            setStatus(
-              `Last refreshed ${new Date().toLocaleTimeString()} · window ${selectedWindow().label}`,
-              "ok",
-            );
+            setStatus(`Last refreshed ${new Date().toLocaleTimeString()}`, "ok");
           } catch (error) {
             const message =
               error instanceof Error ? error.message : "Failed to load Prometheus metrics";

--- a/gestaltd/internal/adminui/out/index.html
+++ b/gestaltd/internal/adminui/out/index.html
@@ -70,8 +70,7 @@
       }
 
       .card,
-      .status,
-      details {
+      .status {
         border: 1px solid hsl(var(--border) / 1);
         border-radius: 12px;
         background: color-mix(in srgb, hsl(var(--surface)) 90%, white);
@@ -81,7 +80,7 @@
       .summary-card,
       .panel-card,
       .status,
-      summary {
+      .controls {
         padding: 20px;
       }
 
@@ -136,6 +135,67 @@
 
       .panel-wide {
         grid-column: 1 / -1;
+      }
+
+      .controls {
+        display: flex;
+        align-items: end;
+        justify-content: space-between;
+        gap: 16px;
+        flex-wrap: wrap;
+        margin-top: 20px;
+      }
+
+      .control-cluster {
+        display: flex;
+        align-items: end;
+        gap: 16px;
+        flex-wrap: wrap;
+      }
+
+      .control-group {
+        display: grid;
+        gap: 8px;
+      }
+
+      .chip-row {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      .control-chip,
+      .control-select {
+        border: 1px solid hsl(var(--border) / 1);
+        border-radius: 999px;
+        background: color-mix(in srgb, hsl(var(--surface-raised)) 48%, white);
+        color: hsl(var(--foreground) / 1);
+        font: inherit;
+      }
+
+      .control-chip {
+        cursor: pointer;
+        padding: 8px 12px;
+        transition:
+          background-color 140ms ease,
+          border-color 140ms ease,
+          color 140ms ease;
+      }
+
+      .control-chip.is-active {
+        border-color: transparent;
+        background: color-mix(in srgb, var(--brand) 82%, black);
+        color: white;
+      }
+
+      .control-select {
+        min-width: 136px;
+        padding: 8px 12px;
+      }
+
+      .controls-note {
+        margin-top: 0;
+        max-width: 380px;
       }
 
       .metric-value {
@@ -205,21 +265,6 @@
         background: linear-gradient(90deg, var(--brand) 0%, var(--brand-soft) 100%);
       }
 
-      summary {
-        cursor: pointer;
-        font-weight: 600;
-      }
-
-      pre {
-        margin: 0;
-        padding: 0 20px 20px;
-        overflow: auto;
-        white-space: pre-wrap;
-        word-break: break-word;
-        color: rgba(var(--alpha-dark), 0.6);
-        font: 0.84rem/1.5 ui-monospace, monospace;
-      }
-
       @media (max-width: 900px) {
         .summary-grid,
         .panel-grid {
@@ -234,6 +279,11 @@
 
         main {
           padding: 28px 0 40px;
+        }
+
+        .controls,
+        .control-cluster {
+          align-items: stretch;
         }
 
         .summary-grid,
@@ -261,7 +311,8 @@
         <p>
           The embedded admin UI reuses the client workspace theme and derives a
           few lightweight views directly from the authenticated
-          <code>/metrics</code> scrape.
+          <code>/metrics</code> scrape, with browser-local chart history for
+          quick operator debugging.
         </p>
       </section>
 
@@ -290,13 +341,41 @@
         </article>
       </section>
 
+      <section class="card controls">
+        <div class="control-cluster">
+          <div class="control-group">
+            <span class="label-text">Time window</span>
+            <div class="chip-row" id="time-window-controls">
+              <button class="control-chip" type="button" data-window-key="15m">15 min</button>
+              <button class="control-chip" type="button" data-window-key="1h">1 hour</button>
+              <button class="control-chip" type="button" data-window-key="6h">6 hours</button>
+              <button class="control-chip" type="button" data-window-key="24h">24 hours</button>
+              <button class="control-chip" type="button" data-window-key="all">All</button>
+            </div>
+          </div>
+
+          <label class="control-group" for="refresh-interval-select">
+            <span class="label-text">Refresh cadence</span>
+            <select class="control-select" id="refresh-interval-select">
+              <option value="15000">15 seconds</option>
+              <option value="30000">30 seconds</option>
+              <option value="60000">1 minute</option>
+              <option value="0">Paused</option>
+            </select>
+          </label>
+        </div>
+
+        <p class="metric-note controls-note" id="history-note">Loading chart controls...</p>
+      </section>
+
       <section class="panel-grid">
         <article class="card panel-card">
           <span class="label-text">Recent activity</span>
           <h2>Requests and failures</h2>
           <div class="chart" id="activity-chart" data-chart-state="empty"></div>
           <p class="metric-note chart-caption">
-            Derived from consecutive authenticated <code>/metrics</code> scrapes.
+            Derived from consecutive authenticated <code>/metrics</code> scrapes
+            stored locally in this browser.
           </p>
         </article>
 
@@ -314,12 +393,11 @@
           <h2>Top providers</h2>
           <div class="chart" id="provider-chart" data-chart-state="empty"></div>
           <div class="bar-list" id="provider-bars"></div>
+          <p class="metric-note chart-caption">
+            Based on the latest authenticated <code>/metrics</code> scrape for
+            this process.
+          </p>
         </article>
-
-        <details class="card panel-wide">
-          <summary>Raw Prometheus output</summary>
-          <pre id="metrics-output">Loading metrics...</pre>
-        </details>
       </section>
     </main>
     <script src="./echarts.simple.min.js"></script>
@@ -327,11 +405,57 @@
       (function () {
         const METRIC_LINE =
           /^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{[^}]*\})?\s+([+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?|NaN|[+-]?Inf)$/;
-        const REFRESH_INTERVAL_MS = 15000;
-        const HISTORY_LIMIT = Math.ceil((60 * 60 * 1000) / REFRESH_INTERVAL_MS);
+        const DEFAULT_REFRESH_INTERVAL_MS = 15000;
+        const HISTORY_RETENTION_MS = 24 * 60 * 60 * 1000;
+        const HISTORY_STORAGE_KEY = "gestalt_admin_metrics_history_v1";
+        const PREFERENCES_STORAGE_KEY = "gestalt_admin_metrics_preferences_v1";
+        const TIME_WINDOWS = [
+          {
+            key: "15m",
+            label: "15 min",
+            noteLabel: "the last 15 minutes",
+            ms: 15 * 60 * 1000,
+          },
+          {
+            key: "1h",
+            label: "1 hour",
+            noteLabel: "the last hour",
+            ms: 60 * 60 * 1000,
+          },
+          {
+            key: "6h",
+            label: "6 hours",
+            noteLabel: "the last 6 hours",
+            ms: 6 * 60 * 60 * 1000,
+          },
+          {
+            key: "24h",
+            label: "24 hours",
+            noteLabel: "the last 24 hours",
+            ms: 24 * 60 * 60 * 1000,
+          },
+          {
+            key: "all",
+            label: "All",
+            noteLabel: "all retained local history",
+            ms: null,
+          },
+        ];
+        const REFRESH_OPTIONS = [
+          { value: 15000, label: "15 seconds", noteLabel: "15 seconds" },
+          { value: 30000, label: "30 seconds", noteLabel: "30 seconds" },
+          { value: 60000, label: "1 minute", noteLabel: "1 minute" },
+          { value: 0, label: "Paused", noteLabel: "paused" },
+        ];
         const charts = {};
-        const history = [];
+        const history = loadHistory();
+        const storedPreferences = loadPreferences();
         let latestSnapshot = null;
+        let selectedWindowKey = normalizeWindowKey(storedPreferences.windowKey);
+        let refreshIntervalMs = normalizeRefreshIntervalMs(
+          storedPreferences.refreshIntervalMs,
+        );
+        let refreshTimer = null;
 
         function byId(id) {
           return document.getElementById(id);
@@ -368,6 +492,182 @@
           return Number.isFinite(value)
             ? `${value.toFixed(value >= 100 ? 0 : 1)} ms`
             : "--";
+        }
+
+        function sanitizeMetricValue(value) {
+          if (value == null) return null;
+          const numeric = Number(value);
+          return Number.isFinite(numeric) ? numeric : null;
+        }
+
+        function normalizeHistoryEntry(entry) {
+          if (!entry || typeof entry !== "object") return null;
+          const timestamp = Number(entry.timestamp);
+          if (!Number.isFinite(timestamp)) return null;
+
+          return {
+            timestamp,
+            requests: Number.isFinite(Number(entry.requests)) ? Number(entry.requests) : 0,
+            errors: Number.isFinite(Number(entry.errors)) ? Number(entry.errors) : 0,
+            avgLatencyMs: sanitizeMetricValue(entry.avgLatencyMs),
+            p95LatencyMs: sanitizeMetricValue(entry.p95LatencyMs),
+            requestsTotal: Number.isFinite(Number(entry.requestsTotal))
+              ? Number(entry.requestsTotal)
+              : 0,
+            errorsTotal: Number.isFinite(Number(entry.errorsTotal))
+              ? Number(entry.errorsTotal)
+              : 0,
+          };
+        }
+
+        function pruneHistoryEntries(entries) {
+          const cutoff = Date.now() - HISTORY_RETENTION_MS;
+          return entries
+            .filter(function (entry) {
+              return entry && entry.timestamp >= cutoff;
+            })
+            .sort(function (left, right) {
+              return left.timestamp - right.timestamp;
+            });
+        }
+
+        function loadHistory() {
+          try {
+            const raw = window.localStorage.getItem(HISTORY_STORAGE_KEY);
+            if (!raw) return [];
+            const parsed = JSON.parse(raw);
+            if (!Array.isArray(parsed)) return [];
+            return pruneHistoryEntries(
+              parsed
+                .map(function (entry) {
+                  return normalizeHistoryEntry(entry);
+                })
+                .filter(Boolean),
+            );
+          } catch {
+            return [];
+          }
+        }
+
+        function persistHistory() {
+          try {
+            window.localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(history));
+          } catch {}
+        }
+
+        function loadPreferences() {
+          try {
+            const raw = window.localStorage.getItem(PREFERENCES_STORAGE_KEY);
+            if (!raw) return {};
+            const parsed = JSON.parse(raw);
+            return parsed && typeof parsed === "object" ? parsed : {};
+          } catch {
+            return {};
+          }
+        }
+
+        function persistPreferences() {
+          try {
+            window.localStorage.setItem(
+              PREFERENCES_STORAGE_KEY,
+              JSON.stringify({
+                windowKey: selectedWindowKey,
+                refreshIntervalMs,
+              }),
+            );
+          } catch {}
+        }
+
+        function normalizeWindowKey(key) {
+          return TIME_WINDOWS.some(function (windowOption) {
+            return windowOption.key === key;
+          })
+            ? key
+            : "1h";
+        }
+
+        function normalizeRefreshIntervalMs(value) {
+          const numeric = Number(value);
+          return REFRESH_OPTIONS.some(function (option) {
+            return option.value === numeric;
+          })
+            ? numeric
+            : DEFAULT_REFRESH_INTERVAL_MS;
+        }
+
+        function selectedWindow() {
+          return (
+            TIME_WINDOWS.find(function (windowOption) {
+              return windowOption.key === selectedWindowKey;
+            }) || TIME_WINDOWS[1]
+          );
+        }
+
+        function selectedRefreshOption() {
+          return (
+            REFRESH_OPTIONS.find(function (option) {
+              return option.value === refreshIntervalMs;
+            }) || REFRESH_OPTIONS[0]
+          );
+        }
+
+        function updateHistoryNote() {
+          byId("history-note").textContent =
+            `Activity and latency charts use ${selectedWindow().noteLabel} stored locally ` +
+            `in this browser for up to 24 hours. Provider totals stay cumulative. ` +
+            `Refresh cadence: ${selectedRefreshOption().noteLabel}.`;
+        }
+
+        function syncControlState() {
+          document.querySelectorAll("[data-window-key]").forEach(function (button) {
+            const isActive = button.getAttribute("data-window-key") === selectedWindowKey;
+            button.classList.toggle("is-active", isActive);
+            button.setAttribute("aria-pressed", isActive ? "true" : "false");
+          });
+          byId("refresh-interval-select").value = String(refreshIntervalMs);
+          updateHistoryNote();
+        }
+
+        function scheduleRefreshTimer() {
+          if (refreshTimer) {
+            window.clearInterval(refreshTimer);
+            refreshTimer = null;
+          }
+          if (refreshIntervalMs > 0) {
+            refreshTimer = window.setInterval(refresh, refreshIntervalMs);
+          }
+        }
+
+        function bindControls() {
+          document.querySelectorAll("[data-window-key]").forEach(function (button) {
+            button.addEventListener("click", function () {
+              const nextKey = button.getAttribute("data-window-key") || "";
+              const normalized = normalizeWindowKey(nextKey);
+              if (normalized === selectedWindowKey) return;
+              selectedWindowKey = normalized;
+              persistPreferences();
+              syncControlState();
+              if (latestSnapshot) {
+                renderCharts(latestSnapshot);
+              }
+            });
+          });
+
+          byId("refresh-interval-select").addEventListener("change", function (event) {
+            const target = event.target;
+            if (!target || typeof target.value !== "string") return;
+            const nextValue = normalizeRefreshIntervalMs(target.value);
+            if (nextValue === refreshIntervalMs) return;
+            refreshIntervalMs = nextValue;
+            persistPreferences();
+            syncControlState();
+            scheduleRefreshTimer();
+            if (refreshIntervalMs > 0) {
+              refresh();
+            }
+          });
+
+          syncControlState();
         }
 
         function parseLabels(raw) {
@@ -593,12 +893,25 @@
             errorsTotal: snapshot.errors,
           });
 
-          while (history.length > HISTORY_LIMIT) {
+          const cutoff = now - HISTORY_RETENTION_MS;
+          while (history.length > 0 && history[0].timestamp < cutoff) {
             history.shift();
           }
+          persistHistory();
         }
 
-        function lineSeries(name, key, extra) {
+        function visibleHistory() {
+          if (history.length === 0) return [];
+          const windowOption = selectedWindow();
+          if (windowOption.ms == null) return history.slice();
+          const latestTimestamp = history[history.length - 1].timestamp;
+          const cutoff = latestTimestamp - windowOption.ms;
+          return history.filter(function (entry) {
+            return entry.timestamp >= cutoff;
+          });
+        }
+
+        function lineSeries(entries, name, key, extra) {
           return Object.assign(
             {
               name,
@@ -606,7 +919,7 @@
               smooth: true,
               showSymbol: false,
               lineStyle: { width: 2 },
-              data: history.map(function (entry) {
+              data: entries.map(function (entry) {
                 return [entry.timestamp, entry[key]];
               }),
             },
@@ -614,7 +927,12 @@
           );
         }
 
-        function renderTimeChart(id, series, colors, formatter) {
+        function renderTimeChart(id, entries, series, colors, formatter) {
+          if (entries.length === 0) {
+            setChartMessage(id, "No local history is available for the selected window yet.");
+            return;
+          }
+
           const chart = ensureChart(id);
           if (!chart) return;
 
@@ -747,11 +1065,15 @@
         }
 
         function renderCharts(snapshot) {
+          const windowedHistory = visibleHistory();
           renderTimeChart(
             "activity-chart",
+            windowedHistory,
             [
-              lineSeries("Requests/min", "requests", { areaStyle: { opacity: 0.12 } }),
-              lineSeries("Errors/min", "errors"),
+              lineSeries(windowedHistory, "Requests/min", "requests", {
+                areaStyle: { opacity: 0.12 },
+              }),
+              lineSeries(windowedHistory, "Errors/min", "errors"),
             ],
             ["brand", "danger"],
             function (value) {
@@ -760,7 +1082,11 @@
           );
           renderTimeChart(
             "latency-chart",
-            [lineSeries("Average", "avgLatencyMs"), lineSeries("P95", "p95LatencyMs")],
+            windowedHistory,
+            [
+              lineSeries(windowedHistory, "Average", "avgLatencyMs"),
+              lineSeries(windowedHistory, "P95", "p95LatencyMs"),
+            ],
             ["success", "brandSoft"],
             function (value) {
               return formatMilliseconds(Number(value));
@@ -798,25 +1124,28 @@
             const snapshot = parseMetrics(body);
             latestSnapshot = snapshot;
             recordHistory(snapshot);
-            byId("metrics-output").textContent = body;
             byId("summary-requests").textContent = formatCount(snapshot.requests);
             byId("summary-errors").textContent = formatCount(snapshot.errors);
             byId("summary-avg-latency").textContent = formatDuration(snapshot.avgLatencySeconds);
             byId("summary-p95-latency").textContent = formatDuration(snapshot.p95LatencySeconds);
             renderCharts(snapshot);
-            setStatus(`Last refreshed ${new Date().toLocaleTimeString()}`, "ok");
+            setStatus(
+              `Last refreshed ${new Date().toLocaleTimeString()} · window ${selectedWindow().label}`,
+              "ok",
+            );
           } catch (error) {
             const message =
               error instanceof Error ? error.message : "Failed to load Prometheus metrics";
-            byId("metrics-output").textContent = message;
+            latestSnapshot = null;
             clearDashboard(message);
             setStatus(message, "error");
           }
         }
 
+        bindControls();
         clearDashboard("Loading metrics...");
         refresh();
-        window.setInterval(refresh, REFRESH_INTERVAL_MS);
+        scheduleRefreshTimer();
         window.addEventListener("resize", function () {
           Object.values(charts).forEach(function (chart) {
             chart.resize();

--- a/gestaltd/ui/e2e/auth.spec.ts
+++ b/gestaltd/ui/e2e/auth.spec.ts
@@ -142,18 +142,10 @@ gestaltd_operation_duration_seconds_count{gestalt_provider="slack",gestalt_opera
     expect(chartColors?.border).toMatch(/^rgba?\(/);
     expect(chartColors?.foreground).toMatch(/^rgba?\(/);
     await expect(page.getByText("Time window")).toBeVisible();
-    await expect(page.getByRole("button", { name: "1 hour" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
+    await expect(page.locator("#time-window-select")).toHaveValue("1h");
     await expect(page.locator("#refresh-interval-select")).toHaveValue("15000");
-    await expect(page.locator("#history-note")).toContainText("last hour");
-    await page.getByRole("button", { name: "15 min" }).click();
-    await expect(page.getByRole("button", { name: "15 min" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
-    await expect(page.locator("#history-note")).toContainText("last 15 minutes");
+    await page.locator("#time-window-select").selectOption("15m");
+    await expect(page.locator("#time-window-select")).toHaveValue("15m");
     await expect(page.getByText("Top providers")).toBeVisible();
     await expect(page.locator("#provider-bars")).toContainText("slash\\nname");
     await expect(page.locator("#provider-bars .bar-name").first()).toHaveText("slash\\nname");

--- a/gestaltd/ui/e2e/auth.spec.ts
+++ b/gestaltd/ui/e2e/auth.spec.ts
@@ -141,11 +141,25 @@ gestaltd_operation_duration_seconds_count{gestalt_provider="slack",gestalt_opera
     expect(chartColors?.surfaceRaised).toMatch(/^rgba?\(/);
     expect(chartColors?.border).toMatch(/^rgba?\(/);
     expect(chartColors?.foreground).toMatch(/^rgba?\(/);
+    await expect(page.getByText("Time window")).toBeVisible();
+    await expect(page.getByRole("button", { name: "1 hour" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect(page.locator("#refresh-interval-select")).toHaveValue("15000");
+    await expect(page.locator("#history-note")).toContainText("last hour");
+    await page.getByRole("button", { name: "15 min" }).click();
+    await expect(page.getByRole("button", { name: "15 min" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect(page.locator("#history-note")).toContainText("last 15 minutes");
     await expect(page.getByText("Top providers")).toBeVisible();
     await expect(page.locator("#provider-bars")).toContainText("slash\\nname");
     await expect(page.locator("#provider-bars .bar-name").first()).toHaveText("slash\\nname");
     await expect(page.locator("#provider-bars")).toContainText("example");
     await expect(page.locator("#provider-bars")).not.toContainText("unknown");
+    await expect(page.locator("#metrics-output")).toHaveCount(0);
   });
 
   test("authenticated user on /login is redirected to dashboard", async ({
@@ -287,9 +301,10 @@ gestaltd_operation_duration_seconds_count{gestalt_provider="slack",gestalt_opera
     await expect(page.locator("#activity-chart")).toHaveAttribute("data-chart-state", "empty");
     await expect(page.locator("#latency-chart")).toHaveAttribute("data-chart-state", "empty");
     await expect(page.locator("#provider-chart")).toHaveAttribute("data-chart-state", "empty");
-    await expect(page.locator("#metrics-output")).toHaveText(
+    await expect(page.locator("#provider-bars")).toContainText(
       "Prometheus metrics are unavailable.",
     );
+    await expect(page.locator("#metrics-output")).toHaveCount(0);
   });
 
   test("admin metrics error body is rendered as text, not injected as HTML", async ({
@@ -320,6 +335,7 @@ gestaltd_operation_duration_seconds_count{gestalt_provider="slack",gestalt_opera
       `<img src=x onerror="window.__gestaltXss=1">metrics unavailable`,
     );
     await expect(page.locator("#provider-bars img")).toHaveCount(0);
+    await expect(page.locator("#metrics-output")).toHaveCount(0);
     const xssMarker = await page.evaluate(() => {
       const scope = window as Window & { __gestaltXss?: number };
       return scope.__gestaltXss ?? null;


### PR DESCRIPTION
## Summary
- add time-window and refresh-cadence controls to the embedded `/admin` metrics UI
- persist browser-local chart history for up to 24 hours so the time controls are meaningful across reloads
- remove the in-page raw Prometheus output panel and update docs/tests to match

## Testing
- `go test ./cmd/gestaltd -run 'TestE2EInitServeLocked(OTLPExportsMetricsAndKeepsLogsOnStdout|StdoutExposesPrometheusAndEmbeddedAdminUIByDefault)'`
- `npm run test:e2e -- auth.spec.ts --grep 'authenticated user can open the embedded admin UI directly|admin metrics html fallback shows a clear unavailable message|admin metrics error body is rendered as text, not injected as HTML'`
- `npm run check`