### PR TITLE
Redesign IndexedDB datastore transport around typed values

### DIFF
--- a/gestaltd/internal/pluginhost/indexeddb_client.go
+++ b/gestaltd/internal/pluginhost/indexeddb_client.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"io"
 
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type IndexedDBExecConfig struct {
@@ -115,7 +115,11 @@ func (o *remoteObjectStore) Get(ctx context.Context, id string) (indexeddb.Recor
 	if err != nil {
 		return nil, grpcToDatastoreErr(err)
 	}
-	return structToRecord(resp.GetRecord()), nil
+	record, err := gestalt.RecordFromProto(resp.GetRecord())
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal record: %w", err)
+	}
+	return record, nil
 }
 
 func (o *remoteObjectStore) GetKey(ctx context.Context, id string) (string, error) {
@@ -131,22 +135,22 @@ func (o *remoteObjectStore) GetKey(ctx context.Context, id string) (string, erro
 func (o *remoteObjectStore) Add(ctx context.Context, record indexeddb.Record) error {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	s, err := structFromMap(record)
+	pbRecord, err := gestalt.RecordToProto(record)
 	if err != nil {
 		return fmt.Errorf("marshal record: %w", err)
 	}
-	_, err = o.client.Add(ctx, &proto.RecordRequest{Store: o.store, Record: s})
+	_, err = o.client.Add(ctx, &proto.RecordRequest{Store: o.store, Record: pbRecord})
 	return grpcToDatastoreErr(err)
 }
 
 func (o *remoteObjectStore) Put(ctx context.Context, record indexeddb.Record) error {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
-	s, err := structFromMap(record)
+	pbRecord, err := gestalt.RecordToProto(record)
 	if err != nil {
 		return fmt.Errorf("marshal record: %w", err)
 	}
-	_, err = o.client.Put(ctx, &proto.RecordRequest{Store: o.store, Record: s})
+	_, err = o.client.Put(ctx, &proto.RecordRequest{Store: o.store, Record: pbRecord})
 	return grpcToDatastoreErr(err)
 }
 
@@ -175,7 +179,11 @@ func (o *remoteObjectStore) GetAll(ctx context.Context, r *indexeddb.KeyRange) (
 	if err != nil {
 		return nil, grpcToDatastoreErr(err)
 	}
-	return structsToRecords(resp.GetRecords()), nil
+	records, err := gestalt.RecordsFromProto(resp.GetRecords())
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal records: %w", err)
+	}
+	return records, nil
 }
 
 func (o *remoteObjectStore) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange) ([]string, error) {
@@ -245,7 +253,11 @@ func (idx *remoteIndex) Get(ctx context.Context, values ...any) (indexeddb.Recor
 	if err != nil {
 		return nil, grpcToDatastoreErr(err)
 	}
-	return structToRecord(resp.GetRecord()), nil
+	record, err := gestalt.RecordFromProto(resp.GetRecord())
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal record: %w", err)
+	}
+	return record, nil
 }
 
 func (idx *remoteIndex) GetKey(ctx context.Context, values ...any) (string, error) {
@@ -281,7 +293,11 @@ func (idx *remoteIndex) GetAll(ctx context.Context, r *indexeddb.KeyRange, value
 	if err != nil {
 		return nil, grpcToDatastoreErr(err)
 	}
-	return structsToRecords(resp.GetRecords()), nil
+	records, err := gestalt.RecordsFromProto(resp.GetRecords())
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal records: %w", err)
+	}
+	return records, nil
 }
 
 func (idx *remoteIndex) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange, values ...any) ([]string, error) {
@@ -342,31 +358,8 @@ func (idx *remoteIndex) Delete(ctx context.Context, values ...any) (int64, error
 
 // --- Helpers ---
 
-func structToRecord(s *structpb.Struct) indexeddb.Record {
-	if s == nil {
-		return nil
-	}
-	return s.AsMap()
-}
-
-func structsToRecords(ss []*structpb.Struct) []indexeddb.Record {
-	records := make([]indexeddb.Record, len(ss))
-	for i, s := range ss {
-		records[i] = structToRecord(s)
-	}
-	return records
-}
-
-func toProtoValues(values []any) ([]*structpb.Value, error) {
-	pbValues := make([]*structpb.Value, len(values))
-	for i, v := range values {
-		pv, err := structpb.NewValue(v)
-		if err != nil {
-			return nil, fmt.Errorf("marshal index value %d: %w", i, err)
-		}
-		pbValues[i] = pv
-	}
-	return pbValues, nil
+func toProtoValues(values []any) ([]*proto.TypedValue, error) {
+	return gestalt.TypedValuesFromAny(values)
 }
 
 func keyRangeToProto(r *indexeddb.KeyRange) (*proto.KeyRange, error) {
@@ -378,14 +371,14 @@ func keyRangeToProto(r *indexeddb.KeyRange) (*proto.KeyRange, error) {
 		UpperOpen: r.UpperOpen,
 	}
 	if r.Lower != nil {
-		v, err := structpb.NewValue(r.Lower)
+		v, err := gestalt.TypedValueFromAny(r.Lower)
 		if err != nil {
 			return nil, fmt.Errorf("marshal key range lower: %w", err)
 		}
 		kr.Lower = v
 	}
 	if r.Upper != nil {
-		v, err := structpb.NewValue(r.Upper)
+		v, err := gestalt.TypedValueFromAny(r.Upper)
 		if err != nil {
 			return nil, fmt.Errorf("marshal key range upper: %w", err)
 		}

--- a/gestaltd/internal/pluginhost/indexeddb_server.go
+++ b/gestaltd/internal/pluginhost/indexeddb_server.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type indexedDBServer struct {
@@ -59,14 +59,22 @@ func (s *indexedDBServer) GetKey(ctx context.Context, req *proto.ObjectStoreRequ
 }
 
 func (s *indexedDBServer) Add(ctx context.Context, req *proto.RecordRequest) (*emptypb.Empty, error) {
-	if err := s.ds.ObjectStore(s.storeName(req.GetStore())).Add(ctx, req.GetRecord().AsMap()); err != nil {
+	record, err := gestalt.RecordFromProto(req.GetRecord())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unmarshal record: %v", err)
+	}
+	if err := s.ds.ObjectStore(s.storeName(req.GetStore())).Add(ctx, record); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
 	return &emptypb.Empty{}, nil
 }
 
 func (s *indexedDBServer) Put(ctx context.Context, req *proto.RecordRequest) (*emptypb.Empty, error) {
-	if err := s.ds.ObjectStore(s.storeName(req.GetStore())).Put(ctx, req.GetRecord().AsMap()); err != nil {
+	record, err := gestalt.RecordFromProto(req.GetRecord())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unmarshal record: %v", err)
+	}
+	if err := s.ds.ObjectStore(s.storeName(req.GetStore())).Put(ctx, record); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
 	return &emptypb.Empty{}, nil
@@ -87,7 +95,11 @@ func (s *indexedDBServer) Clear(ctx context.Context, req *proto.ObjectStoreNameR
 }
 
 func (s *indexedDBServer) GetAll(ctx context.Context, req *proto.ObjectStoreRangeRequest) (*proto.RecordsResponse, error) {
-	recs, err := s.ds.ObjectStore(s.storeName(req.GetStore())).GetAll(ctx, protoToKeyRange(req.Range))
+	keyRange, err := protoToKeyRange(req.Range)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unmarshal key range: %v", err)
+	}
+	recs, err := s.ds.ObjectStore(s.storeName(req.GetStore())).GetAll(ctx, keyRange)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -95,7 +107,11 @@ func (s *indexedDBServer) GetAll(ctx context.Context, req *proto.ObjectStoreRang
 }
 
 func (s *indexedDBServer) GetAllKeys(ctx context.Context, req *proto.ObjectStoreRangeRequest) (*proto.KeysResponse, error) {
-	keys, err := s.ds.ObjectStore(s.storeName(req.GetStore())).GetAllKeys(ctx, protoToKeyRange(req.Range))
+	keyRange, err := protoToKeyRange(req.Range)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unmarshal key range: %v", err)
+	}
+	keys, err := s.ds.ObjectStore(s.storeName(req.GetStore())).GetAllKeys(ctx, keyRange)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -103,7 +119,11 @@ func (s *indexedDBServer) GetAllKeys(ctx context.Context, req *proto.ObjectStore
 }
 
 func (s *indexedDBServer) Count(ctx context.Context, req *proto.ObjectStoreRangeRequest) (*proto.CountResponse, error) {
-	count, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Count(ctx, protoToKeyRange(req.Range))
+	keyRange, err := protoToKeyRange(req.Range)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unmarshal key range: %v", err)
+	}
+	count, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Count(ctx, keyRange)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -111,7 +131,10 @@ func (s *indexedDBServer) Count(ctx context.Context, req *proto.ObjectStoreRange
 }
 
 func (s *indexedDBServer) DeleteRange(ctx context.Context, req *proto.ObjectStoreRangeRequest) (*proto.DeleteResponse, error) {
-	kr := protoToKeyRange(req.Range)
+	kr, err := protoToKeyRange(req.Range)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unmarshal key range: %v", err)
+	}
 	if kr == nil {
 		return nil, status.Error(codes.InvalidArgument, "key range is required for DeleteRange")
 	}
@@ -123,7 +146,11 @@ func (s *indexedDBServer) DeleteRange(ctx context.Context, req *proto.ObjectStor
 }
 
 func (s *indexedDBServer) IndexGet(ctx context.Context, req *proto.IndexQueryRequest) (*proto.RecordResponse, error) {
-	rec, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).Get(ctx, protoValuesToAny(req.GetValues())...)
+	values, err := protoValuesToAny(req.GetValues())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", err)
+	}
+	rec, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).Get(ctx, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -131,7 +158,11 @@ func (s *indexedDBServer) IndexGet(ctx context.Context, req *proto.IndexQueryReq
 }
 
 func (s *indexedDBServer) IndexGetKey(ctx context.Context, req *proto.IndexQueryRequest) (*proto.KeyResponse, error) {
-	key, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).GetKey(ctx, protoValuesToAny(req.GetValues())...)
+	values, err := protoValuesToAny(req.GetValues())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", err)
+	}
+	key, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).GetKey(ctx, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -139,7 +170,15 @@ func (s *indexedDBServer) IndexGetKey(ctx context.Context, req *proto.IndexQuery
 }
 
 func (s *indexedDBServer) IndexGetAll(ctx context.Context, req *proto.IndexQueryRequest) (*proto.RecordsResponse, error) {
-	recs, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).GetAll(ctx, protoToKeyRange(req.Range), protoValuesToAny(req.GetValues())...)
+	keyRange, err := protoToKeyRange(req.Range)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unmarshal key range: %v", err)
+	}
+	values, err := protoValuesToAny(req.GetValues())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", err)
+	}
+	recs, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).GetAll(ctx, keyRange, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -147,7 +186,15 @@ func (s *indexedDBServer) IndexGetAll(ctx context.Context, req *proto.IndexQuery
 }
 
 func (s *indexedDBServer) IndexGetAllKeys(ctx context.Context, req *proto.IndexQueryRequest) (*proto.KeysResponse, error) {
-	keys, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).GetAllKeys(ctx, protoToKeyRange(req.Range), protoValuesToAny(req.GetValues())...)
+	keyRange, err := protoToKeyRange(req.Range)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unmarshal key range: %v", err)
+	}
+	values, err := protoValuesToAny(req.GetValues())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", err)
+	}
+	keys, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).GetAllKeys(ctx, keyRange, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -155,7 +202,15 @@ func (s *indexedDBServer) IndexGetAllKeys(ctx context.Context, req *proto.IndexQ
 }
 
 func (s *indexedDBServer) IndexCount(ctx context.Context, req *proto.IndexQueryRequest) (*proto.CountResponse, error) {
-	count, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).Count(ctx, protoToKeyRange(req.Range), protoValuesToAny(req.GetValues())...)
+	keyRange, err := protoToKeyRange(req.Range)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unmarshal key range: %v", err)
+	}
+	values, err := protoValuesToAny(req.GetValues())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", err)
+	}
+	count, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).Count(ctx, keyRange, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -163,7 +218,11 @@ func (s *indexedDBServer) IndexCount(ctx context.Context, req *proto.IndexQueryR
 }
 
 func (s *indexedDBServer) IndexDelete(ctx context.Context, req *proto.IndexQueryRequest) (*proto.DeleteResponse, error) {
-	deleted, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).Delete(ctx, protoValuesToAny(req.GetValues())...)
+	values, err := protoValuesToAny(req.GetValues())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", err)
+	}
+	deleted, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).Delete(ctx, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -171,23 +230,19 @@ func (s *indexedDBServer) IndexDelete(ctx context.Context, req *proto.IndexQuery
 }
 
 func recordToProto(rec indexeddb.Record) (*proto.RecordResponse, error) {
-	s, err := structpb.NewStruct(rec)
+	pbRecord, err := gestalt.RecordToProto(rec)
 	if err != nil {
 		return nil, fmt.Errorf("marshal record: %w", err)
 	}
-	return &proto.RecordResponse{Record: s}, nil
+	return &proto.RecordResponse{Record: pbRecord}, nil
 }
 
 func recordsToProto(recs []indexeddb.Record) (*proto.RecordsResponse, error) {
-	structs := make([]*structpb.Struct, len(recs))
-	for i, rec := range recs {
-		s, err := structpb.NewStruct(rec)
-		if err != nil {
-			return nil, fmt.Errorf("marshal record %d: %w", i, err)
-		}
-		structs[i] = s
+	pbRecords, err := gestalt.RecordsToProto(recs)
+	if err != nil {
+		return nil, err
 	}
-	return &proto.RecordsResponse{Records: structs}, nil
+	return &proto.RecordsResponse{Records: pbRecords}, nil
 }
 
 func protoToSchema(ps *proto.ObjectStoreSchema) indexeddb.ObjectStoreSchema {
@@ -212,29 +267,33 @@ func protoToSchema(ps *proto.ObjectStoreSchema) indexeddb.ObjectStoreSchema {
 	return schema
 }
 
-func protoToKeyRange(kr *proto.KeyRange) *indexeddb.KeyRange {
+func protoToKeyRange(kr *proto.KeyRange) (*indexeddb.KeyRange, error) {
 	if kr == nil {
-		return nil
+		return nil, nil
 	}
 	r := &indexeddb.KeyRange{
 		LowerOpen: kr.GetLowerOpen(),
 		UpperOpen: kr.GetUpperOpen(),
 	}
 	if kr.GetLower() != nil {
-		r.Lower = kr.GetLower().AsInterface()
+		value, err := gestalt.AnyFromTypedValue(kr.GetLower())
+		if err != nil {
+			return nil, fmt.Errorf("key range lower: %w", err)
+		}
+		r.Lower = value
 	}
 	if kr.GetUpper() != nil {
-		r.Upper = kr.GetUpper().AsInterface()
+		value, err := gestalt.AnyFromTypedValue(kr.GetUpper())
+		if err != nil {
+			return nil, fmt.Errorf("key range upper: %w", err)
+		}
+		r.Upper = value
 	}
-	return r
+	return r, nil
 }
 
-func protoValuesToAny(vals []*structpb.Value) []any {
-	out := make([]any, len(vals))
-	for i, v := range vals {
-		out[i] = v.AsInterface()
-	}
-	return out
+func protoValuesToAny(vals []*proto.TypedValue) ([]any, error) {
+	return gestalt.AnyFromTypedValues(vals)
 }
 
 func indexeddbToGRPCErr(err error) error {

--- a/gestaltd/internal/testutil/testdata/provider-go-indexeddb/provider.go
+++ b/gestaltd/internal/testutil/testdata/provider-go-indexeddb/provider.go
@@ -2,13 +2,14 @@ package provider
 
 import (
 	"context"
+	"reflect"
 	"sync"
 
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type Provider struct {
@@ -18,7 +19,7 @@ type Provider struct {
 }
 
 type objectStore struct {
-	records map[string]*structpb.Struct
+	records map[string]*proto.Record
 	schema  *proto.ObjectStoreSchema
 }
 
@@ -34,7 +35,7 @@ func (p *Provider) getStore(name string) *objectStore {
 	if s, ok := p.stores[name]; ok {
 		return s
 	}
-	s := &objectStore{records: make(map[string]*structpb.Struct)}
+	s := &objectStore{records: make(map[string]*proto.Record)}
 	p.stores[name] = s
 	return s
 }
@@ -46,7 +47,7 @@ func (p *Provider) CreateObjectStore(_ context.Context, req *proto.CreateObjectS
 		s.schema = req.GetSchema()
 	} else {
 		p.stores[req.GetName()] = &objectStore{
-			records: make(map[string]*structpb.Struct),
+			records: make(map[string]*proto.Record),
 			schema:  req.GetSchema(),
 		}
 	}
@@ -126,7 +127,7 @@ func (p *Provider) Clear(_ context.Context, req *proto.ObjectStoreNameRequest) (
 	s := p.getStore(req.GetStore())
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	s.records = make(map[string]*structpb.Struct)
+	s.records = make(map[string]*proto.Record)
 	return &emptypb.Empty{}, nil
 }
 
@@ -134,7 +135,7 @@ func (p *Provider) GetAll(_ context.Context, req *proto.ObjectStoreRangeRequest)
 	s := p.getStore(req.GetStore())
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	recs := make([]*structpb.Struct, 0, len(s.records))
+	recs := make([]*proto.Record, 0, len(s.records))
 	for _, r := range s.records {
 		recs = append(recs, r)
 	}
@@ -187,7 +188,7 @@ func (p *Provider) IndexGetAll(_ context.Context, req *proto.IndexQueryRequest) 
 	s := p.getStore(req.GetStore())
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	var recs []*structpb.Struct
+	var recs []*proto.Record
 	for _, rec := range s.records {
 		if indexMatches(rec, s.schema, req.GetIndex(), req.GetValues()) {
 			recs = append(recs, rec)
@@ -232,17 +233,22 @@ func (p *Provider) IndexDelete(_ context.Context, req *proto.IndexQueryRequest) 
 	return &proto.DeleteResponse{Deleted: int64(len(toDelete))}, nil
 }
 
-func fieldString(rec *structpb.Struct, key string) string {
+func fieldString(rec *proto.Record, key string) string {
 	if rec == nil {
 		return ""
 	}
 	if v, ok := rec.GetFields()[key]; ok {
-		return v.GetStringValue()
+		value, err := gestalt.AnyFromTypedValue(v)
+		if err == nil {
+			if s, ok := value.(string); ok {
+				return s
+			}
+		}
 	}
 	return ""
 }
 
-func indexMatches(rec *structpb.Struct, schema *proto.ObjectStoreSchema, indexName string, values []*structpb.Value) bool {
+func indexMatches(rec *proto.Record, schema *proto.ObjectStoreSchema, indexName string, values []*proto.TypedValue) bool {
 	if schema == nil || rec == nil {
 		return false
 	}
@@ -265,14 +271,22 @@ func indexMatches(rec *structpb.Struct, schema *proto.ObjectStoreSchema, indexNa
 		if !ok {
 			return false
 		}
-		if rv.GetStringValue() != values[i].GetStringValue() {
+		recordValue, err := gestalt.AnyFromTypedValue(rv)
+		if err != nil {
+			return false
+		}
+		queryValue, err := gestalt.AnyFromTypedValue(values[i])
+		if err != nil {
+			return false
+		}
+		if !reflect.DeepEqual(recordValue, queryValue) {
 			return false
 		}
 	}
 	return true
 }
 
-func fieldsMatch(a, b *structpb.Struct, keyPath []string) bool {
+func fieldsMatch(a, b *proto.Record, keyPath []string) bool {
 	af, bf := a.GetFields(), b.GetFields()
 	for _, field := range keyPath {
 		av, aok := af[field]
@@ -280,7 +294,15 @@ func fieldsMatch(a, b *structpb.Struct, keyPath []string) bool {
 		if !aok || !bok {
 			return false
 		}
-		if av.GetStringValue() != bv.GetStringValue() {
+		left, err := gestalt.AnyFromTypedValue(av)
+		if err != nil {
+			return false
+		}
+		right, err := gestalt.AnyFromTypedValue(bv)
+		if err != nil {
+			return false
+		}
+		if !reflect.DeepEqual(left, right) {
 			return false
 		}
 	}

--- a/sdk/go/gen/v1/datastore.pb.go
+++ b/sdk/go/gen/v1/datastore.pb.go
@@ -11,6 +11,7 @@ import (
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -23,6 +24,228 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type TypedValue struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Kind:
+	//
+	//	*TypedValue_NullValue
+	//	*TypedValue_StringValue
+	//	*TypedValue_IntValue
+	//	*TypedValue_FloatValue
+	//	*TypedValue_BoolValue
+	//	*TypedValue_TimeValue
+	//	*TypedValue_BytesValue
+	//	*TypedValue_JsonValue
+	Kind          isTypedValue_Kind `protobuf_oneof:"kind"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TypedValue) Reset() {
+	*x = TypedValue{}
+	mi := &file_v1_datastore_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TypedValue) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TypedValue) ProtoMessage() {}
+
+func (x *TypedValue) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_datastore_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TypedValue.ProtoReflect.Descriptor instead.
+func (*TypedValue) Descriptor() ([]byte, []int) {
+	return file_v1_datastore_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *TypedValue) GetKind() isTypedValue_Kind {
+	if x != nil {
+		return x.Kind
+	}
+	return nil
+}
+
+func (x *TypedValue) GetNullValue() structpb.NullValue {
+	if x != nil {
+		if x, ok := x.Kind.(*TypedValue_NullValue); ok {
+			return x.NullValue
+		}
+	}
+	return structpb.NullValue(0)
+}
+
+func (x *TypedValue) GetStringValue() string {
+	if x != nil {
+		if x, ok := x.Kind.(*TypedValue_StringValue); ok {
+			return x.StringValue
+		}
+	}
+	return ""
+}
+
+func (x *TypedValue) GetIntValue() int64 {
+	if x != nil {
+		if x, ok := x.Kind.(*TypedValue_IntValue); ok {
+			return x.IntValue
+		}
+	}
+	return 0
+}
+
+func (x *TypedValue) GetFloatValue() float64 {
+	if x != nil {
+		if x, ok := x.Kind.(*TypedValue_FloatValue); ok {
+			return x.FloatValue
+		}
+	}
+	return 0
+}
+
+func (x *TypedValue) GetBoolValue() bool {
+	if x != nil {
+		if x, ok := x.Kind.(*TypedValue_BoolValue); ok {
+			return x.BoolValue
+		}
+	}
+	return false
+}
+
+func (x *TypedValue) GetTimeValue() *timestamppb.Timestamp {
+	if x != nil {
+		if x, ok := x.Kind.(*TypedValue_TimeValue); ok {
+			return x.TimeValue
+		}
+	}
+	return nil
+}
+
+func (x *TypedValue) GetBytesValue() []byte {
+	if x != nil {
+		if x, ok := x.Kind.(*TypedValue_BytesValue); ok {
+			return x.BytesValue
+		}
+	}
+	return nil
+}
+
+func (x *TypedValue) GetJsonValue() *structpb.Value {
+	if x != nil {
+		if x, ok := x.Kind.(*TypedValue_JsonValue); ok {
+			return x.JsonValue
+		}
+	}
+	return nil
+}
+
+type isTypedValue_Kind interface {
+	isTypedValue_Kind()
+}
+
+type TypedValue_NullValue struct {
+	NullValue structpb.NullValue `protobuf:"varint,1,opt,name=null_value,json=nullValue,proto3,enum=google.protobuf.NullValue,oneof"`
+}
+
+type TypedValue_StringValue struct {
+	StringValue string `protobuf:"bytes,2,opt,name=string_value,json=stringValue,proto3,oneof"`
+}
+
+type TypedValue_IntValue struct {
+	IntValue int64 `protobuf:"varint,3,opt,name=int_value,json=intValue,proto3,oneof"`
+}
+
+type TypedValue_FloatValue struct {
+	FloatValue float64 `protobuf:"fixed64,4,opt,name=float_value,json=floatValue,proto3,oneof"`
+}
+
+type TypedValue_BoolValue struct {
+	BoolValue bool `protobuf:"varint,5,opt,name=bool_value,json=boolValue,proto3,oneof"`
+}
+
+type TypedValue_TimeValue struct {
+	TimeValue *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=time_value,json=timeValue,proto3,oneof"`
+}
+
+type TypedValue_BytesValue struct {
+	BytesValue []byte `protobuf:"bytes,7,opt,name=bytes_value,json=bytesValue,proto3,oneof"`
+}
+
+type TypedValue_JsonValue struct {
+	JsonValue *structpb.Value `protobuf:"bytes,8,opt,name=json_value,json=jsonValue,proto3,oneof"`
+}
+
+func (*TypedValue_NullValue) isTypedValue_Kind() {}
+
+func (*TypedValue_StringValue) isTypedValue_Kind() {}
+
+func (*TypedValue_IntValue) isTypedValue_Kind() {}
+
+func (*TypedValue_FloatValue) isTypedValue_Kind() {}
+
+func (*TypedValue_BoolValue) isTypedValue_Kind() {}
+
+func (*TypedValue_TimeValue) isTypedValue_Kind() {}
+
+func (*TypedValue_BytesValue) isTypedValue_Kind() {}
+
+func (*TypedValue_JsonValue) isTypedValue_Kind() {}
+
+type Record struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Fields        map[string]*TypedValue `protobuf:"bytes,1,rep,name=fields,proto3" json:"fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Record) Reset() {
+	*x = Record{}
+	mi := &file_v1_datastore_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Record) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Record) ProtoMessage() {}
+
+func (x *Record) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_datastore_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Record.ProtoReflect.Descriptor instead.
+func (*Record) Descriptor() ([]byte, []int) {
+	return file_v1_datastore_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *Record) GetFields() map[string]*TypedValue {
+	if x != nil {
+		return x.Fields
+	}
+	return nil
+}
+
 type ObjectStoreSchema struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Indexes       []*IndexSchema         `protobuf:"bytes,1,rep,name=indexes,proto3" json:"indexes,omitempty"`
@@ -33,7 +256,7 @@ type ObjectStoreSchema struct {
 
 func (x *ObjectStoreSchema) Reset() {
 	*x = ObjectStoreSchema{}
-	mi := &file_v1_datastore_proto_msgTypes[0]
+	mi := &file_v1_datastore_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -45,7 +268,7 @@ func (x *ObjectStoreSchema) String() string {
 func (*ObjectStoreSchema) ProtoMessage() {}
 
 func (x *ObjectStoreSchema) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_datastore_proto_msgTypes[0]
+	mi := &file_v1_datastore_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58,7 +281,7 @@ func (x *ObjectStoreSchema) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ObjectStoreSchema.ProtoReflect.Descriptor instead.
 func (*ObjectStoreSchema) Descriptor() ([]byte, []int) {
-	return file_v1_datastore_proto_rawDescGZIP(), []int{0}
+	return file_v1_datastore_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *ObjectStoreSchema) GetIndexes() []*IndexSchema {
@@ -86,7 +309,7 @@ type IndexSchema struct {
 
 func (x *IndexSchema) Reset() {
 	*x = IndexSchema{}
-	mi := &file_v1_datastore_proto_msgTypes[1]
+	mi := &file_v1_datastore_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -98,7 +321,7 @@ func (x *IndexSchema) String() string {
 func (*IndexSchema) ProtoMessage() {}
 
 func (x *IndexSchema) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_datastore_proto_msgTypes[1]
+	mi := &file_v1_datastore_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -111,7 +334,7 @@ func (x *IndexSchema) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IndexSchema.ProtoReflect.Descriptor instead.
 func (*IndexSchema) Descriptor() ([]byte, []int) {
-	return file_v1_datastore_proto_rawDescGZIP(), []int{1}
+	return file_v1_datastore_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *IndexSchema) GetName() string {
@@ -148,7 +371,7 @@ type ColumnDef struct {
 
 func (x *ColumnDef) Reset() {
 	*x = ColumnDef{}
-	mi := &file_v1_datastore_proto_msgTypes[2]
+	mi := &file_v1_datastore_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -160,7 +383,7 @@ func (x *ColumnDef) String() string {
 func (*ColumnDef) ProtoMessage() {}
 
 func (x *ColumnDef) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_datastore_proto_msgTypes[2]
+	mi := &file_v1_datastore_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -173,7 +396,7 @@ func (x *ColumnDef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ColumnDef.ProtoReflect.Descriptor instead.
 func (*ColumnDef) Descriptor() ([]byte, []int) {
-	return file_v1_datastore_proto_rawDescGZIP(), []int{2}
+	return file_v1_datastore_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *ColumnDef) GetName() string {
@@ -213,8 +436,8 @@ func (x *ColumnDef) GetUnique() bool {
 
 type KeyRange struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Lower         *structpb.Value        `protobuf:"bytes,1,opt,name=lower,proto3" json:"lower,omitempty"`
-	Upper         *structpb.Value        `protobuf:"bytes,2,opt,name=upper,proto3" json:"upper,omitempty"`
+	Lower         *TypedValue            `protobuf:"bytes,1,opt,name=lower,proto3" json:"lower,omitempty"`
+	Upper         *TypedValue            `protobuf:"bytes,2,opt,name=upper,proto3" json:"upper,omitempty"`
 	LowerOpen     bool                   `protobuf:"varint,3,opt,name=lower_open,json=lowerOpen,proto3" json:"lower_open,omitempty"`
 	UpperOpen     bool                   `protobuf:"varint,4,opt,name=upper_open,json=upperOpen,proto3" json:"upper_open,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -223,7 +446,7 @@ type KeyRange struct {
 
 func (x *KeyRange) Reset() {
 	*x = KeyRange{}
-	mi := &file_v1_datastore_proto_msgTypes[3]
+	mi := &file_v1_datastore_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -235,7 +458,7 @@ func (x *KeyRange) String() string {
 func (*KeyRange) ProtoMessage() {}
 
 func (x *KeyRange) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_datastore_proto_msgTypes[3]
+	mi := &file_v1_datastore_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -248,17 +471,17 @@ func (x *KeyRange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KeyRange.ProtoReflect.Descriptor instead.
 func (*KeyRange) Descriptor() ([]byte, []int) {
-	return file_v1_datastore_proto_rawDescGZIP(), []int{3}
+	return file_v1_datastore_proto_rawDescGZIP(), []int{5}
 }
 
-func (x *KeyRange) GetLower() *structpb.Value {
+func (x *KeyRange) GetLower() *TypedValue {
 	if x != nil {
 		return x.Lower
 	}
 	return nil
 }
 
-func (x *KeyRange) GetUpper() *structpb.Value {
+func (x *KeyRange) GetUpper() *TypedValue {
 	if x != nil {
 		return x.Upper
 	}
@@ -282,14 +505,14 @@ func (x *KeyRange) GetUpperOpen() bool {
 type RecordRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Store         string                 `protobuf:"bytes,1,opt,name=store,proto3" json:"store,omitempty"`
-	Record        *structpb.Struct       `protobuf:"bytes,2,opt,name=record,proto3" json:"record,omitempty"`
+	Record        *Record                `protobuf:"bytes,2,opt,name=record,proto3" json:"record,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *RecordRequest) Reset() {
 	*x = RecordRequest{}
-	mi := &file_v1_datastore_proto_msgTypes[4]
+	mi := &file_v1_datastore_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -301,7 +524,7 @@ func (x *RecordRequest) String() string {
 func (*RecordRequest) ProtoMessage() {}
 
 func (x *RecordRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_datastore_proto_msgTypes[4]
+	mi := &file_v1_datastore_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -314,7 +537,7 @@ func (x *RecordRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RecordRequest.ProtoReflect.Descriptor instead.
 func (*RecordRequest) Descriptor() ([]byte, []int) {
-	return file_v1_datastore_proto_rawDescGZIP(), []int{4}
+	return file_v1_datastore_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *RecordRequest) GetStore() string {
@@ -324,7 +547,7 @@ func (x *RecordRequest) GetStore() string {
 	return ""
 }
 
-func (x *RecordRequest) GetRecord() *structpb.Struct {
+func (x *RecordRequest) GetRecord() *Record {
 	if x != nil {
 		return x.Record
 	}
@@ -333,14 +556,14 @@ func (x *RecordRequest) GetRecord() *structpb.Struct {
 
 type RecordResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Record        *structpb.Struct       `protobuf:"bytes,1,opt,name=record,proto3" json:"record,omitempty"`
+	Record        *Record                `protobuf:"bytes,1,opt,name=record,proto3" json:"record,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *RecordResponse) Reset() {
 	*x = RecordResponse{}
-	mi := &file_v1_datastore_proto_msgTypes[5]
+	mi := &file_v1_datastore_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -352,7 +575,7 @@ func (x *RecordResponse) String() string {
 func (*RecordResponse) ProtoMessage() {}
 
 func (x *RecordResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_datastore_proto_msgTypes[5]
+	mi := &file_v1_datastore_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -365,10 +588,10 @@ func (x *RecordResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RecordResponse.ProtoReflect.Descriptor instead.
 func (*RecordResponse) Descriptor() ([]byte, []int) {
-	return file_v1_datastore_proto_rawDescGZIP(), []int{5}
+	return file_v1_datastore_proto_rawDescGZIP(), []int{7}
 }
 
-func (x *RecordResponse) GetRecord() *structpb.Struct {
+func (x *RecordResponse) GetRecord() *Record {
 	if x != nil {
 		return x.Record
 	}
@@ -377,14 +600,14 @@ func (x *RecordResponse) GetRecord() *structpb.Struct {
 
 type RecordsResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Records       []*structpb.Struct     `protobuf:"bytes,1,rep,name=records,proto3" json:"records,omitempty"`
+	Records       []*Record              `protobuf:"bytes,1,rep,name=records,proto3" json:"records,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *RecordsResponse) Reset() {
 	*x = RecordsResponse{}
-	mi := &file_v1_datastore_proto_msgTypes[6]
+	mi := &file_v1_datastore_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -396,7 +619,7 @@ func (x *RecordsResponse) String() string {
 func (*RecordsResponse) ProtoMessage() {}
 
 func (x *RecordsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_datastore_proto_msgTypes[6]
+	mi := &file_v1_datastore_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -409,10 +632,10 @@ func (x *RecordsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RecordsResponse.ProtoReflect.Descriptor instead.
 func (*RecordsResponse) Descriptor() ([]byte, []int) {
-	return file_v1_datastore_proto_rawDescGZIP(), []int{6}
+	return file_v1_datastore_proto_rawDescGZIP(), []int{8}
 }
 
-func (x *RecordsResponse) GetRecords() []*structpb.Struct {
+func (x *RecordsResponse) GetRecords() []*Record {
 	if x != nil {
 		return x.Records
 	}
@@ -428,7 +651,7 @@ type KeysResponse struct {
 
 func (x *KeysResponse) Reset() {
 	*x = KeysResponse{}
-	mi := &file_v1_datastore_proto_msgTypes[7]
+	mi := &file_v1_datastore_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -440,7 +663,7 @@ func (x *KeysResponse) String() string {
 func (*KeysResponse) ProtoMessage() {}
 
 func (x *KeysResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_datastore_proto_msgTypes[7]
+	mi := &file_v1_datastore_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -453,7 +676,7 @@ func (x *KeysResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KeysResponse.ProtoReflect.Descriptor instead.
 func (*KeysResponse) Descriptor() ([]byte, []int) {
-	return file_v1_datastore_proto_rawDescGZIP(), []int{7}
+	return file_v1_datastore_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *KeysResponse) GetKeys() []string {
@@ -473,7 +696,7 @@ type ObjectStoreRequest struct {
 
 func (x *ObjectStoreRequest) Reset() {
 	*x = ObjectStoreRequest{}
-	mi := &file_v1_datastore_proto_msgTypes[8]
+	mi := &file_v1_datastore_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -485,7 +708,7 @@ func (x *ObjectStoreRequest) String() string {
 func (*ObjectStoreRequest) ProtoMessage() {}
 
 func (x *ObjectStoreRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_datastore_proto_msgTypes[8]
+	mi := &file_v1_datastore_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -498,7 +721,7 @@ func (x *ObjectStoreRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ObjectStoreRequest.ProtoReflect.Descriptor instead.
 func (*ObjectStoreRequest) Descriptor() ([]byte, []int) {
-	return file_v1_datastore_proto_rawDescGZIP(), []int{8}
+	return file_v1_datastore_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ObjectStoreRequest) GetStore() string {
@@ -524,7 +747,7 @@ type ObjectStoreNameRequest struct {
 
 func (x *ObjectStoreNameRequest) Reset() {
 	*x = ObjectStoreNameRequest{}
-	mi := &file_v1_datastore_proto_msgTypes[9]
+	mi := &file_v1_datastore_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -536,7 +759,7 @@ func (x *ObjectStoreNameRequest) String() string {
 func (*ObjectStoreNameRequest) ProtoMessage() {}
 
 func (x *ObjectStoreNameRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_datastore_proto_msgTypes[9]
+	mi := &file_v1_datastore_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -549,7 +772,7 @@ func (x *ObjectStoreNameRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ObjectStoreNameRequest.ProtoReflect.Descriptor instead.
 func (*ObjectStoreNameRequest) Descriptor() ([]byte, []int) {
-	return file_v1_datastore_proto_rawDescGZIP(), []int{9}
+	return file_v1_datastore_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ObjectStoreNameRequest) GetStore() string {
@@ -569,7 +792,7 @@ type ObjectStoreRangeRequest struct {
 
 func (x *ObjectStoreRangeRequest) Reset() {
 	*x = ObjectStoreRangeRequest{}
-	mi := &file_v1_datastore_proto_msgTypes[10]
+	mi := &file_v1_datastore_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -581,7 +804,7 @@ func (x *ObjectStoreRangeRequest) String() string {
 func (*ObjectStoreRangeRequest) ProtoMessage() {}
 
 func (x *ObjectStoreRangeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_datastore_proto_msgTypes[10]
+	mi := &file_v1_datastore_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -594,7 +817,7 @@ func (x *ObjectStoreRangeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ObjectStoreRangeRequest.ProtoReflect.Descriptor instead.
 func (*ObjectStoreRangeRequest) Descriptor() ([]byte, []int) {
-	return file_v1_datastore_proto_rawDescGZIP(), []int{10}
+	return file_v1_datastore_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ObjectStoreRangeRequest) GetStore() string {
@@ -621,7 +844,7 @@ type CreateObjectStoreRequest struct {
 
 func (x *CreateObjectStoreRequest) Reset() {
 	*x = CreateObjectStoreRequest{}
-	mi := &file_v1_datastore_proto_msgTypes[11]
+	mi := &file_v1_datastore_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -633,7 +856,7 @@ func (x *CreateObjectStoreRequest) String() string {
 func (*CreateObjectStoreRequest) ProtoMessage() {}
 
 func (x *CreateObjectStoreRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_datastore_proto_msgTypes[11]
+	mi := &file_v1_datastore_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -646,7 +869,7 @@ func (x *CreateObjectStoreRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateObjectStoreRequest.ProtoReflect.Descriptor instead.
 func (*CreateObjectStoreRequest) Descriptor() ([]byte, []int) {
-	return file_v1_datastore_proto_rawDescGZIP(), []int{11}
+	return file_v1_datastore_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *CreateObjectStoreRequest) GetName() string {
@@ -672,7 +895,7 @@ type DeleteObjectStoreRequest struct {
 
 func (x *DeleteObjectStoreRequest) Reset() {
 	*x = DeleteObjectStoreRequest{}
-	mi := &file_v1_datastore_proto_msgTypes[12]
+	mi := &file_v1_datastore_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -684,7 +907,7 @@ func (x *DeleteObjectStoreRequest) String() string {
 func (*DeleteObjectStoreRequest) ProtoMessage() {}
 
 func (x *DeleteObjectStoreRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_datastore_proto_msgTypes[12]
+	mi := &file_v1_datastore_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -697,7 +920,7 @@ func (x *DeleteObjectStoreRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteObjectStoreRequest.ProtoReflect.Descriptor instead.
 func (*DeleteObjectStoreRequest) Descriptor() ([]byte, []int) {
-	return file_v1_datastore_proto_rawDescGZIP(), []int{12}
+	return file_v1_datastore_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *DeleteObjectStoreRequest) GetName() string {
@@ -711,7 +934,7 @@ type IndexQueryRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Store         string                 `protobuf:"bytes,1,opt,name=store,proto3" json:"store,omitempty"`
 	Index         string                 `protobuf:"bytes,2,opt,name=index,proto3" json:"index,omitempty"`
-	Values        []*structpb.Value      `protobuf:"bytes,3,rep,name=values,proto3" json:"values,omitempty"`
+	Values        []*TypedValue          `protobuf:"bytes,3,rep,name=values,proto3" json:"values,omitempty"`
 	Range         *KeyRange              `protobuf:"bytes,4,opt,name=range,proto3,oneof" json:"range,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -719,7 +942,7 @@ type IndexQueryRequest struct {
 
 func (x *IndexQueryRequest) Reset() {
 	*x = IndexQueryRequest{}
-	mi := &file_v1_datastore_proto_msgTypes[13]
+	mi := &file_v1_datastore_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -731,7 +954,7 @@ func (x *IndexQueryRequest) String() string {
 func (*IndexQueryRequest) ProtoMessage() {}
 
 func (x *IndexQueryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_datastore_proto_msgTypes[13]
+	mi := &file_v1_datastore_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -744,7 +967,7 @@ func (x *IndexQueryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IndexQueryRequest.ProtoReflect.Descriptor instead.
 func (*IndexQueryRequest) Descriptor() ([]byte, []int) {
-	return file_v1_datastore_proto_rawDescGZIP(), []int{13}
+	return file_v1_datastore_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *IndexQueryRequest) GetStore() string {
@@ -761,7 +984,7 @@ func (x *IndexQueryRequest) GetIndex() string {
 	return ""
 }
 
-func (x *IndexQueryRequest) GetValues() []*structpb.Value {
+func (x *IndexQueryRequest) GetValues() []*TypedValue {
 	if x != nil {
 		return x.Values
 	}
@@ -784,7 +1007,7 @@ type CountResponse struct {
 
 func (x *CountResponse) Reset() {
 	*x = CountResponse{}
-	mi := &file_v1_datastore_proto_msgTypes[14]
+	mi := &file_v1_datastore_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -796,7 +1019,7 @@ func (x *CountResponse) String() string {
 func (*CountResponse) ProtoMessage() {}
 
 func (x *CountResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_datastore_proto_msgTypes[14]
+	mi := &file_v1_datastore_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -809,7 +1032,7 @@ func (x *CountResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CountResponse.ProtoReflect.Descriptor instead.
 func (*CountResponse) Descriptor() ([]byte, []int) {
-	return file_v1_datastore_proto_rawDescGZIP(), []int{14}
+	return file_v1_datastore_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *CountResponse) GetCount() int64 {
@@ -828,7 +1051,7 @@ type DeleteResponse struct {
 
 func (x *DeleteResponse) Reset() {
 	*x = DeleteResponse{}
-	mi := &file_v1_datastore_proto_msgTypes[15]
+	mi := &file_v1_datastore_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -840,7 +1063,7 @@ func (x *DeleteResponse) String() string {
 func (*DeleteResponse) ProtoMessage() {}
 
 func (x *DeleteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_datastore_proto_msgTypes[15]
+	mi := &file_v1_datastore_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -853,7 +1076,7 @@ func (x *DeleteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteResponse.ProtoReflect.Descriptor instead.
 func (*DeleteResponse) Descriptor() ([]byte, []int) {
-	return file_v1_datastore_proto_rawDescGZIP(), []int{15}
+	return file_v1_datastore_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *DeleteResponse) GetDeleted() int64 {
@@ -872,7 +1095,7 @@ type KeyResponse struct {
 
 func (x *KeyResponse) Reset() {
 	*x = KeyResponse{}
-	mi := &file_v1_datastore_proto_msgTypes[16]
+	mi := &file_v1_datastore_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -884,7 +1107,7 @@ func (x *KeyResponse) String() string {
 func (*KeyResponse) ProtoMessage() {}
 
 func (x *KeyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_datastore_proto_msgTypes[16]
+	mi := &file_v1_datastore_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -897,7 +1120,7 @@ func (x *KeyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KeyResponse.ProtoReflect.Descriptor instead.
 func (*KeyResponse) Descriptor() ([]byte, []int) {
-	return file_v1_datastore_proto_rawDescGZIP(), []int{16}
+	return file_v1_datastore_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *KeyResponse) GetKey() string {
@@ -911,7 +1134,29 @@ var File_v1_datastore_proto protoreflect.FileDescriptor
 
 const file_v1_datastore_proto_rawDesc = "" +
 	"\n" +
-	"\x12v1/datastore.proto\x12\x13gestalt.provider.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1cgoogle/protobuf/struct.proto\"\x89\x01\n" +
+	"\x12v1/datastore.proto\x12\x13gestalt.provider.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xf2\x02\n" +
+	"\n" +
+	"TypedValue\x12;\n" +
+	"\n" +
+	"null_value\x18\x01 \x01(\x0e2\x1a.google.protobuf.NullValueH\x00R\tnullValue\x12#\n" +
+	"\fstring_value\x18\x02 \x01(\tH\x00R\vstringValue\x12\x1d\n" +
+	"\tint_value\x18\x03 \x01(\x03H\x00R\bintValue\x12!\n" +
+	"\vfloat_value\x18\x04 \x01(\x01H\x00R\n" +
+	"floatValue\x12\x1f\n" +
+	"\n" +
+	"bool_value\x18\x05 \x01(\bH\x00R\tboolValue\x12;\n" +
+	"\n" +
+	"time_value\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\ttimeValue\x12!\n" +
+	"\vbytes_value\x18\a \x01(\fH\x00R\n" +
+	"bytesValue\x127\n" +
+	"\n" +
+	"json_value\x18\b \x01(\v2\x16.google.protobuf.ValueH\x00R\tjsonValueB\x06\n" +
+	"\x04kind\"\xa5\x01\n" +
+	"\x06Record\x12?\n" +
+	"\x06fields\x18\x01 \x03(\v2'.gestalt.provider.v1.Record.FieldsEntryR\x06fields\x1aZ\n" +
+	"\vFieldsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x125\n" +
+	"\x05value\x18\x02 \x01(\v2\x1f.gestalt.provider.v1.TypedValueR\x05value:\x028\x01\"\x89\x01\n" +
 	"\x11ObjectStoreSchema\x12:\n" +
 	"\aindexes\x18\x01 \x03(\v2 .gestalt.provider.v1.IndexSchemaR\aindexes\x128\n" +
 	"\acolumns\x18\x02 \x03(\v2\x1e.gestalt.provider.v1.ColumnDefR\acolumns\"T\n" +
@@ -925,21 +1170,21 @@ const file_v1_datastore_proto_rawDesc = "" +
 	"\vprimary_key\x18\x03 \x01(\bR\n" +
 	"primaryKey\x12\x19\n" +
 	"\bnot_null\x18\x04 \x01(\bR\anotNull\x12\x16\n" +
-	"\x06unique\x18\x05 \x01(\bR\x06unique\"\xa4\x01\n" +
-	"\bKeyRange\x12,\n" +
-	"\x05lower\x18\x01 \x01(\v2\x16.google.protobuf.ValueR\x05lower\x12,\n" +
-	"\x05upper\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05upper\x12\x1d\n" +
+	"\x06unique\x18\x05 \x01(\bR\x06unique\"\xb6\x01\n" +
+	"\bKeyRange\x125\n" +
+	"\x05lower\x18\x01 \x01(\v2\x1f.gestalt.provider.v1.TypedValueR\x05lower\x125\n" +
+	"\x05upper\x18\x02 \x01(\v2\x1f.gestalt.provider.v1.TypedValueR\x05upper\x12\x1d\n" +
 	"\n" +
 	"lower_open\x18\x03 \x01(\bR\tlowerOpen\x12\x1d\n" +
 	"\n" +
-	"upper_open\x18\x04 \x01(\bR\tupperOpen\"V\n" +
+	"upper_open\x18\x04 \x01(\bR\tupperOpen\"Z\n" +
 	"\rRecordRequest\x12\x14\n" +
-	"\x05store\x18\x01 \x01(\tR\x05store\x12/\n" +
-	"\x06record\x18\x02 \x01(\v2\x17.google.protobuf.StructR\x06record\"A\n" +
-	"\x0eRecordResponse\x12/\n" +
-	"\x06record\x18\x01 \x01(\v2\x17.google.protobuf.StructR\x06record\"D\n" +
-	"\x0fRecordsResponse\x121\n" +
-	"\arecords\x18\x01 \x03(\v2\x17.google.protobuf.StructR\arecords\"\"\n" +
+	"\x05store\x18\x01 \x01(\tR\x05store\x123\n" +
+	"\x06record\x18\x02 \x01(\v2\x1b.gestalt.provider.v1.RecordR\x06record\"E\n" +
+	"\x0eRecordResponse\x123\n" +
+	"\x06record\x18\x01 \x01(\v2\x1b.gestalt.provider.v1.RecordR\x06record\"H\n" +
+	"\x0fRecordsResponse\x125\n" +
+	"\arecords\x18\x01 \x03(\v2\x1b.gestalt.provider.v1.RecordR\arecords\"\"\n" +
 	"\fKeysResponse\x12\x12\n" +
 	"\x04keys\x18\x01 \x03(\tR\x04keys\":\n" +
 	"\x12ObjectStoreRequest\x12\x14\n" +
@@ -955,11 +1200,11 @@ const file_v1_datastore_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12>\n" +
 	"\x06schema\x18\x02 \x01(\v2&.gestalt.provider.v1.ObjectStoreSchemaR\x06schema\".\n" +
 	"\x18DeleteObjectStoreRequest\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\"\xb3\x01\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\"\xbc\x01\n" +
 	"\x11IndexQueryRequest\x12\x14\n" +
 	"\x05store\x18\x01 \x01(\tR\x05store\x12\x14\n" +
-	"\x05index\x18\x02 \x01(\tR\x05index\x12.\n" +
-	"\x06values\x18\x03 \x03(\v2\x16.google.protobuf.ValueR\x06values\x128\n" +
+	"\x05index\x18\x02 \x01(\tR\x05index\x127\n" +
+	"\x06values\x18\x03 \x03(\v2\x1f.gestalt.provider.v1.TypedValueR\x06values\x128\n" +
 	"\x05range\x18\x04 \x01(\v2\x1d.gestalt.provider.v1.KeyRangeH\x00R\x05range\x88\x01\x01B\b\n" +
 	"\x06_range\"%\n" +
 	"\rCountResponse\x12\x14\n" +
@@ -1003,82 +1248,91 @@ func file_v1_datastore_proto_rawDescGZIP() []byte {
 	return file_v1_datastore_proto_rawDescData
 }
 
-var file_v1_datastore_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_v1_datastore_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
 var file_v1_datastore_proto_goTypes = []any{
-	(*ObjectStoreSchema)(nil),        // 0: gestalt.provider.v1.ObjectStoreSchema
-	(*IndexSchema)(nil),              // 1: gestalt.provider.v1.IndexSchema
-	(*ColumnDef)(nil),                // 2: gestalt.provider.v1.ColumnDef
-	(*KeyRange)(nil),                 // 3: gestalt.provider.v1.KeyRange
-	(*RecordRequest)(nil),            // 4: gestalt.provider.v1.RecordRequest
-	(*RecordResponse)(nil),           // 5: gestalt.provider.v1.RecordResponse
-	(*RecordsResponse)(nil),          // 6: gestalt.provider.v1.RecordsResponse
-	(*KeysResponse)(nil),             // 7: gestalt.provider.v1.KeysResponse
-	(*ObjectStoreRequest)(nil),       // 8: gestalt.provider.v1.ObjectStoreRequest
-	(*ObjectStoreNameRequest)(nil),   // 9: gestalt.provider.v1.ObjectStoreNameRequest
-	(*ObjectStoreRangeRequest)(nil),  // 10: gestalt.provider.v1.ObjectStoreRangeRequest
-	(*CreateObjectStoreRequest)(nil), // 11: gestalt.provider.v1.CreateObjectStoreRequest
-	(*DeleteObjectStoreRequest)(nil), // 12: gestalt.provider.v1.DeleteObjectStoreRequest
-	(*IndexQueryRequest)(nil),        // 13: gestalt.provider.v1.IndexQueryRequest
-	(*CountResponse)(nil),            // 14: gestalt.provider.v1.CountResponse
-	(*DeleteResponse)(nil),           // 15: gestalt.provider.v1.DeleteResponse
-	(*KeyResponse)(nil),              // 16: gestalt.provider.v1.KeyResponse
-	(*structpb.Value)(nil),           // 17: google.protobuf.Value
-	(*structpb.Struct)(nil),          // 18: google.protobuf.Struct
-	(*emptypb.Empty)(nil),            // 19: google.protobuf.Empty
+	(*TypedValue)(nil),               // 0: gestalt.provider.v1.TypedValue
+	(*Record)(nil),                   // 1: gestalt.provider.v1.Record
+	(*ObjectStoreSchema)(nil),        // 2: gestalt.provider.v1.ObjectStoreSchema
+	(*IndexSchema)(nil),              // 3: gestalt.provider.v1.IndexSchema
+	(*ColumnDef)(nil),                // 4: gestalt.provider.v1.ColumnDef
+	(*KeyRange)(nil),                 // 5: gestalt.provider.v1.KeyRange
+	(*RecordRequest)(nil),            // 6: gestalt.provider.v1.RecordRequest
+	(*RecordResponse)(nil),           // 7: gestalt.provider.v1.RecordResponse
+	(*RecordsResponse)(nil),          // 8: gestalt.provider.v1.RecordsResponse
+	(*KeysResponse)(nil),             // 9: gestalt.provider.v1.KeysResponse
+	(*ObjectStoreRequest)(nil),       // 10: gestalt.provider.v1.ObjectStoreRequest
+	(*ObjectStoreNameRequest)(nil),   // 11: gestalt.provider.v1.ObjectStoreNameRequest
+	(*ObjectStoreRangeRequest)(nil),  // 12: gestalt.provider.v1.ObjectStoreRangeRequest
+	(*CreateObjectStoreRequest)(nil), // 13: gestalt.provider.v1.CreateObjectStoreRequest
+	(*DeleteObjectStoreRequest)(nil), // 14: gestalt.provider.v1.DeleteObjectStoreRequest
+	(*IndexQueryRequest)(nil),        // 15: gestalt.provider.v1.IndexQueryRequest
+	(*CountResponse)(nil),            // 16: gestalt.provider.v1.CountResponse
+	(*DeleteResponse)(nil),           // 17: gestalt.provider.v1.DeleteResponse
+	(*KeyResponse)(nil),              // 18: gestalt.provider.v1.KeyResponse
+	nil,                              // 19: gestalt.provider.v1.Record.FieldsEntry
+	(structpb.NullValue)(0),          // 20: google.protobuf.NullValue
+	(*timestamppb.Timestamp)(nil),    // 21: google.protobuf.Timestamp
+	(*structpb.Value)(nil),           // 22: google.protobuf.Value
+	(*emptypb.Empty)(nil),            // 23: google.protobuf.Empty
 }
 var file_v1_datastore_proto_depIdxs = []int32{
-	1,  // 0: gestalt.provider.v1.ObjectStoreSchema.indexes:type_name -> gestalt.provider.v1.IndexSchema
-	2,  // 1: gestalt.provider.v1.ObjectStoreSchema.columns:type_name -> gestalt.provider.v1.ColumnDef
-	17, // 2: gestalt.provider.v1.KeyRange.lower:type_name -> google.protobuf.Value
-	17, // 3: gestalt.provider.v1.KeyRange.upper:type_name -> google.protobuf.Value
-	18, // 4: gestalt.provider.v1.RecordRequest.record:type_name -> google.protobuf.Struct
-	18, // 5: gestalt.provider.v1.RecordResponse.record:type_name -> google.protobuf.Struct
-	18, // 6: gestalt.provider.v1.RecordsResponse.records:type_name -> google.protobuf.Struct
-	3,  // 7: gestalt.provider.v1.ObjectStoreRangeRequest.range:type_name -> gestalt.provider.v1.KeyRange
-	0,  // 8: gestalt.provider.v1.CreateObjectStoreRequest.schema:type_name -> gestalt.provider.v1.ObjectStoreSchema
-	17, // 9: gestalt.provider.v1.IndexQueryRequest.values:type_name -> google.protobuf.Value
-	3,  // 10: gestalt.provider.v1.IndexQueryRequest.range:type_name -> gestalt.provider.v1.KeyRange
-	11, // 11: gestalt.provider.v1.IndexedDB.CreateObjectStore:input_type -> gestalt.provider.v1.CreateObjectStoreRequest
-	12, // 12: gestalt.provider.v1.IndexedDB.DeleteObjectStore:input_type -> gestalt.provider.v1.DeleteObjectStoreRequest
-	8,  // 13: gestalt.provider.v1.IndexedDB.Get:input_type -> gestalt.provider.v1.ObjectStoreRequest
-	8,  // 14: gestalt.provider.v1.IndexedDB.GetKey:input_type -> gestalt.provider.v1.ObjectStoreRequest
-	4,  // 15: gestalt.provider.v1.IndexedDB.Add:input_type -> gestalt.provider.v1.RecordRequest
-	4,  // 16: gestalt.provider.v1.IndexedDB.Put:input_type -> gestalt.provider.v1.RecordRequest
-	8,  // 17: gestalt.provider.v1.IndexedDB.Delete:input_type -> gestalt.provider.v1.ObjectStoreRequest
-	9,  // 18: gestalt.provider.v1.IndexedDB.Clear:input_type -> gestalt.provider.v1.ObjectStoreNameRequest
-	10, // 19: gestalt.provider.v1.IndexedDB.GetAll:input_type -> gestalt.provider.v1.ObjectStoreRangeRequest
-	10, // 20: gestalt.provider.v1.IndexedDB.GetAllKeys:input_type -> gestalt.provider.v1.ObjectStoreRangeRequest
-	10, // 21: gestalt.provider.v1.IndexedDB.Count:input_type -> gestalt.provider.v1.ObjectStoreRangeRequest
-	10, // 22: gestalt.provider.v1.IndexedDB.DeleteRange:input_type -> gestalt.provider.v1.ObjectStoreRangeRequest
-	13, // 23: gestalt.provider.v1.IndexedDB.IndexGet:input_type -> gestalt.provider.v1.IndexQueryRequest
-	13, // 24: gestalt.provider.v1.IndexedDB.IndexGetKey:input_type -> gestalt.provider.v1.IndexQueryRequest
-	13, // 25: gestalt.provider.v1.IndexedDB.IndexGetAll:input_type -> gestalt.provider.v1.IndexQueryRequest
-	13, // 26: gestalt.provider.v1.IndexedDB.IndexGetAllKeys:input_type -> gestalt.provider.v1.IndexQueryRequest
-	13, // 27: gestalt.provider.v1.IndexedDB.IndexCount:input_type -> gestalt.provider.v1.IndexQueryRequest
-	13, // 28: gestalt.provider.v1.IndexedDB.IndexDelete:input_type -> gestalt.provider.v1.IndexQueryRequest
-	19, // 29: gestalt.provider.v1.IndexedDB.CreateObjectStore:output_type -> google.protobuf.Empty
-	19, // 30: gestalt.provider.v1.IndexedDB.DeleteObjectStore:output_type -> google.protobuf.Empty
-	5,  // 31: gestalt.provider.v1.IndexedDB.Get:output_type -> gestalt.provider.v1.RecordResponse
-	16, // 32: gestalt.provider.v1.IndexedDB.GetKey:output_type -> gestalt.provider.v1.KeyResponse
-	19, // 33: gestalt.provider.v1.IndexedDB.Add:output_type -> google.protobuf.Empty
-	19, // 34: gestalt.provider.v1.IndexedDB.Put:output_type -> google.protobuf.Empty
-	19, // 35: gestalt.provider.v1.IndexedDB.Delete:output_type -> google.protobuf.Empty
-	19, // 36: gestalt.provider.v1.IndexedDB.Clear:output_type -> google.protobuf.Empty
-	6,  // 37: gestalt.provider.v1.IndexedDB.GetAll:output_type -> gestalt.provider.v1.RecordsResponse
-	7,  // 38: gestalt.provider.v1.IndexedDB.GetAllKeys:output_type -> gestalt.provider.v1.KeysResponse
-	14, // 39: gestalt.provider.v1.IndexedDB.Count:output_type -> gestalt.provider.v1.CountResponse
-	15, // 40: gestalt.provider.v1.IndexedDB.DeleteRange:output_type -> gestalt.provider.v1.DeleteResponse
-	5,  // 41: gestalt.provider.v1.IndexedDB.IndexGet:output_type -> gestalt.provider.v1.RecordResponse
-	16, // 42: gestalt.provider.v1.IndexedDB.IndexGetKey:output_type -> gestalt.provider.v1.KeyResponse
-	6,  // 43: gestalt.provider.v1.IndexedDB.IndexGetAll:output_type -> gestalt.provider.v1.RecordsResponse
-	7,  // 44: gestalt.provider.v1.IndexedDB.IndexGetAllKeys:output_type -> gestalt.provider.v1.KeysResponse
-	14, // 45: gestalt.provider.v1.IndexedDB.IndexCount:output_type -> gestalt.provider.v1.CountResponse
-	15, // 46: gestalt.provider.v1.IndexedDB.IndexDelete:output_type -> gestalt.provider.v1.DeleteResponse
-	29, // [29:47] is the sub-list for method output_type
-	11, // [11:29] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	20, // 0: gestalt.provider.v1.TypedValue.null_value:type_name -> google.protobuf.NullValue
+	21, // 1: gestalt.provider.v1.TypedValue.time_value:type_name -> google.protobuf.Timestamp
+	22, // 2: gestalt.provider.v1.TypedValue.json_value:type_name -> google.protobuf.Value
+	19, // 3: gestalt.provider.v1.Record.fields:type_name -> gestalt.provider.v1.Record.FieldsEntry
+	3,  // 4: gestalt.provider.v1.ObjectStoreSchema.indexes:type_name -> gestalt.provider.v1.IndexSchema
+	4,  // 5: gestalt.provider.v1.ObjectStoreSchema.columns:type_name -> gestalt.provider.v1.ColumnDef
+	0,  // 6: gestalt.provider.v1.KeyRange.lower:type_name -> gestalt.provider.v1.TypedValue
+	0,  // 7: gestalt.provider.v1.KeyRange.upper:type_name -> gestalt.provider.v1.TypedValue
+	1,  // 8: gestalt.provider.v1.RecordRequest.record:type_name -> gestalt.provider.v1.Record
+	1,  // 9: gestalt.provider.v1.RecordResponse.record:type_name -> gestalt.provider.v1.Record
+	1,  // 10: gestalt.provider.v1.RecordsResponse.records:type_name -> gestalt.provider.v1.Record
+	5,  // 11: gestalt.provider.v1.ObjectStoreRangeRequest.range:type_name -> gestalt.provider.v1.KeyRange
+	2,  // 12: gestalt.provider.v1.CreateObjectStoreRequest.schema:type_name -> gestalt.provider.v1.ObjectStoreSchema
+	0,  // 13: gestalt.provider.v1.IndexQueryRequest.values:type_name -> gestalt.provider.v1.TypedValue
+	5,  // 14: gestalt.provider.v1.IndexQueryRequest.range:type_name -> gestalt.provider.v1.KeyRange
+	0,  // 15: gestalt.provider.v1.Record.FieldsEntry.value:type_name -> gestalt.provider.v1.TypedValue
+	13, // 16: gestalt.provider.v1.IndexedDB.CreateObjectStore:input_type -> gestalt.provider.v1.CreateObjectStoreRequest
+	14, // 17: gestalt.provider.v1.IndexedDB.DeleteObjectStore:input_type -> gestalt.provider.v1.DeleteObjectStoreRequest
+	10, // 18: gestalt.provider.v1.IndexedDB.Get:input_type -> gestalt.provider.v1.ObjectStoreRequest
+	10, // 19: gestalt.provider.v1.IndexedDB.GetKey:input_type -> gestalt.provider.v1.ObjectStoreRequest
+	6,  // 20: gestalt.provider.v1.IndexedDB.Add:input_type -> gestalt.provider.v1.RecordRequest
+	6,  // 21: gestalt.provider.v1.IndexedDB.Put:input_type -> gestalt.provider.v1.RecordRequest
+	10, // 22: gestalt.provider.v1.IndexedDB.Delete:input_type -> gestalt.provider.v1.ObjectStoreRequest
+	11, // 23: gestalt.provider.v1.IndexedDB.Clear:input_type -> gestalt.provider.v1.ObjectStoreNameRequest
+	12, // 24: gestalt.provider.v1.IndexedDB.GetAll:input_type -> gestalt.provider.v1.ObjectStoreRangeRequest
+	12, // 25: gestalt.provider.v1.IndexedDB.GetAllKeys:input_type -> gestalt.provider.v1.ObjectStoreRangeRequest
+	12, // 26: gestalt.provider.v1.IndexedDB.Count:input_type -> gestalt.provider.v1.ObjectStoreRangeRequest
+	12, // 27: gestalt.provider.v1.IndexedDB.DeleteRange:input_type -> gestalt.provider.v1.ObjectStoreRangeRequest
+	15, // 28: gestalt.provider.v1.IndexedDB.IndexGet:input_type -> gestalt.provider.v1.IndexQueryRequest
+	15, // 29: gestalt.provider.v1.IndexedDB.IndexGetKey:input_type -> gestalt.provider.v1.IndexQueryRequest
+	15, // 30: gestalt.provider.v1.IndexedDB.IndexGetAll:input_type -> gestalt.provider.v1.IndexQueryRequest
+	15, // 31: gestalt.provider.v1.IndexedDB.IndexGetAllKeys:input_type -> gestalt.provider.v1.IndexQueryRequest
+	15, // 32: gestalt.provider.v1.IndexedDB.IndexCount:input_type -> gestalt.provider.v1.IndexQueryRequest
+	15, // 33: gestalt.provider.v1.IndexedDB.IndexDelete:input_type -> gestalt.provider.v1.IndexQueryRequest
+	23, // 34: gestalt.provider.v1.IndexedDB.CreateObjectStore:output_type -> google.protobuf.Empty
+	23, // 35: gestalt.provider.v1.IndexedDB.DeleteObjectStore:output_type -> google.protobuf.Empty
+	7,  // 36: gestalt.provider.v1.IndexedDB.Get:output_type -> gestalt.provider.v1.RecordResponse
+	18, // 37: gestalt.provider.v1.IndexedDB.GetKey:output_type -> gestalt.provider.v1.KeyResponse
+	23, // 38: gestalt.provider.v1.IndexedDB.Add:output_type -> google.protobuf.Empty
+	23, // 39: gestalt.provider.v1.IndexedDB.Put:output_type -> google.protobuf.Empty
+	23, // 40: gestalt.provider.v1.IndexedDB.Delete:output_type -> google.protobuf.Empty
+	23, // 41: gestalt.provider.v1.IndexedDB.Clear:output_type -> google.protobuf.Empty
+	8,  // 42: gestalt.provider.v1.IndexedDB.GetAll:output_type -> gestalt.provider.v1.RecordsResponse
+	9,  // 43: gestalt.provider.v1.IndexedDB.GetAllKeys:output_type -> gestalt.provider.v1.KeysResponse
+	16, // 44: gestalt.provider.v1.IndexedDB.Count:output_type -> gestalt.provider.v1.CountResponse
+	17, // 45: gestalt.provider.v1.IndexedDB.DeleteRange:output_type -> gestalt.provider.v1.DeleteResponse
+	7,  // 46: gestalt.provider.v1.IndexedDB.IndexGet:output_type -> gestalt.provider.v1.RecordResponse
+	18, // 47: gestalt.provider.v1.IndexedDB.IndexGetKey:output_type -> gestalt.provider.v1.KeyResponse
+	8,  // 48: gestalt.provider.v1.IndexedDB.IndexGetAll:output_type -> gestalt.provider.v1.RecordsResponse
+	9,  // 49: gestalt.provider.v1.IndexedDB.IndexGetAllKeys:output_type -> gestalt.provider.v1.KeysResponse
+	16, // 50: gestalt.provider.v1.IndexedDB.IndexCount:output_type -> gestalt.provider.v1.CountResponse
+	17, // 51: gestalt.provider.v1.IndexedDB.IndexDelete:output_type -> gestalt.provider.v1.DeleteResponse
+	34, // [34:52] is the sub-list for method output_type
+	16, // [16:34] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_v1_datastore_proto_init() }
@@ -1086,15 +1340,25 @@ func file_v1_datastore_proto_init() {
 	if File_v1_datastore_proto != nil {
 		return
 	}
-	file_v1_datastore_proto_msgTypes[10].OneofWrappers = []any{}
-	file_v1_datastore_proto_msgTypes[13].OneofWrappers = []any{}
+	file_v1_datastore_proto_msgTypes[0].OneofWrappers = []any{
+		(*TypedValue_NullValue)(nil),
+		(*TypedValue_StringValue)(nil),
+		(*TypedValue_IntValue)(nil),
+		(*TypedValue_FloatValue)(nil),
+		(*TypedValue_BoolValue)(nil),
+		(*TypedValue_TimeValue)(nil),
+		(*TypedValue_BytesValue)(nil),
+		(*TypedValue_JsonValue)(nil),
+	}
+	file_v1_datastore_proto_msgTypes[12].OneofWrappers = []any{}
+	file_v1_datastore_proto_msgTypes[15].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_v1_datastore_proto_rawDesc), len(file_v1_datastore_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   17,
+			NumMessages:   20,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sdk/go/indexeddb.go
+++ b/sdk/go/indexeddb.go
@@ -11,7 +11,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 const EnvIndexedDBSocket = "GESTALT_INDEXEDDB_SOCKET"
@@ -99,7 +98,11 @@ func (o *ObjectStoreClient) Get(ctx context.Context, id string) (Record, error) 
 	if err != nil {
 		return nil, grpcErr(err)
 	}
-	return resp.GetRecord().AsMap(), nil
+	record, err := RecordFromProto(resp.GetRecord())
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal record: %w", err)
+	}
+	return record, nil
 }
 
 func (o *ObjectStoreClient) GetKey(ctx context.Context, id string) (string, error) {
@@ -111,20 +114,20 @@ func (o *ObjectStoreClient) GetKey(ctx context.Context, id string) (string, erro
 }
 
 func (o *ObjectStoreClient) Add(ctx context.Context, record Record) error {
-	s, err := structpb.NewStruct(record)
+	pbRecord, err := RecordToProto(record)
 	if err != nil {
 		return fmt.Errorf("marshal record: %w", err)
 	}
-	_, err = o.client.Add(ctx, &proto.RecordRequest{Store: o.store, Record: s})
+	_, err = o.client.Add(ctx, &proto.RecordRequest{Store: o.store, Record: pbRecord})
 	return grpcErr(err)
 }
 
 func (o *ObjectStoreClient) Put(ctx context.Context, record Record) error {
-	s, err := structpb.NewStruct(record)
+	pbRecord, err := RecordToProto(record)
 	if err != nil {
 		return fmt.Errorf("marshal record: %w", err)
 	}
-	_, err = o.client.Put(ctx, &proto.RecordRequest{Store: o.store, Record: s})
+	_, err = o.client.Put(ctx, &proto.RecordRequest{Store: o.store, Record: pbRecord})
 	return grpcErr(err)
 }
 
@@ -147,7 +150,11 @@ func (o *ObjectStoreClient) GetAll(ctx context.Context, r *KeyRange) ([]Record, 
 	if err != nil {
 		return nil, grpcErr(err)
 	}
-	return structsToMaps(resp.GetRecords()), nil
+	records, err := RecordsFromProto(resp.GetRecords())
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal records: %w", err)
+	}
+	return records, nil
 }
 
 func (o *ObjectStoreClient) GetAllKeys(ctx context.Context, r *KeyRange) ([]string, error) {
@@ -207,7 +214,11 @@ func (idx *IndexClient) Get(ctx context.Context, values ...any) (Record, error) 
 	if err != nil {
 		return nil, grpcErr(err)
 	}
-	return resp.GetRecord().AsMap(), nil
+	record, err := RecordFromProto(resp.GetRecord())
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal record: %w", err)
+	}
+	return record, nil
 }
 
 func (idx *IndexClient) GetKey(ctx context.Context, values ...any) (string, error) {
@@ -239,7 +250,11 @@ func (idx *IndexClient) GetAll(ctx context.Context, r *KeyRange, values ...any) 
 	if err != nil {
 		return nil, grpcErr(err)
 	}
-	return structsToMaps(resp.GetRecords()), nil
+	records, err := RecordsFromProto(resp.GetRecords())
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal records: %w", err)
+	}
+	return records, nil
 }
 
 func (idx *IndexClient) GetAllKeys(ctx context.Context, r *KeyRange, values ...any) ([]string, error) {
@@ -298,14 +313,14 @@ func krToProto(r *KeyRange) (*proto.KeyRange, error) {
 	}
 	kr := &proto.KeyRange{LowerOpen: r.LowerOpen, UpperOpen: r.UpperOpen}
 	if r.Lower != nil {
-		v, err := structpb.NewValue(r.Lower)
+		v, err := TypedValueFromAny(r.Lower)
 		if err != nil {
 			return nil, fmt.Errorf("marshal key range lower: %w", err)
 		}
 		kr.Lower = v
 	}
 	if r.Upper != nil {
-		v, err := structpb.NewValue(r.Upper)
+		v, err := TypedValueFromAny(r.Upper)
 		if err != nil {
 			return nil, fmt.Errorf("marshal key range upper: %w", err)
 		}
@@ -314,24 +329,8 @@ func krToProto(r *KeyRange) (*proto.KeyRange, error) {
 	return kr, nil
 }
 
-func anyToProtoValues(values []any) ([]*structpb.Value, error) {
-	out := make([]*structpb.Value, len(values))
-	for i, v := range values {
-		pv, err := structpb.NewValue(v)
-		if err != nil {
-			return nil, fmt.Errorf("marshal value %d: %w", i, err)
-		}
-		out[i] = pv
-	}
-	return out, nil
-}
-
-func structsToMaps(ss []*structpb.Struct) []Record {
-	out := make([]Record, len(ss))
-	for i, s := range ss {
-		out[i] = s.AsMap()
-	}
-	return out
+func anyToProtoValues(values []any) ([]*proto.TypedValue, error) {
+	return TypedValuesFromAny(values)
 }
 
 func grpcErr(err error) error {

--- a/sdk/go/indexeddb_codec.go
+++ b/sdk/go/indexeddb_codec.go
@@ -1,0 +1,221 @@
+package gestalt
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"reflect"
+	"time"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var timeType = reflect.TypeOf(time.Time{})
+
+// TypedValueFromAny converts a Go value into the datastore typed proto form.
+func TypedValueFromAny(v any) (*proto.TypedValue, error) {
+	if v == nil {
+		return &proto.TypedValue{
+			Kind: &proto.TypedValue_NullValue{NullValue: structpb.NullValue_NULL_VALUE},
+		}, nil
+	}
+
+	switch value := v.(type) {
+	case time.Time:
+		return timestampToTypedValue(value)
+	case *time.Time:
+		if value == nil {
+			return &proto.TypedValue{
+				Kind: &proto.TypedValue_NullValue{NullValue: structpb.NullValue_NULL_VALUE},
+			}, nil
+		}
+		return timestampToTypedValue(*value)
+	case []byte:
+		return &proto.TypedValue{
+			Kind: &proto.TypedValue_BytesValue{BytesValue: append([]byte(nil), value...)},
+		}, nil
+	case json.Number:
+		if i, err := value.Int64(); err == nil {
+			return &proto.TypedValue{Kind: &proto.TypedValue_IntValue{IntValue: i}}, nil
+		}
+		f, err := value.Float64()
+		if err != nil {
+			return nil, fmt.Errorf("marshal json.Number %q: %w", value, err)
+		}
+		return &proto.TypedValue{Kind: &proto.TypedValue_FloatValue{FloatValue: f}}, nil
+	}
+
+	rv := reflect.ValueOf(v)
+	for rv.IsValid() && rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return &proto.TypedValue{
+				Kind: &proto.TypedValue_NullValue{NullValue: structpb.NullValue_NULL_VALUE},
+			}, nil
+		}
+		if rv.Type() == reflect.TypeOf(&time.Time{}) {
+			ts := rv.Interface().(*time.Time)
+			return timestampToTypedValue(*ts)
+		}
+		rv = rv.Elem()
+	}
+	if !rv.IsValid() {
+		return &proto.TypedValue{
+			Kind: &proto.TypedValue_NullValue{NullValue: structpb.NullValue_NULL_VALUE},
+		}, nil
+	}
+	if rv.Type() == timeType {
+		return timestampToTypedValue(rv.Interface().(time.Time))
+	}
+
+	switch rv.Kind() {
+	case reflect.String:
+		return &proto.TypedValue{Kind: &proto.TypedValue_StringValue{StringValue: rv.String()}}, nil
+	case reflect.Bool:
+		return &proto.TypedValue{Kind: &proto.TypedValue_BoolValue{BoolValue: rv.Bool()}}, nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return &proto.TypedValue{Kind: &proto.TypedValue_IntValue{IntValue: rv.Int()}}, nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		u := rv.Uint()
+		if u > math.MaxInt64 {
+			return nil, fmt.Errorf("marshal unsigned integer %d: overflows int64", u)
+		}
+		return &proto.TypedValue{Kind: &proto.TypedValue_IntValue{IntValue: int64(u)}}, nil
+	case reflect.Float32, reflect.Float64:
+		return &proto.TypedValue{Kind: &proto.TypedValue_FloatValue{FloatValue: rv.Float()}}, nil
+	}
+
+	jsonValue, err := structpb.NewValue(v)
+	if err != nil {
+		return nil, fmt.Errorf("marshal json value: %w", err)
+	}
+	return &proto.TypedValue{Kind: &proto.TypedValue_JsonValue{JsonValue: jsonValue}}, nil
+}
+
+// AnyFromTypedValue converts a datastore typed proto value back into the Go form.
+func AnyFromTypedValue(v *proto.TypedValue) (any, error) {
+	if v == nil || v.GetKind() == nil {
+		return nil, nil
+	}
+
+	switch kind := v.GetKind().(type) {
+	case *proto.TypedValue_NullValue:
+		return nil, nil
+	case *proto.TypedValue_StringValue:
+		return kind.StringValue, nil
+	case *proto.TypedValue_IntValue:
+		return kind.IntValue, nil
+	case *proto.TypedValue_FloatValue:
+		return kind.FloatValue, nil
+	case *proto.TypedValue_BoolValue:
+		return kind.BoolValue, nil
+	case *proto.TypedValue_TimeValue:
+		if kind.TimeValue == nil {
+			return nil, nil
+		}
+		if err := kind.TimeValue.CheckValid(); err != nil {
+			return nil, fmt.Errorf("unmarshal timestamp: %w", err)
+		}
+		return kind.TimeValue.AsTime(), nil
+	case *proto.TypedValue_BytesValue:
+		return append([]byte(nil), kind.BytesValue...), nil
+	case *proto.TypedValue_JsonValue:
+		if kind.JsonValue == nil {
+			return nil, nil
+		}
+		return kind.JsonValue.AsInterface(), nil
+	default:
+		return nil, fmt.Errorf("unmarshal typed value: unsupported kind %T", kind)
+	}
+}
+
+// TypedValuesFromAny converts index or key-range values into typed proto values.
+func TypedValuesFromAny(values []any) ([]*proto.TypedValue, error) {
+	out := make([]*proto.TypedValue, len(values))
+	for i, value := range values {
+		pbValue, err := TypedValueFromAny(value)
+		if err != nil {
+			return nil, fmt.Errorf("marshal value %d: %w", i, err)
+		}
+		out[i] = pbValue
+	}
+	return out, nil
+}
+
+// AnyFromTypedValues converts typed proto values back into Go values.
+func AnyFromTypedValues(values []*proto.TypedValue) ([]any, error) {
+	out := make([]any, len(values))
+	for i, value := range values {
+		goValue, err := AnyFromTypedValue(value)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshal value %d: %w", i, err)
+		}
+		out[i] = goValue
+	}
+	return out, nil
+}
+
+// RecordToProto converts a datastore record into the typed proto form.
+func RecordToProto(record Record) (*proto.Record, error) {
+	fields := make(map[string]*proto.TypedValue, len(record))
+	for key, value := range record {
+		pbValue, err := TypedValueFromAny(value)
+		if err != nil {
+			return nil, fmt.Errorf("marshal record field %q: %w", key, err)
+		}
+		fields[key] = pbValue
+	}
+	return &proto.Record{Fields: fields}, nil
+}
+
+// RecordFromProto converts a typed proto record into a datastore record.
+func RecordFromProto(record *proto.Record) (Record, error) {
+	if record == nil {
+		return nil, nil
+	}
+	fields := record.GetFields()
+	out := make(Record, len(fields))
+	for key, value := range fields {
+		goValue, err := AnyFromTypedValue(value)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshal record field %q: %w", key, err)
+		}
+		out[key] = goValue
+	}
+	return out, nil
+}
+
+// RecordsFromProto converts a slice of proto records into datastore records.
+func RecordsFromProto(records []*proto.Record) ([]Record, error) {
+	out := make([]Record, len(records))
+	for i, record := range records {
+		goRecord, err := RecordFromProto(record)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshal record %d: %w", i, err)
+		}
+		out[i] = goRecord
+	}
+	return out, nil
+}
+
+// RecordsToProto converts a slice of datastore records into proto records.
+func RecordsToProto(records []Record) ([]*proto.Record, error) {
+	out := make([]*proto.Record, len(records))
+	for i, record := range records {
+		pbRecord, err := RecordToProto(record)
+		if err != nil {
+			return nil, fmt.Errorf("marshal record %d: %w", i, err)
+		}
+		out[i] = pbRecord
+	}
+	return out, nil
+}
+
+func timestampToTypedValue(value time.Time) (*proto.TypedValue, error) {
+	timestamp := timestamppb.New(value)
+	if err := timestamp.CheckValid(); err != nil {
+		return nil, fmt.Errorf("marshal timestamp: %w", err)
+	}
+	return &proto.TypedValue{Kind: &proto.TypedValue_TimeValue{TimeValue: timestamp}}, nil
+}

--- a/sdk/go/indexeddb_codec_test.go
+++ b/sdk/go/indexeddb_codec_test.go
@@ -1,0 +1,167 @@
+package gestalt
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestTypedValueRoundTrip(t *testing.T) {
+	now := time.Date(2026, time.April, 11, 19, 4, 5, 123456000, time.UTC)
+
+	tests := []struct {
+		name  string
+		input any
+		check func(t *testing.T, got any)
+	}{
+		{
+			name:  "null",
+			input: nil,
+			check: func(t *testing.T, got any) {
+				if got != nil {
+					t.Fatalf("got %T %#v, want nil", got, got)
+				}
+			},
+		},
+		{
+			name:  "string",
+			input: "hello",
+			check: func(t *testing.T, got any) {
+				if got != "hello" {
+					t.Fatalf("got %v, want hello", got)
+				}
+			},
+		},
+		{
+			name:  "bool",
+			input: true,
+			check: func(t *testing.T, got any) {
+				if got != true {
+					t.Fatalf("got %v, want true", got)
+				}
+			},
+		},
+		{
+			name:  "int",
+			input: int(42),
+			check: func(t *testing.T, got any) {
+				if got != int64(42) {
+					t.Fatalf("got %T %#v, want int64(42)", got, got)
+				}
+			},
+		},
+		{
+			name:  "float",
+			input: 3.5,
+			check: func(t *testing.T, got any) {
+				if got != 3.5 {
+					t.Fatalf("got %v, want 3.5", got)
+				}
+			},
+		},
+		{
+			name:  "time",
+			input: now,
+			check: func(t *testing.T, got any) {
+				gotTime, ok := got.(time.Time)
+				if !ok {
+					t.Fatalf("got %T, want time.Time", got)
+				}
+				if !gotTime.Equal(now) {
+					t.Fatalf("got %v, want %v", gotTime, now)
+				}
+			},
+		},
+		{
+			name:  "bytes",
+			input: []byte("hello"),
+			check: func(t *testing.T, got any) {
+				gotBytes, ok := got.([]byte)
+				if !ok {
+					t.Fatalf("got %T, want []byte", got)
+				}
+				if !bytes.Equal(gotBytes, []byte("hello")) {
+					t.Fatalf("got %q, want %q", gotBytes, []byte("hello"))
+				}
+			},
+		},
+		{
+			name:  "json",
+			input: map[string]any{"items": []any{"one", float64(2), nil}},
+			check: func(t *testing.T, got any) {
+				want := map[string]any{"items": []any{"one", float64(2), nil}}
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("got %#v, want %#v", got, want)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pbValue, err := TypedValueFromAny(tt.input)
+			if err != nil {
+				t.Fatalf("TypedValueFromAny() error = %v", err)
+			}
+			got, err := AnyFromTypedValue(pbValue)
+			if err != nil {
+				t.Fatalf("AnyFromTypedValue() error = %v", err)
+			}
+			tt.check(t, got)
+		})
+	}
+}
+
+func TestRecordRoundTripPreservesTypes(t *testing.T) {
+	now := time.Date(2026, time.April, 11, 19, 4, 5, 123456000, time.UTC)
+	record := Record{
+		"id":        "conn_123",
+		"enabled":   true,
+		"attempts":  int32(3),
+		"score":     9.25,
+		"updatedAt": now,
+		"secret":    []byte("token"),
+		"meta": map[string]any{
+			"team": "platform",
+			"tags": []any{"oauth", float64(2)},
+		},
+	}
+
+	pbRecord, err := RecordToProto(record)
+	if err != nil {
+		t.Fatalf("RecordToProto() error = %v", err)
+	}
+	got, err := RecordFromProto(pbRecord)
+	if err != nil {
+		t.Fatalf("RecordFromProto() error = %v", err)
+	}
+
+	if got["id"] != "conn_123" {
+		t.Fatalf("id = %#v, want conn_123", got["id"])
+	}
+	if got["enabled"] != true {
+		t.Fatalf("enabled = %#v, want true", got["enabled"])
+	}
+	if got["attempts"] != int64(3) {
+		t.Fatalf("attempts = %T %#v, want int64(3)", got["attempts"], got["attempts"])
+	}
+	if got["score"] != 9.25 {
+		t.Fatalf("score = %#v, want 9.25", got["score"])
+	}
+	gotTime, ok := got["updatedAt"].(time.Time)
+	if !ok || !gotTime.Equal(now) {
+		t.Fatalf("updatedAt = %#v, want %v", got["updatedAt"], now)
+	}
+	gotBytes, ok := got["secret"].([]byte)
+	if !ok || !bytes.Equal(gotBytes, []byte("token")) {
+		t.Fatalf("secret = %#v, want []byte(\"token\")", got["secret"])
+	}
+	wantMeta := map[string]any{
+		"team": "platform",
+		"tags": []any{"oauth", float64(2)},
+	}
+	if !reflect.DeepEqual(got["meta"], wantMeta) {
+		t.Fatalf("meta = %#v, want %#v", got["meta"], wantMeta)
+	}
+}

--- a/sdk/proto/v1/datastore.proto
+++ b/sdk/proto/v1/datastore.proto
@@ -6,6 +6,24 @@ option go_package = "github.com/valon-technologies/gestalt/sdk/go/gen/v1;proto";
 
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
+message TypedValue {
+  oneof kind {
+    google.protobuf.NullValue null_value = 1;
+    string string_value = 2;
+    int64 int_value = 3;
+    double float_value = 4;
+    bool bool_value = 5;
+    google.protobuf.Timestamp time_value = 6;
+    bytes bytes_value = 7;
+    google.protobuf.Value json_value = 8;
+  }
+}
+
+message Record {
+  map<string, TypedValue> fields = 1;
+}
 
 message ObjectStoreSchema {
   repeated IndexSchema indexes = 1;
@@ -27,23 +45,23 @@ message ColumnDef {
 }
 
 message KeyRange {
-  google.protobuf.Value lower = 1;
-  google.protobuf.Value upper = 2;
+  TypedValue lower = 1;
+  TypedValue upper = 2;
   bool lower_open = 3;
   bool upper_open = 4;
 }
 
 message RecordRequest {
   string store = 1;
-  google.protobuf.Struct record = 2;
+  Record record = 2;
 }
 
 message RecordResponse {
-  google.protobuf.Struct record = 1;
+  Record record = 1;
 }
 
 message RecordsResponse {
-  repeated google.protobuf.Struct records = 1;
+  repeated Record records = 1;
 }
 
 message KeysResponse {
@@ -76,7 +94,7 @@ message DeleteObjectStoreRequest {
 message IndexQueryRequest {
   string store = 1;
   string index = 2;
-  repeated google.protobuf.Value values = 3;
+  repeated TypedValue values = 3;
   optional KeyRange range = 4;
 }
 

--- a/sdk/python/gestalt/_indexeddb.py
+++ b/sdk/python/gestalt/_indexeddb.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import datetime as _dt
 import os
 from dataclasses import dataclass, field
 from typing import Any
 
 import grpc
 from google.protobuf import struct_pb2 as _struct_pb2
+from google.protobuf import timestamp_pb2 as _timestamp_pb2
 
 from .gen.v1 import datastore_pb2 as _pb
 from .gen.v1 import datastore_pb2_grpc as _pb_grpc
@@ -13,6 +15,7 @@ from .gen.v1 import datastore_pb2_grpc as _pb_grpc
 pb: Any = _pb
 pb_grpc: Any = _pb_grpc
 struct_pb2: Any = _struct_pb2
+timestamp_pb2: Any = _timestamp_pb2
 
 ENV_INDEXEDDB_SOCKET = "GESTALT_INDEXEDDB_SOCKET"
 
@@ -85,17 +88,17 @@ class ObjectStore:
 
     def get(self, id: str) -> dict[str, Any]:
         resp = _grpc_call(self._stub.Get, pb.ObjectStoreRequest(store=self._store, id=id))
-        return _struct_to_dict(resp.record)
+        return _record_to_dict(resp.record)
 
     def get_key(self, id: str) -> str:
         resp = _grpc_call(self._stub.GetKey, pb.ObjectStoreRequest(store=self._store, id=id))
         return resp.key
 
     def add(self, record: dict[str, Any]) -> None:
-        _grpc_call(self._stub.Add, pb.RecordRequest(store=self._store, record=_dict_to_struct(record)))
+        _grpc_call(self._stub.Add, pb.RecordRequest(store=self._store, record=_dict_to_record(record)))
 
     def put(self, record: dict[str, Any]) -> None:
-        _grpc_call(self._stub.Put, pb.RecordRequest(store=self._store, record=_dict_to_struct(record)))
+        _grpc_call(self._stub.Put, pb.RecordRequest(store=self._store, record=_dict_to_record(record)))
 
     def delete(self, id: str) -> None:
         _grpc_call(self._stub.Delete, pb.ObjectStoreRequest(store=self._store, id=id))
@@ -108,7 +111,7 @@ class ObjectStore:
             self._stub.GetAll,
             pb.ObjectStoreRangeRequest(store=self._store, range=_kr_to_proto(key_range)),
         )
-        return [_struct_to_dict(r) for r in resp.records]
+        return [_record_to_dict(r) for r in resp.records]
 
     def get_all_keys(self, key_range: KeyRange | None = None) -> list[str]:
         resp = _grpc_call(
@@ -143,7 +146,7 @@ class Index:
 
     def get(self, *values: Any) -> dict[str, Any]:
         resp = _grpc_call(self._stub.IndexGet, self._req(values))
-        return _struct_to_dict(resp.record)
+        return _record_to_dict(resp.record)
 
     def get_key(self, *values: Any) -> str:
         resp = _grpc_call(self._stub.IndexGetKey, self._req(values))
@@ -151,7 +154,7 @@ class Index:
 
     def get_all(self, *values: Any, key_range: KeyRange | None = None) -> list[dict[str, Any]]:
         resp = _grpc_call(self._stub.IndexGetAll, self._req(values, key_range))
-        return [_struct_to_dict(r) for r in resp.records]
+        return [_record_to_dict(r) for r in resp.records]
 
     def get_all_keys(self, *values: Any, key_range: KeyRange | None = None) -> list[str]:
         resp = _grpc_call(self._stub.IndexGetAllKeys, self._req(values, key_range))
@@ -189,37 +192,113 @@ def _grpc_call(method: Any, request: Any) -> Any:
         raise
 
 
-def _dict_to_struct(d: dict[str, Any]) -> Any:
-    s = struct_pb2.Struct()
-    s.update(d)
-    return s
+def _dict_to_record(d: dict[str, Any]) -> Any:
+    record = pb.Record()
+    for key, value in d.items():
+        record.fields[key].CopyFrom(_to_typed_value(value))
+    return record
 
 
-def _struct_to_dict(s: Any) -> dict[str, Any]:
-    return dict(s)
+def _record_to_dict(record: Any) -> dict[str, Any]:
+    return {key: _typed_value_to_python(value) for key, value in record.fields.items()}
 
 
-def _to_proto_value(v: Any) -> Any:
-    val = struct_pb2.Value()
+def _to_typed_value(v: Any) -> Any:
+    val = pb.TypedValue()
     if v is None:
         val.null_value = 0
     elif isinstance(v, bool):
         val.bool_value = v
-    elif isinstance(v, (int, float)):
-        val.number_value = float(v)
+    elif isinstance(v, int) and not isinstance(v, bool):
+        val.int_value = v
+    elif isinstance(v, float):
+        val.float_value = v
     elif isinstance(v, str):
         val.string_value = v
+    elif isinstance(v, (bytes, bytearray, memoryview)):
+        val.bytes_value = bytes(v)
+    elif isinstance(v, _dt.datetime):
+        timestamp = timestamp_pb2.Timestamp()
+        dt = v if v.tzinfo is not None else v.replace(tzinfo=_dt.timezone.utc)
+        timestamp.FromDatetime(dt.astimezone(_dt.timezone.utc))
+        val.time_value.CopyFrom(timestamp)
     else:
-        val.string_value = str(v)
+        val.json_value.CopyFrom(_to_json_value(v))
     return val
+
+
+def _typed_value_to_python(v: Any) -> Any:
+    kind = v.WhichOneof("kind")
+    if kind in (None, "null_value"):
+        return None
+    if kind == "string_value":
+        return v.string_value
+    if kind == "int_value":
+        return v.int_value
+    if kind == "float_value":
+        return v.float_value
+    if kind == "bool_value":
+        return v.bool_value
+    if kind == "time_value":
+        return _dt.datetime.fromtimestamp(
+            v.time_value.seconds + (v.time_value.nanos / 1_000_000_000),
+            tz=_dt.timezone.utc,
+        )
+    if kind == "bytes_value":
+        return bytes(v.bytes_value)
+    if kind == "json_value":
+        return _json_value_to_python(v.json_value)
+    raise TypeError(f"unsupported typed value kind: {kind}")
+
+
+def _to_json_value(v: Any) -> Any:
+    value = struct_pb2.Value()
+    if v is None:
+        value.null_value = 0
+    elif isinstance(v, bool):
+        value.bool_value = v
+    elif isinstance(v, (int, float)) and not isinstance(v, bool):
+        value.number_value = float(v)
+    elif isinstance(v, str):
+        value.string_value = v
+    elif isinstance(v, dict):
+        struct = struct_pb2.Struct()
+        for key, inner in v.items():
+            struct.fields[key].CopyFrom(_to_json_value(inner))
+        value.struct_value.CopyFrom(struct)
+    elif isinstance(v, (list, tuple)):
+        list_value = struct_pb2.ListValue()
+        for inner in v:
+            list_value.values.append(_to_json_value(inner))
+        value.list_value.CopyFrom(list_value)
+    else:
+        raise TypeError(f"unsupported JSON value type: {type(v)!r}")
+    return value
+
+
+def _json_value_to_python(v: Any) -> Any:
+    kind = v.WhichOneof("kind")
+    if kind in (None, "null_value"):
+        return None
+    if kind == "number_value":
+        return v.number_value
+    if kind == "string_value":
+        return v.string_value
+    if kind == "bool_value":
+        return v.bool_value
+    if kind == "struct_value":
+        return {key: _json_value_to_python(value) for key, value in v.struct_value.fields.items()}
+    if kind == "list_value":
+        return [_json_value_to_python(value) for value in v.list_value.values]
+    raise TypeError(f"unsupported JSON value kind: {kind}")
 
 
 def _kr_to_proto(kr: KeyRange | None) -> Any:
     if kr is None:
         return None
     return pb.KeyRange(
-        lower=_to_proto_value(kr.lower) if kr.lower is not None else None,
-        upper=_to_proto_value(kr.upper) if kr.upper is not None else None,
+        lower=_to_typed_value(kr.lower) if kr.lower is not None else None,
+        upper=_to_typed_value(kr.upper) if kr.upper is not None else None,
         lower_open=kr.lower_open,
         upper_open=kr.upper_open,
     )

--- a/sdk/python/gestalt/gen/v1/datastore_pb2.py
+++ b/sdk/python/gestalt/gen/v1/datastore_pb2.py
@@ -24,9 +24,10 @@ _sym_db = _symbol_database.Default()
 
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
+from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x12v1/datastore.proto\x12\x13gestalt.provider.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1cgoogle/protobuf/struct.proto\"\x89\x01\n\x11ObjectStoreSchema\x12:\n\x07indexes\x18\x01 \x03(\x0b\x32 .gestalt.provider.v1.IndexSchemaR\x07indexes\x12\x38\n\x07\x63olumns\x18\x02 \x03(\x0b\x32\x1e.gestalt.provider.v1.ColumnDefR\x07\x63olumns\"T\n\x0bIndexSchema\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x19\n\x08key_path\x18\x02 \x03(\tR\x07keyPath\x12\x16\n\x06unique\x18\x03 \x01(\x08R\x06unique\"\x87\x01\n\tColumnDef\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n\x04type\x18\x02 \x01(\x05R\x04type\x12\x1f\n\x0bprimary_key\x18\x03 \x01(\x08R\nprimaryKey\x12\x19\n\x08not_null\x18\x04 \x01(\x08R\x07notNull\x12\x16\n\x06unique\x18\x05 \x01(\x08R\x06unique\"\xa4\x01\n\x08KeyRange\x12,\n\x05lower\x18\x01 \x01(\x0b\x32\x16.google.protobuf.ValueR\x05lower\x12,\n\x05upper\x18\x02 \x01(\x0b\x32\x16.google.protobuf.ValueR\x05upper\x12\x1d\n\nlower_open\x18\x03 \x01(\x08R\tlowerOpen\x12\x1d\n\nupper_open\x18\x04 \x01(\x08R\tupperOpen\"V\n\rRecordRequest\x12\x14\n\x05store\x18\x01 \x01(\tR\x05store\x12/\n\x06record\x18\x02 \x01(\x0b\x32\x17.google.protobuf.StructR\x06record\"A\n\x0eRecordResponse\x12/\n\x06record\x18\x01 \x01(\x0b\x32\x17.google.protobuf.StructR\x06record\"D\n\x0fRecordsResponse\x12\x31\n\x07records\x18\x01 \x03(\x0b\x32\x17.google.protobuf.StructR\x07records\"\"\n\x0cKeysResponse\x12\x12\n\x04keys\x18\x01 \x03(\tR\x04keys\":\n\x12ObjectStoreRequest\x12\x14\n\x05store\x18\x01 \x01(\tR\x05store\x12\x0e\n\x02id\x18\x02 \x01(\tR\x02id\".\n\x16ObjectStoreNameRequest\x12\x14\n\x05store\x18\x01 \x01(\tR\x05store\"s\n\x17ObjectStoreRangeRequest\x12\x14\n\x05store\x18\x01 \x01(\tR\x05store\x12\x38\n\x05range\x18\x02 \x01(\x0b\x32\x1d.gestalt.provider.v1.KeyRangeH\x00R\x05range\x88\x01\x01\x42\x08\n\x06_range\"n\n\x18\x43reateObjectStoreRequest\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12>\n\x06schema\x18\x02 \x01(\x0b\x32&.gestalt.provider.v1.ObjectStoreSchemaR\x06schema\".\n\x18\x44\x65leteObjectStoreRequest\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\"\xb3\x01\n\x11IndexQueryRequest\x12\x14\n\x05store\x18\x01 \x01(\tR\x05store\x12\x14\n\x05index\x18\x02 \x01(\tR\x05index\x12.\n\x06values\x18\x03 \x03(\x0b\x32\x16.google.protobuf.ValueR\x06values\x12\x38\n\x05range\x18\x04 \x01(\x0b\x32\x1d.gestalt.provider.v1.KeyRangeH\x00R\x05range\x88\x01\x01\x42\x08\n\x06_range\"%\n\rCountResponse\x12\x14\n\x05\x63ount\x18\x01 \x01(\x03R\x05\x63ount\"*\n\x0e\x44\x65leteResponse\x12\x18\n\x07\x64\x65leted\x18\x01 \x01(\x03R\x07\x64\x65leted\"\x1f\n\x0bKeyResponse\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key2\xa9\x0c\n\tIndexedDB\x12Z\n\x11\x43reateObjectStore\x12-.gestalt.provider.v1.CreateObjectStoreRequest\x1a\x16.google.protobuf.Empty\x12Z\n\x11\x44\x65leteObjectStore\x12-.gestalt.provider.v1.DeleteObjectStoreRequest\x1a\x16.google.protobuf.Empty\x12S\n\x03Get\x12\'.gestalt.provider.v1.ObjectStoreRequest\x1a#.gestalt.provider.v1.RecordResponse\x12S\n\x06GetKey\x12\'.gestalt.provider.v1.ObjectStoreRequest\x1a .gestalt.provider.v1.KeyResponse\x12\x41\n\x03\x41\x64\x64\x12\".gestalt.provider.v1.RecordRequest\x1a\x16.google.protobuf.Empty\x12\x41\n\x03Put\x12\".gestalt.provider.v1.RecordRequest\x1a\x16.google.protobuf.Empty\x12I\n\x06\x44\x65lete\x12\'.gestalt.provider.v1.ObjectStoreRequest\x1a\x16.google.protobuf.Empty\x12L\n\x05\x43lear\x12+.gestalt.provider.v1.ObjectStoreNameRequest\x1a\x16.google.protobuf.Empty\x12\\\n\x06GetAll\x12,.gestalt.provider.v1.ObjectStoreRangeRequest\x1a$.gestalt.provider.v1.RecordsResponse\x12]\n\nGetAllKeys\x12,.gestalt.provider.v1.ObjectStoreRangeRequest\x1a!.gestalt.provider.v1.KeysResponse\x12Y\n\x05\x43ount\x12,.gestalt.provider.v1.ObjectStoreRangeRequest\x1a\".gestalt.provider.v1.CountResponse\x12`\n\x0b\x44\x65leteRange\x12,.gestalt.provider.v1.ObjectStoreRangeRequest\x1a#.gestalt.provider.v1.DeleteResponse\x12W\n\x08IndexGet\x12&.gestalt.provider.v1.IndexQueryRequest\x1a#.gestalt.provider.v1.RecordResponse\x12W\n\x0bIndexGetKey\x12&.gestalt.provider.v1.IndexQueryRequest\x1a .gestalt.provider.v1.KeyResponse\x12[\n\x0bIndexGetAll\x12&.gestalt.provider.v1.IndexQueryRequest\x1a$.gestalt.provider.v1.RecordsResponse\x12\\\n\x0fIndexGetAllKeys\x12&.gestalt.provider.v1.IndexQueryRequest\x1a!.gestalt.provider.v1.KeysResponse\x12X\n\nIndexCount\x12&.gestalt.provider.v1.IndexQueryRequest\x1a\".gestalt.provider.v1.CountResponse\x12Z\n\x0bIndexDelete\x12&.gestalt.provider.v1.IndexQueryRequest\x1a#.gestalt.provider.v1.DeleteResponseB;Z9github.com/valon-technologies/gestalt/sdk/go/gen/v1;protob\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x12v1/datastore.proto\x12\x13gestalt.provider.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xf2\x02\n\nTypedValue\x12;\n\nnull_value\x18\x01 \x01(\x0e\x32\x1a.google.protobuf.NullValueH\x00R\tnullValue\x12#\n\x0cstring_value\x18\x02 \x01(\tH\x00R\x0bstringValue\x12\x1d\n\tint_value\x18\x03 \x01(\x03H\x00R\x08intValue\x12!\n\x0b\x66loat_value\x18\x04 \x01(\x01H\x00R\nfloatValue\x12\x1f\n\nbool_value\x18\x05 \x01(\x08H\x00R\tboolValue\x12;\n\ntime_value\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.TimestampH\x00R\ttimeValue\x12!\n\x0b\x62ytes_value\x18\x07 \x01(\x0cH\x00R\nbytesValue\x12\x37\n\njson_value\x18\x08 \x01(\x0b\x32\x16.google.protobuf.ValueH\x00R\tjsonValueB\x06\n\x04kind\"\xa5\x01\n\x06Record\x12?\n\x06\x66ields\x18\x01 \x03(\x0b\x32\'.gestalt.provider.v1.Record.FieldsEntryR\x06\x66ields\x1aZ\n\x0b\x46ieldsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x35\n\x05value\x18\x02 \x01(\x0b\x32\x1f.gestalt.provider.v1.TypedValueR\x05value:\x02\x38\x01\"\x89\x01\n\x11ObjectStoreSchema\x12:\n\x07indexes\x18\x01 \x03(\x0b\x32 .gestalt.provider.v1.IndexSchemaR\x07indexes\x12\x38\n\x07\x63olumns\x18\x02 \x03(\x0b\x32\x1e.gestalt.provider.v1.ColumnDefR\x07\x63olumns\"T\n\x0bIndexSchema\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x19\n\x08key_path\x18\x02 \x03(\tR\x07keyPath\x12\x16\n\x06unique\x18\x03 \x01(\x08R\x06unique\"\x87\x01\n\tColumnDef\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n\x04type\x18\x02 \x01(\x05R\x04type\x12\x1f\n\x0bprimary_key\x18\x03 \x01(\x08R\nprimaryKey\x12\x19\n\x08not_null\x18\x04 \x01(\x08R\x07notNull\x12\x16\n\x06unique\x18\x05 \x01(\x08R\x06unique\"\xb6\x01\n\x08KeyRange\x12\x35\n\x05lower\x18\x01 \x01(\x0b\x32\x1f.gestalt.provider.v1.TypedValueR\x05lower\x12\x35\n\x05upper\x18\x02 \x01(\x0b\x32\x1f.gestalt.provider.v1.TypedValueR\x05upper\x12\x1d\n\nlower_open\x18\x03 \x01(\x08R\tlowerOpen\x12\x1d\n\nupper_open\x18\x04 \x01(\x08R\tupperOpen\"Z\n\rRecordRequest\x12\x14\n\x05store\x18\x01 \x01(\tR\x05store\x12\x33\n\x06record\x18\x02 \x01(\x0b\x32\x1b.gestalt.provider.v1.RecordR\x06record\"E\n\x0eRecordResponse\x12\x33\n\x06record\x18\x01 \x01(\x0b\x32\x1b.gestalt.provider.v1.RecordR\x06record\"H\n\x0fRecordsResponse\x12\x35\n\x07records\x18\x01 \x03(\x0b\x32\x1b.gestalt.provider.v1.RecordR\x07records\"\"\n\x0cKeysResponse\x12\x12\n\x04keys\x18\x01 \x03(\tR\x04keys\":\n\x12ObjectStoreRequest\x12\x14\n\x05store\x18\x01 \x01(\tR\x05store\x12\x0e\n\x02id\x18\x02 \x01(\tR\x02id\".\n\x16ObjectStoreNameRequest\x12\x14\n\x05store\x18\x01 \x01(\tR\x05store\"s\n\x17ObjectStoreRangeRequest\x12\x14\n\x05store\x18\x01 \x01(\tR\x05store\x12\x38\n\x05range\x18\x02 \x01(\x0b\x32\x1d.gestalt.provider.v1.KeyRangeH\x00R\x05range\x88\x01\x01\x42\x08\n\x06_range\"n\n\x18\x43reateObjectStoreRequest\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12>\n\x06schema\x18\x02 \x01(\x0b\x32&.gestalt.provider.v1.ObjectStoreSchemaR\x06schema\".\n\x18\x44\x65leteObjectStoreRequest\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\"\xbc\x01\n\x11IndexQueryRequest\x12\x14\n\x05store\x18\x01 \x01(\tR\x05store\x12\x14\n\x05index\x18\x02 \x01(\tR\x05index\x12\x37\n\x06values\x18\x03 \x03(\x0b\x32\x1f.gestalt.provider.v1.TypedValueR\x06values\x12\x38\n\x05range\x18\x04 \x01(\x0b\x32\x1d.gestalt.provider.v1.KeyRangeH\x00R\x05range\x88\x01\x01\x42\x08\n\x06_range\"%\n\rCountResponse\x12\x14\n\x05\x63ount\x18\x01 \x01(\x03R\x05\x63ount\"*\n\x0e\x44\x65leteResponse\x12\x18\n\x07\x64\x65leted\x18\x01 \x01(\x03R\x07\x64\x65leted\"\x1f\n\x0bKeyResponse\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key2\xa9\x0c\n\tIndexedDB\x12Z\n\x11\x43reateObjectStore\x12-.gestalt.provider.v1.CreateObjectStoreRequest\x1a\x16.google.protobuf.Empty\x12Z\n\x11\x44\x65leteObjectStore\x12-.gestalt.provider.v1.DeleteObjectStoreRequest\x1a\x16.google.protobuf.Empty\x12S\n\x03Get\x12\'.gestalt.provider.v1.ObjectStoreRequest\x1a#.gestalt.provider.v1.RecordResponse\x12S\n\x06GetKey\x12\'.gestalt.provider.v1.ObjectStoreRequest\x1a .gestalt.provider.v1.KeyResponse\x12\x41\n\x03\x41\x64\x64\x12\".gestalt.provider.v1.RecordRequest\x1a\x16.google.protobuf.Empty\x12\x41\n\x03Put\x12\".gestalt.provider.v1.RecordRequest\x1a\x16.google.protobuf.Empty\x12I\n\x06\x44\x65lete\x12\'.gestalt.provider.v1.ObjectStoreRequest\x1a\x16.google.protobuf.Empty\x12L\n\x05\x43lear\x12+.gestalt.provider.v1.ObjectStoreNameRequest\x1a\x16.google.protobuf.Empty\x12\\\n\x06GetAll\x12,.gestalt.provider.v1.ObjectStoreRangeRequest\x1a$.gestalt.provider.v1.RecordsResponse\x12]\n\nGetAllKeys\x12,.gestalt.provider.v1.ObjectStoreRangeRequest\x1a!.gestalt.provider.v1.KeysResponse\x12Y\n\x05\x43ount\x12,.gestalt.provider.v1.ObjectStoreRangeRequest\x1a\".gestalt.provider.v1.CountResponse\x12`\n\x0b\x44\x65leteRange\x12,.gestalt.provider.v1.ObjectStoreRangeRequest\x1a#.gestalt.provider.v1.DeleteResponse\x12W\n\x08IndexGet\x12&.gestalt.provider.v1.IndexQueryRequest\x1a#.gestalt.provider.v1.RecordResponse\x12W\n\x0bIndexGetKey\x12&.gestalt.provider.v1.IndexQueryRequest\x1a .gestalt.provider.v1.KeyResponse\x12[\n\x0bIndexGetAll\x12&.gestalt.provider.v1.IndexQueryRequest\x1a$.gestalt.provider.v1.RecordsResponse\x12\\\n\x0fIndexGetAllKeys\x12&.gestalt.provider.v1.IndexQueryRequest\x1a!.gestalt.provider.v1.KeysResponse\x12X\n\nIndexCount\x12&.gestalt.provider.v1.IndexQueryRequest\x1a\".gestalt.provider.v1.CountResponse\x12Z\n\x0bIndexDelete\x12&.gestalt.provider.v1.IndexQueryRequest\x1a#.gestalt.provider.v1.DeleteResponseB;Z9github.com/valon-technologies/gestalt/sdk/go/gen/v1;protob\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -34,40 +35,48 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'v1.datastore_pb2', _globals
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'Z9github.com/valon-technologies/gestalt/sdk/go/gen/v1;proto'
-  _globals['_OBJECTSTORESCHEMA']._serialized_start=103
-  _globals['_OBJECTSTORESCHEMA']._serialized_end=240
-  _globals['_INDEXSCHEMA']._serialized_start=242
-  _globals['_INDEXSCHEMA']._serialized_end=326
-  _globals['_COLUMNDEF']._serialized_start=329
-  _globals['_COLUMNDEF']._serialized_end=464
-  _globals['_KEYRANGE']._serialized_start=467
-  _globals['_KEYRANGE']._serialized_end=631
-  _globals['_RECORDREQUEST']._serialized_start=633
-  _globals['_RECORDREQUEST']._serialized_end=719
-  _globals['_RECORDRESPONSE']._serialized_start=721
-  _globals['_RECORDRESPONSE']._serialized_end=786
-  _globals['_RECORDSRESPONSE']._serialized_start=788
-  _globals['_RECORDSRESPONSE']._serialized_end=856
-  _globals['_KEYSRESPONSE']._serialized_start=858
-  _globals['_KEYSRESPONSE']._serialized_end=892
-  _globals['_OBJECTSTOREREQUEST']._serialized_start=894
-  _globals['_OBJECTSTOREREQUEST']._serialized_end=952
-  _globals['_OBJECTSTORENAMEREQUEST']._serialized_start=954
-  _globals['_OBJECTSTORENAMEREQUEST']._serialized_end=1000
-  _globals['_OBJECTSTORERANGEREQUEST']._serialized_start=1002
-  _globals['_OBJECTSTORERANGEREQUEST']._serialized_end=1117
-  _globals['_CREATEOBJECTSTOREREQUEST']._serialized_start=1119
-  _globals['_CREATEOBJECTSTOREREQUEST']._serialized_end=1229
-  _globals['_DELETEOBJECTSTOREREQUEST']._serialized_start=1231
-  _globals['_DELETEOBJECTSTOREREQUEST']._serialized_end=1277
-  _globals['_INDEXQUERYREQUEST']._serialized_start=1280
-  _globals['_INDEXQUERYREQUEST']._serialized_end=1459
-  _globals['_COUNTRESPONSE']._serialized_start=1461
-  _globals['_COUNTRESPONSE']._serialized_end=1498
-  _globals['_DELETERESPONSE']._serialized_start=1500
-  _globals['_DELETERESPONSE']._serialized_end=1542
-  _globals['_KEYRESPONSE']._serialized_start=1544
-  _globals['_KEYRESPONSE']._serialized_end=1575
-  _globals['_INDEXEDDB']._serialized_start=1578
-  _globals['_INDEXEDDB']._serialized_end=3155
+  _globals['_RECORD_FIELDSENTRY']._loaded_options = None
+  _globals['_RECORD_FIELDSENTRY']._serialized_options = b'8\001'
+  _globals['_TYPEDVALUE']._serialized_start=136
+  _globals['_TYPEDVALUE']._serialized_end=506
+  _globals['_RECORD']._serialized_start=509
+  _globals['_RECORD']._serialized_end=674
+  _globals['_RECORD_FIELDSENTRY']._serialized_start=584
+  _globals['_RECORD_FIELDSENTRY']._serialized_end=674
+  _globals['_OBJECTSTORESCHEMA']._serialized_start=677
+  _globals['_OBJECTSTORESCHEMA']._serialized_end=814
+  _globals['_INDEXSCHEMA']._serialized_start=816
+  _globals['_INDEXSCHEMA']._serialized_end=900
+  _globals['_COLUMNDEF']._serialized_start=903
+  _globals['_COLUMNDEF']._serialized_end=1038
+  _globals['_KEYRANGE']._serialized_start=1041
+  _globals['_KEYRANGE']._serialized_end=1223
+  _globals['_RECORDREQUEST']._serialized_start=1225
+  _globals['_RECORDREQUEST']._serialized_end=1315
+  _globals['_RECORDRESPONSE']._serialized_start=1317
+  _globals['_RECORDRESPONSE']._serialized_end=1386
+  _globals['_RECORDSRESPONSE']._serialized_start=1388
+  _globals['_RECORDSRESPONSE']._serialized_end=1460
+  _globals['_KEYSRESPONSE']._serialized_start=1462
+  _globals['_KEYSRESPONSE']._serialized_end=1496
+  _globals['_OBJECTSTOREREQUEST']._serialized_start=1498
+  _globals['_OBJECTSTOREREQUEST']._serialized_end=1556
+  _globals['_OBJECTSTORENAMEREQUEST']._serialized_start=1558
+  _globals['_OBJECTSTORENAMEREQUEST']._serialized_end=1604
+  _globals['_OBJECTSTORERANGEREQUEST']._serialized_start=1606
+  _globals['_OBJECTSTORERANGEREQUEST']._serialized_end=1721
+  _globals['_CREATEOBJECTSTOREREQUEST']._serialized_start=1723
+  _globals['_CREATEOBJECTSTOREREQUEST']._serialized_end=1833
+  _globals['_DELETEOBJECTSTOREREQUEST']._serialized_start=1835
+  _globals['_DELETEOBJECTSTOREREQUEST']._serialized_end=1881
+  _globals['_INDEXQUERYREQUEST']._serialized_start=1884
+  _globals['_INDEXQUERYREQUEST']._serialized_end=2072
+  _globals['_COUNTRESPONSE']._serialized_start=2074
+  _globals['_COUNTRESPONSE']._serialized_end=2111
+  _globals['_DELETERESPONSE']._serialized_start=2113
+  _globals['_DELETERESPONSE']._serialized_end=2155
+  _globals['_KEYRESPONSE']._serialized_start=2157
+  _globals['_KEYRESPONSE']._serialized_end=2188
+  _globals['_INDEXEDDB']._serialized_start=2191
+  _globals['_INDEXEDDB']._serialized_end=3768
 # @@protoc_insertion_point(module_scope)

--- a/sdk/typescript/gen/v1/datastore_pb.ts
+++ b/sdk/typescript/gen/v1/datastore_pb.ts
@@ -4,15 +4,97 @@
 
 import type { GenFile, GenMessage, GenService } from "@bufbuild/protobuf/codegenv2";
 import { fileDesc, messageDesc, serviceDesc } from "@bufbuild/protobuf/codegenv2";
-import type { EmptySchema, Value } from "@bufbuild/protobuf/wkt";
-import { file_google_protobuf_empty, file_google_protobuf_struct } from "@bufbuild/protobuf/wkt";
-import type { JsonObject, Message } from "@bufbuild/protobuf";
+import type { EmptySchema, NullValue, Timestamp, Value } from "@bufbuild/protobuf/wkt";
+import { file_google_protobuf_empty, file_google_protobuf_struct, file_google_protobuf_timestamp } from "@bufbuild/protobuf/wkt";
+import type { Message } from "@bufbuild/protobuf";
 
 /**
  * Describes the file v1/datastore.proto.
  */
 export const file_v1_datastore: GenFile = /*@__PURE__*/
-  fileDesc("ChJ2MS9kYXRhc3RvcmUucHJvdG8SE2dlc3RhbHQucHJvdmlkZXIudjEidwoRT2JqZWN0U3RvcmVTY2hlbWESMQoHaW5kZXhlcxgBIAMoCzIgLmdlc3RhbHQucHJvdmlkZXIudjEuSW5kZXhTY2hlbWESLwoHY29sdW1ucxgCIAMoCzIeLmdlc3RhbHQucHJvdmlkZXIudjEuQ29sdW1uRGVmIj0KC0luZGV4U2NoZW1hEgwKBG5hbWUYASABKAkSEAoIa2V5X3BhdGgYAiADKAkSDgoGdW5pcXVlGAMgASgIIl4KCUNvbHVtbkRlZhIMCgRuYW1lGAEgASgJEgwKBHR5cGUYAiABKAUSEwoLcHJpbWFyeV9rZXkYAyABKAgSEAoIbm90X251bGwYBCABKAgSDgoGdW5pcXVlGAUgASgIIoABCghLZXlSYW5nZRIlCgVsb3dlchgBIAEoCzIWLmdvb2dsZS5wcm90b2J1Zi5WYWx1ZRIlCgV1cHBlchgCIAEoCzIWLmdvb2dsZS5wcm90b2J1Zi5WYWx1ZRISCgpsb3dlcl9vcGVuGAMgASgIEhIKCnVwcGVyX29wZW4YBCABKAgiRwoNUmVjb3JkUmVxdWVzdBINCgVzdG9yZRgBIAEoCRInCgZyZWNvcmQYAiABKAsyFy5nb29nbGUucHJvdG9idWYuU3RydWN0IjkKDlJlY29yZFJlc3BvbnNlEicKBnJlY29yZBgBIAEoCzIXLmdvb2dsZS5wcm90b2J1Zi5TdHJ1Y3QiOwoPUmVjb3Jkc1Jlc3BvbnNlEigKB3JlY29yZHMYASADKAsyFy5nb29nbGUucHJvdG9idWYuU3RydWN0IhwKDEtleXNSZXNwb25zZRIMCgRrZXlzGAEgAygJIi8KEk9iamVjdFN0b3JlUmVxdWVzdBINCgVzdG9yZRgBIAEoCRIKCgJpZBgCIAEoCSInChZPYmplY3RTdG9yZU5hbWVSZXF1ZXN0Eg0KBXN0b3JlGAEgASgJImUKF09iamVjdFN0b3JlUmFuZ2VSZXF1ZXN0Eg0KBXN0b3JlGAEgASgJEjEKBXJhbmdlGAIgASgLMh0uZ2VzdGFsdC5wcm92aWRlci52MS5LZXlSYW5nZUgAiAEBQggKBl9yYW5nZSJgChhDcmVhdGVPYmplY3RTdG9yZVJlcXVlc3QSDAoEbmFtZRgBIAEoCRI2CgZzY2hlbWEYAiABKAsyJi5nZXN0YWx0LnByb3ZpZGVyLnYxLk9iamVjdFN0b3JlU2NoZW1hIigKGERlbGV0ZU9iamVjdFN0b3JlUmVxdWVzdBIMCgRuYW1lGAEgASgJIpYBChFJbmRleFF1ZXJ5UmVxdWVzdBINCgVzdG9yZRgBIAEoCRINCgVpbmRleBgCIAEoCRImCgZ2YWx1ZXMYAyADKAsyFi5nb29nbGUucHJvdG9idWYuVmFsdWUSMQoFcmFuZ2UYBCABKAsyHS5nZXN0YWx0LnByb3ZpZGVyLnYxLktleVJhbmdlSACIAQFCCAoGX3JhbmdlIh4KDUNvdW50UmVzcG9uc2USDQoFY291bnQYASABKAMiIQoORGVsZXRlUmVzcG9uc2USDwoHZGVsZXRlZBgBIAEoAyIaCgtLZXlSZXNwb25zZRILCgNrZXkYASABKAkyqQwKCUluZGV4ZWREQhJaChFDcmVhdGVPYmplY3RTdG9yZRItLmdlc3RhbHQucHJvdmlkZXIudjEuQ3JlYXRlT2JqZWN0U3RvcmVSZXF1ZXN0GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5EloKEURlbGV0ZU9iamVjdFN0b3JlEi0uZ2VzdGFsdC5wcm92aWRlci52MS5EZWxldGVPYmplY3RTdG9yZVJlcXVlc3QaFi5nb29nbGUucHJvdG9idWYuRW1wdHkSUwoDR2V0EicuZ2VzdGFsdC5wcm92aWRlci52MS5PYmplY3RTdG9yZVJlcXVlc3QaIy5nZXN0YWx0LnByb3ZpZGVyLnYxLlJlY29yZFJlc3BvbnNlElMKBkdldEtleRInLmdlc3RhbHQucHJvdmlkZXIudjEuT2JqZWN0U3RvcmVSZXF1ZXN0GiAuZ2VzdGFsdC5wcm92aWRlci52MS5LZXlSZXNwb25zZRJBCgNBZGQSIi5nZXN0YWx0LnByb3ZpZGVyLnYxLlJlY29yZFJlcXVlc3QaFi5nb29nbGUucHJvdG9idWYuRW1wdHkSQQoDUHV0EiIuZ2VzdGFsdC5wcm92aWRlci52MS5SZWNvcmRSZXF1ZXN0GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5EkkKBkRlbGV0ZRInLmdlc3RhbHQucHJvdmlkZXIudjEuT2JqZWN0U3RvcmVSZXF1ZXN0GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5EkwKBUNsZWFyEisuZ2VzdGFsdC5wcm92aWRlci52MS5PYmplY3RTdG9yZU5hbWVSZXF1ZXN0GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5ElwKBkdldEFsbBIsLmdlc3RhbHQucHJvdmlkZXIudjEuT2JqZWN0U3RvcmVSYW5nZVJlcXVlc3QaJC5nZXN0YWx0LnByb3ZpZGVyLnYxLlJlY29yZHNSZXNwb25zZRJdCgpHZXRBbGxLZXlzEiwuZ2VzdGFsdC5wcm92aWRlci52MS5PYmplY3RTdG9yZVJhbmdlUmVxdWVzdBohLmdlc3RhbHQucHJvdmlkZXIudjEuS2V5c1Jlc3BvbnNlElkKBUNvdW50EiwuZ2VzdGFsdC5wcm92aWRlci52MS5PYmplY3RTdG9yZVJhbmdlUmVxdWVzdBoiLmdlc3RhbHQucHJvdmlkZXIudjEuQ291bnRSZXNwb25zZRJgCgtEZWxldGVSYW5nZRIsLmdlc3RhbHQucHJvdmlkZXIudjEuT2JqZWN0U3RvcmVSYW5nZVJlcXVlc3QaIy5nZXN0YWx0LnByb3ZpZGVyLnYxLkRlbGV0ZVJlc3BvbnNlElcKCEluZGV4R2V0EiYuZ2VzdGFsdC5wcm92aWRlci52MS5JbmRleFF1ZXJ5UmVxdWVzdBojLmdlc3RhbHQucHJvdmlkZXIudjEuUmVjb3JkUmVzcG9uc2USVwoLSW5kZXhHZXRLZXkSJi5nZXN0YWx0LnByb3ZpZGVyLnYxLkluZGV4UXVlcnlSZXF1ZXN0GiAuZ2VzdGFsdC5wcm92aWRlci52MS5LZXlSZXNwb25zZRJbCgtJbmRleEdldEFsbBImLmdlc3RhbHQucHJvdmlkZXIudjEuSW5kZXhRdWVyeVJlcXVlc3QaJC5nZXN0YWx0LnByb3ZpZGVyLnYxLlJlY29yZHNSZXNwb25zZRJcCg9JbmRleEdldEFsbEtleXMSJi5nZXN0YWx0LnByb3ZpZGVyLnYxLkluZGV4UXVlcnlSZXF1ZXN0GiEuZ2VzdGFsdC5wcm92aWRlci52MS5LZXlzUmVzcG9uc2USWAoKSW5kZXhDb3VudBImLmdlc3RhbHQucHJvdmlkZXIudjEuSW5kZXhRdWVyeVJlcXVlc3QaIi5nZXN0YWx0LnByb3ZpZGVyLnYxLkNvdW50UmVzcG9uc2USWgoLSW5kZXhEZWxldGUSJi5nZXN0YWx0LnByb3ZpZGVyLnYxLkluZGV4UXVlcnlSZXF1ZXN0GiMuZ2VzdGFsdC5wcm92aWRlci52MS5EZWxldGVSZXNwb25zZUI7WjlnaXRodWIuY29tL3ZhbG9uLXRlY2hub2xvZ2llcy9nZXN0YWx0L3Nkay9nby9nZW4vdjE7cHJvdG9iBnByb3RvMw", [file_google_protobuf_empty, file_google_protobuf_struct]);
+  fileDesc("ChJ2MS9kYXRhc3RvcmUucHJvdG8SE2dlc3RhbHQucHJvdmlkZXIudjEilwIKClR5cGVkVmFsdWUSMAoKbnVsbF92YWx1ZRgBIAEoDjIaLmdvb2dsZS5wcm90b2J1Zi5OdWxsVmFsdWVIABIWCgxzdHJpbmdfdmFsdWUYAiABKAlIABITCglpbnRfdmFsdWUYAyABKANIABIVCgtmbG9hdF92YWx1ZRgEIAEoAUgAEhQKCmJvb2xfdmFsdWUYBSABKAhIABIwCgp0aW1lX3ZhbHVlGAYgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcEgAEhUKC2J5dGVzX3ZhbHVlGAcgASgMSAASLAoKanNvbl92YWx1ZRgIIAEoCzIWLmdvb2dsZS5wcm90b2J1Zi5WYWx1ZUgAQgYKBGtpbmQikQEKBlJlY29yZBI3CgZmaWVsZHMYASADKAsyJy5nZXN0YWx0LnByb3ZpZGVyLnYxLlJlY29yZC5GaWVsZHNFbnRyeRpOCgtGaWVsZHNFbnRyeRILCgNrZXkYASABKAkSLgoFdmFsdWUYAiABKAsyHy5nZXN0YWx0LnByb3ZpZGVyLnYxLlR5cGVkVmFsdWU6AjgBIncKEU9iamVjdFN0b3JlU2NoZW1hEjEKB2luZGV4ZXMYASADKAsyIC5nZXN0YWx0LnByb3ZpZGVyLnYxLkluZGV4U2NoZW1hEi8KB2NvbHVtbnMYAiADKAsyHi5nZXN0YWx0LnByb3ZpZGVyLnYxLkNvbHVtbkRlZiI9CgtJbmRleFNjaGVtYRIMCgRuYW1lGAEgASgJEhAKCGtleV9wYXRoGAIgAygJEg4KBnVuaXF1ZRgDIAEoCCJeCglDb2x1bW5EZWYSDAoEbmFtZRgBIAEoCRIMCgR0eXBlGAIgASgFEhMKC3ByaW1hcnlfa2V5GAMgASgIEhAKCG5vdF9udWxsGAQgASgIEg4KBnVuaXF1ZRgFIAEoCCKSAQoIS2V5UmFuZ2USLgoFbG93ZXIYASABKAsyHy5nZXN0YWx0LnByb3ZpZGVyLnYxLlR5cGVkVmFsdWUSLgoFdXBwZXIYAiABKAsyHy5nZXN0YWx0LnByb3ZpZGVyLnYxLlR5cGVkVmFsdWUSEgoKbG93ZXJfb3BlbhgDIAEoCBISCgp1cHBlcl9vcGVuGAQgASgIIksKDVJlY29yZFJlcXVlc3QSDQoFc3RvcmUYASABKAkSKwoGcmVjb3JkGAIgASgLMhsuZ2VzdGFsdC5wcm92aWRlci52MS5SZWNvcmQiPQoOUmVjb3JkUmVzcG9uc2USKwoGcmVjb3JkGAEgASgLMhsuZ2VzdGFsdC5wcm92aWRlci52MS5SZWNvcmQiPwoPUmVjb3Jkc1Jlc3BvbnNlEiwKB3JlY29yZHMYASADKAsyGy5nZXN0YWx0LnByb3ZpZGVyLnYxLlJlY29yZCIcCgxLZXlzUmVzcG9uc2USDAoEa2V5cxgBIAMoCSIvChJPYmplY3RTdG9yZVJlcXVlc3QSDQoFc3RvcmUYASABKAkSCgoCaWQYAiABKAkiJwoWT2JqZWN0U3RvcmVOYW1lUmVxdWVzdBINCgVzdG9yZRgBIAEoCSJlChdPYmplY3RTdG9yZVJhbmdlUmVxdWVzdBINCgVzdG9yZRgBIAEoCRIxCgVyYW5nZRgCIAEoCzIdLmdlc3RhbHQucHJvdmlkZXIudjEuS2V5UmFuZ2VIAIgBAUIICgZfcmFuZ2UiYAoYQ3JlYXRlT2JqZWN0U3RvcmVSZXF1ZXN0EgwKBG5hbWUYASABKAkSNgoGc2NoZW1hGAIgASgLMiYuZ2VzdGFsdC5wcm92aWRlci52MS5PYmplY3RTdG9yZVNjaGVtYSIoChhEZWxldGVPYmplY3RTdG9yZVJlcXVlc3QSDAoEbmFtZRgBIAEoCSKfAQoRSW5kZXhRdWVyeVJlcXVlc3QSDQoFc3RvcmUYASABKAkSDQoFaW5kZXgYAiABKAkSLwoGdmFsdWVzGAMgAygLMh8uZ2VzdGFsdC5wcm92aWRlci52MS5UeXBlZFZhbHVlEjEKBXJhbmdlGAQgASgLMh0uZ2VzdGFsdC5wcm92aWRlci52MS5LZXlSYW5nZUgAiAEBQggKBl9yYW5nZSIeCg1Db3VudFJlc3BvbnNlEg0KBWNvdW50GAEgASgDIiEKDkRlbGV0ZVJlc3BvbnNlEg8KB2RlbGV0ZWQYASABKAMiGgoLS2V5UmVzcG9uc2USCwoDa2V5GAEgASgJMqkMCglJbmRleGVkREISWgoRQ3JlYXRlT2JqZWN0U3RvcmUSLS5nZXN0YWx0LnByb3ZpZGVyLnYxLkNyZWF0ZU9iamVjdFN0b3JlUmVxdWVzdBoWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eRJaChFEZWxldGVPYmplY3RTdG9yZRItLmdlc3RhbHQucHJvdmlkZXIudjEuRGVsZXRlT2JqZWN0U3RvcmVSZXF1ZXN0GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5ElMKA0dldBInLmdlc3RhbHQucHJvdmlkZXIudjEuT2JqZWN0U3RvcmVSZXF1ZXN0GiMuZ2VzdGFsdC5wcm92aWRlci52MS5SZWNvcmRSZXNwb25zZRJTCgZHZXRLZXkSJy5nZXN0YWx0LnByb3ZpZGVyLnYxLk9iamVjdFN0b3JlUmVxdWVzdBogLmdlc3RhbHQucHJvdmlkZXIudjEuS2V5UmVzcG9uc2USQQoDQWRkEiIuZ2VzdGFsdC5wcm92aWRlci52MS5SZWNvcmRSZXF1ZXN0GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5EkEKA1B1dBIiLmdlc3RhbHQucHJvdmlkZXIudjEuUmVjb3JkUmVxdWVzdBoWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eRJJCgZEZWxldGUSJy5nZXN0YWx0LnByb3ZpZGVyLnYxLk9iamVjdFN0b3JlUmVxdWVzdBoWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eRJMCgVDbGVhchIrLmdlc3RhbHQucHJvdmlkZXIudjEuT2JqZWN0U3RvcmVOYW1lUmVxdWVzdBoWLmdvb2dsZS5wcm90b2J1Zi5FbXB0eRJcCgZHZXRBbGwSLC5nZXN0YWx0LnByb3ZpZGVyLnYxLk9iamVjdFN0b3JlUmFuZ2VSZXF1ZXN0GiQuZ2VzdGFsdC5wcm92aWRlci52MS5SZWNvcmRzUmVzcG9uc2USXQoKR2V0QWxsS2V5cxIsLmdlc3RhbHQucHJvdmlkZXIudjEuT2JqZWN0U3RvcmVSYW5nZVJlcXVlc3QaIS5nZXN0YWx0LnByb3ZpZGVyLnYxLktleXNSZXNwb25zZRJZCgVDb3VudBIsLmdlc3RhbHQucHJvdmlkZXIudjEuT2JqZWN0U3RvcmVSYW5nZVJlcXVlc3QaIi5nZXN0YWx0LnByb3ZpZGVyLnYxLkNvdW50UmVzcG9uc2USYAoLRGVsZXRlUmFuZ2USLC5nZXN0YWx0LnByb3ZpZGVyLnYxLk9iamVjdFN0b3JlUmFuZ2VSZXF1ZXN0GiMuZ2VzdGFsdC5wcm92aWRlci52MS5EZWxldGVSZXNwb25zZRJXCghJbmRleEdldBImLmdlc3RhbHQucHJvdmlkZXIudjEuSW5kZXhRdWVyeVJlcXVlc3QaIy5nZXN0YWx0LnByb3ZpZGVyLnYxLlJlY29yZFJlc3BvbnNlElcKC0luZGV4R2V0S2V5EiYuZ2VzdGFsdC5wcm92aWRlci52MS5JbmRleFF1ZXJ5UmVxdWVzdBogLmdlc3RhbHQucHJvdmlkZXIudjEuS2V5UmVzcG9uc2USWwoLSW5kZXhHZXRBbGwSJi5nZXN0YWx0LnByb3ZpZGVyLnYxLkluZGV4UXVlcnlSZXF1ZXN0GiQuZ2VzdGFsdC5wcm92aWRlci52MS5SZWNvcmRzUmVzcG9uc2USXAoPSW5kZXhHZXRBbGxLZXlzEiYuZ2VzdGFsdC5wcm92aWRlci52MS5JbmRleFF1ZXJ5UmVxdWVzdBohLmdlc3RhbHQucHJvdmlkZXIudjEuS2V5c1Jlc3BvbnNlElgKCkluZGV4Q291bnQSJi5nZXN0YWx0LnByb3ZpZGVyLnYxLkluZGV4UXVlcnlSZXF1ZXN0GiIuZ2VzdGFsdC5wcm92aWRlci52MS5Db3VudFJlc3BvbnNlEloKC0luZGV4RGVsZXRlEiYuZ2VzdGFsdC5wcm92aWRlci52MS5JbmRleFF1ZXJ5UmVxdWVzdBojLmdlc3RhbHQucHJvdmlkZXIudjEuRGVsZXRlUmVzcG9uc2VCO1o5Z2l0aHViLmNvbS92YWxvbi10ZWNobm9sb2dpZXMvZ2VzdGFsdC9zZGsvZ28vZ2VuL3YxO3Byb3RvYgZwcm90bzM", [file_google_protobuf_empty, file_google_protobuf_struct, file_google_protobuf_timestamp]);
+
+/**
+ * @generated from message gestalt.provider.v1.TypedValue
+ */
+export type TypedValue = Message<"gestalt.provider.v1.TypedValue"> & {
+  /**
+   * @generated from oneof gestalt.provider.v1.TypedValue.kind
+   */
+  kind: {
+    /**
+     * @generated from field: google.protobuf.NullValue null_value = 1;
+     */
+    value: NullValue;
+    case: "nullValue";
+  } | {
+    /**
+     * @generated from field: string string_value = 2;
+     */
+    value: string;
+    case: "stringValue";
+  } | {
+    /**
+     * @generated from field: int64 int_value = 3;
+     */
+    value: bigint;
+    case: "intValue";
+  } | {
+    /**
+     * @generated from field: double float_value = 4;
+     */
+    value: number;
+    case: "floatValue";
+  } | {
+    /**
+     * @generated from field: bool bool_value = 5;
+     */
+    value: boolean;
+    case: "boolValue";
+  } | {
+    /**
+     * @generated from field: google.protobuf.Timestamp time_value = 6;
+     */
+    value: Timestamp;
+    case: "timeValue";
+  } | {
+    /**
+     * @generated from field: bytes bytes_value = 7;
+     */
+    value: Uint8Array;
+    case: "bytesValue";
+  } | {
+    /**
+     * @generated from field: google.protobuf.Value json_value = 8;
+     */
+    value: Value;
+    case: "jsonValue";
+  } | { case: undefined; value?: undefined };
+};
+
+/**
+ * Describes the message gestalt.provider.v1.TypedValue.
+ * Use `create(TypedValueSchema)` to create a new message.
+ */
+export const TypedValueSchema: GenMessage<TypedValue> = /*@__PURE__*/
+  messageDesc(file_v1_datastore, 0);
+
+/**
+ * @generated from message gestalt.provider.v1.Record
+ */
+export type Record = Message<"gestalt.provider.v1.Record"> & {
+  /**
+   * @generated from field: map<string, gestalt.provider.v1.TypedValue> fields = 1;
+   */
+  fields: { [key: string]: TypedValue };
+};
+
+/**
+ * Describes the message gestalt.provider.v1.Record.
+ * Use `create(RecordSchema)` to create a new message.
+ */
+export const RecordSchema: GenMessage<Record> = /*@__PURE__*/
+  messageDesc(file_v1_datastore, 1);
 
 /**
  * @generated from message gestalt.provider.v1.ObjectStoreSchema
@@ -34,7 +116,7 @@ export type ObjectStoreSchema = Message<"gestalt.provider.v1.ObjectStoreSchema">
  * Use `create(ObjectStoreSchemaSchema)` to create a new message.
  */
 export const ObjectStoreSchemaSchema: GenMessage<ObjectStoreSchema> = /*@__PURE__*/
-  messageDesc(file_v1_datastore, 0);
+  messageDesc(file_v1_datastore, 2);
 
 /**
  * @generated from message gestalt.provider.v1.IndexSchema
@@ -61,7 +143,7 @@ export type IndexSchema = Message<"gestalt.provider.v1.IndexSchema"> & {
  * Use `create(IndexSchemaSchema)` to create a new message.
  */
 export const IndexSchemaSchema: GenMessage<IndexSchema> = /*@__PURE__*/
-  messageDesc(file_v1_datastore, 1);
+  messageDesc(file_v1_datastore, 3);
 
 /**
  * @generated from message gestalt.provider.v1.ColumnDef
@@ -98,21 +180,21 @@ export type ColumnDef = Message<"gestalt.provider.v1.ColumnDef"> & {
  * Use `create(ColumnDefSchema)` to create a new message.
  */
 export const ColumnDefSchema: GenMessage<ColumnDef> = /*@__PURE__*/
-  messageDesc(file_v1_datastore, 2);
+  messageDesc(file_v1_datastore, 4);
 
 /**
  * @generated from message gestalt.provider.v1.KeyRange
  */
 export type KeyRange = Message<"gestalt.provider.v1.KeyRange"> & {
   /**
-   * @generated from field: google.protobuf.Value lower = 1;
+   * @generated from field: gestalt.provider.v1.TypedValue lower = 1;
    */
-  lower?: Value;
+  lower?: TypedValue;
 
   /**
-   * @generated from field: google.protobuf.Value upper = 2;
+   * @generated from field: gestalt.provider.v1.TypedValue upper = 2;
    */
-  upper?: Value;
+  upper?: TypedValue;
 
   /**
    * @generated from field: bool lower_open = 3;
@@ -130,7 +212,7 @@ export type KeyRange = Message<"gestalt.provider.v1.KeyRange"> & {
  * Use `create(KeyRangeSchema)` to create a new message.
  */
 export const KeyRangeSchema: GenMessage<KeyRange> = /*@__PURE__*/
-  messageDesc(file_v1_datastore, 3);
+  messageDesc(file_v1_datastore, 5);
 
 /**
  * @generated from message gestalt.provider.v1.RecordRequest
@@ -142,9 +224,9 @@ export type RecordRequest = Message<"gestalt.provider.v1.RecordRequest"> & {
   store: string;
 
   /**
-   * @generated from field: google.protobuf.Struct record = 2;
+   * @generated from field: gestalt.provider.v1.Record record = 2;
    */
-  record?: JsonObject;
+  record?: Record;
 };
 
 /**
@@ -152,16 +234,16 @@ export type RecordRequest = Message<"gestalt.provider.v1.RecordRequest"> & {
  * Use `create(RecordRequestSchema)` to create a new message.
  */
 export const RecordRequestSchema: GenMessage<RecordRequest> = /*@__PURE__*/
-  messageDesc(file_v1_datastore, 4);
+  messageDesc(file_v1_datastore, 6);
 
 /**
  * @generated from message gestalt.provider.v1.RecordResponse
  */
 export type RecordResponse = Message<"gestalt.provider.v1.RecordResponse"> & {
   /**
-   * @generated from field: google.protobuf.Struct record = 1;
+   * @generated from field: gestalt.provider.v1.Record record = 1;
    */
-  record?: JsonObject;
+  record?: Record;
 };
 
 /**
@@ -169,16 +251,16 @@ export type RecordResponse = Message<"gestalt.provider.v1.RecordResponse"> & {
  * Use `create(RecordResponseSchema)` to create a new message.
  */
 export const RecordResponseSchema: GenMessage<RecordResponse> = /*@__PURE__*/
-  messageDesc(file_v1_datastore, 5);
+  messageDesc(file_v1_datastore, 7);
 
 /**
  * @generated from message gestalt.provider.v1.RecordsResponse
  */
 export type RecordsResponse = Message<"gestalt.provider.v1.RecordsResponse"> & {
   /**
-   * @generated from field: repeated google.protobuf.Struct records = 1;
+   * @generated from field: repeated gestalt.provider.v1.Record records = 1;
    */
-  records: JsonObject[];
+  records: Record[];
 };
 
 /**
@@ -186,7 +268,7 @@ export type RecordsResponse = Message<"gestalt.provider.v1.RecordsResponse"> & {
  * Use `create(RecordsResponseSchema)` to create a new message.
  */
 export const RecordsResponseSchema: GenMessage<RecordsResponse> = /*@__PURE__*/
-  messageDesc(file_v1_datastore, 6);
+  messageDesc(file_v1_datastore, 8);
 
 /**
  * @generated from message gestalt.provider.v1.KeysResponse
@@ -203,7 +285,7 @@ export type KeysResponse = Message<"gestalt.provider.v1.KeysResponse"> & {
  * Use `create(KeysResponseSchema)` to create a new message.
  */
 export const KeysResponseSchema: GenMessage<KeysResponse> = /*@__PURE__*/
-  messageDesc(file_v1_datastore, 7);
+  messageDesc(file_v1_datastore, 9);
 
 /**
  * @generated from message gestalt.provider.v1.ObjectStoreRequest
@@ -225,7 +307,7 @@ export type ObjectStoreRequest = Message<"gestalt.provider.v1.ObjectStoreRequest
  * Use `create(ObjectStoreRequestSchema)` to create a new message.
  */
 export const ObjectStoreRequestSchema: GenMessage<ObjectStoreRequest> = /*@__PURE__*/
-  messageDesc(file_v1_datastore, 8);
+  messageDesc(file_v1_datastore, 10);
 
 /**
  * @generated from message gestalt.provider.v1.ObjectStoreNameRequest
@@ -242,7 +324,7 @@ export type ObjectStoreNameRequest = Message<"gestalt.provider.v1.ObjectStoreNam
  * Use `create(ObjectStoreNameRequestSchema)` to create a new message.
  */
 export const ObjectStoreNameRequestSchema: GenMessage<ObjectStoreNameRequest> = /*@__PURE__*/
-  messageDesc(file_v1_datastore, 9);
+  messageDesc(file_v1_datastore, 11);
 
 /**
  * @generated from message gestalt.provider.v1.ObjectStoreRangeRequest
@@ -264,7 +346,7 @@ export type ObjectStoreRangeRequest = Message<"gestalt.provider.v1.ObjectStoreRa
  * Use `create(ObjectStoreRangeRequestSchema)` to create a new message.
  */
 export const ObjectStoreRangeRequestSchema: GenMessage<ObjectStoreRangeRequest> = /*@__PURE__*/
-  messageDesc(file_v1_datastore, 10);
+  messageDesc(file_v1_datastore, 12);
 
 /**
  * @generated from message gestalt.provider.v1.CreateObjectStoreRequest
@@ -286,7 +368,7 @@ export type CreateObjectStoreRequest = Message<"gestalt.provider.v1.CreateObject
  * Use `create(CreateObjectStoreRequestSchema)` to create a new message.
  */
 export const CreateObjectStoreRequestSchema: GenMessage<CreateObjectStoreRequest> = /*@__PURE__*/
-  messageDesc(file_v1_datastore, 11);
+  messageDesc(file_v1_datastore, 13);
 
 /**
  * @generated from message gestalt.provider.v1.DeleteObjectStoreRequest
@@ -303,7 +385,7 @@ export type DeleteObjectStoreRequest = Message<"gestalt.provider.v1.DeleteObject
  * Use `create(DeleteObjectStoreRequestSchema)` to create a new message.
  */
 export const DeleteObjectStoreRequestSchema: GenMessage<DeleteObjectStoreRequest> = /*@__PURE__*/
-  messageDesc(file_v1_datastore, 12);
+  messageDesc(file_v1_datastore, 14);
 
 /**
  * @generated from message gestalt.provider.v1.IndexQueryRequest
@@ -320,9 +402,9 @@ export type IndexQueryRequest = Message<"gestalt.provider.v1.IndexQueryRequest">
   index: string;
 
   /**
-   * @generated from field: repeated google.protobuf.Value values = 3;
+   * @generated from field: repeated gestalt.provider.v1.TypedValue values = 3;
    */
-  values: Value[];
+  values: TypedValue[];
 
   /**
    * @generated from field: optional gestalt.provider.v1.KeyRange range = 4;
@@ -335,7 +417,7 @@ export type IndexQueryRequest = Message<"gestalt.provider.v1.IndexQueryRequest">
  * Use `create(IndexQueryRequestSchema)` to create a new message.
  */
 export const IndexQueryRequestSchema: GenMessage<IndexQueryRequest> = /*@__PURE__*/
-  messageDesc(file_v1_datastore, 13);
+  messageDesc(file_v1_datastore, 15);
 
 /**
  * @generated from message gestalt.provider.v1.CountResponse
@@ -352,7 +434,7 @@ export type CountResponse = Message<"gestalt.provider.v1.CountResponse"> & {
  * Use `create(CountResponseSchema)` to create a new message.
  */
 export const CountResponseSchema: GenMessage<CountResponse> = /*@__PURE__*/
-  messageDesc(file_v1_datastore, 14);
+  messageDesc(file_v1_datastore, 16);
 
 /**
  * @generated from message gestalt.provider.v1.DeleteResponse
@@ -369,7 +451,7 @@ export type DeleteResponse = Message<"gestalt.provider.v1.DeleteResponse"> & {
  * Use `create(DeleteResponseSchema)` to create a new message.
  */
 export const DeleteResponseSchema: GenMessage<DeleteResponse> = /*@__PURE__*/
-  messageDesc(file_v1_datastore, 15);
+  messageDesc(file_v1_datastore, 17);
 
 /**
  * @generated from message gestalt.provider.v1.KeyResponse
@@ -386,7 +468,7 @@ export type KeyResponse = Message<"gestalt.provider.v1.KeyResponse"> & {
  * Use `create(KeyResponseSchema)` to create a new message.
  */
 export const KeyResponseSchema: GenMessage<KeyResponse> = /*@__PURE__*/
-  messageDesc(file_v1_datastore, 16);
+  messageDesc(file_v1_datastore, 18);
 
 /**
  * @generated from service gestalt.provider.v1.IndexedDB

--- a/sdk/typescript/src/indexeddb.ts
+++ b/sdk/typescript/src/indexeddb.ts
@@ -83,7 +83,7 @@ export class ObjectStore {
 
   async get(id: string): Promise<Record> {
     const resp = await rpc(() => this.client.get({ store: this.store, id }));
-    return (resp.record ?? {}) as Record;
+    return fromProtoRecord(resp.record);
   }
 
   async getKey(id: string): Promise<string> {
@@ -92,11 +92,11 @@ export class ObjectStore {
   }
 
   async add(record: Record): Promise<void> {
-    await rpc(() => this.client.add({ store: this.store, record: record as any }));
+    await rpc(() => this.client.add({ store: this.store, record: toProtoRecord(record) }));
   }
 
   async put(record: Record): Promise<void> {
-    await rpc(() => this.client.put({ store: this.store, record: record as any }));
+    await rpc(() => this.client.put({ store: this.store, record: toProtoRecord(record) }));
   }
 
   async delete(id: string): Promise<void> {
@@ -112,7 +112,7 @@ export class ObjectStore {
       store: this.store,
       range: keyRange ? toProtoKeyRange(keyRange) : undefined,
     });
-    return resp.records.map((r) => r as unknown as Record);
+    return resp.records.map((r) => fromProtoRecord(r));
   }
 
   async getAllKeys(keyRange?: KeyRange): Promise<string[]> {
@@ -156,10 +156,10 @@ export class Index {
       this.client.indexGet({
         store: this.store,
         index: this.indexName,
-        values: values.map(toProtoValue),
+        values: values.map(toProtoTypedValue),
       }),
     );
-    return (resp.record ?? {}) as Record;
+    return fromProtoRecord(resp.record);
   }
 
   async getKey(...values: unknown[]): Promise<string> {
@@ -167,7 +167,7 @@ export class Index {
       this.client.indexGetKey({
         store: this.store,
         index: this.indexName,
-        values: values.map(toProtoValue),
+        values: values.map(toProtoTypedValue),
       }),
     );
     return resp.key;
@@ -177,17 +177,17 @@ export class Index {
     const resp = await this.client.indexGetAll({
       store: this.store,
       index: this.indexName,
-      values: values.map(toProtoValue),
+      values: values.map(toProtoTypedValue),
       range: keyRange ? toProtoKeyRange(keyRange) : undefined,
     });
-    return resp.records.map((r) => r as unknown as Record);
+    return resp.records.map((r) => fromProtoRecord(r));
   }
 
   async getAllKeys(keyRange?: KeyRange, ...values: unknown[]): Promise<string[]> {
     const resp = await this.client.indexGetAllKeys({
       store: this.store,
       index: this.indexName,
-      values: values.map(toProtoValue),
+      values: values.map(toProtoTypedValue),
       range: keyRange ? toProtoKeyRange(keyRange) : undefined,
     });
     return resp.keys;
@@ -197,7 +197,7 @@ export class Index {
     const resp = await this.client.indexCount({
       store: this.store,
       index: this.indexName,
-      values: values.map(toProtoValue),
+      values: values.map(toProtoTypedValue),
       range: keyRange ? toProtoKeyRange(keyRange) : undefined,
     });
     return Number(resp.count);
@@ -207,27 +207,149 @@ export class Index {
     const resp = await this.client.indexDelete({
       store: this.store,
       index: this.indexName,
-      values: values.map(toProtoValue),
+      values: values.map(toProtoTypedValue),
     });
     return Number(resp.deleted);
   }
 }
 
-function toProtoValue(v: unknown): any {
+function toProtoRecord(record: Record): any {
+  const fields: { [key: string]: unknown } = {};
+  for (const [key, value] of Object.entries(record)) {
+    fields[key] = toProtoTypedValue(value);
+  }
+  return { fields };
+}
+
+function fromProtoRecord(record: any): Record {
+  const fields = record?.fields ?? {};
+  const out: Record = {};
+  for (const [key, value] of Object.entries(fields)) {
+    out[key] = fromProtoTypedValue(value);
+  }
+  return out;
+}
+
+function toProtoTypedValue(v: unknown): any {
   if (v === null || v === undefined) return { kind: { case: "nullValue", value: 0 } };
   if (typeof v === "boolean") return { kind: { case: "boolValue", value: v } };
-  if (typeof v === "number") return { kind: { case: "numberValue", value: v } };
+  if (typeof v === "bigint") return { kind: { case: "intValue", value: v } };
+  if (typeof v === "number") {
+    if (Number.isInteger(v) && Number.isSafeInteger(v)) {
+      return { kind: { case: "intValue", value: BigInt(v) } };
+    }
+    return { kind: { case: "floatValue", value: v } };
+  }
   if (typeof v === "string") return { kind: { case: "stringValue", value: v } };
-  return { kind: { case: "stringValue", value: String(v) } };
+  if (v instanceof Date) return { kind: { case: "timeValue", value: toProtoTimestamp(v) } };
+  if (v instanceof Uint8Array) return { kind: { case: "bytesValue", value: v } };
+  if (v instanceof ArrayBuffer) return { kind: { case: "bytesValue", value: new Uint8Array(v) } };
+  return { kind: { case: "jsonValue", value: toProtoJsonValue(v) } };
+}
+
+function fromProtoTypedValue(v: any): unknown {
+  switch (v?.kind?.case) {
+    case undefined:
+    case "nullValue":
+      return null;
+    case "stringValue":
+      return v.kind.value;
+    case "intValue":
+      return toJsInt(v.kind.value);
+    case "floatValue":
+      return v.kind.value;
+    case "boolValue":
+      return v.kind.value;
+    case "timeValue":
+      return fromProtoTimestamp(v.kind.value);
+    case "bytesValue":
+      return new Uint8Array(v.kind.value);
+    case "jsonValue":
+      return fromProtoJsonValue(v.kind.value);
+    default:
+      throw new Error(`unsupported typed value kind: ${String(v?.kind?.case)}`);
+  }
 }
 
 function toProtoKeyRange(kr: KeyRange): any {
   return {
-    lower: kr.lower !== undefined ? toProtoValue(kr.lower) : undefined,
-    upper: kr.upper !== undefined ? toProtoValue(kr.upper) : undefined,
+    lower: kr.lower !== undefined ? toProtoTypedValue(kr.lower) : undefined,
+    upper: kr.upper !== undefined ? toProtoTypedValue(kr.upper) : undefined,
     lowerOpen: kr.lowerOpen ?? false,
     upperOpen: kr.upperOpen ?? false,
   };
+}
+
+function toProtoTimestamp(value: Date): any {
+  const millis = value.getTime();
+  const seconds = Math.trunc(millis / 1000);
+  const nanos = Math.trunc((millis % 1000) * 1_000_000);
+  return { seconds: BigInt(seconds), nanos };
+}
+
+function fromProtoTimestamp(value: any): Date {
+  const seconds = Number(value?.seconds ?? 0n);
+  const nanos = Number(value?.nanos ?? 0);
+  return new Date((seconds * 1000) + Math.trunc(nanos / 1_000_000));
+}
+
+function toJsInt(value: bigint): number | bigint {
+  const asNumber = Number(value);
+  return Number.isSafeInteger(asNumber) ? asNumber : value;
+}
+
+function toProtoJsonValue(value: unknown): any {
+  if (value === null || value === undefined) return { kind: { case: "nullValue", value: 0 } };
+  if (typeof value === "boolean") return { kind: { case: "boolValue", value } };
+  if (typeof value === "number") return { kind: { case: "numberValue", value } };
+  if (typeof value === "string") return { kind: { case: "stringValue", value } };
+  if (value instanceof Date || value instanceof Uint8Array || value instanceof ArrayBuffer) {
+    throw new Error(`unsupported JSON value type: ${value.constructor.name}`);
+  }
+  if (Array.isArray(value)) {
+    return {
+      kind: {
+        case: "listValue",
+        value: { values: value.map((item) => toProtoJsonValue(item)) },
+      },
+    };
+  }
+  if (typeof value === "object") {
+    const fields: { [key: string]: unknown } = {};
+    for (const [key, inner] of Object.entries(value as { [key: string]: unknown })) {
+      fields[key] = toProtoJsonValue(inner);
+    }
+    return {
+      kind: {
+        case: "structValue",
+        value: { fields },
+      },
+    };
+  }
+  throw new Error(`unsupported JSON value type: ${typeof value}`);
+}
+
+function fromProtoJsonValue(value: any): unknown {
+  switch (value?.kind?.case) {
+    case undefined:
+    case "nullValue":
+      return null;
+    case "numberValue":
+    case "stringValue":
+    case "boolValue":
+      return value.kind.value;
+    case "listValue":
+      return (value.kind.value?.values ?? []).map((item: unknown) => fromProtoJsonValue(item));
+    case "structValue": {
+      const out: Record = {};
+      for (const [key, inner] of Object.entries(value.kind.value?.fields ?? {})) {
+        out[key] = fromProtoJsonValue(inner);
+      }
+      return out;
+    }
+    default:
+      throw new Error(`unsupported JSON value kind: ${String(value?.kind?.case)}`);
+  }
 }
 
 async function rpc<T>(fn: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
## Summary
- replace the IndexedDB datastore `Struct`/`Value` contract with first-class typed `TypedValue` and `Record` messages
- add shared typed record/value codecs in `sdk/go` and migrate the Go, Python, and TypeScript IndexedDB SDK shims plus gestaltd pluginhost to the new contract
- cover the shared codec with Go tests and update the in-repo test provider to use typed records

## Validation
- `go test ./...` (from `gestaltd`)
- `go test ./...` (from `sdk/go`)
- `python3 -m py_compile sdk/python/gestalt/_indexeddb.py`
- `bun run check` (from `sdk/typescript`)