### PR TITLE
Add IndexedDB cursor support to the Go SDK

### DIFF
--- a/gestaltd/core/indexeddb/datastore.go
+++ b/gestaltd/core/indexeddb/datastore.go
@@ -8,6 +8,17 @@ import (
 var (
 	ErrNotFound      = errors.New("datastore: not found")
 	ErrAlreadyExists = errors.New("datastore: already exists")
+	ErrKeysOnly      = errors.New("datastore: value not available on key-only cursor")
+)
+
+// CursorDirection controls the traversal order of a cursor.
+type CursorDirection string
+
+const (
+	CursorNext       CursorDirection = "next"
+	CursorNextUnique CursorDirection = "nextunique"
+	CursorPrev       CursorDirection = "prev"
+	CursorPrevUnique CursorDirection = "prevunique"
 )
 
 type Record = map[string]any
@@ -40,6 +51,10 @@ type ObjectStore interface {
 
 	// Index access
 	Index(name string) Index
+
+	// Cursor iteration
+	OpenCursor(ctx context.Context, r *KeyRange, dir CursorDirection) (Cursor, error)
+	OpenKeyCursor(ctx context.Context, r *KeyRange, dir CursorDirection) (Cursor, error)
 }
 
 // Index provides queries on a named index.
@@ -51,6 +66,52 @@ type Index interface {
 	GetAllKeys(ctx context.Context, r *KeyRange, values ...any) ([]string, error)
 	Count(ctx context.Context, r *KeyRange, values ...any) (int64, error)
 	Delete(ctx context.Context, values ...any) (int64, error)
+
+	// Cursor iteration
+	OpenCursor(ctx context.Context, r *KeyRange, dir CursorDirection, values ...any) (Cursor, error)
+	OpenKeyCursor(ctx context.Context, r *KeyRange, dir CursorDirection, values ...any) (Cursor, error)
+}
+
+// Cursor iterates over records in an object store or index.
+// Modeled after IDBCursor / IDBCursorWithValue.
+//
+// Usage:
+//
+//	cursor, err := store.OpenCursor(ctx, nil, indexeddb.CursorNext)
+//	if err != nil { ... }
+//	defer cursor.Close()
+//	for cursor.Continue(ctx) {
+//	    rec, _ := cursor.Value()
+//	    // ...
+//	}
+//	if err := cursor.Err(); err != nil { ... }
+type Cursor interface {
+	// Continue advances to the next record. Returns false when exhausted.
+	Continue(ctx context.Context) bool
+	// ContinueToKey advances to the next record whose key is >= the given key
+	// (or <= for reverse cursors).
+	ContinueToKey(ctx context.Context, key any) bool
+	// Advance skips count records, then positions on the next one.
+	Advance(ctx context.Context, count int) bool
+
+	// Key returns the cursor's current key (index key for index cursors,
+	// primary key for object store cursors).
+	Key() any
+	// PrimaryKey returns the primary key at the cursor's current position.
+	PrimaryKey() string
+	// Value returns the record at the cursor's current position.
+	// Returns ErrKeysOnly if the cursor was opened via OpenKeyCursor.
+	Value() (Record, error)
+
+	// Delete removes the record at the cursor's current position.
+	Delete(ctx context.Context) error
+	// Update replaces the record at the cursor's current position.
+	Update(ctx context.Context, value Record) error
+
+	// Err returns any error encountered during iteration.
+	Err() error
+	// Close releases cursor resources. Must be called when done.
+	Close() error
 }
 
 // KeyRange represents a range over keys, modeled after IDBKeyRange.

--- a/gestaltd/core/testing/indexeddb_stub.go
+++ b/gestaltd/core/testing/indexeddb_stub.go
@@ -2,6 +2,8 @@ package coretesting
 
 import (
 	"context"
+	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
@@ -191,6 +193,44 @@ func (o *stubObjectStore) Index(name string) indexeddb.Index {
 	return &stubIndex{store: o, name: name, schema: o.schema}
 }
 
+func (o *stubObjectStore) OpenCursor(_ context.Context, _ *indexeddb.KeyRange, dir indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	if o.db.Err != nil {
+		return nil, o.db.Err
+	}
+	return o.newCursor(dir, false), nil
+}
+
+func (o *stubObjectStore) OpenKeyCursor(_ context.Context, _ *indexeddb.KeyRange, dir indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	if o.db.Err != nil {
+		return nil, o.db.Err
+	}
+	return o.newCursor(dir, true), nil
+}
+
+func (o *stubObjectStore) newCursor(dir indexeddb.CursorDirection, keysOnly bool) *stubCursor {
+	o.mu.RLock()
+	keys := make([]string, 0, len(o.records))
+	snapshot := make(map[string]indexeddb.Record, len(o.records))
+	for k, r := range o.records {
+		keys = append(keys, k)
+		snapshot[k] = r
+	}
+	o.mu.RUnlock()
+
+	sort.Strings(keys)
+	if dir == indexeddb.CursorPrev || dir == indexeddb.CursorPrevUnique {
+		sort.Sort(sort.Reverse(sort.StringSlice(keys)))
+	}
+
+	return &stubCursor{
+		store:    o,
+		keys:     keys,
+		snapshot: snapshot,
+		pos:      -1,
+		keysOnly: keysOnly,
+	}
+}
+
 type stubIndex struct {
 	store  *stubObjectStore
 	name   string
@@ -307,5 +347,128 @@ func (idx *stubIndex) Delete(_ context.Context, values ...any) (int64, error) {
 	}
 	return int64(len(toDelete)), nil
 }
+
+func (idx *stubIndex) OpenCursor(_ context.Context, _ *indexeddb.KeyRange, dir indexeddb.CursorDirection, values ...any) (indexeddb.Cursor, error) {
+	if idx.store.db.Err != nil {
+		return nil, idx.store.db.Err
+	}
+	c := idx.store.newCursor(dir, false)
+	c.filterIndex = idx
+	c.filterValues = values
+	c.applyIndexFilter()
+	return c, nil
+}
+
+func (idx *stubIndex) OpenKeyCursor(_ context.Context, _ *indexeddb.KeyRange, dir indexeddb.CursorDirection, values ...any) (indexeddb.Cursor, error) {
+	if idx.store.db.Err != nil {
+		return nil, idx.store.db.Err
+	}
+	c := idx.store.newCursor(dir, true)
+	c.filterIndex = idx
+	c.filterValues = values
+	c.applyIndexFilter()
+	return c, nil
+}
+
+type stubCursor struct {
+	store        *stubObjectStore
+	keys         []string
+	snapshot     map[string]indexeddb.Record
+	pos          int
+	keysOnly     bool
+	err          error
+	filterIndex  *stubIndex
+	filterValues []any
+}
+
+func (c *stubCursor) applyIndexFilter() {
+	if c.filterIndex == nil {
+		return
+	}
+	filtered := c.keys[:0]
+	for _, k := range c.keys {
+		if rec, ok := c.snapshot[k]; ok && c.filterIndex.matches(rec, c.filterValues) {
+			filtered = append(filtered, k)
+		}
+	}
+	c.keys = filtered
+}
+
+func (c *stubCursor) Continue(_ context.Context) bool {
+	if c.err != nil {
+		return false
+	}
+	c.pos++
+	return c.pos < len(c.keys)
+}
+
+func (c *stubCursor) ContinueToKey(_ context.Context, key any) bool {
+	if c.err != nil {
+		return false
+	}
+	target := fmt.Sprint(key)
+	for c.pos++; c.pos < len(c.keys); c.pos++ {
+		if c.keys[c.pos] >= target {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *stubCursor) Advance(_ context.Context, count int) bool {
+	if c.err != nil {
+		return false
+	}
+	c.pos += count
+	return c.pos < len(c.keys)
+}
+
+func (c *stubCursor) Key() any {
+	if c.pos < 0 || c.pos >= len(c.keys) {
+		return nil
+	}
+	return c.keys[c.pos]
+}
+
+func (c *stubCursor) PrimaryKey() string {
+	if c.pos < 0 || c.pos >= len(c.keys) {
+		return ""
+	}
+	return c.keys[c.pos]
+}
+
+func (c *stubCursor) Value() (indexeddb.Record, error) {
+	if c.keysOnly {
+		return nil, indexeddb.ErrKeysOnly
+	}
+	if c.pos < 0 || c.pos >= len(c.keys) {
+		return nil, indexeddb.ErrNotFound
+	}
+	return c.snapshot[c.keys[c.pos]], nil
+}
+
+func (c *stubCursor) Delete(_ context.Context) error {
+	if c.pos < 0 || c.pos >= len(c.keys) {
+		return indexeddb.ErrNotFound
+	}
+	c.store.mu.Lock()
+	delete(c.store.records, c.keys[c.pos])
+	c.store.mu.Unlock()
+	return nil
+}
+
+func (c *stubCursor) Update(_ context.Context, value indexeddb.Record) error {
+	if c.pos < 0 || c.pos >= len(c.keys) {
+		return indexeddb.ErrNotFound
+	}
+	c.store.mu.Lock()
+	c.store.records[c.keys[c.pos]] = value
+	c.store.mu.Unlock()
+	c.snapshot[c.keys[c.pos]] = value
+	return nil
+}
+
+func (c *stubCursor) Err() error   { return c.err }
+func (c *stubCursor) Close() error { return nil }
 
 var _ indexeddb.IndexedDB = (*StubIndexedDB)(nil)

--- a/gestaltd/core/testing/indexeddb_stub.go
+++ b/gestaltd/core/testing/indexeddb_stub.go
@@ -222,12 +222,14 @@ func (o *stubObjectStore) newCursor(dir indexeddb.CursorDirection, keysOnly bool
 		sort.Sort(sort.Reverse(sort.StringSlice(keys)))
 	}
 
+	reverse := dir == indexeddb.CursorPrev || dir == indexeddb.CursorPrevUnique
 	return &stubCursor{
 		store:    o,
 		keys:     keys,
 		snapshot: snapshot,
 		pos:      -1,
 		keysOnly: keysOnly,
+		reverse:  reverse,
 	}
 }
 
@@ -356,6 +358,7 @@ func (idx *stubIndex) OpenCursor(_ context.Context, _ *indexeddb.KeyRange, dir i
 	c.filterIndex = idx
 	c.filterValues = values
 	c.applyIndexFilter()
+	c.buildIndexKeys()
 	return c, nil
 }
 
@@ -367,18 +370,44 @@ func (idx *stubIndex) OpenKeyCursor(_ context.Context, _ *indexeddb.KeyRange, di
 	c.filterIndex = idx
 	c.filterValues = values
 	c.applyIndexFilter()
+	c.buildIndexKeys()
 	return c, nil
 }
 
 type stubCursor struct {
 	store        *stubObjectStore
 	keys         []string
+	indexKeys    []any
 	snapshot     map[string]indexeddb.Record
 	pos          int
 	keysOnly     bool
+	reverse      bool
 	err          error
 	filterIndex  *stubIndex
 	filterValues []any
+}
+
+func (c *stubCursor) buildIndexKeys() {
+	if c.filterIndex == nil {
+		return
+	}
+	kp := c.filterIndex.keyPath()
+	if kp == nil {
+		return
+	}
+	c.indexKeys = make([]any, len(c.keys))
+	for i, k := range c.keys {
+		rec := c.snapshot[k]
+		if len(kp) == 1 {
+			c.indexKeys[i] = rec[kp[0]]
+		} else {
+			vals := make([]any, len(kp))
+			for j, field := range kp {
+				vals[j] = rec[field]
+			}
+			c.indexKeys[i] = vals
+		}
+	}
 }
 
 func (c *stubCursor) applyIndexFilter() {
@@ -408,8 +437,14 @@ func (c *stubCursor) ContinueToKey(_ context.Context, key any) bool {
 	}
 	target := fmt.Sprint(key)
 	for c.pos++; c.pos < len(c.keys); c.pos++ {
-		if c.keys[c.pos] >= target {
-			return true
+		if c.reverse {
+			if c.keys[c.pos] <= target {
+				return true
+			}
+		} else {
+			if c.keys[c.pos] >= target {
+				return true
+			}
 		}
 	}
 	return false
@@ -426,6 +461,9 @@ func (c *stubCursor) Advance(_ context.Context, count int) bool {
 func (c *stubCursor) Key() any {
 	if c.pos < 0 || c.pos >= len(c.keys) {
 		return nil
+	}
+	if c.indexKeys != nil {
+		return c.indexKeys[c.pos]
 	}
 	return c.keys[c.pos]
 }

--- a/gestaltd/core/testing/indexeddb_stub.go
+++ b/gestaltd/core/testing/indexeddb_stub.go
@@ -408,6 +408,28 @@ func (c *stubCursor) buildIndexKeys() {
 			c.indexKeys[i] = vals
 		}
 	}
+	sort.Sort(&indexKeySorter{keys: c.keys, indexKeys: c.indexKeys, reverse: c.reverse})
+}
+
+type indexKeySorter struct {
+	keys      []string
+	indexKeys []any
+	reverse   bool
+}
+
+func (s *indexKeySorter) Len() int { return len(s.keys) }
+
+func (s *indexKeySorter) Swap(i, j int) {
+	s.keys[i], s.keys[j] = s.keys[j], s.keys[i]
+	s.indexKeys[i], s.indexKeys[j] = s.indexKeys[j], s.indexKeys[i]
+}
+
+func (s *indexKeySorter) Less(i, j int) bool {
+	a, b := fmt.Sprint(s.indexKeys[i]), fmt.Sprint(s.indexKeys[j])
+	if s.reverse {
+		return a > b
+	}
+	return a < b
 }
 
 func (c *stubCursor) applyIndexFilter() {

--- a/gestaltd/internal/metricutil/indexeddb.go
+++ b/gestaltd/internal/metricutil/indexeddb.go
@@ -126,6 +126,20 @@ func (s *instrumentedObjectStore) Index(name string) indexeddb.Index {
 	return &instrumentedIndex{inner: s.inner.Index(name), store: s.store}
 }
 
+func (s *instrumentedObjectStore) OpenCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	startedAt := time.Now()
+	c, err := s.inner.OpenCursor(ctx, r, dir)
+	RecordIndexedDBMetrics(ctx, startedAt, s.store, "OpenCursor", err != nil)
+	return c, err
+}
+
+func (s *instrumentedObjectStore) OpenKeyCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	startedAt := time.Now()
+	c, err := s.inner.OpenKeyCursor(ctx, r, dir)
+	RecordIndexedDBMetrics(ctx, startedAt, s.store, "OpenKeyCursor", err != nil)
+	return c, err
+}
+
 type instrumentedIndex struct {
 	inner indexeddb.Index
 	store string
@@ -171,4 +185,18 @@ func (i *instrumentedIndex) Delete(ctx context.Context, values ...any) (int64, e
 	n, err := i.inner.Delete(ctx, values...)
 	RecordIndexedDBMetrics(ctx, startedAt, i.store, "Index.Delete", err != nil)
 	return n, err
+}
+
+func (i *instrumentedIndex) OpenCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection, values ...any) (indexeddb.Cursor, error) {
+	startedAt := time.Now()
+	c, err := i.inner.OpenCursor(ctx, r, dir, values...)
+	RecordIndexedDBMetrics(ctx, startedAt, i.store, "Index.OpenCursor", err != nil)
+	return c, err
+}
+
+func (i *instrumentedIndex) OpenKeyCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection, values ...any) (indexeddb.Cursor, error) {
+	startedAt := time.Now()
+	c, err := i.inner.OpenKeyCursor(ctx, r, dir, values...)
+	RecordIndexedDBMetrics(ctx, startedAt, i.store, "Index.OpenKeyCursor", err != nil)
+	return c, err
 }

--- a/gestaltd/internal/pluginhost/indexeddb_client.go
+++ b/gestaltd/internal/pluginhost/indexeddb_client.go
@@ -592,7 +592,11 @@ func (c *remoteCursor) Update(_ context.Context, value indexeddb.Record) error {
 		return grpcToDatastoreErr(err)
 	}
 	_, err = c.stream.Recv()
-	return grpcToDatastoreErr(err)
+	if err != nil {
+		return grpcToDatastoreErr(err)
+	}
+	c.entry.Record = pbRec
+	return nil
 }
 
 func (c *remoteCursor) Err() error { return c.err }

--- a/gestaltd/internal/pluginhost/indexeddb_client.go
+++ b/gestaltd/internal/pluginhost/indexeddb_client.go
@@ -448,8 +448,10 @@ func openRemoteCursor(ctx context.Context, client proto.IndexedDBClient, store, 
 			return nil, err
 		}
 	}
