### PR TITLE
Fix connection labels and auth leakage for integrations

### DIFF
--- a/gestalt/cli/src/commands/plugins.rs
+++ b/gestalt/cli/src/commands/plugins.rs
@@ -33,6 +33,8 @@ struct IntegrationInfo {
 struct ConnectionDefInfo {
     name: String,
     #[serde(default)]
+    display_name: Option<String>,
+    #[serde(default)]
     auth_types: Vec<String>,
     #[serde(default)]
     credential_fields: Vec<CredentialFieldInfo>,
@@ -436,7 +438,7 @@ fn resolve_connection(
         .connections
         .iter()
         .map(|connection| PromptOption {
-            label: user_facing_connection_name(&connection.name).to_string(),
+            label: connection.display_name(),
             detail: Some(format!(
                 "Auth: {}",
                 format_auth_types(&connection.auth_types)
@@ -595,9 +597,17 @@ impl IntegrationInfo {
     fn available_connections(&self) -> String {
         self.connections
             .iter()
-            .map(|connection| user_facing_connection_name(&connection.name).to_string())
+            .map(ConnectionDefInfo::display_name)
             .collect::<Vec<_>>()
             .join(", ")
+    }
+}
+
+impl ConnectionDefInfo {
+    fn display_name(&self) -> String {
+        non_empty(self.display_name.as_deref())
+            .unwrap_or(user_facing_connection_name(&self.name))
+            .to_string()
     }
 }
 

--- a/gestalt/cli/tests/integration.rs
+++ b/gestalt/cli/tests/integration.rs
@@ -1095,16 +1095,16 @@ fn test_manual_connect_prompts_for_connection_and_finishes_candidate_selection()
     let mut server = Server::new();
     let _integrations = authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
         .with_body(
-            r#"[{
-                "name":"manual-svc",
-                "displayName":"Manual Service",
-                "authTypes":["manual"],
-                "connections":[
-                    {"name":"workspace","credentialFields":[{"name":"token","label":"Workspace token"}]},
-                    {"name":"plugin","authTypes":["oauth"]}
-                ]
-            }]"#,
-        )
+	            r#"[{
+	                "name":"manual-svc",
+	                "displayName":"Manual Service",
+	                "authTypes":["manual"],
+	                "connections":[
+	                    {"name":"workspace","displayName":"Workspace OAuth","credentialFields":[{"name":"token","label":"Workspace token"}]},
+	                    {"name":"plugin","displayName":"Legacy Plugin","authTypes":["oauth"]}
+	                ]
+	            }]"#,
+	        )
         .create();
     let _connect = authed_json_mock!(
         server,
@@ -1157,6 +1157,7 @@ fn test_manual_connect_prompts_for_connection_and_finishes_candidate_selection()
         .stderr(predicate::str::contains(
             "Select a Manual Service connection:",
         ))
+        .stderr(predicate::str::contains("Workspace OAuth"))
         .stderr(predicate::str::contains("Workspace token"))
         .stderr(predicate::str::contains(
             "Gestalt found more than one manual-svc connection. Choose one to save:",

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -228,6 +228,7 @@ func (s ServerConfig) ManagementAddr() string {
 // ConnectionDef owns authentication and connection parameters for a named
 // connection. All connections in a single integration must share the same Mode.
 type ConnectionDef struct {
+	DisplayName      string                              `yaml:"displayName,omitempty"`
 	Mode             pluginmanifestv1.ConnectionMode     `yaml:"mode"`
 	Auth             ConnectionAuthDef                   `yaml:"auth"`
 	ConnectionParams map[string]ConnectionParamDef       `yaml:"params"`
@@ -373,6 +374,9 @@ func MergeConnectionDef(dst *ConnectionDef, src *ConnectionDef) {
 	if dst == nil || src == nil {
 		return
 	}
+	if src.DisplayName != "" {
+		dst.DisplayName = src.DisplayName
+	}
 	if src.Mode != "" {
 		dst.Mode = src.Mode
 	}
@@ -474,6 +478,7 @@ func EffectiveNamedConnectionDef(plugin *ProviderEntry, manifestPlugin *pluginma
 	if manifestPlugin != nil && manifestPlugin.Connections != nil {
 		if def, ok := manifestPlugin.Connections[name]; ok && def != nil {
 			found = true
+			conn.DisplayName = def.DisplayName
 			if def.Mode != "" {
 				conn.Mode = def.Mode
 			}

--- a/gestaltd/internal/pluginpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/pluginpkg/manifest_workflow_test.go
@@ -306,6 +306,7 @@ spec:
       auth:
         type: none
     api:
+      displayName: OAuth
       auth:
         type: oauth2
         authorizationUrl: https://auth.example.com/authorize
@@ -347,6 +348,9 @@ spec:
 	if manifest.Spec.SurfaceConnectionName("openapi") != "api" {
 		t.Fatalf("provider openapi connection = %q, want api", manifest.Spec.SurfaceConnectionName("openapi"))
 	}
+	if manifest.Spec.Connections["api"] == nil || manifest.Spec.Connections["api"].DisplayName != "OAuth" {
+		t.Fatalf("provider api connection displayName = %#v", manifest.Spec.Connections["api"])
+	}
 	if len(manifest.Spec.ManagedParameters) != 1 {
 		t.Fatalf("managed_parameters = %+v", manifest.Spec.ManagedParameters)
 	}
@@ -374,6 +378,7 @@ displayName: Notion
 spec:
   connections:
     mcp:
+      displayName: MCP
       mode: user
       auth:
         type: mcp_oauth
@@ -398,6 +403,9 @@ spec:
 	}
 	if conn := dirManifest.Spec.Connections["mcp"]; conn == nil || conn.Auth == nil || conn.Auth.Type != pluginmanifestv1.AuthTypeMCPOAuth {
 		t.Fatalf("plugin connection auth = %#v", dirManifest.Spec.Connections["mcp"])
+	}
+	if conn := dirManifest.Spec.Connections["mcp"]; conn == nil || conn.DisplayName != "MCP" {
+		t.Fatalf("plugin connection displayName = %#v", dirManifest.Spec.Connections["mcp"])
 	}
 
 	archivePath := filepath.Join(root, "plugin-mcp-oauth.tar.gz")

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -56,6 +56,7 @@ type credentialFieldInfo struct {
 }
 
 type connectionDefInfo struct {
+	DisplayName      string                `json:"displayName,omitempty"`
 	Name             string                `json:"name"`
 	AuthTypes        []string              `json:"authTypes"`
 	CredentialFields []credentialFieldInfo `json:"credentialFields"`

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	pluginmanifestv1 "github.com/valon-technologies/gestalt/server/sdk/pluginmanifest/v1"
 )
 
 type createTokenRequest struct {
@@ -175,7 +174,8 @@ func (s *Server) connectionInfosForPlugin(integration string, plugin *config.Pro
 	manifestProvider := plugin.ManifestSpec()
 
 	infos := make([]connectionDefInfo, 0, len(plugin.Connections)+1)
-	if info, ok := s.connectionInfoFromAuth(integration, config.PluginConnectionAlias, config.EffectivePluginConnectionDef(plugin, manifestProvider).Auth, integrationAuthTypes, defaultCredentialFields); ok {
+	effectivePluginConn := config.EffectivePluginConnectionDef(plugin, manifestProvider)
+	if info, ok := s.connectionInfoFromAuth(integration, config.PluginConnectionAlias, effectivePluginConn, integrationAuthTypes, defaultCredentialFields); ok {
 		infos = append(infos, info)
 	}
 
@@ -207,7 +207,7 @@ func (s *Server) connectionInfosForPlugin(integration string, plugin *config.Pro
 		if !ok {
 			continue
 		}
-		if info, ok := s.connectionInfoFromAuth(integration, name, conn.Auth, integrationAuthTypes, defaultCredentialFields); ok {
+		if info, ok := s.connectionInfoFromAuth(integration, name, conn, integrationAuthTypes, defaultCredentialFields); ok {
 			infos = append(infos, info)
 		}
 	}
@@ -259,19 +259,20 @@ func credentialFieldInfos[T any](fields []T, mapField func(T) credentialFieldInf
 	return infos
 }
 
-func (s *Server) connectionInfoFromAuth(integration, name string, auth config.ConnectionAuthDef, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo) (connectionDefInfo, bool) {
-	authTypes := connectionAuthTypes(auth.Type, integrationAuthTypes)
+func (s *Server) connectionInfoFromAuth(integration, name string, conn config.ConnectionDef, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo) (connectionDefInfo, bool) {
+	authTypes := connectionAuthTypes(conn.Auth, integrationAuthTypes)
 	authTypes = s.supportedConnectionAuthTypes(integration, name, authTypes)
 	if len(authTypes) == 0 {
 		return connectionDefInfo{}, false
 	}
 
 	info := connectionDefInfo{
+		DisplayName:      connectionDisplayName(name, conn.DisplayName),
 		Name:             name,
 		AuthTypes:        authTypes,
 		CredentialFields: []credentialFieldInfo{},
 	}
-	if fields := credentialFieldInfos(auth.Credentials, func(field config.CredentialFieldDef) credentialFieldInfo {
+	if fields := credentialFieldInfos(conn.Auth.Credentials, func(field config.CredentialFieldDef) credentialFieldInfo {
 		return credentialFieldInfo{
 			Name:        field.Name,
 			Label:       field.Label,
@@ -326,20 +327,24 @@ func fallbackAuthTypesForProvider(prov core.Provider) []string {
 	return []string{"oauth"}
 }
 
-func connectionAuthTypes(authType pluginmanifestv1.AuthType, integrationAuthTypes []string) []string {
-	if authType == "" {
+func connectionDisplayName(name, configured string) string {
+	if strings.TrimSpace(configured) != "" {
+		return configured
+	}
+	return userFacingConnectionName(name)
+}
+
+func connectionAuthTypes(auth config.ConnectionAuthDef, integrationAuthTypes []string) []string {
+	if auth.Type == "" {
 		if len(integrationAuthTypes) == 0 {
 			return nil
 		}
 		return append([]string(nil), integrationAuthTypes...)
 	}
 
-	authTypes := userFacingAuthTypes([]string{string(authType)})
+	authTypes := userFacingAuthTypes([]string{string(auth.Type)})
 	if len(authTypes) == 0 {
 		return nil
-	}
-	if authTypesContain(integrationAuthTypes, "manual") && !authTypesContain(authTypes, "manual") {
-		authTypes = append(authTypes, "manual")
 	}
 	return authTypes
 }

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -886,6 +886,7 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		},
 		Connections: map[string]*config.ConnectionDef{
 			"workspace": {
+				DisplayName: "Workspace OAuth",
 				Auth: config.ConnectionAuthDef{
 					Type: pluginmanifestv1.AuthTypeManual,
 					Credentials: []config.CredentialFieldDef{
@@ -906,6 +907,7 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 				},
 				Connections: map[string]*pluginmanifestv1.ManifestConnectionDef{
 					"workspace": {
+						DisplayName: "Workspace Access",
 						Auth: &pluginmanifestv1.ProviderAuth{
 							Type: pluginmanifestv1.AuthTypeManual,
 							Credentials: []pluginmanifestv1.CredentialField{
@@ -971,6 +973,7 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		Description string `json:"description"`
 	}
 	type connectionInfo struct {
+		DisplayName      string            `json:"displayName"`
 		Name             string            `json:"name"`
 		AuthTypes        []string          `json:"authTypes"`
 		CredentialFields []credentialField `json:"credentialFields"`
@@ -1005,6 +1008,9 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		{Name: "plugin_local_only", Label: "Plugin Local Only", Description: "Plugin Local Only Description"},
 	}) {
 		t.Fatalf("plugin connection info = %+v", got[config.PluginConnectionAlias])
+	}
+	if got["workspace"].DisplayName != "Workspace OAuth" {
+		t.Fatalf("workspace connection info = %+v", got["workspace"])
 	}
 	if !reflect.DeepEqual(got["workspace"].AuthTypes, []string{"manual"}) || !reflect.DeepEqual(got["workspace"].CredentialFields, []credentialField{
 		{Name: "workspace_token", Label: "Workspace Config Token", Description: "Workspace Manifest Description"},
@@ -1108,13 +1114,11 @@ func TestListIntegrations_ConnectionInfosIncludeProviderManualAuth(t *testing.T)
 					TokenURL:         "https://example.com/oauth/token",
 				},
 			},
-			wantAuth: []string{"oauth", "manual"},
+			wantAuth: []string{"oauth"},
 			wantFields: []struct {
 				Name  string `json:"name"`
 				Label string `json:"label"`
-			}{
-				{Name: "api_token", Label: "API Token"},
-			},
+			}{},
 		},
 		{
 			name: "empty auth type still exposes oauth",

--- a/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/pluginmanifest/v1/manifest.jsonschema.json
@@ -233,6 +233,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "displayName": {
+          "type": "string",
+          "minLength": 1
+        },
         "mode": {
           "type": "string",
           "enum": [
@@ -260,6 +264,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "displayName": {
+          "type": "string",
+          "minLength": 1
+        },
         "mode": {
           "type": "string",
           "enum": [

--- a/gestaltd/sdk/pluginmanifest/v1/types.go
+++ b/gestaltd/sdk/pluginmanifest/v1/types.go
@@ -230,10 +230,11 @@ type ManifestOperationOverride struct {
 }
 
 type ManifestConnectionDef struct {
-	Mode      ConnectionMode                     `json:"mode,omitempty" yaml:"mode,omitempty"`
-	Auth      *ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
-	Params    map[string]ProviderConnectionParam `json:"params,omitempty" yaml:"params,omitempty"`
-	Discovery *ProviderDiscovery                 `json:"discovery,omitempty" yaml:"discovery,omitempty"`
+	DisplayName string                             `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	Mode        ConnectionMode                     `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Auth        *ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
+	Params      map[string]ProviderConnectionParam `json:"params,omitempty" yaml:"params,omitempty"`
+	Discovery   *ProviderDiscovery                 `json:"discovery,omitempty" yaml:"discovery,omitempty"`
 }
 
 type ProviderOperation struct {

--- a/gestaltd/ui/e2e/integrations.spec.ts
+++ b/gestaltd/ui/e2e/integrations.spec.ts
@@ -23,11 +23,13 @@ const MULTI_CONNECTION_DUAL_AUTH_INTEGRATION: Integration = {
   connections: [
     {
       name: "workspace",
+      displayName: "Workspace OAuth",
       authTypes: ["oauth", "manual"],
       credentialFields: [{ name: "api_token", label: "API Token" }],
     },
     {
       name: "personal",
+      displayName: "Personal Token",
       authTypes: ["manual"],
       credentialFields: [{ name: "personal_token", label: "Personal Token" }],
     },
@@ -42,11 +44,13 @@ const MULTI_CONNECTION_MULTI_OAUTH_INTEGRATION: Integration = {
   connections: [
     {
       name: "workspace",
+      displayName: "Workspace OAuth",
       authTypes: ["oauth", "manual"],
       credentialFields: [{ name: "workspace_token", label: "Workspace Token" }],
     },
     {
       name: "personal",
+      displayName: "Personal OAuth",
       authTypes: ["oauth", "manual"],
       credentialFields: [{ name: "personal_token", label: "Personal Token" }],
     },
@@ -242,9 +246,9 @@ test.describe("Integrations", () => {
     await page.getByRole("button", { name: "Workspace Service settings" }).click();
     const dialog = page.getByRole("dialog");
 
-    await expect(dialog.getByRole("button", { name: "Connect with workspace" })).toBeVisible();
-    await expect(dialog.getByRole("button", { name: "Use API Token for workspace" })).toBeVisible();
-    await expect(dialog.getByRole("button", { name: "Connect with personal" })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Connect with Workspace OAuth" })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Use API Token for Workspace OAuth" })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Connect with Personal Token" })).toBeVisible();
   });
 
   test("multi-connection loading state stays on the clicked oauth action", async ({
@@ -266,9 +270,9 @@ test.describe("Integrations", () => {
     await page.getByRole("button", { name: "Team Service settings" }).click();
     const dialog = page.getByRole("dialog");
 
-    await dialog.getByRole("button", { name: "Connect with personal" }).click();
+    await dialog.getByRole("button", { name: "Connect with Personal OAuth" }).click();
     await expect(dialog.getByRole("button", { name: "Connecting..." })).toBeVisible();
-    await expect(dialog.getByRole("button", { name: "Connect with workspace" })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Connect with Workspace OAuth" })).toBeVisible();
 
     releaseOAuthRequest?.();
     await expect(dialog.getByText("oauth failed")).toBeVisible();

--- a/gestaltd/ui/src/components/IntegrationSettingsModal.tsx
+++ b/gestaltd/ui/src/components/IntegrationSettingsModal.tsx
@@ -65,7 +65,7 @@ function resolveAuthTargets(integration: Integration): AuthTarget[] {
       .map((connection) => ({
         key: connection.name,
         connection: connection.name,
-        label: connection.name,
+        label: connection.displayName || connection.name,
         authTypes: normalizeAuthTypes(connection.authTypes, false),
         credentialFields: connection.credentialFields?.length
           ? connection.credentialFields
@@ -211,6 +211,11 @@ export default function IntegrationSettingsModal({
       ? authTargets.find((authTarget) => authTarget.connection === pendingAction.connection)
       : defaultTarget;
     return target?.credentialFields ?? integration.credentialFields;
+  }
+
+  function displayConnectionName(name?: string): string | undefined {
+    if (!name) return undefined;
+    return authTargets.find((target) => target.connection === name)?.label || name;
   }
 
   function isPendingAction(action: AuthAction): boolean {
@@ -394,7 +399,7 @@ export default function IntegrationSettingsModal({
                           <div>
                             <div className="text-sm text-primary">{inst.name}</div>
                             {inst.connection && (
-                              <div className="text-xs text-faint">{inst.connection}</div>
+                              <div className="text-xs text-faint">{displayConnectionName(inst.connection)}</div>
                             )}
                           </div>
                         </div>

--- a/gestaltd/ui/src/lib/api.ts
+++ b/gestaltd/ui/src/lib/api.ts
@@ -20,6 +20,7 @@ export interface InstanceInfo {
 
 export interface ConnectionDefInfo {
   name: string;
+  displayName?: string;
   authTypes: ("oauth" | "manual")[];
   credentialFields?: CredentialFieldDef[];
 }


### PR DESCRIPTION
## Summary
- add connection-level display names to the manifest/server/client contract
- stop integration-level manual auth from leaking onto explicit named OAuth/MCP connections
- update the CLI and web UI to render connection display names instead of raw internal ids
- augment existing manifest, server, CLI, and UI tests for the new connection metadata behavior

## Why
Several integrations are leaking internal connection identifiers like `plugin` and raw manifest keys like `mcp` into the UX. The same auth merge logic also causes impossible actions like `Add mcp with API Token` by propagating manual auth from one surface onto a different named connection.

## Validation
- `go test ./internal/server ./internal/pluginpkg`
- `cargo test --test integration test_manual_connect_prompts_for_connection_and_finishes_candidate_selection`
- `npm run typecheck`

## Follow-up
After this merges and ships, `toolshed` should be bumped alongside the matching `gestalt-providers` plugin releases.