### PR TITLE
[codex] return absent connection params across SDKs

### DIFF
--- a/sdk/go/router.go
+++ b/sdk/go/router.go
@@ -19,12 +19,14 @@ type Request struct {
 	ConnectionParams map[string]string
 }
 
-// ConnectionParam returns one resolved connection parameter by name.
-func (r Request) ConnectionParam(name string) string {
+// ConnectionParam returns one resolved connection parameter by name and whether
+// it was present in the request.
+func (r Request) ConnectionParam(name string) (string, bool) {
 	if r.ConnectionParams == nil {
-		return ""
+		return "", false
 	}
-	return r.ConnectionParams[name]
+	value, ok := r.ConnectionParams[name]
+	return value, ok
 }
 
 // Response is the typed handler result marshaled into the provider response body.
@@ -425,4 +427,3 @@ func isOptionalType(t reflect.Type) bool {
 		return false
 	}
 }
-

--- a/sdk/go/router_test.go
+++ b/sdk/go/router_test.go
@@ -100,15 +100,18 @@ type execInput struct {
 }
 
 type execOutput struct {
-	Echo string `json:"echo"`
+	Echo          string `json:"echo"`
+	Region        string `json:"region"`
+	RegionPresent bool   `json:"region_present"`
 }
 
 type execProvider struct{}
 
 func (p *execProvider) Configure(context.Context, string, map[string]any) error { return nil }
 
