### PR TITLE
[codex] Fix slack oauth follow-ups

### DIFF
--- a/gestaltd/internal/egress/http.go
+++ b/gestaltd/internal/egress/http.go
@@ -8,6 +8,15 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/apiexec"
 )
 
+// CloneDefaultTransport returns an isolated transport initialized from the
+// process default transport when possible.
+func CloneDefaultTransport() *http.Transport {
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		return transport.Clone()
+	}
+	return &http.Transport{}
+}
+
 // HTTPRequestSpec is the generic outbound HTTP representation shared by
 // product-specific adapters.
 type HTTPRequestSpec struct {

--- a/gestaltd/internal/mcpoauth/discovery.go
+++ b/gestaltd/internal/mcpoauth/discovery.go
@@ -66,7 +66,8 @@ func (m *DiscoveredMetadata) PreferredAuthMethod() string {
 // RFC 9728 indirection (authorization_servers) and servers that embed
 // endpoints directly in resource metadata (ClickHouse).
 func Discover(ctx context.Context, mcpURL string) (*DiscoveredMetadata, error) {
-	client := &http.Client{Timeout: discoveryTimeout}
+	client, closeIdleConnections := newHTTPClient(discoveryTimeout)
+	defer closeIdleConnections()
 
 	resourceMetadataURL, err := probeForResourceMetadata(ctx, client, mcpURL)
 	if err != nil {

--- a/gestaltd/internal/mcpoauth/http_client.go
+++ b/gestaltd/internal/mcpoauth/http_client.go
@@ -3,19 +3,14 @@ package mcpoauth
 import (
 	"net/http"
 	"time"
+
+	"github.com/valon-technologies/gestalt/server/internal/egress"
 )
 
 func newHTTPClient(timeout time.Duration) (*http.Client, func()) {
-	transport := cloneDefaultTransport()
+	transport := egress.CloneDefaultTransport()
 	return &http.Client{
 		Timeout:   timeout,
 		Transport: transport,
 	}, transport.CloseIdleConnections
-}
-
-func cloneDefaultTransport() *http.Transport {
-	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
-		return transport.Clone()
-	}
-	return &http.Transport{}
 }

--- a/gestaltd/internal/mcpoauth/http_client.go
+++ b/gestaltd/internal/mcpoauth/http_client.go
@@ -1,0 +1,21 @@
+package mcpoauth
+
+import (
+	"net/http"
+	"time"
+)
+
+func newHTTPClient(timeout time.Duration) (*http.Client, func()) {
+	transport := cloneDefaultTransport()
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}, transport.CloseIdleConnections
+}
+
+func cloneDefaultTransport() *http.Transport {
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		return transport.Clone()
+	}
+	return &http.Transport{}
+}

--- a/gestaltd/internal/mcpoauth/mcpoauth_test.go
+++ b/gestaltd/internal/mcpoauth/mcpoauth_test.go
@@ -389,4 +389,86 @@ func TestMCPOAuthFlow(t *testing.T) {
 			t.Fatalf("re-registered client_id = %q, want client-002", parsed3.Query().Get("client_id"))
 		}
 	})
