### PR TITLE
Reframe data model docs in IndexedDB API terms

### DIFF
--- a/docs/content/architecture/data-model.mdx
+++ b/docs/content/architecture/data-model.mdx
@@ -1,83 +1,83 @@
 # Data Model
 
-Gestalt creates its own tables in the configured datastore. All SQL backends (SQLite, PostgreSQL, MySQL, SQL Server, Oracle) share the same logical schema. MongoDB and DynamoDB use equivalent document structures. Migrations run automatically on startup.
+Gestalt stores all persistent state through the configured [IndexedDB provider](/providers/indexeddb). At startup, gestaltd provisions four object stores and their indexes through the same `CreateObjectStore` interface that plugins use. Any backend that implements the IndexedDB contract (RelationalDB, MongoDB, DynamoDB) can store this data. Migrations run automatically on startup.
 
-For encryption mechanics, see [Security Internals](/architecture/security-internals). For choosing a datastore, see [Configuration](/configuration).
+For encryption mechanics, see [Security Internals](/architecture/security-internals). For choosing a provider, see [Configuration](/configuration).
 
-## Tables
+## Object stores
 
 ### `users`
 
 Created automatically on first login.
 
-| Column | Type | Notes |
+| Field | Type | Notes |
 | --- | --- | --- |
-| `id` | text, PK | UUID. |
-| `email` | text, unique | Plaintext. From the identity provider. |
-| `display_name` | text | Plaintext. |
-| `created_at` | timestamp | |
-| `updated_at` | timestamp | |
+| `id` | string, PK | UUID. |
+| `email` | string, unique | Plaintext. From the identity provider. |
+| `display_name` | string | Plaintext. |
+| `created_at` | time | |
+| `updated_at` | time | |
 
-Emails and display names are plaintext. If you need encrypted PII at rest, handle it at the database layer (e.g., Postgres TDE).
+Emails and display names are plaintext. If you need encrypted PII at rest, handle it at the storage layer.
 
 ### `integration_tokens`
 
 Stores upstream credentials (OAuth tokens, API keys, manual credentials) for each user's connected integrations.
 
-| Column | Type | Notes |
+| Field | Type | Notes |
 | --- | --- | --- |
-| `id` | text, PK | UUID. |
-| `user_id` | text, FK | References `users.id`. |
-| `integration` | text | Provider name from config (e.g., `github`). |
-| `connection` | text | Named connection within the provider (e.g., `default`, `mcp`). |
-| `instance` | text | User-chosen or discovery-assigned name for multi-account providers. |
-| `access_token_encrypted` | text | **Encrypted.** AES-256-GCM. |
-| `refresh_token_encrypted` | text | **Encrypted.** AES-256-GCM. Empty (still encrypted) if no refresh token. |
-| `scopes` | text | Plaintext. Space-separated OAuth scopes. |
-| `expires_at` | timestamp | Null if the provider doesn't report expiry. |
-| `last_refreshed_at` | timestamp | |
-| `refresh_error_count` | integer | Consecutive failed refreshes. Reset to 0 on success. |
-| `metadata_json` | text | Plaintext. Connection metadata from post-connect discovery. |
-| `created_at` | timestamp | |
-| `updated_at` | timestamp | |
+| `id` | string, PK | UUID. |
+| `user_id` | string | References `users.id`. |
+| `integration` | string | Provider name from config (e.g., `slack`). |
+| `connection` | string | Named connection within the provider (e.g., `default`, `mcp`). |
+| `instance` | string | User-chosen or discovery-assigned name for multi-account providers. |
+| `access_token_encrypted` | string | **Encrypted.** AES-256-GCM. |
+| `refresh_token_encrypted` | string | **Encrypted.** AES-256-GCM. Empty (still encrypted) if no refresh token. |
+| `scopes` | string | Plaintext. Space-separated OAuth scopes. |
+| `expires_at` | time | Null if the provider doesn't report expiry. |
+| `last_refreshed_at` | time | |
+| `refresh_error_count` | int | Consecutive failed refreshes. Reset to 0 on success. |
+| `metadata_json` | string | Plaintext. Connection metadata from post-connect discovery. |
+| `created_at` | time | |
+| `updated_at` | time | |
 
-Unique constraint: `(user_id, integration, connection, instance)`. Reconnecting overwrites the existing row via upsert.
+Unique index on `(user_id, integration, connection, instance)`. Reconnecting overwrites the existing record via `Put`.
 
 ### `api_tokens`
 
 Gestalt API tokens (`gst_api_*`). The plaintext is never stored, only a one-way hash.
 
-| Column | Type | Notes |
+| Field | Type | Notes |
 | --- | --- | --- |
