### PR TITLE
Rename Datastores provider page to IndexedDB

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -8,7 +8,7 @@ Gestalt has six core concepts you configure in YAML:
 
 - **[Plugin.](/providers/plugins)** A tool backed by a provider package. Plugins expose operations that agents and users invoke over HTTP, MCP, or the CLI. Plugins can come from published packages or local source.
 - **Connection.** How Gestalt authenticates to an upstream API on behalf of a user or service. Connections handle OAuth flows, API keys, and manual credentials.
-- **[IndexedDB.](/providers/datastores)** The persistent storage layer. Stores users, sessions, tokens, and credentials through a provider that implements the IndexedDB interface.
+- **[IndexedDB.](/providers/indexeddb)** The persistent storage layer. Stores users, sessions, tokens, and credentials through a provider that implements the IndexedDB interface.
 - **[Auth.](/providers/auth)** Platform login for the Gestalt server. Separate from connection auth, which is per-plugin and per-upstream.
 - **[Secrets.](/providers/secrets)** Resolves `secret://` references in the config at startup. Backed by environment variables, files, or cloud secret managers.
 - **[UI.](/providers/web-uis)** The public web interface served at `/`. Uses the default bundle, a custom package, or can be disabled entirely.
@@ -220,7 +220,7 @@ providers:
         dsn: sqlite://./gestalt.db
 ```
 
-SQLite works for single-instance deployments. For production, use a Postgres or MySQL DSN. See [Datastores](/providers/datastores) for the full provider model.
+SQLite works for single-instance deployments. For production, use a Postgres or MySQL DSN. See [IndexedDB](/providers/indexeddb) for the full provider model.
 
 ## Config file mechanics
 

--- a/docs/content/deploy/index.mdx
+++ b/docs/content/deploy/index.mdx
@@ -8,7 +8,7 @@ The server image `valontechnologies/gestaltd:latest` is published for `linux/amd
 
 ## Production considerations
 
-**Database.** SQLite works for single-instance deployments. For multi-replica or horizontally scaled deployments, use a networked datastore provider such as the first-party `indexeddb/relationaldb` package with a Postgres or MySQL DSN. See [Datastores](/providers/datastores) for the provider model.
+**Database.** SQLite works for single-instance deployments. For multi-replica or horizontally scaled deployments, use a networked datastore provider such as the first-party `indexeddb/relationaldb` package with a Postgres or MySQL DSN. See [IndexedDB](/providers/indexeddb) for the provider model.
 
 **Secrets.** Use `file` or a cloud secret manager instead of `env` in production. `file` is built in and works with Kubernetes volume-mounted secrets. Cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) are available as external providers from [`gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). Gestalt config supports `secret://` references that are resolved at boot time through the configured secrets provider. See [Secrets Providers](/providers/secrets) for setup details.
 

--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -16,7 +16,7 @@ Run `gestaltd` with no arguments:
 gestaltd
 ```
 
-When no config file exists, `gestaltd` generates one at `~/.gestaltd/config.yaml` and starts immediately with SQLite storage via the [RelationalDB](https://github.com/valon-technologies/gestalt-providers/tree/main/datastore) implementation of the [IndexedDB provider](/providers/datastores), no authentication, and an [HTTPBin](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/httpbin) implementation of the [plugin provider](/providers/plugins) on port 8080.
+When no config file exists, `gestaltd` generates one at `~/.gestaltd/config.yaml` and starts immediately with SQLite storage via the [RelationalDB](https://github.com/valon-technologies/gestalt-providers/tree/main/datastore) implementation of the [IndexedDB provider](/providers/indexeddb), no authentication, and an [HTTPBin](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/httpbin) implementation of the [plugin provider](/providers/plugins) on port 8080.
 
 ```
 2026/04/10 10:00:00 INFO generated default config path=~/.gestaltd/config.yaml

--- a/docs/content/providers/_meta.ts
+++ b/docs/content/providers/_meta.ts
@@ -1,7 +1,7 @@
 export default {
   plugins: "Plugins",
   auth: "Auth",
-  datastores: "Datastores",
+  indexeddb: "IndexedDB",
   secrets: "Secrets",
   "web-uis": "Web UIs",
   releasing: "Releasing",

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -4,7 +4,7 @@ asIndexPage: true
 
 # Providers
 
-Gestalt has a unified runtime model: plugins, auth backends, datastores, and web UIs all run as providers. The server binary (`gestaltd`) does not compile any of these in. Instead, each provider is a separate package with a manifest and an executable (or a passthrough surface definition) that the host loads at startup.
+Gestalt has a unified runtime model: plugins, auth backends, IndexedDB stores, and web UIs all run as providers. The server binary (`gestaltd`) does not compile any of these in. Instead, each provider is a separate package with a manifest and an executable (or a passthrough surface definition) that the host loads at startup.
 
 ## Provider kinds
 
@@ -47,6 +47,6 @@ Go, Rust, and TypeScript support plugin, auth, and datastore providers. Python r
 
 - [Plugins](/providers/plugins): plugin providers that expose operations
 - [Auth](/providers/auth): platform login providers
-- [Datastores](/providers/datastores): persistent storage backends
+- [IndexedDB](/providers/indexeddb): persistent storage backends
 - [Web UIs](/providers/web-uis): custom web frontends
 - [Releasing](/providers/releasing): packaging and publishing providers

--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -1,6 +1,6 @@
 import { Tabs } from 'nextra/components'
 
-# Datastores
+# IndexedDB
 
 Datastore providers back the persistent state layer using an interface modeled on the [IndexedDB API](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API). IndexedDB's vocabulary of object stores, primary keys, named indexes, and key ranges maps naturally onto SQL tables, document collections, and key-value stores alike, so a single provider contract can target Postgres, SQLite, MongoDB, DynamoDB, and others without leaking backend-specific abstractions. Building on an established open-source convention means the concepts are already documented, widely understood, and proven to cover the access patterns most applications need.
 

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -612,5 +612,5 @@ Do not define the same operation ID in both a passthrough surface and an executa
 ## What to read next
 
 - [Releasing](/providers/releasing): packaging and publishing provider releases
-- [Datastores](/providers/datastores): persistent storage SDK for plugins
+- [IndexedDB](/providers/indexeddb): persistent storage SDK for plugins
 - [Provider Manifests](/reference/plugin-manifests): full manifest field reference


### PR DESCRIPTION
## Summary

The provider kind was renamed from `datastore` to `indexeddb` in #855
but the docs page and nav still used the old name. This renames the file,
updates the sidebar entry, page title, and all cross-references to match
the kind name used everywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>