### PR TITLE
[codex] Add Rust examples to plugin docs

### DIFF
--- a/docs/content/plugins/index.mdx
+++ b/docs/content/plugins/index.mdx
@@ -29,7 +29,7 @@ Plugins run in process isolation. They cannot access the host process memory, ot
 
 ## SDK support
 
-Gestalt ships SDKs for Go (`sdk/go`) and Python (`sdk/python`). The underlying protocol is gRPC, so other languages are possible, but the documented authoring flow uses those two.
+Gestalt ships SDKs for Go (`sdk/go`), Python (`sdk/python`), and Rust (`sdk/rust`). The underlying protocol is gRPC, so other languages are possible, but the documented authoring flow uses those three.
 
 ## Common pitfalls
 

--- a/docs/content/plugins/releasing.mdx
+++ b/docs/content/plugins/releasing.mdx
@@ -1,3 +1,5 @@
+import { Tabs } from 'nextra/components'
+
 # Releasing
 
 Once a provider or UI package works locally, you can publish a release archive
@@ -26,10 +28,68 @@ provider:
         type: none
 ```
 
-For Go source plugins, the provider code lives at the module root. For Python
-source plugins, Gestalt loads the module declared in
-`[tool.gestalt].plugin`. In both cases, Gestalt synthesizes the runnable
-wrapper for local source execution and release packaging.
+Executable source packages stay language-native. Gestalt loads the provider
+from the package root, then synthesizes the runnable wrapper during local
+source execution and release packaging.
+
+<Tabs items={['Go', 'Python', 'Rust']}>
+  <Tabs.Tab>
+    ```text
+    my-plugin/
+      go.mod
+      plugin.yaml
+      provider.go
+    ```
+
+    ```go
+    module github.com/acme/plugins/my-plugin
+
+    go 1.26
+
+    require github.com/valon-technologies/gestalt/sdk/go v0.0.1-alpha.1
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```text
+    my-plugin/
+      pyproject.toml
+      plugin.yaml
+      provider.py
+    ```
+
+    ```toml
+    [project]
+    name = "my-plugin"
+    version = "0.0.1-alpha.1"
+    dependencies = ["gestalt"]
+
+    [tool.gestalt]
+    plugin = "provider"
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```text
+    my-plugin/
+      Cargo.toml
+      plugin.yaml
+      src/
+        lib.rs
+    ```
+
+    ```toml
+    [package]
+    name = "my-plugin"
+    version = "0.0.1-alpha.1"
+    edition = "2024"
+
+    [dependencies]
+    gestalt_plugin_sdk = { git = "https://github.com/valon-technologies/gestalt", tag = "sdk/rust/v0.0.1-alpha.1" }
+    schemars = { version = "0.8", features = ["derive"] }
+    serde = { version = "1", features = ["derive"] }
+    serde_json = "1"
+    ```
+  </Tabs.Tab>
+</Tabs>
 
 ### Release manifest for an executable provider
 
@@ -77,18 +137,14 @@ Run this from the plugin source directory. It produces release archives and writ
 
 Release tags are derived from the package path after the repository. For example, `source: github.com/acme/plugins/catalog/support-api` releases from the tag `plugins/catalog/support-api/v0.1.0`.
 
-For executable Go, Rust, and Python integration source plugins, `plugin
-release` materializes the executable catalog automatically and builds the
-host-platform artifact by default. Go and Rust auth/datastore source packages
-use the same release flow without catalog generation. Pass `--platform` with a
-comma-separated list such as `--platform linux/amd64,darwin/arm64` to build
-explicit targets. Pass `--platform all` in CI release jobs to build the full
-supported platform matrix for source builds.
-Pass `--platform` with a comma-separated list such as
-`--platform linux/amd64/glibc,linux/amd64/musl,darwin/arm64` to build explicit targets.
-
-Pass `--platform all` in CI release jobs to build the full supported platform
-matrix for source builds.
+For executable Go, Rust, and Python integration source plugins, `plugin release`
+materializes the executable catalog automatically and builds the host-platform
+artifact by default. Go and Rust auth/datastore source packages use the same
+release flow without catalog generation. Pass `--platform` with a
+comma-separated list such as
+`--platform linux/amd64/glibc,linux/amd64/musl,darwin/arm64` to build explicit
+targets. Pass `--platform all` in CI release jobs to build the full supported
+platform matrix for source builds.
 
 For non-host Python targets, point Gestalt at a matching interpreter with
 `GESTALT_PYTHON_<GOOS>_<GOARCH>` or a target-specific virtualenv such as

--- a/docs/content/plugins/writing-a-plugin.mdx
+++ b/docs/content/plugins/writing-a-plugin.mdx
@@ -86,7 +86,22 @@ The host still owns auth, token storage, connection selection, and HTTP or MCP r
         lib.rs
     ```
 
