### PR TITLE
Remove main/serve boilerplate from provider examples

### DIFF
--- a/docs/content/providers/auth.mdx
+++ b/docs/content/providers/auth.mdx
@@ -29,7 +29,7 @@ You implement three methods: `Configure`, `BeginLogin`, and `CompleteLogin`. `Be
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
-    package main
+    package googleauth
 
     import (
     	"context"
@@ -44,6 +44,8 @@ You implement three methods: `Configure`, `BeginLogin`, and `CompleteLogin`. `Be
     	clientID     string
     	clientSecret string
     }
+
+    func New() *GoogleAuth { return &GoogleAuth{} }
 
     func (g *GoogleAuth) Configure(_ context.Context, _ string, config map[string]any) error {
     	g.clientID, _ = config["clientId"].(string)
@@ -77,9 +79,6 @@ You implement three methods: `Configure`, `BeginLogin`, and `CompleteLogin`. `Be
     	}, nil
     }
 
-    func main() {
-    	gestalt.ServeAuthProvider(context.Background(), &GoogleAuth{})
-    }
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -111,7 +110,6 @@ You implement three methods: `Configure`, `BeginLogin`, and `CompleteLogin`. `Be
                 display_name="Example User",
             )
 
-    GoogleAuth().serve()
     ```
   </Tabs.Tab>
   <Tabs.Tab>

--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -135,9 +135,6 @@ You implement the [IndexedDB gRPC service](https://www.w3.org/TR/IndexedDB/#obje
 
         # See the W3C IndexedDB specification for the remaining methods:
         # https://www.w3.org/TR/IndexedDB/#object-store-interface
-
-        # See the W3C IndexedDB specification for the remaining methods:
-        # https://www.w3.org/TR/IndexedDB/#object-store-interface
     ```
   </Tabs.Tab>
   <Tabs.Tab>

--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -36,7 +36,7 @@ You implement the [IndexedDB gRPC service](https://www.w3.org/TR/IndexedDB/#obje
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
-    package main
+    package relationaldb
 
     import (
     	"context"
@@ -44,7 +44,6 @@ You implement the [IndexedDB gRPC service](https://www.w3.org/TR/IndexedDB/#obje
     	"fmt"
     	"strings"
 
-    	gestalt "github.com/valon-technologies/gestalt/sdk/go"
     	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
     	"google.golang.org/protobuf/types/known/emptypb"
     )
@@ -52,6 +51,8 @@ You implement the [IndexedDB gRPC service](https://www.w3.org/TR/IndexedDB/#obje
     type RelationalDB struct {
     	db *sql.DB
     }
+
+    func New() *RelationalDB { return &RelationalDB{} }
 
     func (r *RelationalDB) Configure(_ context.Context, _ string, config map[string]any) error {
     	dsn, _ := config["dsn"].(string)
@@ -101,10 +102,6 @@ You implement the [IndexedDB gRPC service](https://www.w3.org/TR/IndexedDB/#obje
 
     // See the W3C IndexedDB specification for the remaining methods:
     // https://www.w3.org/TR/IndexedDB/#object-store-interface
-
-    func main() {
-    	gestalt.ServeIndexedDBProvider(context.Background(), &RelationalDB{})
-    }
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -139,7 +136,8 @@ You implement the [IndexedDB gRPC service](https://www.w3.org/TR/IndexedDB/#obje
         # See the W3C IndexedDB specification for the remaining methods:
         # https://www.w3.org/TR/IndexedDB/#object-store-interface
 
-    RelationalDB().serve()
+        # See the W3C IndexedDB specification for the remaining methods:
+        # https://www.w3.org/TR/IndexedDB/#object-store-interface
     ```
   </Tabs.Tab>
   <Tabs.Tab>

--- a/docs/content/providers/secrets.mdx
+++ b/docs/content/providers/secrets.mdx
@@ -31,7 +31,7 @@ A secrets provider implements two methods: `Configure` and `GetSecret`. `Configu
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
-    package main
+    package googlesecrets
 
     import (
     	"context"
@@ -39,7 +39,6 @@ A secrets provider implements two methods: `Configure` and `GetSecret`. `Configu
 
     	secretmanager "cloud.google.com/go/secretmanager/apiv1"
     	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
-    	gestalt "github.com/valon-technologies/gestalt/sdk/go"
     )
 
     type GoogleSecrets struct {
@@ -47,6 +46,8 @@ A secrets provider implements two methods: `Configure` and `GetSecret`. `Configu
     	project string
     	version string
     }
+
+    func New() *GoogleSecrets { return &GoogleSecrets{} }
 
     func (s *GoogleSecrets) Configure(ctx context.Context, _ string, config map[string]any) error {
     	s.project, _ = config["project"].(string)
@@ -72,9 +73,6 @@ A secrets provider implements two methods: `Configure` and `GetSecret`. `Configu
     	return string(resp.Payload.Data), nil
     }
 
-    func main() {
-    	gestalt.ServeSecretsProvider(context.Background(), &GoogleSecrets{})
-    }
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -93,7 +91,6 @@ A secrets provider implements two methods: `Configure` and `GetSecret`. `Configu
             response = self.client.access_secret_version(request={"name": resource})
             return response.payload.data.decode("utf-8")
 
-    GoogleSecrets().serve()
     ```
   </Tabs.Tab>
   <Tabs.Tab>


### PR DESCRIPTION
The build system auto-generates entry points for all languages: Go uses
a wrapper template, TypeScript bundles a wrapper, Rust uses macros, and
Python auto-discovers at runtime. Provider authors only need to export
their implementation, so the docs were showing unnecessary boilerplate.

Changes across indexeddb, auth, and secrets provider pages:
- Go: changed from `package main` with `func main()` to library packages with `New()` constructors
- Python: removed explicit `.serve()` calls
- Rust and TypeScript were already clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)