### PR TITLE
[codex] build: replace #684 with pip retry hardening

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -19,7 +19,7 @@
         "@types/node": "25.5.2",
         "@types/react": "^19.2.14",
         "pagefind": "^1.3.2",
-        "typescript": "5.9.3"
+        "typescript": "6.0.2"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -1406,6 +1406,19 @@
       },
       "peerDependencies": {
         "typescript": ">=5.5.0"
+      }
+    },
+    "node_modules/@shikijs/twoslash/node_modules/twoslash": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/twoslash/-/twoslash-0.3.6.tgz",
+      "integrity": "sha512-VuI5OKl+MaUO9UIW3rXKoPgHI3X40ZgB/j12VY6h98Ae1mCBihjPvhOPeJWlxCYcmSbmeZt5ZKkK0dsVtp+6pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript/vfs": "^1.6.2",
+        "twoslash-protocol": "0.3.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5.5.0"
       }
     },
     "node_modules/@shikijs/types": {
@@ -6269,19 +6282,6 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
-    "node_modules/twoslash": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/twoslash/-/twoslash-0.3.6.tgz",
-      "integrity": "sha512-VuI5OKl+MaUO9UIW3rXKoPgHI3X40ZgB/j12VY6h98Ae1mCBihjPvhOPeJWlxCYcmSbmeZt5ZKkK0dsVtp+6pA==",
-      "license": "MIT",
-      "dependencies": {
-        "@typescript/vfs": "^1.6.2",
-        "twoslash-protocol": "0.3.6"
-      },
-      "peerDependencies": {
-        "typescript": "^5.5.0"
-      }
-    },
     "node_modules/twoslash-protocol": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/twoslash-protocol/-/twoslash-protocol-0.3.6.tgz",
@@ -6289,9 +6289,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,8 +19,8 @@
   },
   "devDependencies": {
     "@types/node": "25.5.2",
-    "pagefind": "^1.3.2",
     "@types/react": "^19.2.14",
-    "typescript": "5.9.3"
+    "pagefind": "^1.3.2",
+    "typescript": "6.0.2"
   }
 }

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -613,6 +613,10 @@ func createLocalPythonSDKVenv(t *testing.T, pythonPath, venvPath, sdkPath string
 		"pip",
 		"install",
 		"--disable-pip-version-check",
+		"--retries",
+		"5",
+		"--timeout",
+		"120",
 		"--quiet",
 		sdkPath,
 	)


### PR DESCRIPTION
Replaces #684.

The TypeScript 6 bump in `docs` is not what breaks CI here. #684 fails in the Go test `TestLoadForExecutionAtPath_GeneratesStaticCatalogForLocalPythonSourcePlugin`, where `pip install` of the local Python SDK times out against `files.pythonhosted.org`.

This branch keeps the docs TypeScript bump to `6.0.2` and hardens the flaky test by adding pip retry and timeout flags:
- `--retries 5`
- `--timeout 120`

Validation:
- `cd docs && npm run build`
- `cd gestaltd && go test ./internal/operator -run TestLoadForExecutionAtPath_GeneratesStaticCatalogForLocalPythonSourcePlugin -count=1`