### PR TITLE
Add explicit mode field to plugin manifests

### DIFF
--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -118,10 +118,11 @@ func buildProvider(ctx context.Context, name string, intg config.PluginDef, deps
 		allowedOperations = maps.Clone(manifestPlugin.AllowedOperations)
 	}
 
-	switch {
-	case manifestPlugin.IsSpecLoaded() && manifest.Entrypoints.Plugin == nil:
+	mode := manifestPlugin.ResolvedMode(manifest.Entrypoints.Plugin != nil)
+	switch mode {
+	case pluginmanifestv1.PluginModeSpecLoaded:
 		return buildSpecLoadedProvider(ctx, name, intg, manifest, pluginConfig, meta, deps, allowedOperations)
-	case manifestPlugin.IsDeclarative() && manifest.Entrypoints.Plugin == nil:
+	case pluginmanifestv1.PluginModeDeclarative:
 		plan, err := buildPluginConnectionPlan(intg.Plugin, manifestPlugin)
 		if err != nil {
 			return nil, fmt.Errorf("build declarative provider %q: %w", name, err)
@@ -141,8 +142,10 @@ func buildProvider(ctx context.Context, name string, intg config.PluginDef, deps
 			return nil, err
 		}
 		return newProviderBuildResult(name, intg, manifest, pluginConfig, prov, nil, deps)
-	default:
+	case pluginmanifestv1.PluginModeHybrid, pluginmanifestv1.PluginModeExecutable:
 		return buildExecutablePluginProvider(ctx, name, intg, pluginConfig, meta, deps)
+	default:
+		return nil, fmt.Errorf("unsupported plugin mode %q for %q", mode, name)
 	}
 }
 

--- a/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -114,6 +114,15 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "executable",
+            "spec-loaded",
+            "declarative",
+            "hybrid"
+          ]
+        },
         "configSchemaPath": {
           "type": "string",
           "minLength": 1

--- a/gestaltd/sdk/pluginmanifest/v1/types.go
+++ b/gestaltd/sdk/pluginmanifest/v1/types.go
@@ -12,6 +12,15 @@ const (
 	KindWebUI     = "webui"
 )
 
+type PluginMode string
+
+const (
+	PluginModeExecutable  PluginMode = "executable"
+	PluginModeSpecLoaded  PluginMode = "spec-loaded"
+	PluginModeDeclarative PluginMode = "declarative"
+	PluginModeHybrid      PluginMode = "hybrid"
+)
+
 type Manifest struct {
 	Kind        string             `json:"kind,omitempty" yaml:"kind,omitempty"`
 	Source      string             `json:"source,omitempty" yaml:"source,omitempty"`
@@ -56,6 +65,7 @@ type WebUIMetadata struct {
 }
 
 type Plugin struct {
+	Mode              PluginMode                         `json:"mode,omitempty" yaml:"mode,omitempty"`
 	ConfigSchemaPath  string                             `json:"configSchemaPath,omitempty" yaml:"configSchemaPath,omitempty"`
 	Auth              *ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
 	ConnectionMode    ConnectionMode                     `json:"connectionMode,omitempty" yaml:"connectionMode,omitempty"`
@@ -100,6 +110,25 @@ type GraphQLSurface struct {
 type MCPSurface struct {
 	Connection string `json:"connection,omitempty" yaml:"connection,omitempty"`
 	URL        string `json:"url" yaml:"url"`
+}
+
+func (p *Plugin) ResolvedMode(hasEntrypoint bool) PluginMode {
+	if p == nil {
+		return PluginModeExecutable
+	}
+	if p.Mode != "" {
+		return p.Mode
+	}
+	if !hasEntrypoint && p.IsDeclarative() {
+		return PluginModeDeclarative
+	}
+	if !hasEntrypoint && p.IsSpecLoaded() {
+		return PluginModeSpecLoaded
+	}
+	if hasEntrypoint && p.IsManifestBacked() {
+		return PluginModeHybrid
+	}
+	return PluginModeExecutable
 }
 
 func (p *Plugin) IsDeclarative() bool {

--- a/gestaltd/sdk/pluginmanifest/v1/types_test.go
+++ b/gestaltd/sdk/pluginmanifest/v1/types_test.go
@@ -1,0 +1,82 @@
+package pluginmanifestv1
+
+import "testing"
+
+func TestPluginResolvedMode(t *testing.T) {
+	tests := []struct {
+		name          string
+		plugin        *Plugin
+		hasEntrypoint bool
+		want          PluginMode
+	}{
+		{
+			name:          "nil plugin returns executable",
+			plugin:        nil,
+			hasEntrypoint: false,
+			want:          PluginModeExecutable,
+		},
+		{
+			name:          "explicit mode returned as-is",
+			plugin:        &Plugin{Mode: PluginModeHybrid},
+			hasEntrypoint: false,
+			want:          PluginModeHybrid,
+		},
+		{
+			name: "no mode + REST operations + no entrypoint = declarative",
+			plugin: &Plugin{
+				Surfaces: &PluginSurfaces{
+					REST: &RESTSurface{
+						BaseURL:    "https://api.example.com",
+						Operations: []ProviderOperation{{Name: "list", Method: "GET", Path: "/items"}},
+					},
+				},
+			},
+			hasEntrypoint: false,
+			want:          PluginModeDeclarative,
+		},
+		{
+			name: "no mode + OpenAPI surface + no entrypoint = spec-loaded",
+			plugin: &Plugin{
+				Surfaces: &PluginSurfaces{
+					OpenAPI: &OpenAPISurface{Document: "openapi.yaml"},
+				},
+			},
+			hasEntrypoint: false,
+			want:          PluginModeSpecLoaded,
+		},
+		{
+			name: "no mode + entrypoint + surfaces = hybrid",
+			plugin: &Plugin{
+				Surfaces: &PluginSurfaces{
+					REST: &RESTSurface{
+						BaseURL:    "https://api.example.com",
+						Operations: []ProviderOperation{{Name: "list", Method: "GET", Path: "/items"}},
+					},
+				},
+			},
+			hasEntrypoint: true,
+			want:          PluginModeHybrid,
+		},
+		{
+			name:          "no mode + entrypoint only = executable",
+			plugin:        &Plugin{},
+			hasEntrypoint: true,
+			want:          PluginModeExecutable,
+		},
+		{
+			name:          "no mode + no entrypoint + no surfaces = executable",
+			plugin:        &Plugin{},
+			hasEntrypoint: false,
+			want:          PluginModeExecutable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.plugin.ResolvedMode(tt.hasEntrypoint)
+			if got != tt.want {
+				t.Errorf("ResolvedMode(%v) = %q, want %q", tt.hasEntrypoint, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add an explicit `mode` field to plugin manifests for self-documenting provider type discrimination. Replace content-based inference in `buildProvider()` with mode-based dispatch. When `mode` is omitted, `ResolvedMode()` infers it from content for backward compatibility.

## Before/After: YAML

**Before:** Plugin authors declare surfaces but cannot predict which code path they hit. The runtime infers provider type from content.
```yaml
# manifest.yaml -- What mode is this? SpecLoaded? Hybrid?
# Depends on whether entrypoints.plugin exists elsewhere in the file.
plugin:
  surfaces:
    openapi:
      document: ./openapi.yaml
    mcp:
      url: https://mcp.example.com
```

**After:** Explicit mode. Plugin author knows exactly what they are building.
```yaml
# manifest.yaml
plugin:
  mode: spec-loaded
  surfaces:
    openapi:
      document: ./openapi.yaml
    mcp:
      url: https://mcp.example.com
```

## Before/After: Go

**Before (provider_build.go, content-based inference):**
```go
switch {
case manifestPlugin.IsSpecLoaded() && manifest.Entrypoints.Plugin == nil:
    return buildSpecLoadedProvider(...)
case manifestPlugin.IsDeclarative() && manifest.Entrypoints.Plugin == nil:
    // inline declarative build
    ...
default:
    return buildExecutablePluginProvider(...)
}
```

**After (explicit dispatch on mode field):**
```go
mode := manifestPlugin.ResolvedMode(manifest.Entrypoints.Plugin != nil)
switch mode {
case pluginmanifestv1.PluginModeSpecLoaded:
    return buildSpecLoadedProvider(...)
case pluginmanifestv1.PluginModeDeclarative:
    // declarative build
    ...
case pluginmanifestv1.PluginModeHybrid, pluginmanifestv1.PluginModeExecutable:
    return buildExecutablePluginProvider(...)
default:
    return nil, fmt.Errorf("unsupported plugin mode %q for %q", mode, name)
}
```

**New types (types.go):**
```go
type PluginMode string

const (
    PluginModeExecutable  PluginMode = "executable"
    PluginModeSpecLoaded  PluginMode = "spec-loaded"
    PluginModeDeclarative PluginMode = "declarative"
    PluginModeHybrid      PluginMode = "hybrid"
)

func (p *Plugin) ResolvedMode(hasEntrypoint bool) PluginMode {
    if p.Mode != "" { return p.Mode }
    // Infer from content for backward compat
    ...
}
```

## Behavior Change

`buildProvider()` previously used content-based inference (`IsSpecLoaded()`, `IsDeclarative()`, `Entrypoints.Plugin == nil`) to determine provider type, creating 7 implicit code paths. Plugin authors could not predict which path their manifest would trigger.

Now manifests can declare an explicit `mode` field. `ResolvedMode()` returns the explicit mode or infers from content for backward compatibility. The dispatch switch is self-documenting and prevents future accumulation of content-based inference branches. JSON schema updated with enum values. Table-driven tests cover all inference paths.

## Test plan
- [x] `cd gestaltd && go build ./...`
- [x] `cd gestaltd && go test ./...`
- [x] Table-driven tests for `ResolvedMode()` covering all inference paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)