### PR TITLE
Fix docs search by correcting pagefind output directory

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build && pagefind --site out",
+    "build": "next build && pagefind --site out --output-subdir _pagefind",
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "lint": "next lint"


### PR DESCRIPTION
## Summary
- Pagefind v1.5.0 changed its default output subdirectory from `_pagefind` to `pagefind`, but nextra-theme-docs loads the search index from `/_pagefind/pagefind.js`
- This mismatch caused the deployed site search to fail with "Failed to load search index"
- Adding `--output-subdir _pagefind` to the build script restores the expected path

## Test plan
- [ ] Verify `out/_pagefind/pagefind.js` exists after local `npm run build`
- [ ] After deploy, confirm `https://gestaltd.ai/_pagefind/pagefind.js` returns 200
- [ ] Confirm search works on the deployed docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)