### PR TITLE
Improve YAML language consistency across config and manifest

### DIFF
--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -186,7 +186,9 @@ source: github.com/test/plugins/pager
 version: 0.0.1-alpha.1
 displayName: Pager
 plugin:
-  openapi: openapi.yaml
+  surfaces:
+    openapi:
+      document: openapi.yaml
   connectionMode: none
   pagination:
     style: cursor
@@ -227,7 +229,9 @@ source: github.com/test/plugins/mapper
 version: 0.0.1-alpha.1
 displayName: Mapper
 plugin:
-  openapi: openapi.yaml
+  surfaces:
+    openapi:
+      document: openapi.yaml
   connectionMode: none
   responseMapping:
     dataPath: results
@@ -370,7 +374,9 @@ source: github.com/test/plugins/manual-basic
 version: 0.0.1-alpha.1
 displayName: Manual Basic Test
 plugin:
-  openapi: openapi.yaml
+  surfaces:
+    openapi:
+      document: openapi.yaml
 `), 0o644)
 
 	manifestPath, err := pluginpkg.FindManifestFile(pluginDir)
@@ -572,7 +578,9 @@ plugin:
           valueFrom:
             credentialFieldRef:
               name: api_key
-  openapi: openapi.yaml
+  surfaces:
+    openapi:
+      document: openapi.yaml
 `), 0o644)
 
 	manifestPath, err := pluginpkg.FindManifestFile(pluginDir)
@@ -725,11 +733,13 @@ plugin:
           valueFrom:
             credentialFieldRef:
               name: api_key
