### PR TITLE
plugin manifests: support explicit kinds

### DIFF
--- a/gestaltd/internal/pluginpkg/manifest_wire.go
+++ b/gestaltd/internal/pluginpkg/manifest_wire.go
@@ -16,6 +16,7 @@ type manifestWire struct {
 	DisplayName string                          `json:"display_name,omitempty" yaml:"display_name,omitempty"`
 	Description string                          `json:"description,omitempty" yaml:"description,omitempty"`
 	IconFile    string                          `json:"icon_file,omitempty" yaml:"icon_file,omitempty"`
+	Kinds       []string                        `json:"kinds,omitempty" yaml:"kinds,omitempty"`
 	Provider    *providerManifestWire           `json:"provider,omitempty" yaml:"provider,omitempty"`
 	WebUI       *pluginmanifestv1.WebUIMetadata `json:"webui,omitempty" yaml:"webui,omitempty"`
 	Artifacts   []pluginmanifestv1.Artifact     `json:"artifacts,omitempty" yaml:"artifacts,omitempty"`
@@ -125,11 +126,12 @@ func wireManifestToInternal(wire *manifestWire) *pluginmanifestv1.Manifest {
 		DisplayName: wire.DisplayName,
 		Description: wire.Description,
 		IconFile:    wire.IconFile,
+		Kinds:       append([]string(nil), wire.Kinds...),
 		WebUI:       wire.WebUI,
 		Artifacts:   wire.Artifacts,
 	}
 	if wire.Provider != nil {
-		manifest.Kinds = append(manifest.Kinds, pluginmanifestv1.KindProvider)
+		appendManifestKind(&manifest.Kinds, pluginmanifestv1.KindProvider)
 		manifest.Provider = &pluginmanifestv1.Provider{
 			ConfigSchemaPath:  wire.Provider.ConfigSchemaPath,
 			Headers:           wire.Provider.Headers,
@@ -197,7 +199,7 @@ func wireManifestToInternal(wire *manifestWire) *pluginmanifestv1.Manifest {
 		}
 	}
 	if wire.WebUI != nil {
-		manifest.Kinds = append(manifest.Kinds, pluginmanifestv1.KindWebUI)
+		appendManifestKind(&manifest.Kinds, pluginmanifestv1.KindWebUI)
 	}
 	return manifest
 }
@@ -213,6 +215,7 @@ func internalManifestToWire(manifest *pluginmanifestv1.Manifest) *manifestWire {
 		DisplayName: manifest.DisplayName,
 		Description: manifest.Description,
 		IconFile:    manifest.IconFile,
+		Kinds:       append([]string(nil), manifest.Kinds...),
 		WebUI:       manifest.WebUI,
 		Artifacts:   manifest.Artifacts,
 	}
@@ -335,4 +338,13 @@ func manifestDefaultConnectionToWire(name string) string {
 	default:
 		return name
 	}
+}
+
+func appendManifestKind(kinds *[]string, kind string) {
+	for _, existing := range *kinds {
+		if existing == kind {
+			return
+		}
+	}
+	*kinds = append(*kinds, kind)
 }

--- a/gestaltd/internal/pluginpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/pluginpkg/manifest_workflow_test.go
@@ -229,6 +229,26 @@ func TestManifestWorkflow_AllowsSourceArtifactsWithoutDigestsUntilPackaging(t *t
 	}
 }
 
+func TestManifestWorkflow_InfersProviderKindWhenKindsOmitted(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "provider-no-kinds")
+	artifactPath := testArtifactPath("provider")
+	wire := mustProviderManifest("github.com/acme/plugins/provider-no-kinds", "0.1.0", testArtifactOS, testArtifactArch, artifactPath, "")
+	wire.Kinds = nil
+	manifestPath := mustWriteManifestData(t, sourceDir, "plugin.yaml", mustManifestYAML(t, wire))
+	mustWriteFile(t, filepath.Join(sourceDir, filepath.FromSlash(artifactPath)), []byte("provider"), 0o755)
+
+	_, manifest, err := ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile: %v", err)
+	}
+	if len(manifest.Kinds) != 1 || manifest.Kinds[0] != pluginmanifestv1.KindProvider {
+		t.Fatalf("Kinds = %v, want [%q]", manifest.Kinds, pluginmanifestv1.KindProvider)
+	}
+}
+
 func TestLoadManifestFromPath_PrefersManifestFileOrder(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/pluginpkg/test_helpers_test.go
+++ b/gestaltd/internal/pluginpkg/test_helpers_test.go
@@ -94,6 +94,7 @@ func mustProviderManifest(source, version, osName, arch, artifactPath, sha strin
 	return &manifestWire{
 		Source:  source,
 		Version: version,
+		Kinds:   []string{pluginmanifestv1.KindProvider},
 		Provider: &providerManifestWire{
 			Exec:     &providerExecWire{ArtifactPath: artifactPath},
 			Surfaces: providerManifestSurfacesWire{},

--- a/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -25,6 +25,18 @@
     "icon_file": {
       "type": "string"
     },
+    "kinds": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "provider",
+          "webui"
+        ]
+      }
+    },
     "provider": {
       "$ref": "#/$defs/provider"
     },


### PR DESCRIPTION
## Summary
- teach the manifest wire format to parse and emit the documented `kinds` field
- keep backward compatibility by still inferring provider/webui kinds when the field is omitted
- update the manifest schema and existing pluginpkg tests accordingly

## Testing
- cd gestaltd && TMPDIR=/Users/hugh/src/.tmpgo go test ./internal/pluginpkg