### PR TITLE
Align CLI command names with server's plugins terminology

### DIFF
--- a/docs/content/client/cli/docker.mdx
+++ b/docs/content/client/cli/docker.mdx
@@ -24,14 +24,14 @@ docker run --rm \
   -e GESTALT_URL=https://gestalt.example.com \
   -e GESTALT_API_KEY=gst_api_... \
   valontechnologies/gestalt:latest \
-  integrations list
+  plugins list
 ```
 
 ## CI example
 
 ```yaml
 jobs:
-  check-integrations:
+  check-plugins:
     runs-on: ubuntu-latest
     steps:
       - run: |
@@ -39,5 +39,5 @@ jobs:
             -e GESTALT_URL="${{ vars.GESTALT_URL }}" \
             -e GESTALT_API_KEY="${{ secrets.GESTALT_API_KEY }}" \
             valontechnologies/gestalt:latest \
-            integrations list --format json
+            plugins list --format json
 ```

--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -22,11 +22,11 @@ asIndexPage: true
 | `gestalt auth status` | Show current auth state and server connectivity. |
 | `gestalt init` | Run the interactive setup wizard. |
 | `gestalt config get\|set\|unset\|list` | Manage the local client config. |
-| `gestalt integrations list` | List plugins from the server. |
-| `gestalt integrations connect NAME` | Connect a plugin through OAuth or interactive manual auth. |
-| `gestalt integrations disconnect NAME` | Disconnect a plugin, removing stored credentials. |
-| `gestalt invoke INTEGRATION [OPERATION]` | Invoke an operation or list operations when omitted. |
-| `gestalt describe INTEGRATION OPERATION` | Show one operation's parameter contract. |
+| `gestalt plugins list` | List plugins from the server. |
+| `gestalt plugins connect NAME` | Connect a plugin through OAuth or interactive manual auth. |
+| `gestalt plugins disconnect NAME` | Disconnect a plugin, removing stored credentials. |
+| `gestalt plugins invoke NAME [OPERATION]` | Invoke an operation or list operations when omitted. |
+| `gestalt plugins describe NAME OPERATION` | Show one operation's parameter contract. |
 | `gestalt tokens create\|list\|revoke` | Manage Gestalt API tokens. |
 
 ## URL resolution
@@ -58,33 +58,33 @@ The CLI searches the current directory and then parent directories until it find
 
 ## Plugin connect flags
 
-`gestalt integrations connect NAME` accepts `--connection` and `--instance`. When the selected connection uses manual auth instead of OAuth, the CLI prompts for the required credential fields and connection parameters.
+`gestalt plugins connect NAME` accepts `--connection` and `--instance`. When the selected connection uses manual auth instead of OAuth, the CLI prompts for the required credential fields and connection parameters.
 
 ## Plugin disconnect flags
 
-`gestalt integrations disconnect NAME` accepts `--connection` and `--instance` to target a specific named connection or stored instance. When both are omitted, the default connection is disconnected.
+`gestalt plugins disconnect NAME` accepts `--connection` and `--instance` to target a specific named connection or stored instance. When both are omitted, the default connection is disconnected.
 
 ## Invoke flags
 
-`gestalt invoke` accepts `-p`/`--param key=value`, `--input-file file.json` (use `-` for stdin), `--connection`, `--instance`, and `--select`. Use `:=` instead of `=` to pass JSON values: `-p items:='["a","b"]'`.
+`gestalt plugins invoke` accepts `-p`/`--param key=value`, `--input-file file.json` (use `-` for stdin), `--connection`, `--instance`, and `--select`. Use `:=` instead of `=` to pass JSON values: `-p items:='["a","b"]'`.
 
 ## Operation name matching
 
 Operation names with dots (like `chat.postMessage`) can be typed as space-separated segments:
 
 ```sh
-gestalt invoke slack chat postMessage
+gestalt plugins invoke slack chat postMessage
 ```
 
-This resolves to `chat.postMessage`. If the segments match a prefix shared by multiple operations, the CLI displays the matching subset instead of an error. For example, `gestalt invoke slack chat` lists all operations starting with `chat.`.
+This resolves to `chat.postMessage`. If the segments match a prefix shared by multiple operations, the CLI displays the matching subset instead of an error. For example, `gestalt plugins invoke slack chat` lists all operations starting with `chat.`.
 
 ## Examples
 
 ```sh
-gestalt integrations list
-gestalt integrations connect notion --connection MCP
-gestalt describe slack chat.postMessage
-gestalt invoke slack chat postMessage \
+gestalt plugins list
+gestalt plugins connect notion --connection MCP
+gestalt plugins describe slack chat.postMessage
+gestalt plugins invoke slack chat postMessage \
   --connection plugin \
   -p channel=C123 \
   -p text='hello'

--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -36,7 +36,7 @@ The wizard prompts for the server URL. Enter `http://localhost:8080` and it save
 Verify the connection:
 
 ```sh
-gestalt integrations list
+gestalt plugins list
 ```
 
 ```
@@ -52,7 +52,7 @@ gestalt integrations list
 See what the httpbin plugin can do:
 
 ```sh
-gestalt invoke httpbin
+gestalt plugins invoke httpbin
 ```
 
 ```
