### PR TITLE
Support Rust auth and datastore source providers

### DIFF
--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -1098,7 +1098,7 @@ func setupAuthProviderDir(t *testing.T, baseDir, name string) string {
 	if err := os.MkdirAll(filepath.Dir(artifactPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(artifactPath), err)
 	}
-	if err := pluginpkg.BuildSourceComponentReleaseBinary(providerDir, artifactPath, pluginmanifestv1.KindAuth, runtime.GOOS, runtime.GOARCH); err != nil {
+	if _, err := pluginpkg.BuildSourceComponentReleaseBinary(providerDir, artifactPath, pluginmanifestv1.KindAuth, runtime.GOOS, runtime.GOARCH, ""); err != nil {
 		t.Fatalf("BuildSourceComponentReleaseBinary(%s): %v", providerDir, err)
 	}
 	writeManifestFile(t, providerDir, &pluginmanifestv1.Manifest{
@@ -1143,7 +1143,7 @@ func setupDatastoreProviderDir(t *testing.T, baseDir, name string) string {
 	if err := os.MkdirAll(filepath.Dir(artifactPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(artifactPath), err)
 	}
-	if err := pluginpkg.BuildSourceComponentReleaseBinary(providerDir, artifactPath, pluginmanifestv1.KindDatastore, runtime.GOOS, runtime.GOARCH); err != nil {
+	if _, err := pluginpkg.BuildSourceComponentReleaseBinary(providerDir, artifactPath, pluginmanifestv1.KindDatastore, runtime.GOOS, runtime.GOARCH, ""); err != nil {
 		t.Fatalf("BuildSourceComponentReleaseBinary(%s): %v", providerDir, err)
 	}
 	writeManifestFile(t, providerDir, &pluginmanifestv1.Manifest{

--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -199,7 +199,7 @@ func resolveReleaseBuildPlatforms(root string, manifest *pluginmanifestv1.Manife
 	builds := make([]releasePlatform, 0, len(platforms))
 	var missingSource bool
 	for _, platform := range platforms {
-		if err := validateReleaseBuildTarget(root, target.Kind, platform.GOOS, platform.GOARCH); err != nil {
+		if err := validateReleaseBuildTarget(root, target.Kind, platform.GOOS, platform.GOARCH, platform.LibC); err != nil {
 			if isMissingReleaseSourceBuildTarget(err, target.Kind) {
 				missingSource = true
 				continue
@@ -318,23 +318,23 @@ func detectReleaseSourceBuildTarget(root, kind string) (bool, error) {
 	}
 }
 
-func validateReleaseBuildTarget(root, kind, goos, goarch string) error {
+func validateReleaseBuildTarget(root, kind, goos, goarch, libc string) error {
 	switch kind {
 	case pluginmanifestv1.KindPlugin:
-		return pluginpkg.ValidateSourceProviderRelease(root, goos, goarch)
+		return pluginpkg.ValidateSourceProviderRelease(root, goos, goarch, libc)
 	case pluginmanifestv1.KindAuth, pluginmanifestv1.KindDatastore:
-		return pluginpkg.ValidateSourceComponentRelease(root, kind, goos, goarch)
+		return pluginpkg.ValidateSourceComponentRelease(root, kind, goos, goarch, libc)
 	default:
 		return fmt.Errorf("unsupported release build target kind %q", kind)
 	}
 }
 
-func buildReleaseTargetBinary(root, outputPath, pluginName, kind, goos, goarch string) (string, error) {
+func buildReleaseTargetBinary(root, outputPath, pluginName, kind, goos, goarch, libc string) (string, error) {
 	switch kind {
 	case pluginmanifestv1.KindPlugin:
-		return pluginpkg.BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch)
+		return pluginpkg.BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch, libc)
 	case pluginmanifestv1.KindAuth, pluginmanifestv1.KindDatastore:
-		return "", pluginpkg.BuildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch)
+		return pluginpkg.BuildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch, libc)
 	default:
 		return "", fmt.Errorf("unsupported release build target kind %q", kind)
 	}
@@ -358,11 +358,11 @@ func missingReleaseSourceBuildTargetError(kinds []string) error {
 	case 1:
 		switch kinds[0] {
 		case pluginmanifestv1.KindPlugin:
-			return fmt.Errorf("no Go or Python provider package found")
+			return fmt.Errorf("no Go, Rust, or Python provider package found")
 		case pluginmanifestv1.KindAuth:
-			return fmt.Errorf("no Go auth source package found")
+			return fmt.Errorf("no Go or Rust auth source package found")
 		case pluginmanifestv1.KindDatastore:
-			return fmt.Errorf("no Go datastore source package found")
+			return fmt.Errorf("no Go or Rust datastore source package found")
 		}
 	}
 	return fmt.Errorf("missing source packages for executable kinds: %s", strings.Join(kinds, ", "))
@@ -428,7 +428,7 @@ func prepareBuiltPackageDir(stagingDir, sourceDir string, srcManifest *pluginman
 	plat := platform
 	binaryName := releaseBinaryName(pluginName, plat.GOOS)
 	binaryPath := filepath.Join(stagingDir, binaryName)
-	builtLibC, err := buildReleaseTargetBinary(sourceDir, binaryPath, pluginName, buildKind, plat.GOOS, plat.GOARCH)
+	builtLibC, err := buildReleaseTargetBinary(sourceDir, binaryPath, pluginName, buildKind, plat.GOOS, plat.GOARCH, plat.LibC)
 	if err != nil {
 		return nil, releasePlatform{}, err
 	}

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"net/url"
 	"os"
 	"os/exec"
@@ -39,6 +40,8 @@ const (
 	datastoreReleasePluginName = "datastore-release"
 	datastoreReleaseSource     = "github.com/testowner/plugins/datastore-release"
 	datastoreReleaseSchemaPath = "schemas/datastore.schema.json"
+	rustReleasePluginName      = "provider-rust"
+	rustWrapperBinaryName      = "gestalt-provider-wrapper"
 )
 
 func TestRun_PluginHelpExitsCleanly(t *testing.T) {
@@ -462,6 +465,137 @@ func TestRun_PluginReleaseBuildsPythonSourcePluginForRequestedPlatforms(t *testi
 	}
 }
 
+func TestRun_PluginReleaseBuildsRustSourcePluginForCurrentPlatform(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake cargo test fixture is POSIX-only")
+	}
+
+	hostTarget, _, err := pluginpkgRustTargetTriple(runtime.GOOS, runtime.GOARCH, "")
+	if err != nil {
+		t.Fatalf("pluginpkgRustTargetTriple(host): %v", err)
+	}
+
+	fakeCargoDir := t.TempDir()
+	writeFakeRustReleaseCargo(t, filepath.Join(fakeCargoDir, "cargo"), fakeRustCargoConfig{
+		ExpectedPluginName:   rustReleasePluginName,
+		ExpectedServeExport:  "__gestalt_serve",
+		ExpectedCatalogWrite: true,
+		GeneratedCatalog:     rustReleasePluginName,
+		DelegateBinary:       pluginBin,
+		AllowedTargets:       []string{hostTarget},
+	})
+	t.Setenv("PATH", fakeCargoDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	pluginDir := newRustSourceReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.12-rust-current"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := expectedRustArchiveName(testVersion, runtime.GOOS, runtime.GOARCH, "")
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+	binaryName := releaseBinaryName(rustReleasePluginName, runtime.GOOS)
+
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != binaryName {
+		t.Fatalf("artifacts = %+v, want path %q", manifest.Artifacts, binaryName)
+	}
+	assertExpectedRustArtifactPlatform(t, manifest.Artifacts[0], runtime.GOOS, runtime.GOARCH, "")
+	if manifest.Entrypoints.Provider == nil || manifest.Entrypoints.Provider.ArtifactPath != binaryName {
+		t.Fatalf("provider entrypoint = %+v, want artifact path %q", manifest.Entrypoints.Provider, binaryName)
+	}
+
+	artifactPath := filepath.Join(extractDir, binaryName)
+	if _, err := os.Stat(artifactPath); err != nil {
+		t.Fatalf("expected %s in archive: %v", binaryName, err)
+	}
+	catalogPath := filepath.Join(extractDir, pluginpkg.StaticCatalogFile)
+	catalogData, err := os.ReadFile(catalogPath)
+	if err != nil {
+		t.Fatalf("read generated catalog: %v", err)
+	}
+	if !strings.Contains(string(catalogData), "id: greet") {
+		t.Fatalf("unexpected generated catalog: %s", catalogData)
+	}
+
+	ctx := context.Background()
+	prov, err := pluginhost.NewExecutableProvider(ctx, pluginhost.ExecConfig{
+		Command: artifactPath,
+		StaticSpec: pluginhost.StaticProviderSpec{
+			Name: rustReleasePluginName,
+		},
+		Config: map[string]any{"greeting": "Hi"},
+	})
+	if err != nil {
+		t.Fatalf("NewExecutableProvider: %v", err)
+	}
+	defer func() {
+		if closer, ok := prov.(interface{ Close() error }); ok {
+			_ = closer.Close()
+		}
+	}()
+
+	result, err := prov.Execute(ctx, "greet", map[string]any{"name": "Ada"}, "")
+	if err != nil {
+		t.Fatalf("Execute(greet): %v", err)
+	}
+	if result.Status != 200 {
+		t.Fatalf("status = %d, want 200", result.Status)
+	}
+	if !strings.Contains(result.Body, "Hi, Ada!") {
+		t.Fatalf("body = %q, want greeting", result.Body)
+	}
+}
+
+func TestRun_PluginReleaseBuildsRustSourcePluginForExplicitLinuxTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake cargo test fixture is POSIX-only")
+	}
+
+	hostTarget, _, err := pluginpkgRustTargetTriple(runtime.GOOS, runtime.GOARCH, "")
+	if err != nil {
+		t.Fatalf("pluginpkgRustTargetTriple(host): %v", err)
+	}
+	explicitTarget, _, err := pluginpkgRustTargetTriple("linux", "amd64", pluginpkg.LinuxLibCMusl)
+	if err != nil {
+		t.Fatalf("pluginpkgRustTargetTriple(linux/amd64/musl): %v", err)
+	}
+
+	fakeCargoDir := t.TempDir()
+	writeFakeRustReleaseCargo(t, filepath.Join(fakeCargoDir, "cargo"), fakeRustCargoConfig{
+		ExpectedPluginName:   rustReleasePluginName,
+		ExpectedServeExport:  "__gestalt_serve",
+		ExpectedCatalogWrite: true,
+		GeneratedCatalog:     rustReleasePluginName,
+		DelegateBinary:       pluginBin,
+		AllowedTargets:       []string{hostTarget, explicitTarget},
+	})
+	t.Setenv("PATH", fakeCargoDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	pluginDir := newRustSourceReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.12-rust-musl"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", "linux/amd64/musl",
+		"--output", outputDir,
+	)
+
+	archiveName := expectedRustArchiveName(testVersion, "linux", "amd64", pluginpkg.LinuxLibCMusl)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+	binaryName := releaseBinaryName(rustReleasePluginName, "linux")
+
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != binaryName {
+		t.Fatalf("artifacts = %+v, want path %q", manifest.Artifacts, binaryName)
+	}
+	assertExpectedRustArtifactPlatform(t, manifest.Artifacts[0], "linux", "amd64", pluginpkg.LinuxLibCMusl)
+}
+
 func TestRun_PluginReleaseRejectsMissingCrossTargetInterpreterForPythonSourcePlugin(t *testing.T) {
 	t.Parallel()
 
@@ -542,7 +676,7 @@ func TestRun_PluginReleaseBuildsGoSourceAuthPlugin(t *testing.T) {
 		"--output", outputDir,
 	)
 
-	archiveName := "gestalt-plugin-" + authReleasePluginName + "_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	archiveName := platformArchiveName(authReleasePluginName, testVersion, expectedGoReleasePlatform(runtime.GOOS, runtime.GOARCH, ""))
 	extractDir := extractReleasedArchive(t, outputDir, archiveName)
 	manifest := readReleasedManifest(t, outputDir, archiveName)
 	binaryName := releaseBinaryName(authReleasePluginName, runtime.GOOS)
@@ -550,6 +684,7 @@ func TestRun_PluginReleaseBuildsGoSourceAuthPlugin(t *testing.T) {
 	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != binaryName {
 		t.Fatalf("artifacts = %+v, want path %q", manifest.Artifacts, binaryName)
 	}
+	assertExpectedGoArtifactPlatform(t, manifest.Artifacts[0], runtime.GOOS, runtime.GOARCH, "")
 	if manifest.Entrypoints.Auth == nil || manifest.Entrypoints.Auth.ArtifactPath != binaryName {
 		t.Fatalf("auth entrypoint = %+v, want artifact path %q", manifest.Entrypoints.Auth, binaryName)
 	}
@@ -666,7 +801,7 @@ func TestRun_PluginReleaseBuildsGoSourceDatastorePlugin(t *testing.T) {
 		"--output", outputDir,
 	)
 
-	archiveName := "gestalt-plugin-" + datastoreReleasePluginName + "_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	archiveName := platformArchiveName(datastoreReleasePluginName, testVersion, expectedGoReleasePlatform(runtime.GOOS, runtime.GOARCH, ""))
 	extractDir := extractReleasedArchive(t, outputDir, archiveName)
 	manifest := readReleasedManifest(t, outputDir, archiveName)
 	binaryName := releaseBinaryName(datastoreReleasePluginName, runtime.GOOS)
@@ -674,6 +809,203 @@ func TestRun_PluginReleaseBuildsGoSourceDatastorePlugin(t *testing.T) {
 	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != binaryName {
 		t.Fatalf("artifacts = %+v, want path %q", manifest.Artifacts, binaryName)
 	}
+	assertExpectedGoArtifactPlatform(t, manifest.Artifacts[0], runtime.GOOS, runtime.GOARCH, "")
+	if manifest.Entrypoints.Datastore == nil || manifest.Entrypoints.Datastore.ArtifactPath != binaryName {
+		t.Fatalf("datastore entrypoint = %+v, want artifact path %q", manifest.Entrypoints.Datastore, binaryName)
+	}
+	if _, err := os.Stat(filepath.Join(extractDir, datastoreReleaseSchemaPath)); err != nil {
+		t.Fatalf("expected %s in archive: %v", datastoreReleaseSchemaPath, err)
+	}
+
+	store, err := pluginhost.NewExecutableDatastore(context.Background(), pluginhost.DatastoreExecConfig{
+		Command:       filepath.Join(extractDir, binaryName),
+		Name:          "datastore-release",
+		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
+	})
+	if err != nil {
+		t.Fatalf("NewExecutableDatastore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	user, err := store.FindOrCreateUser(context.Background(), "datastore-user@example.com")
+	if err != nil {
+		t.Fatalf("FindOrCreateUser: %v", err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	token := &core.IntegrationToken{
+		ID:           "tok-1",
+		UserID:       user.ID,
+		Integration:  "github",
+		Connection:   "default",
+		Instance:     "prod",
+		AccessToken:  "plain-access",
+		RefreshToken: "plain-refresh",
+		MetadataJSON: `{"tenant":"acme"}`,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if err := store.StoreToken(context.Background(), token); err != nil {
+		t.Fatalf("StoreToken: %v", err)
+	}
+	got, err := store.Token(context.Background(), user.ID, "github", "default", "prod")
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if got == nil || got.AccessToken != "plain-access" || got.RefreshToken != "plain-refresh" {
+		t.Fatalf("token = %+v", got)
+	}
+	if warnings, ok := store.(interface{ Warnings() []string }); !ok {
+		t.Fatal("datastore did not expose Warnings()")
+	} else if gotWarnings := warnings.Warnings(); len(gotWarnings) != 1 || gotWarnings[0] != "generated datastore warning" {
+		t.Fatalf("Warnings() = %v", gotWarnings)
+	}
+}
+
+func TestRun_PluginReleaseBuildsRustSourceAuthPlugin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake cargo test fixture is POSIX-only")
+	}
+
+	hostTarget, _, err := pluginpkgRustTargetTriple(runtime.GOOS, runtime.GOARCH, "")
+	if err != nil {
+		t.Fatalf("pluginpkgRustTargetTriple(host): %v", err)
+	}
+
+	fakeCargoDir := t.TempDir()
+	writeFakeRustReleaseCargo(t, filepath.Join(fakeCargoDir, "cargo"), fakeRustCargoConfig{
+		ExpectedPluginName:   authReleasePluginName,
+		ExpectedServeExport:  "__gestalt_serve_auth",
+		ExpectedCatalogWrite: false,
+		DelegateBinary:       buildGoSourceAuthBinary(t),
+		AllowedTargets:       []string{hostTarget},
+	})
+	t.Setenv("PATH", fakeCargoDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	pluginDir := newRustSourceAuthReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.17-rust-auth"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := platformArchiveName(authReleasePluginName, testVersion, expectedRustReleasePlatform(runtime.GOOS, runtime.GOARCH, ""))
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+	binaryName := releaseBinaryName(authReleasePluginName, runtime.GOOS)
+
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != binaryName {
+		t.Fatalf("artifacts = %+v, want path %q", manifest.Artifacts, binaryName)
+	}
+	assertExpectedRustArtifactPlatform(t, manifest.Artifacts[0], runtime.GOOS, runtime.GOARCH, "")
+	if manifest.Entrypoints.Auth == nil || manifest.Entrypoints.Auth.ArtifactPath != binaryName {
+		t.Fatalf("auth entrypoint = %+v, want artifact path %q", manifest.Entrypoints.Auth, binaryName)
+	}
+	if _, err := os.Stat(filepath.Join(extractDir, authReleaseSchemaPath)); err != nil {
+		t.Fatalf("expected %s in archive: %v", authReleaseSchemaPath, err)
+	}
+
+	auth, err := pluginhost.NewExecutableAuthProvider(context.Background(), pluginhost.AuthExecConfig{
+		Command:     filepath.Join(extractDir, binaryName),
+		Name:        "auth-release",
+		CallbackURL: "https://gestalt.example.test/api/v1/auth/login/callback",
+		SessionKey:  []byte("0123456789abcdef0123456789abcdef"),
+	})
+	if err != nil {
+		t.Fatalf("NewExecutableAuthProvider: %v", err)
+	}
+	defer func() {
+		if closer, ok := auth.(interface{ Close() error }); ok {
+			_ = closer.Close()
+		}
+	}()
+
+	loginURL, err := auth.LoginURL("host-state")
+	if err != nil {
+		t.Fatalf("LoginURL: %v", err)
+	}
+	parsed, err := url.Parse(loginURL)
+	if err != nil {
+		t.Fatalf("url.Parse(loginURL): %v", err)
+	}
+	state := parsed.Query().Get("state")
+	if state == "" {
+		t.Fatal("login URL did not include state")
+	}
+
+	callbackHandler, ok := auth.(interface {
+		HandleCallbackRequest(context.Context, url.Values) (*core.UserIdentity, string, error)
+	})
+	if !ok {
+		t.Fatal("auth provider did not expose HandleCallbackRequest")
+	}
+	identity, originalState, err := callbackHandler.HandleCallbackRequest(context.Background(), url.Values{
+		"code":   {"callback-code"},
+		"state":  {state},
+		"prompt": {parsed.Query().Get("prompt")},
+	})
+	if err != nil {
+		t.Fatalf("HandleCallbackRequest: %v", err)
+	}
+	if originalState != "host-state" {
+		t.Fatalf("original state = %q, want %q", originalState, "host-state")
+	}
+	if identity == nil || identity.Email != "generated-auth@example.com" {
+		t.Fatalf("identity = %+v", identity)
+	}
+	if ttlProvider, ok := auth.(interface{ SessionTokenTTL() time.Duration }); !ok || ttlProvider.SessionTokenTTL() != 90*time.Minute {
+		t.Fatalf("SessionTokenTTL = %v", ttlProvider)
+	}
+}
+
+func TestRun_PluginReleaseBuildsRustSourceDatastorePlugin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake cargo test fixture is POSIX-only")
+	}
+
+	hostTarget, _, err := pluginpkgRustTargetTriple(runtime.GOOS, runtime.GOARCH, "")
+	if err != nil {
+		t.Fatalf("pluginpkgRustTargetTriple(host): %v", err)
+	}
+
+	fakeCargoDir := t.TempDir()
+	writeFakeRustReleaseCargo(t, filepath.Join(fakeCargoDir, "cargo"), fakeRustCargoConfig{
+		ExpectedPluginName:   datastoreReleasePluginName,
+		ExpectedServeExport:  "__gestalt_serve_datastore",
+		ExpectedCatalogWrite: false,
+		DelegateBinary:       buildGoSourceDatastoreBinary(t),
+		AllowedTargets:       []string{hostTarget},
+	})
+	t.Setenv("PATH", fakeCargoDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	pluginDir := newRustSourceDatastoreReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.18-rust-datastore"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := platformArchiveName(datastoreReleasePluginName, testVersion, expectedRustReleasePlatform(runtime.GOOS, runtime.GOARCH, ""))
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+	binaryName := releaseBinaryName(datastoreReleasePluginName, runtime.GOOS)
+
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != binaryName {
+		t.Fatalf("artifacts = %+v, want path %q", manifest.Artifacts, binaryName)
+	}
+	assertExpectedRustArtifactPlatform(t, manifest.Artifacts[0], runtime.GOOS, runtime.GOARCH, "")
 	if manifest.Entrypoints.Datastore == nil || manifest.Entrypoints.Datastore.ArtifactPath != binaryName {
 		t.Fatalf("datastore entrypoint = %+v, want artifact path %q", manifest.Entrypoints.Datastore, binaryName)
 	}
@@ -1006,7 +1338,7 @@ func TestRun_PluginReleaseRejectsRequiredExecutableKindsWithoutSourceOrEntrypoin
 				Kinds:       []string{pluginmanifestv1.KindPlugin},
 				Plugin:      &pluginmanifestv1.Plugin{},
 			},
-			wantError: "no Go or Python provider package found",
+			wantError: "no Go, Rust, or Python provider package found",
 		},
 		{
 			name: "auth",
@@ -1017,7 +1349,7 @@ func TestRun_PluginReleaseRejectsRequiredExecutableKindsWithoutSourceOrEntrypoin
 				Kinds:       []string{pluginmanifestv1.KindAuth},
 				Auth:        &pluginmanifestv1.AuthMetadata{},
 			},
-			wantError: "no Go auth source package found",
+			wantError: "no Go or Rust auth source package found",
 		},
 		{
 			name: "datastore",
@@ -1028,7 +1360,7 @@ func TestRun_PluginReleaseRejectsRequiredExecutableKindsWithoutSourceOrEntrypoin
 				Kinds:       []string{pluginmanifestv1.KindDatastore},
 				Datastore:   &pluginmanifestv1.DatastoreMetadata{},
 			},
-			wantError: "no Go datastore source package found",
+			wantError: "no Go or Rust datastore source package found",
 		},
 	}
 
@@ -1330,10 +1662,58 @@ func expectedPythonArchiveName(version, goos, goarch string) string {
 	return platformArchiveName("python-release", version, expectedPythonReleasePlatform(goos, goarch))
 }
 
+func expectedGoReleasePlatform(goos, goarch, libc string) releasePlatform {
+	return releasePlatform{GOOS: goos, GOARCH: goarch, LibC: libc}
+}
+
+func expectedRustReleasePlatform(goos, goarch, libc string) releasePlatform {
+	plat := releasePlatform{GOOS: goos, GOARCH: goarch, LibC: libc}
+	if plat.GOOS != "linux" || plat.LibC != "" {
+		return plat
+	}
+	if runtime.GOOS == "linux" && goos == "linux" {
+		plat.LibC = pluginpkg.CurrentRuntimeLibC()
+	}
+	if plat.LibC == "" {
+		plat.LibC = pluginpkg.LinuxLibCGLibC
+	}
+	return plat
+}
+
+func expectedRustArchiveName(version, goos, goarch, libc string) string {
+	return platformArchiveName(rustReleasePluginName, version, expectedRustReleasePlatform(goos, goarch, libc))
+}
+
 func assertExpectedPythonArtifactPlatform(t *testing.T, artifact pluginmanifestv1.Artifact, goos, goarch string) {
 	t.Helper()
 
 	want := expectedPythonReleasePlatform(goos, goarch)
+	if artifact.OS != want.GOOS || artifact.Arch != want.GOARCH || artifact.LibC != want.LibC {
+		t.Fatalf(
+			"artifact platform = %s/%s/%s, want %s/%s/%s",
+			artifact.OS, artifact.Arch, artifact.LibC,
+			want.GOOS, want.GOARCH, want.LibC,
+		)
+	}
+}
+
+func assertExpectedGoArtifactPlatform(t *testing.T, artifact pluginmanifestv1.Artifact, goos, goarch, libc string) {
+	t.Helper()
+
+	want := expectedGoReleasePlatform(goos, goarch, libc)
+	if artifact.OS != want.GOOS || artifact.Arch != want.GOARCH || artifact.LibC != want.LibC {
+		t.Fatalf(
+			"artifact platform = %s/%s/%s, want %s/%s/%s",
+			artifact.OS, artifact.Arch, artifact.LibC,
+			want.GOOS, want.GOARCH, want.LibC,
+		)
+	}
+}
+
+func assertExpectedRustArtifactPlatform(t *testing.T, artifact pluginmanifestv1.Artifact, goos, goarch, libc string) {
+	t.Helper()
+
+	want := expectedRustReleasePlatform(goos, goarch, libc)
 	if artifact.OS != want.GOOS || artifact.Arch != want.GOARCH || artifact.LibC != want.LibC {
 		t.Fatalf(
 			"artifact platform = %s/%s/%s, want %s/%s/%s",
@@ -1385,6 +1765,24 @@ func newSourceAuthReleaseFixture(t *testing.T, dir string) string {
 	return pluginDir
 }
 
+func newRustSourceAuthReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(dir, authReleasePluginName)
+	copyFixtureTree(t, rustAuthProviderFixturePath(t), pluginDir)
+	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
+		Source:      authReleaseSource,
+		Version:     "0.0.1",
+		DisplayName: "Auth Release",
+		Kinds:       []string{pluginmanifestv1.KindAuth},
+		Auth: &pluginmanifestv1.AuthMetadata{
+			ConfigSchemaPath: authReleaseSchemaPath,
+		},
+	})
+	writeTestFile(t, pluginDir, authReleaseSchemaPath, []byte(`{"type":"object"}`), 0o644)
+	return pluginDir
+}
+
 func newSourceDatastoreReleaseFixture(t *testing.T, dir string) string {
 	t.Helper()
 
@@ -1395,6 +1793,24 @@ func newSourceDatastoreReleaseFixture(t *testing.T, dir string) string {
 	writeTestFile(t, pluginDir, "go.mod", []byte(testutil.GeneratedProviderModuleSource(t, "example.com/"+datastoreReleasePluginName)), 0o644)
 	writeTestFile(t, pluginDir, "go.sum", testutil.GeneratedProviderModuleSum(t), 0o644)
 	writeTestFile(t, pluginDir, "datastore.go", []byte(testutil.GeneratedDatastorePackageSource()), 0o644)
+	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
+		Source:      datastoreReleaseSource,
+		Version:     "0.0.1",
+		DisplayName: "Datastore Release",
+		Kinds:       []string{pluginmanifestv1.KindDatastore},
+		Datastore: &pluginmanifestv1.DatastoreMetadata{
+			ConfigSchemaPath: datastoreReleaseSchemaPath,
+		},
+	})
+	writeTestFile(t, pluginDir, datastoreReleaseSchemaPath, []byte(`{"type":"object"}`), 0o644)
+	return pluginDir
+}
+
+func newRustSourceDatastoreReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(dir, datastoreReleasePluginName)
+	copyFixtureTree(t, rustDatastoreProviderFixturePath(t), pluginDir)
 	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
 		Source:      datastoreReleaseSource,
 		Version:     "0.0.1",
@@ -1422,6 +1838,14 @@ func pathWithoutGo(t *testing.T) string {
 		}
 	}
 	return dir
+}
+
+func newRustSourceReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(dir, rustReleasePluginName)
+	copyFixtureTree(t, rustProviderFixturePath(t), pluginDir)
+	return pluginDir
 }
 
 func newSourceProviderReleaseFixture(t *testing.T, dir string) string {
@@ -1488,6 +1912,262 @@ func writeStaticCatalogProviderMain(t *testing.T, dir string) {
 func writeStaticCatalogProviderMainAt(t *testing.T, dir, rel string) {
 	t.Helper()
 	writeTestFile(t, dir, rel, []byte(testutil.GeneratedProviderPackageSource()), 0644)
+}
+
+func rustProviderFixturePath(t *testing.T) string {
+	t.Helper()
+
+	root, ok := pluginTestRepoRoot()
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Join(root, "gestaltd", "internal", "testutil", "testdata", "provider-rust")
+}
+
+func rustAuthProviderFixturePath(t *testing.T) string {
+	t.Helper()
+
+	root, ok := pluginTestRepoRoot()
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Join(root, "gestaltd", "internal", "testutil", "testdata", "provider-rust-auth")
+}
+
+func rustDatastoreProviderFixturePath(t *testing.T) string {
+	t.Helper()
+
+	root, ok := pluginTestRepoRoot()
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Join(root, "gestaltd", "internal", "testutil", "testdata", "provider-rust-datastore")
+}
+
+func buildGoSourceAuthBinary(t *testing.T) string {
+	t.Helper()
+
+	providerDir := filepath.Join(t.TempDir(), "go-auth")
+	if err := os.MkdirAll(providerDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(providerDir): %v", err)
+	}
+	writeTestFile(t, providerDir, "go.mod", []byte(testutil.GeneratedProviderModuleSource(t, "example.com/test-go-auth")), 0o644)
+	writeTestFile(t, providerDir, "go.sum", testutil.GeneratedProviderModuleSum(t), 0o644)
+	writeTestFile(t, providerDir, "auth.go", []byte(testutil.GeneratedAuthPackageSource()), 0o644)
+	outputPath := filepath.Join(t.TempDir(), "auth-provider")
+	if err := pluginpkg.BuildGoComponentBinary(providerDir, outputPath, pluginmanifestv1.KindAuth, runtime.GOOS, runtime.GOARCH); err != nil {
+		t.Fatalf("BuildGoComponentBinary(auth): %v", err)
+	}
+	return outputPath
+}
+
+func buildGoSourceDatastoreBinary(t *testing.T) string {
+	t.Helper()
+
+	providerDir := filepath.Join(t.TempDir(), "go-datastore")
+	if err := os.MkdirAll(providerDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(providerDir): %v", err)
+	}
+	writeTestFile(t, providerDir, "go.mod", []byte(testutil.GeneratedProviderModuleSource(t, "example.com/test-go-datastore")), 0o644)
+	writeTestFile(t, providerDir, "go.sum", testutil.GeneratedProviderModuleSum(t), 0o644)
+	writeTestFile(t, providerDir, "datastore.go", []byte(testutil.GeneratedDatastorePackageSource()), 0o644)
+	outputPath := filepath.Join(t.TempDir(), "datastore-provider")
+	if err := pluginpkg.BuildGoComponentBinary(providerDir, outputPath, pluginmanifestv1.KindDatastore, runtime.GOOS, runtime.GOARCH); err != nil {
+		t.Fatalf("BuildGoComponentBinary(datastore): %v", err)
+	}
+	return outputPath
+}
+
+func copyFixtureTree(t *testing.T, src, dst string) {
+	t.Helper()
+
+	if err := filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, info.Mode())
+	}); err != nil {
+		t.Fatalf("copy fixture tree: %v", err)
+	}
+}
+
+type fakeRustCargoConfig struct {
+	ExpectedPluginName   string
+	ExpectedServeExport  string
+	ExpectedCatalogWrite bool
+	GeneratedCatalog     string
+	DelegateBinary       string
+	AllowedTargets       []string
+}
+
+func writeFakeRustReleaseCargo(t *testing.T, path string, cfg fakeRustCargoConfig) {
+	t.Helper()
+
+	allowedTargets := make([]string, 0, len(cfg.AllowedTargets))
+	for _, target := range cfg.AllowedTargets {
+		if target == "" {
+			continue
+		}
+		allowedTargets = append(allowedTargets, shellSingleQuoted(target))
+	}
+	script := `#!/bin/sh
+set -eu
+
+manifest=""
+target=""
+target_dir=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --manifest-path)
+      manifest="$2"
+      shift 2
+      ;;
+    --target)
+      target="$2"
+      shift 2
+      ;;
+    --target-dir)
+      target_dir="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$manifest" ] || [ -z "$target" ] || [ -z "$target_dir" ]; then
+  echo "missing cargo wrapper args" >&2
+  exit 1
+fi
+
+allowed=false
+for candidate in ` + strings.Join(allowedTargets, " ") + `; do
+  if [ "$target" = "$candidate" ]; then
+    allowed=true
+    break
+  fi
+done
+if [ "$allowed" != "true" ]; then
+  echo "unexpected target triple: $target" >&2
+  exit 1
+fi
+
+main_rs="$(dirname "$manifest")/src/main.rs"
+if ! grep -q 'const PLUGIN_NAME: &str = "` + cfg.ExpectedPluginName + `";' "$main_rs"; then
+  echo "missing plugin name in wrapper source" >&2
+  exit 1
+fi
+if ! grep -Fq 'provider_plugin::` + cfg.ExpectedServeExport + `(PLUGIN_NAME)?' "$main_rs"; then
+  echo "missing serve export in wrapper source" >&2
+  exit 1
+fi
+` + fakeRustReleaseCatalogCheck(cfg.ExpectedCatalogWrite) + `
+if ! grep -Fq 'Ok(())' "$main_rs"; then
+  echo "missing explicit Ok return in wrapper source" >&2
+  exit 1
+fi
+
+binary="$target_dir/$target/release/` + rustWrapperBinaryName + `"
+mkdir -p "$(dirname "$binary")"
+cat > "$binary" <<'EOF'
+#!/bin/sh
+set -eu
+if [ -n "${GESTALT_PLUGIN_WRITE_CATALOG:-}" ]; then
+  cat > "$GESTALT_PLUGIN_WRITE_CATALOG" <<'YAML'
+name: ` + cfg.GeneratedCatalog + `
+operations:
+  - id: greet
+    method: GET
+YAML
+  exit 0
+fi
+exec ` + shellSingleQuoted(cfg.DelegateBinary) + ` "$@"
+EOF
+chmod +x "$binary"
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+func fakeRustReleaseCatalogCheck(expectCatalog bool) string {
+	if expectCatalog {
+		return `if ! grep -Fq 'provider_plugin::__gestalt_write_catalog(PLUGIN_NAME, &path)?' "$main_rs"; then
+  echo "missing write-catalog export in wrapper source" >&2
+  exit 1
+fi`
+	}
+	return `if grep -Fq 'provider_plugin::__gestalt_write_catalog(PLUGIN_NAME, &path)?' "$main_rs"; then
+  echo "unexpected write-catalog export in wrapper source" >&2
+  exit 1
+fi`
+}
+
+func pluginpkgRustTargetTriple(goos, goarch, libc string) (string, string, error) {
+	switch goos {
+	case "darwin":
+		switch goarch {
+		case "amd64":
+			return "x86_64-apple-darwin", "", nil
+		case "arm64":
+			return "aarch64-apple-darwin", "", nil
+		}
+	case "linux":
+		normalizedLibC, err := pluginpkg.NormalizeArtifactLibC(goos, libc)
+		if err != nil {
+			return "", "", err
+		}
+		if normalizedLibC == "" {
+			normalizedLibC = expectedRustReleasePlatform(goos, goarch, "").LibC
+		}
+		switch goarch {
+		case "amd64":
+			if normalizedLibC == pluginpkg.LinuxLibCMusl {
+				return "x86_64-unknown-linux-musl", normalizedLibC, nil
+			}
+			return "x86_64-unknown-linux-gnu", normalizedLibC, nil
+		case "arm64":
+			if normalizedLibC == pluginpkg.LinuxLibCMusl {
+				return "aarch64-unknown-linux-musl", normalizedLibC, nil
+			}
+			return "aarch64-unknown-linux-gnu", normalizedLibC, nil
+		}
+	case "windows":
+		switch goarch {
+		case "amd64":
+			return "x86_64-pc-windows-gnu", "", nil
+		}
+	}
+	return "", "", fmt.Errorf("unsupported Rust target platform %s/%s", goos, goarch)
+}
+
+func shellSingleQuoted(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
+}
+
+func pluginTestRepoRoot() (string, bool) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", false
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..")), true
 }
 
 func newPrebuiltProviderReleaseFixture(t *testing.T, dir string) string {

--- a/gestaltd/internal/drivers/auth/plugin/factory.go
+++ b/gestaltd/internal/drivers/auth/plugin/factory.go
@@ -26,7 +26,7 @@ var Factory bootstrap.AuthFactory = func(node yaml.Node, deps bootstrap.Deps) (c
 	prepared, err := componentplugin.PrepareExecution(componentplugin.PrepareParams{
 		Kind:                 pluginmanifestv1.KindAuth,
 		Subject:              "plugin auth",
-		SourceMissingMessage: "no Go auth source package found",
+		SourceMissingMessage: "no Go or Rust auth source package found",
 		Config:               cfg.YAMLConfig,
 	})
 	if err != nil {

--- a/gestaltd/internal/drivers/datastore/plugin/factory.go
+++ b/gestaltd/internal/drivers/datastore/plugin/factory.go
@@ -19,7 +19,7 @@ var Factory bootstrap.DatastoreFactory = func(node yaml.Node, deps bootstrap.Dep
 	prepared, err := componentplugin.PrepareExecution(componentplugin.PrepareParams{
 		Kind:                 pluginmanifestv1.KindDatastore,
 		Subject:              "plugin datastore",
-		SourceMissingMessage: "no Go datastore source package found",
+		SourceMissingMessage: "no Go or Rust datastore source package found",
 		Config:               cfg,
 	})
 	if err != nil {

--- a/gestaltd/internal/pluginpkg/go_provider.go
+++ b/gestaltd/internal/pluginpkg/go_provider.go
@@ -1,6 +1,7 @@
 package pluginpkg
 
 import (
+	"bufio"
 	"bytes"
 	_ "embed"
 	"errors"
@@ -85,33 +86,54 @@ func BuildGoComponentBinary(root, outputPath, kind, goos, goarch string) error {
 }
 
 func SourceComponentExecutionCommand(root, kind, goos, goarch string) (string, []string, func(), error) {
-	if err := validateSourceComponentKind(kind); err != nil {
+	sourceKind, err := detectSourceComponent(root, kind, goos, goarch)
+	if err != nil {
 		return "", nil, nil, err
 	}
-	command, cleanup, err := BuildGoComponentTempBinary(root, kind, goos, goarch)
-	if err != nil {
-		if errors.Is(err, ErrNoSourceComponentPackage) {
-			return "", nil, nil, err
+	switch sourceKind {
+	case sourceProviderKindGo:
+		command, cleanup, err := BuildGoComponentTempBinary(root, kind, goos, goarch)
+		if err != nil {
+			return "", nil, nil, fmt.Errorf("build source %s temp binary: %w", kind, err)
 		}
-		return "", nil, nil, fmt.Errorf("build source %s temp binary: %w", kind, err)
+		return command, nil, cleanup, nil
+	case sourceProviderKindRust:
+		return rustComponentExecutionCommand(root, kind, goos, goarch)
+	default:
+		return "", nil, nil, ErrNoSourceComponentPackage
 	}
-	return command, nil, cleanup, nil
 }
 
-func ValidateSourceComponentRelease(root, kind, goos, goarch string) error {
-	_, err := DetectGoComponentImportPath(root, kind, goos, goarch)
-	return err
-}
-
-func BuildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch string) error {
-	if err := ValidateSourceComponentRelease(root, kind, goos, goarch); err != nil {
+func ValidateSourceComponentRelease(root, kind, goos, goarch, libc string) error {
+	sourceKind, err := detectSourceComponent(root, kind, goos, goarch)
+	if err != nil {
 		return err
 	}
-	return BuildGoComponentBinary(root, outputPath, kind, goos, goarch)
+	switch sourceKind {
+	case sourceProviderKindRust:
+		return ValidateRustComponentRelease(root, kind, goos, goarch, libc)
+	default:
+		return nil
+	}
+}
+
+func BuildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch, libc string) (string, error) {
+	sourceKind, err := detectSourceComponent(root, kind, goos, goarch)
+	if err != nil {
+		return "", err
+	}
+	switch sourceKind {
+	case sourceProviderKindGo:
+		return "", BuildGoComponentBinary(root, outputPath, kind, goos, goarch)
+	case sourceProviderKindRust:
+		return BuildRustComponentBinary(root, outputPath, kind, goos, goarch, libc)
+	default:
+		return "", ErrNoSourceComponentPackage
+	}
 }
 
 func HasSourceComponentPackage(root, kind string) (bool, error) {
-	_, err := DetectGoComponentImportPath(root, kind, runtime.GOOS, runtime.GOARCH)
+	_, err := detectSourceComponent(root, kind, runtime.GOOS, runtime.GOARCH)
 	switch {
 	case err == nil:
 		return true, nil
@@ -141,6 +163,10 @@ func detectGoPackageImportPath(root, buildTarget string, noSourceErr error, sour
 		return importPath, nil
 	}
 
+	fallbackModulePath, moduleErr := goModulePathFromFile(root)
+	if moduleErr != nil {
+		return "", moduleErr
+	}
 	modulePath, err := goPackageField(root, buildTarget, "{{if .Module}}{{.Module.Path}}{{end}}", goos, goarch)
 	if err == nil {
 		modulePath = strings.TrimSpace(modulePath)
@@ -148,7 +174,45 @@ func detectGoPackageImportPath(root, buildTarget string, noSourceErr error, sour
 			return modulePath, nil
 		}
 	}
+	if fallbackModulePath != "" {
+		return fallbackModulePath, nil
+	}
 	return importPath, nil
+}
+
+func goModulePathFromFile(root string) (string, error) {
+	file, err := os.Open(filepath.Join(root, "go.mod"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read go.mod: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(stripGoModComment(scanner.Text()))
+		if line == "" || !strings.HasPrefix(line, "module") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return "", fmt.Errorf("parse go.mod: module path is required")
+		}
+		return strings.Trim(fields[1], `"`), nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("scan go.mod: %w", err)
+	}
+	return "", nil
+}
+
+func stripGoModComment(line string) string {
+	if idx := strings.Index(line, "//"); idx >= 0 {
+		return line[:idx]
+	}
+	return line
 }
 
 func newGoSourceWrapper(root, goos, goarch string, noSourceErr error, sourceExists func(string) bool, tempPattern, description string, wrapperData func(string) (goExecutableWrapperData, error)) (string, func(), error) {
@@ -339,6 +403,32 @@ func slugPluginName(value string) string {
 		return "plugin"
 	}
 	return cleaned
+}
+
+func detectSourceComponent(root, kind, goos, goarch string) (string, error) {
+	if err := validateSourceComponentKind(kind); err != nil {
+		return "", err
+	}
+
+	var goToolUnavailable error
+	if _, err := DetectGoComponentImportPath(root, kind, goos, goarch); err == nil {
+		return sourceProviderKindGo, nil
+	} else if errors.Is(err, ErrGoToolUnavailable) {
+		goToolUnavailable = err
+	} else if !errors.Is(err, ErrNoSourceComponentPackage) {
+		return "", err
+	}
+
+	if _, err := detectRustPackage(root); err == nil {
+		return sourceProviderKindRust, nil
+	} else if !errors.Is(err, ErrNoRustProviderPackage) {
+		return "", err
+	}
+
+	if goToolUnavailable != nil {
+		return "", goToolUnavailable
+	}
+	return "", ErrNoSourceComponentPackage
 }
 
 func validateSourceComponentKind(kind string) error {

--- a/gestaltd/internal/pluginpkg/go_provider_test.go
+++ b/gestaltd/internal/pluginpkg/go_provider_test.go
@@ -1,0 +1,36 @@
+package pluginpkg
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestGoModulePathFromFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "go.mod"), []byte("module example.com/provider\n\ngo 1.26\n"), 0o644)
+
+	got, err := goModulePathFromFile(root)
+	if err != nil {
+		t.Fatalf("goModulePathFromFile: %v", err)
+	}
+	if got != "example.com/provider" {
+		t.Fatalf("module path = %q, want %q", got, "example.com/provider")
+	}
+}
+
+func TestGoModulePathFromFileStripsComments(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "go.mod"), []byte("module example.com/provider // comment\n"), 0o644)
+
+	got, err := goModulePathFromFile(root)
+	if err != nil {
+		t.Fatalf("goModulePathFromFile: %v", err)
+	}
+	if got != "example.com/provider" {
+		t.Fatalf("module path = %q, want %q", got, "example.com/provider")
+	}
+}

--- a/gestaltd/internal/pluginpkg/rust_provider.go
+++ b/gestaltd/internal/pluginpkg/rust_provider.go
@@ -1,0 +1,404 @@
+package pluginpkg
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"text/template"
+
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+)
+
+const (
+	rustProjectFile       = "Cargo.toml"
+	rustWrapperBinaryName = "gestalt-provider-wrapper"
+)
+
+var (
+	ErrNoRustProviderPackage = errors.New("no Rust provider package found")
+	ErrRustToolUnavailable   = errors.New("cargo tool unavailable")
+)
+
+type rustProviderTarget struct {
+	PackageName string
+}
+
+type rustWrapperData struct {
+	PluginNameLiteral  string
+	RootPathLiteral    string
+	PackageNameLiteral string
+	ServeFunction      string
+	SupportsCatalog    bool
+}
+
+var rustWrapperCargoTemplate = template.Must(template.New("rust-wrapper-cargo").Parse(`[package]
+name = "gestalt-provider-wrapper"
+version = "0.0.0"
+edition = "2024"
+
+[dependencies]
+provider_plugin = { package = {{.PackageNameLiteral}}, path = {{.RootPathLiteral}} }
+`))
+
+var rustWrapperMainTemplate = template.Must(template.New("rust-wrapper-main").Parse(`use std::error::Error;
+
+const PLUGIN_NAME: &str = {{.PluginNameLiteral}};
+
+fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+{{- if .SupportsCatalog }}
+    if let Ok(path) = std::env::var("GESTALT_PLUGIN_WRITE_CATALOG") {
+        provider_plugin::__gestalt_write_catalog(PLUGIN_NAME, &path)?;
+    } else {
+        provider_plugin::{{.ServeFunction}}(PLUGIN_NAME)?;
+    }
+{{- else }}
+    provider_plugin::{{.ServeFunction}}(PLUGIN_NAME)?;
+{{- end }}
+    Ok(())
+}
+`))
+
+func detectRustProviderPackage(root string) (*rustProviderTarget, error) {
+	return detectRustPackage(root)
+}
+
+func detectRustPackage(root string) (*rustProviderTarget, error) {
+	projectPath := filepath.Join(root, rustProjectFile)
+	if _, err := os.Stat(projectPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNoRustProviderPackage
+		}
+		return nil, fmt.Errorf("stat %s: %w", rustProjectFile, err)
+	}
+
+	data, err := os.ReadFile(projectPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", rustProjectFile, err)
+	}
+	target, err := rustProjectPackageTarget(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", rustProjectFile, err)
+	}
+	if target == nil {
+		return nil, ErrNoRustProviderPackage
+	}
+	return target, nil
+}
+
+func rustProviderExecutionCommand(root, goos, goarch string) (string, []string, func(), error) {
+	pluginName := sourcePluginName(root)
+	command, cleanup, err := BuildRustProviderTempBinary(root, pluginName, goos, goarch)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	return command, nil, cleanup, nil
+}
+
+func rustComponentExecutionCommand(root, kind, goos, goarch string) (string, []string, func(), error) {
+	command, cleanup, err := BuildRustComponentTempBinary(root, kind, goos, goarch)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	return command, nil, cleanup, nil
+}
+
+func BuildRustProviderTempBinary(root, pluginName, goos, goarch string) (string, func(), error) {
+	return buildRustTempBinary(root, pluginName, pluginmanifestv1.KindPlugin, goos, goarch)
+}
+
+func BuildRustComponentTempBinary(root, kind, goos, goarch string) (string, func(), error) {
+	if err := validateSourceComponentKind(kind); err != nil {
+		return "", nil, err
+	}
+	return buildRustTempBinary(root, sourcePluginName(root), kind, goos, goarch)
+}
+
+func buildRustTempBinary(root, pluginName, kind, goos, goarch string) (string, func(), error) {
+	return buildGoTempBinary("gestalt-rust-provider-bin-*", rustBinaryName(kind), goos, func(outputPath string) error {
+		_, err := buildRustBinary(root, outputPath, pluginName, kind, goos, goarch, "")
+		return err
+	})
+}
+
+func ValidateRustProviderRelease(root, goos, goarch, libc string) error {
+	if _, err := detectRustPackage(root); err != nil {
+		return err
+	}
+	if _, _, err := rustTargetTriple(goos, goarch, libc); err != nil {
+		return err
+	}
+	return ensureCargoAvailable()
+}
+
+func ValidateRustComponentRelease(root, kind, goos, goarch, libc string) error {
+	if err := validateSourceComponentKind(kind); err != nil {
+		return err
+	}
+	if _, err := detectRustPackage(root); err != nil {
+		return err
+	}
+	if _, _, err := rustTargetTriple(goos, goarch, libc); err != nil {
+		return err
+	}
+	return ensureCargoAvailable()
+}
+
+func BuildRustProviderBinary(root, outputPath, pluginName, goos, goarch, libc string) (string, error) {
+	return buildRustBinary(root, outputPath, pluginName, pluginmanifestv1.KindPlugin, goos, goarch, libc)
+}
+
+func BuildRustComponentBinary(root, outputPath, kind, goos, goarch, libc string) (string, error) {
+	if err := validateSourceComponentKind(kind); err != nil {
+		return "", err
+	}
+	return buildRustBinary(root, outputPath, sourcePluginName(root), kind, goos, goarch, libc)
+}
+
+func buildRustBinary(root, outputPath, pluginName, kind, goos, goarch, libc string) (string, error) {
+	target, err := detectRustPackage(root)
+	if err != nil {
+		return "", err
+	}
+	targetTriple, builtLibC, err := rustTargetTriple(goos, goarch, libc)
+	if err != nil {
+		return "", err
+	}
+	if err := ensureCargoAvailable(); err != nil {
+		return "", err
+	}
+
+	wrapperDir, cleanup, err := newRustWrapperProject(root, target.PackageName, pluginName, kind)
+	if err != nil {
+		return "", err
+	}
+	defer cleanup()
+
+	targetDir := filepath.Join(wrapperDir, "target")
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		return "", fmt.Errorf("create output directory: %w", err)
+	}
+
+	cmd := exec.Command("cargo", "build",
+		"--manifest-path", filepath.Join(wrapperDir, rustProjectFile),
+		"--release",
+		"--target", targetTriple,
+		"--target-dir", targetDir,
+	)
+	cmd.Env = os.Environ()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("cargo build: %w", err)
+	}
+
+	builtBinaryPath := filepath.Join(targetDir, targetTriple, "release", rustWrapperBinaryName)
+	if goos == "windows" {
+		builtBinaryPath += ".exe"
+	}
+	if err := copyRustBuiltBinary(builtBinaryPath, outputPath); err != nil {
+		return "", err
+	}
+
+	return builtLibC, nil
+}
+
+func rustProjectPackageTarget(data []byte) (*rustProviderTarget, error) {
+	var (
+		inPackageSection  bool
+		sawPackageSection bool
+		packageName       string
+	)
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := strings.TrimSpace(stripTOMLComment(scanner.Text()))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+			inPackageSection = section == "package"
+			if inPackageSection {
+				sawPackageSection = true
+			}
+			continue
+		}
+
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+
+		if inPackageSection && key == "name" {
+			parsed, err := parseTOMLString(value)
+			if err != nil {
+				return nil, fmt.Errorf("package.name: %w", err)
+			}
+			packageName = strings.TrimSpace(parsed)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if !sawPackageSection {
+		return nil, nil
+	}
+	if packageName == "" {
+		return nil, fmt.Errorf("package.name is required")
+	}
+	return &rustProviderTarget{PackageName: packageName}, nil
+}
+
+func ensureCargoAvailable() error {
+	if _, err := exec.LookPath("cargo"); err != nil {
+		return fmt.Errorf("%w: %v", ErrRustToolUnavailable, err)
+	}
+	return nil
+}
+
+func rustTargetTriple(goos, goarch, requestedLibC string) (string, string, error) {
+	normalizedLibC, err := NormalizeArtifactLibC(goos, requestedLibC)
+	if err != nil {
+		return "", "", err
+	}
+	switch goos {
+	case "darwin":
+		switch goarch {
+		case "amd64":
+			return "x86_64-apple-darwin", "", nil
+		case "arm64":
+			return "aarch64-apple-darwin", "", nil
+		}
+	case "linux":
+		libc := normalizedLibC
+		if libc == "" {
+			libc = LinuxLibCGLibC
+			if runtime.GOOS == "linux" && CurrentRuntimeLibC() == LinuxLibCMusl {
+				libc = LinuxLibCMusl
+			}
+		}
+		switch goarch {
+		case "amd64":
+			if libc == LinuxLibCMusl {
+				return "x86_64-unknown-linux-musl", libc, nil
+			}
+			return "x86_64-unknown-linux-gnu", libc, nil
+		case "arm64":
+			if libc == LinuxLibCMusl {
+				return "aarch64-unknown-linux-musl", libc, nil
+			}
+			return "aarch64-unknown-linux-gnu", libc, nil
+		}
+	case "windows":
+		if goarch == "amd64" {
+			return "x86_64-pc-windows-gnu", "", nil
+		}
+	}
+	return "", "", fmt.Errorf("unsupported Rust target platform %s/%s", goos, goarch)
+}
+
+func rustServeFunction(kind string) (string, bool, error) {
+	switch kind {
+	case pluginmanifestv1.KindPlugin:
+		return "__gestalt_serve", true, nil
+	case pluginmanifestv1.KindAuth:
+		return "__gestalt_serve_auth", false, nil
+	case pluginmanifestv1.KindDatastore:
+		return "__gestalt_serve_datastore", false, nil
+	default:
+		return "", false, fmt.Errorf("unsupported Rust provider kind %q", kind)
+	}
+}
+
+func rustBinaryName(kind string) string {
+	switch kind {
+	case pluginmanifestv1.KindAuth, pluginmanifestv1.KindDatastore:
+		return kind
+	default:
+		return "provider"
+	}
+}
+
+func newRustWrapperProject(root, packageName, pluginName, kind string) (string, func(), error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve Rust package root: %w", err)
+	}
+	serveFunction, supportsCatalog, err := rustServeFunction(kind)
+	if err != nil {
+		return "", nil, err
+	}
+
+	wrapperDir, err := os.MkdirTemp("", "gestalt-rust-wrapper-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create Rust wrapper directory: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(wrapperDir) }
+
+	srcDir := filepath.Join(wrapperDir, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("create Rust wrapper src directory: %w", err)
+	}
+
+	data := rustWrapperData{
+		PluginNameLiteral:  strconv.Quote(pluginName),
+		RootPathLiteral:    strconv.Quote(absRoot),
+		PackageNameLiteral: strconv.Quote(packageName),
+		ServeFunction:      serveFunction,
+		SupportsCatalog:    supportsCatalog,
+	}
+	if err := writeRustWrapperFile(filepath.Join(wrapperDir, rustProjectFile), rustWrapperCargoTemplate, data); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	if err := writeRustWrapperFile(filepath.Join(srcDir, "main.rs"), rustWrapperMainTemplate, data); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return wrapperDir, cleanup, nil
+}
+
+func writeRustWrapperFile(path string, tmpl *template.Template, data rustWrapperData) error {
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return fmt.Errorf("render %s: %w", filepath.Base(path), err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func copyRustBuiltBinary(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open built Rust binary %q: %w", src, err)
+	}
+	defer func() { _ = in.Close() }()
+
+	info, err := in.Stat()
+	if err != nil {
+		return fmt.Errorf("stat built Rust binary %q: %w", src, err)
+	}
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return fmt.Errorf("create Rust provider binary %q: %w", dst, err)
+	}
+	defer func() { _ = out.Close() }()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("copy Rust provider binary: %w", err)
+	}
+	return out.Close()
+}

