### PR TITLE
Support manifest auth_mapping for manual auth

### DIFF
--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -112,6 +112,29 @@ The `auth.type` field on a connection accepts these values:
 | `manual` | Custom credential fields. Define `credentials` to describe each field. |
 | `none` | No authentication. |
 
+Manual auth in provider manifests also supports `auth_mapping`, using the same `value` / `valueFrom.credentialFieldRef.name` shape as deploy config.
+
+```yaml
+plugin:
+  auth:
+    type: manual
+    credentials:
+      - name: organization_id
+        label: Organization ID
+      - name: api_key
+        label: API Key
+    auth_mapping:
+      basic:
+        username:
+          valueFrom:
+            credentialFieldRef:
+              name: organization_id
+        password:
+          valueFrom:
+            credentialFieldRef:
+              name: api_key
+```
+
 ### Pagination
 
 Plugin-level pagination configuration applies to all operations by default. Individual operations can override this through `allowed_operations`.

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -508,7 +508,8 @@ func TestE2EManifestManualAuthMappingValueFromBasicAuth(t *testing.T) {
 		upstreamAuth.Store(r.Header.Get("Authorization"))
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"auth": r.Header.Get("Authorization"),
+			"auth":      r.Header.Get("Authorization"),
+			"x_app_key": r.Header.Get("X-App-Key"),
 		})
 	}))
 	testutil.CloseOnCleanup(t, upstream)
@@ -552,7 +553,14 @@ plugin:
         label: Organization ID
       - name: api_key
         label: API Key
+      - name: app_key
+        label: App Key
     auth_mapping:
+      headers:
+        X-App-Key:
+          valueFrom:
+            credentialFieldRef:
+              name: app_key
       basic:
         username:
           valueFrom:
@@ -612,11 +620,11 @@ plugins:
 			t.Fatalf("unexpected integrations payload: %+v", integrations)
 		}
 		fields := integrations[0].Connections[0].CredentialFields
-		if len(fields) != 2 || fields[0].Name != "organization_id" || fields[1].Name != "api_key" {
-			t.Fatalf("credential fields = %+v, want organization_id and api_key", fields)
+		if len(fields) != 3 || fields[0].Name != "organization_id" || fields[1].Name != "api_key" || fields[2].Name != "app_key" {
+			t.Fatalf("credential fields = %+v, want organization_id, api_key, and app_key", fields)
 		}
 
-		connectReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/auth/connect-manual", strings.NewReader(`{"integration":"mt","credentials":{"organization_id":"org-123","api_key":"api-key-123"}}`))
+		connectReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/auth/connect-manual", strings.NewReader(`{"integration":"mt","credentials":{"organization_id":"org-123","api_key":"api-key-123","app_key":"app-key-123"}}`))
 		connectReq.Header.Set("Authorization", "Bearer alice")
 		connectReq.Header.Set("Content-Type", "application/json")
 		connectResp, err := http.DefaultClient.Do(connectReq)
@@ -651,6 +659,9 @@ plugins:
 		if result["auth"] != wantAuth {
 			t.Fatalf("invoke auth = %v, want %v", result["auth"], wantAuth)
 		}
+		if result["x_app_key"] != "app-key-123" {
+			t.Fatalf("invoke x_app_key = %v, want %v", result["x_app_key"], "app-key-123")
+		}
 		if got, _ := upstreamAuth.Load().(string); got != wantAuth {
 			t.Fatalf("upstream auth = %q, want %q", got, wantAuth)
 		}
@@ -667,7 +678,8 @@ func TestE2EDeclarativeManifestManualAuthMappingValueFromBasicAuth(t *testing.T)
 		upstreamAuth.Store(r.Header.Get("Authorization"))
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"auth": r.Header.Get("Authorization"),
+			"auth":      r.Header.Get("Authorization"),
+			"x_app_key": r.Header.Get("X-App-Key"),
 		})
 	}))
 	testutil.CloseOnCleanup(t, upstream)
@@ -690,7 +702,14 @@ plugin:
         label: Organization ID
       - name: api_key
         label: API Key
+      - name: app_key
+        label: App Key
     auth_mapping:
+      headers:
+        X-App-Key:
+          valueFrom:
+            credentialFieldRef:
+              name: app_key
       basic:
         username:
           valueFrom:
@@ -727,7 +746,7 @@ plugins:
 	}
 
 	serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
-		connectReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/auth/connect-manual", strings.NewReader(`{"integration":"mt","credentials":{"organization_id":"org-456","api_key":"api-key-456"}}`))
+		connectReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/auth/connect-manual", strings.NewReader(`{"integration":"mt","credentials":{"organization_id":"org-456","api_key":"api-key-456","app_key":"app-key-456"}}`))
 		connectReq.Header.Set("Authorization", "Bearer alice")
 		connectReq.Header.Set("Content-Type", "application/json")
 		connectResp, err := http.DefaultClient.Do(connectReq)
