### PR TITLE
Fix callout icon vertical alignment

### DIFF
--- a/docs/globals.css
+++ b/docs/globals.css
@@ -437,6 +437,10 @@ article.nextra-content main::before {
   order: 1;
 }
 
+.nextra-callout {
+  align-items: center;
+}
+
 article div:has(> table) {
   width: 100%;
 }


### PR DESCRIPTION
Adds align-items: center to .nextra-callout so the icon stays vertically centered when text wraps.