### PR TITLE
docs: update stale snake_case config keys to camelCase

### DIFF
--- a/docs/content/architecture/data-model.mdx
+++ b/docs/content/architecture/data-model.mdx
@@ -91,7 +91,7 @@ Credentials are encrypted. Everything else is plaintext.
 | API tokens | `api_tokens.hashed_token` | One-way SHA-256 |
 | Emails, names, metadata, scopes, timestamps | Various | Plaintext |
 
-All encrypted fields use the same key derived from `server.encryption_key`. There is no per-user or per-provider key separation.
+All encrypted fields use the same key derived from `server.encryptionKey`. There is no per-user or per-provider key separation.
 
 ## Token storage granularity
 

--- a/docs/content/architecture/index.mdx
+++ b/docs/content/architecture/index.mdx
@@ -16,7 +16,7 @@ Next, Gestalt initializes the secret manager from the `secrets` block. This is t
 
 Once the secret manager is ready, Gestalt resolves every `secret://` reference across the rest of the config: server, auth, datastore, telemetry, audit, and all plugin configs. The `secrets.config` block is skipped to avoid a circular dependency.
 
-With secrets resolved, `server.encryption_key` gets converted into a 32-byte AES key. A 64-character hex string is decoded directly; anything else goes through Argon2id derivation. This derived key protects all stored tokens.
+With secrets resolved, `server.encryptionKey` gets converted into a 32-byte AES key. A 64-character hex string is decoded directly; anything else goes through Argon2id derivation. This derived key protects all stored tokens.
 
 From there, the auth and datastore providers are spawned as child processes over gRPC, schema migrations run, integration plugins start, and the HTTP listeners come up. The `/ready` endpoint returns 503 until everything reports ready.
 

--- a/docs/content/architecture/security-internals.mdx
+++ b/docs/content/architecture/security-internals.mdx
@@ -4,7 +4,7 @@ Implementation details of how Gestalt protects credentials. For operator guidanc
 
 ## Key derivation
 
-`server.encryption_key` is converted to a 32-byte AES key at startup.
+`server.encryptionKey` is converted to a 32-byte AES key at startup.
 
 If the key is a 64-character hex string, it's hex-decoded directly into 32 bytes. No derivation, no extra cost. Generate one with `openssl rand -hex 32`.
 
@@ -42,7 +42,7 @@ Disconnecting deletes the token row. No soft-delete, no upstream revocation. If 
 
 API tokens (`gst_api_*`) work differently: the plaintext is never stored.
 
-**Creation.** Gestalt generates 32 random bytes, formats them as `gst_api_` + hex, computes the SHA-256 hash, and stores only the hash. The plaintext is returned once. Default TTL is 30 days (`server.api_token_ttl`). CLI login tokens are non-expiring.
+**Creation.** Gestalt generates 32 random bytes, formats them as `gst_api_` + hex, computes the SHA-256 hash, and stores only the hash. The plaintext is returned once. Default TTL is 30 days (`server.apiTokenTtl`). CLI login tokens are non-expiring.
 
 **Validation.** On each request, Gestalt hashes the bearer token and looks up the hash. Match + not expired = authenticated.
 
@@ -56,6 +56,6 @@ The `secrets.config` block is excluded from resolution. Use `${ENV_VAR}` or `${E
 
 ## Key rotation
 
-There is no automated key rotation. Changing `server.encryption_key` makes all stored encrypted values unreadable.
+There is no automated key rotation. Changing `server.encryptionKey` makes all stored encrypted values unreadable.
 
 To rotate: stop all instances, decrypt tokens with the old key, re-encrypt with the new key, update config, restart. This requires direct database access and the logic in `core/crypto`. There is no built-in tool for this.

--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -20,7 +20,7 @@ The default chart profile is intentionally minimal:
 
 - platform auth disabled
 - SQLite on a PVC mounted at `/data`
-- a static dev-only `server.encryption_key`
+- a static dev-only `server.encryptionKey`
 - one replica
 - no ingress
 
@@ -37,8 +37,8 @@ separate management listener and internal management Service so `/admin` and
 ```yaml
 config:
   server:
-    base_url: "${GESTALT_BASE_URL}"
-    encryption_key: "${GESTALT_ENCRYPTION_KEY}"
+    baseUrl: "${GESTALT_BASE_URL}"
+    encryptionKey: "${GESTALT_ENCRYPTION_KEY}"
   auth:
     provider:
       source:
@@ -46,8 +46,8 @@ config:
         version: 0.0.1-alpha.1
     config:
       issuer_url: "${OIDC_ISSUER_URL}"
-      client_id: "${OIDC_CLIENT_ID}"
-      client_secret: "${OIDC_CLIENT_SECRET}"
+      clientId: "${OIDC_CLIENT_ID}"
+      clientSecret: "${OIDC_CLIENT_SECRET}"
   datastore:
     provider:
       source:
@@ -115,8 +115,8 @@ config:
     management:
       host: 0.0.0.0
       port: 9090
-    base_url: "${GESTALT_BASE_URL}"
-    encryption_key: "${GESTALT_ENCRYPTION_KEY}"
+    baseUrl: "${GESTALT_BASE_URL}"
+    encryptionKey: "${GESTALT_ENCRYPTION_KEY}"
   auth:
     provider:
       source:
@@ -124,8 +124,8 @@ config:
         version: 0.0.1-alpha.1
     config:
       issuer_url: "${OIDC_ISSUER_URL}"
-      client_id: "${OIDC_CLIENT_ID}"
-      client_secret: "${OIDC_CLIENT_SECRET}"
+      clientId: "${OIDC_CLIENT_ID}"
+      clientSecret: "${OIDC_CLIENT_SECRET}"
       redirect_url: "${OIDC_REDIRECT_URL}"
   datastore:
     provider:
@@ -171,7 +171,7 @@ This configuration keeps the public UI and API on port `8080` while exposing
 `/admin` and `/metrics` only through the internal `gestalt-management` Service
 on port `9090`. If operators need browser access to `/admin`, place an
 internal-only ingress, VPN, or identity-aware proxy in front of that management
-Service rather than exposing it on the public ingress. Because `server.base_url`
+Service rather than exposing it on the public ingress. Because `server.baseUrl`
 is set, the management admin UI can still link operators back to the public
 client UI hostname.
 

--- a/docs/content/deploy/index.mdx
+++ b/docs/content/deploy/index.mdx
@@ -12,7 +12,7 @@ The server image `valontechnologies/gestaltd:latest` is published for `linux/amd
 
 **Secrets.** Use a dedicated secret manager (`google_secret_manager`, `aws_secrets_manager`, `vault`, `azure_key_vault`, or `file`) instead of `env` in production. Gestalt config supports `secret://` references that are resolved at boot time through the configured secret manager.
 
-**TLS.** Gestalt does not terminate TLS. Deploy behind a reverse proxy or load balancer that handles TLS termination. Set `server.base_url` to the public HTTPS URL so that OAuth callback URLs are derived correctly.
+**TLS.** Gestalt does not terminate TLS. Deploy behind a reverse proxy or load balancer that handles TLS termination. Set `server.baseUrl` to the public HTTPS URL so that OAuth callback URLs are derived correctly.
 
 **Locked startup.** For deterministic deployments, run `gestaltd init` locally
 to resolve plugins and generate prepared state, then bake that state into a

--- a/docs/content/providers/auth.mdx
+++ b/docs/content/providers/auth.mdx
@@ -13,13 +13,13 @@ An auth provider manifest uses an `auth` block:
 ```yaml
 source: github.com/example/plugins/my-auth
 version: 0.0.1-alpha.1
-display_name: My Auth Provider
+displayName: My Auth Provider
 description: Custom OAuth 2.0 authentication
 auth:
-  config_schema_path: ./auth_config.json
+  configSchemaPath: ./auth_config.json
 ```
 
-The optional `auth.config_schema_path` field points to a JSON Schema that validates the `auth.config` block in the server config. If you provide one, Gestalt rejects invalid config at startup rather than letting bad values reach the provider at runtime.
+The optional `auth.configSchemaPath` field points to a JSON Schema that validates the `auth.config` block in the server config. If you provide one, Gestalt rejects invalid config at startup rather than letting bad values reach the provider at runtime.
 
 ## Interface
 
@@ -246,8 +246,8 @@ auth:
       path: ./my-auth/manifest.yaml
   config:
     issuer_url: https://login.example.com
