### PR TITLE
docs: update all examples to unified config and manifest model

### DIFF
--- a/docs/content/architecture/index.mdx
+++ b/docs/content/architecture/index.mdx
@@ -12,9 +12,9 @@ When `gestaltd serve` starts, it goes through a specific sequence that matters w
 
 First, the YAML config file is loaded and `${ENV_VAR}` placeholders are expanded. If a variable isn't set, Gestalt checks for a corresponding `_FILE` variable and reads that file instead (this is how Docker secrets work). If neither exists, config loading fails. Use `${ENV_VAR:-}` when an explicit empty default is intentional. Unknown fields are rejected.
 
-Next, Gestalt initializes the secret manager from the `secrets` block. This is the one part of config that *cannot* use `secret://` references, because the secret manager doesn't exist yet. Credentials for the secret manager itself have to come in through `${ENV_VAR}` or `${ENV_VAR_FILE}`.
+Next, Gestalt initializes the secret manager from `providers.secrets`. This is the one part of config that *cannot* use `secret://` references, because the secret manager doesn't exist yet. Credentials for the secret manager itself have to come in through `${ENV_VAR}` or `${ENV_VAR_FILE}`.
 
-Once the secret manager is ready, Gestalt resolves every `secret://` reference across the rest of the config: server, auth, datastore, telemetry, audit, and all plugin configs. The `secrets.config` block is skipped to avoid a circular dependency.
+Once the secret manager is ready, Gestalt resolves every `secret://` reference across the rest of the config: server settings, auth, indexeddb, telemetry, audit, and all plugin configs. The `providers.secrets.config` block is skipped to avoid a circular dependency.
 
 With secrets resolved, `server.encryptionKey` gets converted into a 32-byte AES key. A 64-character hex string is decoded directly; anything else goes through Argon2id derivation. This derived key protects all stored tokens.
 

--- a/docs/content/architecture/security-internals.mdx
+++ b/docs/content/architecture/security-internals.mdx
@@ -52,7 +52,7 @@ API tokens (`gst_api_*`) work differently: the plaintext is never stored.
 
 `secret://` resolution is a one-shot operation at startup. Gestalt resolves every reference, replaces it in memory, and never consults the secret manager again. If a secret rotates after startup, restart Gestalt to pick it up.
 
-The `secrets.config` block is excluded from resolution. Use `${ENV_VAR}` or `${ENV_VAR_FILE}` for secret manager credentials.
+The `providers.secrets.config` block is excluded from resolution. Use `${ENV_VAR}` or `${ENV_VAR_FILE}` for secret manager credentials.
 
 ## Key rotation
 

--- a/docs/content/audit-logging.mdx
+++ b/docs/content/audit-logging.mdx
@@ -100,11 +100,11 @@ definitions.
 
 ## Routing
 
-By default, audit records follow the main telemetry log pipeline. With `telemetry: { builtin: stdout }` they appear in local structured logs; with `telemetry: { builtin: otlp }` they export through the OTLP log pipeline.
+By default, audit records follow the main telemetry log pipeline. With `providers.telemetry` set to `source: stdout` they appear in local structured logs; with `source: otlp` they export through the OTLP log pipeline.
 
-If you need a dedicated audit route, configure the top-level `audit:` block. Set `audit: { builtin: stdout }` to keep audit logs on stdout even when telemetry uses a different builtin, `audit: { builtin: otlp }` to export only audit records to a dedicated OTLP collector, or `audit: { builtin: noop }` to disable audit output explicitly.
+If you need a dedicated audit route, configure `providers.audit` separately. Set `source: stdout` to keep audit logs on stdout even when telemetry uses a different source, `source: otlp` to export only audit records to a dedicated OTLP collector, or `source: noop` to disable audit output explicitly.
 
-With the default `audit: { builtin: inherit }`, you can still split audit records downstream by filtering on `log.type=audit` in your collector. See [Config File](/reference/config-file) for the config surface and [Observability](/observability) for export options.
+With the default `providers.audit` source of `inherit`, you can still split audit records downstream by filtering on `log.type=audit` in your collector. See [Config File](/reference/config-file) for the config surface and [Observability](/observability) for export options.
 
 ## Metrics Notes
 

--- a/docs/content/client/web.mdx
+++ b/docs/content/client/web.mdx
@@ -24,11 +24,11 @@ Create and revoke API tokens for programmatic access. Each token shows its name,
 
 ## Authentication
 
-When `auth.provider` points to a Google or OIDC auth provider, the web UI redirects to your identity provider for login. With a local auth provider, login is automatic. With `auth: { disabled: true }`, every request is anonymous.
+When `providers.auth` points to a Google or OIDC auth provider, the web UI redirects to your identity provider for login. With a local auth provider, login is automatic. With `providers.auth` disabled, every request is anonymous.
 
 ## Custom UI bundles
 
-The public web UI is configured through the `ui` block.
+The public web UI is configured through the `providers.ui` entry.
 
 - Omit `ui` to use the pinned first-party default UI bundle.
 - Set `ui: { disabled: true }` to run headless with no public UI at `/`.

--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -15,28 +15,28 @@ Gestalt has six core concepts you configure in YAML:
 
 ## Adding a plugin
 
-Each entry under `plugins:` registers a plugin backed by a provider package:
+Each entry under `providers.plugins` registers a plugin backed by a provider package:
 
 ```yaml
-plugins:
-  github:
-    displayName: GitHub
-    provider:
+providers:
+  plugins:
+    github:
+      displayName: GitHub
       source:
         ref: github.com/valon-technologies/gestalt-providers/plugins/github
         version: 0.0.1-alpha.1
-    config:
-      apiBaseUrl: https://api.github.com
+      config:
+        apiBaseUrl: https://api.github.com
 ```
 
-`provider.source.ref` points at a published provider package. Gestalt resolves and downloads it on startup. First-party providers are published to `github.com/valon-technologies/gestalt-providers/`.
+`source.ref` points at a published provider package. Gestalt resolves and downloads it on startup. First-party providers are published to `github.com/valon-technologies/gestalt-providers/`.
 
 During development, point at a local provider manifest instead:
 
 ```yaml
-plugins:
-  support:
-    provider:
+providers:
+  plugins:
+    support:
       source:
         path: ./plugins/support/manifest.yaml
 ```
@@ -48,29 +48,29 @@ See [Providers](/providers) for how to build your own.
 A provider package may expose a large catalog. Use `allowedOperations` to publish only the subset you want:
 
 ```yaml
-plugins:
-  support:
-    provider:
+providers:
+  plugins:
+    support:
       source:
         ref: github.com/acme/providers/support
         version: 2.4.0
-    allowedOperations:
-      tickets.list:
-        alias: list_tickets
-      tickets.get:
-        alias: get_ticket
+      allowedOperations:
+        tickets.list:
+          alias: list_tickets
+        tickets.get:
+          alias: get_ticket
 ```
 
 Each entry can set an `alias` to rename the operation as it appears to callers.
 
 ### Network sandbox
 
-Executable provider processes run inside a network sandbox. Outbound requests to hosts not listed in `provider.allowedHosts` are rejected:
+Executable provider processes run inside a network sandbox. Outbound requests to hosts not listed in `allowedHosts` are rejected:
 
 ```yaml
-plugins:
-  example:
-    provider:
+providers:
+  plugins:
+    example:
       source:
         ref: github.com/acme/providers/example
         version: 1.0.0
@@ -84,13 +84,14 @@ plugins:
 Connections define how Gestalt authenticates to upstream services on behalf of callers. Each plugin declares its connections under `connections:`:
 
 ```yaml
-plugins:
-  github:
-    connections:
-      default:
-        mode: user
-        auth:
-          type: oauth2
+providers:
+  plugins:
+    github:
+      connections:
+        default:
+          mode: user
+          auth:
+            type: oauth2
 ```
 
 ### Connection modes
@@ -116,56 +117,49 @@ plugins:
 
 `connections.default` is the common case. When a provider defines more than one connection, callers pass `_connection` and `_instance` through the [HTTP API](/reference/http-api) to select which stored credential to use. Connection parameters (`params`) and post-connect discovery are only supported on `connections.default`.
 
-Gestalt stores upstream credentials keyed by user, plugin name, connection name, and instance. Renaming a `plugins:` key is a breaking change for stored connections.
+Gestalt stores upstream credentials keyed by user, plugin name, connection name, and instance. Renaming a plugin key under `providers.plugins` is a breaking change for stored connections.
 
 ## Exposing over MCP
 
-Enable MCP tool exposure per plugin:
-
-```yaml
-plugins:
-  github:
-    mcp:
-      enabled: true
-      toolPrefix: github_
-```
-
-`toolPrefix` avoids name collisions when multiple plugins expose MCP tools. The MCP endpoint is served at `/mcp` using the same auth model as the HTTP API.
+MCP tool exposure is declared in the provider manifest via `spec.mcp: true`. When enabled, the plugin's operations are available at `/mcp` using the same auth model as the HTTP API.
 
 ## Secrets
 
-The `secrets` block configures how `secret://` references in the config are resolved at startup. The default is `env`, which reads secrets from environment variables:
+The `providers.secrets` entry configures how `secret://` references in the config are resolved at startup. The default is `env`, which reads secrets from environment variables:
 
 ```yaml
-secrets:
-  builtin: env
+providers:
+  secrets:
+    source: env
 ```
 
 For production, use `file` (reads from a directory, works with Kubernetes volume-mounted secrets) or a cloud secret manager:
 
 ```yaml
-secrets:
-  builtin: file
-  config:
-    dir: /etc/gestalt-secrets
+providers:
+  secrets:
+    source: file
+    config:
+      dir: /etc/gestalt-secrets
 ```
 
 Cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) are also available. See [Secret Providers](/providers/secrets) for the full list.
 
 ## Web UI
 
-The `ui` block controls the public client UI served at `/`. Omit it to use the default bundled UI. Disable it to run headless:
+The `providers.ui` entry controls the public client UI served at `/`. Omit it to use the default bundled UI. Disable it to run headless:
 
 ```yaml
-ui:
-  disabled: true
+providers:
+  ui:
+    disabled: true
 ```
 
 Or point at a custom UI bundle:
 
 ```yaml
-ui:
-  provider:
+providers:
+  ui:
     source:
       ref: github.com/your-org/your-ui
       version: 1.0.0
@@ -175,31 +169,32 @@ The built-in admin UI at `/admin` is always available regardless of this setting
 
 ## Platform auth
 
-The `auth` block protects the web UI, HTTP API, and `/mcp` endpoint. For local development, omit it or disable it explicitly:
+The `providers.auth` entry protects the web UI, HTTP API, and `/mcp` endpoint. For local development, omit it or disable it explicitly:
 
 ```yaml
-auth:
-  disabled: true
+providers:
+  auth:
+    disabled: true
 ```
 
 For multi-user deployments, point at a published auth provider:
 
 ```yaml
-auth:
-  provider:
+providers:
+  auth:
     source:
       ref: github.com/valon-technologies/gestalt-providers/auth/oidc
       version: 0.0.1-alpha.1
-  config:
-    issuerUrl: https://login.example.com
-    clientId: ${OIDC_CLIENT_ID}
-    clientSecret: secret://oidc-client-secret
+    config:
+      issuerUrl: https://login.example.com
+      clientId: ${OIDC_CLIENT_ID}
+      clientSecret: secret://oidc-client-secret
 ```
 
 | Scenario | Configuration |
 | --- | --- |
-| Local development | Omit `auth` or set `auth: { disabled: true }` |
-| Multi-user deployment | `auth.provider` with a published OIDC or Google auth provider |
+| Local development | Omit `providers.auth` or set `providers.auth.disabled: true` |
+| Multi-user deployment | `providers.auth` with a published OIDC or Google auth provider |
 | Per-user upstream access | `mode: user` on plugin connections |
 | Shared service credential | `mode: identity` on plugin connections |
 
@@ -209,19 +204,20 @@ For programmatic access, Gestalt issues API tokens prefixed with `gst_api_`. The
 
 ## Configuring storage
 
-The `indexeddbs` block declares storage providers. The `indexeddb` field selects which one Gestalt uses:
+The `providers.indexeddbs` block declares storage providers. The `server.indexeddb` field selects which one Gestalt uses:
 
 ```yaml
