### PR TITLE
Add Python session catalogs and multi-platform release builds

### DIFF
--- a/docs/content/plugins/packaging-and-releasing.mdx
+++ b/docs/content/plugins/packaging-and-releasing.mdx
@@ -98,13 +98,19 @@ gestaltd plugin release --version 0.1.0
 
 Run this from the plugin source directory. It produces release archives and writes a checksums file.
 
-For executable Go plugins, release materializes the executable catalog from the
-typed router before packaging and can target multiple platforms.
+For executable Go and Python source plugins, release materializes the
+executable catalog automatically and builds the host-platform artifact by
+default.
 
-For Python source plugins, release loads the module declared in
-`[tool.gestalt].plugin`, materializes the executable catalog automatically, and
-builds a current-platform executable artifact from the selected Python
-environment.
+Pass `--platform` with a comma-separated list such as
+`--platform linux/amd64,darwin/arm64` to build explicit targets.
+
+Pass `--platform all` in CI release jobs to build the full supported platform
+matrix for both Go and Python source plugins.
+
+For non-host targets, point Gestalt at a matching interpreter with
+`GESTALT_PYTHON_<GOOS>_<GOARCH>` or a target-specific virtualenv such as
+`.venv-<goos>-<goarch>/`.
 
 ## Reference packages from config
 

--- a/docs/content/plugins/writing-a-plugin.mdx
+++ b/docs/content/plugins/writing-a-plugin.mdx
@@ -244,9 +244,28 @@ The manifest stays the source of truth for display name, description, auth, the 
     | `SessionCatalogProvider` | `CatalogForRequest(ctx, token)` | Return a dynamic catalog that depends on the caller's credentials or runtime state. |
   </Tabs.Tab>
   <Tabs.Tab>
-    Dynamic catalogs are not yet supported in the Python SDK.
+    Register a dynamic session catalog with `@gestalt.session_catalog` to return
+    a per-request `gestalt.Catalog`.
   </Tabs.Tab>
 </Tabs>
+
+For example:
+
+```python
+@gestalt.session_catalog
+def dynamic_catalog(request: gestalt.Request) -> gestalt.Catalog:
+    return gestalt.Catalog(
+        name="my-plugin-session",
+        display_name=request.token,
+        operations=[
+            gestalt.CatalogOperation(
+                id="search_private",
+                method="POST",
+                read_only=True,
+            )
+        ],
+    )
+```
 
 ## Test locally
 
@@ -285,14 +304,14 @@ gestalt invoke my-plugin greet -p name=Gestalt
 gestaltd plugin release --version 0.1.0
 ```
 
-<Tabs items={['Go', 'Python']} storageKey="sdk-lang">
-  <Tabs.Tab>
-    Gestalt materializes the executable catalog automatically during local source-plugin execution and release. Release builds every requested target platform.
-  </Tabs.Tab>
-  <Tabs.Tab>
-    Gestalt materializes the executable catalog automatically during local source-plugin execution and release. Release builds a current-platform executable artifact from the selected Python environment.
-  </Tabs.Tab>
-</Tabs>
+Gestalt materializes the executable catalog automatically during local source-plugin execution and release.
+
+- For Go and Python source plugins, release builds the host platform by
+  default.
+- Pass `--platform` with a comma-separated target list to build explicit
+  platforms.
+- Pass `--platform all` in CI when you want the full supported release matrix.
+- For non-host Python targets, point Gestalt at a matching interpreter with `GESTALT_PYTHON_<GOOS>_<GOARCH>` or a target-specific virtualenv such as `.venv-<goos>-<goarch>/`.
 
 ## Hybrid providers
 

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -17,7 +17,7 @@
 
 | Command | Purpose |
 | --- | --- |
-| `gestaltd plugin release --version VERSION` | Build and package a plugin release. Go source plugins can target multiple platforms; Python source plugins build a current-platform executable artifact. |
+| `gestaltd plugin release --version VERSION` | Build and package a plugin release. Go and Python source plugins default to the host platform; pass `--platform ...` or `--platform all` for multi-platform builds. |
 
 ## Examples
 
@@ -27,6 +27,7 @@ gestaltd init --config ./config.yaml
 gestaltd serve --locked --config ./config.yaml
 gestaltd validate --config ./config.yaml
 gestaltd plugin release --version 0.1.0
+gestaltd plugin release --version 0.1.0 --platform all
 ```
 
 See [Configuration](/configuration) for the relationship between `init`, `serve --locked`, and `validate`.

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -362,5 +362,7 @@ gestaltd plugin release --version 1.2.3
 For executable Go plugins, release materializes the executable catalog
 automatically from the provider's typed router before packaging. For Python
 source plugins, release loads the module declared in `[tool.gestalt].plugin`,
-materializes the executable catalog automatically, and builds a current-platform
-executable artifact.
+materializes the executable catalog automatically. Go and Python source plugins
+both build the host-platform artifact by default. Pass `--platform` for an
+explicit target list, or `--platform all` in CI to build the full supported
+release matrix.

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -243,7 +243,7 @@ COPY --from=gestaltd /gestaltd /usr/local/bin/gestaltd
 WORKDIR /src
 COPY . .
 RUN cd ./my-plugin && \
