### PR TITLE
Document session_ttl for Google auth provider

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -80,9 +80,10 @@ auth:
     redirect_url: https://gestalt.example.com/api/v1/auth/login/callback
     allowed_domains:
       - example.com
+    session_ttl: 24h
 ```
 
-`client_id` and `client_secret` are both required and identify your Google OAuth application. `redirect_url` defaults to a path derived from `server.base_url` when omitted. `allowed_domains` restricts login to specific email domains.
+`client_id` and `client_secret` are both required and identify your Google OAuth application. `redirect_url` defaults to a path derived from `server.base_url` when omitted. `allowed_domains` restricts login to specific email domains. `session_ttl` controls session token lifetime and defaults to `24h`.
 
 Google checks `email_verified` on every login. Unverified accounts are rejected.
 


### PR DESCRIPTION
The Google auth provider supports session_ttl but it was missing from the config reference example and prose. The OIDC section already documented it.