### PR TITLE
Add workload authorization v1 for MCP

### DIFF
--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -386,6 +386,7 @@ func (s mcpSurface) handler(result *bootstrap.Result, invoker invocation.Invoker
 			TokenResolver:    broker,
 			AuditSink:        result.AuditSink,
 			Providers:        result.Providers,
+			Authorizer:       result.Authorizer,
 			AllowedProviders: s.providers,
 			ToolPrefixes:     s.toolPrefixes,
 			MCPConnection:    s.mcpConnection,

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -201,11 +201,17 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	if p.Scopes != nil && !slices.Contains(p.Scopes, providerName) {
 		return fail(fmt.Errorf("%w: %s", ErrScopeDenied, providerName))
 	}
+	if b.authorizer != nil && b.authorizer.IsWorkload(p) {
+		if binding, ok := b.authorizer.Binding(p, providerName); ok {
+			SetCredentialAudit(ctx, binding.Mode, binding.CredentialSubjectID, binding.Connection, binding.Instance)
+		}
+	}
 	if b.authorizer != nil && !b.authorizer.AllowOperation(p, providerName, operation) {
 		return fail(fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operation))
 	}
 
 	conn := ConnectionFromContext(ctx)
+	conn, instance = b.workloadSelectors(p, providerName, conn, instance)
 
 	transport, err := b.resolveTransport(ctx, p, prov, providerName, operation, conn, instance)
 	if err != nil {
@@ -289,6 +295,23 @@ func (b *Broker) mcpConnection(providerName string) string {
 		return b.connMapper.ConnectionForProvider(providerName)
 	}
 	return ""
+}
+
+func (b *Broker) workloadSelectors(p *principal.Principal, providerName, connection, instance string) (string, string) {
+	if b.authorizer == nil || !b.authorizer.IsWorkload(p) {
+		return connection, instance
+	}
+	binding, ok := b.authorizer.Binding(p, providerName)
+	if !ok {
+		return connection, instance
+	}
+	if connection == "" {
+		connection = binding.Connection
+	}
+	if instance == "" {
+		instance = binding.Instance
+	}
+	return connection, instance
 }
 
 func toolResultToOperationResult(result *mcpgo.CallToolResult) (*core.OperationResult, error) {

--- a/gestaltd/internal/invocation/catalog.go
+++ b/gestaltd/internal/invocation/catalog.go
@@ -8,6 +8,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/core/integration"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
@@ -74,4 +75,20 @@ func mergeCatalogs(provName string, staticCat, sessionCat *catalog.Catalog) (*ca
 
 	integration.CompileSchemas(merged)
 	return merged, nil
+}
+
+func FilterCatalogForPrincipal(cat *catalog.Catalog, provName string, p *principal.Principal, authorizer *authorization.Authorizer) *catalog.Catalog {
+	if cat == nil || authorizer == nil || !authorizer.IsWorkload(p) {
+		return cat
+	}
+
+	filtered := cat.Clone()
+	ops := filtered.Operations[:0]
+	for i := range filtered.Operations {
+		if authorizer.AllowOperation(p, provName, filtered.Operations[i].ID) {
+			ops = append(ops, filtered.Operations[i])
+		}
+	}
+	filtered.Operations = ops
+	return filtered
 }

--- a/gestaltd/internal/invocation/guarded.go
+++ b/gestaltd/internal/invocation/guarded.go
@@ -2,6 +2,7 @@ package invocation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -104,7 +105,14 @@ func (g *GuardedInvoker) Invoke(ctx context.Context, p *principal.Principal, pro
 	}
 	ctx = ContextWithMeta(ctx, next)
 
-	return g.inner.Invoke(ctx, p, providerName, instance, operation, params)
+	result, err := g.inner.Invoke(ctx, p, providerName, instance, operation, params)
+	if err != nil {
+		entry.Error = err.Error()
+		if errors.Is(err, ErrAuthorizationDenied) || errors.Is(err, ErrScopeDenied) || errors.Is(err, ErrNotAuthenticated) {
+			entry.Allowed = false
+		}
+	}
+	return result, err
 }
 
 func (g *GuardedInvoker) ListCapabilities() []core.Capability {

--- a/gestaltd/internal/mcp/authorization.go
+++ b/gestaltd/internal/mcp/authorization.go
@@ -1,0 +1,54 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
+
+func allowOperation(cfg Config, p *principal.Principal, provider, operation string) bool {
+	if cfg.Authorizer == nil {
+		return true
+	}
+	return cfg.Authorizer.AllowOperation(p, provider, operation)
+}
+
+func toolTarget(cfg Config, providers []string, name string) (provider, operation string, ok bool) {
+	provider = providerNameForTool(cfg.ToolPrefixes, providers, name)
+	if provider == "" {
+		return "", "", false
+	}
+
+	prefix := toolName(cfg.ToolPrefixes, provider, "")
+	if !strings.HasPrefix(name, prefix) || len(name) <= len(prefix) {
+		return "", "", false
+	}
+	return provider, strings.TrimPrefix(name, prefix), true
+}
+
+func filterVisibleTools(ctx context.Context, cfg Config, providers []string, result *mcpgo.ListToolsResult) {
+	if result == nil {
+		return
+	}
+
+	p := principal.FromContext(ctx)
+	workload := cfg.Authorizer != nil && cfg.Authorizer.IsWorkload(p)
+
+	tools := result.Tools[:0]
+	for i := range result.Tools {
+		if isHydrationMarkerTool(result.Tools[i].Name) {
+			continue
+		}
+		if workload {
+			provider, operation, ok := toolTarget(cfg, providers, result.Tools[i].Name)
+			if ok && !allowOperation(cfg, p, provider, operation) {
+				continue
+			}
+		}
+		tools = append(tools, result.Tools[i])
+	}
+	result.Tools = tools
+}

--- a/gestaltd/internal/mcp/binding.go
+++ b/gestaltd/internal/mcp/binding.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 
@@ -22,6 +23,7 @@ type Config struct {
 	TokenResolver    invocation.TokenResolver
 	AuditSink        core.AuditSink
 	Providers        *registry.ProviderMap[core.Provider]
+	Authorizer       *authorization.Authorizer
 	AllowedProviders []string
 	ToolPrefixes     map[string]string
 	IncludeREST      map[string]bool
@@ -42,6 +44,8 @@ func NewServer(cfg Config) *mcpserver.MCPServer {
 		allowed[p] = struct{}{}
 	}
 
+	staticToolNames := map[string]struct{}{}
+	visibleProviders := make([]string, 0, len(cfg.Providers.List()))
 	var dynamicProviders []string
 	for _, provName := range cfg.Providers.List() {
 		if cfg.AllowedProviders != nil {
@@ -60,20 +64,27 @@ func NewServer(cfg Config) *mcpserver.MCPServer {
 		}
 
 		if cat := prov.Catalog(); cat != nil {
+			for name := range buildToolMap(cfg, provName, cat) {
+				staticToolNames[name] = struct{}{}
+			}
 			addCatalogTools(srv, cfg, provName, cat)
 		}
+		visibleProviders = append(visibleProviders, provName)
 	}
 
 	if len(dynamicProviders) > 0 {
 		hooks.AddBeforeListTools(func(ctx context.Context, _ any, _ *mcpgo.ListToolsRequest) {
-			hydrateSessionTools(ctx, cfg, dynamicProviders)
+			hydrateSessionTools(ctx, cfg, dynamicProviders, staticToolNames)
 		})
 		hooks.AddBeforeCallTool(func(ctx context.Context, _ any, req *mcpgo.CallToolRequest) {
 			if provName := providerNameForTool(cfg.ToolPrefixes, dynamicProviders, req.Params.Name); provName != "" {
-				hydrateSessionTools(ctx, cfg, []string{provName})
+				hydrateSessionTools(ctx, cfg, []string{provName}, staticToolNames)
 			}
 		})
 	}
+	hooks.AddAfterListTools(func(ctx context.Context, _ any, _ *mcpgo.ListToolsRequest, result *mcpgo.ListToolsResult) {
+		filterVisibleTools(ctx, cfg, visibleProviders, result)
+	})
 
 	return srv
 }

--- a/gestaltd/internal/mcp/binding_test.go
+++ b/gestaltd/internal/mcp/binding_test.go
@@ -5,13 +5,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coreintegration "github.com/valon-technologies/gestalt/server/core/integration"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/composite"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
@@ -19,6 +22,7 @@ import (
 	gestaltmcp "github.com/valon-technologies/gestalt/server/internal/mcp"
 	"github.com/valon-technologies/gestalt/server/internal/mcpupstream"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -134,6 +138,24 @@ func ctxWithIdentityPrincipal(email, userID string) context.Context {
 	return principal.WithPrincipal(context.Background(), p)
 }
 
+func ctxWithWorkloadPrincipal(workloadID string) context.Context {
+	p := &principal.Principal{
+		Kind:      principal.KindWorkload,
+		SubjectID: principal.WorkloadSubjectID(workloadID),
+		Source:    principal.SourceWorkloadToken,
+	}
+	return principal.WithPrincipal(context.Background(), p)
+}
+
+func mustAuthorizer(t *testing.T, cfg config.AuthorizationConfig, providers *registry.ProviderMap[core.Provider]) *authorization.Authorizer {
+	t.Helper()
+	authz, err := authorization.New(cfg, nil, providers, map[string]string{})
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+	return authz
+}
+
 type testSessionWithTools struct {
 	id            string
 	initialized   bool
@@ -143,10 +165,14 @@ type testSessionWithTools struct {
 
 func newTestSessionWithTools() *testSessionWithTools {
 	return &testSessionWithTools{
-		id:            "session-1",
+		id:            fmt.Sprintf("session-%d", time.Now().UnixNano()),
 		initialized:   true,
 		notifications: make(chan mcpgo.JSONRPCNotification, 1),
 	}
+}
+
+func hydrationMarkerToolName(provider string) string {
+	return "__gestalt_internal_hydrated__:" + provider
 }
 
 func (s *testSessionWithTools) Initialize() { s.initialized = true }
@@ -776,6 +802,424 @@ func TestNewServer_DirectCallerPassthrough(t *testing.T) {
 	}
 	if text.Text != "query result" {
 		t.Fatalf("expected direct passthrough result, got %q", text.Text)
+	}
+}
+
+func TestNewServer_WorkloadListToolsFiltersStaticAndSessionTools(t *testing.T) {
+	t.Parallel()
+
+	staticCat := &catalog.Catalog{
+		Name: "clickhouse",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:          "run_query",
+				Description: "static query",
+				Transport:   catalog.TransportMCPPassthrough,
+			},
+			{
+				ID:          "delete_table",
+				Description: "delete a table",
+				Transport:   catalog.TransportMCPPassthrough,
+			},
+		},
+	}
+
+	sessionCat := &catalog.Catalog{
+		Name: "clickhouse",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:          "run_query",
+				Description: "session query",
+				Transport:   catalog.TransportMCPPassthrough,
+			},
+			{
+				ID:          "list_databases",
+				Description: "list databases",
+				Transport:   catalog.TransportMCPPassthrough,
+			},
+			{
+				ID:          "drop_database",
+				Description: "drop a database",
+				Transport:   catalog.TransportMCPPassthrough,
+			},
+		},
+	}
+
+	prov := &directCallerProvider{
+		StubIntegration: coretesting.StubIntegration{N: "clickhouse", ConnMode: core.ConnectionModeIdentity},
+		cat:             staticCat,
+		sessionCatalogFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			if token != "identity-token" {
+				t.Fatalf("session catalog token = %q, want %q", token, "identity-token")
+			}
+			return sessionCat, nil
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, prov)
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Workloads: map[string]config.WorkloadDef{
+			"triage-bot": {
+				Token: "gst_wld_triage-bot-token",
+				Providers: map[string]config.WorkloadProviderDef{
+					"clickhouse": {
+						Connection: "workspace",
+						Instance:   "team-a",
+						Allow:      []string{"run_query", "list_databases"},
+					},
+				},
+			},
+		},
+	}, providers)
+
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker: &testutil.StubInvoker{
+			InvokeFn: func(context.Context, *principal.Principal, string, string, string, map[string]any) (*core.OperationResult, error) {
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		TokenResolver: &stubTokenResolver{
+			resolveFn: func(_ context.Context, p *principal.Principal, providerName, connection, instance string) (string, error) {
+				if p == nil || p.Kind != principal.KindWorkload {
+					t.Fatalf("expected workload principal, got %+v", p)
+				}
+				if providerName != "clickhouse" {
+					t.Fatalf("providerName = %q, want %q", providerName, "clickhouse")
+				}
+				if connection != "workspace" || instance != "team-a" {
+					t.Fatalf("unexpected session hydration selector inputs: connection=%q instance=%q", connection, instance)
+				}
+				return "identity-token", nil
+			},
+		},
+		Providers:     providers,
+		Authorizer:    authz,
+		MCPConnection: map[string]string{"clickhouse": "default"},
+	})
+
+	session := newTestSessionWithTools()
+	result := listToolsForSession(t, srv, ctxWithWorkloadPrincipal("triage-bot"), session)
+
+	names := make([]string, 0, len(result.Tools))
+	descriptions := map[string]string{}
+	for _, tool := range result.Tools {
+		names = append(names, tool.Name)
+		descriptions[tool.Name] = tool.Description
+	}
+	sort.Strings(names)
+
+	if !reflect.DeepEqual(names, []string{"clickhouse_list_databases", "clickhouse_run_query"}) {
+		t.Fatalf("tool names = %v, want %v", names, []string{"clickhouse_list_databases", "clickhouse_run_query"})
+	}
+	if descriptions["clickhouse_run_query"] != "static query" {
+		t.Fatalf("run_query description = %q, want %q", descriptions["clickhouse_run_query"], "static query")
+	}
+	sessionTools := session.GetSessionTools()
+	if _, ok := sessionTools["clickhouse_run_query"]; ok {
+		t.Fatal("expected static tool collision to keep global tool and skip session override")
+	}
+	if _, ok := sessionTools["clickhouse_list_databases"]; !ok {
+		t.Fatal("expected allowed session-only tool to remain registered for the session")
+	}
+	if _, ok := sessionTools["clickhouse_drop_database"]; !ok {
+		t.Fatal("expected denied session-only tool to remain registered for call-time authorization")
+	}
+	if _, ok := sessionTools[hydrationMarkerToolName("clickhouse")]; !ok {
+		t.Fatal("expected hydration marker to remain in session tool state")
+	}
+}
+
+func TestNewServer_WorkloadCallToolDeniedReturnsErrorResult(t *testing.T) {
+	t.Parallel()
+
+	var sessionCatalogCalls int
+	var called bool
+	prov := &directCallerProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "clickhouse",
+			ConnMode: core.ConnectionModeNone,
+		},
+		sessionCatalogFn: func(_ context.Context, _ string) (*catalog.Catalog, error) {
+			sessionCatalogCalls++
+			return &catalog.Catalog{
+				Name: "clickhouse",
+				Operations: []catalog.CatalogOperation{
+					{
+						ID:          "run_query",
+						Description: "run a query",
+						Transport:   catalog.TransportMCPPassthrough,
+					},
+					{
+						ID:          "delete_table",
+						Description: "delete a table",
+						Transport:   catalog.TransportMCPPassthrough,
+					},
+				},
+			}, nil
+		},
+		callFn: func(_ context.Context, _ string, _ map[string]any) (*mcpgo.CallToolResult, error) {
+			called = true
+			return mcpgo.NewToolResultText("unexpected provider call"), nil
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, prov)
+	ds := coretesting.NewStubServices(t)
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Workloads: map[string]config.WorkloadDef{
+			"triage-bot": {
+				Token: "gst_wld_triage-bot-token",
+				Providers: map[string]config.WorkloadProviderDef{
+					"clickhouse": {
+						Allow: []string{"run_query"},
+					},
+				},
+			},
+		},
+	}, providers)
+
+	broker := invocation.NewBroker(providers, ds.Users, ds.Tokens, invocation.WithAuthorizer(authz))
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker:    broker,
+		Providers:  providers,
+		Authorizer: authz,
+	})
+
+	result := callToolForSession(t, srv, ctxWithWorkloadPrincipal("triage-bot"), newTestSessionWithTools(), "clickhouse_delete_table", map[string]any{"table": "users"})
+	if !result.IsError {
+		t.Fatalf("expected MCP error result, got %+v", result)
+	}
+	text, ok := result.Content[0].(mcpgo.TextContent)
+	if !ok || text.Text != "operation access denied" {
+		t.Fatalf("unexpected MCP error content: %+v", result.Content)
+	}
+	if called {
+		t.Fatal("expected denied tool call to stop before provider execution")
+	}
+	if sessionCatalogCalls != 1 {
+		t.Fatalf("session catalog calls = %d, want %d", sessionCatalogCalls, 1)
+	}
+}
+
+func TestNewServer_WorkloadCallToolDeniedForUnboundSessionOnlyProvider(t *testing.T) {
+	t.Parallel()
+
+	var sessionCatalogCalls int
+	var called bool
+	prov := &directCallerProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "clickhouse",
+			ConnMode: core.ConnectionModeNone,
+		},
+		sessionCatalogFn: func(_ context.Context, _ string) (*catalog.Catalog, error) {
+			sessionCatalogCalls++
+			return &catalog.Catalog{
+				Name: "clickhouse",
+				Operations: []catalog.CatalogOperation{
+					{
+						ID:          "run_query",
+						Description: "run a query",
+						Transport:   catalog.TransportMCPPassthrough,
+					},
+				},
+			}, nil
+		},
+		callFn: func(_ context.Context, _ string, _ map[string]any) (*mcpgo.CallToolResult, error) {
+			called = true
+			return mcpgo.NewToolResultText("unexpected provider call"), nil
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, prov)
+	ds := coretesting.NewStubServices(t)
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Workloads: map[string]config.WorkloadDef{
+			"triage-bot": {
+				Token: "gst_wld_triage-bot-token",
+			},
+		},
+	}, providers)
+
+	broker := invocation.NewBroker(providers, ds.Users, ds.Tokens, invocation.WithAuthorizer(authz))
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker:    broker,
+		Providers:  providers,
+		Authorizer: authz,
+	})
+
+	session := newTestSessionWithTools()
+	result := callToolForSession(t, srv, ctxWithWorkloadPrincipal("triage-bot"), session, "clickhouse_run_query", map[string]any{"sql": "select 1"})
+	if !result.IsError {
+		t.Fatalf("expected MCP error result, got %+v", result)
+	}
+	text, ok := result.Content[0].(mcpgo.TextContent)
+	if !ok || text.Text != "operation access denied" {
+		t.Fatalf("unexpected MCP error content: %+v", result.Content)
+	}
+	if called {
+		t.Fatal("expected denied tool call to stop before provider execution")
+	}
+	if sessionCatalogCalls != 1 {
+		t.Fatalf("session catalog calls = %d, want %d", sessionCatalogCalls, 1)
+	}
+	if _, ok := session.GetSessionTools()["clickhouse_run_query"]; !ok {
+		t.Fatal("expected hidden session-only tool to remain registered for call-time authorization")
+	}
+}
+
+func TestNewServer_WorkloadCallToolUsesBoundConnectionForSessionOnlyProvider(t *testing.T) {
+	t.Parallel()
+
+	var sessionCatalogCalls int
+	var called bool
+	prov := &directCallerProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "clickhouse",
+			ConnMode: core.ConnectionModeIdentity,
+		},
+		sessionCatalogFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			sessionCatalogCalls++
+			if token != "identity-token" {
+				t.Fatalf("session catalog token = %q, want %q", token, "identity-token")
+			}
+			return &catalog.Catalog{
+				Name: "clickhouse",
+				Operations: []catalog.CatalogOperation{
+					{
+						ID:          "run_query",
+						Description: "run a query",
+						Transport:   catalog.TransportMCPPassthrough,
+					},
+				},
+			}, nil
+		},
+		callFn: func(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
+			called = true
+			if name != "run_query" {
+				t.Fatalf("name = %q, want %q", name, "run_query")
+			}
+			if token := mcpupstream.UpstreamTokenFromContext(ctx); token != "identity-token" {
+				t.Fatalf("upstream token = %q, want %q", token, "identity-token")
+			}
+			if sql, _ := args["sql"].(string); sql != "select 1" {
+				t.Fatalf("sql = %q, want %q", sql, "select 1")
+			}
+			return mcpgo.NewToolResultText("ok"), nil
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, prov)
+	ds := coretesting.NewStubServices(t)
+	ctx := context.Background()
+	if err := ds.Tokens.StoreToken(ctx, &core.IntegrationToken{
+		ID:          "tok-identity",
+		UserID:      principal.IdentityPrincipal,
+		Integration: "clickhouse",
+		Connection:  "workspace",
+		Instance:    "team-a",
+		AccessToken: "identity-token",
+	}); err != nil {
+		t.Fatalf("StoreToken: %v", err)
+	}
+
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Workloads: map[string]config.WorkloadDef{
+			"triage-bot": {
+				Token: "gst_wld_triage-bot-token",
+				Providers: map[string]config.WorkloadProviderDef{
+					"clickhouse": {
+						Connection: "workspace",
+						Instance:   "team-a",
+						Allow:      []string{"run_query"},
+					},
+				},
+			},
+		},
+	}, providers)
+
+	broker := invocation.NewBroker(providers, ds.Users, ds.Tokens, invocation.WithAuthorizer(authz))
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker:       broker,
+		TokenResolver: broker,
+		Providers:     providers,
+		Authorizer:    authz,
+		MCPConnection: map[string]string{"clickhouse": "default"},
+	})
+
+	result := callToolForSession(t, srv, ctxWithWorkloadPrincipal("triage-bot"), newTestSessionWithTools(), "clickhouse_run_query", map[string]any{"sql": "select 1"})
+	if result.IsError {
+		t.Fatalf("expected success result, got %+v", result)
+	}
+	text, ok := result.Content[0].(mcpgo.TextContent)
+	if !ok || text.Text != "ok" {
+		t.Fatalf("unexpected MCP success content: %+v", result.Content)
+	}
+	if !called {
+		t.Fatal("expected workload tool call to reach provider")
+	}
+	if sessionCatalogCalls != 2 {
+		t.Fatalf("session catalog calls = %d, want %d", sessionCatalogCalls, 2)
+	}
+}
+
+func TestNewServer_DynamicCatalogProviderDoesNotRehydrateAfterExactCollisionOnly(t *testing.T) {
+	t.Parallel()
+
+	var sessionCatalogCalls int
+	prov := &directCallerProvider{
+		StubIntegration: coretesting.StubIntegration{N: "clickhouse", ConnMode: core.ConnectionModeNone},
+		cat: &catalog.Catalog{
+			Name: "clickhouse",
+			Operations: []catalog.CatalogOperation{
+				{
+					ID:          "run_query",
+					Description: "static query",
+					Transport:   catalog.TransportMCPPassthrough,
+				},
+			},
+		},
+		sessionCatalogFn: func(_ context.Context, _ string) (*catalog.Catalog, error) {
+			sessionCatalogCalls++
+			return &catalog.Catalog{
+				Name: "clickhouse",
+				Operations: []catalog.CatalogOperation{
+					{
+						ID:          "run_query",
+						Description: "session query",
+						Transport:   catalog.TransportMCPPassthrough,
+					},
+				},
+			}, nil
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, prov)
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker:   &testutil.StubInvoker{},
+		Providers: providers,
+	})
+
+	session := newTestSessionWithTools()
+	ctx := ctxWithPrincipal("stub-user-id")
+
+	first := listToolsForSession(t, srv, ctx, session)
+	second := listToolsForSession(t, srv, ctx, session)
+
+	if sessionCatalogCalls != 1 {
+		t.Fatalf("session catalog calls = %d, want %d", sessionCatalogCalls, 1)
+	}
+	if len(first.Tools) != 1 || first.Tools[0].Name != "clickhouse_run_query" {
+		t.Fatalf("first tools = %+v, want only clickhouse_run_query", first.Tools)
+	}
+	if len(second.Tools) != 1 || second.Tools[0].Name != "clickhouse_run_query" {
+		t.Fatalf("second tools = %+v, want only clickhouse_run_query", second.Tools)
+	}
+	tools := session.GetSessionTools()
+	if len(tools) != 1 {
+		t.Fatalf("session tools = %+v, want only hydration marker after exact collision hydration", tools)
+	}
+	if _, ok := tools[hydrationMarkerToolName("clickhouse")]; !ok {
+		t.Fatalf("session tools = %+v, want hydration marker after exact collision hydration", tools)
 	}
 }
 

