### PR TITLE
Deduplicate integration tokens by logical lookup key

### DIFF
--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -26,7 +26,7 @@ var IntegrationTokensSchema = indexeddb.ObjectStoreSchema{
 		{Name: "by_user", KeyPath: []string{"user_id"}},
 		{Name: "by_user_integration", KeyPath: []string{"user_id", "integration"}},
 		{Name: "by_user_connection", KeyPath: []string{"user_id", "integration", "connection"}},
-		{Name: "by_lookup", KeyPath: []string{"user_id", "integration", "connection", "instance"}},
+		{Name: "by_lookup", KeyPath: []string{"user_id", "integration", "connection", "instance"}, Unique: true},
 	},
 	Columns: []indexeddb.ColumnDef{
 		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	corecrypto "github.com/valon-technologies/gestalt/server/core/crypto"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
 )
@@ -359,6 +360,7 @@ func TestTokenService(t *testing.T) {
 			t.Fatalf("first StoreToken: %v", err)
 		}
 
+		tok.ID = "tok-upsert-replacement"
 		tok.AccessToken = "updated"
 		if err := svc.Tokens.StoreToken(ctx, tok); err != nil {
 			t.Fatalf("second StoreToken: %v", err)
@@ -368,8 +370,94 @@ func TestTokenService(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Token: %v", err)
 		}
+		if got.ID != "tok-upsert" {
+			t.Errorf("ID = %q, want %q", got.ID, "tok-upsert")
+		}
 		if got.AccessToken != "updated" {
 			t.Errorf("AccessToken = %q, want %q", got.AccessToken, "updated")
+		}
+
+		tokens, err := svc.Tokens.ListTokensForConnection(ctx, user.ID, "svc", "default")
+		if err != nil {
+			t.Fatalf("ListTokensForConnection: %v", err)
+		}
+		if len(tokens) != 1 {
+			t.Fatalf("got %d tokens, want 1", len(tokens))
+		}
+	})
+
+	t.Run("ListTokensForConnection_dedupes_legacy_duplicate_rows", func(t *testing.T) {
+		t.Parallel()
+		svc, db := newTestServicesWithDB(t)
+		ctx := context.Background()
+
+		user := mustCreateUser(t, svc, "dupes@test.com")
+		newest := &core.IntegrationToken{
+			ID:           "tok-primary",
+			UserID:       user.ID,
+			Integration:  "svc",
+			Connection:   "default",
+			Instance:     "i1",
+			AccessToken:  "newest",
+			RefreshToken: "refresh-newest",
+		}
+		if err := svc.Tokens.StoreToken(ctx, newest); err != nil {
+			t.Fatalf("StoreToken newest: %v", err)
+		}
+
+		legacySource := &core.IntegrationToken{
+			ID:           "tok-legacy-source",
+			UserID:       user.ID,
+			Integration:  "svc",
+			Connection:   "default",
+			Instance:     "legacy-source",
+			AccessToken:  "legacy",
+			RefreshToken: "refresh-legacy",
+		}
+		if err := svc.Tokens.StoreToken(ctx, legacySource); err != nil {
+			t.Fatalf("StoreToken legacy source: %v", err)
+		}
+
+		store := db.ObjectStore(coredata.StoreIntegrationTokens)
+		primaryRaw, err := store.Get(ctx, newest.ID)
+		if err != nil {
+			t.Fatalf("Get primary raw: %v", err)
+		}
+		legacyRaw, err := store.Get(ctx, legacySource.ID)
+		if err != nil {
+			t.Fatalf("Get legacy raw: %v", err)
+		}
+		if err := store.Delete(ctx, legacySource.ID); err != nil {
+			t.Fatalf("Delete legacy source: %v", err)
+		}
+
+		duplicate := indexeddb.Record{}
+		for k, v := range legacyRaw {
+			duplicate[k] = v
+		}
+		duplicate["id"] = "tok-legacy-duplicate"
+		duplicate["user_id"] = user.ID
+		duplicate["integration"] = "svc"
+		duplicate["connection"] = "default"
+		duplicate["instance"] = "i1"
+		duplicate["created_at"] = recOrNow(primaryRaw, "created_at").Add(-time.Minute)
+		duplicate["updated_at"] = recOrNow(primaryRaw, "updated_at").Add(-time.Minute)
+		if err := store.Put(ctx, duplicate); err != nil {
+			t.Fatalf("Put duplicate raw token: %v", err)
+		}
+
+		tokens, err := svc.Tokens.ListTokensForConnection(ctx, user.ID, "svc", "default")
+		if err != nil {
+			t.Fatalf("ListTokensForConnection: %v", err)
+		}
+		if len(tokens) != 1 {
+			t.Fatalf("got %d tokens, want 1", len(tokens))
+		}
+		if tokens[0].ID != newest.ID {
+			t.Fatalf("ID = %q, want %q", tokens[0].ID, newest.ID)
+		}
+		if tokens[0].AccessToken != "newest" {
+			t.Fatalf("AccessToken = %q, want %q", tokens[0].AccessToken, "newest")
 		}
 	})
 
