### PR TITLE
Fix Python source plugin packaging docs

### DIFF
--- a/docs/content/plugins/packaging-and-releasing.mdx
+++ b/docs/content/plugins/packaging-and-releasing.mdx
@@ -33,9 +33,9 @@ provider:
 ```
 
 For Go source plugins, the provider code lives at the module root. For Python
-source plugins, Gestalt loads the plugin object declared in `[tool.gestalt]`.
-In both cases, Gestalt synthesizes the runnable wrapper for local source
-execution and release packaging.
+source plugins, Gestalt loads the module declared in
+`[tool.gestalt].plugin`. In both cases, Gestalt synthesizes the runnable
+wrapper for local source execution and release packaging.
 
 ### Declarative provider package
 


### PR DESCRIPTION
## Summary
- fix the stale Python source-plugin wording in the packaging guide
- make the guide match the merged module-based `[tool.gestalt].plugin = "provider"` model

## Why
The packaging guide still said Python source plugins load a "plugin object" from `[tool.gestalt]`, which contradicted the rest of the docs and the current runtime behavior.

## Verification
- audited `docs/content` for stale `provider:plugin`, `plugin object`, and `module or plugin object` wording
- confirmed the remaining Python plugin docs already use the module-based model