-    Add `gestalt_plugin_sdk`, `serde`, and `schemars` to `Cargo.toml`. The initial Rust SDK release is tagged from `sdk/rust/v*` and is not published to crates.io, so the exact dependency stanza depends on the release channel that ships with the SDK.
+    Add the SDK and schema dependencies to `Cargo.toml`:
+
+    ```toml
+    [package]
+    name = "my-plugin"
+    version = "0.0.1-alpha.1"
+    edition = "2024"
+
+    [dependencies]
+    gestalt_plugin_sdk = { git = "https://github.com/valon-technologies/gestalt", tag = "sdk/rust/v0.0.1-alpha.1" }
+    schemars = { version = "0.8", features = ["derive"] }
+    serde = { version = "1", features = ["derive"] }
+    serde_json = "1"
+    ```
+
+    Use the `sdk/rust/v*` tag that matches the SDK release you want to target.
   </Tabs.Tab>
 </Tabs>
 
@@ -134,8 +149,6 @@ The manifest stays the source of truth for display name, description, auth, the 
 `source` may include nested segments after the repository, such as `github.com/example/plugins/catalog/my-plugin`. Gestalt keeps the final segment as the plugin name and uses the full path for release tag resolution.
 
 ## Define operations
-
-Rust examples below show the intended shape of the first SDK release. Exact helper names may change slightly as the Rust API is finalized.
 
 <Tabs items={['Go', 'Python', 'Rust']}>
   <Tabs.Tab>
@@ -302,13 +315,12 @@ Rust examples below show the intended shape of the first SDK release. Exact help
         )
     }
 
-    // Placeholder: the exact export helper may change slightly before the first stable release.
     gestalt::export_provider!(constructor = new, router = router);
     ```
   </Tabs.Tab>
 </Tabs>
 
-You do not write an entrypoint. Gestalt synthesizes the executable wrapper automatically for local source execution and release.
+You do not write an entrypoint. Gestalt synthesizes the executable wrapper automatically for local source execution and release. Rust auth and datastore packages follow the same model with `gestalt::export_auth_provider!(constructor = new);` and `gestalt::export_datastore_provider!(constructor = new);`.
 
 By default, input decode failures return a structured `400` response, and unhandled errors return a structured `500` response. Return a non-2xx response explicitly when the operation wants to signal a deliberate application-level error.
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1,3 +1,5 @@
+import { Tabs } from 'nextra/components'
+
 # Config File
 
 Every `gestaltd` deployment reads a single YAML config file. The top-level keys map one-to-one with the subsystems they configure:
@@ -441,6 +443,48 @@ provider:
 ```
 
 Gestalt synthesizes Go and Rust executable wrappers automatically when needed and runs Python source plugins from the module declared in `[tool.gestalt].plugin`. Integration plugins do not support `provider.builtin`.
+
+<Tabs items={['Go', 'Python', 'Rust']}>
+  <Tabs.Tab>
+    A local Go source plugin typically looks like:
+
+    ```text
+    my-plugin/
+      go.mod
+      plugin.yaml
+      provider.go
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    A local Python source plugin typically looks like:
+
+    ```toml
+    [project]
+    name = "my-plugin"
+    version = "0.0.1-alpha.1"
+    dependencies = ["gestalt"]
+
+    [tool.gestalt]
+    plugin = "provider"
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    A local Rust source plugin typically looks like:
+
+    ```toml
+    [package]
+    name = "my-plugin"
+    version = "0.0.1-alpha.1"
+    edition = "2024"
+
+    [dependencies]
+    gestalt_plugin_sdk = { git = "https://github.com/valon-technologies/gestalt", tag = "sdk/rust/v0.0.1-alpha.1" }
+    schemars = { version = "0.8", features = ["derive"] }
+    serde = { version = "1", features = ["derive"] }
+    serde_json = "1"
+    ```
+  </Tabs.Tab>
+</Tabs>
 
 | Field | Description |
 | --- | --- |

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -470,6 +470,43 @@ A connection using `mcp_oauth` auth requires the plugin to declare an MCP surfac
 
 When an executable plugin defines helper operations in Go, Rust, or Python, Gestalt materializes the executable catalog automatically during local source-plugin execution and `plugin release`. Auth and datastore source packages use the same release flow for Go and Rust, but they do not generate catalogs. See [Writing a Plugin](/plugins/writing-a-plugin) for the end-to-end authoring flow.
 