+
+	t.Run("IsolatedFromDefaultTransportCloseIdleConnections", func(t *testing.T) {
+		t.Parallel()
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("POST /mcp", func(w http.ResponseWriter, r *http.Request) {
+			baseURL := "http://" + r.Host
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf(
+				`Bearer resource_metadata="%s/.well-known/oauth-protected-resource/mcp"`, baseURL))
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+		mux.HandleFunc("GET /.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
+			baseURL := "http://" + r.Host
+			writeJSON(w, 0, map[string]any{
+				"resource":              baseURL + "/mcp",
+				"authorization_servers": []string{baseURL},
+			})
+		})
+		mux.HandleFunc("GET /.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+			baseURL := "http://" + r.Host
+			writeJSON(w, 0, map[string]any{
+				"issuer":                                baseURL,
+				"authorization_endpoint":                baseURL + "/oauth/authorize",
+				"token_endpoint":                        baseURL + "/oauth/token",
+				"registration_endpoint":                 baseURL + "/oauth/register",
+				"code_challenge_methods_supported":      []string{"S256"},
+				"token_endpoint_auth_methods_supported": []string{"none"},
+			})
+		})
+		mux.HandleFunc("POST /oauth/register", func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, http.StatusCreated, map[string]any{"client_id": "client-001"})
+		})
+
+		srv := httptest.NewServer(mux)
+		testutil.CloseOnCleanup(t, srv)
+
+		handler := mcpoauth.NewHandler(mcpoauth.HandlerConfig{
+			MCPURL:      srv.URL + "/mcp",
+			RedirectURL: "http://localhost:9999/callback",
+		})
+
+		defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			t.Fatalf("http.DefaultTransport = %T, want *http.Transport", http.DefaultTransport)
+		}
+
+		stop := make(chan struct{})
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					defaultTransport.CloseIdleConnections()
+				}
+			}
+		}()
+		t.Cleanup(func() {
+			close(stop)
+			<-done
+		})
+
+		for i := range 5 {
+			authURL, verifier := handler.StartOAuth(fmt.Sprintf("s%d", i+1), nil)
+			if authURL == "" {
+				t.Fatalf("StartOAuth #%d returned empty authURL", i+1)
+			}
+			if verifier == "" {
+				t.Fatalf("StartOAuth #%d returned empty verifier", i+1)
+			}
+			parsed, err := url.Parse(authURL)
+			if err != nil {
+				t.Fatalf("parse auth URL #%d: %v", i+1, err)
+			}
+			if parsed.Query().Get("client_id") != "client-001" {
+				t.Fatalf("client_id #%d = %q, want client-001", i+1, parsed.Query().Get("client_id"))
+			}
+			handler.ClearRegistration()
+		}
+	})
 }

--- a/gestaltd/internal/mcpoauth/registration.go
+++ b/gestaltd/internal/mcpoauth/registration.go
@@ -52,7 +52,8 @@ func RegisterClient(ctx context.Context, endpoint, redirectURI, clientName, toke
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: discoveryTimeout}
+	client, closeIdleConnections := newHTTPClient(discoveryTimeout)
+	defer closeIdleConnections()
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("sending DCR request to %s: %w", endpoint, err)

--- a/gestaltd/internal/mcpupstream/upstream.go
+++ b/gestaltd/internal/mcpupstream/upstream.go
@@ -175,7 +175,7 @@ func (u *Upstream) connect(ctx context.Context, token string) (mcpclient.MCPClie
 		return u.client, nil
 	}
 
