### PR TITLE
Support Python auth and datastore source components

### DIFF
--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -360,9 +360,9 @@ func missingReleaseSourceBuildTargetError(kinds []string) error {
 		case pluginmanifestv1.KindPlugin:
 			return fmt.Errorf("no Go, Rust, or Python provider package found")
 		case pluginmanifestv1.KindAuth:
-			return fmt.Errorf("no Go or Rust auth source package found")
+			return fmt.Errorf("no Go, Rust, or Python auth source package found")
 		case pluginmanifestv1.KindDatastore:
-			return fmt.Errorf("no Go or Rust datastore source package found")
+			return fmt.Errorf("no Go, Rust, or Python datastore source package found")
 		}
 	}
 	return fmt.Errorf("missing source packages for executable kinds: %s", strings.Join(kinds, ", "))

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -23,25 +23,29 @@ import (
 )
 
 const (
-	releaseTestPluginName      = "release-test"
-	releaseTestSource          = "github.com/testowner/plugins/catalog/release-test"
-	releaseTestModule          = "example.com/release-test"
-	releaseTestIconPath        = "branding/icon.svg"
-	releaseProviderSchemaPath  = "schemas/provider.schema.json"
-	webUITestPluginName        = "webui-test"
-	webUITestSource            = "github.com/testowner/plugins/catalog/webui-test"
-	webUITestAssetRoot         = "out"
-	prebuiltProviderPluginName = "prebuilt-provider"
-	prebuiltProviderSource     = "github.com/testowner/plugins/prebuilt-provider"
-	prebuiltProviderBinaryPath = "bin/provider"
-	authReleasePluginName      = "auth-release"
-	authReleaseSource          = "github.com/testowner/plugins/auth-release"
-	authReleaseSchemaPath      = "schemas/auth.schema.json"
-	datastoreReleasePluginName = "datastore-release"
-	datastoreReleaseSource     = "github.com/testowner/plugins/datastore-release"
-	datastoreReleaseSchemaPath = "schemas/datastore.schema.json"
-	rustReleasePluginName      = "provider-rust"
-	rustWrapperBinaryName      = "gestalt-provider-wrapper"
+	releaseTestPluginName            = "release-test"
+	releaseTestSource                = "github.com/testowner/plugins/catalog/release-test"
+	releaseTestModule                = "example.com/release-test"
+	releaseTestIconPath              = "branding/icon.svg"
+	releaseProviderSchemaPath        = "schemas/provider.schema.json"
+	webUITestPluginName              = "webui-test"
+	webUITestSource                  = "github.com/testowner/plugins/catalog/webui-test"
+	webUITestAssetRoot               = "out"
+	prebuiltProviderPluginName       = "prebuilt-provider"
+	prebuiltProviderSource           = "github.com/testowner/plugins/prebuilt-provider"
+	prebuiltProviderBinaryPath       = "bin/provider"
+	authReleasePluginName            = "auth-release"
+	authReleaseSource                = "github.com/testowner/plugins/auth-release"
+	authReleaseSchemaPath            = "schemas/auth.schema.json"
+	datastoreReleasePluginName       = "datastore-release"
+	datastoreReleaseSource           = "github.com/testowner/plugins/datastore-release"
+	datastoreReleaseSchemaPath       = "schemas/datastore.schema.json"
+	rustReleasePluginName            = "provider-rust"
+	rustWrapperBinaryName            = "gestalt-provider-wrapper"
+	pythonAuthReleasePluginName      = "python-auth-release"
+	pythonAuthReleaseSource          = "github.com/testowner/plugins/python-auth-release"
+	pythonDatastoreReleasePluginName = "python-datastore-release"
+	pythonDatastoreReleaseSource     = "github.com/testowner/plugins/python-datastore-release"
 )
 
 func TestRun_PluginHelpExitsCleanly(t *testing.T) {
@@ -1064,6 +1068,142 @@ func TestRun_PluginReleaseBuildsRustSourceDatastorePlugin(t *testing.T) {
 	}
 }
 