--- a/gestaltd/internal/mcp/handlers.go
+++ b/gestaltd/internal/mcp/handlers.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
@@ -29,6 +30,9 @@ func makeHandler(invoker invocation.Invoker, provName, opName, connection string
 		ctx = mcpupstream.WithCallToolMeta(ctx, req.Params.Meta)
 		result, err := invoker.Invoke(ctx, p, provName, instance, opName, args)
 		if err != nil {
+			if errors.Is(err, invocation.ErrAuthorizationDenied) || errors.Is(err, invocation.ErrScopeDenied) {
+				return mcpgo.NewToolResultError("operation access denied"), nil
+			}
 			return mcpgo.NewToolResultError(err.Error()), nil
 		}
 		if result == nil {

--- a/gestaltd/internal/mcp/session_tools.go
+++ b/gestaltd/internal/mcp/session_tools.go
@@ -3,15 +3,17 @@ package mcp
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 )
 
-func hydrateSessionTools(ctx context.Context, cfg Config, providerNames []string) {
+const hydrationMarkerPrefix = "__gestalt_internal_hydrated__:"
+
+func hydrateSessionTools(ctx context.Context, cfg Config, providerNames []string, staticToolNames map[string]struct{}) {
 	session := mcpserver.ClientSessionFromContext(ctx)
 	if session == nil {
 		return
@@ -28,8 +30,7 @@ func hydrateSessionTools(ctx context.Context, cfg Config, providerNames []string
 
 	changed := false
 	for _, provName := range providerNames {
-		prefix := toolName(cfg.ToolPrefixes, provName, "")
-		if hasToolsWithPrefix(tools, prefix) {
+		if sessionProviderHydrated(tools, provName) {
 			continue
 		}
 
@@ -49,12 +50,21 @@ func hydrateSessionTools(ctx context.Context, cfg Config, providerNames []string
 		}
 
 		cat, err := scp.CatalogForRequest(ctx, token)
-		if err != nil || cat == nil {
+		if err != nil {
+			continue
+		}
+		if markSessionProviderHydrated(tools, provName) {
+			changed = true
+		}
+		if cat == nil {
 			continue
 		}
 
 		m := buildToolMap(cfg, provName, cat)
 		for name := range m {
+			if _, exists := staticToolNames[name]; exists {
+				continue
+			}
 			tools[name] = m[name]
 		}
 		changed = true
@@ -65,15 +75,6 @@ func hydrateSessionTools(ctx context.Context, cfg Config, providerNames []string
 	}
 }
 
-func hasToolsWithPrefix(tools map[string]mcpserver.ServerTool, prefix string) bool {
-	for name := range tools {
-		if strings.HasPrefix(name, prefix) {
-			return true
-		}
-	}
-	return false
-}
-
 func resolveSessionToken(ctx context.Context, cfg Config, provName string, prov core.Provider) (string, error) {
 	if cfg.TokenResolver == nil || prov.ConnectionMode() == core.ConnectionModeNone {
 		return "", nil
@@ -82,5 +83,44 @@ func resolveSessionToken(ctx context.Context, cfg Config, provName string, prov 
 	if p == nil {
 		return "", fmt.Errorf("not authenticated")
 	}
-	return cfg.TokenResolver.ResolveToken(ctx, p, provName, cfg.MCPConnection[provName], "")
+	connection, instance := sessionTokenSelectors(cfg, p, provName)
+	return cfg.TokenResolver.ResolveToken(ctx, p, provName, connection, instance)
+}
+
+func sessionProviderHydrated(tools map[string]mcpserver.ServerTool, provider string) bool {
+	_, ok := tools[hydrationMarkerName(provider)]
+	return ok
+}
+
+func markSessionProviderHydrated(tools map[string]mcpserver.ServerTool, provider string) bool {
+	name := hydrationMarkerName(provider)
+	if _, ok := tools[name]; ok {
+		return false
+	}
+	tools[name] = mcpserver.ServerTool{
+		Tool: mcpgo.NewTool(name, mcpgo.WithDescription("gestalt internal hydration marker")),
+		Handler: func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+			return mcpgo.NewToolResultError("tool not found"), nil
+		},
+	}
+	return true
+}
+
+func hydrationMarkerName(provider string) string {
+	return hydrationMarkerPrefix + provider
+}
+
+func isHydrationMarkerTool(name string) bool {
+	return len(name) > len(hydrationMarkerPrefix) && name[:len(hydrationMarkerPrefix)] == hydrationMarkerPrefix
+}
+
+func sessionTokenSelectors(cfg Config, p *principal.Principal, provName string) (string, string) {
+	connection := cfg.MCPConnection[provName]
+	if cfg.Authorizer == nil || !cfg.Authorizer.IsWorkload(p) {
+		return connection, ""
+	}
+	if binding, ok := cfg.Authorizer.Binding(p, provName); ok {
+		return binding.Connection, binding.Instance
+	}
+	return connection, ""
 }

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -9,8 +9,11 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
+	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
 )
 
 type stubProvider struct {
@@ -234,6 +237,75 @@ func TestResolveCatalog_SameIDCollision_StaticWins(t *testing.T) {
 	}
 	if cat.Operations[0].Method != http.MethodGet {
 		t.Fatalf("expected GET from static, got %q", cat.Operations[0].Method)
+	}
+}
+
+func TestFilterCatalogForPrincipal_WorkloadFilteringUsesMergedCatalog(t *testing.T) {
+	t.Parallel()
+
+	prov := &stubSessionProvider{
+		stubCatalogProvider: stubCatalogProvider{
+			stubProvider: stubProvider{
+				name:     "clash-api",
+				connMode: core.ConnectionModeIdentity,
+			},
+			cat: &catalog.Catalog{
+				Name: "clash-api",
+				Operations: []catalog.CatalogOperation{
+					{ID: "shared_op", Method: http.MethodGet, Transport: catalog.TransportREST, Description: "static version"},
+					{ID: "static_only", Method: http.MethodGet, Transport: catalog.TransportREST},
+				},
+			},
+		},
+		sessionCat: &catalog.Catalog{
+			Name: "clash-api",
+			Operations: []catalog.CatalogOperation{
+				{ID: "shared_op", Method: http.MethodPost, Transport: catalog.TransportMCPPassthrough, Description: "session version"},
+				{ID: "session_only", Method: http.MethodPost, Transport: catalog.TransportMCPPassthrough},
+			},
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, prov)
+	authz, err := authorization.New(config.AuthorizationConfig{
+		Workloads: map[string]config.WorkloadDef{
+			"triage-bot": {
+				Token: "gst_wld_triage-bot-token",
+				Providers: map[string]config.WorkloadProviderDef{
+					"clash-api": {
+						Connection: "default",
+						Instance:   "default",
+						Allow:      []string{"shared_op", "session_only"},
+					},
+				},
+			},
+		},
+	}, nil, providers, map[string]string{"clash-api": "default"})
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+
+	p := &principal.Principal{
+		Kind:      principal.KindWorkload,
+		SubjectID: principal.WorkloadSubjectID("triage-bot"),
+	}
+	cat, err := invocation.ResolveCatalog(context.Background(), prov, "clash-api", &stubTokenResolver{token: "tok_456"}, p, "default", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	filtered := invocation.FilterCatalogForPrincipal(cat, "clash-api", p, authz)
+	if len(filtered.Operations) != 2 {
+		t.Fatalf("expected 2 operations after workload filtering, got %d", len(filtered.Operations))
+	}
+	if filtered.Operations[0].ID != "shared_op" {
+		t.Fatalf("expected first filtered op shared_op, got %q", filtered.Operations[0].ID)
+	}
+	if filtered.Operations[0].Description != "static version" {
+		t.Fatalf("expected static version to win after filtering, got %q", filtered.Operations[0].Description)
+	}
+	if filtered.Operations[1].ID != "session_only" {
+		t.Fatalf("expected second filtered op session_only, got %q", filtered.Operations[1].ID)
 	}
 }
 

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -469,16 +469,8 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 		s.writeInvocationError(w, r, name, "", err)
 		return
 	}
+	cat = invocation.FilterCatalogForPrincipal(cat, name, p, s.authorizer)
 	ops := httpVisibleCatalogOperations(cat.Operations)
-	if p != nil && p.Kind == principal.KindWorkload {
-		filtered := ops[:0]
-		for i := range ops {
-			if s.allowOperation(p, name, ops[i].ID) {
-				filtered = append(filtered, ops[i])
-			}
-		}
-		ops = filtered
-	}
 	sort.Slice(ops, func(i, j int) bool {
 		return ops[i].ID < ops[j].ID
 	})

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -6165,20 +6165,25 @@ func TestRefresh_UsesConnectionAuth(t *testing.T) {
 	}
 }
 
-func newMCPHandler(t *testing.T, providers *registry.ProviderMap[core.Provider], svc *coredata.Services, auditSink core.AuditSink) http.Handler {
+func newMCPHandler(t *testing.T, providers *registry.ProviderMap[core.Provider], svc *coredata.Services, auditSink core.AuditSink, authorizer *authorization.Authorizer) http.Handler {
 	t.Helper()
-	broker := invocation.NewBroker(providers, svc.Users, svc.Tokens)
+	brokerOpts := []invocation.BrokerOption{}
+	if authorizer != nil {
+		brokerOpts = append(brokerOpts, invocation.WithAuthorizer(authorizer))
+	}
+	broker := invocation.NewBroker(providers, svc.Users, svc.Tokens, brokerOpts...)
 	mcpInvoker := invocation.NewGuarded(broker, broker, "mcp", auditSink)
 	srv := gestaltmcp.NewServer(gestaltmcp.Config{
 		Invoker:       mcpInvoker,
 		TokenResolver: broker,
 		AuditSink:     auditSink,
 		Providers:     providers,
+		Authorizer:    authorizer,
 	})
 	return mcpserver.NewStreamableHTTPServer(srv, mcpserver.WithStateLess(true))
 }
 
-func mcpJSONRPC(t *testing.T, ts *httptest.Server, headers map[string]string, body map[string]any) (int, map[string]any) {
+func mcpJSONRPCWithHeaders(t *testing.T, ts *httptest.Server, headers map[string]string, body map[string]any) (int, map[string]any, http.Header) {
 	t.Helper()
 	payload, _ := json.Marshal(body)
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/mcp", bytes.NewReader(payload))
@@ -6198,7 +6203,13 @@ func mcpJSONRPC(t *testing.T, ts *httptest.Server, headers map[string]string, bo
 			t.Fatalf("decoding MCP response: %v\nbody: %s", err, raw)
 		}
 	}
-	return resp.StatusCode, result
+	return resp.StatusCode, result, resp.Header.Clone()
+}
+
+func mcpJSONRPC(t *testing.T, ts *httptest.Server, headers map[string]string, body map[string]any) (int, map[string]any) {
+	t.Helper()
+	status, result, _ := mcpJSONRPCWithHeaders(t, ts, headers, body)
+	return status, result
 }
 
 func TestMCPEndpoint_InitializeAndListTools(t *testing.T) {
@@ -6212,7 +6223,7 @@ func TestMCPEndpoint_InitializeAndListTools(t *testing.T) {
 	}
 	svc := coretesting.NewStubServices(t)
 	providers := testutil.NewProviderRegistry(t, stub)
-	mcpHandler := newMCPHandler(t, providers, svc, nil)
+	mcpHandler := newMCPHandler(t, providers, svc, nil, nil)
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = providers
@@ -6272,7 +6283,7 @@ func TestMCPEndpoint_RequiresAuth(t *testing.T) {
 		return &reg.Providers
 	}()
 	svc := coretesting.NewStubServices(t)
-	mcpHandler := newMCPHandler(t, providers, svc, nil)
+	mcpHandler := newMCPHandler(t, providers, svc, nil, nil)
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
@@ -6340,7 +6351,7 @@ func TestMCPEndpoint_DirectPassthrough(t *testing.T) {
 
 	svc := coretesting.NewStubServices(t)
 	providers := testutil.NewProviderRegistry(t, prov)
-	mcpHandler := newMCPHandler(t, providers, svc, auditSink)
+	mcpHandler := newMCPHandler(t, providers, svc, auditSink, nil)
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -6491,6 +6502,188 @@ func TestMCPEndpoint_DirectPassthrough(t *testing.T) {
 	structured, ok := result["structuredContent"].(map[string]any)
 	if !ok || structured["code"] != "bad_query" {
 		t.Fatalf("expected structuredContent.code=bad_query, got %v", result["structuredContent"])
+	}
+}
+
+func TestMCPEndpoint_WorkloadAuthorizationAndAudit(t *testing.T) {
+	t.Parallel()
+
+	staticCat := &catalog.Catalog{
+		Name: "clickhouse",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:          "run_query",
+				Description: "Execute a SQL query",
+				Transport:   catalog.TransportMCPPassthrough,
+			},
+			{
+				ID:          "delete_table",
+				Description: "Delete a table",
+				Transport:   catalog.TransportMCPPassthrough,
+			},
+		},
+	}
+
+	var auditBuf bytes.Buffer
+	var calledName string
+	auditSink := invocation.NewSlogAuditSink(&auditBuf)
+	prov := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "clickhouse", ConnMode: core.ConnectionModeIdentity},
+			ops: []core.Operation{
+				{Name: "run_query", Description: "Execute a SQL query"},
+				{Name: "delete_table", Description: "Delete a table"},
+			},
+		},
+		catalog: staticCat,
+		callFn: func(_ context.Context, name string, _ map[string]any) (*mcpgo.CallToolResult, error) {
+			calledName = name
+			return mcpgo.NewToolResultText("unexpected"), nil
+		},
+	}
+
+	svc := coretesting.NewStubServices(t)
+	seedIdentityToken(t, svc, "clickhouse", "default", "default", "identity-token")
+
+	providers := testutil.NewProviderRegistry(t, prov)
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Workloads: map[string]config.WorkloadDef{
+			"triage-bot": {
+				Token: "gst_wld_triage-bot-token",
+				Providers: map[string]config.WorkloadProviderDef{
+					"clickhouse": {
+						Connection: "default",
+						Instance:   "default",
+						Allow:      []string{"run_query"},
+					},
+				},
+			},
+		},
+	}, providers, nil, nil)
+	mcpHandler := newMCPHandler(t, providers, svc, auditSink, authz)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{N: "stub"}
+		cfg.Providers = providers
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.MCPHandler = mcpHandler
+	})
+	defer ts.Close()
+
+	headers := map[string]string{
+		"Authorization": "Bearer gst_wld_triage-bot-token",
+	}
+
+	_, _, initHeaders := mcpJSONRPCWithHeaders(t, ts, headers, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-03-26",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+		},
+	})
+	if sessionID := initHeaders.Get("Mcp-Session-Id"); sessionID != "" {
+		headers["Mcp-Session-Id"] = sessionID
+	}
+
+	status, resp := mcpJSONRPC(t, ts, headers, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/list",
+	})
+	if status != http.StatusOK {
+		t.Fatalf("tools/list: expected 200, got %d", status)
+	}
+	result, ok := resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("tools/list: expected result object, got %v", resp)
+	}
+	tools, ok := result["tools"].([]any)
+	if !ok {
+		t.Fatalf("tools/list: expected tools array, got %v", result)
+	}
+	names := make([]string, 0, len(tools))
+	for _, raw := range tools {
+		names = append(names, raw.(map[string]any)["name"].(string))
+	}
+	if !reflect.DeepEqual(names, []string{"clickhouse_run_query"}) {
+		t.Fatalf("tools/list names = %v, want %v", names, []string{"clickhouse_run_query"})
+	}
+
+	status, resp = mcpJSONRPC(t, ts, headers, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      3,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "clickhouse_delete_table",
+			"arguments": map[string]any{"table": "users"},
+		},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("tools/call: expected 200, got %d", status)
+	}
+	result, ok = resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("tools/call: expected result object, got %v", resp)
+	}
+	if result["isError"] != true {
+		t.Fatalf("expected MCP error result, got %v", result["isError"])
+	}
+	content, ok := result["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatalf("expected MCP error content, got %v", result)
+	}
+	firstText, ok := content[0].(map[string]any)
+	if !ok || firstText["text"] != "operation access denied" {
+		t.Fatalf("unexpected MCP error content: %v", content)
+	}
+	if calledName != "" {
+		t.Fatalf("expected denied tool call to stop before provider CallTool, got %q", calledName)
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+	if len(lines) == 0 {
+		t.Fatal("expected MCP audit record")
+	}
+	var auditRecord map[string]any
+	if err := json.Unmarshal(lines[len(lines)-1], &auditRecord); err != nil {
+		t.Fatalf("parsing MCP audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["source"] != "mcp" {
+		t.Fatalf("expected audit source mcp, got %v", auditRecord["source"])
+	}
+	if auditRecord["provider"] != "clickhouse" {
+		t.Fatalf("expected audit provider clickhouse, got %v", auditRecord["provider"])
+	}
+	if auditRecord["operation"] != "delete_table" {
+		t.Fatalf("expected audit operation delete_table, got %v", auditRecord["operation"])
+	}
+	if auditRecord["allowed"] != false {
+		t.Fatalf("expected audit allowed=false, got %v", auditRecord["allowed"])
+	}
+	if auditRecord["auth_source"] != "workload_token" {
+		t.Fatalf("expected audit auth_source workload_token, got %v", auditRecord["auth_source"])
+	}
+	if auditRecord["subject_id"] != "workload:triage-bot" {
+		t.Fatalf("expected subject_id workload:triage-bot, got %v", auditRecord["subject_id"])
+	}
+	if auditRecord["subject_kind"] != "workload" {
+		t.Fatalf("expected subject_kind workload, got %v", auditRecord["subject_kind"])
+	}
+	if auditRecord["credential_mode"] != "identity" {
+		t.Fatalf("expected credential_mode identity, got %v", auditRecord["credential_mode"])
+	}
+	if auditRecord["credential_subject_id"] != "identity:__identity__" {
+		t.Fatalf("expected credential_subject_id identity:__identity__, got %v", auditRecord["credential_subject_id"])
+	}
+	if auditRecord["credential_connection"] != "default" {
+		t.Fatalf("expected credential_connection default, got %v", auditRecord["credential_connection"])
+	}
+	if auditRecord["credential_instance"] != "default" {
+		t.Fatalf("expected credential_instance default, got %v", auditRecord["credential_instance"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- enforce workload authorization on the MCP surface by filtering `tools/list` results and re-checking `tools/call`
- preserve static-catalog precedence over session catalogs while filtering dynamic session tools with the same workload allowlists used by HTTP
- add a shared merged-catalog filter helper so HTTP and MCP use the same workload-visible operation set after static/session merge
- record denied broker-level authorization failures as `allowed=false` in audit logs and pre-populate workload credential-path audit fields for denied calls
- wire the MCP surface to the host authorizer in production and extend MCP/server integration coverage for workload discovery, call denial, and audit metadata

## New Interfaces
Go MCP server surface:

```go
type Config struct {
    Invoker          invocation.Invoker
    TokenResolver    invocation.TokenResolver
    AuditSink        core.AuditSink
    Providers        *registry.ProviderMap[core.Provider]
    Authorizer       *authorization.Authorizer
    AllowedProviders []string
    ToolPrefixes     map[string]string
    IncludeREST      map[string]bool
    MCPConnection    map[string]string
}

func NewServer(cfg Config) *mcpserver.MCPServer
```

Go authorization helpers added in this PR:

```go
func allowProvider(cfg Config, p *principal.Principal, provider string) bool
func allowOperation(cfg Config, p *principal.Principal, provider, operation string) bool
func filterVisibleTools(ctx context.Context, cfg Config, providers []string, result *mcpgo.ListToolsResult)
```

YAML surface consumed by MCP in this PR:

```yaml
server:
  authorization:
    workloads:
      triage-bot:
        token: secret://triage-bot-token
        providers:
          github:
            connection: default
            instance: default
            allow:
              - list_issues
              - get_issue

providers:
  plugins:
    github:
      mcp:
        enabled: true
```

## Examples
Host wiring example:

```go
mcpServer := mcp.NewServer(mcp.Config{
    Invoker:       broker,
    TokenResolver: broker,
    AuditSink:     auditSink,
    Providers:     providers,
    Authorizer:    authorizer,
    MCPConnection: map[string]string{
        "github": "default",
    },
})
```

Use the workload token over MCP:

```sh
curl \
  -H "Authorization: Bearer $TRIAGE_BOT_TOKEN" \
  -H 'Content-Type: application/json' \
  https://gestalt.example.com/mcp
```

With the workload config above, the MCP client only sees the `github` tools mapped to `list_issues` and `get_issue`, and denied tool calls now return the host authorization error path with a matching denied audit entry.

## Validation
- `cd gestaltd && go test ./internal/server -run 'TestMCPEndpoint_|TestFilterCatalogForPrincipal_|TestResolveCatalog_'`
- `cd gestaltd && go test ./internal/mcp -run 'TestNewServer_(Workload|DirectCallerPassthrough)'`
- `cd gestaltd && go test ./internal/server ./internal/mcp ./internal/invocation ./cmd/gestaltd`

## Notes
- this PR is stacked on `main` after #919 merged
- session-catalog hydration is covered at the MCP package seam, while the HTTP `/mcp` coverage focuses on end-to-end auth middleware, list filtering, denied tool calls, and audit fields
