### PR TITLE
Instrument IndexedDB operations with metrics

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -13,6 +13,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
@@ -299,6 +300,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	if storeErr != nil {
 		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", cfg.Server.IndexedDB, storeErr)
 	}
+	store = metricutil.InstrumentIndexedDB(store)
 	svc, svcErr := coredata.New(store, enc)
 	if svcErr != nil {
 		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", cfg.Server.IndexedDB, svcErr)

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -20,6 +20,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/mcpoauth"
 	"github.com/valon-technologies/gestalt/server/internal/mcpupstream"
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
 	"github.com/valon-technologies/gestalt/server/internal/openapi"
 	"github.com/valon-technologies/gestalt/server/internal/operationexposure"
@@ -35,7 +36,7 @@ func buildRegistrationStore(deps Deps) mcpoauth.RegistrationStore {
 	if deps.Services == nil {
 		return nil
 	}
-	if store, ok := deps.Services.DB.(mcpoauth.RegistrationStore); ok {
+	if store, ok := metricutil.UnwrapIndexedDB(deps.Services.DB).(mcpoauth.RegistrationStore); ok {
 		return store
 	}
 	return nil

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 )
 
@@ -24,7 +25,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 	defer func() { _ = prepared.Close(context.Background()) }()
 
 	var warnings []string
-	if w, ok := prepared.Services.DB.(interface{ Warnings() []string }); ok {
+	if w, ok := metricutil.UnwrapIndexedDB(prepared.Services.DB).(interface{ Warnings() []string }); ok {
 		warnings = w.Warnings()
 	}
 

--- a/gestaltd/internal/metricutil/indexeddb.go
+++ b/gestaltd/internal/metricutil/indexeddb.go
@@ -1,0 +1,174 @@
+package metricutil
+
+import (
+	"context"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+type instrumentedIndexedDB struct {
+	inner indexeddb.IndexedDB
+}
+
+// InstrumentIndexedDB wraps an IndexedDB instance to record metrics on every
+// ObjectStore and Index operation.
+func InstrumentIndexedDB(db indexeddb.IndexedDB) indexeddb.IndexedDB {
+	return &instrumentedIndexedDB{inner: db}
+}
+
+// UnwrapIndexedDB returns the underlying IndexedDB if db is instrumented,
+// or db itself otherwise. Use this before type-asserting optional interfaces
+// (e.g. RegistrationStore, Warnings) that the wrapper does not implement.
+func UnwrapIndexedDB(db indexeddb.IndexedDB) indexeddb.IndexedDB {
+	if w, ok := db.(*instrumentedIndexedDB); ok {
+		return w.inner
+	}
+	return db
+}
+
+func (d *instrumentedIndexedDB) ObjectStore(name string) indexeddb.ObjectStore {
+	return &instrumentedObjectStore{inner: d.inner.ObjectStore(name), store: name}
+}
+
+func (d *instrumentedIndexedDB) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
+	return d.inner.CreateObjectStore(ctx, name, schema)
+}
+
+func (d *instrumentedIndexedDB) DeleteObjectStore(ctx context.Context, name string) error {
+	return d.inner.DeleteObjectStore(ctx, name)
+}
+
+func (d *instrumentedIndexedDB) Ping(ctx context.Context) error {
+	return d.inner.Ping(ctx)
+}
+
+func (d *instrumentedIndexedDB) Close() error {
+	return d.inner.Close()
+}
+
+type instrumentedObjectStore struct {
+	inner indexeddb.ObjectStore
+	store string
+}
+
+func (s *instrumentedObjectStore) Get(ctx context.Context, id string) (indexeddb.Record, error) {
+	startedAt := time.Now()
+	rec, err := s.inner.Get(ctx, id)
+	RecordIndexedDBMetrics(ctx, startedAt, s.store, "Get", err != nil)
+	return rec, err
+}
+
+func (s *instrumentedObjectStore) GetKey(ctx context.Context, id string) (string, error) {
+	startedAt := time.Now()
+	key, err := s.inner.GetKey(ctx, id)
+	RecordIndexedDBMetrics(ctx, startedAt, s.store, "GetKey", err != nil)
+	return key, err
+}
+
+func (s *instrumentedObjectStore) Add(ctx context.Context, record indexeddb.Record) error {
+	startedAt := time.Now()
+	err := s.inner.Add(ctx, record)
+	RecordIndexedDBMetrics(ctx, startedAt, s.store, "Add", err != nil)
+	return err
+}
+
+func (s *instrumentedObjectStore) Put(ctx context.Context, record indexeddb.Record) error {
+	startedAt := time.Now()
+	err := s.inner.Put(ctx, record)
+	RecordIndexedDBMetrics(ctx, startedAt, s.store, "Put", err != nil)
+	return err
+}
+
+func (s *instrumentedObjectStore) Delete(ctx context.Context, id string) error {
+	startedAt := time.Now()
+	err := s.inner.Delete(ctx, id)
+	RecordIndexedDBMetrics(ctx, startedAt, s.store, "Delete", err != nil)
+	return err
+}
+
+func (s *instrumentedObjectStore) Clear(ctx context.Context) error {
+	startedAt := time.Now()
+	err := s.inner.Clear(ctx)
+	RecordIndexedDBMetrics(ctx, startedAt, s.store, "Clear", err != nil)
+	return err
+}
+
+func (s *instrumentedObjectStore) GetAll(ctx context.Context, r *indexeddb.KeyRange) ([]indexeddb.Record, error) {
+	startedAt := time.Now()
+	recs, err := s.inner.GetAll(ctx, r)
+	RecordIndexedDBMetrics(ctx, startedAt, s.store, "GetAll", err != nil)
+	return recs, err
+}
+
+func (s *instrumentedObjectStore) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange) ([]string, error) {
+	startedAt := time.Now()
+	keys, err := s.inner.GetAllKeys(ctx, r)
+	RecordIndexedDBMetrics(ctx, startedAt, s.store, "GetAllKeys", err != nil)
+	return keys, err
+}
+
+func (s *instrumentedObjectStore) Count(ctx context.Context, r *indexeddb.KeyRange) (int64, error) {
+	startedAt := time.Now()
+	n, err := s.inner.Count(ctx, r)
+	RecordIndexedDBMetrics(ctx, startedAt, s.store, "Count", err != nil)
+	return n, err
+}
+
+func (s *instrumentedObjectStore) DeleteRange(ctx context.Context, r indexeddb.KeyRange) (int64, error) {
+	startedAt := time.Now()
+	n, err := s.inner.DeleteRange(ctx, r)
+	RecordIndexedDBMetrics(ctx, startedAt, s.store, "DeleteRange", err != nil)
+	return n, err
+}
+
+func (s *instrumentedObjectStore) Index(name string) indexeddb.Index {
+	return &instrumentedIndex{inner: s.inner.Index(name), store: s.store}
+}
+
+type instrumentedIndex struct {
+	inner indexeddb.Index
+	store string
+}
+
+func (i *instrumentedIndex) Get(ctx context.Context, values ...any) (indexeddb.Record, error) {
+	startedAt := time.Now()
+	rec, err := i.inner.Get(ctx, values...)
+	RecordIndexedDBMetrics(ctx, startedAt, i.store, "Index.Get", err != nil)
+	return rec, err
+}
+
+func (i *instrumentedIndex) GetKey(ctx context.Context, values ...any) (string, error) {
+	startedAt := time.Now()
+	key, err := i.inner.GetKey(ctx, values...)
+	RecordIndexedDBMetrics(ctx, startedAt, i.store, "Index.GetKey", err != nil)
+	return key, err
+}
+
+func (i *instrumentedIndex) GetAll(ctx context.Context, r *indexeddb.KeyRange, values ...any) ([]indexeddb.Record, error) {
+	startedAt := time.Now()
+	recs, err := i.inner.GetAll(ctx, r, values...)
+	RecordIndexedDBMetrics(ctx, startedAt, i.store, "Index.GetAll", err != nil)
+	return recs, err
+}
+
+func (i *instrumentedIndex) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange, values ...any) ([]string, error) {
+	startedAt := time.Now()
+	keys, err := i.inner.GetAllKeys(ctx, r, values...)
+	RecordIndexedDBMetrics(ctx, startedAt, i.store, "Index.GetAllKeys", err != nil)
+	return keys, err
+}
+
+func (i *instrumentedIndex) Count(ctx context.Context, r *indexeddb.KeyRange, values ...any) (int64, error) {
+	startedAt := time.Now()
+	n, err := i.inner.Count(ctx, r, values...)
+	RecordIndexedDBMetrics(ctx, startedAt, i.store, "Index.Count", err != nil)
+	return n, err
+}
+
+func (i *instrumentedIndex) Delete(ctx context.Context, values ...any) (int64, error) {
+	startedAt := time.Now()
+	n, err := i.inner.Delete(ctx, values...)
+	RecordIndexedDBMetrics(ctx, startedAt, i.store, "Index.Delete", err != nil)
+	return n, err
+}

--- a/gestaltd/internal/metricutil/semantic_metrics.go
+++ b/gestaltd/internal/metricutil/semantic_metrics.go
@@ -14,6 +14,8 @@ var (
 	attrProvider       = attribute.Key("gestalt.provider")
 	attrAction         = attribute.Key("gestalt.action")
 	attrType           = attribute.Key("gestalt.type")
+	attrMethod         = attribute.Key("gestalt.method")
+	attrStore          = attribute.Key("gestalt.store")
 	attrConnectionMode = attribute.Key("gestalt.connection_mode")
 )
 
@@ -47,6 +49,7 @@ func newCounterMetrics(meter metric.Meter, prefix, desc string) counterMetrics {
 var (
 	authMetricsCache           MeterCache[counterMetrics]
 	connectionAuthMetricsCache MeterCache[counterMetrics]
+	indexedDBMetricsCache      MeterCache[counterMetrics]
 )
 
 func RecordAuthMetrics(ctx context.Context, startedAt time.Time, provider string, action string, failed bool) {
@@ -68,6 +71,16 @@ func RecordConnectionAuthMetrics(ctx context.Context, startedAt time.Time, provi
 		attrType.String(AttrValue(authType)),
 		attrAction.String(AttrValue(action)),
 		attrConnectionMode.String(AttrValue(connectionMode)),
+	)
+}
+
+func RecordIndexedDBMetrics(ctx context.Context, startedAt time.Time, store string, method string, failed bool) {
+	metrics := indexedDBMetricsCache.Load(meterName, func(meter metric.Meter) counterMetrics {
+		return newCounterMetrics(meter, "gestaltd.indexeddb", "gestaltd indexeddb operations")
+	})
+	recordCounterMetrics(ctx, metrics, startedAt, failed,
+		attrStore.String(AttrValue(store)),
+		attrMethod.String(AttrValue(method)),
 	)
 }
 


### PR DESCRIPTION
Adds a decorator at the indexeddb.IndexedDB interface level that records store name, method, duration, and error status on every ObjectStore and Index operation under the gestaltd.indexeddb.* metric namespace. The wrapper is applied once in bootstrap before the store is shared with coredata services and the plugin host, so both core and plugin traffic are covered from a single instrumentation point.