### PR TITLE
Add declarative auto-pagination to plugin manifests

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1279,7 +1279,8 @@ func applyManagedParameters(def *provider.Definition, manifestPlugin *pluginmani
 		}
 	}
 
-	for opName, op := range def.Operations {
+	for opName := range def.Operations {
+		op := def.Operations[opName]
 		for _, param := range manifestPlugin.ManagedParameters {
 			if strings.EqualFold(strings.TrimSpace(param.In), "path") {
 				op.Path = strings.ReplaceAll(op.Path, "{"+strings.TrimSpace(param.Name)+"}", param.Value)

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1005,6 +1005,7 @@ func loadConfiguredAPIDefinition(ctx context.Context, name string, resolved reso
 	if cfg.applyResponseMapping {
 		applyProviderResponseMapping(def, cfg.manifestPlugin)
 	}
+	applyProviderPagination(def, cfg.manifestPlugin, cfg.allowedOperations)
 	if meta.displayName != "" {
 		def.DisplayName = meta.displayName
 	}
@@ -1331,6 +1332,67 @@ func applyProviderResponseMapping(def *provider.Definition, manifestPlugin *plug
 		}
 	}
 	def.ResponseMapping = rm
+}
+
+func applyProviderPagination(def *provider.Definition, manifestPlugin *pluginmanifestv1.Plugin, allowedOperations map[string]*config.OperationOverride) {
+	if def == nil || manifestPlugin == nil {
+		return
+	}
+	for opName, override := range allowedOperations {
+		if override == nil || !override.Paginate {
+			continue
+		}
+		pgn := mergedPaginationConfig(manifestPlugin.Pagination, override.Pagination)
+		if pgn == nil {
+			continue
+		}
+		op := def.Operations[opName]
+		op.Pagination = &provider.PaginationDef{
+			Style:        pgn.Style,
+			CursorParam:  pgn.CursorParam,
+			CursorPath:   pgn.CursorPath,
+			LimitParam:   pgn.LimitParam,
+			DefaultLimit: pgn.DefaultLimit,
+			ResultsPath:  pgn.ResultsPath,
+			MaxPages:     pgn.MaxPages,
+		}
+		def.Operations[opName] = op
+	}
+}
+
+func mergedPaginationConfig(base, override *pluginmanifestv1.ManifestPaginationConfig) *pluginmanifestv1.ManifestPaginationConfig {
+	if base == nil && override == nil {
+		return nil
+	}
+	if base == nil {
+		return override
+	}
+	if override == nil {
+		return base
+	}
+	merged := *base
+	if override.Style != "" {
+		merged.Style = override.Style
+	}
+	if override.CursorParam != "" {
+		merged.CursorParam = override.CursorParam
+	}
+	if override.CursorPath != "" {
+		merged.CursorPath = override.CursorPath
+	}
+	if override.LimitParam != "" {
+		merged.LimitParam = override.LimitParam
+	}
+	if override.DefaultLimit != 0 {
+		merged.DefaultLimit = override.DefaultLimit
+	}
+	if override.ResultsPath != "" {
+		merged.ResultsPath = override.ResultsPath
+	}
+	if override.MaxPages != 0 {
+		merged.MaxPages = override.MaxPages
+	}
+	return &merged
 }
 
 func firstProviderIconSVG(providers ...core.Provider) string {

--- a/gestaltd/internal/bootstrap/connections.go
+++ b/gestaltd/internal/bootstrap/connections.go
@@ -172,8 +172,8 @@ func (plan pluginConnectionPlan) connectionMode() core.ConnectionMode {
 	}
 
 	addMode(connectionModeForConnection(plan.pluginConnection))
-	for _, conn := range plan.namedConnections {
-		addMode(connectionModeForConnection(conn))
+	for name := range plan.namedConnections {
+		addMode(connectionModeForConnection(plan.namedConnections[name]))
 	}
 
 	switch {

--- a/gestaltd/internal/pluginpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/pluginpkg/manifest_workflow_test.go
@@ -312,6 +312,16 @@ provider:
     - in: path
       name: workspaceId
       value: ws_123
+  pagination:
+    style: cursor
+    cursor_param: cursor
+    cursor_path: nextCursor
+    results_path: results
+    max_pages: 10
+  allowed_operations:
+    items.list:
+      paginate: true
+    items.info: {}
   surfaces:
     openapi:
       document: openapi.yaml
@@ -338,5 +348,11 @@ provider:
 	}
 	if manifest.Entrypoints.Provider != nil {
 		t.Fatalf("expected declarative/spec provider to omit provider entrypoint, got %+v", manifest.Entrypoints.Provider)
+	}
+	if pgn := manifest.Plugin.Pagination; pgn == nil || pgn.Style != "cursor" || pgn.CursorPath != "nextCursor" || pgn.MaxPages != 10 {
+		t.Fatalf("unexpected pagination config: %+v", manifest.Plugin.Pagination)
+	}
+	if op := manifest.Plugin.AllowedOperations["items.list"]; op == nil || !op.Paginate {
+		t.Fatalf("items.list should have paginate=true, got %+v", manifest.Plugin.AllowedOperations["items.list"])
 	}
 }

--- a/gestaltd/internal/pluginpkg/provider_manifest_wire.go
+++ b/gestaltd/internal/pluginpkg/provider_manifest_wire.go
@@ -29,6 +29,7 @@ type providerManifestWire struct {
 	Headers           map[string]string                                      `json:"headers,omitempty" yaml:"headers,omitempty"`
 	ManagedParameters []pluginmanifestv1.ManagedParameter                    `json:"managed_parameters,omitempty" yaml:"managed_parameters,omitempty"`
 	ResponseMapping   *pluginmanifestv1.ManifestResponseMapping              `json:"response_mapping,omitempty" yaml:"response_mapping,omitempty"`
+	Pagination        *pluginmanifestv1.ManifestPaginationConfig             `json:"pagination,omitempty" yaml:"pagination,omitempty"`
 	AllowedOperations map[string]*pluginmanifestv1.ManifestOperationOverride `json:"allowed_operations,omitempty" yaml:"allowed_operations,omitempty"`
 	Surfaces          providerManifestSurfacesWire                           `json:"surfaces,omitempty" yaml:"surfaces,omitempty"`
 	MCP               *providerManifestMCPWire                               `json:"mcp,omitempty" yaml:"mcp,omitempty"`
@@ -129,6 +130,7 @@ func providerWireToInternal(wire *providerManifestWireRoot) *pluginmanifestv1.Ma
 			Headers:           wire.Provider.Headers,
 			ManagedParameters: wire.Provider.ManagedParameters,
 			ResponseMapping:   wire.Provider.ResponseMapping,
+			Pagination:        wire.Provider.Pagination,
 			AllowedOperations: wire.Provider.AllowedOperations,
 		}
 		if len(manifest.Kinds) == 0 {
@@ -237,6 +239,7 @@ func internalProviderManifestToWire(manifest *pluginmanifestv1.Manifest) *provid
 		Headers:           manifest.Plugin.Headers,
 		ManagedParameters: manifest.Plugin.ManagedParameters,
 		ResponseMapping:   manifest.Plugin.ResponseMapping,
+		Pagination:        manifest.Plugin.Pagination,
 		AllowedOperations: manifest.Plugin.AllowedOperations,
 	}
 	if manifest.Entrypoints.Provider != nil {

--- a/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -107,6 +107,9 @@
         "response_mapping": {
           "$ref": "#/$defs/response_mapping"
         },
+        "pagination": {
+          "$ref": "#/$defs/pagination_config"
+        },
         "allowed_operations": {
           "type": "object",
           "additionalProperties": {
@@ -666,6 +669,43 @@
         }
       }
     },
+    "pagination_config": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "style"
+      ],
+      "properties": {
+        "style": {
+          "type": "string",
+          "enum": [
+            "cursor",
+            "offset",
+            "page"
+          ]
+        },
+        "cursor_param": {
+          "type": "string"
+        },
+        "cursor_path": {
+          "type": "string"
+        },
+        "limit_param": {
+          "type": "string"
+        },
+        "default_limit": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "results_path": {
+          "type": "string"
+        },
+        "max_pages": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
     "manifest_operation_override": {
       "type": "object",
       "additionalProperties": false,
@@ -675,6 +715,12 @@
         },
         "description": {
           "type": "string"
+        },
+        "paginate": {
+          "type": "boolean"
+        },
+        "pagination": {
+          "$ref": "#/$defs/pagination_config"
         }
       }
     },

--- a/gestaltd/sdk/pluginmanifest/v1/types.go
+++ b/gestaltd/sdk/pluginmanifest/v1/types.go
@@ -60,6 +60,7 @@ type Plugin struct {
 	DefaultConnection string                                `json:"default_connection,omitempty" yaml:"default_connection,omitempty"`
 	Connections       map[string]*ManifestConnectionDef     `json:"connections,omitempty" yaml:"connections,omitempty"`
 	ResponseMapping   *ManifestResponseMapping              `json:"response_mapping,omitempty" yaml:"response_mapping,omitempty"`
+	Pagination        *ManifestPaginationConfig             `json:"pagination,omitempty" yaml:"pagination,omitempty"`
 }
 
 func (p *Plugin) IsDeclarative() bool {
@@ -105,9 +106,21 @@ type ProviderConnectionParam struct {
 	From        string `json:"from,omitempty" yaml:"from,omitempty"`
 }
 
+type ManifestPaginationConfig struct {
+	Style        string `json:"style" yaml:"style"`
+	CursorParam  string `json:"cursor_param,omitempty" yaml:"cursor_param,omitempty"`
+	CursorPath   string `json:"cursor_path,omitempty" yaml:"cursor_path,omitempty"`
+	LimitParam   string `json:"limit_param,omitempty" yaml:"limit_param,omitempty"`
+	DefaultLimit int    `json:"default_limit,omitempty" yaml:"default_limit,omitempty"`
+	ResultsPath  string `json:"results_path,omitempty" yaml:"results_path,omitempty"`
+	MaxPages     int    `json:"max_pages,omitempty" yaml:"max_pages,omitempty"`
+}
+
 type ManifestOperationOverride struct {
-	Alias       string `json:"alias,omitempty" yaml:"alias,omitempty"`
-	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Alias       string                    `json:"alias,omitempty" yaml:"alias,omitempty"`
+	Description string                    `json:"description,omitempty" yaml:"description,omitempty"`
+	Paginate    bool                      `json:"paginate,omitempty" yaml:"paginate,omitempty"`
+	Pagination  *ManifestPaginationConfig `json:"pagination,omitempty" yaml:"pagination,omitempty"`
 }
 
 type ManifestConnectionDef struct {


### PR DESCRIPTION
## Summary

- Plugins can declare provider-wide `pagination` config (style, cursor_param, cursor_path, limit_param, results_path, max_pages)
- Individual operations opt in via `paginate: true` on `allowed_operations` entries, with optional per-operation overrides
- When enabled, gestaltd auto-paginates (fetches all pages, combines results) instead of returning single pages with cursor metadata
- Reuses existing `DoPaginated` engine and `buildPaginationConfigs` pipeline — no changes needed to the execution layer

Example plugin.yaml:
```yaml
plugin:
  pagination:
    style: cursor
    cursor_param: cursor
    cursor_path: nextCursor
    limit_param: limit
    default_limit: 100
    results_path: results
  allowed_operations:
    candidate.list: { paginate: true }
    candidate.info: {}
```

## Test plan

- [x] Wire format round-trip: pagination config survives encode/decode through provider manifest wire format
- [x] All existing tests pass (pluginpkg, bootstrap, provider)
- [x] `go build ./...` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)