### PR TITLE
Use Kubernetes-style auth_mapping values for manual auth

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -536,8 +536,14 @@ connections:
           help_url: https://us5.datadoghq.com/organization-settings/application-keys
       auth_mapping:
         headers:
-          DD-API-KEY: api_key
-          DD-APPLICATION-KEY: app_key
+          DD-API-KEY:
+            valueFrom:
+              credentialFieldRef:
+                name: api_key
+          DD-APPLICATION-KEY:
+            valueFrom:
+              credentialFieldRef:
+                name: app_key
 ```
 
 | Field | Description |
@@ -546,7 +552,30 @@ connections:
 | `credentials[].label` | UI display label. Falls back to `name` when omitted. |
 | `credentials[].description` | Hint text below the label. Supports inline links via `[text](url)`. |
 | `credentials[].help_url` | Link placed next to the label pointing to where the credential can be found. |
-| `auth_mapping.headers` | Maps credential field names to HTTP headers. Required when multiple credentials are declared. |
+| `auth_mapping.headers.<HEADER>.value` | Supplies a static deployer-managed value for a header. |
+| `auth_mapping.headers.<HEADER>.valueFrom.credentialFieldRef.name` | Reads a header value from the named manual credential field. |
+| `auth_mapping.basic.username` / `auth_mapping.basic.password` | Build the Basic auth username/password from either a static `value` or `valueFrom.credentialFieldRef.name`. |
+
+For Basic auth providers that should collect only an API key while keeping the organization ID static, declare just the user-facing field and map the rest explicitly:
+
+```yaml
+connections:
+  default:
+    auth:
+      type: manual
+      credentials:
+        - name: api_key
+          label: API Key
+          help_url: https://app.moderntreasury.com/settings/api_keys
+      auth_mapping:
+        basic:
+          username:
+            value: ${MODERN_TREASURY_ORG_ID}
+          password:
+            valueFrom:
+              credentialFieldRef:
+                name: api_key
+```
 
 #### Post-connect discovery
 

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -321,6 +322,182 @@ plugins:
 		}
 		if !mapped.Pagination.HasMore || mapped.Pagination.Cursor != "cursor-map" {
 			t.Fatalf("mapped pagination = %+v", mapped.Pagination)
+		}
+	})
+}
+
+func TestE2EManualAuthMappingValueAndValueFromBasicAuth(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	port := allocateTestPort(t)
+
+	var upstreamAuth atomic.Value
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamAuth.Store(r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"auth":        r.Header.Get("Authorization"),
+			"org_header":  r.Header.Get("X-Org-ID"),
+			"echo_header": r.Header.Get("X-API-Key-Echo"),
+		})
+	}))
+	testutil.CloseOnCleanup(t, upstream)
+
+	pluginDir := filepath.Join(dir, "manual-basic-plugin")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll plugin dir: %v", err)
+	}
+	writeTestFile(t, pluginDir, "openapi.yaml", []byte(fmt.Sprintf(`openapi: 3.0.0
+info:
+  title: Manual Basic Test
+  version: 1.0.0
+servers:
+  - url: %s
+components:
+  securitySchemes:
+    basic_auth:
+      type: http
+      scheme: basic
+security:
+  - basic_auth: []
+paths:
+  /whoami:
+    get:
+      operationId: whoami
+      responses:
+        '200':
+          description: ok
+`, upstream.URL)), 0o644)
+	writeTestFile(t, pluginDir, "plugin.yaml", []byte(`
+source: github.com/test/plugins/manual-basic
+version: 0.0.1-alpha.1
+display_name: Manual Basic Test
+kinds:
+  - plugin
+plugin:
+  openapi: openapi.yaml
+`), 0o644)
+
+	manifestPath, err := pluginpkg.FindManifestFile(pluginDir)
+	if err != nil {
+		t.Fatalf("FindManifestFile: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := authDatastoreConfigYAML(t, dir, "session-auth", "sqlite", filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`server:
+  port: %d
+  encryption_key: test-e2e-key
+plugins:
+  mt:
+    provider:
+      source:
+        path: %s
+    connections:
+      default:
+        auth:
+          type: manual
+          credentials:
+            - name: api_key
+              label: API Key
+          auth_mapping:
+            headers:
+              X-Org-ID:
+                value: org-fixed
+              X-API-Key-Echo:
+                valueFrom:
+                  credentialFieldRef:
+                    name: api_key
+            basic:
+              username:
+                value: org-fixed
+              password:
+                valueFrom:
+                  credentialFieldRef:
+                    name: api_key
+`, port, manifestPath)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
+		listReq, _ := http.NewRequest(http.MethodGet, baseURL+"/api/v1/integrations", nil)
+		listReq.Header.Set("Authorization", "Bearer alice")
+		listResp, err := http.DefaultClient.Do(listReq)
+		if err != nil {
+			t.Fatalf("list integrations: %v", err)
+		}
+		defer func() { _ = listResp.Body.Close() }()
+		if listResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(listResp.Body)
+			t.Fatalf("list integrations status = %d: %s", listResp.StatusCode, body)
+		}
+
+		var integrations []struct {
+			Name        string `json:"name"`
+			Connections []struct {
+				CredentialFields []struct {
+					Name string `json:"name"`
+				} `json:"credential_fields"`
+			} `json:"connections"`
+		}
+		if err := json.NewDecoder(listResp.Body).Decode(&integrations); err != nil {
+			t.Fatalf("decode integrations: %v", err)
+		}
+		if len(integrations) != 1 || integrations[0].Name != "mt" {
+			t.Fatalf("unexpected integrations payload: %+v", integrations)
+		}
+		if len(integrations[0].Connections) != 1 {
+			t.Fatalf("unexpected connections payload: %+v", integrations[0].Connections)
+		}
+		fields := integrations[0].Connections[0].CredentialFields
+		if len(fields) != 1 || fields[0].Name != "api_key" {
+			t.Fatalf("credential fields = %+v, want only api_key", fields)
+		}
+
+		connectReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/auth/connect-manual", strings.NewReader(`{"integration":"mt","credential":"api-key-123"}`))
+		connectReq.Header.Set("Authorization", "Bearer alice")
+		connectReq.Header.Set("Content-Type", "application/json")
+		connectResp, err := http.DefaultClient.Do(connectReq)
+		if err != nil {
+			t.Fatalf("connect manual: %v", err)
+		}
+		defer func() { _ = connectResp.Body.Close() }()
+		if connectResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(connectResp.Body)
+			t.Fatalf("connect manual status = %d: %s", connectResp.StatusCode, body)
+		}
+
+		invokeReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/mt/whoami", strings.NewReader(`{}`))
+		invokeReq.Header.Set("Authorization", "Bearer alice")
+		invokeReq.Header.Set("Content-Type", "application/json")
+		invokeResp, err := http.DefaultClient.Do(invokeReq)
+		if err != nil {
+			t.Fatalf("invoke whoami: %v", err)
+		}
+		defer func() { _ = invokeResp.Body.Close() }()
+		if invokeResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(invokeResp.Body)
+			t.Fatalf("invoke whoami status = %d: %s", invokeResp.StatusCode, body)
+		}
+
+		var result map[string]any
+		if err := json.NewDecoder(invokeResp.Body).Decode(&result); err != nil {
+			t.Fatalf("decode invoke response: %v", err)
+		}
+
+		wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("org-fixed:api-key-123"))
+		if result["auth"] != wantAuth {
+			t.Fatalf("invoke auth = %v, want %v", result["auth"], wantAuth)
+		}
+		if result["org_header"] != "org-fixed" {
+			t.Fatalf("invoke org_header = %v, want org-fixed", result["org_header"])
+		}
+		if result["echo_header"] != "api-key-123" {
+			t.Fatalf("invoke echo_header = %v, want api-key-123", result["echo_header"])
+		}
+		if got, _ := upstreamAuth.Load().(string); got != wantAuth {
+			t.Fatalf("upstream auth = %q, want %q", got, wantAuth)
 		}
 	})
 }

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -371,7 +371,26 @@ type ConnectionAuthDef struct {
 type CredentialFieldDef = pluginmanifestv1.CredentialField
 
 type AuthMappingDef struct {
-	Headers map[string]string `yaml:"headers"`
+	Headers map[string]AuthValueDef `yaml:"headers"`
+	Basic   *BasicAuthMappingDef    `yaml:"basic"`
+}
+
+type BasicAuthMappingDef struct {
+	Username AuthValueDef `yaml:"username"`
+	Password AuthValueDef `yaml:"password"`
+}
+
+type AuthValueDef struct {
+	Value     string            `yaml:"value"`
+	ValueFrom *AuthValueFromDef `yaml:"valueFrom"`
+}
+
+type AuthValueFromDef struct {
+	CredentialFieldRef *CredentialFieldRefDef `yaml:"credentialFieldRef"`
+}
+
+type CredentialFieldRefDef struct {
+	Name string `yaml:"name"`
 }
 
 type ConnectionParamDef = pluginmanifestv1.ProviderConnectionParam
@@ -1173,6 +1192,75 @@ func validateManifestBackedIntegration(name string, plugin *PluginDef) error {
 	}
 	if err := validateExecutableConnectionAuthSupport(name, plugin, effectiveProvider); err != nil {
 		return err
+	}
+	if err := validateConnectionAuthMappings(name, EffectivePluginConnectionDef(plugin, effectiveProvider).Auth, "plugin"); err != nil {
+		return err
+	}
+	declared := declaredManifestBackedConnections(plugin, effectiveProvider)
+	names := make([]string, 0, len(declared))
+	for connName := range declared {
+		if connName == PluginConnectionName {
+			continue
+		}
+		names = append(names, connName)
+	}
+	slices.Sort(names)
+	for _, connName := range names {
+		conn, ok := EffectiveNamedConnectionDef(plugin, effectiveProvider, connName)
+		if !ok {
+			continue
+		}
+		if err := validateConnectionAuthMappings(name, conn.Auth, fmt.Sprintf("connection %q", connName)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateConnectionAuthMappings(integration string, auth ConnectionAuthDef, subject string) error {
+	credentialNames := make(map[string]struct{}, len(auth.Credentials))
+	for _, field := range auth.Credentials {
+		if field.Name != "" {
+			credentialNames[field.Name] = struct{}{}
+		}
+	}
+	if auth.AuthMapping == nil {
+		return nil
+	}
+	for headerName, value := range auth.AuthMapping.Headers {
+		if err := validateAuthValueDef(integration, subject, fmt.Sprintf("auth_mapping.headers[%q]", headerName), value, credentialNames); err != nil {
+			return err
+		}
+	}
+	if auth.AuthMapping.Basic != nil {
+		if err := validateAuthValueDef(integration, subject, "auth_mapping.basic.username", auth.AuthMapping.Basic.Username, credentialNames); err != nil {
+			return err
+		}
+		if err := validateAuthValueDef(integration, subject, "auth_mapping.basic.password", auth.AuthMapping.Basic.Password, credentialNames); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateAuthValueDef(integration, subject, path string, value AuthValueDef, credentialNames map[string]struct{}) error {
+	hasValue := value.Value != ""
+	hasValueFrom := value.ValueFrom != nil
+	if hasValue == hasValueFrom {
+		return fmt.Errorf("config validation: integration %q %s %s must set exactly one of value or valueFrom", integration, subject, path)
+	}
+	if hasValue {
+		return nil
+	}
+	if value.ValueFrom.CredentialFieldRef == nil {
+		return fmt.Errorf("config validation: integration %q %s %s.valueFrom must set credentialFieldRef", integration, subject, path)
+	}
+	name := value.ValueFrom.CredentialFieldRef.Name
+	if name == "" {
+		return fmt.Errorf("config validation: integration %q %s %s.valueFrom.credentialFieldRef.name is required", integration, subject, path)
+	}
+	if _, ok := credentialNames[name]; !ok {
+		return fmt.Errorf("config validation: integration %q %s %s.valueFrom.credentialFieldRef references undeclared credential %q", integration, subject, path, name)
 	}
 	return nil
 }

--- a/gestaltd/internal/openapi/auth.go
+++ b/gestaltd/internal/openapi/auth.go
@@ -100,7 +100,7 @@ func applyAPIKeySecurityAuth(def *provider.Definition, schemes []namedSecuritySc
 		return false
 	}
 
-	authMapping := &provider.AuthMappingDef{Headers: make(map[string]string, len(schemes))}
+	authMapping := &provider.AuthMappingDef{Headers: make(map[string]provider.AuthValueDef, len(schemes))}
 	credentialFields := make([]provider.CredentialFieldDef, 0, len(schemes))
 	for _, named := range schemes {
 		if named.scheme == nil || named.scheme.Type != secTypeAPIKey || named.scheme.In != secInHeader {
@@ -108,7 +108,11 @@ func applyAPIKeySecurityAuth(def *provider.Definition, schemes []namedSecuritySc
 		}
 		field := credentialFieldForSecurityScheme(named.name, named.scheme)
 		credentialFields = append(credentialFields, field)
-		authMapping.Headers[named.scheme.Name] = field.Name
+		authMapping.Headers[named.scheme.Name] = provider.AuthValueDef{
+			ValueFrom: &provider.AuthValueFromDef{
+				CredentialFieldRef: &provider.CredentialFieldRefDef{Name: field.Name},
+			},
+		}
 	}
 
 	def.Auth.Type = "manual"

--- a/gestaltd/internal/provider/build.go
+++ b/gestaltd/internal/provider/build.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -121,22 +122,45 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 	}
 
 	switch {
-	case def.AuthMapping != nil && len(def.AuthMapping.Headers) > 0:
-		mapping := def.AuthMapping.Headers
+	case def.AuthMapping != nil && (len(def.AuthMapping.Headers) > 0 || def.AuthMapping.Basic != nil):
+		if base.AuthStyle != coreintegration.AuthStyleBasic {
+			if def.AuthMapping.Basic != nil {
+				return nil, fmt.Errorf("%s: auth_mapping.basic requires auth_style basic", def.Provider)
+			}
+		}
+		mapping := def.AuthMapping
 		base.TokenParser = func(token string) (string, map[string]string, error) {
-			var tokenData map[string]any
-			if err := json.Unmarshal([]byte(token), &tokenData); err != nil {
-				return "", nil, fmt.Errorf("parsing token as JSON for auth_mapping: %w", err)
-			}
-			headers := make(map[string]string, len(mapping))
-			for headerName, jsonField := range mapping {
-				val, ok := tokenData[jsonField]
-				if !ok || val == nil {
-					return "", nil, fmt.Errorf("auth_mapping: token field %q for header %q is missing or null", jsonField, headerName)
+			var (
+				tokenData map[string]any
+				headers   map[string]string
+			)
+			if len(mapping.Headers) > 0 {
+				headers = make(map[string]string, len(mapping.Headers))
+				for headerName, value := range mapping.Headers {
+					resolved, err := resolveAuthValue(value, token, &tokenData)
+					if err != nil {
+						return "", nil, fmt.Errorf("auth_mapping.headers[%q]: %w", headerName, err)
+					}
+					headers[headerName] = resolved
 				}
-				headers[headerName] = fmt.Sprintf("%v", val)
 			}
-			return "", headers, nil
+			authToken := ""
+			if mapping.Basic != nil {
+				username, err := resolveAuthValue(mapping.Basic.Username, token, &tokenData)
+				if err != nil {
+					return "", nil, fmt.Errorf("auth_mapping.basic.username: %w", err)
+				}
+				password, err := resolveAuthValue(mapping.Basic.Password, token, &tokenData)
+				if err != nil {
+					return "", nil, fmt.Errorf("auth_mapping.basic.password: %w", err)
+				}
+				credential := fmt.Sprintf("%s:%s", username, password)
+				authToken = "Basic " + base64.StdEncoding.EncodeToString([]byte(credential))
+			}
+			if len(headers) == 0 {
+				headers = nil
+			}
+			return authToken, headers, nil
 		}
 	case def.AuthHeader != "":
 		headerName := def.AuthHeader
@@ -256,9 +280,74 @@ func ApplyConnectionAuth(def *Definition, conn config.ConnectionDef) {
 			}
 		}
 	}
-	if o.AuthMapping != nil && len(o.AuthMapping.Headers) > 0 {
-		def.AuthMapping = &AuthMappingDef{Headers: o.AuthMapping.Headers}
+	if o.AuthMapping != nil {
+		def.AuthMapping = cloneConfigAuthMapping(o.AuthMapping)
 	}
+}
+
+func parseMappedToken(token string) (map[string]any, error) {
+	var tokenData map[string]any
+	if err := json.Unmarshal([]byte(token), &tokenData); err != nil {
+		return nil, fmt.Errorf("parsing token as JSON for auth_mapping: %w", err)
+	}
+	return tokenData, nil
+}
+
+func resolveAuthValue(value AuthValueDef, token string, tokenData *map[string]any) (string, error) {
+	hasValue := value.Value != ""
+	hasValueFrom := value.ValueFrom != nil
+	if hasValue == hasValueFrom {
+		return "", fmt.Errorf("must set exactly one of value or valueFrom.credentialFieldRef")
+	}
+	if hasValue {
+		return value.Value, nil
+	}
+	if value.ValueFrom == nil || value.ValueFrom.CredentialFieldRef == nil {
+		return "", fmt.Errorf("must set exactly one of value or valueFrom.credentialFieldRef")
+	}
+	if *tokenData == nil {
+		parsed, err := parseMappedToken(token)
+		if err != nil {
+			return "", err
+		}
+		*tokenData = parsed
+	}
+	fieldName := value.ValueFrom.CredentialFieldRef.Name
+	val, ok := (*tokenData)[fieldName]
+	if !ok || val == nil {
+		return "", fmt.Errorf("token field %q is missing or null", fieldName)
+	}
+	return fmt.Sprintf("%v", val), nil
+}
+
+func cloneConfigAuthMapping(src *config.AuthMappingDef) *AuthMappingDef {
+	if src == nil {
+		return nil
+	}
+	dst := &AuthMappingDef{}
+	if len(src.Headers) > 0 {
+		dst.Headers = make(map[string]AuthValueDef, len(src.Headers))
+		for name, value := range src.Headers {
+			dst.Headers[name] = cloneConfigAuthValue(value)
+		}
+	}
+	if src.Basic != nil {
+		dst.Basic = &BasicAuthMappingDef{
+			Username: cloneConfigAuthValue(src.Basic.Username),
+			Password: cloneConfigAuthValue(src.Basic.Password),
+		}
+	}
+	return dst
+}
+
+func cloneConfigAuthValue(src config.AuthValueDef) AuthValueDef {
+	dst := AuthValueDef{Value: src.Value}
+	if src.ValueFrom != nil && src.ValueFrom.CredentialFieldRef != nil {
+		dst.ValueFrom = &AuthValueFromDef{
+			CredentialFieldRef: &CredentialFieldRefDef{Name: src.ValueFrom.CredentialFieldRef.Name},
+		}
+	}
+	return dst
 }
 
 func setStr(dst *string, val string) {

--- a/gestaltd/internal/provider/build_test.go
+++ b/gestaltd/internal/provider/build_test.go
@@ -405,9 +405,17 @@ func TestBuildAuthMapping(t *testing.T) {
 		BaseURL:     srv.URL,
 		Auth:        AuthDef{Type: "manual"},
 		AuthMapping: &AuthMappingDef{
-			Headers: map[string]string{
-				"DD-API-KEY":         "api_key",
-				"DD-APPLICATION-KEY": "app_key",
+			Headers: map[string]AuthValueDef{
+				"DD-API-KEY": {
+					ValueFrom: &AuthValueFromDef{
+						CredentialFieldRef: &CredentialFieldRefDef{Name: "api_key"},
+					},
+				},
+				"DD-APPLICATION-KEY": {
+					ValueFrom: &AuthValueFromDef{
+						CredentialFieldRef: &CredentialFieldRefDef{Name: "app_key"},
+					},
+				},
 			},
 		},
 		Operations: map[string]OperationDef{
@@ -455,7 +463,13 @@ func TestBuildAuthMappingMissingField(t *testing.T) {
 		BaseURL:     srv.URL,
 		Auth:        AuthDef{Type: "manual"},
 		AuthMapping: &AuthMappingDef{
-			Headers: map[string]string{"X-Key": "missing_field"},
+			Headers: map[string]AuthValueDef{
+				"X-Key": {
+					ValueFrom: &AuthValueFromDef{
+						CredentialFieldRef: &CredentialFieldRefDef{Name: "missing_field"},
+					},
+				},
+			},
 		},
 		Operations: map[string]OperationDef{
 			"op": {Description: "Op", Method: http.MethodGet, Path: "/op"},
@@ -1000,9 +1014,17 @@ func TestBuildAuthMappingFromConfig(t *testing.T) {
 	conn := config.ConnectionDef{
 		Auth: config.ConnectionAuthDef{
 			AuthMapping: &config.AuthMappingDef{
-				Headers: map[string]string{
-					"X-Api-Key": "api_key",
-					"X-App-Key": "app_key",
+				Headers: map[string]config.AuthValueDef{
+					"X-Api-Key": {
+						ValueFrom: &config.AuthValueFromDef{
+							CredentialFieldRef: &config.CredentialFieldRefDef{Name: "api_key"},
+						},
+					},
+					"X-App-Key": {
+						ValueFrom: &config.AuthValueFromDef{
+							CredentialFieldRef: &config.CredentialFieldRefDef{Name: "app_key"},
+						},
+					},
 				},
 			},
 		},

--- a/gestaltd/internal/provider/definition.go
+++ b/gestaltd/internal/provider/definition.go
@@ -94,7 +94,26 @@ type OperationDef struct {
 }
 
 type AuthMappingDef struct {
-	Headers map[string]string `yaml:"headers" json:"headers"`
+	Headers map[string]AuthValueDef `yaml:"headers" json:"headers"`
+	Basic   *BasicAuthMappingDef    `yaml:"basic" json:"basic,omitempty"`
+}
+
+type BasicAuthMappingDef struct {
+	Username AuthValueDef `yaml:"username" json:"username"`
+	Password AuthValueDef `yaml:"password" json:"password"`
+}
+
+type AuthValueDef struct {
+	Value     string            `yaml:"value" json:"value,omitempty"`
+	ValueFrom *AuthValueFromDef `yaml:"valueFrom" json:"valueFrom,omitempty"`
+}
+
+type AuthValueFromDef struct {
+	CredentialFieldRef *CredentialFieldRefDef `yaml:"credentialFieldRef" json:"credentialFieldRef,omitempty"`
+}
+
+type CredentialFieldRefDef struct {
+	Name string `yaml:"name" json:"name"`
 }
 
 type ValueSelectorDef struct {

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -1204,29 +1204,9 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 	}
 	providerName = req.Integration
 
-	var effectiveCredential string
-	if len(req.Credentials) > 0 {
-		for k, v := range req.Credentials {
-			if v == "" {
-				auditErr = fmt.Errorf("credential %q must not be empty", k)
-				writeError(w, http.StatusBadRequest, fmt.Sprintf("credential %q must not be empty", k))
-				return
-			}
-		}
-		b, err := json.Marshal(req.Credentials)
-		if err != nil {
-			auditErr = errors.New("invalid credentials map")
-			writeError(w, http.StatusBadRequest, "invalid credentials map")
-			return
-		}
-		effectiveCredential = string(b)
-	} else {
-		effectiveCredential = req.Credential
-	}
-
-	if req.Integration == "" || effectiveCredential == "" {
-		auditErr = errors.New("integration and credential are required")
-		writeError(w, http.StatusBadRequest, "integration and credential are required")
+	if req.Integration == "" {
+		auditErr = errors.New("integration is required")
+		writeError(w, http.StatusBadRequest, "integration is required")
 		return
 	}
 
@@ -1260,6 +1240,19 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 	manualConnection, ok := s.resolveRequestedConnection(w, req.Integration, req.Connection)
 	if !ok {
 		auditErr = errors.New("invalid connection")
+		return
+	}
+
+	auth := s.effectiveConnectionAuth(req.Integration, manualConnection)
+	effectiveCredential, credErr := buildEffectiveManualCredential(req, auth)
+	if credErr != nil {
+		auditErr = credErr
+		writeError(w, http.StatusBadRequest, credErr.Error())
+		return
+	}
+	if effectiveCredential == "" {
+		auditErr = errors.New("credential is required")
+		writeError(w, http.StatusBadRequest, "credential is required")
 		return
 	}
 
@@ -1515,6 +1508,57 @@ func connectionInfoFromAuth(name string, auth config.ConnectionAuthDef, integrat
 		info.CredentialFields = append([]credentialFieldInfo(nil), defaultCredentialFields...)
 	}
 	return info, true
+}
+
+func (s *Server) effectiveConnectionAuth(integration, connection string) config.ConnectionAuthDef {
+	intg, ok := s.integrationDefs[integration]
+	if !ok || intg.Plugin == nil {
+		return config.ConnectionAuthDef{}
+	}
+	manifestProvider := intg.Plugin.ManifestPlugin()
+	if connection == config.PluginConnectionName {
+		return config.EffectivePluginConnectionDef(intg.Plugin, manifestProvider).Auth
+	}
+	conn, ok := config.EffectiveNamedConnectionDef(intg.Plugin, manifestProvider, connection)
+	if !ok {
+		return config.ConnectionAuthDef{}
+	}
+	return conn.Auth
+}
+
+func buildEffectiveManualCredential(req connectManualRequest, auth config.ConnectionAuthDef) (string, error) {
+	if len(req.Credentials) > 0 {
+		return marshalManualCredentials(req.Credentials)
+	}
+
+	structured := auth.AuthMapping != nil && (len(auth.AuthMapping.Headers) > 0 || auth.AuthMapping.Basic != nil)
+	if !structured {
+		return req.Credential, nil
+	}
+
+	switch {
+	case req.Credential != "" && len(auth.Credentials) == 1:
+		return marshalManualCredentials(map[string]string{auth.Credentials[0].Name: req.Credential})
+	case req.Credential != "":
+		return "", errors.New("manual connection requires named credentials")
+	}
+	return "", nil
+}
+
+func marshalManualCredentials(creds map[string]string) (string, error) {
+	if len(creds) == 0 {
+		return "", nil
+	}
+	for name, value := range creds {
+		if value == "" {
+			return "", fmt.Errorf("credential %q must not be empty", name)
+		}
+	}
+	data, err := json.Marshal(creds)
+	if err != nil {
+		return "", errors.New("invalid credentials map")
+	}
+	return string(data), nil
 }
 
 func connectionAuthTypes(authType string, integrationAuthTypes []string) []string {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1022,6 +1022,40 @@ func TestListIntegrations_ConnectionInfosIncludeProviderManualAuth(t *testing.T)
 				{Name: "secondary_token", Label: "Secondary Token"},
 			},
 		},
+		{
+			name: "declared manual credential fields are exposed without synthetic auth inputs",
+			provider: func(t *testing.T) core.Provider {
+				t.Helper()
+				return &coretesting.StubIntegration{N: "example", DN: "Example"}
+			},
+			plugin: &config.PluginDef{
+				Auth: &config.ConnectionAuthDef{
+					Type: pluginmanifestv1.AuthTypeManual,
+					Credentials: []config.CredentialFieldDef{
+						{Name: "api_key", Label: "API Key"},
+					},
+					AuthMapping: &config.AuthMappingDef{
+						Basic: &config.BasicAuthMappingDef{
+							Username: config.AuthValueDef{
+								Value: "org-123",
+							},
+							Password: config.AuthValueDef{
+								ValueFrom: &config.AuthValueFromDef{
+									CredentialFieldRef: &config.CredentialFieldRefDef{Name: "api_key"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantAuth: []string{"manual"},
+			wantFields: []struct {
+				Name  string `json:"name"`
+				Label string `json:"label"`
+			}{
+				{Name: "api_key", Label: "API Key"},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -6407,49 +6441,103 @@ func TestExecuteOperation_ConnectionModeEither(t *testing.T) {
 func TestConnectManual_MultiCredential(t *testing.T) {
 	t.Parallel()
 
-	var stored *core.IntegrationToken
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = testutil.NewProviderRegistry(t, &stubManualProvider{
-			StubIntegration: coretesting.StubIntegration{N: "multi-key-svc"},
+	cases := []struct {
+		name            string
+		integration     string
+		requestBody     string
+		integrationDefs map[string]config.IntegrationDef
+		wantTokenData   map[string]string
+	}{
+		{
+			name:        "stores named credentials map",
+			integration: "multi-key-svc",
+			requestBody: `{"integration":"multi-key-svc","credentials":{"api_key":"k1","app_key":"k2"}}`,
+			wantTokenData: map[string]string{
+				"api_key": "k1",
+				"app_key": "k2",
+			},
+		},
+		{
+			name:        "single credential input wraps structured auth mapping field",
+			integration: "modern-treasury",
+			requestBody: `{"integration":"modern-treasury","credential":"api-key-abc"}`,
+			integrationDefs: map[string]config.IntegrationDef{
+				"modern-treasury": {
+					Plugin: &config.PluginDef{
+						Auth: &config.ConnectionAuthDef{
+							Type: pluginmanifestv1.AuthTypeManual,
+							Credentials: []config.CredentialFieldDef{
+								{Name: "api_key", Label: "API Key"},
+							},
+							AuthMapping: &config.AuthMappingDef{
+								Basic: &config.BasicAuthMappingDef{
+									Username: config.AuthValueDef{
+										Value: "org-123",
+									},
+									Password: config.AuthValueDef{
+										ValueFrom: &config.AuthValueFromDef{
+											CredentialFieldRef: &config.CredentialFieldRefDef{Name: "api_key"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantTokenData: map[string]string{
+				"api_key": "api-key-abc",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var stored *core.IntegrationToken
+			ts := newTestServer(t, func(cfg *server.Config) {
+				cfg.Providers = testutil.NewProviderRegistry(t, &stubManualProvider{
+					StubIntegration: coretesting.StubIntegration{N: tc.integration},
+				})
+				cfg.DefaultConnection = map[string]string{tc.integration: config.PluginConnectionName}
+				cfg.IntegrationDefs = tc.integrationDefs
+				cfg.Datastore = &coretesting.StubDatastore{
+					FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+						return &core.User{ID: "u1", Email: email}, nil
+					},
+					StoreTokenFn: func(_ context.Context, tok *core.IntegrationToken) error {
+						stored = tok
+						return nil
+					},
+				}
+			})
+			testutil.CloseOnCleanup(t, ts)
+
+			req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", bytes.NewBufferString(tc.requestBody))
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("expected 200, got %d", resp.StatusCode)
+			}
+			if stored == nil {
+				t.Fatal("expected StoreToken to be called")
+			}
+
+			var tokenData map[string]string
+			if err := json.Unmarshal([]byte(stored.AccessToken), &tokenData); err != nil {
+				t.Fatalf("stored token is not valid JSON: %v", err)
+			}
+			if !reflect.DeepEqual(tokenData, tc.wantTokenData) {
+				t.Fatalf("token data = %+v, want %+v", tokenData, tc.wantTokenData)
+			}
 		})
-		cfg.DefaultConnection = map[string]string{"multi-key-svc": config.PluginConnectionName}
-		cfg.Datastore = &coretesting.StubDatastore{
-			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
-				return &core.User{ID: "u1", Email: email}, nil
-			},
-			StoreTokenFn: func(_ context.Context, tok *core.IntegrationToken) error {
-				stored = tok
-				return nil
-			},
-		}
-	})
-	testutil.CloseOnCleanup(t, ts)
-
-	body := bytes.NewBufferString(`{"integration":"multi-key-svc","credentials":{"api_key":"k1","app_key":"k2"}}`)
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("request: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
-	}
-	if stored == nil {
-		t.Fatal("expected StoreToken to be called")
-	}
-
-	var tokenData map[string]string
-	if err := json.Unmarshal([]byte(stored.AccessToken), &tokenData); err != nil {
-		t.Fatalf("stored token is not valid JSON: %v", err)
-	}
-	if tokenData["api_key"] != "k1" {
-		t.Errorf("api_key = %q, want k1", tokenData["api_key"])
-	}
-	if tokenData["app_key"] != "k2" {
-		t.Errorf("app_key = %q, want k2", tokenData["app_key"])
 	}
 }
 


### PR DESCRIPTION
Summary:
Replace the credential_overrides model with Kubernetes-style auth mapping values for manual auth. This lets deployers provide static literals directly at the wire-mapping layer while users only enter the credential fields they actually own.

New Interfaces:
```yaml
connections:
  default:
    auth:
      type: manual
      credentials:
        - name: api_key
          label: API Key
      auth_mapping:
        basic:
          username:
            value: ${MODERN_TREASURY_ORG_ID}
          password:
            valueFrom:
              credentialFieldRef:
                name: api_key
