### PR TITLE
Simplify source-managed secrets release and bootstrap code

### DIFF
--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -284,12 +284,8 @@ func releaseRequiresBuildTarget(manifest *pluginmanifestv1.Manifest) bool {
 	switch kind {
 	case pluginmanifestv1.KindPlugin:
 		return manifest.Entrypoints.Provider == nil && !manifest.Plugin.IsManifestBacked()
-	case pluginmanifestv1.KindAuth:
-		return manifest.Entrypoints.Auth == nil
-	case pluginmanifestv1.KindDatastore:
-		return manifest.Entrypoints.Datastore == nil
-	case pluginmanifestv1.KindSecrets:
-		return manifest.Entrypoints.Secrets == nil
+	case pluginmanifestv1.KindAuth, pluginmanifestv1.KindDatastore, pluginmanifestv1.KindSecrets:
+		return pluginpkg.EntrypointForKind(manifest, kind) == nil
 	default:
 		return false
 	}
@@ -343,12 +339,8 @@ func missingReleaseSourceBuildTargetError(kind string) error {
 	switch kind {
 	case pluginmanifestv1.KindPlugin:
 		return fmt.Errorf("no Go, Rust, Python, or TypeScript provider package found")
-	case pluginmanifestv1.KindAuth:
-		return fmt.Errorf("no Go, Rust, Python, or TypeScript auth source package found")
-	case pluginmanifestv1.KindDatastore:
-		return fmt.Errorf("no Go, Rust, Python, or TypeScript datastore source package found")
-	case pluginmanifestv1.KindSecrets:
-		return fmt.Errorf("no Go, Rust, Python, or TypeScript secrets source package found")
+	case pluginmanifestv1.KindAuth, pluginmanifestv1.KindDatastore, pluginmanifestv1.KindSecrets:
+		return fmt.Errorf("no Go, Rust, Python, or TypeScript %s source package found", kind)
 	default:
 		return fmt.Errorf("unsupported release build target kind %q", kind)
 	}
@@ -460,28 +452,7 @@ func buildReleaseManifest(srcManifest *pluginmanifestv1.Manifest, version, binar
 		{OS: plat.GOOS, Arch: plat.GOARCH, LibC: plat.LibC, Path: binaryName, SHA256: digest},
 	}
 
-	switch buildKind {
-	case pluginmanifestv1.KindPlugin:
-		if manifest.Entrypoints.Provider == nil {
-			manifest.Entrypoints.Provider = &pluginmanifestv1.Entrypoint{}
-		}
-		manifest.Entrypoints.Provider.ArtifactPath = binaryName
-	case pluginmanifestv1.KindAuth:
-		if manifest.Entrypoints.Auth == nil {
-			manifest.Entrypoints.Auth = &pluginmanifestv1.Entrypoint{}
-		}
-		manifest.Entrypoints.Auth.ArtifactPath = binaryName
-	case pluginmanifestv1.KindDatastore:
-		if manifest.Entrypoints.Datastore == nil {
-			manifest.Entrypoints.Datastore = &pluginmanifestv1.Entrypoint{}
-		}
-		manifest.Entrypoints.Datastore.ArtifactPath = binaryName
-	case pluginmanifestv1.KindSecrets:
-		if manifest.Entrypoints.Secrets == nil {
-			manifest.Entrypoints.Secrets = &pluginmanifestv1.Entrypoint{}
-		}
-		manifest.Entrypoints.Secrets.ArtifactPath = binaryName
-	}
+	pluginpkg.EnsureEntrypointForKind(manifest, buildKind).ArtifactPath = binaryName
 
 	return manifest, nil
 }

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -684,7 +684,16 @@ plugin = "os import path\nimport os;os.system('cmd')#:attr"
 func TestRun_PluginReleaseBuildsGoSourceAuthPlugin(t *testing.T) {
 	t.Parallel()
 
-	pluginDir := newSourceAuthReleaseFixture(t, t.TempDir())
+	pluginDir := newSourceComponentReleaseFixture(t, t.TempDir(), sourceComponentReleaseFixtureParams{
+		pluginName: authReleasePluginName,
+		schemaPath: authReleaseSchemaPath,
+		sourceFile: "auth.go",
+		sourceCode: testutil.GeneratedAuthPackageSource(),
+		manifest: &pluginmanifestv1.Manifest{
+			Source: authReleaseSource, Version: "0.0.1", DisplayName: "Auth Release",
+			Auth: &pluginmanifestv1.AuthMetadata{ConfigSchemaPath: authReleaseSchemaPath},
+		},
+	})
 	outputDir := t.TempDir()
 	const testVersion = "0.0.15-test"
 
@@ -786,7 +795,16 @@ func TestRun_PluginReleaseBuildsGoSourceAuthPluginForExplicitLinuxLibC(t *testin
 		t.Skip("current linux runtime libc is unknown")
 	}
 
-	pluginDir := newSourceAuthReleaseFixture(t, t.TempDir())
+	pluginDir := newSourceComponentReleaseFixture(t, t.TempDir(), sourceComponentReleaseFixtureParams{
+		pluginName: authReleasePluginName,
+		schemaPath: authReleaseSchemaPath,
+		sourceFile: "auth.go",
+		sourceCode: testutil.GeneratedAuthPackageSource(),
+		manifest: &pluginmanifestv1.Manifest{
+			Source: authReleaseSource, Version: "0.0.1", DisplayName: "Auth Release",
+			Auth: &pluginmanifestv1.AuthMetadata{ConfigSchemaPath: authReleaseSchemaPath},
+		},
+	})
 	outputDir := t.TempDir()
 	const testVersion = "0.0.15-linux-libc"
 
@@ -809,7 +827,16 @@ func TestRun_PluginReleaseBuildsGoSourceAuthPluginForExplicitLinuxLibC(t *testin
 func TestRun_PluginReleaseBuildsGoSourceDatastorePlugin(t *testing.T) {
 	t.Parallel()
 
-	pluginDir := newSourceDatastoreReleaseFixture(t, t.TempDir())
+	pluginDir := newSourceComponentReleaseFixture(t, t.TempDir(), sourceComponentReleaseFixtureParams{
+		pluginName: datastoreReleasePluginName,
+		schemaPath: datastoreReleaseSchemaPath,
+		sourceFile: "datastore.go",
+		sourceCode: testutil.GeneratedDatastorePackageSource(),
+		manifest: &pluginmanifestv1.Manifest{
+			Source: datastoreReleaseSource, Version: "0.0.1", DisplayName: "Datastore Release",
+			Datastore: &pluginmanifestv1.DatastoreMetadata{ConfigSchemaPath: datastoreReleaseSchemaPath},
+		},
+	})
 	outputDir := t.TempDir()
 	const testVersion = "0.0.16-test"
 
@@ -889,7 +916,16 @@ func TestRun_PluginReleaseBuildsGoSourceDatastorePlugin(t *testing.T) {
 func TestRun_PluginReleaseBuildsGoSourceSecretsPlugin(t *testing.T) {
 	t.Parallel()
 
-	pluginDir := newSourceSecretsReleaseFixture(t, t.TempDir())
+	pluginDir := newSourceComponentReleaseFixture(t, t.TempDir(), sourceComponentReleaseFixtureParams{
+		pluginName: secretsReleasePluginName,
+		schemaPath: secretsReleaseSchemaPath,
+		sourceFile: "secrets.go",
+		sourceCode: testutil.GeneratedSecretsPackageSource(),
+		manifest: &pluginmanifestv1.Manifest{
+			Source: secretsReleaseSource, Version: "0.0.1", DisplayName: "Secrets Release",
+			Secrets: &pluginmanifestv1.SecretsMetadata{ConfigSchemaPath: secretsReleaseSchemaPath},
+		},
+	})
 	outputDir := t.TempDir()
 	const testVersion = "0.0.19-test"
 
@@ -1138,7 +1174,16 @@ func TestRun_PluginReleaseBuildsPythonSourceAuthPlugin(t *testing.T) {
 		t.Skip("fake Python build fixture is POSIX-only")
 	}
 
-	goFixtureDir := newSourceAuthReleaseFixture(t, t.TempDir())
+	goFixtureDir := newSourceComponentReleaseFixture(t, t.TempDir(), sourceComponentReleaseFixtureParams{
+		pluginName: authReleasePluginName,
+		schemaPath: authReleaseSchemaPath,
+		sourceFile: "auth.go",
+		sourceCode: testutil.GeneratedAuthPackageSource(),
+		manifest: &pluginmanifestv1.Manifest{
+			Source: authReleaseSource, Version: "0.0.1", DisplayName: "Auth Release",
+			Auth: &pluginmanifestv1.AuthMetadata{ConfigSchemaPath: authReleaseSchemaPath},
+		},
+	})
 	t.Setenv("GESTALT_TEST_PYINSTALLER_BINARY", buildGoSourceComponentBinaryForTest(t, goFixtureDir, pluginmanifestv1.KindAuth))
 	t.Setenv("PATH", pathWithoutGo(t))
 
@@ -1222,7 +1267,16 @@ func TestRun_PluginReleaseBuildsPythonSourceDatastorePlugin(t *testing.T) {
 		t.Skip("fake Python build fixture is POSIX-only")
 	}
 
-	goFixtureDir := newSourceDatastoreReleaseFixture(t, t.TempDir())
+	goFixtureDir := newSourceComponentReleaseFixture(t, t.TempDir(), sourceComponentReleaseFixtureParams{
+		pluginName: datastoreReleasePluginName,
+		schemaPath: datastoreReleaseSchemaPath,
+		sourceFile: "datastore.go",
+		sourceCode: testutil.GeneratedDatastorePackageSource(),
+		manifest: &pluginmanifestv1.Manifest{
+			Source: datastoreReleaseSource, Version: "0.0.1", DisplayName: "Datastore Release",
+			Datastore: &pluginmanifestv1.DatastoreMetadata{ConfigSchemaPath: datastoreReleaseSchemaPath},
+		},
+	})
 	t.Setenv("GESTALT_TEST_PYINSTALLER_BINARY", buildGoSourceComponentBinaryForTest(t, goFixtureDir, pluginmanifestv1.KindDatastore))
 	t.Setenv("PATH", pathWithoutGo(t))
 
@@ -2426,25 +2480,26 @@ func pluginpkgPythonEnvVar(goos, goarch string) string {
 	return "GESTALT_PYTHON_" + strings.ToUpper(replacer.Replace(goos)) + "_" + strings.ToUpper(replacer.Replace(goarch))
 }
 
-func newSourceAuthReleaseFixture(t *testing.T, dir string) string {
+type sourceComponentReleaseFixtureParams struct {
+	pluginName string
+	schemaPath string
+	sourceFile string
+	sourceCode string
+	manifest   *pluginmanifestv1.Manifest
+}
+
+func newSourceComponentReleaseFixture(t *testing.T, dir string, p sourceComponentReleaseFixtureParams) string {
 	t.Helper()
 
-	pluginDir := filepath.Join(dir, authReleasePluginName)
+	pluginDir := filepath.Join(dir, p.pluginName)
 	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(pluginDir): %v", err)
 	}
-	writeTestFile(t, pluginDir, "go.mod", []byte(testutil.GeneratedProviderModuleSource(t, "example.com/"+authReleasePluginName)), 0o644)
+	writeTestFile(t, pluginDir, "go.mod", []byte(testutil.GeneratedProviderModuleSource(t, "example.com/"+p.pluginName)), 0o644)
 	writeTestFile(t, pluginDir, "go.sum", testutil.GeneratedProviderModuleSum(t), 0o644)
-	writeTestFile(t, pluginDir, "auth.go", []byte(testutil.GeneratedAuthPackageSource()), 0o644)
-	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
-		Source:      authReleaseSource,
-		Version:     "0.0.1",
-		DisplayName: "Auth Release",
-		Auth: &pluginmanifestv1.AuthMetadata{
-			ConfigSchemaPath: authReleaseSchemaPath,
-		},
-	})
-	writeTestFile(t, pluginDir, authReleaseSchemaPath, []byte(`{"type":"object"}`), 0o644)
+	writeTestFile(t, pluginDir, p.sourceFile, []byte(p.sourceCode), 0o644)
+	writeReleaseTestManifest(t, pluginDir, p.manifest)
+	writeTestFile(t, pluginDir, p.schemaPath, []byte(`{"type":"object"}`), 0o644)
 	return pluginDir
 }
 
@@ -2465,49 +2520,6 @@ func newRustSourceAuthReleaseFixture(t *testing.T, dir string) string {
 	return pluginDir
 }
 
-func newSourceDatastoreReleaseFixture(t *testing.T, dir string) string {
-	t.Helper()
-
-	pluginDir := filepath.Join(dir, datastoreReleasePluginName)
-	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll(pluginDir): %v", err)
-	}
-	writeTestFile(t, pluginDir, "go.mod", []byte(testutil.GeneratedProviderModuleSource(t, "example.com/"+datastoreReleasePluginName)), 0o644)
-	writeTestFile(t, pluginDir, "go.sum", testutil.GeneratedProviderModuleSum(t), 0o644)
-	writeTestFile(t, pluginDir, "datastore.go", []byte(testutil.GeneratedDatastorePackageSource()), 0o644)
-	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
-		Source:      datastoreReleaseSource,
-		Version:     "0.0.1",
-		DisplayName: "Datastore Release",
-		Datastore: &pluginmanifestv1.DatastoreMetadata{
-			ConfigSchemaPath: datastoreReleaseSchemaPath,
-		},
-	})
-	writeTestFile(t, pluginDir, datastoreReleaseSchemaPath, []byte(`{"type":"object"}`), 0o644)
-	return pluginDir
-}
-
-func newSourceSecretsReleaseFixture(t *testing.T, dir string) string {
-	t.Helper()
-
-	pluginDir := filepath.Join(dir, secretsReleasePluginName)
-	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll(pluginDir): %v", err)
-	}
-	writeTestFile(t, pluginDir, "go.mod", []byte(testutil.GeneratedProviderModuleSource(t, "example.com/"+secretsReleasePluginName)), 0o644)
-	writeTestFile(t, pluginDir, "go.sum", testutil.GeneratedProviderModuleSum(t), 0o644)
-	writeTestFile(t, pluginDir, "secrets.go", []byte(testutil.GeneratedSecretsPackageSource()), 0o644)
-	writeReleaseTestManifest(t, pluginDir, &pluginmanifestv1.Manifest{
-		Source:      secretsReleaseSource,
-		Version:     "0.0.1",
-		DisplayName: "Secrets Release",
-		Secrets: &pluginmanifestv1.SecretsMetadata{
-			ConfigSchemaPath: secretsReleaseSchemaPath,
-		},
-	})
-	writeTestFile(t, pluginDir, secretsReleaseSchemaPath, []byte(`{"type":"object"}`), 0o644)
-	return pluginDir
-}
 
 func newRustSourceDatastoreReleaseFixture(t *testing.T, dir string) string {
 	t.Helper()

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -2520,7 +2520,6 @@ func newRustSourceAuthReleaseFixture(t *testing.T, dir string) string {
 	return pluginDir
 }
 
-
 func newRustSourceDatastoreReleaseFixture(t *testing.T, dir string) string {
 	t.Helper()
 

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -118,16 +118,8 @@ func (l *Lifecycle) InitAtPathWithArtifactsDir(configPath, artifactsDir string) 
 		}
 		lock.Datastore = &entry
 	}
