### PR TITLE
[codex] Fix wrapped CLI login callback state

### DIFF
--- a/gestaltd/ui/e2e/auth.spec.ts
+++ b/gestaltd/ui/e2e/auth.spec.ts
@@ -8,6 +8,26 @@ import {
 
 const hasBackend = !!process.env.PLAYWRIGHT_BASE_URL;
 
+function encodeWrappedState(hostState: string): string {
+  return Buffer.from(
+    JSON.stringify({ host_state: hostState }),
+    "utf8",
+  ).toString("base64url");
+}
+
+async function seedOAuthState(
+  page: import("@playwright/test").Page,
+  oauthState?: string,
+) {
+  await page.addInitScript((state) => {
+    localStorage.clear();
+    sessionStorage.clear();
+    if (state) {
+      sessionStorage.setItem("oauth_state", state);
+    }
+  }, oauthState);
+}
+
 test.describe("Authentication", () => {
   test.skip(
     hasBackend,
@@ -225,11 +245,7 @@ gestaltd_operation_duration_seconds_count{gestalt_provider="slack",gestalt_opera
   test("auth callback rejects mismatched OAuth state (CSRF protection)", async ({
     page,
   }) => {
-    await page.addInitScript(() => {
-      localStorage.clear();
-      sessionStorage.clear();
-      sessionStorage.setItem("oauth_state", "correct-state");
-    });
+    await seedOAuthState(page, "correct-state");
 
     await page.goto("/auth/callback?code=test-code&state=wrong-state");
     await expect(page.getByText(/Invalid OAuth state/)).toBeVisible();
@@ -239,12 +255,79 @@ gestaltd_operation_duration_seconds_count{gestalt_provider="slack",gestalt_opera
   test("auth callback rejects when no OAuth state was saved (CSRF protection)", async ({
     page,
   }) => {
-    await page.addInitScript(() => {
-      localStorage.clear();
-      sessionStorage.clear();
-    });
+    await seedOAuthState(page);
     await page.goto("/auth/callback?code=attacker-code&state=attacker-state");
     await expect(page.getByText(/Invalid OAuth state/)).toBeVisible();
+  });
+
+  test("auth callback accepts wrapped host_state and completes login", async ({
+    page,
+  }) => {
+    const wrappedState = encodeWrappedState("correct-state");
+
+    await seedOAuthState(page, "correct-state");
+    await mockIntegrations(page, []);
+    await mockTokens(page, []);
+
+    let callbackState: string | null = null;
+    await page.route("**/api/v1/auth/login/callback?**", (route, request) => {
+      callbackState = new URL(request.url()).searchParams.get("state");
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          email: "test@gestalt.dev",
+          display_name: "Test User",
+        }),
+      });
+    });
+
+    await page.goto(`/auth/callback?code=test-code&state=${wrappedState}`);
+
+    await expect.poll(() => callbackState).toBe(wrappedState);
+    await expect(page).toHaveURL("/");
+    await expect(page.getByText("test@gestalt.dev")).toBeVisible();
+  });
+
+  test("auth callback redirects wrapped CLI state to the local listener", async ({
+    page,
+  }) => {
+    const port = 43123;
+    const cliState = "cli-original-state";
+    const wrappedState = encodeWrappedState(`cli:${port}:${cliState}`);
+
+    await seedOAuthState(page);
+
+    let localCallbackURL: string | null = null;
+    let serverCallbackCalled = false;
+
+    await page.route(`http://127.0.0.1:${port}/**`, (route, request) => {
+      localCallbackURL = request.url();
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: "<!doctype html><title>CLI callback</title><p>ok</p>",
+      });
+    });
+    await page.route("**/api/v1/auth/login/callback?**", (route) => {
+      serverCallbackCalled = true;
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          email: "unexpected@gestalt.dev",
+          display_name: "Unexpected",
+        }),
+      });
+    });
+
+    await page.goto(`/auth/callback?code=test-code&state=${wrappedState}`);
+
+    await expect(page).toHaveURL(new RegExp(`^http://127\\.0\\.0\\.1:${port}/\\?`));
+    await expect.poll(() => localCallbackURL).not.toBeNull();
+    expect(new URL(localCallbackURL!).searchParams.get("code")).toBe("test-code");
+    expect(new URL(localCallbackURL!).searchParams.get("state")).toBe(cliState);
+    expect(serverCallbackCalled).toBe(false);
   });
 
   test("401 response clears session and redirects to login", async ({

--- a/gestaltd/ui/src/app/auth/callback/page.tsx
+++ b/gestaltd/ui/src/app/auth/callback/page.tsx
@@ -5,6 +5,55 @@ import { useRouter } from "next/navigation";
 import { loginCallback } from "@/lib/api";
 import { setUserEmail } from "@/lib/auth";
 
+const CLI_STATE_PREFIX = "cli:";
+const CLI_CALLBACK_ORIGIN = "http://127.0.0.1";
+const MAX_PORT = 65535;
+
+type WrappedAuthState = {
+  host_state?: string;
+};
+
+function decodeWrappedHostState(state: string | null): string | null {
+  if (!state) {
+    return state;
+  }
+
+  try {
+    const padded = state
+      .replace(/-/g, "+")
+      .replace(/_/g, "/")
+      .padEnd(Math.ceil(state.length / 4) * 4, "=");
+    const binary = atob(padded);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    const parsed = JSON.parse(
+      new TextDecoder().decode(bytes),
+    ) as WrappedAuthState;
+    return typeof parsed.host_state === "string" && parsed.host_state.length > 0
+      ? parsed.host_state
+      : state;
+  } catch {
+    return state;
+  }
+}
+
+function getCliCallbackURL(state: string | null, code: string): string | null {
+  if (!state?.startsWith(CLI_STATE_PREFIX)) {
+    return null;
+  }
+
+  const [, rawPort, ...rest] = state.split(":");
+  const port = Number(rawPort);
+  const callbackState = rest.join(":");
+  if (!Number.isInteger(port) || port < 1 || port > MAX_PORT || !callbackState) {
+    return null;
+  }
+
+  return `${CLI_CALLBACK_ORIGIN}:${port}/?${new URLSearchParams({
+    code,
+    state: callbackState,
+  })}`;
+}
+
 export default function AuthCallbackPage() {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
@@ -12,7 +61,8 @@ export default function AuthCallbackPage() {
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const code = params.get("code");
-    const returnedState = params.get("state");
+    const rawState = params.get("state");
+    const hostState = decodeWrappedHostState(rawState);
     const savedState = sessionStorage.getItem("oauth_state");
 
     if (!code) {
@@ -20,35 +70,25 @@ export default function AuthCallbackPage() {
       return;
     }
 
-    // CLI-initiated login encodes callback port in state as "cli:{port}:{original_state}".
-    const CLI_STATE_PREFIX = "cli:";
-    const MAX_PORT = 65535;
-    if (returnedState?.startsWith(CLI_STATE_PREFIX)) {
-      const parts = returnedState.split(":");
-      if (parts.length >= 3) {
-        const port = parseInt(parts[1], 10);
-        const originalState = parts.slice(2).join(":");
-        if (port > 0 && port <= MAX_PORT) {
-          const redirectParams = new URLSearchParams({
-            state: originalState,
-            code,
-          });
-          window.location.href = `http://127.0.0.1:${port}/?${redirectParams}`;
-          return;
-        }
-      }
+    const cliCallbackURL = getCliCallbackURL(hostState, code);
+    if (cliCallbackURL) {
+      window.location.href = cliCallbackURL;
+      return;
+    }
+
+    if (hostState?.startsWith(CLI_STATE_PREFIX)) {
       setError("Invalid CLI callback state");
       return;
     }
 
-    if (!savedState || returnedState !== savedState) {
+    if (!savedState || hostState !== savedState) {
       setError("Invalid OAuth state — possible CSRF attack");
       return;
     }
 
     sessionStorage.removeItem("oauth_state");
 
-    loginCallback(code, returnedState ?? undefined)
+    loginCallback(code, rawState ?? undefined)
       .then((result) => {
         setUserEmail(result.email);
         router.replace("/");


### PR DESCRIPTION
## What changed
- decode wrapped OAuth callback state on the web auth callback page before deciding whether the flow is browser login or CLI login
- keep sending the original callback `state` value back to `/api/v1/auth/login/callback` so server-side plugin and upstream state handling still works
- add Playwright coverage for wrapped browser login state and wrapped CLI login state

## Why
CLI login state is prefixed as `cli:{port}:{state}` so the web callback page can bounce the browser back to the CLI's localhost listener. That worked when the browser saw the raw state value.

Some auth providers now wrap callback state in a base64url JSON payload with `host_state`, so the browser receives an encoded value instead of the raw `cli:` prefix. The callback page treated that as a normal browser login, compared it against missing `sessionStorage`, and showed `Invalid OAuth state — possible CSRF attack` instead of redirecting to the CLI.

## Impact
- restores CLI login flows that go through wrapped callback state
- also allows wrapped browser login state to pass the UI-side CSRF check while preserving the original state for the server callback

## Validation
- `npm run check`
- `npm run test:e2e -- auth.spec.ts -g wrapped`

## Notes
A broader `npm run test:e2e -- auth.spec.ts` run still shows pre-existing admin-route failures when executed against a Next-only dev server (`/admin` resolves to 404 in that setup). The new wrapped-state callback tests passed.