### PR TITLE
Document the TypeScript provider SDK and CI workflows

### DIFF
--- a/.github/workflows/build-typescript-sdk.yml
+++ b/.github/workflows/build-typescript-sdk.yml
@@ -1,0 +1,39 @@
+name: Build TypeScript SDK
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'sdk/typescript/**'
+      - 'sdk/proto/**'
+      - '.github/workflows/build-typescript-sdk.yml'
+  pull_request:
+    paths:
+      - 'sdk/typescript/**'
+      - 'sdk/proto/**'
+      - '.github/workflows/build-typescript-sdk.yml'
+
+  workflow_dispatch:
+
+jobs:
+  typescript-sdk:
+    name: TypeScript SDK Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: sdk/typescript
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run SDK checks
+        run: bun run check

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -6,6 +6,7 @@ on:
       - 'sdk/go/v*'
       - 'sdk/python/v*'
       - 'sdk/rust/v*'
+      - 'sdk/typescript/v*'
 
 permissions:
   contents: write
@@ -170,3 +171,94 @@ jobs:
           fi
 
           uv publish --publish-url "${GESTALT_PYTHON_PUBLISH_URL}"
+
+  publish-typescript-sdk:
+    if: ${{ startsWith(github.ref_name, 'sdk/typescript/v') }}
+    name: Publish TypeScript SDK
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: sdk/typescript
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Normalize package version from tag
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path("package.json")
+          data = json.loads(path.read_text())
+          data["version"] = os.environ["VERSION"].removeprefix("sdk/typescript/v")
+          path.write_text(json.dumps(data, indent=2) + "\n")
+          PY
+
+      - name: Run SDK checks
+        run: bun run check
+
+      - name: Configure registry auth
+        env:
+          GESTALT_TYPESCRIPT_PUBLISH_URL: ${{ secrets.GESTALT_TYPESCRIPT_PUBLISH_URL }}
+          GESTALT_TYPESCRIPT_PUBLISH_TOKEN: ${{ secrets.GESTALT_TYPESCRIPT_PUBLISH_TOKEN }}
+          GESTALT_TYPESCRIPT_PUBLISH_USERNAME: ${{ secrets.GESTALT_TYPESCRIPT_PUBLISH_USERNAME }}
+          GESTALT_TYPESCRIPT_PUBLISH_PASSWORD: ${{ secrets.GESTALT_TYPESCRIPT_PUBLISH_PASSWORD }}
+        run: |
+          if [ -z "${GESTALT_TYPESCRIPT_PUBLISH_URL}" ]; then
+            echo "GESTALT_TYPESCRIPT_PUBLISH_URL must be configured" >&2
+            exit 1
+          fi
+
+          if [ -z "${GESTALT_TYPESCRIPT_PUBLISH_TOKEN}" ] && { [ -z "${GESTALT_TYPESCRIPT_PUBLISH_USERNAME}" ] || [ -z "${GESTALT_TYPESCRIPT_PUBLISH_PASSWORD}" ]; }; then
+            echo "configure GESTALT_TYPESCRIPT_PUBLISH_TOKEN or GESTALT_TYPESCRIPT_PUBLISH_USERNAME and GESTALT_TYPESCRIPT_PUBLISH_PASSWORD" >&2
+            exit 1
+          fi
+
+          registry_host="$(python3 - <<'PY'
+          import os
+          from urllib.parse import urlparse
+
+          url = urlparse(os.environ["GESTALT_TYPESCRIPT_PUBLISH_URL"])
+          path = url.path or "/"
+          if not path.endswith("/"):
+            path += "/"
+          print(f"//{url.netloc}{path}")
+          PY
+          )"
+
+          userconfig="$RUNNER_TEMP/.npmrc"
+          {
+            printf "registry=%s\n" "$GESTALT_TYPESCRIPT_PUBLISH_URL"
+            printf "always-auth=true\n"
+            if [ -n "${GESTALT_TYPESCRIPT_PUBLISH_TOKEN}" ]; then
+              printf "%s:_authToken=%s\n" "$registry_host" "$GESTALT_TYPESCRIPT_PUBLISH_TOKEN"
+            else
+              password_b64="$(printf '%s' "$GESTALT_TYPESCRIPT_PUBLISH_PASSWORD" | base64 | tr -d '\n')"
+              printf "%s:username=%s\n" "$registry_host" "$GESTALT_TYPESCRIPT_PUBLISH_USERNAME"
+              printf "%s:_password=%s\n" "$registry_host" "$password_b64"
+              printf "%s:email=%s\n" "$registry_host" "gestalt-ci@valon.com"
+            fi
+          } > "$userconfig"
+
+          echo "NPM_CONFIG_USERCONFIG=$userconfig" >> "$GITHUB_ENV"
+
+      - name: Dry-run publish
+        env:
+          GESTALT_TYPESCRIPT_PUBLISH_URL: ${{ secrets.GESTALT_TYPESCRIPT_PUBLISH_URL }}
+        run: bun publish --dry-run --registry "${GESTALT_TYPESCRIPT_PUBLISH_URL}"
+
+      - name: Publish package
+        env:
+          GESTALT_TYPESCRIPT_PUBLISH_URL: ${{ secrets.GESTALT_TYPESCRIPT_PUBLISH_URL }}
+        run: bun publish --registry "${GESTALT_TYPESCRIPT_PUBLISH_URL}"

