### PR TITLE
Rename builtin provider field and enforce component exclusivity

### DIFF
--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -53,14 +53,14 @@ func TestE2EValidateRejectsInvalidAuditSettings(t *testing.T) {
 		{
 			name: "unknown audit provider",
 			auditYAML: `audit:
-  provider: bogus
+  builtin: bogus
 `,
 			wantError: "unknown audit.provider",
 		},
 		{
 			name: "stdout audit requires mapping config",
 			auditYAML: `audit:
-  provider: stdout
+  builtin: stdout
   config: nope
 `,
 			wantError: "stdout audit: parsing config",
@@ -68,7 +68,7 @@ func TestE2EValidateRejectsInvalidAuditSettings(t *testing.T) {
 		{
 			name: "otlp audit rejects non-otlp logs exporter",
 			auditYAML: `audit:
-  provider: otlp
+  builtin: otlp
   config:
     logs:
       exporter: stdout
@@ -106,6 +106,1495 @@ func TestE2EValidateRejectsInvalidAuditSettings(t *testing.T) {
 	}
 }
 
+func TestE2EDeclarativeSelectorsSupportHeaderPaginationAndResponseMapping(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	port := allocateTestPort(t)
+
+	var (
+		mu              sync.Mutex
+		paginationCalls []string
+	)
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/paginated-items":
+			cursor := r.URL.Query().Get("after_cursor")
+			mu.Lock()
+			paginationCalls = append(paginationCalls, cursor)
+			mu.Unlock()
+			if cursor == "" {
+				w.Header().Set("X-After-Cursor", "cursor-2")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"data": []any{
+						map[string]any{"id": "1"},
+						map[string]any{"id": "2"},
+					},
+				})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []any{
+					map[string]any{"id": "3"},
+				},
+			})
+		case "/mapped-items":
+			w.Header().Set("X-After-Cursor", "cursor-map")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"results": []any{
+					map[string]any{"id": "7"},
+				},
+				"moreDataAvailable": true,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	testutil.CloseOnCleanup(t, apiSrv)
+
+	pagerDir := filepath.Join(dir, "pager-plugin")
+	if err := os.MkdirAll(pagerDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll pager plugin: %v", err)
+	}
+	writeTestFile(t, pagerDir, "openapi.yaml", []byte(fmt.Sprintf(`openapi: 3.0.0
+info:
+  title: Pager
+  version: 1.0.0
+servers:
+  - url: %s
+paths:
+  /paginated-items:
+    get:
+      operationId: list_items
+      responses:
+        '200':
+          description: ok
+`, apiSrv.URL)), 0o644)
+	writeTestFile(t, pagerDir, "manifest.yaml", []byte(`
+source: github.com/test/plugins/pager
+version: 0.0.1-alpha.1
+displayName: Pager
+plugin:
+  surfaces:
+    openapi:
+      document: openapi.yaml
+  connectionMode: none
+  pagination:
+    style: cursor
+    cursorParam: after_cursor
+    cursor:
+      source: header
+      path: X-After-Cursor
+    resultsPath: data
+  allowedOperations:
+    list_items:
+      paginate: true
+`), 0o644)
+	pagerManifest, err := pluginpkg.FindManifestFile(pagerDir)
+	if err != nil {
+		t.Fatalf("FindManifestFile pager: %v", err)
+	}
+
+	mapperDir := filepath.Join(dir, "mapper-plugin")
+	if err := os.MkdirAll(mapperDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll mapper plugin: %v", err)
+	}
+	writeTestFile(t, mapperDir, "openapi.yaml", []byte(fmt.Sprintf(`openapi: 3.0.0
+info:
+  title: Mapper
+  version: 1.0.0
+servers:
+  - url: %s
+paths:
+  /mapped-items:
+    get:
+      operationId: list_items
+      responses:
+        '200':
+          description: ok
+`, apiSrv.URL)), 0o644)
+	writeTestFile(t, mapperDir, "manifest.yaml", []byte(`
+source: github.com/test/plugins/mapper
+version: 0.0.1-alpha.1
+displayName: Mapper
+plugin:
+  surfaces:
+    openapi:
+      document: openapi.yaml
+  connectionMode: none
+  responseMapping:
+    dataPath: results
+    pagination:
+      hasMore:
+        source: body
+        path: moreDataAvailable
+      cursor:
+        source: header
+        path: X-After-Cursor
+`), 0o644)
+	mapperManifest, err := pluginpkg.FindManifestFile(mapperDir)
+	if err != nil {
+		t.Fatalf("FindManifestFile mapper: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := authDatastoreConfigYAML(t, dir, "", "sqlite", filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`server:
+  public:
+    port: %d
+  encryptionKey: test-e2e-key
+plugins:
+  pager:
+    provider:
+      source:
+        path: %s
+  mapper:
+    provider:
+      source:
+        path: %s
+`, port, pagerManifest, mapperManifest)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
+		pagerReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/pager/list_items", strings.NewReader(`{}`))
+		pagerReq.Header.Set("Content-Type", "application/json")
+		pagerResp, err := http.DefaultClient.Do(pagerReq)
+		if err != nil {
+			t.Fatalf("invoke pager: %v", err)
+		}
+		defer func() { _ = pagerResp.Body.Close() }()
+		if pagerResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(pagerResp.Body)
+			t.Fatalf("pager status = %d: %s", pagerResp.StatusCode, body)
+		}
+
+		var pagerItems []map[string]any
+		if err := json.NewDecoder(pagerResp.Body).Decode(&pagerItems); err != nil {
+			t.Fatalf("decode pager response: %v", err)
+		}
+		if len(pagerItems) != 3 {
+			t.Fatalf("pager item count = %d, want 3", len(pagerItems))
+		}
+
+		mu.Lock()
+		gotCalls := append([]string(nil), paginationCalls...)
+		mu.Unlock()
+		if len(gotCalls) != 2 || gotCalls[0] != "" || gotCalls[1] != "cursor-2" {
+			t.Fatalf("pagination calls = %v, want [\"\", \"cursor-2\"]", gotCalls)
+		}
+
+		mapperReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/mapper/list_items", strings.NewReader(`{}`))
+		mapperReq.Header.Set("Content-Type", "application/json")
+		mapperResp, err := http.DefaultClient.Do(mapperReq)
+		if err != nil {
+			t.Fatalf("invoke mapper: %v", err)
+		}
+		defer func() { _ = mapperResp.Body.Close() }()
+		if mapperResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(mapperResp.Body)
+			t.Fatalf("mapper status = %d: %s", mapperResp.StatusCode, body)
+		}
+
+		var mapped struct {
+			Data       []map[string]any `json:"data"`
+			Pagination struct {
+				HasMore bool   `json:"hasMore"`
+				Cursor  string `json:"cursor"`
+			} `json:"pagination"`
+		}
+		if err := json.NewDecoder(mapperResp.Body).Decode(&mapped); err != nil {
+			t.Fatalf("decode mapper response: %v", err)
+		}
+		if len(mapped.Data) != 1 || mapped.Data[0]["id"] != "7" {
+			t.Fatalf("mapped data = %+v, want single id=7 item", mapped.Data)
+		}
+		if !mapped.Pagination.HasMore || mapped.Pagination.Cursor != "cursor-map" {
+			t.Fatalf("mapped pagination = %+v", mapped.Pagination)
+		}
+	})
+}
+
+func TestE2EManualAuthMappingValueAndValueFromBasicAuth(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	port := allocateTestPort(t)
+
+	var upstreamAuth atomic.Value
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamAuth.Store(r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"auth":        r.Header.Get("Authorization"),
+			"org_header":  r.Header.Get("X-Org-ID"),
+			"echo_header": r.Header.Get("X-API-Key-Echo"),
+		})
+	}))
+	testutil.CloseOnCleanup(t, upstream)
+
+	pluginDir := filepath.Join(dir, "manual-basic-plugin")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll plugin dir: %v", err)
+	}
+	writeTestFile(t, pluginDir, "openapi.yaml", []byte(fmt.Sprintf(`openapi: 3.0.0
+info:
+  title: Manual Basic Test
+  version: 1.0.0
+servers:
+  - url: %s
+components:
+  securitySchemes:
+    basic_auth:
+      type: http
+      scheme: basic
+security:
+  - basic_auth: []
+paths:
+  /whoami:
+    get:
+      operationId: whoami
+      responses:
+        '200':
+          description: ok
+`, upstream.URL)), 0o644)
+	writeTestFile(t, pluginDir, "manifest.yaml", []byte(`
+source: github.com/test/plugins/manual-basic
+version: 0.0.1-alpha.1
+displayName: Manual Basic Test
+plugin:
+  surfaces:
+    openapi:
+      document: openapi.yaml
+`), 0o644)
+
+	manifestPath, err := pluginpkg.FindManifestFile(pluginDir)
+	if err != nil {
+		t.Fatalf("FindManifestFile: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := authDatastoreConfigYAML(t, dir, "session-auth", "sqlite", filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`server:
+  public:
+    port: %d
+  encryptionKey: test-e2e-key
+plugins:
+  mt:
+    provider:
+      source:
+        path: %s
+    connections:
+      default:
+        auth:
+          type: manual
+          credentials:
+            - name: api_key
+              label: API Key
+          authMapping:
+            headers:
+              X-Org-ID:
+                value: org-fixed
+              X-API-Key-Echo:
+                valueFrom:
+                  credentialFieldRef:
+                    name: api_key
+            basic:
+              username:
+                value: org-fixed
+              password:
+                valueFrom:
+                  credentialFieldRef:
+                    name: api_key
+`, port, manifestPath)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
+		listReq, _ := http.NewRequest(http.MethodGet, baseURL+"/api/v1/integrations", nil)
+		listReq.Header.Set("Authorization", "Bearer alice")
+		listResp, err := http.DefaultClient.Do(listReq)
+		if err != nil {
+			t.Fatalf("list integrations: %v", err)
+		}
+		defer func() { _ = listResp.Body.Close() }()
+		if listResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(listResp.Body)
+			t.Fatalf("list integrations status = %d: %s", listResp.StatusCode, body)
+		}
+
+		var integrations []struct {
+			Name        string `json:"name"`
+			Connections []struct {
+				CredentialFields []struct {
+					Name string `json:"name"`
+				} `json:"credentialFields"`
+			} `json:"connections"`
+		}
+		if err := json.NewDecoder(listResp.Body).Decode(&integrations); err != nil {
+			t.Fatalf("decode integrations: %v", err)
+		}
+		if len(integrations) != 1 || integrations[0].Name != "mt" {
+			t.Fatalf("unexpected integrations payload: %+v", integrations)
+		}
+		if len(integrations[0].Connections) != 1 {
+			t.Fatalf("unexpected connections payload: %+v", integrations[0].Connections)
+		}
+		fields := integrations[0].Connections[0].CredentialFields
+		if len(fields) != 1 || fields[0].Name != "api_key" {
+			t.Fatalf("credential fields = %+v, want only api_key", fields)
+		}
+
+		connectReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/auth/connect-manual", strings.NewReader(`{"integration":"mt","credential":"api-key-123"}`))
+		connectReq.Header.Set("Authorization", "Bearer alice")
+		connectReq.Header.Set("Content-Type", "application/json")
+		connectResp, err := http.DefaultClient.Do(connectReq)
+		if err != nil {
+			t.Fatalf("connect manual: %v", err)
+		}
+		defer func() { _ = connectResp.Body.Close() }()
+		if connectResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(connectResp.Body)
+			t.Fatalf("connect manual status = %d: %s", connectResp.StatusCode, body)
+		}
+
+		invokeReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/mt/whoami", strings.NewReader(`{}`))
+		invokeReq.Header.Set("Authorization", "Bearer alice")
+		invokeReq.Header.Set("Content-Type", "application/json")
+		invokeResp, err := http.DefaultClient.Do(invokeReq)
+		if err != nil {
+			t.Fatalf("invoke whoami: %v", err)
+		}
+		defer func() { _ = invokeResp.Body.Close() }()
+		if invokeResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(invokeResp.Body)
+			t.Fatalf("invoke whoami status = %d: %s", invokeResp.StatusCode, body)
+		}
+
+		var result map[string]any
+		if err := json.NewDecoder(invokeResp.Body).Decode(&result); err != nil {
+			t.Fatalf("decode invoke response: %v", err)
+		}
+
+		wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("org-fixed:api-key-123"))
+		if result["auth"] != wantAuth {
+			t.Fatalf("invoke auth = %v, want %v", result["auth"], wantAuth)
+		}
+		if result["org_header"] != "org-fixed" {
+			t.Fatalf("invoke org_header = %v, want org-fixed", result["org_header"])
+		}
+		if result["echo_header"] != "api-key-123" {
+			t.Fatalf("invoke echo_header = %v, want api-key-123", result["echo_header"])
+		}
+		if got, _ := upstreamAuth.Load().(string); got != wantAuth {
+			t.Fatalf("upstream auth = %q, want %q", got, wantAuth)
+		}
+	})
+}
+
+//nolint:paralleltest // Spawns gestaltd and is flaky under package-wide parallel load in CI.
+func TestE2EManifestManualAuthMappingValueFromBasicAuth(t *testing.T) {
+	dir := t.TempDir()
+	port := allocateTestPort(t)
+
+	var upstreamAuth atomic.Value
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamAuth.Store(r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"auth":      r.Header.Get("Authorization"),
+			"x_app_key": r.Header.Get("X-App-Key"),
+		})
+	}))
+	testutil.CloseOnCleanup(t, upstream)
+
+	pluginDir := filepath.Join(dir, "manifest-basic-plugin")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll plugin dir: %v", err)
+	}
+	writeTestFile(t, pluginDir, "openapi.yaml", []byte(fmt.Sprintf(`openapi: 3.0.0
+info:
+  title: Manifest Basic Test
+  version: 1.0.0
+servers:
+  - url: %s
+components:
+  securitySchemes:
+    basic_auth:
+      type: http
+      scheme: basic
+security:
+  - basic_auth: []
+paths:
+  /whoami:
+    get:
+      operationId: whoami
+      responses:
+        '200':
+          description: ok
+`, upstream.URL)), 0o644)
+	writeTestFile(t, pluginDir, "manifest.yaml", []byte(`
+source: github.com/test/plugins/manifest-basic
+version: 0.0.1-alpha.1
+displayName: Manifest Basic Test
+plugin:
+  auth:
+    type: manual
+    credentials:
+      - name: organization_id
+        label: Organization ID
+      - name: api_key
+        label: API Key
+      - name: app_key
+        label: App Key
+    authMapping:
+      headers:
+        X-App-Key:
+          valueFrom:
+            credentialFieldRef:
+              name: app_key
+      basic:
+        username:
+          valueFrom:
+            credentialFieldRef:
+              name: organization_id
+        password:
+          valueFrom:
+            credentialFieldRef:
+              name: api_key
+  surfaces:
+    openapi:
+      document: openapi.yaml
+`), 0o644)
+
+	manifestPath, err := pluginpkg.FindManifestFile(pluginDir)
+	if err != nil {
+		t.Fatalf("FindManifestFile: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := authDatastoreConfigYAML(t, dir, "session-auth", "sqlite", filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`server:
+  public:
+    port: %d
+  encryptionKey: test-e2e-key
+plugins:
+  mt:
+    provider:
+      source:
+        path: %s
+`, port, manifestPath)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
+		listReq, _ := http.NewRequest(http.MethodGet, baseURL+"/api/v1/integrations", nil)
+		listReq.Header.Set("Authorization", "Bearer alice")
+		listResp, err := http.DefaultClient.Do(listReq)
+		if err != nil {
+			t.Fatalf("list integrations: %v", err)
+		}
+		defer func() { _ = listResp.Body.Close() }()
+		if listResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(listResp.Body)
+			t.Fatalf("list integrations status = %d: %s", listResp.StatusCode, body)
+		}
+
+		var integrations []struct {
+			Name        string `json:"name"`
+			Connections []struct {
+				CredentialFields []struct {
+					Name string `json:"name"`
+				} `json:"credentialFields"`
+			} `json:"connections"`
+		}
+		if err := json.NewDecoder(listResp.Body).Decode(&integrations); err != nil {
+			t.Fatalf("decode integrations: %v", err)
+		}
+		if len(integrations) != 1 || integrations[0].Name != "mt" {
+			t.Fatalf("unexpected integrations payload: %+v", integrations)
+		}
+		fields := integrations[0].Connections[0].CredentialFields
+		if len(fields) != 3 || fields[0].Name != "organization_id" || fields[1].Name != "api_key" || fields[2].Name != "app_key" {
+			t.Fatalf("credential fields = %+v, want organization_id, api_key, and app_key", fields)
+		}
+
+		connectReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/auth/connect-manual", strings.NewReader(`{"integration":"mt","credentials":{"organization_id":"org-123","api_key":"api-key-123","app_key":"app-key-123"}}`))
+		connectReq.Header.Set("Authorization", "Bearer alice")
+		connectReq.Header.Set("Content-Type", "application/json")
+		connectResp, err := http.DefaultClient.Do(connectReq)
+		if err != nil {
+			t.Fatalf("connect manual: %v", err)
+		}
+		defer func() { _ = connectResp.Body.Close() }()
+		if connectResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(connectResp.Body)
+			t.Fatalf("connect manual status = %d: %s", connectResp.StatusCode, body)
+		}
+
+		invokeReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/mt/whoami", strings.NewReader(`{}`))
+		invokeReq.Header.Set("Authorization", "Bearer alice")
+		invokeReq.Header.Set("Content-Type", "application/json")
+		invokeResp, err := http.DefaultClient.Do(invokeReq)
+		if err != nil {
+			t.Fatalf("invoke whoami: %v", err)
+		}
+		defer func() { _ = invokeResp.Body.Close() }()
+		if invokeResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(invokeResp.Body)
+			t.Fatalf("invoke whoami status = %d: %s", invokeResp.StatusCode, body)
+		}
+
+		var result map[string]any
+		if err := json.NewDecoder(invokeResp.Body).Decode(&result); err != nil {
+			t.Fatalf("decode invoke response: %v", err)
+		}
+
+		wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("org-123:api-key-123"))
+		if result["auth"] != wantAuth {
+			t.Fatalf("invoke auth = %v, want %v", result["auth"], wantAuth)
+		}
+		if result["x_app_key"] != "app-key-123" {
+			t.Fatalf("invoke x_app_key = %v, want %v", result["x_app_key"], "app-key-123")
+		}
+		if got, _ := upstreamAuth.Load().(string); got != wantAuth {
+			t.Fatalf("upstream auth = %q, want %q", got, wantAuth)
+		}
+	})
+}
+
+//nolint:paralleltest // Spawns gestaltd and is flaky under package-wide parallel load in CI.
+func TestE2EDeclarativeManifestManualAuthMappingValueFromBasicAuth(t *testing.T) {
+	dir := t.TempDir()
+	port := allocateTestPort(t)
+
+	var upstreamAuth atomic.Value
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamAuth.Store(r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"auth":      r.Header.Get("Authorization"),
+			"x_app_key": r.Header.Get("X-App-Key"),
+		})
+	}))
+	testutil.CloseOnCleanup(t, upstream)
+
+	pluginDir := filepath.Join(dir, "declarative-basic-plugin")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll plugin dir: %v", err)
+	}
+	writeTestFile(t, pluginDir, "manifest.yaml", []byte(fmt.Sprintf(`
+source: github.com/test/plugins/declarative-basic
+version: 0.0.1-alpha.1
+displayName: Declarative Basic Test
+plugin:
+  auth:
+    type: manual
+    credentials:
+      - name: organization_id
+        label: Organization ID
+      - name: api_key
+        label: API Key
+      - name: app_key
+        label: App Key
+    authMapping:
+      headers:
+        X-App-Key:
+          valueFrom:
+            credentialFieldRef:
+              name: app_key
+      basic:
+        username:
+          valueFrom:
+            credentialFieldRef:
+              name: organization_id
+        password:
+          valueFrom:
+            credentialFieldRef:
+              name: api_key
+  surfaces:
+    rest:
+      baseUrl: %s
+      operations:
+        - name: whoami
+          method: GET
+          path: /whoami
+`, upstream.URL)), 0o644)
+
+	manifestPath, err := pluginpkg.FindManifestFile(pluginDir)
+	if err != nil {
+		t.Fatalf("FindManifestFile: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := authDatastoreConfigYAML(t, dir, "session-auth", "sqlite", filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`server:
+  public:
+    port: %d
+  encryptionKey: test-e2e-key
+plugins:
+  mt:
+    provider:
+      source:
+        path: %s
+`, port, manifestPath)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
+		connectReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/auth/connect-manual", strings.NewReader(`{"integration":"mt","credentials":{"organization_id":"org-456","api_key":"api-key-456","app_key":"app-key-456"}}`))
+		connectReq.Header.Set("Authorization", "Bearer alice")
+		connectReq.Header.Set("Content-Type", "application/json")
+		connectResp, err := http.DefaultClient.Do(connectReq)
+		if err != nil {
+			t.Fatalf("connect manual: %v", err)
+		}
+		defer func() { _ = connectResp.Body.Close() }()
+		if connectResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(connectResp.Body)
+			t.Fatalf("connect manual status = %d: %s", connectResp.StatusCode, body)
+		}
+
+		invokeReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/mt/whoami", strings.NewReader(`{}`))
+		invokeReq.Header.Set("Authorization", "Bearer alice")
+		invokeReq.Header.Set("Content-Type", "application/json")
+		invokeResp, err := http.DefaultClient.Do(invokeReq)
+		if err != nil {
+			t.Fatalf("invoke whoami: %v", err)
+		}
+		defer func() { _ = invokeResp.Body.Close() }()
+		if invokeResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(invokeResp.Body)
+			t.Fatalf("invoke whoami status = %d: %s", invokeResp.StatusCode, body)
+		}
+
+		var result map[string]any
+		if err := json.NewDecoder(invokeResp.Body).Decode(&result); err != nil {
+			t.Fatalf("decode invoke response: %v", err)
+		}
+
+		wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("org-456:api-key-456"))
+		if result["auth"] != wantAuth {
+			t.Fatalf("invoke auth = %v, want %v", result["auth"], wantAuth)
+		}
+		if result["x_app_key"] != "app-key-456" {
+			t.Fatalf("invoke x_app_key = %v, want %v", result["x_app_key"], "app-key-456")
+		}
+		if got, _ := upstreamAuth.Load().(string); got != wantAuth {
+			t.Fatalf("upstream auth = %q, want %q", got, wantAuth)
+		}
+	})
+}
+
+func TestE2EInitServeLockedGoldenPath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	deployDir := filepath.Join(dir, "deploy")
+	dataDir := filepath.Join(dir, "data")
+	artifactsDir := filepath.Join(dir, "runtime-artifacts")
+	if err := os.MkdirAll(deployDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll deploy dir: %v", err)
+	}
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll data dir: %v", err)
+	}
+
+	pluginDir := setupPluginDir(t, dir)
+
+	port := allocateTestPort(t)
+	cfgPath := writeE2EConfigWithPaths(t, deployDir, pluginDir, filepath.Join(dataDir, "gestalt.db"), artifactsDir, port)
+	cfgBytes, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	cfgBytes = append(cfgBytes, []byte(`telemetry:
+  builtin: stdout
+  config:
+    level: warn
+    format: json
+`)...)
+	if err := os.WriteFile(cfgPath, cfgBytes, 0o644); err != nil {
+		t.Fatalf("write config telemetry: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath, "--artifacts-dir", artifactsDir).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	lockPath := filepath.Join(deployDir, operator.InitLockfileName)
+	lockBytes, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read lockfile: %v", err)
+	}
+	var rawLock map[string]any
+	if err := json.Unmarshal(lockBytes, &rawLock); err != nil {
+		t.Fatalf("decode lockfile json: %v", err)
+	}
+	if _, ok := rawLock["plugins"]; ok {
+		t.Fatalf("expected lockfile to omit legacy plugins map: %s", lockBytes)
+	}
+	rawProviders, ok := rawLock["providers"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected lockfile providers object: %s", lockBytes)
+	}
+	if len(rawProviders) != 0 {
+		t.Fatalf("expected local source config to avoid prepared provider entries, got: %s", lockBytes)
+	}
+
+	lock, err := operator.ReadLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	if lock.Version != 2 {
+		t.Fatalf("lock version = %d, want 2", lock.Version)
+	}
+	if len(lock.Providers) != 0 {
+		t.Fatalf("expected no prepared provider entries for local source config, got %+v", lock.Providers)
+	}
+	if lock.UI != nil {
+		t.Fatalf("expected no ui lock entry when config has no managed ui plugin")
+	}
+
+	t.Cleanup(func() {
+		_ = os.Chmod(deployDir, 0o755)
+		_ = os.Chmod(cfgPath, 0o644)
+		_ = os.Chmod(lockPath, 0o644)
+	})
+	if err := os.Chmod(cfgPath, 0o444); err != nil {
+		t.Fatalf("Chmod config: %v", err)
+	}
+	if err := os.Chmod(lockPath, 0o444); err != nil {
+		t.Fatalf("Chmod lockfile: %v", err)
+	}
+	if err := os.Chmod(deployDir, 0o555); err != nil {
+		t.Fatalf("Chmod deploy dir: %v", err)
+	}
+
+	stdout, stderr := serveLockedAndInvokeExampleEcho(t, cfgPath, port, artifactsDir)
+
+	var foundAudit bool
+	for _, line := range strings.Split(strings.TrimSpace(stdout), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			continue
+		}
+		if record["msg"] != "audit" {
+			continue
+		}
+
+		foundAudit = true
+		if record["level"] != "INFO" {
+			t.Fatalf("expected audit log level=INFO, got %v\nstdout:\n%s\nstderr:\n%s", record["level"], stdout, stderr)
+		}
+		if record["log.type"] != "audit" {
+			t.Fatalf("expected audit log.type=audit, got %v\nstdout:\n%s\nstderr:\n%s", record["log.type"], stdout, stderr)
+		}
+		if record["provider"] != "example" {
+			t.Fatalf("expected audit provider=example, got %v\nstdout:\n%s\nstderr:\n%s", record["provider"], stdout, stderr)
+		}
+		if record["operation"] != "echo" {
+			t.Fatalf("expected audit operation=echo, got %v\nstdout:\n%s\nstderr:\n%s", record["operation"], stdout, stderr)
+		}
+		if record["allowed"] != true {
+			t.Fatalf("expected audit allowed=true, got %v\nstdout:\n%s\nstderr:\n%s", record["allowed"], stdout, stderr)
+		}
+		break
+	}
+
+	if !foundAudit {
+		t.Fatalf("expected audit log in stdout\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+}
+
+func TestE2EInitServeLockedOTLPExportsTracesAndMetricsButKeepsLogsOnStdout(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+
+	var logRequests, traceRequests, metricRequests atomic.Int32
+	var metricBodiesMu sync.Mutex
+	var metricBodies [][]byte
+	otlpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+
+		switch r.URL.Path {
+		case "/v1/logs":
+			logRequests.Add(1)
+		case "/v1/traces":
+			traceRequests.Add(1)
+		case "/v1/metrics":
+			metricRequests.Add(1)
+			metricBodiesMu.Lock()
+			metricBodies = append(metricBodies, bytes.Clone(body))
+			metricBodiesMu.Unlock()
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(otlpServer.Close)
+
+	port := allocateTestPort(t)
+	cfgPath := writeE2EConfig(t, dir, pluginDir, port)
+	cfgBytes, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	cfgBytes = append(cfgBytes, []byte(`telemetry:
+  builtin: otlp
+  config:
+    endpoint: `+strings.TrimPrefix(otlpServer.URL, "http://")+`
+    protocol: http
+    insecure: true
+    traces:
+      samplingRatio: 1.0
+    metrics:
+      interval: 50ms
+    logs:
+      exporter: stdout
+      format: json
+      level: info
+`)...)
+	if err := os.WriteFile(cfgPath, cfgBytes, 0o644); err != nil {
+		t.Fatalf("write config telemetry: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	stdout, stderr := serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
+		body := invokeExampleOperation(t, baseURL, "echo", `{"message":"hello"}`, http.StatusOK)
+
+		var result map[string]any
+		if err := json.Unmarshal(body, &result); err != nil {
+			t.Fatalf("unmarshal success response: %v\nbody: %s", err, body)
+		}
+		if result["echo"] != "hello" {
+			t.Fatalf("expected echo=hello, got %v", result)
+		}
+
+		invokeExampleOperation(t, baseURL, "nope", `{}`, http.StatusNotFound)
+
+		promBody := getEndpointBody(t, baseURL+"/metrics", http.StatusOK)
+		if !bytes.Contains(promBody, []byte("gestaltd_operation_count_total")) {
+			t.Fatalf("expected prometheus counter in /metrics body: %s", promBody)
+		}
+		if !bytes.Contains(promBody, []byte("gestaltd_operation_duration_seconds_bucket")) {
+			t.Fatalf("expected prometheus histogram in /metrics body: %s", promBody)
+		}
+
+		adminBody := getEndpointBody(t, baseURL+"/admin", http.StatusOK)
+		if !bytes.Contains(adminBody, []byte("Prometheus metrics")) {
+			t.Fatalf("expected embedded admin UI at /admin: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("Requests and failures")) {
+			t.Fatalf("expected activity graph section in embedded admin UI: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("Average and p95")) {
+			t.Fatalf("expected latency graph section in embedded admin UI: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("Top providers")) {
+			t.Fatalf("expected graph sections in embedded admin UI: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("Time window")) {
+			t.Fatalf("expected chart controls in embedded admin UI: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("Refresh cadence")) {
+			t.Fatalf("expected refresh controls in embedded admin UI: %s", adminBody)
+		}
+		if bytes.Contains(adminBody, []byte("Raw Prometheus output")) {
+			t.Fatalf("did not expect raw prometheus section in embedded admin UI: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("echarts.min.js")) {
+			t.Fatalf("expected admin ui to include echarts asset: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("theme.css")) {
+			t.Fatalf("expected admin ui to include shared theme asset: %s", adminBody)
+		}
+	})
+
+	if traceRequests.Load() == 0 {
+		t.Fatalf("expected OTLP trace export\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if metricRequests.Load() == 0 {
+		t.Fatalf("expected OTLP metric export\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if logRequests.Load() != 0 {
+		t.Fatalf("expected logs to stay on stdout, saw %d OTLP log exports\nstdout:\n%s\nstderr:\n%s", logRequests.Load(), stdout, stderr)
+	}
+	metricBodiesMu.Lock()
+	exports := append([][]byte(nil), metricBodies...)
+	metricBodiesMu.Unlock()
+	requireMetricPayload(t, exports, stdout, stderr, "gestaltd.operation.count")
+	requireMetricPayload(t, exports, stdout, stderr, "gestaltd.operation.duration")
+	requireMetricPayload(t, exports, stdout, stderr, "gestaltd.operation.error_count")
+	requireMetricPayload(t, exports, stdout, stderr,
+		"gestaltd.operation.count",
+		"gestalt.connection_mode",
+		"none",
+		"gestalt.operation",
+		"echo",
+		"gestalt.provider",
+		"example",
+		"gestalt.transport",
+		"plugin",
+	)
+	requireMetricPayload(t, exports, stdout, stderr,
+		"gestaltd.operation.error_count",
+		"gestalt.connection_mode",
+		"none",
+		"gestalt.operation",
+		"unknown",
+		"gestalt.provider",
+		"example",
+		"gestalt.transport",
+		"unknown",
+	)
+	if !strings.Contains(stdout, `"msg":"audit"`) {
+		t.Fatalf("expected audit log in stdout\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+}
+
+func TestE2EInitServeLockedOTLPAuditExportsAuditWithoutStdoutAuditLogs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+
+	var logRequests atomic.Int32
+	otlpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/logs":
+			logRequests.Add(1)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(otlpServer.Close)
+
+	port := allocateTestPort(t)
+	cfgPath := writeE2EConfig(t, dir, pluginDir, port)
+	cfgBytes, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	cfgBytes = append(cfgBytes, []byte(`telemetry:
+  builtin: stdout
+  config:
+    level: info
+    format: json
+audit:
+  builtin: otlp
+  config:
+    endpoint: `+strings.TrimPrefix(otlpServer.URL, "http://")+`
+    protocol: http
+    insecure: true
+`)...)
+	if err := os.WriteFile(cfgPath, cfgBytes, 0o644); err != nil {
+		t.Fatalf("write config telemetry: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	stdout, stderr := serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
+		body := invokeExampleOperation(t, baseURL, "echo", `{"message":"hello"}`, http.StatusOK)
+
+		var result map[string]any
+		if err := json.Unmarshal(body, &result); err != nil {
+			t.Fatalf("unmarshal success response: %v\nbody: %s", err, body)
+		}
+		if result["echo"] != "hello" {
+			t.Fatalf("expected echo=hello, got %v", result)
+		}
+	})
+
+	if logRequests.Load() == 0 {
+		t.Fatalf("expected audit logs to export over OTLP\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if strings.Contains(stdout, `"msg":"audit"`) {
+		t.Fatalf("did not expect audit logs on stdout when audit.provider=otlp\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+}
+
+func TestE2EInitServeLockedStdoutExposesPrometheusAndEmbeddedAdminUIByDefault(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+
+	port := allocateTestPort(t)
+	cfgPath := writeE2EConfig(t, dir, pluginDir, port)
+	cfgBytes, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	cfgBytes = append(cfgBytes, []byte(`telemetry:
+  builtin: stdout
+  config:
+    level: info
+    format: json
+`)...)
+	if err := os.WriteFile(cfgPath, cfgBytes, 0o644); err != nil {
+		t.Fatalf("write config telemetry: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	stdout, stderr := serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
+		invokeExampleOperation(t, baseURL, "echo", `{"message":"hello"}`, http.StatusOK)
+		invokeExampleOperation(t, baseURL, "nope", `{}`, http.StatusNotFound)
+
+		promBody := getEndpointBody(t, baseURL+"/metrics", http.StatusOK)
+		if !bytes.Contains(promBody, []byte("gestaltd_operation_count_total")) {
+			t.Fatalf("expected prometheus counter in /metrics body: %s", promBody)
+		}
+		if !bytes.Contains(promBody, []byte(`gestalt_provider="example"`)) {
+			t.Fatalf("expected provider label in /metrics body: %s", promBody)
+		}
+
+		adminBody := getEndpointBody(t, baseURL+"/admin", http.StatusOK)
+		if !bytes.Contains(adminBody, []byte("Prometheus metrics")) {
+			t.Fatalf("expected embedded admin UI at /admin: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("Requests and failures")) {
+			t.Fatalf("expected activity graph section in embedded admin UI: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("Top providers")) {
+			t.Fatalf("expected provider chart section in embedded admin UI: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("Time window")) {
+			t.Fatalf("expected chart controls in embedded admin UI: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("Refresh cadence")) {
+			t.Fatalf("expected refresh controls in embedded admin UI: %s", adminBody)
+		}
+		if bytes.Contains(adminBody, []byte("Raw Prometheus output")) {
+			t.Fatalf("did not expect raw prometheus section in embedded admin UI: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("echarts.min.js")) {
+			t.Fatalf("expected admin ui to include echarts asset: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("theme.css")) {
+			t.Fatalf("expected admin ui to include shared theme asset: %s", adminBody)
+		}
+	})
+
+	if !strings.Contains(stdout, `"msg":"audit"`) {
+		t.Fatalf("expected audit log in stdout\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+}
+
+func TestE2EInitServeLockedNoopKeepsAdminUIAndReturnsMetricsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+
+	port := allocateTestPort(t)
+	cfgPath := writeE2EConfig(t, dir, pluginDir, port)
+	cfgBytes, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	cfgBytes = append(cfgBytes, []byte(`telemetry:
+  builtin: noop
+`)...)
+	if err := os.WriteFile(cfgPath, cfgBytes, 0o644); err != nil {
+		t.Fatalf("write config telemetry: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
+		invokeExampleOperation(t, baseURL, "echo", `{"message":"hello"}`, http.StatusOK)
+
+		promBody := getEndpointBody(t, baseURL+"/metrics", http.StatusServiceUnavailable)
+		if !bytes.Contains(promBody, []byte("Prometheus metrics are unavailable")) {
+			t.Fatalf("expected disabled metrics message in /metrics body: %s", promBody)
+		}
+
+		adminBody := getEndpointBody(t, baseURL+"/admin", http.StatusOK)
+		if !bytes.Contains(adminBody, []byte("Prometheus metrics")) {
+			t.Fatalf("expected embedded admin UI at /admin: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("echarts.min.js")) {
+			t.Fatalf("expected admin ui to include echarts asset: %s", adminBody)
+		}
+		if !bytes.Contains(adminBody, []byte("theme.css")) {
+			t.Fatalf("expected admin ui to include shared theme asset: %s", adminBody)
+		}
+	})
+}
+
+func TestE2EInitServeLockedNoopTelemetryWithStdoutAuditStillEmitsAuditLogs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+
+	port := allocateTestPort(t)
+	cfgPath := writeE2EConfig(t, dir, pluginDir, port)
+	cfgBytes, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	cfgBytes = append(cfgBytes, []byte(`telemetry:
+  builtin: noop
+audit:
+  builtin: stdout
+  config:
+    format: json
+`)...)
+	if err := os.WriteFile(cfgPath, cfgBytes, 0o644); err != nil {
+		t.Fatalf("write config telemetry: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	stdout, stderr := serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
+		invokeExampleOperation(t, baseURL, "echo", `{"message":"hello"}`, http.StatusOK)
+
+		promBody := getEndpointBody(t, baseURL+"/metrics", http.StatusServiceUnavailable)
+		if !bytes.Contains(promBody, []byte("Prometheus metrics are unavailable")) {
+			t.Fatalf("expected disabled metrics message in /metrics body: %s", promBody)
+		}
+	})
+
+	if !strings.Contains(stdout, `"msg":"audit"`) {
+		t.Fatalf("expected audit log on stdout even with telemetry.provider=noop\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+}
+
+func TestE2EInitServeLockedStdoutAuditHonorsConfiguredLevel(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+
+	port := allocateTestPort(t)
+	cfgPath := writeE2EConfig(t, dir, pluginDir, port)
+	cfgBytes, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	cfgBytes = append(cfgBytes, []byte(`telemetry:
+  builtin: noop
+audit:
+  builtin: stdout
+  config:
+    format: json
+    level: warn
+`)...)
+	if err := os.WriteFile(cfgPath, cfgBytes, 0o644); err != nil {
+		t.Fatalf("write config telemetry: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	stdout, stderr := serveLockedAndExerciseExample(t, cfgPath, port, "", func(t *testing.T, baseURL string) {
+		invokeExampleOperation(t, baseURL, "echo", `{"message":"hello"}`, http.StatusOK)
+	})
+
+	if strings.Contains(stdout, `"operation":"echo"`) {
+		t.Fatalf("did not expect info-level audit log at audit.level=warn\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if strings.Contains(stdout, `"msg":"audit"`) {
+		t.Fatalf("did not expect any audit log on stdout for info-only traffic at audit.level=warn\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+}
+
+func TestE2EInitServeLockedSplitManagementListener(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+
+	publicPort := allocateTestPort(t)
+	managementPort := allocateTestPort(t)
+	cfgPath := writeSplitListenerE2EConfig(t, dir, pluginDir, publicPort, managementPort)
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init: %v\n%s", err, out)
+	}
+
+	stdout, stderr := serveLockedAndExerciseWithManagement(t, cfgPath, publicPort, managementPort, "", func(t *testing.T, publicBaseURL, managementBaseURL string) {
+		invokeExampleOperation(t, publicBaseURL, "echo", `{"message":"hello"}`, http.StatusOK)
+
+		publicMetrics := getEndpointBody(t, publicBaseURL+"/metrics", http.StatusNotFound)
+		if bytes.Contains(publicMetrics, []byte("gestaltd_operation_count_total")) {
+			t.Fatalf("did not expect public listener to expose /metrics: %s", publicMetrics)
+		}
+
+		publicAdmin := getEndpointBody(t, publicBaseURL+"/admin", http.StatusNotFound)
+		if bytes.Contains(publicAdmin, []byte("Prometheus metrics")) {
+			t.Fatalf("did not expect public listener to expose /admin: %s", publicAdmin)
+		}
+
+		managementMetrics := getEndpointBody(t, managementBaseURL+"/metrics", http.StatusOK)
+		if !bytes.Contains(managementMetrics, []byte("gestaltd_operation_count_total")) {
+			t.Fatalf("expected management listener to expose /metrics: %s", managementMetrics)
+		}
+
+		managementRoot := getEndpointBody(t, managementBaseURL+"/", http.StatusOK)
+		if !bytes.Contains(managementRoot, []byte("Prometheus metrics")) {
+			t.Fatalf("expected management listener root to land on admin ui: %s", managementRoot)
+		}
+
+		managementAdmin := getEndpointBody(t, managementBaseURL+"/admin", http.StatusOK)
+		if !bytes.Contains(managementAdmin, []byte("Prometheus metrics")) {
+			t.Fatalf("expected management listener to expose /admin: %s", managementAdmin)
+		}
+		if !bytes.Contains(managementAdmin, []byte(`class="brand" href="/admin/"`)) {
+			t.Fatalf("expected management admin brand link to stay on /admin: %s", managementAdmin)
+		}
+		if bytes.Contains(managementAdmin, []byte(`<a href="/">Client UI</a>`)) {
+			t.Fatalf("did not expect management admin to link to same-origin /: %s", managementAdmin)
+		}
+		if !bytes.Contains(managementAdmin, []byte(`href="https://gestalt.example.test"`)) {
+			t.Fatalf("expected management admin to link to configured public base url: %s", managementAdmin)
+		}
+	})
+	if !strings.Contains(stdout, "management listener serves /admin and /metrics without Gestalt auth") {
+		t.Fatalf("expected management-listener warning in stdout\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+}
+
+func TestE2EBareGestaltdUsesDotGestaltdHomeConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	homeDir := filepath.Join(dir, "home")
+	configDir := filepath.Join(homeDir, ".gestaltd")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll config dir: %v", err)
+	}
+
+	port := allocateTestPort(t)
+	cfg := authDatastoreConfigYAML(t, dir, "", "sqlite", filepath.Join(configDir, "gestalt.db")) + `server:
+  public:
+    port: ` + fmt.Sprintf("%d", port) + `
+  encryptionKey: test-key
+`
+	cfgPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	cmd := exec.Command(gestaltdBin)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = withoutEnvVar(os.Environ(), "GESTALT_CONFIG")
+	cmd.Env = append(cmd.Env,
+		"HOME="+homeDir,
+		"GOMODCACHE="+goEnvPath(t, "GOMODCACHE"),
+		"GOCACHE="+goEnvPath(t, "GOCACHE"),
+	)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start gestaltd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(os.Interrupt)
+		_ = cmd.Wait()
+	})
+
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	waitForHealth(t, baseURL, 20*time.Second)
+}
+
+func goEnvPath(t *testing.T, key string) string {
+	t.Helper()
+
+	out, err := exec.Command("go", "env", key).Output()
+	if err != nil {
+		t.Fatalf("go env %s: %v", key, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func TestE2EValidateNonMutating(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+
+	cfgPath := writeE2EConfig(t, dir, pluginDir, 0)
+	lockPath := filepath.Join(dir, operator.InitLockfileName)
+
+	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected validate to succeed without init for local source plugins: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatal("expected no lockfile after non-mutating validate")
+	}
+}
+
+func TestE2EHelmChart(t *testing.T) {
+	helmPath, err := exec.LookPath("helm")
+	if err != nil {
+		t.Skip("helm not installed")
+	}
+
+	chartDir := filepath.Join("..", "..", "deploy", "helm", "gestalt")
+
+	t.Run("default chart profile boots", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		port := allocateTestPort(t)
+		dbPath := filepath.Join(dir, "gestalt.db")
+
+		cfgPath := filepath.Join(dir, "config.yaml")
+		cfg := fmt.Sprintf(`datastores:
+  sqlite:
+    provider:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/datastore/sqlite
+        version: 0.0.1-alpha.1
+    config:
+      path: %s
+datastore: sqlite
+server:
+  encryptionKey: test-helm-key
+  public:
+    port: %d
+ui:
+  disabled: true
+`, dbPath, port)
+		if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+		if err != nil {
+			t.Fatalf("gestaltd validate: %v\n%s", err, out)
+		}
+
+		cmd := exec.Command(gestaltdBin, "serve", "--locked", "--config", cfgPath)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start serve: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = cmd.Process.Signal(os.Interrupt)
+			_ = cmd.Wait()
+		})
+
+		baseURL := fmt.Sprintf("http://localhost:%d", port)
+		waitForHealth(t, baseURL, 20*time.Second)
+		waitForReady(t, baseURL, 20*time.Second)
+	})
+
+	t.Run("ingress paths render from values", func(t *testing.T) {
+		t.Parallel()
+
+		rendered := renderHelmChart(t, helmPath, chartDir,
+			"--set", "ingress.enabled=true",
+			"--set-string", "ingress.hosts[0].host=gestalt.example.com",
+			"--set-string", "ingress.hosts[0].paths[0].path=/gestalt",
+			"--set-string", "ingress.hosts[0].paths[0].pathType=Prefix",
+		)
+
+		for _, want := range []string{
+			`host: "gestalt.example.com"`,
+			`path: "/gestalt"`,
+			`pathType: Prefix`,
+		} {
+			if !strings.Contains(rendered, want) {
+				t.Fatalf("expected rendered manifest to contain %q\n%s", want, rendered)
+			}
+		}
+	})
+
+	t.Run("management service renders from values", func(t *testing.T) {
+		t.Parallel()
+
+		rendered := renderHelmChart(t, helmPath, chartDir,
+			"--set", "managementService.enabled=true",
+			"--set", "managementService.port=9090",
+			"--set", "config.server.management.port=9090",
+			"--set-string", "config.server.management.host=0.0.0.0",
+		)
+
+		for _, want := range []string{
+			`kind: Service`,
+			`name: test-release-gestalt-management`,
+			`port: 9090`,
+			`targetPort: management`,
+			`containerPort: 9090`,
+		} {
+			if !strings.Contains(rendered, want) {
+				t.Fatalf("expected rendered manifest to contain %q\n%s", want, rendered)
+			}
+		}
+	})
+}
+
+func withoutEnvVar(env []string, name string) []string {
+	prefix := name + "="
+	filtered := env[:0]
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
+func renderHelmChart(t *testing.T, helmPath, chartDir string, extraArgs ...string) string {
+	t.Helper()
+	args := append([]string{"template", "test-release", chartDir}, extraArgs...)
+	out, err := exec.Command(helmPath, args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	return string(out)
+}
+
+//nolint:paralleltest // Spawns the CLI binary; keeping it serial avoids package-level e2e flake.
 func TestE2EValidateRejectsUnknownYAMLField(t *testing.T) {
 	t.Parallel()
 
@@ -279,14 +1768,14 @@ func authDatastoreConfigYAML(t *testing.T, dir, authName, datastoreName, dbPath 
   %s:
     provider:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
+        ref: github.com/valon-technologies/gestalt-providers/datastore/sqlite
         version: 0.0.1-alpha.1
     config:
-      dsn: %q
+      path: %s
 datastore: %s
 ui:
-  provider: none
-`, authBlock, datastoreName, "sqlite://"+dbPath, datastoreName)
+  disabled: true
+`, authBlock, datastoreName, dbPath, datastoreName)
 }
 
 func writeManifestFile(t *testing.T, pluginDir string, manifest *pluginmanifestv1.Manifest) {

--- a/gestaltd/cmd/gestaltd/factories.go
+++ b/gestaltd/cmd/gestaltd/factories.go
@@ -88,7 +88,7 @@ func buildFactories() *bootstrap.FactoryRegistry {
 		if cfg.Provider != nil {
 			return nil, nil, fmt.Errorf("plugin-based audit providers are not yet supported")
 		}
-		switch cfg.BuiltinProvider {
+		switch cfg.Builtin {
 		case "", "inherit":
 			return invocation.NewLoggerAuditSink(telemetry.Logger()), nil, nil
 		case "noop":
@@ -111,7 +111,7 @@ func buildFactories() *bootstrap.FactoryRegistry {
 			}
 			return invocation.NewLevelAwareLoggerAuditSink(logger), closeFn, nil
 		default:
-			return nil, nil, fmt.Errorf("unknown audit provider %q", cfg.BuiltinProvider)
+			return nil, nil, fmt.Errorf("unknown audit provider %q", cfg.Builtin)
 		}
 	}
 	factories.Auth = authplugin.Factory

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -452,7 +452,7 @@ func logConfigSummary(path string, cfg *config.Config) {
 		"server_encryption", maskSecret(cfg.Server.EncryptionKey),
 		"auth_provider", providerLabel(cfg.Auth.Provider),
 		"secrets_provider", secretsProviderLabel(cfg.Secrets),
-		"telemetry_provider", cfg.Telemetry.BuiltinProvider,
+		"telemetry_provider", cfg.Telemetry.Builtin,
 	)
 
 	for name, intg := range cfg.Plugins {
@@ -480,8 +480,8 @@ func secretsProviderLabel(secrets config.SecretsConfig) string {
 	if secrets.Provider != nil {
 		return providerLabel(secrets.Provider)
 	}
-	if secrets.BuiltinProvider != "" {
-		return secrets.BuiltinProvider
+	if secrets.Builtin != "" {
+		return secrets.Builtin
 	}
 	return "env"
 }

--- a/gestaltd/deploy/helm/gestalt/values.yaml
+++ b/gestaltd/deploy/helm/gestalt/values.yaml
@@ -103,7 +103,7 @@ config:
   # Keep the default chart profile self-contained. Set this to a managed
   # provider source when you want a public web UI.
   ui:
-    provider: none
+    disabled: true
 
 # Extra environment variables for the container. These are only required
 # when your config uses ${VAR} placeholders for auth, baseUrl, or

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -407,40 +407,61 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 }
 
 func buildTelemetry(cfg *config.Config, factories *FactoryRegistry) (core.TelemetryProvider, error) {
+	if cfg.Telemetry.Disabled {
+		factory, ok := factories.Telemetry["noop"]
+		if !ok {
+			return nil, fmt.Errorf("bootstrap: noop telemetry factory is not registered")
+		}
+		return factory(cfg.Telemetry.Config)
+	}
 	if cfg.Telemetry.Provider != nil {
 		return nil, fmt.Errorf("bootstrap: plugin-based telemetry providers are not yet supported")
 	}
-	factory, ok := factories.Telemetry[cfg.Telemetry.BuiltinProvider]
+	factory, ok := factories.Telemetry[cfg.Telemetry.Builtin]
 	if !ok {
-		return nil, fmt.Errorf("bootstrap: unknown telemetry provider %q", cfg.Telemetry.BuiltinProvider)
+		return nil, fmt.Errorf("bootstrap: unknown telemetry provider %q", cfg.Telemetry.Builtin)
 	}
 	tp, err := factory(cfg.Telemetry.Config)
 	if err != nil {
-		return nil, fmt.Errorf("bootstrap: telemetry provider %q: %w", cfg.Telemetry.BuiltinProvider, err)
+		return nil, fmt.Errorf("bootstrap: telemetry provider %q: %w", cfg.Telemetry.Builtin, err)
 	}
 	return tp, nil
 }
 
 func buildAuditSink(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, telemetry core.TelemetryProvider) (core.AuditSink, func(context.Context) error, error) {
+	if cfg.Audit.Disabled {
+		return invocation.NewLoggerAuditSink(slog.New(slog.DiscardHandler)), nil, nil
+	}
 	if cfg.Audit.Provider != nil {
 		return nil, nil, fmt.Errorf("bootstrap: plugin-based audit providers are not yet supported")
 	}
 	if factories.Audit == nil {
-		switch cfg.Audit.BuiltinProvider {
+		switch cfg.Audit.Builtin {
 		case "", "inherit":
 			return invocation.NewLoggerAuditSink(telemetry.Logger()), nil, nil
 		default:
-			return nil, nil, fmt.Errorf("bootstrap: unknown audit provider %q", cfg.Audit.BuiltinProvider)
+			return nil, nil, fmt.Errorf("bootstrap: unknown audit provider %q", cfg.Audit.Builtin)
 		}
 	}
 	sink, closeFn, err := factories.Audit(ctx, cfg.Audit, telemetry)
 	if err != nil {
-		return nil, nil, fmt.Errorf("bootstrap: audit provider %q: %w", cfg.Audit.BuiltinProvider, err)
+		return nil, nil, fmt.Errorf("bootstrap: audit provider %q: %w", cfg.Audit.Builtin, err)
 	}
 	return sink, closeFn, nil
 }
 
+type disabledSecretManager struct{}
+
+var errSecretsDisabled = fmt.Errorf("%w: secrets provider is disabled", core.ErrSecretNotFound)
+
+func (disabledSecretManager) GetSecret(_ context.Context, _ string) (string, error) {
+	return "", errSecretsDisabled
+}
+
 func buildSecretManager(cfg *config.Config, factories *FactoryRegistry) (core.SecretManager, error) {
+	if cfg.Secrets.Disabled {
+		return disabledSecretManager{}, nil
+	}
 	if cfg.Secrets.Provider != nil {
 		factory, ok := factories.Secrets["plugin"]
 		if !ok {
@@ -461,7 +482,7 @@ func buildSecretManager(cfg *config.Config, factories *FactoryRegistry) (core.Se
 		return sm, nil
 	}
 
-	name := cfg.Secrets.BuiltinProvider
+	name := cfg.Secrets.Builtin
 	if name == "" {
 		name = "env"
 	}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -62,8 +62,8 @@ func validConfig() *config.Config {
 		Datastores: map[string]config.DatastoreDef{
 			"test": {Provider: &config.ProviderDef{Source: &config.PluginSourceDef{Path: "stub"}}},
 		},
-		Secrets:   config.SecretsConfig{BuiltinProvider: "test-secrets"},
-		Telemetry: config.TelemetryConfig{BuiltinProvider: "test-telemetry"},
+		Secrets:   config.SecretsConfig{Builtin: "test-secrets"},
+		Telemetry: config.TelemetryConfig{Builtin: "test-telemetry"},
 		Plugins:   map[string]config.PluginDef{},
 		Server: config.ServerConfig{
 			Public:        config.ListenerConfig{Port: 8080},
@@ -557,6 +557,59 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "secrets broke") {
 			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestBootstrapDisabledComponents(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("disabled telemetry uses noop", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := validConfig()
+		cfg.Telemetry = config.TelemetryConfig{Disabled: true}
+
+		factories := validFactories()
+		factories.Telemetry["noop"] = telemetrynoop.Factory
+
+		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
+			t.Fatalf("Bootstrap: %v", err)
+		}
+		<-result.ProvidersReady
+		if result.Telemetry == nil {
+			t.Fatal("Telemetry is nil")
+		}
+		if err := result.Close(context.Background()); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	})
+
+	t.Run("disabled secrets returns not found", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := validConfig()
+		cfg.Secrets = config.SecretsConfig{Disabled: true}
+
+		result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+		if err != nil {
+			t.Fatalf("Bootstrap: %v", err)
+		}
+		<-result.ProvidersReady
+		if result.SecretManager == nil {
+			t.Fatal("SecretManager is nil")
+		}
+		_, getErr := result.SecretManager.GetSecret(ctx, "any-key")
+		if getErr == nil {
+			t.Fatal("expected error from disabled secret manager")
+		}
+		if !strings.Contains(getErr.Error(), "disabled") {
+			t.Fatalf("error should mention disabled: %v", getErr)
+		}
+		if err := result.Close(context.Background()); err != nil {
+			t.Fatalf("Close: %v", err)
 		}
 	})
 }

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -51,23 +51,16 @@ type Config struct {
 }
 
 // ComponentConfig is the unified configuration for top-level infrastructure
-// components (auth, secrets, telemetry, audit, ui). Each component's provider
-// can be a builtin (provider: { builtin: <name> } or the legacy scalar form
-// provider: <name>) or an external plugin (provider: { source: ... }).
+// components (auth, secrets, telemetry, audit, ui).
 type ComponentConfig struct {
-	Provider          *ProviderDef `yaml:"provider"`
-	Config            yaml.Node    `yaml:"config"`
-	BuiltinProvider   string       `yaml:"-"`
-	Disabled          bool         `yaml:"-"`
+	Builtin           string       `yaml:"builtin,omitempty"`
+	Provider          *ProviderDef `yaml:"provider,omitempty"`
+	Config            yaml.Node    `yaml:"config,omitempty"`
+	Disabled          bool         `yaml:"disabled,omitempty"`
 	ResolvedAssetRoot string       `yaml:"-"`
 }
 
 func (c *ComponentConfig) UnmarshalYAML(value *yaml.Node) error {
-	return c.unmarshalComponent(value)
-}
-
-func (c *ComponentConfig) unmarshalComponent(value *yaml.Node) error {
-	kind := "component"
 	if value == nil || value.Kind == 0 {
 		*c = ComponentConfig{}
 		return nil
@@ -79,38 +72,58 @@ func (c *ComponentConfig) unmarshalComponent(value *yaml.Node) error {
 	for i := 0; i+1 < len(value.Content); i += 2 {
 		key := value.Content[i].Value
 		switch key {
-		case "provider", "config":
+		case "builtin", "provider", "config", "disabled":
 		default:
-			return fmt.Errorf("field %s not found in type %s config", key, kind)
+			return fmt.Errorf("field %s not found in type component config", key)
 		}
 	}
-	*c = ComponentConfig{}
+
 	providerNode := mappingValueNode(value, "provider")
-	if providerNode != nil {
-		switch {
-		case providerNode.Kind == yaml.ScalarNode && providerNode.Tag != "!!null":
-			v := strings.TrimSpace(providerNode.Value)
-			if v == "none" {
-				c.Disabled = true
-			} else if v != "" {
-				c.BuiltinProvider = v
-			}
-		case providerNode.Kind == yaml.MappingNode:
-			if builtinNode := mappingValueNode(providerNode, "builtin"); builtinNode != nil && builtinNode.Kind == yaml.ScalarNode {
-				c.BuiltinProvider = strings.TrimSpace(builtinNode.Value)
-			} else {
-				decoded, err := decodeExternalProvider(providerNode)
-				if err != nil {
-					return err
-				}
-				c.Provider = decoded
-			}
-		case providerNode.Kind != yaml.ScalarNode || providerNode.Tag != "!!null":
-			return fmt.Errorf("%s.provider must be a string or a provider reference mapping", kind)
+	if providerNode != nil && providerNode.Kind == yaml.ScalarNode && providerNode.Tag != "!!null" {
+		v := strings.TrimSpace(providerNode.Value)
+		if v == "none" {
+			return fmt.Errorf("provider: \"none\" is no longer supported; use disabled: true")
 		}
+		return fmt.Errorf("provider: %q is no longer supported as a scalar string; use builtin: %s", v, v)
+	}
+	if providerNode != nil && providerNode.Kind == yaml.MappingNode {
+		if builtinNode := mappingValueNode(providerNode, "builtin"); builtinNode != nil && builtinNode.Kind == yaml.ScalarNode {
+			return fmt.Errorf("provider: { builtin: %s } is no longer supported; use builtin: %s", builtinNode.Value, builtinNode.Value)
+		}
+	}
+
+	*c = ComponentConfig{}
+	if builtinNode := mappingValueNode(value, "builtin"); builtinNode != nil && builtinNode.Kind == yaml.ScalarNode && builtinNode.Tag != "!!null" {
+		c.Builtin = strings.TrimSpace(builtinNode.Value)
+	}
+	if disabledNode := mappingValueNode(value, "disabled"); disabledNode != nil && disabledNode.Kind == yaml.ScalarNode {
+		if err := disabledNode.Decode(&c.Disabled); err != nil {
+			return fmt.Errorf("decoding disabled field: %w", err)
+		}
+	}
+	if providerNode != nil && providerNode.Kind == yaml.MappingNode {
+		decoded, err := decodeExternalProvider(providerNode)
+		if err != nil {
+			return err
+		}
+		c.Provider = decoded
 	}
 	if configNode := mappingValueNode(value, "config"); configNode != nil {
 		c.Config = *configNode
+	}
+
+	set := 0
+	if c.Builtin != "" {
+		set++
+	}
+	if c.Provider != nil {
+		set++
+	}
+	if c.Disabled {
+		set++
+	}
+	if set > 1 {
+		return fmt.Errorf("builtin, provider, and disabled are mutually exclusive")
 	}
 	return nil
 }
@@ -826,14 +839,14 @@ func applyDefaults(cfg *Config) {
 	if cfg.Server.Public.Port == 0 {
 		cfg.Server.Public.Port = 8080
 	}
-	if !cfg.Secrets.Disabled && cfg.Secrets.Provider == nil && cfg.Secrets.BuiltinProvider == "" {
-		cfg.Secrets.BuiltinProvider = "env"
+	if !cfg.Secrets.Disabled && cfg.Secrets.Provider == nil && cfg.Secrets.Builtin == "" {
+		cfg.Secrets.Builtin = "env"
 	}
-	if !cfg.Telemetry.Disabled && cfg.Telemetry.Provider == nil && cfg.Telemetry.BuiltinProvider == "" {
-		cfg.Telemetry.BuiltinProvider = "stdout"
+	if !cfg.Telemetry.Disabled && cfg.Telemetry.Provider == nil && cfg.Telemetry.Builtin == "" {
+		cfg.Telemetry.Builtin = "stdout"
 	}
-	if !cfg.Audit.Disabled && cfg.Audit.Provider == nil && cfg.Audit.BuiltinProvider == "" {
-		cfg.Audit.BuiltinProvider = "inherit"
+	if !cfg.Audit.Disabled && cfg.Audit.Provider == nil && cfg.Audit.Builtin == "" {
+		cfg.Audit.Builtin = "inherit"
 	}
 	if !cfg.UI.Disabled && cfg.UI.Provider == nil {
 		cfg.UI.Provider = defaultUIProvider()

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -124,8 +124,8 @@ plugins:
 	if cfg.Server.Public.Port != 8080 {
 		t.Fatalf("Server.Public.Port = %d, want 8080", cfg.Server.Public.Port)
 	}
-	if cfg.Secrets.BuiltinProvider != "env" {
-		t.Fatalf("Secrets.BuiltinProvider = %q, want env", cfg.Secrets.BuiltinProvider)
+	if cfg.Secrets.Builtin != "env" {
+		t.Fatalf("Secrets.Builtin = %q, want env", cfg.Secrets.Builtin)
 	}
 	if cfg.Server.EncryptionKey != "encryption-from-env" {
 		t.Fatalf("Server.EncryptionKey = %q", cfg.Server.EncryptionKey)
@@ -302,7 +302,7 @@ server:
 			name: "missing datastore",
 			yaml: `
 auth:
-  provider: none
+  disabled: true
 server:
   encryptionKey: server-key
 `,
@@ -321,10 +321,10 @@ datastore: sqlite
 			wantErr: true,
 		},
 		{
-			name: "auth provider none is allowed",
+			name: "auth disabled is allowed",
 			yaml: `
 auth:
-  provider: none
+  disabled: true
 datastores:
   sqlite:
     provider:
@@ -356,8 +356,8 @@ server:
 			if err != nil {
 				t.Fatalf("ValidateRuntime: %v", err)
 			}
-			if tc.name == "auth provider none is allowed" && cfg.Auth.Provider != nil {
-				t.Fatalf("Auth.Provider = %#v, want nil", cfg.Auth.Provider)
+			if tc.name == "auth disabled is allowed" && !cfg.Auth.Disabled {
+				t.Fatal("Auth.Disabled = false, want true")
 			}
 		})
 	}
@@ -394,7 +394,7 @@ server:
 			name: "legacy datastore plugin field rejected",
 			yaml: `
 auth:
-  provider: none
+  disabled: true
 datastore:
   plugin:
     source:
@@ -430,7 +430,7 @@ server:
 			name: "datastore config accepted",
 			yaml: `
 auth:
-  provider: none
+  disabled: true
 datastores:
   sqlite:
     provider:
@@ -520,12 +520,12 @@ server:
 		}
 	})
 