+<Tabs items={['Go', 'Python', 'Rust']}>
+  <Tabs.Tab>
+    ```text
+    my-plugin/
+      go.mod
+      plugin.yaml
+      provider.go
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```text
+    my-plugin/
+      pyproject.toml
+      plugin.yaml
+      provider.py
+    ```
+
+    ```toml
+    [tool.gestalt]
+    plugin = "provider"
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```text
+    my-plugin/
+      Cargo.toml
+      plugin.yaml
+      src/
+        lib.rs
+    ```
+
+    ```rust
+    gestalt::export_provider!(constructor = new, router = router);
+    ```
+  </Tabs.Tab>
+</Tabs>
+
 ## Release
 
 Build a release from a plugin source directory:

--- a/docs/content/troubleshooting.mdx
+++ b/docs/content/troubleshooting.mdx
@@ -1,3 +1,5 @@
+import { Tabs } from 'nextra/components'
+
 # Troubleshooting
 
 ## Startup
@@ -36,7 +38,39 @@ A "failed to reach" error means the outbound connection could not be established
 
 ## Plugins
 
-When a plugin fails to start, check that the binary exists at the expected path, is executable, and that any required runtime dependencies are available. For Python source plugins, verify the virtualenv is intact and the module declared in `[tool.gestalt].plugin` is importable. Plugin startup errors appear in the server log with the provider name.
+When a plugin fails to start, check that the binary exists at the expected path, is executable, and that any required runtime dependencies are available. Plugin startup errors appear in the server log with the provider name.
+
+Common source-package checks:
+
+<Tabs items={['Go', 'Python', 'Rust']}>
+  <Tabs.Tab>
+    Verify the package builds from the plugin root:
+
+    ```sh
+    go build ./...
+    ```
+
+    The source package should include `go.mod`, `plugin.yaml`, and provider code at the module root.
+  </Tabs.Tab>
+  <Tabs.Tab>
+    Verify the virtualenv is intact and the configured module is importable:
+
+    ```sh
+    uv run python -c "import provider"
+    ```
+
+    Also confirm `[tool.gestalt].plugin` in `pyproject.toml` points at the module Gestalt should load.
+  </Tabs.Tab>
+  <Tabs.Tab>
+    Verify the crate builds from the plugin root:
+
+    ```sh
+    cargo check
+    ```
+
+    The plugin root needs a real `Cargo.toml` package with a `[package]` section, not just a workspace manifest, and `src/lib.rs` should export the provider with `gestalt::export_provider!(...)`, `gestalt::export_auth_provider!(...)`, or `gestalt::export_datastore_provider!(...)`.
+  </Tabs.Tab>
+</Tabs>
 
 A sandbox 403 means the plugin made an outbound request to a host not listed in `plugin.allowed_hosts`. Add every upstream domain the plugin contacts to the allowlist in your plugin config.
 


### PR DESCRIPTION
## What changed

This updates the plugin docs so Rust appears anywhere we currently document Go and Python source-package authoring.

The diff adds or expands Rust examples in:

- `docs/content/plugins/writing-a-plugin.mdx`
- `docs/content/plugins/releasing.mdx`
- `docs/content/reference/config-file.mdx`
- `docs/content/reference/plugin-manifests.mdx`
- `docs/content/troubleshooting.mdx`
- `docs/content/plugins/index.mdx`

## Why

The Rust SDK and source-provider flow are now merged, but the docs still described Rust inconsistently:

- some pages mentioned only Go and Python
- some pages described Rust only in prose, without concrete examples
- `writing-a-plugin` still had provisional wording that no longer matches the shipped SDK surface

This brings the docs up to date and makes Rust a first-class documented authoring path.

## User impact

Users can now find concrete Rust examples for:

- plugin project layout
- `Cargo.toml` dependency setup
- source manifest and source-package expectations
- release behavior
- startup troubleshooting
- exported Rust provider entrypoints

## Validation

Ran:

- `npm run typecheck` in `docs`
- `npx next build` in `docs`
- `npx pagefind --site out` in `docs`

Not run:

- `npm run lint` in `docs` because the current script invokes `next lint`, which errors under this Next version with `Invalid project directory provided, no such directory: /Users/hugh/src/gestalt/docs/lint`.