--- a/docs/content/plugins/index.mdx
+++ b/docs/content/plugins/index.mdx
@@ -29,7 +29,13 @@ Plugins run in process isolation. They cannot access the host process memory, ot
 
 ## SDK support
 
-Gestalt ships SDKs for Go (`sdk/go`), Python (`sdk/python`), and Rust (`sdk/rust`). The underlying protocol is gRPC, so other languages are possible, but the documented authoring flow uses those three.
+Gestalt ships first-party SDKs for Go (`sdk/go`), Python (`sdk/python`),
+Rust (`sdk/rust`), and TypeScript (`sdk/typescript`). The underlying protocol
+is gRPC, so other languages are still possible, but the documented authoring
+flow is centered on those SDKs.
+
+Go, Rust, and TypeScript support plugin, auth, and datastore providers.
+Python remains focused on plugin providers.
 
 ## Common pitfalls
 

--- a/docs/content/plugins/releasing.mdx
+++ b/docs/content/plugins/releasing.mdx
@@ -29,10 +29,11 @@ provider:
 ```
 
 Executable source packages stay language-native. Gestalt loads the provider
-from the package root, then synthesizes the runnable wrapper during local
-source execution and release packaging.
+from the package root or the language-specific target declaration, then
+synthesizes the runnable wrapper during local source execution and release
+packaging.
 
-<Tabs items={['Go', 'Python', 'Rust']}>
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```text
     my-plugin/
@@ -88,6 +89,30 @@ source execution and release packaging.
     serde = { version = "1", features = ["derive"] }
     serde_json = "1"
     ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```text
+    my-plugin/
+      package.json
+      plugin.yaml
+      provider.ts
+    ```
+
+    ```json
+    {
+      "name": "my-plugin",
+      "version": "0.0.1-alpha.1",
+      "dependencies": {
+        "@valon-technologies/gestalt": "0.0.1-alpha.1"
+      },
+      "gestalt": {
+        "provider": "./provider.ts#plugin"
+      }
+    }
+    ```
+
+    TypeScript auth and datastore providers use `gestalt.provider` objects
+    such as `{ "kind": "auth", "target": "./auth.ts#auth" }`.
   </Tabs.Tab>
 </Tabs>
 
@@ -158,18 +183,23 @@ Run this from the provider source directory. It produces release archives and wr
 
 Release tags are derived from the package path after the repository. For example, `source: github.com/acme/plugins/catalog/support-api` releases from the tag `plugins/catalog/support-api/v0.1.0`.
 
