### PR TITLE
Handle operation errors centrally in Go and Python SDKs

### DIFF
--- a/docs/content/plugins/writing-a-plugin.mdx
+++ b/docs/content/plugins/writing-a-plugin.mdx
@@ -125,6 +125,11 @@ func (p *Provider) greet(
 
 You do not write `main.go`. Gestalt synthesizes the executable wrapper automatically for local source execution, packaging, and release.
 
+By default, typed input decode failures return a structured `400` response, and
+unhandled handler errors or panics return a structured `500` response. Return a
+non-2xx `gestalt.Response[...]` explicitly when the operation wants to signal a
+deliberate application-level error.
+
 ## Python typed operations
 
 Point `pyproject.toml` at the module or plugin object that Gestalt should load:
@@ -173,6 +178,11 @@ If your plugin needs startup config, define a plain top-level
 `configure(name, config)` function. It does not need a decorator.
 
 You do not write a launcher script for local development or release. Gestalt loads the module declared in `[tool.gestalt].plugin`, materializes the static catalog automatically, and packages a runnable executable artifact during release.
+
+By default, input decode failures return a structured `400` response, and
+unhandled exceptions return a structured `500` response. Return
+`gestalt.Response(...)` explicitly when the operation wants to signal a
+deliberate application-level error.
 
 ## Write `plugin.yaml`
 

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"encoding/json"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -247,6 +248,11 @@ def double(value: int, _req: gestalt.Request) -> dict[str, object]:
 
 
 @gestalt.operation(method="POST")
+def explode(_req: gestalt.Request) -> dict[str, object]:
+    raise RuntimeError("boom")
+
+
+@gestalt.operation(method="POST")
 def maybe_filters(input: Optional[Filters], _req: gestalt.Request) -> dict[str, object]:
     return {
         "filters_type": type(input).__name__ if input else "",
@@ -314,6 +320,10 @@ status, body = provider.plugin.execute("echo", {
 double_status, double_body = provider.plugin.execute("times_two", {
     "value": 3,
 }, gestalt.Request())
+decode_status, decode_body = provider.plugin.execute("times_two", {
+    "value": "oops",
+}, gestalt.Request())
+explode_status, explode_body = provider.plugin.execute("explode", {}, gestalt.Request())
 zero_status, zero_body = provider.plugin.execute("status_zero", {}, gestalt.Request())
 maybe_status, maybe_body = provider.plugin.execute("maybe_filters", {
     "owner": "Grace",
@@ -324,6 +334,10 @@ print(json.dumps({
     "body": json.loads(body),
     "double_status": double_status,
     "double_body": json.loads(double_body),
+    "decode_status": decode_status,
+    "decode_body": json.loads(decode_body),
+    "explode_status": explode_status,
+    "explode_body": json.loads(explode_body),
     "list_status": list_status,
     "list_body": json.loads(list_body),
     "maybe_status": maybe_status,
@@ -393,7 +407,7 @@ print(json.dumps({
 	command := filepath.Join(dir, ".venv", "bin", "python")
 	cmd := exec.Command(command, "exercise.py")
 	cmd.Dir = dir
-	result, err := cmd.CombinedOutput()
+	result, err := cmd.Output()
 	if err != nil {
 		t.Fatalf("exercise.py: %v\n%s", err, result)
 	}
@@ -438,6 +452,27 @@ print(json.dumps({
 	}
 	if doublePayload["value"] != float64(6) {
 		t.Fatalf("double value = %v, want 6", doublePayload["value"])
+	}
+	decodePayload, ok := body["decode_body"].(map[string]any)
+	if !ok {
+		t.Fatalf("decode payload = %#v, want object", body["decode_body"])
+	}
+	if body["decode_status"] != float64(http.StatusBadRequest) {
+		t.Fatalf("decode_status = %v, want %d", body["decode_status"], http.StatusBadRequest)
+	}
+	decodeError, ok := decodePayload["error"].(string)
+	if !ok || !strings.Contains(decodeError, "invalid literal for int()") {
+		t.Fatalf("decode error = %#v, want conversion error", decodePayload["error"])
+	}
+	explodePayload, ok := body["explode_body"].(map[string]any)
+	if !ok {
+		t.Fatalf("explode payload = %#v, want object", body["explode_body"])
+	}
+	if body["explode_status"] != float64(http.StatusInternalServerError) {
+		t.Fatalf("explode_status = %v, want %d", body["explode_status"], http.StatusInternalServerError)
+	}
+	if explodePayload["error"] != "boom" {
+		t.Fatalf("explode error = %v, want boom", explodePayload["error"])
 	}
 	listPayload, ok := body["list_body"].(map[string]any)
 	if !ok {

--- a/sdk/go/operation_errors.go
+++ b/sdk/go/operation_errors.go
@@ -1,0 +1,112 @@
+package gestalt
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"runtime/debug"
+)
+
+const (
+	operationErrorField       = "error"
+	unknownOperationMessage   = "unknown operation"
+	routerNilMessage          = "router is nil"
+	nilResultMessage          = "provider returned nil result"
+	internalErrorBodyFallback = `{"error":"internal error"}`
+)
+
+type operationError struct {
+	status  int
+	message string
+	cause   error
+}
+
+func (e *operationError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.cause != nil {
+		return e.cause.Error()
+	}
+	return e.message
+}
+
+func (e *operationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func newOperationError(status int, message string, cause error) error {
+	message = stringsOrFallback(message, http.StatusText(status))
+	return &operationError{
+		status:  status,
+		message: message,
+		cause:   cause,
+	}
+}
+
+func operationResultFromError(err error) *OperationResult {
+	if err == nil {
+		return nil
+	}
+	status := http.StatusInternalServerError
+	message := err.Error()
+	var opErr *operationError
+	if errors.As(err, &opErr) {
+		if opErr.status != 0 {
+			status = opErr.status
+		}
+		message = stringsOrFallback(opErr.message, opErr.Error())
+	}
+	return operationResult(status, message)
+}
+
+func recoveredOperationResult(operation string, recovered any) *OperationResult {
+	message := fmt.Sprint(recovered)
+	if operation == "" {
+		fmt.Fprintf(os.Stderr, "panic in Gestalt operation: %v\n", recovered)
+	} else {
+		fmt.Fprintf(os.Stderr, "panic in Gestalt operation %q: %v\n", operation, recovered)
+	}
+	_, _ = os.Stderr.Write(debug.Stack())
+	return operationResult(http.StatusInternalServerError, message)
+}
+
+func protectedOperationResult(operation string, fn func() (*OperationResult, error)) (result *OperationResult) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			result = recoveredOperationResult(operation, recovered)
+		}
+	}()
+	result, err := fn()
+	if err != nil {
+		return operationResultFromError(err)
+	}
+	return result
+}
+
+func operationResult(status int, message string) *OperationResult {
+	return &OperationResult{
+		Status: status,
+		Body:   operationErrorBody(message),
+	}
+}
+
+func operationErrorBody(message string) string {
+	data, err := json.Marshal(map[string]string{operationErrorField: message})
+	if err != nil {
+		return internalErrorBodyFallback
+	}
+	return string(data)
+}
+
+func stringsOrFallback(value, fallback string) string {
+	if value != "" {
+		return value
+	}
+	return fallback
+}

--- a/sdk/go/plugin_test.go
+++ b/sdk/go/plugin_test.go
@@ -2,7 +2,9 @@ package gestalt_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	gestalt "github.com/valon-technologies/gestalt/sdk/go"
@@ -17,6 +19,14 @@ type stubInput struct{}
 
 type stubOutput struct {
 	Operation string `json:"operation"`
+}
+
+type decodeInput struct {
+	Count int `json:"count"`
+}
+
+type decodeOutput struct {
+	Count int `json:"count"`
 }
 
 var stubRouter = gestalt.MustRouter(
@@ -55,6 +65,18 @@ func (p *stubProvider) Configure(_ context.Context, _ string, _ map[string]any) 
 
 func (p *stubProvider) testOp(_ context.Context, _ stubInput, _ gestalt.Request) (gestalt.Response[stubOutput], error) {
 	return gestalt.OK(stubOutput{Operation: "test_op"}), nil
+}
+
+func (p *stubProvider) decodeOp(_ context.Context, input decodeInput, _ gestalt.Request) (gestalt.Response[decodeOutput], error) {
+	return gestalt.OK(decodeOutput{Count: input.Count}), nil
+}
+
+func (p *stubProvider) errorOp(_ context.Context, _ stubInput, _ gestalt.Request) (gestalt.Response[stubOutput], error) {
+	return gestalt.Response[stubOutput]{}, errors.New("boom")
+}
+
+func (p *stubProvider) panicOp(_ context.Context, _ stubInput, _ gestalt.Request) (gestalt.Response[stubOutput], error) {
+	panic("boom")
 }
 
 type startableStubProvider struct {
@@ -136,23 +158,112 @@ func TestProviderServerGetSessionCatalog(t *testing.T) {
 func TestProviderServerExecute(t *testing.T) {
 	t.Parallel()
 
-	client := newProviderPluginClient(t, &stubProvider{}, stubRouter)
-	ctx := context.Background()
+	decodeRouter := gestalt.MustRouter(
+		gestalt.Register(
+			gestalt.Operation[decodeInput, decodeOutput]{
+				ID:     "decode_op",
+				Method: http.MethodPost,
+			},
+			(*stubProvider).decodeOp,
+		),
+	)
+	errorRouter := gestalt.MustRouter(
+		gestalt.Register(
+			gestalt.Operation[stubInput, stubOutput]{
+				ID:     "error_op",
+				Method: http.MethodPost,
+			},
+			(*stubProvider).errorOp,
+		),
+	)
+	panicRouter := gestalt.MustRouter(
+		gestalt.Register(
+			gestalt.Operation[stubInput, stubOutput]{
+				ID:     "panic_op",
+				Method: http.MethodPost,
+			},
+			(*stubProvider).panicOp,
+		),
+	)
 
-	params, _ := structpb.NewStruct(map[string]any{"key": "value"})
-	resp, err := client.Execute(ctx, &proto.ExecuteRequest{
-		Operation: "test_op",
-		Params:    params,
-		Token:     "tok",
-	})
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
+	tests := []struct {
+		name            string
+		router          *gestalt.Router[stubProvider]
+		request         *proto.ExecuteRequest
+		wantStatus      int32
+		wantBody        string
+		wantBodyContain []string
+	}{
+		{
+			name:       "success",
+			router:     stubRouter,
+			wantStatus: http.StatusOK,
+			wantBody:   `{"operation":"test_op"}`,
+			request: &proto.ExecuteRequest{
+				Operation: "test_op",
+				Params: func() *structpb.Struct {
+					params, _ := structpb.NewStruct(map[string]any{"key": "value"})
+					return params
+				}(),
+				Token: "tok",
+			},
+		},
+		{
+			name:       "decode error",
+			router:     decodeRouter,
+			wantStatus: http.StatusBadRequest,
+			wantBodyContain: []string{
+				"decode params for",
+				"decode_op",
+			},
+			request: &proto.ExecuteRequest{
+				Operation: "decode_op",
+				Params: func() *structpb.Struct {
+					params, _ := structpb.NewStruct(map[string]any{"count": "oops"})
+					return params
+				}(),
+			},
+		},
+		{
+			name:       "handler error",
+			router:     errorRouter,
+			wantStatus: http.StatusInternalServerError,
+			wantBody:   `{"error":"boom"}`,
+			request: &proto.ExecuteRequest{
+				Operation: "error_op",
+			},
+		},
+		{
+			name:       "panic",
+			router:     panicRouter,
+			wantStatus: http.StatusInternalServerError,
+			wantBody:   `{"error":"boom"}`,
+			request: &proto.ExecuteRequest{
+				Operation: "panic_op",
+			},
+		},
 	}
-	if resp.GetStatus() != 200 {
-		t.Errorf("Status = %d, want 200", resp.GetStatus())
-	}
-	if resp.GetBody() != `{"operation":"test_op"}` {
-		t.Errorf("Body = %q, want %q", resp.GetBody(), `{"operation":"test_op"}`)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newProviderPluginClient(t, &stubProvider{}, tt.router)
+
+			resp, err := client.Execute(context.Background(), tt.request)
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			if resp.GetStatus() != tt.wantStatus {
+				t.Fatalf("Status = %d, want %d", resp.GetStatus(), tt.wantStatus)
+			}
+			if tt.wantBody != "" && resp.GetBody() != tt.wantBody {
+				t.Fatalf("Body = %q, want %q", resp.GetBody(), tt.wantBody)
+			}
+			for _, want := range tt.wantBodyContain {
+				if !strings.Contains(resp.GetBody(), want) {
+					t.Fatalf("Body = %q, want substring %q", resp.GetBody(), want)
+				}
+			}
+		})
 	}
 }
 

--- a/sdk/go/provider_server.go
+++ b/sdk/go/provider_server.go
@@ -2,6 +2,7 @@ package gestalt
 
 import (
 	"context"
+	"net/http"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"google.golang.org/grpc/codes"
@@ -53,24 +54,20 @@ func (s *ProviderServer) GetMetadata(_ context.Context, _ *emptypb.Empty) (*prot
 	}, nil
 }
 
-func (s *ProviderServer) Execute(ctx context.Context, req *proto.ExecuteRequest) (*proto.OperationResult, error) {
+func (s *ProviderServer) Execute(ctx context.Context, req *proto.ExecuteRequest) (resp *proto.OperationResult, err error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
 	if len(req.GetConnectionParams()) > 0 {
 		ctx = WithConnectionParams(ctx, req.GetConnectionParams())
 	}
-	result, err := s.provider.execute(ctx, req.GetOperation(), mapFromStruct(req.GetParams()), req.GetToken())
-	if err != nil {
-		return nil, status.Errorf(codes.Unknown, "execute: %v", err)
-	}
+	result := protectedOperationResult(req.GetOperation(), func() (*OperationResult, error) {
+		return s.provider.execute(ctx, req.GetOperation(), mapFromStruct(req.GetParams()), req.GetToken())
+	})
 	if result == nil {
-		return nil, status.Error(codes.Internal, "provider returned nil result")
+		return operationResultProto(operationResult(http.StatusInternalServerError, nilResultMessage)), nil
 	}
-	return &proto.OperationResult{
-		Status: int32(result.Status),
-		Body:   result.Body,
-	}, nil
+	return operationResultProto(result), nil
 }
 
 func (s *ProviderServer) GetSessionCatalog(ctx context.Context, req *proto.GetSessionCatalogRequest) (*proto.GetSessionCatalogResponse, error) {
@@ -95,4 +92,14 @@ func (s *ProviderServer) GetSessionCatalog(ctx context.Context, req *proto.GetSe
 func supportsSessionCatalog(p executableProvider) bool {
 	_, ok := p.sessionCatalogProvider()
 	return ok
+}
+
+func operationResultProto(result *OperationResult) *proto.OperationResult {
+	if result == nil {
+		return nil
+	}
+	return &proto.OperationResult{
+		Status: int32(result.Status),
+		Body:   result.Body,
+	}
 }

--- a/sdk/go/router.go
+++ b/sdk/go/router.go
@@ -73,12 +73,12 @@ func Register[P any, In any, Out any](
 		execute: func(ctx context.Context, provider *P, rawParams map[string]any, req Request) (*OperationResult, error) {
 			var input In
 			if err := decodeParams(rawParams, &input); err != nil {
-				return nil, fmt.Errorf("decode params for %q: %w", op.ID, err)
+				return nil, newOperationError(http.StatusBadRequest, fmt.Sprintf("decode params for %q: %v", op.ID, err), err)
 			}
 
 			resp, err := handler(provider, ctx, input, req)
 			if err != nil {
-				return nil, err
+				return nil, newOperationError(http.StatusInternalServerError, err.Error(), err)
 			}
 
 			status := resp.Status
@@ -87,7 +87,7 @@ func Register[P any, In any, Out any](
 			}
 			body, err := json.Marshal(resp.Body)
 			if err != nil {
-				return nil, fmt.Errorf("marshal response for %q: %w", op.ID, err)
+				return nil, newOperationError(http.StatusInternalServerError, fmt.Sprintf("marshal response for %q: %v", op.ID, err), err)
 			}
 			return &OperationResult{Status: status, Body: string(body)}, nil
 		},
@@ -191,19 +191,22 @@ func (r *Router[P]) WithName(name string) *Router[P] {
 // Execute decodes params into the typed input struct and dispatches the named operation.
 func (r *Router[P]) Execute(ctx context.Context, provider *P, operation string, params map[string]any, token string) (*OperationResult, error) {
 	if r == nil {
-		return nil, fmt.Errorf("router is nil")
+		return operationResult(http.StatusInternalServerError, routerNilMessage), nil
 	}
 	handler, ok := r.handlers[operation]
 	if !ok {
-		return &OperationResult{
-			Status: http.StatusNotFound,
-			Body:   `{"error":"unknown operation"}`,
-		}, nil
+		return operationResult(http.StatusNotFound, unknownOperationMessage), nil
 	}
-	return handler(ctx, provider, params, Request{
-		Token:            token,
-		ConnectionParams: ConnectionParams(ctx),
+	result := protectedOperationResult(operation, func() (*OperationResult, error) {
+		return handler(ctx, provider, params, Request{
+			Token:            token,
+			ConnectionParams: ConnectionParams(ctx),
+		})
 	})
+	if result == nil {
+		return operationResult(http.StatusInternalServerError, nilResultMessage), nil
+	}
+	return result, nil
 }
 
 func encodeCatalogYAML(cat *Catalog) ([]byte, error) {

--- a/sdk/python/gestalt/_plugin.py
+++ b/sdk/python/gestalt/_plugin.py
@@ -1,17 +1,21 @@
 import asyncio
 import dataclasses
+from http import HTTPStatus
 import inspect
 import json
 import pathlib
 import re
 import sys
+import traceback
 import types
 from dataclasses import MISSING
-from typing import Any, Generic, TypeVar, Union, dataclass_transform, get_args, get_origin, get_type_hints
+from typing import Any, Final, Generic, TypeVar, Union, dataclass_transform, get_args, get_origin, get_type_hints
 
 import yaml
 
-ENV_WRITE_CATALOG = "GESTALT_PLUGIN_WRITE_CATALOG"
+ENV_WRITE_CATALOG: Final[str] = "GESTALT_PLUGIN_WRITE_CATALOG"
+ERROR_FIELD: Final[str] = "error"
+UNKNOWN_OPERATION_MESSAGE: Final[str] = "unknown operation"
 
 T = TypeVar("T")
 
@@ -32,7 +36,7 @@ class Response(Generic[T]):
 
 
 def OK(body: T) -> Response[T]:
-    return Response(status=200, body=body)
+    return Response(status=int(HTTPStatus.OK), body=body)
 
 
 def field(
@@ -150,22 +154,28 @@ class Plugin:
     def execute(self, operation: str, params: dict[str, Any], request: Request) -> tuple[int, str]:
         op = self._operations.get(operation)
         if op is None:
-            return 404, json.dumps({"error": "unknown operation"})
+            return _error_result(HTTPStatus.NOT_FOUND, UNKNOWN_OPERATION_MESSAGE)
 
         args: list[Any] = []
         if op.input_type is not None:
-            args.append(_decode_input(op.input_type, params))
+            try:
+                args.append(_decode_input(op.input_type, params))
+            except Exception as err:
+                return _error_result(HTTPStatus.BAD_REQUEST, str(err))
         if op.takes_request:
             args.append(request)
 
-        result = _maybe_await(op.handler(*args))
-        if isinstance(result, Response):
-            status = result.status if result.status is not None else 200
-            body = result.body
-        else:
-            status = 200
-            body = result
-        return status, _json_body(body)
+        try:
+            result = _maybe_await(op.handler(*args))
+            if isinstance(result, Response):
+                status = result.status if result.status is not None else int(HTTPStatus.OK)
+                body = result.body
+            else:
+                status = int(HTTPStatus.OK)
+                body = result
+            return status, _json_body(body)
+        except Exception as err:
+            return _internal_error_result(err)
 
     def catalog_dict(self) -> dict[str, Any]:
         return {
@@ -483,6 +493,15 @@ def _is_optional_type(annotation: Any) -> bool:
 
 def _json_body(value: Any) -> str:
     return json.dumps(_json_value(value), separators=(",", ":"))
+
+
+def _error_result(status: int | HTTPStatus, message: str) -> tuple[int, str]:
+    return int(status), _json_body({ERROR_FIELD: message})
+
+
+def _internal_error_result(err: Exception) -> tuple[int, str]:
+    traceback.print_exc()
+    return _error_result(HTTPStatus.INTERNAL_SERVER_ERROR, str(err))
 
 
 def _json_value(value: Any) -> Any:

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -1,17 +1,21 @@
 import importlib
+import json
 import os
 import pathlib
 import signal
 import sys
+import traceback
 from concurrent import futures
 from dataclasses import dataclass
+from http import HTTPStatus
+from typing import Final
 
 from ._bootstrap import parse_plugin_target, read_bundled_plugin_config
 from ._plugin import ENV_WRITE_CATALOG, Plugin, Request, _module_plugin
 
-ENV_PLUGIN_SOCKET = "GESTALT_PLUGIN_SOCKET"
-CURRENT_PROTOCOL_VERSION = 2
-GRPC_SERVER_MAX_WORKERS = 4
+ENV_PLUGIN_SOCKET: Final[str] = "GESTALT_PLUGIN_SOCKET"
+CURRENT_PROTOCOL_VERSION: Final[int] = 2
+GRPC_SERVER_MAX_WORKERS: Final[int] = 4
 
 
 @dataclass(frozen=True)
@@ -60,14 +64,19 @@ def serve(plugin: Plugin) -> None:
                     request.params,
                     preserving_proto_field_name=True,
                 )
-            status, body = plugin.execute(
-                request.operation,
-                params,
-                Request(
-                    token=request.token,
-                    connection_params=dict(request.connection_params),
-                ),
-            )
+            try:
+                status, body = plugin.execute(
+                    request.operation,
+                    params,
+                    Request(
+                        token=request.token,
+                        connection_params=dict(request.connection_params),
+                    ),
+                )
+            except Exception as err:
+                traceback.print_exc()
+                status = int(HTTPStatus.INTERNAL_SERVER_ERROR)
+                body = json.dumps({"error": str(err)}, separators=(",", ":"))
             return plugin_pb2.OperationResult(status=status, body=body)
 
     plugin_pb2_grpc.add_ProviderPluginServicer_to_server(ProviderServicer(), server)


### PR DESCRIPTION
## Summary
- centralize default operation error handling in the Python SDK so decode failures become structured 400s and unhandled exceptions become structured 500s
- centralize default operation error handling in the Go SDK so decode failures, handler errors, nil results, and panics return structured results instead of gRPC transport errors
- keep the new coverage functional by augmenting the existing Go grpc execute flow and the existing local Python source-plugin lifecycle test instead of adding unit-only tests

## Why this helps plugin authors
This makes the out-of-the-box authoring path smaller. Plugin code no longer needs catch-all boilerplate just to translate common failures into structured `400` or `500` responses.

Python before:
```python
@gestalt.operation
def query(input: QueryInput, req: gestalt.Request):
    try:
        return run_query(input, req)
    except Exception as err:
        return gestalt.Response(status=500, body={"error": str(err)})
```

Python now:
```python
@gestalt.operation
def query(input: QueryInput, req: gestalt.Request):
    return run_query(input, req)
```

Go before:
```go
func (p *Provider) Query(ctx context.Context, input QueryInput, req gestalt.Request) (gestalt.Response[QueryOutput], error) {
    out, err := runQuery(ctx, input, req)
    if err != nil {
        return gestalt.Response[QueryOutput]{Status: http.StatusInternalServerError, Body: QueryOutput{}}, nil
    }
    return gestalt.OK(out), nil
}
```

Go now:
```go
func (p *Provider) Query(ctx context.Context, input QueryInput, req gestalt.Request) (gestalt.Response[QueryOutput], error) {
    out, err := runQuery(ctx, input, req)
    return gestalt.OK(out), err
}
```

## Testing
- `TMPDIR=/Users/hugh/src/.tmpgo go test ./...` in `sdk/go`
- `TMPDIR=/Users/hugh/src/.tmpgo go test ./internal/operator -run TestLoadForExecutionAtPath_GeneratesStaticCatalogForLocalPythonSourcePlugin` in `gestaltd`
- `source /Users/hugh/src/.tmpgo/sdk-error-handling-venv/bin/activate && cd sdk/python && python -m unittest discover -s tests`
- `source /Users/hugh/src/.tmpgo/sdk-error-handling-venv/bin/activate && cd sdk/python && python -m py_compile gestalt/_plugin.py gestalt/_runtime.py`
