### PR TITLE
sdk/rust: remove serde_yaml, reduce public API surface

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -18,7 +18,6 @@ prost-types = "0.12"
 schemars = { version = "0.8", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yaml = "0.9"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "time"] }
 tokio-stream = { version = "0.1", features = ["net"] }

--- a/sdk/rust/src/catalog.rs
+++ b/sdk/rust/src/catalog.rs
@@ -104,7 +104,7 @@ pub fn write_catalog(catalog: &Catalog, path: impl AsRef<Path>) -> Result<()> {
             op.annotations = None;
         }
     }
-    let yaml = serde_yaml::to_string(&yaml_catalog)?;
+    let yaml = serde_json::to_string_pretty(&yaml_catalog)?;
     std::fs::write(path, yaml)?;
     Ok(())
 }

--- a/sdk/rust/src/error.rs
+++ b/sdk/rust/src/error.rs
@@ -58,12 +58,6 @@ impl From<serde_json::Error> for Error {
     }
 }
 
-impl From<serde_yaml::Error> for Error {
-    fn from(value: serde_yaml::Error) -> Self {
-        Self::internal(value.to_string())
-    }
-}
-
 impl From<std::io::Error> for Error {
     fn from(value: std::io::Error) -> Self {
         Self::internal(value.to_string())

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -14,9 +14,6 @@ mod rpc_status;
 pub mod runtime;
 mod runtime_server;
 
-/// The shared protobuf package name used by the Gestalt SDK protocol surface.
-pub const PROTO_PACKAGE: &str = "gestalt.plugin.v1";
-
 /// Generated protobuf and gRPC bindings compiled from `sdk/proto/v1/*.proto`.
 mod generated {
     pub mod v1 {
@@ -29,22 +26,18 @@ pub mod proto {
 }
 
 pub use api::RuntimeMetadata;
-pub use api::{IntoResponse, Provider, Request, Response, ok};
+pub use api::{Provider, Request, Response, ok};
 pub use async_trait::async_trait;
 pub use auth::{
     AuthProvider, AuthenticatedUser, BeginLoginRequest, BeginLoginResponse, CompleteLoginRequest,
 };
-pub use catalog::{
-    Catalog, CatalogOperation, CatalogParameter, OperationAnnotations, write_catalog,
-};
+pub use catalog::{Catalog, CatalogOperation};
 pub use datastore::{
     DatastoreProvider, OAuthRegistration, StoredApiToken, StoredIntegrationToken, StoredUser,
 };
-pub use env::{
-    CURRENT_PROTOCOL_VERSION, ENV_PLUGIN_NAME, ENV_PLUGIN_PARENT_PID, ENV_PLUGIN_SOCKET,
-    ENV_WRITE_CATALOG,
-};
+pub use env::{CURRENT_PROTOCOL_VERSION, ENV_PLUGIN_SOCKET};
 pub use error::{Error, Result};
+#[doc(hidden)]
 pub use provider_server::{OperationResult, ProviderServer};
 pub use router::{Operation, Router};
 

--- a/sdk/rust/src/provider_server.rs
+++ b/sdk/rust/src/provider_server.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
 
 use crate::api::{Request, Response};
-use crate::catalog::{Catalog, catalog_json, object_map};
+use crate::catalog::{catalog_json, object_map};
 use crate::env::CURRENT_PROTOCOL_VERSION;
 use crate::error::Error;
 use crate::generated::v1::provider_plugin_server::ProviderPlugin;
@@ -52,10 +52,6 @@ impl OperationResult {
 impl<P> ProviderServer<P> {
     pub fn new(provider: Arc<P>, router: Router<P>) -> Self {
         Self { provider, router }
-    }
-
-    pub fn catalog(&self) -> Catalog {
-        self.router.catalog()
     }
 }
 

--- a/sdk/rust/src/router.rs
+++ b/sdk/rust/src/router.rs
@@ -123,8 +123,8 @@ impl<P> Router<P> {
         self
     }
 
-    pub fn catalog(&self) -> Catalog {
-        self.catalog.clone()
+    pub fn catalog(&self) -> &Catalog {
+        &self.catalog
     }
 
     pub async fn execute(
@@ -175,18 +175,19 @@ where
 
         let input_schema = schema_json::<In>()?;
         let output_schema = schema_json::<Out>()?;
+        let parameters = schema_parameters(&input_schema);
         self.catalog.operations.push(CatalogOperation {
             id: operation_id.to_owned(),
             method: operation.method.clone(),
             title: operation.title.trim().to_owned(),
             description: operation.description.trim().to_owned(),
-            input_schema: Some(input_schema.clone()),
+            input_schema: Some(input_schema),
             output_schema: Some(output_schema),
             annotations: Some(OperationAnnotations {
                 read_only_hint: operation.read_only.then_some(true),
                 ..OperationAnnotations::default()
             }),
-            parameters: schema_parameters(&input_schema),
+            parameters,
             required_scopes: Vec::new(),
             tags: operation.tags.clone(),
             read_only: operation.read_only,

--- a/sdk/rust/src/runtime.rs
+++ b/sdk/rust/src/runtime.rs
@@ -16,6 +16,7 @@ use tokio_stream::wrappers::UnixListenerStream;
 #[cfg(unix)]
 use tonic::transport::Server;
 
+use crate::catalog::write_catalog;
 use crate::env::{ENV_PLUGIN_NAME, ENV_PLUGIN_PARENT_PID, ENV_PLUGIN_SOCKET, ENV_WRITE_CATALOG};
 use crate::error::{Error, Result};
 #[cfg(unix)]
@@ -26,9 +27,10 @@ use crate::generated::v1::datastore_plugin_server::DatastorePluginServer;
 use crate::generated::v1::plugin_runtime_server::PluginRuntimeServer;
 #[cfg(unix)]
 use crate::generated::v1::provider_plugin_server::ProviderPluginServer;
+use crate::provider_server::ProviderServer;
 #[cfg(unix)]
 use crate::{AuthProvider, DatastoreProvider};
-use crate::{Provider, ProviderServer, Router, write_catalog};
+use crate::{Provider, Router};
 #[cfg(unix)]
 use crate::{
     auth_server::AuthServer, datastore_server::DatastoreServer, runtime_server::RuntimeServer,
@@ -59,7 +61,7 @@ pub fn run_datastore_provider<P: DatastoreProvider>(provider: Arc<P>) -> Result<
 }
 
 pub fn write_catalog_path<P>(router: &Router<P>, path: impl AsRef<Path>) -> Result<()> {
-    write_catalog(&router.catalog(), path)
+    write_catalog(router.catalog(), path)
 }
 
 pub fn maybe_write_catalog<P>(router: &Router<P>) -> Result<bool> {
@@ -68,9 +70,9 @@ pub fn maybe_write_catalog<P>(router: &Router<P>) -> Result<bool> {
     };
 
     let catalog = if let Ok(name) = env::var(ENV_PLUGIN_NAME) {
-        router.catalog().with_name(name)
+        router.catalog().clone().with_name(name)
     } else {
-        router.catalog()
+        router.catalog().clone()
     };
 
     write_catalog(&catalog, PathBuf::from(path))?;


### PR DESCRIPTION
## Summary

- Drop `serde_yaml` dependency by switching `write_catalog()` to `serde_json::to_string_pretty` (JSON is valid YAML and matches the Go consumer's struct tags)
- Remove dead `PROTO_PACKAGE` constant and unused `ProviderServer::catalog()` method
- Narrow public API surface: hide `ProviderServer`/`OperationResult` behind `#[doc(hidden)]`, remove re-exports for internal-only types (`CatalogParameter`, `OperationAnnotations`, `write_catalog`, `IntoResponse`, env constants)
- Change `Router::catalog()` to return `&Catalog` instead of cloning, and reorder `register()` to avoid an unnecessary `input_schema.clone()`

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo test` passes (10 tests across unit and integration suites)
- [x] `cargo clippy -- -D warnings` passes with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)