### PR TITLE
Rename Rust SDK crate from gestalt_plugin_sdk to gestalt

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -117,7 +117,7 @@ jobs:
       component-summary: |
         Rust SDK for building Gestalt executable providers, including integration, auth, and datastore surfaces, against the shared protocol bindings in this repository.
       install-markdown: |
-        - Crate name: `gestalt_plugin_sdk`
+        - Crate name: `gestalt`
         - Crates.io publishing is not enabled for this release yet.
         - Consume the crate source from `sdk/rust` at tag `${tag}` until registry publishing is added.
 

--- a/docs/content/providers/auth.mdx
+++ b/docs/content/providers/auth.mdx
@@ -118,7 +118,6 @@ An auth provider implements three methods: `Configure`, `BeginLogin`, and `Compl
     ```rust
     use std::sync::Mutex;
 
-    use gestalt_plugin_sdk as gestalt;
     use gestalt::{AuthProvider, AuthenticatedUser, BeginLoginRequest, BeginLoginResponse, CompleteLoginRequest};
 
     pub struct MyAuth {

--- a/docs/content/providers/datastores.mdx
+++ b/docs/content/providers/datastores.mdx
@@ -85,8 +85,6 @@ A datastore provider implements the `IndexedDB` gRPC service, which maps to thes
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
-    use gestalt_plugin_sdk as gestalt;
-
     pub struct MyDatastore { /* database connection */ }
 
     #[gestalt::async_trait]

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -126,7 +126,7 @@ The manifest stays the source of truth for display name, description, auth, the 
     edition = "2024"
 
     [dependencies]
-    gestalt_plugin_sdk = { git = "https://github.com/valon-technologies/gestalt", tag = "sdk/rust/v0.0.1-alpha.1" }
+    gestalt = { git = "https://github.com/valon-technologies/gestalt", tag = "sdk/rust/v0.0.1-alpha.1" }
     schemars = { version = "0.8", features = ["derive"] }
     serde = { version = "1", features = ["derive"] }
     serde_json = "1"
@@ -296,7 +296,6 @@ Operations are the callable units of a plugin. Each operation has an ID, an HTTP
     ```rust
     use std::sync::{Arc, Mutex};
 
-    use gestalt_plugin_sdk as gestalt;
     use serde::{Deserialize, Serialize};
 
     pub struct Provider {

--- a/docs/content/providers/releasing.mdx
+++ b/docs/content/providers/releasing.mdx
@@ -84,7 +84,7 @@ packaging.
     edition = "2024"
 
     [dependencies]
-    gestalt_plugin_sdk = { git = "https://github.com/valon-technologies/gestalt", tag = "sdk/rust/v0.0.1-alpha.1" }
+    gestalt = { git = "https://github.com/valon-technologies/gestalt", tag = "sdk/rust/v0.0.1-alpha.1" }
     schemars = { version = "0.8", features = ["derive"] }
     serde = { version = "1", features = ["derive"] }
     serde_json = "1"

--- a/docs/content/providers/secrets.mdx
+++ b/docs/content/providers/secrets.mdx
@@ -84,7 +84,6 @@ A secrets provider implements two methods: `Configure` and `GetSecret`. `Configu
     ```rust
     use std::sync::Mutex;
 
-    use gestalt_plugin_sdk as gestalt;
     use gestalt::SecretsProvider;
 
     pub struct MySecrets {

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -478,7 +478,7 @@ Gestalt synthesizes Go and Rust executable wrappers automatically when needed an
     edition = "2024"
 
     [dependencies]
-    gestalt_plugin_sdk = { git = "https://github.com/valon-technologies/gestalt", tag = "sdk/rust/v0.0.1-alpha.1" }
+    gestalt = { git = "https://github.com/valon-technologies/gestalt", tag = "sdk/rust/v0.0.1-alpha.1" }
     schemars = { version = "0.8", features = ["derive"] }
     serde = { version = "1", features = ["derive"] }
     serde_json = "1"

--- a/gestaltd/internal/testutil/testdata/provider-rust-auth/Cargo.toml
+++ b/gestaltd/internal/testutil/testdata/provider-rust-auth/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2024"
 path = "src/lib.rs"
 
 [dependencies]
-gestalt_plugin_sdk = { path = "../../../../../sdk/rust" }
+gestalt = { path = "../../../../../sdk/rust" }

--- a/gestaltd/internal/testutil/testdata/provider-rust-auth/src/lib.rs
+++ b/gestaltd/internal/testutil/testdata/provider-rust-auth/src/lib.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use gestalt_plugin_sdk as gestalt;
 
 pub struct Provider;
 

--- a/gestaltd/internal/testutil/testdata/provider-rust-datastore/Cargo.toml
+++ b/gestaltd/internal/testutil/testdata/provider-rust-datastore/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2024"
 path = "src/lib.rs"
 
 [dependencies]
-gestalt_plugin_sdk = { path = "../../../../../sdk/rust" }
+gestalt = { path = "../../../../../sdk/rust" }
 prost-types = "0.14"

--- a/gestaltd/internal/testutil/testdata/provider-rust-datastore/src/lib.rs
+++ b/gestaltd/internal/testutil/testdata/provider-rust-datastore/src/lib.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use gestalt_plugin_sdk as gestalt;
 use prost_types::Timestamp;
 
 pub struct Provider {

--- a/gestaltd/internal/testutil/testdata/provider-rust/Cargo.toml
+++ b/gestaltd/internal/testutil/testdata/provider-rust/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 path = "src/lib.rs"
 
 [dependencies]
-gestalt_plugin_sdk = { path = "../../../../../sdk/rust" }
+gestalt = { path = "../../../../../sdk/rust" }
 schemars = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/gestaltd/internal/testutil/testdata/provider-rust/src/lib.rs
+++ b/gestaltd/internal/testutil/testdata/provider-rust/src/lib.rs
@@ -1,6 +1,5 @@
 use std::sync::{Arc, Mutex};
 
-use gestalt_plugin_sdk as gestalt;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Value as JsonValue};

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "gestalt_plugin_sdk"
+name = "gestalt"
 version = "0.0.1-alpha.1"
 edition = "2024"
 rust-version = "1.85"

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -4,7 +4,7 @@ This directory contains the Rust SDK for Gestalt executable providers.
 
 Current scope:
 
-- standalone Cargo package named `gestalt_plugin_sdk`
+- standalone Cargo package named `gestalt`
 - build-time protobuf/gRPC generation from `sdk/proto/v1/*.proto`
 - vendored `protoc` via `protoc-bin-vendored`
 - generated protocol bindings exposed via `proto::v1`

--- a/sdk/rust/tests/component_transport.rs
+++ b/sdk/rust/tests/component_transport.rs
@@ -6,13 +6,13 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use gestalt_plugin_sdk::proto::v1::auth_provider_client::AuthProviderClient;
-use gestalt_plugin_sdk::proto::v1::provider_lifecycle_client::ProviderLifecycleClient;
-use gestalt_plugin_sdk::proto::v1::{
+use gestalt::proto::v1::auth_provider_client::AuthProviderClient;
+use gestalt::proto::v1::provider_lifecycle_client::ProviderLifecycleClient;
+use gestalt::proto::v1::{
     BeginLoginRequest, CompleteLoginRequest, ConfigureProviderRequest, ProviderKind,
     ValidateExternalTokenRequest,
 };
-use gestalt_plugin_sdk::{AuthProvider, RuntimeMetadata};
+use gestalt::{AuthProvider, RuntimeMetadata};
 use hyper_util::rt::tokio::TokioIo;
 use tokio::net::UnixStream;
 use tonic::Code;
@@ -38,7 +38,7 @@ impl AuthProvider for TestAuthProvider {
         &self,
         name: &str,
         _config: serde_json::Map<String, serde_json::Value>,
-    ) -> gestalt_plugin_sdk::Result<()> {
+    ) -> gestalt::Result<()> {
         *self.configured_name.lock().expect("lock configured_name") = name.to_string();
         Ok(())
     }
@@ -59,8 +59,8 @@ impl AuthProvider for TestAuthProvider {
     async fn begin_login(
         &self,
         req: BeginLoginRequest,
-    ) -> gestalt_plugin_sdk::Result<gestalt_plugin_sdk::BeginLoginResponse> {
-        Ok(gestalt_plugin_sdk::BeginLoginResponse {
+    ) -> gestalt::Result<gestalt::BeginLoginResponse> {
+        Ok(gestalt::BeginLoginResponse {
             authorization_url: format!("https://example.com/login?state={}", req.host_state),
             provider_state: b"provider-state".to_vec(),
         })
@@ -69,8 +69,8 @@ impl AuthProvider for TestAuthProvider {
     async fn complete_login(
         &self,
         req: CompleteLoginRequest,
-    ) -> gestalt_plugin_sdk::Result<gestalt_plugin_sdk::AuthenticatedUser> {
-        Ok(gestalt_plugin_sdk::AuthenticatedUser {
+    ) -> gestalt::Result<gestalt::AuthenticatedUser> {
+        Ok(gestalt::AuthenticatedUser {
             subject: "sub_123".to_string(),
             email: req
                 .query
@@ -87,9 +87,9 @@ impl AuthProvider for TestAuthProvider {
     async fn validate_external_token(
         &self,
         token: &str,
-    ) -> gestalt_plugin_sdk::Result<Option<gestalt_plugin_sdk::AuthenticatedUser>> {
+    ) -> gestalt::Result<Option<gestalt::AuthenticatedUser>> {
         if token == "external-token" {
-            return Ok(Some(gestalt_plugin_sdk::AuthenticatedUser {
+            return Ok(Some(gestalt::AuthenticatedUser {
                 subject: "sub_external".to_string(),
                 email: "external@example.com".to_string(),
                 email_verified: true,
@@ -111,12 +111,12 @@ async fn serves_auth_provider_and_runtime_over_unix_socket() {
     let _env_lock = helpers::env_lock().lock().await;
     let socket = helpers::temp_socket("gestalt-rust-auth.sock");
     let _socket_guard =
-        helpers::EnvGuard::set(gestalt_plugin_sdk::ENV_PROVIDER_SOCKET, socket.as_os_str());
+        helpers::EnvGuard::set(gestalt::ENV_PROVIDER_SOCKET, socket.as_os_str());
 
     let provider = Arc::new(TestAuthProvider::default());
     let serve_provider = Arc::clone(&provider);
     let serve_task = tokio::spawn(async move {
-        gestalt_plugin_sdk::runtime::serve_auth_provider(serve_provider)
+        gestalt::runtime::serve_auth_provider(serve_provider)
             .await
             .expect("serve auth provider");
     });
@@ -147,14 +147,14 @@ async fn serves_auth_provider_and_runtime_over_unix_socket() {
             config: Some(helpers::struct_from_json(
                 serde_json::json!({ "issuer": "https://issuer" }),
             )),
-            protocol_version: gestalt_plugin_sdk::CURRENT_PROTOCOL_VERSION,
+            protocol_version: gestalt::CURRENT_PROTOCOL_VERSION,
         })
         .await
         .expect("configure provider")
         .into_inner();
     assert_eq!(
         configured.protocol_version,
-        gestalt_plugin_sdk::CURRENT_PROTOCOL_VERSION
+        gestalt::CURRENT_PROTOCOL_VERSION
     );
 
     let begin = auth

--- a/sdk/rust/tests/component_transport.rs
+++ b/sdk/rust/tests/component_transport.rs
@@ -110,8 +110,7 @@ impl AuthProvider for TestAuthProvider {
 async fn serves_auth_provider_and_runtime_over_unix_socket() {
     let _env_lock = helpers::env_lock().lock().await;
     let socket = helpers::temp_socket("gestalt-rust-auth.sock");
-    let _socket_guard =
-        helpers::EnvGuard::set(gestalt::ENV_PROVIDER_SOCKET, socket.as_os_str());
+    let _socket_guard = helpers::EnvGuard::set(gestalt::ENV_PROVIDER_SOCKET, socket.as_os_str());
 
     let provider = Arc::new(TestAuthProvider::default());
     let serve_provider = Arc::clone(&provider);

--- a/sdk/rust/tests/router.rs
+++ b/sdk/rust/tests/router.rs
@@ -4,16 +4,15 @@ mod helpers;
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
-use gestalt_plugin_sdk as gestalt;
-use gestalt_plugin_sdk::proto::v1::integration_provider_server::IntegrationProvider;
-use gestalt_plugin_sdk::proto::v1::{ExecuteRequest, StartProviderRequest};
+use gestalt::proto::v1::integration_provider_server::IntegrationProvider;
+use gestalt::proto::v1::{ExecuteRequest, StartProviderRequest};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Value as JsonValue, json};
 use tonic::Request as GrpcRequest;
 use tonic::codegen::async_trait;
 
-use gestalt_plugin_sdk::{Operation, Provider, Request, Response, Router, ok};
+use gestalt::{Operation, Provider, Request, Response, Router, ok};
 
 #[derive(Default)]
 struct TestProvider;

--- a/sdk/rust/tests/transport.rs
+++ b/sdk/rust/tests/transport.rs
@@ -3,11 +3,11 @@ mod helpers;
 
 use std::sync::{Arc, Mutex};
 
-use gestalt_plugin_sdk::proto::v1::integration_provider_client::IntegrationProviderClient;
-use gestalt_plugin_sdk::proto::v1::{
+use gestalt::proto::v1::integration_provider_client::IntegrationProviderClient;
+use gestalt::proto::v1::{
     ExecuteRequest, GetSessionCatalogRequest, PostConnectRequest, StartProviderRequest,
 };
-use gestalt_plugin_sdk::{
+use gestalt::{
     Catalog, CatalogOperation, Operation, Provider, Request, Response, Router, ok,
 };
 use hyper_util::rt::tokio::TokioIo;
@@ -28,7 +28,7 @@ impl Provider for TestProvider {
         &self,
         _name: &str,
         config: serde_json::Map<String, serde_json::Value>,
-    ) -> gestalt_plugin_sdk::Result<()> {
+    ) -> gestalt::Result<()> {
         let greeting = config
             .get("greeting")
             .and_then(serde_json::Value::as_str)
@@ -45,7 +45,7 @@ impl Provider for TestProvider {
     async fn catalog_for_request(
         &self,
         request: &Request,
-    ) -> gestalt_plugin_sdk::Result<Option<Catalog>> {
+    ) -> gestalt::Result<Option<Catalog>> {
         Ok(Some(Catalog {
             name: "session-example".to_string(),
             display_name: request
@@ -88,7 +88,7 @@ async fn serves_provider_requests_over_unix_socket() {
     let _env_lock = helpers::env_lock().lock().await;
     let socket = helpers::temp_socket("gestalt-rust-sdk.sock");
     let _socket_guard =
-        helpers::EnvGuard::set(gestalt_plugin_sdk::ENV_PROVIDER_SOCKET, socket.as_os_str());
+        helpers::EnvGuard::set(gestalt::ENV_PROVIDER_SOCKET, socket.as_os_str());
 
     let router = Router::new()
         .register(
@@ -106,7 +106,7 @@ async fn serves_provider_requests_over_unix_socket() {
     let serve_provider = Arc::clone(&provider);
     let serve_router = router.clone();
     let serve_task = tokio::spawn(async move {
-        gestalt_plugin_sdk::runtime::serve_provider(serve_provider, serve_router)
+        gestalt::runtime::serve_provider(serve_provider, serve_router)
             .await
             .expect("serve provider");
     });
@@ -134,11 +134,11 @@ async fn serves_provider_requests_over_unix_socket() {
     assert!(metadata.supports_session_catalog);
     assert_eq!(
         metadata.min_protocol_version,
-        gestalt_plugin_sdk::CURRENT_PROTOCOL_VERSION
+        gestalt::CURRENT_PROTOCOL_VERSION
     );
     assert_eq!(
         metadata.max_protocol_version,
-        gestalt_plugin_sdk::CURRENT_PROTOCOL_VERSION
+        gestalt::CURRENT_PROTOCOL_VERSION
     );
 
     let started = client
@@ -147,14 +147,14 @@ async fn serves_provider_requests_over_unix_socket() {
             config: Some(helpers::struct_from_json(
                 serde_json::json!({ "greeting": "Hi" }),
             )),
-            protocol_version: gestalt_plugin_sdk::CURRENT_PROTOCOL_VERSION,
+            protocol_version: gestalt::CURRENT_PROTOCOL_VERSION,
         })
         .await
         .expect("start provider")
         .into_inner();
     assert_eq!(
         started.protocol_version,
-        gestalt_plugin_sdk::CURRENT_PROTOCOL_VERSION
+        gestalt::CURRENT_PROTOCOL_VERSION
     );
 
     let response = client

--- a/sdk/rust/tests/transport.rs
+++ b/sdk/rust/tests/transport.rs
@@ -7,9 +7,7 @@ use gestalt::proto::v1::integration_provider_client::IntegrationProviderClient;
 use gestalt::proto::v1::{
     ExecuteRequest, GetSessionCatalogRequest, PostConnectRequest, StartProviderRequest,
 };
-use gestalt::{
-    Catalog, CatalogOperation, Operation, Provider, Request, Response, Router, ok,
-};
+use gestalt::{Catalog, CatalogOperation, Operation, Provider, Request, Response, Router, ok};
 use hyper_util::rt::tokio::TokioIo;
 use tokio::net::UnixStream;
 use tonic::Code;
@@ -42,10 +40,7 @@ impl Provider for TestProvider {
         true
     }
 
-    async fn catalog_for_request(
-        &self,
-        request: &Request,
-    ) -> gestalt::Result<Option<Catalog>> {
+    async fn catalog_for_request(&self, request: &Request) -> gestalt::Result<Option<Catalog>> {
         Ok(Some(Catalog {
             name: "session-example".to_string(),
             display_name: request
@@ -87,8 +82,7 @@ struct Output {
 async fn serves_provider_requests_over_unix_socket() {
     let _env_lock = helpers::env_lock().lock().await;
     let socket = helpers::temp_socket("gestalt-rust-sdk.sock");
-    let _socket_guard =
-        helpers::EnvGuard::set(gestalt::ENV_PROVIDER_SOCKET, socket.as_os_str());
+    let _socket_guard = helpers::EnvGuard::set(gestalt::ENV_PROVIDER_SOCKET, socket.as_os_str());
 
     let router = Router::new()
         .register(
@@ -152,10 +146,7 @@ async fn serves_provider_requests_over_unix_socket() {
         .await
         .expect("start provider")
         .into_inner();
-    assert_eq!(
-        started.protocol_version,
-        gestalt::CURRENT_PROTOCOL_VERSION
-    );
+    assert_eq!(started.protocol_version, gestalt::CURRENT_PROTOCOL_VERSION);
 
     let response = client
         .execute(ExecuteRequest {


### PR DESCRIPTION
## Summary
- Renames the Rust SDK crate from `gestalt_plugin_sdk` to `gestalt`, aligning it with the Python, Go, and TypeScript SDKs which already use `gestalt` as their package name
- Updates all 18 files that referenced the old name: SDK core (Cargo.toml, README, tests), gestaltd test provider fixtures, documentation code samples, and CI release notes
- Removes the now-redundant `use gestalt_plugin_sdk as gestalt;` alias lines since the crate itself is named `gestalt`

## Test plan
- [x] `cargo check` passes in `sdk/rust/`
- [x] `cargo test` passes in `sdk/rust/` (8/8 tests)
- [x] `cargo check` passes for `provider-rust` test fixture
- [x] `cargo check` passes for `provider-rust-auth` test fixture
- [ ] `provider-rust-datastore` has a pre-existing build failure (references `DatastoreProvider`, `StoredUser`, etc. which are not yet implemented in the SDK)
- [x] `grep -r gestalt_plugin_sdk .` returns zero matches