-indexeddbs:
-  main:
-    provider:
+server:
+  indexeddb: main
+
+providers:
+  indexeddbs:
+    main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
         version: 0.0.1-alpha.1
-    config:
-      dsn: sqlite://./gestalt.db
-
-indexeddb: main
+      config:
+        dsn: sqlite://./gestalt.db
 ```
 
 SQLite works for single-instance deployments. For production, use a Postgres or MySQL DSN. See [Datastores](/providers/datastores) for the full provider model.
@@ -256,7 +252,7 @@ gestaltd validate --config ./config.yaml
 
 ### Defaults and required fields
 
-Gestalt defaults `server.public.port` to `8080`, `secrets.builtin` to `env`, and `telemetry.builtin` to `stdout`. The required fields are `indexeddbs`, `indexeddb`, and `server.encryptionKey`. Platform auth is optional.
+Gestalt defaults `server.public.port` to `8080`, `providers.secrets` to `env`, and `providers.telemetry` to `stdout`. The required fields are `providers.indexeddbs`, `server.indexeddb`, and `server.encryptionKey`. Platform auth is optional.
 
 `server.encryptionKey` is the root deployment secret. Gestalt derives token encryption and session material from it. Changing this key invalidates all existing sessions and tokens, so treat it as a meaningful deployment event.
 
@@ -268,52 +264,46 @@ A production deployment with OIDC auth, a GitHub plugin with per-user connection
 server:
   baseUrl: https://gestalt.example.com
   encryptionKey: secret://gestalt-encryption-key
+  indexeddb: main
 
-auth:
-  provider:
+providers:
+  auth:
     source:
       ref: github.com/valon-technologies/gestalt-providers/auth/oidc
       version: 0.0.1-alpha.1
-  config:
-    issuerUrl: https://login.example.com
-    clientId: ${OIDC_CLIENT_ID}
-    clientSecret: secret://oidc-client-secret
+    config:
+      issuerUrl: https://login.example.com
+      clientId: ${OIDC_CLIENT_ID}
+      clientSecret: secret://oidc-client-secret
 
-indexeddbs:
-  main:
-    provider:
+  indexeddbs:
+    main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
         version: 0.0.1-alpha.1
-    config:
-      dsn: sqlite://./gestalt.db
+      config:
+        dsn: sqlite://./gestalt.db
 
-indexeddb: main
-
-plugins:
-  github:
-    displayName: GitHub
-    provider:
+  plugins:
+    github:
+      displayName: GitHub
       source:
         ref: github.com/valon-technologies/gestalt-providers/plugins/github
         version: 0.0.1-alpha.1
-    config:
-      apiBaseUrl: https://api.github.com
-    mcp:
-      enabled: true
-      toolPrefix: github_
-    connections:
-      api:
-        mode: user
-        auth:
-          type: bearer
-          credentials:
-            - name: token
-              label: Personal Access Token
-      mcp:
-        mode: user
-        auth:
-          type: mcp_oauth
+      config:
+        apiBaseUrl: https://api.github.com
+      connections:
+        api:
+          mode: user
+          auth:
+            type: bearer
+            credentials:
+              - name: token
+                label: Personal Access Token
+        mcp:
+          mode: user
+          auth:
+            type: mcp_oauth
 ```
 
 ## Minimal config
@@ -326,19 +316,16 @@ server:
     port: 8080
   baseUrl: http://localhost:8080
   encryptionKey: change-me
+  indexeddb: main
 
-indexeddbs:
-  main:
-    provider:
+providers:
+  indexeddbs:
+    main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
         version: 0.0.1-alpha.1
-    config:
-      dsn: sqlite://./gestalt.db
-
-indexeddb: main
-
-plugins: {}
+      config:
+        dsn: sqlite://./gestalt.db
 ```
 
 See [Observability](/observability) for adding metrics, logs, and OTLP export. See [Deploy](/deploy) for production startup workflows, lockfiles, and prepared artifacts.

--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -39,24 +39,23 @@ config:
   server:
     baseUrl: "${GESTALT_BASE_URL}"
     encryptionKey: "${GESTALT_ENCRYPTION_KEY}"
-  auth:
-    provider:
+    indexeddb: main
+  providers:
+    auth:
       source:
         ref: github.com/valon-technologies/gestalt-providers/auth/oidc
         version: 0.0.1-alpha.1
-    config:
-      issuerUrl: "${OIDC_ISSUER_URL}"
-      clientId: "${OIDC_CLIENT_ID}"
-      clientSecret: "${OIDC_CLIENT_SECRET}"
-  datastores:
-    main:
-      provider:
+      config:
+        issuerUrl: "${OIDC_ISSUER_URL}"
+        clientId: "${OIDC_CLIENT_ID}"
+        clientSecret: "${OIDC_CLIENT_SECRET}"
+    indexeddbs:
+      main:
         source:
           ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
           version: 0.0.1-alpha.2
-      config:
-        dsn: "${DATABASE_URL}"
-  datastore: main
+        config:
+          dsn: "${DATABASE_URL}"
 
 extraEnv:
   - name: GESTALT_BASE_URL
@@ -119,25 +118,24 @@ config:
       port: 9090
     baseUrl: "${GESTALT_BASE_URL}"
     encryptionKey: "${GESTALT_ENCRYPTION_KEY}"
-  auth:
-    provider:
+    indexeddb: main
+  providers:
+    auth:
       source:
         ref: github.com/valon-technologies/gestalt-providers/auth/oidc
         version: 0.0.1-alpha.1
-    config:
-      issuerUrl: "${OIDC_ISSUER_URL}"
-      clientId: "${OIDC_CLIENT_ID}"
-      clientSecret: "${OIDC_CLIENT_SECRET}"
-      redirectUrl: "${OIDC_REDIRECT_URL}"
-  datastores:
-    main:
-      provider:
+      config:
+        issuerUrl: "${OIDC_ISSUER_URL}"
+        clientId: "${OIDC_CLIENT_ID}"
+        clientSecret: "${OIDC_CLIENT_SECRET}"
+        redirectUrl: "${OIDC_REDIRECT_URL}"
+    indexeddbs:
+      main:
         source:
           ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
           version: 0.0.1-alpha.2
-      config:
-        dsn: "${DATABASE_URL}"
-  datastore: main
+        config:
+          dsn: "${DATABASE_URL}"
 
 extraEnv:
   - name: GESTALT_BASE_URL
@@ -181,7 +179,7 @@ client UI hostname.
 
 ## When to enable `pluginInit`
 
-Enable the init container when your config uses `plugins.*.provider.source.ref`, `auth.provider.source.ref`, `datastores.*.provider.source.ref`, or `ui.provider.source.ref` and you want that state prepared before the main container starts. The init container copies the rendered config and runs:
+Enable the init container when your config uses `providers.plugins.*.source.ref`, `providers.auth.source.ref`, `providers.indexeddbs.*.source.ref`, or `providers.ui.source.ref` and you want that state prepared before the main container starts. The init container copies the rendered config and runs:
 
 `/gestaltd init --config /etc/gestalt/config.yaml`
 

--- a/docs/content/observability.mdx
+++ b/docs/content/observability.mdx
@@ -15,78 +15,82 @@ finished initialization, then switches to `200`.
 
 ## Default Telemetry
 
-If you omit the `telemetry` block, Gestalt defaults to stdout.
+If you omit the `providers.telemetry` block, Gestalt defaults to stdout.
 
 ```yaml
-telemetry:
-  builtin: stdout
+providers:
+  telemetry:
+    source: stdout
 ```
 
 That gives you structured logs without external collectors. The `stdout`
-builtin also exposes a Prometheus-compatible `/metrics` endpoint. Traces remain
-disabled unless you switch to `telemetry: { builtin: otlp }`.
+source also exposes a Prometheus-compatible `/metrics` endpoint. Traces remain
+disabled unless you switch to `source: otlp` under `providers.telemetry`.
 
 ## OTLP Export
 
-Set `telemetry: { builtin: otlp }` to export traces, metrics, and logs over
-OpenTelemetry.
+Set `source: otlp` under `providers.telemetry` to export traces, metrics, and
+logs over OpenTelemetry.
 
 ```yaml
-telemetry:
-  builtin: otlp
-  config:
-    endpoint: otel-collector:4317
-    protocol: grpc
-    service_name: gestaltd
-    traces:
-      sampling_ratio: 1.0
-    metrics:
-      interval: 60s
-    logs:
-      level: info
+providers:
+  telemetry:
+    source: otlp
+    config:
+      endpoint: otel-collector:4317
+      protocol: grpc
+      service_name: gestaltd
+      traces:
+        sampling_ratio: 1.0
+      metrics:
+        interval: 60s
+      logs:
+        level: info
 ```
 
 If you want traces and metrics in OTLP but need application logs to remain on
 stdout for the host platform to collect, override the log exporter.
 
 ```yaml
-telemetry:
-  builtin: otlp
-  config:
-    endpoint: otel-collector:4317
-    protocol: grpc
-    logs:
-      exporter: stdout
-      format: json
-      level: info
+providers:
+  telemetry:
+    source: otlp
+    config:
+      endpoint: otel-collector:4317
+      protocol: grpc
+      logs:
+        exporter: stdout
+        format: json
+        level: info
 ```
 
 ## Audit Routing
 
 Audit logs inherit the main telemetry logger by default. If you need a
-different route for compliance, analytics, or warehousing, configure the
-top-level `audit:` block separately.
+different route for compliance, analytics, or warehousing, configure
+`providers.audit` separately.
 
 ```yaml
-telemetry:
-  builtin: stdout
-  config:
-    format: json
+providers:
+  telemetry:
+    source: stdout
+    config:
+      format: json
 
-audit:
-  builtin: otlp
-  config:
-    endpoint: audit-collector:4317
-    protocol: grpc
-    headers:
-      Authorization: Bearer ${AUDIT_OTLP_TOKEN}
+  audit:
+    source: otlp
+    config:
+      endpoint: audit-collector:4317
+      protocol: grpc
+      headers:
+        Authorization: Bearer ${AUDIT_OTLP_TOKEN}
 ```
 
 That keeps application logs on stdout while exporting only audit records over
-OTLP. You can also set `audit: { builtin: stdout }` to keep audit logs on stdout
-when telemetry is `noop`, or `audit: { builtin: noop }` to disable audit output
-explicitly. If you leave `audit: { builtin: inherit }`, collectors can still split
-the stream by filtering on `log.type=audit`.
+OTLP. You can also set `providers.audit` with `source: stdout` to keep audit
+logs on stdout when telemetry is `noop`, or `source: noop` to disable audit
+output explicitly. If you leave `source: inherit` under `providers.audit`,
+collectors can still split the stream by filtering on `log.type=audit`.
 
 ## Emitted Metrics
 
@@ -319,12 +323,11 @@ These metrics use standard OpenTelemetry gRPC client semantic attributes such as
 ## Prometheus Scrape Endpoint
 
 When telemetry metrics are enabled, Gestalt exposes a Prometheus scrape endpoint
-at `/metrics`. With `telemetry: { builtin: stdout }`, metrics are kept local and
-served directly. With `telemetry: { builtin: otlp }`, metrics are exported over OTLP
-and also served at `/metrics` locally unless you disable the Prometheus bridge.
-Setting `telemetry: { builtin: noop }` disables Prometheus scraping entirely;
-`/metrics` returns a clear unavailable response so the admin UI can surface that
-state.
+at `/metrics`. With `providers.telemetry` set to `source: stdout`, metrics are
+kept local and served directly. With `source: otlp`, metrics are exported over
+OTLP and also served at `/metrics` locally unless you disable the Prometheus
+bridge. Setting `source: noop` disables Prometheus scraping entirely; `/metrics`
+returns a clear unavailable response so the admin UI can surface that state.
 
 When Gestalt serves `/metrics` on the public listener, it is authenticated with
 the same session or bearer-token middleware as the rest of the HTTP API. When

--- a/docs/content/providers/auth.mdx
+++ b/docs/content/providers/auth.mdx
@@ -8,18 +8,19 @@ Beyond the core login flow, an auth provider can optionally validate externally 
 
 ## Manifest
 
-An auth provider manifest uses an `auth` block:
+An auth provider manifest uses a `spec` block with `kind: auth`:
 
 ```yaml
