### PR TITLE
[codex] add separate management listener for admin and metrics

### DIFF
--- a/docs/content/concepts/configuration.mdx
+++ b/docs/content/concepts/configuration.mdx
@@ -43,7 +43,7 @@ ui: {}
 
 Gestalt applies these defaults:
 
-- `server.port`: `8080`
+- `server.public.port`: `8080` via the legacy `server.port` shorthand
 - `secrets.provider`: `env`
 - `telemetry.provider`: `stdout`
 

--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -85,13 +85,27 @@ helm upgrade --install gestalt \
 | `pluginInit.enabled` | Runs `gestaltd init` in an init container before the main server starts. |
 | `ingress` | Standard ingress settings. |
 | `ingress.hosts[].paths` | Per-host ingress paths and path types. |
+| `managementService` | Optional internal Service for a separate management listener. |
 
 ## Example Values
 
 ```yaml
+service:
+  type: LoadBalancer
+  port: 8080
+
+managementService:
+  enabled: true
+  type: ClusterIP
+  port: 9090
+
 config:
   server:
-    port: 8080
+    public:
+      port: 8080
+    management:
+      host: 0.0.0.0
+      port: 9090
     base_url: "${GESTALT_BASE_URL}"
     encryption_key: "${GESTALT_ENCRYPTION_KEY}"
   auth:
@@ -137,6 +151,12 @@ extraEnv:
 pluginInit:
   enabled: true
 ```
+
+This configuration keeps the public UI and API on port `8080` while exposing
+`/admin` and `/metrics` only through the internal `gestalt-management` Service
+on port `9090`. If operators need browser access to `/admin`, place an
+internal-only ingress, VPN, or identity-aware proxy in front of that management
+Service rather than exposing it on the public ingress.
 
 ## When To Enable `pluginInit`
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -19,7 +19,7 @@ ui: {}
 - `${ENV_VAR}` expansion happens before YAML decode
 - If `${ENV_VAR}` is unset and `ENV_VAR_FILE` is set, Gestalt reads the value from that file path
 - Unknown YAML fields are rejected
-- `server.port` defaults to `8080`
+- `server.public.port` defaults to `8080` (via the legacy `server.port` shorthand)
 - `secrets.provider` defaults to `env`
 - `telemetry.provider` defaults to `stdout`
 - Relative paths resolve relative to the config file directory