-	t.Run("ui provider none disables public ui", func(t *testing.T) {
+	t.Run("ui disabled true disables public ui", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
 ui:
-  provider: none
+  disabled: true
 datastores:
   sqlite:
     provider:
@@ -548,12 +548,44 @@ server:
 		}
 	})
 
-	t.Run("ui config is rejected with provider none", func(t *testing.T) {
+	t.Run("disabled field accepts all YAML boolean variants", func(t *testing.T) {
+		t.Parallel()
+
+		for _, variant := range []string{"true", "True", "TRUE"} {
+			variant := variant
+			t.Run(variant, func(t *testing.T) {
+				t.Parallel()
+
+				path := mustWriteConfigFile(t, fmt.Sprintf(`
+ui:
+  disabled: %s
+datastores:
+  sqlite:
+    provider:
+      source:
+        path: ./providers/datastore/sqlite
+datastore: sqlite
+server:
+  encryptionKey: server-key
+`, variant))
+
+				cfg, err := Load(path)
+				if err != nil {
+					t.Fatalf("Load: %v", err)
+				}
+				if !cfg.UI.Disabled {
+					t.Fatalf("UI.Disabled = false with disabled: %s, want true", variant)
+				}
+			})
+		}
+	})
+
+	t.Run("ui config is rejected when disabled", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
 ui:
-  provider: none
+  disabled: true
   config:
     brand_name: Acme
 datastores:
@@ -570,7 +602,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `ui.config is not supported when ui.provider is "none"`) {
+		if !strings.Contains(err.Error(), "ui.config is not supported when ui is disabled") {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -605,6 +637,155 @@ server:
 			t.Fatalf("UI.Provider.Source.Path = %q, want %q", got, wantPath)
 		}
 	})
+}
+
+func TestLoadRejectsOldProviderScalarForms(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "provider none is rejected",
+			yaml: `
+ui:
+  provider: none
+`,
+			wantErr: `provider: "none" is no longer supported; use disabled: true`,
+		},
+		{
+			name: "provider scalar string is rejected",
+			yaml: `
+telemetry:
+  provider: stdout
+`,
+			wantErr: `provider: "stdout" is no longer supported as a scalar string; use builtin: stdout`,
+		},
+		{
+			name: "provider builtin mapping is rejected",
+			yaml: `
+audit:
+  provider:
+    builtin: noop
+`,
+			wantErr: `provider: { builtin: noop } is no longer supported; use builtin: noop`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := mustWriteConfigFile(t, tc.yaml)
+			_, err := Load(path)
+			if err == nil {
+				t.Fatal("Load: expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestLoadAcceptsNewComponentForms(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "builtin string",
+			yaml: `
+telemetry:
+  builtin: stdout
+`,
+		},
+		{
+			name: "disabled true",
+			yaml: `
+ui:
+  disabled: true
+`,
+		},
+		{
+			name: "external provider source",
+			yaml: `
+auth:
+  provider:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/auth/google
+      version: 1.0.0
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := mustWriteConfigFile(t, tc.yaml)
+			_, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadRejectsMutuallyExclusiveComponentFields(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "builtin and disabled",
+			yaml: `
+telemetry:
+  builtin: stdout
+  disabled: true
+`,
+		},
+		{
+			name: "provider and disabled",
+			yaml: `
+auth:
+  provider:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/auth/google
+      version: 1.0.0
+  disabled: true
+`,
+		},
+		{
+			name: "provider and builtin",
+			yaml: `
+telemetry:
+  provider:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/telemetry/custom
+      version: 1.0.0
+  builtin: stdout
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := mustWriteConfigFile(t, tc.yaml)
+			_, err := Load(path)
+			if err == nil {
+				t.Fatal("Load: expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "mutually exclusive") {
+				t.Fatalf("expected mutual exclusivity error, got: %v", err)
+			}
+		})
+	}
 }
 
 func TestLoadConfigValidation(t *testing.T) {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -38,8 +38,8 @@ func ValidateStructure(cfg *Config) error {
 	if err := validateUIConfig(cfg.UI); err != nil {
 		return err
 	}
-	if cfg.Auth.BuiltinProvider != "" {
-		return fmt.Errorf("config validation: auth.provider must be a provider reference mapping or the string \"none\"")
+	if cfg.Auth.Builtin != "" {
+		return fmt.Errorf("config validation: auth does not support builtin providers; use a provider reference or omit auth")
 	}
 	if err := validateTopLevelComponentConfig("auth", cfg.Auth.Provider, cfg.Auth.Config); err != nil {
 		return err
@@ -75,12 +75,12 @@ func validateAudit(cfg AuditConfig) error {
 	if cfg.Provider != nil {
 		return validateTopLevelComponentProvider("audit", cfg.Provider)
 	}
-	switch cfg.BuiltinProvider {
+	switch cfg.Builtin {
 	case "", "inherit", "noop":
 		if cfg.Config.Kind == 0 {
 			return nil
 		}
-		return fmt.Errorf("config validation: audit.config is not supported when audit.provider is %q", cfg.BuiltinProvider)
+		return fmt.Errorf("config validation: audit.config is not supported when audit.provider is %q", cfg.Builtin)
 	case "stdout":
 		if cfg.Config.Kind == 0 {
 			return nil
@@ -118,7 +118,7 @@ func validateAudit(cfg AuditConfig) error {
 		}
 		return nil
 	default:
-		return fmt.Errorf("config validation: unknown audit.provider %q", cfg.BuiltinProvider)
+		return fmt.Errorf("config validation: unknown audit.provider %q", cfg.Builtin)
 	}
 }
 
@@ -161,7 +161,7 @@ func ValidateResolvedStructure(cfg *Config) error {
 
 // ValidateRuntime checks runtime-only requirements: encryption key plus the
 // required top-level datastore provider. Platform auth is optional; omitting it
-// or setting auth.provider to "none" disables authentication. Callers that need a fully
+// or setting auth.disabled to true disables authentication. Callers that need a fully
 // operational config (serve) should call this after Load. Callers that only
 // need structural correctness (init, validate) should not.
 func ValidateRuntime(cfg *Config) error {
@@ -465,7 +465,7 @@ func validateAuthValueDef(integration, subject, path string, value AuthValueDef,
 func validateUIConfig(cfg UIConfig) error {
 	if cfg.Disabled {
 		if cfg.Config.Kind != 0 {
-			return fmt.Errorf(`config validation: ui.config is not supported when ui.provider is "none"`)
+			return fmt.Errorf("config validation: ui.config is not supported when ui is disabled")
 		}
 		return nil
 	}

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -233,7 +233,7 @@ func writeConfigYAML(t *testing.T, dir, source, version, artifactsDir string) st
 
 	lines := []string{
 		"ui:",
-		"  provider: none",
+		"  disabled: true",
 		"server:",
 		"  artifactsDir: " + artifactsDir,
 		"plugins:",
@@ -529,7 +529,7 @@ func TestSourceAuthPluginLoadForExecution(t *testing.T) {
 	configYAML := strings.Join([]string{
 		requiredDatastoreConfigYAML(t, dir, filepath.Join(dir, "data.db")),
 		"secrets:",
-		"  provider: test-secrets",
+		"  builtin: test-secrets",
 		"auth:",
 		"  provider:",
 		"    source:",

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -61,32 +61,32 @@ func decodeNodeMap(t *testing.T, node any) map[string]any {
 
 func requiredComponentConfigYAML(_ *testing.T, _, dbPath string) string {
 	return fmt.Sprintf(`datastores:
-  main:
+  sqlite:
     provider:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
+        ref: github.com/valon-technologies/gestalt-providers/datastore/sqlite
         version: 0.0.1-alpha.1
     config:
-      dsn: %q
-datastore: main
+      path: %q
+datastore: sqlite
 ui:
-  provider: none
-`, "sqlite://"+dbPath)
+  disabled: true
+`, dbPath)
 }
 
 func requiredDatastoreConfigYAML(_ *testing.T, _, dbPath string) string {
 	return fmt.Sprintf(`datastores:
-  main:
+  sqlite:
     provider:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
+        ref: github.com/valon-technologies/gestalt-providers/datastore/sqlite
         version: 0.0.1-alpha.1
     config:
-      dsn: %q
-datastore: main
+      path: %q
+datastore: sqlite
 ui:
-  provider: none
-`, "sqlite://"+dbPath)
+  disabled: true
+`, dbPath)
 }
 
 func TestLoadForExecutionAtPath_ResolvesLocalManifestPluginWithoutLockfile(t *testing.T) {
@@ -295,7 +295,7 @@ datastores:
       dsn: %q
 datastore: sqlite
 ui:
-  provider: none
+  disabled: true
 server:
   encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `, "sqlite://"+dbPath)
@@ -380,7 +380,7 @@ datastores:
       dsn: %q
 datastore: sqlite
 ui:
-  provider: none
+  disabled: true
 server:
   encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `, "sqlite://"+dbPath)

--- a/gestaltd/internal/operator/localconfig.go
+++ b/gestaltd/internal/operator/localconfig.go
@@ -65,7 +65,7 @@ func defaultManagedConfig(dbPath, encryptionKey string) string {
       dsn: %q
 datastore: main
 secrets:
-  provider: env
+  builtin: env
 server:
   public:
     port: 8080
@@ -88,7 +88,7 @@ ui:
     source:
       path: %q
 secrets:
-  provider: env
+  builtin: env
 server:
   public:
     port: 8080


### PR DESCRIPTION
ComponentConfig previously stored builtin providers in a BuiltinProvider
field with yaml:"-" tag, requiring custom UnmarshalYAML logic to parse
the overloaded provider field (which accepted scalars, "none" for
disabled, and mappings). This replaces that with three explicit YAML
fields: builtin, provider, and disabled. Old scalar and mapping forms
(provider: stdout, provider: none, provider: { builtin: ... }) now
produce clear migration errors directing users to the new syntax.

UnmarshalYAML now validates that builtin, provider, and disabled are
mutually exclusive, rejecting ambiguous configs like setting both
builtin: stdout and disabled: true. The bootstrap layer also gains
early-return checks for cfg.Disabled on buildTelemetry, buildAuditSink,
and buildSecretManager so that disabled: true actually takes effect at
runtime rather than falling through to the active code paths.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>