### PR TITLE
sdk/go: consolidate overlapping tests, remove trivial assertions

### DIFF
--- a/sdk/go/plugin_test.go
+++ b/sdk/go/plugin_test.go
@@ -103,56 +103,65 @@ func (p *sessionCatalogStubProvider) CatalogForRequest(_ context.Context, _ stri
 func TestProviderServerGetMetadata(t *testing.T) {
 	t.Parallel()
 
-	client := newProviderPluginClient(t, &stubProvider{}, stubRouter)
-	meta, err := client.GetMetadata(context.Background(), &emptypb.Empty{})
-	if err != nil {
-		t.Fatalf("GetMetadata: %v", err)
-	}
-	if meta.GetSupportsSessionCatalog() {
-		t.Fatal("SupportsSessionCatalog = true, want false")
-	}
-}
+	t.Run("plain provider", func(t *testing.T) {
+		client := newProviderPluginClient(t, &stubProvider{}, stubRouter)
+		meta, err := client.GetMetadata(context.Background(), &emptypb.Empty{})
+		if err != nil {
+			t.Fatalf("GetMetadata: %v", err)
+		}
+		if meta.GetSupportsSessionCatalog() {
+			t.Fatal("SupportsSessionCatalog = true, want false")
+		}
+	})
 
-func TestProviderServerGetMetadata_SessionCatalogCapability(t *testing.T) {
-	t.Parallel()
-
-	client := newProviderPluginClient(t, &sessionCatalogStubProvider{
-		sessionCatalog: &gestalt.Catalog{
-			Name: "test-provider",
-			Operations: []gestalt.CatalogOperation{
-				{ID: "session_op", Method: http.MethodGet},
+	t.Run("session catalog provider", func(t *testing.T) {
+		client := newProviderPluginClient(t, &sessionCatalogStubProvider{
+			sessionCatalog: &gestalt.Catalog{
+				Name: "test-provider",
+				Operations: []gestalt.CatalogOperation{
+					{ID: "session_op", Method: http.MethodGet},
+				},
 			},
-		},
-	}, sessionCatalogStubRouter)
-	meta, err := client.GetMetadata(context.Background(), &emptypb.Empty{})
-	if err != nil {
-		t.Fatalf("GetMetadata: %v", err)
-	}
-	if !meta.GetSupportsSessionCatalog() {
-		t.Fatal("SupportsSessionCatalog = false, want true")
-	}
+		}, sessionCatalogStubRouter)
+		meta, err := client.GetMetadata(context.Background(), &emptypb.Empty{})
+		if err != nil {
+			t.Fatalf("GetMetadata: %v", err)
+		}
+		if !meta.GetSupportsSessionCatalog() {
+			t.Fatal("SupportsSessionCatalog = false, want true")
+		}
+	})
 }
 
 func TestProviderServerGetSessionCatalog(t *testing.T) {
 	t.Parallel()
 
-	prov := &sessionCatalogStubProvider{
-		sessionCatalog: &gestalt.Catalog{
-			Name: "test-provider",
-			Operations: []gestalt.CatalogOperation{
-				{ID: "session_op", Method: http.MethodPost},
+	t.Run("supported", func(t *testing.T) {
+		prov := &sessionCatalogStubProvider{
+			sessionCatalog: &gestalt.Catalog{
+				Name: "test-provider",
+				Operations: []gestalt.CatalogOperation{
+					{ID: "session_op", Method: http.MethodPost},
+				},
 			},
-		},
-	}
+		}
+		client := newProviderPluginClient(t, prov, sessionCatalogStubRouter)
+		resp, err := client.GetSessionCatalog(context.Background(), &proto.GetSessionCatalogRequest{Token: "tok"})
+		if err != nil {
+			t.Fatalf("GetSessionCatalog: %v", err)
+		}
+		if resp.GetCatalogJson() == "" {
+			t.Fatal("expected session catalog json")
+		}
+	})
 
-	client := newProviderPluginClient(t, prov, sessionCatalogStubRouter)
-	resp, err := client.GetSessionCatalog(context.Background(), &proto.GetSessionCatalogRequest{Token: "tok"})
-	if err != nil {
-		t.Fatalf("GetSessionCatalog: %v", err)
-	}
-	if resp.GetCatalogJson() == "" {
-		t.Fatal("expected session catalog json")
-	}
+	t.Run("unsupported", func(t *testing.T) {
+		client := newProviderPluginClient(t, &stubProvider{}, stubRouter)
+		_, err := client.GetSessionCatalog(context.Background(), &proto.GetSessionCatalogRequest{Token: "t"})
+		if err == nil {
+			t.Fatal("GetSessionCatalog should return error for unsupported provider")
+		}
+	})
 }
 
 func TestProviderServerExecute(t *testing.T) {
@@ -294,19 +303,3 @@ func TestProviderServerStartProvider(t *testing.T) {
 	}
 }
 
-func TestProviderServerUnimplementedRPCs(t *testing.T) {
-	t.Parallel()
-
-	client := newProviderPluginClient(t, &stubProvider{}, stubRouter)
-	ctx := context.Background()
-
-	_, err := client.GetSessionCatalog(ctx, &proto.GetSessionCatalogRequest{Token: "t"})
-	if err == nil {
-		t.Error("GetSessionCatalog should return UNIMPLEMENTED")
-	}
-
-	_, err = client.PostConnect(ctx, &proto.PostConnectRequest{})
-	if err == nil {
-		t.Error("PostConnect should return UNIMPLEMENTED")
-	}
-}

--- a/sdk/go/plugin_transport_test.go
+++ b/sdk/go/plugin_transport_test.go
@@ -89,18 +89,22 @@ func TestServeAuthProviderClosesProviderOnShutdown(t *testing.T) {
 	}
 }
 
-type closeableStubProvider struct {
-	stubProvider
+type closeTracker struct {
 	closed atomic.Bool
 }
 
-func (p *closeableStubProvider) Close() error {
-	p.closed.Store(true)
+func (c *closeTracker) Close() error {
+	c.closed.Store(true)
 	return nil
 }
 
+type closeableStubProvider struct {
+	stubProvider
+	closeTracker
+}
+
 type closeableStubAuthProvider struct {
-	closed atomic.Bool
+	closeTracker
 }
 
 func (p *closeableStubAuthProvider) Configure(context.Context, string, map[string]any) error {
@@ -113,11 +117,6 @@ func (p *closeableStubAuthProvider) BeginLogin(context.Context, gestalt.BeginLog
 
 func (p *closeableStubAuthProvider) CompleteLogin(context.Context, gestalt.CompleteLoginRequest) (*gestalt.AuthenticatedUser, error) {
 	return &gestalt.AuthenticatedUser{Email: "user@example.com"}, nil
-}
-
-func (p *closeableStubAuthProvider) Close() error {
-	p.closed.Store(true)
-	return nil
 }
 
 func newSocketPath(t *testing.T, name string) string {


### PR DESCRIPTION
## Summary

- Merge `TestProviderServerGetMetadata` and `TestProviderServerGetMetadata_SessionCatalogCapability` into a single test with two subtests (plain provider vs session catalog provider).
- Fold the `GetSessionCatalog` error case from `TestProviderServerUnimplementedRPCs` into `TestProviderServerGetSessionCatalog` as an "unsupported" subtest, and delete the remaining `PostConnect` assertion which only tested gRPC framework behavior.
- Extract a shared `closeTracker` type in `plugin_transport_test.go` to deduplicate the identical `closed atomic.Bool` / `Close()` pattern across two stub types.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)