### PR TITLE
[codex] simplify manifests to a single kind

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -291,8 +291,6 @@ jobs:
           version: 0.0.1-alpha.1
           display_name: SQLite
           description: Local CI sqlite datastore fixture
-          kinds:
-            - datastore
           datastore: {}
           artifacts:
             - os: __GOOS__

--- a/docs/content/providers/auth.mdx
+++ b/docs/content/providers/auth.mdx
@@ -8,15 +8,13 @@ Beyond the core login flow, an auth provider can optionally validate externally 
 
 ## Manifest
 
-An auth provider manifest declares `kinds: [auth]` instead of `kinds: [plugin]`:
+An auth provider manifest uses an `auth` block:
 
 ```yaml
 source: github.com/example/plugins/my-auth
 version: 0.0.1-alpha.1
 display_name: My Auth Provider
 description: Custom OAuth 2.0 authentication
-kinds:
-  - auth
 auth:
   config_schema_path: ./auth_config.json
 ```

--- a/docs/content/providers/datastores.mdx
+++ b/docs/content/providers/datastores.mdx
@@ -8,15 +8,13 @@ The host encrypts all integration tokens before passing them to the datastore us
 
 ## Manifest
 
-A datastore provider manifest declares `kinds: [datastore]`:
+A datastore provider manifest uses a `datastore` block:
 
 ```yaml
 source: github.com/example/plugins/my-datastore
 version: 0.0.1-alpha.1
 display_name: My Datastore
 description: Custom persistent storage backend
-kinds:
-  - datastore
 datastore:
   config_schema_path: ./datastore_config.json
 ```

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -8,7 +8,7 @@ Gestalt has a unified runtime model: integration plugins, auth backends, datasto
 
 ## Provider kinds
 
-A provider declares one or more `kinds` in its manifest:
+A provider's kind is implied by the one top-level metadata block in its manifest:
 
 | Kind | Purpose |
 | --- | --- |

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -2,7 +2,7 @@ import { Tabs } from 'nextra/components'
 
 # Integration Plugins
 
-Integration plugins are one provider kind. They use `plugin:` metadata in the manifest and appear under the top-level `plugins:` map in deployment config. A plugin can define operations as executable code, as passthrough surfaces (REST, OpenAPI, GraphQL, or MCP endpoints forwarded by the host), or both.
+Integration plugins are one provider kind. Their manifests use a top-level `plugin:` block, and deployments reference them under the top-level `plugins:` map. A plugin can define operations as executable code (handled by the provider process), as passthrough surfaces (REST, OpenAPI, GraphQL, or MCP endpoints forwarded by the host), or both.
 
 ## Manifest
 
@@ -15,8 +15,6 @@ Static metadata, auth, and passthrough surfaces live in a manifest file. Gestalt
     version: 0.0.1-alpha.1
     display_name: My Plugin
     description: A custom integration plugin
-    kinds:
-      - plugin
     plugin:
       connections:
         default:
@@ -31,7 +29,6 @@ Static metadata, auth, and passthrough surfaces live in a manifest file. Gestalt
       "version": "0.0.1-alpha.1",
       "display_name": "My Plugin",
       "description": "A custom integration plugin",
