### PR TITLE
Update default IndexedDB provider path from datastore/ to indexeddb/

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -200,7 +200,7 @@ jobs:
 
       - name: Create local IndexedDB provider fixture
         run: |
-          provider_dir="$GITHUB_WORKSPACE/gestalt-providers/datastore/relationaldb"
+          provider_dir="$GITHUB_WORKSPACE/gestalt-providers/indexeddb/relationaldb"
           provider_src="$GITHUB_WORKSPACE/gestaltd/internal/testutil/testdata/provider-go-indexeddb"
           mkdir -p "$provider_dir"
           cp "$provider_src/manifest.yaml" "$provider_dir/manifest.yaml"

--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -206,8 +206,8 @@ datastores:
   main:
     provider:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
-        version: 0.0.1-alpha.1
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+        version: 0.0.1-alpha.2
     config:
       dsn: sqlite://./gestalt.db
 
@@ -344,8 +344,8 @@ datastores:
   main:
     provider:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
-        version: 0.0.1-alpha.1
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+        version: 0.0.1-alpha.2
     config:
       dsn: sqlite://./gestalt.db
 
@@ -392,8 +392,8 @@ datastores:
   main:
     provider:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
-        version: 0.0.1-alpha.1
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+        version: 0.0.1-alpha.2
     config:
       dsn: sqlite://./gestalt.db
 

--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -52,8 +52,8 @@ config:
     main:
       provider:
         source:
-          ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
-          version: 0.0.1-alpha.1
+          ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+          version: 0.0.1-alpha.2
       config:
         dsn: "${DATABASE_URL}"
   datastore: main
@@ -133,8 +133,8 @@ config:
     main:
       provider:
         source:
-          ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
-          version: 0.0.1-alpha.1
+          ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+          version: 0.0.1-alpha.2
       config:
         dsn: "${DATABASE_URL}"
   datastore: main

--- a/docs/content/deploy/index.mdx
+++ b/docs/content/deploy/index.mdx
@@ -8,7 +8,7 @@ The server image `valontechnologies/gestaltd:latest` is published for `linux/amd
 
 ## Production considerations
 
-**Database.** SQLite works for single-instance deployments. For multi-replica or horizontally scaled deployments, use a networked datastore provider such as the first-party `datastore/relationaldb` package with a Postgres or MySQL DSN. See [Datastores](/providers/datastores) for the provider model.
+**Database.** SQLite works for single-instance deployments. For multi-replica or horizontally scaled deployments, use a networked datastore provider such as the first-party `indexeddb/relationaldb` package with a Postgres or MySQL DSN. See [Datastores](/providers/datastores) for the provider model.
 
 **Secrets.** Use `file` or a cloud secret manager instead of `env` in production. `file` is built in and works with Kubernetes volume-mounted secrets. Cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) are available as external providers from [`gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). Gestalt config supports `secret://` references that are resolved at boot time through the configured secrets provider. See [Secrets Providers](/providers/secrets) for setup details.
 

--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -36,8 +36,8 @@ datastores:
   main:
     provider:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
-        version: 0.0.1-alpha.1
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+        version: 0.0.1-alpha.2
     config:
       dsn: sqlite://./gestalt.db
 
@@ -72,8 +72,8 @@ datastores:
   main:
     provider:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
-        version: 0.0.1-alpha.1
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+        version: 0.0.1-alpha.2
     config:
       dsn: sqlite://./gestalt.db
 
@@ -154,8 +154,8 @@ datastores:
   main:
     provider:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
-        version: 0.0.1-alpha.1
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+        version: 0.0.1-alpha.2
     config:
       dsn: sqlite://./gestalt.db
 

--- a/docs/content/providers/datastores.mdx
+++ b/docs/content/providers/datastores.mdx
@@ -272,7 +272,7 @@ datastores:
   main:
     provider:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
         version: 0.0.1
     config:
       dsn: ${DATABASE_URL}

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -36,7 +36,7 @@ datastores:
   main:
     provider:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
         version: 1.0.0
     config:
       dsn: ${DATABASE_URL}

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -147,8 +147,8 @@ datastores:
   main:
     provider:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
