### PR TITLE
Update docs for unified egress host-check model

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -63,9 +63,9 @@ providers:
 
 Each entry can set an `alias` to rename the operation as it appears to callers.
 
-### Network sandbox
+### Egress control
 
-Executable provider processes run inside a network sandbox. Outbound requests to hosts not listed in `allowedHosts` are rejected:
+Every provider supports `allowedHosts` to restrict which upstream hosts it can reach. When `server.egress.defaultAction` is `deny`, providers without an explicit allowlist are blocked from all outbound requests. Executable plugin providers are additionally sandboxed at the OS level when egress restrictions are active.
 
 ```yaml
 providers:

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -28,7 +28,7 @@ The host owns auth, token storage, connection selection, and HTTP or MCP routing
 
 ## Process isolation
 
-Providers run in their own process. They cannot access the host process memory, other users' credentials, or (for plugins) the datastore directly. Plugins also run inside a network sandbox: outbound requests to hosts not listed in `allowedHosts` are rejected with a 403.
+Providers run in their own process. They cannot access the host process memory, other users' credentials, or (for plugins) the datastore directly. All provider types respect `allowedHosts` for egress control: outbound requests to hosts not in the allowlist are rejected.
 
 ## SDK support
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -656,54 +656,31 @@ connections:
 
 ## `server.egress`
 
-`server.egress` controls outbound requests made through providers and grants operator-managed credentials to specific outbound destinations.
+`server.egress` sets the server-wide default for outbound network access. Per-provider `allowedHosts` lists control which hosts each provider can reach.
 
 ```yaml
 server:
   egress:
     defaultAction: deny
-    policies:
-      - action: allow
-        provider: github
-        method: GET
-        host: api.github.com
-    credentials:
-      - secretRef: github-service-token
-        authStyle: bearer
-        host: api.github.com
+
+providers:
+  plugins:
+    github:
+      allowedHosts:
+        - api.github.com
+        - "*.github.com"
+    my-plugin:
+      source:
+        path: ./plugins/my-plugin
+      allowedHosts:
+        - external-api.com
 ```
 
-`defaultAction` sets the global fallback policy to `allow` or `deny`.
-
-### Policies
-
-`policies` declares static allow or deny rules. Each rule matches against a combination of fields; all specified fields must match for the rule to apply.
-
 | Field | Description |
 | --- | --- |
-| `action` | **Required.** `allow` or `deny`. |
-| `subjectKind` | Match by subject kind. |
-| `subjectId` | Match by subject identifier. |
-| `provider` | Match by plugin name. |
-| `operation` | Match by operation name. |
-| `method` | Match by HTTP method. |
-| `host` | Match by destination host. |
-| `pathPrefix` | Match by URL path prefix. |
+| `defaultAction` | `allow` (default) or `deny`. Applies when a provider has no `allowedHosts`. |
 
-### Credentials
-
-`credentials` attaches secret-backed outbound credentials to requests matching at least one criterion. `secretRef` is a bare secret name (not a `secret://` URI) resolved through the configured secret manager.
-
-| Field | Description |
-| --- | --- |
-| `secretRef` | **Required.** Bare secret name resolved through the secret manager. |
-| `authStyle` | How to inject the credential: `bearer`, `raw`, `basic`, or `none`. |
-| `subjectKind` | Match by subject kind. |
-| `subjectId` | Match by subject identifier. |
-| `operation` | Match by operation name. |
-| `method` | Match by HTTP method. |
-| `host` | Match by destination host. |
-| `pathPrefix` | Match by URL path prefix. |
+When `allowedHosts` is set on a provider, only listed hosts are reachable (exact match and `*.suffix` wildcards). When `allowedHosts` is empty, `defaultAction` decides: `allow` permits all outbound requests, `deny` blocks them. This applies uniformly to REST, GraphQL, MCP, and executable plugin providers. For executable plugins, `deny` also activates the OS-level sandbox even when no `allowedHosts` are configured.
 
 ## `providers.ui`
 
@@ -739,7 +716,7 @@ Only `connections.default` may define `params` or `discovery`. All connections i
 
 `providers.ui` must use exactly one mode: `disabled: true`, or a source mapping with exactly one loading mode: local `providers.ui.source.path` or managed `providers.ui.source.ref`. `providers.ui.source.version` is required with `providers.ui.source.ref` and invalid with `providers.ui.source.path`. `providers.ui.config` is only allowed when `providers.ui.source` is set.
 
