### PR TITLE
[codex] Preserve handler error statuses across SDKs

### DIFF
--- a/sdk/go/errors.go
+++ b/sdk/go/errors.go
@@ -48,6 +48,12 @@ func newOperationError(status int, message string, cause error) error {
 	}
 }
 
+// Error returns an operation error that causes the handler response to use the
+// provided HTTP status and message.
+func Error(status int, message string) error {
+	return newOperationError(status, message, nil)
+}
+
 func operationResultFromError(err error) *OperationResult {
 	if err == nil {
 		return nil

--- a/sdk/go/router.go
+++ b/sdk/go/router.go
@@ -76,7 +76,7 @@ func Register[P any, In any, Out any](
 
 			resp, err := handler(provider, ctx, input, req)
 			if err != nil {
-				return nil, newOperationError(http.StatusInternalServerError, err.Error(), err)
+				return nil, err
 			}
 
 			status := resp.Status
@@ -425,4 +425,3 @@ func isOptionalType(t reflect.Type) bool {
 		return false
 	}
 }
-

--- a/sdk/go/router_test.go
+++ b/sdk/go/router_test.go
@@ -2,6 +2,7 @@ package gestalt_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -122,6 +123,24 @@ func TestRouterOperationExecution(t *testing.T) {
 			},
 			(*execProvider).echo,
 		),
+		gestalt.Register(
+			gestalt.Operation[struct{}, struct{}]{
+				ID:     "bad_request",
+				Method: http.MethodPost,
+			},
+			func(*execProvider, context.Context, struct{}, gestalt.Request) (gestalt.Response[struct{}], error) {
+				return gestalt.Response[struct{}]{}, gestalt.Error(http.StatusBadRequest, "invalid input")
+			},
+		),
+		gestalt.Register(
+			gestalt.Operation[struct{}, struct{}]{
+				ID:     "plain_error",
+				Method: http.MethodPost,
+			},
+			func(*execProvider, context.Context, struct{}, gestalt.Request) (gestalt.Response[struct{}], error) {
+				return gestalt.Response[struct{}]{}, errors.New("boom")
+			},
+		),
 	)
 
 	provider := &execProvider{}
@@ -144,6 +163,28 @@ func TestRouterOperationExecution(t *testing.T) {
 	}
 	if result.Status != http.StatusNotFound {
 		t.Fatalf("nonexistent status = %d, want %d", result.Status, http.StatusNotFound)
+	}
+
+	result, err = router.Execute(ctx, provider, "bad_request", nil, "tok")
+	if err != nil {
+		t.Fatalf("Execute(bad_request): %v", err)
+	}
+	if result.Status != http.StatusBadRequest {
+		t.Fatalf("bad_request status = %d, want %d", result.Status, http.StatusBadRequest)
+	}
+	if result.Body != `{"error":"invalid input"}` {
+		t.Fatalf("bad_request body = %q, want %q", result.Body, `{"error":"invalid input"}`)
+	}
+
+	result, err = router.Execute(ctx, provider, "plain_error", nil, "tok")
+	if err != nil {
+		t.Fatalf("Execute(plain_error): %v", err)
+	}
+	if result.Status != http.StatusInternalServerError {
+		t.Fatalf("plain_error status = %d, want %d", result.Status, http.StatusInternalServerError)
+	}
+	if result.Body != `{"error":"boom"}` {
+		t.Fatalf("plain_error body = %q, want %q", result.Body, `{"error":"boom"}`)
 	}
 
 	var nilRouter *gestalt.Router[execProvider]

