### PR TITLE
Fix documentation inaccuracies found in audit

### DIFF
--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -9,8 +9,11 @@
 | `gestaltd` | Local-friendly startup. Generates a config if needed and serves. |
 | `gestaltd serve --config PATH` | Start the server. |
 | `gestaltd serve --locked --config PATH` | Start from lock state. Uses prepared artifacts when present and can materialize missing artifacts from the lockfile. |
+| `gestaltd serve --artifacts-dir DIR` | Directory for prepared provider artifacts. |
 | `gestaltd init --config PATH` | Resolve published plugin sources and write lock state. |
+| `gestaltd init --artifacts-dir DIR` | Directory for prepared provider artifacts. |
 | `gestaltd validate --config PATH` | Validate config without serving. |
+| `gestaltd validate --artifacts-dir DIR` | Directory for prepared provider artifacts. |
 | `gestaltd --version` | Print the server version. |
 
 ## Provider commands
@@ -18,6 +21,7 @@
 | Command | Purpose |
 | --- | --- |
 | `gestaltd provider release --version VERSION` | Build and package a provider release. Go, Python, Rust, and TypeScript source plugins default to the host platform. Pass `--platform ...` with `os/arch[/libc]` targets or `--platform all` for multi-platform builds. |
+| `gestaltd provider release --output DIR` | Output directory for the release archive. Defaults to `dist/`. |
 
 ## Examples
 

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -66,6 +66,7 @@ The `spec` block for a `kind: plugin` manifest describes a plugin. It supports d
 | `headers` | map[string]string | Static headers injected into every outbound request. |
 | `surfaces` | Surfaces | Spec-loaded and declarative REST surfaces. See [Surfaces](#surfaces). |
 | `defaultConnection` | string | Name of the connection to use when none is specified. |
+| `requires` | string[] | Provider source identifiers that this provider depends on. Gestalt ensures the listed providers are available before starting this provider. |
 
 ### Connections
 
@@ -107,6 +108,7 @@ Surfaces load operation catalogs from external specifications. They are configur
 
 | Field | Type | Purpose |
 | --- | --- | --- |
+| `connection` | string | Connection name used for REST calls. Optional. |
 | `baseUrl` | string | Base URL for declarative REST operations. |
 | `operations` | ProviderOperation[] | Declarative REST operations. Presence of this field makes the plugin declarative. |
 


### PR DESCRIPTION
## Summary
- Fix manifest JSON schema `kind` enum: `"datastore"` -> `"indexeddb"` to match Go constant `KindIndexedDB`
- Add missing `connection` field to `spec.surfaces.rest` documentation
- Add missing `--artifacts-dir` flag to `serve`, `init`, and `validate` CLI docs
- Add missing `--output` flag to `provider release` CLI docs
- Add missing `spec.requires` field to plugin manifest documentation

## Test plan
- [ ] Verify JSON schema validates correctly with `kind: indexeddb`
- [ ] Confirm CLI docs match actual flag definitions in `run.go` and `plugin.go`
- [ ] Confirm manifest docs match Go types in `types.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)