### PR TITLE
[codex] Move auth capability into server contract

### DIFF
--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -13,8 +13,8 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | `GET` | `/health` | Basic liveness check. |
 | `GET` | `/ready` | Readiness check. Returns `503` until providers and datastore are ready. |
 | `GET` | `/admin` and `/admin/*` | Embedded admin UI shell. On the management listener it reads same-origin `/metrics` without Gestalt auth, so access control is expected to come from your network or reverse proxy. When `server.base_url` is set, the management admin UI links back to that public URL for `Client UI`; otherwise it omits that link. |
-| `GET` | `/api/v1/auth/info` | Returns platform auth metadata. |
-| `POST` | `/api/v1/auth/login` | Starts platform login. |
+| `GET` | `/api/v1/auth/info` | Returns platform auth metadata, including whether interactive login is supported. |
+| `POST` | `/api/v1/auth/login` | Starts platform login and returns an absolute browser URL. |
 | `GET` | `/api/v1/auth/login/callback` | Completes platform login. |
 | `POST` | `/api/v1/auth/logout` | Clears the current platform session. |
 | `GET` | `/api/v1/auth/callback` | Completes integration OAuth. |

--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -15,6 +15,9 @@ pub const DEFAULT_URL: &str = "http://localhost:8080";
 pub const ENV_API_KEY: &str = "GESTALT_API_KEY";
 pub const PROJECT_CONFIG_DIR: &str = ".gestalt";
 pub const PROJECT_CONFIG_FILE: &str = ".gestalt/config.json";
+pub const AUTH_INFO_PATH: &str = "/api/v1/auth/info";
+pub const AUTH_LOGIN_PATH: &str = "/api/v1/auth/login";
+pub const AUTH_LOGIN_CALLBACK_PATH: &str = "/api/v1/auth/login/callback";
 
 pub fn normalize_url(url: &str) -> String {
     let trimmed = url.trim().trim_end_matches('/');

--- a/gestalt/cli/src/commands/auth.rs
+++ b/gestalt/cli/src/commands/auth.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result, bail};
 use reqwest::{StatusCode, header};
 
-use crate::api::{self, ApiClient};
+use crate::api::{self, AUTH_LOGIN_CALLBACK_PATH, AUTH_LOGIN_PATH, ApiClient};
 use crate::credentials::{CredentialStore, Credentials};
 use crate::http;
 use crate::output::{self, Format};
@@ -64,7 +64,7 @@ where
     let port = listener.local_addr()?.port();
     let state = random_hex_string();
 
-    let login_url = format!("{}/api/v1/auth/login", base_url);
+    let login_url = format!("{}{}", base_url, AUTH_LOGIN_PATH);
     let client = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
         .cookie_store(true)
@@ -142,7 +142,7 @@ where
         .map(|(_, v)| v.into_owned())
         .context("callback did not contain an authorization code")?;
 
-    let mut callback_url = url::Url::parse(&format!("{}/api/v1/auth/login/callback", base_url))
+    let mut callback_url = url::Url::parse(&format!("{}{}", base_url, AUTH_LOGIN_CALLBACK_PATH))
         .context("failed to build callback URL")?;
     callback_url
         .query_pairs_mut()

--- a/gestalt/cli/src/commands/init.rs
+++ b/gestalt/cli/src/commands/init.rs
@@ -1,10 +1,16 @@
 use anyhow::{Context, Result};
+use serde::Deserialize;
 
-use crate::api::{self, DEFAULT_URL, PROJECT_CONFIG_DIR, PROJECT_CONFIG_FILE};
+use crate::api::{self, AUTH_INFO_PATH, DEFAULT_URL, PROJECT_CONFIG_DIR, PROJECT_CONFIG_FILE};
 use crate::commands::auth;
 use crate::config::ConfigStore;
 use crate::interactive::{InputPrompt, prompt_confirm, prompt_input};
 use crate::output;
