### PR TITLE
[codex] standardize HTTP instance/connection control params

### DIFF
--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -420,8 +420,8 @@ func (b *Broker) resolveUserToken(ctx context.Context, prov core.Provider, userI
 			for i, t := range tokens {
 				instances[i] = t.Instance
 			}
-			return ctx, "", fmt.Errorf("%w: integration %q has %d connections (%v); specify which instance to use",
-				ErrAmbiguousInstance, providerName, len(tokens), instances)
+			return ctx, "", fmt.Errorf("%w: integration %q has %d connections (%v); specify which instance to use with the %q parameter",
+				ErrAmbiguousInstance, providerName, len(tokens), instances, "_instance")
 		}
 	}
 

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -25,6 +26,8 @@ import (
 )
 
 const defaultTokenInstance = "default"
+const httpInstanceParam = "_instance"
+const httpConnectionParam = "_connection"
 
 const cliStatePrefix = "cli:"
 const maxPort = 65535
@@ -214,14 +217,17 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	requestedInstance := r.URL.Query().Get("instance")
-	requestedConnection := r.URL.Query().Get("connection")
+	requestedInstance, ok := resolveHTTPControlQueryParam(w, r.URL.Query(), httpInstanceParam, "instance", "instance", true)
+	if !ok {
+		auditErr = errors.New("invalid instance parameter")
+		return
+	}
+	requestedConnection, ok := resolveHTTPControlQueryParam(w, r.URL.Query(), httpConnectionParam, "connection", "connection", true)
+	if !ok {
+		auditErr = errors.New("invalid connection parameter")
+		return
+	}
 	if requestedConnection != "" {
-		if !safeParamValue.MatchString(requestedConnection) {
-			auditErr = errors.New("connection name contains invalid characters")
-			writeError(w, http.StatusBadRequest, "connection name contains invalid characters")
-			return
-		}
 		requestedConnection = config.ResolveConnectionAlias(requestedConnection)
 	}
 
@@ -267,9 +273,9 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 		for i, t := range matched {
 			labels[i] = fmt.Sprintf("%s/%s", t.Connection, t.Instance)
 		}
-		hint := "?instance=NAME"
+		hint := "?" + httpInstanceParam + "=NAME"
 		if requestedInstance != "" {
-			hint = "?connection=NAME"
+			hint = "?" + httpConnectionParam + "=NAME"
 		}
 		writeError(w, http.StatusConflict, fmt.Sprintf("multiple connections exist for %q (%v); specify %s", name, labels, hint))
 		return
@@ -353,6 +359,39 @@ func resolveRequestedInstance(w http.ResponseWriter, requested string) (string, 
 	return instance, true
 }
 