@@ -72,7 +72,7 @@ gestalt invoke httpbin
 <Tabs items={['CLI', 'HTTP']}>
   <Tabs.Tab>
     ```sh
-    gestalt invoke httpbin get_ip
+    gestalt plugins invoke httpbin get_ip
     ```
 
     ```
@@ -100,7 +100,7 @@ gestalt invoke httpbin
   </Tabs.Tab>
 </Tabs>
 
-Both access the same underlying operation. Anything you can do with `gestalt invoke` you can also do with `curl` or any HTTP client.
+Both access the same underlying operation. Anything you can do with `gestalt plugins invoke` you can also do with `curl` or any HTTP client.
 
 ## Connecting over MCP
 

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -519,7 +519,7 @@ providers:
 ```
 
 ```sh
-gestalt invoke slack-readonly conversations.list -p limit=5
+gestalt plugins invoke slack-readonly conversations.list -p limit=5
 ```
 
 Gestalt handles OAuth token injection, request formatting, and response passthrough. The `spec.surfaces.rest.baseUrl` is the root for all declared paths, and each operation's `parameters` define how input fields map to query parameters or request body fields.
@@ -530,7 +530,7 @@ You can also declare OpenAPI, GraphQL, and MCP surfaces using `spec.surfaces.ope
 
 Operation IDs should use period-separated hierarchical names. The Slack plugin uses `conversations.list`, `conversations.history`, `chat.postMessage`, and `users.info`.
 
-This convention enables prefix matching in the CLI. When you run `gestalt invoke slack conversations`, the CLI joins the space-separated segments with periods and shows all operations whose ID starts with `conversations.`. This makes large catalogs navigable without memorizing every operation name.
+This convention enables prefix matching in the CLI. When you run `gestalt plugins invoke slack conversations`, the CLI joins the space-separated segments with periods and shows all operations whose ID starts with `conversations.`. This makes large catalogs navigable without memorizing every operation name.
 
 ## Dynamic catalogs
 
@@ -656,7 +656,7 @@ gestaltd serve --config ./config.yaml
 ```
 
 ```sh
-gestalt invoke slack conversations.getMessage -p channel=C01ABC23DEF -p ts=1712161829.000300
+gestalt plugins invoke slack conversations.getMessage -p channel=C01ABC23DEF -p ts=1712161829.000300
 ```
 
 If your plugin makes outbound HTTP requests and you see 403 errors, check `allowedHosts`. Executable providers run inside a network sandbox, and requests to hosts not in the allowlist are rejected. Add every upstream domain the provider contacts to `allowedHosts` in the config or manifest.

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -393,7 +393,7 @@ Disables audit output explicitly. `providers.audit.config` is not allowed when `
 
 ## `providers.plugins`
 
-Each entry in the `providers.plugins` map is a named plugin backed by an executable provider package. The provider package is the source of truth for operations and transport details. Server config selects the provider, passes provider-specific config, and declares connection policy. The HTTP API and client CLI use the synonym "integrations" in route paths and commands (e.g. `/api/v1/integrations`, `gestalt integrations list`), but `plugins` is the canonical config term.
+Each entry in the `providers.plugins` map is a named plugin backed by an executable provider package. The provider package is the source of truth for operations and transport details. Server config selects the provider, passes provider-specific config, and declares connection policy. The HTTP API route paths still use "integrations" (e.g. `/api/v1/integrations`) as stable code surface, but the CLI and config both use `plugins` as the canonical term.
 
 ```yaml
 providers:

--- a/gestalt/cli/src/catalog.rs
+++ b/gestalt/cli/src/catalog.rs
@@ -107,8 +107,8 @@ fn is_valid_operation_query(query: &str) -> bool {
     })
 }
 
