### PR TITLE
Rewrite docs for provider-oriented Gestalt

### DIFF
--- a/docs/content/architecture/index.mdx
+++ b/docs/content/architecture/index.mdx
@@ -14,17 +14,17 @@ First, the YAML config file is loaded and `${ENV_VAR}` placeholders are expanded
 
 Next, Gestalt initializes the secret manager from the `secrets` block. This is the one part of config that *cannot* use `secret://` references, because the secret manager doesn't exist yet. Credentials for the secret manager itself have to come in through `${ENV_VAR}` or `${ENV_VAR_FILE}`.
 
-Once the secret manager is ready, Gestalt resolves every `secret://` reference across the rest of the config: server, auth, datastore, telemetry, audit, and all provider configs. The `secrets.config` block is skipped to avoid a circular dependency.
+Once the secret manager is ready, Gestalt resolves every `secret://` reference across the rest of the config: server, auth, datastore, telemetry, audit, and all plugin configs. The `secrets.config` block is skipped to avoid a circular dependency.
 
 With secrets resolved, `server.encryption_key` gets converted into a 32-byte AES key. A 64-character hex string is decoded directly; anything else goes through Argon2id derivation. This derived key protects all stored tokens.
 
-From there: auth provider, datastore (with schema migrations), provider plugins, then HTTP listeners. The `/ready` endpoint returns 503 until all providers report ready.
+From there, the auth and datastore plugins are spawned as child processes over gRPC (they use the same plugin runtime as integration plugins), schema migrations run, integration plugins start, and the HTTP listeners come up. The `/ready` endpoint returns 503 until everything reports ready.
 
 ## How requests flow
 
-Auth middleware runs first on every request. It checks for a `session_token` cookie, then for a `Bearer` header. If the bearer token starts with `gst_api_`, it's hashed with SHA-256 and looked up in the `api_tokens` table. Any other bearer value is treated as a raw provider token.
+Auth middleware runs first on every request. It checks for a `session_token` cookie, then for a `Bearer` header. If the bearer token starts with `gst_api_`, it's hashed with SHA-256 and looked up in the datastore. Any other bearer value is treated as a raw provider token.
 
-For operation invocations (`/api/v1/{integration}/{operation}` or `/mcp`), the request reaches the *broker*. The broker resolves the caller's integration token from the datastore, decrypts it, refreshes it if needed, and dispatches to the provider (plugin gRPC, REST, GraphQL, or MCP upstream). The same broker handles both HTTP and MCP calls.
+For operation invocations (`/api/v1/{integration}/{operation}` or `/mcp`), the request reaches the *broker*. The broker resolves the caller's integration token from the datastore, decrypts it, refreshes it if needed, and dispatches to the plugin (over gRPC, or to a REST/GraphQL/MCP upstream). The same broker handles both HTTP and MCP calls.
 
 ## Further reading
 

--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -19,33 +19,34 @@ asIndexPage: true
 | --- | --- |
 | `gestalt auth login` | Log in through the browser flow. |
 | `gestalt auth logout` | Clear local credentials. |
-| `gestalt auth status` | Show current auth state. |
+| `gestalt auth status` | Show current auth state and server connectivity. |
 | `gestalt init` | Run the interactive setup wizard. |
-| `gestalt config get|set|unset|list` | Manage the local client config. |
+| `gestalt config get\|set\|unset\|list` | Manage the local client config. |
 | `gestalt integrations list` | List integrations from the server. |
 | `gestalt integrations connect NAME` | Connect an integration through OAuth or interactive manual auth. |
 | `gestalt integrations disconnect NAME` | Disconnect an integration, removing stored credentials. |
 | `gestalt invoke INTEGRATION [OPERATION]` | Invoke an operation or list operations when omitted. |
 | `gestalt describe INTEGRATION OPERATION` | Show one operation's parameter contract. |
-| `gestalt tokens create|list|revoke` | Manage Gestalt API tokens. |
+| `gestalt tokens create\|list\|revoke` | Manage Gestalt API tokens. |
 
 ## URL resolution
 
-The `gestalt` client resolves the server URL in this order:
+The CLI resolves the server URL in this order:
 
 1. `--url`
 2. `GESTALT_URL`
 3. project-local `.gestalt/config.json`
-4. user-local CLI config file (for example `~/.config/gestalt/config.json`)
+4. user-local config at `~/.config/gestalt/config.json`
 
-For auth, the CLI uses this order:
+For auth, the CLI checks `GESTALT_API_KEY` first, then stored credentials from `gestalt auth login`.
 
-1. `GESTALT_API_KEY`
-2. stored credentials from `gestalt auth login`
+## Auth status
+
+`gestalt auth status` reports structured connectivity information: the target server URL, where the URL came from, whether the server is reachable, whether login is supported, and what credentials are available. This is the first thing to run when debugging connection issues.
 
 ## Project config file
 
-`gestalt init` can create a `.gestalt/config.json` file in the current directory. This file is a project-local override for the server URL, intended for cases where one checkout or deployment directory should always point to a specific Gestalt server without changing your machine-wide default.
+`gestalt init` can create a `.gestalt/config.json` file in the current directory. This is a project-local override for the server URL, intended for cases where one checkout or deployment directory should always point to a specific Gestalt server.
 
 ```json
 {
@@ -53,7 +54,7 @@ For auth, the CLI uses this order:
 }
 ```
 
-When present, the CLI searches the current directory and then parent directories until it finds the nearest `.gestalt/config.json`.
+The CLI searches the current directory and then parent directories until it finds the nearest `.gestalt/config.json`.
 
 ## Integration connect flags
 
@@ -67,13 +68,23 @@ When present, the CLI searches the current directory and then parent directories
 
 `gestalt invoke` accepts `-p`/`--param key=value`, `--input-file file.json` (use `-` for stdin), `--connection`, `--instance`, and `--select`. Use `:=` instead of `=` to pass JSON values: `-p items:='["a","b"]'`.
 
+## Operation name matching
+
+Operation names with dots (like `chat.postMessage`) can be typed as space-separated segments:
+
+```sh
+gestalt invoke slack chat postMessage
+```
+
+This resolves to `chat.postMessage`. If the segments match a prefix shared by multiple operations, the CLI displays the matching subset instead of an error. For example, `gestalt invoke slack chat` lists all operations starting with `chat.`.
+
 ## Examples
 
 ```sh
 gestalt integrations list
 gestalt integrations connect notion --connection MCP
 gestalt describe slack chat.postMessage
-gestalt invoke slack chat.postMessage \
+gestalt invoke slack chat postMessage \
   --connection plugin \
   -p channel=C123 \
   -p text='hello'

--- a/docs/content/client/web.mdx
+++ b/docs/content/client/web.mdx
@@ -24,7 +24,7 @@ Create and revoke API tokens for programmatic access. Each token shows its name,
 
 ## Authentication
 
-When the configured auth provider is Google or OIDC, the web UI redirects to your identity provider for login. When platform auth is omitted or set to `auth.provider: none`, every request is anonymous.
+When `auth.provider` is set to `google` or `oidc`, the web UI redirects to your identity provider for login. With `auth.provider: local`, login is automatic. With `auth.provider: none`, every request is anonymous.
 
 ## Custom UI bundles
 

--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -4,42 +4,68 @@ Gestalt is configured from a single YAML file. The [Config File](/reference/conf
 
 ## Config lifecycle
 
-When `--config` is not supplied, `gestaltd` looks for config in this order:
+When `--config` is not supplied, `gestaltd` looks for a config file in this order:
 
-1. `GESTALT_CONFIG`
-2. `./config.yaml`
+1. `GESTALT_CONFIG` environment variable
+2. `./config.yaml` in the working directory
 3. `~/.gestaltd/config.yaml`
 4. `/etc/gestalt/config.yaml`
 
-If nothing is found, `gestaltd` generates a default local config at `~/.gestaltd/config.yaml`.
+If nothing is found, `gestaltd` generates a default config at `~/.gestaltd/config.yaml` with SQLite storage, no auth, and a random encryption key.
 
-Gestalt expands `${ENV_VAR}` placeholders before YAML decode, falling back to `ENV_VAR_FILE` when the direct variable is unset. Unknown fields are rejected. Relative paths resolve from the config file directory, and `secret://` references are resolved through the configured secret manager at bootstrap.
+### Environment expansion
+
+Gestalt expands `${ENV_VAR}` placeholders before YAML decoding. When a referenced variable is unset but a corresponding `ENV_VAR_FILE` variable exists, Gestalt reads the value from that file path instead. This is useful for container runtimes that mount secrets as files.
+
+### Secret resolution
+
+Values prefixed with `secret://` are resolved through the configured secret manager during bootstrap, not during YAML parsing. This lets you reference secrets from Vault, AWS Secrets Manager, Google Secret Manager, or Azure Key Vault without embedding them in the config file.
+
+### Validation
+
+Unknown YAML fields are rejected at load time. Relative paths resolve from the config file's directory. You can check a config without starting the server:
+
+```sh
+gestaltd validate --config ./config.yaml
+```
 
 ## Top-level blocks
 
-A config file is organized into a handful of top-level blocks: `server` (HTTP listener, base URL, encryption key, API token TTL, prepared artifacts dir), `auth` (platform login for the web UI, HTTP API, and `/mcp`), `datastore` (persistent storage for users, sessions, API tokens, and integration credentials), `secrets` (resolution for `secret://` references), `telemetry` (structured logs, metrics, traces, and OTLP export), `plugins` (the integrations users actually invoke), and optionally `egress` (outbound policy rules and credential grants) and `ui` (packaged web UI bundle). The full example and minimal config at the bottom of this page show the structure in practice.
+A config file has the following top-level blocks:
+
+- `server` controls the HTTP listener, base URL, encryption key, API token TTL, and prepared artifacts directory.
+- `auth` selects the platform login provider for the web UI, HTTP API, and `/mcp`.
+- `datastore` selects persistent storage for users, sessions, API tokens, and integration credentials.
+- `secrets` configures resolution for `secret://` references.
+- `telemetry` configures structured logs, metrics, traces, and OTLP export.
+- `plugins` declares the integrations users invoke.
+- `egress` defines outbound policy rules and credential grants (optional).
+- `ui` references a packaged web UI bundle (optional).
 
 ## Defaults and required fields
 
-Gestalt defaults `server.port` to `8080`, `secrets.provider` to `env`, and `telemetry.provider` to `stdout`. The most important required fields are `datastore.provider` and `server.encryption_key`. Platform auth is optional.
+Gestalt defaults `server.port` to `8080`, `secrets.provider` to `env`, and `telemetry.provider` to `stdout`. The required fields are `datastore.provider` and `server.encryption_key`. Platform auth is optional.
 
-`server.encryption_key` is the root deployment secret. Gestalt derives token encryption and related session material from it, so changing it is a meaningful deployment event rather than a cosmetic config update.
+`server.encryption_key` is the root deployment secret. Gestalt derives token encryption and session material from it. Changing this key invalidates all existing sessions and tokens, so treat it as a meaningful deployment event.
 
 ## Plugins
 
-Each entry under `plugins:` becomes a runtime provider backed by a provider package. That package can come from a local source manifest during development or a versioned published package resolved during `init`. The executable provider process is the source of truth for operations; the server config supplies only provider selection, provider config, connection policy, and MCP exposure settings.
+Each entry under `plugins:` registers an integration backed by a provider package. The provider package is the source of truth for available operations, request schemas, and response schemas. The config supplies only provider selection, provider-level config, connection policy, and MCP exposure settings.
 
-## Provider patterns
+A provider package can come from two places: a versioned published package resolved by `source.ref`, or a local source manifest at `source.path` for development.
 
-A builtin or first-party provider shorthand keeps local setup small.
+### Published provider
+
+Published providers use a `source.ref` and `version` that Gestalt resolves during startup or `init`.
 
 ```yaml
 plugins:
   github:
+    display_name: GitHub
     provider:
       source:
-        ref: github.com/valon-technologies/gestalt/github
-        version: 1.2.3
+        ref: github.com/valon-technologies/gestalt-providers/plugins/github
+        version: 0.0.1-alpha.1
     config:
       api_base_url: https://api.github.com
     connections:
@@ -52,7 +78,11 @@ plugins:
       tool_prefix: github_
 ```
 
