### PR TITLE
Support secret refs in source auth

### DIFF
--- a/gestaltd/cmd/gestaltd/init.go
+++ b/gestaltd/cmd/gestaltd/init.go
@@ -1,13 +1,18 @@
 package main
 
 import (
+	"context"
+
+	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/operator"
 	github "github.com/valon-technologies/gestalt/server/internal/pluginsource/github"
 )
 
 func operatorLifecycle() *operator.Lifecycle {
-	return operator.NewLifecycle(&github.GitHubResolver{})
+	return operator.NewLifecycle(&github.GitHubResolver{}).WithConfigSecretResolver(func(ctx context.Context, cfg *config.Config) error {
+		return bootstrap.ResolveConfigSecrets(ctx, cfg, buildFactories())
+	})
 }
 
 func initConfigWithArtifactsDir(configFlag, artifactsDir string) error {

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -243,8 +243,30 @@ type preparedCore struct {
 	Deps          Deps
 }
 
-func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, requireEncryptionKey bool) (*preparedCore, error) {
+func prepareSecretManager(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) (core.SecretManager, error) {
 	sm, err := buildSecretManager(cfg, factories)
+	if err != nil {
+		return nil, err
+	}
+	if err := resolveSecretRefs(ctx, cfg, sm); err != nil {
+		_ = closeSecretManager(sm)
+		return nil, err
+	}
+	return sm, nil
+}
+
+// ResolveConfigSecrets resolves secret:// references in config using the
+// configured secrets provider, then closes the temporary secret manager.
+func ResolveConfigSecrets(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) error {
+	sm, err := prepareSecretManager(ctx, cfg, factories)
+	if err != nil {
+		return err
+	}
+	return closeSecretManager(sm)
+}
+
+func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, requireEncryptionKey bool) (*preparedCore, error) {
+	sm, err := prepareSecretManager(ctx, cfg, factories)
 	if err != nil {
 		return nil, err
 	}
@@ -254,10 +276,6 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 			_ = closeSecretManager(sm)
 		}
 	}()
-
-	if err := resolveSecretRefs(ctx, cfg, sm); err != nil {
-		return nil, err
-	}
 
 	tp, err := buildTelemetry(cfg, factories)
 	if err != nil {
@@ -509,6 +527,21 @@ func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretMa
 			}
 		}
 		cfg.Integrations[name] = intg
