### PR TITLE
python: switch SDK to installed `gestalt` package model

### DIFF
--- a/docs/pages/plugins/writing-a-plugin.mdx
+++ b/docs/pages/plugins/writing-a-plugin.mdx
@@ -113,7 +113,9 @@ You do not write `main.go`. Gestalt synthesizes the executable wrapper automatic
 
 ## Python typed operations
 
-Point `pyproject.toml` at the plugin object that Gestalt should load:
+Install `gestalt` into the plugin's Python environment, typically from the
+internal wheel or private index, then point `pyproject.toml` at the plugin
+object that Gestalt should load:
 
 ```toml
 [build-system]
@@ -123,7 +125,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "my-plugin"
 version = "0.1.0"
-dependencies = ["gestalt-sdk-python"]
+dependencies = ["gestalt"]
 
 [tool.gestalt]
 plugin = "provider:plugin"
@@ -167,7 +169,7 @@ if __name__ == "__main__":
     plugin.serve()
 ```
 
-You do not write a launcher script for local development or release. Gestalt loads `provider:plugin` from `[tool.gestalt]`, materializes the static catalog automatically, and packages a runnable executable artifact during release.
+You do not write a launcher script for local development or release. Gestalt loads `provider:plugin` from `[tool.gestalt]`, materializes the static catalog automatically, and packages a runnable executable artifact during release. The selected Python environment must already have `gestalt` installed.
 
 ## Write `plugin.yaml`
 

--- a/examples/plugins/provider-python/pyproject.toml
+++ b/examples/plugins/provider-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "provider-python"
 version = "0.1.0"
-dependencies = ["gestalt-sdk-python"]
+dependencies = ["gestalt"]
 
 [tool.gestalt]
 plugin = "provider:plugin"

--- a/gestaltd/cmd/gestaltd/plugin_python.go
+++ b/gestaltd/cmd/gestaltd/plugin_python.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -20,6 +21,9 @@ func buildPythonReleaseBinary(sourceDir, binaryPath, pluginName, target string) 
 	interpreter, err := pluginpkg.DetectPythonInterpreter(sourceDir)
 	if err != nil {
 		return fmt.Errorf("detect Python release interpreter: %w", err)
+	}
+	if err := validatePythonReleaseEnvironment(interpreter); err != nil {
+		return err
 	}
 
 	workDir, err := os.MkdirTemp("", "gestalt-python-release-*")
@@ -50,18 +54,14 @@ func buildPythonReleaseBinary(sourceDir, binaryPath, pluginName, target string) 
 		"--hidden-import", module,
 		"--paths", sourceDir,
 	}
-	for _, sdkPath := range pythonReleaseImportPaths() {
-		args = append(args, "--paths", sdkPath)
-	}
 	args = append(args, launcherPath)
 
 	cmd := exec.Command(interpreter, args...)
 	cmd.Dir = sourceDir
-	cmd.Env = append(os.Environ(), pythonReleaseEnv()...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("python release build: %w (ensure PyInstaller is installed in the selected Python environment)", err)
+		return fmt.Errorf("python release build: %w", err)
 	}
 	return nil
 }