-For executable Go, Rust, and Python integration source plugins, `provider release`
-materializes the executable catalog automatically and builds the host-platform
-artifact by default. Go and Rust auth/datastore source packages use the same
-release flow without catalog generation. Pass `--platform` with a
-comma-separated list such as
-`--platform linux/amd64/glibc,linux/amd64/musl,darwin/arm64` to build explicit
-targets. Pass `--platform all` in CI release jobs to build the full supported
-platform matrix for source builds.
+For executable Go, Rust, Python, and TypeScript source providers,
+`provider release` materializes the executable catalog automatically and builds
+the host-platform artifact by default. Go, Rust, and TypeScript auth/datastore
+source packages use the same release flow without catalog generation. Pass
+`--platform` with a comma-separated list such as
+`--platform linux/amd64,darwin/arm64` to build explicit targets, or
+`--platform linux/amd64/glibc,linux/amd64/musl,darwin/arm64` when you need
+Linux libc variants. Pass `--platform all` in CI release jobs to build the
+full supported platform matrix for source builds.
 
 For non-host Python targets, point Gestalt at a matching interpreter with
 `GESTALT_PYTHON_<GOOS>_<GOARCH>` or a target-specific virtualenv such as
 `.venv-<goos>-<goarch>/`.
+
+TypeScript source plugins require Bun for local source execution and
+packaging. The SDK uses Bun's compile flow to build standalone provider
+binaries during release.
 
 ## Reference releases from config
 

--- a/docs/content/plugins/writing-a-plugin.mdx
+++ b/docs/content/plugins/writing-a-plugin.mdx
@@ -10,7 +10,7 @@ The host still owns auth, token storage, connection selection, and HTTP or MCP r
 
 ## Prerequisites
 
-<Tabs items={['Go', 'Python', 'Rust']}>
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     You need Go 1.26+ and a running `gestaltd` instance for testing.
   </Tabs.Tab>
@@ -20,11 +20,14 @@ The host still owns auth, token storage, connection selection, and HTTP or MCP r
   <Tabs.Tab>
     You need the current stable Rust toolchain, Cargo, and a running `gestaltd` instance for testing.
   </Tabs.Tab>
+  <Tabs.Tab>
+    You need Bun 1.3+ and a running `gestaltd` instance for testing.
+  </Tabs.Tab>
 </Tabs>
 
 ## Create the project
 
-<Tabs items={['Go', 'Python', 'Rust']}>
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```sh
     mkdir my-plugin && cd my-plugin
@@ -103,6 +106,57 @@ The host still owns auth, token storage, connection selection, and HTTP or MCP r
 
     Use the `sdk/rust/v*` tag that matches the SDK release you want to target.
   </Tabs.Tab>
+  <Tabs.Tab>
+    ```sh
+    mkdir my-plugin && cd my-plugin
+    bun init -y
+    bun add @valon-technologies/gestalt
+    ```
+
+    Recommended layout:
+
+    ```text
+    my-plugin/
+      package.json
+      plugin.yaml
+      provider.ts
+    ```
+
+    Point `package.json` at the source file Gestalt should load:
+
+    ```json
+    {
+      "name": "my-plugin",
+      "version": "0.0.1-alpha.1",
+      "private": true,
+      "type": "module",
+      "dependencies": {
+        "@valon-technologies/gestalt": "0.0.1-alpha.1"
+      },
+      "gestalt": {
+        "provider": "./provider.ts#plugin"
+      }
+    }
+    ```
+
+    A string `gestalt.provider` target defaults to a plugin provider. For auth
+    or datastore providers, use an object with an explicit kind:
+
+    ```json
+    {
+      "gestalt": {
+        "provider": {
+          "kind": "auth",
+          "target": "./auth.ts#provider"
+        }
+      }
+    }
+    ```
+
+    Use `"plugin"` when you need to spell the plugin kind explicitly. The
+    legacy `integration` spelling and the older `gestalt.plugin` shorthand are
+    still accepted.
+  </Tabs.Tab>
 </Tabs>
 
 ## Write the plugin manifest
@@ -150,7 +204,9 @@ The manifest stays the source of truth for display name, description, auth, the 
 
 ## Define operations
 
-<Tabs items={['Go', 'Python', 'Rust']}>
+Rust examples below show the intended shape of the first SDK release. Exact helper names may change slightly as the Rust API is finalized.
+
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
     package provider
@@ -318,6 +374,38 @@ The manifest stays the source of truth for display name, description, auth, the 
     gestalt::export_provider!(constructor = new, router = router);
     ```
   </Tabs.Tab>