-    client_id: ${OIDC_CLIENT_ID}
-    client_secret: secret://oidc-client-secret
+    clientId: ${OIDC_CLIENT_ID}
+    clientSecret: secret://oidc-client-secret
 ```
 
 `provider.source.path` points at the auth provider's `manifest.yaml` during development. For production, use `provider.source.ref` and `version` to reference a published release. The `config` block is passed to `Configure` at startup and validated against the config schema if one was declared in the manifest.

--- a/docs/content/providers/datastores.mdx
+++ b/docs/content/providers/datastores.mdx
@@ -13,13 +13,13 @@ A datastore provider manifest uses a `datastore` block:
 ```yaml
 source: github.com/example/plugins/my-datastore
 version: 0.0.1-alpha.1
-display_name: My Datastore
+displayName: My Datastore
 description: Custom persistent storage backend
 datastore:
-  config_schema_path: ./datastore_config.json
+  configSchemaPath: ./datastore_config.json
 ```
 
-The optional `datastore.config_schema_path` field points to a JSON Schema that validates the `datastore.config` block in the server config. If you provide one, Gestalt rejects invalid config at startup.
+The optional `datastore.configSchemaPath` field points to a JSON Schema that validates the `datastore.config` block in the server config. If you provide one, Gestalt rejects invalid config at startup.
 
 ## Interface
 

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -28,7 +28,7 @@ The host owns auth, token storage, connection selection, and HTTP or MCP routing
 
 ## Process isolation
 
-Providers run in their own process. They cannot access the host process memory, other users' credentials, or (for integration plugins) the datastore directly. Integration plugins also run inside a network sandbox: outbound requests to hosts not listed in `plugin.allowed_hosts` in the manifest are rejected with a 403.
+Providers run in their own process. They cannot access the host process memory, other users' credentials, or (for integration plugins) the datastore directly. Integration plugins also run inside a network sandbox: outbound requests to hosts not listed in `plugin.allowedHosts` in the manifest are rejected with a 403.
 
 ## SDK support
 
@@ -53,7 +53,7 @@ This convention enables prefix matching in the CLI. When you run `gestalt invoke
 
 **Duplicate operation IDs.** Operation IDs must be unique within a provider. If two surfaces (for example, an OpenAPI passthrough and an executable operation) expose the same ID, the provider fails validation at startup. Use `allowed_operations` to filter or alias collisions.
 
-**Sandbox 403 errors.** Executable providers run inside a network sandbox. Outbound HTTP requests to hosts not listed in `plugin.allowed_hosts` are rejected with a 403. Add every upstream domain the provider contacts to the allowlist in the manifest.
+**Sandbox 403 errors.** Executable providers run inside a network sandbox. Outbound HTTP requests to hosts not listed in `plugin.allowedHosts` are rejected with a 403. Add every upstream domain the provider contacts to the allowlist in the manifest.
 
 ## What to read next
 

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -13,7 +13,7 @@ Static metadata, auth, and passthrough surfaces live in a manifest file. Gestalt
     ```yaml
     source: github.com/example/plugins/my-plugin
     version: 0.0.1-alpha.1
-    display_name: My Plugin
+    displayName: My Plugin
     description: A custom integration plugin
     plugin:
       connections:
@@ -27,7 +27,7 @@ Static metadata, auth, and passthrough surfaces live in a manifest file. Gestalt
     {
       "source": "github.com/example/plugins/my-plugin",
       "version": "0.0.1-alpha.1",
-      "display_name": "My Plugin",
+      "displayName": "My Plugin",
       "description": "A custom integration plugin",
       "plugin": {
         "connections": {

--- a/docs/content/providers/releasing.mdx
+++ b/docs/content/providers/releasing.mdx
@@ -170,7 +170,7 @@ source: github.com/acme/plugins/web/default
 version: 1.2.0
 webui:
   asset_root: ui/out
-  config_schema_path: schemas/ui-config.schema.json
+  configSchemaPath: schemas/ui-config.schema.json
 ```
 
 `gestaltd init` prepares the released UI and records it in `gestalt.lock.json`. `gestaltd serve --locked` then serves the prepared asset root at `/`. Omit `ui` to use the pinned first-party default UI bundle, or set `ui.provider: none` to disable the public UI. The built-in admin UI remains available at `/admin` regardless.

--- a/docs/content/providers/secrets.mdx
+++ b/docs/content/providers/secrets.mdx
@@ -13,13 +13,13 @@ A secrets provider manifest uses a `secrets` block:
 ```yaml
 source: github.com/example/plugins/my-secrets
 version: 0.0.1-alpha.1
-display_name: My Secrets Provider
+displayName: My Secrets Provider
 description: Resolves secrets from a custom vault.
 secrets:
-  config_schema_path: ./secrets_config.json
+  configSchemaPath: ./secrets_config.json
 ```
 
