### PR TITLE
operator: expand libc-less linux archives to musl and glibc variants

### DIFF
--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -648,7 +648,38 @@ func (l *Lifecycle) buildArchivesMap(ctx context.Context, src pluginsource.Sourc
 		}
 		archives[pa.Platform] = LockArchive{URL: pa.URL}
 	}
+	expandLinuxLibCVariants(archives)
 	return archives
+}
+
+// expandLinuxLibCVariants ensures that libc-agnostic Linux archives
+// (e.g. "linux/amd64") are also available under explicit libc-qualified
+// keys ("linux/amd64/musl", "linux/amd64/glibc"). This allows platforms
+// like Alpine (musl) to find an exact match in the lockfile without
+// relying on runtime fallback resolution.
+func expandLinuxLibCVariants(archives map[string]LockArchive) {
+	var expansions []struct {
+		key     string
+		archive LockArchive
+	}
+	for key, archive := range archives {
+		goos, goarch, libc, err := pluginpkg.ParsePlatformString(key)
+		if err != nil || goos != "linux" || libc != "" {
+			continue
+		}
+		for _, variant := range []string{pluginpkg.LinuxLibCMusl, pluginpkg.LinuxLibCGLibC} {
+			variantKey := pluginpkg.PlatformString(goos, goarch, variant)
+			if _, exists := archives[variantKey]; !exists {
+				expansions = append(expansions, struct {
+					key     string
+					archive LockArchive
+				}{variantKey, LockArchive{URL: archive.URL}})
+			}
+		}
+	}
+	for _, e := range expansions {
+		archives[e.key] = e.archive
+	}
 }
 
 func (l *Lifecycle) writeProviderArtifacts(ctx context.Context, cfg *config.Config, paths initPaths) (map[string]LockProviderEntry, error) {

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -1193,3 +1193,104 @@ func TestResolveArchiveForPlatform(t *testing.T) {
 		t.Error("expected no match for darwin/arm64 when only windows is available")
 	}
 }
+
+func TestExpandLinuxLibCVariants(t *testing.T) {
+	t.Parallel()
+
+	t.Run("expands libc-less linux entry", func(t *testing.T) {
+		t.Parallel()
+		archives := map[string]LockArchive{
+			"linux/amd64": {URL: "https://example.com/linux-amd64"},
+		}
+		expandLinuxLibCVariants(archives)
+		if len(archives) != 3 {
+			t.Fatalf("got %d entries, want 3", len(archives))
+		}
+		if archives["linux/amd64/musl"].URL != "https://example.com/linux-amd64" {
+			t.Errorf("musl URL = %q", archives["linux/amd64/musl"].URL)
+		}
+		if archives["linux/amd64/glibc"].URL != "https://example.com/linux-amd64" {
+			t.Errorf("glibc URL = %q", archives["linux/amd64/glibc"].URL)
+		}
+	})
+
+	t.Run("does not overwrite explicit libc entry", func(t *testing.T) {
+		t.Parallel()
+		archives := map[string]LockArchive{
+			"linux/amd64":      {URL: "https://example.com/linux-amd64"},
+			"linux/amd64/musl": {URL: "https://example.com/linux-amd64-musl", SHA256: "abc"},
+		}
+		expandLinuxLibCVariants(archives)
+		if archives["linux/amd64/musl"].URL != "https://example.com/linux-amd64-musl" {
+			t.Error("explicit musl entry was overwritten")
+		}
+		if archives["linux/amd64/musl"].SHA256 != "abc" {
+			t.Error("explicit musl entry SHA256 was overwritten")
+		}
+		if archives["linux/amd64/glibc"].URL != "https://example.com/linux-amd64" {
+			t.Errorf("glibc URL = %q", archives["linux/amd64/glibc"].URL)
+		}
+	})
+
+	t.Run("skips non-linux entries", func(t *testing.T) {
+		t.Parallel()
+		archives := map[string]LockArchive{
+			"darwin/arm64": {URL: "https://example.com/darwin-arm64"},
+		}
+		expandLinuxLibCVariants(archives)
+		if len(archives) != 1 {
+			t.Fatalf("got %d entries, want 1", len(archives))
+		}
+	})
+
+	t.Run("skips entries that already have libc", func(t *testing.T) {
+		t.Parallel()
+		archives := map[string]LockArchive{
+			"linux/amd64/glibc": {URL: "https://example.com/linux-amd64-glibc"},
+		}
+		expandLinuxLibCVariants(archives)
+		if len(archives) != 1 {
+			t.Fatalf("got %d entries, want 1", len(archives))
+		}
+	})
+
+	t.Run("expands multiple architectures", func(t *testing.T) {
+		t.Parallel()
+		archives := map[string]LockArchive{
+			"linux/amd64": {URL: "https://example.com/linux-amd64"},
+			"linux/arm64": {URL: "https://example.com/linux-arm64"},
+		}
+		expandLinuxLibCVariants(archives)
+		if len(archives) != 6 {
+			t.Fatalf("got %d entries, want 6", len(archives))
+		}
+		if archives["linux/arm64/musl"].URL != "https://example.com/linux-arm64" {
+			t.Errorf("arm64 musl URL = %q", archives["linux/arm64/musl"].URL)
+		}
+	})
+
+	t.Run("skips generic key", func(t *testing.T) {
+		t.Parallel()
+		archives := map[string]LockArchive{
+			"generic": {URL: "https://example.com/generic"},
+		}
+		expandLinuxLibCVariants(archives)
+		if len(archives) != 1 {
+			t.Fatalf("got %d entries, want 1", len(archives))
+		}
+	})
+
+	t.Run("expanded entries have no sha256", func(t *testing.T) {
+		t.Parallel()
+		archives := map[string]LockArchive{
+			"linux/amd64": {URL: "https://example.com/linux-amd64", SHA256: "abc"},
+		}
+		expandLinuxLibCVariants(archives)
+		if archives["linux/amd64/musl"].SHA256 != "" {
+			t.Error("expanded musl entry should not inherit SHA256")
+		}
+		if archives["linux/amd64/glibc"].SHA256 != "" {
+			t.Error("expanded glibc entry should not inherit SHA256")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- When `buildArchivesMap` discovers a `linux/<arch>` archive without a libc qualifier (e.g. from a Go plugin built with `CGO_ENABLED=0`), the lockfile now also records `linux/<arch>/musl` and `linux/<arch>/glibc` entries pointing to the same URL
- This fixes `gestaltd init --platform linux/amd64/musl` silently doing nothing when only `linux/amd64` exists in the archives map, and fixes runtime resolution on Alpine failing the integrity check in `--locked` mode
- Explicit libc-specific archives from the release (e.g. a Rust plugin publishing `linux_amd64_musl.tar.gz`) take precedence and are not overwritten

## Test plan

- [x] `TestExpandLinuxLibCVariants` covers expansion, non-overwrite of explicit entries, skip non-linux, skip already-qualified, multiple architectures, skip generic, no SHA256 inheritance
- [x] `TestResolveArchiveForPlatform` still passes (no regression)
- [ ] Regenerate lockfile in a downstream repo and verify `linux/amd64/musl` entries appear
- [ ] Run `gestaltd init --platform linux/amd64/musl` and verify hash is computed

🤖 Generated with [Claude Code](https://claude.com/claude-code)