### PR TITLE
Rewrite provider examples with real providers

### DIFF
--- a/docs/content/providers/auth.mdx
+++ b/docs/content/providers/auth.mdx
@@ -6,25 +6,25 @@ Auth providers handle platform login. When a user visits the Gestalt web UI or h
 
 Beyond the core login flow, an auth provider can optionally validate externally issued tokens (so API clients can present a bearer token directly instead of going through the browser) and control session TTL.
 
+The examples on this page use a Google OAuth provider as the running example.
+
 ## Manifest
 
-An auth provider manifest uses a `spec` block with `kind: auth`:
+An auth provider manifest declares `kind: auth`. You can optionally include a `configSchemaPath` so Gestalt validates provider config at startup.
 
 ```yaml
 kind: auth
-source: github.com/example/plugins/my-auth
-version: 0.0.1-alpha.1
-displayName: My Auth Provider
-description: Custom OAuth 2.0 authentication
+source: github.com/your-org/auth/google
+version: 0.0.1
+displayName: Google
+description: Authenticate users with Google OAuth.
 spec:
   configSchemaPath: ./auth_config.json
 ```
 
-The optional `spec.configSchemaPath` field points to a JSON Schema that validates the `config` block in the server config. If you provide one, Gestalt rejects invalid config at startup rather than letting bad values reach the provider at runtime.
-
 ## Interface
 
-An auth provider implements three methods: `Configure`, `BeginLogin`, and `CompleteLogin`. `BeginLogin` receives the callback URL and a host-generated state parameter and returns an authorization URL that Gestalt redirects the user to. `CompleteLogin` receives the query parameters from the identity provider callback and returns the authenticated user's identity.
+You implement three methods: `Configure`, `BeginLogin`, and `CompleteLogin`. `BeginLogin` returns an authorization URL that Gestalt redirects the user to. `CompleteLogin` exchanges the callback parameters for an authenticated identity.
 
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
@@ -34,42 +34,41 @@ An auth provider implements three methods: `Configure`, `BeginLogin`, and `Compl
     import (
     	"context"
     	"fmt"
-    	"net/url"
 
     	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+    	"golang.org/x/oauth2"
+    	googleoauth "golang.org/x/oauth2/google"
     )
 
-    type MyAuth struct {
-    	clientID  string
-    	issuerURL string
+    type GoogleAuth struct {
+    	clientID     string
+    	clientSecret string
     }
 
-    func (a *MyAuth) Configure(_ context.Context, _ string, config map[string]any) error {
-    	a.clientID, _ = config["clientId"].(string)
-    	a.issuerURL, _ = config["issuerUrl"].(string)
-    	if a.clientID == "" || a.issuerURL == "" {
-    		return fmt.Errorf("clientId and issuerUrl are required")
+    func (g *GoogleAuth) Configure(_ context.Context, _ string, config map[string]any) error {
+    	g.clientID, _ = config["clientId"].(string)
+    	g.clientSecret, _ = config["clientSecret"].(string)
+    	if g.clientID == "" || g.clientSecret == "" {
+    		return fmt.Errorf("clientId and clientSecret are required")
     	}
     	return nil
     }
 
-    func (a *MyAuth) BeginLogin(_ context.Context, req gestalt.BeginLoginRequest) (*gestalt.BeginLoginResponse, error) {
-    	authURL := fmt.Sprintf(
-    		"%s/authorize?client_id=%s&redirect_uri=%s&state=%s&response_type=code",
-    		a.issuerURL,
-    		url.QueryEscape(a.clientID),
-    		url.QueryEscape(req.CallbackURL),
-    		url.QueryEscape(req.HostState),
-    	)
-    	return &gestalt.BeginLoginResponse{AuthorizationURL: authURL}, nil
+    func (g *GoogleAuth) BeginLogin(_ context.Context, req gestalt.BeginLoginRequest) (*gestalt.BeginLoginResponse, error) {
+    	cfg := &oauth2.Config{
+    		ClientID:     g.clientID,
+    		ClientSecret: g.clientSecret,
+    		RedirectURL:  req.CallbackURL,
+    		Scopes:       []string{"openid", "email", "profile"},
+    		Endpoint:     googleoauth.Endpoint,
+    	}
+    	return &gestalt.BeginLoginResponse{
+    		AuthorizationURL: cfg.AuthCodeURL(req.HostState, oauth2.AccessTypeOffline),
+    	}, nil
     }
 
-    func (a *MyAuth) CompleteLogin(_ context.Context, req gestalt.CompleteLoginRequest) (*gestalt.AuthenticatedUser, error) {
-    	code := req.Query["code"]
-    	if code == "" {
-    		return nil, fmt.Errorf("missing authorization code")
-    	}
-    	// Exchange code for tokens, extract user info.
+    func (g *GoogleAuth) CompleteLogin(ctx context.Context, req gestalt.CompleteLoginRequest) (*gestalt.AuthenticatedUser, error) {
+    	// Exchange req.Query["code"] for a token, then fetch userinfo.
     	return &gestalt.AuthenticatedUser{
     		Subject:       "user-123",
     		Email:         "user@example.com",
@@ -79,7 +78,7 @@ An auth provider implements three methods: `Configure`, `BeginLogin`, and `Compl
     }
 
     func main() {
-    	gestalt.ServeAuthProvider(context.Background(), &MyAuth{})
+    	gestalt.ServeAuthProvider(context.Background(), &GoogleAuth{})
     }
     ```
   </Tabs.Tab>
@@ -87,24 +86,24 @@ An auth provider implements three methods: `Configure`, `BeginLogin`, and `Compl
     ```python
     import gestalt
 
-    class MyAuth(gestalt.AuthProvider):
+    class GoogleAuth(gestalt.AuthProvider):
         def configure(self, name: str, config: dict) -> None:
-            self.client_id = config.get("clientId", "")
-            self.issuer_url = config.get("issuerUrl", "")
+            self.client_id = config["clientId"]
+            self.client_secret = config["clientSecret"]
 
         def begin_login(self, request: gestalt.BeginLoginRequest) -> gestalt.BeginLoginResponse:
             auth_url = (
-                f"{self.issuer_url}/authorize"
+                "https://accounts.google.com/o/oauth2/v2/auth"
                 f"?client_id={self.client_id}"
                 f"&redirect_uri={request.callback_url}"
                 f"&state={request.host_state}"
-                f"&response_type=code"
+                "&response_type=code"
+                "&scope=openid+email+profile"
             )
             return gestalt.BeginLoginResponse(authorization_url=auth_url)
 
         def complete_login(self, request: gestalt.CompleteLoginRequest) -> gestalt.AuthenticatedUser:
-            code = request.query.get("code", "")
-            # Exchange code for tokens, extract user info.
+            # Exchange request.query["code"] for a token, then fetch userinfo.
             return gestalt.AuthenticatedUser(
                 subject="user-123",
                 email="user@example.com",
@@ -112,40 +111,38 @@ An auth provider implements three methods: `Configure`, `BeginLogin`, and `Compl
                 display_name="Example User",
             )
 
-    MyAuth().serve()
+    GoogleAuth().serve()
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
     use std::sync::Mutex;
-
     use gestalt::{AuthProvider, AuthenticatedUser, BeginLoginRequest, BeginLoginResponse, CompleteLoginRequest};
 
