### PR TITLE
Add TypeScript SDK examples to provider docs

### DIFF
--- a/docs/content/providers/auth.mdx
+++ b/docs/content/providers/auth.mdx
@@ -27,7 +27,7 @@ The optional `auth.config_schema_path` field points to a JSON Schema that valida
 
 An auth provider implements three methods: `Configure`, `BeginLogin`, and `CompleteLogin`. `BeginLogin` receives the callback URL and a host-generated state parameter and returns an authorization URL that Gestalt redirects the user to. `CompleteLogin` receives the query parameters from the identity provider callback and returns the authenticated user's identity.
 
-<Tabs items={['Go', 'Python', 'Rust']}>
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
     package main
@@ -172,6 +172,37 @@ An auth provider implements three methods: `Configure`, `BeginLogin`, and `Compl
 
     gestalt::export_auth_provider!(constructor = MyAuth::default);
     ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```typescript
+    import { defineAuthProvider } from "@valon-technologies/gestalt";
+
+    let clientId = "";
+    let issuerUrl = "";
+
+    export const provider = defineAuthProvider({
+      configure(_name, config) {
+        clientId = config.client_id as string;
+        issuerUrl = config.issuer_url as string;
+      },
+      beginLogin(request) {
+        const authUrl = `${issuerUrl}/authorize?client_id=${clientId}&redirect_uri=${request.callbackUrl}&state=${request.hostState}&response_type=code`;
+        return { authorizationUrl: authUrl };
+      },
+      completeLogin(request) {
+        const code = request.query.code ?? "";
+        // Exchange code for tokens, extract user info.
+        return {
+          subject: "user-123",
+          email: "user@example.com",
+          emailVerified: true,
+          displayName: "Example User",
+        };
+      },
+    });
+    ```
+
+    Optional handlers: `validateExternalToken` for direct token validation, `sessionSettings` to control session lifetime.
   </Tabs.Tab>
 </Tabs>
 

--- a/docs/content/providers/datastores.mdx
+++ b/docs/content/providers/datastores.mdx
@@ -27,7 +27,7 @@ The optional `datastore.config_schema_path` field points to a JSON Schema that v
 
 A datastore provider is a larger interface than auth or integration providers. It composes user storage, integration token storage, and API token storage, plus `Migrate` for schema setup and `HealthCheck` for readiness probes.
 
-<Tabs items={['Go', 'Python', 'Rust']}>
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
     package main
@@ -170,6 +170,39 @@ A datastore provider is a larger interface than auth or integration providers. I
     ```
 
     OAuth registration methods (`get_oauth_registration`, `put_oauth_registration`, `delete_oauth_registration`) have default implementations that return unimplemented errors. Override them to support MCP OAuth.
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```typescript
+    import { defineDatastoreProvider, type StoredUser, type StoredIntegrationToken, type StoredAPIToken } from "@valon-technologies/gestalt";
+
+    export const provider = defineDatastoreProvider({
+      configure(_name, config) {
+        // Initialize database connection from config.dsn
+      },
+      migrate() {
+        // Create users, integration_tokens, and api_tokens tables.
+      },
+
+      // UserStore
+      getUser(id) { /* ... */ },
+      findOrCreateUser(email) { /* ... */ },
+
+      // IntegrationTokenStore (tokens are pre-sealed by the host)
+      putIntegrationToken(token) { /* ... */ },
+      getIntegrationToken(userId, integration, connection, instance) { /* ... */ },
+      listIntegrationTokens(userId, integration, connection) { /* ... */ },
+      deleteIntegrationToken(id) { /* ... */ },
+
+      // APITokenStore (tokens are SHA-256 hashed, not encrypted)
+      putApiToken(token) { /* ... */ },
+      getApiTokenByHash(hashedToken) { /* ... */ },
+      listApiTokens(userId) { /* ... */ },
+      revokeApiToken(userId, id) { /* ... */ },
+      revokeAllApiTokens(userId) { /* ... */ },
+    });
+    ```
+
+    Optional handlers: `getOAuthRegistration`, `putOAuthRegistration`, `deleteOAuthRegistration` for MCP OAuth dynamic client registration.
   </Tabs.Tab>
 </Tabs>
 

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -31,13 +31,14 @@ Providers run in their own process. They cannot access the host process memory, 
 
 ## SDK support
 