-The optional `secrets.config_schema_path` field points to a JSON Schema that validates the `secrets.config` block in the server config.
+The optional `secrets.configSchemaPath` field points to a JSON Schema that validates the `secrets.config` block in the server config.
 
 ## Interface
 

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -12,7 +12,7 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | --- | --- | --- |
 | `GET` | `/health` | Basic liveness check. |
 | `GET` | `/ready` | Readiness check. Returns `503` until providers and datastore are ready. |
-| `GET` | `/admin` and `/admin/*` | Embedded admin UI shell. On the management listener it reads same-origin `/metrics` without Gestalt auth, so access control is expected to come from your network or reverse proxy. When `server.base_url` is set, the management admin UI links back to that public URL for `Client UI`; otherwise it omits that link. |
+| `GET` | `/admin` and `/admin/*` | Embedded admin UI shell. On the management listener it reads same-origin `/metrics` without Gestalt auth, so access control is expected to come from your network or reverse proxy. When `server.baseUrl` is set, the management admin UI links back to that public URL for `Client UI`; otherwise it omits that link. |
 | `GET` | `/api/v1/auth/info` | Returns platform auth metadata, including whether interactive login is supported. |
 | `POST` | `/api/v1/auth/login` | Starts platform login and returns an absolute browser URL. |
 | `GET` | `/api/v1/auth/login/callback` | Completes platform login. |

--- a/docs/content/security.mdx
+++ b/docs/content/security.mdx
@@ -42,7 +42,7 @@ Gestalt sits between callers and upstream APIs. It authenticates users, stores e
 
 All integration tokens are encrypted before storage using AES-256-GCM.
 
-The `server.encryption_key` is the root deployment secret. If the key is a 64-character hex string, it is decoded directly as a 32-byte AES key. Otherwise, Argon2id derives a 32-byte key from the string (3 iterations, 64 MiB, 4 threads).
+The `server.encryptionKey` is the root deployment secret. If the key is a 64-character hex string, it is decoded directly as a 32-byte AES key. Otherwise, Argon2id derives a 32-byte key from the string (3 iterations, 64 MiB, 4 threads).
 
 Every encryption operation generates a fresh 12-byte nonce using `crypto/rand`. GCM provides authenticated encryption, so tampering with stored ciphertexts is detected at decryption time.
 
@@ -52,7 +52,7 @@ Access tokens, refresh tokens, pending connection state, and OAuth state paramet
 
 **Platform sessions.** Users log in through the configured identity provider. Gestalt validates the callback, checks `email_verified`, and issues a session cookie. Sessions expire based on the auth provider's TTL (default 24 hours).
 
-**API tokens.** Generated with 32 random bytes from `crypto/rand` and prefixed with `gst_api_`. The plaintext is returned once at creation time. Only the SHA-256 hash is stored. Default TTL is 30 days, configurable via `server.api_token_ttl`.
+**API tokens.** Generated with 32 random bytes from `crypto/rand` and prefixed with `gst_api_`. The plaintext is returned once at creation time. Only the SHA-256 hash is stored. Default TTL is 30 days, configurable via `server.apiTokenTtl`.
 
 **Integration tokens (OAuth).** OAuth state is encrypted with a 10-minute TTL to prevent state injection. After the authorization code exchange, access and refresh tokens are encrypted separately and stored. Gestalt automatically refreshes tokens that expire within 5 minutes.
 
@@ -82,7 +82,7 @@ The host resolves the caller's access token and passes it to the provider in eac
 
 ### OS-level sandbox
 
-When `allowed_hosts` is configured on a provider, the integration provider is automatically sandboxed:
+When `allowedHosts` is configured on a provider, the integration provider is automatically sandboxed:
 
 ```yaml
 plugins:
@@ -91,7 +91,7 @@ plugins:
       source:
         ref: github.com/acme/plugins/my-plugin
         version: 1.0.0
-      allowed_hosts:
+      allowedHosts:
         - "api.example.com"
         - "*.slack.com"
 ```
@@ -106,13 +106,13 @@ plugins:
 
 | Setting | Impact |
 | --- | --- |
