### PR TITLE
Document uv-managed Python source plugins

### DIFF
--- a/docs/content/plugins/packaging-and-releasing.mdx
+++ b/docs/content/plugins/packaging-and-releasing.mdx
@@ -112,9 +112,9 @@ Run this from the plugin source directory. It produces release archives and writ
 For executable Go plugins, release materializes the executable catalog from the
 typed router before packaging and can target multiple platforms.
 
-For Python source plugins, release loads the module or plugin object declared
-in `[tool.gestalt].plugin`, materializes the executable catalog automatically,
-and builds a current-platform executable artifact from the selected Python
+For Python source plugins, release loads the module declared in
+`[tool.gestalt].plugin`, materializes the executable catalog automatically, and
+builds a current-platform executable artifact from the selected Python
 environment.
 
 ## Reference packages from config

--- a/docs/content/plugins/writing-a-plugin.mdx
+++ b/docs/content/plugins/writing-a-plugin.mdx
@@ -132,24 +132,26 @@ deliberate application-level error.
 
 ## Python typed operations
 
-Point `pyproject.toml` at the module or plugin object that Gestalt should load:
+Point `pyproject.toml` at the module that Gestalt should load:
 
 ```toml
-[build-system]
-requires = ["setuptools==82.0.1"]
-build-backend = "setuptools.build_meta"
-
 [project]
 name = "my-plugin"
 version = "0.1.0"
 dependencies = ["gestalt"]
 
+[tool.uv]
+package = false
+
 [tool.gestalt]
 plugin = "provider"
 ```
 
-If you install the SDK from a private index, pin `gestalt` to that index with
-`uv` rather than relying on PyPI fallback.
+Python source plugins are `uv`-managed apps, not Python packages. You do not
+need a `build-system` table or setuptools config. If you install the SDK from a
+private index, pin `gestalt` to that index with `uv` rather than relying on
+PyPI fallback. If you source the SDK directly from Git instead, declare it in
+`[tool.uv.sources]`.
 
 Then define operations in `provider.py`:
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -464,7 +464,7 @@ from:
 
 | Field | Purpose |
 | --- | --- |
-| `source.path` | Load a local source plugin from its manifest path. Gestalt synthesizes the Go executable wrapper automatically when needed and runs Python source plugins from the module or plugin object declared in `[tool.gestalt].plugin`. |
+| `source.path` | Load a local source plugin from its manifest path. Gestalt synthesizes the Go executable wrapper automatically when needed and runs Python source plugins from the module declared in `[tool.gestalt].plugin`. |
 | `source.ref` | Resolve a versioned plugin source during `init`. Format: `github.com/<org>/<repo>/<plugin>`. |
 | `source.version` | Required with `source.ref`. Invalid with `source.path`. |
 | `env` | Extra environment variables for executable providers. |

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -225,6 +225,6 @@ gestaltd plugin release --version 1.2.3
 `plugin.yaml` stays YAML and `plugin.json` stays JSON in the release archive.
 For executable Go plugins, release materializes the executable catalog
 automatically from the provider's typed router before packaging. For Python
-source plugins, release loads the module or plugin object declared in
-`[tool.gestalt].plugin`, materializes the executable catalog automatically, and
-builds a current-platform executable artifact.
+source plugins, release loads the module declared in `[tool.gestalt].plugin`,
+materializes the executable catalog automatically, and builds a current-platform
+executable artifact.

--- a/examples/plugins/provider-python/pyproject.toml
+++ b/examples/plugins/provider-python/pyproject.toml
@@ -1,11 +1,10 @@
-[build-system]
-requires = ["setuptools>=68"]
-build-backend = "setuptools.build_meta"
-
 [project]
 name = "provider-python"
 version = "0.1.0"
 dependencies = ["gestalt"]
+
+[tool.uv]
+package = false
 
 [tool.gestalt]
 plugin = "provider"


### PR DESCRIPTION
## Summary
- update the Python plugin authoring guide to show the uv-managed app model
- remove the old setuptools-style example from the Python example project
- align reference docs with module-based Python plugin loading

## Why
The current docs still suggest a package/build-system setup for Python plugins, but the intended long-term model is simpler: `uv`-managed apps with `[tool.uv] package = false` and `[tool.gestalt].plugin = "provider"`.

## Verification
- `python3 -m py_compile examples/plugins/provider-python/provider.py`