### PR TITLE
[codex] Run Dependabot daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,62 +3,62 @@ updates:
   - package-ecosystem: docker
     directory: /gestaltd
     schedule:
-      interval: weekly
+      interval: daily
     commit-message:
       prefix: build
 
   - package-ecosystem: docker
     directory: /gestalt
     schedule:
-      interval: weekly
+      interval: daily
     commit-message:
       prefix: build
 
   - package-ecosystem: docker
     directory: /docs
     schedule:
-      interval: weekly
+      interval: daily
     commit-message:
       prefix: build
 
   - package-ecosystem: cargo
     directory: /gestalt
     schedule:
-      interval: weekly
+      interval: daily
     commit-message:
       prefix: build
 
   - package-ecosystem: gomod
     directory: /gestaltd
     schedule:
-      interval: weekly
+      interval: daily
     commit-message:
       prefix: build
 
   - package-ecosystem: gomod
     directory: /sdk/go
     schedule:
-      interval: weekly
+      interval: daily
     commit-message:
       prefix: build
 
   - package-ecosystem: npm
     directory: /gestaltd/ui
     schedule:
-      interval: weekly
+      interval: daily
     commit-message:
       prefix: build
 
   - package-ecosystem: npm
     directory: /docs
     schedule:
-      interval: weekly
+      interval: daily
     commit-message:
       prefix: build
 
   - package-ecosystem: pip
     directory: /sdk/python
     schedule:
-      interval: weekly
+      interval: daily
     commit-message:
       prefix: build


### PR DESCRIPTION
## Summary
Change Dependabot schedules from weekly to daily for the repository's existing update entries.

## What changed
- switch all current Dependabot `schedule.interval` values in `.github/dependabot.yml` from `weekly` to `daily`
- leave the existing ecosystems, directories, and commit-message prefixes unchanged

## Why
The repository already has Dependabot coverage configured, but it only checks for updates weekly. This change increases update frequency without changing the scope of what Dependabot manages.

## Validation
- parsed `.github/dependabot.yml` with Ruby YAML
- ran `git diff --check`
