### PR TITLE
Fix stale datastore references in docs

### DIFF
--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -16,7 +16,7 @@ Run `gestaltd` with no arguments:
 gestaltd
 ```
 
-When no config file exists, `gestaltd` generates one at `~/.gestaltd/config.yaml` and starts immediately with SQLite storage via the [RelationalDB](https://github.com/valon-technologies/gestalt-providers/tree/main/datastore) implementation of the [IndexedDB provider](/providers/indexeddb), no authentication, and an [HTTPBin](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/httpbin) implementation of the [plugin provider](/providers/plugins) on port 8080.
+When no config file exists, `gestaltd` generates one at `~/.gestaltd/config.yaml` and starts immediately with SQLite storage via the [RelationalDB](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/relationaldb) implementation of the [IndexedDB provider](/providers/indexeddb), no authentication, and an [HTTPBin](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/httpbin) implementation of the [plugin provider](/providers/plugins) on port 8080.
 
 ```
 2026/04/10 10:00:00 INFO generated default config path=~/.gestaltd/config.yaml

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -27,7 +27,7 @@ providers:
 
 To disable platform auth entirely, omit the `providers.auth` block or set `providers: { auth: { disabled: true } }`.
 
-## Datastore Providers
+## IndexedDB Providers
 
 Datastore providers back the persistent state layer. They are configured under named entries in `providers.indexeddbs`, and `server.indexeddb` selects which one the host uses. Gestalt does not compile datastore drivers into the binary; it starts the configured external datastore provider process at runtime.
 

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -280,17 +280,17 @@ IndexedDB providers require an executable entrypoint. Declare it under `entrypoi
 
 ```yaml
 kind: indexeddb
-source: github.com/valon-technologies/gestalt-providers/datastore-postgres
+source: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
 version: 1.0.0
 displayName: PostgreSQL
 spec:
   configSchemaPath: schemas/config.schema.json
 entrypoint:
-  artifactPath: artifacts/linux/amd64/datastore
+  artifactPath: artifacts/linux/amd64/provider
 artifacts:
   - os: linux
     arch: amd64
-    path: artifacts/linux/amd64/datastore
+    path: artifacts/linux/amd64/provider
 ```
 
 ## Web UI Metadata


### PR DESCRIPTION
## Summary

- Updates the plugin manifests example to point to `indexeddb/relationaldb` instead of the nonexistent `datastore-postgres` path, and changes artifact filenames from `datastore` to `provider`.
- Fixes the getting-started link to point to `tree/main/indexeddb/relationaldb` instead of `tree/main/datastore`.
- Renames the "Datastore Providers" section header in built-in-providers to "IndexedDB Providers" to match the kind name used elsewhere.

## Test plan

- [ ] Verify the three updated doc pages render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)