### PR TITLE
Update docs to reflect cloud secret managers as external providers

### DIFF
--- a/docs/content/deploy/index.mdx
+++ b/docs/content/deploy/index.mdx
@@ -10,7 +10,7 @@ The server image `valontechnologies/gestaltd:latest` is published for `linux/amd
 
 **Database.** SQLite works for single-instance deployments. For multi-replica or horizontally scaled deployments, use a networked datastore provider such as the first-party `datastore/relationaldb` package with a Postgres or MySQL DSN. See [Datastores](/providers/datastores) for the provider model.
 
-**Secrets.** Use a dedicated secret manager in production. `file` is built in; cloud-backed backends are packaged external providers such as `github.com/valon-technologies/gestalt-providers/secrets/google`, `.../secrets/aws`, `.../secrets/vault`, or `.../secrets/azure`. Gestalt config supports `secret://` references that are resolved at boot time through the configured secret manager.
+**Secrets.** Use `file` or a cloud secret manager instead of `env` in production. `file` is built in and works with Kubernetes volume-mounted secrets. Cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) are available as external providers from [`gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). Gestalt config supports `secret://` references that are resolved at boot time through the configured secrets provider. See [Secrets Providers](/providers/secrets) for setup details.
 
 **TLS.** Gestalt does not terminate TLS. Deploy behind a reverse proxy or load balancer that handles TLS termination. Set `server.baseUrl` to the public HTTPS URL so that OAuth callback URLs are derived correctly.
 

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -2,7 +2,7 @@
 
 Gestalt does not compile auth or datastore providers into the `gestaltd` binary. Both are loaded at startup as external provider processes through the same runtime model that also powers plugins. The first-party implementations are published from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers) and maintained alongside the server.
 
-Secrets, telemetry, and audit remain built into the binary because they must be available before provider runtime bootstrapping starts.
+Two simple secrets providers (`env` and `file`), telemetry, and audit remain built into the binary. Cloud secret backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) are available as external providers from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). See [Secrets Providers](/providers/secrets) for the full list and configuration.
 
 ## Auth Providers
 
@@ -46,19 +46,14 @@ datastore: main
 
 ## Secret Managers
 
-The following secret managers are compiled into the binary. They resolve `secret://` references during bootstrap. Cloud secret backends and other advanced secret managers are packaged as external providers and configured under `secrets.provider`.
+Two secret managers are compiled into the `gestaltd` binary and resolve `secret://` references during bootstrap. Cloud secret backends are available as external providers published from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers).
 
 | Name | Purpose |
 | --- | --- |
 | `env` | Resolves secrets from environment variables. Default when `secrets` is omitted. |
 | `file` | Resolves secrets from files in a configured directory. Works with Kubernetes volume-mounted secrets. |
 