-  baseUrl: %s
-  operations:
-    - name: whoami
-      method: GET
-      path: /whoami
+  surfaces:
+    rest:
+      baseUrl: %s
+      operations:
+        - name: whoami
+          method: GET
+          path: /whoami
 `, upstream.URL)), 0o644)
 
 	manifestPath, err := pluginpkg.FindManifestFile(pluginDir)

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -143,10 +143,12 @@ func TestRun_PluginReleaseRejectsInvalidManifest(t *testing.T) {
 source: github.com/testowner/plugins/invalid
 version: 0.0.1-alpha.1
 plugin:
-  operations:
-    - name: list_items
-      method: GET
-      path: /items
+  surfaces:
+    rest:
+      operations:
+        - name: list_items
+          method: GET
+          path: /items
 `,
 			wantError: "provider.baseUrl is required",
 		},

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -230,7 +230,7 @@ func buildExecutablePluginProvider(ctx context.Context, name string, intg config
 	specProv, specDef, err := buildConfiguredSpecProvider(ctx, name, resolved, meta, specProviderConfig{
 		manifestPlugin:       manifestPlugin,
 		allowedOperations:    allowedOperations,
-		baseURL:              manifestPlugin.BaseURL,
+		baseURL:              manifestPlugin.RESTBaseURL(),
 		applyResponseMapping: true,
 		providerBuildOptions: func(conn config.ConnectionDef) []provider.BuildOption {
 			return mcpOAuthBuildOpts(conn, manifestPlugin, deps)
@@ -302,7 +302,7 @@ func buildSpecLoadedProvider(ctx context.Context, name string, intg config.Plugi
 		return buildConfiguredSpecProvider(ctx, name, resolved, meta, specProviderConfig{
 			manifestPlugin:       mp,
 			allowedOperations:    allowed,
-			baseURL:              mp.BaseURL,
+			baseURL:              mp.RESTBaseURL(),
 			applyResponseMapping: true,
 			providerBuildOptions: func(conn config.ConnectionDef) []provider.BuildOption {
 				return mcpOAuthBuildOpts(conn, mp, deps)
@@ -606,7 +606,7 @@ func buildPluginStaticSpec(name string, intg config.PluginDef, manifest *pluginm
 	}, nil
 }
 
-func staticAuthTypes(authType string) []string {
+func staticAuthTypes(authType pluginmanifestv1.AuthType) []string {
 	switch authType {
 	case "", pluginmanifestv1.AuthTypeNone:
 		return nil
@@ -618,11 +618,11 @@ func staticAuthTypes(authType string) []string {
 }
 
 func mcpOAuthBuildOpts(conn config.ConnectionDef, manifestPlugin *pluginmanifestv1.Plugin, deps Deps) []provider.BuildOption {
-	if manifestPlugin == nil || conn.Auth.Type != pluginmanifestv1.AuthTypeMCPOAuth || manifestPlugin.MCPURL == "" {
+	if manifestPlugin == nil || conn.Auth.Type != pluginmanifestv1.AuthTypeMCPOAuth || manifestPlugin.MCPURL() == "" {
 		return nil
 	}
 	return []provider.BuildOption{
-		provider.WithAuthHandler(buildMCPOAuthHandler(conn, manifestPlugin.MCPURL, buildRegistrationStore(deps), deps)),
+		provider.WithAuthHandler(buildMCPOAuthHandler(conn, manifestPlugin.MCPURL(), buildRegistrationStore(deps), deps)),
 	}
 }
 
@@ -737,7 +737,7 @@ func applyProviderPagination(def *provider.Definition, manifestPlugin *pluginman
 		}
 		op := def.Operations[opName]
 		op.Pagination = &provider.PaginationDef{
-			Style:        pgn.Style,
+			Style:        string(pgn.Style),
 			CursorParam:  pgn.CursorParam,
 			Cursor:       cloneManifestValueSelectorDef(pgn.Cursor),
 			LimitParam:   pgn.LimitParam,

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -230,7 +230,7 @@ func buildExecutablePluginProvider(ctx context.Context, name string, intg config
 	specProv, specDef, err := buildConfiguredSpecProvider(ctx, name, resolved, meta, specProviderConfig{
 		manifestPlugin:       manifestPlugin,
 		allowedOperations:    allowedOperations,
-		baseURL:              manifestPlugin.RESTBaseURL(),
+		baseURL:              manifestPlugin.SpecBaseURL(),
 		applyResponseMapping: true,
 		providerBuildOptions: func(conn config.ConnectionDef) []provider.BuildOption {
 			return mcpOAuthBuildOpts(conn, manifestPlugin, deps)

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -55,11 +55,11 @@ type Config struct {
 // can be a builtin (provider: { builtin: <name> } or the legacy scalar form
 // provider: <name>) or an external plugin (provider: { source: ... }).
 type ComponentConfig struct {
-	Provider        *ProviderDef `yaml:"provider"`
-	Config          yaml.Node    `yaml:"config"`
-	BuiltinProvider string       `yaml:"-"`
-	Disabled        bool         `yaml:"-"`
-	ResolvedAssetRoot string     `yaml:"-"`
+	Provider          *ProviderDef `yaml:"provider"`
+	Config            yaml.Node    `yaml:"config"`
+	BuiltinProvider   string       `yaml:"-"`
+	Disabled          bool         `yaml:"-"`
+	ResolvedAssetRoot string       `yaml:"-"`
 }
 
 func (c *ComponentConfig) UnmarshalYAML(value *yaml.Node) error {
@@ -172,10 +172,10 @@ type ProviderDef struct {
 
 	Discovery *pluginmanifestv1.ProviderDiscovery `yaml:"-"`
 
-	Auth              *ConnectionAuthDef                 `yaml:"-"`
-	ConnectionMode    pluginmanifestv1.ConnectionMode   `yaml:"-"`
-	Connections       map[string]*ConnectionDef `yaml:"-"`
-	DefaultConnection string                    `yaml:"-"`
+	Auth              *ConnectionAuthDef              `yaml:"-"`
+	ConnectionMode    pluginmanifestv1.ConnectionMode `yaml:"-"`
+	Connections       map[string]*ConnectionDef       `yaml:"-"`
+	DefaultConnection string                          `yaml:"-"`
 
 	ConnectionParams  map[string]ConnectionParamDef `yaml:"-"`
 	MCP               bool                          `yaml:"-"`
@@ -258,7 +258,6 @@ type DatastoreDef struct {
 	Driver string `yaml:"driver"`
 	DSN    string `yaml:"dsn"`
 }
-
 
 func (c *DatastoreConfig) UnmarshalYAML(value *yaml.Node) error {
 	if value == nil || value.Kind == 0 {
@@ -379,25 +378,25 @@ type ConnectionDef struct {
 
 type ConnectionAuthDef struct {
 	Type                pluginmanifestv1.AuthType `yaml:"type"`
-	AuthorizationURL    string               `yaml:"authorizationUrl"`
-	TokenURL            string               `yaml:"tokenUrl"`
-	ClientID            string               `yaml:"clientId"`
-	ClientSecret        string               `yaml:"clientSecret"`
-	RedirectURL         string               `yaml:"redirectUrl"`
-	ClientAuth          string               `yaml:"clientAuth"`
-	TokenExchange       string               `yaml:"tokenExchange"`
-	Scopes              []string             `yaml:"scopes"`
-	ScopeParam          string               `yaml:"scopeParam"`
-	ScopeSeparator      string               `yaml:"scopeSeparator"`
-	PKCE                bool                 `yaml:"pkce"`
-	AuthorizationParams map[string]string    `yaml:"authorizationParams"`
-	TokenParams         map[string]string    `yaml:"tokenParams"`
-	RefreshParams       map[string]string    `yaml:"refreshParams"`
-	AcceptHeader        string               `yaml:"acceptHeader"`
-	AccessTokenPath     string               `yaml:"accessTokenPath"`
-	TokenMetadata       []string             `yaml:"tokenMetadata"`
-	Credentials         []CredentialFieldDef `yaml:"credentials"`
-	AuthMapping         *AuthMappingDef      `yaml:"authMapping"`
+	AuthorizationURL    string                    `yaml:"authorizationUrl"`
+	TokenURL            string                    `yaml:"tokenUrl"`
+	ClientID            string                    `yaml:"clientId"`
+	ClientSecret        string                    `yaml:"clientSecret"`
+	RedirectURL         string                    `yaml:"redirectUrl"`
+	ClientAuth          string                    `yaml:"clientAuth"`
+	TokenExchange       string                    `yaml:"tokenExchange"`
+	Scopes              []string                  `yaml:"scopes"`
+	ScopeParam          string                    `yaml:"scopeParam"`
+	ScopeSeparator      string                    `yaml:"scopeSeparator"`
+	PKCE                bool                      `yaml:"pkce"`
+	AuthorizationParams map[string]string         `yaml:"authorizationParams"`
+	TokenParams         map[string]string         `yaml:"tokenParams"`
+	RefreshParams       map[string]string         `yaml:"refreshParams"`
+	AcceptHeader        string                    `yaml:"acceptHeader"`
+	AccessTokenPath     string                    `yaml:"accessTokenPath"`
+	TokenMetadata       []string                  `yaml:"tokenMetadata"`
+	Credentials         []CredentialFieldDef      `yaml:"credentials"`
+	AuthMapping         *AuthMappingDef           `yaml:"authMapping"`
 }
 
 type CredentialFieldDef = pluginmanifestv1.CredentialField

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -38,36 +38,89 @@ const PluginConnectionName = "_plugin"
 const PluginConnectionAlias = "plugin"
 
 type Config struct {
-	Auth       AuthConfig              `yaml:"auth"`
+	Auth       ComponentConfig         `yaml:"auth"`
 	Datastore  DatastoreConfig         `yaml:"datastore"`
 	Datastores map[string]DatastoreDef `yaml:"datastores"`
-	Secrets    SecretsConfig           `yaml:"secrets"`
-	Telemetry  TelemetryConfig         `yaml:"telemetry"`
-	Audit      AuditConfig             `yaml:"audit"`
+	Secrets    ComponentConfig         `yaml:"secrets"`
+	Telemetry  ComponentConfig         `yaml:"telemetry"`
+	Audit      ComponentConfig         `yaml:"audit"`
 	Plugins    map[string]PluginDef    `yaml:"plugins"`
 	Server     ServerConfig            `yaml:"server"`
 	Egress     EgressConfig            `yaml:"egress"`
-	UI         UIConfig                `yaml:"ui"`
+	UI         ComponentConfig         `yaml:"ui"`
 }
 
-type TelemetryConfig struct {
+// ComponentConfig is the unified configuration for top-level infrastructure
+// components (auth, secrets, telemetry, audit, ui). Each component's provider
+// can be a builtin (provider: { builtin: <name> } or the legacy scalar form
+// provider: <name>) or an external plugin (provider: { source: ... }).
+type ComponentConfig struct {
 	Provider        *ProviderDef `yaml:"provider"`
 	Config          yaml.Node    `yaml:"config"`
 	BuiltinProvider string       `yaml:"-"`
+	Disabled        bool         `yaml:"-"`
+	ResolvedAssetRoot string     `yaml:"-"`
 }
 
-type AuditConfig struct {
-	Provider        *ProviderDef `yaml:"provider"`
-	Config          yaml.Node    `yaml:"config"`
-	BuiltinProvider string       `yaml:"-"`
+func (c *ComponentConfig) UnmarshalYAML(value *yaml.Node) error {
+	return c.unmarshalComponent(value)
 }
 
-type UIConfig struct {
-	Provider          *ProviderDef `yaml:"provider"`
-	Config            yaml.Node    `yaml:"config"`
-	Disabled          bool         `yaml:"-"`
-	ResolvedAssetRoot string       `yaml:"-"`
+func (c *ComponentConfig) unmarshalComponent(value *yaml.Node) error {
+	kind := "component"
+	if value == nil || value.Kind == 0 {
+		*c = ComponentConfig{}
+		return nil
+	}
+	if value.Kind != yaml.MappingNode {
+		var probe map[string]any
+		return value.Decode(&probe)
+	}
+	for i := 0; i+1 < len(value.Content); i += 2 {
+		key := value.Content[i].Value
+		switch key {
+		case "provider", "config":
+		default:
+			return fmt.Errorf("field %s not found in type %s config", key, kind)
+		}
+	}
+	*c = ComponentConfig{}
+	providerNode := mappingValueNode(value, "provider")
+	if providerNode != nil {
+		switch {
+		case providerNode.Kind == yaml.ScalarNode && providerNode.Tag != "!!null":
+			v := strings.TrimSpace(providerNode.Value)
+			if v == "none" {
+				c.Disabled = true
+			} else if v != "" {
+				c.BuiltinProvider = v
+			}
+		case providerNode.Kind == yaml.MappingNode:
+			if builtinNode := mappingValueNode(providerNode, "builtin"); builtinNode != nil && builtinNode.Kind == yaml.ScalarNode {
+				c.BuiltinProvider = strings.TrimSpace(builtinNode.Value)
+			} else {
+				decoded, err := decodeExternalProvider(providerNode)
+				if err != nil {
+					return err
+				}
+				c.Provider = decoded
+			}
+		case providerNode.Kind != yaml.ScalarNode || providerNode.Tag != "!!null":
+			return fmt.Errorf("%s.provider must be a string or a provider reference mapping", kind)
+		}
+	}
+	if configNode := mappingValueNode(value, "config"); configNode != nil {
+		c.Config = *configNode
+	}
+	return nil
 }
+
+// Type aliases preserved for consumer compatibility.
+type TelemetryConfig = ComponentConfig
+type AuditConfig = ComponentConfig
+type UIConfig = ComponentConfig
+type SecretsConfig = ComponentConfig
+type AuthConfig = ComponentConfig
 
 type PluginSourceAuthDef struct {
 	Token string `yaml:"token"`
@@ -119,8 +172,8 @@ type ProviderDef struct {
 
 	Discovery *pluginmanifestv1.ProviderDiscovery `yaml:"-"`
 
-	Auth              *ConnectionAuthDef        `yaml:"-"`
-	ConnectionMode    string                    `yaml:"-"`
+	Auth              *ConnectionAuthDef                 `yaml:"-"`
+	ConnectionMode    pluginmanifestv1.ConnectionMode   `yaml:"-"`
 	Connections       map[string]*ConnectionDef `yaml:"-"`
 	DefaultConnection string                    `yaml:"-"`
 
@@ -195,18 +248,6 @@ func (p *ProviderDef) DeclaresMCP() bool {
 	return provider.MCP
 }
 
-type SecretsConfig struct {
-	Provider *ProviderDef `yaml:"provider"`
-	Config   yaml.Node    `yaml:"config"`
-
-	BuiltinProvider string `yaml:"-"`
-}
-
-type AuthConfig struct {
-	Provider *ProviderDef `yaml:"provider"`
-	Config   yaml.Node    `yaml:"config"`
-}
-
 type DatastoreConfig struct {
 	Resource string       `yaml:"-"`
 	Provider *ProviderDef `yaml:"provider"`
@@ -218,9 +259,6 @@ type DatastoreDef struct {
 	DSN    string `yaml:"dsn"`
 }
 
-func (c *AuthConfig) UnmarshalYAML(value *yaml.Node) error {
-	return unmarshalTopLevelComponentConfig(value, "AuthConfig", "auth", &c.Provider, &c.Config)
-}
 
 func (c *DatastoreConfig) UnmarshalYAML(value *yaml.Node) error {
 	if value == nil || value.Kind == 0 {
@@ -253,7 +291,7 @@ func (c *DatastoreConfig) UnmarshalYAML(value *yaml.Node) error {
 	c.Config = yaml.Node{}
 	c.Resource = ""
 	if providerNode := mappingValueNode(value, "provider"); providerNode != nil {
-		decoded, err := decodeTopLevelComponentProvider("datastore", providerNode)
+		decoded, err := decodeExternalProvider(providerNode)
 		if err != nil {
 			return err
 		}
@@ -265,175 +303,15 @@ func (c *DatastoreConfig) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
-func (c *UIConfig) UnmarshalYAML(value *yaml.Node) error {
-	if value == nil || value.Kind == 0 {
-		*c = UIConfig{}
-		return nil
-	}
-	if value.Kind != yaml.MappingNode {
-		var probe map[string]any
-		return value.Decode(&probe)
-	}
-	for i := 0; i+1 < len(value.Content); i += 2 {
-		key := value.Content[i].Value
-		switch key {
-		case "provider", "config":
-		default:
-			return fmt.Errorf("field %s not found in type config.UIConfig", key)
-		}
-	}
-	c.Provider = nil
-	c.Config = yaml.Node{}
-	c.Disabled = false
-	if providerNode := mappingValueNode(value, "provider"); providerNode != nil {
-		decoded, disabled, err := decodeUIProvider(providerNode)
-		if err != nil {
-			return err
-		}
-		c.Provider = decoded
-		c.Disabled = disabled
-	}
-	if configNode := mappingValueNode(value, "config"); configNode != nil {
-		c.Config = *configNode
-	}
-	return nil
-}
-
-func unmarshalHybridProvider(value *yaml.Node, kind string, provider **ProviderDef, builtin *string, cfg *yaml.Node) error {
-	if value == nil || value.Kind == 0 {
-		*provider = nil
-		*builtin = ""
-		*cfg = yaml.Node{}
-		return nil
-	}
-	if value.Kind != yaml.MappingNode {
-		var probe map[string]any
-		return value.Decode(&probe)
-	}
-	for i := 0; i+1 < len(value.Content); i += 2 {
-		key := value.Content[i].Value
-		switch key {
-		case "provider", "config":
-		default:
-			return fmt.Errorf("field %s not found in type %s config", key, kind)
-		}
-	}
-	*provider = nil
-	*builtin = ""
-	*cfg = yaml.Node{}
-	providerNode := mappingValueNode(value, "provider")
-	if providerNode != nil {
-		switch {
-		case providerNode.Kind == yaml.ScalarNode && providerNode.Tag != "!!null":
-			*builtin = strings.TrimSpace(providerNode.Value)
-		case providerNode.Kind == yaml.MappingNode:
-			decoded, err := decodeTopLevelComponentProvider(kind, providerNode)
-			if err != nil {
-				return err
-			}
-			*provider = decoded
-		case providerNode.Kind != yaml.ScalarNode || providerNode.Tag != "!!null":
-			return fmt.Errorf("%s.provider must be a string or a provider reference mapping", kind)
-		}
-	}
-	if configNode := mappingValueNode(value, "config"); configNode != nil {
-		*cfg = *configNode
-	}
-	return nil
-}
-
-func (c *TelemetryConfig) UnmarshalYAML(value *yaml.Node) error {
-	return unmarshalHybridProvider(value, "telemetry", &c.Provider, &c.BuiltinProvider, &c.Config)
-}
-
-func (c *AuditConfig) UnmarshalYAML(value *yaml.Node) error {
-	return unmarshalHybridProvider(value, "audit", &c.Provider, &c.BuiltinProvider, &c.Config)
-}
-
-func (c *SecretsConfig) UnmarshalYAML(value *yaml.Node) error {
-	return unmarshalHybridProvider(value, "secrets", &c.Provider, &c.BuiltinProvider, &c.Config)
-}
-
-func unmarshalTopLevelComponentConfig(value *yaml.Node, typeName, kind string, provider **ProviderDef, cfg *yaml.Node) error {
-	if value == nil || value.Kind == 0 {
-		*provider = nil
-		*cfg = yaml.Node{}
-		return nil
-	}
-	if value.Kind != yaml.MappingNode {
-		var probe map[string]any
-		return value.Decode(&probe)
-	}
-	for i := 0; i+1 < len(value.Content); i += 2 {
-		key := value.Content[i].Value
-		switch key {
-		case "provider", "config":
-		default:
-			return fmt.Errorf("field %s not found in type config.%s", key, typeName)
-		}
-	}
-	*provider = nil
-	*cfg = yaml.Node{}
-	if providerNode := mappingValueNode(value, "provider"); providerNode != nil {
-		decoded, err := decodeTopLevelComponentProvider(kind, providerNode)
-		if err != nil {
-			return err
-		}
-		*provider = decoded
-	}
-	if configNode := mappingValueNode(value, "config"); configNode != nil {
-		*cfg = *configNode
-	}
-	return nil
-}
-
-func decodeTopLevelComponentProvider(kind string, node *yaml.Node) (*ProviderDef, error) {
+func decodeExternalProvider(node *yaml.Node) (*ProviderDef, error) {
 	if node == nil || node.Kind == 0 {
 		return nil, nil
-	}
-	if node.Kind == yaml.ScalarNode {
-		value := strings.TrimSpace(node.Value)
-		if node.Tag == "!!null" || value == "" {
-			return nil, nil
-		}
-		if kind == "auth" && value == "none" {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("config validation: %s.provider must be a provider reference mapping%s", kind, authProviderScalarHint(kind))
 	}
 	var provider ProviderDef
 	if err := node.Decode(&provider); err != nil {
 		return nil, err
 	}
 	return &provider, nil
-}
-
-func decodeUIProvider(node *yaml.Node) (*ProviderDef, bool, error) {
-	if node == nil || node.Kind == 0 {
-		return nil, false, nil
-	}
-	if node.Kind == yaml.ScalarNode {
-		value := strings.TrimSpace(node.Value)
-		if node.Tag == "!!null" || value == "" {
-			return nil, false, nil
-		}
-		if value == "none" {
-			return nil, true, nil
-		}
-		return nil, false, fmt.Errorf(`config validation: ui.provider must be a provider reference mapping or the string "none"`)
-	}
-	var provider ProviderDef
-	if err := node.Decode(&provider); err != nil {
-		return nil, false, err
-	}
-	return &provider, false, nil
-}
-
-func authProviderScalarHint(kind string) string {
-	if kind == "auth" {
-		return ` or the string "none"`
-	}
-	return ""
 }
 
 type ListenerConfig struct {
@@ -493,14 +371,14 @@ type PluginDef struct {
 // ConnectionDef owns authentication and connection parameters for a named
 // connection. All connections in a single integration must share the same Mode.
 type ConnectionDef struct {
-	Mode             string                              `yaml:"mode"`
+	Mode             pluginmanifestv1.ConnectionMode     `yaml:"mode"`
 	Auth             ConnectionAuthDef                   `yaml:"auth"`
 	ConnectionParams map[string]ConnectionParamDef       `yaml:"params"`
 	Discovery        *pluginmanifestv1.ProviderDiscovery `yaml:"-"`
 }
 
 type ConnectionAuthDef struct {
-	Type                string               `yaml:"type"`
+	Type                pluginmanifestv1.AuthType `yaml:"type"`
 	AuthorizationURL    string               `yaml:"authorizationUrl"`
 	TokenURL            string               `yaml:"tokenUrl"`
 	ClientID            string               `yaml:"clientId"`
@@ -552,7 +430,9 @@ func MergeConnectionAuth(dst *ConnectionAuthDef, src ConnectionAuthDef) {
 			*dst = src
 		}
 	}
-	setString(&dst.Type, src.Type)
+	if src.Type != "" {
+		dst.Type = src.Type
+	}
 	setString(&dst.AuthorizationURL, src.AuthorizationURL)
 	setString(&dst.TokenURL, src.TokenURL)
 	setString(&dst.ClientID, src.ClientID)

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -876,13 +876,13 @@ func applyDefaults(cfg *Config) {
 	if cfg.Server.Public.Port == 0 {
 		cfg.Server.Public.Port = 8080
 	}
-	if cfg.Secrets.Provider == nil && cfg.Secrets.BuiltinProvider == "" {
+	if !cfg.Secrets.Disabled && cfg.Secrets.Provider == nil && cfg.Secrets.BuiltinProvider == "" {
 		cfg.Secrets.BuiltinProvider = "env"
 	}
-	if cfg.Telemetry.Provider == nil && cfg.Telemetry.BuiltinProvider == "" {
+	if !cfg.Telemetry.Disabled && cfg.Telemetry.Provider == nil && cfg.Telemetry.BuiltinProvider == "" {
 		cfg.Telemetry.BuiltinProvider = "stdout"
 	}
-	if cfg.Audit.Provider == nil && cfg.Audit.BuiltinProvider == "" {
+	if !cfg.Audit.Disabled && cfg.Audit.Provider == nil && cfg.Audit.BuiltinProvider == "" {
 		cfg.Audit.BuiltinProvider = "inherit"
 	}
 	if !cfg.UI.Disabled && cfg.UI.Provider == nil {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -379,7 +379,7 @@ datastore: sqlite
 server:
   encryptionKey: server-key
 `,
-			wantErr: "field plugin not found in type config.AuthConfig",
+			wantErr: "field plugin not found in type component config",
 		},
 		{
 			name: "legacy datastore plugin field rejected",

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -38,6 +38,9 @@ func ValidateStructure(cfg *Config) error {
 	if err := validateUIConfig(cfg.UI); err != nil {
 		return err
 	}
+	if cfg.Auth.BuiltinProvider != "" {
+		return fmt.Errorf("config validation: auth.provider must be a provider reference mapping or the string \"none\"")
+	}
 	if err := validateTopLevelComponentConfig("auth", cfg.Auth.Provider, cfg.Auth.Config); err != nil {
 		return err
 	}

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -224,7 +224,7 @@ func validateManifestBackedConnectionDefaults(name string, plugin *ProviderDef, 
 }
 
 func validateExecutableConnectionAuthSupport(name string, plugin *ProviderDef, provider *pluginmanifestv1.Plugin) error {
-	supportsMCPOAuth := provider != nil && provider.MCPURL != ""
+	supportsMCPOAuth := provider != nil && provider.MCPURL() != ""
 	if conn := EffectivePluginConnectionDef(plugin, provider); conn.Auth.Type == pluginmanifestv1.AuthTypeMCPOAuth && !supportsMCPOAuth {
 		return fmt.Errorf("config validation: integration %q plugin auth type %q requires an MCP surface", name, pluginmanifestv1.AuthTypeMCPOAuth)
 	}

--- a/gestaltd/internal/config/provider_ref.go
+++ b/gestaltd/internal/config/provider_ref.go
@@ -27,17 +27,10 @@ type integrationWire struct {
 }
 
 type integrationConnection struct {
-	Mode      string                        `yaml:"mode"`
-	Auth      ConnectionAuthDef             `yaml:"auth"`
-	Params    map[string]ConnectionParamDef `yaml:"params"`
-	Discovery *integrationDiscoveryWire     `yaml:"discovery"`
-}
-
-type integrationDiscoveryWire struct {
-	URL      string            `yaml:"url"`
-	IDPath   string            `yaml:"idPath"`
-	NamePath string            `yaml:"namePath"`
-	Metadata map[string]string `yaml:"metadata"`
+	Mode      pluginmanifestv1.ConnectionMode    `yaml:"mode"`
+	Auth      ConnectionAuthDef                  `yaml:"auth"`
+	Params    map[string]ConnectionParamDef      `yaml:"params"`
+	Discovery *pluginmanifestv1.ProviderDiscovery `yaml:"discovery"`
 }
 
 type integrationMCPWire struct {
@@ -100,7 +93,7 @@ func (i *PluginDef) UnmarshalYAML(value *yaml.Node) error {
 			plugin.Auth = &auth
 			plugin.ConnectionMode = defaultConn.Mode
 			plugin.ConnectionParams = defaultConn.Params
-			plugin.Discovery = defaultConn.toManifestDiscovery()
+			plugin.Discovery = defaultConn.Discovery
 		}
 		if len(wire.Connections) > 0 {
 			plugin.Connections = make(map[string]*ConnectionDef, len(wire.Connections))
@@ -116,7 +109,7 @@ func (i *PluginDef) UnmarshalYAML(value *yaml.Node) error {
 					Mode:             conn.Mode,
 					Auth:             conn.Auth,
 					ConnectionParams: conn.Params,
-					Discovery:        conn.toManifestDiscovery(),
+					Discovery:        conn.Discovery,
 				}
 			}
 			if len(plugin.Connections) == 0 {
@@ -152,18 +145,5 @@ func validateIntegrationWire(wire *integrationWire) error {
 	if wire.MCP != nil && wire.MCP.ToolPrefix != "" && !wire.MCP.Enabled {
 		return fmt.Errorf("mcp.toolPrefix is only valid when mcp.enabled is true")
 	}
-
 	return nil
-}
-
-func (w *integrationConnection) toManifestDiscovery() *pluginmanifestv1.ProviderDiscovery {
-	if w == nil || w.Discovery == nil {
-		return nil
-	}
-	return &pluginmanifestv1.ProviderDiscovery{
-		URL:      w.Discovery.URL,
-		IDPath:   w.Discovery.IDPath,
-		NamePath: w.Discovery.NamePath,
-		Metadata: w.Discovery.Metadata,
-	}
 }

--- a/gestaltd/internal/config/provider_ref.go
+++ b/gestaltd/internal/config/provider_ref.go
@@ -27,9 +27,9 @@ type integrationWire struct {
 }
 
 type integrationConnection struct {
-	Mode      pluginmanifestv1.ConnectionMode    `yaml:"mode"`
-	Auth      ConnectionAuthDef                  `yaml:"auth"`
-	Params    map[string]ConnectionParamDef      `yaml:"params"`
+	Mode      pluginmanifestv1.ConnectionMode     `yaml:"mode"`
+	Auth      ConnectionAuthDef                   `yaml:"auth"`
+	Params    map[string]ConnectionParamDef       `yaml:"params"`
 	Discovery *pluginmanifestv1.ProviderDiscovery `yaml:"discovery"`
 }
 

--- a/gestaltd/internal/config/surfaces.go
+++ b/gestaltd/internal/config/surfaces.go
@@ -35,11 +35,11 @@ func ManifestProviderSurfaceURL(provider *pluginmanifestv1.Plugin, surface SpecS
 	}
 	switch surface {
 	case SpecSurfaceOpenAPI:
-		return provider.OpenAPI
+		return provider.OpenAPIDocument()
 	case SpecSurfaceGraphQL:
-		return provider.GraphQLURL
+		return provider.GraphQLURL()
 	case SpecSurfaceMCP:
-		return provider.MCPURL
+		return provider.MCPURL()
 	default:
 		return ""
 	}
@@ -49,14 +49,5 @@ func ManifestProviderSurfaceConnectionName(provider *pluginmanifestv1.Plugin, su
 	if provider == nil {
 		return ""
 	}
-	switch surface {
-	case SpecSurfaceOpenAPI:
-		return provider.OpenAPIConnection
-	case SpecSurfaceGraphQL:
-		return provider.GraphQLConnection
-	case SpecSurfaceMCP:
-		return provider.MCPConnection
-	default:
-		return ""
-	}
+	return provider.SurfaceConnectionName(string(surface))
 }

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -152,8 +152,10 @@ source: github.com/testowner/plugins/notion
 version: 0.0.1-alpha.1
 displayName: Notion
 plugin:
-  mcpUrl: https://mcp.notion.com/mcp
-  mcpConnection: mcp
+  surfaces:
+    mcp:
+      url: https://mcp.notion.com/mcp
+      connection: mcp
   connections:
     mcp:
       mode: user
@@ -187,7 +189,7 @@ plugins:
 	if intg.Plugin == nil || intg.Plugin.ResolvedManifest == nil || intg.Plugin.ResolvedManifest.Plugin == nil {
 		t.Fatalf("ResolvedManifest = %+v", intg.Plugin)
 	}
-	if got := intg.Plugin.ResolvedManifest.Plugin.MCPURL; got != "https://mcp.notion.com/mcp" {
+	if got := intg.Plugin.ResolvedManifest.Plugin.MCPURL(); got != "https://mcp.notion.com/mcp" {
 		t.Fatalf("MCPURL = %q, want %q", got, "https://mcp.notion.com/mcp")
 	}
 	conn := intg.Plugin.ResolvedManifest.Plugin.Connections["mcp"]

--- a/gestaltd/internal/pluginhost/declarative.go
+++ b/gestaltd/internal/pluginhost/declarative.go
@@ -63,24 +63,25 @@ func NewDeclarativeProvider(manifest *pluginmanifestv1.Manifest, httpClient *htt
 		httpClient = &http.Client{Timeout: declarativeHTTPTimeout}
 	}
 
+	ops := manifest.Plugin.RESTOperations()
 	p := &DeclarativeProvider{
 		catalog: &catalog.Catalog{
 			Name:        manifest.Source,
 			DisplayName: manifest.DisplayName,
 			Description: manifest.Description,
 			Headers:     maps.Clone(manifest.Plugin.Headers),
-			Operations:  make([]catalog.CatalogOperation, 0, len(manifest.Plugin.Operations)),
+			Operations:  make([]catalog.CatalogOperation, 0, len(ops)),
 		},
-		opsByName:      make(map[string]*catalog.CatalogOperation, len(manifest.Plugin.Operations)),
-		baseURL:        manifest.Plugin.BaseURL,
+		opsByName:      make(map[string]*catalog.CatalogOperation, len(ops)),
+		baseURL:        manifest.Plugin.RESTBaseURL(),
 		auth:           manifest.Plugin.Auth,
 		httpClient:     httpClient,
 		discovery:      manifest.Plugin.Discovery,
 		connectionDefs: manifest.Plugin.ConnectionParams,
 	}
 
-	for i := range manifest.Plugin.Operations {
-		mop := &manifest.Plugin.Operations[i]
+	for i := range ops {
+		mop := &ops[i]
 		catOp := catalog.CatalogOperation{
 			ID:          mop.Name,
 			Method:      mop.Method,

--- a/gestaltd/internal/pluginpkg/manifest.go
+++ b/gestaltd/internal/pluginpkg/manifest.go
@@ -79,9 +79,24 @@ func ValidateManifest(manifest *pluginmanifestv1.Manifest) error {
 	return validateManifest(manifest, false)
 }
 
+var validManifestKinds = map[string]bool{
+	pluginmanifestv1.KindPlugin:    true,
+	pluginmanifestv1.KindAuth:      true,
+	pluginmanifestv1.KindDatastore: true,
+	pluginmanifestv1.KindSecrets:   true,
+	pluginmanifestv1.KindWebUI:     true,
+}
+
 func ManifestKind(manifest *pluginmanifestv1.Manifest) (string, error) {
 	if manifest == nil {
 		return "", fmt.Errorf("manifest is required")
+	}
+
+	if manifest.Kind != "" {
+		if !validManifestKinds[manifest.Kind] {
+			return "", fmt.Errorf("manifest kind %q is not valid; expected one of plugin, auth, datastore, secrets, or webui", manifest.Kind)
+		}
+		return manifest.Kind, nil
 	}
 
 	var (
@@ -109,7 +124,7 @@ func ManifestKind(manifest *pluginmanifestv1.Manifest) (string, error) {
 		count++
 	}
 	if count != 1 {
-		return "", fmt.Errorf("manifest must define exactly one of plugin, auth, datastore, secrets, or webui")
+		return "", fmt.Errorf("manifest must define exactly one of plugin, auth, datastore, secrets, or webui (or set the kind field explicitly)")
 	}
 	return kind, nil
 }
@@ -479,7 +494,7 @@ func validateExecutableProviderMetadata(provider *pluginmanifestv1.Plugin) error
 	if err := validateProviderAuth("provider.auth", provider.Auth); err != nil {
 		return err
 	}
-	if provider.Auth != nil && provider.Auth.Type == pluginmanifestv1.AuthTypeMCPOAuth && provider.MCPURL == "" {
+	if provider.Auth != nil && provider.Auth.Type == pluginmanifestv1.AuthTypeMCPOAuth && provider.MCPURL() == "" {
 		return fmt.Errorf("provider.auth.type %q requires an MCP surface", pluginmanifestv1.AuthTypeMCPOAuth)
 	}
 	for name, conn := range provider.Connections {
@@ -489,7 +504,7 @@ func validateExecutableProviderMetadata(provider *pluginmanifestv1.Plugin) error
 		if err := validateProviderAuth(fmt.Sprintf("provider.connections.%s.auth", name), conn.Auth); err != nil {
 			return err
 		}
-		if conn.Auth != nil && conn.Auth.Type == pluginmanifestv1.AuthTypeMCPOAuth && provider.MCPURL == "" {
+		if conn.Auth != nil && conn.Auth.Type == pluginmanifestv1.AuthTypeMCPOAuth && provider.MCPURL() == "" {
 			return fmt.Errorf("provider.connections.%s.auth.type %q requires an MCP surface", name, pluginmanifestv1.AuthTypeMCPOAuth)
 		}
 		if conn.Mode == "" {
@@ -522,8 +537,8 @@ func validateExecutableProviderMetadata(provider *pluginmanifestv1.Plugin) error
 		field   string
 		present bool
 	}{
-		{field: "provider.baseUrl", present: provider.BaseURL != "" && !provider.IsDeclarative() && provider.OpenAPI == ""},
-		{field: "provider.operations", present: len(provider.Operations) > 0 && !provider.IsDeclarative()},
+		{field: "provider.baseUrl", present: provider.RESTBaseURL() != "" && !provider.IsDeclarative() && provider.OpenAPIDocument() == ""},
+		{field: "provider.operations", present: len(provider.RESTOperations()) > 0 && !provider.IsDeclarative()},
 	}
 	for _, check := range checks {
 		if check.present {
@@ -548,11 +563,12 @@ var validHTTPMethods = map[string]bool{
 }
 
 func validateDeclarativeProvider(provider *pluginmanifestv1.Plugin) error {
-	if provider.BaseURL == "" {
+	if provider.RESTBaseURL() == "" {
 		return fmt.Errorf("provider.baseUrl is required for declarative providers")
 	}
-	seen := make(map[string]struct{}, len(provider.Operations))
-	for i, op := range provider.Operations {
+	ops := provider.RESTOperations()
+	seen := make(map[string]struct{}, len(ops))
+	for i, op := range ops {
 		if op.Name == "" {
 			return fmt.Errorf("provider.operations[%d].name is required", i)
 		}

--- a/gestaltd/internal/pluginpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/pluginpkg/manifest_workflow_test.go
@@ -331,8 +331,10 @@ plugin:
     items.list:
       paginate: true
     items.info: {}
-  openapi: openapi.yaml
-  openapiConnection: api
+  surfaces:
+    openapi:
+      document: openapi.yaml
+      connection: api
 `))
 	mustWriteFile(t, filepath.Join(dir, "schemas", "config.schema.json"), []byte(`{"type":"object"}`), 0o644)
 	mustWriteFile(t, filepath.Join(dir, "openapi.yaml"), []byte("openapi: 3.1.0\ninfo:\n  title: Example\n  version: 1.0.0\npaths: {}\n"), 0o644)
@@ -344,11 +346,11 @@ plugin:
 	if manifest.Plugin == nil {
 		t.Fatal("expected provider metadata")
 	}
-	if manifest.Plugin.OpenAPI != "openapi.yaml" {
-		t.Fatalf("provider openapi = %q", manifest.Plugin.OpenAPI)
+	if manifest.Plugin.OpenAPIDocument() != "openapi.yaml" {
+		t.Fatalf("provider openapi document = %q", manifest.Plugin.OpenAPIDocument())
 	}
-	if manifest.Plugin.OpenAPIConnection != "api" {
-		t.Fatalf("provider openapi_connection = %q, want api", manifest.Plugin.OpenAPIConnection)
+	if manifest.Plugin.SurfaceConnectionName("openapi") != "api" {
+		t.Fatalf("provider openapi connection = %q, want api", manifest.Plugin.SurfaceConnectionName("openapi"))
 	}
 	if len(manifest.Plugin.ManagedParameters) != 1 {
 		t.Fatalf("managed_parameters = %+v", manifest.Plugin.ManagedParameters)
@@ -356,7 +358,7 @@ plugin:
 	if manifest.Entrypoints.Plugin != nil {
 		t.Fatalf("expected declarative/spec provider to omit provider entrypoint, got %+v", manifest.Entrypoints.Plugin)
 	}
-	if pgn := manifest.Plugin.Pagination; pgn == nil || pgn.Style != "cursor" || pgn.Cursor == nil || pgn.Cursor.Source != "header" || pgn.Cursor.Path != "X-After-Cursor" || pgn.MaxPages != 10 {
+	if pgn := manifest.Plugin.Pagination; pgn == nil || pgn.Style != pluginmanifestv1.PaginationStyleCursor || pgn.Cursor == nil || pgn.Cursor.Source != "header" || pgn.Cursor.Path != "X-After-Cursor" || pgn.MaxPages != 10 {
 		t.Fatalf("unexpected pagination config: %+v", manifest.Plugin.Pagination)
 	}
 	if op := manifest.Plugin.AllowedOperations["items.list"]; op == nil || !op.Paginate {
@@ -379,8 +381,10 @@ plugin:
       mode: user
       auth:
         type: mcp_oauth
-  mcpUrl: https://mcp.notion.com/mcp
-  mcpConnection: mcp
+  surfaces:
+    mcp:
+      url: https://mcp.notion.com/mcp
+      connection: mcp
 `))
 
 	_, dirManifest, err := ReadManifestFile(manifestPath)
@@ -390,11 +394,11 @@ plugin:
 	if dirManifest.Plugin == nil {
 		t.Fatal("expected plugin metadata")
 	}
-	if dirManifest.Plugin.MCPURL != "https://mcp.notion.com/mcp" {
-		t.Fatalf("plugin mcp_url = %q", dirManifest.Plugin.MCPURL)
+	if dirManifest.Plugin.MCPURL() != "https://mcp.notion.com/mcp" {
+		t.Fatalf("plugin mcp_url = %q", dirManifest.Plugin.MCPURL())
 	}
-	if dirManifest.Plugin.MCPConnection != "mcp" {
-		t.Fatalf("plugin mcp_connection = %q, want mcp", dirManifest.Plugin.MCPConnection)
+	if dirManifest.Plugin.SurfaceConnectionName("mcp") != "mcp" {
+		t.Fatalf("plugin mcp_connection = %q, want mcp", dirManifest.Plugin.SurfaceConnectionName("mcp"))
 	}
 	if conn := dirManifest.Plugin.Connections["mcp"]; conn == nil || conn.Auth == nil || conn.Auth.Type != pluginmanifestv1.AuthTypeMCPOAuth {
 		t.Fatalf("plugin connection auth = %#v", dirManifest.Plugin.Connections["mcp"])
@@ -468,8 +472,10 @@ plugin:
         namePath: name
         metadata:
           region: region
-  openapi: openapi.yaml
-  openapiConnection: api
+  surfaces:
+    openapi:
+      document: openapi.yaml
+      connection: api
 `))
 	mustWriteFile(t, filepath.Join(dir, "openapi.yaml"), []byte("openapi: 3.1.0\ninfo:\n  title: Example\n  version: 1.0.0\npaths: {}\n"), 0o644)
 

--- a/gestaltd/internal/pluginpkg/references.go
+++ b/gestaltd/internal/pluginpkg/references.go
@@ -35,14 +35,14 @@ func LocalPackageReferences(manifest *pluginmanifestv1.Manifest) []LocalPackageR
 
 	if manifest.Plugin != nil {
 		add(manifest.Plugin.ConfigSchemaPath, "provider config schema")
-		if manifest.Plugin.OpenAPI != "" && !strings.Contains(manifest.Plugin.OpenAPI, "://") {
-			add(manifest.Plugin.OpenAPI, "provider openapi document")
+		if doc := manifest.Plugin.OpenAPIDocument(); doc != "" && !strings.Contains(doc, "://") {
+			add(doc, "provider openapi document")
 		}
-		if manifest.Plugin.GraphQLURL != "" && !strings.Contains(manifest.Plugin.GraphQLURL, "://") {
-			add(manifest.Plugin.GraphQLURL, "provider graphql document")
+		if url := manifest.Plugin.GraphQLURL(); url != "" && !strings.Contains(url, "://") {
+			add(url, "provider graphql document")
 		}
-		if manifest.Plugin.MCPURL != "" && !strings.Contains(manifest.Plugin.MCPURL, "://") {
-			add(manifest.Plugin.MCPURL, "provider mcp document")
+		if url := manifest.Plugin.MCPURL(); url != "" && !strings.Contains(url, "://") {
+			add(url, "provider mcp document")
 		}
 	}
 	if manifest.WebUI != nil {
@@ -56,6 +56,9 @@ func ResolveManifestLocalReferences(manifest *pluginmanifestv1.Manifest, manifes
 	if manifest == nil || manifest.Plugin == nil || manifestPath == "" {
 		return manifest
 	}
+	if manifest.Plugin.Surfaces == nil {
+		return manifest
+	}
 
 	resolve := func(value string) string {
 		if value == "" || filepath.IsAbs(value) || strings.Contains(value, "://") {
@@ -65,25 +68,39 @@ func ResolveManifestLocalReferences(manifest *pluginmanifestv1.Manifest, manifes
 	}
 
 	provider := *manifest.Plugin
+	surfaces := *provider.Surfaces
 	changed := false
 
-	if resolved := resolve(provider.OpenAPI); resolved != provider.OpenAPI {
-		provider.OpenAPI = resolved
-		changed = true
+	if surfaces.OpenAPI != nil {
+		s := *surfaces.OpenAPI
+		if resolved := resolve(s.Document); resolved != s.Document {
+			s.Document = resolved
+			surfaces.OpenAPI = &s
+			changed = true
+		}
 	}
-	if resolved := resolve(provider.GraphQLURL); resolved != provider.GraphQLURL {
-		provider.GraphQLURL = resolved
-		changed = true
+	if surfaces.GraphQL != nil {
+		s := *surfaces.GraphQL
+		if resolved := resolve(s.URL); resolved != s.URL {
+			s.URL = resolved
+			surfaces.GraphQL = &s
+			changed = true
+		}
 	}
-	if resolved := resolve(provider.MCPURL); resolved != provider.MCPURL {
-		provider.MCPURL = resolved
-		changed = true
+	if surfaces.MCP != nil {
+		s := *surfaces.MCP
+		if resolved := resolve(s.URL); resolved != s.URL {
+			s.URL = resolved
+			surfaces.MCP = &s
+			changed = true
+		}
 	}
 
 	if !changed {
 		return manifest
 	}
 
+	provider.Surfaces = &surfaces
 	cloned := *manifest
 	cloned.Plugin = &provider
 	return &cloned

--- a/gestaltd/internal/provider/build.go
+++ b/gestaltd/internal/provider/build.go
@@ -15,6 +15,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
 
 // BuildOption configures optional aspects of provider construction.
@@ -79,10 +80,11 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 
 	connMode := conn.Mode
 	if connMode == "" {
-		connMode = def.ConnectionMode
+		connMode = pluginmanifestv1.ConnectionMode(def.ConnectionMode)
 	}
 	switch connMode {
-	case "", "none", "user", "identity", "either":
+	case "", pluginmanifestv1.ConnectionModeNone, pluginmanifestv1.ConnectionModeUser,
+		pluginmanifestv1.ConnectionModeIdentity, pluginmanifestv1.ConnectionModeEither:
 		if connMode != "" {
 			base.ConnMode = core.ConnectionMode(connMode)
 		}
@@ -208,7 +210,7 @@ func ReadIconFile(path string) (string, error) {
 // ApplyConnectionAuth merges connection auth overrides into the Definition.
 func ApplyConnectionAuth(def *Definition, conn config.ConnectionDef) {
 	o := conn.Auth
-	setStr(&def.Auth.Type, o.Type)
+	setStr(&def.Auth.Type, string(o.Type))
 	setStr(&def.Auth.AuthorizationURL, o.AuthorizationURL)
 	setStr(&def.Auth.TokenURL, o.TokenURL)
 	setStr(&def.Auth.ClientAuth, o.ClientAuth)

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
 
 type createTokenRequest struct {
@@ -279,7 +280,7 @@ func connectionInfoFromAuth(name string, auth config.ConnectionAuthDef, integrat
 	return info, true
 }
 
-func connectionAuthTypes(authType string, integrationAuthTypes []string) []string {
+func connectionAuthTypes(authType pluginmanifestv1.AuthType, integrationAuthTypes []string) []string {
 	if authType == "" {
 		if len(integrationAuthTypes) == 0 {
 			return nil
@@ -287,7 +288,7 @@ func connectionAuthTypes(authType string, integrationAuthTypes []string) []strin
 		return append([]string(nil), integrationAuthTypes...)
 	}
 
-	authTypes := userFacingAuthTypes([]string{authType})
+	authTypes := userFacingAuthTypes([]string{string(authType)})
 	if len(authTypes) == 0 {
 		return nil
 	}

--- a/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -8,6 +8,16 @@
     "version"
   ],
   "properties": {
+    "kind": {
+      "type": "string",
+      "enum": [
+        "plugin",
+        "auth",
+        "datastore",
+        "secrets",
+        "webui"
+      ]
+    },
     "source": {
       "type": "string",
       "pattern": "^github\\.com/[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)*$"

--- a/gestaltd/sdk/pluginmanifest/v1/types.go
+++ b/gestaltd/sdk/pluginmanifest/v1/types.go
@@ -122,6 +122,20 @@ func (p *Plugin) OpenAPIDocument() string {
 	return p.Surfaces.OpenAPI.Document
 }
 
+func (p *Plugin) OpenAPIBaseURL() string {
+	if p == nil || p.Surfaces == nil || p.Surfaces.OpenAPI == nil {
+		return ""
+	}
+	return p.Surfaces.OpenAPI.BaseURL
+}
+
+func (p *Plugin) SpecBaseURL() string {
+	if u := p.RESTBaseURL(); u != "" {
+		return u
+	}
+	return p.OpenAPIBaseURL()
+}
+
 func (p *Plugin) GraphQLURL() string {
 	if p == nil || p.Surfaces == nil || p.Surfaces.GraphQL == nil {
 		return ""

--- a/gestaltd/sdk/pluginmanifest/v1/types.go
+++ b/gestaltd/sdk/pluginmanifest/v1/types.go
@@ -13,6 +13,7 @@ const (
 )
 
 type Manifest struct {
+	Kind        string             `json:"kind,omitempty" yaml:"kind,omitempty"`
 	Source      string             `json:"source,omitempty" yaml:"source,omitempty"`
 	Version     string             `json:"version" yaml:"version"`
 	DisplayName string             `json:"displayName,omitempty" yaml:"displayName,omitempty"`
@@ -57,38 +58,121 @@ type WebUIMetadata struct {
 type Plugin struct {
 	ConfigSchemaPath  string                             `json:"configSchemaPath,omitempty" yaml:"configSchemaPath,omitempty"`
 	Auth              *ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
-	ConnectionMode    string                             `json:"connectionMode,omitempty" yaml:"connectionMode,omitempty"`
+	ConnectionMode    ConnectionMode                     `json:"connectionMode,omitempty" yaml:"connectionMode,omitempty"`
 	MCP               bool                               `json:"mcp,omitempty" yaml:"mcp,omitempty"`
-	BaseURL           string                             `json:"baseUrl,omitempty" yaml:"baseUrl,omitempty"`
 	Headers           map[string]string                  `json:"headers,omitempty" yaml:"headers,omitempty"`
 	ManagedParameters []ManagedParameter                 `json:"managedParameters,omitempty" yaml:"managedParameters,omitempty"`
-	Operations        []ProviderOperation                `json:"operations,omitempty" yaml:"operations,omitempty"`
 	Discovery         *ProviderDiscovery                 `json:"discovery,omitempty" yaml:"discovery,omitempty"`
 	ConnectionParams  map[string]ProviderConnectionParam `json:"connectionParams,omitempty" yaml:"connectionParams,omitempty"`
 
-	OpenAPI           string                                `json:"openapi,omitempty" yaml:"openapi,omitempty"`
-	GraphQLURL        string                                `json:"graphqlUrl,omitempty" yaml:"graphqlUrl,omitempty"`
-	MCPURL            string                                `json:"mcpUrl,omitempty" yaml:"mcpUrl,omitempty"`
+	Surfaces          *PluginSurfaces                       `json:"surfaces,omitempty" yaml:"surfaces,omitempty"`
 	AllowedOperations map[string]*ManifestOperationOverride `json:"allowedOperations,omitempty" yaml:"allowedOperations,omitempty"`
-	OpenAPIConnection string                                `json:"openapiConnection,omitempty" yaml:"openapiConnection,omitempty"`
-	GraphQLConnection string                                `json:"graphqlConnection,omitempty" yaml:"graphqlConnection,omitempty"`
-	MCPConnection     string                                `json:"mcpConnection,omitempty" yaml:"mcpConnection,omitempty"`
 	DefaultConnection string                                `json:"defaultConnection,omitempty" yaml:"defaultConnection,omitempty"`
 	Connections       map[string]*ManifestConnectionDef     `json:"connections,omitempty" yaml:"connections,omitempty"`
 	ResponseMapping   *ManifestResponseMapping              `json:"responseMapping,omitempty" yaml:"responseMapping,omitempty"`
 	Pagination        *ManifestPaginationConfig             `json:"pagination,omitempty" yaml:"pagination,omitempty"`
 }
 
+type PluginSurfaces struct {
+	REST    *RESTSurface    `json:"rest,omitempty" yaml:"rest,omitempty"`
+	OpenAPI *OpenAPISurface `json:"openapi,omitempty" yaml:"openapi,omitempty"`
+	GraphQL *GraphQLSurface `json:"graphql,omitempty" yaml:"graphql,omitempty"`
+	MCP     *MCPSurface     `json:"mcp,omitempty" yaml:"mcp,omitempty"`
+}
+
+type RESTSurface struct {
+	Connection string              `json:"connection,omitempty" yaml:"connection,omitempty"`
+	BaseURL    string              `json:"baseUrl" yaml:"baseUrl"`
+	Operations []ProviderOperation `json:"operations" yaml:"operations"`
+}
+
+type OpenAPISurface struct {
+	Connection string `json:"connection,omitempty" yaml:"connection,omitempty"`
+	Document   string `json:"document" yaml:"document"`
+	BaseURL    string `json:"baseUrl,omitempty" yaml:"baseUrl,omitempty"`
+}
+
+type GraphQLSurface struct {
+	Connection string `json:"connection,omitempty" yaml:"connection,omitempty"`
+	URL        string `json:"url" yaml:"url"`
+}
+
+type MCPSurface struct {
+	Connection string `json:"connection,omitempty" yaml:"connection,omitempty"`
+	URL        string `json:"url" yaml:"url"`
+}
+
 func (p *Plugin) IsDeclarative() bool {
-	return p != nil && len(p.Operations) > 0
+	return p != nil && p.Surfaces != nil && p.Surfaces.REST != nil && len(p.Surfaces.REST.Operations) > 0
 }
 
 func (p *Plugin) IsSpecLoaded() bool {
-	return p != nil && (p.OpenAPI != "" || p.GraphQLURL != "" || p.MCPURL != "")
+	return p != nil && p.Surfaces != nil &&
+		(p.Surfaces.OpenAPI != nil || p.Surfaces.GraphQL != nil || p.Surfaces.MCP != nil)
 }
 
 func (p *Plugin) IsManifestBacked() bool {
 	return p != nil && (p.IsDeclarative() || p.IsSpecLoaded())
+}
+
+func (p *Plugin) OpenAPIDocument() string {
+	if p == nil || p.Surfaces == nil || p.Surfaces.OpenAPI == nil {
+		return ""
+	}
+	return p.Surfaces.OpenAPI.Document
+}
+
+func (p *Plugin) GraphQLURL() string {
+	if p == nil || p.Surfaces == nil || p.Surfaces.GraphQL == nil {
+		return ""
+	}
+	return p.Surfaces.GraphQL.URL
+}
+
+func (p *Plugin) MCPURL() string {
+	if p == nil || p.Surfaces == nil || p.Surfaces.MCP == nil {
+		return ""
+	}
+	return p.Surfaces.MCP.URL
+}
+
+func (p *Plugin) RESTBaseURL() string {
+	if p == nil || p.Surfaces == nil || p.Surfaces.REST == nil {
+		return ""
+	}
+	return p.Surfaces.REST.BaseURL
+}
+
+func (p *Plugin) RESTOperations() []ProviderOperation {
+	if p == nil || p.Surfaces == nil || p.Surfaces.REST == nil {
+		return nil
+	}
+	return p.Surfaces.REST.Operations
+}
+
+func (p *Plugin) SurfaceConnectionName(surface string) string {
+	if p == nil || p.Surfaces == nil {
+		return ""
+	}
+	switch surface {
+	case "openapi":
+		if p.Surfaces.OpenAPI != nil {
+			return p.Surfaces.OpenAPI.Connection
+		}
+	case "graphql":
+		if p.Surfaces.GraphQL != nil {
+			return p.Surfaces.GraphQL.Connection
+		}
+	case "mcp":
+		if p.Surfaces.MCP != nil {
+			return p.Surfaces.MCP.Connection
+		}
+	case "rest":
+		if p.Surfaces.REST != nil {
+			return p.Surfaces.REST.Connection
+		}
+	}
+	return ""
 }
 
 func (m *Manifest) IsHybridProvider() bool {
@@ -128,7 +212,7 @@ type ProviderConnectionParam struct {
 }
 
 type ManifestPaginationConfig struct {
-	Style        string                 `json:"style" yaml:"style"`
+	Style        PaginationStyle        `json:"style" yaml:"style"`
 	CursorParam  string                 `json:"cursorParam,omitempty" yaml:"cursorParam,omitempty"`
 	Cursor       *ManifestValueSelector `json:"cursor,omitempty" yaml:"cursor,omitempty"`
 	LimitParam   string                 `json:"limitParam,omitempty" yaml:"limitParam,omitempty"`
@@ -145,7 +229,7 @@ type ManifestOperationOverride struct {
 }
 
 type ManifestConnectionDef struct {
-	Mode      string                             `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Mode      ConnectionMode                     `json:"mode,omitempty" yaml:"mode,omitempty"`
 	Auth      *ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
 	Params    map[string]ProviderConnectionParam `json:"params,omitempty" yaml:"params,omitempty"`
 	Discovery *ProviderDiscovery                 `json:"discovery,omitempty" yaml:"discovery,omitempty"`
@@ -173,16 +257,35 @@ type ManagedParameter struct {
 	Value string `json:"value" yaml:"value"`
 }
 
+type AuthType string
+
 const (
-	AuthTypeOAuth2   = "oauth2"
-	AuthTypeMCPOAuth = "mcp_oauth"
-	AuthTypeBearer   = "bearer"
-	AuthTypeManual   = "manual"
-	AuthTypeNone     = "none"
+	AuthTypeOAuth2   AuthType = "oauth2"
+	AuthTypeMCPOAuth AuthType = "mcp_oauth"
+	AuthTypeBearer   AuthType = "bearer"
+	AuthTypeManual   AuthType = "manual"
+	AuthTypeNone     AuthType = "none"
+)
+
+type ConnectionMode string
+
+const (
+	ConnectionModeNone     ConnectionMode = "none"
+	ConnectionModeUser     ConnectionMode = "user"
+	ConnectionModeIdentity ConnectionMode = "identity"
+	ConnectionModeEither   ConnectionMode = "either"
+)
+
+type PaginationStyle string
+
+const (
+	PaginationStyleCursor PaginationStyle = "cursor"
+	PaginationStyleOffset PaginationStyle = "offset"
+	PaginationStylePage   PaginationStyle = "page"
 )
 
 type ProviderAuth struct {
-	Type                string            `json:"type" yaml:"type"`
+	Type                AuthType          `json:"type" yaml:"type"`
 	AuthorizationURL    string            `json:"authorizationUrl,omitempty" yaml:"authorizationUrl,omitempty"`
 	TokenURL            string            `json:"tokenUrl,omitempty" yaml:"tokenUrl,omitempty"`
 	ClientID            string            `json:"clientId,omitempty" yaml:"clientId,omitempty"`


### PR DESCRIPTION
## Summary

- **Structured surfaces block**: Replace 8 flat surface fields on Plugin (`OpenAPI`, `GraphQLURL`, `MCPURL`, etc.) with a structured `Surfaces` sub-struct containing `REST`, `OpenAPI`, `GraphQL`, and `MCP` types, each with consistent `Connection` and type-specific fields. Aligns Go types with the existing JSON schema.
- **Typed string enums**: Add `AuthType`, `ConnectionMode`, and `PaginationStyle` as typed strings in the manifest SDK, replacing raw string comparisons with compile-time safe constants.
- **Unified component config**: Replace 5 nearly-identical component config types and 6 custom `UnmarshalYAML` methods with a single `ComponentConfig` struct and one shared unmarshal function. Supports both the new `provider: { builtin: X }` format and the legacy `provider: X` scalar form.
- **Explicit manifest kind**: Add optional `kind` field to Manifest, enabling self-describing manifests while maintaining backward compatibility with inference from metadata blocks.
- **Wire type simplification**: Eliminate `integrationDiscoveryWire` and its conversion method by using `ProviderDiscovery` directly.

## Test plan

- [ ] `go build ./...` compiles cleanly
- [ ] `go test ./...` passes (all 17 changed files covered by existing tests)
- [ ] Verify manifest YAML fixtures use new `surfaces:` block format
- [ ] Verify config YAML fixtures work with both old and new provider formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)