+  <Tabs.Tab>
+    ```ts
+    import { Request, definePlugin, ok, operation, s } from "@valon-technologies/gestalt";
+
+    let greeting = "Hello";
+
+    export const plugin = definePlugin({
+      async configure(_name, config) {
+        greeting = typeof config.greeting === "string" ? config.greeting : "Hello";
+      },
+      operations: [
+        operation({
+          id: "greet",
+          method: "GET",
+          description: "Return a greeting message",
+          readOnly: true,
+          input: s.object({
+            name: s.string({ description: "Name to greet", default: "World" }),
+          }),
+          async handler(input: { name: string }, _req: Request) {
+            return ok({ message: `${greeting}, ${input.name}!` });
+          },
+        }),
+      ],
+    });
+    ```
+
+    The `package.json` field `gestalt.provider` points Gestalt at the provider
+    module and optional export. Use a string target such as
+    `./provider.ts#plugin` for plugin providers, or an object with `kind` and
+    `target` for auth and datastore providers.
+  </Tabs.Tab>
 </Tabs>
 
 You do not write an entrypoint. Gestalt synthesizes the executable wrapper automatically for local source execution and release. Rust auth and datastore packages follow the same model with `gestalt::export_auth_provider!(constructor = new);` and `gestalt::export_datastore_provider!(constructor = new);`.
@@ -328,7 +416,7 @@ By default, input decode failures return a structured `400` response, and unhand
 
 The router derives catalog parameters from the input type. Fields are required by default unless marked optional. Nested types are emitted as `object` parameters and collections as `array`.
 
-<Tabs items={['Go', 'Python', 'Rust']}>
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
     type SearchInput struct {
@@ -370,13 +458,28 @@ The router derives catalog parameters from the input type. Fields are required b
 
     Fields are required unless you model them as `Option<T>` or provide a serde default. Use `schemars(description = "...")` for catalog descriptions and serde defaults for scalar defaults.
   </Tabs.Tab>
+  <Tabs.Tab>
+    ```ts
+    const SearchInput = s.object({
+      query: s.string({ description: "Search query" }),
+      max_items: s.integer({ description: "Maximum results", default: 10 }),
+      filters: s.optional(
+        s.object({}, { description: "Optional filter set" }),
+      ),
+    });
+    ```
+
+    TypeScript plugins describe runtime input schemas explicitly. Requiredness,
+    descriptions, defaults, nested objects, and arrays come from that schema
+    definition rather than from erased TypeScript types.
+  </Tabs.Tab>
 </Tabs>
 
 ## Dynamic catalogs
 
 By default, the operation catalog is static and materialized at startup. If your plugin needs to expose different operations depending on the caller's credentials or runtime state, implement a session catalog.
 
-<Tabs items={['Go', 'Python', 'Rust']}>
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     Implement the `SessionCatalogProvider` interface on your provider:
 
@@ -449,6 +552,27 @@ By default, the operation catalog is static and materialized at startup. If your
     }
     ```
   </Tabs.Tab>
+  <Tabs.Tab>
+    Return a per-request catalog from the plugin definition:
+
+    ```ts
+    export const plugin = definePlugin({
+      async sessionCatalog(request) {
+        return {
+          name: "my-plugin-session",
+          displayName: request.token,
+          operations: [
+            {
+              id: "search_private",
+              method: "POST",
+              readOnly: true,
+            },
+          ],
+        };
+      },
+    });
+    ```
+  </Tabs.Tab>
 </Tabs>
 
 ## Test locally
@@ -484,11 +608,81 @@ gestalt invoke my-plugin greet -p name=Gestalt
 gestaltd provider release --version 0.0.1-alpha.1
 ```
 
