### PR TITLE
[codex] tighten provider release flow

### DIFF
--- a/docs/content/plugins/releasing.mdx
+++ b/docs/content/plugins/releasing.mdx
@@ -12,7 +12,7 @@ Gestalt uses the same release system for executable provider packages, auth and 
 
 ## Source manifests vs release manifests
 
-During local development and `gestaltd plugin release`, source manifests can
+During local development and `gestaltd provider release`, source manifests can
 omit `artifacts` and executable `entrypoints`. Release packaging materializes
 those fields for you.
 
@@ -91,6 +91,27 @@ source execution and release packaging.
   </Tabs.Tab>
 </Tabs>
 
+### Source release builds
+
+Source manifests may optionally define a `release.build` command. Gestalt runs
+it before source-manifest preparation, which lets web UI packages generate
+static assets and lets provider/auth/datastore packages generate support files
+such as config schemas before packaging.
+
+```yaml
+source: github.com/acme/plugins/gestalt-ui
+version: 1.2.0
+release:
+  build:
+    workdir: ui
+    command:
+      - npm
+      - run
+      - build
+webui:
+  asset_root: ui/out
+```
+
 ### Release manifest for an executable provider
 
 Released executable providers add concrete `entrypoints.provider` and
@@ -127,17 +148,17 @@ webui:
 
 ## Build a release
 
-Use `gestaltd plugin release` to build a plugin release and produce release archives:
+Use `gestaltd provider release` to build a provider release and produce release archives:
 
 ```sh
-gestaltd plugin release --version 0.0.1-alpha.1
+gestaltd provider release --version 0.0.1-alpha.1
 ```
 
-Run this from the plugin source directory. It produces release archives and writes a checksums file.
+Run this from the provider source directory. It produces release archives and writes a checksums file.
 
 Release tags are derived from the package path after the repository. For example, `source: github.com/acme/plugins/catalog/support-api` releases from the tag `plugins/catalog/support-api/v0.1.0`.
 
-For executable Go, Rust, and Python integration source plugins, `plugin release`
+For executable Go, Rust, and Python integration source plugins, `provider release`
 materializes the executable catalog automatically and builds the host-platform
 artifact by default. Go and Rust auth/datastore source packages use the same
 release flow without catalog generation. Pass `--platform` with a

--- a/docs/content/plugins/writing-a-plugin.mdx
+++ b/docs/content/plugins/writing-a-plugin.mdx
@@ -481,7 +481,7 @@ gestalt invoke my-plugin greet -p name=Gestalt
 ## Release
 
 ```sh
-gestaltd plugin release --version 0.0.1-alpha.1
+gestaltd provider release --version 0.0.1-alpha.1
 ```
 
 Gestalt materializes the executable catalog automatically during release. Go, Python, and Rust source plugins build the host-platform artifact by default. Pass `--platform` with a comma-separated target list to build explicit platforms, or `--platform all` in CI to build the full supported release matrix.

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -1,6 +1,6 @@
 # Server CLI
 
-`gestaltd` manages server lifecycle and plugin releases.
+`gestaltd` manages server lifecycle and provider releases.
 
 ## Server commands
 
@@ -13,11 +13,11 @@
 | `gestaltd validate --config PATH` | Validate config without serving. |
 | `gestaltd --version` | Print the server version. |
 
-## Plugin commands
+## Provider commands
 
 | Command | Purpose |
 | --- | --- |
-| `gestaltd plugin release --version VERSION` | Build and package a plugin release. Go, Rust, and Python integration source plugins default to the host platform; Go and Rust auth/datastore source packages do too. Pass `--platform ...` with `os/arch[/libc]` targets or `--platform all` for multi-platform builds. |
+| `gestaltd provider release --version VERSION` | Build and package a provider release. Go, Rust, and Python integration source plugins default to the host platform; Go and Rust auth/datastore source packages do too. Pass `--platform ...` with `os/arch[/libc]` targets or `--platform all` for multi-platform builds. |
 
 ## Examples
 
@@ -26,9 +26,9 @@ gestaltd
 gestaltd init --config ./config.yaml
 gestaltd serve --locked --config ./config.yaml
 gestaltd validate --config ./config.yaml
