### PR TITLE
Add Python SDK helper for explicit HTTP responses

### DIFF
--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -1,12 +1,34 @@
-from ._api import OK, Model, Request, Response, field
+from ._api import (
+    OK,
+    BadGateway,
+    BadRequest,
+    Conflict,
+    Forbidden,
+    InternalServerError,
+    Model,
+    NotFound,
+    Request,
+    Response,
+    ServiceUnavailable,
+    Unauthorized,
+    field,
+)
 from ._plugin import Plugin, operation
 
 __all__ = [
+    "BadGateway",
+    "BadRequest",
+    "Conflict",
+    "Forbidden",
+    "InternalServerError",
     "Model",
+    "NotFound",
     "OK",
     "Plugin",
     "Request",
     "Response",
+    "ServiceUnavailable",
+    "Unauthorized",
     "field",
     "operation",
 ]

--- a/sdk/python/gestalt/_api.py
+++ b/sdk/python/gestalt/_api.py
@@ -26,8 +26,44 @@ class Response(Generic[T]):
     body: T
 
 
+def _respond(status: int, body: T) -> Response[T]:
+    return Response(status=status, body=body)
+
+
 def OK(body: T) -> Response[T]:
-    return Response(status=HTTPStatus.OK, body=body)
+    return _respond(HTTPStatus.OK, body)
+
+
+def BadRequest(body: T) -> Response[T]:
+    return _respond(HTTPStatus.BAD_REQUEST, body)
+
+
+def Unauthorized(body: T) -> Response[T]:
+    return _respond(HTTPStatus.UNAUTHORIZED, body)
+
+
+def Forbidden(body: T) -> Response[T]:
+    return _respond(HTTPStatus.FORBIDDEN, body)
+
+
+def NotFound(body: T) -> Response[T]:
+    return _respond(HTTPStatus.NOT_FOUND, body)
+
+
+def Conflict(body: T) -> Response[T]:
+    return _respond(HTTPStatus.CONFLICT, body)
+
+
+def InternalServerError(body: T) -> Response[T]:
+    return _respond(HTTPStatus.INTERNAL_SERVER_ERROR, body)
+
+
+def BadGateway(body: T) -> Response[T]:
+    return _respond(HTTPStatus.BAD_GATEWAY, body)
+
+
+def ServiceUnavailable(body: T) -> Response[T]:
+    return _respond(HTTPStatus.SERVICE_UNAVAILABLE, body)
 
 
 def field(

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -1,9 +1,12 @@
+import contextlib
+import io
 import json
 import pathlib
 import tempfile
 import unittest
 from unittest import mock
 
+import gestalt
 from gestalt import Plugin, Request, _bootstrap, _runtime
 
 
@@ -131,6 +134,49 @@ class MainEntrypointTests(unittest.TestCase):
         """Invalid args should return exit code 2."""
         result = _runtime.main(["/only-one-arg"])
         self.assertEqual(result, 2)
+
+
+class PluginExecutionTests(unittest.TestCase):
+    """Tests for Plugin.execute() response shaping."""
+
+    def test_execute_returns_http_results_for_operation_outcomes(self) -> None:
+        plugin = Plugin("source-name")
+
+        @plugin.operation
+        def ok() -> dict[str, str]:
+            return {"status": "ok"}
+
+        @plugin.operation
+        def broken() -> object:
+            return object()
+
+        @plugin.operation
+        def bad_request() -> gestalt.Response[dict[str, str]]:
+            return gestalt.BadRequest({"error": "bad query"})
+
+        @plugin.operation
+        def internal_error() -> gestalt.Response[dict[str, str]]:
+            return gestalt.InternalServerError({"error": "backend unavailable"})
+
+        cases = [
+            ("ok", 200, {"status": "ok"}, None),
+            ("missing", 404, None, "unknown operation"),
+            ("broken", 500, None, "not JSON serializable"),
+            ("bad_request", 400, {"error": "bad query"}, None),
+            ("internal_error", 500, {"error": "backend unavailable"}, None),
+        ]
+        for operation_name, expected_status, expected_body, expected_error in cases:
+            with self.subTest(operation_name=operation_name):
+                stderr_buffer = io.StringIO()
+                with contextlib.redirect_stderr(stderr_buffer):
+                    status, body = plugin.execute(operation_name, {}, Request())
+
+                self.assertEqual(status, expected_status)
+                payload = json.loads(body)
+                if expected_body is not None:
+                    self.assertEqual(payload, expected_body)
+                if expected_error is not None:
+                    self.assertIn(expected_error, payload["error"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `gestalt.respond(status, body)` alongside the existing `gestalt.OK(body)` helper
- re-export the helper from the public Python SDK surface
- cover non-200 helper behavior in the runtime tests

## Why
Python plugin handlers can already return `gestalt.Response(...)` for explicit non-200 responses, but the public API only had the `OK(...)` helper. This adds a symmetric helper for non-200 cases without introducing ambiguous tuple-return behavior.