### PR TITLE
[codex] Fail fast on missing config env vars

### DIFF
--- a/docs/content/architecture/index.mdx
+++ b/docs/content/architecture/index.mdx
@@ -10,7 +10,7 @@ This section covers the internal design of Gestalt: how the server starts up, ho
 
 When `gestaltd serve` starts, it goes through a specific sequence that matters when you're debugging boot failures.
 
-First, the YAML config file is loaded and `${ENV_VAR}` placeholders are expanded. If a variable isn't set, Gestalt checks for a corresponding `_FILE` variable and reads that file instead (this is how Docker secrets work). Unknown fields are rejected.
+First, the YAML config file is loaded and `${ENV_VAR}` placeholders are expanded. If a variable isn't set, Gestalt checks for a corresponding `_FILE` variable and reads that file instead (this is how Docker secrets work). If neither exists, config loading fails. Use `${ENV_VAR:-}` when an explicit empty default is intentional. Unknown fields are rejected.
 
 Next, Gestalt initializes the secret manager from the `secrets` block. This is the one part of config that *cannot* use `secret://` references, because the secret manager doesn't exist yet. Credentials for the secret manager itself have to come in through `${ENV_VAR}` or `${ENV_VAR_FILE}`.
 

--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -15,7 +15,7 @@ If nothing is found, `gestaltd` generates a default config at `~/.gestaltd/confi
 
 ### Environment expansion
 
-Gestalt expands `${ENV_VAR}` placeholders before YAML decoding. When a referenced variable is unset but a corresponding `ENV_VAR_FILE` variable exists, Gestalt reads the value from that file path instead. This is useful for container runtimes that mount secrets as files.
+Gestalt expands `${ENV_VAR}` placeholders before YAML decoding. When a referenced variable is unset, Gestalt checks for a corresponding `ENV_VAR_FILE` variable and reads that file path instead. If neither is set, config loading fails. Use `${ENV_VAR:-}` when an explicit empty default is intentional. This is useful for container runtimes that mount secrets as files.
 
 ### Secret resolution
 

--- a/docs/content/deploy/docker.mdx
+++ b/docs/content/deploy/docker.mdx
@@ -72,7 +72,7 @@ why `serve --locked` depends on it.
 
 ## Environment variables and secrets
 
-Gestalt expands `${VAR}` placeholders in the config before YAML decoding. The image also supports the `*_FILE` convention: if `VAR` is not set but `VAR_FILE` is, `${VAR}` resolves to the contents of that file. This works well with Docker secrets:
+Gestalt expands `${VAR}` placeholders in the config before YAML decoding. The image also supports the `*_FILE` convention: if `VAR` is not set but `VAR_FILE` is, `${VAR}` resolves to the contents of that file. If neither is set, config loading fails. Use `${VAR:-}` when an explicit empty default is intentional. This works well with Docker secrets:
 
 ```sh
 docker run --rm \

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -18,7 +18,7 @@ ui: {}
 
 ## Load Semantics
 
-`${ENV_VAR}` references are expanded before YAML decoding. When a referenced variable is unset but a corresponding `ENV_VAR_FILE` variable exists, Gestalt reads the value from that file path instead. Unknown YAML fields are rejected.
+`${ENV_VAR}` references are expanded before YAML decoding. When a referenced variable is unset, Gestalt checks for a corresponding `ENV_VAR_FILE` variable and reads that file path instead. If neither is set, config loading fails. Use `${ENV_VAR:-}` when an explicit empty default is intentional. Unknown YAML fields are rejected.
 
 Several fields carry defaults when omitted: `server.public.port` defaults to `8080`, `secrets.provider` to `env`, and `telemetry.provider` to `stdout`. Relative paths resolve relative to the config file's directory. `secret://...` values are resolved during bootstrap, not during YAML parsing.
 

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -177,6 +177,7 @@ Gestalt expands `${VAR}` placeholders before YAML decode. The image also support
 
 - if `VAR` is set, `${VAR}` resolves to that value
 - otherwise, if `VAR_FILE` is set, `${VAR}` resolves to the contents of that file
+- otherwise, config loading fails unless you used `${VAR:-}` for an explicit empty default
 
 That means this works well with Docker secrets:
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -49,14 +49,6 @@ type Config struct {
 	UI           UIConfig                  `yaml:"ui"`
 }
 