-	baseTransport := cloneDefaultTransport()
+	baseTransport := egress.CloneDefaultTransport()
 	httpClient := &http.Client{
 		Timeout:   httpTimeout,
 		Transport: egress.NewResolvingRoundTripper(baseTransport, u.resolver),
@@ -213,13 +213,6 @@ func (u *Upstream) connect(ctx context.Context, token string) (mcpclient.MCPClie
 	}
 
 	return &managedMCPClient{MCPClient: client, onClose: closeIdleConnections}, nil
-}
-
-func cloneDefaultTransport() *http.Transport {
-	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
-		return transport.Clone()
-	}
-	return &http.Transport{}
 }
 
 func (u *Upstream) discover(ctx context.Context, token string) (*catalog.Catalog, error) {

--- a/gestaltd/internal/pluginhost/convert.go
+++ b/gestaltd/internal/pluginhost/convert.go
@@ -2,6 +2,9 @@ package pluginhost
 
 import (
 	"encoding/json"
+	"fmt"
+	"reflect"
+	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
@@ -13,7 +16,11 @@ func structFromMap(values map[string]any) (*structpb.Struct, error) {
 	if len(values) == 0 {
 		return nil, nil
 	}
-	return structpb.NewStruct(values)
+	normalized, err := normalizeStructMap(values)
+	if err != nil {
+		return nil, err
+	}
+	return structpb.NewStruct(normalized)
 }
 
 func mapFromStruct(s *structpb.Struct) map[string]any {
@@ -139,4 +146,72 @@ func protoValueToAny(v *structpb.Value) any {
 		return nil
 	}
 	return v.AsInterface()
+}
+
+func normalizeStructMap(values map[string]any) (map[string]any, error) {
+	normalized := make(map[string]any, len(values))
+	for key, value := range values {
+		out, err := normalizeStructValue(value)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", key, err)
+		}
+		normalized[key] = out
+	}
+	return normalized, nil
+}
+
+func normalizeStructValue(value any) (any, error) {
+	switch v := value.(type) {
+	case nil:
+		return nil, nil
+	case time.Time:
+		return v.UTC().Format(time.RFC3339Nano), nil
+	case *time.Time:
+		if v == nil {
+			return nil, nil
+		}
+		return v.UTC().Format(time.RFC3339Nano), nil
+	case map[string]any:
+		return normalizeStructMap(v)
+	}
+
+	rv := reflect.ValueOf(value)
+	if !rv.IsValid() {
+		return nil, nil
+	}
+
+	switch rv.Kind() {
+	case reflect.Map:
+		if rv.IsNil() {
+			return nil, nil
+		}
+		if rv.Type().Key().Kind() != reflect.String {
+			return value, nil
+		}
+		normalized := make(map[string]any, rv.Len())
+		iter := rv.MapRange()
+		for iter.Next() {
+			out, err := normalizeStructValue(iter.Value().Interface())
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", iter.Key().String(), err)
+			}
+			normalized[iter.Key().String()] = out
+		}
+		return normalized, nil
+	case reflect.Slice, reflect.Array:
+		if rv.Kind() == reflect.Slice && rv.IsNil() {
+			return nil, nil
+		}
+		normalized := make([]any, rv.Len())
+		for i := 0; i < rv.Len(); i++ {
+			out, err := normalizeStructValue(rv.Index(i).Interface())
+			if err != nil {
+				return nil, fmt.Errorf("[%d]: %w", i, err)
+			}
+			normalized[i] = out
+		}
+		return normalized, nil
+	default:
+		return value, nil
+	}
 }

--- a/gestaltd/internal/pluginhost/convert_test.go
+++ b/gestaltd/internal/pluginhost/convert_test.go
@@ -1,0 +1,45 @@
+package pluginhost
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStructFromMap_NormalizesTimeValues(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.April, 11, 20, 31, 30, 840502000, time.UTC)
+	record := map[string]any{
+		"created_at": now,
+		"expires_at": &now,
+		"nested": map[string]any{
+			"updated_at": now,
+		},
+		"values": []any{now, &now},
+	}
+
+	s, err := structFromMap(record)
+	if err != nil {
+		t.Fatalf("structFromMap: %v", err)
+	}
+
+	got := s.AsMap()
+	want := now.Format(time.RFC3339Nano)
+	if got["created_at"] != want {
+		t.Fatalf("created_at = %#v, want %#v", got["created_at"], want)
+	}
+	if got["expires_at"] != want {
+		t.Fatalf("expires_at = %#v, want %#v", got["expires_at"], want)
+	}
+	nested, ok := got["nested"].(map[string]any)
+	if !ok || nested["updated_at"] != want {
+		t.Fatalf("nested = %#v, want updated_at=%#v", got["nested"], want)
+	}
+	values, ok := got["values"].([]any)
+	if !ok || len(values) != 2 {
+		t.Fatalf("values = %#v, want 2 normalized entries", got["values"])
+	}
+	if values[0] != want || values[1] != want {
+		t.Fatalf("values = %#v, want both %#v", values, want)
+	}
+}

