### PR TITLE
[codex] Complete IndexedDB SDK parity

### DIFF
--- a/gestaltd/core/testing/indexeddb_stub.go
+++ b/gestaltd/core/testing/indexeddb_stub.go
@@ -147,46 +147,49 @@ func (o *stubObjectStore) Clear(_ context.Context) error {
 	return nil
 }
 
-func (o *stubObjectStore) GetAll(_ context.Context, _ *indexeddb.KeyRange) ([]indexeddb.Record, error) {
+func (o *stubObjectStore) GetAll(_ context.Context, r *indexeddb.KeyRange) ([]indexeddb.Record, error) {
 	if o.db.Err != nil {
 		return nil, o.db.Err
 	}
-	o.mu.RLock()
-	defer o.mu.RUnlock()
-	out := make([]indexeddb.Record, 0, len(o.records))
-	for _, r := range o.records {
-		out = append(out, r)
+	c := o.newCursor(indexeddb.CursorNext, false)
+	c.applyKeyRange(r)
+	out := make([]indexeddb.Record, 0, len(c.keys))
+	for _, key := range c.keys {
+		out = append(out, c.snapshot[key])
 	}
 	return out, nil
 }
 
-func (o *stubObjectStore) GetAllKeys(_ context.Context, _ *indexeddb.KeyRange) ([]string, error) {
+func (o *stubObjectStore) GetAllKeys(_ context.Context, r *indexeddb.KeyRange) ([]string, error) {
 	if o.db.Err != nil {
 		return nil, o.db.Err
 	}
-	o.mu.RLock()
-	defer o.mu.RUnlock()
-	out := make([]string, 0, len(o.records))
-	for k := range o.records {
-		out = append(out, k)
-	}
-	return out, nil
+	c := o.newCursor(indexeddb.CursorNext, true)
+	c.applyKeyRange(r)
+	return append([]string(nil), c.keys...), nil
 }
 
-func (o *stubObjectStore) Count(_ context.Context, _ *indexeddb.KeyRange) (int64, error) {
+func (o *stubObjectStore) Count(_ context.Context, r *indexeddb.KeyRange) (int64, error) {
 	if o.db.Err != nil {
 		return 0, o.db.Err
 	}
-	o.mu.RLock()
-	defer o.mu.RUnlock()
-	return int64(len(o.records)), nil
+	c := o.newCursor(indexeddb.CursorNext, true)
+	c.applyKeyRange(r)
+	return int64(len(c.keys)), nil
 }
 
-func (o *stubObjectStore) DeleteRange(_ context.Context, _ indexeddb.KeyRange) (int64, error) {
+func (o *stubObjectStore) DeleteRange(_ context.Context, r indexeddb.KeyRange) (int64, error) {
 	if o.db.Err != nil {
 		return 0, o.db.Err
 	}
-	return 0, nil
+	c := o.newCursor(indexeddb.CursorNext, true)
+	c.applyKeyRange(&r)
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	for _, key := range c.keys {
+		delete(o.records, key)
+	}
+	return int64(len(c.keys)), nil
 }
 
 func (o *stubObjectStore) Index(name string) indexeddb.Index {
@@ -297,17 +300,24 @@ func (idx *stubIndex) GetKey(ctx context.Context, values ...any) (string, error)
 	return id, nil
 }
 
-func (idx *stubIndex) GetAll(_ context.Context, _ *indexeddb.KeyRange, values ...any) ([]indexeddb.Record, error) {
+func (idx *stubIndex) newCursor(dir indexeddb.CursorDirection, r *indexeddb.KeyRange, keysOnly bool, values ...any) *stubCursor {
+	c := idx.store.newCursor(dir, keysOnly)
+	c.filterIndex = idx
+	c.filterValues = values
+	c.applyIndexFilter()
+	c.buildIndexKeys()
+	c.applyKeyRange(r)
+	return c
+}
+
+func (idx *stubIndex) GetAll(_ context.Context, r *indexeddb.KeyRange, values ...any) ([]indexeddb.Record, error) {
 	if idx.store.db.Err != nil {
 		return nil, idx.store.db.Err
 	}
-	idx.store.mu.RLock()
-	defer idx.store.mu.RUnlock()
-	var out []indexeddb.Record
-	for _, r := range idx.store.records {
-		if idx.matches(r, values) {
-			out = append(out, r)
-		}
+	c := idx.newCursor(indexeddb.CursorNext, r, false, values...)
+	out := make([]indexeddb.Record, 0, len(c.keys))
+	for _, key := range c.keys {
+		out = append(out, c.snapshot[key])
 	}
 	return out, nil
 }
@@ -331,11 +341,8 @@ func (idx *stubIndex) Count(ctx context.Context, r *indexeddb.KeyRange, values .
 	if idx.store.db.Err != nil {
 		return 0, idx.store.db.Err
 	}
-	records, err := idx.GetAll(ctx, r, values...)
-	if err != nil {
-		return 0, err
-	}
-	return int64(len(records)), nil
+	c := idx.newCursor(indexeddb.CursorNext, r, true, values...)
+	return int64(len(c.keys)), nil
 }
 
 func (idx *stubIndex) Delete(_ context.Context, values ...any) (int64, error) {
@@ -360,26 +367,14 @@ func (idx *stubIndex) OpenCursor(_ context.Context, r *indexeddb.KeyRange, dir i
 	if idx.store.db.Err != nil {
 		return nil, idx.store.db.Err
 	}
-	c := idx.store.newCursor(dir, false)
-	c.filterIndex = idx
-	c.filterValues = values
-	c.applyIndexFilter()
-	c.buildIndexKeys()
-	c.applyKeyRange(r)
-	return c, nil
+	return idx.newCursor(dir, r, false, values...), nil
 }
 
 func (idx *stubIndex) OpenKeyCursor(_ context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection, values ...any) (indexeddb.Cursor, error) {
 	if idx.store.db.Err != nil {
 		return nil, idx.store.db.Err
 	}
-	c := idx.store.newCursor(dir, true)
-	c.filterIndex = idx
-	c.filterValues = values
-	c.applyIndexFilter()
-	c.buildIndexKeys()
-	c.applyKeyRange(r)
-	return c, nil
+	return idx.newCursor(dir, r, true, values...), nil
 }
 
 type stubCursor struct {

--- a/sdk/rust/src/indexeddb.rs
+++ b/sdk/rust/src/indexeddb.rs
@@ -384,6 +384,18 @@ impl ObjectStore {
             .unwrap_or_default())
     }
 
+    pub async fn get_key(&mut self, id: &str) -> Result<String, IndexedDBError> {
+        let resp = self
+            .client
+            .get_key(pb::ObjectStoreRequest {
+                store: self.store.clone(),
+                id: id.to_string(),
+            })
+            .await
+            .map_err(map_status)?;
+        Ok(resp.into_inner().key)
+    }
+
     pub async fn add(&mut self, record: Record) -> Result<(), IndexedDBError> {
         self.client
             .add(pb::RecordRequest {
@@ -425,6 +437,65 @@ impl ObjectStore {
             .await
             .map_err(map_status)?;
         Ok(())
+    }
+
+    pub async fn get_all(
+        &mut self,
+        range: Option<KeyRange>,
+    ) -> Result<Vec<Record>, IndexedDBError> {
+        let resp = self
+            .client
+            .get_all(pb::ObjectStoreRangeRequest {
+                store: self.store.clone(),
+                range: range.map(key_range_to_pb),
+            })
+            .await
+            .map_err(map_status)?;
+        Ok(resp
+            .into_inner()
+            .records
+            .iter()
+            .map(pb_record_to_record)
+            .collect())
+    }
+
+    pub async fn get_all_keys(
+        &mut self,
+        range: Option<KeyRange>,
+    ) -> Result<Vec<String>, IndexedDBError> {
+        let resp = self
+            .client
+            .get_all_keys(pb::ObjectStoreRangeRequest {
+                store: self.store.clone(),
+                range: range.map(key_range_to_pb),
+            })
+            .await
+            .map_err(map_status)?;
+        Ok(resp.into_inner().keys)
+    }
+
+    pub async fn count(&mut self, range: Option<KeyRange>) -> Result<i64, IndexedDBError> {
+        let resp = self
+            .client
+            .count(pb::ObjectStoreRangeRequest {
+                store: self.store.clone(),
+                range: range.map(key_range_to_pb),
+            })
+            .await
+            .map_err(map_status)?;
+        Ok(resp.into_inner().count)
+    }
+
+    pub async fn delete_range(&mut self, range: KeyRange) -> Result<i64, IndexedDBError> {
+        let resp = self
+            .client
+            .delete_range(pb::ObjectStoreRangeRequest {
+                store: self.store.clone(),
+                range: Some(key_range_to_pb(range)),
+            })
+            .await
+            .map_err(map_status)?;
+        Ok(resp.into_inner().deleted)
     }
 
     pub fn index(&self, name: &str) -> IndexClient {
@@ -494,9 +565,27 @@ impl IndexClient {
             .unwrap_or_default())
     }
 
+    pub async fn get_key(
+        &mut self,
+        values: &[serde_json::Value],
+    ) -> Result<String, IndexedDBError> {
+        let resp = self
+            .client
+            .index_get_key(pb::IndexQueryRequest {
+                store: self.store.clone(),
+                index: self.index.clone(),
+                values: values.iter().map(json_to_typed_value).collect(),
+                range: None,
+            })
+            .await
+            .map_err(map_status)?;
+        Ok(resp.into_inner().key)
+    }
+
     pub async fn get_all(
         &mut self,
         values: &[serde_json::Value],
+        range: Option<KeyRange>,
     ) -> Result<Vec<Record>, IndexedDBError> {
         let resp = self
             .client
@@ -504,7 +593,7 @@ impl IndexClient {
                 store: self.store.clone(),
                 index: self.index.clone(),
                 values: values.iter().map(json_to_typed_value).collect(),
-                range: None,
+                range: range.map(key_range_to_pb),
             })
             .await
             .map_err(map_status)?;
@@ -514,6 +603,42 @@ impl IndexClient {
             .iter()
             .map(pb_record_to_record)
             .collect())
+    }
+
+    pub async fn get_all_keys(
+        &mut self,
+        values: &[serde_json::Value],
+        range: Option<KeyRange>,
+    ) -> Result<Vec<String>, IndexedDBError> {
+        let resp = self
+            .client
+            .index_get_all_keys(pb::IndexQueryRequest {
+                store: self.store.clone(),
+                index: self.index.clone(),
+                values: values.iter().map(json_to_typed_value).collect(),
+                range: range.map(key_range_to_pb),
+            })
+            .await
+            .map_err(map_status)?;
+        Ok(resp.into_inner().keys)
+    }
+
+    pub async fn count(
+        &mut self,
+        values: &[serde_json::Value],
+        range: Option<KeyRange>,
+    ) -> Result<i64, IndexedDBError> {
+        let resp = self
+            .client
+            .index_count(pb::IndexQueryRequest {
+                store: self.store.clone(),
+                index: self.index.clone(),
+                values: values.iter().map(json_to_typed_value).collect(),
+                range: range.map(key_range_to_pb),
+            })
+            .await
+            .map_err(map_status)?;
+        Ok(resp.into_inner().count)
     }
 
     pub async fn delete(&mut self, values: &[serde_json::Value]) -> Result<i64, IndexedDBError> {

--- a/sdk/rust/tests/indexeddb_transport.rs
+++ b/sdk/rust/tests/indexeddb_transport.rs
@@ -5,7 +5,7 @@ use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
 
 use gestalt::indexeddb::{
-    CursorDirection, ENV_INDEXEDDB_SOCKET, IndexSchema, IndexedDB, IndexedDBError,
+    CursorDirection, ENV_INDEXEDDB_SOCKET, IndexSchema, IndexedDB, IndexedDBError, KeyRange,
     ObjectStoreSchema, Record,
 };
 
@@ -109,6 +109,74 @@ async fn nested_json_round_trip() {
         got["tags"]
     );
     assert_eq!(got["tags"][0], serde_json::json!("alpha"));
+}
+
+#[tokio::test]
+async fn object_store_bulk_helpers() {
+    let _lock = helpers::env_lock().lock().await;
+    let _harness = start_harness("idb-store-helpers.sock").await;
+
+    let mut db = IndexedDB::connect().await.expect("connect");
+    db.create_object_store("store_helpers", ObjectStoreSchema { indexes: vec![] })
+        .await
+        .expect("create store");
+
+    let mut store = db.object_store("store_helpers");
+    for id in ["a", "b", "c", "d"] {
+        store
+            .put(make_record(&[
+                ("id", serde_json::json!(id)),
+                ("label", serde_json::json!(format!("label-{id}"))),
+            ]))
+            .await
+            .expect("put");
+    }
+
+    let key = store.get_key("b").await.expect("get_key");
+    assert_eq!(key, "b");
+
+    let all = store.get_all(None).await.expect("get_all");
+    assert_eq!(all.len(), 4);
+
+    let ranged = store
+        .get_all(Some(KeyRange {
+            lower: Some(serde_json::json!("b")),
+            upper: Some(serde_json::json!("c")),
+            lower_open: false,
+            upper_open: false,
+        }))
+        .await
+        .expect("get_all with range");
+    let ranged_ids: Vec<_> = ranged
+        .iter()
+        .map(|record| record["id"].as_str().expect("id").to_string())
+        .collect();
+    assert_eq!(ranged_ids, vec!["b", "c"]);
+
+    let all_keys = store.get_all_keys(None).await.expect("get_all_keys");
+    assert_eq!(all_keys, vec!["a", "b", "c", "d"]);
+
+    let count = store.count(None).await.expect("count");
+    assert_eq!(count, 4);
+
+    let deleted = store
+        .delete_range(KeyRange {
+            lower: Some(serde_json::json!("b")),
+            upper: Some(serde_json::json!("c")),
+            lower_open: false,
+            upper_open: false,
+        })
+        .await
+        .expect("delete_range");
+    assert_eq!(deleted, 2);
+    assert_eq!(
+        store.count(None).await.expect("count after delete_range"),
+        2
+    );
+    assert_eq!(
+        store.get_all_keys(None).await.expect("remaining keys"),
+        vec!["a", "d"]
+    );
 }
 
 #[tokio::test]
@@ -387,13 +455,80 @@ async fn index_cursor() {
 
     let mut idx = store.index("by_status");
     let all_active = idx
-        .get_all(&[serde_json::json!("active")])
+        .get_all(&[serde_json::json!("active")], None)
         .await
         .expect("get_all active");
     assert_eq!(all_active.len(), 3, "expected 3 active records");
     for rec in &all_active {
         assert_eq!(rec["status"], serde_json::json!("active"));
     }
+}
+
+#[tokio::test]
+async fn index_query_helpers() {
+    let _lock = helpers::env_lock().lock().await;
+    let _harness = start_harness("idb-index-helpers.sock").await;
+
+    let mut db = IndexedDB::connect().await.expect("connect");
+    db.create_object_store(
+        "index_helpers_store",
+        ObjectStoreSchema {
+            indexes: vec![IndexSchema {
+                name: "by_num".to_string(),
+                key_path: vec!["n".to_string()],
+                unique: false,
+            }],
+        },
+    )
+    .await
+    .expect("create store");
+
+    let mut store = db.object_store("index_helpers_store");
+    for (id, n) in [("a", 1), ("b", 2), ("c", 2), ("d", 4)] {
+        store
+            .put(make_record(&[
+                ("id", serde_json::json!(id)),
+                ("n", serde_json::json!(n)),
+            ]))
+            .await
+            .expect("put");
+    }
+
+    let mut idx = store.index("by_num");
+    let key = idx
+        .get_key(&[serde_json::json!(2)])
+        .await
+        .expect("index get_key");
+    assert_eq!(key, "b");
+
+    let keys = idx
+        .get_all_keys(&[], None)
+        .await
+        .expect("index get_all_keys");
+    assert_eq!(keys, vec!["a", "b", "c", "d"]);
+
+    let ranged_keys = idx
+        .get_all_keys(
+            &[],
+            Some(KeyRange {
+                lower: Some(serde_json::json!(2)),
+                upper: Some(serde_json::json!(2)),
+                lower_open: false,
+                upper_open: false,
+            }),
+        )
+        .await
+        .expect("index get_all_keys with range");
+    assert_eq!(ranged_keys, vec!["b", "c"]);
+
+    let count = idx.count(&[], None).await.expect("index count");
+    assert_eq!(count, 4);
+
+    let exact_count = idx
+        .count(&[serde_json::json!(2)], None)
+        .await
+        .expect("index count exact");
+    assert_eq!(exact_count, 2);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

This completes IndexedDB client-surface parity across the SDKs by filling in the remaining Rust object-oriented wrapper methods and tightening the IndexedDB transport test harness used by the Rust SDK tests.

## What Changed

- added the missing Rust `ObjectStore` helpers: `get_key`, `get_all`, `get_all_keys`, `count`, and `delete_range`
- added the missing Rust `IndexClient` helpers: `get_key`, ranged `get_all`, `get_all_keys`, and `count`
- extended the Rust transport tests to cover the new store/index helper methods end to end
- fixed the in-memory IndexedDB stub used by transport tests so bulk helper methods respect key ranges and stable ordering, matching the cursor path more closely

## Why

Go, Python, and TypeScript already exposed the IndexedDB API through `IndexedDB -> ObjectStore -> Index -> Cursor` wrappers. Rust still had a narrower client surface, so the SDKs were not actually aligned even though the underlying proto supported the full method set.

## Impact

Provider authors using the Rust SDK now get the same IndexedDB helper coverage as the other SDKs, including object-store range helpers and index key/count helpers.

## Root Cause

The Rust wrapper lagged behind the proto and the other SDKs, and the transport-test stub had partial IndexedDB behavior: cursor paths handled ordering/ranges, but the bulk helper paths did not.

## Validation

- `cargo test --test indexeddb_transport --manifest-path sdk/rust/Cargo.toml`
- `go test ./core/testing ./internal/testutil/indexeddbtransport ./internal/pluginhost`