-gestaltd plugin release --version 0.0.1-alpha.1
-gestaltd plugin release --version 0.0.1-alpha.1 --platform all
-gestaltd plugin release --version 0.0.1-alpha.1 --platform linux/amd64/glibc,linux/amd64/musl
+gestaltd provider release --version 0.0.1-alpha.1
+gestaltd provider release --version 0.0.1-alpha.1 --platform all
+gestaltd provider release --version 0.0.1-alpha.1 --platform linux/amd64/glibc,linux/amd64/musl
 ```
 
 See [Configuration](/configuration) for the relationship between `init`, `serve --locked`, and `validate`.

--- a/docs/content/reference/index.mdx
+++ b/docs/content/reference/index.mdx
@@ -17,7 +17,7 @@ import { Cards } from 'nextra/components'
     Every route, authentication model, and invocation semantic.
   </Cards.Card>
   <Cards.Card title="Server CLI" href="/reference/cli">
-    Server lifecycle commands, plugin release, and common examples.
+    Server lifecycle commands, provider release, and common examples.
   </Cards.Card>
   <Cards.Card title="Built-in Providers" href="/reference/built-in-providers">
     Auth providers, datastores, secret managers, and telemetry providers.

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -278,7 +278,7 @@ The `artifacts` array lists platform-specific binaries included in the package.
 | `path` | string | yes | Path to the binary inside the package. |
 | `sha256` | string | no | SHA-256 hex digest for integrity verification. |
 
-Declarative-only plugin packages do not require `artifacts`. Pure executable source manifests used with `plugins.*.plugin.source.path` or `gestaltd plugin release` may omit them.
+Declarative-only plugin packages do not require `artifacts`. Pure executable source manifests used with `plugins.*.plugin.source.path` or `gestaltd provider release` may omit them.
 
 ## Full Example
 
@@ -468,7 +468,7 @@ Manifest paths must stay inside the package. `source` and `version` are required
 
 A connection using `mcp_oauth` auth requires the plugin to declare an MCP surface (via `mcp_url` or an equivalent). Manifests that set `auth.type: mcp_oauth` without an MCP surface fail validation.
 
-When an executable plugin defines helper operations in Go, Rust, or Python, Gestalt materializes the executable catalog automatically during local source-plugin execution and `plugin release`. Auth and datastore source packages use the same release flow for Go and Rust, but they do not generate catalogs. See [Writing a Plugin](/plugins/writing-a-plugin) for the end-to-end authoring flow.
+When an executable plugin defines helper operations in Go, Rust, or Python, Gestalt materializes the executable catalog automatically during local source-plugin execution and `provider release`. Auth and datastore source packages use the same release flow for Go and Rust, but they do not generate catalogs. See [Writing a Plugin](/plugins/writing-a-plugin) for the end-to-end authoring flow.
 
 <Tabs items={['Go', 'Python', 'Rust']}>
   <Tabs.Tab>
@@ -507,12 +507,31 @@ When an executable plugin defines helper operations in Go, Rust, or Python, Gest
   </Tabs.Tab>
 </Tabs>
 
-## Release
+Release-only build steps can be declared in source manifests with `release.build`.
+Gestalt runs that command before source-manifest preparation, which lets
+packages generate support files or UI bundles without checking built artifacts
+into source control.
 
-Build a release from a plugin source directory:
-
-```sh
-gestaltd plugin release --version 1.2.3
+```yaml
+source: github.com/acme/plugins/gestalt-ui
+version: 1.0.0
+release:
+  build:
+    workdir: ui
+    command:
+      - npm
+      - run
+      - build
+webui:
+  asset_root: ui/out
 ```
 
-`gestaltd plugin release` preserves the source manifest format, so `plugin.yaml` stays YAML and `plugin.json` stays JSON in the release archive. For executable Go, Rust, and Python integration plugins, release materializes the executable catalog automatically before packaging. Python source plugins load the module declared in `[tool.gestalt].plugin`, while Go and Rust source plugins synthesize the executable wrapper from the source package itself. Auth and datastore source packages support the same release flow for Go and Rust, but they do not generate catalogs. Source packages build the host-platform artifact by default. Pass `--platform` for an explicit `os/arch[/libc]` target list, or `--platform all` in CI to build the full supported release matrix.
+## Release
+
+Build a release from a provider source directory:
+
+```sh
+gestaltd provider release --version 1.2.3
+```
+
+`gestaltd provider release` preserves the source manifest format, so `plugin.yaml` stays YAML and `plugin.json` stays JSON in the release archive. For executable Go, Rust, and Python integration plugins, release materializes the executable catalog automatically before packaging. Python source plugins load the module declared in `[tool.gestalt].plugin`, while Go and Rust source plugins synthesize the executable wrapper from the source package itself. Auth and datastore source packages support the same release flow for Go and Rust, but they do not generate catalogs. Source packages build the host-platform artifact by default. Pass `--platform` for an explicit `os/arch[/libc]` target list, or `--platform all` in CI to build the full supported release matrix.

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -230,10 +230,10 @@ You can also use it to check startup behavior directly:
 docker run --rm valontechnologies/gestaltd:latest --help
 ```
 
-## Releasing plugins
+## Releasing providers
 
-If you build a plugin release in Docker, run `gestaltd plugin release` from the
-plugin source directory:
+If you build a provider release in Docker, run `gestaltd provider release` from
+the provider source directory:
 
 ```dockerfile
 FROM valontechnologies/gestaltd:latest AS gestaltd
@@ -244,7 +244,7 @@ COPY --from=gestaltd /gestaltd /usr/local/bin/gestaltd
 WORKDIR /src
 COPY . .
 RUN cd ./my-plugin && \