+func TestRun_PluginReleaseBuildsPythonSourceAuthPlugin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake Python build fixture is POSIX-only")
+	}
+
+	goFixtureDir := newSourceAuthReleaseFixture(t, t.TempDir())
+	t.Setenv("GESTALT_TEST_PYINSTALLER_BINARY", buildGoSourceComponentBinaryForTest(t, goFixtureDir, pluginmanifestv1.KindAuth))
+	t.Setenv("PATH", pathWithoutGo(t))
+
+	pluginDir := newPythonSourceAuthReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.16-python-auth"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := expectedPythonArchiveNameFor(pythonAuthReleasePluginName, testVersion, runtime.GOOS, runtime.GOARCH)
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+	binaryName := releaseBinaryName(pythonAuthReleasePluginName, runtime.GOOS)
+
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != binaryName {
+		t.Fatalf("artifacts = %+v, want path %q", manifest.Artifacts, binaryName)
+	}
+	if manifest.Entrypoints.Auth == nil || manifest.Entrypoints.Auth.ArtifactPath != binaryName {
+		t.Fatalf("auth entrypoint = %+v, want artifact path %q", manifest.Entrypoints.Auth, binaryName)
+	}
+	if _, err := os.Stat(filepath.Join(extractDir, authReleaseSchemaPath)); err != nil {
+		t.Fatalf("expected %s in archive: %v", authReleaseSchemaPath, err)
+	}
+
+	auth, err := pluginhost.NewExecutableAuthProvider(context.Background(), pluginhost.AuthExecConfig{
+		Command:     filepath.Join(extractDir, binaryName),
+		Name:        pythonAuthReleasePluginName,
+		CallbackURL: "https://gestalt.example.test/api/v1/auth/login/callback",
+		SessionKey:  []byte("0123456789abcdef0123456789abcdef"),
+	})
+	if err != nil {
+		t.Fatalf("NewExecutableAuthProvider: %v", err)
+	}
+	defer func() {
+		if closer, ok := auth.(interface{ Close() error }); ok {
+			_ = closer.Close()
+		}
+	}()
+
+	loginURL, err := auth.LoginURL("host-state")
+	if err != nil {
+		t.Fatalf("LoginURL: %v", err)
+	}
+	parsed, err := url.Parse(loginURL)
+	if err != nil {
+		t.Fatalf("url.Parse(loginURL): %v", err)
+	}
+	state := parsed.Query().Get("state")
+	if state == "" {
+		t.Fatal("login URL did not include state")
+	}
+
+	callbackHandler, ok := auth.(interface {
+		HandleCallbackRequest(context.Context, url.Values) (*core.UserIdentity, string, error)
+	})
+	if !ok {
+		t.Fatal("auth provider did not expose HandleCallbackRequest")
+	}
+	identity, originalState, err := callbackHandler.HandleCallbackRequest(context.Background(), url.Values{
+		"code":   {"callback-code"},
+		"state":  {state},
+		"prompt": {parsed.Query().Get("prompt")},
+	})
+	if err != nil {
+		t.Fatalf("HandleCallbackRequest: %v", err)
+	}
+	if originalState != "host-state" {
+		t.Fatalf("original state = %q, want %q", originalState, "host-state")
+	}
+	if identity == nil || identity.Email != "generated-auth@example.com" {
+		t.Fatalf("identity = %+v", identity)
+	}
+}
+
+func TestRun_PluginReleaseBuildsPythonSourceDatastorePlugin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake Python build fixture is POSIX-only")
+	}
+
+	goFixtureDir := newSourceDatastoreReleaseFixture(t, t.TempDir())
+	t.Setenv("GESTALT_TEST_PYINSTALLER_BINARY", buildGoSourceComponentBinaryForTest(t, goFixtureDir, pluginmanifestv1.KindDatastore))
+	t.Setenv("PATH", pathWithoutGo(t))
+
+	pluginDir := newPythonSourceDatastoreReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.16-python-datastore"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := expectedPythonArchiveNameFor(pythonDatastoreReleasePluginName, testVersion, runtime.GOOS, runtime.GOARCH)
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+	binaryName := releaseBinaryName(pythonDatastoreReleasePluginName, runtime.GOOS)
+
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != binaryName {
+		t.Fatalf("artifacts = %+v, want path %q", manifest.Artifacts, binaryName)
+	}
+	if manifest.Entrypoints.Datastore == nil || manifest.Entrypoints.Datastore.ArtifactPath != binaryName {
+		t.Fatalf("datastore entrypoint = %+v, want artifact path %q", manifest.Entrypoints.Datastore, binaryName)
+	}
+	if _, err := os.Stat(filepath.Join(extractDir, datastoreReleaseSchemaPath)); err != nil {
+		t.Fatalf("expected %s in archive: %v", datastoreReleaseSchemaPath, err)
+	}
+
+	store, err := pluginhost.NewExecutableDatastore(context.Background(), pluginhost.DatastoreExecConfig{
+		Command:       filepath.Join(extractDir, binaryName),
+		Name:          pythonDatastoreReleasePluginName,
+		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
+	})
+	if err != nil {
+		t.Fatalf("NewExecutableDatastore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+}
+
 func TestRun_PluginReleaseCopiesCompiledSupportFiles(t *testing.T) {
 	t.Parallel()
 
@@ -1349,7 +1489,7 @@ func TestRun_PluginReleaseRejectsRequiredExecutableKindsWithoutSourceOrEntrypoin
 				Kinds:       []string{pluginmanifestv1.KindAuth},
 				Auth:        &pluginmanifestv1.AuthMetadata{},
 			},
-			wantError: "no Go or Rust auth source package found",
+			wantError: "no Go, Rust, or Python auth source package found",
 		},
 		{
 			name: "datastore",
@@ -1360,7 +1500,7 @@ func TestRun_PluginReleaseRejectsRequiredExecutableKindsWithoutSourceOrEntrypoin
 				Kinds:       []string{pluginmanifestv1.KindDatastore},
 				Datastore:   &pluginmanifestv1.DatastoreMetadata{},
 			},
-			wantError: "no Go or Rust datastore source package found",
+			wantError: "no Go, Rust, or Python datastore source package found",
 		},
 	}
 