-      "kinds": ["plugin"],
       "plugin": {
         "connections": {
           "default": {

--- a/docs/content/providers/releasing.mdx
+++ b/docs/content/providers/releasing.mdx
@@ -144,8 +144,7 @@ Released executable integration providers add concrete `entrypoints.plugin` and
 ```yaml
 source: github.com/acme/plugins/my-plugin
 version: 0.0.1-alpha.1
-kinds:
-  - plugin
+plugin: {}
 entrypoints:
   plugin:
     artifact_path: artifacts/linux/amd64/provider

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -90,4 +90,4 @@ plugins:
 
 ## Community and Custom Providers
 
-Third-party auth providers, datastore providers, and integration plugins use the same provider package model as the first-party packages. Package your implementation with a provider manifest and the appropriate kind (`auth`, `datastore`, or `plugin`), publish it to a Git-accessible source, and reference it in your config the same way you would reference any first-party provider.
+Third-party auth providers, datastore providers, and integration plugins use the same provider package model as the first-party packages. Package your implementation with a provider manifest that includes the appropriate top-level block (`auth`, `datastore`, or `plugin`), publish it to a Git-accessible source, and reference it in your config the same way you would reference any first-party provider.

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -17,7 +17,7 @@ Every manifest defines exactly one of four provider kinds, determined by which m
 | `datastore` | `datastore` | Persistence backend (Postgres, SQLite, DynamoDB, or custom). |
 | `webui` | `webui` | Static UI package served by `gestaltd`. |
 
-The JSON schema enforces `oneOf` across these four keys: a manifest must include exactly one.
+The JSON schema enforces `oneOf` across these four keys: a manifest must include exactly one. There is no separate `kind` or `kinds` field.
 
 ## Common Fields
 
@@ -27,12 +27,11 @@ These fields appear at the top level of every manifest regardless of kind.
 | --- | --- | --- | --- |
 | `source` | string | yes | Canonical provider source identifier. Use `github.com/<org>/<repo>/<path>`. The final path segment is the provider package name; preceding segments are used for release tags and source resolution. |
 | `version` | string | yes | Semver version. Pre-release suffixes like `-alpha.1` are allowed. |
-| `kinds` | string[] | no | Explicit kind list. When omitted, the kind is inferred from which metadata block is present. |
 | `display_name` | string | no | Human-readable label shown in the UI. |
 | `description` | string | no | Human-readable description. |
 | `icon_file` | string | no | Relative path to an SVG icon bundled with the package. |
 | `artifacts` | Artifact[] | no | Packaged executable artifacts keyed by platform. Omit for declarative-only integration plugin packages or source manifests used during local development. |
-| `entrypoints` | Entrypoints | no | Executable entrypoints for each kind the manifest provides. |
+| `entrypoints` | Entrypoints | no | Executable entrypoint metadata for the manifest's kind. |
 
 ## Entrypoints
 

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -186,8 +186,6 @@ paths:
 source: github.com/test/plugins/pager
 version: 0.0.1-alpha.1
 display_name: Pager
-kinds:
-  - plugin
 plugin:
   openapi: openapi.yaml
   connection_mode: none
@@ -229,8 +227,6 @@ paths:
 source: github.com/test/plugins/mapper
 version: 0.0.1-alpha.1
 display_name: Mapper
-kinds:
-  - plugin
 plugin:
   openapi: openapi.yaml
   connection_mode: none
@@ -374,8 +370,6 @@ paths:
 source: github.com/test/plugins/manual-basic
 version: 0.0.1-alpha.1
 display_name: Manual Basic Test
-kinds:
-  - plugin
 plugin:
   openapi: openapi.yaml
 `), 0o644)
@@ -1465,7 +1459,6 @@ func setupPluginDirWithVersion(t *testing.T, baseDir, version string) string {
 		Version:     version,
 		DisplayName: "Example Provider",
 		Description: "A minimal example provider built with the public SDK",
-		Kinds:       []string{pluginmanifestv1.KindPlugin},
 		Plugin:      &pluginmanifestv1.Plugin{},
 	}
 	writeManifestFile(t, pluginDir, manifest)
@@ -1494,7 +1487,6 @@ func setupAuthProviderDir(t *testing.T, baseDir, name string) string {
 		Source:      "github.com/test/providers/auth/" + name,
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Test Auth " + name,
-		Kinds:       []string{pluginmanifestv1.KindAuth},
 		Auth:        &pluginmanifestv1.AuthMetadata{},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{OS: runtime.GOOS, Arch: runtime.GOARCH, Path: artifactRel},
@@ -1539,7 +1531,6 @@ func setupDatastoreProviderDir(t *testing.T, baseDir, name string) string {
 		Source:      "github.com/test/providers/datastore/" + name,
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Test Datastore " + name,
-		Kinds:       []string{pluginmanifestv1.KindDatastore},
 		Datastore:   &pluginmanifestv1.DatastoreMetadata{},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{OS: runtime.GOOS, Arch: runtime.GOARCH, Path: artifactRel},

--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -145,40 +145,24 @@ func runProviderRelease(args []string) error {
 }
 
 func resolveReleaseBuildTarget(root string, manifest *pluginmanifestv1.Manifest) (*releaseBuildTarget, error) {
-	executableKinds := releaseExecutableKinds(manifest)
-	if len(executableKinds) == 0 {
+	kind, err := pluginpkg.ManifestKind(manifest)
+	if err != nil {
+		return nil, err
+	}
+	if kind == pluginmanifestv1.KindWebUI {
 		return nil, nil
 	}
-
-	var (
-		buildKinds      []string
-		requiredMissing []string
-	)
-	for _, kind := range executableKinds {
-		hasSource, err := detectReleaseSourceBuildTarget(root, kind)
-		switch {
-		case err != nil:
-			return nil, fmt.Errorf("detect source %s package: %w", kind, err)
-		case hasSource:
-			buildKinds = append(buildKinds, kind)
-		case releaseRequiresBuildTarget(manifest, kind):
-			requiredMissing = append(requiredMissing, kind)
+	hasSource, err := detectReleaseSourceBuildTarget(root, kind)
+	if err != nil {
+		return nil, fmt.Errorf("detect source %s package: %w", kind, err)
+	}
+	if !hasSource {
+		if releaseRequiresBuildTarget(manifest) {
+			return nil, missingReleaseSourceBuildTargetError(kind)
 		}
-	}
-
-	if len(buildKinds) > 1 {
-		return nil, fmt.Errorf("provider release does not support building multiple executable kinds from source in one package: %s", strings.Join(buildKinds, ", "))
-	}
-	if len(requiredMissing) > 0 {
-		if len(buildKinds) > 0 {
-			return nil, fmt.Errorf("provider release does not support mixing source-built %q with missing executable source kinds %s in one package", buildKinds[0], strings.Join(requiredMissing, ", "))
-		}
-		return nil, missingReleaseSourceBuildTargetError(requiredMissing)
-	}
-	if len(buildKinds) == 0 {
 		return nil, nil
 	}
-	return &releaseBuildTarget{Kind: buildKinds[0]}, nil
+	return &releaseBuildTarget{Kind: kind}, nil
 }
 
 func resolveReleaseBuildPlatforms(root string, manifest *pluginmanifestv1.Manifest, target *releaseBuildTarget, value string, explicit bool) ([]releasePlatform, error) {
@@ -186,7 +170,7 @@ func resolveReleaseBuildPlatforms(root string, manifest *pluginmanifestv1.Manife
 		return nil, nil
 	}
 
-	buildRequired := releaseRequiresBuildTarget(manifest, target.Kind)
+	buildRequired := releaseRequiresBuildTarget(manifest)
 	if !buildRequired && !explicit {
 		return nil, nil
 	}
@@ -218,10 +202,10 @@ func resolveReleaseBuildPlatforms(root string, manifest *pluginmanifestv1.Manife
 	}
 
 	if len(builds) == 0 {
-		return nil, missingReleaseSourceBuildTargetError([]string{target.Kind})
+		return nil, missingReleaseSourceBuildTargetError(target.Kind)
 	}
 	if missingSource {
-		return nil, missingReleaseSourceBuildTargetError([]string{target.Kind})
+		return nil, missingReleaseSourceBuildTargetError(target.Kind)
 	}
 	return builds, nil
 }
@@ -292,27 +276,21 @@ func writeReleaseManifestFile(stagingDir, manifestFile, manifestFormat string, m
 	return os.WriteFile(filepath.Join(stagingDir, manifestFile), data, 0644)
 }
 
-func releaseRequiresBuildTarget(manifest *pluginmanifestv1.Manifest, kind string) bool {
+func releaseRequiresBuildTarget(manifest *pluginmanifestv1.Manifest) bool {
+	kind, err := pluginpkg.ManifestKind(manifest)
+	if err != nil {
+		return false
+	}
 	switch kind {
 	case pluginmanifestv1.KindPlugin:
-		return manifestHasKind(manifest, kind) && manifest.Entrypoints.Provider == nil && (manifest == nil || manifest.Plugin == nil || !manifest.Plugin.IsManifestBacked())
+		return manifest.Entrypoints.Provider == nil && (manifest.Plugin == nil || !manifest.Plugin.IsManifestBacked())
 	case pluginmanifestv1.KindAuth:
-		return manifestHasKind(manifest, kind) && manifest.Entrypoints.Auth == nil
+		return manifest.Entrypoints.Auth == nil
 	case pluginmanifestv1.KindDatastore:
-		return manifestHasKind(manifest, kind) && manifest.Entrypoints.Datastore == nil
+		return manifest.Entrypoints.Datastore == nil
 	default:
 		return false
 	}
-}
-
-func releaseExecutableKinds(manifest *pluginmanifestv1.Manifest) []string {
-	var kinds []string
-	for _, kind := range []string{pluginmanifestv1.KindPlugin, pluginmanifestv1.KindAuth, pluginmanifestv1.KindDatastore} {
-		if manifestHasKind(manifest, kind) {
-			kinds = append(kinds, kind)
-		}
-	}
-	return kinds
 }
 
 func detectReleaseSourceBuildTarget(root, kind string) (bool, error) {
@@ -359,33 +337,17 @@ func isMissingReleaseSourceBuildTarget(err error, kind string) bool {
 	}
 }
 
-func missingReleaseSourceBuildTargetError(kinds []string) error {
-	switch len(kinds) {
-	case 0:
+func missingReleaseSourceBuildTargetError(kind string) error {
+	switch kind {
+	case pluginmanifestv1.KindPlugin:
+		return fmt.Errorf("no Go, Rust, Python, or TypeScript provider package found")
+	case pluginmanifestv1.KindAuth:
+		return fmt.Errorf("no Go, Rust, Python, or TypeScript auth source package found")
+	case pluginmanifestv1.KindDatastore:
+		return fmt.Errorf("no Go, Rust, Python, or TypeScript datastore source package found")
+	default:
 		return nil
-	case 1:
-		switch kinds[0] {
-		case pluginmanifestv1.KindPlugin:
-			return fmt.Errorf("no Go, Rust, Python, or TypeScript provider package found")
-		case pluginmanifestv1.KindAuth:
-			return fmt.Errorf("no Go, Rust, Python, or TypeScript auth source package found")
-		case pluginmanifestv1.KindDatastore:
-			return fmt.Errorf("no Go, Rust, Python, or TypeScript datastore source package found")
-		}
 	}
-	return fmt.Errorf("missing source packages for executable kinds: %s", strings.Join(kinds, ", "))
-}
-
-func manifestHasKind(manifest *pluginmanifestv1.Manifest, kind string) bool {
-	if manifest == nil {
-		return false
-	}
-	for _, manifestKind := range manifest.Kinds {
-		if manifestKind == kind {
-			return true
-		}
-	}
-	return false
 }
 
 func parseReleasePlatforms(value string) ([]releasePlatform, error) {

--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -283,7 +283,7 @@ func releaseRequiresBuildTarget(manifest *pluginmanifestv1.Manifest) bool {
 	}
 	switch kind {
 	case pluginmanifestv1.KindPlugin:
-		return manifest.Entrypoints.Provider == nil && (manifest.Plugin == nil || !manifest.Plugin.IsManifestBacked())
+		return manifest.Entrypoints.Provider == nil && !manifest.Plugin.IsManifestBacked()
 	case pluginmanifestv1.KindAuth:
 		return manifest.Entrypoints.Auth == nil
 	case pluginmanifestv1.KindDatastore:
@@ -346,7 +346,7 @@ func missingReleaseSourceBuildTargetError(kind string) error {
 	case pluginmanifestv1.KindDatastore:
 		return fmt.Errorf("no Go, Rust, Python, or TypeScript datastore source package found")
 	default:
-		return nil
+		return fmt.Errorf("unsupported release build target kind %q", kind)
 	}
 }
 

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -190,6 +190,18 @@ provider:
 	}
 }
 
+func TestMissingReleaseSourceBuildTargetErrorRejectsUnsupportedKind(t *testing.T) {
+	t.Parallel()
+
+	err := missingReleaseSourceBuildTargetError(pluginmanifestv1.KindWebUI)
+	if err == nil {
+		t.Fatal("expected error for unsupported kind")
+	}
+	if !strings.Contains(err.Error(), "unsupported release build target kind") {
+		t.Fatalf("error = %q, want unsupported kind message", err)
+	}
+}
+
 func TestE2EPluginReleaseBigquery(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -146,8 +146,6 @@ func TestRun_PluginReleaseRejectsInvalidManifest(t *testing.T) {
 			manifestYAML: `
 source: github.com/testowner/plugins/invalid
 version: 0.0.1-alpha.1
-kinds:
-  - plugin
 provider:
   surfaces:
     rest:
@@ -163,8 +161,6 @@ provider:
 			manifestYAML: `
 source: github.com/testowner/plugins/invalid
 version: 0.0.1-alpha.1
-kinds:
-  - plugin
 provider:
   exec: {}
 `,
@@ -652,7 +648,6 @@ plugin = "os import path\nimport os;os.system('cmd')#:attr"
 	manifestData, err := pluginpkg.EncodeSourceManifestFormat(&pluginmanifestv1.Manifest{
 		Source:  "github.com/testowner/plugins/invalid-python-release",
 		Version: "0.0.1",
-		Kinds:   []string{pluginmanifestv1.KindPlugin},
 		Plugin: &pluginmanifestv1.Plugin{
 			Auth: &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeNone},
 		},
@@ -1483,7 +1478,6 @@ func TestRun_PluginReleaseAllowsOverlappingSupportPaths(t *testing.T) {
 		Version:     "0.0.1",
 		DisplayName: "WebUI Overlap",
 		IconFile:    "out/icon.svg",
-		Kinds:       []string{pluginmanifestv1.KindWebUI},
 		WebUI: &pluginmanifestv1.WebUIMetadata{
 			AssetRoot: "out",
 		},
@@ -1541,7 +1535,6 @@ func TestRun_PluginReleasePreservesYAMLManifestFormatAndConnectionDefaults(t *te
 		Source:      "github.com/testowner/plugins/provider-yaml",
 		Version:     "0.0.1",
 		DisplayName: "Provider YAML",
-		Kinds:       []string{pluginmanifestv1.KindPlugin},
 		Plugin: &pluginmanifestv1.Plugin{
 			ConfigSchemaPath: releaseProviderSchemaPath,
 			MCP:              true,
@@ -1686,7 +1679,6 @@ func TestRun_PluginReleaseRejectsRequiredExecutableKindsWithoutSourceOrEntrypoin
 				Source:      "github.com/testowner/plugins/missing-provider",
 				Version:     "0.0.1",
 				DisplayName: "Missing Provider",
-				Kinds:       []string{pluginmanifestv1.KindPlugin},
 				Plugin:      &pluginmanifestv1.Plugin{},
 			},
 			wantError: "no Go, Rust, Python, or TypeScript provider package found",
@@ -1697,7 +1689,6 @@ func TestRun_PluginReleaseRejectsRequiredExecutableKindsWithoutSourceOrEntrypoin
 				Source:      "github.com/testowner/plugins/missing-auth",
 				Version:     "0.0.1",
 				DisplayName: "Missing Auth",
-				Kinds:       []string{pluginmanifestv1.KindAuth},
 				Auth:        &pluginmanifestv1.AuthMetadata{},
 			},
 			wantError: "no Go, Rust, Python, or TypeScript auth source package found",
@@ -1708,7 +1699,6 @@ func TestRun_PluginReleaseRejectsRequiredExecutableKindsWithoutSourceOrEntrypoin
 				Source:      "github.com/testowner/plugins/missing-datastore",
 				Version:     "0.0.1",
 				DisplayName: "Missing Datastore",
-				Kinds:       []string{pluginmanifestv1.KindDatastore},
 				Datastore:   &pluginmanifestv1.DatastoreMetadata{},
 			},
 			wantError: "no Go, Rust, Python, or TypeScript datastore source package found",
@@ -1908,7 +1898,6 @@ def dynamic_catalog(request: gestalt.Request) -> gestalt.Catalog:
 	manifestData, err := pluginpkg.EncodeSourceManifestFormat(&pluginmanifestv1.Manifest{
 		Source:  "github.com/testowner/plugins/python-release",
 		Version: "0.0.1",
-		Kinds:   []string{pluginmanifestv1.KindPlugin},
 		Plugin: &pluginmanifestv1.Plugin{
 			Auth: &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeNone},
 		},
@@ -1946,7 +1935,6 @@ auth = "provider:auth_provider"
 		Source:      pythonAuthReleaseSource,
 		Version:     "0.0.1",
 		DisplayName: "Python Auth Release",
-		Kinds:       []string{pluginmanifestv1.KindAuth},
 		Auth: &pluginmanifestv1.AuthMetadata{
 			ConfigSchemaPath: authReleaseSchemaPath,
 		},
@@ -1989,7 +1977,6 @@ datastore = "provider:datastore_provider"
 		Source:      pythonDatastoreReleaseSource,
 		Version:     "0.0.1",
 		DisplayName: "Python Datastore Release",
-		Kinds:       []string{pluginmanifestv1.KindDatastore},
 		Datastore: &pluginmanifestv1.DatastoreMetadata{
 			ConfigSchemaPath: datastoreReleaseSchemaPath,
 		},
@@ -2030,7 +2017,6 @@ func newTypeScriptSourceAuthReleaseFixture(t *testing.T, dir string) string {
 		Source:      authReleaseSource,
 		Version:     "0.0.1",
 		DisplayName: "Auth Release",
-		Kinds:       []string{pluginmanifestv1.KindAuth},
 		Auth: &pluginmanifestv1.AuthMetadata{
 			ConfigSchemaPath: authReleaseSchemaPath,
 		},
@@ -2062,7 +2048,6 @@ func newTypeScriptSourceDatastoreReleaseFixture(t *testing.T, dir string) string
 		Source:      datastoreReleaseSource,
 		Version:     "0.0.1",
 		DisplayName: "Datastore Release",
-		Kinds:       []string{pluginmanifestv1.KindDatastore},
 		Datastore: &pluginmanifestv1.DatastoreMetadata{
 			ConfigSchemaPath: datastoreReleaseSchemaPath,
 		},
@@ -2379,7 +2364,6 @@ func newSourceAuthReleaseFixture(t *testing.T, dir string) string {
 		Source:      authReleaseSource,
 		Version:     "0.0.1",
 		DisplayName: "Auth Release",
-		Kinds:       []string{pluginmanifestv1.KindAuth},
 		Auth: &pluginmanifestv1.AuthMetadata{
 			ConfigSchemaPath: authReleaseSchemaPath,
 		},
@@ -2397,7 +2381,6 @@ func newRustSourceAuthReleaseFixture(t *testing.T, dir string) string {
 		Source:      authReleaseSource,
 		Version:     "0.0.1",
 		DisplayName: "Auth Release",
-		Kinds:       []string{pluginmanifestv1.KindAuth},
 		Auth: &pluginmanifestv1.AuthMetadata{
 			ConfigSchemaPath: authReleaseSchemaPath,
 		},
@@ -2420,7 +2403,6 @@ func newSourceDatastoreReleaseFixture(t *testing.T, dir string) string {
 		Source:      datastoreReleaseSource,
 		Version:     "0.0.1",
 		DisplayName: "Datastore Release",
-		Kinds:       []string{pluginmanifestv1.KindDatastore},
 		Datastore: &pluginmanifestv1.DatastoreMetadata{
 			ConfigSchemaPath: datastoreReleaseSchemaPath,
 		},
@@ -2438,7 +2420,6 @@ func newRustSourceDatastoreReleaseFixture(t *testing.T, dir string) string {
 		Source:      datastoreReleaseSource,
 		Version:     "0.0.1",
 		DisplayName: "Datastore Release",
-		Kinds:       []string{pluginmanifestv1.KindDatastore},
 		Datastore: &pluginmanifestv1.DatastoreMetadata{
 			ConfigSchemaPath: datastoreReleaseSchemaPath,
 		},
@@ -2497,7 +2478,6 @@ func newSourceProviderReleaseFixture(t *testing.T, dir string) string {
 		Version:     "0.0.1",
 		DisplayName: "Release Test",
 		IconFile:    releaseTestIconPath,
-		Kinds:       []string{pluginmanifestv1.KindPlugin},
 		Plugin: &pluginmanifestv1.Plugin{
 			ConfigSchemaPath: releaseProviderSchemaPath,
 		},
@@ -2532,7 +2512,6 @@ func newGoSourceReleaseFixture(t *testing.T, dir string) string {
 		Source:      releaseTestSource,
 		Version:     "0.0.1",
 		DisplayName: "Release Test",
-		Kinds:       []string{pluginmanifestv1.KindPlugin},
 		Plugin: &pluginmanifestv1.Plugin{
 			Auth: &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeNone},
 		},
@@ -2829,7 +2808,6 @@ func newPrebuiltProviderReleaseFixture(t *testing.T, dir string) string {
 		Version:     "0.0.1",
 		DisplayName: "Prebuilt Provider",
 		IconFile:    releaseTestIconPath,
-		Kinds:       []string{pluginmanifestv1.KindPlugin},
 		Plugin: &pluginmanifestv1.Plugin{
 			ConfigSchemaPath: releaseProviderSchemaPath,
 		},
@@ -2866,7 +2844,6 @@ func newBuiltWebUIReleaseFixture(t *testing.T, dir string) string {
 		Version:     "0.0.1",
 		DisplayName: "WebUI Test",
 		IconFile:    releaseTestIconPath,
-		Kinds:       []string{pluginmanifestv1.KindWebUI},
 		Release: &pluginmanifestv1.ReleaseMetadata{
 			Build: &pluginmanifestv1.ReleaseBuild{
 				Workdir: "ui",
@@ -2894,7 +2871,6 @@ func newWebUIReleaseFixtureWithAssetRoot(t *testing.T, dir, assetRoot string) st
 		Version:     "0.0.1",
 		DisplayName: "WebUI Test",
 		IconFile:    releaseTestIconPath,
-		Kinds:       []string{pluginmanifestv1.KindWebUI},
 		WebUI: &pluginmanifestv1.WebUIMetadata{
 			AssetRoot: assetRoot,
 		},

--- a/gestaltd/cmd/gestaltd/prepared_plugin_e2e_test.go
+++ b/gestaltd/cmd/gestaltd/prepared_plugin_e2e_test.go
@@ -150,7 +150,6 @@ func buildPreparedPluginRequiringAPIKey(t *testing.T, dir, source, version strin
 		Version:     version,
 		DisplayName: "Example Provider",
 		Description: "A minimal example provider built with the public SDK",
-		Kinds:       []string{pluginmanifestv1.KindPlugin},
 		Plugin: &pluginmanifestv1.Plugin{
 			ConfigSchemaPath: schemaRel,
 		},

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -111,7 +111,6 @@ func TestPythonSourcePluginFallsBackWithoutGoOnPath(t *testing.T) {
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Python Source",
 		Description: "Python source provider fixture",
-		Kinds:       []string{pluginmanifestv1.KindPlugin},
 		Plugin: &pluginmanifestv1.Plugin{
 			Auth: &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeNone},
 		},
@@ -306,7 +305,6 @@ func newExecutableManifest(displayName, description string) *pluginmanifestv1.Ma
 	return &pluginmanifestv1.Manifest{
 		Source:      "github.com/acme/plugins/test",
 		Version:     "1.0.0",
-		Kinds:       []string{pluginmanifestv1.KindPlugin},
 		DisplayName: displayName,
 		Description: description,
 		Plugin:      &pluginmanifestv1.Plugin{},

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -1079,12 +1079,14 @@ func validateInstalledManifestKind(kind, name string, manifest *pluginmanifestv1
 	if manifest == nil {
 		return fmt.Errorf("manifest for %s %q is required", kind, name)
 	}
-	for _, declared := range manifest.Kinds {
-		if declared == kind {
-			return nil
-		}
+	declared, err := pluginpkg.ManifestKind(manifest)
+	if err != nil {
+		return fmt.Errorf("%s %q manifest is invalid: %w", kind, name, err)
 	}
-	return fmt.Errorf("%s %q manifest does not declare kind %q", kind, name, kind)
+	if declared != kind {
+		return fmt.Errorf("%s %q manifest has kind %q, want %q", kind, name, declared, kind)
+	}
+	return nil
 }
 
 func buildComponentRuntimeConfigNode(name, kind string, provider *config.PluginDef, providerConfig yaml.Node) (yaml.Node, error) {

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -83,7 +83,6 @@ func buildV2ArchiveForArtifact(t *testing.T, dir, source, version, artifactPath,
 	manifest := &pluginmanifestv1.Manifest{
 		Source:  source,
 		Version: version,
-		Kinds:   []string{pluginmanifestv1.KindPlugin},
 		Plugin:  &pluginmanifestv1.Plugin{},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
@@ -132,7 +131,6 @@ func buildExecutableArchive(t *testing.T, dir, srcDirName, source, version, kind
 	manifest := &pluginmanifestv1.Manifest{
 		Source:  source,
 		Version: version,
-		Kinds:   []string{kind},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
 				OS:     runtime.GOOS,

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -72,7 +72,6 @@ func writeRequiredComponentManifests(t *testing.T, dir string) (string, string) 
 		manifest := &pluginmanifestv1.Manifest{
 			Source:  source,
 			Version: "0.0.1-alpha.1",
-			Kinds:   []string{kind},
 		}
 		switch kind {
 		case pluginmanifestv1.KindAuth:
@@ -130,7 +129,6 @@ func TestLoadForExecutionAtPath_ResolvesLocalManifestPluginWithoutLockfile(t *te
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Local Provider",
 		Description: "Local executable provider",
-		Kinds:       []string{pluginmanifestv1.KindPlugin},
 		Plugin: &pluginmanifestv1.Plugin{
 			Auth: &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeNone},
 		},
@@ -251,7 +249,6 @@ func TestLockProviderEntryForSource_RejectsManifestWithoutProviderKind(t *testin
 	pkgPath := mustBuildManagedProviderPackage(t, dir, &pluginmanifestv1.Manifest{
 		Source:  "github.com/testowner/gestalt-providers/plugins/auth-only",
 		Version: "0.0.1-alpha.1",
-		Kinds:   []string{pluginmanifestv1.KindAuth},
 		Auth:    &pluginmanifestv1.AuthMetadata{},
 		Entrypoints: pluginmanifestv1.Entrypoints{
 			Auth: &pluginmanifestv1.Entrypoint{ArtifactPath: filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "auth"))},
@@ -274,7 +271,7 @@ func TestLockProviderEntryForSource_RejectsManifestWithoutProviderKind(t *testin
 	if err == nil {
 		t.Fatal("expected provider kind validation error")
 	}
-	if !strings.Contains(err.Error(), `manifest does not declare kind "plugin"`) {
+	if !strings.Contains(err.Error(), `manifest has kind "auth", want "plugin"`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -288,7 +285,6 @@ func TestLoadForExecutionAtPath_ResolvesLocalTopLevelPluginsWithoutLockfile(t *t
 	authManifest, err := pluginpkg.EncodeSourceManifestFormat(&pluginmanifestv1.Manifest{
 		Source:  "github.com/testowner/plugins/local-auth",
 		Version: "0.0.1-alpha.1",
-		Kinds:   []string{pluginmanifestv1.KindAuth},
 		Auth:    &pluginmanifestv1.AuthMetadata{},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{OS: runtime.GOOS, Arch: runtime.GOARCH, Path: authArtifact},
@@ -316,7 +312,6 @@ func TestLoadForExecutionAtPath_ResolvesLocalTopLevelPluginsWithoutLockfile(t *t
 	datastoreManifest, err := pluginpkg.EncodeSourceManifestFormat(&pluginmanifestv1.Manifest{
 		Source:    "github.com/testowner/plugins/local-datastore",
 		Version:   "0.0.1-alpha.1",
-		Kinds:     []string{pluginmanifestv1.KindDatastore},
 		Datastore: &pluginmanifestv1.DatastoreMetadata{},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{OS: runtime.GOOS, Arch: runtime.GOARCH, Path: datastoreArtifact},
@@ -429,7 +424,6 @@ func TestLoadForExecutionAtPath_ResolvesLocalSourceTopLevelPluginsWithoutArtifac
 	authManifest, err := pluginpkg.EncodeSourceManifestFormat(&pluginmanifestv1.Manifest{
 		Source:  "github.com/testowner/plugins/local-source-auth",
 		Version: "0.0.1-alpha.1",
-		Kinds:   []string{pluginmanifestv1.KindAuth},
 		Auth:    &pluginmanifestv1.AuthMetadata{},
 	}, pluginpkg.ManifestFormatYAML)
 	if err != nil {
@@ -444,7 +438,6 @@ func TestLoadForExecutionAtPath_ResolvesLocalSourceTopLevelPluginsWithoutArtifac
 	datastoreManifest, err := pluginpkg.EncodeSourceManifestFormat(&pluginmanifestv1.Manifest{
 		Source:    "github.com/testowner/plugins/local-source-datastore",
 		Version:   "0.0.1-alpha.1",
-		Kinds:     []string{pluginmanifestv1.KindDatastore},
 		Datastore: &pluginmanifestv1.DatastoreMetadata{},
 	}, pluginpkg.ManifestFormatYAML)
 	if err != nil {
@@ -527,7 +520,6 @@ func TestLoadForExecutionAtPath_GeneratesStaticCatalogForLocalSourceHybridPlugin
 		Source:      "github.com/testowner/plugins/local-generated-provider",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Generated Local Provider",
-		Kinds:       []string{pluginmanifestv1.KindPlugin},
 		Plugin: &pluginmanifestv1.Plugin{
 			Auth: &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeNone},
 		},
@@ -700,7 +692,6 @@ def session_catalog(request: gestalt.Request) -> gestalt.Catalog:
 		Source:      "github.com/testowner/plugins/local-python-provider",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Generated Local Python Provider",
-		Kinds:       []string{pluginmanifestv1.KindPlugin},
 		Plugin: &pluginmanifestv1.Plugin{
 			Auth: &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeNone},
 		},
@@ -1027,7 +1018,6 @@ func TestApplyLockedPlugins_SkipsNilIntegrationPlugins(t *testing.T) {
 		Source:      "github.com/testowner/plugins/local-provider",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Local Provider",
-		Kinds:       []string{pluginmanifestv1.KindPlugin},
 		Plugin: &pluginmanifestv1.Plugin{
 			Auth: &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeNone},
 		},

--- a/gestaltd/internal/pluginpkg/config_test.go
+++ b/gestaltd/internal/pluginpkg/config_test.go
@@ -56,7 +56,6 @@ properties:
 			manifest := &pluginmanifestv1.Manifest{
 				Source:  "github.com/acme/plugins/provider",
 				Version: "0.0.1-alpha.1",
-				Kinds:   []string{pluginmanifestv1.KindPlugin},
 				Plugin: &pluginmanifestv1.Plugin{
 					ConfigSchemaPath: tc.schemaPath,
 				},

--- a/gestaltd/internal/pluginpkg/manifest.go
+++ b/gestaltd/internal/pluginpkg/manifest.go
@@ -86,6 +86,37 @@ func ValidateManifest(manifest *pluginmanifestv1.Manifest) error {
 	return validateManifest(manifest, false)
 }
 
+func ManifestKind(manifest *pluginmanifestv1.Manifest) (string, error) {
+	if manifest == nil {
+		return "", fmt.Errorf("manifest is required")
+	}
+
+	var (
+		kind  string
+		count int
+	)
+	if manifest.Plugin != nil {
+		kind = pluginmanifestv1.KindPlugin
+		count++
+	}
+	if manifest.Auth != nil {
+		kind = pluginmanifestv1.KindAuth
+		count++
+	}
+	if manifest.Datastore != nil {
+		kind = pluginmanifestv1.KindDatastore
+		count++
+	}
+	if manifest.WebUI != nil {
+		kind = pluginmanifestv1.KindWebUI
+		count++
+	}
+	if count != 1 {
+		return "", fmt.Errorf("manifest must define exactly one of plugin, auth, datastore, or webui")
+	}
+	return kind, nil
+}
+
 func validateManifest(manifest *pluginmanifestv1.Manifest, sourceMode bool) error {
 	if manifest == nil {
 		return fmt.Errorf("manifest is required")
@@ -113,49 +144,9 @@ func validateManifest(manifest *pluginmanifestv1.Manifest, sourceMode bool) erro
 			return err
 		}
 	}
-	if len(manifest.Kinds) == 0 {
-		if manifest.Plugin != nil {
-			manifest.Kinds = append(manifest.Kinds, pluginmanifestv1.KindPlugin)
-		}
-		if manifest.Auth != nil {
-			manifest.Kinds = append(manifest.Kinds, pluginmanifestv1.KindAuth)
-		}
-		if manifest.Datastore != nil {
-			manifest.Kinds = append(manifest.Kinds, pluginmanifestv1.KindDatastore)
-		}
-		if manifest.WebUI != nil {
-			manifest.Kinds = append(manifest.Kinds, pluginmanifestv1.KindWebUI)
-		}
-	}
-	if len(manifest.Kinds) == 0 {
-		return fmt.Errorf("manifest kinds are required")
-	}
-	seenKinds := make(map[string]struct{}, len(manifest.Kinds))
-	for _, kind := range manifest.Kinds {
-		if _, exists := seenKinds[kind]; exists {
-			return fmt.Errorf("duplicate manifest kind %q", kind)
-		}
-		seenKinds[kind] = struct{}{}
-	}
-	if manifest.Plugin != nil {
-		if _, ok := seenKinds[pluginmanifestv1.KindPlugin]; !ok {
-			return fmt.Errorf("provider metadata requires kind %q", pluginmanifestv1.KindPlugin)
-		}
-	}
-	if manifest.Auth != nil {
-		if _, ok := seenKinds[pluginmanifestv1.KindAuth]; !ok {
-			return fmt.Errorf("auth metadata requires kind %q", pluginmanifestv1.KindAuth)
-		}
-	}
-	if manifest.Datastore != nil {
-		if _, ok := seenKinds[pluginmanifestv1.KindDatastore]; !ok {
-			return fmt.Errorf("datastore metadata requires kind %q", pluginmanifestv1.KindDatastore)
-		}
-	}
-	if manifest.WebUI != nil {
-		if _, ok := seenKinds[pluginmanifestv1.KindWebUI]; !ok {
-			return fmt.Errorf("webui metadata requires kind %q", pluginmanifestv1.KindWebUI)
-		}
+	kind, err := ManifestKind(manifest)
+	if err != nil {
+		return err
 	}
 
 	allowsSourceExecutableEntrypointOmission := sourceMode && manifest.Entrypoints.Provider == nil
@@ -163,19 +154,13 @@ func validateManifest(manifest *pluginmanifestv1.Manifest, sourceMode bool) erro
 	allowsSourceDatastoreEntrypointOmission := sourceMode && manifest.Entrypoints.Datastore == nil
 
 	needsArtifacts := len(manifest.Artifacts) > 0
-	for _, kind := range manifest.Kinds {
-		if kind == pluginmanifestv1.KindPlugin && manifest.Entrypoints.Provider != nil {
-			needsArtifacts = true
-			break
-		}
-		if kind == pluginmanifestv1.KindAuth && !allowsSourceAuthEntrypointOmission {
-			needsArtifacts = true
-			break
-		}
-		if kind == pluginmanifestv1.KindDatastore && !allowsSourceDatastoreEntrypointOmission {
-			needsArtifacts = true
-			break
-		}
+	switch kind {
+	case pluginmanifestv1.KindPlugin:
+		needsArtifacts = needsArtifacts || manifest.Entrypoints.Provider != nil
+	case pluginmanifestv1.KindAuth:
+		needsArtifacts = needsArtifacts || !allowsSourceAuthEntrypointOmission
+	case pluginmanifestv1.KindDatastore:
+		needsArtifacts = needsArtifacts || !allowsSourceDatastoreEntrypointOmission
 	}
 
 	var artifactPaths map[string]struct{}
@@ -205,85 +190,78 @@ func validateManifest(manifest *pluginmanifestv1.Manifest, sourceMode bool) erro
 		}
 	}
 
-	for _, kind := range manifest.Kinds {
-		switch kind {
-		case pluginmanifestv1.KindPlugin:
-			if manifest.Plugin == nil {
-				return fmt.Errorf("provider metadata is required when kind %q is present", pluginmanifestv1.KindPlugin)
-			}
-			if err := validateExecutableProviderMetadata(manifest.Plugin); err != nil {
-				return err
-			}
-			if manifest.Plugin.ConfigSchemaPath != "" {
-				if err := validateRelativePackagePath(manifest.Plugin.ConfigSchemaPath, "provider config schema path"); err != nil {
-					return err
-				}
-			}
-			if manifest.Plugin.IsDeclarative() {
-				if err := validateDeclarativeProvider(manifest.Plugin); err != nil {
-					return err
-				}
-			}
-			switch {
-			case manifest.Entrypoints.Provider != nil:
-				if err := validateEntrypoint(kind, manifest.Entrypoints.Provider, artifactPaths); err != nil {
-					return err
-				}
-			case manifest.IsDeclarativeOnlyProvider():
-			case manifest.Plugin.IsSpecLoaded():
-			case allowsSourceExecutableEntrypointOmission:
-			default:
-				return fmt.Errorf("%s is required", EntrypointFieldForKind(kind))
-			}
-		case pluginmanifestv1.KindAuth:
-			if manifest.Auth == nil {
-				return fmt.Errorf("auth metadata is required when kind %q is present", pluginmanifestv1.KindAuth)
-			}
-			if manifest.Auth.ConfigSchemaPath != "" {
-				if err := validateRelativePackagePath(manifest.Auth.ConfigSchemaPath, "auth config schema path"); err != nil {
-					return err
-				}
-			}
-			if manifest.Entrypoints.Auth == nil && !allowsSourceAuthEntrypointOmission {
-				return fmt.Errorf("%s is required", EntrypointFieldForKind(kind))
-			}
-			if manifest.Entrypoints.Auth != nil {
-				if err := validateEntrypoint(kind, manifest.Entrypoints.Auth, artifactPaths); err != nil {
-					return err
-				}
-			}
-		case pluginmanifestv1.KindDatastore:
-			if manifest.Datastore == nil {
-				return fmt.Errorf("datastore metadata is required when kind %q is present", pluginmanifestv1.KindDatastore)
-			}
-			if manifest.Datastore.ConfigSchemaPath != "" {
-				if err := validateRelativePackagePath(manifest.Datastore.ConfigSchemaPath, "datastore config schema path"); err != nil {
-					return err
-				}
-			}
-			if manifest.Entrypoints.Datastore == nil && !allowsSourceDatastoreEntrypointOmission {
-				return fmt.Errorf("%s is required", EntrypointFieldForKind(kind))
-			}
-			if manifest.Entrypoints.Datastore != nil {
-				if err := validateEntrypoint(kind, manifest.Entrypoints.Datastore, artifactPaths); err != nil {
-					return err
-				}
-			}
-		case pluginmanifestv1.KindWebUI:
-			if manifest.WebUI == nil {
-				return fmt.Errorf("webui metadata is required when kind %q is present", pluginmanifestv1.KindWebUI)
-			}
-			if err := validateRelativePackagePath(manifest.WebUI.AssetRoot, "webui asset root"); err != nil {
-				return err
-			}
-			for _, other := range manifest.Kinds {
-				if other != pluginmanifestv1.KindWebUI {
-					return fmt.Errorf("webui kind cannot be combined with %q", other)
-				}
-			}
-		default:
-			return fmt.Errorf("unsupported manifest kind %q", kind)
+	switch kind {
+	case pluginmanifestv1.KindPlugin:
+		if err := validateExecutableProviderMetadata(manifest.Plugin); err != nil {
+			return err
 		}
+		if manifest.Plugin.ConfigSchemaPath != "" {
+			if err := validateRelativePackagePath(manifest.Plugin.ConfigSchemaPath, "provider config schema path"); err != nil {
+				return err
+			}
+		}
+		if manifest.Plugin.IsDeclarative() {
+			if err := validateDeclarativeProvider(manifest.Plugin); err != nil {
+				return err
+			}
+		}
+		if manifest.Entrypoints.Auth != nil || manifest.Entrypoints.Datastore != nil {
+			return fmt.Errorf("plugin manifests may only define entrypoints.provider")
+		}
+		switch {
+		case manifest.Entrypoints.Provider != nil:
+			if err := validateEntrypoint(kind, manifest.Entrypoints.Provider, artifactPaths); err != nil {
+				return err
+			}
+		case manifest.IsDeclarativeOnlyProvider():
+		case manifest.Plugin.IsSpecLoaded():
+		case allowsSourceExecutableEntrypointOmission:
+		default:
+			return fmt.Errorf("%s is required", EntrypointFieldForKind(kind))
+		}
+	case pluginmanifestv1.KindAuth:
+		if manifest.Auth.ConfigSchemaPath != "" {
+			if err := validateRelativePackagePath(manifest.Auth.ConfigSchemaPath, "auth config schema path"); err != nil {
+				return err
+			}
+		}
+		if manifest.Entrypoints.Provider != nil || manifest.Entrypoints.Datastore != nil {
+			return fmt.Errorf("auth manifests may only define entrypoints.auth")
+		}
+		if manifest.Entrypoints.Auth == nil && !allowsSourceAuthEntrypointOmission {
+			return fmt.Errorf("%s is required", EntrypointFieldForKind(kind))
+		}
+		if manifest.Entrypoints.Auth != nil {
+			if err := validateEntrypoint(kind, manifest.Entrypoints.Auth, artifactPaths); err != nil {
+				return err
+			}
+		}
+	case pluginmanifestv1.KindDatastore:
+		if manifest.Datastore.ConfigSchemaPath != "" {
+			if err := validateRelativePackagePath(manifest.Datastore.ConfigSchemaPath, "datastore config schema path"); err != nil {
+				return err
+			}
+		}
+		if manifest.Entrypoints.Provider != nil || manifest.Entrypoints.Auth != nil {
+			return fmt.Errorf("datastore manifests may only define entrypoints.datastore")
+		}
+		if manifest.Entrypoints.Datastore == nil && !allowsSourceDatastoreEntrypointOmission {
+			return fmt.Errorf("%s is required", EntrypointFieldForKind(kind))
+		}
+		if manifest.Entrypoints.Datastore != nil {
+			if err := validateEntrypoint(kind, manifest.Entrypoints.Datastore, artifactPaths); err != nil {
+				return err
+			}
+		}
+	case pluginmanifestv1.KindWebUI:
+		if manifest.Entrypoints.Provider != nil || manifest.Entrypoints.Auth != nil || manifest.Entrypoints.Datastore != nil {
+			return fmt.Errorf("webui manifests may not define executable entrypoints")
+		}
+		if err := validateRelativePackagePath(manifest.WebUI.AssetRoot, "webui asset root"); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported manifest kind %q", kind)
 	}
 
 	return nil

--- a/gestaltd/internal/pluginpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/pluginpkg/manifest_workflow_test.go
@@ -77,7 +77,6 @@ func TestManifestWorkflow_RoundTripsWebUIPackage(t *testing.T) {
 	manifest := &pluginmanifestv1.Manifest{
 		Source:  "github.com/acme/plugins/webui",
 		Version: "1.0.0",
-		Kinds:   []string{pluginmanifestv1.KindWebUI},
 		WebUI:   &pluginmanifestv1.WebUIMetadata{AssetRoot: "ui/dist"},
 	}
 
@@ -175,7 +174,6 @@ func TestLoadManifestFromPath_PrefersManifestFileOrder(t *testing.T) {
 				manifest := &pluginmanifestv1.Manifest{
 					Source:  source,
 					Version: "1.0.0",
-					Kinds:   []string{pluginmanifestv1.KindWebUI},
 					WebUI:   &pluginmanifestv1.WebUIMetadata{AssetRoot: "ui"},
 				}
 				data := mustManifestYAML(t, manifest)
@@ -215,7 +213,16 @@ func TestManifestWorkflow_RejectsInvalidPackageInputs(t *testing.T) {
 					Version: "1.0.0",
 				}))
 			},
-			wantError: "manifest kinds are required",
+			wantError: "manifest must define exactly one of plugin, auth, datastore, or webui",
+		},
+		{
+			name: "multiple metadata blocks",
+			buildData: func(t *testing.T, dir string) string {
+				manifest := mustProviderManifest("github.com/acme/plugins/too-many-kinds", "1.0.0", testArtifactOS, testArtifactArch, testArtifactPath("provider"), sha256Hex("provider"))
+				manifest.Auth = &pluginmanifestv1.AuthMetadata{}
+				return mustWriteManifestData(t, dir, ManifestFile, mustRawManifestJSON(t, manifest))
+			},
+			wantError: "manifest must define exactly one of plugin, auth, datastore, or webui",
 		},
 		{
 			name: "entrypoint references unknown artifact",

--- a/gestaltd/internal/pluginpkg/provider_manifest_wire.go
+++ b/gestaltd/internal/pluginpkg/provider_manifest_wire.go
@@ -16,7 +16,6 @@ type providerManifestWireRoot struct {
 	DisplayName string                            `json:"display_name,omitempty" yaml:"display_name,omitempty"`
 	Description string                            `json:"description,omitempty" yaml:"description,omitempty"`
 	IconFile    string                            `json:"icon_file,omitempty" yaml:"icon_file,omitempty"`
-	Kinds       []string                          `json:"kinds,omitempty" yaml:"kinds,omitempty"`
 	Release     *pluginmanifestv1.ReleaseMetadata `json:"release,omitempty" yaml:"release,omitempty"`
 	Provider    *providerManifestWire             `json:"provider,omitempty" yaml:"provider,omitempty"`
 	WebUI       *pluginmanifestv1.WebUIMetadata   `json:"webui,omitempty" yaml:"webui,omitempty"`
@@ -120,7 +119,6 @@ func providerWireToInternal(wire *providerManifestWireRoot) *pluginmanifestv1.Ma
 		DisplayName: wire.DisplayName,
 		Description: wire.Description,
 		IconFile:    wire.IconFile,
-		Kinds:       append([]string(nil), wire.Kinds...),
 		Release:     wire.Release,
 		WebUI:       wire.WebUI,
 		Artifacts:   append([]pluginmanifestv1.Artifact(nil), wire.Artifacts...),
@@ -134,9 +132,6 @@ func providerWireToInternal(wire *providerManifestWireRoot) *pluginmanifestv1.Ma
 			ResponseMapping:   wire.Provider.ResponseMapping,
 			Pagination:        wire.Provider.Pagination,
 			AllowedOperations: wire.Provider.AllowedOperations,
-		}
-		if len(manifest.Kinds) == 0 {
-			manifest.Kinds = append(manifest.Kinds, pluginmanifestv1.KindPlugin)
 		}
 		if wire.Provider.MCP != nil {
 			manifest.Plugin.MCP = wire.Provider.MCP.Enabled
@@ -192,9 +187,6 @@ func providerWireToInternal(wire *providerManifestWireRoot) *pluginmanifestv1.Ma
 			manifest.Plugin.MCPURL = s.URL
 			manifest.Plugin.MCPConnection = remapManifestWireConnectionName(s.Connection)
 		}
-	}
-	if wire.WebUI != nil && len(manifest.Kinds) == 0 {
-		manifest.Kinds = append(manifest.Kinds, pluginmanifestv1.KindWebUI)
 	}
 	return manifest
 }

--- a/gestaltd/internal/pluginpkg/test_helpers_test.go
+++ b/gestaltd/internal/pluginpkg/test_helpers_test.go
@@ -50,7 +50,6 @@ func newProviderManifest(source, version, artifactPath, digest string) *pluginma
 	return &pluginmanifestv1.Manifest{
 		Source:  source,
 		Version: version,
-		Kinds:   []string{pluginmanifestv1.KindPlugin},
 		Plugin:  &pluginmanifestv1.Plugin{},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
@@ -93,7 +92,6 @@ func mustProviderManifest(source, version, osName, arch, artifactPath, sha strin
 	return &pluginmanifestv1.Manifest{
 		Source:  source,
 		Version: version,
-		Kinds:   []string{pluginmanifestv1.KindPlugin},
 		Plugin:  &pluginmanifestv1.Plugin{},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{

--- a/gestaltd/internal/pluginpkg/typescript_provider_test.go
+++ b/gestaltd/internal/pluginpkg/typescript_provider_test.go
@@ -579,7 +579,6 @@ func mustWriteTypeScriptSourceManifest(t *testing.T, root, pluginName string) st
 	data, err := EncodeSourceManifestFormat(&pluginmanifestv1.Manifest{
 		Source:  "github.com/testowner/plugins/" + pluginName,
 		Version: "0.0.1",
-		Kinds:   []string{pluginmanifestv1.KindPlugin},
 		Plugin: &pluginmanifestv1.Plugin{
 			Auth: &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeNone},
 		},
@@ -599,7 +598,6 @@ func mustWriteTypeScriptSourceComponentManifest(t *testing.T, root, pluginName, 
 	manifest := &pluginmanifestv1.Manifest{
 		Source:  "github.com/testowner/plugins/" + pluginName,
 		Version: "0.0.1",
-		Kinds:   []string{kind},
 	}
 	switch kind {
 	case pluginmanifestv1.KindAuth:

--- a/gestaltd/internal/pluginstore/store.go
+++ b/gestaltd/internal/pluginstore/store.go
@@ -25,26 +25,16 @@ type InstalledPlugin struct {
 }
 
 func isWebUIOnly(manifest *pluginmanifestv1.Manifest) bool {
-	return len(manifest.Kinds) == 1 && manifest.Kinds[0] == pluginmanifestv1.KindWebUI
+	kind, err := pluginpkg.ManifestKind(manifest)
+	return err == nil && kind == pluginmanifestv1.KindWebUI
 }
 
 func manifestNeedsExecutableArtifact(manifest *pluginmanifestv1.Manifest) bool {
-	if manifest == nil {
+	kind, err := pluginpkg.ManifestKind(manifest)
+	if err != nil {
 		return false
 	}
-	for _, kind := range []string{
-		pluginmanifestv1.KindPlugin,
-		pluginmanifestv1.KindAuth,
-		pluginmanifestv1.KindDatastore,
-	} {
-		if !manifestDeclaresKind(manifest, kind) {
-			continue
-		}
-		if pluginpkg.EntrypointForKind(manifest, kind) != nil {
-			return true
-		}
-	}
-	return false
+	return pluginpkg.EntrypointForKind(manifest, kind) != nil
 }
 
 func Install(packagePath, destDir string) (*InstalledPlugin, error) {
@@ -212,20 +202,11 @@ func executablePathForManifest(root string, manifest *pluginmanifestv1.Manifest)
 	if isWebUIOnly(manifest) {
 		return "", nil
 	}
-	var entry *pluginmanifestv1.Entrypoint
-	for _, kind := range []string{
-		pluginmanifestv1.KindPlugin,
-		pluginmanifestv1.KindAuth,
-		pluginmanifestv1.KindDatastore,
-	} {
-		if !manifestDeclaresKind(manifest, kind) {
-			continue
-		}
-		entry = pluginpkg.EntrypointForKind(manifest, kind)
-		if entry != nil {
-			break
-		}
+	kind, err := pluginpkg.ManifestKind(manifest)
+	if err != nil {
+		return "", err
 	}
+	entry := pluginpkg.EntrypointForKind(manifest, kind)
 	if entry == nil {
 		if manifest.Plugin != nil && manifest.Plugin.IsManifestBacked() {
 			return "", nil
@@ -236,18 +217,6 @@ func executablePathForManifest(root string, manifest *pluginmanifestv1.Manifest)
 		return "", fmt.Errorf("manifest entrypoint artifact_path is required")
 	}
 	return filepath.Join(root, filepath.FromSlash(entry.ArtifactPath)), nil
-}
-
-func manifestDeclaresKind(manifest *pluginmanifestv1.Manifest, kind string) bool {
-	if manifest == nil {
-		return false
-	}
-	for _, declared := range manifest.Kinds {
-		if declared == kind {
-			return true
-		}
-	}
-	return false
 }
 
 func copyManifestReferencedFiles(srcDir, destDir string, manifest *pluginmanifestv1.Manifest) error {

--- a/gestaltd/internal/pluginstore/store_test.go
+++ b/gestaltd/internal/pluginstore/store_test.go
@@ -65,35 +65,6 @@ func TestInstall(t *testing.T) {
 	}
 }
 
-func TestExecutablePathForManifestPrefersProviderEntrypoint(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	providerArtifact := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider"))
-	authArtifact := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "auth"))
-	manifest := &pluginmanifestv1.Manifest{
-		Source:  "github.com/testowner/plugins/multi-kind",
-		Version: "0.0.1-alpha.1",
-		Kinds:   []string{pluginmanifestv1.KindAuth, pluginmanifestv1.KindPlugin},
-		Auth:    &pluginmanifestv1.AuthMetadata{},
-		Plugin: &pluginmanifestv1.Plugin{
-			Auth: &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeNone},
-		},
-		Entrypoints: pluginmanifestv1.Entrypoints{
-			Auth:     &pluginmanifestv1.Entrypoint{ArtifactPath: authArtifact},
-			Provider: &pluginmanifestv1.Entrypoint{ArtifactPath: providerArtifact},
-		},
-	}
-
-	executablePath, err := executablePathForManifest(root, manifest)
-	if err != nil {
-		t.Fatalf("executablePathForManifest: %v", err)
-	}
-	if executablePath != filepath.Join(root, filepath.FromSlash(providerArtifact)) {
-		t.Fatalf("ExecutablePath = %q, want %q", executablePath, filepath.Join(root, filepath.FromSlash(providerArtifact)))
-	}
-}
-
 func TestInstallRejectsDigestMismatch(t *testing.T) {
 	t.Parallel()
 
@@ -514,7 +485,6 @@ func mustBuildPluginDir(t *testing.T, dir, source, version, content, schema stri
 	manifest := &pluginmanifestv1.Manifest{
 		Source:  source,
 		Version: version,
-		Kinds:   []string{pluginmanifestv1.KindPlugin},
 		Plugin: &pluginmanifestv1.Plugin{
 			ConfigSchemaPath: schemaPath,
 		},
@@ -559,7 +529,6 @@ func mustBuildPluginDirWithDigest(t *testing.T, dir, source, version, content, d
 	manifest := &pluginmanifestv1.Manifest{
 		Source:  source,
 		Version: version,
-		Kinds:   []string{pluginmanifestv1.KindPlugin},
 		Plugin:  &pluginmanifestv1.Plugin{},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
@@ -612,7 +581,6 @@ func mustBuildPackageWithDigest(t *testing.T, dir, source, version, content, dig
 	manifest := &pluginmanifestv1.Manifest{
 		Source:  source,
 		Version: version,
-		Kinds:   []string{pluginmanifestv1.KindPlugin},
 		Plugin:  &pluginmanifestv1.Plugin{},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
@@ -652,7 +620,6 @@ func mustBuildMismatchPackage(t *testing.T, dir, source, version, content, diges
 	manifest := &pluginmanifestv1.Manifest{
 		Source:  source,
 		Version: version,
-		Kinds:   []string{pluginmanifestv1.KindPlugin},
 		Plugin:  &pluginmanifestv1.Plugin{},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
@@ -714,7 +681,6 @@ func mustBuildPackageWithDuplicateArtifact(t *testing.T, dir, source, version, f
 	manifest := &pluginmanifestv1.Manifest{
 		Source:  source,
 		Version: version,
-		Kinds:   []string{pluginmanifestv1.KindPlugin},
 		Plugin:  &pluginmanifestv1.Plugin{},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{
@@ -775,7 +741,6 @@ func newV2Manifest(source, version, content string) *pluginmanifestv1.Manifest {
 	return &pluginmanifestv1.Manifest{
 		Source:  source,
 		Version: version,
-		Kinds:   []string{pluginmanifestv1.KindPlugin},
 		Plugin:  &pluginmanifestv1.Plugin{},
 		Artifacts: []pluginmanifestv1.Artifact{
 			{

--- a/gestaltd/internal/testutil/testdata/provider-go/plugin.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-go/plugin.yaml
@@ -2,8 +2,6 @@ source: github.com/valon-technologies/gestalt/provider-go
 version: 0.0.1-alpha.1
 display_name: Example Provider
 description: A minimal example provider built with the public SDK
-kinds:
-  - plugin
 plugin:
   connections:
     default:

--- a/gestaltd/internal/testutil/testdata/provider-rust-auth/plugin.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-rust-auth/plugin.yaml
@@ -2,6 +2,4 @@ source: github.com/valon-technologies/gestalt/provider-rust-auth
 version: 0.0.1-alpha.1
 display_name: Example Rust Auth Provider
 description: A minimal Rust auth provider built with the public Rust SDK
-kinds:
-  - auth
 auth: {}

--- a/gestaltd/internal/testutil/testdata/provider-rust-datastore/plugin.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-rust-datastore/plugin.yaml
@@ -2,6 +2,4 @@ source: github.com/valon-technologies/gestalt/provider-rust-datastore
 version: 0.0.1-alpha.1
 display_name: Example Rust Datastore Provider
 description: A minimal Rust datastore provider built with the public Rust SDK
-kinds:
-  - datastore
 datastore: {}

--- a/gestaltd/internal/testutil/testdata/provider-rust/plugin.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-rust/plugin.yaml
@@ -2,8 +2,6 @@ source: github.com/valon-technologies/gestalt/provider-rust
 version: 0.0.1-alpha.1
 display_name: Example Rust Provider
 description: A minimal example provider built with the public Rust SDK
-kinds:
-  - plugin
 plugin:
   connections:
     default:

--- a/gestaltd/sdk/pluginmanifest/v1/types.go
+++ b/gestaltd/sdk/pluginmanifest/v1/types.go
@@ -17,7 +17,6 @@ type Manifest struct {
 	DisplayName string             `json:"display_name,omitempty" yaml:"display_name,omitempty"`
 	Description string             `json:"description,omitempty" yaml:"description,omitempty"`
 	IconFile    string             `json:"icon_file,omitempty" yaml:"icon_file,omitempty"`
-	Kinds       []string           `json:"kinds" yaml:"kinds"`
 	Release     *ReleaseMetadata   `json:"release,omitempty" yaml:"release,omitempty"`
 	Plugin      *Plugin            `json:"plugin,omitempty" yaml:"plugin,omitempty"`
 	Auth        *AuthMetadata      `json:"auth,omitempty" yaml:"auth,omitempty"`


### PR DESCRIPTION
## What changed
- removed manifest-level `kinds` from the v1 manifest type and derive the manifest kind from the single top-level metadata block (`plugin`, `auth`, `datastore`, or `webui`)
- simplified manifest validation, package install, lifecycle kind checks, and provider release logic to operate on one manifest kind instead of a set
- deleted the explicit multi-kind manifest test path and trimmed fixtures, inline test manifests, and provider testdata that only existed to carry `kinds`
- updated docs and examples to describe kind inference from the top-level block instead of a `kinds` field

## Why
The codebase already documented and schematized manifests as exactly one kind, but the implementation still carried multi-kind plumbing. That created redundant state, special-case precedence rules, and extra test surface for a model we were not actually using.

## Impact
- manifests are simpler: the top-level metadata block is the source of truth for kind
- invalid manifests with zero or multiple metadata blocks now fail with one clear validation rule
- release/install paths no longer need to search across manifest kinds or reason about multi-kind source builds

## Validation
- `go test ./...` in `gestaltd/`
- `go test ./...` in `sdk/go/`
- post-rebase smoke: `go test ./internal/pluginpkg ./internal/pluginstore ./internal/operator ./internal/bootstrap ./cmd/gestaltd` in `gestaltd/`