-| `server.encryption_key` | Root deployment secret. If compromised, all stored tokens can be decrypted. Use a strong random string or 64-character hex key. Must be the same across all instances in a cluster. |
+| `server.encryptionKey` | Root deployment secret. If compromised, all stored tokens can be decrypted. Use a strong random string or 64-character hex key. Must be the same across all instances in a cluster. |
 | `auth.provider` | Omitting `auth` or setting `auth.provider: none` disables all authentication. Do not use in production. |
-| `server.base_url` | Must match the public URL exactly. OAuth callbacks are derived from it. |
+| `server.baseUrl` | Must match the public URL exactly. OAuth callbacks are derived from it. |
 | TLS termination | Gestalt does not terminate TLS. Deploy behind a reverse proxy that handles TLS. |
 | `secrets.provider` | Use a dedicated secret manager in production. `env` is acceptable but secrets may appear in process listings. |
 | `datastore.provider` | Use Postgres or another production-grade datastore. SQLite is single-writer and not suitable for multi-replica deployments. |
 
 ## Known limitations
 
-Changing `server.encryption_key` requires re-encrypting all stored tokens; there is no automated key rotation (see [Security Internals: Key rotation](/architecture/security-internals#key-rotation)). Platform sessions cannot be explicitly revoked and expire based on the configured TTL. Rate limiting and CORS must be configured at the reverse proxy layer. Gestalt encrypts tokens at the application level, but the database may store non-sensitive metadata in plaintext (connection metadata, scopes, timestamps). See [Data Model: Encryption boundaries](/architecture/data-model#encryption-boundaries) for the full list. Appropriate database access controls are still important.
+Changing `server.encryptionKey` requires re-encrypting all stored tokens; there is no automated key rotation (see [Security Internals: Key rotation](/architecture/security-internals#key-rotation)). Platform sessions cannot be explicitly revoked and expire based on the configured TTL. Rate limiting and CORS must be configured at the reverse proxy layer. Gestalt encrypts tokens at the application level, but the database may store non-sensitive metadata in plaintext (connection metadata, scopes, timestamps). See [Data Model: Encryption boundaries](/architecture/data-model#encryption-boundaries) for the full list. Appropriate database access controls are still important.

--- a/docs/content/troubleshooting.mdx
+++ b/docs/content/troubleshooting.mdx
@@ -6,9 +6,9 @@ import { Tabs } from 'nextra/components'
 
 When `gestaltd serve --locked` reports that prepared artifacts are missing or stale, the lock state has drifted from the current config. Run `gestaltd init --config ./config.yaml` to re-resolve and re-prepare all references, then start the server again with `gestaltd serve --locked --config ./config.yaml`.
 
-The validation error `server.encryption_key is required` means the config is missing its root deployment secret. Set `server.encryption_key` to a `secret://` reference or other secret-backed value. The encryption key is used for token encryption and derived session material, so the server refuses to start without it.
+The validation error `server.encryptionKey is required` means the config is missing its root deployment secret. Set `server.encryptionKey` to a `secret://` reference or other secret-backed value. The encryption key is used for token encryption and derived session material, so the server refuses to start without it.
 
-Set `server.encryption_key` for every real deployment. Gestalt derives token and session encryption from it regardless of which auth and datastore providers you use.
+Set `server.encryptionKey` for every real deployment. Gestalt derives token and session encryption from it regardless of which auth and datastore providers you use.
 
 If the `/mcp` endpoint is not mounted, the server found no plugin that exposes tools. At least one integration plugin must surface MCP-visible operations before `/mcp` becomes available.
 
@@ -81,7 +81,7 @@ Common source-package checks:
   </Tabs.Tab>
 </Tabs>
 
-A sandbox 403 means the provider process made an outbound request to a host not listed in `plugin.allowed_hosts`. Add every upstream domain the integration plugin contacts to the allowlist in your plugin config.
+A sandbox 403 means the provider process made an outbound request to a host not listed in `plugin.allowedHosts`. Add every upstream domain the integration plugin contacts to the allowlist in your plugin config.
 
 An input decode error means the operation received a request body that does not match the expected schema. Check the operation's parameter definitions and ensure the caller is sending the correct types and required fields.
 


### PR DESCRIPTION
The Go config types and YAML keys were aligned to camelCase in #820 and the compat layer was removed in #834, but the documentation still referenced the old snake_case forms. This updates YAML examples and prose references across 14 doc files to match the current config format: server.encryptionKey, server.baseUrl, server.apiTokenTtl, allowedHosts, displayName, configSchemaPath, clientId, clientSecret.