### PR TITLE
Add workload authorization v1 for HTTP

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -37,6 +37,21 @@ server:
   encryptionKey: secret://gestalt-encryption-key
   apiTokenTtl: 30d
   artifactsDir: ./state
+  authorization:
+    workloads:
+      triage-bot:
+        displayName: Triage Bot
+        token: secret://triage-bot-token
+        providers:
+          github:
+            connection: default
+            instance: default
+            allow:
+              - list_issues
+              - get_issue
+          weather:
+            allow:
+              - get_forecast
 ```
 
 `public.host` and `public.port` control the public listener address. Both default to all-interfaces on port `8080`.
@@ -49,6 +64,8 @@ server:
 
 `apiTokenTtl` controls the lifetime of newly issued API tokens, defaulting to `30d`. It accepts Go duration strings (`1h`, `720h`) and day suffixes (`30d`). `artifactsDir` is a writable directory for prepared artifacts produced by `init` and consumed by `serve --locked` when no CLI override is supplied; it defaults to the config file's directory. See [Configuration](/configuration) for the full `init`/`serve` lifecycle.
 
+`server.authorization.workloads` configures non-human workload callers. Each workload uses a dedicated bearer token with the `gst_wld_` prefix and a per-provider allowlist. In v1, workloads may bind only to `identity` or `none` providers. For `identity` providers, `connection` and `instance` resolve the exact stored identity credential the workload may use; `instance` defaults to `default` and `connection` falls back to the provider's default connection when omitted. For `none` providers, omit `connection` and `instance`.
+
 | Field | Default | Description |
 | --- | --- | --- |
 | `public.host` | `0.0.0.0` | Bind address for the public listener. |
@@ -59,6 +76,7 @@ server:
 | `encryptionKey` | | **Required.** Root encryption key. Typically a `secret://` reference. |
 | `apiTokenTtl` | `30d` | Lifetime of newly issued API tokens. Go durations or day suffixes (`30d`). |
 | `artifactsDir` | config directory | Directory for prepared `init` artifacts. |