+kind: auth
 source: github.com/example/plugins/my-auth
 version: 0.0.1-alpha.1
 displayName: My Auth Provider
 description: Custom OAuth 2.0 authentication
-auth:
+spec:
   configSchemaPath: ./auth_config.json
 ```
 
-The optional `auth.configSchemaPath` field points to a JSON Schema that validates the `auth.config` block in the server config. If you provide one, Gestalt rejects invalid config at startup rather than letting bad values reach the provider at runtime.
+The optional `spec.configSchemaPath` field points to a JSON Schema that validates the `config` block in the server config. If you provide one, Gestalt rejects invalid config at startup rather than letting bad values reach the provider at runtime.
 
 ## Interface
 
@@ -236,19 +237,19 @@ Two optional interfaces extend the base contract.
 
 ## Config reference
 
-To use your auth provider in a Gestalt deployment, reference it in the `auth` block:
+To use your auth provider in a Gestalt deployment, reference it in the `providers.auth` block:
 
 ```yaml
-auth:
-  provider:
+providers:
+  auth:
     source:
       path: ./my-auth/manifest.yaml
-  config:
-    issuerUrl: https://login.example.com
-    clientId: ${OIDC_CLIENT_ID}
-    clientSecret: secret://oidc-client-secret
+    config:
+      issuerUrl: https://login.example.com
+      clientId: ${OIDC_CLIENT_ID}
+      clientSecret: secret://oidc-client-secret
 ```
 
-`provider.source.path` points at the auth provider's `manifest.yaml` during development. For production, use `provider.source.ref` and `version` to reference a published release. The `config` block is passed to `Configure` at startup and validated against the config schema if one was declared in the manifest.
+`source.path` points at the auth provider's `manifest.yaml` during development. For production, use `source.ref` and `version` to reference a published release. The `config` block is passed to `Configure` at startup and validated against the config schema if one was declared in the manifest.
 
 Secret references like `secret://oidc-client-secret` are resolved through the configured secret manager before reaching the provider. Environment variable placeholders like `${OIDC_CLIENT_ID}` are expanded during config loading. See [Configuration](/configuration) for details on both.

--- a/docs/content/providers/datastores.mdx
+++ b/docs/content/providers/datastores.mdx
@@ -10,14 +10,15 @@ Gestalt stores users, plugin tokens, API tokens, and OAuth registrations through
 
 ## Manifest
 
-A datastore provider manifest uses a `datastore` block:
+A datastore provider manifest uses a `spec` block with `kind: indexeddb`:
 
 ```yaml
+kind: indexeddb
 source: github.com/example/plugins/my-datastore
 version: 0.0.1-alpha.1
 displayName: My Datastore
 description: Custom persistent storage backend
-datastore:
+spec:
   configSchemaPath: ./datastore_config.json
 ```
 
@@ -251,40 +252,32 @@ Plugins access datastores through the SDK. The host serves the IndexedDB interfa
 
 ## Config reference
 
-Reference a datastore provider in the `datastores` section:
+Reference a datastore provider in the `providers.indexeddbs` section, and set `server.indexeddb` to the name of the active provider:
 
 ```yaml
-datastores:
-  main:
-    provider:
+server:
+  indexeddb: main
+
+providers:
+  indexeddbs:
+    main:
       source:
         path: ./my-datastore/manifest.yaml
-    config:
-      dsn: ${DATABASE_URL}
-
-datastore: main
+      config:
+        dsn: ${DATABASE_URL}
 ```
 
-`provider.source.path` points at the provider's `manifest.yaml` during development. For production, use `provider.source.ref` and `version` to reference a published release:
+`source.path` points at the provider's `manifest.yaml` during development. For production, use `source.ref` and `version` to reference a published release:
 
 ```yaml
-datastores:
-  main:
-    provider:
+providers:
+  indexeddbs:
+    main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
         version: 0.0.1
-    config:
-      dsn: ${DATABASE_URL}
-```
-
-Plugins bind to named datastores:
-
-```yaml
-plugins:
-  my-plugin:
-    datastores:
-      db: main
+      config:
+        dsn: ${DATABASE_URL}
 ```
 
 The plugin receives the `IndexedDB` interface over a gRPC socket. Object store names are automatically namespaced per plugin to prevent cross-plugin data access.

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -8,13 +8,13 @@ Gestalt has a unified runtime model: plugins, auth backends, datastores, and web
 
 ## Provider kinds
 
-A provider's kind is implied by the one top-level metadata block in its manifest:
+A provider's kind is set by the `kind` field in its manifest:
 
 | Kind | Purpose |
 | --- | --- |
 | `plugin` | Plugin. Exposes operations that users invoke through the CLI, the HTTP API, or MCP. |
 | `auth` | Platform auth backend. Handles login, session validation, and external token verification. |
-| `datastore` | Persistent storage. Stores users, plugin tokens, API tokens, and OAuth registrations. |
+| `indexeddb` | Persistent storage. Stores users, plugin tokens, API tokens, and OAuth registrations. |
 | `secrets` | Secret manager. Resolves `secret://` references at bootstrap. Go SDK only for now. |
 | `webui` | Replacement web UI served at `/`. |
 
@@ -28,7 +28,7 @@ The host owns auth, token storage, connection selection, and HTTP or MCP routing
 
 ## Process isolation
 
-Providers run in their own process. They cannot access the host process memory, other users' credentials, or (for plugins) the datastore directly. Plugins also run inside a network sandbox: outbound requests to hosts not listed in `plugin.allowedHosts` in the manifest are rejected with a 403.
+Providers run in their own process. They cannot access the host process memory, other users' credentials, or (for plugins) the datastore directly. Plugins also run inside a network sandbox: outbound requests to hosts not listed in `allowedHosts` are rejected with a 403.
 
 ## SDK support
 
@@ -51,9 +51,9 @@ This convention enables prefix matching in the CLI. When you run `gestalt invoke
 
 ## Common pitfalls
 
-**Duplicate operation IDs.** Operation IDs must be unique within a provider. If two surfaces (for example, an OpenAPI passthrough and an executable operation) expose the same ID, the provider fails validation at startup. Use `allowed_operations` to filter or alias collisions.
+**Duplicate operation IDs.** Operation IDs must be unique within a provider. If two surfaces (for example, an OpenAPI passthrough and an executable operation) expose the same ID, the provider fails validation at startup. Use `allowedOperations` to filter or alias collisions.
 
-**Sandbox 403 errors.** Executable providers run inside a network sandbox. Outbound HTTP requests to hosts not listed in `plugin.allowedHosts` are rejected with a 403. Add every upstream domain the provider contacts to the allowlist in the manifest.
+**Sandbox 403 errors.** Executable providers run inside a network sandbox. Outbound HTTP requests to hosts not listed in `allowedHosts` are rejected with a 403. Add every upstream domain the provider contacts to the allowlist in the config or manifest.
 
 ## What to read next
 

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -2,7 +2,7 @@ import { Tabs } from 'nextra/components'
 
 # Plugins
 
-Plugins are one provider kind. Their manifests use a top-level `plugin:` block, and deployments reference them under the top-level `plugins:` map. A plugin can define operations as executable code (handled by the provider process), as passthrough surfaces (REST, OpenAPI, GraphQL, or MCP endpoints forwarded by the host), or both.
+Plugins are one provider kind. Their manifests use a top-level `spec:` block, and deployments reference them under `providers.plugins`. A plugin can define operations as executable code (handled by the provider process), as passthrough surfaces (REST, OpenAPI, GraphQL, or MCP endpoints forwarded by the host), or both.
 
 ## Manifest
 
@@ -11,11 +11,12 @@ Static metadata, auth, and passthrough surfaces live in a manifest file. Gestalt
 <Tabs items={['YAML', 'JSON']}>
   <Tabs.Tab>
     ```yaml
+    kind: plugin
     source: github.com/example/plugins/my-plugin
     version: 0.0.1-alpha.1
     displayName: My Plugin
     description: A custom plugin
-    plugin:
+    spec:
       connections:
         default:
           auth:
@@ -25,11 +26,12 @@ Static metadata, auth, and passthrough surfaces live in a manifest file. Gestalt
   <Tabs.Tab>
     ```json
     {
+      "kind": "plugin",
       "source": "github.com/example/plugins/my-plugin",
       "version": "0.0.1-alpha.1",
       "displayName": "My Plugin",
       "description": "A custom plugin",
-      "plugin": {
+      "spec": {
         "connections": {
           "default": {
             "auth": {
@@ -574,16 +576,13 @@ By default, the operation catalog is static and materialized at startup. If your
 Point a local config at the source plugin. Gestalt synthesizes the executable wrapper and materializes the catalog automatically:
 
 ```yaml
-plugins:
-  my-plugin:
-    provider:
+providers:
+  plugins:
+    my-plugin:
       source:
         path: ./manifest.yaml
-    config:
-      greeting: Hello
-    mcp:
-      enabled: true
-      tool_prefix: my_
+      config:
+        greeting: Hello
 ```
 
 Start the server and invoke the operation:
@@ -598,6 +597,6 @@ gestalt invoke my-plugin greet -p name=Gestalt
 
 ## Hybrid providers
 
-A manifest can define passthrough surfaces (`plugin.openapi`, `plugin.base_url` plus `plugin.operations`, `plugin.graphql_url`, or `plugin.mcp_url`) alongside executable operations. The passthrough surfaces are forwarded by the host directly to the upstream API, while the executable operations are handled by the provider process. This is useful when a plugin adds custom logic on top of an existing API.
+A manifest can define passthrough surfaces (`spec.surfaces.openapi`, `spec.surfaces.rest`, `spec.surfaces.graphql`, or `spec.surfaces.mcp`) alongside executable operations. The passthrough surfaces are forwarded by the host directly to the upstream API, while the executable operations are handled by the provider process. This is useful when a plugin adds custom logic on top of an existing API.
 
-Do not define the same operation ID in both a passthrough surface and an executable operation. If two surfaces expose the same ID, the provider fails validation at startup. Use `allowed_operations` to filter or alias collisions when needed.
+Do not define the same operation ID in both a passthrough surface and an executable operation. If two surfaces expose the same ID, the provider fails validation at startup. Use `allowedOperations` to filter or alias collisions when needed.

--- a/docs/content/providers/releasing.mdx
+++ b/docs/content/providers/releasing.mdx
@@ -19,9 +19,10 @@ those fields for you.
 ### Minimal executable source manifest
 
 ```yaml
+kind: plugin
 source: github.com/acme/plugins/my-plugin
 version: 0.0.1-alpha.1
-plugin:
+spec:
   connections:
     default:
       auth:
@@ -128,6 +129,7 @@ static assets and lets provider/auth/datastore packages generate support files
 such as config schemas before packaging.
 
 ```yaml
+kind: webui
 source: github.com/acme/plugins/gestalt-ui
 version: 1.2.0
 release:
@@ -137,22 +139,22 @@ release:
       - npm
       - run
       - build
-webui:
-  asset_root: ui/out
+spec:
+  assetRoot: ui/out
 ```
 
 ### Release manifest for an executable provider
 
-Released executable plugin providers add concrete `entrypoints.plugin` and
+Released executable plugin providers add concrete `entrypoint` and
 `artifacts` entries:
 
 ```yaml
+kind: plugin
 source: github.com/acme/plugins/my-plugin
 version: 0.0.1-alpha.1
-plugin: {}
-entrypoints:
-  plugin:
-    artifact_path: artifacts/linux/amd64/provider
+spec: {}
+entrypoint:
+  artifactPath: artifacts/linux/amd64/provider
 artifacts:
   - os: linux
     arch: amd64
@@ -166,10 +168,11 @@ artifacts:
 UI packages use the same manifest system:
 
 ```yaml
+kind: webui
 source: github.com/acme/plugins/web/default
 version: 1.2.0
-webui:
-  asset_root: ui/out
+spec:
+  assetRoot: ui/out
   configSchemaPath: schemas/ui-config.schema.json
 ```
 
@@ -210,9 +213,9 @@ binaries during release.
 Use the source tree directly during development:
 
 ```yaml
