### PR TITLE
Add secrets provider authoring page with Go example

### DIFF
--- a/docs/content/providers/_meta.ts
+++ b/docs/content/providers/_meta.ts
@@ -2,6 +2,7 @@ export default {
   plugins: "Plugins",
   auth: "Auth",
   datastores: "Datastores",
+  secrets: "Secrets",
   "web-uis": "Web UIs",
   releasing: "Releasing",
 };

--- a/docs/content/providers/secrets.mdx
+++ b/docs/content/providers/secrets.mdx
@@ -1,0 +1,79 @@
+import { Tabs } from 'nextra/components'
+
+# Secrets
+
+Secrets providers resolve `secret://` references in the server config at bootstrap time. Gestalt ships several built-in secret managers (env, file, Google Secret Manager, AWS Secrets Manager, Vault, Azure Key Vault), but you can write your own for a custom secret backend using the same provider model as auth and datastores.
+
+The secrets provider interface is currently available in the Go SDK only. Python, Rust, and TypeScript support will follow.
+
+## Manifest
+
+A secrets provider manifest uses a `secrets` block:
+
+```yaml
+source: github.com/example/providers/my-secrets
+version: 0.0.1-alpha.1
+display_name: My Secrets Provider
+description: Custom secret resolution backend
+secrets:
+  config_schema_path: ./secrets_config.json
+```
+
+The optional `secrets.config_schema_path` field points to a JSON Schema that validates the `secrets.config` block in the server config.
+
+## Interface
+
+A secrets provider implements `Configure` and `GetSecret`. The host calls `GetSecret` once for each `secret://` reference found in the config during bootstrap. The provider returns the resolved plaintext value.
+
+<Tabs items={['Go']}>
+  <Tabs.Tab>
+    ```go
+    package main
+
+    import (
+    	"context"
+    	"fmt"
+    	"os"
+
+    	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+    )
+
+    type MySecrets struct {
+    	prefix string
+    }
+
+    func (s *MySecrets) Configure(_ context.Context, _ string, config map[string]any) error {
+    	s.prefix, _ = config["prefix"].(string)
+    	return nil
+    }
+
+    func (s *MySecrets) GetSecret(_ context.Context, name string) (string, error) {
+    	key := s.prefix + name
+    	val := os.Getenv(key)
+    	if val == "" {
+    		return "", fmt.Errorf("secret %q not found (env var %s)", name, key)
+    	}
+    	return val, nil
+    }
+
+    func main() {
+    	gestalt.ServeSecretsProvider(context.Background(), &MySecrets{})
+    }
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+`GetSecret` receives the name portion after the `secret://` prefix. For example, if the config contains `encryption_key: secret://my-encryption-key`, the provider receives `"my-encryption-key"` as the name. Return an error if the secret cannot be resolved; Gestalt treats any resolution failure as fatal and refuses to start.
+
+## Config reference
+
+```yaml
+secrets:
+  provider:
+    source:
+      path: ./my-secrets/plugin.yaml
+  config:
+    prefix: GESTALT_SECRET_
+```
+
+Note that `secrets.config` cannot itself use `secret://` references, because the secrets provider hasn't been initialized yet at that point. Use `${ENV_VAR}` or `${ENV_VAR_FILE}` for any credentials the secrets provider needs.


### PR DESCRIPTION
Adds a dedicated Secrets page to the Providers section with a Go SDK example showing the SecretsProvider interface (Configure + GetSecret) and ServeSecretsProvider. Includes manifest format, the bootstrap constraint that secrets.config cannot use secret:// references, and a config reference.