-External secret provider packages include:
-
-- `github.com/valon-technologies/gestalt-providers/secrets/google`
-- `github.com/valon-technologies/gestalt-providers/secrets/aws`
-- `github.com/valon-technologies/gestalt-providers/secrets/vault`
-- `github.com/valon-technologies/gestalt-providers/secrets/azure`
+For cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault), see [Secrets Providers](/providers/secrets#available-providers). These use the `provider:` config key under `secrets` rather than `builtin:`.
 
 ## Telemetry Providers (built-in)
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -159,7 +159,7 @@ The exact config fields depend on the selected external datastore provider packa
 
 ## `secrets`
 
-The secrets manager resolves `secret://` references at startup. Two simple secret managers are built into the `gestaltd` binary and selected by the `builtin` field. Cloud-backed secret managers and other advanced backends are packaged as external providers and configured through `secrets.provider`.
+The secrets manager resolves `secret://` references at startup. Two providers (`env` and `file`) are built into the binary and selected by the `builtin` field. Cloud secret backends are loaded as external providers using the `provider` field, the same way auth and datastore providers work.
 
 ```yaml
 secrets:
@@ -173,7 +173,9 @@ secrets:
 | `env` | `prefix` | Reads secrets from environment variables. Default when `secrets` is omitted. |
 | `file` | `dir` | Reads one secret per file from a base directory. Works with Kubernetes volume-mounted secrets. |
 
-For external secret managers, use the same provider package model as auth and IndexedDB providers:
+### Cloud secret backends
+
+Cloud secret managers are external providers configured with `provider:` instead of `builtin:`:
 
 ```yaml
 secrets:
@@ -185,27 +187,29 @@ secrets:
     project: my-gcp-project
 ```
 
-| External provider | Config fields | Purpose |
+| Provider | Source ref | Config fields |
 | --- | --- | --- |
-| `github.com/valon-technologies/gestalt-providers/secrets/google` | `project`, `version` | Google Cloud Secret Manager. `version` defaults to `latest`. |
-| `github.com/valon-technologies/gestalt-providers/secrets/aws` | `region`, `versionStage`, `endpoint` | AWS Secrets Manager. `region` is required. `versionStage` defaults to `AWSCURRENT`. |
-| `github.com/valon-technologies/gestalt-providers/secrets/vault` | `address`, `token`, `mountPath`, `namespace` | HashiCorp Vault KV v2. `address` and `token` are required. `mountPath` defaults to `secret`. |
-| `github.com/valon-technologies/gestalt-providers/secrets/azure` | `vaultUrl`, `version` | Azure Key Vault. `vaultUrl` is required. `version` defaults to latest. |
+| Google Secret Manager | `github.com/valon-technologies/gestalt-providers/secrets/google` | `project` (required), `version` |
+| AWS Secrets Manager | `github.com/valon-technologies/gestalt-providers/secrets/aws` | `region` (required), `versionStage`, `endpoint` |
+| HashiCorp Vault | `github.com/valon-technologies/gestalt-providers/secrets/vault` | `address` (required), `token` (required), `mountPath`, `namespace` |
+| Azure Key Vault | `github.com/valon-technologies/gestalt-providers/secrets/azure` | `vaultUrl` (required), `version` |
+
+See [Secrets Providers](/providers/secrets) for the complete reference and SDK interface.
 
 ### Bootstrap credentials
 
 `secret://` references are resolved through the configured secret manager at startup, but the secret manager's own configuration (`secrets.config`) cannot use `secret://` because it would be self-referential. Use `${ENV_VAR}` or `${ENV_VAR_FILE}` placeholders for any credentials the secret manager itself needs.
 
-Each provider authenticates to its backing service differently:
+Each provider authenticates to its backing service differently. The `env` and `file` providers are built in. The remaining rows apply when using the corresponding external provider from `gestalt-providers`:
 
 | Provider | Authentication model |
 | --- | --- |
 | `env` | Reads from process environment. No external auth needed. |
 | `file` | Reads from local filesystem. No external auth needed. |
-| `github.com/valon-technologies/gestalt-providers/secrets/google` | Uses [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials). In production, attach a service account or use workload identity. Locally, run `gcloud auth application-default login`. |
-| `github.com/valon-technologies/gestalt-providers/secrets/aws` | Uses the [AWS SDK default credential chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html). In production, use an instance profile, ECS task role, or IRSA. Locally, run `aws configure` or set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. |
-| `github.com/valon-technologies/gestalt-providers/secrets/vault` | Requires explicit `address` and `token` in config. Inject the token via `${VAULT_TOKEN}` or `${VAULT_TOKEN_FILE}`. |
-| `github.com/valon-technologies/gestalt-providers/secrets/azure` | Uses [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication). In production, use managed identity. Locally, run `az login`. |
+| Google Secret Manager | Uses [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials). In production, attach a service account or use workload identity. Locally, run `gcloud auth application-default login`. |
+| AWS Secrets Manager | Uses the [AWS SDK default credential chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html). In production, use an instance profile, ECS task role, or IRSA. Locally, run `aws configure` or set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. |
+| HashiCorp Vault | Requires explicit `address` and `token` in config. Inject the token via `${VAULT_TOKEN}` or `${VAULT_TOKEN_FILE}`. |
+| Azure Key Vault | Uses [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication). In production, use managed identity. Locally, run `az login`. |
 
 For local development, `env` or `file` avoids external dependencies entirely. Switch to a cloud secret manager when deploying to a managed environment where ambient identity is available.
 

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -254,7 +254,7 @@ docker run --rm \
   valontechnologies/gestaltd:latest
 ```
 
-For more advanced setups, Gestalt also supports `secret://...` references with the built-in `env` and `file` secret managers, or external secret provider packages such as `github.com/valon-technologies/gestalt-providers/secrets/google`, `.../secrets/aws`, `.../secrets/vault`, and `.../secrets/azure`.
+For more advanced setups, Gestalt also supports `secret://...` references. The built-in `env` and `file` providers are always available. Cloud secret backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) are available as external providers from [gestalt-providers](https://github.com/valon-technologies/gestalt-providers). See the [secrets documentation](https://gestaltd.ai/providers/secrets) for configuration details.
 
 ## Health endpoints
 


### PR DESCRIPTION
The cloud secret backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) were removed as builtins from the gestaltd binary but four doc files still listed them as compiled-in. This updates the reference docs, deploy guide, and DockerHub README to correctly describe only env and file as built-in, and point to the external providers in gestalt-providers for cloud backends.