### PR TITLE
Remove stale doc references to deprecated APIs

### DIFF
--- a/docs/content/providers/releasing.mdx
+++ b/docs/content/providers/releasing.mdx
@@ -168,8 +168,6 @@ UI packages use the same manifest system:
 ```yaml
 source: github.com/acme/plugins/web/default
 version: 1.2.0
-kinds:
-  - webui
 webui:
   asset_root: ui/out
   config_schema_path: schemas/ui-config.schema.json

--- a/docs/content/providers/secrets.mdx
+++ b/docs/content/providers/secrets.mdx
@@ -15,8 +15,6 @@ source: github.com/example/plugins/my-secrets
 version: 0.0.1-alpha.1
 display_name: My Secrets Provider
 description: Resolves secrets from a custom vault.
-kinds:
-  - secrets
 secrets:
   config_schema_path: ./secrets_config.json
 ```

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -9,9 +9,9 @@ Current scope:
 - vendored `protoc` via `protoc-bin-vendored`
 - generated protocol bindings exposed via `proto::v1`
 - typed integration-provider authoring helpers for requests, responses, catalogs, and routing
-- auth-provider and datastore-provider traits that map to the shared executable runtime protocol
-- runtime servers for the integration, auth, and datastore provider surfaces over the Unix socket exposed by `gestaltd`
-- `export_provider!`, `export_auth_provider!`, and `export_datastore_provider!` macros for source builds that let `gestaltd` synthesize the executable wrapper
+- auth-provider and secrets-provider traits that map to the shared executable runtime protocol
+- runtime servers for the integration, auth, and secrets provider surfaces over the Unix socket exposed by `gestaltd`
+- `export_provider!`, `export_auth_provider!`, and `export_secrets_provider!` macros for source builds that let `gestaltd` synthesize the executable wrapper
 
 ## Codegen strategy
 
@@ -32,14 +32,14 @@ The crate is intentionally small:
 
 - `Provider`, `Request`, `Response`, and `ok(...)` model integration providers
 - `AuthProvider`, `BeginLoginRequest`, `BeginLoginResponse`, `CompleteLoginRequest`, and `AuthenticatedUser` model auth providers
-- `DatastoreProvider`, `StoredUser`, `StoredIntegrationToken`, `StoredApiToken`, and `OAuthRegistration` model datastore providers
+- `SecretsProvider` models secrets providers
 - `Router` and `Operation` register typed operations and derive catalog metadata from `serde` + `schemars`
 - `Catalog` types expose explicit static or session-scoped catalogs when needed
 - `RuntimeMetadata` lets any provider kind describe its runtime name/display metadata and version
-- `runtime` runs the integration, auth, or datastore gRPC servers, or writes the static catalog when `GESTALT_PLUGIN_WRITE_CATALOG` is set
+- `runtime` runs the integration, auth, or secrets gRPC servers, or writes the static catalog when `GESTALT_PLUGIN_WRITE_CATALOG` is set
 - `export_provider!` exports `__gestalt_serve` and `__gestalt_write_catalog` for integration providers
 - `export_auth_provider!` exports `__gestalt_serve_auth` for auth providers
-- `export_datastore_provider!` exports `__gestalt_serve_datastore` for datastore providers
+- `export_secrets_provider!` exports `__gestalt_serve_secrets` for secrets providers
 
 ## Package layout
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -96,10 +96,10 @@ Use `ok(body)` for normal responses and `response(status, body)` when a handler
 needs to set a non-200 status. Plain objects with `status` and `body` fields
 are treated as user data.
 
-Auth providers and datastore providers use dedicated helpers:
+Auth providers and secrets providers use dedicated helpers:
 
 ```ts
-import { defineAuthProvider, defineDatastoreProvider } from "@valon-technologies/gestalt";
+import { defineAuthProvider, defineSecretsProvider } from "@valon-technologies/gestalt";
 ```
 
 ## Runtime and build entrypoints


### PR DESCRIPTION
The secrets and releasing docs still included the deprecated `kinds:`
manifest field, which the plugin-manifests reference explicitly says
does not exist. The TypeScript and Rust SDK READMEs still referenced
`DatastoreProvider` and `defineDatastoreProvider`, which were removed
when datastore support moved to built-in drivers.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>