### PR TITLE
Add Linux libc-aware plugin artifacts

### DIFF
--- a/docs/content/plugins/releasing.mdx
+++ b/docs/content/plugins/releasing.mdx
@@ -71,6 +71,7 @@ provider:
 artifacts:
   - os: linux
     arch: amd64
+    libc: glibc
     path: artifacts/linux/amd64/provider
     sha256: "..."
 ```
@@ -104,6 +105,12 @@ default. Pass `--platform` with a comma-separated list such as
 `--platform linux/amd64,darwin/arm64` to build explicit targets. Pass
 `--platform all` in CI release jobs to build the full supported platform matrix
 for both Go and Python source plugins.
+
+Pass `--platform` with a comma-separated list such as
+`--platform linux/amd64/glibc,linux/amd64/musl,darwin/arm64` to build explicit targets.
+
+Pass `--platform all` in CI release jobs to build the full supported platform
+matrix for both Go and Python source plugins.
 
 For non-host Python targets, point Gestalt at a matching interpreter with
 `GESTALT_PYTHON_<GOOS>_<GOARCH>` or a target-specific virtualenv such as

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -17,7 +17,7 @@
 
 | Command | Purpose |
 | --- | --- |
-| `gestaltd plugin release --version VERSION` | Build and package a plugin release. Go and Python source plugins default to the host platform; pass `--platform ...` or `--platform all` for multi-platform builds. |
+| `gestaltd plugin release --version VERSION` | Build and package a plugin release. Go and Python source plugins default to the host platform; pass `--platform ...` with `os/arch[/libc]` targets or `--platform all` for multi-platform builds. |
 
 ## Examples
 
@@ -28,6 +28,7 @@ gestaltd serve --locked --config ./config.yaml
 gestaltd validate --config ./config.yaml
 gestaltd plugin release --version 0.1.0
 gestaltd plugin release --version 0.1.0 --platform all
+gestaltd plugin release --version 0.1.0 --platform linux/amd64/glibc,linux/amd64/musl
 ```
 
 See [Configuration](/configuration) for the relationship between `init`, `serve --locked`, and `validate`.

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -19,7 +19,7 @@ A manifest defines exactly one of `provider` or `webui`.
 | `icon_file` | Relative path to an SVG icon bundled with the package. |
 | `provider` | Provider metadata and optional declarative surfaces. |
 | `webui` | UI metadata for UI-only packages. |
-| `artifacts` | Packaged executable artifacts keyed by platform. Source manifests used for local development or `plugin release` may omit them for pure executable providers. |
+| `artifacts` | Packaged executable artifacts keyed by platform. Linux artifacts may also set `libc` to distinguish `glibc` and `musl` builds. Source manifests used for local development or `plugin release` may omit them for pure executable providers. |
 
 ## Basic manifest
 
@@ -163,6 +163,7 @@ This example shows a provider package with a config schema, an executable entryp
     artifacts:
       - os: linux
         arch: amd64
+        libc: glibc
         path: artifacts/linux/amd64/provider
         sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     ```
@@ -224,13 +225,14 @@ This example shows a provider package with a config schema, an executable entryp
           "tickets.get": { "alias": "get_ticket" }
         }
       },
-      "artifacts": [
-        {
-          "os": "linux",
-          "arch": "amd64",
-          "path": "artifacts/linux/amd64/provider",
-          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-        }
+        "artifacts": [
+          {
+            "os": "linux",
+            "arch": "amd64",
+            "libc": "glibc",
+            "path": "artifacts/linux/amd64/provider",
+            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
       ]
     }
     ```
@@ -364,5 +366,5 @@ automatically from the provider's typed router before packaging. For Python
 source plugins, release loads the module declared in `[tool.gestalt].plugin`,
 materializes the executable catalog automatically. Go and Python source plugins
 both build the host-platform artifact by default. Pass `--platform` for an
-explicit target list, or `--platform all` in CI to build the full supported
-release matrix.
+explicit `os/arch[/libc]` target list, or `--platform all` in CI to build the
+full supported release matrix.

