### PR TITLE
Fix CI E2E manifest using removed snake_case fields

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -192,10 +192,10 @@ jobs:
           cat >"$provider_dir/manifest.yaml" <<'EOF'
           source: github.com/valon-technologies/gestalt-providers/web/default
           version: 0.0.1-alpha.1
-          display_name: Default Web UI
+          displayName: Default Web UI
           description: Local CI web UI fixture
           webui:
-            asset_root: out
+            assetRoot: out
           EOF
 
       - name: Build Go server


### PR DESCRIPTION
## Summary
- The web UI provider fixture in the CI workflow still used old snake_case field names (`display_name`, `asset_root`) that were removed in #822 when backward compatibility layers were stripped
- Updates them to the canonical camelCase names (`displayName`, `assetRoot`) that the manifest parser now requires
- This is the root cause of the "Web E2E Tests (Go Server)" failure on all open PRs (e.g. #827)

## Test plan
- [ ] CI "Web E2E Tests (Go Server)" job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)