### PR TITLE
sdk/typescript: brand explicit response wrappers

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -49,6 +49,7 @@ import {
   defineIntegrationProvider,
   ok,
   operation,
+  response,
   s,
 } from "@valon-technologies/gestalt";
 
@@ -90,6 +91,10 @@ export const provider = defineIntegrationProvider({
   ],
 });
 ```
+
+Use `ok(body)` for normal responses and `response(status, body)` when a handler
+needs to set a non-200 status. Plain objects with `status` and `body` fields
+are treated as user data.
 
 Auth providers and datastore providers use dedicated helpers:
 

--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -3,7 +3,10 @@ export interface Request {
   connectionParams: Record<string, string>;
 }
 
+export const responseBrand: unique symbol = Symbol("gestalt.response");
+
 export interface Response<T> {
+  readonly [responseBrand]: true;
   status?: number;
   body: T;
 }
@@ -15,11 +18,16 @@ export interface OperationResult {
 
 export type MaybePromise<T> = T | Promise<T>;
 
-export function ok<T>(body: T): Response<T> {
+export function response<T>(status: number, body: T): Response<T> {
   return {
-    status: 200,
+    [responseBrand]: true,
+    status,
     body,
   };
+}
+
+export function ok<T>(body: T): Response<T> {
+  return response(200, body);
 }
 
 export function request(token = "", connectionParams: Record<string, string> = {}): Request {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,6 +1,8 @@
 export {
   connectionParam,
   ok,
+  response,
+  responseBrand,
   request,
   type MaybePromise,
   type OperationResult,

--- a/sdk/typescript/src/plugin.ts
+++ b/sdk/typescript/src/plugin.ts
@@ -1,5 +1,5 @@
 import { type Catalog, type CatalogOperation, type CatalogSchema, catalogToJson, schemaToCatalogSchema, schemaToParameters, writeCatalogYaml } from "./catalog.ts";
-import { errorMessage, type MaybePromise, type OperationResult, type Request, type Response } from "./api.ts";
+import { errorMessage, type MaybePromise, type OperationResult, type Request, responseBrand, type Response } from "./api.ts";
 import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
 import type { Schema } from "./schema.ts";
 
@@ -248,7 +248,7 @@ function isResponse(value: unknown): value is Response<unknown> {
   if (typeof value !== "object" || value === null) {
     return false;
   }
-  if (!("body" in value) || !("status" in value)) {
+  if (!(responseBrand in value)) {
     return false;
   }
   const status = (value as { status?: unknown }).status;

--- a/sdk/typescript/tests/plugin.test.ts
+++ b/sdk/typescript/tests/plugin.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import { ok, request } from "../src/api.ts";
+import { ok, request, response } from "../src/api.ts";
 import { definePlugin, operation } from "../src/plugin.ts";
 import { s } from "../src/schema.ts";
 
@@ -178,7 +178,34 @@ test("plugin treats raw outputs with a body field as plain output values", async
   });
 });
 
-test("plugin accepts explicit response wrappers with a status field", async () => {
+test("plugin treats raw outputs with status and body fields as plain output values", async () => {
+  const plugin = definePlugin({
+    operations: [
+      operation({
+        id: "echo",
+        output: s.object({
+          status: s.integer(),
+          body: s.string(),
+        }),
+        handler() {
+          return {
+            status: 42,
+            body: "payload",
+          };
+        },
+      }),
+    ],
+  });
+
+  const result = await plugin.execute("echo", {}, request());
+  expect(result.status).toBe(200);
+  expect(JSON.parse(result.body)).toEqual({
+    status: 42,
+    body: "payload",
+  });
+});
+
+test("plugin accepts explicit branded response wrappers with a status field", async () => {
   const plugin = definePlugin({
     operations: [
       operation({
@@ -187,12 +214,9 @@ test("plugin accepts explicit response wrappers with a status field", async () =
           id: s.string(),
         }),
         handler() {
-          return {
-            status: 201,
-            body: {
-              id: "new-id",
-            },
-          };
+          return response(201, {
+            id: "new-id",
+          });
         },
       }),
     ],


### PR DESCRIPTION
## Summary
- replace duck-typed response detection with a symbol-branded `Response` wrapper
- add a `response(status, body)` helper for explicit non-200 returns and keep `ok(body)` for 200s
- add regression coverage for plain `{ status, body }` payloads and document the new response API

## Validation
- `bun test tests/plugin.test.ts`
- focused compile: `./node_modules/.bin/tsc --noEmit --pretty false --target ES2022 --module Preserve --moduleResolution bundler --strict --allowImportingTsExtensions --verbatimModuleSyntax --exactOptionalPropertyTypes --noUncheckedIndexedAccess --skipLibCheck --types bun src/api.ts src/plugin.ts tests/plugin.test.ts`

## Notes
- `bun run typecheck` still fails on current `main` due existing `sdk/typescript/src/runtime.ts` and generated protobuf export mismatches unrelated to this patch.