-        version: 0.0.1-alpha.1
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+        version: 0.0.1-alpha.2
     config:
       dsn: ${DATABASE_URL}
 

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -82,8 +82,8 @@ datastores:
   main:
     provider:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
-        version: 0.0.1-alpha.1
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+        version: 0.0.1-alpha.2
     config:
       dsn: sqlite:///data/gestalt.db
 datastore: main
@@ -109,8 +109,8 @@ datastores:
   main:
     provider:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
-        version: 0.0.1-alpha.1
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+        version: 0.0.1-alpha.2
     config:
       dsn: sqlite:///data/gestalt.db
 datastore: main

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -279,8 +279,8 @@ func authIndexedDBConfigYAML(t *testing.T, dir, authName, datastoreName, dbPath 
   %s:
     provider:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
-        version: 0.0.1-alpha.1
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+        version: 0.0.1-alpha.2
     config:
       dsn: %q
 indexeddb: %s

--- a/gestaltd/deploy/helm/gestalt/values.yaml
+++ b/gestaltd/deploy/helm/gestalt/values.yaml
@@ -95,8 +95,8 @@ config:
       # deployments with mounted persistent storage at /data.
       provider:
         source:
-          ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
-          version: 0.0.1-alpha.1
+          ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+          version: 0.0.1-alpha.2
       config:
         dsn: "sqlite:///data/gestalt.db"
   datastore: main

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -28,8 +28,8 @@ const (
 	DefaultWebUIProvider = DefaultProviderRepo + "/web/default"
 	DefaultWebUIVersion  = "0.0.1-alpha.9"
 
-	DefaultIndexedDBProvider = DefaultProviderRepo + "/datastore/relationaldb"
-	DefaultIndexedDBVersion  = "0.0.1-alpha.1"
+	DefaultIndexedDBProvider = DefaultProviderRepo + "/indexeddb/relationaldb"
+	DefaultIndexedDBVersion  = "0.0.1-alpha.2"
 )
 
 // PluginConnectionName is the implicit connection name used when storing

--- a/gestaltd/internal/operator/localconfig.go
+++ b/gestaltd/internal/operator/localconfig.go
@@ -94,5 +94,5 @@ server:
   public:
     port: 8080
   encryptionKey: %q
-`, filepath.Join(providersDir, "datastore", "relationaldb", "manifest.yaml"), "sqlite://"+dbPath, filepath.Join(providersDir, "web", "default", "manifest.yaml"), encryptionKey)
+`, filepath.Join(providersDir, "indexeddb", "relationaldb", "manifest.yaml"), "sqlite://"+dbPath, filepath.Join(providersDir, "web", "default", "manifest.yaml"), encryptionKey)
 }

--- a/gestaltd/internal/testutil/testdata/provider-go/config.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-go/config.yaml
@@ -2,8 +2,8 @@ datastores:
   main:
     provider:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
-        version: 0.0.1-alpha.1
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+        version: 0.0.1-alpha.2
     config:
       dsn: sqlite://./example.db
 

--- a/gestaltd/internal/testutil/testdata/provider-rust/config.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-rust/config.yaml
@@ -2,8 +2,8 @@ datastores:
   main:
     provider:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/datastore/relationaldb
-        version: 0.0.1-alpha.1
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+        version: 0.0.1-alpha.2
     config:
       dsn: sqlite://./example.db
 


### PR DESCRIPTION
The upstream gestalt-providers repo refactored its directory layout, moving the first-party relational database provider from datastore/relationaldb to indexeddb/relationaldb. This updates the default provider source ref and version across gestaltd constants, CI fixtures, Helm values, test configs, and all documentation to match the new path and latest published release (0.0.1-alpha.2).