@@ -88,34 +88,24 @@ if __name__ == "__main__":
 `, module, attr, pluginName)
 }
 
-func pythonReleaseImportPaths() []string {
-	paths := []string{}
-	if sdkPath := localPythonSDKPath(); sdkPath != "" {
-		paths = append(paths, sdkPath)
+func validatePythonReleaseEnvironment(interpreter string) error {
+	cmd := exec.Command(
+		interpreter,
+		"-c",
+		"import gestalt; import PyInstaller",
+	)
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(output.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return fmt.Errorf(
+			"python release environment must have gestalt and PyInstaller installed (typically from the internal wheel or private index): %s",
+			msg,
+		)
 	}
-	return paths
-}
-
-func pythonReleaseEnv() []string {
-	paths := pythonReleaseImportPaths()
-	if len(paths) == 0 {
-		return nil
-	}
-	value := strings.Join(paths, string(os.PathListSeparator))
-	if existing := os.Getenv("PYTHONPATH"); existing != "" {
-		value += string(os.PathListSeparator) + existing
-	}
-	return []string{"PYTHONPATH=" + value}
-}
-
-func localPythonSDKPath() string {
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		return ""
-	}
-	path := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", "sdk", "python"))
-	if _, err := os.Stat(filepath.Join(path, "pyproject.toml")); err != nil {
-		return ""
-	}
-	return path
+	return nil
 }

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -371,7 +371,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "invalid-python-release"
 version = "0.1.0"
-dependencies = ["gestalt-sdk-python"]
+dependencies = ["gestalt"]
 
 [tool.gestalt]
 plugin = "os import path\nimport os;os.system('cmd')#:attr"
@@ -959,7 +959,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "python-release"
 version = "0.1.0"
-dependencies = ["gestalt-sdk-python"]
+dependencies = ["gestalt"]
 
 [tool.gestalt]
 plugin = "provider:plugin"
@@ -998,6 +998,10 @@ def greet(input: GreetInput, _req: gestalt.Request) -> GreetOutput:
 	writeTestFile(t, pluginDir, filepath.ToSlash(filepath.Join(".venv", "bin", "python")), []byte(`#!/bin/sh
 set -eu
 
+if [ "$#" -ge 2 ] && [ "$1" = "-c" ] && [ "$2" = "import gestalt; import PyInstaller" ]; then
+  exit 0
+fi
+
 if [ "$#" -ge 2 ] && [ "$1" = "-m" ] && [ "$2" = "gestalt._runtime" ]; then
   if [ -z "${GESTALT_PLUGIN_WRITE_CATALOG:-}" ]; then
     echo "missing GESTALT_PLUGIN_WRITE_CATALOG" >&2
@@ -1016,6 +1020,7 @@ if [ "$#" -ge 2 ] && [ "$1" = "-m" ] && [ "$2" = "PyInstaller" ]; then
   distpath=""
   hidden_import=""
   name=""
+  paths_count=0
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --distpath)
@@ -1030,6 +1035,10 @@ if [ "$#" -ge 2 ] && [ "$1" = "-m" ] && [ "$2" = "PyInstaller" ]; then
         name="$2"
         shift 2
         ;;
+      --paths)
+        paths_count=$((paths_count + 1))
+        shift 2
+        ;;
       *)
         shift
         ;;
@@ -1041,6 +1050,10 @@ if [ "$#" -ge 2 ] && [ "$1" = "-m" ] && [ "$2" = "PyInstaller" ]; then
   fi
   if [ "$hidden_import" != "provider" ]; then
     echo "expected --hidden-import provider, got: $hidden_import" >&2
+    exit 1
+  fi
+  if [ "$paths_count" -ne 1 ]; then
+    echo "expected exactly one --paths argument, got: $paths_count" >&2
     exit 1
   fi
   mkdir -p "$distpath"

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -191,6 +191,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-python-provider"
+dependencies = ["gestalt"]
 
 [tool.gestalt]
 plugin = "provider:plugin"
