### PR TITLE
Consolidate duplicated test helpers and merge overlapping tests

### DIFF
--- a/gestaltd/cmd/gestaltd/run_metrics_test.go
+++ b/gestaltd/cmd/gestaltd/run_metrics_test.go
@@ -2,108 +2,27 @@ package main
 
 import (
 	"context"
-	"sync"
 	"testing"
 
-	"github.com/valon-technologies/gestalt/server/core"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 )
-
-var cmdMeterProviderTestMu sync.Mutex
-
-func useManualMeterProvider(t *testing.T) *sdkmetric.ManualReader {
-	t.Helper()
-
-	cmdMeterProviderTestMu.Lock()
-	prev := otel.GetMeterProvider()
-	reader := sdkmetric.NewManualReader()
-	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
-	otel.SetMeterProvider(provider)
-	t.Cleanup(func() {
-		_ = provider.Shutdown(context.Background())
-		otel.SetMeterProvider(prev)
-		cmdMeterProviderTestMu.Unlock()
-	})
-	return reader
-}
-
-func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
-	t.Helper()
-
-	var rm metricdata.ResourceMetrics
-	if err := reader.Collect(context.Background(), &rm); err != nil {
-		t.Fatalf("collect metrics: %v", err)
-	}
-	return rm
-}
-
-func requireInt64Sum(t *testing.T, rm metricdata.ResourceMetrics, name string, want int64, attrs map[string]string) {
-	t.Helper()
-
-	for _, scope := range rm.ScopeMetrics {
-		for _, metric := range scope.Metrics {
-			if metric.Name != name {
-				continue
-			}
-			sum, ok := metric.Data.(metricdata.Sum[int64])
-			if !ok {
-				t.Fatalf("metric %q is %T, want Sum[int64]", name, metric.Data)
-			}
-			for _, point := range sum.DataPoints {
-				if attrsMatch(point.Attributes, attrs) {
-					if point.Value != want {
-						t.Fatalf("metric %q attrs %v = %d, want %d", name, attrs, point.Value, want)
-					}
-					return
-				}
-			}
-		}
-	}
-
-	t.Fatalf("metric %q with attrs %v not found", name, attrs)
-}
-
-func attrsMatch(set attribute.Set, want map[string]string) bool {
-	for key, expected := range want {
-		value, ok := set.Value(attribute.Key(key))
-		if !ok || value.AsString() != expected {
-			return false
-		}
-	}
-	return true
-}
-
-type namedStubDatastore struct {
-	coretesting.StubDatastore
-	name string
-}
-
-func (s *namedStubDatastore) Name() string { return s.name }
 
 func TestDatastoreReadinessEmitsPingMetric(t *testing.T) {
 	t.Parallel()
 
-	reader := useManualMeterProvider(t)
-	check := datastoreReadiness(&namedStubDatastore{
-		name: "ready-store",
-		StubDatastore: coretesting.StubDatastore{
-			PingFn: func(context.Context) error { return nil },
-		},
-	})
+	reader := metrictest.UseManualMeterProvider(t)
+	check := datastoreReadiness(metrictest.NewNamedStubDatastore("ready-store", coretesting.StubDatastore{
+		PingFn: func(context.Context) error { return nil },
+	}))
 
 	if got := check(); got != "" {
 		t.Fatalf("readiness = %q, want ready", got)
 	}
 
-	rm := collectMetrics(t, reader)
-	requireInt64Sum(t, rm, "gestaltd.datastore.count", 1, map[string]string{
+	rm := metrictest.CollectMetrics(t, reader)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.datastore.count", 1, map[string]string{
 		"gestalt.provider": "ready-store",
 		"gestalt.method":   "ping",
 	})
 }
-
-var _ core.Datastore = (*namedStubDatastore)(nil)

--- a/gestaltd/core/integration/catalog_test.go
+++ b/gestaltd/core/integration/catalog_test.go
@@ -8,44 +8,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 )
 
