### PR TITLE
Fix remote IndexedDB typed transport for datastore writes

### DIFF
--- a/gestaltd/internal/pluginhost/convert.go
+++ b/gestaltd/internal/pluginhost/convert.go
@@ -1,18 +1,34 @@
 package pluginhost
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math"
 	"reflect"
+	"strconv"
+	"strings"
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-const sqlDateTimeLayout = "2006-01-02 15:04:05"
+const (
+	transportTimeLayout     = time.RFC3339Nano
+	legacySQLDateTimeLayout = "2006-01-02 15:04:05"
+	legacySQLDateTimeMicros = "2006-01-02 15:04:05.999999"
+	legacySQLDateTimeNanos  = "2006-01-02 15:04:05.999999999"
+	transportBytesPrefix    = "b64:"
+)
+
+type valueCodec struct {
+	columnType indexeddb.ColumnType
+	known      bool
+}
 
 func structFromMap(values map[string]any) (*structpb.Struct, error) {
 	if len(values) == 0 {
@@ -30,6 +46,112 @@ func mapFromStruct(s *structpb.Struct) map[string]any {
 		return nil
 	}
 	return s.AsMap()
+}
+
+func structFromRecord(values indexeddb.Record, schema *indexeddb.ObjectStoreSchema) (*structpb.Struct, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	normalized, err := normalizeRecordForStruct(values, schema)
+	if err != nil {
+		return nil, err
+	}
+	return structpb.NewStruct(normalized)
+}
+
+func recordFromStruct(s *structpb.Struct, schema *indexeddb.ObjectStoreSchema) (indexeddb.Record, error) {
+	if s == nil {
+		return nil, nil
+	}
+	return decodeRecordFromStruct(s.AsMap(), schema)
+}
+
+func protoValuesFromAny(values []any, codecs []valueCodec) ([]*structpb.Value, error) {
+	pbValues := make([]*structpb.Value, len(values))
+	for i, value := range values {
+		codec := codecAt(codecs, i)
+		normalized, err := encodeTransportValue(value, codec)
+		if err != nil {
+			return nil, fmt.Errorf("marshal index value %d: %w", i, err)
+		}
+		pv, err := structpb.NewValue(normalized)
+		if err != nil {
+			return nil, fmt.Errorf("marshal index value %d: %w", i, err)
+		}
+		pbValues[i] = pv
+	}
+	return pbValues, nil
+}
+
+func anyFromProtoValues(values []*structpb.Value, codecs []valueCodec) ([]any, error) {
+	out := make([]any, len(values))
+	for i, value := range values {
+		codec := codecAt(codecs, i)
+		decoded, err := decodeTransportValue(value.AsInterface(), codec)
+		if err != nil {
+			return nil, fmt.Errorf("decode index value %d: %w", i, err)
+		}
+		out[i] = decoded
+	}
+	return out, nil
+}
+
+func protoKeyRangeFromRange(r *indexeddb.KeyRange, codec valueCodec) (*proto.KeyRange, error) {
+	if r == nil {
+		return nil, nil
+	}
+	kr := &proto.KeyRange{
+		LowerOpen: r.LowerOpen,
+		UpperOpen: r.UpperOpen,
+	}
+	if r.Lower != nil {
+		normalized, err := encodeTransportValue(r.Lower, codec)
+		if err != nil {
+			return nil, fmt.Errorf("marshal key range lower: %w", err)
+		}
+		v, err := structpb.NewValue(normalized)
+		if err != nil {
+			return nil, fmt.Errorf("marshal key range lower: %w", err)
+		}
+		kr.Lower = v
+	}
+	if r.Upper != nil {
+		normalized, err := encodeTransportValue(r.Upper, codec)
+		if err != nil {
+			return nil, fmt.Errorf("marshal key range upper: %w", err)
+		}
+		v, err := structpb.NewValue(normalized)
+		if err != nil {
+			return nil, fmt.Errorf("marshal key range upper: %w", err)
+		}
+		kr.Upper = v
+	}
+	return kr, nil
+}
+
+func keyRangeFromProto(kr *proto.KeyRange, codec valueCodec) (*indexeddb.KeyRange, error) {
+	if kr == nil {
+		return nil, nil
+	}
+	r := &indexeddb.KeyRange{
+		LowerOpen: kr.GetLowerOpen(),
+		UpperOpen: kr.GetUpperOpen(),
+	}
+	if kr.GetLower() != nil {
+		decoded, err := decodeTransportValue(kr.GetLower().AsInterface(), codec)
+		if err != nil {
+			return nil, fmt.Errorf("decode key range lower: %w", err)
+		}
+		r.Lower = decoded
+	}
+	if kr.GetUpper() != nil {
+		decoded, err := decodeTransportValue(kr.GetUpper().AsInterface(), codec)
+		if err != nil {
+			return nil, fmt.Errorf("decode key range upper: %w", err)
+		}
+		r.Upper = decoded
+	}
+	return r, nil
 }
 
 func catalogFromProto(src *proto.Catalog) (*catalog.Catalog, error) {
@@ -150,6 +272,59 @@ func protoValueToAny(v *structpb.Value) any {
 	return v.AsInterface()
 }
 
+func schemaColumnCodec(schema *indexeddb.ObjectStoreSchema, field string) valueCodec {
+	if schema == nil {
+		return valueCodec{}
+	}
+	for _, col := range schema.Columns {
+		if col.Name == field {
+			return valueCodec{columnType: col.Type, known: true}
+		}
+	}
+	return valueCodec{}
+}
+
+func schemaPrimaryKeyCodec(schema *indexeddb.ObjectStoreSchema) valueCodec {
+	if schema == nil {
+		return valueCodec{}
+	}
+	for _, col := range schema.Columns {
+		if col.PrimaryKey {
+			return valueCodec{columnType: col.Type, known: true}
+		}
+	}
+	for _, col := range schema.Columns {
+		if col.Name == "id" {
+			return valueCodec{columnType: col.Type, known: true}
+		}
+	}
+	return valueCodec{}
+}
+
+func schemaIndexCodecs(schema *indexeddb.ObjectStoreSchema, index string) []valueCodec {
+	if schema == nil {
+		return nil
+	}
+	for _, idx := range schema.Indexes {
+		if idx.Name != index {
+			continue
+		}
+		codecs := make([]valueCodec, len(idx.KeyPath))
+		for i, field := range idx.KeyPath {
+			codecs[i] = schemaColumnCodec(schema, field)
+		}
+		return codecs
+	}
+	return nil
+}
+
+func codecAt(codecs []valueCodec, index int) valueCodec {
+	if index < len(codecs) {
+		return codecs[index]
+	}
+	return valueCodec{}
+}
+
 func normalizeStructMap(values map[string]any) (map[string]any, error) {
 	normalized := make(map[string]any, len(values))
 	for key, value := range values {
@@ -167,12 +342,12 @@ func normalizeStructValue(value any) (any, error) {
 	case nil:
 		return nil, nil
 	case time.Time:
-		return v.UTC().Format(sqlDateTimeLayout), nil
+		return formatTransportTime(v), nil
 	case *time.Time:
 		if v == nil {
 			return nil, nil
 		}
-		return v.UTC().Format(sqlDateTimeLayout), nil
+		return formatTransportTime(*v), nil
 	case map[string]any:
 		return normalizeStructMap(v)
 	}
@@ -215,5 +390,305 @@ func normalizeStructValue(value any) (any, error) {
 		return normalized, nil
 	default:
 		return value, nil
+	}
+}
+
+func normalizeRecordForStruct(values indexeddb.Record, schema *indexeddb.ObjectStoreSchema) (map[string]any, error) {
+	normalized := make(map[string]any, len(values))
+	for key, value := range values {
+		out, err := encodeTransportValue(value, schemaColumnCodec(schema, key))
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", key, err)
+		}
+		normalized[key] = out
+	}
+	return normalized, nil
+}
+
+func decodeRecordFromStruct(values map[string]any, schema *indexeddb.ObjectStoreSchema) (indexeddb.Record, error) {
+	record := make(indexeddb.Record, len(values))
+	for key, value := range values {
+		out, err := decodeTransportValue(value, schemaColumnCodec(schema, key))
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", key, err)
+		}
+		record[key] = out
+	}
+	return record, nil
+}
+
+func encodeTransportValue(value any, codec valueCodec) (any, error) {
+	if !codec.known {
+		return normalizeStructValue(value)
+	}
+
+	switch codec.columnType {
+	case indexeddb.TypeTime:
+		return encodeTransportTime(value)
+	case indexeddb.TypeBytes:
+		return encodeTransportBytes(value)
+	case indexeddb.TypeInt:
+		return encodeTransportInt(value)
+	case indexeddb.TypeFloat:
+		return encodeTransportFloat(value)
+	case indexeddb.TypeBool:
+		return encodeTransportBool(value)
+	default:
+		return normalizeStructValue(value)
+	}
+}
+
+func decodeTransportValue(value any, codec valueCodec) (any, error) {
+	if !codec.known {
+		return value, nil
+	}
+
+	switch codec.columnType {
+	case indexeddb.TypeTime:
+		return decodeTransportTime(value)
+	case indexeddb.TypeBytes:
+		return decodeTransportBytes(value)
+	case indexeddb.TypeInt:
+		return decodeTransportInt(value)
+	case indexeddb.TypeFloat:
+		return decodeTransportFloat(value)
+	case indexeddb.TypeBool:
+		return decodeTransportBool(value)
+	default:
+		return value, nil
+	}
+}
+
+func encodeTransportTime(value any) (any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	switch v := value.(type) {
+	case time.Time:
+		return formatTransportTime(v), nil
+	case *time.Time:
+		if v == nil {
+			return nil, nil
+		}
+		return formatTransportTime(*v), nil
+	case string:
+		parsed, err := parseTransportTime(v)
+		if err != nil {
+			return nil, err
+		}
+		return formatTransportTime(parsed), nil
+	default:
+		return nil, fmt.Errorf("expected time-compatible value, got %T", value)
+	}
+}
+
+func decodeTransportTime(value any) (any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	switch v := value.(type) {
+	case time.Time:
+		return v, nil
+	case *time.Time:
+		if v == nil {
+			return nil, nil
+		}
+		return *v, nil
+	case string:
+		return parseTransportTime(v)
+	default:
+		return nil, fmt.Errorf("expected time-compatible value, got %T", value)
+	}
+}
+
+func encodeTransportBytes(value any) (any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	switch v := value.(type) {
+	case []byte:
+		return transportBytesPrefix + base64.StdEncoding.EncodeToString(v), nil
+	case string:
+		return transportBytesPrefix + base64.StdEncoding.EncodeToString([]byte(v)), nil
+	default:
+		return nil, fmt.Errorf("expected bytes-compatible value, got %T", value)
+	}
+}
+
+func decodeTransportBytes(value any) (any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	s, ok := value.(string)
+	if !ok {
+		return nil, fmt.Errorf("expected bytes-compatible value, got %T", value)
+	}
+	if !strings.HasPrefix(s, transportBytesPrefix) {
+		return []byte(s), nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(s, transportBytesPrefix))
+	if err != nil {
+		return nil, fmt.Errorf("decode bytes: %w", err)
+	}
+	return decoded, nil
+}
+
+func encodeTransportInt(value any) (any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	parsed, err := int64FromValue(value)
+	if err != nil {
+		return nil, err
+	}
+	return strconv.FormatInt(parsed, 10), nil
+}
+
+func decodeTransportInt(value any) (any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	return int64FromValue(value)
+}
+
+func encodeTransportFloat(value any) (any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	return float64FromValue(value)
+}
+
+func decodeTransportFloat(value any) (any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	return float64FromValue(value)
+}
+
+func encodeTransportBool(value any) (any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	return boolFromValue(value)
+}
+
+func decodeTransportBool(value any) (any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	return boolFromValue(value)
+}
+
+func formatTransportTime(t time.Time) string {
+	return t.UTC().Format(transportTimeLayout)
+}
+
+func parseTransportTime(value string) (time.Time, error) {
+	layouts := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		legacySQLDateTimeNanos,
+		legacySQLDateTimeMicros,
+		legacySQLDateTimeLayout,
+	}
+	for _, layout := range layouts {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed.UTC(), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("invalid time string %q", value)
+}
+
+func int64FromValue(value any) (int64, error) {
+	switch v := value.(type) {
+	case string:
+		if parsed, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return parsed, nil
+		}
+		parsed, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid integer string %q", v)
+		}
+		if parsed > math.MaxInt64 {
+			return 0, fmt.Errorf("integer %d exceeds int64", parsed)
+		}
+		return int64(parsed), nil
+	}
+
+	rv := reflect.ValueOf(value)
+	if !rv.IsValid() {
+		return 0, fmt.Errorf("invalid integer value")
+	}
+
+	switch rv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return rv.Int(), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if rv.Uint() > math.MaxInt64 {
+			return 0, fmt.Errorf("integer %d exceeds int64", rv.Uint())
+		}
+		return int64(rv.Uint()), nil
+	case reflect.Float32, reflect.Float64:
+		f := rv.Float()
+		if math.Trunc(f) != f {
+			return 0, fmt.Errorf("expected whole number, got %v", f)
+		}
+		return int64(f), nil
+	default:
+		return 0, fmt.Errorf("expected integer-compatible value, got %T", value)
+	}
+}
+
+func float64FromValue(value any) (float64, error) {
+	if s, ok := value.(string); ok {
+		parsed, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid float string %q", s)
+		}
+		return parsed, nil
+	}
+
+	rv := reflect.ValueOf(value)
+	if !rv.IsValid() {
+		return 0, fmt.Errorf("invalid float value")
+	}
+
+	switch rv.Kind() {
+	case reflect.Float32, reflect.Float64:
+		return rv.Float(), nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return float64(rv.Int()), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return float64(rv.Uint()), nil
+	default:
+		return 0, fmt.Errorf("expected float-compatible value, got %T", value)
+	}
+}
+
+func boolFromValue(value any) (bool, error) {
+	if s, ok := value.(string); ok {
+		parsed, err := strconv.ParseBool(s)
+		if err != nil {
+			return false, fmt.Errorf("invalid bool string %q", s)
+		}
+		return parsed, nil
+	}
+
+	rv := reflect.ValueOf(value)
+	if !rv.IsValid() {
+		return false, fmt.Errorf("invalid bool value")
+	}
+
+	switch rv.Kind() {
+	case reflect.Bool:
+		return rv.Bool(), nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return rv.Int() != 0, nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return rv.Uint() != 0, nil
+	case reflect.Float32, reflect.Float64:
+		return rv.Float() != 0, nil
+	default:
+		return false, fmt.Errorf("expected bool-compatible value, got %T", value)
 	}
 }

