### PR TITLE
Align Go config types with YAML and unify provider primitive

### DIFF
--- a/gestaltd/cmd/gestaltd/factories.go
+++ b/gestaltd/cmd/gestaltd/factories.go
@@ -94,7 +94,7 @@ func buildFactories() *bootstrap.FactoryRegistry {
 	factories.Telemetry["stdout"] = telemetrystdout.Factory
 	factories.Telemetry["otlp"] = telemetryotlp.Factory
 	factories.Audit = func(ctx context.Context, cfg config.AuditConfig, telemetry core.TelemetryProvider) (core.AuditSink, func(context.Context) error, error) {
-		switch cfg.Provider {
+		switch cfg.BuiltinProvider {
 		case "", "inherit":
 			return invocation.NewLoggerAuditSink(telemetry.Logger()), nil, nil
 		case "noop":
@@ -117,7 +117,7 @@ func buildFactories() *bootstrap.FactoryRegistry {
 			}
 			return invocation.NewLevelAwareLoggerAuditSink(logger), closeFn, nil
 		default:
-			return nil, nil, fmt.Errorf("unknown audit provider %q", cfg.Provider)
+			return nil, nil, fmt.Errorf("unknown audit provider %q", cfg.BuiltinProvider)
 		}
 	}
 	factories.Auth = authplugin.Factory

--- a/gestaltd/cmd/gestaltd/factories.go
+++ b/gestaltd/cmd/gestaltd/factories.go
@@ -94,6 +94,9 @@ func buildFactories() *bootstrap.FactoryRegistry {
 	factories.Telemetry["stdout"] = telemetrystdout.Factory
 	factories.Telemetry["otlp"] = telemetryotlp.Factory
 	factories.Audit = func(ctx context.Context, cfg config.AuditConfig, telemetry core.TelemetryProvider) (core.AuditSink, func(context.Context) error, error) {
+		if cfg.Provider != nil {
+			return nil, nil, fmt.Errorf("plugin-based audit providers are not yet supported")
+		}
 		switch cfg.BuiltinProvider {
 		case "", "inherit":
 			return invocation.NewLoggerAuditSink(telemetry.Logger()), nil, nil

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -157,7 +157,7 @@ func runServer(env *bootstrapEnv) error {
 		DefaultConnection: connMaps.DefaultConnection,
 		CatalogConnection: connMaps.MCPConnection,
 		ConnectionAuth:    result.ConnectionAuth,
-		PluginDefs:   env.Config.Plugins,
+		PluginDefs:        env.Config.Plugins,
 		PublicBaseURL:     env.Config.Server.BaseURL,
 		SecureCookies:     strings.HasPrefix(env.Config.Server.BaseURL, "https://"),
 		StateSecret:       crypto.DeriveKey(env.Config.Server.EncryptionKey),

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -157,7 +157,7 @@ func runServer(env *bootstrapEnv) error {
 		DefaultConnection: connMaps.DefaultConnection,
 		CatalogConnection: connMaps.MCPConnection,
 		ConnectionAuth:    result.ConnectionAuth,
-		IntegrationDefs:   env.Config.Integrations,
+		PluginDefs:   env.Config.Plugins,
 		PublicBaseURL:     env.Config.Server.BaseURL,
 		SecureCookies:     strings.HasPrefix(env.Config.Server.BaseURL, "https://"),
 		StateSecret:       crypto.DeriveKey(env.Config.Server.EncryptionKey),
@@ -352,7 +352,7 @@ func buildMCPSurface(cfg *config.Config, connMaps bootstrap.ConnectionMaps) mcpS
 		mcpConnection: make(map[string]string),
 	}
 
-	for name, intg := range cfg.Integrations {
+	for name, intg := range cfg.Plugins {
 		if intg.Plugin == nil {
 			continue
 		}
@@ -454,10 +454,10 @@ func logConfigSummary(path string, cfg *config.Config) {
 		"auth_provider", providerLabel(cfg.Auth.Provider),
 		"datastore_provider", providerLabel(cfg.Datastore.Provider),
 		"secrets_provider", secretsProviderLabel(cfg.Secrets),
-		"telemetry_provider", cfg.Telemetry.Provider,
+		"telemetry_provider", cfg.Telemetry.BuiltinProvider,
 	)
 
-	for name, intg := range cfg.Integrations {
+	for name, intg := range cfg.Plugins {
 		if intg.Plugin != nil {
 			slog.Info("integration configured", "integration", name, "type", "plugin")
 		}

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -424,6 +424,9 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 }
 
 func buildTelemetry(cfg *config.Config, factories *FactoryRegistry) (core.TelemetryProvider, error) {
+	if cfg.Telemetry.Provider != nil {
+		return nil, fmt.Errorf("bootstrap: plugin-based telemetry providers are not yet supported")
+	}
 	factory, ok := factories.Telemetry[cfg.Telemetry.BuiltinProvider]
 	if !ok {
 		return nil, fmt.Errorf("bootstrap: unknown telemetry provider %q", cfg.Telemetry.BuiltinProvider)
@@ -436,6 +439,9 @@ func buildTelemetry(cfg *config.Config, factories *FactoryRegistry) (core.Teleme
 }
 
 func buildAuditSink(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, telemetry core.TelemetryProvider) (core.AuditSink, func(context.Context) error, error) {
+	if cfg.Audit.Provider != nil {
+		return nil, nil, fmt.Errorf("bootstrap: plugin-based audit providers are not yet supported")
+	}
 	if factories.Audit == nil {
 		switch cfg.Audit.BuiltinProvider {
 		case "", "inherit":

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -85,7 +85,7 @@ type providerMetadata struct {
 	iconSVG     string
 }
 
-func resolveProviderMetadata(intg config.IntegrationDef) providerMetadata {
+func resolveProviderMetadata(intg config.PluginDef) providerMetadata {
 	meta := providerMetadata{
 		displayName: intg.DisplayName,
 		description: intg.Description,
@@ -424,29 +424,29 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 }
 
 func buildTelemetry(cfg *config.Config, factories *FactoryRegistry) (core.TelemetryProvider, error) {
-	factory, ok := factories.Telemetry[cfg.Telemetry.Provider]
+	factory, ok := factories.Telemetry[cfg.Telemetry.BuiltinProvider]
 	if !ok {
-		return nil, fmt.Errorf("bootstrap: unknown telemetry provider %q", cfg.Telemetry.Provider)
+		return nil, fmt.Errorf("bootstrap: unknown telemetry provider %q", cfg.Telemetry.BuiltinProvider)
 	}
 	tp, err := factory(cfg.Telemetry.Config)
 	if err != nil {
-		return nil, fmt.Errorf("bootstrap: telemetry provider %q: %w", cfg.Telemetry.Provider, err)
+		return nil, fmt.Errorf("bootstrap: telemetry provider %q: %w", cfg.Telemetry.BuiltinProvider, err)
 	}
 	return tp, nil
 }
 
 func buildAuditSink(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, telemetry core.TelemetryProvider) (core.AuditSink, func(context.Context) error, error) {
 	if factories.Audit == nil {
-		switch cfg.Audit.Provider {
+		switch cfg.Audit.BuiltinProvider {
 		case "", "inherit":
 			return invocation.NewLoggerAuditSink(telemetry.Logger()), nil, nil
 		default:
-			return nil, nil, fmt.Errorf("bootstrap: unknown audit provider %q", cfg.Audit.Provider)
+			return nil, nil, fmt.Errorf("bootstrap: unknown audit provider %q", cfg.Audit.BuiltinProvider)
 		}
 	}
 	sink, closeFn, err := factories.Audit(ctx, cfg.Audit, telemetry)
 	if err != nil {
-		return nil, nil, fmt.Errorf("bootstrap: audit provider %q: %w", cfg.Audit.Provider, err)
+		return nil, nil, fmt.Errorf("bootstrap: audit provider %q: %w", cfg.Audit.BuiltinProvider, err)
 	}
 	return sink, closeFn, nil
 }

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -58,9 +58,9 @@ func validConfig() *config.Config {
 		Datastores: map[string]config.DatastoreDef{
 			"sqlite": {Driver: "sqlite", DSN: ":memory:"},
 		},
-		Secrets:      config.SecretsConfig{BuiltinProvider: "test-secrets"},
-		Telemetry:    config.TelemetryConfig{BuiltinProvider: "test-telemetry"},
-		Plugins: map[string]config.PluginDef{},
+		Secrets:   config.SecretsConfig{BuiltinProvider: "test-secrets"},
+		Telemetry: config.TelemetryConfig{BuiltinProvider: "test-telemetry"},
+		Plugins:   map[string]config.PluginDef{},
 		Server: config.ServerConfig{
 			Public:        config.ListenerConfig{Port: 8080},
 			EncryptionKey: "test-key",

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -59,8 +59,8 @@ func validConfig() *config.Config {
 			"sqlite": {Driver: "sqlite", DSN: ":memory:"},
 		},
 		Secrets:      config.SecretsConfig{BuiltinProvider: "test-secrets"},
-		Telemetry:    config.TelemetryConfig{Provider: "test-telemetry"},
-		Integrations: map[string]config.IntegrationDef{},
+		Telemetry:    config.TelemetryConfig{BuiltinProvider: "test-telemetry"},
+		Plugins: map[string]config.PluginDef{},
 		Server: config.ServerConfig{
 			Public:        config.ListenerConfig{Port: 8080},
 			EncryptionKey: "test-key",
@@ -157,7 +157,7 @@ func TestBootstrapNoIntegrations(t *testing.T) {
 	ctx := context.Background()
 
 	cfg := validConfig()
-	cfg.Integrations = nil
+	cfg.Plugins = nil
 
 	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
 	if err != nil {

--- a/gestaltd/internal/bootstrap/connections.go
+++ b/gestaltd/internal/bootstrap/connections.go
@@ -19,12 +19,12 @@ type ConnectionMaps struct {
 
 func BuildConnectionMaps(cfg *config.Config) (ConnectionMaps, error) {
 	maps := ConnectionMaps{
-		DefaultConnection: make(map[string]string, len(cfg.Integrations)),
-		APIConnection:     make(map[string]string, len(cfg.Integrations)),
-		MCPConnection:     make(map[string]string, len(cfg.Integrations)),
+		DefaultConnection: make(map[string]string, len(cfg.Plugins)),
+		APIConnection:     make(map[string]string, len(cfg.Plugins)),
+		MCPConnection:     make(map[string]string, len(cfg.Plugins)),
 	}
 
-	for name, intg := range cfg.Integrations {
+	for name, intg := range cfg.Plugins {
 		defaultConnection := config.PluginConnectionName
 		apiConnection := config.PluginConnectionName
 		mcpConnection := config.PluginConnectionName
@@ -261,7 +261,7 @@ func resolveManifestRelativeSpecURL(plugin *config.ProviderDef, raw string) stri
 	return filepath.Clean(filepath.Join(filepath.Dir(plugin.ResolvedManifestPath), raw))
 }
 
-func buildConnectionAuthMap(name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, pluginConfig map[string]any, authFallback *specAuthFallback, deps Deps) (map[string]OAuthHandler, error) {
+func buildConnectionAuthMap(name string, intg config.PluginDef, manifest *pluginmanifestv1.Manifest, pluginConfig map[string]any, authFallback *specAuthFallback, deps Deps) (map[string]OAuthHandler, error) {
 	manifestPlugin := (*pluginmanifestv1.Plugin)(nil)
 	if manifest != nil {
 		manifestPlugin = manifest.Plugin

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -26,7 +26,7 @@ func TestExecutableSDKExampleProviderReceivesStartConfig(t *testing.T) {
 	manifestRoot := exampleProviderRoot(t)
 	manifest := newExecutableManifest("Example Provider", "A minimal example provider built with the public SDK")
 	cfg := &config.Config{
-		Integrations: map[string]config.IntegrationDef{
+		Plugins: map[string]config.PluginDef{
 			"example": {
 				Plugin: &config.ProviderDef{
 					Command:              bin,
@@ -151,7 +151,7 @@ plugin = "provider"
 	t.Setenv("PATH", t.TempDir())
 
 	cfg := &config.Config{
-		Integrations: map[string]config.IntegrationDef{
+		Plugins: map[string]config.PluginDef{
 			"python-source": {
 				Plugin: &config.ProviderDef{
 					ResolvedManifest:     manifest,
@@ -210,7 +210,7 @@ func TestExecutableSDKExampleProviderAppliesConfigMetadataOverrides(t *testing.T
 	manifest := newExecutableManifest("Manifest Display", "Manifest Description")
 
 	cfg := &config.Config{
-		Integrations: map[string]config.IntegrationDef{
+		Plugins: map[string]config.PluginDef{
 			"example": {
 				DisplayName: "Config Display",
 				Description: "Config Description",
@@ -330,7 +330,7 @@ func TestPluginManifestOAuthWiresConnectionAuth(t *testing.T) {
 		Scopes:           []string{"read", "write"},
 	}
 	cfg := &config.Config{
-		Integrations: map[string]config.IntegrationDef{
+		Plugins: map[string]config.PluginDef{
 			"echoauth": {
 				Plugin: &config.ProviderDef{
 					Command: bin,
@@ -393,7 +393,7 @@ func TestPluginManifestNoAuthSkipsConnectionAuth(t *testing.T) {
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	cfg := &config.Config{
-		Integrations: map[string]config.IntegrationDef{
+		Plugins: map[string]config.PluginDef{
 			"echonoauth": {
 				Plugin: &config.ProviderDef{
 					Command:              bin,
@@ -430,7 +430,7 @@ func TestPluginManifestNamedOAuthKeepsProviderTokenMode(t *testing.T) {
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	cfg := &config.Config{
-		Integrations: map[string]config.IntegrationDef{
+		Plugins: map[string]config.PluginDef{
 			"echoauth": {
 				Plugin: &config.ProviderDef{
 					Command:           bin,
@@ -489,7 +489,7 @@ func TestPluginProcessEnvIsolation(t *testing.T) {
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 
 	cfg := &config.Config{
-		Integrations: map[string]config.IntegrationDef{
+		Plugins: map[string]config.PluginDef{
 			"echoext": {
 				Plugin: &config.ProviderDef{
 					Command:              bin,
@@ -546,7 +546,7 @@ func TestExecutablePluginRequiresManifest(t *testing.T) {
 
 	bin := buildEchoPluginBinary(t)
 	cfg := &config.Config{
-		Integrations: map[string]config.IntegrationDef{
+		Plugins: map[string]config.PluginDef{
 			"echoext": {
 				Plugin: &config.ProviderDef{
 					Command: bin,

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -70,14 +70,14 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 	}
 
 	ready := make(chan struct{})
-	if len(cfg.Integrations) == 0 {
+	if len(cfg.Plugins) == 0 {
 		close(ready)
 		return &reg.Providers, ready, func() map[string]map[string]OAuthHandler { return connAuth }, nil
 	}
 
 	var wg sync.WaitGroup
-	for name := range cfg.Integrations {
-		intgDef := cfg.Integrations[name]
+	for name := range cfg.Plugins {
+		intgDef := cfg.Plugins[name]
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -112,7 +112,7 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 	return &reg.Providers, ready, resolver, nil
 }
 
-func buildProvider(ctx context.Context, name string, intg config.IntegrationDef, deps Deps) (*ProviderBuildResult, error) {
+func buildProvider(ctx context.Context, name string, intg config.PluginDef, deps Deps) (*ProviderBuildResult, error) {
 	if intg.Plugin == nil {
 		return nil, fmt.Errorf("integration %q has no plugin defined", name)
 	}
@@ -162,7 +162,7 @@ func buildProvider(ctx context.Context, name string, intg config.IntegrationDef,
 	}
 }
 
-func buildExecutablePluginProvider(ctx context.Context, name string, intg config.IntegrationDef, pluginConfig map[string]any, meta providerMetadata, deps Deps) (*ProviderBuildResult, error) {
+func buildExecutablePluginProvider(ctx context.Context, name string, intg config.PluginDef, pluginConfig map[string]any, meta providerMetadata, deps Deps) (*ProviderBuildResult, error) {
 	manifest := intg.Plugin.ResolvedManifest
 	manifestPlugin := intg.Plugin.ManifestPlugin()
 	if manifest == nil || manifestPlugin == nil {
@@ -275,7 +275,7 @@ type specAuthFallback struct {
 	connectionName string
 }
 
-func newProviderBuildResult(name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, pluginConfig map[string]any, prov core.Provider, authFallback *specAuthFallback, deps Deps) (*ProviderBuildResult, error) {
+func newProviderBuildResult(name string, intg config.PluginDef, manifest *pluginmanifestv1.Manifest, pluginConfig map[string]any, prov core.Provider, authFallback *specAuthFallback, deps Deps) (*ProviderBuildResult, error) {
 	result := &ProviderBuildResult{Provider: prov}
 	var err error
 	result.ConnectionAuth, err = buildConnectionAuthMap(name, intg, manifest, pluginConfig, authFallback, deps)
@@ -286,7 +286,7 @@ func newProviderBuildResult(name string, intg config.IntegrationDef, manifest *p
 	return result, nil
 }
 
-func buildSpecLoadedProvider(ctx context.Context, name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, pluginConfig map[string]any, meta providerMetadata, deps Deps, allowedOperations map[string]*config.OperationOverride) (*ProviderBuildResult, error) {
+func buildSpecLoadedProvider(ctx context.Context, name string, intg config.PluginDef, manifest *pluginmanifestv1.Manifest, pluginConfig map[string]any, meta providerMetadata, deps Deps, allowedOperations map[string]*config.OperationOverride) (*ProviderBuildResult, error) {
 	mp := manifest.Plugin
 	plan, err := buildPluginConnectionPlan(intg.Plugin, mp)
 	if err != nil {
@@ -466,7 +466,7 @@ func catalogOperationCount(cat *catalog.Catalog) int {
 	return len(cat.Operations)
 }
 
-func buildPluginProvider(ctx context.Context, intg config.IntegrationDef, pluginConfig map[string]any, spec pluginhost.StaticProviderSpec, deps Deps) (core.Provider, error) {
+func buildPluginProvider(ctx context.Context, intg config.PluginDef, pluginConfig map[string]any, spec pluginhost.StaticProviderSpec, deps Deps) (core.Provider, error) {
 	command := intg.Plugin.Command
 	args := intg.Plugin.Args
 	env := clonePluginEnv(intg.Plugin.Env)
@@ -539,7 +539,7 @@ func clonePluginEnv(src map[string]string) map[string]string {
 	return dst
 }
 
-func buildPluginStaticSpec(name string, intg config.IntegrationDef, manifest *pluginmanifestv1.Manifest, meta providerMetadata) (pluginhost.StaticProviderSpec, error) {
+func buildPluginStaticSpec(name string, intg config.PluginDef, manifest *pluginmanifestv1.Manifest, meta providerMetadata) (pluginhost.StaticProviderSpec, error) {
 	if manifest == nil || manifest.Plugin == nil {
 		return pluginhost.StaticProviderSpec{}, fmt.Errorf("resolved manifest is required")
 	}

--- a/gestaltd/internal/bootstrap/sandbox_test.go
+++ b/gestaltd/internal/bootstrap/sandbox_test.go
@@ -62,7 +62,7 @@ func TestSandboxedPluginCannotReadUnauthorizedFile(t *testing.T) {
 	)
 
 	cfg := &config.Config{
-		Integrations: map[string]config.IntegrationDef{
+		Plugins: map[string]config.PluginDef{
 			"sandboxed": {
 				Plugin: &config.ProviderDef{
 					Command:              bin,
@@ -108,7 +108,7 @@ func TestSandboxedPluginCanCommunicateViaGRPC(t *testing.T) {
 	)
 
 	cfg := &config.Config{
-		Integrations: map[string]config.IntegrationDef{
+		Plugins: map[string]config.PluginDef{
 			"sandboxed": {
 				Plugin: &config.ProviderDef{
 					Command:              bin,
@@ -157,7 +157,7 @@ func TestSandboxedSynthesizedSourcePluginCanStart(t *testing.T) {
 	}
 
 	cfg := &config.Config{
-		Integrations: map[string]config.IntegrationDef{
+		Plugins: map[string]config.PluginDef{
 			"example": {
 				Plugin: &config.ProviderDef{
 					AllowedHosts:         []string{"localhost"},
@@ -211,7 +211,7 @@ func TestSandboxDisabledByDefault(t *testing.T) {
 	)
 
 	cfg := &config.Config{
-		Integrations: map[string]config.IntegrationDef{
+		Plugins: map[string]config.PluginDef{
 			"nosandbox": {
 				Plugin: &config.ProviderDef{
 					Command:              bin,
@@ -260,7 +260,7 @@ func TestSandboxedPluginHTTPProxyAllowsConfiguredHosts(t *testing.T) {
 	)
 
 	cfg := &config.Config{
-		Integrations: map[string]config.IntegrationDef{
+		Plugins: map[string]config.PluginDef{
 			"proxied": {
 				Plugin: &config.ProviderDef{
 					Command:              bin,
@@ -318,7 +318,7 @@ func TestSandboxedPluginHTTPProxyBlocksUnconfiguredHosts(t *testing.T) {
 	)
 
 	cfg := &config.Config{
-		Integrations: map[string]config.IntegrationDef{
+		Plugins: map[string]config.PluginDef{
 			"blocked": {
 				Plugin: &config.ProviderDef{
 					Command:              bin,

--- a/gestaltd/internal/bootstrap/secret_resolution.go
+++ b/gestaltd/internal/bootstrap/secret_resolution.go
@@ -40,8 +40,8 @@ func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretMa
 	if err := resolveStringFields(&cfg.Server, resolve); err != nil {
 		return err
 	}
-	for name := range cfg.Integrations {
-		intg := cfg.Integrations[name]
+	for name := range cfg.Plugins {
+		intg := cfg.Plugins[name]
 		if err := resolveStringFields(&intg, resolve); err != nil {
 			return err
 		}
@@ -60,7 +60,7 @@ func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretMa
 				return err
 			}
 		}
-		cfg.Integrations[name] = intg
+		cfg.Plugins[name] = intg
 	}
 	if cfg.Auth.Provider != nil {
 		if err := resolveStringFields(cfg.Auth.Provider, resolve); err != nil {
@@ -79,6 +79,16 @@ func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretMa
 	}
 	if cfg.UI.Provider != nil {
 		if err := resolveStringFields(cfg.UI.Provider, resolve); err != nil {
+			return err
+		}
+	}
+	if cfg.Telemetry.Provider != nil {
+		if err := resolveStringFields(cfg.Telemetry.Provider, resolve); err != nil {
+			return err
+		}
+	}
+	if cfg.Audit.Provider != nil {
+		if err := resolveStringFields(cfg.Audit.Provider, resolve); err != nil {
 			return err
 		}
 	}

--- a/gestaltd/internal/bootstrap/structured_logging_test.go
+++ b/gestaltd/internal/bootstrap/structured_logging_test.go
@@ -20,7 +20,7 @@ func TestBootstrapSkippedProviderLogsWarning(t *testing.T) { //nolint:parallelte
 	t.Cleanup(func() { slog.SetDefault(prev) })
 
 	cfg := validConfig()
-	cfg.Integrations = map[string]config.IntegrationDef{
+	cfg.Plugins = map[string]config.PluginDef{
 		"broken": {
 			Plugin: &config.ProviderDef{
 				Source: &config.PluginSourceDef{Path: "./manifest.yaml"},

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -71,11 +71,11 @@ func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *Fa
 		}
 	}
 
-	names := slices.Sorted(maps.Keys(cfg.Integrations))
+	names := slices.Sorted(maps.Keys(cfg.Plugins))
 
 	var errs []error
 	for _, name := range names {
-		intgDef := cfg.Integrations[name]
+		intgDef := cfg.Plugins[name]
 		result, err := buildProviderForValidation(ctx, name, intgDef, deps)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("integration %q: %w", name, err))
@@ -98,7 +98,7 @@ func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *Fa
 	return &reg.Providers, connAuth, nil
 }
 
-func buildProviderForValidation(ctx context.Context, name string, intg config.IntegrationDef, deps Deps) (*ProviderBuildResult, error) {
+func buildProviderForValidation(ctx context.Context, name string, intg config.PluginDef, deps Deps) (*ProviderBuildResult, error) {
 	if intg.Plugin == nil || !intg.Plugin.HasManagedArtifacts() || !intg.Plugin.HasResolvedManifest() {
 		return buildProvider(ctx, name, intg, deps)
 	}
@@ -116,7 +116,7 @@ type preparedProviderStub struct {
 	connectionMode core.ConnectionMode
 }
 
-func newPreparedProviderStub(name string, intg config.IntegrationDef) (core.Provider, error) {
+func newPreparedProviderStub(name string, intg config.PluginDef) (core.Provider, error) {
 	if intg.Plugin == nil || intg.Plugin.ResolvedManifest == nil {
 		return nil, fmt.Errorf("prepared manifest is not resolved")
 	}
@@ -152,7 +152,7 @@ func (p *preparedProviderStub) Execute(context.Context, string, map[string]any, 
 	return nil, fmt.Errorf("prepared validation stub cannot execute operations")
 }
 
-func connectionModeFromPlugin(intg config.IntegrationDef) core.ConnectionMode {
+func connectionModeFromPlugin(intg config.PluginDef) core.ConnectionMode {
 	if intg.Plugin == nil {
 		return core.ConnectionModeUser
 	}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -44,20 +44,22 @@ type Config struct {
 	Secrets      SecretsConfig             `yaml:"secrets"`
 	Telemetry    TelemetryConfig           `yaml:"telemetry"`
 	Audit        AuditConfig               `yaml:"audit"`
-	Integrations map[string]IntegrationDef `yaml:"plugins"`
+	Plugins map[string]PluginDef `yaml:"plugins"`
 	Server       ServerConfig              `yaml:"server"`
 	Egress       EgressConfig              `yaml:"egress"`
 	UI           UIConfig                  `yaml:"ui"`
 }
 
 type TelemetryConfig struct {
-	Provider string    `yaml:"provider"`
-	Config   yaml.Node `yaml:"config"`
+	Provider        *ProviderDef `yaml:"provider"`
+	Config          yaml.Node    `yaml:"config"`
+	BuiltinProvider string       `yaml:"-"`
 }
 
 type AuditConfig struct {
-	Provider string    `yaml:"provider"`
-	Config   yaml.Node `yaml:"config"`
+	Provider        *ProviderDef `yaml:"provider"`
+	Config          yaml.Node    `yaml:"config"`
+	BuiltinProvider string       `yaml:"-"`
 }
 
 type UIConfig struct {
@@ -297,11 +299,11 @@ func (c *UIConfig) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
-func (c *SecretsConfig) UnmarshalYAML(value *yaml.Node) error {
+func unmarshalHybridProvider(value *yaml.Node, kind string, provider **ProviderDef, builtin *string, cfg *yaml.Node) error {
 	if value == nil || value.Kind == 0 {
-		c.Provider = nil
-		c.BuiltinProvider = ""
-		c.Config = yaml.Node{}
+		*provider = nil
+		*builtin = ""
+		*cfg = yaml.Node{}
 		return nil
 	}
 	if value.Kind != yaml.MappingNode {
@@ -313,31 +315,43 @@ func (c *SecretsConfig) UnmarshalYAML(value *yaml.Node) error {
 		switch key {
 		case "provider", "config":
 		default:
-			return fmt.Errorf("field %s not found in type config.SecretsConfig", key)
+			return fmt.Errorf("field %s not found in type config.%sConfig", key, kind)
 		}
 	}
-	c.Provider = nil
-	c.BuiltinProvider = ""
-	c.Config = yaml.Node{}
+	*provider = nil
+	*builtin = ""
+	*cfg = yaml.Node{}
 	providerNode := mappingValueNode(value, "provider")
 	if providerNode != nil {
 		switch {
 		case providerNode.Kind == yaml.ScalarNode && providerNode.Tag != "!!null":
-			c.BuiltinProvider = strings.TrimSpace(providerNode.Value)
+			*builtin = strings.TrimSpace(providerNode.Value)
 		case providerNode.Kind == yaml.MappingNode:
-			decoded, err := decodeTopLevelComponentProvider("secrets", providerNode)
+			decoded, err := decodeTopLevelComponentProvider(kind, providerNode)
 			if err != nil {
 				return err
 			}
-			c.Provider = decoded
+			*provider = decoded
 		case providerNode.Kind != yaml.ScalarNode || providerNode.Tag != "!!null":
-			return fmt.Errorf("secrets.provider must be a string or a provider reference mapping")
+			return fmt.Errorf("%s.provider must be a string or a provider reference mapping", kind)
 		}
 	}
 	if configNode := mappingValueNode(value, "config"); configNode != nil {
-		c.Config = *configNode
+		*cfg = *configNode
 	}
 	return nil
+}
+
+func (c *TelemetryConfig) UnmarshalYAML(value *yaml.Node) error {
+	return unmarshalHybridProvider(value, "telemetry", &c.Provider, &c.BuiltinProvider, &c.Config)
+}
+
+func (c *AuditConfig) UnmarshalYAML(value *yaml.Node) error {
+	return unmarshalHybridProvider(value, "audit", &c.Provider, &c.BuiltinProvider, &c.Config)
+}
+
+func (c *SecretsConfig) UnmarshalYAML(value *yaml.Node) error {
+	return unmarshalHybridProvider(value, "secrets", &c.Provider, &c.BuiltinProvider, &c.Config)
 }
 
 func unmarshalTopLevelComponentConfig(value *yaml.Node, typeName, kind string, provider **ProviderDef, cfg *yaml.Node) error {
@@ -467,7 +481,7 @@ func (s ServerConfig) ManagementAddr() string {
 	return net.JoinHostPort(listener.Host, strconv.Itoa(listener.Port))
 }
 
-type IntegrationDef struct {
+type PluginDef struct {
 	Plugin        *ProviderDef      `yaml:"plugin"`
 	DisplayName   string            `yaml:"displayName"`
 	Description   string            `yaml:"description"`
@@ -777,15 +791,15 @@ func OverlayManagedPluginConfig(path string, cfg *Config) error {
 		return fmt.Errorf("parsing config YAML: %w", err)
 	}
 	plugins := mappingValueNode(documentValueNode(&root), "plugins")
-	for name := range cfg.Integrations {
-		intg := cfg.Integrations[name]
+	for name := range cfg.Plugins {
+		intg := cfg.Plugins[name]
 		if intg.Plugin == nil || !intg.Plugin.HasManagedArtifacts() {
 			continue
 		}
 		if err := overlayManagedPluginConfigNode(mappingValueNode(plugins, name), intg.Plugin, "integration "+strconv.Quote(name)); err != nil {
 			return err
 		}
-		cfg.Integrations[name] = intg
+		cfg.Plugins[name] = intg
 	}
 	if err := overlayManagedComponentConfigNode(mappingValueNode(documentValueNode(&root), "auth"), cfg.Auth.Provider, &cfg.Auth.Config, "auth"); err != nil {
 		return err
@@ -797,6 +811,12 @@ func OverlayManagedPluginConfig(path string, cfg *Config) error {
 		return err
 	}
 	if err := overlayManagedComponentConfigNode(mappingValueNode(documentValueNode(&root), "ui"), cfg.UI.Provider, &cfg.UI.Config, "ui"); err != nil {
+		return err
+	}
+	if err := overlayManagedComponentConfigNode(mappingValueNode(documentValueNode(&root), "telemetry"), cfg.Telemetry.Provider, &cfg.Telemetry.Config, "telemetry"); err != nil {
+		return err
+	}
+	if err := overlayManagedComponentConfigNode(mappingValueNode(documentValueNode(&root), "audit"), cfg.Audit.Provider, &cfg.Audit.Config, "audit"); err != nil {
 		return err
 	}
 	return nil
@@ -980,11 +1000,11 @@ func applyDefaults(cfg *Config) {
 	if cfg.Secrets.Provider == nil && cfg.Secrets.BuiltinProvider == "" {
 		cfg.Secrets.BuiltinProvider = "env"
 	}
-	if cfg.Telemetry.Provider == "" {
-		cfg.Telemetry.Provider = "stdout"
+	if cfg.Telemetry.Provider == nil && cfg.Telemetry.BuiltinProvider == "" {
+		cfg.Telemetry.BuiltinProvider = "stdout"
 	}
-	if cfg.Audit.Provider == "" {
-		cfg.Audit.Provider = "inherit"
+	if cfg.Audit.Provider == nil && cfg.Audit.BuiltinProvider == "" {
+		cfg.Audit.BuiltinProvider = "inherit"
 	}
 	if !cfg.UI.Disabled && cfg.UI.Provider == nil {
 		cfg.UI.Provider = defaultUIProvider()
@@ -1014,8 +1034,8 @@ func resolveRelativePaths(configPath string, cfg *Config) {
 		baseDir = filepath.Dir(absPath)
 	}
 
-	for name := range cfg.Integrations {
-		intg := cfg.Integrations[name]
+	for name := range cfg.Plugins {
+		intg := cfg.Plugins[name]
 		if intg.IconFile != "" {
 			intg.IconFile = resolveRelativePath(baseDir, intg.IconFile)
 		}
@@ -1024,7 +1044,7 @@ func resolveRelativePaths(configPath string, cfg *Config) {
 				intg.Plugin.Source.Path = resolveRelativePath(baseDir, intg.Plugin.Source.Path)
 			}
 		}
-		cfg.Integrations[name] = intg
+		cfg.Plugins[name] = intg
 	}
 	if cfg.Auth.Provider != nil && cfg.Auth.Provider.Source != nil {
 		cfg.Auth.Provider.Source.Path = resolveRelativePath(baseDir, cfg.Auth.Provider.Source.Path)

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -315,7 +315,7 @@ func unmarshalHybridProvider(value *yaml.Node, kind string, provider **ProviderD
 		switch key {
 		case "provider", "config":
 		default:
-			return fmt.Errorf("field %s not found in type config.%sConfig", key, kind)
+			return fmt.Errorf("field %s not found in type %s config", key, kind)
 		}
 	}
 	*provider = nil

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -38,16 +38,16 @@ const PluginConnectionName = "_plugin"
 const PluginConnectionAlias = "plugin"
 
 type Config struct {
-	Auth         AuthConfig                `yaml:"auth"`
-	Datastore    DatastoreConfig           `yaml:"datastore"`
-	Datastores   map[string]DatastoreDef   `yaml:"datastores"`
-	Secrets      SecretsConfig             `yaml:"secrets"`
-	Telemetry    TelemetryConfig           `yaml:"telemetry"`
-	Audit        AuditConfig               `yaml:"audit"`
-	Plugins map[string]PluginDef `yaml:"plugins"`
-	Server       ServerConfig              `yaml:"server"`
-	Egress       EgressConfig              `yaml:"egress"`
-	UI           UIConfig                  `yaml:"ui"`
+	Auth       AuthConfig              `yaml:"auth"`
+	Datastore  DatastoreConfig         `yaml:"datastore"`
+	Datastores map[string]DatastoreDef `yaml:"datastores"`
+	Secrets    SecretsConfig           `yaml:"secrets"`
+	Telemetry  TelemetryConfig         `yaml:"telemetry"`
+	Audit      AuditConfig             `yaml:"audit"`
+	Plugins    map[string]PluginDef    `yaml:"plugins"`
+	Server     ServerConfig            `yaml:"server"`
+	Egress     EgressConfig            `yaml:"egress"`
+	UI         UIConfig                `yaml:"ui"`
 }
 
 type TelemetryConfig struct {
@@ -1057,6 +1057,12 @@ func resolveRelativePaths(configPath string, cfg *Config) {
 	}
 	if cfg.UI.Provider != nil && cfg.UI.Provider.Source != nil {
 		cfg.UI.Provider.Source.Path = resolveRelativePath(baseDir, cfg.UI.Provider.Source.Path)
+	}
+	if cfg.Telemetry.Provider != nil && cfg.Telemetry.Provider.Source != nil {
+		cfg.Telemetry.Provider.Source.Path = resolveRelativePath(baseDir, cfg.Telemetry.Provider.Source.Path)
+	}
+	if cfg.Audit.Provider != nil && cfg.Audit.Provider.Source != nil {
+		cfg.Audit.Provider.Source.Path = resolveRelativePath(baseDir, cfg.Audit.Provider.Source.Path)
 	}
 }
 

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -74,8 +74,8 @@ plugins:
 	if cfg.Server.EncryptionKey != "server-key" {
 		t.Fatalf("Server.EncryptionKey = %q", cfg.Server.EncryptionKey)
 	}
-	if got := cfg.Integrations["service-a"].DisplayName; got != "Service A" {
-		t.Fatalf("Integrations[service-a].DisplayName = %q", got)
+	if got := cfg.Plugins["service-a"].DisplayName; got != "Service A" {
+		t.Fatalf("Plugins[service-a].DisplayName = %q", got)
 	}
 }
 
@@ -469,7 +469,7 @@ plugins:
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if got := cfg.Integrations["custom_tool"].Plugin.SourcePath(); got != filepath.Join(filepath.Dir(path), "manifest.yaml") {
+	if got := cfg.Plugins["custom_tool"].Plugin.SourcePath(); got != filepath.Join(filepath.Dir(path), "manifest.yaml") {
 		t.Fatalf("unexpected plugin source path: %q", got)
 	}
 }
@@ -885,7 +885,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 		{
 			name: "local source valid",
 			cfg: &Config{
-				Integrations: map[string]IntegrationDef{
+				Plugins: map[string]PluginDef{
 					"sample": {Plugin: &ProviderDef{Source: &PluginSourceDef{Path: "./some-dir/manifest.yaml"}}},
 				},
 			},
@@ -893,7 +893,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 		{
 			name: "source valid",
 			cfg: &Config{
-				Integrations: map[string]IntegrationDef{
+				Plugins: map[string]PluginDef{
 					"sample": {Plugin: &ProviderDef{Source: &PluginSourceDef{Ref: "github.com/test-org/test-repo/test-plugin", Version: "1.0.0"}}},
 				},
 			},
@@ -901,7 +901,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 		{
 			name: "source path and ref rejected",
 			cfg: &Config{
-				Integrations: map[string]IntegrationDef{
+				Plugins: map[string]PluginDef{
 					"sample": {Plugin: &ProviderDef{Source: &PluginSourceDef{Path: "./manifest.yaml", Ref: "github.com/test-org/test-repo/test-plugin", Version: "1.0.0"}}},
 				},
 			},
@@ -910,7 +910,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 		{
 			name: "nil plugin rejected",
 			cfg: &Config{
-				Integrations: map[string]IntegrationDef{
+				Plugins: map[string]PluginDef{
 					"sample": {},
 				},
 			},
@@ -919,7 +919,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 		{
 			name: "source without version rejected",
 			cfg: &Config{
-				Integrations: map[string]IntegrationDef{
+				Plugins: map[string]PluginDef{
 					"sample": {Plugin: &ProviderDef{Source: &PluginSourceDef{Ref: "github.com/test-org/test-repo/test-plugin"}}},
 				},
 			},
@@ -928,7 +928,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 		{
 			name: "source version without ref rejected",
 			cfg: &Config{
-				Integrations: map[string]IntegrationDef{
+				Plugins: map[string]PluginDef{
 					"sample": {Plugin: &ProviderDef{Source: &PluginSourceDef{Version: "1.0.0"}}},
 				},
 			},
@@ -976,7 +976,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 		{
 			name: "plugin auth rejects mcp oauth early",
 			cfg: &Config{
-				Integrations: map[string]IntegrationDef{
+				Plugins: map[string]PluginDef{
 					"sample": {
 						Plugin: &ProviderDef{
 							Source: &PluginSourceDef{Path: "./manifest.yaml"},
@@ -990,7 +990,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 		{
 			name: "named connection rejects mcp oauth early",
 			cfg: &Config{
-				Integrations: map[string]IntegrationDef{
+				Plugins: map[string]PluginDef{
 					"sample": {
 						Plugin: &ProviderDef{
 							Source: &PluginSourceDef{Path: "./manifest.yaml"},
@@ -1067,13 +1067,13 @@ plugins:
 		t.Fatalf("Load: %v", err)
 	}
 
-	if got := cfg.Integrations["service-a"].IconFile; got != iconPath {
+	if got := cfg.Plugins["service-a"].IconFile; got != iconPath {
 		t.Fatalf("IconFile = %q, want %q", got, iconPath)
 	}
 	if got := cfg.Auth.Provider.SourcePath(); got != filepath.Join(dir, "auth-plugin", "provider.yaml") {
 		t.Fatalf("auth plugin source path = %q, want %q", got, filepath.Join(dir, "auth-plugin", "provider.yaml"))
 	}
-	if got := cfg.Integrations["service-a"].Plugin.SourcePath(); got != filepath.Join(dir, "bin", "manifest.yaml") {
+	if got := cfg.Plugins["service-a"].Plugin.SourcePath(); got != filepath.Join(dir, "bin", "manifest.yaml") {
 		t.Fatalf("integration plugin source path = %q, want %q", got, filepath.Join(dir, "bin", "manifest.yaml"))
 	}
 }
@@ -1200,7 +1200,7 @@ func TestLoad_ResolvesRelativePluginSourcePath(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 
-	plugin := loaded.Integrations["sample"].Plugin
+	plugin := loaded.Plugins["sample"].Plugin
 	if plugin == nil {
 		t.Fatal("expected plugin to be loaded")
 	}

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -26,6 +26,9 @@ func ValidateStructure(cfg *Config) error {
 			return fmt.Errorf("config validation: server.apiTokenTtl: %w", err)
 		}
 	}
+	if err := validateTelemetry(cfg.Telemetry); err != nil {
+		return err
+	}
 	if err := validateAudit(cfg.Audit); err != nil {
 		return err
 	}
@@ -49,22 +52,32 @@ func ValidateStructure(cfg *Config) error {
 			return err
 		}
 	}
-	for name := range cfg.Integrations {
-		intg := cfg.Integrations[name]
-		if err := validatePluginIntegration(name, intg); err != nil {
+	for name := range cfg.Plugins {
+		intg := cfg.Plugins[name]
+		if err := validatePlugin(name, intg); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
+func validateTelemetry(cfg TelemetryConfig) error {
+	if cfg.Provider != nil {
+		return validateTopLevelComponentProvider("telemetry", cfg.Provider)
+	}
+	return nil
+}
+
 func validateAudit(cfg AuditConfig) error {
-	switch cfg.Provider {
+	if cfg.Provider != nil {
+		return validateTopLevelComponentProvider("audit", cfg.Provider)
+	}
+	switch cfg.BuiltinProvider {
 	case "", "inherit", "noop":
 		if cfg.Config.Kind == 0 {
 			return nil
 		}
-		return fmt.Errorf("config validation: audit.config is not supported when audit.provider is %q", cfg.Provider)
+		return fmt.Errorf("config validation: audit.config is not supported when audit.provider is %q", cfg.BuiltinProvider)
 	case "stdout":
 		if cfg.Config.Kind == 0 {
 			return nil
@@ -102,7 +115,7 @@ func validateAudit(cfg AuditConfig) error {
 		}
 		return nil
 	default:
-		return fmt.Errorf("config validation: unknown audit.provider %q", cfg.Provider)
+		return fmt.Errorf("config validation: unknown audit.provider %q", cfg.BuiltinProvider)
 	}
 }
 
@@ -131,8 +144,8 @@ func validateTopLevelComponentConfig(kind string, provider *ProviderDef, cfg yam
 // applied locked plugin artifacts into the config. It intentionally does not
 // rerun the full structural validator on the mutated config.
 func ValidateResolvedStructure(cfg *Config) error {
-	for name := range cfg.Integrations {
-		intg := cfg.Integrations[name]
+	for name := range cfg.Plugins {
+		intg := cfg.Plugins[name]
 		if intg.Plugin == nil {
 			return fmt.Errorf("config validation: integration %q requires a plugin", name)
 		}
@@ -164,7 +177,7 @@ func ValidateRuntime(cfg *Config) error {
 	return nil
 }
 
-func validatePluginIntegration(name string, intg IntegrationDef) error {
+func validatePlugin(name string, intg PluginDef) error {
 	if intg.Plugin == nil {
 		return fmt.Errorf("config validation: integration %q requires a plugin", name)
 	}
@@ -524,8 +537,8 @@ func validateDatastores(cfg *Config) error {
 			return fmt.Errorf("config validation: datastores.%s.dsn is required", name)
 		}
 	}
-	for name := range cfg.Integrations {
-		intg := cfg.Integrations[name]
+	for name := range cfg.Plugins {
+		intg := cfg.Plugins[name]
 		if err := validateDatastoreBindings(name, intg.Datastores, cfg); err != nil {
 			return err
 		}

--- a/gestaltd/internal/config/provider_ref.go
+++ b/gestaltd/internal/config/provider_ref.go
@@ -70,9 +70,9 @@ func (p *ProviderDef) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
-func (i *IntegrationDef) UnmarshalYAML(value *yaml.Node) error {
+func (i *PluginDef) UnmarshalYAML(value *yaml.Node) error {
 	if value == nil || value.Kind == 0 {
-		*i = IntegrationDef{}
+		*i = PluginDef{}
 		return nil
 	}
 	if value.Kind != yaml.MappingNode {
@@ -125,7 +125,7 @@ func (i *IntegrationDef) UnmarshalYAML(value *yaml.Node) error {
 		}
 	}
 
-	*i = IntegrationDef{
+	*i = PluginDef{
 		Plugin:      plugin,
 		DisplayName: wire.DisplayName,
 		Description: wire.Description,

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -26,6 +26,8 @@ const (
 	PreparedProvidersDir = ".gestaltd/providers"
 	PreparedAuthDir      = ".gestaltd/auth"
 	PreparedSecretsDir   = ".gestaltd/secrets"
+	PreparedTelemetryDir = ".gestaltd/telemetry"
+	PreparedAuditDir     = ".gestaltd/audit"
 	PreparedUIDir        = ".gestaltd/ui"
 	LockVersion          = 2
 
@@ -38,6 +40,8 @@ type Lockfile struct {
 	Auth      *LockEntry                   `json:"auth,omitempty"`
 	Datastore *LockEntry                   `json:"datastore,omitempty"`
 	Secrets   *LockEntry                   `json:"secrets,omitempty"`
+	Telemetry *LockEntry                   `json:"telemetry,omitempty"`
+	Audit     *LockEntry                   `json:"audit,omitempty"`
 	UI        *LockUIEntry                 `json:"ui,omitempty"`
 }
 
@@ -149,6 +153,20 @@ func (l *Lifecycle) initAtPath(configPath, artifactsDir string) (*Lockfile, *con
 	if secretsEntry != nil {
 		lock.Secrets = secretsEntry
 	}
+	if cfg.Telemetry.Provider != nil && cfg.Telemetry.Provider.HasManagedArtifacts() {
+		entry, err := l.writeComponentArtifact(context.Background(), paths, pluginmanifestv1.KindPlugin, "telemetry", telemetryDestDir(paths), cfg.Telemetry.Provider, cfg.Telemetry.Config)
+		if err != nil {
+			return nil, nil, err
+		}
+		lock.Telemetry = &entry
+	}
+	if cfg.Audit.Provider != nil && cfg.Audit.Provider.HasManagedArtifacts() {
+		entry, err := l.writeComponentArtifact(context.Background(), paths, pluginmanifestv1.KindPlugin, "audit", auditDestDir(paths), cfg.Audit.Provider, cfg.Audit.Config)
+		if err != nil {
+			return nil, nil, err
+		}
+		lock.Audit = &entry
+	}
 	if cfg.UI.Provider != nil && cfg.UI.Provider.HasManagedArtifacts() {
 		uiEntry, err := l.writeUIProviderArtifact(context.Background(), cfg, paths)
 		if err != nil {
@@ -179,7 +197,7 @@ func buildSourceTokenMap(cfg *config.Config) map[string]string {
 			tokens[intg.Plugin.SourceRef()] = intg.Plugin.Source.Auth.Token
 		}
 	}
-	for _, p := range []*config.ProviderDef{cfg.Auth.Provider, cfg.Datastore.Provider, cfg.Secrets.Provider} {
+	for _, p := range []*config.ProviderDef{cfg.Auth.Provider, cfg.Datastore.Provider, cfg.Secrets.Provider, cfg.Telemetry.Provider, cfg.Audit.Provider} {
 		if p != nil && p.Source != nil && p.Source.Auth != nil {
 			tokens[p.SourceRef()] = p.Source.Auth.Token
 		}
@@ -306,6 +324,8 @@ type initPaths struct {
 	providersDir string
 	authDir      string
 	secretsDir   string
+	telemetryDir string
+	auditDir     string
 	uiDir        string
 }
 
@@ -322,13 +342,12 @@ func configHasPluginLoading(cfg *config.Config) bool {
 			return true
 		}
 	}
-	if cfg.Auth.Provider != nil && (cfg.Auth.Provider.HasManagedArtifacts() || cfg.Auth.Provider.HasLocalSource()) {
-		return true
+	for _, p := range []*config.ProviderDef{cfg.Auth.Provider, cfg.Secrets.Provider, cfg.UI.Provider, cfg.Telemetry.Provider, cfg.Audit.Provider} {
+		if p != nil && (p.HasManagedArtifacts() || p.HasLocalSource()) {
+			return true
+		}
 	}
-	if cfg.Secrets.Provider != nil && (cfg.Secrets.Provider.HasManagedArtifacts() || cfg.Secrets.Provider.HasLocalSource()) {
-		return true
-	}
-	return cfg.UI.Provider != nil && (cfg.UI.Provider.HasManagedArtifacts() || cfg.UI.Provider.HasLocalSource())
+	return false
 }
 
 func configHasManagedPlugins(cfg *config.Config) bool {
@@ -337,13 +356,12 @@ func configHasManagedPlugins(cfg *config.Config) bool {
 			return true
 		}
 	}
-	if cfg.Auth.Provider != nil && cfg.Auth.Provider.HasManagedArtifacts() {
-		return true
+	for _, p := range []*config.ProviderDef{cfg.Auth.Provider, cfg.Secrets.Provider, cfg.UI.Provider, cfg.Telemetry.Provider, cfg.Audit.Provider} {
+		if p != nil && p.HasManagedArtifacts() {
+			return true
+		}
 	}
-	if cfg.Secrets.Provider != nil && cfg.Secrets.Provider.HasManagedArtifacts() {
-		return true
-	}
-	return cfg.UI.Provider != nil && cfg.UI.Provider.HasManagedArtifacts()
+	return false
 }
 
 func resolveLockPath(baseDir, provider string) string {
@@ -386,6 +404,8 @@ func initPathsForConfigWithArtifactsDir(configPath, artifactsDir string) initPat
 		providersDir: filepath.Join(artifactsDir, filepath.FromSlash(PreparedProvidersDir)),
 		authDir:      filepath.Join(artifactsDir, filepath.FromSlash(PreparedAuthDir)),
 		secretsDir:   filepath.Join(artifactsDir, filepath.FromSlash(PreparedSecretsDir)),
+		telemetryDir: filepath.Join(artifactsDir, filepath.FromSlash(PreparedTelemetryDir)),
+		auditDir:     filepath.Join(artifactsDir, filepath.FromSlash(PreparedAuditDir)),
 		uiDir:        filepath.Join(artifactsDir, filepath.FromSlash(PreparedUIDir)),
 	}
 }
@@ -404,6 +424,14 @@ func authDestDir(paths initPaths) string {
 
 func secretsDestDir(paths initPaths) string {
 	return paths.secretsDir
+}
+
+func telemetryDestDir(paths initPaths) string {
+	return paths.telemetryDir
+}
+
+func auditDestDir(paths initPaths) string {
+	return paths.auditDir
 }
 
 func writeJSONFile(path string, v any) error {
@@ -461,6 +489,16 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 	}
 	if cfg.Secrets.Provider != nil && cfg.Secrets.Provider.HasManagedArtifacts() {
 		if lock.Secrets == nil || !lockEntryMatches(paths, "secrets", cfg.Secrets.Provider, *lock.Secrets, true) {
+			return false
+		}
+	}
+	if cfg.Telemetry.Provider != nil && cfg.Telemetry.Provider.HasManagedArtifacts() {
+		if lock.Telemetry == nil || !lockEntryMatches(paths, "telemetry", cfg.Telemetry.Provider, *lock.Telemetry, true) {
+			return false
+		}
+	}
+	if cfg.Audit.Provider != nil && cfg.Audit.Provider.HasManagedArtifacts() {
+		if lock.Audit == nil || !lockEntryMatches(paths, "audit", cfg.Audit.Provider, *lock.Audit, true) {
 			return false
 		}
 	}
@@ -864,6 +902,16 @@ func (l *Lifecycle) applyLockedPlugins(configPath, artifactsDir string, cfg *con
 			return err
 		}
 	}
+	if cfg.Telemetry.Provider != nil {
+		if err := l.applyComponentProvider(paths, lock, pluginmanifestv1.KindPlugin, "telemetry", cfg.Telemetry.Provider, cfg.Telemetry.Config, &cfg.Telemetry.Config, locked); err != nil {
+			return err
+		}
+	}
+	if cfg.Audit.Provider != nil {
+		if err := l.applyComponentProvider(paths, lock, pluginmanifestv1.KindPlugin, "audit", cfg.Audit.Provider, cfg.Audit.Config, &cfg.Audit.Config, locked); err != nil {
+			return err
+		}
+	}
 	if cfg.UI.Provider != nil {
 		configMap, err := config.NodeToMap(cfg.UI.Config)
 		if err != nil {
@@ -932,11 +980,15 @@ func (l *Lifecycle) applyComponentProvider(paths initPaths, lock *Lockfile, kind
 			return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", kind, name, paths.configPath)
 		}
 		var entry *LockEntry
-		switch kind {
-		case pluginmanifestv1.KindAuth:
+		switch name {
+		case "auth":
 			entry = lock.Auth
-		case pluginmanifestv1.KindSecrets:
+		case "secrets":
 			entry = lock.Secrets
+		case "telemetry":
+			entry = lock.Telemetry
+		case "audit":
+			entry = lock.Audit
 		}
 		if err := l.applyLockedComponentEntry(paths, entry, kind, name, provider, configMap, locked); err != nil {
 			return err
@@ -1277,13 +1329,17 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 	}
 
 	var destDir string
-	switch kind {
-	case pluginmanifestv1.KindAuth:
+	switch name {
+	case "auth":
 		destDir = authDestDir(paths)
-	case pluginmanifestv1.KindSecrets:
+	case "secrets":
 		destDir = secretsDestDir(paths)
+	case "telemetry":
+		destDir = telemetryDestDir(paths)
+	case "audit":
+		destDir = auditDestDir(paths)
 	default:
-		return fmt.Errorf("unsupported component kind %q", kind)
+		return fmt.Errorf("unsupported component %q", name)
 	}
 	if err := os.RemoveAll(destDir); err != nil {
 		return fmt.Errorf("remove stale plugin cache for %s %q: %w", kind, name, err)

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -174,7 +174,7 @@ func (l *Lifecycle) initAtPath(configPath, artifactsDir string) (*Lockfile, *con
 
 func buildSourceTokenMap(cfg *config.Config) map[string]string {
 	tokens := make(map[string]string)
-	for _, intg := range cfg.Integrations {
+	for _, intg := range cfg.Plugins {
 		if intg.Plugin != nil && intg.Plugin.Source != nil && intg.Plugin.Source.Auth != nil {
 			tokens[intg.Plugin.SourceRef()] = intg.Plugin.Source.Auth.Token
 		}
@@ -316,8 +316,8 @@ type pluginFingerprintInput struct {
 }
 
 func configHasPluginLoading(cfg *config.Config) bool {
-	for name := range cfg.Integrations {
-		plugin := cfg.Integrations[name].Plugin
+	for name := range cfg.Plugins {
+		plugin := cfg.Plugins[name].Plugin
 		if plugin.HasManagedArtifacts() || plugin.HasLocalSource() {
 			return true
 		}
@@ -332,8 +332,8 @@ func configHasPluginLoading(cfg *config.Config) bool {
 }
 
 func configHasManagedPlugins(cfg *config.Config) bool {
-	for name := range cfg.Integrations {
-		if cfg.Integrations[name].Plugin.HasManagedArtifacts() {
+	for name := range cfg.Plugins {
+		if cfg.Plugins[name].Plugin.HasManagedArtifacts() {
 			return true
 		}
 	}
@@ -444,8 +444,8 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 	if lock == nil || lock.Version != LockVersion {
 		return false
 	}
-	for name := range cfg.Integrations {
-		provider := cfg.Integrations[name]
+	for name := range cfg.Plugins {
+		provider := cfg.Plugins[name]
 		if !provider.Plugin.HasManagedArtifacts() {
 			continue
 		}
@@ -586,8 +586,8 @@ func (l *Lifecycle) buildArchivesMap(ctx context.Context, src pluginsource.Sourc
 
 func (l *Lifecycle) writeProviderArtifacts(ctx context.Context, cfg *config.Config, paths initPaths) (map[string]LockProviderEntry, error) {
 	written := make(map[string]LockProviderEntry)
-	for name := range cfg.Integrations {
-		provider := cfg.Integrations[name]
+	for name := range cfg.Plugins {
+		provider := cfg.Plugins[name]
 		if provider.Plugin == nil {
 			continue
 		}
@@ -826,8 +826,8 @@ func (l *Lifecycle) applyLockedPlugins(configPath, artifactsDir string, cfg *con
 		}
 	}
 
-	for name := range cfg.Integrations {
-		provider := cfg.Integrations[name]
+	for name := range cfg.Plugins {
+		provider := cfg.Plugins[name]
 		if provider.Plugin == nil {
 			continue
 		}
@@ -852,7 +852,7 @@ func (l *Lifecycle) applyLockedPlugins(configPath, artifactsDir string, cfg *con
 			provider.Description = cmp.Or(provider.Description, manifest.Description)
 		}
 		provider.IconFile = cmp.Or(provider.IconFile, provider.Plugin.ResolvedIconFile)
-		cfg.Integrations[name] = provider
+		cfg.Plugins[name] = provider
 	}
 	if cfg.Auth.Provider != nil {
 		if err := l.applyComponentProvider(paths, lock, pluginmanifestv1.KindAuth, "auth", cfg.Auth.Provider, cfg.Auth.Config, &cfg.Auth.Config, locked); err != nil {

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -185,7 +185,7 @@ func (l *Lifecycle) initAtPath(configPath, artifactsDir string) (*Lockfile, *con
 		return nil, nil, err
 	}
 
-	slog.Info("prepared locked artifacts", "providers", len(lock.Providers), "auth", lock.Auth != nil, "secrets", lock.Secrets != nil, "ui", lock.UI != nil)
+	slog.Info("prepared locked artifacts", "providers", len(lock.Providers), "auth", lock.Auth != nil, "secrets", lock.Secrets != nil, "telemetry", lock.Telemetry != nil, "audit", lock.Audit != nil, "ui", lock.UI != nil)
 	slog.Info("wrote lockfile", "path", paths.lockfilePath)
 	return lock, cfg, nil
 }

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -490,8 +490,8 @@ func TestSourcePluginLoadForExecution(t *testing.T) {
 	if _, err := os.Stat(executablePath); err != nil {
 		t.Fatalf("executable not rehydrated at %s: %v", executablePath, err)
 	}
-	if cfg.Integrations["gadget"].Plugin.Command != executablePath {
-		t.Fatalf("plugin command = %q, want %q", cfg.Integrations["gadget"].Plugin.Command, executablePath)
+	if cfg.Plugins["gadget"].Plugin.Command != executablePath {
+		t.Fatalf("plugin command = %q, want %q", cfg.Plugins["gadget"].Plugin.Command, executablePath)
 	}
 }
 
@@ -1005,8 +1005,8 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 	if got := assetCount.Load() - assetsBefore; got != 1 {
 		t.Errorf("asset request count during locked load = %d, want 1", got)
 	}
-	if cfg.Integrations["alpha"].Plugin.Command != executablePath {
-		t.Errorf("plugin command = %q, want %q", cfg.Integrations["alpha"].Plugin.Command, executablePath)
+	if cfg.Plugins["alpha"].Plugin.Command != executablePath {
+		t.Errorf("plugin command = %q, want %q", cfg.Plugins["alpha"].Plugin.Command, executablePath)
 	}
 }
 

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -124,7 +124,7 @@ plugins:
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
 
-	intg := loaded.Integrations["example"]
+	intg := loaded.Plugins["example"]
 	if intg.DisplayName != "Local Provider" {
 		t.Fatalf("DisplayName = %q", intg.DisplayName)
 	}
@@ -185,7 +185,7 @@ plugins:
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
 
-	intg := loaded.Integrations["notion"]
+	intg := loaded.Plugins["notion"]
 	if intg.Plugin == nil || intg.Plugin.ResolvedManifest == nil || intg.Plugin.ResolvedManifest.Plugin == nil {
 		t.Fatalf("ResolvedManifest = %+v", intg.Plugin)
 	}
@@ -442,7 +442,7 @@ plugins:
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
 
-	intg := loaded.Integrations["example"]
+	intg := loaded.Plugins["example"]
 	if intg.Plugin == nil || intg.Plugin.ResolvedManifest == nil {
 		t.Fatalf("ResolvedManifest = %+v", intg.Plugin)
 	}
@@ -668,7 +668,7 @@ print(json.dumps({
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
 
-	intg := loaded.Integrations["example"]
+	intg := loaded.Plugins["example"]
 	if intg.Plugin == nil || intg.Plugin.ResolvedManifest == nil {
 		t.Fatalf("ResolvedManifest = %+v", intg.Plugin)
 	}
@@ -945,14 +945,14 @@ plugins:
 	if err != nil {
 		t.Fatalf("Load config: %v", err)
 	}
-	loaded.Integrations["missing"] = config.IntegrationDef{}
+	loaded.Plugins["missing"] = config.PluginDef{}
 
 	lc := NewLifecycle(nil)
 	if err := lc.applyLockedPlugins(cfgPath, "", loaded, false); err != nil {
 		t.Fatalf("applyLockedPlugins: %v", err)
 	}
-	if loaded.Integrations["example"].Plugin == nil || loaded.Integrations["example"].Plugin.ResolvedManifest == nil {
-		t.Fatalf("ResolvedManifest = %+v", loaded.Integrations["example"].Plugin)
+	if loaded.Plugins["example"].Plugin == nil || loaded.Plugins["example"].Plugin.ResolvedManifest == nil {
+		t.Fatalf("ResolvedManifest = %+v", loaded.Plugins["example"].Plugin)
 	}
 }
 

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -357,7 +357,7 @@ func discoveryCandidateInfos(candidates []core.DiscoveryCandidate) []discoveryCa
 }
 
 func (s *Server) effectiveConnectionAuth(integration, connection string) config.ConnectionAuthDef {
-	intg, ok := s.integrationDefs[integration]
+	intg, ok := s.pluginDefs[integration]
 	if !ok || intg.Plugin == nil {
 		return config.ConnectionAuthDef{}
 	}

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -160,7 +160,7 @@ func (s *Server) revokeAllAPITokens(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) integrationConnectionInfos(name string, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo) []connectionDefInfo {
-	intg, ok := s.integrationDefs[name]
+	intg, ok := s.pluginDefs[name]
 	if !ok || intg.Plugin == nil {
 		return nil
 	}

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -44,7 +44,7 @@ type Server struct {
 	defaultConnection  map[string]string
 	catalogConnection  map[string]string
 	connectionAuth     func() map[string]map[string]bootstrap.OAuthHandler
-	integrationDefs    map[string]config.IntegrationDef
+	pluginDefs    map[string]config.PluginDef
 	noAuth             bool
 	anonymousPrincipal *principal.Principal
 	publicBaseURL      string
@@ -71,7 +71,7 @@ type Config struct {
 	DefaultConnection map[string]string
 	CatalogConnection map[string]string
 	ConnectionAuth    func() map[string]map[string]bootstrap.OAuthHandler
-	IntegrationDefs   map[string]config.IntegrationDef
+	PluginDefs   map[string]config.PluginDef
 	PublicBaseURL     string
 	SecureCookies     bool
 	StateSecret       []byte
@@ -127,7 +127,7 @@ func New(cfg Config) (*Server, error) {
 		defaultConnection: cfg.DefaultConnection,
 		catalogConnection: cfg.CatalogConnection,
 		connectionAuth:    cfg.ConnectionAuth,
-		integrationDefs:   cfg.IntegrationDefs,
+		pluginDefs:   cfg.PluginDefs,
 		noAuth:            noAuth,
 		publicBaseURL:     strings.TrimRight(cfg.PublicBaseURL, "/"),
 		secureCookies:     cfg.SecureCookies,

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -44,7 +44,7 @@ type Server struct {
 	defaultConnection  map[string]string
 	catalogConnection  map[string]string
 	connectionAuth     func() map[string]map[string]bootstrap.OAuthHandler
-	pluginDefs    map[string]config.PluginDef
+	pluginDefs         map[string]config.PluginDef
 	noAuth             bool
 	anonymousPrincipal *principal.Principal
 	publicBaseURL      string
@@ -71,7 +71,7 @@ type Config struct {
 	DefaultConnection map[string]string
 	CatalogConnection map[string]string
 	ConnectionAuth    func() map[string]map[string]bootstrap.OAuthHandler
-	PluginDefs   map[string]config.PluginDef
+	PluginDefs        map[string]config.PluginDef
 	PublicBaseURL     string
 	SecureCookies     bool
 	StateSecret       []byte
@@ -127,7 +127,7 @@ func New(cfg Config) (*Server, error) {
 		defaultConnection: cfg.DefaultConnection,
 		catalogConnection: cfg.CatalogConnection,
 		connectionAuth:    cfg.ConnectionAuth,
-		pluginDefs:   cfg.PluginDefs,
+		pluginDefs:        cfg.PluginDefs,
 		noAuth:            noAuth,
 		publicBaseURL:     strings.TrimRight(cfg.PublicBaseURL, "/"),
 		secureCookies:     cfg.SecureCookies,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -866,7 +866,7 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
-		cfg.IntegrationDefs = map[string]config.IntegrationDef{
+		cfg.PluginDefs = map[string]config.PluginDef{
 			"example": {Plugin: plugin},
 		}
 		cfg.Datastore = &coretesting.StubDatastore{
@@ -1064,7 +1064,7 @@ func TestListIntegrations_ConnectionInfosIncludeProviderManualAuth(t *testing.T)
 
 			ts := newTestServer(t, func(cfg *server.Config) {
 				cfg.Providers = testutil.NewProviderRegistry(t, tc.provider(t))
-				cfg.IntegrationDefs = map[string]config.IntegrationDef{
+				cfg.PluginDefs = map[string]config.PluginDef{
 					"example": {Plugin: tc.plugin},
 				}
 				cfg.Datastore = &coretesting.StubDatastore{
@@ -6580,7 +6580,7 @@ func TestConnectManual_MultiCredential(t *testing.T) {
 		name            string
 		integration     string
 		requestBody     string
-		integrationDefs map[string]config.IntegrationDef
+		pluginDefs map[string]config.PluginDef
 		wantTokenData   map[string]string
 	}{
 		{
@@ -6596,7 +6596,7 @@ func TestConnectManual_MultiCredential(t *testing.T) {
 			name:        "single credential input wraps structured auth mapping field",
 			integration: "modern-treasury",
 			requestBody: `{"integration":"modern-treasury","credential":"api-key-abc"}`,
-			integrationDefs: map[string]config.IntegrationDef{
+			pluginDefs: map[string]config.PluginDef{
 				"modern-treasury": {
 					Plugin: &config.ProviderDef{
 						Auth: &config.ConnectionAuthDef{
@@ -6637,7 +6637,7 @@ func TestConnectManual_MultiCredential(t *testing.T) {
 					StubIntegration: coretesting.StubIntegration{N: tc.integration},
 				})
 				cfg.DefaultConnection = map[string]string{tc.integration: config.PluginConnectionName}
-				cfg.IntegrationDefs = tc.integrationDefs
+				cfg.PluginDefs = tc.pluginDefs
 				cfg.Datastore = &coretesting.StubDatastore{
 					FindOrCreateUserFn: func(_ context.Context, email string) (*core.User, error) {
 						return &core.User{ID: "u1", Email: email}, nil

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -6577,11 +6577,11 @@ func TestConnectManual_MultiCredential(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name            string
-		integration     string
-		requestBody     string
-		pluginDefs map[string]config.PluginDef
-		wantTokenData   map[string]string
+		name          string
+		integration   string
+		requestBody   string
+		pluginDefs    map[string]config.PluginDef
+		wantTokenData map[string]string
 	}{
 		{
 			name:        "stores named credentials map",


### PR DESCRIPTION
## Summary

- Renames `IntegrationDef` to `PluginDef` and `Config.Integrations` to `Config.Plugins` so Go types match the YAML key `plugins` (22 files, mechanical rename)
- Unifies the `provider` field shape: `TelemetryConfig` and `AuditConfig` now accept either a builtin string or a `ProviderDef` object, matching the existing `SecretsConfig` pattern
- Extracts a shared `unmarshalHybridProvider()` helper used by telemetry, audit, and secrets config unmarshaling

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/config/... ./internal/bootstrap/... ./internal/server/...` passes (pre-existing failures in config are unrelated path resolution issues)
- [ ] Existing YAML configs with `telemetry: { provider: "stdout" }` and `audit: { provider: "otlp" }` continue to parse correctly
- [ ] New YAML form `telemetry: { provider: { source: { ref: ... } } }` is now accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)