-    pub struct MyAuth {
+    pub struct GoogleAuth {
         client_id: Mutex<String>,
-        issuer_url: Mutex<String>,
+        client_secret: Mutex<String>,
     }
 
     #[gestalt::async_trait]
-    impl AuthProvider for MyAuth {
+    impl AuthProvider for GoogleAuth {
         async fn configure(
-            &self,
-            _name: &str,
-            config: serde_json::Map<String, serde_json::Value>,
+            &self, _name: &str, config: serde_json::Map<String, serde_json::Value>,
         ) -> gestalt::Result<()> {
             *self.client_id.lock().unwrap() = config
                 .get("clientId").and_then(|v| v.as_str()).unwrap_or("").to_string();
-            *self.issuer_url.lock().unwrap() = config
-                .get("issuerUrl").and_then(|v| v.as_str()).unwrap_or("").to_string();
+            *self.client_secret.lock().unwrap() = config
+                .get("clientSecret").and_then(|v| v.as_str()).unwrap_or("").to_string();
             Ok(())
         }
 
         async fn begin_login(&self, req: BeginLoginRequest) -> gestalt::Result<BeginLoginResponse> {
-            let issuer = self.issuer_url.lock().unwrap().clone();
             let client_id = self.client_id.lock().unwrap().clone();
             Ok(BeginLoginResponse {
                 authorization_url: format!(
-                    "{issuer}/authorize?client_id={client_id}&redirect_uri={}&state={}&response_type=code",
+                    "https://accounts.google.com/o/oauth2/v2/auth\
+                    ?client_id={client_id}&redirect_uri={}&state={}&response_type=code\
+                    &scope=openid+email+profile",
                     req.callback_url, req.host_state,
                 ),
                 provider_state: vec![],
@@ -153,11 +150,7 @@ An auth provider implements three methods: `Configure`, `BeginLogin`, and `Compl
         }
 
         async fn complete_login(&self, req: CompleteLoginRequest) -> gestalt::Result<AuthenticatedUser> {
-            let code = req.query.get("code").cloned().unwrap_or_default();
-            if code.is_empty() {
-                return Err(gestalt::Error::invalid_argument("missing authorization code"));
-            }
-            // Exchange code for tokens, extract user info.
+            // Exchange req.query["code"] for a token, then fetch userinfo.
             Ok(AuthenticatedUser {
                 subject: "user-123".into(),
                 email: "user@example.com".into(),
@@ -168,7 +161,7 @@ An auth provider implements three methods: `Configure`, `BeginLogin`, and `Compl
         }
     }
 
-    gestalt::export_auth_provider!(constructor = MyAuth::default);
+    gestalt::export_auth_provider!(constructor = GoogleAuth::default);
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -176,29 +169,25 @@ An auth provider implements three methods: `Configure`, `BeginLogin`, and `Compl
     import { defineAuthProvider } from "@valon-technologies/gestalt";
 
     let clientId = "";
-    let issuerUrl = "";
+    let clientSecret = "";
 
     export const provider = defineAuthProvider({
       async configure(_name, config) {
-        clientId = typeof config.clientId === "string" ? config.clientId : "";
-        issuerUrl = typeof config.issuerUrl === "string" ? config.issuerUrl : "";
+        clientId = config.clientId as string;
+        clientSecret = config.clientSecret as string;
       },
       async beginLogin(request) {
         return {
           authorizationUrl:
-            `${issuerUrl}/authorize` +
+            `https://accounts.google.com/o/oauth2/v2/auth` +
             `?client_id=${encodeURIComponent(clientId)}` +
             `&redirect_uri=${encodeURIComponent(request.callbackUrl)}` +
             `&state=${encodeURIComponent(request.hostState)}` +
-            `&response_type=code`,
+            `&response_type=code&scope=${encodeURIComponent("openid email profile")}`,
         };
       },
       async completeLogin(request) {
-        const code = request.query.code ?? "";
-        if (!code) {
-          throw new Error("missing authorization code");
-        }
-        // Exchange code for tokens, extract user info.
+        // Exchange request.query.code for a token, then fetch userinfo.
         return {
           subject: "user-123",
           email: "user@example.com",
@@ -221,9 +210,6 @@ An auth provider implements three methods: `Configure`, `BeginLogin`, and `Compl
       }
     }
     ```
-
-    Optional handlers: `validateExternalToken` for direct token validation and
-    `sessionSettings` to control session lifetime.
   </Tabs.Tab>
 </Tabs>
 
@@ -231,28 +217,29 @@ An auth provider implements three methods: `Configure`, `BeginLogin`, and `Compl
 
 Two optional interfaces extend the base contract.
 
-**ExternalTokenValidator** lets API clients present a token directly instead of going through the browser login flow. In Go, implement the `ExternalTokenValidator` interface on your provider. In Python, inherit from `gestalt.ExternalTokenValidator`. In Rust, override the `validate_external_token` method, which returns an unimplemented error by default. In TypeScript, provide the optional `validateExternalToken` handler to `defineAuthProvider`.
+**ExternalTokenValidator** lets API clients present a bearer token directly instead of going through the browser login flow. In Go, implement the `ExternalTokenValidator` interface on your provider. In Python, inherit from `gestalt.ExternalTokenValidator`. In Rust, override the `validate_external_token` method, which returns an unimplemented error by default. In TypeScript, provide the optional `validateExternalToken` handler to `defineAuthProvider`.
 
 **SessionTTLProvider** controls session lifetime. The default is 24 hours. In Go, implement the `SessionTTLProvider` interface. In Python, inherit from `gestalt.SessionTTLProvider`. In Rust, override the `session_ttl` method, which returns `None` (the 24-hour default) by default. In TypeScript, provide the optional `sessionSettings` handler to `defineAuthProvider`.
 
 ## Config reference
 
-To use your auth provider in a Gestalt deployment, reference it in the `providers.auth` block:
+To use a Google auth provider in a Gestalt deployment, reference it in the `providers.auth` block:
 
 ```yaml
 providers:
   auth:
     source:
-      path: ./my-auth/manifest.yaml
+      path: ./google-auth/manifest.yaml
     config:
-      issuerUrl: https://login.example.com
-      clientId: ${OIDC_CLIENT_ID}
-      clientSecret: secret://oidc-client-secret
+      clientId: ${GOOGLE_CLIENT_ID}
+      clientSecret: secret://google-client-secret
+      allowedDomains:
+        - example.com
 ```
 
 `source.path` points at the auth provider's `manifest.yaml` during development. For production, use `source.ref` and `version` to reference a published release. The `config` block is passed to `Configure` at startup and validated against the config schema if one was declared in the manifest.
 
-Secret references like `secret://oidc-client-secret` are resolved through the configured secret manager before reaching the provider. Environment variable placeholders like `${OIDC_CLIENT_ID}` are expanded during config loading. See [Configuration](/configuration) for details on both.
+Secret references like `secret://google-client-secret` are resolved through the configured secret manager before reaching the provider. Environment variable placeholders like `${GOOGLE_CLIENT_ID}` are expanded during config loading. See [Configuration](/configuration) for details on both.
 
 ## What to read next
 

--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -10,17 +10,19 @@ Gestalt stores users, plugin tokens, API tokens, and OAuth registrations through
 
 ## Manifest
 
-A datastore provider manifest uses a `spec` block with `kind: indexeddb`:
+The RelationalDB provider ships a manifest with `kind: indexeddb`. This tells Gestalt the provider implements the IndexedDB gRPC service and can be referenced in the `providers.indexeddbs` config section.
 
 ```yaml
 kind: indexeddb
-source: github.com/example/plugins/my-datastore
-version: 0.0.1-alpha.1
-displayName: My Datastore
-description: Custom persistent storage backend
+source: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+version: 0.0.1
+displayName: RelationalDB
+description: IndexedDB provider supporting PostgreSQL, MySQL, SQLite, and SQL Server.
 spec:
   configSchemaPath: ./datastore_config.json
 ```
+
+The `source` field identifies the provider in the registry. RelationalDB supports four SQL dialects through a single `dsn` config value, so one provider covers most relational databases.
 
 ## Provider interface
 
@@ -31,6 +33,8 @@ A datastore provider implements the `IndexedDB` gRPC service, which maps to thes
 - **GetAll / GetAllKeys / Count / Clear / DeleteRange** -- bulk operations with optional key ranges
 - **IndexGet / IndexGetKey / IndexGetAll / IndexGetAllKeys / IndexCount / IndexDelete** -- query and delete via named indexes
 
+The RelationalDB provider parses the `dsn` config value to determine the SQL driver and dialect, then opens a database connection. The DSN prefix selects the backend: `postgres://` for PostgreSQL, `mysql://` for MySQL, `sqlite://` for SQLite, and `sqlserver://` for SQL Server.
+
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
@@ -39,23 +43,40 @@ A datastore provider implements the `IndexedDB` gRPC service, which maps to thes
     import (
     	"context"
     	"database/sql"
+    	"fmt"
+    	"strings"
 
     	gestalt "github.com/valon-technologies/gestalt/sdk/go"
     )
 
-    type MyDatastore struct {
+    type RelationalDB struct {
     	db *sql.DB
     }
 
-    func (ds *MyDatastore) Configure(_ context.Context, _ string, config map[string]any) error {
+    func (r *RelationalDB) Configure(_ context.Context, _ string, config map[string]any) error {
     	dsn, _ := config["dsn"].(string)
+    	if dsn == "" {
+    		return fmt.Errorf("relationaldb: dsn is required")
+    	}
+    	driver := "sqlite"
+    	connStr := dsn
+    	switch {
+    	case strings.HasPrefix(dsn, "postgres://"):
+    		driver, connStr = "pgx", dsn
+    	case strings.HasPrefix(dsn, "mysql://"):
+    		driver, connStr = "mysql", strings.TrimPrefix(dsn, "mysql://")
+    	case strings.HasPrefix(dsn, "sqlserver://"):
+    		driver, connStr = "sqlserver", dsn
+    	case strings.HasPrefix(dsn, "sqlite://"):
+    		driver, connStr = "sqlite", strings.TrimPrefix(dsn, "sqlite://")
+    	}
     	var err error
-    	ds.db, err = sql.Open("postgres", dsn)
+    	r.db, err = sql.Open(driver, connStr)
     	return err
     }
 
-    func (ds *MyDatastore) HealthCheck(ctx context.Context) error {
-    	return ds.db.PingContext(ctx)
+    func (r *RelationalDB) HealthCheck(ctx context.Context) error {
+    	return r.db.PingContext(ctx)
     }
 
     // Implement the IndexedDB gRPC service:
@@ -65,7 +86,7 @@ A datastore provider implements the `IndexedDB` gRPC service, which maps to thes
     // IndexGet, IndexGetKey, IndexGetAll, IndexGetAllKeys, IndexCount, IndexDelete
 
     func main() {
-    	gestalt.ServeIndexedDBProvider(context.Background(), &MyDatastore{})
+    	gestalt.ServeIndexedDBProvider(context.Background(), &RelationalDB{})
     }
     ```
   </Tabs.Tab>
@@ -73,9 +94,12 @@ A datastore provider implements the `IndexedDB` gRPC service, which maps to thes
     ```python
     import gestalt
 
-    class MyDatastore(gestalt.IndexedDBProvider):
+    class RelationalDB(gestalt.IndexedDBProvider):
         def configure(self, name: str, config: dict) -> None:
-            self.dsn = config.get("dsn", "")
+            dsn = config.get("dsn", "")
+            if not dsn:
+                raise ValueError("relationaldb: dsn is required")
+            self.dsn = dsn
 
         # Implement the IndexedDB gRPC service:
         # create_object_store, delete_object_store,
@@ -83,24 +107,27 @@ A datastore provider implements the `IndexedDB` gRPC service, which maps to thes
         # get_all, get_all_keys, count, clear, delete_range,
         # index_get, index_get_key, index_get_all, index_get_all_keys, index_count, index_delete
 
-    MyDatastore().serve()
+    RelationalDB().serve()
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
-    pub struct MyDatastore { /* database connection */ }
+    pub struct RelationalDB { /* database connection */ }
 
     #[gestalt::async_trait]
-    impl gestalt::IndexedDBProvider for MyDatastore {
+    impl gestalt::IndexedDBProvider for RelationalDB {
         async fn configure(&self, _name: &str, config: serde_json::Map<String, serde_json::Value>) -> gestalt::Result<()> {
-            // Initialize database connection from config["dsn"]
+            let dsn = config.get("dsn")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| gestalt::Error::Config("dsn is required"))?;
+            // Parse DSN prefix to select driver, open connection
             Ok(())
         }
 
         // Implement the IndexedDB gRPC service methods
     }
 
-    gestalt::export_indexeddb_provider!(constructor = MyDatastore::default);
+    gestalt::export_indexeddb_provider!(constructor = RelationalDB::default);
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -109,13 +136,17 @@ A datastore provider implements the `IndexedDB` gRPC service, which maps to thes
 
     export const provider = defineIndexedDBProvider({
       async configure(name, config) {
-        // Initialize from config.dsn
+        const dsn = config.dsn;
+        if (!dsn) throw new Error("relationaldb: dsn is required");
+        // Parse DSN prefix to select driver, open connection
       },
       // Implement the IndexedDB service methods
     });
     ```
   </Tabs.Tab>
 </Tabs>
+
+Each language follows the same pattern: read the `dsn` from config, determine the database driver from the URL prefix, and open a connection. The remaining IndexedDB methods translate object store operations into SQL queries against that connection.
 
 ## Plugin SDK
 
@@ -252,7 +283,7 @@ Plugins access datastores through the SDK. The host serves the IndexedDB interfa
 
 ## Config reference
 
-Reference a datastore provider in the `providers.indexeddbs` section, and set `server.indexeddb` to the name of the active provider:
+Reference a datastore provider in the `providers.indexeddbs` section, and set `server.indexeddb` to the name of the active provider. For local development, SQLite keeps things simple with a file path:
 
 ```yaml
 server:
@@ -262,12 +293,12 @@ providers:
   indexeddbs:
     main:
       source:
-        path: ./my-datastore/manifest.yaml
+        path: ./relationaldb/manifest.yaml
       config:
-        dsn: ${DATABASE_URL}
+        dsn: sqlite://gestalt.db
 ```
 
-`source.path` points at the provider's `manifest.yaml` during development. For production, use `source.ref` and `version` to reference a published release:
+For production, use `source.ref` and `version` to reference a published release, and point the DSN at your Postgres instance:
 
 ```yaml
 providers:
@@ -279,6 +310,8 @@ providers:
       config:
         dsn: ${DATABASE_URL}
 ```
+
+`DATABASE_URL` is typically a connection string like `postgres://user:pass@host:5432/gestalt`. The RelationalDB provider also accepts `mysql://`, `sqlite://`, and `sqlserver://` prefixes.
 
 The plugin receives the `IndexedDB` interface over a gRPC socket. Object store names are automatically namespaced per plugin to prevent cross-plugin data access.
 

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -4,38 +4,58 @@ import { Tabs } from 'nextra/components'
 
 Plugins are one provider kind. Their manifests use a top-level `spec:` block, and deployments reference them under `providers.plugins`. A plugin can define operations as executable code (handled by the provider process), as passthrough surfaces (REST, OpenAPI, GraphQL, or MCP endpoints forwarded by the host), or both.
 
+The examples on this page use a Slack plugin as the running example, since it demonstrates most plugin features: OAuth connections, REST passthrough surfaces, executable operations, and MCP.
+
 ## Manifest
 
-Static metadata, auth, and passthrough surfaces live in a manifest file. Gestalt accepts `manifest.yaml`, `manifest.yml`, or `manifest.json`.
+You declare static metadata, connections, and passthrough surfaces in a manifest file. Gestalt accepts `manifest.yaml`, `manifest.yml`, or `manifest.json`.
 
 <Tabs items={['YAML', 'JSON']}>
   <Tabs.Tab>
     ```yaml
     kind: plugin
-    source: github.com/example/plugins/my-plugin
-    version: 0.0.1-alpha.1
-    displayName: My Plugin
-    description: A custom plugin
+    source: github.com/your-org/plugins/slack
+    version: 0.0.1
+    displayName: Slack
+    description: Send messages, search conversations, and manage channels.
     spec:
+      mcp: true
       connections:
         default:
           auth:
-            type: none
+            type: oauth2
+            authorizationUrl: https://slack.com/oauth/v2/authorize
+            tokenUrl: https://slack.com/api/oauth.v2.access
+            accessTokenPath: authed_user.access_token
+            scopeParam: user_scope
+            scopeSeparator: ','
+            scopes:
+              - channels:read
+              - chat:write
+              - search:read
+              - users:read
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```json
     {
       "kind": "plugin",
-      "source": "github.com/example/plugins/my-plugin",
-      "version": "0.0.1-alpha.1",
-      "displayName": "My Plugin",
-      "description": "A custom plugin",
+      "source": "github.com/your-org/plugins/slack",
+      "version": "0.0.1",
+      "displayName": "Slack",
+      "description": "Send messages, search conversations, and manage channels.",
       "spec": {
+        "mcp": true,
         "connections": {
           "default": {
             "auth": {
-              "type": "none"
+              "type": "oauth2",
+              "authorizationUrl": "https://slack.com/oauth/v2/authorize",
+              "tokenUrl": "https://slack.com/api/oauth.v2.access",
+              "accessTokenPath": "authed_user.access_token",
+              "scopeParam": "user_scope",
+              "scopeSeparator": ",",
+              "scopes": ["channels:read", "chat:write", "search:read", "users:read"]
             }
           }
         }
@@ -45,9 +65,9 @@ Static metadata, auth, and passthrough surfaces live in a manifest file. Gestalt
   </Tabs.Tab>
 </Tabs>
 
-The manifest stays the source of truth for display name, description, auth, the connection model, and any passthrough API surfaces (REST, OpenAPI, GraphQL, or MCP). See [Provider Manifests](/reference/plugin-manifests) for the full field reference.
+The manifest is the source of truth for display name, description, the connection model, and any passthrough API surfaces (REST, OpenAPI, GraphQL, or MCP). Setting `spec.mcp: true` exposes the plugin's operations through Gestalt's MCP server. See [Provider Manifests](/reference/plugin-manifests) for the full field reference.
 
-`source` may include nested segments after the repository, such as `github.com/example/plugins/catalog/my-plugin`. Gestalt keeps the final segment as the plugin name and uses the full path for release tag resolution.
+`source` may include nested segments after the repository, such as `github.com/your-org/plugins/catalog/slack`. Gestalt keeps the final segment as the plugin name and uses the full path for release tag resolution.
 
 ## Creating a project
 
@@ -56,15 +76,15 @@ The manifest stays the source of truth for display name, description, auth, the 
     You need Go 1.26+ and a running `gestaltd` instance for testing.
 
     ```sh
-    mkdir my-plugin && cd my-plugin
-    go mod init example.com/my-plugin
+    mkdir slack && cd slack
+    go mod init github.com/your-org/plugins/slack
     go get github.com/valon-technologies/gestalt/sdk/go
     ```
 
     Recommended layout:
 
     ```text
-    my-plugin/
+    slack/
       go.mod
       manifest.yaml
       provider.go
@@ -74,13 +94,13 @@ The manifest stays the source of truth for display name, description, auth, the 
     You need Python 3.10+ and a running `gestaltd` instance for testing.
 
     ```sh
-    mkdir my-plugin && cd my-plugin
+    mkdir slack && cd slack
     ```
 
     Recommended layout:
 
     ```text
-    my-plugin/
+    slack/
       pyproject.toml
       manifest.yaml
       provider.py
@@ -90,8 +110,8 @@ The manifest stays the source of truth for display name, description, auth, the 
 
     ```toml
     [project]
-    name = "my-plugin"
-    version = "0.0.1-alpha.1"
+    name = "gestalt-slack"
+    version = "0.0.1"
     dependencies = ["gestalt"]
 
     [tool.uv]
@@ -105,14 +125,14 @@ The manifest stays the source of truth for display name, description, auth, the 
     You need the current stable Rust toolchain, Cargo, and a running `gestaltd` instance for testing.
 
     ```sh
-    mkdir my-plugin && cd my-plugin
+    mkdir slack && cd slack
     cargo init --lib
     ```
 
     Recommended layout:
 
     ```text
-    my-plugin/
+    slack/
       Cargo.toml
       manifest.yaml
       src/
@@ -123,12 +143,12 @@ The manifest stays the source of truth for display name, description, auth, the 
 
     ```toml
     [package]
-    name = "my-plugin"
-    version = "0.0.1-alpha.1"
+    name = "gestalt-slack"
+    version = "0.0.1"
     edition = "2024"
 
     [dependencies]
-    gestalt = { git = "https://github.com/valon-technologies/gestalt", tag = "sdk/rust/v0.0.1-alpha.1" }
+    gestalt = { git = "https://github.com/valon-technologies/gestalt", tag = "sdk/rust/v0.0.1" }
     schemars = { version = "0.8", features = ["derive"] }
     serde = { version = "1", features = ["derive"] }
     serde_json = "1"
@@ -140,7 +160,7 @@ The manifest stays the source of truth for display name, description, auth, the 
     You need Bun 1.3+ and a running `gestaltd` instance for testing.
 
     ```sh
-    mkdir my-plugin && cd my-plugin
+    mkdir slack && cd slack
     bun init -y
     bun add @valon-technologies/gestalt
     ```
@@ -148,7 +168,7 @@ The manifest stays the source of truth for display name, description, auth, the 
     Recommended layout:
 
     ```text
-    my-plugin/
+    slack/
       package.json
       manifest.yaml
       provider.ts
@@ -158,12 +178,12 @@ The manifest stays the source of truth for display name, description, auth, the 
 
     ```json
     {
-      "name": "my-plugin",
-      "version": "0.0.1-alpha.1",
+      "name": "gestalt-slack",
+      "version": "0.0.1",
       "private": true,
       "type": "module",
       "dependencies": {
-        "@valon-technologies/gestalt": "0.0.1-alpha.1"
+        "@valon-technologies/gestalt": "0.0.1"
       },
       "gestalt": {
         "provider": {
@@ -196,6 +216,8 @@ The manifest stays the source of truth for display name, description, auth, the 
 
 Operations are the callable units of a plugin. Each operation has an ID, an HTTP method, input and output types, and a handler function. You do not write an entrypoint. Gestalt synthesizes the executable wrapper automatically for local source execution and release.
 
+The following example defines a `conversations.getMessage` operation that fetches a single Slack message by channel and timestamp. The handler uses the caller's OAuth token from the request context to call the Slack API.
+
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
@@ -203,61 +225,47 @@ Operations are the callable units of a plugin. Each operation has an ID, an HTTP
 
     import (
       "context"
-      "fmt"
       "net/http"
 
       gestalt "github.com/valon-technologies/gestalt/sdk/go"
     )
 
-    type Provider struct {
-      greeting string
+    type Provider struct{}
+
+    type GetMessageInput struct {
+      Channel string `json:"channel" doc:"Channel ID"        required:"true"`
+      TS      string `json:"ts"      doc:"Message timestamp" required:"true"`
     }
 
-    type GreetInput struct {
-      Name string `json:"name,omitempty" doc:"Name to greet"`
-    }
-
-    type GreetOutput struct {
-      Message string `json:"message"`
+    type GetMessageOutput struct {
+      Message map[string]any `json:"message"`
     }
 
     var (
-      greetOperation = gestalt.Operation[GreetInput, GreetOutput]{
-        ID:          "greet",
+      getMessageOp = gestalt.Operation[GetMessageInput, GetMessageOutput]{
+        ID:          "conversations.getMessage",
         Method:      http.MethodGet,
-        Description: "Return a greeting message",
+        Description: "Get a single message from a Slack channel",
       }
       Router = gestalt.MustRouter(
-        gestalt.Register(greetOperation, (*Provider).greet),
+        gestalt.Register(getMessageOp, (*Provider).getMessage),
       )
     )
 
-    func New() *Provider {
-      return &Provider{}
-    }
+    func New() *Provider { return &Provider{} }
 
-    func (p *Provider) Configure(_ context.Context, _ string, config map[string]any) error {
-      if g, ok := config["greeting"].(string); ok {
-        p.greeting = g
-      }
+    func (p *Provider) Configure(_ context.Context, _ string, _ map[string]any) error {
       return nil
     }
 
-    func (p *Provider) greet(
-      _ context.Context,
-      input GreetInput,
-      _ gestalt.Request,
-    ) (gestalt.Response[GreetOutput], error) {
-      greeting := p.greeting
-      if greeting == "" {
-        greeting = "Hello"
-      }
-      if input.Name == "" {
-        input.Name = "World"
-      }
-      return gestalt.OK(GreetOutput{
-        Message: fmt.Sprintf("%s, %s!", greeting, input.Name),
-      }), nil
+    func (p *Provider) getMessage(
+      ctx context.Context,
+      input GetMessageInput,
+      req gestalt.Request,
+    ) (gestalt.Response[GetMessageOutput], error) {
+      // Call Slack API using req.Token as Bearer token.
+      // Fetch conversations.history filtered to the single message at input.TS.
+      return gestalt.OK(GetMessageOutput{Message: map[string]any{"ts": input.TS}}), nil
     }
     ```
   </Tabs.Tab>
@@ -265,128 +273,99 @@ Operations are the callable units of a plugin. Each operation has an ID, an HTTP
     ```python
     import gestalt
 
-    greeting = "Hello"
+
+    class GetMessageInput(gestalt.Model):
+        channel: str = gestalt.field(description="Channel ID")
+        ts: str = gestalt.field(description="Message timestamp")
 
 
-    def configure(name, config):
-        global greeting
-        greeting = config.get("greeting", "Hello")
-
-
-    class GreetInput(gestalt.Model):
-        name: str = gestalt.field(description="Name to greet", default="World")
-
-
-    class GreetOutput(gestalt.Model):
-        message: str
+    class GetMessageOutput(gestalt.Model):
+        message: dict
 
 
     @gestalt.operation(
         method="GET",
-        description="Return a greeting message",
-        read_only=True,
+        description="Get a single message from a Slack channel",
     )
-    def greet(input: GreetInput, _req: gestalt.Request) -> GreetOutput:
-        return GreetOutput(message=f"{greeting}, {input.name}!")
+    def conversations_getMessage(
+        input: GetMessageInput, req: gestalt.Request
+    ) -> GetMessageOutput:
+        # Call Slack API using req.token as Bearer token.
+        # Fetch conversations.history filtered to the single message at input.ts.
+        return GetMessageOutput(message={"ts": input.ts})
     ```
 
-    The top-level `configure(name, config)` function runs once at startup. It does not need a decorator.
+    The top-level `configure(name, config)` function runs once at startup if defined. It does not need a decorator.
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
-    use std::sync::{Arc, Mutex};
-
     use serde::{Deserialize, Serialize};
+    use std::sync::Arc;
 
-    pub struct Provider {
-        greeting: Mutex<String>,
-    }
-
-    impl Default for Provider {
-        fn default() -> Self {
-            Self {
-                greeting: Mutex::new("Hello".to_string()),
-            }
-        }
-    }
+    pub struct Provider;
 
     #[gestalt::async_trait]
     impl gestalt::Provider for Provider {
         async fn configure(
-            &self,
-            _name: &str,
-            config: serde_json::Map<String, serde_json::Value>,
+            &self, _name: &str, _config: serde_json::Map<String, serde_json::Value>,
         ) -> gestalt::Result<()> {
-            let greeting = config
-                .get("greeting")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("Hello")
-                .to_string();
-            *self.greeting.lock().expect("lock greeting") = greeting;
             Ok(())
         }
     }
 
     #[derive(Deserialize, schemars::JsonSchema)]
-    pub struct GreetInput {
-        #[schemars(description = "Name to greet")]
-        name: Option<String>,
+    pub struct GetMessageInput {
+        #[schemars(description = "Channel ID")]
+        channel: String,
+        #[schemars(description = "Message timestamp")]
+        ts: String,
     }
 
     #[derive(Serialize, schemars::JsonSchema)]
-    pub struct GreetOutput {
-        message: String,
-    }
-
-    pub fn new() -> Provider {
-        Provider::default()
+    pub struct GetMessageOutput {
+        message: serde_json::Value,
     }
 
     pub fn router() -> gestalt::Result<gestalt::Router<Provider>> {
         gestalt::Router::new().register(
-            gestalt::Operation::<GreetInput, GreetOutput>::new("greet")
-                .method("GET")
-                .description("Return a greeting message")
-                .read_only(true),
-            |provider: Arc<Provider>, input: GreetInput, _request: gestalt::Request| async move {
-                let greeting = provider.greeting.lock().expect("lock greeting").clone();
-                let name = input.name.unwrap_or_else(|| "World".to_string());
-                Ok::<gestalt::Response<GreetOutput>, std::convert::Infallible>(gestalt::ok(
-                    GreetOutput {
-                        message: format!("{greeting}, {name}!"),
-                    },
-                ))
+            gestalt::Operation::<GetMessageInput, GetMessageOutput>::new(
+                "conversations.getMessage",
+            )
+            .method("GET")
+            .description("Get a single message from a Slack channel"),
+            |_provider: Arc<Provider>, input: GetMessageInput, request: gestalt::Request| async move {
+                // Call Slack API using request.token as Bearer token.
+                let _ = (input, request);
+                todo!("fetch conversations.history")
             },
         )
     }
 
-    gestalt::export_provider!(constructor = new, router = router);
+    gestalt::export_provider!(constructor = Provider, router = router);
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```typescript
     import { defineIntegrationProvider, ok, operation, s } from "@valon-technologies/gestalt";
 
-    let greeting = "Hello";
-
     export const provider = defineIntegrationProvider({
-      configure(_name, config) {
-        greeting = (config.greeting as string) ?? "Hello";
-      },
       operations: [
         operation({
-          id: "greet",
+          id: "conversations.getMessage",
           method: "GET",
-          description: "Return a greeting message",
+          description: "Get a single message from a Slack channel",
           readOnly: true,
           input: s.object({
-            name: s.string({ description: "Name to greet", default: "World" }),
+            channel: s.string({ description: "Channel ID" }),
+            ts: s.string({ description: "Message timestamp" }),
           }),
           output: s.object({
-            message: s.string(),
+            message: s.any({ description: "The Slack message object" }),
           }),
-          handler(input) {
-            return ok({ message: `${greeting}, ${input.name}!` });
+          async handler(input, request) {
+            // Call Slack API using request.token as Bearer token.
+            // Fetch conversations.history filtered to the single message at input.ts.
+            return ok({ message: { ts: input.ts } });
           },
         }),
       ],
@@ -409,10 +388,10 @@ The router derives catalog parameters from the input type. Fields are required b
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
-    type SearchInput struct {
-      Query    string `json:"query"              doc:"Search query"         required:"true"`
-      MaxItems int    `json:"max_items,omitempty" doc:"Maximum results"      default:"10"`
-      Filters  Filter `json:"filters,omitempty"   doc:"Optional filter set"`
+    type ListMessagesInput struct {
+      Channel string `json:"channel"            doc:"Channel ID"              required:"true"`
+      Limit   int    `json:"limit,omitempty"    doc:"Maximum messages"        default:"100"`
+      Oldest  string `json:"oldest,omitempty"   doc:"Unix timestamp bound"`
     }
     ```
 
@@ -420,10 +399,10 @@ The router derives catalog parameters from the input type. Fields are required b
   </Tabs.Tab>
   <Tabs.Tab>
     ```python
-    class SearchInput(gestalt.Model):
-        query: str = gestalt.field(description="Search query")
-        max_items: int = gestalt.field(description="Maximum results", default=10)
-        filters: Filter | None = gestalt.field(description="Optional filter set", default=None)
+    class ListMessagesInput(gestalt.Model):
+        channel: str = gestalt.field(description="Channel ID")
+        limit: int = gestalt.field(description="Maximum messages", default=100)
+        oldest: str | None = gestalt.field(description="Unix timestamp bound", default=None)
     ```
 
     Fields without a default are required. Use `gestalt.field(description="...")` for descriptions and `default=...` for default values.
@@ -431,18 +410,18 @@ The router derives catalog parameters from the input type. Fields are required b
   <Tabs.Tab>
     ```rust
     #[derive(serde::Deserialize, schemars::JsonSchema)]
-    struct SearchInput {
-        #[schemars(description = "Search query")]
-        query: String,
-        #[serde(default = "default_max_items")]
-        #[schemars(description = "Maximum results")]
-        max_items: u32,
-        #[schemars(description = "Optional filter set")]
-        filters: Option<Filter>,
+    struct ListMessagesInput {
+        #[schemars(description = "Channel ID")]
+        channel: String,
+        #[serde(default = "default_limit")]
+        #[schemars(description = "Maximum messages")]
+        limit: u32,
+        #[schemars(description = "Unix timestamp bound")]
+        oldest: Option<String>,
     }
 
-    fn default_max_items() -> u32 {
-        10
+    fn default_limit() -> u32 {
+        100
     }
     ```
 
@@ -450,17 +429,10 @@ The router derives catalog parameters from the input type. Fields are required b
   </Tabs.Tab>
   <Tabs.Tab>
     ```ts
-    const SearchInput = s.object({
-      query: s.string({ description: "Search query" }),
-      max_items: s.integer({ description: "Maximum results", default: 10 }),
-      filters: s.optional(
-        s.object(
-          {
-            status: s.optional(s.string()),
-          },
-          { description: "Optional filter set" },
-        ),
-      ),
+    const ListMessagesInput = s.object({
+      channel: s.string({ description: "Channel ID" }),
+      limit: s.integer({ description: "Maximum messages", default: 100 }),
+      oldest: s.optional(s.string({ description: "Unix timestamp bound" })),
     });
     ```
 
@@ -470,15 +442,101 @@ The router derives catalog parameters from the input type. Fields are required b
   </Tabs.Tab>
 </Tabs>
 
+## Declarative plugins
+
+Not every plugin needs executable code. If the upstream API is already reachable over HTTP, you can expose it as a set of REST operations declared entirely in the manifest. Gestalt forwards each invocation to the upstream, injecting the caller's credentials automatically. No provider process runs.
+
+The following manifest exposes three Slack API endpoints as Gestalt operations, with no code at all:
+
+```yaml
+kind: plugin
+source: github.com/your-org/plugins/slack-readonly
+version: 0.0.1
+displayName: Slack (read-only)
+description: Read Slack channels and messages via the REST API.
+spec:
+  mcp: true
+  surfaces:
+    rest:
+      baseUrl: https://slack.com
+      operations:
+        - name: conversations.list
+          description: List conversations and channels
+          method: GET
+          path: /api/conversations.list
+          parameters:
+            - name: limit
+              type: int
+              in: query
+            - name: types
+              type: string
+              in: query
+        - name: conversations.history
+          description: Read message history for a channel
+          method: GET
+          path: /api/conversations.history
+          parameters:
+            - name: channel
+              type: string
+              in: query
+              required: true
+            - name: limit
+              type: int
+              in: query
+            - name: oldest
+              type: string
+              in: query
+        - name: users.list
+          description: List workspace users
+          method: GET
+          path: /api/users.list
+          parameters:
+            - name: limit
+              type: int
+              in: query
+  connections:
+    default:
+      auth:
+        type: oauth2
+        authorizationUrl: https://slack.com/oauth/v2/authorize
+        tokenUrl: https://slack.com/api/oauth.v2.access
+        accessTokenPath: authed_user.access_token
+        scopeParam: user_scope
+        scopeSeparator: ','
+        scopes:
+          - channels:read
+          - users:read
+```
+
+You configure a declarative plugin the same way as any other. Point the config at the manifest, and the declared operations appear in the catalog:
+
+```yaml
+providers:
+  plugins:
+    slack-readonly:
+      source:
+        path: ./slack-readonly/manifest.yaml
+```
+
+```sh
+gestalt invoke slack-readonly conversations.list -p limit=5
+```
+
+Gestalt handles OAuth token injection, request formatting, and response passthrough. The `spec.surfaces.rest.baseUrl` is the root for all declared paths, and each operation's `parameters` define how input fields map to query parameters or request body fields.
+
+You can also declare OpenAPI, GraphQL, and MCP surfaces using `spec.surfaces.openapi`, `spec.surfaces.graphql`, and `spec.surfaces.mcp`. See [Provider Manifests](/reference/plugin-manifests) for the full surface schema.
+
 ## Operation ID conventions
 
-Operation IDs should use period-separated hierarchical names. For example, a Slack plugin might use `messages.list`, `messages.send`, `channels.list`, and `channels.archive`.
+Operation IDs should use period-separated hierarchical names. The Slack plugin uses `conversations.list`, `conversations.history`, `chat.postMessage`, and `users.info`.
 
-This convention enables prefix matching in the CLI. When you run `gestalt invoke slack messages`, the CLI joins the space-separated segments with periods and shows all operations whose ID starts with `messages.`. This makes large catalogs navigable without memorizing every operation name.
+This convention enables prefix matching in the CLI. When you run `gestalt invoke slack conversations`, the CLI joins the space-separated segments with periods and shows all operations whose ID starts with `conversations.`. This makes large catalogs navigable without memorizing every operation name.
 
 ## Dynamic catalogs
 
 By default, the operation catalog is static and materialized at startup. If your plugin needs to expose different operations depending on the caller's credentials or runtime state, implement a session catalog.
+
+A Slack plugin could use this to check which Slack workspace the caller is connected to and adjust the available operations accordingly.
 
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
@@ -487,12 +545,12 @@ By default, the operation catalog is static and materialized at startup. If your
     ```go
     func (p *Provider) CatalogForRequest(ctx context.Context, token string) (*gestalt.Catalog, error) {
         return &gestalt.Catalog{
-            Name:        "my-plugin-session",
-            DisplayName: token,
+            Name:        "slack-session",
+            DisplayName: "Slack",
             Operations: []gestalt.CatalogOperation{
                 {
-                    ID:     "search_private",
-                    Method: http.MethodPost,
+                    ID:     "conversations.getMessage",
+                    Method: http.MethodGet,
                     Annotations: gestalt.OperationAnnotations{
                         ReadOnlyHint: true,
                     },
@@ -509,12 +567,12 @@ By default, the operation catalog is static and materialized at startup. If your
     @gestalt.session_catalog
     def dynamic_catalog(request: gestalt.Request) -> gestalt.Catalog:
         return gestalt.Catalog(
-            name="my-plugin-session",
-            display_name=request.token,
+            name="slack-session",
+            display_name="Slack",
             operations=[
                 gestalt.CatalogOperation(
-                    id="search_private",
-                    method="POST",
+                    id="conversations.getMessage",
+                    method="GET",
                     read_only=True,
                 )
             ],
@@ -536,11 +594,11 @@ By default, the operation catalog is static and materialized at startup. If your
             request: &gestalt::Request,
         ) -> gestalt::Result<Option<gestalt::Catalog>> {
             Ok(Some(gestalt::Catalog {
-                name: "my-plugin-session".to_string(),
-                display_name: request.token.clone(),
+                name: "slack-session".to_string(),
+                display_name: "Slack".to_string(),
                 operations: vec![gestalt::CatalogOperation {
-                    id: "search_private".to_string(),
-                    method: "POST".to_string(),
+                    id: "conversations.getMessage".to_string(),
+                    method: "GET".to_string(),
                     annotations: Some(gestalt::OperationAnnotations {
                         read_only_hint: Some(true),
                         ..Default::default()
@@ -560,12 +618,12 @@ By default, the operation catalog is static and materialized at startup. If your
     export const provider = defineIntegrationProvider({
       sessionCatalog(request) {
         return {
-          name: "my-plugin-session",
-          displayName: request.token,
+          name: "slack-session",
+          displayName: "Slack",
           operations: [
             {
-              id: "search_private",
-              method: "POST",
+              id: "conversations.getMessage",
+              method: "GET",
               readOnly: true,
             },
           ],
@@ -584,28 +642,30 @@ Point a local config at the source plugin. Gestalt synthesizes the executable wr
 ```yaml
 providers:
   plugins:
-    my-plugin:
+    slack:
       source:
-        path: ./manifest.yaml
-      config:
-        greeting: Hello
+        path: ./slack/manifest.yaml
+      allowedHosts:
+        - slack.com
 ```
 
-Start the server and invoke the operation:
+Start the server and invoke an operation:
 
 ```sh
 gestaltd serve --config ./config.yaml
 ```
 
 ```sh
-gestalt invoke my-plugin greet -p name=Gestalt
+gestalt invoke slack conversations.getMessage -p channel=C01ABC23DEF -p ts=1712161829.000300
 ```
 
 If your plugin makes outbound HTTP requests and you see 403 errors, check `allowedHosts`. Executable providers run inside a network sandbox, and requests to hosts not in the allowlist are rejected. Add every upstream domain the provider contacts to `allowedHosts` in the config or manifest.
 
 ## Hybrid providers
 
-A manifest can define passthrough surfaces (`spec.surfaces.openapi`, `spec.surfaces.rest`, `spec.surfaces.graphql`, or `spec.surfaces.mcp`) alongside executable operations. The passthrough surfaces are forwarded by the host directly to the upstream API, while the executable operations are handled by the provider process. This is useful when a plugin adds custom logic on top of an existing API.
+A manifest can define passthrough surfaces alongside executable operations. The passthrough surfaces are forwarded by the host directly to the upstream API, while the executable operations are handled by the provider process.
+
+The first-party Slack plugin is a hybrid provider. It declares 14 REST operations in its manifest (such as `chat.postMessage`, `conversations.list`, and `users.info`) that Gestalt forwards directly to the Slack API. On top of those, it defines 3 executable operations (such as `conversations.getMessage`) that add custom logic like URL parsing and multi-API orchestration. Both sets of operations appear in the same catalog.
 
 Do not define the same operation ID in both a passthrough surface and an executable operation. If two surfaces expose the same ID, the provider fails validation at startup. Use `allowedOperations` to filter or alias collisions when needed.
 

--- a/docs/content/providers/secrets.mdx
+++ b/docs/content/providers/secrets.mdx
@@ -6,16 +6,18 @@ Secrets providers resolve named secrets at server startup. When the Gestalt conf
 
 The built-in `env` and `file` providers cover local development. For production deployments that store secrets in a cloud vault, use an external secrets provider.
 
+The examples on this page use a Google Secret Manager provider as the running example.
+
 ## Manifest
 
-A secrets provider manifest uses a `spec` block with `kind: secrets`:
+A secrets provider manifest declares `kind: secrets`:
 
 ```yaml
 kind: secrets
-source: github.com/example/plugins/my-secrets
-version: 0.0.1-alpha.1
-displayName: My Secrets Provider
-description: Resolves secrets from a custom vault.
+source: github.com/your-org/secrets/google
+version: 0.0.1
+displayName: Google Secret Manager
+description: Resolves secrets from Google Cloud Secret Manager.
 spec:
   configSchemaPath: ./secrets_config.json
 ```
@@ -34,104 +36,123 @@ A secrets provider implements two methods: `Configure` and `GetSecret`. `Configu
     import (
     	"context"
     	"fmt"
-    	"os"
 
+    	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+    	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
     	gestalt "github.com/valon-technologies/gestalt/sdk/go"
     )
 
-    type MySecrets struct {
-    	prefix string
+    type GoogleSecrets struct {
+    	client  *secretmanager.Client
+    	project string
+    	version string
     }
 
-    func (s *MySecrets) Configure(_ context.Context, _ string, config map[string]any) error {
-    	s.prefix, _ = config["prefix"].(string)
-    	return nil
-    }
-
-    func (s *MySecrets) GetSecret(_ context.Context, name string) (string, error) {
-    	key := s.prefix + name
-    	value, ok := os.LookupEnv(key)
-    	if !ok {
-    		return "", fmt.Errorf("secret %q not found", name)
+    func (s *GoogleSecrets) Configure(ctx context.Context, _ string, config map[string]any) error {
+    	s.project, _ = config["project"].(string)
+    	if s.project == "" {
+    		return fmt.Errorf("project is required")
     	}
-    	return value, nil
+    	s.version, _ = config["version"].(string)
+    	if s.version == "" {
+    		s.version = "latest"
+    	}
+    	var err error
+    	s.client, err = secretmanager.NewClient(ctx)
+    	return err
+    }
+
+    func (s *GoogleSecrets) GetSecret(ctx context.Context, name string) (string, error) {
+    	resp, err := s.client.AccessSecretVersion(ctx, &secretmanagerpb.AccessSecretVersionRequest{
+    		Name: fmt.Sprintf("projects/%s/secrets/%s/versions/%s", s.project, name, s.version),
+    	})
+    	if err != nil {
+    		return "", err
+    	}
+    	return string(resp.Payload.Data), nil
     }
 
     func main() {
-    	gestalt.ServeSecretsProvider(context.Background(), &MySecrets{})
+    	gestalt.ServeSecretsProvider(context.Background(), &GoogleSecrets{})
     }
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```python
-    import os
+    from google.cloud import secretmanager
     import gestalt
 
-    class MySecrets(gestalt.SecretsProvider):
+    class GoogleSecrets(gestalt.SecretsProvider):
         def configure(self, name: str, config: dict) -> None:
-            self.prefix = config.get("prefix", "")
+            self.project = config["project"]
+            self.version = config.get("version", "latest")
+            self.client = secretmanager.SecretManagerServiceClient()
 
         def get_secret(self, name: str) -> str:
-            key = self.prefix + name
-            value = os.environ.get(key)
-            if value is None:
-                raise KeyError(f"secret {name!r} not found")
-            return value
+            resource = f"projects/{self.project}/secrets/{name}/versions/{self.version}"
+            response = self.client.access_secret_version(request={"name": resource})
+            return response.payload.data.decode("utf-8")
 
-    MySecrets().serve()
+    GoogleSecrets().serve()
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
     use std::sync::Mutex;
-
     use gestalt::SecretsProvider;
 
-    pub struct MySecrets {
-        prefix: Mutex<String>,
+    pub struct GoogleSecrets {
+        project: Mutex<String>,
+        version: Mutex<String>,
     }
 
     #[gestalt::async_trait]
-    impl SecretsProvider for MySecrets {
+    impl SecretsProvider for GoogleSecrets {
         async fn configure(
-            &self,
-            _name: &str,
-            config: serde_json::Map<String, serde_json::Value>,
+            &self, _name: &str, config: serde_json::Map<String, serde_json::Value>,
         ) -> gestalt::Result<()> {
-            *self.prefix.lock().unwrap() = config
-                .get("prefix").and_then(|v| v.as_str()).unwrap_or("").to_string();
+            *self.project.lock().unwrap() = config
+                .get("project").and_then(|v| v.as_str())
+                .ok_or_else(|| gestalt::Error::config("project is required"))?
+                .to_string();
+            *self.version.lock().unwrap() = config
+                .get("version").and_then(|v| v.as_str())
+                .unwrap_or("latest").to_string();
             Ok(())
         }
 
         async fn get_secret(&self, name: &str) -> gestalt::Result<String> {
-            let prefix = self.prefix.lock().unwrap().clone();
-            let key = format!("{prefix}{name}");
-            std::env::var(&key).map_err(|_| {
-                gestalt::Error::not_found(format!("secret {name:?} not found"))
-            })
+            let project = self.project.lock().unwrap().clone();
+            let version = self.version.lock().unwrap().clone();
+            // Call Secret Manager API with projects/{project}/secrets/{name}/versions/{version}
+            todo!()
         }
     }
 
-    gestalt::export_secrets_provider!(constructor = MySecrets::default);
+    gestalt::export_secrets_provider!(constructor = GoogleSecrets::default);
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```typescript
+    import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
     import { defineSecretsProvider } from "@valon-technologies/gestalt";
 
-    let prefix = "";
+    let client: SecretManagerServiceClient;
+    let project = "";
+    let version = "latest";
 
     export const provider = defineSecretsProvider({
       configure(_name, config) {
-        prefix = (config.prefix as string) ?? "";
+        project = config.project as string;
+        if (!project) throw new Error("project is required");
+        version = (config.version as string) ?? "latest";
+        client = new SecretManagerServiceClient();
       },
-      getSecret(name) {
-        const key = prefix + name;
-        const value = process.env[key];
-        if (value === undefined) {
-          throw new Error(`secret "${name}" not found`);
-        }
-        return value;
+      async getSecret(name) {
+        const [resp] = await client.accessSecretVersion({
+          name: `projects/${project}/secrets/${name}/versions/${version}`,
+        });
+        return resp.payload?.data?.toString() ?? "";
       },
     });
     ```
@@ -146,19 +167,19 @@ To use a secrets provider in a Gestalt deployment, reference it in the `provider
 providers:
   secrets:
     source:
-      path: ./my-secrets/manifest.yaml
+      path: ./google-secrets/manifest.yaml
     config:
-      prefix: MY_APP_
+      project: my-gcp-project
 ```
 
-`source.path` points at the secrets provider's `manifest.yaml` during development. For production, use `source.ref` and `version` to reference a published release:
+`source.path` points at the provider's `manifest.yaml` during development. For production, use `source.ref` and `version` to reference a published release:
 
 ```yaml
 providers:
   secrets:
     source:
       ref: github.com/valon-technologies/gestalt-providers/secrets/google
-      version: 0.0.1-alpha.1
+      version: 0.0.1
     config:
       project: my-gcp-project
 ```

--- a/docs/content/providers/web-uis.mdx
+++ b/docs/content/providers/web-uis.mdx
@@ -8,14 +8,21 @@ A UI bundle is not a plugin in the executable sense. It contains no server-side 
 
 ## Manifest
 
-A UI bundle manifest declares `spec.assetRoot`, which points to the directory containing the built static assets:
+The Default Web UI manifest declares `spec.assetRoot`, which points to the directory containing the built static assets. The source field identifies the provider in the registry.
 
 ```yaml
 kind: webui
-source: github.com/acme/plugins/gestalt-ui
-version: 1.2.0
+source: github.com/valon-technologies/gestalt-providers/web/default
+version: 0.0.1
+displayName: Default Web UI
+description: Default Gestalt web UI bundle served at /.
+release:
+  build:
+    command:
+      - sh
+      - ./build.sh
 spec:
-  assetRoot: ui/out
+  assetRoot: out
 ```
 
 The `assetRoot` path is relative to the manifest file. It should contain the output of your frontend build (typically an `index.html` and accompanying JS, CSS, and image files).
@@ -24,22 +31,23 @@ The `assetRoot` path is relative to the manifest file. It should contain the out
 
 If your UI needs a build step before packaging, use `release.build` to run it automatically during `gestaltd provider release`. This runs before source-manifest preparation, so the built assets are included in the release archive.
 
+The Default Web UI uses a shell script that runs `npm ci && npm run build` to produce the static output:
+
 ```yaml
 kind: webui
-source: github.com/acme/plugins/gestalt-ui
-version: 1.2.0
+source: github.com/valon-technologies/gestalt-providers/web/default
+version: 0.0.1
 release:
   build:
-    workdir: ui
     command:
       - npm
       - run
       - build
 spec:
-  assetRoot: ui/out
+  assetRoot: out
 ```
 
-`workdir` is relative to the manifest directory. The command runs in that directory, so `npm run build` executes inside `ui/`. After the build completes, Gestalt packages everything under `assetRoot` into the release archive.
+The command runs relative to the manifest directory. After the build completes, Gestalt packages everything under `assetRoot` into the release archive. You can use any build tool here -- `npm run build`, `vite build`, `next build && next export` -- as long as it writes output to the directory specified in `assetRoot`.
 
 ## Configuring a UI bundle
 
@@ -49,7 +57,7 @@ Reference a UI bundle in the `providers.ui` block of the server config. During d
 providers:
   ui:
     source:
-      path: ./gestalt-ui/manifest.yaml
+      path: ./web-default/manifest.yaml
 ```
 
 For production, reference a published release by source and version:
@@ -58,8 +66,8 @@ For production, reference a published release by source and version:
 providers:
   ui:
     source:
-      ref: github.com/acme/plugins/gestalt-ui
-      version: 1.2.0
+      ref: github.com/valon-technologies/gestalt-providers/web/default
+      version: 0.0.1
 ```
 
 When a config references a published UI bundle, run `gestaltd init` to resolve and prepare it. This writes lock state to `gestalt.lock.json` and extracts the assets under `.gestaltd/`. After init, `gestaltd serve --locked` serves the locked UI bundle at `/`. If the prepared UI files are already present, Gestalt uses them directly; if they are missing, Gestalt can materialize them from the lockfile at startup.
@@ -75,7 +83,7 @@ The built-in admin UI is always served at `/admin`, regardless of whether a cust
 UI bundles use the same release system as provider packages:
 
 ```sh
-gestaltd provider release --version 1.2.0
+gestaltd provider release --version 0.0.1
 ```
 
 Run this from the directory containing the manifest. If `release.build` is defined, the build command runs first, then Gestalt packages the manifest and the asset root into a release archive. See [Releasing](/providers/releasing) for details on release archives, tag resolution, and prepared state.


### PR DESCRIPTION
## Summary

- Replaces generic placeholder examples (MyPlugin, MyAuth, MyDatastore, MySecrets) with real first-party provider domains: Slack for plugins, Google OAuth for auth, RelationalDB for IndexedDB, Google Secret Manager for secrets, Default Web UI for web bundles
- Adds a new "Declarative plugins" section to the plugins page showing how to expose REST operations purely through the manifest with no executable code
- Implementation details unrelated to the Gestalt SDK interface are described in comments rather than spelled out in full

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>