### PR TITLE
[codex] Add first-class audit logging config

### DIFF
--- a/docs/content/audit-logging.mdx
+++ b/docs/content/audit-logging.mdx
@@ -92,13 +92,21 @@ Non-invocation HTTP audit events use explicit operation names:
 
 ## Routing
 
-Audit records are standard structured logs, so you route them the same way as
-the rest of `gestaltd` telemetry:
+By default, audit records follow the main `telemetry` log pipeline:
 
 - `telemetry.provider: stdout` writes them to local structured logs
 - `telemetry.provider: otlp` exports them through the OTLP log pipeline
 
-If you need a dedicated sink, route on `log.type=audit` in your collector.
+If you need a dedicated audit route, configure the top-level `audit:` block:
+
+- `audit.provider: stdout` keeps audit logs on stdout even when telemetry uses a different provider
+- `audit.provider: otlp` exports only audit records to a dedicated OTLP collector
+- `audit.provider: noop` disables audit output explicitly
+
+If you keep `audit.provider: inherit`, you can still split audit records
+downstream by filtering on `log.type=audit` in your collector. For the config
+surface itself, see [Config File](/reference/config-file). For export options,
+see [Observability](/observability).
 
 ## Metrics Notes
 

--- a/docs/content/observability.mdx
+++ b/docs/content/observability.mdx
@@ -74,6 +74,33 @@ telemetry:
       level: info
 ```
 
+## Audit Routing
+
+Audit logs inherit the main telemetry logger by default. If you need a
+different route for compliance, analytics, or warehousing, configure the
+top-level `audit:` block separately:
+
+```yaml
+telemetry:
+  provider: stdout
+  config:
+    format: json
+
+audit:
+  provider: otlp
+  config:
+    endpoint: audit-collector:4317
+    protocol: grpc
+    headers:
+      Authorization: Bearer ${AUDIT_OTLP_TOKEN}
+```
+
+That keeps application logs on stdout while exporting only audit records over
+OTLP. You can also set `audit.provider: stdout` to keep audit logs on stdout
+when telemetry is `noop`, or `audit.provider: noop` to disable audit output
+explicitly. If you leave `audit.provider: inherit`, collectors can still split
+the stream by filtering on `log.type=audit`.
+
 ## Emitted Metrics
 
 The built-in metric surface currently covers:

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -219,6 +219,7 @@ telemetry:
 | Field | Required | Default | Purpose |
 | --- | --- | --- | --- |
 | `format` | No | `text` | `text` or `json`. |
+| `level` | No | `info` | Minimum audit log level for this dedicated stdout audit sink. `warn` keeps denied audit events while suppressing successful ones. |
 | `level` | No | `info` | `debug`, `info`, `warn`, or `error`. |
 | `service_name` | No | `gestaltd` | Service name attached to locally exposed metrics. |
 | `resource_attributes` | No | — | Extra resource attributes attached to local metrics. |
@@ -310,10 +311,91 @@ response, and the built-in admin UI shows that metrics are unavailable.
 ### Audit logs
 
 Audit records are emitted as structured log entries with `log.type=audit`.
-Route them to a dedicated audit backend using OTel Collector attribute-based
-filtering. See [Audit Logging](/audit-logging) for the event schema
-and coverage details, and [Observability](/observability) for export
-options.
+By default they inherit the normal telemetry log pipeline, but you can override
+that with the top-level `audit:` block below. See
+[Audit Logging](/audit-logging) for the event schema and coverage details, and
+[Observability](/observability) for export options. If you keep
+`audit.provider: inherit`, you can still route audit traffic to a dedicated
+backend by filtering on `log.type=audit` in your collector.
+
+## `audit`
+
+Controls where audit records are written. Audit output defaults to inheriting
+the main telemetry logger.
+
+### `inherit`
+
+```yaml
+audit:
+  provider: inherit
+```
+
+This is the default when `audit` is omitted. Audit records follow the same log
+route as `telemetry`:
+
+- `telemetry.provider: stdout` keeps audit logs on standard output
+- `telemetry.provider: otlp` exports audit logs through the OTLP log pipeline
+- `telemetry.provider: noop` disables audit output unless you override it
+
+`audit.config` is not allowed when `audit.provider` is `inherit`.
+
+### `stdout`
+
+```yaml
+audit:
+  provider: stdout
+  config:
+    format: json
+```
+
+Writes audit records to standard output even if the main telemetry pipeline is
+using a different provider.
+
+| Field | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `format` | No | `text` | `text` or `json`. |
+| `level` | No | `info` | Minimum audit log level for this dedicated stdout audit sink. `warn` keeps denied audit events while suppressing successful ones. |
+
+### `otlp`
+
+```yaml
+audit:
+  provider: otlp
+  config:
+    endpoint: audit-collector:4317
+    protocol: grpc
+    service_name: gestaltd
+    insecure: false
+    headers:
+      Authorization: Bearer ${AUDIT_OTLP_TOKEN}
+    resource_attributes:
+      log.stream: audit
+```
+
+Exports audit records over OTLP without changing where application logs,
+metrics, or traces go.
+
+| Field | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `endpoint` | No | SDK default | OTLP collector address. |
+| `protocol` | No | `grpc` | `grpc` or `http`. |
+| `service_name` | No | `gestaltd` | OpenTelemetry service name for exported audit logs. |
+| `insecure` | No | `false` | Skip TLS verification. |
+| `headers` | No | — | Extra headers on every export request. |
+| `resource_attributes` | No | — | Extra resource attributes attached to audit log exports. |
+
+Use this when you want audit records in a dedicated compliance pipeline while
+keeping the rest of `gestaltd` on `stdout` or a different OTLP collector.
+
+### `noop`
+
+```yaml
+audit:
+  provider: noop
+```
+
+Disables audit output explicitly. `audit.config` is not allowed when
+`audit.provider` is `noop`.
 
 ## `providers`
 

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -108,6 +108,98 @@ providers:
 	}
 }
 
+func TestE2EValidateRejectsAuditConfigWhenProviderInheritsTelemetry(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+
+	cfgPath := writeE2EConfig(t, dir, pluginDir, 18080)
+	cfgBytes, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	cfgBytes = append(cfgBytes, []byte(`audit:
+  config:
+    format: json
+`)...)
+	if err := os.WriteFile(cfgPath, cfgBytes, 0o644); err != nil {
+		t.Fatalf("write config audit: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected gestaltd validate to fail, got success\n%s", out)
+	}
+	if !strings.Contains(string(out), "audit.config is not supported when audit.provider is") {
+		t.Fatalf("expected inherit-provider audit config error, got: %s", out)
+	}
+}
+
+func TestE2EValidateRejectsInvalidAuditSettings(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		auditYAML string
+		wantError string
+	}{
+		{
+			name: "unknown audit provider",
+			auditYAML: `audit:
+  provider: bogus
+`,
+			wantError: "unknown audit.provider",
+		},
+		{
+			name: "stdout audit requires mapping config",
+			auditYAML: `audit:
+  provider: stdout
+  config: nope
+`,
+			wantError: "stdout audit: parsing config",
+		},
+		{
+			name: "otlp audit rejects non-otlp logs exporter",
+			auditYAML: `audit:
+  provider: otlp
+  config:
+    logs:
+      exporter: stdout
+`,
+			wantError: "otlp audit: logs.exporter must be",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			pluginDir := setupPluginDir(t, dir)
+
+			cfgPath := writeE2EConfig(t, dir, pluginDir, 18080)
+			cfgBytes, err := os.ReadFile(cfgPath)
+			if err != nil {
+				t.Fatalf("read config: %v", err)
+			}
+			cfgBytes = append(cfgBytes, []byte(tc.auditYAML)...)
+			if err := os.WriteFile(cfgPath, cfgBytes, 0o644); err != nil {
+				t.Fatalf("write config audit: %v", err)
+			}
+
+			out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+			if err == nil {
+				t.Fatalf("expected gestaltd validate to fail, got success\n%s", out)
+			}
+			if !strings.Contains(string(out), tc.wantError) {
+				t.Fatalf("expected %q, got: %s", tc.wantError, out)
+			}
+		})
+	}
+}
+
 func TestE2EInitServeLockedGoldenPath(t *testing.T) {
 	t.Parallel()
 
@@ -387,6 +479,69 @@ func TestE2EInitServeLockedOTLPExportsTracesAndMetricsButKeepsLogsOnStdout(t *te
 	}
 }
 
+func TestE2EInitServeLockedOTLPAuditExportsAuditWithoutStdoutAuditLogs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+
+	var logRequests atomic.Int32
+	otlpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/logs":
+			logRequests.Add(1)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(otlpServer.Close)
+
+	port := allocateTestPort(t)
+	cfgPath := writeE2EConfig(t, dir, pluginDir, port)
+	cfgBytes, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	cfgBytes = append(cfgBytes, []byte(`telemetry:
+  provider: stdout
+  config:
+    level: info
+    format: json
+audit:
+  provider: otlp
+  config:
+    endpoint: `+strings.TrimPrefix(otlpServer.URL, "http://")+`
+    protocol: http
+    insecure: true
+`)...)
+	if err := os.WriteFile(cfgPath, cfgBytes, 0o644); err != nil {
+		t.Fatalf("write config telemetry: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	stdout, stderr := serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
+		body := invokeExampleOperation(t, baseURL, "echo", `{"message":"hello"}`, http.StatusOK)
+
+		var result map[string]any
+		if err := json.Unmarshal(body, &result); err != nil {
+			t.Fatalf("unmarshal success response: %v\nbody: %s", err, body)
+		}
+		if result["echo"] != "hello" {
+			t.Fatalf("expected echo=hello, got %v", result)
+		}
+	})
+
+	if logRequests.Load() == 0 {
+		t.Fatalf("expected audit logs to export over OTLP\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if strings.Contains(stdout, `"msg":"audit"`) {
+		t.Fatalf("did not expect audit logs on stdout when audit.provider=otlp\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+}
+
 func TestE2EInitServeLockedStdoutExposesPrometheusAndEmbeddedAdminUIByDefault(t *testing.T) {
 	t.Parallel()
 
@@ -501,6 +656,89 @@ func TestE2EInitServeLockedNoopKeepsAdminUIAndReturnsMetricsUnavailable(t *testi
 			t.Fatalf("expected admin ui to include shared theme asset: %s", adminBody)
 		}
 	})
+}
+
+func TestE2EInitServeLockedNoopTelemetryWithStdoutAuditStillEmitsAuditLogs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+
+	port := allocateTestPort(t)
+	cfgPath := writeE2EConfig(t, dir, pluginDir, port)
+	cfgBytes, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	cfgBytes = append(cfgBytes, []byte(`telemetry:
+  provider: noop
+audit:
+  provider: stdout
+  config:
+    format: json
+`)...)
+	if err := os.WriteFile(cfgPath, cfgBytes, 0o644); err != nil {
+		t.Fatalf("write config telemetry: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	stdout, stderr := serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
+		invokeExampleOperation(t, baseURL, "echo", `{"message":"hello"}`, http.StatusOK)
+
+		promBody := getEndpointBody(t, baseURL+"/metrics", http.StatusServiceUnavailable)
+		if !bytes.Contains(promBody, []byte("Prometheus metrics are unavailable")) {
+			t.Fatalf("expected disabled metrics message in /metrics body: %s", promBody)
+		}
+	})
+
+	if !strings.Contains(stdout, `"msg":"audit"`) {
+		t.Fatalf("expected audit log on stdout even with telemetry.provider=noop\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+}
+
+func TestE2EInitServeLockedStdoutAuditHonorsConfiguredLevel(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+
+	port := allocateTestPort(t)
+	cfgPath := writeE2EConfig(t, dir, pluginDir, port)
+	cfgBytes, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	cfgBytes = append(cfgBytes, []byte(`telemetry:
+  provider: noop
+audit:
+  provider: stdout
+  config:
+    format: json
+    level: warn
+`)...)
+	if err := os.WriteFile(cfgPath, cfgBytes, 0o644); err != nil {
+		t.Fatalf("write config telemetry: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	stdout, stderr := serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
+		invokeExampleOperation(t, baseURL, "echo", `{"message":"hello"}`, http.StatusOK)
+	})
+
+	if strings.Contains(stdout, `"operation":"echo"`) {
+		t.Fatalf("did not expect info-level audit log at audit.level=warn\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if strings.Contains(stdout, `"msg":"audit"`) {
+		t.Fatalf("did not expect any audit log on stdout for info-only traffic at audit.level=warn\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
 }
 
 func TestE2EInitServeLockedSplitManagementListener(t *testing.T) {

--- a/gestaltd/cmd/gestaltd/factories.go
+++ b/gestaltd/cmd/gestaltd/factories.go
@@ -33,6 +33,7 @@ import (
 	telemetrynoop "github.com/valon-technologies/gestalt/server/internal/drivers/telemetry/noop"
 	telemetryotlp "github.com/valon-technologies/gestalt/server/internal/drivers/telemetry/otlp"
 	telemetrystdout "github.com/valon-technologies/gestalt/server/internal/drivers/telemetry/stdout"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/operator"
 )
 
@@ -105,6 +106,33 @@ func buildFactories() *bootstrap.FactoryRegistry {
 	factories.Telemetry["noop"] = telemetrynoop.Factory
 	factories.Telemetry["stdout"] = telemetrystdout.Factory
 	factories.Telemetry["otlp"] = telemetryotlp.Factory
+	factories.Audit = func(ctx context.Context, cfg config.AuditConfig, telemetry core.TelemetryProvider) (core.AuditSink, func(context.Context) error, error) {
+		switch cfg.Provider {
+		case "", "inherit":
+			return invocation.NewLoggerAuditSink(telemetry.Logger()), nil, nil
+		case "noop":
+			return invocation.NewLoggerAuditSink(telemetrynoop.New().Logger()), nil, nil
+		case "stdout":
+			var stdoutCfg struct {
+				Level  string `yaml:"level"`
+				Format string `yaml:"format"`
+			}
+			if cfg.Config.Kind != 0 {
+				if err := cfg.Config.Decode(&stdoutCfg); err != nil {
+					return nil, nil, fmt.Errorf("stdout audit: parsing config: %w", err)
+				}
+			}
+			return invocation.NewLevelAwareLoggerAuditSink(telemetrystdout.NewLogger(stdoutCfg.Level, stdoutCfg.Format)), nil, nil
+		case "otlp":
+			logger, closeFn, err := telemetryotlp.NewAuditLogger(ctx, cfg.Config)
+			if err != nil {
+				return nil, nil, err
+			}
+			return invocation.NewLevelAwareLoggerAuditSink(logger), closeFn, nil
+		default:
+			return nil, nil, fmt.Errorf("unknown audit provider %q", cfg.Provider)
+		}
+	}
 	factories.Auth["google"] = google.Factory
 	factories.Auth["local"] = local.Factory
 	factories.Auth["none"] = authnone.Factory

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -161,12 +161,14 @@ type AuthFactory func(node yaml.Node, deps Deps) (core.AuthProvider, error)
 type DatastoreFactory func(node yaml.Node, deps Deps) (core.Datastore, error)
 type SecretManagerFactory func(node yaml.Node) (core.SecretManager, error)
 type TelemetryFactory func(node yaml.Node) (core.TelemetryProvider, error)
+type AuditFactory func(ctx context.Context, cfg config.AuditConfig, telemetry core.TelemetryProvider) (core.AuditSink, func(context.Context) error, error)
 
 type FactoryRegistry struct {
 	Auth       map[string]AuthFactory
 	Datastores map[string]DatastoreFactory
 	Secrets    map[string]SecretManagerFactory
 	Telemetry  map[string]TelemetryFactory
+	Audit      AuditFactory
 	Builtins   []core.Provider
 }
 
@@ -192,8 +194,9 @@ type Result struct {
 	Telemetry        core.TelemetryProvider
 	Egress           EgressDeps
 
-	mu     sync.Mutex
-	closed bool
+	auditClose func(context.Context) error
+	mu         sync.Mutex
+	closed     bool
 }
 
 func (r *Result) Start(ctx context.Context) error {
@@ -226,6 +229,9 @@ func (r *Result) Close(ctx context.Context) error {
 		closeDatastore(r.Datastore),
 		closeSecretManager(r.SecretManager),
 	)
+	if r.auditClose != nil {
+		errs = append(errs, r.auditClose(ctx))
+	}
 	if r.Telemetry != nil {
 		errs = append(errs, r.Telemetry.Shutdown(ctx))
 	}
@@ -372,10 +378,20 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(connMaps.MCPConnection)),
 		invocation.WithConnectionAuth(lazyRefreshers(providersReady, connAuthResolver)),
 	)
-	audit := core.AuditSink(invocation.NewLoggerAuditSink(prepared.Telemetry.Logger()))
+	audit, auditClose, err := buildAuditSink(ctx, cfg, factories, prepared.Telemetry)
+	if err != nil {
+		return nil, err
+	}
+	closeAudit := true
+	defer func() {
+		if closeAudit && auditClose != nil {
+			_ = auditClose(context.Background())
+		}
+	}()
 
 	closeProviders = false
 	closeCore = false
+	closeAudit = false
 	return &Result{
 		Auth:             prepared.Auth,
 		Datastore:        prepared.Datastore,
@@ -388,6 +404,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		SecretManager:    prepared.SecretManager,
 		Telemetry:        prepared.Telemetry,
 		Egress:           prepared.Deps.Egress,
+		auditClose:       auditClose,
 	}, nil
 }
 
@@ -401,6 +418,22 @@ func buildTelemetry(cfg *config.Config, factories *FactoryRegistry) (core.Teleme
 		return nil, fmt.Errorf("bootstrap: telemetry provider %q: %w", cfg.Telemetry.Provider, err)
 	}
 	return tp, nil
+}
+
+func buildAuditSink(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, telemetry core.TelemetryProvider) (core.AuditSink, func(context.Context) error, error) {
+	if factories.Audit == nil {
+		switch cfg.Audit.Provider {
+		case "", "inherit":
+			return invocation.NewLoggerAuditSink(telemetry.Logger()), nil, nil
+		default:
+			return nil, nil, fmt.Errorf("bootstrap: unknown audit provider %q", cfg.Audit.Provider)
+		}
+	}
+	sink, closeFn, err := factories.Audit(ctx, cfg.Audit, telemetry)
+	if err != nil {
+		return nil, nil, fmt.Errorf("bootstrap: audit provider %q: %w", cfg.Audit.Provider, err)
+	}
+	return sink, closeFn, nil
 }
 
 func buildSecretManager(cfg *config.Config, factories *FactoryRegistry) (core.SecretManager, error) {
@@ -488,6 +521,9 @@ func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretMa
 		return err
 	}
 	if err := resolveYAMLNode(&cfg.Telemetry.Config, resolve); err != nil {
+		return err
+	}
+	if err := resolveYAMLNode(&cfg.Audit.Config, resolve); err != nil {
 		return err
 	}
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	Datastore    DatastoreConfig           `yaml:"datastore"`
 	Secrets      SecretsConfig             `yaml:"secrets"`
 	Telemetry    TelemetryConfig           `yaml:"telemetry"`
+	Audit        AuditConfig               `yaml:"audit"`
 	Integrations map[string]IntegrationDef `yaml:"providers"`
 	Server       ServerConfig              `yaml:"server"`
 	Egress       EgressConfig              `yaml:"egress"`
@@ -45,6 +46,11 @@ type Config struct {
 }
 
 type TelemetryConfig struct {
+	Provider string    `yaml:"provider"`
+	Config   yaml.Node `yaml:"config"`
+}
+
+type AuditConfig struct {
 	Provider string    `yaml:"provider"`
 	Config   yaml.Node `yaml:"config"`
 }
@@ -702,6 +708,9 @@ func applyDefaults(cfg *Config) {
 	if cfg.Telemetry.Provider == "" {
 		cfg.Telemetry.Provider = "stdout"
 	}
+	if cfg.Audit.Provider == "" {
+		cfg.Audit.Provider = "inherit"
+	}
 }
 
 func resolveBaseURL(cfg *Config) {
@@ -769,6 +778,9 @@ func ValidateStructure(cfg *Config) error {
 			return fmt.Errorf("config validation: server.api_token_ttl: %w", err)
 		}
 	}
+	if err := validateAudit(cfg.Audit); err != nil {
+		return err
+	}
 	if err := validateEgress(&cfg.Egress); err != nil {
 		return err
 	}
@@ -782,6 +794,54 @@ func ValidateStructure(cfg *Config) error {
 		}
 	}
 	return nil
+}
+
+func validateAudit(cfg AuditConfig) error {
+	switch cfg.Provider {
+	case "", "inherit", "noop":
+		if cfg.Config.Kind == 0 {
+			return nil
+		}
+		return fmt.Errorf("config validation: audit.config is not supported when audit.provider is %q", cfg.Provider)
+	case "stdout":
+		if cfg.Config.Kind == 0 {
+			return nil
+		}
+		var stdoutCfg struct {
+			Level  string `yaml:"level"`
+			Format string `yaml:"format"`
+		}
+		if err := cfg.Config.Decode(&stdoutCfg); err != nil {
+			return fmt.Errorf("config validation: stdout audit: parsing config: %w", err)
+		}
+		return nil
+	case "otlp":
+		if cfg.Config.Kind == 0 {
+			return nil
+		}
+		var otlpCfg struct {
+			Protocol string `yaml:"protocol"`
+			Logs     struct {
+				Exporter string `yaml:"exporter"`
+			} `yaml:"logs"`
+		}
+		if err := cfg.Config.Decode(&otlpCfg); err != nil {
+			return fmt.Errorf("config validation: otlp audit: parsing config: %w", err)
+		}
+		if otlpCfg.Protocol != "" {
+			switch strings.ToLower(otlpCfg.Protocol) {
+			case "grpc", "http":
+			default:
+				return fmt.Errorf("config validation: otlp audit: unknown protocol %q (expected \"grpc\" or \"http\")", otlpCfg.Protocol)
+			}
+		}
+		if otlpCfg.Logs.Exporter != "" && !strings.EqualFold(otlpCfg.Logs.Exporter, "otlp") {
+			return fmt.Errorf("config validation: otlp audit: logs.exporter must be %q", "otlp")
+		}
+		return nil
+	default:
+		return fmt.Errorf("config validation: unknown audit.provider %q", cfg.Provider)
+	}
 }
 
 // ValidateResolvedStructure checks integration fields whose support depends on

--- a/gestaltd/internal/drivers/telemetry/otlp/otlp.go
+++ b/gestaltd/internal/drivers/telemetry/otlp/otlp.go
@@ -336,12 +336,43 @@ func (h levelFilterHandler) WithGroup(name string) slog.Handler {
 	return levelFilterHandler{level: h.level, inner: h.inner.WithGroup(name)}
 }
 
-var Factory bootstrap.TelemetryFactory = func(node yaml.Node) (core.TelemetryProvider, error) {
+func decodeConfig(node yaml.Node, subject string) (yamlConfig, error) {
 	var cfg yamlConfig
 	if node.Kind != 0 {
 		if err := node.Decode(&cfg); err != nil {
-			return nil, fmt.Errorf("otlp telemetry: parsing config: %w", err)
+			return yamlConfig{}, fmt.Errorf("%s: parsing config: %w", subject, err)
 		}
 	}
+	return cfg, nil
+}
+
+var Factory bootstrap.TelemetryFactory = func(node yaml.Node) (core.TelemetryProvider, error) {
+	cfg, err := decodeConfig(node, "otlp telemetry")
+	if err != nil {
+		return nil, err
+	}
 	return New(context.Background(), cfg)
+}
+
+func NewAuditLogger(ctx context.Context, node yaml.Node) (*slog.Logger, func(context.Context) error, error) {
+	cfg, err := decodeConfig(node, "otlp audit")
+	if err != nil {
+		return nil, nil, err
+	}
+	applyConfigDefaults(&cfg)
+	if !strings.EqualFold(cfg.Logs.Exporter, "otlp") {
+		return nil, nil, fmt.Errorf("otlp audit: logs.exporter must be %q", "otlp")
+	}
+
+	logger, lp, err := buildLogger(ctx, cfg, telemetryutil.BuildResource(cfg.ServiceName, cfg.ResourceAttributes))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var closeFn func(context.Context) error
+	if lp != nil {
+		closeFn = lp.Shutdown
+	}
+
+	return logger, closeFn, nil
 }

--- a/gestaltd/internal/invocation/audit.go
+++ b/gestaltd/internal/invocation/audit.go
@@ -30,11 +30,19 @@ func NewSlogAuditSink(w io.Writer) *SlogAuditSink {
 }
 
 func NewLoggerAuditSink(logger *slog.Logger) *SlogAuditSink {
+	return newLoggerAuditSink(logger, false)
+}
+
+func NewLevelAwareLoggerAuditSink(logger *slog.Logger) *SlogAuditSink {
+	return newLoggerAuditSink(logger, true)
+}
+
+func newLoggerAuditSink(logger *slog.Logger, respectLevel bool) *SlogAuditSink {
 	if logger == nil {
 		return NewSlogAuditSink(nil)
 	}
 	return &SlogAuditSink{
-		logger: slog.New(auditHandler{inner: logger.Handler()}),
+		logger: slog.New(auditHandler{inner: logger.Handler(), respectLevel: respectLevel}),
 	}
 }
 
@@ -115,10 +123,14 @@ func (s *SlogAuditSink) Log(ctx context.Context, entry core.AuditEntry) {
 }
 
 type auditHandler struct {
-	inner slog.Handler
+	inner        slog.Handler
+	respectLevel bool
 }
 
-func (h auditHandler) Enabled(context.Context, slog.Level) bool {
+func (h auditHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	if h.respectLevel {
+		return h.inner.Enabled(ctx, level)
+	}
 	return true
 }
 
@@ -127,9 +139,9 @@ func (h auditHandler) Handle(ctx context.Context, record slog.Record) error {
 }
 
 func (h auditHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return auditHandler{inner: h.inner.WithAttrs(attrs)}
+	return auditHandler{inner: h.inner.WithAttrs(attrs), respectLevel: h.respectLevel}
 }
 
 func (h auditHandler) WithGroup(name string) slog.Handler {
-	return auditHandler{inner: h.inner.WithGroup(name)}
+	return auditHandler{inner: h.inner.WithGroup(name), respectLevel: h.respectLevel}
 }


### PR DESCRIPTION
## Summary
- add a public top-level `audit:` config block so operators can route audit logs separately from general telemetry
- keep the implementation on the existing telemetry/bootstrap building blocks rather than adding a separate audit logging stack
- document the config surface and extend the existing `gestaltd` end-to-end suite for the new routing modes

## Public Interface
The public config surface added in this PR is:

```go
type AuditConfig struct {
    Provider string    `yaml:"provider"`
    Config   yaml.Node `yaml:"config"`
}
```

Supported providers:
- `inherit`
- `stdout`
- `otlp`
- `noop`

`inherit` remains the default and keeps audit logs on the active telemetry logger.

## Usage Examples
Inherit the active telemetry logger:

```yaml
audit:
  provider: inherit