@@ -29,7 +29,12 @@ ui: {}
 
 ```yaml
 server:
-  port: 8080
+  public:
+    host: 0.0.0.0
+    port: 8080
+  management:
+    host: 127.0.0.1
+    port: 9090
   base_url: https://gestalt.example.com
   encryption_key: secret://gestalt-encryption-key
   api_token_ttl: 30d
@@ -38,11 +43,25 @@ server:
 
 | Field | Required | Default | Purpose |
 | --- | --- | --- | --- |
-| `port` | No | `8080` | HTTP listen port. |
+| `public.host` | No | all interfaces | Host or IP for the public listener. |
+| `public.port` | No | `8080` | Port for the public listener. |
+| `management.host` | No | all interfaces | Host or IP for the optional management listener. |
+| `management.port` | No | — | Port for the optional management listener. When omitted, `/admin` and `/metrics` stay on the public listener. |
+| `port` | No | `8080` | Backward-compatible shorthand for `public.port`. `public.port` takes precedence when both are set. |
 | `base_url` | No | — | Derives OAuth callback URLs when explicit redirect URLs are omitted. |
 | `encryption_key` | Yes | — | Root deployment secret. Used for encryption and derived session material. |
 | `api_token_ttl` | No | `30d` | Lifetime of newly issued API tokens. Accepts Go duration strings (`1h`, `720h`) and day suffixes (`30d`). |
 | `artifacts_dir` | No | Config file directory | Writable directory for prepared artifacts produced by `init` and consumed by `serve --locked` when no CLI override is supplied. See [Configuration](/concepts/configuration). |
+
+When `server.management` is configured, Gestalt serves:
+
+- public listener: `/`, `/api/v1/*`, auth routes, and `/mcp`
+- management listener: `/admin`, `/metrics`, `/health`, and `/ready`
+
+The management listener is intended to be protected by deployment infrastructure
+such as private networking, VPN, or an internal-only reverse proxy. Gestalt does
+not apply its own session or API-token auth to `/metrics` on the management
+listener.
 
 ## `auth`
 

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -2,6 +2,11 @@
 
 This page documents the HTTP surface exposed by `gestaltd`.
 
+When `server.management` is not configured, every route below is served from the
+public listener. When `server.management` is configured, `/admin`, `/metrics`,
+`/health`, and `/ready` move to the management listener and return `404` on the
+public listener.
+
 ## Authentication Model
 
 Authenticated routes accept:
@@ -20,7 +25,7 @@ Valid bearer tokens are:
 | --- | --- | --- |
 | `GET` | `/health` | Basic liveness check. |
 | `GET` | `/ready` | Readiness check. Returns `503` until providers and datastore are ready. |
-| `GET` | `/admin` and `/admin/*` | Embedded admin UI shell. The UI fetches `/metrics` in the browser, so metric data still requires authenticated access to the scrape endpoint. |
+| `GET` | `/admin` and `/admin/*` | Embedded admin UI shell. On the management listener it reads same-origin `/metrics` without Gestalt auth, so access control is expected to come from your network or reverse proxy. |
 | `GET` | `/api/v1/auth/info` | Returns platform auth metadata. |
 | `POST` | `/api/v1/auth/login` | Starts platform login. |
 | `GET` | `/api/v1/auth/login/callback` | Completes platform login. |
@@ -59,7 +64,7 @@ Valid bearer tokens are:
 
 | Method | Path | Purpose |
 | --- | --- | --- |
-| `GET` | `/metrics` | Prometheus scrape endpoint for emitted metrics. |
+| `GET` | `/metrics` | Prometheus scrape endpoint for emitted metrics. Requires Gestalt auth only when served on the public listener. |
 
 ## MCP
 

--- a/docs/content/reference/observability.mdx
+++ b/docs/content/reference/observability.mdx
@@ -199,8 +199,12 @@ at `/metrics`.
 - `telemetry.provider: noop` disables Prometheus scraping; `/metrics` returns a
   clear unavailable response so the admin UI can surface that state.
 
-`/metrics` is an authenticated Prometheus text endpoint. The embedded admin UI
-visualizes that same scrape surface instead of using a separate metrics API.
+When Gestalt serves `/metrics` on the public listener, it is authenticated with
+the same session or bearer-token middleware as the rest of the HTTP API. When
+`server.management` is configured, `/metrics` moves to the management listener
+and is expected to be protected by network policy or an internal-only reverse
+proxy instead. The embedded admin UI visualizes that same scrape surface instead
+of using a separate metrics API.
 
 The Prometheus endpoint and OTLP export hang off the same meter provider and
 include the HTTP middleware metrics, broker metrics, plugin gRPC client

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -62,7 +62,8 @@ Example minimal config:
 
 ```yaml
 server:
-  port: 8080
+  public:
+    port: 8080
   encryption_key: ${GESTALT_ENCRYPTION_KEY}
 
 auth:
@@ -75,6 +76,42 @@ datastore:
 
 providers: {}
 ```
+
+Example with a separate internal-only management listener:
+
+```yaml
+server:
+  public:
+    host: 0.0.0.0
+    port: 8080
+  management:
+    host: 0.0.0.0
+    port: 9090
+  encryption_key: ${GESTALT_ENCRYPTION_KEY}
+
+auth:
+  provider: none
+
+datastore:
+  provider: sqlite
+  config:
+    path: /data/gestalt.db
+
+providers: {}
+```
+
+```sh
+docker run --rm \
+  -p 8080:8080 \
+  -p 127.0.0.1:9090:9090 \
+  -e GESTALT_ENCRYPTION_KEY=change-me \
+  -v "$(pwd)/gestalt.yaml:/etc/gestalt/config.yaml:ro" \
+  -v gestalt-data:/data \
+  valontechnologies/gestaltd:latest
+```
+
+This keeps `/admin` and `/metrics` off the public interface while still making
+them reachable from the host at `127.0.0.1:9090`.
 
 ## Run a prepared production image
 
@@ -113,6 +150,7 @@ services:
     image: valontechnologies/gestaltd:latest
     ports:
       - "8080:8080"
+      - "127.0.0.1:9090:9090"
     volumes:
       - ./config.yaml:/etc/gestalt/config.yaml:ro
       - gestalt-data:/data
@@ -155,8 +193,10 @@ The container exposes:
 - `GET /health` for liveness
 - `GET /ready` for readiness
 
-The client UI is served from `/` on the same port, and the built-in admin UI is
-served from `/admin`.
+By default the client UI is served from `/` and the built-in admin UI is served
+from `/admin` on the public listener. If you configure `server.management`, then
+`/admin`, `/metrics`, `/health`, and `/ready` move to the management listener
+instead.
 
 ## SQLite and `/data`
 

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -503,6 +503,46 @@ func TestE2EInitServeLockedNoopKeepsAdminUIAndReturnsMetricsUnavailable(t *testi
 	})
 }
 
+func TestE2EInitServeLockedSplitManagementListener(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+
+	publicPort := allocateTestPort(t)
+	managementPort := allocateTestPort(t)
+	cfgPath := writeSplitListenerE2EConfig(t, dir, pluginDir, publicPort, managementPort)
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	serveLockedAndExerciseWithManagement(t, cfgPath, publicPort, managementPort, "", func(t *testing.T, publicBaseURL, managementBaseURL string) {
+		invokeExampleOperation(t, publicBaseURL, "echo", `{"message":"hello"}`, http.StatusOK)
+
+		publicMetrics := getEndpointBody(t, publicBaseURL+"/metrics", http.StatusNotFound)
+		if bytes.Contains(publicMetrics, []byte("gestaltd_operation_count_total")) {
+			t.Fatalf("did not expect public listener to expose /metrics: %s", publicMetrics)
+		}
+
+		publicAdmin := getEndpointBody(t, publicBaseURL+"/admin", http.StatusNotFound)
+		if bytes.Contains(publicAdmin, []byte("Prometheus metrics")) {
+			t.Fatalf("did not expect public listener to expose /admin: %s", publicAdmin)
+		}
+
+		managementMetrics := getEndpointBody(t, managementBaseURL+"/metrics", http.StatusOK)
+		if !bytes.Contains(managementMetrics, []byte("gestaltd_operation_count_total")) {
+			t.Fatalf("expected management listener to expose /metrics: %s", managementMetrics)
+		}
+
+		managementAdmin := getEndpointBody(t, managementBaseURL+"/admin", http.StatusOK)
+		if !bytes.Contains(managementAdmin, []byte("Prometheus metrics")) {
+			t.Fatalf("expected management listener to expose /admin: %s", managementAdmin)
+		}
+	})
+}
+
 func TestE2EBareGestaltdAutoInit(t *testing.T) {
 	t.Parallel()
 
@@ -655,6 +695,29 @@ func TestE2EHelmChart(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("management service renders from values", func(t *testing.T) {
+		t.Parallel()
+
+		rendered := renderHelmChart(t, helmPath, chartDir,
+			"--set", "managementService.enabled=true",
+			"--set", "managementService.port=9090",
+			"--set", "config.server.management.port=9090",
+			"--set-string", "config.server.management.host=0.0.0.0",
+		)
+
+		for _, want := range []string{
+			`kind: Service`,
+			`name: test-release-gestalt-management`,
+			`port: 9090`,
+			`targetPort: management`,
+			`containerPort: 9090`,
+		} {
+			if !strings.Contains(rendered, want) {
+				t.Fatalf("expected rendered manifest to contain %q\n%s", want, rendered)
+			}
+		}
+	})
 }
 
 func withoutEnvVar(env []string, name string) []string {
@@ -776,6 +839,7 @@ providers:
 				t.Fatalf("expected output to mention %q and YAML parsing, got: %s", tc.wantError, out)
 			}
 		})
+
 	}
 }
 
@@ -1066,6 +1130,47 @@ func writeE2EConfig(t *testing.T, dir, pluginDir string, port int) string {
 	return writeE2EConfigWithPaths(t, dir, pluginDir, filepath.Join(dir, "gestalt.db"), "", port)
 }
 
+func writeSplitListenerE2EConfig(t *testing.T, dir, pluginDir string, publicPort, managementPort int) string {
+	t.Helper()
+
+	if publicPort == 0 {
+		publicPort = 18080
+	}
+	if managementPort == 0 {
+		managementPort = 19090
+	}
+	manifestPath, err := pluginpkg.FindManifestFile(pluginDir)
+	if err != nil {
+		t.Fatalf("FindManifestFile(%s): %v", pluginDir, err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := fmt.Sprintf(`auth:
+  provider: none
+datastore:
+  provider: sqlite
+  config:
+    path: %s
+server:
+  encryption_key: test-e2e-key
+  public:
+    port: %d
+  management:
+    host: 127.0.0.1
+    port: %d
+providers:
+  example:
+    from:
+      source:
+        path: %s
+`, filepath.Join(dir, "gestalt.db"), publicPort, managementPort, manifestPath)
+
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return cfgPath
+}
+
 func writeE2EConfigWithPaths(t *testing.T, dir, pluginDir, dbPath, artifactsDir string, port int) string {
 	t.Helper()
 
@@ -1132,6 +1237,43 @@ func serveLockedAndExerciseExample(t *testing.T, cfgPath string, port int, artif
 	waitForReady(t, baseURL, 30*time.Second)
 
 	exercise(t, baseURL)
+
+	stopped = true
+	_ = cmd.Process.Signal(os.Interrupt)
+	_ = cmd.Wait()
+	return stdout.String(), stderr.String()
+}
+
+func serveLockedAndExerciseWithManagement(t *testing.T, cfgPath string, publicPort, managementPort int, artifactsDir string, exercise func(t *testing.T, publicBaseURL, managementBaseURL string)) (string, string) {
+	t.Helper()
+
+	args := []string{"serve", "--locked", "--config", cfgPath}
+	if artifactsDir != "" {
+		args = append(args, "--artifacts-dir", artifactsDir)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := exec.Command(gestaltdBin, args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start serve: %v", err)
+	}
+	stopped := false
+	t.Cleanup(func() {
+		if !stopped {
+			_ = cmd.Process.Signal(os.Interrupt)
+			_ = cmd.Wait()
+		}
+	})
+
+	publicBaseURL := fmt.Sprintf("http://localhost:%d", publicPort)
+	managementBaseURL := fmt.Sprintf("http://localhost:%d", managementPort)
+	waitForReady(t, publicBaseURL, 30*time.Second)
+	waitForReady(t, managementBaseURL, 30*time.Second)
+
+	exercise(t, publicBaseURL, managementBaseURL)
 
 	stopped = true
 	_ = cmd.Process.Signal(os.Interrupt)

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -147,7 +147,7 @@ func runServer(env *bootstrapEnv) error {
 		}
 	}
 
-	srv, err := server.New(server.Config{
+	baseServerConfig := server.Config{
 		Auth:              result.Auth,
 		AuditSink:         result.AuditSink,
 		Datastore:         result.Datastore,
@@ -168,41 +168,84 @@ func runServer(env *bootstrapEnv) error {
 		MCPHandler:        mcpHandler,
 		ClientUI:          clientUI,
 		AdminUI:           adminUI,
-	})
+	}
+
+	publicProfile := server.RouteProfileAll
+	if env.Config.Server.ManagementAddr() != "" {
+		publicProfile = server.RouteProfilePublic
+	}
+	baseServerConfig.RouteProfile = publicProfile
+
+	srv, err := server.New(baseServerConfig)
 	if err != nil {
 		return fmt.Errorf("creating server: %w", err)
 	}
 
-	addr := fmt.Sprintf(":%d", env.Config.Server.Port)
-	httpServer := &http.Server{
-		Addr:              addr,
-		Handler:           srv,
-		ReadHeaderTimeout: 10 * time.Second,
-		IdleTimeout:       120 * time.Second,
-		MaxHeaderBytes:    1 << 20,
+	type namedHTTPServer struct {
+		name   string
+		server *http.Server
 	}
 
-	listenErr := make(chan error, 1)
-	go func() {
-		slog.Info("gestaltd listening", "addr", addr)
-		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			listenErr <- err
+	newHTTPServer := func(name, addr string, handler http.Handler) *http.Server {
+		return &http.Server{
+			Addr:              addr,
+			Handler:           handler,
+			ReadHeaderTimeout: 10 * time.Second,
+			IdleTimeout:       120 * time.Second,
+			MaxHeaderBytes:    1 << 20,
 		}
-	}()
+	}
+
+	servers := []namedHTTPServer{{
+		name:   "public",
+		server: newHTTPServer("public", env.Config.Server.PublicAddr(), srv),
+	}}
+
+	if managementAddr := env.Config.Server.ManagementAddr(); managementAddr != "" {
+		managementConfig := baseServerConfig
+		managementConfig.RouteProfile = server.RouteProfileManagement
+		managementConfig.MCPHandler = nil
+		managementConfig.ClientUI = nil
+		managementSrv, err := server.New(managementConfig)
+		if err != nil {
+			return fmt.Errorf("creating management server: %w", err)
+		}
+		servers = append(servers, namedHTTPServer{
+			name:   "management",
+			server: newHTTPServer("management", managementAddr, managementSrv),
+		})
+	}
+
+	type listenFailure struct {
+		name string
+		err  error
+	}
+	listenErr := make(chan listenFailure, len(servers))
+	for _, entry := range servers {
+		entry := entry
+		go func() {
+			slog.Info("gestaltd listening", "listener", entry.name, "addr", entry.server.Addr)
+			if err := entry.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				listenErr <- listenFailure{name: entry.name, err: err}
+			}
+		}()
+	}
 
 	defer func() {
 		drainCtx, drainCancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
 		defer drainCancel()
-		if err := httpServer.Shutdown(drainCtx); err != nil {
-			slog.Warn("server shutdown", "error", err)
+		for _, entry := range servers {
+			if err := entry.server.Shutdown(drainCtx); err != nil {
+				slog.Warn("server shutdown", "listener", entry.name, "error", err)
+			}
 		}
 	}()
 
 	select {
 	case <-result.ProvidersReady:
 		slog.Info("all providers ready", "count", len(result.Providers.List()))
-	case err := <-listenErr:
-		return fmt.Errorf("http server: %v", err)
+	case failure := <-listenErr:
+		return fmt.Errorf("%s http server: %v", failure.name, failure.err)
 	case <-env.Ctx.Done():
 		return nil
 	}
@@ -219,8 +262,8 @@ func runServer(env *bootstrapEnv) error {
 	slog.Info("MCP endpoint enabled", "path", "/mcp")
 
 	select {
-	case err := <-listenErr:
-		return fmt.Errorf("http server: %v", err)
+	case failure := <-listenErr:
+		return fmt.Errorf("%s http server: %v", failure.name, failure.err)
 	case <-env.Ctx.Done():
 	}
 
@@ -379,6 +422,8 @@ func logConfigSummary(path string, cfg *config.Config) {
 	slog.Info("config loaded",
 		"config_file", path,
 		"server_port", cfg.Server.Port,
+		"server_public_addr", cfg.Server.PublicAddr(),
+		"server_management_addr", maskEmpty(cfg.Server.ManagementAddr()),
 		"server_base_url", maskEmpty(cfg.Server.BaseURL),
 		"server_encryption", maskSecret(cfg.Server.EncryptionKey),
 		"auth_provider", cfg.Auth.Provider,

--- a/gestaltd/deploy/helm/gestalt/templates/NOTES.txt
+++ b/gestaltd/deploy/helm/gestalt/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{- $management := .Values.config.server.management | default dict }}
 Gestalt has been deployed successfully.
 
 {{- if .Values.ingress.enabled }}
@@ -36,6 +37,16 @@ Verify the deployment:
 
 Health check:
   curl http://127.0.0.1:{{ .Values.service.port }}/health
+
+{{- if and .Values.managementService.enabled (get $management "port") }}
+
+Management listener:
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "gestalt.fullname" . }}-management {{ .Values.managementService.port }}:{{ .Values.managementService.port }}
+
+Then visit:
+  http://127.0.0.1:{{ .Values.managementService.port }}/admin
+  http://127.0.0.1:{{ .Values.managementService.port }}/metrics
+{{- end }}
 
 Default chart profile:
   auth.provider=none, SQLite on /data, single replica

--- a/gestaltd/deploy/helm/gestalt/templates/deployment.yaml
+++ b/gestaltd/deploy/helm/gestalt/templates/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     {{- include "gestalt.labels" . | nindent 4 }}
     app.kubernetes.io/component: api
 spec:
+  {{- $public := .Values.config.server.public | default dict }}
+  {{- $management := .Values.config.server.management | default dict }}
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
@@ -85,8 +87,13 @@ spec:
             - /etc/gestalt/config.yaml
           ports:
             - name: http
-              containerPort: {{ .Values.config.server.port | default 8080 }}
+              containerPort: {{ get $public "port" | default (.Values.config.server.port | default 8080) }}
               protocol: TCP
+            {{- if get $management "port" }}
+            - name: management
+              containerPort: {{ get $management "port" }}
+              protocol: TCP
+            {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/gestaltd/deploy/helm/gestalt/templates/management-service.yaml
+++ b/gestaltd/deploy/helm/gestalt/templates/management-service.yaml
@@ -1,0 +1,23 @@
+{{- $management := .Values.config.server.management | default dict }}
+{{- if and .Values.managementService.enabled (get $management "port") }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gestalt.fullname" . }}-management
+  labels:
+    {{- include "gestalt.labels" . | nindent 4 }}
+  {{- with .Values.managementService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.managementService.type }}
+  ports:
+    - port: {{ .Values.managementService.port }}
+      targetPort: management
+      protocol: TCP
+      name: management
+  selector:
+    {{- include "gestalt.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+{{- end }}

--- a/gestaltd/deploy/helm/gestalt/values.yaml
+++ b/gestaltd/deploy/helm/gestalt/values.yaml
@@ -26,6 +26,12 @@ service:
   type: ClusterIP
   port: 8080
 
+managementService:
+  enabled: false
+  type: ClusterIP
+  port: 9090
+  annotations: {}
+
 ingress:
   enabled: false
   className: ""
@@ -68,6 +74,17 @@ persistence:
 config:
   server:
     port: 8080
+    # Explicit public listener config. When set, public.port takes precedence
+    # over server.port.
+    # public:
+    #   host: 0.0.0.0
+    #   port: 8080
+    # Configure a separate internal-only management listener for /admin and
+    # /metrics. Keep the management service disabled unless you also expose a
+    # matching internal Kubernetes Service below.
+    # management:
+    #   host: 0.0.0.0
+    #   port: 9090
     # Dev-only default so the default chart profile can boot. Override this with
     # a secret value before production use.
     encryption_key: "dev-only-insecure-key-change-me"

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"net"
 	"os"
 	"path/filepath"
 	"slices"
@@ -231,12 +232,53 @@ type DatastoreConfig struct {
 	Config   yaml.Node `yaml:"config"`
 }
 
+type ListenerConfig struct {
+	Host string `yaml:"host"`
+	Port int    `yaml:"port"`
+}
+
 type ServerConfig struct {
-	Port          int    `yaml:"port"`
-	BaseURL       string `yaml:"base_url"`
-	EncryptionKey string `yaml:"encryption_key"`
-	APITokenTTL   string `yaml:"api_token_ttl"`
-	ArtifactsDir  string `yaml:"artifacts_dir"`
+	Port          int            `yaml:"port"`
+	Public        ListenerConfig `yaml:"public"`
+	Management    ListenerConfig `yaml:"management"`
+	BaseURL       string         `yaml:"base_url"`
+	EncryptionKey string         `yaml:"encryption_key"`
+	APITokenTTL   string         `yaml:"api_token_ttl"`
+	ArtifactsDir  string         `yaml:"artifacts_dir"`
+}
+
+func (s ServerConfig) PublicListener() ListenerConfig {
+	port := s.Public.Port
+	if port == 0 {
+		port = s.Port
+	}
+	if port == 0 {
+		port = 8080
+	}
+	return ListenerConfig{
+		Host: s.Public.Host,
+		Port: port,
+	}
+}
+
+func (s ServerConfig) PublicAddr() string {
+	listener := s.PublicListener()
+	return net.JoinHostPort(listener.Host, strconv.Itoa(listener.Port))
+}
+
+func (s ServerConfig) ManagementListener() (ListenerConfig, bool) {
+	if s.Management.Port == 0 {
+		return ListenerConfig{}, false
+	}
+	return s.Management, true
+}
+
+func (s ServerConfig) ManagementAddr() string {
+	listener, ok := s.ManagementListener()
+	if !ok {
+		return ""
+	}
+	return net.JoinHostPort(listener.Host, strconv.Itoa(listener.Port))
 }
 
 type IntegrationDef struct {
@@ -651,6 +693,9 @@ func applyDefaults(cfg *Config) {
 	if cfg.Server.Port == 0 {
 		cfg.Server.Port = 8080
 	}
+	if cfg.Server.Public.Port != 0 {
+		cfg.Server.Port = cfg.Server.Public.Port
+	}
 	if cfg.Secrets.Provider == "" {
 		cfg.Secrets.Provider = "env"
 	}
@@ -716,6 +761,9 @@ func resolveUpstreamURL(baseDir, value string) string {
 // Called by Load (and therefore by init, validate, and serve). Does not require
 // runtime secrets like encryption_key, auth.provider, or datastore.provider.
 func ValidateStructure(cfg *Config) error {
+	if err := validateServerListeners(cfg.Server); err != nil {
+		return err
+	}
 	if cfg.Server.APITokenTTL != "" {
 		if _, err := ParseDuration(cfg.Server.APITokenTTL); err != nil {
 			return fmt.Errorf("config validation: server.api_token_ttl: %w", err)
@@ -1202,6 +1250,35 @@ func validateUIPlugin(plugin *UIPluginDef) error {
 		}
 	}
 
+	return nil
+}
+
+func validateServerListeners(cfg ServerConfig) error {
+	public := cfg.PublicListener()
+	if public.Port <= 0 {
+		return fmt.Errorf("config validation: server.public.port must be greater than zero")
+	}
+	if _, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(public.Host, strconv.Itoa(public.Port))); err != nil {
+		return fmt.Errorf("config validation: server.public is invalid: %w", err)
+	}
+
+	management, ok := cfg.ManagementListener()
+	if !ok {
+		if cfg.Management.Host != "" {
+			return fmt.Errorf("config validation: server.management.port is required when server.management.host is set")
+		}
+		return nil
+	}
+	if management.Port <= 0 {
+		return fmt.Errorf("config validation: server.management.port must be greater than zero")
+	}
+	managementAddr := net.JoinHostPort(management.Host, strconv.Itoa(management.Port))
+	if _, err := net.ResolveTCPAddr("tcp", managementAddr); err != nil {
+		return fmt.Errorf("config validation: server.management is invalid: %w", err)
+	}
+	if managementAddr == cfg.PublicAddr() {
+		return fmt.Errorf("config validation: server.management must differ from server.public")
+	}
 	return nil
 }
 

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -41,7 +41,12 @@ datastore:
   provider: data-store
 server:
   encryption_key: server-key
-  port: 9090
+  public:
+    host: 127.0.0.1
+    port: 9090
+  management:
+    host: 127.0.0.1
+    port: 9191
 providers:
   service-a:
     display_name: Service A

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -14,23 +14,47 @@ func (s *Server) routes() {
 	r.Use(s.securityHeadersMiddleware)
 	r.Use(maxBodyMiddleware(1 << 20)) // 1 MB
 
-	s.mountCoreRoutes(r)
-	s.mountMCPRoutes(r)
-	s.mountAPIRoutes(r)
-	s.mountAdminUIRoutes(r)
+	switch s.routeProfile {
+	case RouteProfilePublic:
+		s.mountCoreRoutes(r, metricsHidden)
+		s.mountMCPRoutes(r)
+		s.mountAPIRoutes(r)
+		s.mountManagementHiddenRoutes(r)
+	case RouteProfileManagement:
+		s.mountCoreRoutes(r, metricsUnauthenticated)
+		s.mountAdminUIRoutes(r)
+	default:
+		s.mountCoreRoutes(r, metricsAuthenticated)
+		s.mountMCPRoutes(r)
+		s.mountAPIRoutes(r)
+		s.mountAdminUIRoutes(r)
+	}
 
 	if s.clientUI != nil {
 		r.NotFound(s.clientUI.ServeHTTP)
 	}
 }
 
-func (s *Server) mountCoreRoutes(r chi.Router) {
+type metricsExposure int
+
+const (
+	metricsHidden metricsExposure = iota
+	metricsAuthenticated
+	metricsUnauthenticated
+)
+
+func (s *Server) mountCoreRoutes(r chi.Router, exposure metricsExposure) {
 	r.Get("/health", s.healthCheck)
 	r.Get("/ready", s.readinessCheck)
-	r.Group(func(r chi.Router) {
-		r.Use(s.authMiddleware)
+	switch exposure {
+	case metricsAuthenticated:
+		r.Group(func(r chi.Router) {
+			r.Use(s.authMiddleware)
+			r.HandleFunc("/metrics", s.servePrometheusMetrics)
+		})
+	case metricsUnauthenticated:
 		r.HandleFunc("/metrics", s.servePrometheusMetrics)
-	})
+	}
 }
 
 func (s *Server) mountAdminUIRoutes(r chi.Router) {
@@ -42,6 +66,13 @@ func (s *Server) mountAdminUIRoutes(r chi.Router) {
 		http.Redirect(w, r, "/admin/", http.StatusMovedPermanently)
 	})
 	r.Handle("/admin/*", http.StripPrefix("/admin", s.adminUI))
+}
+
+func (s *Server) mountManagementHiddenRoutes(r chi.Router) {
+	notFound := http.NotFoundHandler()
+	r.Handle("/metrics", notFound)
+	r.Handle("/admin", notFound)
+	r.Handle("/admin/*", notFound)
 }
 
 func (s *Server) mountMCPRoutes(r chi.Router) {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -21,6 +21,14 @@ import (
 // status message in the /ready response.
 type ReadinessChecker func() string
 
+type RouteProfile int
+
+const (
+	RouteProfileAll RouteProfile = iota
+	RouteProfilePublic
+	RouteProfileManagement
+)
+
 type Server struct {
 	router             chi.Router
 	handler            http.Handler
@@ -46,6 +54,7 @@ type Server struct {
 	mcpHandler         http.Handler
 	clientUI           http.Handler
 	adminUI            http.Handler
+	routeProfile       RouteProfile
 }
 
 type Config struct {
@@ -67,6 +76,7 @@ type Config struct {
 	MCPHandler        http.Handler
 	ClientUI          http.Handler
 	AdminUI           http.Handler
+	RouteProfile      RouteProfile
 }
 
 func New(cfg Config) (*Server, error) {
@@ -122,6 +132,7 @@ func New(cfg Config) (*Server, error) {
 		mcpHandler:        cfg.MCPHandler,
 		clientUI:          cfg.ClientUI,
 		adminUI:           cfg.AdminUI,
+		routeProfile:      cfg.RouteProfile,
 	}
 	if noAuth {
 		s.anonymousPrincipal = resolver.ResolveEmail(anonymousEmail)


### PR DESCRIPTION
## Summary

This adds an optional separate management listener to `gestaltd` so operators can keep `/admin` and `/metrics` off the public listener without pushing operator auth or ACL logic into the app itself.

## What Changed

- added structured listener config under `server.public` and `server.management`
- kept `server.port` as a backward-compatible shorthand for `server.public.port`
- split the HTTP surface into public and management route profiles
- when `server.management` is configured:
  - public listener serves `/`, `/api/v1/*`, auth routes, and `/mcp`
  - management listener serves `/admin`, `/metrics`, `/health`, and `/ready`
  - `/metrics` is no longer protected by Gestalt session/API-token auth on the management listener and is instead expected to be protected by network policy / proxying
  - `/admin` and `/metrics` return `404` on the public listener
- added Helm support for an optional internal management `Service`
- documented the exposed config interface and added deployment examples for Docker and Helm

## How To Configure It

Base config:

```yaml
server:
  public:
    host: 0.0.0.0
    port: 8080
  management:
    host: 0.0.0.0
    port: 9090
  base_url: https://gestalt.example.com
  encryption_key: ${GESTALT_ENCRYPTION_KEY}
```

With that config:
- public listener: `/`, `/api/v1/*`, auth routes, `/mcp`
- management listener: `/admin`, `/metrics`, `/health`, `/ready`

For Helm, expose the management listener through a separate internal Service:

```yaml
managementService:
  enabled: true
  port: 9090

config:
  server:
    public:
      port: 8080
    management:
      host: 0.0.0.0
      port: 9090
```

That lets deployers keep the public ingress on the main Service and put `/admin` and `/metrics` behind an internal-only Service, VPN, or identity-aware proxy.

## Why

Long term, the clean operator story is a separate management surface rather than path-based filtering on the public listener. That keeps the app simple, lets infrastructure control access, and gives deployers an explicit interface for both the public and management listeners.

## Validation

- `go test ./cmd/gestaltd -run 'TestE2EInitServeLockedSplitManagementListener|TestE2EHelmChart|TestE2EInitServeLockedStdoutExposesPrometheusAndEmbeddedAdminUIByDefault|TestE2EInitServeLockedNoopKeepsAdminUIAndReturnsMetricsUnavailable'`