-| `id` | text, PK | UUID. |
-| `user_id` | text, FK | References `users.id`. |
-| `name` | text | Display name (e.g., `automation`, `cli-token`). |
-| `hashed_token` | text, unique | **SHA-256 hash.** Plaintext returned once at creation. |
-| `scopes` | text | Plaintext. Space-separated provider names. |
-| `expires_at` | timestamp | Null for non-expiring tokens. |
-| `created_at` | timestamp | |
-| `updated_at` | timestamp | |
+| `id` | string, PK | UUID. |
+| `user_id` | string | References `users.id`. |
+| `name` | string | Display name (e.g., `automation`, `cli-token`). |
+| `hashed_token` | string, unique | **SHA-256 hash.** Plaintext returned once at creation. |
+| `scopes` | string | Plaintext. Space-separated provider names. |
+| `expires_at` | time | Null for non-expiring tokens. |
+| `created_at` | time | |
+| `updated_at` | time | |
 
 ### `oauth_registrations`
 
 Caches dynamic OAuth client registrations for `mcp_oauth` connections, so Gestalt doesn't re-register on every request.
 
-| Column | Type | Notes |
+| Field | Type | Notes |
 | --- | --- | --- |
-| `id` | text, PK | |
-| `auth_server_url` | text | Upstream authorization server. |
-| `redirect_uri` | text | Callback URI. |
-| `client_id` | text | Dynamically registered client ID. |
-| `client_secret_encrypted` | text | **Encrypted.** AES-256-GCM. |
-| `expires_at` | timestamp | |
-| `authorization_endpoint` | text | Discovered URL. |
-| `token_endpoint` | text | Discovered URL. |
-| `scopes_supported` | text | |
-| `discovered_at` | timestamp | |
-| `created_at` | timestamp | |
-| `updated_at` | timestamp | |
+| `id` | string, PK | |
+| `auth_server_url` | string | Upstream authorization server. |
+| `redirect_uri` | string | Callback URI. |
+| `client_id` | string | Dynamically registered client ID. |
+| `client_secret_encrypted` | string | **Encrypted.** AES-256-GCM. |
+| `expires_at` | time | |
+| `authorization_endpoint` | string | Discovered URL. |
+| `token_endpoint` | string | Discovered URL. |
+| `scopes_supported` | string | |
+| `discovered_at` | time | |
+| `created_at` | time | |
+| `updated_at` | time | |
 
-Unique constraint: `(auth_server_url, redirect_uri)`.
+Unique index on `(auth_server_url, redirect_uri)`.
 
 ## Encryption summary
 
@@ -112,4 +112,4 @@ Renaming a `plugins` key in config is a breaking change. Stored tokens reference
 
 ## Sessions
 
-Platform sessions (Google, OIDC, local) are not in the datastore. They're HTTP-only cookies (`session_token`) with `Secure` (when HTTPS), `SameSite=Lax`, and a default 24-hour TTL (configurable via `session_ttl` for OIDC). Sessions can't be revoked server-side; they expire on TTL. Logout clears the client cookie.
+Platform sessions (Google, OIDC, local) are not stored in the IndexedDB provider. They are HTTP-only cookies (`session_token`) with `Secure` (when HTTPS), `SameSite=Lax`, and a default 24-hour TTL (configurable via `session_ttl` for OIDC). Sessions cannot be revoked server-side; they expire on TTL. Logout clears the client cookie.

--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -2,9 +2,9 @@ import { Tabs } from 'nextra/components'
 
 # IndexedDB
 
-IndexedDB providers back the persistent state layer using an interface modeled on the [W3C IndexedDB API](https://www.w3.org/TR/IndexedDB/). IndexedDB's vocabulary of object stores, primary keys, named indexes, and key ranges maps naturally onto SQL tables, document collections, and key-value stores alike, so a single provider contract can target Postgres, SQLite, MongoDB, DynamoDB, and others without leaking backend-specific abstractions. Building on an established W3C standard means the concepts are already documented, widely understood, and proven to cover the access patterns most applications need.
+IndexedDB providers back the persistent state layer. Rather than inventing a custom storage API, Gestalt adopts the [W3C IndexedDB specification](https://www.w3.org/TR/IndexedDB/), the web platform's native storage primitive. IndexedDB has been implemented across every major browser for over a decade, its semantics are formally specified, and its concepts (object stores, primary keys, named indexes, key ranges) are already [documented](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) and widely understood. By building on this foundation, Gestalt inherits a proven API surface without requiring developers to learn a new abstraction.
 
-Every IndexedDB provider implements the same set of operations. The storage backend is fully replaceable: swap from SQLite to Postgres to MongoDB without changing any application code.
+IndexedDB's vocabulary maps naturally onto SQL tables, document collections, and key-value stores alike. This means a single provider contract can target Postgres, SQLite, MongoDB, DynamoDB, and others without leaking backend-specific abstractions. The storage backend is fully replaceable: swap from SQLite to Postgres to MongoDB without changing any application code.
 
 | Category | Methods | W3C equivalent |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary

- Reframes the data model page from SQL terminology to IndexedDB vocabulary: object stores instead of tables, fields instead of columns, IndexedDB types (string, int, time) instead of SQL types (text, integer, timestamp)
- Clarifies that gestaltd provisions these four object stores at startup through the same `CreateObjectStore` interface that plugins use
- Makes the docs provider-agnostic so they apply equally to RelationalDB, MongoDB, and DynamoDB backends

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>