### PR TITLE
Instrument IndexedDB operations with metrics and remove dead code

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -159,7 +159,6 @@ type Result struct {
 	AuditSink        core.AuditSink
 	SecretManager    core.SecretManager
 	Telemetry        core.TelemetryProvider
-	Egress           EgressDeps
 
 	auditClose func(context.Context) error
 	mu         sync.Mutex
@@ -401,7 +400,6 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		AuditSink:        audit,
 		SecretManager:    prepared.SecretManager,
 		Telemetry:        prepared.Telemetry,
-		Egress:           prepared.Deps.Egress,
 		auditClose:       auditClose,
 	}, nil
 }

--- a/gestaltd/internal/metricutil/semantic_metrics.go
+++ b/gestaltd/internal/metricutil/semantic_metrics.go
@@ -14,7 +14,6 @@ var (
 	attrProvider       = attribute.Key("gestalt.provider")
 	attrAction         = attribute.Key("gestalt.action")
 	attrType           = attribute.Key("gestalt.type")
-	attrMethod         = attribute.Key("gestalt.method")
 	attrConnectionMode = attribute.Key("gestalt.connection_mode")
 )
 
@@ -48,7 +47,6 @@ func newCounterMetrics(meter metric.Meter, prefix, desc string) counterMetrics {
 var (
 	authMetricsCache           MeterCache[counterMetrics]
 	connectionAuthMetricsCache MeterCache[counterMetrics]
-	datastoreMetricsCache      MeterCache[counterMetrics]
 )
 
 func RecordAuthMetrics(ctx context.Context, startedAt time.Time, provider string, action string, failed bool) {
@@ -70,16 +68,6 @@ func RecordConnectionAuthMetrics(ctx context.Context, startedAt time.Time, provi
 		attrType.String(AttrValue(authType)),
 		attrAction.String(AttrValue(action)),
 		attrConnectionMode.String(AttrValue(connectionMode)),
-	)
-}
-
-func RecordDatastoreMetrics(ctx context.Context, startedAt time.Time, provider string, method string, failed bool) {
-	metrics := datastoreMetricsCache.Load(meterName, func(meter metric.Meter) counterMetrics {
-		return newCounterMetrics(meter, "gestaltd.datastore", "gestaltd datastore calls")
-	})
-	recordCounterMetrics(ctx, metrics, startedAt, failed,
-		attrProvider.String(AttrValue(provider)),
-		attrMethod.String(AttrValue(method)),
 	)
 }
 

--- a/gestaltd/internal/pluginpkg/manifest.go
+++ b/gestaltd/internal/pluginpkg/manifest.go
@@ -75,10 +75,6 @@ func decodeManifest(data []byte, format string, sourceMode bool) (*pluginmanifes
 	return &manifest, nil
 }
 
-func ValidateManifest(manifest *pluginmanifestv1.Manifest) error {
-	return validateManifest(manifest, false)
-}
-
 var validManifestKinds = map[string]bool{
 	pluginmanifestv1.KindPlugin:    true,
 	pluginmanifestv1.KindAuth:      true,


### PR DESCRIPTION
All IndexedDB operations (both core coredata services and plugin host traffic) flow through a single indexeddb.IndexedDB instance. This adds a decorator at the interface level in bootstrap that records store name, method, duration, and error status on every ObjectStore and Index call under the gestaltd.indexeddb.* metric namespace.

The previously unused RecordDatastoreMetrics function is renamed to RecordIndexedDBMetrics with appropriate attribute keys. Dead code is also removed: the unused ValidateManifest export from pluginpkg and the Result.Egress field that was set but never read by callers.