### PR TITLE
[codex] build: replace #682 with a Firestore contention fix

### DIFF
--- a/gestaltd/go.mod
+++ b/gestaltd/go.mod
@@ -38,7 +38,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.42.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.42.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.65.0
 	go.opentelemetry.io/otel/metric v1.43.0
@@ -138,7 +138,7 @@ require (
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/log v0.19.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect

--- a/gestaltd/go.sum
+++ b/gestaltd/go.sum
@@ -281,10 +281,10 @@ go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.42.0 h1:MdK
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.42.0/go.mod h1:RolT8tWtfHcjajEH5wFIZ4Dgh5jpPdFXYV9pTAk/qjc=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.42.0 h1:H7O6RlGOMTizyl3R08Kn5pdM06bnH8oscSj7o11tmLA=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.42.0/go.mod h1:mBFWu/WOVDkWWsR7Tx7h6EpQB8wsv7P0Yrh0Pb7othc=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0 h1:THuZiwpQZuHPul65w4WcwEnkX2QIuMT+UFoOrygtoJw=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0/go.mod h1:J2pvYM5NGHofZ2/Ru6zw/TNWnEQp5crgyDeSrYpXkAw=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0 h1:zWWrB1U6nqhS/k6zYB74CjRpuiitRtLLi68VcgmOEto=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0/go.mod h1:2qXPNBX1OVRC0IwOnfo1ljoid+RD0QK3443EaqVlsOU=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 h1:88Y4s2C8oTui1LGM6bTWkw0ICGcOLCAI5l6zsD1j20k=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0/go.mod h1:Vl1/iaggsuRlrHf/hfPJPvVag77kKyvrLeD10kpMl+A=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 h1:RAE+JPfvEmvy+0LzyUA25/SGawPwIUbZ6u0Wug54sLc=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0/go.mod h1:AGmbycVGEsRx9mXMZ75CsOyhSP6MFIcj/6dnG+vhVjk=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.42.0 h1:uLXP+3mghfMf7XmV4PkGfFhFKuNWoCvvx5wP/wOXo0o=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.42.0/go.mod h1:v0Tj04armyT59mnURNUJf7RCKcKzq+lgJs6QSjHjaTc=
 go.opentelemetry.io/otel/exporters/prometheus v0.65.0 h1:jOveH/b4lU9HT7y+Gfamf18BqlOuz2PWEvs8yM7Q6XE=

--- a/gestaltd/internal/drivers/datastore/firestore/firestore.go
+++ b/gestaltd/internal/drivers/datastore/firestore/firestore.go
@@ -21,6 +21,9 @@ const (
 	usersByEmailCollection         = "users_by_email"
 	integrationTokenKeysCollection = "integration_token_keys"
 	apiTokensByHashCollection      = "api_tokens_by_hash"
+	findUserByEmailRetryAttempts   = 4
+	findUserByEmailRetryBackoff    = 25 * time.Millisecond
+	createUserRetryAttempts        = 3
 )
 
 type Store struct {
@@ -124,49 +127,58 @@ func (s *Store) FindOrCreateUser(ctx context.Context, email string) (*core.User,
 	lookupRef := s.client.Collection(usersByEmailCollection).Doc(email)
 	userRef := s.client.Collection(datastore.UsersCollection).Doc(id)
 
-	var created bool
-	err = s.client.RunTransaction(ctx, func(_ context.Context, tx *gcpfirestore.Transaction) error {
-		snap, err := tx.Get(lookupRef)
-		if err != nil && status.Code(err) != codes.NotFound {
-			return fmt.Errorf("checking email lookup: %w", err)
+	for attempt := 0; attempt < createUserRetryAttempts; attempt++ {
+		created := false
+		err = s.client.RunTransaction(ctx, func(_ context.Context, tx *gcpfirestore.Transaction) error {
+			snap, err := tx.Get(lookupRef)
+			if err != nil && status.Code(err) != codes.NotFound {
+				return fmt.Errorf("checking email lookup: %w", err)
+			}
+			if snap != nil && snap.Exists() {
+				created = false
+				return nil
+			}
+			if err := tx.Create(lookupRef, userLookupDoc{UserID: id}); err != nil {
+				return err
+			}
+			created = true
+			return tx.Create(userRef, doc)
+		})
+		if err == nil {
+			if !created {
+				user, err = s.findUserByEmail(ctx, email)
+				if err != nil {
+					return nil, fmt.Errorf("firestore: querying existing user: %w", err)
+				}
+				if user == nil {
+					return nil, fmt.Errorf("firestore: email lookup exists but user not found")
+				}
+				return user, nil
+			}
+
+			return &core.User{
+				ID:        id,
+				Email:     email,
+				CreatedAt: now,
+				UpdatedAt: now,
+			}, nil
 		}
-		if snap != nil && snap.Exists() {
-			created = false
-			return nil
-		}
-		if err := tx.Create(lookupRef, userLookupDoc{UserID: id}); err != nil {
-			return err
-		}
-		created = true
-		return tx.Create(userRef, doc)
-	})
-	if err != nil {
-		user, err2 := s.findUserByEmail(ctx, email)
+
+		user, err2 := s.waitForUserByEmail(ctx, email, findUserByEmailRetryAttempts)
 		if err2 != nil {
 			return nil, fmt.Errorf("firestore: re-querying user after conflict: %w", err2)
 		}
 		if user != nil {
 			return user, nil
 		}
-		return nil, fmt.Errorf("firestore: creating user: %w", err)
-	}
-	if !created {
-		user, err = s.findUserByEmail(ctx, email)
-		if err != nil {
-			return nil, fmt.Errorf("firestore: querying existing user: %w", err)
+		if !isRetryableCreateUserError(err) || attempt == createUserRetryAttempts-1 {
+			return nil, fmt.Errorf("firestore: creating user: %w", err)
 		}
-		if user == nil {
-			return nil, fmt.Errorf("firestore: email lookup exists but user not found")
+		if err := sleepWithContext(ctx, findUserByEmailRetryBackoff*time.Duration(attempt+1)); err != nil {
+			return nil, err
 		}
-		return user, nil
 	}
-
-	return &core.User{
-		ID:        id,
-		Email:     email,
-		CreatedAt: now,
-		UpdatedAt: now,
-	}, nil
+	return nil, fmt.Errorf("firestore: creating user: exhausted retries")
 }
 
 func (s *Store) findUserByEmail(ctx context.Context, email string) (*core.User, error) {
@@ -191,6 +203,38 @@ func (s *Store) findUserByEmail(ctx context.Context, email string) (*core.User, 
 		return nil, fmt.Errorf("firestore: getting user from email lookup: %w", err)
 	}
 	return user, nil
+}
+
+func (s *Store) waitForUserByEmail(ctx context.Context, email string, attempts int) (*core.User, error) {
+	for attempt := 0; attempt < attempts; attempt++ {
+		user, err := s.findUserByEmail(ctx, email)
+		if err != nil || user != nil {
+			return user, err
+		}
+		if attempt == attempts-1 {
+			break
+		}
+		if err := sleepWithContext(ctx, findUserByEmailRetryBackoff*time.Duration(attempt+1)); err != nil {
+			return nil, err
+		}
+	}
+	return nil, nil
+}
+
+func isRetryableCreateUserError(err error) bool {
+	return status.Code(err) == codes.Aborted
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func snapToUser(snap *gcpfirestore.DocumentSnapshot) (*core.User, error) {


### PR DESCRIPTION
Replaces #682.

The `otlptracegrpc` bump itself is not the blocker here. #682 fails in CI because touching `gestaltd/go.mod` triggers the datastore integration workflow, and the Firestore job flakes in `FindOrCreateUserRace` with `rpc error: code = Aborted desc = Transaction lock timeout`.

This branch keeps the dependency bump to `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.43.0` and hardens Firestore `FindOrCreateUser` to:
- retry aborted transaction contention
- re-query for the winning user with short backoff before failing

Validation:
- `cd gestaltd && go test ./internal/drivers/datastore/firestore`