-plugins:
-  my-plugin:
-    provider:
+providers:
+  plugins:
+    my-plugin:
       source:
         path: ./plugins/my-plugin/manifest.yaml
 ```
@@ -223,9 +226,9 @@ Reference a published release by source and version. `gestaltd init` resolves
 the release archive and writes it to lock state:
 
 ```yaml
-plugins:
-  my-plugin:
-    provider:
+providers:
+  plugins:
+    my-plugin:
       source:
         ref: github.com/your-org/your-plugins/my-plugin
         version: 0.0.1-alpha.1
@@ -235,16 +238,16 @@ This is the recommended approach for production deployments.
 
 ### UI bundle
 
-Reference a released UI bundle separately under `ui.provider`:
+Reference a released UI bundle separately under `providers.ui`:
 
 ```yaml
-ui:
-  provider:
+providers:
+  ui:
     source:
       ref: github.com/acme/plugins/web/default
       version: 1.2.0
-  config:
-    brand_name: Acme
+    config:
+      brand_name: Acme
 ```
 
 ## Prepared state

--- a/docs/content/providers/secrets.mdx
+++ b/docs/content/providers/secrets.mdx
@@ -8,18 +8,19 @@ The built-in `env` and `file` providers cover local development. For production 
 
 ## Manifest
 
-A secrets provider manifest uses a `secrets` block:
+A secrets provider manifest uses a `spec` block with `kind: secrets`:
 
 ```yaml
+kind: secrets
 source: github.com/example/plugins/my-secrets
 version: 0.0.1-alpha.1
 displayName: My Secrets Provider
 description: Resolves secrets from a custom vault.
-secrets:
+spec:
   configSchemaPath: ./secrets_config.json
 ```
 
-The optional `secrets.configSchemaPath` field points to a JSON Schema that validates the `secrets.config` block in the server config.
+The optional `spec.configSchemaPath` field points to a JSON Schema that validates the `config` block in the server config.
 
 ## Interface
 
@@ -139,27 +140,27 @@ A secrets provider implements two methods: `Configure` and `GetSecret`. `Configu
 
 ## Config reference
 
-To use a secrets provider in a Gestalt deployment, reference it in the `secrets` block:
+To use a secrets provider in a Gestalt deployment, reference it in the `providers.secrets` block:
 
 ```yaml
-secrets:
-  provider:
+providers:
+  secrets:
     source:
       path: ./my-secrets/manifest.yaml
-  config:
-    prefix: MY_APP_
+    config:
+      prefix: MY_APP_
 ```
 
-`provider.source.path` points at the secrets provider's `manifest.yaml` during development. For production, use `provider.source.ref` and `version` to reference a published release:
+`source.path` points at the secrets provider's `manifest.yaml` during development. For production, use `source.ref` and `version` to reference a published release:
 
 ```yaml
-secrets:
-  provider:
+providers:
+  secrets:
     source:
       ref: github.com/valon-technologies/gestalt-providers/secrets/google
       version: 0.0.1-alpha.1
-  config:
-    project: my-gcp-project
+    config:
+      project: my-gcp-project
 ```
 
 The `config` block is passed to `Configure` at startup.
@@ -171,19 +172,21 @@ Two simple providers are built in and do not require a plugin manifest:
 **`env`** resolves secrets from environment variables. Secret names are uppercased with hyphens converted to underscores. An optional `prefix` is prepended.
 
 ```yaml
-secrets:
-  builtin: env
-  config:
-    prefix: GESTALT_
+providers:
+  secrets:
+    source: env
+    config:
+      prefix: GESTALT_
 ```
 
 **`file`** reads secrets from files in a directory. Each secret name maps to a file in the configured directory.
 
 ```yaml
-secrets:
-  builtin: file
-  config:
-    dir: /run/secrets
+providers:
+  secrets:
+    source: file
+    config:
+      dir: /run/secrets
 ```
 
 ## Available providers

--- a/docs/content/providers/web-uis.mdx
+++ b/docs/content/providers/web-uis.mdx
@@ -8,22 +8,24 @@ A UI bundle is not a plugin in the executable sense. It contains no server-side 
 
 ## Manifest
 
-A UI bundle manifest declares `webui.asset_root`, which points to the directory containing the built static assets:
+A UI bundle manifest declares `spec.assetRoot`, which points to the directory containing the built static assets:
 
 ```yaml
+kind: webui
 source: github.com/acme/plugins/gestalt-ui
 version: 1.2.0
-webui:
-  asset_root: ui/out
+spec:
+  assetRoot: ui/out
 ```
 
-The `asset_root` path is relative to the manifest file. It should contain the output of your frontend build (typically an `index.html` and accompanying JS, CSS, and image files).
+The `assetRoot` path is relative to the manifest file. It should contain the output of your frontend build (typically an `index.html` and accompanying JS, CSS, and image files).
 
 ## Build step
 
 If your UI needs a build step before packaging, use `release.build` to run it automatically during `gestaltd provider release`. This runs before source-manifest preparation, so the built assets are included in the release archive.
 
 ```yaml
+kind: webui
 source: github.com/acme/plugins/gestalt-ui
 version: 1.2.0
 release:
@@ -33,19 +35,19 @@ release:
       - npm
       - run
       - build
-webui:
-  asset_root: ui/out
+spec:
+  assetRoot: ui/out
 ```
 
-`workdir` is relative to the manifest directory. The command runs in that directory, so `npm run build` executes inside `ui/`. After the build completes, Gestalt packages everything under `asset_root` into the release archive.
+`workdir` is relative to the manifest directory. The command runs in that directory, so `npm run build` executes inside `ui/`. After the build completes, Gestalt packages everything under `assetRoot` into the release archive.
 
 ## Configuring a UI bundle
 
-Reference a UI bundle in the `ui.plugin` block of the server config. During development, point at the source manifest:
+Reference a UI bundle in the `providers.ui` block of the server config. During development, point at the source manifest:
 
 ```yaml
-ui:
-  plugin:
+providers:
+  ui:
     source:
       path: ./gestalt-ui/manifest.yaml
 ```
@@ -53,15 +55,16 @@ ui:
 For production, reference a published release by source and version:
 
 ```yaml
-ui:
-  plugin:
-    source: github.com/acme/plugins/gestalt-ui
-    version: 1.2.0
+providers:
+  ui:
+    source:
+      ref: github.com/acme/plugins/gestalt-ui
+      version: 1.2.0
 ```
 
 When a config references a published UI bundle, run `gestaltd init` to resolve and prepare it. This writes lock state to `gestalt.lock.json` and extracts the assets under `.gestaltd/`. After init, `gestaltd serve --locked` serves the locked UI bundle at `/`. If the prepared UI files are already present, Gestalt uses them directly; if they are missing, Gestalt can materialize them from the lockfile at startup.
 
-If `ui.plugin` is omitted entirely, Gestalt falls back to the built-in client UI.
+If `providers.ui` is omitted entirely, Gestalt falls back to the built-in client UI.
 
 ## The admin UI
 

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -6,7 +6,7 @@ Two simple secrets providers (`env` and `file`), telemetry, and audit remain bui
 
 ## Auth Providers
 
-Auth providers handle platform login. They are configured under `auth.provider` in your config file, using the `provider:` key to reference the provider source.
+Auth providers handle platform login. They are configured under `providers.auth` in your config file.
 
 | Name | Purpose |
 | --- | --- |
@@ -15,33 +15,34 @@ Auth providers handle platform login. They are configured under `auth.provider` 
 | `oidc` | Generic OpenID Connect. Works with Okta, Auth0, Azure AD, Keycloak, and others. |
 
 ```yaml
-auth:
-  provider:
+providers:
+  auth:
     source:
       ref: github.com/valon-technologies/gestalt-providers/auth-google
       version: 1.0.0
-  config:
-    allowedDomains:
-      - example.com
+    config:
+      allowedDomains:
+        - example.com
 ```
 
-To disable platform auth entirely, omit the `auth` block or set `auth: { disabled: true }`.
+To disable platform auth entirely, omit the `providers.auth` block or set `providers: { auth: { disabled: true } }`.
 
 ## Datastore Providers
 
-Datastore providers back the persistent state layer. They are configured under named entries in `datastores`, and `datastore` selects which one the host uses. Gestalt does not compile datastore drivers into the binary; it starts the configured external datastore provider process at runtime.
+Datastore providers back the persistent state layer. They are configured under named entries in `providers.indexeddbs`, and `server.indexeddb` selects which one the host uses. Gestalt does not compile datastore drivers into the binary; it starts the configured external datastore provider process at runtime.
 
 ```yaml
-datastores:
-  main:
-    provider:
+server:
+  indexeddb: main
+
+providers:
+  indexeddbs:
+    main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
         version: 1.0.0
-    config:
-      dsn: ${DATABASE_URL}
-
-datastore: main
+      config:
+        dsn: ${DATABASE_URL}
 ```
 
 ## Secret Managers
@@ -50,10 +51,10 @@ Two secret managers are compiled into the `gestaltd` binary and resolve `secret:
 
 | Name | Purpose |
 | --- | --- |
-| `env` | Resolves secrets from environment variables. Default when `secrets` is omitted. |
+| `env` | Resolves secrets from environment variables. Default when `providers.secrets` is omitted. |
 | `file` | Resolves secrets from files in a configured directory. Works with Kubernetes volume-mounted secrets. |
 
-For cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault), see [Secrets Providers](/providers/secrets#available-providers). These use the `provider:` config key under `secrets` rather than `builtin:`.
+For cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault), see [Secrets Providers](/providers/secrets#available-providers). These use a `source:` config key under `providers.secrets`.
 
 ## Telemetry Providers (built-in)
 
@@ -67,12 +68,12 @@ Telemetry providers are compiled into the binary.
 
 ## Plugins
 
-Plugins (BigQuery, Jira, Slack, and others) are published separately from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). They use the `provider:` key under each named entry in the `plugins` map:
+Plugins (BigQuery, Jira, Slack, and others) are published separately from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). They are configured under `providers.plugins`:
 
 ```yaml
-plugins:
-  jira:
-    provider:
+providers:
+  plugins:
+    jira:
       source:
         ref: github.com/valon-technologies/gestalt-providers/jira
         version: 1.0.0
@@ -80,4 +81,4 @@ plugins:
 
 ## Community and Custom Providers
 
-Third-party auth providers, datastore providers, and plugins use the same provider package model as the first-party packages. Package your implementation with a provider manifest that includes the appropriate top-level block (`auth`, `datastore`, or `plugin`), publish it to a Git-accessible source, and reference it in your config the same way you would reference any first-party provider.
+Third-party auth providers, datastore providers, and plugins use the same provider package model as the first-party packages. Package your implementation with a provider manifest that includes the appropriate `kind` and `spec` block, publish it to a Git-accessible source, and reference it in your config the same way you would reference any first-party provider.

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -2,25 +2,26 @@ import { Tabs } from 'nextra/components'
 
 # Config File
 
-Every `gestaltd` deployment reads a single YAML config file. The top-level keys map one-to-one with the subsystems they configure:
+Every `gestaltd` deployment reads a single YAML config file. The two top-level keys are `server` (listener, encryption, egress, and indexeddb selection) and `providers` (auth, secrets, telemetry, audit, UI, indexeddbs, and plugins):
 
 ```yaml
-server: {}
-auth: {}
-datastore: {}
-secrets: {}
-telemetry: {}
-audit: {}
-plugins: {}
-egress: {}
-ui: {}
+server:
+  # listener, encryption, egress, indexeddb selector
+providers:
+  auth: {}
+  secrets: {}
+  telemetry: {}
+  audit: {}
+  ui: {}
+  indexeddbs: {}
+  plugins: {}
 ```
 
 ## Load Semantics
 
 `${ENV_VAR}` references are expanded before YAML decoding. When a referenced variable is unset, Gestalt checks for a corresponding `ENV_VAR_FILE` variable and reads that file path instead. If neither is set, config loading fails. Use `${ENV_VAR:-}` when an explicit empty default is intentional. Unknown YAML fields are rejected.
 
-Several fields carry defaults when omitted: `server.public.port` defaults to `8080`, `secrets.builtin` to `env`, and `telemetry.builtin` to `stdout`. Relative paths resolve relative to the config file's directory. `secret://...` values are resolved during bootstrap, not during YAML parsing.
+Several fields carry defaults when omitted: `server.public.port` defaults to `8080`, `providers.secrets.source` to `env`, and `providers.telemetry.source` to `stdout`. Relative paths resolve relative to the config file's directory. `secret://...` values are resolved during bootstrap, not during YAML parsing.
 
 ## `server`
 