-A local source provider manifest is convenient while iterating on a provider in the same repo.
+First-party providers are published to `github.com/valon-technologies/gestalt-providers/`.
+
+### Local source provider
+
+During development, point at a local plugin manifest instead.
 
 ```yaml
 plugins:
@@ -73,7 +103,9 @@ plugins:
               label: API Token
 ```
 
-A provider package can also expose a larger catalog and use `allowed_operations` to publish only the subset you want users to see.
+### Filtering operations
+
+A provider package may expose a large catalog. Use `allowed_operations` to publish only the subset you want.
 
 ```yaml
 plugins:
@@ -94,42 +126,96 @@ plugins:
         alias: get_ticket
 ```
 
+Each entry can set an `alias` to rename the operation as it appears to callers.
+
+### Network sandbox
+
+Executable plugins run inside a network sandbox. Outbound requests to hosts not listed in `provider.allowed_hosts` are rejected. Add every upstream domain the plugin contacts to the allowlist.
+
+```yaml
+plugins:
+  example:
+    provider:
+      source:
+        ref: github.com/acme/providers/example
+        version: 1.0.0
+      allowed_hosts:
+        - api.example.com
+        - cdn.example.com
+```
+
 ## Connections and auth
 
-Connections define how Gestalt authenticates to upstream systems.
+Connections define how Gestalt authenticates to upstream systems. Each plugin declares its connections under `connections:`, with `default` being the most common.
 
 ### Connection modes
 
-**none** means no upstream credential is needed. **user** means each user stores their own. **identity** uses one shared service credential. **either** prefers user, falls back to identity.
+**none** means no upstream credential is needed. **user** means each user stores their own credential. **identity** uses one shared service credential. **either** prefers a user credential and falls back to identity.
 
 ### Connection naming
 
-`connections.default` is common but not required. When a provider package defines more than one connection, callers can pass `_connection` and `_instance` through the [HTTP API](/reference/http-api) to select which stored credential to use.
+`connections.default` is the common case. When a provider defines more than one connection, callers pass `_connection` and `_instance` through the [HTTP API](/reference/http-api) to select which stored credential to use. Connection parameters (`params`) and post-connect discovery are only supported on `connections.default`.
 
 ### Auth types
 
 Common connection auth types are `oauth2`, `mcp_oauth`, `bearer`, `manual`, and `none`.
 
-Gestalt stores upstream credentials by user, plugin name, connection name, and instance. Renaming a `plugins:` key is therefore a breaking change for stored connections.
+OAuth2 connections support the full set of OAuth2 configuration: `authorization_url`, `token_url`, `client_id`, `client_secret`, `scopes`, `pkce`, and custom authorization/token/refresh parameters. Bearer and manual connections declare `credentials` fields that the user fills in during connection setup.
 
-### Choosing an auth strategy
+Gestalt stores upstream credentials keyed by user, plugin name, connection name, and instance. Renaming a `plugins:` key is a breaking change for stored connections.
 
-| Scenario | Recommended configuration |
-| --- | --- |
-| Local development | omit `auth` or set `auth.provider: none` |
-| Multi-user deployment | `auth.provider.source.ref: .../auth/google` or `.../auth/oidc` |
-| Per-user upstream access | `mode: user` on provider connections |
-| Shared service credential | `mode: identity` on provider connections |
+## Auth
 
-## Platform auth and API tokens
+The `auth` block selects a platform login provider that protects the web UI, HTTP API, and `/mcp` endpoint. Auth providers run as external gRPC plugin processes, following the same architecture as integration providers.
 
-Platform auth controls access to the web UI, HTTP API, and `/mcp`. For local development, omit the `auth` block entirely or set `auth.provider: none`. Use `.../auth/google` or `.../auth/oidc` for authenticated multi-user setups. Put backend-specific settings in `auth.config`. See [Security](/security) for trust boundaries and token handling details.
+For local development, omit the `auth` block entirely or use the `none` shorthand:
 
-For programmatic access, Gestalt issues API tokens prefixed with `gst_api_`. They are accepted through `Authorization: Bearer ...` and use the same auth middleware as browser sessions.
+```yaml
+auth:
+  provider: none
+```
+
+Both are equivalent. Omitting `auth` means no platform login is required.
+
+For multi-user deployments, point `auth.provider` at a published auth provider. Provider-specific settings go in `auth.config`.
+
+```yaml
+auth:
+  provider:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/auth/oidc
+      version: 0.0.1-alpha.1
+  config:
+    issuer_url: https://login.example.com
+    client_id: ${OIDC_CLIENT_ID}
+    client_secret: secret://oidc-client-secret
+```
+
+The `auth.provider` field is a PluginDef with `source.ref` and `version`, the same shape as integration providers. The `none` scalar shorthand is the only exception.
+
+### API tokens
+
+For programmatic access, Gestalt issues API tokens prefixed with `gst_api_`. They are accepted through `Authorization: Bearer ...` and use the same auth middleware as browser sessions. Token lifetime is controlled by `server.api_token_ttl`, which defaults to `30d`.
+
+## Datastore
+
+The `datastore` block selects persistent storage for users, sessions, API tokens, and integration credentials. Like auth, the datastore runs as an external gRPC plugin process.
+
+```yaml
+datastore:
+  provider:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/datastore/sqlite
+      version: 0.0.1-alpha.1
+  config:
+    path: ./gestalt.db
+```
+
+`datastore.provider` is required. The `source.ref` and `version` fields work the same as for integration and auth providers. Provider-specific settings go in `datastore.config`.
 
 ## MCP
 
-Gestalt exposes a single MCP endpoint at `/mcp`, using the same auth model as the rest of the HTTP surface. Control tool naming with the provider-level `mcp` block.
+Gestalt exposes a single MCP endpoint at `/mcp`, using the same auth model as the rest of the HTTP surface. Enable MCP tool exposure per plugin with the `mcp` block.
 
 ```yaml
 plugins:
@@ -139,11 +225,15 @@ plugins:
       tool_prefix: github_
 ```
 
-Tool exposure follows the packaged provider catalog loaded at startup. If you need static request shaping, response mapping, or OpenAPI/MCP passthrough behavior, define it in the provider package rather than the deployment config.
+`tool_prefix` controls the prefix added to tool names to avoid collisions when multiple plugins expose MCP tools. Tool exposure follows the provider catalog loaded at startup.
+
+## Managed parameters and response mapping
+
+Operations, request schemas, response schemas, managed parameters, and response mappings are defined in the provider plugin manifest, not in the deployment config. Inline configuration surfaces that existed in earlier versions of Gestalt (such as `openapi`, `graphql_url`, `mcp_url`, `base_url`, `headers`, `managed_parameters`, `operations`, and `response_mapping`) have been removed from config. See [Plugin Manifests](/reference/plugin-manifests) for the manifest schema.
 
 ## Startup workflows
 
-For fast local development, run the server directly.
+For local development, start the server directly. Gestalt resolves provider packages on the fly.
 
 ```sh
 gestaltd serve --config ./config.yaml
@@ -156,19 +246,11 @@ gestaltd init --config ./config.yaml
 gestaltd serve --locked --config ./config.yaml
 ```
 
-To validate a config without starting the server, use the validate command.
-
-```sh
-gestaltd validate --config ./config.yaml
-```
-
-`init` prepares published [plugin](/plugins) sources, packaged UI bundles, and other locked artifacts into writable state. `serve --locked` starts only from that prepared state.
+`init` downloads and prepares published provider packages, packaged UI bundles, and other artifacts into a writable directory. `serve --locked` starts only from that prepared state and refuses to download anything at runtime.
 
 ## Prepared state and lockfiles
 
-Gestalt supports two startup modes: mutable startup with `gestaltd serve`, and deterministic startup with `gestaltd init` followed by `gestaltd serve --locked`.
-
-`gestaltd init` writes `gestalt.lock.json` next to the config file, along with prepared provider and UI artifacts under `.gestaltd/` in the configured artifacts directory. A typical layout looks like this:
+`gestaltd init` writes `gestalt.lock.json` next to the config file, along with prepared provider and UI artifacts under `.gestaltd/` in the configured artifacts directory. A typical layout:
 
 ```text
 deploy/
@@ -178,11 +260,11 @@ deploy/
   .gestaltd/ui/...
 ```
 
-The config declares intent, while the lockfile records the exact prepared result that `serve --locked` should trust. That lets Gestalt verify that prepared artifacts still match the current config instead of just using whatever happens to exist on disk.
+The config declares intent. The lockfile records the exact prepared result that `serve --locked` trusts. This lets Gestalt verify that prepared artifacts still match the current config instead of using whatever happens to exist on disk.
 
 ### Lockfile example
 
-For a source-backed plugin, the YAML config says which release you intend to use.
+For a published plugin, the config says which release you intend to use.
 
 ```yaml
 plugins:
@@ -193,7 +275,7 @@ plugins:
         version: 1.2.3
 ```
 
-The lockfile records the concrete prepared result of resolving that config.
+The lockfile records the concrete result of resolving that config.
 
 ```json
 {
@@ -208,24 +290,24 @@ The lockfile records the concrete prepared result of resolving that config.
       "manifest": ".gestaltd/providers/example/plugin.yaml",
       "executable": ".gestaltd/providers/example/artifacts/linux/amd64/provider"
     }
-  },
-  "ui": {
-    "fingerprint": "...",
-    "source": "github.com/acme/plugins/web",
-    "version": "1.2.3",
-    "resolved_url": "https://github.com/...",
-    "archive_sha256": "...",
-    "manifest": ".gestaltd/ui/plugin.yaml",
-    "asset_root": ".gestaltd/ui/dist"
   }
 }
 ```
 
-That distinction matters because `serve --locked` needs a durable record of what was prepared during `init`, not just whatever files happen to exist on disk.
+`serve --locked` uses the lockfile to verify that the prepared artifacts match the current config before starting.
 
-## Example
+## Choosing an auth strategy
 
-This config shows a production-style deployment with OIDC auth, a GitHub provider backed by both OpenAPI and upstream MCP, and per-user connections.
+| Scenario | Configuration |
+| --- | --- |
+| Local development | Omit `auth` or set `auth.provider: none` |
+| Multi-user deployment | `auth.provider` with an OIDC or Google auth provider |
+| Per-user upstream access | `mode: user` on plugin connections |
+| Shared service credential | `mode: identity` on plugin connections |
+
+## Full example
+
+This config shows a production deployment with OIDC auth, a GitHub plugin with per-user connections, and MCP enabled.
 
 ```yaml
 server:
@@ -241,6 +323,14 @@ auth:
     issuer_url: https://login.example.com
     client_id: ${OIDC_CLIENT_ID}
     client_secret: secret://oidc-client-secret
+
+datastore:
+  provider:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/datastore/sqlite
+      version: 0.0.1-alpha.1
+  config:
+    path: ./gestalt.db
 
 plugins:
   github:
@@ -270,7 +360,7 @@ plugins:
 
 ## Minimal config
 
-The smallest useful config sets up a local server with SQLite storage and no auth. See [Observability](/observability) for adding metrics, logs, and OTLP export.
+The smallest useful config sets up a local server with SQLite storage, no auth, and an empty plugin list.
 
 ```yaml
 server:
@@ -288,3 +378,5 @@ datastore:
 
 plugins: {}
 ```
+
+See [Observability](/observability) for adding metrics, logs, and OTLP export.

--- a/docs/content/deploy/index.mdx
+++ b/docs/content/deploy/index.mdx
@@ -8,7 +8,7 @@ The server image `valontechnologies/gestaltd:latest` is published for `linux/amd
 
 ## Production considerations
 
-**Database.** SQLite works for single-instance deployments. For multi-replica or horizontally scaled deployments, use Postgres, MySQL, or another supported datastore. See [Built-in Providers](/reference/built-in-providers) for the full list.
+**Database.** SQLite works for single-instance deployments. For multi-replica or horizontally scaled deployments, use Postgres, MySQL, or another supported datastore. See [First-Party Providers](/reference/built-in-providers) for the full list.
 
 **Secrets.** Use a dedicated secret manager (`google_secret_manager`, `aws_secrets_manager`, `vault`, `azure_key_vault`, or `file`) instead of `env` in production. Gestalt config supports `secret://` references that are resolved at boot time through the configured secret manager.
 

