### PR TITLE
[codex] Gate gestaltd image publishing on build

### DIFF
--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -111,6 +111,7 @@ jobs:
 
   publish-image:
     name: Publish Docker Image
+    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:


### PR DESCRIPTION
## Summary

- make `gestaltd` Docker image publishing wait for the release build job
- align that gating behavior with the existing `gestalt` CLI release workflow

## Why

`gestalt` only publishes its Docker image after its tagged release build succeeds. `gestaltd` already follows the same tag-only release model, but its `publish-image` job did not depend on `build`.

This makes the two release workflows more consistent without changing any product-specific post-release steps.

## Validation

- parsed `.github/workflows/release-gestaltd.yml` as YAML
- ran `git diff --check`
