### PR TITLE
Clean up Python SDK runtime and stub tooling

### DIFF
--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 import os
 import pathlib
@@ -5,6 +7,7 @@ import signal
 import sys
 from concurrent import futures
 from dataclasses import dataclass
+from typing import Any
 
 from ._bootstrap import parse_plugin_target, read_bundled_plugin_config
 from ._plugin import ENV_WRITE_CATALOG, Plugin, Request
@@ -12,6 +15,7 @@ from ._plugin import ENV_WRITE_CATALOG, Plugin, Request
 ENV_PLUGIN_SOCKET = "GESTALT_PLUGIN_SOCKET"
 CURRENT_PROTOCOL_VERSION = 2
 GRPC_SERVER_MAX_WORKERS = 4
+USAGE = "usage: python -m gestalt._runtime ROOT MODULE:ATTRIBUTE"
 
 
 @dataclass(frozen=True)
@@ -21,64 +25,32 @@ class RuntimeArgs:
     plugin_name: str | None = None
 
 
+@dataclass(frozen=True)
+class _RuntimeImports:
+    grpc: Any
+    json_format: Any
+    plugin_pb2: Any
+    plugin_pb2_grpc: Any
+
+
 def serve(plugin: Plugin) -> None:
-    import grpc
-    from google.protobuf import json_format
+    runtime = _runtime_imports()
+    socket_path = _socket_path_from_env()
+    _remove_stale_socket(socket_path)
 
-    from .gen.v1 import plugin_pb2, plugin_pb2_grpc
-
-    socket_path = os.environ.get(ENV_PLUGIN_SOCKET)
-    if not socket_path:
-        raise RuntimeError(f"{ENV_PLUGIN_SOCKET} is required")
-
-    if os.path.exists(socket_path):
-        os.unlink(socket_path)
-
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=GRPC_SERVER_MAX_WORKERS))
-
-    class ProviderServicer(plugin_pb2_grpc.ProviderPluginServicer):
-        def GetMetadata(self, _request, _context):
-            return plugin_pb2.ProviderMetadata(
-                min_protocol_version=CURRENT_PROTOCOL_VERSION,
-                max_protocol_version=CURRENT_PROTOCOL_VERSION,
-            )
-
-        def StartProvider(self, request, _context):
-            config = {}
-            if request.HasField("config"):
-                config = json_format.MessageToDict(
-                    request.config,
-                    preserving_proto_field_name=True,
-                )
-            plugin.configure_provider(request.name, config)
-            return plugin_pb2.StartProviderResponse(protocol_version=CURRENT_PROTOCOL_VERSION)
-
-        def Execute(self, request, _context):
-            params = {}
-            if request.HasField("params"):
-                params = json_format.MessageToDict(
-                    request.params,
-                    preserving_proto_field_name=True,
-                )
-            status, body = plugin.execute(
-                request.operation,
-                params,
-                Request(
-                    token=request.token,
-                    connection_params=dict(request.connection_params),
-                ),
-            )
-            return plugin_pb2.OperationResult(status=status, body=body)
-
-    plugin_pb2_grpc.add_ProviderPluginServicer_to_server(ProviderServicer(), server)
+    server = runtime.grpc.server(
+        futures.ThreadPoolExecutor(max_workers=GRPC_SERVER_MAX_WORKERS)
+    )
+    runtime.plugin_pb2_grpc.add_ProviderPluginServicer_to_server(
+        _provider_servicer(
+            plugin=plugin,
+            runtime=runtime,
+        ),
+        server,
+    )
     server.add_insecure_port(f"unix:{socket_path}")
     server.start()
-
-    def _shutdown(_signum, _frame):
-        server.stop(grace=2)
-
-    signal.signal(signal.SIGTERM, _shutdown)
-    signal.signal(signal.SIGINT, _shutdown)
+    _register_shutdown_handlers(server)
     server.wait_for_termination()
 
 
@@ -92,9 +64,7 @@ def main(argv: list[str] | None = None) -> int:
     if runtime_args.plugin_name:
         plugin.name = runtime_args.plugin_name
 
-    catalog_path = os.environ.get(ENV_WRITE_CATALOG)
-    if catalog_path:
-        plugin.write_catalog(catalog_path)
+    if _write_catalog_if_requested(plugin):
         return 0
 
     serve(plugin)
