### PR TITLE
docs: fix datastore SDK snippets and IndexedDB preface

### DIFF
--- a/docs/content/architecture/index.mdx
+++ b/docs/content/architecture/index.mdx
@@ -18,13 +18,13 @@ Once the secret manager is ready, Gestalt resolves every `secret://` reference a
 
 With secrets resolved, `server.encryptionKey` gets converted into a 32-byte AES key. A 64-character hex string is decoded directly; anything else goes through Argon2id derivation. This derived key protects all stored tokens.
 
-From there, the auth and datastore providers are spawned as child processes over gRPC, schema migrations run, integration plugins start, and the HTTP listeners come up. The `/ready` endpoint returns 503 until everything reports ready.
+From there, the auth and datastore providers are spawned as child processes over gRPC, schema migrations run, plugins start, and the HTTP listeners come up. The `/ready` endpoint returns 503 until everything reports ready.
 
 ## How requests flow
 
 Auth middleware runs first on every request. It checks for a `session_token` cookie, then for a `Bearer` header. If the bearer token starts with `gst_api_`, it's hashed with SHA-256 and looked up in the datastore. Any other bearer value is treated as a raw provider token.
 
-For operation invocations (`/api/v1/{integration}/{operation}` or `/mcp`), the request reaches the *broker*. The broker resolves the caller's integration token from the datastore, decrypts it, refreshes it if needed, and dispatches to the plugin (over gRPC, or to a REST/GraphQL/MCP upstream). The same broker handles both HTTP and MCP calls.
+For operation invocations (`/api/v1/{integration}/{operation}` or `/mcp`), the request reaches the *broker*. The broker resolves the caller's plugin token from the datastore, decrypts it, refreshes it if needed, and dispatches to the plugin (over gRPC, or to a REST/GraphQL/MCP upstream). The same broker handles both HTTP and MCP calls.
 
 ## Further reading
 

--- a/docs/content/architecture/security-internals.mdx
+++ b/docs/content/architecture/security-internals.mdx
@@ -18,7 +18,7 @@ All credential encryption uses AES-256-GCM, an authenticated mode that protects 
 
 Each encryption generates a fresh 12-byte nonce via `crypto/rand`, encrypts the plaintext, prepends the nonce to the ciphertext, and base64-encodes the result for storage. Tampered ciphertexts are detected at decryption. Access and refresh tokens are encrypted independently, each with their own nonce.
 
-## Integration token lifecycle
+## Plugin token lifecycle
 
 ### Creation
 

--- a/docs/content/audit-logging.mdx
+++ b/docs/content/audit-logging.mdx
@@ -8,7 +8,7 @@ backend without having to reconstruct behavior from mixed application logs.
 
 ## Coverage
 
-Audit events cover HTTP and MCP operation invocations, other guarded runtime surfaces such as binding hooks, login and logout flows, integration connect and disconnect flows, and API token lifecycle. Each event carries a `source` field (`http`, `mcp`, or a surface-specific value like `binding:...`) so consumers can filter by surface.
+Audit events cover HTTP and MCP operation invocations, other guarded runtime surfaces such as binding hooks, login and logout flows, plugin connect and disconnect flows, and API token lifecycle. Each event carries a `source` field (`http`, `mcp`, or a surface-specific value like `binding:...`) so consumers can filter by surface.
 
 `gestaltd` resolves the authenticated user ID before emitting session-backed audit events, so both session requests and API-token requests produce stable `user_id` values when a user identity exists.
 
@@ -22,7 +22,7 @@ Every audit record includes:
 | `event_time` | Event timestamp |
 | `request_id` | Request-scoped correlation ID |
 | `source` | Surface that emitted the event, such as `http`, `mcp`, or `binding:...` |
-| `provider` | Integration key for provider-scoped events |
+| `provider` | Plugin key for provider-scoped events |
 | `operation` | Operation or event name |
 | `depth` | Invocation depth for guarded invocation events |
 | `allowed` | Whether `gestaltd` allowed or completed the audited action |
@@ -41,7 +41,7 @@ These fields are emitted when available:
 | `span_id` | Active OpenTelemetry span ID |
 
 For platform-level events such as API-token CRUD, `provider` is empty because
-the event is not tied to a specific integration.
+the event is not tied to a specific plugin.
 
 ## Event Names
 

--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -4,7 +4,7 @@ asIndexPage: true
 
 # CLI
 
-`gestalt` is the client CLI for interacting with a running `gestaltd` server. It handles authentication, integration connections, operation invocation, and API token management. A [Docker image](/client/cli/docker) is also available for CI and containerized environments.
+`gestalt` is the client CLI for interacting with a running `gestaltd` server. It handles authentication, plugin connections, operation invocation, and API token management. A [Docker image](/client/cli/docker) is also available for CI and containerized environments.
 
 ## Global flags
 
@@ -22,9 +22,9 @@ asIndexPage: true
 | `gestalt auth status` | Show current auth state and server connectivity. |
 | `gestalt init` | Run the interactive setup wizard. |
 | `gestalt config get\|set\|unset\|list` | Manage the local client config. |
-| `gestalt integrations list` | List integrations from the server. |
-| `gestalt integrations connect NAME` | Connect an integration through OAuth or interactive manual auth. |
-| `gestalt integrations disconnect NAME` | Disconnect an integration, removing stored credentials. |
+| `gestalt integrations list` | List plugins from the server. |
+| `gestalt integrations connect NAME` | Connect a plugin through OAuth or interactive manual auth. |
+| `gestalt integrations disconnect NAME` | Disconnect a plugin, removing stored credentials. |
 | `gestalt invoke INTEGRATION [OPERATION]` | Invoke an operation or list operations when omitted. |
 | `gestalt describe INTEGRATION OPERATION` | Show one operation's parameter contract. |
 | `gestalt tokens create\|list\|revoke` | Manage Gestalt API tokens. |
@@ -56,11 +56,11 @@ For auth, the CLI checks `GESTALT_API_KEY` first, then stored credentials from `
 
 The CLI searches the current directory and then parent directories until it finds the nearest `.gestalt/config.json`.
 
-## Integration connect flags
+## Plugin connect flags
 
 `gestalt integrations connect NAME` accepts `--connection` and `--instance`. When the selected connection uses manual auth instead of OAuth, the CLI prompts for the required credential fields and connection parameters.
 
-## Integration disconnect flags
+## Plugin disconnect flags
 
 `gestalt integrations disconnect NAME` accepts `--connection` and `--instance` to target a specific named connection or stored instance. When both are omitted, the default connection is disconnected.
 

--- a/docs/content/client/web.mdx
+++ b/docs/content/client/web.mdx
@@ -2,17 +2,17 @@
 
 Open your Gestalt server's base URL in a browser to access the web client. For a local server, that's `http://localhost:8080`.
 