--- a/gestaltd/internal/pluginpkg/rust_provider_test.go
+++ b/gestaltd/internal/pluginpkg/rust_provider_test.go
@@ -1,0 +1,486 @@
+package pluginpkg
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestDetectRustProviderPackage(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeRustProviderCargoToml(t, root)
+
+	target, err := detectRustProviderPackage(root)
+	if err != nil {
+		t.Fatalf("detectRustProviderPackage: %v", err)
+	}
+	if target == nil {
+		t.Fatal("target = nil")
+	}
+	if target.PackageName != "rust-provider" {
+		t.Fatalf("PackageName = %q, want %q", target.PackageName, "rust-provider")
+	}
+}
+
+func TestDetectRustProviderPackage_RequiresPackageName(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, rustProjectFile), []byte("[package]\nversion = \"0.0.1\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", rustProjectFile, err)
+	}
+
+	_, err := detectRustProviderPackage(root)
+	if err == nil || !strings.Contains(err.Error(), "package.name is required") {
+		t.Fatalf("error = %v, want package.name failure", err)
+	}
+}
+
+func TestRustProjectPackageTarget_WorkspaceManifestReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	target, err := rustProjectPackageTarget([]byte("[workspace]\nmembers = [\"provider\"]\n"))
+	if err != nil {
+		t.Fatalf("rustProjectPackageTarget: %v", err)
+	}
+	if target != nil {
+		t.Fatalf("target = %#v, want nil", target)
+	}
+}
+
+func TestDetectRustProviderPackage_WorkspaceManifestReturnsNoPackage(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeRustWorkspaceCargoToml(t, root)
+
+	_, err := detectRustProviderPackage(root)
+	if !errors.Is(err, ErrNoRustProviderPackage) {
+		t.Fatalf("error = %v, want %v", err, ErrNoRustProviderPackage)
+	}
+}
+
+func TestBuildRustProviderBinary_UsesSynthesizedCargoWrapper(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake cargo test fixture is POSIX-only")
+	}
+
+	root := t.TempDir()
+	writeRustProviderCargoToml(t, root)
+
+	targetTriple, expectedLibC, err := rustTargetTriple(runtime.GOOS, runtime.GOARCH, "")
+	if err != nil {
+		t.Fatalf("rustTargetTriple(host): %v", err)
+	}
+
+	fakeCargoDir := t.TempDir()
+	writeFakeCargo(t, filepath.Join(fakeCargoDir, "cargo"), fakeCargoConfig{
+		ExpectedPluginName:   "rust-release",
+		ExpectedTarget:       targetTriple,
+		ExpectedServeExport:  "__gestalt_serve",
+		ExpectedCatalogWrite: true,
+		GeneratedCatalog:     "rust-release",
+	})
+	t.Setenv("PATH", fakeCargoDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	outputPath := filepath.Join(t.TempDir(), "provider")
+	builtLibC, err := BuildRustProviderBinary(root, outputPath, "rust-release", runtime.GOOS, runtime.GOARCH, "")
+	if err != nil {
+		t.Fatalf("BuildRustProviderBinary: %v", err)
+	}
+	if _, err := os.Stat(outputPath); err != nil {
+		t.Fatalf("stat output binary: %v", err)
+	}
+	if builtLibC != expectedLibC {
+		t.Fatalf("builtLibC = %q, want %q", builtLibC, expectedLibC)
+	}
+}
+
+func TestBuildRustComponentBinary_UsesKindSpecificWrapper(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake cargo test fixture is POSIX-only")
+	}
+
+	tests := []struct {
+		name                string
+		kind                string
+		expectedServeExport string
+	}{
+		{name: "auth", kind: "auth", expectedServeExport: "__gestalt_serve_auth"},
+		{name: "datastore", kind: "datastore", expectedServeExport: "__gestalt_serve_datastore"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeRustProviderCargoToml(t, root)
+
+			targetTriple, _, err := rustTargetTriple(runtime.GOOS, runtime.GOARCH, "")
+			if err != nil {
+				t.Fatalf("rustTargetTriple(host): %v", err)
+			}
+
+			fakeCargoDir := t.TempDir()
+			writeFakeCargo(t, filepath.Join(fakeCargoDir, "cargo"), fakeCargoConfig{
+				ExpectedPluginName:   sourcePluginName(root),
+				ExpectedTarget:       targetTriple,
+				ExpectedServeExport:  tt.expectedServeExport,
+				ExpectedCatalogWrite: false,
+			})
+			t.Setenv("PATH", fakeCargoDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+			outputPath := filepath.Join(t.TempDir(), tt.kind)
+			if _, err := BuildRustComponentBinary(root, outputPath, tt.kind, runtime.GOOS, runtime.GOARCH, ""); err != nil {
+				t.Fatalf("BuildRustComponentBinary(%s): %v", tt.kind, err)
+			}
+			if _, err := os.Stat(outputPath); err != nil {
+				t.Fatalf("stat output binary: %v", err)
+			}
+		})
+	}
+}
+
+func TestHasSourceComponentPackage_DetectsRustPackage(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeRustProviderCargoToml(t, root)
+
+	ok, err := HasSourceComponentPackage(root, "auth")
+	if err != nil {
+		t.Fatalf("HasSourceComponentPackage(auth): %v", err)
+	}
+	if !ok {
+		t.Fatal("HasSourceComponentPackage(auth) = false, want true")
+	}
+}
+
+func TestNewRustWrapperProject_UsesAbsoluteDependencyPath(t *testing.T) { //nolint:paralleltest // changes process cwd
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX path assertions")
+	}
+
+	baseDir := t.TempDir()
+	pluginDir := filepath.Join(baseDir, "provider-rust")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", pluginDir, err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(baseDir); err != nil {
+		t.Fatalf("Chdir(%s): %v", baseDir, err)
+	}
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	}()
+
+	wrapperDir, cleanup, err := newRustWrapperProject("provider-rust", "provider-rust", "rust-release", "plugin")
+	if err != nil {
+		t.Fatalf("newRustWrapperProject: %v", err)
+	}
+	defer cleanup()
+
+	data, err := os.ReadFile(filepath.Join(wrapperDir, rustProjectFile))
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", rustProjectFile, err)
+	}
+	match := regexp.MustCompile(`path = "([^"]+)"`).FindStringSubmatch(string(data))
+	if len(match) != 2 {
+		t.Fatalf("wrapper Cargo.toml = %q, want dependency path", data)
+	}
+	if !filepath.IsAbs(match[1]) {
+		t.Fatalf("wrapper dependency path = %q, want absolute path", match[1])
+	}
+	if !strings.HasSuffix(match[1], string(filepath.Separator)+"provider-rust") {
+		t.Fatalf("wrapper dependency path = %q, want provider-rust suffix", match[1])
+	}
+}
+
+func TestBuildRustProviderBinary_UsesExplicitLinuxLibCTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake cargo test fixture is POSIX-only")
+	}
+
+	root := t.TempDir()
+	writeRustProviderCargoToml(t, root)
+
+	fakeCargoDir := t.TempDir()
+	writeFakeCargo(t, filepath.Join(fakeCargoDir, "cargo"), fakeCargoConfig{
+		ExpectedPluginName:   "rust-release",
+		ExpectedTarget:       "x86_64-unknown-linux-musl",
+		ExpectedServeExport:  "__gestalt_serve",
+		ExpectedCatalogWrite: true,
+		GeneratedCatalog:     "rust-release",
+	})
+	t.Setenv("PATH", fakeCargoDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	outputPath := filepath.Join(t.TempDir(), "provider")
+	builtLibC, err := BuildRustProviderBinary(root, outputPath, "rust-release", "linux", "amd64", LinuxLibCMusl)
+	if err != nil {
+		t.Fatalf("BuildRustProviderBinary(linux/amd64/musl): %v", err)
+	}
+	if builtLibC != LinuxLibCMusl {
+		t.Fatalf("builtLibC = %q, want %q", builtLibC, LinuxLibCMusl)
+	}
+}
+
+func TestPrepareSourceManifest_GeneratesStaticCatalogForRustProvider(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake cargo test fixture is POSIX-only")
+	}
+
+	root := t.TempDir()
+	copyRustProviderFixture(t, root)
+
+	targetTriple, _, err := rustTargetTriple(runtime.GOOS, runtime.GOARCH, "")
+	if err != nil {
+		t.Fatalf("rustTargetTriple(host): %v", err)
+	}
+
+	fakeCargoDir := t.TempDir()
+	writeFakeCargo(t, filepath.Join(fakeCargoDir, "cargo"), fakeCargoConfig{
+		ExpectedPluginName:   "provider-rust",
+		ExpectedTarget:       targetTriple,
+		ExpectedServeExport:  "__gestalt_serve",
+		ExpectedCatalogWrite: true,
+		GeneratedCatalog:     "provider-rust",
+	})
+	t.Setenv("PATH", fakeCargoDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	manifestPath := filepath.Join(root, "plugin.yaml")
+	_, manifest, err := PrepareSourceManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("PrepareSourceManifest: %v", err)
+	}
+	if manifest == nil || manifest.Plugin == nil {
+		t.Fatalf("manifest = %#v, want plugin manifest", manifest)
+	}
+
+	catalogPath := filepath.Join(root, StaticCatalogFile)
+	data, err := os.ReadFile(catalogPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", catalogPath, err)
+	}
+	if !strings.Contains(string(data), "name: provider-rust") {
+		t.Fatalf("catalog = %q, want provider name", data)
+	}
+	if !strings.Contains(string(data), "id: greet") {
+		t.Fatalf("catalog = %q, want greet operation", data)
+	}
+}
+
+func TestRustTargetTriple(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		goos     string
+		goarch   string
+		libc     string
+		want     string
+		wantLibC string
+	}{
+		{name: "darwin-amd64", goos: "darwin", goarch: "amd64", want: "x86_64-apple-darwin"},
+		{name: "darwin-arm64", goos: "darwin", goarch: "arm64", want: "aarch64-apple-darwin"},
+		{name: "windows-amd64", goos: "windows", goarch: "amd64", want: "x86_64-pc-windows-gnu"},
+		{name: "linux-amd64-glibc", goos: "linux", goarch: "amd64", libc: LinuxLibCGLibC, want: "x86_64-unknown-linux-gnu", wantLibC: LinuxLibCGLibC},
+		{name: "linux-amd64-musl", goos: "linux", goarch: "amd64", libc: LinuxLibCMusl, want: "x86_64-unknown-linux-musl", wantLibC: LinuxLibCMusl},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, gotLibC, err := rustTargetTriple(tt.goos, tt.goarch, tt.libc)
+			if err != nil {
+				t.Fatalf("rustTargetTriple: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("target = %q, want %q", got, tt.want)
+			}
+			if gotLibC != tt.wantLibC {
+				t.Fatalf("libc = %q, want %q", gotLibC, tt.wantLibC)
+			}
+		})
+	}
+}
+
+func writeRustProviderCargoToml(t *testing.T, root string) {
+	t.Helper()
+
+	content := `[package]
+name = "rust-provider"
+version = "0.0.1"
+`
+	if err := os.WriteFile(filepath.Join(root, rustProjectFile), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", rustProjectFile, err)
+	}
+}
+
+func writeRustWorkspaceCargoToml(t *testing.T, root string) {
+	t.Helper()
+
+	content := `[workspace]
+members = ["provider"]
+`
+	if err := os.WriteFile(filepath.Join(root, rustProjectFile), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", rustProjectFile, err)
+	}
+}
+
+type fakeCargoConfig struct {
+	ExpectedPluginName   string
+	ExpectedTarget       string
+	ExpectedServeExport  string
+	ExpectedCatalogWrite bool
+	GeneratedCatalog     string
+}
+
+func writeFakeCargo(t *testing.T, path string, cfg fakeCargoConfig) {
+	t.Helper()
+
+	script := `#!/bin/sh
+set -eu
+
+manifest=""
+target=""
+target_dir=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --manifest-path)
+      manifest="$2"
+      shift 2
+      ;;
+    --target)
+      target="$2"
+      shift 2
+      ;;
+    --target-dir)
+      target_dir="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$manifest" ] || [ -z "$target" ] || [ -z "$target_dir" ]; then
+  echo "missing cargo wrapper args" >&2
+  exit 1
+fi
+
+if [ "$target" != ` + shellSingleQuoted(cfg.ExpectedTarget) + ` ]; then
+  echo "unexpected target triple: $target" >&2
+  exit 1
+fi
+
+main_rs="$(dirname "$manifest")/src/main.rs"
+if ! grep -q 'const PLUGIN_NAME: &str = ` + rustDoubleQuoted(cfg.ExpectedPluginName) + `;' "$main_rs"; then
+  echo "missing plugin name in wrapper source" >&2
+  exit 1
+fi
+if ! grep -Fq 'provider_plugin::` + cfg.ExpectedServeExport + `(PLUGIN_NAME)?' "$main_rs"; then
+  echo "missing serve export in wrapper source" >&2
+  exit 1
+fi
+` + fakeCargoCatalogCheck(cfg.ExpectedCatalogWrite) + `
+if ! grep -Fq 'Ok(())' "$main_rs"; then
+  echo "missing explicit Ok return in wrapper source" >&2
+  exit 1
+fi
+
+binary="$target_dir/$target/release/` + rustWrapperBinaryName + `"
+mkdir -p "$(dirname "$binary")"
+cat > "$binary" <<'EOF'
+#!/bin/sh
+set -eu
+if [ -n "${GESTALT_PLUGIN_WRITE_CATALOG:-}" ]; then
+  cat > "$GESTALT_PLUGIN_WRITE_CATALOG" <<'YAML'
+name: ` + cfg.GeneratedCatalog + `
+operations:
+  - id: greet
+    method: GET
+YAML
+fi
+exit 0
+EOF
+chmod +x "$binary"
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+func copyRustProviderFixture(t *testing.T, dst string) {
+	t.Helper()
+
+	src := rustProviderFixturePath(t)
+	if err := filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, info.Mode())
+	}); err != nil {
+		t.Fatalf("copy Rust provider fixture: %v", err)
+	}
+}
+
+func fakeCargoCatalogCheck(expectCatalog bool) string {
+	if expectCatalog {
+		return `if ! grep -Fq 'provider_plugin::__gestalt_write_catalog(PLUGIN_NAME, &path)?' "$main_rs"; then
+  echo "missing write-catalog export in wrapper source" >&2
+  exit 1
+fi`
+	}
+	return `if grep -Fq 'provider_plugin::__gestalt_write_catalog(PLUGIN_NAME, &path)?' "$main_rs"; then
+  echo "unexpected write-catalog export in wrapper source" >&2
+  exit 1
+fi`
+}
+
+func rustProviderFixturePath(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "testutil", "testdata", "provider-rust"))
+}
+
+func shellSingleQuoted(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
+}
+
+func rustDoubleQuoted(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `\"`) + `"`
+}

--- a/gestaltd/internal/pluginpkg/source_provider.go
+++ b/gestaltd/internal/pluginpkg/source_provider.go
@@ -9,6 +9,7 @@ var ErrNoSourceProviderPackage = errors.New("no source provider package found")
 
 const (
 	sourceProviderKindGo     = "go"
+	sourceProviderKindRust   = "rust"
 	sourceProviderKindPython = "python"
 )
 
@@ -19,6 +20,12 @@ func detectSourceProvider(root, goos, goarch string) (kind string, pythonTarget 
 	} else if errors.Is(err, ErrGoToolUnavailable) {
 		goToolUnavailable = err
 	} else if !errors.Is(err, ErrNoGoProviderPackage) {
+		return "", "", err
+	}
+
+	if _, err := detectRustProviderPackage(root); err == nil {
+		return sourceProviderKindRust, "", nil
+	} else if !errors.Is(err, ErrNoRustProviderPackage) {
 		return "", "", err
 	}
 
@@ -47,6 +54,8 @@ func SourceProviderExecutionCommand(root, goos, goarch string) (string, []string
 			return "", nil, nil, err
 		}
 		return command, nil, cleanup, nil
+	case sourceProviderKindRust:
+		return rustProviderExecutionCommand(root, goos, goarch)
 	case sourceProviderKindPython:
 		return pythonProviderExecutionCommand(root, pythonTarget)
 	default:
@@ -54,18 +63,22 @@ func SourceProviderExecutionCommand(root, goos, goarch string) (string, []string
 	}
 }
 
-func ValidateSourceProviderRelease(root, goos, goarch string) error {
+func ValidateSourceProviderRelease(root, goos, goarch, libc string) error {
 	kind, _, err := detectSourceProvider(root, goos, goarch)
 	if err != nil {
 		return err
 	}
-	if kind == sourceProviderKindPython {
+	switch kind {
+	case sourceProviderKindRust:
+		return ValidateRustProviderRelease(root, goos, goarch, libc)
+	case sourceProviderKindPython:
 		_, err = DetectPythonInterpreter(root, goos, goarch)
+		return err
 	}
-	return err
+	return nil
 }
 
-func BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch string) (string, error) {
+func BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch, libc string) (string, error) {
 	kind, pythonTarget, err := detectSourceProvider(root, goos, goarch)
 	if err != nil {
 		return "", err
@@ -73,6 +86,8 @@ func BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch
 	switch kind {
 	case sourceProviderKindGo:
 		return "", BuildGoProviderBinary(root, outputPath, pluginName, goos, goarch)
+	case sourceProviderKindRust:
+		return BuildRustProviderBinary(root, outputPath, pluginName, goos, goarch, libc)
 	case sourceProviderKindPython:
 		return BuildPythonProviderBinary(root, outputPath, pluginName, pythonTarget, goos, goarch)
 	default:

--- a/gestaltd/internal/pluginpkg/source_provider_test.go
+++ b/gestaltd/internal/pluginpkg/source_provider_test.go
@@ -1,0 +1,43 @@
+package pluginpkg
+
+import (
+	"errors"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+)
+
+func TestDetectSourceProvider_FallsBackToPythonWhenCargoIsWorkspaceManifest(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeRustWorkspaceCargoToml(t, root)
+	mustWriteFile(t, filepath.Join(root, pythonProjectFile), []byte(`[tool.gestalt]
+plugin = "provider.plugin:plugin"
+`), 0o644)
+
+	kind, target, err := detectSourceProvider(root, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatalf("detectSourceProvider: %v", err)
+	}
+	if kind != sourceProviderKindPython {
+		t.Fatalf("kind = %q, want %q", kind, sourceProviderKindPython)
+	}
+	if target != "provider.plugin:plugin" {
+		t.Fatalf("target = %q, want %q", target, "provider.plugin:plugin")
+	}
+}
+
+func TestDetectSourceComponent_WorkspaceCargoManifestIsMiss(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeRustWorkspaceCargoToml(t, root)
+
+	_, err := detectSourceComponent(root, pluginmanifestv1.KindAuth, runtime.GOOS, runtime.GOARCH)
+	if !errors.Is(err, ErrNoSourceComponentPackage) {
+		t.Fatalf("error = %v, want %v", err, ErrNoSourceComponentPackage)
+	}
+}

--- a/gestaltd/internal/testutil/testdata/provider-rust-auth/Cargo.toml
+++ b/gestaltd/internal/testutil/testdata/provider-rust-auth/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "provider-rust-auth"
+version = "0.0.1-alpha.1"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+gestalt_plugin_sdk = { path = "../../../../../sdk/rust" }

--- a/gestaltd/internal/testutil/testdata/provider-rust-auth/plugin.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-rust-auth/plugin.yaml
@@ -1,0 +1,7 @@
+source: github.com/valon-technologies/gestalt/provider-rust-auth
+version: 0.0.1-alpha.1
+display_name: Example Rust Auth Provider
+description: A minimal Rust auth provider built with the public Rust SDK
+kinds:
+  - auth
+auth: {}

--- a/gestaltd/internal/testutil/testdata/provider-rust-auth/src/lib.rs
+++ b/gestaltd/internal/testutil/testdata/provider-rust-auth/src/lib.rs
@@ -1,0 +1,76 @@
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use gestalt_plugin_sdk as gestalt;
+
+pub struct Provider;
+
+#[gestalt::async_trait]
+impl gestalt::AuthProvider for Provider {
+    fn metadata(&self) -> Option<gestalt::RuntimeMetadata> {
+        Some(gestalt::RuntimeMetadata {
+            name: "generated-auth".to_string(),
+            display_name: "Generated Auth".to_string(),
+            description: "Generated Rust auth provider".to_string(),
+            version: "0.0.1-alpha.1".to_string(),
+        })
+    }
+
+    async fn begin_login(
+        &self,
+        _req: gestalt::BeginLoginRequest,
+    ) -> gestalt::Result<gestalt::BeginLoginResponse> {
+        Ok(gestalt::BeginLoginResponse {
+            authorization_url: "https://auth.example.test/login?state=idp-state&prompt=consent"
+                .to_string(),
+            plugin_state: Vec::new(),
+        })
+    }
+
+    async fn complete_login(
+        &self,
+        req: gestalt::CompleteLoginRequest,
+    ) -> gestalt::Result<gestalt::AuthenticatedUser> {
+        if req.query.get("state").map(String::as_str) != Some("idp-state") {
+            return Err(gestalt::Error::bad_request("unexpected state"));
+        }
+        if req.query.get("prompt").map(String::as_str) != Some("consent") {
+            return Err(gestalt::Error::bad_request("unexpected prompt"));
+        }
+        Ok(gestalt::AuthenticatedUser {
+            email: "generated-auth@example.com".to_string(),
+            display_name: "Generated Auth User".to_string(),
+            ..gestalt::AuthenticatedUser::default()
+        })
+    }
+
+    async fn validate_external_token(
+        &self,
+        token: &str,
+    ) -> gestalt::Result<Option<gestalt::AuthenticatedUser>> {
+        if token.is_empty() {
+            return Err(gestalt::Error::bad_request("token is required"));
+        }
+        let email = if token.matches('.').count() == 2 {
+            "jwt@example.com".to_string()
+        } else {
+            format!("{token}@example.com")
+        };
+        Ok(Some(gestalt::AuthenticatedUser {
+            email,
+            display_name: "Validated User".to_string(),
+            claims: BTreeMap::new(),
+            ..gestalt::AuthenticatedUser::default()
+        }))
+    }
+
+    fn session_ttl(&self) -> Option<Duration> {
+        Some(Duration::from_secs(90 * 60))
+    }
+}
+
+fn new() -> Provider {
+    Provider
+}
+
+gestalt::export_auth_provider!(constructor = new);

--- a/gestaltd/internal/testutil/testdata/provider-rust-datastore/Cargo.toml
+++ b/gestaltd/internal/testutil/testdata/provider-rust-datastore/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "provider-rust-datastore"
+version = "0.0.1-alpha.1"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+gestalt_plugin_sdk = { path = "../../../../../sdk/rust" }
+prost-types = "0.12"

--- a/gestaltd/internal/testutil/testdata/provider-rust-datastore/plugin.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-rust-datastore/plugin.yaml
@@ -1,0 +1,7 @@
+source: github.com/valon-technologies/gestalt/provider-rust-datastore
+version: 0.0.1-alpha.1
+display_name: Example Rust Datastore Provider
+description: A minimal Rust datastore provider built with the public Rust SDK
+kinds:
+  - datastore
+datastore: {}

--- a/gestaltd/internal/testutil/testdata/provider-rust-datastore/src/lib.rs
+++ b/gestaltd/internal/testutil/testdata/provider-rust-datastore/src/lib.rs
@@ -1,0 +1,154 @@
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use gestalt_plugin_sdk as gestalt;
+use prost_types::Timestamp;
+
+pub struct Provider {
+    users: Mutex<BTreeMap<String, gestalt::StoredUser>>,
+    tokens: Mutex<BTreeMap<String, gestalt::StoredIntegrationToken>>,
+}
+
+impl Provider {
+    fn new() -> Self {
+        Self {
+            users: Mutex::new(BTreeMap::new()),
+            tokens: Mutex::new(BTreeMap::new()),
+        }
+    }
+}
+
+#[gestalt::async_trait]
+impl gestalt::DatastoreProvider for Provider {
+    fn metadata(&self) -> Option<gestalt::RuntimeMetadata> {
+        Some(gestalt::RuntimeMetadata {
+            name: "generated-datastore".to_string(),
+            display_name: "Generated Datastore".to_string(),
+            description: "Generated Rust datastore provider".to_string(),
+            version: "0.0.1-alpha.1".to_string(),
+        })
+    }
+
+    fn warnings(&self) -> Vec<String> {
+        vec!["generated datastore warning".to_string()]
+    }
+
+    async fn health_check(&self) -> gestalt::Result<()> {
+        Ok(())
+    }
+
+    async fn migrate(&self) -> gestalt::Result<()> {
+        Ok(())
+    }
+
+    async fn get_user(&self, id: &str) -> gestalt::Result<Option<gestalt::StoredUser>> {
+        Ok(self.users.lock().expect("lock users").get(id).cloned())
+    }
+
+    async fn find_or_create_user(&self, email: &str) -> gestalt::Result<gestalt::StoredUser> {
+        let mut users = self.users.lock().expect("lock users");
+        if let Some(user) = users.get(email) {
+            return Ok(user.clone());
+        }
+        let now = now_timestamp();
+        let user = gestalt::StoredUser {
+            id: email.to_string(),
+            email: email.to_string(),
+            display_name: String::new(),
+            created_at: now.clone(),
+            updated_at: now,
+        };
+        users.insert(email.to_string(), user.clone());
+        Ok(user)
+    }
+
+    async fn put_integration_token(
+        &self,
+        token: gestalt::StoredIntegrationToken,
+    ) -> gestalt::Result<()> {
+        self.tokens
+            .lock()
+            .expect("lock tokens")
+            .insert(token.user_id.clone(), token);
+        Ok(())
+    }
+
+    async fn get_integration_token(
+        &self,
+        user_id: &str,
+        _integration: &str,
+        _connection: &str,
+        _instance: &str,
+    ) -> gestalt::Result<Option<gestalt::StoredIntegrationToken>> {
+        Ok(self
+            .tokens
+            .lock()
+            .expect("lock tokens")
+            .get(user_id)
+            .cloned())
+    }
+
+    async fn list_integration_tokens(
+        &self,
+        user_id: &str,
+        _integration: &str,
+        _connection: &str,
+    ) -> gestalt::Result<Vec<gestalt::StoredIntegrationToken>> {
+        Ok(self
+            .tokens
+            .lock()
+            .expect("lock tokens")
+            .get(user_id)
+            .cloned()
+            .into_iter()
+            .collect())
+    }
+
+    async fn delete_integration_token(&self, id: &str) -> gestalt::Result<()> {
+        self.tokens.lock().expect("lock tokens").remove(id);
+        Ok(())
+    }
+
+    async fn put_api_token(&self, _token: gestalt::StoredApiToken) -> gestalt::Result<()> {
+        Ok(())
+    }
+
+    async fn get_api_token_by_hash(
+        &self,
+        _hashed_token: &str,
+    ) -> gestalt::Result<Option<gestalt::StoredApiToken>> {
+        Ok(None)
+    }
+
+    async fn list_api_tokens(
+        &self,
+        _user_id: &str,
+    ) -> gestalt::Result<Vec<gestalt::StoredApiToken>> {
+        Ok(Vec::new())
+    }
+
+    async fn revoke_api_token(&self, _user_id: &str, _id: &str) -> gestalt::Result<()> {
+        Ok(())
+    }
+
+    async fn revoke_all_api_tokens(&self, _user_id: &str) -> gestalt::Result<i64> {
+        Ok(0)
+    }
+}
+
+fn now_timestamp() -> Option<Timestamp> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("unix epoch");
+    Some(Timestamp {
+        seconds: now.as_secs() as i64,
+        nanos: 0,
+    })
+}
+
+fn new() -> Provider {
+    Provider::new()
+}
+
+gestalt::export_datastore_provider!(constructor = new);

--- a/gestaltd/internal/testutil/testdata/provider-rust/Cargo.toml
+++ b/gestaltd/internal/testutil/testdata/provider-rust/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "provider-rust"
+version = "0.0.1-alpha.1"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+gestalt_plugin_sdk = { path = "../../../../../sdk/rust" }
+schemars = "0.8"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/gestaltd/internal/testutil/testdata/provider-rust/config.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-rust/config.yaml
@@ -1,0 +1,18 @@
+datastore:
+  provider:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/datastore/sqlite
+      version: 0.0.1-alpha.1
+  config:
+    path: ./example.db
+
+server:
+  encryption_key: dev-key-for-example-only
+
+plugins:
+  example:
+    provider:
+      source:
+        path: ./plugin.yaml
+    config:
+      greeting: "Hello from example Rust plugin"

--- a/gestaltd/internal/testutil/testdata/provider-rust/plugin.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-rust/plugin.yaml
@@ -1,0 +1,11 @@
+source: github.com/valon-technologies/gestalt/provider-rust
+version: 0.0.1-alpha.1
+display_name: Example Rust Provider
+description: A minimal example provider built with the public Rust SDK
+kinds:
+  - plugin
+plugin:
+  connections:
+    default:
+      auth:
+        type: none

--- a/gestaltd/internal/testutil/testdata/provider-rust/src/lib.rs
+++ b/gestaltd/internal/testutil/testdata/provider-rust/src/lib.rs
@@ -1,0 +1,71 @@
+use std::sync::{Arc, Mutex};
+
+use gestalt_plugin_sdk as gestalt;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map as JsonMap, Value as JsonValue};
+
+pub struct Provider {
+    greeting: Mutex<String>,
+}
+
+impl Default for Provider {
+    fn default() -> Self {
+        Self {
+            greeting: Mutex::new("Hello".to_string()),
+        }
+    }
+}
+
+#[gestalt::async_trait]
+impl gestalt::Provider for Provider {
+    async fn configure(&self, _name: &str, config: JsonMap<String, JsonValue>) -> gestalt::Result<()> {
+        let greeting = config
+            .get("greeting")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("Hello")
+            .to_string();
+        *self.greeting.lock().expect("lock greeting") = greeting;
+        Ok(())
+    }
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct GreetInput {
+    /// Name to greet.
+    name: Option<String>,
+}
+
+#[derive(Serialize, JsonSchema)]
+struct GreetOutput {
+    message: String,
+}
+
+async fn greet(
+    provider: Arc<Provider>,
+    input: GreetInput,
+    _request: gestalt::Request,
+) -> gestalt::Result<gestalt::Response<GreetOutput>> {
+    let greeting = provider.greeting.lock().expect("lock greeting").clone();
+    let name = input.name.unwrap_or_else(|| "World".to_string());
+    Ok(gestalt::ok(GreetOutput {
+        message: format!("{greeting}, {name}!"),
+    }))
+}
+
+fn new() -> Provider {
+    Provider::default()
+}
+
+fn router() -> gestalt::Result<gestalt::Router<Provider>> {
+    gestalt::Router::new()
+        .register(
+            gestalt::Operation::<GreetInput, GreetOutput>::new("greet")
+                .method("GET")
+                .description("Return a greeting message")
+                .read_only(true),
+            greet,
+        )
+}
+
+gestalt::export_provider!(constructor = new, router = router);


### PR DESCRIPTION
Squashed to one commit: 1fda5b10

Depends on #728.

## Interface changes

The host now treats a Rust source package as any valid root `Cargo.toml` package with a `package.name`; it no longer requires `[package.metadata.gestalt]` or `plugin = true`.

Minimal Rust source package marker now:

```toml
[package]
name = "provider-rust-auth"
version = "0.0.1-alpha.1"
edition = "2024"
```

Rust source wrappers are now kind-specific:

- integration provider: `__gestalt_serve(name)` and `__gestalt_write_catalog(name, path)`
- auth provider: `__gestalt_serve_auth(name)`
- datastore provider: `__gestalt_serve_datastore(name)`

Host-side component release/build plumbing now threads libc through auth/datastore source builds too:

```go
builtLibC, err := pluginpkg.BuildSourceComponentReleaseBinary(
    root,
    outputPath,
    kind,
    goos,
    goarch,
    libc,
)
```

Config usage stays manifest-driven, but Rust now works for the auth/datastore source paths too:

```yaml
auth:
  provider:
    source:
      path: ./components/auth/plugin.yaml

datastore:
  provider:
    source:
      path: ./components/datastore/plugin.yaml
```

## Usage examples

Rust auth/datastore source packages can now be used in the same source-build flow as integration providers:

- `gestaltd plugin release --version 0.0.17 --platform linux/amd64/musl`
- `auth.provider.source.path: ./components/auth/plugin.yaml`
- `datastore.provider.source.path: ./components/datastore/plugin.yaml`

The branch also adds concrete Rust auth/datastore test fixtures under `gestaltd/internal/testutil/testdata/` so the host exercises those paths directly.

## Newly supported behavior

- Rust auth source packages now work through the source-component execution path.
- Rust datastore source packages now work through the source-component execution path.
- `gestaltd plugin release` now supports Rust auth/datastore source packages, including Linux libc-aware artifact metadata.
- Rust source-package detection no longer depends on a plugin-only metadata sentinel.

## Not supported

- Python auth/datastore source packages are still not supported.
- Rust secrets/telemetry source packages are still not wired through the host.
- Rust still does not override Go when both source package types are present in the same root; auto-detection remains ordered Go first, then Rust.