--- a/gestaltd/internal/pluginhost/convert.go
+++ b/gestaltd/internal/pluginhost/convert.go
@@ -12,6 +12,8 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+const sqlDateTimeLayout = "2006-01-02 15:04:05"
+
 func structFromMap(values map[string]any) (*structpb.Struct, error) {
 	if len(values) == 0 {
 		return nil, nil
@@ -165,12 +167,12 @@ func normalizeStructValue(value any) (any, error) {
 	case nil:
 		return nil, nil
 	case time.Time:
-		return v.UTC().Format(time.RFC3339Nano), nil
+		return v.UTC().Format(sqlDateTimeLayout), nil
 	case *time.Time:
 		if v == nil {
 			return nil, nil
 		}
-		return v.UTC().Format(time.RFC3339Nano), nil
+		return v.UTC().Format(sqlDateTimeLayout), nil
 	case map[string]any:
 		return normalizeStructMap(v)
 	}

--- a/gestaltd/internal/pluginhost/convert_test.go
+++ b/gestaltd/internal/pluginhost/convert_test.go
@@ -24,7 +24,7 @@ func TestStructFromMap_NormalizesTimeValues(t *testing.T) {
 	}
 
 	got := s.AsMap()
-	want := now.Format(time.RFC3339Nano)
+	want := now.Format(sqlDateTimeLayout)
 	if got["created_at"] != want {
 		t.Fatalf("created_at = %#v, want %#v", got["created_at"], want)
 	}

--- a/gestaltd/internal/pluginhost/convert_test.go
+++ b/gestaltd/internal/pluginhost/convert_test.go
@@ -3,6 +3,10 @@ package pluginhost
 import (
 	"testing"
 	"time"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 )
 
 func TestStructFromMap_NormalizesTimeValues(t *testing.T) {
@@ -24,7 +28,7 @@ func TestStructFromMap_NormalizesTimeValues(t *testing.T) {
 	}
 
 	got := s.AsMap()
-	want := now.Format(sqlDateTimeLayout)
+	want := now.Format(transportTimeLayout)
 	if got["created_at"] != want {
 		t.Fatalf("created_at = %#v, want %#v", got["created_at"], want)
 	}
@@ -41,5 +45,151 @@ func TestStructFromMap_NormalizesTimeValues(t *testing.T) {
 	}
 	if values[0] != want || values[1] != want {
 		t.Fatalf("values = %#v, want both %#v", values, want)
+	}
+}
+
+func TestRecordTransportRoundTrip_UsesSchemaTypes(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.April, 11, 20, 31, 30, 840502000, time.FixedZone("EDT", -4*60*60))
+	schema := &indexeddb.ObjectStoreSchema{
+		Columns: []indexeddb.ColumnDef{
+			{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+			{Name: "created_at", Type: indexeddb.TypeTime},
+			{Name: "refresh_error_count", Type: indexeddb.TypeInt},
+			{Name: "payload", Type: indexeddb.TypeBytes},
+			{Name: "enabled", Type: indexeddb.TypeBool},
+			{Name: "score", Type: indexeddb.TypeFloat},
+		},
+	}
+	record := indexeddb.Record{
+		"id":                  "tok_123",
+		"created_at":          now,
+		"refresh_error_count": 7,
+		"payload":             []byte("secret"),
+		"enabled":             true,
+		"score":               1.5,
+	}
+
+	s, err := structFromRecord(record, schema)
+	if err != nil {
+		t.Fatalf("structFromRecord: %v", err)
+	}
+
+	got := s.AsMap()
+	if got["created_at"] != now.UTC().Format(transportTimeLayout) {
+		t.Fatalf("created_at = %#v, want %#v", got["created_at"], now.UTC().Format(transportTimeLayout))
+	}
+	if got["refresh_error_count"] != "7" {
+		t.Fatalf("refresh_error_count = %#v, want %#v", got["refresh_error_count"], "7")
+	}
+	if got["payload"] != "b64:c2VjcmV0" {
+		t.Fatalf("payload = %#v, want %#v", got["payload"], "b64:c2VjcmV0")
+	}
+
+	decoded, err := recordFromStruct(s, schema)
+	if err != nil {
+		t.Fatalf("recordFromStruct: %v", err)
+	}
+
+	createdAt, ok := decoded["created_at"].(time.Time)
+	if !ok || !createdAt.Equal(now.UTC()) {
+		t.Fatalf("created_at = %#v, want %v", decoded["created_at"], now.UTC())
+	}
+	if decoded["refresh_error_count"] != int64(7) {
+		t.Fatalf("refresh_error_count = %#v, want %#v", decoded["refresh_error_count"], int64(7))
+	}
+	payload, ok := decoded["payload"].([]byte)
+	if !ok || string(payload) != "secret" {
+		t.Fatalf("payload = %#v, want []byte(\"secret\")", decoded["payload"])
+	}
+	if decoded["enabled"] != true {
+		t.Fatalf("enabled = %#v, want true", decoded["enabled"])
+	}
+	if decoded["score"] != 1.5 {
+		t.Fatalf("score = %#v, want 1.5", decoded["score"])
+	}
+}
+
+func TestRecordFromStruct_AcceptsLegacyTimeLayout(t *testing.T) {
+	t.Parallel()
+
+	schema := &indexeddb.ObjectStoreSchema{
+		Columns: []indexeddb.ColumnDef{
+			{Name: "created_at", Type: indexeddb.TypeTime},
+		},
+	}
+	s, err := structFromMap(map[string]any{"created_at": "2026-04-11 23:52:45"})
+	if err != nil {
+		t.Fatalf("structFromMap: %v", err)
+	}
+
+	record, err := recordFromStruct(s, schema)
+	if err != nil {
+		t.Fatalf("recordFromStruct: %v", err)
+	}
+
+	got, ok := record["created_at"].(time.Time)
+	if !ok {
+		t.Fatalf("created_at = %#v, want time.Time", record["created_at"])
+	}
+	want := time.Date(2026, time.April, 11, 23, 52, 45, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("created_at = %v, want %v", got, want)
+	}
+}
+
+func TestIndexedDBServer_AddRestoresTypedValuesFromSchema(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	srv := NewIndexedDBServer(db, "test")
+	ctx := t.Context()
+	now := time.Date(2026, time.April, 11, 23, 52, 45, 123000000, time.UTC)
+
+	_, err := srv.CreateObjectStore(ctx, &proto.CreateObjectStoreRequest{
+		Name: "tokens",
+		Schema: &proto.ObjectStoreSchema{
+			Columns: []*proto.ColumnDef{
+				{Name: "id", Type: int32(indexeddb.TypeString), PrimaryKey: true},
+				{Name: "last_refreshed_at", Type: int32(indexeddb.TypeTime)},
+				{Name: "refresh_error_count", Type: int32(indexeddb.TypeInt)},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateObjectStore: %v", err)
+	}
+
+	record, err := structFromRecord(indexeddb.Record{
+		"id":                  "tok_123",
+		"last_refreshed_at":   now,
+		"refresh_error_count": 2,
+	}, &indexeddb.ObjectStoreSchema{
+		Columns: []indexeddb.ColumnDef{
+			{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+			{Name: "last_refreshed_at", Type: indexeddb.TypeTime},
+			{Name: "refresh_error_count", Type: indexeddb.TypeInt},
+		},
+	})
+	if err != nil {
+		t.Fatalf("structFromRecord: %v", err)
+	}
+
+	if _, err := srv.Add(ctx, &proto.RecordRequest{Store: "tokens", Record: record}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	stored, err := db.ObjectStore("plugin_test_tokens").Get(ctx, "tok_123")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	gotTime, ok := stored["last_refreshed_at"].(time.Time)
+	if !ok || !gotTime.Equal(now.UTC()) {
+		t.Fatalf("last_refreshed_at = %#v, want %v", stored["last_refreshed_at"], now.UTC())
+	}
+	if stored["refresh_error_count"] != int64(2) {
+		t.Fatalf("refresh_error_count = %#v, want %#v", stored["refresh_error_count"], int64(2))
 	}
 }

--- a/gestaltd/internal/pluginhost/indexeddb_client.go
+++ b/gestaltd/internal/pluginhost/indexeddb_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
@@ -28,6 +29,8 @@ type remoteIndexedDB struct {
 	client  proto.IndexedDBClient
 	runtime proto.ProviderLifecycleClient
 	closer  io.Closer
+	mu      sync.RWMutex
+	schemas map[string]indexeddb.ObjectStoreSchema
 }
 
 func NewExecutableIndexedDB(ctx context.Context, cfg IndexedDBExecConfig) (indexeddb.IndexedDB, error) {
@@ -53,11 +56,16 @@ func NewExecutableIndexedDB(ctx context.Context, cfg IndexedDBExecConfig) (index
 		return nil, err
 	}
 
-	return &remoteIndexedDB{client: dsClient, runtime: runtimeClient, closer: proc}, nil
+	return &remoteIndexedDB{
+		client:  dsClient,
+		runtime: runtimeClient,
+		closer:  proc,
+		schemas: make(map[string]indexeddb.ObjectStoreSchema),
+	}, nil
 }
 
 func (r *remoteIndexedDB) ObjectStore(name string) indexeddb.ObjectStore {
-	return &remoteObjectStore{client: r.client, store: name}
+	return &remoteObjectStore{db: r, store: name}
 }
 
 func (r *remoteIndexedDB) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
@@ -77,6 +85,9 @@ func (r *remoteIndexedDB) CreateObjectStore(ctx context.Context, name string, sc
 	_, err := r.client.CreateObjectStore(ctx, &proto.CreateObjectStoreRequest{
 		Name: name, Schema: &proto.ObjectStoreSchema{Indexes: indexes, Columns: columns},
 	})
+	if err == nil {
+		r.setSchema(name, schema)
+	}
 	return grpcToDatastoreErr(err)
 }
 
@@ -84,6 +95,9 @@ func (r *remoteIndexedDB) DeleteObjectStore(ctx context.Context, name string) er
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
 	_, err := r.client.DeleteObjectStore(ctx, &proto.DeleteObjectStoreRequest{Name: name})
+	if err == nil {
+		r.deleteSchema(name)
+	}
 	return grpcToDatastoreErr(err)
 }
 
@@ -101,27 +115,50 @@ func (r *remoteIndexedDB) Close() error {
 	return r.closer.Close()
 }
 
+func (r *remoteIndexedDB) schema(name string) *indexeddb.ObjectStoreSchema {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	schema, ok := r.schemas[name]
+	if !ok {
+		return nil
+	}
+	copy := schema
+	return &copy
+}
+
+func (r *remoteIndexedDB) setSchema(name string, schema indexeddb.ObjectStoreSchema) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.schemas[name] = schema
+}
+
+func (r *remoteIndexedDB) deleteSchema(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.schemas, name)
+}
+
 // --- ObjectStore ---
 
 type remoteObjectStore struct {
-	client proto.IndexedDBClient
-	store  string
+	db    *remoteIndexedDB
+	store string
 }
 
 func (o *remoteObjectStore) Get(ctx context.Context, id string) (indexeddb.Record, error) {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	resp, err := o.client.Get(ctx, &proto.ObjectStoreRequest{Store: o.store, Id: id})
+	resp, err := o.db.client.Get(ctx, &proto.ObjectStoreRequest{Store: o.store, Id: id})
 	if err != nil {
 		return nil, grpcToDatastoreErr(err)
 	}
-	return structToRecord(resp.GetRecord()), nil
+	return structToRecord(resp.GetRecord(), o.db.schema(o.store))
 }
 
 func (o *remoteObjectStore) GetKey(ctx context.Context, id string) (string, error) {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	resp, err := o.client.GetKey(ctx, &proto.ObjectStoreRequest{Store: o.store, Id: id})
+	resp, err := o.db.client.GetKey(ctx, &proto.ObjectStoreRequest{Store: o.store, Id: id})
 	if err != nil {
 		return "", grpcToDatastoreErr(err)
 	}
@@ -131,61 +168,61 @@ func (o *remoteObjectStore) GetKey(ctx context.Context, id string) (string, erro
 func (o *remoteObjectStore) Add(ctx context.Context, record indexeddb.Record) error {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	s, err := structFromMap(record)
+	s, err := structFromRecord(record, o.db.schema(o.store))
 	if err != nil {
 		return fmt.Errorf("marshal record: %w", err)
 	}
-	_, err = o.client.Add(ctx, &proto.RecordRequest{Store: o.store, Record: s})
+	_, err = o.db.client.Add(ctx, &proto.RecordRequest{Store: o.store, Record: s})
 	return grpcToDatastoreErr(err)
 }
 
 func (o *remoteObjectStore) Put(ctx context.Context, record indexeddb.Record) error {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	s, err := structFromMap(record)
+	s, err := structFromRecord(record, o.db.schema(o.store))
 	if err != nil {
 		return fmt.Errorf("marshal record: %w", err)
 	}
-	_, err = o.client.Put(ctx, &proto.RecordRequest{Store: o.store, Record: s})
+	_, err = o.db.client.Put(ctx, &proto.RecordRequest{Store: o.store, Record: s})
 	return grpcToDatastoreErr(err)
 }
 
 func (o *remoteObjectStore) Delete(ctx context.Context, id string) error {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	_, err := o.client.Delete(ctx, &proto.ObjectStoreRequest{Store: o.store, Id: id})
+	_, err := o.db.client.Delete(ctx, &proto.ObjectStoreRequest{Store: o.store, Id: id})
 	return grpcToDatastoreErr(err)
 }
 
 func (o *remoteObjectStore) Clear(ctx context.Context) error {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	_, err := o.client.Clear(ctx, &proto.ObjectStoreNameRequest{Store: o.store})
+	_, err := o.db.client.Clear(ctx, &proto.ObjectStoreNameRequest{Store: o.store})
 	return grpcToDatastoreErr(err)
 }
 
 func (o *remoteObjectStore) GetAll(ctx context.Context, r *indexeddb.KeyRange) ([]indexeddb.Record, error) {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	kr, err := keyRangeToProto(r)
+	kr, err := keyRangeToProto(r, schemaPrimaryKeyCodec(o.db.schema(o.store)))
 	if err != nil {
 		return nil, err
 	}
-	resp, err := o.client.GetAll(ctx, &proto.ObjectStoreRangeRequest{Store: o.store, Range: kr})
+	resp, err := o.db.client.GetAll(ctx, &proto.ObjectStoreRangeRequest{Store: o.store, Range: kr})
 	if err != nil {
 		return nil, grpcToDatastoreErr(err)
 	}
-	return structsToRecords(resp.GetRecords()), nil
+	return structsToRecords(resp.GetRecords(), o.db.schema(o.store))
 }
 
 func (o *remoteObjectStore) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange) ([]string, error) {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	kr, err := keyRangeToProto(r)
+	kr, err := keyRangeToProto(r, schemaPrimaryKeyCodec(o.db.schema(o.store)))
 	if err != nil {
 		return nil, err
 	}
-	resp, err := o.client.GetAllKeys(ctx, &proto.ObjectStoreRangeRequest{Store: o.store, Range: kr})
+	resp, err := o.db.client.GetAllKeys(ctx, &proto.ObjectStoreRangeRequest{Store: o.store, Range: kr})
 	if err != nil {
 		return nil, grpcToDatastoreErr(err)
 	}
@@ -195,11 +232,11 @@ func (o *remoteObjectStore) GetAllKeys(ctx context.Context, r *indexeddb.KeyRang
 func (o *remoteObjectStore) Count(ctx context.Context, r *indexeddb.KeyRange) (int64, error) {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	kr, err := keyRangeToProto(r)
+	kr, err := keyRangeToProto(r, schemaPrimaryKeyCodec(o.db.schema(o.store)))
 	if err != nil {
 		return 0, err
 	}
-	resp, err := o.client.Count(ctx, &proto.ObjectStoreRangeRequest{Store: o.store, Range: kr})
+	resp, err := o.db.client.Count(ctx, &proto.ObjectStoreRangeRequest{Store: o.store, Range: kr})
 	if err != nil {
 		return 0, grpcToDatastoreErr(err)
 	}
@@ -209,11 +246,11 @@ func (o *remoteObjectStore) Count(ctx context.Context, r *indexeddb.KeyRange) (i
 func (o *remoteObjectStore) DeleteRange(ctx context.Context, r indexeddb.KeyRange) (int64, error) {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	kr, err := keyRangeToProto(&r)
+	kr, err := keyRangeToProto(&r, schemaPrimaryKeyCodec(o.db.schema(o.store)))
 	if err != nil {
 		return 0, err
 	}
-	resp, err := o.client.DeleteRange(ctx, &proto.ObjectStoreRangeRequest{Store: o.store, Range: kr})
+	resp, err := o.db.client.DeleteRange(ctx, &proto.ObjectStoreRangeRequest{Store: o.store, Range: kr})
 	if err != nil {
 		return 0, grpcToDatastoreErr(err)
 	}
@@ -221,41 +258,41 @@ func (o *remoteObjectStore) DeleteRange(ctx context.Context, r indexeddb.KeyRang
 }
 
 func (o *remoteObjectStore) Index(name string) indexeddb.Index {
-	return &remoteIndex{client: o.client, store: o.store, index: name}
+	return &remoteIndex{db: o.db, store: o.store, index: name}
 }
 
 // --- Index ---
 
 type remoteIndex struct {
-	client proto.IndexedDBClient
-	store  string
-	index  string
+	db    *remoteIndexedDB
+	store string
+	index string
 }
 
 func (idx *remoteIndex) Get(ctx context.Context, values ...any) (indexeddb.Record, error) {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	pbValues, err := toProtoValues(values)
+	pbValues, err := toProtoValues(values, schemaIndexCodecs(idx.db.schema(idx.store), idx.index))
 	if err != nil {
 		return nil, err
 	}
-	resp, err := idx.client.IndexGet(ctx, &proto.IndexQueryRequest{
+	resp, err := idx.db.client.IndexGet(ctx, &proto.IndexQueryRequest{
 		Store: idx.store, Index: idx.index, Values: pbValues,
 	})
 	if err != nil {
 		return nil, grpcToDatastoreErr(err)
 	}
-	return structToRecord(resp.GetRecord()), nil
+	return structToRecord(resp.GetRecord(), idx.db.schema(idx.store))
 }
 
 func (idx *remoteIndex) GetKey(ctx context.Context, values ...any) (string, error) {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	pbValues, err := toProtoValues(values)
+	pbValues, err := toProtoValues(values, schemaIndexCodecs(idx.db.schema(idx.store), idx.index))
 	if err != nil {
 		return "", err
 	}
-	resp, err := idx.client.IndexGetKey(ctx, &proto.IndexQueryRequest{
+	resp, err := idx.db.client.IndexGetKey(ctx, &proto.IndexQueryRequest{
 		Store: idx.store, Index: idx.index, Values: pbValues,
 	})
 	if err != nil {
@@ -267,35 +304,35 @@ func (idx *remoteIndex) GetKey(ctx context.Context, values ...any) (string, erro
 func (idx *remoteIndex) GetAll(ctx context.Context, r *indexeddb.KeyRange, values ...any) ([]indexeddb.Record, error) {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	pbValues, err := toProtoValues(values)
+	pbValues, err := toProtoValues(values, schemaIndexCodecs(idx.db.schema(idx.store), idx.index))
 	if err != nil {
 		return nil, err
 	}
-	kr, err := keyRangeToProto(r)
+	kr, err := keyRangeToProto(r, schemaPrimaryKeyCodec(idx.db.schema(idx.store)))
 	if err != nil {
 		return nil, err
 	}
-	resp, err := idx.client.IndexGetAll(ctx, &proto.IndexQueryRequest{
+	resp, err := idx.db.client.IndexGetAll(ctx, &proto.IndexQueryRequest{
 		Store: idx.store, Index: idx.index, Values: pbValues, Range: kr,
 	})
 	if err != nil {
 		return nil, grpcToDatastoreErr(err)
 	}
-	return structsToRecords(resp.GetRecords()), nil
+	return structsToRecords(resp.GetRecords(), idx.db.schema(idx.store))
 }
 
 func (idx *remoteIndex) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange, values ...any) ([]string, error) {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	pbValues, err := toProtoValues(values)
+	pbValues, err := toProtoValues(values, schemaIndexCodecs(idx.db.schema(idx.store), idx.index))
 	if err != nil {
 		return nil, err
 	}
-	kr, err := keyRangeToProto(r)
+	kr, err := keyRangeToProto(r, schemaPrimaryKeyCodec(idx.db.schema(idx.store)))
 	if err != nil {
 		return nil, err
 	}
-	resp, err := idx.client.IndexGetAllKeys(ctx, &proto.IndexQueryRequest{
+	resp, err := idx.db.client.IndexGetAllKeys(ctx, &proto.IndexQueryRequest{
 		Store: idx.store, Index: idx.index, Values: pbValues, Range: kr,
 	})
 	if err != nil {
@@ -307,15 +344,15 @@ func (idx *remoteIndex) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange, v
 func (idx *remoteIndex) Count(ctx context.Context, r *indexeddb.KeyRange, values ...any) (int64, error) {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	pbValues, err := toProtoValues(values)
+	pbValues, err := toProtoValues(values, schemaIndexCodecs(idx.db.schema(idx.store), idx.index))
 	if err != nil {
 		return 0, err
 	}
-	kr, err := keyRangeToProto(r)
+	kr, err := keyRangeToProto(r, schemaPrimaryKeyCodec(idx.db.schema(idx.store)))
 	if err != nil {
 		return 0, err
 	}
-	resp, err := idx.client.IndexCount(ctx, &proto.IndexQueryRequest{
+	resp, err := idx.db.client.IndexCount(ctx, &proto.IndexQueryRequest{
 		Store: idx.store, Index: idx.index, Values: pbValues, Range: kr,
 	})
 	if err != nil {
@@ -327,11 +364,11 @@ func (idx *remoteIndex) Count(ctx context.Context, r *indexeddb.KeyRange, values
 func (idx *remoteIndex) Delete(ctx context.Context, values ...any) (int64, error) {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	pbValues, err := toProtoValues(values)
+	pbValues, err := toProtoValues(values, schemaIndexCodecs(idx.db.schema(idx.store), idx.index))
 	if err != nil {
 		return 0, err
 	}
-	resp, err := idx.client.IndexDelete(ctx, &proto.IndexQueryRequest{
+	resp, err := idx.db.client.IndexDelete(ctx, &proto.IndexQueryRequest{
 		Store: idx.store, Index: idx.index, Values: pbValues,
 	})
 	if err != nil {
@@ -342,56 +379,28 @@ func (idx *remoteIndex) Delete(ctx context.Context, values ...any) (int64, error
 
 // --- Helpers ---
 
-func structToRecord(s *structpb.Struct) indexeddb.Record {
-	if s == nil {
-		return nil
-	}
-	return s.AsMap()
+func structToRecord(s *structpb.Struct, schema *indexeddb.ObjectStoreSchema) (indexeddb.Record, error) {
+	return recordFromStruct(s, schema)
 }
 
-func structsToRecords(ss []*structpb.Struct) []indexeddb.Record {
+func structsToRecords(ss []*structpb.Struct, schema *indexeddb.ObjectStoreSchema) ([]indexeddb.Record, error) {
 	records := make([]indexeddb.Record, len(ss))
 	for i, s := range ss {
-		records[i] = structToRecord(s)
+		record, err := structToRecord(s, schema)
+		if err != nil {
+			return nil, fmt.Errorf("decode record %d: %w", i, err)
+		}
+		records[i] = record
 	}
-	return records
+	return records, nil
 }
 
-func toProtoValues(values []any) ([]*structpb.Value, error) {
-	pbValues := make([]*structpb.Value, len(values))
-	for i, v := range values {
-		pv, err := structpb.NewValue(v)
-		if err != nil {
-			return nil, fmt.Errorf("marshal index value %d: %w", i, err)
-		}
-		pbValues[i] = pv
-	}
-	return pbValues, nil
+func toProtoValues(values []any, codecs []valueCodec) ([]*structpb.Value, error) {
+	return protoValuesFromAny(values, codecs)
 }
 
-func keyRangeToProto(r *indexeddb.KeyRange) (*proto.KeyRange, error) {
-	if r == nil {
-		return nil, nil
-	}
-	kr := &proto.KeyRange{
-		LowerOpen: r.LowerOpen,
-		UpperOpen: r.UpperOpen,
-	}
-	if r.Lower != nil {
-		v, err := structpb.NewValue(r.Lower)
-		if err != nil {
-			return nil, fmt.Errorf("marshal key range lower: %w", err)
-		}
-		kr.Lower = v
-	}
-	if r.Upper != nil {
-		v, err := structpb.NewValue(r.Upper)
-		if err != nil {
-			return nil, fmt.Errorf("marshal key range upper: %w", err)
-		}
-		kr.Upper = v
-	}
-	return kr, nil
+func keyRangeToProto(r *indexeddb.KeyRange, codec valueCodec) (*proto.KeyRange, error) {
+	return protoKeyRangeFromRange(r, codec)
 }
 
 func grpcToDatastoreErr(err error) error {

--- a/gestaltd/internal/pluginhost/indexeddb_server.go
+++ b/gestaltd/internal/pluginhost/indexeddb_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
@@ -15,12 +16,18 @@ import (
 
 type indexedDBServer struct {
 	proto.UnimplementedIndexedDBServer
-	ds     indexeddb.IndexedDB
-	prefix string
+	ds       indexeddb.IndexedDB
+	prefix   string
+	schemaMu sync.RWMutex
+	schemas  map[string]indexeddb.ObjectStoreSchema
 }
 
 func NewIndexedDBServer(ds indexeddb.IndexedDB, pluginName string) proto.IndexedDBServer {
-	return &indexedDBServer{ds: ds, prefix: "plugin_" + pluginName + "_"}
+	return &indexedDBServer{
+		ds:      ds,
+		prefix:  "plugin_" + pluginName + "_",
+		schemas: make(map[string]indexeddb.ObjectStoreSchema),
+	}
 }
 
 func (s *indexedDBServer) storeName(name string) string {
@@ -29,25 +36,30 @@ func (s *indexedDBServer) storeName(name string) string {
 
 func (s *indexedDBServer) CreateObjectStore(ctx context.Context, req *proto.CreateObjectStoreRequest) (*emptypb.Empty, error) {
 	schema := protoToSchema(req.GetSchema())
-	if err := s.ds.CreateObjectStore(ctx, s.storeName(req.GetName()), schema); err != nil {
+	storeName := s.storeName(req.GetName())
+	if err := s.ds.CreateObjectStore(ctx, storeName, schema); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
+	s.setSchema(storeName, schema)
 	return &emptypb.Empty{}, nil
 }
 
 func (s *indexedDBServer) DeleteObjectStore(ctx context.Context, req *proto.DeleteObjectStoreRequest) (*emptypb.Empty, error) {
-	if err := s.ds.DeleteObjectStore(ctx, s.storeName(req.GetName())); err != nil {
+	storeName := s.storeName(req.GetName())
+	if err := s.ds.DeleteObjectStore(ctx, storeName); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
+	s.deleteSchema(storeName)
 	return &emptypb.Empty{}, nil
 }
 
 func (s *indexedDBServer) Get(ctx context.Context, req *proto.ObjectStoreRequest) (*proto.RecordResponse, error) {
-	rec, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Get(ctx, req.GetId())
+	storeName := s.storeName(req.GetStore())
+	rec, err := s.ds.ObjectStore(storeName).Get(ctx, req.GetId())
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
-	return recordToProto(rec)
+	return recordToProto(rec, s.schema(storeName))
 }
 
 func (s *indexedDBServer) GetKey(ctx context.Context, req *proto.ObjectStoreRequest) (*proto.KeyResponse, error) {
@@ -59,14 +71,24 @@ func (s *indexedDBServer) GetKey(ctx context.Context, req *proto.ObjectStoreRequ
 }
 
 func (s *indexedDBServer) Add(ctx context.Context, req *proto.RecordRequest) (*emptypb.Empty, error) {
-	if err := s.ds.ObjectStore(s.storeName(req.GetStore())).Add(ctx, req.GetRecord().AsMap()); err != nil {
+	storeName := s.storeName(req.GetStore())
+	record, err := recordFromStruct(req.GetRecord(), s.schema(storeName))
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	if err := s.ds.ObjectStore(storeName).Add(ctx, record); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
 	return &emptypb.Empty{}, nil
 }
 
 func (s *indexedDBServer) Put(ctx context.Context, req *proto.RecordRequest) (*emptypb.Empty, error) {
-	if err := s.ds.ObjectStore(s.storeName(req.GetStore())).Put(ctx, req.GetRecord().AsMap()); err != nil {
+	storeName := s.storeName(req.GetStore())
+	record, err := recordFromStruct(req.GetRecord(), s.schema(storeName))
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	if err := s.ds.ObjectStore(storeName).Put(ctx, record); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
 	return &emptypb.Empty{}, nil
@@ -87,15 +109,25 @@ func (s *indexedDBServer) Clear(ctx context.Context, req *proto.ObjectStoreNameR
 }
 
 func (s *indexedDBServer) GetAll(ctx context.Context, req *proto.ObjectStoreRangeRequest) (*proto.RecordsResponse, error) {
-	recs, err := s.ds.ObjectStore(s.storeName(req.GetStore())).GetAll(ctx, protoToKeyRange(req.Range))
+	storeName := s.storeName(req.GetStore())
+	keyRange, err := protoToKeyRange(req.Range, schemaPrimaryKeyCodec(s.schema(storeName)))
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	recs, err := s.ds.ObjectStore(storeName).GetAll(ctx, keyRange)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
-	return recordsToProto(recs)
+	return recordsToProto(recs, s.schema(storeName))
 }
 
 func (s *indexedDBServer) GetAllKeys(ctx context.Context, req *proto.ObjectStoreRangeRequest) (*proto.KeysResponse, error) {
-	keys, err := s.ds.ObjectStore(s.storeName(req.GetStore())).GetAllKeys(ctx, protoToKeyRange(req.Range))
+	storeName := s.storeName(req.GetStore())
+	keyRange, err := protoToKeyRange(req.Range, schemaPrimaryKeyCodec(s.schema(storeName)))
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	keys, err := s.ds.ObjectStore(storeName).GetAllKeys(ctx, keyRange)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -103,7 +135,12 @@ func (s *indexedDBServer) GetAllKeys(ctx context.Context, req *proto.ObjectStore
 }
 
 func (s *indexedDBServer) Count(ctx context.Context, req *proto.ObjectStoreRangeRequest) (*proto.CountResponse, error) {
-	count, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Count(ctx, protoToKeyRange(req.Range))
+	storeName := s.storeName(req.GetStore())
+	keyRange, err := protoToKeyRange(req.Range, schemaPrimaryKeyCodec(s.schema(storeName)))
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	count, err := s.ds.ObjectStore(storeName).Count(ctx, keyRange)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -111,11 +148,15 @@ func (s *indexedDBServer) Count(ctx context.Context, req *proto.ObjectStoreRange
 }
 
 func (s *indexedDBServer) DeleteRange(ctx context.Context, req *proto.ObjectStoreRangeRequest) (*proto.DeleteResponse, error) {
-	kr := protoToKeyRange(req.Range)
+	storeName := s.storeName(req.GetStore())
+	kr, err := protoToKeyRange(req.Range, schemaPrimaryKeyCodec(s.schema(storeName)))
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 	if kr == nil {
 		return nil, status.Error(codes.InvalidArgument, "key range is required for DeleteRange")
 	}
-	deleted, err := s.ds.ObjectStore(s.storeName(req.GetStore())).DeleteRange(ctx, *kr)
+	deleted, err := s.ds.ObjectStore(storeName).DeleteRange(ctx, *kr)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -123,15 +164,25 @@ func (s *indexedDBServer) DeleteRange(ctx context.Context, req *proto.ObjectStor
 }
 
 func (s *indexedDBServer) IndexGet(ctx context.Context, req *proto.IndexQueryRequest) (*proto.RecordResponse, error) {
-	rec, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).Get(ctx, protoValuesToAny(req.GetValues())...)
+	storeName := s.storeName(req.GetStore())
+	values, err := protoValuesToAny(req.GetValues(), schemaIndexCodecs(s.schema(storeName), req.GetIndex()))
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	rec, err := s.ds.ObjectStore(storeName).Index(req.GetIndex()).Get(ctx, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
-	return recordToProto(rec)
+	return recordToProto(rec, s.schema(storeName))
 }
 
 func (s *indexedDBServer) IndexGetKey(ctx context.Context, req *proto.IndexQueryRequest) (*proto.KeyResponse, error) {
-	key, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).GetKey(ctx, protoValuesToAny(req.GetValues())...)
+	storeName := s.storeName(req.GetStore())
+	values, err := protoValuesToAny(req.GetValues(), schemaIndexCodecs(s.schema(storeName), req.GetIndex()))
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	key, err := s.ds.ObjectStore(storeName).Index(req.GetIndex()).GetKey(ctx, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -139,15 +190,33 @@ func (s *indexedDBServer) IndexGetKey(ctx context.Context, req *proto.IndexQuery
 }
 
 func (s *indexedDBServer) IndexGetAll(ctx context.Context, req *proto.IndexQueryRequest) (*proto.RecordsResponse, error) {
-	recs, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).GetAll(ctx, protoToKeyRange(req.Range), protoValuesToAny(req.GetValues())...)
+	storeName := s.storeName(req.GetStore())
+	keyRange, err := protoToKeyRange(req.Range, schemaPrimaryKeyCodec(s.schema(storeName)))
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	values, err := protoValuesToAny(req.GetValues(), schemaIndexCodecs(s.schema(storeName), req.GetIndex()))
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	recs, err := s.ds.ObjectStore(storeName).Index(req.GetIndex()).GetAll(ctx, keyRange, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
-	return recordsToProto(recs)
+	return recordsToProto(recs, s.schema(storeName))
 }
 
 func (s *indexedDBServer) IndexGetAllKeys(ctx context.Context, req *proto.IndexQueryRequest) (*proto.KeysResponse, error) {
-	keys, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).GetAllKeys(ctx, protoToKeyRange(req.Range), protoValuesToAny(req.GetValues())...)
+	storeName := s.storeName(req.GetStore())
+	keyRange, err := protoToKeyRange(req.Range, schemaPrimaryKeyCodec(s.schema(storeName)))
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	values, err := protoValuesToAny(req.GetValues(), schemaIndexCodecs(s.schema(storeName), req.GetIndex()))
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	keys, err := s.ds.ObjectStore(storeName).Index(req.GetIndex()).GetAllKeys(ctx, keyRange, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -155,7 +224,16 @@ func (s *indexedDBServer) IndexGetAllKeys(ctx context.Context, req *proto.IndexQ
 }
 
 func (s *indexedDBServer) IndexCount(ctx context.Context, req *proto.IndexQueryRequest) (*proto.CountResponse, error) {
-	count, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).Count(ctx, protoToKeyRange(req.Range), protoValuesToAny(req.GetValues())...)
+	storeName := s.storeName(req.GetStore())
+	keyRange, err := protoToKeyRange(req.Range, schemaPrimaryKeyCodec(s.schema(storeName)))
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	values, err := protoValuesToAny(req.GetValues(), schemaIndexCodecs(s.schema(storeName), req.GetIndex()))
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	count, err := s.ds.ObjectStore(storeName).Index(req.GetIndex()).Count(ctx, keyRange, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -163,25 +241,53 @@ func (s *indexedDBServer) IndexCount(ctx context.Context, req *proto.IndexQueryR
 }
 
 func (s *indexedDBServer) IndexDelete(ctx context.Context, req *proto.IndexQueryRequest) (*proto.DeleteResponse, error) {
-	deleted, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).Delete(ctx, protoValuesToAny(req.GetValues())...)
+	storeName := s.storeName(req.GetStore())
+	values, err := protoValuesToAny(req.GetValues(), schemaIndexCodecs(s.schema(storeName), req.GetIndex()))
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	deleted, err := s.ds.ObjectStore(storeName).Index(req.GetIndex()).Delete(ctx, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
 	return &proto.DeleteResponse{Deleted: deleted}, nil
 }
 
-func recordToProto(rec indexeddb.Record) (*proto.RecordResponse, error) {
-	s, err := structpb.NewStruct(rec)
+func (s *indexedDBServer) schema(name string) *indexeddb.ObjectStoreSchema {
+	s.schemaMu.RLock()
+	defer s.schemaMu.RUnlock()
+	schema, ok := s.schemas[name]
+	if !ok {
+		return nil
+	}
+	copy := schema
+	return &copy
+}
+
+func (s *indexedDBServer) setSchema(name string, schema indexeddb.ObjectStoreSchema) {
+	s.schemaMu.Lock()
+	defer s.schemaMu.Unlock()
+	s.schemas[name] = schema
+}
+
+func (s *indexedDBServer) deleteSchema(name string) {
+	s.schemaMu.Lock()
+	defer s.schemaMu.Unlock()
+	delete(s.schemas, name)
+}
+
+func recordToProto(rec indexeddb.Record, schema *indexeddb.ObjectStoreSchema) (*proto.RecordResponse, error) {
+	s, err := structFromRecord(rec, schema)
 	if err != nil {
 		return nil, fmt.Errorf("marshal record: %w", err)
 	}
 	return &proto.RecordResponse{Record: s}, nil
 }
 
-func recordsToProto(recs []indexeddb.Record) (*proto.RecordsResponse, error) {
+func recordsToProto(recs []indexeddb.Record, schema *indexeddb.ObjectStoreSchema) (*proto.RecordsResponse, error) {
 	structs := make([]*structpb.Struct, len(recs))
 	for i, rec := range recs {
-		s, err := structpb.NewStruct(rec)
+		s, err := structFromRecord(rec, schema)
 		if err != nil {
 			return nil, fmt.Errorf("marshal record %d: %w", i, err)
 		}
@@ -212,29 +318,12 @@ func protoToSchema(ps *proto.ObjectStoreSchema) indexeddb.ObjectStoreSchema {
 	return schema
 }
 
-func protoToKeyRange(kr *proto.KeyRange) *indexeddb.KeyRange {
-	if kr == nil {
-		return nil
-	}
-	r := &indexeddb.KeyRange{
-		LowerOpen: kr.GetLowerOpen(),
-		UpperOpen: kr.GetUpperOpen(),
-	}
-	if kr.GetLower() != nil {
-		r.Lower = kr.GetLower().AsInterface()
-	}
-	if kr.GetUpper() != nil {
-		r.Upper = kr.GetUpper().AsInterface()
-	}
-	return r
+func protoToKeyRange(kr *proto.KeyRange, codec valueCodec) (*indexeddb.KeyRange, error) {
+	return keyRangeFromProto(kr, codec)
 }
 
-func protoValuesToAny(vals []*structpb.Value) []any {
-	out := make([]any, len(vals))
-	for i, v := range vals {
-		out[i] = v.AsInterface()
-	}
-	return out
+func protoValuesToAny(vals []*structpb.Value, codecs []valueCodec) ([]any, error) {
+	return anyFromProtoValues(vals, codecs)
 }
 
 func indexeddbToGRPCErr(err error) error {


### PR DESCRIPTION
## Summary
- make the remote IndexedDB transport schema-aware so typed columns survive the gRPC `Struct` boundary
- cache object store schemas in the pluginhost IndexedDB client/server and use them for record, index, and key-range conversion
- add focused pluginhost tests for typed round-trips and server-side schema restoration

## Testing
- `go test ./internal/pluginhost`
- `go test ./...`