--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -45,6 +45,7 @@ const windowsExecutableSuffix = ".exe"
 type releasePlatform struct {
 	GOOS   string
 	GOARCH string
+	LibC   string
 }
 
 func runPluginRelease(args []string) error {
@@ -52,7 +53,7 @@ func runPluginRelease(args []string) error {
 	fs.Usage = func() { printPluginReleaseUsage(fs.Output()) }
 	version := fs.String("version", "", "semantic version string (required)")
 	outputDir := fs.String("output", defaultReleaseOutputDir, "output directory")
-	platforms := fs.String("platform", "", "comma-separated platforms (os/arch) or 'all'")
+	platforms := fs.String("platform", "", "comma-separated platforms (os/arch[/libc]) or 'all'")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -107,7 +108,7 @@ func runPluginRelease(args []string) error {
 		for _, platform := range buildPlatforms {
 			archivePath, err := buildPlatformArchive(srcManifest, pluginName, *version, platform, *outputDir, manifestFile, manifestFormat)
 			if err != nil {
-				return fmt.Errorf("build %s/%s: %w", platform.GOOS, platform.GOARCH, err)
+				return fmt.Errorf("build %s: %w", pluginpkg.PlatformString(platform.GOOS, platform.GOARCH, platform.LibC), err)
 			}
 			archivePaths = append(archivePaths, archivePath)
 		}
@@ -182,7 +183,7 @@ func expandReleasePlatformValue(value string) (string, error) {
 	trimmed := strings.TrimSpace(value)
 	switch {
 	case trimmed == "":
-		return "", fmt.Errorf("--platform requires a comma-separated os/arch list or %q", allPlatformsValue)
+		return "", fmt.Errorf("--platform requires a comma-separated os/arch[/libc] list or %q", allPlatformsValue)
 	case strings.EqualFold(trimmed, allPlatformsValue):
 		return defaultPlatforms, nil
 	default:
@@ -191,11 +192,26 @@ func expandReleasePlatformValue(value string) (string, error) {
 }
 
 func buildPlatformArchive(srcManifest *pluginmanifestv1.Manifest, pluginName, version string, platform releasePlatform, outputDir, manifestFile, manifestFormat string) (string, error) {
-	plat := platform
-	archiveName := fmt.Sprintf("gestalt-plugin-%s_v%s_%s_%s.tar.gz", pluginName, version, plat.GOOS, plat.GOARCH)
-	return createReleaseArchive(outputDir, archiveName, manifestFile, manifestFormat, func(stagingDir string) (*pluginmanifestv1.Manifest, error) {
-		return prepareBuiltPackageDir(stagingDir, ".", srcManifest, version, pluginName, platform)
-	})
+	stagingDir, err := os.MkdirTemp("", "gestalt-release-*")
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = os.RemoveAll(stagingDir) }()
+
+	manifest, plat, err := prepareBuiltPackageDir(stagingDir, ".", srcManifest, version, pluginName, platform)
+	if err != nil {
+		return "", err
+	}
+	archivePath := filepath.Join(outputDir, platformArchiveName(pluginName, version, plat))
+	if err := writeReleaseManifestFile(stagingDir, manifestFile, manifestFormat, manifest); err != nil {
+		return "", err
+	}
+	if err := pluginpkg.CreatePackageFromDir(stagingDir, archivePath); err != nil {
+		return "", err
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "created %s\n", archivePath)
+	return archivePath, nil
 }
 
 func createReleaseArchive(outputDir, archiveName, manifestFile, manifestFormat string, prepare func(stagingDir string) (*pluginmanifestv1.Manifest, error)) (string, error) {
@@ -250,13 +266,22 @@ func parseReleasePlatforms(value string) ([]releasePlatform, error) {
 	platforms := make([]releasePlatform, 0, len(parts))
 	for _, part := range parts {
 		plat := strings.TrimSpace(part)
-		pieces := strings.SplitN(plat, "/", 2)
-		if len(pieces) != 2 || pieces[0] == "" || pieces[1] == "" {
-			return nil, fmt.Errorf("invalid platform %q, expected os/arch", plat)
+		pieces := strings.Split(plat, "/")
+		if len(pieces) < 2 || len(pieces) > 3 || pieces[0] == "" || pieces[1] == "" {
+			return nil, fmt.Errorf("invalid platform %q, expected os/arch[/libc]", plat)
+		}
+		libc := ""
+		if len(pieces) == 3 {
+			libc = pieces[2]
+		}
+		normalizedLibC, err := pluginpkg.NormalizeArtifactLibC(pieces[0], libc)
+		if err != nil {
+			return nil, err
 		}
 		platforms = append(platforms, releasePlatform{
 			GOOS:   pieces[0],
 			GOARCH: pieces[1],
+			LibC:   normalizedLibC,
 		})
 	}
 	return platforms, nil
@@ -276,22 +301,35 @@ func buildSourceArchive(srcManifest *pluginmanifestv1.Manifest, pluginName, vers
 	})
 }
 
-func prepareBuiltPackageDir(stagingDir, sourceDir string, srcManifest *pluginmanifestv1.Manifest, version, pluginName string, platform releasePlatform) (*pluginmanifestv1.Manifest, error) {
+func prepareBuiltPackageDir(stagingDir, sourceDir string, srcManifest *pluginmanifestv1.Manifest, version, pluginName string, platform releasePlatform) (*pluginmanifestv1.Manifest, releasePlatform, error) {
 	plat := platform
 	binaryName := releaseBinaryName(pluginName, plat.GOOS)
 	binaryPath := filepath.Join(stagingDir, binaryName)
-	if err := pluginpkg.BuildSourceProviderReleaseBinary(sourceDir, binaryPath, pluginName, plat.GOOS, plat.GOARCH); err != nil {
-		return nil, err
+	builtLibC, err := pluginpkg.BuildSourceProviderReleaseBinary(sourceDir, binaryPath, pluginName, plat.GOOS, plat.GOARCH)
+	if err != nil {
+		return nil, releasePlatform{}, err
+	}
+	switch {
+	case plat.LibC == "":
+		plat.LibC = builtLibC
+	case builtLibC == "":
+		return nil, releasePlatform{}, fmt.Errorf("requested linux libc %q but the built artifact does not report a libc", plat.LibC)
+	case builtLibC != plat.LibC:
+		return nil, releasePlatform{}, fmt.Errorf("requested linux libc %q but built artifact targets %q", plat.LibC, builtLibC)
 	}
 
 	digest, err := pluginpkg.FileSHA256(binaryPath)
 	if err != nil {
-		return nil, fmt.Errorf("hash binary: %w", err)
+		return nil, releasePlatform{}, fmt.Errorf("hash binary: %w", err)
 	}
 	if err := copyReleasePackageFiles(srcManifest, sourceDir, stagingDir, false); err != nil {
-		return nil, err
+		return nil, releasePlatform{}, err
 	}
-	return buildReleaseManifest(srcManifest, version, binaryName, plat, digest)
+	manifest, err := buildReleaseManifest(srcManifest, version, binaryName, plat, digest)
+	if err != nil {
+		return nil, releasePlatform{}, err
+	}
+	return manifest, plat, nil
 }
 
 func buildSourceReleaseManifest(srcManifest *pluginmanifestv1.Manifest, version, sourceDir string) (*pluginmanifestv1.Manifest, error) {
@@ -322,7 +360,7 @@ func buildReleaseManifest(srcManifest *pluginmanifestv1.Manifest, version, binar
 	}
 	manifest.Version = version
 	manifest.Artifacts = []pluginmanifestv1.Artifact{
-		{OS: plat.GOOS, Arch: plat.GOARCH, Path: binaryName, SHA256: digest},
+		{OS: plat.GOOS, Arch: plat.GOARCH, LibC: plat.LibC, Path: binaryName, SHA256: digest},
 	}
 
 	for _, kind := range manifest.Kinds {
@@ -335,6 +373,10 @@ func buildReleaseManifest(srcManifest *pluginmanifestv1.Manifest, version, binar
 	}
 
 	return manifest, nil
+}
+
+func platformArchiveName(pluginName, version string, plat releasePlatform) string {
+	return fmt.Sprintf("gestalt-plugin-%s_v%s_%s.tar.gz", pluginName, version, pluginpkg.PlatformArchiveSuffix(plat.GOOS, plat.GOARCH, plat.LibC))
 }
 
 func releaseBinaryName(pluginName, goos string) string {
@@ -577,12 +619,12 @@ func printPluginReleaseUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd plugin release --version VERSION [--output DIR] [--platform PLATFORMS]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Build a plugin release archive for the host platform by default.")
-	writeUsageLine(w, "Pass --platform with a comma-separated os/arch list or --platform all")
+	writeUsageLine(w, "Pass --platform with a comma-separated os/arch[/libc] list or --platform all")
 	writeUsageLine(w, "to build multiple per-platform tar.gz archives plus a checksums file.")
 	writeUsageLine(w, "Run from the plugin source directory.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --version    Semantic version string (required)")
 	writeUsageLine(w, "  --output     Output directory (default: dist/)")
-	writeUsageLine(w, "  --platform   Comma-separated platforms (os/arch) or all (default: host platform only)")
+	writeUsageLine(w, "  --platform   Comma-separated platforms (os/arch[/libc]) or all (default: host platform only)")
 }

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -285,7 +285,7 @@ func TestRun_PluginReleaseBuildsPythonSourcePluginForCurrentPlatform(t *testing.
 		"--output", outputDir,
 	)
 
-	archiveName := "gestalt-plugin-python-release_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	archiveName := expectedPythonArchiveName(testVersion, runtime.GOOS, runtime.GOARCH)
 	extractDir := extractReleasedArchive(t, outputDir, archiveName)
 	manifest := readReleasedManifest(t, outputDir, archiveName)
 
@@ -395,14 +395,12 @@ func TestRun_PluginReleaseDefaultsPythonSourcePluginToHostPlatform(t *testing.T)
 		"--output", outputDir,
 	)
 
-	archiveName := "gestalt-plugin-python-release_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	archiveName := expectedPythonArchiveName(testVersion, runtime.GOOS, runtime.GOARCH)
 	manifest := readReleasedManifest(t, outputDir, archiveName)
 	if len(manifest.Artifacts) != 1 {
 		t.Fatalf("artifacts = %+v, want exactly one host-platform artifact", manifest.Artifacts)
 	}
-	if manifest.Artifacts[0].OS != runtime.GOOS || manifest.Artifacts[0].Arch != runtime.GOARCH {
-		t.Fatalf("artifact platform = %s/%s, want %s/%s", manifest.Artifacts[0].OS, manifest.Artifacts[0].Arch, runtime.GOOS, runtime.GOARCH)
-	}
+	assertExpectedPythonArtifactPlatform(t, manifest.Artifacts[0], runtime.GOOS, runtime.GOARCH)
 }
 
 func TestRun_PluginReleaseBuildsPythonSourcePluginForAllPlatforms(t *testing.T) {
@@ -426,14 +424,12 @@ func TestRun_PluginReleaseBuildsPythonSourcePluginForAllPlatforms(t *testing.T) 
 	)
 
 	for _, platform := range defaultReleasePlatformsForTest(t) {
-		archiveName := "gestalt-plugin-python-release_v" + testVersion + "_" + platform.GOOS + "_" + platform.GOARCH + ".tar.gz"
+		archiveName := expectedPythonArchiveName(testVersion, platform.GOOS, platform.GOARCH)
 		manifest := readReleasedManifest(t, outputDir, archiveName)
 		if len(manifest.Artifacts) != 1 {
 			t.Fatalf("artifacts for %s/%s = %+v, want one artifact", platform.GOOS, platform.GOARCH, manifest.Artifacts)
 		}
-		if manifest.Artifacts[0].OS != platform.GOOS || manifest.Artifacts[0].Arch != platform.GOARCH {
-			t.Fatalf("artifact platform = %s/%s, want %s/%s", manifest.Artifacts[0].OS, manifest.Artifacts[0].Arch, platform.GOOS, platform.GOARCH)
-		}
+		assertExpectedPythonArtifactPlatform(t, manifest.Artifacts[0], platform.GOOS, platform.GOARCH)
 	}
 }
 
@@ -458,8 +454,8 @@ func TestRun_PluginReleaseBuildsPythonSourcePluginForRequestedPlatforms(t *testi
 		"--output", outputDir,
 	)
 
-	currentArchive := "gestalt-plugin-python-release_v0.0.13-test_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
-	otherArchive := "gestalt-plugin-python-release_v0.0.13-test_" + otherGOOS + "_" + otherGOARCH + ".tar.gz"
+	currentArchive := expectedPythonArchiveName("0.0.13-test", runtime.GOOS, runtime.GOARCH)
+	otherArchive := expectedPythonArchiveName("0.0.13-test", otherGOOS, otherGOARCH)
 	for _, archiveName := range []string{currentArchive, otherArchive} {
 		extractDir := extractReleasedArchive(t, outputDir, archiveName)
 		manifest := readReleasedManifest(t, outputDir, archiveName)
@@ -1228,6 +1224,31 @@ func defaultReleasePlatformsForTest(t *testing.T) []releasePlatform {
 		t.Fatalf("parseReleasePlatforms(defaultPlatforms): %v", err)
 	}
 	return platforms
+}
+
+func expectedPythonReleasePlatform(goos, goarch string) releasePlatform {
+	plat := releasePlatform{GOOS: goos, GOARCH: goarch}
+	if runtime.GOOS == "linux" && goos == "linux" {
+		plat.LibC = pluginpkg.CurrentRuntimeLibC()
+	}
+	return plat
+}
+
+func expectedPythonArchiveName(version, goos, goarch string) string {
+	return platformArchiveName("python-release", version, expectedPythonReleasePlatform(goos, goarch))
+}
+
+func assertExpectedPythonArtifactPlatform(t *testing.T, artifact pluginmanifestv1.Artifact, goos, goarch string) {
+	t.Helper()
+
+	want := expectedPythonReleasePlatform(goos, goarch)
+	if artifact.OS != want.GOOS || artifact.Arch != want.GOARCH || artifact.LibC != want.LibC {
+		t.Fatalf(
+			"artifact platform = %s/%s/%s, want %s/%s/%s",
+			artifact.OS, artifact.Arch, artifact.LibC,
+			want.GOOS, want.GOARCH, want.LibC,
+		)
+	}
 }
 
 func configurePythonReleaseInterpretersForAllPlatforms(t *testing.T, pluginDir string) {

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -60,8 +60,15 @@ func buildV2Archive(t *testing.T, dir, source, version, binaryContent string) st
 	t.Helper()
 
 	artPath := artifactRelPath("provider")
-	srcDir := filepath.Join(dir, "provider-src")
-	if err := os.MkdirAll(filepath.Join(srcDir, filepath.Dir(filepath.FromSlash(artPath))), 0755); err != nil {
+	return buildV2ArchiveForArtifact(t, dir, source, version, artPath, "", binaryContent)
+}
+
+func buildV2ArchiveForArtifact(t *testing.T, dir, source, version, artifactPath, libc, binaryContent string) string {
+	t.Helper()
+
+	safeName := strings.NewReplacer("/", "-", ".", "_").Replace(artifactPath + "-" + libc + "-" + binaryContent)
+	srcDir := filepath.Join(dir, safeName+"-src")
+	if err := os.MkdirAll(filepath.Join(srcDir, filepath.Dir(filepath.FromSlash(artifactPath))), 0755); err != nil {
 		t.Fatalf("create provider src dir: %v", err)
 	}
 	manifest := &pluginmanifestv1.Manifest{
@@ -73,12 +80,13 @@ func buildV2Archive(t *testing.T, dir, source, version, binaryContent string) st
 			{
 				OS:     runtime.GOOS,
 				Arch:   runtime.GOARCH,
-				Path:   artPath,
+				LibC:   libc,
+				Path:   artifactPath,
 				SHA256: sha256hex(binaryContent),
 			},
 		},
 		Entrypoints: pluginmanifestv1.Entrypoints{
-			Provider: &pluginmanifestv1.Entrypoint{ArtifactPath: artPath},
+			Provider: &pluginmanifestv1.Entrypoint{ArtifactPath: artifactPath},
 		},
 	}
 
@@ -92,11 +100,11 @@ func buildV2Archive(t *testing.T, dir, source, version, binaryContent string) st
 	if err := os.WriteFile(filepath.Join(srcDir, "catalog.yaml"), []byte("name: provider\noperations:\n  - id: echo\n    method: POST\n"), 0644); err != nil {
 		t.Fatalf("write provider catalog: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(srcDir, filepath.FromSlash(artPath)), []byte(binaryContent), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(srcDir, filepath.FromSlash(artifactPath)), []byte(binaryContent), 0755); err != nil {
 		t.Fatalf("write provider artifact: %v", err)
 	}
 
-	archivePath := filepath.Join(dir, "plugin.tar.gz")
+	archivePath := filepath.Join(dir, safeName+".tar.gz")
 	if err := pluginpkg.CreatePackageFromDir(srcDir, archivePath); err != nil {
 		t.Fatalf("CreatePackageFromDir provider: %v", err)
 	}
@@ -546,5 +554,92 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 	}
 	if cfg.Integrations["alpha"].Plugin.Command != executablePath {
 		t.Errorf("plugin command = %q, want %q", cfg.Integrations["alpha"].Plugin.Command, executablePath)
+	}
+}
+
+func TestSourcePluginGitHubResolverPrefersCurrentLinuxLibcAsset(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "linux" {
+		t.Skip("linux libc-specific asset selection only applies on linux hosts")
+	}
+	currentLibC := pluginpkg.CurrentRuntimeLibC()
+	if currentLibC == "" {
+		t.Skip("linux libc detection unavailable on this host")
+	}
+
+	src := pluginsource.Source{
+		Host:   pluginsource.HostGitHub,
+		Owner:  testOwner,
+		Repo:   testRepo,
+		Plugin: testPlugin,
+	}
+	dir := t.TempDir()
+	exactPath := artifactRelPath("provider-" + currentLibC)
+	exactArchivePath := buildV2ArchiveForArtifact(t, dir, testSource, testVersion, exactPath, currentLibC, "exact-libc-binary")
+	genericArchivePath := buildV2ArchiveForArtifact(t, dir, testSource, testVersion, artifactRelPath("provider-generic"), "", "generic-binary")
+	exactArchiveData, err := os.ReadFile(exactArchivePath)
+	if err != nil {
+		t.Fatalf("read exact archive: %v", err)
+	}
+	genericArchiveData, err := os.ReadFile(genericArchivePath)
+	if err != nil {
+		t.Fatalf("read generic archive: %v", err)
+	}
+
+	exactAssetName := "gestalt-plugin-" + testPlugin + "_v" + testVersion + "_" + pluginpkg.PlatformArchiveSuffix(runtime.GOOS, runtime.GOARCH, currentLibC) + ".tar.gz"
+	genericAssetName := "gestalt-plugin-" + testPlugin + "_v" + testVersion + "_" + pluginpkg.PlatformArchiveSuffix(runtime.GOOS, runtime.GOARCH, "") + ".tar.gz"
+	releasePath := "/repos/" + testOwner + "/" + testRepo + "/releases/tags/" + src.ReleaseTag(testVersion)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case releasePath:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"assets": []map[string]any{
+					{
+						"name":                 genericAssetName,
+						"url":                  "http://" + r.Host + "/generic-dl",
+						"browser_download_url": "https://github.com/" + testOwner + "/" + testRepo + "/releases/download/" + src.ReleaseTag(testVersion) + "/" + genericAssetName,
+					},
+					{
+						"name":                 exactAssetName,
+						"url":                  "http://" + r.Host + "/exact-dl",
+						"browser_download_url": "https://github.com/" + testOwner + "/" + testRepo + "/releases/download/" + src.ReleaseTag(testVersion) + "/" + exactAssetName,
+					},
+				},
+			})
+		case "/generic-dl":
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(genericArchiveData)
+		case "/exact-dl":
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(exactArchiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configPath := writeConfigYAML(t, dir, testSource, testVersion, artifactsDir)
+
+	lc := NewLifecycle(&ghresolver.GitHubResolver{BaseURL: srv.URL})
+	lock, err := lc.InitAtPath(configPath)
+	if err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+
+	entry := lock.Providers["alpha"]
+	if entry.ResolvedURL != srv.URL+"/exact-dl" {
+		t.Fatalf("ResolvedURL = %q, want %q", entry.ResolvedURL, srv.URL+"/exact-dl")
+	}
+	executablePath := resolveLockPath(artifactsDir, entry.Executable)
+	data, err := os.ReadFile(executablePath)
+	if err != nil {
+		t.Fatalf("read executable: %v", err)
+	}
+	if string(data) != "exact-libc-binary" {
+		t.Fatalf("executable content = %q, want %q", data, "exact-libc-binary")
 	}
 }

--- a/gestaltd/internal/pluginpkg/manifest.go
+++ b/gestaltd/internal/pluginpkg/manifest.go
@@ -150,6 +150,9 @@ func validateManifest(manifest *pluginmanifestv1.Manifest, sourceMode bool) erro
 			if err := validateRelativePackagePath(artifact.Path, "artifact path"); err != nil {
 				return err
 			}
+			if _, err := NormalizeArtifactLibC(artifact.OS, artifact.LibC); err != nil {
+				return err
+			}
 			if artifact.SHA256 == "" && !sourceMode {
 				return fmt.Errorf("artifact %s sha256 is required", artifact.Path)
 			}
@@ -158,7 +161,7 @@ func validateManifest(manifest *pluginmanifestv1.Manifest, sourceMode bool) erro
 			}
 			artifactPaths[artifact.Path] = struct{}{}
 
-			key := artifact.OS + "/" + artifact.Arch
+			key := PlatformString(artifact.OS, artifact.Arch, artifact.LibC)
 			if _, exists := artifactPlatforms[key]; exists {
 				return fmt.Errorf("duplicate artifact platform %q", key)
 			}
@@ -225,11 +228,23 @@ func CurrentPlatformArtifact(manifest *pluginmanifestv1.Manifest) (*pluginmanife
 	if manifest == nil {
 		return nil, fmt.Errorf("manifest is required")
 	}
+	currentLibC := CurrentRuntimeLibC()
+	var generic *pluginmanifestv1.Artifact
 	for _, artifact := range manifest.Artifacts {
-		if artifact.OS == runtime.GOOS && artifact.Arch == runtime.GOARCH {
+		if artifact.OS != runtime.GOOS || artifact.Arch != runtime.GOARCH {
+			continue
+		}
+		switch {
+		case runtime.GOOS == "linux" && currentLibC != "" && artifact.LibC == currentLibC:
 			artifact := artifact
 			return &artifact, nil
+		case artifact.LibC == "":
+			artifact := artifact
+			generic = &artifact
 		}
+	}
+	if generic != nil {
+		return generic, nil
 	}
 	return nil, fmt.Errorf("no artifact for current platform %s/%s", runtime.GOOS, runtime.GOARCH)
 }

--- a/gestaltd/internal/pluginpkg/platform.go
+++ b/gestaltd/internal/pluginpkg/platform.go
@@ -1,0 +1,62 @@
+package pluginpkg
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+const (
+	LinuxLibCGLibC = "glibc"
+	LinuxLibCMusl  = "musl"
+)
+
+func NormalizeArtifactLibC(goos, libc string) (string, error) {
+	libc = strings.TrimSpace(strings.ToLower(libc))
+	if goos != "linux" {
+		if libc != "" {
+			return "", fmt.Errorf("artifact libc %q is only supported for linux artifacts", libc)
+		}
+		return "", nil
+	}
+	switch libc {
+	case "", LinuxLibCGLibC, LinuxLibCMusl:
+		return libc, nil
+	default:
+		return "", fmt.Errorf("unsupported linux libc %q (want %q or %q)", libc, LinuxLibCGLibC, LinuxLibCMusl)
+	}
+}
+
+func CurrentRuntimeLibC() string {
+	if runtime.GOOS != "linux" {
+		return ""
+	}
+	out, err := exec.Command("ldd", "--version").CombinedOutput()
+	if err != nil && len(out) == 0 {
+		return ""
+	}
+	lower := strings.ToLower(string(out))
+	switch {
+	case strings.Contains(lower, LinuxLibCMusl):
+		return LinuxLibCMusl
+	case strings.Contains(lower, LinuxLibCGLibC), strings.Contains(lower, "gnu libc"), strings.Contains(lower, "gnu c library"):
+		return LinuxLibCGLibC
+	default:
+		return ""
+	}
+}
+
+func PlatformString(goos, goarch, libc string) string {
+	if goos == "linux" && libc != "" {
+		return fmt.Sprintf("%s/%s/%s", goos, goarch, libc)
+	}
+	return fmt.Sprintf("%s/%s", goos, goarch)
+}
+
+func PlatformArchiveSuffix(goos, goarch, libc string) string {
+	if goos == "linux" && libc != "" {
+		return fmt.Sprintf("%s_%s_%s", goos, goarch, libc)
+	}
+	return fmt.Sprintf("%s_%s", goos, goarch)
+}

--- a/gestaltd/internal/pluginpkg/python_provider.go
+++ b/gestaltd/internal/pluginpkg/python_provider.go
@@ -61,10 +61,10 @@ func pythonProviderExecutionCommand(root, target string) (string, []string, func
 	return interpreter, []string{"-m", pythonRuntimeModule, root, target}, nil, nil
 }
 
-func BuildPythonProviderBinary(sourceDir, binaryPath, pluginName, target, goos, goarch string) error {
+func BuildPythonProviderBinary(sourceDir, binaryPath, pluginName, target, goos, goarch string) (string, error) {
 	interpreter, err := DetectPythonInterpreter(sourceDir, goos, goarch)
 	if err != nil {
-		return fmt.Errorf("detect Python release interpreter for %s/%s: %w", goos, goarch, err)
+		return "", fmt.Errorf("detect Python release interpreter for %s/%s: %w", goos, goarch, err)
 	}
 
 	cmd := exec.Command(interpreter, "-m", pythonBuildModule, sourceDir, target, binaryPath, pluginName, goos, goarch)
@@ -73,9 +73,12 @@ func BuildPythonProviderBinary(sourceDir, binaryPath, pluginName, target, goos, 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("python release build: %w (ensure gestalt and PyInstaller are installed in the selected Python environment)", err)
+		return "", fmt.Errorf("python release build: %w (ensure gestalt and PyInstaller are installed in the selected Python environment)", err)
 	}
-	return nil
+	if goos != "linux" || runtime.GOOS != "linux" {
+		return "", nil
+	}
+	return CurrentRuntimeLibC(), nil
 }
 
 func DetectPythonInterpreter(root, goos, goarch string) (string, error) {

--- a/gestaltd/internal/pluginpkg/source_provider.go
+++ b/gestaltd/internal/pluginpkg/source_provider.go
@@ -65,18 +65,18 @@ func ValidateSourceProviderRelease(root, goos, goarch string) error {
 	return err
 }
 
-func BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch string) error {
+func BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch string) (string, error) {
 	kind, pythonTarget, err := detectSourceProvider(root, goos, goarch)
 	if err != nil {
-		return err
+		return "", err
 	}
 	switch kind {
 	case sourceProviderKindGo:
-		return BuildGoProviderBinary(root, outputPath, pluginName, goos, goarch)
+		return "", BuildGoProviderBinary(root, outputPath, pluginName, goos, goarch)
 	case sourceProviderKindPython:
 		return BuildPythonProviderBinary(root, outputPath, pluginName, pythonTarget, goos, goarch)
 	default:
-		return ErrNoSourceProviderPackage
+		return "", ErrNoSourceProviderPackage
 	}
 }
 

--- a/gestaltd/internal/pluginsource/github/resolver.go
+++ b/gestaltd/internal/pluginsource/github/resolver.go
@@ -25,10 +25,10 @@ const (
 	platformAssetPrefix = "gestalt-plugin-"
 )
 
-type platformAssetMatch int
+type platformAssetMatchKind int
 
 const (
-	noPlatformAssetMatch platformAssetMatch = iota
+	noPlatformAssetMatch platformAssetMatchKind = iota
 	pluginOnlyPlatformAssetMatch
 	versionedPlatformAssetMatch
 )
@@ -141,14 +141,13 @@ func findAsset(assets []releaseAsset, plugin, version string) (releaseAsset, err
 	if plugin == "" {
 		return releaseAsset{}, fmt.Errorf("plugin name is required")
 	}
-
-	expectedName := platformAssetName(plugin, version)
-	oldName := pluginsource.Source{Plugin: plugin}.AssetName(version)
-
-	if asset, ok := findAssetByName(assets, expectedName); ok {
-		return asset, nil
+	currentLibC := pluginpkg.CurrentRuntimeLibC()
+	for _, expectedName := range candidatePlatformAssetNames(plugin, version, currentLibC) {
+		if asset, ok := findAssetByName(assets, expectedName); ok {
+			return asset, nil
+		}
 	}
-
+	oldName := pluginsource.Source{Plugin: plugin}.AssetName(version)
 	oldAsset, hasOldAsset := findAssetByName(assets, oldName)
 
 	versionedMatches := make([]releaseAsset, 0, 1)
@@ -200,8 +199,25 @@ func findAsset(assets []releaseAsset, plugin, version string) (releaseAsset, err
 	)
 }
 
-func platformAssetName(plugin, version string) string {
-	return fmt.Sprintf("%s%s_v%s_%s_%s.tar.gz", platformAssetPrefix, plugin, version, runtime.GOOS, runtime.GOARCH)
+func platformAssetName(plugin, version, libc string) string {
+	return fmt.Sprintf("%s%s_v%s_%s.tar.gz", platformAssetPrefix, plugin, version, pluginpkg.PlatformArchiveSuffix(runtime.GOOS, runtime.GOARCH, libc))
+}
+
+func candidatePlatformAssetNames(plugin, version, libc string) []string {
+	names := []string{platformAssetName(plugin, version, libc)}
+	if runtime.GOOS == "linux" && libc != "" {
+		names = append(names, fmt.Sprintf("%s%s_v%s_%s.tar.gz", platformAssetPrefix, plugin, version, pluginpkg.PlatformArchiveSuffix(runtime.GOOS, runtime.GOARCH, "")))
+	}
+	seen := make(map[string]struct{}, len(names))
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	return out
 }
 
 func findAssetByName(assets []releaseAsset, name string) (releaseAsset, bool) {
@@ -213,7 +229,7 @@ func findAssetByName(assets []releaseAsset, name string) (releaseAsset, bool) {
 	return releaseAsset{}, false
 }
 
-func matchesPlatformAsset(name, plugin, version string) platformAssetMatch {
+func matchesPlatformAsset(name, plugin, version string) platformAssetMatchKind {
 	stem, ok := trimPlatformArchive(name)
 	if !ok {
 		return noPlatformAssetMatch
@@ -243,16 +259,9 @@ func trimPlatformArchive(name string) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	for _, goos := range platformAliases(platformOSAliases, runtime.GOOS) {
-		for _, goarch := range platformAliases(platformArchAliases, runtime.GOARCH) {
-			for _, leadSep := range platformSeparators {
-				for _, midSep := range platformSeparators {
-					suffix := leadSep + goos + midSep + goarch
-					if strings.HasSuffix(base, suffix) {
-						return strings.TrimSuffix(base, suffix), true
-					}
-				}
-			}
+	for _, suffix := range platformSuffixCandidates() {
+		if strings.HasSuffix(base, suffix) {
+			return strings.TrimSuffix(base, suffix), true
 		}
 	}
 	return "", false
@@ -263,6 +272,22 @@ func platformAliases(aliasMap map[string][]string, name string) []string {
 		return aliases
 	}
 	return []string{name}
+}
+
+func platformSuffixCandidates() []string {
+	suffixes := make([]string, 0, 8)
+	goosAliases := platformAliases(platformOSAliases, runtime.GOOS)
+	goarchAliases := platformAliases(platformArchAliases, runtime.GOARCH)
+	for _, goos := range goosAliases {
+		for _, goarch := range goarchAliases {
+			for _, leadSep := range platformSeparators {
+				for _, midSep := range platformSeparators {
+					suffixes = append(suffixes, leadSep+goos+midSep+goarch)
+				}
+			}
+		}
+	}
+	return suffixes
 }
 
 // Remote plugin packages are tarball archives today; pluginpkg only reads gzip-compressed tar packages.

--- a/gestaltd/internal/pluginstore/store_test.go
+++ b/gestaltd/internal/pluginstore/store_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -308,6 +309,185 @@ func TestInstall_ArchiveArtifactDigestVerified(t *testing.T) {
 	sum := sha256.Sum256([]byte("correct-content"))
 	if installed.SHA256 != hex.EncodeToString(sum[:]) {
 		t.Fatalf("SHA256 = %q, want %q", installed.SHA256, hex.EncodeToString(sum[:]))
+	}
+}
+
+func TestInstallRejectsNonLinuxLibcArtifact(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	srcDir := mustBuildV2PluginDir(t, dir, "github.com/testowner/plugins/provider", "0.4.0", "bad-artifact")
+	manifestPath := filepath.Join(srcDir, pluginpkg.ManifestFile)
+	_, manifest, err := pluginpkg.ReadManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadManifestFile: %v", err)
+	}
+
+	oldPath := manifest.Artifacts[0].Path
+	newPath := "artifacts/darwin/arm64/provider"
+	manifest.Artifacts[0].OS = "darwin"
+	manifest.Artifacts[0].Arch = "arm64"
+	manifest.Artifacts[0].Path = newPath
+	manifest.Entrypoints.Provider.ArtifactPath = newPath
+
+	oldArtifactPath := filepath.Join(srcDir, filepath.FromSlash(oldPath))
+	newArtifactPath := filepath.Join(srcDir, filepath.FromSlash(newPath))
+	if err := os.MkdirAll(filepath.Dir(newArtifactPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll artifact dir: %v", err)
+	}
+	if err := os.Rename(oldArtifactPath, newArtifactPath); err != nil {
+		t.Fatalf("Rename artifact: %v", err)
+	}
+
+	manifestBytes, err := pluginpkg.EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	var manifestDoc map[string]any
+	if err := json.Unmarshal(manifestBytes, &manifestDoc); err != nil {
+		t.Fatalf("json.Unmarshal manifest: %v", err)
+	}
+	artifacts, ok := manifestDoc["artifacts"].([]any)
+	if !ok || len(artifacts) != 1 {
+		t.Fatalf("manifest artifacts = %#v, want one artifact", manifestDoc["artifacts"])
+	}
+	artifact, ok := artifacts[0].(map[string]any)
+	if !ok {
+		t.Fatalf("artifact doc = %T, want map[string]any", artifacts[0])
+	}
+	artifact["libc"] = pluginpkg.LinuxLibCGLibC
+	manifestBytes, err = json.Marshal(manifestDoc)
+	if err != nil {
+		t.Fatalf("json.Marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(manifestPath, manifestBytes, 0o644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	pkg := filepath.Join(dir, "invalid-libc.tar.gz")
+	out, err := os.Create(pkg)
+	if err != nil {
+		t.Fatalf("Create archive: %v", err)
+	}
+	gzw := gzip.NewWriter(out)
+	tw := tar.NewWriter(gzw)
+	writeFile := func(name string, data []byte, mode int64) {
+		t.Helper()
+		hdr := &tar.Header{Name: name, Mode: mode, Size: int64(len(data))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("WriteHeader %s: %v", name, err)
+		}
+		if _, err := io.Copy(tw, bytes.NewReader(data)); err != nil {
+			t.Fatalf("Write file %s: %v", name, err)
+		}
+	}
+	writeFile(pluginpkg.ManifestFile, manifestBytes, 0o644)
+	writeFile("catalog.yaml", []byte(testCatalogYAML), 0o644)
+	artifactData, err := os.ReadFile(newArtifactPath)
+	if err != nil {
+		t.Fatalf("ReadFile artifact: %v", err)
+	}
+	writeFile(newPath, artifactData, 0o755)
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatalf("close archive: %v", err)
+	}
+
+	_, err = Install(pkg, filepath.Join(dir, "plugins", "integration_invalid_libc"))
+	if err == nil {
+		t.Fatal("expected invalid non-linux libc artifact error")
+	}
+	if !strings.Contains(err.Error(), `only supported for linux artifacts`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestInstallPrefersCurrentLinuxLibcArtifact(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "linux" {
+		t.Skip("linux libc-specific artifact selection only applies on linux hosts")
+	}
+	currentLibC := pluginpkg.CurrentRuntimeLibC()
+	if currentLibC == "" {
+		t.Skip("linux libc detection unavailable on this host")
+	}
+
+	otherLibC := pluginpkg.LinuxLibCGLibC
+	if currentLibC == pluginpkg.LinuxLibCGLibC {
+		otherLibC = pluginpkg.LinuxLibCMusl
+	}
+
+	dir := t.TempDir()
+	srcDir := mustBuildV2PluginDir(t, dir, "github.com/testowner/plugins/provider", "0.5.0", "exact-libc-provider")
+	manifestPath := filepath.Join(srcDir, pluginpkg.ManifestFile)
+	_, manifest, err := pluginpkg.ReadManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadManifestFile: %v", err)
+	}
+
+	exactPath := manifest.Artifacts[0].Path
+	manifest.Artifacts[0].LibC = currentLibC
+
+	appendArtifact := func(path, libc, content string) {
+		t.Helper()
+		sum := sha256.Sum256([]byte(content))
+		manifest.Artifacts = append(manifest.Artifacts, pluginmanifestv1.Artifact{
+			OS:     runtime.GOOS,
+			Arch:   runtime.GOARCH,
+			LibC:   libc,
+			Path:   path,
+			SHA256: hex.EncodeToString(sum[:]),
+		})
+		filePath := filepath.Join(srcDir, filepath.FromSlash(path))
+		if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+			t.Fatalf("MkdirAll artifact dir: %v", err)
+		}
+		if err := os.WriteFile(filePath, []byte(content), 0o755); err != nil {
+			t.Fatalf("WriteFile artifact: %v", err)
+		}
+	}
+
+	appendArtifact(filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider-generic")), "", "generic-provider")
+	appendArtifact(filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider-"+otherLibC)), otherLibC, "other-libc-provider")
+
+	manifestBytes, err := pluginpkg.EncodeManifest(manifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(manifestPath, manifestBytes, 0o644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	pkg := filepath.Join(dir, "exact-libc.tar.gz")
+	if err := pluginpkg.CreatePackageFromDir(srcDir, pkg); err != nil {
+		t.Fatalf("CreatePackageFromDir: %v", err)
+	}
+
+	installed, err := Install(pkg, filepath.Join(dir, "plugins", "integration_exact_libc"))
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if installed.Artifact == nil {
+		t.Fatal("Artifact is nil")
+	}
+	if installed.Artifact.Path != exactPath {
+		t.Fatalf("Artifact.Path = %q, want %q", installed.Artifact.Path, exactPath)
+	}
+	if installed.ExecutablePath != filepath.Join(installed.Root, filepath.FromSlash(exactPath)) {
+		t.Fatalf("ExecutablePath = %q, want %q", installed.ExecutablePath, filepath.Join(installed.Root, filepath.FromSlash(exactPath)))
+	}
+	data, err := os.ReadFile(installed.ExecutablePath)
+	if err != nil {
+		t.Fatalf("ReadFile executable: %v", err)
+	}
+	if string(data) != "exact-libc-provider" {
+		t.Fatalf("executable content = %q, want %q", data, "exact-libc-provider")
 	}
 }
 

--- a/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -653,6 +653,13 @@
           "type": "string",
           "minLength": 1
         },
+        "libc": {
+          "type": "string",
+          "enum": [
+            "glibc",
+            "musl"
+          ]
+        },
         "path": {
           "type": "string",
           "minLength": 1

--- a/gestaltd/sdk/pluginmanifest/v1/types.go
+++ b/gestaltd/sdk/pluginmanifest/v1/types.go
@@ -164,6 +164,7 @@ type CredentialField struct {
 type Artifact struct {
 	OS     string `json:"os" yaml:"os"`
 	Arch   string `json:"arch" yaml:"arch"`
+	LibC   string `json:"libc,omitempty" yaml:"libc,omitempty"`
 	Path   string `json:"path" yaml:"path"`
 	SHA256 string `json:"sha256,omitempty" yaml:"sha256,omitempty"`
 }


### PR DESCRIPTION
## Summary
- add Linux libc-aware artifact metadata and selection so `gestaltd` can distinguish `glibc` and `musl` provider binaries
- make plugin release archives and GitHub asset resolution understand `os/arch[/libc]` platform targets with generic fallback for older releases
- document the new manifest and CLI contract and cover the resolver and packaging behavior with tests

## Testing
- go test ./internal/platform ./internal/pluginpkg ./internal/pluginsource/github ./cmd/gestaltd