### PR TITLE
[codex] Fix IndexedDB cursor follow-up bugs

### DIFF
--- a/gestaltd/core/testing/indexeddb_stub.go
+++ b/gestaltd/core/testing/indexeddb_stub.go
@@ -1,6 +1,7 @@
 package coretesting
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sort"
@@ -501,6 +502,10 @@ func compareIndexKeys(a, b any) int {
 			}
 			return 0
 		}
+	case []byte:
+		if bv, ok := b.([]byte); ok {
+			return bytes.Compare(av, bv)
+		}
 	}
 	// Coerce numeric types for cross-type comparison (e.g. int vs int64 after gRPC round-trip).
 	af, aOk := toFloat64(a)
@@ -665,7 +670,7 @@ func (c *stubCursor) Advance(count int) bool {
 		c.err = fmt.Errorf("advance count must be positive")
 		return false
 	}
-	for i := 0; i < count; i++ {
+	for i := 0; i <= count; i++ {
 		if !c.Continue() {
 			return false
 		}

--- a/gestaltd/core/testing/indexeddb_stub_test.go
+++ b/gestaltd/core/testing/indexeddb_stub_test.go
@@ -1,0 +1,85 @@
+package coretesting
+
+import (
+	"context"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+func TestStubCursorAdvanceSkipsRequestedRows(t *testing.T) {
+	t.Parallel()
+
+	db := &StubIndexedDB{}
+	ctx := context.Background()
+	if err := db.CreateObjectStore(ctx, "items", indexeddb.ObjectStoreSchema{}); err != nil {
+		t.Fatalf("CreateObjectStore: %v", err)
+	}
+
+	store := db.ObjectStore("items")
+	for _, record := range []indexeddb.Record{
+		{"id": "a"},
+		{"id": "b"},
+		{"id": "c"},
+	} {
+		if err := store.Add(ctx, record); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+	}
+
+	cursor, err := store.OpenCursor(ctx, nil, indexeddb.CursorNext)
+	if err != nil {
+		t.Fatalf("OpenCursor: %v", err)
+	}
+	defer func() { _ = cursor.Close() }()
+
+	if !cursor.Advance(1) {
+		t.Fatalf("Advance(1) returned false")
+	}
+	if cursor.PrimaryKey() != "b" {
+		t.Fatalf("PrimaryKey after Advance(1) = %q, want b", cursor.PrimaryKey())
+	}
+}
+
+func TestStubIndexCursorOrdersBinaryKeysBytewise(t *testing.T) {
+	t.Parallel()
+
+	db := &StubIndexedDB{}
+	ctx := context.Background()
+	if err := db.CreateObjectStore(ctx, "items", indexeddb.ObjectStoreSchema{
+		Indexes: []indexeddb.IndexSchema{{Name: "by_blob", KeyPath: []string{"blob"}}},
+	}); err != nil {
+		t.Fatalf("CreateObjectStore: %v", err)
+	}
+
+	store := db.ObjectStore("items")
+	for _, record := range []indexeddb.Record{
+		{"id": "a", "blob": []byte{10}},
+		{"id": "b", "blob": []byte{2}},
+		{"id": "c", "blob": []byte{2, 0}},
+	} {
+		if err := store.Add(ctx, record); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+	}
+
+	cursor, err := store.Index("by_blob").OpenCursor(ctx, nil, indexeddb.CursorNext)
+	if err != nil {
+		t.Fatalf("OpenCursor: %v", err)
+	}
+	defer func() { _ = cursor.Close() }()
+
+	var keys []string
+	for cursor.Continue() {
+		keys = append(keys, cursor.PrimaryKey())
+	}
+	want := []string{"b", "c", "a"}
+	if len(keys) != len(want) {
+		t.Fatalf("got %d keys, want %d: %v", len(keys), len(want), keys)
+	}
+	for i, key := range want {
+		if keys[i] != key {
+			t.Fatalf("keys[%d] = %q, want %q (full order %v)", i, keys[i], key, keys)
+		}
+	}
+}

--- a/gestaltd/internal/pluginhost/cursor_test.go
+++ b/gestaltd/internal/pluginhost/cursor_test.go
@@ -395,13 +395,13 @@ func TestCursor_Advance(t *testing.T) {
 	}
 	defer func() { _ = cursor.Close() }()
 
-	// Advance(2) should skip first 2 records
+	// Advance(2) should skip the first 2 records and land on the next one.
 	if !cursor.Advance(2) {
 		t.Fatal("Advance(2) returned false")
 	}
 	pk := cursor.PrimaryKey()
-	if pk != "b" {
-		t.Errorf("PrimaryKey after Advance(2) = %q, want b", pk)
+	if pk != "c" {
+		t.Errorf("PrimaryKey after Advance(2) = %q, want c", pk)
 	}
 }
 

--- a/sdk/go/indexeddb_transport_test.go
+++ b/sdk/go/indexeddb_transport_test.go
@@ -246,6 +246,23 @@ func TestTransport_AdvancePastEnd(t *testing.T) {
 	}
 }
 
+func TestTransport_AdvanceOnFreshCursorSkipsRequestedRows(t *testing.T) {
+	store := seedStore(t)
+	ctx := context.Background()
+	cursor, err := testClient.ObjectStore(store).OpenCursor(ctx, nil, gestalt.CursorNext)
+	if err != nil {
+		t.Fatalf("OpenCursor: %v", err)
+	}
+	defer cursor.Close()
+
+	if !cursor.Advance(1) {
+		t.Fatalf("Advance(1) returned false err=%v", cursor.Err())
+	}
+	if cursor.PrimaryKey() != "b" {
+		t.Fatalf("PrimaryKey after Advance(1) = %q, want b", cursor.PrimaryKey())
+	}
+}
+
 func TestTransport_AdvanceRejectsNonPositiveCounts(t *testing.T) {
 	store := seedStore(t)
 	ctx := context.Background()
@@ -359,6 +376,52 @@ func TestTransport_IndexContinueToKeyRoundTrip(t *testing.T) {
 	}
 	if cursor.PrimaryKey() != "b" {
 		t.Fatalf("PrimaryKey = %q, want b", cursor.PrimaryKey())
+	}
+}
+
+func TestTransport_IndexCursorOrdersBinaryKeysBytewise(t *testing.T) {
+	ctx := context.Background()
+	store := "index_binary_" + t.Name()
+
+	err := testClient.CreateObjectStore(ctx, store, gestalt.ObjectStoreSchema{
+		Indexes: []gestalt.IndexSchema{{Name: "by_blob", KeyPath: []string{"blob"}}},
+	})
+	if err != nil {
+		t.Fatalf("CreateObjectStore: %v", err)
+	}
+
+	s := testClient.ObjectStore(store)
+	for _, r := range []gestalt.Record{
+		{"id": "a", "blob": []byte{10}},
+		{"id": "b", "blob": []byte{2}},
+		{"id": "c", "blob": []byte{2, 0}},
+	} {
+		if err := s.Add(ctx, r); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+	}
+
+	cursor, err := s.Index("by_blob").OpenCursor(ctx, nil, gestalt.CursorNext)
+	if err != nil {
+		t.Fatalf("OpenCursor: %v", err)
+	}
+	defer cursor.Close()
+
+	var keys []string
+	for cursor.Continue() {
+		keys = append(keys, cursor.PrimaryKey())
+	}
+	if err := cursor.Err(); err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	want := []string{"b", "c", "a"}
+	if len(keys) != len(want) {
+		t.Fatalf("got %d keys, want %d: %v", len(keys), len(want), keys)
+	}
+	for i, key := range want {
+		if keys[i] != key {
+			t.Fatalf("keys[%d] = %q, want %q (full order %v)", i, keys[i], key, keys)
+		}
 	}
 }
 

--- a/sdk/python/gestalt/_indexeddb.py
+++ b/sdk/python/gestalt/_indexeddb.py
@@ -433,6 +433,9 @@ class Cursor:
         if self._closed:
             return
         self._closed = True
+        self._key = None
+        self._primary_key = None
+        self._record = None
         try:
             self._send_command(close=True)
             self._request_iter.close()

--- a/sdk/python/tests/test_indexeddb_cursor_unit.py
+++ b/sdk/python/tests/test_indexeddb_cursor_unit.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import unittest
+
+from gestalt._indexeddb import Cursor
+
+
+class _DummyRequestIterator:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class TestCursorCloseClearsState(unittest.TestCase):
+    def test_close_clears_last_entry(self) -> None:
+        cursor = Cursor.__new__(Cursor)
+        cursor._keys_only = False
+        cursor._closed = False
+        cursor._exhausted = False
+        cursor._index_cursor = False
+        cursor._key = "key"
+        cursor._primary_key = "primary"
+        cursor._record = {"id": "primary"}
+        cursor._request_iter = _DummyRequestIterator()
+        cursor._send_command = lambda **kwargs: None
+
+        cursor.close()
+
+        self.assertTrue(cursor._closed)
+        self.assertTrue(cursor._request_iter.closed)
+        self.assertIsNone(cursor.key)
+        self.assertIsNone(cursor.primary_key)
+        with self.assertRaises(TypeError):
+            _ = cursor.value

--- a/sdk/python/tests/test_indexeddb_transport.py
+++ b/sdk/python/tests/test_indexeddb_transport.py
@@ -173,6 +173,22 @@ class TestAdvancePastEnd(unittest.TestCase):
         c.close()
 
 
+class TestCursorCloseClearsState(unittest.TestCase):
+    def test_close_clears_last_entry(self) -> None:
+        c = _client()
+        _seed_store(c, "close_clears_state")
+        s = c.object_store("close_clears_state")
+        with s.open_cursor(direction=CURSOR_NEXT) as cursor:
+            self.assertTrue(cursor.continue_())
+            self.assertEqual(cursor.primary_key, "a")
+
+        self.assertIsNone(cursor.key)
+        self.assertIsNone(cursor.primary_key)
+        with self.assertRaises(TypeError):
+            _ = cursor.value
+        c.close()
+
+
 class TestAdvanceRejectsNonPositiveCounts(unittest.TestCase):
     def test_zero_raises_invalid_argument(self) -> None:
         c = _client()


### PR DESCRIPTION
## Summary
This follow-up fixes three cursor behavior bugs that remained after `#878` landed:

- make `StubIndexedDB` cursor `Advance` skip the requested rows before landing on the next entry
- compare binary index keys bytewise instead of via `fmt.Sprint`
- clear Python cursor state on `close()` so closed cursors stop exposing the last entry

## Root Cause
The in-memory stub was still using pre-merge cursor semantics in two places:

- `Advance` only called `Continue()` `count` times, so a fresh cursor landed one row too early
- binary key comparison fell through to string formatting, which sorts byte slices by their printed form instead of byte order

The Python SDK also only flipped `_closed` and kept `_key`, `_primary_key`, and `_record` populated after closing.

## Impact
This keeps the shared stub/harness aligned with the documented cursor contract and the binary key support already exposed by the wire types. It also makes Python cursor close behavior match the Go and TypeScript SDKs more closely.

## Validation
Added regression coverage for the stub and SDKs:

- `go test ./core/testing -run 'TestStub(CursorAdvanceSkipsRequestedRows|IndexCursorOrdersBinaryKeysBytewise)$'`
- `uv run python -m unittest tests.test_indexeddb_cursor_unit`

I also added transport/harness regressions in the Go and Python suites, but I could not run those end-to-end locally because the harness build is currently blocked by an unrelated compile error in `gestaltd/internal/invocation/direct_tool.go` (`resolver.ResolveToken` signature mismatch).