### PR TITLE
[codex] treat web ui as a managed provider

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -341,8 +341,6 @@ jobs:
           version: 0.0.1-alpha.1
           display_name: Default Web UI
           description: Local CI web UI fixture
-          kinds:
-            - webui
           webui:
             asset_root: out
           EOF

--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -329,8 +329,23 @@ jobs:
       - name: Build frontend
         run: cd gestaltd/ui && npm ci && npm run build
 
-      - name: Copy frontend assets
-        run: rm -rf gestaltd/internal/webui/out && cp -r gestaltd/ui/out gestaltd/internal/webui/out
+      - name: Create local default web UI provider fixture
+        run: |
+          provider_dir="$GITHUB_WORKSPACE/gestalt-providers/web/default"
+          mkdir -p "$provider_dir"
+          rm -rf "$provider_dir/out"
+          cp -r "$GITHUB_WORKSPACE/gestaltd/ui/out" "$provider_dir/out"
+
+          cat >"$provider_dir/plugin.yaml" <<'EOF'
+          source: github.com/valon-technologies/gestalt-providers/web/default
+          version: 0.0.1-alpha.1
+          display_name: Default Web UI
+          description: Local CI web UI fixture
+          kinds:
+            - webui
+          webui:
+            asset_root: out
+          EOF
 
       - name: Build Go server
         run: |

--- a/docs/content/client/web.mdx
+++ b/docs/content/client/web.mdx
@@ -28,4 +28,10 @@ When `auth.provider` is set to `google` or `oidc`, the web UI redirects to your 
 
 ## Custom UI bundles
 
-The built-in web UI ships with `gestaltd`. To replace it with a custom frontend, configure `ui.plugin` in your server config to point at a packaged UI bundle. The built-in admin UI at `/admin` remains available regardless. See [Releasing](/providers/releasing) for the bundle format.
+The public web UI is configured through `ui.provider`.
+
+- Omit `ui` to use the pinned first-party default UI bundle.
+- Set `ui.provider: none` to run headless with no public UI at `/`.
+- Set `ui.provider.source` to a packaged `webui` bundle to bring your own frontend.
+
+The built-in admin UI at `/admin` remains available regardless. See [Releasing](/providers/releasing) for the bundle format.

--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -177,7 +177,7 @@ client UI hostname.
 
 ## When to enable `pluginInit`
 
-Enable the init container when your config uses `plugins.*.provider.source.ref` or `ui.plugin.source` and you want that state prepared before the main container starts. The init container copies the rendered config and runs:
+Enable the init container when your config uses `plugins.*.provider.source.ref`, `auth.provider.source.ref`, `datastore.provider.source.ref`, or `ui.provider.source.ref` and you want that state prepared before the main container starts. The init container copies the rendered config and runs:
 
 `/gestaltd init --config /etc/gestalt/config.yaml`
 

--- a/docs/content/providers/releasing.mdx
+++ b/docs/content/providers/releasing.mdx
@@ -161,13 +161,16 @@ artifacts:
 UI packages use the same manifest system:
 
 ```yaml
-source: github.com/acme/plugins/gestalt-ui
+source: github.com/acme/plugins/web/default
 version: 1.2.0
+kinds:
+  - webui
 webui:
   asset_root: ui/out
+  config_schema_path: schemas/ui-config.schema.json
 ```
 
-`gestaltd init` prepares the released UI and records it in `gestalt.lock.json`. `gestaltd serve --locked` then serves the prepared asset root at `/`. If `ui.plugin` is omitted, Gestalt falls back to the built-in client UI. The built-in admin UI remains available at `/admin` regardless.
+`gestaltd init` prepares the released UI and records it in `gestalt.lock.json`. `gestaltd serve --locked` then serves the prepared asset root at `/`. Omit `ui` to use the pinned first-party default UI bundle, or set `ui.provider: none` to disable the public UI. The built-in admin UI remains available at `/admin` regardless.
 
 ## Build a release
 
@@ -226,13 +229,16 @@ This is the recommended approach for production deployments.
 
 ### UI bundle
 
-Reference a released UI bundle separately under `ui.plugin`:
+Reference a released UI bundle separately under `ui.provider`:
 
 ```yaml
 ui:
-  plugin:
-    source: github.com/acme/plugins/gestalt-ui
-    version: 1.2.0
+  provider:
+    source:
+      ref: github.com/acme/plugins/web/default
+      version: 1.2.0
+  config:
+    brand_name: Acme
 ```
 
 ## Prepared state

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -707,17 +707,20 @@ egress:
 
 ```yaml
 ui:
-  plugin:
-    source: github.com/your-org/your-repo/console
-    version: 1.0.0
+  provider:
+    source:
+      ref: github.com/your-org/your-repo/web/console
+      version: 1.0.0
+  config:
+    brand_name: Acme
 ```
 
-`plugin.source` is a managed plugin source address and requires `plugin.version`, which must be valid SemVer without a leading `v`. `ui.plugin` provides the public client UI at `/`, while the built-in admin UI remains available at `/admin`. See [Releasing](/providers/releasing) for the full workflow.
+`ui.provider` controls the public client UI at `/`, while the built-in admin UI remains available at `/admin`. Omit `ui` to use the pinned first-party default UI bundle. Set `ui.provider: none` to disable the public UI entirely. Or set `ui.provider.source` to a packaged `webui` bundle. See [Releasing](/providers/releasing) for the full workflow.
 
 | Field | Description |
 | --- | --- |
-| `plugin.source` | **Required** when `ui.plugin` is configured. Managed plugin source address. |
-| `plugin.version` | **Required** with `plugin.source`. SemVer without a leading `v`. |
+| `provider` | `none` to disable the public UI, or a provider mapping with `source.path` or `source.ref`. |
+| `config` | Optional UI-provider config validated against the bundle schema when present. |
 
 ## Validation rules
 
@@ -731,7 +734,7 @@ Auth and datastore providers use the same PluginDef shape. When `auth.provider` 
 
 Only `connections.default` may define `params` or `discovery`. `mcp.tool_prefix` is valid only when `mcp.enabled` is `true`. All connections in an integration must share the same mode.
 
-`ui.plugin.source` is required when `ui.plugin` is configured, and `ui.plugin.version` is required with `ui.plugin.source`.
+`ui.provider` must be either `none` or a provider mapping with exactly one loading mode: local `ui.provider.source.path` or managed `ui.provider.source.ref`. `ui.provider.source.version` is required with `ui.provider.source.ref` and invalid with `ui.provider.source.path`. `ui.config` is only allowed when `ui.provider` is not `none`.
 
 `egress.default_action` must be `allow` or `deny`. Each egress policy rule requires an `action`. Each egress credential grant requires `secret_ref` (as a bare name, not a `secret://` URI) and at least one match criterion.
 

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -3,7 +3,7 @@
 `gestaltd` is a platform for self-hostable, configurable integrations and tooling. You describe your platform in one YAML file, and `gestaltd` turns that file into a running server with:
 
 - an HTTP API
-- a client UI at `/`
+- a public client UI at `/` when enabled
 - a built-in admin UI at `/admin`
 - `/health` and `/ready` endpoints
 - an `/mcp` endpoint when providers expose tools
@@ -24,7 +24,8 @@
 - This image is not zero-config. Mount or bake a config file before starting it.
 - Locked startup is the default. If your config uses
   `plugins.*.provider.source.ref`, `auth.provider.source.ref`,
-  `datastore.provider.source.ref`, or `ui.plugin.source`, run `init` first.
+  `datastore.provider.source.ref`, or `ui.provider.source.ref`, run `init`
+  first.
 
 ## Supported tags
 
@@ -75,6 +76,8 @@ datastore:
     path: /data/gestalt.db
 
 plugins: {}