--- a/gestaltd/internal/pluginhost/indexeddb_client.go
+++ b/gestaltd/internal/pluginhost/indexeddb_client.go
@@ -131,7 +131,7 @@ func (o *remoteObjectStore) GetKey(ctx context.Context, id string) (string, erro
 func (o *remoteObjectStore) Add(ctx context.Context, record indexeddb.Record) error {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	s, err := structpb.NewStruct(record)
+	s, err := structFromMap(record)
 	if err != nil {
 		return fmt.Errorf("marshal record: %w", err)
 	}
@@ -142,7 +142,7 @@ func (o *remoteObjectStore) Add(ctx context.Context, record indexeddb.Record) er
 func (o *remoteObjectStore) Put(ctx context.Context, record indexeddb.Record) error {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	s, err := structpb.NewStruct(record)
+	s, err := structFromMap(record)
 	if err != nil {
 		return fmt.Errorf("marshal record: %w", err)
 	}

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -165,17 +165,17 @@ func (s *Server) integrationConnectionInfos(name string, integrationAuthTypes []
 	if !ok || intg.Plugin == nil {
 		return []connectionDefInfo{}
 	}
-	return connectionInfosForPlugin(intg.Plugin, integrationAuthTypes, defaultCredentialFields)
+	return s.connectionInfosForPlugin(name, intg.Plugin, integrationAuthTypes, defaultCredentialFields)
 }
 
-func connectionInfosForPlugin(plugin *config.ProviderDef, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo) []connectionDefInfo {
+func (s *Server) connectionInfosForPlugin(integration string, plugin *config.ProviderDef, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo) []connectionDefInfo {
 	if plugin == nil {
 		return []connectionDefInfo{}
 	}
 	manifestProvider := plugin.ManifestPlugin()
 
 	infos := make([]connectionDefInfo, 0, len(plugin.Connections)+1)
-	if info, ok := connectionInfoFromAuth(config.PluginConnectionAlias, config.EffectivePluginConnectionDef(plugin, manifestProvider).Auth, integrationAuthTypes, defaultCredentialFields); ok {
+	if info, ok := s.connectionInfoFromAuth(integration, config.PluginConnectionAlias, config.EffectivePluginConnectionDef(plugin, manifestProvider).Auth, integrationAuthTypes, defaultCredentialFields); ok {
 		infos = append(infos, info)
 	}
 
@@ -207,7 +207,7 @@ func connectionInfosForPlugin(plugin *config.ProviderDef, integrationAuthTypes [
 		if !ok {
 			continue
 		}
-		if info, ok := connectionInfoFromAuth(name, conn.Auth, integrationAuthTypes, defaultCredentialFields); ok {
+		if info, ok := s.connectionInfoFromAuth(integration, name, conn.Auth, integrationAuthTypes, defaultCredentialFields); ok {
 			infos = append(infos, info)
 		}
 	}
@@ -259,8 +259,9 @@ func credentialFieldInfos[T any](fields []T, mapField func(T) credentialFieldInf
 	return infos
 }
 
-func connectionInfoFromAuth(name string, auth config.ConnectionAuthDef, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo) (connectionDefInfo, bool) {
+func (s *Server) connectionInfoFromAuth(integration, name string, auth config.ConnectionAuthDef, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo) (connectionDefInfo, bool) {
 	authTypes := connectionAuthTypes(auth.Type, integrationAuthTypes)
+	authTypes = s.supportedConnectionAuthTypes(integration, name, authTypes)
 	if len(authTypes) == 0 {
 		return connectionDefInfo{}, false
 	}
@@ -282,6 +283,32 @@ func connectionInfoFromAuth(name string, auth config.ConnectionAuthDef, integrat
 		info.CredentialFields = append([]credentialFieldInfo(nil), defaultCredentialFields...)
 	}
 	return info, true
+}
+
+func (s *Server) supportedConnectionAuthTypes(integration, connection string, authTypes []string) []string {
+	if !authTypesContain(authTypes, "oauth") || s.connectionAuth == nil {
+		return authTypes
+	}
+
+	connMap := s.connectionAuth()[integration]
+	if connMap == nil {
+		return removeAuthType(authTypes, "oauth")
+	}
+
+	if _, ok := connMap[config.ResolveConnectionAlias(connection)]; ok {
+		return authTypes
+	}
+	return removeAuthType(authTypes, "oauth")
+}
+
+func removeAuthType(authTypes []string, drop string) []string {
+	filtered := make([]string, 0, len(authTypes))
+	for _, authType := range authTypes {
+		if authType != drop {
+			filtered = append(filtered, authType)
+		}
+	}
+	return filtered
 }
 
 func authTypesFromConnections(connections []connectionDefInfo) []string {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1015,6 +1015,71 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 	}
 }
 
+func TestListIntegrations_ConnectionInfosHideOAuthConnectionsWithoutHandler(t *testing.T) {
+	t.Parallel()
+
+	stub := &coretesting.StubIntegration{N: "slack", DN: "Slack"}
+	plugin := &config.ProviderDef{
+		Source: &config.PluginSourceDef{
+			Ref:     "github.com/acme/plugins/slack",
+			Version: "1.0.0",
+		},
+		Connections: map[string]*config.ConnectionDef{
+			"default": {},
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.PluginDefs = map[string]config.PluginDef{
+			"slack": {Plugin: plugin},
+		}
+		cfg.ConnectionAuth = func() map[string]map[string]bootstrap.OAuthHandler {
+			return map[string]map[string]bootstrap.OAuthHandler{
+				"slack": {
+					"default": &testOAuthHandler{authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize"},
+				},
+			}
+		}
+		cfg.Services = coretesting.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var integrations []struct {
+		Name        string `json:"name"`
+		Connections []struct {
+			Name      string   `json:"name"`
+			AuthTypes []string `json:"authTypes"`
+		} `json:"connections"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if len(integrations) != 1 {
+		t.Fatalf("expected 1 integration, got %d", len(integrations))
+	}
+	if len(integrations[0].Connections) != 1 {
+		t.Fatalf("expected 1 connection, got %+v", integrations[0].Connections)
+	}
+	if integrations[0].Connections[0].Name != "default" {
+		t.Fatalf("expected only default connection, got %+v", integrations[0].Connections)
+	}
+	if !reflect.DeepEqual(integrations[0].Connections[0].AuthTypes, []string{"oauth"}) {
+		t.Fatalf("expected default authTypes [oauth], got %+v", integrations[0].Connections[0].AuthTypes)
+	}
+}
+
 func TestListIntegrations_ConnectionInfosIncludeProviderManualAuth(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed
Fix two remaining Slack connect regressions after the integrations response contract change:

- stop advertising the implicit `plugin` connection as OAuth-capable unless it actually has a runtime OAuth handler
- normalize `time.Time` and `*time.Time` values before sending IndexedDB records over the protobuf boundary so OAuth callback token persistence succeeds
- add regression tests for both behaviors

## Why
The current Slack config exposes two connections in the CLI/UI:

- `plugin` (the implicit `_plugin` connection)
- `default` (the named configured connection)

Only `default` actually has an OAuth handler. The integrations API was still marking `plugin` as OAuth-capable because it inherited provider-level auth metadata, so the CLI offered a broken path that failed immediately.

Separately, the browser OAuth flow was succeeding with Slack and then failing during `post_connect` while saving the token. Cloud Run logs showed `marshal record: proto: invalid type: *time.Time`, which came from passing token timestamp fields directly through the IndexedDB gRPC adapter.

## Impact
- `gestalt integrations connect slack` should only offer the working OAuth path
- the web callback path should be able to finish saving the Slack connection instead of failing on the confirmation page

## Validation
- `go test ./internal/server ./internal/pluginhost ./internal/coredata`