@@ -61,34 +62,35 @@ server:
 
 When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth routes, and `/mcp` on the public listener, while `/admin`, `/metrics`, `/health`, and `/ready` move to the management listener. The management listener is intended to be protected by deployment infrastructure such as private networking, VPN, or an internal-only reverse proxy. Gestalt does not apply its own session or API-token auth to `/metrics` on the management listener.
 
-## `auth`
+## `providers.auth`
 
-Top-level platform auth is optional. Omit the `auth` block entirely to disable platform authentication, or set `auth: { disabled: true }` explicitly. When auth is enabled, configure it with `auth.provider` and `auth.config`. `auth.provider` uses the same provider-reference shape as plugins: a `source` block plus optional `env` and `allowedHosts`.
+Platform auth is optional. Omit the `providers.auth` block entirely to disable platform authentication, or set `providers: { auth: { disabled: true } }` explicitly. When auth is enabled, configure it with `providers.auth.source` and `providers.auth.config`. The source uses the same provider-reference shape as plugins: a `source` block plus optional `env` and `allowedHosts`.
 
 ### `disabled`
 
 ```yaml
-auth:
-  disabled: true
+providers:
+  auth:
+    disabled: true
 ```
 
-Disables platform authentication. Every request is treated as a single anonymous user. Omitting the `auth` block has the same effect.
+Disables platform authentication. Every request is treated as a single anonymous user. Omitting the `providers.auth` block has the same effect.
 
 ### `google`
 
 ```yaml
-auth:
-  provider:
+providers:
+  auth:
     source:
       ref: github.com/valon-technologies/gestalt-providers/auth/google
       version: 0.0.1-alpha.1
-  config:
-    clientId: ${GOOGLE_CLIENT_ID}
-    clientSecret: secret://google-client-secret
-    redirectUrl: https://gestalt.example.com/api/v1/auth/login/callback
-    allowedDomains:
-      - example.com
-    sessionTtl: 24h
+    config:
+      clientId: ${GOOGLE_CLIENT_ID}
+      clientSecret: secret://google-client-secret
+      redirectUrl: https://gestalt.example.com/api/v1/auth/login/callback
+      allowedDomains:
+        - example.com
+      sessionTtl: 24h
 ```
 
 `clientId` and `clientSecret` are both required and identify your Google OAuth application. `redirectUrl` defaults to a path derived from `server.baseUrl` when omitted. `allowedDomains` restricts login to specific email domains. `sessionTtl` controls session token lifetime and defaults to `24h`.
@@ -98,25 +100,25 @@ Google checks `email_verified` on every login. Unverified accounts are rejected.
 ### `oidc`
 
 ```yaml
-auth:
-  provider:
+providers:
+  auth:
     source:
       ref: github.com/valon-technologies/gestalt-providers/auth/oidc
       version: 0.0.1-alpha.1
-  config:
-    issuerUrl: https://login.example.com
-    clientId: ${OIDC_CLIENT_ID}
-    clientSecret: secret://oidc-client-secret
-    redirectUrl: https://gestalt.example.com/api/v1/auth/login/callback
-    allowedDomains:
-      - example.com
-    scopes:
-      - openid
-      - email
-      - profile
-    sessionTtl: 24h
-    pkce: true
-    displayName: Company SSO
+    config:
+      issuerUrl: https://login.example.com
+      clientId: ${OIDC_CLIENT_ID}
+      clientSecret: secret://oidc-client-secret
+      redirectUrl: https://gestalt.example.com/api/v1/auth/login/callback
+      allowedDomains:
+        - example.com
+      scopes:
+        - openid
+        - email
+        - profile
+      sessionTtl: 24h
+      pkce: true
+      displayName: Company SSO
 ```
 
 Two fields are required: `issuerUrl` (the OIDC discovery base URL) and `clientId`. `clientSecret` may be omitted for PKCE-only public clients.
@@ -127,9 +129,9 @@ Two fields are required: `issuerUrl` (the OIDC discovery base URL) and `clientId
 
 OIDC checks `email_verified` when the claim is present. Unverified accounts are rejected.
 
-### `auth.provider` shape
+### `providers.auth` shape
 
-Both `google` and `oidc` use the same PluginDef provider reference shape under `auth.provider`. First-party auth providers are published at `github.com/valon-technologies/gestalt-providers/auth/<name>`.
+Both `google` and `oidc` use the same PluginDef provider reference shape under `providers.auth`. First-party auth providers are published at `github.com/valon-technologies/gestalt-providers/auth/<name>`.
 
 | Field | Description |
 | --- | --- |
@@ -138,53 +140,55 @@ Both `google` and `oidc` use the same PluginDef provider reference shape under `
 | `env` | Extra environment variables passed to the provider process. |
 | `allowedHosts` | Network allowlist for sandboxed provider processes. |
 
-## `datastore`
+## `providers.indexeddbs`
 
-Top-level datastores are also provider-based. Configure one or more named entries under `datastores`, then set `datastore` to the name the host should use for system storage. First-party datastore providers are published at `github.com/valon-technologies/gestalt-providers/datastore/<name>`.
+Indexed databases are provider-based. Configure one or more named entries under `providers.indexeddbs`, then set `server.indexeddb` to the name the host should use for system storage. First-party indexeddb providers are published at `github.com/valon-technologies/gestalt-providers/indexeddb/<name>`.
 
 ```yaml
-datastores:
-  main:
-    provider:
+server:
+  indexeddb: main
+
+providers:
+  indexeddbs:
+    main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
         version: 0.0.1-alpha.2
-    config:
-      dsn: ${DATABASE_URL}
-
-datastore: main
+      config:
+        dsn: ${DATABASE_URL}
 ```
 
-The exact config fields depend on the selected external datastore provider package. Gestalt itself does not have a built-in datastore driver matrix; it loads the configured provider process and passes the selected `datastores.<name>.config` block through to that provider.
+The exact config fields depend on the selected external indexeddb provider package. Gestalt itself does not have a built-in indexeddb driver matrix; it loads the configured provider process and passes the selected `providers.indexeddbs.<name>.config` block through to that provider.
 
-## `secrets`
+## `providers.secrets`
 
-The secrets manager resolves `secret://` references at startup. Two providers (`env` and `file`) are built into the binary and selected by the `builtin` field. Cloud secret backends are loaded as external providers using the `provider` field, the same way auth and datastore providers work.
+The secrets manager resolves `secret://` references at startup. Two built-in sources (`env` and `file`) are selected by the `source` field. Cloud secret backends are loaded as external providers using `source.ref`, the same way auth and indexeddb providers work.
 
 ```yaml
-secrets:
-  builtin: file
-  config:
-    dir: /etc/gestalt-secrets
+providers:
+  secrets:
+    source: file
+    config:
+      dir: /etc/gestalt-secrets
 ```
 
-| Builtin | Config fields | Purpose |
+| Source | Config fields | Purpose |
 | --- | --- | --- |
-| `env` | `prefix` | Reads secrets from environment variables. Default when `secrets` is omitted. |
+| `env` | `prefix` | Reads secrets from environment variables. Default when `providers.secrets` is omitted. |
 | `file` | `dir` | Reads one secret per file from a base directory. Works with Kubernetes volume-mounted secrets. |
 
 ### Cloud secret backends
 
-Cloud secret managers are external providers configured with `provider:` instead of `builtin:`:
+Cloud secret managers are external providers configured with `source.ref` instead of a string `source`:
 
 ```yaml
-secrets:
-  provider:
+providers:
+  secrets:
     source:
       ref: github.com/valon-technologies/gestalt-providers/secrets/google
       version: 0.0.1-alpha.13
-  config:
-    project: my-gcp-project
+    config:
+      project: my-gcp-project
 ```
 
 | Provider | Source ref | Config fields |
@@ -198,7 +202,7 @@ See [Secrets Providers](/providers/secrets) for the complete reference and SDK i
 
 ### Bootstrap credentials
 
-`secret://` references are resolved through the configured secret manager at startup, but the secret manager's own configuration (`secrets.config`) cannot use `secret://` because it would be self-referential. Use `${ENV_VAR}` or `${ENV_VAR_FILE}` placeholders for any credentials the secret manager itself needs.
+`secret://` references are resolved through the configured secret manager at startup, but the secret manager's own configuration (`providers.secrets.config`) cannot use `secret://` because it would be self-referential. Use `${ENV_VAR}` or `${ENV_VAR_FILE}` placeholders for any credentials the secret manager itself needs.
 
 Each provider authenticates to its backing service differently. The `env` and `file` providers are built in. The remaining rows apply when using the corresponding external provider from `gestalt-providers`:
 
@@ -213,22 +217,23 @@ Each provider authenticates to its backing service differently. The `env` and `f
 
 For local development, `env` or `file` avoids external dependencies entirely. Switch to a cloud secret manager when deploying to a managed environment where ambient identity is available.
 
-## `telemetry`
+## `providers.telemetry`
 
 Gestalt uses [OpenTelemetry](https://opentelemetry.io) for distributed traces, metrics, and structured logs. Every HTTP request, broker invocation, and plugin gRPC call is automatically traced. See [Observability](/observability) for the emitted metric inventory and Prometheus name translation.
 
 ### `stdout`
 
 ```yaml
-telemetry:
-  builtin: stdout
-  config:
-    format: text
-    level: info
-    serviceName: gestaltd
+providers:
+  telemetry:
+    source: stdout
+    config:
+      format: text
+      level: info
+      serviceName: gestaltd
 ```
 
-Outputs structured logs to standard output. Traces remain disabled, but metrics are collected locally and exposed through the Prometheus-compatible `/metrics` endpoint. The built-in admin UI at `/admin` reads that same scrape surface. This is the default when `telemetry` is omitted.
+Outputs structured logs to standard output. Traces remain disabled, but metrics are collected locally and exposed through the Prometheus-compatible `/metrics` endpoint. The built-in admin UI at `/admin` reads that same scrape surface. This is the default when `providers.telemetry` is omitted.
 
 | Field | Default | Description |
 | --- | --- | --- |
@@ -241,25 +246,26 @@ Outputs structured logs to standard output. Traces remain disabled, but metrics 
 ### `otlp`
 
 ```yaml
-telemetry:
-  builtin: otlp
-  config:
-    endpoint: otel-collector:4317
-    protocol: grpc
-    serviceName: gestaltd
-    insecure: false
-    headers:
-      Authorization: Bearer ${OTEL_TOKEN}
-    resourceAttributes:
-      deployment.environment: production
-      service.version: "1.0.0"
-    traces:
-      samplingRatio: 1.0
-    metrics:
-      interval: 60s
-    logs:
-      exporter: otlp
-      level: info
+providers:
+  telemetry:
+    source: otlp
+    config:
+      endpoint: otel-collector:4317
+      protocol: grpc
+      serviceName: gestaltd
+      insecure: false
+      headers:
+        Authorization: Bearer ${OTEL_TOKEN}
+      resourceAttributes:
+        deployment.environment: production
+        service.version: "1.0.0"
+      traces:
+        samplingRatio: 1.0
+      metrics:
+        interval: 60s
+      logs:
+        exporter: otlp
+        level: info
 ```
 
 Exports to any OpenTelemetry-compatible collector (Jaeger, Grafana Alloy, Datadog Agent) while still keeping local `/metrics` available by default. The built-in admin UI at `/admin` reads that same local scrape surface.
@@ -282,24 +288,26 @@ Exports to any OpenTelemetry-compatible collector (Jaeger, Grafana Alloy, Datado
 To keep system logs on stdout while still exporting traces and metrics over OTLP:
 
 ```yaml
