### PR TITLE
[codex] Reconcile client docs with the in-product guide

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -128,8 +128,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
       - name: Build docs
         run: npm run build
+
+      - name: Run docs smoke tests
+        run: npm run test:smoke
 
   helm-validate:
     name: Helm Chart Validation

--- a/docs/content/client/index.mdx
+++ b/docs/content/client/index.mdx
@@ -5,3 +5,5 @@ asIndexPage: true
 # Clients
 
 Gestalt exposes two client interfaces for interacting with a running `gestaltd` server: the [CLI](/client/cli) for terminal workflows and automation, and the [Web UI](/client/web) for browser-based access. Both use the same HTTP API and authentication model.
+
+When the public UI is enabled, a running server also hosts an in-product user guide at `/docs`. That guide is for the current server you are using. The pages in this `docs/` site cover the full product, including local setup, configuration, and deployment.

--- a/docs/content/client/web.mdx
+++ b/docs/content/client/web.mdx
@@ -4,6 +4,8 @@ Open your Gestalt server's base URL in a browser to access the web client. For a
 
 The web UI lets you browse plugins, connect to upstream services through OAuth or manual auth, invoke operations, and manage API tokens. It uses the same HTTP API and authentication model as the CLI.
 
+When the public UI is enabled, the same server also hosts an in-product user guide at `/docs`.
+
 ## Dashboard
 
 The dashboard shows an overview of the workspace with plugin and API token counts.
@@ -12,9 +14,9 @@ The dashboard shows an overview of the workspace with plugin and API token count
 
 ## Plugins
 
-The plugins page lists all configured providers. Connected plugins show a green checkmark. Click the settings icon to manage connections or disconnect.
+The Plugins page lists all configured plugins. Connected plugins show a green checkmark. Click the settings icon to manage connections or disconnect.
 
-![Integrations](/images/web-integrations.png)
+![Plugins](/images/web-integrations.png)
 
 ## API Tokens
 
@@ -32,6 +34,6 @@ The public web UI is configured through the `providers.ui` entry.
 
 - Omit `ui` to use the pinned first-party default UI bundle.
 - Set `ui: { disabled: true }` to run headless with no public UI at `/`.
-- Set `ui.provider.source` to a packaged `webui` bundle to bring your own frontend.
+- Set `providers.ui.source` to a packaged `webui` bundle to bring your own frontend.
 
 The built-in admin UI at `/admin` remains available regardless. See [Releasing](/providers/releasing) for the bundle format.

--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -23,6 +23,13 @@ When no config file exists, `gestaltd` generates one at `~/.gestaltd/config.yaml
 2026/04/10 10:00:01 INFO gestaltd ready url=http://localhost:8080
 ```
 
+With the default public UI enabled, open:
+
+- `http://localhost:8080/` for the web client
+- `http://localhost:8080/docs` for the in-product user guide for this running server
+
+If you later disable `providers.ui`, those browser pages are not served.
+
 ## Using the client
 
 In a separate terminal, run the setup wizard:
@@ -108,41 +115,23 @@ Gestalt exposes all MCP-enabled plugins at a single endpoint: `http://localhost:
 
 <Tabs items={['Claude Code', 'Codex', 'Cursor']}>
   <Tabs.Tab>
-    Add the following to your [`~/.claude.json`](https://docs.anthropic.com/en/docs/claude-code/mcp) (user) or `.claude/settings.json` (project-level):
-
-    ```json
-    {
-      "mcpServers": {
-        "gestalt": {
-          "type": "http",
-          "url": "http://localhost:8080/mcp"
-        }
-      }
-    }
-    ```
-
-    Or via the CLI:
+    The default local server has authentication disabled, so you can add it directly:
 
     ```sh