-The web UI lets you browse integrations, connect to upstream services through OAuth or manual auth, invoke operations, and manage API tokens. It uses the same HTTP API and authentication model as the CLI.
+The web UI lets you browse plugins, connect to upstream services through OAuth or manual auth, invoke operations, and manage API tokens. It uses the same HTTP API and authentication model as the CLI.
 
 ## Dashboard
 
-The dashboard shows an overview of the workspace with integration and API token counts.
+The dashboard shows an overview of the workspace with plugin and API token counts.
 
 ![Dashboard](/images/web-dashboard.png)
 
-## Integrations
+## Plugins
 
-The integrations page lists all configured providers. Connected integrations show a green checkmark. Click the settings icon to manage connections or disconnect.
+The plugins page lists all configured providers. Connected plugins show a green checkmark. Click the settings icon to manage connections or disconnect.
 
 ![Integrations](/images/web-integrations.png)
 

--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -35,22 +35,22 @@ A config file has the following top-level blocks:
 
 - `server` controls the HTTP listener, base URL, encryption key, API token TTL, and prepared artifacts directory.
 - `auth` selects the platform login provider for the web UI, HTTP API, and `/mcp`.
-- `datastore` selects persistent storage for users, sessions, API tokens, and integration credentials.
+- `datastore` selects persistent storage for users, sessions, API tokens, and plugin credentials.
 - `secrets` configures resolution for `secret://` references.
 - `telemetry` configures structured logs, metrics, traces, and OTLP export.
-- `plugins` declares the integrations users invoke.
+- `plugins` declares the plugins users invoke.
 - `egress` defines outbound policy rules and credential grants (optional).
 - `ui` references a packaged web UI bundle (optional).
 
 ## Defaults and required fields
 
-Gestalt defaults `server.port` to `8080`, `secrets.provider` to `env`, and `telemetry.provider` to `stdout`. The required fields are `datastore.provider` and `server.encryptionKey`. Platform auth is optional.
+Gestalt defaults `server.public.port` to `8080`, `secrets.provider` to `env`, and `telemetry.provider` to `stdout`. The required fields are `datastore.provider` and `server.encryptionKey`. Platform auth is optional.
 
 `server.encryptionKey` is the root deployment secret. Gestalt derives token encryption and session material from it. Changing this key invalidates all existing sessions and tokens, so treat it as a meaningful deployment event.
 
 ## Plugins
 
-Each entry under `plugins:` registers an integration backed by a provider package. The provider package is the source of truth for available operations, request schemas, and response schemas. The config supplies only provider selection, provider-level config, connection policy, and MCP exposure settings.
+Each entry under `plugins:` registers a plugin backed by a provider package. The provider package is the source of truth for available operations, request schemas, and response schemas. The config supplies only provider selection, provider-level config, connection policy, and MCP exposure settings.
 
 A provider package can come from two places: a versioned published package resolved by `source.ref`, or a local source manifest at `source.path` for development.
 
@@ -130,7 +130,7 @@ Each entry can set an `alias` to rename the operation as it appears to callers.
 
 ### Network sandbox
 
-Executable provider processes run inside a network sandbox. Outbound requests to hosts not listed in `provider.allowedHosts` are rejected. Add every upstream domain the integration plugin contacts to the allowlist.
+Executable provider processes run inside a network sandbox. Outbound requests to hosts not listed in `provider.allowedHosts` are rejected. Add every upstream domain the plugin contacts to the allowlist.
 
 ```yaml
 plugins:
@@ -166,7 +166,7 @@ Gestalt stores upstream credentials keyed by user, plugin name, connection name,
 
 ## Auth
 
-The `auth` block selects a platform login provider that protects the web UI, HTTP API, and `/mcp` endpoint. Auth providers run as external gRPC provider processes, following the same architecture as integration plugins.
+The `auth` block selects a platform login provider that protects the web UI, HTTP API, and `/mcp` endpoint. Auth providers run as external gRPC provider processes, following the same architecture as plugins.
 
 For local development, omit the `auth` block entirely or use the `none` shorthand:
 
@@ -191,7 +191,7 @@ auth:
     clientSecret: secret://oidc-client-secret
 ```
 
-The `auth.provider` field is a provider reference with `source.ref` and `version`, the same shape used for integration plugins. The `none` scalar shorthand is the only exception.
+The `auth.provider` field is a provider reference with `source.ref` and `version`, the same shape used for plugins. The `none` scalar shorthand is the only exception.
 
 ### API tokens
 
@@ -199,7 +199,7 @@ For programmatic access, Gestalt issues API tokens prefixed with `gst_api_`. The
 
 ## Datastore
 
-The `datastore` block selects persistent storage for users, sessions, API tokens, and integration credentials. Like auth, the datastore runs as an external gRPC provider process.
+The `datastore` block selects persistent storage for users, sessions, API tokens, and plugin credentials. Like auth, the datastore runs as an external gRPC provider process.
 
 ```yaml
 datastore:
@@ -211,7 +211,7 @@ datastore:
     path: ./gestalt.db
 ```
 
-`datastore.provider` is required. The `source.ref` and `version` fields work the same as for integration and auth providers. Provider-specific settings go in `datastore.config`.
+`datastore.provider` is required. The `source.ref` and `version` fields work the same as for plugin and auth providers. Provider-specific settings go in `datastore.config`.
 
 ## MCP
 
@@ -377,7 +377,8 @@ The smallest useful config sets up a local server with SQLite storage, no auth, 
 
 ```yaml
 server:
-  port: 8080
+  public:
+    port: 8080
   baseUrl: http://localhost:8080
   encryptionKey: change-me
 

--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -24,7 +24,8 @@ The generated config is fine for a first look, but let's write one explicitly so
 
 ```yaml
 server:
-  port: 8080
+  public:
+    port: 8080
   baseUrl: http://localhost:8080
   encryptionKey: dev-only-change-me
 
@@ -52,11 +53,12 @@ gestaltd serve --config ./config.yaml
 
 ## Add a plugin
 
-Plugins are where the interesting things happen. Each entry under `plugins:` registers an integration backed by a provider package. Let's add the first-party `httpbin` provider, which wraps httpbin.org and is useful for testing:
+Plugins are where the interesting things happen. Each entry under `plugins:` registers a plugin backed by a provider package. Let's add the first-party `httpbin` provider, which wraps httpbin.org and is useful for testing:
 
 ```yaml
 server:
-  port: 8080
+  public:
+    port: 8080
   baseUrl: http://localhost:8080
   encryptionKey: dev-only-change-me
 
@@ -98,7 +100,7 @@ The wizard prompts for the server URL and saves it to your local config. You can
 gestalt config set url http://localhost:8080
 ```
 
-Verify the connection by listing available integrations:
+Verify the connection by listing available plugins:
 
 ```sh
 gestalt integrations list
@@ -108,7 +110,7 @@ You should see `httpbin` in the output.
 
 ## Invoke an operation
 
-List the operations available on the httpbin integration:
+List the operations available on the httpbin plugin:
 
 ```sh
 gestalt invoke httpbin
