### PR TITLE
Add declarative auto-pagination to plugin manifests

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -911,6 +911,7 @@ func loadConfiguredAPIDefinition(ctx context.Context, name string, resolved reso
 	if cfg.applyResponseMapping {
 		applyProviderResponseMapping(def, cfg.manifestProvider, cfg.plugin)
 	}
+	applyProviderPagination(def, cfg.manifestProvider, cfg.plugin, cfg.allowedOperations)
 	meta.applyToDefinition(def)
 	return def, nil
 }
@@ -1458,6 +1459,68 @@ func applyProviderResponseMapping(def *provider.Definition, manifestProvider *pl
 		}
 	}
 	def.ResponseMapping = rm
+}
+
+func applyProviderPagination(def *provider.Definition, manifestProvider *pluginmanifestv1.Provider, plugin *config.PluginDef, allowedOperations map[string]*config.OperationOverride) {
+	providerPgn := config.MergedProviderPagination(manifestProvider, plugin)
+
+	for opName, override := range allowedOperations {
+		if override == nil || !override.Paginate {
+			continue
+		}
+
+		pgn := mergedPaginationConfig(providerPgn, override.Pagination)
+		if pgn == nil {
+			continue
+		}
+
+		op := def.Operations[opName]
+		op.Pagination = &provider.PaginationDef{
+			Style:        pgn.Style,
+			CursorParam:  pgn.CursorParam,
+			CursorPath:   pgn.CursorPath,
+			LimitParam:   pgn.LimitParam,
+			DefaultLimit: pgn.DefaultLimit,
+			ResultsPath:  pgn.ResultsPath,
+			MaxPages:     pgn.MaxPages,
+		}
+		def.Operations[opName] = op
+	}
+}
+
+func mergedPaginationConfig(base, override *pluginmanifestv1.ManifestPaginationConfig) *pluginmanifestv1.ManifestPaginationConfig {
+	if base == nil && override == nil {
+		return nil
+	}
+	if base == nil {
+		return override
+	}
+	if override == nil {
+		return base
+	}
+	merged := *base
+	if override.Style != "" {
+		merged.Style = override.Style
+	}
+	if override.CursorParam != "" {
+		merged.CursorParam = override.CursorParam
+	}
+	if override.CursorPath != "" {
+		merged.CursorPath = override.CursorPath
+	}
+	if override.LimitParam != "" {
+		merged.LimitParam = override.LimitParam
+	}
+	if override.DefaultLimit != 0 {
+		merged.DefaultLimit = override.DefaultLimit
+	}
+	if override.ResultsPath != "" {
+		merged.ResultsPath = override.ResultsPath
+	}
+	if override.MaxPages != 0 {
+		merged.MaxPages = override.MaxPages
+	}
+	return &merged
 }
 
 func lazyRefreshers(ready <-chan struct{}, resolver func() map[string]map[string]OAuthHandler) invocation.RefresherResolver {

--- a/gestaltd/internal/bootstrap/inline_gaps_test.go
+++ b/gestaltd/internal/bootstrap/inline_gaps_test.go
@@ -744,6 +744,91 @@ func TestInlineResponseMapping(t *testing.T) {
 	}
 }
 