-    claude mcp add --transport http gestalt http://localhost:8080/mcp
+    claude mcp add --transport http --scope project gestalt http://localhost:8080/mcp
     ```
+
+    This writes a project-scoped entry to `.mcp.json`. For a private local or user-scoped config, Claude Code stores MCP settings in `~/.claude.json`.
   </Tabs.Tab>
   <Tabs.Tab>
-    Add the following to [`~/.codex/config.toml`](https://developers.openai.com/codex/mcp) (global) or `.codex/config.toml` (project-level):
-
-    ```toml
-    [mcp_servers.gestalt]
-    url = "http://localhost:8080/mcp"
-    ```
-
-    Or via the CLI:
+    Add it from the Codex CLI:
 
     ```sh
     codex mcp add gestalt --url http://localhost:8080/mcp
     ```
   </Tabs.Tab>
   <Tabs.Tab>
-    Add the following to [`~/.cursor/mcp.json`](https://cursor.com/docs/mcp) (global) or `.cursor/mcp.json` (project-level):
+    Add the following to `.cursor/mcp.json` in the current project, or `~/.cursor/mcp.json` globally:
 
     ```json
     {
@@ -156,7 +145,7 @@ Gestalt exposes all MCP-enabled plugins at a single endpoint: `http://localhost:
   </Tabs.Tab>
 </Tabs>
 
-Once connected, your agent can call any operation exposed by the server. The same auth model applies: when plugins require credentials, users connect through the Gestalt web UI or CLI before the agent can invoke those tools.
+Once connected, your agent can call any operation exposed by the server. On deployments with authentication enabled, users connect through the Gestalt web UI or CLI first and then configure MCP client auth as required.
 
 ## Next steps
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -16,6 +16,7 @@
         "react-dom": "^19.2.5"
       },
       "devDependencies": {
+        "@playwright/test": "1.59.1",
         "@types/node": "25.6.0",
         "@types/react": "^19.2.14",
         "pagefind": "^1.5.2",
@@ -1245,6 +1246,22 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@react-aria/focus": {
       "version": "3.21.5",
@@ -3082,6 +3099,21 @@
       "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
       "engines": {
         "node": ">=0.4.x"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/get-stream": {
@@ -5296,6 +5328,38 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/points-on-curve": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build && pagefind --site out --output-subdir _pagefind",
     "start": "next start",
+    "test:smoke": "playwright test",
     "typecheck": "tsc --noEmit",
     "lint": "next lint"
   },
@@ -19,6 +20,7 @@
   },
   "devDependencies": {
     "@types/node": "25.6.0",
+    "@playwright/test": "1.59.1",
     "pagefind": "^1.5.2",
     "@types/react": "^19.2.14",
     "typescript": "5.9.3"

--- a/docs/playwright.config.ts
+++ b/docs/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL: "http://127.0.0.1:3100",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "python3 -m http.server 3100 -d out",
+    url: "http://127.0.0.1:3100",
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+});

--- a/docs/tests/smoke.spec.ts
+++ b/docs/tests/smoke.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@playwright/test";
+
+test("getting started covers local UI, in-product docs, and plugin CLI usage", async ({
+  page,
+}) => {
+  await page.goto("/getting-started.html");
+
+  const body = page.locator("body");
+
+  await expect(page).toHaveTitle(/Getting Started/);
+  await expect(body).toContainText("http://localhost:8080/");
+  await expect(body).toContainText("http://localhost:8080/docs");
+  await expect(body).toContainText("gestalt plugins list");
+  await expect(body).toContainText(
+    "claude mcp add --transport http --scope project gestalt http://localhost:8080/mcp",
+  );
+  await expect(body).toContainText(
+    "codex mcp add gestalt --url http://localhost:8080/mcp",
+  );
+});
+
+test("client index distinguishes in-product docs from the full docs site", async ({
+  page,
+}) => {
+  await page.goto("/client.html");
+
+  const body = page.locator("body");
+
+  await expect(page).toHaveTitle(/Clients/);
+  await expect(body).toContainText("in-product user guide at /docs");
+  await expect(body).toContainText(
+    "cover the full product, including local setup, configuration, and deployment",
+  );
+});
+
+test("web UI docs use Plugins terminology and the correct UI source key", async ({
+  page,
+}) => {
+  await page.goto("/client/web.html");
+
+  const body = page.locator("body");
+
+  await expect(page).toHaveTitle(/Web UI/);
+  await expect(body).toContainText("The Plugins page lists all configured plugins.");
+  await expect(body).toContainText("in-product user guide at /docs");
+  await expect(body).toContainText("providers.ui.source");
+  await expect(body).not.toContainText("ui.provider.source");
+});


### PR DESCRIPTION
## What changed
- updated `getting-started` so local users are told where the web client and in-product docs live when they run `gestaltd`
- refreshed the client-facing docs to distinguish the deployment-hosted `/docs` guide from the full `docs/` site
- aligned the web UI reference with canonical `Plugins` terminology and the correct `providers.ui.source` config key
- replaced stale MCP setup examples in `getting-started` with current Claude Code, Codex, and Cursor flows
- added a docs smoke suite and wired it into the docs build workflow in CI

## Why
The top-level docs need to cover both how to use a running server and how to run or deploy one. They had drifted from the provider-hosted `/docs` page on terminology, local discovery, and some client configuration examples.

## Impact
- local users now see `http://localhost:8080/` and `http://localhost:8080/docs` called out directly
- `docs/` now makes the split between in-product guidance and full product documentation explicit
- CI now exercises the built docs output with browser-level smoke tests instead of relying on static build success alone

## Validation
- `npm run typecheck`
- `npm run build`
- `npm run test:smoke`
