### PR TITLE
Replace audit validation switch with registry pattern

### DIFF
--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -71,55 +72,79 @@ func validateTelemetry(cfg TelemetryConfig) error {
 	return nil
 }
 
+func noConfigAllowed(component, provider string) func(yaml.Node) error {
+	return func(cfg yaml.Node) error {
+		if cfg.Kind == 0 {
+			return nil
+		}
+		return fmt.Errorf("config validation: %s.config is not supported when %s.provider is %q", component, component, provider)
+	}
+}
+
+func validateStdoutAuditConfig(cfg yaml.Node) error {
+	if cfg.Kind == 0 {
+		return nil
+	}
+	var stdoutCfg struct {
+		Level  string `yaml:"level"`
+		Format string `yaml:"format"`
+	}
+	if err := cfg.Decode(&stdoutCfg); err != nil {
+		return fmt.Errorf("config validation: stdout audit: parsing config: %w", err)
+	}
+	return nil
+}
+
+func validateOTLPAuditConfig(cfg yaml.Node) error {
+	if cfg.Kind == 0 {
+		return nil
+	}
+	var otlpCfg struct {
+		Protocol string `yaml:"protocol"`
+		Logs     struct {
+			Exporter string `yaml:"exporter"`
+		} `yaml:"logs"`
+	}
+	if err := cfg.Decode(&otlpCfg); err != nil {
+		return fmt.Errorf("config validation: otlp audit: parsing config: %w", err)
+	}
+	if otlpCfg.Protocol != "" {
+		switch strings.ToLower(otlpCfg.Protocol) {
+		case "grpc", "http":
+		default:
+			return fmt.Errorf("config validation: otlp audit: unknown protocol %q (expected \"grpc\" or \"http\")", otlpCfg.Protocol)
+		}
+	}
+	if otlpCfg.Logs.Exporter != "" && !strings.EqualFold(otlpCfg.Logs.Exporter, "otlp") {
+		return fmt.Errorf("config validation: otlp audit: logs.exporter must be %q", "otlp")
+	}
+	return nil
+}
+
+var builtinAuditValidators = map[string]func(yaml.Node) error{
+	"":        noConfigAllowed("audit", ""),
+	"inherit": noConfigAllowed("audit", "inherit"),
+	"noop":    noConfigAllowed("audit", "noop"),
+	"stdout":  validateStdoutAuditConfig,
+	"otlp":    validateOTLPAuditConfig,
+}
+
 func validateAudit(cfg AuditConfig) error {
 	if cfg.Provider != nil {
 		return validateTopLevelComponentProvider("audit", cfg.Provider)
 	}
-	switch cfg.BuiltinProvider {
-	case "", "inherit", "noop":
-		if cfg.Config.Kind == 0 {
-			return nil
-		}
-		return fmt.Errorf("config validation: audit.config is not supported when audit.provider is %q", cfg.BuiltinProvider)
-	case "stdout":
-		if cfg.Config.Kind == 0 {
-			return nil
-		}
-		var stdoutCfg struct {
-			Level  string `yaml:"level"`
-			Format string `yaml:"format"`
-		}
-		if err := cfg.Config.Decode(&stdoutCfg); err != nil {
-			return fmt.Errorf("config validation: stdout audit: parsing config: %w", err)
-		}
-		return nil
-	case "otlp":
-		if cfg.Config.Kind == 0 {
-			return nil
-		}
-		var otlpCfg struct {
-			Protocol string `yaml:"protocol"`
-			Logs     struct {
-				Exporter string `yaml:"exporter"`
-			} `yaml:"logs"`
-		}
-		if err := cfg.Config.Decode(&otlpCfg); err != nil {
-			return fmt.Errorf("config validation: otlp audit: parsing config: %w", err)
-		}
-		if otlpCfg.Protocol != "" {
-			switch strings.ToLower(otlpCfg.Protocol) {
-			case "grpc", "http":
-			default:
-				return fmt.Errorf("config validation: otlp audit: unknown protocol %q (expected \"grpc\" or \"http\")", otlpCfg.Protocol)
+	validator, ok := builtinAuditValidators[cfg.BuiltinProvider]
+	if !ok {
+		validNames := make([]string, 0, len(builtinAuditValidators))
+		for name := range builtinAuditValidators {
+			if name != "" {
+				validNames = append(validNames, name)
 			}
 		}
-		if otlpCfg.Logs.Exporter != "" && !strings.EqualFold(otlpCfg.Logs.Exporter, "otlp") {
-			return fmt.Errorf("config validation: otlp audit: logs.exporter must be %q", "otlp")
-		}
-		return nil
-	default:
-		return fmt.Errorf("config validation: unknown audit.provider %q", cfg.BuiltinProvider)
+		sort.Strings(validNames)
+		return fmt.Errorf("config validation: unknown audit.provider %q (valid: %s)", cfg.BuiltinProvider, strings.Join(validNames, ", "))
 	}
+	return validator(cfg.Config)
 }
 
 func validateTopLevelComponentProvider(kind string, provider *ProviderDef) error {


### PR DESCRIPTION
## Summary

Replace the monolithic 50-line `validateAudit` switch statement with a registry-based pattern. Each builtin provider's validation logic is extracted into an independent function and registered in a map. Unknown provider errors now list all valid options.

## Before/After: YAML

**Before:** Unknown providers give unhelpful errors.
```yaml
audit:
  provider: custom
# Error: "config validation: unknown audit.provider "custom""
# (no hint about valid values)
```

**After:** Error messages list valid options.
```yaml
audit:
  provider: custom
# Error: "config validation: unknown audit.provider "custom" (valid: inherit, noop, otlp, stdout)"
```

## Before/After: Go

**Before (config_validate.go, 50-line switch):**
```go
func validateAudit(cfg AuditConfig) error {
    if cfg.Provider != nil {
        return validateTopLevelComponentProvider("audit", cfg.Provider)
    }
    switch cfg.BuiltinProvider {
    case "", "inherit", "noop":
        if cfg.Config.Kind == 0 { return nil }
        return fmt.Errorf("audit.config is not supported when audit.provider is %q", cfg.BuiltinProvider)
    case "stdout":
        if cfg.Config.Kind == 0 { return nil }
        var stdoutCfg struct {
            Level  string `yaml:"level"`
            Format string `yaml:"format"`
        }
        if err := cfg.Config.Decode(&stdoutCfg); err != nil { return ... }
        return nil
    case "otlp":
        // ... 20 more lines with inline struct, protocol check, exporter check ...
    default:
        return fmt.Errorf("unknown audit.provider %q", cfg.BuiltinProvider)
    }
}
```

**After (registry pattern):**
```go
var builtinAuditValidators = map[string]func(yaml.Node) error{
    "":        noConfigAllowed("audit", ""),
    "inherit": noConfigAllowed("audit", "inherit"),
    "noop":    noConfigAllowed("audit", "noop"),
    "stdout":  validateStdoutAuditConfig,
    "otlp":    validateOTLPAuditConfig,
}

func validateAudit(cfg AuditConfig) error {
    if cfg.Provider != nil {
        return validateTopLevelComponentProvider("audit", cfg.Provider)
    }
    validator, ok := builtinAuditValidators[cfg.BuiltinProvider]
    if !ok {
        return fmt.Errorf("unknown audit.provider %q (valid: %s)", cfg.BuiltinProvider, validBuiltinNames())
    }
    return validator(cfg.Config)
}
```

## Behavior Change

The `validateAudit` function was a monolithic 50-line switch statement with inline struct definitions for each builtin provider. Adding a new builtin required modifying the switch, and unknown providers gave unhelpful error messages with no hint about valid options.

Now validators are registered in a map. Each builtin's validation logic is an independent function. Adding a new builtin is a one-line map entry. Unknown provider errors list all valid options. The `noConfigAllowed` helper is reusable across component types.

## Test plan
- [x] `cd gestaltd && go build ./...`
- [x] `cd gestaltd && go test ./...`
- [x] All audit-related tests pass including e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)