-    gestaltd plugin release --version 0.0.1-alpha.1 --platform all && \
+    gestaltd provider release --version 0.0.1-alpha.1 --platform all && \
     gestaltd init --config ./deploy/config.yaml
 ```
 

--- a/gestaltd/cmd/gestaltd/main_test.go
+++ b/gestaltd/cmd/gestaltd/main_test.go
@@ -20,7 +20,7 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "root",
 			args:      []string{"--help"},
-			wantParts: []string{"gestaltd validate", "gestaltd init", "gestaltd plugin <command> [flags]", "gestaltd serve", "--locked"},
+			wantParts: []string{"gestaltd validate", "gestaltd init", "gestaltd provider <command> [flags]", "gestaltd serve", "--locked"},
 			notWant:   []string{"gestaltd bundle", "gestaltd dev"},
 		},
 		{
@@ -34,9 +34,9 @@ func TestE2ECLIHelp(t *testing.T) {
 			wantParts: []string{"gestaltd init"},
 		},
 		{
-			name:      "plugin",
-			args:      []string{"plugin", "--help"},
-			wantParts: []string{"gestaltd plugin <command> [flags]"},
+			name:      "provider",
+			args:      []string{"provider", "--help"},
+			wantParts: []string{"gestaltd provider <command> [flags]"},
 		},
 	}
 

--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -18,20 +18,20 @@ import (
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
 
-func runPlugin(args []string) error {
+func runProvider(args []string) error {
 	if len(args) == 0 {
-		printPluginUsage(os.Stderr)
+		printProviderUsage(os.Stderr)
 		return flag.ErrHelp
 	}
 
 	switch args[0] {
 	case "-h", "--help", "help":
-		printPluginUsage(os.Stderr)
+		printProviderUsage(os.Stderr)
 		return flag.ErrHelp
 	case "release":
-		return runPluginRelease(args[1:])
+		return runProviderRelease(args[1:])
 	default:
-		return fmt.Errorf("unknown plugin command %q", args[0])
+		return fmt.Errorf("unknown provider command %q", args[0])
 	}
 }
 
@@ -52,9 +52,9 @@ type releaseBuildTarget struct {
 	Kind string
 }
 
-func runPluginRelease(args []string) error {
-	fs := flag.NewFlagSet("gestaltd plugin release", flag.ContinueOnError)
-	fs.Usage = func() { printPluginReleaseUsage(fs.Output()) }
+func runProviderRelease(args []string) error {
+	fs := flag.NewFlagSet("gestaltd provider release", flag.ContinueOnError)
+	fs.Usage = func() { printProviderReleaseUsage(fs.Output()) }
 	version := fs.String("version", "", "semantic version string (required)")
 	outputDir := fs.String("output", defaultReleaseOutputDir, "output directory")
 	platforms := fs.String("platform", "", "comma-separated platforms (os/arch[/libc]) or 'all'")
@@ -82,6 +82,17 @@ func runPluginRelease(args []string) error {
 	if err != nil {
 		return err
 	}
+	sourceDir := filepath.Dir(manifestPath)
+	_, releaseManifest, err := pluginpkg.ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", manifestPath, err)
+	}
+	if err := validateReleaseOutputDir(releaseManifest, sourceDir, *outputDir); err != nil {
+		return err
+	}
+	if err := pluginpkg.RunSourceReleaseBuild(manifestPath, releaseManifest); err != nil {
+		return err
+	}
 	_, srcManifest, err := pluginpkg.PrepareSourceManifest(manifestPath)
 	if err != nil {
 		return fmt.Errorf("prepare %s: %w", manifestPath, err)
@@ -95,19 +106,16 @@ func runPluginRelease(args []string) error {
 	}
 	pluginName := src.PluginName()
 
-	if err := validateReleaseOutputDir(srcManifest, ".", *outputDir); err != nil {
-		return err
-	}
 	if err := os.MkdirAll(*outputDir, 0755); err != nil {
 		return fmt.Errorf("create output dir: %w", err)
 	}
 
-	buildTarget, err := resolveReleaseBuildTarget(".", srcManifest)
+	buildTarget, err := resolveReleaseBuildTarget(sourceDir, srcManifest)
 	if err != nil {
 		return err
 	}
 
-	buildPlatforms, err := resolveReleaseBuildPlatforms(".", srcManifest, buildTarget, *platforms, platformFlagExplicit)
+	buildPlatforms, err := resolveReleaseBuildPlatforms(sourceDir, srcManifest, buildTarget, *platforms, platformFlagExplicit)
 	if err != nil {
 		return err
 	}
@@ -115,14 +123,14 @@ func runPluginRelease(args []string) error {
 	var archivePaths []string
 	if len(buildPlatforms) > 0 {
 		for _, platform := range buildPlatforms {
-			archivePath, err := buildPlatformArchive(srcManifest, pluginName, *version, buildTarget.Kind, platform, *outputDir, manifestFile, manifestFormat)
+			archivePath, err := buildPlatformArchive(sourceDir, srcManifest, pluginName, *version, buildTarget.Kind, platform, *outputDir, manifestFile, manifestFormat)
 			if err != nil {
 				return fmt.Errorf("build %s: %w", pluginpkg.PlatformString(platform.GOOS, platform.GOARCH, platform.LibC), err)
 			}
 			archivePaths = append(archivePaths, archivePath)
 		}
 	} else {
-		archivePath, err := buildSourceArchive(srcManifest, pluginName, *version, *outputDir, manifestFile, manifestFormat)
+		archivePath, err := buildSourceArchive(sourceDir, srcManifest, pluginName, *version, *outputDir, manifestFile, manifestFormat)
 		if err != nil {
 			return err
 		}
@@ -159,11 +167,11 @@ func resolveReleaseBuildTarget(root string, manifest *pluginmanifestv1.Manifest)
 	}
 
 	if len(buildKinds) > 1 {
-		return nil, fmt.Errorf("plugin release does not support building multiple executable kinds from source in one package: %s", strings.Join(buildKinds, ", "))
+		return nil, fmt.Errorf("provider release does not support building multiple executable kinds from source in one package: %s", strings.Join(buildKinds, ", "))
 	}
 	if len(requiredMissing) > 0 {
 		if len(buildKinds) > 0 {
-			return nil, fmt.Errorf("plugin release does not support mixing source-built %q with missing executable source kinds %s in one package", buildKinds[0], strings.Join(requiredMissing, ", "))
+			return nil, fmt.Errorf("provider release does not support mixing source-built %q with missing executable source kinds %s in one package", buildKinds[0], strings.Join(requiredMissing, ", "))
 		}
 		return nil, missingReleaseSourceBuildTargetError(requiredMissing)
 	}
@@ -230,14 +238,14 @@ func expandReleasePlatformValue(value string) (string, error) {
 	}
 }
 
-func buildPlatformArchive(srcManifest *pluginmanifestv1.Manifest, pluginName, version, buildKind string, platform releasePlatform, outputDir, manifestFile, manifestFormat string) (string, error) {
+func buildPlatformArchive(sourceDir string, srcManifest *pluginmanifestv1.Manifest, pluginName, version, buildKind string, platform releasePlatform, outputDir, manifestFile, manifestFormat string) (string, error) {
 	stagingDir, err := os.MkdirTemp("", "gestalt-release-*")
 	if err != nil {
 		return "", err
 	}
 	defer func() { _ = os.RemoveAll(stagingDir) }()
 
-	manifest, plat, err := prepareBuiltPackageDir(stagingDir, ".", srcManifest, version, pluginName, buildKind, platform)
+	manifest, plat, err := prepareBuiltPackageDir(stagingDir, sourceDir, srcManifest, version, pluginName, buildKind, platform)
 	if err != nil {
 		return "", err
 	}
@@ -410,14 +418,14 @@ func currentReleasePlatform() string {
 	return runtime.GOOS + "/" + runtime.GOARCH
 }
 
-func buildSourceArchive(srcManifest *pluginmanifestv1.Manifest, pluginName, version, outputDir, manifestFile, manifestFormat string) (string, error) {
+func buildSourceArchive(sourceDir string, srcManifest *pluginmanifestv1.Manifest, pluginName, version, outputDir, manifestFile, manifestFormat string) (string, error) {
 	archiveName := fmt.Sprintf("gestalt-plugin-%s_v%s.tar.gz", pluginName, version)
 	return createReleaseArchive(outputDir, archiveName, manifestFile, manifestFormat, func(stagingDir string) (*pluginmanifestv1.Manifest, error) {
-		manifest, err := buildSourceReleaseManifest(srcManifest, version, ".")
+		manifest, err := buildSourceReleaseManifest(srcManifest, version, sourceDir)
 		if err != nil {
 			return nil, err
 		}
-		if err := copyReleasePackageFiles(manifest, ".", stagingDir, true); err != nil {
+		if err := copyReleasePackageFiles(manifest, sourceDir, stagingDir, true); err != nil {
 			return nil, err
 		}
 		return manifest, nil
@@ -459,6 +467,7 @@ func buildSourceReleaseManifest(srcManifest *pluginmanifestv1.Manifest, version,
 		return nil, fmt.Errorf("clone manifest: %w", err)
 	}
 	manifest.Version = version
+	manifest.Release = nil
 
 	for i, artifact := range srcManifest.Artifacts {
 		digest, err := pluginpkg.FileSHA256(filepath.Join(sourceDir, filepath.FromSlash(artifact.Path)))
@@ -480,6 +489,7 @@ func buildReleaseManifest(srcManifest *pluginmanifestv1.Manifest, version, binar
 		return nil, fmt.Errorf("clone manifest: %w", err)
 	}
 	manifest.Version = version
+	manifest.Release = nil
 	manifest.Artifacts = []pluginmanifestv1.Artifact{
 		{OS: plat.GOOS, Arch: plat.GOARCH, LibC: plat.LibC, Path: binaryName, SHA256: digest},
 	}
@@ -732,22 +742,22 @@ func normalizeReleasePath(rel string) (string, error) {
 	return cleanPath, nil
 }
 
-func printPluginUsage(w io.Writer) {
+func printProviderUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd plugin <command> [flags]")
+	writeUsageLine(w, "  gestaltd provider <command> [flags]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
-	writeUsageLine(w, "  release     Build plugin release archives")
+	writeUsageLine(w, "  release     Build provider release archives")
 }
 
-func printPluginReleaseUsage(w io.Writer) {
+func printProviderReleaseUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd plugin release --version VERSION [--output DIR] [--platform PLATFORMS]")
+	writeUsageLine(w, "  gestaltd provider release --version VERSION [--output DIR] [--platform PLATFORMS]")
 	writeUsageLine(w, "")
-	writeUsageLine(w, "Build a plugin release archive for the host platform by default.")
+	writeUsageLine(w, "Build a provider release archive for the host platform by default.")
 	writeUsageLine(w, "Pass --platform with a comma-separated os/arch[/libc] list or --platform all")
 	writeUsageLine(w, "to build multiple per-platform tar.gz archives plus a checksums file.")
-	writeUsageLine(w, "Run from the plugin source directory.")
+	writeUsageLine(w, "Run from the provider source directory.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --version    Semantic version string (required)")

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -48,15 +48,15 @@ const (
 	pythonDatastoreReleaseSource     = "github.com/testowner/plugins/python-datastore-release"
 )
 
-func TestRun_PluginHelpExitsCleanly(t *testing.T) {
+func TestRun_ProviderHelpExitsCleanly(t *testing.T) {
 	t.Parallel()
 
 	out, err := runPluginCommandResult("", "--help")
 	if err != nil {
-		t.Fatalf("expected exit 0 for 'plugin --help', got error: %v\noutput: %s", err, out)
+		t.Fatalf("expected exit 0 for 'provider --help', got error: %v\noutput: %s", err, out)
 	}
-	if !strings.Contains(string(out), "gestaltd plugin <command> [flags]") {
-		t.Fatalf("expected plugin usage output, got: %s", out)
+	if !strings.Contains(string(out), "gestaltd provider <command> [flags]") {
+		t.Fatalf("expected provider usage output, got: %s", out)
 	}
 	if !strings.Contains(string(out), "release") {
 		t.Fatalf("expected release in help output, got: %s", out)
@@ -68,50 +68,50 @@ func TestRun_PluginHelpExitsCleanly(t *testing.T) {
 	}
 }
 
-func TestRun_PluginReleaseHelpExitsCleanly(t *testing.T) {
+func TestRun_ProviderReleaseHelpExitsCleanly(t *testing.T) {
 	t.Parallel()
 
 	out, err := runPluginCommandResult("", "release", "--help")
 	if err != nil {
-		t.Fatalf("expected exit 0 for 'plugin release --help', got error: %v\noutput: %s", err, out)
+		t.Fatalf("expected exit 0 for 'provider release --help', got error: %v\noutput: %s", err, out)
 	}
 	if !strings.Contains(string(out), "--version") {
 		t.Fatalf("expected --version in release help, got: %s", out)
 	}
 }
 
-func TestRun_PluginRootReturnsHelpWhenNoSubcommandProvided(t *testing.T) {
+func TestRun_ProviderRootReturnsHelpWhenNoSubcommandProvided(t *testing.T) {
 	t.Parallel()
 
 	out, err := runPluginCommandResult("")
 	if err != nil {
-		t.Fatalf("expected exit 0 for 'plugin', got error: %v\noutput: %s", err, out)
+		t.Fatalf("expected exit 0 for 'provider', got error: %v\noutput: %s", err, out)
 	}
-	if !strings.Contains(string(out), "gestaltd plugin <command> [flags]") {
-		t.Fatalf("expected plugin usage output, got: %s", out)
+	if !strings.Contains(string(out), "gestaltd provider <command> [flags]") {
+		t.Fatalf("expected provider usage output, got: %s", out)
 	}
 }
 
-func TestRun_PluginRejectsUnknownSubcommand(t *testing.T) {
+func TestRun_ProviderRejectsUnknownSubcommand(t *testing.T) {
 	t.Parallel()
 
 	out, err := runPluginCommandResult("", "bogus")
 	if err == nil {
-		t.Fatal("expected error for unknown plugin subcommand")
+		t.Fatal("expected error for unknown provider subcommand")
 	}
-	if !strings.Contains(string(out), "unknown plugin command") || !strings.Contains(string(out), "bogus") {
+	if !strings.Contains(string(out), "unknown provider command") || !strings.Contains(string(out), "bogus") {
 		t.Fatalf("unexpected output: %s", out)
 	}
 }
 
-func TestRun_PluginRejectsRemovedPackageSubcommand(t *testing.T) {
+func TestRun_ProviderRejectsRemovedPackageSubcommand(t *testing.T) {
 	t.Parallel()
 
 	out, err := runPluginCommandResult("", "package")
 	if err == nil {
-		t.Fatal("expected error for removed plugin package subcommand")
+		t.Fatal("expected error for removed provider package subcommand")
 	}
-	if !strings.Contains(string(out), "unknown plugin command") || !strings.Contains(string(out), "package") {
+	if !strings.Contains(string(out), "unknown provider command") || !strings.Contains(string(out), "package") {
 		t.Fatalf("unexpected output: %s", out)
 	}
 }
@@ -203,7 +203,7 @@ func TestE2EPluginReleaseBigquery(t *testing.T) {
 	const testVersion = "0.0.1-test"
 	const testPlatform = "linux/amd64"
 
-	cmd := exec.Command(gestaltdBin, "plugin", "release",
+	cmd := exec.Command(gestaltdBin, "provider", "release",
 		"--version", testVersion,
 		"--platform", testPlatform,
 		"--output", outputDir,
@@ -211,7 +211,7 @@ func TestE2EPluginReleaseBigquery(t *testing.T) {
 	cmd.Dir = bigqueryDir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("plugin release failed: %v\n%s", err, out)
+		t.Fatalf("provider release failed: %v\n%s", err, out)
 	}
 
 	archiveName := "gestalt-plugin-bigquery_v" + testVersion + "_linux_amd64.tar.gz"
@@ -1260,6 +1260,67 @@ func TestRun_PluginReleaseCopiesWebUISupportFiles(t *testing.T) {
 	}
 }
 
+func TestRun_ProviderReleaseBuildsProviderSupportFilesBeforePackaging(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("release build fixture uses POSIX shell")
+	}
+
+	pluginDir := newBuiltSourceProviderReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.3-build-provider"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-release-test_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+	if manifest.Release != nil {
+		t.Fatalf("released manifest unexpectedly retained release metadata: %+v", manifest.Release)
+	}
+	if _, err := os.Stat(filepath.Join(extractDir, releaseProviderSchemaPath)); err != nil {
+		t.Fatalf("expected %s in archive: %v", releaseProviderSchemaPath, err)
+	}
+}
+
+func TestRun_ProviderReleaseBuildsWebUIAssetsBeforePackaging(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("release build fixture uses POSIX shell")
+	}
+
+	pluginDir := newBuiltWebUIReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.3-build-webui"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-webui-test_v" + testVersion + ".tar.gz"
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+	if manifest.Release != nil {
+		t.Fatalf("released manifest unexpectedly retained release metadata: %+v", manifest.Release)
+	}
+	for _, rel := range []string{
+		"branding/icon.svg",
+		"ui/out/index.html",
+		"ui/out/static/app.js",
+	} {
+		if _, err := os.Stat(filepath.Join(extractDir, filepath.FromSlash(rel))); err != nil {
+			t.Fatalf("expected %s in archive: %v", rel, err)
+		}
+	}
+}
+
 func TestRun_PluginReleaseAllowsOverlappingSupportPaths(t *testing.T) {
 	t.Parallel()
 
@@ -1419,7 +1480,7 @@ func TestRun_PluginReleaseRejectsOutputInsideWebUIAssetRoot(t *testing.T) {
 
 	out, err := runPluginReleaseCommandResult(pluginDir, "--version", "1.0.0", "--output", outputDir)
 	if err == nil {
-		t.Fatalf("expected plugin release to fail, got output: %s", out)
+		t.Fatalf("expected provider release to fail, got output: %s", out)
 	}
 	if !strings.Contains(string(out), "must not be inside webui.asset_root") {
 		t.Fatalf("expected overlap error, got: %s", out)
@@ -2154,6 +2215,17 @@ func newSourceProviderReleaseFixture(t *testing.T, dir string) string {
 	return pluginDir
 }
 
+func newBuiltSourceProviderReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := newSourceProviderReleaseFixture(t, dir)
+	if err := os.Remove(filepath.Join(pluginDir, releaseProviderSchemaPath)); err != nil {
+		t.Fatalf("Remove(%s): %v", releaseProviderSchemaPath, err)
+	}
+	addReleaseBuild(t, pluginDir, filepath.Join("scripts", "build.sh"), "", "mkdir -p schemas\nprintf '{\"type\":\"object\"}\\n' > "+releaseProviderSchemaPath+"\n")
+	return pluginDir
+}
+
 func newGoSourceReleaseFixture(t *testing.T, dir string) string {
 	t.Helper()
 
@@ -2490,6 +2562,34 @@ func newWebUIReleaseFixture(t *testing.T, dir string) string {
 	return newWebUIReleaseFixtureWithAssetRoot(t, dir, webUITestAssetRoot)
 }
 
+func newBuiltWebUIReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(dir, webUITestPluginName)
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatalf("MkdirAll(pluginDir): %v", err)
+	}
+	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
+		Source:      webUITestSource,
+		Version:     "0.0.1",
+		DisplayName: "WebUI Test",
+		IconFile:    releaseTestIconPath,
+		Kinds:       []string{pluginmanifestv1.KindWebUI},
+		Release: &pluginmanifestv1.ReleaseMetadata{
+			Build: &pluginmanifestv1.ReleaseBuild{
+				Workdir: "ui",
+				Command: []string{"sh", "./build.sh"},
+			},
+		},
+		WebUI: &pluginmanifestv1.WebUIMetadata{
+			AssetRoot: "ui/out",
+		},
+	})
+	writeTestFile(t, pluginDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0644)
+	writeReleaseBuildScript(t, pluginDir, filepath.Join("ui", "build.sh"), "mkdir -p out/static\nprintf '<html></html>\\n' > out/index.html\nprintf 'console.log(\"ok\")\\n' > out/static/app.js\n")
+	return pluginDir
+}
+
 func newWebUIReleaseFixtureWithAssetRoot(t *testing.T, dir, assetRoot string) string {
 	t.Helper()
 
@@ -2513,18 +2613,41 @@ func newWebUIReleaseFixtureWithAssetRoot(t *testing.T, dir, assetRoot string) st
 	return pluginDir
 }
 
+func addReleaseBuild(t *testing.T, pluginDir, scriptPath, workdir, body string) {
+	t.Helper()
+
+	_, manifest, err := pluginpkg.ReadSourceManifestFile(filepath.Join(pluginDir, pluginpkg.ManifestFile))
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile(%s): %v", pluginpkg.ManifestFile, err)
+	}
+	manifest.Release = &pluginmanifestv1.ReleaseMetadata{
+		Build: &pluginmanifestv1.ReleaseBuild{
+			Workdir: workdir,
+			Command: []string{"sh", "./" + filepath.ToSlash(scriptPath)},
+		},
+	}
+	writeReleaseTestManifest(t, pluginDir, manifest)
+	writeReleaseBuildScript(t, pluginDir, scriptPath, body)
+}
+
+func writeReleaseBuildScript(t *testing.T, dir, rel, body string) {
+	t.Helper()
+
+	writeTestFile(t, dir, rel, []byte("#!/bin/sh\nset -eu\n"+body), 0o755)
+}
+
 func runPluginReleaseCommand(t *testing.T, pluginDir string, args ...string) string {
 	t.Helper()
 
 	out, err := runPluginReleaseCommandResult(pluginDir, args...)
 	if err != nil {
-		t.Fatalf("plugin release failed: %v\n%s", err, out)
+		t.Fatalf("provider release failed: %v\n%s", err, out)
 	}
 	return string(out)
 }
 
 func runPluginCommandResult(pluginDir string, args ...string) ([]byte, error) {
-	cmdArgs := append([]string{"plugin"}, args...)
+	cmdArgs := append([]string{"provider"}, args...)
 	cmd := exec.Command(gestaltdBin, cmdArgs...)
 	cmd.Dir = pluginDir
 	return cmd.CombinedOutput()

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -39,8 +39,8 @@ func run(args []string) error {
 		case "version", "--version", "-v":
 			fmt.Println(version)
 			return nil
-		case "plugin":
-			return runPlugin(args[1:])
+		case "provider":
+			return runProvider(args[1:])
 		case "serve":
 			return runServe(args[1:])
 		case "init":
@@ -497,13 +497,13 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd [--config PATH] [--artifacts-dir PATH]")
 	writeUsageLine(w, "  gestaltd init [--config PATH] [--artifacts-dir PATH]")
 	writeUsageLine(w, "  gestaltd serve [--config PATH] [--artifacts-dir PATH] [--locked]")
-	writeUsageLine(w, "  gestaltd plugin <command> [flags]")
+	writeUsageLine(w, "  gestaltd provider <command> [flags]")
 	writeUsageLine(w, "  gestaltd validate [--config PATH] [--artifacts-dir PATH]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
 	writeUsageLine(w, "  init        Resolve providers and plugins and write lock state")
+	writeUsageLine(w, "  provider    Build provider release archives")
 	writeUsageLine(w, "  serve       Start the server (use --locked for production)")
-	writeUsageLine(w, "  plugin      Build plugin release archives")
 	writeUsageLine(w, "  validate    Load and validate configuration without starting the server")
 	writeUsageLine(w, "  version     Print the version and exit")
 	writeUsageLine(w, "")

--- a/gestaltd/internal/pluginpkg/manifest.go
+++ b/gestaltd/internal/pluginpkg/manifest.go
@@ -105,6 +105,14 @@ func validateManifest(manifest *pluginmanifestv1.Manifest, sourceMode bool) erro
 			return err
 		}
 	}
+	if manifest.Release != nil {
+		if !sourceMode {
+			return fmt.Errorf("release metadata is only allowed in source manifests")
+		}
+		if err := validateReleaseMetadata(manifest.Release); err != nil {
+			return err
+		}
+	}
 	if len(manifest.Kinds) == 0 {
 		if manifest.Plugin != nil {
 			manifest.Kinds = append(manifest.Kinds, pluginmanifestv1.KindPlugin)
@@ -363,6 +371,44 @@ func validateRelativePackagePath(value, label string) error {
 	}
 	cleaned := path.Clean(value)
 	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return fmt.Errorf("%s must stay within the package", label)
+	}
+	if strings.Contains(value, "\\") {
+		return fmt.Errorf("%s must use forward slashes", label)
+	}
+	if cleaned != value {
+		return fmt.Errorf("%s must be normalized", label)
+	}
+	return nil
+}
+
+func validateReleaseMetadata(release *pluginmanifestv1.ReleaseMetadata) error {
+	if release == nil || release.Build == nil {
+		return nil
+	}
+	if err := validateRelativePackageDirectory(release.Build.Workdir, "release.build.workdir"); err != nil {
+		return err
+	}
+	if len(release.Build.Command) == 0 {
+		return fmt.Errorf("release.build.command is required")
+	}
+	for i, arg := range release.Build.Command {
+		if strings.TrimSpace(arg) == "" {
+			return fmt.Errorf("release.build.command[%d] is required", i)
+		}
+	}
+	return nil
+}
+
+func validateRelativePackageDirectory(value, label string) error {
+	if value == "" {
+		return nil
+	}
+	if strings.HasPrefix(value, "/") {
+		return fmt.Errorf("%s must be relative", label)
+	}
+	cleaned := path.Clean(value)
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
 		return fmt.Errorf("%s must stay within the package", label)
 	}
 	if strings.Contains(value, "\\") {

--- a/gestaltd/internal/pluginpkg/manifest.go
+++ b/gestaltd/internal/pluginpkg/manifest.go
@@ -386,8 +386,10 @@ func validateReleaseMetadata(release *pluginmanifestv1.ReleaseMetadata) error {
 	if release == nil || release.Build == nil {
 		return nil
 	}
-	if err := validateRelativePackageDirectory(release.Build.Workdir, "release.build.workdir"); err != nil {
-		return err
+	if release.Build.Workdir != "" {
+		if err := validateRelativePackagePath(release.Build.Workdir, "release.build.workdir"); err != nil {
+			return err
+		}
 	}
 	if len(release.Build.Command) == 0 {
 		return fmt.Errorf("release.build.command is required")
@@ -396,26 +398,6 @@ func validateReleaseMetadata(release *pluginmanifestv1.ReleaseMetadata) error {
 		if strings.TrimSpace(arg) == "" {
 			return fmt.Errorf("release.build.command[%d] is required", i)
 		}
-	}
-	return nil
-}
-
-func validateRelativePackageDirectory(value, label string) error {
-	if value == "" {
-		return nil
-	}
-	if strings.HasPrefix(value, "/") {
-		return fmt.Errorf("%s must be relative", label)
-	}
-	cleaned := path.Clean(value)
-	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
-		return fmt.Errorf("%s must stay within the package", label)
-	}
-	if strings.Contains(value, "\\") {
-		return fmt.Errorf("%s must use forward slashes", label)
-	}
-	if cleaned != value {
-		return fmt.Errorf("%s must be normalized", label)
 	}
 	return nil
 }

--- a/gestaltd/internal/pluginpkg/provider_manifest_wire.go
+++ b/gestaltd/internal/pluginpkg/provider_manifest_wire.go
@@ -11,15 +11,16 @@ import (
 )
 
 type providerManifestWireRoot struct {
-	Source      string                          `json:"source,omitempty" yaml:"source,omitempty"`
-	Version     string                          `json:"version" yaml:"version"`
-	DisplayName string                          `json:"display_name,omitempty" yaml:"display_name,omitempty"`
-	Description string                          `json:"description,omitempty" yaml:"description,omitempty"`
-	IconFile    string                          `json:"icon_file,omitempty" yaml:"icon_file,omitempty"`
-	Kinds       []string                        `json:"kinds,omitempty" yaml:"kinds,omitempty"`
-	Provider    *providerManifestWire           `json:"provider,omitempty" yaml:"provider,omitempty"`
-	WebUI       *pluginmanifestv1.WebUIMetadata `json:"webui,omitempty" yaml:"webui,omitempty"`
-	Artifacts   []pluginmanifestv1.Artifact     `json:"artifacts,omitempty" yaml:"artifacts,omitempty"`
+	Source      string                            `json:"source,omitempty" yaml:"source,omitempty"`
+	Version     string                            `json:"version" yaml:"version"`
+	DisplayName string                            `json:"display_name,omitempty" yaml:"display_name,omitempty"`
+	Description string                            `json:"description,omitempty" yaml:"description,omitempty"`
+	IconFile    string                            `json:"icon_file,omitempty" yaml:"icon_file,omitempty"`
+	Kinds       []string                          `json:"kinds,omitempty" yaml:"kinds,omitempty"`
+	Release     *pluginmanifestv1.ReleaseMetadata `json:"release,omitempty" yaml:"release,omitempty"`
+	Provider    *providerManifestWire             `json:"provider,omitempty" yaml:"provider,omitempty"`
+	WebUI       *pluginmanifestv1.WebUIMetadata   `json:"webui,omitempty" yaml:"webui,omitempty"`
+	Artifacts   []pluginmanifestv1.Artifact       `json:"artifacts,omitempty" yaml:"artifacts,omitempty"`
 }
 
 type providerManifestWire struct {
@@ -120,6 +121,7 @@ func providerWireToInternal(wire *providerManifestWireRoot) *pluginmanifestv1.Ma
 		Description: wire.Description,
 		IconFile:    wire.IconFile,
 		Kinds:       append([]string(nil), wire.Kinds...),
+		Release:     wire.Release,
 		WebUI:       wire.WebUI,
 		Artifacts:   append([]pluginmanifestv1.Artifact(nil), wire.Artifacts...),
 	}
@@ -227,6 +229,7 @@ func internalProviderManifestToWire(manifest *pluginmanifestv1.Manifest) *provid
 		DisplayName: manifest.DisplayName,
 		Description: manifest.Description,
 		IconFile:    manifest.IconFile,
+		Release:     manifest.Release,
 		WebUI:       manifest.WebUI,
 		Artifacts:   append([]pluginmanifestv1.Artifact(nil), manifest.Artifacts...),
 	}

--- a/gestaltd/internal/pluginpkg/source_build.go
+++ b/gestaltd/internal/pluginpkg/source_build.go
@@ -1,0 +1,39 @@
+package pluginpkg
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+)
+
+func RunSourceReleaseBuild(manifestPath string, manifest *pluginmanifestv1.Manifest) error {
+	if manifest == nil || manifest.Release == nil || manifest.Release.Build == nil {
+		return nil
+	}
+
+	rootDir := filepath.Dir(manifestPath)
+	workdir := rootDir
+	if manifest.Release.Build.Workdir != "" {
+		workdir = filepath.Join(rootDir, filepath.FromSlash(manifest.Release.Build.Workdir))
+	}
+
+	info, err := os.Stat(workdir)
+	if err != nil {
+		return fmt.Errorf("stat release.build.workdir %q: %w", manifest.Release.Build.Workdir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("release.build.workdir %q is not a directory", manifest.Release.Build.Workdir)
+	}
+
+	cmd := exec.Command(manifest.Release.Build.Command[0], manifest.Release.Build.Command[1:]...)
+	cmd.Dir = workdir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("run release.build.command: %w", err)
+	}
+	return nil
+}

--- a/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -25,6 +25,9 @@
     "icon_file": {
       "type": "string"
     },
+    "release": {
+      "$ref": "#/$defs/release"
+    },
     "plugin": {
       "$ref": "#/$defs/plugin"
     },
@@ -67,6 +70,36 @@
     }
   ],
   "$defs": {
+    "release": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "build": {
+          "$ref": "#/$defs/release_build"
+        }
+      }
+    },
+    "release_build": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command"
+      ],
+      "properties": {
+        "workdir": {
+          "type": "string",
+          "minLength": 1
+        },
+        "command": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
     "plugin": {
       "type": "object",
       "additionalProperties": false,

--- a/gestaltd/sdk/pluginmanifest/v1/types.go
+++ b/gestaltd/sdk/pluginmanifest/v1/types.go
@@ -18,12 +18,22 @@ type Manifest struct {
 	Description string             `json:"description,omitempty" yaml:"description,omitempty"`
 	IconFile    string             `json:"icon_file,omitempty" yaml:"icon_file,omitempty"`
 	Kinds       []string           `json:"kinds" yaml:"kinds"`
+	Release     *ReleaseMetadata   `json:"release,omitempty" yaml:"release,omitempty"`
 	Plugin      *Plugin            `json:"plugin,omitempty" yaml:"plugin,omitempty"`
 	Auth        *AuthMetadata      `json:"auth,omitempty" yaml:"auth,omitempty"`
 	Datastore   *DatastoreMetadata `json:"datastore,omitempty" yaml:"datastore,omitempty"`
 	WebUI       *WebUIMetadata     `json:"webui,omitempty" yaml:"webui,omitempty"`
 	Artifacts   []Artifact         `json:"artifacts,omitempty" yaml:"artifacts,omitempty"`
 	Entrypoints Entrypoints        `json:"entrypoints,omitzero" yaml:"entrypoints,omitempty"`
+}
+
+type ReleaseMetadata struct {
+	Build *ReleaseBuild `json:"build,omitempty" yaml:"build,omitempty"`
+}
+
+type ReleaseBuild struct {
+	Workdir string   `json:"workdir,omitempty" yaml:"workdir,omitempty"`
+	Command []string `json:"command" yaml:"command"`
 }
 
 type AuthMetadata struct {


### PR DESCRIPTION
## What changed

This renames the release command from `gestaltd plugin release` to `gestaltd provider release`.

It also adds first-class source release build support at the manifest layer:

```yaml
release:
  build:
    workdir: ui
    command:
      - npm
      - run
      - build
```

That build step runs before source-manifest preparation, which means release packaging now has an upstream way to generate required inputs before archiving:

- `plugin` providers can generate support files before packaging
- `auth` providers can generate support files before packaging
- `datastore` providers can generate support files before packaging
- `webui` providers can build static assets before packaging

Released manifests strip the `release` metadata back out so published packages stay clean.

## Why this changed

The previous flow handled executable packaging and web UI packaging asymmetrically. In particular, `webui` packaging assumed `webui.asset_root` already existed on disk, which forced first-party repos into ad hoc prep scripts.

This change tightens the upstream contract instead:

- one provider-oriented release command
- one source-only build hook
- one packaging flow that works across provider kinds

## User and developer impact

Developers should use `gestaltd provider release` going forward.

Provider packages can now declare source-only build steps directly in the manifest instead of relying on repo-specific CI glue to materialize generated files before release packaging.

## Validation

- `go test ./cmd/gestaltd ./internal/pluginpkg`
