### PR TITLE
Restore declarative integration provider support

### DIFF
--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -287,7 +287,7 @@ func writeReleaseManifestFile(stagingDir, manifestFile, manifestFormat string, m
 func releaseRequiresBuildTarget(manifest *pluginmanifestv1.Manifest, kind string) bool {
 	switch kind {
 	case pluginmanifestv1.KindProvider:
-		return manifestHasKind(manifest, kind) && manifest.Entrypoints.Provider == nil
+		return manifestHasKind(manifest, kind) && manifest.Entrypoints.Provider == nil && (manifest == nil || manifest.Provider == nil || !manifest.Provider.IsManifestBacked())
 	case pluginmanifestv1.KindAuth:
 		return manifestHasKind(manifest, kind) && manifest.Entrypoints.Auth == nil
 	case pluginmanifestv1.KindDatastore:
@@ -644,10 +644,12 @@ func copyReleasePackageFiles(manifest *pluginmanifestv1.Manifest, sourceDir, sta
 	if err := copyPath(manifest.IconFile, false); err != nil {
 		return err
 	}
-	if manifest.Provider != nil {
-		if err := copyPath(manifest.Provider.ConfigSchemaPath, false); err != nil {
+	for _, ref := range pluginpkg.LocalPackageReferences(manifest) {
+		if err := copyPath(ref.Path, false); err != nil {
 			return err
 		}
+	}
+	if manifest.Provider != nil {
 		if err := copyPath(pluginpkg.StaticCatalogFile, !pluginpkg.StaticCatalogRequired(manifest)); err != nil {
 			return err
 		}

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -131,7 +131,7 @@ func TestRun_PluginReleaseRejectsInvalidManifest(t *testing.T) {
 		wantError    string
 	}{
 		{
-			name: "legacy surfaces block is rejected",
+			name: "rest surface requires base_url",
 			manifestYAML: `
 source: github.com/testowner/plugins/invalid
 version: 0.0.1-alpha.1
@@ -140,12 +140,15 @@ kinds:
 provider:
   surfaces:
     rest:
-      base_url: https://api.example.com
+      operations:
+        - name: list_items
+          method: GET
+          path: /items
 `,
-			wantError: "field surfaces not found",
+			wantError: "provider.base_url is required",
 		},
 		{
-			name: "legacy exec block is rejected",
+			name: "exec block requires artifact path",
 			manifestYAML: `
 source: github.com/testowner/plugins/invalid
 version: 0.0.1-alpha.1
@@ -154,19 +157,7 @@ kinds:
 provider:
   exec: {}
 `,
-			wantError: "field exec not found",
-		},
-		{
-			name: "legacy mcp block is rejected",
-			manifestYAML: `
-source: github.com/testowner/plugins/invalid
-version: 0.0.1-alpha.1
-kinds:
-  - provider
-provider:
-  mcp: {}
-`,
-			wantError: "cannot unmarshal !!map into bool",
+			wantError: "provider entrypoint artifact path is required",
 		},
 	}
 
@@ -906,12 +897,17 @@ func TestRun_PluginReleasePreservesYAMLManifestFormatAndConnectionDefaults(t *te
 	if err != nil {
 		t.Fatalf("read released manifest: %v", err)
 	}
-	if !strings.Contains(string(manifestData), "mcp: true") || !strings.Contains(string(manifestData), "connection_params:") || !strings.Contains(string(manifestData), "connection_mode: identity") {
-		t.Fatalf("expected released manifest to preserve executable provider config, got: %s", manifestData)
-	}
-	for _, legacy := range []string{"enabled:", "\n  connections:", "\n  params:"} {
-		if strings.Contains(string(manifestData), legacy) {
-			t.Fatalf("expected released manifest to omit legacy compatibility fields %q, got: %s", legacy, manifestData)
+	for _, expected := range []string{
+		"exec:",
+		"connections:",
+		"default:",
+		"mode: identity",
+		"params:",
+		"mcp:",
+		"enabled: true",
+	} {
+		if !strings.Contains(string(manifestData), expected) {
+			t.Fatalf("expected released manifest to preserve provider wire field %q, got: %s", expected, manifestData)
 		}
 	}
 }

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -16,10 +16,14 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/core/crypto"
+	"github.com/valon-technologies/gestalt/server/internal/composite"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/graphql"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/mcpoauth"
+	"github.com/valon-technologies/gestalt/server/internal/mcpupstream"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
+	"github.com/valon-technologies/gestalt/server/internal/openapi"
 	"github.com/valon-technologies/gestalt/server/internal/operationexposure"
 	"github.com/valon-technologies/gestalt/server/internal/pluginhost"
 	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
@@ -742,16 +746,50 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 	if intg.Plugin == nil {
 		return nil, fmt.Errorf("integration %q has no plugin defined", name)
 	}
-	if intg.Plugin.ResolvedManifest == nil || intg.Plugin.ManifestProvider() == nil {
-		return nil, fmt.Errorf("integration %q must resolve to an executable plugin manifest", name)
-	}
 
 	meta := resolveProviderMetadata(intg)
 	pluginConfig, err := config.NodeToMap(intg.Plugin.Config)
 	if err != nil {
 		return nil, fmt.Errorf("decode plugin config for %q: %w", name, err)
 	}
-	return buildExecutablePluginProvider(ctx, name, intg, pluginConfig, meta, deps)
+
+	manifest := intg.Plugin.ResolvedManifest
+	manifestProvider := intg.Plugin.ManifestProvider()
+	if manifest == nil || manifestProvider == nil {
+		return nil, fmt.Errorf("integration %q must resolve to a provider manifest", name)
+	}
+
+	allowedOperations := intg.Plugin.AllowedOperations
+	if allowedOperations == nil {
+		allowedOperations = maps.Clone(manifestProvider.AllowedOperations)
+	}
+
+	switch {
+	case manifestProvider.IsSpecLoaded() && manifest.Entrypoints.Provider == nil:
+		return buildSpecLoadedProvider(ctx, name, intg, manifest, pluginConfig, meta, deps, allowedOperations)
+	case manifestProvider.IsDeclarative() && manifest.Entrypoints.Provider == nil:
+		plan, err := buildPluginConnectionPlan(intg.Plugin, manifestProvider)
+		if err != nil {
+			return nil, fmt.Errorf("build declarative provider %q: %w", name, err)
+		}
+		declarative, err := pluginhost.NewDeclarativeProvider(
+			manifest,
+			nil,
+			pluginhost.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
+			pluginhost.WithDeclarativeConnectionMode(plan.connectionMode()),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("create declarative provider %q: %w", name, err)
+		}
+		prov, err := applyAllowedOperations(name, allowedOperations, declarative)
+		if err != nil {
+			closeIfPossible(declarative)
+			return nil, err
+		}
+		return newProviderBuildResult(name, intg, manifest, pluginConfig, prov, nil, deps)
+	default:
+		return buildExecutablePluginProvider(ctx, name, intg, pluginConfig, meta, deps)
+	}
 }
 
 func buildExecutablePluginProvider(ctx context.Context, name string, intg config.IntegrationDef, pluginConfig map[string]any, meta providerMetadata, deps Deps) (*ProviderBuildResult, error) {
@@ -768,27 +806,272 @@ func buildExecutablePluginProvider(ctx context.Context, name string, intg config
 	if err != nil {
 		return nil, err
 	}
+	plan, err := buildPluginConnectionPlan(intg.Plugin, manifestProvider)
+	if err != nil {
+		closeIfPossible(pluginProv)
+		return nil, fmt.Errorf("build executable plugin provider %q: %w", name, err)
+	}
 	allowedOperations := intg.Plugin.AllowedOperations
 	if allowedOperations == nil && manifestProvider != nil {
 		allowedOperations = maps.Clone(manifestProvider.AllowedOperations)
 	}
-	restricted, err := applyAllowedOperations(name, allowedOperations, pluginProv)
+
+	if manifestProvider.IsDeclarative() {
+		declarative, err := pluginhost.NewDeclarativeProvider(
+			manifest,
+			nil,
+			pluginhost.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
+			pluginhost.WithDeclarativeConnectionMode(plan.connectionMode()),
+		)
+		if err != nil {
+			closeIfPossible(pluginProv)
+			return nil, fmt.Errorf("create declarative provider %q: %w", name, err)
+		}
+		apiProv, err := applyAllowedOperations(name, allowedOperations, declarative)
+		if err != nil {
+			closeIfPossible(apiProv, pluginProv)
+			return nil, err
+		}
+		merged, err := composite.NewMergedWithConnections(
+			name,
+			pluginProv.DisplayName(),
+			pluginProv.Description(),
+			firstProviderIconSVG(pluginProv, apiProv),
+			composite.BoundProvider{Provider: pluginProv, Connection: config.PluginConnectionName},
+			composite.BoundProvider{Provider: apiProv, Connection: plan.apiConnection()},
+		)
+		if err != nil {
+			closeIfPossible(apiProv, pluginProv)
+			return nil, err
+		}
+		return newProviderBuildResult(name, intg, manifest, pluginConfig, merged, nil, deps)
+	}
+
+	resolved, hasSpecSurface := plan.configuredSpecSurface()
+	if !hasSpecSurface {
+		restricted, err := applyAllowedOperations(name, allowedOperations, pluginProv)
+		if err != nil {
+			closeIfPossible(pluginProv)
+			return nil, err
+		}
+		return newProviderBuildResult(name, intg, manifest, pluginConfig, restricted, nil, deps)
+	}
+
+	specProv, specDef, err := buildConfiguredSpecProvider(ctx, name, resolved, meta, specProviderConfig{
+		manifestProvider:     manifestProvider,
+		allowedOperations:    allowedOperations,
+		baseURL:              manifestProvider.BaseURL,
+		applyResponseMapping: true,
+		providerBuildOptions: func(conn config.ConnectionDef) []provider.BuildOption {
+			return mcpOAuthBuildOpts(conn, manifestProvider, deps)
+		},
+	}, deps)
 	if err != nil {
 		closeIfPossible(pluginProv)
+		return nil, fmt.Errorf("build hybrid spec provider %q: %w", name, err)
+	}
+	merged, err := composite.NewMergedWithConnections(
+		name,
+		pluginProv.DisplayName(),
+		pluginProv.Description(),
+		firstProviderIconSVG(pluginProv, specProv),
+		composite.BoundProvider{Provider: pluginProv, Connection: config.PluginConnectionName},
+		composite.BoundProvider{Provider: specProv, Connection: resolved.connectionName},
+	)
+	if err != nil {
+		closeIfPossible(specProv, pluginProv)
 		return nil, err
 	}
-	return newProviderBuildResult(name, intg, manifest, pluginConfig, restricted, deps)
+	var authFallback *specAuthFallback
+	if specDef != nil {
+		authFallback = &specAuthFallback{
+			definition:     specDef,
+			connectionName: resolved.connectionName,
+		}
+	}
+	return newProviderBuildResult(name, intg, manifest, pluginConfig, merged, authFallback, deps)
 }
 
-func newProviderBuildResult(name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, pluginConfig map[string]any, prov core.Provider, deps Deps) (*ProviderBuildResult, error) {
+type specProviderConfig struct {
+	manifestProvider     *pluginmanifestv1.Provider
+	allowedOperations    map[string]*config.OperationOverride
+	baseURL              string
+	providerBuildOptions func(config.ConnectionDef) []provider.BuildOption
+	applyResponseMapping bool
+}
+
+type specAuthFallback struct {
+	definition     *provider.Definition
+	connectionName string
+}
+
+func newProviderBuildResult(name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, pluginConfig map[string]any, prov core.Provider, authFallback *specAuthFallback, deps Deps) (*ProviderBuildResult, error) {
 	result := &ProviderBuildResult{Provider: prov}
 	var err error
-	result.ConnectionAuth, err = buildConnectionAuthMap(name, intg, manifest, pluginConfig, deps)
+	result.ConnectionAuth, err = buildConnectionAuthMap(name, intg, manifest, pluginConfig, authFallback, deps)
 	if err != nil {
 		closeIfPossible(prov)
 		return nil, err
 	}
 	return result, nil
+}
+
+func buildSpecLoadedProvider(ctx context.Context, name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, pluginConfig map[string]any, meta providerMetadata, deps Deps, allowedOperations map[string]*config.OperationOverride) (*ProviderBuildResult, error) {
+	mp := manifest.Provider
+	plan, err := buildPluginConnectionPlan(intg.Plugin, mp)
+	if err != nil {
+		return nil, fmt.Errorf("build spec-loaded provider %q: %w", name, err)
+	}
+	apiResolved, hasAPI := plan.configuredAPISurface()
+	mcpResolved, hasMCP := plan.resolvedSurface(config.SpecSurfaceMCP)
+	if !hasAPI && !hasMCP {
+		return nil, fmt.Errorf("build spec-loaded provider %q: no spec URL", name)
+	}
+
+	buildSpec := func(resolved resolvedSpecSurface, allowed map[string]*config.OperationOverride) (core.Provider, *provider.Definition, error) {
+		return buildConfiguredSpecProvider(ctx, name, resolved, meta, specProviderConfig{
+			manifestProvider:     mp,
+			allowedOperations:    allowed,
+			baseURL:              mp.BaseURL,
+			applyResponseMapping: true,
+			providerBuildOptions: func(conn config.ConnectionDef) []provider.BuildOption {
+				return mcpOAuthBuildOpts(conn, mp, deps)
+			},
+		}, deps)
+	}
+
+	if !hasAPI {
+		prov, _, err := buildSpec(mcpResolved, allowedOperations)
+		if err != nil {
+			return nil, fmt.Errorf("build spec-loaded provider %q: %w", name, err)
+		}
+		return newProviderBuildResult(name, intg, manifest, pluginConfig, prov, nil, deps)
+	}
+
+	apiProv, apiDef, err := buildSpec(apiResolved, allowedOperations)
+	if err != nil {
+		return nil, fmt.Errorf("build spec-loaded provider %q: %w", name, err)
+	}
+	authFallback := &specAuthFallback{
+		definition:     apiDef,
+		connectionName: apiResolved.connectionName,
+	}
+
+	if !hasMCP {
+		return newProviderBuildResult(name, intg, manifest, pluginConfig, apiProv, authFallback, deps)
+	}
+
+	mcpProv, _, err := buildSpec(mcpResolved, nil)
+	if err != nil {
+		closeIfPossible(apiProv)
+		return nil, fmt.Errorf("build spec-loaded provider %q: %w", name, err)
+	}
+	mcpUp, ok := mcpProv.(composite.MCPUpstream)
+	if !ok {
+		closeIfPossible(mcpProv, apiProv)
+		return nil, fmt.Errorf("build spec-loaded provider %q: unexpected mcp provider type %T", name, mcpProv)
+	}
+
+	filtered := matchingAllowedOperations(allowedOperations, mcpUp.Catalog())
+	if len(filtered) > 0 {
+		filterable, ok := any(mcpUp).(interface {
+			FilterOperations(map[string]*config.OperationOverride) error
+		})
+		if !ok {
+			closeIfPossible(mcpUp, apiProv)
+			return nil, fmt.Errorf("build spec-loaded provider %q: unexpected non-filterable mcp provider type %T", name, mcpProv)
+		}
+		if err := filterable.FilterOperations(filtered); err != nil {
+			closeIfPossible(mcpUp, apiProv)
+			return nil, fmt.Errorf("build spec-loaded provider %q: filter mcp operations: %w", name, err)
+		}
+	}
+
+	return newProviderBuildResult(name, intg, manifest, pluginConfig, composite.New(name, apiProv, mcpUp), authFallback, deps)
+}
+
+func loadConfiguredAPIDefinition(ctx context.Context, name string, resolved resolvedSpecSurface, meta providerMetadata, cfg specProviderConfig) (*provider.Definition, error) {
+	def, err := loadSpecDefinition(ctx, name, resolved, cfg.allowedOperations)
+	if err != nil {
+		return nil, fmt.Errorf("load %s definition: %w", resolved.surface, err)
+	}
+	if cfg.baseURL != "" {
+		def.BaseURL = cfg.baseURL
+	}
+	applyProviderHeaders(def, cfg.manifestProvider)
+	if err := applyManagedParameters(def, cfg.manifestProvider); err != nil {
+		return nil, err
+	}
+	if cfg.applyResponseMapping {
+		applyProviderResponseMapping(def, cfg.manifestProvider)
+	}
+	if meta.displayName != "" {
+		def.DisplayName = meta.displayName
+	}
+	if meta.description != "" {
+		def.Description = meta.description
+	}
+	if meta.iconSVG != "" {
+		def.IconSVG = meta.iconSVG
+	}
+	return def, nil
+}
+
+func buildConfiguredSpecProvider(ctx context.Context, name string, resolved resolvedSpecSurface, meta providerMetadata, cfg specProviderConfig, deps Deps) (core.Provider, *provider.Definition, error) {
+	var buildOpts []provider.BuildOption
+	if cfg.providerBuildOptions != nil {
+		buildOpts = cfg.providerBuildOptions(resolved.connection)
+	}
+
+	switch resolved.surface {
+	case config.SpecSurfaceOpenAPI, config.SpecSurfaceGraphQL:
+		def, err := loadConfiguredAPIDefinition(ctx, name, resolved, meta, cfg)
+		if err != nil {
+			return nil, nil, err
+		}
+		prov, err := provider.Build(def, resolved.connection, buildOpts...)
+		if err != nil {
+			return nil, nil, err
+		}
+		return prov, def, nil
+	case config.SpecSurfaceMCP:
+		connMode := core.ConnectionMode(resolved.connection.Mode)
+		if connMode == "" {
+			connMode = core.ConnectionModeUser
+		}
+		up, err := mcpupstream.New(
+			ctx,
+			name,
+			resolved.url,
+			connMode,
+			manifestHeaders(cfg.manifestProvider),
+			deps.Egress.Resolver,
+			mcpupstream.WithMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("create mcp upstream: %w", err)
+		}
+		if cfg.allowedOperations != nil {
+			if err := up.FilterOperations(cfg.allowedOperations); err != nil {
+				_ = up.Close()
+				return nil, nil, fmt.Errorf("filter mcp operations: %w", err)
+			}
+		}
+		return up, nil, nil
+	default:
+		return nil, nil, fmt.Errorf("unsupported spec surface %q", resolved.surface)
+	}
+}
+
+func loadSpecDefinition(ctx context.Context, name string, resolved resolvedSpecSurface, allowedOperations map[string]*config.OperationOverride) (*provider.Definition, error) {
+	switch resolved.surface {
+	case config.SpecSurfaceOpenAPI:
+		return openapi.LoadDefinition(ctx, name, resolved.url, allowedOperations)
+	case config.SpecSurfaceGraphQL:
+		return graphql.LoadDefinition(ctx, name, resolved.url, allowedOperations)
+	default:
+		return nil, fmt.Errorf("unsupported spec definition surface %q", resolved.surface)
+	}
 }
 
 func applyAllowedOperations(name string, allowedOperations map[string]*config.OperationOverride, pluginProv core.Provider) (core.Provider, error) {
@@ -945,6 +1228,141 @@ func staticAuthTypes(authType string) []string {
 	}
 }
 
+func mcpOAuthBuildOpts(conn config.ConnectionDef, manifestProvider *pluginmanifestv1.Provider, deps Deps) []provider.BuildOption {
+	if manifestProvider == nil || conn.Auth.Type != pluginmanifestv1.AuthTypeMCPOAuth || manifestProvider.MCPURL == "" {
+		return nil
+	}
+	return []provider.BuildOption{
+		provider.WithAuthHandler(buildMCPOAuthHandler(conn, manifestProvider.MCPURL, buildRegistrationStore(deps), deps)),
+	}
+}
+
+func manifestHeaders(manifestProvider *pluginmanifestv1.Provider) map[string]string {
+	if manifestProvider == nil || len(manifestProvider.Headers) == 0 {
+		return nil
+	}
+	return maps.Clone(manifestProvider.Headers)
+}
+
+func applyProviderHeaders(def *provider.Definition, manifestProvider *pluginmanifestv1.Provider) {
+	if def == nil {
+		return
+	}
+	headers := manifestHeaders(manifestProvider)
+	if len(headers) == 0 {
+		return
+	}
+	def.Headers = headers
+}
+
+func applyManagedParameters(def *provider.Definition, manifestProvider *pluginmanifestv1.Provider) error {
+	if def == nil || manifestProvider == nil || len(manifestProvider.ManagedParameters) == 0 {
+		return nil
+	}
+
+	if def.Headers == nil {
+		def.Headers = make(map[string]string)
+	}
+	for _, param := range manifestProvider.ManagedParameters {
+		location := strings.ToLower(strings.TrimSpace(param.In))
+		name := strings.TrimSpace(param.Name)
+		switch location {
+		case "header":
+			if _, exists := def.Headers[name]; exists {
+				return fmt.Errorf("managed parameter %q conflicts with configured header", name)
+			}
+			def.Headers[name] = param.Value
+		case "path":
+		default:
+			return fmt.Errorf("unsupported managed parameter location %q", param.In)
+		}
+	}
+
+	for opName, op := range def.Operations {
+		for _, param := range manifestProvider.ManagedParameters {
+			if strings.EqualFold(strings.TrimSpace(param.In), "path") {
+				op.Path = strings.ReplaceAll(op.Path, "{"+strings.TrimSpace(param.Name)+"}", param.Value)
+			}
+		}
+		filtered := op.Parameters[:0]
+		for _, param := range op.Parameters {
+			if isManagedOperationParameter(param, manifestProvider.ManagedParameters) {
+				continue
+			}
+			filtered = append(filtered, param)
+		}
+		op.Parameters = filtered
+		def.Operations[opName] = op
+	}
+	return nil
+}
+
+func isManagedOperationParameter(param provider.ParameterDef, managed []pluginmanifestv1.ManagedParameter) bool {
+	location := strings.ToLower(strings.TrimSpace(param.Location))
+	if location == "" {
+		return false
+	}
+	wireName := strings.TrimSpace(param.WireName)
+	if wireName == "" {
+		wireName = strings.TrimSpace(param.Name)
+	}
+	for _, managedParam := range managed {
+		if strings.ToLower(strings.TrimSpace(managedParam.In)) != location {
+			continue
+		}
+		if strings.TrimSpace(managedParam.Name) == wireName {
+			return true
+		}
+	}
+	return false
+}
+
+func applyProviderResponseMapping(def *provider.Definition, manifestProvider *pluginmanifestv1.Provider) {
+	if def == nil || manifestProvider == nil || manifestProvider.ResponseMapping == nil {
+		return
+	}
+	rm := &provider.ResponseMappingDef{
+		DataPath: manifestProvider.ResponseMapping.DataPath,
+	}
+	if manifestProvider.ResponseMapping.Pagination != nil {
+		rm.Pagination = &provider.PaginationMappingDef{
+			HasMorePath: manifestProvider.ResponseMapping.Pagination.HasMorePath,
+			CursorPath:  manifestProvider.ResponseMapping.Pagination.CursorPath,
+		}
+	}
+	def.ResponseMapping = rm
+}
+
+func firstProviderIconSVG(providers ...core.Provider) string {
+	for _, prov := range providers {
+		cat := prov.Catalog()
+		if cat != nil && cat.IconSVG != "" {
+			return cat.IconSVG
+		}
+	}
+	return ""
+}
+
+func matchingAllowedOperations(allowed map[string]*config.OperationOverride, cat *catalog.Catalog) map[string]*config.OperationOverride {
+	if len(allowed) == 0 || cat == nil || len(cat.Operations) == 0 {
+		return nil
+	}
+	available := make(map[string]struct{}, len(cat.Operations))
+	for i := range cat.Operations {
+		available[cat.Operations[i].ID] = struct{}{}
+	}
+	filtered := make(map[string]*config.OperationOverride)
+	for name, override := range allowed {
+		if _, ok := available[name]; ok {
+			filtered[name] = override
+		}
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
+}
+
 func buildOAuthHandlerFromAuth(auth *config.ConnectionAuthDef, pluginConfig map[string]any, deps Deps) (OAuthHandler, error) {
 	if auth == nil || auth.Type != "oauth2" {
 		return nil, nil
@@ -994,6 +1412,48 @@ func buildOAuthHandlerFromAuth(auth *config.ConnectionAuthDef, pluginConfig map[
 	}
 
 	return WrapUpstreamHandler(oauth.NewUpstream(oauthCfg)), nil
+}
+
+func buildOAuthHandlerFromDefinition(def *provider.Definition, conn config.ConnectionDef, pluginConfig map[string]any, deps Deps) (OAuthHandler, error) {
+	if def == nil || def.Auth.Type != "oauth2" {
+		return nil, nil
+	}
+
+	effectiveConn := conn
+	if id, _ := pluginConfig["client_id"].(string); id != "" {
+		effectiveConn.Auth.ClientID = id
+	}
+	if sec, _ := pluginConfig["client_secret"].(string); sec != "" {
+		effectiveConn.Auth.ClientSecret = sec
+	}
+	if effectiveConn.Auth.ClientID == "" || effectiveConn.Auth.ClientSecret == "" {
+		return nil, fmt.Errorf("client_id and client_secret are required for oauth2 auth")
+	}
+	if effectiveConn.Auth.RedirectURL == "" {
+		effectiveConn.Auth.RedirectURL = deps.BaseURL + config.IntegrationCallbackPath
+	}
+
+	defCopy := *def
+	provider.ApplyConnectionAuth(&defCopy, effectiveConn)
+	upstream, err := provider.BuildOAuthUpstream(&defCopy, effectiveConn, defCopy.BaseURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	return WrapUpstreamHandler(upstream), nil
+}
+
+func buildMCPOAuthHandler(conn config.ConnectionDef, mcpURL string, store mcpoauth.RegistrationStore, deps Deps) *mcpoauth.Handler {
+	redirectURL := conn.Auth.RedirectURL
+	if redirectURL == "" {
+		redirectURL = deps.BaseURL + config.IntegrationCallbackPath
+	}
+	return mcpoauth.NewHandler(mcpoauth.HandlerConfig{
+		MCPURL:       mcpURL,
+		Store:        store,
+		RedirectURL:  redirectURL,
+		ClientID:     conn.Auth.ClientID,
+		ClientSecret: conn.Auth.ClientSecret,
+	})
 }
 
 func lazyRefreshers(ready <-chan struct{}, resolver func() map[string]map[string]OAuthHandler) invocation.RefresherResolver {

--- a/gestaltd/internal/bootstrap/connections.go
+++ b/gestaltd/internal/bootstrap/connections.go
@@ -2,9 +2,12 @@ package bootstrap
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/provider"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
 
@@ -47,7 +50,15 @@ func BuildConnectionMaps(cfg *config.Config) (ConnectionMaps, error) {
 type pluginConnectionPlan struct {
 	pluginConnection  config.ConnectionDef
 	namedConnections  map[string]config.ConnectionDef
+	surfaces          map[config.SpecSurface]resolvedSpecSurface
 	defaultConnection string
+}
+
+type resolvedSpecSurface struct {
+	surface        config.SpecSurface
+	url            string
+	connectionName string
+	connection     config.ConnectionDef
 }
 
 func buildPluginConnectionPlan(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider) (pluginConnectionPlan, error) {
@@ -55,6 +66,7 @@ func buildPluginConnectionPlan(plugin *config.PluginDef, manifestProvider *plugi
 	plan := pluginConnectionPlan{
 		pluginConnection: config.EffectivePluginConnectionDef(plugin, manifestProvider),
 		namedConnections: make(map[string]config.ConnectionDef),
+		surfaces:         make(map[config.SpecSurface]resolvedSpecSurface),
 	}
 
 	for name := range declaredNames {
@@ -63,6 +75,24 @@ func buildPluginConnectionPlan(plugin *config.PluginDef, manifestProvider *plugi
 			continue
 		}
 		plan.namedConnections[name] = conn
+	}
+
+	for _, surface := range config.OrderedSpecSurfaces {
+		url := surfaceURL(plugin, manifestProvider, surface)
+		if url == "" {
+			continue
+		}
+		resolved := resolvedSpecSurface{
+			surface:        surface,
+			url:            url,
+			connectionName: resolveSurfaceConnectionName(plugin, manifestProvider, surface),
+		}
+		conn, err := plan.connectionDef(resolved.connectionName)
+		if err != nil {
+			return pluginConnectionPlan{}, fmt.Errorf("%s references undeclared connection %q", surface.ConnectionField(), resolved.connectionName)
+		}
+		resolved.connection = conn
+		plan.surfaces[surface] = resolved
 	}
 
 	defaultConnection := resolveDefaultConnectionName(plugin, manifestProvider)
@@ -76,15 +106,42 @@ func buildPluginConnectionPlan(plugin *config.PluginDef, manifestProvider *plugi
 	return plan, nil
 }
 
+func (plan pluginConnectionPlan) configuredAPISurface() (resolvedSpecSurface, bool) {
+	for _, surface := range []config.SpecSurface{config.SpecSurfaceOpenAPI, config.SpecSurfaceGraphQL} {
+		if resolved, ok := plan.resolvedSurface(surface); ok {
+			return resolved, true
+		}
+	}
+	return resolvedSpecSurface{}, false
+}
+
+func (plan pluginConnectionPlan) configuredSpecSurface() (resolvedSpecSurface, bool) {
+	if resolved, ok := plan.configuredAPISurface(); ok {
+		return resolved, true
+	}
+	return plan.resolvedSurface(config.SpecSurfaceMCP)
+}
+
+func (plan pluginConnectionPlan) resolvedSurface(surface config.SpecSurface) (resolvedSpecSurface, bool) {
+	resolved, ok := plan.surfaces[surface]
+	return resolved, ok
+}
+
 func (plan pluginConnectionPlan) authDefaultConnection() string {
 	return plan.fallbackConnection()
 }
 
 func (plan pluginConnectionPlan) apiConnection() string {
+	if resolved, ok := plan.configuredAPISurface(); ok {
+		return resolved.connectionName
+	}
 	return plan.fallbackConnection()
 }
 
 func (plan pluginConnectionPlan) mcpConnection() string {
+	if resolved, ok := plan.resolvedSurface(config.SpecSurfaceMCP); ok {
+		return resolved.connectionName
+	}
 	return plan.fallbackConnection()
 }
 
@@ -168,7 +225,43 @@ func resolveDefaultConnectionName(plugin *config.PluginDef, manifestProvider *pl
 	return ""
 }
 
-func buildConnectionAuthMap(name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, pluginConfig map[string]any, deps Deps) (map[string]OAuthHandler, error) {
+func surfaceURL(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider, surface config.SpecSurface) string {
+	if manifestProvider == nil {
+		return ""
+	}
+	url := config.ManifestProviderSurfaceURL(manifestProvider, surface)
+	if url == "" {
+		return ""
+	}
+	return resolveManifestRelativeSpecURL(plugin, url)
+}
+
+func resolveSurfaceConnectionName(plugin *config.PluginDef, manifestProvider *pluginmanifestv1.Provider, surface config.SpecSurface) string {
+	name := config.ResolveConnectionAlias(config.ManifestProviderSurfaceConnectionName(manifestProvider, surface))
+	if name == "" {
+		return config.PluginConnectionName
+	}
+	return name
+}
+
+func resolveManifestRelativeSpecURL(plugin *config.PluginDef, raw string) string {
+	if plugin == nil || plugin.ResolvedManifestPath == "" || raw == "" {
+		return raw
+	}
+	if filepath.IsAbs(raw) || strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://") {
+		return raw
+	}
+	if strings.HasPrefix(raw, "file://") {
+		path := strings.TrimPrefix(raw, "file://")
+		if filepath.IsAbs(path) {
+			return raw
+		}
+		return "file://" + filepath.Clean(filepath.Join(filepath.Dir(plugin.ResolvedManifestPath), path))
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(plugin.ResolvedManifestPath), raw))
+}
+
+func buildConnectionAuthMap(name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, pluginConfig map[string]any, authFallback *specAuthFallback, deps Deps) (map[string]OAuthHandler, error) {
 	manifestProvider := (*pluginmanifestv1.Provider)(nil)
 	if manifest != nil {
 		manifestProvider = manifest.Provider
@@ -178,8 +271,20 @@ func buildConnectionAuthMap(name string, intg config.IntegrationDef, manifest *p
 		return nil, fmt.Errorf("resolve connections for %q: %w", name, err)
 	}
 
+	mcpURL := ""
+	if resolved, ok := plan.resolvedSurface(config.SpecSurfaceMCP); ok {
+		mcpURL = resolved.url
+	}
+
+	specAuthForConnection := func(connectionName string) *provider.Definition {
+		if authFallback == nil || authFallback.definition == nil || authFallback.connectionName != connectionName {
+			return nil
+		}
+		return authFallback.definition
+	}
+
 	handlers := make(map[string]OAuthHandler)
-	if handler, err := buildConnectionHandler(plan.pluginConnection, pluginConfig, deps); err != nil {
+	if handler, err := buildConnectionHandler(plan.pluginConnection, mcpURL, pluginConfig, specAuthForConnection(config.PluginConnectionName), deps); err != nil {
 		return nil, fmt.Errorf("build plugin connection auth for %q: %w", name, err)
 	} else if handler != nil {
 		handlers[config.PluginConnectionName] = handler
@@ -187,7 +292,7 @@ func buildConnectionAuthMap(name string, intg config.IntegrationDef, manifest *p
 
 	for resolvedName := range plan.namedConnections {
 		conn := plan.namedConnections[resolvedName]
-		handler, err := buildConnectionHandler(conn, pluginConfig, deps)
+		handler, err := buildConnectionHandler(conn, mcpURL, pluginConfig, specAuthForConnection(resolvedName), deps)
 		if err != nil {
 			return nil, fmt.Errorf("build named connection auth for %q/%q: %w", name, resolvedName, err)
 		}
@@ -223,12 +328,19 @@ func namedConnectionNames(plugin *config.PluginDef, manifestProvider *pluginmani
 	return names
 }
 
-func buildConnectionHandler(conn config.ConnectionDef, pluginConfig map[string]any, deps Deps) (OAuthHandler, error) {
+func buildConnectionHandler(conn config.ConnectionDef, mcpURL string, pluginConfig map[string]any, specDef *provider.Definition, deps Deps) (OAuthHandler, error) {
 	switch conn.Auth.Type {
 	case "", pluginmanifestv1.AuthTypeOAuth2:
-		return buildOAuthHandlerFromAuth(&conn.Auth, pluginConfig, deps)
+		handler, err := buildOAuthHandlerFromAuth(&conn.Auth, pluginConfig, deps)
+		if err != nil || handler != nil || conn.Auth.Type == pluginmanifestv1.AuthTypeOAuth2 {
+			return handler, err
+		}
+		return buildOAuthHandlerFromDefinition(specDef, conn, pluginConfig, deps)
 	case pluginmanifestv1.AuthTypeMCPOAuth:
-		return nil, fmt.Errorf("mcp_oauth auth is no longer supported for executable providers")
+		if mcpURL == "" {
+			return nil, fmt.Errorf("mcp_oauth auth requires mcp_url")
+		}
+		return buildMCPOAuthHandler(conn, mcpURL, buildRegistrationStore(deps), deps), nil
 	default:
 		return nil, nil
 	}

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -563,7 +563,7 @@ func TestExecutablePluginRequiresManifest(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected buildProvidersStrict to reject executable plugin without manifest")
 	}
-	if got := err.Error(); got != `bootstrap: provider validation failed: integration "echoext": integration "echoext" must resolve to an executable plugin manifest` {
+	if got := err.Error(); got != `bootstrap: provider validation failed: integration "echoext": integration "echoext" must resolve to a provider manifest` {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1003,8 +1003,9 @@ func validateManifestBackedConnectionDefaults(name string, plugin *PluginDef, pr
 }
 
 func validateExecutableConnectionAuthSupport(name string, plugin *PluginDef, provider *pluginmanifestv1.Provider) error {
-	if conn := EffectivePluginConnectionDef(plugin, provider); conn.Auth.Type == pluginmanifestv1.AuthTypeMCPOAuth {
-		return fmt.Errorf("config validation: integration %q plugin auth type %q is not supported for executable providers", name, pluginmanifestv1.AuthTypeMCPOAuth)
+	supportsMCPOAuth := provider != nil && provider.MCPURL != ""
+	if conn := EffectivePluginConnectionDef(plugin, provider); conn.Auth.Type == pluginmanifestv1.AuthTypeMCPOAuth && !supportsMCPOAuth {
+		return fmt.Errorf("config validation: integration %q plugin auth type %q requires an MCP surface", name, pluginmanifestv1.AuthTypeMCPOAuth)
 	}
 
 	declared := declaredManifestBackedConnections(plugin, provider)
@@ -1018,7 +1019,9 @@ func validateExecutableConnectionAuthSupport(name string, plugin *PluginDef, pro
 		if !ok || conn.Auth.Type != pluginmanifestv1.AuthTypeMCPOAuth {
 			continue
 		}
-		return fmt.Errorf("config validation: integration %q connection %q auth type %q is not supported for executable providers", name, connName, pluginmanifestv1.AuthTypeMCPOAuth)
+		if !supportsMCPOAuth {
+			return fmt.Errorf("config validation: integration %q connection %q auth type %q requires an MCP surface", name, connName, pluginmanifestv1.AuthTypeMCPOAuth)
+		}
 	}
 	return nil
 }

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -773,7 +773,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 					},
 				},
 			},
-			wantErr: `plugin auth type "mcp_oauth" is not supported`,
+			wantErr: `plugin auth type "mcp_oauth" requires an MCP surface`,
 		},
 		{
 			name: "named connection rejects mcp oauth early",
@@ -789,7 +789,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 					},
 				},
 			},
-			wantErr: `connection "default" auth type "mcp_oauth" is not supported`,
+			wantErr: `connection "default" auth type "mcp_oauth" requires an MCP surface`,
 		},
 	}
 

--- a/gestaltd/internal/config/surfaces.go
+++ b/gestaltd/internal/config/surfaces.go
@@ -1,0 +1,62 @@
+package config
+
+import pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+
+type SpecSurface string
+
+const (
+	SpecSurfaceOpenAPI SpecSurface = "openapi"
+	SpecSurfaceGraphQL SpecSurface = "graphql"
+	SpecSurfaceMCP     SpecSurface = "mcp"
+)
+
+var OrderedSpecSurfaces = []SpecSurface{
+	SpecSurfaceOpenAPI,
+	SpecSurfaceGraphQL,
+	SpecSurfaceMCP,
+}
+
+func (s SpecSurface) ConnectionField() string {
+	switch s {
+	case SpecSurfaceOpenAPI:
+		return "openapi_connection"
+	case SpecSurfaceGraphQL:
+		return "graphql_connection"
+	case SpecSurfaceMCP:
+		return "mcp_connection"
+	default:
+		return "connection"
+	}
+}
+
+func ManifestProviderSurfaceURL(provider *pluginmanifestv1.Provider, surface SpecSurface) string {
+	if provider == nil {
+		return ""
+	}
+	switch surface {
+	case SpecSurfaceOpenAPI:
+		return provider.OpenAPI
+	case SpecSurfaceGraphQL:
+		return provider.GraphQLURL
+	case SpecSurfaceMCP:
+		return provider.MCPURL
+	default:
+		return ""
+	}
+}
+
+func ManifestProviderSurfaceConnectionName(provider *pluginmanifestv1.Provider, surface SpecSurface) string {
+	if provider == nil {
+		return ""
+	}
+	switch surface {
+	case SpecSurfaceOpenAPI:
+		return provider.OpenAPIConnection
+	case SpecSurfaceGraphQL:
+		return provider.GraphQLConnection
+	case SpecSurfaceMCP:
+		return provider.MCPConnection
+	default:
+		return ""
+	}
+}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -518,10 +518,6 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 	if err := pluginpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, pluginmanifestv1.KindProvider, configMap); err != nil {
 		return LockProviderEntry{}, fmt.Errorf("plugin config validation for provider %q: %w", name, err)
 	}
-	entrypoint := pluginpkg.EntrypointForKind(installed.Manifest, pluginmanifestv1.KindProvider)
-	if entrypoint == nil {
-		return LockProviderEntry{}, fmt.Errorf("provider %q manifest does not define a %s entrypoint", name, pluginmanifestv1.KindProvider)
-	}
 	fingerprint, err := PluginFingerprint(name, plugin, paths.configDir)
 	if err != nil {
 		return LockProviderEntry{}, fmt.Errorf("fingerprinting provider %q plugin: %w", name, err)
@@ -530,10 +526,12 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 	if err != nil {
 		return LockProviderEntry{}, fmt.Errorf("compute manifest path for provider %q: %w", name, err)
 	}
-	executablePath := filepath.Join(installed.Root, filepath.FromSlash(entrypoint.ArtifactPath))
-	executableRel, err := filepath.Rel(paths.artifactsDir, executablePath)
-	if err != nil {
-		return LockProviderEntry{}, fmt.Errorf("compute executable path for provider %q: %w", name, err)
+	executableRel := ""
+	if installed.ExecutablePath != "" {
+		executableRel, err = filepath.Rel(paths.artifactsDir, installed.ExecutablePath)
+		if err != nil {
+			return LockProviderEntry{}, fmt.Errorf("compute executable path for provider %q: %w", name, err)
+		}
 	}
 	return LockProviderEntry{
 		Fingerprint:   fingerprint,
@@ -731,7 +729,20 @@ func applyLocalProviderManifest(name string, plugin *config.PluginDef, configMap
 	if err != nil {
 		return fmt.Errorf("prepare manifest for provider %q: %w", name, err)
 	}
-	return bindResolvedProviderManifest(name, plugin, manifestPath, manifest, configMap)
+	if err := bindResolvedProviderManifest(name, plugin, manifestPath, manifest, configMap); err != nil {
+		return err
+	}
+	if plugin.Command != "" {
+		return nil
+	}
+	if entry := pluginpkg.EntrypointForKind(plugin.ResolvedManifest, pluginmanifestv1.KindProvider); entry != nil {
+		candidate := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(entry.ArtifactPath))
+		if _, err := os.Stat(candidate); err == nil {
+			plugin.Command = candidate
+			plugin.Args = append([]string(nil), entry.Args...)
+		}
+	}
+	return nil
 }
 
 func applyLocalComponentManifest(kind, name string, plugin *config.PluginDef, configMap map[string]any) error {
@@ -804,17 +815,17 @@ func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, na
 	if err := bindResolvedProviderManifest(name, plugin, manifestPath, manifest, configMap); err != nil {
 		return err
 	}
-	if _, err := os.Stat(executablePath); err != nil {
-		return fmt.Errorf("prepared executable for provider %q not found at %s; run `gestaltd init --config %s`", name, executablePath, paths.configPath)
+	if entry.Executable != "" {
+		if _, err := os.Stat(executablePath); err != nil {
+			return fmt.Errorf("prepared executable for provider %q not found at %s; run `gestaltd init --config %s`", name, executablePath, paths.configPath)
+		}
+		args, err := providerEntrypointArgs(manifest)
+		if err != nil {
+			return fmt.Errorf("resolve entrypoint for provider %q: %w", name, err)
+		}
+		plugin.Command = executablePath
+		plugin.Args = append([]string(nil), args...)
 	}
-
-	args, err := providerEntrypointArgs(manifest)
-	if err != nil {
-		return fmt.Errorf("resolve entrypoint for provider %q: %w", name, err)
-	}
-
-	plugin.Command = executablePath
-	plugin.Args = append([]string(nil), args...)
 	return nil
 }
 

--- a/gestaltd/internal/pluginhost/declarative.go
+++ b/gestaltd/internal/pluginhost/declarative.go
@@ -1,0 +1,245 @@
+package pluginhost
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"net/http"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/core/integration"
+	"github.com/valon-technologies/gestalt/server/internal/apiexec"
+	"github.com/valon-technologies/gestalt/server/internal/paraminterp"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+)
+
+const declarativeHTTPTimeout = 30 * time.Second
+
+type DeclarativeProviderOption func(*DeclarativeProvider)
+
+func WithDeclarativeMetadataOverrides(displayName, description, iconSVG string) DeclarativeProviderOption {
+	return func(p *DeclarativeProvider) {
+		if displayName != "" {
+			p.catalog.DisplayName = displayName
+		}
+		if description != "" {
+			p.catalog.Description = description
+		}
+		if iconSVG != "" {
+			p.catalog.IconSVG = iconSVG
+		}
+	}
+}
+
+func WithDeclarativeConnectionMode(mode core.ConnectionMode) DeclarativeProviderOption {
+	return func(p *DeclarativeProvider) {
+		p.connectionMode = mode
+	}
+}
+
+type DeclarativeProvider struct {
+	catalog              *catalog.Catalog
+	opsByName            map[string]*catalog.CatalogOperation
+	baseURL              string
+	auth                 *pluginmanifestv1.ProviderAuth
+	httpClient           *http.Client
+	postConnectDiscovery *pluginmanifestv1.ProviderPostConnectDiscovery
+	connectionDefs       map[string]pluginmanifestv1.ProviderConnectionParam
+	connectionMode       core.ConnectionMode
+}
+
+func NewDeclarativeProvider(manifest *pluginmanifestv1.Manifest, httpClient *http.Client, opts ...DeclarativeProviderOption) (*DeclarativeProvider, error) {
+	if manifest == nil {
+		return nil, fmt.Errorf("manifest is required")
+	}
+	if manifest.Provider == nil || !manifest.Provider.IsDeclarative() {
+		return nil, fmt.Errorf("manifest is not a declarative provider")
+	}
+
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: declarativeHTTPTimeout}
+	}
+
+	p := &DeclarativeProvider{
+		catalog: &catalog.Catalog{
+			Name:        manifest.Source,
+			DisplayName: manifest.DisplayName,
+			Description: manifest.Description,
+			Headers:     maps.Clone(manifest.Provider.Headers),
+			Operations:  make([]catalog.CatalogOperation, 0, len(manifest.Provider.Operations)),
+		},
+		opsByName:            make(map[string]*catalog.CatalogOperation, len(manifest.Provider.Operations)),
+		baseURL:              manifest.Provider.BaseURL,
+		auth:                 manifest.Provider.Auth,
+		httpClient:           httpClient,
+		postConnectDiscovery: manifest.Provider.PostConnectDiscovery,
+		connectionDefs:       manifest.Provider.ConnectionParams,
+	}
+
+	for i := range manifest.Provider.Operations {
+		mop := &manifest.Provider.Operations[i]
+		catOp := catalog.CatalogOperation{
+			ID:          mop.Name,
+			Method:      mop.Method,
+			Path:        mop.Path,
+			Description: mop.Description,
+			Transport:   catalog.TransportREST,
+			Parameters:  make([]catalog.CatalogParameter, 0, len(mop.Parameters)),
+		}
+		for _, mp := range mop.Parameters {
+			catOp.Parameters = append(catOp.Parameters, catalog.CatalogParameter{
+				Name:        mp.Name,
+				Type:        mp.Type,
+				Location:    mp.In,
+				Description: mp.Description,
+				Required:    mp.Required,
+			})
+		}
+		p.catalog.Operations = append(p.catalog.Operations, catOp)
+	}
+
+	integration.CompileSchemas(p.catalog)
+	for i := range p.catalog.Operations {
+		op := &p.catalog.Operations[i]
+		p.opsByName[op.ID] = op
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	if p.connectionMode == "" {
+		if p.auth == nil || p.auth.Type == "" || p.auth.Type == pluginmanifestv1.AuthTypeNone {
+			p.connectionMode = core.ConnectionModeNone
+		} else {
+			p.connectionMode = core.ConnectionModeUser
+		}
+	}
+
+	return p, nil
+}
+
+func (p *DeclarativeProvider) Name() string        { return p.catalog.Name }
+func (p *DeclarativeProvider) DisplayName() string { return p.catalog.DisplayName }
+func (p *DeclarativeProvider) Description() string { return p.catalog.Description }
+func (p *DeclarativeProvider) Catalog() *catalog.Catalog {
+	return p.catalog.Clone()
+}
+func (p *DeclarativeProvider) ConnectionMode() core.ConnectionMode { return p.connectionMode }
+
+func (p *DeclarativeProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
+	op, ok := p.opsByName[operation]
+	if !ok {
+		return &core.OperationResult{Status: http.StatusNotFound, Body: `{"error":"unknown operation"}`}, nil
+	}
+
+	queryParams := make(map[string]any)
+	bodyParams := make(map[string]any)
+	isBodyMethod := op.Method == http.MethodPost || op.Method == http.MethodPut || op.Method == http.MethodPatch
+
+	for k, v := range params {
+		loc, declared := declarativeParamLocation(op, k)
+		if !declared {
+			if isBodyMethod {
+				loc = "body"
+			} else {
+				loc = "query"
+			}
+		}
+		switch loc {
+		case "query":
+			queryParams[k] = v
+		case "body", "path":
+			bodyParams[k] = v
+		}
+	}
+
+	baseURL := p.baseURL
+	headers := maps.Clone(p.catalog.Headers)
+	if cp := core.ConnectionParams(ctx); cp != nil {
+		baseURL = paraminterp.Interpolate(baseURL, cp)
+		for k, v := range headers {
+			headers[k] = paraminterp.Interpolate(v, cp)
+		}
+	}
+
+	req := apiexec.Request{
+		Method:        op.Method,
+		BaseURL:       baseURL,
+		Path:          op.Path,
+		Params:        bodyParams,
+		QueryParams:   queryParams,
+		CustomHeaders: headers,
+		Token:         token,
+		NoRetry:       true,
+	}
+	return apiexec.Do(ctx, p.httpClient, req)
+}
+
+func declarativeParamLocation(op *catalog.CatalogOperation, name string) (string, bool) {
+	for _, param := range op.Parameters {
+		if param.Name == name {
+			return param.Location, true
+		}
+	}
+	return "", false
+}
+
+func (p *DeclarativeProvider) SupportsManualAuth() bool {
+	if p.auth == nil {
+		return false
+	}
+	return p.auth.Type == pluginmanifestv1.AuthTypeManual || p.auth.Type == pluginmanifestv1.AuthTypeBearer
+}
+
+func (p *DeclarativeProvider) CredentialFields() []core.CredentialFieldDef {
+	if p.auth == nil {
+		return nil
+	}
+	return CredentialFieldsFromManifest(p.auth.Credentials)
+}
+
+func (p *DeclarativeProvider) AuthTypes() []string {
+	if p.auth == nil {
+		return nil
+	}
+	switch p.auth.Type {
+	case pluginmanifestv1.AuthTypeOAuth2:
+		return []string{"oauth"}
+	case pluginmanifestv1.AuthTypeBearer, pluginmanifestv1.AuthTypeManual:
+		return []string{"manual"}
+	case pluginmanifestv1.AuthTypeNone:
+		return nil
+	default:
+		return nil
+	}
+}
+
+func (p *DeclarativeProvider) AuthorizationURL(state string, scopes []string) string {
+	if p.auth == nil || p.auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
+		return ""
+	}
+	return p.auth.AuthorizationURL
+}
+
+func (p *DeclarativeProvider) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	if p.auth == nil || p.auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
+		return nil, fmt.Errorf("provider does not support OAuth")
+	}
+	return nil, fmt.Errorf("declarative provider OAuth exchange not implemented")
+}
+
+func (p *DeclarativeProvider) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	if p.auth == nil || p.auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
+		return nil, fmt.Errorf("provider does not support OAuth")
+	}
+	return nil, fmt.Errorf("declarative provider OAuth refresh not implemented")
+}
+
+func (p *DeclarativeProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return ConnectionParamDefsFromManifest(p.connectionDefs)
+}
+
+func (p *DeclarativeProvider) DiscoveryConfig() *core.DiscoveryConfig {
+	return DiscoveryConfigFromManifest(p.postConnectDiscovery)
+}

--- a/gestaltd/internal/pluginpkg/catalog.go
+++ b/gestaltd/internal/pluginpkg/catalog.go
@@ -19,7 +19,7 @@ func StaticCatalogPath(rootDir string) string {
 }
 
 func StaticCatalogRequired(manifest *pluginmanifestv1.Manifest) bool {
-	return manifest != nil && manifest.Provider != nil
+	return manifest != nil && manifest.Provider != nil && !manifest.Provider.IsManifestBacked()
 }
 
 func ReadStaticCatalog(rootDir, name string) (*catalog.Catalog, error) {

--- a/gestaltd/internal/pluginpkg/manifest.go
+++ b/gestaltd/internal/pluginpkg/manifest.go
@@ -66,13 +66,20 @@ func DecodeManifestFormat(data []byte, format string) (*pluginmanifestv1.Manifes
 
 func decodeManifest(data []byte, format string, sourceMode bool) (*pluginmanifestv1.Manifest, error) {
 	var manifest pluginmanifestv1.Manifest
-	if err := decodeStrict(data, format, "manifest", &manifest); err != nil {
+	if err := decodeStrict(data, format, "manifest", &manifest); err == nil {
+		if err := validateManifest(&manifest, sourceMode); err != nil {
+			return nil, err
+		}
+		return &manifest, nil
+	}
+	providerManifest, err := decodeProviderManifestWire(data, format)
+	if err != nil {
+		return nil, decodeStrict(data, format, "manifest", &manifest)
+	}
+	if err := validateManifest(providerManifest, sourceMode); err != nil {
 		return nil, err
 	}
-	if err := validateManifest(&manifest, sourceMode); err != nil {
-		return nil, err
-	}
-	return &manifest, nil
+	return providerManifest, nil
 }
 
 func ValidateManifest(manifest *pluginmanifestv1.Manifest) error {
@@ -96,6 +103,20 @@ func validateManifest(manifest *pluginmanifestv1.Manifest, sourceMode bool) erro
 	if manifest.IconFile != "" {
 		if err := validateRelativePackagePath(manifest.IconFile, "icon_file"); err != nil {
 			return err
+		}
+	}
+	if len(manifest.Kinds) == 0 {
+		if manifest.Provider != nil {
+			manifest.Kinds = append(manifest.Kinds, pluginmanifestv1.KindProvider)
+		}
+		if manifest.Auth != nil {
+			manifest.Kinds = append(manifest.Kinds, pluginmanifestv1.KindAuth)
+		}
+		if manifest.Datastore != nil {
+			manifest.Kinds = append(manifest.Kinds, pluginmanifestv1.KindDatastore)
+		}
+		if manifest.WebUI != nil {
+			manifest.Kinds = append(manifest.Kinds, pluginmanifestv1.KindWebUI)
 		}
 	}
 	if len(manifest.Kinds) == 0 {
@@ -135,7 +156,7 @@ func validateManifest(manifest *pluginmanifestv1.Manifest, sourceMode bool) erro
 
 	needsArtifacts := len(manifest.Artifacts) > 0
 	for _, kind := range manifest.Kinds {
-		if kind == pluginmanifestv1.KindProvider && !allowsSourceExecutableEntrypointOmission {
+		if kind == pluginmanifestv1.KindProvider && manifest.Entrypoints.Provider != nil {
 			needsArtifacts = true
 			break
 		}
@@ -190,13 +211,21 @@ func validateManifest(manifest *pluginmanifestv1.Manifest, sourceMode bool) erro
 					return err
 				}
 			}
-			if manifest.Entrypoints.Provider == nil && !allowsSourceExecutableEntrypointOmission {
-				return fmt.Errorf("%s entrypoint is required", kind)
+			if manifest.Provider.IsDeclarative() {
+				if err := validateDeclarativeProvider(manifest.Provider); err != nil {
+					return err
+				}
 			}
-			if manifest.Entrypoints.Provider != nil {
+			switch {
+			case manifest.Entrypoints.Provider != nil:
 				if err := validateEntrypoint(kind, manifest.Entrypoints.Provider, artifactPaths); err != nil {
 					return err
 				}
+			case manifest.IsDeclarativeOnlyProvider():
+			case manifest.Provider.IsSpecLoaded():
+			case allowsSourceExecutableEntrypointOmission:
+			default:
+				return fmt.Errorf("%s entrypoint is required", kind)
 			}
 		case pluginmanifestv1.KindAuth:
 			if manifest.Auth == nil {
@@ -369,13 +398,13 @@ func validateExecutableProviderMetadata(provider *pluginmanifestv1.Provider) err
 			continue
 		}
 		switch conn.Mode {
-		case "none", "user", "identity":
+		case "none", "user", "identity", "either":
 		default:
 			return fmt.Errorf("unsupported provider.connections.%s.mode %q", name, conn.Mode)
 		}
 	}
 	switch provider.ConnectionMode {
-	case "", "none", "user", "identity":
+	case "", "none", "user", "identity", "either":
 	default:
 		return fmt.Errorf("unsupported provider.connection_mode %q", provider.ConnectionMode)
 	}
@@ -395,21 +424,65 @@ func validateExecutableProviderMetadata(provider *pluginmanifestv1.Provider) err
 		field   string
 		present bool
 	}{
-		{field: "provider.base_url", present: provider.BaseURL != ""},
-		{field: "provider.headers", present: len(provider.Headers) > 0},
-		{field: "provider.managed_parameters", present: len(provider.ManagedParameters) > 0},
-		{field: "provider.operations", present: len(provider.Operations) > 0},
-		{field: "provider.openapi", present: provider.OpenAPI != ""},
-		{field: "provider.graphql_url", present: provider.GraphQLURL != ""},
-		{field: "provider.mcp_url", present: provider.MCPURL != ""},
-		{field: "provider.openapi_connection", present: provider.OpenAPIConnection != ""},
-		{field: "provider.graphql_connection", present: provider.GraphQLConnection != ""},
-		{field: "provider.mcp_connection", present: provider.MCPConnection != ""},
-		{field: "provider.response_mapping", present: provider.ResponseMapping != nil},
+		{field: "provider.base_url", present: provider.BaseURL != "" && !provider.IsDeclarative() && provider.OpenAPI == ""},
+		{field: "provider.operations", present: len(provider.Operations) > 0 && !provider.IsDeclarative()},
 	}
 	for _, check := range checks {
 		if check.present {
 			return fmt.Errorf("%s is no longer supported for executable providers", check.field)
+		}
+	}
+	return nil
+}
+
+var validParamIn = map[string]bool{
+	"query": true,
+	"body":  true,
+	"path":  true,
+}
+
+var validHTTPMethods = map[string]bool{
+	"GET":    true,
+	"POST":   true,
+	"PUT":    true,
+	"PATCH":  true,
+	"DELETE": true,
+}
+
+func validateDeclarativeProvider(provider *pluginmanifestv1.Provider) error {
+	if provider.BaseURL == "" {
+		return fmt.Errorf("provider.base_url is required for declarative providers")
+	}
+	seen := make(map[string]struct{}, len(provider.Operations))
+	for i, op := range provider.Operations {
+		if op.Name == "" {
+			return fmt.Errorf("provider.operations[%d].name is required", i)
+		}
+		if _, exists := seen[op.Name]; exists {
+			return fmt.Errorf("duplicate operation name %q", op.Name)
+		}
+		seen[op.Name] = struct{}{}
+		if !validHTTPMethods[op.Method] {
+			return fmt.Errorf("provider.operations[%d].method %q is not a valid HTTP method", i, op.Method)
+		}
+		if op.Path == "" {
+			return fmt.Errorf("provider.operations[%d].path is required", i)
+		}
+		seenParams := make(map[string]struct{}, len(op.Parameters))
+		for j, param := range op.Parameters {
+			if param.Name == "" {
+				return fmt.Errorf("provider.operations[%d].parameters[%d].name is required", i, j)
+			}
+			if _, dup := seenParams[param.Name]; dup {
+				return fmt.Errorf("provider.operations[%d] has duplicate parameter name %q", i, param.Name)
+			}
+			seenParams[param.Name] = struct{}{}
+			if !validParamIn[param.In] {
+				return fmt.Errorf("provider.operations[%d].parameters[%d].in %q must be query, body, or path", i, j, param.In)
+			}
+			if param.In == "path" && !strings.Contains(op.Path, "{"+param.Name+"}") {
+				return fmt.Errorf("provider.operations[%d].parameters[%d] %q declared as path param but %q has no {%s} placeholder", i, j, param.Name, op.Path, param.Name)
+			}
 		}
 	}
 	return nil
@@ -430,6 +503,9 @@ func EncodeSourceManifestFormat(manifest *pluginmanifestv1.Manifest, format stri
 func encodeManifestFormat(manifest *pluginmanifestv1.Manifest, format string, sourceMode bool) ([]byte, error) {
 	if err := validateManifest(manifest, sourceMode); err != nil {
 		return nil, err
+	}
+	if manifest != nil && manifest.Provider != nil && manifest.Auth == nil && manifest.Datastore == nil {
+		return encodeProviderManifestWire(manifest, format)
 	}
 	switch format {
 	case ManifestFormatJSON:

--- a/gestaltd/internal/pluginpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/pluginpkg/manifest_workflow_test.go
@@ -268,32 +268,6 @@ func TestManifestWorkflow_RejectsInvalidPackageInputs(t *testing.T) {
 			},
 			wantError: "provider.auth.token_url is required for oauth2",
 		},
-		{
-			name: "rejects legacy declarative provider fields",
-			buildData: func(t *testing.T, dir string) string {
-				artifactPath := testArtifactPath("provider")
-				manifest := mustProviderManifest("github.com/acme/plugins/legacy-declarative", "1.0.0", testArtifactOS, testArtifactArch, artifactPath, sha256Hex("provider"))
-				manifest.Provider.BaseURL = "https://api.example.com"
-				manifest.Provider.Operations = []pluginmanifestv1.ProviderOperation{
-					{Name: "list_items", Method: "GET", Path: "/items"},
-				}
-				mustWriteFile(t, filepath.Join(dir, filepath.FromSlash(artifactPath)), []byte("provider"), 0o755)
-				return mustWriteManifestData(t, dir, ManifestFile, mustRawManifestJSON(t, manifest))
-			},
-			wantError: "provider.base_url is no longer supported",
-		},
-		{
-			name: "rejects legacy spec provider fields",
-			buildData: func(t *testing.T, dir string) string {
-				artifactPath := testArtifactPath("provider")
-				manifest := mustProviderManifest("github.com/acme/plugins/legacy-spec", "1.0.0", testArtifactOS, testArtifactArch, artifactPath, sha256Hex("provider"))
-				manifest.Provider.OpenAPI = "openapi.yaml"
-				mustWriteFile(t, filepath.Join(dir, filepath.FromSlash(artifactPath)), []byte("provider"), 0o755)
-				mustWriteFile(t, filepath.Join(dir, "openapi.yaml"), []byte("openapi: 3.1.0\ninfo:\n  title: Example\n  version: 1.0.0\npaths: {}\n"), 0o644)
-				return mustWriteManifestData(t, dir, ManifestFile, mustRawManifestJSON(t, manifest))
-			},
-			wantError: "provider.openapi is no longer supported",
-		},
 	}
 
 	for _, tc := range tests {
@@ -312,5 +286,57 @@ func TestManifestWorkflow_RejectsInvalidPackageInputs(t *testing.T) {
 				t.Fatalf("error = %v, want %q", err, tc.wantError)
 			}
 		})
+	}
+}
+
+func TestManifestWorkflow_AcceptsProviderWireSurfaceManifest(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := mustWriteManifestData(t, dir, "plugin.yaml", []byte(`
+source: github.com/acme/plugins/provider-wire
+version: 1.0.0
+display_name: Provider Wire
+provider:
+  config_schema_path: schemas/config.schema.json
+  connections:
+    default:
+      auth:
+        type: none
+    api:
+      auth:
+        type: oauth2
+        authorization_url: https://auth.example.com/authorize
+        token_url: https://auth.example.com/token
+  managed_parameters:
+    - in: path
+      name: workspaceId
+      value: ws_123
+  surfaces:
+    openapi:
+      document: openapi.yaml
+      connection: api
+`))
+	mustWriteFile(t, filepath.Join(dir, "schemas", "config.schema.json"), []byte(`{"type":"object"}`), 0o644)
+	mustWriteFile(t, filepath.Join(dir, "openapi.yaml"), []byte("openapi: 3.1.0\ninfo:\n  title: Example\n  version: 1.0.0\npaths: {}\n"), 0o644)
+
+	_, manifest, err := ReadManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadManifestFile: %v", err)
+	}
+	if manifest.Provider == nil {
+		t.Fatal("expected provider metadata")
+	}
+	if manifest.Provider.OpenAPI != "openapi.yaml" {
+		t.Fatalf("provider openapi = %q", manifest.Provider.OpenAPI)
+	}
+	if manifest.Provider.OpenAPIConnection != "api" {
+		t.Fatalf("provider openapi_connection = %q, want api", manifest.Provider.OpenAPIConnection)
+	}
+	if len(manifest.Provider.ManagedParameters) != 1 {
+		t.Fatalf("managed_parameters = %+v", manifest.Provider.ManagedParameters)
+	}
+	if manifest.Entrypoints.Provider != nil {
+		t.Fatalf("expected declarative/spec provider to omit provider entrypoint, got %+v", manifest.Entrypoints.Provider)
 	}
 }

--- a/gestaltd/internal/pluginpkg/provider_manifest_wire.go
+++ b/gestaltd/internal/pluginpkg/provider_manifest_wire.go
@@ -1,0 +1,345 @@
+package pluginpkg
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+	"gopkg.in/yaml.v3"
+)
+
+type providerManifestWireRoot struct {
+	Source      string                          `json:"source,omitempty" yaml:"source,omitempty"`
+	Version     string                          `json:"version" yaml:"version"`
+	DisplayName string                          `json:"display_name,omitempty" yaml:"display_name,omitempty"`
+	Description string                          `json:"description,omitempty" yaml:"description,omitempty"`
+	IconFile    string                          `json:"icon_file,omitempty" yaml:"icon_file,omitempty"`
+	Kinds       []string                        `json:"kinds,omitempty" yaml:"kinds,omitempty"`
+	Provider    *providerManifestWire           `json:"provider,omitempty" yaml:"provider,omitempty"`
+	WebUI       *pluginmanifestv1.WebUIMetadata `json:"webui,omitempty" yaml:"webui,omitempty"`
+	Artifacts   []pluginmanifestv1.Artifact     `json:"artifacts,omitempty" yaml:"artifacts,omitempty"`
+}
+
+type providerManifestWire struct {
+	ConfigSchemaPath  string                                                 `json:"config_schema_path,omitempty" yaml:"config_schema_path,omitempty"`
+	Exec              *providerExecWire                                      `json:"exec,omitempty" yaml:"exec,omitempty"`
+	Connections       map[string]*providerManifestConnectionWire             `json:"connections,omitempty" yaml:"connections,omitempty"`
+	Headers           map[string]string                                      `json:"headers,omitempty" yaml:"headers,omitempty"`
+	ManagedParameters []pluginmanifestv1.ManagedParameter                    `json:"managed_parameters,omitempty" yaml:"managed_parameters,omitempty"`
+	ResponseMapping   *pluginmanifestv1.ManifestResponseMapping              `json:"response_mapping,omitempty" yaml:"response_mapping,omitempty"`
+	AllowedOperations map[string]*pluginmanifestv1.ManifestOperationOverride `json:"allowed_operations,omitempty" yaml:"allowed_operations,omitempty"`
+	Surfaces          providerManifestSurfacesWire                           `json:"surfaces,omitempty" yaml:"surfaces,omitempty"`
+	MCP               *providerManifestMCPWire                               `json:"mcp,omitempty" yaml:"mcp,omitempty"`
+}
+
+type providerExecWire struct {
+	ArtifactPath string   `json:"artifact_path" yaml:"artifact_path"`
+	Args         []string `json:"args,omitempty" yaml:"args,omitempty"`
+}
+
+type providerManifestConnectionWire struct {
+	Mode      string                                              `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Auth      *pluginmanifestv1.ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
+	Params    map[string]pluginmanifestv1.ProviderConnectionParam `json:"params,omitempty" yaml:"params,omitempty"`
+	Discovery *providerManifestDiscoveryWire                      `json:"discovery,omitempty" yaml:"discovery,omitempty"`
+}
+
+type providerManifestDiscoveryWire struct {
+	URL      string            `json:"url" yaml:"url"`
+	IDPath   string            `json:"id_path,omitempty" yaml:"id_path,omitempty"`
+	NamePath string            `json:"name_path,omitempty" yaml:"name_path,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+}
+
+type providerManifestSurfacesWire struct {
+	REST    *providerManifestRESTSurfaceWire    `json:"rest,omitempty" yaml:"rest,omitempty"`
+	OpenAPI *providerManifestOpenAPISurfaceWire `json:"openapi,omitempty" yaml:"openapi,omitempty"`
+	GraphQL *providerManifestGraphQLSurfaceWire `json:"graphql,omitempty" yaml:"graphql,omitempty"`
+	MCP     *providerManifestMCPSurfaceWire     `json:"mcp,omitempty" yaml:"mcp,omitempty"`
+}
+
+type providerManifestRESTSurfaceWire struct {
+	Connection string                               `json:"connection,omitempty" yaml:"connection,omitempty"`
+	BaseURL    string                               `json:"base_url" yaml:"base_url"`
+	Operations []pluginmanifestv1.ProviderOperation `json:"operations" yaml:"operations"`
+}
+
+type providerManifestOpenAPISurfaceWire struct {
+	Connection string `json:"connection,omitempty" yaml:"connection,omitempty"`
+	Document   string `json:"document" yaml:"document"`
+	BaseURL    string `json:"base_url,omitempty" yaml:"base_url,omitempty"`
+}
+
+type providerManifestGraphQLSurfaceWire struct {
+	Connection string `json:"connection,omitempty" yaml:"connection,omitempty"`
+	URL        string `json:"url" yaml:"url"`
+}
+
+type providerManifestMCPSurfaceWire struct {
+	Connection string `json:"connection,omitempty" yaml:"connection,omitempty"`
+	URL        string `json:"url" yaml:"url"`
+}
+
+type providerManifestMCPWire struct {
+	Enabled bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+}
+
+func decodeProviderManifestWire(data []byte, format string) (*pluginmanifestv1.Manifest, error) {
+	var wire providerManifestWireRoot
+	switch format {
+	case ManifestFormatJSON:
+		dec := json.NewDecoder(bytes.NewReader(data))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&wire); err != nil {
+			return nil, fmt.Errorf("parse manifest JSON: %w", err)
+		}
+	case ManifestFormatYAML:
+		dec := yaml.NewDecoder(bytes.NewReader(data))
+		dec.KnownFields(true)
+		if err := dec.Decode(&wire); err != nil {
+			return nil, fmt.Errorf("parse manifest YAML: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported manifest format %q", format)
+	}
+	return providerWireToInternal(&wire), nil
+}
+
+func providerWireToInternal(wire *providerManifestWireRoot) *pluginmanifestv1.Manifest {
+	if wire == nil {
+		return nil
+	}
+
+	manifest := &pluginmanifestv1.Manifest{
+		Source:      wire.Source,
+		Version:     wire.Version,
+		DisplayName: wire.DisplayName,
+		Description: wire.Description,
+		IconFile:    wire.IconFile,
+		Kinds:       append([]string(nil), wire.Kinds...),
+		WebUI:       wire.WebUI,
+		Artifacts:   append([]pluginmanifestv1.Artifact(nil), wire.Artifacts...),
+	}
+
+	if wire.Provider != nil {
+		manifest.Provider = &pluginmanifestv1.Provider{
+			ConfigSchemaPath:  wire.Provider.ConfigSchemaPath,
+			Headers:           wire.Provider.Headers,
+			ManagedParameters: wire.Provider.ManagedParameters,
+			ResponseMapping:   wire.Provider.ResponseMapping,
+			AllowedOperations: wire.Provider.AllowedOperations,
+		}
+		if len(manifest.Kinds) == 0 {
+			manifest.Kinds = append(manifest.Kinds, pluginmanifestv1.KindProvider)
+		}
+		if wire.Provider.MCP != nil {
+			manifest.Provider.MCP = wire.Provider.MCP.Enabled
+		}
+		if wire.Provider.Exec != nil {
+			manifest.Entrypoints.Provider = &pluginmanifestv1.Entrypoint{
+				ArtifactPath: wire.Provider.Exec.ArtifactPath,
+				Args:         append([]string(nil), wire.Provider.Exec.Args...),
+			}
+		}
+		if defaultConn, ok := wire.Provider.Connections["default"]; ok && defaultConn != nil {
+			manifest.Provider.Auth = defaultConn.Auth
+			manifest.Provider.ConnectionMode = defaultConn.Mode
+			manifest.Provider.ConnectionParams = defaultConn.Params
+			manifest.Provider.PostConnectDiscovery = defaultConn.toInternalDiscovery()
+		}
+		if len(wire.Provider.Connections) > 0 {
+			manifest.Provider.Connections = make(map[string]*pluginmanifestv1.ManifestConnectionDef, len(wire.Provider.Connections))
+			for name, conn := range wire.Provider.Connections {
+				if name == "default" {
+					continue
+				}
+				if conn == nil {
+					manifest.Provider.Connections[name] = nil
+					continue
+				}
+				manifest.Provider.Connections[name] = &pluginmanifestv1.ManifestConnectionDef{
+					Mode: conn.Mode,
+					Auth: conn.Auth,
+				}
+			}
+			if len(manifest.Provider.Connections) == 0 {
+				manifest.Provider.Connections = nil
+			}
+		}
+		if s := wire.Provider.Surfaces.REST; s != nil {
+			manifest.Provider.BaseURL = s.BaseURL
+			manifest.Provider.Operations = s.Operations
+			manifest.Provider.DefaultConnection = remapManifestWireConnectionName(s.Connection)
+		}
+		if s := wire.Provider.Surfaces.OpenAPI; s != nil {
+			manifest.Provider.OpenAPI = s.Document
+			if s.BaseURL != "" {
+				manifest.Provider.BaseURL = s.BaseURL
+			}
+			manifest.Provider.OpenAPIConnection = remapManifestWireConnectionName(s.Connection)
+		}
+		if s := wire.Provider.Surfaces.GraphQL; s != nil {
+			manifest.Provider.GraphQLURL = s.URL
+			manifest.Provider.GraphQLConnection = remapManifestWireConnectionName(s.Connection)
+		}
+		if s := wire.Provider.Surfaces.MCP; s != nil {
+			manifest.Provider.MCPURL = s.URL
+			manifest.Provider.MCPConnection = remapManifestWireConnectionName(s.Connection)
+		}
+	}
+	if wire.WebUI != nil && len(manifest.Kinds) == 0 {
+		manifest.Kinds = append(manifest.Kinds, pluginmanifestv1.KindWebUI)
+	}
+	return manifest
+}
+
+func encodeProviderManifestWire(manifest *pluginmanifestv1.Manifest, format string) ([]byte, error) {
+	wire := internalProviderManifestToWire(manifest)
+	switch format {
+	case ManifestFormatJSON:
+		data, err := json.MarshalIndent(wire, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("marshal manifest: %w", err)
+		}
+		return append(data, '\n'), nil
+	case ManifestFormatYAML:
+		data, err := yaml.Marshal(wire)
+		if err != nil {
+			return nil, fmt.Errorf("marshal manifest YAML: %w", err)
+		}
+		return data, nil
+	default:
+		return nil, fmt.Errorf("unsupported manifest format %q", format)
+	}
+}
+
+func internalProviderManifestToWire(manifest *pluginmanifestv1.Manifest) *providerManifestWireRoot {
+	if manifest == nil {
+		return nil
+	}
+	wire := &providerManifestWireRoot{
+		Source:      manifest.Source,
+		Version:     manifest.Version,
+		DisplayName: manifest.DisplayName,
+		Description: manifest.Description,
+		IconFile:    manifest.IconFile,
+		WebUI:       manifest.WebUI,
+		Artifacts:   append([]pluginmanifestv1.Artifact(nil), manifest.Artifacts...),
+	}
+	if manifest.Provider == nil {
+		return wire
+	}
+
+	provider := &providerManifestWire{
+		ConfigSchemaPath:  manifest.Provider.ConfigSchemaPath,
+		Headers:           manifest.Provider.Headers,
+		ManagedParameters: manifest.Provider.ManagedParameters,
+		ResponseMapping:   manifest.Provider.ResponseMapping,
+		AllowedOperations: manifest.Provider.AllowedOperations,
+	}
+	if manifest.Entrypoints.Provider != nil {
+		provider.Exec = &providerExecWire{
+			ArtifactPath: manifest.Entrypoints.Provider.ArtifactPath,
+			Args:         append([]string(nil), manifest.Entrypoints.Provider.Args...),
+		}
+	}
+	if manifest.Provider.MCP {
+		provider.MCP = &providerManifestMCPWire{Enabled: true}
+	}
+	if manifest.Provider.ConnectionMode != "" || manifest.Provider.Auth != nil || len(manifest.Provider.ConnectionParams) > 0 || manifest.Provider.PostConnectDiscovery != nil {
+		provider.Connections = map[string]*providerManifestConnectionWire{
+			"default": {
+				Mode:      manifest.Provider.ConnectionMode,
+				Auth:      manifest.Provider.Auth,
+				Params:    manifest.Provider.ConnectionParams,
+				Discovery: internalDiscoveryToWire(manifest.Provider.PostConnectDiscovery),
+			},
+		}
+	}
+	if len(manifest.Provider.Connections) > 0 {
+		if provider.Connections == nil {
+			provider.Connections = make(map[string]*providerManifestConnectionWire, len(manifest.Provider.Connections))
+		}
+		for name, conn := range manifest.Provider.Connections {
+			if conn == nil {
+				provider.Connections[name] = nil
+				continue
+			}
+			provider.Connections[name] = &providerManifestConnectionWire{
+				Mode: conn.Mode,
+				Auth: conn.Auth,
+			}
+		}
+	}
+	switch {
+	case manifest.Provider.IsDeclarative():
+		provider.Surfaces.REST = &providerManifestRESTSurfaceWire{
+			Connection: manifestDefaultConnectionToWire(manifest.Provider.DefaultConnection),
+			BaseURL:    manifest.Provider.BaseURL,
+			Operations: manifest.Provider.Operations,
+		}
+	case manifest.Provider.OpenAPI != "":
+		provider.Surfaces.OpenAPI = &providerManifestOpenAPISurfaceWire{
+			Connection: manifestDefaultConnectionToWire(manifest.Provider.OpenAPIConnection),
+			Document:   manifest.Provider.OpenAPI,
+			BaseURL:    manifest.Provider.BaseURL,
+		}
+	case manifest.Provider.GraphQLURL != "":
+		provider.Surfaces.GraphQL = &providerManifestGraphQLSurfaceWire{
+			Connection: manifestDefaultConnectionToWire(manifest.Provider.GraphQLConnection),
+			URL:        manifest.Provider.GraphQLURL,
+		}
+	}
+	if manifest.Provider.MCPURL != "" {
+		provider.Surfaces.MCP = &providerManifestMCPSurfaceWire{
+			Connection: manifestDefaultConnectionToWire(manifest.Provider.MCPConnection),
+			URL:        manifest.Provider.MCPURL,
+		}
+	}
+	wire.Provider = provider
+	return wire
+}
+
+func (w *providerManifestConnectionWire) toInternalDiscovery() *pluginmanifestv1.ProviderPostConnectDiscovery {
+	if w == nil || w.Discovery == nil {
+		return nil
+	}
+	return &pluginmanifestv1.ProviderPostConnectDiscovery{
+		URL:             w.Discovery.URL,
+		IDPath:          w.Discovery.IDPath,
+		NamePath:        w.Discovery.NamePath,
+		MetadataMapping: w.Discovery.Metadata,
+	}
+}
+
+func internalDiscoveryToWire(discovery *pluginmanifestv1.ProviderPostConnectDiscovery) *providerManifestDiscoveryWire {
+	if discovery == nil {
+		return nil
+	}
+	return &providerManifestDiscoveryWire{
+		URL:      discovery.URL,
+		IDPath:   discovery.IDPath,
+		NamePath: discovery.NamePath,
+		Metadata: discovery.MetadataMapping,
+	}
+}
+
+func remapManifestWireConnectionName(name string) string {
+	switch name {
+	case "", "default":
+		return ""
+	default:
+		return name
+	}
+}
+
+func manifestDefaultConnectionToWire(name string) string {
+	switch name {
+	case "", config.PluginConnectionAlias, config.PluginConnectionName:
+		return ""
+	default:
+		return name
+	}
+}

--- a/gestaltd/internal/pluginpkg/references.go
+++ b/gestaltd/internal/pluginpkg/references.go
@@ -35,6 +35,15 @@ func LocalPackageReferences(manifest *pluginmanifestv1.Manifest) []LocalPackageR
 
 	if manifest.Provider != nil {
 		add(manifest.Provider.ConfigSchemaPath, "provider config schema")
+		if manifest.Provider.OpenAPI != "" && !strings.Contains(manifest.Provider.OpenAPI, "://") {
+			add(manifest.Provider.OpenAPI, "provider openapi document")
+		}
+		if manifest.Provider.GraphQLURL != "" && !strings.Contains(manifest.Provider.GraphQLURL, "://") {
+			add(manifest.Provider.GraphQLURL, "provider graphql document")
+		}
+		if manifest.Provider.MCPURL != "" && !strings.Contains(manifest.Provider.MCPURL, "://") {
+			add(manifest.Provider.MCPURL, "provider mcp document")
+		}
 	}
 	add(manifest.IconFile, "icon_file")
 	return refs

--- a/gestaltd/internal/pluginstore/store.go
+++ b/gestaltd/internal/pluginstore/store.go
@@ -28,6 +28,25 @@ func isWebUIOnly(manifest *pluginmanifestv1.Manifest) bool {
 	return len(manifest.Kinds) == 1 && manifest.Kinds[0] == pluginmanifestv1.KindWebUI
 }
 
+func manifestNeedsExecutableArtifact(manifest *pluginmanifestv1.Manifest) bool {
+	if manifest == nil {
+		return false
+	}
+	for _, kind := range []string{
+		pluginmanifestv1.KindProvider,
+		pluginmanifestv1.KindAuth,
+		pluginmanifestv1.KindDatastore,
+	} {
+		if !manifestDeclaresKind(manifest, kind) {
+			continue
+		}
+		if pluginpkg.EntrypointForKind(manifest, kind) != nil {
+			return true
+		}
+	}
+	return false
+}
+
 func Install(packagePath, destDir string) (*InstalledPlugin, error) {
 	_, manifest, err := pluginpkg.ReadPackageManifest(packagePath)
 	if err != nil {
@@ -50,17 +69,20 @@ func Install(packagePath, destDir string) (*InstalledPlugin, error) {
 		return installed, nil
 	}
 
-	artifact, err := pluginpkg.CurrentPlatformArtifact(manifest)
-	if err != nil {
-		return nil, err
-	}
-	artifactBytes, err := pluginpkg.ReadArchiveEntry(packagePath, artifact.Path)
-	if err != nil {
-		return nil, err
-	}
-	sum := sha256.Sum256(artifactBytes)
-	if got := hex.EncodeToString(sum[:]); got != artifact.SHA256 {
-		return nil, fmt.Errorf("artifact digest mismatch for %s: package has %s, manifest expects %s", artifact.Path, got, artifact.SHA256)
+	var artifact *pluginmanifestv1.Artifact
+	if manifestNeedsExecutableArtifact(manifest) {
+		artifact, err = pluginpkg.CurrentPlatformArtifact(manifest)
+		if err != nil {
+			return nil, err
+		}
+		artifactBytes, err := pluginpkg.ReadArchiveEntry(packagePath, artifact.Path)
+		if err != nil {
+			return nil, err
+		}
+		sum := sha256.Sum256(artifactBytes)
+		if got := hex.EncodeToString(sum[:]); got != artifact.SHA256 {
+			return nil, fmt.Errorf("artifact digest mismatch for %s: package has %s, manifest expects %s", artifact.Path, got, artifact.SHA256)
+		}
 	}
 
 	if err := os.MkdirAll(destDir, 0755); err != nil {
@@ -106,24 +128,27 @@ func InstallFromDir(dirPath, destDir string) (*InstalledPlugin, error) {
 		return installed, nil
 	}
 
-	artifact, err := pluginpkg.CurrentPlatformArtifact(manifest)
-	if err != nil {
-		return nil, err
-	}
+	var artifact *pluginmanifestv1.Artifact
+	if manifestNeedsExecutableArtifact(manifest) {
+		artifact, err = pluginpkg.CurrentPlatformArtifact(manifest)
+		if err != nil {
+			return nil, err
+		}
 
-	artifactPath := filepath.Join(dirPath, filepath.FromSlash(artifact.Path))
-	artifactFile, err := os.Open(artifactPath)
-	if err != nil {
-		return nil, fmt.Errorf("open artifact %s: %w", artifact.Path, err)
-	}
-	sum := sha256.New()
-	if _, err := io.Copy(sum, artifactFile); err != nil {
+		artifactPath := filepath.Join(dirPath, filepath.FromSlash(artifact.Path))
+		artifactFile, err := os.Open(artifactPath)
+		if err != nil {
+			return nil, fmt.Errorf("open artifact %s: %w", artifact.Path, err)
+		}
+		sum := sha256.New()
+		if _, err := io.Copy(sum, artifactFile); err != nil {
+			_ = artifactFile.Close()
+			return nil, fmt.Errorf("read artifact %s: %w", artifact.Path, err)
+		}
 		_ = artifactFile.Close()
-		return nil, fmt.Errorf("read artifact %s: %w", artifact.Path, err)
-	}
-	_ = artifactFile.Close()
-	if got := hex.EncodeToString(sum.Sum(nil)); got != artifact.SHA256 {
-		return nil, fmt.Errorf("artifact digest mismatch for %s: directory has %s, manifest expects %s", artifact.Path, got, artifact.SHA256)
+		if got := hex.EncodeToString(sum.Sum(nil)); got != artifact.SHA256 {
+			return nil, fmt.Errorf("artifact digest mismatch for %s: directory has %s, manifest expects %s", artifact.Path, got, artifact.SHA256)
+		}
 	}
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return nil, fmt.Errorf("create plugin directory: %w", err)
@@ -138,12 +163,15 @@ func InstallFromDir(dirPath, destDir string) (*InstalledPlugin, error) {
 		return nil, fmt.Errorf("copy manifest: %w", err)
 	}
 
-	artifactDest := filepath.Join(destDir, filepath.FromSlash(artifact.Path))
-	if err := os.MkdirAll(filepath.Dir(artifactDest), 0755); err != nil {
-		return nil, fmt.Errorf("create artifact directory: %w", err)
-	}
-	if err := copyFile(artifactPath, artifactDest); err != nil {
-		return nil, fmt.Errorf("copy artifact: %w", err)
+	if artifact != nil {
+		artifactPath := filepath.Join(dirPath, filepath.FromSlash(artifact.Path))
+		artifactDest := filepath.Join(destDir, filepath.FromSlash(artifact.Path))
+		if err := os.MkdirAll(filepath.Dir(artifactDest), 0755); err != nil {
+			return nil, fmt.Errorf("create artifact directory: %w", err)
+		}
+		if err := copyFile(artifactPath, artifactDest); err != nil {
+			return nil, fmt.Errorf("copy artifact: %w", err)
+		}
 	}
 
 	if err := copyManifestReferencedFiles(dirPath, destDir, manifest); err != nil {
@@ -199,6 +227,9 @@ func executablePathForManifest(root string, manifest *pluginmanifestv1.Manifest)
 		}
 	}
 	if entry == nil {
+		if manifest.Provider != nil && manifest.Provider.IsManifestBacked() {
+			return "", nil
+		}
 		return "", fmt.Errorf("manifest does not define an executable entrypoint")
 	}
 	if entry.ArtifactPath == "" {

--- a/gestaltd/sdk/pluginmanifest/v1/types.go
+++ b/gestaltd/sdk/pluginmanifest/v1/types.go
@@ -62,6 +62,26 @@ type Provider struct {
 	ResponseMapping   *ManifestResponseMapping              `json:"response_mapping,omitempty" yaml:"response_mapping,omitempty"`
 }
 
+func (p *Provider) IsDeclarative() bool {
+	return p != nil && len(p.Operations) > 0
+}
+
+func (p *Provider) IsSpecLoaded() bool {
+	return p != nil && (p.OpenAPI != "" || p.GraphQLURL != "" || p.MCPURL != "")
+}
+
+func (p *Provider) IsManifestBacked() bool {
+	return p != nil && (p.IsDeclarative() || p.IsSpecLoaded())
+}
+
+func (m *Manifest) IsHybridProvider() bool {
+	return m != nil && m.Provider != nil && m.Provider.IsManifestBacked() && m.Entrypoints.Provider != nil
+}
+
+func (m *Manifest) IsDeclarativeOnlyProvider() bool {
+	return m != nil && m.Provider != nil && m.Provider.IsManifestBacked() && m.Entrypoints.Provider == nil
+}
+
 type ManifestResponseMapping struct {
 	DataPath   string                     `json:"data_path" yaml:"data_path"`
 	Pagination *ManifestPaginationMapping `json:"pagination,omitempty" yaml:"pagination,omitempty"`


### PR DESCRIPTION
## Summary
- restore support for declarative and spec-backed integration providers
- accept the current `provider.exec` / `provider.surfaces` manifest shape again
- restore declarative, spec-loaded, and hybrid executable-plus-spec provider runtime assembly
- stop requiring an executable or `catalog.yaml` for manifest-backed providers
- allow declarative providers through install, init, lock, and release again

## Testing
- `cd gestaltd && go test ./...`
- local-source smoke test with `pagerduty` declarative provider plus `sqlite` datastore from `gestalt-providers`
- `gestaltd validate` and `gestaltd init` on that config
- declarative provider release smoke via `plugin release` from `gestalt-providers/plugins/pagerduty`

## Note
- I also tried the managed `source.ref` path against GitHub releases, and `plugins/pagerduty/v0.0.1-alpha.1` was not available through release resolution. That appears to be a release availability issue separate from this runtime compatibility fix.