### PR TITLE
manifest: add params and discovery to named connections, consolidate naming

### DIFF
--- a/gestaltd/core/provider.go
+++ b/gestaltd/core/provider.go
@@ -88,7 +88,7 @@ type DiscoveryConfig struct {
 	ItemsPath       string
 	IDPath          string
 	NamePath        string
-	MetadataMapping map[string]string
+	Metadata map[string]string
 }
 
 type DiscoveryConfigProvider interface {

--- a/gestaltd/core/provider.go
+++ b/gestaltd/core/provider.go
@@ -84,11 +84,11 @@ type DiscoveryCandidate struct {
 }
 
 type DiscoveryConfig struct {
-	URL             string
-	ItemsPath       string
-	IDPath          string
-	NamePath        string
-	Metadata map[string]string
+	URL       string
+	ItemsPath string
+	IDPath    string
+	NamePath  string
+	Metadata  map[string]string
 }
 
 type DiscoveryConfigProvider interface {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -594,7 +594,7 @@ func buildPluginStaticSpec(name string, intg config.IntegrationDef, manifest *pl
 		AuthTypes:        staticAuthTypes(conn.Auth.Type),
 		ConnectionParams: pluginhost.ConnectionParamDefsFromManifest(conn.ConnectionParams),
 		CredentialFields: pluginhost.CredentialFieldsFromManifest(conn.Auth.Credentials),
-		DiscoveryConfig:  pluginhost.DiscoveryConfigFromManifest(manifest.Plugin.PostConnectDiscovery),
+		DiscoveryConfig:  pluginhost.DiscoveryConfigFromManifest(manifest.Plugin.Discovery),
 	}, nil
 }
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -114,7 +114,7 @@ type ProviderDef struct {
 	Config       yaml.Node `yaml:"-"`
 	AllowedHosts []string  `yaml:"allowed_hosts"`
 
-	PostConnectDiscovery *pluginmanifestv1.ProviderPostConnectDiscovery `yaml:"-"`
+	Discovery *pluginmanifestv1.ProviderDiscovery `yaml:"-"`
 
 	Auth              *ConnectionAuthDef        `yaml:"-"`
 	ConnectionMode    string                    `yaml:"-"`
@@ -432,9 +432,10 @@ type IntegrationDef struct {
 // ConnectionDef owns authentication and connection parameters for a named
 // connection. All connections in a single integration must share the same Mode.
 type ConnectionDef struct {
-	Mode             string                        `yaml:"mode"`
-	Auth             ConnectionAuthDef             `yaml:"auth"`
-	ConnectionParams map[string]ConnectionParamDef `yaml:"params"`
+	Mode             string                              `yaml:"mode"`
+	Auth             ConnectionAuthDef                   `yaml:"auth"`
+	ConnectionParams map[string]ConnectionParamDef       `yaml:"params"`
+	Discovery        *pluginmanifestv1.ProviderDiscovery `yaml:"-"`
 }
 
 type ConnectionAuthDef struct {
@@ -584,6 +585,9 @@ func MergeConnectionDef(dst *ConnectionDef, src *ConnectionDef) {
 	if len(src.ConnectionParams) > 0 {
 		dst.ConnectionParams = maps.Clone(src.ConnectionParams)
 	}
+	if src.Discovery != nil {
+		dst.Discovery = src.Discovery
+	}
 }
 
 func ManifestAuthToConnectionAuthDef(auth *pluginmanifestv1.ProviderAuth) ConnectionAuthDef {
@@ -680,6 +684,12 @@ func EffectiveNamedConnectionDef(plugin *ProviderDef, manifestPlugin *pluginmani
 			}
 			if def.Auth != nil {
 				MergeConnectionAuth(&conn.Auth, ManifestAuthToConnectionAuthDef(def.Auth))
+			}
+			if len(def.Params) > 0 {
+				conn.ConnectionParams = maps.Clone(def.Params)
+			}
+			if def.Discovery != nil {
+				conn.Discovery = def.Discovery
 			}
 		}
 	}

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -788,7 +788,7 @@ plugins:
 			wantErr: "plugin.source.version is required",
 		},
 		{
-			name: "non-default connection params are rejected",
+			name: "non-default connection params are accepted",
 			yaml: `
 plugins:
   external:
@@ -804,10 +804,9 @@ plugins:
           team:
             required: true
 `,
-			wantErr: "connections.named.params are only supported on connections.default",
 		},
 		{
-			name: "non-default connection discovery is rejected",
+			name: "non-default connection discovery is accepted",
 			yaml: `
 plugins:
   external:
@@ -822,7 +821,6 @@ plugins:
         discovery:
           url: https://example.com/connections
 `,
-			wantErr: "connections.named.discovery is only supported on connections.default",
 		},
 		{
 			name: "mcp tool prefix requires mcp enabled",

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -343,7 +343,7 @@ func validateExternalPlugin(kind, name string, plugin *ProviderDef) error {
 	if kind != "integration" {
 		hasIntegrationConfig := plugin.Auth != nil || len(plugin.Connections) > 0 ||
 			len(plugin.ConnectionParams) > 0 || plugin.MCP || len(plugin.AllowedOperations) > 0 ||
-			plugin.DefaultConnection != "" || plugin.PostConnectDiscovery != nil
+			plugin.DefaultConnection != "" || plugin.Discovery != nil
 		if hasIntegrationConfig {
 			return fmt.Errorf("config validation: %s %q provider cannot use integration-only fields", kind, name)
 		}

--- a/gestaltd/internal/config/provider_ref.go
+++ b/gestaltd/internal/config/provider_ref.go
@@ -99,7 +99,7 @@ func (i *IntegrationDef) UnmarshalYAML(value *yaml.Node) error {
 			plugin.Auth = &auth
 			plugin.ConnectionMode = defaultConn.Mode
 			plugin.ConnectionParams = defaultConn.Params
-			plugin.PostConnectDiscovery = defaultConn.toManifestDiscovery()
+			plugin.Discovery = defaultConn.toManifestDiscovery()
 		}
 		if len(wire.Connections) > 0 {
 			plugin.Connections = make(map[string]*ConnectionDef, len(wire.Connections))
@@ -115,6 +115,7 @@ func (i *IntegrationDef) UnmarshalYAML(value *yaml.Node) error {
 					Mode:             conn.Mode,
 					Auth:             conn.Auth,
 					ConnectionParams: conn.Params,
+					Discovery:        conn.toManifestDiscovery(),
 				}
 			}
 			if len(plugin.Connections) == 0 {
@@ -150,31 +151,17 @@ func validateIntegrationWire(wire *integrationWire) error {
 		return fmt.Errorf("mcp.tool_prefix is only valid when mcp.enabled is true")
 	}
 
-	for name, conn := range wire.Connections {
-		if conn == nil {
-			continue
-		}
-		if name != "default" {
-			if len(conn.Params) > 0 {
-				return fmt.Errorf("connections.%s.params are only supported on connections.default", name)
-			}
-			if conn.Discovery != nil {
-				return fmt.Errorf("connections.%s.discovery is only supported on connections.default", name)
-			}
-		}
-	}
-
 	return nil
 }
 
-func (w *integrationConnection) toManifestDiscovery() *pluginmanifestv1.ProviderPostConnectDiscovery {
+func (w *integrationConnection) toManifestDiscovery() *pluginmanifestv1.ProviderDiscovery {
 	if w == nil || w.Discovery == nil {
 		return nil
 	}
-	return &pluginmanifestv1.ProviderPostConnectDiscovery{
-		URL:             w.Discovery.URL,
-		IDPath:          w.Discovery.IDPath,
-		NamePath:        w.Discovery.NamePath,
-		MetadataMapping: w.Discovery.Metadata,
+	return &pluginmanifestv1.ProviderDiscovery{
+		URL:      w.Discovery.URL,
+		IDPath:   w.Discovery.IDPath,
+		NamePath: w.Discovery.NamePath,
+		Metadata: w.Discovery.Metadata,
 	}
 }

--- a/gestaltd/internal/discovery/discovery.go
+++ b/gestaltd/internal/discovery/discovery.go
@@ -63,7 +63,7 @@ func Run(ctx context.Context, cfg *core.DiscoveryConfig, client *http.Client) ([
 				c.Name = fmt.Sprintf("%v", v)
 			}
 		}
-		for metaKey, jsonPath := range cfg.MetadataMapping {
+		for metaKey, jsonPath := range cfg.Metadata {
 			if v, ok := extractPath(obj, jsonPath); ok {
 				c.Metadata[metaKey] = fmt.Sprintf("%v", v)
 			}

--- a/gestaltd/internal/discovery/discovery_test.go
+++ b/gestaltd/internal/discovery/discovery_test.go
@@ -25,7 +25,7 @@ func TestRun_TopLevelArray(t *testing.T) {
 		URL:      srv.URL,
 		IDPath:   "site_id",
 		NamePath: "site_name",
-		MetadataMapping: map[string]string{
+		Metadata: map[string]string{
 			"region": "region",
 		},
 	}

--- a/gestaltd/internal/pluginhost/declarative.go
+++ b/gestaltd/internal/pluginhost/declarative.go
@@ -46,7 +46,7 @@ type DeclarativeProvider struct {
 	baseURL              string
 	auth                 *pluginmanifestv1.ProviderAuth
 	httpClient           *http.Client
-	postConnectDiscovery *pluginmanifestv1.ProviderPostConnectDiscovery
+	discovery *pluginmanifestv1.ProviderDiscovery
 	connectionDefs       map[string]pluginmanifestv1.ProviderConnectionParam
 	connectionMode       core.ConnectionMode
 }
@@ -75,7 +75,7 @@ func NewDeclarativeProvider(manifest *pluginmanifestv1.Manifest, httpClient *htt
 		baseURL:              manifest.Plugin.BaseURL,
 		auth:                 manifest.Plugin.Auth,
 		httpClient:           httpClient,
-		postConnectDiscovery: manifest.Plugin.PostConnectDiscovery,
+		discovery: manifest.Plugin.Discovery,
 		connectionDefs:       manifest.Plugin.ConnectionParams,
 	}
 
@@ -259,5 +259,5 @@ func (p *DeclarativeProvider) ConnectionParamDefs() map[string]core.ConnectionPa
 }
 
 func (p *DeclarativeProvider) DiscoveryConfig() *core.DiscoveryConfig {
-	return DiscoveryConfigFromManifest(p.postConnectDiscovery)
+	return DiscoveryConfigFromManifest(p.discovery)
 }

--- a/gestaltd/internal/pluginhost/declarative.go
+++ b/gestaltd/internal/pluginhost/declarative.go
@@ -41,14 +41,14 @@ func WithDeclarativeConnectionMode(mode core.ConnectionMode) DeclarativeProvider
 }
 
 type DeclarativeProvider struct {
-	catalog              *catalog.Catalog
-	opsByName            map[string]*catalog.CatalogOperation
-	baseURL              string
-	auth                 *pluginmanifestv1.ProviderAuth
-	httpClient           *http.Client
-	discovery *pluginmanifestv1.ProviderDiscovery
-	connectionDefs       map[string]pluginmanifestv1.ProviderConnectionParam
-	connectionMode       core.ConnectionMode
+	catalog        *catalog.Catalog
+	opsByName      map[string]*catalog.CatalogOperation
+	baseURL        string
+	auth           *pluginmanifestv1.ProviderAuth
+	httpClient     *http.Client
+	discovery      *pluginmanifestv1.ProviderDiscovery
+	connectionDefs map[string]pluginmanifestv1.ProviderConnectionParam
+	connectionMode core.ConnectionMode
 }
 
 func NewDeclarativeProvider(manifest *pluginmanifestv1.Manifest, httpClient *http.Client, opts ...DeclarativeProviderOption) (*DeclarativeProvider, error) {
@@ -71,12 +71,12 @@ func NewDeclarativeProvider(manifest *pluginmanifestv1.Manifest, httpClient *htt
 			Headers:     maps.Clone(manifest.Plugin.Headers),
 			Operations:  make([]catalog.CatalogOperation, 0, len(manifest.Plugin.Operations)),
 		},
-		opsByName:            make(map[string]*catalog.CatalogOperation, len(manifest.Plugin.Operations)),
-		baseURL:              manifest.Plugin.BaseURL,
-		auth:                 manifest.Plugin.Auth,
-		httpClient:           httpClient,
-		discovery: manifest.Plugin.Discovery,
-		connectionDefs:       manifest.Plugin.ConnectionParams,
+		opsByName:      make(map[string]*catalog.CatalogOperation, len(manifest.Plugin.Operations)),
+		baseURL:        manifest.Plugin.BaseURL,
+		auth:           manifest.Plugin.Auth,
+		httpClient:     httpClient,
+		discovery:      manifest.Plugin.Discovery,
+		connectionDefs: manifest.Plugin.ConnectionParams,
 	}
 
 	for i := range manifest.Plugin.Operations {

--- a/gestaltd/internal/pluginhost/manifest_core.go
+++ b/gestaltd/internal/pluginhost/manifest_core.go
@@ -38,14 +38,14 @@ func CredentialFieldsFromManifest(fields []pluginmanifestv1.CredentialField) []c
 	return out
 }
 
-func DiscoveryConfigFromManifest(discovery *pluginmanifestv1.ProviderPostConnectDiscovery) *core.DiscoveryConfig {
+func DiscoveryConfigFromManifest(discovery *pluginmanifestv1.ProviderDiscovery) *core.DiscoveryConfig {
 	if discovery == nil {
 		return nil
 	}
 	return &core.DiscoveryConfig{
-		URL:             discovery.URL,
-		IDPath:          discovery.IDPath,
-		NamePath:        discovery.NamePath,
-		MetadataMapping: maps.Clone(discovery.MetadataMapping),
+		URL:      discovery.URL,
+		IDPath:   discovery.IDPath,
+		NamePath: discovery.NamePath,
+		Metadata: maps.Clone(discovery.Metadata),
 	}
 }

--- a/gestaltd/internal/pluginpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/pluginpkg/manifest_workflow_test.go
@@ -440,3 +440,92 @@ provider:
 		t.Fatalf("error = %v", err)
 	}
 }
+
+func TestManifestWorkflow_NamedConnectionParamsAndDiscovery(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := mustWriteManifestData(t, dir, "plugin.yaml", []byte(`
+source: github.com/acme/plugins/multi-conn
+version: 1.0.0
+display_name: Multi Connection
+provider:
+  connections:
+    default:
+      auth:
+        type: none
+    api:
+      mode: user
+      auth:
+        type: oauth2
+        authorization_url: https://auth.example.com/authorize
+        token_url: https://auth.example.com/token
+      params:
+        workspace_id:
+          required: true
+          description: The workspace ID
+        region:
+          from: discovery
+      discovery:
+        url: https://api.example.com/workspaces
+        id_path: id
+        name_path: name
+        metadata:
+          region: region
+  surfaces:
+    openapi:
+      document: openapi.yaml
+      connection: api
+`))
+	mustWriteFile(t, filepath.Join(dir, "openapi.yaml"), []byte("openapi: 3.1.0\ninfo:\n  title: Example\n  version: 1.0.0\npaths: {}\n"), 0o644)
+
+	_, manifest, err := ReadManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadManifestFile: %v", err)
+	}
+	if manifest.Plugin == nil {
+		t.Fatal("expected plugin metadata")
+	}
+
+	conn := manifest.Plugin.Connections["api"]
+	if conn == nil {
+		t.Fatal("expected api connection")
+	}
+	if conn.Mode != "user" {
+		t.Fatalf("api connection mode = %q, want user", conn.Mode)
+	}
+	if len(conn.Params) != 2 {
+		t.Fatalf("api connection params = %+v, want 2 entries", conn.Params)
+	}
+	if p := conn.Params["workspace_id"]; !p.Required || p.Description != "The workspace ID" {
+		t.Fatalf("workspace_id param = %+v", p)
+	}
+	if p := conn.Params["region"]; p.From != "discovery" {
+		t.Fatalf("region param = %+v", p)
+	}
+	if conn.Discovery == nil {
+		t.Fatal("expected api connection discovery")
+	}
+	if conn.Discovery.URL != "https://api.example.com/workspaces" {
+		t.Fatalf("discovery url = %q", conn.Discovery.URL)
+	}
+	if conn.Discovery.IDPath != "id" || conn.Discovery.NamePath != "name" {
+		t.Fatalf("discovery paths: id=%q name=%q", conn.Discovery.IDPath, conn.Discovery.NamePath)
+	}
+	if conn.Discovery.Metadata["region"] != "region" {
+		t.Fatalf("discovery metadata = %+v", conn.Discovery.Metadata)
+	}
+
+	// Round-trip: encode then decode and verify equality.
+	encoded, err := EncodeManifestFormat(manifest, ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeManifestFormat: %v", err)
+	}
+	roundTripped, err := DecodeManifestFormat(encoded, ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("DecodeManifestFormat: %v", err)
+	}
+	if !ManifestEqual(manifest, roundTripped) {
+		t.Fatalf("round-trip mismatch:\noriginal=%#v\nround-tripped=%#v", manifest, roundTripped)
+	}
+}

--- a/gestaltd/internal/pluginpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/pluginpkg/manifest_workflow_test.go
@@ -483,40 +483,7 @@ provider:
 	if err != nil {
 		t.Fatalf("ReadManifestFile: %v", err)
 	}
-	if manifest.Plugin == nil {
-		t.Fatal("expected plugin metadata")
-	}
 
-	conn := manifest.Plugin.Connections["api"]
-	if conn == nil {
-		t.Fatal("expected api connection")
-	}
-	if conn.Mode != "user" {
-		t.Fatalf("api connection mode = %q, want user", conn.Mode)
-	}
-	if len(conn.Params) != 2 {
-		t.Fatalf("api connection params = %+v, want 2 entries", conn.Params)
-	}
-	if p := conn.Params["workspace_id"]; !p.Required || p.Description != "The workspace ID" {
-		t.Fatalf("workspace_id param = %+v", p)
-	}
-	if p := conn.Params["region"]; p.From != "discovery" {
-		t.Fatalf("region param = %+v", p)
-	}
-	if conn.Discovery == nil {
-		t.Fatal("expected api connection discovery")
-	}
-	if conn.Discovery.URL != "https://api.example.com/workspaces" {
-		t.Fatalf("discovery url = %q", conn.Discovery.URL)
-	}
-	if conn.Discovery.IDPath != "id" || conn.Discovery.NamePath != "name" {
-		t.Fatalf("discovery paths: id=%q name=%q", conn.Discovery.IDPath, conn.Discovery.NamePath)
-	}
-	if conn.Discovery.Metadata["region"] != "region" {
-		t.Fatalf("discovery metadata = %+v", conn.Discovery.Metadata)
-	}
-
-	// Round-trip: encode then decode and verify equality.
 	encoded, err := EncodeManifestFormat(manifest, ManifestFormatYAML)
 	if err != nil {
 		t.Fatalf("EncodeManifestFormat: %v", err)

--- a/gestaltd/internal/pluginpkg/provider_manifest_wire.go
+++ b/gestaltd/internal/pluginpkg/provider_manifest_wire.go
@@ -146,7 +146,7 @@ func providerWireToInternal(wire *providerManifestWireRoot) *pluginmanifestv1.Ma
 			manifest.Plugin.Auth = defaultConn.Auth
 			manifest.Plugin.ConnectionMode = defaultConn.Mode
 			manifest.Plugin.ConnectionParams = defaultConn.Params
-			manifest.Plugin.PostConnectDiscovery = defaultConn.toInternalDiscovery()
+			manifest.Plugin.Discovery = defaultConn.toInternalDiscovery()
 		}
 		if len(wire.Provider.Connections) > 0 {
 			manifest.Plugin.Connections = make(map[string]*pluginmanifestv1.ManifestConnectionDef, len(wire.Provider.Connections))
@@ -159,8 +159,10 @@ func providerWireToInternal(wire *providerManifestWireRoot) *pluginmanifestv1.Ma
 					continue
 				}
 				manifest.Plugin.Connections[name] = &pluginmanifestv1.ManifestConnectionDef{
-					Mode: conn.Mode,
-					Auth: conn.Auth,
+					Mode:      conn.Mode,
+					Auth:      conn.Auth,
+					Params:    conn.Params,
+					Discovery: conn.toInternalDiscovery(),
 				}
 			}
 			if len(manifest.Plugin.Connections) == 0 {
@@ -246,13 +248,13 @@ func internalProviderManifestToWire(manifest *pluginmanifestv1.Manifest) *provid
 	if manifest.Plugin.MCP {
 		provider.MCP = &providerManifestMCPWire{Enabled: true}
 	}
-	if manifest.Plugin.ConnectionMode != "" || manifest.Plugin.Auth != nil || len(manifest.Plugin.ConnectionParams) > 0 || manifest.Plugin.PostConnectDiscovery != nil {
+	if manifest.Plugin.ConnectionMode != "" || manifest.Plugin.Auth != nil || len(manifest.Plugin.ConnectionParams) > 0 || manifest.Plugin.Discovery != nil {
 		provider.Connections = map[string]*providerManifestConnectionWire{
 			"default": {
 				Mode:      manifest.Plugin.ConnectionMode,
 				Auth:      manifest.Plugin.Auth,
 				Params:    manifest.Plugin.ConnectionParams,
-				Discovery: internalDiscoveryToWire(manifest.Plugin.PostConnectDiscovery),
+				Discovery: internalDiscoveryToWire(manifest.Plugin.Discovery),
 			},
 		}
 	}
@@ -266,8 +268,10 @@ func internalProviderManifestToWire(manifest *pluginmanifestv1.Manifest) *provid
 				continue
 			}
 			provider.Connections[name] = &providerManifestConnectionWire{
-				Mode: conn.Mode,
-				Auth: conn.Auth,
+				Mode:      conn.Mode,
+				Auth:      conn.Auth,
+				Params:    conn.Params,
+				Discovery: internalDiscoveryToWire(conn.Discovery),
 			}
 		}
 	}
@@ -300,19 +304,19 @@ func internalProviderManifestToWire(manifest *pluginmanifestv1.Manifest) *provid
 	return wire
 }
 
-func (w *providerManifestConnectionWire) toInternalDiscovery() *pluginmanifestv1.ProviderPostConnectDiscovery {
+func (w *providerManifestConnectionWire) toInternalDiscovery() *pluginmanifestv1.ProviderDiscovery {
 	if w == nil || w.Discovery == nil {
 		return nil
 	}
-	return &pluginmanifestv1.ProviderPostConnectDiscovery{
-		URL:             w.Discovery.URL,
-		IDPath:          w.Discovery.IDPath,
-		NamePath:        w.Discovery.NamePath,
-		MetadataMapping: w.Discovery.Metadata,
+	return &pluginmanifestv1.ProviderDiscovery{
+		URL:      w.Discovery.URL,
+		IDPath:   w.Discovery.IDPath,
+		NamePath: w.Discovery.NamePath,
+		Metadata: w.Discovery.Metadata,
 	}
 }
 
-func internalDiscoveryToWire(discovery *pluginmanifestv1.ProviderPostConnectDiscovery) *providerManifestDiscoveryWire {
+func internalDiscoveryToWire(discovery *pluginmanifestv1.ProviderDiscovery) *providerManifestDiscoveryWire {
 	if discovery == nil {
 		return nil
 	}
@@ -320,7 +324,7 @@ func internalDiscoveryToWire(discovery *pluginmanifestv1.ProviderPostConnectDisc
 		URL:      discovery.URL,
 		IDPath:   discovery.IDPath,
 		NamePath: discovery.NamePath,
-		Metadata: discovery.MetadataMapping,
+		Metadata: discovery.Metadata,
 	}
 }
 

--- a/gestaltd/internal/provider/build.go
+++ b/gestaltd/internal/provider/build.go
@@ -141,8 +141,8 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 		}
 	}
 
-	if def.PostConnectDiscovery != nil {
-		base.DiscoveryDef = def.PostConnectDiscovery.ToCore()
+	if def.Discovery != nil {
+		base.DiscoveryDef = def.Discovery.ToCore()
 	}
 
 	base.ManualAuthEnabled = def.ManualAuth

--- a/gestaltd/internal/provider/definition.go
+++ b/gestaltd/internal/provider/definition.go
@@ -26,8 +26,8 @@ type Definition struct {
 	ManualAuth       bool                 `yaml:"manual_auth" json:"manual_auth"`
 	CredentialFields []CredentialFieldDef `yaml:"credential_fields" json:"credential_fields,omitempty"`
 
-	Discovery *DiscoveryDef `yaml:"discovery" json:"discovery,omitempty"`
-	ResponseMapping      *ResponseMappingDef      `yaml:"response_mapping" json:"response_mapping,omitempty"`
+	Discovery       *DiscoveryDef       `yaml:"discovery" json:"discovery,omitempty"`
+	ResponseMapping *ResponseMappingDef `yaml:"response_mapping" json:"response_mapping,omitempty"`
 
 	Connection map[string]ConnectionParamDef `yaml:"connection" json:"connection"`
 	Operations map[string]OperationDef       `yaml:"operations" json:"operations"`
@@ -39,20 +39,20 @@ type ResponseCheckDef struct {
 }
 
 type DiscoveryDef struct {
-	URL      string            `yaml:"url" json:"url"`
-	ItemsPath string           `yaml:"items_path" json:"items_path"`
-	IDPath   string            `yaml:"id_path" json:"id_path"`
-	NamePath string            `yaml:"name_path" json:"name_path"`
-	Metadata map[string]string `yaml:"metadata" json:"metadata"`
+	URL       string            `yaml:"url" json:"url"`
+	ItemsPath string            `yaml:"items_path" json:"items_path"`
+	IDPath    string            `yaml:"id_path" json:"id_path"`
+	NamePath  string            `yaml:"name_path" json:"name_path"`
+	Metadata  map[string]string `yaml:"metadata" json:"metadata"`
 }
 
 func (d *DiscoveryDef) ToCore() *core.DiscoveryConfig {
 	return &core.DiscoveryConfig{
-		URL:             d.URL,
-		ItemsPath:       d.ItemsPath,
-		IDPath:          d.IDPath,
-		NamePath:        d.NamePath,
-		Metadata: d.Metadata,
+		URL:       d.URL,
+		ItemsPath: d.ItemsPath,
+		IDPath:    d.IDPath,
+		NamePath:  d.NamePath,
+		Metadata:  d.Metadata,
 	}
 }
 

--- a/gestaltd/internal/provider/definition.go
+++ b/gestaltd/internal/provider/definition.go
@@ -26,7 +26,7 @@ type Definition struct {
 	ManualAuth       bool                 `yaml:"manual_auth" json:"manual_auth"`
 	CredentialFields []CredentialFieldDef `yaml:"credential_fields" json:"credential_fields,omitempty"`
 
-	PostConnectDiscovery *PostConnectDiscoveryDef `yaml:"post_connect_discovery" json:"post_connect_discovery,omitempty"`
+	Discovery *DiscoveryDef `yaml:"discovery" json:"discovery,omitempty"`
 	ResponseMapping      *ResponseMappingDef      `yaml:"response_mapping" json:"response_mapping,omitempty"`
 
 	Connection map[string]ConnectionParamDef `yaml:"connection" json:"connection"`
@@ -38,21 +38,21 @@ type ResponseCheckDef struct {
 	ErrorMessagePath string         `yaml:"error_message_path" json:"error_message_path,omitempty"`
 }
 
-type PostConnectDiscoveryDef struct {
-	URL             string            `yaml:"url" json:"url"`
-	ItemsPath       string            `yaml:"items_path" json:"items_path"`
-	IDPath          string            `yaml:"id_path" json:"id_path"`
-	NamePath        string            `yaml:"name_path" json:"name_path"`
-	MetadataMapping map[string]string `yaml:"metadata_mapping" json:"metadata_mapping"`
+type DiscoveryDef struct {
+	URL      string            `yaml:"url" json:"url"`
+	ItemsPath string           `yaml:"items_path" json:"items_path"`
+	IDPath   string            `yaml:"id_path" json:"id_path"`
+	NamePath string            `yaml:"name_path" json:"name_path"`
+	Metadata map[string]string `yaml:"metadata" json:"metadata"`
 }
 
-func (d *PostConnectDiscoveryDef) ToCore() *core.DiscoveryConfig {
+func (d *DiscoveryDef) ToCore() *core.DiscoveryConfig {
 	return &core.DiscoveryConfig{
 		URL:             d.URL,
 		ItemsPath:       d.ItemsPath,
 		IDPath:          d.IDPath,
 		NamePath:        d.NamePath,
-		MetadataMapping: d.MetadataMapping,
+		Metadata: d.Metadata,
 	}
 }
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2919,9 +2919,9 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		stub := &stubDiscoveringProvider{
 			StubIntegration: coretesting.StubIntegration{N: "slack"},
 			discovery: &core.DiscoveryConfig{
-				URL:             discoverySrv.URL,
-				IDPath:          "id",
-				NamePath:        "name",
+				URL:      discoverySrv.URL,
+				IDPath:   "id",
+				NamePath: "name",
 				Metadata: map[string]string{"workspace": "workspace"},
 			},
 		}
@@ -4883,9 +4883,9 @@ func TestConnectManual(t *testing.T) {
 					StubIntegration: coretesting.StubIntegration{N: "manual-svc"},
 				},
 				discovery: &core.DiscoveryConfig{
-					URL:             discoverySrv.URL,
-					IDPath:          "id",
-					NamePath:        "name",
+					URL:      discoverySrv.URL,
+					IDPath:   "id",
+					NamePath: "name",
 					Metadata: map[string]string{"workspace": "workspace"},
 				},
 			})

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2922,7 +2922,7 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 				URL:             discoverySrv.URL,
 				IDPath:          "id",
 				NamePath:        "name",
-				MetadataMapping: map[string]string{"workspace": "workspace"},
+				Metadata: map[string]string{"workspace": "workspace"},
 			},
 		}
 
@@ -4886,7 +4886,7 @@ func TestConnectManual(t *testing.T) {
 					URL:             discoverySrv.URL,
 					IDPath:          "id",
 					NamePath:        "name",
-					MetadataMapping: map[string]string{"workspace": "workspace"},
+					Metadata: map[string]string{"workspace": "workspace"},
 				},
 			})
 			cfg.DefaultConnection = map[string]string{"manual-svc": config.PluginConnectionName}

--- a/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -261,6 +261,15 @@
         },
         "auth": {
           "$ref": "#/$defs/plugin_auth"
+        },
+        "params": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/plugin_connection_param"
+          }
+        },
+        "discovery": {
+          "$ref": "#/$defs/plugin_discovery"
         }
       }
     },

