### PR TITLE
Add portable Linux musl release targets for the CLI

### DIFF
--- a/.github/workflows/build-gestalt-cli.yml
+++ b/.github/workflows/build-gestalt-cli.yml
@@ -7,9 +7,12 @@ on:
     paths:
       - 'gestalt/**'
       - '.github/workflows/build-gestalt-cli.yml'
+      - '.github/workflows/rust-build-matrix.yml'
   pull_request:
     paths:
       - 'gestalt/**'
+      - '.github/workflows/build-gestalt-cli.yml'
+      - '.github/workflows/rust-build-matrix.yml'
 
   workflow_dispatch:
 

--- a/.github/workflows/release-gestalt-cli.yml
+++ b/.github/workflows/release-gestalt-cli.yml
@@ -85,41 +85,43 @@ jobs:
       - name: Parse checksums
         id: checksums
         run: |
-          for platform in macos-arm64 macos-x86_64 linux-arm64 linux-x86_64; do
-            hash=$(awk '{print $1}' "checksums/gestalt-${platform}.tar.gz.sha256")
-            echo "${platform}=${hash}" >> "$GITHUB_OUTPUT"
-          done
+          {
+            echo "macos_arm64=$(awk '{print $1}' checksums/gestalt-macos-arm64.tar.gz.sha256)"
+            echo "macos_x86_64=$(awk '{print $1}' checksums/gestalt-macos-x86_64.tar.gz.sha256)"
+            echo "linux_arm64_musl=$(awk '{print $1}' checksums/gestalt-linux-arm64-musl.tar.gz.sha256)"
+            echo "linux_x86_64_musl=$(awk '{print $1}' checksums/gestalt-linux-x86_64-musl.tar.gz.sha256)"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Update formula
         env:
           VERSION: ${{ steps.version.outputs.version }}
           TAG: ${{ github.ref_name }}
-          SHA_MACOS_ARM64: ${{ steps.checksums.outputs.macos-arm64 }}
-          SHA_MACOS_X86: ${{ steps.checksums.outputs.macos-x86_64 }}
-          SHA_LINUX_ARM64: ${{ steps.checksums.outputs.linux-arm64 }}
-          SHA_LINUX_X86: ${{ steps.checksums.outputs.linux-x86_64 }}
+          SHA_MACOS_ARM64: ${{ steps.checksums.outputs.macos_arm64 }}
+          SHA_MACOS_X86_64: ${{ steps.checksums.outputs.macos_x86_64 }}
+          SHA_LINUX_ARM64_MUSL: ${{ steps.checksums.outputs.linux_arm64_musl }}
+          SHA_LINUX_X86_64_MUSL: ${{ steps.checksums.outputs.linux_x86_64_musl }}
         run: |
           FORMULA="Formula/gestalt.rb"
           OLD_VERSION=$(grep '^\s*version ' "$FORMULA" | sed 's/.*version "\(.*\)"/\1/')
 
           sed -i "s/version \"${OLD_VERSION}\"/version \"${VERSION}\"/" "$FORMULA"
-          perl -0pi -e 's{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-macos-arm64\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-macos-arm64.tar.gz}g; s{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-macos-x86_64\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-macos-x86_64.tar.gz}g; s{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-linux-arm64\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-linux-arm64.tar.gz}g; s{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-linux-x86_64\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-linux-x86_64.tar.gz}g' "$FORMULA"
+          perl -0pi -e 's{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-macos-arm64\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-macos-arm64.tar.gz}g; s{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-macos-x86_64\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-macos-x86_64.tar.gz}g; s{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-linux-arm64(?:-musl)?\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-linux-arm64-musl.tar.gz}g; s{https://github.com/valon-technologies/gestalt/releases/download/[^"]+/gestalt-linux-x86_64(?:-musl)?\.tar\.gz}{https://github.com/valon-technologies/gestalt/releases/download/'"$TAG"'/gestalt-linux-x86_64-musl.tar.gz}g' "$FORMULA"
 
           # Update SHA256 for each platform by matching the URL above it
           awk -v sha_macos_arm64="$SHA_MACOS_ARM64" \
-              -v sha_macos_x86="$SHA_MACOS_X86" \
-              -v sha_linux_arm64="$SHA_LINUX_ARM64" \
-              -v sha_linux_x86="$SHA_LINUX_X86" \
+              -v sha_macos_x86_64="$SHA_MACOS_X86_64" \
+              -v sha_linux_arm64_musl="$SHA_LINUX_ARM64_MUSL" \
+              -v sha_linux_x86_64_musl="$SHA_LINUX_X86_64_MUSL" \
           '
           /gestalt-macos-arm64\.tar\.gz/ { found="macos-arm64" }
-          /gestalt-macos-x86_64\.tar\.gz/ { found="macos-x86" }
-          /gestalt-linux-arm64\.tar\.gz/ { found="linux-arm64" }
-          /gestalt-linux-x86_64\.tar\.gz/ { found="linux-x86" }
+          /gestalt-macos-x86_64\.tar\.gz/ { found="macos-x86_64" }
+          /gestalt-linux-arm64(-musl)?\.tar\.gz/ { found="linux-arm64-musl" }
+          /gestalt-linux-x86_64(-musl)?\.tar\.gz/ { found="linux-x86_64-musl" }
           /sha256 "/ {
             if (found == "macos-arm64") { sub(/"[^"]*"/, "\"" sha_macos_arm64 "\"") }
