### PR TITLE
Fix CI E2E manifest using removed snake_case fields

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -192,10 +192,10 @@ jobs:
           cat >"$provider_dir/manifest.yaml" <<'EOF'
           source: github.com/valon-technologies/gestalt-providers/web/default
           version: 0.0.1-alpha.1
-          display_name: Default Web UI
+          displayName: Default Web UI
           description: Local CI web UI fixture
           webui:
-            asset_root: out
+            assetRoot: out
           EOF
 
       - name: Build Go server


### PR DESCRIPTION
## Summary
- The E2E test fixture manifest in `build-gestaltd.yml` still used `display_name` and `asset_root` (snake_case), which were only supported by the backward-compat layer removed in abc861c5
- Updates them to `displayName` and `assetRoot` (camelCase) to match the strict YAML decoder

## Test plan
- [ ] "Web E2E Tests (Go Server)" CI job passes (gestaltd starts successfully with the corrected manifest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)