### PR TITLE
Remove redundant types, instrument IndexedDB metrics, clean dead code

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -451,8 +451,8 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		<-result.ProvidersReady
 
 		var decoded struct {
-			Source *config.PluginSourceDef `yaml:"source"`
-			Config map[string]string       `yaml:"config"`
+			Source *config.ProviderSource `yaml:"source"`
+			Config map[string]string      `yaml:"config"`
 		}
 		if err := receivedNode.Decode(&decoded); err != nil {
 			t.Fatalf("decode: %v", err)
@@ -537,8 +537,8 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		<-result.ProvidersReady
 
 		var authCfg struct {
-			Source *config.PluginSourceDef `yaml:"source"`
-			Config map[string]string       `yaml:"config"`
+			Source *config.ProviderSource `yaml:"source"`
+			Config map[string]string      `yaml:"config"`
 		}
 		if err := authNode.Decode(&authCfg); err != nil {
 			t.Fatalf("decode auth node: %v", err)

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -61,11 +61,11 @@ type ProvidersConfig struct {
 //   - Managed: source: {ref, version} -> ProviderSource{Ref: "...", Version: "..."}
 //   - Local:   source: {path}         -> ProviderSource{Path: "..."}
 type ProviderSource struct {
-	Builtin string               `yaml:"-"`
-	Ref     string               `yaml:"ref,omitempty"`
-	Version string               `yaml:"version,omitempty"`
-	Path    string               `yaml:"path,omitempty"`
-	Auth    *PluginSourceAuthDef `yaml:"auth,omitempty"`
+	Builtin string         `yaml:"-"`
+	Ref     string         `yaml:"ref,omitempty"`
+	Version string         `yaml:"version,omitempty"`
+	Path    string         `yaml:"path,omitempty"`
+	Auth    *SourceAuthDef `yaml:"auth,omitempty"`
 }
 
 func (s *ProviderSource) UnmarshalYAML(value *yaml.Node) error {
@@ -170,15 +170,8 @@ func (e *ProviderEntry) DeclaresMCP() bool {
 	return spec.MCP
 }
 
-type PluginSourceAuthDef struct {
+type SourceAuthDef struct {
 	Token string `yaml:"token"`
-}
-
-type PluginSourceDef struct {
-	Path    string               `yaml:"path"`
-	Ref     string               `yaml:"ref"`
-	Version string               `yaml:"version"`
-	Auth    *PluginSourceAuthDef `yaml:"auth,omitempty"`
 }
 
 type EgressConfig struct {

--- a/gestaltd/internal/config/runtime_config.go
+++ b/gestaltd/internal/config/runtime_config.go
@@ -9,7 +9,7 @@ import (
 
 type componentRuntimeConfig struct {
 	Name         string            `yaml:"name"`
-	Source       *PluginSourceDef  `yaml:"source,omitempty"`
+	Source       *ProviderSource   `yaml:"source,omitempty"`
 	Command      string            `yaml:"command"`
 	Args         []string          `yaml:"args,omitempty"`
 	Env          map[string]string `yaml:"env,omitempty"`
@@ -19,21 +19,17 @@ type componentRuntimeConfig struct {
 	Config       yaml.Node         `yaml:"config,omitempty"`
 }
 
-func sanitizeRuntimeSource(src ProviderSource) *PluginSourceDef {
-	return &PluginSourceDef{
-		Path:    src.Path,
-		Ref:     src.Ref,
-		Version: src.Version,
-	}
-}
-
 func BuildComponentRuntimeConfigNode(name, kind string, entry *ProviderEntry, providerConfig yaml.Node) (yaml.Node, error) {
 	if entry == nil {
 		return yaml.Node{}, fmt.Errorf("%s %q provider is required", kind, name)
 	}
 	node := componentRuntimeConfig{
-		Name:         name,
-		Source:       sanitizeRuntimeSource(entry.Source),
+		Name: name,
+		Source: &ProviderSource{
+			Path:    entry.Source.Path,
+			Ref:     entry.Source.Ref,
+			Version: entry.Source.Version,
+		},
 		Command:      entry.Command,
 		Args:         append([]string(nil), entry.Args...),
 		Env:          entry.Env,


### PR DESCRIPTION
## Summary
- Deletes `PluginSourceDef` (redundant parallel of `ProviderSource`) and `sanitizeRuntimeSource`, inlining the construction at its single call site
- Renames `PluginSourceAuthDef` to `SourceAuthDef` to drop the legacy "Plugin" prefix
- Adds an IndexedDB metrics decorator (`InstrumentIndexedDB`) that wraps every `ObjectStore` and `Index` operation with timing and `RecordIndexedDBMetrics` calls, covering both core coredata services and plugin host traffic from a single instrumentation point in bootstrap
- Renames unused `RecordDatastoreMetrics` to `RecordIndexedDBMetrics` with `gestaltd.indexeddb.*` metric namespace and `gestalt.store`/`gestalt.method` attributes
- Removes dead `ValidateManifest` export (zero callers) and dead `Result.Egress` field (set but never read)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/metricutil/... ./internal/bootstrap/... ./internal/pluginpkg/... ./internal/coredata/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)