-Gestalt ships SDKs for three languages:
+Gestalt ships SDKs for four languages:
 
 - **Go** (`sdk/go`)
 - **Python** (`sdk/python`)
 - **Rust** (`sdk/rust`)
+- **TypeScript** (`@valon-technologies/gestalt`)
 
-The underlying protocol is gRPC, so other languages are possible, but the documented authoring flow targets Go, Python, and Rust.
+The underlying protocol is gRPC, so other languages are possible, but the documented authoring flow targets Go, Python, Rust, and TypeScript.
 
 ## Operation ID conventions
 

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -52,7 +52,7 @@ The manifest stays the source of truth for display name, description, auth, the 
 
 ## Creating a project
 
-<Tabs items={['Go', 'Python', 'Rust']}>
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     You need Go 1.26+ and a running `gestaltd` instance for testing.
 
@@ -137,13 +137,46 @@ The manifest stays the source of truth for display name, description, auth, the 
 
     Use the `sdk/rust/v*` tag that matches the SDK release you want to target.
   </Tabs.Tab>
+  <Tabs.Tab>
+    You need Bun (or Node.js 22+) and a running `gestaltd` instance for testing.
+
+    ```sh
+    mkdir my-plugin && cd my-plugin
+    bun init
+    bun add @valon-technologies/gestalt
+    ```
+
+    Recommended layout:
+
+    ```text
+    my-plugin/
+      package.json
+      plugin.yaml
+      provider.ts
+    ```
+
+    Point `package.json` at the module that Gestalt should load:
+
+    ```json
+    {
+      "name": "my-plugin",
+      "type": "module",
+      "dependencies": {
+        "@valon-technologies/gestalt": "0.0.1-alpha.1"
+      },
+      "gestalt": {
+        "plugin": "./provider.ts#plugin"
+      }
+    }
+    ```
+  </Tabs.Tab>
 </Tabs>
 
 ## Defining operations
 
 Operations are the callable units of a plugin. Each operation has an ID, an HTTP method, input and output types, and a handler function. You do not write an entrypoint. Gestalt synthesizes the executable wrapper automatically for local source execution and release.
 
-<Tabs items={['Go', 'Python', 'Rust']}>
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
     package provider
@@ -311,6 +344,36 @@ Operations are the callable units of a plugin. Each operation has an ID, an HTTP
     gestalt::export_provider!(constructor = new, router = router);
     ```
   </Tabs.Tab>
+  <Tabs.Tab>
+    ```typescript
+    import { definePlugin, ok, operation, s } from "@valon-technologies/gestalt";
+
+    let greeting = "Hello";
+
+    export const plugin = definePlugin({
+      configure(_name, config) {
+        greeting = (config.greeting as string) ?? "Hello";
+      },
+      operations: [
+        operation({
+          id: "greet",
+          method: "GET",
+          description: "Return a greeting message",
+          readOnly: true,
+          input: s.object({
+            name: s.optional(s.string({ description: "Name to greet", default: "World" })),
+          }),
+          output: s.object({
+            message: s.string(),
+          }),
+          handler(input) {
+            return ok({ message: `${greeting}, ${input.name}!` });
+          },
+        }),
+      ],
+    });
+    ```
+  </Tabs.Tab>
 </Tabs>
 
 By default, input decode failures return a structured `400` response, and unhandled errors return a structured `500` response. Return a non-2xx response explicitly when the operation wants to signal a deliberate application-level error.
@@ -319,7 +382,7 @@ By default, input decode failures return a structured `400` response, and unhand
 
 The router derives catalog parameters from the input type. Fields are required by default unless marked optional. Nested types are emitted as `object` parameters and collections as `array`.
 
-<Tabs items={['Go', 'Python', 'Rust']}>
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
     type SearchInput struct {
@@ -361,13 +424,28 @@ The router derives catalog parameters from the input type. Fields are required b
 
     Fields are required unless you model them as `Option<T>` or provide a serde default. Use `schemars(description = "...")` for catalog descriptions and serde defaults for scalar defaults.
   </Tabs.Tab>
+  <Tabs.Tab>
+    ```typescript
+    import { s } from "@valon-technologies/gestalt";
+
+    const searchInput = s.object({
+      query: s.string({ description: "Search query" }),
+      max_items: s.optional(s.integer({ description: "Maximum results", default: 10 })),
+      filters: s.optional(s.object({
+        status: s.optional(s.string()),
+      })),
+    });
+    ```
+
+    Fields are required by default. Wrap with `s.optional()` for optional fields. Use `s.object()` for nested types and `s.array()` for collections.
+  </Tabs.Tab>
 </Tabs>
 
 ## Dynamic catalogs
 
 By default, the operation catalog is static and materialized at startup. If your plugin needs to expose different operations depending on the caller's credentials or runtime state, implement a session catalog.
 
-<Tabs items={['Go', 'Python', 'Rust']}>
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     Implement the `SessionCatalogProvider` interface on your provider:
 
@@ -438,6 +516,24 @@ By default, the operation catalog is static and materialized at startup. If your
             }))
         }
     }
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    Export a `sessionCatalog` function from your plugin definition:
+
+    ```typescript
+    export const plugin = definePlugin({
+      sessionCatalog(request) {
+        return {
+          name: "my-plugin-session",
+          displayName: request.token,
+          operations: [
+            { id: "search_private", method: "POST", readOnly: true },
+          ],
+        };
+      },
+      operations: [/* ... */],
+    });
     ```
   </Tabs.Tab>
 </Tabs>

--- a/docs/content/providers/releasing.mdx
+++ b/docs/content/providers/releasing.mdx
@@ -32,7 +32,7 @@ Executable source packages stay language-native. Gestalt loads the provider
 from the package root, then synthesizes the runnable wrapper during local
 source execution and release packaging.
 
-<Tabs items={['Go', 'Python', 'Rust']}>
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```text
     my-plugin/