-Gestalt materializes the executable catalog automatically during release. Go, Python, and Rust source plugins build the host-platform artifact by default. Pass `--platform` with a comma-separated target list to build explicit platforms, or `--platform all` in CI to build the full supported release matrix.
+Gestalt materializes the executable catalog automatically during release. Go,
+Python, Rust, and TypeScript source plugins build the host-platform artifact
+by default. Pass `--platform` with a comma-separated target list to build
+explicit platforms, or `--platform all` in CI to build the full supported
+release matrix.
 
 For non-host Python targets, point Gestalt at a matching interpreter with `GESTALT_PYTHON_<GOOS>_<GOARCH>` or a target-specific virtualenv such as `.venv-<goos>-<goarch>/`.
 
+TypeScript source plugins require Bun for both local source execution and
+release packaging. Bun handles the platform targeting directly, so there is no
+interpreter matrix equivalent to the Python flow.
+
 See [Plugin Manifests](/reference/plugin-manifests) for the manifest schema and [Releasing](/plugins/releasing) for the release archive workflow.
+
+## TypeScript auth and datastore providers
+
+TypeScript auth and datastore providers use the same runtime packaging flow as
+integration plugins, but they expose different SDK surfaces and do not define
+operation catalogs.
+
+```ts
+import { defineAuthProvider } from "@valon-technologies/gestalt";
+
+export const provider = defineAuthProvider({
+  async beginLogin(request) {
+    return {
+      authorizationUrl: `https://idp.example.test/authorize?state=${request.hostState}`,
+    };
+  },
+  async completeLogin() {
+    return {
+      subject: "user-1",
+      email: "user@example.com",
+    };
+  },
+});
+```
+
+```ts
+import { defineDatastoreProvider } from "@valon-technologies/gestalt";
+
+const users = new Map<string, { id: string; email: string }>();
+
+export const provider = defineDatastoreProvider({
+  async healthCheck() {},
+  async migrate() {},
+  async getUser(id) {
+    return users.get(id) ?? null;
+  },
+  async findOrCreateUser(email) {
+    const user = users.get(email) ?? { id: email, email };
+    users.set(email, user);
+    return user;
+  },
+  async putIntegrationToken() {},
+  async getIntegrationToken() {
+    return null;
+  },
+  async listIntegrationTokens() {
+    return [];
+  },
+  async deleteIntegrationToken() {},
+  async putApiToken() {},
+  async getApiTokenByHash() {
+    return null;
+  },
+  async listApiTokens() {
+    return [];
+  },
+  async revokeApiToken() {},
+  async revokeAllApiTokens() {
+    return 0;
+  },
+});
+```
 
 ## Hybrid providers
 

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -478,7 +478,12 @@ Manifest paths must stay inside the package. `source` and `version` are required
 
 A connection using `mcp_oauth` auth requires the plugin to declare an MCP surface (via `mcp_url` or an equivalent). Manifests that set `auth.type: mcp_oauth` without an MCP surface fail validation.
 
-When an executable plugin defines helper operations in Go, Rust, or Python, Gestalt materializes the executable catalog automatically during local source-plugin execution and `provider release`. Auth and datastore source packages use the same release flow for Go and Rust, but they do not generate catalogs. See [Writing a Plugin](/plugins/writing-a-plugin) for the end-to-end authoring flow.
+When an executable plugin defines helper operations in Go, Rust, Python, or
+TypeScript, Gestalt materializes the executable catalog automatically during
+local source-plugin execution and `provider release`. Auth and datastore
+source packages use the same release flow for Go, Rust, and TypeScript, but
+they do not generate catalogs. See [Writing a Plugin](/plugins/writing-a-plugin)
+for the end-to-end authoring flow.
 
 <Tabs items={['Go', 'Python', 'Rust']}>
   <Tabs.Tab>
@@ -544,4 +549,18 @@ Build a release from a provider source directory:
 gestaltd provider release --version 1.2.3
 ```
 