-    gestaltd plugin release --version 0.1.0 && \
+    gestaltd plugin release --version 0.1.0 --platform all && \
     gestaltd init --config ./deploy/config.yaml
 ```
 

--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -36,6 +36,7 @@ func runPlugin(args []string) error {
 }
 
 const defaultPlatforms = "darwin/amd64,darwin/arm64,linux/amd64,linux/arm64"
+const allPlatformsValue = "all"
 const defaultReleaseOutputDir = "dist/"
 const releaseBinaryPrefix = "gestalt-plugin-"
 const windowsOS = "windows"
@@ -51,10 +52,16 @@ func runPluginRelease(args []string) error {
 	fs.Usage = func() { printPluginReleaseUsage(fs.Output()) }
 	version := fs.String("version", "", "semantic version string (required)")
 	outputDir := fs.String("output", defaultReleaseOutputDir, "output directory")
-	platforms := fs.String("platform", defaultPlatforms, "comma-separated platforms (os/arch)")
+	platforms := fs.String("platform", "", "comma-separated platforms (os/arch) or 'all'")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	platformFlagExplicit := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "platform" {
+			platformFlagExplicit = true
+		}
+	})
 	if fs.NArg() > 0 {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
 	}
@@ -90,7 +97,7 @@ func runPluginRelease(args []string) error {
 		return fmt.Errorf("create output dir: %w", err)
 	}
 
-	buildPlatforms, err := resolveReleaseBuildPlatforms(".", srcManifest, *platforms)
+	buildPlatforms, err := resolveReleaseBuildPlatforms(".", srcManifest, *platforms, platformFlagExplicit)
 	if err != nil {
 		return err
 	}
@@ -119,24 +126,26 @@ func runPluginRelease(args []string) error {
 	return nil
 }
 
-func resolveReleaseBuildPlatforms(root string, manifest *pluginmanifestv1.Manifest, value string) ([]releasePlatform, error) {
+func resolveReleaseBuildPlatforms(root string, manifest *pluginmanifestv1.Manifest, value string, explicit bool) ([]releasePlatform, error) {
 	hasProviderKind := manifestHasKind(manifest, pluginmanifestv1.KindProvider)
 	if !hasProviderKind {
 		return nil, nil
 	}
 
 	providerBuildRequired := releaseRequiresBuildTarget(manifest)
-	if value == defaultPlatforms {
-		currentPlatformOnly, err := pluginpkg.SourceProviderCurrentPlatformOnly(root, runtime.GOOS, runtime.GOARCH)
-		switch {
-		case err == nil && currentPlatformOnly:
-			value = currentReleasePlatform()
-		case err == nil || errors.Is(err, pluginpkg.ErrNoSourceProviderPackage):
-		default:
-			return nil, fmt.Errorf("detect source provider package: %w", err)
-		}
+	if !providerBuildRequired && !explicit {
+		return nil, nil
 	}
 
+	if explicit {
+		var err error
+		value, err = expandReleasePlatformValue(value)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		value = runtime.GOOS + "/" + runtime.GOARCH
+	}
 	platforms, err := parseReleasePlatforms(value)
 	if err != nil {
 		return nil, err
@@ -167,6 +176,18 @@ func resolveReleaseBuildPlatforms(root string, manifest *pluginmanifestv1.Manife
 		return nil, fmt.Errorf("no Go or Python provider package found")
 	}
 	return builds, nil
+}
+
+func expandReleasePlatformValue(value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	switch {
+	case trimmed == "":
+		return "", fmt.Errorf("--platform requires a comma-separated os/arch list or %q", allPlatformsValue)
+	case strings.EqualFold(trimmed, allPlatformsValue):
+		return defaultPlatforms, nil
+	default:
+		return value, nil
+	}
 }
 
 func buildPlatformArchive(srcManifest *pluginmanifestv1.Manifest, pluginName, version string, platform releasePlatform, outputDir, manifestFile, manifestFormat string) (string, error) {
@@ -322,10 +343,6 @@ func releaseBinaryName(pluginName, goos string) string {
 		return binaryName + windowsExecutableSuffix
 	}
 	return binaryName
-}
-
-func currentReleasePlatform() string {
-	return runtime.GOOS + "/" + runtime.GOARCH
 }
 
 func writeChecksums(dir string, archivePaths []string) error {
@@ -552,18 +569,20 @@ func printPluginUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd plugin <command> [flags]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
-	writeUsageLine(w, "  release     Cross-compile and build plugin release archives")
+	writeUsageLine(w, "  release     Build plugin release archives")
 }
 
 func printPluginReleaseUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
 	writeUsageLine(w, "  gestaltd plugin release --version VERSION [--output DIR] [--platform PLATFORMS]")
 	writeUsageLine(w, "")
-	writeUsageLine(w, "Cross-compile a plugin for multiple platforms and produce per-platform")
-	writeUsageLine(w, "tar.gz archives and a checksums file. Run from the plugin source directory.")
+	writeUsageLine(w, "Build a plugin release archive for the host platform by default.")
+	writeUsageLine(w, "Pass --platform with a comma-separated os/arch list or --platform all")
+	writeUsageLine(w, "to build multiple per-platform tar.gz archives plus a checksums file.")
+	writeUsageLine(w, "Run from the plugin source directory.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --version    Semantic version string (required)")
 	writeUsageLine(w, "  --output     Output directory (default: dist/)")
-	writeUsageLine(w, "  --platform   Comma-separated platforms (default: darwin/amd64,darwin/arm64,linux/amd64,linux/arm64)")
+	writeUsageLine(w, "  --platform   Comma-separated platforms (os/arch) or all (default: host platform only)")
 }

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -281,6 +281,7 @@ func TestRun_PluginReleaseBuildsPythonSourcePluginForCurrentPlatform(t *testing.
 
 	runPluginReleaseCommand(t, pluginDir,
 		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
 		"--output", outputDir,
 	)
 
@@ -330,7 +331,149 @@ func TestRun_PluginReleaseBuildsPythonSourcePluginForCurrentPlatform(t *testing.
 	}
 }
 
-func TestRun_PluginReleaseRejectsNonCurrentPlatformForPythonSourcePlugin(t *testing.T) {
+func TestRun_PluginReleaseDefaultsGoSourcePluginToHostPlatform(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newGoSourceReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.12-go-default"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-release-test_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+	if len(manifest.Artifacts) != 1 {
+		t.Fatalf("artifacts = %+v, want exactly one host-platform artifact", manifest.Artifacts)
+	}
+	if manifest.Artifacts[0].OS != runtime.GOOS || manifest.Artifacts[0].Arch != runtime.GOARCH {
+		t.Fatalf("artifact platform = %s/%s, want %s/%s", manifest.Artifacts[0].OS, manifest.Artifacts[0].Arch, runtime.GOOS, runtime.GOARCH)
+	}
+}
+
+func TestRun_PluginReleaseBuildsGoSourcePluginForAllPlatforms(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newGoSourceReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.12-go-all"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", allPlatformsValue,
+		"--output", outputDir,
+	)
+
+	for _, platform := range defaultReleasePlatformsForTest(t) {
+		archiveName := "gestalt-plugin-release-test_v" + testVersion + "_" + platform.GOOS + "_" + platform.GOARCH + ".tar.gz"
+		manifest := readReleasedManifest(t, outputDir, archiveName)
+		if len(manifest.Artifacts) != 1 {
+			t.Fatalf("artifacts for %s/%s = %+v, want one artifact", platform.GOOS, platform.GOARCH, manifest.Artifacts)
+		}
+		if manifest.Artifacts[0].OS != platform.GOOS || manifest.Artifacts[0].Arch != platform.GOARCH {
+			t.Fatalf("artifact platform = %s/%s, want %s/%s", manifest.Artifacts[0].OS, manifest.Artifacts[0].Arch, platform.GOOS, platform.GOARCH)
+		}
+	}
+}
+
+func TestRun_PluginReleaseDefaultsPythonSourcePluginToHostPlatform(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake Python build fixture is POSIX-only")
+	}
+
+	t.Setenv("GESTALT_TEST_PYINSTALLER_BINARY", pluginBin)
+	t.Setenv("PATH", pathWithoutGo(t))
+
+	pluginDir := newPythonSourceReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.12-default"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-python-release_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+	if len(manifest.Artifacts) != 1 {
+		t.Fatalf("artifacts = %+v, want exactly one host-platform artifact", manifest.Artifacts)
+	}
+	if manifest.Artifacts[0].OS != runtime.GOOS || manifest.Artifacts[0].Arch != runtime.GOARCH {
+		t.Fatalf("artifact platform = %s/%s, want %s/%s", manifest.Artifacts[0].OS, manifest.Artifacts[0].Arch, runtime.GOOS, runtime.GOARCH)
+	}
+}
+
+func TestRun_PluginReleaseBuildsPythonSourcePluginForAllPlatforms(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake Python build fixture is POSIX-only")
+	}
+
+	t.Setenv("GESTALT_TEST_PYINSTALLER_BINARY", pluginBin)
+	t.Setenv("PATH", pathWithoutGo(t))
+
+	pluginDir := newPythonSourceReleaseFixture(t, t.TempDir())
+	configurePythonReleaseInterpretersForAllPlatforms(t, pluginDir)
+
+	outputDir := t.TempDir()
+	const testVersion = "0.0.12-python-all"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", allPlatformsValue,
+		"--output", outputDir,
+	)
+
+	for _, platform := range defaultReleasePlatformsForTest(t) {
+		archiveName := "gestalt-plugin-python-release_v" + testVersion + "_" + platform.GOOS + "_" + platform.GOARCH + ".tar.gz"
+		manifest := readReleasedManifest(t, outputDir, archiveName)
+		if len(manifest.Artifacts) != 1 {
+			t.Fatalf("artifacts for %s/%s = %+v, want one artifact", platform.GOOS, platform.GOARCH, manifest.Artifacts)
+		}
+		if manifest.Artifacts[0].OS != platform.GOOS || manifest.Artifacts[0].Arch != platform.GOARCH {
+			t.Fatalf("artifact platform = %s/%s, want %s/%s", manifest.Artifacts[0].OS, manifest.Artifacts[0].Arch, platform.GOOS, platform.GOARCH)
+		}
+	}
+}
+
+func TestRun_PluginReleaseBuildsPythonSourcePluginForRequestedPlatforms(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake Python build fixture is POSIX-only")
+	}
+
+	t.Setenv("GESTALT_TEST_PYINSTALLER_BINARY", pluginBin)
+	t.Setenv("PATH", pathWithoutGo(t))
+
+	pluginDir := newPythonSourceReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	otherGOOS, otherGOARCH := pythonReleaseOtherPlatform()
+	otherPlatform := otherGOOS + "/" + otherGOARCH
+	writeFakePythonReleaseInterpreter(t, filepath.Join(pluginDir, "cross-python"), otherGOOS, otherGOARCH)
+	t.Setenv(pluginpkgPythonEnvVar(otherGOOS, otherGOARCH), filepath.Join(pluginDir, "cross-python"))
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", "0.0.13-test",
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH+","+otherPlatform,
+		"--output", outputDir,
+	)
+
+	currentArchive := "gestalt-plugin-python-release_v0.0.13-test_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	otherArchive := "gestalt-plugin-python-release_v0.0.13-test_" + otherGOOS + "_" + otherGOARCH + ".tar.gz"
+	for _, archiveName := range []string{currentArchive, otherArchive} {
+		extractDir := extractReleasedArchive(t, outputDir, archiveName)
+		manifest := readReleasedManifest(t, outputDir, archiveName)
+		binaryName := releaseBinaryName("python-release", manifest.Artifacts[0].OS)
+		if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != binaryName {
+			t.Fatalf("artifacts = %+v, want path %q", manifest.Artifacts, binaryName)
+		}
+		if _, err := os.Stat(filepath.Join(extractDir, binaryName)); err != nil {
+			t.Fatalf("expected %s in archive: %v", binaryName, err)
+		}
+	}
+}
+
+func TestRun_PluginReleaseRejectsMissingCrossTargetInterpreterForPythonSourcePlugin(t *testing.T) {
 	t.Parallel()
 
 	if runtime.GOOS == "windows" {
@@ -339,10 +482,8 @@ func TestRun_PluginReleaseRejectsNonCurrentPlatformForPythonSourcePlugin(t *test
 
 	pluginDir := newPythonSourceReleaseFixture(t, t.TempDir())
 	outputDir := t.TempDir()
-	otherPlatform := "linux/amd64"
-	if runtime.GOOS == "linux" && runtime.GOARCH == "amd64" {
-		otherPlatform = "darwin/arm64"
-	}
+	otherGOOS, otherGOARCH := pythonReleaseOtherPlatform()
+	otherPlatform := otherGOOS + "/" + otherGOARCH
 
 	out, err := runPluginReleaseCommandResult(pluginDir,
 		"--version", "0.0.13-test",
@@ -352,7 +493,7 @@ func TestRun_PluginReleaseRejectsNonCurrentPlatformForPythonSourcePlugin(t *test
 	if err == nil {
 		t.Fatalf("expected error for non-current platform, got output: %s", out)
 	}
-	if !strings.Contains(string(out), "python source plugins can only be released for the current platform") {
+	if !strings.Contains(string(out), pluginpkgPythonEnvVar(otherGOOS, otherGOARCH)) {
 		t.Fatalf("unexpected output: %s", out)
 	}
 }
@@ -978,6 +1119,20 @@ class GreetOutput(gestalt.Model):
 @gestalt.operation(method="GET", read_only=True)
 def greet(input: GreetInput, _req: gestalt.Request) -> GreetOutput:
     return GreetOutput(message=f"Hello, {input.name}!")
+
+
+@gestalt.session_catalog
+def dynamic_catalog(request: gestalt.Request) -> gestalt.Catalog:
+    return gestalt.Catalog(
+        name="python-release-session",
+        display_name=request.token,
+        operations=[
+            gestalt.CatalogOperation(
+                id="session_greet",
+                method="GET",
+            )
+        ],
+    )
 `), 0o644)
 	manifestData, err := pluginpkg.EncodeSourceManifestFormat(&pluginmanifestv1.Manifest{
 		Source:  "github.com/testowner/plugins/python-release",
@@ -991,7 +1146,14 @@ def greet(input: GreetInput, _req: gestalt.Request) -> GreetOutput:
 		t.Fatalf("EncodeSourceManifestFormat: %v", err)
 	}
 	writeTestFile(t, pluginDir, "plugin.yaml", manifestData, 0o644)
-	writeTestFile(t, pluginDir, filepath.ToSlash(filepath.Join(".venv", "bin", "python")), []byte(`#!/bin/sh
+	writeFakePythonReleaseInterpreter(t, filepath.Join(pluginDir, ".venv", "bin", "python"), runtime.GOOS, runtime.GOARCH)
+	return pluginDir
+}
+
+func writeFakePythonReleaseInterpreter(t *testing.T, path, expectedGOOS, expectedGOARCH string) {
+	t.Helper()
+
+	script := `#!/bin/sh
 set -eu
 
 if [ "$#" -ge 2 ] && [ "$1" = "-m" ] && [ "$2" = "gestalt._build" ]; then
@@ -999,7 +1161,7 @@ if [ "$#" -ge 2 ] && [ "$1" = "-m" ] && [ "$2" = "gestalt._build" ]; then
     echo "missing GESTALT_TEST_PYINSTALLER_BINARY" >&2
     exit 1
   fi
-  if [ "$#" -ne 6 ]; then
+  if [ "$#" -ne 8 ]; then
     echo "unexpected gestalt._build args: $*" >&2
     exit 1
   fi
@@ -1007,12 +1169,18 @@ if [ "$#" -ge 2 ] && [ "$1" = "-m" ] && [ "$2" = "gestalt._build" ]; then
   target="$4"
   output="$5"
   name="$6"
+  goos="$7"
+  goarch="$8"
   if [ "$target" != "provider" ]; then
     echo "unexpected provider target: $target" >&2
     exit 1
   fi
   if [ "$name" != "python-release" ]; then
     echo "unexpected plugin name: $name" >&2
+    exit 1
+  fi
+  if [ "$goos" != "` + expectedGOOS + `" ] || [ "$goarch" != "` + expectedGOARCH + `" ]; then
+    echo "unexpected target platform: $goos/$goarch" >&2
     exit 1
   fi
   output_dir="${output%/*}"
@@ -1041,8 +1209,44 @@ fi
 
 echo "unexpected fake python invocation: $*" >&2
 exit 1
-`), 0o755)
-	return pluginDir
+`
+	writeTestFile(t, filepath.Dir(path), filepath.Base(path), []byte(script), 0o755)
+}
+
+func pythonReleaseOtherPlatform() (string, string) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		return "darwin", "arm64"
+	}
+	return "linux", "amd64"
+}
+
+func defaultReleasePlatformsForTest(t *testing.T) []releasePlatform {
+	t.Helper()
+
+	platforms, err := parseReleasePlatforms(defaultPlatforms)
+	if err != nil {
+		t.Fatalf("parseReleasePlatforms(defaultPlatforms): %v", err)
+	}
+	return platforms
+}
+
+func configurePythonReleaseInterpretersForAllPlatforms(t *testing.T, pluginDir string) {
+	t.Helper()
+
+	replacer := strings.NewReplacer("/", "-", "\\", "-")
+	for _, platform := range defaultReleasePlatformsForTest(t) {
+		if platform.GOOS == runtime.GOOS && platform.GOARCH == runtime.GOARCH {
+			continue
+		}
+		interpreterPath := filepath.Join(pluginDir, "python-"+replacer.Replace(platform.GOOS+"-"+platform.GOARCH))
+		writeFakePythonReleaseInterpreter(t, interpreterPath, platform.GOOS, platform.GOARCH)
+		t.Setenv(pluginpkgPythonEnvVar(platform.GOOS, platform.GOARCH), interpreterPath)
+	}
+}
+
+func pluginpkgPythonEnvVar(goos, goarch string) string {
+	replacer := strings.NewReplacer("-", "_", ".", "_", "/", "_")
+	return "GESTALT_PYTHON_" + strings.ToUpper(replacer.Replace(goos)) + "_" + strings.ToUpper(replacer.Replace(goarch))
 }
 
 func pathWithoutGo(t *testing.T) string {
@@ -1101,6 +1305,28 @@ func newCompiledReleaseFixture(t *testing.T, dir string) string {
 	})
 	writeTestFile(t, pluginDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0644)
 	writeTestFile(t, pluginDir, releaseProviderSchemaPath, []byte(`{"type":"object"}`), 0644)