-	stream, err := client.OpenCursor(ctx)
+	streamCtx, streamCancel := context.WithCancel(ctx)
+	stream, err := client.OpenCursor(streamCtx)
 	if err != nil {
+		streamCancel()
 		return nil, grpcToDatastoreErr(err)
 	}
 	if err := stream.Send(&proto.CursorClientMessage{
@@ -462,13 +464,15 @@ func openRemoteCursor(ctx context.Context, client proto.IndexedDBClient, store, 
 			Values:    pbValues,
 		}},
 	}); err != nil {
+		streamCancel()
 		return nil, grpcToDatastoreErr(err)
 	}
-	return &remoteCursor{stream: stream, keysOnly: keysOnly}, nil
+	return &remoteCursor{stream: stream, cancel: streamCancel, keysOnly: keysOnly}, nil
 }
 
 type remoteCursor struct {
 	stream   proto.IndexedDB_OpenCursorClient
+	cancel   context.CancelFunc
 	keysOnly bool
 	entry    *proto.CursorEntry
 	err      error
@@ -602,7 +606,9 @@ func (c *remoteCursor) Close() error {
 			Command: &proto.CursorCommand_Close{Close: true},
 		}},
 	})
-	return c.stream.CloseSend()
+	_ = c.stream.CloseSend()
+	c.cancel()
+	return nil
 }
 
 var _ indexeddb.IndexedDB = (*remoteIndexedDB)(nil)

--- a/gestaltd/internal/pluginhost/indexeddb_client.go
+++ b/gestaltd/internal/pluginhost/indexeddb_client.go
@@ -595,7 +595,9 @@ func (c *remoteCursor) Update(_ context.Context, value indexeddb.Record) error {
 	if err != nil {
 		return grpcToDatastoreErr(err)
 	}
-	c.entry.Record = pbRec
+	if c.entry != nil {
+		c.entry.Record = pbRec
+	}
 	return nil
 }
 

--- a/gestaltd/internal/pluginhost/indexeddb_client.go
+++ b/gestaltd/internal/pluginhost/indexeddb_client.go
@@ -232,6 +232,14 @@ func (o *remoteObjectStore) Index(name string) indexeddb.Index {
 	return &remoteIndex{client: o.client, store: o.store, index: name}
 }
 
+func (o *remoteObjectStore) OpenCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	return openRemoteCursor(ctx, o.client, o.store, "", r, dir, false, nil)
+}
+
+func (o *remoteObjectStore) OpenKeyCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	return openRemoteCursor(ctx, o.client, o.store, "", r, dir, true, nil)
+}
+
 // --- Index ---
 
 type remoteIndex struct {
@@ -340,6 +348,14 @@ func (idx *remoteIndex) Count(ctx context.Context, r *indexeddb.KeyRange, values
 	return resp.GetCount(), nil
 }
 
+func (idx *remoteIndex) OpenCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection, values ...any) (indexeddb.Cursor, error) {
+	return openRemoteCursor(ctx, idx.client, idx.store, idx.index, r, dir, false, values)
+}
+
+func (idx *remoteIndex) OpenKeyCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection, values ...any) (indexeddb.Cursor, error) {
+	return openRemoteCursor(ctx, idx.client, idx.store, idx.index, r, dir, true, values)
+}
+
 func (idx *remoteIndex) Delete(ctx context.Context, values ...any) (int64, error) {
 	ctx, cancel := providerCallContext(ctx)
 	defer cancel()
@@ -403,6 +419,190 @@ func grpcToDatastoreErr(err error) error {
 	default:
 		return err
 	}
+}
+
+// --- Remote Cursor ---
+
+func cursorDirectionToProto(dir indexeddb.CursorDirection) proto.CursorDirection {
+	switch dir {
+	case indexeddb.CursorNextUnique:
+		return proto.CursorDirection_CURSOR_NEXT_UNIQUE
+	case indexeddb.CursorPrev:
+		return proto.CursorDirection_CURSOR_PREV
+	case indexeddb.CursorPrevUnique:
+		return proto.CursorDirection_CURSOR_PREV_UNIQUE
+	default:
+		return proto.CursorDirection_CURSOR_NEXT
+	}
+}
+
+func openRemoteCursor(ctx context.Context, client proto.IndexedDBClient, store, index string, r *indexeddb.KeyRange, dir indexeddb.CursorDirection, keysOnly bool, values []any) (*remoteCursor, error) {
+	kr, err := keyRangeToProto(r)
+	if err != nil {
+		return nil, err
+	}
+	var pbValues []*proto.TypedValue
+	if len(values) > 0 {
+		pbValues, err = toProtoValues(values)
+		if err != nil {
+			return nil, err
+		}
+	}
+	stream, err := client.OpenCursor(ctx)
+	if err != nil {
+		return nil, grpcToDatastoreErr(err)
+	}
+	if err := stream.Send(&proto.CursorClientMessage{
+		Msg: &proto.CursorClientMessage_Open{Open: &proto.OpenCursorRequest{
+			Store:     store,
+			Range:     kr,
+			Direction: cursorDirectionToProto(dir),
+			KeysOnly:  keysOnly,
+			Index:     index,
+			Values:    pbValues,
+		}},
+	}); err != nil {
+		return nil, grpcToDatastoreErr(err)
+	}
+	return &remoteCursor{stream: stream, keysOnly: keysOnly}, nil
+}
+
+type remoteCursor struct {
+	stream   proto.IndexedDB_OpenCursorClient
+	keysOnly bool
+	entry    *proto.CursorEntry
+	err      error
+	done     bool
+}
+
+func (c *remoteCursor) sendAndRecv(msg *proto.CursorClientMessage) bool {
+	if c.done || c.err != nil {
+		return false
+	}
+	if err := c.stream.Send(msg); err != nil {
+		c.err = grpcToDatastoreErr(err)
+		return false
+	}
+	resp, err := c.stream.Recv()
+	if err != nil {
+		c.err = grpcToDatastoreErr(err)
+		return false
+	}
+	switch v := resp.GetResult().(type) {
+	case *proto.CursorResponse_Entry:
+		c.entry = v.Entry
+		return true
+	case *proto.CursorResponse_Done:
+		if v.Done {
+			c.done = true
+		}
+		return false
+	default:
+		c.err = fmt.Errorf("unexpected cursor response")
+		return false
+	}
+}
+
+func (c *remoteCursor) Continue(_ context.Context) bool {
+	return c.sendAndRecv(&proto.CursorClientMessage{
+		Msg: &proto.CursorClientMessage_Command{Command: &proto.CursorCommand{
+			Command: &proto.CursorCommand_Next{Next: true},
+		}},
+	})
+}
+
+func (c *remoteCursor) ContinueToKey(_ context.Context, key any) bool {
+	tv, err := gestalt.TypedValueFromAny(key)
+	if err != nil {
+		c.err = err
+		return false
+	}
+	return c.sendAndRecv(&proto.CursorClientMessage{
+		Msg: &proto.CursorClientMessage_Command{Command: &proto.CursorCommand{
+			Command: &proto.CursorCommand_ContinueToKey{ContinueToKey: tv},
+		}},
+	})
+}
+
+func (c *remoteCursor) Advance(_ context.Context, count int) bool {
+	return c.sendAndRecv(&proto.CursorClientMessage{
+		Msg: &proto.CursorClientMessage_Command{Command: &proto.CursorCommand{
+			Command: &proto.CursorCommand_Advance{Advance: int32(count)},
+		}},
+	})
+}
+
+func (c *remoteCursor) Key() any {
+	if c.entry == nil || c.entry.Key == nil {
+		return nil
+	}
+	v, _ := gestalt.AnyFromTypedValue(c.entry.Key)
+	return v
+}
+
+func (c *remoteCursor) PrimaryKey() string {
+	if c.entry == nil {
+		return ""
+	}
+	return c.entry.PrimaryKey
+}
+
+func (c *remoteCursor) Value() (indexeddb.Record, error) {
+	if c.keysOnly {
+		return nil, indexeddb.ErrKeysOnly
+	}
+	if c.entry == nil || c.entry.Record == nil {
+		return nil, indexeddb.ErrNotFound
+	}
+	return gestalt.RecordFromProto(c.entry.Record)
+}
+
+func (c *remoteCursor) Delete(_ context.Context) error {
+	if c.done || c.err != nil {
+		return indexeddb.ErrNotFound
+	}
+	if err := c.stream.Send(&proto.CursorClientMessage{
+		Msg: &proto.CursorClientMessage_Command{Command: &proto.CursorCommand{
+			Command: &proto.CursorCommand_Delete{Delete: true},
+		}},
+	}); err != nil {
+		return grpcToDatastoreErr(err)
+	}
+	_, err := c.stream.Recv()
+	return grpcToDatastoreErr(err)
+}
+
+func (c *remoteCursor) Update(_ context.Context, value indexeddb.Record) error {
+	if c.done || c.err != nil {
+		return indexeddb.ErrNotFound
+	}
+	pbRec, err := gestalt.RecordToProto(value)
+	if err != nil {
+		return fmt.Errorf("marshal update record: %w", err)
+	}
+	if err := c.stream.Send(&proto.CursorClientMessage{
+		Msg: &proto.CursorClientMessage_Command{Command: &proto.CursorCommand{
+			Command: &proto.CursorCommand_Update{Update: pbRec},
+		}},
+	}); err != nil {
+		return grpcToDatastoreErr(err)
+	}
+	_, err = c.stream.Recv()
+	return grpcToDatastoreErr(err)
+}
+
+func (c *remoteCursor) Err() error { return c.err }
+
+func (c *remoteCursor) Close() error {
+	if c.stream == nil {
+		return nil
+	}
+	_ = c.stream.Send(&proto.CursorClientMessage{
+		Msg: &proto.CursorClientMessage_Command{Command: &proto.CursorCommand{
+			Command: &proto.CursorCommand_Close{Close: true},
+		}},
+	})
+	return c.stream.CloseSend()
 }
 
 var _ indexeddb.IndexedDB = (*remoteIndexedDB)(nil)

