### PR TITLE
Fix management admin navigation on split listeners

### DIFF
--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -29,7 +29,9 @@ It is not a production-ready security posture.
 ## Production Install Pattern
 
 For production, override the default auth and datastore settings and provide
-the required environment variables through `extraEnv`.
+the required environment variables through `extraEnv`. Prefer enabling the
+separate management listener and internal management Service so `/admin` and
+`/metrics` do not share the public listener.
 
 ```yaml
 config:
@@ -156,7 +158,9 @@ This configuration keeps the public UI and API on port `8080` while exposing
 `/admin` and `/metrics` only through the internal `gestalt-management` Service
 on port `9090`. If operators need browser access to `/admin`, place an
 internal-only ingress, VPN, or identity-aware proxy in front of that management
-Service rather than exposing it on the public ingress.
+Service rather than exposing it on the public ingress. Because `server.base_url`
+is set, the management admin UI can still link operators back to the public
+client UI hostname.
 
 ## When To Enable `pluginInit`
 

--- a/docs/content/observability.mdx
+++ b/docs/content/observability.mdx
@@ -203,8 +203,10 @@ When Gestalt serves `/metrics` on the public listener, it is authenticated with
 the same session or bearer-token middleware as the rest of the HTTP API. When
 `server.management` is configured, `/metrics` moves to the management listener
 and is expected to be protected by network policy or an internal-only reverse
-proxy instead. The embedded admin UI visualizes that same scrape surface instead
-of using a separate metrics API.
+proxy instead. That split-listener shape is the recommended production
+deployment. Keeping `/metrics` on the public listener is mainly for local
+development and other trusted-network environments. The embedded admin UI
+visualizes that same scrape surface instead of using a separate metrics API.
 
 The Prometheus endpoint and OTLP export hang off the same meter provider and
 include the HTTP middleware metrics, broker metrics, plugin gRPC client

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -47,12 +47,15 @@ server:
 | `public.host` | No | all interfaces | Host or IP for the public listener. |
 | `public.port` | No | `8080` | Port for the public listener. |
 | `management.host` | No | all interfaces | Host or IP for the optional management listener. |
-| `management.port` | No | — | Port for the optional management listener. When omitted, `/admin` and `/metrics` stay on the public listener. |
+| `management.port` | No | — | Port for the optional management listener. When omitted, `/admin` and `/metrics` stay on the public listener. That mode is best kept to local development or other trusted-network deployments. |
 | `port` | No | `8080` | Backward-compatible shorthand for `public.port`. `public.port` takes precedence when both are set. |
-| `base_url` | No | — | Derives OAuth callback URLs when explicit redirect URLs are omitted. |
+| `base_url` | No | — | Derives OAuth callback URLs when explicit redirect URLs are omitted, and gives the management admin UI an absolute link back to the public client UI. |
 | `encryption_key` | Yes | — | Root deployment secret. Used for encryption and derived session material. |
 | `api_token_ttl` | No | `30d` | Lifetime of newly issued API tokens. Accepts Go duration strings (`1h`, `720h`) and day suffixes (`30d`). |
 | `artifacts_dir` | No | Config file directory | Writable directory for prepared artifacts produced by `init` and consumed by `serve --locked` when no CLI override is supplied. See [Configuration](/configuration). |
+
+For production, prefer configuring `server.management` so the operator surface
+leaves the public listener entirely.
 
 When `server.management` is configured, Gestalt serves:
 
@@ -63,6 +66,10 @@ The management listener is intended to be protected by deployment infrastructure
 such as private networking, VPN, or an internal-only reverse proxy. Gestalt does
 not apply its own session or API-token auth to `/metrics` on the management
 listener.
+
+When `server.base_url` is set, the management admin UI uses that absolute URL
+for its `Client UI` link. When `server.base_url` is unset, the management admin
+UI omits that link rather than sending operators to a broken same-origin `/`.
 
 ## `auth`
 

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -5,7 +5,8 @@ This page documents the HTTP surface exposed by `gestaltd`.
 When `server.management` is not configured, every route below is served from the
 public listener. When `server.management` is configured, `/admin`, `/metrics`,
 `/health`, and `/ready` move to the management listener and return `404` on the
-public listener.
+public listener. For production deployments, prefer the split-listener setup so
+the operator surface does not share the public listener.
 
 ## Authentication Model
 
@@ -25,7 +26,7 @@ Valid bearer tokens are:
 | --- | --- | --- |
 | `GET` | `/health` | Basic liveness check. |
 | `GET` | `/ready` | Readiness check. Returns `503` until providers and datastore are ready. |
-| `GET` | `/admin` and `/admin/*` | Embedded admin UI shell. On the management listener it reads same-origin `/metrics` without Gestalt auth, so access control is expected to come from your network or reverse proxy. |
+| `GET` | `/admin` and `/admin/*` | Embedded admin UI shell. On the management listener it reads same-origin `/metrics` without Gestalt auth, so access control is expected to come from your network or reverse proxy. When `server.base_url` is set, the management admin UI links back to that public URL for `Client UI`; otherwise it omits that link. |
 | `GET` | `/api/v1/auth/info` | Returns platform auth metadata. |
 | `POST` | `/api/v1/auth/login` | Starts platform login. |
 | `GET` | `/api/v1/auth/login/callback` | Completes platform login. |
@@ -64,7 +65,7 @@ Valid bearer tokens are:
 
 | Method | Path | Purpose |
 | --- | --- | --- |
-| `GET` | `/metrics` | Prometheus scrape endpoint for emitted metrics. Requires Gestalt auth only when served on the public listener. |
+| `GET` | `/metrics` | Prometheus scrape endpoint for emitted metrics. Requires Gestalt auth only when served on the public listener. The recommended production pattern is to move it to `server.management` and protect that listener at the network or proxy layer. |
 
 ## MCP
 

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -113,6 +113,11 @@ docker run --rm \
 This keeps `/admin` and `/metrics` off the public interface while still making
 them reachable from the host at `127.0.0.1:9090`.
 
+For production-style deployments, prefer this split-listener pattern over
+leaving `/admin` and `/metrics` on the public listener. If you also set
+`server.base_url`, the management admin UI can link back to the public client
+UI hostname; otherwise it omits that link.
+
 ## Run a prepared production image
 
 For deterministic production images, run `gestaltd init` before `docker build`
@@ -196,7 +201,8 @@ The container exposes:
 By default the client UI is served from `/` and the built-in admin UI is served
 from `/admin` on the public listener. If you configure `server.management`, then
 `/admin`, `/metrics`, `/health`, and `/ready` move to the management listener
-instead.
+instead. That split is the recommended production deployment shape; the
+single-listener mode is mainly for local development and trusted-network use.
 
 ## SQLite and `/data`
 

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -518,7 +518,7 @@ func TestE2EInitServeLockedSplitManagementListener(t *testing.T) {
 		t.Fatalf("gestaltd init: %v\n%s", err, out)
 	}
 
-	serveLockedAndExerciseWithManagement(t, cfgPath, publicPort, managementPort, "", func(t *testing.T, publicBaseURL, managementBaseURL string) {
+	stdout, stderr := serveLockedAndExerciseWithManagement(t, cfgPath, publicPort, managementPort, "", func(t *testing.T, publicBaseURL, managementBaseURL string) {
 		invokeExampleOperation(t, publicBaseURL, "echo", `{"message":"hello"}`, http.StatusOK)
 
 		publicMetrics := getEndpointBody(t, publicBaseURL+"/metrics", http.StatusNotFound)
@@ -536,11 +536,28 @@ func TestE2EInitServeLockedSplitManagementListener(t *testing.T) {
 			t.Fatalf("expected management listener to expose /metrics: %s", managementMetrics)
 		}
 
+		managementRoot := getEndpointBody(t, managementBaseURL+"/", http.StatusOK)
+		if !bytes.Contains(managementRoot, []byte("Prometheus metrics")) {
+			t.Fatalf("expected management listener root to land on admin ui: %s", managementRoot)
+		}
+
 		managementAdmin := getEndpointBody(t, managementBaseURL+"/admin", http.StatusOK)
 		if !bytes.Contains(managementAdmin, []byte("Prometheus metrics")) {
 			t.Fatalf("expected management listener to expose /admin: %s", managementAdmin)
 		}
+		if !bytes.Contains(managementAdmin, []byte(`class="brand" href="/admin/"`)) {
+			t.Fatalf("expected management admin brand link to stay on /admin: %s", managementAdmin)
+		}
+		if bytes.Contains(managementAdmin, []byte(`<a href="/">Client UI</a>`)) {
+			t.Fatalf("did not expect management admin to link to same-origin /: %s", managementAdmin)
+		}
+		if !bytes.Contains(managementAdmin, []byte(`href="https://gestalt.example.test"`)) {
+			t.Fatalf("expected management admin to link to configured public base url: %s", managementAdmin)
+		}
 	})
+	if !strings.Contains(stdout, "management listener serves /admin and /metrics without Gestalt auth") {
+		t.Fatalf("expected management-listener warning in stdout\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
 }
 
 func TestE2EBareGestaltdAutoInit(t *testing.T) {
@@ -1153,6 +1170,7 @@ datastore:
     path: %s
 server:
   encryption_key: test-e2e-key
+  base_url: https://gestalt.example.test
   public:
     port: %d
   management:

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -130,7 +130,7 @@ func runServer(env *bootstrapEnv) error {
 		)
 	}
 
-	clientUI, adminUI, err := resolveUIHandlers(env.Config)
+	clientUI, publicAdminUI, managementAdminUI, err := resolveUIHandlers(env.Config)
 	if err != nil {
 		return fmt.Errorf("resolving ui handlers: %w", err)
 	}
@@ -167,7 +167,7 @@ func runServer(env *bootstrapEnv) error {
 		PrometheusMetrics: env.Result.Telemetry.PrometheusHandler(),
 		MCPHandler:        mcpHandler,
 		ClientUI:          clientUI,
-		AdminUI:           adminUI,
+		AdminUI:           publicAdminUI,
 	}
 
 	publicProfile := server.RouteProfileAll
@@ -202,10 +202,16 @@ func runServer(env *bootstrapEnv) error {
 	}}
 
 	if managementAddr := env.Config.Server.ManagementAddr(); managementAddr != "" {
+		slog.Warn(
+			"management listener serves /admin and /metrics without Gestalt auth; protect server.management with private networking or an internal reverse proxy",
+			"addr", managementAddr,
+		)
+
 		managementConfig := baseServerConfig
 		managementConfig.RouteProfile = server.RouteProfileManagement
 		managementConfig.MCPHandler = nil
 		managementConfig.ClientUI = nil
+		managementConfig.AdminUI = managementAdminUI
 		managementSrv, err := server.New(managementConfig)
 		if err != nil {
 			return fmt.Errorf("creating management server: %w", err)
@@ -275,16 +281,33 @@ const (
 	adminUIDirEnv  = "GESTALTD_ADMIN_UI_DIR"
 )
 
-func resolveUIHandlers(cfg *config.Config) (http.Handler, http.Handler, error) {
+func resolveUIHandlers(cfg *config.Config) (http.Handler, http.Handler, http.Handler, error) {
 	clientUI, err := resolveClientUIHandler(cfg)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	adminUI, err := resolveAdminUIHandler()
+
+	publicAdminUI, err := resolveAdminUIHandler(adminui.Options{
+		BrandHref:    "/",
+		ClientUIHref: "/",
+	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return clientUI, adminUI, nil
+
+	managementClientUIHref := ""
+	if cfg.Server.BaseURL != "" {
+		managementClientUIHref = cfg.Server.BaseURL
+	}
+	managementAdminUI, err := resolveAdminUIHandler(adminui.Options{
+		BrandHref:    "/admin/",
+		ClientUIHref: managementClientUIHref,
+	})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return clientUI, publicAdminUI, managementAdminUI, nil
 }
 
 func resolveClientUIHandler(cfg *config.Config) (http.Handler, error) {
@@ -300,11 +323,11 @@ func resolveClientUIHandler(cfg *config.Config) (http.Handler, error) {
 	return nil, fmt.Errorf("ui plugin configured but asset root not resolved")
 }
 
-func resolveAdminUIHandler() (http.Handler, error) {
+func resolveAdminUIHandler(opts adminui.Options) (http.Handler, error) {
 	if dir := strings.TrimSpace(os.Getenv(adminUIDirEnv)); dir != "" {
-		return webui.DirHandler(dir)
+		return adminui.DirHandler(dir, opts)
 	}
-	handler := adminui.EmbeddedHandler()
+	handler := adminui.EmbeddedHandler(opts)
 	if handler == nil {
 		return nil, fmt.Errorf("embedded admin ui assets not found")
 	}

--- a/gestaltd/internal/adminui/adminui.go
+++ b/gestaltd/internal/adminui/adminui.go
@@ -71,13 +71,13 @@ func renderIndexHTML(indexHTML []byte, opts Options) []byte {
 	replaced := strings.Replace(
 		string(indexHTML),
 		`<a class="brand" href="/">Gestalt</a>`,
-		fmt.Sprintf(`<a class="brand" href="%s">Gestalt</a>`, html.EscapeString(normalized.BrandHref)),
+		fmt.Sprintf(`<a class="brand" href=%q>Gestalt</a>`, html.EscapeString(normalized.BrandHref)),
 		1,
 	)
 
 	clientUILink := ""
 	if normalized.ClientUIHref != "" {
-		clientUILink = fmt.Sprintf(`<a href="%s">Client UI</a>`, html.EscapeString(normalized.ClientUIHref))
+		clientUILink = fmt.Sprintf(`<a href=%q>Client UI</a>`, html.EscapeString(normalized.ClientUIHref))
 	}
 	replaced = strings.Replace(replaced, `<a href="/">Client UI</a>`, clientUILink, 1)
 	return []byte(replaced)

--- a/gestaltd/internal/adminui/adminui.go
+++ b/gestaltd/internal/adminui/adminui.go
@@ -1,15 +1,93 @@
 package adminui
 
 import (
+	"bytes"
 	"embed"
+	"fmt"
+	"html"
+	"io/fs"
 	"net/http"
-
-	"github.com/valon-technologies/gestalt/server/internal/webui"
+	"os"
+	"strings"
+	"time"
 )
 
 //go:embed all:out
 var assets embed.FS
 
-func EmbeddedHandler() http.Handler {
-	return webui.SubdirHandler(assets, "out")
+type Options struct {
+	BrandHref    string
+	ClientUIHref string
+}
+
+func EmbeddedHandler(opts Options) http.Handler {
+	handler, err := subdirHandler(assets, "out", opts)
+	if err != nil {
+		return nil
+	}
+	return handler
+}
+
+func DirHandler(path string, opts Options) (http.Handler, error) {
+	return newHandler(os.DirFS(path), opts)
+}
+
+func subdirHandler(root fs.FS, dir string, opts Options) (http.Handler, error) {
+	sub, err := fs.Sub(root, dir)
+	if err != nil {
+		return nil, err
+	}
+	return newHandler(sub, opts)
+}
+
+func newHandler(root fs.FS, opts Options) (http.Handler, error) {
+	if _, err := fs.Stat(root, "index.html"); err != nil {
+		return nil, fmt.Errorf("admin ui asset root does not contain index.html")
+	}
+
+	indexHTML, err := fs.ReadFile(root, "index.html")
+	if err != nil {
+		return nil, fmt.Errorf("read admin ui index: %w", err)
+	}
+	renderedIndex := renderIndexHTML(indexHTML, opts)
+	fileServer := http.FileServer(http.FS(root))
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/")
+		if path != "" && strings.Contains(path, ".") && path != "index.html" {
+			if info, err := fs.Stat(root, path); err == nil && !info.IsDir() {
+				fileServer.ServeHTTP(w, r)
+				return
+			}
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		http.ServeContent(w, r, "index.html", time.Time{}, bytes.NewReader(renderedIndex))
+	}), nil
+}
+
+func renderIndexHTML(indexHTML []byte, opts Options) []byte {
+	normalized := normalizeOptions(opts)
+	replaced := strings.Replace(
+		string(indexHTML),
+		`<a class="brand" href="/">Gestalt</a>`,
+		fmt.Sprintf(`<a class="brand" href="%s">Gestalt</a>`, html.EscapeString(normalized.BrandHref)),
+		1,
+	)
+
+	clientUILink := ""
+	if normalized.ClientUIHref != "" {
+		clientUILink = fmt.Sprintf(`<a href="%s">Client UI</a>`, html.EscapeString(normalized.ClientUIHref))
+	}
+	replaced = strings.Replace(replaced, `<a href="/">Client UI</a>`, clientUILink, 1)
+	return []byte(replaced)
+}
+
+func normalizeOptions(opts Options) Options {
+	opts.BrandHref = strings.TrimSpace(opts.BrandHref)
+	if opts.BrandHref == "" {
+		opts.BrandHref = "/"
+	}
+	opts.ClientUIHref = strings.TrimSpace(opts.ClientUIHref)
+	return opts
 }

--- a/gestaltd/internal/adminui/out/index.html
+++ b/gestaltd/internal/adminui/out/index.html
@@ -288,7 +288,7 @@
         <h1>Prometheus metrics</h1>
         <p>
           The embedded admin UI reuses the client workspace theme and derives a
-          few lightweight views directly from the authenticated
+          few lightweight views directly from the same-origin
           <code>/metrics</code> scrape, with browser-local chart history for
           quick operator debugging.
         </p>
@@ -344,7 +344,7 @@
         </div>
 
         <p class="metric-note controls-note">
-          Filters the browser's current chart history from authenticated
+          Filters the browser's current chart history from same-origin
           <code>/metrics</code> scrapes. Provider totals stay cumulative.
         </p>
       </section>
@@ -355,7 +355,7 @@
           <h2>Requests and failures</h2>
           <div class="chart" id="activity-chart" data-chart-state="empty"></div>
           <p class="metric-note chart-caption">
-            Derived from consecutive authenticated <code>/metrics</code> scrapes
+            Derived from consecutive same-origin <code>/metrics</code> scrapes
             captured in this browser session.
           </p>
         </article>
@@ -375,7 +375,7 @@
           <div class="chart" id="provider-chart" data-chart-state="empty"></div>
           <div class="bar-list" id="provider-bars"></div>
           <p class="metric-note chart-caption">
-            Based on the latest authenticated <code>/metrics</code> scrape for
+            Based on the latest same-origin <code>/metrics</code> scrape for
             this process.
           </p>
         </article>

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -22,6 +22,7 @@ func (s *Server) routes() {
 		s.mountManagementHiddenRoutes(r)
 	case RouteProfileManagement:
 		s.mountCoreRoutes(r, metricsUnauthenticated)
+		s.mountManagementRootRedirect(r)
 		s.mountAdminUIRoutes(r)
 	default:
 		s.mountCoreRoutes(r, metricsAuthenticated)
@@ -55,6 +56,16 @@ func (s *Server) mountCoreRoutes(r chi.Router, exposure metricsExposure) {
 	case metricsUnauthenticated:
 		r.HandleFunc("/metrics", s.servePrometheusMetrics)
 	}
+}
+
+func (s *Server) mountManagementRootRedirect(r chi.Router) {
+	if s.adminUI == nil {
+		return
+	}
+
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/admin/", http.StatusMovedPermanently)
+	})
 }
 
 func (s *Server) mountAdminUIRoutes(r chi.Router) {


### PR DESCRIPTION
## Summary
- keep the split-listener surface intact while fixing the embedded admin UI navigation on the management listener
- point the management admin UI brand link at `/admin/`, use `server.base_url` for the public `Client UI` link when available, and omit that link when it is not
- add a startup warning that `/admin` and `/metrics` on the management listener are expected to be protected by private networking or an internal reverse proxy
- tighten the docs and existing `cmd/gestaltd` functional coverage around the recommended production deployment shape

## How To Configure It
```yaml
server:
  public:
    host: 0.0.0.0
    port: 8080
  management:
    host: 127.0.0.1
    port: 9090
  base_url: https://gestalt.example.com
  encryption_key: ${GESTALT_ENCRYPTION_KEY}
```

With that config:
- public listener: `/`, `/api/v1/*`, auth routes, `/mcp`
- management listener: `/admin`, `/metrics`, `/health`, `/ready`
- when `server.base_url` is set, the management admin UI links back to that public URL for `Client UI`
- when `server.base_url` is unset, the management admin UI omits that link instead of pointing operators at a broken same-origin `/`

## Helm Example
```yaml
managementService:
  enabled: true
  type: ClusterIP
  port: 9090

config:
  server:
    public:
      port: 8080
    management:
      host: 0.0.0.0
      port: 9090
    base_url: https://gestalt.example.com
    encryption_key: ${GESTALT_ENCRYPTION_KEY}
```

Prometheus scraping and operator browser access should go through that internal management Service or an internal-only ingress in front of it, not the public ingress.

## Validation
```sh
go test ./cmd/gestaltd -run 'TestE2EInitServeLockedSplitManagementListener|TestE2EHelmChart|TestE2EInitServeLockedStdoutExposesPrometheusAndEmbeddedAdminUIByDefault|TestE2EInitServeLockedNoopKeepsAdminUIAndReturnsMetricsUnavailable'
```