### PR TITLE
Standardize YAML/JSON fields on camelCase, remove help_url

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -44,9 +44,9 @@ A config file has the following top-level blocks:
 
 ## Defaults and required fields
 
-Gestalt defaults `server.port` to `8080`, `secrets.provider` to `env`, and `telemetry.provider` to `stdout`. The required fields are `datastore.provider` and `server.encryption_key`. Platform auth is optional.
+Gestalt defaults `server.port` to `8080`, `secrets.provider` to `env`, and `telemetry.provider` to `stdout`. The required fields are `datastore.provider` and `server.encryptionKey`. Platform auth is optional.
 
-`server.encryption_key` is the root deployment secret. Gestalt derives token encryption and session material from it. Changing this key invalidates all existing sessions and tokens, so treat it as a meaningful deployment event.
+`server.encryptionKey` is the root deployment secret. Gestalt derives token encryption and session material from it. Changing this key invalidates all existing sessions and tokens, so treat it as a meaningful deployment event.
 
 ## Plugins
 
@@ -61,13 +61,13 @@ Published providers use a `source.ref` and `version` that Gestalt resolves durin
 ```yaml
 plugins:
   github:
-    display_name: GitHub
+    displayName: GitHub
     provider:
       source:
         ref: github.com/valon-technologies/gestalt-providers/plugins/github
         version: 0.0.1-alpha.1
     config:
-      api_base_url: https://api.github.com
+      apiBaseUrl: https://api.github.com
     connections:
       default:
         mode: user
@@ -75,7 +75,7 @@ plugins:
           type: oauth2
     mcp:
       enabled: true
-      tool_prefix: github_
+      toolPrefix: github_
 ```
 
 First-party providers are published to `github.com/valon-technologies/gestalt-providers/`.
@@ -87,7 +87,7 @@ During development, point at a local provider manifest instead.
 ```yaml
 plugins:
   support:
-    display_name: Support
+    displayName: Support
     provider:
       source:
         path: ./plugins/support/manifest.yaml
@@ -105,7 +105,7 @@ plugins:
 
 ### Filtering operations
 
-A provider package may expose a large catalog. Use `allowed_operations` to publish only the subset you want.
+A provider package may expose a large catalog. Use `allowedOperations` to publish only the subset you want.
 
 ```yaml
 plugins:
@@ -119,7 +119,7 @@ plugins:
         mode: user
         auth:
           type: oauth2
-    allowed_operations:
+    allowedOperations:
       tickets.list:
         alias: list_tickets
       tickets.get:
@@ -130,7 +130,7 @@ Each entry can set an `alias` to rename the operation as it appears to callers.
 
 ### Network sandbox
 
-Executable provider processes run inside a network sandbox. Outbound requests to hosts not listed in `provider.allowed_hosts` are rejected. Add every upstream domain the integration plugin contacts to the allowlist.
+Executable provider processes run inside a network sandbox. Outbound requests to hosts not listed in `provider.allowedHosts` are rejected. Add every upstream domain the integration plugin contacts to the allowlist.
 
 ```yaml
 plugins:
@@ -139,7 +139,7 @@ plugins:
       source:
         ref: github.com/acme/providers/example
         version: 1.0.0
-      allowed_hosts:
+      allowedHosts:
         - api.example.com
         - cdn.example.com
 ```
@@ -160,7 +160,7 @@ Connections define how Gestalt authenticates to upstream systems. Each plugin de
 
 Common connection auth types are `oauth2`, `mcp_oauth`, `bearer`, `manual`, and `none`.
 
-OAuth2 connections support the full set of OAuth2 configuration: `authorization_url`, `token_url`, `client_id`, `client_secret`, `scopes`, `pkce`, and custom authorization/token/refresh parameters. Bearer and manual connections declare `credentials` fields that the user fills in during connection setup.
+OAuth2 connections support the full set of OAuth2 configuration: `authorizationUrl`, `tokenUrl`, `clientId`, `clientSecret`, `scopes`, `pkce`, and custom authorization/token/refresh parameters. Bearer and manual connections declare `credentials` fields that the user fills in during connection setup.
 
 Gestalt stores upstream credentials keyed by user, plugin name, connection name, and instance. Renaming a `plugins:` key is a breaking change for stored connections.
 
@@ -186,16 +186,16 @@ auth:
       ref: github.com/valon-technologies/gestalt-providers/auth/oidc
       version: 0.0.1-alpha.1
   config:
-    issuer_url: https://login.example.com
-    client_id: ${OIDC_CLIENT_ID}
-    client_secret: secret://oidc-client-secret
+    issuerUrl: https://login.example.com
+    clientId: ${OIDC_CLIENT_ID}
+    clientSecret: secret://oidc-client-secret
 ```
 
 The `auth.provider` field is a provider reference with `source.ref` and `version`, the same shape used for integration plugins. The `none` scalar shorthand is the only exception.
 
 ### API tokens
 
-For programmatic access, Gestalt issues API tokens prefixed with `gst_api_`. They are accepted through `Authorization: Bearer ...` and use the same auth middleware as browser sessions. Token lifetime is controlled by `server.api_token_ttl`, which defaults to `30d`.
+For programmatic access, Gestalt issues API tokens prefixed with `gst_api_`. They are accepted through `Authorization: Bearer ...` and use the same auth middleware as browser sessions. Token lifetime is controlled by `server.apiTokenTtl`, which defaults to `30d`.
 
 ## Datastore
 
@@ -222,14 +222,14 @@ plugins:
   github:
     mcp:
       enabled: true
-      tool_prefix: github_
+      toolPrefix: github_
 ```
 
-`tool_prefix` controls the prefix added to tool names to avoid collisions when multiple plugins expose MCP tools. Tool exposure follows the provider catalog loaded at startup.
+`toolPrefix` controls the prefix added to tool names to avoid collisions when multiple plugins expose MCP tools. Tool exposure follows the provider catalog loaded at startup.
 
 ## Managed parameters and response mapping
 
-Operations, request schemas, response schemas, managed parameters, and response mappings are defined in the provider manifest, not in the deployment config. Inline configuration surfaces that existed in earlier versions of Gestalt (such as `openapi`, `graphql_url`, `mcp_url`, `base_url`, `headers`, `managed_parameters`, `operations`, and `response_mapping`) have been removed from config. See [Provider Manifests](/reference/plugin-manifests) for the manifest schema.
+Operations, request schemas, response schemas, managed parameters, and response mappings are defined in the provider manifest, not in the deployment config. Inline configuration surfaces that existed in earlier versions of Gestalt (such as `openapi`, `graphqlUrl`, `mcpUrl`, `baseUrl`, `headers`, `managedParameters`, `operations`, and `responseMapping`) have been removed from config. See [Provider Manifests](/reference/plugin-manifests) for the manifest schema.
 
 ## Startup workflows
 
@@ -285,8 +285,8 @@ The lockfile records the concrete result of resolving that config.
       "fingerprint": "...",
       "source": "github.com/acme/plugins/example",
       "version": "1.2.3",
-      "resolved_url": "https://github.com/...",
-      "archive_sha256": "...",
+      "resolvedUrl": "https://github.com/...",
+      "archiveSha256": "...",
       "manifest": ".gestaltd/providers/example/manifest.yaml",
       "executable": ".gestaltd/providers/example/artifacts/linux/amd64/provider"
     }
@@ -311,8 +311,8 @@ This config shows a production deployment with OIDC auth, a GitHub plugin with p
 
 ```yaml
 server:
-  base_url: https://gestalt.example.com
-  encryption_key: secret://gestalt-encryption-key
+  baseUrl: https://gestalt.example.com
+  encryptionKey: secret://gestalt-encryption-key
 
 auth:
   provider:
@@ -320,9 +320,9 @@ auth:
       ref: github.com/valon-technologies/gestalt-providers/auth/oidc
       version: 0.0.1-alpha.1
   config:
-    issuer_url: https://login.example.com
-    client_id: ${OIDC_CLIENT_ID}
-    client_secret: secret://oidc-client-secret
+    issuerUrl: https://login.example.com
+    clientId: ${OIDC_CLIENT_ID}
+    clientSecret: secret://oidc-client-secret
 
 datastore:
   provider:
@@ -334,16 +334,16 @@ datastore:
 
 plugins:
   github:
-    display_name: GitHub
+    displayName: GitHub
     provider:
       source:
         ref: github.com/valon-technologies/gestalt-providers/plugins/github
         version: 0.0.1-alpha.1
     config:
-      api_base_url: https://api.github.com
+      apiBaseUrl: https://api.github.com
     mcp:
       enabled: true
-      tool_prefix: github_
+      toolPrefix: github_
     connections:
       api:
         mode: user
@@ -365,8 +365,8 @@ The smallest useful config sets up a local server with SQLite storage, no auth, 
 ```yaml
 server:
   port: 8080
-  base_url: http://localhost:8080
-  encryption_key: change-me
+  baseUrl: http://localhost:8080
+  encryptionKey: change-me
 
 datastore:
   provider:

--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -25,8 +25,8 @@ The generated config is fine for a first look, but let's write one explicitly so
 ```yaml
 server:
   port: 8080
-  base_url: http://localhost:8080
-  encryption_key: dev-only-change-me
+  baseUrl: http://localhost:8080
+  encryptionKey: dev-only-change-me
 
 auth:
   provider: none
@@ -57,8 +57,8 @@ Plugins are where the interesting things happen. Each entry under `plugins:` reg
 ```yaml
 server:
   port: 8080
-  base_url: http://localhost:8080
-  encryption_key: dev-only-change-me
+  baseUrl: http://localhost:8080
+  encryptionKey: dev-only-change-me
 
 auth:
   provider: none
@@ -73,7 +73,7 @@ datastore:
 
 plugins:
   httpbin:
-    display_name: HTTPBin
+    displayName: HTTPBin
     provider:
       source:
         ref: github.com/valon-technologies/gestalt-providers/plugins/httpbin

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -32,21 +32,21 @@ server:
   management:
     host: 127.0.0.1
     port: 9090
-  base_url: https://gestalt.example.com
-  encryption_key: secret://gestalt-encryption-key
-  api_token_ttl: 30d
-  artifacts_dir: ./state
+  baseUrl: https://gestalt.example.com
+  encryptionKey: secret://gestalt-encryption-key
+  apiTokenTtl: 30d
+  artifactsDir: ./state
 ```
 
 `public.host` and `public.port` control the public listener address. Both default to all-interfaces on port `8080`. The legacy `port` shorthand still works but `public.port` takes precedence.
 
 `management.host` and `management.port` bind a separate listener for operator traffic. When `management.port` is omitted, `/admin` and `/metrics` stay on the public listener, a mode best kept to local development or other trusted-network deployments. For production, prefer configuring `server.management` so the operator surface leaves the public listener entirely.
 
-`base_url` derives OAuth callback URLs when explicit redirect URLs are omitted, and gives the management admin UI an absolute link back to the public client UI. When unset, the management admin UI omits the `Client UI` link rather than sending operators to a broken same-origin `/`.
+`baseUrl` derives OAuth callback URLs when explicit redirect URLs are omitted, and gives the management admin UI an absolute link back to the public client UI. When unset, the management admin UI omits the `Client UI` link rather than sending operators to a broken same-origin `/`.
 
-`encryption_key` is the only required server field. It is the root deployment secret, used for encryption and derived session material.
+`encryptionKey` is the only required server field. It is the root deployment secret, used for encryption and derived session material.
 
-`api_token_ttl` controls the lifetime of newly issued API tokens, defaulting to `30d`. It accepts Go duration strings (`1h`, `720h`) and day suffixes (`30d`). `artifacts_dir` is a writable directory for prepared artifacts produced by `init` and consumed by `serve --locked` when no CLI override is supplied; it defaults to the config file's directory. See [Configuration](/configuration) for the full `init`/`serve` lifecycle.
+`apiTokenTtl` controls the lifetime of newly issued API tokens, defaulting to `30d`. It accepts Go duration strings (`1h`, `720h`) and day suffixes (`30d`). `artifactsDir` is a writable directory for prepared artifacts produced by `init` and consumed by `serve --locked` when no CLI override is supplied; it defaults to the config file's directory. See [Configuration](/configuration) for the full `init`/`serve` lifecycle.
 
 | Field | Default | Description |
 | --- | --- | --- |
@@ -54,16 +54,16 @@ server:
 | `public.port` | `8080` | Port for the public listener. |
 | `management.host` | | Bind address for the management listener. |
 | `management.port` | | Port for the management listener. Required when `management.host` is set. |
-| `base_url` | | Public origin URL used for OAuth callbacks and admin UI links. |
-| `encryption_key` | | **Required.** Root encryption key. Typically a `secret://` reference. |
-| `api_token_ttl` | `30d` | Lifetime of newly issued API tokens. Go durations or day suffixes (`30d`). |
-| `artifacts_dir` | config directory | Directory for prepared `init` artifacts. |
+| `baseUrl` | | Public origin URL used for OAuth callbacks and admin UI links. |
+| `encryptionKey` | | **Required.** Root encryption key. Typically a `secret://` reference. |
+| `apiTokenTtl` | `30d` | Lifetime of newly issued API tokens. Go durations or day suffixes (`30d`). |
+| `artifactsDir` | config directory | Directory for prepared `init` artifacts. |
 
 When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth routes, and `/mcp` on the public listener, while `/admin`, `/metrics`, `/health`, and `/ready` move to the management listener. The management listener is intended to be protected by deployment infrastructure such as private networking, VPN, or an internal-only reverse proxy. Gestalt does not apply its own session or API-token auth to `/metrics` on the management listener.
 
 ## `auth`
 
-Top-level platform auth is optional. Omit the `auth` block entirely to disable platform authentication, or set `auth.provider: none` explicitly. When auth is enabled, configure it with `auth.provider` and `auth.config`. `auth.provider` uses the same provider-reference shape as integration plugins: a `source` block plus optional `env` and `allowed_hosts`.
+Top-level platform auth is optional. Omit the `auth` block entirely to disable platform authentication, or set `auth.provider: none` explicitly. When auth is enabled, configure it with `auth.provider` and `auth.config`. `auth.provider` uses the same provider-reference shape as integration plugins: a `source` block plus optional `env` and `allowedHosts`.
 
 ### `none`
 
@@ -83,15 +83,15 @@ auth:
       ref: github.com/valon-technologies/gestalt-providers/auth/google
       version: 0.0.1-alpha.1
   config:
-    client_id: ${GOOGLE_CLIENT_ID}
-    client_secret: secret://google-client-secret
-    redirect_url: https://gestalt.example.com/api/v1/auth/login/callback
-    allowed_domains:
+    clientId: ${GOOGLE_CLIENT_ID}
+    clientSecret: secret://google-client-secret
+    redirectUrl: https://gestalt.example.com/api/v1/auth/login/callback
+    allowedDomains:
       - example.com
-    session_ttl: 24h
+    sessionTtl: 24h
 ```
 
-`client_id` and `client_secret` are both required and identify your Google OAuth application. `redirect_url` defaults to a path derived from `server.base_url` when omitted. `allowed_domains` restricts login to specific email domains. `session_ttl` controls session token lifetime and defaults to `24h`.
+`clientId` and `clientSecret` are both required and identify your Google OAuth application. `redirectUrl` defaults to a path derived from `server.baseUrl` when omitted. `allowedDomains` restricts login to specific email domains. `sessionTtl` controls session token lifetime and defaults to `24h`.
 
 Google checks `email_verified` on every login. Unverified accounts are rejected.
 
@@ -104,26 +104,26 @@ auth:
       ref: github.com/valon-technologies/gestalt-providers/auth/oidc
       version: 0.0.1-alpha.1
   config:
-    issuer_url: https://login.example.com
-    client_id: ${OIDC_CLIENT_ID}
-    client_secret: secret://oidc-client-secret
-    redirect_url: https://gestalt.example.com/api/v1/auth/login/callback
-    allowed_domains:
+    issuerUrl: https://login.example.com
+    clientId: ${OIDC_CLIENT_ID}
+    clientSecret: secret://oidc-client-secret
+    redirectUrl: https://gestalt.example.com/api/v1/auth/login/callback
+    allowedDomains:
       - example.com
     scopes:
       - openid
       - email
       - profile
-    session_ttl: 24h
+    sessionTtl: 24h
     pkce: true
-    display_name: Company SSO
+    displayName: Company SSO
 ```
 
-Two fields are required: `issuer_url` (the OIDC discovery base URL) and `client_id`. `client_secret` may be omitted for PKCE-only public clients.
+Two fields are required: `issuerUrl` (the OIDC discovery base URL) and `clientId`. `clientSecret` may be omitted for PKCE-only public clients.
 
-`redirect_url` defaults to a path derived from `server.base_url`. `allowed_domains` restricts login by email domain. `scopes` defaults to `openid`, `email`, and `profile`.
+`redirectUrl` defaults to a path derived from `server.baseUrl`. `allowedDomains` restricts login by email domain. `scopes` defaults to `openid`, `email`, and `profile`.
 
-`session_ttl` controls session token lifetime and defaults to `24h`. Set `pkce` to `true` to enable Proof Key for Code Exchange. `display_name` controls the label shown in the login UI, defaulting to `SSO`.
+`sessionTtl` controls session token lifetime and defaults to `24h`. Set `pkce` to `true` to enable Proof Key for Code Exchange. `displayName` controls the label shown in the login UI, defaulting to `SSO`.
 
 OIDC checks `email_verified` when the claim is present. Unverified accounts are rejected.
 
@@ -136,7 +136,7 @@ Both `google` and `oidc` use the same PluginDef provider reference shape under `
 | `source.ref` | Managed provider source address. |
 | `source.version` | Required with `source.ref`. SemVer without a leading `v`. |
 | `env` | Extra environment variables passed to the provider process. |
-| `allowed_hosts` | Network allowlist for sandboxed provider processes. |
+| `allowedHosts` | Network allowlist for sandboxed provider processes. |
 
 ## `datastore`
 
@@ -160,7 +160,7 @@ datastore:
 | `dynamodb` | `table`, `region`, `endpoint` | `table` defaults to `gestalt`. |
 | `mongodb` | `uri`, `database` | `database` defaults to `gestalt`. |
 | `oracle` | `dsn` | Enterprise SQL option. |
-| `firestore` | `project_id`, `database` | Firestore-backed deployment. |
+| `firestore` | `projectId`, `database` | Firestore-backed deployment. |
 | `sqlserver` | `dsn` | SQL Server-backed deployment. |
 
 Gestalt auto-detects and validates the connected backend release series for the versioned datastores below. Only MySQL currently uses an explicit `version` override because its SQL dialect changes across supported series. For the other datastores, a legacy `version` field is ignored for backward compatibility.
@@ -189,9 +189,9 @@ secrets:
 | `env` | `prefix` | Reads secrets from environment variables. Default when `secrets` is omitted. |
 | `file` | `dir` | Reads one secret per file from a base directory. Works with Kubernetes volume-mounted secrets. |
 | `google_secret_manager` | `project`, `version` | Google Cloud Secret Manager. `version` defaults to `latest`. |
-| `aws_secrets_manager` | `region`, `version_stage`, `endpoint` | AWS Secrets Manager. `region` is required. `version_stage` defaults to `AWSCURRENT`. |
-| `vault` | `address`, `token`, `mount_path`, `namespace` | HashiCorp Vault KV v2. `address` and `token` are required. `mount_path` defaults to `secret`. |
-| `azure_key_vault` | `vault_url`, `version` | Azure Key Vault. `vault_url` is required. `version` defaults to latest. |
+| `aws_secrets_manager` | `region`, `versionStage`, `endpoint` | AWS Secrets Manager. `region` is required. `versionStage` defaults to `AWSCURRENT`. |
+| `vault` | `address`, `token`, `mountPath`, `namespace` | HashiCorp Vault KV v2. `address` and `token` are required. `mountPath` defaults to `secret`. |
+| `azure_key_vault` | `vaultUrl`, `version` | Azure Key Vault. `vaultUrl` is required. `version` defaults to latest. |
 
 ### Bootstrap credentials
 
@@ -222,7 +222,7 @@ telemetry:
   config:
     format: text
     level: info
-    service_name: gestaltd
+    serviceName: gestaltd
 ```
 
 Outputs structured logs to standard output. Traces remain disabled, but metrics are collected locally and exposed through the Prometheus-compatible `/metrics` endpoint. The built-in admin UI at `/admin` reads that same scrape surface. This is the default provider when `telemetry` is omitted.
@@ -231,8 +231,8 @@ Outputs structured logs to standard output. Traces remain disabled, but metrics 
 | --- | --- | --- |
 | `format` | `text` | Log format: `text` or `json`. |
 | `level` | `info` | Minimum log level: `debug`, `info`, `warn`, or `error`. |
-| `service_name` | `gestaltd` | Attached to locally exposed metrics. |
-| `resource_attributes` | | Extra key-value pairs attached to local metrics. |
+| `serviceName` | `gestaltd` | Attached to locally exposed metrics. |
+| `resourceAttributes` | | Extra key-value pairs attached to local metrics. |
 | `metrics.prometheus.enabled` | `true` | Toggle the `/metrics` scrape endpoint. |
 
 ### `otlp`
@@ -243,15 +243,15 @@ telemetry:
   config:
     endpoint: otel-collector:4317
     protocol: grpc
-    service_name: gestaltd
+    serviceName: gestaltd
     insecure: false
     headers:
       Authorization: Bearer ${OTEL_TOKEN}
-    resource_attributes:
+    resourceAttributes:
       deployment.environment: production
       service.version: "1.0.0"
     traces:
-      sampling_ratio: 1.0
+      samplingRatio: 1.0
     metrics:
       interval: 60s
     logs:
@@ -267,9 +267,9 @@ Exports to any OpenTelemetry-compatible collector (Jaeger, Grafana Alloy, Datado
 | `protocol` | `grpc` | Transport protocol: `grpc` or `http`. |
 | `insecure` | `false` | Skip TLS verification when `true`. |
 | `headers` | | Extra headers on every export request. |
-| `service_name` | `gestaltd` | OpenTelemetry service name. |
-| `resource_attributes` | | Arbitrary key-value pairs as OTel resource attributes. |
-| `traces.sampling_ratio` | `1.0` | Fraction of traces sampled, from `0.0` to `1.0`. |
+| `serviceName` | `gestaltd` | OpenTelemetry service name. |
+| `resourceAttributes` | | Arbitrary key-value pairs as OTel resource attributes. |
+| `traces.samplingRatio` | `1.0` | Fraction of traces sampled, from `0.0` to `1.0`. |
 | `metrics.interval` | `60s` | OTLP metric export interval. |
 | `metrics.prometheus.enabled` | `true` | Toggle the local `/metrics` scrape endpoint. |
 | `logs.exporter` | `otlp` | Where logs go: `otlp` or `stdout`. |
@@ -306,7 +306,7 @@ Disables all telemetry. Instrumentation points remain but produce zero overhead.
 | Layer | Span name | Key attributes |
 | --- | --- | --- |
 | HTTP | `gestaltd: {method} {route}` | Standard HTTP semantic conventions |
-| Broker | `broker.invoke` | `gestalt.provider`, `gestalt.operation`, `gestalt.user_id`, `gestalt.connection_mode` |
+| Broker | `broker.invoke` | `gestalt.provider`, `gestalt.operation`, `gestalt.userId`, `gestalt.connectionMode` |
 | gRPC plugin | Per-RPC spans | Standard gRPC semantic conventions |
 
 ## `audit`
@@ -348,11 +348,11 @@ audit:
   config:
     endpoint: audit-collector:4317
     protocol: grpc
-    service_name: gestaltd
+    serviceName: gestaltd
     insecure: false
     headers:
       Authorization: Bearer ${AUDIT_OTLP_TOKEN}
-    resource_attributes:
+    resourceAttributes:
       log.stream: audit
 ```
 
@@ -363,9 +363,9 @@ Exports audit records over OTLP without changing where application logs, metrics
 | `endpoint` | SDK default | OTLP collector address. |
 | `protocol` | `grpc` | Transport protocol: `grpc` or `http`. |
 | `insecure` | `false` | Skip TLS verification when `true`. |
-| `service_name` | `gestaltd` | Attached to exported audit logs. |
+| `serviceName` | `gestaltd` | Attached to exported audit logs. |
 | `headers` | | Extra headers on every export request. |
-| `resource_attributes` | | Extra key-value pairs attached to audit log exports. |
+| `resourceAttributes` | | Extra key-value pairs attached to audit log exports. |
 
 ### `noop`
 
@@ -383,26 +383,26 @@ Each entry in the top-level `plugins` map is a named integration instance backed
 ```yaml
 plugins:
   github:
-    display_name: GitHub
+    displayName: GitHub
     description: Public GitHub operations
-    icon_file: ./icons/github.svg
+    iconFile: ./icons/github.svg
     provider:
       source:
         ref: github.com/valon-technologies/gestalt-providers/github
         version: 1.2.3
     config:
-      api_base_url: https://api.github.com
+      apiBaseUrl: https://api.github.com
     connections:
       default:
         mode: user
         auth:
           type: oauth2
-    allowed_operations:
+    allowedOperations:
       repos.get:
         alias: get_repo
     mcp:
       enabled: true
-      tool_prefix: github_
+      toolPrefix: github_
 ```
 
 The config key is `plugins`, but the HTTP API and client CLI still refer to these named entries as integrations.
@@ -411,15 +411,15 @@ The config key is `plugins`, but the HTTP API and client CLI still refer to thes
 
 | Field | Description |
 | --- | --- |
-| `display_name` | Human-readable name shown in the UI and API. |
+| `displayName` | Human-readable name shown in the UI and API. |
 | `description` | Short description of the integration. |
-| `icon_file` | SVG icon path, resolved relative to the config directory. |
+| `iconFile` | SVG icon path, resolved relative to the config directory. |
 | `provider` | **Required.** The backing provider package. See [provider shape](#pluginsprovider) below. |
 | `config` | Provider-specific configuration passed into the provider package. |
 | `connections` | Named connection declarations. See [connections](#connections) below. |
-| `allowed_operations` | Allowlist with optional `alias` and `description` overrides per operation. |
+| `allowedOperations` | Allowlist with optional `alias` and `description` overrides per operation. |
 | `mcp.enabled` | Expose this integration over MCP. |
-| `mcp.tool_prefix` | Prefix for MCP tool names. Only valid when `mcp.enabled` is `true`. |
+| `mcp.toolPrefix` | Prefix for MCP tool names. Only valid when `mcp.enabled` is `true`. |
 
 ### `plugins.*.provider`
 
@@ -492,7 +492,7 @@ Gestalt synthesizes Go and Rust executable wrappers automatically when needed an
 | `source.version` | Required with `source.ref`. SemVer without a leading `v`. Invalid with `source.path`. |
 | `source.path` | Path to a local provider manifest. Mutually exclusive with `source.ref`. |
 | `env` | Extra environment variables passed to the provider process. |
-| `allowed_hosts` | Network allowlist for sandboxed provider processes. |
+| `allowedHosts` | Network allowlist for sandboxed provider processes. |
 
 ### `connections`
 
@@ -504,10 +504,10 @@ connections:
     mode: user
     auth:
       type: oauth2
-      authorization_url: https://accounts.example.com/oauth/authorize
-      token_url: https://accounts.example.com/oauth/token
-      client_id: ${CLIENT_ID}
-      client_secret: ${CLIENT_SECRET}
+      authorizationUrl: https://accounts.example.com/oauth/authorize
+      tokenUrl: https://accounts.example.com/oauth/token
+      clientId: ${CLIENT_ID}
+      clientSecret: ${CLIENT_SECRET}
     params:
       tenant:
         required: true
@@ -527,23 +527,23 @@ Every connection `auth` block uses the same shape. `type` selects the auth strat
 | Field | Default | Description |
 | --- | --- | --- |
 | `type` | | Auth strategy: `oauth2`, `manual`, `bearer`, `none`, or `mcp_oauth`. |
-| `authorization_url` | | OAuth2 authorization endpoint. |
-| `token_url` | | OAuth2 token endpoint. |
-| `client_id` | | OAuth2 client identifier. |
-| `client_secret` | | OAuth2 client secret. |
-| `redirect_url` | derived from `server.base_url` | OAuth2 callback URL. |
-| `client_auth` | `body` | How credentials are sent to the token endpoint: `body` or `header`. |
-| `token_exchange` | `form` | Token request encoding: `form` or `json`. |
+| `authorizationUrl` | | OAuth2 authorization endpoint. |
+| `tokenUrl` | | OAuth2 token endpoint. |
+| `clientId` | | OAuth2 client identifier. |
+| `clientSecret` | | OAuth2 client secret. |
+| `redirectUrl` | derived from `server.baseUrl` | OAuth2 callback URL. |
+| `clientAuth` | `body` | How credentials are sent to the token endpoint: `body` or `header`. |
+| `tokenExchange` | `form` | Token request encoding: `form` or `json`. |
 | `scopes` | | OAuth2 scopes to request. |
-| `scope_param` | `scope` | Query parameter name for scopes. Set to `user_scope` for Slack and other providers that use a non-standard parameter. |
-| `scope_separator` | space | Separator between scope values. |
+| `scopeParam` | `scope` | Query parameter name for scopes. Set to `user_scope` for Slack and other providers that use a non-standard parameter. |
+| `scopeSeparator` | space | Separator between scope values. |
 | `pkce` | `false` | Enable Proof Key for Code Exchange. |
-| `authorization_params` | | Extra parameters for the authorization request. |
-| `token_params` | | Extra parameters for the token request. |
-| `refresh_params` | | Extra parameters for the refresh request. |
-| `accept_header` | | `Accept` header for the token endpoint. |
-| `access_token_path` | | JSON path to the access token in the token response. |
-| `token_metadata` | | Fields to extract from the token response and store as connection metadata. |
+| `authorizationParams` | | Extra parameters for the authorization request. |
+| `tokenParams` | | Extra parameters for the token request. |
+| `refreshParams` | | Extra parameters for the refresh request. |
+| `acceptHeader` | | `Accept` header for the token endpoint. |
+| `accessTokenPath` | | JSON path to the access token in the token response. |
+| `tokenMetadata` | | Fields to extract from the token response and store as connection metadata. |
 
 `mcp_oauth` is an advanced mode for MCP-driven OAuth discovery. It delegates authorization URL and token URL resolution to the upstream MCP server.
 
@@ -561,10 +561,9 @@ connections:
       credentials:
         - name: token
           label: API Access Token
-          help_url: https://app.example.com/settings/tokens
 ```
 
-Multiple credentials require `auth_mapping` to map each field to an HTTP header:
+Multiple credentials require `authMapping` to map each field to an HTTP header:
 
 ```yaml
 connections:
@@ -574,11 +573,9 @@ connections:
       credentials:
         - name: api_key
           label: API Key
-          help_url: https://us5.datadoghq.com/organization-settings/api-keys
         - name: app_key
           label: Application Key
-          help_url: https://us5.datadoghq.com/organization-settings/application-keys
-      auth_mapping:
+      authMapping:
         headers:
           DD-API-KEY:
             valueFrom:
@@ -595,10 +592,9 @@ connections:
 | `credentials[].name` | Unique, lowercase-with-underscores identifier. Required when `auth.type` is `manual`. |
 | `credentials[].label` | UI display label. Falls back to `name` when omitted. |
 | `credentials[].description` | Hint text below the label. Supports inline links via `[text](url)`. |
-| `credentials[].help_url` | Link placed next to the label pointing to where the credential can be found. |
-| `auth_mapping.headers.<HEADER>.value` | Supplies a static deployer-managed value for a header. |
-| `auth_mapping.headers.<HEADER>.valueFrom.credentialFieldRef.name` | Reads a header value from the named manual credential field. |
-| `auth_mapping.basic.username` / `auth_mapping.basic.password` | Build the Basic auth username/password from either a static `value` or `valueFrom.credentialFieldRef.name`. |
+| `authMapping.headers.<HEADER>.value` | Supplies a static deployer-managed value for a header. |
+| `authMapping.headers.<HEADER>.valueFrom.credentialFieldRef.name` | Reads a header value from the named manual credential field. |
+| `authMapping.basic.username` / `authMapping.basic.password` | Build the Basic auth username/password from either a static `value` or `valueFrom.credentialFieldRef.name`. |
 
 For Basic auth providers that should collect only an API key while keeping the organization ID static, declare just the user-facing field and map the rest explicitly:
 
@@ -610,8 +606,7 @@ connections:
       credentials:
         - name: api_key
           label: API Key
-          help_url: https://app.moderntreasury.com/settings/api_keys
-      auth_mapping:
+      authMapping:
         basic:
           username:
             value: ${MODERN_TREASURY_ORG_ID}
@@ -631,8 +626,8 @@ connections:
     mode: user
     auth:
       type: oauth2
-      authorization_url: https://accounts.example.com/oauth/authorize
-      token_url: https://accounts.example.com/oauth/token
+      authorizationUrl: https://accounts.example.com/oauth/authorize
+      tokenUrl: https://accounts.example.com/oauth/token
     params:
       workspace_id:
         required: true
@@ -640,8 +635,8 @@ connections:
         from: discovery
     discovery:
       url: https://api.example.com/workspaces
-      id_path: id
-      name_path: name
+      idPath: id
+      namePath: name
       metadata:
         workspace_id: id
 ```
@@ -649,8 +644,8 @@ connections:
 | Field | Description |
 | --- | --- |
 | `discovery.url` | URL to fetch the list of resources after connect. |
-| `discovery.id_path` | JSON path to the resource identifier. |
-| `discovery.name_path` | JSON path to the resource display name. |
+| `discovery.idPath` | JSON path to the resource identifier. |
+| `discovery.namePath` | JSON path to the resource display name. |
 | `discovery.metadata` | Maps connection metadata keys to JSON paths in the discovery response. |
 
 ## `egress`
@@ -659,19 +654,19 @@ connections:
 
 ```yaml
 egress:
-  default_action: deny
+  defaultAction: deny
   policies:
     - action: allow
       provider: github
       method: GET
       host: api.github.com
   credentials:
-    - secret_ref: github-service-token
-      auth_style: bearer
+    - secretRef: github-service-token
+      authStyle: bearer
       host: api.github.com
 ```
 
-`default_action` sets the global fallback policy to `allow` or `deny`.
+`defaultAction` sets the global fallback policy to `allow` or `deny`.
 
 ### Policies
 
@@ -680,28 +675,28 @@ egress:
 | Field | Description |
 | --- | --- |
 | `action` | **Required.** `allow` or `deny`. |
-| `subject_kind` | Match by subject kind. |
-| `subject_id` | Match by subject identifier. |
+| `subjectKind` | Match by subject kind. |
+| `subjectId` | Match by subject identifier. |
 | `provider` | Match by integration name. |
 | `operation` | Match by operation name. |
 | `method` | Match by HTTP method. |
 | `host` | Match by destination host. |
-| `path_prefix` | Match by URL path prefix. |
+| `pathPrefix` | Match by URL path prefix. |
 
 ### Credentials
 
-`credentials` attaches secret-backed outbound credentials to requests matching at least one criterion. `secret_ref` is a bare secret name (not a `secret://` URI) resolved through the configured secret manager.
+`credentials` attaches secret-backed outbound credentials to requests matching at least one criterion. `secretRef` is a bare secret name (not a `secret://` URI) resolved through the configured secret manager.
 
 | Field | Description |
 | --- | --- |
-| `secret_ref` | **Required.** Bare secret name resolved through the secret manager. |
-| `auth_style` | How to inject the credential: `bearer`, `raw`, `basic`, or `none`. |
-| `subject_kind` | Match by subject kind. |
-| `subject_id` | Match by subject identifier. |
+| `secretRef` | **Required.** Bare secret name resolved through the secret manager. |
+| `authStyle` | How to inject the credential: `bearer`, `raw`, `basic`, or `none`. |
+| `subjectKind` | Match by subject kind. |
+| `subjectId` | Match by subject identifier. |
 | `operation` | Match by operation name. |
 | `method` | Match by HTTP method. |
 | `host` | Match by destination host. |
-| `path_prefix` | Match by URL path prefix. |
+| `pathPrefix` | Match by URL path prefix. |
 
 ## `ui`
 
@@ -712,7 +707,7 @@ ui:
       ref: github.com/your-org/your-repo/web/console
       version: 1.0.0
   config:
-    brand_name: Acme
+    brandName: Acme
 ```
 
 `ui.provider` controls the public client UI at `/`, while the built-in admin UI remains available at `/admin`. Omit `ui` to use the pinned first-party default UI bundle. Set `ui.provider: none` to disable the public UI entirely. Or set `ui.provider.source` to a packaged `webui` bundle. See [Releasing](/providers/releasing) for the full workflow.
@@ -732,14 +727,14 @@ Each plugin uses a nested `provider` block. Every plugin must use exactly one lo
 
 Auth and datastore providers use the same PluginDef shape. When `auth.provider` or `datastore.provider` is set, `source.ref` or `source.path` must be present. `auth.config` and `datastore.config` are only allowed when their corresponding provider is set.
 
-Only `connections.default` may define `params` or `discovery`. `mcp.tool_prefix` is valid only when `mcp.enabled` is `true`. All connections in an integration must share the same mode.
+Only `connections.default` may define `params` or `discovery`. `mcp.toolPrefix` is valid only when `mcp.enabled` is `true`. All connections in an integration must share the same mode.
 
 `ui.provider` must be either `none` or a provider mapping with exactly one loading mode: local `ui.provider.source.path` or managed `ui.provider.source.ref`. `ui.provider.source.version` is required with `ui.provider.source.ref` and invalid with `ui.provider.source.path`. `ui.config` is only allowed when `ui.provider` is not `none`.
 
-`egress.default_action` must be `allow` or `deny`. Each egress policy rule requires an `action`. Each egress credential grant requires `secret_ref` (as a bare name, not a `secret://` URI) and at least one match criterion.
+`egress.defaultAction` must be `allow` or `deny`. Each egress policy rule requires an `action`. Each egress credential grant requires `secretRef` (as a bare name, not a `secret://` URI) and at least one match criterion.
 
 Server listener ports must be greater than zero. When `server.management` is configured, it must differ from `server.public`.
 
 ### Runtime
 
-`datastore.provider` and `server.encryption_key` are required at `serve` time. `auth` is optional.
+`datastore.provider` and `server.encryptionKey` are required at `serve` time. `auth` is optional.

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -28,9 +28,9 @@ These fields appear at the top level of every manifest regardless of kind.
 | --- | --- | --- | --- |
 | `source` | string | yes | Canonical provider source identifier. Use `github.com/<org>/<repo>/<path>`. The final path segment is the provider package name; preceding segments are used for release tags and source resolution. |
 | `version` | string | yes | Semver version. Pre-release suffixes like `-alpha.1` are allowed. |
-| `display_name` | string | no | Human-readable label shown in the UI. |
+| `displayName` | string | no | Human-readable label shown in the UI. |
 | `description` | string | no | Human-readable description. |
-| `icon_file` | string | no | Relative path to an SVG icon bundled with the package. |
+| `iconFile` | string | no | Relative path to an SVG icon bundled with the package. |
 | `artifacts` | Artifact[] | no | Packaged executable artifacts keyed by platform. Omit for declarative-only integration plugin packages or source manifests used during local development. |
 | `entrypoints` | Entrypoints | no | Executable entrypoint metadata for the manifest's kind. |
 
@@ -49,13 +49,13 @@ Note that the JSON/YAML tag for the integration-plugin entrypoint is `plugin`, n
 
 | Field | Type | Required | Purpose |
 | --- | --- | --- | --- |
-| `artifact_path` | string | yes | Path to the binary inside the package. |
+| `artifactPath` | string | yes | Path to the binary inside the package. |
 | `args` | string[] | no | Additional arguments passed to the binary at startup. |
 
 ```yaml
 entrypoints:
   plugin:
-    artifact_path: artifacts/linux/amd64/plugin
+    artifactPath: artifacts/linux/amd64/plugin
     args: ["--verbose"]
 ```
 
@@ -67,14 +67,14 @@ The `plugin` block describes an integration plugin. It supports declarative REST
 
 | Field | Type | Purpose |
 | --- | --- | --- |
-| `config_schema_path` | string | Path to a JSON/YAML schema that validates `plugins.<name>.config` in the server config. |
+| `configSchemaPath` | string | Path to a JSON/YAML schema that validates `plugins.<name>.config` in the server config. |
 | `auth` | ProviderAuth | Default connection auth when no `connections` map is defined. |
-| `connection_mode` | string | Default connection mode when no `connections` map is defined. One of `none`, `user`, `identity`, `either`. |
+| `connectionMode` | string | Default connection mode when no `connections` map is defined. One of `none`, `user`, `identity`, `either`. |
 | `mcp` | bool | When true, the plugin exposes its operations as MCP tools. |
-| `base_url` | string | Base URL for declarative REST operations. |
+| `baseUrl` | string | Base URL for declarative REST operations. |
 | `headers` | map[string]string | Static headers injected into every outbound request. |
 | `operations` | ProviderOperation[] | Declarative REST operations. Presence of this field makes the plugin declarative. |
-| `default_connection` | string | Name of the connection to use when none is specified. |
+| `defaultConnection` | string | Name of the connection to use when none is specified. |
 
 ### Connections
 
@@ -94,13 +94,13 @@ Surfaces load operation catalogs from external specifications. The following top
 | Field | Type | Purpose |
 | --- | --- | --- |
 | `openapi` | string | Path to a bundled OpenAPI document. |
-| `openapi_connection` | string | Connection name used for OpenAPI calls. |
-| `graphql_url` | string | URL of the upstream GraphQL endpoint. |
-| `graphql_connection` | string | Connection name used for GraphQL calls. |
-| `mcp_url` | string | URL of the upstream MCP server. |
-| `mcp_connection` | string | Connection name used for MCP calls. |
+| `openapiConnection` | string | Connection name used for OpenAPI calls. |
+| `graphqlUrl` | string | URL of the upstream GraphQL endpoint. |
+| `graphqlConnection` | string | Connection name used for GraphQL calls. |
+| `mcpUrl` | string | URL of the upstream MCP server. |
+| `mcpConnection` | string | Connection name used for MCP calls. |
 
-The `rest`/`openapi`/`graphql` surface types are mutually exclusive (use `openapi` or `graphql_url`, not both), but `mcp_url` may be combined with any of them.
+The `rest`/`openapi`/`graphql` surface types are mutually exclusive (use `openapi` or `graphqlUrl`, not both), but `mcpUrl` may be combined with any of them.
 
 ### Auth Types
 
@@ -108,13 +108,13 @@ The `auth.type` field on a connection accepts these values:
 
 | Type | Purpose |
 | --- | --- |
-| `oauth2` | Standard OAuth 2.0. Requires `authorization_url` and `token_url`. |
-| `mcp_oauth` | MCP-native OAuth. The plugin must also declare `mcp_url` (either directly or via a surface). A manifest that uses `mcp_oauth` without an MCP surface fails validation. |
+| `oauth2` | Standard OAuth 2.0. Requires `authorizationUrl` and `tokenUrl`. |
+| `mcp_oauth` | MCP-native OAuth. The plugin must also declare `mcpUrl` (either directly or via a surface). A manifest that uses `mcp_oauth` without an MCP surface fails validation. |
 | `bearer` | Static bearer token. Define `credentials` to prompt the user for the token value. |
 | `manual` | Custom credential fields. Define `credentials` to describe each field. |
 | `none` | No authentication. |
 
-Manual auth in provider manifests also supports `auth_mapping`, using the same `value` / `valueFrom.credentialFieldRef.name` shape as deploy config.
+Manual auth in provider manifests also supports `authMapping`, using the same `value` / `valueFrom.credentialFieldRef.name` shape as deploy config.
 
 ```yaml
 plugin:
@@ -125,7 +125,7 @@ plugin:
         label: Organization ID
       - name: api_key
         label: API Key
-    auth_mapping:
+    authMapping:
       basic:
         username:
           valueFrom:
@@ -139,35 +139,35 @@ plugin:
 
 ### Pagination
 
-Plugin-level pagination configuration applies to all operations by default. Individual operations can override this through `allowed_operations`.
+Plugin-level pagination configuration applies to all operations by default. Individual operations can override this through `allowedOperations`.
 
 | Field | Type | Purpose |
 | --- | --- | --- |
 | `style` | string | Required. One of `cursor`, `offset`, `page`. |
-| `cursor_param` | string | Query parameter name for the cursor value. |
+| `cursorParam` | string | Query parameter name for the cursor value. |
 | `cursor.source` | string | Value source for the next cursor. One of `body`, `header`. |
 | `cursor.path` | string | Lookup path for the cursor value in the selected source. |
-| `limit_param` | string | Query parameter name for page size. |
-| `default_limit` | int | Default page size when the caller does not specify one. |
-| `results_path` | string | JSON path to the array of results in the response. |
-| `max_pages` | int | Maximum number of pages to fetch in a single paginated request. |
+| `limitParam` | string | Query parameter name for page size. |
+| `defaultLimit` | int | Default page size when the caller does not specify one. |
+| `resultsPath` | string | JSON path to the array of results in the response. |
+| `maxPages` | int | Maximum number of pages to fetch in a single paginated request. |
 
 ```yaml
 plugin:
   pagination:
     style: cursor
-    cursor_param: starting_after
+    cursorParam: starting_after
     cursor:
       source: body
       path: next_cursor
-    limit_param: limit
-    default_limit: 100
-    max_pages: 10
+    limitParam: limit
+    defaultLimit: 100
+    maxPages: 10
 ```
 
 ### Allowed Operations
 
-The `allowed_operations` map selectively exposes and customizes operations from a spec-loaded surface. Keys are the original operation IDs from the OpenAPI/GraphQL/MCP spec.
+The `allowedOperations` map selectively exposes and customizes operations from a spec-loaded surface. Keys are the original operation IDs from the OpenAPI/GraphQL/MCP spec.
 
 | Field | Type | Purpose |
 | --- | --- | --- |
@@ -178,7 +178,7 @@ The `allowed_operations` map selectively exposes and customizes operations from 
 
 ```yaml
 plugin:
-  allowed_operations:
+  allowedOperations:
     tickets.list:
       alias: list_tickets
       paginate: true
@@ -188,13 +188,13 @@ plugin:
 
 ### Response Mapping
 
-The `response_mapping` block extracts a data array and pagination metadata from API responses that wrap results in an envelope.
+The `responseMapping` block extracts a data array and pagination metadata from API responses that wrap results in an envelope.
 
 | Field | Type | Purpose |
 | --- | --- | --- |
-| `data_path` | string | Required. JSON path to the results array. |
-| `pagination.has_more.source` | string | Value source for the has-more flag. One of `body`, `header`. |
-| `pagination.has_more.path` | string | Lookup path for the has-more flag in the selected source. |
+| `dataPath` | string | Required. JSON path to the results array. |
+| `pagination.hasMore.source` | string | Value source for the has-more flag. One of `body`, `header`. |
+| `pagination.hasMore.path` | string | Lookup path for the has-more flag in the selected source. |
 | `pagination.cursor.source` | string | Value source for the next-page cursor. One of `body`, `header`. |
 | `pagination.cursor.path` | string | Lookup path for the next-page cursor in the selected source. |
 
@@ -215,8 +215,8 @@ The `discovery` block on a connection performs an authenticated lookup immediate
 | Field | Type | Purpose |
 | --- | --- | --- |
 | `url` | string | Required. Endpoint to call after connect. |
-| `id_path` | string | JSON path to the item identifier. |
-| `name_path` | string | JSON path to the item display name. |
+| `idPath` | string | JSON path to the item identifier. |
+| `namePath` | string | JSON path to the item display name. |
 | `metadata` | map[string]string | Maps connection parameter names to JSON paths in each discovered item. |
 
 If discovery returns exactly one item, Gestalt merges its metadata into the stored connection automatically. Multiple items prompt the user to choose. Zero items fails the connection.
@@ -237,19 +237,19 @@ The `auth` block describes a platform auth provider package.
 
 | Field | Type | Purpose |
 | --- | --- | --- |
-| `config_schema_path` | string | Path to a JSON/YAML schema that validates the `auth.config` block in the server config. |
+| `configSchemaPath` | string | Path to a JSON/YAML schema that validates the `auth.config` block in the server config. |
 
 Auth providers require an executable entrypoint. Declare it under `entrypoints.auth`.
 
 ```yaml
 source: github.com/valon-technologies/gestalt-providers/auth-google
 version: 1.0.0
-display_name: Google Auth
+displayName: Google Auth
 auth:
-  config_schema_path: schemas/config.schema.json
+  configSchemaPath: schemas/config.schema.json
 entrypoints:
   auth:
-    artifact_path: artifacts/linux/amd64/auth
+    artifactPath: artifacts/linux/amd64/auth
 artifacts:
   - os: linux
     arch: amd64
@@ -262,19 +262,19 @@ The `datastore` block describes a persistence backend package.
 
 | Field | Type | Purpose |
 | --- | --- | --- |
-| `config_schema_path` | string | Path to a JSON/YAML schema that validates the `datastore.config` block in the server config. |
+| `configSchemaPath` | string | Path to a JSON/YAML schema that validates the `datastore.config` block in the server config. |
 
 Datastore providers require an executable entrypoint. Declare it under `entrypoints.datastore`.
 
 ```yaml
 source: github.com/valon-technologies/gestalt-providers/datastore-postgres
 version: 1.0.0
-display_name: PostgreSQL
+displayName: PostgreSQL
 datastore:
-  config_schema_path: schemas/config.schema.json
+  configSchemaPath: schemas/config.schema.json
 entrypoints:
   datastore:
-    artifact_path: artifacts/linux/amd64/datastore
+    artifactPath: artifacts/linux/amd64/datastore
 artifacts:
   - os: linux
     arch: amd64
@@ -287,14 +287,14 @@ The `webui` block describes a static UI package.
 
 | Field | Type | Required | Purpose |
 | --- | --- | --- | --- |
-| `asset_root` | string | yes | Directory containing the built static assets. |
+| `assetRoot` | string | yes | Directory containing the built static assets. |
 
 ```yaml
 source: github.com/acme/plugins/gestalt-ui
 version: 1.0.0
-display_name: Custom UI
+displayName: Custom UI
 webui:
-  asset_root: ui/out
+  assetRoot: ui/out
 ```
 
 ## Artifacts
@@ -320,14 +320,14 @@ This manifest shows an integration plugin with an executable entrypoint, multipl
     ```yaml
     source: github.com/acme/plugins/support
     version: 1.2.3
-    display_name: Support
+    displayName: Support
     description: Tickets, knowledge base, and MCP workspace tools
-    icon_file: assets/icon.svg
+    iconFile: assets/icon.svg
     plugin:
-      config_schema_path: schemas/config.schema.yaml
+      configSchemaPath: schemas/config.schema.yaml
       headers:
         X-App-Version: "2026-04-01"
-      managed_parameters:
+      managedParameters:
         - in: path
           name: workspace_id
           value: primary
@@ -336,10 +336,10 @@ This manifest shows an integration plugin with an executable entrypoint, multipl
           mode: user
           auth:
             type: oauth2
-            authorization_url: https://accounts.support.example.com/oauth/authorize
-            token_url: https://accounts.support.example.com/oauth/token
-            client_id: ${SUPPORT_CLIENT_ID}
-            client_secret: ${SUPPORT_CLIENT_SECRET}
+            authorizationUrl: https://accounts.support.example.com/oauth/authorize
+            tokenUrl: https://accounts.support.example.com/oauth/token
+            clientId: ${SUPPORT_CLIENT_ID}
+            clientSecret: ${SUPPORT_CLIENT_SECRET}
             scopes:
               - tickets.read
               - tickets.write
@@ -349,8 +349,8 @@ This manifest shows an integration plugin with an executable entrypoint, multipl
               from: discovery
           discovery:
             url: https://api.support.example.com/workspaces
-            id_path: id
-            name_path: name
+            idPath: id
+            namePath: name
             metadata:
               workspace_id: id
         mcp:
@@ -358,19 +358,19 @@ This manifest shows an integration plugin with an executable entrypoint, multipl
           auth:
             type: mcp_oauth
       openapi: openapi.yaml
-      openapi_connection: default
-      mcp_url: https://mcp.support.example.com/mcp
-      mcp_connection: mcp
+      openapiConnection: default
+      mcpUrl: https://mcp.support.example.com/mcp
+      mcpConnection: mcp
       pagination:
         style: cursor
-        cursor_param: starting_after
+        cursorParam: starting_after
         cursor:
           source: body
           path: next_cursor
-        limit_param: limit
-        default_limit: 50
-        max_pages: 5
-      allowed_operations:
+        limitParam: limit
+        defaultLimit: 50
+        maxPages: 5
+      allowedOperations:
         tickets.list:
           alias: list_tickets
           paginate: true
@@ -378,7 +378,7 @@ This manifest shows an integration plugin with an executable entrypoint, multipl
           alias: get_ticket
     entrypoints:
       plugin:
-        artifact_path: artifacts/linux/amd64/plugin
+        artifactPath: artifacts/linux/amd64/plugin
     artifacts:
       - os: linux
         arch: amd64
@@ -392,15 +392,15 @@ This manifest shows an integration plugin with an executable entrypoint, multipl
     {
       "source": "github.com/acme/plugins/support",
       "version": "1.2.3",
-      "display_name": "Support",
+      "displayName": "Support",
       "description": "Tickets, knowledge base, and MCP workspace tools",
-      "icon_file": "assets/icon.svg",
+      "iconFile": "assets/icon.svg",
       "plugin": {
-        "config_schema_path": "schemas/config.schema.yaml",
+        "configSchemaPath": "schemas/config.schema.yaml",
         "headers": {
           "X-App-Version": "2026-04-01"
         },
-        "managed_parameters": [
+        "managedParameters": [
           { "in": "path", "name": "workspace_id", "value": "primary" }
         ],
         "connections": {
@@ -408,10 +408,10 @@ This manifest shows an integration plugin with an executable entrypoint, multipl
             "mode": "user",
             "auth": {
               "type": "oauth2",
-              "authorization_url": "https://accounts.support.example.com/oauth/authorize",
-              "token_url": "https://accounts.support.example.com/oauth/token",
-              "client_id": "${SUPPORT_CLIENT_ID}",
-              "client_secret": "${SUPPORT_CLIENT_SECRET}",
+              "authorizationUrl": "https://accounts.support.example.com/oauth/authorize",
+              "tokenUrl": "https://accounts.support.example.com/oauth/token",
+              "clientId": "${SUPPORT_CLIENT_ID}",
+              "clientSecret": "${SUPPORT_CLIENT_SECRET}",
               "scopes": ["tickets.read", "tickets.write"]
             },
             "params": {
@@ -419,8 +419,8 @@ This manifest shows an integration plugin with an executable entrypoint, multipl
             },
             "discovery": {
               "url": "https://api.support.example.com/workspaces",
-              "id_path": "id",
-              "name_path": "name",
+              "idPath": "id",
+              "namePath": "name",
               "metadata": { "workspace_id": "id" }
             }
           },
@@ -430,28 +430,28 @@ This manifest shows an integration plugin with an executable entrypoint, multipl
           }
         },
         "openapi": "openapi.yaml",
-        "openapi_connection": "default",
-        "mcp_url": "https://mcp.support.example.com/mcp",
-        "mcp_connection": "mcp",
+        "openapiConnection": "default",
+        "mcpUrl": "https://mcp.support.example.com/mcp",
+        "mcpConnection": "mcp",
         "pagination": {
           "style": "cursor",
-          "cursor_param": "starting_after",
+          "cursorParam": "starting_after",
           "cursor": {
             "source": "body",
             "path": "next_cursor"
           },
-          "limit_param": "limit",
-          "default_limit": 50,
-          "max_pages": 5
+          "limitParam": "limit",
+          "defaultLimit": 50,
+          "maxPages": 5
         },
-        "allowed_operations": {
+        "allowedOperations": {
           "tickets.list": { "alias": "list_tickets", "paginate": true },
           "tickets.get": { "alias": "get_ticket" }
         }
       },
       "entrypoints": {
         "plugin": {
-          "artifact_path": "artifacts/linux/amd64/plugin"
+          "artifactPath": "artifacts/linux/amd64/plugin"
         }
       },
       "artifacts": [
@@ -475,16 +475,16 @@ This plugin requires no binary. It defines REST operations entirely in the manif
 ```yaml
 source: github.com/acme/plugins/support-api
 version: 0.0.1-alpha.1
-display_name: Support API
+displayName: Support API
 description: Small ticket API
-icon_file: assets/icon.svg
+iconFile: assets/icon.svg
 plugin:
   auth:
     type: bearer
     credentials:
       - name: token
         label: API Token
-  base_url: https://api.support.example.com
+  baseUrl: https://api.support.example.com
   operations:
     - name: list_tickets
       description: Return open tickets
@@ -500,9 +500,9 @@ plugin:
 
 Manifest paths must stay inside the package. `source` and `version` are required. A manifest defines exactly one provider kind: `plugin`, `auth`, `datastore`, `secrets`, or `webui`.
 
-`config_schema_path` validates per-plugin config and may be written in JSON or YAML. Any connection may define `params` and `discovery`. The OpenAPI/GraphQL surface types are mutually exclusive, but MCP may be added alongside either.
+`configSchemaPath` validates per-plugin config and may be written in JSON or YAML. Any connection may define `params` and `discovery`. The OpenAPI/GraphQL surface types are mutually exclusive, but MCP may be added alongside either.
 
-A connection using `mcp_oauth` auth requires the plugin to declare an MCP surface (via `mcp_url` or an equivalent). Manifests that set `auth.type: mcp_oauth` without an MCP surface fail validation.
+A connection using `mcp_oauth` auth requires the plugin to declare an MCP surface (via `mcpUrl` or an equivalent). Manifests that set `auth.type: mcp_oauth` without an MCP surface fail validation.
 
 When an executable plugin defines helper operations in Go, Rust, Python, or
 TypeScript, Gestalt materializes the executable catalog automatically during
@@ -583,7 +583,7 @@ release:
       - run
       - build
 webui:
-  asset_root: ui/out
+  assetRoot: ui/out
 ```
 
 ## Release

--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -21,6 +21,7 @@ pub const AUTH_LOGIN_PATH: &str = "/api/v1/auth/login";
 pub const AUTH_LOGIN_CALLBACK_PATH: &str = "/api/v1/auth/login/callback";
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AuthInfo {
     pub login_supported: bool,
 }

--- a/gestalt/cli/src/commands/auth.rs
+++ b/gestalt/cli/src/commands/auth.rs
@@ -75,7 +75,7 @@ where
         .context("failed to build HTTP client")?;
     let resp = client
         .post(&login_url)
-        .json(&serde_json::json!({"state": state, "callback_port": port}))
+        .json(&serde_json::json!({"state": state, "callbackPort": port}))
         .send()
         .with_context(|| format!("failed to reach {}", login_url))?;
 
@@ -288,13 +288,13 @@ pub fn status(url_override: Option<&str>, format: Format) -> Result<()> {
             };
             output::print_json(&serde_json::json!({
                 "authenticated": configured,
-                "login_supported": login_supported,
+                "loginSupported": login_supported,
                 "source": source,
-                "env_var_set": has_env_key,
-                "stored_credentials": has_stored_credentials,
-                "server_url": server_url,
-                "url_source": url_source,
-                "server_reachable": reachable,
+                "envVarSet": has_env_key,
+                "storedCredentials": has_stored_credentials,
+                "serverUrl": server_url,
+                "urlSource": url_source,
+                "serverReachable": reachable,
             }));
         }
         Format::Table => {

--- a/gestalt/cli/src/commands/init.rs
+++ b/gestalt/cli/src/commands/init.rs
@@ -13,7 +13,6 @@ pub fn run(url_override: Option<&str>) -> Result<()> {
     let url = api::normalize_url(&prompt_input(&InputPrompt {
         label: "API server URL".to_string(),
         description: None,
-        help_url: None,
         default: Some(current_url),
         required: true,
         secret: false,

--- a/gestalt/cli/src/commands/integrations.rs
+++ b/gestalt/cli/src/commands/integrations.rs
@@ -11,6 +11,7 @@ const PLUGIN_CONNECTION_NAME: &str = "_plugin";
 const PLUGIN_CONNECTION_ALIAS: &str = "plugin";
 
 #[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 struct IntegrationInfo {
     name: String,
     #[serde(default)]
@@ -28,6 +29,7 @@ struct IntegrationInfo {
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 struct ConnectionDefInfo {
     name: String,
     #[serde(default)]
@@ -47,6 +49,7 @@ struct ConnectionParamDef {
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 struct ConnectManualResponse {
     status: String,
     #[serde(default)]
@@ -66,8 +69,6 @@ struct CredentialFieldInfo {
     label: Option<String>,
     #[serde(default)]
     description: Option<String>,
-    #[serde(default)]
-    help_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
@@ -78,6 +79,7 @@ struct DiscoveryCandidateInfo {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct StartOAuthRequest<'a> {
     integration: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -89,6 +91,7 @@ struct StartOAuthRequest<'a> {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct ConnectManualRequest<'a> {
     integration: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -488,7 +491,6 @@ fn prompt_connection_params(
                 .unwrap_or(name)
                 .to_string(),
             description: None,
-            help_url: None,
             default: non_empty(def.default.as_deref()).map(str::to_string),
             required: def.required,
             secret: false,
@@ -511,7 +513,6 @@ fn prompt_manual_credentials(fields: &[CredentialFieldInfo]) -> Result<ManualCre
             name: "credential".to_string(),
             label: Some("Credential".to_string()),
             description: None,
-            help_url: None,
         }]
     } else {
         fields.to_vec()
@@ -534,7 +535,6 @@ fn prompt_for_credential(field: &CredentialFieldInfo) -> Result<String> {
     prompt_input(&InputPrompt {
         label: field.display_label(),
         description: non_empty(field.description.as_deref()).map(str::to_string),
-        help_url: non_empty(field.help_url.as_deref()).map(str::to_string),
         default: None,
         required: true,
         secret: true,

--- a/gestalt/cli/src/interactive.rs
+++ b/gestalt/cli/src/interactive.rs
@@ -12,7 +12,6 @@ pub struct PromptOption {
 pub struct InputPrompt {
     pub label: String,
     pub description: Option<String>,
-    pub help_url: Option<String>,
     pub default: Option<String>,
     pub required: bool,
     pub secret: bool,
@@ -64,9 +63,6 @@ pub fn prompt_input(prompt: &InputPrompt) -> Result<String> {
     writeln!(stderr, "{}", prompt.label)?;
     if let Some(description) = prompt.description.as_deref() {
         writeln!(stderr, "  {description}")?;
-    }
-    if let Some(help_url) = prompt.help_url.as_deref() {
-        writeln!(stderr, "  Help: {help_url}")?;
     }
 
     loop {

--- a/gestalt/cli/tests/integration.rs
+++ b/gestalt/cli/tests/integration.rs
@@ -158,13 +158,13 @@ fn handle_login_request(
                 &mut stream,
                 StatusCode::OK,
                 http::APPLICATION_JSON,
-                r#"{"provider":"local","display_name":"local","login_supported":true}"#,
+                r#"{"provider":"local","displayName":"local","loginSupported":true}"#,
             );
         }
         "/api/v1/auth/login" if request.method == Method::POST => {
             let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
             let mut state = state.lock().unwrap();
-            state.callback_port = Some(body["callback_port"].as_u64().unwrap() as u16);
+            state.callback_port = Some(body["callbackPort"].as_u64().unwrap() as u16);
             state.expected_state = Some(body["state"].as_str().unwrap().to_string());
             write_http_response(
                 &mut stream,
@@ -304,7 +304,7 @@ fn test_list_integrations() {
     let mut server = Server::new();
     let mock = authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
         .with_body(
-            r#"[{"name":"github","display_name":"GitHub","description":"GitHub integration"}]"#,
+            r#"[{"name":"github","displayName":"GitHub","description":"GitHub integration"}]"#,
         )
         .create();
 
@@ -322,7 +322,7 @@ fn test_list_tokens() {
     let mut server = Server::new();
     let mock = authed_json_mock!(server, Method::GET, "/api/v1/tokens", StatusCode::OK)
         .with_body(
-            r#"[{"id":"1","name":"my-token","scopes":"","created_at":"2025-01-01T00:00:00Z"}]"#,
+            r#"[{"id":"1","name":"my-token","scopes":"","createdAt":"2025-01-01T00:00:00Z"}]"#,
         )
         .create();
 
@@ -653,7 +653,7 @@ fn test_auth_login_fails_when_server_auth_is_disabled() {
     let _env = EnvGuard::new(tempdir.path());
     let mut server = Server::new();
     let _auth_info = json_mock!(server, Method::GET, "/api/v1/auth/info", StatusCode::OK)
-        .with_body(r#"{"provider":"none","display_name":"none","login_supported":false}"#)
+        .with_body(r#"{"provider":"none","displayName":"none","loginSupported":false}"#)
         .create();
     let login = json_mock!(server, Method::POST, "/api/v1/auth/login", StatusCode::OK)
         .expect(0)
@@ -783,7 +783,7 @@ fn test_cli_accepts_legacy_credentials_without_api_url_when_url_is_provided() {
 fn test_init_skips_login_when_server_auth_is_disabled() {
     let mut server = Server::new();
     let _auth_info = json_mock!(server, Method::GET, "/api/v1/auth/info", StatusCode::OK)
-        .with_body(r#"{"provider":"none","display_name":"none","login_supported":false}"#)
+        .with_body(r#"{"provider":"none","displayName":"none","loginSupported":false}"#)
         .create();
 
     let home = tempfile::tempdir().unwrap();
@@ -804,7 +804,7 @@ fn test_init_skips_login_when_server_auth_is_disabled() {
 fn test_auth_status_reports_auth_disabled_before_stored_credentials() {
     let mut server = Server::new();
     let _auth_info = json_mock!(server, Method::GET, "/api/v1/auth/info", StatusCode::OK)
-        .with_body(r#"{"login_supported":false}"#)
+        .with_body(r#"{"loginSupported":false}"#)
         .create();
 
     let home = tempfile::tempdir().unwrap();
@@ -869,7 +869,7 @@ fn test_auth_status_no_url_configured() {
 fn test_auth_status_json_includes_server_fields() {
     let mut server = Server::new();
     let _auth_info = json_mock!(server, Method::GET, "/api/v1/auth/info", StatusCode::OK)
-        .with_body(r#"{"login_supported":true}"#)
+        .with_body(r#"{"loginSupported":true}"#)
         .create();
 
     let home = tempfile::tempdir().unwrap();
@@ -882,10 +882,10 @@ fn test_auth_status_json_includes_server_fields() {
         .unwrap();
 
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json["server_reachable"], serde_json::json!(true));
-    assert_eq!(json["login_supported"], serde_json::json!(true));
-    assert_eq!(json["server_url"], serde_json::json!(server.url()));
-    assert_eq!(json["url_source"], serde_json::json!("--url flag"));
+    assert_eq!(json["serverReachable"], serde_json::json!(true));
+    assert_eq!(json["loginSupported"], serde_json::json!(true));
+    assert_eq!(json["serverUrl"], serde_json::json!(server.url()));
+    assert_eq!(json["urlSource"], serde_json::json!("--url flag"));
     assert_eq!(json["authenticated"], serde_json::json!(false));
 }
 
@@ -919,7 +919,7 @@ fn test_connect_includes_connection_and_instance() {
     let mut server = Server::new();
     let _integrations =
         authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-            .with_body(r#"[{"name":"github","auth_types":["oauth"],"connected":false}]"#)
+            .with_body(r#"[{"name":"github","authTypes":["oauth"],"connected":false}]"#)
             .create();
     let mock = authed_json_mock!(
         server,
@@ -952,7 +952,7 @@ fn test_connect_prefers_oauth_when_manual_also_exists_and_omits_null_connection_
     let mut server = Server::new();
     let _integrations =
         authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-            .with_body(r#"[{"name":"github","auth_types":["oauth","manual"],"connected":false}]"#)
+            .with_body(r#"[{"name":"github","authTypes":["oauth","manual"],"connected":false}]"#)
             .create();
     let mock = authed_json_mock!(
         server,
@@ -1059,11 +1059,11 @@ fn test_manual_connect_uses_prompted_credentials_and_connection_params() {
         .with_body(
             r#"[{
                 "name":"datadog",
-                "display_name":"Datadog",
+                "displayName":"Datadog",
                 "description":"Metrics and logs",
-                "auth_types":["manual"],
-                "connection_params":{"site":{"description":"Datadog site","default":"datadoghq.com","required":true}},
-                "credential_fields":[{"name":"api_key","label":"API key","description":"Use a personal API key","help_url":"https://docs.example.com/datadog"}]
+                "authTypes":["manual"],
+                "connectionParams":{"site":{"description":"Datadog site","default":"datadoghq.com","required":true}},
+                "credentialFields":[{"name":"api_key","label":"API key","description":"Use a personal API key"}]
             }]"#,
         )
         .create();
@@ -1075,7 +1075,7 @@ fn test_manual_connect_uses_prompted_credentials_and_connection_params() {
     )
         .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
         .match_body(Matcher::JsonString(
-            r#"{"connection_params":{"site":"datadoghq.eu"},"credential":"dd-key","integration":"datadog"}"#.to_string(),
+            r#"{"connectionParams":{"site":"datadoghq.eu"},"credential":"dd-key","integration":"datadog"}"#.to_string(),
         ))
         .with_body(r#"{"status":"connected","integration":"datadog"}"#)
         .create();
@@ -1098,11 +1098,11 @@ fn test_manual_connect_prompts_for_connection_and_finishes_candidate_selection()
         .with_body(
             r#"[{
                 "name":"manual-svc",
-                "display_name":"Manual Service",
-                "auth_types":["manual"],
+                "displayName":"Manual Service",
+                "authTypes":["manual"],
                 "connections":[
-                    {"name":"workspace","credential_fields":[{"name":"token","label":"Workspace token"}]},
-                    {"name":"plugin","auth_types":["oauth"]}
+                    {"name":"workspace","credentialFields":[{"name":"token","label":"Workspace token"}]},
+                    {"name":"plugin","authTypes":["oauth"]}
                 ]
             }]"#,
         )
@@ -1122,8 +1122,8 @@ fn test_manual_connect_prompts_for_connection_and_finishes_candidate_selection()
         r#"{
                 "status":"selection_required",
                 "integration":"manual-svc",
-                "selection_url":"/api/v1/auth/pending-connection",
-                "pending_token":"pending-123",
+                "selectionUrl":"/api/v1/auth/pending-connection",
+                "pendingToken":"pending-123",
                 "candidates":[
                     {"id":"site-a","name":"Site A"},
                     {"id":"site-b","name":"Site B"}
@@ -1170,7 +1170,7 @@ fn test_manual_connect_falls_back_to_generic_credential_prompt() {
     let mut server = Server::new();
     let _integrations =
         authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-            .with_body(r#"[{"name":"manual-svc","auth_types":["manual"]}]"#)
+            .with_body(r#"[{"name":"manual-svc","authTypes":["manual"]}]"#)
             .create();
     let _connect = authed_json_mock!(
         server,
@@ -1200,7 +1200,7 @@ fn test_manual_connect_fails_when_stdin_closes_during_prompt() {
     let mut server = Server::new();
     let _integrations =
         authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-            .with_body(r#"[{"name":"manual-svc","auth_types":["manual"]}]"#)
+            .with_body(r#"[{"name":"manual-svc","authTypes":["manual"]}]"#)
             .create();
 
     let home = tempfile::tempdir().unwrap();

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -184,18 +184,18 @@ paths:
 	writeTestFile(t, pagerDir, "manifest.yaml", []byte(`
 source: github.com/test/plugins/pager
 version: 0.0.1-alpha.1
-display_name: Pager
+displayName: Pager
 plugin:
   openapi: openapi.yaml
-  connection_mode: none
+  connectionMode: none
   pagination:
     style: cursor
-    cursor_param: after_cursor
+    cursorParam: after_cursor
     cursor:
       source: header
       path: X-After-Cursor
-    results_path: data
-  allowed_operations:
+    resultsPath: data
+  allowedOperations:
     list_items:
       paginate: true
 `), 0o644)
@@ -225,14 +225,14 @@ paths:
 	writeTestFile(t, mapperDir, "manifest.yaml", []byte(`
 source: github.com/test/plugins/mapper
 version: 0.0.1-alpha.1
-display_name: Mapper
+displayName: Mapper
 plugin:
   openapi: openapi.yaml
-  connection_mode: none
-  response_mapping:
-    data_path: results
+  connectionMode: none
+  responseMapping:
+    dataPath: results
     pagination:
-      has_more:
+      hasMore:
         source: body
         path: moreDataAvailable
       cursor:
@@ -248,7 +248,7 @@ plugin:
 	cfg := authDatastoreConfigYAML(t, dir, "", "sqlite", filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`server:
   public:
     port: %d
-  encryption_key: test-e2e-key
+  encryptionKey: test-e2e-key
 plugins:
   pager:
     provider:
@@ -306,7 +306,7 @@ plugins:
 		var mapped struct {
 			Data       []map[string]any `json:"data"`
 			Pagination struct {
-				HasMore bool   `json:"has_more"`
+				HasMore bool   `json:"hasMore"`
 				Cursor  string `json:"cursor"`
 			} `json:"pagination"`
 		}
@@ -368,7 +368,7 @@ paths:
 	writeTestFile(t, pluginDir, "manifest.yaml", []byte(`
 source: github.com/test/plugins/manual-basic
 version: 0.0.1-alpha.1
-display_name: Manual Basic Test
+displayName: Manual Basic Test
 plugin:
   openapi: openapi.yaml
 `), 0o644)
@@ -382,7 +382,7 @@ plugin:
 	cfg := authDatastoreConfigYAML(t, dir, "session-auth", "sqlite", filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`server:
   public:
     port: %d
-  encryption_key: test-e2e-key
+  encryptionKey: test-e2e-key
 plugins:
   mt:
     provider:
@@ -395,7 +395,7 @@ plugins:
           credentials:
             - name: api_key
               label: API Key
-          auth_mapping:
+          authMapping:
             headers:
               X-Org-ID:
                 value: org-fixed
@@ -438,7 +438,7 @@ plugins:
 			Connections []struct {
 				CredentialFields []struct {
 					Name string `json:"name"`
-				} `json:"credential_fields"`
+				} `json:"credentialFields"`
 			} `json:"connections"`
 		}
 		if err := json.NewDecoder(listResp.Body).Decode(&integrations); err != nil {
@@ -546,7 +546,7 @@ paths:
 	writeTestFile(t, pluginDir, "manifest.yaml", []byte(`
 source: github.com/test/plugins/manifest-basic
 version: 0.0.1-alpha.1
-display_name: Manifest Basic Test
+displayName: Manifest Basic Test
 plugin:
   auth:
     type: manual
@@ -557,7 +557,7 @@ plugin:
         label: API Key
       - name: app_key
         label: App Key
-    auth_mapping:
+    authMapping:
       headers:
         X-App-Key:
           valueFrom:
@@ -584,7 +584,7 @@ plugin:
 	cfg := authDatastoreConfigYAML(t, dir, "session-auth", "sqlite", filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`server:
   public:
     port: %d
-  encryption_key: test-e2e-key
+  encryptionKey: test-e2e-key
 plugins:
   mt:
     provider:
@@ -618,7 +618,7 @@ plugins:
 			Connections []struct {
 				CredentialFields []struct {
 					Name string `json:"name"`
-				} `json:"credential_fields"`
+				} `json:"credentialFields"`
 			} `json:"connections"`
 		}
 		if err := json.NewDecoder(listResp.Body).Decode(&integrations); err != nil {
@@ -699,7 +699,7 @@ func TestE2EDeclarativeManifestManualAuthMappingValueFromBasicAuth(t *testing.T)
 	writeTestFile(t, pluginDir, "manifest.yaml", []byte(fmt.Sprintf(`
 source: github.com/test/plugins/declarative-basic
 version: 0.0.1-alpha.1
-display_name: Declarative Basic Test
+displayName: Declarative Basic Test
 plugin:
   auth:
     type: manual
@@ -710,7 +710,7 @@ plugin:
         label: API Key
       - name: app_key
         label: App Key
-    auth_mapping:
+    authMapping:
       headers:
         X-App-Key:
           valueFrom:
@@ -725,7 +725,7 @@ plugin:
           valueFrom:
             credentialFieldRef:
               name: api_key
-  base_url: %s
+  baseUrl: %s
   operations:
     - name: whoami
       method: GET
@@ -741,7 +741,7 @@ plugin:
 	cfg := authDatastoreConfigYAML(t, dir, "session-auth", "sqlite", filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`server:
   public:
     port: %d
-  encryption_key: test-e2e-key
+  encryptionKey: test-e2e-key
 plugins:
   mt:
     provider:
@@ -971,7 +971,7 @@ func TestE2EInitServeLockedOTLPExportsTracesAndMetricsButKeepsLogsOnStdout(t *te
     protocol: http
     insecure: true
     traces:
-      sampling_ratio: 1.0
+      samplingRatio: 1.0
     metrics:
       interval: 50ms
     logs:
@@ -1437,7 +1437,7 @@ func TestE2EBareGestaltdUsesDotGestaltdHomeConfig(t *testing.T) {
 	cfg := authDatastoreConfigYAML(t, dir, "", "sqlite", filepath.Join(configDir, "gestalt.db")) + `server:
   public:
     port: ` + fmt.Sprintf("%d", port) + `
-  encryption_key: test-key
+  encryptionKey: test-key
 `
 	cfgPath := filepath.Join(configDir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
@@ -1515,7 +1515,7 @@ func TestE2EHelmChart(t *testing.T) {
     dsn: %s
 datastore: sqlite
 server:
-  encryption_key: test-helm-key
+  encryptionKey: test-helm-key
   public:
     port: %d
 ui:
@@ -1658,7 +1658,7 @@ params:
 			dir := t.TempDir()
 			cfgPath := filepath.Join(dir, "config.yaml")
 			cfg := authDatastoreConfigYAML(t, dir, "local", "sqlite", filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`server:
-  encryption_key: test-key
+  encryptionKey: test-key
 plugins:
   example:
     %s
@@ -1684,7 +1684,7 @@ func TestE2EDefaultStartRejectsUnknownYAMLField(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := authDatastoreConfigYAML(t, dir, "local", "sqlite", filepath.Join(dir, "gestalt.db")) + `server:
-  encryption_key: test-key
+  encryptionKey: test-key
   typo: true
 plugins:
   example:
@@ -1870,8 +1870,8 @@ func writeSplitListenerE2EConfig(t *testing.T, dir, pluginDir string, publicPort
 
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := authDatastoreConfigYAML(t, dir, "", "sqlite", filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`server:
-  encryption_key: test-e2e-key
-  base_url: https://gestalt.example.test
+  encryptionKey: test-e2e-key
+  baseUrl: https://gestalt.example.test
   public:
     port: %d
   management:
@@ -1905,10 +1905,10 @@ func writeE2EConfigWithPaths(t *testing.T, dir, pluginDir, dbPath, artifactsDir 
 	serverBlock := fmt.Sprintf(`server:
   public:
     port: %d
-  encryption_key: test-e2e-key
+  encryptionKey: test-e2e-key
 `, port)
 	if artifactsDir != "" {
-		serverBlock += fmt.Sprintf("  artifacts_dir: %s\n", artifactsDir)
+		serverBlock += fmt.Sprintf("  artifactsDir: %s\n", artifactsDir)
 	}
 	cfg := authDatastoreConfigYAML(t, dir, "", "sqlite", dbPath) + fmt.Sprintf(`%splugins:
   example:

--- a/gestaltd/cmd/gestaltd/main_test.go
+++ b/gestaltd/cmd/gestaltd/main_test.go
@@ -120,10 +120,10 @@ func TestE2ECLIValidateWithStrictProviderErrors(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := authDatastoreConfigYAML(t, dir, "google", "sqlite", filepath.Join(dir, "gestalt.db")) + `server:
-  encryption_key: test-key
+  encryptionKey: test-key
 plugins:
   broken:
-    display_name: Broken
+    displayName: Broken
 `
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {
 		t.Fatalf("WriteFile: %v", err)

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -138,7 +138,7 @@ func TestRun_PluginReleaseRejectsInvalidManifest(t *testing.T) {
 		wantError    string
 	}{
 		{
-			name: "rest surface requires base_url",
+			name: "rest surface requires baseUrl",
 			manifestYAML: `
 source: github.com/testowner/plugins/invalid
 version: 0.0.1-alpha.1
@@ -150,7 +150,7 @@ provider:
           method: GET
           path: /items
 `,
-			wantError: "provider.base_url is required",
+			wantError: "provider.baseUrl is required",
 		},
 		{
 			name: "exec block requires artifact path",
@@ -160,7 +160,7 @@ version: 0.0.1-alpha.1
 provider:
   exec: {}
 `,
-			wantError: "entrypoints.provider.artifact_path is required",
+			wantError: "entrypoints.provider.artifactPath is required",
 		},
 	}
 

--- a/gestaltd/cmd/gestaltd/prepared_plugin_e2e_test.go
+++ b/gestaltd/cmd/gestaltd/prepared_plugin_e2e_test.go
@@ -23,7 +23,7 @@ func TestE2EValidateUsesUpdatedManagedPluginConfigAfterInit(t *testing.T) {
 	cfgPath := writePreparedSourceConfig(t, dir, pluginDir, map[string]string{
 		"api_key": "one",
 	}, []string{
-		"encryption_key: test-key",
+		"encryptionKey: test-key",
 	})
 
 	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
@@ -34,7 +34,7 @@ func TestE2EValidateUsesUpdatedManagedPluginConfigAfterInit(t *testing.T) {
 	writePreparedSourceConfig(t, dir, pluginDir, map[string]string{
 		"wrong_key": "two",
 	}, []string{
-		"encryption_key: test-key",
+		"encryptionKey: test-key",
 	})
 
 	out, err = exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
@@ -58,7 +58,7 @@ func TestE2EServeLockedResolvesLateBoundManagedPluginEnv(t *testing.T) {
 	}, []string{
 		"public:",
 		"  port: ${" + portEnv + "}",
-		"encryption_key: test-key",
+		"encryptionKey: test-key",
 	})
 
 	initCmd := exec.Command(gestaltdBin, "init", "--config", cfgPath)

--- a/gestaltd/core/catalog/catalog.go
+++ b/gestaltd/core/catalog/catalog.go
@@ -20,18 +20,18 @@ const (
 // rest of Gestalt can derive runtime and MCP views from a single source.
 type Catalog struct {
 	Name        string             `yaml:"name"                   json:"name"`
-	DisplayName string             `yaml:"display_name"           json:"displayName"`
+	DisplayName string             `yaml:"displayName"           json:"displayName"`
 	Description string             `yaml:"description"            json:"description"`
-	IconSVG     string             `yaml:"icon_svg,omitempty"     json:"iconSvg,omitempty"`
-	BaseURL     string             `yaml:"base_url,omitempty"     json:"baseUrl,omitempty"`
-	AuthStyle   string             `yaml:"auth_style,omitempty"   json:"authStyle,omitempty"`
+	IconSVG     string             `yaml:"iconSvg,omitempty"     json:"iconSvg,omitempty"`
+	BaseURL     string             `yaml:"baseUrl,omitempty"     json:"baseUrl,omitempty"`
+	AuthStyle   string             `yaml:"authStyle,omitempty"   json:"authStyle,omitempty"`
 	Headers     map[string]string  `yaml:"headers,omitempty"      json:"headers,omitempty"`
 	Operations  []CatalogOperation `yaml:"operations"             json:"operations"`
 }
 
 type CatalogOperation struct {
 	ID             string               `yaml:"id"                       json:"id"`
-	ProviderID     string               `yaml:"provider_id,omitempty"    json:"providerId,omitempty"`
+	ProviderID     string               `yaml:"providerId,omitempty"    json:"providerId,omitempty"`
 	Method         string               `yaml:"method"                   json:"method"`
 	Path           string               `yaml:"path"                     json:"path"`
 	Title          string               `yaml:"title,omitempty"          json:"title,omitempty"`
@@ -40,24 +40,24 @@ type CatalogOperation struct {
 	OutputSchema   json.RawMessage      `yaml:"-"                        json:"outputSchema,omitempty"`
 	Annotations    OperationAnnotations `yaml:"annotations,omitempty"    json:"annotations,omitempty"`
 	Parameters     []CatalogParameter   `yaml:"parameters,omitempty"     json:"parameters,omitempty"`
-	RequiredScopes []string             `yaml:"required_scopes,omitempty" json:"requiredScopes,omitempty"`
+	RequiredScopes []string             `yaml:"requiredScopes,omitempty" json:"requiredScopes,omitempty"`
 	Tags           []string             `yaml:"tags,omitempty"           json:"tags,omitempty"`
-	ReadOnly       bool                 `yaml:"read_only,omitempty"      json:"readOnly,omitempty"`
+	ReadOnly       bool                 `yaml:"readOnly,omitempty"      json:"readOnly,omitempty"`
 	Visible        *bool                `yaml:"visible,omitempty"        json:"visible,omitempty"`
 	Transport      string               `yaml:"transport,omitempty"      json:"transport,omitempty"`
 	Query          string               `yaml:"query,omitempty"          json:"query,omitempty"`
 }
 
 type OperationAnnotations struct {
-	ReadOnlyHint    *bool `yaml:"read_only_hint,omitempty"    json:"readOnlyHint,omitempty"`
-	IdempotentHint  *bool `yaml:"idempotent_hint,omitempty"   json:"idempotentHint,omitempty"`
-	DestructiveHint *bool `yaml:"destructive_hint,omitempty"  json:"destructiveHint,omitempty"`
-	OpenWorldHint   *bool `yaml:"open_world_hint,omitempty"   json:"openWorldHint,omitempty"`
+	ReadOnlyHint    *bool `yaml:"readOnlyHint,omitempty"    json:"readOnlyHint,omitempty"`
+	IdempotentHint  *bool `yaml:"idempotentHint,omitempty"   json:"idempotentHint,omitempty"`
+	DestructiveHint *bool `yaml:"destructiveHint,omitempty"  json:"destructiveHint,omitempty"`
+	OpenWorldHint   *bool `yaml:"openWorldHint,omitempty"   json:"openWorldHint,omitempty"`
 }
 
 type CatalogParameter struct {
 	Name        string `yaml:"name"                  json:"name"`
-	WireName    string `yaml:"wire_name,omitempty"    json:"wireName,omitempty"`
+	WireName    string `yaml:"wireName,omitempty"    json:"wireName,omitempty"`
 	Type        string `yaml:"type"                  json:"type"`
 	Location    string `yaml:"location,omitempty"    json:"location,omitempty"`
 	Description string `yaml:"description,omitempty"  json:"description,omitempty"`
@@ -124,7 +124,7 @@ func (c *Catalog) Validate() error {
 		return fmt.Errorf("catalog %q must declare at least one operation", c.Name)
 	}
 	if !isValidAuthStyle(c.AuthStyle) {
-		return fmt.Errorf("catalog %q has unknown auth_style %q", c.Name, c.AuthStyle)
+		return fmt.Errorf("catalog %q has unknown authStyle %q", c.Name, c.AuthStyle)
 	}
 
 	seen := make(map[string]struct{}, len(c.Operations))

--- a/gestaltd/core/integration/response_mapping.go
+++ b/gestaltd/core/integration/response_mapping.go
@@ -41,7 +41,7 @@ func applyResponseMapping(result *core.OperationResult, cfg *ResponseMappingConf
 	if cfg.Pagination != nil {
 		pgn := make(map[string]any)
 		if v, ok := apiexec.SelectValue(result, raw, cfg.Pagination.HasMore); ok {
-			pgn["has_more"] = v
+			pgn["hasMore"] = v
 		}
 		if v, ok := apiexec.SelectValue(result, raw, cfg.Pagination.Cursor); ok {
 			pgn["cursor"] = v

--- a/gestaltd/core/integration/response_mapping_test.go
+++ b/gestaltd/core/integration/response_mapping_test.go
@@ -65,8 +65,8 @@ func TestResponseMappingExtractsDataAndPagination(t *testing.T) {
 	}
 
 	pgn := parsed["pagination"].(map[string]any)
-	if pgn["has_more"] != true {
-		t.Fatalf("has_more = %v, want true", pgn["has_more"])
+	if pgn["hasMore"] != true {
+		t.Fatalf("hasMore = %v, want true", pgn["hasMore"])
 	}
 	if pgn["cursor"] != "cursor-abc" {
 		t.Fatalf("cursor = %v, want cursor-abc", pgn["cursor"])

--- a/gestaltd/core/provider.go
+++ b/gestaltd/core/provider.go
@@ -66,7 +66,6 @@ type CredentialFieldDef struct {
 	Name        string
 	Label       string
 	Description string
-	HelpURL     string
 }
 
 type CredentialFieldsProvider interface {

--- a/gestaltd/deploy/helm/gestalt/ci-values-plugin-init.yaml
+++ b/gestaltd/deploy/helm/gestalt/ci-values-plugin-init.yaml
@@ -1,11 +1,11 @@
 config:
   server:
-    base_url: "https://gestalt.example.com"
-    encryption_key: "ci-test-encryption-key"
+    baseUrl: "https://gestalt.example.com"
+    encryptionKey: "ci-test-encryption-key"
   auth:
     config:
-      client_id: "ci-test-client-id"
-      client_secret: "ci-test-client-secret"
+      clientId: "ci-test-client-id"
+      clientSecret: "ci-test-client-secret"
 
 image:
   tag: "ci-test"

--- a/gestaltd/deploy/helm/gestalt/ci-values.yaml
+++ b/gestaltd/deploy/helm/gestalt/ci-values.yaml
@@ -1,11 +1,11 @@
 config:
   server:
-    base_url: "https://gestalt.example.com"
-    encryption_key: "ci-test-encryption-key"
+    baseUrl: "https://gestalt.example.com"
+    encryptionKey: "ci-test-encryption-key"
   auth:
     config:
-      client_id: "ci-test-client-id"
-      client_secret: "ci-test-client-secret"
+      clientId: "ci-test-client-id"
+      clientSecret: "ci-test-client-secret"
 
 image:
   tag: "ci-test"

--- a/gestaltd/deploy/helm/gestalt/values.yaml
+++ b/gestaltd/deploy/helm/gestalt/values.yaml
@@ -84,11 +84,11 @@ config:
     #   port: 9090
     # Dev-only default so the default chart profile can boot. Override this with
     # a secret value before production use.
-    encryption_key: "dev-only-insecure-key-change-me"
-    # base_url is optional for the default local/dev profile.
+    encryptionKey: "dev-only-insecure-key-change-me"
+    # baseUrl is optional for the default local/dev profile.
     # Set it to your public HTTPS URL when auth callbacks or external
     # integrations need it.
-    # base_url: "${GESTALT_BASE_URL}"
+    # baseUrl: "${GESTALT_BASE_URL}"
   datastore:
     # SQLite is appropriate for local development or single-instance
     # deployments with mounted persistent storage at /data.

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -79,31 +79,31 @@ type PluginSourceDef struct {
 }
 
 type EgressConfig struct {
-	DefaultAction string                  `yaml:"default_action"`
+	DefaultAction string                  `yaml:"defaultAction"`
 	Policies      []EgressPolicyRule      `yaml:"policies"`
 	Credentials   []EgressCredentialGrant `yaml:"credentials"`
 }
 
 type EgressPolicyRule struct {
 	Action      string `yaml:"action"`
-	SubjectKind string `yaml:"subject_kind"`
-	SubjectID   string `yaml:"subject_id"`
+	SubjectKind string `yaml:"subjectKind"`
+	SubjectID   string `yaml:"subjectId"`
 	Provider    string `yaml:"provider"`
 	Operation   string `yaml:"operation"`
 	Method      string `yaml:"method"`
 	Host        string `yaml:"host"`
-	PathPrefix  string `yaml:"path_prefix"`
+	PathPrefix  string `yaml:"pathPrefix"`
 }
 
 type EgressCredentialGrant struct {
-	SecretRef   string `yaml:"secret_ref"`
-	AuthStyle   string `yaml:"auth_style"`
-	SubjectKind string `yaml:"subject_kind"`
-	SubjectID   string `yaml:"subject_id"`
+	SecretRef   string `yaml:"secretRef"`
+	AuthStyle   string `yaml:"authStyle"`
+	SubjectKind string `yaml:"subjectKind"`
+	SubjectID   string `yaml:"subjectId"`
 	Operation   string `yaml:"operation"`
 	Method      string `yaml:"method"`
 	Host        string `yaml:"host"`
-	PathPrefix  string `yaml:"path_prefix"`
+	PathPrefix  string `yaml:"pathPrefix"`
 }
 
 type ProviderDef struct {
@@ -113,7 +113,7 @@ type ProviderDef struct {
 	Env     map[string]string `yaml:"env"`
 
 	Config       yaml.Node `yaml:"-"`
-	AllowedHosts []string  `yaml:"allowed_hosts"`
+	AllowedHosts []string  `yaml:"allowedHosts"`
 
 	Discovery *pluginmanifestv1.ProviderDiscovery `yaml:"-"`
 
@@ -430,10 +430,10 @@ type ListenerConfig struct {
 type ServerConfig struct {
 	Public        ListenerConfig `yaml:"public"`
 	Management    ListenerConfig `yaml:"management"`
-	BaseURL       string         `yaml:"base_url"`
-	EncryptionKey string         `yaml:"encryption_key"`
-	APITokenTTL   string         `yaml:"api_token_ttl"`
-	ArtifactsDir  string         `yaml:"artifacts_dir"`
+	BaseURL       string         `yaml:"baseUrl"`
+	EncryptionKey string         `yaml:"encryptionKey"`
+	APITokenTTL   string         `yaml:"apiTokenTtl"`
+	ArtifactsDir  string         `yaml:"artifactsDir"`
 }
 
 func (s ServerConfig) PublicListener() ListenerConfig {
@@ -469,10 +469,10 @@ func (s ServerConfig) ManagementAddr() string {
 
 type IntegrationDef struct {
 	Plugin        *ProviderDef      `yaml:"plugin"`
-	DisplayName   string            `yaml:"display_name"`
+	DisplayName   string            `yaml:"displayName"`
 	Description   string            `yaml:"description"`
 	MCPToolPrefix string            `yaml:"-"`
-	IconFile      string            `yaml:"icon_file"`
+	IconFile      string            `yaml:"iconFile"`
 	Datastores    map[string]string `yaml:"-"`
 }
 
@@ -487,25 +487,25 @@ type ConnectionDef struct {
 
 type ConnectionAuthDef struct {
 	Type                string               `yaml:"type"`
-	AuthorizationURL    string               `yaml:"authorization_url"`
-	TokenURL            string               `yaml:"token_url"`
-	ClientID            string               `yaml:"client_id"`
-	ClientSecret        string               `yaml:"client_secret"`
-	RedirectURL         string               `yaml:"redirect_url"`
-	ClientAuth          string               `yaml:"client_auth"`
-	TokenExchange       string               `yaml:"token_exchange"`
+	AuthorizationURL    string               `yaml:"authorizationUrl"`
+	TokenURL            string               `yaml:"tokenUrl"`
+	ClientID            string               `yaml:"clientId"`
+	ClientSecret        string               `yaml:"clientSecret"`
+	RedirectURL         string               `yaml:"redirectUrl"`
+	ClientAuth          string               `yaml:"clientAuth"`
+	TokenExchange       string               `yaml:"tokenExchange"`
 	Scopes              []string             `yaml:"scopes"`
-	ScopeParam          string               `yaml:"scope_param"`
-	ScopeSeparator      string               `yaml:"scope_separator"`
+	ScopeParam          string               `yaml:"scopeParam"`
+	ScopeSeparator      string               `yaml:"scopeSeparator"`
 	PKCE                bool                 `yaml:"pkce"`
-	AuthorizationParams map[string]string    `yaml:"authorization_params"`
-	TokenParams         map[string]string    `yaml:"token_params"`
-	RefreshParams       map[string]string    `yaml:"refresh_params"`
-	AcceptHeader        string               `yaml:"accept_header"`
-	AccessTokenPath     string               `yaml:"access_token_path"`
-	TokenMetadata       []string             `yaml:"token_metadata"`
+	AuthorizationParams map[string]string    `yaml:"authorizationParams"`
+	TokenParams         map[string]string    `yaml:"tokenParams"`
+	RefreshParams       map[string]string    `yaml:"refreshParams"`
+	AcceptHeader        string               `yaml:"acceptHeader"`
+	AccessTokenPath     string               `yaml:"accessTokenPath"`
+	TokenMetadata       []string             `yaml:"tokenMetadata"`
 	Credentials         []CredentialFieldDef `yaml:"credentials"`
-	AuthMapping         *AuthMappingDef      `yaml:"auth_mapping"`
+	AuthMapping         *AuthMappingDef      `yaml:"authMapping"`
 }
 
 type CredentialFieldDef = pluginmanifestv1.CredentialField
@@ -615,9 +615,6 @@ func mergeCredentialField(dst *CredentialFieldDef, src CredentialFieldDef) {
 	}
 	if src.Description != "" {
 		dst.Description = src.Description
-	}
-	if src.HelpURL != "" {
-		dst.HelpURL = src.HelpURL
 	}
 }
 

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -48,7 +48,7 @@ datastores:
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
-  encryption_key: server-key
+  encryptionKey: server-key
   public:
     host: 127.0.0.1
     port: 9090
@@ -57,7 +57,7 @@ server:
     port: 9191
 plugins:
   service-a:
-    display_name: Service A
+    displayName: Service A
     provider:
       source:
         path: /tmp/manifest.yaml
@@ -103,7 +103,7 @@ datastores:
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
-  encryption_key: ${TEST_ENCRYPTION}
+  encryptionKey: ${TEST_ENCRYPTION}
 plugins:
   service-a:
     provider:
@@ -154,7 +154,7 @@ datastores:
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
-  encryption_key: ${TEST_ENCRYPTION}
+  encryptionKey: ${TEST_ENCRYPTION}
 `)
 
 	cfg, err := LoadWithLookup(path, func(key string) (string, bool) {
@@ -186,7 +186,7 @@ datastores:
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
-  encryption_key: ${%s}
+  encryptionKey: ${%s}
   public:
     port: ${%s}
 `, encryptionEnv, portEnv))
@@ -226,7 +226,7 @@ datastores:
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
-  encryption_key: ${TEST_ENCRYPTION:-}
+  encryptionKey: ${TEST_ENCRYPTION:-}
 `)
 
 	cfg, err := LoadWithLookup(path, func(string) (string, bool) {
@@ -288,7 +288,7 @@ datastores:
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
-  encryption_key: server-key
+  encryptionKey: server-key
 `,
 			wantErr: false,
 		},
@@ -298,7 +298,7 @@ server:
 auth:
   provider: none
 server:
-  encryption_key: server-key
+  encryptionKey: server-key
 `,
 			wantErr: true,
 		},
@@ -324,7 +324,7 @@ datastores:
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
-  encryption_key: server-key
+  encryptionKey: server-key
 `,
 			wantErr: false,
 		},
@@ -377,7 +377,7 @@ datastores:
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
-  encryption_key: server-key
+  encryptionKey: server-key
 `,
 			wantErr: "field plugin not found in type config.AuthConfig",
 		},
@@ -392,7 +392,7 @@ datastore:
       ref: github.com/valon-technologies/gestalt-providers/datastore/sqlite
       version: 1.0.0
 server:
-  encryption_key: server-key
+  encryptionKey: server-key
 `,
 			wantErr: "field plugin not found in type config.DatastoreConfig",
 		},
@@ -412,7 +412,7 @@ datastores:
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
-  encryption_key: server-key
+  encryptionKey: server-key
 `,
 			wantErr: "",
 		},
@@ -427,7 +427,7 @@ datastores:
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
-  encryption_key: server-key
+  encryptionKey: server-key
 `,
 			wantErr: "",
 		},
@@ -487,7 +487,7 @@ datastores:
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
-  encryption_key: server-key
+  encryptionKey: server-key
 `)
 
 		cfg, err := Load(path)
@@ -520,7 +520,7 @@ datastores:
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
-  encryption_key: server-key
+  encryptionKey: server-key
 `)
 
 		cfg, err := Load(path)
@@ -549,7 +549,7 @@ datastores:
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
-  encryption_key: server-key
+  encryptionKey: server-key
 `)
 
 		_, err := Load(path)
@@ -575,7 +575,7 @@ datastores:
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
-  encryption_key: server-key
+  encryptionKey: server-key
 `)
 
 		cfg, err := Load(path)
@@ -585,7 +585,7 @@ server:
 		if cfg.UI.Provider == nil || cfg.UI.Provider.Source == nil {
 			t.Fatalf("UI.Provider = %#v", cfg.UI.Provider)
 		}
-		wantPath := filepath.Join(filepath.Dir(path), "web", "default", "manifest.yaml")
+		wantPath := filepath.Join(filepath.Dir(path), "web", "default", "provider.yaml")
 		if got := cfg.UI.Provider.Source.Path; got != wantPath {
 			t.Fatalf("UI.Provider.Source.Path = %q, want %q", got, wantPath)
 		}
@@ -604,14 +604,14 @@ func TestLoadConfigValidation(t *testing.T) {
 			yaml: `
 plugins:
   service-a:
-    display_name: Service A
+    displayName: Service A
 `,
 		},
 		{
 			name: "egress default action must be allow or deny",
 			yaml: `
 egress:
-  default_action: block
+  defaultAction: block
 `,
 		},
 	}
@@ -825,29 +825,29 @@ plugins:
       source:
         path: ./plugins/dummy/manifest.yaml
     mcp:
-      tool_prefix: external_
+      toolPrefix: external_
 `,
-			wantErr: "mcp.tool_prefix is only valid when mcp.enabled is true",
+			wantErr: "mcp.toolPrefix is only valid when mcp.enabled is true",
 		},
 		{
 			name: "egress default_action allow is valid",
 			yaml: `
 egress:
-  default_action: allow
+  defaultAction: allow
 `,
 		},
 		{
 			name: "egress default_action deny is valid",
 			yaml: `
 egress:
-  default_action: deny
+  defaultAction: deny
 `,
 		},
 		{
 			name: "egress default_action invalid",
 			yaml: `
 egress:
-  default_action: block
+  defaultAction: block
 `,
 			wantErr: "default_action must be \"allow\" or \"deny\"",
 		},
@@ -1054,7 +1054,7 @@ datastores:
 datastore: sqlite
 plugins:
   service-a:
-    icon_file: ../assets/service.svg
+    iconFile: ../assets/service.svg
     provider:
       source:
         path: ../bin/manifest.yaml
@@ -1070,11 +1070,11 @@ plugins:
 	if got := cfg.Integrations["service-a"].IconFile; got != iconPath {
 		t.Fatalf("IconFile = %q, want %q", got, iconPath)
 	}
-	if got := cfg.Auth.Provider.SourcePath(); got != filepath.Join(dir, "auth-plugin", "manifest.yaml") {
-		t.Fatalf("auth plugin source path = %q, want %q", got, filepath.Join(dir, "auth-plugin", "manifest.yaml"))
+	if got := cfg.Auth.Provider.SourcePath(); got != filepath.Join(dir, "auth-plugin", "provider.yaml") {
+		t.Fatalf("auth plugin source path = %q, want %q", got, filepath.Join(dir, "auth-plugin", "provider.yaml"))
 	}
-	if got := cfg.Integrations["service-a"].Plugin.SourcePath(); got != filepath.Join(dir, "bin", "provider.yaml") {
-		t.Fatalf("integration plugin source path = %q, want %q", got, filepath.Join(dir, "bin", "provider.yaml"))
+	if got := cfg.Integrations["service-a"].Plugin.SourcePath(); got != filepath.Join(dir, "bin", "manifest.yaml") {
+		t.Fatalf("integration plugin source path = %q, want %q", got, filepath.Join(dir, "bin", "manifest.yaml"))
 	}
 }
 
@@ -1097,7 +1097,7 @@ datastores:
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
-  encryption_key: server-key
+  encryptionKey: server-key
 `)
 
 	cfg, err := Load(path)
@@ -1130,7 +1130,7 @@ func TestLoadConfig_APITokenTTL(t *testing.T) {
 		t.Parallel()
 		path := mustWriteConfigFile(t, `
 server:
-  api_token_ttl: "14d"
+  apiTokenTtl: "14d"
 `)
 		cfg, err := Load(path)
 		if err != nil {
@@ -1145,7 +1145,7 @@ server:
 		t.Parallel()
 		path := mustWriteConfigFile(t, `
 server:
-  api_token_ttl: "not-a-duration"
+  apiTokenTtl: "not-a-duration"
 `)
 		_, err := Load(path)
 		if err == nil {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -23,7 +23,7 @@ func ValidateStructure(cfg *Config) error {
 	}
 	if cfg.Server.APITokenTTL != "" {
 		if _, err := ParseDuration(cfg.Server.APITokenTTL); err != nil {
-			return fmt.Errorf("config validation: server.api_token_ttl: %w", err)
+			return fmt.Errorf("config validation: server.apiTokenTtl: %w", err)
 		}
 	}
 	if err := validateAudit(cfg.Audit); err != nil {
@@ -196,7 +196,7 @@ func manifestBackedConnectionReferences(plugin *ProviderDef, provider *pluginman
 	}
 	return []inlineConnectionReference{
 		{
-			field: "plugin.default_connection",
+			field: "plugin.defaultConnection",
 			name:  defaultConnection,
 		},
 	}
@@ -412,15 +412,15 @@ func validateConnectionAuthMappings(integration string, auth ConnectionAuthDef, 
 		return nil
 	}
 	for headerName, value := range auth.AuthMapping.Headers {
-		if err := validateAuthValueDef(integration, subject, fmt.Sprintf("auth_mapping.headers[%q]", headerName), value, credentialNames); err != nil {
+		if err := validateAuthValueDef(integration, subject, fmt.Sprintf("authMapping.headers[%q]", headerName), value, credentialNames); err != nil {
 			return err
 		}
 	}
 	if auth.AuthMapping.Basic != nil {
-		if err := validateAuthValueDef(integration, subject, "auth_mapping.basic.username", auth.AuthMapping.Basic.Username, credentialNames); err != nil {
+		if err := validateAuthValueDef(integration, subject, "authMapping.basic.username", auth.AuthMapping.Basic.Username, credentialNames); err != nil {
 			return err
 		}
-		if err := validateAuthValueDef(integration, subject, "auth_mapping.basic.password", auth.AuthMapping.Basic.Password, credentialNames); err != nil {
+		if err := validateAuthValueDef(integration, subject, "authMapping.basic.password", auth.AuthMapping.Basic.Password, credentialNames); err != nil {
 			return err
 		}
 	}

--- a/gestaltd/internal/config/provider_ref.go
+++ b/gestaltd/internal/config/provider_ref.go
@@ -11,17 +11,17 @@ import (
 type pluginDefWire struct {
 	Source       *PluginSourceDef  `yaml:"source"`
 	Env          map[string]string `yaml:"env"`
-	AllowedHosts []string          `yaml:"allowed_hosts"`
+	AllowedHosts []string          `yaml:"allowedHosts"`
 }
 
 type integrationWire struct {
-	DisplayName       string                            `yaml:"display_name"`
+	DisplayName       string                            `yaml:"displayName"`
 	Description       string                            `yaml:"description"`
-	IconFile          string                            `yaml:"icon_file"`
+	IconFile          string                            `yaml:"iconFile"`
 	Provider          *ProviderDef                      `yaml:"provider"`
 	Config            yaml.Node                         `yaml:"config"`
 	Connections       map[string]*integrationConnection `yaml:"connections"`
-	AllowedOperations map[string]*OperationOverride     `yaml:"allowed_operations"`
+	AllowedOperations map[string]*OperationOverride     `yaml:"allowedOperations"`
 	MCP               *integrationMCPWire               `yaml:"mcp"`
 	Datastores        map[string]string                 `yaml:"datastores"`
 }
@@ -35,14 +35,14 @@ type integrationConnection struct {
 
 type integrationDiscoveryWire struct {
 	URL      string            `yaml:"url"`
-	IDPath   string            `yaml:"id_path"`
-	NamePath string            `yaml:"name_path"`
+	IDPath   string            `yaml:"idPath"`
+	NamePath string            `yaml:"namePath"`
 	Metadata map[string]string `yaml:"metadata"`
 }
 
 type integrationMCPWire struct {
 	Enabled    bool   `yaml:"enabled"`
-	ToolPrefix string `yaml:"tool_prefix"`
+	ToolPrefix string `yaml:"toolPrefix"`
 }
 
 func (p *ProviderDef) UnmarshalYAML(value *yaml.Node) error {
@@ -150,7 +150,7 @@ func decodeKnownYAMLNode(value *yaml.Node, out any) error {
 
 func validateIntegrationWire(wire *integrationWire) error {
 	if wire.MCP != nil && wire.MCP.ToolPrefix != "" && !wire.MCP.Enabled {
-		return fmt.Errorf("mcp.tool_prefix is only valid when mcp.enabled is true")
+		return fmt.Errorf("mcp.toolPrefix is only valid when mcp.enabled is true")
 	}
 
 	return nil

--- a/gestaltd/internal/config/runtime_config.go
+++ b/gestaltd/internal/config/runtime_config.go
@@ -13,9 +13,9 @@ type componentRuntimeConfig struct {
 	Command      string            `yaml:"command"`
 	Args         []string          `yaml:"args,omitempty"`
 	Env          map[string]string `yaml:"env,omitempty"`
-	AllowedHosts []string          `yaml:"allowed_hosts,omitempty"`
-	HostBinary   string            `yaml:"host_binary,omitempty"`
-	ManifestPath string            `yaml:"manifest_path,omitempty"`
+	AllowedHosts []string          `yaml:"allowedHosts,omitempty"`
+	HostBinary   string            `yaml:"hostBinary,omitempty"`
+	ManifestPath string            `yaml:"manifestPath,omitempty"`
 	Config       yaml.Node         `yaml:"config,omitempty"`
 }
 
@@ -68,7 +68,7 @@ func IsComponentRuntimeConfigNode(node yaml.Node) bool {
 	if mappingValueNode(raw, "config") == nil {
 		return false
 	}
-	for _, key := range []string{"source", "command", "manifest_path", "host_binary"} {
+	for _, key := range []string{"source", "command", "manifestPath", "hostBinary"} {
 		if mappingValueNode(raw, key) != nil {
 			return true
 		}

--- a/gestaltd/internal/drivers/auth/plugin/factory.go
+++ b/gestaltd/internal/drivers/auth/plugin/factory.go
@@ -15,7 +15,7 @@ import (
 
 type yamlConfig struct {
 	componentplugin.YAMLConfig `yaml:",inline"`
-	CallbackURL                string `yaml:"callback_url"`
+	CallbackURL                string `yaml:"callbackUrl"`
 }
 
 var Factory bootstrap.AuthFactory = func(node yaml.Node, deps bootstrap.Deps) (core.AuthProvider, error) {

--- a/gestaltd/internal/drivers/componentplugin/factory.go
+++ b/gestaltd/internal/drivers/componentplugin/factory.go
@@ -16,9 +16,9 @@ type YAMLConfig struct {
 	Command      string            `yaml:"command"`
 	Args         []string          `yaml:"args"`
 	Env          map[string]string `yaml:"env"`
-	AllowedHosts []string          `yaml:"allowed_hosts"`
-	HostBinary   string            `yaml:"host_binary"`
-	ManifestPath string            `yaml:"manifest_path"`
+	AllowedHosts []string          `yaml:"allowedHosts"`
+	HostBinary   string            `yaml:"hostBinary"`
+	ManifestPath string            `yaml:"manifestPath"`
 	Config       map[string]any    `yaml:"config"`
 }
 

--- a/gestaltd/internal/drivers/telemetry/otlp/otlp.go
+++ b/gestaltd/internal/drivers/telemetry/otlp/otlp.go
@@ -38,17 +38,17 @@ var _ core.TelemetryProvider = (*Provider)(nil)
 type yamlConfig struct {
 	Endpoint           string            `yaml:"endpoint"`
 	Protocol           string            `yaml:"protocol"`
-	ServiceName        string            `yaml:"service_name"`
+	ServiceName        string            `yaml:"serviceName"`
 	Insecure           bool              `yaml:"insecure"`
 	Headers            map[string]string `yaml:"headers"`
-	ResourceAttributes map[string]string `yaml:"resource_attributes"`
+	ResourceAttributes map[string]string `yaml:"resourceAttributes"`
 	Traces             tracesConfig      `yaml:"traces"`
 	Metrics            metricsConfig     `yaml:"metrics"`
 	Logs               logsConfig        `yaml:"logs"`
 }
 
 type tracesConfig struct {
-	SamplingRatio *float64 `yaml:"sampling_ratio"`
+	SamplingRatio *float64 `yaml:"samplingRatio"`
 }
 
 type metricsConfig struct {

--- a/gestaltd/internal/drivers/telemetry/stdout/stdout.go
+++ b/gestaltd/internal/drivers/telemetry/stdout/stdout.go
@@ -25,8 +25,8 @@ var _ core.TelemetryProvider = (*Provider)(nil)
 type yamlConfig struct {
 	Level              string                 `yaml:"level"`
 	Format             string                 `yaml:"format"`
-	ServiceName        string                 `yaml:"service_name"`
-	ResourceAttributes map[string]string      `yaml:"resource_attributes"`
+	ServiceName        string                 `yaml:"serviceName"`
+	ResourceAttributes map[string]string      `yaml:"resourceAttributes"`
 	Metrics            metricspipeline.Config `yaml:"metrics"`
 }
 

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -54,7 +54,7 @@ type LockEntry struct {
 	Archives    map[string]LockArchive `json:"archives,omitempty"`
 	Manifest    string                 `json:"manifest"`
 	Executable  string                 `json:"executable,omitempty"`
-	AssetRoot   string                 `json:"asset_root,omitempty"`
+	AssetRoot   string                 `json:"assetRoot,omitempty"`
 }
 
 type LockProviderEntry = LockEntry

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -235,7 +235,7 @@ func writeConfigYAML(t *testing.T, dir, source, version, artifactsDir string) st
 		"ui:",
 		"  provider: none",
 		"server:",
-		"  artifacts_dir: " + artifactsDir,
+		"  artifactsDir: " + artifactsDir,
 		"plugins:",
 		"  alpha:",
 		"    provider:",
@@ -429,8 +429,8 @@ func TestSourcePluginLoadForExecution(t *testing.T) {
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	yaml := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
 		"server:",
-		"  artifacts_dir: " + artifactsDir,
-		"  encryption_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		"plugins:",
 		"  gadget:",
 		"    provider:",
@@ -540,8 +540,8 @@ func TestSourceAuthPluginLoadForExecution(t *testing.T) {
 		"  config:",
 		"    client_id: managed-auth-client",
 		"server:",
-		"  artifacts_dir: " + artifactsDir,
-		"  encryption_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	}, "\n") + "\n"
 
 	configPath := filepath.Join(dir, "gestalt.yaml")
@@ -732,8 +732,8 @@ func TestSourceSecretsPluginBootstrapsManagedAuthSourceToken(t *testing.T) {
 		"  config:",
 		"    client_id: managed-auth-client",
 		"server:",
-		"  artifacts_dir: " + artifactsDir,
-		"  encryption_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	}, "\n") + "\n"
 
 	configPath := filepath.Join(dir, "gestalt.yaml")
@@ -893,8 +893,8 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
 		"server:",
-		"  artifacts_dir: " + artifactsDir,
-		"  encryption_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		"plugins:",
 		"  alpha:",
 		"    provider:",

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -107,7 +107,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalManifestPluginWithoutLockfile(t *te
 
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `server:
-  encryption_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 plugins:
   example:
     provider:
@@ -150,7 +150,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalMCPOAuthManifestPluginWithoutLockfi
 	manifest := []byte(`
 source: github.com/testowner/plugins/notion
 version: 0.0.1-alpha.1
-display_name: Notion
+displayName: Notion
 provider:
   connections:
     mcp:
@@ -168,7 +168,7 @@ provider:
 
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `server:
-  encryption_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 plugins:
   notion:
     provider:
@@ -285,7 +285,7 @@ datastore: sqlite
 ui:
   provider: none
 server:
-  encryption_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `, dbPath)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("WriteFile config: %v", err)
@@ -357,7 +357,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalSourceTopLevelPluginsWithoutArtifac
 	cfg := fmt.Sprintf(`auth:
   provider:
     source:
-      path: ./auth-provider.yaml
+      path: ./auth-manifest.yaml
 datastores:
   sqlite:
     driver: sqlite3
@@ -366,7 +366,7 @@ datastore: sqlite
 ui:
   provider: none
 server:
-  encryption_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `, dbPath)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("WriteFile config: %v", err)
@@ -385,8 +385,8 @@ server:
 		t.Fatalf("auth command = %q, want empty", loaded.Auth.Provider.Command)
 	}
 	authCfg := decodeNodeMap(t, loaded.Auth.Config)
-	if authCfg["manifest_path"] != authManifestPath {
-		t.Fatalf("auth manifest_path = %v, want %q", authCfg["manifest_path"], authManifestPath)
+	if authCfg["manifestPath"] != authManifestPath {
+		t.Fatalf("auth manifest_path = %v, want %q", authCfg["manifestPath"], authManifestPath)
 	}
 	if authCfg["command"] != "" {
 		t.Fatalf("auth config command = %v, want empty", authCfg["command"])
@@ -427,7 +427,7 @@ func TestLoadForExecutionAtPath_GeneratesStaticCatalogForLocalSourceHybridPlugin
 
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `server:
-  encryption_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 plugins:
   example:
     provider:
@@ -598,7 +598,7 @@ def session_catalog(request: gestalt.Request) -> gestalt.Catalog:
 	writeTestFile("manifest.yaml", manifest, 0o644)
 
 	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `server:
-  encryption_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 plugins:
   example:
     provider:
@@ -930,7 +930,7 @@ func TestApplyLockedPlugins_SkipsNilIntegrationPlugins(t *testing.T) {
 
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `server:
-  encryption_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 plugins:
   example:
     provider:

--- a/gestaltd/internal/operator/localconfig.go
+++ b/gestaltd/internal/operator/localconfig.go
@@ -65,7 +65,7 @@ secrets:
 server:
   public:
     port: 8080
-  encryption_key: %q
+  encryptionKey: %q
 `, dbPath, encryptionKey)
 }
 
@@ -84,6 +84,6 @@ secrets:
 server:
   public:
     port: 8080
-  encryption_key: %q
-`, dbPath, filepath.Join(providersDir, "web", "default", "provider.yaml"), encryptionKey)
+  encryptionKey: %q
+`, dbPath, filepath.Join(providersDir, "web", "default", "manifest.yaml"), encryptionKey)
 }

--- a/gestaltd/internal/pluginhost/manifest_core.go
+++ b/gestaltd/internal/pluginhost/manifest_core.go
@@ -32,7 +32,6 @@ func CredentialFieldsFromManifest(fields []pluginmanifestv1.CredentialField) []c
 			Name:        field.Name,
 			Label:       field.Label,
 			Description: field.Description,
-			HelpURL:     field.HelpURL,
 		}
 	}
 	return out

--- a/gestaltd/internal/pluginpkg/config.go
+++ b/gestaltd/internal/pluginpkg/config.go
@@ -45,6 +45,11 @@ func configSchemaForManifest(manifestPath string, manifest *pluginmanifestv1.Man
 			return "", "", false, nil
 		}
 		return filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(manifest.Auth.ConfigSchemaPath)), manifest.Auth.ConfigSchemaPath, true, nil
+	case pluginmanifestv1.KindDatastore:
+		if manifest.Datastore == nil || manifest.Datastore.ConfigSchemaPath == "" {
+			return "", "", false, nil
+		}
+		return filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(manifest.Datastore.ConfigSchemaPath)), manifest.Datastore.ConfigSchemaPath, true, nil
 	case pluginmanifestv1.KindSecrets:
 		if manifest.Secrets == nil || manifest.Secrets.ConfigSchemaPath == "" {
 			return "", "", false, nil

--- a/gestaltd/internal/pluginpkg/go_provider.go
+++ b/gestaltd/internal/pluginpkg/go_provider.go
@@ -485,7 +485,7 @@ func slugPluginName(value string) string {
 
 func validateSourceComponentKind(kind string) error {
 	switch kind {
-	case pluginmanifestv1.KindAuth, pluginmanifestv1.KindSecrets:
+	case pluginmanifestv1.KindAuth, pluginmanifestv1.KindDatastore, pluginmanifestv1.KindSecrets:
 		return nil
 	default:
 		return fmt.Errorf("unsupported source component kind %q", kind)
@@ -496,6 +496,8 @@ func componentServeCall(kind string) (string, error) {
 	switch kind {
 	case pluginmanifestv1.KindAuth:
 		return "gestalt.ServeAuthProvider(ctx, pluginpkg.New())", nil
+	case pluginmanifestv1.KindDatastore:
+		return "gestalt.ServeDatastoreProvider(ctx, pluginpkg.New())", nil
 	case pluginmanifestv1.KindSecrets:
 		return "gestalt.ServeSecretsProvider(ctx, pluginpkg.New())", nil
 	default:

--- a/gestaltd/internal/pluginpkg/manifest.go
+++ b/gestaltd/internal/pluginpkg/manifest.go
@@ -120,6 +120,10 @@ func ManifestKind(manifest *pluginmanifestv1.Manifest) (string, error) {
 		kind = pluginmanifestv1.KindAuth
 		count++
 	}
+	if manifest.Datastore != nil {
+		kind = pluginmanifestv1.KindDatastore
+		count++
+	}
 	if manifest.Secrets != nil {
 		kind = pluginmanifestv1.KindSecrets
 		count++
@@ -129,7 +133,7 @@ func ManifestKind(manifest *pluginmanifestv1.Manifest) (string, error) {
 		count++
 	}
 	if count != 1 {
-		return "", fmt.Errorf("manifest must define exactly one of plugin, auth, secrets, or webui")
+		return "", fmt.Errorf("manifest must define exactly one of plugin, auth, datastore, secrets, or webui")
 	}
 	return kind, nil
 }
@@ -149,7 +153,7 @@ func validateManifest(manifest *pluginmanifestv1.Manifest, sourceMode bool) erro
 		return fmt.Errorf("manifest version: %w", err)
 	}
 	if manifest.IconFile != "" {
-		if err := validateRelativePackagePath(manifest.IconFile, "icon_file"); err != nil {
+		if err := validateRelativePackagePath(manifest.IconFile, "iconFile"); err != nil {
 			return err
 		}
 	}
@@ -168,6 +172,7 @@ func validateManifest(manifest *pluginmanifestv1.Manifest, sourceMode bool) erro
 
 	allowsSourceExecutableEntrypointOmission := sourceMode && manifest.Entrypoints.Provider == nil
 	allowsSourceAuthEntrypointOmission := sourceMode && manifest.Entrypoints.Auth == nil
+	allowsSourceDatastoreEntrypointOmission := sourceMode && manifest.Entrypoints.Datastore == nil
 	allowsSourceSecretsEntrypointOmission := sourceMode && manifest.Entrypoints.Secrets == nil
 
 	needsArtifacts := len(manifest.Artifacts) > 0
@@ -176,6 +181,8 @@ func validateManifest(manifest *pluginmanifestv1.Manifest, sourceMode bool) erro
 		needsArtifacts = needsArtifacts || manifest.Entrypoints.Provider != nil
 	case pluginmanifestv1.KindAuth:
 		needsArtifacts = needsArtifacts || !allowsSourceAuthEntrypointOmission
+	case pluginmanifestv1.KindDatastore:
+		needsArtifacts = needsArtifacts || !allowsSourceDatastoreEntrypointOmission
 	case pluginmanifestv1.KindSecrets:
 		needsArtifacts = needsArtifacts || !allowsSourceSecretsEntrypointOmission
 	}
@@ -250,6 +257,23 @@ func validateManifest(manifest *pluginmanifestv1.Manifest, sourceMode bool) erro
 		}
 		if manifest.Entrypoints.Auth != nil {
 			if err := validateEntrypoint(kind, manifest.Entrypoints.Auth, artifactPaths); err != nil {
+				return err
+			}
+		}
+	case pluginmanifestv1.KindDatastore:
+		if manifest.Datastore.ConfigSchemaPath != "" {
+			if err := validateRelativePackagePath(manifest.Datastore.ConfigSchemaPath, "datastore config schema path"); err != nil {
+				return err
+			}
+		}
+		if manifest.Entrypoints.Provider != nil || manifest.Entrypoints.Auth != nil {
+			return fmt.Errorf("datastore manifests may only define entrypoints.datastore")
+		}
+		if manifest.Entrypoints.Datastore == nil && !allowsSourceDatastoreEntrypointOmission {
+			return fmt.Errorf("%s is required", EntrypointFieldForKind(kind))
+		}
+		if manifest.Entrypoints.Datastore != nil {
+			if err := validateEntrypoint(kind, manifest.Entrypoints.Datastore, artifactPaths); err != nil {
 				return err
 			}
 		}
@@ -340,6 +364,8 @@ func EntrypointFieldForKind(kind string) string {
 		return "entrypoints.provider"
 	case pluginmanifestv1.KindAuth:
 		return "entrypoints.auth"
+	case pluginmanifestv1.KindDatastore:
+		return "entrypoints.datastore"
 	case pluginmanifestv1.KindSecrets:
 		return "entrypoints.secrets"
 	default:
@@ -356,6 +382,8 @@ func EntrypointForKind(manifest *pluginmanifestv1.Manifest, kind string) *plugin
 		return manifest.Entrypoints.Provider
 	case pluginmanifestv1.KindAuth:
 		return manifest.Entrypoints.Auth
+	case pluginmanifestv1.KindDatastore:
+		return manifest.Entrypoints.Datastore
 	case pluginmanifestv1.KindSecrets:
 		return manifest.Entrypoints.Secrets
 	default:
@@ -375,6 +403,11 @@ func EnsureEntrypointForKind(manifest *pluginmanifestv1.Manifest, kind string) *
 			manifest.Entrypoints.Auth = &pluginmanifestv1.Entrypoint{}
 		}
 		return manifest.Entrypoints.Auth
+	case pluginmanifestv1.KindDatastore:
+		if manifest.Entrypoints.Datastore == nil {
+			manifest.Entrypoints.Datastore = &pluginmanifestv1.Entrypoint{}
+		}
+		return manifest.Entrypoints.Datastore
 	case pluginmanifestv1.KindSecrets:
 		if manifest.Entrypoints.Secrets == nil {
 			manifest.Entrypoints.Secrets = &pluginmanifestv1.Entrypoint{}
@@ -390,9 +423,9 @@ func validateEntrypoint(kind string, entry *pluginmanifestv1.Entrypoint, artifac
 		return fmt.Errorf("%s is required", EntrypointFieldForKind(kind))
 	}
 	if entry.ArtifactPath == "" {
-		return fmt.Errorf("%s.artifact_path is required", EntrypointFieldForKind(kind))
+		return fmt.Errorf("%s.artifactPath is required", EntrypointFieldForKind(kind))
 	}
-	if err := validateRelativePackagePath(entry.ArtifactPath, EntrypointFieldForKind(kind)+".artifact_path"); err != nil {
+	if err := validateRelativePackagePath(entry.ArtifactPath, EntrypointFieldForKind(kind)+".artifactPath"); err != nil {
 		return err
 	}
 	if len(artifactPaths) == 0 {
@@ -451,10 +484,10 @@ func validateProviderAuth(path string, auth *pluginmanifestv1.ProviderAuth) erro
 	switch auth.Type {
 	case pluginmanifestv1.AuthTypeOAuth2:
 		if auth.AuthorizationURL == "" {
-			return fmt.Errorf("%s.authorization_url is required for oauth2", path)
+			return fmt.Errorf("%s.authorizationUrl is required for oauth2", path)
 		}
 		if auth.TokenURL == "" {
-			return fmt.Errorf("%s.token_url is required for oauth2", path)
+			return fmt.Errorf("%s.tokenUrl is required for oauth2", path)
 		}
 	case pluginmanifestv1.AuthTypeMCPOAuth, pluginmanifestv1.AuthTypeBearer, pluginmanifestv1.AuthTypeManual, pluginmanifestv1.AuthTypeNone:
 	default:
@@ -495,11 +528,11 @@ func validateExecutableProviderMetadata(provider *pluginmanifestv1.Plugin) error
 	switch provider.ConnectionMode {
 	case "", "none", "user", "identity", "either":
 	default:
-		return fmt.Errorf("unsupported provider.connection_mode %q", provider.ConnectionMode)
+		return fmt.Errorf("unsupported provider.connectionMode %q", provider.ConnectionMode)
 	}
 	if provider.DefaultConnection != "" {
 		if _, ok := provider.Connections[provider.DefaultConnection]; !ok {
-			return fmt.Errorf("provider.default_connection %q references undefined provider.connections entry", provider.DefaultConnection)
+			return fmt.Errorf("provider.defaultConnection %q references undefined provider.connections entry", provider.DefaultConnection)
 		}
 	}
 	if len(provider.Connections) > 0 {
@@ -513,7 +546,7 @@ func validateExecutableProviderMetadata(provider *pluginmanifestv1.Plugin) error
 		field   string
 		present bool
 	}{
-		{field: "provider.base_url", present: provider.BaseURL != "" && !provider.IsDeclarative() && provider.OpenAPI == ""},
+		{field: "provider.baseUrl", present: provider.BaseURL != "" && !provider.IsDeclarative() && provider.OpenAPI == ""},
 		{field: "provider.operations", present: len(provider.Operations) > 0 && !provider.IsDeclarative()},
 	}
 	for _, check := range checks {
@@ -540,7 +573,7 @@ var validHTTPMethods = map[string]bool{
 
 func validateDeclarativeProvider(provider *pluginmanifestv1.Plugin) error {
 	if provider.BaseURL == "" {
-		return fmt.Errorf("provider.base_url is required for declarative providers")
+		return fmt.Errorf("provider.baseUrl is required for declarative providers")
 	}
 	seen := make(map[string]struct{}, len(provider.Operations))
 	for i, op := range provider.Operations {
@@ -666,6 +699,9 @@ func normalizeLegacyManifestCompatibility(data []byte, format string) ([]byte, b
 	if normalizeLegacyProviderResponseMapping(root) {
 		changed = true
 	}
+	if normalizeSnakeCaseKeys(root) {
+		changed = true
+	}
 	if !changed {
 		return data, false, nil
 	}
@@ -688,14 +724,57 @@ func normalizeLegacyManifestCompatibility(data []byte, format string) ([]byte, b
 	}
 }
 
+func normalizeSnakeCaseKeys(m map[string]any) bool {
+	changed := false
+	for key, val := range m {
+		camel := snakeToCamel(key)
+		if camel != key {
+			delete(m, key)
+			m[camel] = val
+			changed = true
+		}
+		switch v := val.(type) {
+		case map[string]any:
+			if normalizeSnakeCaseKeys(v) {
+				changed = true
+			}
+		case []any:
+			for _, item := range v {
+				if sub, ok := item.(map[string]any); ok {
+					if normalizeSnakeCaseKeys(sub) {
+						changed = true
+					}
+				}
+			}
+		}
+	}
+	return changed
+}
+
+func snakeToCamel(s string) string {
+	if !strings.Contains(s, "_") {
+		return s
+	}
+	parts := strings.Split(s, "_")
+	for i := 1; i < len(parts); i++ {
+		if len(parts[i]) > 0 {
+			parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
+		}
+	}
+	return strings.Join(parts, "")
+}
+
 func normalizeLegacyProviderResponseMapping(root map[string]any) bool {
 	provider, ok := root["provider"].(map[string]any)
 	if !ok {
 		return false
 	}
-	responseMapping, ok := provider["response_mapping"].(map[string]any)
+	responseMapping, ok := provider["responseMapping"].(map[string]any)
 	if !ok {
-		return false
+		responseMapping, ok = provider["response_mapping"].(map[string]any)
+		if !ok {
+			return false
+		}
 	}
 	pagination, ok := responseMapping["pagination"].(map[string]any)
 	if !ok {
@@ -705,8 +784,8 @@ func normalizeLegacyProviderResponseMapping(root map[string]any) bool {
 	changed := false
 	if path, ok := pagination["has_more_path"].(string); ok {
 		delete(pagination, "has_more_path")
-		if _, exists := pagination["has_more"]; !exists {
-			pagination["has_more"] = map[string]any{
+		if _, exists := pagination["hasMore"]; !exists {
+			pagination["hasMore"] = map[string]any{
 				"source": "body",
 				"path":   path,
 			}

--- a/gestaltd/internal/pluginpkg/manifest_compat_test.go
+++ b/gestaltd/internal/pluginpkg/manifest_compat_test.go
@@ -38,7 +38,7 @@ auth: {}
 			data: []byte(`
 source: github.com/acme/providers/datastore
 version: 0.0.1-alpha.1
-display_name: Datastore
+displayName: Datastore
 kinds:
   - datastore
 datastore: {}
@@ -49,7 +49,7 @@ artifacts:
     sha256: deadbeef
 entrypoints:
   datastore:
-    artifact_path: gestalt-plugin-datastore
+    artifactPath: gestalt-plugin-datastore
 `),
 			decode: decodeManifestCompat,
 			assert: func(t *testing.T, manifest *testManifestCompat) {
@@ -77,7 +77,7 @@ artifacts:
     sha256: cafebabe
 entrypoints:
   secrets:
-    artifact_path: gestalt-plugin-secrets
+    artifactPath: gestalt-plugin-secrets
 `),
 			decode: decodeManifestCompat,
 			assert: func(t *testing.T, manifest *testManifestCompat) {
@@ -113,8 +113,8 @@ func TestDecodeManifestCompatibility_MapsLegacyProviderResponsePaginationPaths(t
 source: github.com/acme/providers/ashby
 version: 0.0.1-alpha.1
 provider:
-  response_mapping:
-    data_path: results
+  responseMapping:
+    dataPath: results
     pagination:
       has_more_path: moreDataAvailable
       cursor_path: nextCursor

--- a/gestaltd/internal/pluginpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/pluginpkg/manifest_workflow_test.go
@@ -244,7 +244,7 @@ func TestManifestWorkflow_RejectsInvalidPackageInputs(t *testing.T) {
 				mustWriteFile(t, filepath.Join(dir, filepath.FromSlash(artifactPath)), []byte("provider"), 0o755)
 				return mustWriteManifestData(t, dir, ManifestFile, mustRawManifestJSON(t, manifest))
 			},
-			wantError: "icon_file must stay within the package",
+			wantError: "iconFile must stay within the package",
 		},
 		{
 			name: "rejects unsupported auth type",
@@ -273,7 +273,7 @@ func TestManifestWorkflow_RejectsInvalidPackageInputs(t *testing.T) {
 				mustWriteFile(t, filepath.Join(dir, filepath.FromSlash(artifactPath)), []byte("provider"), 0o755)
 				return mustWriteManifestData(t, dir, ManifestFile, mustRawManifestJSON(t, manifest))
 			},
-			wantError: "provider.auth.token_url is required for oauth2",
+			wantError: "provider.auth.tokenUrl is required for oauth2",
 		},
 	}
 
@@ -303,9 +303,9 @@ func TestManifestWorkflow_AcceptsProviderWireSurfaceManifest(t *testing.T) {
 	manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
 source: github.com/acme/plugins/provider-wire
 version: 1.0.0
-display_name: Provider Wire
+displayName: Provider Wire
 provider:
-  config_schema_path: schemas/config.schema.json
+  configSchemaPath: schemas/config.schema.json
   connections:
     default:
       auth:
@@ -313,21 +313,21 @@ provider:
     api:
       auth:
         type: oauth2
-        authorization_url: https://auth.example.com/authorize
-        token_url: https://auth.example.com/token
-  managed_parameters:
+        authorizationUrl: https://auth.example.com/authorize
+        tokenUrl: https://auth.example.com/token
+  managedParameters:
     - in: path
       name: workspaceId
       value: ws_123
   pagination:
     style: cursor
-    cursor_param: cursor
+    cursorParam: cursor
     cursor:
       source: header
       path: X-After-Cursor
-    results_path: results
-    max_pages: 10
-  allowed_operations:
+    resultsPath: results
+    maxPages: 10
+  allowedOperations:
     items.list:
       paginate: true
     items.info: {}
@@ -374,7 +374,7 @@ func TestManifestWorkflow_AcceptsProviderWireMCPOAuthManifestAcrossDirectoryAndA
 	manifestPath := mustWriteManifestData(t, sourceDir, "manifest.yaml", []byte(`
 source: github.com/acme/plugins/notion
 version: 0.0.1-alpha.1
-display_name: Notion
+displayName: Notion
 provider:
   connections:
     mcp:
@@ -448,7 +448,7 @@ func TestManifestWorkflow_NamedConnectionParamsAndDiscovery(t *testing.T) {
 	manifestPath := mustWriteManifestData(t, dir, "plugin.yaml", []byte(`
 source: github.com/acme/plugins/multi-conn
 version: 1.0.0
-display_name: Multi Connection
+displayName: Multi Connection
 provider:
   connections:
     default:
@@ -458,8 +458,8 @@ provider:
       mode: user
       auth:
         type: oauth2
-        authorization_url: https://auth.example.com/authorize
-        token_url: https://auth.example.com/token
+        authorizationUrl: https://auth.example.com/authorize
+        tokenUrl: https://auth.example.com/token
       params:
         workspace_id:
           required: true
@@ -468,8 +468,8 @@ provider:
           from: discovery
       discovery:
         url: https://api.example.com/workspaces
-        id_path: id
-        name_path: name
+        idPath: id
+        namePath: name
         metadata:
           region: region
   surfaces:

--- a/gestaltd/internal/pluginpkg/provider_manifest_wire.go
+++ b/gestaltd/internal/pluginpkg/provider_manifest_wire.go
@@ -13,9 +13,9 @@ import (
 type providerManifestWireRoot struct {
 	Source      string                            `json:"source,omitempty" yaml:"source,omitempty"`
 	Version     string                            `json:"version" yaml:"version"`
-	DisplayName string                            `json:"display_name,omitempty" yaml:"display_name,omitempty"`
+	DisplayName string                            `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	Description string                            `json:"description,omitempty" yaml:"description,omitempty"`
-	IconFile    string                            `json:"icon_file,omitempty" yaml:"icon_file,omitempty"`
+	IconFile    string                            `json:"iconFile,omitempty" yaml:"iconFile,omitempty"`
 	Release     *pluginmanifestv1.ReleaseMetadata `json:"release,omitempty" yaml:"release,omitempty"`
 	Provider    *providerManifestWire             `json:"provider,omitempty" yaml:"provider,omitempty"`
 	WebUI       *pluginmanifestv1.WebUIMetadata   `json:"webui,omitempty" yaml:"webui,omitempty"`
@@ -23,20 +23,20 @@ type providerManifestWireRoot struct {
 }
 
 type providerManifestWire struct {
-	ConfigSchemaPath  string                                                 `json:"config_schema_path,omitempty" yaml:"config_schema_path,omitempty"`
+	ConfigSchemaPath  string                                                 `json:"configSchemaPath,omitempty" yaml:"configSchemaPath,omitempty"`
 	Exec              *providerExecWire                                      `json:"exec,omitempty" yaml:"exec,omitempty"`
 	Connections       map[string]*providerManifestConnectionWire             `json:"connections,omitempty" yaml:"connections,omitempty"`
 	Headers           map[string]string                                      `json:"headers,omitempty" yaml:"headers,omitempty"`
-	ManagedParameters []pluginmanifestv1.ManagedParameter                    `json:"managed_parameters,omitempty" yaml:"managed_parameters,omitempty"`
-	ResponseMapping   *pluginmanifestv1.ManifestResponseMapping              `json:"response_mapping,omitempty" yaml:"response_mapping,omitempty"`
+	ManagedParameters []pluginmanifestv1.ManagedParameter                    `json:"managedParameters,omitempty" yaml:"managedParameters,omitempty"`
+	ResponseMapping   *pluginmanifestv1.ManifestResponseMapping              `json:"responseMapping,omitempty" yaml:"responseMapping,omitempty"`
 	Pagination        *pluginmanifestv1.ManifestPaginationConfig             `json:"pagination,omitempty" yaml:"pagination,omitempty"`
-	AllowedOperations map[string]*pluginmanifestv1.ManifestOperationOverride `json:"allowed_operations,omitempty" yaml:"allowed_operations,omitempty"`
+	AllowedOperations map[string]*pluginmanifestv1.ManifestOperationOverride `json:"allowedOperations,omitempty" yaml:"allowedOperations,omitempty"`
 	Surfaces          providerManifestSurfacesWire                           `json:"surfaces,omitempty" yaml:"surfaces,omitempty"`
 	MCP               *providerManifestMCPWire                               `json:"mcp,omitempty" yaml:"mcp,omitempty"`
 }
 
 type providerExecWire struct {
-	ArtifactPath string   `json:"artifact_path" yaml:"artifact_path"`
+	ArtifactPath string   `json:"artifactPath" yaml:"artifactPath"`
 	Args         []string `json:"args,omitempty" yaml:"args,omitempty"`
 }
 
@@ -49,8 +49,8 @@ type providerManifestConnectionWire struct {
 
 type providerManifestDiscoveryWire struct {
 	URL      string            `json:"url" yaml:"url"`
-	IDPath   string            `json:"id_path,omitempty" yaml:"id_path,omitempty"`
-	NamePath string            `json:"name_path,omitempty" yaml:"name_path,omitempty"`
+	IDPath   string            `json:"idPath,omitempty" yaml:"idPath,omitempty"`
+	NamePath string            `json:"namePath,omitempty" yaml:"namePath,omitempty"`
 	Metadata map[string]string `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 }
 
@@ -63,14 +63,14 @@ type providerManifestSurfacesWire struct {
 
 type providerManifestRESTSurfaceWire struct {
 	Connection string                               `json:"connection,omitempty" yaml:"connection,omitempty"`
-	BaseURL    string                               `json:"base_url" yaml:"base_url"`
+	BaseURL    string                               `json:"baseUrl" yaml:"baseUrl"`
 	Operations []pluginmanifestv1.ProviderOperation `json:"operations" yaml:"operations"`
 }
 
 type providerManifestOpenAPISurfaceWire struct {
 	Connection string `json:"connection,omitempty" yaml:"connection,omitempty"`
 	Document   string `json:"document" yaml:"document"`
-	BaseURL    string `json:"base_url,omitempty" yaml:"base_url,omitempty"`
+	BaseURL    string `json:"baseUrl,omitempty" yaml:"baseUrl,omitempty"`
 }
 
 type providerManifestGraphQLSurfaceWire struct {

--- a/gestaltd/internal/pluginpkg/python_provider.go
+++ b/gestaltd/internal/pluginpkg/python_provider.go
@@ -257,6 +257,7 @@ func SplitPythonProviderTarget(target string) (module string, attr string, err e
 const (
 	pythonRuntimeKindIntegration = "integration"
 	pythonRuntimeKindAuth        = "auth"
+	pythonRuntimeKindDatastore   = "datastore"
 	pythonRuntimeKindSecrets     = "secrets"
 )
 
@@ -266,6 +267,8 @@ func pythonRuntimeKind(kind string) (string, error) {
 		return pythonRuntimeKindIntegration, nil
 	case pluginmanifestv1.KindAuth:
 		return pythonRuntimeKindAuth, nil
+	case pluginmanifestv1.KindDatastore:
+		return pythonRuntimeKindDatastore, nil
 	case pluginmanifestv1.KindSecrets:
 		return pythonRuntimeKindSecrets, nil
 	default:

--- a/gestaltd/internal/pluginpkg/rust_provider.go
+++ b/gestaltd/internal/pluginpkg/rust_provider.go
@@ -313,6 +313,8 @@ func rustServeFunction(kind string) (string, bool, error) {
 		return "__gestalt_serve", true, nil
 	case pluginmanifestv1.KindAuth:
 		return "__gestalt_serve_auth", false, nil
+	case pluginmanifestv1.KindDatastore:
+		return "__gestalt_serve_datastore", false, nil
 	case pluginmanifestv1.KindSecrets:
 		return "__gestalt_serve_secrets", false, nil
 	default:
@@ -322,7 +324,7 @@ func rustServeFunction(kind string) (string, bool, error) {
 
 func rustBinaryName(kind string) string {
 	switch kind {
-	case pluginmanifestv1.KindAuth, pluginmanifestv1.KindSecrets:
+	case pluginmanifestv1.KindAuth, pluginmanifestv1.KindDatastore, pluginmanifestv1.KindSecrets:
 		return kind
 	default:
 		return "provider"

--- a/gestaltd/internal/pluginpkg/typescript_provider.go
+++ b/gestaltd/internal/pluginpkg/typescript_provider.go
@@ -174,6 +174,8 @@ func typeScriptComponentKind(kind string) (string, error) {
 	switch kind {
 	case pluginmanifestv1.KindAuth:
 		return "auth", nil
+	case pluginmanifestv1.KindDatastore:
+		return "datastore", nil
 	case pluginmanifestv1.KindSecrets:
 		return "secrets", nil
 	default:

--- a/gestaltd/internal/provider/build.go
+++ b/gestaltd/internal/provider/build.go
@@ -87,7 +87,7 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 			base.ConnMode = core.ConnectionMode(connMode)
 		}
 	default:
-		return nil, fmt.Errorf("%s: unknown connection_mode %q", def.Provider, connMode)
+		return nil, fmt.Errorf("%s: unknown connectionMode %q", def.Provider, connMode)
 	}
 
 	switch def.AuthStyle {
@@ -99,7 +99,7 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 	case "basic":
 		base.AuthStyle = coreintegration.AuthStyleBasic
 	default:
-		return nil, fmt.Errorf("%s: unknown auth_style %q", def.Provider, def.AuthStyle)
+		return nil, fmt.Errorf("%s: unknown authStyle %q", def.Provider, def.AuthStyle)
 	}
 
 	switch {
@@ -125,7 +125,7 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 	case def.AuthMapping != nil && (len(def.AuthMapping.Headers) > 0 || def.AuthMapping.Basic != nil):
 		if base.AuthStyle != coreintegration.AuthStyleBasic {
 			if def.AuthMapping.Basic != nil {
-				return nil, fmt.Errorf("%s: auth_mapping.basic requires auth_style basic", def.Provider)
+				return nil, fmt.Errorf("%s: authMapping.basic requires authStyle basic", def.Provider)
 			}
 		}
 		base.TokenParser = MappedCredentialParser(def.AuthMapping)
@@ -167,7 +167,6 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 				Name:        cf.Name,
 				Label:       cf.Label,
 				Description: cf.Description,
-				HelpURL:     cf.HelpURL,
 			}
 		}
 	}
@@ -248,7 +247,7 @@ func ApplyConnectionAuth(def *Definition, conn config.ConnectionDef) {
 func parseMappedToken(token string) (map[string]any, error) {
 	var tokenData map[string]any
 	if err := json.Unmarshal([]byte(token), &tokenData); err != nil {
-		return nil, fmt.Errorf("parsing token as JSON for auth_mapping: %w", err)
+		return nil, fmt.Errorf("parsing token as JSON for authMapping: %w", err)
 	}
 	return tokenData, nil
 }
@@ -264,7 +263,7 @@ func MappedCredentialParser(mapping *AuthMappingDef) func(string) (string, map[s
 			for headerName, value := range mapping.Headers {
 				resolved, err := resolveAuthValue(value, token, &tokenData)
 				if err != nil {
-					return "", nil, fmt.Errorf("auth_mapping.headers[%q]: %w", headerName, err)
+					return "", nil, fmt.Errorf("authMapping.headers[%q]: %w", headerName, err)
 				}
 				headers[headerName] = resolved
 			}
@@ -273,11 +272,11 @@ func MappedCredentialParser(mapping *AuthMappingDef) func(string) (string, map[s
 		if mapping.Basic != nil {
 			username, err := resolveAuthValue(mapping.Basic.Username, token, &tokenData)
 			if err != nil {
-				return "", nil, fmt.Errorf("auth_mapping.basic.username: %w", err)
+				return "", nil, fmt.Errorf("authMapping.basic.username: %w", err)
 			}
 			password, err := resolveAuthValue(mapping.Basic.Password, token, &tokenData)
 			if err != nil {
-				return "", nil, fmt.Errorf("auth_mapping.basic.password: %w", err)
+				return "", nil, fmt.Errorf("authMapping.basic.password: %w", err)
 			}
 			credential := fmt.Sprintf("%s:%s", username, password)
 			authToken = "Basic " + base64.StdEncoding.EncodeToString([]byte(credential))
@@ -347,7 +346,7 @@ func BuildOAuthUpstream(def *Definition, conn config.ConnectionDef, baseURL stri
 	case "json":
 		tokenExchange = oauth.TokenExchangeJSON
 	default:
-		return nil, fmt.Errorf("unknown token_exchange %q", def.Auth.TokenExchange)
+		return nil, fmt.Errorf("unknown tokenExchange %q", def.Auth.TokenExchange)
 	}
 
 	authURL := resolveURL(baseURL, def.Auth.AuthorizationURL)

--- a/gestaltd/internal/provider/build_test.go
+++ b/gestaltd/internal/provider/build_test.go
@@ -919,7 +919,7 @@ func TestBuildCredentialFields(t *testing.T) {
 		BaseURL:     "https://api.example.com",
 		Auth:        AuthDef{Type: "manual"},
 		CredentialFields: []CredentialFieldDef{
-			{Name: "api_key", Label: "API Key", HelpURL: "https://example.com/keys"},
+			{Name: "api_key", Label: "API Key"},
 			{Name: "app_key", Label: "App Key", Description: "Your application key"},
 		},
 		Operations: map[string]OperationDef{
@@ -941,7 +941,7 @@ func TestBuildCredentialFields(t *testing.T) {
 	if len(fields) != 2 {
 		t.Fatalf("got %d credential fields, want 2", len(fields))
 	}
-	if fields[0].Name != "api_key" || fields[0].Label != "API Key" || fields[0].HelpURL != "https://example.com/keys" {
+	if fields[0].Name != "api_key" || fields[0].Label != "API Key" {
 		t.Errorf("field[0] = %+v", fields[0])
 	}
 	if fields[1].Name != "app_key" || fields[1].Description != "Your application key" {
@@ -965,7 +965,7 @@ func TestBuildCredentialFieldsFromConfig(t *testing.T) {
 	conn := config.ConnectionDef{
 		Auth: config.ConnectionAuthDef{
 			Credentials: []config.CredentialFieldDef{
-				{Name: "token", Label: "Access Token", HelpURL: "https://example.com/tokens"},
+				{Name: "token", Label: "Access Token"},
 			},
 		},
 	}

--- a/gestaltd/internal/provider/definition.go
+++ b/gestaltd/internal/provider/definition.go
@@ -9,40 +9,40 @@ import (
 
 type Definition struct {
 	Provider         string            `yaml:"provider" json:"provider"`
-	DisplayName      string            `yaml:"display_name" json:"display_name"`
+	DisplayName      string            `yaml:"displayName" json:"displayName"`
 	Description      string            `yaml:"description" json:"description"`
-	IconSVG          string            `yaml:"icon_svg" json:"icon_svg"`
-	ConnectionMode   string            `yaml:"connection_mode" json:"connection_mode"`
-	BaseURL          string            `yaml:"base_url" json:"base_url"`
+	IconSVG          string            `yaml:"iconSvg" json:"iconSvg"`
+	ConnectionMode   string            `yaml:"connectionMode" json:"connectionMode"`
+	BaseURL          string            `yaml:"baseUrl" json:"baseUrl"`
 	Auth             AuthDef           `yaml:"auth" json:"auth"`
-	AuthStyle        string            `yaml:"auth_style" json:"auth_style"` // bearer (default), raw, none, basic
-	AuthHeader       string            `yaml:"auth_header" json:"auth_header"`
-	TokenPrefix      string            `yaml:"token_prefix" json:"token_prefix"`
+	AuthStyle        string            `yaml:"authStyle" json:"authStyle"` // bearer (default), raw, none, basic
+	AuthHeader       string            `yaml:"authHeader" json:"authHeader"`
+	TokenPrefix      string            `yaml:"tokenPrefix" json:"tokenPrefix"`
 	Headers          map[string]string `yaml:"headers" json:"headers"`
-	AuthMapping      *AuthMappingDef   `yaml:"auth_mapping" json:"auth_mapping"`
-	ErrorMessagePath string            `yaml:"error_message_path" json:"error_message_path"`
+	AuthMapping      *AuthMappingDef   `yaml:"authMapping" json:"authMapping"`
+	ErrorMessagePath string            `yaml:"errorMessagePath" json:"errorMessagePath"`
 
-	ResponseCheck    *ResponseCheckDef    `yaml:"response_check" json:"response_check,omitempty"`
-	ManualAuth       bool                 `yaml:"manual_auth" json:"manual_auth"`
-	CredentialFields []CredentialFieldDef `yaml:"credential_fields" json:"credential_fields,omitempty"`
+	ResponseCheck    *ResponseCheckDef    `yaml:"responseCheck" json:"responseCheck,omitempty"`
+	ManualAuth       bool                 `yaml:"manualAuth" json:"manualAuth"`
+	CredentialFields []CredentialFieldDef `yaml:"credentialFields" json:"credentialFields,omitempty"`
 
 	Discovery       *DiscoveryDef       `yaml:"discovery" json:"discovery,omitempty"`
-	ResponseMapping *ResponseMappingDef `yaml:"response_mapping" json:"response_mapping,omitempty"`
+	ResponseMapping *ResponseMappingDef `yaml:"responseMapping" json:"responseMapping,omitempty"`
 
 	Connection map[string]ConnectionParamDef `yaml:"connection" json:"connection"`
 	Operations map[string]OperationDef       `yaml:"operations" json:"operations"`
 }
 
 type ResponseCheckDef struct {
-	SuccessBodyMatch map[string]any `yaml:"success_body_match" json:"success_body_match,omitempty"`
-	ErrorMessagePath string         `yaml:"error_message_path" json:"error_message_path,omitempty"`
+	SuccessBodyMatch map[string]any `yaml:"successBodyMatch" json:"successBodyMatch,omitempty"`
+	ErrorMessagePath string         `yaml:"errorMessagePath" json:"errorMessagePath,omitempty"`
 }
 
 type DiscoveryDef struct {
 	URL       string            `yaml:"url" json:"url"`
-	ItemsPath string            `yaml:"items_path" json:"items_path"`
-	IDPath    string            `yaml:"id_path" json:"id_path"`
-	NamePath  string            `yaml:"name_path" json:"name_path"`
+	ItemsPath string            `yaml:"itemsPath" json:"itemsPath"`
+	IDPath    string            `yaml:"idPath" json:"idPath"`
+	NamePath  string            `yaml:"namePath" json:"namePath"`
 	Metadata  map[string]string `yaml:"metadata" json:"metadata"`
 }
 
@@ -66,21 +66,21 @@ type ConnectionParamDef struct {
 
 type AuthDef struct {
 	Type                string            `yaml:"type" json:"type"` // oauth2, manual
-	AuthorizationURL    string            `yaml:"authorization_url" json:"authorization_url"`
-	TokenURL            string            `yaml:"token_url" json:"token_url"`
-	ClientAuth          string            `yaml:"client_auth" json:"client_auth"`       // body (default), header
-	TokenExchange       string            `yaml:"token_exchange" json:"token_exchange"` // form (default), json
+	AuthorizationURL    string            `yaml:"authorizationUrl" json:"authorizationUrl"`
+	TokenURL            string            `yaml:"tokenUrl" json:"tokenUrl"`
+	ClientAuth          string            `yaml:"clientAuth" json:"clientAuth"`       // body (default), header
+	TokenExchange       string            `yaml:"tokenExchange" json:"tokenExchange"` // form (default), json
 	Scopes              []string          `yaml:"scopes" json:"scopes"`
-	ScopeParam          string            `yaml:"scope_param" json:"scope_param"`
-	ScopeSeparator      string            `yaml:"scope_separator" json:"scope_separator"`
+	ScopeParam          string            `yaml:"scopeParam" json:"scopeParam"`
+	ScopeSeparator      string            `yaml:"scopeSeparator" json:"scopeSeparator"`
 	PKCE                bool              `yaml:"pkce" json:"pkce"`
-	AuthorizationParams map[string]string `yaml:"authorization_params" json:"authorization_params"`
-	TokenParams         map[string]string `yaml:"token_params" json:"token_params"`
-	RefreshParams       map[string]string `yaml:"refresh_params" json:"refresh_params"`
-	AcceptHeader        string            `yaml:"accept_header" json:"accept_header"`
-	TokenMetadata       []string          `yaml:"token_metadata" json:"token_metadata"`
-	AccessTokenPath     string            `yaml:"access_token_path" json:"access_token_path,omitempty"`
-	ResponseCheck       *ResponseCheckDef `yaml:"response_check" json:"response_check,omitempty"`
+	AuthorizationParams map[string]string `yaml:"authorizationParams" json:"authorizationParams"`
+	TokenParams         map[string]string `yaml:"tokenParams" json:"tokenParams"`
+	RefreshParams       map[string]string `yaml:"refreshParams" json:"refreshParams"`
+	AcceptHeader        string            `yaml:"acceptHeader" json:"acceptHeader"`
+	TokenMetadata       []string          `yaml:"tokenMetadata" json:"tokenMetadata"`
+	AccessTokenPath     string            `yaml:"accessTokenPath" json:"accessTokenPath,omitempty"`
+	ResponseCheck       *ResponseCheckDef `yaml:"responseCheck" json:"responseCheck,omitempty"`
 }
 
 type OperationDef struct {
@@ -88,9 +88,9 @@ type OperationDef struct {
 	Method      string          `yaml:"method" json:"method"`
 	Path        string          `yaml:"path" json:"path"`
 	Parameters  []ParameterDef  `yaml:"parameters" json:"parameters"`
-	Query       string          `yaml:"query" json:"query"`                         // GraphQL query/mutation template
-	Transport   string          `yaml:"transport" json:"transport"`                 // "rest" (default) or "graphql"
-	InputSchema json.RawMessage `yaml:"input_schema" json:"input_schema,omitempty"` // pre-built JSON Schema (skips synthesis)
+	Query       string          `yaml:"query" json:"query"`                       // GraphQL query/mutation template
+	Transport   string          `yaml:"transport" json:"transport"`               // "rest" (default) or "graphql"
+	InputSchema json.RawMessage `yaml:"inputSchema" json:"inputSchema,omitempty"` // pre-built JSON Schema (skips synthesis)
 	Pagination  *PaginationDef  `yaml:"pagination" json:"pagination"`
 }
 
@@ -107,29 +107,29 @@ type ValueSelectorDef struct {
 
 type PaginationDef struct {
 	Style        string            `yaml:"style" json:"style"`
-	CursorParam  string            `yaml:"cursor_param" json:"cursor_param"`
+	CursorParam  string            `yaml:"cursorParam" json:"cursorParam"`
 	Cursor       *ValueSelectorDef `yaml:"cursor" json:"cursor,omitempty"`
-	LimitParam   string            `yaml:"limit_param" json:"limit_param"`
-	DefaultLimit int               `yaml:"default_limit" json:"default_limit"`
-	ResultsPath  string            `yaml:"results_path" json:"results_path"`
-	MaxPages     int               `yaml:"max_pages" json:"max_pages"`
+	LimitParam   string            `yaml:"limitParam" json:"limitParam"`
+	DefaultLimit int               `yaml:"defaultLimit" json:"defaultLimit"`
+	ResultsPath  string            `yaml:"resultsPath" json:"resultsPath"`
+	MaxPages     int               `yaml:"maxPages" json:"maxPages"`
 }
 
 type CredentialFieldDef = pluginmanifestv1.CredentialField
 
 type ResponseMappingDef struct {
-	DataPath   string                `yaml:"data_path" json:"data_path"`
+	DataPath   string                `yaml:"dataPath" json:"dataPath"`
 	Pagination *PaginationMappingDef `yaml:"pagination" json:"pagination,omitempty"`
 }
 
 type PaginationMappingDef struct {
-	HasMore *ValueSelectorDef `yaml:"has_more" json:"has_more,omitempty"`
+	HasMore *ValueSelectorDef `yaml:"hasMore" json:"hasMore,omitempty"`
 	Cursor  *ValueSelectorDef `yaml:"cursor" json:"cursor,omitempty"`
 }
 
 type ParameterDef struct {
 	Name        string `yaml:"name" json:"name"`
-	WireName    string `yaml:"wire_name,omitempty" json:"wire_name,omitempty"`
+	WireName    string `yaml:"wireName,omitempty" json:"wireName,omitempty"`
 	Type        string `yaml:"type" json:"type"`
 	Location    string `yaml:"location,omitempty" json:"location,omitempty"`
 	Description string `yaml:"description" json:"description"`

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -53,26 +53,25 @@ type credentialFieldInfo struct {
 	Name        string `json:"name"`
 	Label       string `json:"label,omitempty"`
 	Description string `json:"description,omitempty"`
-	HelpURL     string `json:"help_url,omitempty"`
 }
 
 type connectionDefInfo struct {
 	Name             string                `json:"name"`
-	AuthTypes        []string              `json:"auth_types"`
-	CredentialFields []credentialFieldInfo `json:"credential_fields,omitempty"`
+	AuthTypes        []string              `json:"authTypes"`
+	CredentialFields []credentialFieldInfo `json:"credentialFields,omitempty"`
 }
 
 type integrationInfo struct {
 	Name             string                         `json:"name"`
-	DisplayName      string                         `json:"display_name,omitempty"`
+	DisplayName      string                         `json:"displayName,omitempty"`
 	Description      string                         `json:"description,omitempty"`
-	IconSVG          string                         `json:"icon_svg,omitempty"`
+	IconSVG          string                         `json:"iconSvg,omitempty"`
 	Connected        bool                           `json:"connected"`
 	Instances        []instanceInfo                 `json:"instances,omitempty"`
-	AuthTypes        []string                       `json:"auth_types"`
-	ConnectionParams map[string]connectionParamInfo `json:"connection_params,omitempty"`
+	AuthTypes        []string                       `json:"authTypes"`
+	ConnectionParams map[string]connectionParamInfo `json:"connectionParams,omitempty"`
 	Connections      []connectionDefInfo            `json:"connections,omitempty"`
-	CredentialFields []credentialFieldInfo          `json:"credential_fields,omitempty"`
+	CredentialFields []credentialFieldInfo          `json:"credentialFields,omitempty"`
 }
 
 type connectionParamInfo struct {

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -17,13 +17,13 @@ import (
 
 type loginRequest struct {
 	State        string `json:"state"`
-	CallbackPort int    `json:"callback_port,omitempty"`
+	CallbackPort int    `json:"callbackPort,omitempty"`
 }
 
 type authInfoResponse struct {
 	Provider       string `json:"provider"`
-	DisplayName    string `json:"display_name"`
-	LoginSupported bool   `json:"login_supported"`
+	DisplayName    string `json:"displayName"`
+	LoginSupported bool   `json:"loginSupported"`
 }
 
 func (s *Server) authProviderName() string {
@@ -305,8 +305,8 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := map[string]any{
-		"email":        identity.Email,
-		"display_name": identity.DisplayName,
+		"email":       identity.Email,
+		"displayName": identity.DisplayName,
 	}
 
 	token, err := s.issueSessionToken(identity)

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -22,7 +22,7 @@ type connectManualRequest struct {
 	Instance         string            `json:"instance"`
 	Credential       string            `json:"credential"`
 	Credentials      map[string]string `json:"credentials"`
-	ConnectionParams map[string]string `json:"connection_params"`
+	ConnectionParams map[string]string `json:"connectionParams"`
 }
 
 func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
@@ -235,8 +235,8 @@ type tokenMaterial struct {
 type postConnectResult struct {
 	Status       string                   `json:"status"`
 	Integration  string                   `json:"integration,omitempty"`
-	SelectionURL string                   `json:"selection_url,omitempty"`
-	PendingToken string                   `json:"pending_token,omitempty"`
+	SelectionURL string                   `json:"selectionUrl,omitempty"`
+	PendingToken string                   `json:"pendingToken,omitempty"`
 	Candidates   []discoveryCandidateInfo `json:"candidates,omitempty"`
 }
 

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -20,7 +20,7 @@ type startOAuthRequest struct {
 	Connection       string            `json:"connection"`
 	Instance         string            `json:"instance"`
 	Scopes           []string          `json:"scopes"`
-	ConnectionParams map[string]string `json:"connection_params"`
+	ConnectionParams map[string]string `json:"connectionParams"`
 }
 
 func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -23,7 +23,7 @@ type createTokenResponse struct {
 	ID        string     `json:"id"`
 	Name      string     `json:"name"`
 	Token     string     `json:"token"`
-	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
 }
 
 func (s *Server) createAPIToken(w http.ResponseWriter, r *http.Request) {
@@ -83,8 +83,8 @@ type apiTokenInfo struct {
 	ID        string     `json:"id"`
 	Name      string     `json:"name"`
 	Scopes    string     `json:"scopes"`
-	CreatedAt time.Time  `json:"created_at"`
-	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	CreatedAt time.Time  `json:"createdAt"`
+	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
 }
 
 func (s *Server) listAPITokens(w http.ResponseWriter, r *http.Request) {
@@ -243,7 +243,6 @@ func credentialFieldInfosFromProvider(prov core.Provider) []credentialFieldInfo 
 			Name:        field.Name,
 			Label:       field.Label,
 			Description: field.Description,
-			HelpURL:     field.HelpURL,
 		}
 	})
 }
@@ -271,7 +270,6 @@ func connectionInfoFromAuth(name string, auth config.ConnectionAuthDef, integrat
 			Name:        field.Name,
 			Label:       field.Label,
 			Description: field.Description,
-			HelpURL:     field.HelpURL,
 		}
 	}); len(fields) > 0 {
 		info.CredentialFields = fields

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -696,7 +696,7 @@ func TestListIntegrations(t *testing.T) {
 
 	var integrations []struct {
 		Name        string `json:"name"`
-		DisplayName string `json:"display_name"`
+		DisplayName string `json:"displayName"`
 		Description string `json:"description"`
 		Connected   bool   `json:"connected"`
 	}
@@ -792,7 +792,7 @@ func TestListIntegrations_AuthTypes(t *testing.T) {
 
 	var integrations []struct {
 		Name      string   `json:"name"`
-		AuthTypes []string `json:"auth_types"`
+		AuthTypes []string `json:"authTypes"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
 		t.Fatalf("decoding: %v", err)
@@ -895,8 +895,8 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 	}
 	type connectionInfo struct {
 		Name             string            `json:"name"`
-		AuthTypes        []string          `json:"auth_types"`
-		CredentialFields []credentialField `json:"credential_fields"`
+		AuthTypes        []string          `json:"authTypes"`
+		CredentialFields []credentialField `json:"credentialFields"`
 	}
 
 	var integrations []struct {
@@ -1090,11 +1090,11 @@ func TestListIntegrations_ConnectionInfosIncludeProviderManualAuth(t *testing.T)
 				Name        string `json:"name"`
 				Connections []struct {
 					Name             string   `json:"name"`
-					AuthTypes        []string `json:"auth_types"`
+					AuthTypes        []string `json:"authTypes"`
 					CredentialFields []struct {
 						Name  string `json:"name"`
 						Label string `json:"label"`
-					} `json:"credential_fields"`
+					} `json:"credentialFields"`
 				} `json:"connections"`
 			}
 			if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
@@ -1162,7 +1162,7 @@ func TestListIntegrationsWithIcon(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 
 		var integrations []struct {
-			IconSVG string `json:"icon_svg"`
+			IconSVG string `json:"iconSvg"`
 		}
 		if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
 			t.Fatalf("decoding: %v", err)
@@ -2317,7 +2317,7 @@ func TestStartLoginWithCallbackPort(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	body := bytes.NewBufferString(`{"state":"abc","callback_port":12345}`)
+	body := bytes.NewBufferString(`{"state":"abc","callbackPort":12345}`)
 	resp, err := http.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -2345,7 +2345,7 @@ func TestStartLoginWithInvalidCallbackPort(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	body := bytes.NewBufferString(`{"state":"abc","callback_port":99999}`)
+	body := bytes.NewBufferString(`{"state":"abc","callbackPort":99999}`)
 	resp, err := http.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -3271,21 +3271,21 @@ func TestCreateAPIToken_DefaultExpiry(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		t.Fatalf("decoding: %v", err)
 	}
-	expiresAtRaw, ok := result["expires_at"]
+	expiresAtRaw, ok := result["expiresAt"]
 	if !ok || expiresAtRaw == nil {
-		t.Fatal("expected expires_at in response, got nil")
+		t.Fatal("expected expiresAt in response, got nil")
 	}
 	expiresAtStr, ok := expiresAtRaw.(string)
 	if !ok {
-		t.Fatalf("expected expires_at to be a string, got %T", expiresAtRaw)
+		t.Fatalf("expected expiresAt to be a string, got %T", expiresAtRaw)
 	}
 	expiresAt, err := time.Parse(time.RFC3339, expiresAtStr)
 	if err != nil {
-		t.Fatalf("parsing expires_at: %v", err)
+		t.Fatalf("parsing expiresAt: %v", err)
 	}
 	expected := fixedNow.Add(30 * 24 * time.Hour).UTC().Truncate(time.Second)
 	if !expiresAt.Equal(expected) {
-		t.Fatalf("expected expires_at %v, got %v", expected, expiresAt)
+		t.Fatalf("expected expiresAt %v, got %v", expected, expiresAt)
 	}
 
 	var auditRecord map[string]any
@@ -3401,17 +3401,17 @@ func TestCreateAPIToken_ConfigurableTTL(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		t.Fatalf("decoding: %v", err)
 	}
-	expiresAtStr, ok := result["expires_at"].(string)
+	expiresAtStr, ok := result["expiresAt"].(string)
 	if !ok {
-		t.Fatal("expected expires_at string in response")
+		t.Fatal("expected expiresAt string in response")
 	}
 	expiresAt, err := time.Parse(time.RFC3339, expiresAtStr)
 	if err != nil {
-		t.Fatalf("parsing expires_at: %v", err)
+		t.Fatalf("parsing expiresAt: %v", err)
 	}
 	expected := fixedNow.Add(customTTL).UTC().Truncate(time.Second)
 	if !expiresAt.Equal(expected) {
-		t.Fatalf("expected expires_at %v, got %v", expected, expiresAt)
+		t.Fatalf("expected expiresAt %v, got %v", expected, expiresAt)
 	}
 }
 
@@ -3571,11 +3571,11 @@ func TestAuthInfo(t *testing.T) {
 	if body["provider"] != "google" {
 		t.Fatalf("expected provider google, got %q", body["provider"])
 	}
-	if body["display_name"] != "Google" {
-		t.Fatalf("expected display_name Google, got %q", body["display_name"])
+	if body["displayName"] != "Google" {
+		t.Fatalf("expected displayName Google, got %q", body["displayName"])
 	}
-	if body["login_supported"] != true {
-		t.Fatalf("expected login_supported true, got %#v", body["login_supported"])
+	if body["loginSupported"] != true {
+		t.Fatalf("expected loginSupported true, got %#v", body["loginSupported"])
 	}
 }
 
@@ -3604,11 +3604,11 @@ func TestAuthInfoFallback(t *testing.T) {
 	if body["provider"] != "custom" {
 		t.Fatalf("expected provider custom, got %q", body["provider"])
 	}
-	if body["display_name"] != "custom" {
-		t.Fatalf("expected display_name to fall back to name custom, got %q", body["display_name"])
+	if body["displayName"] != "custom" {
+		t.Fatalf("expected displayName to fall back to name custom, got %q", body["displayName"])
 	}
-	if body["login_supported"] != true {
-		t.Fatalf("expected login_supported true, got %#v", body["login_supported"])
+	if body["loginSupported"] != true {
+		t.Fatalf("expected loginSupported true, got %#v", body["loginSupported"])
 	}
 }
 
@@ -3637,11 +3637,11 @@ func TestAuthInfoNoAuth(t *testing.T) {
 	if body["provider"] != "none" {
 		t.Fatalf("expected provider none, got %q", body["provider"])
 	}
-	if body["display_name"] != "none" {
-		t.Fatalf("expected display_name none, got %q", body["display_name"])
+	if body["displayName"] != "none" {
+		t.Fatalf("expected displayName none, got %q", body["displayName"])
 	}
-	if body["login_supported"] != false {
-		t.Fatalf("expected login_supported false, got %#v", body["login_supported"])
+	if body["loginSupported"] != false {
+		t.Fatalf("expected loginSupported false, got %#v", body["loginSupported"])
 	}
 }
 
@@ -4933,8 +4933,8 @@ func TestConnectManual(t *testing.T) {
 		var connectResult struct {
 			Status       string `json:"status"`
 			Integration  string `json:"integration"`
-			SelectionURL string `json:"selection_url"`
-			PendingToken string `json:"pending_token"`
+			SelectionURL string `json:"selectionUrl"`
+			PendingToken string `json:"pendingToken"`
 			Candidates   []struct {
 				ID   string `json:"id"`
 				Name string `json:"name"`

--- a/gestaltd/internal/testutil/testdata/provider-go/catalog.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-go/catalog.yaml
@@ -18,4 +18,4 @@ operations:
   - id: status
     method: GET
     description: Return provider startup state
-    read_only: true
+    readOnly: true

--- a/gestaltd/internal/testutil/testdata/provider-go/config.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-go/config.yaml
@@ -7,7 +7,7 @@ datastore:
     path: ./example.db
 
 server:
-  encryption_key: dev-key-for-example-only
+  encryptionKey: dev-key-for-example-only
 
 plugins:
   example:

--- a/gestaltd/internal/testutil/testdata/provider-go/manifest.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-go/manifest.yaml
@@ -1,6 +1,6 @@
 source: github.com/valon-technologies/gestalt/provider-go
 version: 0.0.1-alpha.1
-display_name: Example Provider
+displayName: Example Provider
 description: A minimal example provider built with the public SDK
 plugin:
   connections:

--- a/gestaltd/internal/testutil/testdata/provider-rust-auth/manifest.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-rust-auth/manifest.yaml
@@ -1,5 +1,5 @@
 source: github.com/valon-technologies/gestalt/provider-rust-auth
 version: 0.0.1-alpha.1
-display_name: Example Rust Auth Provider
+displayName: Example Rust Auth Provider
 description: A minimal Rust auth provider built with the public Rust SDK
 auth: {}

--- a/gestaltd/internal/testutil/testdata/provider-rust-datastore/manifest.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-rust-datastore/manifest.yaml
@@ -1,5 +1,5 @@
 source: github.com/valon-technologies/gestalt/provider-rust-datastore
 version: 0.0.1-alpha.1
-display_name: Example Rust Datastore Provider
+displayName: Example Rust Datastore Provider
 description: A minimal Rust datastore provider built with the public Rust SDK
 datastore: {}

--- a/gestaltd/internal/testutil/testdata/provider-rust/config.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-rust/config.yaml
@@ -7,7 +7,7 @@ datastore:
     path: ./example.db
 
 server:
-  encryption_key: dev-key-for-example-only
+  encryptionKey: dev-key-for-example-only
 
 plugins:
   example:

--- a/gestaltd/internal/testutil/testdata/provider-rust/manifest.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-rust/manifest.yaml
@@ -1,6 +1,6 @@
 source: github.com/valon-technologies/gestalt/provider-rust
 version: 0.0.1-alpha.1
-display_name: Example Rust Provider
+displayName: Example Rust Provider
 description: A minimal example provider built with the public Rust SDK
 plugin:
   connections:

--- a/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -16,13 +16,13 @@
       "type": "string",
       "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
     },
-    "display_name": {
+    "displayName": {
       "type": "string"
     },
     "description": {
       "type": "string"
     },
-    "icon_file": {
+    "iconFile": {
       "type": "string"
     },
     "release": {
@@ -75,11 +75,11 @@
       "additionalProperties": false,
       "properties": {
         "build": {
-          "$ref": "#/$defs/release_build"
+          "$ref": "#/$defs/releaseBuild"
         }
       }
     },
-    "release_build": {
+    "releaseBuild": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -104,7 +104,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "config_schema_path": {
+        "configSchemaPath": {
           "type": "string",
           "minLength": 1
         },
@@ -115,14 +115,14 @@
           "type": "object",
           "properties": {
             "default": {
-              "$ref": "#/$defs/plugin_default_connection"
+              "$ref": "#/$defs/pluginDefaultConnection"
             }
           },
           "propertyNames": {
             "minLength": 1
           },
           "additionalProperties": {
-            "$ref": "#/$defs/plugin_named_connection"
+            "$ref": "#/$defs/pluginNamedConnection"
           }
         },
         "headers": {
@@ -131,29 +131,29 @@
             "type": "string"
           }
         },
-        "managed_parameters": {
+        "managedParameters": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/managed_parameter"
+            "$ref": "#/$defs/managedParameter"
           }
         },
-        "response_mapping": {
-          "$ref": "#/$defs/response_mapping"
+        "responseMapping": {
+          "$ref": "#/$defs/responseMapping"
         },
         "pagination": {
-          "$ref": "#/$defs/pagination_config"
+          "$ref": "#/$defs/paginationConfig"
         },
-        "allowed_operations": {
+        "allowedOperations": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/manifest_operation_override"
+            "$ref": "#/$defs/manifestOperationOverride"
           }
         },
         "surfaces": {
           "$ref": "#/$defs/surfaces"
         },
         "mcp": {
-          "$ref": "#/$defs/mcp_config"
+          "$ref": "#/$defs/mcpConfig"
         }
       }
     },
@@ -161,14 +161,14 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "asset_root"
+        "assetRoot"
       ],
       "properties": {
-        "asset_root": {
+        "assetRoot": {
           "type": "string",
           "minLength": 1
         },
-        "config_schema_path": {
+        "configSchemaPath": {
           "type": "string",
           "minLength": 1
         }
@@ -178,7 +178,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "config_schema_path": {
+        "configSchemaPath": {
           "type": "string",
           "minLength": 1
         },
@@ -191,7 +191,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "config_schema_path": {
+        "configSchemaPath": {
           "type": "string",
           "minLength": 1
         },
@@ -204,10 +204,10 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "artifact_path"
+        "artifactPath"
       ],
       "properties": {
-        "artifact_path": {
+        "artifactPath": {
           "type": "string",
           "minLength": 1
         },
@@ -219,7 +219,7 @@
         }
       }
     },
-    "provider_default_connection": {
+    "pluginDefaultConnection": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -233,20 +233,20 @@
           ]
         },
         "auth": {
-          "$ref": "#/$defs/plugin_auth"
+          "$ref": "#/$defs/pluginAuth"
         },
         "params": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/plugin_connection_param"
+            "$ref": "#/$defs/pluginConnectionParam"
           }
         },
         "discovery": {
-          "$ref": "#/$defs/plugin_discovery"
+          "$ref": "#/$defs/pluginDiscovery"
         }
       }
     },
-    "provider_named_connection": {
+    "pluginNamedConnection": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -260,20 +260,20 @@
           ]
         },
         "auth": {
-          "$ref": "#/$defs/plugin_auth"
+          "$ref": "#/$defs/pluginAuth"
         },
         "params": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/plugin_connection_param"
+            "$ref": "#/$defs/pluginConnectionParam"
           }
         },
         "discovery": {
-          "$ref": "#/$defs/plugin_discovery"
+          "$ref": "#/$defs/pluginDiscovery"
         }
       }
     },
-    "provider_connection_param": {
+    "pluginConnectionParam": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -291,7 +291,7 @@
         }
       }
     },
-    "provider_discovery": {
+    "pluginDiscovery": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -302,10 +302,10 @@
           "type": "string",
           "format": "uri"
         },
-        "id_path": {
+        "idPath": {
           "type": "string"
         },
-        "name_path": {
+        "namePath": {
           "type": "string"
         },
         "metadata": {
@@ -316,7 +316,7 @@
         }
       }
     },
-    "credential_field_ref": {
+    "credentialFieldRef": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -330,7 +330,7 @@
         }
       }
     },
-    "auth_value_from": {
+    "authValueFrom": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -338,11 +338,11 @@
       ],
       "properties": {
         "credentialFieldRef": {
-          "$ref": "#/$defs/credential_field_ref"
+          "$ref": "#/$defs/credentialFieldRef"
         }
       }
     },
-    "auth_value": {
+    "authValue": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -350,7 +350,7 @@
           "type": "string"
         },
         "valueFrom": {
-          "$ref": "#/$defs/auth_value_from"
+          "$ref": "#/$defs/authValueFrom"
         }
       },
       "oneOf": [
@@ -376,7 +376,7 @@
         }
       ]
     },
-    "basic_auth_mapping": {
+    "basicAuthMapping": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -385,25 +385,25 @@
       ],
       "properties": {
         "username": {
-          "$ref": "#/$defs/auth_value"
+          "$ref": "#/$defs/authValue"
         },
         "password": {
-          "$ref": "#/$defs/auth_value"
+          "$ref": "#/$defs/authValue"
         }
       }
     },
-    "auth_mapping": {
+    "authMapping": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "headers": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/auth_value"
+            "$ref": "#/$defs/authValue"
           }
         },
         "basic": {
-          "$ref": "#/$defs/basic_auth_mapping"
+          "$ref": "#/$defs/basicAuthMapping"
         }
       }
     },
@@ -412,16 +412,16 @@
       "additionalProperties": false,
       "properties": {
         "rest": {
-          "$ref": "#/$defs/rest_surface"
+          "$ref": "#/$defs/restSurface"
         },
         "openapi": {
-          "$ref": "#/$defs/openapi_surface"
+          "$ref": "#/$defs/openapiSurface"
         },
         "graphql": {
-          "$ref": "#/$defs/graphql_surface"
+          "$ref": "#/$defs/graphqlSurface"
         },
         "mcp": {
-          "$ref": "#/$defs/mcp_surface"
+          "$ref": "#/$defs/mcpSurface"
         }
       },
       "allOf": [
@@ -451,11 +451,11 @@
         }
       ]
     },
-    "rest_surface": {
+    "restSurface": {
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "base_url",
+        "baseUrl",
         "operations"
       ],
       "properties": {
@@ -463,7 +463,7 @@
           "type": "string",
           "minLength": 1
         },
-        "base_url": {
+        "baseUrl": {
           "type": "string",
           "minLength": 1
         },
@@ -471,12 +471,12 @@
           "type": "array",
           "minItems": 1,
           "items": {
-            "$ref": "#/$defs/plugin_operation"
+            "$ref": "#/$defs/pluginOperation"
           }
         }
       }
     },
-    "openapi_surface": {
+    "openapiSurface": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -491,13 +491,13 @@
           "type": "string",
           "minLength": 1
         },
-        "base_url": {
+        "baseUrl": {
           "type": "string",
           "minLength": 1
         }
       }
     },
-    "graphql_surface": {
+    "graphqlSurface": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -514,7 +514,7 @@
         }
       }
     },
-    "mcp_surface": {
+    "mcpSurface": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -531,7 +531,7 @@
         }
       }
     },
-    "mcp_config": {
+    "mcpConfig": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -543,14 +543,14 @@
         }
       }
     },
-    "response_mapping": {
+    "responseMapping": {
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "data_path"
+        "dataPath"
       ],
       "properties": {
-        "data_path": {
+        "dataPath": {
           "type": "string",
           "minLength": 1
         },
@@ -558,17 +558,17 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "has_more": {
-              "$ref": "#/$defs/value_selector"
+            "hasMore": {
+              "$ref": "#/$defs/valueSelector"
             },
             "cursor": {
-              "$ref": "#/$defs/value_selector"
+              "$ref": "#/$defs/valueSelector"
             }
           }
         }
       }
     },
-    "provider_auth": {
+    "pluginAuth": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -585,18 +585,18 @@
             "none"
           ]
         },
-        "authorization_url": {
+        "authorizationUrl": {
           "type": "string",
           "format": "uri"
         },
-        "token_url": {
+        "tokenUrl": {
           "type": "string",
           "format": "uri"
         },
-        "client_id": {
+        "clientId": {
           "type": "string"
         },
-        "client_secret": {
+        "clientSecret": {
           "type": "string"
         },
         "scopes": {
@@ -608,50 +608,50 @@
         "pkce": {
           "type": "boolean"
         },
-        "client_auth": {
+        "clientAuth": {
           "type": "string",
           "enum": [
             "header"
           ]
         },
-        "token_exchange": {
+        "tokenExchange": {
           "type": "string",
           "enum": [
             "form",
             "json"
           ]
         },
-        "access_token_path": {
+        "accessTokenPath": {
           "type": "string"
         },
-        "scope_param": {
+        "scopeParam": {
           "type": "string"
         },
-        "scope_separator": {
+        "scopeSeparator": {
           "type": "string"
         },
-        "authorization_params": {
+        "authorizationParams": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           }
         },
-        "token_params": {
+        "tokenParams": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           }
         },
-        "refresh_params": {
+        "refreshParams": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           }
         },
-        "accept_header": {
+        "acceptHeader": {
           "type": "string"
         },
-        "token_metadata": {
+        "tokenMetadata": {
           "type": "array",
           "items": {
             "type": "string"
@@ -676,16 +676,12 @@
               },
               "description": {
                 "type": "string"
-              },
-              "help_url": {
-                "type": "string",
-                "format": "uri"
               }
             }
           }
         },
-        "auth_mapping": {
-          "$ref": "#/$defs/auth_mapping"
+        "authMapping": {
+          "$ref": "#/$defs/authMapping"
         }
       },
       "allOf": [
@@ -699,14 +695,14 @@
           },
           "then": {
             "required": [
-              "authorization_url",
-              "token_url"
+              "authorizationUrl",
+              "tokenUrl"
             ]
           }
         }
       ]
     },
-    "provider_operation": {
+    "pluginOperation": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -739,12 +735,12 @@
         "parameters": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/plugin_parameter"
+            "$ref": "#/$defs/pluginParameter"
           }
         }
       }
     },
-    "provider_parameter": {
+    "pluginParameter": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -783,7 +779,7 @@
         }
       }
     },
-    "managed_parameter": {
+    "managedParameter": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -809,7 +805,7 @@
         }
       }
     },
-    "value_selector": {
+    "valueSelector": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -830,7 +826,7 @@
         }
       }
     },
-    "pagination_config": {
+    "paginationConfig": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -845,29 +841,29 @@
             "page"
           ]
         },
-        "cursor_param": {
+        "cursorParam": {
           "type": "string"
         },
         "cursor": {
-          "$ref": "#/$defs/value_selector"
+          "$ref": "#/$defs/valueSelector"
         },
-        "limit_param": {
+        "limitParam": {
           "type": "string"
         },
-        "default_limit": {
+        "defaultLimit": {
           "type": "integer",
           "minimum": 1
         },
-        "results_path": {
+        "resultsPath": {
           "type": "string"
         },
-        "max_pages": {
+        "maxPages": {
           "type": "integer",
           "minimum": 1
         }
       }
     },
-    "manifest_operation_override": {
+    "manifestOperationOverride": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -881,7 +877,7 @@
           "type": "boolean"
         },
         "pagination": {
-          "$ref": "#/$defs/pagination_config"
+          "$ref": "#/$defs/paginationConfig"
         }
       }
     },

--- a/gestaltd/sdk/pluginmanifest/v1/types.go
+++ b/gestaltd/sdk/pluginmanifest/v1/types.go
@@ -15,9 +15,9 @@ const (
 type Manifest struct {
 	Source      string             `json:"source,omitempty" yaml:"source,omitempty"`
 	Version     string             `json:"version" yaml:"version"`
-	DisplayName string             `json:"display_name,omitempty" yaml:"display_name,omitempty"`
+	DisplayName string             `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	Description string             `json:"description,omitempty" yaml:"description,omitempty"`
-	IconFile    string             `json:"icon_file,omitempty" yaml:"icon_file,omitempty"`
+	IconFile    string             `json:"iconFile,omitempty" yaml:"iconFile,omitempty"`
 	Release     *ReleaseMetadata   `json:"release,omitempty" yaml:"release,omitempty"`
 	Plugin      *Plugin            `json:"plugin,omitempty" yaml:"plugin,omitempty"`
 	Auth        *AuthMetadata      `json:"auth,omitempty" yaml:"auth,omitempty"`
@@ -38,44 +38,44 @@ type ReleaseBuild struct {
 }
 
 type AuthMetadata struct {
-	ConfigSchemaPath string `json:"config_schema_path,omitempty" yaml:"config_schema_path,omitempty"`
+	ConfigSchemaPath string `json:"configSchemaPath,omitempty" yaml:"configSchemaPath,omitempty"`
 }
 
 type DatastoreMetadata struct {
-	ConfigSchemaPath string `json:"config_schema_path,omitempty" yaml:"config_schema_path,omitempty"`
+	ConfigSchemaPath string `json:"configSchemaPath,omitempty" yaml:"configSchemaPath,omitempty"`
 }
 
 type SecretsMetadata struct {
-	ConfigSchemaPath string `json:"config_schema_path,omitempty" yaml:"config_schema_path,omitempty"`
+	ConfigSchemaPath string `json:"configSchemaPath,omitempty" yaml:"configSchemaPath,omitempty"`
 }
 
 type WebUIMetadata struct {
-	AssetRoot        string `json:"asset_root" yaml:"asset_root"`
-	ConfigSchemaPath string `json:"config_schema_path,omitempty" yaml:"config_schema_path,omitempty"`
+	AssetRoot        string `json:"assetRoot" yaml:"assetRoot"`
+	ConfigSchemaPath string `json:"configSchemaPath,omitempty" yaml:"configSchemaPath,omitempty"`
 }
 
 type Plugin struct {
-	ConfigSchemaPath  string                             `json:"config_schema_path,omitempty" yaml:"config_schema_path,omitempty"`
+	ConfigSchemaPath  string                             `json:"configSchemaPath,omitempty" yaml:"configSchemaPath,omitempty"`
 	Auth              *ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
-	ConnectionMode    string                             `json:"connection_mode,omitempty" yaml:"connection_mode,omitempty"`
+	ConnectionMode    string                             `json:"connectionMode,omitempty" yaml:"connectionMode,omitempty"`
 	MCP               bool                               `json:"mcp,omitempty" yaml:"mcp,omitempty"`
-	BaseURL           string                             `json:"base_url,omitempty" yaml:"base_url,omitempty"`
+	BaseURL           string                             `json:"baseUrl,omitempty" yaml:"baseUrl,omitempty"`
 	Headers           map[string]string                  `json:"headers,omitempty" yaml:"headers,omitempty"`
-	ManagedParameters []ManagedParameter                 `json:"managed_parameters,omitempty" yaml:"managed_parameters,omitempty"`
+	ManagedParameters []ManagedParameter                 `json:"managedParameters,omitempty" yaml:"managedParameters,omitempty"`
 	Operations        []ProviderOperation                `json:"operations,omitempty" yaml:"operations,omitempty"`
 	Discovery         *ProviderDiscovery                 `json:"discovery,omitempty" yaml:"discovery,omitempty"`
-	ConnectionParams  map[string]ProviderConnectionParam `json:"connection_params,omitempty" yaml:"connection_params,omitempty"`
+	ConnectionParams  map[string]ProviderConnectionParam `json:"connectionParams,omitempty" yaml:"connectionParams,omitempty"`
 
 	OpenAPI           string                                `json:"openapi,omitempty" yaml:"openapi,omitempty"`
-	GraphQLURL        string                                `json:"graphql_url,omitempty" yaml:"graphql_url,omitempty"`
-	MCPURL            string                                `json:"mcp_url,omitempty" yaml:"mcp_url,omitempty"`
-	AllowedOperations map[string]*ManifestOperationOverride `json:"allowed_operations,omitempty" yaml:"allowed_operations,omitempty"`
-	OpenAPIConnection string                                `json:"openapi_connection,omitempty" yaml:"openapi_connection,omitempty"`
-	GraphQLConnection string                                `json:"graphql_connection,omitempty" yaml:"graphql_connection,omitempty"`
-	MCPConnection     string                                `json:"mcp_connection,omitempty" yaml:"mcp_connection,omitempty"`
-	DefaultConnection string                                `json:"default_connection,omitempty" yaml:"default_connection,omitempty"`
+	GraphQLURL        string                                `json:"graphqlUrl,omitempty" yaml:"graphqlUrl,omitempty"`
+	MCPURL            string                                `json:"mcpUrl,omitempty" yaml:"mcpUrl,omitempty"`
+	AllowedOperations map[string]*ManifestOperationOverride `json:"allowedOperations,omitempty" yaml:"allowedOperations,omitempty"`
+	OpenAPIConnection string                                `json:"openapiConnection,omitempty" yaml:"openapiConnection,omitempty"`
+	GraphQLConnection string                                `json:"graphqlConnection,omitempty" yaml:"graphqlConnection,omitempty"`
+	MCPConnection     string                                `json:"mcpConnection,omitempty" yaml:"mcpConnection,omitempty"`
+	DefaultConnection string                                `json:"defaultConnection,omitempty" yaml:"defaultConnection,omitempty"`
 	Connections       map[string]*ManifestConnectionDef     `json:"connections,omitempty" yaml:"connections,omitempty"`
-	ResponseMapping   *ManifestResponseMapping              `json:"response_mapping,omitempty" yaml:"response_mapping,omitempty"`
+	ResponseMapping   *ManifestResponseMapping              `json:"responseMapping,omitempty" yaml:"responseMapping,omitempty"`
 	Pagination        *ManifestPaginationConfig             `json:"pagination,omitempty" yaml:"pagination,omitempty"`
 }
 
@@ -100,7 +100,7 @@ func (m *Manifest) IsDeclarativeOnlyProvider() bool {
 }
 
 type ManifestResponseMapping struct {
-	DataPath   string                     `json:"data_path" yaml:"data_path"`
+	DataPath   string                     `json:"dataPath" yaml:"dataPath"`
 	Pagination *ManifestPaginationMapping `json:"pagination,omitempty" yaml:"pagination,omitempty"`
 }
 
@@ -110,14 +110,14 @@ type ManifestValueSelector struct {
 }
 
 type ManifestPaginationMapping struct {
-	HasMore *ManifestValueSelector `json:"has_more,omitempty" yaml:"has_more,omitempty"`
+	HasMore *ManifestValueSelector `json:"hasMore,omitempty" yaml:"hasMore,omitempty"`
 	Cursor  *ManifestValueSelector `json:"cursor,omitempty" yaml:"cursor,omitempty"`
 }
 
 type ProviderDiscovery struct {
 	URL      string            `json:"url" yaml:"url"`
-	IDPath   string            `json:"id_path,omitempty" yaml:"id_path,omitempty"`
-	NamePath string            `json:"name_path,omitempty" yaml:"name_path,omitempty"`
+	IDPath   string            `json:"idPath,omitempty" yaml:"idPath,omitempty"`
+	NamePath string            `json:"namePath,omitempty" yaml:"namePath,omitempty"`
 	Metadata map[string]string `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 }
 
@@ -129,12 +129,12 @@ type ProviderConnectionParam struct {
 
 type ManifestPaginationConfig struct {
 	Style        string                 `json:"style" yaml:"style"`
-	CursorParam  string                 `json:"cursor_param,omitempty" yaml:"cursor_param,omitempty"`
+	CursorParam  string                 `json:"cursorParam,omitempty" yaml:"cursorParam,omitempty"`
 	Cursor       *ManifestValueSelector `json:"cursor,omitempty" yaml:"cursor,omitempty"`
-	LimitParam   string                 `json:"limit_param,omitempty" yaml:"limit_param,omitempty"`
-	DefaultLimit int                    `json:"default_limit,omitempty" yaml:"default_limit,omitempty"`
-	ResultsPath  string                 `json:"results_path,omitempty" yaml:"results_path,omitempty"`
-	MaxPages     int                    `json:"max_pages,omitempty" yaml:"max_pages,omitempty"`
+	LimitParam   string                 `json:"limitParam,omitempty" yaml:"limitParam,omitempty"`
+	DefaultLimit int                    `json:"defaultLimit,omitempty" yaml:"defaultLimit,omitempty"`
+	ResultsPath  string                 `json:"resultsPath,omitempty" yaml:"resultsPath,omitempty"`
+	MaxPages     int                    `json:"maxPages,omitempty" yaml:"maxPages,omitempty"`
 }
 
 type ManifestOperationOverride struct {
@@ -183,31 +183,30 @@ const (
 
 type ProviderAuth struct {
 	Type                string            `json:"type" yaml:"type"`
-	AuthorizationURL    string            `json:"authorization_url,omitempty" yaml:"authorization_url,omitempty"`
-	TokenURL            string            `json:"token_url,omitempty" yaml:"token_url,omitempty"`
-	ClientID            string            `json:"client_id,omitempty" yaml:"client_id,omitempty"`
-	ClientSecret        string            `json:"client_secret,omitempty" yaml:"client_secret,omitempty"`
+	AuthorizationURL    string            `json:"authorizationUrl,omitempty" yaml:"authorizationUrl,omitempty"`
+	TokenURL            string            `json:"tokenUrl,omitempty" yaml:"tokenUrl,omitempty"`
+	ClientID            string            `json:"clientId,omitempty" yaml:"clientId,omitempty"`
+	ClientSecret        string            `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
 	Scopes              []string          `json:"scopes,omitempty" yaml:"scopes,omitempty"`
 	PKCE                bool              `json:"pkce,omitempty" yaml:"pkce,omitempty"`
-	ClientAuth          string            `json:"client_auth,omitempty" yaml:"client_auth,omitempty"`
-	TokenExchange       string            `json:"token_exchange,omitempty" yaml:"token_exchange,omitempty"`
-	AccessTokenPath     string            `json:"access_token_path,omitempty" yaml:"access_token_path,omitempty"`
-	ScopeParam          string            `json:"scope_param,omitempty" yaml:"scope_param,omitempty"`
-	ScopeSeparator      string            `json:"scope_separator,omitempty" yaml:"scope_separator,omitempty"`
-	AuthorizationParams map[string]string `json:"authorization_params,omitempty" yaml:"authorization_params,omitempty"`
-	TokenParams         map[string]string `json:"token_params,omitempty" yaml:"token_params,omitempty"`
-	RefreshParams       map[string]string `json:"refresh_params,omitempty" yaml:"refresh_params,omitempty"`
-	AcceptHeader        string            `json:"accept_header,omitempty" yaml:"accept_header,omitempty"`
-	TokenMetadata       []string          `json:"token_metadata,omitempty" yaml:"token_metadata,omitempty"`
+	ClientAuth          string            `json:"clientAuth,omitempty" yaml:"clientAuth,omitempty"`
+	TokenExchange       string            `json:"tokenExchange,omitempty" yaml:"tokenExchange,omitempty"`
+	AccessTokenPath     string            `json:"accessTokenPath,omitempty" yaml:"accessTokenPath,omitempty"`
+	ScopeParam          string            `json:"scopeParam,omitempty" yaml:"scopeParam,omitempty"`
+	ScopeSeparator      string            `json:"scopeSeparator,omitempty" yaml:"scopeSeparator,omitempty"`
+	AuthorizationParams map[string]string `json:"authorizationParams,omitempty" yaml:"authorizationParams,omitempty"`
+	TokenParams         map[string]string `json:"tokenParams,omitempty" yaml:"tokenParams,omitempty"`
+	RefreshParams       map[string]string `json:"refreshParams,omitempty" yaml:"refreshParams,omitempty"`
+	AcceptHeader        string            `json:"acceptHeader,omitempty" yaml:"acceptHeader,omitempty"`
+	TokenMetadata       []string          `json:"tokenMetadata,omitempty" yaml:"tokenMetadata,omitempty"`
 	Credentials         []CredentialField `json:"credentials,omitempty" yaml:"credentials,omitempty"`
-	AuthMapping         *AuthMapping      `json:"auth_mapping,omitempty" yaml:"auth_mapping,omitempty"`
+	AuthMapping         *AuthMapping      `json:"authMapping,omitempty" yaml:"authMapping,omitempty"`
 }
 
 type CredentialField struct {
 	Name        string `json:"name" yaml:"name"`
 	Label       string `json:"label,omitempty" yaml:"label,omitempty"`
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
-	HelpURL     string `json:"help_url,omitempty" yaml:"help_url,omitempty"`
 }
 
 type AuthMapping struct {
@@ -249,7 +248,7 @@ type Entrypoints struct {
 }
 
 type Entrypoint struct {
-	ArtifactPath string   `json:"artifact_path" yaml:"artifact_path"`
+	ArtifactPath string   `json:"artifactPath" yaml:"artifactPath"`
 	Args         []string `json:"args,omitempty" yaml:"args,omitempty"`
 }
 

--- a/gestaltd/ui/e2e/auth.spec.ts
+++ b/gestaltd/ui/e2e/auth.spec.ts
@@ -40,7 +40,7 @@ test.describe("Authentication", () => {
     });
     await mockAuthInfo(page, {
       provider: "test-sso",
-      display_name: "Test SSO",
+      displayName: "Test SSO",
     });
     await page.goto("/");
     await expect(page).toHaveURL(/\/login/);
@@ -53,7 +53,7 @@ test.describe("Authentication", () => {
     });
     await mockAuthInfo(page, {
       provider: "test-sso",
-      display_name: "Test SSO",
+      displayName: "Test SSO",
     });
     await page.goto("/login");
     await expect(page.getByRole("heading", { name: "Gestalt" })).toBeVisible();
@@ -67,8 +67,8 @@ test.describe("Authentication", () => {
   }) => {
     await mockAuthInfo(page, {
       provider: "none",
-      display_name: "none",
-      login_supported: false,
+      displayName: "none",
+      loginSupported: false,
     });
     await mockIntegrations(page, []);
     await mockTokens(page, []);
@@ -96,7 +96,7 @@ test.describe("Authentication", () => {
       route.abort();
     });
     await mockIntegrations(page, [
-      { name: "test-svc", display_name: "Test Service" },
+      { name: "test-svc", displayName: "Test Service" },
     ]);
     await mockTokens(page, []);
 
@@ -222,7 +222,7 @@ gestaltd_operation_duration_seconds_count{gestalt_provider="slack",gestalt_opera
   test("logout clears session and redirects to login", async ({ page }) => {
     await mockAuthInfo(page, {
       provider: "test-sso",
-      display_name: "Test SSO",
+      displayName: "Test SSO",
     });
     await mockIntegrations(page, []);
     await mockTokens(page, []);
@@ -277,7 +277,7 @@ gestaltd_operation_duration_seconds_count{gestalt_provider="slack",gestalt_opera
         contentType: "application/json",
         body: JSON.stringify({
           email: "test@gestalt.dev",
-          display_name: "Test User",
+          displayName: "Test User",
         }),
       });
     });
@@ -316,7 +316,7 @@ gestaltd_operation_duration_seconds_count{gestalt_provider="slack",gestalt_opera
         contentType: "application/json",
         body: JSON.stringify({
           email: "unexpected@gestalt.dev",
-          display_name: "Unexpected",
+          displayName: "Unexpected",
         }),
       });
     });
@@ -350,7 +350,7 @@ gestaltd_operation_duration_seconds_count{gestalt_provider="slack",gestalt_opera
   }) => {
     await mockAuthInfo(page, {
       provider: "test-sso",
-      display_name: "Test SSO",
+      displayName: "Test SSO",
     });
     await page.route("**/metrics", (route) => {
       route.fulfill({
@@ -387,7 +387,7 @@ gestaltd_operation_duration_seconds_count{gestalt_provider="slack",gestalt_opera
   }) => {
     await mockAuthInfo(page, {
       provider: "test-sso",
-      display_name: "Test SSO",
+      displayName: "Test SSO",
     });
     await page.route("**/metrics", (route) => {
       route.fulfill({
@@ -421,7 +421,7 @@ gestaltd_operation_duration_seconds_count{gestalt_provider="slack",gestalt_opera
   }) => {
     await mockAuthInfo(page, {
       provider: "test-sso",
-      display_name: "Test SSO",
+      displayName: "Test SSO",
     });
     await page.route("**/metrics", (route) => {
       route.fulfill({

--- a/gestaltd/ui/e2e/docs.spec.ts
+++ b/gestaltd/ui/e2e/docs.spec.ts
@@ -17,7 +17,7 @@ test.describe("Docs page", () => {
     });
     await mockAuthInfo(page, {
       provider: "test-sso",
-      display_name: "Test SSO",
+      displayName: "Test SSO",
     });
 
     await page.goto("/login");

--- a/gestaltd/ui/e2e/fixtures.ts
+++ b/gestaltd/ui/e2e/fixtures.ts
@@ -49,10 +49,10 @@ export async function mockManualConnect(
 
 export async function mockAuthInfo(
   page: Page,
-  info: { provider: string; display_name: string; login_supported?: boolean },
+  info: { provider: string; displayName: string; loginSupported?: boolean },
 ) {
   await page.route("**/api/v1/auth/info", (route: Route) => {
-    route.fulfill({ json: { login_supported: true, ...info } });
+    route.fulfill({ json: { loginSupported: true, ...info } });
   });
 }
 

--- a/gestaltd/ui/e2e/integrations.spec.ts
+++ b/gestaltd/ui/e2e/integrations.spec.ts
@@ -2,53 +2,53 @@ import { test, expect, mockIntegrations, mockManualConnect, mockTokens } from ".
 import type { Integration } from "../src/lib/api";
 
 const OAUTH_INTEGRATION: Integration = {
-  name: "oauth-svc", display_name: "OAuth Service", description: "Example OAuth integration",
+  name: "oauth-svc", displayName: "OAuth Service", description: "Example OAuth integration",
 };
 
 const MANUAL_INTEGRATION: Integration = {
-  name: "manual-svc", display_name: "Manual Service", description: "Example manual integration", auth_types: ["manual"],
-  credential_fields: [{ name: "token", label: "API Token" }],
+  name: "manual-svc", displayName: "Manual Service", description: "Example manual integration", authTypes: ["manual"],
+  credentialFields: [{ name: "token", label: "API Token" }],
 };
 
 const MANUAL_WITH_LINKED_DESC: Integration = {
-  name: "linked-svc", display_name: "Linked Service", auth_types: ["manual"],
-  credential_fields: [{ name: "api_key", label: "API Key", description: "Find yours in [Account Settings](https://example.com/settings)" }],
+  name: "linked-svc", displayName: "Linked Service", authTypes: ["manual"],
+  credentialFields: [{ name: "api_key", label: "API Key", description: "Find yours in [Account Settings](https://example.com/settings)" }],
 };
 
 const MULTI_CONNECTION_DUAL_AUTH_INTEGRATION: Integration = {
   name: "workspace-svc",
-  display_name: "Workspace Service",
-  auth_types: ["oauth", "manual"],
-  credential_fields: [{ name: "api_token", label: "API Token" }],
+  displayName: "Workspace Service",
+  authTypes: ["oauth", "manual"],
+  credentialFields: [{ name: "api_token", label: "API Token" }],
   connections: [
     {
       name: "workspace",
-      auth_types: ["oauth", "manual"],
-      credential_fields: [{ name: "api_token", label: "API Token" }],
+      authTypes: ["oauth", "manual"],
+      credentialFields: [{ name: "api_token", label: "API Token" }],
     },
     {
       name: "personal",
-      auth_types: ["manual"],
-      credential_fields: [{ name: "personal_token", label: "Personal Token" }],
+      authTypes: ["manual"],
+      credentialFields: [{ name: "personal_token", label: "Personal Token" }],
     },
   ],
 };
 
 const MULTI_CONNECTION_MULTI_OAUTH_INTEGRATION: Integration = {
   name: "team-svc",
-  display_name: "Team Service",
-  auth_types: ["oauth", "manual"],
-  credential_fields: [{ name: "api_token", label: "API Token" }],
+  displayName: "Team Service",
+  authTypes: ["oauth", "manual"],
+  credentialFields: [{ name: "api_token", label: "API Token" }],
   connections: [
     {
       name: "workspace",
-      auth_types: ["oauth", "manual"],
-      credential_fields: [{ name: "workspace_token", label: "Workspace Token" }],
+      authTypes: ["oauth", "manual"],
+      credentialFields: [{ name: "workspace_token", label: "Workspace Token" }],
     },
     {
       name: "personal",
-      auth_types: ["oauth", "manual"],
-      credential_fields: [{ name: "personal_token", label: "Personal Token" }],
+      authTypes: ["oauth", "manual"],
+      credentialFields: [{ name: "personal_token", label: "Personal Token" }],
     },
   ],
 };
@@ -56,7 +56,7 @@ const MULTI_CONNECTION_MULTI_OAUTH_INTEGRATION: Integration = {
 const sampleIntegrations: Integration[] = [
   OAUTH_INTEGRATION,
   MANUAL_INTEGRATION,
-  { name: "another-svc", display_name: "Another Service" },
+  { name: "another-svc", displayName: "Another Service" },
 ];
 
 test.describe("Integrations", () => {
@@ -69,8 +69,8 @@ test.describe("Integrations", () => {
     await expect(
       page.getByRole("heading", { name: "Integrations" }),
     ).toBeVisible();
-    await expect(page.getByText(OAUTH_INTEGRATION.display_name!)).toBeVisible();
-    await expect(page.getByText(MANUAL_INTEGRATION.display_name!)).toBeVisible();
+    await expect(page.getByText(OAUTH_INTEGRATION.displayName!)).toBeVisible();
+    await expect(page.getByText(MANUAL_INTEGRATION.displayName!)).toBeVisible();
     await expect(page.getByText("Another Service")).toBeVisible();
     await expect(page.getByText(OAUTH_INTEGRATION.description!)).toBeVisible();
     await expect(page.getByText(MANUAL_INTEGRATION.description!)).toBeVisible();
@@ -102,8 +102,8 @@ test.describe("Integrations", () => {
     ]);
 
     await page.goto("/integrations");
-    await expect(page.getByText(OAUTH_INTEGRATION.display_name!)).toBeVisible();
-    await expect(page.getByText(MANUAL_INTEGRATION.display_name!)).toBeVisible();
+    await expect(page.getByText(OAUTH_INTEGRATION.displayName!)).toBeVisible();
+    await expect(page.getByText(MANUAL_INTEGRATION.displayName!)).toBeVisible();
     await expect(page.getByRole("button", { name: "OAuth Service settings" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Manual Service settings" })).toBeVisible();
 

--- a/gestaltd/ui/e2e/tokens.spec.ts
+++ b/gestaltd/ui/e2e/tokens.spec.ts
@@ -11,14 +11,14 @@ const sampleTokens: APIToken[] = [
     id: "tok-1",
     name: "ci-pipeline",
     scopes: "read",
-    created_at: "2026-01-15T10:00:00Z",
+    createdAt: "2026-01-15T10:00:00Z",
   },
   {
     id: "tok-2",
     name: "deploy-key",
     scopes: "",
-    created_at: "2026-02-20T14:30:00Z",
-    expires_at: "2027-02-20T14:30:00Z",
+    createdAt: "2026-02-20T14:30:00Z",
+    expiresAt: "2027-02-20T14:30:00Z",
   },
 ];
 
@@ -60,7 +60,7 @@ test.describe("Token Management", () => {
             id: "tok-new",
             name: "my-new-token",
             scopes: "",
-            created_at: new Date().toISOString(),
+            createdAt: new Date().toISOString(),
           },
         ];
         route.fulfill({
@@ -111,7 +111,7 @@ test.describe("Token Management", () => {
             id: "tok-race",
             name: "race-token",
             scopes: "",
-            created_at: new Date().toISOString(),
+            createdAt: new Date().toISOString(),
           },
         ];
         await route.fulfill({

--- a/gestaltd/ui/src/app/login/page.tsx
+++ b/gestaltd/ui/src/app/login/page.tsx
@@ -19,12 +19,12 @@ export default function LoginPage() {
     }
     getAuthInfo()
       .then((info) => {
-        if (!info.login_supported) {
+        if (!info.loginSupported) {
           setUserEmail(DEFAULT_LOCAL_EMAIL);
           window.location.replace("/");
           return;
         }
-        setAuthLabel("Sign in with " + info.display_name);
+        setAuthLabel("Sign in with " + info.displayName);
       })
       .catch(() => {});
   }, []);

--- a/gestaltd/ui/src/components/IntegrationCard.tsx
+++ b/gestaltd/ui/src/components/IntegrationCard.tsx
@@ -52,8 +52,8 @@ function sanitizeSVG(raw: string): string {
 
 function hasConnectionParams(integration: Integration): boolean {
   return (
-    !!integration.connection_params &&
-    Object.keys(integration.connection_params).length > 0
+    !!integration.connectionParams &&
+    Object.keys(integration.connectionParams).length > 0
   );
 }
 
@@ -86,8 +86,8 @@ export default function IntegrationCard({
   const [submitting, setSubmitting] = useState(false);
   const pendingSelectionFormRef = useRef<HTMLFormElement>(null);
 
-  const safeIconSVG = integration.icon_svg
-    ? sanitizeSVG(integration.icon_svg)
+  const safeIconSVG = integration.iconSvg
+    ? sanitizeSVG(integration.iconSvg)
     : "";
   const needsParams = hasConnectionParams(integration);
 
@@ -100,8 +100,8 @@ export default function IntegrationCard({
     form: HTMLFormElement,
   ): Record<string, string> {
     const params: Record<string, string> = {};
-    if (!integration.connection_params) return params;
-    for (const name of Object.keys(integration.connection_params)) {
+    if (!integration.connectionParams) return params;
+    for (const name of Object.keys(integration.connectionParams)) {
       const val = (new FormData(form).get(`cp_${name}`) as string)?.trim();
       if (val) params[name] = val;
     }
@@ -146,13 +146,13 @@ export default function IntegrationCard({
         integration.name, credential, connectionParams, instance, connection,
       );
       if (result.status === "selection_required") {
-        if (!result.pending_token) {
+        if (!result.pendingToken) {
           throw new Error("Connection requires selection, but the server did not return a pending token.");
         }
         setSettingsOpen(false);
         setPendingSelection({
-          action: resolveAPIPath(result.selection_url || PENDING_CONNECTION_PATH),
-          pendingToken: result.pending_token,
+          action: resolveAPIPath(result.selectionUrl || PENDING_CONNECTION_PATH),
+          pendingToken: result.pendingToken,
         });
       } else {
         setSettingsOpen(false);
@@ -197,8 +197,8 @@ export default function IntegrationCard({
   }
 
   function renderConnectionParamFields() {
-    if (!integration.connection_params) return null;
-    return Object.entries(integration.connection_params).map(([name, def]) => (
+    if (!integration.connectionParams) return null;
+    return Object.entries(integration.connectionParams).map(([name, def]) => (
       <div key={name} className="mt-3">
         <label
           htmlFor={`cp_${name}-${integration.name}`}
@@ -249,7 +249,7 @@ export default function IntegrationCard({
           </div>
           <div>
             <h3 className="text-base font-heading font-semibold text-primary">
-              {integration.display_name || integration.name}
+              {integration.displayName || integration.name}
             </h3>
             {integration.description && (
               <p className="mt-1 line-clamp-2 text-sm text-muted">
@@ -265,7 +265,7 @@ export default function IntegrationCard({
           <button
             onClick={() => setSettingsOpen(true)}
             className="flex h-8 w-8 items-center justify-center rounded-md text-faint transition-all duration-150 hover:bg-alpha-5 hover:text-muted"
-            aria-label={`${integration.display_name || integration.name} settings`}
+            aria-label={`${integration.displayName || integration.name} settings`}
           >
             <GearIcon className="h-4 w-4" />
           </button>

--- a/gestaltd/ui/src/components/IntegrationSettingsModal.tsx
+++ b/gestaltd/ui/src/components/IntegrationSettingsModal.tsx
@@ -59,16 +59,16 @@ function normalizeAuthTypes(authTypes?: AuthType[], fallbackToOAuth = true): Aut
 }
 
 function resolveAuthTargets(integration: Integration): AuthTarget[] {
-  const defaultCredentialFields = integration.credential_fields;
+  const defaultCredentialFields = integration.credentialFields;
   if (integration.connections?.length) {
     return integration.connections
       .map((connection) => ({
         key: connection.name,
         connection: connection.name,
         label: connection.name,
-        authTypes: normalizeAuthTypes(connection.auth_types, false),
-        credentialFields: connection.credential_fields?.length
-          ? connection.credential_fields
+        authTypes: normalizeAuthTypes(connection.authTypes, false),
+        credentialFields: connection.credentialFields?.length
+          ? connection.credentialFields
           : defaultCredentialFields,
       }))
       .filter((target) => target.authTypes.length > 0);
@@ -76,8 +76,8 @@ function resolveAuthTargets(integration: Integration): AuthTarget[] {
 
   return [{
     key: integration.name,
-    label: integration.display_name || integration.name,
-    authTypes: normalizeAuthTypes(integration.auth_types),
+    label: integration.displayName || integration.name,
+    authTypes: normalizeAuthTypes(integration.authTypes),
     credentialFields: defaultCredentialFields,
   }];
 }
@@ -157,13 +157,13 @@ export default function IntegrationSettingsModal({
     dialogRef.current?.showModal();
   }, []);
 
-  const displayName = integration.display_name || integration.name;
+  const displayName = integration.displayName || integration.name;
   const headingId = `settings-modal-heading-${integration.name}`;
   const authTargets = resolveAuthTargets(integration);
   const defaultTarget = authTargets.length === 1 ? authTargets[0] : undefined;
   const defaultConnection = defaultTarget?.connection;
   const connectionActions = buildAuthActions(authTargets, !!integration.connected);
-  const needsParams = integration.connection_params && Object.keys(integration.connection_params).length > 0;
+  const needsParams = integration.connectionParams && Object.keys(integration.connectionParams).length > 0;
 
   function handleCancel(e: React.SyntheticEvent<HTMLDialogElement>) {
     if (disconnecting || submitting) {
@@ -210,7 +210,7 @@ export default function IntegrationSettingsModal({
     const target = pendingAction?.connection
       ? authTargets.find((authTarget) => authTarget.connection === pendingAction.connection)
       : defaultTarget;
-    return target?.credentialFields ?? integration.credential_fields;
+    return target?.credentialFields ?? integration.credentialFields;
   }
 
   function isPendingAction(action: AuthAction): boolean {
@@ -242,9 +242,9 @@ export default function IntegrationSettingsModal({
     }
 
     let params: Record<string, string> | undefined;
-    if (integration.connection_params) {
+    if (integration.connectionParams) {
       const collected: Record<string, string> = {};
-      for (const name of Object.keys(integration.connection_params)) {
+      for (const name of Object.keys(integration.connectionParams)) {
         const val = (fd.get(`cp_${name}`) as string)?.trim();
         if (val) collected[name] = val;
       }
@@ -359,7 +359,7 @@ export default function IntegrationSettingsModal({
             integrationName={integration.name}
             headingId={headingId}
             credentialFields={resolveCredentialFields()}
-            connectionParams={needsParams ? integration.connection_params : undefined}
+            connectionParams={needsParams ? integration.connectionParams : undefined}
             error={error}
             submitting={submitting}
             onSubmit={handleTokenSubmit}
@@ -497,16 +497,6 @@ function TokenForm({
             className="label-text block"
           >
             {field.label || field.name}
-            {field.help_url && (
-              <a
-                href={field.help_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="ml-1.5 normal-case tracking-normal text-gold-600 hover:underline dark:text-gold-400"
-              >
-                (where to find this)
-              </a>
-            )}
           </label>
           {field.description && (
             <p className="mt-1 text-xs text-faint normal-case tracking-normal">{renderLinkedText(field.description)}</p>

--- a/gestaltd/ui/src/components/Nav.tsx
+++ b/gestaltd/ui/src/components/Nav.tsx
@@ -33,7 +33,7 @@ export default function Nav() {
     getAuthInfo()
       .then((info) => {
         if (active) {
-          setLoginSupported(info.login_supported);
+          setLoginSupported(info.loginSupported);
         }
       })
       .catch(() => {

--- a/gestaltd/ui/src/components/TokenTable.tsx
+++ b/gestaltd/ui/src/components/TokenTable.tsx
@@ -53,11 +53,11 @@ export default function TokenTable({ tokens, onRevoked }: TokenTableProps) {
               <td className="px-5 py-4 text-primary font-medium">{token.name}</td>
               <td className="px-5 py-4 text-muted">{token.scopes || "all"}</td>
               <td className="px-5 py-4 text-muted font-mono text-xs">
-                {new Date(token.created_at).toLocaleDateString()}
+                {new Date(token.createdAt).toLocaleDateString()}
               </td>
               <td className="px-5 py-4 text-muted font-mono text-xs">
-                {token.expires_at
-                  ? new Date(token.expires_at).toLocaleDateString()
+                {token.expiresAt
+                  ? new Date(token.expiresAt).toLocaleDateString()
                   : "Never"}
               </td>
               <td className="px-5 py-4">

--- a/gestaltd/ui/src/lib/api.ts
+++ b/gestaltd/ui/src/lib/api.ts
@@ -11,7 +11,6 @@ export interface CredentialFieldDef {
   name: string;
   label?: string;
   description?: string;
-  help_url?: string;
 }
 
 export interface InstanceInfo {
@@ -21,29 +20,29 @@ export interface InstanceInfo {
 
 export interface ConnectionDefInfo {
   name: string;
-  auth_types: ("oauth" | "manual")[];
-  credential_fields?: CredentialFieldDef[];
+  authTypes: ("oauth" | "manual")[];
+  credentialFields?: CredentialFieldDef[];
 }
 
 export interface Integration {
   name: string;
-  display_name?: string;
+  displayName?: string;
   description?: string;
-  icon_svg?: string;
+  iconSvg?: string;
   connected?: boolean;
   instances?: InstanceInfo[];
-  auth_types?: ("oauth" | "manual")[];
-  connection_params?: Record<string, ConnectionParamDef>;
+  authTypes?: ("oauth" | "manual")[];
+  connectionParams?: Record<string, ConnectionParamDef>;
   connections?: ConnectionDefInfo[];
-  credential_fields?: CredentialFieldDef[];
+  credentialFields?: CredentialFieldDef[];
 }
 
 export interface APIToken {
   id: string;
   name: string;
   scopes: string;
-  created_at: string;
-  expires_at?: string;
+  createdAt: string;
+  expiresAt?: string;
 }
 
 export interface CreateTokenResponse {
@@ -55,8 +54,8 @@ export interface CreateTokenResponse {
 export interface ConnectIntegrationResult {
   status: string;
   integration?: string;
-  selection_url?: string;
-  pending_token?: string;
+  selectionUrl?: string;
+  pendingToken?: string;
   candidates?: { id: string; name?: string }[];
 }
 
@@ -118,8 +117,8 @@ export async function fetchAPI<T>(
 
 export interface AuthInfo {
   provider: string;
-  display_name: string;
-  login_supported: boolean;
+  displayName: string;
+  loginSupported: boolean;
 }
 
 export async function getAuthInfo(): Promise<AuthInfo> {
@@ -136,7 +135,7 @@ export async function startLogin(state: string): Promise<{ url: string }> {
 export async function loginCallback(
   code: string,
   state?: string,
-): Promise<{ email: string; display_name: string }> {
+): Promise<{ email: string; displayName: string }> {
   const params = new URLSearchParams({ code });
   if (state) params.set("state", state);
   return fetchAPI(`/api/v1/auth/login/callback?${params}`);
@@ -164,7 +163,7 @@ export async function startIntegrationOAuth(
       instance,
       connection,
       scopes: scopes || [],
-      connection_params: connectionParams,
+      connectionParams,
     }),
   });
 }
@@ -180,7 +179,7 @@ export async function connectManualIntegration(
     integration,
     instance,
     connection,
-    connection_params: connectionParams,
+    connectionParams,
   };
   if (typeof credential === "string") {
     body.credential = credential;

--- a/sdk/go/convert.go
+++ b/sdk/go/convert.go
@@ -18,7 +18,7 @@ func writeCatalogYAML(cat *proto.Catalog, path string) error {
 		}
 		return nil
 	}
-	jsonData, err := protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: false}.Marshal(cat)
+	jsonData, err := protojson.MarshalOptions{UseProtoNames: false, EmitDefaultValues: false}.Marshal(cat)
 	if err != nil {
 		return fmt.Errorf("marshal catalog: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Converts all YAML and JSON serialized field names from snake_case to camelCase across Go struct tags, JSON schema, TypeScript interfaces, Rust serde definitions, test fixtures, Helm chart values, and documentation
- Removes the `help_url` field from credential definitions entirely
- Switches the SDK protojson catalog serializer from `UseProtoNames` to emit camelCase, matching the new struct tags

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `cargo check` passes (Rust CLI)
- [x] Zero remaining snake_case YAML/JSON struct tags (verified with grep)
- [x] Zero remaining `help_url`/`HelpURL` references (verified with grep)
- [ ] Verify UI builds (`cd gestaltd/ui && npx tsc --noEmit`)
- [ ] Verify Rust tests (`cd gestalt/cli && cargo test`)
- [ ] Confirm external auth plugins (gestalt-providers) are updated to expect camelCase config fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)