### PR TITLE
Improve Providers docs structure and navigation

### DIFF
--- a/docs/content/providers/auth.mdx
+++ b/docs/content/providers/auth.mdx
@@ -253,3 +253,9 @@ providers:
 `source.path` points at the auth provider's `manifest.yaml` during development. For production, use `source.ref` and `version` to reference a published release. The `config` block is passed to `Configure` at startup and validated against the config schema if one was declared in the manifest.
 
 Secret references like `secret://oidc-client-secret` are resolved through the configured secret manager before reaching the provider. Environment variable placeholders like `${OIDC_CLIENT_ID}` are expanded during config loading. See [Configuration](/configuration) for details on both.
+
+## What to read next
+
+- [Secrets](/providers/secrets): configuring the secret manager that resolves `secret://` references
+- [Releasing](/providers/releasing): packaging and publishing provider releases
+- [Built-in Providers](/reference/built-in-providers): first-party auth provider reference

--- a/docs/content/providers/datastores.mdx
+++ b/docs/content/providers/datastores.mdx
@@ -281,3 +281,9 @@ providers:
 ```
 
 The plugin receives the `IndexedDB` interface over a gRPC socket. Object store names are automatically namespaced per plugin to prevent cross-plugin data access.
+
+## What to read next
+
+- [Plugins](/providers/plugins): building plugins that use the datastore SDK
+- [Releasing](/providers/releasing): packaging and publishing provider releases
+- [Configuration](/configuration): full server config reference

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -43,18 +43,6 @@ The underlying protocol is gRPC, so other languages are possible, but the docume
 
 Go, Rust, and TypeScript support plugin, auth, and datastore providers. Python remains focused on plugin providers.
 
-## Operation ID conventions
-
-Operation IDs should use period-separated hierarchical names. For example, a Slack plugin might use `messages.list`, `messages.send`, `channels.list`, and `channels.archive`.
-
-This convention enables prefix matching in the CLI. When you run `gestalt invoke slack messages`, the CLI joins the space-separated segments with periods and shows all operations whose ID starts with `messages.`. This makes large catalogs navigable without memorizing every operation name.
-
-## Common pitfalls
-
-**Duplicate operation IDs.** Operation IDs must be unique within a provider. If two surfaces (for example, an OpenAPI passthrough and an executable operation) expose the same ID, the provider fails validation at startup. Use `allowedOperations` to filter or alias collisions.
-
-**Sandbox 403 errors.** Executable providers run inside a network sandbox. Outbound HTTP requests to hosts not listed in `allowedHosts` are rejected with a 403. Add every upstream domain the provider contacts to the allowlist in the config or manifest.
-
 ## What to read next
 
 - [Plugins](/providers/plugins): plugin providers that expose operations

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -45,7 +45,7 @@ Static metadata, auth, and passthrough surfaces live in a manifest file. Gestalt
   </Tabs.Tab>
 </Tabs>
 
-The manifest stays the source of truth for display name, description, auth, the connection model, and any passthrough API surfaces (REST, OpenAPI, GraphQL, or MCP).
+The manifest stays the source of truth for display name, description, auth, the connection model, and any passthrough API surfaces (REST, OpenAPI, GraphQL, or MCP). See [Provider Manifests](/reference/plugin-manifests) for the full field reference.
 
 `source` may include nested segments after the repository, such as `github.com/example/plugins/catalog/my-plugin`. Gestalt keeps the final segment as the plugin name and uses the full path for release tag resolution.
 
@@ -470,6 +470,12 @@ The router derives catalog parameters from the input type. Fields are required b
   </Tabs.Tab>
 </Tabs>
 
+## Operation ID conventions
+
+Operation IDs should use period-separated hierarchical names. For example, a Slack plugin might use `messages.list`, `messages.send`, `channels.list`, and `channels.archive`.
+
+This convention enables prefix matching in the CLI. When you run `gestalt invoke slack messages`, the CLI joins the space-separated segments with periods and shows all operations whose ID starts with `messages.`. This makes large catalogs navigable without memorizing every operation name.
+
 ## Dynamic catalogs
 
 By default, the operation catalog is static and materialized at startup. If your plugin needs to expose different operations depending on the caller's credentials or runtime state, implement a session catalog.
@@ -595,8 +601,16 @@ gestaltd serve --config ./config.yaml
 gestalt invoke my-plugin greet -p name=Gestalt
 ```
 
+If your plugin makes outbound HTTP requests and you see 403 errors, check `allowedHosts`. Executable providers run inside a network sandbox, and requests to hosts not in the allowlist are rejected. Add every upstream domain the provider contacts to `allowedHosts` in the config or manifest.
+
 ## Hybrid providers
 
 A manifest can define passthrough surfaces (`spec.surfaces.openapi`, `spec.surfaces.rest`, `spec.surfaces.graphql`, or `spec.surfaces.mcp`) alongside executable operations. The passthrough surfaces are forwarded by the host directly to the upstream API, while the executable operations are handled by the provider process. This is useful when a plugin adds custom logic on top of an existing API.
 
 Do not define the same operation ID in both a passthrough surface and an executable operation. If two surfaces expose the same ID, the provider fails validation at startup. Use `allowedOperations` to filter or alias collisions when needed.
