### PR TITLE
[codex] Handle auth-disabled login flow

### DIFF
--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -3,7 +3,7 @@ use reqwest::Method;
 use reqwest::StatusCode;
 use reqwest::blocking::Client;
 use reqwest::header::{self, HeaderValue};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -18,6 +18,11 @@ pub const PROJECT_CONFIG_FILE: &str = ".gestalt/config.json";
 pub const AUTH_INFO_PATH: &str = "/api/v1/auth/info";
 pub const AUTH_LOGIN_PATH: &str = "/api/v1/auth/login";
 pub const AUTH_LOGIN_CALLBACK_PATH: &str = "/api/v1/auth/login/callback";
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AuthInfo {
+    pub login_supported: bool,
+}
 
 pub fn normalize_url(url: &str) -> String {
     let trimmed = url.trim().trim_end_matches('/');
@@ -57,6 +62,32 @@ pub fn resolve_url_with_fallback(
             None => bail_no_url_configured(),
         },
     }
+}
+
+pub fn fetch_auth_info(base_url: &str) -> Result<AuthInfo> {
+    let auth_info_url = format!("{}{}", base_url.trim_end_matches('/'), AUTH_INFO_PATH);
+    let client = Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .context("failed to build HTTP client")?;
+    let resp = client
+        .get(&auth_info_url)
+        .send()
+        .with_context(|| format!("failed to reach {}", auth_info_url))?;
+    let status = resp.status();
+    let body = resp.text().context("failed to read response body")?;
+
+    if !status.is_success() {
+        bail!(
+            "request to {} failed (HTTP {}): {}",
+            auth_info_url,
+            status.as_u16(),
+            body.chars().take(200).collect::<String>()
+        );
+    }
+
+    serde_json::from_str(&body)
+        .with_context(|| format!("server at {} returned non-JSON auth info", base_url))
 }
 
 fn find_configured_url(url_override: Option<&str>) -> Result<Option<String>> {

--- a/gestalt/cli/src/commands/auth.rs
+++ b/gestalt/cli/src/commands/auth.rs
@@ -58,6 +58,9 @@ where
     }
 
     let base_url = api::resolve_url(url_override)?;
+    if matches!(api::fetch_auth_info(&base_url), Ok(info) if !info.login_supported) {
+        bail!("authentication is disabled on this server");
+    }
 
     let listener =
         std::net::TcpListener::bind("127.0.0.1:0").context("failed to bind callback listener")?;

--- a/gestalt/cli/src/commands/init.rs
+++ b/gestalt/cli/src/commands/init.rs
@@ -1,16 +1,10 @@
 use anyhow::{Context, Result};
-use serde::Deserialize;
 
-use crate::api::{self, AUTH_INFO_PATH, DEFAULT_URL, PROJECT_CONFIG_DIR, PROJECT_CONFIG_FILE};
+use crate::api::{self, DEFAULT_URL, PROJECT_CONFIG_DIR, PROJECT_CONFIG_FILE};
 use crate::commands::auth;
 use crate::config::ConfigStore;
 use crate::interactive::{InputPrompt, prompt_confirm, prompt_input};
 use crate::output;
-
-#[derive(Debug, Deserialize)]
-struct AuthInfo {
-    login_supported: bool,
-}
 
 pub fn run(url_override: Option<&str>) -> Result<()> {
     eprintln!("Welcome to Gestalt! Let's get you set up.\n");
@@ -53,22 +47,5 @@ pub fn run(url_override: Option<&str>) -> Result<()> {
 }
 
 fn server_auth_disabled(url: &str) -> bool {
-    let auth_info_url = format!("{url}{AUTH_INFO_PATH}");
-    let client = reqwest::blocking::Client::builder()
-        .timeout(std::time::Duration::from_secs(5))
-        .build()
-        .ok();
-    let Some(client) = client else {
-        return false;
-    };
-    let resp = client.get(&auth_info_url).send().ok();
-    let Some(resp) = resp else {
-        return false;
-    };
-    if !resp.status().is_success() {
-        return false;
-    }
-    resp.json::<AuthInfo>()
-        .map(|info| !info.login_supported)
-        .unwrap_or(false)
+    matches!(api::fetch_auth_info(url), Ok(info) if !info.login_supported)
 }

--- a/gestalt/cli/tests/integration.rs
+++ b/gestalt/cli/tests/integration.rs
@@ -13,6 +13,7 @@ use reqwest::{Method, StatusCode, header};
 use tempfile::TempDir;
 
 const TEST_TOKEN: &str = "test-token";
+const LOGIN_FLOW_REQUEST_COUNT: usize = 4;
 
 macro_rules! json_mock {
     ($server:expr, $method:expr, $path:expr, $status:expr) => {
@@ -126,7 +127,7 @@ fn spawn_login_server() -> LoginServer {
     let server_state = Arc::clone(&state);
     let handle = std::thread::spawn(move || {
         let mut workers = Vec::new();
-        for _ in 0..3 {
+        for _ in 0..LOGIN_FLOW_REQUEST_COUNT {
             let (stream, _) = listener.accept().unwrap();
             let state = Arc::clone(&server_state);
             let login_response_url = login_response_url.clone();
@@ -152,6 +153,14 @@ fn handle_login_request(
 ) {
     let request = read_http_request(&mut stream);
     match request.target.as_str() {
+        "/api/v1/auth/info" if request.method == Method::GET => {
+            write_http_response(
+                &mut stream,
+                StatusCode::OK,
+                http::APPLICATION_JSON,
+                r#"{"provider":"local","display_name":"local","login_supported":true}"#,
+            );
+        }
         "/api/v1/auth/login" if request.method == Method::POST => {
             let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
             let mut state = state.lock().unwrap();
@@ -615,6 +624,28 @@ fn test_auth_login_stores_credentials_and_serves_styled_browser_page() {
     assert_eq!(credentials["api_url"], base_url);
     assert_eq!(credentials["api_token"], "cli-secret");
     assert_eq!(credentials["api_token_id"], "tok-123");
+}
+
+#[test]
+fn test_auth_login_fails_when_server_auth_is_disabled() {
+    let _lock = env_lock();
+    let tempdir = tempfile::tempdir().unwrap();
+    let _env = EnvGuard::new(tempdir.path());
+    let mut server = Server::new();
+    let _auth_info = json_mock!(server, Method::GET, "/api/v1/auth/info", StatusCode::OK)
+        .with_body(r#"{"provider":"none","display_name":"none","login_supported":false}"#)
+        .create();
+    let login = json_mock!(server, Method::POST, "/api/v1/auth/login", StatusCode::OK)
+        .expect(0)
+        .create();
+
+    let err = gestalt::commands::auth::login_with_browser_opener(Some(&server.url()), |_| {
+        panic!("browser should not open when auth is disabled");
+    })
+    .unwrap_err();
+
+    assert_eq!(err.to_string(), "authentication is disabled on this server");
+    login.assert();
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add shared CLI auth-info fetching in API plumbing instead of per-command probing
- skip `gestalt init` login prompts when the server reports `login_supported: false`
- make `gestalt auth login` fail fast with a clear message instead of posting to `/api/v1/auth/login` on auth-disabled servers

## Why
Local `gestaltd` can run with auth disabled. In that mode, `gestalt auth login` currently attempts the browser flow anyway and surfaces a backend 404/JSON error. The CLI should treat `login_supported` as the capability check and stop before starting the login flow.

## Testing
- `cargo test -p gestalt`
- `cargo clippy -p gestalt --all-targets -- -D warnings`
- `cargo fmt --all -- --check`