### PR TITLE
Fix Docker Hub docs accuracy and trim to OSS conventions

### DIFF
--- a/docs/content/deploy/index.mdx
+++ b/docs/content/deploy/index.mdx
@@ -25,8 +25,9 @@ This guarantees that the image you test is byte-for-byte the image you deploy.
 
 ```
 deploy/
-  lockfile.json        # pinned provider refs and checksums
-  providers/           # vendored provider artifacts (optional)
+  gestalt.lock.json    # pinned provider refs and checksums
+  .gestaltd/providers/ # vendored provider artifacts (optional)
+  .gestaltd/ui/        # vendored UI assets (optional)
 ```
 
 The lock file is a JSON document that records every resolved provider:
@@ -47,7 +48,7 @@ The lock file is a JSON document that records every resolved provider:
 You can choose between two patterns:
 
 - **Vendored** -- commit the full `deploy/` directory (including `providers/`). The server loads artifacts directly with no network calls at boot. Best for air-gapped or latency-sensitive environments.
-- **Lockfile-only** -- commit only `lockfile.json`. The server fetches providers on first boot but verifies each artifact against the recorded checksum. Keeps your repo lightweight while still guaranteeing integrity.
+- **Lockfile-only** -- commit only `gestalt.lock.json`. The server fetches providers on first boot but verifies each artifact against the recorded checksum. Keeps your repo lightweight while still guaranteeing integrity.
 
 See [Configuration](/configuration) for the config model and [Docker](/deploy/docker) for the recommended production image pattern.
 

--- a/docs/dockerhub/gestalt.md
+++ b/docs/dockerhub/gestalt.md
@@ -1,12 +1,8 @@
 # gestalt Docker image
 
 `gestalt` is a CLI client for the Gestalt API. It connects to a running
-`gestaltd` server and provides commands for:
-
-- authenticating via OAuth or API tokens
-- listing and connecting third-party integrations
-- invoking integration operations
-- managing configuration and credentials
+`gestaltd` server and provides commands for authenticating, listing plugins,
+invoking integration operations, and managing credentials.
 
 > **Alpha.** Gestalt is under active development. Images are tagged
 > with alpha versions and may introduce breaking changes. See the
@@ -38,9 +34,9 @@ Point the CLI at a running `gestaltd` server:
 ```sh
 docker run --rm \
   -e GESTALT_URL=https://gestalt.example.com \
-  -e GESTALT_API_KEY=gst_... \
+  -e GESTALT_API_KEY=gst_api_... \
   valontechnologies/gestalt:latest \
-  integrations list
+  plugins list
 ```
 
 ### Invoke an operation
@@ -48,9 +44,9 @@ docker run --rm \
 ```sh
 docker run --rm \
   -e GESTALT_URL=https://gestalt.example.com \
-  -e GESTALT_API_KEY=gst_... \
+  -e GESTALT_API_KEY=gst_api_... \
   valontechnologies/gestalt:latest \
-  invoke github search_code -p "query=gestalt org:my-org"
+  plugins invoke github search_code -p "query=gestalt org:my-org"
 ```
 
 ### Use in CI pipelines
@@ -60,7 +56,7 @@ binary is inconvenient:
 
 ```yaml
 jobs:
-  check-integrations:
+  check-plugins:
     runs-on: ubuntu-latest
     steps:
       - run: |
@@ -68,32 +64,28 @@ jobs:
             -e GESTALT_URL="${{ vars.GESTALT_URL }}" \
             -e GESTALT_API_KEY="${{ secrets.GESTALT_API_KEY }}" \
             valontechnologies/gestalt:latest \
-            integrations list --format json
+            plugins list --format json
 ```
 
-## Available commands
+## Key commands
 
-| Command                     | Description                            |
-|-----------------------------|----------------------------------------|
-| `auth login`                | Log in via browser OAuth flow          |
-| `auth logout`               | Log out and clear stored credentials   |
-| `auth status`               | Show authentication status             |
-| `init`                      | Interactive setup wizard               |
-| `config get/set/unset/list` | Manage persistent configuration        |
-| `integrations list`         | List available integrations            |
-| `integrations connect`      | Connect an integration via OAuth or interactive manual auth |
-| `invoke <integ> <op>`       | Execute an integration operation       |
-| `describe <integ> <op>`     | Describe an integration operation      |
-| `tokens create/list/revoke` | Manage API tokens                      |
+| Command | Description |
+|---|---|
+| `plugins list` | List available plugins |
+| `plugins connect NAME` | Connect a plugin via OAuth or manual auth |
+| `plugins disconnect NAME` | Disconnect a plugin |
+| `plugins invoke NAME OP` | Execute a plugin operation |
+| `tokens create/list/revoke` | Manage API tokens |
 
