### PR TITLE
sdk/rust: bump tonic/prost to 0.14, remove async-trait dependency

### DIFF
--- a/gestaltd/internal/testutil/testdata/provider-rust-datastore/Cargo.toml
+++ b/gestaltd/internal/testutil/testdata/provider-rust-datastore/Cargo.toml
@@ -8,4 +8,4 @@ path = "src/lib.rs"
 
 [dependencies]
 gestalt_plugin_sdk = { path = "../../../../../sdk/rust" }
-prost-types = "0.12"
+prost-types = "0.14"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -26,7 +26,6 @@ tonic-prost = "0.14"
 [build-dependencies]
 prost-build = "0.14"
 protoc-bin-vendored = "3"
-tonic-build = "0.14"
 tonic-prost-build = "0.14"
 
 [dev-dependencies]

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -11,22 +11,24 @@ keywords = ["gestalt", "grpc", "protobuf", "sdk"]
 categories = ["api-bindings", "development-tools"]
 
 [dependencies]
-async-trait = "0.1"
 libc = "0.2"
-prost = "0.12"
-prost-types = "0.12"
+prost = "0.14"
+prost-types = "0.14"
 schemars = { version = "0.8", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "time"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = { version = "0.11", features = ["transport"] }
+tonic = { version = "0.14", features = ["transport"] }
+tonic-prost = "0.14"
 
 [build-dependencies]
-prost-build = "0.12"
+prost-build = "0.14"
 protoc-bin-vendored = "3"
-tonic-build = "0.11"
+tonic-build = "0.14"
+tonic-prost-build = "0.14"
 
 [dev-dependencies]
-tower = "0.4"
+hyper-util = "0.1.20"
+tower = "0.5"

--- a/sdk/rust/build.rs
+++ b/sdk/rust/build.rs
@@ -22,7 +22,7 @@ fn main() {
     // Stable ordering makes the generated bindings and any derived snapshots easier to inspect.
     prost_config.btree_map(["."]);
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .build_client(true)
         .build_server(true)
         .compile_with_config(prost_config, &protos, &includes)

--- a/sdk/rust/src/api.rs
+++ b/sdk/rust/src/api.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::convert::Infallible;
 
-use async_trait::async_trait;
+use tonic::codegen::async_trait;
 
 use crate::catalog::Catalog;
 use crate::error::{Error, Result};

--- a/sdk/rust/src/auth.rs
+++ b/sdk/rust/src/auth.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use async_trait::async_trait;
+use tonic::codegen::async_trait;
 
 use crate::api::RuntimeMetadata;
 use crate::error::{Error, Result};

--- a/sdk/rust/src/datastore.rs
+++ b/sdk/rust/src/datastore.rs
@@ -1,4 +1,4 @@
-use async_trait::async_trait;
+use tonic::codegen::async_trait;
 
 use crate::api::RuntimeMetadata;
 use crate::error::{Error, Result};

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -27,7 +27,6 @@ pub mod proto {
 
 pub use api::RuntimeMetadata;
 pub use api::{Provider, Request, Response, ok};
-pub use async_trait::async_trait;
 pub use auth::{
     AuthProvider, AuthenticatedUser, BeginLoginRequest, BeginLoginResponse, CompleteLoginRequest,
 };
@@ -40,6 +39,7 @@ pub use error::{Error, Result};
 #[doc(hidden)]
 pub use provider_server::{OperationResult, ProviderServer};
 pub use router::{Operation, Router};
+pub use tonic::codegen::async_trait;
 
 #[doc(hidden)]
 pub trait IntoRouterResult<P> {

--- a/sdk/rust/src/runtime_server.rs
+++ b/sdk/rust/src/runtime_server.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use async_trait::async_trait;
+use tonic::codegen::async_trait;
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
 
 use crate::api::RuntimeMetadata;

--- a/sdk/rust/tests/component_transport.rs
+++ b/sdk/rust/tests/component_transport.rs
@@ -6,7 +6,6 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use async_trait::async_trait;
 use gestalt_plugin_sdk::proto::v1::auth_plugin_client::AuthPluginClient;
 use gestalt_plugin_sdk::proto::v1::datastore_plugin_client::DatastorePluginClient;
 use gestalt_plugin_sdk::proto::v1::plugin_runtime_client::PluginRuntimeClient;
@@ -19,9 +18,11 @@ use gestalt_plugin_sdk::proto::v1::{
     StoredIntegrationToken, StoredUser, ValidateExternalTokenRequest,
 };
 use gestalt_plugin_sdk::{AuthProvider, DatastoreProvider, RuntimeMetadata};
+use hyper_util::rt::tokio::TokioIo;
 use prost_types::Timestamp;
 use tokio::net::UnixStream;
 use tonic::Code;
+use tonic::codegen::async_trait;
 use tonic::transport::Endpoint;
 use tower::service_fn;
 
@@ -643,7 +644,10 @@ async fn connect_unix(path: &Path) -> tonic::transport::Channel {
         .expect("endpoint")
         .connect_with_connector(service_fn({
             let path = path.to_path_buf();
-            move |_| UnixStream::connect(path.clone())
+            move |_| {
+                let path = path.clone();
+                async move { UnixStream::connect(path).await.map(TokioIo::new) }
+            }
         }))
         .await
         .expect("connect channel")

--- a/sdk/rust/tests/router.rs
+++ b/sdk/rust/tests/router.rs
@@ -4,7 +4,6 @@ mod helpers;
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
-use async_trait::async_trait;
 use gestalt_plugin_sdk as gestalt;
 use gestalt_plugin_sdk::proto::v1::provider_plugin_server::ProviderPlugin;
 use gestalt_plugin_sdk::proto::v1::{ExecuteRequest, StartProviderRequest};
@@ -12,6 +11,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Value as JsonValue, json};
 use tonic::Request as GrpcRequest;
+use tonic::codegen::async_trait;
 
 use gestalt_plugin_sdk::{Operation, Provider, Request, Response, Router, ok};
 

--- a/sdk/rust/tests/transport.rs
+++ b/sdk/rust/tests/transport.rs
@@ -3,7 +3,6 @@ mod helpers;
 
 use std::sync::{Arc, Mutex};
 
-use async_trait::async_trait;
 use gestalt_plugin_sdk::proto::v1::provider_plugin_client::ProviderPluginClient;
 use gestalt_plugin_sdk::proto::v1::{
     ExecuteRequest, GetSessionCatalogRequest, PostConnectRequest, StartProviderRequest,
@@ -11,8 +10,10 @@ use gestalt_plugin_sdk::proto::v1::{
 use gestalt_plugin_sdk::{
     Catalog, CatalogOperation, Operation, Provider, Request, Response, Router, ok,
 };
+use hyper_util::rt::tokio::TokioIo;
 use tokio::net::UnixStream;
 use tonic::Code;
+use tonic::codegen::async_trait;
 use tonic::transport::Endpoint;
 use tower::service_fn;
 
@@ -112,7 +113,10 @@ async fn serves_provider_requests_over_unix_socket() {
         .expect("endpoint")
         .connect_with_connector(service_fn({
             let socket = socket.clone();
-            move |_| UnixStream::connect(socket.clone())
+            move |_| {
+                let socket = socket.clone();
+                async move { UnixStream::connect(socket).await.map(TokioIo::new) }
+            }
         }))
         .await
         .expect("connect channel");


### PR DESCRIPTION
## Summary
- Upgrades tonic (0.11 -> 0.14), prost (0.12 -> 0.14), and all related build-time crates (tonic-build, prost-build) to their latest major versions
- Removes the direct `async-trait` crate dependency -- the macro is now sourced from tonic's codegen re-export (`tonic::codegen::async_trait`) since tonic 0.14 still uses it internally for generated service traits
- Adapts to tonic 0.14 breaking changes: protobuf codegen moved to `tonic-prost-build`, generated code references `tonic-prost` for codec types, and `connect_with_connector` now requires hyper IO traits (solved with `hyper_util::rt::tokio::TokioIo`)
- Bumps tower (0.4 -> 0.5), adds hyper-util as a dev dependency, and updates the downstream provider-rust-datastore fixture for prost-types 0.14

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo test` -- all 10 tests pass (4 unit, 6 integration)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo check` passes for all 3 downstream test fixtures (provider-rust, provider-rust-auth, provider-rust-datastore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)