--- a/gestaltd/internal/pluginhost/indexeddb_server.go
+++ b/gestaltd/internal/pluginhost/indexeddb_server.go
@@ -229,6 +229,175 @@ func (s *indexedDBServer) IndexDelete(ctx context.Context, req *proto.IndexQuery
 	return &proto.DeleteResponse{Deleted: deleted}, nil
 }
 
+func protoCursorDirection(d proto.CursorDirection) indexeddb.CursorDirection {
+	switch d {
+	case proto.CursorDirection_CURSOR_NEXT_UNIQUE:
+		return indexeddb.CursorNextUnique
+	case proto.CursorDirection_CURSOR_PREV:
+		return indexeddb.CursorPrev
+	case proto.CursorDirection_CURSOR_PREV_UNIQUE:
+		return indexeddb.CursorPrevUnique
+	default:
+		return indexeddb.CursorNext
+	}
+}
+
+func (s *indexedDBServer) OpenCursor(stream proto.IndexedDB_OpenCursorServer) error {
+	first, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	openReq := first.GetOpen()
+	if openReq == nil {
+		return status.Error(codes.InvalidArgument, "first message must be OpenCursorRequest")
+	}
+
+	keyRange, err := protoToKeyRange(openReq.Range)
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "unmarshal key range: %v", err)
+	}
+	dir := protoCursorDirection(openReq.GetDirection())
+	ctx := stream.Context()
+
+	var cursor indexeddb.Cursor
+	store := s.ds.ObjectStore(s.storeName(openReq.GetStore()))
+
+	if openReq.GetIndex() != "" {
+		values, vErr := protoValuesToAny(openReq.GetValues())
+		if vErr != nil {
+			return status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", vErr)
+		}
+		idx := store.Index(openReq.GetIndex())
+		if openReq.GetKeysOnly() {
+			cursor, err = idx.OpenKeyCursor(ctx, keyRange, dir, values...)
+		} else {
+			cursor, err = idx.OpenCursor(ctx, keyRange, dir, values...)
+		}
+	} else {
+		if openReq.GetKeysOnly() {
+			cursor, err = store.OpenKeyCursor(ctx, keyRange, dir)
+		} else {
+			cursor, err = store.OpenCursor(ctx, keyRange, dir)
+		}
+	}
+	if err != nil {
+		return indexeddbToGRPCErr(err)
+	}
+	defer cursor.Close()
+
+	for {
+		msg, recvErr := stream.Recv()
+		if recvErr != nil {
+			return recvErr
+		}
+		cmd := msg.GetCommand()
+		if cmd == nil {
+			return status.Error(codes.InvalidArgument, "expected CursorCommand after open")
+		}
+
+		switch v := cmd.GetCommand().(type) {
+		case *proto.CursorCommand_Next:
+			if !cursor.Continue(ctx) {
+				if cErr := cursor.Err(); cErr != nil {
+					return indexeddbToGRPCErr(cErr)
+				}
+				return stream.Send(&proto.CursorResponse{Result: &proto.CursorResponse_Done{Done: true}})
+			}
+			entry, eErr := cursorEntryToProto(cursor, openReq.GetKeysOnly())
+			if eErr != nil {
+				return eErr
+			}
+			if sErr := stream.Send(&proto.CursorResponse{Result: &proto.CursorResponse_Entry{Entry: entry}}); sErr != nil {
+				return sErr
+			}
+
+		case *proto.CursorCommand_ContinueToKey:
+			key, kErr := gestalt.AnyFromTypedValue(v.ContinueToKey)
+			if kErr != nil {
+				return status.Errorf(codes.InvalidArgument, "unmarshal continue key: %v", kErr)
+			}
+			if !cursor.ContinueToKey(ctx, key) {
+				if cErr := cursor.Err(); cErr != nil {
+					return indexeddbToGRPCErr(cErr)
+				}
+				return stream.Send(&proto.CursorResponse{Result: &proto.CursorResponse_Done{Done: true}})
+			}
+			entry, eErr := cursorEntryToProto(cursor, openReq.GetKeysOnly())
+			if eErr != nil {
+				return eErr
+			}
+			if sErr := stream.Send(&proto.CursorResponse{Result: &proto.CursorResponse_Entry{Entry: entry}}); sErr != nil {
+				return sErr
+			}
+
+		case *proto.CursorCommand_Advance:
+			if !cursor.Advance(ctx, int(v.Advance)) {
+				if cErr := cursor.Err(); cErr != nil {
+					return indexeddbToGRPCErr(cErr)
+				}
+				return stream.Send(&proto.CursorResponse{Result: &proto.CursorResponse_Done{Done: true}})
+			}
+			entry, eErr := cursorEntryToProto(cursor, openReq.GetKeysOnly())
+			if eErr != nil {
+				return eErr
+			}
+			if sErr := stream.Send(&proto.CursorResponse{Result: &proto.CursorResponse_Entry{Entry: entry}}); sErr != nil {
+				return sErr
+			}
+
+		case *proto.CursorCommand_Delete:
+			if dErr := cursor.Delete(ctx); dErr != nil {
+				return indexeddbToGRPCErr(dErr)
+			}
+			if sErr := stream.Send(&proto.CursorResponse{Result: &proto.CursorResponse_Done{Done: false}}); sErr != nil {
+				return sErr
+			}
+
+		case *proto.CursorCommand_Update:
+			rec, rErr := gestalt.RecordFromProto(v.Update)
+			if rErr != nil {
+				return status.Errorf(codes.InvalidArgument, "unmarshal update record: %v", rErr)
+			}
+			if uErr := cursor.Update(ctx, rec); uErr != nil {
+				return indexeddbToGRPCErr(uErr)
+			}
+			if sErr := stream.Send(&proto.CursorResponse{Result: &proto.CursorResponse_Done{Done: false}}); sErr != nil {
+				return sErr
+			}
+
+		case *proto.CursorCommand_Close:
+			return nil
+
+		default:
+			return status.Error(codes.InvalidArgument, "unknown cursor command")
+		}
+	}
+}
+
+func cursorEntryToProto(c indexeddb.Cursor, keysOnly bool) (*proto.CursorEntry, error) {
+	entry := &proto.CursorEntry{PrimaryKey: c.PrimaryKey()}
+	key := c.Key()
+	if key != nil {
+		tv, err := gestalt.TypedValueFromAny(key)
+		if err != nil {
+			return nil, fmt.Errorf("marshal cursor key: %w", err)
+		}
+		entry.Key = tv
+	}
+	if !keysOnly {
+		rec, err := c.Value()
+		if err != nil {
+			return nil, fmt.Errorf("cursor value: %w", err)
+		}
+		pbRec, err := gestalt.RecordToProto(rec)
+		if err != nil {
+			return nil, fmt.Errorf("marshal cursor record: %w", err)
+		}
+		entry.Record = pbRec
+	}
+	return entry, nil
+}
+
 func recordToProto(rec indexeddb.Record) (*proto.RecordResponse, error) {
 	pbRecord, err := gestalt.RecordToProto(rec)
 	if err != nil {

--- a/sdk/go/gen/v1/datastore.pb.go
+++ b/sdk/go/gen/v1/datastore.pb.go
@@ -24,6 +24,58 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type CursorDirection int32
+
+const (
+	CursorDirection_CURSOR_NEXT        CursorDirection = 0
+	CursorDirection_CURSOR_NEXT_UNIQUE CursorDirection = 1
+	CursorDirection_CURSOR_PREV        CursorDirection = 2
+	CursorDirection_CURSOR_PREV_UNIQUE CursorDirection = 3
+)
+
+// Enum value maps for CursorDirection.
+var (
+	CursorDirection_name = map[int32]string{
+		0: "CURSOR_NEXT",
+		1: "CURSOR_NEXT_UNIQUE",
+		2: "CURSOR_PREV",
+		3: "CURSOR_PREV_UNIQUE",
+	}
+	CursorDirection_value = map[string]int32{
+		"CURSOR_NEXT":        0,
+		"CURSOR_NEXT_UNIQUE": 1,
+		"CURSOR_PREV":        2,
+		"CURSOR_PREV_UNIQUE": 3,
+	}
+)
+
+func (x CursorDirection) Enum() *CursorDirection {
+	p := new(CursorDirection)
+	*p = x
+	return p
+}
+
+func (x CursorDirection) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CursorDirection) Descriptor() protoreflect.EnumDescriptor {
+	return file_v1_datastore_proto_enumTypes[0].Descriptor()
+}
+
+func (CursorDirection) Type() protoreflect.EnumType {
+	return &file_v1_datastore_proto_enumTypes[0]
+}
+
+func (x CursorDirection) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CursorDirection.Descriptor instead.
+func (CursorDirection) EnumDescriptor() ([]byte, []int) {
+	return file_v1_datastore_proto_rawDescGZIP(), []int{0}
+}
+
 type TypedValue struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Kind:
@@ -1042,6 +1094,460 @@ func (x *CountResponse) GetCount() int64 {
 	return 0
 }
 
+type OpenCursorRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Store         string                 `protobuf:"bytes,1,opt,name=store,proto3" json:"store,omitempty"`
+	Range         *KeyRange              `protobuf:"bytes,2,opt,name=range,proto3,oneof" json:"range,omitempty"`
+	Direction     CursorDirection        `protobuf:"varint,3,opt,name=direction,proto3,enum=gestalt.provider.v1.CursorDirection" json:"direction,omitempty"`
+	KeysOnly      bool                   `protobuf:"varint,4,opt,name=keys_only,json=keysOnly,proto3" json:"keys_only,omitempty"`
+	Index         string                 `protobuf:"bytes,5,opt,name=index,proto3" json:"index,omitempty"`
+	Values        []*TypedValue          `protobuf:"bytes,6,rep,name=values,proto3" json:"values,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OpenCursorRequest) Reset() {
+	*x = OpenCursorRequest{}
+	mi := &file_v1_datastore_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OpenCursorRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OpenCursorRequest) ProtoMessage() {}
+
+func (x *OpenCursorRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_datastore_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OpenCursorRequest.ProtoReflect.Descriptor instead.
+func (*OpenCursorRequest) Descriptor() ([]byte, []int) {
+	return file_v1_datastore_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *OpenCursorRequest) GetStore() string {
+	if x != nil {
+		return x.Store
+	}
+	return ""
+}
+
+func (x *OpenCursorRequest) GetRange() *KeyRange {
+	if x != nil {
+		return x.Range
+	}
+	return nil
+}
+
+func (x *OpenCursorRequest) GetDirection() CursorDirection {
+	if x != nil {
+		return x.Direction
+	}
+	return CursorDirection_CURSOR_NEXT
+}
+
+func (x *OpenCursorRequest) GetKeysOnly() bool {
+	if x != nil {
+		return x.KeysOnly
+	}
+	return false
+}
+
+func (x *OpenCursorRequest) GetIndex() string {
+	if x != nil {
+		return x.Index
+	}
+	return ""
+}
+
+func (x *OpenCursorRequest) GetValues() []*TypedValue {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
+type CursorCommand struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Command:
+	//
+	//	*CursorCommand_Next
+	//	*CursorCommand_ContinueToKey
+	//	*CursorCommand_Advance
+	//	*CursorCommand_Update
+	//	*CursorCommand_Delete
+	//	*CursorCommand_Close
+	Command       isCursorCommand_Command `protobuf_oneof:"command"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CursorCommand) Reset() {
+	*x = CursorCommand{}
+	mi := &file_v1_datastore_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CursorCommand) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CursorCommand) ProtoMessage() {}
+
+func (x *CursorCommand) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_datastore_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CursorCommand.ProtoReflect.Descriptor instead.
+func (*CursorCommand) Descriptor() ([]byte, []int) {
+	return file_v1_datastore_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *CursorCommand) GetCommand() isCursorCommand_Command {
+	if x != nil {
+		return x.Command
+	}
+	return nil
+}
+
+func (x *CursorCommand) GetNext() bool {
+	if x != nil {
+		if x, ok := x.Command.(*CursorCommand_Next); ok {
+			return x.Next
+		}
+	}
+	return false
+}
+
+func (x *CursorCommand) GetContinueToKey() *TypedValue {
+	if x != nil {
+		if x, ok := x.Command.(*CursorCommand_ContinueToKey); ok {
+			return x.ContinueToKey
+		}
+	}
+	return nil
+}
+
+func (x *CursorCommand) GetAdvance() int32 {
+	if x != nil {
+		if x, ok := x.Command.(*CursorCommand_Advance); ok {
+			return x.Advance
+		}
+	}
+	return 0
+}
+
+func (x *CursorCommand) GetUpdate() *Record {
+	if x != nil {
+		if x, ok := x.Command.(*CursorCommand_Update); ok {
+			return x.Update
+		}
+	}
+	return nil
+}
+
+func (x *CursorCommand) GetDelete() bool {
+	if x != nil {
+		if x, ok := x.Command.(*CursorCommand_Delete); ok {
+			return x.Delete
+		}
+	}
+	return false
+}
+
+func (x *CursorCommand) GetClose() bool {
+	if x != nil {
+		if x, ok := x.Command.(*CursorCommand_Close); ok {
+			return x.Close
+		}
+	}
+	return false
+}
+
+type isCursorCommand_Command interface {
+	isCursorCommand_Command()
+}
+
+type CursorCommand_Next struct {
+	Next bool `protobuf:"varint,1,opt,name=next,proto3,oneof"`
+}
+
+type CursorCommand_ContinueToKey struct {
+	ContinueToKey *TypedValue `protobuf:"bytes,2,opt,name=continue_to_key,json=continueToKey,proto3,oneof"`
+}
+
+type CursorCommand_Advance struct {
+	Advance int32 `protobuf:"varint,3,opt,name=advance,proto3,oneof"`
+}
+
+type CursorCommand_Update struct {
+	Update *Record `protobuf:"bytes,4,opt,name=update,proto3,oneof"`
+}
+
+type CursorCommand_Delete struct {
+	Delete bool `protobuf:"varint,5,opt,name=delete,proto3,oneof"`
+}
+
+type CursorCommand_Close struct {
+	Close bool `protobuf:"varint,6,opt,name=close,proto3,oneof"`
+}
+
+func (*CursorCommand_Next) isCursorCommand_Command() {}
+
+func (*CursorCommand_ContinueToKey) isCursorCommand_Command() {}
+
+func (*CursorCommand_Advance) isCursorCommand_Command() {}
+
+func (*CursorCommand_Update) isCursorCommand_Command() {}
+
+func (*CursorCommand_Delete) isCursorCommand_Command() {}
+
+func (*CursorCommand_Close) isCursorCommand_Command() {}
+
+type CursorClientMessage struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Msg:
+	//
+	//	*CursorClientMessage_Open
+	//	*CursorClientMessage_Command
+	Msg           isCursorClientMessage_Msg `protobuf_oneof:"msg"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CursorClientMessage) Reset() {
+	*x = CursorClientMessage{}
+	mi := &file_v1_datastore_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CursorClientMessage) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CursorClientMessage) ProtoMessage() {}
+
+func (x *CursorClientMessage) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_datastore_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CursorClientMessage.ProtoReflect.Descriptor instead.
+func (*CursorClientMessage) Descriptor() ([]byte, []int) {
+	return file_v1_datastore_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *CursorClientMessage) GetMsg() isCursorClientMessage_Msg {
+	if x != nil {
+		return x.Msg
+	}
+	return nil
+}
+
+func (x *CursorClientMessage) GetOpen() *OpenCursorRequest {
+	if x != nil {
+		if x, ok := x.Msg.(*CursorClientMessage_Open); ok {
+			return x.Open
+		}
+	}
+	return nil
+}
+
+func (x *CursorClientMessage) GetCommand() *CursorCommand {
+	if x != nil {
+		if x, ok := x.Msg.(*CursorClientMessage_Command); ok {
+			return x.Command
+		}
+	}
+	return nil
+}
+
+type isCursorClientMessage_Msg interface {
+	isCursorClientMessage_Msg()
+}
+
+type CursorClientMessage_Open struct {
+	Open *OpenCursorRequest `protobuf:"bytes,1,opt,name=open,proto3,oneof"`
+}
+
+type CursorClientMessage_Command struct {
+	Command *CursorCommand `protobuf:"bytes,2,opt,name=command,proto3,oneof"`
+}
+
+func (*CursorClientMessage_Open) isCursorClientMessage_Msg() {}
+
+func (*CursorClientMessage_Command) isCursorClientMessage_Msg() {}
+
+type CursorEntry struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Key           *TypedValue            `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	PrimaryKey    string                 `protobuf:"bytes,2,opt,name=primary_key,json=primaryKey,proto3" json:"primary_key,omitempty"`
+	Record        *Record                `protobuf:"bytes,3,opt,name=record,proto3" json:"record,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CursorEntry) Reset() {
+	*x = CursorEntry{}
+	mi := &file_v1_datastore_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CursorEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CursorEntry) ProtoMessage() {}
+
+func (x *CursorEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_datastore_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CursorEntry.ProtoReflect.Descriptor instead.
+func (*CursorEntry) Descriptor() ([]byte, []int) {
+	return file_v1_datastore_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *CursorEntry) GetKey() *TypedValue {
+	if x != nil {
+		return x.Key
+	}
+	return nil
+}
+
+func (x *CursorEntry) GetPrimaryKey() string {
+	if x != nil {
+		return x.PrimaryKey
+	}
+	return ""
+}
+
+func (x *CursorEntry) GetRecord() *Record {
+	if x != nil {
+		return x.Record
+	}
+	return nil
+}
+
+type CursorResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Result:
+	//
+	//	*CursorResponse_Entry
+	//	*CursorResponse_Done
+	Result        isCursorResponse_Result `protobuf_oneof:"result"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CursorResponse) Reset() {
+	*x = CursorResponse{}
+	mi := &file_v1_datastore_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CursorResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CursorResponse) ProtoMessage() {}
+
+func (x *CursorResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_datastore_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CursorResponse.ProtoReflect.Descriptor instead.
+func (*CursorResponse) Descriptor() ([]byte, []int) {
+	return file_v1_datastore_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *CursorResponse) GetResult() isCursorResponse_Result {
+	if x != nil {
+		return x.Result
+	}
+	return nil
+}
+
+func (x *CursorResponse) GetEntry() *CursorEntry {
+	if x != nil {
+		if x, ok := x.Result.(*CursorResponse_Entry); ok {
+			return x.Entry
+		}
+	}
+	return nil
+}
+
+func (x *CursorResponse) GetDone() bool {
+	if x != nil {
+		if x, ok := x.Result.(*CursorResponse_Done); ok {
+			return x.Done
+		}
+	}
+	return false
+}
+
+type isCursorResponse_Result interface {
+	isCursorResponse_Result()
+}
+
+type CursorResponse_Entry struct {
+	Entry *CursorEntry `protobuf:"bytes,1,opt,name=entry,proto3,oneof"`
+}
+
+type CursorResponse_Done struct {
+	Done bool `protobuf:"varint,2,opt,name=done,proto3,oneof"`
+}
+
+func (*CursorResponse_Entry) isCursorResponse_Result() {}
+
+func (*CursorResponse_Done) isCursorResponse_Result() {}
+
 type DeleteResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Deleted       int64                  `protobuf:"varint,1,opt,name=deleted,proto3" json:"deleted,omitempty"`
@@ -1051,7 +1557,7 @@ type DeleteResponse struct {
 
 func (x *DeleteResponse) Reset() {
 	*x = DeleteResponse{}
-	mi := &file_v1_datastore_proto_msgTypes[17]
+	mi := &file_v1_datastore_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1063,7 +1569,7 @@ func (x *DeleteResponse) String() string {
 func (*DeleteResponse) ProtoMessage() {}
 
 func (x *DeleteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_datastore_proto_msgTypes[17]
+	mi := &file_v1_datastore_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1076,7 +1582,7 @@ func (x *DeleteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteResponse.ProtoReflect.Descriptor instead.
 func (*DeleteResponse) Descriptor() ([]byte, []int) {
-	return file_v1_datastore_proto_rawDescGZIP(), []int{17}
+	return file_v1_datastore_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *DeleteResponse) GetDeleted() int64 {
@@ -1095,7 +1601,7 @@ type KeyResponse struct {
 
 func (x *KeyResponse) Reset() {
 	*x = KeyResponse{}
-	mi := &file_v1_datastore_proto_msgTypes[18]
+	mi := &file_v1_datastore_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1107,7 +1613,7 @@ func (x *KeyResponse) String() string {
 func (*KeyResponse) ProtoMessage() {}
 
 func (x *KeyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_datastore_proto_msgTypes[18]
+	mi := &file_v1_datastore_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1120,7 +1626,7 @@ func (x *KeyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KeyResponse.ProtoReflect.Descriptor instead.
 func (*KeyResponse) Descriptor() ([]byte, []int) {
-	return file_v1_datastore_proto_rawDescGZIP(), []int{18}
+	return file_v1_datastore_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *KeyResponse) GetKey() string {
@@ -1208,11 +1714,45 @@ const file_v1_datastore_proto_rawDesc = "" +
 	"\x05range\x18\x04 \x01(\v2\x1d.gestalt.provider.v1.KeyRangeH\x00R\x05range\x88\x01\x01B\b\n" +
 	"\x06_range\"%\n" +
 	"\rCountResponse\x12\x14\n" +
-	"\x05count\x18\x01 \x01(\x03R\x05count\"*\n" +
+	"\x05count\x18\x01 \x01(\x03R\x05count\"\x9d\x02\n" +
+	"\x11OpenCursorRequest\x12\x14\n" +
+	"\x05store\x18\x01 \x01(\tR\x05store\x128\n" +
+	"\x05range\x18\x02 \x01(\v2\x1d.gestalt.provider.v1.KeyRangeH\x00R\x05range\x88\x01\x01\x12B\n" +
+	"\tdirection\x18\x03 \x01(\x0e2$.gestalt.provider.v1.CursorDirectionR\tdirection\x12\x1b\n" +
+	"\tkeys_only\x18\x04 \x01(\bR\bkeysOnly\x12\x14\n" +
+	"\x05index\x18\x05 \x01(\tR\x05index\x127\n" +
+	"\x06values\x18\x06 \x03(\v2\x1f.gestalt.provider.v1.TypedValueR\x06valuesB\b\n" +
+	"\x06_range\"\x80\x02\n" +
+	"\rCursorCommand\x12\x14\n" +
+	"\x04next\x18\x01 \x01(\bH\x00R\x04next\x12I\n" +
+	"\x0fcontinue_to_key\x18\x02 \x01(\v2\x1f.gestalt.provider.v1.TypedValueH\x00R\rcontinueToKey\x12\x1a\n" +
+	"\aadvance\x18\x03 \x01(\x05H\x00R\aadvance\x125\n" +
+	"\x06update\x18\x04 \x01(\v2\x1b.gestalt.provider.v1.RecordH\x00R\x06update\x12\x18\n" +
+	"\x06delete\x18\x05 \x01(\bH\x00R\x06delete\x12\x16\n" +
+	"\x05close\x18\x06 \x01(\bH\x00R\x05closeB\t\n" +
+	"\acommand\"\x9a\x01\n" +
+	"\x13CursorClientMessage\x12<\n" +
+	"\x04open\x18\x01 \x01(\v2&.gestalt.provider.v1.OpenCursorRequestH\x00R\x04open\x12>\n" +
+	"\acommand\x18\x02 \x01(\v2\".gestalt.provider.v1.CursorCommandH\x00R\acommandB\x05\n" +
+	"\x03msg\"\x96\x01\n" +
+	"\vCursorEntry\x121\n" +
+	"\x03key\x18\x01 \x01(\v2\x1f.gestalt.provider.v1.TypedValueR\x03key\x12\x1f\n" +
+	"\vprimary_key\x18\x02 \x01(\tR\n" +
+	"primaryKey\x123\n" +
+	"\x06record\x18\x03 \x01(\v2\x1b.gestalt.provider.v1.RecordR\x06record\"j\n" +
+	"\x0eCursorResponse\x128\n" +
+	"\x05entry\x18\x01 \x01(\v2 .gestalt.provider.v1.CursorEntryH\x00R\x05entry\x12\x14\n" +
+	"\x04done\x18\x02 \x01(\bH\x00R\x04doneB\b\n" +
+	"\x06result\"*\n" +
 	"\x0eDeleteResponse\x12\x18\n" +
 	"\adeleted\x18\x01 \x01(\x03R\adeleted\"\x1f\n" +
 	"\vKeyResponse\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key2\xa9\f\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key*c\n" +
+	"\x0fCursorDirection\x12\x0f\n" +
+	"\vCURSOR_NEXT\x10\x00\x12\x16\n" +
+	"\x12CURSOR_NEXT_UNIQUE\x10\x01\x12\x0f\n" +
+	"\vCURSOR_PREV\x10\x02\x12\x16\n" +
+	"\x12CURSOR_PREV_UNIQUE\x10\x032\x8a\r\n" +
 	"\tIndexedDB\x12Z\n" +
 	"\x11CreateObjectStore\x12-.gestalt.provider.v1.CreateObjectStoreRequest\x1a\x16.google.protobuf.Empty\x12Z\n" +
 	"\x11DeleteObjectStore\x12-.gestalt.provider.v1.DeleteObjectStoreRequest\x1a\x16.google.protobuf.Empty\x12S\n" +
@@ -1233,7 +1773,9 @@ const file_v1_datastore_proto_rawDesc = "" +
 	"\x0fIndexGetAllKeys\x12&.gestalt.provider.v1.IndexQueryRequest\x1a!.gestalt.provider.v1.KeysResponse\x12X\n" +
 	"\n" +
 	"IndexCount\x12&.gestalt.provider.v1.IndexQueryRequest\x1a\".gestalt.provider.v1.CountResponse\x12Z\n" +
-	"\vIndexDelete\x12&.gestalt.provider.v1.IndexQueryRequest\x1a#.gestalt.provider.v1.DeleteResponseB\xd2\x01\n" +
+	"\vIndexDelete\x12&.gestalt.provider.v1.IndexQueryRequest\x1a#.gestalt.provider.v1.DeleteResponse\x12_\n" +
+	"\n" +
+	"OpenCursor\x12(.gestalt.provider.v1.CursorClientMessage\x1a#.gestalt.provider.v1.CursorResponse(\x010\x01B\xd2\x01\n" +
 	"\x17com.gestalt.provider.v1B\x0eDatastoreProtoP\x01Z9github.com/valon-technologies/gestalt/sdk/go/gen/v1;proto\xa2\x02\x03GPX\xaa\x02\x13Gestalt.Provider.V1\xca\x02\x13Gestalt\\Provider\\V1\xe2\x02\x1fGestalt\\Provider\\V1\\GPBMetadata\xea\x02\x15Gestalt::Provider::V1b\x06proto3"
 
 var (
@@ -1248,91 +1790,110 @@ func file_v1_datastore_proto_rawDescGZIP() []byte {
 	return file_v1_datastore_proto_rawDescData
 }
 
-var file_v1_datastore_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
+var file_v1_datastore_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_v1_datastore_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
 var file_v1_datastore_proto_goTypes = []any{
-	(*TypedValue)(nil),               // 0: gestalt.provider.v1.TypedValue
-	(*Record)(nil),                   // 1: gestalt.provider.v1.Record
-	(*ObjectStoreSchema)(nil),        // 2: gestalt.provider.v1.ObjectStoreSchema
-	(*IndexSchema)(nil),              // 3: gestalt.provider.v1.IndexSchema
-	(*ColumnDef)(nil),                // 4: gestalt.provider.v1.ColumnDef
-	(*KeyRange)(nil),                 // 5: gestalt.provider.v1.KeyRange
-	(*RecordRequest)(nil),            // 6: gestalt.provider.v1.RecordRequest
-	(*RecordResponse)(nil),           // 7: gestalt.provider.v1.RecordResponse
-	(*RecordsResponse)(nil),          // 8: gestalt.provider.v1.RecordsResponse
-	(*KeysResponse)(nil),             // 9: gestalt.provider.v1.KeysResponse
-	(*ObjectStoreRequest)(nil),       // 10: gestalt.provider.v1.ObjectStoreRequest
-	(*ObjectStoreNameRequest)(nil),   // 11: gestalt.provider.v1.ObjectStoreNameRequest
-	(*ObjectStoreRangeRequest)(nil),  // 12: gestalt.provider.v1.ObjectStoreRangeRequest
-	(*CreateObjectStoreRequest)(nil), // 13: gestalt.provider.v1.CreateObjectStoreRequest
-	(*DeleteObjectStoreRequest)(nil), // 14: gestalt.provider.v1.DeleteObjectStoreRequest
-	(*IndexQueryRequest)(nil),        // 15: gestalt.provider.v1.IndexQueryRequest
-	(*CountResponse)(nil),            // 16: gestalt.provider.v1.CountResponse
-	(*DeleteResponse)(nil),           // 17: gestalt.provider.v1.DeleteResponse
-	(*KeyResponse)(nil),              // 18: gestalt.provider.v1.KeyResponse
-	nil,                              // 19: gestalt.provider.v1.Record.FieldsEntry
-	(structpb.NullValue)(0),          // 20: google.protobuf.NullValue
-	(*timestamppb.Timestamp)(nil),    // 21: google.protobuf.Timestamp
-	(*structpb.Value)(nil),           // 22: google.protobuf.Value
-	(*emptypb.Empty)(nil),            // 23: google.protobuf.Empty
+	(CursorDirection)(0),             // 0: gestalt.provider.v1.CursorDirection
+	(*TypedValue)(nil),               // 1: gestalt.provider.v1.TypedValue
+	(*Record)(nil),                   // 2: gestalt.provider.v1.Record
+	(*ObjectStoreSchema)(nil),        // 3: gestalt.provider.v1.ObjectStoreSchema
+	(*IndexSchema)(nil),              // 4: gestalt.provider.v1.IndexSchema
+	(*ColumnDef)(nil),                // 5: gestalt.provider.v1.ColumnDef
+	(*KeyRange)(nil),                 // 6: gestalt.provider.v1.KeyRange
+	(*RecordRequest)(nil),            // 7: gestalt.provider.v1.RecordRequest
+	(*RecordResponse)(nil),           // 8: gestalt.provider.v1.RecordResponse
+	(*RecordsResponse)(nil),          // 9: gestalt.provider.v1.RecordsResponse
+	(*KeysResponse)(nil),             // 10: gestalt.provider.v1.KeysResponse
+	(*ObjectStoreRequest)(nil),       // 11: gestalt.provider.v1.ObjectStoreRequest
+	(*ObjectStoreNameRequest)(nil),   // 12: gestalt.provider.v1.ObjectStoreNameRequest
+	(*ObjectStoreRangeRequest)(nil),  // 13: gestalt.provider.v1.ObjectStoreRangeRequest
+	(*CreateObjectStoreRequest)(nil), // 14: gestalt.provider.v1.CreateObjectStoreRequest
+	(*DeleteObjectStoreRequest)(nil), // 15: gestalt.provider.v1.DeleteObjectStoreRequest
+	(*IndexQueryRequest)(nil),        // 16: gestalt.provider.v1.IndexQueryRequest
+	(*CountResponse)(nil),            // 17: gestalt.provider.v1.CountResponse
+	(*OpenCursorRequest)(nil),        // 18: gestalt.provider.v1.OpenCursorRequest
+	(*CursorCommand)(nil),            // 19: gestalt.provider.v1.CursorCommand
+	(*CursorClientMessage)(nil),      // 20: gestalt.provider.v1.CursorClientMessage
+	(*CursorEntry)(nil),              // 21: gestalt.provider.v1.CursorEntry
+	(*CursorResponse)(nil),           // 22: gestalt.provider.v1.CursorResponse
+	(*DeleteResponse)(nil),           // 23: gestalt.provider.v1.DeleteResponse
+	(*KeyResponse)(nil),              // 24: gestalt.provider.v1.KeyResponse
+	nil,                              // 25: gestalt.provider.v1.Record.FieldsEntry
+	(structpb.NullValue)(0),          // 26: google.protobuf.NullValue
+	(*timestamppb.Timestamp)(nil),    // 27: google.protobuf.Timestamp
+	(*structpb.Value)(nil),           // 28: google.protobuf.Value
+	(*emptypb.Empty)(nil),            // 29: google.protobuf.Empty
 }
 var file_v1_datastore_proto_depIdxs = []int32{
-	20, // 0: gestalt.provider.v1.TypedValue.null_value:type_name -> google.protobuf.NullValue
-	21, // 1: gestalt.provider.v1.TypedValue.time_value:type_name -> google.protobuf.Timestamp
-	22, // 2: gestalt.provider.v1.TypedValue.json_value:type_name -> google.protobuf.Value
-	19, // 3: gestalt.provider.v1.Record.fields:type_name -> gestalt.provider.v1.Record.FieldsEntry
-	3,  // 4: gestalt.provider.v1.ObjectStoreSchema.indexes:type_name -> gestalt.provider.v1.IndexSchema
-	4,  // 5: gestalt.provider.v1.ObjectStoreSchema.columns:type_name -> gestalt.provider.v1.ColumnDef
-	0,  // 6: gestalt.provider.v1.KeyRange.lower:type_name -> gestalt.provider.v1.TypedValue
-	0,  // 7: gestalt.provider.v1.KeyRange.upper:type_name -> gestalt.provider.v1.TypedValue
-	1,  // 8: gestalt.provider.v1.RecordRequest.record:type_name -> gestalt.provider.v1.Record
-	1,  // 9: gestalt.provider.v1.RecordResponse.record:type_name -> gestalt.provider.v1.Record
-	1,  // 10: gestalt.provider.v1.RecordsResponse.records:type_name -> gestalt.provider.v1.Record
-	5,  // 11: gestalt.provider.v1.ObjectStoreRangeRequest.range:type_name -> gestalt.provider.v1.KeyRange
-	2,  // 12: gestalt.provider.v1.CreateObjectStoreRequest.schema:type_name -> gestalt.provider.v1.ObjectStoreSchema
-	0,  // 13: gestalt.provider.v1.IndexQueryRequest.values:type_name -> gestalt.provider.v1.TypedValue
-	5,  // 14: gestalt.provider.v1.IndexQueryRequest.range:type_name -> gestalt.provider.v1.KeyRange
-	0,  // 15: gestalt.provider.v1.Record.FieldsEntry.value:type_name -> gestalt.provider.v1.TypedValue
-	13, // 16: gestalt.provider.v1.IndexedDB.CreateObjectStore:input_type -> gestalt.provider.v1.CreateObjectStoreRequest
-	14, // 17: gestalt.provider.v1.IndexedDB.DeleteObjectStore:input_type -> gestalt.provider.v1.DeleteObjectStoreRequest
-	10, // 18: gestalt.provider.v1.IndexedDB.Get:input_type -> gestalt.provider.v1.ObjectStoreRequest
-	10, // 19: gestalt.provider.v1.IndexedDB.GetKey:input_type -> gestalt.provider.v1.ObjectStoreRequest
-	6,  // 20: gestalt.provider.v1.IndexedDB.Add:input_type -> gestalt.provider.v1.RecordRequest
-	6,  // 21: gestalt.provider.v1.IndexedDB.Put:input_type -> gestalt.provider.v1.RecordRequest
-	10, // 22: gestalt.provider.v1.IndexedDB.Delete:input_type -> gestalt.provider.v1.ObjectStoreRequest
-	11, // 23: gestalt.provider.v1.IndexedDB.Clear:input_type -> gestalt.provider.v1.ObjectStoreNameRequest
-	12, // 24: gestalt.provider.v1.IndexedDB.GetAll:input_type -> gestalt.provider.v1.ObjectStoreRangeRequest
-	12, // 25: gestalt.provider.v1.IndexedDB.GetAllKeys:input_type -> gestalt.provider.v1.ObjectStoreRangeRequest
-	12, // 26: gestalt.provider.v1.IndexedDB.Count:input_type -> gestalt.provider.v1.ObjectStoreRangeRequest
-	12, // 27: gestalt.provider.v1.IndexedDB.DeleteRange:input_type -> gestalt.provider.v1.ObjectStoreRangeRequest
-	15, // 28: gestalt.provider.v1.IndexedDB.IndexGet:input_type -> gestalt.provider.v1.IndexQueryRequest
-	15, // 29: gestalt.provider.v1.IndexedDB.IndexGetKey:input_type -> gestalt.provider.v1.IndexQueryRequest
-	15, // 30: gestalt.provider.v1.IndexedDB.IndexGetAll:input_type -> gestalt.provider.v1.IndexQueryRequest
-	15, // 31: gestalt.provider.v1.IndexedDB.IndexGetAllKeys:input_type -> gestalt.provider.v1.IndexQueryRequest
-	15, // 32: gestalt.provider.v1.IndexedDB.IndexCount:input_type -> gestalt.provider.v1.IndexQueryRequest
-	15, // 33: gestalt.provider.v1.IndexedDB.IndexDelete:input_type -> gestalt.provider.v1.IndexQueryRequest
-	23, // 34: gestalt.provider.v1.IndexedDB.CreateObjectStore:output_type -> google.protobuf.Empty
-	23, // 35: gestalt.provider.v1.IndexedDB.DeleteObjectStore:output_type -> google.protobuf.Empty
-	7,  // 36: gestalt.provider.v1.IndexedDB.Get:output_type -> gestalt.provider.v1.RecordResponse
-	18, // 37: gestalt.provider.v1.IndexedDB.GetKey:output_type -> gestalt.provider.v1.KeyResponse
-	23, // 38: gestalt.provider.v1.IndexedDB.Add:output_type -> google.protobuf.Empty
-	23, // 39: gestalt.provider.v1.IndexedDB.Put:output_type -> google.protobuf.Empty
-	23, // 40: gestalt.provider.v1.IndexedDB.Delete:output_type -> google.protobuf.Empty
-	23, // 41: gestalt.provider.v1.IndexedDB.Clear:output_type -> google.protobuf.Empty
-	8,  // 42: gestalt.provider.v1.IndexedDB.GetAll:output_type -> gestalt.provider.v1.RecordsResponse
-	9,  // 43: gestalt.provider.v1.IndexedDB.GetAllKeys:output_type -> gestalt.provider.v1.KeysResponse
-	16, // 44: gestalt.provider.v1.IndexedDB.Count:output_type -> gestalt.provider.v1.CountResponse
-	17, // 45: gestalt.provider.v1.IndexedDB.DeleteRange:output_type -> gestalt.provider.v1.DeleteResponse
-	7,  // 46: gestalt.provider.v1.IndexedDB.IndexGet:output_type -> gestalt.provider.v1.RecordResponse
-	18, // 47: gestalt.provider.v1.IndexedDB.IndexGetKey:output_type -> gestalt.provider.v1.KeyResponse
-	8,  // 48: gestalt.provider.v1.IndexedDB.IndexGetAll:output_type -> gestalt.provider.v1.RecordsResponse
-	9,  // 49: gestalt.provider.v1.IndexedDB.IndexGetAllKeys:output_type -> gestalt.provider.v1.KeysResponse
-	16, // 50: gestalt.provider.v1.IndexedDB.IndexCount:output_type -> gestalt.provider.v1.CountResponse
-	17, // 51: gestalt.provider.v1.IndexedDB.IndexDelete:output_type -> gestalt.provider.v1.DeleteResponse
-	34, // [34:52] is the sub-list for method output_type
-	16, // [16:34] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	26, // 0: gestalt.provider.v1.TypedValue.null_value:type_name -> google.protobuf.NullValue
+	27, // 1: gestalt.provider.v1.TypedValue.time_value:type_name -> google.protobuf.Timestamp
+	28, // 2: gestalt.provider.v1.TypedValue.json_value:type_name -> google.protobuf.Value
+	25, // 3: gestalt.provider.v1.Record.fields:type_name -> gestalt.provider.v1.Record.FieldsEntry
+	4,  // 4: gestalt.provider.v1.ObjectStoreSchema.indexes:type_name -> gestalt.provider.v1.IndexSchema
+	5,  // 5: gestalt.provider.v1.ObjectStoreSchema.columns:type_name -> gestalt.provider.v1.ColumnDef
+	1,  // 6: gestalt.provider.v1.KeyRange.lower:type_name -> gestalt.provider.v1.TypedValue
+	1,  // 7: gestalt.provider.v1.KeyRange.upper:type_name -> gestalt.provider.v1.TypedValue
+	2,  // 8: gestalt.provider.v1.RecordRequest.record:type_name -> gestalt.provider.v1.Record
+	2,  // 9: gestalt.provider.v1.RecordResponse.record:type_name -> gestalt.provider.v1.Record
+	2,  // 10: gestalt.provider.v1.RecordsResponse.records:type_name -> gestalt.provider.v1.Record
+	6,  // 11: gestalt.provider.v1.ObjectStoreRangeRequest.range:type_name -> gestalt.provider.v1.KeyRange
+	3,  // 12: gestalt.provider.v1.CreateObjectStoreRequest.schema:type_name -> gestalt.provider.v1.ObjectStoreSchema
+	1,  // 13: gestalt.provider.v1.IndexQueryRequest.values:type_name -> gestalt.provider.v1.TypedValue
+	6,  // 14: gestalt.provider.v1.IndexQueryRequest.range:type_name -> gestalt.provider.v1.KeyRange
+	6,  // 15: gestalt.provider.v1.OpenCursorRequest.range:type_name -> gestalt.provider.v1.KeyRange
+	0,  // 16: gestalt.provider.v1.OpenCursorRequest.direction:type_name -> gestalt.provider.v1.CursorDirection
+	1,  // 17: gestalt.provider.v1.OpenCursorRequest.values:type_name -> gestalt.provider.v1.TypedValue
+	1,  // 18: gestalt.provider.v1.CursorCommand.continue_to_key:type_name -> gestalt.provider.v1.TypedValue
+	2,  // 19: gestalt.provider.v1.CursorCommand.update:type_name -> gestalt.provider.v1.Record
+	18, // 20: gestalt.provider.v1.CursorClientMessage.open:type_name -> gestalt.provider.v1.OpenCursorRequest
+	19, // 21: gestalt.provider.v1.CursorClientMessage.command:type_name -> gestalt.provider.v1.CursorCommand
+	1,  // 22: gestalt.provider.v1.CursorEntry.key:type_name -> gestalt.provider.v1.TypedValue
+	2,  // 23: gestalt.provider.v1.CursorEntry.record:type_name -> gestalt.provider.v1.Record
+	21, // 24: gestalt.provider.v1.CursorResponse.entry:type_name -> gestalt.provider.v1.CursorEntry
+	1,  // 25: gestalt.provider.v1.Record.FieldsEntry.value:type_name -> gestalt.provider.v1.TypedValue
+	14, // 26: gestalt.provider.v1.IndexedDB.CreateObjectStore:input_type -> gestalt.provider.v1.CreateObjectStoreRequest
+	15, // 27: gestalt.provider.v1.IndexedDB.DeleteObjectStore:input_type -> gestalt.provider.v1.DeleteObjectStoreRequest
+	11, // 28: gestalt.provider.v1.IndexedDB.Get:input_type -> gestalt.provider.v1.ObjectStoreRequest
+	11, // 29: gestalt.provider.v1.IndexedDB.GetKey:input_type -> gestalt.provider.v1.ObjectStoreRequest
+	7,  // 30: gestalt.provider.v1.IndexedDB.Add:input_type -> gestalt.provider.v1.RecordRequest
+	7,  // 31: gestalt.provider.v1.IndexedDB.Put:input_type -> gestalt.provider.v1.RecordRequest
+	11, // 32: gestalt.provider.v1.IndexedDB.Delete:input_type -> gestalt.provider.v1.ObjectStoreRequest
+	12, // 33: gestalt.provider.v1.IndexedDB.Clear:input_type -> gestalt.provider.v1.ObjectStoreNameRequest
+	13, // 34: gestalt.provider.v1.IndexedDB.GetAll:input_type -> gestalt.provider.v1.ObjectStoreRangeRequest
+	13, // 35: gestalt.provider.v1.IndexedDB.GetAllKeys:input_type -> gestalt.provider.v1.ObjectStoreRangeRequest
+	13, // 36: gestalt.provider.v1.IndexedDB.Count:input_type -> gestalt.provider.v1.ObjectStoreRangeRequest
+	13, // 37: gestalt.provider.v1.IndexedDB.DeleteRange:input_type -> gestalt.provider.v1.ObjectStoreRangeRequest
+	16, // 38: gestalt.provider.v1.IndexedDB.IndexGet:input_type -> gestalt.provider.v1.IndexQueryRequest
+	16, // 39: gestalt.provider.v1.IndexedDB.IndexGetKey:input_type -> gestalt.provider.v1.IndexQueryRequest
+	16, // 40: gestalt.provider.v1.IndexedDB.IndexGetAll:input_type -> gestalt.provider.v1.IndexQueryRequest
+	16, // 41: gestalt.provider.v1.IndexedDB.IndexGetAllKeys:input_type -> gestalt.provider.v1.IndexQueryRequest
+	16, // 42: gestalt.provider.v1.IndexedDB.IndexCount:input_type -> gestalt.provider.v1.IndexQueryRequest
+	16, // 43: gestalt.provider.v1.IndexedDB.IndexDelete:input_type -> gestalt.provider.v1.IndexQueryRequest
+	20, // 44: gestalt.provider.v1.IndexedDB.OpenCursor:input_type -> gestalt.provider.v1.CursorClientMessage
+	29, // 45: gestalt.provider.v1.IndexedDB.CreateObjectStore:output_type -> google.protobuf.Empty
+	29, // 46: gestalt.provider.v1.IndexedDB.DeleteObjectStore:output_type -> google.protobuf.Empty
+	8,  // 47: gestalt.provider.v1.IndexedDB.Get:output_type -> gestalt.provider.v1.RecordResponse
+	24, // 48: gestalt.provider.v1.IndexedDB.GetKey:output_type -> gestalt.provider.v1.KeyResponse
+	29, // 49: gestalt.provider.v1.IndexedDB.Add:output_type -> google.protobuf.Empty
+	29, // 50: gestalt.provider.v1.IndexedDB.Put:output_type -> google.protobuf.Empty
+	29, // 51: gestalt.provider.v1.IndexedDB.Delete:output_type -> google.protobuf.Empty
+	29, // 52: gestalt.provider.v1.IndexedDB.Clear:output_type -> google.protobuf.Empty
+	9,  // 53: gestalt.provider.v1.IndexedDB.GetAll:output_type -> gestalt.provider.v1.RecordsResponse
+	10, // 54: gestalt.provider.v1.IndexedDB.GetAllKeys:output_type -> gestalt.provider.v1.KeysResponse
+	17, // 55: gestalt.provider.v1.IndexedDB.Count:output_type -> gestalt.provider.v1.CountResponse
+	23, // 56: gestalt.provider.v1.IndexedDB.DeleteRange:output_type -> gestalt.provider.v1.DeleteResponse
+	8,  // 57: gestalt.provider.v1.IndexedDB.IndexGet:output_type -> gestalt.provider.v1.RecordResponse
+	24, // 58: gestalt.provider.v1.IndexedDB.IndexGetKey:output_type -> gestalt.provider.v1.KeyResponse
+	9,  // 59: gestalt.provider.v1.IndexedDB.IndexGetAll:output_type -> gestalt.provider.v1.RecordsResponse
+	10, // 60: gestalt.provider.v1.IndexedDB.IndexGetAllKeys:output_type -> gestalt.provider.v1.KeysResponse
+	17, // 61: gestalt.provider.v1.IndexedDB.IndexCount:output_type -> gestalt.provider.v1.CountResponse
+	23, // 62: gestalt.provider.v1.IndexedDB.IndexDelete:output_type -> gestalt.provider.v1.DeleteResponse
+	22, // 63: gestalt.provider.v1.IndexedDB.OpenCursor:output_type -> gestalt.provider.v1.CursorResponse
+	45, // [45:64] is the sub-list for method output_type
+	26, // [26:45] is the sub-list for method input_type
+	26, // [26:26] is the sub-list for extension type_name
+	26, // [26:26] is the sub-list for extension extendee
+	0,  // [0:26] is the sub-list for field type_name
 }
 
 func init() { file_v1_datastore_proto_init() }
@@ -1352,18 +1913,36 @@ func file_v1_datastore_proto_init() {
 	}
 	file_v1_datastore_proto_msgTypes[12].OneofWrappers = []any{}
 	file_v1_datastore_proto_msgTypes[15].OneofWrappers = []any{}
+	file_v1_datastore_proto_msgTypes[17].OneofWrappers = []any{}
+	file_v1_datastore_proto_msgTypes[18].OneofWrappers = []any{
+		(*CursorCommand_Next)(nil),
+		(*CursorCommand_ContinueToKey)(nil),
+		(*CursorCommand_Advance)(nil),
+		(*CursorCommand_Update)(nil),
+		(*CursorCommand_Delete)(nil),
+		(*CursorCommand_Close)(nil),
+	}
+	file_v1_datastore_proto_msgTypes[19].OneofWrappers = []any{
+		(*CursorClientMessage_Open)(nil),
+		(*CursorClientMessage_Command)(nil),
+	}
+	file_v1_datastore_proto_msgTypes[21].OneofWrappers = []any{
+		(*CursorResponse_Entry)(nil),
+		(*CursorResponse_Done)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_v1_datastore_proto_rawDesc), len(file_v1_datastore_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   20,
+			NumEnums:      1,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_v1_datastore_proto_goTypes,
 		DependencyIndexes: file_v1_datastore_proto_depIdxs,
+		EnumInfos:         file_v1_datastore_proto_enumTypes,
 		MessageInfos:      file_v1_datastore_proto_msgTypes,
 	}.Build()
 	File_v1_datastore_proto = out.File

--- a/sdk/go/gen/v1/datastore_grpc.pb.go
+++ b/sdk/go/gen/v1/datastore_grpc.pb.go
@@ -38,6 +38,7 @@ const (
 	IndexedDB_IndexGetAllKeys_FullMethodName   = "/gestalt.provider.v1.IndexedDB/IndexGetAllKeys"
 	IndexedDB_IndexCount_FullMethodName        = "/gestalt.provider.v1.IndexedDB/IndexCount"
 	IndexedDB_IndexDelete_FullMethodName       = "/gestalt.provider.v1.IndexedDB/IndexDelete"
+	IndexedDB_OpenCursor_FullMethodName        = "/gestalt.provider.v1.IndexedDB/OpenCursor"
 )
 
 // IndexedDBClient is the client API for IndexedDB service.
@@ -66,6 +67,8 @@ type IndexedDBClient interface {
 	IndexGetAllKeys(ctx context.Context, in *IndexQueryRequest, opts ...grpc.CallOption) (*KeysResponse, error)
 	IndexCount(ctx context.Context, in *IndexQueryRequest, opts ...grpc.CallOption) (*CountResponse, error)
 	IndexDelete(ctx context.Context, in *IndexQueryRequest, opts ...grpc.CallOption) (*DeleteResponse, error)
+	// Cursor iteration (bidirectional stream)
+	OpenCursor(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[CursorClientMessage, CursorResponse], error)
 }
 
 type indexedDBClient struct {
@@ -256,6 +259,19 @@ func (c *indexedDBClient) IndexDelete(ctx context.Context, in *IndexQueryRequest
 	return out, nil
 }
 
+func (c *indexedDBClient) OpenCursor(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[CursorClientMessage, CursorResponse], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &IndexedDB_ServiceDesc.Streams[0], IndexedDB_OpenCursor_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[CursorClientMessage, CursorResponse]{ClientStream: stream}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type IndexedDB_OpenCursorClient = grpc.BidiStreamingClient[CursorClientMessage, CursorResponse]
+
 // IndexedDBServer is the server API for IndexedDB service.
 // All implementations must embed UnimplementedIndexedDBServer
 // for forward compatibility.
@@ -282,6 +298,8 @@ type IndexedDBServer interface {
 	IndexGetAllKeys(context.Context, *IndexQueryRequest) (*KeysResponse, error)
 	IndexCount(context.Context, *IndexQueryRequest) (*CountResponse, error)
 	IndexDelete(context.Context, *IndexQueryRequest) (*DeleteResponse, error)
+	// Cursor iteration (bidirectional stream)
+	OpenCursor(grpc.BidiStreamingServer[CursorClientMessage, CursorResponse]) error
 	mustEmbedUnimplementedIndexedDBServer()
 }
 
@@ -345,6 +363,9 @@ func (UnimplementedIndexedDBServer) IndexCount(context.Context, *IndexQueryReque
 }
 func (UnimplementedIndexedDBServer) IndexDelete(context.Context, *IndexQueryRequest) (*DeleteResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method IndexDelete not implemented")
+}
+func (UnimplementedIndexedDBServer) OpenCursor(grpc.BidiStreamingServer[CursorClientMessage, CursorResponse]) error {
+	return status.Error(codes.Unimplemented, "method OpenCursor not implemented")
 }
 func (UnimplementedIndexedDBServer) mustEmbedUnimplementedIndexedDBServer() {}
 func (UnimplementedIndexedDBServer) testEmbeddedByValue()                   {}
@@ -691,6 +712,13 @@ func _IndexedDB_IndexDelete_Handler(srv interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 
+func _IndexedDB_OpenCursor_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(IndexedDBServer).OpenCursor(&grpc.GenericServerStream[CursorClientMessage, CursorResponse]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type IndexedDB_OpenCursorServer = grpc.BidiStreamingServer[CursorClientMessage, CursorResponse]
+
 // IndexedDB_ServiceDesc is the grpc.ServiceDesc for IndexedDB service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -771,6 +799,13 @@ var IndexedDB_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _IndexedDB_IndexDelete_Handler,
 		},
 	},
-	Streams:  []grpc.StreamDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "OpenCursor",
+			Handler:       _IndexedDB_OpenCursor_Handler,
+			ServerStreams: true,
+			ClientStreams: true,
+		},
+	},
 	Metadata: "v1/datastore.proto",
 }

--- a/sdk/go/gen/v1/env.go
+++ b/sdk/go/gen/v1/env.go
@@ -11,7 +11,7 @@ const (
 	// CurrentProtocolVersion is the provider protocol version spoken by this
 	// build of the host and SDK. Providers must echo this version in their
 	// StartProviderResponse.
-	CurrentProtocolVersion int32 = 3
+	CurrentProtocolVersion int32 = 2
 
 	// Deprecated: Use EnvProviderSocket instead.
 	EnvPluginSocket = EnvProviderSocket

--- a/sdk/go/gen/v1/env.go
+++ b/sdk/go/gen/v1/env.go
@@ -11,7 +11,7 @@ const (
 	// CurrentProtocolVersion is the provider protocol version spoken by this
 	// build of the host and SDK. Providers must echo this version in their
 	// StartProviderResponse.
-	CurrentProtocolVersion int32 = 2
+	CurrentProtocolVersion int32 = 3
 
 	// Deprecated: Use EnvProviderSocket instead.
 	EnvPluginSocket = EnvProviderSocket

--- a/sdk/go/indexeddb.go
+++ b/sdk/go/indexeddb.go
@@ -18,6 +18,16 @@ const EnvIndexedDBSocket = "GESTALT_INDEXEDDB_SOCKET"
 var (
 	ErrNotFound      = fmt.Errorf("indexeddb: not found")
 	ErrAlreadyExists = fmt.Errorf("indexeddb: already exists")
+	ErrKeysOnly      = fmt.Errorf("indexeddb: value not available on key-only cursor")
+)
+
+type CursorDirection string
+
+const (
+	CursorNext       CursorDirection = "next"
+	CursorNextUnique CursorDirection = "nextunique"
+	CursorPrev       CursorDirection = "prev"
+	CursorPrevUnique CursorDirection = "prevunique"
 )
 
 type Record = map[string]any
@@ -193,6 +203,14 @@ func (o *ObjectStoreClient) DeleteRange(ctx context.Context, r KeyRange) (int64,
 	return resp.GetDeleted(), nil
 }
 
+func (o *ObjectStoreClient) OpenCursor(ctx context.Context, r *KeyRange, dir CursorDirection) (*Cursor, error) {
+	return openCursor(ctx, o.client, o.store, "", r, dir, false, nil)
+}
+
+func (o *ObjectStoreClient) OpenKeyCursor(ctx context.Context, r *KeyRange, dir CursorDirection) (*Cursor, error) {
+	return openCursor(ctx, o.client, o.store, "", r, dir, true, nil)
+}
+
 func (o *ObjectStoreClient) Index(name string) *IndexClient {
 	return &IndexClient{client: o.client, store: o.store, index: name}
 }
@@ -305,6 +323,227 @@ func (idx *IndexClient) Delete(ctx context.Context, values ...any) (int64, error
 		return 0, grpcErr(err)
 	}
 	return resp.GetDeleted(), nil
+}
+
+func (idx *IndexClient) OpenCursor(ctx context.Context, r *KeyRange, dir CursorDirection, values ...any) (*Cursor, error) {
+	return openCursor(ctx, idx.client, idx.store, idx.index, r, dir, false, values)
+}
+
+func (idx *IndexClient) OpenKeyCursor(ctx context.Context, r *KeyRange, dir CursorDirection, values ...any) (*Cursor, error) {
+	return openCursor(ctx, idx.client, idx.store, idx.index, r, dir, true, values)
+}
+
+type Cursor struct {
+	stream   proto.IndexedDB_OpenCursorClient
+	keysOnly bool
+	entry    *proto.CursorEntry
+	err      error
+	done     bool
+}
+
+func (c *Cursor) Continue(ctx context.Context) bool {
+	return c.sendAndRecv(&proto.CursorCommand{
+		Command: &proto.CursorCommand_Next{Next: true},
+	})
+}
+
+func (c *Cursor) ContinueToKey(ctx context.Context, key any) bool {
+	tv, err := TypedValueFromAny(key)
+	if err != nil {
+		c.err = fmt.Errorf("indexeddb: marshal cursor key: %w", err)
+		return false
+	}
+	return c.sendAndRecv(&proto.CursorCommand{
+		Command: &proto.CursorCommand_ContinueToKey{ContinueToKey: tv},
+	})
+}
+
+func (c *Cursor) Advance(ctx context.Context, count int) bool {
+	return c.sendAndRecv(&proto.CursorCommand{
+		Command: &proto.CursorCommand_Advance{Advance: int32(count)},
+	})
+}
+
+func (c *Cursor) Key() any {
+	if c.entry == nil {
+		return nil
+	}
+	v, _ := AnyFromTypedValue(c.entry.GetKey())
+	return v
+}
+
+func (c *Cursor) PrimaryKey() string {
+	if c.entry == nil {
+		return ""
+	}
+	return c.entry.GetPrimaryKey()
+}
+
+func (c *Cursor) Value() (Record, error) {
+	if c.keysOnly {
+		return nil, ErrKeysOnly
+	}
+	if c.entry == nil {
+		return nil, nil
+	}
+	return RecordFromProto(c.entry.GetRecord())
+}
+
+func (c *Cursor) Delete(ctx context.Context) error {
+	if c.done || c.err != nil {
+		return c.err
+	}
+	err := c.stream.Send(&proto.CursorClientMessage{
+		Msg: &proto.CursorClientMessage_Command{
+			Command: &proto.CursorCommand{
+				Command: &proto.CursorCommand_Delete{Delete: true},
+			},
+		},
+	})
+	if err != nil {
+		c.err = grpcErr(err)
+		return c.err
+	}
+	resp, err := c.stream.Recv()
+	if err != nil {
+		c.err = grpcErr(err)
+		return c.err
+	}
+	if resp.GetDone() {
+		c.done = true
+	}
+	return nil
+}
+
+func (c *Cursor) Update(ctx context.Context, value Record) error {
+	if c.done || c.err != nil {
+		return c.err
+	}
+	pbRecord, err := RecordToProto(value)
+	if err != nil {
+		return fmt.Errorf("indexeddb: marshal cursor update: %w", err)
+	}
+	err = c.stream.Send(&proto.CursorClientMessage{
+		Msg: &proto.CursorClientMessage_Command{
+			Command: &proto.CursorCommand{
+				Command: &proto.CursorCommand_Update{Update: pbRecord},
+			},
+		},
+	})
+	if err != nil {
+		c.err = grpcErr(err)
+		return c.err
+	}
+	resp, err := c.stream.Recv()
+	if err != nil {
+		c.err = grpcErr(err)
+		return c.err
+	}
+	if resp.GetDone() {
+		c.done = true
+	}
+	return nil
+}
+
+func (c *Cursor) Err() error {
+	return c.err
+}
+
+func (c *Cursor) Close() error {
+	if c.done {
+		return nil
+	}
+	c.done = true
+	err := c.stream.Send(&proto.CursorClientMessage{
+		Msg: &proto.CursorClientMessage_Command{
+			Command: &proto.CursorCommand{
+				Command: &proto.CursorCommand_Close{Close: true},
+			},
+		},
+	})
+	if err != nil {
+		return grpcErr(err)
+	}
+	return grpcErr(c.stream.CloseSend())
+}
+
+func (c *Cursor) sendAndRecv(cmd *proto.CursorCommand) bool {
+	if c.done || c.err != nil {
+		return false
+	}
+	err := c.stream.Send(&proto.CursorClientMessage{
+		Msg: &proto.CursorClientMessage_Command{Command: cmd},
+	})
+	if err != nil {
+		c.err = grpcErr(err)
+		return false
+	}
+	resp, err := c.stream.Recv()
+	if err != nil {
+		c.err = grpcErr(err)
+		return false
+	}
+	if resp.GetDone() {
+		c.done = true
+		c.entry = nil
+		return false
+	}
+	c.entry = resp.GetEntry()
+	return c.entry != nil
+}
+
+func cursorDirectionToProto(dir CursorDirection) proto.CursorDirection {
+	switch dir {
+	case CursorNextUnique:
+		return proto.CursorDirection_CURSOR_NEXT_UNIQUE
+	case CursorPrev:
+		return proto.CursorDirection_CURSOR_PREV
+	case CursorPrevUnique:
+		return proto.CursorDirection_CURSOR_PREV_UNIQUE
+	default:
+		return proto.CursorDirection_CURSOR_NEXT
+	}
+}
+
+func openCursor(ctx context.Context, client proto.IndexedDBClient, store, index string, r *KeyRange, dir CursorDirection, keysOnly bool, values []any) (*Cursor, error) {
+	kr, err := krToProto(r)
+	if err != nil {
+		return nil, err
+	}
+	vals, err := TypedValuesFromAny(values)
+	if err != nil {
+		return nil, err
+	}
+	stream, err := client.OpenCursor(ctx)
+	if err != nil {
+		return nil, grpcErr(err)
+	}
+	err = stream.Send(&proto.CursorClientMessage{
+		Msg: &proto.CursorClientMessage_Open{
+			Open: &proto.OpenCursorRequest{
+				Store:     store,
+				Range:     kr,
+				Direction: cursorDirectionToProto(dir),
+				KeysOnly:  keysOnly,
+				Index:     index,
+				Values:    vals,
+			},
+		},
+	})
+	if err != nil {
+		return nil, grpcErr(err)
+	}
+	c := &Cursor{stream: stream, keysOnly: keysOnly}
+	resp, err := stream.Recv()
+	if err != nil {
+		return nil, grpcErr(err)
+	}
+	if resp.GetDone() {
+		c.done = true
+	} else {
+		c.entry = resp.GetEntry()
+	}
+	return c, nil
 }
 
 func krToProto(r *KeyRange) (*proto.KeyRange, error) {

--- a/sdk/proto/v1/datastore.proto
+++ b/sdk/proto/v1/datastore.proto
@@ -102,6 +102,53 @@ message CountResponse {
   int64 count = 1;
 }
 
+enum CursorDirection {
+  CURSOR_NEXT = 0;
+  CURSOR_NEXT_UNIQUE = 1;
+  CURSOR_PREV = 2;
+  CURSOR_PREV_UNIQUE = 3;
+}
+
+message OpenCursorRequest {
+  string store = 1;
+  optional KeyRange range = 2;
+  CursorDirection direction = 3;
+  bool keys_only = 4;
+  string index = 5;
+  repeated TypedValue values = 6;
+}
+
+message CursorCommand {
+  oneof command {
+    bool next = 1;
+    TypedValue continue_to_key = 2;
+    int32 advance = 3;
+    Record update = 4;
+    bool delete = 5;
+    bool close = 6;
+  }
+}
+
+message CursorClientMessage {
+  oneof msg {
+    OpenCursorRequest open = 1;
+    CursorCommand command = 2;
+  }
+}
+
+message CursorEntry {
+  TypedValue key = 1;
+  string primary_key = 2;
+  Record record = 3;
+}
+
+message CursorResponse {
+  oneof result {
+    CursorEntry entry = 1;
+    bool done = 2;
+  }
+}
+
 message DeleteResponse {
   int64 deleted = 1;
 }
@@ -136,4 +183,7 @@ service IndexedDB {
   rpc IndexGetAllKeys(IndexQueryRequest) returns (KeysResponse);
   rpc IndexCount(IndexQueryRequest) returns (CountResponse);
   rpc IndexDelete(IndexQueryRequest) returns (DeleteResponse);
+
+  // Cursor iteration (bidirectional stream)
+  rpc OpenCursor(stream CursorClientMessage) returns (stream CursorResponse);
 }


### PR DESCRIPTION
Implements the Cursor type and bidirectional streaming integration for the OpenCursor gRPC method. This adds OpenCursor and OpenKeyCursor on both ObjectStoreClient and IndexClient, along with cursor navigation (Continue, ContinueToKey, Advance), value access (Key, PrimaryKey, Value), and mutation (Delete, Update) methods.