### PR TITLE
[codex] use camelCase oauth config keys

### DIFF
--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -45,7 +45,7 @@ config:
         ref: github.com/valon-technologies/gestalt-providers/auth/oidc
         version: 0.0.1-alpha.1
     config:
-      issuer_url: "${OIDC_ISSUER_URL}"
+      issuerUrl: "${OIDC_ISSUER_URL}"
       clientId: "${OIDC_CLIENT_ID}"
       clientSecret: "${OIDC_CLIENT_SECRET}"
   datastore:
@@ -123,10 +123,10 @@ config:
         ref: github.com/valon-technologies/gestalt-providers/auth/oidc
         version: 0.0.1-alpha.1
     config:
-      issuer_url: "${OIDC_ISSUER_URL}"
+      issuerUrl: "${OIDC_ISSUER_URL}"
       clientId: "${OIDC_CLIENT_ID}"
       clientSecret: "${OIDC_CLIENT_SECRET}"
-      redirect_url: "${OIDC_REDIRECT_URL}"
+      redirectUrl: "${OIDC_REDIRECT_URL}"
   datastore:
     provider:
       source:

--- a/docs/content/providers/auth.mdx
+++ b/docs/content/providers/auth.mdx
@@ -44,10 +44,10 @@ An auth provider implements three methods: `Configure`, `BeginLogin`, and `Compl
     }
 
     func (a *MyAuth) Configure(_ context.Context, _ string, config map[string]any) error {
-    	a.clientID, _ = config["client_id"].(string)
-    	a.issuerURL, _ = config["issuer_url"].(string)
+    	a.clientID, _ = config["clientId"].(string)
+    	a.issuerURL, _ = config["issuerUrl"].(string)
     	if a.clientID == "" || a.issuerURL == "" {
-    		return fmt.Errorf("client_id and issuer_url are required")
+    		return fmt.Errorf("clientId and issuerUrl are required")
     	}
     	return nil
     }
@@ -88,8 +88,8 @@ An auth provider implements three methods: `Configure`, `BeginLogin`, and `Compl
 
     class MyAuth(gestalt.AuthProvider):
         def configure(self, name: str, config: dict) -> None:
-            self.client_id = config.get("client_id", "")
-            self.issuer_url = config.get("issuer_url", "")
+            self.client_id = config.get("clientId", "")
+            self.issuer_url = config.get("issuerUrl", "")
 
         def begin_login(self, request: gestalt.BeginLoginRequest) -> gestalt.BeginLoginResponse:
             auth_url = (
@@ -134,9 +134,9 @@ An auth provider implements three methods: `Configure`, `BeginLogin`, and `Compl
             config: serde_json::Map<String, serde_json::Value>,
         ) -> gestalt::Result<()> {
             *self.client_id.lock().unwrap() = config
-                .get("client_id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                .get("clientId").and_then(|v| v.as_str()).unwrap_or("").to_string();
             *self.issuer_url.lock().unwrap() = config
-                .get("issuer_url").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                .get("issuerUrl").and_then(|v| v.as_str()).unwrap_or("").to_string();
             Ok(())
         }
 
@@ -180,8 +180,8 @@ An auth provider implements three methods: `Configure`, `BeginLogin`, and `Compl
 
     export const provider = defineAuthProvider({
       async configure(_name, config) {
-        clientId = typeof config.client_id === "string" ? config.client_id : "";
-        issuerUrl = typeof config.issuer_url === "string" ? config.issuer_url : "";
+        clientId = typeof config.clientId === "string" ? config.clientId : "";
+        issuerUrl = typeof config.issuerUrl === "string" ? config.issuerUrl : "";
       },
       async beginLogin(request) {
         return {
@@ -245,7 +245,7 @@ auth:
     source:
       path: ./my-auth/manifest.yaml
   config:
-    issuer_url: https://login.example.com
+    issuerUrl: https://login.example.com
     clientId: ${OIDC_CLIENT_ID}
     clientSecret: secret://oidc-client-secret
 ```

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -11,7 +11,7 @@ Auth providers handle platform login. They are configured under `auth.provider` 
 | Name | Purpose |
 | --- | --- |
 | `local` | Single-user auth for local development. No external identity provider required. |
-| `google` | Google OAuth 2.0 platform login. Supports `allowed_domains` restriction. |
+| `google` | Google OAuth 2.0 platform login. Supports `allowedDomains` restriction. |
 | `oidc` | Generic OpenID Connect. Works with Okta, Auth0, Azure AD, Keycloak, and others. |
 
 ```yaml
@@ -21,7 +21,7 @@ auth:
       ref: github.com/valon-technologies/gestalt-providers/auth-google
       version: 1.0.0
   config:
-    allowed_domains:
+    allowedDomains:
       - example.com
 ```
 

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -177,7 +177,7 @@ func TestBootstrap_ReusesPreparedComponentRuntimeConfig(t *testing.T) {
 	authRuntime, err := config.BuildComponentRuntimeConfigNode("auth", "auth", cfg.Auth.Provider, yaml.Node{
 		Kind: yaml.MappingNode,
 		Content: []*yaml.Node{
-			{Kind: yaml.ScalarNode, Tag: "!!str", Value: "client_id"},
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: "clientId"},
 			{Kind: yaml.ScalarNode, Tag: "!!str", Value: "prepared-auth"},
 		},
 	})
@@ -210,7 +210,7 @@ func TestBootstrap_ReusesPreparedComponentRuntimeConfig(t *testing.T) {
 	if _, nested := authConfig["config"]; nested {
 		t.Fatalf("auth config was rewrapped: %#v", authConfig)
 	}
-	if authConfig["client_id"] != "prepared-auth" {
+	if authConfig["clientId"] != "prepared-auth" {
 		t.Fatalf("auth config = %#v", authConfig)
 	}
 
@@ -432,7 +432,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		cfg.Auth.Config = yaml.Node{
 			Kind: yaml.MappingNode,
 			Content: []*yaml.Node{
-				{Kind: yaml.ScalarNode, Value: "client_secret", Tag: "!!str"},
+				{Kind: yaml.ScalarNode, Value: "clientSecret", Tag: "!!str"},
 				{Kind: yaml.ScalarNode, Value: "secret://auth-secret", Tag: "!!str"},
 			},
 		}
@@ -453,8 +453,8 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		if decoded.Source == nil || decoded.Source.Ref != "github.com/valon-technologies/gestalt-providers/auth/oidc" {
 			t.Fatalf("source = %+v", decoded.Source)
 		}
-		if decoded.Config["client_secret"] != "resolved-auth-secret" {
-			t.Errorf("client_secret: got %q, want %q", decoded.Config["client_secret"], "resolved-auth-secret")
+		if decoded.Config["clientSecret"] != "resolved-auth-secret" {
+			t.Errorf("clientSecret: got %q, want %q", decoded.Config["clientSecret"], "resolved-auth-secret")
 		}
 	})
 
@@ -466,7 +466,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		cfg.Auth.Config = yaml.Node{
 			Kind: yaml.MappingNode,
 			Content: []*yaml.Node{
-				{Kind: yaml.ScalarNode, Value: "issuer_url", Tag: "!!str"},
+				{Kind: yaml.ScalarNode, Value: "issuerUrl", Tag: "!!str"},
 				{Kind: yaml.ScalarNode, Value: "https://issuer.example.test", Tag: "!!str"},
 			},
 		}
@@ -494,7 +494,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		if authCfg.Source == nil || authCfg.Source.Ref != "github.com/valon-technologies/gestalt-providers/auth/oidc" {
 			t.Fatalf("auth source = %+v", authCfg.Source)
 		}
-		if authCfg.Config["issuer_url"] != "https://issuer.example.test" {
+		if authCfg.Config["issuerUrl"] != "https://issuer.example.test" {
 			t.Fatalf("auth config = %+v", authCfg.Config)
 		}
 	})

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -336,8 +336,8 @@ func TestPluginManifestOAuthWiresConnectionAuth(t *testing.T) {
 					Command: bin,
 					Args:    []string{"provider"},
 					Config: mustNode(t, map[string]any{
-						"client_id":     "test-client-id",
-						"client_secret": "test-client-secret",
+						"clientId":     "test-client-id",
+						"clientSecret": "test-client-secret",
 					}),
 					ResolvedManifest:     manifest,
 					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
@@ -447,8 +447,8 @@ func TestPluginManifestNamedOAuthKeepsProviderTokenMode(t *testing.T) {
 						},
 					},
 					Config: mustNode(t, map[string]any{
-						"client_id":     "test-client-id",
-						"client_secret": "test-client-secret",
+						"clientId":     "test-client-id",
+						"clientSecret": "test-client-secret",
 					}),
 					ResolvedManifest:     manifest,
 					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -841,14 +841,14 @@ func buildOAuthHandlerFromAuth(auth *config.ConnectionAuthDef, pluginConfig map[
 
 	clientID := auth.ClientID
 	clientSecret := auth.ClientSecret
-	if id, _ := pluginConfig["client_id"].(string); id != "" {
+	if id, _ := pluginConfig["clientId"].(string); id != "" {
 		clientID = id
 	}
-	if sec, _ := pluginConfig["client_secret"].(string); sec != "" {
+	if sec, _ := pluginConfig["clientSecret"].(string); sec != "" {
 		clientSecret = sec
 	}
 	if clientID == "" || clientSecret == "" {
-		return nil, fmt.Errorf("client_id and client_secret are required for oauth2 auth")
+		return nil, fmt.Errorf("clientId and clientSecret are required for oauth2 auth")
 	}
 
 	var tokenExchange oauth.TokenExchangeFormat
@@ -858,7 +858,7 @@ func buildOAuthHandlerFromAuth(auth *config.ConnectionAuthDef, pluginConfig map[
 	case "json":
 		tokenExchange = oauth.TokenExchangeJSON
 	default:
-		return nil, fmt.Errorf("unknown token_exchange %q", auth.TokenExchange)
+		return nil, fmt.Errorf("unknown tokenExchange %q", auth.TokenExchange)
 	}
 
 	oauthCfg := oauth.UpstreamConfig{
@@ -891,14 +891,14 @@ func buildOAuthHandlerFromDefinition(def *provider.Definition, conn config.Conne
 	}
 
 	effectiveConn := conn
-	if id, _ := pluginConfig["client_id"].(string); id != "" {
+	if id, _ := pluginConfig["clientId"].(string); id != "" {
 		effectiveConn.Auth.ClientID = id
 	}
-	if sec, _ := pluginConfig["client_secret"].(string); sec != "" {
+	if sec, _ := pluginConfig["clientSecret"].(string); sec != "" {
 		effectiveConn.Auth.ClientSecret = sec
 	}
 	if effectiveConn.Auth.ClientID == "" || effectiveConn.Auth.ClientSecret == "" {
-		return nil, fmt.Errorf("client_id and client_secret are required for oauth2 auth")
+		return nil, fmt.Errorf("clientId and clientSecret are required for oauth2 auth")
 	}
 	if effectiveConn.Auth.RedirectURL == "" {
 		effectiveConn.Auth.RedirectURL = deps.BaseURL + config.IntegrationCallbackPath

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -40,8 +40,8 @@ auth:
       ref: github.com/valon-technologies/gestalt-providers/auth/google
       version: 1.0.0
   config:
-    client_id: client-1
-    client_secret: secret-1
+    clientId: client-1
+    clientSecret: secret-1
 datastores:
   sqlite:
     driver: sqlite
@@ -96,7 +96,7 @@ auth:
       ref: github.com/valon-technologies/gestalt-providers/auth/google
       version: 1.0.0
   config:
-    client_id: ${TEST_CLIENT_ID}
+    clientId: ${TEST_CLIENT_ID}
 datastores:
   sqlite:
     driver: sqlite
@@ -133,8 +133,8 @@ plugins:
 		t.Fatal("Auth.Provider = nil")
 	}
 	authCfg := mustDecodeNode(t, cfg.Auth.Config)
-	if authCfg["client_id"] != "client-from-env" {
-		t.Fatalf("Auth.Config.client_id = %#v", authCfg["client_id"])
+	if authCfg["clientId"] != "client-from-env" {
+		t.Fatalf("Auth.Config.clientId = %#v", authCfg["clientId"])
 	}
 }
 
@@ -405,7 +405,7 @@ auth:
       ref: github.com/valon-technologies/gestalt-providers/auth/oidc
       version: 1.0.0
   config:
-    issuer_url: https://issuer.example.test
+    issuerUrl: https://issuer.example.test
 datastores:
   sqlite:
     driver: sqlite
@@ -1088,9 +1088,9 @@ auth:
       ref: github.com/valon-technologies/gestalt-providers/auth/google
       version: 1.0.0
   config:
-    client_id: client-1
-    client_secret: secret-1
-    allowed_domain: example.test
+    clientId: client-1
+    clientSecret: secret-1
+    redirectUrl: https://example.test/callback
 datastores:
   sqlite:
     driver: sqlite
@@ -1112,14 +1112,14 @@ server:
 	if len(authCfg) != 3 {
 		t.Fatalf("Auth.Config length = %d, want 3", len(authCfg))
 	}
-	if authCfg["client_id"] != "client-1" {
-		t.Fatalf("Auth.Config.client_id = %#v", authCfg["client_id"])
+	if authCfg["clientId"] != "client-1" {
+		t.Fatalf("Auth.Config.clientId = %#v", authCfg["clientId"])
 	}
-	if authCfg["client_secret"] != "secret-1" {
-		t.Fatalf("Auth.Config.client_secret = %#v", authCfg["client_secret"])
+	if authCfg["clientSecret"] != "secret-1" {
+		t.Fatalf("Auth.Config.clientSecret = %#v", authCfg["clientSecret"])
 	}
-	if authCfg["allowed_domain"] != "example.test" {
-		t.Fatalf("Auth.Config.allowed_domain = %#v", authCfg["allowed_domain"])
+	if authCfg["redirectUrl"] != "https://example.test/callback" {
+		t.Fatalf("Auth.Config.redirectUrl = %#v", authCfg["redirectUrl"])
 	}
 }
 

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -538,7 +538,7 @@ func TestSourceAuthPluginLoadForExecution(t *testing.T) {
 		"      auth:",
 		"        token: secret://source-token",
 		"  config:",
-		"    client_id: managed-auth-client",
+		"    clientId: managed-auth-client",
 		"server:",
 		"  artifactsDir: " + artifactsDir,
 		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -627,7 +627,7 @@ func TestSourceAuthPluginLoadForExecution(t *testing.T) {
 		t.Fatalf("auth source config leaked source.auth: %#v", sourceCfg)
 	}
 	nested, ok := authCfg["config"].(map[string]any)
-	if !ok || nested["client_id"] != "managed-auth-client" {
+	if !ok || nested["clientId"] != "managed-auth-client" {
 		t.Fatalf("auth nested config = %#v", authCfg["config"])
 	}
 }
@@ -730,7 +730,7 @@ func TestSourceSecretsPluginBootstrapsManagedAuthSourceToken(t *testing.T) {
 		"      auth:",
 		"        token: secret://source-token",
 		"  config:",
-		"    client_id: managed-auth-client",
+		"    clientId: managed-auth-client",
 		"server:",
 		"  artifactsDir: " + artifactsDir,
 		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -276,7 +276,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalTopLevelPluginsWithoutLockfile(t *t
     source:
       path: ./auth-manifest.yaml
   config:
-    client_id: local-auth-client
+    clientId: local-auth-client
 datastores:
   sqlite:
     driver: sqlite
@@ -311,7 +311,7 @@ server:
 		t.Fatalf("auth config command = %v, want %q", authCfg["command"], authExecutablePath)
 	}
 	authPluginCfg, ok := authCfg["config"].(map[string]any)
-	if !ok || authPluginCfg["client_id"] != "local-auth-client" {
+	if !ok || authPluginCfg["clientId"] != "local-auth-client" {
 		t.Fatalf("auth nested config = %#v", authCfg["config"])
 	}
 

--- a/sdk/go/auth_transport_test.go
+++ b/sdk/go/auth_transport_test.go
@@ -129,7 +129,7 @@ func TestAuthProviderRoundTrip(t *testing.T) {
 		t.Fatalf("warnings = %v, want to contain %q", meta.GetWarnings(), "battery low")
 	}
 
-	cfg, _ := structpb.NewStruct(map[string]any{"client_id": "abc"})
+	cfg, _ := structpb.NewStruct(map[string]any{"clientId": "abc"})
 	_, err = runtimeClient.ConfigureProvider(rpcCtx, &proto.ConfigureProviderRequest{
 		Name:            "my-auth",
 		Config:          cfg,
@@ -144,8 +144,8 @@ func TestAuthProviderRoundTrip(t *testing.T) {
 	if provider.configured[0].name != "my-auth" {
 		t.Fatalf("configured name = %q, want %q", provider.configured[0].name, "my-auth")
 	}
-	if provider.configured[0].config["client_id"] != "abc" {
-		t.Fatalf("configured config[client_id] = %v, want %q", provider.configured[0].config["client_id"], "abc")
+	if provider.configured[0].config["clientId"] != "abc" {
+		t.Fatalf("configured config[clientId] = %v, want %q", provider.configured[0].config["clientId"], "abc")
 	}
 
 	health, err := runtimeClient.HealthCheck(rpcCtx, &emptypb.Empty{})


### PR DESCRIPTION
## Summary
- switch plugin OAuth override config to camelCase-only keys (`clientId`, `clientSecret`, related docs/examples)
- update bootstrap/config/operator/sdk tests to use the camelCase contract
- remove stale snake_case expectations from first-party auth docs and fixtures

## Why
The public config contract has already moved to camelCase, but bootstrap still expected snake_case in the override path. This makes the runtime disagree with deploy config and causes provider bootstrap failures.

## Validation
- `cd gestaltd && go test ./internal/bootstrap ./internal/config ./internal/operator`
- `cd sdk/go && go test ./...`
