### PR TITLE
Add alpha stability disclaimers across all documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Stability: Alpha](https://img.shields.io/badge/stability-alpha-f4d03f.svg)](https://github.com/valon-technologies/gestalt/issues)
 
-> **Alpha software** -- Gestalt is under active development. APIs and configuration may change between releases. We welcome feedback and bug reports via [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
+> **Alpha.** Gestalt is under active development. APIs and configuration may change between releases. We welcome feedback and bug reports via [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
 
 Gestalt is a platform for self-hostable, configurable integrations and tooling, with authentication and execution out-of-the-box.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Gestalt
 
+[![Stability: Alpha](https://img.shields.io/badge/stability-alpha-f4d03f.svg)](https://github.com/valon-technologies/gestalt/issues)
+
+> **Alpha software** -- Gestalt is under active development. APIs and configuration may change between releases. We welcome feedback and bug reports via [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
+
 Gestalt is a platform for self-hostable, configurable integrations and tooling, with authentication and execution out-of-the-box.
 
 ## How does Gestalt work?

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -1,10 +1,16 @@
-import { Cards } from 'nextra/components'
+import { Cards, Callout } from 'nextra/components'
 
 # Gestalt
 
 Gestalt is a self-hostable integration platform. A single YAML config defines
 how users authenticate, how upstream APIs are connected, and which tools are
 exposed through the HTTP API, web UI, and `/mcp`.
+
+<Callout type="warning">
+  **Alpha software** -- Gestalt is under active development. APIs and
+  configuration may change between releases. Feedback and bug reports are
+  welcome via [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
+</Callout>
 
 ## How it works
 

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -7,7 +7,7 @@ how users authenticate, how upstream APIs are connected, and which tools are
 exposed through the HTTP API, web UI, and `/mcp`.
 
 <Callout type="warning">
-  **Alpha software** -- Gestalt is under active development. APIs and
+  **Alpha.** Gestalt is under active development. APIs and
   configuration may change between releases. Feedback and bug reports are
   welcome via [GitHub Issues](https://github.com/valon-technologies/gestalt/issues).
 </Callout>

--- a/docs/dockerhub/gestalt.md
+++ b/docs/dockerhub/gestalt.md
@@ -8,6 +8,10 @@
 - invoking integration operations
 - managing configuration and credentials
 
+> **Alpha software** -- Gestalt is under active development. Images are tagged
+> with alpha versions and may introduce breaking changes. See the
+> [documentation](https://gestaltd.ai) for the latest guidance.
+
 ## Quick reference
 
 - Image: `valontechnologies/gestalt`

--- a/docs/dockerhub/gestalt.md
+++ b/docs/dockerhub/gestalt.md
@@ -8,7 +8,7 @@
 - invoking integration operations
 - managing configuration and credentials
 
-> **Alpha software** -- Gestalt is under active development. Images are tagged
+> **Alpha.** Gestalt is under active development. Images are tagged
 > with alpha versions and may introduce breaking changes. See the
 > [documentation](https://gestaltd.ai) for the latest guidance.
 

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -9,7 +9,7 @@
 - an `/mcp` endpoint when providers expose tools
 - support for REST, GraphQL, MCP, and source or published plugins
 
-> **Alpha software** -- Gestalt is under active development. Images are tagged
+> **Alpha.** Gestalt is under active development. Images are tagged
 > with alpha versions and may introduce breaking changes. See the
 > [documentation](https://gestaltd.ai) for the latest guidance.
 

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -9,6 +9,10 @@
 - an `/mcp` endpoint when providers expose tools
 - support for REST, GraphQL, MCP, and source or published plugins
 
+> **Alpha software** -- Gestalt is under active development. Images are tagged
+> with alpha versions and may introduce breaking changes. See the
+> [documentation](https://gestaltd.ai) for the latest guidance.
+
 ## Quick reference
 
 - Image: `valontechnologies/gestaltd`


### PR DESCRIPTION
## Summary
- Add shields.io alpha stability badge and blockquote disclaimer to the main README
- Add Nextra `Callout` warning to the docs site landing page (`docs/content/index.mdx`)
- Add plain markdown blockquote disclaimers to both Docker Hub image descriptions (`gestaltd.md` and `gestalt.md`)

All locations communicate the same core message: Gestalt is alpha software under active development, APIs and configuration may change between releases, and feedback is welcome via GitHub Issues.

## Test plan
- [ ] Verify the shields.io badge renders correctly on the GitHub README
- [ ] Run docs dev server (`npm run dev` in `docs/`) and confirm the Callout renders with yellow/amber warning styling on the landing page
- [ ] Visual review of Docker Hub markdown formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)