### PR TITLE
sdk/rust: remove http crate, fix clones, inline runtime_types, dedup run functions

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["api-bindings", "development-tools"]
 
 [dependencies]
 async-trait = "0.1"
-http = "0.2"
 libc = "0.2"
 prost = "0.12"
 prost-types = "0.12"

--- a/sdk/rust/src/api.rs
+++ b/sdk/rust/src/api.rs
@@ -5,7 +5,6 @@ use async_trait::async_trait;
 
 use crate::catalog::Catalog;
 use crate::error::{Error, Result};
-use crate::runtime_types::RuntimeMetadata;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Request {
@@ -38,7 +37,7 @@ impl<T> Response<T> {
 }
 
 pub fn ok<T>(body: T) -> Response<T> {
-    Response::new(http::StatusCode::OK.as_u16(), body)
+    Response::new(200, body)
 }
 
 pub trait IntoResponse<T> {
@@ -55,6 +54,14 @@ impl<T> IntoResponse<T> for T {
     fn into_response(self) -> Response<T> {
         ok(self)
     }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct RuntimeMetadata {
+    pub name: String,
+    pub display_name: String,
+    pub description: String,
+    pub version: String,
 }
 
 #[async_trait]

--- a/sdk/rust/src/auth.rs
+++ b/sdk/rust/src/auth.rs
@@ -6,7 +6,7 @@ use crate::error::{Error, Result};
 pub use crate::generated::v1::{
     AuthenticatedUser, BeginLoginRequest, BeginLoginResponse, CompleteLoginRequest,
 };
-use crate::runtime_types::RuntimeMetadata;
+use crate::api::RuntimeMetadata;
 
 #[async_trait]
 pub trait AuthProvider: Send + Sync + 'static {

--- a/sdk/rust/src/auth.rs
+++ b/sdk/rust/src/auth.rs
@@ -2,11 +2,11 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 
+use crate::api::RuntimeMetadata;
 use crate::error::{Error, Result};
 pub use crate::generated::v1::{
     AuthenticatedUser, BeginLoginRequest, BeginLoginResponse, CompleteLoginRequest,
 };
-use crate::api::RuntimeMetadata;
 
 #[async_trait]
 pub trait AuthProvider: Send + Sync + 'static {

--- a/sdk/rust/src/datastore.rs
+++ b/sdk/rust/src/datastore.rs
@@ -1,10 +1,10 @@
 use async_trait::async_trait;
 
+use crate::api::RuntimeMetadata;
 use crate::error::{Error, Result};
 pub use crate::generated::v1::{
     OAuthRegistration, StoredApiToken, StoredIntegrationToken, StoredUser,
 };
-use crate::api::RuntimeMetadata;
 
 #[async_trait]
 pub trait DatastoreProvider: Send + Sync + 'static {

--- a/sdk/rust/src/datastore.rs
+++ b/sdk/rust/src/datastore.rs
@@ -4,7 +4,7 @@ use crate::error::{Error, Result};
 pub use crate::generated::v1::{
     OAuthRegistration, StoredApiToken, StoredIntegrationToken, StoredUser,
 };
-use crate::runtime_types::RuntimeMetadata;
+use crate::api::RuntimeMetadata;
 
 #[async_trait]
 pub trait DatastoreProvider: Send + Sync + 'static {

--- a/sdk/rust/src/error.rs
+++ b/sdk/rust/src/error.rs
@@ -5,6 +5,11 @@ pub struct Error {
     message: String,
 }
 
+pub(crate) const HTTP_BAD_REQUEST: u16 = 400;
+pub(crate) const HTTP_NOT_FOUND: u16 = 404;
+pub(crate) const HTTP_INTERNAL_SERVER_ERROR: u16 = 500;
+pub(crate) const HTTP_NOT_IMPLEMENTED: u16 = 501;
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 impl Error {
@@ -23,19 +28,19 @@ impl Error {
     }
 
     pub fn bad_request(message: impl Into<String>) -> Self {
-        Self::with_status(http::StatusCode::BAD_REQUEST.as_u16(), message)
+        Self::with_status(HTTP_BAD_REQUEST, message)
     }
 
     pub fn internal(message: impl Into<String>) -> Self {
-        Self::with_status(http::StatusCode::INTERNAL_SERVER_ERROR.as_u16(), message)
+        Self::with_status(HTTP_INTERNAL_SERVER_ERROR, message)
     }
 
     pub fn not_found(message: impl Into<String>) -> Self {
-        Self::with_status(http::StatusCode::NOT_FOUND.as_u16(), message)
+        Self::with_status(HTTP_NOT_FOUND, message)
     }
 
     pub fn unimplemented(message: impl Into<String>) -> Self {
-        Self::with_status(http::StatusCode::NOT_IMPLEMENTED.as_u16(), message)
+        Self::with_status(HTTP_NOT_IMPLEMENTED, message)
     }
 
     pub fn status(&self) -> Option<u16> {

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -12,8 +12,6 @@ mod provider_server;
 mod router;
 mod rpc_status;
 mod runtime_server;
-mod runtime_types;
-
 pub mod runtime;
 
 /// The shared protobuf package name used by the Gestalt SDK protocol surface.
@@ -48,7 +46,7 @@ pub use env::{
 pub use error::{Error, Result};
 pub use provider_server::{OperationResult, ProviderServer};
 pub use router::{Operation, Router};
-pub use runtime_types::RuntimeMetadata;
+pub use api::RuntimeMetadata;
 
 #[doc(hidden)]
 pub trait IntoRouterResult<P> {

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -11,8 +11,8 @@ mod error;
 mod provider_server;
 mod router;
 mod rpc_status;
-mod runtime_server;
 pub mod runtime;
+mod runtime_server;
 
 /// The shared protobuf package name used by the Gestalt SDK protocol surface.
 pub const PROTO_PACKAGE: &str = "gestalt.plugin.v1";
@@ -28,6 +28,7 @@ pub mod proto {
     pub use crate::generated::v1;
 }
 
+pub use api::RuntimeMetadata;
 pub use api::{IntoResponse, Provider, Request, Response, ok};
 pub use async_trait::async_trait;
 pub use auth::{
@@ -46,7 +47,6 @@ pub use env::{
 pub use error::{Error, Result};
 pub use provider_server::{OperationResult, ProviderServer};
 pub use router::{Operation, Router};
-pub use api::RuntimeMetadata;
 
 #[doc(hidden)]
 pub trait IntoRouterResult<P> {

--- a/sdk/rust/src/provider_server.rs
+++ b/sdk/rust/src/provider_server.rs
@@ -38,10 +38,7 @@ impl OperationResult {
     }
 
     pub fn from_error(error: Error) -> Self {
-        Self::error(
-            error.status().unwrap_or(500),
-            error.message().to_owned(),
-        )
+        Self::error(error.status().unwrap_or(500), error.message().to_owned())
     }
 
     pub fn error(status: u16, message: impl Into<String>) -> Self {

--- a/sdk/rust/src/provider_server.rs
+++ b/sdk/rust/src/provider_server.rs
@@ -30,21 +30,16 @@ pub struct OperationResult {
 
 impl OperationResult {
     pub fn from_response<T: Serialize>(response: Response<T>) -> Self {
-        let status = response.status.unwrap_or(http::StatusCode::OK.as_u16());
+        let status = response.status.unwrap_or(200);
         match serde_json::to_string(&response.body) {
             Ok(body) => Self { status, body },
-            Err(error) => Self::error(
-                http::StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
-                error.to_string(),
-            ),
+            Err(error) => Self::error(500, error.to_string()),
         }
     }
 
     pub fn from_error(error: Error) -> Self {
         Self::error(
-            error
-                .status()
-                .unwrap_or(http::StatusCode::INTERNAL_SERVER_ERROR.as_u16()),
+            error.status().unwrap_or(500),
             error.message().to_owned(),
         )
     }

--- a/sdk/rust/src/router.rs
+++ b/sdk/rust/src/router.rs
@@ -135,18 +135,12 @@ impl<P> Router<P> {
         request: Request,
     ) -> OperationResult {
         let Some(handler) = self.handlers.get(operation) else {
-            return OperationResult::error(
-                404,
-                "unknown operation",
-            );
+            return OperationResult::error(404, "unknown operation");
         };
 
         match tokio::spawn(handler(provider, params, request)).await {
             Ok(result) => result,
-            Err(error) => OperationResult::error(
-                500,
-                join_error_message(error),
-            ),
+            Err(error) => OperationResult::error(500, join_error_message(error)),
         }
     }
 }
@@ -232,10 +226,9 @@ fn decode_params<In: DeserializeOwned>(operation_id: &str, raw_params: Value) ->
     let empty = is_empty_object(&raw_params);
     match serde_json::from_value::<In>(raw_params) {
         Ok(input) => Ok(input),
-        Err(error) if empty => serde_json::from_value::<In>(Value::Null)
-            .map_err(|_| {
-                Error::bad_request(format!("decode params for {:?}: {}", operation_id, error))
-            }),
+        Err(error) if empty => serde_json::from_value::<In>(Value::Null).map_err(|_| {
+            Error::bad_request(format!("decode params for {:?}: {}", operation_id, error))
+        }),
         Err(error) => Err(Error::bad_request(format!(
             "decode params for {:?}: {}",
             operation_id, error

--- a/sdk/rust/src/router.rs
+++ b/sdk/rust/src/router.rs
@@ -136,7 +136,7 @@ impl<P> Router<P> {
     ) -> OperationResult {
         let Some(handler) = self.handlers.get(operation) else {
             return OperationResult::error(
-                http::StatusCode::NOT_FOUND.as_u16(),
+                404,
                 "unknown operation",
             );
         };
@@ -144,7 +144,7 @@ impl<P> Router<P> {
         match tokio::spawn(handler(provider, params, request)).await {
             Ok(result) => result,
             Err(error) => OperationResult::error(
-                http::StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+                500,
                 join_error_message(error),
             ),
         }
@@ -229,9 +229,10 @@ where
 }
 
 fn decode_params<In: DeserializeOwned>(operation_id: &str, raw_params: Value) -> Result<In> {
-    match serde_json::from_value::<In>(raw_params.clone()) {
+    let empty = is_empty_object(&raw_params);
+    match serde_json::from_value::<In>(raw_params) {
         Ok(input) => Ok(input),
-        Err(error) if is_empty_object(&raw_params) => serde_json::from_value::<In>(Value::Null)
+        Err(error) if empty => serde_json::from_value::<In>(Value::Null)
             .map_err(|_| {
                 Error::bad_request(format!("decode params for {:?}: {}", operation_id, error))
             }),
@@ -291,7 +292,7 @@ mod tests {
                 Request::default(),
             )
             .await;
-        assert_eq!(result.status, http::StatusCode::NOT_FOUND.as_u16());
+        assert_eq!(result.status, 404);
     }
 
     #[test]

--- a/sdk/rust/src/rpc_status.rs
+++ b/sdk/rust/src/rpc_status.rs
@@ -4,15 +4,9 @@ use crate::Error;
 
 pub(crate) fn rpc_status(operation: &str, error: Error) -> Status {
     match error.status() {
-        Some(status) if status == http::StatusCode::BAD_REQUEST.as_u16() => {
-            Status::invalid_argument(error.message().to_owned())
-        }
-        Some(status) if status == http::StatusCode::NOT_FOUND.as_u16() => {
-            Status::not_found(error.message().to_owned())
-        }
-        Some(status) if status == http::StatusCode::NOT_IMPLEMENTED.as_u16() => {
-            Status::unimplemented(error.message().to_owned())
-        }
+        Some(400) => Status::invalid_argument(error.message().to_owned()),
+        Some(404) => Status::not_found(error.message().to_owned()),
+        Some(501) => Status::unimplemented(error.message().to_owned()),
         _ => Status::unknown(format!("{operation}: {}", error.message())),
     }
 }

--- a/sdk/rust/src/runtime.rs
+++ b/sdk/rust/src/runtime.rs
@@ -34,37 +34,28 @@ use crate::{
     auth_server::AuthServer, datastore_server::DatastoreServer, runtime_server::RuntimeServer,
 };
 
-pub fn run_provider<P>(provider: Arc<P>, router: Router<P>) -> Result<()>
+fn build_runtime_and_block_on<F, Fut>(f: F) -> Result<()>
 where
-    P: Provider,
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<()>>,
 {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .map_err(|error| Error::internal(error.to_string()))?;
-    runtime.block_on(serve_provider(provider, router))
+    runtime.block_on(f())
 }
 
-pub fn run_auth_provider<P>(provider: Arc<P>) -> Result<()>
-where
-    P: AuthProvider,
-{
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| Error::internal(error.to_string()))?;
-    runtime.block_on(serve_auth_provider(provider))
+pub fn run_provider<P: Provider>(provider: Arc<P>, router: Router<P>) -> Result<()> {
+    build_runtime_and_block_on(|| serve_provider(provider, router))
 }
 
-pub fn run_datastore_provider<P>(provider: Arc<P>) -> Result<()>
-where
-    P: DatastoreProvider,
-{
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| Error::internal(error.to_string()))?;
-    runtime.block_on(serve_datastore_provider(provider))
+pub fn run_auth_provider<P: AuthProvider>(provider: Arc<P>) -> Result<()> {
+    build_runtime_and_block_on(|| serve_auth_provider(provider))
+}
+
+pub fn run_datastore_provider<P: DatastoreProvider>(provider: Arc<P>) -> Result<()> {
+    build_runtime_and_block_on(|| serve_datastore_provider(provider))
 }
 
 pub fn write_catalog_path<P>(router: &Router<P>, path: impl AsRef<Path>) -> Result<()> {
@@ -76,13 +67,13 @@ pub fn maybe_write_catalog<P>(router: &Router<P>) -> Result<bool> {
         return Ok(false);
     };
 
-    let router = if let Ok(name) = env::var(ENV_PLUGIN_NAME) {
-        (*router).clone().with_name(name)
+    let catalog = if let Ok(name) = env::var(ENV_PLUGIN_NAME) {
+        router.catalog().with_name(name)
     } else {
-        (*router).clone()
+        router.catalog()
     };
 
-    write_catalog(&router.catalog(), PathBuf::from(path))?;
+    write_catalog(&catalog, PathBuf::from(path))?;
     Ok(true)
 }
 

--- a/sdk/rust/src/runtime_server.rs
+++ b/sdk/rust/src/runtime_server.rs
@@ -11,7 +11,7 @@ use crate::generated::v1::{
     ConfigurePluginRequest, ConfigurePluginResponse, HealthCheckResponse, PluginKind,
     PluginMetadata,
 };
-use crate::runtime_types::RuntimeMetadata;
+use crate::api::RuntimeMetadata;
 use crate::{CURRENT_PROTOCOL_VERSION, Provider};
 
 #[async_trait]

--- a/sdk/rust/src/runtime_server.rs
+++ b/sdk/rust/src/runtime_server.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
 
+use crate::api::RuntimeMetadata;
 use crate::auth::AuthProvider;
 use crate::datastore::DatastoreProvider;
 use crate::error::Result;
@@ -11,7 +12,6 @@ use crate::generated::v1::{
     ConfigurePluginRequest, ConfigurePluginResponse, HealthCheckResponse, PluginKind,
     PluginMetadata,
 };
-use crate::api::RuntimeMetadata;
 use crate::{CURRENT_PROTOCOL_VERSION, Provider};
 
 #[async_trait]

--- a/sdk/rust/src/runtime_types.rs
+++ b/sdk/rust/src/runtime_types.rs
@@ -1,7 +1,0 @@
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct RuntimeMetadata {
-    pub name: String,
-    pub display_name: String,
-    pub description: String,
-    pub version: String,
-}


### PR DESCRIPTION
## Summary

- Remove the `http` 0.2 crate dependency, replacing all `StatusCode::*.as_u16()` usages with plain u16 constants or literals across error.rs, api.rs, router.rs, provider_server.rs, and rpc_status.rs
- Fix unnecessary clone in `decode_params` (check emptiness before consuming the Value) and in `maybe_write_catalog` (clone only the lightweight Catalog instead of the entire Router with handler closures)
- Inline the trivial `runtime_types.rs` module (just the `RuntimeMetadata` struct) into `api.rs`
- Deduplicate the three `run_*` functions by extracting `build_runtime_and_block_on`

## Test plan

- [x] `cargo test` passes (all 18 tests)
- [x] `cargo clippy -- -D warnings` is clean
- [x] `cargo check` succeeds for all 3 downstream test fixtures (provider-rust, provider-rust-auth, provider-rust-datastore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)