### PR TITLE
sdk/go: reduce API surface, eliminate Provider alias and internal abstractions

### DIFF
--- a/sdk/go/auth_server.go
+++ b/sdk/go/auth_server.go
@@ -10,16 +10,16 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-type AuthServer struct {
+type authServer struct {
 	proto.UnimplementedAuthPluginServer
 	auth AuthProvider
 }
 
-func NewAuthProviderServer(auth AuthProvider) *AuthServer {
-	return &AuthServer{auth: auth}
+func newAuthProviderServer(auth AuthProvider) *authServer {
+	return &authServer{auth: auth}
 }
 
-func (s *AuthServer) BeginLogin(ctx context.Context, req *proto.BeginLoginRequest) (*proto.BeginLoginResponse, error) {
+func (s *authServer) BeginLogin(ctx context.Context, req *proto.BeginLoginRequest) (*proto.BeginLoginResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
@@ -41,7 +41,7 @@ func (s *AuthServer) BeginLogin(ctx context.Context, req *proto.BeginLoginReques
 	}, nil
 }
 
-func (s *AuthServer) CompleteLogin(ctx context.Context, req *proto.CompleteLoginRequest) (*proto.AuthenticatedUser, error) {
+func (s *authServer) CompleteLogin(ctx context.Context, req *proto.CompleteLoginRequest) (*proto.AuthenticatedUser, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
@@ -59,7 +59,7 @@ func (s *AuthServer) CompleteLogin(ctx context.Context, req *proto.CompleteLogin
 	return authenticatedUserToProto(user), nil
 }
 
-func (s *AuthServer) ValidateExternalToken(ctx context.Context, req *proto.ValidateExternalTokenRequest) (*proto.AuthenticatedUser, error) {
+func (s *authServer) ValidateExternalToken(ctx context.Context, req *proto.ValidateExternalTokenRequest) (*proto.AuthenticatedUser, error) {
 	validator, ok := s.auth.(ExternalTokenValidator)
 	if !ok {
 		return nil, providerRPCError("validate external token", ErrExternalTokenValidationUnsupported)
@@ -77,7 +77,7 @@ func (s *AuthServer) ValidateExternalToken(ctx context.Context, req *proto.Valid
 	return authenticatedUserToProto(user), nil
 }
 
-func (s *AuthServer) GetSessionSettings(context.Context, *emptypb.Empty) (*proto.AuthSessionSettings, error) {
+func (s *authServer) GetSessionSettings(context.Context, *emptypb.Empty) (*proto.AuthSessionSettings, error) {
 	provider, ok := s.auth.(SessionTTLProvider)
 	if !ok {
 		return nil, status.Error(codes.Unimplemented, "auth provider does not expose session settings")

--- a/sdk/go/convert.go
+++ b/sdk/go/convert.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -18,13 +17,6 @@ func cloneStringMap(values map[string]string) map[string]string {
 		out[key] = value
 	}
 	return out
-}
-
-func mapFromStruct(s *structpb.Struct) map[string]any {
-	if s == nil {
-		return nil
-	}
-	return s.AsMap()
 }
 
 func catalogToJSON(cat *Catalog) (string, error) {
@@ -61,14 +53,6 @@ func catalogToJSON(cat *Catalog) (string, error) {
 		return "", fmt.Errorf("marshal catalog: %w", err)
 	}
 	return string(data), nil
-}
-
-func configFromRequest(s *structpb.Struct) map[string]any {
-	config := mapFromStruct(s)
-	if config == nil {
-		config = map[string]any{}
-	}
-	return config
 }
 
 func timeToProto(value time.Time) *timestamppb.Timestamp {

--- a/sdk/go/datastore_server.go
+++ b/sdk/go/datastore_server.go
@@ -9,23 +9,23 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-type DatastoreServer struct {
+type datastoreServer struct {
 	proto.UnimplementedDatastorePluginServer
 	store DatastoreProvider
 }
 
-func NewDatastoreProviderServer(store DatastoreProvider) *DatastoreServer {
-	return &DatastoreServer{store: store}
+func newDatastoreProviderServer(store DatastoreProvider) *datastoreServer {
+	return &datastoreServer{store: store}
 }
 
-func (s *DatastoreServer) Migrate(ctx context.Context, _ *emptypb.Empty) (*emptypb.Empty, error) {
+func (s *datastoreServer) Migrate(ctx context.Context, _ *emptypb.Empty) (*emptypb.Empty, error) {
 	if err := s.store.Migrate(ctx); err != nil {
 		return nil, providerRPCError("migrate", err)
 	}
 	return &emptypb.Empty{}, nil
 }
 
-func (s *DatastoreServer) GetUser(ctx context.Context, req *proto.GetUserRequest) (*proto.StoredUser, error) {
+func (s *datastoreServer) GetUser(ctx context.Context, req *proto.GetUserRequest) (*proto.StoredUser, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
@@ -39,7 +39,7 @@ func (s *DatastoreServer) GetUser(ctx context.Context, req *proto.GetUserRequest
 	return storedUserToProto(user), nil
 }
 
-func (s *DatastoreServer) FindOrCreateUser(ctx context.Context, req *proto.FindOrCreateUserRequest) (*proto.StoredUser, error) {
+func (s *datastoreServer) FindOrCreateUser(ctx context.Context, req *proto.FindOrCreateUserRequest) (*proto.StoredUser, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
@@ -53,7 +53,7 @@ func (s *DatastoreServer) FindOrCreateUser(ctx context.Context, req *proto.FindO
 	return storedUserToProto(user), nil
 }
 
-func (s *DatastoreServer) PutStoredIntegrationToken(ctx context.Context, req *proto.StoredIntegrationToken) (*emptypb.Empty, error) {
+func (s *datastoreServer) PutStoredIntegrationToken(ctx context.Context, req *proto.StoredIntegrationToken) (*emptypb.Empty, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
@@ -63,7 +63,7 @@ func (s *DatastoreServer) PutStoredIntegrationToken(ctx context.Context, req *pr
 	return &emptypb.Empty{}, nil
 }
 
-func (s *DatastoreServer) GetStoredIntegrationToken(ctx context.Context, req *proto.GetStoredIntegrationTokenRequest) (*proto.StoredIntegrationToken, error) {
+func (s *datastoreServer) GetStoredIntegrationToken(ctx context.Context, req *proto.GetStoredIntegrationTokenRequest) (*proto.StoredIntegrationToken, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
@@ -77,7 +77,7 @@ func (s *DatastoreServer) GetStoredIntegrationToken(ctx context.Context, req *pr
 	return storedIntegrationTokenToProto(token), nil
 }
 
-func (s *DatastoreServer) ListStoredIntegrationTokens(ctx context.Context, req *proto.ListStoredIntegrationTokensRequest) (*proto.ListStoredIntegrationTokensResponse, error) {
+func (s *datastoreServer) ListStoredIntegrationTokens(ctx context.Context, req *proto.ListStoredIntegrationTokensRequest) (*proto.ListStoredIntegrationTokensResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
@@ -92,7 +92,7 @@ func (s *DatastoreServer) ListStoredIntegrationTokens(ctx context.Context, req *
 	return &proto.ListStoredIntegrationTokensResponse{Tokens: protoTokens}, nil
 }
 
-func (s *DatastoreServer) DeleteStoredIntegrationToken(ctx context.Context, req *proto.DeleteStoredIntegrationTokenRequest) (*emptypb.Empty, error) {
+func (s *datastoreServer) DeleteStoredIntegrationToken(ctx context.Context, req *proto.DeleteStoredIntegrationTokenRequest) (*emptypb.Empty, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
@@ -102,7 +102,7 @@ func (s *DatastoreServer) DeleteStoredIntegrationToken(ctx context.Context, req 
 	return &emptypb.Empty{}, nil
 }
 
-func (s *DatastoreServer) PutAPIToken(ctx context.Context, req *proto.StoredAPIToken) (*emptypb.Empty, error) {
+func (s *datastoreServer) PutAPIToken(ctx context.Context, req *proto.StoredAPIToken) (*emptypb.Empty, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
@@ -112,7 +112,7 @@ func (s *DatastoreServer) PutAPIToken(ctx context.Context, req *proto.StoredAPIT
 	return &emptypb.Empty{}, nil
 }
 
-func (s *DatastoreServer) GetAPITokenByHash(ctx context.Context, req *proto.GetAPITokenByHashRequest) (*proto.StoredAPIToken, error) {
+func (s *datastoreServer) GetAPITokenByHash(ctx context.Context, req *proto.GetAPITokenByHashRequest) (*proto.StoredAPIToken, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
@@ -126,7 +126,7 @@ func (s *DatastoreServer) GetAPITokenByHash(ctx context.Context, req *proto.GetA
 	return storedAPITokenToProto(token), nil
 }
 
-func (s *DatastoreServer) ListAPITokens(ctx context.Context, req *proto.ListAPITokensRequest) (*proto.ListAPITokensResponse, error) {
+func (s *datastoreServer) ListAPITokens(ctx context.Context, req *proto.ListAPITokensRequest) (*proto.ListAPITokensResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
@@ -141,7 +141,7 @@ func (s *DatastoreServer) ListAPITokens(ctx context.Context, req *proto.ListAPIT
 	return &proto.ListAPITokensResponse{Tokens: protoTokens}, nil
 }
 
-func (s *DatastoreServer) RevokeAPIToken(ctx context.Context, req *proto.RevokeAPITokenRequest) (*emptypb.Empty, error) {
+func (s *datastoreServer) RevokeAPIToken(ctx context.Context, req *proto.RevokeAPITokenRequest) (*emptypb.Empty, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
@@ -151,7 +151,7 @@ func (s *DatastoreServer) RevokeAPIToken(ctx context.Context, req *proto.RevokeA
 	return &emptypb.Empty{}, nil
 }
 
-func (s *DatastoreServer) RevokeAllAPITokens(ctx context.Context, req *proto.RevokeAllAPITokensRequest) (*proto.RevokeAllAPITokensResponse, error) {
+func (s *datastoreServer) RevokeAllAPITokens(ctx context.Context, req *proto.RevokeAllAPITokensRequest) (*proto.RevokeAllAPITokensResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
@@ -162,7 +162,7 @@ func (s *DatastoreServer) RevokeAllAPITokens(ctx context.Context, req *proto.Rev
 	return &proto.RevokeAllAPITokensResponse{Revoked: revoked}, nil
 }
 
-func (s *DatastoreServer) GetOAuthRegistration(ctx context.Context, req *proto.GetOAuthRegistrationRequest) (*proto.OAuthRegistration, error) {
+func (s *datastoreServer) GetOAuthRegistration(ctx context.Context, req *proto.GetOAuthRegistrationRequest) (*proto.OAuthRegistration, error) {
 	store, ok := s.store.(OAuthRegistrationStore)
 	if !ok {
 		return nil, providerRPCError("get oauth registration", ErrOAuthRegistrationStoreUnsupported)
@@ -180,7 +180,7 @@ func (s *DatastoreServer) GetOAuthRegistration(ctx context.Context, req *proto.G
 	return oauthRegistrationToProto(registration), nil
 }
 
-func (s *DatastoreServer) PutOAuthRegistration(ctx context.Context, req *proto.OAuthRegistration) (*emptypb.Empty, error) {
+func (s *datastoreServer) PutOAuthRegistration(ctx context.Context, req *proto.OAuthRegistration) (*emptypb.Empty, error) {
 	store, ok := s.store.(OAuthRegistrationStore)
 	if !ok {
 		return nil, providerRPCError("put oauth registration", ErrOAuthRegistrationStoreUnsupported)
@@ -194,7 +194,7 @@ func (s *DatastoreServer) PutOAuthRegistration(ctx context.Context, req *proto.O
 	return &emptypb.Empty{}, nil
 }
 
-func (s *DatastoreServer) DeleteOAuthRegistration(ctx context.Context, req *proto.DeleteOAuthRegistrationRequest) (*emptypb.Empty, error) {
+func (s *datastoreServer) DeleteOAuthRegistration(ctx context.Context, req *proto.DeleteOAuthRegistrationRequest) (*emptypb.Empty, error) {
 	store, ok := s.store.(OAuthRegistrationStore)
 	if !ok {
 		return nil, providerRPCError("delete oauth registration", ErrOAuthRegistrationStoreUnsupported)

--- a/sdk/go/doc.go
+++ b/sdk/go/doc.go
@@ -1,7 +1,7 @@
 // Package gestalt provides a Go SDK for building Gestalt executable plugins.
 //
 // Gestalt plugins extend the platform with new integrations and automations.
-// A [Provider] is the current runtime contract for integration plugins: it
+// [RuntimeProvider] is the runtime contract for integration plugins: it
 // receives startup config and serves typed executable operations when the host
 // invokes them.
 //
@@ -9,7 +9,7 @@
 // operations are authored in Go and materialized automatically by the SDK and
 // host. The recommended authoring flow is:
 //
-//  1. Implement [Provider.Configure].
+//  1. Implement [RuntimeProvider.Configure].
 //  2. Define typed operations and handlers in Go with [Operation], [Register],
 //     and [Router].
 //  3. Export `New()` plus `Router` from the provider package.
@@ -36,10 +36,6 @@
 //	var Router = gestalt.MustRouter(
 //		gestalt.Register(myOperation, (*MyProvider).myHandler),
 //	)
-//
-// Source-plugin flows derive the executable catalog name from plugin.yaml. Use
-// [MustNamedRouter] only when you need an explicit catalog name outside that
-// manifest-backed flow.
 //
 // See `/docs/plugins/writing-a-plugin` for the full typed authoring flow.
 package gestalt

--- a/sdk/go/errors.go
+++ b/sdk/go/errors.go
@@ -38,7 +38,9 @@ func (e *operationError) Unwrap() error {
 }
 
 func newOperationError(status int, message string, cause error) error {
-	message = stringOr(message, http.StatusText(status))
+	if message == "" {
+		message = http.StatusText(status)
+	}
 	return &operationError{
 		status:  status,
 		message: message,
@@ -57,7 +59,10 @@ func operationResultFromError(err error) *OperationResult {
 		if opErr.status != 0 {
 			status = opErr.status
 		}
-		message = stringOr(opErr.message, opErr.Error())
+		message = opErr.message
+		if message == "" {
+			message = opErr.Error()
+		}
 	}
 	return operationResult(status, message)
 }
@@ -99,13 +104,6 @@ func operationErrorBody(message string) string {
 		return internalErrorBodyFallback
 	}
 	return string(data)
-}
-
-func stringOr(value, fallback string) string {
-	if value != "" {
-		return value
-	}
-	return fallback
 }
 
 var (

--- a/sdk/go/plugin.go
+++ b/sdk/go/plugin.go
@@ -17,44 +17,14 @@ const envWriteCatalog = "GESTALT_PLUGIN_WRITE_CATALOG"
 
 type pluginCloserContextKey struct{}
 
-type executableProvider interface {
-	Provider
-	execute(ctx context.Context, operation string, params map[string]any, token string) (*OperationResult, error)
-	sessionCatalogProvider() (SessionCatalogProvider, bool)
-}
-
-type routedProvider[P any, PP interface {
-	*P
-	Provider
-}] struct {
-	provider PP
-	router   *Router[P]
-}
-
-func (p *routedProvider[P, PP]) Configure(ctx context.Context, name string, config map[string]any) error {
-	return p.provider.Configure(ctx, name, config)
-}
-
-func (p *routedProvider[P, PP]) execute(ctx context.Context, operation string, params map[string]any, token string) (*OperationResult, error) {
-	if p.router == nil {
-		return nil, fmt.Errorf("router is nil")
-	}
-	return p.router.Execute(ctx, (*P)(p.provider), operation, params, token)
-}
-
-func (p *routedProvider[P, PP]) sessionCatalogProvider() (SessionCatalogProvider, bool) {
-	scp, ok := any(p.provider).(SessionCatalogProvider)
-	return scp, ok
-}
-
-// ServeProvider starts a gRPC server for the given [Provider] and typed
+// ServeProvider starts a gRPC server for the given [RuntimeProvider] and typed
 // router on the Unix socket specified by the GESTALT_PLUGIN_SOCKET environment
 // variable. It blocks until ctx is cancelled, at which point it drains
 // in-flight requests and returns nil. This is the main entry point for
 // provider plugins.
 func ServeProvider[P any, PP interface {
 	*P
-	Provider
+	RuntimeProvider
 }](ctx context.Context, provider PP, router *Router[P]) error {
 	if catalogPath := os.Getenv(envWriteCatalog); catalogPath != "" {
 		if router == nil {

--- a/sdk/go/provider_server.go
+++ b/sdk/go/provider_server.go
@@ -2,6 +2,7 @@ package gestalt
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
@@ -10,24 +11,28 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-// ProviderServer adapts a [Provider] implementation to the gRPC
-// ProviderPlugin service. Most plugin authors should use [ServeProvider]
-// instead of constructing this directly.
 type ProviderServer struct {
 	proto.UnimplementedProviderPluginServer
-	provider executableProvider
+	provider   RuntimeProvider
+	executeFn  func(ctx context.Context, operation string, params map[string]any, token string) (*OperationResult, error)
+	sessionCat func() (SessionCatalogProvider, bool)
 }
 
-// NewProviderServer wraps a [Provider] and typed router in a [ProviderServer]
-// ready to be registered on a gRPC server.
 func NewProviderServer[P any, PP interface {
 	*P
-	Provider
+	RuntimeProvider
 }](provider PP, router *Router[P]) *ProviderServer {
 	return &ProviderServer{
-		provider: &routedProvider[P, PP]{
-			provider: provider,
-			router:   router,
+		provider: provider,
+		executeFn: func(ctx context.Context, operation string, params map[string]any, token string) (*OperationResult, error) {
+			if router == nil {
+				return nil, fmt.Errorf("router is nil")
+			}
+			return router.Execute(ctx, (*P)(provider), operation, params, token)
+		},
+		sessionCat: func() (SessionCatalogProvider, bool) {
+			scp, ok := any(provider).(SessionCatalogProvider)
+			return scp, ok
 		},
 	}
 }
@@ -36,7 +41,11 @@ func (s *ProviderServer) StartProvider(ctx context.Context, req *proto.StartProv
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
-	if err := s.provider.Configure(ctx, req.GetName(), configFromRequest(req.GetConfig())); err != nil {
+	config := req.GetConfig().AsMap()
+	if config == nil {
+		config = map[string]any{}
+	}
+	if err := s.provider.Configure(ctx, req.GetName(), config); err != nil {
 		return nil, status.Errorf(codes.Unknown, "configure provider: %v", err)
 	}
 	return &proto.StartProviderResponse{
@@ -45,8 +54,9 @@ func (s *ProviderServer) StartProvider(ctx context.Context, req *proto.StartProv
 }
 
 func (s *ProviderServer) GetMetadata(_ context.Context, _ *emptypb.Empty) (*proto.ProviderMetadata, error) {
+	_, ok := s.sessionCat()
 	return &proto.ProviderMetadata{
-		SupportsSessionCatalog: supportsSessionCatalog(s.provider),
+		SupportsSessionCatalog: ok,
 	}, nil
 }
 
@@ -57,7 +67,7 @@ func (s *ProviderServer) Execute(ctx context.Context, req *proto.ExecuteRequest)
 	if len(req.GetConnectionParams()) > 0 {
 		ctx = WithConnectionParams(ctx, req.GetConnectionParams())
 	}
-	result, err := s.provider.execute(ctx, req.GetOperation(), mapFromStruct(req.GetParams()), req.GetToken())
+	result, err := s.executeFn(ctx, req.GetOperation(), req.GetParams().AsMap(), req.GetToken())
 	if err != nil {
 		return operationResultProto(operationResultFromError(err)), nil
 	}
@@ -68,7 +78,7 @@ func (s *ProviderServer) Execute(ctx context.Context, req *proto.ExecuteRequest)
 }
 
 func (s *ProviderServer) GetSessionCatalog(ctx context.Context, req *proto.GetSessionCatalogRequest) (*proto.GetSessionCatalogResponse, error) {
-	scp, ok := s.provider.sessionCatalogProvider()
+	scp, ok := s.sessionCat()
 	if !ok {
 		return nil, status.Error(codes.Unimplemented, "provider does not support session catalogs")
 	}
@@ -84,11 +94,6 @@ func (s *ProviderServer) GetSessionCatalog(ctx context.Context, req *proto.GetSe
 		return nil, status.Errorf(codes.Internal, "encode session catalog: %v", err)
 	}
 	return &proto.GetSessionCatalogResponse{CatalogJson: raw}, nil
-}
-
-func supportsSessionCatalog(p executableProvider) bool {
-	_, ok := p.sessionCatalogProvider()
-	return ok
 }
 
 func operationResultProto(result *OperationResult) *proto.OperationResult {

--- a/sdk/go/router.go
+++ b/sdk/go/router.go
@@ -144,6 +144,7 @@ func (r *Router[P]) Catalog() *Catalog {
 		return nil
 	}
 	c := r.catalog
+	c.Operations = append([]CatalogOperation(nil), c.Operations...)
 	return &c
 }
 
@@ -153,6 +154,7 @@ func (r *Router[P]) WithName(name string) *Router[P] {
 	}
 	trimmed := strings.TrimSpace(name)
 	catalog := r.catalog
+	catalog.Operations = append([]CatalogOperation(nil), catalog.Operations...)
 	if trimmed != "" {
 		catalog.Name = trimmed
 	}

--- a/sdk/go/router.go
+++ b/sdk/go/router.go
@@ -107,15 +107,6 @@ func NewRouter[P any](registrations ...Registration[P]) (*Router[P], error) {
 	return newRouter("", registrations...)
 }
 
-// NewNamedRouter constructs a typed router with an explicit catalog name.
-func NewNamedRouter[P any](name string, registrations ...Registration[P]) (*Router[P], error) {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return nil, fmt.Errorf("router name is required")
-	}
-	return newRouter(name, registrations...)
-}
-
 func newRouter[P any](name string, registrations ...Registration[P]) (*Router[P], error) {
 	router := &Router[P]{
 		catalog: Catalog{
@@ -134,7 +125,7 @@ func newRouter[P any](name string, registrations ...Registration[P]) (*Router[P]
 			return nil, fmt.Errorf("duplicate operation id %q", opID)
 		}
 		router.handlers[opID] = reg.execute
-		router.catalog.Operations = append(router.catalog.Operations, cloneCatalogOperation(reg.catalogOp))
+		router.catalog.Operations = append(router.catalog.Operations, reg.catalogOp)
 	}
 	return router, nil
 }
@@ -148,42 +139,29 @@ func MustRouter[P any](registrations ...Registration[P]) *Router[P] {
 	return router
 }
 
-// MustNamedRouter panics if [NewNamedRouter] returns an error.
-func MustNamedRouter[P any](name string, registrations ...Registration[P]) *Router[P] {
-	router, err := NewNamedRouter(name, registrations...)
-	if err != nil {
-		panic(err)
-	}
-	return router
-}
-
-// Catalog returns a clone of the router's static executable catalog.
 func (r *Router[P]) Catalog() *Catalog {
 	if r == nil {
 		return nil
 	}
-	return cloneCatalog(&r.catalog)
+	c := r.catalog
+	return &c
 }
 
-// WithName returns a clone of the router with the provided catalog name.
-// Empty names preserve the existing router name.
 func (r *Router[P]) WithName(name string) *Router[P] {
 	if r == nil {
 		return nil
 	}
-	cloned := cloneCatalog(&r.catalog)
-	if cloned == nil {
-		cloned = &Catalog{}
-	}
-	if trimmed := strings.TrimSpace(name); trimmed != "" {
-		cloned.Name = trimmed
+	trimmed := strings.TrimSpace(name)
+	catalog := r.catalog
+	if trimmed != "" {
+		catalog.Name = trimmed
 	}
 	handlers := make(map[string]func(context.Context, *P, map[string]any, Request) (*OperationResult, error), len(r.handlers))
 	for opID, handler := range r.handlers {
 		handlers[opID] = handler
 	}
 	return &Router[P]{
-		catalog:  *cloned,
+		catalog:  catalog,
 		handlers: handlers,
 	}
 }
@@ -270,10 +248,7 @@ func catalogOperationFor[In any, Out any](op Operation[In, Out]) (CatalogOperati
 }
 
 func catalogParametersFor[In any]() ([]CatalogParameter, error) {
-	t := reflect.TypeFor[In]()
-	for t.Kind() == reflect.Pointer {
-		t = t.Elem()
-	}
+	t := underlyingType(reflect.TypeFor[In]())
 	if t.Kind() != reflect.Struct {
 		return nil, fmt.Errorf("input type %s must be a struct", t)
 	}
@@ -470,34 +445,6 @@ func isOptionalType(t reflect.Type) bool {
 	default:
 		return false
 	}
-}
-
-func cloneCatalog(src *Catalog) *Catalog {
-	if src == nil {
-		return nil
-	}
-	out := &Catalog{
-		Name:        src.Name,
-		DisplayName: src.DisplayName,
-		Description: src.Description,
-		IconSVG:     src.IconSVG,
-		Operations:  make([]CatalogOperation, len(src.Operations)),
-	}
-	for i := range src.Operations {
-		out.Operations[i] = cloneCatalogOperation(src.Operations[i])
-	}
-	return out
-}
-
-func cloneCatalogOperation(src CatalogOperation) CatalogOperation {
-	out := src
-	out.InputSchema = append(json.RawMessage(nil), src.InputSchema...)
-	out.OutputSchema = append(json.RawMessage(nil), src.OutputSchema...)
-	out.Parameters = append([]CatalogParameter(nil), src.Parameters...)
-	out.RequiredScopes = append([]string(nil), src.RequiredScopes...)
-	out.Tags = append([]string(nil), src.Tags...)
-	out.Visible = cloneBoolPtr(src.Visible)
-	return out
 }
 
 func cloneBoolPtr(src *bool) *bool {

--- a/sdk/go/runtime_server.go
+++ b/sdk/go/runtime_server.go
@@ -9,20 +9,20 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-type RuntimeServer struct {
+type runtimeServer struct {
 	proto.UnimplementedPluginRuntimeServer
 	kind     proto.PluginKind
 	provider RuntimeProvider
 }
 
-func NewRuntimeProviderServer(kind ProviderKind, provider RuntimeProvider) *RuntimeServer {
-	return &RuntimeServer{
+func newRuntimeProviderServer(kind ProviderKind, provider RuntimeProvider) *runtimeServer {
+	return &runtimeServer{
 		kind:     providerKindToProto(kind),
 		provider: provider,
 	}
 }
 
-func (s *RuntimeServer) GetPluginMetadata(_ context.Context, _ *emptypb.Empty) (*proto.PluginMetadata, error) {
+func (s *runtimeServer) GetPluginMetadata(_ context.Context, _ *emptypb.Empty) (*proto.PluginMetadata, error) {
 	meta := proto.PluginMetadata{
 		Kind:               s.kind,
 		MinProtocolVersion: proto.CurrentProtocolVersion,
@@ -45,7 +45,7 @@ func (s *RuntimeServer) GetPluginMetadata(_ context.Context, _ *emptypb.Empty) (
 	return &meta, nil
 }
 
-func (s *RuntimeServer) ConfigurePlugin(ctx context.Context, req *proto.ConfigurePluginRequest) (*proto.ConfigurePluginResponse, error) {
+func (s *runtimeServer) ConfigurePlugin(ctx context.Context, req *proto.ConfigurePluginRequest) (*proto.ConfigurePluginResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
@@ -57,13 +57,17 @@ func (s *RuntimeServer) ConfigurePlugin(ctx context.Context, req *proto.Configur
 			proto.CurrentProtocolVersion,
 		)
 	}
-	if err := s.provider.Configure(ctx, req.GetName(), configFromRequest(req.GetConfig())); err != nil {
+	config := req.GetConfig().AsMap()
+	if config == nil {
+		config = map[string]any{}
+	}
+	if err := s.provider.Configure(ctx, req.GetName(), config); err != nil {
 		return nil, status.Errorf(codes.Unknown, "configure plugin: %v", err)
 	}
 	return &proto.ConfigurePluginResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
 }
 
-func (s *RuntimeServer) HealthCheck(ctx context.Context, _ *emptypb.Empty) (*proto.HealthCheckResponse, error) {
+func (s *runtimeServer) HealthCheck(ctx context.Context, _ *emptypb.Empty) (*proto.HealthCheckResponse, error) {
 	if checker, ok := s.provider.(HealthChecker); ok {
 		if err := checker.HealthCheck(ctx); err != nil {
 			return &proto.HealthCheckResponse{
@@ -90,10 +94,6 @@ func providerKindToProto(kind ProviderKind) proto.PluginKind {
 		return proto.PluginKind_PLUGIN_KIND_AUTH
 	case ProviderKindDatastore:
 		return proto.PluginKind_PLUGIN_KIND_DATASTORE
-	case ProviderKindSecrets:
-		return proto.PluginKind_PLUGIN_KIND_SECRETS
-	case ProviderKindTelemetry:
-		return proto.PluginKind_PLUGIN_KIND_TELEMETRY
 	default:
 		return proto.PluginKind_PLUGIN_KIND_UNSPECIFIED
 	}

--- a/sdk/go/serve_auth.go
+++ b/sdk/go/serve_auth.go
@@ -10,7 +10,7 @@ import (
 // ServeAuthProvider starts a gRPC server for an [AuthProvider].
 func ServeAuthProvider(ctx context.Context, auth AuthProvider) error {
 	return servePlugin(withPluginCloser(ctx, auth), func(srv *grpc.Server) {
-		proto.RegisterPluginRuntimeServer(srv, NewRuntimeProviderServer(ProviderKindAuth, auth))
-		proto.RegisterAuthPluginServer(srv, NewAuthProviderServer(auth))
+		proto.RegisterPluginRuntimeServer(srv, newRuntimeProviderServer(ProviderKindAuth, auth))
+		proto.RegisterAuthPluginServer(srv, newAuthProviderServer(auth))
 	})
 }

--- a/sdk/go/serve_datastore.go
+++ b/sdk/go/serve_datastore.go
@@ -10,7 +10,7 @@ import (
 // ServeDatastoreProvider starts a gRPC server for a [DatastoreProvider].
 func ServeDatastoreProvider(ctx context.Context, store DatastoreProvider) error {
 	return servePlugin(withPluginCloser(ctx, store), func(srv *grpc.Server) {
-		proto.RegisterPluginRuntimeServer(srv, NewRuntimeProviderServer(ProviderKindDatastore, store))
-		proto.RegisterDatastorePluginServer(srv, NewDatastoreProviderServer(store))
+		proto.RegisterPluginRuntimeServer(srv, newRuntimeProviderServer(ProviderKindDatastore, store))
+		proto.RegisterDatastorePluginServer(srv, newDatastoreProviderServer(store))
 	})
 }

--- a/sdk/go/test_helpers_test.go
+++ b/sdk/go/test_helpers_test.go
@@ -16,7 +16,7 @@ import (
 
 func newProviderPluginClient[P any, PP interface {
 	*P
-	gestalt.Provider
+	gestalt.RuntimeProvider
 }](t *testing.T, prov PP, router *gestalt.Router[P]) proto.ProviderPluginClient {
 	t.Helper()
 

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -12,8 +12,6 @@ const (
 	ProviderKindIntegration ProviderKind = "integration"
 	ProviderKindAuth        ProviderKind = "auth"
 	ProviderKindDatastore   ProviderKind = "datastore"
-	ProviderKindSecrets     ProviderKind = "secrets"
-	ProviderKindTelemetry   ProviderKind = "telemetry"
 )
 
 // ProviderMetadata describes a provider instance independent of its concrete
@@ -52,15 +50,6 @@ type Closer interface {
 // environment warnings the host should surface.
 type WarningsProvider interface {
 	Warnings() []string
-}
-
-// Provider is the core interface that every executable integration provider must
-// implement.
-//
-// Static metadata still comes from the manifest. Executable helper operations
-// are declared separately through the typed router passed to [ServeProvider].
-type Provider interface {
-	RuntimeProvider
 }
 
 type SessionCatalogProvider interface {


### PR DESCRIPTION
## Summary

- Delete the vacuous `Provider` interface (just embedded `RuntimeProvider`) and update all references to use `RuntimeProvider` directly
- Replace `executableProvider` interface and `routedProvider` generic struct with closure-based fields on `ProviderServer`, removing an unnecessary abstraction layer
- Unexport `AuthServer`, `DatastoreServer`, `RuntimeServer` and their constructors (zero external callers)
- Remove `NewNamedRouter` and `MustNamedRouter` (zero external callers)
- Delete unused `ProviderKindSecrets` and `ProviderKindTelemetry` constants
- Simplify catalog cloning: remove `cloneCatalog` and `cloneCatalogOperation` in favor of shallow value copies
- Inline trivial helpers (`mapFromStruct`, `configFromRequest`, `stringOr`) at their call sites
- Use existing `underlyingType` helper in `catalogParametersFor` instead of duplicating the pointer-peeling loop

## Test plan

- [x] `go build ./...` passes in `sdk/go/`
- [x] `go vet ./...` passes in `sdk/go/`
- [x] `go test -count=1 ./...` passes in `sdk/go/`
- [x] `go build ./...` passes in `gestaltd/`
- [x] `go test ./internal/pluginhost/... -count=1` passes in `gestaltd/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)