### PR TITLE
Deploy docs to gestaltd.ai

### DIFF
--- a/.github/workflows/publish-dockerhub-image.yml
+++ b/.github/workflows/publish-dockerhub-image.yml
@@ -63,7 +63,7 @@ jobs:
     env:
       IMAGE_NAME: ${{ inputs.image-name }}
       IMAGE_SOURCE: https://github.com/${{ github.repository }}
-      IMAGE_DOCUMENTATION: https://docs.valon.tools
+      IMAGE_DOCUMENTATION: https://gestaltd.ai
       IMAGE_URL: ${{ inputs.image-url }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release-gestalt-cli.yml
+++ b/.github/workflows/release-gestalt-cli.yml
@@ -36,7 +36,7 @@ jobs:
       install-markdown: |
         - Homebrew: `brew upgrade gestalt`
         - Docker: `docker pull valontechnologies/gestalt:${version}`
-        - Docs: [CLI reference](https://docs.valon.tools/reference/cli)
+        - Docs: [CLI reference](https://gestaltd.ai/reference/cli)
       exclude-subject-patterns: |
         ^Update gestalt formula to v
       download-artifact-pattern: 'gestalt-*'

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -107,7 +107,7 @@ jobs:
       install-markdown: |
         - Homebrew: `brew upgrade gestaltd`
         - Docker: `docker pull valontechnologies/gestaltd:${version}`
-        - Docs: [Deployment guide](https://docs.valon.tools/deploy)
+        - Docs: [Deployment guide](https://gestaltd.ai/deploy)
       exclude-subject-patterns: |
         ^Update gestaltd formula and chart to v
       download-artifact-pattern: 'gestaltd-*'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,5 +61,5 @@ If you add a new built-in auth provider, datastore, secret manager, or named pro
 
 1. Register it in the relevant `gestaltd/cmd/gestaltd` file.
 2. Add or update tests.
-3. Update [Built-in Providers](https://docs.valon.tools/reference/built-in-providers).
+3. Update [Built-in Providers](https://gestaltd.ai/reference/built-in-providers).
 4. Update any docs or examples that describe the supported inventory.

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Write your own plugins or point Gestalt at any OpenAPI spec, MCP server, or Grap
 
 ## Getting started
 
-See the [Getting Started](https://docs.valon.tools/getting-started) guide.
+See the [Getting Started](https://gestaltd.ai/getting-started) guide.
 
 ## Documentation
 
-[docs.valon.tools](https://docs.valon.tools)
+[gestaltd.ai](https://gestaltd.ai)

--- a/docs/dockerhub/gestalt.md
+++ b/docs/dockerhub/gestalt.md
@@ -106,6 +106,6 @@ of the Docker image.
 
 ## Learn more
 
-- Docs: https://docs.valon.tools
-- CLI reference: https://docs.valon.tools/reference/cli
+- Docs: https://gestaltd.ai
+- CLI reference: https://gestaltd.ai/reference/cli
 - Source: https://github.com/valon-technologies/gestalt

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -257,7 +257,7 @@ RUN cd ./my-plugin && \
 
 ## Learn more
 
-- Docs: https://docs.valon.tools
-- CLI reference: https://docs.valon.tools/reference/cli
-- Deployment docs: https://docs.valon.tools/deploy
+- Docs: https://gestaltd.ai
+- CLI reference: https://gestaltd.ai/reference/cli
+- Deployment docs: https://gestaltd.ai/deploy
 - Source: https://github.com/valon-technologies/gestalt

--- a/docs/terraform/main.tf
+++ b/docs/terraform/main.tf
@@ -114,11 +114,43 @@ resource "google_compute_global_forwarding_rule" "docs" {
   ip_address            = google_compute_global_address.docs.address
 }
 
+# ---------- HTTP-to-HTTPS Redirect ----------
+
+resource "google_compute_url_map" "docs_http_redirect" {
+  name = "toolshed-docs-http-redirect"
+
+  default_url_redirect {
+    https_redirect         = true
+    strip_query            = false
+    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+  }
+}
+
+resource "google_compute_target_http_proxy" "docs_redirect" {
+  name    = "toolshed-docs-http-proxy"
+  url_map = google_compute_url_map.docs_http_redirect.id
+}
+
+resource "google_compute_global_forwarding_rule" "docs_http" {
+  name                  = "toolshed-docs-http-forwarding-rule"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  target                = google_compute_target_http_proxy.docs_redirect.id
+  port_range            = "80"
+  ip_address            = google_compute_global_address.docs.address
+}
+
 # ---------- DNS ----------
+
+resource "google_dns_managed_zone" "docs" {
+  provider    = google.dns
+  name        = "gestaltd-ai"
+  dns_name    = "${var.domain}."
+  description = "DNS zone for ${var.domain}"
+}
 
 resource "google_dns_record_set" "docs" {
   provider     = google.dns
-  managed_zone = var.dns_zone_name
+  managed_zone = google_dns_managed_zone.docs.name
   name         = "${var.domain}."
   type         = "A"
   ttl          = 300

--- a/docs/terraform/outputs.tf
+++ b/docs/terraform/outputs.tf
@@ -12,3 +12,8 @@ output "cloud_run_url" {
   description = "Direct Cloud Run URL (not publicly reachable due to ingress restriction)"
   value       = google_cloud_run_v2_service.docs.uri
 }
+
+output "dns_zone_nameservers" {
+  description = "Nameservers for the DNS zone - set these in your domain registrar"
+  value       = google_dns_managed_zone.docs.name_servers
+}

--- a/docs/terraform/variables.tf
+++ b/docs/terraform/variables.tf
@@ -21,16 +21,10 @@ variable "dns_project_id" {
   default     = "serviceone"
 }
 
-variable "dns_zone_name" {
-  description = "Cloud DNS managed zone name"
-  type        = string
-  default     = "valon-tools"
-}
-
 variable "domain" {
   description = "Docs site domain"
   type        = string
-  default     = "docs.valon.tools"
+  default     = "gestaltd.ai"
 }
 
 variable "docs_image" {

--- a/gestalt/Dockerfile
+++ b/gestalt/Dockerfile
@@ -2,7 +2,7 @@ ARG GESTALT_VERSION=dev
 ARG GESTALT_REVISION=unknown
 ARG GESTALT_CREATED=unknown
 ARG GESTALT_SOURCE=https://github.com/valon-technologies/gestalt
-ARG GESTALT_DOCUMENTATION=https://docs.valon.tools
+ARG GESTALT_DOCUMENTATION=https://gestaltd.ai
 ARG GESTALT_URL=https://hub.docker.com/r/valontechnologies/gestalt
 
 FROM --platform=$BUILDPLATFORM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS unpack

--- a/gestaltd/Dockerfile
+++ b/gestaltd/Dockerfile
@@ -2,7 +2,7 @@ ARG GESTALT_VERSION=dev
 ARG GESTALT_REVISION=unknown
 ARG GESTALT_CREATED=unknown
 ARG GESTALT_SOURCE=https://github.com/valon-technologies/gestalt
-ARG GESTALT_DOCUMENTATION=https://docs.valon.tools
+ARG GESTALT_DOCUMENTATION=https://gestaltd.ai
 ARG GESTALT_URL=https://hub.docker.com/r/valontechnologies/gestaltd
 
 FROM --platform=$BUILDPLATFORM node:25.9.0-alpine3.23@sha256:ad82ecad30371c43f4057aaa4800a8ed88f9446553a2d21323710c7b937177fc AS frontend


### PR DESCRIPTION
Switch the docs site domain from docs.valon.tools to gestaltd.ai. This adds a Terraform-managed Cloud DNS zone for gestaltd.ai in the serviceone project, updates the DNS record and SSL certificate to use the new domain, and adds an HTTP-to-HTTPS redirect on port 80 for the apex domain. The dns_zone_nameservers output provides the nameserver values to configure in Squarespace.

All hardcoded docs.valon.tools URLs across the repo (README, CONTRIBUTING, Dockerfiles, release workflows, DockerHub descriptions) are updated to gestaltd.ai.