### PR TITLE
[codex] Fix generic archive hashing during init

### DIFF
--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -590,7 +590,7 @@ func lockEntryMatches(paths initPaths, name string, plugin *config.ProviderDef, 
 	}
 	if len(entry.Archives) > 0 {
 		platform := pluginpkg.CurrentPlatformString()
-		if _, ok := resolveArchiveForPlatform(entry, platform); !ok {
+		if _, _, ok := resolveArchiveForPlatform(entry, platform); !ok {
 			return false
 		}
 	}
@@ -609,23 +609,23 @@ func lockEntryMatches(paths initPaths, name string, plugin *config.ProviderDef, 
 
 // resolveArchiveForPlatform looks up a LockArchive for the given platform
 // string using a fallback chain: exact match → without libc → generic.
-func resolveArchiveForPlatform(entry LockEntry, platform string) (LockArchive, bool) {
+func resolveArchiveForPlatform(entry LockEntry, platform string) (LockArchive, string, bool) {
 	if a, ok := entry.Archives[platform]; ok {
-		return a, true
+		return a, platform, true
 	}
 	goos, goarch, err := pluginpkg.ParsePlatformString(platform)
 	if err == nil {
 		key := pluginpkg.PlatformString(goos, goarch)
 		if key != platform {
 			if a, ok := entry.Archives[key]; ok {
-				return a, true
+				return a, key, true
 			}
 		}
 	}
 	if a, ok := entry.Archives[platformKeyGeneric]; ok {
-		return a, true
+		return a, platformKeyGeneric, true
 	}
-	return LockArchive{}, false
+	return LockArchive{}, "", false
 }
 
 // buildArchivesMap constructs the Archives map for a lock entry. It enumerates
@@ -1288,7 +1288,7 @@ func bindResolvedUIManifest(plugin *config.ProviderDef, manifestPath string, man
 
 func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPaths, name string, plugin *config.ProviderDef, entry LockProviderEntry, locked bool) error {
 	platform := pluginpkg.CurrentPlatformString()
-	archive, ok := resolveArchiveForPlatform(entry, platform)
+	archive, _, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {
 		return fmt.Errorf("no archive for platform %s for provider %q; run `gestaltd init --config %s`", platform, name, paths.configPath)
 	}
@@ -1340,7 +1340,7 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPat
 
 func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPaths, kind, name string, plugin *config.ProviderDef, entry LockEntry, locked bool) error {
 	platform := pluginpkg.CurrentPlatformString()
-	archive, ok := resolveArchiveForPlatform(entry, platform)
+	archive, _, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {
 		return fmt.Errorf("no archive for platform %s for %s %q; run `gestaltd init --config %s`", platform, kind, name, paths.configPath)
 	}
@@ -1411,7 +1411,7 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 
 func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths initPaths, plugin *config.ProviderDef, entry LockUIEntry, locked bool) error {
 	platform := pluginpkg.CurrentPlatformString()
-	archive, ok := resolveArchiveForPlatform(entry, platform)
+	archive, _, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {
 		return fmt.Errorf("no archive for platform %s for ui provider; run `gestaltd init --config %s`", platform, paths.configPath)
 	}
@@ -1490,7 +1490,7 @@ func hashArchiveEntry(ctx context.Context, entry *LockEntry, platformKey string,
 	if entry.Archives == nil {
 		return nil
 	}
-	archive, ok := entry.Archives[platformKey]
+	archive, resolvedKey, ok := resolveArchiveForPlatform(*entry, platformKey)
 	if !ok || archive.URL == "" || archive.SHA256 != "" {
 		return nil
 	}
@@ -1514,7 +1514,7 @@ func hashArchiveEntry(ctx context.Context, entry *LockEntry, platformKey string,
 	}
 	archive.SHA256 = dl.SHA256Hex
 	dl.Cleanup()
-	entry.Archives[platformKey] = archive
+	entry.Archives[resolvedKey] = archive
 	return nil
 }
 

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1181,7 +1182,7 @@ func TestResolveArchiveForPlatform(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			archive, ok := resolveArchiveForPlatform(entry, tt.platform)
+			archive, _, ok := resolveArchiveForPlatform(entry, tt.platform)
 			if ok != tt.wantOK {
 				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
 			}
@@ -1193,7 +1194,37 @@ func TestResolveArchiveForPlatform(t *testing.T) {
 
 	// No match at all
 	sparse := LockEntry{Archives: map[string]LockArchive{"windows/amd64": {URL: "x"}}}
-	if _, ok := resolveArchiveForPlatform(sparse, "darwin/arm64"); ok {
+	if _, _, ok := resolveArchiveForPlatform(sparse, "darwin/arm64"); ok {
 		t.Error("expected no match for darwin/arm64 when only windows is available")
+	}
+}
+
+func TestHashArchiveEntry_HashesFallbackArchive(t *testing.T) {
+	t.Parallel()
+
+	const payload = "generic plugin archive"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer server.Close()
+
+	entry := LockEntry{
+		Source: server.URL,
+		Archives: map[string]LockArchive{
+			platformKeyGeneric: {URL: server.URL},
+		},
+	}
+
+	if err := hashArchiveEntry(context.Background(), &entry, "linux/amd64", nil); err != nil {
+		t.Fatalf("hashArchiveEntry: %v", err)
+	}
+
+	got := entry.Archives[platformKeyGeneric]
+	if got.URL != server.URL {
+		t.Fatalf("generic URL = %q, want %q", got.URL, server.URL)
+	}
+	want := sha256.Sum256([]byte(payload))
+	if got.SHA256 != hex.EncodeToString(want[:]) {
+		t.Fatalf("generic SHA256 = %q, want %q", got.SHA256, hex.EncodeToString(want[:]))
 	}
 }


### PR DESCRIPTION
## Summary
Fix `gestaltd init --platform ...` so it hashes whichever archive actually resolves for the requested platform, including libc-less and `generic` fallback archives.

## Why
The previous implementation only hashed an exact `archives[platform]` entry. When a plugin only exposed a `generic` archive, the lockfile still lacked a verified hash for the runtime fallback path and `serve --locked` failed on Cloud Run.

## Validation
- `go test ./internal/operator`