### PR TITLE
Fix default connection inference for REST integrations

### DIFF
--- a/gestaltd/internal/bootstrap/connections.go
+++ b/gestaltd/internal/bootstrap/connections.go
@@ -51,6 +51,7 @@ type pluginConnectionPlan struct {
 	pluginConnection  config.ConnectionDef
 	namedConnections  map[string]config.ConnectionDef
 	surfaces          map[config.SpecSurface]resolvedSpecSurface
+	restConnection    string
 	defaultConnection string
 }
 
@@ -75,6 +76,15 @@ func buildPluginConnectionPlan(plugin *config.ProviderEntry, manifestPlugin *plu
 			continue
 		}
 		plan.namedConnections[name] = conn
+	}
+
+	if manifestPlugin != nil && manifestPlugin.Surfaces != nil && manifestPlugin.Surfaces.REST != nil {
+		plan.restConnection = config.ResolveConnectionAlias(manifestPlugin.Surfaces.REST.Connection)
+		if plan.restConnection != "" {
+			if _, err := plan.connectionDef(plan.restConnection); err != nil {
+				return pluginConnectionPlan{}, fmt.Errorf("rest connection references undeclared connection %q", plan.restConnection)
+			}
+		}
 	}
 
 	for _, surface := range config.OrderedSpecSurfaces {
@@ -135,6 +145,9 @@ func (plan pluginConnectionPlan) apiConnection() string {
 	if resolved, ok := plan.configuredAPISurface(); ok {
 		return resolved.connectionName
 	}
+	if plan.restConnection != "" {
+		return plan.restConnection
+	}
 	return plan.fallbackConnection()
 }
 
@@ -151,6 +164,11 @@ func (plan pluginConnectionPlan) fallbackConnection() string {
 	}
 	if len(plan.namedConnections) == 0 {
 		return config.PluginConnectionName
+	}
+	if len(plan.namedConnections) == 1 {
+		for name := range plan.namedConnections {
+			return name
+		}
 	}
 	return ""
 }

--- a/gestaltd/internal/bootstrap/connections_test.go
+++ b/gestaltd/internal/bootstrap/connections_test.go
@@ -1,0 +1,126 @@
+package bootstrap
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
+)
+
+func TestBuildConnectionMaps_InferSingleNamedConnectionAsDefault(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Providers: config.ProvidersConfig{
+			Plugins: map[string]*config.ProviderEntry{
+				"slack": {
+					ResolvedManifest: &pluginmanifestv1.Manifest{
+						Spec: &pluginmanifestv1.Spec{
+							Surfaces: &pluginmanifestv1.PluginSurfaces{
+								REST: &pluginmanifestv1.RESTSurface{
+									BaseURL: "https://slack.com",
+								},
+							},
+							Connections: map[string]*pluginmanifestv1.ManifestConnectionDef{
+								"default": {
+									Auth: &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeOAuth2},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	entry := cfg.Providers.Plugins["slack"]
+	if entry == nil || entry.ResolvedManifest == nil || entry.ResolvedManifest.Spec == nil {
+		t.Fatalf("slack entry manifest not populated: %#v", entry)
+	}
+	if entry.ManifestSpec() == nil {
+		t.Fatal("entry.ManifestSpec() returned nil")
+	}
+
+	plan, err := buildPluginConnectionPlan(entry, entry.ManifestSpec())
+	if err != nil {
+		t.Fatalf("buildPluginConnectionPlan: %v", err)
+	}
+	if got := plan.authDefaultConnection(); got != "default" {
+		t.Fatalf("plan.authDefaultConnection() = %q, want %q", got, "default")
+	}
+	if got := plan.apiConnection(); got != "default" {
+		t.Fatalf("plan.apiConnection() = %q, want %q", got, "default")
+	}
+
+	maps, err := BuildConnectionMaps(cfg)
+	if err != nil {
+		t.Fatalf("BuildConnectionMaps: %v", err)
+	}
+	if got := maps.DefaultConnection["slack"]; got != "default" {
+		t.Fatalf("DefaultConnection[slack] = %q, want %q", got, "default")
+	}
+	if got := maps.APIConnection["slack"]; got != "default" {
+		t.Fatalf("APIConnection[slack] = %q, want %q", got, "default")
+	}
+	if got := maps.MCPConnection["slack"]; got != "default" {
+		t.Fatalf("MCPConnection[slack] = %q, want %q", got, "default")
+	}
+}
+
+func TestBuildConnectionMaps_DeclarativeRESTSurfaceUsesDeclaredConnection(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Providers: config.ProvidersConfig{
+			Plugins: map[string]*config.ProviderEntry{
+				"example": {
+					ResolvedManifest: &pluginmanifestv1.Manifest{
+						Spec: &pluginmanifestv1.Spec{
+							Surfaces: &pluginmanifestv1.PluginSurfaces{
+								REST: &pluginmanifestv1.RESTSurface{
+									BaseURL:    "https://api.example.com",
+									Connection: "workspace",
+								},
+							},
+							Connections: map[string]*pluginmanifestv1.ManifestConnectionDef{
+								"workspace": {
+									Auth: &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeOAuth2},
+								},
+								"backup": {
+									Auth: &pluginmanifestv1.ProviderAuth{Type: pluginmanifestv1.AuthTypeOAuth2},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	entry := cfg.Providers.Plugins["example"]
+	if entry == nil || entry.ResolvedManifest == nil || entry.ResolvedManifest.Spec == nil {
+		t.Fatalf("example entry manifest not populated: %#v", entry)
+	}
+	if entry.ManifestSpec() == nil {
+		t.Fatal("entry.ManifestSpec() returned nil")
+	}
+
+	plan, err := buildPluginConnectionPlan(entry, entry.ManifestSpec())
+	if err != nil {
+		t.Fatalf("buildPluginConnectionPlan: %v", err)
+	}
+	if got := plan.apiConnection(); got != "workspace" {
+		t.Fatalf("plan.apiConnection() = %q, want %q", got, "workspace")
+	}
+
+	maps, err := BuildConnectionMaps(cfg)
+	if err != nil {
+		t.Fatalf("BuildConnectionMaps: %v", err)
+	}
+	if got := maps.APIConnection["example"]; got != "workspace" {
+		t.Fatalf("APIConnection[example] = %q, want %q", got, "workspace")
+	}
+	if got := maps.DefaultConnection["example"]; got != "" {
+		t.Fatalf("DefaultConnection[example] = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary
- infer the sole named connection as the default fallback for declarative REST integrations
- honor an explicitly configured REST surface connection when choosing the API connection
- add bootstrap regression coverage for both cases

## Testing
- `cd gestaltd && go test ./internal/bootstrap ./internal/coredata ./internal/server`
