### PR TITLE
Improve Go and Python source plugin ergonomics

### DIFF
--- a/docs/content/plugins/packaging-and-releasing.mdx
+++ b/docs/content/plugins/packaging-and-releasing.mdx
@@ -112,9 +112,9 @@ Run this from the plugin source directory. It produces release archives and writ
 For executable Go plugins, release materializes the executable catalog from the
 typed router before packaging and can target multiple platforms.
 
-For Python source plugins, release loads the plugin declared in
-`[tool.gestalt].plugin`, materializes the executable catalog automatically, and
-builds a current-platform executable artifact from the selected Python
+For Python source plugins, release loads the module or plugin object declared
+in `[tool.gestalt].plugin`, materializes the executable catalog automatically,
+and builds a current-platform executable artifact from the selected Python
 environment.
 
 ## Reference packages from config

--- a/docs/content/plugins/writing-a-plugin.mdx
+++ b/docs/content/plugins/writing-a-plugin.mdx
@@ -151,8 +151,6 @@ Then define operations in `provider.py`:
 ```python
 import gestalt
 
-GREETING = "Hello"
-
 
 class GreetInput(gestalt.Model):
     name: str = gestalt.field(description="Name to greet", default="World")
@@ -162,19 +160,17 @@ class GreetOutput(gestalt.Model):
     message: str
 
 
-def configure(_name: str, config: dict[str, object]) -> None:
-    global GREETING
-    GREETING = str(config.get("greeting", "Hello"))
-
-
 @gestalt.operation(
     method="GET",
     description="Return a greeting message",
     read_only=True,
 )
 def greet(input: GreetInput, _req: gestalt.Request) -> GreetOutput:
-    return GreetOutput(message=f"{GREETING}, {input.name}!")
+    return GreetOutput(message=f"Hello, {input.name}!")
 ```
+
+If your plugin needs startup config, define a plain top-level
+`configure(name, config)` function. It does not need a decorator.
 
 You do not write a launcher script for local development or release. Gestalt loads the module declared in `[tool.gestalt].plugin`, materializes the static catalog automatically, and packages a runnable executable artifact during release.
 

--- a/docs/content/plugins/writing-a-plugin.mdx
+++ b/docs/content/plugins/writing-a-plugin.mdx
@@ -90,7 +90,6 @@ var (
     Description: "Return a greeting message",
   }
   Router = gestalt.MustRouter(
-    "my-plugin",
     gestalt.Register(greetOperation, (*Provider).greet),
   )
 )
@@ -128,7 +127,7 @@ You do not write `main.go`. Gestalt synthesizes the executable wrapper automatic
 
 ## Python typed operations
 
-Point `pyproject.toml` at the plugin object that Gestalt should load:
+Point `pyproject.toml` at the module or plugin object that Gestalt should load:
 
 ```toml
 [build-system]
@@ -141,7 +140,7 @@ version = "0.1.0"
 dependencies = ["gestalt"]
 
 [tool.gestalt]
-plugin = "provider:plugin"
+plugin = "provider"
 ```
 
 If you install the SDK from a private index, pin `gestalt` to that index with
@@ -150,11 +149,9 @@ If you install the SDK from a private index, pin `gestalt` to that index with
 Then define operations in `provider.py`:
 
 ```python
-from __future__ import annotations
-
 import gestalt
 
-plugin = gestalt.Plugin.from_manifest("plugin.yaml")
+GREETING = "Hello"
 
 
 class GreetInput(gestalt.Model):
@@ -165,27 +162,21 @@ class GreetOutput(gestalt.Model):
     message: str
 
 
-@plugin.configure
 def configure(_name: str, config: dict[str, object]) -> None:
-    plugin.greeting = str(config.get("greeting", "Hello"))
+    global GREETING
+    GREETING = str(config.get("greeting", "Hello"))
 
 
-@plugin.operation(
-    id="greet",
+@gestalt.operation(
     method="GET",
     description="Return a greeting message",
     read_only=True,
 )
 def greet(input: GreetInput, _req: gestalt.Request) -> GreetOutput:
-    greeting = getattr(plugin, "greeting", "Hello")
-    return GreetOutput(message=f"{greeting}, {input.name}!")
-
-
-if __name__ == "__main__":
-    plugin.serve()
+    return GreetOutput(message=f"{GREETING}, {input.name}!")
 ```
 
-You do not write a launcher script for local development or release. Gestalt loads `provider:plugin` from `[tool.gestalt]`, materializes the static catalog automatically, and packages a runnable executable artifact during release.
+You do not write a launcher script for local development or release. Gestalt loads the module declared in `[tool.gestalt].plugin`, materializes the static catalog automatically, and packages a runnable executable artifact during release.
 
 ## Write `plugin.yaml`
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -464,7 +464,7 @@ from:
 
 | Field | Purpose |
 | --- | --- |
