### PR TITLE
Add TypeScript source support for plugin, auth, and datastore providers

### DIFF
--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -366,11 +366,11 @@ func missingReleaseSourceBuildTargetError(kinds []string) error {
 	case 1:
 		switch kinds[0] {
 		case pluginmanifestv1.KindPlugin:
-			return fmt.Errorf("no Go, Rust, or Python provider package found")
+			return fmt.Errorf("no Go, Rust, Python, or TypeScript provider package found")
 		case pluginmanifestv1.KindAuth:
-			return fmt.Errorf("no Go, Rust, or Python auth source package found")
+			return fmt.Errorf("no Go, Rust, Python, or TypeScript auth source package found")
 		case pluginmanifestv1.KindDatastore:
-			return fmt.Errorf("no Go, Rust, or Python datastore source package found")
+			return fmt.Errorf("no Go, Rust, Python, or TypeScript datastore source package found")
 		}
 	}
 	return fmt.Errorf("missing source packages for executable kinds: %s", strings.Join(kinds, ", "))

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -46,6 +46,10 @@ const (
 	pythonAuthReleaseSource          = "github.com/testowner/plugins/python-auth-release"
 	pythonDatastoreReleasePluginName = "python-datastore-release"
 	pythonDatastoreReleaseSource     = "github.com/testowner/plugins/python-datastore-release"
+	authReleaseTypeScriptModule      = "./auth.ts#auth"
+	authReleaseTypeScriptTarget      = "auth:./auth.ts#auth"
+	datastoreReleaseTypeScriptModule = "./datastore.ts#datastore"
+	datastoreReleaseTypeScriptTarget = "datastore:./datastore.ts#datastore"
 )
 
 func TestRun_ProviderHelpExitsCleanly(t *testing.T) {
@@ -400,7 +404,7 @@ func TestRun_PluginReleaseDefaultsPythonSourcePluginToHostPlatform(t *testing.T)
 	if len(manifest.Artifacts) != 1 {
 		t.Fatalf("artifacts = %+v, want exactly one host-platform artifact", manifest.Artifacts)
 	}
-	assertExpectedPythonArtifactPlatform(t, manifest.Artifacts[0], runtime.GOOS, runtime.GOARCH)
+	assertExpectedScriptArtifactPlatform(t, manifest.Artifacts[0], runtime.GOOS, runtime.GOARCH)
 }
 
 func TestRun_PluginReleaseBuildsPythonSourcePluginForAllPlatforms(t *testing.T) {
@@ -429,7 +433,7 @@ func TestRun_PluginReleaseBuildsPythonSourcePluginForAllPlatforms(t *testing.T) 
 		if len(manifest.Artifacts) != 1 {
 			t.Fatalf("artifacts for %s/%s = %+v, want one artifact", platform.GOOS, platform.GOARCH, manifest.Artifacts)
 		}
-		assertExpectedPythonArtifactPlatform(t, manifest.Artifacts[0], platform.GOOS, platform.GOARCH)
+		assertExpectedScriptArtifactPlatform(t, manifest.Artifacts[0], platform.GOOS, platform.GOARCH)
 	}
 }
 
@@ -1204,6 +1208,152 @@ func TestRun_PluginReleaseBuildsPythonSourceDatastorePlugin(t *testing.T) {
 	}
 }
 
+func TestRun_PluginReleaseBuildsTypeScriptSourceAuthPlugin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake Bun build fixture is POSIX-only")
+	}
+
+	builtBinary := buildGoSourceAuthBinary(t)
+	t.Setenv("PATH", pathWithoutGo(t))
+
+	pluginDir := newTypeScriptSourceAuthReleaseFixture(t, t.TempDir())
+	bunPath := writeFakeTypeScriptComponentReleaseBun(t, filepath.Join(pluginDir, "fake-bun"), authReleaseTypeScriptTarget, authReleasePluginName, runtime.GOOS, runtime.GOARCH, builtBinary)
+	t.Setenv("GESTALT_BUN", bunPath)
+
+	outputDir := t.TempDir()
+	const testVersion = "0.0.15-ts-auth"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := platformArchiveName(authReleasePluginName, testVersion, expectedScriptReleasePlatform(runtime.GOOS, runtime.GOARCH))
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+	binaryName := releaseBinaryName(authReleasePluginName, runtime.GOOS)
+
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != binaryName {
+		t.Fatalf("artifacts = %+v, want path %q", manifest.Artifacts, binaryName)
+	}
+	if runtime.GOOS == "linux" && manifest.Artifacts[0].LibC != pluginpkg.CurrentRuntimeLibC() {
+		t.Fatalf("artifact libc = %q, want %q", manifest.Artifacts[0].LibC, pluginpkg.CurrentRuntimeLibC())
+	}
+	if manifest.Entrypoints.Auth == nil || manifest.Entrypoints.Auth.ArtifactPath != binaryName {
+		t.Fatalf("auth entrypoint = %+v, want artifact path %q", manifest.Entrypoints.Auth, binaryName)
+	}
+	if _, err := os.Stat(filepath.Join(extractDir, authReleaseSchemaPath)); err != nil {
+		t.Fatalf("expected %s in archive: %v", authReleaseSchemaPath, err)
+	}
+
+	auth, err := pluginhost.NewExecutableAuthProvider(context.Background(), pluginhost.AuthExecConfig{
+		Command:     filepath.Join(extractDir, binaryName),
+		Name:        authReleasePluginName,
+		CallbackURL: "https://gestalt.example.test/api/v1/auth/login/callback",
+		SessionKey:  []byte("0123456789abcdef0123456789abcdef"),
+	})
+	if err != nil {
+		t.Fatalf("NewExecutableAuthProvider: %v", err)
+	}
+	defer func() {
+		if closer, ok := auth.(interface{ Close() error }); ok {
+			_ = closer.Close()
+		}
+	}()
+
+	loginURL, err := auth.LoginURL("host-state")
+	if err != nil {
+		t.Fatalf("LoginURL: %v", err)
+	}
+	parsed, err := url.Parse(loginURL)
+	if err != nil {
+		t.Fatalf("url.Parse(loginURL): %v", err)
+	}
+	state := parsed.Query().Get("state")
+	if state == "" {
+		t.Fatal("login URL did not include state")
+	}
+
+	callbackHandler, ok := auth.(interface {
+		HandleCallbackRequest(context.Context, url.Values) (*core.UserIdentity, string, error)
+	})
+	if !ok {
+		t.Fatal("auth provider did not expose HandleCallbackRequest")
+	}
+	identity, originalState, err := callbackHandler.HandleCallbackRequest(context.Background(), url.Values{
+		"code":   {"callback-code"},
+		"state":  {state},
+		"prompt": {parsed.Query().Get("prompt")},
+	})
+	if err != nil {
+		t.Fatalf("HandleCallbackRequest: %v", err)
+	}
+	if originalState != "host-state" {
+		t.Fatalf("original state = %q, want %q", originalState, "host-state")
+	}
+	if identity == nil || identity.Email != "generated-auth@example.com" {
+		t.Fatalf("identity = %+v", identity)
+	}
+}
+
+func TestRun_PluginReleaseBuildsTypeScriptSourceDatastorePlugin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake Bun build fixture is POSIX-only")
+	}
+
+	builtBinary := buildGoSourceDatastoreBinary(t)
+	t.Setenv("PATH", pathWithoutGo(t))
+
+	pluginDir := newTypeScriptSourceDatastoreReleaseFixture(t, t.TempDir())
+	bunPath := writeFakeTypeScriptComponentReleaseBun(t, filepath.Join(pluginDir, "fake-bun"), datastoreReleaseTypeScriptTarget, datastoreReleasePluginName, runtime.GOOS, runtime.GOARCH, builtBinary)
+	t.Setenv("GESTALT_BUN", bunPath)
+
+	outputDir := t.TempDir()
+	const testVersion = "0.0.16-ts-datastore"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := platformArchiveName(datastoreReleasePluginName, testVersion, expectedScriptReleasePlatform(runtime.GOOS, runtime.GOARCH))
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+	binaryName := releaseBinaryName(datastoreReleasePluginName, runtime.GOOS)
+
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != binaryName {
+		t.Fatalf("artifacts = %+v, want path %q", manifest.Artifacts, binaryName)
+	}
+	if runtime.GOOS == "linux" && manifest.Artifacts[0].LibC != pluginpkg.CurrentRuntimeLibC() {
+		t.Fatalf("artifact libc = %q, want %q", manifest.Artifacts[0].LibC, pluginpkg.CurrentRuntimeLibC())
+	}
+	if manifest.Entrypoints.Datastore == nil || manifest.Entrypoints.Datastore.ArtifactPath != binaryName {
+		t.Fatalf("datastore entrypoint = %+v, want artifact path %q", manifest.Entrypoints.Datastore, binaryName)
+	}
+	if _, err := os.Stat(filepath.Join(extractDir, datastoreReleaseSchemaPath)); err != nil {
+		t.Fatalf("expected %s in archive: %v", datastoreReleaseSchemaPath, err)
+	}
+
+	store, err := pluginhost.NewExecutableDatastore(context.Background(), pluginhost.DatastoreExecConfig{
+		Command:       filepath.Join(extractDir, binaryName),
+		Name:          datastoreReleasePluginName,
+		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
+	})
+	if err != nil {
+		t.Fatalf("NewExecutableDatastore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+}
+
 func TestRun_PluginReleaseCopiesCompiledSupportFiles(t *testing.T) {
 	t.Parallel()
 
@@ -1539,7 +1689,7 @@ func TestRun_PluginReleaseRejectsRequiredExecutableKindsWithoutSourceOrEntrypoin
 				Kinds:       []string{pluginmanifestv1.KindPlugin},
 				Plugin:      &pluginmanifestv1.Plugin{},
 			},
-			wantError: "no Go, Rust, or Python provider package found",
+			wantError: "no Go, Rust, Python, or TypeScript provider package found",
 		},
 		{
 			name: "auth",
@@ -1550,7 +1700,7 @@ func TestRun_PluginReleaseRejectsRequiredExecutableKindsWithoutSourceOrEntrypoin
 				Kinds:       []string{pluginmanifestv1.KindAuth},
 				Auth:        &pluginmanifestv1.AuthMetadata{},
 			},
-			wantError: "no Go, Rust, or Python auth source package found",
+			wantError: "no Go, Rust, Python, or TypeScript auth source package found",
 		},
 		{
 			name: "datastore",
@@ -1561,7 +1711,7 @@ func TestRun_PluginReleaseRejectsRequiredExecutableKindsWithoutSourceOrEntrypoin
 				Kinds:       []string{pluginmanifestv1.KindDatastore},
 				Datastore:   &pluginmanifestv1.DatastoreMetadata{},
 			},
