### PR TITLE
Add SecretsProvider to the Rust SDK

### DIFF
--- a/sdk/rust/build.rs
+++ b/sdk/rust/build.rs
@@ -15,6 +15,7 @@ fn main() {
         proto_root.join("v1").join("runtime.proto"),
         proto_root.join("v1").join("auth.proto"),
         proto_root.join("v1").join("datastore.proto"),
+        proto_root.join("v1").join("secrets.proto"),
     ];
     let includes = [proto_root];
     let mut prost_config = prost_build::Config::new();

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -6,6 +6,8 @@ mod auth_server;
 mod catalog;
 mod datastore;
 mod datastore_server;
+mod secrets;
+mod secrets_server;
 mod env;
 mod error;
 mod provider_server;
@@ -34,6 +36,7 @@ pub use catalog::{Catalog, CatalogOperation};
 pub use datastore::{
     DatastoreProvider, OAuthRegistration, StoredApiToken, StoredIntegrationToken, StoredUser,
 };
+pub use secrets::SecretsProvider;
 pub use env::{CURRENT_PROTOCOL_VERSION, ENV_PLUGIN_SOCKET};
 pub use error::{Error, Result};
 #[doc(hidden)]
@@ -98,6 +101,16 @@ macro_rules! export_datastore_provider {
         pub fn __gestalt_serve_datastore(_name: &str) -> $crate::Result<()> {
             let provider = std::sync::Arc::new($constructor());
             $crate::runtime::run_datastore_provider(provider)
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! export_secrets_provider {
+    (constructor = $constructor:path $(,)?) => {
+        pub fn __gestalt_serve_secrets(_name: &str) -> $crate::Result<()> {
+            let provider = std::sync::Arc::new($constructor());
+            $crate::runtime::run_secrets_provider(provider)
         }
     };
 }

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -6,8 +6,6 @@ mod auth_server;
 mod catalog;
 mod datastore;
 mod datastore_server;
-mod secrets;
-mod secrets_server;
 mod env;
 mod error;
 mod provider_server;
@@ -15,6 +13,8 @@ mod router;
 mod rpc_status;
 pub mod runtime;
 mod runtime_server;
+mod secrets;
+mod secrets_server;
 
 /// Generated protobuf and gRPC bindings compiled from `sdk/proto/v1/*.proto`.
 mod generated {
@@ -36,12 +36,12 @@ pub use catalog::{Catalog, CatalogOperation};
 pub use datastore::{
     DatastoreProvider, OAuthRegistration, StoredApiToken, StoredIntegrationToken, StoredUser,
 };
-pub use secrets::SecretsProvider;
 pub use env::{CURRENT_PROTOCOL_VERSION, ENV_PLUGIN_SOCKET};
 pub use error::{Error, Result};
 #[doc(hidden)]
 pub use provider_server::{OperationResult, ProviderServer};
 pub use router::{Operation, Router};
+pub use secrets::SecretsProvider;
 pub use tonic::codegen::async_trait;
 
 #[doc(hidden)]

--- a/sdk/rust/src/runtime.rs
+++ b/sdk/rust/src/runtime.rs
@@ -26,17 +26,17 @@ use crate::generated::v1::datastore_provider_server::DatastoreProviderServer;
 #[cfg(unix)]
 use crate::generated::v1::plugin_provider_server::PluginProviderServer;
 #[cfg(unix)]
-use crate::generated::v1::secrets_provider_server::SecretsProviderServer;
-#[cfg(unix)]
 use crate::generated::v1::provider_lifecycle_server::ProviderLifecycleServer;
+#[cfg(unix)]
+use crate::generated::v1::secrets_provider_server::SecretsProviderServer;
 use crate::provider_server::ProviderServer;
 #[cfg(unix)]
 use crate::{AuthProvider, DatastoreProvider, SecretsProvider};
 use crate::{Provider, Router};
 #[cfg(unix)]
 use crate::{
-    auth_server::AuthServer, datastore_server::DatastoreServer,
-    secrets_server::SecretsServer, runtime_server::RuntimeServer,
+    auth_server::AuthServer, datastore_server::DatastoreServer, runtime_server::RuntimeServer,
+    secrets_server::SecretsServer,
 };
 
 fn build_runtime_and_block_on<F, Fut>(f: F) -> Result<()>
@@ -166,9 +166,9 @@ where
                 .add_service(ProviderLifecycleServer::new(RuntimeServer::for_secrets(
                     Arc::clone(&provider),
                 )))
-                .add_service(SecretsProviderServer::new(SecretsServer::new(
-                    Arc::clone(&provider),
-                )))
+                .add_service(SecretsProviderServer::new(SecretsServer::new(Arc::clone(
+                    &provider,
+                ))))
                 .serve_with_incoming_shutdown(incoming, shutdown_signal(parent_pid()))
         },
         |provider| async move { provider.close().await },

--- a/sdk/rust/src/runtime.rs
+++ b/sdk/rust/src/runtime.rs
@@ -26,14 +26,17 @@ use crate::generated::v1::datastore_provider_server::DatastoreProviderServer;
 #[cfg(unix)]
 use crate::generated::v1::plugin_provider_server::PluginProviderServer;
 #[cfg(unix)]
+use crate::generated::v1::secrets_provider_server::SecretsProviderServer;
+#[cfg(unix)]
 use crate::generated::v1::provider_lifecycle_server::ProviderLifecycleServer;
 use crate::provider_server::ProviderServer;
 #[cfg(unix)]
-use crate::{AuthProvider, DatastoreProvider};
+use crate::{AuthProvider, DatastoreProvider, SecretsProvider};
 use crate::{Provider, Router};
 #[cfg(unix)]
 use crate::{
-    auth_server::AuthServer, datastore_server::DatastoreServer, runtime_server::RuntimeServer,
+    auth_server::AuthServer, datastore_server::DatastoreServer,
+    secrets_server::SecretsServer, runtime_server::RuntimeServer,
 };
 
 fn build_runtime_and_block_on<F, Fut>(f: F) -> Result<()>
@@ -58,6 +61,10 @@ pub fn run_auth_provider<P: AuthProvider>(provider: Arc<P>) -> Result<()> {
 
 pub fn run_datastore_provider<P: DatastoreProvider>(provider: Arc<P>) -> Result<()> {
     build_runtime_and_block_on(|| serve_datastore_provider(provider))
+}
+
+pub fn run_secrets_provider<P: SecretsProvider>(provider: Arc<P>) -> Result<()> {
+    build_runtime_and_block_on(|| serve_secrets_provider(provider))
 }
 
 pub fn write_catalog_path<P>(router: &Router<P>, path: impl AsRef<Path>) -> Result<()> {
@@ -147,6 +154,28 @@ where
     .await
 }
 
+#[cfg(unix)]
+pub async fn serve_secrets_provider<P>(provider: Arc<P>) -> Result<()>
+where
+    P: SecretsProvider,
+{
+    serve_unix_plugin(
+        provider,
+        move |incoming, provider| {
+            Server::builder()
+                .add_service(ProviderLifecycleServer::new(RuntimeServer::for_secrets(
+                    Arc::clone(&provider),
+                )))
+                .add_service(SecretsProviderServer::new(SecretsServer::new(
+                    Arc::clone(&provider),
+                )))
+                .serve_with_incoming_shutdown(incoming, shutdown_signal(parent_pid()))
+        },
+        |provider| async move { provider.close().await },
+    )
+    .await
+}
+
 #[cfg(not(unix))]
 pub async fn serve_provider<P>(_provider: Arc<P>, router: Router<P>) -> Result<()>
 where
@@ -174,6 +203,16 @@ where
 pub async fn serve_datastore_provider<P>(_provider: Arc<P>) -> Result<()>
 where
     P: DatastoreProvider,
+{
+    Err(Error::internal(
+        "unix sockets are unsupported on this platform",
+    ))
+}
+
+#[cfg(not(unix))]
+pub async fn serve_secrets_provider<P>(_provider: Arc<P>) -> Result<()>
+where
+    P: SecretsProvider,
 {
     Err(Error::internal(
         "unix sockets are unsupported on this platform",

--- a/sdk/rust/src/runtime_server.rs
+++ b/sdk/rust/src/runtime_server.rs
@@ -6,6 +6,7 @@ use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
 use crate::api::RuntimeMetadata;
 use crate::auth::AuthProvider;
 use crate::datastore::DatastoreProvider;
+use crate::secrets::SecretsProvider;
 use crate::error::Result;
 use crate::generated::v1::provider_lifecycle_server::ProviderLifecycle;
 use crate::generated::v1::{
@@ -38,6 +39,10 @@ struct AuthRuntime<P> {
 }
 
 struct DatastoreRuntime<P> {
+    provider: Arc<P>,
+}
+
+struct SecretsRuntime<P> {
     provider: Arc<P>,
 }
 
@@ -74,6 +79,7 @@ macro_rules! impl_runtime_hooks {
 impl_runtime_hooks!(ProviderRuntime, Provider);
 impl_runtime_hooks!(AuthRuntime, AuthProvider);
 impl_runtime_hooks!(DatastoreRuntime, DatastoreProvider);
+impl_runtime_hooks!(SecretsRuntime, SecretsProvider);
 
 #[derive(Clone)]
 pub struct RuntimeServer {
@@ -109,6 +115,16 @@ impl RuntimeServer {
         Self {
             kind: PluginKind::Datastore,
             provider: Arc::new(DatastoreRuntime { provider }),
+        }
+    }
+
+    pub fn for_secrets<P>(provider: Arc<P>) -> Self
+    where
+        P: SecretsProvider,
+    {
+        Self {
+            kind: PluginKind::Secrets,
+            provider: Arc::new(SecretsRuntime { provider }),
         }
     }
 }

--- a/sdk/rust/src/runtime_server.rs
+++ b/sdk/rust/src/runtime_server.rs
@@ -6,13 +6,13 @@ use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
 use crate::api::RuntimeMetadata;
 use crate::auth::AuthProvider;
 use crate::datastore::DatastoreProvider;
-use crate::secrets::SecretsProvider;
 use crate::error::Result;
 use crate::generated::v1::provider_lifecycle_server::ProviderLifecycle;
 use crate::generated::v1::{
     ConfigurePluginRequest, ConfigurePluginResponse, HealthCheckResponse, PluginKind,
     PluginMetadata,
 };
+use crate::secrets::SecretsProvider;
 use crate::{CURRENT_PROTOCOL_VERSION, Provider};
 
 #[async_trait]

--- a/sdk/rust/src/secrets.rs
+++ b/sdk/rust/src/secrets.rs
@@ -1,0 +1,33 @@
+use tonic::codegen::async_trait;
+
+use crate::api::RuntimeMetadata;
+use crate::error::Result;
+
+#[async_trait]
+pub trait SecretsProvider: Send + Sync + 'static {
+    async fn configure(
+        &self,
+        _name: &str,
+        _config: serde_json::Map<String, serde_json::Value>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn metadata(&self) -> Option<RuntimeMetadata> {
+        None
+    }
+
+    fn warnings(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    async fn health_check(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn close(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn get_secret(&self, name: &str) -> Result<String>;
+}

--- a/sdk/rust/src/secrets_server.rs
+++ b/sdk/rust/src/secrets_server.rs
@@ -1,0 +1,38 @@
+use std::sync::Arc;
+
+use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
+
+use crate::generated::v1::secrets_provider_server::SecretsProvider as SecretsProviderGrpc;
+use crate::generated::v1::{GetSecretRequest, GetSecretResponse};
+use crate::rpc_status::rpc_status;
+use crate::secrets::SecretsProvider;
+
+#[derive(Clone)]
+pub struct SecretsServer<P> {
+    secrets: Arc<P>,
+}
+
+impl<P> SecretsServer<P> {
+    pub fn new(secrets: Arc<P>) -> Self {
+        Self { secrets }
+    }
+}
+
+#[tonic::async_trait]
+impl<P> SecretsProviderGrpc for SecretsServer<P>
+where
+    P: SecretsProvider,
+{
+    async fn get_secret(
+        &self,
+        request: GrpcRequest<GetSecretRequest>,
+    ) -> std::result::Result<GrpcResponse<GetSecretResponse>, Status> {
+        let request = request.into_inner();
+        let value = self
+            .secrets
+            .get_secret(&request.name)
+            .await
+            .map_err(|error| rpc_status("get secret", error))?;
+        Ok(GrpcResponse::new(GetSecretResponse { value }))
+    }
+}


### PR DESCRIPTION
Add secrets provider support to the Rust plugin SDK, following the same patterns established by AuthProvider and DatastoreProvider. This includes the secrets.proto service definition, the SecretsProvider async trait, the SecretsServer gRPC adapter, runtime lifecycle wiring (SecretsRuntime struct, RuntimeServer::for_secrets, serve/run functions for both unix and non-unix targets), and the export_secrets_provider! macro.