```

Force audit logs to stdout while leaving the rest of telemetry unchanged:

```yaml
telemetry:
  provider: noop

audit:
  provider: stdout
  config:
    format: json
    level: info
```

Export only audit logs through OTLP while keeping general logs on stdout:

```yaml
telemetry:
  provider: stdout
  config:
    format: json
    level: info

audit:
  provider: otlp
  config:
    endpoint: collector:4318
    protocol: http
    insecure: true
```

Explicitly discard audit logs:

```yaml
audit:
  provider: noop
```

## Implementation Notes
This does not expose `core.AuditSink` directly as a user-facing extension point.
Instead, it adds a first-class config surface and reuses the existing logger
construction paths.

The main bootstrap seam is a single audit builder hook:

```go
factories.Audit = func(ctx context.Context, cfg config.AuditConfig,
    telemetry core.TelemetryProvider) (core.AuditSink,
    func(context.Context) error, error) {
    ...
}
```

Behavior:
- `inherit` reuses `telemetry.Logger()`
- `stdout` reuses the existing stdout logger constructor
- `otlp` reuses the existing OTLP logger builder and keeps dedicated shutdown where needed
- `noop` reuses the existing noop logger
- `audit.config` is rejected for providers that do not consume config (`inherit`, `noop`)

## Test Plan
- `go test ./cmd/gestaltd -run 'TestE2E(ValidateRejectsAuditConfigWhenProviderInheritsTelemetry|InitServeLockedGoldenPath|InitServeLockedOTLPExportsTracesAndMetricsButKeepsLogsOnStdout|InitServeLockedOTLPAuditExportsAuditWithoutStdoutAuditLogs|InitServeLockedNoopKeepsAdminUIAndReturnsMetricsUnavailable|InitServeLockedNoopTelemetryWithStdoutAuditStillEmitsAuditLogs)$'`