```

```yaml
connections:
  default:
    auth:
      type: manual
      credentials:
        - name: api_key
          label: API Key
        - name: app_key
          label: Application Key
      auth_mapping:
        headers:
          DD-API-KEY:
            valueFrom:
              credentialFieldRef:
                name: api_key
          DD-APPLICATION-KEY:
            valueFrom:
              credentialFieldRef:
                name: app_key
          X-ORG-ID:
            value: org-fixed
```

Behavioral Notes:
- Breaking change: plain string `auth_mapping` entries and `credential_overrides` are removed.
- Only declared credential fields are shown to users.
- Static deployer-managed values are applied when building the outbound request, not merged into stored user credentials.
- `auth_mapping.basic` and `auth_mapping.headers` can be used together.

Why:
The previous design modeled static auth pieces as hidden credential fields. That leaked transport concerns into the credential form and forced extra server-side merge logic. The new interface keeps the form focused on real user input and makes the wire mapping explicit.

Testing:
- `go test ./internal/server -run 'TestListIntegrations_ConnectionInfosIncludeProviderManualAuth|TestConnectManual_MultiCredential' -count=1`
- `go test ./cmd/gestaltd -run TestE2EManualAuthMappingValueAndValueFromBasicAuth -count=1`
- `go test ./internal/provider -run '^$' -count=1`
- `go test ./internal/openapi -run '^$' -count=1`
- `go test ./internal/config -run '^$' -count=1`