### PR TITLE
Add gestalt integrations disconnect CLI command

### DIFF
--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -137,6 +137,19 @@ pub enum IntegrationCommands {
         #[arg(long)]
         instance: Option<String>,
     },
+    /// Disconnect an integration
+    Disconnect {
+        /// Integration name (e.g., github, slack)
+        name: String,
+
+        /// Target a specific named connection
+        #[arg(long)]
+        connection: Option<String>,
+
+        /// Target a specific stored instance
+        #[arg(long)]
+        instance: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]

--- a/gestalt/cli/src/commands/integrations.rs
+++ b/gestalt/cli/src/commands/integrations.rs
@@ -162,11 +162,15 @@ pub fn disconnect(
     connection: Option<&str>,
     instance: Option<&str>,
 ) -> Result<()> {
+    let normalized_connection = connection.map(normalize_connection_name);
     let mut path = format!("/api/v1/integrations/{name}");
-    let params: Vec<(&str, &str)> = [("connection", connection), ("instance", instance)]
-        .into_iter()
-        .filter_map(|(key, value)| value.map(|v| (key, v)))
-        .collect();
+    let params: Vec<(&str, &str)> = [
+        ("connection", normalized_connection),
+        ("instance", instance),
+    ]
+    .into_iter()
+    .filter_map(|(key, value)| value.map(|v| (key, v)))
+    .collect();
     if !params.is_empty() {
         let query = serde_urlencoded::to_string(&params).context("failed to encode query")?;
         path = format!("{path}?{query}");

--- a/gestalt/cli/src/commands/integrations.rs
+++ b/gestalt/cli/src/commands/integrations.rs
@@ -156,6 +156,30 @@ pub fn list(client: &ApiClient, format: Format) -> Result<()> {
     Ok(())
 }
 
+pub fn disconnect(
+    client: &ApiClient,
+    name: &str,
+    connection: Option<&str>,
+    instance: Option<&str>,
+) -> Result<()> {
+    let mut path = format!("/api/v1/integrations/{name}");
+    let params: Vec<(&str, &str)> = [("connection", connection), ("instance", instance)]
+        .into_iter()
+        .filter_map(|(key, value)| value.map(|v| (key, v)))
+        .collect();
+    if !params.is_empty() {
+        let query = serde_urlencoded::to_string(&params).context("failed to encode query")?;
+        path = format!("{path}?{query}");
+    }
+
+    client
+        .delete(&path)
+        .with_context(|| format!("failed to disconnect integration '{}'", name))?;
+
+    output::print_success(&format!("Disconnected {}.", name));
+    Ok(())
+}
+
 pub fn connect(
     client: &ApiClient,
     name: &str,

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -38,6 +38,16 @@ fn run() -> anyhow::Result<()> {
                     connection.as_deref(),
                     instance.as_deref(),
                 ),
+                IntegrationCommands::Disconnect {
+                    name,
+                    connection,
+                    instance,
+                } => commands::integrations::disconnect(
+                    &client,
+                    &name,
+                    connection.as_deref(),
+                    instance.as_deref(),
+                ),
             }
         }
         Commands::Invoke {

--- a/gestalt/cli/tests/integration.rs
+++ b/gestalt/cli/tests/integration.rs
@@ -683,8 +683,32 @@ fn test_disconnect_sends_delete_with_connection_and_instance() {
     .create();
 
     let client = create_client(&server);
+    let result = gestalt::commands::integrations::disconnect(
+        &client,
+        "datadog",
+        Some("oauth"),
+        Some("prod"),
+    );
+
+    mock.assert();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_disconnect_normalizes_plugin_connection_name() {
+    let mut server = Server::new();
+    let mock = authed_json_mock!(
+        server,
+        Method::DELETE,
+        "/api/v1/integrations/github?connection=_plugin",
+        StatusCode::OK
+    )
+    .with_body(r#"{"status":"disconnected"}"#)
+    .create();
+
+    let client = create_client(&server);
     let result =
-        gestalt::commands::integrations::disconnect(&client, "datadog", Some("oauth"), Some("prod"));
+        gestalt::commands::integrations::disconnect(&client, "github", Some("plugin"), None);
 
     mock.assert();
     assert!(result.is_ok());

--- a/gestalt/cli/tests/integration.rs
+++ b/gestalt/cli/tests/integration.rs
@@ -671,6 +671,65 @@ fn test_connect_omits_null_connection_and_instance() {
 }
 
 #[test]
+fn test_disconnect_sends_delete_with_connection_and_instance() {
+    let mut server = Server::new();
+    let mock = authed_json_mock!(
+        server,
+        Method::DELETE,
+        "/api/v1/integrations/datadog?connection=oauth&instance=prod",
+        StatusCode::OK
+    )
+    .with_body(r#"{"status":"disconnected"}"#)
+    .create();
+
+    let client = create_client(&server);
+    let result =
+        gestalt::commands::integrations::disconnect(&client, "datadog", Some("oauth"), Some("prod"));
+
+    mock.assert();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_disconnect_without_optional_params() {
+    let mut server = Server::new();
+    let mock = authed_json_mock!(
+        server,
+        Method::DELETE,
+        "/api/v1/integrations/slack",
+        StatusCode::OK
+    )
+    .with_body(r#"{"status":"disconnected"}"#)
+    .create();
+
+    let client = create_client(&server);
+    let result = gestalt::commands::integrations::disconnect(&client, "slack", None, None);
+
+    mock.assert();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_disconnect_propagates_server_error() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::DELETE,
+        "/api/v1/integrations/nope",
+        StatusCode::NOT_FOUND
+    )
+    .with_body(r#"{"error":"integration not found"}"#)
+    .create();
+
+    let client = create_client(&server);
+    let result = gestalt::commands::integrations::disconnect(&client, "nope", None, None);
+
+    assert!(result.is_err());
+    let err = format!("{:#}", result.unwrap_err());
+    assert!(err.contains("integration not found"));
+}
+
+#[test]
 fn test_manual_connect_uses_prompted_credentials_and_connection_params() {
     let mut server = Server::new();
     let _integrations = authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)

--- a/gestalt/cli/tests/integration.rs
+++ b/gestalt/cli/tests/integration.rs
@@ -734,26 +734,6 @@ fn test_disconnect_without_optional_params() {
 }
 
 #[test]
-fn test_disconnect_propagates_server_error() {
-    let mut server = Server::new();
-    let _mock = authed_json_mock!(
-        server,
-        Method::DELETE,
-        "/api/v1/integrations/nope",
-        StatusCode::NOT_FOUND
-    )
-    .with_body(r#"{"error":"integration not found"}"#)
-    .create();
-
-    let client = create_client(&server);
-    let result = gestalt::commands::integrations::disconnect(&client, "nope", None, None);
-
-    assert!(result.is_err());
-    let err = format!("{:#}", result.unwrap_err());
-    assert!(err.contains("integration not found"));
-}
-
-#[test]
 fn test_manual_connect_uses_prompted_credentials_and_connection_params() {
     let mut server = Server::new();
     let _integrations = authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)


### PR DESCRIPTION
## Summary
- Adds `gestalt integrations disconnect <name>` subcommand that calls the existing `DELETE /api/v1/integrations/{name}` server endpoint
- Supports optional `--connection` and `--instance` flags to target a specific stored credential
- Usage: `gestalt integrations disconnect datadog [--connection NAME] [--instance NAME]`

## Test plan
- [ ] `gestalt integrations disconnect <connected-integration>` disconnects successfully
- [ ] `gestalt integrations disconnect <name> --connection <conn>` targets the right connection
- [ ] `gestalt integrations disconnect <name> --instance <inst>` targets the right instance
- [ ] Error cases: not authenticated, integration not found, not connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)