-	if cfg.Secrets.Provider != nil && cfg.Secrets.Provider.HasManagedArtifacts() {
-		if secretsEntry != nil {
-			lock.Secrets = secretsEntry
-		} else {
-			entry, err := l.writeComponentArtifact(context.Background(), paths, pluginmanifestv1.KindSecrets, "secrets", secretsDestDir(paths), cfg.Secrets.Provider, cfg.Secrets.Config)
-			if err != nil {
-				return nil, err
-			}
-			lock.Secrets = &entry
-		}
+	if secretsEntry != nil {
+		lock.Secrets = secretsEntry
 	}
 	if cfg.UI.Provider != nil && cfg.UI.Provider.HasManagedArtifacts() {
 		uiEntry, err := l.writeUIProviderArtifact(context.Background(), cfg, paths)

--- a/gestaltd/internal/pluginpkg/manifest.go
+++ b/gestaltd/internal/pluginpkg/manifest.go
@@ -354,6 +354,33 @@ func EntrypointForKind(manifest *pluginmanifestv1.Manifest, kind string) *plugin
 	}
 }
 
+func EnsureEntrypointForKind(manifest *pluginmanifestv1.Manifest, kind string) *pluginmanifestv1.Entrypoint {
+	switch kind {
+	case pluginmanifestv1.KindPlugin:
+		if manifest.Entrypoints.Provider == nil {
+			manifest.Entrypoints.Provider = &pluginmanifestv1.Entrypoint{}
+		}
+		return manifest.Entrypoints.Provider
+	case pluginmanifestv1.KindAuth:
+		if manifest.Entrypoints.Auth == nil {
+			manifest.Entrypoints.Auth = &pluginmanifestv1.Entrypoint{}
+		}
+		return manifest.Entrypoints.Auth
+	case pluginmanifestv1.KindDatastore:
+		if manifest.Entrypoints.Datastore == nil {
+			manifest.Entrypoints.Datastore = &pluginmanifestv1.Entrypoint{}
+		}
+		return manifest.Entrypoints.Datastore
+	case pluginmanifestv1.KindSecrets:
+		if manifest.Entrypoints.Secrets == nil {
+			manifest.Entrypoints.Secrets = &pluginmanifestv1.Entrypoint{}
+		}
+		return manifest.Entrypoints.Secrets
+	default:
+		return nil
+	}
+}
+
 func validateEntrypoint(kind string, entry *pluginmanifestv1.Entrypoint, artifactPaths map[string]struct{}) error {
 	if entry == nil {
 		return fmt.Errorf("%s is required", EntrypointFieldForKind(kind))


### PR DESCRIPTION
## Summary
- Collapse per-kind switch cases in `releaseRequiresBuildTarget`, `missingReleaseSourceBuildTargetError`, and `buildReleaseManifest` using existing `EntrypointForKind` and a new `EnsureEntrypointForKind` companion
- Remove dead `else` branch in `InitAtPathWithArtifactsDir` — `primeSecretsProviderForConfigResolution` guarantees a non-nil entry when `HasManagedArtifacts()` is true
- Merge three identical test fixtures (`newSource{Auth,Datastore,Secrets}ReleaseFixture`) into one parameterized `newSourceComponentReleaseFixture`

## Test plan
- [x] `go build ./...` compiles clean
- [x] `go test ./internal/pluginpkg/` passes
- [x] `go test ./cmd/gestaltd/ -run "PluginRelease"` passes
- [x] `go test ./internal/operator/ -run "Source"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)