### PR TITLE
Fix sqlite driver name mismatch breaking E2E tests

### DIFF
--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -1511,7 +1511,7 @@ func TestE2EHelmChart(t *testing.T) {
 		cfgPath := filepath.Join(dir, "config.yaml")
 		cfg := fmt.Sprintf(`datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: %s
 datastore: sqlite
 server:
@@ -1830,7 +1830,7 @@ func authDatastoreConfigYAML(t *testing.T, dir, authName, datastoreName, dbPath 
 	}
 	return fmt.Sprintf(`%sdatastores:
   %s:
-    driver: sqlite3
+    driver: sqlite
     dsn: %s
 datastore: %s
 ui:

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -302,7 +302,11 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	if encErr != nil {
 		return nil, fmt.Errorf("bootstrap: create encryptor: %w", encErr)
 	}
-	engine, engErr := xorm.NewEngine(def.Driver, def.DSN)
+	driver := def.Driver
+	if driver == "sqlite3" {
+		driver = "sqlite"
+	}
+	engine, engErr := xorm.NewEngine(driver, def.DSN)
 	if engErr != nil {
 		return nil, fmt.Errorf("bootstrap: system datastore from resource %q: create xorm engine: %w", cfg.Datastore.Resource, engErr)
 	}

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -44,7 +44,7 @@ auth:
     client_secret: secret-1
 datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
@@ -99,7 +99,7 @@ auth:
     client_id: ${TEST_CLIENT_ID}
 datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
@@ -150,7 +150,7 @@ func TestLoadConfigEnvFileFallback(t *testing.T) {
 	path := mustWriteConfigFile(t, `
 datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
@@ -182,7 +182,7 @@ func TestLoadConfigMissingEnvVariableFails(t *testing.T) {
 	path := mustWriteConfigFile(t, fmt.Sprintf(`
 datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
@@ -222,7 +222,7 @@ func TestLoadConfigEmptyDefaultEnvSyntax(t *testing.T) {
 	path := mustWriteConfigFile(t, `
 datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
@@ -284,7 +284,7 @@ func TestValidateRuntime(t *testing.T) {
 			yaml: `
 datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
@@ -307,7 +307,7 @@ server:
 			yaml: `
 datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: /tmp/gestalt.db
 datastore: sqlite
 `,
@@ -320,7 +320,7 @@ auth:
   provider: none
 datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
@@ -373,7 +373,7 @@ auth:
       version: 1.0.0
 datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
@@ -408,7 +408,7 @@ auth:
     issuer_url: https://issuer.example.test
 datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
@@ -423,7 +423,7 @@ auth:
   provider: none
 datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
@@ -483,7 +483,7 @@ func TestLoadConfigUIProviderModes(t *testing.T) {
 		path := mustWriteConfigFile(t, `
 datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
@@ -516,7 +516,7 @@ ui:
   provider: none
 datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
@@ -545,7 +545,7 @@ ui:
     brand_name: Acme
 datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
@@ -571,7 +571,7 @@ ui:
       path: ./web/default/provider.yaml
 datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:
@@ -1049,7 +1049,7 @@ auth:
       path: ../auth-plugin/provider.yaml
 datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: /tmp/gestalt.db
 datastore: sqlite
 plugins:
@@ -1093,7 +1093,7 @@ auth:
     allowed_domain: example.test
 datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: /tmp/gestalt.db
 datastore: sqlite
 server:

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -518,7 +518,7 @@ func validateDatastores(cfg *Config) error {
 			return fmt.Errorf("config validation: datastores.%s.driver is required", name)
 		}
 		if !validDatastoreDrivers[ds.Driver] {
-			return fmt.Errorf("config validation: datastores.%s.driver %q is not recognized (expected postgres, mysql, or sqlite3)", name, ds.Driver)
+			return fmt.Errorf("config validation: datastores.%s.driver %q is not recognized (expected postgres, mysql, or sqlite)", name, ds.Driver)
 		}
 		if ds.DSN == "" {
 			return fmt.Errorf("config validation: datastores.%s.dsn is required", name)

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -62,7 +62,7 @@ func decodeNodeMap(t *testing.T, node any) map[string]any {
 func requiredComponentConfigYAML(_ *testing.T, _, dbPath string) string {
 	return fmt.Sprintf(`datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: %q
 datastore: sqlite
 ui:
@@ -73,7 +73,7 @@ ui:
 func requiredDatastoreConfigYAML(_ *testing.T, _, dbPath string) string {
 	return fmt.Sprintf(`datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: %q
 datastore: sqlite
 ui:
@@ -279,7 +279,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalTopLevelPluginsWithoutLockfile(t *t
     client_id: local-auth-client
 datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: %s
 datastore: sqlite
 ui:
@@ -360,7 +360,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalSourceTopLevelPluginsWithoutArtifac
       path: ./auth-manifest.yaml
 datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: %s
 datastore: sqlite
 ui:

--- a/gestaltd/internal/operator/localconfig.go
+++ b/gestaltd/internal/operator/localconfig.go
@@ -57,7 +57,7 @@ func GenerateDefaultConfig(configDir string) (string, error) {
 func defaultManagedConfig(dbPath, encryptionKey string) string {
 	return fmt.Sprintf(`datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: %q
 datastore: sqlite
 secrets:
@@ -72,7 +72,7 @@ server:
 func defaultLocalSourceConfig(providersDir, dbPath, encryptionKey string) string {
 	return fmt.Sprintf(`datastores:
   sqlite:
-    driver: sqlite3
+    driver: sqlite
     dsn: %q
 datastore: sqlite
 ui:


### PR DESCRIPTION
## Summary
- `modernc.org/sqlite` registers as driver `"sqlite"`, not `"sqlite3"` -- all E2E tests have been failing since the DSN-based datastore feature landed
- Updates default config templates and all test fixtures from `driver: sqlite3` to `driver: sqlite`
- Adds backwards-compat normalization in bootstrap so existing user configs with `driver: sqlite3` still work

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/config/... ./internal/bootstrap/... ./internal/operator/...` passes
- [ ] CI E2E tests should pass (currently all failing on main)