@@ -761,6 +780,9 @@ plugins:
 		wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("org-456:api-key-456"))
 		if result["auth"] != wantAuth {
 			t.Fatalf("invoke auth = %v, want %v", result["auth"], wantAuth)
+		}
+		if result["x_app_key"] != "app-key-456" {
+			t.Fatalf("invoke x_app_key = %v, want %v", result["x_app_key"], "app-key-456")
 		}
 		if got, _ := upstreamAuth.Load().(string); got != wantAuth {
 			t.Fatalf("upstream auth = %q, want %q", got, wantAuth)

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -498,6 +498,278 @@ plugins:
 	})
 }
 
+func TestE2EManifestManualAuthMappingValueFromBasicAuth(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	port := allocateTestPort(t)
+
+	var upstreamAuth atomic.Value
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamAuth.Store(r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"auth": r.Header.Get("Authorization"),
+		})
+	}))
+	testutil.CloseOnCleanup(t, upstream)
+
+	pluginDir := filepath.Join(dir, "manifest-basic-plugin")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll plugin dir: %v", err)
+	}
+	writeTestFile(t, pluginDir, "openapi.yaml", []byte(fmt.Sprintf(`openapi: 3.0.0
+info:
+  title: Manifest Basic Test
+  version: 1.0.0
+servers:
+  - url: %s
+components:
+  securitySchemes:
+    basic_auth:
+      type: http
+      scheme: basic
+security:
+  - basic_auth: []
+paths:
+  /whoami:
+    get:
+      operationId: whoami
+      responses:
+        '200':
+          description: ok
+`, upstream.URL)), 0o644)
+	writeTestFile(t, pluginDir, "plugin.yaml", []byte(`
+source: github.com/test/plugins/manifest-basic
+version: 0.0.1-alpha.1
+display_name: Manifest Basic Test
+kinds:
+  - plugin
+plugin:
+  auth:
+    type: manual
+    credentials:
+      - name: organization_id
+        label: Organization ID
+      - name: api_key
+        label: API Key
+    auth_mapping:
+      basic:
+        username:
+          valueFrom:
+            credentialFieldRef:
+              name: organization_id
+        password:
+          valueFrom:
+            credentialFieldRef:
+              name: api_key
+  openapi: openapi.yaml
+`), 0o644)
+
+	manifestPath, err := pluginpkg.FindManifestFile(pluginDir)
+	if err != nil {
+		t.Fatalf("FindManifestFile: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := authDatastoreConfigYAML(t, dir, "session-auth", "sqlite", filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`server:
+  port: %d
+  encryption_key: test-e2e-key
+plugins:
+  mt:
+    provider:
+      source:
+        path: %s
+`, port, manifestPath)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
+		listReq, _ := http.NewRequest(http.MethodGet, baseURL+"/api/v1/integrations", nil)
+		listReq.Header.Set("Authorization", "Bearer alice")
+		listResp, err := http.DefaultClient.Do(listReq)
+		if err != nil {
+			t.Fatalf("list integrations: %v", err)
+		}
+		defer func() { _ = listResp.Body.Close() }()
+		if listResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(listResp.Body)
+			t.Fatalf("list integrations status = %d: %s", listResp.StatusCode, body)
+		}
+
+		var integrations []struct {
+			Name        string `json:"name"`
+			Connections []struct {
+				CredentialFields []struct {
+					Name string `json:"name"`
+				} `json:"credential_fields"`
+			} `json:"connections"`
+		}
+		if err := json.NewDecoder(listResp.Body).Decode(&integrations); err != nil {
+			t.Fatalf("decode integrations: %v", err)
+		}
+		if len(integrations) != 1 || integrations[0].Name != "mt" {
+			t.Fatalf("unexpected integrations payload: %+v", integrations)
+		}
+		fields := integrations[0].Connections[0].CredentialFields
+		if len(fields) != 2 || fields[0].Name != "organization_id" || fields[1].Name != "api_key" {
+			t.Fatalf("credential fields = %+v, want organization_id and api_key", fields)
+		}
+
+		connectReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/auth/connect-manual", strings.NewReader(`{"integration":"mt","credentials":{"organization_id":"org-123","api_key":"api-key-123"}}`))
+		connectReq.Header.Set("Authorization", "Bearer alice")
+		connectReq.Header.Set("Content-Type", "application/json")
+		connectResp, err := http.DefaultClient.Do(connectReq)
+		if err != nil {
+			t.Fatalf("connect manual: %v", err)
+		}
+		defer func() { _ = connectResp.Body.Close() }()
+		if connectResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(connectResp.Body)
+			t.Fatalf("connect manual status = %d: %s", connectResp.StatusCode, body)
+		}
+
+		invokeReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/mt/whoami", strings.NewReader(`{}`))
+		invokeReq.Header.Set("Authorization", "Bearer alice")
+		invokeReq.Header.Set("Content-Type", "application/json")
+		invokeResp, err := http.DefaultClient.Do(invokeReq)
+		if err != nil {
+			t.Fatalf("invoke whoami: %v", err)
+		}
+		defer func() { _ = invokeResp.Body.Close() }()
+		if invokeResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(invokeResp.Body)
+			t.Fatalf("invoke whoami status = %d: %s", invokeResp.StatusCode, body)
+		}
+
+		var result map[string]any
+		if err := json.NewDecoder(invokeResp.Body).Decode(&result); err != nil {
+			t.Fatalf("decode invoke response: %v", err)
+		}
+
+		wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("org-123:api-key-123"))
+		if result["auth"] != wantAuth {
+			t.Fatalf("invoke auth = %v, want %v", result["auth"], wantAuth)
+		}
+		if got, _ := upstreamAuth.Load().(string); got != wantAuth {
+			t.Fatalf("upstream auth = %q, want %q", got, wantAuth)
+		}
+	})
+}
+
+func TestE2EDeclarativeManifestManualAuthMappingValueFromBasicAuth(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	port := allocateTestPort(t)
+
+	var upstreamAuth atomic.Value
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamAuth.Store(r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"auth": r.Header.Get("Authorization"),
+		})
+	}))
+	testutil.CloseOnCleanup(t, upstream)
+
+	pluginDir := filepath.Join(dir, "declarative-basic-plugin")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll plugin dir: %v", err)
+	}
+	writeTestFile(t, pluginDir, "plugin.yaml", []byte(fmt.Sprintf(`
+source: github.com/test/plugins/declarative-basic
+version: 0.0.1-alpha.1
+display_name: Declarative Basic Test
+kinds:
+  - plugin
+plugin:
+  auth:
+    type: manual
+    credentials:
+      - name: organization_id
+        label: Organization ID
+      - name: api_key
+        label: API Key
+    auth_mapping:
+      basic:
+        username:
+          valueFrom:
+            credentialFieldRef:
+              name: organization_id
+        password:
+          valueFrom:
+            credentialFieldRef:
+              name: api_key
+  base_url: %s
+  operations:
+    - name: whoami
+      method: GET
+      path: /whoami
+`, upstream.URL)), 0o644)
+
+	manifestPath, err := pluginpkg.FindManifestFile(pluginDir)
+	if err != nil {
+		t.Fatalf("FindManifestFile: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := authDatastoreConfigYAML(t, dir, "session-auth", "sqlite", filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`server:
+  port: %d
+  encryption_key: test-e2e-key
+plugins:
+  mt:
+    provider:
+      source:
+        path: %s
+`, port, manifestPath)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
+		connectReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/auth/connect-manual", strings.NewReader(`{"integration":"mt","credentials":{"organization_id":"org-456","api_key":"api-key-456"}}`))
+		connectReq.Header.Set("Authorization", "Bearer alice")
+		connectReq.Header.Set("Content-Type", "application/json")
+		connectResp, err := http.DefaultClient.Do(connectReq)
+		if err != nil {
+			t.Fatalf("connect manual: %v", err)
+		}
+		defer func() { _ = connectResp.Body.Close() }()
+		if connectResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(connectResp.Body)
+			t.Fatalf("connect manual status = %d: %s", connectResp.StatusCode, body)
+		}
+
+		invokeReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/mt/whoami", strings.NewReader(`{}`))
+		invokeReq.Header.Set("Authorization", "Bearer alice")
+		invokeReq.Header.Set("Content-Type", "application/json")
+		invokeResp, err := http.DefaultClient.Do(invokeReq)
+		if err != nil {
+			t.Fatalf("invoke whoami: %v", err)
+		}
+		defer func() { _ = invokeResp.Body.Close() }()
+		if invokeResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(invokeResp.Body)
+			t.Fatalf("invoke whoami status = %d: %s", invokeResp.StatusCode, body)
+		}
+
+		var result map[string]any
+		if err := json.NewDecoder(invokeResp.Body).Decode(&result); err != nil {
+			t.Fatalf("decode invoke response: %v", err)
+		}
+
+		wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("org-456:api-key-456"))
+		if result["auth"] != wantAuth {
+			t.Fatalf("invoke auth = %v, want %v", result["auth"], wantAuth)
+		}
+		if got, _ := upstreamAuth.Load().(string); got != wantAuth {
+			t.Fatalf("upstream auth = %q, want %q", got, wantAuth)
+		}
+	})
+}
+
 func TestE2EInitServeLockedGoldenPath(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -498,9 +498,8 @@ plugins:
 	})
 }
 
+//nolint:paralleltest // Spawns gestaltd and is flaky under package-wide parallel load in CI.
 func TestE2EManifestManualAuthMappingValueFromBasicAuth(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 	port := allocateTestPort(t)
 
@@ -658,9 +657,8 @@ plugins:
 	})
 }
 
+//nolint:paralleltest // Spawns gestaltd and is flaky under package-wide parallel load in CI.
 func TestE2EDeclarativeManifestManualAuthMappingValueFromBasicAuth(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 	port := allocateTestPort(t)
 

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -596,6 +596,11 @@ plugins:
 		t.Fatalf("write config: %v", err)
 	}
 
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
 	serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
 		listReq, _ := http.NewRequest(http.MethodGet, baseURL+"/api/v1/integrations", nil)
 		listReq.Header.Set("Authorization", "Bearer alice")

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -416,6 +416,11 @@ plugins:
 		t.Fatalf("write config: %v", err)
 	}
 
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
 	serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
 		listReq, _ := http.NewRequest(http.MethodGet, baseURL+"/api/v1/integrations", nil)
 		listReq.Header.Set("Authorization", "Bearer alice")
@@ -543,8 +548,6 @@ paths:
 source: github.com/test/plugins/manifest-basic
 version: 0.0.1-alpha.1
 display_name: Manifest Basic Test
-kinds:
-  - plugin
 plugin:
   auth:
     type: manual
@@ -580,7 +583,8 @@ plugin:
 
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := authDatastoreConfigYAML(t, dir, "session-auth", "sqlite", filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`server:
-  port: %d
+  public:
+    port: %d
   encryption_key: test-e2e-key
 plugins:
   mt:
@@ -692,8 +696,6 @@ func TestE2EDeclarativeManifestManualAuthMappingValueFromBasicAuth(t *testing.T)
 source: github.com/test/plugins/declarative-basic
 version: 0.0.1-alpha.1
 display_name: Declarative Basic Test
-kinds:
-  - plugin
 plugin:
   auth:
     type: manual
@@ -733,7 +735,8 @@ plugin:
 
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := authDatastoreConfigYAML(t, dir, "session-auth", "sqlite", filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`server:
-  port: %d
+  public:
+    port: %d
   encryption_key: test-e2e-key
 plugins:
   mt:
@@ -743,6 +746,11 @@ plugins:
 `, port, manifestPath)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
 	}
 
 	serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
@@ -1388,9 +1396,8 @@ func TestE2EInitServeLockedSplitManagementListener(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // Spawns gestaltd and is flaky under package-wide parallel load in CI.
 func TestE2EBareGestaltdAutoInit(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 	pluginDir := setupPluginDir(t, dir)
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -363,29 +363,11 @@ type ConnectionAuthDef struct {
 }
 
 type CredentialFieldDef = pluginmanifestv1.CredentialField
-
-type AuthMappingDef struct {
-	Headers map[string]AuthValueDef `yaml:"headers"`
-	Basic   *BasicAuthMappingDef    `yaml:"basic"`
-}
-
-type BasicAuthMappingDef struct {
-	Username AuthValueDef `yaml:"username"`
-	Password AuthValueDef `yaml:"password"`
-}
-
-type AuthValueDef struct {
-	Value     string            `yaml:"value"`
-	ValueFrom *AuthValueFromDef `yaml:"valueFrom"`
-}
-
-type AuthValueFromDef struct {
-	CredentialFieldRef *CredentialFieldRefDef `yaml:"credentialFieldRef"`
-}
-
-type CredentialFieldRefDef struct {
-	Name string `yaml:"name"`
-}
+type AuthMappingDef = pluginmanifestv1.AuthMapping
+type BasicAuthMappingDef = pluginmanifestv1.BasicAuthMapping
+type AuthValueDef = pluginmanifestv1.AuthValue
+type AuthValueFromDef = pluginmanifestv1.AuthValueFrom
+type CredentialFieldRefDef = pluginmanifestv1.CredentialFieldRef
 
 type ConnectionParamDef = pluginmanifestv1.ProviderConnectionParam
 
@@ -529,8 +511,39 @@ func ManifestAuthToConnectionAuthDef(auth *pluginmanifestv1.ProviderAuth) Connec
 		AccessTokenPath:     auth.AccessTokenPath,
 		TokenMetadata:       slices.Clone(auth.TokenMetadata),
 		Credentials:         slices.Clone(auth.Credentials),
+		AuthMapping:         cloneManifestAuthMapping(auth.AuthMapping),
 	}
 	return out
+}
+
+func cloneManifestAuthMapping(src *pluginmanifestv1.AuthMapping) *AuthMappingDef {
+	if src == nil {
+		return nil
+	}
+	dst := &AuthMappingDef{}
+	if len(src.Headers) > 0 {
+		dst.Headers = make(map[string]AuthValueDef, len(src.Headers))
+		for name, value := range src.Headers {
+			dst.Headers[name] = cloneManifestAuthValue(value)
+		}
+	}
+	if src.Basic != nil {
+		dst.Basic = &BasicAuthMappingDef{
+			Username: cloneManifestAuthValue(src.Basic.Username),
+			Password: cloneManifestAuthValue(src.Basic.Password),
+		}
+	}
+	return dst
+}
+
+func cloneManifestAuthValue(src pluginmanifestv1.AuthValue) AuthValueDef {
+	dst := AuthValueDef{Value: src.Value}
+	if src.ValueFrom != nil && src.ValueFrom.CredentialFieldRef != nil {
+		dst.ValueFrom = &AuthValueFromDef{
+			CredentialFieldRef: &CredentialFieldRefDef{Name: src.ValueFrom.CredentialFieldRef.Name},
+		}
+	}
+	return dst
 }
 
 func EffectivePluginConnectionDef(plugin *PluginDef, manifestPlugin *pluginmanifestv1.Plugin) ConnectionDef {

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -511,12 +511,12 @@ func ManifestAuthToConnectionAuthDef(auth *pluginmanifestv1.ProviderAuth) Connec
 		AccessTokenPath:     auth.AccessTokenPath,
 		TokenMetadata:       slices.Clone(auth.TokenMetadata),
 		Credentials:         slices.Clone(auth.Credentials),
-		AuthMapping:         cloneManifestAuthMapping(auth.AuthMapping),
+		AuthMapping:         CloneAuthMapping(auth.AuthMapping),
 	}
 	return out
 }
 
