### PR TITLE
Add datastore resource plugin lifecycle and host-side clients

### DIFF
--- a/gestaltd/core/resource.go
+++ b/gestaltd/core/resource.go
@@ -1,0 +1,89 @@
+package core
+
+import "context"
+
+// ResourceCapability identifies a storage capability that a resource provider
+// can expose.
+type ResourceCapability string
+
+const (
+	ResourceCapabilityKeyValue  ResourceCapability = "key_value"
+	ResourceCapabilitySQL       ResourceCapability = "sql"
+	ResourceCapabilityBlobStore ResourceCapability = "blob_store"
+)
+
+// ResourceProvider represents a started resource instance.
+type ResourceProvider interface {
+	Name() string
+	Capabilities() []ResourceCapability
+	Ping(ctx context.Context) error
+	Close() error
+}
+
+// ResourceHandle holds a resolved resource binding for a single consumer. At
+// most one of KV, SQL, or Blob is non-nil depending on the requested
+// capability.
+type ResourceHandle struct {
+	ResourceName string
+	Namespace    string
+	Capability   ResourceCapability
+	KV           KeyValueStore
+	SQL          SQLStore
+	Blob         BlobStore
+}
+
+// KeyValueStore is the consumer interface for key-value storage.
+type KeyValueStore interface {
+	Get(ctx context.Context, key string) (value []byte, found bool, err error)
+	Put(ctx context.Context, key string, value []byte) error
+	PutWithTTL(ctx context.Context, key string, value []byte, ttlSeconds int64) error
+	Delete(ctx context.Context, key string) (deleted bool, err error)
+	List(ctx context.Context, prefix string, cursor string, limit int32) (entries []KVEntry, nextCursor string, err error)
+}
+
+// KVEntry is a single key-value pair.
+type KVEntry struct {
+	Key   string
+	Value []byte
+}
+
+// SQLStore is the consumer interface for SQL storage.
+type SQLStore interface {
+	Query(ctx context.Context, query string, params ...any) (*SQLRows, error)
+	Exec(ctx context.Context, query string, params ...any) (SQLExecResult, error)
+	Migrate(ctx context.Context, migrations []SQLMigration) error
+}
+
+// SQLRows holds the result of a SQL query.
+type SQLRows struct {
+	Columns []string
+	Rows    [][]any
+}
+
+// SQLExecResult holds the result of a SQL exec statement.
+type SQLExecResult struct {
+	RowsAffected int64
+	LastInsertID int64
+}
+
+// SQLMigration describes a single forward migration.
+type SQLMigration struct {
+	Version     int32
+	Description string
+	UpSQL       string
+}
+
+// BlobStore is the consumer interface for blob storage.
+type BlobStore interface {
+	Get(ctx context.Context, key string) (data []byte, contentType string, err error)
+	Put(ctx context.Context, key string, data []byte, contentType string) error
+	Delete(ctx context.Context, key string) error
+	List(ctx context.Context, prefix string, cursor string, limit int32) (entries []BlobEntry, nextCursor string, err error)
+}
+
+// BlobEntry describes a single blob.
+type BlobEntry struct {
+	Key         string
+	Size        int64
+	ContentType string
+}

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -120,6 +120,7 @@ type Deps struct {
 	BaseURL       string
 	SecretManager core.SecretManager
 	Datastore     core.Datastore
+	Datastores    map[string]core.ResourceProvider
 	SQLDB         any // *sql.DB when available, nil otherwise
 	SQLDialect    any // Placeholder(int)string when available, nil otherwise
 	Egress        EgressDeps
@@ -153,6 +154,7 @@ func NewFactoryRegistry() *FactoryRegistry {
 type Result struct {
 	Auth             core.AuthProvider
 	Datastore        core.Datastore
+	Datastores       map[string]core.ResourceProvider
 	Providers        *registry.PluginMap[core.Provider]
 	ProvidersReady   <-chan struct{}
 	ConnectionAuth   func() map[string]map[string]OAuthHandler
@@ -199,6 +201,9 @@ func (r *Result) Close(ctx context.Context) error {
 		closeDatastore(r.Datastore),
 		closeSecretManager(r.SecretManager),
 	)
+	for _, ds := range r.Datastores {
+		errs = append(errs, ds.Close())
+	}
 	if r.auditClose != nil {
 		errs = append(errs, r.auditClose(ctx))
 	}
@@ -220,6 +225,7 @@ func closeIfPossible(values ...any) {
 type preparedCore struct {
 	Auth          core.AuthProvider
 	Datastore     core.Datastore
+	Datastores    *datastoreBuildResult
 	SecretManager core.SecretManager
 	Telemetry     core.TelemetryProvider
 	Deps          Deps
@@ -285,6 +291,12 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	if err != nil {
 		return nil, err
 	}
+	cleanupAuth := true
+	defer func() {
+		if cleanupAuth {
+			_ = closeAuth(auth)
+		}
+	}()
 
 	ds, err := buildDatastore(cfg, factories, deps)
 	if err != nil {
@@ -297,6 +309,18 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		}
 	}()
 
+	datastores, err := buildDatastores(ctx, cfg, deps)
+	if err != nil {
+		return nil, err
+	}
+	closeDatastores := true
+	defer func() {
+		if closeDatastores {
+			_ = datastores.Close()
+		}
+	}()
+
+	deps.Datastores = datastores.providers
 	deps.Egress = newEgressDeps(cfg, sm)
 	deps.Datastore = ds
 	if acc, ok := ds.(sqlDBAccessor); ok {
@@ -308,10 +332,13 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 
 	closeSM = false
 	shutdownTelemetry = false
+	cleanupAuth = false
 	closeDS = false
+	closeDatastores = false
 	return &preparedCore{
 		Auth:          auth,
 		Datastore:     ds,
+		Datastores:    datastores,
 		SecretManager: sm,
 		Telemetry:     tp,
 		Deps:          deps,
@@ -329,6 +356,9 @@ func (p *preparedCore) Close(ctx context.Context) error {
 		closeDatastore(p.Datastore),
 		closeSecretManager(p.SecretManager),
 	)
+	if p.Datastores != nil {
+		errs = append(errs, p.Datastores.Close())
+	}
 	if p.Telemetry != nil {
 		errs = append(errs, p.Telemetry.Shutdown(ctx))
 	}
@@ -385,6 +415,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	return &Result{
 		Auth:             prepared.Auth,
 		Datastore:        prepared.Datastore,
+		Datastores:       prepared.Datastores.providers,
 		Providers:        providers,
 		ProvidersReady:   providersReady,
 		ConnectionAuth:   connAuthResolver,

--- a/gestaltd/internal/bootstrap/resource_build.go
+++ b/gestaltd/internal/bootstrap/resource_build.go
@@ -1,0 +1,189 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/pluginhost"
+)
+
+// datastoreBuildResult holds started resource providers keyed by name.
+type datastoreBuildResult struct {
+	providers map[string]core.ResourceProvider
+}
+
+func (r *datastoreBuildResult) Close() error {
+	if r == nil {
+		return nil
+	}
+	var errs []error
+	for _, p := range r.providers {
+		if err := p.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func buildDatastores(ctx context.Context, cfg *config.Config, deps Deps) (*datastoreBuildResult, error) {
+	if len(cfg.Datastores) == 0 {
+		return &datastoreBuildResult{providers: map[string]core.ResourceProvider{}}, nil
+	}
+
+	type result struct {
+		name     string
+		provider core.ResourceProvider
+		err      error
+	}
+
+	var wg sync.WaitGroup
+	results := make(chan result, len(cfg.Datastores))
+
+	for name := range cfg.Datastores {
+		resDef := cfg.Datastores[name]
+		wg.Add(1)
+		go func(name string, resDef config.DatastoreDef) {
+			defer wg.Done()
+			provider, err := buildSingleResource(ctx, name, resDef, deps)
+			results <- result{name: name, provider: provider, err: err}
+		}(name, resDef)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	started := make(map[string]core.ResourceProvider, len(cfg.Datastores))
+	var firstErr error
+	for res := range results {
+		if res.err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("resource %q: %w", res.name, res.err)
+			}
+			continue
+		}
+		started[res.name] = res.provider
+		slog.Info("resource started", "name", res.name, "capabilities", res.provider.Capabilities())
+	}
+
+	if firstErr != nil {
+		for _, p := range started {
+			_ = p.Close()
+		}
+		return nil, firstErr
+	}
+
+	return &datastoreBuildResult{providers: started}, nil
+}
+
+func buildSingleResource(ctx context.Context, name string, resDef config.DatastoreDef, deps Deps) (core.ResourceProvider, error) {
+	if resDef.Provider == nil {
+		return nil, fmt.Errorf("provider is required")
+	}
+
+	cfgMap, err := config.NodeToMap(resDef.Config)
+	if err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+
+	execCfg := pluginhost.ResourceExecConfig{
+		Command:      resDef.Provider.Command,
+		Args:         resDef.Provider.Args,
+		Env:          resDef.Provider.Env,
+		Config:       cfgMap,
+		AllowedHosts: resDef.Provider.AllowedHosts,
+		HostBinary:   resDef.Provider.HostBinary,
+		Cleanup:      nil,
+		Name:         name,
+	}
+
+	provider, err := pluginhost.NewExecutableResource(ctx, execCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, wantCap := range resDef.Capabilities {
+		found := false
+		for _, haveCap := range provider.Capabilities() {
+			if string(haveCap) == wantCap {
+				found = true
+				break
+			}
+		}
+		if !found {
+			_ = provider.Close()
+			return nil, fmt.Errorf("declared capability %q not reported by provider (has %v)", wantCap, provider.Capabilities())
+		}
+	}
+
+	if err := provider.Ping(ctx); err != nil {
+		_ = provider.Close()
+		return nil, fmt.Errorf("health check failed: %w", err)
+	}
+
+	return provider, nil
+}
+
+// ResolveDatastoreHandles builds resource handles for a plugin's resource
+// bindings by looking up the started resource providers and creating
+// namespace-injecting wrappers.
+func ResolveDatastoreHandles(bindings map[string]config.DatastoreBindingDef, pluginName string, providers map[string]core.ResourceProvider) (map[string]*core.ResourceHandle, error) {
+	if len(bindings) == 0 {
+		return nil, nil
+	}
+
+	handles := make(map[string]*core.ResourceHandle, len(bindings))
+	for alias, binding := range bindings {
+		provider, ok := providers[binding.Resource]
+		if !ok {
+			return nil, fmt.Errorf("resource %q not found for binding %q", binding.Resource, alias)
+		}
+
+		ns := binding.Namespace
+		if ns == "" {
+			ns = pluginName
+		}
+
+		cap := core.ResourceCapability(binding.Capability)
+		handle := &core.ResourceHandle{
+			ResourceName: binding.Resource,
+			Namespace:    ns,
+			Capability:   cap,
+		}
+
+		remote, ok := provider.(*pluginhost.RemoteResourceProvider)
+		if !ok {
+			return nil, fmt.Errorf("resource %q: unexpected provider type", binding.Resource)
+		}
+
+		switch cap {
+		case core.ResourceCapabilityKeyValue:
+			kvClient := remote.KVClient()
+			if kvClient == nil {
+				return nil, fmt.Errorf("resource %q does not support key_value capability", binding.Resource)
+			}
+			handle.KV = pluginhost.NewNamespacedKVStore(kvClient, ns)
+		case core.ResourceCapabilitySQL:
+			sqlClient := remote.SQLClient()
+			if sqlClient == nil {
+				return nil, fmt.Errorf("resource %q does not support sql capability", binding.Resource)
+			}
+			handle.SQL = pluginhost.NewNamespacedSQLStore(sqlClient, ns)
+		case core.ResourceCapabilityBlobStore:
+			blobClient := remote.BlobClient()
+			if blobClient == nil {
+				return nil, fmt.Errorf("resource %q does not support blob_store capability", binding.Resource)
+			}
+			handle.Blob = pluginhost.NewNamespacedBlobStore(blobClient, ns)
+		}
+
+		handles[alias] = handle
+	}
+	return handles, nil
+}

--- a/gestaltd/internal/pluginhost/resource_client.go
+++ b/gestaltd/internal/pluginhost/resource_client.go
@@ -1,0 +1,395 @@
+package pluginhost
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/core"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// ResourceExecConfig holds the parameters for launching a resource provider
+// plugin as a child process.
+type ResourceExecConfig struct {
+	Command      string
+	Args         []string
+	Env          map[string]string
+	Config       map[string]any
+	AllowedHosts []string
+	HostBinary   string
+	Cleanup      func()
+	Name         string
+}
+
+// RemoteResourceProvider is the host-side representation of a resource plugin
+// process. It implements [core.ResourceProvider] and exposes typed gRPC clients
+// for each capability.
+type RemoteResourceProvider struct {
+	runtime      proto.ResourceRuntimeClient
+	kvClient     proto.KeyValueResourceClient
+	sqlClient    proto.SQLResourceClient
+	blobClient   proto.BlobStoreResourceClient
+	name         string
+	capabilities []core.ResourceCapability
+	closer       io.Closer
+}
+
+// NewExecutableResource launches a resource provider plugin process, configures
+// it, and returns a [core.ResourceProvider].
+func NewExecutableResource(ctx context.Context, cfg ResourceExecConfig) (core.ResourceProvider, error) {
+	proc, err := startPluginProcess(ctx, ExecConfig{
+		Command:      cfg.Command,
+		Args:         cfg.Args,
+		Env:          cfg.Env,
+		Config:       cfg.Config,
+		AllowedHosts: cfg.AllowedHosts,
+		HostBinary:   cfg.HostBinary,
+		Cleanup:      cfg.Cleanup,
+	}, nil, "")
+	if err != nil {
+		return nil, err
+	}
+
+	runtimeClient := proto.NewResourceRuntimeClient(proc.conn)
+	res, err := newRemoteResource(ctx, proc.conn, runtimeClient, cfg.Name, cfg.Config)
+	if err != nil {
+		_ = proc.Close()
+		return nil, err
+	}
+	res.closer = proc
+	return res, nil
+}
+
+func newRemoteResource(ctx context.Context, conn *grpc.ClientConn, runtimeClient proto.ResourceRuntimeClient, name string, config map[string]any) (*RemoteResourceProvider, error) {
+	res := &RemoteResourceProvider{
+		runtime: runtimeClient,
+	}
+	if err := res.configure(ctx, runtimeClient, name, config); err != nil {
+		return nil, err
+	}
+	for _, cap := range res.capabilities {
+		switch cap {
+		case core.ResourceCapabilityKeyValue:
+			res.kvClient = proto.NewKeyValueResourceClient(conn)
+		case core.ResourceCapabilitySQL:
+			res.sqlClient = proto.NewSQLResourceClient(conn)
+		case core.ResourceCapabilityBlobStore:
+			res.blobClient = proto.NewBlobStoreResourceClient(conn)
+		}
+	}
+	return res, nil
+}
+
+func (r *RemoteResourceProvider) configure(ctx context.Context, runtimeClient proto.ResourceRuntimeClient, name string, config map[string]any) error {
+	metaCtx, cancel := pluginConfigureContext(ctx)
+	defer cancel()
+	meta, err := runtimeClient.GetResourceMetadata(metaCtx, &emptypb.Empty{})
+	if err != nil {
+		return fmt.Errorf("get resource metadata: %w", err)
+	}
+
+	if err := validateResourceProtocol(meta); err != nil {
+		return err
+	}
+
+	cfgStruct, err := structFromMap(config)
+	if err != nil {
+		return fmt.Errorf("encode resource config: %w", err)
+	}
+	cfgCtx, cfgCancel := pluginConfigureContext(ctx)
+	defer cfgCancel()
+	cfgResp, err := runtimeClient.ConfigureResource(cfgCtx, &proto.ConfigureResourceRequest{
+		Name:            name,
+		Config:          cfgStruct,
+		ProtocolVersion: proto.CurrentProtocolVersion,
+	})
+	if err != nil {
+		return fmt.Errorf("configure resource %q: %w", name, err)
+	}
+	if cfgResp.GetProtocolVersion() != proto.CurrentProtocolVersion {
+		return fmt.Errorf("resource %q: protocol version mismatch: got %d, want %d",
+			name, cfgResp.GetProtocolVersion(), proto.CurrentProtocolVersion)
+	}
+
+	r.name = name
+	if meta.GetName() != "" {
+		r.name = meta.GetName()
+	}
+	for _, cap := range meta.GetCapabilities() {
+		switch cap {
+		case proto.ResourceCapability_RESOURCE_CAPABILITY_KEY_VALUE:
+			r.capabilities = append(r.capabilities, core.ResourceCapabilityKeyValue)
+		case proto.ResourceCapability_RESOURCE_CAPABILITY_SQL:
+			r.capabilities = append(r.capabilities, core.ResourceCapabilitySQL)
+		case proto.ResourceCapability_RESOURCE_CAPABILITY_BLOB_STORE:
+			r.capabilities = append(r.capabilities, core.ResourceCapabilityBlobStore)
+		}
+	}
+	return nil
+}
+
+func validateResourceProtocol(meta *proto.ResourceMetadata) error {
+	min := meta.GetMinProtocolVersion()
+	max := meta.GetMaxProtocolVersion()
+	if min == 0 && max == 0 {
+		return nil
+	}
+	if min > 0 && proto.CurrentProtocolVersion < min {
+		return fmt.Errorf("resource protocol version %d below minimum %d", proto.CurrentProtocolVersion, min)
+	}
+	if max > 0 && proto.CurrentProtocolVersion > max {
+		return fmt.Errorf("resource protocol version %d above maximum %d", proto.CurrentProtocolVersion, max)
+	}
+	return nil
+}
+
+func (r *RemoteResourceProvider) Name() string                            { return r.name }
+func (r *RemoteResourceProvider) Capabilities() []core.ResourceCapability { return r.capabilities }
+
+func (r *RemoteResourceProvider) Ping(ctx context.Context) error {
+	rpcCtx, cancel := context.WithTimeout(ctx, pluginRPCTimeout)
+	defer cancel()
+	resp, err := r.runtime.HealthCheck(rpcCtx, &emptypb.Empty{})
+	if err != nil {
+		return fmt.Errorf("resource health check: %w", err)
+	}
+	if !resp.GetReady() {
+		return fmt.Errorf("resource not ready: %s", resp.GetMessage())
+	}
+	return nil
+}
+
+func (r *RemoteResourceProvider) Close() error {
+	if r.closer != nil {
+		return r.closer.Close()
+	}
+	return nil
+}
+
+// HasCapability reports whether the resource provider supports the given
+// capability.
+func (r *RemoteResourceProvider) HasCapability(cap core.ResourceCapability) bool {
+	for _, c := range r.capabilities {
+		if c == cap {
+			return true
+		}
+	}
+	return false
+}
+
+// KVClient returns the KeyValue gRPC client, or nil if not supported.
+func (r *RemoteResourceProvider) KVClient() proto.KeyValueResourceClient { return r.kvClient }
+
+// SQLClient returns the SQL gRPC client, or nil if not supported.
+func (r *RemoteResourceProvider) SQLClient() proto.SQLResourceClient { return r.sqlClient }
+
+// BlobClient returns the BlobStore gRPC client, or nil if not supported.
+func (r *RemoteResourceProvider) BlobClient() proto.BlobStoreResourceClient { return r.blobClient }
+
+// --- Namespace-injecting consumer wrappers ---
+
+// NewNamespacedKVStore wraps a KeyValue gRPC client with a fixed namespace.
+func NewNamespacedKVStore(client proto.KeyValueResourceClient, namespace string) core.KeyValueStore {
+	return &namespacedKVStore{client: client, namespace: namespace}
+}
+
+type namespacedKVStore struct {
+	client    proto.KeyValueResourceClient
+	namespace string
+}
+
+func (s *namespacedKVStore) Get(ctx context.Context, key string) ([]byte, bool, error) {
+	resp, err := s.client.Get(ctx, &proto.KVGetRequest{Namespace: s.namespace, Key: key})
+	if err != nil {
+		return nil, false, err
+	}
+	return resp.GetValue(), resp.GetFound(), nil
+}
+
+func (s *namespacedKVStore) Put(ctx context.Context, key string, value []byte) error {
+	_, err := s.client.Put(ctx, &proto.KVPutRequest{Namespace: s.namespace, Key: key, Value: value})
+	return err
+}
+
+func (s *namespacedKVStore) PutWithTTL(ctx context.Context, key string, value []byte, ttlSeconds int64) error {
+	_, err := s.client.Put(ctx, &proto.KVPutRequest{Namespace: s.namespace, Key: key, Value: value, TtlSeconds: ttlSeconds})
+	return err
+}
+
+func (s *namespacedKVStore) Delete(ctx context.Context, key string) (bool, error) {
+	resp, err := s.client.Delete(ctx, &proto.KVDeleteRequest{Namespace: s.namespace, Key: key})
+	if err != nil {
+		return false, err
+	}
+	return resp.GetDeleted(), nil
+}
+
+func (s *namespacedKVStore) List(ctx context.Context, prefix string, cursor string, limit int32) ([]core.KVEntry, string, error) {
+	resp, err := s.client.List(ctx, &proto.KVListRequest{Namespace: s.namespace, Prefix: prefix, Cursor: cursor, Limit: limit})
+	if err != nil {
+		return nil, "", err
+	}
+	entries := make([]core.KVEntry, len(resp.GetEntries()))
+	for i, e := range resp.GetEntries() {
+		entries[i] = core.KVEntry{Key: e.GetKey(), Value: e.GetValue()}
+	}
+	return entries, resp.GetNextCursor(), nil
+}
+
+// NewNamespacedSQLStore wraps a SQL gRPC client with a fixed namespace.
+func NewNamespacedSQLStore(client proto.SQLResourceClient, namespace string) core.SQLStore {
+	return &namespacedSQLStore{client: client, namespace: namespace}
+}
+
+type namespacedSQLStore struct {
+	client    proto.SQLResourceClient
+	namespace string
+}
+
+func (s *namespacedSQLStore) Query(ctx context.Context, query string, params ...any) (*core.SQLRows, error) {
+	protoParams, err := anySliceToProtoSQLValues(params)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.client.Query(ctx, &proto.SQLQueryRequest{Namespace: s.namespace, Query: query, Params: protoParams})
+	if err != nil {
+		return nil, err
+	}
+	return protoSQLRowsToCore(resp), nil
+}
+
+func (s *namespacedSQLStore) Exec(ctx context.Context, query string, params ...any) (core.SQLExecResult, error) {
+	protoParams, err := anySliceToProtoSQLValues(params)
+	if err != nil {
+		return core.SQLExecResult{}, err
+	}
+	resp, err := s.client.Exec(ctx, &proto.SQLExecRequest{Namespace: s.namespace, Query: query, Params: protoParams})
+	if err != nil {
+		return core.SQLExecResult{}, err
+	}
+	return core.SQLExecResult{RowsAffected: resp.GetRowsAffected(), LastInsertID: resp.GetLastInsertId()}, nil
+}
+
+func (s *namespacedSQLStore) Migrate(ctx context.Context, migrations []core.SQLMigration) error {
+	protoMigrations := make([]*proto.SQLMigration, len(migrations))
+	for i, m := range migrations {
+		protoMigrations[i] = &proto.SQLMigration{Version: m.Version, Description: m.Description, UpSql: m.UpSQL}
+	}
+	_, err := s.client.Migrate(ctx, &proto.SQLMigrateRequest{Namespace: s.namespace, Migrations: protoMigrations})
+	return err
+}
+
+// NewNamespacedBlobStore wraps a BlobStore gRPC client with a fixed namespace.
+func NewNamespacedBlobStore(client proto.BlobStoreResourceClient, namespace string) core.BlobStore {
+	return &namespacedBlobStore{client: client, namespace: namespace}
+}
+
+type namespacedBlobStore struct {
+	client    proto.BlobStoreResourceClient
+	namespace string
+}
+
+func (s *namespacedBlobStore) Get(ctx context.Context, key string) ([]byte, string, error) {
+	resp, err := s.client.Get(ctx, &proto.BlobGetRequest{Namespace: s.namespace, Key: key})
+	if err != nil {
+		return nil, "", err
+	}
+	return resp.GetData(), resp.GetContentType(), nil
+}
+
+func (s *namespacedBlobStore) Put(ctx context.Context, key string, data []byte, contentType string) error {
+	_, err := s.client.Put(ctx, &proto.BlobPutRequest{Namespace: s.namespace, Key: key, Data: data, ContentType: contentType})
+	return err
+}
+
+func (s *namespacedBlobStore) Delete(ctx context.Context, key string) error {
+	_, err := s.client.Delete(ctx, &proto.BlobDeleteRequest{Namespace: s.namespace, Key: key})
+	return err
+}
+
+func (s *namespacedBlobStore) List(ctx context.Context, prefix string, cursor string, limit int32) ([]core.BlobEntry, string, error) {
+	resp, err := s.client.List(ctx, &proto.BlobListRequest{Namespace: s.namespace, Prefix: prefix, Cursor: cursor, Limit: limit})
+	if err != nil {
+		return nil, "", err
+	}
+	entries := make([]core.BlobEntry, len(resp.GetEntries()))
+	for i, e := range resp.GetEntries() {
+		entries[i] = core.BlobEntry{Key: e.GetKey(), Size: e.GetSize(), ContentType: e.GetContentType()}
+	}
+	return entries, resp.GetNextCursor(), nil
+}
+
+// --- Proto conversion helpers ---
+
+func anySliceToProtoSQLValues(params []any) ([]*proto.SQLValue, error) {
+	if len(params) == 0 {
+		return nil, nil
+	}
+	out := make([]*proto.SQLValue, len(params))
+	for i, p := range params {
+		out[i] = anyToProtoSQLValue(p)
+	}
+	return out, nil
+}
+
+func anyToProtoSQLValue(v any) *proto.SQLValue {
+	if v == nil {
+		return &proto.SQLValue{Kind: &proto.SQLValue_IsNull{IsNull: true}}
+	}
+	switch val := v.(type) {
+	case string:
+		return &proto.SQLValue{Kind: &proto.SQLValue_StringValue{StringValue: val}}
+	case int:
+		return &proto.SQLValue{Kind: &proto.SQLValue_IntValue{IntValue: int64(val)}}
+	case int64:
+		return &proto.SQLValue{Kind: &proto.SQLValue_IntValue{IntValue: val}}
+	case float64:
+		return &proto.SQLValue{Kind: &proto.SQLValue_DoubleValue{DoubleValue: val}}
+	case bool:
+		return &proto.SQLValue{Kind: &proto.SQLValue_BoolValue{BoolValue: val}}
+	case []byte:
+		return &proto.SQLValue{Kind: &proto.SQLValue_BytesValue{BytesValue: val}}
+	default:
+		return &proto.SQLValue{Kind: &proto.SQLValue_StringValue{StringValue: fmt.Sprintf("%v", val)}}
+	}
+}
+
+func protoSQLRowsToCore(resp *proto.SQLQueryResponse) *core.SQLRows {
+	if resp == nil {
+		return &core.SQLRows{}
+	}
+	rows := make([][]any, len(resp.GetRows()))
+	for i, row := range resp.GetRows() {
+		vals := make([]any, len(row.GetValues()))
+		for j, v := range row.GetValues() {
+			vals[j] = protoSQLValueToAny(v)
+		}
+		rows[i] = vals
+	}
+	return &core.SQLRows{Columns: resp.GetColumns(), Rows: rows}
+}
+
+func protoSQLValueToAny(v *proto.SQLValue) any {
+	if v == nil {
+		return nil
+	}
+	switch k := v.GetKind().(type) {
+	case *proto.SQLValue_StringValue:
+		return k.StringValue
+	case *proto.SQLValue_IntValue:
+		return k.IntValue
+	case *proto.SQLValue_DoubleValue:
+		return k.DoubleValue
+	case *proto.SQLValue_BoolValue:
+		return k.BoolValue
+	case *proto.SQLValue_BytesValue:
+		return k.BytesValue
+	case *proto.SQLValue_IsNull:
+		return nil
+	default:
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary
- Add `core/resource.go` with ResourceProvider, KeyValueStore, SQLStore, BlobStore interfaces
- Add `pluginhost/resource_client.go` with gRPC clients that inject namespace into every request
- Add `bootstrap/resource_build.go` for parallel resource startup, health check, capability verification
- Extend bootstrap `Deps` with `Resources` map, add resource cleanup to `Result.Close()`

Stacks on #787 (Phase 2: config).

## Test plan
- [x] gestaltd builds

Generated with [Claude Code](https://claude.com/claude-code)