+func resolveHTTPControlQueryParam(w http.ResponseWriter, values url.Values, canonical, legacy, label string, allowLegacy bool) (string, bool) {
+	canonicalValue := values.Get(canonical)
+	legacyValue := ""
+	if allowLegacy {
+		legacyValue = values.Get(legacy)
+	}
+	if canonicalValue != "" && legacyValue != "" && canonicalValue != legacyValue {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("conflicting %s parameters %q and %q; use %q", label, legacy, canonical, canonical))
+		return "", false
+	}
+
+	value := canonicalValue
+	if value == "" {
+		value = legacyValue
+	}
+	if value != "" && !safeParamValue.MatchString(value) {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("%s name contains invalid characters", label))
+		return "", false
+	}
+	return value, true
+}
+
+func mergeHTTPControlParam(w http.ResponseWriter, label, key, queryValue, bodyValue string) (string, bool) {
+	if queryValue != "" && bodyValue != "" && queryValue != bodyValue {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("conflicting %s parameter %q in query string and JSON body", label, key))
+		return "", false
+	}
+	if bodyValue != "" {
+		return bodyValue, true
+	}
+	return queryValue, true
+}
+
 func resolveConnectionParams(w http.ResponseWriter, prov core.Provider, provided map[string]string) (map[string]string, bool) {
 	cpp, ok := prov.(core.ConnectionParamProvider)
 	if !ok {
@@ -373,14 +412,12 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	requestedConnection := r.URL.Query().Get("_connection")
-	if requestedConnection != "" && !safeParamValue.MatchString(requestedConnection) {
-		writeError(w, http.StatusBadRequest, "connection name contains invalid characters")
+	requestedConnection, ok := resolveHTTPControlQueryParam(w, r.URL.Query(), httpConnectionParam, "connection", "connection", true)
+	if !ok {
 		return
 	}
-	requestedInstance := r.URL.Query().Get("_instance")
-	if requestedInstance != "" && !safeParamValue.MatchString(requestedInstance) {
-		writeError(w, http.StatusBadRequest, "instance name contains invalid characters")
+	requestedInstance, ok := resolveHTTPControlQueryParam(w, r.URL.Query(), httpInstanceParam, "instance", "instance", true)
+	if !ok {
 		return
 	}
 	p := PrincipalFromContext(r.Context())
@@ -413,6 +450,15 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	requestedConnection, ok := resolveHTTPControlQueryParam(w, r.URL.Query(), httpConnectionParam, "connection", "connection", false)
+	if !ok {
+		return
+	}
+	requestedInstance, ok := resolveHTTPControlQueryParam(w, r.URL.Query(), httpInstanceParam, "instance", "instance", false)
+	if !ok {
+		return
+	}
+
 	params := make(map[string]any)
 	if r.Method == http.MethodPost {
 		if r.Body != nil {
@@ -430,10 +476,23 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	instance, _ := params["_instance"].(string)
-	delete(params, "_instance")
-	connection, _ := params["_connection"].(string)
-	delete(params, "_connection")
+	bodyInstance, _ := params[httpInstanceParam].(string)
+	delete(params, httpInstanceParam)
+	bodyConnection, _ := params[httpConnectionParam].(string)
+	delete(params, httpConnectionParam)
+
+	instance, ok := mergeHTTPControlParam(w, "instance", httpInstanceParam, requestedInstance, bodyInstance)
+	if !ok {
+		return
+	}
+	if instance != "" && !safeParamValue.MatchString(instance) {
+		writeError(w, http.StatusBadRequest, "instance name contains invalid characters")
+		return
+	}
+	connection, ok := mergeHTTPControlParam(w, "connection", httpConnectionParam, requestedConnection, bodyConnection)
+	if !ok {
+		return
+	}
 	ctx := r.Context()
 	if connection != "" {
 		if !safeParamValue.MatchString(connection) {

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -217,18 +216,23 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	requestedInstance, ok := resolveHTTPControlQueryParam(w, r.URL.Query(), httpInstanceParam, "instance", "instance", true)
-	if !ok {
-		auditErr = errors.New("invalid instance parameter")
-		return
+	requestedInstance := r.URL.Query().Get(httpInstanceParam)
+	if requestedInstance != "" {
+		var ok bool
+		requestedInstance, ok = resolveRequestedInstance(w, requestedInstance)
+		if !ok {
+			auditErr = errors.New("invalid instance parameter")
+			return
+		}
 	}
-	requestedConnection, ok := resolveHTTPControlQueryParam(w, r.URL.Query(), httpConnectionParam, "connection", "connection", true)
-	if !ok {
-		auditErr = errors.New("invalid connection parameter")
-		return
-	}
+	requestedConnection := r.URL.Query().Get(httpConnectionParam)
 	if requestedConnection != "" {
-		requestedConnection = config.ResolveConnectionAlias(requestedConnection)
+		var ok bool
+		requestedConnection, ok = s.resolveRequestedConnection(w, name, requestedConnection)
+		if !ok {
+			auditErr = errors.New("invalid connection parameter")
+			return
+		}
 	}
 
 	tokens, err := s.datastore.ListTokensForIntegration(r.Context(), userID, name)
@@ -359,39 +363,6 @@ func resolveRequestedInstance(w http.ResponseWriter, requested string) (string, 
 	return instance, true
 }
 
-func resolveHTTPControlQueryParam(w http.ResponseWriter, values url.Values, canonical, legacy, label string, allowLegacy bool) (string, bool) {
-	canonicalValue := values.Get(canonical)
-	legacyValue := ""
-	if allowLegacy {
-		legacyValue = values.Get(legacy)
-	}
-	if canonicalValue != "" && legacyValue != "" && canonicalValue != legacyValue {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("conflicting %s parameters %q and %q; use %q", label, legacy, canonical, canonical))
-		return "", false
-	}
-
-	value := canonicalValue
-	if value == "" {
-		value = legacyValue
-	}
-	if value != "" && !safeParamValue.MatchString(value) {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("%s name contains invalid characters", label))
-		return "", false
-	}
-	return value, true
-}
-
-func mergeHTTPControlParam(w http.ResponseWriter, label, key, queryValue, bodyValue string) (string, bool) {
-	if queryValue != "" && bodyValue != "" && queryValue != bodyValue {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("conflicting %s parameter %q in query string and JSON body", label, key))
-		return "", false
-	}
-	if bodyValue != "" {
-		return bodyValue, true
-	}
-	return queryValue, true
-}
-
 func resolveConnectionParams(w http.ResponseWriter, prov core.Provider, provided map[string]string) (map[string]string, bool) {
 	cpp, ok := prov.(core.ConnectionParamProvider)
 	if !ok {
@@ -412,13 +383,21 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	requestedConnection, ok := resolveHTTPControlQueryParam(w, r.URL.Query(), httpConnectionParam, "connection", "connection", true)
-	if !ok {
-		return
+	requestedConnection := r.URL.Query().Get(httpConnectionParam)
+	if requestedConnection != "" {
+		var ok bool
+		requestedConnection, ok = s.resolveRequestedConnection(w, name, requestedConnection)
+		if !ok {
+			return
+		}
 	}
-	requestedInstance, ok := resolveHTTPControlQueryParam(w, r.URL.Query(), httpInstanceParam, "instance", "instance", true)
-	if !ok {
-		return
+	requestedInstance := r.URL.Query().Get(httpInstanceParam)
+	if requestedInstance != "" {
+		var ok bool
+		requestedInstance, ok = resolveRequestedInstance(w, requestedInstance)
+		if !ok {
+			return
+		}
 	}
 	p := PrincipalFromContext(r.Context())
 	var resolver invocation.TokenResolver
@@ -450,13 +429,21 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	requestedConnection, ok := resolveHTTPControlQueryParam(w, r.URL.Query(), httpConnectionParam, "connection", "connection", false)
-	if !ok {
-		return
+	requestedConnection := r.URL.Query().Get(httpConnectionParam)
+	if requestedConnection != "" {
+		var ok bool
+		requestedConnection, ok = s.resolveRequestedConnection(w, providerName, requestedConnection)
+		if !ok {
+			return
+		}
 	}
-	requestedInstance, ok := resolveHTTPControlQueryParam(w, r.URL.Query(), httpInstanceParam, "instance", "instance", false)
-	if !ok {
-		return
+	requestedInstance := r.URL.Query().Get(httpInstanceParam)
+	if requestedInstance != "" {
+		var ok bool
+		requestedInstance, ok = resolveRequestedInstance(w, requestedInstance)
+		if !ok {
+			return
+		}
 	}
 
 	params := make(map[string]any)
@@ -481,17 +468,36 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 	bodyConnection, _ := params[httpConnectionParam].(string)
 	delete(params, httpConnectionParam)
 
-	instance, ok := mergeHTTPControlParam(w, "instance", httpInstanceParam, requestedInstance, bodyInstance)
-	if !ok {
+	if bodyInstance != "" {
+		var ok bool
+		bodyInstance, ok = resolveRequestedInstance(w, bodyInstance)
+		if !ok {
+			return
+		}
+	}
+	if requestedInstance != "" && bodyInstance != "" && requestedInstance != bodyInstance {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("conflicting instance parameter %q in query string and JSON body", httpInstanceParam))
 		return
 	}
-	if instance != "" && !safeParamValue.MatchString(instance) {
-		writeError(w, http.StatusBadRequest, "instance name contains invalid characters")
+	instance := bodyInstance
+	if instance == "" {
+		instance = requestedInstance
+	}
+
+	if bodyConnection != "" {
+		var ok bool
+		bodyConnection, ok = s.resolveRequestedConnection(w, providerName, bodyConnection)
+		if !ok {
+			return
+		}
+	}
+	if requestedConnection != "" && bodyConnection != "" && requestedConnection != bodyConnection {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("conflicting connection parameter %q in query string and JSON body", httpConnectionParam))
 		return
 	}
-	connection, ok := mergeHTTPControlParam(w, "connection", httpConnectionParam, requestedConnection, bodyConnection)
-	if !ok {
-		return
+	connection := bodyConnection
+	if connection == "" {
+		connection = requestedConnection
 	}
 	ctx := r.Context()
 	if connection != "" {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1378,6 +1378,95 @@ func TestDisconnectIntegration_NotConnected(t *testing.T) {
 	}
 }
 
+func TestDisconnectIntegration_AcceptsUnderscoredParameters(t *testing.T) {
+	t.Parallel()
+
+	var deletedTokenID string
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "slack", DN: "Slack"})
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, _ string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: "dev@example.com"}, nil
+			},
+			ListTokensForIntegrationFn: func(_ context.Context, userID, integration string) ([]*core.IntegrationToken, error) {
+				if userID != "u1" {
+					return nil, fmt.Errorf("unexpected user ID %q", userID)
+				}
+				if integration != "slack" {
+					return nil, fmt.Errorf("unexpected integration %q", integration)
+				}
+				return []*core.IntegrationToken{
+					{ID: "tok-a", UserID: "u1", Integration: "slack", Connection: "workspace", Instance: "team-a"},
+					{ID: "tok-b", UserID: "u1", Integration: "slack", Connection: "workspace", Instance: "team-b"},
+				}, nil
+			},
+			DeleteTokenFn: func(_ context.Context, id string) error {
+				deletedTokenID = id
+				return nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/integrations/slack?_connection=workspace&_instance=team-b", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if deletedTokenID != "tok-b" {
+		t.Fatalf("deleted token = %q, want %q", deletedTokenID, "tok-b")
+	}
+}
+
+func TestDisconnectIntegration_AmbiguousErrorMentionsCanonicalParameter(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "slack", DN: "Slack"})
+		cfg.Datastore = &coretesting.StubDatastore{
+			FindOrCreateUserFn: func(_ context.Context, _ string) (*core.User, error) {
+				return &core.User{ID: "u1", Email: "dev@example.com"}, nil
+			},
+			ListTokensForIntegrationFn: func(_ context.Context, _, integration string) ([]*core.IntegrationToken, error) {
+				if integration != "slack" {
+					return nil, fmt.Errorf("unexpected integration %q", integration)
+				}
+				return []*core.IntegrationToken{
+					{ID: "tok-a", UserID: "u1", Integration: "slack", Connection: "workspace", Instance: "team-a"},
+					{ID: "tok-b", UserID: "u1", Integration: "slack", Connection: "workspace", Instance: "team-b"},
+				}, nil
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/integrations/slack?_connection=workspace", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusConflict {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 409, got %d: %s", resp.StatusCode, body)
+	}
+	var result map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if !strings.Contains(result["error"], "?_instance=NAME") {
+		t.Fatalf("expected canonical parameter hint, got %q", result["error"])
+	}
+}
+
 func TestListOperations(t *testing.T) {
 	t.Parallel()
 
@@ -1714,6 +1803,13 @@ func TestListOperations_TokenSelectionErrors(t *testing.T) {
 			body, _ := io.ReadAll(resp.Body)
 			t.Fatalf("expected 409, got %d: %s", resp.StatusCode, body)
 		}
+		var result map[string]string
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decoding error response: %v", err)
+		}
+		if !strings.Contains(result["error"], `"_instance"`) {
+			t.Fatalf("expected error to mention _instance, got %q", result["error"])
+		}
 	})
 }
 
@@ -1774,8 +1870,10 @@ func TestExecuteOperation_UsesInjectedInvoker(t *testing.T) {
 
 	var called bool
 	var gotProvider string
+	var gotInstance string
 	var gotOperation string
 	var gotParams map[string]any
+	var gotConnection string
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, &stubIntegrationWithOps{
@@ -1785,11 +1883,13 @@ func TestExecuteOperation_UsesInjectedInvoker(t *testing.T) {
 			},
 		})
 		cfg.Invoker = &testutil.StubInvoker{
-			InvokeFn: func(_ context.Context, p *principal.Principal, providerName, _, operation string, params map[string]any) (*core.OperationResult, error) {
+			InvokeFn: func(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
 				called = true
 				gotProvider = providerName
+				gotInstance = instance
 				gotOperation = operation
 				gotParams = params
+				gotConnection = invocation.ConnectionFromContext(ctx)
 				if p == nil || p.Identity == nil || p.Identity.Email == "" {
 					t.Fatal("expected authenticated principal")
 				}
@@ -1799,7 +1899,7 @@ func TestExecuteOperation_UsesInjectedInvoker(t *testing.T) {
 	})
 	defer ts.Close()
 
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/custom-provider/custom-operation", bytes.NewBufferString(`{"foo":"bar"}`))
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/custom-provider/custom-operation?_connection=workspace&_instance=tenant-a", bytes.NewBufferString(`{"foo":"bar"}`))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -1815,11 +1915,23 @@ func TestExecuteOperation_UsesInjectedInvoker(t *testing.T) {
 	if gotProvider != "custom-provider" {
 		t.Fatalf("expected provider custom-provider, got %q", gotProvider)
 	}
+	if gotInstance != "tenant-a" {
+		t.Fatalf("expected instance tenant-a, got %q", gotInstance)
+	}
 	if gotOperation != "custom-operation" {
 		t.Fatalf("expected operation custom-operation, got %q", gotOperation)
 	}
+	if gotConnection != "workspace" {
+		t.Fatalf("expected connection workspace, got %q", gotConnection)
+	}
 	if gotParams["foo"] != "bar" {
 		t.Fatalf("expected params to include foo=bar, got %v", gotParams)
+	}
+	if _, ok := gotParams["_instance"]; ok {
+		t.Fatalf("expected _instance to be stripped from params, got %v", gotParams)
+	}
+	if _, ok := gotParams["_connection"]; ok {
+		t.Fatalf("expected _connection to be stripped from params, got %v", gotParams)
 	}
 }
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1307,46 +1307,139 @@ func TestListIntegrations_ListTokensError(t *testing.T) {
 func TestDisconnectIntegration(t *testing.T) {
 	t.Parallel()
 
-	stub := &coretesting.StubIntegration{N: "slack", DN: "Slack"}
-	var deletedID string
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = testutil.NewProviderRegistry(t, stub)
-		cfg.Datastore = &coretesting.StubDatastore{
-			FindOrCreateUserFn: func(_ context.Context, _ string) (*core.User, error) {
-				return &core.User{ID: "u1", Email: "dev@example.com"}, nil
-			},
-			ListTokensFn: func(_ context.Context, _ string) ([]*core.IntegrationToken, error) {
-				return []*core.IntegrationToken{
-					{ID: "tok-1", UserID: "u1", Integration: "slack", Instance: "default"},
-				}, nil
-			},
-			ListTokensForIntegrationFn: func(_ context.Context, _, _ string) ([]*core.IntegrationToken, error) {
-				return []*core.IntegrationToken{
-					{ID: "tok-1", UserID: "u1", Integration: "slack", Instance: "default"},
-				}, nil
-			},
-			DeleteTokenFn: func(_ context.Context, id string) error {
-				deletedID = id
-				return nil
-			},
+	t.Run("default token", func(t *testing.T) {
+		t.Parallel()
+
+		stub := &coretesting.StubIntegration{N: "slack", DN: "Slack"}
+		var deletedID string
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, stub)
+			cfg.Datastore = &coretesting.StubDatastore{
+				FindOrCreateUserFn: func(_ context.Context, _ string) (*core.User, error) {
+					return &core.User{ID: "u1", Email: "dev@example.com"}, nil
+				},
+				ListTokensFn: func(_ context.Context, _ string) ([]*core.IntegrationToken, error) {
+					return []*core.IntegrationToken{
+						{ID: "tok-1", UserID: "u1", Integration: "slack", Instance: "default"},
+					}, nil
+				},
+				ListTokensForIntegrationFn: func(_ context.Context, _, _ string) ([]*core.IntegrationToken, error) {
+					return []*core.IntegrationToken{
+						{ID: "tok-1", UserID: "u1", Integration: "slack", Instance: "default"},
+					}, nil
+				},
+				DeleteTokenFn: func(_ context.Context, id string) error {
+					deletedID = id
+					return nil
+				},
+			}
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/integrations/slack", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		}
+		if deletedID != "tok-1" {
+			t.Fatalf("expected token tok-1 to be deleted, got %q", deletedID)
 		}
 	})
-	testutil.CloseOnCleanup(t, ts)
 
-	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/integrations/slack", nil)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("request: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
+	t.Run("underscored parameters", func(t *testing.T) {
+		t.Parallel()
 
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
-	}
-	if deletedID != "tok-1" {
-		t.Fatalf("expected token tok-1 to be deleted, got %q", deletedID)
-	}
+		var deletedTokenID string
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "slack", DN: "Slack"})
+			cfg.Datastore = &coretesting.StubDatastore{
+				FindOrCreateUserFn: func(_ context.Context, _ string) (*core.User, error) {
+					return &core.User{ID: "u1", Email: "dev@example.com"}, nil
+				},
+				ListTokensForIntegrationFn: func(_ context.Context, userID, integration string) ([]*core.IntegrationToken, error) {
+					if userID != "u1" {
+						return nil, fmt.Errorf("unexpected user ID %q", userID)
+					}
+					if integration != "slack" {
+						return nil, fmt.Errorf("unexpected integration %q", integration)
+					}
+					return []*core.IntegrationToken{
+						{ID: "tok-a", UserID: "u1", Integration: "slack", Connection: "workspace", Instance: "team-a"},
+						{ID: "tok-b", UserID: "u1", Integration: "slack", Connection: "workspace", Instance: "team-b"},
+					}, nil
+				},
+				DeleteTokenFn: func(_ context.Context, id string) error {
+					deletedTokenID = id
+					return nil
+				},
+			}
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/integrations/slack?_connection=workspace&_instance=team-b", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		}
+		if deletedTokenID != "tok-b" {
+			t.Fatalf("deleted token = %q, want %q", deletedTokenID, "tok-b")
+		}
+	})
+
+	t.Run("ambiguous error uses canonical hint", func(t *testing.T) {
+		t.Parallel()
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "slack", DN: "Slack"})
+			cfg.Datastore = &coretesting.StubDatastore{
+				FindOrCreateUserFn: func(_ context.Context, _ string) (*core.User, error) {
+					return &core.User{ID: "u1", Email: "dev@example.com"}, nil
+				},
+				ListTokensForIntegrationFn: func(_ context.Context, _, integration string) ([]*core.IntegrationToken, error) {
+					if integration != "slack" {
+						return nil, fmt.Errorf("unexpected integration %q", integration)
+					}
+					return []*core.IntegrationToken{
+						{ID: "tok-a", UserID: "u1", Integration: "slack", Connection: "workspace", Instance: "team-a"},
+						{ID: "tok-b", UserID: "u1", Integration: "slack", Connection: "workspace", Instance: "team-b"},
+					}, nil
+				},
+			}
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/integrations/slack?_connection=workspace", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusConflict {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 409, got %d: %s", resp.StatusCode, body)
+		}
+		var result map[string]string
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decoding: %v", err)
+		}
+		if !strings.Contains(result["error"], "?_instance=NAME") {
+			t.Fatalf("expected canonical parameter hint, got %q", result["error"])
+		}
+	})
 }
 
 func TestDisconnectIntegration_NotConnected(t *testing.T) {
@@ -1375,95 +1468,6 @@ func TestDisconnectIntegration_NotConnected(t *testing.T) {
 
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", resp.StatusCode)
-	}
-}
-
-func TestDisconnectIntegration_AcceptsUnderscoredParameters(t *testing.T) {
-	t.Parallel()
-
-	var deletedTokenID string
-
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "slack", DN: "Slack"})
-		cfg.Datastore = &coretesting.StubDatastore{
-			FindOrCreateUserFn: func(_ context.Context, _ string) (*core.User, error) {
-				return &core.User{ID: "u1", Email: "dev@example.com"}, nil
-			},
-			ListTokensForIntegrationFn: func(_ context.Context, userID, integration string) ([]*core.IntegrationToken, error) {
-				if userID != "u1" {
-					return nil, fmt.Errorf("unexpected user ID %q", userID)
-				}
-				if integration != "slack" {
-					return nil, fmt.Errorf("unexpected integration %q", integration)
-				}
-				return []*core.IntegrationToken{
-					{ID: "tok-a", UserID: "u1", Integration: "slack", Connection: "workspace", Instance: "team-a"},
-					{ID: "tok-b", UserID: "u1", Integration: "slack", Connection: "workspace", Instance: "team-b"},
-				}, nil
-			},
-			DeleteTokenFn: func(_ context.Context, id string) error {
-				deletedTokenID = id
-				return nil
-			},
-		}
-	})
-	testutil.CloseOnCleanup(t, ts)
-
-	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/integrations/slack?_connection=workspace&_instance=team-b", nil)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("request: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
-	}
-	if deletedTokenID != "tok-b" {
-		t.Fatalf("deleted token = %q, want %q", deletedTokenID, "tok-b")
-	}
-}
-
-func TestDisconnectIntegration_AmbiguousErrorMentionsCanonicalParameter(t *testing.T) {
-	t.Parallel()
-
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "slack", DN: "Slack"})
-		cfg.Datastore = &coretesting.StubDatastore{
-			FindOrCreateUserFn: func(_ context.Context, _ string) (*core.User, error) {
-				return &core.User{ID: "u1", Email: "dev@example.com"}, nil
-			},
-			ListTokensForIntegrationFn: func(_ context.Context, _, integration string) ([]*core.IntegrationToken, error) {
-				if integration != "slack" {
-					return nil, fmt.Errorf("unexpected integration %q", integration)
-				}
-				return []*core.IntegrationToken{
-					{ID: "tok-a", UserID: "u1", Integration: "slack", Connection: "workspace", Instance: "team-a"},
-					{ID: "tok-b", UserID: "u1", Integration: "slack", Connection: "workspace", Instance: "team-b"},
-				}, nil
-			},
-		}
-	})
-	testutil.CloseOnCleanup(t, ts)
-
-	req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/integrations/slack?_connection=workspace", nil)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("request: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusConflict {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 409, got %d: %s", resp.StatusCode, body)
-	}
-	var result map[string]string
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		t.Fatalf("decoding: %v", err)
-	}
-	if !strings.Contains(result["error"], "?_instance=NAME") {
-		t.Fatalf("expected canonical parameter hint, got %q", result["error"])
 	}
 }
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1708,6 +1708,34 @@ func TestListOperations_UsesCatalogConnectionOverride(t *testing.T) {
 	if gotInstance != altInstance {
 		t.Fatalf("override list instance = %q, want %q", gotInstance, altInstance)
 	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations/test-int/operations?connection="+altCatalogConnection+"&instance="+altInstance, nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("legacy override list request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("legacy override list: expected 200, got %d: %s", resp.StatusCode, respBody)
+	}
+	ops = nil
+	if err := json.NewDecoder(resp.Body).Decode(&ops); err != nil {
+		t.Fatalf("decoding legacy override response: %v", err)
+	}
+	if len(ops) != 2 {
+		t.Fatalf("expected 2 legacy override operations, got %d", len(ops))
+	}
+	if ops[0]["id"] != "alpha_rest" {
+		t.Fatalf("expected first id 'alpha_rest' for legacy override, got %v", ops[0]["id"])
+	}
+	if ops[1]["id"] != "zeta_rest" {
+		t.Fatalf("expected second id 'zeta_rest' for legacy override, got %v", ops[1]["id"])
+	}
+	if gotConnection != testCatalogConnection {
+		t.Fatalf("legacy override list connection = %q, want %q", gotConnection, testCatalogConnection)
+	}
 }
 
 func TestListOperations_NotFound(t *testing.T) {


### PR DESCRIPTION
## Summary
Standardize the HTTP control parameters for instance/connection selection around `_instance` and `_connection`, and make the affected handlers consistent about how they read and report them.

## What changed
- `DELETE /api/v1/integrations/{name}` now uses the same canonical `_instance` / `_connection` query params as the other HTTP surfaces.
- `GET /api/v1/integrations/{name}/operations` remains canonical-only for `_instance` / `_connection` and now has an assertion that plain `instance` / `connection` do not override selection.
- `POST /api/v1/{integration}/{operation}` now honors `_instance` / `_connection` from the query string as well as the JSON body, with conflict checks when both sources disagree.
- Ambiguous-instance errors now mention the actual `_instance` parameter name.
- Regression coverage was folded into the existing server tests instead of adding new standalone test blocks where avoidable.

## Intent
This is an intentional breaking change. The HTTP API should use one control-parameter convention: `_instance` and `_connection`.
No legacy support for plain `instance` / `connection` is preserved.

## Why
The HTTP surface was inconsistent:
- disconnect used `instance` / `connection`
- list-operations and execute used `_instance` / `_connection`
- POST execute silently ignored query-string control params
- ambiguous-instance errors did not tell callers which parameter name to send

That made it easy to learn the wrong parameter spelling from one endpoint and reuse it on another.

## Validation
- `go test ./internal/server ./internal/invocation`