@@ -87,6 +87,27 @@ source execution and release packaging.
     schemars = { version = "0.8", features = ["derive"] }
     serde = { version = "1", features = ["derive"] }
     serde_json = "1"
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```text
+    my-plugin/
+      package.json
+      plugin.yaml
+      provider.ts
+    ```
+
+    ```json
+    {
+      "name": "my-plugin",
+      "type": "module",
+      "dependencies": {
+        "@valon-technologies/gestalt": "0.0.1-alpha.1"
+      },
+      "gestalt": {
+        "plugin": "./provider.ts#plugin"
+      }
+    }
     ```
   </Tabs.Tab>
 </Tabs>
@@ -158,9 +179,9 @@ Run this from the provider source directory. It produces release archives and wr
 
 Release tags are derived from the package path after the repository. For example, `source: github.com/acme/plugins/catalog/support-api` releases from the tag `plugins/catalog/support-api/v0.1.0`.
 
-For executable Go, Rust, and Python integration source plugins, `provider release`
+For executable Go, Python, Rust, and TypeScript integration source plugins, `provider release`
 materializes the executable catalog automatically and builds the host-platform
-artifact by default. Go and Rust auth/datastore source packages use the same
+artifact by default. Auth and datastore source packages use the same
 release flow without catalog generation. Pass `--platform` with a
 comma-separated list such as
 `--platform linux/amd64/glibc,linux/amd64/musl,darwin/arm64` to build explicit

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -17,7 +17,7 @@
 
 | Command | Purpose |
 | --- | --- |
-| `gestaltd provider release --version VERSION` | Build and package a provider release. Go, Rust, and Python integration source plugins default to the host platform; Go and Rust auth/datastore source packages do too. Pass `--platform ...` with `os/arch[/libc]` targets or `--platform all` for multi-platform builds. |
+| `gestaltd provider release --version VERSION` | Build and package a provider release. Go, Python, Rust, and TypeScript source plugins default to the host platform. Pass `--platform ...` with `os/arch[/libc]` targets or `--platform all` for multi-platform builds. |
 
 ## Examples
 

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -478,9 +478,9 @@ Manifest paths must stay inside the package. `source` and `version` are required
 
 A connection using `mcp_oauth` auth requires the plugin to declare an MCP surface (via `mcp_url` or an equivalent). Manifests that set `auth.type: mcp_oauth` without an MCP surface fail validation.
 