--- a/gestaltd/sdk/pluginmanifest/v1/types.go
+++ b/gestaltd/sdk/pluginmanifest/v1/types.go
@@ -63,7 +63,7 @@ type Plugin struct {
 	Headers              map[string]string                  `json:"headers,omitempty" yaml:"headers,omitempty"`
 	ManagedParameters    []ManagedParameter                 `json:"managed_parameters,omitempty" yaml:"managed_parameters,omitempty"`
 	Operations           []ProviderOperation                `json:"operations,omitempty" yaml:"operations,omitempty"`
-	PostConnectDiscovery *ProviderPostConnectDiscovery      `json:"post_connect_discovery,omitempty" yaml:"post_connect_discovery,omitempty"`
+	Discovery *ProviderDiscovery `json:"discovery,omitempty" yaml:"discovery,omitempty"`
 	ConnectionParams     map[string]ProviderConnectionParam `json:"connection_params,omitempty" yaml:"connection_params,omitempty"`
 
 	OpenAPI           string                                `json:"openapi,omitempty" yaml:"openapi,omitempty"`
@@ -114,11 +114,11 @@ type ManifestPaginationMapping struct {
 	Cursor  *ManifestValueSelector `json:"cursor,omitempty" yaml:"cursor,omitempty"`
 }
 
-type ProviderPostConnectDiscovery struct {
-	URL             string            `json:"url" yaml:"url"`
-	IDPath          string            `json:"id_path,omitempty" yaml:"id_path,omitempty"`
-	NamePath        string            `json:"name_path,omitempty" yaml:"name_path,omitempty"`
-	MetadataMapping map[string]string `json:"metadata_mapping,omitempty" yaml:"metadata_mapping,omitempty"`
+type ProviderDiscovery struct {
+	URL      string            `json:"url" yaml:"url"`
+	IDPath   string            `json:"id_path,omitempty" yaml:"id_path,omitempty"`
+	NamePath string            `json:"name_path,omitempty" yaml:"name_path,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 }
 
 type ProviderConnectionParam struct {
@@ -145,8 +145,10 @@ type ManifestOperationOverride struct {
 }
 
 type ManifestConnectionDef struct {
-	Mode string        `json:"mode,omitempty" yaml:"mode,omitempty"`
-	Auth *ProviderAuth `json:"auth,omitempty" yaml:"auth,omitempty"`
+	Mode      string                             `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Auth      *ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
+	Params    map[string]ProviderConnectionParam `json:"params,omitempty" yaml:"params,omitempty"`
+	Discovery *ProviderDiscovery                 `json:"discovery,omitempty" yaml:"discovery,omitempty"`
 }
 
 type ProviderOperation struct {

--- a/gestaltd/sdk/pluginmanifest/v1/types.go
+++ b/gestaltd/sdk/pluginmanifest/v1/types.go
@@ -55,16 +55,16 @@ type WebUIMetadata struct {
 }
 
 type Plugin struct {
-	ConfigSchemaPath     string                             `json:"config_schema_path,omitempty" yaml:"config_schema_path,omitempty"`
-	Auth                 *ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
-	ConnectionMode       string                             `json:"connection_mode,omitempty" yaml:"connection_mode,omitempty"`
-	MCP                  bool                               `json:"mcp,omitempty" yaml:"mcp,omitempty"`
-	BaseURL              string                             `json:"base_url,omitempty" yaml:"base_url,omitempty"`
-	Headers              map[string]string                  `json:"headers,omitempty" yaml:"headers,omitempty"`
-	ManagedParameters    []ManagedParameter                 `json:"managed_parameters,omitempty" yaml:"managed_parameters,omitempty"`
-	Operations           []ProviderOperation                `json:"operations,omitempty" yaml:"operations,omitempty"`
-	Discovery *ProviderDiscovery `json:"discovery,omitempty" yaml:"discovery,omitempty"`
-	ConnectionParams     map[string]ProviderConnectionParam `json:"connection_params,omitempty" yaml:"connection_params,omitempty"`
+	ConfigSchemaPath  string                             `json:"config_schema_path,omitempty" yaml:"config_schema_path,omitempty"`
+	Auth              *ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
+	ConnectionMode    string                             `json:"connection_mode,omitempty" yaml:"connection_mode,omitempty"`
+	MCP               bool                               `json:"mcp,omitempty" yaml:"mcp,omitempty"`
+	BaseURL           string                             `json:"base_url,omitempty" yaml:"base_url,omitempty"`
+	Headers           map[string]string                  `json:"headers,omitempty" yaml:"headers,omitempty"`
+	ManagedParameters []ManagedParameter                 `json:"managed_parameters,omitempty" yaml:"managed_parameters,omitempty"`
+	Operations        []ProviderOperation                `json:"operations,omitempty" yaml:"operations,omitempty"`
+	Discovery         *ProviderDiscovery                 `json:"discovery,omitempty" yaml:"discovery,omitempty"`
+	ConnectionParams  map[string]ProviderConnectionParam `json:"connection_params,omitempty" yaml:"connection_params,omitempty"`
 
 	OpenAPI           string                                `json:"openapi,omitempty" yaml:"openapi,omitempty"`
 	GraphQLURL        string                                `json:"graphql_url,omitempty" yaml:"graphql_url,omitempty"`


### PR DESCRIPTION
ManifestConnectionDef previously only had Mode and Auth, while the config schema supported params and discovery on connections. The wire format already parsed these fields but silently dropped them for named connections during conversion to the internal type. This adds Params and Discovery fields to ManifestConnectionDef so named connections can declare their own connection parameters and post-connect discovery, achieving feature parity with config.

Also consolidates naming across all packages: ProviderPostConnectDiscovery becomes ProviderDiscovery, PostConnectDiscovery fields become Discovery, and MetadataMapping becomes Metadata everywhere. The config validation that restricted params/discovery to only the default connection is removed.