+	return pluginDir
+}
+
+func newGoSourceReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(dir, releaseTestPluginName)
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(pluginDir): %v", err)
+	}
+	writeTestFile(t, pluginDir, "go.mod", []byte(testutil.GeneratedProviderModuleSource(t, releaseTestModule)), 0o644)
+	writeTestFile(t, pluginDir, "go.sum", testutil.GeneratedProviderModuleSum(t), 0o644)
+	writeStaticCatalogProviderMain(t, pluginDir)
+	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
+		Source:      releaseTestSource,
+		Version:     "0.0.1",
+		DisplayName: "Release Test",
+		Kinds:       []string{pluginmanifestv1.KindProvider},
+		Provider: &pluginmanifestv1.Provider{
+			Auth: &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeNone},
+		},
+	})
 	return pluginDir
 }
 

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -271,6 +271,21 @@ def list_items(_req: gestalt.Request) -> dict[str, object]:
 @gestalt.operation(method="POST")
 def status_zero(_req: gestalt.Request) -> gestalt.Response[dict[str, bool]]:
     return gestalt.Response(status=0, body={"ok": True})
+
+
+@gestalt.session_catalog
+def session_catalog(request: gestalt.Request) -> gestalt.Catalog:
+    return gestalt.Catalog(
+        name="session-source",
+        display_name=request.token,
+        operations=[
+            gestalt.CatalogOperation(
+                id="private_search",
+                method="POST",
+                read_only=True,
+            )
+        ],
+    )
 `), 0o644)
 	createLocalPythonSDKVenv(t, python3Path, filepath.Join(dir, ".venv"), localPythonSDKPath(t))
 
@@ -329,6 +344,7 @@ maybe_status, maybe_body = provider.plugin.execute("maybe_filters", {
     "owner": "Grace",
 }, gestalt.Request())
 list_status, list_body = provider.plugin.execute("list_items", {}, gestalt.Request())
+session_catalog = provider.plugin.catalog_for_request(gestalt.Request(token="secret-token"))
 print(json.dumps({
     "status": status,
     "body": json.loads(body),
@@ -342,6 +358,18 @@ print(json.dumps({
     "list_body": json.loads(list_body),
     "maybe_status": maybe_status,
     "maybe_body": json.loads(maybe_body),
+    "supports_session_catalog": provider.plugin.supports_session_catalog(),
+    "session_catalog": {
+        "name": session_catalog.name if session_catalog else "",
+        "display_name": session_catalog.display_name if session_catalog else "",
+        "operations": [
+            {
+                "id": operation.id,
+                "read_only": operation.read_only,
+            }
+            for operation in (session_catalog.operations if session_catalog else [])
+        ],
+    },
     "zero_status": zero_status,
     "zero_body": json.loads(zero_body),
 }, sort_keys=True))
@@ -513,6 +541,33 @@ print(json.dumps({
 	}
 	if maybePayload["owner"] != "Grace" {
 		t.Fatalf("maybe owner = %v, want Grace", maybePayload["owner"])
+	}
+	if body["supports_session_catalog"] != true {
+		t.Fatalf("supports_session_catalog = %v, want true", body["supports_session_catalog"])
+	}
+	sessionCatalog, ok := body["session_catalog"].(map[string]any)
+	if !ok {
+		t.Fatalf("session_catalog = %#v, want object", body["session_catalog"])
+	}
+	if sessionCatalog["name"] != "session-source" {
+		t.Fatalf("session catalog name = %v, want session-source", sessionCatalog["name"])
+	}
+	if sessionCatalog["display_name"] != "secret-token" {
+		t.Fatalf("session catalog display_name = %v, want secret-token", sessionCatalog["display_name"])
+	}
+	sessionOps, ok := sessionCatalog["operations"].([]any)
+	if !ok || len(sessionOps) != 1 {
+		t.Fatalf("session catalog operations = %#v, want one item", sessionCatalog["operations"])
+	}
+	sessionOp, ok := sessionOps[0].(map[string]any)
+	if !ok {
+		t.Fatalf("session catalog operation = %#v, want object", sessionOps[0])
+	}
+	if sessionOp["id"] != "private_search" {
+		t.Fatalf("session catalog operation id = %v, want private_search", sessionOp["id"])
+	}
+	if sessionOp["read_only"] != true {
+		t.Fatalf("session catalog operation read_only = %v, want true", sessionOp["read_only"])
 	}
 	if body["zero_status"] != float64(0) {
 		t.Fatalf("zero_status = %v, want 0", body["zero_status"])

--- a/gestaltd/internal/pluginpkg/python_provider.go
+++ b/gestaltd/internal/pluginpkg/python_provider.go
@@ -18,6 +18,7 @@ const (
 	pythonProjectFile   = "pyproject.toml"
 	pythonRuntimeModule = "gestalt._runtime"
 	pythonBuildModule   = "gestalt._build"
+	pythonEnvVarPrefix  = "GESTALT_PYTHON_"
 )
 
 var ErrNoPythonProviderPackage = errors.New("no Python provider package found")
@@ -53,20 +54,20 @@ func DetectPythonProviderTarget(root string) (string, error) {
 }
 
 func pythonProviderExecutionCommand(root, target string) (string, []string, func(), error) {
-	interpreter, err := DetectPythonInterpreter(root)
+	interpreter, err := DetectPythonInterpreter(root, runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		return "", nil, nil, err
 	}
 	return interpreter, []string{"-m", pythonRuntimeModule, root, target}, nil, nil
 }
 
-func BuildPythonProviderBinary(sourceDir, binaryPath, pluginName, target string) error {
-	interpreter, err := DetectPythonInterpreter(sourceDir)
+func BuildPythonProviderBinary(sourceDir, binaryPath, pluginName, target, goos, goarch string) error {
+	interpreter, err := DetectPythonInterpreter(sourceDir, goos, goarch)
 	if err != nil {
-		return fmt.Errorf("detect Python release interpreter: %w", err)
+		return fmt.Errorf("detect Python release interpreter for %s/%s: %w", goos, goarch, err)
 	}
 
-	cmd := exec.Command(interpreter, "-m", pythonBuildModule, sourceDir, target, binaryPath, pluginName)
+	cmd := exec.Command(interpreter, "-m", pythonBuildModule, sourceDir, target, binaryPath, pluginName, goos, goarch)
 	cmd.Dir = sourceDir
 	cmd.Env = append(os.Environ(), pythonBackendEnv()...)
 	cmd.Stdout = os.Stdout
@@ -77,8 +78,8 @@ func BuildPythonProviderBinary(sourceDir, binaryPath, pluginName, target string)
 	return nil
 }
 
-func DetectPythonInterpreter(root string) (string, error) {
-	for _, candidate := range pythonInterpreterCandidates(root) {
+func DetectPythonInterpreter(root, goos, goarch string) (string, error) {
+	for _, candidate := range pythonInterpreterCandidates(root, goos, goarch) {
 		if candidate == "" {
 			continue
 		}
@@ -92,7 +93,11 @@ func DetectPythonInterpreter(root string) (string, error) {
 			return resolved, nil
 		}
 	}
-	return "", fmt.Errorf("detect Python interpreter: %w", exec.ErrNotFound)
+	envVar := pythonInterpreterEnvVar(goos, goarch)
+	if goos == runtime.GOOS && goarch == runtime.GOARCH {
+		return "", fmt.Errorf("detect Python interpreter: %w", exec.ErrNotFound)
+	}
+	return "", fmt.Errorf("detect Python interpreter: %w (set %s or provide a target-specific virtualenv)", exec.ErrNotFound, envVar)
 }
 
 func pythonBackendImportPaths() []string {
@@ -126,9 +131,36 @@ func localPythonSDKPath() string {
 	return path
 }
 
-func pythonInterpreterCandidates(root string) []string {
+func pythonInterpreterCandidates(root, goos, goarch string) []string {
+	candidates := []string{
+		os.Getenv(pythonInterpreterEnvVar(goos, goarch)),
+	}
+	suffix := goos + "-" + goarch
+	if goos == "windows" {
+		candidates = append(candidates,
+			filepath.Join(root, ".venv-"+suffix, "Scripts", "python.exe"),
+			filepath.Join(root, "venv-"+suffix, "Scripts", "python.exe"),
+			filepath.Join(root, ".venv", suffix, "Scripts", "python.exe"),
+			filepath.Join(root, "venv", suffix, "Scripts", "python.exe"),
+		)
+	} else {
+		candidates = append(candidates,
+			filepath.Join(root, ".venv-"+suffix, "bin", "python"),
+			filepath.Join(root, "venv-"+suffix, "bin", "python"),
+			filepath.Join(root, ".venv", suffix, "bin", "python"),
+			filepath.Join(root, "venv", suffix, "bin", "python"),
+		)
+	}
+	if goos == runtime.GOOS && goarch == runtime.GOARCH {
+		candidates = append(candidates, pythonGenericInterpreterCandidates(root)...)
+	}
+	return candidates
+}
+
+func pythonGenericInterpreterCandidates(root string) []string {
 	if runtime.GOOS == "windows" {
 		return []string{
+			os.Getenv("GESTALT_PYTHON"),
 			filepath.Join(root, ".venv", "Scripts", "python.exe"),
 			filepath.Join(root, "venv", "Scripts", "python.exe"),
 			"py",
@@ -136,11 +168,17 @@ func pythonInterpreterCandidates(root string) []string {
 		}
 	}
 	return []string{
+		os.Getenv("GESTALT_PYTHON"),
 		filepath.Join(root, ".venv", "bin", "python"),
 		filepath.Join(root, "venv", "bin", "python"),
 		"python3",
 		"python",
 	}
+}
+
+func pythonInterpreterEnvVar(goos, goarch string) string {
+	replacer := strings.NewReplacer("-", "_", ".", "_", "/", "_")
+	return pythonEnvVarPrefix + strings.ToUpper(replacer.Replace(goos)) + "_" + strings.ToUpper(replacer.Replace(goarch))
 }
 
 func SplitPythonProviderTarget(target string) (module string, attr string, err error) {

--- a/gestaltd/internal/pluginpkg/python_provider_test.go
+++ b/gestaltd/internal/pluginpkg/python_provider_test.go
@@ -1,0 +1,85 @@
+package pluginpkg
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestDetectPythonInterpreter_CurrentPlatformFallsBackToGenericVenv(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	pythonPath := pythonTestInterpreterPath(root, runtime.GOOS, ".venv")
+	mustWritePythonInterpreter(t, pythonPath)
+
+	got, err := DetectPythonInterpreter(root, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatalf("DetectPythonInterpreter(current): %v", err)
+	}
+	if got != pythonPath {
+		t.Fatalf("interpreter = %q, want %q", got, pythonPath)
+	}
+}
+
+func TestDetectPythonInterpreter_UsesPlatformSpecificOverride(t *testing.T) {
+	root := t.TempDir()
+	goos, goarch := pythonTestOtherPlatform()
+	pythonPath := filepath.Join(root, "cross-python")
+	mustWritePythonInterpreter(t, pythonPath)
+	t.Setenv(pythonInterpreterEnvVar(goos, goarch), pythonPath)
+
+	got, err := DetectPythonInterpreter(root, goos, goarch)
+	if err != nil {
+		t.Fatalf("DetectPythonInterpreter(cross): %v", err)
+	}
+	if got != pythonPath {
+		t.Fatalf("interpreter = %q, want %q", got, pythonPath)
+	}
+}
+
+func TestDetectPythonInterpreter_CrossTargetRequiresExplicitInterpreter(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	goos, goarch := pythonTestOtherPlatform()
+
+	_, err := DetectPythonInterpreter(root, goos, goarch)
+	if err == nil {
+		t.Fatal("expected cross-target interpreter error")
+	}
+	if want := pythonInterpreterEnvVar(goos, goarch); !containsString(err.Error(), want) {
+		t.Fatalf("error = %q, want mention of %s", err, want)
+	}
+}
+
+func pythonTestOtherPlatform() (string, string) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		return "darwin", "arm64"
+	}
+	return "linux", "amd64"
+}
+
+func pythonTestInterpreterPath(root, goos, suffix string) string {
+	if goos == "windows" {
+		return filepath.Join(root, suffix, "Scripts", "python.exe")
+	}
+	return filepath.Join(root, suffix, "bin", "python")
+}
+
+func mustWritePythonInterpreter(t *testing.T, path string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+func containsString(haystack, needle string) bool {
+	return strings.Contains(haystack, needle)
+}

--- a/gestaltd/internal/pluginpkg/source_provider.go
+++ b/gestaltd/internal/pluginpkg/source_provider.go
@@ -2,7 +2,6 @@ package pluginpkg
 
 import (
 	"errors"
-	"fmt"
 	"runtime"
 )
 
@@ -55,20 +54,15 @@ func SourceProviderExecutionCommand(root, goos, goarch string) (string, []string
 	}
 }
 
-func SourceProviderCurrentPlatformOnly(root, goos, goarch string) (bool, error) {
-	kind, _, err := detectSourceProvider(root, goos, goarch)
-	if err != nil {
-		return false, err
-	}
-	return kind == sourceProviderKindPython, nil
-}
-
 func ValidateSourceProviderRelease(root, goos, goarch string) error {
 	kind, _, err := detectSourceProvider(root, goos, goarch)
 	if err != nil {
 		return err
 	}
-	return validateSourceProviderReleaseKind(kind, goos, goarch)
+	if kind == sourceProviderKindPython {
+		_, err = DetectPythonInterpreter(root, goos, goarch)
+	}
+	return err
 }
 
 func BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch string) error {
@@ -80,20 +74,10 @@ func BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch
 	case sourceProviderKindGo:
 		return BuildGoProviderBinary(root, outputPath, pluginName, goos, goarch)
 	case sourceProviderKindPython:
-		if err := validateSourceProviderReleaseKind(kind, goos, goarch); err != nil {
-			return err
-		}
-		return BuildPythonProviderBinary(root, outputPath, pluginName, pythonTarget)
+		return BuildPythonProviderBinary(root, outputPath, pluginName, pythonTarget, goos, goarch)
 	default:
 		return ErrNoSourceProviderPackage
 	}
-}
-
-func validateSourceProviderReleaseKind(kind, goos, goarch string) error {
-	if kind == sourceProviderKindPython && (goos != runtime.GOOS || goarch != runtime.GOARCH) {
-		return fmt.Errorf("python source plugins can only be released for the current platform %s/%s", runtime.GOOS, runtime.GOARCH)
-	}
-	return nil
 }
 
 func HasSourceProviderPackage(root string) (bool, error) {

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -8,8 +8,13 @@ It is intended to be used by source plugins discovered through
 same source tree.
 
 Python source plugins are developed locally via `from.source.path` and
-released through `gestaltd plugin release` as current-platform executable
-artifacts.
+released through `gestaltd plugin release` for the host platform by default,
+or for every requested target platform when you pass `--platform`. In CI,
+prefer `--platform all` to build the full supported release matrix.
+
+For non-host targets, configure a matching Python build interpreter with
+`GESTALT_PYTHON_<GOOS>_<GOARCH>` or a target-specific virtualenv such as
+`.venv-<goos>-<goarch>/`.
 
 ## Regenerating Protobuf Stubs
 

--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -1,12 +1,25 @@
 from ._api import OK, Model, Request, Response, field
-from ._plugin import Plugin, operation
+from ._catalog import (
+    Catalog,
+    CatalogOperation,
+    CatalogParameter,
+    OperationAnnotations,
+    SessionCatalogProvider,
+)
+from ._plugin import Plugin, operation, session_catalog
 
 __all__ = [
+    "Catalog",
+    "CatalogOperation",
+    "CatalogParameter",
     "Model",
     "OK",
+    "OperationAnnotations",
     "Plugin",
     "Request",
     "Response",
+    "SessionCatalogProvider",
     "field",
     "operation",
+    "session_catalog",
 ]

--- a/sdk/python/gestalt/_build.py
+++ b/sdk/python/gestalt/_build.py
@@ -12,7 +12,7 @@ from ._bootstrap import (
     write_bundled_plugin_config,
 )
 
-USAGE: Final[str] = "usage: python -m gestalt._build ROOT MODULE[:ATTRIBUTE] OUTPUT PLUGIN_NAME"
+USAGE: Final[str] = "usage: python -m gestalt._build ROOT MODULE[:ATTRIBUTE] OUTPUT PLUGIN_NAME GOOS GOARCH"
 
 
 @dataclass(frozen=True)
@@ -21,6 +21,8 @@ class BuildArgs:
     target: str
     output_path: pathlib.Path
     plugin_name: str
+    goos: str
+    goarch: str
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -34,15 +36,17 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _parse_build_args(args: list[str]) -> BuildArgs | None:
-    if len(args) != 4:
+    if len(args) != 6:
         return None
 
-    root, target, output_path, plugin_name = args
+    root, target, output_path, plugin_name, goos, goarch = args
     return BuildArgs(
         root=pathlib.Path(root),
         target=target,
         output_path=pathlib.Path(output_path),
         plugin_name=plugin_name,
+        goos=goos,
+        goarch=goarch,
     )
 
 
@@ -67,6 +71,8 @@ def build_plugin_binary(args: BuildArgs) -> None:
                 output_path=output_path,
                 module_name=plugin_target.module_name,
                 bundle_config_path=bundle_config_path,
+                target_goos=args.goos,
+                target_goarch=args.goarch,
             ),
             cwd=root_path,
             check=True,
@@ -79,10 +85,12 @@ def _pyinstaller_command(
     output_path: pathlib.Path,
     module_name: str,
     bundle_config_path: pathlib.Path,
+    target_goos: str,
+    target_goarch: str,
 ) -> list[str]:
-    pyinstaller_name = output_path.name.removesuffix(".exe") if sys.platform == "win32" else output_path.name
+    pyinstaller_name = output_path.name.removesuffix(".exe") if target_goos == "windows" else output_path.name
 
-    return [
+    command = [
         sys.executable,
         "-m",
         "PyInstaller",
@@ -105,6 +113,18 @@ def _pyinstaller_command(
         f"{bundle_config_path}{os.pathsep}.",
         str(pathlib.Path(__file__).with_name("_pyinstaller.py")),
     ]
+    if sys.platform == "darwin" and target_goos == "darwin":
+        target_arch = _darwin_target_arch(target_goarch)
+        if target_arch:
+            command.extend(["--target-arch", target_arch])
+    return command
+
+
+def _darwin_target_arch(goarch: str) -> str | None:
+    return {
+        "amd64": "x86_64",
+        "arm64": "arm64",
+    }.get(goarch)
 
 
 if __name__ == "__main__":

--- a/sdk/python/gestalt/_catalog.py
+++ b/sdk/python/gestalt/_catalog.py
@@ -1,31 +1,100 @@
 import dataclasses
+import json
 import pathlib
+from collections.abc import Mapping
 from dataclasses import MISSING
-from typing import Any, Iterable, get_origin, get_type_hints
+from typing import (
+    Any,
+    Iterable,
+    Protocol,
+    cast,
+    get_origin,
+    get_type_hints,
+    runtime_checkable,
+)
 
 import yaml
 
-from ._api import FIELD_DESCRIPTION_KEY, FIELD_REQUIRED_KEY
+from ._api import FIELD_DESCRIPTION_KEY, FIELD_REQUIRED_KEY, Request
 from ._operations import OperationDefinition, is_optional_type, strip_optional
+
+_UNSET = object()
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class OperationAnnotations:
+    read_only_hint: bool | None = None
+    idempotent_hint: bool | None = None
+    destructive_hint: bool | None = None
+    open_world_hint: bool | None = None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class CatalogParameter:
+    name: str
+    type: str
+    description: str = ""
+    required: bool = False
+    default: Any = dataclasses.field(default=_UNSET)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class CatalogOperation:
+    id: str
+    method: str
+    title: str = ""
+    description: str = ""
+    input_schema: Any = dataclasses.field(default=_UNSET)
+    output_schema: Any = dataclasses.field(default=_UNSET)
+    annotations: OperationAnnotations | None = None
+    parameters: list[CatalogParameter] = dataclasses.field(default_factory=list)
+    required_scopes: list[str] = dataclasses.field(default_factory=list)
+    tags: list[str] = dataclasses.field(default_factory=list)
+    read_only: bool = False
+    visible: bool | None = None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Catalog:
+    name: str = ""
+    display_name: str = ""
+    description: str = ""
+    icon_svg: str = ""
+    operations: list[CatalogOperation] = dataclasses.field(default_factory=list)
+
+
+@runtime_checkable
+class SessionCatalogProvider(Protocol):
+    def catalog_for_request(self, request: Request) -> Catalog | Mapping[str, Any] | None: ...
 
 
 def build_catalog(
     *,
     plugin_name: str,
     operations: Iterable[OperationDefinition],
-) -> dict[str, Any]:
-    return {
-        "name": plugin_name,
-        "operations": [_catalog_operation(operation) for operation in operations],
-    }
+) -> Catalog:
+    return Catalog(
+        name=plugin_name,
+        operations=[_catalog_operation(operation) for operation in operations],
+    )
 
 
-def write_catalog(path: str | pathlib.Path, *, catalog: dict[str, Any]) -> None:
+def catalog_to_dict(catalog: Catalog | Mapping[str, Any], *, field_style: str = "yaml") -> dict[str, Any]:
+    return _serialize_catalog_dict(_catalog_python_dict(catalog), field_style=field_style)
+
+
+def catalog_to_json(catalog: Catalog | Mapping[str, Any] | None) -> str:
+    if catalog is None:
+        return ""
+    return json.dumps(catalog_to_dict(catalog, field_style="json"), separators=(",", ":"))
+
+
+def write_catalog(path: str | pathlib.Path, *, catalog: Catalog | Mapping[str, Any]) -> None:
     catalog_path = pathlib.Path(path)
     catalog_path.parent.mkdir(parents=True, exist_ok=True)
     catalog_path.write_text(
         yaml.dump(
-            catalog,
+            catalog_to_dict(catalog, field_style="yaml"),
             Dumper=_CatalogDumper,
             sort_keys=False,
             default_flow_style=False,
@@ -35,30 +104,20 @@ def write_catalog(path: str | pathlib.Path, *, catalog: dict[str, Any]) -> None:
     )
 
 
-def _catalog_operation(operation: OperationDefinition) -> dict[str, Any]:
-    data: dict[str, Any] = {
-        "id": operation.id,
-        "method": operation.method,
-    }
-    if operation.title:
-        data["title"] = operation.title
-    if operation.description:
-        data["description"] = operation.description
-    if operation.tags:
-        data["tags"] = operation.tags
-    if operation.read_only:
-        data["read_only"] = True
-    if operation.visible is not None:
-        data["visible"] = operation.visible
-
-    parameters = _catalog_parameters(operation.input_type)
-    if parameters:
-        data["parameters"] = parameters
-
-    return data
+def _catalog_operation(operation: OperationDefinition) -> CatalogOperation:
+    return CatalogOperation(
+        id=operation.id,
+        method=operation.method,
+        title=operation.title,
+        description=operation.description,
+        parameters=_catalog_parameters(operation.input_type),
+        tags=list(operation.tags),
+        read_only=operation.read_only,
+        visible=operation.visible,
+    )
 
 
-def _catalog_parameters(input_type: Any) -> list[dict[str, Any]]:
+def _catalog_parameters(input_type: Any) -> list[CatalogParameter]:
     if input_type is None:
         return []
 
@@ -71,18 +130,15 @@ def _catalog_parameters(input_type: Any) -> list[dict[str, Any]]:
         return []
 
     type_hints = get_type_hints(input_type)
-    parameters: list[dict[str, Any]] = []
+    parameters: list[CatalogParameter] = []
     for field_definition in dataclasses.fields(input_type):
         annotation = type_hints.get(field_definition.name, field_definition.type)
-        parameter: dict[str, Any] = {
-            "name": field_definition.name,
-            "type": _catalog_type(annotation),
-        }
+        parameter = CatalogParameter(
+            name=field_definition.name,
+            type=_catalog_type(annotation),
+        )
 
         description = str(field_definition.metadata.get(FIELD_DESCRIPTION_KEY, "")).strip()
-        if description:
-            parameter["description"] = description
-
         required = field_definition.metadata.get(FIELD_REQUIRED_KEY)
         if required is None:
             required = (
@@ -90,12 +146,13 @@ def _catalog_parameters(input_type: Any) -> list[dict[str, Any]]:
                 and field_definition.default_factory is MISSING
                 and not is_optional_type(annotation)
             )
-        if required:
-            parameter["required"] = True
 
-        if field_definition.default is not MISSING:
-            parameter["default"] = field_definition.default
-
+        parameter = dataclasses.replace(
+            parameter,
+            description=description,
+            required=bool(required),
+            default=field_definition.default if field_definition.default is not MISSING else _UNSET,
+        )
         parameters.append(parameter)
 
     return parameters
@@ -124,7 +181,155 @@ def _catalog_type(annotation: Any) -> str:
     return "object"
 
 
+def _catalog_python_dict(catalog: Catalog | Mapping[str, Any]) -> dict[str, Any]:
+    if dataclasses.is_dataclass(catalog):
+        return _catalog_python_value(catalog)
+    if isinstance(catalog, Mapping):
+        return _normalize_catalog_mapping(cast(Mapping[str, Any], catalog), _CATALOG_FIELDS)
+    raise TypeError("catalog must be a gestalt.Catalog or mapping")
+
+
+def _serialize_catalog_dict(value: dict[str, Any], *, field_style: str) -> dict[str, Any]:
+    return _serialize_catalog_mapping(value, _CATALOG_FIELDS, field_style=field_style)
+
+
+def _omit_catalog_value(key: str, value: Any) -> bool:
+    if value is _UNSET:
+        return True
+    if key == "default":
+        return False
+    if value in ("", None):
+        return True
+    if key != "operations" and value == []:
+        return True
+    return key in {"read_only", "required"} and value is False
+
+
+def _catalog_python_value(value: Any) -> Any:
+    if dataclasses.is_dataclass(value):
+        return {
+            field_definition.name: _catalog_python_value(getattr(value, field_definition.name))
+            for field_definition in dataclasses.fields(value)
+        }
+    if isinstance(value, pathlib.Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {_catalog_python_value(key): _catalog_python_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_catalog_python_value(item) for item in value]
+    return value
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _CatalogFieldSpec:
+    json_name: str | None = None
+    children: dict[str, "_CatalogFieldSpec"] | None = None
+    sequence: bool = False
+
+
+def _normalize_catalog_mapping(
+    value: Mapping[str, Any],
+    fields: dict[str, _CatalogFieldSpec],
+) -> dict[str, Any]:
+    aliases = {
+        alias: name
+        for name, field_spec in fields.items()
+        for alias in (name, field_spec.json_name)
+        if alias
+    }
+    data: dict[str, Any] = {}
+    for raw_key, raw_value in value.items():
+        key = aliases.get(str(raw_key), str(raw_key))
+        field_spec = fields.get(key)
+        data[key] = _normalize_catalog_value(raw_value, field_spec)
+    return data
+
+
+def _normalize_catalog_value(value: Any, field_spec: _CatalogFieldSpec | None) -> Any:
+    if field_spec is None or field_spec.children is None:
+        return _catalog_python_value(value)
+    if field_spec.sequence:
+        items = value if isinstance(value, (list, tuple)) else []
+        return [
+            _normalize_catalog_mapping(item, field_spec.children) if isinstance(item, Mapping) else _catalog_python_value(item)
+            for item in items
+        ]
+    if isinstance(value, Mapping):
+        return _normalize_catalog_mapping(value, field_spec.children)
+    return _catalog_python_value(value)
+
+
+def _serialize_catalog_mapping(
+    value: Mapping[str, Any],
+    fields: dict[str, _CatalogFieldSpec],
+    *,
+    field_style: str,
+) -> dict[str, Any]:
+    serialized: dict[str, Any] = {}
+    for key, item in value.items():
+        if _omit_catalog_value(key, item):
+            continue
+        field_spec = fields.get(key)
+        output_key = key if field_style == "yaml" or field_spec is None or field_spec.json_name is None else field_spec.json_name
+        serialized[output_key] = _serialize_catalog_value(item, field_spec, field_style=field_style)
+    return serialized
+
+
+def _serialize_catalog_value(value: Any, field_spec: _CatalogFieldSpec | None, *, field_style: str) -> Any:
+    if field_spec is None or field_spec.children is None:
+        return _catalog_python_value(value)
+    if field_spec.sequence:
+        return [
+            _serialize_catalog_mapping(item, field_spec.children, field_style=field_style)
+            if isinstance(item, Mapping)
+            else _catalog_python_value(item)
+            for item in value
+        ]
+    if isinstance(value, Mapping):
+        return _serialize_catalog_mapping(value, field_spec.children, field_style=field_style)
+    return _catalog_python_value(value)
+
+
 class _CatalogDumper(yaml.SafeDumper):
     def increase_indent(self, flow: bool = False, indentless: bool = False) -> Any:
         del indentless
         return super().increase_indent(flow, False)
+
+
+_CATALOG_ANNOTATION_FIELDS = {
+    "read_only_hint": _CatalogFieldSpec(json_name="readOnlyHint"),
+    "idempotent_hint": _CatalogFieldSpec(json_name="idempotentHint"),
+    "destructive_hint": _CatalogFieldSpec(json_name="destructiveHint"),
+    "open_world_hint": _CatalogFieldSpec(json_name="openWorldHint"),
+}
+
+_CATALOG_PARAMETER_FIELDS = {
+    "name": _CatalogFieldSpec(),
+    "type": _CatalogFieldSpec(),
+    "description": _CatalogFieldSpec(),
+    "required": _CatalogFieldSpec(),
+    "default": _CatalogFieldSpec(),
+}
+
+_CATALOG_OPERATION_FIELDS = {
+    "id": _CatalogFieldSpec(),
+    "method": _CatalogFieldSpec(),
+    "title": _CatalogFieldSpec(),
+    "description": _CatalogFieldSpec(),
+    "input_schema": _CatalogFieldSpec(json_name="inputSchema"),
+    "output_schema": _CatalogFieldSpec(json_name="outputSchema"),
+    "annotations": _CatalogFieldSpec(children=_CATALOG_ANNOTATION_FIELDS),
+    "parameters": _CatalogFieldSpec(children=_CATALOG_PARAMETER_FIELDS, sequence=True),
+    "required_scopes": _CatalogFieldSpec(json_name="requiredScopes"),
+    "tags": _CatalogFieldSpec(),
+    "read_only": _CatalogFieldSpec(json_name="readOnly"),
+    "visible": _CatalogFieldSpec(),
+}
+
+_CATALOG_FIELDS = {
+    "name": _CatalogFieldSpec(),
+    "display_name": _CatalogFieldSpec(json_name="displayName"),
+    "description": _CatalogFieldSpec(),
+    "icon_svg": _CatalogFieldSpec(json_name="iconSvg"),
+    "operations": _CatalogFieldSpec(children=_CATALOG_OPERATION_FIELDS, sequence=True),
+}

--- a/sdk/python/gestalt/_plugin.py
+++ b/sdk/python/gestalt/_plugin.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import pathlib
 import re
@@ -8,7 +9,13 @@ from typing import Any, Final
 import yaml
 
 from ._api import Request
-from ._catalog import build_catalog, write_catalog
+from ._catalog import (
+    Catalog,
+    SessionCatalogProvider,
+    build_catalog,
+    catalog_to_dict,
+    write_catalog,
+)
 from ._operations import (
     OperationDefinition,
     OperationResult,
@@ -20,12 +27,13 @@ from ._operations import (
 DEFAULT_OPERATION_METHOD: Final[str] = "POST"
 
 
-class Plugin:
+class Plugin(SessionCatalogProvider):
     def __init__(self, name: str, *, module_name: str | None = None) -> None:
         self.name = _slug_name(name)
         self._module_name = module_name
         self._operations: dict[str, OperationDefinition] = {}
         self._configure_handler: Any = None
+        self._session_catalog_handler: tuple[Any, bool] | None = None
 
     @classmethod
     def from_manifest(
@@ -42,6 +50,10 @@ class Plugin:
 
     def configure(self, func: Any) -> Any:
         self._configure_handler = func
+        return func
+
+    def session_catalog(self, func: Any) -> Any:
+        self._session_catalog_handler = (func, _inspect_session_catalog_handler(func))
         return func
 
     def operation(
@@ -84,13 +96,7 @@ class Plugin:
         return decorator(func)
 
     def configure_provider(self, name: str, config: dict[str, Any]) -> None:
-        handler = self._configure_handler
-        if handler is None and self._module_name:
-            module = sys.modules.get(self._module_name)
-            if module is not None:
-                candidate = getattr(module, "configure", None)
-                if callable(candidate):
-                    handler = candidate
+        handler = self._resolve_configure_handler()
         if handler is None:
             return
         run_sync(handler(name, config))
@@ -102,19 +108,68 @@ class Plugin:
             request=request,
         )
 
-    def catalog_dict(self) -> dict[str, Any]:
+    def _static_catalog(self) -> Catalog:
         return build_catalog(
             plugin_name=self.name,
             operations=self._operations.values(),
         )
 
+    def catalog_dict(self) -> dict[str, Any]:
+        return catalog_to_dict(self._static_catalog())
+
     def write_catalog(self, path: str | pathlib.Path) -> None:
-        write_catalog(path, catalog=self.catalog_dict())
+        write_catalog(path, catalog=self._static_catalog())
+
+    def supports_session_catalog(self) -> bool:
+        return self._resolve_session_catalog_handler() is not None
+
+    def catalog_for_request(self, request: Request) -> Catalog | dict[str, Any] | None:
+        definition = self._resolve_session_catalog_handler()
+        if definition is None:
+            return None
+
+        handler, takes_request = definition
+        if takes_request:
+            return run_sync(handler(request))
+        return run_sync(handler())
 
     def serve(self) -> None:
         from . import _runtime
 
         _runtime.serve(self)
+
+    def _resolve_configure_handler(self) -> Any:
+        if self._configure_handler is not None:
+            return self._configure_handler
+        if not self._module_name:
+            return None
+
+        module = sys.modules.get(self._module_name)
+        if module is None:
+            return None
+
+        configure = getattr(module, "configure", None)
+        if callable(configure):
+            self._configure_handler = configure
+        return self._configure_handler
+
+    def _resolve_session_catalog_handler(self) -> tuple[Any, bool] | None:
+        if self._session_catalog_handler is not None:
+            return self._session_catalog_handler
+        if not self._module_name:
+            return None
+
+        module = sys.modules.get(self._module_name)
+        if module is None:
+            return None
+
+        session_catalog = getattr(module, "session_catalog", None)
+        if callable(session_catalog) and getattr(session_catalog, "__module__", None) == module.__name__:
+            self._session_catalog_handler = (
+                session_catalog,
+                _inspect_session_catalog_handler(session_catalog),
+            )
+        return self._session_catalog_handler
 
 
 class _ModulePluginRegistry:
@@ -137,13 +192,11 @@ class _ModulePluginRegistry:
 
         plugin = self._plugins.get(module.__name__)
         if plugin is None:
-            name = _slug_name(module.__name__.rsplit(".", 1)[-1])
-            plugin = Plugin(name, module_name=module.__name__)
+            plugin = Plugin(_module_plugin_name(module), module_name=module.__name__)
             self._plugins[module.__name__] = plugin
 
         if not isinstance(getattr(module, "plugin", None), Plugin):
             setattr(module, "plugin", plugin)
-
         return plugin
 
 
@@ -179,8 +232,42 @@ def operation(
     return decorator(func)
 
 
+def session_catalog(func: Any | None = None, /) -> Any:
+    def decorator(handler: Any) -> Any:
+        plugin = _MODULE_PLUGINS.for_function(handler)
+        return plugin.session_catalog(handler)
+
+    if func is None:
+        return decorator
+    return decorator(func)
+
+
 def _module_plugin(module: types.ModuleType) -> "Plugin":
     return _MODULE_PLUGINS.for_module(module)
+
+
+def _inspect_session_catalog_handler(func: Any) -> bool:
+    signature = inspect.signature(func)
+    parameters = list(signature.parameters.values())
+    type_hints = inspect.get_annotations(func, eval_str=True)
+
+    if len(parameters) > 1:
+        raise TypeError("session catalog handlers may declare at most one parameter")
+    if not parameters:
+        return False
+
+    annotation = type_hints.get(parameters[0].name, parameters[0].annotation)
+    if annotation not in (inspect.Signature.empty, Request):
+        raise TypeError("session catalog handler parameter must be annotated as gestalt.Request")
+    return True
+
+
+def _module_plugin_name(module: types.ModuleType) -> str:
+    file_path = getattr(module, "__file__", None)
+    if file_path:
+        manifest_path = pathlib.Path(file_path).resolve().parent / "plugin.yaml"
+        return _derive_name_from_manifest(manifest_path)
+    return _slug_name(module.__name__.rsplit(".", 1)[-1])
 
 
 def _derive_name_from_manifest(path: pathlib.Path) -> str:

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -14,6 +14,7 @@ from google.protobuf import json_format
 
 from ._api import Request
 from ._bootstrap import parse_plugin_target, read_bundled_plugin_config
+from ._catalog import catalog_to_json
 from ._plugin import Plugin, _module_plugin
 from ._serialization import json_body
 from .gen.v1 import plugin_pb2 as _plugin_pb2
@@ -40,63 +41,24 @@ class RuntimeArgs:
     plugin_name: str | None = None
 
 
-class _ProviderServicer(plugin_pb2_grpc.ProviderPluginServicer):
-    def __init__(self, plugin: Plugin) -> None:
-        self._plugin = plugin
-
-    def GetMetadata(self, request: Any, context: Any) -> Any:
-        del request, context
-        return plugin_pb2.ProviderMetadata(
-            min_protocol_version=CURRENT_PROTOCOL_VERSION,
-            max_protocol_version=CURRENT_PROTOCOL_VERSION,
-        )
-
-    def StartProvider(self, request: Any, context: Any) -> Any:
-        del context
-        self._plugin.configure_provider(
-            request.name,
-            _message_to_dict(
-                field_name="config",
-                message=request.config,
-                request=request,
-            ),
-        )
-        return plugin_pb2.StartProviderResponse(
-            protocol_version=CURRENT_PROTOCOL_VERSION
-        )
-
-    def Execute(self, request: Any, context: Any) -> Any:
-        del context
-        try:
-            result = self._plugin.execute(
-                request.operation,
-                _message_to_dict(
-                    field_name="params",
-                    message=request.params,
-                    request=request,
-                ),
-                Request(
-                    token=request.token,
-                    connection_params=dict(request.connection_params),
-                ),
-            )
-        except Exception as error:
-            traceback.print_exception(error)
-            status = HTTPStatus.INTERNAL_SERVER_ERROR
-            body = json_body({"error": str(error)})
-            return plugin_pb2.OperationResult(status=status, body=body)
-        return plugin_pb2.OperationResult(status=result.status, body=result.body)
+@dataclass(frozen=True)
+class _RuntimeImports:
+    grpc: Any
+    json_format: Any
+    plugin_pb2: Any
+    plugin_pb2_grpc: Any
 
 
 def serve(plugin: Plugin) -> None:
+    runtime = _runtime_imports()
     socket_path = _socket_path_from_env()
     _remove_stale_socket(socket_path)
 
-    server = grpc.server(
+    server = runtime.grpc.server(
         futures.ThreadPoolExecutor(max_workers=GRPC_SERVER_MAX_WORKERS)
     )
-    plugin_pb2_grpc.add_ProviderPluginServicer_to_server(
-        _ProviderServicer(plugin),
+    runtime.plugin_pb2_grpc.add_ProviderPluginServicer_to_server(
+        _provider_servicer(plugin=plugin, runtime=runtime),
         server,
     )
     server.add_insecure_port(f"unix:{socket_path}")
@@ -181,9 +143,84 @@ def _register_shutdown_handlers(server: Any) -> None:
     signal.signal(signal.SIGINT, _shutdown)
 
 
+def _provider_servicer(*, plugin: Plugin, runtime: _RuntimeImports) -> Any:
+    class ProviderServicer(runtime.plugin_pb2_grpc.ProviderPluginServicer):
+        def GetMetadata(self, request: Any, context: Any) -> Any:
+            del request, context
+            return runtime.plugin_pb2.ProviderMetadata(
+                supports_session_catalog=plugin.supports_session_catalog(),
+                min_protocol_version=CURRENT_PROTOCOL_VERSION,
+                max_protocol_version=CURRENT_PROTOCOL_VERSION,
+            )
+
+        def StartProvider(self, request: Any, context: Any) -> Any:
+            del context
+            plugin.configure_provider(
+                request.name,
+                _message_to_dict(
+                    field_name="config",
+                    json_format=runtime.json_format,
+                    message=request.config,
+                    request=request,
+                ),
+            )
+            return runtime.plugin_pb2.StartProviderResponse(
+                protocol_version=CURRENT_PROTOCOL_VERSION
+            )
+
+        def Execute(self, request: Any, context: Any) -> Any:
+            del context
+            try:
+                result = plugin.execute(
+                    request.operation,
+                    _message_to_dict(
+                        field_name="params",
+                        json_format=runtime.json_format,
+                        message=request.params,
+                        request=request,
+                    ),
+                    Request(
+                        token=request.token,
+                        connection_params=dict(request.connection_params),
+                    ),
+                )
+            except Exception as error:
+                traceback.print_exception(error)
+                status = HTTPStatus.INTERNAL_SERVER_ERROR
+                body = json_body({"error": str(error)})
+                return runtime.plugin_pb2.OperationResult(status=status, body=body)
+            return runtime.plugin_pb2.OperationResult(status=result.status, body=result.body)
+
+        def GetSessionCatalog(self, request: Any, context: Any) -> Any:
+            if not plugin.supports_session_catalog():
+                return context.abort(runtime.grpc.StatusCode.UNIMPLEMENTED, "provider does not support session catalogs")
+
+            try:
+                catalog = plugin.catalog_for_request(_plugin_request(request))
+            except Exception as error:
+                return context.abort(runtime.grpc.StatusCode.UNKNOWN, f"session catalog: {error}")
+
+            try:
+                raw_catalog = catalog_to_json(catalog)
+            except Exception as error:
+                return context.abort(runtime.grpc.StatusCode.INTERNAL, f"encode session catalog: {error}")
+
+            return runtime.plugin_pb2.GetSessionCatalogResponse(catalog_json=raw_catalog)
+
+    return ProviderServicer()
+
+
+def _plugin_request(request: Any) -> Request:
+    return Request(
+        token=getattr(request, "token", ""),
+        connection_params=dict(getattr(request, "connection_params", {})),
+    )
+
+
 def _message_to_dict(
     *,
     field_name: str,
+    json_format: Any,
     message: Any,
     request: Any,
 ) -> dict[str, Any]:
@@ -193,6 +230,15 @@ def _message_to_dict(
     return json_format.MessageToDict(
         message,
         preserving_proto_field_name=True,
+    )
+
+
+def _runtime_imports() -> _RuntimeImports:
+    return _RuntimeImports(
+        grpc=grpc,
+        json_format=json_format,
+        plugin_pb2=plugin_pb2,
+        plugin_pb2_grpc=plugin_pb2_grpc,
     )
 
 

--- a/sdk/python/tests/test_build.py
+++ b/sdk/python/tests/test_build.py
@@ -1,78 +1,106 @@
+import dataclasses
 import json
 import pathlib
 import tempfile
 import unittest
-from typing import Any
 from unittest import mock
 
 from gestalt import _build
 
 
+@dataclasses.dataclass(slots=True)
+class CapturedBuildRun:
+    command: list[str]
+    cwd: pathlib.Path
+    check: bool
+    binary_name: str
+    target_arch: str | None
+    destination: str
+    bundle_config: dict[str, str]
+
+
 class BuildTests(unittest.TestCase):
     """Build entrypoint tests."""
 
-    def test_build_writes_config_and_invokes_pyinstaller(self) -> None:
-        """Build should package runtime metadata alongside the frozen entrypoint."""
+    def test_build_plugin_binary_writes_bundle_config_and_uses_target_platform_settings(self) -> None:
+        """Build mode should package runtime metadata alongside the frozen entrypoint."""
         cases = [
-            ("linux", "provider-bin", "provider-bin"),
-            ("linux", "provider.exe", "provider.exe"),
-            ("win32", "provider.exe", "provider"),
+            ("linux", "linux", "amd64", "provider-bin", "provider-bin", None),
+            ("linux", "windows", "amd64", "provider.exe", "provider", None),
+            ("darwin", "darwin", "amd64", "provider-bin", "provider-bin", "x86_64"),
         ]
-        for platform, output_name, expected_binary_name in cases:
-            with self.subTest(platform=platform, output_name=output_name):
+        for platform, target_goos, target_goarch, output_name, expected_binary_name, expected_target_arch in cases:
+            with self.subTest(platform=platform, target_goos=target_goos, target_goarch=target_goarch, output_name=output_name):
                 with tempfile.TemporaryDirectory() as tmpdir:
                     root = pathlib.Path(tmpdir) / "plugin"
                     output = root / "dist" / output_name
                     root.mkdir()
+                    captured: CapturedBuildRun | None = None
 
-                    captured_config: dict[str, Any] = {}
+                    def fake_run(command: list[str], cwd: pathlib.Path, check: bool) -> None:
+                        nonlocal captured
 
-                    def capture_run(command: list[str], **kwargs: Any) -> None:
                         add_data = command[command.index("--add-data") + 1]
-                        source = add_data.split(_build.os.pathsep, 1)[0]
-                        captured_config.update(
-                            json.loads(pathlib.Path(source).read_text(encoding="utf-8"))
+                        separator = _build.os.pathsep
+                        source, destination = add_data.split(separator, 1)
+                        captured = CapturedBuildRun(
+                            command=command,
+                            cwd=cwd,
+                            check=check,
+                            binary_name=command[command.index("--name") + 1],
+                            target_arch=command[command.index("--target-arch") + 1] if "--target-arch" in command else None,
+                            destination=destination,
+                            bundle_config=json.loads(pathlib.Path(source).read_text(encoding="utf-8")),
                         )
 
                     with mock.patch.object(_build.sys, "platform", platform), mock.patch.object(
                         _build.subprocess,
                         "run",
-                        side_effect=capture_run,
-                    ) as mock_run:
+                        side_effect=fake_run,
+                    ):
                         _build.build_plugin_binary(
                             _build.BuildArgs(
                                 root=root,
                                 target="provider",
                                 output_path=output,
                                 plugin_name="released-plugin",
+                                goos=target_goos,
+                                goarch=target_goarch,
                             )
                         )
 
-                    mock_run.assert_called_once()
-                    command = mock_run.call_args[0][0]
-                    call_kwargs = mock_run.call_args[1]
-
-                    self.assertEqual(call_kwargs["cwd"], root.resolve())
-                    self.assertTrue(call_kwargs["check"])
-                    self.assertEqual(command[command.index("--name") + 1], expected_binary_name)
-                    self.assertEqual(
-                        captured_config,
-                        {"target": "provider", "plugin_name": "released-plugin"},
-                    )
-                    self.assertEqual(
-                        command[-1],
-                        str(pathlib.Path(_build.__file__).with_name("_pyinstaller.py")),
-                    )
+                self.assertIsNotNone(captured)
+                assert captured is not None
+                self.assertIn("--add-data", captured.command)
+                self.assertEqual(captured.cwd, root.resolve())
+                self.assertTrue(captured.check)
+                self.assertEqual(captured.binary_name, expected_binary_name)
+                self.assertEqual(captured.target_arch, expected_target_arch)
+                self.assertEqual(captured.destination, ".")
+                self.assertEqual(
+                    captured.bundle_config,
+                    {
+                        "target": "provider",
+                        "plugin_name": "released-plugin",
+                    },
+                )
+                self.assertIn(
+                    str(pathlib.Path(_build.__file__).with_name("_pyinstaller.py")),
+                    captured.command,
+                )
 
     def test_parse_build_args_rejects_wrong_count(self) -> None:
         """Build arg parser should reject incorrect argument counts."""
         self.assertIsNone(_build._parse_build_args([]))
         self.assertIsNone(_build._parse_build_args(["one"]))
         self.assertIsNone(_build._parse_build_args(["one", "two", "three"]))
+        self.assertIsNone(_build._parse_build_args(["one", "two", "three", "four", "five"]))
 
-    def test_parse_build_args_accepts_four_args(self) -> None:
-        """Build arg parser should accept exactly four arguments."""
-        result = _build._parse_build_args(["/root", "mod:attr", "/out/bin", "my-plugin"])
+    def test_parse_build_args_accepts_six_args(self) -> None:
+        """Build arg parser should accept the release build argument list."""
+        result = _build._parse_build_args(
+            ["/root", "mod:attr", "/out/bin", "my-plugin", "linux", "amd64"]
+        )
 
         self.assertIsNotNone(result)
         assert result is not None
@@ -80,6 +108,8 @@ class BuildTests(unittest.TestCase):
         self.assertEqual(result.target, "mod:attr")
         self.assertEqual(result.output_path, pathlib.Path("/out/bin"))
         self.assertEqual(result.plugin_name, "my-plugin")
+        self.assertEqual(result.goos, "linux")
+        self.assertEqual(result.goarch, "amd64")
 
 
 if __name__ == "__main__":

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -4,7 +4,14 @@ import tempfile
 import unittest
 from unittest import mock
 
-from gestalt import Plugin, Request, _bootstrap, _runtime
+from gestalt import (
+    Catalog,
+    CatalogOperation,
+    Plugin,
+    Request,
+    _bootstrap,
+    _runtime,
+)
 
 
 class ParseRuntimeArgsTests(unittest.TestCase):
@@ -131,6 +138,58 @@ class MainEntrypointTests(unittest.TestCase):
         """Invalid args should return exit code 2."""
         result = _runtime.main(["/only-one-arg"])
         self.assertEqual(result, 2)
+
+    def test_provider_servicer_reports_and_serves_session_catalogs(self) -> None:
+        """Runtime gRPC servicer should advertise and encode session catalogs."""
+        plugin = Plugin("source-name")
+
+        @plugin.session_catalog
+        def dynamic_catalog(request: Request) -> Catalog:
+            return Catalog(
+                name="session-source",
+                display_name=request.connection_param("tenant"),
+                operations=[CatalogOperation(id="private_search", method="POST")],
+            )
+
+        runtime = _runtime._runtime_imports()
+        servicer = _runtime._provider_servicer(plugin=plugin, runtime=runtime)
+        metadata = servicer.GetMetadata(mock.Mock(), mock.Mock())
+        response = servicer.GetSessionCatalog(
+            runtime.plugin_pb2.GetSessionCatalogRequest(
+                token="secret-token",
+                connection_params={"tenant": "acme"},
+            ),
+            mock.Mock(),
+        )
+
+        self.assertTrue(metadata.supports_session_catalog)
+        self.assertEqual(
+            json.loads(response.catalog_json),
+            {
+                "name": "session-source",
+                "displayName": "acme",
+                "operations": [
+                    {
+                        "id": "private_search",
+                        "method": "POST",
+                    }
+                ],
+            },
+        )
+
+    def test_provider_servicer_rejects_missing_session_catalog_support(self) -> None:
+        """Runtime gRPC servicer should surface UNIMPLEMENTED when no session catalog handler exists."""
+        plugin = Plugin("source-name")
+        runtime = _runtime._runtime_imports()
+        servicer = _runtime._provider_servicer(plugin=plugin, runtime=runtime)
+        context = mock.Mock()
+
+        servicer.GetSessionCatalog(runtime.plugin_pb2.GetSessionCatalogRequest(), context)
+
+        context.abort.assert_called_once_with(
+            runtime.grpc.StatusCode.UNIMPLEMENTED,
+            "provider does not support session catalogs",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a public Python session catalog API with shared catalog model types and runtime `GetSessionCatalog` wiring
- make Python plugin releases honor the requested `--platform` list via target-aware build args and per-platform interpreter selection
- update docs and tests to reflect the new Python SDK surface and release behavior

## Testing
- `cd sdk/python && uv run ruff check gestalt tests`
- `cd sdk/python && uv run python -m unittest tests.test_build tests.test_runtime`
- `cd sdk/python && uv run ty check --exclude 'gestalt/gen/**' gestalt tests`
- `cd gestaltd && go test ./internal/pluginpkg ./cmd/gestaltd`
- `cd sdk/go && go test ./...`