-`server.egress.defaultAction` must be `allow` or `deny`. Each egress policy rule requires an `action`. Each egress credential grant requires `secretRef` (as a bare name, not a `secret://` URI) and at least one match criterion.
+`server.egress.defaultAction` must be `allow` or `deny`.
 
 Server listener ports must be greater than zero. When `server.management` is configured, it must differ from `server.public`.
 

--- a/docs/content/security.mdx
+++ b/docs/content/security.mdx
@@ -4,37 +4,10 @@ Gestalt sits between callers and upstream APIs. It authenticates users, stores e
 
 ## Trust boundaries
 
-```
-┌─────────────────────────────────────────────────────────┐
-│                      INTERNET                           │
-└────────────────────────┬────────────────────────────────┘
-                         │
-                    ┌────▼────┐
-                    │ Platform │  session_token cookie
-                    │   Auth   │  or Authorization: Bearer
-                    └────┬────┘
-                         │
-           ┌─────────────▼─────────────┐
-           │         gestaltd          │
-           │                           │
-           │  ┌─────────┐ ┌─────────┐  │
-           │  │ Invoker │ │  MCP    │  │
-           │  │ (Broker)│ │ Server  │  │
-           │  └────┬────┘ └────┬────┘  │
-           └───────┬───────────┬───────┘
-                   │           │
-         ┌─────────▼──┐  ┌────▼──────────┐
-         │  Upstream   │  │   Provider    │
-         │  APIs       │  │   Processes   │
-         │ (REST/GQL/  │  │  (gRPC over   │
-         │  MCP)       │  │  Unix socket) │
-         └────────────┘  └───────────────┘
-```
-
 | Boundary | What crosses it | Protection |
 | --- | --- | --- |
 | Internet to Gestalt | User requests | Platform auth (session or API token) |
-| Gestalt to upstream APIs | OAuth tokens, API keys | Credential encryption, TLS |
+| Gestalt to upstream APIs | OAuth tokens, API keys | Credential encryption, TLS, egress host allowlist |
 | Gestalt to providers | Config, operation requests, access tokens | Process isolation, Unix socket, scoped capabilities |
 | Operator to Gestalt | Config, encryption key, secrets | Secret manager, env var expansion, `secret://` refs |
 
@@ -80,11 +53,15 @@ Providers run as separate OS processes with communication over temporary Unix so
 
 The host resolves the caller's access token and passes it to the provider in each gRPC request. Providers receive only the token for the current invocation.
 
-### OS-level sandbox
+### Egress control
 
-When `allowedHosts` is configured on a provider, the plugin is automatically sandboxed:
+Every provider entry supports `allowedHosts` to restrict which upstream hosts it can reach. When `server.egress.defaultAction` is `deny`, providers without an explicit allowlist are blocked from all outbound requests.
 
 ```yaml
+server:
+  egress:
+    defaultAction: deny
+
 providers:
   plugins:
     my-plugin:
@@ -96,9 +73,15 @@ providers:
         - "*.slack.com"
 ```
 
+Wildcards are supported (`*.example.com` matches `api.example.com`). The same check applies uniformly to REST, GraphQL, and MCP providers.
+
+### OS-level sandbox
+
+Executable plugin providers run with additional OS-level isolation when `allowedHosts` is configured or when `server.egress.defaultAction` is `deny`.
+
 **Filesystem.** On Linux, [Landlock](https://docs.kernel.org/userspace-api/landlock.html) restricts file access to system libraries, SSL certificates, and DNS configuration. Writes are limited to the socket directory and an isolated temp directory. On macOS, equivalent restrictions are applied via `sandbox-exec`.
 
-**Network.** `gestaltd` starts a local HTTP proxy and sets `HTTP_PROXY`/`HTTPS_PROXY` in the provider's environment. The proxy checks each request's hostname against the allowlist before forwarding. Wildcards are supported (`*.example.com` matches `api.example.com`).
+**Network.** `gestaltd` starts a local HTTP proxy and sets `HTTP_PROXY`/`HTTPS_PROXY` in the provider's environment. The proxy checks each request's hostname against the same `allowedHosts` and `defaultAction` rules used by all other provider types.
 
 **Process group.** Sandboxed providers run in their own process group. On shutdown, `gestaltd` signals the entire group to ensure child processes are also cleaned up.
 


### PR DESCRIPTION
The egress system was simplified to a single `allowedHosts` per provider with `server.egress.defaultAction` as the fallback. This updates the security page, configuration guide, provider overview, and config reference to reflect the new model. The architecture diagram on the security page is removed, and references to the deleted `policies` and `credentials` config sections are replaced with the current `allowedHosts` and `defaultAction` surface.