### PR TITLE
Update provider-go-indexeddb manifest to new format

### DIFF
--- a/gestaltd/internal/testutil/testdata/provider-go-indexeddb/manifest.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-go-indexeddb/manifest.yaml
@@ -1,5 +1,6 @@
+kind: indexeddb
 source: github.com/valon-technologies/gestalt/testdata/provider-go-indexeddb
 version: 0.0.1-alpha.1
 displayName: In-Memory IndexedDB Provider
 description: An in-memory IndexedDB provider for testing
-indexeddb: {}
+spec: {}


### PR DESCRIPTION
The manifest used the old `indexeddb: {}` shorthand which was replaced by `kind: indexeddb` and `spec: {}` in the providers model unification (#855).