### PR TITLE
[codex] Report auth-disabled state in auth status

### DIFF
--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -90,6 +90,10 @@ pub fn fetch_auth_info(base_url: &str) -> Result<AuthInfo> {
         .with_context(|| format!("server at {} returned non-JSON auth info", base_url))
 }
 
+pub fn server_auth_disabled(base_url: &str) -> Result<bool> {
+    Ok(!fetch_auth_info(base_url)?.login_supported)
+}
+
 fn find_configured_url(url_override: Option<&str>) -> Result<Option<String>> {
     if let Some(url) = url_override {
         return Ok(Some(normalize_url(url)));

--- a/gestalt/cli/src/commands/auth.rs
+++ b/gestalt/cli/src/commands/auth.rs
@@ -58,7 +58,7 @@ where
     }
 
     let base_url = api::resolve_url(url_override)?;
-    if matches!(api::fetch_auth_info(&base_url), Ok(info) if !info.login_supported) {
+    if api::server_auth_disabled(&base_url).unwrap_or(false) {
         bail!("authentication is disabled on this server");
     }
 
@@ -247,13 +247,17 @@ pub fn logout() -> Result<()> {
     Ok(())
 }
 
-pub fn status(_url_override: Option<&str>, format: Format) -> Result<()> {
+pub fn status(url_override: Option<&str>, format: Format) -> Result<()> {
     let has_env_key = api::env_api_key_is_set();
     let (has_stored_credentials, stored_credentials_error) = match CredentialStore::new()?.load() {
         Ok(Some(_)) => (true, None),
         Ok(None) => (false, None),
         Err(err) => (false, Some(err.to_string())),
     };
+    let server_auth_disabled = api::resolve_url(url_override)
+        .ok()
+        .and_then(|url| api::server_auth_disabled(&url).ok())
+        .unwrap_or(false);
     let configured = has_env_key || has_stored_credentials;
 
     match format {
@@ -267,13 +271,32 @@ pub fn status(_url_override: Option<&str>, format: Format) -> Result<()> {
             };
             output::print_json(&serde_json::json!({
                 "authenticated": configured,
+                "login_supported": !server_auth_disabled,
                 "source": source,
                 "env_var_set": has_env_key,
                 "stored_credentials": has_stored_credentials,
             }));
         }
         Format::Table => {
-            if has_env_key {
+            if server_auth_disabled {
+                eprintln!("Authentication is disabled on this server.");
+                if has_env_key {
+                    output::print_warning(&format!(
+                        "{} is set, but browser login is unavailable on this server.",
+                        api::ENV_API_KEY,
+                    ));
+                } else if has_stored_credentials {
+                    output::print_warning(
+                        "Stored CLI credentials are present. Run 'gestalt auth logout' to clear them.",
+                    );
+                }
+                if let Some(err) = &stored_credentials_error {
+                    output::print_warning(&format!(
+                        "Stored CLI credentials could not be read: {}",
+                        err
+                    ));
+                }
+            } else if has_env_key {
                 eprintln!("Configured via {} environment variable.", api::ENV_API_KEY);
                 if has_stored_credentials {
                     output::print_warning(&format!(

--- a/gestalt/cli/src/commands/init.rs
+++ b/gestalt/cli/src/commands/init.rs
@@ -23,7 +23,7 @@ pub fn run(url_override: Option<&str>) -> Result<()> {
     store.set("url", &url)?;
     eprintln!("Saved to global config.\n");
 
-    if server_auth_disabled(&url) {
+    if api::server_auth_disabled(&url).unwrap_or(false) {
         eprintln!("Authentication is disabled on this server; skipping login.\n");
     } else if prompt_confirm("Log in now?", true)? {
         eprintln!();
@@ -44,8 +44,4 @@ pub fn run(url_override: Option<&str>) -> Result<()> {
     eprintln!();
     output::print_success("You're all set! Run 'gestalt --help' to see available commands.");
     Ok(())
-}
-
-fn server_auth_disabled(url: &str) -> bool {
-    matches!(api::fetch_auth_info(url), Ok(info) if !info.login_supported)
 }

--- a/gestalt/cli/tests/integration.rs
+++ b/gestalt/cli/tests/integration.rs
@@ -716,6 +716,37 @@ fn test_init_skips_login_when_server_auth_is_disabled() {
 }
 
 #[test]
+fn test_auth_status_reports_auth_disabled_before_stored_credentials() {
+    let mut server = Server::new();
+    let _auth_info = json_mock!(server, Method::GET, "/api/v1/auth/info", StatusCode::OK)
+        .with_body(r#"{"login_supported":false}"#)
+        .create();
+
+    let home = tempfile::tempdir().unwrap();
+    write_credentials(
+        home.path(),
+        serde_json::json!({
+            "api_url": server.url(),
+            "api_token": TEST_TOKEN,
+            "api_token_id": "tok-123",
+        }),
+    );
+
+    cli_command(home.path())
+        .arg("--url")
+        .arg(server.url())
+        .args(["auth", "status"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Authentication is disabled on this server.",
+        ))
+        .stderr(predicate::str::contains(
+            "Stored CLI credentials are present. Run 'gestalt auth logout' to clear them.",
+        ));
+}
+
+#[test]
 fn test_connect_includes_connection_and_instance() {
     let mut server = Server::new();
     let _integrations =


### PR DESCRIPTION
## Summary
- reuse shared CLI auth capability detection in `auth status`
- report `Authentication is disabled on this server.` before local credential state
- remove duplicated auth-disabled probing from `init` by using shared API plumbing

## Why
`gestalt auth status` was only checking whether an env var or credentials file existed. On a local server with `login_supported: false`, that produced misleading output like `Stored CLI credentials are present.` even though browser login was unavailable.

## Testing
- `cargo test -p gestalt`
- `cargo clippy -p gestalt --all-targets -- -D warnings`
- `cargo fmt --all -- --check`