-`gestaltd provider release` preserves the source manifest format, so `plugin.yaml` stays YAML and `plugin.json` stays JSON in the release archive. For executable Go, Rust, and Python integration plugins, release materializes the executable catalog automatically before packaging. Python source plugins load the module declared in `[tool.gestalt].plugin`, while Go and Rust source plugins synthesize the executable wrapper from the source package itself. Auth and datastore source packages support the same release flow for Go and Rust, but they do not generate catalogs. Source packages build the host-platform artifact by default. Pass `--platform` for an explicit `os/arch[/libc]` target list, or `--platform all` in CI to build the full supported release matrix.
+`gestaltd provider release` preserves the source manifest format, so
+`plugin.yaml` stays YAML and `plugin.json` stays JSON in the release archive.
+For executable Go and Rust plugins, release materializes the executable
+catalog automatically before packaging. Python source plugins load the module
+declared in `[tool.gestalt].plugin` and materialize the executable catalog
+automatically. TypeScript source providers load the target declared in
+`package.json` under `gestalt.provider`. A string target such as
+`./provider.ts#plugin` defaults to a plugin provider; auth and datastore
+providers use an object with `kind` and `target`. Use `"plugin"` as the
+explicit plugin kind when needed. The legacy `integration` spelling and the
+older `gestalt.plugin` shorthand are still accepted. Auth and datastore source
+packages support the same release flow for Go, Rust, and TypeScript, but they
+do not generate catalogs. Source packages build the host-platform artifact by
+default. Pass `--platform` for an explicit `os/arch[/libc]` target list, or
+`--platform all` in CI to build the full supported release matrix.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -20,7 +20,7 @@ property in `package.json`:
   },
   "gestalt": {
     "provider": {
-      "kind": "plugin",
+      "kind": "integration",
       "target": "./provider.ts#provider"
     }
   }
@@ -31,28 +31,25 @@ The target is a relative file path with an optional export suffix. The runtime
 accepts:
 
 - `gestalt.provider` as `{ "kind": "...", "target": "./file.ts#export" }`
-- `gestalt.provider` as a string like `"plugin:./provider.ts#provider"` or `"auth:./auth.ts#provider"`
+- `gestalt.provider` as a string like `"auth:./auth.ts#provider"`
 - legacy integration-only `gestalt.plugin`
-
-Use `"plugin"` as the kind token for executable plugins. The older
-`"integration"` spelling is still accepted for compatibility.
 
 If the export suffix is omitted, the runtime looks for `provider`, then
 `plugin`, then the default export.
 
 ## Authoring
 
-Use explicit runtime schemas to define plugin operation inputs and outputs:
+Use explicit runtime schemas to define integration operation inputs and outputs:
 
 ```ts
 import {
-  definePlugin,
+  defineIntegrationProvider,
   ok,
   operation,
   s,
 } from "@valon-technologies/gestalt";
 
-export const plugin = definePlugin({
+export const provider = defineIntegrationProvider({
   displayName: "Example Provider",
   description: "A provider implemented with the Gestalt TypeScript SDK",
   configure(name, config) {
@@ -102,7 +99,7 @@ import { defineAuthProvider, defineDatastoreProvider } from "@valon-technologies
 Source-mode runtime:
 
 ```sh