+func TestInlinePagination(t *testing.T) {
+	t.Parallel()
+
+	pageCount := 0
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/openapi.json":
+			writeTestJSON(w, map[string]any{
+				"openapi": "3.0.0",
+				"info":    map[string]string{"title": "Paginated API"},
+				"servers": []any{map[string]string{"url": "http://" + r.Host}},
+				"paths": map[string]any{
+					"/items": map[string]any{
+						"get": map[string]any{
+							"operationId": "list_items",
+							"summary":     "List items",
+						},
+					},
+					"/items/{id}": map[string]any{
+						"get": map[string]any{
+							"operationId": "get_item",
+							"summary":     "Get item",
+						},
+					},
+				},
+			})
+		case "/items":
+			pageCount++
+			cursor := r.URL.Query().Get("cursor")
+			switch cursor {
+			case "":
+				writeTestJSON(w, map[string]any{
+					"data":       []string{"a", "b"},
+					"nextCursor": "page2",
+				})
+			case "page2":
+				writeTestJSON(w, map[string]any{
+					"data":       []string{"c"},
+					"nextCursor": nil,
+				})
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	testutil.CloseOnCleanup(t, apiSrv)
+
+	prov := bootstrapInlineProvider(t, "paginated", &config.PluginDef{
+		OpenAPI: apiSrv.URL + "/openapi.json",
+		Auth:    &config.ConnectionAuthDef{Type: "none"},
+		Pagination: &config.PaginationConfigDef{
+			Style:       "cursor",
+			CursorParam: "cursor",
+			CursorPath:  "nextCursor",
+			ResultsPath: "data",
+			LimitParam:  "limit",
+		},
+		AllowedOperations: map[string]*config.OperationOverride{
+			"list_items": {Paginate: true},
+			"get_item":   {},
+		},
+	})
+
+	ctx := context.Background()
+
+	result, err := prov.Execute(ctx, "list_items", nil, "")
+	if err != nil {
+		t.Fatalf("Execute list_items: %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", result.Status, result.Body)
+	}
+
+	var items []string
+	if err := json.Unmarshal([]byte(result.Body), &items); err != nil {
+		t.Fatalf("unmarshal: %v (body = %s)", err, result.Body)
+	}
+	if len(items) != 3 {
+		t.Fatalf("got %d items %v, want 3 (auto-pagination should combine pages)", len(items), items)
+	}
+	if pageCount != 2 {
+		t.Fatalf("expected 2 page fetches, got %d", pageCount)
+	}
+}
+
 func TestInlineOpenAPI_NamedConnectionAuthMapping(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -126,6 +126,7 @@ type PluginDef struct {
 	Connections     map[string]*ConnectionDef `yaml:"connections"`
 	Operations      []InlineOperationDef      `yaml:"operations"`
 	ResponseMapping *ResponseMappingDef       `yaml:"response_mapping"`
+	Pagination      *PaginationConfigDef      `yaml:"pagination"`
 
 	OpenAPIConnection string `yaml:"openapi_connection"`
 	GraphQLConnection string `yaml:"graphql_connection"`
@@ -222,6 +223,7 @@ type ManagedParameterDef = pluginmanifestv1.ManagedParameter
 
 type ResponseMappingDef = pluginmanifestv1.ManifestResponseMapping
 type PaginationMapping = pluginmanifestv1.ManifestPaginationMapping
+type PaginationConfigDef = pluginmanifestv1.ManifestPaginationConfig
 
 type SecretsConfig struct {
 	Provider string    `yaml:"provider"`

--- a/gestaltd/internal/config/effective_manifest.go
+++ b/gestaltd/internal/config/effective_manifest.go
@@ -90,6 +90,16 @@ func MergedProviderResponseMapping(manifestProvider *pluginmanifestv1.Provider, 
 	return manifestProvider.ResponseMapping
 }
 
+func MergedProviderPagination(manifestProvider *pluginmanifestv1.Provider, plugin *PluginDef) *pluginmanifestv1.ManifestPaginationConfig {
+	if plugin != nil && plugin.Pagination != nil {
+		return plugin.Pagination
+	}
+	if manifestProvider == nil {
+		return nil
+	}
+	return manifestProvider.Pagination
+}
+
 func mergedManifestProviderAuth(base *pluginmanifestv1.ProviderAuth, override *ConnectionAuthDef) *pluginmanifestv1.ProviderAuth {
 	if base == nil && override == nil {
 		return nil
@@ -137,7 +147,8 @@ func mergeManifestProviderRuntimeConfig(manifest *pluginmanifestv1.Manifest, plu
 		len(plugin.ManagedParameters) == 0 &&
 		plugin.Auth == nil &&
 		plugin.ConnectionParams == nil &&
-		plugin.ResponseMapping == nil {
+		plugin.ResponseMapping == nil &&
+		plugin.Pagination == nil {
 		return manifest
 	}
 
@@ -149,6 +160,7 @@ func mergeManifestProviderRuntimeConfig(manifest *pluginmanifestv1.Manifest, plu
 	providerCopy.ManagedParameters = MergedProviderManagedParameters(provider, plugin)
 	providerCopy.ConnectionParams = mergedProviderConnectionParams(provider, plugin)
 	providerCopy.ResponseMapping = MergedProviderResponseMapping(provider, plugin)
+	providerCopy.Pagination = MergedProviderPagination(provider, plugin)
 	if plugin.Auth != nil {
 		providerCopy.Auth = mergedManifestProviderAuth(provider.Auth, plugin.Auth)
 	}

--- a/gestaltd/internal/config/inline_manifest.go
+++ b/gestaltd/internal/config/inline_manifest.go
@@ -32,6 +32,7 @@ func InlineToManifest(name string, p *PluginDef) (*pluginmanifestv1.Manifest, er
 			PostConnectDiscovery: p.PostConnectDiscovery,
 			Operations:           cloneInlineOperations(p.Operations),
 			ResponseMapping:      p.ResponseMapping,
+			Pagination:           p.Pagination,
 			ConnectionParams:     maps.Clone(p.ConnectionParams),
 			AllowedOperations:    maps.Clone(p.AllowedOperations),
 		},

--- a/gestaltd/internal/config/provider_wire.go
+++ b/gestaltd/internal/config/provider_wire.go
@@ -19,6 +19,7 @@ type providerWire struct {
 	Headers           map[string]string                  `yaml:"headers"`
 	ManagedParameters []ManagedParameterDef              `yaml:"managed_parameters"`
 	ResponseMapping   *ResponseMappingDef                `yaml:"response_mapping"`
+	Pagination        *PaginationConfigDef               `yaml:"pagination"`
 	AllowedOperations map[string]*OperationOverride      `yaml:"allowed_operations"`
 	Surfaces          providerSurfacesWire               `yaml:"surfaces"`
 	MCP               *providerMCPWire                   `yaml:"mcp"`
@@ -109,6 +110,7 @@ func (i *IntegrationDef) UnmarshalYAML(value *yaml.Node) error {
 		Headers:           wire.Headers,
 		ManagedParameters: wire.ManagedParameters,
 		ResponseMapping:   wire.ResponseMapping,
+		Pagination:        wire.Pagination,
 		AllowedOperations: wire.AllowedOperations,
 	}
 	if wire.MCP != nil {

--- a/gestaltd/internal/pluginpkg/manifest_wire.go
+++ b/gestaltd/internal/pluginpkg/manifest_wire.go
@@ -28,6 +28,7 @@ type providerManifestWire struct {
 	Headers           map[string]string                                      `json:"headers,omitempty" yaml:"headers,omitempty"`
 	ManagedParameters []pluginmanifestv1.ManagedParameter                    `json:"managed_parameters,omitempty" yaml:"managed_parameters,omitempty"`
 	ResponseMapping   *pluginmanifestv1.ManifestResponseMapping              `json:"response_mapping,omitempty" yaml:"response_mapping,omitempty"`
+	Pagination        *pluginmanifestv1.ManifestPaginationConfig             `json:"pagination,omitempty" yaml:"pagination,omitempty"`
 	AllowedOperations map[string]*pluginmanifestv1.ManifestOperationOverride `json:"allowed_operations,omitempty" yaml:"allowed_operations,omitempty"`
 	Surfaces          providerManifestSurfacesWire                           `json:"surfaces" yaml:"surfaces"`
 	MCP               *providerManifestMCPWire                               `json:"mcp,omitempty" yaml:"mcp,omitempty"`
@@ -135,6 +136,7 @@ func wireManifestToInternal(wire *manifestWire) *pluginmanifestv1.Manifest {
 			Headers:           wire.Provider.Headers,
 			ManagedParameters: wire.Provider.ManagedParameters,
 			ResponseMapping:   wire.Provider.ResponseMapping,
+			Pagination:        wire.Provider.Pagination,
 			AllowedOperations: wire.Provider.AllowedOperations,
 		}
 		if wire.Provider.MCP != nil {
@@ -226,6 +228,7 @@ func internalManifestToWire(manifest *pluginmanifestv1.Manifest) *manifestWire {
 		Headers:           manifest.Provider.Headers,
 		ManagedParameters: manifest.Provider.ManagedParameters,
 		ResponseMapping:   manifest.Provider.ResponseMapping,
+		Pagination:        manifest.Provider.Pagination,
 		AllowedOperations: manifest.Provider.AllowedOperations,
 		Surfaces:          providerManifestSurfacesWire{},
 	}

--- a/gestaltd/internal/pluginpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/pluginpkg/manifest_workflow_test.go
@@ -89,8 +89,15 @@ func TestManifestWorkflow_RoundTripsProviderPackagesAcrossDirectoryAndArchive(t 
 						CursorPath:  "next_cursor",
 					},
 				},
+				Pagination: &pluginmanifestv1.ManifestPaginationConfig{
+					Style:       "cursor",
+					CursorParam: "cursor",
+					CursorPath:  "nextCursor",
+					ResultsPath: "results",
+					MaxPages:    10,
+				},
 				AllowedOperations: map[string]*pluginmanifestv1.ManifestOperationOverride{
-					"tickets.list": {Alias: "list_tickets"},
+					"tickets.list": {Alias: "list_tickets", Paginate: true},
 				},
 				Connections: map[string]*providerManifestConnectionWire{
 					"default": {
@@ -142,8 +149,11 @@ func TestManifestWorkflow_RoundTripsProviderPackagesAcrossDirectoryAndArchive(t 
 		if dirManifest.Provider.MCPURL != "https://mcp.example.com/mcp" || dirManifest.Provider.MCPConnection != "mcp" {
 			t.Fatalf("unexpected mcp surface: %#v", dirManifest.Provider)
 		}
-		if got := dirManifest.Provider.AllowedOperations["tickets.list"]; got == nil || got.Alias != "list_tickets" {
+		if got := dirManifest.Provider.AllowedOperations["tickets.list"]; got == nil || got.Alias != "list_tickets" || !got.Paginate {
 			t.Fatalf("unexpected allowed operations: %#v", dirManifest.Provider.AllowedOperations)
+		}
+		if pgn := dirManifest.Provider.Pagination; pgn == nil || pgn.Style != "cursor" || pgn.CursorPath != "nextCursor" {
+			t.Fatalf("unexpected pagination config: %+v", dirManifest.Provider.Pagination)
 		}
 		if dirManifest.Provider.ResponseMapping == nil || dirManifest.Provider.ResponseMapping.DataPath != "items" {
 			t.Fatalf("unexpected response mapping: %#v", dirManifest.Provider.ResponseMapping)

--- a/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -91,6 +91,9 @@
         "response_mapping": {
           "$ref": "#/$defs/response_mapping"
         },
+        "pagination": {
+          "$ref": "#/$defs/pagination_config"
+        },
         "allowed_operations": {
           "type": "object",
           "additionalProperties": {
@@ -624,6 +627,43 @@
         }
       }
     },
+    "pagination_config": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "style"
+      ],
+      "properties": {
+        "style": {
+          "type": "string",
+          "enum": [
+            "cursor",
+            "offset",
+            "page"
+          ]
+        },
+        "cursor_param": {
+          "type": "string"
+        },
+        "cursor_path": {
+          "type": "string"
+        },
+        "limit_param": {
+          "type": "string"
+        },
+        "default_limit": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "results_path": {
+          "type": "string"
+        },
+        "max_pages": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
     "manifest_operation_override": {
       "type": "object",
       "additionalProperties": false,
@@ -633,6 +673,12 @@
         },
         "description": {
           "type": "string"
+        },
+        "paginate": {
+          "type": "boolean"
+        },
+        "pagination": {
+          "$ref": "#/$defs/pagination_config"
         }
       }
     },

--- a/gestaltd/sdk/pluginmanifest/v1/types.go
+++ b/gestaltd/sdk/pluginmanifest/v1/types.go
@@ -48,6 +48,7 @@ type Provider struct {
 	DefaultConnection string                                `json:"default_connection,omitempty" yaml:"default_connection,omitempty"`
 	Connections       map[string]*ManifestConnectionDef     `json:"connections,omitempty" yaml:"connections,omitempty"`
 	ResponseMapping   *ManifestResponseMapping              `json:"response_mapping,omitempty" yaml:"response_mapping,omitempty"`
+	Pagination        *ManifestPaginationConfig             `json:"pagination,omitempty" yaml:"pagination,omitempty"`
 }
 
 type ManifestResponseMapping struct {
@@ -93,9 +94,21 @@ func (m *Manifest) IsDeclarativeOnlyProvider() bool {
 	return m != nil && m.Provider != nil && m.Provider.IsManifestBacked() && m.Entrypoints.Provider == nil
 }
 
+type ManifestPaginationConfig struct {
+	Style        string `json:"style" yaml:"style"`
+	CursorParam  string `json:"cursor_param,omitempty" yaml:"cursor_param,omitempty"`
+	CursorPath   string `json:"cursor_path,omitempty" yaml:"cursor_path,omitempty"`
+	LimitParam   string `json:"limit_param,omitempty" yaml:"limit_param,omitempty"`
+	DefaultLimit int    `json:"default_limit,omitempty" yaml:"default_limit,omitempty"`
+	ResultsPath  string `json:"results_path,omitempty" yaml:"results_path,omitempty"`
+	MaxPages     int    `json:"max_pages,omitempty" yaml:"max_pages,omitempty"`
+}
+
 type ManifestOperationOverride struct {
-	Alias       string `json:"alias,omitempty" yaml:"alias,omitempty"`
-	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Alias       string                    `json:"alias,omitempty" yaml:"alias,omitempty"`
+	Description string                    `json:"description,omitempty" yaml:"description,omitempty"`
+	Paginate    bool                      `json:"paginate,omitempty" yaml:"paginate,omitempty"`
+	Pagination  *ManifestPaginationConfig `json:"pagination,omitempty" yaml:"pagination,omitempty"`
 }
 
 type ManifestConnectionDef struct {


### PR DESCRIPTION
## Summary

- Expose gestaltd's existing `DoPaginated` engine through the plugin manifest format, enabling OpenAPI-surface plugins to opt into server-side auto-pagination without custom code
- Provider-wide `pagination` config (style, cursor_param, cursor_path, limit_param, results_path, max_pages) avoids duplicating identical config across many list operations
- Per-operation `paginate: true` on `allowed_operations` entries opts individual operations in; per-operation `pagination` overrides allow selective field changes

Example plugin.yaml:
```yaml
provider:
  pagination:
    style: cursor
    cursor_param: cursor
    cursor_path: nextCursor
    limit_param: limit
    default_limit: 100
    results_path: results
  allowed_operations:
    candidate.list: { paginate: true }
    candidate.info: {}
```

## Test plan

- [x] Manifest wire round-trip test: pagination config survives YAML encode/decode through all layers
- [x] Bootstrap integration test: serves paginated mock API, verifies `DoPaginated` combines 2 pages into 3 items from single `Execute` call
- [x] All existing tests pass (pluginpkg, config, bootstrap, provider, integration, apiexec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)