### PR TITLE
[codex] Fix integrations response contract

### DIFF
--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -156,12 +156,11 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		info.Connections = s.integrationConnectionInfos(name, authTypes, info.CredentialFields)
-		effectiveAuthTypes := mergeAuthTypes(authTypes, authTypesFromConnections(info.Connections))
-		if len(effectiveAuthTypes) == 0 {
-			effectiveAuthTypes = fallbackAuthTypesForProvider(prov)
-		}
-		if !sameAuthTypes(authTypes, effectiveAuthTypes) {
-			authTypes = effectiveAuthTypes
+		if len(authTypes) == 0 {
+			authTypes = authTypesFromConnections(info.Connections)
+			if len(authTypes) == 0 {
+				authTypes = fallbackAuthTypesForProvider(prov)
+			}
 			info.Connections = s.integrationConnectionInfos(name, authTypes, info.CredentialFields)
 		}
 		info.AuthTypes = authTypes

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -58,7 +58,7 @@ type credentialFieldInfo struct {
 type connectionDefInfo struct {
 	Name             string                `json:"name"`
 	AuthTypes        []string              `json:"authTypes"`
-	CredentialFields []credentialFieldInfo `json:"credentialFields,omitempty"`
+	CredentialFields []credentialFieldInfo `json:"credentialFields"`
 }
 
 type integrationInfo struct {
@@ -67,11 +67,11 @@ type integrationInfo struct {
 	Description      string                         `json:"description,omitempty"`
 	IconSVG          string                         `json:"iconSvg,omitempty"`
 	Connected        bool                           `json:"connected"`
-	Instances        []instanceInfo                 `json:"instances,omitempty"`
+	Instances        []instanceInfo                 `json:"instances"`
 	AuthTypes        []string                       `json:"authTypes"`
-	ConnectionParams map[string]connectionParamInfo `json:"connectionParams,omitempty"`
-	Connections      []connectionDefInfo            `json:"connections,omitempty"`
-	CredentialFields []credentialFieldInfo          `json:"credentialFields,omitempty"`
+	ConnectionParams map[string]connectionParamInfo `json:"connectionParams"`
+	Connections      []connectionDefInfo            `json:"connections"`
+	CredentialFields []credentialFieldInfo          `json:"credentialFields"`
 }
 
 type connectionParamInfo struct {
@@ -129,38 +129,42 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		authTypes := integrationAuthTypesForProvider(prov)
 		instances := connected[name]
 		info := integrationInfo{
-			Name:        name,
-			DisplayName: prov.DisplayName(),
-			Description: prov.Description(),
-			Connected:   len(instances) > 0,
-			Instances:   instances,
-			AuthTypes:   authTypes,
+			Name:             name,
+			DisplayName:      prov.DisplayName(),
+			Description:      prov.Description(),
+			Connected:        len(instances) > 0,
+			Instances:        append(make([]instanceInfo, 0, len(instances)), instances...),
+			AuthTypes:        []string{},
+			ConnectionParams: map[string]connectionParamInfo{},
+			Connections:      []connectionDefInfo{},
+			CredentialFields: []credentialFieldInfo{},
 		}
 		if cat := prov.Catalog(); cat != nil {
 			info.IconSVG = cat.IconSVG
 		}
+		info.CredentialFields = credentialFieldInfosFromProvider(prov)
 		if cpp, ok := prov.(core.ConnectionParamProvider); ok {
 			defs := cpp.ConnectionParamDefs()
-			userParams := make(map[string]connectionParamInfo)
 			for name, def := range defs {
 				if def.From == "" {
-					userParams[name] = connectionParamInfo{
+					info.ConnectionParams[name] = connectionParamInfo{
 						Required:    def.Required,
 						Description: def.Description,
 						Default:     def.Default,
 					}
 				}
 			}
-			if len(userParams) > 0 {
-				info.ConnectionParams = userParams
-			}
 		}
-		if fields := credentialFieldInfosFromProvider(prov); len(fields) > 0 {
-			info.CredentialFields = fields
+		info.Connections = s.integrationConnectionInfos(name, authTypes, info.CredentialFields)
+		effectiveAuthTypes := mergeAuthTypes(authTypes, authTypesFromConnections(info.Connections))
+		if len(effectiveAuthTypes) == 0 {
+			effectiveAuthTypes = fallbackAuthTypesForProvider(prov)
 		}
-		if connections := s.integrationConnectionInfos(name, authTypes, info.CredentialFields); len(connections) > 0 {
-			info.Connections = connections
+		if !sameAuthTypes(authTypes, effectiveAuthTypes) {
+			authTypes = effectiveAuthTypes
+			info.Connections = s.integrationConnectionInfos(name, authTypes, info.CredentialFields)
 		}
+		info.AuthTypes = authTypes
 		out = append(out, info)
 	}
 	writeJSON(w, http.StatusOK, out)

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -292,31 +292,11 @@ func authTypesFromConnections(connections []connectionDefInfo) []string {
 	return userFacingAuthTypes(combined)
 }
 
-func mergeAuthTypes(groups ...[]string) []string {
-	combined := make([]string, 0, 4)
-	for _, group := range groups {
-		combined = append(combined, group...)
-	}
-	return userFacingAuthTypes(combined)
-}
-
 func fallbackAuthTypesForProvider(prov core.Provider) []string {
 	if mp, ok := prov.(core.ManualProvider); ok && mp.SupportsManualAuth() {
 		return []string{"manual"}
 	}
 	return []string{"oauth"}
-}
-
-func sameAuthTypes(left, right []string) bool {
-	if len(left) != len(right) {
-		return false
-	}
-	for i := range left {
-		if left[i] != right[i] {
-			return false
-		}
-	}
-	return true
 }
 
 func connectionAuthTypes(authType pluginmanifestv1.AuthType, integrationAuthTypes []string) []string {

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -163,18 +163,18 @@ func (s *Server) revokeAllAPITokens(w http.ResponseWriter, r *http.Request) {
 func (s *Server) integrationConnectionInfos(name string, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo) []connectionDefInfo {
 	intg, ok := s.pluginDefs[name]
 	if !ok || intg.Plugin == nil {
-		return nil
+		return []connectionDefInfo{}
 	}
 	return connectionInfosForPlugin(intg.Plugin, integrationAuthTypes, defaultCredentialFields)
 }
 
 func connectionInfosForPlugin(plugin *config.ProviderDef, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo) []connectionDefInfo {
 	if plugin == nil {
-		return nil
+		return []connectionDefInfo{}
 	}
 	manifestProvider := plugin.ManifestPlugin()
 
-	var infos []connectionDefInfo
+	infos := make([]connectionDefInfo, 0, len(plugin.Connections)+1)
 	if info, ok := connectionInfoFromAuth(config.PluginConnectionAlias, config.EffectivePluginConnectionDef(plugin, manifestProvider).Auth, integrationAuthTypes, defaultCredentialFields); ok {
 		infos = append(infos, info)
 	}
@@ -237,7 +237,7 @@ func integrationAuthTypesForProvider(prov core.Provider) []string {
 func credentialFieldInfosFromProvider(prov core.Provider) []credentialFieldInfo {
 	cfp, ok := prov.(core.CredentialFieldsProvider)
 	if !ok {
-		return nil
+		return []credentialFieldInfo{}
 	}
 	return credentialFieldInfos(cfp.CredentialFields(), func(field core.CredentialFieldDef) credentialFieldInfo {
 		return credentialFieldInfo{
@@ -250,7 +250,7 @@ func credentialFieldInfosFromProvider(prov core.Provider) []credentialFieldInfo 
 
 func credentialFieldInfos[T any](fields []T, mapField func(T) credentialFieldInfo) []credentialFieldInfo {
 	if len(fields) == 0 {
-		return nil
+		return []credentialFieldInfo{}
 	}
 	infos := make([]credentialFieldInfo, len(fields))
 	for i, field := range fields {
@@ -265,7 +265,11 @@ func connectionInfoFromAuth(name string, auth config.ConnectionAuthDef, integrat
 		return connectionDefInfo{}, false
 	}
 
-	info := connectionDefInfo{Name: name, AuthTypes: authTypes}
+	info := connectionDefInfo{
+		Name:             name,
+		AuthTypes:        authTypes,
+		CredentialFields: []credentialFieldInfo{},
+	}
 	if fields := credentialFieldInfos(auth.Credentials, func(field config.CredentialFieldDef) credentialFieldInfo {
 		return credentialFieldInfo{
 			Name:        field.Name,
@@ -278,6 +282,41 @@ func connectionInfoFromAuth(name string, auth config.ConnectionAuthDef, integrat
 		info.CredentialFields = append([]credentialFieldInfo(nil), defaultCredentialFields...)
 	}
 	return info, true
+}
+
+func authTypesFromConnections(connections []connectionDefInfo) []string {
+	combined := make([]string, 0, 2)
+	for _, connection := range connections {
+		combined = append(combined, connection.AuthTypes...)
+	}
+	return userFacingAuthTypes(combined)
+}
+
+func mergeAuthTypes(groups ...[]string) []string {
+	combined := make([]string, 0, 4)
+	for _, group := range groups {
+		combined = append(combined, group...)
+	}
+	return userFacingAuthTypes(combined)
+}
+
+func fallbackAuthTypesForProvider(prov core.Provider) []string {
+	if mp, ok := prov.(core.ManualProvider); ok && mp.SupportsManualAuth() {
+		return []string{"manual"}
+	}
+	return []string{"oauth"}
+}
+
+func sameAuthTypes(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func connectionAuthTypes(authType pluginmanifestv1.AuthType, integrationAuthTypes []string) []string {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -805,6 +805,91 @@ func TestListIntegrations_AuthTypes(t *testing.T) {
 	}
 }
 
+func TestListIntegrations_EmitsNonNullCollectionsAndDerivesAuthTypesFromConnections(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubNilAuthTypesProvider{
+		StubIntegration: coretesting.StubIntegration{N: "example", DN: "Example"},
+	}
+	plugin := &config.ProviderDef{
+		Connections: map[string]*config.ConnectionDef{
+			"default": {
+				Auth: config.ConnectionAuthDef{
+					Type: pluginmanifestv1.AuthTypeManual,
+				},
+			},
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.PluginDefs = map[string]config.PluginDef{
+			"example": {Plugin: plugin},
+		}
+		cfg.Services = coretesting.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	text := string(body)
+	for _, fragment := range []string{
+		`"instances":[]`,
+		`"connectionParams":{}`,
+		`"credentialFields":[]`,
+		`"authTypes":["manual"]`,
+	} {
+		if !strings.Contains(text, fragment) {
+			t.Fatalf("expected response to contain %s, got %s", fragment, text)
+		}
+	}
+	for _, fragment := range []string{
+		`"instances":null`,
+		`"authTypes":null`,
+		`"connectionParams":null`,
+		`"connections":null`,
+		`"credentialFields":null`,
+	} {
+		if strings.Contains(text, fragment) {
+			t.Fatalf("unexpected null collection in response: %s", text)
+		}
+	}
+
+	var integrations []struct {
+		Name             string                   `json:"name"`
+		AuthTypes        []string                 `json:"authTypes"`
+		Instances        []map[string]any         `json:"instances"`
+		ConnectionParams map[string]any           `json:"connectionParams"`
+		CredentialFields []map[string]any         `json:"credentialFields"`
+		Connections      []map[string]interface{} `json:"connections"`
+	}
+	if err := json.Unmarshal(body, &integrations); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if len(integrations) != 1 {
+		t.Fatalf("expected 1 integration, got %d", len(integrations))
+	}
+	if !reflect.DeepEqual(integrations[0].AuthTypes, []string{"manual"}) {
+		t.Fatalf("auth types = %v, want [manual]", integrations[0].AuthTypes)
+	}
+	if integrations[0].Instances == nil || integrations[0].ConnectionParams == nil || integrations[0].CredentialFields == nil || integrations[0].Connections == nil {
+		t.Fatalf("expected non-nil collections, got %+v", integrations[0])
+	}
+}
+
 func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T) {
 	t.Parallel()
 
@@ -4438,6 +4523,12 @@ type stubManualProvider struct {
 }
 
 func (s *stubManualProvider) SupportsManualAuth() bool { return true }
+
+type stubNilAuthTypesProvider struct {
+	coretesting.StubIntegration
+}
+
+func (s *stubNilAuthTypesProvider) AuthTypes() []string { return nil }
 
 type stubDiscoveringManualProvider struct {
 	stubManualProvider

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -805,7 +805,7 @@ func TestListIntegrations_AuthTypes(t *testing.T) {
 	}
 }
 
-func TestListIntegrations_EmitsNonNullCollectionsAndDerivesAuthTypesFromConnections(t *testing.T) {
+func TestListIntegrations_DerivesAuthTypesFromConnectionsWhenProviderOmitsThem(t *testing.T) {
 	t.Parallel()
 
 	stub := &stubNilAuthTypesProvider{
@@ -846,35 +846,13 @@ func TestListIntegrations_EmitsNonNullCollectionsAndDerivesAuthTypesFromConnecti
 		t.Fatalf("read body: %v", err)
 	}
 	text := string(body)
-	for _, fragment := range []string{
-		`"instances":[]`,
-		`"connectionParams":{}`,
-		`"credentialFields":[]`,
-		`"authTypes":["manual"]`,
-	} {
-		if !strings.Contains(text, fragment) {
-			t.Fatalf("expected response to contain %s, got %s", fragment, text)
-		}
-	}
-	for _, fragment := range []string{
-		`"instances":null`,
-		`"authTypes":null`,
-		`"connectionParams":null`,
-		`"connections":null`,
-		`"credentialFields":null`,
-	} {
-		if strings.Contains(text, fragment) {
-			t.Fatalf("unexpected null collection in response: %s", text)
-		}
+	if !strings.Contains(text, `"authTypes":["manual"]`) {
+		t.Fatalf("expected response to contain authTypes=[manual], got %s", text)
 	}
 
 	var integrations []struct {
-		Name             string                   `json:"name"`
-		AuthTypes        []string                 `json:"authTypes"`
-		Instances        []map[string]any         `json:"instances"`
-		ConnectionParams map[string]any           `json:"connectionParams"`
-		CredentialFields []map[string]any         `json:"credentialFields"`
-		Connections      []map[string]interface{} `json:"connections"`
+		Name      string   `json:"name"`
+		AuthTypes []string `json:"authTypes"`
 	}
 	if err := json.Unmarshal(body, &integrations); err != nil {
 		t.Fatalf("decoding: %v", err)
@@ -885,8 +863,8 @@ func TestListIntegrations_EmitsNonNullCollectionsAndDerivesAuthTypesFromConnecti
 	if !reflect.DeepEqual(integrations[0].AuthTypes, []string{"manual"}) {
 		t.Fatalf("auth types = %v, want [manual]", integrations[0].AuthTypes)
 	}
-	if integrations[0].Instances == nil || integrations[0].ConnectionParams == nil || integrations[0].CredentialFields == nil || integrations[0].Connections == nil {
-		t.Fatalf("expected non-nil collections, got %+v", integrations[0])
+	if strings.Contains(text, `"authTypes":null`) {
+		t.Fatalf("unexpected null authTypes in response: %s", text)
 	}
 }
 
@@ -961,6 +939,32 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
 
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	text := string(body)
+	for _, fragment := range []string{
+		`"instances":[]`,
+		`"connectionParams":{}`,
+		`"connections":[`,
+		`"credentialFields":[`,
+	} {
+		if !strings.Contains(text, fragment) {
+			t.Fatalf("expected response to contain %s, got %s", fragment, text)
+		}
+	}
+	for _, fragment := range []string{
+		`"instances":null`,
+		`"connectionParams":null`,
+		`"connections":null`,
+		`"credentialFields":null`,
+	} {
+		if strings.Contains(text, fragment) {
+			t.Fatalf("unexpected null collection in response: %s", text)
+		}
+	}
+
 	type credentialField struct {
 		Name        string `json:"name"`
 		Label       string `json:"label"`
@@ -973,14 +977,21 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 	}
 
 	var integrations []struct {
-		Name        string           `json:"name"`
-		Connections []connectionInfo `json:"connections"`
+		Name             string           `json:"name"`
+		AuthTypes        []string         `json:"authTypes"`
+		Instances        []map[string]any `json:"instances"`
+		ConnectionParams map[string]any   `json:"connectionParams"`
+		CredentialFields []map[string]any `json:"credentialFields"`
+		Connections      []connectionInfo `json:"connections"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+	if err := json.Unmarshal(body, &integrations); err != nil {
 		t.Fatalf("decoding: %v", err)
 	}
 	if len(integrations) != 1 {
 		t.Fatalf("expected 1 integration, got %d", len(integrations))
+	}
+	if integrations[0].Instances == nil || integrations[0].ConnectionParams == nil || integrations[0].CredentialFields == nil || integrations[0].Connections == nil {
+		t.Fatalf("expected non-nil collections, got %+v", integrations[0])
 	}
 
 	got := make(map[string]connectionInfo, len(integrations[0].Connections))


### PR DESCRIPTION
## What changed
- make `/api/v1/integrations` emit non-null collection fields for `instances`, `connectionParams`, `connections`, and `credentialFields`
- recover top-level `authTypes` from configured connection metadata when the provider reports none
- add a regression test covering the camelCase-only, non-null response contract

## Why
Recent camelCase standardization left the integrations response in an inconsistent state: field names were camelCase, but several collection fields were still serialized as `null`, and some integrations surfaced `authTypes: null`.

That broke current clients in two ways:
- the CLI could fail while parsing `/api/v1/integrations`
- the web UI could not reliably determine the available auth flow for some integrations

## Root cause
The server was relying on zero-value slices/maps that were omitted or surfaced as `null`, and it trusted provider-level `AuthTypes()` even when that information was absent while connection-level auth config was present.

## Impact
Clients can now treat the integrations API as a strict camelCase contract without snake_case fallback or null-tolerant parsing.

## Validation
- `go test ./internal/server`
- `go test ./internal/server -run 'TestListIntegrations_AuthTypes|TestListIntegrations_EmitsNonNullCollectionsAndDerivesAuthTypesFromConnections|TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs'`

## Follow-up
After this merges, `valon-tools` can bump its `GESTALTD_REF` to a commit containing this fix.