-func cloneManifestAuthMapping(src *pluginmanifestv1.AuthMapping) *AuthMappingDef {
+func CloneAuthMapping(src *AuthMappingDef) *AuthMappingDef {
 	if src == nil {
 		return nil
 	}
@@ -524,19 +524,19 @@ func cloneManifestAuthMapping(src *pluginmanifestv1.AuthMapping) *AuthMappingDef
 	if len(src.Headers) > 0 {
 		dst.Headers = make(map[string]AuthValueDef, len(src.Headers))
 		for name, value := range src.Headers {
-			dst.Headers[name] = cloneManifestAuthValue(value)
+			dst.Headers[name] = cloneAuthValue(value)
 		}
 	}
 	if src.Basic != nil {
 		dst.Basic = &BasicAuthMappingDef{
-			Username: cloneManifestAuthValue(src.Basic.Username),
-			Password: cloneManifestAuthValue(src.Basic.Password),
+			Username: cloneAuthValue(src.Basic.Username),
+			Password: cloneAuthValue(src.Basic.Password),
 		}
 	}
 	return dst
 }
 
-func cloneManifestAuthValue(src pluginmanifestv1.AuthValue) AuthValueDef {
+func cloneAuthValue(src AuthValueDef) AuthValueDef {
 	dst := AuthValueDef{Value: src.Value}
 	if src.ValueFrom != nil && src.ValueFrom.CredentialFieldRef != nil {
 		dst.ValueFrom = &AuthValueFromDef{

--- a/gestaltd/internal/pluginhost/declarative.go
+++ b/gestaltd/internal/pluginhost/declarative.go
@@ -12,6 +12,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/integration"
 	"github.com/valon-technologies/gestalt/server/internal/apiexec"
 	"github.com/valon-technologies/gestalt/server/internal/paraminterp"
+	"github.com/valon-technologies/gestalt/server/internal/provider"
 	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
 
@@ -163,6 +164,19 @@ func (p *DeclarativeProvider) Execute(ctx context.Context, operation string, par
 		}
 	}
 
+	authHeader := ""
+	if p.auth != nil && p.auth.AuthMapping != nil && (len(p.auth.AuthMapping.Headers) > 0 || p.auth.AuthMapping.Basic != nil) {
+		resolvedAuth, extraHeaders, err := provider.MappedCredentialParser(p.auth.AuthMapping)(token)
+		if err != nil {
+			return nil, err
+		}
+		authHeader = resolvedAuth
+		token = ""
+		for k, v := range extraHeaders {
+			headers[k] = v
+		}
+	}
+
 	req := apiexec.Request{
 		Method:        op.Method,
 		BaseURL:       baseURL,
@@ -170,6 +184,7 @@ func (p *DeclarativeProvider) Execute(ctx context.Context, operation string, par
 		Params:        bodyParams,
 		QueryParams:   queryParams,
 		CustomHeaders: headers,
+		AuthHeader:    authHeader,
 		Token:         token,
 		NoRetry:       true,
 	}

--- a/gestaltd/internal/pluginhost/declarative.go
+++ b/gestaltd/internal/pluginhost/declarative.go
@@ -172,6 +172,9 @@ func (p *DeclarativeProvider) Execute(ctx context.Context, operation string, par
 		}
 		authHeader = resolvedAuth
 		token = ""
+		if headers == nil && len(extraHeaders) > 0 {
+			headers = make(map[string]string, len(extraHeaders))
+		}
 		for k, v := range extraHeaders {
 			headers[k] = v
 		}

--- a/gestaltd/internal/pluginhost/secrets_client.go
+++ b/gestaltd/internal/pluginhost/secrets_client.go
@@ -39,7 +39,7 @@ func NewExecutableSecretManager(ctx context.Context, cfg SecretsExecConfig) (cor
 		return nil, err
 	}
 
-	runtimeClient := proto.NewPluginRuntimeClient(proc.conn)
+	runtimeClient := proto.NewProviderLifecycleClient(proc.conn)
 	secretsClient := proto.NewSecretsProviderClient(proc.conn)
 
 	_, err = configureRuntimePlugin(ctx, runtimeClient, proto.PluginKind_PLUGIN_KIND_SECRETS, cfg.Name, cfg.Config)

--- a/gestaltd/internal/provider/build.go
+++ b/gestaltd/internal/provider/build.go
@@ -238,9 +238,7 @@ func ApplyConnectionAuth(def *Definition, conn config.ConnectionDef) {
 	}
 	if len(o.Credentials) > 0 {
 		def.CredentialFields = make([]CredentialFieldDef, len(o.Credentials))
-		for i, cf := range o.Credentials {
-			def.CredentialFields[i] = CredentialFieldDef(cf)
-		}
+		copy(def.CredentialFields, o.Credentials)
 	}
 	if o.AuthMapping != nil {
 		def.AuthMapping = config.CloneAuthMapping(o.AuthMapping)

--- a/gestaltd/internal/provider/build.go
+++ b/gestaltd/internal/provider/build.go
@@ -128,40 +128,7 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 				return nil, fmt.Errorf("%s: auth_mapping.basic requires auth_style basic", def.Provider)
 			}
 		}
-		mapping := def.AuthMapping
-		base.TokenParser = func(token string) (string, map[string]string, error) {
-			var (
-				tokenData map[string]any
-				headers   map[string]string
-			)
-			if len(mapping.Headers) > 0 {
-				headers = make(map[string]string, len(mapping.Headers))
-				for headerName, value := range mapping.Headers {
-					resolved, err := resolveAuthValue(value, token, &tokenData)
-					if err != nil {
-						return "", nil, fmt.Errorf("auth_mapping.headers[%q]: %w", headerName, err)
-					}
-					headers[headerName] = resolved
-				}
-			}
-			authToken := ""
-			if mapping.Basic != nil {
-				username, err := resolveAuthValue(mapping.Basic.Username, token, &tokenData)
-				if err != nil {
-					return "", nil, fmt.Errorf("auth_mapping.basic.username: %w", err)
-				}
-				password, err := resolveAuthValue(mapping.Basic.Password, token, &tokenData)
-				if err != nil {
-					return "", nil, fmt.Errorf("auth_mapping.basic.password: %w", err)
-				}
-				credential := fmt.Sprintf("%s:%s", username, password)
-				authToken = "Basic " + base64.StdEncoding.EncodeToString([]byte(credential))
-			}
-			if len(headers) == 0 {
-				headers = nil
-			}
-			return authToken, headers, nil
-		}
+		base.TokenParser = MappedCredentialParser(def.AuthMapping)
 	case def.AuthHeader != "":
 		headerName := def.AuthHeader
 		base.TokenParser = func(token string) (string, map[string]string, error) {
@@ -291,6 +258,42 @@ func parseMappedToken(token string) (map[string]any, error) {
 		return nil, fmt.Errorf("parsing token as JSON for auth_mapping: %w", err)
 	}
 	return tokenData, nil
+}
+
+func MappedCredentialParser(mapping *AuthMappingDef) func(string) (string, map[string]string, error) {
+	return func(token string) (string, map[string]string, error) {
+		var (
+			tokenData map[string]any
+			headers   map[string]string
+		)
+		if len(mapping.Headers) > 0 {
+			headers = make(map[string]string, len(mapping.Headers))
+			for headerName, value := range mapping.Headers {
+				resolved, err := resolveAuthValue(value, token, &tokenData)
+				if err != nil {
+					return "", nil, fmt.Errorf("auth_mapping.headers[%q]: %w", headerName, err)
+				}
+				headers[headerName] = resolved
+			}
+		}
+		authToken := ""
+		if mapping.Basic != nil {
+			username, err := resolveAuthValue(mapping.Basic.Username, token, &tokenData)
+			if err != nil {
+				return "", nil, fmt.Errorf("auth_mapping.basic.username: %w", err)
+			}
+			password, err := resolveAuthValue(mapping.Basic.Password, token, &tokenData)
+			if err != nil {
+				return "", nil, fmt.Errorf("auth_mapping.basic.password: %w", err)
+			}
+			credential := fmt.Sprintf("%s:%s", username, password)
+			authToken = "Basic " + base64.StdEncoding.EncodeToString([]byte(credential))
+		}
+		if len(headers) == 0 {
+			headers = nil
+		}
+		return authToken, headers, nil
+	}
 }
 
 func resolveAuthValue(value AuthValueDef, token string, tokenData *map[string]any) (string, error) {

--- a/gestaltd/internal/provider/build.go
+++ b/gestaltd/internal/provider/build.go
@@ -239,16 +239,11 @@ func ApplyConnectionAuth(def *Definition, conn config.ConnectionDef) {
 	if len(o.Credentials) > 0 {
 		def.CredentialFields = make([]CredentialFieldDef, len(o.Credentials))
 		for i, cf := range o.Credentials {
-			def.CredentialFields[i] = CredentialFieldDef{
-				Name:        cf.Name,
-				Label:       cf.Label,
-				Description: cf.Description,
-				HelpURL:     cf.HelpURL,
-			}
+			def.CredentialFields[i] = CredentialFieldDef(cf)
 		}
 	}
 	if o.AuthMapping != nil {
-		def.AuthMapping = cloneConfigAuthMapping(o.AuthMapping)
+		def.AuthMapping = config.CloneAuthMapping(o.AuthMapping)
 	}
 }
 
@@ -321,36 +316,6 @@ func resolveAuthValue(value AuthValueDef, token string, tokenData *map[string]an
 		return "", fmt.Errorf("token field %q is missing or null", fieldName)
 	}
 	return fmt.Sprintf("%v", val), nil
-}
-
-func cloneConfigAuthMapping(src *config.AuthMappingDef) *AuthMappingDef {
-	if src == nil {
-		return nil
-	}
-	dst := &AuthMappingDef{}
-	if len(src.Headers) > 0 {
-		dst.Headers = make(map[string]AuthValueDef, len(src.Headers))
-		for name, value := range src.Headers {
-			dst.Headers[name] = cloneConfigAuthValue(value)
-		}
-	}
-	if src.Basic != nil {
-		dst.Basic = &BasicAuthMappingDef{
-			Username: cloneConfigAuthValue(src.Basic.Username),
-			Password: cloneConfigAuthValue(src.Basic.Password),
-		}
-	}
-	return dst
-}
-
-func cloneConfigAuthValue(src config.AuthValueDef) AuthValueDef {
-	dst := AuthValueDef{Value: src.Value}
-	if src.ValueFrom != nil && src.ValueFrom.CredentialFieldRef != nil {
-		dst.ValueFrom = &AuthValueFromDef{
-			CredentialFieldRef: &CredentialFieldRefDef{Name: src.ValueFrom.CredentialFieldRef.Name},
-		}
-	}
-	return dst
 }
 
 func setStr(dst *string, val string) {

--- a/gestaltd/internal/provider/definition.go
+++ b/gestaltd/internal/provider/definition.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
 
 type Definition struct {
@@ -93,28 +94,11 @@ type OperationDef struct {
 	Pagination  *PaginationDef  `yaml:"pagination" json:"pagination"`
 }
 
-type AuthMappingDef struct {
-	Headers map[string]AuthValueDef `yaml:"headers" json:"headers"`
-	Basic   *BasicAuthMappingDef    `yaml:"basic" json:"basic,omitempty"`
-}
-
-type BasicAuthMappingDef struct {
-	Username AuthValueDef `yaml:"username" json:"username"`
-	Password AuthValueDef `yaml:"password" json:"password"`
-}
-
-type AuthValueDef struct {
-	Value     string            `yaml:"value" json:"value,omitempty"`
-	ValueFrom *AuthValueFromDef `yaml:"valueFrom" json:"valueFrom,omitempty"`
-}
-
-type AuthValueFromDef struct {
-	CredentialFieldRef *CredentialFieldRefDef `yaml:"credentialFieldRef" json:"credentialFieldRef,omitempty"`
-}
-
-type CredentialFieldRefDef struct {
-	Name string `yaml:"name" json:"name"`
-}
+type AuthMappingDef = pluginmanifestv1.AuthMapping
+type BasicAuthMappingDef = pluginmanifestv1.BasicAuthMapping
+type AuthValueDef = pluginmanifestv1.AuthValue
+type AuthValueFromDef = pluginmanifestv1.AuthValueFrom
+type CredentialFieldRefDef = pluginmanifestv1.CredentialFieldRef
 
 type ValueSelectorDef struct {
 	Source string `yaml:"source" json:"source"`
@@ -131,12 +115,7 @@ type PaginationDef struct {
 	MaxPages     int               `yaml:"max_pages" json:"max_pages"`
 }
 
-type CredentialFieldDef struct {
-	Name        string `yaml:"name" json:"name"`
-	Label       string `yaml:"label" json:"label,omitempty"`
-	Description string `yaml:"description" json:"description,omitempty"`
-	HelpURL     string `yaml:"help_url" json:"help_url,omitempty"`
-}
+type CredentialFieldDef = pluginmanifestv1.CredentialField
 
 type ResponseMappingDef struct {
 	DataPath   string                `yaml:"data_path" json:"data_path"`

--- a/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -303,6 +303,97 @@
         }
       }
     },
+    "credential_field_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z][a-z0-9_]*$"
+        }
+      }
+    },
+    "auth_value_from": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "credentialFieldRef"
+      ],
+      "properties": {
+        "credentialFieldRef": {
+          "$ref": "#/$defs/credential_field_ref"
+        }
+      }
+    },
+    "auth_value": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "valueFrom": {
+          "$ref": "#/$defs/auth_value_from"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "value"
+          ],
+          "not": {
+            "required": [
+              "valueFrom"
+            ]
+          }
+        },
+        {
+          "required": [
+            "valueFrom"
+          ],
+          "not": {
+            "required": [
+              "value"
+            ]
+          }
+        }
+      ]
+    },
+    "basic_auth_mapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "username",
+        "password"
+      ],
+      "properties": {
+        "username": {
+          "$ref": "#/$defs/auth_value"
+        },
+        "password": {
+          "$ref": "#/$defs/auth_value"
+        }
+      }
+    },
+    "auth_mapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/auth_value"
+          }
+        },
+        "basic": {
+          "$ref": "#/$defs/basic_auth_mapping"
+        }
+      }
+    },
     "surfaces": {
       "type": "object",
       "additionalProperties": false,
@@ -579,6 +670,9 @@
               }
             }
           }