--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -1,28 +1,67 @@
 # Getting Started
 
+This tutorial walks you through running a Gestalt server, adding a plugin, and invoking an operation. It takes about five minutes.
+
 ## Prerequisites
 
-`gestaltd` and `gestalt` have been installed via the [installation instructions](/install).
+Install `gestaltd` (the server) and `gestalt` (the client CLI) using the [installation instructions](/install).
 
-## Run a local server
+## Start the server
 
-Start a local Gestalt server with a single command:
+Run `gestaltd` with no arguments:
 
 ```sh
 gestaltd
 ```
 
-When no configuration file is provided, `gestaltd` generates a default local config and starts immediately. The server is now running at `http://localhost:8080`.
+When no config file exists, `gestaltd` generates one at `~/.gestaltd/config.yaml` and starts immediately. The generated config uses SQLite for storage, no authentication, and listens on port 8080.
 
-## Add a plugin
+You now have a Gestalt server running at `http://localhost:8080`.
 
-Create a file called `config.yaml` with a plugin definition. This example points at a local provider package checked out next to your Gestalt repo:
+## Write a config file
+
+The generated config is fine for a first look, but let's write one explicitly so you can see what is going on. Create a file called `config.yaml`:
 
 ```yaml
 server:
   port: 8080
   base_url: http://localhost:8080
   encryption_key: dev-only-change-me
+
+auth:
+  provider: none
+
+datastore:
+  provider:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/datastore/sqlite
+      version: 0.0.1-alpha.1
+  config:
+    path: ./gestalt.db
+
+plugins: {}
+```
+
+A few things to note. `auth.provider: none` disables platform login, which is what you want for local development. `datastore.provider` points at a first-party SQLite provider published to `github.com/valon-technologies/gestalt-providers/`. The `plugins` map is empty for now.
+
+Start the server with your config:
+
+```sh
+gestaltd serve --config ./config.yaml
+```
+
+## Add a plugin
+
+Plugins are where the interesting things happen. Each entry under `plugins:` registers an integration backed by a provider package. Let's add the first-party `httpbin` provider, which wraps httpbin.org and is useful for testing:
+
+```yaml
+server:
+  port: 8080
+  base_url: http://localhost:8080
+  encryption_key: dev-only-change-me
+
+auth:
+  provider: none
 
 datastore:
   provider:
@@ -33,58 +72,66 @@ datastore:
     path: ./gestalt.db
 
 plugins:
-  example:
-    display_name: Example
+  httpbin:
+    display_name: HTTPBin
     provider:
       source:
-        path: ../my-provider/plugin.yaml
-    config:
-      greeting: Hello from example plugin
-    mcp:
-      enabled: true
-      tool_prefix: example_
+        ref: github.com/valon-technologies/gestalt-providers/plugins/httpbin
+        version: 0.0.1-alpha.1
 ```
 
-Start the server with your config:
+The `provider.source.ref` tells Gestalt where to fetch the plugin package. On first startup, Gestalt downloads the package and caches it locally.
 
-```sh
-gestaltd serve --config ./config.yaml
-```
+Restart the server so it picks up the new config.
 
 ## Connect the CLI
 
-Point the `gestalt` client at your running server:
+In a separate terminal, point the `gestalt` client at your running server:
 
 ```sh
 gestalt init
 ```
 
-The wizard prompts for the server URL and saves it to your local config. It can also create a project-local `.gestalt/config.json` so a specific checkout keeps using the same server without changing your machine-wide default. You can also set the URL directly:
+The wizard prompts for the server URL and saves it to your local config. You can skip the wizard and set the URL directly:
 
 ```sh
 gestalt config set url http://localhost:8080
 ```
 
-## Call an integration
-
-Once the server is running and the CLI is configured, you can invoke the provider through any surface.
-
-**Client CLI**
+Verify the connection by listing available integrations:
 
 ```sh
-gestalt invoke example status
+gestalt integrations list
 ```
 
-**HTTP API**
+You should see `httpbin` in the output.
+
+## Invoke an operation
+
+List the operations available on the httpbin integration:
 
 ```sh
-curl http://localhost:8080/api/v1/example/status
+gestalt invoke httpbin
 ```
 
-**Web UI**
+Then invoke one:
 
-Open `http://localhost:8080` in a browser to explore and invoke integrations interactively.
+```sh
+gestalt invoke httpbin get_headers
+```
+
+The same operation is available over HTTP. Here is the curl equivalent:
+
+```sh
+curl http://localhost:8080/api/v1/httpbin/get_headers
+```
+
+Both return the same response from the provider.
 
 ## Next steps
 
-Read [Configuration](/configuration) for the full config model, environment expansion, and locked startup. If you want to build your own executable provider package, see [Plugins](/plugins).
+You have a running Gestalt server with a plugin, and you know how to invoke operations from the CLI and over HTTP. From here:
+
+- [Configuration](/configuration) covers the full config model, environment variable expansion, and secret references.
+- [Plugins](/plugins) explains how to write your own provider package.
+- [Deploy](/deploy) walks through production deployment with Helm and Docker.

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -8,7 +8,7 @@ exposed through the HTTP API, web UI, and `/mcp`.
 
 ## How it works
 
-You define providers in a YAML config, connect users or shared identities to upstream systems through OAuth or manual auth, then invoke the same provider catalog through the browser, HTTP API, CLI, or MCP. Providers are packaged and executed through the provider runtime, whether they come from a local source manifest or a published package.
+You define plugins in a YAML config, connect users or shared identities to upstream systems through OAuth or manual auth, then invoke the same catalog through the browser, HTTP API, CLI, or MCP. Auth, datastores, and integrations all run as plugins with the same runtime model, whether they come from a local source or a published package.
 
 ## Start here
 
@@ -17,10 +17,10 @@ You define providers in a YAML config, connect users or shared identities to ups
     Run Gestalt locally, invoke a sample integration, and verify the core flow.
   </Cards.Card>
   <Cards.Card title="Configuration" href="/configuration">
-    Learn the configuration model, provider surfaces, auth, connections, and MCP.
+    Learn the configuration model, plugin setup, auth, connections, and MCP.
   </Cards.Card>
   <Cards.Card title="Plugins" href="/plugins">
-    Decide when to use executable plugins, provider packages, or UI bundles.
+    Write, release, and configure plugins for integrations, auth, datastores, and custom UIs.
   </Cards.Card>
   <Cards.Card title="Security" href="/security">
     Review trust boundaries, encryption, headers, and token handling.

--- a/docs/content/plugins/index.mdx
+++ b/docs/content/plugins/index.mdx
@@ -4,38 +4,39 @@ asIndexPage: true
 
 # Plugins
 
-Gestalt uses one packaging system for executable provider packages and packaged web UI bundles. This section covers how those packages are authored, released, and consumed by `gestaltd`.
+Everything in Gestalt runs as a plugin. Integration providers, auth backends, datastore engines, and custom web UIs all use the same packaging system: a manifest, an executable, and a gRPC contract. This section covers how plugins are authored, released, and consumed by `gestaltd`.
 
-## When you need a plugin
+## Plugin kinds
 
-Use a provider package whenever you need an integration. The package can come from a local source manifest while developing or from a published release during deployment. Use a packaged web UI bundle only when you want to replace the default client UI at `/`.
+A plugin declares one or more `kinds` in its manifest:
+
+| Kind | Purpose |
+| --- | --- |
+| `plugin` | Integration provider. Exposes operations that users invoke. |
+| `auth` | Platform auth backend. Handles login, session validation, and external token verification. |
+| `datastore` | Persistent storage. Stores users, tokens, and OAuth registrations. |
+| `webui` | Replacement web UI served at `/`. |
+
+First-party auth and datastore plugins are published at `github.com/valon-technologies/gestalt-providers/`. You can write your own for any kind.
 
 ## How plugins work
 
-When a plugin entry includes a `provider` block that resolves to an executable
-plugin, `gestaltd` starts the plugin as a child process. The host creates a
-temporary Unix socket, passes the socket path through
-`GESTALT_PLUGIN_SOCKET`, and the plugin connects back over gRPC to register
-itself.
+When a plugin entry resolves to an executable, `gestaltd` starts the plugin as a child process. The host creates a temporary Unix socket, passes the socket path through `GESTALT_PLUGIN_SOCKET`, and the plugin connects back over gRPC.
 
-The host still owns auth, token storage, and request routing. The plugin
-receives only its configured plugin name, provider config, and the current
-request context it needs to execute operations.
+The host owns auth, token storage, and request routing. Integration plugins receive only their config and the current request context needed to execute operations. Auth and datastore plugins implement their respective gRPC service contracts and are called by the host during login flows and data persistence.
 
-Plugins run in process isolation. They cannot access the datastore, other users' credentials, or the host process memory. The host resolves credentials and passes only the current caller's access token to the plugin for each request.
+Plugins run in process isolation. They cannot access the host process memory, other users' credentials, or (for integration plugins) the datastore.
 
 ## SDK support
 
-Gestalt ships first-party SDKs for Go (`sdk/go`) and Python (`sdk/python`). The underlying protocol is gRPC, so other languages are possible, but the documented authoring flow is centered on those two.
+Gestalt ships SDKs for Go (`sdk/go`) and Python (`sdk/python`). The underlying protocol is gRPC, so other languages are possible, but the documented authoring flow uses those two.
 
 ## Common pitfalls
 
-Plugins run in process isolation. They cannot access the host datastore, so any state a plugin needs must be passed through the request context or plugin config. Attempting to open the host database from plugin code will fail silently or connect to an unrelated file.
+Operation IDs must be unique within a plugin. If two surfaces expose the same operation ID, the plugin fails validation at startup. Use `allowed_operations` to filter or alias collisions.
 
-Operation IDs must be unique within a provider. If two surfaces expose the same operation ID, the provider will fail validation at startup. Rename or filter with `allowed_operations` to resolve collisions.
-
-Executable plugins run inside a network sandbox. Outbound requests to hosts not listed in `provider.allowed_hosts` are rejected with a 403. Add every upstream domain the plugin contacts to the allowlist in your plugin config.
+Executable plugins run inside a network sandbox. Outbound requests to hosts not listed in `plugin.allowed_hosts` are rejected with a 403. Add every upstream domain the plugin contacts to the allowlist.
 
 ## Packaging model
 
-The same manifest and release format packages executable provider binaries and web UI bundles referenced through `ui.plugin`. See [Plugin Manifests](/reference/plugin-manifests) for the manifest schema, [Writing a Plugin](/plugins/writing-a-plugin) for the end-to-end authoring flow, and [Releasing](/plugins/releasing) for release archives.
+The same manifest and release format packages executable binaries and web UI bundles. See [Plugin Manifests](/reference/plugin-manifests) for the manifest schema, [Writing a Plugin](/plugins/writing-a-plugin) for end-to-end authoring, and [Releasing](/plugins/releasing) for release archives.

--- a/docs/content/reference/_meta.ts
+++ b/docs/content/reference/_meta.ts
@@ -3,5 +3,5 @@ export default {
   "plugin-manifests": "Plugin Manifests",
   "http-api": "HTTP API",
   cli: "Server CLI",
-  "built-in-providers": "Built-in Providers",
+  "built-in-providers": "First-Party Providers",
 };

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -1,10 +1,12 @@
-# Built-in Providers
+# First-Party Providers
 
-`gestaltd` still includes a small set of host-native providers for secrets and telemetry. Auth providers, datastore providers, and integration plugins are no longer compiled into the server binary; they are published separately and loaded through the provider runtime.
+Gestalt does not compile auth or datastore providers into the `gestaltd` binary. Both are loaded at startup as external plugins through the same plugin runtime that powers integration plugins. The first-party implementations are published from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers) and maintained alongside the server.
 
-## First-Party Auth Providers
+Secrets, telemetry, and audit remain built into the binary because they must be available before the plugin runtime starts.
 
-These ship from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers) and are referenced via `auth.provider.source.ref`.
+## Auth Providers
+
+Auth providers handle platform login. They are configured under `auth.provider` in your config file, using the `provider:` key to reference the plugin source.
 
 | Name | Purpose |
 | --- | --- |
