### PR TITLE
bootstrap: teach resolveStringFields to handle yaml.Node natively

### DIFF
--- a/gestaltd/internal/bootstrap/secret_resolution.go
+++ b/gestaltd/internal/bootstrap/secret_resolution.go
@@ -13,6 +13,8 @@ import (
 
 const secretPrefix = "secret://"
 
+var yamlNodeType = reflect.TypeOf(yaml.Node{})
+
 // resolveSecretRefs walks the config struct and replaces any string value
 // starting with "secret://" with the resolved secret value. The
 // SecretsConfig.Config node is skipped to avoid self-referential resolution,
@@ -56,34 +58,20 @@ func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretMa
 					}
 				}
 			}
-			if err := resolveYAMLNode(&intg.Plugin.Config, resolve); err != nil {
-				return err
-			}
 		}
 		cfg.Plugins[name] = intg
 	}
-	if cfg.Auth.Provider != nil {
-		if err := resolveStringFields(cfg.Auth.Provider, resolve); err != nil {
+	// resolveStringFields handles both Provider (*ProviderDef, via pointer
+	// recursion) and Config (yaml.Node, via type detection) automatically.
+	// Secrets is handled separately to skip its Config node and avoid
+	// self-referential resolution.
+	for _, comp := range []*config.ComponentConfig{&cfg.Auth, &cfg.UI, &cfg.Telemetry, &cfg.Audit} {
+		if err := resolveStringFields(comp, resolve); err != nil {
 			return err
 		}
 	}
 	if cfg.Secrets.Provider != nil {
 		if err := resolveStringFields(cfg.Secrets.Provider, resolve); err != nil {
-			return err
-		}
-	}
-	if cfg.UI.Provider != nil {
-		if err := resolveStringFields(cfg.UI.Provider, resolve); err != nil {
-			return err
-		}
-	}
-	if cfg.Telemetry.Provider != nil {
-		if err := resolveStringFields(cfg.Telemetry.Provider, resolve); err != nil {
-			return err
-		}
-	}
-	if cfg.Audit.Provider != nil {
-		if err := resolveStringFields(cfg.Audit.Provider, resolve); err != nil {
 			return err
 		}
 	}
@@ -93,24 +81,7 @@ func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretMa
 		if err := resolveStringFields(&ds, resolve); err != nil {
 			return err
 		}
-		if err := resolveYAMLNode(&ds.Config, resolve); err != nil {
-			return err
-		}
 		cfg.IndexedDBs[name] = ds
-	}
-
-	// Skip cfg.Secrets.Config to avoid self-referential resolution.
-	if err := resolveYAMLNode(&cfg.Auth.Config, resolve); err != nil {
-		return err
-	}
-	if err := resolveYAMLNode(&cfg.UI.Config, resolve); err != nil {
-		return err
-	}
-	if err := resolveYAMLNode(&cfg.Telemetry.Config, resolve); err != nil {
-		return err
-	}
-	if err := resolveYAMLNode(&cfg.Audit.Config, resolve); err != nil {
-		return err
 	}
 
 	return nil
@@ -133,8 +104,15 @@ func resolveStringFields(ptr any, resolve func(string) (string, error)) error {
 			field.SetString(resolved)
 		case reflect.Struct:
 			if field.CanSet() {
-				if err := resolveStringFields(field.Addr().Interface(), resolve); err != nil {
-					return err
+				if field.Type() == yamlNodeType {
+					nodePtr := field.Addr().Interface().(*yaml.Node)
+					if err := resolveYAMLNode(nodePtr, resolve); err != nil {
+						return err
+					}
+				} else {
+					if err := resolveStringFields(field.Addr().Interface(), resolve); err != nil {
+						return err
+					}
 				}
 			}
 		case reflect.Pointer:


### PR DESCRIPTION
## Summary

- Extends the generic struct reflector in `resolveStringFields` to detect `yaml.Node` fields and delegate to `resolveYAMLNode` instead of incorrectly walking Go struct fields (which resolved Tag/Anchor/Comment and missed nested Content).
- Removes now-redundant explicit `resolveYAMLNode` calls for `Plugin.Config` and `IndexedDB.Config`, since their parent structs already pass through the reflector.
- Adds targeted unit tests for the new behavior: secret resolution, error propagation, and a regression guard ensuring YAML Tag fields are not mistakenly resolved.

## Test plan

- [x] New unit tests pass (`TestResolveStringFields_YAMLNode*`)
- [x] Existing integration tests pass, including `resolves_secret://_in_yaml.Node_indexeddb_config` and `resolves_secret://_in_yaml.Node_auth_config`
- [x] Full `go test ./internal/bootstrap/` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)