-func TestCompileSchemasFillsInputSchema(t *testing.T) {
-	t.Parallel()
-
-	cat := &catalog.Catalog{
-		Name: "test",
-		Operations: []catalog.CatalogOperation{
-			{
-				ID:     "op1",
-				Method: http.MethodGet,
-				Path:   "/test",
-				Parameters: []catalog.CatalogParameter{
-					{Name: "q", Type: "string", Description: "Query", Required: true},
-					{Name: "limit", Type: "integer", Default: 50},
-				},
-			},
-		},
-	}
-
-	CompileSchemas(cat)
-
-	op := cat.Operations[0]
-	if op.InputSchema == nil {
-		t.Fatal("CompileSchemas should synthesize InputSchema from Parameters")
-	}
-
-	var schema map[string]any
-	if err := json.Unmarshal(op.InputSchema, &schema); err != nil {
-		t.Fatalf("unmarshal InputSchema: %v", err)
-	}
-	if schema["type"] != "object" {
-		t.Errorf("schema type = %v", schema["type"])
-	}
-	props := schema["properties"].(map[string]any)
-	if len(props) != 2 {
-		t.Errorf("got %d properties, want 2", len(props))
-	}
-}
-
 func TestCompileSchemasPreservesExistingInputSchema(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/core/integration/restricted_test.go
+++ b/gestaltd/core/integration/restricted_test.go
@@ -54,8 +54,26 @@ func TestCatalogFilters(t *testing.T) {
 	}
 
 	r := coreintegration.NewRestricted(inner, map[string]string{"list_channels": "", "send_message": ""})
-	ops := coreintegration.OperationsList(r.Catalog())
 
+	cat := r.Catalog()
+	if cat == nil {
+		t.Fatal("Catalog() returned nil")
+	}
+	if len(cat.Operations) != 2 {
+		t.Fatalf("Catalog().Operations: got %d, want 2", len(cat.Operations))
+	}
+	catIDs := make(map[string]bool, len(cat.Operations))
+	for _, op := range cat.Operations {
+		catIDs[op.ID] = true
+	}
+	if !catIDs["list_channels"] {
+		t.Error("expected list_channels in Catalog().Operations")
+	}
+	if !catIDs["send_message"] {
+		t.Error("expected send_message in Catalog().Operations")
+	}
+
+	ops := coreintegration.OperationsList(cat)
 	if len(ops) != 2 {
 		t.Fatalf("OperationsList: got %d ops, want 2", len(ops))
 	}
@@ -259,56 +277,6 @@ func (s *stubOAuth) RefreshToken(ctx context.Context, refreshToken string) (*cor
 		return s.refreshTokenFn(ctx, refreshToken)
 	}
 	return nil, nil
-}
-
-func TestCatalogFiltersOperations(t *testing.T) {
-	t.Parallel()
-
-	inner := &stubCatalogProvider{
-		stubWithOps: stubWithOps{
-			StubIntegration: coretesting.StubIntegration{N: "test_provider"},
-			ops: []core.Operation{
-				{Name: "op_alpha"},
-				{Name: "op_beta"},
-				{Name: "op_gamma"},
-			},
-		},
-		cat: &catalog.Catalog{
-			Name: "test_provider",
-			Operations: []catalog.CatalogOperation{
-				{ID: "op_alpha", Title: "Alpha"},
-				{ID: "op_beta", Title: "Beta"},
-				{ID: "op_gamma", Title: "Gamma"},
-			},
-		},
-	}
-
-	r := coreintegration.NewRestricted(inner, map[string]string{
-		"op_alpha": "",
-		"op_gamma": "",
-	})
-
-	cat := r.Catalog()
-	if cat == nil {
-		t.Fatal("Catalog() returned nil")
-	}
-	if len(cat.Operations) != 2 {
-		t.Fatalf("Catalog().Operations: got %d, want 2", len(cat.Operations))
-	}
-
-	ids := make(map[string]bool, len(cat.Operations))
-	for _, op := range cat.Operations {
-		ids[op.ID] = true
-	}
-	if !ids["op_alpha"] {
-		t.Error("expected op_alpha in catalog")
-	}
-	if !ids["op_gamma"] {
-		t.Error("expected op_gamma in catalog")
-	}
-	if ids["op_beta"] {
-		t.Error("op_beta should not appear in filtered catalog")
-	}
 }
 
 func TestCatalogRenamesAliasedOperations(t *testing.T) {

--- a/gestaltd/internal/metricutil/datastore_test.go
+++ b/gestaltd/internal/metricutil/datastore_test.go
@@ -3,151 +3,29 @@ package metricutil_test
 import (
 	"context"
 	"errors"
-	"sync"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 )
-
-var datastoreMeterProviderTestMu sync.Mutex
-
-func useManualMeterProvider(t *testing.T) *sdkmetric.ManualReader {
-	t.Helper()
-
-	datastoreMeterProviderTestMu.Lock()
-	prev := otel.GetMeterProvider()
-	reader := sdkmetric.NewManualReader()
-	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
-	otel.SetMeterProvider(provider)
-	t.Cleanup(func() {
-		_ = provider.Shutdown(context.Background())
-		otel.SetMeterProvider(prev)
-		datastoreMeterProviderTestMu.Unlock()
-	})
-	return reader
-}
-
-func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
-	t.Helper()
-
-	var rm metricdata.ResourceMetrics
-	if err := reader.Collect(context.Background(), &rm); err != nil {
-		t.Fatalf("collect metrics: %v", err)
-	}
-	return rm
-}
-
-func requireInt64Sum(t *testing.T, rm metricdata.ResourceMetrics, name string, want int64, attrs map[string]string) {
-	t.Helper()
-
-	for _, scope := range rm.ScopeMetrics {
-		for _, metric := range scope.Metrics {
-			if metric.Name != name {
-				continue
-			}
-			sum, ok := metric.Data.(metricdata.Sum[int64])
-			if !ok {
-				t.Fatalf("metric %q is %T, want Sum[int64]", name, metric.Data)
-			}
-			for _, point := range sum.DataPoints {
-				if attrsMatch(point.Attributes, attrs) {
-					if point.Value != want {
-						t.Fatalf("metric %q attrs %v = %d, want %d", name, attrs, point.Value, want)
-					}
-					return
-				}
-			}
-		}
-	}
-
-	t.Fatalf("metric %q with attrs %v not found", name, attrs)
-}
-
-func requireNoInt64Sum(t *testing.T, rm metricdata.ResourceMetrics, name string, attrs map[string]string) {
-	t.Helper()
-
-	for _, scope := range rm.ScopeMetrics {
-		for _, metric := range scope.Metrics {
-			if metric.Name != name {
-				continue
-			}
-			sum, ok := metric.Data.(metricdata.Sum[int64])
-			if !ok {
-				t.Fatalf("metric %q is %T, want Sum[int64]", name, metric.Data)
-			}
-			for _, point := range sum.DataPoints {
-				if attrsMatch(point.Attributes, attrs) {
-					t.Fatalf("metric %q with attrs %v unexpectedly found", name, attrs)
-				}
-			}
-		}
-	}
-}
-
-func requireFloat64Histogram(t *testing.T, rm metricdata.ResourceMetrics, name string, attrs map[string]string) {
-	t.Helper()
-
-	for _, scope := range rm.ScopeMetrics {
-		for _, metric := range scope.Metrics {
-			if metric.Name != name {
-				continue
-			}
-			histogram, ok := metric.Data.(metricdata.Histogram[float64])
-			if !ok {
-				t.Fatalf("metric %q is %T, want Histogram[float64]", name, metric.Data)
-			}
-			for _, point := range histogram.DataPoints {
-				if attrsMatch(point.Attributes, attrs) {
-					return
-				}
-			}
-		}
-	}
-
-	t.Fatalf("metric %q with attrs %v not found", name, attrs)
-}
-
-func attrsMatch(set attribute.Set, want map[string]string) bool {
-	for key, expected := range want {
-		value, ok := set.Value(attribute.Key(key))
-		if !ok || value.AsString() != expected {
-			return false
-		}
-	}
-	return true
-}
-
-type namedStubDatastore struct {
-	coretesting.StubDatastore
-	name string
-}
-
-func (s *namedStubDatastore) Name() string { return s.name }
 
 func TestWrapDatastoreEmitsMethodMetrics(t *testing.T) {
 	t.Parallel()
 
-	reader := useManualMeterProvider(t)
-	store := metricutil.WrapDatastore(&namedStubDatastore{
-		name: "wrapped-store",
-		StubDatastore: coretesting.StubDatastore{
-			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
-				return &core.User{ID: "u1", Email: email}, nil
-			},
-			GetUserFn: func(context.Context, string) (*core.User, error) {
-				return nil, errors.New("boom")
-			},
-			TokenFn: func(context.Context, string, string, string, string) (*core.IntegrationToken, error) {
-				return nil, core.ErrNotFound
-			},
+	reader := metrictest.UseManualMeterProvider(t)
+	store := metricutil.WrapDatastore(metrictest.NewNamedStubDatastore("wrapped-store", coretesting.StubDatastore{
+		FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+			return &core.User{ID: "u1", Email: email}, nil
 		},
-	})
+		GetUserFn: func(context.Context, string) (*core.User, error) {
+			return nil, errors.New("boom")
+		},
+		TokenFn: func(context.Context, string, string, string, string) (*core.IntegrationToken, error) {
+			return nil, core.ErrNotFound
+		},
+	}))
 
 	if _, err := store.FindOrCreateUser(context.Background(), "metrics@example.com"); err != nil {
 		t.Fatalf("FindOrCreateUser: %v", err)
@@ -159,28 +37,28 @@ func TestWrapDatastoreEmitsMethodMetrics(t *testing.T) {
 		t.Fatalf("Token: got %v, want ErrNotFound", err)
 	}
 
-	rm := collectMetrics(t, reader)
-	requireInt64Sum(t, rm, "gestaltd.datastore.count", 1, map[string]string{
+	rm := metrictest.CollectMetrics(t, reader)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.datastore.count", 1, map[string]string{
 		"gestalt.provider": "wrapped-store",
 		"gestalt.method":   "find_or_create_user",
 	})
-	requireInt64Sum(t, rm, "gestaltd.datastore.count", 1, map[string]string{
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.datastore.count", 1, map[string]string{
 		"gestalt.provider": "wrapped-store",
 		"gestalt.method":   "get_user",
 	})
-	requireInt64Sum(t, rm, "gestaltd.datastore.error_count", 1, map[string]string{
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.datastore.error_count", 1, map[string]string{
 		"gestalt.provider": "wrapped-store",
 		"gestalt.method":   "get_user",
 	})
-	requireInt64Sum(t, rm, "gestaltd.datastore.count", 1, map[string]string{
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.datastore.count", 1, map[string]string{
 		"gestalt.provider": "wrapped-store",
 		"gestalt.method":   "token",
 	})
-	requireNoInt64Sum(t, rm, "gestaltd.datastore.error_count", map[string]string{
+	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.datastore.error_count", map[string]string{
 		"gestalt.provider": "wrapped-store",
 		"gestalt.method":   "token",
 	})
-	requireFloat64Histogram(t, rm, "gestaltd.datastore.duration", map[string]string{
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.datastore.duration", map[string]string{
 		"gestalt.provider": "wrapped-store",
 		"gestalt.method":   "find_or_create_user",
 	})

--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
-	"sync"
 	"testing"
 	"time"
 
@@ -18,113 +17,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 )
-
-var meterProviderTestMu sync.Mutex
-
-func useManualMeterProvider(t *testing.T) *sdkmetric.ManualReader {
-	t.Helper()
-
-	meterProviderTestMu.Lock()
-	prev := otel.GetMeterProvider()
-	reader := sdkmetric.NewManualReader()
-	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
-	otel.SetMeterProvider(provider)
-	t.Cleanup(func() {
-		_ = provider.Shutdown(context.Background())
-		otel.SetMeterProvider(prev)
-		meterProviderTestMu.Unlock()
-	})
-	return reader
-}
-
-func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
-	t.Helper()
-
-	var rm metricdata.ResourceMetrics
-	if err := reader.Collect(context.Background(), &rm); err != nil {
-		t.Fatalf("collect metrics: %v", err)
-	}
-	return rm
-}
-
-func requireInt64Sum(t *testing.T, rm metricdata.ResourceMetrics, name string, want int64, attrs map[string]string) {
-	t.Helper()
-
-	for _, scope := range rm.ScopeMetrics {
-		for _, metric := range scope.Metrics {
-			if metric.Name != name {
-				continue
-			}
-			sum, ok := metric.Data.(metricdata.Sum[int64])
-			if !ok {
-				t.Fatalf("metric %q is %T, want Sum[int64]", name, metric.Data)
-			}
-			for _, point := range sum.DataPoints {
-				if attrsMatch(point.Attributes, attrs) {
-					if point.Value != want {
-						t.Fatalf("metric %q attrs %v = %d, want %d", name, attrs, point.Value, want)
-					}
-					return
-				}
-			}
-		}
-	}
-
-	t.Fatalf("metric %q with attrs %v not found", name, attrs)
-}
-
-func requireFloat64Histogram(t *testing.T, rm metricdata.ResourceMetrics, name string, attrs map[string]string) {
-	t.Helper()
-
-	for _, scope := range rm.ScopeMetrics {
-		for _, metric := range scope.Metrics {
-			if metric.Name != name {
-				continue
-			}
-			histogram, ok := metric.Data.(metricdata.Histogram[float64])
-			if !ok {
-				t.Fatalf("metric %q is %T, want Histogram[float64]", name, metric.Data)
-			}
-			for _, point := range histogram.DataPoints {
-				if attrsMatch(point.Attributes, attrs) {
-					return
-				}
-			}
-		}
-	}
-
-	t.Fatalf("metric %q with attrs %v not found", name, attrs)
-}
-
-func attrsMatch(set attribute.Set, want map[string]string) bool {
-	for key, expected := range want {
-		value, ok := set.Value(attribute.Key(key))
-		if !ok || value.AsString() != expected {
-			return false
-		}
-	}
-	return true
-}
-
-type namedStubDatastore struct {
-	coretesting.StubDatastore
-	name            string
-	listAPITokensFn func(context.Context, string) ([]*core.APIToken, error)
-}
-
-func (s *namedStubDatastore) Name() string { return s.name }
-
-func (s *namedStubDatastore) ListAPITokens(ctx context.Context, userID string) ([]*core.APIToken, error) {
-	if s.listAPITokensFn != nil {
-		return s.listAPITokensFn(ctx, userID)
-	}
-	return s.StubDatastore.ListAPITokens(ctx, userID)
-}
 
 type manualMetricsProvider struct {
 	name string
@@ -175,7 +69,7 @@ func (s *metricsHostIssuedSessionAuth) SessionTokenTTL() time.Duration {
 func TestConnectionAuthMetrics(t *testing.T) {
 	t.Parallel()
 
-	reader := useManualMeterProvider(t)
+	reader := metrictest.UseManualMeterProvider(t)
 	const providerName = "metrics-slack"
 
 	handler := &testOAuthHandler{
@@ -243,26 +137,26 @@ func TestConnectionAuthMetrics(t *testing.T) {
 		t.Fatalf("failed oauth callback status = %d, want %d", status, http.StatusBadGateway)
 	}
 
-	rm := collectMetrics(t, reader)
-	requireInt64Sum(t, rm, "gestaltd.connection.auth.count", 2, map[string]string{
+	rm := metrictest.CollectMetrics(t, reader)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.connection.auth.count", 2, map[string]string{
 		"gestalt.provider":        providerName,
 		"gestalt.type":            "oauth",
 		"gestalt.action":          "start",
 		"gestalt.connection_mode": "user",
 	})
-	requireInt64Sum(t, rm, "gestaltd.connection.auth.count", 2, map[string]string{
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.connection.auth.count", 2, map[string]string{
 		"gestalt.provider":        providerName,
 		"gestalt.type":            "oauth",
 		"gestalt.action":          "complete",
 		"gestalt.connection_mode": "user",
 	})
-	requireInt64Sum(t, rm, "gestaltd.connection.auth.error_count", 1, map[string]string{
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.connection.auth.error_count", 1, map[string]string{
 		"gestalt.provider":        providerName,
 		"gestalt.type":            "oauth",
 		"gestalt.action":          "complete",
 		"gestalt.connection_mode": "user",
 	})
-	requireFloat64Histogram(t, rm, "gestaltd.connection.auth.duration", map[string]string{
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.connection.auth.duration", map[string]string{
 		"gestalt.provider": providerName,
 		"gestalt.type":     "oauth",
 		"gestalt.action":   "complete",
@@ -272,7 +166,7 @@ func TestConnectionAuthMetrics(t *testing.T) {
 func TestRefreshAndOperationResultMetrics(t *testing.T) {
 	t.Parallel()
 
-	reader := useManualMeterProvider(t)
+	reader := metrictest.UseManualMeterProvider(t)
 	const providerName = "metrics-fake"
 
 	successStub := &stubOAuthIntegration{
@@ -370,31 +264,31 @@ func TestRefreshAndOperationResultMetrics(t *testing.T) {
 		t.Fatalf("refresh error status = %d, want %d", errorResp.StatusCode, http.StatusBadGateway)
 	}
 
-	rm := collectMetrics(t, reader)
-	requireInt64Sum(t, rm, "gestaltd.connection.auth.count", 2, map[string]string{
+	rm := metrictest.CollectMetrics(t, reader)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.connection.auth.count", 2, map[string]string{
 		"gestalt.provider":        providerName,
 		"gestalt.type":            "oauth",
 		"gestalt.action":          "refresh",
 		"gestalt.connection_mode": "user",
 	})
-	requireInt64Sum(t, rm, "gestaltd.connection.auth.error_count", 1, map[string]string{
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.connection.auth.error_count", 1, map[string]string{
 		"gestalt.provider":        providerName,
 		"gestalt.type":            "oauth",
 		"gestalt.action":          "refresh",
 		"gestalt.connection_mode": "user",
 	})
-	requireFloat64Histogram(t, rm, "gestaltd.connection.auth.duration", map[string]string{
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.connection.auth.duration", map[string]string{
 		"gestalt.provider": providerName,
 		"gestalt.type":     "oauth",
 		"gestalt.action":   "refresh",
 	})
-	requireInt64Sum(t, rm, "gestaltd.operation.count", 2, map[string]string{
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.operation.count", 2, map[string]string{
 		"gestalt.provider":        providerName,
 		"gestalt.operation":       "list",
 		"gestalt.transport":       "rest",
 		"gestalt.connection_mode": "user",
 	})
-	requireInt64Sum(t, rm, "gestaltd.operation.error_count", 1, map[string]string{
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.operation.error_count", 1, map[string]string{
 		"gestalt.provider":        providerName,
 		"gestalt.operation":       "list",
 		"gestalt.transport":       "rest",
@@ -405,23 +299,20 @@ func TestRefreshAndOperationResultMetrics(t *testing.T) {
 func TestManualConnectionMetrics(t *testing.T) {
 	t.Parallel()
 
-	reader := useManualMeterProvider(t)
+	reader := metrictest.UseManualMeterProvider(t)
 	const providerName = "manual-metrics"
 
-	ds := &namedStubDatastore{
-		name: "metrics-store",
-		StubDatastore: coretesting.StubDatastore{
-			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
-				return &core.User{ID: "u1", Email: email}, nil
-			},
-			StoreTokenFn: func(_ context.Context, token *core.IntegrationToken) error {
-				if token.AccessToken != `{"api_key":"secret"}` {
-					t.Fatalf("unexpected stored credential %q", token.AccessToken)
-				}
-				return nil
-			},
+	ds := metrictest.NewNamedStubDatastore("metrics-store", coretesting.StubDatastore{
+		FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+			return &core.User{ID: "u1", Email: email}, nil
 		},
-	}
+		StoreTokenFn: func(_ context.Context, token *core.IntegrationToken) error {
+			if token.AccessToken != `{"api_key":"secret"}` {
+				t.Fatalf("unexpected stored credential %q", token.AccessToken)
+			}
+			return nil
+		},
+	})
 
 	srv := newTestServer(t, func(cfg *server.Config) {
 		cfg.Datastore = ds
@@ -442,18 +333,18 @@ func TestManualConnectionMetrics(t *testing.T) {
 		t.Fatalf("manual connect status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 
-	rm := collectMetrics(t, reader)
-	requireInt64Sum(t, rm, "gestaltd.connection.auth.count", 1, map[string]string{
+	rm := metrictest.CollectMetrics(t, reader)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.connection.auth.count", 1, map[string]string{
 		"gestalt.provider":        providerName,
 		"gestalt.type":            "manual",
 		"gestalt.action":          "complete",
 		"gestalt.connection_mode": "user",
 	})
-	requireInt64Sum(t, rm, "gestaltd.datastore.count", 1, map[string]string{
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.datastore.count", 1, map[string]string{
 		"gestalt.provider": "metrics-store",
 		"gestalt.method":   "store_token",
 	})
-	requireFloat64Histogram(t, rm, "gestaltd.datastore.duration", map[string]string{
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.datastore.duration", map[string]string{
 		"gestalt.provider": "metrics-store",
 		"gestalt.method":   "store_token",
 	})
@@ -462,7 +353,7 @@ func TestManualConnectionMetrics(t *testing.T) {
 func TestConnectionAuthMetricsUseUnknownProviderForMissingIntegration(t *testing.T) {
 	t.Parallel()
 
-	reader := useManualMeterProvider(t)
+	reader := metrictest.UseManualMeterProvider(t)
 	srv := newTestServer(t)
 	testutil.CloseOnCleanup(t, srv)
 
@@ -490,26 +381,26 @@ func TestConnectionAuthMetricsUseUnknownProviderForMissingIntegration(t *testing
 		t.Fatalf("manual connect status = %d, want %d", manualResp.StatusCode, http.StatusNotFound)
 	}
 
-	rm := collectMetrics(t, reader)
-	requireInt64Sum(t, rm, "gestaltd.connection.auth.count", 1, map[string]string{
+	rm := metrictest.CollectMetrics(t, reader)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.connection.auth.count", 1, map[string]string{
 		"gestalt.provider":        "unknown",
 		"gestalt.type":            "oauth",
 		"gestalt.action":          "start",
 		"gestalt.connection_mode": "unknown",
 	})
-	requireInt64Sum(t, rm, "gestaltd.connection.auth.error_count", 1, map[string]string{
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.connection.auth.error_count", 1, map[string]string{
 		"gestalt.provider":        "unknown",
 		"gestalt.type":            "oauth",
 		"gestalt.action":          "start",
 		"gestalt.connection_mode": "unknown",
 	})
-	requireInt64Sum(t, rm, "gestaltd.connection.auth.count", 1, map[string]string{
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.connection.auth.count", 1, map[string]string{
 		"gestalt.provider":        "unknown",
 		"gestalt.type":            "manual",
 		"gestalt.action":          "complete",
 		"gestalt.connection_mode": "unknown",
 	})
-	requireInt64Sum(t, rm, "gestaltd.connection.auth.error_count", 1, map[string]string{
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.connection.auth.error_count", 1, map[string]string{
 		"gestalt.provider":        "unknown",
 		"gestalt.type":            "manual",
 		"gestalt.action":          "complete",
@@ -520,19 +411,16 @@ func TestConnectionAuthMetricsUseUnknownProviderForMissingIntegration(t *testing
 func TestPlatformAuthMetrics(t *testing.T) {
 	t.Parallel()
 
-	reader := useManualMeterProvider(t)
+	reader := metrictest.UseManualMeterProvider(t)
 	secret := []byte("0123456789abcdef0123456789abcdef")
 	var auditBuf bytes.Buffer
 
-	ds := &namedStubDatastore{
-		name: "auth-metrics-store",
-		StubDatastore: coretesting.StubDatastore{
-			FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
-				return &core.User{ID: "u1", Email: email}, nil
-			},
+	ds := metrictest.NewNamedStubDatastore("auth-metrics-store", coretesting.StubDatastore{
+		FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
+			return &core.User{ID: "u1", Email: email}, nil
 		},
-		listAPITokensFn: func(context.Context, string) ([]*core.APIToken, error) { return nil, nil },
-	}
+	})
+	ds.ListAPITokensFn = func(context.Context, string) ([]*core.APIToken, error) { return nil, nil }
 
 	client := &http.Client{}
 	jar, err := cookiejar.New(nil)
@@ -594,28 +482,28 @@ func TestPlatformAuthMetrics(t *testing.T) {
 		t.Fatalf("validate-token and datastore read should not emit audit logs, got: %s", got)
 	}
 
-	rm := collectMetrics(t, reader)
-	requireInt64Sum(t, rm, "gestaltd.auth.count", 1, map[string]string{
+	rm := metrictest.CollectMetrics(t, reader)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.auth.count", 1, map[string]string{
 		"gestalt.provider": "metrics-host-issued",
 		"gestalt.action":   "begin_login",
 	})
-	requireInt64Sum(t, rm, "gestaltd.auth.count", 1, map[string]string{
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.auth.count", 1, map[string]string{
 		"gestalt.provider": "metrics-host-issued",
 		"gestalt.action":   "complete_login",
 	})
-	requireInt64Sum(t, rm, "gestaltd.auth.count", 1, map[string]string{
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.auth.count", 1, map[string]string{
 		"gestalt.provider": "metrics-host-issued",
 		"gestalt.action":   "validate_token",
 	})
-	requireFloat64Histogram(t, rm, "gestaltd.auth.duration", map[string]string{
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.auth.duration", map[string]string{
 		"gestalt.provider": "metrics-host-issued",
 		"gestalt.action":   "complete_login",
 	})
-	requireInt64Sum(t, rm, "gestaltd.datastore.count", 2, map[string]string{
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.datastore.count", 2, map[string]string{
 		"gestalt.provider": "auth-metrics-store",
 		"gestalt.method":   "find_or_create_user",
 	})
-	requireInt64Sum(t, rm, "gestaltd.datastore.count", 1, map[string]string{
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.datastore.count", 1, map[string]string{
 		"gestalt.provider": "auth-metrics-store",
 		"gestalt.method":   "list_api_tokens",
 	})

--- a/gestaltd/internal/testutil/metrictest/metrictest.go
+++ b/gestaltd/internal/testutil/metrictest/metrictest.go
@@ -1,0 +1,143 @@
+package metrictest
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+var meterProviderMu sync.Mutex
+
+func UseManualMeterProvider(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+
+	meterProviderMu.Lock()
+	prev := otel.GetMeterProvider()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	otel.SetMeterProvider(provider)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+		otel.SetMeterProvider(prev)
+		meterProviderMu.Unlock()
+	})
+	return reader
+}
+
+func CollectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+	return rm
+}
+
+func RequireInt64Sum(t *testing.T, rm metricdata.ResourceMetrics, name string, want int64, attrs map[string]string) {
+	t.Helper()
+
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != name {
+				continue
+			}
+			sum, ok := metric.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("metric %q is %T, want Sum[int64]", name, metric.Data)
+			}
+			for _, point := range sum.DataPoints {
+				if AttrsMatch(point.Attributes, attrs) {
+					if point.Value != want {
+						t.Fatalf("metric %q attrs %v = %d, want %d", name, attrs, point.Value, want)
+					}
+					return
+				}
+			}
+		}
+	}
+
+	t.Fatalf("metric %q with attrs %v not found", name, attrs)
+}
+
+func RequireNoInt64Sum(t *testing.T, rm metricdata.ResourceMetrics, name string, attrs map[string]string) {
+	t.Helper()
+
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != name {
+				continue
+			}
+			sum, ok := metric.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("metric %q is %T, want Sum[int64]", name, metric.Data)
+			}
+			for _, point := range sum.DataPoints {
+				if AttrsMatch(point.Attributes, attrs) {
+					t.Fatalf("metric %q with attrs %v unexpectedly found", name, attrs)
+				}
+			}
+		}
+	}
+}
+
+func RequireFloat64Histogram(t *testing.T, rm metricdata.ResourceMetrics, name string, attrs map[string]string) {
+	t.Helper()
+
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != name {
+				continue
+			}
+			histogram, ok := metric.Data.(metricdata.Histogram[float64])
+			if !ok {
+				t.Fatalf("metric %q is %T, want Histogram[float64]", name, metric.Data)
+			}
+			for _, point := range histogram.DataPoints {
+				if AttrsMatch(point.Attributes, attrs) {
+					return
+				}
+			}
+		}
+	}
+
+	t.Fatalf("metric %q with attrs %v not found", name, attrs)
+}
+
+func AttrsMatch(set attribute.Set, want map[string]string) bool {
+	for key, expected := range want {
+		value, ok := set.Value(attribute.Key(key))
+		if !ok || value.AsString() != expected {
+			return false
+		}
+	}
+	return true
+}
+
+type NamedStubDatastore struct {
+	coretesting.StubDatastore
+	N               string
+	ListAPITokensFn func(context.Context, string) ([]*core.APIToken, error)
+}
+
+func NewNamedStubDatastore(name string, stub coretesting.StubDatastore) *NamedStubDatastore {
+	return &NamedStubDatastore{StubDatastore: stub, N: name}
+}
+
+func (s *NamedStubDatastore) Name() string { return s.N }
+
+func (s *NamedStubDatastore) ListAPITokens(ctx context.Context, userID string) ([]*core.APIToken, error) {
+	if s.ListAPITokensFn != nil {
+		return s.ListAPITokensFn(ctx, userID)
+	}
+	return s.StubDatastore.ListAPITokens(ctx, userID)
+}
+
+var _ core.Datastore = (*NamedStubDatastore)(nil)


### PR DESCRIPTION
## Summary

- Extract metric test helpers (UseManualMeterProvider, CollectMetrics, RequireInt64Sum, RequireNoInt64Sum, RequireFloat64Histogram, AttrsMatch, NamedStubDatastore) into a shared `internal/testutil/metrictest` package, replacing identical copies across 3 test files in cmd/gestaltd, internal/metricutil, and internal/server.
- Merge `TestCatalogFiltersOperations` into `TestCatalogFilters` in core/integration so one test asserts both the `Catalog().Operations` and `OperationsList()` code paths.
- Delete redundant `TestCompileSchemasFillsInputSchema` from catalog_test.go since its coverage is subsumed by `TestSynthesizeInputSchemaBasic` in schema_test.go.

Net reduction: ~240 lines deleted.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] Verified all affected packages (cmd/gestaltd, internal/metricutil, internal/server, core/integration) pass individually with `-count=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)