-| `source.path` | Load a local source plugin from its manifest path. Gestalt synthesizes the Go executable wrapper automatically when needed and runs Python source plugins from `[tool.gestalt].plugin`. |
+| `source.path` | Load a local source plugin from its manifest path. Gestalt synthesizes the Go executable wrapper automatically when needed and runs Python source plugins from the module or plugin object declared in `[tool.gestalt].plugin`. |
 | `source.ref` | Resolve a versioned plugin source during `init`. Format: `github.com/<org>/<repo>/<plugin>`. |
 | `source.version` | Required with `source.ref`. Invalid with `source.path`. |
 | `env` | Extra environment variables for executable providers. |

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -225,6 +225,6 @@ gestaltd plugin release --version 1.2.3
 `plugin.yaml` stays YAML and `plugin.json` stays JSON in the release archive.
 For executable Go plugins, release materializes the executable catalog
 automatically from the provider's typed router before packaging. For Python
-source plugins, release loads the plugin declared in `[tool.gestalt].plugin`,
-materializes the executable catalog automatically, and builds a current-platform
-executable artifact.
+source plugins, release loads the module or plugin object declared in
+`[tool.gestalt].plugin`, materializes the executable catalog automatically, and
+builds a current-platform executable artifact.

--- a/examples/plugins/provider-go/provider.go
+++ b/examples/plugins/provider-go/provider.go
@@ -54,7 +54,6 @@ var (
 		ReadOnly:    true,
 	}
 	Router = gestalt.MustRouter(
-		"example",
 		gestalt.Register(greetOperation, (*Provider).greet),
 		gestalt.Register(echoOperation, (*Provider).echo),
 		gestalt.Register(statusOperation, (*Provider).status),

--- a/examples/plugins/provider-python/provider.py
+++ b/examples/plugins/provider-python/provider.py
@@ -1,7 +1,5 @@
 import gestalt
 
-GREETING = "Hello"
-
 
 class GreetInput(gestalt.Model):
     name: str = gestalt.field(description="Name to greet", default="World")
@@ -11,15 +9,10 @@ class GreetOutput(gestalt.Model):
     message: str
 
 
-def configure(_name: str, config: dict[str, object]) -> None:
-    global GREETING
-    GREETING = str(config.get("greeting", "Hello"))
-
-
 @gestalt.operation(
     method="GET",
     description="Return a greeting message",
     read_only=True,
 )
 def greet(input: GreetInput, _req: gestalt.Request) -> GreetOutput:
-    return GreetOutput(message=f"{GREETING}, {input.name}!")
+    return GreetOutput(message=f"Hello, {input.name}!")

--- a/examples/plugins/provider-python/provider.py
+++ b/examples/plugins/provider-python/provider.py
@@ -1,6 +1,6 @@
 import gestalt
 
-plugin = gestalt.Plugin.from_manifest("plugin.yaml")
+GREETING = "Hello"
 
 
 class GreetInput(gestalt.Model):
@@ -11,15 +11,15 @@ class GreetOutput(gestalt.Model):
     message: str
 
 
-@plugin.operation(
-    id="greet",
+def configure(_name: str, config: dict[str, object]) -> None:
+    global GREETING
+    GREETING = str(config.get("greeting", "Hello"))
+
+
+@gestalt.operation(
     method="GET",
     description="Return a greeting message",
     read_only=True,
 )
 def greet(input: GreetInput, _req: gestalt.Request) -> GreetOutput:
-    return GreetOutput(message=f"Hello, {input.name}!")
-
-
-if __name__ == "__main__":
-    plugin.serve()
+    return GreetOutput(message=f"{GREETING}, {input.name}!")

--- a/examples/plugins/provider-python/pyproject.toml
+++ b/examples/plugins/provider-python/pyproject.toml
@@ -8,4 +8,4 @@ version = "0.1.0"
 dependencies = ["gestalt"]
 
 [tool.gestalt]
-plugin = "provider:plugin"
+plugin = "provider"

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -962,13 +962,9 @@ version = "0.1.0"
 dependencies = ["gestalt"]
 
 [tool.gestalt]
-plugin = "provider:plugin"
+plugin = "provider"
 `), 0o644)
-	writeTestFile(t, pluginDir, "provider.py", []byte(`from __future__ import annotations
-
-import gestalt
-
-plugin = gestalt.Plugin.from_manifest("plugin.yaml")
+	writeTestFile(t, pluginDir, "provider.py", []byte(`import gestalt
 
 
 class GreetInput(gestalt.Model):
@@ -979,7 +975,7 @@ class GreetOutput(gestalt.Model):
     message: str
 
 
-@plugin.operation(id="greet", method="GET", read_only=True)
+@gestalt.operation(method="GET", read_only=True)
 def greet(input: GreetInput, _req: gestalt.Request) -> GreetOutput:
     return GreetOutput(message=f"Hello, {input.name}!")
 `), 0o644)
@@ -1011,7 +1007,7 @@ if [ "$#" -ge 2 ] && [ "$1" = "-m" ] && [ "$2" = "gestalt._build" ]; then
   target="$4"
   output="$5"
   name="$6"
-  if [ "$target" != "provider:plugin" ]; then
+  if [ "$target" != "provider" ]; then
     echo "unexpected provider target: $target" >&2
     exit 1
   fi

--- a/gestaltd/cmd/gestaltd/testmain_test.go
+++ b/gestaltd/cmd/gestaltd/testmain_test.go
@@ -33,7 +33,7 @@ func TestMain(m *testing.M) {
 	go func() { defer wg.Done(); errs[0] = buildGo(".", gestaltdBin) }()
 	go func() {
 		defer wg.Done()
-		errs[1] = pluginpkg.BuildGoProviderBinary("../../../examples/plugins/provider-go", pluginBin, runtime.GOOS, runtime.GOARCH)
+		errs[1] = pluginpkg.BuildGoProviderBinary("../../../examples/plugins/provider-go", pluginBin, "provider-go", runtime.GOOS, runtime.GOARCH)
 	}()
 	wg.Wait()
 

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -126,7 +126,7 @@ func TestPythonSourcePluginFallsBackWithoutGoOnPath(t *testing.T) {
 		t.Fatalf("WriteFile(plugin.yaml): %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte(`[tool.gestalt]
-plugin = "provider:plugin"
+plugin = "provider"
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(pyproject.toml): %v", err)
 	}

--- a/gestaltd/internal/bootstrap/testmain_test.go
+++ b/gestaltd/internal/bootstrap/testmain_test.go
@@ -91,7 +91,7 @@ func TestMain(m *testing.M) {
 
 func buildBootstrapTestBinary(dir, target, output string) error {
 	if target == "" {
-		return pluginpkg.BuildGoProviderBinary(dir, output, runtime.GOOS, runtime.GOARCH)
+		return pluginpkg.BuildGoProviderBinary(dir, output, filepath.Base(dir), runtime.GOOS, runtime.GOARCH)
 	}
 	return runGoCommand(dir, "build", "-o", output, target)
 }

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -192,13 +192,13 @@ build-backend = "setuptools.build_meta"
 name = "local-python-provider"
 
 [tool.gestalt]
-plugin = "provider:plugin"
-`, "\n")), 0o644)
+plugin = "provider"
+	`, "\n")), 0o644)
 	writeTestFile("provider.py", []byte(`from typing import Optional
 
 import gestalt
 
-plugin = gestalt.Plugin.from_manifest("plugin.yaml")
+PREFIX = ""
 
 
 class BaseInput(gestalt.Model):
@@ -220,9 +220,15 @@ class EchoInput(BaseInput):
     limit: int = 0
 
 
-@plugin.operation(id="echo", method="POST")
+def configure(_name: str, config: dict[str, object]) -> None:
+    global PREFIX
+    PREFIX = str(config.get("prefix", ""))
+
+
+@gestalt.operation(method="POST")
 def echo(input: EchoInput, _req: gestalt.Request) -> dict[str, object]:
     return {
+        "configured_prefix": PREFIX,
         "names": input.names or [],
         "metadata": input.metadata or {},
         "filters_type": type(input.filters).__name__ if input.filters else "",
@@ -232,7 +238,7 @@ def echo(input: EchoInput, _req: gestalt.Request) -> dict[str, object]:
     }
 
 
-@plugin.operation(id="double", method="POST")
+@gestalt.operation(id="times_two", method="POST")
 def double(value: int, _req: gestalt.Request) -> dict[str, object]:
     return {
         "value_type": type(value).__name__,
@@ -240,7 +246,7 @@ def double(value: int, _req: gestalt.Request) -> dict[str, object]:
     }
 
 
-@plugin.operation(id="maybe_filters", method="POST")
+@gestalt.operation(method="POST")
 def maybe_filters(input: Optional[Filters], _req: gestalt.Request) -> dict[str, object]:
     return {
         "filters_type": type(input).__name__ if input else "",
@@ -248,7 +254,7 @@ def maybe_filters(input: Optional[Filters], _req: gestalt.Request) -> dict[str, 
     }
 
 
-@plugin.operation(id="list_items", method="GET", read_only=True)
+@gestalt.operation(method="GET", read_only=True)
 def list_items(_req: gestalt.Request) -> dict[str, object]:
     return {
         "items": [Item(name="Ada"), Item(name="Grace")],
@@ -256,7 +262,7 @@ def list_items(_req: gestalt.Request) -> dict[str, object]:
     }
 
 
-@plugin.operation(id="status_zero", method="POST")
+@gestalt.operation(method="POST")
 def status_zero(_req: gestalt.Request) -> gestalt.Response[dict[str, bool]]:
     return gestalt.Response(status=0, body={"ok": True})
 `), 0o644)
@@ -298,13 +304,14 @@ providers:
 import gestalt
 import provider
 
+provider.plugin.configure_provider("example", {"prefix": "Hello"})
 status, body = provider.plugin.execute("echo", {
     "names": ["Ada", "Grace"],
     "metadata": {"role": "admin"},
     "filters": {"owner": "Ada"},
     "limit": 3,
 }, gestalt.Request())
-double_status, double_body = provider.plugin.execute("double", {
+double_status, double_body = provider.plugin.execute("times_two", {
     "value": 3,
 }, gestalt.Request())
 zero_status, zero_body = provider.plugin.execute("status_zero", {}, gestalt.Request())
@@ -347,6 +354,9 @@ print(json.dumps({
 	catalogText := string(catalogData)
 	if !strings.Contains(catalogText, "id: echo") {
 		t.Fatalf("unexpected catalog contents: %s", catalogData)
+	}
+	if !strings.Contains(catalogText, "id: times_two") || strings.Contains(catalogText, "id: double") {
+		t.Fatalf("catalog did not apply explicit operation id override: %s", catalogData)
 	}
 	if strings.Contains(catalogText, "\n\n") {
 		t.Fatalf("catalog contains unexpected blank lines: %q", catalogText)
@@ -402,6 +412,9 @@ print(json.dumps({
 	}
 	if payload["filters_type"] != "Filters" {
 		t.Fatalf("filters_type = %v, want Filters", payload["filters_type"])
+	}
+	if payload["configured_prefix"] != "Hello" {
+		t.Fatalf("configured_prefix = %v, want Hello", payload["configured_prefix"])
 	}
 	if payload["owner"] != "Ada" {
 		t.Fatalf("owner = %v, want Ada", payload["owner"])

--- a/gestaltd/internal/pluginpkg/go_provider.go
+++ b/gestaltd/internal/pluginpkg/go_provider.go
@@ -9,8 +9,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"text/template"
+
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
 
 const goProviderPackageTarget = "."
@@ -18,6 +21,7 @@ const goReadonlyFlag = "-mod=readonly"
 
 var ErrNoGoProviderPackage = errors.New("no Go provider package found")
 var ErrGoToolUnavailable = errors.New("go tool unavailable")
+var goProviderNameSlugPattern = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
 
 //go:embed go_provider_wrapper.go.tmpl
 var goProviderWrapperSource string
@@ -41,7 +45,7 @@ func DetectGoProviderImportPath(root, goos, goarch string) (string, error) {
 	return strings.TrimSpace(importPath), nil
 }
 
-func NewGoProviderWrapper(root, goos, goarch string) (string, func(), error) {
+func NewGoProviderWrapper(root, pluginName, goos, goarch string) (string, func(), error) {
 	importPath, err := DetectGoProviderImportPath(root, goos, goarch)
 	if err != nil {
 		return "", nil, err
@@ -58,7 +62,13 @@ func NewGoProviderWrapper(root, goos, goarch string) (string, func(), error) {
 	}()
 
 	var buf bytes.Buffer
-	if err := goProviderWrapperTemplate.Execute(&buf, struct{ ImportPath string }{ImportPath: importPath}); err != nil {
+	if err := goProviderWrapperTemplate.Execute(&buf, struct {
+		ImportPath string
+		PluginName string
+	}{
+		ImportPath: importPath,
+		PluginName: pluginName,
+	}); err != nil {
 		cleanup()
 		return "", nil, fmt.Errorf("render Go provider wrapper: %w", err)
 	}
@@ -80,21 +90,22 @@ func BuildGoProviderTempBinary(root, goos, goarch string) (string, func(), error
 		return "", nil, fmt.Errorf("create Go provider temp dir: %w", err)
 	}
 	cleanup := func() { _ = os.RemoveAll(tempDir) }
+	pluginName := sourcePluginName(root)
 
 	binaryName := "provider"
 	if goos == "windows" {
 		binaryName += ".exe"
 	}
 	binaryPath := filepath.Join(tempDir, binaryName)
-	if err := BuildGoProviderBinary(root, binaryPath, goos, goarch); err != nil {
+	if err := BuildGoProviderBinary(root, binaryPath, pluginName, goos, goarch); err != nil {
 		cleanup()
 		return "", nil, err
 	}
 	return binaryPath, cleanup, nil
 }
 
-func BuildGoProviderBinary(root, outputPath, goos, goarch string) error {
-	wrapperPath, cleanup, err := NewGoProviderWrapper(root, goos, goarch)
+func BuildGoProviderBinary(root, outputPath, pluginName, goos, goarch string) error {
+	wrapperPath, cleanup, err := NewGoProviderWrapper(root, pluginName, goos, goarch)
 	if err != nil {
 		return err
 	}
@@ -176,4 +187,41 @@ func isMissingGoPackageError(err error) bool {
 		strings.Contains(msg, "no Go files") ||
 		strings.Contains(msg, "build constraints exclude all Go files") ||
 		strings.Contains(msg, "matched no packages")
+}
+
+func sourcePluginName(root string) string {
+	fallback := filepath.Base(filepath.Clean(root))
+	manifestPath, err := FindManifestFile(root)
+	if err != nil {
+		return slugPluginName(fallback)
+	}
+	_, manifest, err := ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		return slugPluginName(fallback)
+	}
+	return sourcePluginManifestName(manifest, fallback)
+}
+
+func sourcePluginManifestName(manifest *pluginmanifestv1.Manifest, fallback string) string {
+	if manifest != nil {
+		if manifest.Source != "" {
+			parts := strings.Split(strings.TrimSpace(manifest.Source), "/")
+			if last := parts[len(parts)-1]; last != "" {
+				return slugPluginName(last)
+			}
+		}
+		if manifest.DisplayName != "" {
+			return slugPluginName(manifest.DisplayName)
+		}
+	}
+	return slugPluginName(fallback)
+}
+
+func slugPluginName(value string) string {
+	cleaned := goProviderNameSlugPattern.ReplaceAllString(strings.TrimSpace(value), "-")
+	cleaned = strings.Trim(cleaned, "-")
+	if cleaned == "" {
+		return "plugin"
+	}
+	return cleaned
 }

--- a/gestaltd/internal/pluginpkg/go_provider_wrapper.go.tmpl
+++ b/gestaltd/internal/pluginpkg/go_provider_wrapper.go.tmpl
@@ -15,7 +15,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	if err := gestalt.ServeProvider(ctx, providerpkg.New(), providerpkg.Router); err != nil {
+	if err := gestalt.ServeProvider(ctx, providerpkg.New(), providerpkg.Router.WithName({{printf "%q" .PluginName}})); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}

--- a/gestaltd/internal/pluginpkg/python_provider.go
+++ b/gestaltd/internal/pluginpkg/python_provider.go
@@ -144,19 +144,18 @@ func pythonInterpreterCandidates(root string) []string {
 }
 
 func SplitPythonProviderTarget(target string) (module string, attr string, err error) {
-	module, attr, ok := strings.Cut(strings.TrimSpace(target), ":")
+	raw := strings.TrimSpace(target)
+	module, attr, hasAttr := strings.Cut(raw, ":")
 	module = strings.TrimSpace(module)
 	attr = strings.TrimSpace(attr)
 	switch {
-	case !ok:
-		return "", "", fmt.Errorf("must be in module:attribute form")
 	case module == "":
 		return "", "", fmt.Errorf("module is required")
-	case attr == "":
-		return "", "", fmt.Errorf("attribute is required")
 	case !isPythonModulePath(module):
 		return "", "", fmt.Errorf("module must be a dot-separated Python identifier path")
-	case !isPythonIdentifier(attr):
+	case hasAttr && attr == "":
+		return "", "", fmt.Errorf("attribute is required")
+	case hasAttr && !isPythonIdentifier(attr):
 		return "", "", fmt.Errorf("attribute must be a Python identifier")
 	default:
 		return module, attr, nil

--- a/gestaltd/internal/pluginpkg/source_provider.go
+++ b/gestaltd/internal/pluginpkg/source_provider.go
@@ -78,7 +78,7 @@ func BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch
 	}
 	switch kind {
 	case sourceProviderKindGo:
-		return BuildGoProviderBinary(root, outputPath, goos, goarch)
+		return BuildGoProviderBinary(root, outputPath, pluginName, goos, goarch)
 	case sourceProviderKindPython:
 		if err := validateSourceProviderReleaseKind(kind, goos, goarch); err != nil {
 			return err

--- a/gestaltd/internal/testutil/sdkplugin.go
+++ b/gestaltd/internal/testutil/sdkplugin.go
@@ -108,7 +108,6 @@ func (p *Provider) generatedOp(context.Context, struct{}, gestalt.Request) (gest
 }
 
 var Router = gestalt.MustRouter(
-	"generated",
 	gestalt.Register(gestalt.Operation[struct{}, map[string]any]{ID: "generated_op"}, (*Provider).generatedOp),
 )
 `

--- a/sdk/go/doc.go
+++ b/sdk/go/doc.go
@@ -29,9 +29,12 @@
 //	func New() *MyProvider { return &MyProvider{} }
 //
 //	var Router = gestalt.MustRouter(
-//		"my-plugin",
 //		gestalt.Register(myOperation, (*MyProvider).myHandler),
 //	)
+//
+// Source-plugin flows derive the executable catalog name from plugin.yaml. Use
+// [MustNamedRouter] only when you need an explicit catalog name outside that
+// manifest-backed flow.
 //
 // See the public example under `examples/plugins/provider-go` and
 // `/docs/plugins/writing-a-plugin` for the full typed authoring flow.

--- a/sdk/go/plugin_test.go
+++ b/sdk/go/plugin_test.go
@@ -20,7 +20,6 @@ type stubOutput struct {
 }
 
 var stubRouter = gestalt.MustRouter(
-	"stub-provider",
 	gestalt.Register(
 		gestalt.Operation[stubInput, stubOutput]{
 			ID:     "test_op",
@@ -31,7 +30,6 @@ var stubRouter = gestalt.MustRouter(
 )
 
 var startableStubRouter = gestalt.MustRouter(
-	"stub-provider",
 	gestalt.Register(
 		gestalt.Operation[stubInput, stubOutput]{
 			ID:     "test_op",
@@ -42,7 +40,6 @@ var startableStubRouter = gestalt.MustRouter(
 )
 
 var sessionCatalogStubRouter = gestalt.MustRouter(
-	"stub-provider",
 	gestalt.Register(
 		gestalt.Operation[stubInput, stubOutput]{
 			ID:     "test_op",

--- a/sdk/go/router.go
+++ b/sdk/go/router.go
@@ -101,13 +101,22 @@ type Router[P any] struct {
 	handlers map[string]func(context.Context, *P, map[string]any, Request) (*OperationResult, error)
 }
 
-// NewRouter constructs a typed router and static catalog from registrations.
-func NewRouter[P any](name string, registrations ...Registration[P]) (*Router[P], error) {
+// NewRouter constructs a typed router from registrations. Source-plugin flows
+// derive the router name from plugin.yaml at build time.
+func NewRouter[P any](registrations ...Registration[P]) (*Router[P], error) {
+	return newRouter("", registrations...)
+}
+
+// NewNamedRouter constructs a typed router with an explicit catalog name.
+func NewNamedRouter[P any](name string, registrations ...Registration[P]) (*Router[P], error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return nil, fmt.Errorf("router name is required")
 	}
+	return newRouter(name, registrations...)
+}
 
+func newRouter[P any](name string, registrations ...Registration[P]) (*Router[P], error) {
 	router := &Router[P]{
 		catalog: Catalog{
 			Name:       name,
@@ -131,8 +140,17 @@ func NewRouter[P any](name string, registrations ...Registration[P]) (*Router[P]
 }
 
 // MustRouter panics if [NewRouter] returns an error.
-func MustRouter[P any](name string, registrations ...Registration[P]) *Router[P] {
-	router, err := NewRouter(name, registrations...)
+func MustRouter[P any](registrations ...Registration[P]) *Router[P] {
+	router, err := NewRouter(registrations...)
+	if err != nil {
+		panic(err)
+	}
+	return router
+}
+
+// MustNamedRouter panics if [NewNamedRouter] returns an error.
+func MustNamedRouter[P any](name string, registrations ...Registration[P]) *Router[P] {
+	router, err := NewNamedRouter(name, registrations...)
 	if err != nil {
 		panic(err)
 	}
@@ -145,6 +163,29 @@ func (r *Router[P]) Catalog() *Catalog {
 		return nil
 	}
 	return cloneCatalog(&r.catalog)
+}
+
+// WithName returns a clone of the router with the provided catalog name.
+// Empty names preserve the existing router name.
+func (r *Router[P]) WithName(name string) *Router[P] {
+	if r == nil {
+		return nil
+	}
+	cloned := cloneCatalog(&r.catalog)
+	if cloned == nil {
+		cloned = &Catalog{}
+	}
+	if trimmed := strings.TrimSpace(name); trimmed != "" {
+		cloned.Name = trimmed
+	}
+	handlers := make(map[string]func(context.Context, *P, map[string]any, Request) (*OperationResult, error), len(r.handlers))
+	for opID, handler := range r.handlers {
+		handlers[opID] = handler
+	}
+	return &Router[P]{
+		catalog:  *cloned,
+		handlers: handlers,
+	}
 }
 
 // Execute decodes params into the typed input struct and dispatches the named operation.

--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -1,4 +1,4 @@
-from ._plugin import Model, OK, Plugin, Request, Response, field
+from ._plugin import Model, OK, Plugin, Request, Response, field, operation
 
 __all__ = [
     "Model",
@@ -7,4 +7,5 @@ __all__ = [
     "Request",
     "Response",
     "field",
+    "operation",
 ]

--- a/sdk/python/gestalt/_bootstrap.py
+++ b/sdk/python/gestalt/_bootstrap.py
@@ -8,7 +8,7 @@ BUNDLED_CONFIG_NAME = "gestalt-runtime.json"
 @dataclass(frozen=True)
 class PluginTarget:
     module_name: str
-    attribute_name: str
+    attribute_name: str | None = None
 
 
 @dataclass(frozen=True)
@@ -18,9 +18,13 @@ class BundledPluginConfig:
 
 
 def parse_plugin_target(target: str) -> PluginTarget:
-    module_name, _, attribute_name = target.partition(":")
-    if not module_name or not attribute_name:
-        raise RuntimeError("tool.gestalt.plugin must be in module:attribute form")
+    module_name, sep, attribute_name = target.partition(":")
+    module_name = module_name.strip()
+    attribute_name = attribute_name.strip() or None
+    if not module_name:
+        raise RuntimeError("tool.gestalt.plugin must be in module or module:attribute form")
+    if sep and attribute_name is None:
+        raise RuntimeError("tool.gestalt.plugin attribute is required when ':' is present")
 
     return PluginTarget(
         module_name=module_name,

--- a/sdk/python/gestalt/_plugin.py
+++ b/sdk/python/gestalt/_plugin.py
@@ -4,6 +4,7 @@ import inspect
 import json
 import pathlib
 import re
+import sys
 import types
 from dataclasses import MISSING
 from typing import Any, Generic, TypeVar, Union, dataclass_transform, get_args, get_origin, get_type_hints
@@ -78,19 +79,24 @@ class _Operation:
 
 
 class Plugin:
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, *, module_name: str | None = None) -> None:
         self.name = _slug_name(name)
+        self._module_name = module_name
         self._operations: dict[str, _Operation] = {}
         self._configure_handler: Any = None
 
     @classmethod
     def from_manifest(cls, path: str | pathlib.Path) -> "Plugin":
-        manifest_path = pathlib.Path(path)
-        if not manifest_path.is_absolute() and not manifest_path.exists():
-            caller = inspect.stack()[1].filename
-            manifest_path = pathlib.Path(caller).resolve().parent / manifest_path
+        caller_frame = inspect.currentframe()
+        caller_file = None
+        caller_module_name = None
+        if caller_frame is not None and caller_frame.f_back is not None:
+            caller = caller_frame.f_back
+            caller_file = caller.f_code.co_filename
+            caller_module_name = caller.f_globals.get("__name__")
+        manifest_path = _resolve_manifest_path(path, caller_file)
         name = _derive_name_from_manifest(manifest_path)
-        return cls(name)
+        return cls(name, module_name=caller_module_name)
 
     def configure(self, func: Any) -> Any:
         self._configure_handler = func
@@ -98,8 +104,10 @@ class Plugin:
 
     def operation(
         self,
+        func: Any | None = None,
+        /,
         *,
-        id: str,
+        id: str | None = None,
         method: str = "POST",
         title: str = "",
         description: str = "",
@@ -107,11 +115,10 @@ class Plugin:
         read_only: bool = False,
         visible: bool | None = None,
     ) -> Any:
-        op_id = id.strip()
-        if not op_id:
-            raise ValueError("operation id is required")
-
         def decorator(func: Any) -> Any:
+            op_id = (id or func.__name__).strip()
+            if not op_id:
+                raise ValueError("operation id is required")
             if op_id in self._operations:
                 raise ValueError(f"duplicate operation id {op_id!r}")
 
@@ -130,12 +137,15 @@ class Plugin:
             )
             return func
 
-        return decorator
+        if func is None:
+            return decorator
+        return decorator(func)
 
     def configure_provider(self, name: str, config: dict[str, Any]) -> None:
-        if self._configure_handler is None:
+        handler = self._resolve_configure_handler()
+        if handler is None:
             return
-        _maybe_await(self._configure_handler(name, config))
+        _maybe_await(handler(name, config))
 
     def execute(self, operation: str, params: dict[str, Any], request: Request) -> tuple[int, str]:
         op = self._operations.get(operation)
@@ -181,6 +191,51 @@ class Plugin:
         from . import _runtime
 
         _runtime.serve(self)
+
+    def _resolve_configure_handler(self) -> Any:
+        if self._configure_handler is not None:
+            return self._configure_handler
+        if not self._module_name:
+            return None
+        module = sys.modules.get(self._module_name)
+        if module is None:
+            return None
+        configure = getattr(module, "configure", None)
+        if callable(configure):
+            self._configure_handler = configure
+        return self._configure_handler
+
+
+_DEFAULT_PLUGINS: dict[str, Plugin] = {}
+
+
+def operation(
+    func: Any | None = None,
+    /,
+    *,
+    id: str | None = None,
+    method: str = "POST",
+    title: str = "",
+    description: str = "",
+    tags: list[str] | None = None,
+    read_only: bool = False,
+    visible: bool | None = None,
+) -> Any:
+    def decorator(func: Any) -> Any:
+        plugin = _module_plugin_for(func)
+        return plugin.operation(
+            id=id,
+            method=method,
+            title=title,
+            description=description,
+            tags=tags,
+            read_only=read_only,
+            visible=visible,
+        )(func)
+
+    if func is None:
+        return decorator
+    return decorator(func)
 
 
 def _inspect_handler(func: Any) -> tuple[Any, bool]:
@@ -440,6 +495,44 @@ def _json_value(value: Any) -> Any:
     if isinstance(value, (list, tuple, set)):
         return [_json_value(item) for item in value]
     return value
+
+
+def _module_plugin_for(func: Any) -> Plugin:
+    module = sys.modules.get(func.__module__)
+    if module is None:
+        raise RuntimeError(f"module {func.__module__!r} is not loaded")
+    return _module_plugin(module)
+
+
+def _module_plugin(module: types.ModuleType) -> Plugin:
+    existing = getattr(module, "plugin", None)
+    if isinstance(existing, Plugin):
+        if existing._module_name is None:
+            existing._module_name = module.__name__
+        _DEFAULT_PLUGINS[module.__name__] = existing
+        return existing
+
+    plugin = _DEFAULT_PLUGINS.get(module.__name__)
+    if plugin is None:
+        plugin = Plugin(_module_plugin_name(module), module_name=module.__name__)
+        _DEFAULT_PLUGINS[module.__name__] = plugin
+    if not isinstance(getattr(module, "plugin", None), Plugin):
+        setattr(module, "plugin", plugin)
+    return plugin
+
+
+def _module_plugin_name(module: types.ModuleType) -> str:
+    file_path = getattr(module, "__file__", None)
+    if file_path:
+        return _derive_name_from_manifest(pathlib.Path(file_path).resolve().parent / "plugin.yaml")
+    return _slug_name(module.__name__.rsplit(".", 1)[-1])
+
+
+def _resolve_manifest_path(path: str | pathlib.Path, caller_file: str | None) -> pathlib.Path:
+    manifest_path = pathlib.Path(path)
+    if not manifest_path.is_absolute() and not manifest_path.exists() and caller_file:
+        manifest_path = pathlib.Path(caller_file).resolve().parent / manifest_path
+    return manifest_path
 
 
 def _derive_name_from_manifest(path: pathlib.Path) -> str:

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -7,7 +7,7 @@ from concurrent import futures
 from dataclasses import dataclass
 
 from ._bootstrap import parse_plugin_target, read_bundled_plugin_config
-from ._plugin import ENV_WRITE_CATALOG, Plugin, Request
+from ._plugin import ENV_WRITE_CATALOG, Plugin, Request, _module_plugin
 
 ENV_PLUGIN_SOCKET = "GESTALT_PLUGIN_SOCKET"
 CURRENT_PROTOCOL_VERSION = 2
@@ -129,14 +129,17 @@ def _load_plugin(args: RuntimeArgs) -> Plugin:
 
     plugin_target = parse_plugin_target(args.target)
     module = importlib.import_module(plugin_target.module_name)
-    plugin = getattr(module, plugin_target.attribute_name, None)
+    if plugin_target.attribute_name is None:
+        plugin = _module_plugin(module)
+    else:
+        plugin = getattr(module, plugin_target.attribute_name, None)
     if not isinstance(plugin, Plugin):
         raise RuntimeError(f"{args.target} did not resolve to a gestalt.Plugin")
     return plugin
 
 
 def _print_usage() -> None:
-    print("usage: python -m gestalt._runtime ROOT MODULE:ATTRIBUTE", file=sys.stderr)
+    print("usage: python -m gestalt._runtime ROOT MODULE[:ATTRIBUTE]", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/sdk/python/tests/test_build.py
+++ b/sdk/python/tests/test_build.py
@@ -34,7 +34,7 @@ class BuildTests(unittest.TestCase):
                 _build.build_plugin_binary(
                     _build.BuildArgs(
                         root=str(root),
-                        target="provider:plugin",
+                        target="provider",
                         output_path=str(output),
                         plugin_name="released-plugin",
                     )
@@ -49,7 +49,7 @@ class BuildTests(unittest.TestCase):
         self.assertEqual(
             captured["bundle_config"],
             {
-                "target": "provider:plugin",
+                "target": "provider",
                 "plugin_name": "released-plugin",
             },
         )

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -21,7 +21,7 @@ class RuntimeTests(unittest.TestCase):
             (bundle_dir / _bootstrap.BUNDLED_CONFIG_NAME).write_text(
                 json.dumps(
                     {
-                        "target": "provider:plugin",
+                        "target": "provider",
                         "plugin_name": "released-plugin",
                     }
                 ),
@@ -38,7 +38,7 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(result, 0)
         load_plugin.assert_called_once_with(
             _runtime.RuntimeArgs(
-                target="provider:plugin",
+                target="provider",
                 plugin_name="released-plugin",
             )
         )


### PR DESCRIPTION
## Summary
- make Python source plugins work with module-level `@gestalt.operation`, plain top-level `configure`, and `[tool.gestalt].plugin = "provider"` while keeping explicit `Plugin` usage working
- make Go source plugins use unnamed `MustRouter(...)` by default, with `MustNamedRouter(...)` as the explicit escape hatch and manifest-derived naming injected by the generated wrapper
- update examples, docs, and existing source-plugin tests to use the new default ergonomics

## Verification
- `TMPDIR=/Users/hugh/src/.tmpgo go test ./...` in `sdk/go`
- `TMPDIR=/Users/hugh/src/.tmpgo go test ./internal/pluginpkg ./internal/operator ./internal/bootstrap ./cmd/gestaltd` in `gestaltd`
- `python3 -m venv <tmp>/venv && <tmp>/venv/bin/pip install -e . && <tmp>/venv/bin/python -m unittest discover -s tests && <tmp>/venv/bin/python -m py_compile gestalt/_plugin.py gestalt/_runtime.py ../../examples/plugins/provider-python/provider.py` in `sdk/python`