+
+#[derive(Debug, Deserialize)]
+struct AuthInfo {
+    login_supported: bool,
+}
 
 pub fn run(url_override: Option<&str>) -> Result<()> {
     eprintln!("Welcome to Gestalt! Let's get you set up.\n");
@@ -23,7 +29,9 @@ pub fn run(url_override: Option<&str>) -> Result<()> {
     store.set("url", &url)?;
     eprintln!("Saved to global config.\n");
 
-    if prompt_confirm("Log in now?", true)? {
+    if server_auth_disabled(&url) {
+        eprintln!("Authentication is disabled on this server; skipping login.\n");
+    } else if prompt_confirm("Log in now?", true)? {
         eprintln!();
         auth::login(Some(&url))?;
         eprintln!();
@@ -42,4 +50,25 @@ pub fn run(url_override: Option<&str>) -> Result<()> {
     eprintln!();
     output::print_success("You're all set! Run 'gestalt --help' to see available commands.");
     Ok(())
+}
+
+fn server_auth_disabled(url: &str) -> bool {
+    let auth_info_url = format!("{url}{AUTH_INFO_PATH}");
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .ok();
+    let Some(client) = client else {
+        return false;
+    };
+    let resp = client.get(&auth_info_url).send().ok();
+    let Some(resp) = resp else {
+        return false;
+    };
+    if !resp.status().is_success() {
+        return false;
+    }
+    resp.json::<AuthInfo>()
+        .map(|info| !info.login_supported)
+        .unwrap_or(false)
 }

--- a/gestalt/cli/src/paths.rs
+++ b/gestalt/cli/src/paths.rs
@@ -3,10 +3,10 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 
 pub fn gestalt_config_dir() -> Result<PathBuf> {
-    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
-        if !xdg.is_empty() {
-            return Ok(PathBuf::from(xdg).join("gestalt"));
-        }
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME")
+        && !xdg.is_empty()
+    {
+        return Ok(PathBuf::from(xdg).join("gestalt"));
     }
     let home = dirs::home_dir().context("could not determine home directory")?;
     Ok(home.join(".config").join("gestalt"))

--- a/gestalt/cli/tests/integration.rs
+++ b/gestalt/cli/tests/integration.rs
@@ -121,17 +121,17 @@ struct LoginServer {
 fn spawn_login_server() -> LoginServer {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let base_url = format!("http://{}", listener.local_addr().unwrap());
+    let login_response_url = format!("{base_url}/browser-login");
     let state = Arc::new(Mutex::new(LoginFlowState::default()));
     let server_state = Arc::clone(&state);
-    let server_url = base_url.clone();
     let handle = std::thread::spawn(move || {
         let mut workers = Vec::new();
         for _ in 0..3 {
             let (stream, _) = listener.accept().unwrap();
             let state = Arc::clone(&server_state);
-            let base_url = server_url.clone();
+            let login_response_url = login_response_url.clone();
             workers.push(std::thread::spawn(move || {
-                handle_login_request(stream, state, &base_url);
+                handle_login_request(stream, state, &login_response_url);
             }));
         }
         for worker in workers {
@@ -145,7 +145,11 @@ fn spawn_login_server() -> LoginServer {
     }
 }
 
-fn handle_login_request(mut stream: TcpStream, state: Arc<Mutex<LoginFlowState>>, base_url: &str) {
+fn handle_login_request(
+    mut stream: TcpStream,
+    state: Arc<Mutex<LoginFlowState>>,
+    login_response_url: &str,
+) {
     let request = read_http_request(&mut stream);
     match request.target.as_str() {
         "/api/v1/auth/login" if request.method == Method::POST => {
@@ -157,7 +161,7 @@ fn handle_login_request(mut stream: TcpStream, state: Arc<Mutex<LoginFlowState>>
                 &mut stream,
                 StatusCode::OK,
                 http::APPLICATION_JSON,
-                &format!(r#"{{"url":"{base_url}/browser-login"}}"#),
+                &format!(r#"{{"url":"{login_response_url}"}}"#),
             );
         }
         "/browser-login" if request.method == Method::GET => {
@@ -593,7 +597,7 @@ fn test_auth_login_stores_credentials_and_serves_styled_browser_page() {
     assert!(!html.contains("CLI login complete"));
     assert!(!html.contains("class=\"pill\""));
 
-    let credentials_path = gestalt_cli::paths::gestalt_config_dir()
+    let credentials_path = gestalt::paths::gestalt_config_dir()
         .unwrap()
         .join("credentials.json");
     let credentials: serde_json::Value =
@@ -601,6 +605,27 @@ fn test_auth_login_stores_credentials_and_serves_styled_browser_page() {
     assert_eq!(credentials["api_url"], base_url);
     assert_eq!(credentials["api_token"], "cli-secret");
     assert_eq!(credentials["api_token_id"], "tok-123");
+}
+
+#[test]
+fn test_init_skips_login_when_server_auth_is_disabled() {
+    let mut server = Server::new();
+    let _auth_info = json_mock!(server, Method::GET, "/api/v1/auth/info", StatusCode::OK)
+        .with_body(r#"{"provider":"none","display_name":"none","login_supported":false}"#)
+        .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command(home.path())
+        .arg("--url")
+        .arg(server.url())
+        .arg("init")
+        .write_stdin("\n\n")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Authentication is disabled on this server; skipping login.",
+        ))
+        .stderr(predicate::str::contains("Log in now?").not());
 }
 
 #[test]

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -157,6 +157,7 @@ func runServer(env *bootstrapEnv) error {
 		CatalogConnection: connMaps.MCPConnection,
 		ConnectionAuth:    result.ConnectionAuth,
 		IntegrationDefs:   env.Config.Integrations,
+		PublicBaseURL:     env.Config.Server.BaseURL,
 		SecureCookies:     strings.HasPrefix(env.Config.Server.BaseURL, "https://"),
 		StateSecret:       crypto.DeriveKey(env.Config.Server.EncryptionKey),
 		APITokenTTL:       apiTokenTTL,

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -555,8 +555,9 @@ type loginRequest struct {
 }
 
 type authInfoResponse struct {
-	Provider    string `json:"provider"`
-	DisplayName string `json:"display_name"`
+	Provider       string `json:"provider"`
+	DisplayName    string `json:"display_name"`
+	LoginSupported bool   `json:"login_supported"`
 }
 
 func (s *Server) authProviderName() string {
@@ -579,8 +580,9 @@ func (s *Server) authInfo(w http.ResponseWriter, _ *http.Request) {
 		}
 	}
 	writeJSON(w, http.StatusOK, authInfoResponse{
-		Provider:    provider,
-		DisplayName: displayName,
+		Provider:       provider,
+		DisplayName:    displayName,
+		LoginSupported: s.authEnabled(),
 	})
 }
 
@@ -612,6 +614,12 @@ func (s *Server) startLogin(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to generate login URL")
 		return
 	}
+	loginURL, err := s.resolvePublicURL(r, url)
+	if err != nil {
+		auditErr = errors.New("failed to resolve login URL")
+		writeError(w, http.StatusInternalServerError, "failed to resolve login URL")
+		return
+	}
 	if s.encryptor != nil {
 		encoded, encErr := encodeLoginState(s.encryptor, loginState{
 			State:     req.State,
@@ -634,7 +642,37 @@ func (s *Server) startLogin(w http.ResponseWriter, r *http.Request) {
 	}
 	auditAllowed = true
 	auditErr = nil
-	writeJSON(w, http.StatusOK, map[string]string{"url": url})
+	writeJSON(w, http.StatusOK, map[string]string{"url": loginURL})
+}
+
+func (s *Server) resolvePublicURL(r *http.Request, raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	if parsed.IsAbs() {
+		return parsed.String(), nil
+	}
+
+	base := s.publicBaseURL
+	if base == "" {
+		scheme := "http"
+		if r.TLS != nil {
+			scheme = "https"
+		}
+		base = scheme + "://" + r.Host
+	}
+	baseURL, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+	if baseURL.Path == "" {
+		baseURL.Path = "/"
+	}
+	return baseURL.ResolveReference(parsed).String(), nil
 }
 
 // AuthProviderDisplayName is an optional interface for a human-readable login label.

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -44,6 +45,7 @@ type Server struct {
 	integrationDefs    map[string]config.IntegrationDef
 	noAuth             bool
 	anonymousPrincipal *principal.Principal
+	publicBaseURL      string
 	secureCookies      bool
 	encryptor          *cryptoutil.AESGCMEncryptor
 	stateCodec         *integrationOAuthStateCodec
@@ -67,6 +69,7 @@ type Config struct {
 	CatalogConnection map[string]string
 	ConnectionAuth    func() map[string]map[string]bootstrap.OAuthHandler
 	IntegrationDefs   map[string]config.IntegrationDef
+	PublicBaseURL     string
 	SecureCookies     bool
 	StateSecret       []byte
 	APITokenTTL       time.Duration
@@ -122,6 +125,7 @@ func New(cfg Config) (*Server, error) {
 		connectionAuth:    cfg.ConnectionAuth,
 		integrationDefs:   cfg.IntegrationDefs,
 		noAuth:            noAuth,
+		publicBaseURL:     strings.TrimRight(cfg.PublicBaseURL, "/"),
 		secureCookies:     cfg.SecureCookies,
 		encryptor:         encryptor,
 		stateCodec:        stateCodec,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2013,31 +2013,69 @@ func TestExecuteOperation_SessionPassthroughAmbiguousInstance(t *testing.T) {
 func TestStartLogin(t *testing.T) {
 	t.Parallel()
 
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Auth = &stubAuthWithLoginURL{
-			StubAuthProvider: coretesting.StubAuthProvider{N: "test"},
-			loginURL:         "https://auth.example.com/login?state=abc",
-		}
-	})
-	testutil.CloseOnCleanup(t, ts)
-
-	body := bytes.NewBufferString(`{"state":"abc"}`)
-	resp, err := http.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
-	if err != nil {
-		t.Fatalf("request: %v", err)
+	tests := []struct {
+		name          string
+		loginURL      string
+		publicBaseURL string
+		wantURL       func(serverURL string) string
+	}{
+		{
+			name:     "preserves absolute login URL",
+			loginURL: "https://auth.example.com/login?state=abc",
+			wantURL: func(_ string) string {
+				return "https://auth.example.com/login?state=abc"
+			},
+		},
+		{
+			name:     "resolves relative login URL against request host",
+			loginURL: "/login/callback?state=abc",
+			wantURL: func(serverURL string) string {
+				return serverURL + "/login/callback?state=abc"
+			},
+		},
+		{
+			name:          "resolves relative login URL against configured public base URL",
+			loginURL:      "/login/callback?state=abc",
+			publicBaseURL: "https://gestalt.example.test",
+			wantURL: func(_ string) string {
+				return "https://gestalt.example.test/login/callback?state=abc"
+			},
+		},
 	}
-	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
-	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	var result map[string]string
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		t.Fatalf("decoding: %v", err)
-	}
-	if result["url"] != "https://auth.example.com/login?state=abc" {
-		t.Fatalf("unexpected url: %q", result["url"])
+			ts := newTestServer(t, func(cfg *server.Config) {
+				cfg.Auth = &stubAuthWithLoginURL{
+					StubAuthProvider: coretesting.StubAuthProvider{N: "test"},
+					loginURL:         tt.loginURL,
+				}
+				cfg.PublicBaseURL = tt.publicBaseURL
+			})
+			testutil.CloseOnCleanup(t, ts)
+
+			body := bytes.NewBufferString(`{"state":"abc"}`)
+			resp, err := http.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("expected 200, got %d", resp.StatusCode)
+			}
+
+			var result map[string]string
+			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+				t.Fatalf("decoding: %v", err)
+			}
+			if result["url"] != tt.wantURL(ts.URL) {
+				t.Fatalf("unexpected url: %q", result["url"])
+			}
+		})
 	}
 }
 
@@ -3310,6 +3348,9 @@ func TestAuthInfo(t *testing.T) {
 	if body["display_name"] != "Google" {
 		t.Fatalf("expected display_name Google, got %q", body["display_name"])
 	}
+	if body["login_supported"] != true {
+		t.Fatalf("expected login_supported true, got %#v", body["login_supported"])
+	}
 }
 
 func TestAuthInfoFallback(t *testing.T) {
@@ -3340,6 +3381,9 @@ func TestAuthInfoFallback(t *testing.T) {
 	if body["display_name"] != "custom" {
 		t.Fatalf("expected display_name to fall back to name custom, got %q", body["display_name"])
 	}
+	if body["login_supported"] != true {
+		t.Fatalf("expected login_supported true, got %#v", body["login_supported"])
+	}
 }
 
 func TestAuthInfoNoAuth(t *testing.T) {
@@ -3369,6 +3413,9 @@ func TestAuthInfoNoAuth(t *testing.T) {
 	}
 	if body["display_name"] != "none" {
 		t.Fatalf("expected display_name none, got %q", body["display_name"])
+	}
+	if body["login_supported"] != false {
+		t.Fatalf("expected login_supported false, got %#v", body["login_supported"])
 	}
 }
 

--- a/gestaltd/ui/e2e/auth.spec.ts
+++ b/gestaltd/ui/e2e/auth.spec.ts
@@ -42,8 +42,39 @@ test.describe("Authentication", () => {
     ).toBeVisible();
   });
 
+  test("no-auth server redirects to dashboard without showing logout", async ({
+    page,
+  }) => {
+    await mockAuthInfo(page, {
+      provider: "none",
+      display_name: "none",
+      login_supported: false,
+    });
+    await mockIntegrations(page, []);
+    await mockTokens(page, []);
+
+    await page.goto("/login");
+    await expect(page).toHaveURL("/");
+    await expect(page.getByText("anonymous@gestalt")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Logout/i })).toHaveCount(0);
+
+    await page.evaluate(() => {
+      localStorage.clear();
+      localStorage.setItem("user_email", "anonymous@gestalt");
+      sessionStorage.clear();
+    });
+
+    await page.goto("/");
+    await expect(page).toHaveURL("/");
+    await expect(page.getByText("anonymous@gestalt")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Logout/i })).toHaveCount(0);
+  });
+
   test("authenticated user sees dashboard", async ({ authenticatedPage }) => {
     const page = authenticatedPage;
+    await page.route("**/api/v1/auth/info", (route) => {
+      route.abort();
+    });
     await mockIntegrations(page, [
       { name: "test-svc", display_name: "Test Service" },
     ]);
@@ -58,6 +89,9 @@ test.describe("Authentication", () => {
     ).toBeVisible();
     await expect(
       page.getByRole("link", { name: "API Tokens", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Logout/i }),
     ).toBeVisible();
   });
 

--- a/gestaltd/ui/e2e/fixtures.ts
+++ b/gestaltd/ui/e2e/fixtures.ts
@@ -49,10 +49,10 @@ export async function mockManualConnect(
 
 export async function mockAuthInfo(
   page: Page,
-  info: { provider: string; display_name: string },
+  info: { provider: string; display_name: string; login_supported?: boolean },
 ) {
   await page.route("**/api/v1/auth/info", (route: Route) => {
-    route.fulfill({ json: info });
+    route.fulfill({ json: { login_supported: true, ...info } });
   });
 }
 

--- a/gestaltd/ui/src/app/login/page.tsx
+++ b/gestaltd/ui/src/app/login/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import Link from "next/link";
 import { getAuthInfo, startLogin } from "@/lib/api";
 import { isAuthenticated, setUserEmail } from "@/lib/auth";
-import { DOCS_PATH, NONE_PROVIDER, DEFAULT_LOCAL_EMAIL } from "@/lib/constants";
+import { DOCS_PATH, DEFAULT_LOCAL_EMAIL } from "@/lib/constants";
 import Button from "@/components/Button";
 
 export default function LoginPage() {
@@ -19,7 +19,7 @@ export default function LoginPage() {
     }
     getAuthInfo()
       .then((info) => {
-        if (info.provider === NONE_PROVIDER) {
+        if (!info.login_supported) {
           setUserEmail(DEFAULT_LOCAL_EMAIL);
           window.location.replace("/");
           return;

--- a/gestaltd/ui/src/components/Nav.tsx
+++ b/gestaltd/ui/src/components/Nav.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { clearSession, getUserEmail } from "@/lib/auth";
-import { logout } from "@/lib/api";
+import { getAuthInfo, logout } from "@/lib/api";
 import { DOCS_PATH, LOGIN_PATH } from "@/lib/constants";
 import { useTheme } from "@/hooks/use-theme";
 import { MoonIcon, SunIcon, SunMoonIcon } from "./icons";
@@ -18,8 +19,33 @@ const links = [
 export default function Nav() {
   const pathname = usePathname();
   const email = getUserEmail();
+  const [loginSupported, setLoginSupported] = useState(() => email !== null);
   const { theme, setTheme } = useTheme();
   const ThemeIcon = theme === "light" ? SunIcon : theme === "dark" ? MoonIcon : SunMoonIcon;
+
+  useEffect(() => {
+    if (!email) {
+      setLoginSupported(false);
+      return;
+    }
+
+    let active = true;
+    getAuthInfo()
+      .then((info) => {
+        if (active) {
+          setLoginSupported(info.login_supported);
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setLoginSupported(true);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [email]);
 
   async function handleLogout() {
     await logout().catch(() => {});
@@ -68,12 +94,14 @@ export default function Nav() {
           {email && (
             <>
               <span className="text-sm text-faint">{email}</span>
-              <button
-                onClick={handleLogout}
-                className="text-sm text-muted hover:text-primary transition-colors duration-150"
-              >
-                Logout
-              </button>
+              {loginSupported && (
+                <button
+                  onClick={handleLogout}
+                  className="text-sm text-muted hover:text-primary transition-colors duration-150"
+                >
+                  Logout
+                </button>
+              )}
             </>
           )}
         </div>

--- a/gestaltd/ui/src/lib/api.ts
+++ b/gestaltd/ui/src/lib/api.ts
@@ -119,6 +119,7 @@ export async function fetchAPI<T>(
 export interface AuthInfo {
   provider: string;
   display_name: string;
+  login_supported: boolean;
 }
 
 export async function getAuthInfo(): Promise<AuthInfo> {

--- a/gestaltd/ui/src/lib/auth.ts
+++ b/gestaltd/ui/src/lib/auth.ts
@@ -1,6 +1,8 @@
+const USER_EMAIL_KEY = "user_email";
+
 export function clearSession(): void {
   if (typeof window === "undefined") return;
-  localStorage.removeItem("user_email");
+  localStorage.removeItem(USER_EMAIL_KEY);
 }
 
 export function isAuthenticated(): boolean {
@@ -9,10 +11,10 @@ export function isAuthenticated(): boolean {
 
 export function getUserEmail(): string | null {
   if (typeof window === "undefined") return null;
-  return localStorage.getItem("user_email");
+  return localStorage.getItem(USER_EMAIL_KEY);
 }
 
 export function setUserEmail(email: string): void {
   if (typeof window === "undefined") return;
-  localStorage.setItem("user_email", email);
+  localStorage.setItem(USER_EMAIL_KEY, email);
 }

--- a/gestaltd/ui/src/lib/constants.ts
+++ b/gestaltd/ui/src/lib/constants.ts
@@ -1,7 +1,6 @@
 export const LOGIN_PATH = "/login";
 export const DOCS_PATH = "/docs";
 export const HTTP_UNAUTHORIZED = 401;
-export const NONE_PROVIDER = "none";
 export const DEFAULT_LOCAL_EMAIL = "anonymous@gestalt";
 
 export const INPUT_CLASSES =


### PR DESCRIPTION
## Summary
This PR moves local auth behavior into the server API contract so the CLI and web UI can consume capability instead of inferring behavior from provider names.

## Old Interface
```json
GET /api/v1/auth/info
{"provider": "local|none|...", "display_name": "Local|none|..."}

POST /api/v1/auth/login
{"url": "<provider-defined login URL>"}
```

Old client assumptions:
- clients inferred anonymous mode from `provider == "none"`
- `/api/v1/auth/login` could return a relative browser URL
- the web UI could still show `Logout` even when interactive auth was unavailable

## New Interface
```json
GET /api/v1/auth/info
{"provider": "local|none|...", "display_name": "Local|none|...", "login_supported": true|false}

POST /api/v1/auth/login
{"url": "<absolute browser URL>"}
```

New client contract:
- clients gate interactive login on `login_supported`
- the server resolves relative provider URLs before returning them from `/api/v1/auth/login`
- the web UI uses the same capability signal to decide whether `Logout` should be shown

## Supported Now
- `gestalt init` skips the login prompt when `login_supported` is `false`
- the local web UI redirects anonymous local sessions to `/` and hides `Logout`
- local interactive auth still works when the auth provider returns a relative login URL
- existing auth handler and browser-flow tests cover the new contract

## Not Supported
- interactive login when `login_supported` is `false`
- clients calling `/api/v1/auth/login` after the server has advertised `login_supported: false`
- changing disabled-auth login error semantics; this PR relies on clients not initiating interactive login when it is unsupported

## Validation
- `cargo test -p gestalt test_auth_login_stores_credentials_and_serves_styled_browser_page -- --nocapture`
- `cargo test -p gestalt test_init_ -- --nocapture`
- `go test ./internal/server -run 'Test(StartLogin|AuthInfo)'`
- `npm run typecheck`
- `npm run test:e2e -- --grep "no-auth server redirects to dashboard without showing logout"`