-gestalt-ts-runtime ROOT plugin:./provider.ts#provider
+gestalt-ts-runtime ROOT integration:./provider.ts#provider
 ```
 
 Release build:

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -137,7 +137,7 @@ export async function loadProviderFromTarget(
   switch (target.kind) {
     case "integration": {
       if (!isIntegrationProvider(candidate)) {
-        throw new Error(`${targetValue} did not resolve to a Gestalt plugin provider`);
+        throw new Error(`${targetValue} did not resolve to a Gestalt integration provider`);
       }
       candidate.resolveName(defaultName);
       return candidate;
@@ -167,7 +167,7 @@ export async function loadPluginFromTarget(
 ): Promise<IntegrationProvider> {
   const provider = await loadProviderFromTarget(root, rawTarget);
   if (!isIntegrationProvider(provider)) {
-    throw new Error("target did not resolve to a plugin provider");
+    throw new Error("target did not resolve to an integration provider");
   }
   return provider;
 }
@@ -188,7 +188,7 @@ export async function runLoadedProvider(
   const catalogPath = process.env[ENV_WRITE_CATALOG];
   if (catalogPath) {
     if (!isIntegrationProvider(provider)) {
-      throw new Error("static catalog generation is only supported for plugin providers");
+      throw new Error("static catalog generation is only supported for integration providers");
     }
     writeFileSync(catalogPath, pluginCatalogYaml(provider), "utf8");
     return;
@@ -226,7 +226,7 @@ export async function runBundledProvider(
   switch (kind) {
     case "integration":
       if (!isIntegrationProvider(provider)) {
-        throw new Error("bundled target did not resolve to a Gestalt plugin provider");
+        throw new Error("bundled target did not resolve to a Gestalt integration provider");
       }
       loaded = provider;
       break;

--- a/sdk/typescript/src/target.ts
+++ b/sdk/typescript/src/target.ts
@@ -25,8 +25,7 @@ type PackageProviderConfig =
       target?: string;
     };
 
-const EXTERNAL_PROVIDER_KIND_TOKENS = new Set<string>([
-  "plugin",
+const KNOWN_PROVIDER_KINDS = new Set<ProviderKind>([
   "integration",
   "auth",
   "datastore",
@@ -121,7 +120,7 @@ export function readPackageProviderTarget(root: string): ProviderTarget {
 export function readPackagePluginTarget(root: string): string {
   const target = readPackageProviderTarget(root);
   if (target.kind !== "integration") {
-    throw new Error(`package.json provider kind ${JSON.stringify(target.kind)} is not a plugin provider`);
+    throw new Error(`package.json provider kind ${JSON.stringify(target.kind)} is not an integration provider`);
   }
   return formatModuleTarget(target);
 }
@@ -150,7 +149,7 @@ export function resolveProviderImportUrl(root: string, target: ProviderTarget | 
 export const resolvePluginImportUrl = resolveProviderImportUrl;
 
 export function formatProviderTarget(target: ProviderTarget): string {
-  return `${formatProviderKind(target.kind)}:${formatModuleTarget(target)}`;
+  return `${target.kind}:${formatModuleTarget(target)}`;
 }
 
 export function formatModuleTarget(target: ModuleTarget): string {
@@ -158,7 +157,7 @@ export function formatModuleTarget(target: ModuleTarget): string {
 }
 
 function parseKindPrefixedTarget(target: string): ProviderTarget | undefined {
-  const match = target.match(/^(plugin|integration|auth|datastore|secrets|telemetry):(.*)$/);
+  const match = target.match(/^(integration|auth|datastore|secrets|telemetry):(.*)$/);
   if (!match) {
     return undefined;
   }
@@ -169,21 +168,11 @@ function parseKindPrefixedTarget(target: string): ProviderTarget | undefined {
 }
 
 function parseProviderKind(value: string): ProviderKind {
-  const normalized = value.trim().toLowerCase();
-  if (!EXTERNAL_PROVIDER_KIND_TOKENS.has(normalized)) {
+  const normalized = value.trim().toLowerCase() as ProviderKind;
+  if (!KNOWN_PROVIDER_KINDS.has(normalized)) {
     throw new Error(`unsupported provider kind ${JSON.stringify(value)}`);
   }
-  if (normalized === "plugin") {
-    return "integration";
-  }
-  return normalized as ProviderKind;
-}
-
-function formatProviderKind(kind: ProviderKind): string {
-  if (kind === "integration") {
-    return "plugin";
-  }
-  return kind;
+  return normalized;
 }
 
 function isProviderConfigObject(value: unknown): value is { kind?: string; target?: string } {

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -38,9 +38,9 @@ import { defineDatastoreProvider } from "../src/index.ts";
 import { fixturePath, makeTempDir, removeTempDir } from "./helpers.ts";
 
 test("runtime arg parsing requires root and target", () => {
-  expect(parseRuntimeArgs(["root", "plugin:./provider.ts#plugin"])).toEqual({
+  expect(parseRuntimeArgs(["root", "integration:./provider.ts#plugin"])).toEqual({
     root: "root",
-    target: "plugin:./provider.ts#plugin",
+    target: "integration:./provider.ts#plugin",
   });
   expect(parseRuntimeArgs(["root"])).toBeUndefined();
 });
@@ -53,7 +53,7 @@ test("runtime main writes a static catalog in catalog mode", async () => {
 
   process.env[ENV_WRITE_CATALOG] = catalogPath;
   try {
-    const code = await main([root, "plugin:./provider.ts#plugin"]);
+    const code = await main([root, "integration:./provider.ts#plugin"]);
     expect(code).toBe(0);
     const catalog = readFileSync(catalogPath, "utf8");
     expect(catalog).toContain("name: basic-provider");

--- a/sdk/typescript/tests/target.test.ts
+++ b/sdk/typescript/tests/target.test.ts
@@ -29,18 +29,8 @@ test("module target parsing validates relative module paths", () => {
   );
 });
 
-test("provider target parsing supports plugin defaults and kind prefixes", () => {
+test("provider target parsing supports integration defaults and kind prefixes", () => {
   expect(parseProviderTarget("./provider.ts#plugin")).toEqual({
-    kind: "integration",
-    modulePath: "./provider.ts",
-    exportName: "plugin",
-  });
-  expect(parseProviderTarget("plugin:./provider.ts#plugin")).toEqual({
-    kind: "integration",
-    modulePath: "./provider.ts",
-    exportName: "plugin",
-  });
-  expect(parseProviderTarget("integration:./provider.ts#plugin")).toEqual({
     kind: "integration",
     modulePath: "./provider.ts",
     exportName: "plugin",
@@ -62,9 +52,6 @@ test("package config reads legacy plugin targets and provider targets", () => {
       exportName: "plugin",
     },
   });
-  expect(formatProviderTarget(readPackageProviderTarget(pluginRoot))).toBe(
-    "plugin:./provider.ts#plugin",
-  );
   expect(readPackagePluginTarget(pluginRoot)).toBe("./provider.ts#plugin");
   expect(defaultProviderName(pluginRoot)).toBe("basic-provider");
   expect(


### PR DESCRIPTION
## Summary
- document the widened TypeScript provider surface for plugin, auth, and datastore providers
- update the docs to describe `gestalt.provider` with `plugin` as the preferred plugin-kind token
- add CI and release workflow coverage for `sdk/typescript`

## Interface Changes
The docs now describe the TypeScript package target through `gestalt.provider`:

```json
{
  "name": "my-plugin",
  "gestalt": {
    "provider": "./provider.ts#plugin"
  }
}
```

```json
{
  "name": "my-auth",
  "gestalt": {
    "provider": {
      "kind": "auth",
      "target": "./auth.ts#provider"
    }
  }
}
```

The authoring docs also include the new SDK entrypoints:

```ts
import { definePlugin, defineAuthProvider, defineDatastoreProvider } from "@valon-technologies/gestalt";
```

The release interface now includes TypeScript SDK tags and dedicated CI coverage:

```sh
git tag sdk/typescript/v0.0.1-alpha.1
git push origin sdk/typescript/v0.0.1-alpha.1
```

## Example Usage
```sh
bun install
bun run check
gestaltd plugin release --version 0.0.1-alpha.1
```

## Newly Supported Behavior
- Documentation for TypeScript plugin, auth, and datastore providers.
- Documentation for the `gestalt.provider` package target and the `plugin` kind token.
- A dedicated Bun-based CI workflow for `sdk/typescript`.
- Release automation for publishing `sdk/typescript` from `sdk/typescript/v*` tags.

## Not Supported
- Python auth or datastore authoring flows.
- Non-Bun packaging guidance for the TypeScript SDK.
- Additional TypeScript provider kinds beyond plugin, auth, and datastore.

## Validation
- workflow changes reviewed against the stacked `hugh/ts-sdk-core` base branch
- SDK checks on the stacked base branch pass: `cd sdk/typescript && bun test && bunx tsc --noEmit`