@@ -12,11 +14,22 @@ These ship from [`valon-technologies/gestalt-providers`](https://github.com/valo
 | `google` | Google OAuth 2.0 platform login. Supports `allowed_domains` restriction. |
 | `oidc` | Generic OpenID Connect. Works with Okta, Auth0, Azure AD, Keycloak, and others. |
 
-To disable platform auth entirely, omit the `auth` block or set `auth.provider: none`. That is a host-side special case rather than a published auth provider package.
+```yaml
+auth:
+  provider:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/auth-google
+      version: 1.0.0
+  config:
+    allowed_domains:
+      - example.com
+```
 
-## First-Party Datastore Providers
+To disable platform auth entirely, omit the `auth` block or set `auth.provider: none`.
 
-These also ship from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers) and are referenced via `datastore.provider.source.ref`.
+## Datastore Providers
+
+Datastore providers back the persistent state layer. They are configured under `datastore.provider` in your config file, also using the `provider:` key.
 
 | Name | Purpose |
 | --- | --- |
@@ -29,7 +42,19 @@ These also ship from [`valon-technologies/gestalt-providers`](https://github.com
 | `firestore` | Firestore-backed datastore. |
 | `sqlserver` | SQL Server-backed datastore. |
 
-## Secret Managers
+```yaml
+datastore:
+  provider:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/datastore-postgres
+      version: 1.0.0
+  config:
+    dsn: ${POSTGRES_DSN}
+```
+
+## Secret Managers (built-in)
+
+Secret managers are compiled into the binary. They resolve `secret://` references and `${VAR}` expansions during bootstrap, before the plugin runtime is available.
 
 | Name | Purpose |
 | --- | --- |
@@ -40,7 +65,9 @@ These also ship from [`valon-technologies/gestalt-providers`](https://github.com
 | `vault` | Resolves secrets from HashiCorp Vault (KV v2). |
 | `azure_key_vault` | Resolves secrets from Azure Key Vault. |
 
-## Telemetry Providers
+## Telemetry Providers (built-in)
+
+Telemetry providers are compiled into the binary.
 
 | Name | Purpose |
 | --- | --- |
@@ -48,6 +75,19 @@ These also ship from [`valon-technologies/gestalt-providers`](https://github.com
 | `otlp` | Exports traces, metrics, and logs via OpenTelemetry Protocol. |
 | `noop` | Disables all telemetry collection. |
 
-## Named Providers
+## Integration Plugins
 
-No named providers are built into the binary. Integration plugins like BigQuery, Jira, Slack, and others are published separately from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers) and referenced in your config via `plugins.<name>.provider.source.ref`.
+Integration plugins (BigQuery, Jira, Slack, and others) are published separately from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). They use the `provider:` key under each named entry in the `plugins` map:
+
+```yaml
+plugins:
+  jira:
+    provider:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/jira
+        version: 1.0.0
+```
+
+## Community and Custom Providers
+
+Third-party auth providers, datastore providers, and integration plugins use the same plugin model as the first-party packages. Package your implementation as a plugin manifest with the appropriate `kinds` (`auth`, `datastore`, or `plugin`), publish it to a Git-accessible source, and reference it in your config the same way you would reference any first-party provider.

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -3,13 +3,14 @@
 Every `gestaltd` deployment reads a single YAML config file. The top-level keys map one-to-one with the subsystems they configure:
 
 ```yaml
+server: {}
 auth: {}
 datastore: {}
 secrets: {}
 telemetry: {}
+audit: {}
 plugins: {}
 egress: {}
-server: {}
 ui: {}
 ```
 
@@ -45,15 +46,22 @@ server:
 
 `api_token_ttl` controls the lifetime of newly issued API tokens, defaulting to `30d`. It accepts Go duration strings (`1h`, `720h`) and day suffixes (`30d`). `artifacts_dir` is a writable directory for prepared artifacts produced by `init` and consumed by `serve --locked` when no CLI override is supplied; it defaults to the config file's directory. See [Configuration](/configuration) for the full `init`/`serve` lifecycle.
 
+| Field | Default | Description |
+| --- | --- | --- |
+| `public.host` | `0.0.0.0` | Bind address for the public listener. |
+| `public.port` | `8080` | Port for the public listener. |
+| `management.host` | | Bind address for the management listener. |
+| `management.port` | | Port for the management listener. Required when `management.host` is set. |
+| `base_url` | | Public origin URL used for OAuth callbacks and admin UI links. |
+| `encryption_key` | | **Required.** Root encryption key. Typically a `secret://` reference. |
+| `api_token_ttl` | `30d` | Lifetime of newly issued API tokens. Go durations or day suffixes (`30d`). |
+| `artifacts_dir` | config directory | Directory for prepared `init` artifacts. |
+
 When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth routes, and `/mcp` on the public listener, while `/admin`, `/metrics`, `/health`, and `/ready` move to the management listener. The management listener is intended to be protected by deployment infrastructure such as private networking, VPN, or an internal-only reverse proxy. Gestalt does not apply its own session or API-token auth to `/metrics` on the management listener.
 
 ## `auth`
 
-Top-level platform auth is optional. Omit the `auth` block entirely to disable
-platform authentication, or set `auth.provider: none` explicitly. When auth is
-enabled, configure it with `auth.provider` and `auth.config`. `auth.provider`
-uses the same provider-reference shape as integration plugins: a `source`
-block plus optional `env` and `allowed_hosts`.
+Top-level platform auth is optional. Omit the `auth` block entirely to disable platform authentication, or set `auth.provider: none` explicitly. When auth is enabled, configure it with `auth.provider` and `auth.config`. `auth.provider` uses the same provider-reference shape as integration plugins: a `source` block plus optional `env` and `allowed_hosts`.
 
 ### `none`
 
@@ -117,10 +125,20 @@ Two fields are required: `issuer_url` (the OIDC discovery base URL) and `client_
 
 OIDC checks `email_verified` when the claim is present. Unverified accounts are rejected.
 
+### `auth.provider` shape
+
+Both `google` and `oidc` use the same PluginDef provider reference shape under `auth.provider`. First-party auth providers are published at `github.com/valon-technologies/gestalt-providers/auth/<name>`.
+
+| Field | Description |
+| --- | --- |
+| `source.ref` | Managed provider source address. |
+| `source.version` | Required with `source.ref`. SemVer without a leading `v`. |
+| `env` | Extra environment variables passed to the provider process. |
+| `allowed_hosts` | Network allowlist for sandboxed provider processes. |
+
 ## `datastore`
 
-Top-level datastores are also provider-based. Configure them with
-`datastore.provider` and `datastore.config`.
+Top-level datastores are also provider-based. Configure them with `datastore.provider` and `datastore.config`. First-party datastore providers are published at `github.com/valon-technologies/gestalt-providers/datastore/<name>`.
 
 ```yaml
 datastore:
@@ -155,6 +173,8 @@ Gestalt auto-detects and validates the connected backend release series for the 
 
 ## `secrets`
 
+The secrets manager resolves `secret://` references at startup. Unlike `auth` and `datastore`, secret providers are built into the `gestaltd` binary and selected by a plain string `provider` field.
+
 ```yaml
 secrets:
   provider: file
@@ -164,16 +184,16 @@ secrets:
 
 | Provider | Config fields | Purpose |
 | --- | --- | --- |
-| `env` | `prefix` | Reads secrets from environment variables. |
+| `env` | `prefix` | Reads secrets from environment variables. Default when `secrets` is omitted. |
 | `file` | `dir` | Reads one secret per file from a base directory. Works with Kubernetes volume-mounted secrets. |
 | `google_secret_manager` | `project`, `version` | Google Cloud Secret Manager. `version` defaults to `latest`. |
-| `aws_secrets_manager` | `region`, `version_stage`, `endpoint` | AWS Secrets Manager. `version_stage` defaults to `AWSCURRENT`. |
-| `vault` | `address`, `token`, `mount_path`, `namespace` | HashiCorp Vault KV v2. `mount_path` defaults to `secret`. |
-| `azure_key_vault` | `vault_url`, `version` | Azure Key Vault. `version` defaults to latest. |
+| `aws_secrets_manager` | `region`, `version_stage`, `endpoint` | AWS Secrets Manager. `region` is required. `version_stage` defaults to `AWSCURRENT`. |
+| `vault` | `address`, `token`, `mount_path`, `namespace` | HashiCorp Vault KV v2. `address` and `token` are required. `mount_path` defaults to `secret`. |
+| `azure_key_vault` | `vault_url`, `version` | Azure Key Vault. `vault_url` is required. `version` defaults to latest. |
 
 ### Bootstrap credentials
 
-`secret://` references are resolved through the configured secret manager at startup, but the secret manager's own configuration (`secrets.config`) cannot use `secret://` — it would be self-referential. Use `${ENV_VAR}` or `${ENV_VAR_FILE}` placeholders for any credentials the secret manager itself needs.
+`secret://` references are resolved through the configured secret manager at startup, but the secret manager's own configuration (`secrets.config`) cannot use `secret://` because it would be self-referential. Use `${ENV_VAR}` or `${ENV_VAR_FILE}` placeholders for any credentials the secret manager itself needs.
 
 Each provider authenticates to its backing service differently:
 
@@ -205,7 +225,13 @@ telemetry:
 
 Outputs structured logs to standard output. Traces remain disabled, but metrics are collected locally and exposed through the Prometheus-compatible `/metrics` endpoint. The built-in admin UI at `/admin` reads that same scrape surface. This is the default provider when `telemetry` is omitted.
 
-`format` selects `text` or `json` output and defaults to `text`. `level` sets the minimum log level (`debug`, `info`, `warn`, or `error`) and defaults to `info`. `service_name` is attached to locally exposed metrics and defaults to `gestaltd`. You can attach extra key-value pairs to local metrics through `resource_attributes`. The Prometheus scrape endpoint at `/metrics` is enabled by default and can be toggled with `metrics.prometheus.enabled`.
+| Field | Default | Description |
+| --- | --- | --- |
+| `format` | `text` | Log format: `text` or `json`. |
+| `level` | `info` | Minimum log level: `debug`, `info`, `warn`, or `error`. |
+| `service_name` | `gestaltd` | Attached to locally exposed metrics. |
+| `resource_attributes` | | Extra key-value pairs attached to local metrics. |
+| `metrics.prometheus.enabled` | `true` | Toggle the `/metrics` scrape endpoint. |
 
 ### `otlp`
 
@@ -233,11 +259,20 @@ telemetry:
 
 Exports to any OpenTelemetry-compatible collector (Jaeger, Grafana Alloy, Datadog Agent) while still keeping local `/metrics` available by default. The built-in admin UI at `/admin` reads that same local scrape surface.
 
-`endpoint` sets the OTLP collector address and defaults to the SDK default. `protocol` selects `grpc` (the default) or `http`, and `insecure` skips TLS verification when set to `true`. `headers` adds extra headers on every export request. `service_name` defaults to `gestaltd`, and `resource_attributes` attaches arbitrary key-value pairs as OpenTelemetry resource attributes.
-
-`traces.sampling_ratio` controls the fraction of traces sampled, from `0.0` to `1.0` (default `1.0`). `metrics.interval` sets the OTLP metric export interval, defaulting to `60s`. The local Prometheus scrape endpoint stays enabled by default and can be toggled with `metrics.prometheus.enabled`.
-
-`logs.exporter` controls where logs go: `otlp` (the default) exports them over OTLP, while `stdout` keeps them on standard output. `logs.level` sets the minimum log level, defaulting to `info`. `logs.format` selects `text` or `json` when the exporter is `stdout`.
+| Field | Default | Description |
+| --- | --- | --- |
+| `endpoint` | SDK default | OTLP collector address. |
+| `protocol` | `grpc` | Transport protocol: `grpc` or `http`. |
+| `insecure` | `false` | Skip TLS verification when `true`. |
+| `headers` | | Extra headers on every export request. |
+| `service_name` | `gestaltd` | OpenTelemetry service name. |
+| `resource_attributes` | | Arbitrary key-value pairs as OTel resource attributes. |
+| `traces.sampling_ratio` | `1.0` | Fraction of traces sampled, from `0.0` to `1.0`. |
+| `metrics.interval` | `60s` | OTLP metric export interval. |
+| `metrics.prometheus.enabled` | `true` | Toggle the local `/metrics` scrape endpoint. |
+| `logs.exporter` | `otlp` | Where logs go: `otlp` or `stdout`. |
+| `logs.level` | `info` | Minimum log level. |
+| `logs.format` | `text` | Log format when exporter is `stdout`: `text` or `json`. |
 
 To keep system logs on stdout while still exporting traces and metrics over OTLP:
 
@@ -272,13 +307,9 @@ Disables all telemetry. Instrumentation points remain but produce zero overhead.
 | Broker | `broker.invoke` | `gestalt.provider`, `gestalt.operation`, `gestalt.user_id`, `gestalt.connection_mode` |
 | gRPC plugin | Per-RPC spans | Standard gRPC semantic conventions |
 
-### Audit logs
-
-Audit records are emitted as structured log entries with `log.type=audit`. By default they inherit the normal telemetry log pipeline, but you can override that with the top-level `audit` block below. See [Audit Logging](/audit-logging) for the event schema and coverage details, and [Observability](/observability) for export options. If you keep `audit.provider: inherit`, you can still route audit traffic to a dedicated backend by filtering on `log.type=audit` in your collector.
-
 ## `audit`
 
-Audit output defaults to inheriting the main telemetry logger. Override it here to send audit records to a dedicated sink.
+Audit records are emitted as structured log entries with `log.type=audit`. By default they inherit the normal telemetry log pipeline, but you can override that with a dedicated `audit` block. See [Audit Logging](/audit-logging) for the event schema and coverage details, and [Observability](/observability) for export options. If you keep `audit.provider: inherit`, you can still route audit traffic to a dedicated backend by filtering on `log.type=audit` in your collector.
 
 ### `inherit`
 
@@ -300,7 +331,12 @@ audit:
     format: json
 ```
 
-Writes audit records to standard output even if the main telemetry pipeline is using a different provider. `format` selects `text` (the default) or `json`. `level` sets the minimum audit log level, defaulting to `info`. Setting it to `warn` keeps denied audit events while suppressing successful ones.
+Writes audit records to standard output even if the main telemetry pipeline is using a different provider.
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `format` | `text` | Output format: `text` or `json`. |
+| `level` | `info` | Minimum audit log level. Setting to `warn` keeps denied events while suppressing successful ones. |
 
 ### `otlp`
 
@@ -320,7 +356,14 @@ audit:
 
 Exports audit records over OTLP without changing where application logs, metrics, or traces go. Use this when you want audit records in a dedicated compliance pipeline while keeping the rest of `gestaltd` on `stdout` or a different OTLP collector.
 
-`endpoint` sets the OTLP collector address and defaults to the SDK default. `protocol` selects `grpc` (the default) or `http`, and `insecure` skips TLS verification when set to `true`. `service_name` defaults to `gestaltd` and is attached to exported audit logs. `headers` adds extra headers on every export request, and `resource_attributes` attaches extra key-value pairs to audit log exports.
+| Field | Default | Description |
+| --- | --- | --- |
+| `endpoint` | SDK default | OTLP collector address. |
+| `protocol` | `grpc` | Transport protocol: `grpc` or `http`. |
+| `insecure` | `false` | Skip TLS verification when `true`. |
+| `service_name` | `gestaltd` | Attached to exported audit logs. |
+| `headers` | | Extra headers on every export request. |
+| `resource_attributes` | | Extra key-value pairs attached to audit log exports. |
 
 ### `noop`
 
@@ -343,7 +386,7 @@ plugins:
     icon_file: ./icons/github.svg
     provider:
       source:
-        ref: github.com/valon-technologies/gestalt/github
+        ref: github.com/valon-technologies/gestalt-providers/github
         version: 1.2.3
     config:
       api_base_url: https://api.github.com
@@ -364,17 +407,32 @@ The config key is `plugins`, but the HTTP API and client CLI still refer to thes
 
 ### Plugin fields
 
-`display_name`, `description`, and `icon_file` control how the plugin appears in the UI and API. `icon_file` is an SVG path resolved from the config directory.
-
-`provider` selects the backing provider package. `config` passes provider-specific configuration into that package.
-
-`connections` declares named connections. `default` is a common convention but not required. Only `connections.default` may define `params` or `discovery`.
-
-`allowed_operations` acts as an allowlist and supports `alias` and `description` overrides per operation. `mcp` controls MCP exposure settings such as `enabled` and `tool_prefix`.
+| Field | Description |
+| --- | --- |
+| `display_name` | Human-readable name shown in the UI and API. |
+| `description` | Short description of the integration. |
+| `icon_file` | SVG icon path, resolved relative to the config directory. |
+| `provider` | **Required.** The backing provider package. See [provider shape](#pluginsprovider) below. |
+| `config` | Provider-specific configuration passed into the provider package. |
+| `connections` | Named connection declarations. See [connections](#connections) below. |
+| `allowed_operations` | Allowlist with optional `alias` and `description` overrides per operation. |
+| `mcp.enabled` | Expose this integration over MCP. |
+| `mcp.tool_prefix` | Prefix for MCP tool names. Only valid when `mcp.enabled` is `true`. |
 
 ### `plugins.*.provider`
 
-Every plugin uses a nested `provider` block.
+Every plugin uses a nested `provider` block to declare its source.
+
+```yaml
+provider:
+  source:
+    ref: github.com/valon-technologies/gestalt-providers/github
+    version: 1.2.3
+```
+
+`source.ref` resolves a versioned plugin source during `init` using the format `github.com/<org>/<repo>/<path-after-repo>`, and requires `source.version`. `source.path` loads a local source plugin from its manifest path instead. `source.path` and `source.ref` are mutually exclusive.
+
+For local development with a source plugin:
 
 ```yaml
 provider:
@@ -382,48 +440,66 @@ provider:
     path: ./plugin.yaml
 ```
 
-`source.path` loads a local source plugin from its manifest path. Gestalt synthesizes the Go executable wrapper automatically when needed and runs Python source plugins from the module declared in `[tool.gestalt].plugin`. `source.ref` resolves a versioned plugin source during `init` using the format `github.com/<org>/<repo>/<path-after-repo>`, and requires `source.version`. `source.path` and `source.ref` are mutually exclusive. Integration plugins do not support `provider.builtin`.
+Gestalt synthesizes the Go executable wrapper automatically when needed and runs Python source plugins from the module declared in `[tool.gestalt].plugin`.
 
-`env` passes extra environment variables to executable providers. `allowed_hosts` sets an optional network allowlist for sandboxed plugin processes.
+| Field | Description |
+| --- | --- |
+| `source.ref` | Managed provider source address. Mutually exclusive with `source.path`. |
+| `source.version` | Required with `source.ref`. SemVer without a leading `v`. Invalid with `source.path`. |
+| `source.path` | Path to a local plugin manifest. Mutually exclusive with `source.ref`. |
+| `env` | Extra environment variables passed to the provider process. |
+| `allowed_hosts` | Network allowlist for sandboxed plugin processes. |
 
-### Auth shapes inside `connections`
+### `connections`
 
-Every connection auth block uses the same shape.
+Connections declare how users authenticate to the upstream service. Only `connections.default` may define `params` and `discovery`.
 
 ```yaml
 connections:
   default:
+    mode: user
     auth:
       type: oauth2
-      authorization_url: https://provider.example.com/oauth/authorize
-      token_url: https://provider.example.com/oauth/token
+      authorization_url: https://accounts.example.com/oauth/authorize
+      token_url: https://accounts.example.com/oauth/token
       client_id: ${CLIENT_ID}
       client_secret: ${CLIENT_SECRET}
-      client_auth: body
-      token_exchange: form
-      scopes:
-        - read
-        - write
-      scope_param: user_scope
-      scope_separator: ","
-      pkce: true
-      authorization_params:
-        audience: https://api.example.com
-      token_params:
-        resource: api
-      refresh_params: {}
-      accept_header: application/json
-      token_metadata:
-        - workspace_id
+    params:
+      tenant:
+        required: true
+        description: Tenant identifier
+  mcp:
+    mode: user
+    auth:
+      type: mcp_oauth
 ```
 
-`type` selects the auth strategy: `oauth2`, `manual`, `bearer`, `none`, or `mcp_oauth`. For OAuth2 connections, `authorization_url` and `token_url` point to the provider's OAuth endpoints, and `client_id` and `client_secret` supply the client credentials. `redirect_url` overrides the callback URL that would otherwise be derived from `server.base_url`.
+Connection `mode` determines how credentials are managed: `none` requires no credentials, `user` requires each user to connect individually, `identity` uses a shared operator credential, and `either` accepts both user and identity connections. All connections in a single integration must share the same mode.
 
-`client_auth` controls how credentials are sent to the token endpoint: `body` (the default) or `header`. `token_exchange` selects the token request encoding: `form` (the default) or `json`. `accept_header` sets the `Accept` header for the token endpoint.
+#### Auth shapes
 
-`scopes` lists OAuth scopes to request. `scope_param` overrides the query parameter name (defaults to `scope`; set to `user_scope` for Slack and other providers that use a non-standard parameter). `scope_separator` controls the separator between scope values, defaulting to space. Set `pkce` to `true` to enable Proof Key for Code Exchange.
+Every connection `auth` block uses the same shape. `type` selects the auth strategy: `oauth2`, `manual`, `bearer`, `none`, or `mcp_oauth`.
 
-`authorization_params`, `token_params`, and `refresh_params` inject extra parameters into their respective OAuth requests. `token_metadata` lists fields to extract from the token response and store as connection metadata.
+| Field | Default | Description |
+| --- | --- | --- |
+| `type` | | Auth strategy: `oauth2`, `manual`, `bearer`, `none`, or `mcp_oauth`. |
+| `authorization_url` | | OAuth2 authorization endpoint. |
+| `token_url` | | OAuth2 token endpoint. |
+| `client_id` | | OAuth2 client identifier. |
+| `client_secret` | | OAuth2 client secret. |
+| `redirect_url` | derived from `server.base_url` | OAuth2 callback URL. |
+| `client_auth` | `body` | How credentials are sent to the token endpoint: `body` or `header`. |
+| `token_exchange` | `form` | Token request encoding: `form` or `json`. |
+| `scopes` | | OAuth2 scopes to request. |
+| `scope_param` | `scope` | Query parameter name for scopes. Set to `user_scope` for Slack and other providers that use a non-standard parameter. |
+| `scope_separator` | space | Separator between scope values. |
+| `pkce` | `false` | Enable Proof Key for Code Exchange. |
+| `authorization_params` | | Extra parameters for the authorization request. |
+| `token_params` | | Extra parameters for the token request. |
+| `refresh_params` | | Extra parameters for the refresh request. |
+| `accept_header` | | `Accept` header for the token endpoint. |
+| `access_token_path` | | JSON path to the access token in the token response. |
+| `token_metadata` | | Fields to extract from the token response and store as connection metadata. |
 
 `mcp_oauth` is an advanced mode for MCP-driven OAuth discovery. It delegates authorization URL and token URL resolution to the upstream MCP server.
 
@@ -464,37 +540,17 @@ connections:
           DD-APPLICATION-KEY: app_key
 ```
 
-Each credential entry has a `name` (a unique, lowercase-with-underscores identifier) and an optional `label` that the UI displays instead of the raw name. `description` adds hint text below the label and supports inline links via `[text](url)`. `help_url` places a link next to the label pointing to where the credential can be found. `auth_mapping.headers` maps credential field names to HTTP headers and is required when multiple credentials are declared.
-
-`credentials` is required when `auth.type` is `manual`.
-
-### `connections`
-
-```yaml
-connections:
-  default:
-    mode: user
-    auth:
-      type: oauth2
-      authorization_url: https://accounts.example.com/oauth/authorize
-      token_url: https://accounts.example.com/oauth/token
-      client_id: ${CLIENT_ID}
-      client_secret: ${CLIENT_SECRET}
-    params:
-      tenant:
-        required: true
-        description: Tenant identifier
-  mcp:
-    mode: user
-    auth:
-      type: mcp_oauth
-```
-
-Only `connections.default` may define `params` and `discovery`.
-
-Connection `mode` determines how credentials are managed: `none` requires no credentials, `user` requires each user to connect individually, `identity` uses a shared operator credential, and `either` accepts both user and identity connections. If you omit `connections.default` and use only named connections, every configured surface must set its own `connection`.
+| Field | Description |
+| --- | --- |
+| `credentials[].name` | Unique, lowercase-with-underscores identifier. Required when `auth.type` is `manual`. |
+| `credentials[].label` | UI display label. Falls back to `name` when omitted. |
+| `credentials[].description` | Hint text below the label. Supports inline links via `[text](url)`. |
+| `credentials[].help_url` | Link placed next to the label pointing to where the credential can be found. |
+| `auth_mapping.headers` | Maps credential field names to HTTP headers. Required when multiple credentials are declared. |
 
 #### Post-connect discovery
+
+Post-connect discovery lets a connection fetch a list of resources after the user authenticates, populating a connection parameter from the user's selection.
 
 ```yaml
 connections:
@@ -517,17 +573,12 @@ connections:
         workspace_id: id
 ```
 
-### Legacy inline fields
-
-Inline and spec-backed plugin config is no longer supported in `config.yaml`. Older fields such as `openapi`, `graphql_url`, `mcp_url`, `base_url`, `headers`, `managed_parameters`, `operations`, `response_mapping`, and the old `*_connection` overrides must move into the provider package itself.
-
-### `mcp`
-
-```yaml
-mcp:
-  enabled: true
-  tool_prefix: github_
-```
+| Field | Description |
+| --- | --- |
+| `discovery.url` | URL to fetch the list of resources after connect. |
+| `discovery.id_path` | JSON path to the resource identifier. |
+| `discovery.name_path` | JSON path to the resource display name. |
+| `discovery.metadata` | Maps connection metadata keys to JSON paths in the discovery response. |
 
 ## `egress`
 
@@ -547,7 +598,37 @@ egress:
       host: api.github.com
 ```
 
-`default_action` sets the global fallback policy to `allow` or `deny`. `policies` declares static allow or deny rules matched by provider, operation, method, host, path, or subject. `credentials` attaches secret-backed outbound credentials matched by subject, method, host, or path. For credential grants, `auth_style` may be `bearer`, `raw`, `basic`, or `none`.
+`default_action` sets the global fallback policy to `allow` or `deny`.
+
+### Policies
+
+`policies` declares static allow or deny rules. Each rule matches against a combination of fields; all specified fields must match for the rule to apply.
+
+| Field | Description |
+| --- | --- |
+| `action` | **Required.** `allow` or `deny`. |
+| `subject_kind` | Match by subject kind. |
+| `subject_id` | Match by subject identifier. |
+| `provider` | Match by integration name. |
+| `operation` | Match by operation name. |
+| `method` | Match by HTTP method. |
+| `host` | Match by destination host. |
+| `path_prefix` | Match by URL path prefix. |
+
+### Credentials
+
+`credentials` attaches secret-backed outbound credentials to requests matching at least one criterion. `secret_ref` is a bare secret name (not a `secret://` URI) resolved through the configured secret manager.
+
+| Field | Description |
+| --- | --- |
+| `secret_ref` | **Required.** Bare secret name resolved through the secret manager. |
+| `auth_style` | How to inject the credential: `bearer`, `raw`, `basic`, or `none`. |
+| `subject_kind` | Match by subject kind. |
+| `subject_id` | Match by subject identifier. |
+| `operation` | Match by operation name. |
+| `method` | Match by HTTP method. |
+| `host` | Match by destination host. |
+| `path_prefix` | Match by URL path prefix. |
 
 ## `ui`
 
@@ -560,6 +641,11 @@ ui:
 
 `plugin.source` is a managed plugin source address and requires `plugin.version`, which must be valid SemVer without a leading `v`. `ui.plugin` provides the public client UI at `/`, while the built-in admin UI remains available at `/admin`. See [Releasing](/plugins/releasing) for the full workflow.
 
+| Field | Description |
+| --- | --- |
+| `plugin.source` | **Required** when `ui.plugin` is configured. Managed plugin source address. |
+| `plugin.version` | **Required** with `plugin.source`. SemVer without a leading `v`. |
+
 ## Validation rules
 
 Structural validation runs at config load time (`init`, `validate`, `serve`). Runtime validation runs only at `serve` time.
@@ -568,10 +654,16 @@ Structural validation runs at config load time (`init`, `validate`, `serve`). Ru
 
 Each plugin uses a nested `provider` block. Every plugin must use exactly one loading mode: local `provider.source.path` or managed `provider.source.ref`. `provider.source.version` is required with `provider.source.ref` and invalid with `provider.source.path`.
 
-Only `connections.default` may define `params` or `discovery`, `mcp.tool_prefix` is valid only when `mcp.enabled` is `true`, and all connections in a provider must share the same mode.
+Auth and datastore providers use the same PluginDef shape. When `auth.provider` or `datastore.provider` is set, `source.ref` or `source.path` must be present. `auth.config` and `datastore.config` are only allowed when their corresponding provider is set.
+
+Only `connections.default` may define `params` or `discovery`. `mcp.tool_prefix` is valid only when `mcp.enabled` is `true`. All connections in an integration must share the same mode.
 
 `ui.plugin.source` is required when `ui.plugin` is configured, and `ui.plugin.version` is required with `ui.plugin.source`.
 
+`egress.default_action` must be `allow` or `deny`. Each egress policy rule requires an `action`. Each egress credential grant requires `secret_ref` (as a bare name, not a `secret://` URI) and at least one match criterion.
+
+Server listener ports must be greater than zero. When `server.management` is configured, it must differ from `server.public`.
+
 ### Runtime
 
-`datastore.provider` and `server.encryption_key` are required. `auth` is optional.
+`datastore.provider` and `server.encryption_key` are required at `serve` time. `auth` is optional.

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -55,7 +55,7 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 
 ## MCP
 
-If at least one provider contributes MCP-visible tools or an upstream MCP
+If at least one plugin contributes MCP-visible tools or an upstream MCP
 surface, Gestalt also mounts:
 
 | Method | Path | Purpose |
@@ -72,7 +72,7 @@ When you call:
 /api/v1/{integration}/{operation}
 ```
 
-Gestalt authenticates the caller, resolves the target provider and operation, then resolves credentials based on the connection's `mode`. If the user has exactly one stored instance it is selected automatically; if there are multiple and none is specified, the call fails with an ambiguity error. OAuth tokens are refreshed when needed before the provider operation executes.
+Gestalt authenticates the caller, resolves the target plugin and operation, then resolves credentials based on the connection's `mode`. If the user has exactly one stored instance it is selected automatically; if there are multiple and none is specified, the call fails with an ambiguity error. OAuth tokens are refreshed when needed before the provider operation executes.
 
 ## Parameter conventions
 

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -4,106 +4,285 @@ import { Tabs } from 'nextra/components'
 
 Gestalt plugins and release archives are described by a manifest file: `plugin.yaml`, `plugin.yml`, or `plugin.json`. YAML is the easiest format to author by hand.
 
-## Top-level shape
+## Manifest Kinds
 
-A manifest defines exactly one of `provider` or `webui`.
+Every manifest defines exactly one of four kinds, determined by which metadata block is present at the top level:
+
+| Kind | Top-level key | Purpose |
+| --- | --- | --- |
+| `plugin` | `plugin` | Integration plugin (REST, OpenAPI, GraphQL, MCP, or executable). |
+| `auth` | `auth` | Platform auth provider (Google, OIDC, local, or custom). |
+| `datastore` | `datastore` | Persistence backend (Postgres, SQLite, DynamoDB, or custom). |
+| `webui` | `webui` | Static UI package served by `gestaltd`. |
+
+The JSON schema enforces `oneOf` across these four keys: a manifest must include exactly one.
 
 ## Common Fields
 
-| Field | Purpose |
+These fields appear at the top level of every manifest regardless of kind.
+
+| Field | Type | Required | Purpose |
+| --- | --- | --- | --- |
+| `source` | string | yes | Canonical plugin source identifier. Use `github.com/<org>/<repo>/<path>`. The final path segment is the plugin name; preceding segments are used for release tags and source resolution. |
+| `version` | string | yes | Semver version. Pre-release suffixes like `-alpha.1` are allowed. |
+| `kinds` | string[] | no | Explicit kind list. When omitted, the kind is inferred from which metadata block is present. |
+| `display_name` | string | no | Human-readable label shown in the UI. |
+| `description` | string | no | Human-readable description. |
+| `icon_file` | string | no | Relative path to an SVG icon bundled with the package. |
+| `artifacts` | Artifact[] | no | Packaged executable artifacts keyed by platform. Omit for declarative-only plugin packages or source manifests used during local development. |
+| `entrypoints` | Entrypoints | no | Executable entrypoints for each kind the manifest provides. |
+
+## Entrypoints
+
+The `entrypoints` block declares executable binaries. Each key corresponds to a kind.
+
+| Key | Kind | Purpose |
+| --- | --- | --- |
+| `plugin` | plugin | Executable entrypoint for an integration plugin. |
+| `auth` | auth | Executable entrypoint for an auth provider. |
+| `datastore` | datastore | Executable entrypoint for a datastore provider. |
+
+Note that the JSON/YAML tag for the integration-plugin entrypoint is `plugin`, not `provider`. Each entrypoint has two fields:
+
+| Field | Type | Required | Purpose |
+| --- | --- | --- | --- |
+| `artifact_path` | string | yes | Path to the binary inside the package. |
+| `args` | string[] | no | Additional arguments passed to the binary at startup. |
+
+```yaml
+entrypoints:
+  plugin:
+    artifact_path: artifacts/linux/amd64/plugin
+    args: ["--verbose"]
+```
+
+## Plugin Metadata
+
+The `plugin` block describes an integration plugin. It supports declarative REST operations, spec-loaded surfaces (OpenAPI, GraphQL, MCP), executable code, or any combination.
+
+### Core Fields
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `config_schema_path` | string | Path to a JSON/YAML schema that validates `plugins.<name>.config` in the server config. |
+| `auth` | ProviderAuth | Default connection auth when no `connections` map is defined. |
+| `connection_mode` | string | Default connection mode when no `connections` map is defined. One of `none`, `user`, `identity`, `either`. |
+| `mcp` | bool | When true, the plugin exposes its operations as MCP tools. |
+| `base_url` | string | Base URL for declarative REST operations. |
+| `headers` | map[string]string | Static headers injected into every outbound request. |
+| `operations` | ProviderOperation[] | Declarative REST operations. Presence of this field makes the plugin declarative. |
+| `default_connection` | string | Name of the connection to use when none is specified. |
+
+### Connections
+
+The `connections` map defines named connection profiles. Each connection has a `mode` and an `auth` block.
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `mode` | string | One of `none`, `user`, `identity`, `either`. |
+| `auth` | ProviderAuth | Authentication configuration for this connection. |
+
+Only the `default` connection may define `connection_params` and `post_connect_discovery`.
+
+### Surfaces
+
+Surfaces load operation catalogs from external specifications. The following top-level `plugin` fields configure surfaces:
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `openapi` | string | Path to a bundled OpenAPI document. |
+| `openapi_connection` | string | Connection name used for OpenAPI calls. |
+| `graphql_url` | string | URL of the upstream GraphQL endpoint. |
+| `graphql_connection` | string | Connection name used for GraphQL calls. |
+| `mcp_url` | string | URL of the upstream MCP server. |
+| `mcp_connection` | string | Connection name used for MCP calls. |
+
+The `rest`/`openapi`/`graphql` surface types are mutually exclusive (use `openapi` or `graphql_url`, not both), but `mcp_url` may be combined with any of them.
+
+### Auth Types
+
+The `auth.type` field on a connection accepts these values:
+
+| Type | Purpose |
 | --- | --- |
-| `source` | Canonical plugin source identifier. Required. Use `github.com/<org>/<repo>/<path-after-repo>`. The final path segment remains the plugin name; any preceding segments are preserved for release tags and source resolution. |
-| `version` | Plugin version. Required. |
-| `display_name` | Human-readable label. |
-| `description` | Human-readable description. |
-| `icon_file` | Relative path to an SVG icon bundled with the package. |
-| `provider` | Provider metadata and optional declarative surfaces. |
-| `webui` | UI metadata for UI-only packages. |
-| `artifacts` | Packaged executable artifacts keyed by platform. Linux artifacts may also set `libc` to distinguish `glibc` and `musl` builds. Source manifests used for local development or `plugin release` may omit them for pure executable providers. |
+| `oauth2` | Standard OAuth 2.0. Requires `authorization_url` and `token_url`. |
+| `mcp_oauth` | MCP-native OAuth. The plugin must also declare `mcp_url` (either directly or via a surface). A manifest that uses `mcp_oauth` without an MCP surface fails validation. |
+| `bearer` | Static bearer token. Define `credentials` to prompt the user for the token value. |
+| `manual` | Custom credential fields. Define `credentials` to describe each field. |
+| `none` | No authentication. |
 
-## Basic manifest
+### Pagination
 
-This example is a declarative-only provider package. It does not need a binary.
+Plugin-level pagination configuration applies to all operations by default. Individual operations can override this through `allowed_operations`.
 
-<Tabs items={['YAML', 'JSON']}>
-  <Tabs.Tab>
-    ```yaml
-    source: github.com/acme/plugins/support-api
-    version: 0.0.1-alpha.1
-    display_name: Support API
-    description: Small ticket API
-    icon_file: assets/icon.svg
-    provider:
-      connections:
-        default:
-          auth:
-            type: bearer
-            credentials:
-              - name: token
-                label: API Token
-      surfaces:
-        rest:
-          base_url: https://api.support.example.com
-          operations:
-            - name: list_tickets
-              description: Return open tickets
-              method: GET
-              path: /tickets
-            - name: get_ticket
-              description: Return one ticket
-              method: GET
-              path: /tickets/{ticket_id}
-    ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ```json
-    {
-      "source": "github.com/acme/plugins/support-api",
-      "version": "0.0.1-alpha.1",
-      "display_name": "Support API",
-      "description": "Small ticket API",
-      "icon_file": "assets/icon.svg",
-      "provider": {
-        "connections": {
-          "default": {
-            "auth": {
-              "type": "bearer",
-              "credentials": [
-                { "name": "token", "label": "API Token" }
-              ]
-            }
-          }
-        },
-        "surfaces": {
-          "rest": {
-            "base_url": "https://api.support.example.com",
-            "operations": [
-              {
-                "name": "list_tickets",
-                "description": "Return open tickets",
-                "method": "GET",
-                "path": "/tickets"
-              },
-              {
-                "name": "get_ticket",
-                "description": "Return one ticket",
-                "method": "GET",
-                "path": "/tickets/{ticket_id}"
-              }
-            ]
-          }
-        }
-      }
-    }
-    ```
-  </Tabs.Tab>
-</Tabs>
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `style` | string | Required. One of `cursor`, `offset`, `page`. |
+| `cursor_param` | string | Query parameter name for the cursor value. |
+| `cursor_path` | string | JSON path to the next-cursor value in the response. |
+| `limit_param` | string | Query parameter name for page size. |
+| `default_limit` | int | Default page size when the caller does not specify one. |
+| `results_path` | string | JSON path to the array of results in the response. |
+| `max_pages` | int | Maximum number of pages to fetch in a single paginated request. |
 
-Use this style when the provider can be described entirely in YAML, requires no custom code, and you want a reusable package that several configs can import.
+```yaml
+plugin:
+  pagination:
+    style: cursor
+    cursor_param: starting_after
+    cursor_path: next_cursor
+    limit_param: limit
+    default_limit: 100
+    max_pages: 10
+```
 
-## Advanced manifest
+### Allowed Operations
 
-This example shows a provider package with a config schema, an executable entrypoint, OpenAPI and upstream MCP surfaces, managed parameters, allowed operation aliases, and multiple connections.
+The `allowed_operations` map selectively exposes and customizes operations from a spec-loaded surface. Keys are the original operation IDs from the OpenAPI/GraphQL/MCP spec.
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `alias` | string | Rename the operation for Gestalt consumers. |
+| `description` | string | Override the operation description. |
+| `paginate` | bool | Enable automatic pagination for this operation. Uses the plugin-level pagination config. |
+| `pagination` | ManifestPaginationConfig | Per-operation pagination config that overrides the plugin-level default. |
+
+```yaml
+plugin:
+  allowed_operations:
+    tickets.list:
+      alias: list_tickets
+      paginate: true
+    tickets.get:
+      alias: get_ticket
+```
+
+### Response Mapping
+
+The `response_mapping` block extracts a data array and pagination metadata from API responses that wrap results in an envelope.
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `data_path` | string | Required. JSON path to the results array. |
+| `pagination.has_more_path` | string | JSON path to a boolean indicating more pages exist. |
+| `pagination.cursor_path` | string | JSON path to the next-page cursor value. |
+
+### Managed Parameters
+
+Managed parameters inject fixed values into every request, removing them from the caller-facing operation signature.
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `in` | string | Required. One of `header`, `path`. |
+| `name` | string | Required. Parameter name. |
+| `value` | string | Required. Fixed value. |
+
+### Post-Connect Discovery
+
+The `post_connect_discovery` block performs an authenticated lookup immediately after a connection is established. Gestalt calls the configured URL with the new access token, parses the response, and turns each item into a candidate connection.
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `url` | string | Required. Endpoint to call after connect. |
+| `id_path` | string | JSON path to the item identifier. |
+| `name_path` | string | JSON path to the item display name. |
+| `metadata_mapping` | map[string]string | Maps connection parameter names to JSON paths in each discovered item. |
+
+If discovery returns exactly one item, Gestalt merges its metadata into the stored connection automatically. Multiple items prompt the user to choose. Zero items fails the connection.
+
+### Connection Params
+
+The `connection_params` map on the `default` connection defines parameters that are populated during or after connect rather than from user input.
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `required` | bool | Whether the parameter must be present for a valid connection. |
+| `description` | string | Describes the parameter to the user. |
+| `from` | string | Set to `discovery` to populate the value from post-connect discovery metadata. |
+
+## Auth Provider Metadata
+
+The `auth` block describes a platform auth provider package.
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `config_schema_path` | string | Path to a JSON/YAML schema that validates the `auth.config` block in the server config. |
+
+Auth providers require an executable entrypoint. Declare it under `entrypoints.auth`.
+
+```yaml
+source: github.com/valon-technologies/gestalt-providers/auth-google
+version: 1.0.0
+display_name: Google Auth
+auth:
+  config_schema_path: schemas/config.schema.json
+entrypoints:
+  auth:
+    artifact_path: artifacts/linux/amd64/auth
+artifacts:
+  - os: linux
+    arch: amd64
+    path: artifacts/linux/amd64/auth
+```
+
+## Datastore Provider Metadata
+
+The `datastore` block describes a persistence backend package.
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `config_schema_path` | string | Path to a JSON/YAML schema that validates the `datastore.config` block in the server config. |
+
+Datastore providers require an executable entrypoint. Declare it under `entrypoints.datastore`.
+
+```yaml
+source: github.com/valon-technologies/gestalt-providers/datastore-postgres
+version: 1.0.0
+display_name: PostgreSQL
+datastore:
+  config_schema_path: schemas/config.schema.json
+entrypoints:
+  datastore:
+    artifact_path: artifacts/linux/amd64/datastore
+artifacts:
+  - os: linux
+    arch: amd64
+    path: artifacts/linux/amd64/datastore
+```
+
+## Web UI Metadata
+
+The `webui` block describes a static UI package.
+
+| Field | Type | Required | Purpose |
+| --- | --- | --- | --- |
+| `asset_root` | string | yes | Directory containing the built static assets. |
+
+```yaml
+source: github.com/acme/plugins/gestalt-ui
+version: 1.0.0
+display_name: Custom UI
+webui:
+  asset_root: ui/out
+```
+
+## Artifacts
+
+The `artifacts` array lists platform-specific binaries included in the package.
+
+| Field | Type | Required | Purpose |
+| --- | --- | --- | --- |
+| `os` | string | yes | Target operating system (e.g. `linux`, `darwin`). |
+| `arch` | string | yes | Target architecture (e.g. `amd64`, `arm64`). |
+| `libc` | string | no | C library variant. Either `glibc` or `musl`. Only relevant for Linux. |
+| `path` | string | yes | Path to the binary inside the package. |
+| `sha256` | string | no | SHA-256 hex digest for integrity verification. |
+
+Declarative-only plugin packages do not require `artifacts`. Pure executable source manifests used with `plugins.*.plugin.source.path` or `gestaltd plugin release` may omit them.
+
+## Full Example
+
+This manifest shows an integration plugin with an executable entrypoint, multiple connections, OpenAPI and MCP surfaces, pagination, allowed operations, and managed parameters.
 
 <Tabs items={['YAML', 'JSON']}>
   <Tabs.Tab>
@@ -113,10 +292,8 @@ This example shows a provider package with a config schema, an executable entryp
     display_name: Support
     description: Tickets, knowledge base, and MCP workspace tools
     icon_file: assets/icon.svg
-    provider:
+    plugin:
       config_schema_path: schemas/config.schema.yaml
-      exec:
-        artifact_path: artifacts/linux/amd64/provider
       headers:
         X-App-Version: "2026-04-01"
       managed_parameters:
@@ -135,36 +312,45 @@ This example shows a provider package with a config schema, an executable entryp
             scopes:
               - tickets.read
               - tickets.write
-          params:
-            workspace_id:
-              required: true
-              from: discovery
-          discovery:
-            url: https://api.support.example.com/workspaces
-            id_path: id
-            name_path: name
-            metadata:
-              workspace_id: id
         mcp:
           mode: user
           auth:
             type: mcp_oauth
-      surfaces:
-        openapi:
-          document: openapi.yaml
-        mcp:
-          url: https://mcp.support.example.com/mcp
-          connection: mcp
+      connection_params:
+        workspace_id:
+          required: true
+          from: discovery
+      post_connect_discovery:
+        url: https://api.support.example.com/workspaces
+        id_path: id
+        name_path: name
+        metadata_mapping:
+          workspace_id: id
+      openapi: openapi.yaml
+      openapi_connection: default
+      mcp_url: https://mcp.support.example.com/mcp
+      mcp_connection: mcp
+      pagination:
+        style: cursor
+        cursor_param: starting_after
+        cursor_path: next_cursor
+        limit_param: limit
+        default_limit: 50
+        max_pages: 5
       allowed_operations:
         tickets.list:
           alias: list_tickets
+          paginate: true
         tickets.get:
           alias: get_ticket
+    entrypoints:
+      plugin:
+        artifact_path: artifacts/linux/amd64/plugin
     artifacts:
       - os: linux
         arch: amd64
         libc: glibc
-        path: artifacts/linux/amd64/provider
+        path: artifacts/linux/amd64/plugin
         sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     ```
   </Tabs.Tab>
@@ -176,11 +362,8 @@ This example shows a provider package with a config schema, an executable entryp
       "display_name": "Support",
       "description": "Tickets, knowledge base, and MCP workspace tools",
       "icon_file": "assets/icon.svg",
-      "provider": {
+      "plugin": {
         "config_schema_path": "schemas/config.schema.yaml",
-        "exec": {
-          "artifact_path": "artifacts/linux/amd64/provider"
-        },
         "headers": {
           "X-App-Version": "2026-04-01"
         },
@@ -197,15 +380,6 @@ This example shows a provider package with a config schema, an executable entryp
               "client_id": "${SUPPORT_CLIENT_ID}",
               "client_secret": "${SUPPORT_CLIENT_SECRET}",
               "scopes": ["tickets.read", "tickets.write"]
-            },
-            "params": {
-              "workspace_id": { "required": true, "from": "discovery" }
-            },
-            "discovery": {
-              "url": "https://api.support.example.com/workspaces",
-              "id_path": "id",
-              "name_path": "name",
-              "metadata": { "workspace_id": "id" }
             }
           },
           "mcp": {
@@ -213,143 +387,88 @@ This example shows a provider package with a config schema, an executable entryp
             "auth": { "type": "mcp_oauth" }
           }
         },
-        "surfaces": {
-          "openapi": { "document": "openapi.yaml" },
-          "mcp": {
-            "url": "https://mcp.support.example.com/mcp",
-            "connection": "mcp"
-          }
+        "connection_params": {
+          "workspace_id": { "required": true, "from": "discovery" }
+        },
+        "post_connect_discovery": {
+          "url": "https://api.support.example.com/workspaces",
+          "id_path": "id",
+          "name_path": "name",
+          "metadata_mapping": { "workspace_id": "id" }
+        },
+        "openapi": "openapi.yaml",
+        "openapi_connection": "default",
+        "mcp_url": "https://mcp.support.example.com/mcp",
+        "mcp_connection": "mcp",
+        "pagination": {
+          "style": "cursor",
+          "cursor_param": "starting_after",
+          "cursor_path": "next_cursor",
+          "limit_param": "limit",
+          "default_limit": 50,
+          "max_pages": 5
         },
         "allowed_operations": {
-          "tickets.list": { "alias": "list_tickets" },
+          "tickets.list": { "alias": "list_tickets", "paginate": true },
           "tickets.get": { "alias": "get_ticket" }
         }
       },
-        "artifacts": [
-          {
-            "os": "linux",
-            "arch": "amd64",
-            "libc": "glibc",
-            "path": "artifacts/linux/amd64/provider",
-            "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-          }
+      "entrypoints": {
+        "plugin": {
+          "artifact_path": "artifacts/linux/amd64/plugin"
+        }
+      },
+      "artifacts": [
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "libc": "glibc",
+          "path": "artifacts/linux/amd64/plugin",
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        }
       ]
     }
     ```
   </Tabs.Tab>
 </Tabs>
 
-Use this style when the provider includes executable logic, should ship its own connection model as a reusable package, or combines custom code with spec-backed operations.
+## Declarative-Only Example
 
-When an executable provider defines helper operations in Go, Gestalt
-materializes that executable catalog automatically during local source-plugin
-execution and package/release. See [Writing a Plugin](/plugins/writing-a-plugin)
-for the end-to-end authoring flow.
+This plugin requires no binary. It defines REST operations entirely in the manifest.
 
-## Post-Connect Discovery
+```yaml
+source: github.com/acme/plugins/support-api
+version: 0.0.1-alpha.1
+display_name: Support API
+description: Small ticket API
+icon_file: assets/icon.svg
+plugin:
+  auth:
+    type: bearer
+    credentials:
+      - name: token
+        label: API Token
+  base_url: https://api.support.example.com
+  operations:
+    - name: list_tickets
+      description: Return open tickets
+      method: GET
+      path: /tickets
+    - name: get_ticket
+      description: Return one ticket
+      method: GET
+      path: /tickets/{ticket_id}
+```
 
-Providers can define `provider.connections.default.discovery` to perform one
-extra authenticated lookup immediately after OAuth or manual connect succeeds.
-Gestalt calls the configured URL with the freshly acquired access token, parses
-the returned items, and turns them into candidate connections.
+## Authoring Notes
 
-Use this when a provider issues user credentials first, but the final stored
-connection still needs one discovered identifier such as a site, tenant, or
-workspace.
+Manifest paths must stay inside the package. `source` and `version` are required. A manifest defines exactly one of `plugin`, `auth`, `datastore`, or `webui`.
 
-<Tabs items={['YAML', 'JSON']}>
-  <Tabs.Tab>
-    ```yaml
-    provider:
-      connections:
-        default:
-          auth:
-            type: oauth2
-            authorization_url: https://auth.example.com/authorize
-            token_url: https://auth.example.com/token
-          params:
-            workspace_id:
-              required: true
-              description: Workspace identifier discovered after connect
-              from: discovery
-          discovery:
-            url: https://api.example.com/me/workspaces
-            id_path: id
-            name_path: display_name
-            metadata:
-              workspace_id: id
-    ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ```json
-    {
-      "provider": {
-        "connections": {
-          "default": {
-            "auth": {
-              "type": "oauth2",
-              "authorization_url": "https://auth.example.com/authorize",
-              "token_url": "https://auth.example.com/token"
-            },
-            "params": {
-              "workspace_id": {
-                "required": true,
-                "description": "Workspace identifier discovered after connect",
-                "from": "discovery"
-              }
-            },
-            "discovery": {
-              "url": "https://api.example.com/me/workspaces",
-              "id_path": "id",
-              "name_path": "display_name",
-              "metadata": { "workspace_id": "id" }
-            }
-          }
-        }
-      }
-    }
-    ```
-  </Tabs.Tab>
-</Tabs>
+`config_schema_path` validates per-plugin config and may be written in JSON or YAML. Only the `default` connection may define `connection_params` and `post_connect_discovery`. The OpenAPI/GraphQL surface types are mutually exclusive, but MCP may be added alongside either.
 
-If discovery returns exactly one item, Gestalt merges its mapped metadata into the stored connection automatically. If discovery returns multiple items, Gestalt asks the user to choose one. If discovery returns zero items, connect fails.
+A connection using `mcp_oauth` auth requires the plugin to declare an MCP surface (via `mcp_url` or an equivalent). Manifests that set `auth.type: mcp_oauth` without an MCP surface fail validation.
 
-`metadata` populates connection metadata, and connection fields marked
-with `from: discovery` are satisfied from that metadata instead of user input.
-
-## Web UI manifest
-
-<Tabs items={['YAML', 'JSON']}>
-  <Tabs.Tab>
-    ```yaml
-    source: github.com/acme/plugins/gestalt-ui
-    version: 1.0.0
-    display_name: Custom UI
-    webui:
-      asset_root: ui/out
-    ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-    ```json
-    {
-      "source": "github.com/acme/plugins/gestalt-ui",
-      "version": "1.0.0",
-      "display_name": "Custom UI",
-      "webui": {
-        "asset_root": "ui/out"
-      }
-    }
-    ```
-  </Tabs.Tab>
-</Tabs>
-
-## Authoring notes
-
-Manifest paths must stay inside the package. `source` and `version` are required, and a manifest defines either `provider` or `webui`, not both.
-
-Declarative-only provider packages do not require `artifacts`. Pure executable source manifests used with `plugins.*.provider.source.path` or `gestaltd plugin release` may omit `artifacts` and `provider.exec.artifact_path`, but executable provider packages do require both.
-
-`config_schema_path` validates `providers.*.config` and may be written in JSON or YAML. Only `provider.connections.default` may define `params` and `discovery`. The surface types `rest`, `openapi`, and `graphql` are mutually exclusive, but `mcp` may be added alongside any of them.
+When an executable plugin defines helper operations in Go or Python, Gestalt materializes the executable catalog automatically during local source-plugin execution and `plugin release`. See [Writing a Plugin](/plugins/writing-a-plugin) for the end-to-end authoring flow.
 
 ## Release
 
@@ -359,12 +478,4 @@ Build a release from a plugin source directory:
 gestaltd plugin release --version 1.2.3
 ```
 
-`gestaltd plugin release` preserves the source manifest format, so
-`plugin.yaml` stays YAML and `plugin.json` stays JSON in the release archive.
-For executable Go plugins, release materializes the executable catalog
-automatically from the provider's typed router before packaging. For Python
-source plugins, release loads the module declared in `[tool.gestalt].plugin`,
-materializes the executable catalog automatically. Go and Python source plugins
-both build the host-platform artifact by default. Pass `--platform` for an
-explicit `os/arch[/libc]` target list, or `--platform all` in CI to build the
-full supported release matrix.
+`gestaltd plugin release` preserves the source manifest format, so `plugin.yaml` stays YAML and `plugin.json` stays JSON in the release archive. For executable Go plugins, release materializes the executable catalog automatically from the provider's typed router before packaging. For Python source plugins, release loads the module declared in `[tool.gestalt].plugin` and materializes the executable catalog automatically. Go and Python source plugins both build the host-platform artifact by default. Pass `--platform` for an explicit `os/arch[/libc]` target list, or `--platform all` in CI to build the full supported release matrix.

--- a/docs/content/troubleshooting.mdx
+++ b/docs/content/troubleshooting.mdx
@@ -6,17 +6,17 @@ When `gestaltd serve --locked` reports that prepared artifacts are missing or st
 
 The validation error `server.encryption_key is required` means the config is missing its root deployment secret. Set `server.encryption_key` to a `secret://` reference or other secret-backed value. The encryption key is used for token encryption and derived session material, so the server refuses to start without it.
 
-Set `server.encryption_key` for every real deployment. Gestalt derives token and session encryption from it even when you use the built-in auth and datastore provider binaries.
+Set `server.encryption_key` for every real deployment. Gestalt derives token and session encryption from it regardless of which auth and datastore plugins you use.
 
-If the `/mcp` endpoint is not mounted, the server found no provider that exposes tools. At least one integration must surface operations through inline declarative REST, OpenAPI, GraphQL, upstream MCP, or an MCP-enabled packaged provider before `/mcp` becomes available.
+If the `/mcp` endpoint is not mounted, the server found no plugin that exposes tools. At least one integration plugin must surface MCP-visible operations before `/mcp` becomes available.
 
-When `/ready` returns `503`, the server has not finished initialization. Readiness stays false until all configured providers finish loading and the datastore answers a ping. Check server logs for provider bootstrap errors or datastore connectivity problems.
+When `/ready` returns `503`, the server has not finished initialization. Readiness stays false until all configured plugins finish loading and the datastore answers a ping. Check server logs for plugin bootstrap errors or datastore connectivity problems.
 
 ## Operation invocation
 
-A "provider not found" error means the integration key in the request does not match any entry in the `plugins` config map. Verify the spelling and confirm the provider loaded without errors at startup.
+A "provider not found" error means the integration key in the request does not match any entry in the `plugins` config map. Verify the spelling and confirm the plugin loaded without errors at startup.
 
-An "operation not found" error means the operation ID does not exist in the provider's catalog. Check that the surface exposes the operation and that `allowed_operations`, if set, includes it.
+An "operation not found" error means the operation ID does not exist in the plugin's catalog. Check that the operation is exposed and that `allowed_operations`, if set, includes it.
 
 A "not authenticated" error on an API or MCP request means no valid session or API token was presented. Log in through the web UI or pass a bearer token in the `Authorization` header.
 
@@ -38,7 +38,7 @@ A "failed to reach" error means the outbound connection could not be established
 
 When a plugin fails to start, check that the binary exists at the expected path, is executable, and that any required runtime dependencies are available. For Python source plugins, verify the virtualenv is intact and the module declared in `[tool.gestalt].plugin` is importable. Plugin startup errors appear in the server log with the provider name.
 
-A sandbox 403 means the plugin made an outbound request to a host not listed in `provider.allowed_hosts`. Add every upstream domain the plugin contacts to the allowlist in your plugin config.
+A sandbox 403 means the plugin made an outbound request to a host not listed in `plugin.allowed_hosts`. Add every upstream domain the plugin contacts to the allowlist in your plugin config.
 
 An input decode error means the operation received a request body that does not match the expected schema. Check the operation's parameter definitions and ensure the caller is sending the correct types and required fields.
 
@@ -48,6 +48,6 @@ An invocation depth error means a plugin-to-plugin call chain exceeded the maxim
 
 ## Connections
 
-When an integration requires an explicit connection, the provider has more than one configured connection and no default. Set `surfaces.*.connection` in the provider config when there is no `connections.default`, or pass `_connection` on the invocation request, or use `--connection` in the client CLI.
+When an integration requires an explicit connection, the plugin has more than one configured connection and no default. Pass `_connection` on the invocation request or use `--connection` in the client CLI to disambiguate.
 
 If a managed path parameter still appears in the operation schema, the operation path template does not contain the expected placeholder. Verify that the path includes the parameter in braces, such as `/workspaces/{workspace_id}/tickets`, rather than omitting it.


### PR DESCRIPTION
Gestalt's architecture changed so that auth, datastore, and integrations all run as external plugins with the same gRPC runtime. The config top-level key is now plugins instead of providers, and auth/datastore use full plugin references instead of simple string names. This rewrites the documentation from the ground up to match the new model.

The core pages (configuration, config-file reference, getting-started, first-party providers, and plugin manifests) were rewritten from scratch against the current source. Supporting pages were updated for correct terminology and new features like partial prefix matching for invoke, structured auth status output, declarative auto-pagination, and MCP OAuth. The CLI client now uses a universal config path at ~/.config/gestalt/ across all platforms.