### PR TITLE
Make surface priority explicit with apiSurface field

### DIFF
--- a/gestaltd/internal/bootstrap/connections.go
+++ b/gestaltd/internal/bootstrap/connections.go
@@ -52,6 +52,7 @@ type pluginConnectionPlan struct {
 	namedConnections  map[string]config.ConnectionDef
 	surfaces          map[config.SpecSurface]resolvedSpecSurface
 	defaultConnection string
+	apiSurface        string
 }
 
 type resolvedSpecSurface struct {
@@ -95,6 +96,10 @@ func buildPluginConnectionPlan(plugin *config.ProviderDef, manifestPlugin *plugi
 		plan.surfaces[surface] = resolved
 	}
 
+	if manifestPlugin != nil {
+		plan.apiSurface = manifestPlugin.APISurface
+	}
+
 	defaultConnection := resolveDefaultConnectionName(plugin, manifestPlugin)
 	if defaultConnection != "" {
 		if _, err := plan.connectionDef(defaultConnection); err != nil {
@@ -107,6 +112,9 @@ func buildPluginConnectionPlan(plugin *config.ProviderDef, manifestPlugin *plugi
 }
 
 func (plan pluginConnectionPlan) configuredAPISurface() (resolvedSpecSurface, bool) {
+	if plan.apiSurface != "" {
+		return plan.resolvedSurface(config.SpecSurface(plan.apiSurface))
+	}
 	for _, surface := range []config.SpecSurface{config.SpecSurfaceOpenAPI, config.SpecSurfaceGraphQL} {
 		if resolved, ok := plan.resolvedSurface(surface); ok {
 			return resolved, true

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -389,6 +389,15 @@ func validateManifestBackedIntegration(name string, plugin *ProviderDef) error {
 		if err := validateManifestBackedConnectionDefaults(name, plugin, effectiveProvider); err != nil {
 			return err
 		}
+		if effectiveProvider.APISurface != "" {
+			validSurfaces := []string{"openapi", "graphql", "mcp"}
+			if !slices.Contains(validSurfaces, effectiveProvider.APISurface) {
+				return fmt.Errorf("config validation: integration %q plugin.apiSurface %q is not valid (must be one of: %s)", name, effectiveProvider.APISurface, strings.Join(validSurfaces, ", "))
+			}
+			if !effectiveProvider.HasSurface(effectiveProvider.APISurface) {
+				return fmt.Errorf("config validation: integration %q plugin.apiSurface %q references an undeclared surface", name, effectiveProvider.APISurface)
+			}
+		}
 	}
 	if err := validateExecutableConnectionAuthSupport(name, plugin, effectiveProvider); err != nil {
 		return err

--- a/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -159,6 +159,11 @@
             "$ref": "#/$defs/manifestOperationOverride"
           }
         },
+        "apiSurface": {
+          "type": "string",
+          "enum": ["openapi", "graphql", "mcp"],
+          "description": "Explicitly sets which surface is primary for API operations"
+        },
         "surfaces": {
           "$ref": "#/$defs/surfaces"
         },

--- a/gestaltd/sdk/pluginmanifest/v1/types.go
+++ b/gestaltd/sdk/pluginmanifest/v1/types.go
@@ -65,6 +65,7 @@ type Plugin struct {
 	Discovery         *ProviderDiscovery                 `json:"discovery,omitempty" yaml:"discovery,omitempty"`
 	ConnectionParams  map[string]ProviderConnectionParam `json:"connectionParams,omitempty" yaml:"connectionParams,omitempty"`
 
+	APISurface        string                                `json:"apiSurface,omitempty" yaml:"apiSurface,omitempty"`
 	Surfaces          *PluginSurfaces                       `json:"surfaces,omitempty" yaml:"surfaces,omitempty"`
 	AllowedOperations map[string]*ManifestOperationOverride `json:"allowedOperations,omitempty" yaml:"allowedOperations,omitempty"`
 	DefaultConnection string                                `json:"defaultConnection,omitempty" yaml:"defaultConnection,omitempty"`
@@ -113,6 +114,24 @@ func (p *Plugin) IsSpecLoaded() bool {
 
 func (p *Plugin) IsManifestBacked() bool {
 	return p != nil && (p.IsDeclarative() || p.IsSpecLoaded())
+}
+
+func (p *Plugin) HasSurface(surface string) bool {
+	if p == nil || p.Surfaces == nil {
+		return false
+	}
+	switch surface {
+	case "openapi":
+		return p.Surfaces.OpenAPI != nil
+	case "graphql":
+		return p.Surfaces.GraphQL != nil
+	case "mcp":
+		return p.Surfaces.MCP != nil
+	case "rest":
+		return p.Surfaces.REST != nil
+	default:
+		return false
+	}
 }
 
 func (p *Plugin) OpenAPIDocument() string {


### PR DESCRIPTION
## Summary

Add an `apiSurface` field to plugin manifests that explicitly declares which surface is primary for API operations. When omitted, the existing implicit priority (OpenAPI > GraphQL) is preserved for backward compatibility.

## Before/After: YAML

**Before:** Implicit priority ordering decides which surface handles API operations. Not visible to plugin authors or operators.
```yaml
# manifest.yaml -- Which surface "wins" for API operations?
# Answer: OpenAPI (hardcoded priority in OrderedSpecSurfaces). Not documented.
plugin:
  surfaces:
    openapi:
      document: ./openapi.yaml
    graphql:
      url: https://gql.example.com
    mcp:
      url: https://mcp.example.com
```

**After:** Explicit `apiSurface` field declares which surface is primary.
```yaml
# manifest.yaml
plugin:
  apiSurface: openapi
  surfaces:
    openapi:
      document: ./openapi.yaml
    graphql:
      url: https://gql.example.com
    mcp:
      url: https://mcp.example.com
```

## Before/After: Go

**Before (connections.go, implicit priority loop):**
```go
func (plan pluginConnectionPlan) configuredAPISurface() (resolvedSpecSurface, bool) {
    for _, surface := range []config.SpecSurface{config.SpecSurfaceOpenAPI, config.SpecSurfaceGraphQL} {
        if resolved, ok := plan.resolvedSurface(surface); ok {
            return resolved, true
        }
    }
    return resolvedSpecSurface{}, false
}
```

**After (explicit lookup with fallback):**
```go
func (plan pluginConnectionPlan) configuredAPISurface() (resolvedSpecSurface, bool) {
    if plan.apiSurface != "" {
        return plan.resolvedSurface(config.SpecSurface(plan.apiSurface))
    }
    // Fallback: implicit priority for backward compat
    for _, surface := range []config.SpecSurface{config.SpecSurfaceOpenAPI, config.SpecSurfaceGraphQL} {
        if resolved, ok := plan.resolvedSurface(surface); ok {
            return resolved, true
        }
    }
    return resolvedSpecSurface{}, false
}
```

**New helper (types.go):**
```go
APISurface string `json:"apiSurface,omitempty" yaml:"apiSurface,omitempty"`

func (p *Plugin) HasSurface(surface string) bool {
    if p == nil || p.Surfaces == nil { return false }
    switch surface {
    case "openapi": return p.Surfaces.OpenAPI != nil
    case "graphql": return p.Surfaces.GraphQL != nil
    case "mcp":     return p.Surfaces.MCP != nil
    default:        return false
    }
}
```

## Behavior Change

When a manifest declared multiple surfaces, an implicit hardcoded priority (OpenAPI > GraphQL > MCP) determined which surface handled API operations. Plugin authors and operators could not see or override this.

Now manifests can declare `apiSurface: openapi|graphql|mcp` to explicitly set the primary API surface. When omitted, the existing implicit priority is preserved. Validation rejects unknown values and surfaces not declared in the manifest. JSON schema updated with enum constraint.

## Test plan
- [x] `cd gestaltd && go build ./...`
- [x] `cd gestaltd && go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)