-telemetry:
-  builtin: otlp
-  config:
-    endpoint: otel-collector:4317
-    protocol: grpc
-    metrics:
-      interval: 60s
-    logs:
-      exporter: stdout
-      format: json
-      level: info
+providers:
+  telemetry:
+    source: otlp
+    config:
+      endpoint: otel-collector:4317
+      protocol: grpc
+      metrics:
+        interval: 60s
+      logs:
+        exporter: stdout
+        format: json
+        level: info
 ```
 
 ### `noop`
 
 ```yaml
-telemetry:
-  builtin: noop
+providers:
+  telemetry:
+    source: noop
 ```
 
 Disables all telemetry. Instrumentation points remain but produce zero overhead. This disables Prometheus scraping. `/metrics` returns a clear unavailable response, and the built-in admin UI shows that metrics are unavailable.
@@ -312,28 +320,30 @@ Disables all telemetry. Instrumentation points remain but produce zero overhead.
 | Broker | `broker.invoke` | `gestalt.provider`, `gestalt.operation`, `gestalt.userId`, `gestalt.connectionMode` |
 | gRPC plugin | Per-RPC spans | Standard gRPC semantic conventions |
 
-## `audit`
+## `providers.audit`
 
-Audit records are emitted as structured log entries with `log.type=audit`. By default they inherit the normal telemetry log pipeline, but you can override that with a dedicated `audit` block. See [Audit Logging](/audit-logging) for the event schema and coverage details, and [Observability](/observability) for export options. If you keep `audit: { builtin: inherit }`, you can still route audit traffic to a dedicated backend by filtering on `log.type=audit` in your collector.
+Audit records are emitted as structured log entries with `log.type=audit`. By default they inherit the normal telemetry log pipeline, but you can override that with a dedicated `providers.audit` block. See [Audit Logging](/audit-logging) for the event schema and coverage details, and [Observability](/observability) for export options. If you keep `providers: { audit: { source: inherit } }`, you can still route audit traffic to a dedicated backend by filtering on `log.type=audit` in your collector.
 
 ### `inherit`
 
 ```yaml
-audit:
-  builtin: inherit
+providers:
+  audit:
+    source: inherit
 ```
 
-This is the default when `audit` is omitted. Audit records follow the same log route as `telemetry`: when telemetry uses `stdout`, audit logs go to standard output; when telemetry uses `otlp`, audit logs export through the OTLP log pipeline; when telemetry uses `noop`, audit output is disabled unless you override it here.
+This is the default when `providers.audit` is omitted. Audit records follow the same log route as `providers.telemetry`: when telemetry uses `stdout`, audit logs go to standard output; when telemetry uses `otlp`, audit logs export through the OTLP log pipeline; when telemetry uses `noop`, audit output is disabled unless you override it here.
 
-`audit.config` is not allowed when `audit.builtin` is `inherit`.
+`providers.audit.config` is not allowed when `providers.audit.source` is `inherit`.
 
 ### `stdout`
 
 ```yaml
-audit:
-  builtin: stdout
-  config:
-    format: json
+providers:
+  audit:
+    source: stdout
+    config:
+      format: json
 ```
 
 Writes audit records to standard output even if the main telemetry pipeline is using a different provider.
@@ -346,17 +356,18 @@ Writes audit records to standard output even if the main telemetry pipeline is u
 ### `otlp`
 
 ```yaml
-audit:
-  builtin: otlp
-  config:
-    endpoint: audit-collector:4317
-    protocol: grpc
-    serviceName: gestaltd
-    insecure: false
-    headers:
-      Authorization: Bearer ${AUDIT_OTLP_TOKEN}
-    resourceAttributes:
-      log.stream: audit
+providers:
+  audit:
+    source: otlp
+    config:
+      endpoint: audit-collector:4317
+      protocol: grpc
+      serviceName: gestaltd
+      insecure: false
+      headers:
+        Authorization: Bearer ${AUDIT_OTLP_TOKEN}
+      resourceAttributes:
+        log.stream: audit
 ```
 
 Exports audit records over OTLP without changing where application logs, metrics, or traces go. Use this when you want audit records in a dedicated compliance pipeline while keeping the rest of `gestaltd` on `stdout` or a different OTLP collector.
@@ -373,39 +384,37 @@ Exports audit records over OTLP without changing where application logs, metrics
 ### `noop`
 
 ```yaml
-audit:
-  builtin: noop
+providers:
+  audit:
+    source: noop
 ```
 
-Disables audit output explicitly. `audit.config` is not allowed when `audit.builtin` is `noop`.
+Disables audit output explicitly. `providers.audit.config` is not allowed when `providers.audit.source` is `noop`.
 
-## `plugins`
+## `providers.plugins`
 
-Each entry in the top-level `plugins` map is a named plugin backed by an executable provider package. The provider package is the source of truth for operations and transport details. Server config selects the provider, passes provider-specific config, declares connection policy, and controls MCP exposure. The HTTP API and client CLI use the synonym "integrations" in route paths and commands (e.g. `/api/v1/integrations`, `gestalt integrations list`), but `plugins` is the canonical config term.
+Each entry in the `providers.plugins` map is a named plugin backed by an executable provider package. The provider package is the source of truth for operations and transport details. Server config selects the provider, passes provider-specific config, and declares connection policy. The HTTP API and client CLI use the synonym "integrations" in route paths and commands (e.g. `/api/v1/integrations`, `gestalt integrations list`), but `plugins` is the canonical config term.
 
 ```yaml
-plugins:
-  github:
-    displayName: GitHub
-    description: Public GitHub operations
-    iconFile: ./icons/github.svg
-    provider:
+providers:
+  plugins:
+    github:
+      displayName: GitHub
+      description: Public GitHub operations
+      iconFile: ./icons/github.svg
       source:
         ref: github.com/valon-technologies/gestalt-providers/github
         version: 1.2.3
-    config:
-      apiBaseUrl: https://api.github.com
-    connections:
-      default:
-        mode: user
-        auth:
-          type: oauth2
-    allowedOperations:
-      repos.get:
-        alias: get_repo
-    mcp:
-      enabled: true
-      toolPrefix: github_
+      config:
+        apiBaseUrl: https://api.github.com
+      connections:
+        default:
+          mode: user
+          auth:
+            type: oauth2
+      allowedOperations:
+        repos.get:
+          alias: get_repo
 ```
 
 ### Plugin Fields
@@ -415,22 +424,19 @@ plugins:
 | `displayName` | Human-readable name shown in the UI and API. |
 | `description` | Short description of the plugin. |
 | `iconFile` | SVG icon path, resolved relative to the config directory. |
-| `provider` | **Required.** The backing provider package. See [provider shape](#pluginsprovider) below. |
+| `source` | **Required.** The backing provider source. See [source shape](#providerspluginssource) below. |
 | `config` | Provider-specific configuration passed into the provider package. |
 | `connections` | Named connection declarations. See [connections](#connections) below. |
 | `allowedOperations` | Allowlist with optional `alias` and `description` overrides per operation. |
-| `mcp.enabled` | Expose this plugin over MCP. |
-| `mcp.toolPrefix` | Prefix for MCP tool names. Only valid when `mcp.enabled` is `true`. |
 
-### `plugins.*.provider`
+### `providers.plugins.*.source`
 
-Every plugin uses a nested `provider` block to declare its source.
+Every plugin uses a `source` block to declare its backing provider.
 
 ```yaml
-provider:
-  source:
-    ref: github.com/valon-technologies/gestalt-providers/github
-    version: 1.2.3
+source:
+  ref: github.com/valon-technologies/gestalt-providers/github
+  version: 1.2.3
 ```
 
 `source.ref` resolves a versioned provider source during `init` using the format `github.com/<org>/<repo>/<path-after-repo>`, and requires `source.version`. `source.path` loads a local provider manifest instead. `source.path` and `source.ref` are mutually exclusive.
@@ -438,12 +444,11 @@ provider:
 For local development with a source provider package:
 
 ```yaml
-provider:
-  source:
-    path: ./manifest.yaml
+source:
+  path: ./manifest.yaml
 ```
 
-Gestalt synthesizes Go and Rust executable wrappers automatically when needed and runs Python source providers from the module declared in `[tool.gestalt].provider` or the legacy `[tool.gestalt].plugin`. Plugins do not support `provider.builtin`.
+Gestalt synthesizes Go and Rust executable wrappers automatically when needed and runs Python source providers from the module declared in `[tool.gestalt].provider` or the legacy `[tool.gestalt].plugin`.
 
 <Tabs items={['Go', 'Python', 'Rust']}>
   <Tabs.Tab>
@@ -649,22 +654,23 @@ connections:
 | `discovery.namePath` | JSON path to the resource display name. |
 | `discovery.metadata` | Maps connection metadata keys to JSON paths in the discovery response. |
 
-## `egress`
+## `server.egress`
 
-`egress` controls outbound requests made through providers and grants operator-managed credentials to specific outbound destinations.
+`server.egress` controls outbound requests made through providers and grants operator-managed credentials to specific outbound destinations.
 
 ```yaml
-egress:
-  defaultAction: deny
-  policies:
-    - action: allow
-      provider: github
-      method: GET
-      host: api.github.com
-  credentials:
-    - secretRef: github-service-token
-      authStyle: bearer
-      host: api.github.com
+server:
+  egress:
+    defaultAction: deny
+    policies:
+      - action: allow
+        provider: github
+        method: GET
+        host: api.github.com
+    credentials:
+      - secretRef: github-service-token
+        authStyle: bearer
+        host: api.github.com
 ```
 
 `defaultAction` sets the global fallback policy to `allow` or `deny`.
@@ -699,24 +705,24 @@ egress:
 | `host` | Match by destination host. |
 | `pathPrefix` | Match by URL path prefix. |
 
-## `ui`
+## `providers.ui`
 
 ```yaml
-ui:
-  provider:
+providers:
+  ui:
     source:
       ref: github.com/your-org/your-repo/web/console
       version: 1.0.0
-  config:
-    brandName: Acme
+    config:
+      brandName: Acme
 ```
 
-The `ui` block controls the public client UI at `/`, while the built-in admin UI remains available at `/admin`. Omit `ui` to use the pinned first-party default UI bundle. Set `ui: { disabled: true }` to disable the public UI entirely. Or set `ui.provider.source` to a packaged `webui` bundle. See [Releasing](/providers/releasing) for the full workflow.
+The `providers.ui` block controls the public client UI at `/`, while the built-in admin UI remains available at `/admin`. Omit `providers.ui` to use the pinned first-party default UI bundle. Set `providers: { ui: { disabled: true } }` to disable the public UI entirely. Or set `providers.ui.source` to a packaged `webui` bundle. See [Releasing](/providers/releasing) for the full workflow.
 
 | Field | Description |
 | --- | --- |
 | `disabled` | `true` to disable the public UI entirely. |
-| `provider` | A provider mapping with `source.path` or `source.ref`. |
+| `source` | A source mapping with `source.path` or `source.ref`. |
 | `config` | Optional UI-provider config validated against the bundle schema when present. |
 
 ## Validation rules
@@ -725,18 +731,18 @@ Structural validation runs at config load time (`init`, `validate`, `serve`). Ru
 
 ### Structural
 
-Each plugin uses a nested `provider` block. Every plugin must use exactly one loading mode: local `provider.source.path` or managed `provider.source.ref`. `provider.source.version` is required with `provider.source.ref` and invalid with `provider.source.path`.
+Each plugin uses a `source` block. Every plugin must use exactly one loading mode: local `source.path` or managed `source.ref`. `source.version` is required with `source.ref` and invalid with `source.path`.
 
-Auth providers and datastore entries use the same external provider shape. When `auth.provider` or `datastores.<name>.provider` is set, `source.ref` or `source.path` must be present. `auth.config` and `datastores.<name>.config` are only allowed when their corresponding provider is set.
+Auth providers and indexeddb entries use the same external provider shape. When `providers.auth` or `providers.indexeddbs.<name>` is set, `source.ref` or `source.path` must be present. `providers.auth.config` and `providers.indexeddbs.<name>.config` are only allowed when their corresponding source is set.
 
-Only `connections.default` may define `params` or `discovery`. `mcp.toolPrefix` is valid only when `mcp.enabled` is `true`. All connections in a plugin must share the same mode.
+Only `connections.default` may define `params` or `discovery`. All connections in a plugin must share the same mode.
 
-`ui` must use exactly one mode: `disabled: true`, or a `provider` mapping with exactly one loading mode: local `ui.provider.source.path` or managed `ui.provider.source.ref`. `ui.provider.source.version` is required with `ui.provider.source.ref` and invalid with `ui.provider.source.path`. `ui.config` is only allowed when `ui.provider` is set.
+`providers.ui` must use exactly one mode: `disabled: true`, or a source mapping with exactly one loading mode: local `providers.ui.source.path` or managed `providers.ui.source.ref`. `providers.ui.source.version` is required with `providers.ui.source.ref` and invalid with `providers.ui.source.path`. `providers.ui.config` is only allowed when `providers.ui.source` is set.
 
-`egress.defaultAction` must be `allow` or `deny`. Each egress policy rule requires an `action`. Each egress credential grant requires `secretRef` (as a bare name, not a `secret://` URI) and at least one match criterion.
+`server.egress.defaultAction` must be `allow` or `deny`. Each egress policy rule requires an `action`. Each egress credential grant requires `secretRef` (as a bare name, not a `secret://` URI) and at least one match criterion.
 
 Server listener ports must be greater than zero. When `server.management` is configured, it must differ from `server.public`.
 
 ### Runtime
 