-When an executable plugin defines helper operations in Go, Rust, or Python, Gestalt materializes the executable catalog automatically during local source-plugin execution and `provider release`. Auth and datastore source packages use the same release flow for Go and Rust, but they do not generate catalogs. See [Plugins](/providers/plugins) for the end-to-end authoring flow.
+When an executable plugin defines operations in Go, Python, Rust, or TypeScript, Gestalt materializes the executable catalog automatically during local source-plugin execution and `provider release`. Auth and datastore source packages use the same release flow without catalog generation. See [Plugins](/providers/plugins) for the end-to-end authoring flow.
 
-<Tabs items={['Go', 'Python', 'Rust']}>
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```text
     my-plugin/
@@ -515,6 +515,22 @@ When an executable plugin defines helper operations in Go, Rust, or Python, Gest
     gestalt::export_provider!(constructor = new, router = router);
     ```
   </Tabs.Tab>
+  <Tabs.Tab>
+    ```text
+    my-plugin/
+      package.json
+      plugin.yaml
+      provider.ts
+    ```
+
+    ```json
+    {
+      "gestalt": {
+        "plugin": "./provider.ts#plugin"
+      }
+    }
+    ```
+  </Tabs.Tab>
 </Tabs>
 
 Release-only build steps can be declared in source manifests with `release.build`.
@@ -544,4 +560,4 @@ Build a release from a provider source directory:
 gestaltd provider release --version 1.2.3
 ```
 
-`gestaltd provider release` preserves the source manifest format, so `plugin.yaml` stays YAML and `plugin.json` stays JSON in the release archive. For executable Go, Rust, and Python integration plugins, release materializes the executable catalog automatically before packaging. Python source plugins load the module declared in `[tool.gestalt].plugin`, while Go and Rust source plugins synthesize the executable wrapper from the source package itself. Auth and datastore source packages support the same release flow for Go and Rust, but they do not generate catalogs. Source packages build the host-platform artifact by default. Pass `--platform` for an explicit `os/arch[/libc]` target list, or `--platform all` in CI to build the full supported release matrix.
+`gestaltd provider release` preserves the source manifest format, so `plugin.yaml` stays YAML and `plugin.json` stays JSON in the release archive. For executable Go, Python, Rust, and TypeScript integration plugins, release materializes the executable catalog automatically before packaging. Auth and datastore source packages use the same release flow without catalog generation. Source packages build the host-platform artifact by default. Pass `--platform` for an explicit `os/arch[/libc]` target list, or `--platform all` in CI to build the full supported release matrix.

--- a/docs/content/troubleshooting.mdx
+++ b/docs/content/troubleshooting.mdx
@@ -42,7 +42,7 @@ When a plugin fails to start, check that the binary exists at the expected path,
 
 Common source-package checks:
 
-<Tabs items={['Go', 'Python', 'Rust']}>
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     Verify the package builds from the plugin root:
 
@@ -69,6 +69,15 @@ Common source-package checks:
     ```
 
     The plugin root needs a real `Cargo.toml` package with a `[package]` section, not just a workspace manifest, and `src/lib.rs` should export the provider with `gestalt::export_provider!(...)`, `gestalt::export_auth_provider!(...)`, or `gestalt::export_datastore_provider!(...)`.
+  </Tabs.Tab>
+  <Tabs.Tab>
+    Verify the module resolves from the plugin root:
+
+    ```sh
+    bun run -e "import('./provider.ts')"
+    ```
+
+    Confirm `package.json` has a `gestalt.plugin` or `gestalt.provider` entry pointing at the correct `./file.ts#export` target. The target path must start with `./` and the export name must match a named export in the module.
   </Tabs.Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

Adds TypeScript as the fourth language tab across all provider documentation: integration plugins, auth, datastores, releasing, troubleshooting, plugin manifests, and server CLI reference.

8 files, 223 insertions. Uses `definePlugin()`, `defineAuthProvider()`, `defineDatastoreProvider()` from `@valon-technologies/gestalt` with `s.*` schema builders and `package.json` gestalt config.

## Test plan

- [x] `next build` passes
- [ ] Browse all provider pages and verify TypeScript tabs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)