### PR TITLE
Document TypeScript provider support and fix secrets runtime wiring

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -6,6 +6,7 @@ on:
       - 'sdk/go/v*'
       - 'sdk/python/v*'
       - 'sdk/rust/v*'
+      - 'sdk/typescript/v*'
 
 permissions:
   contents: write
@@ -170,3 +171,94 @@ jobs:
           fi
 
           uv publish --publish-url "${GESTALT_PYTHON_PUBLISH_URL}"
+
+  publish-typescript-sdk:
+    if: ${{ startsWith(github.ref_name, 'sdk/typescript/v') }}
+    name: Publish TypeScript SDK
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: sdk/typescript
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Normalize package version from tag
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path("package.json")
+          data = json.loads(path.read_text())
+          data["version"] = os.environ["VERSION"].removeprefix("sdk/typescript/v")
+          path.write_text(json.dumps(data, indent=2) + "\n")
+          PY
+
+      - name: Run SDK checks
+        run: bun run check
+
+      - name: Configure registry auth
+        env:
+          GESTALT_TYPESCRIPT_PUBLISH_URL: ${{ secrets.GESTALT_TYPESCRIPT_PUBLISH_URL }}
+          GESTALT_TYPESCRIPT_PUBLISH_TOKEN: ${{ secrets.GESTALT_TYPESCRIPT_PUBLISH_TOKEN }}
+          GESTALT_TYPESCRIPT_PUBLISH_USERNAME: ${{ secrets.GESTALT_TYPESCRIPT_PUBLISH_USERNAME }}
+          GESTALT_TYPESCRIPT_PUBLISH_PASSWORD: ${{ secrets.GESTALT_TYPESCRIPT_PUBLISH_PASSWORD }}
+        run: |
+          if [ -z "${GESTALT_TYPESCRIPT_PUBLISH_URL}" ]; then
+            echo "GESTALT_TYPESCRIPT_PUBLISH_URL must be configured" >&2
+            exit 1
+          fi
+
+          if [ -z "${GESTALT_TYPESCRIPT_PUBLISH_TOKEN}" ] && { [ -z "${GESTALT_TYPESCRIPT_PUBLISH_USERNAME}" ] || [ -z "${GESTALT_TYPESCRIPT_PUBLISH_PASSWORD}" ]; }; then
+            echo "configure GESTALT_TYPESCRIPT_PUBLISH_TOKEN or GESTALT_TYPESCRIPT_PUBLISH_USERNAME and GESTALT_TYPESCRIPT_PUBLISH_PASSWORD" >&2
+            exit 1
+          fi
+
+          registry_host="$(python3 - <<'PY'
+          import os
+          from urllib.parse import urlparse
+
+          url = urlparse(os.environ["GESTALT_TYPESCRIPT_PUBLISH_URL"])
+          path = url.path or "/"
+          if not path.endswith("/"):
+            path += "/"
+          print(f"//{url.netloc}{path}")
+          PY
+          )"
+
+          userconfig="$RUNNER_TEMP/.npmrc"
+          {
+            printf "registry=%s\n" "$GESTALT_TYPESCRIPT_PUBLISH_URL"
+            printf "always-auth=true\n"
+            if [ -n "${GESTALT_TYPESCRIPT_PUBLISH_TOKEN}" ]; then
+              printf "%s:_authToken=%s\n" "$registry_host" "$GESTALT_TYPESCRIPT_PUBLISH_TOKEN"
+            else
+              password_b64="$(printf '%s' "$GESTALT_TYPESCRIPT_PUBLISH_PASSWORD" | base64 | tr -d '\n')"
+              printf "%s:username=%s\n" "$registry_host" "$GESTALT_TYPESCRIPT_PUBLISH_USERNAME"
+              printf "%s:_password=%s\n" "$registry_host" "$password_b64"
+              printf "%s:email=%s\n" "$registry_host" "gestalt-ci@valon.com"
+            fi
+          } > "$userconfig"
+
+          echo "NPM_CONFIG_USERCONFIG=$userconfig" >> "$GITHUB_ENV"
+
+      - name: Dry-run publish
+        env:
+          GESTALT_TYPESCRIPT_PUBLISH_URL: ${{ secrets.GESTALT_TYPESCRIPT_PUBLISH_URL }}
+        run: bun publish --dry-run --registry "${GESTALT_TYPESCRIPT_PUBLISH_URL}"
+
+      - name: Publish package
+        env:
+          GESTALT_TYPESCRIPT_PUBLISH_URL: ${{ secrets.GESTALT_TYPESCRIPT_PUBLISH_URL }}
+        run: bun publish --registry "${GESTALT_TYPESCRIPT_PUBLISH_URL}"