@@ -263,15 +264,9 @@ def list_items(_req: gestalt.Request) -> dict[str, object]:
 def status_zero(_req: gestalt.Request) -> gestalt.Response[dict[str, bool]]:
     return gestalt.Response(status=0, body={"ok": True})
 `), 0o644)
-	sdkPath := localPythonSDKPath(t)
-	writeTestFile(filepath.ToSlash(filepath.Join(".venv", "bin", "python")), []byte(strings.TrimSpace(
-		fmt.Sprintf(`
-			#!/bin/sh
-			set -eu
-
-			export PYTHONPATH=%q${PYTHONPATH:+:$PYTHONPATH}
-			exec %q "$@"
-		`, sdkPath, python3Path))+"\n"), 0o755)
+	if err := installLocalPythonSDK(t, python3Path, filepath.Join(dir, ".venv")); err != nil {
+		t.Fatalf("installLocalPythonSDK: %v", err)
+	}
 
 	manifest, err := pluginpkg.EncodeSourceManifestFormat(&pluginmanifestv1.Manifest{
 		Source:      "github.com/testowner/plugins/local-python-provider",
@@ -488,7 +483,7 @@ print(json.dumps({
 	}
 }
 
-func localPythonSDKPath(t *testing.T) string {
+func localPythonSDKSourceDir(t *testing.T) string {
 	t.Helper()
 
 	_, file, _, ok := runtime.Caller(0)
@@ -500,6 +495,31 @@ func localPythonSDKPath(t *testing.T) string {
 		t.Fatalf("Stat(%s): %v", path, err)
 	}
 	return path
+}
+
+func installLocalPythonSDK(t *testing.T, python3Path, venvDir string) error {
+	t.Helper()
+
+	create := exec.Command(python3Path, "-m", "venv", venvDir)
+	if output, err := create.CombinedOutput(); err != nil {
+		return fmt.Errorf("create venv: %w\n%s", err, output)
+	}
+
+	venvPython := filepath.Join(venvDir, "bin", "python")
+	pipPath := filepath.Join(venvDir, "bin", "pip")
+	if _, err := os.Stat(pipPath); err != nil {
+		ensurePip := exec.Command(venvPython, "-m", "ensurepip", "--upgrade")
+		if output, ensureErr := ensurePip.CombinedOutput(); ensureErr != nil {
+			return fmt.Errorf("ensure pip: %w\n%s", ensureErr, output)
+		}
+	}
+
+	install := exec.Command(pipPath, "install", "--no-deps", localPythonSDKSourceDir(t))
+	install.Env = append(os.Environ(), "PIP_DISABLE_PIP_VERSION_CHECK=1")
+	if output, err := install.CombinedOutput(); err != nil {
+		return fmt.Errorf("install local gestalt package: %w\n%s", err, output)
+	}
+	return nil
 }
 
 func TestApplyLockedPlugins_SkipsNilIntegrationPlugins(t *testing.T) {

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -3,10 +3,11 @@
 This package provides the Python authoring surface for executable Gestalt
 provider plugins.
 
-It is intended to be used by source plugins discovered through
-`[tool.gestalt]` in `pyproject.toml` and by packaged plugins built from that
-same source tree.
+The published package name is `gestalt`. Plugin authors should install it into
+their Python environment from the internal wheel or private index, then point
+`[tool.gestalt]` in `pyproject.toml` at the plugin object Gestalt should load.
 
 Python source plugins are developed locally via `from.source.path` and
 released through `gestaltd plugin release` as current-platform executable
-artifacts.
+artifacts. Release uses the selected Python environment directly, so that
+environment must already have `gestalt` and `PyInstaller` installed.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools==82.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "gestalt-sdk-python"
+name = "gestalt"
 version = "0.0.1-alpha.1"
 description = "Python SDK for Gestalt executable provider plugins"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- switch the Python SDK package name to `gestalt` and update the example plugin/docs to match
- remove the repo-local SDK path injection from Python release builds and require the selected Python environment to already have `gestalt` and `PyInstaller` installed
- update the functional Python lifecycle test to provision a real venv and install the local SDK package into it instead of relying on `PYTHONPATH`

## Context
This is a follow-up to #594. The initial Python source-plugin support is already merged into `main`; this PR only carries the installed-package/private-index model cleanup on top of that.

## Validation
- `go test ./internal/operator -run TestLoadForExecutionAtPath_GeneratesStaticCatalogForLocalPythonSourcePlugin`
- `go test ./cmd/gestaltd -run 'TestRun_PluginRelease(BuildsPythonSourcePluginForCurrentPlatform|RejectsNonCurrentPlatformForPythonSourcePlugin|RejectsInvalidPythonProviderTarget)'`
- `python3 -m py_compile sdk/python/gestalt/__init__.py sdk/python/gestalt/_plugin.py sdk/python/gestalt/_runtime.py examples/plugins/provider-python/provider.py`