@@ -120,7 +90,9 @@ def _parse_runtime_args(args: list[str]) -> RuntimeArgs | None:
 
 
 def _bundle_root() -> pathlib.Path:
-    return pathlib.Path(getattr(sys, "_MEIPASS", pathlib.Path(__file__).resolve().parent))
+    return pathlib.Path(
+        getattr(sys, "_MEIPASS", pathlib.Path(__file__).resolve().parent)
+    )
 
 
 def _load_plugin(args: RuntimeArgs) -> Plugin:
@@ -136,7 +108,107 @@ def _load_plugin(args: RuntimeArgs) -> Plugin:
 
 
 def _print_usage() -> None:
-    print("usage: python -m gestalt._runtime ROOT MODULE:ATTRIBUTE", file=sys.stderr)
+    print(USAGE, file=sys.stderr)
+
+
+def _write_catalog_if_requested(plugin: Plugin) -> bool:
+    catalog_path = os.environ.get(ENV_WRITE_CATALOG)
+    if not catalog_path:
+        return False
+
+    plugin.write_catalog(catalog_path)
+    return True
+
+
+def _socket_path_from_env() -> pathlib.Path:
+    socket_path = os.environ.get(ENV_PLUGIN_SOCKET)
+    if not socket_path:
+        raise RuntimeError(f"{ENV_PLUGIN_SOCKET} is required")
+    return pathlib.Path(socket_path)
+
+
+def _remove_stale_socket(socket_path: pathlib.Path) -> None:
+    if socket_path.exists():
+        socket_path.unlink()
+
+
+def _register_shutdown_handlers(server: Any) -> None:
+    def _shutdown(_signum, _frame):
+        server.stop(grace=2)
+
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+
+
+def _provider_servicer(*, plugin: Plugin, runtime: _RuntimeImports):
+    class ProviderServicer(runtime.plugin_pb2_grpc.ProviderPluginServicer):
+        def GetMetadata(self, _request, _context):
+            return runtime.plugin_pb2.ProviderMetadata(
+                min_protocol_version=CURRENT_PROTOCOL_VERSION,
+                max_protocol_version=CURRENT_PROTOCOL_VERSION,
+            )
+
+        def StartProvider(self, request, _context):
+            plugin.configure_provider(
+                request.name,
+                _message_to_dict(
+                    field_name="config",
+                    json_format=runtime.json_format,
+                    message=request.config,
+                    request=request,
+                ),
+            )
+            return runtime.plugin_pb2.StartProviderResponse(
+                protocol_version=CURRENT_PROTOCOL_VERSION
+            )
+
+        def Execute(self, request, _context):
+            status, body = plugin.execute(
+                request.operation,
+                _message_to_dict(
+                    field_name="params",
+                    json_format=runtime.json_format,
+                    message=request.params,
+                    request=request,
+                ),
+                Request(
+                    token=request.token,
+                    connection_params=dict(request.connection_params),
+                ),
+            )
+            return runtime.plugin_pb2.OperationResult(status=status, body=body)
+
+    return ProviderServicer()
+
+
+def _message_to_dict(
+    *,
+    field_name: str,
+    json_format: Any,
+    message: Any,
+    request: Any,
+) -> dict[str, Any]:
+    if not request.HasField(field_name):
+        return {}
+
+    return json_format.MessageToDict(
+        message,
+        preserving_proto_field_name=True,
+    )
+
+
+def _runtime_imports() -> _RuntimeImports:
+    import grpc
+    from google.protobuf import json_format
+
+    from .gen.v1 import plugin_pb2, plugin_pb2_grpc
+
+    return _RuntimeImports(
+        grpc=grpc,
+        json_format=json_format,
+        plugin_pb2=plugin_pb2,
+        plugin_pb2_grpc=plugin_pb2_grpc,
+    )
 
 
 if __name__ == "__main__":

--- a/sdk/python/scripts/generate_stubs.py
+++ b/sdk/python/scripts/generate_stubs.py
@@ -4,18 +4,26 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 
+EXPECTED_PROTOBUF_VERSION = "6.33.1"
+EXPECTED_GRPC_VERSION = "1.80.0"
 EXPECTED_GRPC_IMPORT = "from v1 import plugin_pb2 as v1_dot_plugin__pb2\n"
 RELATIVE_GRPC_IMPORT = "from . import plugin_pb2 as v1_dot_plugin__pb2\n"