-            if (found == "macos-x86") { sub(/"[^"]*"/, "\"" sha_macos_x86 "\"") }
-            if (found == "linux-arm64") { sub(/"[^"]*"/, "\"" sha_linux_arm64 "\"") }
-            if (found == "linux-x86") { sub(/"[^"]*"/, "\"" sha_linux_x86 "\"") }
+            if (found == "macos-x86_64") { sub(/"[^"]*"/, "\"" sha_macos_x86_64 "\"") }
+            if (found == "linux-arm64-musl") { sub(/"[^"]*"/, "\"" sha_linux_arm64_musl "\"") }
+            if (found == "linux-x86_64-musl") { sub(/"[^"]*"/, "\"" sha_linux_x86_64_musl "\"") }
             found=""
           }
           { print }

--- a/.github/workflows/rust-build-matrix.yml
+++ b/.github/workflows/rust-build-matrix.yml
@@ -46,10 +46,20 @@ jobs:
             runs-on: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             suffix: linux-x86_64
+          - name: Linux-x86_64-musl
+            runs-on: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            suffix: linux-x86_64-musl
+            cross: true
           - name: Linux-ARM64
             runs-on: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             suffix: linux-arm64
+            cross: true
+          - name: Linux-ARM64-musl
+            runs-on: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            suffix: linux-arm64-musl
             cross: true
           - name: Windows-x86_64
             runs-on: windows-latest

--- a/gestalt/Dockerfile
+++ b/gestalt/Dockerfile
@@ -9,8 +9,8 @@ FROM --platform=$BUILDPLATFORM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623
 ARG TARGETARCH
 COPY dist/gestalt-linux-*.tar.gz /dist/
 RUN case "$TARGETARCH" in \
-      amd64) archive=/dist/gestalt-linux-x86_64.tar.gz ;; \
-      arm64) archive=/dist/gestalt-linux-arm64.tar.gz ;; \
+      amd64) archive=/dist/gestalt-linux-x86_64-musl.tar.gz ;; \
+      arm64) archive=/dist/gestalt-linux-arm64-musl.tar.gz ;; \
       *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
     esac && \
     mkdir -p /out && \


### PR DESCRIPTION
## Summary
- add `linux-x86_64-musl` and `linux-arm64-musl` CLI release artifacts to the shared Rust build matrix
- switch the future CLI Docker image to consume the musl release tarballs
- update the CLI release workflow so the next tagged release rewrites Linux Homebrew formula URLs/checksums to the portable musl assets
- trigger CLI build CI when the shared Rust build matrix changes

## Why
The current Linux CLI artifact is built for `*-unknown-linux-gnu`, so it inherits the glibc baseline of the GitHub Actions runner. Older Linux VMs can fail at runtime with `GLIBC_2.38` / `GLIBC_2.39` errors even when the CPU architecture is correct.

Publishing musl artifacts gives us portable Linux binaries, and teaching the release workflow to move Linux Homebrew installs to those artifacts fixes the compatibility issue on the next CLI release without breaking the current formula in `main` before the new assets exist.

## Verification
- `cargo test --workspace`
- `cargo fmt --all -- --check`
- `git diff --check`
- `actionlint .github/workflows/rust-build-matrix.yml .github/workflows/build-gestalt-cli.yml .github/workflows/release-gestalt-cli.yml .github/workflows/publish-dockerhub-image.yml`