+	}
+	if cfg.Auth.Provider != nil {
+		if err := resolveStringFields(cfg.Auth.Provider, resolve); err != nil {
+			return err
+		}
+	}
+	if cfg.Datastore.Provider != nil {
+		if err := resolveStringFields(cfg.Datastore.Provider, resolve); err != nil {
+			return err
+		}
+	}
+	if cfg.UI.Plugin != nil {
+		if err := resolveStringFields(cfg.UI.Plugin, resolve); err != nil {
+			return err
+		}
 	}
 
 	// Skip cfg.Secrets.Config to avoid self-referential resolution.

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1144,9 +1144,6 @@ func validateExternalPlugin(kind, name string, plugin *PluginDef) error {
 		if strings.TrimSpace(plugin.Source.Auth.Token) == "" {
 			return fmt.Errorf("config validation: %s %q plugin.source.auth.token is required when plugin.source.auth is set", kind, name)
 		}
-		if strings.HasPrefix(plugin.Source.Auth.Token, "secret://") {
-			return fmt.Errorf("config validation: %s %q plugin.source.auth.token does not support secret:// references; use environment expansion instead", kind, name)
-		}
 	}
 
 	if kind != "integration" {

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -53,11 +53,17 @@ type LockProviderEntry = LockEntry
 type LockUIEntry = LockEntry
 
 type Lifecycle struct {
-	sourceResolver pluginsource.Resolver
+	sourceResolver       pluginsource.Resolver
+	configSecretResolver func(context.Context, *config.Config) error
 }
 
 func NewLifecycle(sourceResolver pluginsource.Resolver) *Lifecycle {
 	return &Lifecycle{sourceResolver: sourceResolver}
+}
+
+func (l *Lifecycle) WithConfigSecretResolver(resolve func(context.Context, *config.Config) error) *Lifecycle {
+	l.configSecretResolver = resolve
+	return l
 }
 
 func (l *Lifecycle) InitAtPath(configPath string) (*Lockfile, error) {
@@ -71,6 +77,9 @@ func (l *Lifecycle) InitAtPathWithArtifactsDir(configPath, artifactsDir string) 
 	}
 	if err := config.OverlayManagedPluginConfig(configPath, cfg); err != nil {
 		return nil, fmt.Errorf("loading config: %v", err)
+	}
+	if err := l.resolveConfigSecrets(context.Background(), cfg); err != nil {
+		return nil, err
 	}
 
 	paths := initPathsForConfigWithArtifactsDir(configPath, resolveArtifactsDir(configPath, cfg, artifactsDir))
@@ -136,6 +145,9 @@ func (l *Lifecycle) LoadForExecutionAtPathWithArtifactsDir(configPath, artifacts
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading config: %v", err)
 	}
+	if err := l.resolveConfigSecrets(context.Background(), cfg); err != nil {
+		return nil, nil, err
+	}
 	if err := config.ValidateRuntime(cfg); err != nil {
 		return nil, nil, err
 	}
@@ -148,6 +160,16 @@ func (l *Lifecycle) LoadForExecutionAtPathWithArtifactsDir(configPath, artifacts
 	}
 
 	return cfg, nil, nil
+}
+
+func (l *Lifecycle) resolveConfigSecrets(ctx context.Context, cfg *config.Config) error {
+	if l.configSecretResolver == nil {
+		return nil
+	}
+	if err := l.configSecretResolver(ctx, cfg); err != nil {
+		return fmt.Errorf("resolving config secrets: %w", err)
+	}
+	return config.ValidateStructure(cfg)
 }
 
 type initPaths struct {

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -15,11 +15,15 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/valon-technologies/gestalt/server/core"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/pluginpkg"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
 	ghresolver "github.com/valon-technologies/gestalt/server/internal/pluginsource/github"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -447,15 +451,17 @@ func TestSourceAuthPluginLoadForExecution(t *testing.T) {
 	}
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
-	yaml := strings.Join([]string{
+	configYAML := strings.Join([]string{
 		requiredDatastoreConfigYAML(t, dir, filepath.Join(dir, "data.db")),
+		"secrets:",
+		"  provider: test-secrets",
 		"auth:",
 		"  provider:",
 		"    source:",
 		"      ref: " + source,
 		"      version: " + version,
 		"      auth:",
-		"        token: ghp_inline_auth_source_token",
+		"        token: secret://source-token",
 		"  config:",
 		"    client_id: managed-auth-client",
 		"server:",
@@ -464,11 +470,20 @@ func TestSourceAuthPluginLoadForExecution(t *testing.T) {
 	}, "\n") + "\n"
 
 	configPath := filepath.Join(dir, "gestalt.yaml")
-	if err := os.WriteFile(configPath, []byte(yaml), 0644); err != nil {
+	if err := os.WriteFile(configPath, []byte(configYAML), 0644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
-	lc := NewLifecycle(resolver)
+	factories := bootstrap.NewFactoryRegistry()
+	factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+		return &coretesting.StubSecretManager{
+			Secrets: map[string]string{"source-token": "ghp_inline_auth_source_token"},
+		}, nil
+	}
+
+	lc := NewLifecycle(resolver).WithConfigSecretResolver(func(ctx context.Context, cfg *config.Config) error {
+		return bootstrap.ResolveConfigSecrets(ctx, cfg, factories)
+	})
 	lock, err := lc.InitAtPath(configPath)
 	if err != nil {
 		t.Fatalf("InitAtPath: %v", err)


### PR DESCRIPTION
## Summary
- allow `plugin.source.auth.token` to use `secret://...` references
- reuse Gestalt's existing secret resolution earlier in `init`/startup before managed source resolution
- keep coverage on the existing lifecycle source-auth path instead of adding new standalone tests

## Testing
- `go test ./internal/config -count=1`
- `go test ./internal/bootstrap -count=1`
- `go test ./internal/operator -count=1`
- `go test ./cmd/gestaltd -count=1`