### PR TITLE
python sdk: clean up catalog yaml output

### DIFF
--- a/examples/plugins/provider-python/provider.py
+++ b/examples/plugins/provider-python/provider.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import gestalt
 
 plugin = gestalt.Plugin.from_manifest("plugin.yaml")

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -2,7 +2,6 @@ package operator
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -261,17 +260,7 @@ def list_items(_req: gestalt.Request) -> dict[str, object]:
 def status_zero(_req: gestalt.Request) -> gestalt.Response[dict[str, bool]]:
     return gestalt.Response(status=0, body={"ok": True})
 `), 0o644)
-	sdkPath := localPythonSDKPath(t)
-	pythonDepsPath := filepath.Join(dir, ".python-deps")
-	installPyYAMLForTest(t, python3Path, pythonDepsPath)
-	writeTestFile(filepath.ToSlash(filepath.Join(".venv", "bin", "python")), []byte(strings.TrimSpace(
-		fmt.Sprintf(`
-			#!/bin/sh
-			set -eu
-
-			export PYTHONPATH=%q:%q${PYTHONPATH:+:$PYTHONPATH}
-			exec %q "$@"
-		`, pythonDepsPath, sdkPath, python3Path))+"\n"), 0o755)
+	createLocalPythonSDKVenv(t, python3Path, filepath.Join(dir, ".venv"), localPythonSDKPath(t))
 
 	manifest, err := pluginpkg.EncodeSourceManifestFormat(&pluginmanifestv1.Manifest{
 		Source:      "github.com/testowner/plugins/local-python-provider",
@@ -500,23 +489,33 @@ func localPythonSDKPath(t *testing.T) string {
 	return path
 }
 
-func installPyYAMLForTest(t *testing.T, pythonPath, target string) {
+func createLocalPythonSDKVenv(t *testing.T, pythonPath, venvPath, sdkPath string) {
 	t.Helper()
 
-	cmd := exec.Command(
+	createVenv := exec.Command(
 		pythonPath,
+		"-m",
+		"venv",
+		venvPath,
+	)
+	result, err := createVenv.CombinedOutput()
+	if err != nil {
+		t.Fatalf("create Python test venv: %v\n%s", err, result)
+	}
+
+	venvPython := filepath.Join(venvPath, "bin", "python")
+	installSDK := exec.Command(
+		venvPython,
 		"-m",
 		"pip",
 		"install",
 		"--disable-pip-version-check",
 		"--quiet",
-		"--target",
-		target,
-		"PyYAML==6.0.3",
+		sdkPath,
 	)
-	result, err := cmd.CombinedOutput()
+	result, err = installSDK.CombinedOutput()
 	if err != nil {
-		t.Fatalf("install PyYAML for test: %v\n%s", err, result)
+		t.Fatalf("install local Python SDK into test venv: %v\n%s", err, result)
 	}
 }
 

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -358,37 +358,37 @@ print(json.dumps({
 		t.Fatalf("ReadFile(catalog.yaml): %v", err)
 	}
 	catalogText := string(catalogData)
-	if !strings.Contains(catalogText, `id: "echo"`) {
+	if !strings.Contains(catalogText, "id: echo") {
 		t.Fatalf("unexpected catalog contents: %s", catalogData)
 	}
 	if strings.Contains(catalogText, "\n\n") {
 		t.Fatalf("catalog contains unexpected blank lines: %q", catalogText)
 	}
-	arrayParam := regexp.MustCompile(`(?m)- name: "names"\n\s+type: "array"$`)
+	arrayParam := regexp.MustCompile(`(?m)- name: names\n\s+type: array$`)
 	if !arrayParam.MatchString(catalogText) {
 		t.Fatalf("catalog missing array parameter type: %s", catalogText)
 	}
-	objectParam := regexp.MustCompile(`(?m)- name: "metadata"\n\s+type: "object"$`)
+	objectParam := regexp.MustCompile(`(?m)- name: metadata\n\s+type: object$`)
 	if !objectParam.MatchString(catalogText) {
 		t.Fatalf("catalog missing object parameter type: %s", catalogText)
 	}
-	namesDefault := regexp.MustCompile(`(?m)- name: "names"\n\s+type: "array"\n\s+default: null$`)
+	namesDefault := regexp.MustCompile(`(?m)- name: names\n\s+type: array\n\s+default: null$`)
 	if !namesDefault.MatchString(catalogText) {
 		t.Fatalf("catalog missing null default for optional array: %s", catalogText)
 	}
-	filtersParam := regexp.MustCompile(`(?m)- name: "filters"\n\s+type: "object"$`)
+	filtersParam := regexp.MustCompile(`(?m)- name: filters\n\s+type: object$`)
 	if !filtersParam.MatchString(catalogText) {
 		t.Fatalf("catalog missing nested object parameter type: %s", catalogText)
 	}
-	optionalModelParams := regexp.MustCompile(`(?s)- id: "maybe_filters".*?- name: "owner"\n\s+type: "string"\n\s+default: ""`)
+	optionalModelParams := regexp.MustCompile(`(?s)- id: maybe_filters.*?- name: owner\n\s+type: string\n\s+default: ""`)
 	if !optionalModelParams.MatchString(catalogText) {
 		t.Fatalf("catalog missing parameters for Optional model input: %s", catalogText)
 	}
-	limitParam := regexp.MustCompile(`(?m)- name: "limit"\n\s+type: "integer"$`)
+	limitParam := regexp.MustCompile(`(?m)- name: limit\n\s+type: integer$`)
 	if !limitParam.MatchString(catalogText) {
 		t.Fatalf("catalog missing integer parameter type: %s", catalogText)
 	}
-	emptyStringDefault := regexp.MustCompile(`(?m)- name: "prefix"\n\s+type: "string"\n\s+default: ""$`)
+	emptyStringDefault := regexp.MustCompile(`(?m)- name: prefix\n\s+type: string\n\s+default: ""$`)
 	if !emptyStringDefault.MatchString(catalogText) {
 		t.Fatalf("catalog missing empty string default: %s", catalogText)
 	}

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -195,9 +195,7 @@ name = "local-python-provider"
 [tool.gestalt]
 plugin = "provider:plugin"
 `, "\n")), 0o644)
