### PR TITLE
Fix CI manifest using snake_case fields after compat removal

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -192,10 +192,10 @@ jobs:
           cat >"$provider_dir/manifest.yaml" <<'EOF'
           source: github.com/valon-technologies/gestalt-providers/web/default
           version: 0.0.1-alpha.1
-          display_name: Default Web UI
+          displayName: Default Web UI
           description: Local CI web UI fixture
           webui:
-            asset_root: out
+            assetRoot: out
           EOF
 
       - name: Build Go server


### PR DESCRIPTION
## Summary

- PR #822 removed the snake_case-to-camelCase backward compatibility layer from manifest parsing, but the inline web UI manifest fixture in `build-gestaltd.yml` still used `display_name` and `asset_root`
- The Go server now strict-decodes manifests (`KnownFields(true)`) and rejects unknown fields, so the E2E test job crashes on startup before any tests run
- Updates the two fields to their canonical camelCase names (`displayName`, `assetRoot`)

## Test plan

- [ ] "Web E2E Tests (Go Server)" CI job passes — the server starts and serves the fixture UI bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)