@@ -127,6 +129,37 @@ curl http://localhost:8080/api/v1/httpbin/get_headers
 ```
 
 Both return the same response from the provider.
+
+## Complete config
+
+Here is the full config from this tutorial, ready to copy:
+
+```yaml
+server:
+  public:
+    port: 8080
+  baseUrl: http://localhost:8080
+  encryptionKey: dev-only-change-me
+
+auth:
+  provider: none
+
+datastore:
+  provider:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/datastore/sqlite
+      version: 0.0.1-alpha.1
+  config:
+    path: ./gestalt.db
+
+plugins:
+  httpbin:
+    displayName: HTTPBin
+    provider:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/plugins/httpbin
+        version: 0.0.1-alpha.1
+```
 
 ## Next steps
 

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -14,19 +14,19 @@ exposed through the HTTP API, web UI, and `/mcp`.
 
 ## How it works
 
-You define integration plugins in a YAML config, connect users or shared identities to upstream systems through OAuth or manual auth, then invoke the same catalog through the browser, HTTP API, CLI, or MCP. Auth providers, datastore providers, and integration plugins all run as providers with the same runtime model, whether they come from a local source tree or a published package.
+You define plugins in a YAML config, connect users or shared identities to upstream systems through OAuth or manual auth, then invoke the same catalog through the browser, HTTP API, CLI, or MCP. Auth providers, datastore providers, and plugins all run as providers with the same runtime model, whether they come from a local source tree or a published package.
 
 ## Start here
 
 <Cards>
   <Cards.Card title="Getting Started" href="/getting-started">
-    Run Gestalt locally, invoke a sample integration, and verify the core flow.
+    Run Gestalt locally, invoke a sample plugin, and verify the core flow.
   </Cards.Card>
   <Cards.Card title="Configuration" href="/configuration">
-    Learn the configuration model, integration setup, auth, connections, and MCP.
+    Learn the configuration model, plugin setup, auth, connections, and MCP.
   </Cards.Card>
   <Cards.Card title="Providers" href="/providers">
-    Write, release, and configure providers for integrations, auth, datastores, and custom UIs.
+    Write, release, and configure providers for plugins, auth, datastores, and custom UIs.
   </Cards.Card>
   <Cards.Card title="Security" href="/security">
     Review trust boundaries, encryption, headers, and token handling.

--- a/docs/content/install/binary.mdx
+++ b/docs/content/install/binary.mdx
@@ -6,7 +6,7 @@ Pre-built binaries are published for every release on GitHub.
 
 ## Server
 
-`gestaltd` is the long-running process that manages authentication and integrations.
+`gestaltd` is the long-running process that manages authentication and plugins.
 
 ### Install
 

--- a/docs/content/install/homebrew.mdx
+++ b/docs/content/install/homebrew.mdx
@@ -6,7 +6,7 @@ If you need a direct-download install or a Linux-specific release artifact, see 
 
 ## Server
 
-`gestaltd` is the long-running process that manages authentication and integrations.
+`gestaltd` is the long-running process that manages authentication and plugins.
 
 ### Install
 

--- a/docs/content/install/source.mdx
+++ b/docs/content/install/source.mdx
@@ -4,7 +4,7 @@ You can compile Gestalt directly from the Git repository.
 
 ## Server
 
-`gestaltd` is the long-running process that manages authentication and integrations.
+`gestaltd` is the long-running process that manages authentication and plugins.
 
 Building the server requires Go 1.26 or later.
 

--- a/docs/content/observability.mdx
+++ b/docs/content/observability.mdx
@@ -133,7 +133,7 @@ These metrics are recorded around `broker.invoke`.
 </Tabs>
 
 These metrics carry low-cardinality attributes: `gestalt.provider` (the
-integration key), `gestalt.operation` (the catalog operation id),
+plugin key), `gestalt.operation` (the catalog operation id),
 `gestalt.transport` (how the operation is implemented: `plugin`, `rest`, or
 `mcp-passthrough`), and `gestalt.connection_mode` (the provider auth mode:
 `none`, `user`, `identity`, or `either`).
@@ -143,7 +143,7 @@ When a request references an unknown provider or operation, `gestaltd` records
 
 ### Connection Auth Metrics
 
-These metrics are recorded around integration connection auth flows including
+These metrics are recorded around plugin connection auth flows including
 OAuth start and completion, manual connect, and token refresh.
 
 <Tabs items={['OpenTelemetry', 'Prometheus']}>
@@ -164,12 +164,12 @@ OAuth start and completion, manual connect, and token refresh.
 </Tabs>
 
 These metrics carry low-cardinality attributes: `gestalt.provider` (the
-integration key), `gestalt.type` (`oauth` or `manual`),
+plugin key), `gestalt.type` (`oauth` or `manual`),
 `gestalt.action` (`start`, `complete`, or `refresh`), and
 `gestalt.connection_mode` (the provider auth mode: `none`, `user`,
 `identity`, or `either`).
 
-When a request references an unknown integration, `gestaltd` records
+When a request references an unknown plugin, `gestaltd` records
 `unknown` for the provider and connection mode metric attributes instead of
 using raw request input.
 
@@ -251,7 +251,7 @@ need actor, target, and outcome details.
 
 The built-in `gestaltd` metric surface does not yet emit per-operation upstream
 HTTP `status_code` or `status_class` metrics, nor deduplicated DAU, WAU, or MAU
-analytics for users or integrations. Those need separate semantic decisions or
+analytics for users or plugins. Those need separate semantic decisions or
 an analytics pipeline instead of more process-local counters.
 
 ### HTTP Server Metrics

--- a/docs/content/providers/datastores.mdx
+++ b/docs/content/providers/datastores.mdx
@@ -64,7 +64,7 @@ A datastore provider implements the `IndexedDB` gRPC service, which maps to thes
     // IndexGet, IndexGetKey, IndexGetAll, IndexGetAllKeys, IndexCount, IndexDelete
 
     func main() {
-    	gestalt.ServeDatastoreProvider(context.Background(), &MyDatastore{})
+    	gestalt.ServeIndexedDBProvider(context.Background(), &MyDatastore{})
     }
     ```
   </Tabs.Tab>
@@ -116,13 +116,20 @@ A datastore provider implements the `IndexedDB` gRPC service, which maps to thes
   </Tabs.Tab>
 </Tabs>
 