+
+## What to read next
+
+- [Releasing](/providers/releasing): packaging and publishing provider releases
+- [Datastores](/providers/datastores): persistent storage SDK for plugins
+- [Provider Manifests](/reference/plugin-manifests): full manifest field reference

--- a/docs/content/providers/releasing.mdx
+++ b/docs/content/providers/releasing.mdx
@@ -208,9 +208,9 @@ binaries during release.
 
 ## Reference releases from config
 
-### Provider source path
+### During development
 
-Use the source tree directly during development:
+Use `source.path` to point at the source tree directly. Gestalt synthesizes the executable wrapper and materializes the catalog automatically:
 
 ```yaml
 providers:
@@ -220,10 +220,18 @@ providers:
         path: ./plugins/my-plugin/manifest.yaml
 ```
 
-### Published provider release
+UI bundles work the same way:
 
-Reference a published release by source and version. `gestaltd init` resolves
-the release archive and writes it to lock state:
+```yaml
+providers:
+  ui:
+    source:
+      path: ./gestalt-ui/manifest.yaml
+```
+
+### For production
+
+Reference a published release by source and version:
 
 ```yaml
 providers:
@@ -234,11 +242,7 @@ providers:
         version: 0.0.1-alpha.1
 ```
 
-This is the recommended approach for production deployments.
-
-### UI bundle
-
-Reference a released UI bundle separately under `providers.ui`:
+UI bundles use the same pattern under `providers.ui`:
 
 ```yaml
 providers:
@@ -250,21 +254,13 @@ providers:
       brand_name: Acme
 ```
 
-## Prepared state
-
-When a config references published releases or a released UI, run `gestaltd init`
-to resolve and prepare them:
+When a config references published releases, run `gestaltd init` to resolve and prepare them:
 
 ```sh
 gestaltd init --config ./config.yaml
 ```
 
-This writes lock state (`gestalt.lock.json`) and extracts prepared artifacts
-under `.gestaltd/`. After init, `gestaltd serve --locked` starts the server
-from that lock state. If the prepared files are already present, Gestalt uses
-them directly. If they are missing, Gestalt can materialize them from the
-lockfile at runtime. See [Configuration](/configuration) for the full startup
-model and the tradeoffs between vendored artifacts and lockfile-only startup.
+This writes lock state (`gestalt.lock.json`) and extracts prepared artifacts under `.gestaltd/`. After init, `gestaltd serve --locked` starts the server from that lock state. If the prepared files are already present, Gestalt uses them directly. If they are missing, Gestalt can materialize them from the lockfile at runtime. See [Configuration](/configuration) for the full startup model and the tradeoffs between vendored artifacts and lockfile-only startup.
 
 ## Release archive layout
 
@@ -287,3 +283,9 @@ other static files.
 
 Use [Provider Manifests](/reference/plugin-manifests) for the canonical manifest
 reference.
+
+## What to read next
+
+- [Provider Manifests](/reference/plugin-manifests): full manifest field reference
+- [Helm Deployment](/deploy/helm): deploying with Helm and referencing published releases
+- [Configuration](/configuration): `gestaltd init`, lock state, and the full startup model

--- a/docs/content/providers/secrets.mdx
+++ b/docs/content/providers/secrets.mdx
@@ -197,3 +197,9 @@ providers:
 | Azure Key Vault | `github.com/valon-technologies/gestalt-providers/secrets/azure` | Config: `vault_url` (required), `version` |
 | Google Secret Manager | `github.com/valon-technologies/gestalt-providers/secrets/google` | Config: `project` (required), `version` |
 | HashiCorp Vault | `github.com/valon-technologies/gestalt-providers/secrets/vault` | Config: `address` (required), `token` (required), `mount_path`, `namespace` |
+
+## What to read next
+
+- [Configuration](/configuration): how `secret://` references are used across the server config
+- [Releasing](/providers/releasing): packaging and publishing provider releases
+- [Built-in Providers](/reference/built-in-providers): full reference for `env` and `file` providers

--- a/docs/content/providers/web-uis.mdx
+++ b/docs/content/providers/web-uis.mdx
@@ -79,3 +79,8 @@ gestaltd provider release --version 1.2.0
 ```
 
 Run this from the directory containing the manifest. If `release.build` is defined, the build command runs first, then Gestalt packages the manifest and the asset root into a release archive. See [Releasing](/providers/releasing) for details on release archives, tag resolution, and prepared state.
+
+## What to read next
+
+- [Releasing](/providers/releasing): release archives, tag resolution, and prepared state
+- [Configuration](/configuration): full server config reference including `providers.ui`


### PR DESCRIPTION
## Summary

The Providers section lacked forward navigation and mixed wayfinding
content with implementation details on the index page. This moves
"Operation ID conventions" and "Common pitfalls" from the index into the
plugins page where they are most relevant, adds "What to read next"
cross-links to every sub-page, and restructures the releasing page to
clearly separate development and production workflows.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>