-Use `--format json` or `--format table` to control output format.
+Use `--format json` or `--format table` to control output format. See the
+[CLI reference](https://gestaltd.ai/reference/cli) for the full command list.
 
 ## Environment variables
 
-| Variable          | Description                     |
-|-------------------|---------------------------------|
-| `GESTALT_URL`     | Base URL of the gestaltd server |
-| `GESTALT_API_KEY` | API token for authentication    |
+| Variable | Description |
+|---|---|
+| `GESTALT_URL` | Base URL of the gestaltd server |
+| `GESTALT_API_KEY` | API token for authentication |
 
 ## Debugging
 
@@ -102,7 +94,7 @@ to inspect available commands:
 
 ```sh
 docker run --rm valontechnologies/gestalt:latest --help
-docker run --rm valontechnologies/gestalt:latest invoke --help
+docker run --rm valontechnologies/gestalt:latest plugins invoke --help
 ```
 
 For an interactive shell, use the native binary or Homebrew install instead

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -1,13 +1,6 @@
 # gestaltd Docker image
 
-`gestaltd` is a platform for self-hostable, configurable integrations and tooling. You describe your platform in one YAML file, and `gestaltd` turns that file into a running server with:
-
-- an HTTP API
-- a public client UI at `/` when enabled
-- a built-in admin UI at `/admin`
-- `/health` and `/ready` endpoints
-- an `/mcp` endpoint when providers expose tools
-- support for REST, GraphQL, MCP, and source or published plugins
+`gestaltd` is a platform for self-hostable, configurable integrations and tooling. You describe your platform in one YAML file, and `gestaltd` turns that file into a running server with an HTTP API, admin UI, health endpoints, and optional MCP endpoint.
 
 > **Alpha.** Gestalt is under active development. Images are tagged
 > with alpha versions and may introduce breaking changes. See the
@@ -26,14 +19,8 @@
 - Default config path: `/etc/gestalt/config.yaml`
 - Default writable data and artifacts dir: `/data`
 - This image is not zero-config. Mount or bake a config file before starting it.
-- Locked startup is the default. If your config uses
-  `plugins.*.provider.source.ref`, `auth.provider.source.ref`,
-  `datastores.*.provider.source.ref`, or `ui.provider.source.ref`, run `init`
-  first.
 
 ## Supported tags
-
-Docker Hub publishes these tag shapes for each release:
 
 | Tag | Base | Shell | Size |
 | --- | --- | --- | --- |
@@ -48,9 +35,8 @@ The default image is a static build: just the `gestaltd` binary and CA
 certificates on a `scratch` base. There is no shell, no package manager, and
 minimal attack surface.
 
-For debugging access or plugin compatibility, use the `-alpine` variant.
-It includes a shell, `ca-certificates`, and a writable `/data` directory
-owned by `nobody`.
+For debugging or plugin compatibility, use the `-alpine` variant. It includes
+a shell, `ca-certificates`, and a writable `/data` directory owned by `nobody`.
 
 ## Run a simple config
 
@@ -64,10 +50,6 @@ docker run --rm \
   -v gestalt-data:/data \
   valontechnologies/gestaltd:latest
 ```
-
-The default image command still points `--artifacts-dir` at `/data`, so keeping
-that volume mounted is the safe default even when your current config does not
-need prepared plugins.
 
 Example minimal config:
 
@@ -92,124 +74,6 @@ ui:
   provider: none
 ```
 
-Example with a separate internal-only management listener:
-
-```yaml
-server:
-  public:
-    host: 0.0.0.0
-    port: 8080
-  management:
-    host: 0.0.0.0
-    port: 9090
-  encryptionKey: ${GESTALT_ENCRYPTION_KEY}
-
-datastores:
-  main:
-    provider:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.2
-    config:
-      dsn: sqlite:///data/gestalt.db
-datastore: main
-
-plugins: {}
-ui:
-  provider: none
-```
-
-```sh
-docker run --rm \
-  -p 8080:8080 \
-  -p 127.0.0.1:9090:9090 \
-  -e GESTALT_ENCRYPTION_KEY=change-me \
-  -v "$(pwd)/gestalt.yaml:/etc/gestalt/config.yaml:ro" \
-  -v gestalt-data:/data \
-  valontechnologies/gestaltd:latest
-```
-
-This keeps `/admin` and `/metrics` off the public interface while still making
-them reachable from the host at `127.0.0.1:9090`.
-
-For production-style deployments, prefer this split-listener pattern over
-leaving `/admin` and `/metrics` on the public listener. If you also set
-`server.baseUrl`, the management admin UI can link back to the public client
-UI hostname; otherwise it omits that link.
-
-## Run a locked production image
-
-For production deployments, use `gestaltd serve --locked` and ship
-`gestalt.lock.json` with the image. There are two valid ways to do that:
-
-- Vendored artifacts: run `gestaltd init` before `docker build` and copy both
-  `gestalt.lock.json` and `.gestaltd/` into the image.
-- Lockfile-only: ship `gestalt.lock.json` but exclude `.gestaltd/` from the
-  repo and build context. `gestaltd` recreates `.gestaltd/` from the lockfile
-  at startup.
-
-Vendored artifacts are more hermetic and usually give faster cold starts.
-Lockfile-only images are smaller and avoid generated-file churn, but require
-runtime network access, source auth, verified hashes in the lockfile, and a
-writable artifacts directory.
-
-### Vendored artifacts
-
-For deterministic production images, run `gestaltd init` before `docker build`
-and copy the prepared state into the image.
-
-For a config at `deploy/config.yaml`, `init` writes:
-
-```text
-deploy/
-  config.yaml
-  gestalt.lock.json
-  .gestaltd/providers/...
-  .gestaltd/ui/...
-```
-
-Build the image from that prepared directory:
-
-```dockerfile
-FROM valontechnologies/gestaltd:latest-alpine
-COPY deploy/ /app/
-CMD ["serve", "--locked", "--config", "/app/config.yaml"]
-```
-
-Use the `-alpine` variant as the base for derived images since it includes a
-shell for build steps.
-
-If you intentionally want the image build itself to generate prepared state,
-`RUN gestaltd init` in a build stage also works, but it is a build-time
-convenience rather than the primary deterministic workflow.
-
-### Lockfile-only images
-
-If you do not want to ship vendored artifacts, keep `gestalt.lock.json` in the
-image but exclude `.gestaltd/` from git and from the Docker build context:
-
-```gitignore
-deploy/.gestaltd/
-```
-
-```dockerignore
-deploy/.gestaltd
-```
-
-Then make sure the configured artifacts directory is writable by the runtime
-user. For example:
-
-```dockerfile
-FROM valontechnologies/gestaltd:latest-alpine
-USER root
-COPY --chown=nobody:nobody deploy/ /app/
-USER nobody
-CMD ["serve", "--locked", "--config", "/app/config.yaml"]
-```
-
-This model treats `.gestaltd/` as a runtime cache. On ephemeral platforms,
-artifacts may be redownloaded on cold start.
-
 ## Compose example
 
 ```yaml
@@ -218,7 +82,6 @@ services:
     image: valontechnologies/gestaltd:latest
     ports:
       - "8080:8080"
-      - "127.0.0.1:9090:9090"
     volumes:
       - ./config.yaml:/etc/gestalt/config.yaml:ro
       - gestalt-data:/data
@@ -229,58 +92,44 @@ volumes:
   gestalt-data:
 ```
 
+## Production images
+
+For deterministic production deployments, run `gestaltd init` locally to
+resolve providers and write `gestalt.lock.json`, then bake the result into a
+derived image:
+
+```dockerfile
+FROM valontechnologies/gestaltd:latest-alpine
+COPY deploy/ /app/
+CMD ["serve", "--locked", "--config", "/app/config.yaml"]
+```
+
+See the [deployment documentation](https://gestaltd.ai/deploy) for the full
+vendored-artifacts vs lockfile-only workflow and recommended patterns.
+
 ## Configuration and environment variables
 
-Gestalt expands `${VAR}` placeholders before YAML decode. The image also supports the common `*_FILE` convention for those placeholders:
-
-- if `VAR` is set, `${VAR}` resolves to that value
-- otherwise, if `VAR_FILE` is set, `${VAR}` resolves to the contents of that file
-- otherwise, config loading fails unless you used `${VAR:-}` for an explicit empty default
-
-That means this works well with Docker secrets:
-
-```yaml
-server:
-  encryptionKey: ${GESTALT_ENCRYPTION_KEY}
-```
-
-```sh
-docker run --rm \
-  -p 8080:8080 \
-  -v "$(pwd)/gestalt.yaml:/etc/gestalt/config.yaml:ro" \
-  -v /run/secrets/gestalt-encryption-key:/run/secrets/gestalt-encryption-key:ro \
-  -e GESTALT_ENCRYPTION_KEY_FILE=/run/secrets/gestalt-encryption-key \
-  valontechnologies/gestaltd:latest
-```
-
-For more advanced setups, Gestalt also supports `secret://...` references. The built-in `env` and `file` providers are always available. Cloud secret backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) are available as external providers from [gestalt-providers](https://github.com/valon-technologies/gestalt-providers). See the [secrets documentation](https://gestaltd.ai/providers/secrets) for configuration details.
+Gestalt expands `${VAR}` placeholders in the config before YAML decoding. The
+image also supports the `*_FILE` convention: if `VAR` is not set but `VAR_FILE`
+is, `${VAR}` resolves to the contents of that file. This works well with
+Docker secrets. See the [configuration documentation](https://gestaltd.ai/configuration)
+for the full config model and `secret://` reference support.
 
 ## Health endpoints
-
-The container exposes:
 
 - `GET /health` for liveness
 - `GET /ready` for readiness
 
-The built-in admin UI is served from `/admin`. The public client UI at `/` is
-controlled by `ui.provider`: set `ui.provider: none` to disable it, omit `ui`
-to use the pinned first-party default bundle, or point `ui.provider.source` at
-your own packaged UI. If you configure `server.management`, then `/admin`,
-`/metrics`, `/health`, and `/ready` move to the management listener instead.
-That split is the recommended production deployment shape; the single-listener
-mode is mainly for local development and trusted-network use.
+The built-in admin UI is served at `/admin`. If you configure
+`server.management`, health and admin endpoints move to the management
+listener. See the [deployment documentation](https://gestaltd.ai/deploy) for
+the recommended split-listener production pattern.
 
 ## SQLite and `/data`
 
-SQLite works well for:
-
-- local development
-- demos
-- single-instance deployments with persistent storage
-
-If you choose SQLite, store the database on mounted durable storage such as `/data/gestalt.db`.
-
-For horizontally scaled deployments, prefer Postgres or MySQL.
+SQLite works for local development, demos, and single-instance deployments.
+Store the database on a mounted volume (e.g. `/data/gestalt.db`). For
+horizontally scaled deployments, use Postgres or MySQL.
 
 ## Debugging
 
@@ -297,28 +146,13 @@ To check startup behavior:
 docker run --rm valontechnologies/gestaltd:latest --help
 ```
 
-## Releasing providers
-
-If you build a provider release in Docker, run `gestaltd provider release` from
-the provider source directory:
-
-```dockerfile
-FROM valontechnologies/gestaltd:latest-alpine AS gestaltd
-
-FROM golang:1.26-alpine AS build
-RUN apk add --no-cache git
-COPY --from=gestaltd /gestaltd /usr/local/bin/gestaltd
-WORKDIR /src
-COPY . .
-RUN cd ./my-plugin && \
-    gestaltd provider release --version 0.0.1-alpha.1 --platform all && \
-    gestaltd init --config ./deploy/config.yaml
-```
-
 ## Caveats
 
-- The published image defaults to locked startup. A missing config file, missing lockfile, missing verified archive hash, or unwritable artifacts directory causes startup to fail fast. Missing prepared artifacts alone do not, because `gestaltd` can materialize them from `gestalt.lock.json`.
-- `docker run valontechnologies/gestaltd:latest` by itself is expected to fail because the image does not auto-generate config in-container.
+- The published image defaults to locked startup. A missing config file,
+  missing lockfile, or unwritable artifacts directory causes startup to fail
+  fast.
+- `docker run valontechnologies/gestaltd:latest` by itself fails because the
+  image does not auto-generate config in-container.
 - The default image does not include a shell. Use `-alpine` for debugging.
 - If you use SQLite, do not scale to multiple replicas.
 
@@ -326,5 +160,5 @@ RUN cd ./my-plugin && \
 
 - Docs: https://gestaltd.ai
 - CLI reference: https://gestaltd.ai/reference/cli
-- Deployment docs: https://gestaltd.ai/deploy
+- Deployment: https://gestaltd.ai/deploy
 - Source: https://github.com/valon-technologies/gestalt


### PR DESCRIPTION
## Summary

- **gestalt.md (CLI):** Fix `integrations` to canonical `plugins` command name, correct `gst_...` token prefix to `gst_api_...`, add missing `disconnect` command, link to full CLI reference instead of duplicating the command table
- **gestaltd.md (server):** Trim from 331 to 164 lines by removing duplicated deployment guidance (vendored vs lockfile-only, management listeners, provider release workflow, secret:// config details) and replacing with links to gestaltd.ai
- **deploy/index.mdx (side-fix):** Rename `lockfile.json` to `gestalt.lock.json` and `providers/` to `.gestaltd/providers/` to match actual codebase (`lifecycle.go:InitLockfileName`)

## Test plan

- [ ] Verify Docker Hub markdown renders correctly (no broken tables or code blocks)
- [ ] Spot-check outbound links to gestaltd.ai resolve: `/deploy`, `/configuration`, `/reference/cli`
- [ ] Grep for stale `integrations` or `lockfile.json` references in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)