--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -1,4 +1,4 @@
-from ._api import OK, Model, Request, Response, field
+from ._api import OK, Error, Model, Request, Response, field
 from ._catalog import (
     Catalog,
     CatalogOperation,
@@ -43,6 +43,7 @@ __all__ = [
     "Closer",
     "CompleteLoginRequest",
     "DatastoreProvider",
+    "Error",
     "ExternalTokenValidator",
     "HealthChecker",
     "Model",

--- a/sdk/python/gestalt/_api.py
+++ b/sdk/python/gestalt/_api.py
@@ -30,6 +30,19 @@ def OK(body: T) -> Response[T]:
     return Response(status=HTTPStatus.OK, body=body)
 
 
+class Error(Exception):
+    def __init__(self, status: int | HTTPStatus, message: str = "") -> None:
+        self.status = int(status)
+        if message:
+            self.message = message
+        else:
+            try:
+                self.message = HTTPStatus(self.status).phrase
+            except ValueError:
+                self.message = ""
+        super().__init__(self.message)
+
+
 def field(
     *,
     description: str = "",

--- a/sdk/python/gestalt/_operations.py
+++ b/sdk/python/gestalt/_operations.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from http import HTTPStatus
 from typing import Any, Union, get_args, get_origin, get_type_hints
 
-from ._api import Request, Response
+from ._api import Error, Request, Response
 from ._serialization import json_body
 
 
@@ -87,6 +87,8 @@ def execute_operation(
             body = result
 
         return OperationResult(status=status, body=json_body(body))
+    except Error as error:
+        return _error_result(error.status, error.message)
     except Exception as error:
         traceback.print_exception(error)
         return _error_result(HTTPStatus.INTERNAL_SERVER_ERROR, str(error))
@@ -109,7 +111,7 @@ def run_sync(value: Any) -> Any:
     return value
 
 
-def _error_result(status: HTTPStatus, message: str) -> OperationResult:
+def _error_result(status: int, message: str) -> OperationResult:
     return OperationResult(status=status, body=json_body({"error": message}))
 
 

--- a/sdk/python/tests/test_plugin.py
+++ b/sdk/python/tests/test_plugin.py
@@ -4,7 +4,7 @@ import tempfile
 import unittest
 from dataclasses import dataclass
 
-from gestalt import OK, Plugin, Request, Response
+from gestalt import OK, Error, Plugin, Request, Response
 
 
 class PluginOperationTests(unittest.TestCase):
@@ -123,16 +123,24 @@ class PluginOperationTests(unittest.TestCase):
         self.assertEqual(json.loads(result.body), {"async": "result"})
 
     def test_handler_exception_returns_500(self) -> None:
-        """A handler that raises should return 500 with the error message."""
+        """Handler exceptions should preserve explicit statuses and default to 500 otherwise."""
         plugin = Plugin("test-plugin")
 
         @plugin.operation
         def broken() -> None:
             raise RuntimeError("something broke")
 
+        @plugin.operation
+        def missing() -> None:
+            raise Error(404, "record not found")
+
         result = plugin.execute("broken", {}, Request())
         self.assertEqual(result.status, 500)
         self.assertIn("something broke", json.loads(result.body)["error"])
+
+        result = plugin.execute("missing", {}, Request())
+        self.assertEqual(result.status, 404)
+        self.assertEqual(json.loads(result.body), {"error": "record not found"})
 
 
 class PluginConfigureTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
Preserve handler-selected HTTP status codes in the Go and Python SDKs instead of collapsing every handler error to `500 Internal Server Error`.

TypeScript is no longer part of this patch because current `main` already exposes a branded `response(status, body)` helper from `sdk/typescript`.

## Root cause
The Go and Python routers still treated every handler error as an internal server error. That meant validation failures, upstream `404`s, and other caller-visible errors could not be returned intentionally from handlers.

## What changed
- Go: exported `gestalt.Error(status, message)` and stopped re-wrapping handler errors as a fresh `500`, so structured handler errors preserve their status.
- Python: exported `gestalt.Error(status, message)` and taught operation execution to preserve that status without printing a traceback for intentional handler errors.
- Folded the new behavior into the existing router/plugin execution tests rather than adding separate bespoke test files.

## Developer impact
Provider authors can now return intentional non-500 responses from handlers for validation failures, not found cases, and upstream API errors in the Go and Python SDKs.

## Validation
- `go test ./...` in `sdk/go`
- `uv run python -m unittest discover -s tests` in `sdk/python`
- `uv run ruff check .` in `sdk/python`