-	writeTestFile("provider.py", []byte(`from __future__ import annotations
-
-from typing import Optional
+	writeTestFile("provider.py", []byte(`from typing import Optional
 
 import gestalt
 
@@ -264,14 +262,16 @@ def status_zero(_req: gestalt.Request) -> gestalt.Response[dict[str, bool]]:
     return gestalt.Response(status=0, body={"ok": True})
 `), 0o644)
 	sdkPath := localPythonSDKPath(t)
+	pythonDepsPath := filepath.Join(dir, ".python-deps")
+	installPyYAMLForTest(t, python3Path, pythonDepsPath)
 	writeTestFile(filepath.ToSlash(filepath.Join(".venv", "bin", "python")), []byte(strings.TrimSpace(
 		fmt.Sprintf(`
 			#!/bin/sh
 			set -eu
 
-			export PYTHONPATH=%q${PYTHONPATH:+:$PYTHONPATH}
+			export PYTHONPATH=%q:%q${PYTHONPATH:+:$PYTHONPATH}
 			exec %q "$@"
-		`, sdkPath, python3Path))+"\n"), 0o755)
+		`, pythonDepsPath, sdkPath, python3Path))+"\n"), 0o755)
 
 	manifest, err := pluginpkg.EncodeSourceManifestFormat(&pluginmanifestv1.Manifest{
 		Source:      "github.com/testowner/plugins/local-python-provider",
@@ -304,9 +304,7 @@ providers:
         path: ./plugin.yaml
 `
 	writeTestFile("config.yaml", []byte(cfg), 0o644)
-	writeTestFile("exercise.py", []byte(`from __future__ import annotations
-
-import json
+	writeTestFile("exercise.py", []byte(`import json
 
 import gestalt
 import provider
@@ -380,7 +378,7 @@ print(json.dumps({
 	if !filtersParam.MatchString(catalogText) {
 		t.Fatalf("catalog missing nested object parameter type: %s", catalogText)
 	}
-	optionalModelParams := regexp.MustCompile(`(?s)- id: maybe_filters.*?- name: owner\n\s+type: string\n\s+default: ""`)
+	optionalModelParams := regexp.MustCompile(`(?s)- id: maybe_filters.*?- name: owner\n\s+type: string\n\s+default: ''`)
 	if !optionalModelParams.MatchString(catalogText) {
 		t.Fatalf("catalog missing parameters for Optional model input: %s", catalogText)
 	}
@@ -388,7 +386,7 @@ print(json.dumps({
 	if !limitParam.MatchString(catalogText) {
 		t.Fatalf("catalog missing integer parameter type: %s", catalogText)
 	}
-	emptyStringDefault := regexp.MustCompile(`(?m)- name: prefix\n\s+type: string\n\s+default: ""$`)
+	emptyStringDefault := regexp.MustCompile(`(?m)- name: prefix\n\s+type: string\n\s+default: ''$`)
 	if !emptyStringDefault.MatchString(catalogText) {
 		t.Fatalf("catalog missing empty string default: %s", catalogText)
 	}
@@ -500,6 +498,26 @@ func localPythonSDKPath(t *testing.T) string {
 		t.Fatalf("Stat(%s): %v", path, err)
 	}
 	return path
+}
+
+func installPyYAMLForTest(t *testing.T, pythonPath, target string) {
+	t.Helper()
+
+	cmd := exec.Command(
+		pythonPath,
+		"-m",
+		"pip",
+		"install",
+		"--disable-pip-version-check",
+		"--quiet",
+		"--target",
+		target,
+		"PyYAML==6.0.3",
+	)
+	result, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install PyYAML for test: %v\n%s", err, result)
+	}
 }
 
 func TestApplyLockedPlugins_SkipsNilIntegrationPlugins(t *testing.T) {

--- a/sdk/python/gestalt/_plugin.py
+++ b/sdk/python/gestalt/_plugin.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 import dataclasses
 import inspect
@@ -516,4 +514,44 @@ def _yaml_scalar(value: Any) -> str:
         return "true" if value else "false"
     if value is None:
         return "null"
+    if isinstance(value, str):
+        if _is_yaml_plain_string(value):
+            return value
+        return json.dumps(value)
     return json.dumps(value)
+
+
+_yaml_bool_like = {"true", "false", "null", "~", "yes", "no", "on", "off"}
+_yaml_number_pattern = re.compile(
+    r"""
+    ^
+    (?:
+        [-+]?(?:0|[1-9][0-9]*)
+        (?:\.[0-9]+)?
+        (?:[eE][-+]?[0-9]+)?
+      |
+        [-+]?\.[0-9]+
+        (?:[eE][-+]?[0-9]+)?
+    )
+    $
+    """,
+    re.VERBOSE,
+)
+
+
+def _is_yaml_plain_string(value: str) -> bool:
+    if value == "" or value != value.strip():
+        return False
+    if value.lower() in _yaml_bool_like:
+        return False
+    if _yaml_number_pattern.match(value):
+        return False
+    if "\n" in value or "\r" in value or "\t" in value:
+        return False
+    if value[0] in "-?:,[]{}#&*!|>'\"%@`":
+        return False
+    if ": " in value or value.endswith(":"):
+        return False
+    if " #" in value:
+        return False
+    return True

--- a/sdk/python/gestalt/_plugin.py
+++ b/sdk/python/gestalt/_plugin.py
@@ -8,6 +8,8 @@ import types
 from dataclasses import MISSING
 from typing import Any, Generic, TypeVar, Union, dataclass_transform, get_args, get_origin, get_type_hints
 
+import yaml
+
 ENV_WRITE_CATALOG = "GESTALT_PLUGIN_WRITE_CATALOG"
 
 T = TypeVar("T")
@@ -473,85 +475,16 @@ def _slug_name(value: str) -> str:
     return cleaned or "plugin"
 
 
-def _yaml_dump(value: Any, indent: int = 0) -> str:
-    return "\n".join(_yaml_lines(value, indent)) + "\n"
+class _CatalogDumper(yaml.SafeDumper):
+    def increase_indent(self, flow: bool = False, indentless: bool = False) -> Any:
+        return super().increase_indent(flow, False)
 
 
-def _yaml_lines(value: Any, indent: int) -> list[str]:
-    prefix = "  " * indent
-    if isinstance(value, dict):
-        lines: list[str] = []
-        for key, item in value.items():
-            if isinstance(item, (dict, list)):
-                nested = _yaml_lines(item, indent + 1)
-                if nested:
-                    lines.append(f"{prefix}{key}:")
-                    lines.extend(nested)
-                else:
-                    lines.append(f"{prefix}{key}: {_yaml_scalar(item)}")
-            else:
-                lines.append(f"{prefix}{key}: {_yaml_scalar(item)}")
-        return lines
-    if isinstance(value, list):
-        lines: list[str] = []
-        for item in value:
-            if isinstance(item, (dict, list)):
-                nested = _yaml_lines(item, indent + 1)
-                if nested:
-                    first, *rest = nested
-                    lines.append(f"{prefix}- {first.lstrip()}")
-                    lines.extend(rest)
-                else:
-                    lines.append(f"{prefix}- {_yaml_scalar(item)}")
-            else:
-                lines.append(f"{prefix}- {_yaml_scalar(item)}")
-        return lines
-    return [f"{prefix}{_yaml_scalar(value)}"]
-
-
-def _yaml_scalar(value: Any) -> str:
-    if isinstance(value, bool):
-        return "true" if value else "false"
-    if value is None:
-        return "null"
-    if isinstance(value, str):
-        if _is_yaml_plain_string(value):
-            return value
-        return json.dumps(value)
-    return json.dumps(value)
-
-
-_yaml_bool_like = {"true", "false", "null", "~", "yes", "no", "on", "off"}
-_yaml_number_pattern = re.compile(
-    r"""
-    ^
-    (?:
-        [-+]?(?:0|[1-9][0-9]*)
-        (?:\.[0-9]+)?
-        (?:[eE][-+]?[0-9]+)?
-      |
-        [-+]?\.[0-9]+
-        (?:[eE][-+]?[0-9]+)?
+def _yaml_dump(value: Any) -> str:
+    return yaml.dump(
+        value,
+        Dumper=_CatalogDumper,
+        sort_keys=False,
+        default_flow_style=False,
+        allow_unicode=True,
     )
-    $
-    """,
-    re.VERBOSE,
-)
-
-
-def _is_yaml_plain_string(value: str) -> bool:
-    if value == "" or value != value.strip():
-        return False
-    if value.lower() in _yaml_bool_like:
-        return False
-    if _yaml_number_pattern.match(value):
-        return False
-    if "\n" in value or "\r" in value or "\t" in value:
-        return False
-    if value[0] in "-?:,[]{}#&*!|>'\"%@`":
-        return False
-    if ": " in value or value.endswith(":"):
-        return False
-    if " #" in value:
-        return False
-    return True

--- a/sdk/python/gestalt/_plugin.py
+++ b/sdk/python/gestalt/_plugin.py
@@ -166,7 +166,16 @@ class Plugin:
     def write_catalog(self, path: str | pathlib.Path) -> None:
         catalog_path = pathlib.Path(path)
         catalog_path.parent.mkdir(parents=True, exist_ok=True)
-        catalog_path.write_text(_yaml_dump(self.catalog_dict()), encoding="utf-8")
+        catalog_path.write_text(
+            yaml.dump(
+                self.catalog_dict(),
+                Dumper=_CatalogDumper,
+                sort_keys=False,
+                default_flow_style=False,
+                allow_unicode=True,
+            ),
+            encoding="utf-8",
+        )
 
     def serve(self) -> None:
         from . import _runtime
@@ -478,13 +487,3 @@ def _slug_name(value: str) -> str:
 class _CatalogDumper(yaml.SafeDumper):
     def increase_indent(self, flow: bool = False, indentless: bool = False) -> Any:
         return super().increase_indent(flow, False)
-
-
-def _yaml_dump(value: Any) -> str:
-    return yaml.dump(
-        value,
-        Dumper=_CatalogDumper,
-        sort_keys=False,
-        default_flow_style=False,
-        allow_unicode=True,
-    )

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -9,6 +9,7 @@ description = "Python SDK for Gestalt executable provider plugins"
 requires-python = ">=3.10"
 dependencies = [
   "grpcio>=1.80.0,<2",
+  "pyyaml==6.0.3",
   "pyinstaller<7",
   "protobuf>=6.33.1,<8",
 ]


### PR DESCRIPTION
## Summary
- stop quoting every safe Python-generated catalog scalar so `catalog.yaml` matches the existing Go style more closely
- keep quoting only when needed, such as empty strings and YAML-ambiguous values
- remove unnecessary `from __future__ import annotations` lines from the touched Python SDK/example files
- update the existing Python source-plugin lifecycle test to assert the cleaner YAML shape

## Validation
- `python3 -m py_compile sdk/python/gestalt/_plugin.py sdk/python/gestalt/_runtime.py examples/plugins/provider-python/provider.py`
- `cd gestaltd && TMPDIR=/Users/hugh/src/.tmpgo go test ./internal/operator -run TestLoadForExecutionAtPath_GeneratesStaticCatalogForLocalPythonSourcePlugin`

## Notes
This keeps the Python SDK on the existing custom YAML writer; it just stops serializing every string through `json.dumps`, which was making the generated catalog look like JSON-in-YAML.