### PR TITLE
Fix CI E2E test manifest using removed snake_case fields

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -192,10 +192,10 @@ jobs:
           cat >"$provider_dir/manifest.yaml" <<'EOF'
           source: github.com/valon-technologies/gestalt-providers/web/default
           version: 0.0.1-alpha.1
-          display_name: Default Web UI
+          displayName: Default Web UI
           description: Local CI web UI fixture
           webui:
-            asset_root: out
+            assetRoot: out
           EOF
 
       - name: Build Go server


### PR DESCRIPTION
## Summary
- The backward compatibility layers removed in #822 normalized snake_case YAML keys to camelCase during manifest parsing. The E2E test fixture in the CI workflow was still using the old snake_case field names (`display_name`, `asset_root`), causing `gestaltd` to fail on startup with unmarshal errors.
- Updates the fixture to use the canonical camelCase names (`displayName`, `assetRoot`).

Fixes the CI failure in #828.

## Test plan
- [ ] CI "Web E2E Tests (Go Server)" job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)