-			wantError: "no Go, Rust, or Python datastore source package found",
+			wantError: "no Go, Rust, Python, or TypeScript datastore source package found",
 		},
 	}
 
@@ -1857,6 +2007,148 @@ datastore = "provider:datastore_provider"
 	return pluginDir
 }
 
+func newTypeScriptSourceAuthReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(dir, authReleasePluginName)
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(pluginDir): %v", err)
+	}
+	writeTestFile(t, pluginDir, "package.json", []byte(`{
+  "name": "`+authReleasePluginName+`",
+  "version": "0.0.1",
+  "gestalt": {
+    "provider": {
+      "kind": "auth",
+      "target": "`+authReleaseTypeScriptModule+`"
+    }
+  }
+}
+`), 0o644)
+	writeTestFile(t, pluginDir, "auth.ts", []byte("export const auth = {};\n"), 0o644)
+	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
+		Source:      authReleaseSource,
+		Version:     "0.0.1",
+		DisplayName: "Auth Release",
+		Kinds:       []string{pluginmanifestv1.KindAuth},
+		Auth: &pluginmanifestv1.AuthMetadata{
+			ConfigSchemaPath: authReleaseSchemaPath,
+		},
+	})
+	writeTestFile(t, pluginDir, authReleaseSchemaPath, []byte(`{"type":"object"}`), 0o644)
+	return pluginDir
+}
+
+func newTypeScriptSourceDatastoreReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(dir, datastoreReleasePluginName)
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(pluginDir): %v", err)
+	}
+	writeTestFile(t, pluginDir, "package.json", []byte(`{
+  "name": "`+datastoreReleasePluginName+`",
+  "version": "0.0.1",
+  "gestalt": {
+    "provider": {
+      "kind": "datastore",
+      "target": "`+datastoreReleaseTypeScriptModule+`"
+    }
+  }
+}
+`), 0o644)
+	writeTestFile(t, pluginDir, "datastore.ts", []byte("export const datastore = {};\n"), 0o644)
+	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
+		Source:      datastoreReleaseSource,
+		Version:     "0.0.1",
+		DisplayName: "Datastore Release",
+		Kinds:       []string{pluginmanifestv1.KindDatastore},
+		Datastore: &pluginmanifestv1.DatastoreMetadata{
+			ConfigSchemaPath: datastoreReleaseSchemaPath,
+		},
+	})
+	writeTestFile(t, pluginDir, datastoreReleaseSchemaPath, []byte(`{"type":"object"}`), 0o644)
+	return pluginDir
+}
+
+func writeFakeTypeScriptComponentReleaseBun(t *testing.T, path, expectedTarget, expectedPluginName, expectedGOOS, expectedGOARCH, builtBinaryPath string) string {
+	t.Helper()
+
+	script := `#!/bin/sh
+set -eu
+
+if [ "$#" -lt 4 ] || [ "$1" != "--cwd" ]; then
+  echo "unexpected fake bun args: $*" >&2
+  exit 1
+fi
+
+cwd="$2"
+shift 2
+
+if [ "$1" != "run" ]; then
+  echo "unexpected bun subcommand: $1" >&2
+  exit 1
+fi
+shift
+
+entry="$1"
+shift
+
+if [ "$#" -gt 0 ] && [ "$1" = "--" ]; then
+  shift
+fi
+
+entry_base="${entry##*/}"
+case "$entry_base" in
+  gestalt-ts-build|build.ts)
+    if [ "$#" -ne 6 ]; then
+      echo "unexpected build args: $*" >&2
+      exit 1
+    fi
+    source_dir="$1"
+    target="$2"
+    output="$3"
+    name="$4"
+    goos="$5"
+    goarch="$6"
+    if [ "$cwd" != "$source_dir" ]; then
+      echo "unexpected build cwd: $cwd != $source_dir" >&2
+      exit 1
+    fi
+    if [ "$target" != "` + authReleaseTypeScriptTarget + `" ] && [ "$target" != "` + datastoreReleaseTypeScriptTarget + `" ]; then
+      echo "unexpected build target: $target" >&2
+      exit 1
+    fi
+    if [ "$target" != "` + expectedTarget + `" ]; then
+      echo "unexpected build target: $target" >&2
+      exit 1
+    fi
+    if [ "$name" != "` + expectedPluginName + `" ]; then
+      echo "unexpected plugin name: $name" >&2
+      exit 1
+    fi
+    if [ "$goos" != "` + expectedGOOS + `" ] || [ "$goarch" != "` + expectedGOARCH + `" ]; then
+      echo "unexpected target platform: $goos/$goarch" >&2
+      exit 1
+    fi
+    output_dir="${output%/*}"
+    if [ "$output_dir" = "$output" ]; then
+      output_dir="."
+    fi
+    mkdir -p "$output_dir"
+    cp "` + builtBinaryPath + `" "$output"
+    chmod +x "$output"
+    exit 0
+    ;;
+esac
+
+echo "unexpected fake bun entry: $entry ($*)" >&2
+exit 1
+`
+	writeTestFile(t, filepath.Dir(path), filepath.Base(path), []byte(script), 0o755)
+	return path
+}
+
 func writeFakePythonReleaseInterpreter(t *testing.T, path, expectedGOOS, expectedGOARCH string) {
 	t.Helper()
 	writeFakePythonReleaseInterpreterForKind(
@@ -1977,7 +2269,7 @@ func defaultReleasePlatformsForTest(t *testing.T) []releasePlatform {
 	return platforms
 }
 
-func expectedPythonReleasePlatform(goos, goarch string) releasePlatform {
+func expectedScriptReleasePlatform(goos, goarch string) releasePlatform {
 	plat := releasePlatform{GOOS: goos, GOARCH: goarch}
 	if runtime.GOOS == "linux" && goos == "linux" {
 		plat.LibC = pluginpkg.CurrentRuntimeLibC()
@@ -1986,7 +2278,7 @@ func expectedPythonReleasePlatform(goos, goarch string) releasePlatform {
 }
 
 func expectedPythonArchiveNameFor(pluginName, version, goos, goarch string) string {
-	return platformArchiveName(pluginName, version, expectedPythonReleasePlatform(goos, goarch))
+	return platformArchiveName(pluginName, version, expectedScriptReleasePlatform(goos, goarch))
 }
 
 func expectedPythonArchiveName(version, goos, goarch string) string {
@@ -2015,10 +2307,10 @@ func expectedRustArchiveName(version, goos, goarch, libc string) string {
 	return platformArchiveName(rustReleasePluginName, version, expectedRustReleasePlatform(goos, goarch, libc))
 }
 
-func assertExpectedPythonArtifactPlatform(t *testing.T, artifact pluginmanifestv1.Artifact, goos, goarch string) {
+func assertExpectedScriptArtifactPlatform(t *testing.T, artifact pluginmanifestv1.Artifact, goos, goarch string) {
 	t.Helper()
 
-	want := expectedPythonReleasePlatform(goos, goarch)
+	want := expectedScriptReleasePlatform(goos, goarch)
 	if artifact.OS != want.GOOS || artifact.Arch != want.GOARCH || artifact.LibC != want.LibC {
 		t.Fatalf(
 			"artifact platform = %s/%s/%s, want %s/%s/%s",

--- a/gestaltd/internal/pluginpkg/go_provider.go
+++ b/gestaltd/internal/pluginpkg/go_provider.go
@@ -86,7 +86,7 @@ func BuildGoComponentBinary(root, outputPath, kind, goos, goarch string) error {
 }
 
 func SourceComponentExecutionCommand(root, kind, goos, goarch string) (string, []string, func(), error) {
-	sourceKind, pythonTarget, err := detectSourceComponent(root, kind, goos, goarch)
+	sourceKind, target, err := detectSourceComponent(root, kind, goos, goarch)
 	if err != nil {
 		return "", nil, nil, err
 	}
@@ -107,7 +107,9 @@ func SourceComponentExecutionCommand(root, kind, goos, goarch string) (string, [
 		if err != nil {
 			return "", nil, nil, err
 		}
-		return pythonComponentExecutionCommand(root, pythonTarget, runtimeKind)
+		return pythonComponentExecutionCommand(root, target, runtimeKind)
+	case sourceProviderKindTypeScript:
+		return typeScriptExecutionCommand(root, target)
 	default:
 		return "", nil, nil, ErrNoSourceComponentPackage
 	}
@@ -124,13 +126,16 @@ func ValidateSourceComponentRelease(root, kind, goos, goarch, libc string) error
 		return err
 	case sourceProviderKindRust:
 		return ValidateRustComponentRelease(root, kind, goos, goarch, libc)
+	case sourceProviderKindTypeScript:
+		_, err = DetectBunExecutable()
+		return err
 	default:
 		return nil
 	}
 }
 
 func BuildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch, libc string) (string, error) {
-	sourceKind, pythonTarget, err := detectSourceComponent(root, kind, goos, goarch)
+	sourceKind, target, err := detectSourceComponent(root, kind, goos, goarch)
 	if err != nil {
 		return "", err
 	}
@@ -145,7 +150,9 @@ func BuildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch, lib
 			return "", err
 		}
 		pluginName := sourcePluginName(root)
-		return BuildPythonComponentBinary(root, outputPath, pluginName, pythonTarget, runtimeKind, goos, goarch)
+		return BuildPythonComponentBinary(root, outputPath, pluginName, target, runtimeKind, goos, goarch)
+	case sourceProviderKindTypeScript:
+		return BuildTypeScriptComponentBinary(root, outputPath, kind, target, goos, goarch)
 	default:
 		return "", ErrNoSourceComponentPackage
 	}
@@ -163,7 +170,7 @@ func HasSourceComponentPackage(root, kind string) (bool, error) {
 	}
 }
 
-func detectSourceComponent(root, kind, goos, goarch string) (sourceKind string, pythonTarget string, err error) {
+func detectSourceComponent(root, kind, goos, goarch string) (sourceKind string, target string, err error) {
 	if err := validateSourceComponentKind(kind); err != nil {
 		return "", "", err
 	}
@@ -183,16 +190,24 @@ func detectSourceComponent(root, kind, goos, goarch string) (sourceKind string, 
 		return "", "", err
 	}
 
-	target, err := DetectPythonComponentTarget(root, kind)
+	target, err = DetectPythonComponentTarget(root, kind)
 	switch {
 	case err == nil:
 		return sourceProviderKindPython, target, nil
 	case !errors.Is(err, ErrNoPythonSourceComponentPackage):
 		return "", "", err
-	case goToolUnavailable != nil:
-		return "", "", goToolUnavailable
 	default:
-		return "", "", ErrNoSourceComponentPackage
+		target, err = DetectTypeScriptComponentTarget(root, kind)
+		switch {
+		case err == nil:
+			return sourceProviderKindTypeScript, target, nil
+		case !errors.Is(err, ErrNoSourceComponentPackage):
+			return "", "", err
+		case goToolUnavailable != nil:
+			return "", "", goToolUnavailable
+		default:
+			return "", "", ErrNoSourceComponentPackage
+		}
 	}
 }
 

--- a/gestaltd/internal/pluginpkg/source_provider.go
+++ b/gestaltd/internal/pluginpkg/source_provider.go
@@ -8,12 +8,13 @@ import (
 var ErrNoSourceProviderPackage = errors.New("no source provider package found")
 
 const (
-	sourceProviderKindGo     = "go"
-	sourceProviderKindRust   = "rust"
-	sourceProviderKindPython = "python"
+	sourceProviderKindGo         = "go"
+	sourceProviderKindRust       = "rust"
+	sourceProviderKindPython     = "python"
+	sourceProviderKindTypeScript = "typescript"
 )
 
-func detectSourceProvider(root, goos, goarch string) (kind string, pythonTarget string, err error) {
+func detectSourceProvider(root, goos, goarch string) (kind string, target string, err error) {
 	var goToolUnavailable error
 	if _, err := DetectGoProviderImportPath(root, goos, goarch); err == nil {
 		return sourceProviderKindGo, "", nil
@@ -29,21 +30,29 @@ func detectSourceProvider(root, goos, goarch string) (kind string, pythonTarget 
 		return "", "", err
 	}
 
-	target, err := DetectPythonProviderTarget(root)
+	target, err = DetectPythonProviderTarget(root)
 	switch {
 	case err == nil:
 		return sourceProviderKindPython, target, nil
 	case !errors.Is(err, ErrNoPythonProviderPackage):
 		return "", "", err
-	case goToolUnavailable != nil:
-		return "", "", goToolUnavailable
 	default:
-		return "", "", ErrNoSourceProviderPackage
+		target, err = DetectTypeScriptProviderTarget(root)
+		switch {
+		case err == nil:
+			return sourceProviderKindTypeScript, target, nil
+		case !errors.Is(err, ErrNoTypeScriptProviderPackage):
+			return "", "", err
+		case goToolUnavailable != nil:
+			return "", "", goToolUnavailable
+		default:
+			return "", "", ErrNoSourceProviderPackage
+		}
 	}
 }
 
 func SourceProviderExecutionCommand(root, goos, goarch string) (string, []string, func(), error) {
-	kind, pythonTarget, err := detectSourceProvider(root, goos, goarch)
+	kind, target, err := detectSourceProvider(root, goos, goarch)
 	if err != nil {
 		return "", nil, nil, err
 	}
@@ -57,7 +66,9 @@ func SourceProviderExecutionCommand(root, goos, goarch string) (string, []string
 	case sourceProviderKindRust:
 		return rustProviderExecutionCommand(root, goos, goarch)
 	case sourceProviderKindPython:
-		return pythonProviderExecutionCommand(root, pythonTarget)
+		return pythonProviderExecutionCommand(root, target)
+	case sourceProviderKindTypeScript:
+		return typeScriptExecutionCommand(root, target)
 	default:
 		return "", nil, nil, ErrNoSourceProviderPackage
 	}
@@ -74,12 +85,16 @@ func ValidateSourceProviderRelease(root, goos, goarch, libc string) error {
 	case sourceProviderKindPython:
 		_, err = DetectPythonInterpreter(root, goos, goarch)
 		return err
+	case sourceProviderKindTypeScript:
+		_, err = DetectBunExecutable()
+		return err
+	default:
+		return nil
 	}
-	return nil
 }
 
 func BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch, libc string) (string, error) {
-	kind, pythonTarget, err := detectSourceProvider(root, goos, goarch)
+	kind, target, err := detectSourceProvider(root, goos, goarch)
 	if err != nil {
 		return "", err
 	}
@@ -89,7 +104,9 @@ func BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch
 	case sourceProviderKindRust:
 		return BuildRustProviderBinary(root, outputPath, pluginName, goos, goarch, libc)
 	case sourceProviderKindPython:
-		return BuildPythonProviderBinary(root, outputPath, pluginName, pythonTarget, goos, goarch)
+		return BuildPythonProviderBinary(root, outputPath, pluginName, target, goos, goarch)
+	case sourceProviderKindTypeScript:
+		return BuildTypeScriptProviderBinary(root, outputPath, pluginName, target, goos, goarch)
 	default:
 		return "", ErrNoSourceProviderPackage
 	}

--- a/gestaltd/internal/pluginpkg/typescript_provider.go
+++ b/gestaltd/internal/pluginpkg/typescript_provider.go
@@ -1,0 +1,350 @@
+package pluginpkg
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+)
+
+const (
+	typeScriptProjectFile  = "package.json"
+	typeScriptRuntimeBin   = "gestalt-ts-runtime"
+	typeScriptBuildBin     = "gestalt-ts-build"
+	typeScriptBunEnvVar    = "GESTALT_BUN"
+	typeScriptProviderKey  = "provider"
+	typeScriptPluginKey    = "plugin"
+	typeScriptAuthKey      = "auth"
+	typeScriptDatastoreKey = "datastore"
+)
+
+var ErrNoTypeScriptProviderPackage = errors.New("no TypeScript provider package found")
+
+var typeScriptExportPattern = regexp.MustCompile(`^[A-Za-z_$][A-Za-z0-9_$]*$`)
+
+type typeScriptPackageConfig struct {
+	Gestalt map[string]any `json:"gestalt"`
+}
+
+func DetectTypeScriptProviderTarget(root string) (string, error) {
+	return detectTypeScriptTarget(root, "integration", ErrNoTypeScriptProviderPackage)
+}
+
+func DetectTypeScriptComponentTarget(root, kind string) (string, error) {
+	providerKind, err := typeScriptComponentKind(kind)
+	if err != nil {
+		return "", err
+	}
+	return detectTypeScriptTarget(root, providerKind, ErrNoSourceComponentPackage)
+}
+
+func detectTypeScriptTarget(root, expectedKind string, missingErr error) (string, error) {
+	projectPath := filepath.Join(root, typeScriptProjectFile)
+	data, err := os.ReadFile(projectPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", missingErr
+		}
+		return "", fmt.Errorf("read %s: %w", typeScriptProjectFile, err)
+	}
+
+	var config typeScriptPackageConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		return "", fmt.Errorf("parse %s: %w", typeScriptProjectFile, err)
+	}
+
+	if rawProvider, ok := config.Gestalt[typeScriptProviderKey]; ok {
+		kind, target, err := parseTypeScriptProviderConfig(rawProvider)
+		if err != nil {
+			return "", fmt.Errorf("%s gestalt.%s: %w", typeScriptProjectFile, typeScriptProviderKey, err)
+		}
+		if kind == expectedKind {
+			return formatTypeScriptRuntimeTarget(kind, target), nil
+		}
+	}
+
+	key, ok := typeScriptLegacyTargetKey(expectedKind)
+	if !ok {
+		return "", missingErr
+	}
+	target, ok := config.Gestalt[key].(string)
+	target = strings.TrimSpace(target)
+	if !ok || target == "" {
+		return "", missingErr
+	}
+	if _, _, err := SplitTypeScriptProviderTarget(target); err != nil {
+		return "", fmt.Errorf("%s gestalt.%s: %w", typeScriptProjectFile, key, err)
+	}
+	return formatTypeScriptRuntimeTarget(expectedKind, target), nil
+}
+
+func typeScriptExecutionCommand(root, target string) (string, []string, func(), error) {
+	bunPath, err := DetectBunExecutable()
+	if err != nil {
+		return "", nil, nil, err
+	}
+	if sdkPath := localTypeScriptSDKPath(); sdkPath != "" {
+		return bunPath, []string{
+			"--cwd", root,
+			"run",
+			filepath.Join(sdkPath, "src", "runtime.ts"),
+			"--",
+			root,
+			target,
+		}, nil, nil
+	}
+	return bunPath, []string{
+		"--cwd", root,
+		"run",
+		typeScriptRuntimeBin,
+		"--",
+		root,
+		target,
+	}, nil, nil
+}
+
+func BuildTypeScriptProviderBinary(sourceDir, binaryPath, pluginName, target, goos, goarch string) (string, error) {
+	return buildTypeScriptBinary(sourceDir, binaryPath, pluginName, target, goos, goarch)
+}
+
+func BuildTypeScriptComponentBinary(sourceDir, binaryPath, kind, target, goos, goarch string) (string, error) {
+	if err := validateSourceComponentKind(kind); err != nil {
+		return "", err
+	}
+	return buildTypeScriptBinary(sourceDir, binaryPath, sourcePluginName(sourceDir), target, goos, goarch)
+}
+
+func buildTypeScriptBinary(sourceDir, binaryPath, pluginName, target, goos, goarch string) (string, error) {
+	bunPath, err := DetectBunExecutable()
+	if err != nil {
+		return "", fmt.Errorf("detect Bun executable: %w", err)
+	}
+
+	var args []string
+	if sdkPath := localTypeScriptSDKPath(); sdkPath != "" {
+		args = []string{
+			"--cwd", sourceDir,
+			"run",
+			filepath.Join(sdkPath, "src", "build.ts"),
+			"--",
+			sourceDir,
+			target,
+			binaryPath,
+			pluginName,
+			goos,
+			goarch,
+		}
+	} else {
+		args = []string{
+			"--cwd", sourceDir,
+			"run",
+			typeScriptBuildBin,
+			"--",
+			sourceDir,
+			target,
+			binaryPath,
+			pluginName,
+			goos,
+			goarch,
+		}
+	}
+
+	cmd := exec.Command(bunPath, args...)
+	cmd.Dir = sourceDir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("TypeScript release build: %w (ensure Bun and @valon-technologies/gestalt are available)", err)
+	}
+	if goos != "linux" || runtime.GOOS != "linux" {
+		return "", nil
+	}
+	return CurrentRuntimeLibC(), nil
+}
+
+func typeScriptComponentKind(kind string) (string, error) {
+	switch kind {
+	case pluginmanifestv1.KindAuth:
+		return "auth", nil
+	case pluginmanifestv1.KindDatastore:
+		return "datastore", nil
+	default:
+		return "", fmt.Errorf("unsupported source component kind %q", kind)
+	}
+}
+
+func typeScriptLegacyTargetKey(kind string) (string, bool) {
+	switch kind {
+	case "integration":
+		return typeScriptPluginKey, true
+	case "auth":
+		return typeScriptAuthKey, true
+	case "datastore":
+		return typeScriptDatastoreKey, true
+	default:
+		return "", false
+	}
+}
+
+func DetectBunExecutable() (string, error) {
+	for _, candidate := range bunExecutableCandidates() {
+		if candidate == "" {
+			continue
+		}
+		if filepath.IsAbs(candidate) {
+			if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+				return candidate, nil
+			}
+			continue
+		}
+		if resolved, err := exec.LookPath(candidate); err == nil {
+			return resolved, nil
+		}
+	}
+	return "", fmt.Errorf("detect Bun executable: %w (set %s if Bun is installed outside PATH)", exec.ErrNotFound, typeScriptBunEnvVar)
+}
+
+func bunExecutableCandidates() []string {
+	candidates := []string{
+		os.Getenv(typeScriptBunEnvVar),
+		"bun",
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		candidates = append(candidates, filepath.Join(home, ".bun", "bin", "bun"))
+	}
+	return candidates
+}
+
+func localTypeScriptSDKPath() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return ""
+	}
+	path := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", "sdk", "typescript"))
+	if _, err := os.Stat(filepath.Join(path, "package.json")); err != nil {
+		return ""
+	}
+	return path
+}
+
+func SplitTypeScriptProviderTarget(target string) (modulePath string, exportName string, err error) {
+	raw := strings.TrimSpace(target)
+	modulePath, exportName, _ = strings.Cut(raw, "#")
+	modulePath = strings.TrimSpace(modulePath)
+	exportName = strings.TrimSpace(exportName)
+	if modulePath == "" {
+		return "", "", fmt.Errorf("module path is required")
+	}
+	if exportName != "" && !typeScriptExportPattern.MatchString(exportName) {
+		return "", "", fmt.Errorf("export must be a JavaScript identifier")
+	}
+	if err := validateTypeScriptModulePath(modulePath); err != nil {
+		return "", "", err
+	}
+	return modulePath, exportName, nil
+}
+
+func parseTypeScriptProviderConfig(raw any) (kind string, target string, err error) {
+	switch value := raw.(type) {
+	case string:
+		return parseTypeScriptProviderString(value)
+	case map[string]any:
+		rawKind, _ := value["kind"].(string)
+		rawTarget, _ := value["target"].(string)
+		kind = normalizeTypeScriptProviderKind(rawKind)
+		if strings.TrimSpace(rawKind) != "" && kind == "" {
+			return "", "", fmt.Errorf("unsupported provider kind %q", rawKind)
+		}
+		if strings.TrimSpace(rawTarget) == "" {
+			return "", "", fmt.Errorf("target is required")
+		}
+		target = strings.TrimSpace(rawTarget)
+		if _, _, err := SplitTypeScriptProviderTarget(target); err != nil {
+			return "", "", err
+		}
+		return kind, target, nil
+	default:
+		return "", "", fmt.Errorf("must be a string or object")
+	}
+}
+
+func parseTypeScriptProviderString(raw string) (kind string, target string, err error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", "", fmt.Errorf("target is required")
+	}
+	if prefix, rest, ok := parseTypeScriptKindPrefixedTarget(trimmed); ok {
+		if _, _, err := SplitTypeScriptProviderTarget(rest); err != nil {
+			return "", "", err
+		}
+		return prefix, rest, nil
+	}
+	if _, _, err := SplitTypeScriptProviderTarget(trimmed); err != nil {
+		return "", "", err
+	}
+	return "integration", trimmed, nil
+}
+
+func parseTypeScriptKindPrefixedTarget(raw string) (kind string, target string, ok bool) {
+	prefix, rest, found := strings.Cut(raw, ":")
+	if !found {
+		return "", "", false
+	}
+	if strings.TrimSpace(prefix) == "" {
+		return "", "", false
+	}
+	kind = normalizeTypeScriptProviderKind(prefix)
+	if kind == "" {
+		return "", "", false
+	}
+	return kind, strings.TrimSpace(rest), true
+}
+
+func normalizeTypeScriptProviderKind(value string) string {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "", "plugin", "integration":
+		return "integration"
+	case "auth":
+		return "auth"
+	case "datastore":
+		return "datastore"
+	case "secrets":
+		return "secrets"
+	case "telemetry":
+		return "telemetry"
+	default:
+		return ""
+	}
+}
+
+func formatTypeScriptRuntimeTarget(kind, target string) string {
+	if kind == "integration" {
+		return "plugin:" + strings.TrimSpace(target)
+	}
+	return kind + ":" + strings.TrimSpace(target)
+}
+
+func validateTypeScriptModulePath(value string) error {
+	if !strings.HasPrefix(value, "./") && !strings.HasPrefix(value, "../") {
+		return fmt.Errorf("module path must be relative")
+	}
+	cleanPath := path.Clean(strings.ReplaceAll(value, "\\", "/"))
+	if path.IsAbs(cleanPath) || cleanPath == "." || cleanPath == ".." || strings.HasPrefix(cleanPath, "../") {
+		return fmt.Errorf("module path must stay within the plugin root")
+	}
+	ext := path.Ext(cleanPath)
+	switch ext {
+	case ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs":
+		return nil
+	default:
+		return fmt.Errorf("module path must end in a TypeScript or JavaScript file extension")
+	}
+}

--- a/gestaltd/internal/pluginpkg/typescript_provider_test.go
+++ b/gestaltd/internal/pluginpkg/typescript_provider_test.go
@@ -1,0 +1,724 @@
+package pluginpkg
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+)
+
+const (
+	typeScriptTestPluginModuleTarget    = "./provider.ts#plugin"
+	typeScriptTestPluginTarget          = "plugin:./provider.ts#plugin"
+	typeScriptTestAuthModuleTarget      = "./auth.ts#auth"
+	typeScriptTestAuthTarget            = "auth:./auth.ts#auth"
+	typeScriptTestDatastoreModuleTarget = "./datastore.ts#datastore"
+	typeScriptTestDatastoreTarget       = "datastore:./datastore.ts#datastore"
+)
+
+func TestSplitTypeScriptProviderTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		target     string
+		wantModule string
+		wantExport string
+		wantErr    string
+	}{
+		{
+			name:       "module only",
+			target:     "./provider.ts",
+			wantModule: "./provider.ts",
+		},
+		{
+			name:       "module and export",
+			target:     typeScriptTestPluginModuleTarget,
+			wantModule: "./provider.ts",
+			wantExport: "plugin",
+		},
+		{
+			name:    "missing relative prefix",
+			target:  "provider.ts#plugin",
+			wantErr: "module path must be relative",
+		},
+		{
+			name:    "escapes root",
+			target:  "../provider.ts#plugin",
+			wantErr: "module path must stay within the plugin root",
+		},
+		{
+			name:    "invalid extension",
+			target:  "./provider",
+			wantErr: "module path must end in a TypeScript or JavaScript file extension",
+		},
+		{
+			name:    "invalid export",
+			target:  "./provider.ts#bad-export",
+			wantErr: "export must be a JavaScript identifier",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			module, exportName, err := SplitTypeScriptProviderTarget(tt.target)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("SplitTypeScriptProviderTarget(%q) error = nil, want %q", tt.target, tt.wantErr)
+				}
+				if !containsString(err.Error(), tt.wantErr) {
+					t.Fatalf("SplitTypeScriptProviderTarget(%q) error = %q, want %q", tt.target, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SplitTypeScriptProviderTarget(%q): %v", tt.target, err)
+			}
+			if module != tt.wantModule || exportName != tt.wantExport {
+				t.Fatalf("SplitTypeScriptProviderTarget(%q) = (%q, %q), want (%q, %q)", tt.target, module, exportName, tt.wantModule, tt.wantExport)
+			}
+		})
+	}
+}
+
+func TestDetectTypeScriptProviderTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{
+			name:   "plugin prefix",
+			target: typeScriptTestPluginTarget,
+			want:   typeScriptTestPluginTarget,
+		},
+		{
+			name:   "legacy integration prefix",
+			target: "integration:./provider.ts#plugin",
+			want:   typeScriptTestPluginTarget,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			mustWriteTypeScriptProviderPackage(t, root, tt.target)
+
+			got, err := DetectTypeScriptProviderTarget(root)
+			if err != nil {
+				t.Fatalf("DetectTypeScriptProviderTarget: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("target = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectTypeScriptProviderTarget_InvalidTarget(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, typeScriptProjectFile), []byte(`{"name":"ts-release","gestalt":{"plugin":"provider.ts"}}`), 0o644)
+
+	_, err := DetectTypeScriptProviderTarget(root)
+	if err == nil {
+		t.Fatal("expected invalid TypeScript provider target error")
+	}
+	if want := "package.json gestalt.plugin"; !containsString(err.Error(), want) {
+		t.Fatalf("error = %q, want mention of %q", err, want)
+	}
+}
+
+func TestDetectTypeScriptProviderTarget_RejectsEmptyKindPrefix(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWriteTypeScriptPackageConfig(t, root, map[string]string{
+		typeScriptProviderKey: ":./provider.ts#plugin",
+	})
+	mustWriteTypeScriptTargetModule(t, root, typeScriptTestPluginTarget)
+
+	_, err := DetectTypeScriptProviderTarget(root)
+	if err == nil {
+		t.Fatal("expected invalid TypeScript provider target error")
+	}
+	if want := "package.json gestalt.provider"; !containsString(err.Error(), want) {
+		t.Fatalf("error = %q, want mention of %q", err, want)
+	}
+}
+
+func TestHasSourceProviderPackage_TypeScript(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWriteTypeScriptProviderPackage(t, root, typeScriptTestPluginTarget)
+
+	ok, err := HasSourceProviderPackage(root)
+	if err != nil {
+		t.Fatalf("HasSourceProviderPackage: %v", err)
+	}
+	if !ok {
+		t.Fatal("HasSourceProviderPackage = false, want true")
+	}
+}
+
+func TestDetectTypeScriptComponentTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		kind   string
+		target string
+	}{
+		{
+			name:   "auth",
+			kind:   pluginmanifestv1.KindAuth,
+			target: typeScriptTestAuthTarget,
+		},
+		{
+			name:   "datastore",
+			kind:   pluginmanifestv1.KindDatastore,
+			target: typeScriptTestDatastoreTarget,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			mustWriteTypeScriptComponentPackage(t, root, tt.kind, tt.target)
+
+			got, err := DetectTypeScriptComponentTarget(root, tt.kind)
+			if err != nil {
+				t.Fatalf("DetectTypeScriptComponentTarget(%q): %v", tt.kind, err)
+			}
+			if got != tt.target {
+				t.Fatalf("target = %q, want %q", got, tt.target)
+			}
+		})
+	}
+}
+
+func TestDetectTypeScriptComponentTarget_InvalidTarget(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWriteTypeScriptPackageConfig(t, root, map[string]string{
+		typeScriptAuthKey: "auth.ts",
+	})
+
+	_, err := DetectTypeScriptComponentTarget(root, pluginmanifestv1.KindAuth)
+	if err == nil {
+		t.Fatal("expected invalid TypeScript auth target error")
+	}
+	if want := "package.json gestalt.auth"; !containsString(err.Error(), want) {
+		t.Fatalf("error = %q, want mention of %q", err, want)
+	}
+}
+
+func TestHasSourceComponentPackage_TypeScript(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWriteTypeScriptComponentPackage(t, root, pluginmanifestv1.KindAuth, typeScriptTestAuthTarget)
+
+	ok, err := HasSourceComponentPackage(root, pluginmanifestv1.KindAuth)
+	if err != nil {
+		t.Fatalf("HasSourceComponentPackage(auth): %v", err)
+	}
+	if !ok {
+		t.Fatal("HasSourceComponentPackage(auth) = false, want true")
+	}
+
+	ok, err = HasSourceComponentPackage(root, pluginmanifestv1.KindDatastore)
+	if err != nil {
+		t.Fatalf("HasSourceComponentPackage(datastore): %v", err)
+	}
+	if ok {
+		t.Fatal("HasSourceComponentPackage(datastore) = true, want false")
+	}
+}
+
+func TestDetectBunExecutable_UsesEnvironmentOverride(t *testing.T) {
+	root := t.TempDir()
+	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH)
+	t.Setenv(typeScriptBunEnvVar, bunPath)
+	t.Setenv("PATH", "")
+	t.Setenv("HOME", filepath.Join(root, "home"))
+
+	got, err := DetectBunExecutable()
+	if err != nil {
+		t.Fatalf("DetectBunExecutable: %v", err)
+	}
+	if got != bunPath {
+		t.Fatalf("bun path = %q, want %q", got, bunPath)
+	}
+}
+
+func TestSourceProviderExecutionCommand_TypeScript(t *testing.T) {
+	root := t.TempDir()
+	mustWriteTypeScriptProviderPackage(t, root, typeScriptTestPluginTarget)
+	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH)
+	t.Setenv(typeScriptBunEnvVar, bunPath)
+
+	command, args, cleanup, err := SourceProviderExecutionCommand(root, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatalf("SourceProviderExecutionCommand: %v", err)
+	}
+	if cleanup != nil {
+		t.Fatal("cleanup should be nil for TypeScript source providers")
+	}
+	if command != bunPath {
+		t.Fatalf("command = %q, want %q", command, bunPath)
+	}
+	if len(args) != 7 {
+		t.Fatalf("args len = %d, want 7 (%v)", len(args), args)
+	}
+	if args[0] != "--cwd" || args[1] != root {
+		t.Fatalf("args prefix = %v, want [--cwd %s ...]", args[:2], root)
+	}
+	if args[2] != "run" {
+		t.Fatalf("args[2] = %q, want run", args[2])
+	}
+	if args[4] != "--" {
+		t.Fatalf("args[4] = %q, want --", args[4])
+	}
+	if args[5] != root || args[6] != typeScriptTestPluginTarget {
+		t.Fatalf("args tail = %v, want [%s %s]", args[5:], root, typeScriptTestPluginTarget)
+	}
+
+	entry := filepath.Base(args[3])
+	switch entry {
+	case typeScriptRuntimeBin, "runtime.ts":
+	default:
+		t.Fatalf("runtime entry = %q, want %q or local runtime.ts path", args[3], typeScriptRuntimeBin)
+	}
+}
+
+func TestSourceComponentExecutionCommand_TypeScript(t *testing.T) {
+	tests := []struct {
+		name   string
+		kind   string
+		target string
+	}{
+		{
+			name:   "auth",
+			kind:   pluginmanifestv1.KindAuth,
+			target: typeScriptTestAuthTarget,
+		},
+		{
+			name:   "datastore",
+			kind:   pluginmanifestv1.KindDatastore,
+			target: typeScriptTestDatastoreTarget,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			mustWriteTypeScriptComponentPackage(t, root, tt.kind, tt.target)
+			bunPath := writeFakeTypeScriptBun(t, root, "ts-release", tt.target, runtime.GOOS, runtime.GOARCH)
+			t.Setenv(typeScriptBunEnvVar, bunPath)
+
+			command, args, cleanup, err := SourceComponentExecutionCommand(root, tt.kind, runtime.GOOS, runtime.GOARCH)
+			if err != nil {
+				t.Fatalf("SourceComponentExecutionCommand(%q): %v", tt.kind, err)
+			}
+			if cleanup != nil {
+				t.Fatal("cleanup should be nil for TypeScript source components")
+			}
+			if command != bunPath {
+				t.Fatalf("command = %q, want %q", command, bunPath)
+			}
+			if len(args) != 7 {
+				t.Fatalf("args len = %d, want 7 (%v)", len(args), args)
+			}
+			if args[5] != root || args[6] != tt.target {
+				t.Fatalf("args tail = %v, want [%s %s]", args[5:], root, tt.target)
+			}
+		})
+	}
+}
+
+func TestPrepareSourceManifest_GeneratesTypeScriptStaticCatalog(t *testing.T) {
+	root := t.TempDir()
+	manifestPath := mustWriteTypeScriptSourceManifest(t, root, "ts-release")
+	mustWriteTypeScriptProviderPackage(t, root, typeScriptTestPluginTarget)
+	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH)
+	t.Setenv(typeScriptBunEnvVar, bunPath)
+
+	_, manifest, err := PrepareSourceManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("PrepareSourceManifest: %v", err)
+	}
+	if manifest == nil || manifest.Plugin == nil {
+		t.Fatalf("manifest = %+v, want provider metadata", manifest)
+	}
+
+	catalogPath := filepath.Join(root, StaticCatalogFile)
+	data, err := os.ReadFile(catalogPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", catalogPath, err)
+	}
+	if !containsString(string(data), "name: ts-release") {
+		t.Fatalf("catalog = %q, want provider name", string(data))
+	}
+}
+
+func TestValidateSourceProviderRelease_TypeScript(t *testing.T) {
+	root := t.TempDir()
+	mustWriteTypeScriptProviderPackage(t, root, typeScriptTestPluginTarget)
+	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH)
+	t.Setenv(typeScriptBunEnvVar, bunPath)
+
+	if err := ValidateSourceProviderRelease(root, runtime.GOOS, runtime.GOARCH, ""); err != nil {
+		t.Fatalf("ValidateSourceProviderRelease: %v", err)
+	}
+}
+
+func TestValidateSourceComponentRelease_TypeScript(t *testing.T) {
+	tests := []struct {
+		name   string
+		kind   string
+		target string
+	}{
+		{
+			name:   "auth",
+			kind:   pluginmanifestv1.KindAuth,
+			target: typeScriptTestAuthTarget,
+		},
+		{
+			name:   "datastore",
+			kind:   pluginmanifestv1.KindDatastore,
+			target: typeScriptTestDatastoreTarget,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			mustWriteTypeScriptComponentPackage(t, root, tt.kind, tt.target)
+			bunPath := writeFakeTypeScriptBun(t, root, "ts-release", tt.target, runtime.GOOS, runtime.GOARCH)
+			t.Setenv(typeScriptBunEnvVar, bunPath)
+
+			if err := ValidateSourceComponentRelease(root, tt.kind, runtime.GOOS, runtime.GOARCH, ""); err != nil {
+				t.Fatalf("ValidateSourceComponentRelease(%q): %v", tt.kind, err)
+			}
+		})
+	}
+}
+
+func TestBuildSourceProviderReleaseBinary_TypeScript(t *testing.T) {
+	root := t.TempDir()
+	mustWriteTypeScriptProviderPackage(t, root, typeScriptTestPluginTarget)
+	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH)
+	t.Setenv(typeScriptBunEnvVar, bunPath)
+
+	outputPath := filepath.Join(t.TempDir(), "gestalt-plugin-ts-release")
+	libc, err := BuildSourceProviderReleaseBinary(root, outputPath, "ts-release", runtime.GOOS, runtime.GOARCH, "")
+	if err != nil {
+		t.Fatalf("BuildSourceProviderReleaseBinary: %v", err)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", outputPath, err)
+	}
+	if !containsString(string(data), "fake ts release binary") {
+		t.Fatalf("binary contents = %q, want fake build marker", string(data))
+	}
+
+	wantLibC := ""
+	if runtime.GOOS == "linux" {
+		wantLibC = CurrentRuntimeLibC()
+	}
+	if libc != wantLibC {
+		t.Fatalf("libc = %q, want %q", libc, wantLibC)
+	}
+}
+
+func TestBuildSourceComponentReleaseBinary_TypeScript(t *testing.T) {
+	tests := []struct {
+		name       string
+		kind       string
+		target     string
+		pluginName string
+	}{
+		{
+			name:       "auth",
+			kind:       pluginmanifestv1.KindAuth,
+			target:     typeScriptTestAuthTarget,
+			pluginName: "ts-auth-release",
+		},
+		{
+			name:       "datastore",
+			kind:       pluginmanifestv1.KindDatastore,
+			target:     typeScriptTestDatastoreTarget,
+			pluginName: "ts-datastore-release",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			mustWriteTypeScriptComponentPackage(t, root, tt.kind, tt.target)
+			mustWriteTypeScriptSourceComponentManifest(t, root, tt.pluginName, tt.kind)
+			bunPath := writeFakeTypeScriptBun(t, root, tt.pluginName, tt.target, runtime.GOOS, runtime.GOARCH)
+			t.Setenv(typeScriptBunEnvVar, bunPath)
+
+			outputPath := filepath.Join(t.TempDir(), "gestalt-plugin-"+tt.pluginName)
+			libc, err := BuildSourceComponentReleaseBinary(root, outputPath, tt.kind, runtime.GOOS, runtime.GOARCH, "")
+			if err != nil {
+				t.Fatalf("BuildSourceComponentReleaseBinary(%q): %v", tt.kind, err)
+			}
+
+			data, err := os.ReadFile(outputPath)
+			if err != nil {
+				t.Fatalf("ReadFile(%q): %v", outputPath, err)
+			}
+			if !containsString(string(data), "fake ts release binary") {
+				t.Fatalf("binary contents = %q, want fake build marker", string(data))
+			}
+
+			wantLibC := ""
+			if runtime.GOOS == "linux" {
+				wantLibC = CurrentRuntimeLibC()
+			}
+			if libc != wantLibC {
+				t.Fatalf("libc = %q, want %q", libc, wantLibC)
+			}
+		})
+	}
+}
+
+func mustWriteTypeScriptProviderPackage(t *testing.T, root, target string) {
+	t.Helper()
+
+	mustWriteTypeScriptPackageConfig(t, root, map[string]string{
+		typeScriptProviderKey: target,
+	})
+	mustWriteTypeScriptTargetModule(t, root, target)
+}
+
+func mustWriteTypeScriptComponentPackage(t *testing.T, root, kind, target string) {
+	t.Helper()
+
+	providerKind, err := typeScriptComponentKind(kind)
+	if err != nil {
+		t.Fatalf("typeScriptComponentKind(%q): %v", kind, err)
+	}
+	mustWriteTypeScriptPackageConfig(t, root, map[string]string{
+		typeScriptProviderKey: providerKind + ":" + runtimeTargetModulePath(t, target),
+	})
+	mustWriteTypeScriptTargetModule(t, root, target)
+}
+
+func mustWriteTypeScriptPackageConfig(t *testing.T, root string, gestalt map[string]string) {
+	t.Helper()
+
+	var fields []string
+	for _, key := range []string{typeScriptProviderKey, typeScriptPluginKey, typeScriptAuthKey, typeScriptDatastoreKey} {
+		value, ok := gestalt[key]
+		if !ok {
+			continue
+		}
+		fields = append(fields, fmt.Sprintf("    %q: %q", key, value))
+	}
+	mustWriteFile(t, filepath.Join(root, typeScriptProjectFile), []byte(fmt.Sprintf(`{
+  "name": "ts-release",
+  "version": "0.0.1",
+  "gestalt": {
+%s
+  }
+}
+`, strings.Join(fields, ",\n"))), 0o644)
+}
+
+func mustWriteTypeScriptTargetModule(t *testing.T, root, target string) {
+	t.Helper()
+
+	modulePath, exportName, err := SplitTypeScriptProviderTarget(runtimeTargetModulePath(t, target))
+	if err != nil {
+		t.Fatalf("SplitTypeScriptProviderTarget(%q): %v", target, err)
+	}
+	modulePath = strings.TrimPrefix(filepath.ToSlash(modulePath), "./")
+	if exportName == "" {
+		exportName = "plugin"
+	}
+	mustWriteFile(t, filepath.Join(root, filepath.FromSlash(modulePath)), []byte("export const "+exportName+" = {};\n"), 0o644)
+}
+
+func runtimeTargetModulePath(t *testing.T, target string) string {
+	t.Helper()
+	for _, prefix := range []string{"plugin:", "integration:", "auth:", "datastore:", "secrets:", "telemetry:"} {
+		if strings.HasPrefix(target, prefix) {
+			return strings.TrimPrefix(target, prefix)
+		}
+	}
+	return target
+}
+
+func mustWriteTypeScriptSourceManifest(t *testing.T, root, pluginName string) string {
+	t.Helper()
+
+	data, err := EncodeSourceManifestFormat(&pluginmanifestv1.Manifest{
+		Source:  "github.com/testowner/plugins/" + pluginName,
+		Version: "0.0.1",
+		Kinds:   []string{pluginmanifestv1.KindPlugin},
+		Plugin: &pluginmanifestv1.Plugin{
+			Auth: &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeNone},
+		},
+	}, ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat: %v", err)
+	}
+
+	path := filepath.Join(root, "plugin.yaml")
+	mustWriteFile(t, path, data, 0o644)
+	return path
+}
+
+func mustWriteTypeScriptSourceComponentManifest(t *testing.T, root, pluginName, kind string) string {
+	t.Helper()
+
+	manifest := &pluginmanifestv1.Manifest{
+		Source:  "github.com/testowner/plugins/" + pluginName,
+		Version: "0.0.1",
+		Kinds:   []string{kind},
+	}
+	switch kind {
+	case pluginmanifestv1.KindAuth:
+		manifest.Auth = &pluginmanifestv1.AuthMetadata{}
+	case pluginmanifestv1.KindDatastore:
+		manifest.Datastore = &pluginmanifestv1.DatastoreMetadata{}
+	default:
+		t.Fatalf("unsupported component kind %q", kind)
+	}
+
+	data, err := EncodeSourceManifestFormat(manifest, ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat: %v", err)
+	}
+
+	path := filepath.Join(root, "plugin.yaml")
+	mustWriteFile(t, path, data, 0o644)
+	return path
+}
+
+func writeFakeTypeScriptBun(t *testing.T, root, pluginName, expectedTarget, expectedGOOS, expectedGOARCH string) string {
+	t.Helper()
+
+	path := filepath.Join(root, "bin", "bun")
+	script := `#!/bin/sh
+set -eu
+
+if [ "$#" -lt 4 ] || [ "$1" != "--cwd" ]; then
+  echo "unexpected fake bun args: $*" >&2
+  exit 1
+fi
+
+cwd="$2"
+shift 2
+
+if [ "$1" != "run" ]; then
+  echo "unexpected bun subcommand: $1" >&2
+  exit 1
+fi
+shift
+
+entry="$1"
+shift
+
+if [ "$#" -gt 0 ] && [ "$1" = "--" ]; then
+  shift
+fi
+
+entry_base="${entry##*/}"
+
+case "$entry_base" in
+  gestalt-ts-runtime|runtime.ts)
+    if [ "$#" -ne 2 ]; then
+      echo "unexpected runtime args: $*" >&2
+      exit 1
+    fi
+    root="$1"
+    target="$2"
+    if [ "$cwd" != "$root" ]; then
+      echo "unexpected runtime cwd: $cwd != $root" >&2
+      exit 1
+    fi
+    if [ "$target" != "` + expectedTarget + `" ]; then
+      echo "unexpected runtime target: $target" >&2
+      exit 1
+    fi
+    if [ -z "${GESTALT_PLUGIN_WRITE_CATALOG:-}" ]; then
+      echo "missing GESTALT_PLUGIN_WRITE_CATALOG" >&2
+      exit 1
+    fi
+    cat > "$GESTALT_PLUGIN_WRITE_CATALOG" <<'EOF'
+name: ` + pluginName + `
+operations:
+  - id: greet
+    method: GET
+EOF
+    exit 0
+    ;;
+  gestalt-ts-build|build.ts)
+    if [ "$#" -ne 6 ]; then
+      echo "unexpected build args: $*" >&2
+      exit 1
+    fi
+    source_dir="$1"
+    target="$2"
+    output="$3"
+    name="$4"
+    goos="$5"
+    goarch="$6"
+    if [ "$cwd" != "$source_dir" ]; then
+      echo "unexpected build cwd: $cwd != $source_dir" >&2
+      exit 1
+    fi
+    if [ "$target" != "` + expectedTarget + `" ]; then
+      echo "unexpected build target: $target" >&2
+      exit 1
+    fi
+    if [ "$name" != "` + pluginName + `" ]; then
+      echo "unexpected plugin name: $name" >&2
+      exit 1
+    fi
+    if [ "$goos" != "` + expectedGOOS + `" ] || [ "$goarch" != "` + expectedGOARCH + `" ]; then
+      echo "unexpected target platform: $goos/$goarch" >&2
+      exit 1
+    fi
+    output_dir="${output%/*}"
+    if [ "$output_dir" = "$output" ]; then
+      output_dir="."
+    fi
+    mkdir -p "$output_dir"
+    printf '#!/bin/sh\n# fake ts release binary\nexit 0\n' > "$output"
+    chmod +x "$output"
+    exit 0
+    ;;
+esac
+
+echo "unexpected fake bun entry: $entry ($*)" >&2
+exit 1
+`
+	mustWriteFile(t, path, []byte(script), 0o755)
+	return path
+}


