### PR TITLE
Strengthen open-source commitment in What Gestalt is not

### DIFF
--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -28,7 +28,7 @@ Gestalt handles this so individual agents and applications don't have to. A sing
 
 ## What Gestalt is not
 
-Gestalt is not a SaaS platform. There is no hosted version. It runs on your infrastructure, and you control the data, the credentials, and the deployment.
+Gestalt is not a SaaS platform. It is open source and self-hostable on any infrastructure you control, giving you full ownership of your data, credentials, and deployment. Gestalt will remain free and open source; self-hosting is a first-class feature and a permanent commitment to the community.
 
 Gestalt does not replace your existing APIs. It sits between agents and upstream services, handling auth and credential lifecycle. Your APIs stay where they are.
 


### PR DESCRIPTION
## Summary
- Replaces the first paragraph in "What Gestalt is not" with a stronger open-source and self-hosting commitment statement, following a Kubernetes-style tone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)