### PR TITLE
Use shared selectors for declarative pagination and response mapping

### DIFF
--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -116,6 +116,215 @@ func TestE2EValidateRejectsInvalidAuditSettings(t *testing.T) {
 	}
 }
 
+func TestE2EDeclarativeSelectorsSupportHeaderPaginationAndResponseMapping(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	port := allocateTestPort(t)
+
+	var (
+		mu              sync.Mutex
+		paginationCalls []string
+	)
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/paginated-items":
+			cursor := r.URL.Query().Get("after_cursor")
+			mu.Lock()
+			paginationCalls = append(paginationCalls, cursor)
+			mu.Unlock()
+			if cursor == "" {
+				w.Header().Set("X-After-Cursor", "cursor-2")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"data": []any{
+						map[string]any{"id": "1"},
+						map[string]any{"id": "2"},
+					},
+				})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []any{
+					map[string]any{"id": "3"},
+				},
+			})
+		case "/mapped-items":
+			w.Header().Set("X-After-Cursor", "cursor-map")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"results": []any{
+					map[string]any{"id": "7"},
+				},
+				"moreDataAvailable": true,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	testutil.CloseOnCleanup(t, apiSrv)
+
+	pagerDir := filepath.Join(dir, "pager-plugin")
+	if err := os.MkdirAll(pagerDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll pager plugin: %v", err)
+	}
+	writeTestFile(t, pagerDir, "openapi.yaml", []byte(fmt.Sprintf(`openapi: 3.0.0
+info:
+  title: Pager
+  version: 1.0.0
+servers:
+  - url: %s
+paths:
+  /paginated-items:
+    get:
+      operationId: list_items
+      responses:
+        '200':
+          description: ok
+`, apiSrv.URL)), 0o644)
+	writeTestFile(t, pagerDir, "plugin.yaml", []byte(`
+source: github.com/test/plugins/pager
+version: 0.0.1-alpha.1
+display_name: Pager
+kinds:
+  - plugin
+plugin:
+  openapi: openapi.yaml
+  connection_mode: none
+  pagination:
+    style: cursor
+    cursor_param: after_cursor
+    cursor:
+      source: header
+      path: X-After-Cursor
+    results_path: data
+  allowed_operations:
+    list_items:
+      paginate: true
+`), 0o644)
+	pagerManifest, err := pluginpkg.FindManifestFile(pagerDir)
+	if err != nil {
+		t.Fatalf("FindManifestFile pager: %v", err)
+	}
+
+	mapperDir := filepath.Join(dir, "mapper-plugin")
+	if err := os.MkdirAll(mapperDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll mapper plugin: %v", err)
+	}
+	writeTestFile(t, mapperDir, "openapi.yaml", []byte(fmt.Sprintf(`openapi: 3.0.0
+info:
+  title: Mapper
+  version: 1.0.0
+servers:
+  - url: %s
+paths:
+  /mapped-items:
+    get:
+      operationId: list_items
+      responses:
+        '200':
+          description: ok
+`, apiSrv.URL)), 0o644)
+	writeTestFile(t, mapperDir, "plugin.yaml", []byte(`
+source: github.com/test/plugins/mapper
+version: 0.0.1-alpha.1
+display_name: Mapper
+kinds:
+  - plugin
+plugin:
+  openapi: openapi.yaml
+  connection_mode: none
+  response_mapping:
+    data_path: results
+    pagination:
+      has_more:
+        source: body
+        path: moreDataAvailable
+      cursor:
+        source: header
+        path: X-After-Cursor
+`), 0o644)
+	mapperManifest, err := pluginpkg.FindManifestFile(mapperDir)
+	if err != nil {
+		t.Fatalf("FindManifestFile mapper: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := authDatastoreConfigYAML(t, dir, "", "sqlite", filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`server:
+  port: %d
+  encryption_key: test-e2e-key
+plugins:
+  pager:
+    provider:
+      source:
+        path: %s
+  mapper:
+    provider:
+      source:
+        path: %s
+`, port, pagerManifest, mapperManifest)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
+		pagerReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/pager/list_items", strings.NewReader(`{}`))
+		pagerReq.Header.Set("Content-Type", "application/json")
+		pagerResp, err := http.DefaultClient.Do(pagerReq)
+		if err != nil {
+			t.Fatalf("invoke pager: %v", err)
+		}
+		defer func() { _ = pagerResp.Body.Close() }()
+		if pagerResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(pagerResp.Body)
+			t.Fatalf("pager status = %d: %s", pagerResp.StatusCode, body)
+		}
+
+		var pagerItems []map[string]any
+		if err := json.NewDecoder(pagerResp.Body).Decode(&pagerItems); err != nil {
+			t.Fatalf("decode pager response: %v", err)
+		}
+		if len(pagerItems) != 3 {
+			t.Fatalf("pager item count = %d, want 3", len(pagerItems))
+		}
+
+		mu.Lock()
+		gotCalls := append([]string(nil), paginationCalls...)
+		mu.Unlock()
+		if len(gotCalls) != 2 || gotCalls[0] != "" || gotCalls[1] != "cursor-2" {
+			t.Fatalf("pagination calls = %v, want [\"\", \"cursor-2\"]", gotCalls)
+		}
+
+		mapperReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/mapper/list_items", strings.NewReader(`{}`))
+		mapperReq.Header.Set("Content-Type", "application/json")
+		mapperResp, err := http.DefaultClient.Do(mapperReq)
+		if err != nil {
+			t.Fatalf("invoke mapper: %v", err)
+		}
+		defer func() { _ = mapperResp.Body.Close() }()
+		if mapperResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(mapperResp.Body)
+			t.Fatalf("mapper status = %d: %s", mapperResp.StatusCode, body)
+		}
+
+		var mapped struct {
+			Data       []map[string]any `json:"data"`
+			Pagination struct {
+				HasMore bool   `json:"has_more"`
+				Cursor  string `json:"cursor"`
+			} `json:"pagination"`
+		}
+		if err := json.NewDecoder(mapperResp.Body).Decode(&mapped); err != nil {
+			t.Fatalf("decode mapper response: %v", err)
+		}
+		if len(mapped.Data) != 1 || mapped.Data[0]["id"] != "7" {
+			t.Fatalf("mapped data = %+v, want single id=7 item", mapped.Data)
+		}
+		if !mapped.Pagination.HasMore || mapped.Pagination.Cursor != "cursor-map" {
+			t.Fatalf("mapped pagination = %+v", mapped.Pagination)
+		}
+	})
+}
+
 func TestE2EInitServeLockedGoldenPath(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/core/integration/response_mapping.go
+++ b/gestaltd/core/integration/response_mapping.go
@@ -9,9 +9,13 @@ import (
 )
 
 type ResponseMappingConfig struct {
-	DataPath              string
-	PaginationHasMorePath string
-	PaginationCursorPath  string
+	DataPath   string
+	Pagination *PaginationProjectionConfig
+}
+
+type PaginationProjectionConfig struct {
+	HasMore *apiexec.ValueSelector
+	Cursor  *apiexec.ValueSelector
 }
 
 func applyResponseMapping(result *core.OperationResult, cfg *ResponseMappingConfig) *core.OperationResult {
@@ -34,17 +38,13 @@ func applyResponseMapping(result *core.OperationResult, cfg *ResponseMappingConf
 		}
 	}
 
-	if cfg.PaginationHasMorePath != "" || cfg.PaginationCursorPath != "" {
+	if cfg.Pagination != nil {
 		pgn := make(map[string]any)
-		if cfg.PaginationHasMorePath != "" {
-			if v, ok := apiexec.ExtractJSONPath(raw, cfg.PaginationHasMorePath); ok {
-				pgn["has_more"] = v
-			}
+		if v, ok := apiexec.SelectValue(result, raw, cfg.Pagination.HasMore); ok {
+			pgn["has_more"] = v
 		}
-		if cfg.PaginationCursorPath != "" {
-			if v, ok := apiexec.ExtractJSONPath(raw, cfg.PaginationCursorPath); ok {
-				pgn["cursor"] = v
-			}
+		if v, ok := apiexec.SelectValue(result, raw, cfg.Pagination.Cursor); ok {
+			pgn["cursor"] = v
 		}
 		if len(pgn) > 0 {
 			output["pagination"] = pgn

--- a/gestaltd/core/integration/response_mapping_test.go
+++ b/gestaltd/core/integration/response_mapping_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/apiexec"
 )
 
 func TestResponseMappingExtractsDataAndPagination(t *testing.T) {
@@ -26,9 +28,17 @@ func TestResponseMappingExtractsDataAndPagination(t *testing.T) {
 		Auth:    mockAuth{},
 		BaseURL: srv.URL,
 		ResponseMapping: &ResponseMappingConfig{
-			DataPath:              "results",
-			PaginationHasMorePath: "moreDataAvailable",
-			PaginationCursorPath:  "nextCursor",
+			DataPath: "results",
+			Pagination: &PaginationProjectionConfig{
+				HasMore: &apiexec.ValueSelector{
+					Source: apiexec.ValueSelectorSourceBody,
+					Path:   "moreDataAvailable",
+				},
+				Cursor: &apiexec.ValueSelector{
+					Source: apiexec.ValueSelectorSourceBody,
+					Path:   "nextCursor",
+				},
+			},
 		},
 	}
 	setTestCatalog(b, restCatalogOp("list", http.MethodPost, "/list"))

--- a/gestaltd/internal/apiexec/pagination.go
+++ b/gestaltd/internal/apiexec/pagination.go
@@ -17,15 +17,23 @@ const (
 	PaginationStyleOffset = "offset"
 	PaginationStylePage   = "page"
 
+	ValueSelectorSourceBody   = "body"
+	ValueSelectorSourceHeader = "header"
+
 	defaultMaxPages    = 10
 	defaultStartPage   = 1
 	defaultStartOffset = 0
 )
 
+type ValueSelector struct {
+	Source string
+	Path   string
+}
+
 type PaginationConfig struct {
 	Style        string
 	CursorParam  string
-	CursorPath   string
+	Cursor       *ValueSelector
 	LimitParam   string
 	DefaultLimit int
 	ResultsPath  string
@@ -103,7 +111,7 @@ func doPaginated(ctx context.Context, client *http.Client, req Request, pgn Pagi
 
 		switch pgn.Style {
 		case PaginationStyleCursor:
-			cursor, ok := ExtractJSONPath(parsed, pgn.CursorPath)
+			cursor, ok := SelectValue(result, parsed, pgn.Cursor)
 			if !ok || cursor == nil {
 				return combinedResult(lastStatus, allResults)
 			}
@@ -140,6 +148,26 @@ func doPaginated(ctx context.Context, client *http.Client, req Request, pgn Pagi
 	}
 
 	return combinedResult(lastStatus, allResults)
+}
+
+func SelectValue(result *core.OperationResult, parsed any, selector *ValueSelector) (any, bool) {
+	if selector == nil || selector.Path == "" {
+		return nil, false
+	}
+	switch selector.Source {
+	case "", ValueSelectorSourceBody:
+		return ExtractJSONPath(parsed, selector.Path)
+	case ValueSelectorSourceHeader:
+		if result == nil {
+			return nil, false
+		}
+		if value := result.Headers.Get(selector.Path); value != "" {
+			return value, true
+		}
+		return nil, false
+	default:
+		return nil, false
+	}
 }
 
 func combinedResult(status int, results []any) (*core.OperationResult, error) {

--- a/gestaltd/internal/apiexec/pagination_test.go
+++ b/gestaltd/internal/apiexec/pagination_test.go
@@ -39,7 +39,10 @@ func TestDoPaginatedCursor(t *testing.T) {
 	}, PaginationConfig{
 		Style:       PaginationStyleCursor,
 		CursorParam: "cursor",
-		CursorPath:  "next_cursor",
+		Cursor: &ValueSelector{
+			Source: ValueSelectorSourceBody,
+			Path:   "next_cursor",
+		},
 		ResultsPath: "data",
 	})
 	if err != nil {
@@ -126,7 +129,10 @@ func TestDoPaginatedMaxPages(t *testing.T) {
 	}, PaginationConfig{
 		Style:       PaginationStyleCursor,
 		CursorParam: "cursor",
-		CursorPath:  "next_cursor",
+		Cursor: &ValueSelector{
+			Source: ValueSelectorSourceBody,
+			Path:   "next_cursor",
+		},
 		ResultsPath: "items",
 		MaxPages:    maxPages,
 	})
@@ -168,7 +174,10 @@ func TestDoPaginatedEmptyResults(t *testing.T) {
 	}, PaginationConfig{
 		Style:       PaginationStyleCursor,
 		CursorParam: "cursor",
-		CursorPath:  "next_cursor",
+		Cursor: &ValueSelector{
+			Source: ValueSelectorSourceBody,
+			Path:   "next_cursor",
+		},
 		ResultsPath: "data",
 	})
 	if err != nil {
@@ -208,9 +217,12 @@ func TestDoPaginatedCallerProvidedLimit(t *testing.T) {
 		Path:    "/items",
 		Params:  map[string]any{"per_page": callerLimit},
 	}, PaginationConfig{
-		Style:        PaginationStyleCursor,
-		CursorParam:  "cursor",
-		CursorPath:   "next_cursor",
+		Style:       PaginationStyleCursor,
+		CursorParam: "cursor",
+		Cursor: &ValueSelector{
+			Source: ValueSelectorSourceBody,
+			Path:   "next_cursor",
+		},
 		LimitParam:   "per_page",
 		DefaultLimit: 25,
 		ResultsPath:  "data",
@@ -296,7 +308,10 @@ func TestDoPaginatedNumericCursor(t *testing.T) {
 	}, PaginationConfig{
 		Style:       PaginationStyleCursor,
 		CursorParam: "cursor",
-		CursorPath:  "next_cursor",
+		Cursor: &ValueSelector{
+			Source: ValueSelectorSourceBody,
+			Path:   "next_cursor",
+		},
 		ResultsPath: "data",
 	})
 	if err != nil {
@@ -337,9 +352,12 @@ func TestDoPaginatedDoesNotMutateCallerParams(t *testing.T) {
 		Path:    "/items",
 		Params:  callerParams,
 	}, PaginationConfig{
-		Style:        PaginationStyleCursor,
-		CursorParam:  "cursor",
-		CursorPath:   "next_cursor",
+		Style:       PaginationStyleCursor,
+		CursorParam: "cursor",
+		Cursor: &ValueSelector{
+			Source: ValueSelectorSourceBody,
+			Path:   "next_cursor",
+		},
 		LimitParam:   "per_page",
 		DefaultLimit: 25,
 		ResultsPath:  "data",
@@ -392,7 +410,10 @@ func TestDoPaginatedNestedResultsPath(t *testing.T) {
 	}, PaginationConfig{
 		Style:       PaginationStyleCursor,
 		CursorParam: "cursor",
-		CursorPath:  "meta.next",
+		Cursor: &ValueSelector{
+			Source: ValueSelectorSourceBody,
+			Path:   "meta.next",
+		},
 		ResultsPath: "response.items",
 	})
 	if err != nil {

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1328,8 +1328,8 @@ func applyProviderResponseMapping(def *provider.Definition, manifestPlugin *plug
 	}
 	if manifestPlugin.ResponseMapping.Pagination != nil {
 		rm.Pagination = &provider.PaginationMappingDef{
-			HasMorePath: manifestPlugin.ResponseMapping.Pagination.HasMorePath,
-			CursorPath:  manifestPlugin.ResponseMapping.Pagination.CursorPath,
+			HasMore: cloneManifestValueSelectorDef(manifestPlugin.ResponseMapping.Pagination.HasMore),
+			Cursor:  cloneManifestValueSelectorDef(manifestPlugin.ResponseMapping.Pagination.Cursor),
 		}
 	}
 	def.ResponseMapping = rm
@@ -1351,7 +1351,7 @@ func applyProviderPagination(def *provider.Definition, manifestPlugin *pluginman
 		op.Pagination = &provider.PaginationDef{
 			Style:        pgn.Style,
 			CursorParam:  pgn.CursorParam,
-			CursorPath:   pgn.CursorPath,
+			Cursor:       cloneManifestValueSelectorDef(pgn.Cursor),
 			LimitParam:   pgn.LimitParam,
 			DefaultLimit: pgn.DefaultLimit,
 			ResultsPath:  pgn.ResultsPath,
@@ -1378,8 +1378,8 @@ func mergedPaginationConfig(base, override *pluginmanifestv1.ManifestPaginationC
 	if override.CursorParam != "" {
 		merged.CursorParam = override.CursorParam
 	}
-	if override.CursorPath != "" {
-		merged.CursorPath = override.CursorPath
+	if override.Cursor != nil {
+		merged.Cursor = cloneManifestValueSelector(override.Cursor)
 	}
 	if override.LimitParam != "" {
 		merged.LimitParam = override.LimitParam
@@ -1394,6 +1394,26 @@ func mergedPaginationConfig(base, override *pluginmanifestv1.ManifestPaginationC
 		merged.MaxPages = override.MaxPages
 	}
 	return &merged
+}
+
+func cloneManifestValueSelector(in *pluginmanifestv1.ManifestValueSelector) *pluginmanifestv1.ManifestValueSelector {
+	if in == nil {
+		return nil
+	}
+	return &pluginmanifestv1.ManifestValueSelector{
+		Source: in.Source,
+		Path:   in.Path,
+	}
+}
+
+func cloneManifestValueSelectorDef(in *pluginmanifestv1.ManifestValueSelector) *provider.ValueSelectorDef {
+	if in == nil {
+		return nil
+	}
+	return &provider.ValueSelectorDef{
+		Source: in.Source,
+		Path:   in.Path,
+	}
 }
 
 func firstProviderIconSVG(providers ...core.Provider) string {

--- a/gestaltd/internal/pluginpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/pluginpkg/manifest_workflow_test.go
@@ -315,7 +315,9 @@ provider:
   pagination:
     style: cursor
     cursor_param: cursor
-    cursor_path: nextCursor
+    cursor:
+      source: header
+      path: X-After-Cursor
     results_path: results
     max_pages: 10
   allowed_operations:
@@ -349,7 +351,7 @@ provider:
 	if manifest.Entrypoints.Provider != nil {
 		t.Fatalf("expected declarative/spec provider to omit provider entrypoint, got %+v", manifest.Entrypoints.Provider)
 	}
-	if pgn := manifest.Plugin.Pagination; pgn == nil || pgn.Style != "cursor" || pgn.CursorPath != "nextCursor" || pgn.MaxPages != 10 {
+	if pgn := manifest.Plugin.Pagination; pgn == nil || pgn.Style != "cursor" || pgn.Cursor == nil || pgn.Cursor.Source != "header" || pgn.Cursor.Path != "X-After-Cursor" || pgn.MaxPages != 10 {
 		t.Fatalf("unexpected pagination config: %+v", manifest.Plugin.Pagination)
 	}
 	if op := manifest.Plugin.AllowedOperations["items.list"]; op == nil || !op.Paginate {

--- a/gestaltd/internal/provider/build.go
+++ b/gestaltd/internal/provider/build.go
@@ -161,8 +161,10 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 			DataPath: def.ResponseMapping.DataPath,
 		}
 		if def.ResponseMapping.Pagination != nil {
-			rm.PaginationHasMorePath = def.ResponseMapping.Pagination.HasMorePath
-			rm.PaginationCursorPath = def.ResponseMapping.Pagination.CursorPath
+			rm.Pagination = &coreintegration.PaginationProjectionConfig{
+				HasMore: buildValueSelector(def.ResponseMapping.Pagination.HasMore),
+				Cursor:  buildValueSelector(def.ResponseMapping.Pagination.Cursor),
+			}
 		}
 		base.ResponseMapping = rm
 	}
@@ -427,7 +429,7 @@ func buildPaginationConfigs(def *Definition) map[string]apiexec.PaginationConfig
 		configs[name] = apiexec.PaginationConfig{
 			Style:        p.Style,
 			CursorParam:  p.CursorParam,
-			CursorPath:   p.CursorPath,
+			Cursor:       buildValueSelector(p.Cursor),
 			LimitParam:   p.LimitParam,
 			DefaultLimit: p.DefaultLimit,
 			ResultsPath:  p.ResultsPath,
@@ -435,6 +437,16 @@ func buildPaginationConfigs(def *Definition) map[string]apiexec.PaginationConfig
 		}
 	}
 	return configs
+}
+
+func buildValueSelector(def *ValueSelectorDef) *apiexec.ValueSelector {
+	if def == nil {
+		return nil
+	}
+	return &apiexec.ValueSelector{
+		Source: def.Source,
+		Path:   def.Path,
+	}
 }
 
 func resolveURL(baseURL, u string) string {

--- a/gestaltd/internal/provider/definition.go
+++ b/gestaltd/internal/provider/definition.go
@@ -97,14 +97,19 @@ type AuthMappingDef struct {
 	Headers map[string]string `yaml:"headers" json:"headers"`
 }
 
+type ValueSelectorDef struct {
+	Source string `yaml:"source" json:"source"`
+	Path   string `yaml:"path" json:"path"`
+}
+
 type PaginationDef struct {
-	Style        string `yaml:"style" json:"style"`
-	CursorParam  string `yaml:"cursor_param" json:"cursor_param"`
-	CursorPath   string `yaml:"cursor_path" json:"cursor_path"`
-	LimitParam   string `yaml:"limit_param" json:"limit_param"`
-	DefaultLimit int    `yaml:"default_limit" json:"default_limit"`
-	ResultsPath  string `yaml:"results_path" json:"results_path"`
-	MaxPages     int    `yaml:"max_pages" json:"max_pages"`
+	Style        string            `yaml:"style" json:"style"`
+	CursorParam  string            `yaml:"cursor_param" json:"cursor_param"`
+	Cursor       *ValueSelectorDef `yaml:"cursor" json:"cursor,omitempty"`
+	LimitParam   string            `yaml:"limit_param" json:"limit_param"`
+	DefaultLimit int               `yaml:"default_limit" json:"default_limit"`
+	ResultsPath  string            `yaml:"results_path" json:"results_path"`
+	MaxPages     int               `yaml:"max_pages" json:"max_pages"`
 }
 
 type CredentialFieldDef struct {
@@ -120,8 +125,8 @@ type ResponseMappingDef struct {
 }
 
 type PaginationMappingDef struct {
-	HasMorePath string `yaml:"has_more_path" json:"has_more_path"`
-	CursorPath  string `yaml:"cursor_path" json:"cursor_path"`
+	HasMore *ValueSelectorDef `yaml:"has_more" json:"has_more,omitempty"`
+	Cursor  *ValueSelectorDef `yaml:"cursor" json:"cursor,omitempty"`
 }
 
 type ParameterDef struct {

--- a/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -421,11 +421,11 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "has_more_path": {
-              "type": "string"
+            "has_more": {
+              "$ref": "#/$defs/value_selector"
             },
-            "cursor_path": {
-              "type": "string"
+            "cursor": {
+              "$ref": "#/$defs/value_selector"
             }
           }
         }
@@ -669,6 +669,27 @@
         }
       }
     },
+    "value_selector": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "path"
+      ],
+      "properties": {
+        "source": {
+          "type": "string",
+          "enum": [
+            "body",
+            "header"
+          ]
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
     "pagination_config": {
       "type": "object",
       "additionalProperties": false,
@@ -687,8 +708,8 @@
         "cursor_param": {
           "type": "string"
         },
-        "cursor_path": {
-          "type": "string"
+        "cursor": {
+          "$ref": "#/$defs/value_selector"
         },
         "limit_param": {
           "type": "string"

--- a/gestaltd/sdk/pluginmanifest/v1/types.go
+++ b/gestaltd/sdk/pluginmanifest/v1/types.go
@@ -88,9 +88,14 @@ type ManifestResponseMapping struct {
 	Pagination *ManifestPaginationMapping `json:"pagination,omitempty" yaml:"pagination,omitempty"`
 }
 
+type ManifestValueSelector struct {
+	Source string `json:"source" yaml:"source"`
+	Path   string `json:"path" yaml:"path"`
+}
+
 type ManifestPaginationMapping struct {
-	HasMorePath string `json:"has_more_path" yaml:"has_more_path"`
-	CursorPath  string `json:"cursor_path" yaml:"cursor_path"`
+	HasMore *ManifestValueSelector `json:"has_more,omitempty" yaml:"has_more,omitempty"`
+	Cursor  *ManifestValueSelector `json:"cursor,omitempty" yaml:"cursor,omitempty"`
 }
 
 type ProviderPostConnectDiscovery struct {
@@ -107,13 +112,13 @@ type ProviderConnectionParam struct {
 }
 
 type ManifestPaginationConfig struct {
-	Style        string `json:"style" yaml:"style"`
-	CursorParam  string `json:"cursor_param,omitempty" yaml:"cursor_param,omitempty"`
-	CursorPath   string `json:"cursor_path,omitempty" yaml:"cursor_path,omitempty"`
-	LimitParam   string `json:"limit_param,omitempty" yaml:"limit_param,omitempty"`
-	DefaultLimit int    `json:"default_limit,omitempty" yaml:"default_limit,omitempty"`
-	ResultsPath  string `json:"results_path,omitempty" yaml:"results_path,omitempty"`
-	MaxPages     int    `json:"max_pages,omitempty" yaml:"max_pages,omitempty"`
+	Style        string                 `json:"style" yaml:"style"`
+	CursorParam  string                 `json:"cursor_param,omitempty" yaml:"cursor_param,omitempty"`
+	Cursor       *ManifestValueSelector `json:"cursor,omitempty" yaml:"cursor,omitempty"`
+	LimitParam   string                 `json:"limit_param,omitempty" yaml:"limit_param,omitempty"`
+	DefaultLimit int                    `json:"default_limit,omitempty" yaml:"default_limit,omitempty"`
+	ResultsPath  string                 `json:"results_path,omitempty" yaml:"results_path,omitempty"`
+	MaxPages     int                    `json:"max_pages,omitempty" yaml:"max_pages,omitempty"`
 }
 
 type ManifestOperationOverride struct {


### PR DESCRIPTION
## Summary
- replace pagination- and response-mapping-specific cursor path fields with a shared value selector abstraction
- allow selectors to read values from either the response body or response headers
- use the new selector shape to support Modern Treasury's `X-After-Cursor` pagination model in declarative plugins
- cover the new behavior with a declarative `gestaltd` end-to-end test instead of adding more low-level selector-specific unit tests

## New Interfaces
```yaml
pagination:
  style: cursor
  cursor_param: after_cursor
  cursor:
    source: body | header
    path: <lookup>
  results_path: data
```

```yaml
response_mapping:
  data_path: results
  pagination:
    has_more:
      source: body | header
      path: <lookup>
    cursor:
      source: body | header
      path: <lookup>
```

## Example Usage
Header-based cursor pagination:

```yaml
pagination:
  style: cursor
  cursor_param: after_cursor
  cursor:
    source: header
    path: X-After-Cursor
  results_path: data
```

Mixed response mapping where the cursor comes from a header:

```yaml
response_mapping:
  data_path: results
  pagination:
    has_more:
      source: body
      path: moreDataAvailable
    cursor:
      source: header
      path: X-After-Cursor
```

## Why
Modern Treasury list endpoints return the next cursor in the `X-After-Cursor` response header rather than in the JSON body. `gestaltd` already supports declarative pagination and response mapping, but those paths only knew how to read values from the response body. This PR adds a shared selector primitive instead of another one-off pagination field.

## Testing
- `go test ./core/integration ./internal/apiexec ./internal/provider -count=1`
- `go test ./cmd/gestaltd -run TestE2EDeclarativeSelectorsSupportHeaderPaginationAndResponseMapping -count=1`

## Follow-up
Deployer-side static credential overrides for manual auth are handled separately in #731.
