### PR TITLE
Make server connectivity state explicit across the CLI

### DIFF
--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -99,9 +99,7 @@ fn find_configured_url(url_override: Option<&str>) -> Result<Option<String>> {
     Ok(find_configured_url_with_source(url_override)?.map(|(url, _)| url))
 }
 
-fn find_configured_url_with_source(
-    url_override: Option<&str>,
-) -> Result<Option<(String, String)>> {
+fn find_configured_url_with_source(url_override: Option<&str>) -> Result<Option<(String, String)>> {
     if let Some(url) = url_override {
         return Ok(Some((normalize_url(url), "--url flag".to_string())));
     }

--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -13,6 +13,7 @@ use crate::http;
 
 pub const DEFAULT_URL: &str = "http://localhost:8080";
 pub const ENV_API_KEY: &str = "GESTALT_API_KEY";
+pub const ENV_URL: &str = "GESTALT_URL";
 pub const PROJECT_CONFIG_DIR: &str = ".gestalt";
 pub const PROJECT_CONFIG_FILE: &str = ".gestalt/config.json";
 pub const AUTH_INFO_PATH: &str = "/api/v1/auth/info";
@@ -104,12 +105,12 @@ fn find_configured_url_with_source(
     if let Some(url) = url_override {
         return Ok(Some((normalize_url(url), "--url flag".to_string())));
     }
-    if let Ok(url) = std::env::var("GESTALT_URL")
+    if let Ok(url) = std::env::var(ENV_URL)
         && !url.trim().is_empty()
     {
         return Ok(Some((
             normalize_url(&url),
-            "GESTALT_URL environment variable".to_string(),
+            format!("{ENV_URL} environment variable"),
         )));
     }
     if let Some((url, path)) = find_project_config_value("url")? {
@@ -138,7 +139,8 @@ pub fn describe_server_config(url_override: Option<&str>) -> Option<(String, Str
 fn bail_no_url_configured() -> Result<String> {
     let config_store = ConfigStore::new()?;
     bail!(
-        "no URL configured: use --url, GESTALT_URL, {}, or the user-local config file at {}",
+        "no URL configured: use --url, {}, {}, or the user-local config file at {}",
+        ENV_URL,
         PROJECT_CONFIG_FILE,
         config_store.path().display()
     )

--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -5,7 +5,7 @@ use reqwest::blocking::Client;
 use reqwest::header::{self, HeaderValue};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::config::ConfigStore;
 use crate::credentials::CredentialStore;
@@ -95,20 +95,44 @@ pub fn server_auth_disabled(base_url: &str) -> Result<bool> {
 }
 
 fn find_configured_url(url_override: Option<&str>) -> Result<Option<String>> {
+    Ok(find_configured_url_with_source(url_override)?.map(|(url, _)| url))
+}
+
+fn find_configured_url_with_source(
+    url_override: Option<&str>,
+) -> Result<Option<(String, String)>> {
     if let Some(url) = url_override {
-        return Ok(Some(normalize_url(url)));
+        return Ok(Some((normalize_url(url), "--url flag".to_string())));
     }
     if let Ok(url) = std::env::var("GESTALT_URL")
         && !url.trim().is_empty()
     {
-        return Ok(Some(normalize_url(&url)));
+        return Ok(Some((
+            normalize_url(&url),
+            "GESTALT_URL environment variable".to_string(),
+        )));
     }
-    if let Some(url) = find_project_config_value("url")? {
-        return Ok(Some(normalize_url(&url)));
+    if let Some((url, path)) = find_project_config_value("url")? {
+        return Ok(Some((
+            normalize_url(&url),
+            format!("project config ({})", path.display()),
+        )));
     }
 
     let config_store = ConfigStore::new()?;
-    Ok(config_store.get("url")?.map(|url| normalize_url(&url)))
+    match config_store.get("url")? {
+        Some(url) => Ok(Some((
+            normalize_url(&url),
+            format!("global config ({})", config_store.path().display()),
+        ))),
+        None => Ok(None),
+    }
+}
+
+/// Returns the configured server URL and a human-readable description of its source,
+/// or `None` if no URL is configured. Never fails — config parse errors are ignored.
+pub fn describe_server_config(url_override: Option<&str>) -> Option<(String, String)> {
+    find_configured_url_with_source(url_override).ok().flatten()
 }
 
 fn bail_no_url_configured() -> Result<String> {
@@ -120,12 +144,12 @@ fn bail_no_url_configured() -> Result<String> {
     )
 }
 
-fn find_project_config_value(key: &str) -> Result<Option<String>> {
+fn find_project_config_value(key: &str) -> Result<Option<(String, PathBuf)>> {
     let mut dir = std::env::current_dir().context("failed to determine current directory")?;
     loop {
         let candidate = dir.join(PROJECT_CONFIG_FILE);
         if let Some(value) = read_project_config_value(&candidate, key)? {
-            return Ok(Some(value));
+            return Ok(Some((value, candidate)));
         }
         if !dir.pop() {
             return Ok(None);
@@ -275,7 +299,7 @@ impl ApiClient {
             )
             .body(encoded)
             .send()
-            .with_context(|| format!("request to {} failed", url))?;
+            .map_err(|e| self.wrap_send_error(e, &url))?;
         self.handle_text_response(resp)
     }
 
@@ -294,10 +318,20 @@ impl ApiClient {
             Some(body) => request.json(body),
             None => request,
         };
-        let resp = request
-            .send()
-            .with_context(|| format!("request to {} failed", url))?;
+        let resp = request.send().map_err(|e| self.wrap_send_error(e, &url))?;
         self.handle_response(resp)
+    }
+
+    fn wrap_send_error(&self, err: reqwest::Error, url: &str) -> anyhow::Error {
+        if err.is_connect() || err.is_timeout() {
+            anyhow::anyhow!(
+                "could not reach server at {}\n  \
+                 Run 'gestalt auth status' for diagnostics.",
+                self.base_url
+            )
+        } else {
+            anyhow::anyhow!(err).context(format!("request to {} failed", url))
+        }
     }
 
     fn handle_response(&self, resp: reqwest::blocking::Response) -> Result<serde_json::Value> {

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -9,7 +9,7 @@ use crate::params;
 #[command(version)]
 pub struct Cli {
     #[command(subcommand)]
-    pub command: Commands,
+    pub command: Option<Commands>,
 
     /// Output format
     #[arg(long, global = true, value_enum, default_value_t = Format::Table)]

--- a/gestalt/cli/src/commands/auth.rs
+++ b/gestalt/cli/src/commands/auth.rs
@@ -340,7 +340,10 @@ pub fn status(url_override: Option<&str>, format: Format) -> Result<()> {
 
             if server_config.is_none() {
                 eprintln!();
-                eprintln!("Run 'gestalt init' or set GESTALT_URL to configure a server.");
+                eprintln!(
+                    "Run 'gestalt init' or set {} to configure a server.",
+                    api::ENV_URL,
+                );
             } else if !configured {
                 eprintln!();
                 eprintln!(

--- a/gestalt/cli/src/commands/auth.rs
+++ b/gestalt/cli/src/commands/auth.rs
@@ -248,16 +248,19 @@ pub fn logout() -> Result<()> {
 }
 
 pub fn status(url_override: Option<&str>, format: Format) -> Result<()> {
+    let server_config = api::describe_server_config(url_override);
+    let server_reachable = server_config.as_ref().map(|(url, _)| {
+        api::fetch_auth_info(url)
+            .ok()
+            .map(|info| info.login_supported)
+    });
+
     let has_env_key = api::env_api_key_is_set();
     let (has_stored_credentials, stored_credentials_error) = match CredentialStore::new()?.load() {
         Ok(Some(_)) => (true, None),
         Ok(None) => (false, None),
         Err(err) => (false, Some(err.to_string())),
     };
-    let server_auth_disabled = api::resolve_url(url_override)
-        .ok()
-        .and_then(|url| api::server_auth_disabled(&url).ok())
-        .unwrap_or(false);
     let configured = has_env_key || has_stored_credentials;
 
     match format {
@@ -269,62 +272,79 @@ pub fn status(url_override: Option<&str>, format: Format) -> Result<()> {
             } else {
                 "none"
             };
+            let (server_url, url_source) = match &server_config {
+                Some((url, src)) => (serde_json::json!(url), serde_json::json!(src)),
+                None => (serde_json::json!(null), serde_json::json!(null)),
+            };
+            let (reachable, login_supported) = match server_reachable {
+                Some(Some(login)) => (serde_json::json!(true), serde_json::json!(login)),
+                Some(None) => (serde_json::json!(false), serde_json::json!(null)),
+                None => (serde_json::json!(null), serde_json::json!(null)),
+            };
             output::print_json(&serde_json::json!({
                 "authenticated": configured,
-                "login_supported": !server_auth_disabled,
+                "login_supported": login_supported,
                 "source": source,
                 "env_var_set": has_env_key,
                 "stored_credentials": has_stored_credentials,
+                "server_url": server_url,
+                "url_source": url_source,
+                "server_reachable": reachable,
             }));
         }
         Format::Table => {
-            if server_auth_disabled {
-                eprintln!("Authentication is disabled on this server.");
-                if has_env_key {
-                    output::print_warning(&format!(
-                        "{} is set, but browser login is unavailable on this server.",
-                        api::ENV_API_KEY,
-                    ));
-                } else if has_stored_credentials {
-                    output::print_warning(
-                        "Stored CLI credentials are present. Run 'gestalt auth logout' to clear them.",
-                    );
+            match &server_config {
+                Some((url, source)) => {
+                    eprintln!("Server:      {}", url);
+                    eprintln!("URL source:  {}", source);
+                    match server_reachable {
+                        Some(Some(login_supported)) => {
+                            eprintln!("Reachable:   yes");
+                            if login_supported {
+                                eprintln!("Auth:        login supported");
+                            } else {
+                                eprintln!("Auth:        disabled");
+                            }
+                        }
+                        _ => {
+                            eprintln!("Reachable:   no");
+                        }
+                    }
                 }
-                if let Some(err) = &stored_credentials_error {
-                    output::print_warning(&format!(
-                        "Stored CLI credentials could not be read: {}",
-                        err
-                    ));
+                None => {
+                    eprintln!("Server:      not configured");
                 }
-            } else if has_env_key {
-                eprintln!("Configured via {} environment variable.", api::ENV_API_KEY);
+            }
+
+            if has_env_key {
+                eprintln!("Credentials: {} set", api::ENV_API_KEY);
                 if has_stored_credentials {
                     output::print_warning(&format!(
                         "Stored CLI credentials also exist but are being ignored. \
-                         Unset {} to use it.",
+                         Unset {} to use them.",
                         api::ENV_API_KEY,
                     ));
                 }
-                if let Some(err) = &stored_credentials_error {
-                    output::print_warning(&format!(
-                        "Stored CLI credentials could not be read: {}",
-                        err
-                    ));
-                }
             } else if has_stored_credentials {
-                eprintln!("Stored CLI credentials are present.");
-            } else if let Some(err) = &stored_credentials_error {
+                eprintln!("Credentials: stored CLI token");
+            } else {
+                eprintln!("Credentials: none");
+            }
+
+            if let Some(err) = &stored_credentials_error {
                 output::print_warning(&format!(
                     "Stored CLI credentials could not be read: {}",
                     err
                 ));
+            }
+
+            if server_config.is_none() {
+                eprintln!();
+                eprintln!("Run 'gestalt init' or set GESTALT_URL to configure a server.");
+            } else if !configured {
+                eprintln!();
                 eprintln!(
-                    "Not configured. Run 'gestalt auth login' or set {}.",
-                    api::ENV_API_KEY
-                );
-            } else {
-                eprintln!(
-                    "Not configured. Run 'gestalt auth login' or set {}.",
+                    "Run 'gestalt auth login' or set {} to authenticate.",
                     api::ENV_API_KEY,
                 );
             }

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -1,5 +1,5 @@
-use clap::Parser;
-use gestalt::api::ApiClient;
+use clap::{CommandFactory, Parser};
+use gestalt::api::{self, ApiClient};
 use gestalt::cli::{
     AuthCommands, Cli, Commands, ConfigCommands, IntegrationCommands, TokenCommands,
 };
@@ -11,7 +11,12 @@ fn run() -> anyhow::Result<()> {
     let format = cli.format;
     let url = cli.url.as_deref();
 
-    match cli.command {
+    let command = match cli.command {
+        Some(cmd) => cmd,
+        None => return print_help_with_context(url),
+    };
+
+    match command {
         Commands::Auth { command } => match command {
             AuthCommands::Login => commands::auth::login(url),
             AuthCommands::Logout => commands::auth::logout(),
@@ -100,6 +105,21 @@ fn run() -> anyhow::Result<()> {
             }
         }
     }
+}
+
+fn print_help_with_context(url_override: Option<&str>) -> anyhow::Result<()> {
+    Cli::command().print_help()?;
+    eprintln!();
+    match api::describe_server_config(url_override) {
+        Some((server_url, source)) => {
+            eprintln!("Target server: {server_url}");
+            eprintln!("Config source: {source}");
+        }
+        None => {
+            eprintln!("Target server: not configured");
+        }
+    }
+    Ok(())
 }
 
 fn main() {

--- a/gestalt/cli/tests/integration.rs
+++ b/gestalt/cli/tests/integration.rs
@@ -451,6 +451,17 @@ fn test_error_response_nested_message() {
 }
 
 #[test]
+fn test_connection_error_shows_actionable_message() {
+    let client = gestalt::api::ApiClient::new("http://127.0.0.1:1", TEST_TOKEN).unwrap();
+    let err = client.get("/api/v1/tokens").unwrap_err().to_string();
+    assert!(
+        err.contains("could not reach server at http://127.0.0.1:1"),
+        "unexpected error: {err}"
+    );
+    assert!(err.contains("gestalt auth status"));
+}
+
+#[test]
 fn test_list_operations_formats_parameters() {
     let mut server = Server::new();
     let mock = authed_json_mock!(
@@ -738,12 +749,93 @@ fn test_auth_status_reports_auth_disabled_before_stored_credentials() {
         .args(["auth", "status"])
         .assert()
         .success()
-        .stderr(predicate::str::contains(
-            "Authentication is disabled on this server.",
-        ))
-        .stderr(predicate::str::contains(
-            "Stored CLI credentials are present. Run 'gestalt auth logout' to clear them.",
-        ));
+        .stderr(predicate::str::contains("Auth:        disabled"))
+        .stderr(predicate::str::contains("Credentials: stored CLI token"))
+        .stderr(predicate::str::contains("Reachable:   yes"))
+        .stderr(predicate::str::contains("URL source:  --url flag"));
+}
+
+#[test]
+fn test_auth_status_reports_unreachable_server() {
+    let home = tempfile::tempdir().unwrap();
+    write_credentials(
+        home.path(),
+        serde_json::json!({
+            "api_url": "http://127.0.0.1:1",
+            "api_token": TEST_TOKEN,
+            "api_token_id": "tok-123",
+        }),
+    );
+
+    cli_command(home.path())
+        .arg("--url")
+        .arg("http://127.0.0.1:1")
+        .args(["auth", "status"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Server:      http://127.0.0.1:1"))
+        .stderr(predicate::str::contains("Reachable:   no"))
+        .stderr(predicate::str::contains("Credentials: stored CLI token"));
+}
+
+#[test]
+fn test_auth_status_no_url_configured() {
+    let home = tempfile::tempdir().unwrap();
+
+    cli_command(home.path())
+        .args(["auth", "status"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Server:      not configured"))
+        .stderr(predicate::str::contains("Credentials: none"))
+        .stderr(predicate::str::contains("gestalt init"));
+}
+
+#[test]
+fn test_auth_status_json_includes_server_fields() {
+    let mut server = Server::new();
+    let _auth_info = json_mock!(server, Method::GET, "/api/v1/auth/info", StatusCode::OK)
+        .with_body(r#"{"login_supported":true}"#)
+        .create();
+
+    let home = tempfile::tempdir().unwrap();
+
+    let output = cli_command(home.path())
+        .arg("--url")
+        .arg(server.url())
+        .args(["auth", "status", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["server_reachable"], serde_json::json!(true));
+    assert_eq!(json["login_supported"], serde_json::json!(true));
+    assert_eq!(json["server_url"], serde_json::json!(server.url()));
+    assert_eq!(json["url_source"], serde_json::json!("--url flag"));
+    assert_eq!(json["authenticated"], serde_json::json!(false));
+}
+
+#[test]
+fn test_bare_command_shows_server_footer() {
+    let home = tempfile::tempdir().unwrap();
+
+    cli_command(home.path())
+        .arg("--url")
+        .arg("http://localhost:9999")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Target server: http://localhost:9999"))
+        .stderr(predicate::str::contains("Config source: --url flag"));
+}
+
+#[test]
+fn test_bare_command_shows_not_configured_when_no_url() {
+    let home = tempfile::tempdir().unwrap();
+
+    cli_command(home.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Target server: not configured"));
 }
 
 #[test]

--- a/gestalt/cli/tests/integration.rs
+++ b/gestalt/cli/tests/integration.rs
@@ -824,7 +824,9 @@ fn test_bare_command_shows_server_footer() {
         .arg("http://localhost:9999")
         .assert()
         .success()
-        .stderr(predicate::str::contains("Target server: http://localhost:9999"))
+        .stderr(predicate::str::contains(
+            "Target server: http://localhost:9999",
+        ))
         .stderr(predicate::str::contains("Config source: --url flag"));
 }
 


### PR DESCRIPTION
The CLI previously hid server connectivity state from users. `gestalt auth status` silently swallowed connection errors and fell back to showing only local credential state. Server-dependent commands failed with raw transport errors when the server was unreachable. Running bare `gestalt` gave no indication of which server was targeted.

This rewrites `auth status` to report structured connectivity state (server URL, config source, reachability, auth mode, credentials) and replaces the tangled if/else output logic with clean key-value lines. Connection errors in `ApiClient` now detect connect/timeout failures and point users to `gestalt auth status` for diagnostics. Bare `gestalt` with no subcommand shows a footer with the target server and where the config came from, using only local state with no network I/O.