### PR TITLE
Remove default connection hoisting magic

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -359,12 +359,14 @@ func (s ServerConfig) ManagementAddr() string {
 }
 
 type PluginDef struct {
-	Plugin        *ProviderDef      `yaml:"plugin"`
-	DisplayName   string            `yaml:"displayName"`
-	Description   string            `yaml:"description"`
-	MCPToolPrefix string            `yaml:"-"`
-	IconFile      string            `yaml:"iconFile"`
-	Datastores    map[string]string `yaml:"-"`
+	Plugin            *ProviderDef              `yaml:"plugin"`
+	DisplayName       string                    `yaml:"displayName"`
+	Description       string                    `yaml:"description"`
+	MCPToolPrefix     string                    `yaml:"-"`
+	IconFile          string                    `yaml:"iconFile"`
+	Datastores        map[string]string         `yaml:"-"`
+	DefaultConnection string                    `yaml:"-"`
+	Connections       map[string]*ConnectionDef `yaml:"-"`
 }
 
 // ConnectionDef owns authentication and connection parameters for a named

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -1040,6 +1040,132 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 	}
 }
 
+func TestPluginDefConnectionsParsing(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default connection populates PluginDef.Connections and backward compat fields", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  svc:
+    provider:
+      source:
+        path: /tmp/manifest.yaml
+    connections:
+      default:
+        mode: user
+        auth:
+          type: oauth2
+          clientId: cid-1
+        params:
+          org:
+            required: true
+      secondary:
+        mode: admin
+        auth:
+          type: none
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+
+		pluginDef := cfg.Plugins["svc"]
+
+		if pluginDef.DefaultConnection != "default" {
+			t.Fatalf("PluginDef.DefaultConnection = %q, want %q", pluginDef.DefaultConnection, "default")
+		}
+		if len(pluginDef.Connections) != 2 {
+			t.Fatalf("len(PluginDef.Connections) = %d, want 2", len(pluginDef.Connections))
+		}
+		if pluginDef.Connections["default"] == nil {
+			t.Fatal("PluginDef.Connections[\"default\"] = nil, want non-nil")
+		}
+		if pluginDef.Connections["secondary"] == nil {
+			t.Fatal("PluginDef.Connections[\"secondary\"] = nil, want non-nil")
+		}
+
+		provider := pluginDef.Plugin
+		if provider.Auth == nil {
+			t.Fatal("ProviderDef.Auth = nil, want hoisted from default connection")
+		}
+		if provider.Auth.Type != pluginmanifestv1.AuthTypeOAuth2 {
+			t.Fatalf("ProviderDef.Auth.Type = %q, want %q", provider.Auth.Type, pluginmanifestv1.AuthTypeOAuth2)
+		}
+		if provider.ConnectionMode != pluginmanifestv1.ConnectionModeUser {
+			t.Fatalf("ProviderDef.ConnectionMode = %q, want %q", provider.ConnectionMode, pluginmanifestv1.ConnectionModeUser)
+		}
+		if _, ok := provider.ConnectionParams["org"]; !ok {
+			t.Fatal("ProviderDef.ConnectionParams missing \"org\"")
+		}
+
+		if len(provider.Connections) != 1 {
+			t.Fatalf("ProviderDef.Connections length = %d, want 1 (non-default only)", len(provider.Connections))
+		}
+		if provider.Connections["secondary"] == nil {
+			t.Fatal("ProviderDef.Connections[\"secondary\"] = nil")
+		}
+	})
+
+	t.Run("explicit defaultConnection overrides implicit default key", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  svc:
+    provider:
+      source:
+        path: /tmp/manifest.yaml
+    defaultConnection: primary
+    connections:
+      default:
+        mode: admin
+        auth:
+          type: none
+      primary:
+        mode: user
+        auth:
+          type: oauth2
+          clientId: cid-primary
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+
+		pluginDef := cfg.Plugins["svc"]
+
+		if pluginDef.DefaultConnection != "primary" {
+			t.Fatalf("PluginDef.DefaultConnection = %q, want %q", pluginDef.DefaultConnection, "primary")
+		}
+
+		provider := pluginDef.Plugin
+		if provider.Auth == nil {
+			t.Fatal("ProviderDef.Auth = nil, want hoisted from primary connection")
+		}
+		if provider.Auth.ClientID != "cid-primary" {
+			t.Fatalf("ProviderDef.Auth.ClientID = %q, want %q", provider.Auth.ClientID, "cid-primary")
+		}
+		if provider.ConnectionMode != pluginmanifestv1.ConnectionModeUser {
+			t.Fatalf("ProviderDef.ConnectionMode = %q, want %q", provider.ConnectionMode, pluginmanifestv1.ConnectionModeUser)
+		}
+
+		if len(pluginDef.Connections) != 2 {
+			t.Fatalf("len(PluginDef.Connections) = %d, want 2", len(pluginDef.Connections))
+		}
+
+		if provider.Connections["default"] == nil {
+			t.Fatal("ProviderDef.Connections[\"default\"] = nil, want non-default connections preserved")
+		}
+		if _, hasPrimary := provider.Connections["primary"]; hasPrimary {
+			t.Fatal("ProviderDef.Connections should not contain the effective default connection")
+		}
+	})
+}
+
 func TestLoadConfigResolvesRelativePaths(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/provider_ref.go
+++ b/gestaltd/internal/config/provider_ref.go
@@ -20,6 +20,7 @@ type integrationWire struct {
 	IconFile          string                            `yaml:"iconFile"`
 	Provider          *ProviderDef                      `yaml:"provider"`
 	Config            yaml.Node                         `yaml:"config"`
+	DefaultConnection string                            `yaml:"defaultConnection"`
 	Connections       map[string]*integrationConnection `yaml:"connections"`
 	AllowedOperations map[string]*OperationOverride     `yaml:"allowedOperations"`
 	MCP               *integrationMCPWire               `yaml:"mcp"`
@@ -88,42 +89,66 @@ func (i *PluginDef) UnmarshalYAML(value *yaml.Node) error {
 		if wire.MCP != nil {
 			plugin.MCP = wire.MCP.Enabled
 		}
-		if defaultConn, ok := wire.Connections["default"]; ok && defaultConn != nil {
-			auth := defaultConn.Auth
-			plugin.Auth = &auth
-			plugin.ConnectionMode = defaultConn.Mode
-			plugin.ConnectionParams = defaultConn.Params
-			plugin.Discovery = defaultConn.Discovery
+	}
+
+	var allConnections map[string]*ConnectionDef
+	if len(wire.Connections) > 0 {
+		allConnections = make(map[string]*ConnectionDef, len(wire.Connections))
+		for name, conn := range wire.Connections {
+			if conn == nil {
+				allConnections[name] = nil
+				continue
+			}
+			allConnections[name] = &ConnectionDef{
+				Mode:             conn.Mode,
+				Auth:             conn.Auth,
+				ConnectionParams: conn.Params,
+				Discovery:        conn.Discovery,
+			}
 		}
-		if len(wire.Connections) > 0 {
-			plugin.Connections = make(map[string]*ConnectionDef, len(wire.Connections))
-			for name, conn := range wire.Connections {
-				if name == "default" {
+	}
+
+	defaultConnName := wire.DefaultConnection
+	if defaultConnName == "" {
+		if _, ok := allConnections["default"]; ok {
+			defaultConnName = "default"
+		}
+	}
+
+	if plugin != nil && defaultConnName != "" {
+		if defConn, ok := allConnections[defaultConnName]; ok && defConn != nil {
+			auth := defConn.Auth
+			plugin.Auth = &auth
+			plugin.ConnectionMode = defConn.Mode
+			plugin.ConnectionParams = defConn.ConnectionParams
+			plugin.Discovery = defConn.Discovery
+		}
+		plugin.DefaultConnection = defaultConnName
+
+		if len(allConnections) > 0 {
+			plugin.Connections = make(map[string]*ConnectionDef, len(allConnections))
+			for name, conn := range allConnections {
+				if name == defaultConnName {
 					continue
 				}
-				if conn == nil {
-					plugin.Connections[name] = nil
-					continue
-				}
-				plugin.Connections[name] = &ConnectionDef{
-					Mode:             conn.Mode,
-					Auth:             conn.Auth,
-					ConnectionParams: conn.Params,
-					Discovery:        conn.Discovery,
-				}
+				plugin.Connections[name] = conn
 			}
 			if len(plugin.Connections) == 0 {
 				plugin.Connections = nil
 			}
 		}
+	} else if plugin != nil && len(allConnections) > 0 {
+		plugin.Connections = allConnections
 	}
 
 	*i = PluginDef{
-		Plugin:      plugin,
-		DisplayName: wire.DisplayName,
-		Description: wire.Description,
-		IconFile:    wire.IconFile,
-		Datastores:  wire.Datastores,
+		Plugin:            plugin,
+		DisplayName:       wire.DisplayName,
+		Description:       wire.Description,
+		IconFile:          wire.IconFile,
+		Datastores:        wire.Datastores,
+		DefaultConnection: defaultConnName,
+		Connections:       allConnections,
 	}
 	if wire.MCP != nil {
 		i.MCPToolPrefix = wire.MCP.ToolPrefix


### PR DESCRIPTION
## Summary

Stop hoisting the "default" connection onto ProviderDef fields during deserialization. All connections (including "default") now live in `PluginDef.Connections`. A new `defaultConnection` YAML field lets operators explicitly name the default. Backward-compat hoisting onto ProviderDef is preserved so downstream code continues to work unchanged.

## Before/After: YAML

**Before:** The connection named "default" is magic -- silently hoisted onto ProviderDef fields, behaving differently from all other connections.
```yaml
plugins:
  github:
    provider:
      source:
        ref: github.com/acme/github
        version: 1.0.0
    connections:
      default:                # magic: hoisted to plugin.Auth, plugin.ConnectionMode, etc.
        mode: user
        auth:
          type: oauth2
          clientId: ${GITHUB_CLIENT_ID}
          clientSecret: ${GITHUB_CLIENT_SECRET}
      readonly:               # normal: stored in plugin.Connections map
        mode: user
        auth:
          type: bearer
```

**After:** All connections are treated equally. Default is named explicitly.
```yaml
plugins:
  github:
    provider:
      source:
        ref: github.com/acme/github
        version: 1.0.0
    defaultConnection: primary
    connections:
      primary:                # just a name, not magic
        mode: user
        auth:
          type: oauth2
          clientId: ${GITHUB_CLIENT_ID}
          clientSecret: ${GITHUB_CLIENT_SECRET}
      readonly:
        mode: user
        auth:
          type: bearer
```

## Before/After: Go

**Before (provider_ref.go, hoisting logic):**
```go
// ProviderDef has 10 yaml:"-" fields populated by wire transform
type ProviderDef struct {
    Source       *PluginSourceDef  `yaml:"source"`
    Env          map[string]string `yaml:"env"`
    AllowedHosts []string          `yaml:"allowedHosts"`
    // Populated by UnmarshalYAML hoisting from "default" connection:
    Auth              *ConnectionAuthDef                `yaml:"-"`
    ConnectionMode    pluginmanifestv1.ConnectionMode   `yaml:"-"`
    Connections       map[string]*ConnectionDef         `yaml:"-"`
    ConnectionParams  map[string]ConnectionParamDef     `yaml:"-"`
    Discovery         *pluginmanifestv1.ProviderDiscovery `yaml:"-"`
}

// UnmarshalYAML hoists "default":
if defaultConn, ok := wire.Connections["default"]; ok {
    plugin.Auth = &defaultConn.Auth
    plugin.ConnectionMode = defaultConn.Mode
    // ... then skips "default" in loop
}
```

**After (connections on PluginDef):**
```go
type PluginDef struct {
    Plugin            *ProviderDef               `yaml:"plugin"`
    DisplayName       string                     `yaml:"displayName"`
    DefaultConnection string                     `yaml:"-"`  // NEW: explicit default
    Connections       map[string]*ConnectionDef  `yaml:"-"`  // NEW: all connections
    // ...
}

// UnmarshalYAML puts ALL connections into PluginDef.Connections.
// DefaultConnection set from explicit wire.DefaultConnection or "default" key.
// Backward compat: ProviderDef hoisted fields still populated from effective default.
```

## Behavior Change

`PluginDef.UnmarshalYAML` previously treated "default" as magic: its Auth, ConnectionMode, ConnectionParams, and Discovery were hoisted onto `ProviderDef`, while other connections went into a separate map. The YAML path `connections.default.auth` mapped to `plugin.Auth` internally. `EffectivePluginConnectionDef()` had to reassemble hoisted fields back into a `ConnectionDef`.

Now all connections (including "default") are stored in `PluginDef.Connections`. A new `defaultConnection` YAML field lets operators explicitly name the default. When omitted, "default" is still recognized for backward compatibility. The old `ProviderDef` hoisted fields are still populated from the effective default so all downstream code works unchanged.

## Test plan
- [x] `cd gestaltd && go build ./...`
- [x] `cd gestaltd && go test ./...`
- [x] Tests for implicit "default" key backward compat
- [x] Tests for explicit `defaultConnection` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)