+ui:
+  provider: none
 ```
 
 Example with a separate internal-only management listener:
@@ -98,6 +101,8 @@ datastore:
     path: /data/gestalt.db
 
 plugins: {}
+ui:
+  provider: none
 ```
 
 ```sh
@@ -198,11 +203,13 @@ The container exposes:
 - `GET /health` for liveness
 - `GET /ready` for readiness
 
-By default the client UI is served from `/` and the built-in admin UI is served
-from `/admin` on the public listener. If you configure `server.management`, then
-`/admin`, `/metrics`, `/health`, and `/ready` move to the management listener
-instead. That split is the recommended production deployment shape; the
-single-listener mode is mainly for local development and trusted-network use.
+The built-in admin UI is served from `/admin`. The public client UI at `/` is
+controlled by `ui.provider`: set `ui.provider: none` to disable it, omit `ui`
+to use the pinned first-party default bundle, or point `ui.provider.source` at
+your own packaged UI. If you configure `server.management`, then `/admin`,
+`/metrics`, `/health`, and `/ready` move to the management listener instead.
+That split is the recommended production deployment shape; the single-listener
+mode is mainly for local development and trusted-network use.
 
 ## SQLite and `/data`
 

--- a/gestaltd/Dockerfile
+++ b/gestaltd/Dockerfile
@@ -5,20 +5,12 @@ ARG GESTALT_SOURCE=https://github.com/valon-technologies/gestalt
 ARG GESTALT_DOCUMENTATION=https://gestaltd.ai
 ARG GESTALT_URL=https://hub.docker.com/r/valontechnologies/gestaltd
 
-FROM --platform=$BUILDPLATFORM node:25.9.0-alpine3.23@sha256:ad82ecad30371c43f4057aaa4800a8ed88f9446553a2d21323710c7b937177fc AS frontend
-WORKDIR /ui
-COPY gestaltd/ui/package.json gestaltd/ui/package-lock.json ./
-RUN npm ci
-COPY gestaltd/ui/ .
-RUN npm run build
-
 FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine3.23@sha256:c2a1f7b2095d046ae14b286b18413a05bb82c9bca9b25fe7ff5efef0f0826166 AS build-binary
 WORKDIR /build
 COPY gestaltd/go.mod gestaltd/go.sum gestaltd/
 COPY sdk/go/go.mod sdk/go/go.sum sdk/go/
 RUN cd gestaltd && go mod download
 COPY . .
-COPY --from=frontend /ui/out/ gestaltd/internal/webui/out/
 ARG TARGETARCH
 RUN mkdir -p /out && \
     cd gestaltd && \

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -1468,11 +1468,11 @@ func setupPluginDirWithVersion(t *testing.T, baseDir, version string) string {
 func setupAuthProviderDir(t *testing.T, baseDir, name string) string {
 	t.Helper()
 
-	providerDir := filepath.Join(baseDir, "components", "auth", name)
+	providerDir := filepath.Join(baseDir, "auth", name)
 	if err := os.MkdirAll(providerDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(%s): %v", providerDir, err)
 	}
-	writeTestFile(t, providerDir, "go.mod", []byte(testutil.GeneratedProviderModuleSource(t, "example.com/components/auth/"+name)), 0o644)
+	writeTestFile(t, providerDir, "go.mod", []byte(testutil.GeneratedProviderModuleSource(t, "example.com/providers/auth/"+name)), 0o644)
 	writeTestFile(t, providerDir, "go.sum", testutil.GeneratedProviderModuleSum(t), 0o644)
 	writeTestFile(t, providerDir, "auth.go", []byte(authProviderSource(name)), 0o644)
 	artifactRel := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "auth-provider"))
@@ -1512,11 +1512,11 @@ func authProviderSource(name string) string {
 func setupDatastoreProviderDir(t *testing.T, baseDir, name string) string {
 	t.Helper()
 
-	providerDir := filepath.Join(baseDir, "components", "datastore", name)
+	providerDir := filepath.Join(baseDir, "datastore", name)
 	if err := os.MkdirAll(providerDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(%s): %v", providerDir, err)
 	}
-	writeTestFile(t, providerDir, "go.mod", []byte(testutil.GeneratedProviderModuleSource(t, "example.com/components/datastore/"+name)), 0o644)
+	writeTestFile(t, providerDir, "go.mod", []byte(testutil.GeneratedProviderModuleSource(t, "example.com/providers/datastore/"+name)), 0o644)
 	writeTestFile(t, providerDir, "go.sum", testutil.GeneratedProviderModuleSum(t), 0o644)
 	writeTestFile(t, providerDir, "datastore.go", []byte(testutil.GeneratedDatastorePackageSource()), 0o644)
 	artifactRel := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "datastore-provider"))
@@ -1537,6 +1537,26 @@ func setupDatastoreProviderDir(t *testing.T, baseDir, name string) string {
 		},
 		Entrypoints: pluginmanifestv1.Entrypoints{
 			Datastore: &pluginmanifestv1.Entrypoint{ArtifactPath: artifactRel},
+		},
+	})
+	return providerDir
+}
+
+func setupWebProviderDir(t *testing.T, baseDir, name string) string {
+	t.Helper()
+
+	providerDir := filepath.Join(baseDir, "web", name)
+	if err := os.MkdirAll(providerDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", providerDir, err)
+	}
+	writeTestFile(t, providerDir, "out/index.html", []byte("<!doctype html><title>test web ui</title>"), 0o644)
+	writeManifestFile(t, providerDir, &pluginmanifestv1.Manifest{
+		Source:      "github.com/test/providers/web/" + name,
+		Version:     "0.0.1-alpha.1",
+		DisplayName: "Test Web " + name,
+		Kinds:       []string{pluginmanifestv1.KindWebUI},
+		WebUI: &pluginmanifestv1.WebUIMetadata{
+			AssetRoot: "out",
 		},
 	})
 	return providerDir
@@ -1571,6 +1591,8 @@ func authDatastoreConfigYAML(t *testing.T, dir, authName, datastoreName, dbPath 
       path: %s
   config:
     path: %s
+ui:
+  provider: none
 `, authBlock, datastoreManifestPath, dbPath)
 }
 

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -1554,7 +1554,6 @@ func setupWebProviderDir(t *testing.T, baseDir, name string) string {
 		Source:      "github.com/test/providers/web/" + name,
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Test Web " + name,
-		Kinds:       []string{pluginmanifestv1.KindWebUI},
 		WebUI: &pluginmanifestv1.WebUIMetadata{
 			AssetRoot: "out",
 		},

--- a/gestaltd/cmd/gestaltd/prepared_plugin_e2e_test.go
+++ b/gestaltd/cmd/gestaltd/prepared_plugin_e2e_test.go
@@ -96,13 +96,14 @@ func TestE2EDefaultStartAutoGeneratesHomeConfig(t *testing.T) {
 	providersDir := filepath.Join(t.TempDir(), "providers")
 	_ = setupAuthProviderDir(t, providersDir, "none")
 	_ = setupDatastoreProviderDir(t, providersDir, "sqlite")
+	_ = setupWebProviderDir(t, providersDir, "default")
 	configPath := filepath.Join(homeDir, ".gestaltd", "config.yaml")
 
 	cmd := exec.Command(gestaltdBin)
 	cmd.Env = withoutEnvVar(os.Environ(), "GESTALT_CONFIG")
 	cmd.Env = append(cmd.Env,
 		"HOME="+homeDir,
-		"GESTALT_PROVIDERS_DIR="+filepath.Join(providersDir, "components"),
+		"GESTALT_PROVIDERS_DIR="+providersDir,
 		"GOMODCACHE="+goEnvPath(t, "GOMODCACHE"),
 		"GOCACHE="+goEnvPath(t, "GOCACHE"),
 	)

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -316,13 +316,16 @@ func resolveClientUIHandler(cfg *config.Config) (http.Handler, error) {
 	if dir := strings.TrimSpace(os.Getenv(clientUIDirEnv)); dir != "" {
 		return webui.DirHandler(dir)
 	}
-	if cfg.UI.Plugin == nil {
-		return webui.EmbeddedHandler(), nil
+	if cfg.UI.Disabled {
+		return http.NotFoundHandler(), nil
 	}
-	if cfg.UI.Plugin.ResolvedAssetRoot != "" {
-		return webui.DirHandler(cfg.UI.Plugin.ResolvedAssetRoot)
+	if cfg.UI.ResolvedAssetRoot != "" {
+		return webui.DirHandler(cfg.UI.ResolvedAssetRoot)
 	}
-	return nil, fmt.Errorf("ui plugin configured but asset root not resolved")
+	if cfg.UI.Provider == nil {
+		return http.NotFoundHandler(), nil
+	}
+	return nil, fmt.Errorf("ui provider configured but asset root not resolved")
 }
 
 func resolveAdminUIHandler(opts adminui.Options) (http.Handler, error) {

--- a/gestaltd/deploy/helm/gestalt/values.yaml
+++ b/gestaltd/deploy/helm/gestalt/values.yaml
@@ -98,6 +98,10 @@ config:
         version: 0.0.1-alpha.1
     config:
       path: /data/gestalt.db
+  # Keep the default chart profile self-contained. Set this to a managed
+  # provider source when you want a public web UI.
+  ui:
+    provider: none
 
 # Extra environment variables for the container. These are only required
 # when your config uses ${VAR} placeholders for auth, base_url, or

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -484,6 +484,16 @@ func buildPluginProvider(ctx context.Context, intg config.IntegrationDef, plugin
 		if err != nil {
 			return nil, fmt.Errorf("prepare synthesized source provider execution: %w", err)
 		}
+		execEnv, err := pluginpkg.SourceProviderExecutionEnv(rootDir, runtime.GOOS, runtime.GOARCH)
+		if err != nil {
+			return nil, fmt.Errorf("prepare synthesized source provider environment: %w", err)
+		}
+		if len(execEnv) > 0 {
+			if env == nil {
+				env = make(map[string]string, len(execEnv))
+			}
+			maps.Copy(env, execEnv)
+		}
 	}
 	if cleanup != nil {
 		defer func() {

--- a/gestaltd/internal/bootstrap/secret_resolution.go
+++ b/gestaltd/internal/bootstrap/secret_resolution.go
@@ -70,8 +70,8 @@ func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretMa
 			return err
 		}
 	}
-	if cfg.UI.Plugin != nil {
-		if err := resolveStringFields(cfg.UI.Plugin, resolve); err != nil {
+	if cfg.UI.Provider != nil {
+		if err := resolveStringFields(cfg.UI.Provider, resolve); err != nil {
 			return err
 		}
 	}
@@ -81,6 +81,9 @@ func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretMa
 		return err
 	}
 	if err := resolveYAMLNode(&cfg.Datastore.Config, resolve); err != nil {
+		return err
+	}
+	if err := resolveYAMLNode(&cfg.UI.Config, resolve); err != nil {
 		return err
 	}
 	if err := resolveYAMLNode(&cfg.Telemetry.Config, resolve); err != nil {

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -22,6 +22,12 @@ const (
 	IntegrationCallbackPath = "/api/v1/auth/callback"
 )
 
+const (
+	DefaultProviderRepo    = "github.com/valon-technologies/gestalt-providers"
+	DefaultProviderVersion = "0.0.1-alpha.1"
+	DefaultWebUIProvider   = DefaultProviderRepo + "/web/default"
+)
+
 // PluginConnectionName is the implicit connection name used when storing
 // tokens for plugin-only integrations that do not declare YAML connections.
 const PluginConnectionName = "_plugin"
@@ -54,18 +60,10 @@ type AuditConfig struct {
 }
 
 type UIConfig struct {
-	Plugin *UIPluginDef `yaml:"plugin"`
-}
-
-type UIPluginDef struct {
-	Source  string `yaml:"source"`
-	Version string `yaml:"version"`
-
-	ResolvedAssetRoot string `yaml:"-"`
-}
-
-func (p *UIPluginDef) HasManagedArtifacts() bool {
-	return p != nil && p.Source != ""
+	Provider          *PluginDef `yaml:"provider"`
+	Config            yaml.Node  `yaml:"config"`
+	Disabled          bool       `yaml:"-"`
+	ResolvedAssetRoot string     `yaml:"-"`
 }
 
 type PluginSourceAuthDef struct {
@@ -217,6 +215,40 @@ func (c *DatastoreConfig) UnmarshalYAML(value *yaml.Node) error {
 	return unmarshalTopLevelComponentConfig(value, "DatastoreConfig", "datastore", &c.Provider, &c.Config)
 }
 
+func (c *UIConfig) UnmarshalYAML(value *yaml.Node) error {
+	if value == nil || value.Kind == 0 {
+		*c = UIConfig{}
+		return nil
+	}
+	if value.Kind != yaml.MappingNode {
+		var probe map[string]any
+		return value.Decode(&probe)
+	}
+	for i := 0; i+1 < len(value.Content); i += 2 {
+		key := value.Content[i].Value
+		switch key {
+		case "provider", "config":
+		default:
+			return fmt.Errorf("field %s not found in type config.UIConfig", key)
+		}
+	}
+	c.Provider = nil
+	c.Config = yaml.Node{}
+	c.Disabled = false
+	if providerNode := mappingValueNode(value, "provider"); providerNode != nil {
+		decoded, disabled, err := decodeUIProvider(providerNode)
+		if err != nil {
+			return err
+		}
+		c.Provider = decoded
+		c.Disabled = disabled
+	}
+	if configNode := mappingValueNode(value, "config"); configNode != nil {
+		c.Config = *configNode
+	}
+	return nil
+}
+
 func unmarshalTopLevelComponentConfig(value *yaml.Node, typeName, kind string, provider **PluginDef, cfg *yaml.Node) error {
 	if value == nil || value.Kind == 0 {
 		*provider = nil
@@ -269,6 +301,27 @@ func decodeTopLevelComponentProvider(kind string, node *yaml.Node) (*PluginDef, 
 		return nil, err
 	}
 	return &provider, nil
+}
+
+func decodeUIProvider(node *yaml.Node) (*PluginDef, bool, error) {
+	if node == nil || node.Kind == 0 {
+		return nil, false, nil
+	}
+	if node.Kind == yaml.ScalarNode {
+		value := strings.TrimSpace(node.Value)
+		if node.Tag == "!!null" || value == "" {
+			return nil, false, nil
+		}
+		if value == "none" {
+			return nil, true, nil
+		}
+		return nil, false, fmt.Errorf(`config validation: ui.provider must be a provider reference mapping or the string "none"`)
+	}
+	var provider PluginDef
+	if err := node.Decode(&provider); err != nil {
+		return nil, false, err
+	}
+	return &provider, false, nil
 }
 
 func authProviderScalarHint(kind string) string {
@@ -624,6 +677,9 @@ func OverlayManagedPluginConfig(path string, cfg *Config) error {
 	if err := overlayManagedComponentConfigNode(mappingValueNode(documentValueNode(&root), "datastore"), cfg.Datastore.Provider, &cfg.Datastore.Config, "datastore"); err != nil {
 		return err
 	}
+	if err := overlayManagedComponentConfigNode(mappingValueNode(documentValueNode(&root), "ui"), cfg.UI.Provider, &cfg.UI.Config, "ui"); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -782,6 +838,18 @@ func applyDefaults(cfg *Config) {
 	if cfg.Audit.Provider == "" {
 		cfg.Audit.Provider = "inherit"
 	}
+	if !cfg.UI.Disabled && cfg.UI.Provider == nil {
+		cfg.UI.Provider = defaultUIProvider()
+	}
+}
+
+func defaultUIProvider() *PluginDef {
+	return &PluginDef{
+		Source: &PluginSourceDef{
+			Ref:     DefaultWebUIProvider,
+			Version: DefaultProviderVersion,
+		},
+	}
 }
 
 func resolveBaseURL(cfg *Config) {
@@ -815,6 +883,9 @@ func resolveRelativePaths(configPath string, cfg *Config) {
 	}
 	if cfg.Datastore.Provider != nil && cfg.Datastore.Provider.Source != nil {
 		cfg.Datastore.Provider.Source.Path = resolveRelativePath(baseDir, cfg.Datastore.Provider.Source.Path)
+	}
+	if cfg.UI.Provider != nil && cfg.UI.Provider.Source != nil {
+		cfg.UI.Provider.Source.Path = resolveRelativePath(baseDir, cfg.UI.Provider.Source.Path)
 	}
 
 }

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -382,6 +382,124 @@ plugins:
 	}
 }
 
+func TestLoadConfigUIProviderModes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("omitted ui uses default provider", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+datastore:
+  provider:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/datastore/sqlite
+      version: 1.0.0
+server:
+  encryption_key: server-key
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.UI.Disabled {
+			t.Fatal("UI.Disabled = true, want false")
+		}
+		if cfg.UI.Provider == nil || cfg.UI.Provider.Source == nil {
+			t.Fatalf("UI.Provider = %#v, want default provider", cfg.UI.Provider)
+		}
+		if got := cfg.UI.Provider.Source.Ref; got != DefaultWebUIProvider {
+			t.Fatalf("UI.Provider.Source.Ref = %q, want %q", got, DefaultWebUIProvider)
+		}
+		if got := cfg.UI.Provider.Source.Version; got != DefaultProviderVersion {
+			t.Fatalf("UI.Provider.Source.Version = %q, want %q", got, DefaultProviderVersion)
+		}
+	})
+
+	t.Run("ui provider none disables public ui", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+ui:
+  provider: none
+datastore:
+  provider:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/datastore/sqlite
+      version: 1.0.0
+server:
+  encryption_key: server-key
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if !cfg.UI.Disabled {
+			t.Fatal("UI.Disabled = false, want true")
+		}
+		if cfg.UI.Provider != nil {
+			t.Fatalf("UI.Provider = %#v, want nil", cfg.UI.Provider)
+		}
+	})
+
+	t.Run("ui config is rejected with provider none", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+ui:
+  provider: none
+  config:
+    brand_name: Acme
+datastore:
+  provider:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/datastore/sqlite
+      version: 1.0.0
+server:
+  encryption_key: server-key
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `ui.config is not supported when ui.provider is "none"`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("relative ui provider path resolves from config directory", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+ui:
+  provider:
+    source:
+      path: ./web/default/plugin.yaml
+datastore:
+  provider:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/datastore/sqlite
+      version: 1.0.0
+server:
+  encryption_key: server-key
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.UI.Provider == nil || cfg.UI.Provider.Source == nil {
+			t.Fatalf("UI.Provider = %#v", cfg.UI.Provider)
+		}
+		wantPath := filepath.Join(filepath.Dir(path), "web", "default", "plugin.yaml")
+		if got := cfg.UI.Provider.Source.Path; got != wantPath {
+			t.Fatalf("UI.Provider.Source.Path = %q, want %q", got, wantPath)
+		}
+	})
+}
+
 func TestLoadConfigValidation(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -32,7 +32,7 @@ func ValidateStructure(cfg *Config) error {
 	if err := validateEgress(&cfg.Egress); err != nil {
 		return err
 	}
-	if err := validateUIPlugin(cfg.UI.Plugin); err != nil {
+	if err := validateUIConfig(cfg.UI); err != nil {
 		return err
 	}
 	if err := validateTopLevelComponentConfig("auth", cfg.Auth.Provider, cfg.Auth.Config); err != nil {
@@ -435,27 +435,17 @@ func validateAuthValueDef(integration, subject, path string, value AuthValueDef,
 	return nil
 }
 
-func validateUIPlugin(plugin *UIPluginDef) error {
-	if plugin == nil {
+func validateUIConfig(cfg UIConfig) error {
+	if cfg.Disabled {
+		if cfg.Config.Kind != 0 {
+			return fmt.Errorf(`config validation: ui.config is not supported when ui.provider is "none"`)
+		}
 		return nil
 	}
-	if plugin.Source == "" {
-		return fmt.Errorf("config validation: ui plugin.source is required")
+	if cfg.Provider == nil {
+		return nil
 	}
-
-	if plugin.Source != "" {
-		if _, err := pluginsource.Parse(plugin.Source); err != nil {
-			return fmt.Errorf("config validation: ui plugin.source: %w", err)
-		}
-		if plugin.Version == "" {
-			return fmt.Errorf("config validation: ui plugin.version is required when plugin.source is set")
-		}
-		if err := pluginsource.ValidateVersion(plugin.Version); err != nil {
-			return fmt.Errorf("config validation: ui plugin.version: %w", err)
-		}
-	}
-
-	return nil
+	return validateExternalPlugin("ui", "provider", cfg.Provider)
 }
 
 func validateServerListeners(cfg ServerConfig) error {

--- a/gestaltd/internal/drivers/componentplugin/factory.go
+++ b/gestaltd/internal/drivers/componentplugin/factory.go
@@ -3,6 +3,7 @@ package componentplugin
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"runtime"
 
@@ -52,6 +53,16 @@ func PrepareExecution(params PrepareParams) (PreparedConfig, error) {
 		}
 		if err != nil {
 			return PreparedConfig{}, fmt.Errorf("%s: prepare synthesized source execution: %w", params.Subject, err)
+		}
+		execEnv, err := pluginpkg.SourceComponentExecutionEnv(filepath.Dir(cfg.ManifestPath), params.Kind, runtime.GOOS, runtime.GOARCH)
+		if err != nil {
+			return PreparedConfig{}, fmt.Errorf("%s: prepare synthesized source environment: %w", params.Subject, err)
+		}
+		if len(execEnv) > 0 {
+			if cfg.Env == nil {
+				cfg.Env = make(map[string]string, len(execEnv))
+			}
+			maps.Copy(cfg.Env, execEnv)
 		}
 		cfg.Command = command
 		cfg.Args = args

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -556,6 +556,9 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 
 func (l *Lifecycle) writeUIProviderArtifact(ctx context.Context, cfg *config.Config, paths initPaths) (LockUIEntry, error) {
 	plugin := cfg.UI.Provider
+	if plugin == nil || !plugin.HasManagedSource() {
+		return LockUIEntry{}, fmt.Errorf("ui provider requires managed source")
+	}
 	configMap, err := config.NodeToMap(cfg.UI.Config)
 	if err != nil {
 		return LockUIEntry{}, fmt.Errorf("decode ui provider config: %w", err)
@@ -566,81 +569,52 @@ func (l *Lifecycle) writeUIProviderArtifact(ctx context.Context, cfg *config.Con
 	}
 
 	destDir := uiDestDir(paths)
-	var installed *pluginstore.InstalledPlugin
-	switch {
-	case plugin.HasManagedSource():
-		src, err := sourceForPlugin(plugin)
-		if err != nil {
-			return LockUIEntry{}, fmt.Errorf("ui provider source.ref %q: %w", plugin.SourceRef(), err)
-		}
-		if l.sourceResolver == nil {
-			return LockUIEntry{}, fmt.Errorf("ui provider: source resolution requires a source resolver")
-		}
-		resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
-		if err != nil {
-			return LockUIEntry{}, fmt.Errorf("ui provider resolve source %q@%s: %w", plugin.SourceRef(), plugin.SourceVersion(), err)
-		}
-		defer resolved.Cleanup()
-		installed, err = pluginstore.Install(resolved.LocalPath, destDir)
-		if err != nil {
-			return LockUIEntry{}, fmt.Errorf("ui provider install source: %w", err)
-		}
-		if err := validateInstalledManifestKind(pluginmanifestv1.KindWebUI, "provider", installed.Manifest); err != nil {
-			return LockUIEntry{}, err
-		}
-		if installed.Manifest.Source != plugin.SourceRef() {
-			return LockUIEntry{}, fmt.Errorf("ui provider manifest source %q does not match config source %q", installed.Manifest.Source, plugin.SourceRef())
-		}
-		if installed.Manifest.Version != plugin.SourceVersion() {
-			return LockUIEntry{}, fmt.Errorf("ui provider manifest version %q does not match config version %q", installed.Manifest.Version, plugin.SourceVersion())
-		}
-		if err := pluginpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, pluginmanifestv1.KindWebUI, configMap); err != nil {
-			return LockUIEntry{}, fmt.Errorf("plugin config validation for ui provider: %w", err)
-		}
-		manifestPath, err := filepath.Rel(paths.artifactsDir, installed.ManifestPath)
-		if err != nil {
-			return LockUIEntry{}, fmt.Errorf("compute manifest path for ui provider: %w", err)
-		}
-		assetRoot, err := filepath.Rel(paths.artifactsDir, installed.AssetRoot)
-		if err != nil {
-			return LockUIEntry{}, fmt.Errorf("compute asset root path for ui provider: %w", err)
-		}
-		return LockUIEntry{
-			Fingerprint:   fingerprint,
-			Source:        plugin.SourceRef(),
-			Version:       plugin.SourceVersion(),
-			ResolvedURL:   resolved.ResolvedURL,
-			ArchiveSHA256: resolved.ArchiveSHA256,
-			Manifest:      filepath.ToSlash(manifestPath),
-			AssetRoot:     filepath.ToSlash(assetRoot),
-		}, nil
-	case plugin.HasLocalSource():
-		installed, err := pluginstore.InstallFromDir(filepath.Dir(plugin.SourcePath()), destDir)
-		if err != nil {
-			return LockUIEntry{}, fmt.Errorf("ui provider install local source: %w", err)
-		}
-		if err := validateInstalledManifestKind(pluginmanifestv1.KindWebUI, "provider", installed.Manifest); err != nil {
-			return LockUIEntry{}, err
-		}
-		if err := pluginpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, pluginmanifestv1.KindWebUI, configMap); err != nil {
-			return LockUIEntry{}, fmt.Errorf("plugin config validation for ui provider: %w", err)
-		}
-		manifestPath, err := filepath.Rel(paths.artifactsDir, installed.ManifestPath)
-		if err != nil {
-			return LockUIEntry{}, fmt.Errorf("compute manifest path for ui provider: %w", err)
-		}
-		assetRoot, err := filepath.Rel(paths.artifactsDir, installed.AssetRoot)
-		if err != nil {
-			return LockUIEntry{}, fmt.Errorf("compute asset root path for ui provider: %w", err)
-		}
-		return LockUIEntry{
-			Fingerprint: fingerprint,
-			Manifest:    filepath.ToSlash(manifestPath),
-			AssetRoot:   filepath.ToSlash(assetRoot),
-		}, nil
+	src, err := sourceForPlugin(plugin)
+	if err != nil {
+		return LockUIEntry{}, fmt.Errorf("ui provider source.ref %q: %w", plugin.SourceRef(), err)
 	}
+	if l.sourceResolver == nil {
+		return LockUIEntry{}, fmt.Errorf("ui provider: source resolution requires a source resolver")
+	}
+	resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
+	if err != nil {
+		return LockUIEntry{}, fmt.Errorf("ui provider resolve source %q@%s: %w", plugin.SourceRef(), plugin.SourceVersion(), err)
+	}
+	defer resolved.Cleanup()
 
-	return LockUIEntry{}, fmt.Errorf("ui provider requires source")
+	installed, err := pluginstore.Install(resolved.LocalPath, destDir)
+	if err != nil {
+		return LockUIEntry{}, fmt.Errorf("ui provider install source: %w", err)
+	}
+	if err := validateInstalledManifestKind(pluginmanifestv1.KindWebUI, "provider", installed.Manifest); err != nil {
+		return LockUIEntry{}, err
+	}
+	if installed.Manifest.Source != plugin.SourceRef() {
+		return LockUIEntry{}, fmt.Errorf("ui provider manifest source %q does not match config source %q", installed.Manifest.Source, plugin.SourceRef())
+	}
+	if installed.Manifest.Version != plugin.SourceVersion() {
+		return LockUIEntry{}, fmt.Errorf("ui provider manifest version %q does not match config version %q", installed.Manifest.Version, plugin.SourceVersion())
+	}
+	if err := pluginpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, pluginmanifestv1.KindWebUI, configMap); err != nil {
+		return LockUIEntry{}, fmt.Errorf("plugin config validation for ui provider: %w", err)
+	}
+	manifestPath, err := filepath.Rel(paths.artifactsDir, installed.ManifestPath)
+	if err != nil {
+		return LockUIEntry{}, fmt.Errorf("compute manifest path for ui provider: %w", err)
+	}
+	assetRoot, err := filepath.Rel(paths.artifactsDir, installed.AssetRoot)
+	if err != nil {
+		return LockUIEntry{}, fmt.Errorf("compute asset root path for ui provider: %w", err)
+	}
+	return LockUIEntry{
+		Fingerprint:   fingerprint,
+		Source:        plugin.SourceRef(),
+		Version:       plugin.SourceVersion(),
+		ResolvedURL:   resolved.ResolvedURL,
+		ArchiveSHA256: resolved.ArchiveSHA256,
+		Manifest:      filepath.ToSlash(manifestPath),
+		AssetRoot:     filepath.ToSlash(assetRoot),
+	}, nil
 }
 
 func sourceForPlugin(plugin *config.PluginDef) (pluginsource.Source, error) {

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -841,9 +841,6 @@ func applyLocalUIManifest(plugin *config.PluginDef, configMap map[string]any, re
 	if err := bindResolvedUIManifest(plugin, manifestPath, manifest, configMap); err != nil {
 		return err
 	}
-	if manifest == nil || manifest.WebUI == nil {
-		return fmt.Errorf("ui provider manifest is missing webui metadata")
-	}
 	assetRoot := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(manifest.WebUI.AssetRoot))
 	if _, err := os.Stat(assetRoot); err != nil {
 		return fmt.Errorf("ui provider asset root not found at %s: %w", assetRoot, err)

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -113,8 +113,8 @@ func (l *Lifecycle) InitAtPathWithArtifactsDir(configPath, artifactsDir string) 
 		}
 		lock.Datastore = &entry
 	}
-	if cfg.UI.Plugin.HasManagedArtifacts() {
-		uiEntry, err := l.writeUIPluginArtifact(context.Background(), cfg, paths)
+	if cfg.UI.Provider != nil && cfg.UI.Provider.HasManagedArtifacts() {
+		uiEntry, err := l.writeUIProviderArtifact(context.Background(), cfg, paths)
 		if err != nil {
 			return nil, err
 		}
@@ -202,7 +202,7 @@ func configHasPluginLoading(cfg *config.Config) bool {
 	if cfg.Datastore.Provider != nil && (cfg.Datastore.Provider.HasManagedArtifacts() || cfg.Datastore.Provider.HasLocalSource()) {
 		return true
 	}
-	return cfg.UI.Plugin.HasManagedArtifacts()
+	return cfg.UI.Provider != nil && (cfg.UI.Provider.HasManagedArtifacts() || cfg.UI.Provider.HasLocalSource())
 }
 
 func configHasManagedPlugins(cfg *config.Config) bool {
@@ -217,7 +217,7 @@ func configHasManagedPlugins(cfg *config.Config) bool {
 	if cfg.Datastore.Provider != nil && cfg.Datastore.Provider.HasManagedArtifacts() {
 		return true
 	}
-	return cfg.UI.Plugin.HasManagedArtifacts()
+	return cfg.UI.Provider != nil && cfg.UI.Provider.HasManagedArtifacts()
 }
 
 func resolveLockPath(baseDir, provider string) string {
@@ -338,11 +338,11 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 			return false
 		}
 	}
-	if cfg.UI.Plugin.HasManagedArtifacts() {
+	if cfg.UI.Provider != nil && cfg.UI.Provider.HasManagedArtifacts() {
 		if lock.UI == nil {
 			return false
 		}
-		fingerprint, err := UIPluginFingerprint(cfg.UI.Plugin)
+		fingerprint, err := UIProviderFingerprint(cfg.UI.Provider)
 		if err != nil || lock.UI.Fingerprint != fingerprint {
 			return false
 		}
@@ -377,20 +377,8 @@ func PluginFingerprint(name string, plugin *config.PluginDef, configDir string) 
 	return hex.EncodeToString(sum[:]), nil
 }
 
-func UIPluginFingerprint(plugin *config.UIPluginDef) (string, error) {
-	input := struct {
-		Source  string `json:"source,omitempty"`
-		Version string `json:"version,omitempty"`
-	}{
-		Source:  plugin.Source,
-		Version: plugin.Version,
-	}
-	payload, err := json.Marshal(input)
-	if err != nil {
-		return "", err
-	}
-	sum := sha256.Sum256(payload)
-	return hex.EncodeToString(sum[:]), nil
+func UIProviderFingerprint(plugin *config.PluginDef) (string, error) {
+	return PluginFingerprint("ui", plugin, "")
 }
 
 func lockEntryMatches(paths initPaths, name string, plugin *config.PluginDef, entry LockEntry, found bool) bool {
@@ -566,58 +554,93 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 	}, nil
 }
 
-func (l *Lifecycle) writeUIPluginArtifact(ctx context.Context, cfg *config.Config, paths initPaths) (LockUIEntry, error) {
-	plugin := cfg.UI.Plugin
-	fingerprint, err := UIPluginFingerprint(plugin)
+func (l *Lifecycle) writeUIProviderArtifact(ctx context.Context, cfg *config.Config, paths initPaths) (LockUIEntry, error) {
+	plugin := cfg.UI.Provider
+	configMap, err := config.NodeToMap(cfg.UI.Config)
 	if err != nil {
-		return LockUIEntry{}, fmt.Errorf("fingerprinting ui plugin: %w", err)
+		return LockUIEntry{}, fmt.Errorf("decode ui provider config: %w", err)
+	}
+	fingerprint, err := UIProviderFingerprint(plugin)
+	if err != nil {
+		return LockUIEntry{}, fmt.Errorf("fingerprinting ui provider: %w", err)
 	}
 
 	destDir := uiDestDir(paths)
 	var installed *pluginstore.InstalledPlugin
-	if plugin.Source != "" {
-		src, err := pluginsource.Parse(plugin.Source)
+	switch {
+	case plugin.HasManagedSource():
+		src, err := sourceForPlugin(plugin)
 		if err != nil {
-			return LockUIEntry{}, fmt.Errorf("ui plugin.source %q: %w", plugin.Source, err)
+			return LockUIEntry{}, fmt.Errorf("ui provider source.ref %q: %w", plugin.SourceRef(), err)
 		}
 		if l.sourceResolver == nil {
-			return LockUIEntry{}, fmt.Errorf("ui plugin: source resolution requires a source resolver")
+			return LockUIEntry{}, fmt.Errorf("ui provider: source resolution requires a source resolver")
 		}
-		resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.Version)
+		resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
 		if err != nil {
-			return LockUIEntry{}, fmt.Errorf("ui plugin resolve source %q@%s: %w", plugin.Source, plugin.Version, err)
+			return LockUIEntry{}, fmt.Errorf("ui provider resolve source %q@%s: %w", plugin.SourceRef(), plugin.SourceVersion(), err)
 		}
 		defer resolved.Cleanup()
 		installed, err = pluginstore.Install(resolved.LocalPath, destDir)
 		if err != nil {
-			return LockUIEntry{}, fmt.Errorf("ui plugin install source: %w", err)
+			return LockUIEntry{}, fmt.Errorf("ui provider install source: %w", err)
 		}
-		if installed.Manifest.Source != plugin.Source {
-			return LockUIEntry{}, fmt.Errorf("ui plugin manifest source %q does not match config source %q", installed.Manifest.Source, plugin.Source)
+		if err := validateInstalledManifestKind(pluginmanifestv1.KindWebUI, "provider", installed.Manifest); err != nil {
+			return LockUIEntry{}, err
 		}
-		if installed.Manifest.Version != plugin.Version {
-			return LockUIEntry{}, fmt.Errorf("ui plugin manifest version %q does not match config version %q", installed.Manifest.Version, plugin.Version)
+		if installed.Manifest.Source != plugin.SourceRef() {
+			return LockUIEntry{}, fmt.Errorf("ui provider manifest source %q does not match config source %q", installed.Manifest.Source, plugin.SourceRef())
+		}
+		if installed.Manifest.Version != plugin.SourceVersion() {
+			return LockUIEntry{}, fmt.Errorf("ui provider manifest version %q does not match config version %q", installed.Manifest.Version, plugin.SourceVersion())
+		}
+		if err := pluginpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, pluginmanifestv1.KindWebUI, configMap); err != nil {
+			return LockUIEntry{}, fmt.Errorf("plugin config validation for ui provider: %w", err)
 		}
 		manifestPath, err := filepath.Rel(paths.artifactsDir, installed.ManifestPath)
 		if err != nil {
-			return LockUIEntry{}, fmt.Errorf("compute manifest path for ui plugin: %w", err)
+			return LockUIEntry{}, fmt.Errorf("compute manifest path for ui provider: %w", err)
 		}
 		assetRoot, err := filepath.Rel(paths.artifactsDir, installed.AssetRoot)
 		if err != nil {
-			return LockUIEntry{}, fmt.Errorf("compute asset root path for ui plugin: %w", err)
+			return LockUIEntry{}, fmt.Errorf("compute asset root path for ui provider: %w", err)
 		}
 		return LockUIEntry{
 			Fingerprint:   fingerprint,
-			Source:        plugin.Source,
-			Version:       plugin.Version,
+			Source:        plugin.SourceRef(),
+			Version:       plugin.SourceVersion(),
 			ResolvedURL:   resolved.ResolvedURL,
 			ArchiveSHA256: resolved.ArchiveSHA256,
 			Manifest:      filepath.ToSlash(manifestPath),
 			AssetRoot:     filepath.ToSlash(assetRoot),
 		}, nil
+	case plugin.HasLocalSource():
+		installed, err := pluginstore.InstallFromDir(filepath.Dir(plugin.SourcePath()), destDir)
+		if err != nil {
+			return LockUIEntry{}, fmt.Errorf("ui provider install local source: %w", err)
+		}
+		if err := validateInstalledManifestKind(pluginmanifestv1.KindWebUI, "provider", installed.Manifest); err != nil {
+			return LockUIEntry{}, err
+		}
+		if err := pluginpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, pluginmanifestv1.KindWebUI, configMap); err != nil {
+			return LockUIEntry{}, fmt.Errorf("plugin config validation for ui provider: %w", err)
+		}
+		manifestPath, err := filepath.Rel(paths.artifactsDir, installed.ManifestPath)
+		if err != nil {
+			return LockUIEntry{}, fmt.Errorf("compute manifest path for ui provider: %w", err)
+		}
+		assetRoot, err := filepath.Rel(paths.artifactsDir, installed.AssetRoot)
+		if err != nil {
+			return LockUIEntry{}, fmt.Errorf("compute asset root path for ui provider: %w", err)
+		}
+		return LockUIEntry{
+			Fingerprint: fingerprint,
+			Manifest:    filepath.ToSlash(manifestPath),
+			AssetRoot:   filepath.ToSlash(assetRoot),
+		}, nil
 	}
 
-	return LockUIEntry{}, fmt.Errorf("ui plugin requires source")
+	return LockUIEntry{}, fmt.Errorf("ui provider requires source")
 }
 
 func sourceForPlugin(plugin *config.PluginDef) (pluginsource.Source, error) {
@@ -688,23 +711,41 @@ func (l *Lifecycle) applyLockedPlugins(configPath, artifactsDir string, cfg *con
 			return err
 		}
 	}
-	if cfg.UI.Plugin.HasManagedArtifacts() {
-		if lock.UI == nil {
-			return fmt.Errorf("prepared artifact for ui plugin is missing or stale; run `gestaltd init --config %s`", paths.configPath)
+	if cfg.UI.Provider != nil {
+		configMap, err := config.NodeToMap(cfg.UI.Config)
+		if err != nil {
+			return fmt.Errorf("decode ui provider config: %w", err)
 		}
-		fingerprint, err := UIPluginFingerprint(cfg.UI.Plugin)
-		if err != nil || lock.UI.Fingerprint != fingerprint {
-			return fmt.Errorf("prepared artifact for ui plugin is missing or stale; run `gestaltd init --config %s`", paths.configPath)
+		switch {
+		case cfg.UI.Provider.HasManagedArtifacts():
+			if lock.UI == nil {
+				return fmt.Errorf("prepared artifact for ui provider is missing or stale; run `gestaltd init --config %s`", paths.configPath)
+			}
+			fingerprint, err := UIProviderFingerprint(cfg.UI.Provider)
+			if err != nil || lock.UI.Fingerprint != fingerprint {
+				return fmt.Errorf("prepared artifact for ui provider is missing or stale; run `gestaltd init --config %s`", paths.configPath)
+			}
+			manifestPath := resolveLockPath(paths.artifactsDir, lock.UI.Manifest)
+			assetRootPath := resolveLockPath(paths.artifactsDir, lock.UI.AssetRoot)
+			if _, err := os.Stat(manifestPath); err != nil {
+				return fmt.Errorf("prepared manifest for ui provider not found at %s", manifestPath)
+			}
+			if _, err := os.Stat(assetRootPath); err != nil {
+				return fmt.Errorf("prepared asset root for ui provider not found at %s", assetRootPath)
+			}
+			_, manifest, err := pluginpkg.ReadManifestFile(manifestPath)
+			if err != nil {
+				return fmt.Errorf("read prepared manifest for ui provider: %w", err)
+			}
+			if err := bindResolvedUIManifest(cfg.UI.Provider, manifestPath, manifest, configMap); err != nil {
+				return err
+			}
+			cfg.UI.ResolvedAssetRoot = assetRootPath
+		case cfg.UI.Provider.HasLocalSource():
+			if err := applyLocalUIManifest(cfg.UI.Provider, configMap, &cfg.UI.ResolvedAssetRoot); err != nil {
+				return err
+			}
 		}
-		manifestPath := resolveLockPath(paths.artifactsDir, lock.UI.Manifest)
-		assetRootPath := resolveLockPath(paths.artifactsDir, lock.UI.AssetRoot)
-		if _, err := os.Stat(manifestPath); err != nil {
-			return fmt.Errorf("prepared manifest for ui plugin not found at %s", manifestPath)
-		}
-		if _, err := os.Stat(assetRootPath); err != nil {
-			return fmt.Errorf("prepared asset root for ui plugin not found at %s", assetRootPath)
-		}
-		cfg.UI.Plugin.ResolvedAssetRoot = assetRootPath
 	}
 
 	return nil
@@ -806,6 +847,34 @@ func applyLocalComponentManifest(kind, name string, plugin *config.PluginDef, co
 			plugin.Args = append([]string(nil), entry.Args...)
 		}
 	}
+	return nil
+}
+
+func applyLocalUIManifest(plugin *config.PluginDef, configMap map[string]any, resolvedAssetRoot *string) error {
+	if plugin == nil || !plugin.HasLocalSource() {
+		return nil
+	}
+
+	manifestPath := plugin.SourcePath()
+	if _, err := os.Stat(manifestPath); err != nil {
+		return fmt.Errorf("manifest for ui provider not found at %s: %w", manifestPath, err)
+	}
+
+	_, manifest, err := pluginpkg.ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("prepare manifest for ui provider: %w", err)
+	}
+	if err := bindResolvedUIManifest(plugin, manifestPath, manifest, configMap); err != nil {
+		return err
+	}
+	if manifest == nil || manifest.WebUI == nil {
+		return fmt.Errorf("ui provider manifest is missing webui metadata")
+	}
+	assetRoot := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(manifest.WebUI.AssetRoot))
+	if _, err := os.Stat(assetRoot); err != nil {
+		return fmt.Errorf("ui provider asset root not found at %s: %w", assetRoot, err)
+	}
+	*resolvedAssetRoot = assetRoot
 	return nil
 }
 
@@ -935,6 +1004,20 @@ func bindResolvedComponentManifest(kind, name string, plugin *config.PluginDef, 
 	}
 	if err := pluginpkg.ValidateConfigForManifest(manifestPath, manifest, kind, configMap); err != nil {
 		return fmt.Errorf("plugin config validation for %s %q: %w", kind, name, err)
+	}
+	resolvePluginIcon(manifest, manifestPath, plugin)
+	plugin.ResolvedManifestPath = manifestPath
+	plugin.ResolvedManifest = manifest
+	return nil
+}
+
+func bindResolvedUIManifest(plugin *config.PluginDef, manifestPath string, manifest *pluginmanifestv1.Manifest, configMap map[string]any) error {
+	manifest = pluginpkg.ResolveManifestLocalReferences(manifest, manifestPath)
+	if err := validateInstalledManifestKind(pluginmanifestv1.KindWebUI, "provider", manifest); err != nil {
+		return err
+	}
+	if err := pluginpkg.ValidateConfigForManifest(manifestPath, manifest, pluginmanifestv1.KindWebUI, configMap); err != nil {
+		return fmt.Errorf("plugin config validation for ui provider: %w", err)
 	}
 	resolvePluginIcon(manifest, manifestPath, plugin)
 	plugin.ResolvedManifestPath = manifestPath

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -180,6 +180,8 @@ func writeConfigYAML(t *testing.T, dir, source, version, artifactsDir string) st
 	t.Helper()
 
 	lines := []string{
+		"ui:",
+		"  provider: none",
 		"server:",
 		"  artifacts_dir: " + artifactsDir,
 		"plugins:",

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -104,6 +104,8 @@ func requiredComponentConfigYAML(t *testing.T, dir, dbPath string) string {
       path: %q
   config:
     path: %q
+ui:
+  provider: none
 `, datastorePath, dbPath)
 }
 
@@ -116,6 +118,8 @@ func requiredDatastoreConfigYAML(t *testing.T, dir, dbPath string) string {
       path: %q
   config:
     path: %q
+ui:
+  provider: none
 `, datastorePath, dbPath)
 }
 
@@ -335,7 +339,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalTopLevelPluginsWithoutLockfile(t *t
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := `auth:
+cfg := `auth:
   provider:
     source:
       path: ./auth-plugin.yaml
@@ -347,6 +351,8 @@ datastore:
       path: ./datastore-plugin.yaml
   config:
     bucket: local-datastore
+ui:
+  provider: none
 server:
   encryption_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `
@@ -448,7 +454,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalSourceTopLevelPluginsWithoutArtifac
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := `auth:
+cfg := `auth:
   provider:
     source:
       path: ./auth-plugin.yaml
@@ -456,6 +462,8 @@ datastore:
   provider:
     source:
       path: ./datastore-plugin.yaml
+ui:
+  provider: none
 server:
   encryption_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -339,7 +339,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalTopLevelPluginsWithoutLockfile(t *t
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-cfg := `auth:
+	cfg := `auth:
   provider:
     source:
       path: ./auth-plugin.yaml
@@ -454,7 +454,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalSourceTopLevelPluginsWithoutArtifac
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-cfg := `auth:
+	cfg := `auth:
   provider:
     source:
       path: ./auth-plugin.yaml

--- a/gestaltd/internal/operator/localconfig.go
+++ b/gestaltd/internal/operator/localconfig.go
@@ -7,12 +7,12 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
 )
 
 const (
-	localConfigDirName     = ".gestaltd"
-	defaultProviderRepo    = "github.com/valon-technologies/gestalt-providers"
-	defaultProviderVersion = "0.0.1-alpha.1"
+	localConfigDirName = ".gestaltd"
 )
 
 func DefaultLocalConfigPath() string {
@@ -70,7 +70,7 @@ server:
   public:
     port: 8080
   encryption_key: %q
-`, defaultProviderRepo, defaultProviderVersion, dbPath, encryptionKey)
+`, config.DefaultProviderRepo, config.DefaultProviderVersion, dbPath, encryptionKey)
 }
 
 func defaultLocalSourceConfig(providersDir, dbPath, encryptionKey string) string {
@@ -80,11 +80,15 @@ func defaultLocalSourceConfig(providersDir, dbPath, encryptionKey string) string
       path: %q
   config:
     path: %q
+ui:
+  provider:
+    source:
+      path: %q
 secrets:
   provider: env
 server:
   public:
     port: 8080
   encryption_key: %q
-`, filepath.Join(providersDir, "datastore", "sqlite", "plugin.yaml"), dbPath, encryptionKey)
+`, filepath.Join(providersDir, "datastore", "sqlite", "plugin.yaml"), dbPath, filepath.Join(providersDir, "web", "default", "plugin.yaml"), encryptionKey)
 }

--- a/gestaltd/internal/pluginhost/secrets_client.go
+++ b/gestaltd/internal/pluginhost/secrets_client.go
@@ -39,7 +39,7 @@ func NewExecutableSecretManager(ctx context.Context, cfg SecretsExecConfig) (cor
 		return nil, err
 	}
 
-	runtimeClient := proto.NewPluginRuntimeClient(proc.conn)
+	runtimeClient := proto.NewProviderLifecycleClient(proc.conn)
 	secretsClient := proto.NewSecretsProviderClient(proc.conn)
 
 	_, err = configureRuntimePlugin(ctx, runtimeClient, proto.PluginKind_PLUGIN_KIND_SECRETS, cfg.Name, cfg.Config)

--- a/gestaltd/internal/pluginpkg/config.go
+++ b/gestaltd/internal/pluginpkg/config.go
@@ -55,6 +55,11 @@ func configSchemaForManifest(manifestPath string, manifest *pluginmanifestv1.Man
 			return "", "", false, nil
 		}
 		return filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(manifest.Secrets.ConfigSchemaPath)), manifest.Secrets.ConfigSchemaPath, true, nil
+	case pluginmanifestv1.KindWebUI:
+		if manifest.WebUI == nil || manifest.WebUI.ConfigSchemaPath == "" {
+			return "", "", false, nil
+		}
+		return filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(manifest.WebUI.ConfigSchemaPath)), manifest.WebUI.ConfigSchemaPath, true, nil
 	default:
 		return "", "", false, fmt.Errorf("unsupported manifest config kind %q", kind)
 	}

--- a/gestaltd/internal/pluginpkg/go_provider.go
+++ b/gestaltd/internal/pluginpkg/go_provider.go
@@ -115,6 +115,17 @@ func SourceComponentExecutionCommand(root, kind, goos, goarch string) (string, [
 	}
 }
 
+func SourceComponentExecutionEnv(root, kind, goos, goarch string) (map[string]string, error) {
+	sourceKind, _, err := detectSourceComponent(root, kind, goos, goarch)
+	if err != nil {
+		return nil, err
+	}
+	if sourceKind != sourceProviderKindPython {
+		return nil, nil
+	}
+	return pythonBackendEnvMap(), nil
+}
+
 func ValidateSourceComponentRelease(root, kind, goos, goarch, libc string) error {
 	sourceKind, _, err := detectSourceComponent(root, kind, goos, goarch)
 	if err != nil {

--- a/gestaltd/internal/pluginpkg/manifest.go
+++ b/gestaltd/internal/pluginpkg/manifest.go
@@ -284,6 +284,11 @@ func validateManifest(manifest *pluginmanifestv1.Manifest, sourceMode bool) erro
 		if err := validateRelativePackagePath(manifest.WebUI.AssetRoot, "webui asset root"); err != nil {
 			return err
 		}
+		if manifest.WebUI.ConfigSchemaPath != "" {
+			if err := validateRelativePackagePath(manifest.WebUI.ConfigSchemaPath, "webui config schema path"); err != nil {
+				return err
+			}
+		}
 	default:
 		return fmt.Errorf("unsupported manifest kind %q", kind)
 	}

--- a/gestaltd/internal/pluginpkg/python_provider.go
+++ b/gestaltd/internal/pluginpkg/python_provider.go
@@ -154,6 +154,14 @@ func pythonBackendImportPaths() []string {
 }
 
 func pythonBackendEnv() []string {
+	env := pythonBackendEnvMap()
+	if len(env) == 0 {
+		return nil
+	}
+	return []string{"PYTHONPATH=" + env["PYTHONPATH"]}
+}
+
+func pythonBackendEnvMap() map[string]string {
 	paths := pythonBackendImportPaths()
 	if len(paths) == 0 {
 		return nil
@@ -162,7 +170,7 @@ func pythonBackendEnv() []string {
 	if existing := os.Getenv("PYTHONPATH"); existing != "" {
 		value += string(os.PathListSeparator) + existing
 	}
-	return []string{"PYTHONPATH=" + value}
+	return map[string]string{"PYTHONPATH": value}
 }
 
 func localPythonSDKPath() string {

--- a/gestaltd/internal/pluginpkg/python_provider_test.go
+++ b/gestaltd/internal/pluginpkg/python_provider_test.go
@@ -169,6 +169,32 @@ func TestPythonComponentExecutionCommand_PassesRuntimeKind(t *testing.T) {
 	}
 }
 
+func TestSourceProviderExecutionEnv_PythonUsesLocalSDK(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte(`[tool.gestalt]
+provider = "provider"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(pyproject.toml): %v", err)
+	}
+
+	env, err := SourceProviderExecutionEnv(root, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatalf("SourceProviderExecutionEnv: %v", err)
+	}
+	if len(env) == 0 {
+		t.Fatal("SourceProviderExecutionEnv returned no environment overrides")
+	}
+	want := localPythonSDKPath()
+	if want == "" {
+		t.Fatal("localPythonSDKPath returned empty path")
+	}
+	if got := env["PYTHONPATH"]; !strings.Contains(got, want) {
+		t.Fatalf("PYTHONPATH = %q, want to contain %q", got, want)
+	}
+}
+
 func pythonTestOtherPlatform() (string, string) {
 	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
 		return "darwin", "arm64"

--- a/gestaltd/internal/pluginpkg/references.go
+++ b/gestaltd/internal/pluginpkg/references.go
@@ -45,6 +45,9 @@ func LocalPackageReferences(manifest *pluginmanifestv1.Manifest) []LocalPackageR
 			add(manifest.Plugin.MCPURL, "provider mcp document")
 		}
 	}
+	if manifest.WebUI != nil {
+		add(manifest.WebUI.ConfigSchemaPath, "webui config schema")
+	}
 	add(manifest.IconFile, "icon_file")
 	return refs
 }

--- a/gestaltd/internal/pluginpkg/source_prepare.go
+++ b/gestaltd/internal/pluginpkg/source_prepare.go
@@ -61,6 +61,13 @@ func generateSourceStaticCatalog(rootDir, catalogPath string) error {
 
 	cmd := exec.Command(command, args...)
 	cmd.Env = append(os.Environ(), envWriteCatalog+"="+catalogPath)
+	execEnv, err := SourceProviderExecutionEnv(rootDir, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return fmt.Errorf("prepare synthesized source provider environment for static catalog: %w", err)
+	}
+	for key, value := range execEnv {
+		cmd.Env = append(cmd.Env, key+"="+value)
+	}
 	var output bytes.Buffer
 	cmd.Stdout = &output
 	cmd.Stderr = &output

--- a/gestaltd/internal/pluginpkg/source_provider.go
+++ b/gestaltd/internal/pluginpkg/source_provider.go
@@ -74,6 +74,17 @@ func SourceProviderExecutionCommand(root, goos, goarch string) (string, []string
 	}
 }
 
+func SourceProviderExecutionEnv(root, goos, goarch string) (map[string]string, error) {
+	kind, _, err := detectSourceProvider(root, goos, goarch)
+	if err != nil {
+		return nil, err
+	}
+	if kind != sourceProviderKindPython {
+		return nil, nil
+	}
+	return pythonBackendEnvMap(), nil
+}
+
 func ValidateSourceProviderRelease(root, goos, goarch, libc string) error {
 	kind, _, err := detectSourceProvider(root, goos, goarch)
 	if err != nil {

--- a/gestaltd/internal/webui/webui.go
+++ b/gestaltd/internal/webui/webui.go
@@ -1,39 +1,19 @@
-// Package webui serves the client UI static assets.
-//
-// Build the client UI before go build:
-//
-//	cd gestaltd/ui && npm run build
-//	cp -r gestaltd/ui/out gestaltd/internal/webui/out
+// Package webui serves the client UI static assets from a prepared directory.
 package webui
 
 import (
-	"embed"
 	"fmt"
-	"io/fs"
 	"net/http"
 	"os"
 
 	"github.com/valon-technologies/gestalt/server/internal/staticui"
 )
 
-//go:embed all:out
-var assets embed.FS
-
-func EmbeddedHandler() http.Handler {
-	sub, err := fs.Sub(assets, "out")
-	if err != nil {
-		return nil
-	}
-	handler, err := staticui.Handler(staticui.Config{FS: sub})
-	if err != nil {
-		return nil
-	}
-	return handler
-}
-
 func DirHandler(path string) (http.Handler, error) {
-	root := os.DirFS(path)
-	handler, err := staticui.Handler(staticui.Config{FS: root, DynamicIndex: true})
+	handler, err := staticui.Handler(staticui.Config{
+		FS:           os.DirFS(path),
+		DynamicIndex: true,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("webui: %s: %w", path, err)
 	}

--- a/gestaltd/internal/webui/webui_test.go
+++ b/gestaltd/internal/webui/webui_test.go
@@ -187,12 +187,3 @@ func TestDirHandler_RejectsDirectoryWithoutIndex(t *testing.T) {
 		t.Fatal("expected error for directory without index.html")
 	}
 }
-
-func TestEmbeddedHandler_NilWhenNotBuilt(t *testing.T) {
-	t.Parallel()
-
-	handler := EmbeddedHandler()
-	if handler != nil {
-		t.Fatal("expected nil handler when embedded frontend has not been built")
-	}
-}

--- a/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -167,6 +167,10 @@
         "asset_root": {
           "type": "string",
           "minLength": 1
+        },
+        "config_schema_path": {
+          "type": "string",
+          "minLength": 1
         }
       }
     },

--- a/gestaltd/sdk/pluginmanifest/v1/types.go
+++ b/gestaltd/sdk/pluginmanifest/v1/types.go
@@ -50,7 +50,8 @@ type SecretsMetadata struct {
 }
 
 type WebUIMetadata struct {
-	AssetRoot string `json:"asset_root" yaml:"asset_root"`
+	AssetRoot        string `json:"asset_root" yaml:"asset_root"`
+	ConfigSchemaPath string `json:"config_schema_path,omitempty" yaml:"config_schema_path,omitempty"`
 }
 
 type Plugin struct {

--- a/sdk/go/secrets.go
+++ b/sdk/go/secrets.go
@@ -5,6 +5,6 @@ import (
 )
 
 type SecretsProvider interface {
-	RuntimeProvider
+	PluginProvider
 	GetSecret(ctx context.Context, name string) (string, error)
 }

--- a/sdk/go/serve_secrets.go
+++ b/sdk/go/serve_secrets.go
@@ -10,7 +10,7 @@ import (
 // ServeSecretsProvider starts a gRPC server for a [SecretsProvider].
 func ServeSecretsProvider(ctx context.Context, secrets SecretsProvider) error {
 	return servePlugin(withPluginCloser(ctx, secrets), func(srv *grpc.Server) {
-		proto.RegisterPluginRuntimeServer(srv, newRuntimeProviderServer(ProviderKindSecrets, secrets))
+		proto.RegisterProviderLifecycleServer(srv, newPluginProviderServer(ProviderKindSecrets, secrets))
 		proto.RegisterSecretsProviderServer(srv, newSecretsProviderServer(secrets))
 	})
 }


### PR DESCRIPTION
## What changed
- replace `ui.plugin` with a provider-shaped `ui` config that supports:
  - omitted `ui` => pinned first-party default UI package
  - `ui.provider: none` => no public UI at `/`
  - `ui.provider.source.path|ref` => custom packaged UI bundle
- wire UI preparation/loading through the existing init/locked-artifacts lifecycle without adding a gRPC runtime surface
- add `webui.config_schema_path` support to the manifest SDK and local manifest validation
- remove the embedded client UI serving path from `gestaltd`; the built-in admin UI at `/admin` remains embedded
- update local config generation, Helm defaults, docs, and tests for the new semantics

## Why
- auth and datastore now use provider-shaped configuration, and web UI should follow the same operator model without pretending it is an executable runtime plugin
- this also allows headless deployments and bring-your-own frontend bundles while keeping a pinned first-party default for compatibility

## Dependency
- depends on `valon-technologies/gestalt-providers#38` for the first-party `web/default` package
- after that lands, the corresponding `web/default` release tag still needs to be published so the pinned managed default resolves outside local-source/dev flows

## Impact
- `ui.plugin` is replaced by `ui.provider`
- the public client UI is no longer embedded in the `gestaltd` binary/image
- Helm now defaults to `ui.provider: none` so the default chart profile stays self-contained unless operators opt into a managed UI bundle

## Validation
- `go test ./internal/operator ./internal/config ./internal/pluginpkg ./internal/webui ./cmd/gestaltd`
- `git diff --check`