-`datastore`, `datastores`, and `server.encryptionKey` are required at `serve` time. `auth` is optional.
+`server.indexeddb`, `providers.indexeddbs`, and `server.encryptionKey` are required at `serve` time. `providers.auth` is optional.

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -4,21 +4,21 @@ import { Tabs } from 'nextra/components'
 
 Gestalt provider packages and release archives are described by a manifest file: `manifest.yaml`, `manifest.yml`, or `manifest.json`. YAML is the easiest format to author by hand.
 
-Providers are the umbrella concept in Gestalt. Auth providers, datastore providers, and plugins all use this manifest format. The `plugin` manifest kind is reserved for providers that expose callable operations.
+Providers are the umbrella concept in Gestalt. Auth providers, indexeddb providers, and plugins all use this manifest format. The `plugin` manifest kind is reserved for providers that expose callable operations.
 
 ## Manifest Kinds
 
-Every manifest defines exactly one provider kind, determined by which metadata block is present at the top level:
+Every manifest defines exactly one provider kind, set by the `kind` field:
 
-| Kind | Top-level key | Purpose |
-| --- | --- | --- |
-| `plugin` | `plugin` | Plugin (REST, OpenAPI, GraphQL, MCP, or executable). |
-| `auth` | `auth` | Platform auth provider (Google, OIDC, local, or custom). |
-| `datastore` | `datastore` | Persistence backend (Postgres, SQLite, DynamoDB, or custom). |
-| `secrets` | `secrets` | Secret manager for resolving `secret://` references. |
-| `webui` | `webui` | Static UI package served by `gestaltd`. |
+| Kind | Purpose |
+| --- | --- |
+| `plugin` | Plugin (REST, OpenAPI, GraphQL, MCP, or executable). |
+| `auth` | Platform auth provider (Google, OIDC, local, or custom). |
+| `indexeddb` | Persistence backend (Postgres, SQLite, DynamoDB, or custom). |
+| `secrets` | Secret manager for resolving `secret://` references. |
+| `webui` | Static UI package served by `gestaltd`. |
 
-A manifest must include exactly one of these keys. There is no separate `kind` or `kinds` field.
+The `kind` field is required. Kind-specific configuration goes under the `spec` block.
 
 ## Common Fields
 
@@ -26,26 +26,19 @@ These fields appear at the top level of every manifest regardless of kind.
 
 | Field | Type | Required | Purpose |
 | --- | --- | --- | --- |
+| `kind` | string | yes | The provider kind (`plugin`, `auth`, `indexeddb`, `secrets`, `webui`). |
 | `source` | string | yes | Canonical provider source identifier. Use `github.com/<org>/<repo>/<path>`. The final path segment is the provider package name; preceding segments are used for release tags and source resolution. |
 | `version` | string | yes | Semver version. Pre-release suffixes like `-alpha.1` are allowed. |
 | `displayName` | string | no | Human-readable label shown in the UI. |
 | `description` | string | no | Human-readable description. |
 | `iconFile` | string | no | Relative path to an SVG icon bundled with the package. |
 | `artifacts` | Artifact[] | no | Packaged executable artifacts keyed by platform. Omit for declarative-only plugin packages or source manifests used during local development. |
-| `entrypoints` | Entrypoints | no | Executable entrypoint metadata for the manifest's kind. |
+| `entrypoint` | Entrypoint | no | Executable entrypoint metadata for the provider. |
+| `spec` | object | no | Kind-specific configuration block. |
 
-## Entrypoints
+## Entrypoint
 
-The `entrypoints` block declares executable binaries. Each key corresponds to a provider kind.
-
-| Key | Kind | Purpose |
-| --- | --- | --- |
-| `plugin` | plugin | Executable entrypoint for a plugin. |
-| `auth` | auth | Executable entrypoint for an auth provider. |
-| `datastore` | datastore | Executable entrypoint for a datastore provider. |
-| `secrets` | secrets | Executable entrypoint for a secrets provider. |
-
-Each entrypoint has two fields:
+The `entrypoint` block declares the executable binary for the provider.
 
 | Field | Type | Required | Purpose |
 | --- | --- | --- | --- |
@@ -53,15 +46,14 @@ Each entrypoint has two fields:
 | `args` | string[] | no | Additional arguments passed to the binary at startup. |
 
 ```yaml
-entrypoints:
-  plugin:
-    artifactPath: artifacts/linux/amd64/plugin
-    args: ["--verbose"]
+entrypoint:
+  artifactPath: artifacts/linux/amd64/plugin
+  args: ["--verbose"]
 ```
 
 ## Plugin Metadata
 
-The `plugin` block describes a plugin. It supports declarative REST operations, spec-loaded surfaces (OpenAPI, GraphQL, MCP), executable code, or any combination.
+The `spec` block for a `kind: plugin` manifest describes a plugin. It supports declarative REST operations, spec-loaded surfaces (OpenAPI, GraphQL, MCP), executable code, or any combination.
 
 ### Core Fields
 
@@ -71,9 +63,8 @@ The `plugin` block describes a plugin. It supports declarative REST operations, 
 | `auth` | ProviderAuth | Default connection auth when no `connections` map is defined. |
 | `connectionMode` | string | Default connection mode when no `connections` map is defined. One of `none`, `user`, `identity`, `either`. |
 | `mcp` | bool | When true, the plugin exposes its operations as MCP tools. |
-| `baseUrl` | string | Base URL for declarative REST operations. |
 | `headers` | map[string]string | Static headers injected into every outbound request. |