--- a/docs/content/providers/auth.mdx
+++ b/docs/content/providers/auth.mdx
@@ -172,23 +172,32 @@ An auth provider implements three methods: `Configure`, `BeginLogin`, and `Compl
     ```
   </Tabs.Tab>
   <Tabs.Tab>
-    ```typescript
+    ```ts
     import { defineAuthProvider } from "@valon-technologies/gestalt";
 
     let clientId = "";
     let issuerUrl = "";
 
     export const provider = defineAuthProvider({
-      configure(_name, config) {
-        clientId = config.client_id as string;
-        issuerUrl = config.issuer_url as string;
+      async configure(_name, config) {
+        clientId = typeof config.client_id === "string" ? config.client_id : "";
+        issuerUrl = typeof config.issuer_url === "string" ? config.issuer_url : "";
       },
-      beginLogin(request) {
-        const authUrl = `${issuerUrl}/authorize?client_id=${clientId}&redirect_uri=${request.callbackUrl}&state=${request.hostState}&response_type=code`;
-        return { authorizationUrl: authUrl };
+      async beginLogin(request) {
+        return {
+          authorizationUrl:
+            `${issuerUrl}/authorize` +
+            `?client_id=${encodeURIComponent(clientId)}` +
+            `&redirect_uri=${encodeURIComponent(request.callbackUrl)}` +
+            `&state=${encodeURIComponent(request.hostState)}` +
+            `&response_type=code`,
+        };
       },
-      completeLogin(request) {
+      async completeLogin(request) {
         const code = request.query.code ?? "";
+        if (!code) {
+          throw new Error("missing authorization code");
+        }
         // Exchange code for tokens, extract user info.
         return {
           subject: "user-123",
@@ -200,7 +209,21 @@ An auth provider implements three methods: `Configure`, `BeginLogin`, and `Compl
     });
     ```
 
-    Optional handlers: `validateExternalToken` for direct token validation, `sessionSettings` to control session lifetime.
+    Point `package.json` at the auth provider with `gestalt.provider`:
+
+    ```json
+    {
+      "gestalt": {
+        "provider": {
+          "kind": "auth",
+          "target": "./auth.ts#provider"
+        }
+      }
+    }
+    ```
+
+    Optional handlers: `validateExternalToken` for direct token validation and
+    `sessionSettings` to control session lifetime.
   </Tabs.Tab>
 </Tabs>
 
@@ -208,9 +231,9 @@ An auth provider implements three methods: `Configure`, `BeginLogin`, and `Compl
 
 Two optional interfaces extend the base contract.
 
-**ExternalTokenValidator** lets API clients present a token directly instead of going through the browser login flow. In Go, implement the `ExternalTokenValidator` interface on your provider. In Python, inherit from `gestalt.ExternalTokenValidator`. In Rust, override the `validate_external_token` method, which returns an unimplemented error by default.
+**ExternalTokenValidator** lets API clients present a token directly instead of going through the browser login flow. In Go, implement the `ExternalTokenValidator` interface on your provider. In Python, inherit from `gestalt.ExternalTokenValidator`. In Rust, override the `validate_external_token` method, which returns an unimplemented error by default. In TypeScript, provide the optional `validateExternalToken` handler to `defineAuthProvider`.
 
-**SessionTTLProvider** controls session lifetime. The default is 24 hours. In Go, implement the `SessionTTLProvider` interface. In Python, inherit from `gestalt.SessionTTLProvider`. In Rust, override the `session_ttl` method, which returns `None` (the 24-hour default) by default.
+**SessionTTLProvider** controls session lifetime. The default is 24 hours. In Go, implement the `SessionTTLProvider` interface. In Python, inherit from `gestalt.SessionTTLProvider`. In Rust, override the `session_ttl` method, which returns `None` (the 24-hour default) by default. In TypeScript, provide the optional `sessionSettings` handler to `defineAuthProvider`.
 
 ## Config reference
 

--- a/docs/content/providers/datastores.mdx
+++ b/docs/content/providers/datastores.mdx
@@ -170,43 +170,65 @@ A datastore provider is a larger interface than auth or integration providers. I
     OAuth registration methods (`get_oauth_registration`, `put_oauth_registration`, `delete_oauth_registration`) have default implementations that return unimplemented errors. Override them to support MCP OAuth.
   </Tabs.Tab>
   <Tabs.Tab>
-    ```typescript
-    import { defineDatastoreProvider, type StoredUser, type StoredIntegrationToken, type StoredAPIToken } from "@valon-technologies/gestalt";
+    ```ts
+    import { defineDatastoreProvider } from "@valon-technologies/gestalt";
+
+    const users = new Map<string, { id: string; email: string }>();
 
     export const provider = defineDatastoreProvider({
-      configure(_name, config) {
-        // Initialize database connection from config.dsn
+      async healthCheck() {},
+      async migrate() {},
+      async getUser(id) {
+        return users.get(id) ?? null;
       },
-      migrate() {
-        // Create users, integration_tokens, and api_tokens tables.
+      async findOrCreateUser(email) {
+        const user = users.get(email) ?? { id: email, email };
+        users.set(email, user);
+        return user;
       },
-
-      // UserStore
-      getUser(id) { /* ... */ },
-      findOrCreateUser(email) { /* ... */ },
-
-      // IntegrationTokenStore (tokens are pre-sealed by the host)
-      putIntegrationToken(token) { /* ... */ },
-      getIntegrationToken(userId, integration, connection, instance) { /* ... */ },
-      listIntegrationTokens(userId, integration, connection) { /* ... */ },
-      deleteIntegrationToken(id) { /* ... */ },
-
-      // APITokenStore (tokens are SHA-256 hashed, not encrypted)
-      putApiToken(token) { /* ... */ },
-      getApiTokenByHash(hashedToken) { /* ... */ },
-      listApiTokens(userId) { /* ... */ },
-      revokeApiToken(userId, id) { /* ... */ },
-      revokeAllApiTokens(userId) { /* ... */ },
+      async putIntegrationToken() {},
+      async getIntegrationToken() {
+        return null;
+      },
+      async listIntegrationTokens() {
+        return [];
+      },
+      async deleteIntegrationToken() {},
+      async putApiToken() {},
+      async getApiTokenByHash() {
+        return null;
+      },
+      async listApiTokens() {
+        return [];
+      },
+      async revokeApiToken() {},
+      async revokeAllApiTokens() {
+        return 0;
+      },
     });
     ```
 
-    Optional handlers: `getOAuthRegistration`, `putOAuthRegistration`, `deleteOAuthRegistration` for MCP OAuth dynamic client registration.
+    Point `package.json` at the datastore provider with `gestalt.provider`:
+
+    ```json
+    {
+      "gestalt": {
+        "provider": {
+          "kind": "datastore",
+          "target": "./datastore.ts#provider"
+        }
+      }
+    }
+    ```
+
+    Optional handlers: `getOAuthRegistration`, `putOAuthRegistration`, and
+    `deleteOAuthRegistration` support MCP OAuth dynamic client registration.
   </Tabs.Tab>
 </Tabs>
 
 ## OAuthRegistrationStore
 
-If your deployment uses MCP OAuth with dynamic client registration, the datastore needs to store OAuth client registrations. This is an optional interface. Implement `GetOAuthRegistration`, `PutOAuthRegistration`, and `DeleteOAuthRegistration` in Go, inherit from `gestalt.OAuthRegistrationStore` in Python, or override the default methods in Rust.
+If your deployment uses MCP OAuth with dynamic client registration, the datastore needs to store OAuth client registrations. This is an optional interface. Implement `GetOAuthRegistration`, `PutOAuthRegistration`, and `DeleteOAuthRegistration` in Go, inherit from `gestalt.OAuthRegistrationStore` in Python, override the default methods in Rust, or provide the optional `getOAuthRegistration`, `putOAuthRegistration`, and `deleteOAuthRegistration` handlers in TypeScript.
 
 Deployments that do not use MCP OAuth can skip this entirely. The default implementations return unimplemented errors, which is the correct behavior when MCP OAuth is not configured.
 

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -31,14 +31,16 @@ Providers run in their own process. They cannot access the host process memory, 
 
 ## SDK support
 
-Gestalt ships SDKs for four languages:
+Gestalt ships first-party SDKs for four languages:
 
 - **Go** (`sdk/go`)
 - **Python** (`sdk/python`)
 - **Rust** (`sdk/rust`)
-- **TypeScript** (`@valon-technologies/gestalt`)
+- **TypeScript** (`sdk/typescript`, published as `@valon-technologies/gestalt`)
 
-The underlying protocol is gRPC, so other languages are possible, but the documented authoring flow targets Go, Python, Rust, and TypeScript.
+The underlying protocol is gRPC, so other languages are possible, but the documented authoring flow targets those SDKs.
+
+Go, Rust, and TypeScript support plugin, auth, and datastore providers. Python remains focused on plugin providers.
 
 ## Operation ID conventions
 

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -135,11 +135,11 @@ The manifest stays the source of truth for display name, description, auth, the 
     Use the `sdk/rust/v*` tag that matches the SDK release you want to target.
   </Tabs.Tab>
   <Tabs.Tab>
-    You need Bun (or Node.js 22+) and a running `gestaltd` instance for testing.
+    You need Bun 1.3+ and a running `gestaltd` instance for testing.
 
     ```sh
     mkdir my-plugin && cd my-plugin
-    bun init
+    bun init -y
     bun add @valon-technologies/gestalt
     ```
 
@@ -152,11 +152,13 @@ The manifest stays the source of truth for display name, description, auth, the 
       provider.ts
     ```
 
-    Point `package.json` at the module that Gestalt should load:
+    Point `package.json` at the source file Gestalt should load:
 
     ```json
     {
       "name": "my-plugin",
+      "version": "0.0.1-alpha.1",
+      "private": true,
       "type": "module",
       "dependencies": {
         "@valon-technologies/gestalt": "0.0.1-alpha.1"
@@ -169,6 +171,24 @@ The manifest stays the source of truth for display name, description, auth, the 
       }
     }
     ```
+
+    A string `gestalt.provider` target defaults to a plugin provider. For auth
+    or datastore providers, use an object with an explicit kind:
+
+    ```json
+    {
+      "gestalt": {
+        "provider": {
+          "kind": "auth",
+          "target": "./auth.ts#provider"
+        }
+      }
+    }
+    ```
+
+    Use `"plugin"` when you need to spell the plugin kind explicitly. The
+    legacy `integration` spelling and the older `gestalt.plugin` shorthand are
+    still accepted.
   </Tabs.Tab>
 </Tabs>
 
@@ -361,7 +381,7 @@ Operations are the callable units of a plugin. Each operation has an ID, an HTTP
           description: "Return a greeting message",
           readOnly: true,
           input: s.object({
-            name: s.optional(s.string({ description: "Name to greet", default: "World" })),
+            name: s.string({ description: "Name to greet", default: "World" }),
           }),
           output: s.object({
             message: s.string(),
@@ -373,6 +393,11 @@ Operations are the callable units of a plugin. Each operation has an ID, an HTTP
       ],
     });
     ```
+
+    The `package.json` field `gestalt.provider` points Gestalt at the provider
+    module and optional export. Use a string target such as
+    `./provider.ts#provider` for plugin providers, or an object with `kind` and
+    `target` for auth and datastore providers.
   </Tabs.Tab>
 </Tabs>
 
@@ -425,19 +450,24 @@ The router derives catalog parameters from the input type. Fields are required b
     Fields are required unless you model them as `Option<T>` or provide a serde default. Use `schemars(description = "...")` for catalog descriptions and serde defaults for scalar defaults.
   </Tabs.Tab>
   <Tabs.Tab>
-    ```typescript
-    import { s } from "@valon-technologies/gestalt";
-
-    const searchInput = s.object({
+    ```ts
+    const SearchInput = s.object({
       query: s.string({ description: "Search query" }),
-      max_items: s.optional(s.integer({ description: "Maximum results", default: 10 })),
-      filters: s.optional(s.object({
-        status: s.optional(s.string()),
-      })),
+      max_items: s.integer({ description: "Maximum results", default: 10 }),
+      filters: s.optional(
+        s.object(
+          {
+            status: s.optional(s.string()),
+          },
+          { description: "Optional filter set" },
+        ),
+      ),
     });
     ```
 
-    Fields are required by default. Wrap with `s.optional()` for optional fields. Use `s.object()` for nested types and `s.array()` for collections.
+    TypeScript plugins describe runtime input schemas explicitly. Requiredness,
+    descriptions, defaults, nested objects, and arrays come from that schema
+    definition rather than from erased TypeScript types.
   </Tabs.Tab>
 </Tabs>
 
@@ -528,7 +558,11 @@ By default, the operation catalog is static and materialized at startup. If your
           name: "my-plugin-session",
           displayName: request.token,
           operations: [
-            { id: "search_private", method: "POST", readOnly: true },
+            {
+              id: "search_private",
+              method: "POST",
+              readOnly: true,
+            },
           ],
         };
       },

--- a/docs/content/providers/releasing.mdx
+++ b/docs/content/providers/releasing.mdx
@@ -29,8 +29,9 @@ plugin:
 ```
 
 Executable source packages stay language-native. Gestalt loads the provider
-from the package root, then synthesizes the runnable wrapper during local
-source execution and release packaging.
+from the package root or the language-specific target declaration, then
+synthesizes the runnable wrapper during local source execution and release
+packaging.
 
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
@@ -100,6 +101,7 @@ source execution and release packaging.
     ```json
     {
       "name": "my-plugin",
+      "version": "0.0.1-alpha.1",
       "type": "module",
       "dependencies": {
         "@valon-technologies/gestalt": "0.0.1-alpha.1"
@@ -112,6 +114,9 @@ source execution and release packaging.
       }
     }
     ```
+
+    TypeScript auth and datastore providers use `gestalt.provider` objects
+    such as `{ "kind": "auth", "target": "./auth.ts#provider" }`.
   </Tabs.Tab>
 </Tabs>
 
@@ -181,18 +186,23 @@ Run this from the provider source directory. It produces release archives and wr
 
 Release tags are derived from the package path after the repository. For example, `source: github.com/acme/plugins/catalog/support-api` releases from the tag `plugins/catalog/support-api/v0.1.0`.
 
-For executable Go, Python, Rust, and TypeScript integration source plugins, `provider release`
-materializes the executable catalog automatically and builds the host-platform
-artifact by default. Auth and datastore source packages use the same
-release flow without catalog generation. Pass `--platform` with a
-comma-separated list such as
-`--platform linux/amd64/glibc,linux/amd64/musl,darwin/arm64` to build explicit
-targets. Pass `--platform all` in CI release jobs to build the full supported
-platform matrix for source builds.
+For executable Go, Rust, Python, and TypeScript source providers,
+`provider release` materializes the executable catalog automatically and builds
+the host-platform artifact by default. Go, Rust, and TypeScript auth/datastore
+source packages use the same release flow without catalog generation. Pass
+`--platform` with a comma-separated list such as
+`--platform linux/amd64,darwin/arm64` to build explicit targets, or
+`--platform linux/amd64/glibc,linux/amd64/musl,darwin/arm64` when you need
+Linux libc variants. Pass `--platform all` in CI release jobs to build the
+full supported platform matrix for source builds.
 
 For non-host Python targets, point Gestalt at a matching interpreter with
 `GESTALT_PYTHON_<GOOS>_<GOARCH>` or a target-specific virtualenv such as
 `.venv-<goos>-<goarch>/`.
+
+TypeScript source plugins require Bun for local source execution and
+packaging. The SDK uses Bun's compile flow to build standalone provider
+binaries during release.
 
 ## Reference releases from config
 

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -479,7 +479,12 @@ Manifest paths must stay inside the package. `source` and `version` are required
 
 A connection using `mcp_oauth` auth requires the plugin to declare an MCP surface (via `mcp_url` or an equivalent). Manifests that set `auth.type: mcp_oauth` without an MCP surface fail validation.
 
-When an executable plugin defines operations in Go, Python, Rust, or TypeScript, Gestalt materializes the executable catalog automatically during local source-plugin execution and `provider release`. Auth and datastore source packages use the same release flow without catalog generation. See [Plugins](/providers/plugins) for the end-to-end authoring flow.
+When an executable plugin defines helper operations in Go, Rust, Python, or
+TypeScript, Gestalt materializes the executable catalog automatically during
+local source-plugin execution and `provider release`. Auth and datastore
+source packages use the same release flow for Go, Rust, and TypeScript, but
+they do not generate catalogs. See [Plugins](/providers/plugins)
+for the end-to-end authoring flow.
 
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
@@ -564,4 +569,18 @@ Build a release from a provider source directory:
 gestaltd provider release --version 1.2.3
 ```
 
-`gestaltd provider release` preserves the source manifest format, so `plugin.yaml` stays YAML and `plugin.json` stays JSON in the release archive. For executable Go, Python, Rust, and TypeScript integration plugins, release materializes the executable catalog automatically before packaging. Auth and datastore source packages use the same release flow without catalog generation. Source packages build the host-platform artifact by default. Pass `--platform` for an explicit `os/arch[/libc]` target list, or `--platform all` in CI to build the full supported release matrix.
+`gestaltd provider release` preserves the source manifest format, so
+`plugin.yaml` stays YAML and `plugin.json` stays JSON in the release archive.
+For executable Go and Rust plugins, release materializes the executable
+catalog automatically before packaging. Python source plugins load the module
+declared in `[tool.gestalt].plugin` and materialize the executable catalog
+automatically. TypeScript source providers load the target declared in
+`package.json` under `gestalt.provider`. A string target such as
+`./provider.ts#plugin` defaults to a plugin provider; auth and datastore
+providers use an object with `kind` and `target`. Use `"plugin"` as the
+explicit plugin kind when needed. The legacy `integration` spelling and the
+older `gestalt.plugin` shorthand are still accepted. Auth and datastore source
+packages support the same release flow for Go, Rust, and TypeScript, but they
+do not generate catalogs. Source packages build the host-platform artifact by
+default. Pass `--platform` for an explicit `os/arch[/libc]` target list, or
+`--platform all` in CI to build the full supported release matrix.

--- a/gestaltd/internal/pluginhost/secrets_client.go
+++ b/gestaltd/internal/pluginhost/secrets_client.go
@@ -39,7 +39,7 @@ func NewExecutableSecretManager(ctx context.Context, cfg SecretsExecConfig) (cor
 		return nil, err
 	}
 
-	runtimeClient := proto.NewPluginRuntimeClient(proc.conn)
+	runtimeClient := proto.NewProviderLifecycleClient(proc.conn)
 	secretsClient := proto.NewSecretsProviderClient(proc.conn)
 
 	_, err = configureRuntimePlugin(ctx, runtimeClient, proto.PluginKind_PLUGIN_KIND_SECRETS, cfg.Name, cfg.Config)

--- a/sdk/go/secrets.go
+++ b/sdk/go/secrets.go
@@ -5,6 +5,6 @@ import (
 )
 
 type SecretsProvider interface {
-	RuntimeProvider
+	PluginProvider
 	GetSecret(ctx context.Context, name string) (string, error)
 }

--- a/sdk/go/serve_secrets.go
+++ b/sdk/go/serve_secrets.go
@@ -10,7 +10,7 @@ import (
 // ServeSecretsProvider starts a gRPC server for a [SecretsProvider].
 func ServeSecretsProvider(ctx context.Context, secrets SecretsProvider) error {
 	return servePlugin(withPluginCloser(ctx, secrets), func(srv *grpc.Server) {
-		proto.RegisterPluginRuntimeServer(srv, newRuntimeProviderServer(ProviderKindSecrets, secrets))
+		proto.RegisterProviderLifecycleServer(srv, newPluginProviderServer(ProviderKindSecrets, secrets))
 		proto.RegisterSecretsProviderServer(srv, newSecretsProviderServer(secrets))
 	})
 }


### PR DESCRIPTION
## Summary
- document TypeScript provider authoring for plugin, auth, and datastore providers
- document `gestalt.provider` targets, Bun-based release packaging, and provider-manifest expectations
- publish `sdk/typescript` from `sdk/typescript/v*` tags in `release-sdk.yml`
- fix the Go secrets-provider runtime wiring after the `ProviderLifecycle` / `PluginProvider` rename so this branch builds cleanly

## Interface Changes
TypeScript source providers are documented through `package.json` under `gestalt.provider`:

```json
{
  "name": "my-plugin",
  "version": "0.0.1-alpha.1",
  "type": "module",
  "gestalt": {
    "provider": {
      "kind": "plugin",
      "target": "./provider.ts#provider"
    }
  }
}
```

Auth and datastore providers can declare the kind explicitly:

```json
{
  "gestalt": {
    "provider": {
      "kind": "auth",
      "target": "./auth.ts#provider"
    }
  }
}
```

```json
{
  "gestalt": {
    "provider": {
      "kind": "datastore",
      "target": "./datastore.ts#provider"
    }
  }
}
```

The docs now show the TypeScript SDK entrypoints:

```ts
import {
  defineIntegrationProvider,
  defineAuthProvider,
  defineDatastoreProvider,
} from "@valon-technologies/gestalt";
```

The branch also aligns the Go secrets-provider runtime with the renamed host interface:

```go
type SecretsProvider interface {
	PluginProvider
	GetSecret(ctx context.Context, name string) (string, error)
}
```

```go
proto.RegisterProviderLifecycleServer(srv, newPluginProviderServer(ProviderKindSecrets, secrets))
```

## Example Usage
```ts
import { defineIntegrationProvider, ok, operation, s } from "@valon-technologies/gestalt";

export const provider = defineIntegrationProvider({
  operations: [
    operation({
      id: "greet",
      method: "GET",
      input: s.object({
        name: s.string({ default: "World" }),
      }),
      output: s.object({
        message: s.string(),
      }),
      handler(input) {
        return ok({ message: `Hello, ${input.name}!` });
      },
    }),
  ],
});
```

```sh
bun install
gestaltd provider release --version 0.0.1-alpha.1
```

```sh
git tag sdk/typescript/v0.0.1-alpha.1
git push origin sdk/typescript/v0.0.1-alpha.1
```

## Newly Supported Behavior
- Documentation for TypeScript plugin, auth, and datastore providers.
- Documentation for `gestalt.provider`, including the preferred `plugin` kind token and the legacy `integration` alias.
- Release automation for publishing `sdk/typescript` from `sdk/typescript/v*` tags.
- The Go secrets-provider path now builds with the renamed `ProviderLifecycle` / `PluginProvider` runtime interfaces.

## Not Supported
- A standalone TypeScript SDK CI workflow in this PR.
- Non-Bun packaging guidance for TypeScript source providers.
- Additional TypeScript provider kinds beyond plugin, auth, and datastore.

## Validation
- `cd gestaltd && go mod tidy && git diff --exit-code go.mod go.sum`
- `cd gestaltd && go test ./...`
- `cd gestaltd && golangci-lint run`
- `cd docs && npm run build`