+        },
+        "auth_mapping": {
+          "$ref": "#/$defs/auth_mapping"
         }
       },
       "allOf": [

--- a/gestaltd/sdk/pluginmanifest/v1/types.go
+++ b/gestaltd/sdk/pluginmanifest/v1/types.go
@@ -197,6 +197,7 @@ type ProviderAuth struct {
 	AcceptHeader        string            `json:"accept_header,omitempty" yaml:"accept_header,omitempty"`
 	TokenMetadata       []string          `json:"token_metadata,omitempty" yaml:"token_metadata,omitempty"`
 	Credentials         []CredentialField `json:"credentials,omitempty" yaml:"credentials,omitempty"`
+	AuthMapping         *AuthMapping      `json:"auth_mapping,omitempty" yaml:"auth_mapping,omitempty"`
 }
 
 type CredentialField struct {
@@ -204,6 +205,29 @@ type CredentialField struct {
 	Label       string `json:"label,omitempty" yaml:"label,omitempty"`
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	HelpURL     string `json:"help_url,omitempty" yaml:"help_url,omitempty"`
+}
+
+type AuthMapping struct {
+	Headers map[string]AuthValue `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Basic   *BasicAuthMapping    `json:"basic,omitempty" yaml:"basic,omitempty"`
+}
+
+type BasicAuthMapping struct {
+	Username AuthValue `json:"username" yaml:"username"`
+	Password AuthValue `json:"password" yaml:"password"`
+}
+
+type AuthValue struct {
+	Value     string         `json:"value,omitempty" yaml:"value,omitempty"`
+	ValueFrom *AuthValueFrom `json:"valueFrom,omitempty" yaml:"valueFrom,omitempty"`
+}
+
+type AuthValueFrom struct {
+	CredentialFieldRef *CredentialFieldRef `json:"credentialFieldRef,omitempty" yaml:"credentialFieldRef,omitempty"`
+}
+
+type CredentialFieldRef struct {
+	Name string `json:"name" yaml:"name"`
 }
 
 type Artifact struct {

--- a/sdk/go/secrets.go
+++ b/sdk/go/secrets.go
@@ -5,6 +5,6 @@ import (
 )
 
 type SecretsProvider interface {
-	RuntimeProvider
+	PluginProvider
 	GetSecret(ctx context.Context, name string) (string, error)
 }

--- a/sdk/go/serve_secrets.go
+++ b/sdk/go/serve_secrets.go
@@ -10,7 +10,7 @@ import (
 // ServeSecretsProvider starts a gRPC server for a [SecretsProvider].
 func ServeSecretsProvider(ctx context.Context, secrets SecretsProvider) error {
 	return servePlugin(withPluginCloser(ctx, secrets), func(srv *grpc.Server) {
-		proto.RegisterPluginRuntimeServer(srv, newRuntimeProviderServer(ProviderKindSecrets, secrets))
+		proto.RegisterProviderLifecycleServer(srv, newPluginProviderServer(ProviderKindSecrets, secrets))
 		proto.RegisterSecretsProviderServer(srv, newSecretsProviderServer(secrets))
 	})
 }


### PR DESCRIPTION
## Summary

Allow provider manifests to declare `auth_mapping` for manual auth, using the same `value` / `valueFrom.credentialFieldRef` model that deploy config already supports. This lets upstream providers own credential composition instead of forcing every deployment to restate it.

This change threads manifest `auth_mapping` through:
- the public manifest SDK types and JSON schema
- manifest-to-config conversion
- spec-loaded provider runtime
- declarative provider runtime
- manifest reference docs

## New Interfaces

- `plugin.auth.auth_mapping.headers.<HEADER>.value`
- `plugin.auth.auth_mapping.headers.<HEADER>.valueFrom.credentialFieldRef.name`
- `plugin.auth.auth_mapping.basic.username`
- `plugin.auth.auth_mapping.basic.password`

## Example Usage

```yaml
plugin:
  auth:
    type: manual
    credentials:
      - name: organization_id
        label: Organization ID
      - name: api_key
        label: API Key
    auth_mapping:
      basic:
        username:
          valueFrom:
            credentialFieldRef:
              name: organization_id
        password:
          valueFrom:
            credentialFieldRef:
              name: api_key
```

With this in place, a downstream integration can just reference the provider package and omit a redundant deploy-side `auth_mapping` block when the upstream contract is fixed.

## Testing

- `go test ./cmd/gestaltd -run 'TestE2EDeclarativeSelectorsSupportHeaderPaginationAndResponseMapping|TestE2EManualAuthMappingValueAndValueFromBasicAuth|TestE2EManifestManualAuthMappingValueFromBasicAuth|TestE2EDeclarativeManifestManualAuthMappingValueFromBasicAuth' -count=1`
- `go test ./internal/config ./internal/provider ./internal/pluginhost -run '^$' -count=1`