+| `authorization.workloads` | | Workload bearer tokens, per-provider allowlists, and identity credential bindings. |
 
 When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth routes, and `/mcp` on the public listener, while `/admin`, `/metrics`, `/health`, and `/ready` move to the management listener. The management listener is intended to be protected by deployment infrastructure such as private networking, VPN, or an internal-only reverse proxy. Gestalt does not apply its own session or API-token auth to `/metrics` on the management listener.
 

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -157,6 +157,7 @@ func runServer(env *bootstrapEnv) error {
 		CatalogConnection: connMaps.MCPConnection,
 		ConnectionAuth:    result.ConnectionAuth,
 		PluginDefs:        env.Config.Providers.Plugins,
+		Authorizer:        result.Authorizer,
 		PublicBaseURL:     env.Config.Server.BaseURL,
 		SecureCookies:     strings.HasPrefix(env.Config.Server.BaseURL, "https://"),
 		StateSecret:       crypto.DeriveKey(env.Config.Server.EncryptionKey),

--- a/gestaltd/core/audit.go
+++ b/gestaltd/core/audit.go
@@ -6,19 +6,25 @@ import (
 )
 
 type AuditEntry struct {
-	Timestamp  time.Time
-	RequestID  string
-	Source     string
-	AuthSource string
-	UserID     string
-	Provider   string
-	Operation  string
-	Depth      int
-	Allowed    bool
-	Error      string
-	ClientIP   string
-	RemoteAddr string
-	UserAgent  string
+	Timestamp            time.Time
+	RequestID            string
+	Source               string
+	AuthSource           string
+	UserID               string
+	SubjectID            string
+	SubjectKind          string
+	CredentialMode       string
+	CredentialSubjectID  string
+	CredentialConnection string
+	CredentialInstance   string
+	Provider             string
+	Operation            string
+	Depth                int
+	Allowed              bool
+	Error                string
+	ClientIP             string
+	RemoteAddr           string
+	UserAgent            string
 }
 
 type AuditSink interface {

--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -1,0 +1,304 @@
+package authorization
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"github.com/valon-technologies/gestalt/server/internal/registry"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+const defaultInstance = "default"
+
+var (
+	safeConnectionValue = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+	safeInstanceValue   = regexp.MustCompile(`^[a-zA-Z0-9._ -]+$`)
+)
+
+type CredentialBinding struct {
+	Mode                core.ConnectionMode
+	CredentialSubjectID string
+	CredentialOwnerID   string
+	Connection          string
+	Instance            string
+}
+
+type WorkloadProviderBinding struct {
+	CredentialBinding
+	Allow map[string]struct{}
+}
+
+type Workload struct {
+	ID          string
+	DisplayName string
+	Providers   map[string]WorkloadProviderBinding
+}
+
+type Authorizer struct {
+	workloadsByHash      map[string]*Workload
+	workloadsBySubjectID map[string]*Workload
+}
+
+func New(cfg config.AuthorizationConfig, pluginDefs map[string]*config.ProviderEntry, providers *registry.ProviderMap[core.Provider], defaultConnections map[string]string) (*Authorizer, error) {
+	a := &Authorizer{
+		workloadsByHash:      map[string]*Workload{},
+		workloadsBySubjectID: map[string]*Workload{},
+	}
+	if len(cfg.Workloads) == 0 {
+		return a, nil
+	}
+
+	for workloadID, def := range cfg.Workloads {
+		token := strings.TrimSpace(def.Token)
+		if token == "" {
+			return nil, fmt.Errorf("authorization validation: workload %q token is required", workloadID)
+		}
+		if !strings.HasPrefix(token, "gst_wld_") {
+			return nil, fmt.Errorf("authorization validation: workload %q token must use gst_wld_ prefix", workloadID)
+		}
+		tokenHash := principal.HashToken(token)
+		if _, exists := a.workloadsByHash[tokenHash]; exists {
+			return nil, fmt.Errorf("authorization validation: workload %q token duplicates another workload", workloadID)
+		}
+
+		workload := &Workload{
+			ID:          workloadID,
+			DisplayName: def.DisplayName,
+			Providers:   make(map[string]WorkloadProviderBinding, len(def.Providers)),
+		}
+
+		for providerName, providerDef := range def.Providers {
+			mode, ok, err := providerMode(providerName, pluginDefs, providers)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				return nil, fmt.Errorf("authorization validation: workload %q references unknown provider %q", workloadID, providerName)
+			}
+
+			allow := normalizeAllowedOperations(providerDef.Allow)
+			if len(allow) == 0 {
+				return nil, fmt.Errorf("authorization validation: workload %q provider %q allow must not be empty", workloadID, providerName)
+			}
+
+			binding, err := buildBinding(mode, workloadID, providerName, providerDef, defaultConnections)
+			if err != nil {
+				return nil, err
+			}
+			binding.Allow = allow
+			workload.Providers[providerName] = binding
+		}
+
+		a.workloadsByHash[tokenHash] = workload
+		a.workloadsBySubjectID[principal.WorkloadSubjectID(workloadID)] = workload
+	}
+
+	return a, nil
+}
+
+func (a *Authorizer) ResolveWorkloadToken(token string) (*principal.ResolvedWorkload, bool) {
+	if a == nil {
+		return nil, false
+	}
+	workload, ok := a.workloadsByHash[principal.HashToken(token)]
+	if !ok || workload == nil {
+		return nil, false
+	}
+	return &principal.ResolvedWorkload{ID: workload.ID, DisplayName: workload.DisplayName}, true
+}
+
+func (a *Authorizer) IsWorkload(p *principal.Principal) bool {
+	return p != nil && p.Kind == principal.KindWorkload
+}
+
+func (a *Authorizer) AllowProvider(p *principal.Principal, provider string) bool {
+	if !a.IsWorkload(p) {
+		return true
+	}
+	_, ok := a.bindingForSubject(p, provider)
+	return ok
+}
+
+func (a *Authorizer) AllowOperation(p *principal.Principal, provider, operation string) bool {
+	if !a.IsWorkload(p) {
+		return true
+	}
+	binding, ok := a.bindingForSubject(p, provider)
+	if !ok {
+		return false
+	}
+	_, ok = binding.Allow[operation]
+	return ok
+}
+
+func (a *Authorizer) Binding(p *principal.Principal, provider string) (CredentialBinding, bool) {
+	if !a.IsWorkload(p) {
+		return CredentialBinding{}, false
+	}
+	binding, ok := a.bindingForSubject(p, provider)
+	if !ok {
+		return CredentialBinding{}, false
+	}
+	return binding.CredentialBinding, true
+}
+
+func (a *Authorizer) bindingForSubject(p *principal.Principal, provider string) (WorkloadProviderBinding, bool) {
+	if a == nil || p == nil || p.SubjectID == "" {
+		return WorkloadProviderBinding{}, false
+	}
+	workload, ok := a.workloadsBySubjectID[p.SubjectID]
+	if !ok || workload == nil {
+		return WorkloadProviderBinding{}, false
+	}
+	binding, ok := workload.Providers[provider]
+	return binding, ok
+}
+
+func buildBinding(mode core.ConnectionMode, workloadID, provider string, def config.WorkloadProviderDef, defaultConnections map[string]string) (WorkloadProviderBinding, error) {
+	switch mode {
+	case core.ConnectionModeNone:
+		if strings.TrimSpace(def.Connection) != "" || strings.TrimSpace(def.Instance) != "" {
+			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q does not accept connection or instance bindings", workloadID, provider)
+		}
+		return WorkloadProviderBinding{
+			CredentialBinding: CredentialBinding{
+				Mode: core.ConnectionModeNone,
+			},
+		}, nil
+	case core.ConnectionModeIdentity:
+		connection := strings.TrimSpace(def.Connection)
+		if connection == "" {
+			connection = defaultConnections[provider]
+		}
+		connection = config.ResolveConnectionAlias(connection)
+		if connection == "" {
+			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q requires a bound connection", workloadID, provider)
+		}
+		if !safeConnectionValue.MatchString(connection) {
+			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q connection contains invalid characters", workloadID, provider)
+		}
+
+		instance := strings.TrimSpace(def.Instance)
+		if instance == "" {
+			instance = defaultInstance
+		}
+		if !safeInstanceValue.MatchString(instance) {
+			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q instance contains invalid characters", workloadID, provider)
+		}
+
+		return WorkloadProviderBinding{
+			CredentialBinding: CredentialBinding{
+				Mode:                core.ConnectionModeIdentity,
+				CredentialSubjectID: principal.IdentitySubjectID(),
+				CredentialOwnerID:   principal.IdentityPrincipal,
+				Connection:          connection,
+				Instance:            instance,
+			},
+		}, nil
+	case core.ConnectionModeUser, core.ConnectionModeEither, "":
+		return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q uses unsupported connection mode %q in v1", workloadID, provider, mode)
+	default:
+		return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q uses unknown connection mode %q", workloadID, provider, mode)
+	}
+}
+
+func normalizeAllowedOperations(ops []string) map[string]struct{} {
+	allowed := make(map[string]struct{}, len(ops))
+	for _, op := range ops {
+		name := strings.TrimSpace(op)
+		if name == "" {
+			continue
+		}
+		allowed[name] = struct{}{}
+	}
+	return allowed
+}
+
+func providerMode(provider string, pluginDefs map[string]*config.ProviderEntry, providers *registry.ProviderMap[core.Provider]) (core.ConnectionMode, bool, error) {
+	if entry, ok := pluginDefs[provider]; ok && entry != nil {
+		return pluginConnectionMode(entry), true, nil
+	}
+	if providers != nil {
+		prov, err := providers.Get(provider)
+		if err == nil && prov != nil {
+			return prov.ConnectionMode(), true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func pluginConnectionMode(entry *config.ProviderEntry) core.ConnectionMode {
+	needUser := false
+	needIdentity := false
+
+	addMode := func(mode core.ConnectionMode) {
+		switch mode {
+		case core.ConnectionModeUser:
+			needUser = true
+		case core.ConnectionModeIdentity:
+			needIdentity = true
+		case core.ConnectionModeEither:
+			needUser = true
+			needIdentity = true
+		}
+	}
+
+	addMode(connectionModeForConnection(config.EffectivePluginConnectionDef(entry, entry.ManifestSpec())))
+
+	for name := range namedConnectionNames(entry) {
+		conn, ok := config.EffectiveNamedConnectionDef(entry, entry.ManifestSpec(), name)
+		if !ok {
+			continue
+		}
+		addMode(connectionModeForConnection(conn))
+	}
+
+	switch {
+	case needUser && needIdentity:
+		return core.ConnectionModeEither
+	case needUser:
+		return core.ConnectionModeUser
+	case needIdentity:
+		return core.ConnectionModeIdentity
+	default:
+		return core.ConnectionModeNone
+	}
+}
+
+func namedConnectionNames(entry *config.ProviderEntry) map[string]struct{} {
+	names := make(map[string]struct{})
+	if entry == nil {
+		return names
+	}
+	if spec := entry.ManifestSpec(); spec != nil {
+		for name := range spec.Connections {
+			resolved := config.ResolveConnectionAlias(name)
+			if resolved != "" && resolved != config.PluginConnectionName {
+				names[resolved] = struct{}{}
+			}
+		}
+	}
+	for name := range entry.Connections {
+		resolved := config.ResolveConnectionAlias(name)
+		if resolved != "" && resolved != config.PluginConnectionName {
+			names[resolved] = struct{}{}
+		}
+	}
+	return names
+}
+
+func connectionModeForConnection(conn config.ConnectionDef) core.ConnectionMode {
+	if conn.Mode != "" {
+		return core.ConnectionMode(conn.Mode)
+	}
+	switch conn.Auth.Type {
+	case "", providermanifestv1.AuthTypeNone:
+		return core.ConnectionModeNone
+	default:
+		return core.ConnectionModeUser
+	}
+}

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -10,6 +10,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/crypto"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
@@ -154,6 +155,7 @@ type Result struct {
 	Services         *coredata.Services
 	Providers        *registry.ProviderMap[core.Provider]
 	ProvidersReady   <-chan struct{}
+	Authorizer       *authorization.Authorizer
 	ConnectionAuth   func() map[string]map[string]OAuthHandler
 	Invoker          invocation.Invoker
 	CapabilityLister invocation.CapabilityLister
@@ -372,7 +374,12 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	if err != nil {
 		return nil, err
 	}
+	authz, err := authorization.New(cfg.Server.Authorization, cfg.Providers.Plugins, providers, connMaps.DefaultConnection)
+	if err != nil {
+		return nil, err
+	}
 	sharedInvoker := invocation.NewBroker(providers, prepared.Services.Users, prepared.Services.Tokens,
+		invocation.WithAuthorizer(authz),
 		invocation.WithConnectionMapper(invocation.ConnectionMap(connMaps.APIConnection)),
 		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(connMaps.MCPConnection)),
 		invocation.WithConnectionAuth(lazyRefreshers(providersReady, connAuthResolver)),
@@ -396,6 +403,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		Services:         prepared.Services,
 		Providers:        providers,
 		ProvidersReady:   providersReady,
+		Authorizer:       authz,
 		ConnectionAuth:   connAuthResolver,
 		Invoker:          sharedInvoker,
 		CapabilityLister: sharedInvoker,

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -647,6 +647,45 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 	})
 
+	t.Run("resolves secret:// in workload tokens", func(t *testing.T) {
+		t.Parallel()
+
+		factories := validFactories()
+		factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+			return &coretesting.StubSecretManager{
+				Secrets: map[string]string{"workload-token": "gst_wld_resolved-workload-token"},
+			}, nil
+		}
+		factories.Builtins = []core.Provider{
+			&coretesting.StubIntegration{N: "weather", ConnMode: core.ConnectionModeNone},
+		}
+
+		cfg := validConfig()
+		cfg.Server.Authorization = config.AuthorizationConfig{
+			Workloads: map[string]config.WorkloadDef{
+				"triage-bot": {
+					Token: "secret://workload-token",
+					Providers: map[string]config.WorkloadProviderDef{
+						"weather": {Allow: []string{"forecast"}},
+					},
+				},
+			},
+		}
+
+		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
+			t.Fatalf("Bootstrap: %v", err)
+		}
+		<-result.ProvidersReady
+
+		if result.Authorizer == nil {
+			t.Fatal("Authorizer is nil")
+		}
+		if _, ok := result.Authorizer.ResolveWorkloadToken("gst_wld_resolved-workload-token"); !ok {
+			t.Fatal("expected resolved workload token to authenticate")
+		}
+	})
+
 	t.Run("passes top-level provider selection to auth factory", func(t *testing.T) {
 		t.Parallel()
 
@@ -743,6 +782,35 @@ func TestBootstrapSecretResolution(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
+}
+
+func TestBootstrapWorkloadAuthorizationRejectsEitherProvider(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig()
+	cfg.Server.Authorization = config.AuthorizationConfig{
+		Workloads: map[string]config.WorkloadDef{
+			"triage-bot": {
+				Token: "gst_wld_triage-bot-token",
+				Providers: map[string]config.WorkloadProviderDef{
+					"svc": {Allow: []string{"run"}},
+				},
+			},
+		},
+	}
+
+	factories := validFactories()
+	factories.Builtins = []core.Provider{
+		&coretesting.StubIntegration{N: "svc", ConnMode: core.ConnectionModeEither},
+	}
+
+	_, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `unsupported connection mode "either"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func TestBootstrapDisabledComponents(t *testing.T) {

--- a/gestaltd/internal/bootstrap/secret_resolution.go
+++ b/gestaltd/internal/bootstrap/secret_resolution.go
@@ -125,13 +125,40 @@ func resolveStringFields(ptr any, resolve func(string) (string, error)) error {
 				}
 			}
 		case reflect.Map:
-			if field.Type().Key().Kind() == reflect.String && field.Type().Elem().Kind() == reflect.String {
+			if field.Type().Key().Kind() != reflect.String {
+				continue
+			}
+			switch field.Type().Elem().Kind() {
+			case reflect.String:
 				for _, k := range field.MapKeys() {
 					resolved, err := resolve(field.MapIndex(k).String())
 					if err != nil {
 						return err
 					}
 					field.SetMapIndex(k, reflect.ValueOf(resolved))
+				}
+			case reflect.Struct:
+				for _, k := range field.MapKeys() {
+					current := field.MapIndex(k)
+					next := reflect.New(field.Type().Elem())
+					next.Elem().Set(current)
+					if err := resolveStringFields(next.Interface(), resolve); err != nil {
+						return err
+					}
+					field.SetMapIndex(k, next.Elem())
+				}
+			case reflect.Pointer:
+				if field.Type().Elem().Elem().Kind() != reflect.Struct {
+					continue
+				}
+				for _, k := range field.MapKeys() {
+					current := field.MapIndex(k)
+					if current.IsNil() {
+						continue
+					}
+					if err := resolveStringFields(current.Interface(), resolve); err != nil {
+						return err
+					}
 				}
 			}
 		case reflect.Slice:

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -178,20 +178,37 @@ type EgressConfig struct {
 	DefaultAction string `yaml:"defaultAction"`
 }
 
+type AuthorizationConfig struct {
+	Workloads map[string]WorkloadDef `yaml:"workloads,omitempty"`
+}
+
+type WorkloadDef struct {
+	DisplayName string                         `yaml:"displayName,omitempty"`
+	Token       string                         `yaml:"token"`
+	Providers   map[string]WorkloadProviderDef `yaml:"providers,omitempty"`
+}
+
+type WorkloadProviderDef struct {
+	Connection string   `yaml:"connection,omitempty"`
+	Instance   string   `yaml:"instance,omitempty"`
+	Allow      []string `yaml:"allow,omitempty"`
+}
+
 type ListenerConfig struct {
 	Host string `yaml:"host"`
 	Port int    `yaml:"port"`
 }
 
 type ServerConfig struct {
-	Public        ListenerConfig `yaml:"public"`
-	Management    ListenerConfig `yaml:"management"`
-	BaseURL       string         `yaml:"baseUrl"`
-	EncryptionKey string         `yaml:"encryptionKey"`
-	APITokenTTL   string         `yaml:"apiTokenTtl"`
-	ArtifactsDir  string         `yaml:"artifactsDir"`
-	IndexedDB     string         `yaml:"indexeddb,omitempty"`
-	Egress        EgressConfig   `yaml:"egress,omitempty"`
+	Public        ListenerConfig      `yaml:"public"`
+	Management    ListenerConfig      `yaml:"management"`
+	BaseURL       string              `yaml:"baseUrl"`
+	EncryptionKey string              `yaml:"encryptionKey"`
+	APITokenTTL   string              `yaml:"apiTokenTtl"`
+	ArtifactsDir  string              `yaml:"artifactsDir"`
+	IndexedDB     string              `yaml:"indexeddb,omitempty"`
+	Egress        EgressConfig        `yaml:"egress,omitempty"`
+	Authorization AuthorizationConfig `yaml:"authorization,omitempty"`
 }
 
 func (s ServerConfig) PublicListener() ListenerConfig {

--- a/gestaltd/internal/invocation/audit.go
+++ b/gestaltd/internal/invocation/audit.go
@@ -62,6 +62,10 @@ func buildAuditEntry(ctx context.Context, p *principal.Principal, source, provid
 	if p != nil {
 		entry.UserID = p.UserID
 		entry.AuthSource = p.AuthSource()
+		entry.SubjectID = p.SubjectID
+		if p.Kind != "" {
+			entry.SubjectKind = string(p.Kind)
+		}
 	}
 	return entry
 }
@@ -72,6 +76,17 @@ func BuildAuditEntry(ctx context.Context, p *principal.Principal, source, provid
 		p = principal.FromContext(ctx)
 	}
 	return ctx, buildAuditEntry(ctx, p, source, providerName, operation, meta)
+}
+
+func SetCredentialAudit(ctx context.Context, mode core.ConnectionMode, subjectID, connection, instance string) {
+	entry := auditEntryFromContext(ctx)
+	if entry == nil {
+		return
+	}
+	entry.CredentialMode = string(mode)
+	entry.CredentialSubjectID = subjectID
+	entry.CredentialConnection = connection
+	entry.CredentialInstance = instance
 }
 
 func (s *SlogAuditSink) Log(ctx context.Context, entry core.AuditEntry) {
@@ -91,6 +106,24 @@ func (s *SlogAuditSink) Log(ctx context.Context, entry core.AuditEntry) {
 	}
 	if entry.UserID != "" {
 		attrs = append(attrs, slog.String("user_id", entry.UserID))
+	}
+	if entry.SubjectID != "" {
+		attrs = append(attrs, slog.String("subject_id", entry.SubjectID))
+	}
+	if entry.SubjectKind != "" {
+		attrs = append(attrs, slog.String("subject_kind", entry.SubjectKind))
+	}
+	if entry.CredentialMode != "" {
+		attrs = append(attrs, slog.String("credential_mode", entry.CredentialMode))
+	}
+	if entry.CredentialSubjectID != "" {
+		attrs = append(attrs, slog.String("credential_subject_id", entry.CredentialSubjectID))
+	}
+	if entry.CredentialConnection != "" {
+		attrs = append(attrs, slog.String("credential_connection", entry.CredentialConnection))
+	}
+	if entry.CredentialInstance != "" {
+		attrs = append(attrs, slog.String("credential_instance", entry.CredentialInstance))
 	}
 
 	if entry.Error != "" {

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -14,6 +14,7 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/mcpupstream"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
@@ -88,6 +89,7 @@ type Broker struct {
 	providers      *registry.ProviderMap[core.Provider]
 	users          *coredata.UserService
 	tokens         *coredata.TokenService
+	authorizer     *authorization.Authorizer
 	connMapper     ConnectionMapper
 	mcpMapper      ConnectionMapper
 	connectionAuth RefresherResolver
@@ -106,6 +108,10 @@ func WithMCPConnectionMapper(m ConnectionMapper) BrokerOption {
 
 func WithConnectionAuth(r RefresherResolver) BrokerOption {
 	return func(b *Broker) { b.connectionAuth = r }
+}
+
+func WithAuthorizer(a *authorization.Authorizer) BrokerOption {
+	return func(b *Broker) { b.authorizer = a }
 }
 
 func NewBroker(providers *registry.ProviderMap[core.Provider], users *coredata.UserService, tokens *coredata.TokenService, opts ...BrokerOption) *Broker {
@@ -194,6 +200,9 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 
 	if p.Scopes != nil && !slices.Contains(p.Scopes, providerName) {
 		return fail(fmt.Errorf("%w: %s", ErrScopeDenied, providerName))
+	}
+	if b.authorizer != nil && !b.authorizer.AllowOperation(p, providerName, operation) {
+		return fail(fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operation))
 	}
 
 	conn := ConnectionFromContext(ctx)
@@ -332,6 +341,9 @@ func (b *Broker) ResolveToken(ctx context.Context, p *principal.Principal, provi
 	if p != nil && p.Scopes != nil && !slices.Contains(p.Scopes, providerName) {
 		return "", fmt.Errorf("%w: %s", ErrScopeDenied, providerName)
 	}
+	if b.authorizer != nil && !b.authorizer.AllowProvider(p, providerName) {
+		return "", fmt.Errorf("%w: %s", ErrAuthorizationDenied, providerName)
+	}
 	prov, err := b.providers.Get(providerName)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
@@ -344,9 +356,14 @@ func (b *Broker) ResolveToken(ctx context.Context, p *principal.Principal, provi
 }
 
 func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error) {
+	if b.authorizer != nil && b.authorizer.IsWorkload(p) {
+		return b.resolveWorkloadToken(ctx, prov, p, providerName, connection, instance)
+	}
+
 	mode := prov.ConnectionMode()
 	switch mode {
 	case core.ConnectionModeNone:
+		SetCredentialAudit(ctx, core.ConnectionModeNone, "", "", "")
 		return ctx, "", nil
 
 	case core.ConnectionModeUser, "":
@@ -362,15 +379,19 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 				return ctx, "", fmt.Errorf("%w: no user record returned", ErrUserResolution)
 			}
 			p.UserID = dbUser.ID
+			if p.Kind == "" {
+				p.Kind = principal.KindUser
+			}
+			p.SubjectID = principal.UserSubjectID(dbUser.ID)
 		}
-		return b.resolveUserToken(ctx, prov, p.UserID, providerName, connection, instance)
+		return b.resolveUserToken(ctx, prov, p.UserID, providerName, connection, instance, core.ConnectionModeUser, principal.UserSubjectID(p.UserID))
 
 	case core.ConnectionModeIdentity:
-		return b.resolveUserToken(ctx, prov, principal.IdentityPrincipal, providerName, connection, instance)
+		return b.resolveUserToken(ctx, prov, principal.IdentityPrincipal, providerName, connection, instance, core.ConnectionModeIdentity, principal.IdentitySubjectID())
 
 	case core.ConnectionModeEither:
 		if p.UserID != "" {
-			enrichedCtx, tok, err := b.resolveUserToken(ctx, prov, p.UserID, providerName, connection, instance)
+			enrichedCtx, tok, err := b.resolveUserToken(ctx, prov, p.UserID, providerName, connection, instance, core.ConnectionModeUser, principal.UserSubjectID(p.UserID))
 			if err == nil {
 				return enrichedCtx, tok, nil
 			}
@@ -381,14 +402,41 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 				return ctx, "", err
 			}
 		}
-		return b.resolveUserToken(ctx, prov, principal.IdentityPrincipal, providerName, connection, instance)
+		return b.resolveUserToken(ctx, prov, principal.IdentityPrincipal, providerName, connection, instance, core.ConnectionModeIdentity, principal.IdentitySubjectID())
 
 	default:
 		return ctx, "", fmt.Errorf("%w: unknown connection mode %q", ErrInternal, mode)
 	}
 }
 
-func (b *Broker) resolveUserToken(ctx context.Context, prov core.Provider, userID, providerName, connection, instance string) (context.Context, string, error) {
+func (b *Broker) resolveWorkloadToken(ctx context.Context, prov core.Provider, p *principal.Principal, providerName, requestedConnection, requestedInstance string) (context.Context, string, error) {
+	if b.authorizer == nil {
+		return ctx, "", fmt.Errorf("%w: no workload authorizer configured", ErrAuthorizationDenied)
+	}
+	binding, ok := b.authorizer.Binding(p, providerName)
+	if !ok {
+		return ctx, "", fmt.Errorf("%w: %s", ErrAuthorizationDenied, providerName)
+	}
+
+	switch binding.Mode {
+	case core.ConnectionModeNone:
+		if requestedConnection != "" || requestedInstance != "" {
+			return ctx, "", fmt.Errorf("%w: workloads may not override connection or instance bindings", ErrAuthorizationDenied)
+		}
+		SetCredentialAudit(ctx, binding.Mode, binding.CredentialSubjectID, binding.Connection, binding.Instance)
+		return ctx, "", nil
+	case core.ConnectionModeIdentity:
+		if (requestedConnection != "" && requestedConnection != binding.Connection) || (requestedInstance != "" && requestedInstance != binding.Instance) {
+			return ctx, "", fmt.Errorf("%w: workloads may not override connection or instance bindings", ErrAuthorizationDenied)
+		}
+		SetCredentialAudit(ctx, binding.Mode, binding.CredentialSubjectID, binding.Connection, binding.Instance)
+		return b.resolveUserToken(ctx, prov, principal.IdentityPrincipal, providerName, binding.Connection, binding.Instance, core.ConnectionModeIdentity, binding.CredentialSubjectID)
+	default:
+		return ctx, "", fmt.Errorf("%w: workloads may only use identity or none providers", ErrAuthorizationDenied)
+	}
+}
+
+func (b *Broker) resolveUserToken(ctx context.Context, prov core.Provider, userID, providerName, connection, instance string, credentialMode core.ConnectionMode, credentialSubjectID string) (context.Context, string, error) {
 	var storedToken *core.IntegrationToken
 	var err error
 
@@ -423,6 +471,7 @@ func (b *Broker) resolveUserToken(ctx context.Context, prov core.Provider, userI
 	if storedToken == nil {
 		return ctx, "", fmt.Errorf("%w: no token stored for integration %q", ErrNoToken, providerName)
 	}
+	SetCredentialAudit(ctx, credentialMode, credentialSubjectID, storedToken.Connection, storedToken.Instance)
 
 	if storedToken.MetadataJSON != "" {
 		var connParams map[string]string

--- a/gestaltd/internal/invocation/context.go
+++ b/gestaltd/internal/invocation/context.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/server/core"
 )
 
 type InvocationMeta struct {
@@ -36,6 +37,7 @@ func ensureMeta(ctx context.Context) (context.Context, *InvocationMeta) {
 }
 
 type requestMetaCtxKey struct{}
+type auditEntryCtxKey struct{}
 
 type RequestMeta struct {
 	ClientIP   string
@@ -56,6 +58,15 @@ func WithRequestMeta(ctx context.Context, meta RequestMeta) context.Context {
 func RequestMetaFromContext(ctx context.Context) RequestMeta {
 	m, _ := ctx.Value(requestMetaCtxKey{}).(RequestMeta)
 	return m
+}
+
+func withAuditEntry(ctx context.Context, entry *core.AuditEntry) context.Context {
+	return context.WithValue(ctx, auditEntryCtxKey{}, entry)
+}
+
+func auditEntryFromContext(ctx context.Context) *core.AuditEntry {
+	entry, _ := ctx.Value(auditEntryCtxKey{}).(*core.AuditEntry)
+	return entry
 }
 
 func WithInvocationSurface(ctx context.Context, surface InvocationSurface) context.Context {

--- a/gestaltd/internal/invocation/errors.go
+++ b/gestaltd/internal/invocation/errors.go
@@ -3,12 +3,13 @@ package invocation
 import "errors"
 
 var (
-	ErrProviderNotFound  = errors.New("provider not found")
-	ErrOperationNotFound = errors.New("operation not found")
-	ErrNotAuthenticated  = errors.New("not authenticated")
-	ErrNoToken           = errors.New("no integration token")
-	ErrAmbiguousInstance = errors.New("ambiguous instance")
-	ErrUserResolution    = errors.New("user resolution failed")
-	ErrInternal          = errors.New("internal error")
-	ErrScopeDenied       = errors.New("token scope denied")
+	ErrProviderNotFound    = errors.New("provider not found")
+	ErrOperationNotFound   = errors.New("operation not found")
+	ErrNotAuthenticated    = errors.New("not authenticated")
+	ErrAuthorizationDenied = errors.New("authorization denied")
+	ErrNoToken             = errors.New("no integration token")
+	ErrAmbiguousInstance   = errors.New("ambiguous instance")
+	ErrUserResolution      = errors.New("user resolution failed")
+	ErrInternal            = errors.New("internal error")
+	ErrScopeDenied         = errors.New("token scope denied")
 )

--- a/gestaltd/internal/invocation/guarded.go
+++ b/gestaltd/internal/invocation/guarded.go
@@ -78,6 +78,7 @@ func (g *GuardedInvoker) Invoke(ctx context.Context, p *principal.Principal, pro
 	}
 
 	entry := buildAuditEntry(ctx, p, g.source, providerName, operation, meta)
+	ctx = withAuditEntry(ctx, &entry)
 
 	if err := g.check(meta, providerName, instance, operation); err != nil {
 		entry.Allowed = false
@@ -87,7 +88,9 @@ func (g *GuardedInvoker) Invoke(ctx context.Context, p *principal.Principal, pro
 	}
 
 	entry.Allowed = true
-	g.logAudit(ctx, entry)
+	defer func() {
+		g.logAudit(ctx, entry)
+	}()
 
 	chainInstance := instance
 	if chainInstance == "" {

--- a/gestaltd/internal/invocation/guarded_test.go
+++ b/gestaltd/internal/invocation/guarded_test.go
@@ -12,6 +12,7 @@ import (
 	coreintegration "github.com/valon-technologies/gestalt/server/core/integration"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 )
 
@@ -54,6 +55,14 @@ type capturingSink struct {
 
 func (s *capturingSink) Log(_ context.Context, entry core.AuditEntry) {
 	s.entries = append(s.entries, entry)
+}
+
+type funcInvoker struct {
+	invoke func(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error)
+}
+
+func (f funcInvoker) Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
+	return f.invoke(ctx, p, providerName, instance, operation, params)
 }
 
 func guardTestProvider(name string) *stubProviderWithOps {
@@ -227,6 +236,49 @@ func TestGuardedInvoker_AuditLogged(t *testing.T) {
 	if denied.Error == "" {
 		t.Error("expected denied call to include an error")
 	}
+}
+
+func TestGuardedInvoker_AuditLoggedOnPanic(t *testing.T) {
+	t.Parallel()
+
+	sink := &capturingSink{}
+	guarded := invocation.NewGuarded(funcInvoker{
+		invoke: func(ctx context.Context, _ *principal.Principal, _ string, _ string, _ string, _ map[string]any) (*core.OperationResult, error) {
+			invocation.SetCredentialAudit(ctx, core.ConnectionModeIdentity, principal.IdentitySubjectID(), "workspace", "team-a")
+			panic("boom")
+		},
+	}, nil, "test", sink, invocation.WithoutRateLimit())
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic")
+		}
+		if r != "boom" {
+			t.Fatalf("unexpected panic: %v", r)
+		}
+		if len(sink.entries) != 1 {
+			t.Fatalf("expected 1 audit entry, got %d", len(sink.entries))
+		}
+		entry := sink.entries[0]
+		if !entry.Allowed {
+			t.Fatal("expected panicing invocation to keep allowed=true audit entry")
+		}
+		if entry.CredentialMode != string(core.ConnectionModeIdentity) {
+			t.Fatalf("expected credential mode identity, got %q", entry.CredentialMode)
+		}
+		if entry.CredentialSubjectID != principal.IdentitySubjectID() {
+			t.Fatalf("expected credential subject %q, got %q", principal.IdentitySubjectID(), entry.CredentialSubjectID)
+		}
+		if entry.CredentialConnection != "workspace" {
+			t.Fatalf("expected credential connection workspace, got %q", entry.CredentialConnection)
+		}
+		if entry.CredentialInstance != "team-a" {
+			t.Fatalf("expected credential instance team-a, got %q", entry.CredentialInstance)
+		}
+	}()
+
+	_, _ = guarded.Invoke(context.Background(), nil, "alpha", "", "ping", nil)
 }
 
 func TestGuardedInvoker_ListCapabilities(t *testing.T) {

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -11,16 +11,26 @@ type Source int
 const (
 	SourceSession Source = iota
 	SourceAPIToken
+	SourceWorkloadToken
 	SourceEnv
 )
 
 const IdentityPrincipal = "__identity__"
 
+type Kind string
+
+const (
+	KindUser     Kind = "user"
+	KindWorkload Kind = "workload"
+)
+
 type Principal struct {
-	Identity *core.UserIdentity
-	UserID   string
-	Source   Source
-	Scopes   []string
+	Identity  *core.UserIdentity
+	UserID    string
+	SubjectID string
+	Kind      Kind
+	Source    Source
+	Scopes    []string
 }
 
 func (s Source) String() string {
@@ -29,6 +39,8 @@ func (s Source) String() string {
 		return "session"
 	case SourceAPIToken:
 		return "api_token"
+	case SourceWorkloadToken:
+		return "workload_token"
 	case SourceEnv:
 		return "env"
 	default:
@@ -40,10 +52,28 @@ func (p *Principal) AuthSource() string {
 	if p == nil {
 		return ""
 	}
-	if p.Identity == nil && p.UserID == "" && len(p.Scopes) == 0 {
+	if p.Identity == nil && p.UserID == "" && p.SubjectID == "" && p.Kind == "" && len(p.Scopes) == 0 {
 		return ""
 	}
 	return p.Source.String()
+}
+
+func UserSubjectID(userID string) string {
+	if userID == "" {
+		return ""
+	}
+	return string(KindUser) + ":" + userID
+}
+
+func WorkloadSubjectID(workloadID string) string {
+	if workloadID == "" {
+		return ""
+	}
+	return string(KindWorkload) + ":" + workloadID
+}
+
+func IdentitySubjectID() string {
+	return "identity:" + IdentityPrincipal
 }
 
 type contextKey struct{}

--- a/gestaltd/internal/principal/resolver.go
+++ b/gestaltd/internal/principal/resolver.go
@@ -19,11 +19,22 @@ type TokenType int
 
 const (
 	TokenTypeAPI TokenType = iota
+	TokenTypeWorkload
 )
 
 const (
-	prefixAPI = "gst_api_"
+	prefixAPI      = "gst_api_"
+	prefixWorkload = "gst_wld_"
 )
+
+type ResolvedWorkload struct {
+	ID          string
+	DisplayName string
+}
+
+type WorkloadTokenResolver interface {
+	ResolveWorkloadToken(token string) (*ResolvedWorkload, bool)
+}
 
 func GenerateToken(typ TokenType) (plaintext, hashed string, err error) {
 	b := make([]byte, 32)
@@ -36,6 +47,8 @@ func GenerateToken(typ TokenType) (plaintext, hashed string, err error) {
 	switch typ {
 	case TokenTypeAPI:
 		prefix = prefixAPI
+	case TokenTypeWorkload:
+		prefix = prefixWorkload
 	default:
 		return "", "", fmt.Errorf("unknown token type %d", typ)
 	}
@@ -49,6 +62,8 @@ func ParseTokenType(token string) (TokenType, bool) {
 	switch {
 	case strings.HasPrefix(token, prefixAPI):
 		return TokenTypeAPI, true
+	case strings.HasPrefix(token, prefixWorkload):
+		return TokenTypeWorkload, true
 	default:
 		return 0, false
 	}
@@ -58,15 +73,21 @@ type Resolver struct {
 	auth      core.AuthProvider
 	users     *coredata.UserService
 	apiTokens *coredata.APITokenService
+	workloads WorkloadTokenResolver
 }
 
-func NewResolver(auth core.AuthProvider, users *coredata.UserService, apiTokens *coredata.APITokenService) *Resolver {
-	return &Resolver{auth: auth, users: users, apiTokens: apiTokens}
+func NewResolver(auth core.AuthProvider, users *coredata.UserService, apiTokens *coredata.APITokenService, workloads WorkloadTokenResolver) *Resolver {
+	return &Resolver{auth: auth, users: users, apiTokens: apiTokens, workloads: workloads}
 }
 
 func (r *Resolver) ResolveToken(ctx context.Context, token string) (*Principal, error) {
-	if typ, ok := ParseTokenType(token); ok && typ == TokenTypeAPI {
-		return r.resolveAPIToken(ctx, token)
+	if typ, ok := ParseTokenType(token); ok {
+		switch typ {
+		case TokenTypeAPI:
+			return r.resolveAPIToken(ctx, token)
+		case TokenTypeWorkload:
+			return r.resolveWorkloadToken(token)
+		}
 	}
 
 	startedAt := time.Now()
@@ -114,8 +135,10 @@ func (r *Resolver) resolveAPIToken(ctx context.Context, token string) (*Principa
 			Email:       user.Email,
 			DisplayName: user.DisplayName,
 		},
-		UserID: user.ID,
-		Source: SourceAPIToken,
+		UserID:    user.ID,
+		SubjectID: UserSubjectID(user.ID),
+		Kind:      KindUser,
+		Source:    SourceAPIToken,
 	}
 	if scopes := strings.Fields(apiToken.Scopes); len(scopes) > 0 {
 		p.Scopes = scopes
@@ -123,9 +146,25 @@ func (r *Resolver) resolveAPIToken(ctx context.Context, token string) (*Principa
 	return p, nil
 }
 
+func (r *Resolver) resolveWorkloadToken(token string) (*Principal, error) {
+	if r.workloads == nil {
+		return nil, ErrInvalidToken
+	}
+	workload, ok := r.workloads.ResolveWorkloadToken(token)
+	if !ok || workload == nil || workload.ID == "" {
+		return nil, ErrInvalidToken
+	}
+	return &Principal{
+		Kind:      KindWorkload,
+		SubjectID: WorkloadSubjectID(workload.ID),
+		Source:    SourceWorkloadToken,
+	}, nil
+}
+
 func (r *Resolver) ResolveEmail(email string) *Principal {
 	return &Principal{
 		Identity: &core.UserIdentity{Email: email},
+		Kind:     KindUser,
 		Source:   SourceEnv,
 	}
 }

--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -9,7 +9,24 @@ import (
 )
 
 func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Principal) (*principal.Principal, error) {
-	if p == nil || p.UserID != "" || p.Identity == nil || p.Identity.Email == "" {
+	if p == nil {
+		return nil, nil
+	}
+	if p.Kind == principal.KindWorkload {
+		return p, nil
+	}
+	if p.Kind == "" {
+		p.Kind = principal.KindUser
+	}
+	if p.UserID != "" {
+		if p.SubjectID == "" {
+			clone := *p
+			clone.SubjectID = principal.UserSubjectID(p.UserID)
+			return &clone, nil
+		}
+		return p, nil
+	}
+	if p.Identity == nil || p.Identity.Email == "" {
 		return p, nil
 	}
 
@@ -23,6 +40,8 @@ func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Princi
 
 	clone := *p
 	clone.UserID = dbUser.ID
+	clone.Kind = principal.KindUser
+	clone.SubjectID = principal.UserSubjectID(dbUser.ID)
 	return &clone, nil
 }
 
@@ -47,6 +66,8 @@ func (s *Server) auditHTTPEventWithUserID(ctx context.Context, userID, authSourc
 	ctx, entry := invocation.BuildAuditEntry(ctx, nil, "http", provider, operation)
 	entry.UserID = userID
 	entry.AuthSource = authSource
+	entry.SubjectID = principal.UserSubjectID(userID)
+	entry.SubjectKind = string(principal.KindUser)
 	entry.Allowed = allowed
 	if err != nil {
 		entry.Error = err.Error()

--- a/gestaltd/internal/server/audit_metadata_test.go
+++ b/gestaltd/internal/server/audit_metadata_test.go
@@ -11,7 +11,10 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
+	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 )
@@ -175,6 +178,119 @@ func TestAuditMetadata_FallbackToRemoteAddr(t *testing.T) {
 	}
 	if record["user_agent"] != "fallback-agent/2.0" {
 		t.Errorf("expected user_agent=fallback-agent/2.0, got %v", record["user_agent"])
+	}
+}
+
+func TestAuditMetadata_WorkloadSubjectAndCredentialPath(t *testing.T) {
+	t.Parallel()
+
+	var auditBuf bytes.Buffer
+	auditSink := invocation.NewSlogAuditSink(&auditBuf)
+
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
+	stub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "audit-workload-prov",
+			ConnMode: core.ConnectionModeIdentity,
+			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, token string) (*core.OperationResult, error) {
+				if token != "identity-token" {
+					t.Fatalf("unexpected token %q", token)
+				}
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "ping", Method: http.MethodPost}},
+	}
+
+	providers := testutil.NewProviderRegistry(t, stub)
+	authz, err := authorization.New(config.AuthorizationConfig{
+		Workloads: map[string]config.WorkloadDef{
+			"triage-bot": {
+				Token: workloadToken,
+				Providers: map[string]config.WorkloadProviderDef{
+					"audit-workload-prov": {
+						Connection: "workspace",
+						Instance:   "team-a",
+						Allow:      []string{"ping"},
+					},
+				},
+			},
+		},
+	}, nil, providers, nil)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	if err := svc.Tokens.StoreToken(t.Context(), &core.IntegrationToken{
+		ID:          "identity-audit-token",
+		UserID:      principal.IdentityPrincipal,
+		Integration: "audit-workload-prov",
+		Connection:  "workspace",
+		Instance:    "team-a",
+		AccessToken: "identity-token",
+	}); err != nil {
+		t.Fatalf("StoreToken: %v", err)
+	}
+
+	broker := invocation.NewBroker(providers, svc.Users, svc.Tokens, invocation.WithAuthorizer(authz))
+	guarded := invocation.NewGuarded(broker, broker, "http", auditSink, invocation.WithoutRateLimit())
+
+	srv, err := server.New(server.Config{
+		Auth:        &coretesting.StubAuthProvider{N: "test"},
+		AuditSink:   auditSink,
+		Services:    svc,
+		Providers:   providers,
+		Invoker:     guarded,
+		Authorizer:  authz,
+		StateSecret: []byte("0123456789abcdef0123456789abcdef"),
+	})
+	if err != nil {
+		t.Fatalf("creating server: %v", err)
+	}
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/audit-workload-prov/ping", bytes.NewBufferString(`{}`))
+	req.Header.Set("Authorization", "Bearer "+workloadToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var record map[string]any
+	if err := json.Unmarshal(auditBuf.Bytes(), &record); err != nil {
+		t.Fatalf("failed to parse audit JSON: %v\nraw: %s", err, auditBuf.String())
+	}
+
+	if record["subject_id"] != "workload:triage-bot" {
+		t.Fatalf("expected workload subject_id, got %v", record["subject_id"])
+	}
+	if record["subject_kind"] != "workload" {
+		t.Fatalf("expected subject_kind=workload, got %v", record["subject_kind"])
+	}
+	if record["credential_mode"] != "identity" {
+		t.Fatalf("expected credential_mode=identity, got %v", record["credential_mode"])
+	}
+	if record["credential_subject_id"] != "identity:__identity__" {
+		t.Fatalf("expected credential_subject_id identity principal, got %v", record["credential_subject_id"])
+	}
+	if record["credential_connection"] != "workspace" {
+		t.Fatalf("expected credential_connection=workspace, got %v", record["credential_connection"])
+	}
+	if record["credential_instance"] != "team-a" {
+		t.Fatalf("expected credential_instance=team-a, got %v", record["credential_instance"])
 	}
 }
 

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+func (s *Server) allowProvider(p *principal.Principal, provider string) bool {
+	if s.authorizer == nil {
+		return true
+	}
+	return s.authorizer.AllowProvider(p, provider)
+}
+
+func (s *Server) allowOperation(p *principal.Principal, provider, operation string) bool {
+	if s.authorizer == nil {
+		return true
+	}
+	return s.authorizer.AllowOperation(p, provider, operation)
+}
+
+func (s *Server) workloadBinding(p *principal.Principal, provider string) (authorization.CredentialBinding, bool) {
+	if s.authorizer == nil {
+		return authorization.CredentialBinding{}, false
+	}
+	return s.authorizer.Binding(p, provider)
+}
+
+func rejectWorkloadSelectors(w http.ResponseWriter, p *principal.Principal, connection, instance string) bool {
+	if p == nil || p.Kind != principal.KindWorkload {
+		return false
+	}
+	if connection == "" && instance == "" {
+		return false
+	}
+	writeError(w, http.StatusForbidden, "workload callers may not override connection or instance bindings")
+	return true
+}
+
+func (s *Server) workloadBindingSelectors(p *principal.Principal, provider, connection, instance string) (string, string) {
+	if p == nil || p.Kind != principal.KindWorkload {
+		return s.catalogLookupConnection(provider, connection), instance
+	}
+	binding, ok := s.workloadBinding(p, provider)
+	if !ok {
+		return s.catalogLookupConnection(provider, connection), instance
+	}
+	if connection == "" {
+		connection = binding.Connection
+	}
+	if instance == "" {
+		instance = binding.Instance
+	}
+	return s.catalogLookupConnection(provider, connection), instance
+}
+
+func (s *Server) workloadBindingConnected(ctx context.Context, binding authorization.CredentialBinding, provider string) (bool, error) {
+	switch binding.Mode {
+	case core.ConnectionModeNone:
+		return true, nil
+	case core.ConnectionModeIdentity:
+		_, err := s.tokens.Token(ctx, binding.CredentialOwnerID, provider, binding.Connection, binding.Instance)
+		switch {
+		case err == nil:
+			return true, nil
+		case errors.Is(err, core.ErrNotFound):
+			return false, nil
+		default:
+			return false, err
+		}
+	default:
+		return false, nil
+	}
+}

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
 
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -37,8 +38,9 @@ const sessionCookieName = "session_token"
 const defaultSessionCookieTTL = 24 * time.Hour
 
 var (
-	errNotAuthenticated = errors.New("not authenticated")
-	errResolveUser      = errors.New("failed to resolve user")
+	errNotAuthenticated  = errors.New("not authenticated")
+	errResolveUser       = errors.New("failed to resolve user")
+	errWorkloadForbidden = errors.New("workload callers are not allowed on this route")
 )
 
 var (
@@ -85,6 +87,10 @@ type connectionParamInfo struct {
 }
 
 func (s *Server) resolveUserID(w http.ResponseWriter, r *http.Request) (string, error) {
+	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
+		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		return "", errWorkloadForbidden
+	}
 	user := UserFromContext(r.Context())
 	if user == nil || user.Email == "" {
 		writeError(w, http.StatusUnauthorized, "not authenticated")
@@ -116,28 +122,34 @@ func (s *Server) readinessCheck(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
-	connected, err := s.userConnectedIntegrations(r)
-	if err != nil {
-		slog.ErrorContext(r.Context(), "listing integrations", "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to check integration status")
-		return
+	p := PrincipalFromContext(r.Context())
+	connected := map[string][]instanceInfo{}
+	if p == nil || p.Kind != principal.KindWorkload {
+		var err error
+		connected, err = s.userConnectedIntegrations(r)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "listing integrations", "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to check integration status")
+			return
+		}
 	}
 
 	names := s.providers.List()
 	out := make([]integrationInfo, 0, len(names))
 	for _, name := range names {
+		if !s.allowProvider(p, name) {
+			continue
+		}
 		prov, err := s.providers.Get(name)
 		if err != nil {
 			continue
 		}
-		authTypes := integrationAuthTypesForProvider(prov)
-		instances := connected[name]
 		info := integrationInfo{
 			Name:             name,
 			DisplayName:      prov.DisplayName(),
 			Description:      prov.Description(),
-			Connected:        len(instances) > 0,
-			Instances:        append(make([]instanceInfo, 0, len(instances)), instances...),
+			Connected:        false,
+			Instances:        []instanceInfo{},
 			AuthTypes:        []string{},
 			ConnectionParams: map[string]connectionParamInfo{},
 			Connections:      []connectionDefInfo{},
@@ -146,6 +158,24 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		if cat := prov.Catalog(); cat != nil {
 			info.IconSVG = cat.IconSVG
 		}
+		if p != nil && p.Kind == principal.KindWorkload {
+			if binding, ok := s.workloadBinding(p, name); ok {
+				bindingConnected, err := s.workloadBindingConnected(r.Context(), binding, name)
+				if err != nil {
+					slog.ErrorContext(r.Context(), "checking workload integration status", "provider", name, "error", err)
+					writeError(w, http.StatusInternalServerError, "failed to check integration status")
+					return
+				}
+				info.Connected = bindingConnected
+			}
+			out = append(out, info)
+			continue
+		}
+
+		authTypes := integrationAuthTypesForProvider(prov)
+		instances := connected[name]
+		info.Connected = len(instances) > 0
+		info.Instances = append(make([]instanceInfo, 0, len(instances)), instances...)
 		info.CredentialFields = credentialFieldInfosFromProvider(prov)
 		if cpp, ok := prov.(core.ConnectionParamProvider); ok {
 			defs := cpp.ConnectionParamDefs()
@@ -401,6 +431,11 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	p := PrincipalFromContext(r.Context())
+	if !s.allowProvider(p, name) {
+		writeError(w, http.StatusForbidden, "operation access denied")
+		return
+	}
 	requestedConnection := r.URL.Query().Get(httpConnectionParam)
 	if requestedConnection != "" {
 		var ok bool
@@ -417,7 +452,9 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	p := PrincipalFromContext(r.Context())
+	if rejectWorkloadSelectors(w, p, requestedConnection, requestedInstance) {
+		return
+	}
 	var resolver invocation.TokenResolver
 	if tr, ok := s.invoker.(invocation.TokenResolver); ok {
 		resolver = tr
@@ -426,12 +463,22 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 	if requestedConnection != "" || requestedInstance != "" {
 		resolveCatalog = invocation.ResolveCatalogStrict
 	}
-	cat, err := resolveCatalog(r.Context(), prov, name, resolver, p, s.catalogLookupConnection(name, requestedConnection), requestedInstance)
+	catalogConnection, catalogInstance := s.workloadBindingSelectors(p, name, requestedConnection, requestedInstance)
+	cat, err := resolveCatalog(r.Context(), prov, name, resolver, p, catalogConnection, catalogInstance)
 	if err != nil {
 		s.writeInvocationError(w, r, name, "", err)
 		return
 	}
 	ops := httpVisibleCatalogOperations(cat.Operations)
+	if p != nil && p.Kind == principal.KindWorkload {
+		filtered := ops[:0]
+		for i := range ops {
+			if s.allowOperation(p, name, ops[i].ID) {
+				filtered = append(filtered, ops[i])
+			}
+		}
+		ops = filtered
+	}
 	sort.Slice(ops, func(i, j int) bool {
 		return ops[i].ID < ops[j].ID
 	})
@@ -444,6 +491,10 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 
 	p := PrincipalFromContext(r.Context())
 	if _, ok := s.getProvider(w, providerName); !ok {
+		return
+	}
+	if !s.allowProvider(p, providerName) || !s.allowOperation(p, providerName, operationName) {
+		writeError(w, http.StatusForbidden, "operation access denied")
 		return
 	}
 
@@ -462,6 +513,9 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		if !ok {
 			return
 		}
+	}
+	if rejectWorkloadSelectors(w, p, requestedConnection, requestedInstance) {
+		return
 	}
 
 	params := make(map[string]any)
@@ -513,6 +567,9 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("conflicting connection parameter %q in query string and JSON body", httpConnectionParam))
 		return
 	}
+	if rejectWorkloadSelectors(w, p, bodyConnection, bodyInstance) {
+		return
+	}
 	connection := bodyConnection
 	if connection == "" {
 		connection = requestedConnection
@@ -546,6 +603,8 @@ func (s *Server) writeInvocationError(w http.ResponseWriter, r *http.Request, pr
 		writeError(w, http.StatusNotFound, fmt.Sprintf("operation %q not found on integration %q", operationName, providerName))
 	case errors.Is(err, invocation.ErrNotAuthenticated):
 		writeError(w, http.StatusUnauthorized, "not authenticated")
+	case errors.Is(err, invocation.ErrAuthorizationDenied):
+		writeError(w, http.StatusForbidden, err.Error())
 	case errors.Is(err, invocation.ErrScopeDenied):
 		writeError(w, http.StatusForbidden, err.Error())
 	case errors.Is(err, invocation.ErrNoToken):

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -370,6 +370,11 @@ func (s *Server) logout(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		s.auditHTTPEvent(r.Context(), auditPrincipal, s.authProviderName(), "auth.logout", auditAllowed, auditErr)
 	}()
+	if auditPrincipal != nil && auditPrincipal.Kind == principal.KindWorkload {
+		auditErr = errWorkloadForbidden
+		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		return
+	}
 
 	s.clearSessionCookie(w)
 	auditAllowed = true

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -14,6 +14,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/discovery"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
 type connectManualRequest struct {
@@ -36,6 +37,11 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, metricProviderName, "manual", "complete", connectionMode, auditErr != nil)
 		s.auditHTTPEvent(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.manual.connect", auditAllowed, auditErr)
 	}()
+	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
+		auditErr = errWorkloadForbidden
+		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		return
+	}
 
 	var req connectManualRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -13,6 +13,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
 	"github.com/valon-technologies/gestalt/server/internal/paraminterp"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
 type startOAuthRequest struct {
@@ -34,6 +35,11 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, metricProviderName, "oauth", "start", connectionMode, auditErr != nil)
 		s.auditHTTPEvent(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.oauth.start", auditAllowed, auditErr)
 	}()
+	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
+		auditErr = errWorkloadForbidden
+		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		return
+	}
 
 	var req startOAuthRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -108,10 +108,14 @@ func (s *Server) resolveRequestPrincipal(r *http.Request) (*principal.Principal,
 
 	if c, err := r.Cookie(sessionCookieName); err == nil && c.Value != "" {
 		p, err := s.resolver.ResolveToken(r.Context(), c.Value)
-		if p != nil {
+		if p != nil && p.Kind != principal.KindWorkload {
 			return p, nil
 		}
-		lastErr = err
+		if p != nil && p.Kind == principal.KindWorkload {
+			lastErr = principal.ErrInvalidToken
+		} else {
+			lastErr = err
+		}
 	}
 
 	token, err := requestBearerToken(r)

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -256,6 +256,9 @@ func (s *Server) resolvePendingConnectionUserID(r *http.Request) (string, bool, 
 	if p == nil {
 		return "", false, nil
 	}
+	if p.Kind == principal.KindWorkload {
+		return "", true, errWorkloadForbidden
+	}
 	if p.UserID == "" {
 		return "", true, fmt.Errorf("authenticated principal missing user ID")
 	}
@@ -286,6 +289,10 @@ func (s *Server) authorizePendingConnectionByCookie(r *http.Request, state *pend
 func (s *Server) authorizePendingConnection(w http.ResponseWriter, r *http.Request, state *pendingConnectionState) bool {
 	userID, authenticated, err := s.resolvePendingConnectionUserID(r)
 	if err != nil {
+		if errors.Is(err, errWorkloadForbidden) {
+			writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+			return false
+		}
 		if errors.Is(err, principal.ErrInvalidToken) {
 			writeError(w, http.StatusUnauthorized, "invalid token")
 			return false

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	cryptoutil "github.com/valon-technologies/gestalt/server/core/crypto"
 	"github.com/valon-technologies/gestalt/server/core/session"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
@@ -47,6 +48,7 @@ type Server struct {
 	catalogConnection  map[string]string
 	connectionAuth     func() map[string]map[string]bootstrap.OAuthHandler
 	pluginDefs         map[string]*config.ProviderEntry
+	authorizer         *authorization.Authorizer
 	noAuth             bool
 	anonymousPrincipal *principal.Principal
 	publicBaseURL      string
@@ -74,6 +76,7 @@ type Config struct {
 	CatalogConnection map[string]string
 	ConnectionAuth    func() map[string]map[string]bootstrap.OAuthHandler
 	PluginDefs        map[string]*config.ProviderEntry
+	Authorizer        *authorization.Authorizer
 	PublicBaseURL     string
 	SecureCookies     bool
 	StateSecret       []byte
@@ -116,7 +119,7 @@ func New(cfg Config) (*Server, error) {
 	users := cfg.Services.Users
 	tokens := cfg.Services.Tokens
 	apiTokens := cfg.Services.APITokens
-	resolver := principal.NewResolver(cfg.Auth, users, apiTokens)
+	resolver := principal.NewResolver(cfg.Auth, users, apiTokens, cfg.Authorizer)
 
 	router := chi.NewRouter()
 	s := &Server{
@@ -134,6 +137,7 @@ func New(cfg Config) (*Server, error) {
 		catalogConnection: cfg.CatalogConnection,
 		connectionAuth:    cfg.ConnectionAuth,
 		pluginDefs:        cfg.PluginDefs,
+		authorizer:        cfg.Authorizer,
 		noAuth:            noAuth,
 		publicBaseURL:     strings.TrimRight(cfg.PublicBaseURL, "/"),
 		secureCookies:     cfg.SecureCookies,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/session"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/apiexec"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/composite"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -78,6 +79,9 @@ func newTestServer(t *testing.T, opts ...func(*server.Config)) *httptest.Server 
 			}
 			return refreshers
 		}))
+	}
+	if cfg.Authorizer != nil {
+		brokerOpts = append(brokerOpts, invocation.WithAuthorizer(cfg.Authorizer))
 	}
 	if cfg.Invoker == nil {
 		cfg.Invoker = invocation.NewBroker(cfg.Providers, cfg.Services.Users, cfg.Services.Tokens, brokerOpts...)
@@ -216,6 +220,27 @@ func seedUser(t *testing.T, svc *coredata.Services, email string) *core.User {
 		t.Fatalf("seedUser: %v", err)
 	}
 	return u
+}
+
+func seedIdentityToken(t *testing.T, svc *coredata.Services, integration, connection, instance, accessToken string) {
+	t.Helper()
+	seedToken(t, svc, &core.IntegrationToken{
+		ID:          integration + "-" + connection + "-" + instance,
+		UserID:      principal.IdentityPrincipal,
+		Integration: integration,
+		Connection:  connection,
+		Instance:    instance,
+		AccessToken: accessToken,
+	})
+}
+
+func mustAuthorizer(t *testing.T, cfg config.AuthorizationConfig, providers *registry.ProviderMap[core.Provider], pluginDefs map[string]*config.ProviderEntry, defaultConnections map[string]string) *authorization.Authorizer {
+	t.Helper()
+	authz, err := authorization.New(cfg, pluginDefs, providers, defaultConnections)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+	return authz
 }
 
 func seedToken(t *testing.T, svc *coredata.Services, tok *core.IntegrationToken) {
@@ -493,6 +518,57 @@ func TestAuthMiddleware_ValidAPIToken(t *testing.T) {
 	}
 }
 
+func TestAuthMiddleware_ValidWorkloadToken(t *testing.T) {
+	t.Parallel()
+
+	plaintext, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
+	stub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{N: "weather", ConnMode: core.ConnectionModeNone},
+		ops:             []core.Operation{{Name: "forecast", Method: http.MethodGet}},
+	}
+	providers := testutil.NewProviderRegistry(t, stub)
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Workloads: map[string]config.WorkloadDef{
+			"weather-bot": {
+				Token: plaintext,
+				Providers: map[string]config.WorkloadProviderDef{
+					"weather": {Allow: []string{"forecast"}},
+				},
+			},
+		},
+	}, providers, nil, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, _ string) (*core.UserIdentity, error) {
+				return nil, fmt.Errorf("not a session token")
+			},
+		}
+		cfg.Providers = providers
+		cfg.Services = coretesting.NewStubServices(t)
+		cfg.Authorizer = authz
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+}
+
 func TestAuthMiddleware_NoAuth(t *testing.T) {
 	t.Parallel()
 	ts := newTestServer(t, func(cfg *server.Config) {
@@ -712,6 +788,280 @@ func TestListIntegrations(t *testing.T) {
 	}
 	if integrations[0].Connected {
 		t.Fatal("expected connected=false when no tokens stored")
+	}
+}
+
+func TestWorkloadAuthorization_ListIntegrationsFiltersAndHidesConnectionAffordances(t *testing.T) {
+	t.Parallel()
+
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	seedIdentityToken(t, svc, "svc", "workspace", "default", "identity-svc-token")
+
+	svcProvider := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{N: "svc", DN: "Service", ConnMode: core.ConnectionModeIdentity},
+		ops:             []core.Operation{{Name: "run", Method: http.MethodGet}},
+	}
+	weatherProvider := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{N: "weather", DN: "Weather", ConnMode: core.ConnectionModeNone},
+		ops:             []core.Operation{{Name: "forecast", Method: http.MethodGet}},
+	}
+	secretProvider := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{N: "secret", DN: "Secret", ConnMode: core.ConnectionModeNone},
+		ops:             []core.Operation{{Name: "peek", Method: http.MethodGet}},
+	}
+	providers := testutil.NewProviderRegistry(t, svcProvider, weatherProvider, secretProvider)
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Workloads: map[string]config.WorkloadDef{
+			"triage-bot": {
+				Token: workloadToken,
+				Providers: map[string]config.WorkloadProviderDef{
+					"svc":     {Allow: []string{"run"}},
+					"weather": {Allow: []string{"forecast"}},
+				},
+			},
+		},
+	}, providers, nil, map[string]string{"svc": "workspace"})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
+		cfg.Providers = providers
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.DefaultConnection = map[string]string{"svc": "workspace"}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var integrations []struct {
+		Name             string                    `json:"name"`
+		Connected        bool                      `json:"connected"`
+		Instances        []map[string]any          `json:"instances"`
+		AuthTypes        []string                  `json:"authTypes"`
+		Connections      []map[string]any          `json:"connections"`
+		CredentialFields []map[string]any          `json:"credentialFields"`
+		ConnectionParams map[string]map[string]any `json:"connectionParams"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if len(integrations) != 2 {
+		t.Fatalf("expected 2 integrations, got %+v", integrations)
+	}
+
+	got := map[string]struct {
+		Connected        bool
+		Instances        []map[string]any
+		AuthTypes        []string
+		Connections      []map[string]any
+		CredentialFields []map[string]any
+		ConnectionParams map[string]map[string]any
+	}{}
+	for _, integration := range integrations {
+		got[integration.Name] = struct {
+			Connected        bool
+			Instances        []map[string]any
+			AuthTypes        []string
+			Connections      []map[string]any
+			CredentialFields []map[string]any
+			ConnectionParams map[string]map[string]any
+		}{
+			Connected:        integration.Connected,
+			Instances:        integration.Instances,
+			AuthTypes:        integration.AuthTypes,
+			Connections:      integration.Connections,
+			CredentialFields: integration.CredentialFields,
+			ConnectionParams: integration.ConnectionParams,
+		}
+	}
+	if _, ok := got["secret"]; ok {
+		t.Fatalf("unauthorized integration was visible: %+v", integrations)
+	}
+	if !got["svc"].Connected {
+		t.Fatalf("expected bound identity integration to be connected, got %+v", got["svc"])
+	}
+	if !got["weather"].Connected {
+		t.Fatalf("expected connection-mode none integration to be connected, got %+v", got["weather"])
+	}
+	for name, info := range got {
+		if len(info.Instances) != 0 || len(info.AuthTypes) != 0 || len(info.Connections) != 0 || len(info.CredentialFields) != 0 || len(info.ConnectionParams) != 0 {
+			t.Fatalf("workload integration %q should not expose connection affordances: %+v", name, info)
+		}
+	}
+
+	stubDB := svc.DB.(*coretesting.StubIndexedDB)
+	stubDB.Err = fmt.Errorf("token store unavailable")
+	t.Cleanup(func() { stubDB.Err = nil })
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request with token store outage: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 500 when workload binding lookup fails, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+func TestWorkloadAuthorization_ListOperationsFiltersAndRejectsSelectors(t *testing.T) {
+	t.Parallel()
+
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
+	provider := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{N: "svc", ConnMode: core.ConnectionModeIdentity},
+		ops: []core.Operation{
+			{Name: "run", Method: http.MethodGet},
+			{Name: "admin", Method: http.MethodGet},
+		},
+	}
+	providers := testutil.NewProviderRegistry(t, provider)
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Workloads: map[string]config.WorkloadDef{
+			"triage-bot": {
+				Token: workloadToken,
+				Providers: map[string]config.WorkloadProviderDef{
+					"svc": {
+						Connection: "workspace",
+						Instance:   "default",
+						Allow:      []string{"run"},
+					},
+				},
+			},
+		},
+	}, providers, nil, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
+		cfg.Providers = providers
+		cfg.Services = coretesting.NewStubServices(t)
+		cfg.Authorizer = authz
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations/svc/operations", nil)
+	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var ops []struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&ops); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if len(ops) != 1 || ops[0].ID != "run" {
+		t.Fatalf("operations = %+v, want only run", ops)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations/svc/operations?_connection=workspace", nil)
+	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request with selector: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 403, got %d: %s", resp.StatusCode, body)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	seedIdentityToken(t, svc, "svc-session", "workspace", "team-a", "session-bound-token")
+
+	var sessionCatalogToken string
+	sessionProvider := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "svc-session", ConnMode: core.ConnectionModeIdentity},
+		},
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			sessionCatalogToken = token
+			return &catalog.Catalog{
+				Name: "svc-session",
+				Operations: []catalog.CatalogOperation{
+					{ID: "run", Method: http.MethodGet},
+				},
+			}, nil
+		},
+	}
+	sessionProviders := testutil.NewProviderRegistry(t, sessionProvider)
+	sessionAuthz := mustAuthorizer(t, config.AuthorizationConfig{
+		Workloads: map[string]config.WorkloadDef{
+			"triage-bot": {
+				Token: workloadToken,
+				Providers: map[string]config.WorkloadProviderDef{
+					"svc-session": {
+						Connection: "workspace",
+						Instance:   "team-a",
+						Allow:      []string{"run"},
+					},
+				},
+			},
+		},
+	}, sessionProviders, nil, map[string]string{"svc-session": testDefaultConnection})
+
+	sessionTS := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
+		cfg.Providers = sessionProviders
+		cfg.Services = svc
+		cfg.Authorizer = sessionAuthz
+		cfg.DefaultConnection = map[string]string{"svc-session": testDefaultConnection}
+	})
+	testutil.CloseOnCleanup(t, sessionTS)
+
+	req, _ = http.NewRequest(http.MethodGet, sessionTS.URL+"/api/v1/integrations/svc-session/operations", nil)
+	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("session catalog request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200 for session-catalog workload discovery, got %d: %s", resp.StatusCode, body)
+	}
+
+	ops = nil
+	if err := json.NewDecoder(resp.Body).Decode(&ops); err != nil {
+		t.Fatalf("decoding session ops: %v", err)
+	}
+	if len(ops) != 1 || ops[0].ID != "run" {
+		t.Fatalf("session operations = %+v, want only run", ops)
+	}
+	if sessionCatalogToken != "session-bound-token" {
+		t.Fatalf("expected session catalog to use bound identity token, got %q", sessionCatalogToken)
 	}
 }
 