-## Plugin SDK (consuming datastores)
+## Plugin SDK
 
 Plugins access datastores through the SDK. The host serves the IndexedDB interface over a gRPC socket, and the SDK wraps it into native types for each language.
 
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
+    import (
+        "context"
+        "log"
+
+        gestalt "github.com/valon-technologies/gestalt/sdk/go"
+    )
+
     db, err := gestalt.IndexedDB()
     if err != nil {
         log.Fatal(err)
@@ -157,6 +164,8 @@ Plugins access datastores through the SDK. The host serves the IndexedDB interfa
   </Tabs.Tab>
   <Tabs.Tab>
     ```python
+    import gestalt
+
     db = gestalt.IndexedDB()
 
     # Create an object store with indexes
@@ -184,6 +193,9 @@ Plugins access datastores through the SDK. The host serves the IndexedDB interfa
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
+    use gestalt_plugin_sdk as gestalt;
+    use serde_json::json;
+
     let mut db = gestalt::IndexedDB::connect().await?;
 
     // Create an object store with indexes

--- a/docs/content/providers/datastores.mdx
+++ b/docs/content/providers/datastores.mdx
@@ -2,9 +2,11 @@ import { Tabs } from 'nextra/components'
 
 # Datastores
 
-Datastore providers back the persistent state layer using an IndexedDB-inspired interface. Every provider implements the same set of operations -- object stores with primary key CRUD, named indexes for queries, and key ranges for scoped operations. The storage backend is fully replaceable: swap from SQLite to Postgres to MongoDB without changing any application code.
+Datastore providers back the persistent state layer using an interface modeled on the [IndexedDB API](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API). IndexedDB's vocabulary of object stores, primary keys, named indexes, and key ranges maps naturally onto SQL tables, document collections, and key-value stores alike, so a single provider contract can target Postgres, SQLite, MongoDB, DynamoDB, and others without leaking backend-specific abstractions. Building on an established open-source convention means the concepts are already documented, widely understood, and proven to cover the access patterns most applications need.
 
-Gestalt stores users, integration tokens, API tokens, and OAuth registrations through the datastore. The host encrypts all integration tokens before storage using AES-256-GCM, so the datastore stores sealed bytes without needing access to the encryption key. API tokens are stored as one-way SHA-256 hashes.
+Every provider implements the same set of operations -- object stores with primary key CRUD, named indexes for queries, and key ranges for scoped operations. The storage backend is fully replaceable: swap from SQLite to Postgres to MongoDB without changing any application code.
+
+Gestalt stores users, plugin tokens, API tokens, and OAuth registrations through the datastore. The host encrypts all plugin tokens before storage using AES-256-GCM, so the datastore stores sealed bytes without needing access to the encryption key. API tokens are stored as one-way SHA-256 hashes.
 
 ## Manifest
 
@@ -267,7 +269,7 @@ datastores:
 Plugins bind to named datastores:
 
 ```yaml
-integrations:
+plugins:
   my-plugin:
     datastores:
       db: main

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -4,7 +4,7 @@ asIndexPage: true
 
 # Providers
 
-Gestalt has a unified runtime model: integration plugins, auth backends, datastores, and web UIs all run as providers. The server binary (`gestaltd`) does not compile any of these in. Instead, each provider is a separate package with a manifest and an executable (or a passthrough surface definition) that the host loads at startup.
+Gestalt has a unified runtime model: plugins, auth backends, datastores, and web UIs all run as providers. The server binary (`gestaltd`) does not compile any of these in. Instead, each provider is a separate package with a manifest and an executable (or a passthrough surface definition) that the host loads at startup.
 
 ## Provider kinds
 
@@ -12,9 +12,9 @@ A provider's kind is implied by the one top-level metadata block in its manifest
 
 | Kind | Purpose |
 | --- | --- |
-| `plugin` | Integration provider. Exposes operations that users invoke through the CLI, the HTTP API, or MCP. |
+| `plugin` | Plugin. Exposes operations that users invoke through the CLI, the HTTP API, or MCP. |
 | `auth` | Platform auth backend. Handles login, session validation, and external token verification. |
-| `datastore` | Persistent storage. Stores users, integration tokens, API tokens, and OAuth registrations. |
+| `datastore` | Persistent storage. Stores users, plugin tokens, API tokens, and OAuth registrations. |
 | `secrets` | Secret manager. Resolves `secret://` references at bootstrap. Go SDK only for now. |
 | `webui` | Replacement web UI served at `/`. |
 
@@ -22,13 +22,13 @@ First-party auth, datastore, and secrets providers are published at `github.com/
 
 ## How the runtime works
 
-When a provider entry resolves to an executable, `gestaltd` starts it as a child process. The host creates a temporary Unix socket, passes the socket path through the `GESTALT_PLUGIN_SOCKET` environment variable, and waits for the provider to connect back over gRPC. At startup the provider receives the configured provider name and the `config` block from the server config. For integration plugins, each invocation also receives the current request context (caller identity, decrypted token, and operation parameters).
+When a provider entry resolves to an executable, `gestaltd` starts it as a child process. The host creates a temporary Unix socket, passes the socket path through the `GESTALT_PLUGIN_SOCKET` environment variable, and waits for the provider to connect back over gRPC. At startup the provider receives the configured provider name and the `config` block from the server config. For plugins, each invocation also receives the current request context (caller identity, decrypted token, and operation parameters).
 
-The host owns auth, token storage, connection selection, and HTTP or MCP routing. Integration providers do not interact with the datastore. Auth providers implement `BeginLogin` and `CompleteLogin`. Datastore providers implement user, token, and API-token storage interfaces. Secrets providers implement `GetSecret` for resolving `secret://` references. Each kind has its own gRPC service contract, but they all share the same process lifecycle.
+The host owns auth, token storage, connection selection, and HTTP or MCP routing. Plugins do not interact with the datastore. Auth providers implement `BeginLogin` and `CompleteLogin`. Datastore providers implement user, token, and API-token storage interfaces. Secrets providers implement `GetSecret` for resolving `secret://` references. Each kind has its own gRPC service contract, but they all share the same process lifecycle.
 
 ## Process isolation
 
-Providers run in their own process. They cannot access the host process memory, other users' credentials, or (for integration plugins) the datastore directly. Integration plugins also run inside a network sandbox: outbound requests to hosts not listed in `plugin.allowedHosts` in the manifest are rejected with a 403.
+Providers run in their own process. They cannot access the host process memory, other users' credentials, or (for plugins) the datastore directly. Plugins also run inside a network sandbox: outbound requests to hosts not listed in `plugin.allowedHosts` in the manifest are rejected with a 403.
 
 ## SDK support
 
@@ -45,7 +45,7 @@ Go, Rust, and TypeScript support plugin, auth, and datastore providers. Python r
 
 ## Operation ID conventions
 
-Operation IDs should use period-separated hierarchical names. For example, a Slack integration might use `messages.list`, `messages.send`, `channels.list`, and `channels.archive`.
+Operation IDs should use period-separated hierarchical names. For example, a Slack plugin might use `messages.list`, `messages.send`, `channels.list`, and `channels.archive`.
 
 This convention enables prefix matching in the CLI. When you run `gestalt invoke slack messages`, the CLI joins the space-separated segments with periods and shows all operations whose ID starts with `messages.`. This makes large catalogs navigable without memorizing every operation name.
 
@@ -57,7 +57,7 @@ This convention enables prefix matching in the CLI. When you run `gestalt invoke
 
 ## What to read next
 
-- [Plugins](/providers/plugins): integration providers that expose operations
+- [Plugins](/providers/plugins): plugin providers that expose operations
 - [Auth](/providers/auth): platform login providers
 - [Datastores](/providers/datastores): persistent storage backends
 - [Web UIs](/providers/web-uis): custom web frontends

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -1,8 +1,8 @@
 import { Tabs } from 'nextra/components'
 
-# Integration Plugins
+# Plugins
 
-Integration plugins are one provider kind. Their manifests use a top-level `plugin:` block, and deployments reference them under the top-level `plugins:` map. A plugin can define operations as executable code (handled by the provider process), as passthrough surfaces (REST, OpenAPI, GraphQL, or MCP endpoints forwarded by the host), or both.
+Plugins are one provider kind. Their manifests use a top-level `plugin:` block, and deployments reference them under the top-level `plugins:` map. A plugin can define operations as executable code (handled by the provider process), as passthrough surfaces (REST, OpenAPI, GraphQL, or MCP endpoints forwarded by the host), or both.
 
 ## Manifest
 
@@ -14,7 +14,7 @@ Static metadata, auth, and passthrough surfaces live in a manifest file. Gestalt
     source: github.com/example/plugins/my-plugin
     version: 0.0.1-alpha.1
     displayName: My Plugin
-    description: A custom integration plugin
+    description: A custom plugin
     plugin:
       connections:
         default:
@@ -28,7 +28,7 @@ Static metadata, auth, and passthrough surfaces live in a manifest file. Gestalt
       "source": "github.com/example/plugins/my-plugin",
       "version": "0.0.1-alpha.1",
       "displayName": "My Plugin",
-      "description": "A custom integration plugin",
+      "description": "A custom plugin",
       "plugin": {
         "connections": {
           "default": {
@@ -186,9 +186,7 @@ The manifest stays the source of truth for display name, description, auth, the 
     }
     ```
 
-    Use `"plugin"` when you need to spell the plugin kind explicitly. The
-    legacy `integration` spelling and the older `gestalt.plugin` shorthand are
-    still accepted.
+    Use `"plugin"` when you need to spell the plugin kind explicitly.
   </Tabs.Tab>
 </Tabs>
 
@@ -548,7 +546,7 @@ By default, the operation catalog is static and materialized at startup. If your
     ```
   </Tabs.Tab>
   <Tabs.Tab>
-    Export a `sessionCatalog` function from your integration provider definition:
+    Export a `sessionCatalog` function from your plugin provider definition:
 
     ```typescript
     export const provider = defineIntegrationProvider({

--- a/docs/content/providers/releasing.mdx
+++ b/docs/content/providers/releasing.mdx
@@ -143,7 +143,7 @@ webui:
 
 ### Release manifest for an executable provider
 
-Released executable integration providers add concrete `entrypoints.plugin` and
+Released executable plugin providers add concrete `entrypoints.plugin` and
 `artifacts` entries:
 
 ```yaml

--- a/docs/content/providers/web-uis.mdx
+++ b/docs/content/providers/web-uis.mdx
@@ -65,7 +65,7 @@ If `ui.plugin` is omitted entirely, Gestalt falls back to the built-in client UI
 
 ## The admin UI
 
-The built-in admin UI is always served at `/admin`, regardless of whether a custom UI bundle is configured. It provides a management interface for users, integrations, connections, and API tokens. A custom UI bundle only replaces the root `/` path.
+The built-in admin UI is always served at `/admin`, regardless of whether a custom UI bundle is configured. It provides a management interface for users, plugins, connections, and API tokens. A custom UI bundle only replaces the root `/` path.
 
 ## Release
 

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -1,6 +1,6 @@
 # First-Party Providers
 
-Gestalt does not compile auth or datastore providers into the `gestaltd` binary. Both are loaded at startup as external provider processes through the same runtime model that also powers integration plugins. The first-party implementations are published from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers) and maintained alongside the server.
+Gestalt does not compile auth or datastore providers into the `gestaltd` binary. Both are loaded at startup as external provider processes through the same runtime model that also powers plugins. The first-party implementations are published from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers) and maintained alongside the server.
 
 Secrets, telemetry, and audit remain built into the binary because they must be available before provider runtime bootstrapping starts.
 
@@ -75,9 +75,9 @@ Telemetry providers are compiled into the binary.
 | `otlp` | Exports traces, metrics, and logs via OpenTelemetry Protocol. |
 | `noop` | Disables all telemetry collection. |
 
-## Integration Plugins
+## Plugins
 
-Integration plugins (BigQuery, Jira, Slack, and others) are published separately from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). They use the `provider:` key under each named entry in the `plugins` map:
+Plugins (BigQuery, Jira, Slack, and others) are published separately from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). They use the `provider:` key under each named entry in the `plugins` map:
 
 ```yaml
 plugins:
@@ -90,4 +90,4 @@ plugins:
 
 ## Community and Custom Providers
 
-Third-party auth providers, datastore providers, and integration plugins use the same provider package model as the first-party packages. Package your implementation with a provider manifest that includes the appropriate top-level block (`auth`, `datastore`, or `plugin`), publish it to a Git-accessible source, and reference it in your config the same way you would reference any first-party provider.
+Third-party auth providers, datastore providers, and plugins use the same provider package model as the first-party packages. Package your implementation with a provider manifest that includes the appropriate top-level block (`auth`, `datastore`, or `plugin`), publish it to a Git-accessible source, and reference it in your config the same way you would reference any first-party provider.

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -38,7 +38,7 @@ server:
   artifactsDir: ./state
 ```
 
-`public.host` and `public.port` control the public listener address. Both default to all-interfaces on port `8080`. The legacy `port` shorthand still works but `public.port` takes precedence.
+`public.host` and `public.port` control the public listener address. Both default to all-interfaces on port `8080`.
 
 `management.host` and `management.port` bind a separate listener for operator traffic. When `management.port` is omitted, `/admin` and `/metrics` stay on the public listener, a mode best kept to local development or other trusted-network deployments. For production, prefer configuring `server.management` so the operator surface leaves the public listener entirely.
 
@@ -63,7 +63,7 @@ When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth ro
 
 ## `auth`
 
-Top-level platform auth is optional. Omit the `auth` block entirely to disable platform authentication, or set `auth.provider: none` explicitly. When auth is enabled, configure it with `auth.provider` and `auth.config`. `auth.provider` uses the same provider-reference shape as integration plugins: a `source` block plus optional `env` and `allowedHosts`.
+Top-level platform auth is optional. Omit the `auth` block entirely to disable platform authentication, or set `auth.provider: none` explicitly. When auth is enabled, configure it with `auth.provider` and `auth.config`. `auth.provider` uses the same provider-reference shape as plugins: a `source` block plus optional `env` and `allowedHosts`.
 
 ### `none`
 
@@ -378,7 +378,7 @@ Disables audit output explicitly. `audit.config` is not allowed when `audit.prov
 
 ## `plugins`
 
-Each entry in the top-level `plugins` map is a named integration instance backed by an executable provider package. The provider package is the source of truth for operations and transport details. Server config selects the provider, passes provider-specific config, declares connection policy, and controls MCP exposure.
+Each entry in the top-level `plugins` map is a named plugin backed by an executable provider package. The provider package is the source of truth for operations and transport details. Server config selects the provider, passes provider-specific config, declares connection policy, and controls MCP exposure. The HTTP API and client CLI use the synonym "integrations" in route paths and commands (e.g. `/api/v1/integrations`, `gestalt integrations list`), but `plugins` is the canonical config term.
 
 ```yaml
 plugins:
@@ -405,25 +405,23 @@ plugins:
       toolPrefix: github_
 ```
 
-The config key is `plugins`, but the HTTP API and client CLI still refer to these named entries as integrations.
-
-### Integration Plugin Fields
+### Plugin Fields
 
 | Field | Description |
 | --- | --- |
 | `displayName` | Human-readable name shown in the UI and API. |
-| `description` | Short description of the integration. |
+| `description` | Short description of the plugin. |
 | `iconFile` | SVG icon path, resolved relative to the config directory. |
 | `provider` | **Required.** The backing provider package. See [provider shape](#pluginsprovider) below. |
 | `config` | Provider-specific configuration passed into the provider package. |
 | `connections` | Named connection declarations. See [connections](#connections) below. |
 | `allowedOperations` | Allowlist with optional `alias` and `description` overrides per operation. |
-| `mcp.enabled` | Expose this integration over MCP. |
+| `mcp.enabled` | Expose this plugin over MCP. |
 | `mcp.toolPrefix` | Prefix for MCP tool names. Only valid when `mcp.enabled` is `true`. |
 
 ### `plugins.*.provider`
 
-Every integration plugin uses a nested `provider` block to declare its source.
+Every plugin uses a nested `provider` block to declare its source.
 
 ```yaml
 provider:
@@ -442,7 +440,7 @@ provider:
     path: ./manifest.yaml
 ```
 
-Gestalt synthesizes Go and Rust executable wrappers automatically when needed and runs Python source providers from the module declared in `[tool.gestalt].provider` or the legacy `[tool.gestalt].plugin`. Integration plugins do not support `provider.builtin`.
+Gestalt synthesizes Go and Rust executable wrappers automatically when needed and runs Python source providers from the module declared in `[tool.gestalt].provider` or the legacy `[tool.gestalt].plugin`. Plugins do not support `provider.builtin`.
 
 <Tabs items={['Go', 'Python', 'Rust']}>
   <Tabs.Tab>
@@ -496,7 +494,7 @@ Gestalt synthesizes Go and Rust executable wrappers automatically when needed an
 
 ### `connections`
 
-Connections declare how users authenticate to the upstream service. Only `connections.default` may define `params` and `discovery`.
+Connections declare how users authenticate to the upstream service. Only `connections.default` may define `params` and `discovery`. A provider manifest can also declare connections; when both the manifest and config define the same connection name, config values are merged on top of the manifest defaults. See [Provider Manifests](/reference/plugin-manifests#connections) for the manifest-side schema.
 
 ```yaml
 connections:
@@ -518,7 +516,7 @@ connections:
       type: mcp_oauth
 ```
 
-Connection `mode` determines how credentials are managed: `none` requires no credentials, `user` requires each user to connect individually, `identity` uses a shared operator credential, and `either` accepts both user and identity connections. All connections in a single integration must share the same mode.
+Connection `mode` determines how credentials are managed: `none` requires no credentials, `user` requires each user to connect individually, `identity` uses a shared operator credential, and `either` accepts both user and identity connections. All connections in a single plugin must share the same mode.
 
 #### Auth shapes
 
@@ -677,7 +675,7 @@ egress:
 | `action` | **Required.** `allow` or `deny`. |
 | `subjectKind` | Match by subject kind. |
 | `subjectId` | Match by subject identifier. |
-| `provider` | Match by integration name. |
+| `provider` | Match by plugin name. |
 | `operation` | Match by operation name. |
 | `method` | Match by HTTP method. |
 | `host` | Match by destination host. |
@@ -727,7 +725,7 @@ Each plugin uses a nested `provider` block. Every plugin must use exactly one lo
 
 Auth and datastore providers use the same PluginDef shape. When `auth.provider` or `datastore.provider` is set, `source.ref` or `source.path` must be present. `auth.config` and `datastore.config` are only allowed when their corresponding provider is set.
 
-Only `connections.default` may define `params` or `discovery`. `mcp.toolPrefix` is valid only when `mcp.enabled` is `true`. All connections in an integration must share the same mode.
+Only `connections.default` may define `params` or `discovery`. `mcp.toolPrefix` is valid only when `mcp.enabled` is `true`. All connections in a plugin must share the same mode.
 
 `ui.provider` must be either `none` or a provider mapping with exactly one loading mode: local `ui.provider.source.path` or managed `ui.provider.source.ref`. `ui.provider.source.version` is required with `ui.provider.source.ref` and invalid with `ui.provider.source.path`. `ui.config` is only allowed when `ui.provider` is not `none`.
 

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -17,26 +17,26 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | `POST` | `/api/v1/auth/login` | Starts platform login and returns an absolute browser URL. |
 | `GET` | `/api/v1/auth/login/callback` | Completes platform login. |
 | `POST` | `/api/v1/auth/logout` | Clears the current platform session. |
-| `GET` | `/api/v1/auth/callback` | Completes integration OAuth. |
+| `GET` | `/api/v1/auth/callback` | Completes plugin OAuth. |
 | `POST` | `/api/v1/auth/pending-connection` | Render or finalize a multi-candidate connection choice using a pending connection token. |
 
 ## Authenticated User Routes
 
-### Integrations
+### Plugins
 
 | Method | Path | Purpose |
 | --- | --- | --- |
-| `GET` | `/api/v1/integrations` | List integrations, connection state, auth types, instances, icons, and connection parameter hints. |
-| `DELETE` | `/api/v1/integrations/{name}` | Disconnect an integration. Use `?connection=...` and `?instance=...` to target one stored connection. |
-| `GET` | `/api/v1/integrations/{name}/operations` | List operations for one integration. Supports `_connection` and `_instance` selectors. |
-| `GET` or `POST` | `/api/v1/{integration}/{operation}` | Invoke an integration operation. Supports `_connection` and `_instance`. |
+| `GET` | `/api/v1/integrations` | List plugins, connection state, auth types, instances, icons, and connection parameter hints. |
+| `DELETE` | `/api/v1/integrations/{name}` | Disconnect a plugin. Use `?connection=...` and `?instance=...` to target one stored connection. |
+| `GET` | `/api/v1/integrations/{name}/operations` | List operations for one plugin. Supports `_connection` and `_instance` selectors. |
+| `GET` or `POST` | `/api/v1/{integration}/{operation}` | Invoke a plugin operation. Supports `_connection` and `_instance`. |
 
-### Integration Connection Flows
+### Plugin Connection Flows
 
 | Method | Path | Purpose |
 | --- | --- | --- |
-| `POST` | `/api/v1/auth/start-oauth` | Start an integration OAuth flow. |
-| `POST` | `/api/v1/auth/connect-manual` | Submit manual integration credentials. |
+| `POST` | `/api/v1/auth/start-oauth` | Start a plugin OAuth flow. |
+| `POST` | `/api/v1/auth/connect-manual` | Submit manual plugin credentials. |
 
 ### API Tokens
 
@@ -76,7 +76,7 @@ Gestalt authenticates the caller, resolves the target plugin and operation, then
 
 ## Parameter conventions
 
-`GET` invocations read parameters from the query string; `POST` invocations read parameters from a JSON body. Use `_connection` to select a named connection when an integration exposes more than one, and `_instance` to select one stored instance for that connection.
+`GET` invocations read parameters from the query string; `POST` invocations read parameters from a JSON body. Use `_connection` to select a named connection when a plugin exposes more than one, and `_instance` to select one stored instance for that connection.
 
 ## Example
 

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -4,7 +4,7 @@ import { Tabs } from 'nextra/components'
 
 Gestalt provider packages and release archives are described by a manifest file: `manifest.yaml`, `manifest.yml`, or `manifest.json`. YAML is the easiest format to author by hand.
 
-Providers are the umbrella concept in Gestalt. Auth providers, datastore providers, and integration plugins all use this manifest format. The `plugin` manifest kind is reserved for integration providers that expose callable operations.
+Providers are the umbrella concept in Gestalt. Auth providers, datastore providers, and plugins all use this manifest format. The `plugin` manifest kind is reserved for providers that expose callable operations.
 
 ## Manifest Kinds
 
@@ -12,7 +12,7 @@ Every manifest defines exactly one provider kind, determined by which metadata b
 
 | Kind | Top-level key | Purpose |
 | --- | --- | --- |
-| `plugin` | `plugin` | Integration plugin (REST, OpenAPI, GraphQL, MCP, or executable). |
+| `plugin` | `plugin` | Plugin (REST, OpenAPI, GraphQL, MCP, or executable). |
 | `auth` | `auth` | Platform auth provider (Google, OIDC, local, or custom). |
 | `datastore` | `datastore` | Persistence backend (Postgres, SQLite, DynamoDB, or custom). |
 | `secrets` | `secrets` | Secret manager for resolving `secret://` references. |
@@ -31,7 +31,7 @@ These fields appear at the top level of every manifest regardless of kind.
 | `displayName` | string | no | Human-readable label shown in the UI. |
 | `description` | string | no | Human-readable description. |
 | `iconFile` | string | no | Relative path to an SVG icon bundled with the package. |
-| `artifacts` | Artifact[] | no | Packaged executable artifacts keyed by platform. Omit for declarative-only integration plugin packages or source manifests used during local development. |
+| `artifacts` | Artifact[] | no | Packaged executable artifacts keyed by platform. Omit for declarative-only plugin packages or source manifests used during local development. |
 | `entrypoints` | Entrypoints | no | Executable entrypoint metadata for the manifest's kind. |
 
 ## Entrypoints
@@ -40,7 +40,7 @@ The `entrypoints` block declares executable binaries. Each key corresponds to a 
 
 | Key | Kind | Purpose |
 | --- | --- | --- |
-| `plugin` | plugin | Executable entrypoint for an integration plugin. |
+| `plugin` | plugin | Executable entrypoint for a plugin. |
 | `auth` | auth | Executable entrypoint for an auth provider. |
 | `datastore` | datastore | Executable entrypoint for a datastore provider. |
 | `secrets` | secrets | Executable entrypoint for a secrets provider. |
@@ -59,9 +59,9 @@ entrypoints:
     args: ["--verbose"]
 ```
 
-## Integration Plugin Metadata
+## Plugin Metadata
 
-The `plugin` block describes an integration plugin. It supports declarative REST operations, spec-loaded surfaces (OpenAPI, GraphQL, MCP), executable code, or any combination.
+The `plugin` block describes a plugin. It supports declarative REST operations, spec-loaded surfaces (OpenAPI, GraphQL, MCP), executable code, or any combination.
 
 ### Core Fields
 
@@ -78,7 +78,7 @@ The `plugin` block describes an integration plugin. It supports declarative REST
 
 ### Connections
 
-The `connections` map defines named connection profiles. Each connection supports the following fields:
+The `connections` map defines named connection profiles. Deployment config can override or extend these defaults; see [Config File](/reference/config-file#connections) for the config-side schema. Each connection supports the following fields:
 
 | Field | Type | Purpose |
 | --- | --- | --- |
@@ -309,11 +309,11 @@ The `artifacts` array lists platform-specific binaries included in the package.
 | `path` | string | yes | Path to the binary inside the package. |
 | `sha256` | string | no | SHA-256 hex digest for integrity verification. |
 
-Declarative-only integration plugin packages do not require `artifacts`. Pure executable source manifests used with `plugins.*.provider.source.path` or `gestaltd provider release` may omit them.
+Declarative-only plugin packages do not require `artifacts`. Pure executable source manifests used with `plugins.*.provider.source.path` or `gestaltd provider release` may omit them.
 
 ## Full Example
 
-This manifest shows an integration plugin with an executable entrypoint, multiple connections, OpenAPI and MCP surfaces, pagination, allowed operations, and managed parameters.
+This manifest shows a plugin with an executable entrypoint, multiple connections, OpenAPI and MCP surfaces, pagination, allowed operations, and managed parameters.
 
 <Tabs items={['YAML', 'JSON']}>
   <Tabs.Tab>
@@ -598,13 +598,11 @@ gestaltd provider release --version 1.2.3
 `manifest.yaml` stays YAML and `manifest.json` stays JSON in the release archive.
 For executable Go and Rust plugins, release materializes the executable
 catalog automatically before packaging. Python source plugins load the module
-declared in `[tool.gestalt].plugin` and materialize the executable catalog
+declared in `[tool.gestalt].provider` and materialize the executable catalog
 automatically. TypeScript source providers load the target declared in
 `package.json` under `gestalt.provider`. A string target such as
 `./provider.ts#plugin` defaults to a plugin provider; auth and datastore
-providers use an object with `kind` and `target`. Use `"plugin"` as the
-explicit plugin kind when needed. The legacy `integration` spelling and the
-older `gestalt.plugin` shorthand are still accepted. Auth and datastore source
+providers use an object with `kind` and `target`. Auth and datastore source
 packages support the same release flow for Go, Rust, and TypeScript, but they
 do not generate catalogs. Source packages build the host-platform artifact by
 default. Pass `--platform` for an explicit `os/arch[/libc]` target list, or

--- a/docs/content/security.mdx
+++ b/docs/content/security.mdx
@@ -40,7 +40,7 @@ Gestalt sits between callers and upstream APIs. It authenticates users, stores e
 
 ## Encryption at rest
 
-All integration tokens are encrypted before storage using AES-256-GCM.
+All plugin tokens are encrypted before storage using AES-256-GCM.
 
 The `server.encryptionKey` is the root deployment secret. If the key is a 64-character hex string, it is decoded directly as a 32-byte AES key. Otherwise, Argon2id derives a 32-byte key from the string (3 iterations, 64 MiB, 4 threads).
 
@@ -54,7 +54,7 @@ Access tokens, refresh tokens, pending connection state, and OAuth state paramet
 
 **API tokens.** Generated with 32 random bytes from `crypto/rand` and prefixed with `gst_api_`. The plaintext is returned once at creation time. Only the SHA-256 hash is stored. Default TTL is 30 days, configurable via `server.apiTokenTtl`.
 
-**Integration tokens (OAuth).** OAuth state is encrypted with a 10-minute TTL to prevent state injection. After the authorization code exchange, access and refresh tokens are encrypted separately and stored. Gestalt automatically refreshes tokens that expire within 5 minutes.
+**Plugin tokens (OAuth).** OAuth state is encrypted with a 10-minute TTL to prevent state injection. After the authorization code exchange, access and refresh tokens are encrypted separately and stored. Gestalt automatically refreshes tokens that expire within 5 minutes.
 
 ## Request authentication
 
@@ -82,7 +82,7 @@ The host resolves the caller's access token and passes it to the provider in eac
 
 ### OS-level sandbox
 
-When `allowedHosts` is configured on a provider, the integration provider is automatically sandboxed:
+When `allowedHosts` is configured on a provider, the plugin is automatically sandboxed:
 
 ```yaml
 plugins:

--- a/docs/content/troubleshooting.mdx
+++ b/docs/content/troubleshooting.mdx
@@ -10,25 +10,25 @@ The validation error `server.encryptionKey is required` means the config is miss
 
 Set `server.encryptionKey` for every real deployment. Gestalt derives token and session encryption from it regardless of which auth and datastore providers you use.
 
-If the `/mcp` endpoint is not mounted, the server found no plugin that exposes tools. At least one integration plugin must surface MCP-visible operations before `/mcp` becomes available.
+If the `/mcp` endpoint is not mounted, the server found no plugin that exposes tools. At least one plugin must surface MCP-visible operations before `/mcp` becomes available.
 
 When `/ready` returns `503`, the server has not finished initialization. Readiness stays false until all configured providers finish loading and the datastore answers a ping. Check server logs for provider bootstrap errors or datastore connectivity problems.
 
 ## Operation invocation
 
-A "provider not found" error means the integration key in the request does not match any entry in the `plugins` config map. Verify the spelling and confirm the plugin loaded without errors at startup.
+A "provider not found" error means the plugin key in the request does not match any entry in the `plugins` config map. Verify the spelling and confirm the plugin loaded without errors at startup.
 
 An "operation not found" error means the operation ID does not exist in the plugin's catalog. Check that the operation is exposed and that `allowed_operations`, if set, includes it.
 
 A "not authenticated" error on an API or MCP request means no valid session or API token was presented. Log in through the web UI or pass a bearer token in the `Authorization` header.
 
-A "no integration token" error means the user has not connected the integration. Complete the OAuth or manual-auth flow for the provider and connection before invoking operations.
+A "no integration token" error means the user has not connected the plugin. Complete the OAuth or manual-auth flow for the provider and connection before invoking operations.
 
-An "ambiguous instance" error means the user has more than one stored instance for that integration and connection. Pass `_instance` in the HTTP request body or `--instance` in the client CLI to select the correct one.
+An "ambiguous instance" error means the user has more than one stored instance for that plugin and connection. Pass `_instance` in the HTTP request body or `--instance` in the client CLI to select the correct one.
 
-A "token scope denied" error means the operation requires an OAuth scope that was not granted during the connection flow. Disconnect and reconnect the integration, ensuring all required scopes are approved.
+A "token scope denied" error means the operation requires an OAuth scope that was not granted during the connection flow. Disconnect and reconnect the plugin, ensuring all required scopes are approved.
 
-Token refresh failures indicate that the upstream provider rejected the stored refresh token. The refresh token may have been revoked, expired, or rotated by the provider. Disconnect and reconnect the integration to obtain fresh credentials.
+Token refresh failures indicate that the upstream provider rejected the stored refresh token. The refresh token may have been revoked, expired, or rotated by the provider. Disconnect and reconnect the plugin to obtain fresh credentials.
 
 ## Upstream errors
 
@@ -77,11 +77,11 @@ Common source-package checks:
     bun run -e "import('./provider.ts')"
     ```
 
-    Confirm `package.json` has a `gestalt.plugin` or `gestalt.provider` entry pointing at the correct `./file.ts#export` target. The target path must start with `./` and the export name must match a named export in the module.
+    Confirm `package.json` has a `gestalt.provider` entry pointing at the correct `./file.ts#export` target. The target path must start with `./` and the export name must match a named export in the module.
   </Tabs.Tab>
 </Tabs>
 
-A sandbox 403 means the provider process made an outbound request to a host not listed in `plugin.allowedHosts`. Add every upstream domain the integration plugin contacts to the allowlist in your plugin config.
+A sandbox 403 means the provider process made an outbound request to a host not listed in `plugin.allowedHosts`. Add every upstream domain the plugin contacts to the allowlist in your plugin config.
 
 An input decode error means the operation received a request body that does not match the expected schema. Check the operation's parameter definitions and ensure the caller is sending the correct types and required fields.
 
@@ -91,6 +91,6 @@ An invocation depth error means a plugin-to-plugin call chain exceeded the maxim
 
 ## Connections
 
-When an integration requires an explicit connection, the plugin has more than one configured connection and no default. Pass `_connection` on the invocation request or use `--connection` in the client CLI to disambiguate.
+When a plugin requires an explicit connection, it has more than one configured connection and no default. Pass `_connection` on the invocation request or use `--connection` in the client CLI to disambiguate.
 
 If a managed path parameter still appears in the operation schema, the operation path template does not contain the expected placeholder. Verify that the path includes the parameter in braces, such as `/workspaces/{workspace_id}/tickets`, rather than omitting it.


### PR DESCRIPTION
## Summary

- Add missing imports to Go, Python, and Rust code snippets in the Plugin SDK section of the datastores doc
- Fix Go server-side example to use the actual function name `ServeIndexedDBProvider` instead of `ServeDatastoreProvider`
- Rename section heading from "Plugin SDK (consuming datastores)" to "Plugin SDK"
- Add IndexedDB preface with MDN link explaining why the API was chosen, and fix `integrations:` to `plugins:` in the YAML example

Follows up on #849.

## Test plan

- [ ] Verify docs site builds without errors
- [ ] Check Go/Python/Rust/TypeScript code snippets all have imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)