### PR TITLE
Fix CI web-e2e test by updating web UI manifest to unified format

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -190,11 +190,12 @@ jobs:
           cp -r "$GITHUB_WORKSPACE/gestaltd/ui/out" "$provider_dir/out"
 
           cat >"$provider_dir/manifest.yaml" <<'EOF'
+          kind: webui
           source: github.com/valon-technologies/gestalt-providers/web/default
           version: 0.0.1-alpha.1
           displayName: Default Web UI
           description: Local CI web UI fixture
-          webui:
+          spec:
             assetRoot: out
           EOF
 


### PR DESCRIPTION
## Summary
- The `build-gestaltd` workflow's web UI provider fixture was still using the old top-level `webui:` section format removed in #855
- The strict YAML decoder (`KnownFields(true)`) rejects the unknown field, causing gestaltd to exit before the e2e test runs
- Updated the fixture to use `kind: webui` + `spec:` to match the unified manifest model

## Test plan
- [ ] `build-gestaltd` CI workflow passes (web-e2e job no longer fails with "field webui not found")

🤖 Generated with [Claude Code](https://claude.com/claude-code)