-func (p *execProvider) echo(_ context.Context, in execInput, _ gestalt.Request) (gestalt.Response[execOutput], error) {
-	return gestalt.OK(execOutput{Echo: in.Value}), nil
+func (p *execProvider) echo(_ context.Context, in execInput, req gestalt.Request) (gestalt.Response[execOutput], error) {
+	region, ok := req.ConnectionParam("region")
+	return gestalt.OK(execOutput{Echo: in.Value, Region: region, RegionPresent: ok}), nil
 }
 
 func TestRouterOperationExecution(t *testing.T) {
@@ -134,8 +137,16 @@ func TestRouterOperationExecution(t *testing.T) {
 	if result.Status != http.StatusOK {
 		t.Fatalf("status = %d, want %d", result.Status, http.StatusOK)
 	}
-	if result.Body != `{"echo":"hello"}` {
-		t.Fatalf("body = %q, want %q", result.Body, `{"echo":"hello"}`)
+	if result.Body != `{"echo":"hello","region":"","region_present":false}` {
+		t.Fatalf("body = %q, want %q", result.Body, `{"echo":"hello","region":"","region_present":false}`)
+	}
+
+	result, err = router.Execute(gestalt.WithConnectionParams(ctx, map[string]string{"region": "iad"}), provider, "echo", map[string]any{"value": "hello"}, "tok")
+	if err != nil {
+		t.Fatalf("Execute(with params): %v", err)
+	}
+	if result.Body != `{"echo":"hello","region":"iad","region_present":true}` {
+		t.Fatalf("body with params = %q, want %q", result.Body, `{"echo":"hello","region":"iad","region_present":true}`)
 	}
 
 	result, err = router.Execute(ctx, provider, "nonexistent", nil, "tok")

--- a/sdk/python/gestalt/_api.py
+++ b/sdk/python/gestalt/_api.py
@@ -16,8 +16,8 @@ class Request:
     token: str = ""
     connection_params: dict[str, str] = dataclasses.field(default_factory=dict)
 
-    def connection_param(self, name: str) -> str:
-        return self.connection_params.get(name, "")
+    def connection_param(self, name: str) -> str | None:
+        return self.connection_params.get(name)
 
 
 @dataclasses.dataclass(slots=True)

--- a/sdk/python/tests/test_plugin.py
+++ b/sdk/python/tests/test_plugin.py
@@ -100,7 +100,7 @@ class PluginOperationTests(unittest.TestCase):
 
         @plugin.operation
         def echo(req: Request) -> dict[str, str]:
-            return {"token": req.token, "region": req.connection_param("region")}
+            return {"token": req.token, "region": req.connection_param("region") or ""}
 
         result = plugin.execute(
             "echo",

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -143,11 +143,11 @@ class ManifestNameTests(unittest.TestCase):
 
 
 class RequestTests(unittest.TestCase):
-    def test_connection_param_returns_value_or_empty_string(self) -> None:
+    def test_connection_param_returns_value_or_none(self) -> None:
         request = Request(connection_params={"region": "us-east-1"})
 
         self.assertEqual(request.connection_param("region"), "us-east-1")
-        self.assertEqual(request.connection_param("missing"), "")
+        self.assertIsNone(request.connection_param("missing"))
 
 
 class MainEntrypointTests(unittest.TestCase):
@@ -181,7 +181,7 @@ class MainEntrypointTests(unittest.TestCase):
         def dynamic_catalog(request: Request) -> Catalog:
             cat = Catalog(
                 name="session-source",
-                display_name=request.connection_param("tenant"),
+                display_name=request.connection_param("tenant") or "",
             )
             cat.operations.append(CatalogOperation(id="private_search", method="POST"))
             return cat

--- a/sdk/rust/src/api.rs
+++ b/sdk/rust/src/api.rs
@@ -13,11 +13,8 @@ pub struct Request {
 }
 
 impl Request {
-    pub fn connection_param(&self, name: &str) -> &str {
-        self.connection_params
-            .get(name)
-            .map(String::as_str)
-            .unwrap_or("")
+    pub fn connection_param(&self, name: &str) -> Option<&str> {
+        self.connection_params.get(name).map(String::as_str)
     }
 }
 

--- a/sdk/rust/tests/router.rs
+++ b/sdk/rust/tests/router.rs
@@ -34,6 +34,8 @@ struct EchoOutput {
 
 #[tokio::test]
 async fn executes_registered_operation() {
+    assert_eq!(Request::default().connection_param("missing"), None);
+
     let router = Router::new()
         .register(
             Operation::<EchoInput, EchoOutput>::new("echo").description("Echo the message"),
@@ -125,7 +127,10 @@ async fn greet(
     let name = input.name.unwrap_or_else(|| "World".to_owned());
     Ok(gestalt::ok(GreetOutput {
         message: format!("{greeting}, {name}!"),
-        api_key: request.connection_param("api_key").to_owned(),
+        api_key: request
+            .connection_param("api_key")
+            .unwrap_or_default()
+            .to_owned(),
     }))
 }
 

--- a/sdk/rust/tests/transport.rs
+++ b/sdk/rust/tests/transport.rs
@@ -48,7 +48,10 @@ impl Provider for TestProvider {
     ) -> gestalt_plugin_sdk::Result<Option<Catalog>> {
         Ok(Some(Catalog {
             name: "session-example".to_string(),
-            display_name: request.connection_param("tenant").to_string(),
+            display_name: request
+                .connection_param("tenant")
+                .unwrap_or_default()
+                .to_string(),
             description: String::new(),
             icon_svg: String::new(),
             operations: vec![CatalogOperation {

--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -39,8 +39,8 @@ export function request(token = "", connectionParams: Record<string, string> = {
   };
 }
 
-export function connectionParam(input: Request | undefined, name: string): string {
-  return input?.connectionParams[name] ?? "";
+export function connectionParam(input: Request | undefined, name: string): string | undefined {
+  return input?.connectionParams[name];
 }
 
 export function errorMessage(error: unknown): string {

--- a/sdk/typescript/tests/fixtures/basic-provider/provider.ts
+++ b/sdk/typescript/tests/fixtures/basic-provider/provider.ts
@@ -1,4 +1,4 @@
-import { definePlugin, ok, operation, s } from "../../../src/index.ts";
+import { connectionParam, definePlugin, ok, operation, s } from "../../../src/index.ts";
 
 let configuredName = "";
 let configuredConfig: Record<string, unknown> = {};
@@ -13,14 +13,15 @@ export const plugin = definePlugin({
     };
   },
   sessionCatalog(request) {
+    const scope = connectionParam(request, "scope");
     return {
       name: "fixture-session",
       operations: [
         {
           id: "session-hello",
           method: "GET",
-          title: request.connectionParams.scope
-            ? `Session Hello ${request.connectionParams.scope}`
+          title: scope
+            ? `Session Hello ${scope}`
             : "Session Hello",
         },
       ],
@@ -52,10 +53,11 @@ export const plugin = definePlugin({
         configuredRegion: s.string(),
       }),
       handler(input, request) {
+        const region = connectionParam(request, "region") ?? "";
         return ok({
           message: `Hello, ${input.name}${input.excited ? "!" : "."}`,
           configuredName,
-          region: request.connectionParams.region ?? "",
+          region,
           configuredRegion: String(configuredConfig.region ?? ""),
         });
       },

--- a/sdk/typescript/tests/plugin.test.ts
+++ b/sdk/typescript/tests/plugin.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import { ok, request, response } from "../src/api.ts";
+import { connectionParam, ok, request, response } from "../src/api.ts";
 import { definePlugin, operation } from "../src/plugin.ts";
 import { s } from "../src/schema.ts";
 
@@ -48,6 +48,8 @@ test("plugin executes operations and exposes catalog metadata", async () => {
     total: 3,
     token: "tok",
   });
+  expect(connectionParam(request("tok", { region: "iad" }), "region")).toBe("iad");
+  expect(connectionParam(request(), "missing")).toBeUndefined();
 
   const invalid = await plugin.execute("sum", { a: "bad" }, request());
   expect(invalid.status).toBe(400);


### PR DESCRIPTION
## What changed

This makes the SDK-level `connection_param()` / `ConnectionParam()` / `connectionParam()` helpers preserve missing-vs-empty semantics instead of collapsing missing params to `""`.

The language-native absent form is now returned in each SDK:

- Go: `(string, bool)`
- Python: `str | None`
- TypeScript: `string | undefined`
- Rust: `Option<&str>`

The nearby existing tests and fixtures were updated to consume the new return shapes.

## Why

The raw request objects already preserve absence via omitted map/object keys. The helper methods were the only layer erasing that distinction by defaulting missing params to the empty string.

This change makes the helper API reflect the real state space more accurately.

## Developer impact

This is intentionally breaking for callers that used the old helper signatures.

Callers that still want empty-string behavior can now opt into it explicitly at the callsite with normal language primitives such as `or ""`, `?? ""`, `unwrap_or_default()`, or the boolean return value in Go.

## Validation

- `go test ./...` in `sdk/go`
- `uv run pytest` in `sdk/python`
- `cargo test` in `sdk/rust`
- `bun test tests/plugin.test.ts` in `sdk/typescript`

## TypeScript suite note

I also ran `bun test` in `sdk/typescript`. It still fails outside this diff because `sdk/typescript/src/runtime.ts` imports `PluginRuntime`, while `sdk/typescript/gen/v1/runtime_pb.ts` exports `ProviderLifecycle`. I left that unrelated runtime/generated-code mismatch out of this PR to keep scope focused.