### PR DESCRIPTION
## Summary
- extend `gestaltd` TypeScript source support from plugin-only detection to generic provider detection
- execute and build Bun-backed TypeScript plugin, auth, and datastore providers through the source-plugin flow
- add host-side tests for source detection, runtime execution, and release packaging across all supported TypeScript provider kinds

## Interface Changes
`gestaltd` now recognizes TypeScript source packages from `package.json` through the generic `gestalt.provider` interface:

```json
{
  "name": "my-plugin",
  "gestalt": {
    "provider": "plugin:./provider.ts#plugin"
  }
}
```

```json
{
  "name": "my-auth",
  "gestalt": {
    "provider": {
      "kind": "auth",
      "target": "./auth.ts#provider"
    }
  }
}
```

```json
{
  "name": "my-datastore",
  "gestalt": {
    "provider": {
      "kind": "datastore",
      "target": "./datastore.ts#provider"
    }
  }
}
```

The host now routes those packages through the TypeScript SDK runtime/build entrypoints. In practice it runs the equivalent of:

```sh
bun --cwd /path/to/provider run .../sdk/typescript/src/runtime.ts -- /path/to/provider plugin:./provider.ts#plugin
bun --cwd /path/to/provider run .../sdk/typescript/src/build.ts -- /path/to/provider auth:./auth.ts#provider /tmp/provider my-auth linux amd64
```

## Example Usage
After this PR, TypeScript source packages can use the same release entrypoint as other source providers:

```sh
gestaltd plugin release --version 0.0.1-alpha.1
```

The same detection path now supports local source execution for auth and datastore providers as well as plugin providers.

## Newly Supported Behavior
- Detecting TypeScript source packages for plugin, auth, and datastore kinds from `package.json`.
- Running TypeScript auth and datastore providers directly from source during local execution.
- Building and packaging TypeScript auth and datastore providers through the same release flow as source plugin providers.
- Normalizing `plugin` and `integration` target prefixes onto the same runtime target semantics.
- Returning libc metadata for TypeScript auth/datastore release builds on Linux.

## Not Supported
- Building multiple executable kinds from the same source package in one `plugin release` invocation.
- TypeScript source execution for secrets or telemetry provider kinds.
- Provider targets that escape the package root or use unsupported file extensions.
- Removing legacy `gestalt.plugin`, `gestalt.auth`, or `gestalt.datastore` config paths.

## Validation
- `cd gestaltd && go test ./internal/pluginpkg`
- `cd gestaltd && go test ./cmd/gestaltd -run 'TestRun_PluginReleaseHelpExitsCleanly|PluginRelease|Plugin_Help'`