@@ -465,6 +553,13 @@ func TestTokenService(t *testing.T) {
 			t.Errorf("decrypted RefreshToken = %q, want %q", got.RefreshToken, "plaintext-refresh")
 		}
 	})
+}
+
+func recOrNow(rec indexeddb.Record, key string) time.Time {
+	if v, ok := rec[key].(time.Time); ok && !v.IsZero() {
+		return v
+	}
+	return time.Now()
 }
 
 func TestAPITokenService(t *testing.T) {

--- a/gestaltd/internal/coredata/tokens.go
+++ b/gestaltd/internal/coredata/tokens.go
@@ -3,6 +3,7 @@ package coredata
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/google/uuid"
@@ -47,26 +48,39 @@ func (s *TokenService) StoreToken(ctx context.Context, token *core.IntegrationTo
 		"updated_at":           now,
 	}
 
-	_, err = s.store.Get(ctx, token.ID)
-	if err == indexeddb.ErrNotFound {
+	existing, err := s.tokenRecord(ctx, token.UserID, token.Integration, token.Connection, token.Instance)
+	switch err {
+	case nil:
+		token.ID = recString(existing, "id")
+		fields["id"] = token.ID
+		createdAt := recTime(existing, "created_at")
+		if createdAt.IsZero() {
+			createdAt = now
+		}
+		fields["created_at"] = createdAt
+		if err := s.store.Put(ctx, fields); err != nil {
+			return fmt.Errorf("update token: %w", err)
+		}
+	case core.ErrNotFound:
 		fields["id"] = token.ID
 		fields["created_at"] = now
-		return s.store.Add(ctx, fields)
-	}
-	if err != nil {
+		if err := s.store.Add(ctx, fields); err != nil {
+			return fmt.Errorf("create token: %w", err)
+		}
+	default:
 		return fmt.Errorf("check existing token: %w", err)
 	}
-	fields["id"] = token.ID
-	return s.store.Put(ctx, fields)
+
+	if err := s.deleteDuplicateLookupRecords(ctx, token.ID, token.UserID, token.Integration, token.Connection, token.Instance); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *TokenService) Token(ctx context.Context, userID, integration, connection, instance string) (*core.IntegrationToken, error) {
-	rec, err := s.store.Index("by_lookup").Get(ctx, userID, integration, connection, instance)
+	rec, err := s.tokenRecord(ctx, userID, integration, connection, instance)
 	if err != nil {
-		if err == indexeddb.ErrNotFound {
-			return nil, core.ErrNotFound
-		}
-		return nil, fmt.Errorf("get token: %w", err)
+		return nil, err
 	}
 	return s.recordToToken(rec)
 }
@@ -126,6 +140,7 @@ func (s *TokenService) recordToToken(rec indexeddb.Record) (*core.IntegrationTok
 }
 
 func (s *TokenService) recordsToTokens(recs []indexeddb.Record) ([]*core.IntegrationToken, error) {
+	recs = dedupeTokenRecords(recs)
 	out := make([]*core.IntegrationToken, 0, len(recs))
 	for _, rec := range recs {
 		t, err := s.recordToToken(rec)
@@ -135,4 +150,80 @@ func (s *TokenService) recordsToTokens(recs []indexeddb.Record) ([]*core.Integra
 		out = append(out, t)
 	}
 	return out, nil
+}
+
+func (s *TokenService) tokenRecord(ctx context.Context, userID, integration, connection, instance string) (indexeddb.Record, error) {
+	recs, err := s.store.Index("by_lookup").GetAll(ctx, nil, userID, integration, connection, instance)
+	if err != nil {
+		return nil, fmt.Errorf("get token: %w", err)
+	}
+	recs = dedupeTokenRecords(recs)
+	if len(recs) == 0 {
+		return nil, core.ErrNotFound
+	}
+	return recs[0], nil
+}
+
+func (s *TokenService) deleteDuplicateLookupRecords(ctx context.Context, keepID, userID, integration, connection, instance string) error {
+	recs, err := s.store.Index("by_lookup").GetAll(ctx, nil, userID, integration, connection, instance)
+	if err != nil {
+		return fmt.Errorf("list duplicate tokens: %w", err)
+	}
+	for _, rec := range recs {
+		id := recString(rec, "id")
+		if id == "" || id == keepID {
+			continue
+		}
+		if err := s.store.Delete(ctx, id); err != nil && err != indexeddb.ErrNotFound {
+			return fmt.Errorf("delete duplicate token %q: %w", id, err)
+		}
+	}
+	return nil
+}
+
+func dedupeTokenRecords(recs []indexeddb.Record) []indexeddb.Record {
+	if len(recs) <= 1 {
+		return recs
+	}
+
+	bestByLookup := make(map[string]indexeddb.Record, len(recs))
+	for _, rec := range recs {
+		key := tokenLookupKey(rec)
+		best, ok := bestByLookup[key]
+		if !ok || tokenRecordLess(rec, best) {
+			bestByLookup[key] = rec
+		}
+	}
+
+	out := make([]indexeddb.Record, 0, len(bestByLookup))
+	for _, rec := range bestByLookup {
+		out = append(out, rec)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return tokenRecordLess(out[i], out[j])
+	})
+	return out
+}
+
+func tokenLookupKey(rec indexeddb.Record) string {
+	return recString(rec, "user_id") + "\x00" +
+		recString(rec, "integration") + "\x00" +
+		recString(rec, "connection") + "\x00" +
+		recString(rec, "instance")
+}
+
+func tokenRecordLess(a, b indexeddb.Record) bool {
+	aUpdated := recTime(a, "updated_at")
+	bUpdated := recTime(b, "updated_at")
+	if !aUpdated.Equal(bUpdated) {
+		return aUpdated.After(bUpdated)
+	}
+
+	aCreated := recTime(a, "created_at")
+	bCreated := recTime(b, "created_at")
+	if !aCreated.Equal(bCreated) {
+		return aCreated.After(bCreated)
+	}
+
+	return recString(a, "id") < recString(b, "id")
 }


### PR DESCRIPTION
## Summary
- upsert integration tokens by logical `(user, integration, connection, instance)` lookup key instead of only by record id
- dedupe legacy duplicate rows on reads and clean up duplicate rows after writes
- make the lookup index unique and extend the existing token service tests to cover both upsert and legacy duplicate rows

## Testing
- `cd gestaltd && go test ./internal/coredata -run TestTokenService -count=1`
- `cd gestaltd && go test ./internal/server -run TestConnectionAuthMetricsUseUnknownProviderForMissingIntegration -count=1`