@@ -2423,6 +2773,235 @@ func TestExecuteOperation_NoStoredToken(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
+}
+
+func TestWorkloadAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelectors(t *testing.T) {
+	t.Parallel()
+
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	seedIdentityToken(t, svc, "svc", "workspace", "team-a", "identity-bound-token")
+
+	stub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "svc",
+			ConnMode: core.ConnectionModeIdentity,
+			ExecuteFn: func(_ context.Context, op string, _ map[string]any, token string) (*core.OperationResult, error) {
+				return &core.OperationResult{Status: http.StatusOK, Body: fmt.Sprintf(`{"operation":%q,"token":%q}`, op, token)}, nil
+			},
+		},
+		ops: []core.Operation{
+			{Name: "run", Method: http.MethodGet},
+			{Name: "admin", Method: http.MethodGet},
+		},
+	}
+	providers := testutil.NewProviderRegistry(t, stub)
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Workloads: map[string]config.WorkloadDef{
+			"triage-bot": {
+				Token: workloadToken,
+				Providers: map[string]config.WorkloadProviderDef{
+					"svc": {
+						Connection: "workspace",
+						Instance:   "team-a",
+						Allow:      []string{"run"},
+					},
+				},
+			},
+		},
+	}, providers, nil, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
+		cfg.Providers = providers
+		cfg.Services = svc
+		cfg.Authorizer = authz
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/run", nil)
+	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if result["token"] != "identity-bound-token" {
+		t.Fatalf("expected bound identity token, got %v", result["token"])
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/admin", nil)
+	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("unauthorized request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 403, got %d: %s", resp.StatusCode, body)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/run?_instance=team-a", nil)
+	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("selector request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 403 for selector override, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+func TestWorkloadAuthorization_ExecuteOperation_MissingBoundIdentityTokenReturns412(t *testing.T) {
+	t.Parallel()
+
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
+	var auditBuf bytes.Buffer
+	auditSink := invocation.NewSlogAuditSink(&auditBuf)
+
+	stub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "svc",
+			ConnMode: core.ConnectionModeIdentity,
+		},
+		ops: []core.Operation{{Name: "run", Method: http.MethodGet}},
+	}
+	providers := testutil.NewProviderRegistry(t, stub)
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Workloads: map[string]config.WorkloadDef{
+			"triage-bot": {
+				Token: workloadToken,
+				Providers: map[string]config.WorkloadProviderDef{
+					"svc": {
+						Connection: "workspace",
+						Instance:   "team-a",
+						Allow:      []string{"run"},
+					},
+				},
+			},
+		},
+	}, providers, nil, nil)
+
+	svc := coretesting.NewStubServices(t)
+	broker := invocation.NewBroker(providers, svc.Users, svc.Tokens, invocation.WithAuthorizer(authz))
+	guarded := invocation.NewGuarded(broker, broker, "http", auditSink, invocation.WithoutRateLimit())
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
+		cfg.Providers = providers
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.AuditSink = auditSink
+		cfg.Invoker = guarded
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/run", nil)
+	req.Header.Set("Authorization", "Bearer "+workloadToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusPreconditionFailed {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 412, got %d: %s", resp.StatusCode, body)
+	}
+
+	var record map[string]any
+	if err := json.Unmarshal(auditBuf.Bytes(), &record); err != nil {
+		t.Fatalf("failed to parse audit JSON: %v\nraw: %s", err, auditBuf.String())
+	}
+	if record["subject_id"] != "workload:triage-bot" {
+		t.Fatalf("expected workload subject_id, got %v", record["subject_id"])
+	}
+	if record["credential_subject_id"] != "identity:__identity__" {
+		t.Fatalf("expected credential_subject_id identity principal, got %v", record["credential_subject_id"])
+	}
+	if record["credential_connection"] != "workspace" {
+		t.Fatalf("expected credential_connection=workspace, got %v", record["credential_connection"])
+	}
+	if record["credential_instance"] != "team-a" {
+		t.Fatalf("expected credential_instance=team-a, got %v", record["credential_instance"])
+	}
+}
+
+func TestWorkloadAuthorization_HumanRoutesReturn403(t *testing.T) {
+	t.Parallel()
+
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
+	stub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{N: "weather", ConnMode: core.ConnectionModeNone},
+		ops:             []core.Operation{{Name: "forecast", Method: http.MethodGet}},
+	}
+	providers := testutil.NewProviderRegistry(t, stub)
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Workloads: map[string]config.WorkloadDef{
+			"triage-bot": {
+				Token: workloadToken,
+				Providers: map[string]config.WorkloadProviderDef{
+					"weather": {Allow: []string{"forecast"}},
+				},
+			},
+		},
+	}, providers, nil, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
+		cfg.Providers = providers
+		cfg.Services = coretesting.NewStubServices(t)
+		cfg.Authorizer = authz
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	for _, request := range []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{method: http.MethodPost, path: "/api/v1/tokens", body: `{"name":"bot-token"}`},
+		{method: http.MethodPost, path: "/api/v1/auth/connect-manual", body: `{"integration":"weather","credential":"abc"}`},
+		{method: http.MethodDelete, path: "/api/v1/integrations/weather"},
+		{method: http.MethodPost, path: "/api/v1/auth/logout"},
+	} {
+		req, _ := http.NewRequest(request.method, ts.URL+request.path, bytes.NewBufferString(request.body))
+		req.Header.Set("Authorization", "Bearer "+workloadToken)
+		if request.body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s %s: %v", request.method, request.path, err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusForbidden {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("%s %s expected 403, got %d: %s", request.method, request.path, resp.StatusCode, body)
+		}
+	}
 }
 
 func TestExecuteOperation_RejectsSessionPassthrough(t *testing.T) {


### PR DESCRIPTION
## Summary
- introduce `server.authorization.workloads` with config-backed workload bearer tokens, exact operation allowlists, and per-provider `identity`/`none` credential bindings
- extend principals and audit metadata with subject and credential-path fields for workload execution
- enforce workload authorization across HTTP integration discovery, operation listing, invocation, and human-only route rejection
- preserve credential-availability failures as `412 Precondition Failed` when a bound identity credential is missing
- update config-file docs and extend integration/functional coverage for discovery, invocation, selector rejection, audit metadata, bootstrap validation, and missing-credential behavior

## New Interfaces
Go config surface:

```go
type AuthorizationConfig struct {
    Workloads map[string]WorkloadDef `yaml:"workloads,omitempty"`
}

type WorkloadDef struct {
    DisplayName string                         `yaml:"displayName,omitempty"`
    Token       string                         `yaml:"token"`
    Providers   map[string]WorkloadProviderDef `yaml:"providers,omitempty"`
}

type WorkloadProviderDef struct {
    Connection string   `yaml:"connection,omitempty"`
    Instance   string   `yaml:"instance,omitempty"`
    Allow      []string `yaml:"allow,omitempty"`
}
```

Host authorizer surface:

```go
type CredentialBinding struct {
    Mode                core.ConnectionMode
    CredentialSubjectID string
    CredentialOwnerID   string
    Connection          string
    Instance            string
}

func New(
    cfg config.AuthorizationConfig,
    pluginDefs map[string]*config.ProviderEntry,
    providers *registry.ProviderMap[core.Provider],
    defaultConnections map[string]string,
) (*Authorizer, error)

func (a *Authorizer) ResolveWorkloadToken(token string) (*principal.ResolvedWorkload, bool)
func (a *Authorizer) AllowProvider(p *principal.Principal, provider string) bool
func (a *Authorizer) AllowOperation(p *principal.Principal, provider, operation string) bool
func (a *Authorizer) Binding(p *principal.Principal, provider string) (CredentialBinding, bool)
```

YAML surface:

```yaml
server:
  authorization:
    workloads:
      triage-bot:
        displayName: Triage Bot
        token: secret://triage-bot-token
        providers:
          github:
            connection: default
            instance: default
            allow:
              - list_issues
              - get_issue
          weather:
            allow:
              - get_forecast
```

## Examples
Bootstrap a workload in Go:

```go
cfg.Server.Authorization = config.AuthorizationConfig{
    Workloads: map[string]config.WorkloadDef{
        "triage-bot": {
            Token: "gst_wld_triage-bot-token",
            Providers: map[string]config.WorkloadProviderDef{
                "weather": {Allow: []string{"forecast"}},
            },
        },
    },
}

result, err := bootstrap.Bootstrap(ctx, cfg, factories)
if err != nil {
    return err
}
if _, ok := result.Authorizer.ResolveWorkloadToken("gst_wld_triage-bot-token"); !ok {
    return fmt.Errorf("expected workload token to authenticate")
}
```

Use the workload token over HTTP:

```sh
curl \
  -H "Authorization: Bearer $TRIAGE_BOT_TOKEN" \
  https://gestalt.example.com/api/v1/integrations/github/operations

curl \
  -H "Authorization: Bearer $TRIAGE_BOT_TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{"state":"open"}' \
  https://gestalt.example.com/api/v1/github/list_issues
```

## Validation
- `cd gestaltd && go test ./internal/server -run 'TestAuthMiddleware|TestExecuteOperation|TestListIntegrations|TestListOperations|TestLogout|TestCreateAPIToken|TestAuditMetadata|TestWorkloadAuthorization'`
- `cd gestaltd && go test ./internal/bootstrap -run 'TestBootstrapSecretResolution|TestBootstrapWorkloadAuthorizationRejectsEitherProvider'`
- `cd gestaltd && go test ./internal/invocation ./internal/authorization`
- `cd gestaltd && go test ./internal/server ./internal/bootstrap ./internal/config ./internal/principal ./internal/invocation ./internal/authorization`
- `cd gestaltd && go test ./cmd/gestaltd`

## Notes
- users remain implicitly allow-all at the host-authz layer in v1, while existing human API-token provider scopes continue to apply as an independent coarse gate
- workloads are deny-by-default, authenticate with `gst_wld_` bearer tokens, and may only use explicitly bound `identity` or `none` providers in this phase
