### PR TITLE
Simplify Python runtime release bootstrap

### DIFF
--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -998,19 +998,19 @@ def greet(input: GreetInput, _req: gestalt.Request) -> GreetOutput:
 	writeTestFile(t, pluginDir, filepath.ToSlash(filepath.Join(".venv", "bin", "python")), []byte(`#!/bin/sh
 set -eu
 
-if [ "$#" -ge 3 ] && [ "$1" = "-m" ] && [ "$2" = "gestalt._runtime" ] && [ "$3" = "build" ]; then
+if [ "$#" -ge 2 ] && [ "$1" = "-m" ] && [ "$2" = "gestalt._build" ]; then
   if [ -z "${GESTALT_TEST_PYINSTALLER_BINARY:-}" ]; then
     echo "missing GESTALT_TEST_PYINSTALLER_BINARY" >&2
     exit 1
   fi
-  if [ "$#" -ne 7 ]; then
-    echo "unexpected gestalt._runtime build args: $*" >&2
+  if [ "$#" -ne 6 ]; then
+    echo "unexpected gestalt._build args: $*" >&2
     exit 1
   fi
-  root="$4"
-  target="$5"
-  output="$6"
-  name="$7"
+  root="$3"
+  target="$4"
+  output="$5"
+  name="$6"
   if [ "$target" != "provider:plugin" ]; then
     echo "unexpected provider target: $target" >&2
     exit 1

--- a/gestaltd/internal/pluginpkg/python_provider.go
+++ b/gestaltd/internal/pluginpkg/python_provider.go
@@ -17,6 +17,7 @@ import (
 const (
 	pythonProjectFile   = "pyproject.toml"
 	pythonRuntimeModule = "gestalt._runtime"
+	pythonBuildModule   = "gestalt._build"
 )
 
 var ErrNoPythonProviderPackage = errors.New("no Python provider package found")
@@ -65,7 +66,7 @@ func BuildPythonProviderBinary(sourceDir, binaryPath, pluginName, target string)
 		return fmt.Errorf("detect Python release interpreter: %w", err)
 	}
 
-	cmd := exec.Command(interpreter, "-m", pythonRuntimeModule, "build", sourceDir, target, binaryPath, pluginName)
+	cmd := exec.Command(interpreter, "-m", pythonBuildModule, sourceDir, target, binaryPath, pluginName)
 	cmd.Dir = sourceDir
 	cmd.Env = append(os.Environ(), pythonBackendEnv()...)
 	cmd.Stdout = os.Stdout

--- a/sdk/python/gestalt/_bootstrap.py
+++ b/sdk/python/gestalt/_bootstrap.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import pathlib
 from dataclasses import dataclass

--- a/sdk/python/gestalt/_bootstrap.py
+++ b/sdk/python/gestalt/_bootstrap.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import pathlib
+from dataclasses import dataclass
+
+BUNDLED_CONFIG_NAME = "gestalt-runtime.json"
+
+
+@dataclass(frozen=True)
+class PluginTarget:
+    module_name: str
+    attribute_name: str
+
+
+@dataclass(frozen=True)
+class BundledPluginConfig:
+    target: str
+    plugin_name: str | None = None
+
+
+def parse_plugin_target(target: str) -> PluginTarget:
+    module_name, _, attribute_name = target.partition(":")
+    if not module_name or not attribute_name:
+        raise RuntimeError("tool.gestalt.plugin must be in module:attribute form")
+
+    return PluginTarget(
+        module_name=module_name,
+        attribute_name=attribute_name,
+    )
+
+
+def read_bundled_plugin_config(*, bundle_root: pathlib.Path) -> BundledPluginConfig | None:
+    config_path = bundle_root / BUNDLED_CONFIG_NAME
+    if not config_path.exists():
+        return None
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    target = str(data.get("target", "")).strip()
+    if not target:
+        raise RuntimeError(f"{config_path} is missing target")
+
+    plugin_name = data.get("plugin_name")
+    if plugin_name is not None:
+        plugin_name = str(plugin_name).strip() or None
+
+    return BundledPluginConfig(
+        target=target,
+        plugin_name=plugin_name,
+    )
+
+
+def write_bundled_plugin_config(
+    path: pathlib.Path,
+    *,
+    target: str,
+    plugin_name: str,
+) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "target": target,
+                "plugin_name": plugin_name,
+            }
+        ),
+        encoding="utf-8",
+    )

--- a/sdk/python/gestalt/_build.py
+++ b/sdk/python/gestalt/_build.py
@@ -95,7 +95,7 @@ def _pyinstaller_command(
         "--paths",
         str(root_path),
         "--add-data",
-        f"{bundle_config_path}{separator}{BUNDLED_CONFIG_NAME}",
+        f"{bundle_config_path}{separator}.",
         str(pathlib.Path(__file__).with_name("_pyinstaller.py")),
     ]
 

--- a/sdk/python/gestalt/_build.py
+++ b/sdk/python/gestalt/_build.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+from ._runtime import BUNDLED_CONFIG_NAME, _split_target
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) != 4:
+        print(
+            "usage: python -m gestalt._build ROOT MODULE:ATTRIBUTE OUTPUT PLUGIN_NAME",
+            file=sys.stderr,
+        )
+        return 2
+
+    root, target, output_path, plugin_name = args
+    build_plugin_binary(root, target, output_path, plugin_name)
+    return 0
+
+
+def build_plugin_binary(root: str, target: str, output_path: str, plugin_name: str) -> None:
+    root_path = pathlib.Path(root).resolve()
+    output = pathlib.Path(output_path).resolve()
+    module_name, _attr_name = _split_target(target)
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="gestalt-python-release-") as work_dir:
+        work_path = pathlib.Path(work_dir)
+        bundle_config_path = work_path / BUNDLED_CONFIG_NAME
+        bundle_config_path.write_text(
+            json.dumps(
+                {
+                    "target": target,
+                    "plugin_name": plugin_name,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        pyinstaller_name = output.name
+        if sys.platform == "win32" and pyinstaller_name.endswith(".exe"):
+            pyinstaller_name = pyinstaller_name[:-4]
+        separator = ";" if sys.platform == "win32" else ":"
+
+        command = [
+            sys.executable,
+            "-m",
+            "PyInstaller",
+            "--noconfirm",
+            "--clean",
+            "--onefile",
+            "--distpath",
+            str(output.parent),
+            "--workpath",
+            str(work_path / "build"),
+            "--specpath",
+            str(work_path / "spec"),
+            "--name",
+            pyinstaller_name,
+            "--hidden-import",
+            module_name,
+            "--paths",
+            str(root_path),
+            "--add-data",
+            f"{bundle_config_path}{separator}{BUNDLED_CONFIG_NAME}",
+            str(pathlib.Path(__file__).with_name("_pyinstaller.py")),
+        ]
+        subprocess.run(command, cwd=root_path, check=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/python/gestalt/_build.py
+++ b/sdk/python/gestalt/_build.py
@@ -1,76 +1,105 @@
 from __future__ import annotations
 
-import json
 import pathlib
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
 
-from ._runtime import BUNDLED_CONFIG_NAME, _split_target
+from ._bootstrap import BUNDLED_CONFIG_NAME, parse_plugin_target, write_bundled_plugin_config
+
+
+@dataclass(frozen=True)
+class BuildArgs:
+    root: str
+    target: str
+    output_path: str
+    plugin_name: str
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = list(sys.argv[1:] if argv is None else argv)
-    if len(args) != 4:
-        print(
-            "usage: python -m gestalt._build ROOT MODULE:ATTRIBUTE OUTPUT PLUGIN_NAME",
-            file=sys.stderr,
-        )
+    build_args = _parse_build_args(sys.argv[1:] if argv is None else argv)
+    if build_args is None:
+        print("usage: python -m gestalt._build ROOT MODULE:ATTRIBUTE OUTPUT PLUGIN_NAME", file=sys.stderr)
         return 2
 
-    root, target, output_path, plugin_name = args
-    build_plugin_binary(root, target, output_path, plugin_name)
+    build_plugin_binary(build_args)
     return 0
 
 
-def build_plugin_binary(root: str, target: str, output_path: str, plugin_name: str) -> None:
-    root_path = pathlib.Path(root).resolve()
-    output = pathlib.Path(output_path).resolve()
-    module_name, _attr_name = _split_target(target)
+def _parse_build_args(args: list[str]) -> BuildArgs | None:
+    if len(args) != 4:
+        return None
 
-    output.parent.mkdir(parents=True, exist_ok=True)
+    root, target, output_path, plugin_name = args
+    return BuildArgs(
+        root=root,
+        target=target,
+        output_path=output_path,
+        plugin_name=plugin_name,
+    )
+
+
+def build_plugin_binary(args: BuildArgs) -> None:
+    root_path = pathlib.Path(args.root).resolve()
+    output_path = pathlib.Path(args.output_path).resolve()
+    plugin_target = parse_plugin_target(args.target)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="gestalt-python-release-") as work_dir:
         work_path = pathlib.Path(work_dir)
         bundle_config_path = work_path / BUNDLED_CONFIG_NAME
-        bundle_config_path.write_text(
-            json.dumps(
-                {
-                    "target": target,
-                    "plugin_name": plugin_name,
-                }
-            ),
-            encoding="utf-8",
+        write_bundled_plugin_config(
+            bundle_config_path,
+            target=args.target,
+            plugin_name=args.plugin_name,
         )
 
-        pyinstaller_name = output.name
-        if sys.platform == "win32" and pyinstaller_name.endswith(".exe"):
-            pyinstaller_name = pyinstaller_name[:-4]
-        separator = ";" if sys.platform == "win32" else ":"
+        subprocess.run(
+            _pyinstaller_command(
+                root_path=root_path,
+                output_path=output_path,
+                module_name=plugin_target.module_name,
+                bundle_config_path=bundle_config_path,
+            ),
+            cwd=root_path,
+            check=True,
+        )
 
-        command = [
-            sys.executable,
-            "-m",
-            "PyInstaller",
-            "--noconfirm",
-            "--clean",
-            "--onefile",
-            "--distpath",
-            str(output.parent),
-            "--workpath",
-            str(work_path / "build"),
-            "--specpath",
-            str(work_path / "spec"),
-            "--name",
-            pyinstaller_name,
-            "--hidden-import",
-            module_name,
-            "--paths",
-            str(root_path),
-            "--add-data",
-            f"{bundle_config_path}{separator}{BUNDLED_CONFIG_NAME}",
-            str(pathlib.Path(__file__).with_name("_pyinstaller.py")),
-        ]
-        subprocess.run(command, cwd=root_path, check=True)
+
+def _pyinstaller_command(
+    *,
+    root_path: pathlib.Path,
+    output_path: pathlib.Path,
+    module_name: str,
+    bundle_config_path: pathlib.Path,
+) -> list[str]:
+    pyinstaller_name = output_path.name.removesuffix(".exe") if sys.platform == "win32" else output_path.name
+    separator = ";" if sys.platform == "win32" else ":"
+
+    return [
+        sys.executable,
+        "-m",
+        "PyInstaller",
+        "--noconfirm",
+        "--clean",
+        "--onefile",
+        "--distpath",
+        str(output_path.parent),
+        "--workpath",
+        str(bundle_config_path.parent / "build"),
+        "--specpath",
+        str(bundle_config_path.parent / "spec"),
+        "--name",
+        pyinstaller_name,
+        "--hidden-import",
+        module_name,
+        "--paths",
+        str(root_path),
+        "--add-data",
+        f"{bundle_config_path}{separator}{BUNDLED_CONFIG_NAME}",
+        str(pathlib.Path(__file__).with_name("_pyinstaller.py")),
+    ]
 
 
 if __name__ == "__main__":

--- a/sdk/python/gestalt/_build.py
+++ b/sdk/python/gestalt/_build.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import pathlib
 import subprocess
 import sys

--- a/sdk/python/gestalt/_pyinstaller.py
+++ b/sdk/python/gestalt/_pyinstaller.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from gestalt._runtime import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/python/gestalt/_pyinstaller.py
+++ b/sdk/python/gestalt/_pyinstaller.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from gestalt._runtime import main
 
 

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -1,24 +1,44 @@
 from __future__ import annotations
 
-import json
+import importlib
 import os
 import pathlib
 import signal
 import sys
 from concurrent import futures
+from dataclasses import dataclass
 
+from ._bootstrap import parse_plugin_target, read_bundled_plugin_config
 from ._plugin import ENV_WRITE_CATALOG, Plugin, Request
 
-ENV_PLUGIN_SOCKET = "GESTALT_PLUGIN_SOCKET"
-CURRENT_PROTOCOL_VERSION = 2
-BUNDLED_CONFIG_NAME = "gestalt-runtime.json"
+_IMPORT_ERROR: ImportError | None = None
 
-
-def serve(plugin: Plugin) -> None:
+try:
     import grpc
     from google.protobuf import json_format
 
     from .gen.v1 import plugin_pb2, plugin_pb2_grpc
+except ImportError as exc:  # pragma: no cover - depends on local runtime deps
+    grpc = None
+    json_format = None
+    plugin_pb2 = None
+    plugin_pb2_grpc = None
+    _IMPORT_ERROR = exc
+
+ENV_PLUGIN_SOCKET = "GESTALT_PLUGIN_SOCKET"
+CURRENT_PROTOCOL_VERSION = 2
+
+
+@dataclass(frozen=True)
+class RuntimeArgs:
+    target: str
+    root: str | None = None
+    plugin_name: str | None = None
+
+
+def serve(plugin: Plugin) -> None:
+    if _IMPORT_ERROR is not None:
+        raise RuntimeError("gestalt runtime dependencies are not installed") from _IMPORT_ERROR
 
     socket_path = os.environ.get(ENV_PLUGIN_SOCKET)
     if not socket_path:
@@ -76,33 +96,15 @@ def serve(plugin: Plugin) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = list(sys.argv[1:] if argv is None else argv)
-    if not args:
-        config_path = pathlib.Path(getattr(sys, "_MEIPASS", pathlib.Path(__file__).resolve().parent))
-        config_path = config_path / BUNDLED_CONFIG_NAME
-        if not config_path.exists():
-            _print_usage()
-            return 2
+    runtime_args = _parse_runtime_args(sys.argv[1:] if argv is None else argv)
+    if runtime_args is None:
+        _print_usage()
+        return 2
 
-        data = json.loads(config_path.read_text(encoding="utf-8"))
-        target = data.get("target", "").strip()
-        if not target:
-            raise RuntimeError(f"{config_path} is missing target")
+    plugin = _load_plugin(runtime_args)
+    if runtime_args.plugin_name:
+        plugin.name = runtime_args.plugin_name
 
-        plugin_name = data.get("plugin_name")
-        if plugin_name is not None:
-            plugin_name = str(plugin_name).strip() or None
-        root = None
-    else:
-        if len(args) != 2:
-            _print_usage()
-            return 2
-        root, target = args
-        plugin_name = None
-
-    plugin = _load_plugin(target, root)
-    if plugin_name:
-        plugin.name = plugin_name
     catalog_path = os.environ.get(ENV_WRITE_CATALOG)
     if catalog_path:
         plugin.write_catalog(catalog_path)
@@ -112,32 +114,42 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-def _load_plugin(target: str, root: str | None = None) -> Plugin:
-    import importlib
+def _parse_runtime_args(args: list[str]) -> RuntimeArgs | None:
+    if args:
+        if len(args) != 2:
+            return None
 
-    if root and root not in sys.path:
-        sys.path.insert(0, root)
+        root, target = args
+        return RuntimeArgs(target=target, root=root)
 
-    module_name, attr_name = _split_target(target)
-    module = importlib.import_module(module_name)
-    plugin = getattr(module, attr_name, None)
+    bundled_config = read_bundled_plugin_config(bundle_root=_bundle_root())
+    if bundled_config is None:
+        return None
+
+    return RuntimeArgs(
+        target=bundled_config.target,
+        plugin_name=bundled_config.plugin_name,
+    )
+
+
+def _bundle_root() -> pathlib.Path:
+    return pathlib.Path(getattr(sys, "_MEIPASS", pathlib.Path(__file__).resolve().parent))
+
+
+def _load_plugin(args: RuntimeArgs) -> Plugin:
+    if args.root and args.root not in sys.path:
+        sys.path.insert(0, args.root)
+
+    plugin_target = parse_plugin_target(args.target)
+    module = importlib.import_module(plugin_target.module_name)
+    plugin = getattr(module, plugin_target.attribute_name, None)
     if not isinstance(plugin, Plugin):
-        raise RuntimeError(f"{target} did not resolve to a gestalt.Plugin")
+        raise RuntimeError(f"{args.target} did not resolve to a gestalt.Plugin")
     return plugin
 
 
-def _split_target(target: str) -> tuple[str, str]:
-    module_name, _, attr_name = target.partition(":")
-    if not module_name or not attr_name:
-        raise RuntimeError("tool.gestalt.plugin must be in module:attribute form")
-    return module_name, attr_name
-
-
 def _print_usage() -> None:
-    print(
-        "usage: python -m gestalt._runtime ROOT MODULE:ATTRIBUTE",
-        file=sys.stderr,
-    )
+    print("usage: python -m gestalt._runtime ROOT MODULE:ATTRIBUTE", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import pathlib
@@ -15,6 +16,11 @@ from ._plugin import ENV_WRITE_CATALOG, Plugin, Request
 ENV_PLUGIN_SOCKET = "GESTALT_PLUGIN_SOCKET"
 CURRENT_PROTOCOL_VERSION = 2
 BUNDLED_CONFIG_NAME = "gestalt-runtime.json"
+SERVER_MAX_WORKERS = 4
+SERVER_SHUTDOWN_GRACE_SECONDS = 2
+WINDOWS_EXECUTABLE_SUFFIX = ".exe"
+PYINSTALLER_BUILD_DIR_NAME = "build"
+PYINSTALLER_SPEC_DIR_NAME = "spec"
 
 
 def serve(plugin: Plugin) -> None:
@@ -27,7 +33,7 @@ def serve(plugin: Plugin) -> None:
     if os.path.exists(socket_path):
         os.unlink(socket_path)
 
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=SERVER_MAX_WORKERS))
 
     class ProviderServicer(plugin_pb2_grpc.ProviderPluginServicer):
         def GetMetadata(self, _request, _context):
@@ -68,7 +74,7 @@ def serve(plugin: Plugin) -> None:
     server.start()
 
     def _shutdown(_signum, _frame):
-        server.stop(grace=2)
+        server.stop(grace=SERVER_SHUTDOWN_GRACE_SECONDS)
 
     signal.signal(signal.SIGTERM, _shutdown)
     signal.signal(signal.SIGINT, _shutdown)
@@ -77,18 +83,23 @@ def serve(plugin: Plugin) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
-    if len(args) == 5 and args[0] == "build":
-        _, root, target, output_path, plugin_name = args
-        build_plugin_binary(root, target, output_path, plugin_name)
-        return 0
+    try:
+        build_config = _build_config(args)
+        if build_config is not None:
+            build_plugin_binary(
+                build_config.root,
+                build_config.target,
+                build_config.output_path,
+                build_config.plugin_name,
+            )
+            return 0
 
-    runtime_config = _runtime_config(args)
+        runtime_config = _runtime_config(args)
+    except SystemExit as exc:
+        return exc.code if isinstance(exc.code, int) else 1
+
     if runtime_config is None:
-        print(
-            "usage: python -m gestalt._runtime [ROOT MODULE:ATTRIBUTE]\n"
-            "   or: python -m gestalt._runtime build ROOT MODULE:ATTRIBUTE OUTPUT PLUGIN_NAME",
-            file=sys.stderr,
-        )
+        _print_usage()
         return 2
 
     plugin = _load_plugin(runtime_config.target, runtime_config.root)
@@ -122,33 +133,13 @@ def build_plugin_binary(root: str, target: str, output_path: str, plugin_name: s
             encoding="utf-8",
         )
 
-        pyinstaller_name = output.name
-        if sys.platform == "win32" and pyinstaller_name.endswith(".exe"):
-            pyinstaller_name = pyinstaller_name[:-4]
-
-        command = [
-            sys.executable,
-            "-m",
-            "PyInstaller",
-            "--noconfirm",
-            "--clean",
-            "--onefile",
-            "--distpath",
-            str(output.parent),
-            "--workpath",
-            str(work_path / "build"),
-            "--specpath",
-            str(work_path / "spec"),
-            "--name",
-            pyinstaller_name,
-            "--hidden-import",
-            module_name,
-            "--paths",
-            str(root_path),
-            "--add-data",
-            _pyinstaller_data_arg(bundle_config_path, BUNDLED_CONFIG_NAME),
-            str(_pyinstaller_entrypoint()),
-        ]
+        command = _pyinstaller_command(
+            module_name=module_name,
+            root_path=root_path,
+            output_path=output,
+            work_path=work_path,
+            bundle_config_path=bundle_config_path,
+        )
         subprocess.run(command, cwd=root_path, check=True)
 
 
@@ -180,13 +171,33 @@ class _RuntimeConfig:
     plugin_name: str | None = None
 
 
+@dataclass(frozen=True)
+class _BuildConfig:
+    root: str
+    target: str
+    output_path: str
+    plugin_name: str
+
+
+def _build_config(args: list[str]) -> _BuildConfig | None:
+    if not args or args[0] != "build":
+        return None
+
+    parsed = _build_argument_parser().parse_args(args[1:])
+    return _BuildConfig(
+        root=parsed.root,
+        target=parsed.target,
+        output_path=parsed.output_path,
+        plugin_name=parsed.plugin_name,
+    )
+
+
 def _runtime_config(args: list[str]) -> _RuntimeConfig | None:
-    if len(args) == 2:
-        root, target = args
-        return _RuntimeConfig(target=target, root=root)
     if len(args) == 0:
         return _bundled_runtime_config()
-    return None
+
+    parsed = _runtime_argument_parser().parse_args(args)
+    return _RuntimeConfig(target=parsed.target, root=parsed.root)
 
 
 def _bundled_runtime_config() -> _RuntimeConfig | None:
@@ -216,6 +227,70 @@ def _pyinstaller_data_arg(source: pathlib.Path, destination_name: str) -> str:
 
 def _pyinstaller_entrypoint() -> pathlib.Path:
     return pathlib.Path(__file__).with_name("_pyinstaller.py")
+
+
+def _runtime_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m gestalt._runtime")
+    parser.add_argument("root")
+    parser.add_argument("target", metavar="MODULE:ATTRIBUTE")
+    return parser
+
+
+def _build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m gestalt._runtime build")
+    parser.add_argument("root")
+    parser.add_argument("target", metavar="MODULE:ATTRIBUTE")
+    parser.add_argument("output_path", metavar="OUTPUT")
+    parser.add_argument("plugin_name", metavar="PLUGIN_NAME")
+    return parser
+
+
+def _pyinstaller_command(
+    *,
+    module_name: str,
+    root_path: pathlib.Path,
+    output_path: pathlib.Path,
+    work_path: pathlib.Path,
+    bundle_config_path: pathlib.Path,
+) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "PyInstaller",
+        "--noconfirm",
+        "--clean",
+        "--onefile",
+        "--distpath",
+        str(output_path.parent),
+        "--workpath",
+        str(work_path / PYINSTALLER_BUILD_DIR_NAME),
+        "--specpath",
+        str(work_path / PYINSTALLER_SPEC_DIR_NAME),
+        "--name",
+        _pyinstaller_name(output_path),
+        "--hidden-import",
+        module_name,
+        "--paths",
+        str(root_path),
+        "--add-data",
+        _pyinstaller_data_arg(bundle_config_path, BUNDLED_CONFIG_NAME),
+        str(_pyinstaller_entrypoint()),
+    ]
+
+
+def _pyinstaller_name(output_path: pathlib.Path) -> str:
+    name = output_path.name
+    if sys.platform == "win32" and name.endswith(WINDOWS_EXECUTABLE_SUFFIX):
+        return name[: -len(WINDOWS_EXECUTABLE_SUFFIX)]
+    return name
+
+
+def _print_usage() -> None:
+    print(
+        "usage: python -m gestalt._runtime ROOT MODULE:ATTRIBUTE\n"
+        "   or: python -m gestalt._runtime build ROOT MODULE:ATTRIBUTE OUTPUT PLUGIN_NAME",
+        file=sys.stderr,
+    )
 
 
 def _runtime_imports():

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -9,18 +9,12 @@ import subprocess
 import sys
 import tempfile
 from concurrent import futures
-from dataclasses import dataclass
 
 from ._plugin import ENV_WRITE_CATALOG, Plugin, Request
 
 ENV_PLUGIN_SOCKET = "GESTALT_PLUGIN_SOCKET"
 CURRENT_PROTOCOL_VERSION = 2
 BUNDLED_CONFIG_NAME = "gestalt-runtime.json"
-SERVER_MAX_WORKERS = 4
-SERVER_SHUTDOWN_GRACE_SECONDS = 2
-WINDOWS_EXECUTABLE_SUFFIX = ".exe"
-PYINSTALLER_BUILD_DIR_NAME = "build"
-PYINSTALLER_SPEC_DIR_NAME = "spec"
 
 
 def serve(plugin: Plugin) -> None:
@@ -33,7 +27,7 @@ def serve(plugin: Plugin) -> None:
     if os.path.exists(socket_path):
         os.unlink(socket_path)
 
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=SERVER_MAX_WORKERS))
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
 
     class ProviderServicer(plugin_pb2_grpc.ProviderPluginServicer):
         def GetMetadata(self, _request, _context):
@@ -74,7 +68,7 @@ def serve(plugin: Plugin) -> None:
     server.start()
 
     def _shutdown(_signum, _frame):
-        server.stop(grace=SERVER_SHUTDOWN_GRACE_SECONDS)
+        server.stop(grace=2)
 
     signal.signal(signal.SIGTERM, _shutdown)
     signal.signal(signal.SIGINT, _shutdown)
@@ -83,28 +77,32 @@ def serve(plugin: Plugin) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
-    try:
-        build_config = _build_config(args)
-        if build_config is not None:
-            build_plugin_binary(
-                build_config.root,
-                build_config.target,
-                build_config.output_path,
-                build_config.plugin_name,
-            )
-            return 0
+    if args[:1] == ["build"]:
+        build_args = _build_argument_parser().parse_args(args[1:])
+        build_plugin_binary(
+            build_args.root,
+            build_args.target,
+            build_args.output_path,
+            build_args.plugin_name,
+        )
+        return 0
 
-        runtime_config = _runtime_config(args)
-    except SystemExit as exc:
-        return exc.code if isinstance(exc.code, int) else 1
+    if args:
+        source_args = _runtime_argument_parser().parse_args(args)
+        root = source_args.root
+        target = source_args.target
+        plugin_name = None
+    else:
+        bundled = _bundled_runtime_config()
+        if bundled is None:
+            _print_usage()
+            return 2
+        target, plugin_name = bundled
+        root = None
 
-    if runtime_config is None:
-        _print_usage()
-        return 2
-
-    plugin = _load_plugin(runtime_config.target, runtime_config.root)
-    if runtime_config.plugin_name:
-        plugin.name = runtime_config.plugin_name
+    plugin = _load_plugin(target, root)
+    if plugin_name:
+        plugin.name = plugin_name
     catalog_path = os.environ.get(ENV_WRITE_CATALOG)
     if catalog_path:
         plugin.write_catalog(catalog_path)
@@ -133,13 +131,33 @@ def build_plugin_binary(root: str, target: str, output_path: str, plugin_name: s
             encoding="utf-8",
         )
 
-        command = _pyinstaller_command(
-            module_name=module_name,
-            root_path=root_path,
-            output_path=output,
-            work_path=work_path,
-            bundle_config_path=bundle_config_path,
-        )
+        pyinstaller_name = output.name
+        if sys.platform == "win32" and pyinstaller_name.endswith(".exe"):
+            pyinstaller_name = pyinstaller_name[:-4]
+
+        command = [
+            sys.executable,
+            "-m",
+            "PyInstaller",
+            "--noconfirm",
+            "--clean",
+            "--onefile",
+            "--distpath",
+            str(output.parent),
+            "--workpath",
+            str(work_path / "build"),
+            "--specpath",
+            str(work_path / "spec"),
+            "--name",
+            pyinstaller_name,
+            "--hidden-import",
+            module_name,
+            "--paths",
+            str(root_path),
+            "--add-data",
+            _pyinstaller_data_arg(bundle_config_path, BUNDLED_CONFIG_NAME),
+            str(_pyinstaller_entrypoint()),
+        ]
         subprocess.run(command, cwd=root_path, check=True)
 
 
@@ -164,43 +182,7 @@ def _split_target(target: str) -> tuple[str, str]:
     return module_name, attr_name
 
 
-@dataclass(frozen=True)
-class _RuntimeConfig:
-    target: str
-    root: str | None = None
-    plugin_name: str | None = None
-
-
-@dataclass(frozen=True)
-class _BuildConfig:
-    root: str
-    target: str
-    output_path: str
-    plugin_name: str
-
-
-def _build_config(args: list[str]) -> _BuildConfig | None:
-    if not args or args[0] != "build":
-        return None
-
-    parsed = _build_argument_parser().parse_args(args[1:])
-    return _BuildConfig(
-        root=parsed.root,
-        target=parsed.target,
-        output_path=parsed.output_path,
-        plugin_name=parsed.plugin_name,
-    )
-
-
-def _runtime_config(args: list[str]) -> _RuntimeConfig | None:
-    if len(args) == 0:
-        return _bundled_runtime_config()
-
-    parsed = _runtime_argument_parser().parse_args(args)
-    return _RuntimeConfig(target=parsed.target, root=parsed.root)
-
-
-def _bundled_runtime_config() -> _RuntimeConfig | None:
+def _bundled_runtime_config() -> tuple[str, str | None] | None:
     config_path = _bundled_config_path()
     if not config_path.exists():
         return None
@@ -212,7 +194,7 @@ def _bundled_runtime_config() -> _RuntimeConfig | None:
         raise RuntimeError(f"{config_path} is missing target")
     if plugin_name is not None:
         plugin_name = str(plugin_name).strip() or None
-    return _RuntimeConfig(target=target, plugin_name=plugin_name)
+    return target, plugin_name
 
 
 def _bundled_config_path() -> pathlib.Path:
@@ -243,46 +225,6 @@ def _build_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument("output_path", metavar="OUTPUT")
     parser.add_argument("plugin_name", metavar="PLUGIN_NAME")
     return parser
-
-
-def _pyinstaller_command(
-    *,
-    module_name: str,
-    root_path: pathlib.Path,
-    output_path: pathlib.Path,
-    work_path: pathlib.Path,
-    bundle_config_path: pathlib.Path,
-) -> list[str]:
-    return [
-        sys.executable,
-        "-m",
-        "PyInstaller",
-        "--noconfirm",
-        "--clean",
-        "--onefile",
-        "--distpath",
-        str(output_path.parent),
-        "--workpath",
-        str(work_path / PYINSTALLER_BUILD_DIR_NAME),
-        "--specpath",
-        str(work_path / PYINSTALLER_SPEC_DIR_NAME),
-        "--name",
-        _pyinstaller_name(output_path),
-        "--hidden-import",
-        module_name,
-        "--paths",
-        str(root_path),
-        "--add-data",
-        _pyinstaller_data_arg(bundle_config_path, BUNDLED_CONFIG_NAME),
-        str(_pyinstaller_entrypoint()),
-    ]
-
-
-def _pyinstaller_name(output_path: pathlib.Path) -> str:
-    name = output_path.name
-    if sys.platform == "win32" and name.endswith(WINDOWS_EXECUTABLE_SUFFIX):
-        return name[: -len(WINDOWS_EXECUTABLE_SUFFIX)]
-    return name
 
 
 def _print_usage() -> None:

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import importlib
 import os
 import pathlib
@@ -10,20 +8,6 @@ from dataclasses import dataclass
 
 from ._bootstrap import parse_plugin_target, read_bundled_plugin_config
 from ._plugin import ENV_WRITE_CATALOG, Plugin, Request
-
-_IMPORT_ERROR: ImportError | None = None
-
-try:
-    import grpc
-    from google.protobuf import json_format
-
-    from .gen.v1 import plugin_pb2, plugin_pb2_grpc
-except ImportError as exc:  # pragma: no cover - depends on local runtime deps
-    grpc = None
-    json_format = None
-    plugin_pb2 = None
-    plugin_pb2_grpc = None
-    _IMPORT_ERROR = exc
 
 ENV_PLUGIN_SOCKET = "GESTALT_PLUGIN_SOCKET"
 CURRENT_PROTOCOL_VERSION = 2
@@ -37,8 +21,10 @@ class RuntimeArgs:
 
 
 def serve(plugin: Plugin) -> None:
-    if _IMPORT_ERROR is not None:
-        raise RuntimeError("gestalt runtime dependencies are not installed") from _IMPORT_ERROR
+    import grpc
+    from google.protobuf import json_format
+
+    from .gen.v1 import plugin_pb2, plugin_pb2_grpc
 
     socket_path = os.environ.get(ENV_PLUGIN_SOCKET)
     if not socket_path:

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -34,7 +34,6 @@ def serve(plugin: Plugin) -> None:
     if os.path.exists(socket_path):
         os.unlink(socket_path)
 
-    # Keep the historical concurrency here so I/O-bound plugin handlers can overlap.
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=GRPC_SERVER_MAX_WORKERS))
 
     class ProviderServicer(plugin_pb2_grpc.ProviderPluginServicer):

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import argparse
 import json
 import os
 import pathlib
@@ -18,7 +17,10 @@ BUNDLED_CONFIG_NAME = "gestalt-runtime.json"
 
 
 def serve(plugin: Plugin) -> None:
-    grpc, json_format, plugin_pb2, plugin_pb2_grpc = _runtime_imports()
+    import grpc
+    from google.protobuf import json_format
+
+    from .gen.v1 import plugin_pb2, plugin_pb2_grpc
 
     socket_path = os.environ.get(ENV_PLUGIN_SOCKET)
     if not socket_path:
@@ -77,28 +79,35 @@ def serve(plugin: Plugin) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
-    if args[:1] == ["build"]:
-        build_args = _build_argument_parser().parse_args(args[1:])
-        build_plugin_binary(
-            build_args.root,
-            build_args.target,
-            build_args.output_path,
-            build_args.plugin_name,
-        )
-        return 0
-
-    if args:
-        source_args = _runtime_argument_parser().parse_args(args)
-        root = source_args.root
-        target = source_args.target
-        plugin_name = None
-    else:
-        bundled = _bundled_runtime_config()
-        if bundled is None:
+    if not args:
+        config_path = pathlib.Path(getattr(sys, "_MEIPASS", pathlib.Path(__file__).resolve().parent))
+        config_path = config_path / BUNDLED_CONFIG_NAME
+        if not config_path.exists():
             _print_usage()
             return 2
-        target, plugin_name = bundled
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        target = data.get("target", "").strip()
+        if not target:
+            raise RuntimeError(f"{config_path} is missing target")
+
+        plugin_name = data.get("plugin_name")
+        if plugin_name is not None:
+            plugin_name = str(plugin_name).strip() or None
         root = None
+    elif args[0] == "build":
+        if len(args) != 5:
+            _print_usage()
+            return 2
+        _, root, target, output_path, plugin_name = args
+        build_plugin_binary(root, target, output_path, plugin_name)
+        return 0
+    else:
+        if len(args) != 2:
+            _print_usage()
+            return 2
+        root, target = args
+        plugin_name = None
 
     plugin = _load_plugin(target, root)
     if plugin_name:
@@ -134,6 +143,7 @@ def build_plugin_binary(root: str, target: str, output_path: str, plugin_name: s
         pyinstaller_name = output.name
         if sys.platform == "win32" and pyinstaller_name.endswith(".exe"):
             pyinstaller_name = pyinstaller_name[:-4]
+        separator = ";" if sys.platform == "win32" else ":"
 
         command = [
             sys.executable,
@@ -155,8 +165,8 @@ def build_plugin_binary(root: str, target: str, output_path: str, plugin_name: s
             "--paths",
             str(root_path),
             "--add-data",
-            _pyinstaller_data_arg(bundle_config_path, BUNDLED_CONFIG_NAME),
-            str(_pyinstaller_entrypoint()),
+            f"{bundle_config_path}{separator}{BUNDLED_CONFIG_NAME}",
+            str(pathlib.Path(__file__).with_name("_pyinstaller.py")),
         ]
         subprocess.run(command, cwd=root_path, check=True)
 
@@ -182,66 +192,12 @@ def _split_target(target: str) -> tuple[str, str]:
     return module_name, attr_name
 
 
-def _bundled_runtime_config() -> tuple[str, str | None] | None:
-    config_path = _bundled_config_path()
-    if not config_path.exists():
-        return None
-
-    data = json.loads(config_path.read_text(encoding="utf-8"))
-    target = data.get("target", "").strip()
-    plugin_name = data.get("plugin_name")
-    if not target:
-        raise RuntimeError(f"{config_path} is missing target")
-    if plugin_name is not None:
-        plugin_name = str(plugin_name).strip() or None
-    return target, plugin_name
-
-
-def _bundled_config_path() -> pathlib.Path:
-    bundle_root = pathlib.Path(getattr(sys, "_MEIPASS", pathlib.Path(__file__).resolve().parent))
-    return bundle_root / BUNDLED_CONFIG_NAME
-
-
-def _pyinstaller_data_arg(source: pathlib.Path, destination_name: str) -> str:
-    separator = ";" if sys.platform == "win32" else ":"
-    return f"{source}{separator}{destination_name}"
-
-
-def _pyinstaller_entrypoint() -> pathlib.Path:
-    return pathlib.Path(__file__).with_name("_pyinstaller.py")
-
-
-def _runtime_argument_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="python -m gestalt._runtime")
-    parser.add_argument("root")
-    parser.add_argument("target", metavar="MODULE:ATTRIBUTE")
-    return parser
-
-
-def _build_argument_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="python -m gestalt._runtime build")
-    parser.add_argument("root")
-    parser.add_argument("target", metavar="MODULE:ATTRIBUTE")
-    parser.add_argument("output_path", metavar="OUTPUT")
-    parser.add_argument("plugin_name", metavar="PLUGIN_NAME")
-    return parser
-
-
 def _print_usage() -> None:
     print(
         "usage: python -m gestalt._runtime ROOT MODULE:ATTRIBUTE\n"
         "   or: python -m gestalt._runtime build ROOT MODULE:ATTRIBUTE OUTPUT PLUGIN_NAME",
         file=sys.stderr,
     )
-
-
-def _runtime_imports():
-    import grpc
-    from google.protobuf import json_format
-
-    from .gen.v1 import plugin_pb2, plugin_pb2_grpc
-
-    return grpc, json_format, plugin_pb2, plugin_pb2_grpc
 
 
 if __name__ == "__main__":

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -11,6 +11,7 @@ from ._plugin import ENV_WRITE_CATALOG, Plugin, Request
 
 ENV_PLUGIN_SOCKET = "GESTALT_PLUGIN_SOCKET"
 CURRENT_PROTOCOL_VERSION = 2
+GRPC_SERVER_MAX_WORKERS = 4
 
 
 @dataclass(frozen=True)
@@ -33,7 +34,8 @@ def serve(plugin: Plugin) -> None:
     if os.path.exists(socket_path):
         os.unlink(socket_path)
 
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
+    # Keep the historical concurrency here so I/O-bound plugin handlers can overlap.
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=GRPC_SERVER_MAX_WORKERS))
 
     class ProviderServicer(plugin_pb2_grpc.ProviderPluginServicer):
         def GetMetadata(self, _request, _context):

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import pathlib
 import signal
@@ -7,11 +8,13 @@ import subprocess
 import sys
 import tempfile
 from concurrent import futures
+from dataclasses import dataclass
 
 from ._plugin import ENV_WRITE_CATALOG, Plugin, Request
 
 ENV_PLUGIN_SOCKET = "GESTALT_PLUGIN_SOCKET"
 CURRENT_PROTOCOL_VERSION = 2
+BUNDLED_CONFIG_NAME = "gestalt-runtime.json"
 
 
 def serve(plugin: Plugin) -> None:
@@ -79,16 +82,18 @@ def main(argv: list[str] | None = None) -> int:
         build_plugin_binary(root, target, output_path, plugin_name)
         return 0
 
-    if len(args) != 2:
+    runtime_config = _runtime_config(args)
+    if runtime_config is None:
         print(
-            "usage: python -m gestalt._runtime ROOT MODULE:ATTRIBUTE\n"
+            "usage: python -m gestalt._runtime [ROOT MODULE:ATTRIBUTE]\n"
             "   or: python -m gestalt._runtime build ROOT MODULE:ATTRIBUTE OUTPUT PLUGIN_NAME",
             file=sys.stderr,
         )
         return 2
 
-    root, target = args
-    plugin = _load_plugin(target, root)
+    plugin = _load_plugin(runtime_config.target, runtime_config.root)
+    if runtime_config.plugin_name:
+        plugin.name = runtime_config.plugin_name
     catalog_path = os.environ.get(ENV_WRITE_CATALOG)
     if catalog_path:
         plugin.write_catalog(catalog_path)
@@ -106,9 +111,14 @@ def build_plugin_binary(root: str, target: str, output_path: str, plugin_name: s
     output.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="gestalt-python-release-") as work_dir:
         work_path = pathlib.Path(work_dir)
-        launcher_path = work_path / "launcher.py"
-        launcher_path.write_text(
-            _launcher_source(target, plugin_name),
+        bundle_config_path = work_path / BUNDLED_CONFIG_NAME
+        bundle_config_path.write_text(
+            json.dumps(
+                {
+                    "target": target,
+                    "plugin_name": plugin_name,
+                }
+            ),
             encoding="utf-8",
         )
 
@@ -135,9 +145,9 @@ def build_plugin_binary(root: str, target: str, output_path: str, plugin_name: s
             module_name,
             "--paths",
             str(root_path),
-            "--paths",
-            str(_sdk_import_root()),
-            str(launcher_path),
+            "--add-data",
+            _pyinstaller_data_arg(bundle_config_path, BUNDLED_CONFIG_NAME),
+            str(_pyinstaller_entrypoint()),
         ]
         subprocess.run(command, cwd=root_path, check=True)
 
@@ -156,29 +166,6 @@ def _load_plugin(target: str, root: str | None = None) -> Plugin:
     return plugin
 
 
-def _launcher_source(target: str, plugin_name: str) -> str:
-    module_name, attr_name = _split_target(target)
-    return f"""from __future__ import annotations
-
-import importlib
-import os
-
-from gestalt._runtime import serve
-
-_gestalt_module = importlib.import_module({module_name!r})
-_gestalt_plugin = getattr(_gestalt_module, {attr_name!r})
-
-_gestalt_plugin.name = {plugin_name!r}
-
-if __name__ == "__main__":
-    catalog_path = os.environ.get("GESTALT_PLUGIN_WRITE_CATALOG")
-    if catalog_path:
-        _gestalt_plugin.write_catalog(catalog_path)
-        raise SystemExit(0)
-    serve(_gestalt_plugin)
-"""
-
-
 def _split_target(target: str) -> tuple[str, str]:
     module_name, _, attr_name = target.partition(":")
     if not module_name or not attr_name:
@@ -186,8 +173,49 @@ def _split_target(target: str) -> tuple[str, str]:
     return module_name, attr_name
 
 
-def _sdk_import_root() -> pathlib.Path:
-    return pathlib.Path(__file__).resolve().parents[1]
+@dataclass(frozen=True)
+class _RuntimeConfig:
+    target: str
+    root: str | None = None
+    plugin_name: str | None = None
+
+
+def _runtime_config(args: list[str]) -> _RuntimeConfig | None:
+    if len(args) == 2:
+        root, target = args
+        return _RuntimeConfig(target=target, root=root)
+    if len(args) == 0:
+        return _bundled_runtime_config()
+    return None
+
+
+def _bundled_runtime_config() -> _RuntimeConfig | None:
+    config_path = _bundled_config_path()
+    if not config_path.exists():
+        return None
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    target = data.get("target", "").strip()
+    plugin_name = data.get("plugin_name")
+    if not target:
+        raise RuntimeError(f"{config_path} is missing target")
+    if plugin_name is not None:
+        plugin_name = str(plugin_name).strip() or None
+    return _RuntimeConfig(target=target, plugin_name=plugin_name)
+
+
+def _bundled_config_path() -> pathlib.Path:
+    bundle_root = pathlib.Path(getattr(sys, "_MEIPASS", pathlib.Path(__file__).resolve().parent))
+    return bundle_root / BUNDLED_CONFIG_NAME
+
+
+def _pyinstaller_data_arg(source: pathlib.Path, destination_name: str) -> str:
+    separator = ";" if sys.platform == "win32" else ":"
+    return f"{source}{separator}{destination_name}"
+
+
+def _pyinstaller_entrypoint() -> pathlib.Path:
+    return pathlib.Path(__file__).with_name("_pyinstaller.py")
 
 
 def _runtime_imports():

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -4,9 +4,7 @@ import json
 import os
 import pathlib
 import signal
-import subprocess
 import sys
-import tempfile
 from concurrent import futures
 
 from ._plugin import ENV_WRITE_CATALOG, Plugin, Request
@@ -95,13 +93,6 @@ def main(argv: list[str] | None = None) -> int:
         if plugin_name is not None:
             plugin_name = str(plugin_name).strip() or None
         root = None
-    elif args[0] == "build":
-        if len(args) != 5:
-            _print_usage()
-            return 2
-        _, root, target, output_path, plugin_name = args
-        build_plugin_binary(root, target, output_path, plugin_name)
-        return 0
     else:
         if len(args) != 2:
             _print_usage()
@@ -119,56 +110,6 @@ def main(argv: list[str] | None = None) -> int:
 
     serve(plugin)
     return 0
-
-
-def build_plugin_binary(root: str, target: str, output_path: str, plugin_name: str) -> None:
-    root_path = pathlib.Path(root).resolve()
-    output = pathlib.Path(output_path).resolve()
-    module_name, _attr_name = _split_target(target)
-
-    output.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory(prefix="gestalt-python-release-") as work_dir:
-        work_path = pathlib.Path(work_dir)
-        bundle_config_path = work_path / BUNDLED_CONFIG_NAME
-        bundle_config_path.write_text(
-            json.dumps(
-                {
-                    "target": target,
-                    "plugin_name": plugin_name,
-                }
-            ),
-            encoding="utf-8",
-        )
-
-        pyinstaller_name = output.name
-        if sys.platform == "win32" and pyinstaller_name.endswith(".exe"):
-            pyinstaller_name = pyinstaller_name[:-4]
-        separator = ";" if sys.platform == "win32" else ":"
-
-        command = [
-            sys.executable,
-            "-m",
-            "PyInstaller",
-            "--noconfirm",
-            "--clean",
-            "--onefile",
-            "--distpath",
-            str(output.parent),
-            "--workpath",
-            str(work_path / "build"),
-            "--specpath",
-            str(work_path / "spec"),
-            "--name",
-            pyinstaller_name,
-            "--hidden-import",
-            module_name,
-            "--paths",
-            str(root_path),
-            "--add-data",
-            f"{bundle_config_path}{separator}{BUNDLED_CONFIG_NAME}",
-            str(pathlib.Path(__file__).with_name("_pyinstaller.py")),
-        ]
-        subprocess.run(command, cwd=root_path, check=True)
 
 
 def _load_plugin(target: str, root: str | None = None) -> Plugin:
@@ -194,8 +135,7 @@ def _split_target(target: str) -> tuple[str, str]:
 
 def _print_usage() -> None:
     print(
-        "usage: python -m gestalt._runtime ROOT MODULE:ATTRIBUTE\n"
-        "   or: python -m gestalt._runtime build ROOT MODULE:ATTRIBUTE OUTPUT PLUGIN_NAME",
+        "usage: python -m gestalt._runtime ROOT MODULE:ATTRIBUTE",
         file=sys.stderr,
     )
 

--- a/sdk/python/tests/test_build.py
+++ b/sdk/python/tests/test_build.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import pathlib
 import tempfile

--- a/sdk/python/tests/test_build.py
+++ b/sdk/python/tests/test_build.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+from gestalt import _build
+
+
+class BuildTests(unittest.TestCase):
+    def test_build_plugin_binary_writes_bundle_config_and_uses_static_entrypoint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = pathlib.Path(tmpdir) / "plugin"
+            output = root / "dist" / "provider-bin"
+            root.mkdir()
+            captured: dict[str, object] = {}
+
+            def fake_run(command: list[str], cwd: pathlib.Path, check: bool) -> None:
+                captured["command"] = command
+                captured["cwd"] = cwd
+                captured["check"] = check
+
+                add_data = command[command.index("--add-data") + 1]
+                separator = ";" if _build.sys.platform == "win32" else ":"
+                source, destination = add_data.split(separator, 1)
+                captured["destination"] = destination
+                captured["bundle_config"] = json.loads(pathlib.Path(source).read_text(encoding="utf-8"))
+
+            with mock.patch.object(_build.subprocess, "run", side_effect=fake_run):
+                _build.build_plugin_binary(
+                    str(root),
+                    "provider:plugin",
+                    str(output),
+                    "released-plugin",
+                )
+
+        command = captured["command"]
+        self.assertIsInstance(command, list)
+        self.assertIn("--add-data", command)
+        self.assertEqual(captured["cwd"], root.resolve())
+        self.assertTrue(captured["check"])
+        self.assertEqual(captured["destination"], _build.BUNDLED_CONFIG_NAME)
+        self.assertEqual(
+            captured["bundle_config"],
+            {
+                "target": "provider:plugin",
+                "plugin_name": "released-plugin",
+            },
+        )
+        self.assertEqual(command[-1], str(pathlib.Path(_build.__file__).with_name("_pyinstaller.py")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/python/tests/test_build.py
+++ b/sdk/python/tests/test_build.py
@@ -45,7 +45,7 @@ class BuildTests(unittest.TestCase):
         self.assertIn("--add-data", command)
         self.assertEqual(captured["cwd"], root.resolve())
         self.assertTrue(captured["check"])
-        self.assertEqual(captured["destination"], _bootstrap.BUNDLED_CONFIG_NAME)
+        self.assertEqual(captured["destination"], ".")
         self.assertEqual(
             captured["bundle_config"],
             {

--- a/sdk/python/tests/test_build.py
+++ b/sdk/python/tests/test_build.py
@@ -6,11 +6,15 @@ import tempfile
 import unittest
 from unittest import mock
 
+from gestalt import _bootstrap
 from gestalt import _build
 
 
 class BuildTests(unittest.TestCase):
+    """Build entrypoint tests."""
+
     def test_build_plugin_binary_writes_bundle_config_and_uses_static_entrypoint(self) -> None:
+        """Build mode should package runtime metadata alongside the frozen entrypoint."""
         with tempfile.TemporaryDirectory() as tmpdir:
             root = pathlib.Path(tmpdir) / "plugin"
             output = root / "dist" / "provider-bin"
@@ -30,10 +34,12 @@ class BuildTests(unittest.TestCase):
 
             with mock.patch.object(_build.subprocess, "run", side_effect=fake_run):
                 _build.build_plugin_binary(
-                    str(root),
-                    "provider:plugin",
-                    str(output),
-                    "released-plugin",
+                    _build.BuildArgs(
+                        root=str(root),
+                        target="provider:plugin",
+                        output_path=str(output),
+                        plugin_name="released-plugin",
+                    )
                 )
 
         command = captured["command"]
@@ -41,7 +47,7 @@ class BuildTests(unittest.TestCase):
         self.assertIn("--add-data", command)
         self.assertEqual(captured["cwd"], root.resolve())
         self.assertTrue(captured["check"])
-        self.assertEqual(captured["destination"], _build.BUNDLED_CONFIG_NAME)
+        self.assertEqual(captured["destination"], _bootstrap.BUNDLED_CONFIG_NAME)
         self.assertEqual(
             captured["bundle_config"],
             {

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -11,7 +11,7 @@ from gestalt import _runtime
 
 
 class RuntimeTests(unittest.TestCase):
-    def test_runtime_config_uses_bundled_metadata_when_no_args(self) -> None:
+    def test_bundled_runtime_config_uses_bundled_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             bundle_dir = pathlib.Path(tmpdir)
             (bundle_dir / _runtime.BUNDLED_CONFIG_NAME).write_text(
@@ -25,15 +25,11 @@ class RuntimeTests(unittest.TestCase):
             )
 
             with mock.patch.object(_runtime.sys, "_MEIPASS", str(bundle_dir), create=True):
-                config = _runtime._runtime_config([])
+                config = _runtime._bundled_runtime_config()
 
         self.assertEqual(
             config,
-            _runtime._RuntimeConfig(
-                root=None,
-                target="provider:plugin",
-                plugin_name="released-plugin",
-            ),
+            ("provider:plugin", "released-plugin"),
         )
 
     def test_main_loads_bundled_plugin_and_applies_plugin_name(self) -> None:
@@ -42,10 +38,7 @@ class RuntimeTests(unittest.TestCase):
         with mock.patch.object(
             _runtime,
             "_bundled_runtime_config",
-            return_value=_runtime._RuntimeConfig(
-                target="provider:plugin",
-                plugin_name="released-plugin",
-            ),
+            return_value=("provider:plugin", "released-plugin"),
         ), mock.patch.object(_runtime, "_load_plugin", return_value=plugin) as load_plugin, mock.patch.object(
             _runtime, "serve"
         ) as serve:

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import pathlib
 import tempfile

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -36,47 +36,6 @@ class RuntimeTests(unittest.TestCase):
         serve.assert_called_once_with(plugin)
         self.assertEqual(plugin.name, "released-plugin")
 
-    def test_build_plugin_binary_writes_bundle_config_and_uses_static_entrypoint(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            root = pathlib.Path(tmpdir) / "plugin"
-            output = root / "dist" / "provider-bin"
-            root.mkdir()
-            captured: dict[str, object] = {}
-
-            def fake_run(command: list[str], cwd: pathlib.Path, check: bool) -> None:
-                captured["command"] = command
-                captured["cwd"] = cwd
-                captured["check"] = check
-
-                add_data = command[command.index("--add-data") + 1]
-                separator = ";" if _runtime.sys.platform == "win32" else ":"
-                source, destination = add_data.split(separator, 1)
-                captured["destination"] = destination
-                captured["bundle_config"] = json.loads(pathlib.Path(source).read_text(encoding="utf-8"))
-
-            with mock.patch.object(_runtime.subprocess, "run", side_effect=fake_run):
-                _runtime.build_plugin_binary(
-                    str(root),
-                    "provider:plugin",
-                    str(output),
-                    "released-plugin",
-                )
-
-        command = captured["command"]
-        self.assertIsInstance(command, list)
-        self.assertIn("--add-data", command)
-        self.assertEqual(captured["cwd"], root.resolve())
-        self.assertTrue(captured["check"])
-        self.assertEqual(captured["destination"], _runtime.BUNDLED_CONFIG_NAME)
-        self.assertEqual(
-            captured["bundle_config"],
-            {
-                "target": "provider:plugin",
-                "plugin_name": "released-plugin",
-            },
-        )
-        self.assertEqual(command[-1], str(pathlib.Path(_runtime.__file__).with_name("_pyinstaller.py")))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -11,7 +11,9 @@ from gestalt import _runtime
 
 
 class RuntimeTests(unittest.TestCase):
-    def test_bundled_runtime_config_uses_bundled_metadata(self) -> None:
+    def test_main_loads_bundled_plugin_and_applies_plugin_name(self) -> None:
+        plugin = Plugin("source-name")
+
         with tempfile.TemporaryDirectory() as tmpdir:
             bundle_dir = pathlib.Path(tmpdir)
             (bundle_dir / _runtime.BUNDLED_CONFIG_NAME).write_text(
@@ -24,25 +26,10 @@ class RuntimeTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            with mock.patch.object(_runtime.sys, "_MEIPASS", str(bundle_dir), create=True):
-                config = _runtime._bundled_runtime_config()
-
-        self.assertEqual(
-            config,
-            ("provider:plugin", "released-plugin"),
-        )
-
-    def test_main_loads_bundled_plugin_and_applies_plugin_name(self) -> None:
-        plugin = Plugin("source-name")
-
-        with mock.patch.object(
-            _runtime,
-            "_bundled_runtime_config",
-            return_value=("provider:plugin", "released-plugin"),
-        ), mock.patch.object(_runtime, "_load_plugin", return_value=plugin) as load_plugin, mock.patch.object(
-            _runtime, "serve"
-        ) as serve:
-            result = _runtime.main([])
+            with mock.patch.object(_runtime.sys, "_MEIPASS", str(bundle_dir), create=True), mock.patch.object(
+                _runtime, "_load_plugin", return_value=plugin
+            ) as load_plugin, mock.patch.object(_runtime, "serve") as serve:
+                result = _runtime.main([])
 
         self.assertEqual(result, 0)
         load_plugin.assert_called_once_with("provider:plugin", None)
@@ -88,7 +75,7 @@ class RuntimeTests(unittest.TestCase):
                 "plugin_name": "released-plugin",
             },
         )
-        self.assertEqual(command[-1], str(_runtime._pyinstaller_entrypoint()))
+        self.assertEqual(command[-1], str(pathlib.Path(_runtime.__file__).with_name("_pyinstaller.py")))
 
 
 if __name__ == "__main__":

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -7,16 +7,20 @@ import unittest
 from unittest import mock
 
 from gestalt import Plugin
+from gestalt import _bootstrap
 from gestalt import _runtime
 
 
 class RuntimeTests(unittest.TestCase):
+    """Runtime entrypoint tests."""
+
     def test_main_loads_bundled_plugin_and_applies_plugin_name(self) -> None:
+        """Bundled executions should load target metadata from the packaged config."""
         plugin = Plugin("source-name")
 
         with tempfile.TemporaryDirectory() as tmpdir:
             bundle_dir = pathlib.Path(tmpdir)
-            (bundle_dir / _runtime.BUNDLED_CONFIG_NAME).write_text(
+            (bundle_dir / _bootstrap.BUNDLED_CONFIG_NAME).write_text(
                 json.dumps(
                     {
                         "target": "provider:plugin",
@@ -27,12 +31,19 @@ class RuntimeTests(unittest.TestCase):
             )
 
             with mock.patch.object(_runtime.sys, "_MEIPASS", str(bundle_dir), create=True), mock.patch.object(
-                _runtime, "_load_plugin", return_value=plugin
+                _runtime,
+                "_load_plugin",
+                return_value=plugin,
             ) as load_plugin, mock.patch.object(_runtime, "serve") as serve:
                 result = _runtime.main([])
 
         self.assertEqual(result, 0)
-        load_plugin.assert_called_once_with("provider:plugin", None)
+        load_plugin.assert_called_once_with(
+            _runtime.RuntimeArgs(
+                target="provider:plugin",
+                plugin_name="released-plugin",
+            )
+        )
         serve.assert_called_once_with(plugin)
         self.assertEqual(plugin.name, "released-plugin")
 

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+from gestalt import Plugin
+from gestalt import _runtime
+
+
+class RuntimeTests(unittest.TestCase):
+    def test_runtime_config_uses_bundled_metadata_when_no_args(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_dir = pathlib.Path(tmpdir)
+            (bundle_dir / _runtime.BUNDLED_CONFIG_NAME).write_text(
+                json.dumps(
+                    {
+                        "target": "provider:plugin",
+                        "plugin_name": "released-plugin",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(_runtime.sys, "_MEIPASS", str(bundle_dir), create=True):
+                config = _runtime._runtime_config([])
+
+        self.assertEqual(
+            config,
+            _runtime._RuntimeConfig(
+                root=None,
+                target="provider:plugin",
+                plugin_name="released-plugin",
+            ),
+        )
+
+    def test_main_loads_bundled_plugin_and_applies_plugin_name(self) -> None:
+        plugin = Plugin("source-name")
+
+        with mock.patch.object(
+            _runtime,
+            "_bundled_runtime_config",
+            return_value=_runtime._RuntimeConfig(
+                target="provider:plugin",
+                plugin_name="released-plugin",
+            ),
+        ), mock.patch.object(_runtime, "_load_plugin", return_value=plugin) as load_plugin, mock.patch.object(
+            _runtime, "serve"
+        ) as serve:
+            result = _runtime.main([])
+
+        self.assertEqual(result, 0)
+        load_plugin.assert_called_once_with("provider:plugin", None)
+        serve.assert_called_once_with(plugin)
+        self.assertEqual(plugin.name, "released-plugin")
+
+    def test_build_plugin_binary_writes_bundle_config_and_uses_static_entrypoint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = pathlib.Path(tmpdir) / "plugin"
+            output = root / "dist" / "provider-bin"
+            root.mkdir()
+            captured: dict[str, object] = {}
+
+            def fake_run(command: list[str], cwd: pathlib.Path, check: bool) -> None:
+                captured["command"] = command
+                captured["cwd"] = cwd
+                captured["check"] = check
+
+                add_data = command[command.index("--add-data") + 1]
+                separator = ";" if _runtime.sys.platform == "win32" else ":"
+                source, destination = add_data.split(separator, 1)
+                captured["destination"] = destination
+                captured["bundle_config"] = json.loads(pathlib.Path(source).read_text(encoding="utf-8"))
+
+            with mock.patch.object(_runtime.subprocess, "run", side_effect=fake_run):
+                _runtime.build_plugin_binary(
+                    str(root),
+                    "provider:plugin",
+                    str(output),
+                    "released-plugin",
+                )
+
+        command = captured["command"]
+        self.assertIsInstance(command, list)
+        self.assertIn("--add-data", command)
+        self.assertEqual(captured["cwd"], root.resolve())
+        self.assertTrue(captured["check"])
+        self.assertEqual(captured["destination"], _runtime.BUNDLED_CONFIG_NAME)
+        self.assertEqual(
+            captured["bundle_config"],
+            {
+                "target": "provider:plugin",
+                "plugin_name": "released-plugin",
+            },
+        )
+        self.assertEqual(command[-1], str(_runtime._pyinstaller_entrypoint()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace the generated PyInstaller launcher with a checked-in bootstrap entrypoint
- let `gestalt._runtime` load either CLI source config or bundled release metadata through one code path
- add Python unit coverage for bundled runtime config loading and release build command assembly

## Testing
- `PYTHONPATH=sdk/python python3 -m unittest discover -s sdk/python/tests -v`
- `python3 -m compileall sdk/python/gestalt sdk/python/tests`
- `go test ./cmd/gestaltd -run TestRun_PluginReleaseBuildsPythonSourcePluginForCurrentPlatform -count=1`