-GRPC_RUNTIME_HEADER = """import grpc
+GENERATED_GRPC_HEADER = (
+    "import grpc\n\n"
+    "from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2\n"
+    "from . import plugin_pb2 as v1_dot_plugin__pb2\n"
+)
+GRPC_RUNTIME_HEADER = f"""import grpc
 import warnings
 
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from . import plugin_pb2 as v1_dot_plugin__pb2
 
-GRPC_GENERATED_VERSION = '1.80.0'
+GRPC_GENERATED_VERSION = '{EXPECTED_GRPC_VERSION}'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 
@@ -27,74 +35,139 @@ except ImportError:
 
 if _version_not_supported:
     raise RuntimeError(
-        f'The grpc package installed is at version {GRPC_VERSION},'
+        f'The grpc package installed is at version {{GRPC_VERSION}},'
         + ' but the generated code in v1/plugin_pb2_grpc.py depends on'
-        + f' grpcio>={GRPC_GENERATED_VERSION}.'
-        + f' Please upgrade your grpc module to grpcio>={GRPC_GENERATED_VERSION}'
-        + f' or downgrade your generated code using grpcio-tools<={GRPC_VERSION}.'
+        + f' grpcio>={{GRPC_GENERATED_VERSION}}.'
+        + f' Please upgrade your grpc module to grpcio>={{GRPC_GENERATED_VERSION}}'
+        + f' or downgrade your generated code using grpcio-tools<={{GRPC_VERSION}}.'
     )
 """
 
 
-def main() -> int:
-    repo_root = Path(__file__).resolve().parents[3]
-    proto_dir = repo_root / "sdk/proto"
-    template_path = proto_dir / "buf.python.gen.yaml"
-    target_dir = repo_root / "sdk/python/gestalt/gen/v1"
+@dataclass(frozen=True)
+class StubGenerationPaths:
+    proto_dir: Path
+    target_dir: Path
+    template_path: Path
 
-    if shutil.which("buf") is None:
+
+@dataclass(frozen=True)
+class GeneratedSources:
+    pb2_source: str
+    pb2_grpc_source: str
+
+
+def main() -> int:
+    paths = _stub_generation_paths(Path(__file__).resolve())
+
+    if not _buf_is_available():
         print("buf is required to regenerate Python protobuf stubs", file=sys.stderr)
         return 1
 
     with tempfile.TemporaryDirectory(prefix="gestalt-python-stubs-") as work_dir:
-        work_path = Path(work_dir)
-        subprocess.run(
-            [
-                "buf",
-                "generate",
-                "--template",
-                str(template_path),
-                "--output",
-                str(work_path),
-            ],
-            cwd=proto_dir,
-            check=True,
+        generated_sources = _generate_sources(
+            output_dir=Path(work_dir),
+            paths=paths,
         )
-
-        generated_dir = work_path / "gen/v1"
-        pb2_path = generated_dir / "plugin_pb2.py"
-        pb2_grpc_path = generated_dir / "plugin_pb2_grpc.py"
-
-        pb2_source = pb2_path.read_text(encoding="utf-8")
-        if "Protobuf Python Version: 6.33.1" not in pb2_source:
-            raise RuntimeError(
-                "buf generated plugin_pb2.py without the expected protobuf 6.33.1 runtime floor"
-            )
-
-        pb2_grpc_source = pb2_grpc_path.read_text(encoding="utf-8")
-        if EXPECTED_GRPC_IMPORT not in pb2_grpc_source:
-            raise RuntimeError("unexpected grpc Python import layout in generated stub")
-
-        # Buf's grpc Python plugin emits a top-level import, but these stubs are
-        # vendored under gestalt.gen.v1 and need a package-relative import.
-        pb2_grpc_source = pb2_grpc_source.replace(
-            EXPECTED_GRPC_IMPORT,
-            RELATIVE_GRPC_IMPORT,
-            1,
+        _write_vendored_sources(
+            generated_sources=generated_sources,
+            target_dir=paths.target_dir,
         )
-        pb2_grpc_source = pb2_grpc_source.replace(
-            'import grpc\n\n'
-            'from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2\n'
-            'from . import plugin_pb2 as v1_dot_plugin__pb2\n',
-            GRPC_RUNTIME_HEADER,
-            1,
-        )
-
-        target_dir.mkdir(parents=True, exist_ok=True)
-        (target_dir / "plugin_pb2.py").write_text(pb2_source, encoding="utf-8")
-        (target_dir / "plugin_pb2_grpc.py").write_text(pb2_grpc_source, encoding="utf-8")
 
     return 0
+
+
+def _stub_generation_paths(script_path: Path) -> StubGenerationPaths:
+    repo_root = script_path.parents[3]
+    proto_dir = repo_root / "sdk/proto"
+    return StubGenerationPaths(
+        proto_dir=proto_dir,
+        target_dir=repo_root / "sdk/python/gestalt/gen/v1",
+        template_path=proto_dir / "buf.python.gen.yaml",
+    )
+
+
+def _buf_is_available() -> bool:
+    return shutil.which("buf") is not None
+
+
+def _generate_sources(*, output_dir: Path, paths: StubGenerationPaths) -> GeneratedSources:
+    _run_buf_generate(
+        output_dir=output_dir,
+        proto_dir=paths.proto_dir,
+        template_path=paths.template_path,
+    )
+    generated_dir = output_dir / "gen/v1"
+    pb2_source = _read_source(generated_dir / "plugin_pb2.py")
+    _validate_pb2_source(pb2_source)
+    pb2_grpc_source = _rewrite_pb2_grpc_source(
+        _read_source(generated_dir / "plugin_pb2_grpc.py")
+    )
+    return GeneratedSources(
+        pb2_source=pb2_source,
+        pb2_grpc_source=pb2_grpc_source,
+    )
+
+
+def _run_buf_generate(*, output_dir: Path, proto_dir: Path, template_path: Path) -> None:
+    subprocess.run(
+        [
+            "buf",
+            "generate",
+            "--template",
+            str(template_path),
+            "--output",
+            str(output_dir),
+        ],
+        cwd=proto_dir,
+        check=True,
+    )
+
+
+def _read_source(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _validate_pb2_source(pb2_source: str) -> None:
+    version_marker = f"Protobuf Python Version: {EXPECTED_PROTOBUF_VERSION}"
+    if version_marker not in pb2_source:
+        raise RuntimeError(
+            "buf generated plugin_pb2.py without the expected "
+            f"protobuf {EXPECTED_PROTOBUF_VERSION} runtime floor"
+        )
+
+
+def _rewrite_pb2_grpc_source(pb2_grpc_source: str) -> str:
+    if EXPECTED_GRPC_IMPORT not in pb2_grpc_source:
+        raise RuntimeError("unexpected grpc Python import layout in generated stub")
+
+    # Buf's grpc Python plugin emits a top-level import, but these stubs are
+    # vendored under gestalt.gen.v1 and need a package-relative import plus a
+    # runtime version guard.
+    rewritten_source = pb2_grpc_source.replace(
+        EXPECTED_GRPC_IMPORT,
+        RELATIVE_GRPC_IMPORT,
+        1,
+    )
+    if GENERATED_GRPC_HEADER not in rewritten_source:
+        raise RuntimeError("unexpected grpc Python header in generated stub")
+    return rewritten_source.replace(
+        GENERATED_GRPC_HEADER,
+        GRPC_RUNTIME_HEADER,
+        1,
+    )
+
+
+def _write_vendored_sources(*, generated_sources: GeneratedSources, target_dir: Path) -> None:
+    target_dir.mkdir(parents=True, exist_ok=True)
+    (target_dir / "plugin_pb2.py").write_text(
+        generated_sources.pb2_source,
+        encoding="utf-8",
+    )
+    (target_dir / "plugin_pb2_grpc.py").write_text(
+        generated_sources.pb2_grpc_source,
+        encoding="utf-8",
+    )
 
 
 if __name__ == "__main__":

--- a/sdk/python/tests/test_generate_stubs.py
+++ b/sdk/python/tests/test_generate_stubs.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+def _load_generate_stubs_module():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "generate_stubs.py"
+    spec = importlib.util.spec_from_file_location("generate_stubs", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load generate_stubs.py for testing")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+generate_stubs = _load_generate_stubs_module()
+
+
+class GenerateStubsTests(unittest.TestCase):
+    def test_validate_pb2_source_rejects_unexpected_version(self) -> None:
+        expected_message = (
+            f"expected protobuf {generate_stubs.EXPECTED_PROTOBUF_VERSION} runtime floor"
+        )
+
+        with self.assertRaisesRegex(RuntimeError, expected_message):
+            generate_stubs._validate_pb2_source("# Protobuf Python Version: 7.34.1\n")
+
+    def test_rewrite_pb2_grpc_source_rewrites_import_and_injects_runtime_header(self) -> None:
+        source = (
+            "import grpc\n\n"
+            "from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2\n"
+            "from v1 import plugin_pb2 as v1_dot_plugin__pb2\n\n"
+            "class ProviderPluginStub:\n"
+            "    pass\n"
+        )
+
+        rewritten = generate_stubs._rewrite_pb2_grpc_source(source)
+
+        self.assertIn(generate_stubs.RELATIVE_GRPC_IMPORT, rewritten)
+        self.assertNotIn(generate_stubs.EXPECTED_GRPC_IMPORT, rewritten)
+        self.assertIn(
+            f"GRPC_GENERATED_VERSION = '{generate_stubs.EXPECTED_GRPC_VERSION}'",
+            rewritten,
+        )
+        self.assertIn("class ProviderPluginStub:", rewritten)
+
+    def test_rewrite_pb2_grpc_source_rejects_unexpected_header(self) -> None:
+        source = "from v1 import plugin_pb2 as v1_dot_plugin__pb2\n"
+
+        with self.assertRaisesRegex(RuntimeError, "unexpected grpc Python header"):
+            generate_stubs._rewrite_pb2_grpc_source(source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import pathlib
 import tempfile
@@ -10,10 +12,7 @@ from gestalt import _runtime
 
 
 class RuntimeTests(unittest.TestCase):
-    """Runtime entrypoint tests."""
-
     def test_main_loads_bundled_plugin_and_applies_plugin_name(self) -> None:
-        """Bundled executions should load target metadata from the packaged config."""
         plugin = Plugin("source-name")
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -28,7 +27,12 @@ class RuntimeTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            with mock.patch.object(_runtime.sys, "_MEIPASS", str(bundle_dir), create=True), mock.patch.object(
+            with mock.patch.object(
+                _runtime.sys,
+                "_MEIPASS",
+                str(bundle_dir),
+                create=True,
+            ), mock.patch.object(
                 _runtime,
                 "_load_plugin",
                 return_value=plugin,
@@ -44,6 +48,44 @@ class RuntimeTests(unittest.TestCase):
         )
         serve.assert_called_once_with(plugin)
         self.assertEqual(plugin.name, "released-plugin")
+
+    def test_parse_runtime_args_accepts_explicit_root_and_target(self) -> None:
+        runtime_args = _runtime._parse_runtime_args(
+            ["/tmp/plugin", "example.plugin:PLUGIN"]
+        )
+
+        self.assertEqual(
+            runtime_args,
+            _runtime.RuntimeArgs(
+                target="example.plugin:PLUGIN",
+                root="/tmp/plugin",
+            ),
+        )
+
+    def test_parse_runtime_args_rejects_invalid_explicit_arguments(self) -> None:
+        self.assertIsNone(_runtime._parse_runtime_args(["/tmp/plugin"]))
+
+    def test_write_catalog_if_requested_returns_false_without_env_var(self) -> None:
+        plugin = mock.Mock(spec=Plugin)
+
+        with mock.patch.dict(_runtime.os.environ, {}, clear=True):
+            wrote_catalog = _runtime._write_catalog_if_requested(plugin)
+
+        self.assertFalse(wrote_catalog)
+        plugin.write_catalog.assert_not_called()
+
+    def test_write_catalog_if_requested_writes_catalog_when_env_is_set(self) -> None:
+        plugin = mock.Mock(spec=Plugin)
+
+        with mock.patch.dict(
+            _runtime.os.environ,
+            {_runtime.ENV_WRITE_CATALOG: "/tmp/catalog.json"},
+            clear=True,
+        ):
+            wrote_catalog = _runtime._write_catalog_if_requested(plugin)
+
+        self.assertTrue(wrote_catalog)
+        plugin.write_catalog.assert_called_once_with("/tmp/catalog.json")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- refactor the Python SDK runtime into explicit command parsing, serve helpers, and build helpers
- refactor Python stub generation into small validation/rewrite helpers with named constants
- add lightweight tests around the fragile runtime wiring and gRPC stub rewrite behavior

## Validation
- `uv run python -m unittest discover -s tests`
- `uv run python scripts/generate_stubs.py`
- `uv build`
- `uv run python -c "import gestalt; from gestalt.gen.v1 import plugin_pb2, plugin_pb2_grpc; print('import smoke ok')"`
