### PR TITLE
Deduplicate code and simplify factory abstractions

### DIFF
--- a/gestaltd/cmd/gestaltd/factories.go
+++ b/gestaltd/cmd/gestaltd/factories.go
@@ -124,8 +124,8 @@ func buildFactories() *bootstrap.FactoryRegistry {
 			return nil, nil, fmt.Errorf("unknown audit provider %q", cfg.Provider)
 		}
 	}
-	factories.Auth["plugin"] = authplugin.Factory
-	factories.Datastores["plugin"] = datastoreplugin.Factory
+	factories.Auth = authplugin.Factory
+	factories.Datastore = datastoreplugin.Factory
 	factories.Secrets["env"] = secretsenv.Factory
 	factories.Secrets["file"] = secretsfile.Factory
 	factories.Secrets["google_secret_manager"] = secretsgoogle.Factory

--- a/gestaltd/core/integration/catalog.go
+++ b/gestaltd/core/integration/catalog.go
@@ -8,6 +8,20 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 )
 
+func ConvertParameters(params []catalog.CatalogParameter) []core.Parameter {
+	out := make([]core.Parameter, 0, len(params))
+	for _, p := range params {
+		out = append(out, core.Parameter{
+			Name:        p.Name,
+			Type:        p.Type,
+			Description: p.Description,
+			Required:    p.Required,
+			Default:     p.Default,
+		})
+	}
+	return out
+}
+
 func OperationsList(c *catalog.Catalog) []core.Operation {
 	if c == nil {
 		return nil
@@ -18,16 +32,6 @@ func OperationsList(c *catalog.Catalog) []core.Operation {
 		if op.Transport == transportGraphQL && op.Query == "" {
 			continue
 		}
-		params := make([]core.Parameter, 0, len(op.Parameters))
-		for _, param := range op.Parameters {
-			params = append(params, core.Parameter{
-				Name:        param.Name,
-				Type:        param.Type,
-				Description: param.Description,
-				Required:    param.Required,
-				Default:     param.Default,
-			})
-		}
 		method := strings.ToUpper(strings.TrimSpace(op.Method))
 		if method == "" && op.Query != "" {
 			method = http.MethodPost
@@ -36,7 +40,7 @@ func OperationsList(c *catalog.Catalog) []core.Operation {
 			Name:        op.ID,
 			Description: op.Description,
 			Method:      method,
-			Parameters:  params,
+			Parameters:  ConvertParameters(op.Parameters),
 		})
 	}
 	return ops

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -151,20 +151,18 @@ type TelemetryFactory func(node yaml.Node) (core.TelemetryProvider, error)
 type AuditFactory func(ctx context.Context, cfg config.AuditConfig, telemetry core.TelemetryProvider) (core.AuditSink, func(context.Context) error, error)
 
 type FactoryRegistry struct {
-	Auth       map[string]AuthFactory
-	Datastores map[string]DatastoreFactory
-	Secrets    map[string]SecretManagerFactory
-	Telemetry  map[string]TelemetryFactory
-	Audit      AuditFactory
-	Builtins   []core.Provider
+	Auth      AuthFactory
+	Datastore DatastoreFactory
+	Secrets   map[string]SecretManagerFactory
+	Telemetry map[string]TelemetryFactory
+	Audit     AuditFactory
+	Builtins  []core.Provider
 }
 
 func NewFactoryRegistry() *FactoryRegistry {
 	return &FactoryRegistry{
-		Auth:       make(map[string]AuthFactory),
-		Datastores: make(map[string]DatastoreFactory),
-		Secrets:    make(map[string]SecretManagerFactory),
-		Telemetry:  make(map[string]TelemetryFactory),
+		Secrets:   make(map[string]SecretManagerFactory),
+		Telemetry: make(map[string]TelemetryFactory),
 	}
 }
 
@@ -655,9 +653,8 @@ func buildAuth(cfg *config.Config, factories *FactoryRegistry, deps Deps) (core.
 	if cfg.Auth.Provider == nil {
 		return nil, nil
 	}
-	factory, ok := factories.Auth["plugin"]
-	if !ok {
-		return nil, fmt.Errorf("bootstrap: auth plugin factory is not registered")
+	if factories.Auth == nil {
+		return nil, fmt.Errorf("bootstrap: auth factory is not registered")
 	}
 	node := cfg.Auth.Config
 	if !config.IsComponentRuntimeConfigNode(node) {
@@ -667,7 +664,7 @@ func buildAuth(cfg *config.Config, factories *FactoryRegistry, deps Deps) (core.
 			return nil, fmt.Errorf("bootstrap: auth plugin: %w", err)
 		}
 	}
-	auth, err := factory(node, deps)
+	auth, err := factories.Auth(node, deps)
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap: auth plugin: %w", err)
 	}
@@ -675,9 +672,8 @@ func buildAuth(cfg *config.Config, factories *FactoryRegistry, deps Deps) (core.
 }
 
 func buildDatastore(cfg *config.Config, factories *FactoryRegistry, deps Deps) (core.Datastore, error) {
-	factory, ok := factories.Datastores["plugin"]
-	if !ok {
-		return nil, fmt.Errorf("bootstrap: datastore plugin factory is not registered")
+	if factories.Datastore == nil {
+		return nil, fmt.Errorf("bootstrap: datastore factory is not registered")
 	}
 	node := cfg.Datastore.Config
 	if !config.IsComponentRuntimeConfigNode(node) {
@@ -687,7 +683,7 @@ func buildDatastore(cfg *config.Config, factories *FactoryRegistry, deps Deps) (
 			return nil, fmt.Errorf("bootstrap: datastore plugin: %w", err)
 		}
 	}
-	ds, err := factory(node, deps)
+	ds, err := factories.Datastore(node, deps)
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap: datastore plugin: %w", err)
 	}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -73,8 +73,8 @@ func validConfig() *config.Config {
 
 func validFactories() *bootstrap.FactoryRegistry {
 	f := bootstrap.NewFactoryRegistry()
-	f.Auth["plugin"] = stubAuthFactory("test-auth")
-	f.Datastores["plugin"] = stubDatastoreFactory()
+	f.Auth = stubAuthFactory("test-auth")
+	f.Datastore = stubDatastoreFactory()
 	f.Secrets["test-secrets"] = stubSecretManagerFactory()
 	f.Telemetry["test-telemetry"] = stubTelemetryFactory()
 	return f
@@ -125,7 +125,7 @@ func TestResultCloseClosesAuthProvider(t *testing.T) {
 
 	closed := &atomic.Bool{}
 	factories := validFactories()
-	factories.Auth["plugin"] = func(yaml.Node, bootstrap.Deps) (core.AuthProvider, error) {
+	factories.Auth = func(yaml.Node, bootstrap.Deps) (core.AuthProvider, error) {
 		return &closableAuthProvider{
 			StubAuthProvider: &coretesting.StubAuthProvider{N: "test-auth"},
 			closed:           closed,
@@ -204,11 +204,11 @@ func TestBootstrap_ReusesPreparedComponentRuntimeConfig(t *testing.T) {
 	var gotAuthNode yaml.Node
 	var gotDatastoreNode yaml.Node
 	factories := validFactories()
-	factories.Auth["plugin"] = func(node yaml.Node, deps bootstrap.Deps) (core.AuthProvider, error) {
+	factories.Auth = func(node yaml.Node, deps bootstrap.Deps) (core.AuthProvider, error) {
 		gotAuthNode = node
 		return &coretesting.StubAuthProvider{N: "test-auth"}, nil
 	}
-	factories.Datastores["plugin"] = func(node yaml.Node, deps bootstrap.Deps) (core.Datastore, error) {
+	factories.Datastore = func(node yaml.Node, deps bootstrap.Deps) (core.Datastore, error) {
 		gotDatastoreNode = node
 		return &coretesting.StubDatastore{}, nil
 	}
@@ -261,7 +261,7 @@ func TestBootstrapFactoryError(t *testing.T) {
 		{
 			name: "auth factory error",
 			mutate: func(f *bootstrap.FactoryRegistry) {
-				f.Auth["plugin"] = func(yaml.Node, bootstrap.Deps) (core.AuthProvider, error) {
+				f.Auth = func(yaml.Node, bootstrap.Deps) (core.AuthProvider, error) {
 					return nil, fmt.Errorf("auth broke")
 				}
 			},
@@ -269,7 +269,7 @@ func TestBootstrapFactoryError(t *testing.T) {
 		{
 			name: "datastore factory error",
 			mutate: func(f *bootstrap.FactoryRegistry) {
-				f.Datastores["plugin"] = func(yaml.Node, bootstrap.Deps) (core.Datastore, error) {
+				f.Datastore = func(yaml.Node, bootstrap.Deps) (core.Datastore, error) {
 					return nil, fmt.Errorf("datastore broke")
 				}
 			},
@@ -298,7 +298,7 @@ func TestBootstrapEncryptionKeyDerivation(t *testing.T) {
 
 		var receivedKey []byte
 		factories := validFactories()
-		factories.Auth["plugin"] = func(_ yaml.Node, deps bootstrap.Deps) (core.AuthProvider, error) {
+		factories.Auth = func(_ yaml.Node, deps bootstrap.Deps) (core.AuthProvider, error) {
 			receivedKey = deps.EncryptionKey
 			return &coretesting.StubAuthProvider{N: "test-auth"}, nil
 		}
@@ -327,7 +327,7 @@ func TestBootstrapEncryptionKeyDerivation(t *testing.T) {
 
 		var receivedKey []byte
 		factories := validFactories()
-		factories.Auth["plugin"] = func(_ yaml.Node, deps bootstrap.Deps) (core.AuthProvider, error) {
+		factories.Auth = func(_ yaml.Node, deps bootstrap.Deps) (core.AuthProvider, error) {
 			receivedKey = deps.EncryptionKey
 			return &coretesting.StubAuthProvider{N: "test-auth"}, nil
 		}
@@ -351,7 +351,7 @@ func TestBootstrapEncryptionKeyDerivation(t *testing.T) {
 		var keys [][]byte
 		for i := 0; i < 2; i++ {
 			factories := validFactories()
-			factories.Auth["plugin"] = func(_ yaml.Node, deps bootstrap.Deps) (core.AuthProvider, error) {
+			factories.Auth = func(_ yaml.Node, deps bootstrap.Deps) (core.AuthProvider, error) {
 				keys = append(keys, deps.EncryptionKey)
 				return &coretesting.StubAuthProvider{N: "test-auth"}, nil
 			}
@@ -383,7 +383,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 				Secrets: map[string]string{"enc-key": "resolved-passphrase"},
 			}, nil
 		}
-		factories.Auth["plugin"] = func(_ yaml.Node, deps bootstrap.Deps) (core.AuthProvider, error) {
+		factories.Auth = func(_ yaml.Node, deps bootstrap.Deps) (core.AuthProvider, error) {
 			receivedKey = deps.EncryptionKey
 			return &coretesting.StubAuthProvider{N: "test-auth"}, nil
 		}
@@ -465,7 +465,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 
 		var receivedNode yaml.Node
-		factories.Auth["plugin"] = func(node yaml.Node, _ bootstrap.Deps) (core.AuthProvider, error) {
+		factories.Auth = func(node yaml.Node, _ bootstrap.Deps) (core.AuthProvider, error) {
 			receivedNode = node
 			return &coretesting.StubAuthProvider{N: "test-auth"}, nil
 		}
@@ -523,11 +523,11 @@ func TestBootstrapSecretResolution(t *testing.T) {
 
 		var authNode, datastoreNode yaml.Node
 		factories := validFactories()
-		factories.Auth["plugin"] = func(node yaml.Node, _ bootstrap.Deps) (core.AuthProvider, error) {
+		factories.Auth = func(node yaml.Node, _ bootstrap.Deps) (core.AuthProvider, error) {
 			authNode = node
 			return &coretesting.StubAuthProvider{N: "test-auth"}, nil
 		}
-		factories.Datastores["plugin"] = func(node yaml.Node, _ bootstrap.Deps) (core.Datastore, error) {
+		factories.Datastore = func(node yaml.Node, _ bootstrap.Deps) (core.Datastore, error) {
 			datastoreNode = node
 			return &coretesting.StubDatastore{}, nil
 		}
@@ -575,7 +575,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 
 		var authFactoryCalled atomic.Bool
 		factories := validFactories()
-		factories.Auth["plugin"] = func(yaml.Node, bootstrap.Deps) (core.AuthProvider, error) {
+		factories.Auth = func(yaml.Node, bootstrap.Deps) (core.AuthProvider, error) {
 			authFactoryCalled.Store(true)
 			return &coretesting.StubAuthProvider{N: "unexpected"}, nil
 		}

--- a/gestaltd/internal/bootstrap/egress.go
+++ b/gestaltd/internal/bootstrap/egress.go
@@ -42,7 +42,7 @@ func newEgressDeps(cfg *config.Config, sm core.SecretManager) EgressDeps {
 			Loaders: []egress.CredentialGrantLoader{
 				&egress.StaticCredentialGrantLoader{Grants: grants},
 			},
-			SecretResolver: sm,
+			Secrets: sm,
 		}
 	}
 

--- a/gestaltd/internal/egress/credential_grant_resolver.go
+++ b/gestaltd/internal/egress/credential_grant_resolver.go
@@ -27,8 +27,8 @@ func (l *StaticCredentialGrantLoader) LoadCredentialGrants(_ context.Context) ([
 // finding the first matching grant, and materializing it via secret lookup.
 // Loaders are evaluated in order; within each loader the first matching grant wins.
 type CredentialGrantResolver struct {
-	Loaders  []CredentialGrantLoader
-	Secrets  core.SecretManager
+	Loaders []CredentialGrantLoader
+	Secrets core.SecretManager
 }
 
 func (r *CredentialGrantResolver) ResolveCredential(ctx context.Context, subject Subject, target Target) (CredentialMaterialization, error) {

--- a/gestaltd/internal/egress/credential_grant_resolver.go
+++ b/gestaltd/internal/egress/credential_grant_resolver.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
 )
 
 // CredentialGrantLoader loads credential grants for resolution. Implementations
@@ -25,8 +27,8 @@ func (l *StaticCredentialGrantLoader) LoadCredentialGrants(_ context.Context) ([
 // finding the first matching grant, and materializing it via secret lookup.
 // Loaders are evaluated in order; within each loader the first matching grant wins.
 type CredentialGrantResolver struct {
-	Loaders        []CredentialGrantLoader
-	SecretResolver SecretResolver
+	Loaders  []CredentialGrantLoader
+	Secrets  core.SecretManager
 }
 
 func (r *CredentialGrantResolver) ResolveCredential(ctx context.Context, subject Subject, target Target) (CredentialMaterialization, error) {
@@ -41,7 +43,7 @@ func (r *CredentialGrantResolver) ResolveCredential(ctx context.Context, subject
 			continue
 		}
 
-		mat, err := resolveSecretGrant(ctx, r.SecretResolver, grant)
+		mat, err := resolveSecretGrant(ctx, r.Secrets, grant)
 		if err != nil {
 			return CredentialMaterialization{}, err
 		}
@@ -65,7 +67,7 @@ func firstMatchingGrant(grants []CredentialGrant, subject Subject, target Target
 	return nil, false
 }
 
-func resolveSecretGrant(ctx context.Context, sr SecretResolver, grant *CredentialGrant) (CredentialMaterialization, error) {
+func resolveSecretGrant(ctx context.Context, sr core.SecretManager, grant *CredentialGrant) (CredentialMaterialization, error) {
 	if sr == nil {
 		return CredentialMaterialization{}, fmt.Errorf("egress credentials: no secret resolver configured")
 	}

--- a/gestaltd/internal/egress/credential_grant_resolver_test.go
+++ b/gestaltd/internal/egress/credential_grant_resolver_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 )
 
-type stubSecretResolver struct {
+type stubSecretManager struct {
 	secrets map[string]string
 	lookups []string
 }
 
-func (s *stubSecretResolver) GetSecret(_ context.Context, name string) (string, error) {
+func (s *stubSecretManager) GetSecret(_ context.Context, name string) (string, error) {
 	s.lookups = append(s.lookups, name)
 	return s.secrets[name], nil
 }
@@ -20,7 +20,7 @@ func (s *stubSecretResolver) GetSecret(_ context.Context, name string) (string, 
 func TestCredentialGrantResolver_ConfigGrant(t *testing.T) {
 	t.Parallel()
 
-	secrets := &stubSecretResolver{
+	secrets := &stubSecretManager{
 		secrets: map[string]string{"vendor-api-key": "sk-test-secret-abc123"},
 	}
 	resolver := &CredentialGrantResolver{
@@ -37,7 +37,7 @@ func TestCredentialGrantResolver_ConfigGrant(t *testing.T) {
 				},
 			},
 		},
-		SecretResolver: secrets,
+		Secrets: secrets,
 	}
 
 	materialized, err := resolver.ResolveCredential(context.Background(),
@@ -60,7 +60,7 @@ func TestCredentialGrantResolver_ConfigGrant(t *testing.T) {
 func TestCredentialGrantResolver_MultiTenantHostMatching(t *testing.T) {
 	t.Parallel()
 
-	secrets := &stubSecretResolver{
+	secrets := &stubSecretManager{
 		secrets: map[string]string{
 			"shop-1-key": "sk-shop-one",
 			"shop-2-key": "sk-shop-two",
@@ -87,7 +87,7 @@ func TestCredentialGrantResolver_MultiTenantHostMatching(t *testing.T) {
 				},
 			},
 		},
-		SecretResolver: secrets,
+		Secrets: secrets,
 	}
 
 	resolve := func(host string) string {
@@ -113,7 +113,7 @@ func TestCredentialGrantResolver_MultiTenantHostMatching(t *testing.T) {
 func TestCredentialGrantResolver_RejectsSecretURIPrefix(t *testing.T) {
 	t.Parallel()
 
-	secrets := &stubSecretResolver{
+	secrets := &stubSecretManager{
 		secrets: map[string]string{"prefixed-key": "sk-with-prefix"},
 	}
 	resolver := &CredentialGrantResolver{
@@ -130,7 +130,7 @@ func TestCredentialGrantResolver_RejectsSecretURIPrefix(t *testing.T) {
 				},
 			},
 		},
-		SecretResolver: secrets,
+		Secrets: secrets,
 	}
 
 	materialized, err := resolver.ResolveCredential(context.Background(),

--- a/gestaltd/internal/egress/provider_credentials.go
+++ b/gestaltd/internal/egress/provider_credentials.go
@@ -6,10 +6,6 @@ type CredentialResolver interface {
 	ResolveCredential(ctx context.Context, subject Subject, target Target) (CredentialMaterialization, error)
 }
 
-type SecretResolver interface {
-	GetSecret(ctx context.Context, name string) (string, error)
-}
-
 type CredentialGrant struct {
 	SecretRef string
 	AuthStyle AuthStyle

--- a/gestaltd/internal/invocation/capabilities.go
+++ b/gestaltd/internal/invocation/capabilities.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/core/integration"
 )
 
 func capabilitiesForProvider(name string, prov core.Provider) []core.Capability {
@@ -23,17 +24,6 @@ func capabilitiesFromCatalog(name string, cat *catalog.Catalog) []core.Capabilit
 			continue
 		}
 
-		params := make([]core.Parameter, 0, len(op.Parameters))
-		for _, p := range op.Parameters {
-			params = append(params, core.Parameter{
-				Name:        p.Name,
-				Type:        p.Type,
-				Description: p.Description,
-				Required:    p.Required,
-				Default:     p.Default,
-			})
-		}
-
 		method := strings.ToUpper(strings.TrimSpace(op.Method))
 		transport := strings.TrimSpace(op.Transport)
 		if transport == "" && method != "" {
@@ -45,7 +35,7 @@ func capabilitiesFromCatalog(name string, cat *catalog.Catalog) []core.Capabilit
 			Operation:   op.ID,
 			Title:       op.Title,
 			Description: op.Description,
-			Parameters:  params,
+			Parameters:  integration.ConvertParameters(op.Parameters),
 			InputSchema: bytes.Clone(op.InputSchema),
 			Method:      method,
 			Transport:   transport,


### PR DESCRIPTION
## Summary

- Extract shared `ConvertParameters` function to eliminate the duplicated `CatalogParameter`-to-`Parameter` conversion loop in `OperationsList` and `capabilitiesFromCatalog`
- Remove `egress.SecretResolver` interface (identical to `core.SecretManager`) and replace all usages with `core.SecretManager` directly
- Simplify `FactoryRegistry` by changing `Auth` and `Datastores` from `map[string]` to scalar fields, since both only ever held a single `"plugin"` entry

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all existing tests updated and green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)