@@ -1570,7 +1710,114 @@ def dynamic_catalog(request: gestalt.Request) -> gestalt.Catalog:
 	return pluginDir
 }
 
+func newPythonSourceAuthReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(dir, pythonAuthReleasePluginName)
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(pluginDir): %v", err)
+	}
+	writeTestFile(t, pluginDir, "pyproject.toml", []byte(`[build-system]
+requires = ["setuptools==82.0.1"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "`+pythonAuthReleasePluginName+`"
+version = "0.0.1-alpha.1"
+dependencies = ["gestalt"]
+
+[tool.gestalt]
+auth = "provider:auth_provider"
+`), 0o644)
+	writeTestFile(t, pluginDir, "provider.py", []byte(`auth_provider = object()
+`), 0o644)
+	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
+		Source:      pythonAuthReleaseSource,
+		Version:     "0.0.1",
+		DisplayName: "Python Auth Release",
+		Kinds:       []string{pluginmanifestv1.KindAuth},
+		Auth: &pluginmanifestv1.AuthMetadata{
+			ConfigSchemaPath: authReleaseSchemaPath,
+		},
+	})
+	writeTestFile(t, pluginDir, authReleaseSchemaPath, []byte(`{"type":"object"}`), 0o644)
+	writeFakePythonReleaseInterpreterForKind(
+		t,
+		filepath.Join(pluginDir, ".venv", "bin", "python"),
+		"provider:auth_provider",
+		"auth",
+		pythonAuthReleasePluginName,
+		runtime.GOOS,
+		runtime.GOARCH,
+	)
+	return pluginDir
+}
+
+func newPythonSourceDatastoreReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(dir, pythonDatastoreReleasePluginName)
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(pluginDir): %v", err)
+	}
+	writeTestFile(t, pluginDir, "pyproject.toml", []byte(`[build-system]
+requires = ["setuptools==82.0.1"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "`+pythonDatastoreReleasePluginName+`"
+version = "0.0.1-alpha.1"
+dependencies = ["gestalt"]
+
+[tool.gestalt]
+datastore = "provider:datastore_provider"
+`), 0o644)
+	writeTestFile(t, pluginDir, "provider.py", []byte(`datastore_provider = object()
+`), 0o644)
+	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
+		Source:      pythonDatastoreReleaseSource,
+		Version:     "0.0.1",
+		DisplayName: "Python Datastore Release",
+		Kinds:       []string{pluginmanifestv1.KindDatastore},
+		Datastore: &pluginmanifestv1.DatastoreMetadata{
+			ConfigSchemaPath: datastoreReleaseSchemaPath,
+		},
+	})
+	writeTestFile(t, pluginDir, datastoreReleaseSchemaPath, []byte(`{"type":"object"}`), 0o644)
+	writeFakePythonReleaseInterpreterForKind(
+		t,
+		filepath.Join(pluginDir, ".venv", "bin", "python"),
+		"provider:datastore_provider",
+		"datastore",
+		pythonDatastoreReleasePluginName,
+		runtime.GOOS,
+		runtime.GOARCH,
+	)
+	return pluginDir
+}
+
 func writeFakePythonReleaseInterpreter(t *testing.T, path, expectedGOOS, expectedGOARCH string) {
+	t.Helper()
+	writeFakePythonReleaseInterpreterForKind(
+		t,
+		path,
+		"provider",
+		"integration",
+		"python-release",
+		expectedGOOS,
+		expectedGOARCH,
+	)
+}
+
+func writeFakePythonReleaseInterpreterForKind(
+	t *testing.T,
+	path string,
+	expectedTarget string,
+	expectedRuntimeKind string,
+	expectedName string,
+	expectedGOOS string,
+	expectedGOARCH string,
+) {
 	t.Helper()
 
 	script := `#!/bin/sh
@@ -1581,7 +1828,7 @@ if [ "$#" -ge 2 ] && [ "$1" = "-m" ] && [ "$2" = "gestalt._build" ]; then
     echo "missing GESTALT_TEST_PYINSTALLER_BINARY" >&2
     exit 1
   fi
-  if [ "$#" -ne 8 ]; then
+  if [ "$#" -ne 9 ]; then
     echo "unexpected gestalt._build args: $*" >&2
     exit 1
   fi
@@ -1589,14 +1836,19 @@ if [ "$#" -ge 2 ] && [ "$1" = "-m" ] && [ "$2" = "gestalt._build" ]; then
   target="$4"
   output="$5"
   name="$6"
-  goos="$7"
-  goarch="$8"
-  if [ "$target" != "provider" ]; then
+  runtime_kind="$7"
+  goos="$8"
+  goarch="$9"
+  if [ "$target" != "` + expectedTarget + `" ]; then
     echo "unexpected provider target: $target" >&2
     exit 1
   fi
-  if [ "$name" != "python-release" ]; then
+  if [ "$name" != "` + expectedName + `" ]; then
     echo "unexpected plugin name: $name" >&2
+    exit 1
+  fi
+  if [ "$runtime_kind" != "` + expectedRuntimeKind + `" ]; then
+    echo "unexpected runtime kind: $runtime_kind" >&2
     exit 1
   fi
   if [ "$goos" != "` + expectedGOOS + `" ] || [ "$goarch" != "` + expectedGOARCH + `" ]; then
@@ -1614,6 +1866,20 @@ if [ "$#" -ge 2 ] && [ "$1" = "-m" ] && [ "$2" = "gestalt._build" ]; then
 fi
 
 if [ "$#" -ge 2 ] && [ "$1" = "-m" ] && [ "$2" = "gestalt._runtime" ]; then
+  if [ "$#" -ne 5 ]; then
+    echo "unexpected gestalt._runtime args: $*" >&2
+    exit 1
+  fi
+  target="$4"
+  runtime_kind="$5"
+  if [ "$target" != "` + expectedTarget + `" ]; then
+    echo "unexpected runtime target: $target" >&2
+    exit 1
+  fi
+  if [ "$runtime_kind" != "` + expectedRuntimeKind + `" ]; then
+    echo "unexpected runtime kind: $runtime_kind" >&2
+    exit 1
+  fi
   if [ -z "${GESTALT_PLUGIN_WRITE_CATALOG:-}" ]; then
     echo "missing GESTALT_PLUGIN_WRITE_CATALOG" >&2
     exit 1
@@ -1658,8 +1924,12 @@ func expectedPythonReleasePlatform(goos, goarch string) releasePlatform {
 	return plat
 }
 
+func expectedPythonArchiveNameFor(pluginName, version, goos, goarch string) string {
+	return platformArchiveName(pluginName, version, expectedPythonReleasePlatform(goos, goarch))
+}
+
 func expectedPythonArchiveName(version, goos, goarch string) string {
-	return platformArchiveName("python-release", version, expectedPythonReleasePlatform(goos, goarch))
+	return expectedPythonArchiveNameFor("python-release", version, goos, goarch)
 }
 
 func expectedGoReleasePlatform(goos, goarch, libc string) releasePlatform {
@@ -1822,6 +2092,17 @@ func newRustSourceDatastoreReleaseFixture(t *testing.T, dir string) string {
 	})
 	writeTestFile(t, pluginDir, datastoreReleaseSchemaPath, []byte(`{"type":"object"}`), 0o644)
 	return pluginDir
+}
+
+func buildGoSourceComponentBinaryForTest(t *testing.T, pluginDir, kind string) string {
+	t.Helper()
+
+	outputDir := t.TempDir()
+	outputPath := filepath.Join(outputDir, releaseBinaryName(filepath.Base(pluginDir), runtime.GOOS))
+	if _, err := pluginpkg.BuildSourceComponentReleaseBinary(pluginDir, outputPath, kind, runtime.GOOS, runtime.GOARCH, ""); err != nil {
+		t.Fatalf("BuildSourceComponentReleaseBinary(%s): %v", kind, err)
+	}
+	return outputPath
 }
 
 func pathWithoutGo(t *testing.T) string {

--- a/gestaltd/internal/drivers/auth/plugin/factory.go
+++ b/gestaltd/internal/drivers/auth/plugin/factory.go
@@ -26,7 +26,7 @@ var Factory bootstrap.AuthFactory = func(node yaml.Node, deps bootstrap.Deps) (c
 	prepared, err := componentplugin.PrepareExecution(componentplugin.PrepareParams{
 		Kind:                 pluginmanifestv1.KindAuth,
 		Subject:              "plugin auth",
-		SourceMissingMessage: "no Go or Rust auth source package found",
+		SourceMissingMessage: "no Go, Rust, or Python auth source package found",
 		Config:               cfg.YAMLConfig,
 	})
 	if err != nil {

--- a/gestaltd/internal/drivers/datastore/plugin/factory.go
+++ b/gestaltd/internal/drivers/datastore/plugin/factory.go
@@ -19,7 +19,7 @@ var Factory bootstrap.DatastoreFactory = func(node yaml.Node, deps bootstrap.Dep
 	prepared, err := componentplugin.PrepareExecution(componentplugin.PrepareParams{
 		Kind:                 pluginmanifestv1.KindDatastore,
 		Subject:              "plugin datastore",
-		SourceMissingMessage: "no Go or Rust datastore source package found",
+		SourceMissingMessage: "no Go, Rust, or Python datastore source package found",
 		Config:               cfg,
 	})
 	if err != nil {

--- a/gestaltd/internal/pluginpkg/go_provider.go
+++ b/gestaltd/internal/pluginpkg/go_provider.go
@@ -86,7 +86,7 @@ func BuildGoComponentBinary(root, outputPath, kind, goos, goarch string) error {
 }
 
 func SourceComponentExecutionCommand(root, kind, goos, goarch string) (string, []string, func(), error) {
-	sourceKind, err := detectSourceComponent(root, kind, goos, goarch)
+	sourceKind, pythonTarget, err := detectSourceComponent(root, kind, goos, goarch)
 	if err != nil {
 		return "", nil, nil, err
 	}
@@ -94,22 +94,34 @@ func SourceComponentExecutionCommand(root, kind, goos, goarch string) (string, [
 	case sourceProviderKindGo:
 		command, cleanup, err := BuildGoComponentTempBinary(root, kind, goos, goarch)
 		if err != nil {
+			if errors.Is(err, ErrNoSourceComponentPackage) {
+				return "", nil, nil, err
+			}
 			return "", nil, nil, fmt.Errorf("build source %s temp binary: %w", kind, err)
 		}
 		return command, nil, cleanup, nil
 	case sourceProviderKindRust:
 		return rustComponentExecutionCommand(root, kind, goos, goarch)
+	case sourceProviderKindPython:
+		runtimeKind, err := pythonRuntimeKind(kind)
+		if err != nil {
+			return "", nil, nil, err
+		}
+		return pythonComponentExecutionCommand(root, pythonTarget, runtimeKind)
 	default:
 		return "", nil, nil, ErrNoSourceComponentPackage
 	}
 }
 
 func ValidateSourceComponentRelease(root, kind, goos, goarch, libc string) error {
-	sourceKind, err := detectSourceComponent(root, kind, goos, goarch)
+	sourceKind, _, err := detectSourceComponent(root, kind, goos, goarch)
 	if err != nil {
 		return err
 	}
 	switch sourceKind {
+	case sourceProviderKindPython:
+		_, err = DetectPythonInterpreter(root, goos, goarch)
+		return err
 	case sourceProviderKindRust:
 		return ValidateRustComponentRelease(root, kind, goos, goarch, libc)
 	default:
@@ -118,7 +130,7 @@ func ValidateSourceComponentRelease(root, kind, goos, goarch, libc string) error
 }
 
 func BuildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch, libc string) (string, error) {
-	sourceKind, err := detectSourceComponent(root, kind, goos, goarch)
+	sourceKind, pythonTarget, err := detectSourceComponent(root, kind, goos, goarch)
 	if err != nil {
 		return "", err
 	}
@@ -127,13 +139,20 @@ func BuildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch, lib
 		return "", BuildGoComponentBinary(root, outputPath, kind, goos, goarch)
 	case sourceProviderKindRust:
 		return BuildRustComponentBinary(root, outputPath, kind, goos, goarch, libc)
+	case sourceProviderKindPython:
+		runtimeKind, err := pythonRuntimeKind(kind)
+		if err != nil {
+			return "", err
+		}
+		pluginName := sourcePluginName(root)
+		return BuildPythonComponentBinary(root, outputPath, pluginName, pythonTarget, runtimeKind, goos, goarch)
 	default:
 		return "", ErrNoSourceComponentPackage
 	}
 }
 
 func HasSourceComponentPackage(root, kind string) (bool, error) {
-	_, err := detectSourceComponent(root, kind, runtime.GOOS, runtime.GOARCH)
+	_, _, err := detectSourceComponent(root, kind, runtime.GOOS, runtime.GOARCH)
 	switch {
 	case err == nil:
 		return true, nil
@@ -141,6 +160,39 @@ func HasSourceComponentPackage(root, kind string) (bool, error) {
 		return false, nil
 	default:
 		return false, err
+	}
+}
+
+func detectSourceComponent(root, kind, goos, goarch string) (sourceKind string, pythonTarget string, err error) {
+	if err := validateSourceComponentKind(kind); err != nil {
+		return "", "", err
+	}
+
+	var goToolUnavailable error
+	if _, err := DetectGoComponentImportPath(root, kind, goos, goarch); err == nil {
+		return sourceProviderKindGo, "", nil
+	} else if errors.Is(err, ErrGoToolUnavailable) {
+		goToolUnavailable = err
+	} else if !errors.Is(err, ErrNoSourceComponentPackage) {
+		return "", "", err
+	}
+
+	if _, err := detectRustPackage(root); err == nil {
+		return sourceProviderKindRust, "", nil
+	} else if !errors.Is(err, ErrNoRustProviderPackage) {
+		return "", "", err
+	}
+
+	target, err := DetectPythonComponentTarget(root, kind)
+	switch {
+	case err == nil:
+		return sourceProviderKindPython, target, nil
+	case !errors.Is(err, ErrNoPythonSourceComponentPackage):
+		return "", "", err
+	case goToolUnavailable != nil:
+		return "", "", goToolUnavailable
+	default:
+		return "", "", ErrNoSourceComponentPackage
 	}
 }
 
@@ -403,32 +455,6 @@ func slugPluginName(value string) string {
 		return "plugin"
 	}
 	return cleaned
-}
-
-func detectSourceComponent(root, kind, goos, goarch string) (string, error) {
-	if err := validateSourceComponentKind(kind); err != nil {
-		return "", err
-	}
-
-	var goToolUnavailable error
-	if _, err := DetectGoComponentImportPath(root, kind, goos, goarch); err == nil {
-		return sourceProviderKindGo, nil
-	} else if errors.Is(err, ErrGoToolUnavailable) {
-		goToolUnavailable = err
-	} else if !errors.Is(err, ErrNoSourceComponentPackage) {
-		return "", err
-	}
-
-	if _, err := detectRustPackage(root); err == nil {
-		return sourceProviderKindRust, nil
-	} else if !errors.Is(err, ErrNoRustProviderPackage) {
-		return "", err
-	}
-
-	if goToolUnavailable != nil {
-		return "", goToolUnavailable
-	}
-	return "", ErrNoSourceComponentPackage
 }
 
 func validateSourceComponentKind(kind string) error {

--- a/gestaltd/internal/pluginpkg/python_provider.go
+++ b/gestaltd/internal/pluginpkg/python_provider.go
@@ -12,6 +12,8 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
 
 const (
@@ -22,14 +24,36 @@ const (
 )
 
 var ErrNoPythonProviderPackage = errors.New("no Python provider package found")
+var ErrNoPythonSourceComponentPackage = errors.New("no Python source component package found")
 
 var pythonIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 func DetectPythonProviderTarget(root string) (string, error) {
+	target, err := detectPythonProjectTarget(root, "plugin")
+	if err != nil {
+		if errors.Is(err, ErrNoPythonSourceComponentPackage) {
+			return "", ErrNoPythonProviderPackage
+		}
+		return "", err
+	}
+	return target, nil
+}
+
+func DetectPythonComponentTarget(root, kind string) (string, error) {
+	if err := validateSourceComponentKind(kind); err != nil {
+		return "", err
+	}
+	return detectPythonProjectTarget(root, kind)
+}
+
+func detectPythonProjectTarget(root, key string) (string, error) {
 	projectPath := filepath.Join(root, pythonProjectFile)
 	if _, err := os.Stat(projectPath); err != nil {
 		if os.IsNotExist(err) {
-			return "", ErrNoPythonProviderPackage
+			if key == "plugin" {
+				return "", ErrNoPythonProviderPackage
+			}
+			return "", ErrNoPythonSourceComponentPackage
 		}
 		return "", fmt.Errorf("stat %s: %w", pythonProjectFile, err)
 	}
@@ -39,35 +63,50 @@ func DetectPythonProviderTarget(root string) (string, error) {
 		return "", fmt.Errorf("read %s: %w", pythonProjectFile, err)
 	}
 
-	target, err := pythonProjectPluginTarget(data)
+	target, err := pythonProjectTarget(data, key)
 	if err != nil {
 		return "", fmt.Errorf("parse %s: %w", pythonProjectFile, err)
 	}
 	target = strings.TrimSpace(target)
 	if target == "" {
-		return "", ErrNoPythonProviderPackage
+		if key == "plugin" {
+			return "", ErrNoPythonProviderPackage
+		}
+		return "", ErrNoPythonSourceComponentPackage
 	}
 	if _, _, err := SplitPythonProviderTarget(target); err != nil {
-		return "", fmt.Errorf("%s tool.gestalt.plugin: %w", pythonProjectFile, err)
+		return "", fmt.Errorf("%s tool.gestalt.%s: %w", pythonProjectFile, key, err)
 	}
 	return target, nil
 }
 
 func pythonProviderExecutionCommand(root, target string) (string, []string, func(), error) {
+	return pythonExecutionCommand(root, target, pythonRuntimeKindIntegration)
+}
+
+func pythonComponentExecutionCommand(root, target, runtimeKind string) (string, []string, func(), error) {
+	return pythonExecutionCommand(root, target, runtimeKind)
+}
+
+func pythonExecutionCommand(root, target, runtimeKind string) (string, []string, func(), error) {
 	interpreter, err := DetectPythonInterpreter(root, runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		return "", nil, nil, err
 	}
-	return interpreter, []string{"-m", pythonRuntimeModule, root, target}, nil, nil
+	return interpreter, []string{"-m", pythonRuntimeModule, root, target, runtimeKind}, nil, nil
 }
 
 func BuildPythonProviderBinary(sourceDir, binaryPath, pluginName, target, goos, goarch string) (string, error) {
+	return BuildPythonComponentBinary(sourceDir, binaryPath, pluginName, target, pythonRuntimeKindIntegration, goos, goarch)
+}
+
+func BuildPythonComponentBinary(sourceDir, binaryPath, pluginName, target, runtimeKind, goos, goarch string) (string, error) {
 	interpreter, err := DetectPythonInterpreter(sourceDir, goos, goarch)
 	if err != nil {
 		return "", fmt.Errorf("detect Python release interpreter for %s/%s: %w", goos, goarch, err)
 	}
 
-	cmd := exec.Command(interpreter, "-m", pythonBuildModule, sourceDir, target, binaryPath, pluginName, goos, goarch)
+	cmd := exec.Command(interpreter, "-m", pythonBuildModule, sourceDir, target, binaryPath, pluginName, runtimeKind, goos, goarch)
 	cmd.Dir = sourceDir
 	cmd.Env = append(os.Environ(), pythonBackendEnv()...)
 	cmd.Stdout = os.Stdout
@@ -203,6 +242,25 @@ func SplitPythonProviderTarget(target string) (module string, attr string, err e
 	}
 }
 
+const (
+	pythonRuntimeKindIntegration = "integration"
+	pythonRuntimeKindAuth        = "auth"
+	pythonRuntimeKindDatastore   = "datastore"
+)
+
+func pythonRuntimeKind(kind string) (string, error) {
+	switch kind {
+	case pluginmanifestv1.KindPlugin:
+		return pythonRuntimeKindIntegration, nil
+	case pluginmanifestv1.KindAuth:
+		return pythonRuntimeKindAuth, nil
+	case pluginmanifestv1.KindDatastore:
+		return pythonRuntimeKindDatastore, nil
+	default:
+		return "", fmt.Errorf("unsupported Python runtime kind %q", kind)
+	}
+}
+
 func isPythonModulePath(value string) bool {
 	parts := strings.Split(value, ".")
 	if len(parts) == 0 {
@@ -220,7 +278,7 @@ func isPythonIdentifier(value string) bool {
 	return pythonIdentifierPattern.MatchString(value)
 }
 
-func pythonProjectPluginTarget(data []byte) (string, error) {
+func pythonProjectTarget(data []byte, wantedKey string) (string, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	inGestaltSection := false
 	for scanner.Scan() {
@@ -237,7 +295,7 @@ func pythonProjectPluginTarget(data []byte) (string, error) {
 			continue
 		}
 		key, value, ok := strings.Cut(line, "=")
-		if !ok || strings.TrimSpace(key) != "plugin" {
+		if !ok || strings.TrimSpace(key) != wantedKey {
 			continue
 		}
 		return parseTOMLString(value)

--- a/gestaltd/internal/pluginpkg/python_provider_test.go
+++ b/gestaltd/internal/pluginpkg/python_provider_test.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
 
 func TestDetectPythonInterpreter_CurrentPlatformFallsBackToGenericVenv(t *testing.T) {
@@ -52,6 +54,79 @@ func TestDetectPythonInterpreter_CrossTargetRequiresExplicitInterpreter(t *testi
 	}
 	if want := pythonInterpreterEnvVar(goos, goarch); !containsString(err.Error(), want) {
 		t.Fatalf("error = %q, want mention of %s", err, want)
+	}
+}
+
+func TestDetectPythonComponentTarget(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte(`[tool.gestalt]
+plugin = "provider"
+auth = "provider:auth_provider"
+datastore = "provider:datastore_provider"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(pyproject.toml): %v", err)
+	}
+
+	authTarget, err := DetectPythonComponentTarget(root, pluginmanifestv1.KindAuth)
+	if err != nil {
+		t.Fatalf("DetectPythonComponentTarget(auth): %v", err)
+	}
+	if authTarget != "provider:auth_provider" {
+		t.Fatalf("auth target = %q, want %q", authTarget, "provider:auth_provider")
+	}
+
+	datastoreTarget, err := DetectPythonComponentTarget(root, pluginmanifestv1.KindDatastore)
+	if err != nil {
+		t.Fatalf("DetectPythonComponentTarget(datastore): %v", err)
+	}
+	if datastoreTarget != "provider:datastore_provider" {
+		t.Fatalf("datastore target = %q, want %q", datastoreTarget, "provider:datastore_provider")
+	}
+}
+
+func TestDetectPythonComponentTarget_MissingKindReturnsNoSourceComponentPackage(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte(`[tool.gestalt]
+plugin = "provider"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(pyproject.toml): %v", err)
+	}
+
+	_, err := DetectPythonComponentTarget(root, pluginmanifestv1.KindAuth)
+	if err == nil {
+		t.Fatal("expected missing auth target error")
+	}
+	if !strings.Contains(err.Error(), ErrNoPythonSourceComponentPackage.Error()) {
+		t.Fatalf("error = %q, want %q", err, ErrNoPythonSourceComponentPackage)
+	}
+}
+
+func TestPythonComponentExecutionCommand_PassesRuntimeKind(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	pythonPath := pythonTestInterpreterPath(root, runtime.GOOS, ".venv")
+	mustWritePythonInterpreter(t, pythonPath)
+
+	command, args, cleanup, err := pythonComponentExecutionCommand(root, "provider:auth_provider", pythonRuntimeKindAuth)
+	if err != nil {
+		t.Fatalf("pythonComponentExecutionCommand: %v", err)
+	}
+	if cleanup != nil {
+		t.Fatal("pythonComponentExecutionCommand cleanup = non-nil, want nil")
+	}
+	if command != pythonPath {
+		t.Fatalf("command = %q, want %q", command, pythonPath)
+	}
+	if len(args) != 5 {
+		t.Fatalf("args = %q, want 5 args", args)
+	}
+	if got := strings.Join(args, " "); got != "-m gestalt._runtime "+root+" provider:auth_provider auth" {
+		t.Fatalf("args = %q", got)
 	}
 }
 

--- a/gestaltd/internal/pluginpkg/source_provider_test.go
+++ b/gestaltd/internal/pluginpkg/source_provider_test.go
@@ -36,7 +36,7 @@ func TestDetectSourceComponent_WorkspaceCargoManifestIsMiss(t *testing.T) {
 	root := t.TempDir()
 	writeRustWorkspaceCargoToml(t, root)
 
-	_, err := detectSourceComponent(root, pluginmanifestv1.KindAuth, runtime.GOOS, runtime.GOARCH)
+	_, _, err := detectSourceComponent(root, pluginmanifestv1.KindAuth, runtime.GOOS, runtime.GOARCH)
 	if !errors.Is(err, ErrNoSourceComponentPackage) {
 		t.Fatalf("error = %v, want %v", err, ErrNoSourceComponentPackage)
 	}


### PR DESCRIPTION
## Summary
- generalize host-side source component detection so auth/datastore providers can come from Go or Python packages
- route auth/datastore source execution and release builds through the Python runtime/build contract when the source package is Python
- update release and missing-source tests to cover Python auth/datastore providers with fake interpreters

## Testing
- `go test ./internal/pluginpkg ./internal/drivers/auth/plugin ./internal/drivers/datastore/plugin`
- `go test ./cmd/gestaltd -run 'TestRun_PluginReleaseBuildsPythonSourcePluginForCurrentPlatform|TestRun_PluginReleaseBuildsPythonSourceAuthPlugin|TestRun_PluginReleaseBuildsPythonSourceDatastorePlugin|TestRun_PluginReleaseRejectsRequiredExecutableKindsWithoutSourceOrEntrypoint'`