### PR TITLE
Inject datastore resources into plugin processes

### DIFF
--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -172,7 +172,7 @@ func buildExecutablePluginProvider(ctx context.Context, name string, intg config
 	if err != nil {
 		return nil, fmt.Errorf("build executable plugin provider %q: %w", name, err)
 	}
-	pluginProv, err := buildPluginProvider(ctx, intg, pluginConfig, staticSpec)
+	pluginProv, err := buildPluginProvider(ctx, name, intg, pluginConfig, staticSpec, deps)
 	if err != nil {
 		return nil, err
 	}
@@ -466,7 +466,7 @@ func catalogOperationCount(cat *catalog.Catalog) int {
 	return len(cat.Operations)
 }
 
-func buildPluginProvider(ctx context.Context, intg config.IntegrationDef, pluginConfig map[string]any, spec pluginhost.StaticProviderSpec) (core.Provider, error) {
+func buildPluginProvider(ctx context.Context, name string, intg config.IntegrationDef, pluginConfig map[string]any, spec pluginhost.StaticProviderSpec, deps Deps) (core.Provider, error) {
 	command := intg.Plugin.Command
 	args := intg.Plugin.Args
 	env := clonePluginEnv(intg.Plugin.Env)
@@ -503,7 +503,12 @@ func buildPluginProvider(ctx context.Context, intg config.IntegrationDef, plugin
 		}()
 	}
 
-	prov, err := pluginhost.NewExecutableProvider(ctx, pluginhost.ExecConfig{
+	proxies, err := buildDatastoreProxies(intg, name, deps.Datastores)
+	if err != nil {
+		return nil, fmt.Errorf("build datastore proxies for %q: %w", name, err)
+	}
+
+	cfg := pluginhost.ExecConfig{
 		Command:      command,
 		Args:         args,
 		Env:          env,
@@ -512,12 +517,49 @@ func buildPluginProvider(ctx context.Context, intg config.IntegrationDef, plugin
 		AllowedHosts: intg.Plugin.AllowedHosts,
 		HostBinary:   intg.Plugin.HostBinary,
 		Cleanup:      cleanup,
-	})
+	}
+
+	var prov core.Provider
+	if len(proxies) > 0 {
+		prov, err = pluginhost.NewExecutableProviderWithResources(ctx, cfg, proxies)
+	} else {
+		prov, err = pluginhost.NewExecutableProvider(ctx, cfg)
+	}
 	if err != nil {
 		return nil, err
 	}
 	cleanup = nil
 	return prov, nil
+}
+
+func buildDatastoreProxies(intg config.IntegrationDef, intgName string, datastores map[string]core.ResourceProvider) ([]*pluginhost.ResourceProxy, error) {
+	if len(intg.Datastores) == 0 {
+		return nil, nil
+	}
+
+	proxies := make([]*pluginhost.ResourceProxy, 0, len(intg.Datastores))
+	for alias, binding := range intg.Datastores {
+		provider, ok := datastores[binding.Resource]
+		if !ok {
+			return nil, fmt.Errorf("resource %q not found for binding %q", binding.Resource, alias)
+		}
+		remote, ok := provider.(*pluginhost.RemoteResourceProvider)
+		if !ok {
+			return nil, fmt.Errorf("resource %q: unexpected provider type", binding.Resource)
+		}
+
+		ns := binding.Namespace
+		if ns == "" {
+			ns = intgName
+		}
+
+		rp, err := pluginhost.NewResourceProxy(remote, ns, binding.Capability)
+		if err != nil {
+			return nil, fmt.Errorf("binding %q: %w", alias, err)
+		}
+		proxies = append(proxies, rp)
+	}
+	return proxies, nil
 }
 
 func clonePluginEnv(src map[string]string) map[string]string {

--- a/gestaltd/internal/pluginhost/process.go
+++ b/gestaltd/internal/pluginhost/process.go
@@ -53,8 +53,43 @@ type pluginProcess struct {
 	closeErr       error
 }
 
+type ResourceProxy struct {
+	KV   proto.KeyValueResourceServer
+	SQL  proto.SQLResourceServer
+	Blob proto.BlobStoreResourceServer
+}
+
+func (rp *ResourceProxy) Register(srv *grpc.Server) {
+	if rp.KV != nil {
+		proto.RegisterKeyValueResourceServer(srv, rp.KV)
+	}
+	if rp.SQL != nil {
+		proto.RegisterSQLResourceServer(srv, rp.SQL)
+	}
+	if rp.Blob != nil {
+		proto.RegisterBlobStoreResourceServer(srv, rp.Blob)
+	}
+}
+
 func NewExecutableProvider(ctx context.Context, cfg ExecConfig) (core.Provider, error) {
-	proc, err := startPluginProcess(ctx, cfg, nil, "")
+	return newExecutableProvider(ctx, cfg, nil)
+}
+
+func NewExecutableProviderWithResources(ctx context.Context, cfg ExecConfig, resources []*ResourceProxy) (core.Provider, error) {
+	registerHost := func(srv *grpc.Server) {
+		for _, rp := range resources {
+			rp.Register(srv)
+		}
+	}
+	return newExecutableProvider(ctx, cfg, registerHost)
+}
+
+func newExecutableProvider(ctx context.Context, cfg ExecConfig, registerHost func(*grpc.Server)) (core.Provider, error) {
+	var hostSocketEnv string
+	if registerHost != nil {
+		hostSocketEnv = proto.EnvResourceHostSocket
+	}
+	proc, err := startPluginProcess(ctx, cfg, registerHost, hostSocketEnv)
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/pluginhost/resource_proxy.go
+++ b/gestaltd/internal/pluginhost/resource_proxy.go
@@ -1,0 +1,123 @@
+package pluginhost
+
+import (
+	"context"
+	"fmt"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// NewResourceProxy creates a [ResourceProxy] that forwards requests from a
+// plugin process to the actual resource provider for a single capability, with
+// the namespace hardcoded. Only the requested capability is exposed.
+func NewResourceProxy(provider *RemoteResourceProvider, namespace string, capability string) (*ResourceProxy, error) {
+	rp := &ResourceProxy{}
+	switch capability {
+	case "key_value":
+		kv := provider.KVClient()
+		if kv == nil {
+			return nil, fmt.Errorf("resource proxy: provider does not support key_value capability")
+		}
+		rp.KV = &kvProxyServer{client: kv, namespace: namespace}
+	case "sql":
+		sql := provider.SQLClient()
+		if sql == nil {
+			return nil, fmt.Errorf("resource proxy: provider does not support sql capability")
+		}
+		rp.SQL = &sqlProxyServer{client: sql, namespace: namespace}
+	case "blob_store":
+		blob := provider.BlobClient()
+		if blob == nil {
+			return nil, fmt.Errorf("resource proxy: provider does not support blob_store capability")
+		}
+		rp.Blob = &blobProxyServer{client: blob, namespace: namespace}
+	default:
+		return nil, fmt.Errorf("resource proxy: unknown capability %q", capability)
+	}
+	return rp, nil
+}
+
+// --- KV proxy ---
+
+type kvProxyServer struct {
+	proto.UnimplementedKeyValueResourceServer
+	client    proto.KeyValueResourceClient
+	namespace string
+}
+
+func (s *kvProxyServer) Get(ctx context.Context, req *proto.KVGetRequest) (*proto.KVGetResponse, error) {
+	req.Namespace = s.namespace
+	return s.client.Get(ctx, req)
+}
+
+func (s *kvProxyServer) Put(ctx context.Context, req *proto.KVPutRequest) (*emptypb.Empty, error) {
+	req.Namespace = s.namespace
+	return s.client.Put(ctx, req)
+}
+
+func (s *kvProxyServer) Delete(ctx context.Context, req *proto.KVDeleteRequest) (*proto.KVDeleteResponse, error) {
+	req.Namespace = s.namespace
+	return s.client.Delete(ctx, req)
+}
+
+func (s *kvProxyServer) List(ctx context.Context, req *proto.KVListRequest) (*proto.KVListResponse, error) {
+	req.Namespace = s.namespace
+	return s.client.List(ctx, req)
+}
+
+func (s *kvProxyServer) Migrate(ctx context.Context, req *proto.KVMigrateRequest) (*emptypb.Empty, error) {
+	req.Namespace = s.namespace
+	return s.client.Migrate(ctx, req)
+}
+
+// --- SQL proxy ---
+
+type sqlProxyServer struct {
+	proto.UnimplementedSQLResourceServer
+	client    proto.SQLResourceClient
+	namespace string
+}
+
+func (s *sqlProxyServer) Query(ctx context.Context, req *proto.SQLQueryRequest) (*proto.SQLQueryResponse, error) {
+	req.Namespace = s.namespace
+	return s.client.Query(ctx, req)
+}
+
+func (s *sqlProxyServer) Exec(ctx context.Context, req *proto.SQLExecRequest) (*proto.SQLExecResponse, error) {
+	req.Namespace = s.namespace
+	return s.client.Exec(ctx, req)
+}
+
+func (s *sqlProxyServer) Migrate(ctx context.Context, req *proto.SQLMigrateRequest) (*emptypb.Empty, error) {
+	req.Namespace = s.namespace
+	return s.client.Migrate(ctx, req)
+}
+
+// --- Blob proxy ---
+
+type blobProxyServer struct {
+	proto.UnimplementedBlobStoreResourceServer
+	client    proto.BlobStoreResourceClient
+	namespace string
+}
+
+func (s *blobProxyServer) Get(ctx context.Context, req *proto.BlobGetRequest) (*proto.BlobGetResponse, error) {
+	req.Namespace = s.namespace
+	return s.client.Get(ctx, req)
+}
+
+func (s *blobProxyServer) Put(ctx context.Context, req *proto.BlobPutRequest) (*emptypb.Empty, error) {
+	req.Namespace = s.namespace
+	return s.client.Put(ctx, req)
+}
+
+func (s *blobProxyServer) Delete(ctx context.Context, req *proto.BlobDeleteRequest) (*emptypb.Empty, error) {
+	req.Namespace = s.namespace
+	return s.client.Delete(ctx, req)
+}
+
+func (s *blobProxyServer) List(ctx context.Context, req *proto.BlobListRequest) (*proto.BlobListResponse, error) {
+	req.Namespace = s.namespace
+	return s.client.List(ctx, req)
+}


### PR DESCRIPTION
## Summary
- Add `GESTALT_RESOURCE_HOST_SOCKET` env var for plugin-to-host resource communication
- Add `NewExecutableProviderWithResources` that uses `registerHost` to expose namespace-injecting proxy servers
- Add `resource_proxy.go` with gRPC proxy servers that forward requests while hardcoding namespace
- Thread resource proxies through `buildPluginProvider` when integrations declare resource bindings

Stacks on #788 (Phase 3: lifecycle).

## Test plan
- [x] gestaltd builds

Generated with [Claude Code](https://claude.com/claude-code)