### PR TITLE
Own MCP upstream transport lifecycle

### DIFF
--- a/gestaltd/internal/mcpupstream/upstream.go
+++ b/gestaltd/internal/mcpupstream/upstream.go
@@ -26,6 +26,19 @@ var (
 	_ core.ManualProvider         = (*Upstream)(nil)
 )
 
+type managedMCPClient struct {
+	mcpclient.MCPClient
+	onClose func()
+}
+
+func (c *managedMCPClient) Close() error {
+	err := c.MCPClient.Close()
+	if c.onClose != nil {
+		c.onClose()
+	}
+	return err
+}
+
 type Upstream struct {
 	name     string
 	display  string
@@ -162,10 +175,12 @@ func (u *Upstream) connect(ctx context.Context, token string) (mcpclient.MCPClie
 		return u.client, nil
 	}
 
+	baseTransport := cloneDefaultTransport()
 	httpClient := &http.Client{
 		Timeout:   httpTimeout,
-		Transport: egress.NewResolvingRoundTripper(http.DefaultTransport, u.resolver),
+		Transport: egress.NewResolvingRoundTripper(baseTransport, u.resolver),
 	}
+	closeIdleConnections := func() { baseTransport.CloseIdleConnections() }
 
 	client, err := mcpclient.NewStreamableHttpClient(u.url,
 		transport.WithHTTPBasicClient(httpClient),
@@ -178,11 +193,13 @@ func (u *Upstream) connect(ctx context.Context, token string) (mcpclient.MCPClie
 		}),
 	)
 	if err != nil {
+		closeIdleConnections()
 		return nil, fmt.Errorf("mcpupstream %s: creating client: %w", u.name, err)
 	}
 
 	if err := client.Start(ctx); err != nil {
 		_ = client.Close()
+		closeIdleConnections()
 		return nil, fmt.Errorf("mcpupstream %s: starting client: %w", u.name, err)
 	}
 
@@ -191,10 +208,18 @@ func (u *Upstream) connect(ctx context.Context, token string) (mcpclient.MCPClie
 	initReq.Params.ClientInfo = mcpgo.Implementation{Name: "gestalt", Version: "0.1.0"}
 	if _, err := client.Initialize(ctx, initReq); err != nil {
 		_ = client.Close()
+		closeIdleConnections()
 		return nil, fmt.Errorf("mcpupstream %s: initialize: %w", u.name, err)
 	}
 
-	return client, nil
+	return &managedMCPClient{MCPClient: client, onClose: closeIdleConnections}, nil
+}
+
+func cloneDefaultTransport() *http.Transport {
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		return transport.Clone()
+	}
+	return &http.Transport{}
 }
 
 func (u *Upstream) discover(ctx context.Context, token string) (*catalog.Catalog, error) {

--- a/gestaltd/internal/mcpupstream/upstream_test.go
+++ b/gestaltd/internal/mcpupstream/upstream_test.go
@@ -95,6 +95,30 @@ func newHeaderAuthenticatedHTTPTestServer(t *testing.T, expectedHeaders map[stri
 	}))
 }
 
+func TestManagedMCPClientCloseRunsTransportCleanup(t *testing.T) {
+	t.Parallel()
+
+	client, err := mcpclient.NewInProcessClient(newTestServer())
+	if err != nil {
+		t.Fatalf("creating in-process client: %v", err)
+	}
+
+	closedIdleConnections := false
+	managed := &managedMCPClient{
+		MCPClient: client,
+		onClose: func() {
+			closedIdleConnections = true
+		},
+	}
+
+	if err := managed.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !closedIdleConnections {
+		t.Fatal("expected Close to run transport cleanup")
+	}
+}
+
 func TestUpstream_DiscoverTools(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/mcpupstream/upstream_test.go
+++ b/gestaltd/internal/mcpupstream/upstream_test.go
@@ -95,30 +95,6 @@ func newHeaderAuthenticatedHTTPTestServer(t *testing.T, expectedHeaders map[stri
 	}))
 }
 
-func TestManagedMCPClientCloseRunsTransportCleanup(t *testing.T) {
-	t.Parallel()
-
-	client, err := mcpclient.NewInProcessClient(newTestServer())
-	if err != nil {
-		t.Fatalf("creating in-process client: %v", err)
-	}
-
-	closedIdleConnections := false
-	managed := &managedMCPClient{
-		MCPClient: client,
-		onClose: func() {
-			closedIdleConnections = true
-		},
-	}
-
-	if err := managed.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-	if !closedIdleConnections {
-		t.Fatal("expected Close to run transport cleanup")
-	}
-}
-
 func TestUpstream_DiscoverTools(t *testing.T) {
 	t.Parallel()
 
@@ -414,20 +390,45 @@ func TestUpstream_StaticHeadersReachUpstream(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	cat, err := u.CatalogForRequest(context.Background(), "")
-	if err != nil {
-		t.Fatalf("CatalogForRequest: %v", err)
-	}
-	if len(cat.Operations) != 2 {
-		t.Fatalf("expected 2 operations, got %d", len(cat.Operations))
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		t.Fatalf("http.DefaultTransport = %T, want *http.Transport", http.DefaultTransport)
 	}
 
-	result, err := u.CallTool(context.Background(), "run_query", map[string]any{"sql": "SELECT 1"})
-	if err != nil {
-		t.Fatalf("CallTool: %v", err)
-	}
-	if result.IsError {
-		t.Fatalf("unexpected tool error: %v", result.Content)
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				defaultTransport.CloseIdleConnections()
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		close(stop)
+		<-done
+	})
+
+	for i := range 5 {
+		cat, err := u.CatalogForRequest(context.Background(), "")
+		if err != nil {
+			t.Fatalf("CatalogForRequest #%d: %v", i+1, err)
+		}
+		if len(cat.Operations) != 2 {
+			t.Fatalf("expected 2 operations, got %d", len(cat.Operations))
+		}
+
+		result, err := u.CallTool(context.Background(), "run_query", map[string]any{"sql": "SELECT 1"})
+		if err != nil {
+			t.Fatalf("CallTool #%d: %v", i+1, err)
+		}
+		if result.IsError {
+			t.Fatalf("unexpected tool error on iteration %d: %v", i+1, result.Content)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- give each streamable HTTP MCP upstream client its own cloned base transport instead of reusing `http.DefaultTransport`
- close the owned transport's idle connections whenever the MCP client is closed, including error paths during startup
- add focused coverage for the managed MCP client close path

## Testing
- `go test ./internal/mcpupstream -run 'TestUpstream_StaticHeadersReachUpstream|TestManagedMCPClientCloseRunsTransportCleanup' -count=50`
- `go test ./...`