-pub fn fetch_catalog(client: &ApiClient, integration: &str) -> Result<OperationsCatalog> {
-    let path = format!("/api/v1/integrations/{}/operations", integration);
+pub fn fetch_catalog(client: &ApiClient, plugin: &str) -> Result<OperationsCatalog> {
+    let path = format!("/api/v1/integrations/{}/operations", plugin);
     let resp = client.get(&path)?;
     let operations: Vec<CatalogOperation> =
         serde_json::from_value(resp).context("failed to parse operations response")?;

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -5,7 +5,7 @@ use crate::params;
 
 #[derive(Parser)]
 #[command(name = "gestalt")]
-#[command(about = "CLI for Gestalt API - authentication, integrations, and operations")]
+#[command(about = "CLI for Gestalt API - authentication, plugins, and operations")]
 #[command(version)]
 pub struct Cli {
     #[command(subcommand)]
@@ -37,16 +37,23 @@ pub enum Commands {
         command: ConfigCommands,
     },
 
-    /// Manage third-party integrations
-    Integrations {
+    /// Manage plugins
+    Plugins {
         #[command(subcommand)]
-        command: IntegrationCommands,
+        command: PluginCommands,
     },
 
-    /// Execute an integration operation
+    #[command(hide = true)]
+    Integrations {
+        #[command(subcommand)]
+        command: PluginCommands,
+    },
+
+    #[command(hide = true)]
+    /// Execute a plugin operation
     Invoke {
-        /// Integration name (e.g., github, slack)
-        integration: String,
+        /// Plugin name (e.g., github, slack)
+        plugin: String,
 
         /// Operation name segments joined by "." (e.g., "chat postMessage" or "chat.postMessage"). Omit to list available operations.
         operation: Vec<String>,
@@ -72,10 +79,11 @@ pub enum Commands {
         input_file: Option<String>,
     },
 
-    /// Describe an integration operation
+    #[command(hide = true)]
+    /// Describe a plugin operation
     Describe {
-        /// Integration name
-        integration: String,
+        /// Plugin name
+        plugin: String,
         /// Operation name
         operation: String,
     },
@@ -121,12 +129,12 @@ pub enum ConfigCommands {
 }
 
 #[derive(Subcommand)]
-pub enum IntegrationCommands {
-    /// List available integrations
+pub enum PluginCommands {
+    /// List available plugins
     List,
-    /// Connect an integration via OAuth or interactive manual auth
+    /// Connect a plugin via OAuth or interactive manual auth
     Connect {
-        /// Integration name (e.g., github, slack)
+        /// Plugin name (e.g., github, slack)
         name: String,
 
         /// Named connection to connect
@@ -137,9 +145,9 @@ pub enum IntegrationCommands {
         #[arg(long)]
         instance: Option<String>,
     },
-    /// Disconnect an integration
+    /// Disconnect a plugin
     Disconnect {
-        /// Integration name (e.g., github, slack)
+        /// Plugin name (e.g., github, slack)
         name: String,
 
         /// Target a specific named connection
@@ -149,6 +157,41 @@ pub enum IntegrationCommands {
         /// Target a specific stored instance
         #[arg(long)]
         instance: Option<String>,
+    },
+    /// Execute a plugin operation
+    Invoke {
+        /// Plugin name (e.g., github, slack)
+        plugin: String,
+
+        /// Operation name segments joined by "." (e.g., "chat postMessage" or "chat.postMessage"). Omit to list available operations.
+        operation: Vec<String>,
+
+        /// Parameters as key=value or key:=json pairs
+        #[arg(short = 'p', long = "param", value_parser = params::parse_param_entry)]
+        params: Vec<params::ParamEntry>,
+
+        /// Select a named connection for this invocation
+        #[arg(long)]
+        connection: Option<String>,
+
+        /// Select a stored connection instance
+        #[arg(long)]
+        instance: Option<String>,
+
+        /// Select a sub-path from the response (e.g., "data.items")
+        #[arg(long = "select")]
+        select: Option<String>,
+
+        /// Load parameters from a JSON file (use "-" for stdin)
+        #[arg(long = "input-file")]
+        input_file: Option<String>,
+    },
+    /// Describe a plugin operation
+    Describe {
+        /// Plugin name
+        plugin: String,
+        /// Operation name
+        operation: String,
     },
 }
 

--- a/gestalt/cli/src/commands/describe.rs
+++ b/gestalt/cli/src/commands/describe.rs
@@ -4,13 +4,8 @@ use crate::api::ApiClient;
 use crate::catalog;
 use crate::output::{self, Format};
 
-pub fn describe(
-    client: &ApiClient,
-    integration: &str,
-    operation: &str,
-    format: Format,
-) -> Result<()> {
-    let cat = catalog::fetch_catalog(client, integration)?;
+pub fn describe(client: &ApiClient, plugin: &str, operation: &str, format: Format) -> Result<()> {
+    let cat = catalog::fetch_catalog(client, plugin)?;
 
     let op = match cat.find_operation(operation) {
         Some(op) => op,

--- a/gestalt/cli/src/commands/invoke.rs
+++ b/gestalt/cli/src/commands/invoke.rs
@@ -17,13 +17,13 @@ pub struct InvokeOptions<'a> {
 
 pub fn run(
     client: &ApiClient,
-    integration: &str,
+    plugin: &str,
     segments: &[String],
     params: &[ParamEntry],
     options: InvokeOptions<'_>,
     format: Format,
 ) -> Result<()> {
-    let cat = catalog::fetch_catalog(client, integration)?;
+    let cat = catalog::fetch_catalog(client, plugin)?;
     let query = segments.join(".");
 
     match cat.resolve(&query)? {
@@ -32,7 +32,7 @@ pub fn run(
             display_operations(ops, format)
         }
         ResolvedOperation::Exact(_) => {
-            execute(client, &cat, integration, &query, params, options, format)
+            execute(client, &cat, plugin, &query, params, options, format)
         }
         ResolvedOperation::Prefix(matches) => {
             let n = matches.len();
@@ -49,33 +49,25 @@ pub fn run(
 
 pub fn invoke(
     client: &ApiClient,
-    integration: &str,
+    plugin: &str,
     operation: &str,
     params: &[ParamEntry],
     options: InvokeOptions<'_>,
     format: Format,
 ) -> Result<()> {
-    let cat = catalog::fetch_catalog(client, integration)?;
-    execute(
-        client,
-        &cat,
-        integration,
-        operation,
-        params,
-        options,
-        format,
-    )
+    let cat = catalog::fetch_catalog(client, plugin)?;
+    execute(client, &cat, plugin, operation, params, options, format)
 }
 
-pub fn list_operations(client: &ApiClient, integration: &str, format: Format) -> Result<()> {
-    let cat = catalog::fetch_catalog(client, integration)?;
+pub fn list_operations(client: &ApiClient, plugin: &str, format: Format) -> Result<()> {
+    let cat = catalog::fetch_catalog(client, plugin)?;
     display_operations(cat.operations(), format)
 }
 
 fn execute(
     client: &ApiClient,
     cat: &OperationsCatalog,
-    integration: &str,
+    plugin: &str,
     operation: &str,
     params: &[ParamEntry],
     options: InvokeOptions<'_>,
@@ -101,7 +93,7 @@ fn execute(
         );
     }
 
-    let path = format!("/api/v1/{}/{}", integration, operation);
+    let path = format!("/api/v1/{}/{}", plugin, operation);
     let resp = (if param_map.is_empty() {
         client.get(&path)
     } else {
@@ -113,7 +105,7 @@ fn execute(
             return err;
         }
 
-        let mut connect_command = format!("gestalt integrations connect {}", integration);
+        let mut connect_command = format!("gestalt plugins connect {}", plugin);
         if let Some(connection) = options.connection {
             connect_command.push_str(" --connection ");
             connect_command.push_str(connection);
@@ -124,12 +116,12 @@ fn execute(
         }
 
         anyhow::anyhow!(
-            "integration {:?} is not connected. Connect it first with `{}`",
-            integration,
+            "plugin {:?} is not connected. Connect it first with `{}`",
+            plugin,
             connect_command,
         )
     })
-    .with_context(|| format!("failed to invoke {}.{}", integration, operation))?;
+    .with_context(|| format!("failed to invoke {}.{}", plugin, operation))?;
 
     let output_value = match options.select {
         Some(sel_path) => output::select_path(&resp, sel_path)?,

--- a/gestalt/cli/src/commands/mod.rs
+++ b/gestalt/cli/src/commands/mod.rs
@@ -2,6 +2,6 @@ pub mod auth;
 pub mod config;
 pub mod describe;
 pub mod init;
-pub mod integrations;
 pub mod invoke;
+pub mod plugins;
 pub mod tokens;

--- a/gestalt/cli/src/commands/plugins.rs
+++ b/gestalt/cli/src/commands/plugins.rs
@@ -132,7 +132,7 @@ enum ManualCredentialPayload {
 pub fn list(client: &ApiClient, format: Format) -> Result<()> {
     let resp = client
         .get("/api/v1/integrations")
-        .context("failed to list integrations")?;
+        .context("failed to list plugins")?;
 
     match format {
         Format::Json => output::print_json(&resp),
@@ -181,7 +181,7 @@ pub fn disconnect(
 
     client
         .delete(&path)
-        .with_context(|| format!("failed to disconnect integration '{}'", name))?;
+        .with_context(|| format!("failed to disconnect plugin '{}'", name))?;
 
     output::print_success(&format!("Disconnected {}.", name));
     Ok(())
@@ -208,7 +208,7 @@ pub fn connect_with_browser_opener<F>(
 where
     F: FnOnce(&str) -> Result<()>,
 {
-    let integration = fetch_integration(client, name)?;
+    let integration = fetch_plugin(client, name)?;
     let selected_connection = resolve_connection(&integration, connection)?;
     let auth_target = resolve_auth_target(&integration, selected_connection.as_deref());
 
@@ -236,7 +236,7 @@ where
     }
 
     bail!(
-        "integration '{}' does not expose a supported connection flow in the CLI",
+        "plugin '{}' does not expose a supported connection flow in the CLI",
         name
     );
 }
@@ -319,7 +319,7 @@ fn connect_manual(
                     connection_params: connection_params.as_ref(),
                 },
             )
-            .context("failed to connect integration")?,
+            .context("failed to connect plugin")?,
     )
     .context("failed to parse manual connect response")?;
 
@@ -392,18 +392,18 @@ fn complete_pending_selection(
     Ok(())
 }
 
-fn fetch_integration(client: &ApiClient, name: &str) -> Result<IntegrationInfo> {
-    let integrations: Vec<IntegrationInfo> = serde_json::from_value(
+fn fetch_plugin(client: &ApiClient, name: &str) -> Result<IntegrationInfo> {
+    let plugins: Vec<IntegrationInfo> = serde_json::from_value(
         client
             .get("/api/v1/integrations")
-            .context("failed to load integrations")?,
+            .context("failed to load plugins")?,
     )
-    .context("failed to parse integrations")?;
+    .context("failed to parse plugins")?;
 
-    integrations
+    plugins
         .into_iter()
-        .find(|integration| integration.name == name)
-        .with_context(|| format!("integration '{}' not found", name))
+        .find(|plugin| plugin.name == name)
+        .with_context(|| format!("plugin '{}' not found", name))
 }
 
 fn resolve_connection(
@@ -420,7 +420,7 @@ fn resolve_connection(
             .map(|connection| Some(connection.name.clone()))
             .with_context(|| {
                 format!(
-                    "unknown connection '{}' for integration '{}'; available connections: {}",
+                    "unknown connection '{}' for plugin '{}'; available connections: {}",
                     requested_connection,
                     integration.name,
                     integration.available_connections()

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -1,8 +1,6 @@
 use clap::{CommandFactory, Parser};
 use gestalt::api::{self, ApiClient};
-use gestalt::cli::{
-    AuthCommands, Cli, Commands, ConfigCommands, IntegrationCommands, TokenCommands,
-};
+use gestalt::cli::{AuthCommands, Cli, Commands, ConfigCommands, PluginCommands, TokenCommands};
 use gestalt::commands;
 use gestalt::output;
 
@@ -29,62 +27,32 @@ fn run() -> anyhow::Result<()> {
             ConfigCommands::Unset { key } => commands::config::unset(&key),
             ConfigCommands::List => commands::config::list(format),
         },
-        Commands::Integrations { command } => {
-            let client = ApiClient::from_env(url)?;
-            match command {
-                IntegrationCommands::List => commands::integrations::list(&client, format),
-                IntegrationCommands::Connect {
-                    name,
-                    connection,
-                    instance,
-                } => commands::integrations::connect(
-                    &client,
-                    &name,
-                    connection.as_deref(),
-                    instance.as_deref(),
-                ),
-                IntegrationCommands::Disconnect {
-                    name,
-                    connection,
-                    instance,
-                } => commands::integrations::disconnect(
-                    &client,
-                    &name,
-                    connection.as_deref(),
-                    instance.as_deref(),
-                ),
-            }
+        Commands::Plugins { command } | Commands::Integrations { command } => {
+            dispatch_plugin_command(command, url, format)
         }
         Commands::Invoke {
-            integration,
+            plugin,
             operation,
             params,
             connection,
             instance,
             select,
             input_file,
-        } => {
-            let client = ApiClient::from_env(url)?;
-            commands::invoke::run(
-                &client,
-                &integration,
-                &operation,
-                &params,
-                commands::invoke::InvokeOptions {
-                    connection: connection.as_deref(),
-                    instance: instance.as_deref(),
-                    select: select.as_deref(),
-                    input_file: input_file.as_deref(),
-                },
-                format,
-            )
-        }
-        Commands::Describe {
-            integration,
-            operation,
-        } => {
-            let client = ApiClient::from_env(url)?;
-            commands::describe::describe(&client, &integration, &operation, format)
+        } => dispatch_plugin_command(
+            PluginCommands::Invoke {
+                plugin,
+                operation,
+                params,
+                connection,
+                instance,
+                select,
+                input_file,
+            },
+            url,
+            format,
+        ),
+        Commands::Describe { plugin, operation } => {
+            dispatch_plugin_command(PluginCommands::Describe { plugin, operation }, url, format)
         }
         Commands::Tokens { command } => {
             let client = ApiClient::from_env(url)?;
@@ -95,6 +63,56 @@ fn run() -> anyhow::Result<()> {
                 TokenCommands::List => commands::tokens::list(&client, format),
                 TokenCommands::Revoke { id } => commands::tokens::revoke(&client, &id, format),
             }
+        }
+    }
+}
+
+fn dispatch_plugin_command(
+    command: PluginCommands,
+    url: Option<&str>,
+    format: gestalt::output::Format,
+) -> anyhow::Result<()> {
+    let client = ApiClient::from_env(url)?;
+    match command {
+        PluginCommands::List => commands::plugins::list(&client, format),
+        PluginCommands::Connect {
+            name,
+            connection,
+            instance,
+        } => commands::plugins::connect(&client, &name, connection.as_deref(), instance.as_deref()),
+        PluginCommands::Disconnect {
+            name,
+            connection,
+            instance,
+        } => commands::plugins::disconnect(
+            &client,
+            &name,
+            connection.as_deref(),
+            instance.as_deref(),
+        ),
+        PluginCommands::Invoke {
+            plugin,
+            operation,
+            params,
+            connection,
+            instance,
+            select,
+            input_file,
+        } => commands::invoke::run(
+            &client,
+            &plugin,
+            &operation,
+            &params,
+            commands::invoke::InvokeOptions {
+                connection: connection.as_deref(),
+                instance: instance.as_deref(),
+                select: select.as_deref(),
+                input_file: input_file.as_deref(),
+            },
+            format,
+        ),
+        PluginCommands::Describe { plugin, operation } => {
+            commands::describe::describe(&client, &plugin, &operation, format)
         }
     }
 }

--- a/gestalt/cli/tests/integration.rs
+++ b/gestalt/cli/tests/integration.rs
@@ -300,11 +300,11 @@ fn write_cli_credentials(home: &Path, json: &str) {
 }
 
 #[test]
-fn test_list_integrations() {
+fn test_list_plugins() {
     let mut server = Server::new();
     let mock = authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
         .with_body(
-            r#"[{"name":"github","displayName":"GitHub","description":"GitHub integration"}]"#,
+            r#"[{"name":"acme_crm","displayName":"Acme CRM","description":"Acme CRM plugin"}]"#,
         )
         .create();
 
@@ -314,7 +314,7 @@ fn test_list_integrations() {
     mock.assert();
     let items = resp.as_array().unwrap();
     assert_eq!(items.len(), 1);
-    assert_eq!(items[0]["name"], "github");
+    assert_eq!(items[0]["name"], "acme_crm");
 }
 
 #[test]
@@ -433,7 +433,7 @@ fn test_error_response() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "failed to invoke auth_svc.list_items: integration \"auth_svc\" is not connected. Connect it first with `gestalt integrations connect auth_svc`",
+            "failed to invoke auth_svc.list_items: plugin \"auth_svc\" is not connected. Connect it first with `gestalt plugins connect auth_svc`",
         ))
         .stderr(predicate::str::contains("OAuth first").not());
 }
@@ -588,7 +588,7 @@ fn test_start_oauth() {
     .create();
 
     let client = create_client(&server);
-    let body = serde_json::json!({"integration": "github"});
+    let body = serde_json::json!({"integration": "acme_crm"});
     let resp = client.post("/api/v1/auth/start-oauth", &body).unwrap();
 
     mock.assert();
@@ -919,7 +919,7 @@ fn test_connect_includes_connection_and_instance() {
     let mut server = Server::new();
     let _integrations =
         authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-            .with_body(r#"[{"name":"github","authTypes":["oauth"],"connected":false}]"#)
+            .with_body(r#"[{"name":"acme_crm","authTypes":["oauth"],"connected":false}]"#)
             .create();
     let mock = authed_json_mock!(
         server,
@@ -929,15 +929,15 @@ fn test_connect_includes_connection_and_instance() {
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
     .match_body(Matcher::JsonString(
-        r#"{"connection":"workspace","instance":"team-a","integration":"github"}"#.to_string(),
+        r#"{"connection":"workspace","instance":"team-a","integration":"acme_crm"}"#.to_string(),
     ))
     .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
     .create();
 
     let client = create_client(&server);
-    let result = gestalt::commands::integrations::connect_with_browser_opener(
+    let result = gestalt::commands::plugins::connect_with_browser_opener(
         &client,
-        "github",
+        "acme_crm",
         Some("workspace"),
         Some("team-a"),
         |_| Ok(()),
@@ -952,7 +952,7 @@ fn test_connect_prefers_oauth_when_manual_also_exists_and_omits_null_connection_
     let mut server = Server::new();
     let _integrations =
         authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-            .with_body(r#"[{"name":"github","authTypes":["oauth","manual"],"connected":false}]"#)
+            .with_body(r#"[{"name":"acme_crm","authTypes":["oauth","manual"],"connected":false}]"#)
             .create();
     let mock = authed_json_mock!(
         server,
@@ -962,7 +962,7 @@ fn test_connect_prefers_oauth_when_manual_also_exists_and_omits_null_connection_
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
     .match_body(Matcher::JsonString(
-        r#"{"integration":"github"}"#.to_string(),
+        r#"{"integration":"acme_crm"}"#.to_string(),
     ))
     .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
     .create();
@@ -970,9 +970,9 @@ fn test_connect_prefers_oauth_when_manual_also_exists_and_omits_null_connection_
     let client = create_client(&server);
     let opened_url = Arc::new(Mutex::new(None));
     let opened_url_handle = Arc::clone(&opened_url);
-    let result = gestalt::commands::integrations::connect_with_browser_opener(
+    let result = gestalt::commands::plugins::connect_with_browser_opener(
         &client,
-        "github",
+        "acme_crm",
         None,
         None,
         move |url| {
@@ -995,16 +995,16 @@ fn test_disconnect_sends_delete_with_connection_and_instance() {
     let mock = authed_json_mock!(
         server,
         Method::DELETE,
-        "/api/v1/integrations/datadog?connection=oauth&instance=prod",
+        "/api/v1/integrations/widget_metrics?connection=oauth&instance=prod",
         StatusCode::OK
     )
     .with_body(r#"{"status":"disconnected"}"#)
     .create();
 
     let client = create_client(&server);
-    let result = gestalt::commands::integrations::disconnect(
+    let result = gestalt::commands::plugins::disconnect(
         &client,
-        "datadog",
+        "widget_metrics",
         Some("oauth"),
         Some("prod"),
     );
@@ -1019,15 +1019,14 @@ fn test_disconnect_normalizes_plugin_connection_name() {
     let mock = authed_json_mock!(
         server,
         Method::DELETE,
-        "/api/v1/integrations/github?connection=_plugin",
+        "/api/v1/integrations/acme_crm?connection=_plugin",
         StatusCode::OK
     )
     .with_body(r#"{"status":"disconnected"}"#)
     .create();
 
     let client = create_client(&server);
-    let result =
-        gestalt::commands::integrations::disconnect(&client, "github", Some("plugin"), None);
+    let result = gestalt::commands::plugins::disconnect(&client, "acme_crm", Some("plugin"), None);
 
     mock.assert();
     assert!(result.is_ok());
@@ -1039,14 +1038,14 @@ fn test_disconnect_without_optional_params() {
     let mock = authed_json_mock!(
         server,
         Method::DELETE,
-        "/api/v1/integrations/slack",
+        "/api/v1/integrations/buzz_chat",
         StatusCode::OK
     )
     .with_body(r#"{"status":"disconnected"}"#)
     .create();
 
     let client = create_client(&server);
-    let result = gestalt::commands::integrations::disconnect(&client, "slack", None, None);
+    let result = gestalt::commands::plugins::disconnect(&client, "buzz_chat", None, None);
 
     mock.assert();
     assert!(result.is_ok());
@@ -1058,11 +1057,11 @@ fn test_manual_connect_uses_prompted_credentials_and_connection_params() {
     let _integrations = authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
         .with_body(
             r#"[{
-                "name":"datadog",
-                "displayName":"Datadog",
+                "name":"widget_metrics",
+                "displayName":"Widget Metrics",
                 "description":"Metrics and logs",
                 "authTypes":["manual"],
-                "connectionParams":{"site":{"description":"Datadog site","default":"datadoghq.com","required":true}},
+                "connectionParams":{"region":{"description":"API region","default":"us-east","required":true}},
                 "credentialFields":[{"name":"api_key","label":"API key","description":"Use a personal API key"}]
             }]"#,
         )
@@ -1075,20 +1074,20 @@ fn test_manual_connect_uses_prompted_credentials_and_connection_params() {
     )
         .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
         .match_body(Matcher::JsonString(
-            r#"{"connectionParams":{"site":"datadoghq.eu"},"credential":"dd-key","integration":"datadog"}"#.to_string(),
+            r#"{"connectionParams":{"region":"eu-west"},"credential":"wm-key","integration":"widget_metrics"}"#.to_string(),
         ))
-        .with_body(r#"{"status":"connected","integration":"datadog"}"#)
+        .with_body(r#"{"status":"connected","integration":"widget_metrics"}"#)
         .create();
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["integrations", "connect", "datadog"])
-        .write_stdin("datadoghq.eu\ndd-key\n")
+        .args(["plugins", "connect", "widget_metrics"])
+        .write_stdin("eu-west\nwm-key\n")
         .assert()
         .success()
-        .stderr(predicate::str::contains("Datadog site"))
+        .stderr(predicate::str::contains("API region"))
         .stderr(predicate::str::contains("API key"))
-        .stderr(predicate::str::contains("Connected datadog."));
+        .stderr(predicate::str::contains("Connected widget_metrics."));
 }
 
 #[test]
@@ -1151,7 +1150,7 @@ fn test_manual_connect_prompts_for_connection_and_finishes_candidate_selection()
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["integrations", "connect", "manual-svc"])
+        .args(["plugins", "connect", "manual-svc"])
         .write_stdin("1\nabc123\n2\n")
         .assert()
         .success()
@@ -1187,7 +1186,7 @@ fn test_manual_connect_falls_back_to_generic_credential_prompt() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["integrations", "connect", "manual-svc"])
+        .args(["plugins", "connect", "manual-svc"])
         .write_stdin("secret\n")
         .assert()
         .success()
@@ -1205,7 +1204,7 @@ fn test_manual_connect_fails_when_stdin_closes_during_prompt() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["integrations", "connect", "manual-svc"])
+        .args(["plugins", "connect", "manual-svc"])
         .write_stdin("")
         .assert()
         .failure()
@@ -1338,7 +1337,7 @@ fn test_invoke_with_connection_and_instance() {
 
     secondary_invoke_mock.assert();
     assert!(err.contains(
-        "Connect it first with `gestalt integrations connect other_svc --connection workspace --instance team-a`"
+        "Connect it first with `gestalt plugins connect other_svc --connection workspace --instance team-a`"
     ));
 }
 
@@ -1361,6 +1360,24 @@ fn test_describe_operation() {
 
     mock.assert();
     assert!(result.is_ok());
+
+    // "plugins describe" subcommand reaches the same handler
+    let mock = json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations",
+        StatusCode::OK
+    )
+    .with_body(catalog_body())
+    .create();
+
+    let output = run_cli(&server, &["plugins", "describe", "test_svc", "do_thing"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    mock.assert();
 }
 
 #[test]
@@ -1441,7 +1458,7 @@ fn test_resolve_url_does_not_read_unsupported_dot_gestalt_json_file() {
 }
 
 #[test]
-fn test_cli_integrations_list_table_output() {
+fn test_cli_plugins_list_table_output() {
     let mut server = Server::new();
     let home = TempDir::new().unwrap();
     write_credentials(
@@ -1454,16 +1471,16 @@ fn test_cli_integrations_list_table_output() {
     );
     let mock = authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
         .with_body(
-            r#"[{"name":"github","description":"GitHub integration with a longer description","connected":true}]"#,
+            r#"[{"name":"acme_crm","description":"Acme CRM plugin with a longer description","connected":true}]"#,
         )
         .create();
 
     let mut cmd = cli_command(home.path());
-    cmd.args(["integrations", "list"]);
+    cmd.args(["plugins", "list"]);
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("GITHUB").or(predicate::str::contains("github")))
-        .stdout(predicate::str::contains("GitHub integration"))
+        .stdout(predicate::str::contains("ACME_CRM").or(predicate::str::contains("acme_crm")))
+        .stdout(predicate::str::contains("Acme CRM plugin"))
         .stdout(
             predicate::str::contains("Connected")
                 .or(predicate::str::contains("CONNECTED"))
@@ -1471,10 +1488,24 @@ fn test_cli_integrations_list_table_output() {
         );
 
     mock.assert();
+
+    let mock = authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
+        .with_body(
+            r#"[{"name":"acme_crm","description":"Acme CRM plugin with a longer description","connected":true}]"#,
+        )
+        .create();
+
+    let mut cmd = cli_command(home.path());
+    cmd.args(["integrations", "list"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("acme_crm"));
+
+    mock.assert();
 }
 
 #[test]
-fn test_cli_integrations_list_accepts_legacy_credentials_without_api_url() {
+fn test_cli_plugins_list_accepts_legacy_credentials_without_api_url() {
     let mut server = Server::new();
     let home = TempDir::new().unwrap();
     write_credentials(
@@ -1486,7 +1517,7 @@ fn test_cli_integrations_list_accepts_legacy_credentials_without_api_url() {
     );
     let mock = authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
         .with_body(
-            r#"[{"name":"github","description":"GitHub integration with a longer description","connected":true}]"#,
+            r#"[{"name":"acme_crm","description":"Acme CRM plugin with a longer description","connected":true}]"#,
         )
         .create();
 
@@ -1495,10 +1526,10 @@ fn test_cli_integrations_list_accepts_legacy_credentials_without_api_url() {
     config_cmd.assert().success();
 
     let mut cmd = cli_command(home.path());
-    cmd.args(["integrations", "list"]);
+    cmd.args(["plugins", "list"]);
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("GitHub integration"));
+        .stdout(predicate::str::contains("Acme CRM plugin"));
 
     mock.assert();
 }
@@ -1755,6 +1786,27 @@ fn test_space_separated_segments_invoke() {
         String::from_utf8_lossy(&output.stderr)
     );
     deep_mock.assert();
+
+    // "plugins invoke" subcommand resolves the same way
+    let subcommand_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/test_svc/widgets.delete",
+        StatusCode::OK
+    )
+    .with_body(r#"{"ok": true}"#)
+    .create();
+
+    let output = run_cli(
+        &server,
+        &["plugins", "invoke", "test_svc", "widgets", "delete"],
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    subcommand_mock.assert();
 }
 
 #[test]

--- a/gestaltd/ui/src/app/docs/DocsClient.tsx
+++ b/gestaltd/ui/src/app/docs/DocsClient.tsx
@@ -29,7 +29,7 @@ const sections: Section[] = [
       { id: "authenticate", label: "Authenticate" },
     ],
   },
-  { id: "connect", label: "Connect Integrations", subsections: [] },
+  { id: "connect", label: "Connect Plugins", subsections: [] },
   {
     id: "invoke",
     label: "Invoke Operations",
@@ -271,24 +271,24 @@ export GESTALT_URL=${origin}`}
 gestalt auth status
 
 export GESTALT_API_KEY=gst_api_your_token_here
-gestalt integrations list`}
+gestalt plugins list`}
               />
             </DocSection>
 
             <DocSection
               id="connect"
-              title="Connect Integrations"
-              description="Inspect available integrations first, then authorize the ones you need."
+              title="Connect Plugins"
+              description="Inspect available plugins first, then authorize the ones you need."
             >
               <p className="doc-copy">
-                Integrations exposed by the deployment appear in both the CLI
+                Plugins exposed by the deployment appear in both the CLI
                 and the web UI. Use either surface to start the underlying OAuth
                 or manual credential flow.
               </p>
               <CodeBlock
-                code={`gestalt integrations list
-gestalt integrations connect <integration>
-gestalt integrations connect <integration> --connection <name> --instance <instance>`}
+                code={`gestalt plugins list
+gestalt plugins connect <plugin>
+gestalt plugins connect <plugin> --connection <name> --instance <instance>`}
               />
               <p className="doc-copy">
                 If you prefer the browser flow, the same work is available on{" "}
@@ -302,19 +302,19 @@ gestalt integrations connect <integration> --connection <name> --instance <insta
             <DocSection
               id="invoke"
               title="Invoke Operations"
-              description="Use the catalog built into Gestalt to discover an integration's operations before making requests."
+              description="Use the catalog built into Gestalt to discover a plugin's operations before making requests."
             >
               <CodeBlock
-                code={`gestalt invoke <integration>
-gestalt describe <integration> <operation>
-gestalt invoke <integration> <operation> -p key=value
-gestalt invoke <integration> <operation> -p filters:='{"status":"open"}'
-gestalt invoke <integration> <operation> --input-file payload.json --select data.items`}
+                code={`gestalt plugins invoke <plugin>
+gestalt plugins describe <plugin> <operation>
+gestalt plugins invoke <plugin> <operation> -p key=value
+gestalt plugins invoke <plugin> <operation> -p filters:='{"status":"open"}'
+gestalt plugins invoke <plugin> <operation> --input-file payload.json --select data.items`}
               />
               <p className="doc-copy">
                 If you omit the operation,{" "}
                 <code className="font-mono text-sm text-primary">
-                  gestalt invoke &lt;integration&gt;
+                  gestalt plugins invoke &lt;plugin&gt;
                 </code>{" "}
                 lists available operations instead of running one.
               </p>


### PR DESCRIPTION
## Summary

- Restructures the CLI so all plugin operations live under `gestalt plugins` (list, connect, disconnect, invoke, describe) instead of using `gestalt integrations` and top-level `gestalt invoke`/`gestalt describe`
- Adds hidden backward-compat aliases so the old command forms still work
- Updates all docs, the embedded admin UI, and error messages to match

The HTTP API routes (`/api/v1/integrations/...`) are unchanged since they are stable external contract.

## Test plan

- [x] `cargo test` passes all 48 tests
- [ ] Manual: `gestalt plugins list`, `gestalt plugins invoke httpbin`, `gestalt plugins describe httpbin get_ip`
- [ ] Manual backward compat: `gestalt integrations list`, `gestalt invoke httpbin get_ip`, `gestalt describe httpbin get_ip`
- [ ] `gestalt --help` shows `plugins` and hides `integrations`, `invoke`, `describe` at top level

🤖 Generated with [Claude Code](https://claude.com/claude-code)