-type missingEnvAction int
-
-const (
-	missingEnvError missingEnvAction = iota
-	missingEnvEmpty
-	missingEnvPreserve
-)
-
 type TelemetryConfig struct {
 	Provider string    `yaml:"provider"`
 	Config   yaml.Node `yaml:"config"`
@@ -708,15 +700,15 @@ func EffectiveNamedConnectionDef(plugin *ProviderDef, manifestPlugin *pluginmani
 type OperationOverride = pluginmanifestv1.ManifestOperationOverride
 
 func Load(path string) (*Config, error) {
-	return loadWithLookup(path, os.LookupEnv, missingEnvError)
+	return loadWithLookup(path, os.LookupEnv, false)
 }
 
 func LoadWithLookup(path string, lookup func(string) (string, bool)) (*Config, error) {
-	return loadWithLookup(path, lookup, missingEnvError)
+	return loadWithLookup(path, lookup, false)
 }
 
 func LoadAllowMissingEnv(path string) (*Config, error) {
-	return loadWithLookup(path, os.LookupEnv, missingEnvEmpty)
+	return loadWithLookup(path, os.LookupEnv, true)
 }
 
 func OverlayManagedPluginConfig(path string, cfg *Config) error {
@@ -771,7 +763,7 @@ func overlayManagedPluginConfigNode(raw *yaml.Node, plugin *ProviderDef, subject
 	if configNode == nil || configNode.Kind == 0 {
 		return nil
 	}
-	node, err := overlayEnvIntoNode(*configNode, os.LookupEnv, missingEnvPreserve)
+	node, err := overlayEnvIntoNode(*configNode, os.LookupEnv, true)
 	if err != nil {
 		return fmt.Errorf("expanding managed plugin config for %s: %w", subject, err)
 	}
@@ -787,7 +779,7 @@ func overlayManagedComponentConfigNode(raw *yaml.Node, provider *ProviderDef, ta
 	if configNode == nil || configNode.Kind == 0 {
 		return nil
 	}
-	node, err := overlayEnvIntoNode(*configNode, os.LookupEnv, missingEnvPreserve)
+	node, err := overlayEnvIntoNode(*configNode, os.LookupEnv, true)
 	if err != nil {
 		return fmt.Errorf("expanding managed provider config for %s: %w", subject, err)
 	}
@@ -818,15 +810,18 @@ func mappingValueNode(node *yaml.Node, key string) *yaml.Node {
 	return nil
 }
 
-func loadWithLookup(path string, lookup func(string) (string, bool), missingEnv missingEnvAction) (*Config, error) {
+func loadWithLookup(path string, lookup func(string) (string, bool), allowMissing bool) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading config file: %w", err)
 	}
 
-	resolved, err := expandEnvVariables(string(data), lookup, missingEnv)
+	resolved, firstMissing, err := expandEnvVariables(string(data), lookup, !allowMissing)
 	if err != nil {
 		return nil, err
+	}
+	if !allowMissing && firstMissing != "" {
+		return nil, fmt.Errorf("expanding config environment variables: environment variable %q not set; use ${%s:-} to allow an empty default", firstMissing, firstMissing)
 	}
 
 	var cfg Config
@@ -861,8 +856,9 @@ func parseEnvPlaceholder(key string) (name string, allowEmptyDefault bool, err e
 	return name, true, nil
 }
 
-func expandEnvVariables(input string, lookup func(string) (string, bool), missingEnv missingEnvAction) (string, error) {
+func expandEnvVariables(input string, lookup func(string) (string, bool), preserveMissing bool) (string, string, error) {
 	var expandErr error
+	var firstMissing string
 	resolved := os.Expand(input, func(key string) string {
 		if expandErr != nil {
 			return ""
@@ -880,13 +876,12 @@ func expandEnvVariables(input string, lookup func(string) (string, bool), missin
 			if allowEmptyDefault {
 				return ""
 			}
-			switch missingEnv {
-			case missingEnvPreserve:
+			if preserveMissing {
+				if firstMissing == "" {
+					firstMissing = name
+				}
 				return "${" + key + "}"
-			case missingEnvEmpty:
-				return ""
 			}
-			expandErr = fmt.Errorf("environment variable %q not set; use ${%s:-} to allow an empty default", name, name)
 			return ""
 		}
 		data, err := os.ReadFile(filePath)
@@ -897,18 +892,18 @@ func expandEnvVariables(input string, lookup func(string) (string, bool), missin
 		return strings.TrimRight(string(data), "\r\n")
 	})
 	if expandErr != nil {
-		return "", fmt.Errorf("expanding config environment variables: %w", expandErr)
+		return "", "", fmt.Errorf("expanding config environment variables: %w", expandErr)
 	}
-	return resolved, nil
+	return resolved, firstMissing, nil
 }
 
-func overlayEnvIntoNode(node yaml.Node, lookup func(string) (string, bool), missingEnv missingEnvAction) (yaml.Node, error) {
+func overlayEnvIntoNode(node yaml.Node, lookup func(string) (string, bool), preserveMissing bool) (yaml.Node, error) {
 	data, err := yaml.Marshal(&node)
 	if err != nil {
 		return yaml.Node{}, fmt.Errorf("marshaling config node: %w", err)
 	}
 
-	resolved, err := expandEnvVariables(string(data), lookup, missingEnv)
+	resolved, _, err := expandEnvVariables(string(data), lookup, preserveMissing)
 	if err != nil {
 		return yaml.Node{}, err
 	}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -835,25 +835,48 @@ func loadWithLookup(path string, lookup func(string) (string, bool), preserveMis
 	return &cfg, nil
 }
 
+func parseEnvPlaceholder(key string) (name string, allowEmptyDefault bool, err error) {
+	if !strings.Contains(key, ":-") {
+		return key, false, nil
+	}
+	name, defaultValue, _ := strings.Cut(key, ":-")
+	if name == "" {
+		return "", false, fmt.Errorf("invalid environment placeholder ${%s}", key)
+	}
+	if defaultValue != "" {
+		return "", false, fmt.Errorf("unsupported environment placeholder ${%s}: only ${%s:-} is supported for empty defaults", key, name)
+	}
+	return name, true, nil
+}
+
 func expandEnvVariables(input string, lookup func(string) (string, bool), preserveMissing bool) (string, error) {
 	var expandErr error
 	resolved := os.Expand(input, func(key string) string {
 		if expandErr != nil {
 			return ""
 		}
-		if val, ok := lookup(key); ok {
+		name, allowEmptyDefault, err := parseEnvPlaceholder(key)
+		if err != nil {
+			expandErr = err
+			return ""
+		}
+		if val, ok := lookup(name); ok {
 			return val
 		}
-		filePath, ok := lookup(key + "_FILE")
+		filePath, ok := lookup(name + "_FILE")
 		if !ok || filePath == "" {
+			if allowEmptyDefault {
+				return ""
+			}
 			if preserveMissing {
 				return "${" + key + "}"
 			}
+			expandErr = fmt.Errorf("environment variable %q not set; use ${%s:-} to allow an empty default", name, name)
 			return ""
 		}
 		data, err := os.ReadFile(filePath)
 		if err != nil {
-			expandErr = fmt.Errorf("resolving %s_FILE: %w", key, err)
+			expandErr = fmt.Errorf("resolving %s_FILE: %w", name, err)
 			return ""
 		}
 		return strings.TrimRight(string(data), "\r\n")

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -49,6 +49,14 @@ type Config struct {
 	UI           UIConfig                  `yaml:"ui"`
 }
 
+type missingEnvAction int
+
+const (
+	missingEnvError missingEnvAction = iota
+	missingEnvEmpty
+	missingEnvPreserve
+)
+
 type TelemetryConfig struct {
 	Provider string    `yaml:"provider"`
 	Config   yaml.Node `yaml:"config"`
@@ -700,11 +708,15 @@ func EffectiveNamedConnectionDef(plugin *ProviderDef, manifestPlugin *pluginmani
 type OperationOverride = pluginmanifestv1.ManifestOperationOverride
 
 func Load(path string) (*Config, error) {
-	return loadWithLookup(path, os.LookupEnv, false)
+	return loadWithLookup(path, os.LookupEnv, missingEnvError)
 }
 
 func LoadWithLookup(path string, lookup func(string) (string, bool)) (*Config, error) {
-	return loadWithLookup(path, lookup, false)
+	return loadWithLookup(path, lookup, missingEnvError)
+}
+
+func LoadAllowMissingEnv(path string) (*Config, error) {
+	return loadWithLookup(path, os.LookupEnv, missingEnvEmpty)
 }
 
 func OverlayManagedPluginConfig(path string, cfg *Config) error {
@@ -759,7 +771,7 @@ func overlayManagedPluginConfigNode(raw *yaml.Node, plugin *ProviderDef, subject
 	if configNode == nil || configNode.Kind == 0 {
 		return nil
 	}
-	node, err := overlayEnvIntoNode(*configNode, os.LookupEnv, true)
+	node, err := overlayEnvIntoNode(*configNode, os.LookupEnv, missingEnvPreserve)
 	if err != nil {
 		return fmt.Errorf("expanding managed plugin config for %s: %w", subject, err)
 	}
@@ -775,7 +787,7 @@ func overlayManagedComponentConfigNode(raw *yaml.Node, provider *ProviderDef, ta
 	if configNode == nil || configNode.Kind == 0 {
 		return nil
 	}
-	node, err := overlayEnvIntoNode(*configNode, os.LookupEnv, true)
+	node, err := overlayEnvIntoNode(*configNode, os.LookupEnv, missingEnvPreserve)
 	if err != nil {
 		return fmt.Errorf("expanding managed provider config for %s: %w", subject, err)
 	}
@@ -806,13 +818,13 @@ func mappingValueNode(node *yaml.Node, key string) *yaml.Node {
 	return nil
 }
 
-func loadWithLookup(path string, lookup func(string) (string, bool), preserveMissing bool) (*Config, error) {
+func loadWithLookup(path string, lookup func(string) (string, bool), missingEnv missingEnvAction) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading config file: %w", err)
 	}
 
-	resolved, err := expandEnvVariables(string(data), lookup, preserveMissing)
+	resolved, err := expandEnvVariables(string(data), lookup, missingEnv)
 	if err != nil {
 		return nil, err
 	}
@@ -849,7 +861,7 @@ func parseEnvPlaceholder(key string) (name string, allowEmptyDefault bool, err e
 	return name, true, nil
 }
 
-func expandEnvVariables(input string, lookup func(string) (string, bool), preserveMissing bool) (string, error) {
+func expandEnvVariables(input string, lookup func(string) (string, bool), missingEnv missingEnvAction) (string, error) {
 	var expandErr error
 	resolved := os.Expand(input, func(key string) string {
 		if expandErr != nil {
@@ -868,8 +880,11 @@ func expandEnvVariables(input string, lookup func(string) (string, bool), preser
 			if allowEmptyDefault {
 				return ""
 			}
-			if preserveMissing {
+			switch missingEnv {
+			case missingEnvPreserve:
 				return "${" + key + "}"
+			case missingEnvEmpty:
+				return ""
 			}
 			expandErr = fmt.Errorf("environment variable %q not set; use ${%s:-} to allow an empty default", name, name)
 			return ""
@@ -887,13 +902,13 @@ func expandEnvVariables(input string, lookup func(string) (string, bool), preser
 	return resolved, nil
 }
 
-func overlayEnvIntoNode(node yaml.Node, lookup func(string) (string, bool), preserveMissing bool) (yaml.Node, error) {
+func overlayEnvIntoNode(node yaml.Node, lookup func(string) (string, bool), missingEnv missingEnvAction) (yaml.Node, error) {
 	data, err := yaml.Marshal(&node)
 	if err != nil {
 		return yaml.Node{}, fmt.Errorf("marshaling config node: %w", err)
 	}
 
-	resolved, err := expandEnvVariables(string(data), lookup, preserveMissing)
+	resolved, err := expandEnvVariables(string(data), lookup, missingEnv)
 	if err != nil {
 		return yaml.Node{}, err
 	}

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -204,6 +204,30 @@ server:
 	}
 }
 
+func TestLoadAllowMissingEnvForInitSemantics(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+datastore:
+  provider:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/datastore/sqlite
+      version: 1.0.0
+server:
+  encryption_key: test-key
+  public:
+    port: ${TEST_PORT}
+`)
+
+	cfg, err := LoadAllowMissingEnv(path)
+	if err != nil {
+		t.Fatalf("LoadAllowMissingEnv: %v", err)
+	}
+	if cfg.Server.Public.Port != 8080 {
+		t.Fatalf("Server.Public.Port = %d, want 8080", cfg.Server.Public.Port)
+	}
+}
+
 func TestLoadConfigEmptyDefaultEnvSyntax(t *testing.T) {
 	t.Parallel()
 
@@ -233,7 +257,7 @@ func TestExpandEnvVariablesPreservesMissingPlaceholder(t *testing.T) {
 
 	got, err := expandEnvVariables("value: ${MISSING}", func(string) (string, bool) {
 		return "", false
-	}, true)
+	}, missingEnvPreserve)
 	if err != nil {
 		t.Fatalf("expandEnvVariables: %v", err)
 	}
@@ -247,7 +271,7 @@ func TestExpandEnvVariablesRejectsNonEmptyDefault(t *testing.T) {
 
 	_, err := expandEnvVariables("value: ${MISSING:-fallback}", func(string) (string, bool) {
 		return "", false
-	}, false)
+	}, missingEnvError)
 	if err == nil {
 		t.Fatal("expandEnvVariables: expected error, got nil")
 	}

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -177,6 +177,85 @@ server:
 	}
 }
 
+func TestLoadConfigMissingEnvVariableFails(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+datastore:
+  provider:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/datastore/sqlite
+      version: 1.0.0
+server:
+  encryption_key: ${TEST_ENCRYPTION}
+`)
+
+	_, err := LoadWithLookup(path, func(string) (string, bool) {
+		return "", false
+	})
+	if err == nil {
+		t.Fatal("LoadWithLookup: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `environment variable "TEST_ENCRYPTION" not set`) {
+		t.Fatalf("expected missing env error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), `${TEST_ENCRYPTION:-}`) {
+		t.Fatalf("expected empty-default hint, got: %v", err)
+	}
+}
+
+func TestLoadConfigEmptyDefaultEnvSyntax(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+datastore:
+  provider:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/datastore/sqlite
+      version: 1.0.0
+server:
+  encryption_key: ${TEST_ENCRYPTION:-}
+`)
+
+	cfg, err := LoadWithLookup(path, func(string) (string, bool) {
+		return "", false
+	})
+	if err != nil {
+		t.Fatalf("LoadWithLookup: %v", err)
+	}
+	if cfg.Server.EncryptionKey != "" {
+		t.Fatalf("Server.EncryptionKey = %q, want empty string", cfg.Server.EncryptionKey)
+	}
+}
+
+func TestExpandEnvVariablesPreservesMissingPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	got, err := expandEnvVariables("value: ${MISSING}", func(string) (string, bool) {
+		return "", false
+	}, true)
+	if err != nil {
+		t.Fatalf("expandEnvVariables: %v", err)
+	}
+	if got != "value: ${MISSING}" {
+		t.Fatalf("expandEnvVariables = %q, want value: ${MISSING}", got)
+	}
+}
+
+func TestExpandEnvVariablesRejectsNonEmptyDefault(t *testing.T) {
+	t.Parallel()
+
+	_, err := expandEnvVariables("value: ${MISSING:-fallback}", func(string) (string, bool) {
+		return "", false
+	}, false)
+	if err == nil {
+		t.Fatal("expandEnvVariables: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "only ${MISSING:-} is supported for empty defaults") {
+		t.Fatalf("expected unsupported default error, got: %v", err)
+	}
+}
+
 func TestValidateRuntime(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -180,15 +181,19 @@ server:
 func TestLoadConfigMissingEnvVariableFails(t *testing.T) {
 	t.Parallel()
 
-	path := mustWriteConfigFile(t, `
+	encryptionEnv := "GESTALT_TEST_ENCRYPTION_" + strings.ToUpper(strings.ReplaceAll(t.Name(), "/", "_"))
+	portEnv := encryptionEnv + "_PORT"
+	path := mustWriteConfigFile(t, fmt.Sprintf(`
 datastore:
   provider:
     source:
       ref: github.com/valon-technologies/gestalt-providers/datastore/sqlite
       version: 1.0.0
 server:
-  encryption_key: ${TEST_ENCRYPTION}
-`)
+  encryption_key: ${%s}
+  public:
+    port: ${%s}
+`, encryptionEnv, portEnv))
 
 	_, err := LoadWithLookup(path, func(string) (string, bool) {
 		return "", false
@@ -196,32 +201,19 @@ server:
 	if err == nil {
 		t.Fatal("LoadWithLookup: expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), `environment variable "TEST_ENCRYPTION" not set`) {
+	if !strings.Contains(err.Error(), fmt.Sprintf(`environment variable %q not set`, encryptionEnv)) {
 		t.Fatalf("expected missing env error, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), `${TEST_ENCRYPTION:-}`) {
+	if !strings.Contains(err.Error(), fmt.Sprintf("${%s:-}", encryptionEnv)) {
 		t.Fatalf("expected empty-default hint, got: %v", err)
 	}
-}
-
-func TestLoadAllowMissingEnvForInitSemantics(t *testing.T) {
-	t.Parallel()
-
-	path := mustWriteConfigFile(t, `
-datastore:
-  provider:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/datastore/sqlite
-      version: 1.0.0
-server:
-  encryption_key: test-key
-  public:
-    port: ${TEST_PORT}
-`)
 
 	cfg, err := LoadAllowMissingEnv(path)
 	if err != nil {
 		t.Fatalf("LoadAllowMissingEnv: %v", err)
+	}
+	if cfg.Server.EncryptionKey != "" {
+		t.Fatalf("Server.EncryptionKey = %q, want empty string", cfg.Server.EncryptionKey)
 	}
 	if cfg.Server.Public.Port != 8080 {
 		t.Fatalf("Server.Public.Port = %d, want 8080", cfg.Server.Public.Port)
@@ -255,11 +247,14 @@ server:
 func TestExpandEnvVariablesPreservesMissingPlaceholder(t *testing.T) {
 	t.Parallel()
 
-	got, err := expandEnvVariables("value: ${MISSING}", func(string) (string, bool) {
+	got, firstMissing, err := expandEnvVariables("value: ${MISSING}", func(string) (string, bool) {
 		return "", false
-	}, missingEnvPreserve)
+	}, true)
 	if err != nil {
 		t.Fatalf("expandEnvVariables: %v", err)
+	}
+	if firstMissing != "MISSING" {
+		t.Fatalf("expandEnvVariables firstMissing = %q, want MISSING", firstMissing)
 	}
 	if got != "value: ${MISSING}" {
 		t.Fatalf("expandEnvVariables = %q, want value: ${MISSING}", got)
@@ -269,9 +264,9 @@ func TestExpandEnvVariablesPreservesMissingPlaceholder(t *testing.T) {
 func TestExpandEnvVariablesRejectsNonEmptyDefault(t *testing.T) {
 	t.Parallel()
 
-	_, err := expandEnvVariables("value: ${MISSING:-fallback}", func(string) (string, bool) {
+	_, _, err := expandEnvVariables("value: ${MISSING:-fallback}", func(string) (string, bool) {
 		return "", false
-	}, missingEnvError)
+	}, false)
 	if err == nil {
 		t.Fatal("expandEnvVariables: expected error, got nil")
 	}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -73,7 +73,7 @@ func (l *Lifecycle) InitAtPath(configPath string) (*Lockfile, error) {
 }
 
 func (l *Lifecycle) InitAtPathWithArtifactsDir(configPath, artifactsDir string) (*Lockfile, error) {
-	cfg, err := config.Load(configPath)
+	cfg, err := config.LoadAllowMissingEnv(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("loading config: %v", err)
 	}


### PR DESCRIPTION
## What changed
This PR changes config environment expansion so unresolved placeholders fail config loading instead of being silently replaced with an empty string.

It also adds explicit `${VAR:-}` support for the cases where an empty value is intentional, while keeping the existing `${VAR_FILE}` fallback behavior.

## Why
Today `gestaltd/internal/config/config.go` uses `os.Expand` with `preserveMissing=false` during normal config loading. That means a typo like `${DATBASE_URL}` resolves to `""` with no direct signal, and the operator only sees a later validation or provider error.

Failing at expansion time makes the real problem obvious and keeps the error close to the typo.

## User impact
Configs that previously relied on an unset `${VAR}` becoming `""` will now fail to load with a direct missing-variable error.

If an empty value is actually intended, the config can opt in with `${VAR:-}`.

## Validation
- `go test ./internal/config`
- `go test ./internal/operator -run 'Test.*' -count=1`
