### PR TITLE
Document secrets provider kind across docs

### DIFF
--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -15,15 +15,16 @@ A provider's kind is implied by the one top-level metadata block in its manifest
 | `plugin` | Integration provider. Exposes operations that users invoke through the CLI, the HTTP API, or MCP. |
 | `auth` | Platform auth backend. Handles login, session validation, and external token verification. |
 | `datastore` | Persistent storage. Stores users, integration tokens, API tokens, and OAuth registrations. |
+| `secrets` | Secret manager. Resolves `secret://` references at bootstrap. Go SDK only for now. |
 | `webui` | Replacement web UI served at `/`. |
 
-First-party auth and datastore providers are published at `github.com/valon-technologies/gestalt-providers/`. You can write your own for any kind.
+First-party auth, datastore, and secrets providers are published at `github.com/valon-technologies/gestalt-providers/`. You can write your own for any kind.
 
 ## How the runtime works
 
 When a provider entry resolves to an executable, `gestaltd` starts it as a child process. The host creates a temporary Unix socket, passes the socket path through the `GESTALT_PLUGIN_SOCKET` environment variable, and waits for the provider to connect back over gRPC. At startup the provider receives the configured provider name and the `config` block from the server config. For integration plugins, each invocation also receives the current request context (caller identity, decrypted token, and operation parameters).
 
-The host owns auth, token storage, connection selection, and HTTP or MCP routing. Integration providers do not interact with the datastore. Auth providers implement `BeginLogin` and `CompleteLogin`. Datastore providers implement user, token, and API-token storage interfaces. Each kind has its own gRPC service contract, but they all share the same process lifecycle.
+The host owns auth, token storage, connection selection, and HTTP or MCP routing. Integration providers do not interact with the datastore. Auth providers implement `BeginLogin` and `CompleteLogin`. Datastore providers implement user, token, and API-token storage interfaces. Secrets providers implement `GetSecret` for resolving `secret://` references. Each kind has its own gRPC service contract, but they all share the same process lifecycle.
 
 ## Process isolation
 

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -52,9 +52,9 @@ datastore:
     dsn: ${POSTGRES_DSN}
 ```
 
-## Secret Managers (built-in)
+## Secret Managers
 
-Secret managers are compiled into the binary. They resolve `secret://` references and `${VAR}` expansions during bootstrap, before provider runtime bootstrapping is available.
+The following secret managers are compiled into the binary. They resolve `secret://` references during bootstrap. Custom secrets providers can also be written using the Go SDK's `SecretsProvider` interface and loaded as external provider processes, the same way auth and datastore providers work.
 
 | Name | Purpose |
 | --- | --- |

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -8,16 +8,17 @@ Providers are the umbrella concept in Gestalt. Auth providers, datastore provide
 
 ## Manifest Kinds
 
-Every manifest defines exactly one of four provider kinds, determined by which metadata block is present at the top level:
+Every manifest defines exactly one provider kind, determined by which metadata block is present at the top level:
 
 | Kind | Top-level key | Purpose |
 | --- | --- | --- |
 | `plugin` | `plugin` | Integration plugin (REST, OpenAPI, GraphQL, MCP, or executable). |
 | `auth` | `auth` | Platform auth provider (Google, OIDC, local, or custom). |
 | `datastore` | `datastore` | Persistence backend (Postgres, SQLite, DynamoDB, or custom). |
+| `secrets` | `secrets` | Secret manager for resolving `secret://` references. |
 | `webui` | `webui` | Static UI package served by `gestaltd`. |
 
-The JSON schema enforces `oneOf` across these four keys: a manifest must include exactly one. There is no separate `kind` or `kinds` field.
+A manifest must include exactly one of these keys. There is no separate `kind` or `kinds` field.
 
 ## Common Fields
 
@@ -42,6 +43,7 @@ The `entrypoints` block declares executable binaries. Each key corresponds to a 
 | `plugin` | plugin | Executable entrypoint for an integration plugin. |
 | `auth` | auth | Executable entrypoint for an auth provider. |
 | `datastore` | datastore | Executable entrypoint for a datastore provider. |
+| `secrets` | secrets | Executable entrypoint for a secrets provider. |
 
 Note that the JSON/YAML tag for the integration-plugin entrypoint is `plugin`, not `provider`. Each entrypoint has two fields:
 
@@ -473,7 +475,7 @@ plugin:
 
 ## Authoring Notes
 
-Manifest paths must stay inside the package. `source` and `version` are required. A manifest defines exactly one provider kind: `plugin`, `auth`, `datastore`, or `webui`.
+Manifest paths must stay inside the package. `source` and `version` are required. A manifest defines exactly one provider kind: `plugin`, `auth`, `datastore`, `secrets`, or `webui`.
 
 `config_schema_path` validates per-plugin config and may be written in JSON or YAML. Only the `default` connection may define `connection_params` and `post_connect_discovery`. The OpenAPI/GraphQL surface types are mutually exclusive, but MCP may be added alongside either.
 


### PR DESCRIPTION
The secrets provider interface landed in the Go SDK, adding a 5th provider kind alongside plugin, auth, datastore, and webui. Updates the providers overview, plugin manifests reference, and first-party providers page to include secrets in their kind tables and note that custom secrets providers can be written using the Go SDK's SecretsProvider interface.