-| `operations` | ProviderOperation[] | Declarative REST operations. Presence of this field makes the plugin declarative. |
+| `surfaces` | Surfaces | Spec-loaded and declarative REST surfaces. See [Surfaces](#surfaces). |
 | `defaultConnection` | string | Name of the connection to use when none is specified. |
 
 ### Connections
@@ -89,18 +80,37 @@ The `connections` map defines named connection profiles. Deployment config can o
 
 ### Surfaces
 
-Surfaces load operation catalogs from external specifications. The following top-level `plugin` fields configure surfaces:
+Surfaces load operation catalogs from external specifications. They are configured under `spec.surfaces`.
+
+#### `spec.surfaces.openapi`
 
 | Field | Type | Purpose |
 | --- | --- | --- |
-| `openapi` | string | Path to a bundled OpenAPI document. |
-| `openapiConnection` | string | Connection name used for OpenAPI calls. |
-| `graphqlUrl` | string | URL of the upstream GraphQL endpoint. |
-| `graphqlConnection` | string | Connection name used for GraphQL calls. |
-| `mcpUrl` | string | URL of the upstream MCP server. |
-| `mcpConnection` | string | Connection name used for MCP calls. |
+| `document` | string | Path to a bundled OpenAPI document. |
+| `connection` | string | Connection name used for OpenAPI calls. |
 
-The `rest`/`openapi`/`graphql` surface types are mutually exclusive (use `openapi` or `graphqlUrl`, not both), but `mcpUrl` may be combined with any of them.
+#### `spec.surfaces.graphql`
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `url` | string | URL of the upstream GraphQL endpoint. |
+| `connection` | string | Connection name used for GraphQL calls. |
+
+#### `spec.surfaces.mcp`
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `url` | string | URL of the upstream MCP server. |
+| `connection` | string | Connection name used for MCP calls. |
+
+#### `spec.surfaces.rest`
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `baseUrl` | string | Base URL for declarative REST operations. |
+| `operations` | ProviderOperation[] | Declarative REST operations. Presence of this field makes the plugin declarative. |
+
+The `rest`/`openapi`/`graphql` surface types are mutually exclusive (use `surfaces.openapi` or `surfaces.graphql`, not both), but `surfaces.mcp` may be combined with any of them.
 
 ### Auth Types
 
@@ -109,7 +119,7 @@ The `auth.type` field on a connection accepts these values:
 | Type | Purpose |
 | --- | --- |
 | `oauth2` | Standard OAuth 2.0. Requires `authorizationUrl` and `tokenUrl`. |
-| `mcp_oauth` | MCP-native OAuth. The plugin must also declare `mcpUrl` (either directly or via a surface). A manifest that uses `mcp_oauth` without an MCP surface fails validation. |
+| `mcp_oauth` | MCP-native OAuth. The plugin must also declare an MCP surface (via `spec.surfaces.mcp`). A manifest that uses `mcp_oauth` without an MCP surface fails validation. |
 | `bearer` | Static bearer token. Define `credentials` to prompt the user for the token value. |
 | `manual` | Custom credential fields. Define `credentials` to describe each field. |
 | `none` | No authentication. |
@@ -117,7 +127,7 @@ The `auth.type` field on a connection accepts these values:
 Manual auth in provider manifests also supports `authMapping`, using the same `value` / `valueFrom.credentialFieldRef.name` shape as deploy config.
 
 ```yaml
-plugin:
+spec:
   auth:
     type: manual
     credentials:
@@ -153,7 +163,7 @@ Plugin-level pagination configuration applies to all operations by default. Indi
 | `maxPages` | int | Maximum number of pages to fetch in a single paginated request. |
 
 ```yaml
-plugin:
+spec:
   pagination:
     style: cursor
     cursorParam: starting_after
@@ -177,7 +187,7 @@ The `allowedOperations` map selectively exposes and customizes operations from a
 | `pagination` | ManifestPaginationConfig | Per-operation pagination config that overrides the plugin-level default. |
 
 ```yaml
-plugin:
+spec:
   allowedOperations:
     tickets.list:
       alias: list_tickets
@@ -233,48 +243,48 @@ The `params` map on a connection defines parameters that are populated during or
 
 ## Auth Provider Metadata
 
-The `auth` block describes a platform auth provider package.
+The `spec` block for a `kind: auth` manifest describes a platform auth provider package.
 
 | Field | Type | Purpose |
 | --- | --- | --- |
 | `configSchemaPath` | string | Path to a JSON/YAML schema that validates the `auth.config` block in the server config. |
 
-Auth providers require an executable entrypoint. Declare it under `entrypoints.auth`.
+Auth providers require an executable entrypoint. Declare it under `entrypoint`.
 
 ```yaml
+kind: auth
 source: github.com/valon-technologies/gestalt-providers/auth-google
 version: 1.0.0
 displayName: Google Auth
-auth:
+spec:
   configSchemaPath: schemas/config.schema.json
-entrypoints:
-  auth:
-    artifactPath: artifacts/linux/amd64/auth
+entrypoint:
+  artifactPath: artifacts/linux/amd64/auth
 artifacts:
   - os: linux
     arch: amd64
     path: artifacts/linux/amd64/auth
 ```
 
-## Datastore Provider Metadata
+## IndexedDB Provider Metadata
 
-The `datastore` block describes a persistence backend package.
+The `spec` block for a `kind: indexeddb` manifest describes a persistence backend package.
 
 | Field | Type | Purpose |
 | --- | --- | --- |
 | `configSchemaPath` | string | Path to a JSON/YAML schema that validates the `datastores.<name>.config` block in the server config. |
 
-Datastore providers require an executable entrypoint. Declare it under `entrypoints.datastore`.
+IndexedDB providers require an executable entrypoint. Declare it under `entrypoint`.
 
 ```yaml
+kind: indexeddb
 source: github.com/valon-technologies/gestalt-providers/datastore-postgres
 version: 1.0.0
 displayName: PostgreSQL
-datastore:
+spec:
   configSchemaPath: schemas/config.schema.json
-entrypoints:
-  datastore:
-    artifactPath: artifacts/linux/amd64/datastore
+entrypoint:
+  artifactPath: artifacts/linux/amd64/datastore
 artifacts:
   - os: linux
     arch: amd64
@@ -283,17 +293,18 @@ artifacts:
 
 ## Web UI Metadata
 
-The `webui` block describes a static UI package.
+The `spec` block for a `kind: webui` manifest describes a static UI package.
 
 | Field | Type | Required | Purpose |
 | --- | --- | --- | --- |
 | `assetRoot` | string | yes | Directory containing the built static assets. |
 
 ```yaml
+kind: webui
 source: github.com/acme/plugins/gestalt-ui
 version: 1.0.0
 displayName: Custom UI
-webui:
+spec:
   assetRoot: ui/out
 ```
 
@@ -318,12 +329,13 @@ This manifest shows a plugin with an executable entrypoint, multiple connections
 <Tabs items={['YAML', 'JSON']}>
   <Tabs.Tab>
     ```yaml
+    kind: plugin
     source: github.com/acme/plugins/support
     version: 1.2.3
     displayName: Support
     description: Tickets, knowledge base, and MCP workspace tools
     iconFile: assets/icon.svg
-    plugin:
+    spec:
       configSchemaPath: schemas/config.schema.yaml
       headers:
         X-App-Version: "2026-04-01"
@@ -357,10 +369,13 @@ This manifest shows a plugin with an executable entrypoint, multiple connections
           mode: user
           auth:
             type: mcp_oauth
-      openapi: openapi.yaml
-      openapiConnection: default
-      mcpUrl: https://mcp.support.example.com/mcp
-      mcpConnection: mcp
+      surfaces:
+        openapi:
+          document: openapi.yaml
+          connection: default
+        mcp:
+          url: https://mcp.support.example.com/mcp
+          connection: mcp
       pagination:
         style: cursor
         cursorParam: starting_after
@@ -376,9 +391,8 @@ This manifest shows a plugin with an executable entrypoint, multiple connections
           paginate: true
         tickets.get:
           alias: get_ticket
-    entrypoints:
-      plugin:
-        artifactPath: artifacts/linux/amd64/plugin
+    entrypoint:
+      artifactPath: artifacts/linux/amd64/plugin
     artifacts:
       - os: linux
         arch: amd64
@@ -390,12 +404,13 @@ This manifest shows a plugin with an executable entrypoint, multiple connections
   <Tabs.Tab>
     ```json
     {
+      "kind": "plugin",
       "source": "github.com/acme/plugins/support",
       "version": "1.2.3",
       "displayName": "Support",
       "description": "Tickets, knowledge base, and MCP workspace tools",
       "iconFile": "assets/icon.svg",
-      "plugin": {
+      "spec": {
         "configSchemaPath": "schemas/config.schema.yaml",
         "headers": {
           "X-App-Version": "2026-04-01"
@@ -429,10 +444,16 @@ This manifest shows a plugin with an executable entrypoint, multiple connections
             "auth": { "type": "mcp_oauth" }
           }
         },
-        "openapi": "openapi.yaml",
-        "openapiConnection": "default",
-        "mcpUrl": "https://mcp.support.example.com/mcp",
-        "mcpConnection": "mcp",
+        "surfaces": {
+          "openapi": {
+            "document": "openapi.yaml",
+            "connection": "default"
+          },
+          "mcp": {
+            "url": "https://mcp.support.example.com/mcp",
+            "connection": "mcp"
+          }
+        },
         "pagination": {
           "style": "cursor",
           "cursorParam": "starting_after",
@@ -449,10 +470,8 @@ This manifest shows a plugin with an executable entrypoint, multiple connections
           "tickets.get": { "alias": "get_ticket" }
         }
       },
-      "entrypoints": {
-        "plugin": {
-          "artifactPath": "artifacts/linux/amd64/plugin"
-        }
+      "entrypoint": {
+        "artifactPath": "artifacts/linux/amd64/plugin"
       },
       "artifacts": [
         {
@@ -473,40 +492,43 @@ This manifest shows a plugin with an executable entrypoint, multiple connections
 This plugin requires no binary. It defines REST operations entirely in the manifest.
 
 ```yaml
+kind: plugin
 source: github.com/acme/plugins/support-api
 version: 0.0.1-alpha.1
 displayName: Support API
 description: Small ticket API
 iconFile: assets/icon.svg
-plugin:
+spec:
   auth:
     type: bearer
     credentials:
       - name: token
         label: API Token
-  baseUrl: https://api.support.example.com
-  operations:
-    - name: list_tickets
-      description: Return open tickets
-      method: GET
-      path: /tickets
-    - name: get_ticket
-      description: Return one ticket
-      method: GET
-      path: /tickets/{ticket_id}
+  surfaces:
+    rest:
+      baseUrl: https://api.support.example.com
+      operations:
+        - name: list_tickets
+          description: Return open tickets
+          method: GET
+          path: /tickets
+        - name: get_ticket
+          description: Return one ticket
+          method: GET
+          path: /tickets/{ticket_id}
 ```
 
 ## Authoring Notes
 
-Manifest paths must stay inside the package. `source` and `version` are required. A manifest defines exactly one provider kind: `plugin`, `auth`, `datastore`, `secrets`, or `webui`.
+Manifest paths must stay inside the package. `kind`, `source`, and `version` are required. A manifest defines exactly one provider kind: `kind: plugin`, `kind: auth`, `kind: indexeddb`, `kind: secrets`, or `kind: webui`.
 
 `configSchemaPath` validates per-plugin config and may be written in JSON or YAML. Any connection may define `params` and `discovery`. The OpenAPI/GraphQL surface types are mutually exclusive, but MCP may be added alongside either.
 
-A connection using `mcp_oauth` auth requires the plugin to declare an MCP surface (via `mcpUrl` or an equivalent). Manifests that set `auth.type: mcp_oauth` without an MCP surface fail validation.
+A connection using `mcp_oauth` auth requires the plugin to declare an MCP surface (via `spec.surfaces.mcp` or an equivalent). Manifests that set `auth.type: mcp_oauth` without an MCP surface fail validation.
 
 When an executable plugin defines helper operations in Go, Rust, Python, or
 TypeScript, Gestalt materializes the executable catalog automatically during
-local source-plugin execution and `provider release`. Auth and datastore
+local source-plugin execution and `provider release`. Auth and indexeddb
 source packages use the same release flow for Go, Rust, and TypeScript, but
 they do not generate catalogs. See [Plugins](/providers/plugins)
 for the end-to-end authoring flow.
@@ -573,6 +595,7 @@ packages generate support files or UI bundles without checking built artifacts
 into source control.
 
 ```yaml
+kind: webui
 source: github.com/acme/plugins/gestalt-ui
 version: 1.0.0
 release:
@@ -582,7 +605,7 @@ release:
       - npm
       - run
       - build
-webui:
+spec:
   assetRoot: ui/out
 ```
 
@@ -601,8 +624,8 @@ catalog automatically before packaging. Python source plugins load the module
 declared in `[tool.gestalt].provider` and materialize the executable catalog
 automatically. TypeScript source providers load the target declared in
 `package.json` under `gestalt.provider`. A string target such as
-`./provider.ts#plugin` defaults to a plugin provider; auth and datastore
-providers use an object with `kind` and `target`. Auth and datastore source
+`./provider.ts#plugin` defaults to a plugin provider; auth and indexeddb
+providers use an object with `kind` and `target`. Auth and indexeddb source
 packages support the same release flow for Go, Rust, and TypeScript, but they
 do not generate catalogs. Source packages build the host-platform artifact by
 default. Pass `--platform` for an explicit `os/arch[/libc]` target list, or

--- a/docs/content/security.mdx
+++ b/docs/content/security.mdx
@@ -85,9 +85,9 @@ The host resolves the caller's access token and passes it to the provider in eac
 When `allowedHosts` is configured on a provider, the plugin is automatically sandboxed:
 
 ```yaml
-plugins:
-  my-plugin:
-    provider:
+providers:
+  plugins:
+    my-plugin:
       source:
         ref: github.com/acme/plugins/my-plugin
         version: 1.0.0
@@ -107,11 +107,11 @@ plugins:
 | Setting | Impact |
 | --- | --- |
 | `server.encryptionKey` | Root deployment secret. If compromised, all stored tokens can be decrypted. Use a strong random string or 64-character hex key. Must be the same across all instances in a cluster. |
-| `auth.provider` | Omitting `auth` or setting `auth: { disabled: true }` disables all authentication. Do not use in production. |
+| `providers.auth` | Omitting `providers.auth` or setting `providers: { auth: { disabled: true } }` disables all authentication. Do not use in production. |
 | `server.baseUrl` | Must match the public URL exactly. OAuth callbacks are derived from it. |
 | TLS termination | Gestalt does not terminate TLS. Deploy behind a reverse proxy that handles TLS. |
-| `secrets.provider` | Use a dedicated secret manager in production. `env` is acceptable but secrets may appear in process listings. |
-| `datastores` and `datastore` | Use a production-grade datastore provider for multi-replica deployments. SQLite is single-writer and not suitable for multi-replica deployments. |
+| `providers.secrets` | Use a dedicated secret manager in production. `env` is acceptable but secrets may appear in process listings. |
+| `providers.indexeddbs` and `server.indexeddb` | Use a production-grade datastore provider for multi-replica deployments. SQLite is single-writer and not suitable for multi-replica deployments. |
 
 ## Known limitations
 

--- a/docs/content/troubleshooting.mdx
+++ b/docs/content/troubleshooting.mdx
@@ -16,9 +16,9 @@ When `/ready` returns `503`, the server has not finished initialization. Readine
 
 ## Operation invocation
 
-A "provider not found" error means the plugin key in the request does not match any entry in the `plugins` config map. Verify the spelling and confirm the plugin loaded without errors at startup.
+A "provider not found" error means the plugin key in the request does not match any entry in `providers.plugins`. Verify the spelling and confirm the plugin loaded without errors at startup.
 
-An "operation not found" error means the operation ID does not exist in the plugin's catalog. Check that the operation is exposed and that `allowed_operations`, if set, includes it.
+An "operation not found" error means the operation ID does not exist in the plugin's catalog. Check that the operation is exposed and that `allowedOperations`, if set, includes it.
 
 A "not authenticated" error on an API or MCP request means no valid session or API token was presented. Log in through the web UI or pass a bearer token in the `Authorization` header.
 
@@ -81,7 +81,7 @@ Common source-package checks:
   </Tabs.Tab>
 </Tabs>
 
-A sandbox 403 means the provider process made an outbound request to a host not listed in `plugin.allowedHosts`. Add every upstream domain the plugin contacts to the allowlist in your plugin config.
+A sandbox 403 means the provider process made an outbound request to a host not listed in `allowedHosts`. Add every upstream domain the plugin contacts to the allowlist in the plugin's config entry or manifest.
 
 An input decode error means the operation received a request body that does not match the expected schema. Check the operation's parameter definitions and ensure the caller is sending the correct types and required fields.
 


### PR DESCRIPTION
## Summary

- Updates every YAML example and prose reference across 19 doc files to match the new config and manifest format from #855
- Config: old top-level keys (`auth`, `secrets`, `telemetry`, `audit`, `ui`, `plugins`, `indexeddbs`, `egress`) moved under `server` and `providers`, `provider:` wrapper removed, `builtin:` replaced with `source:` string
- Manifests: `kind` field added, kind-specific blocks (`plugin:`, `auth:`, `datastore:`, `webui:`, `secrets:`) replaced with `spec:`, `entrypoints:` (plural) replaced with `entrypoint:` (singular), `datastore` kind renamed to `indexeddb`

## Test plan

- [ ] Verify docs site builds without errors
- [ ] Spot-check YAML examples match actual config/manifest Go types

🤖 Generated with [Claude Code](https://claude.com/claude-code)