### PR TITLE
[codex] Rename pluginhost to providerhost

### DIFF
--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/session"
-	"github.com/valon-technologies/gestalt/server/internal/pluginhost"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -314,9 +314,9 @@ func TestRun_PluginReleaseBuildsPythonSourcePluginForCurrentPlatform(t *testing.
 	}
 
 	ctx := context.Background()
-	prov, err := pluginhost.NewExecutableProvider(ctx, pluginhost.ExecConfig{
+	prov, err := providerhost.NewExecutableProvider(ctx, providerhost.ExecConfig{
 		Command: artifactPath,
-		StaticSpec: pluginhost.StaticProviderSpec{
+		StaticSpec: providerhost.StaticProviderSpec{
 			Name: "python-release",
 		},
 		Config: map[string]any{"greeting": "Hi"},
@@ -538,9 +538,9 @@ func TestRun_PluginReleaseBuildsRustSourcePluginForCurrentPlatform(t *testing.T)
 	}
 
 	ctx := context.Background()
-	prov, err := pluginhost.NewExecutableProvider(ctx, pluginhost.ExecConfig{
+	prov, err := providerhost.NewExecutableProvider(ctx, providerhost.ExecConfig{
 		Command: artifactPath,
-		StaticSpec: pluginhost.StaticProviderSpec{
+		StaticSpec: providerhost.StaticProviderSpec{
 			Name: rustReleasePluginName,
 		},
 		Config: map[string]any{"greeting": "Hi"},
@@ -717,7 +717,7 @@ func TestRun_PluginReleaseBuildsGoSourceAuthPlugin(t *testing.T) {
 		t.Fatalf("expected %s in archive: %v", authReleaseSchemaPath, err)
 	}
 
-	auth, err := pluginhost.NewExecutableAuthProvider(context.Background(), pluginhost.AuthExecConfig{
+	auth, err := providerhost.NewExecutableAuthProvider(context.Background(), providerhost.AuthExecConfig{
 		Command:     filepath.Join(extractDir, binaryName),
 		Name:        "auth-release",
 		CallbackURL: "https://gestalt.example.test/api/v1/auth/login/callback",
@@ -821,7 +821,7 @@ func TestRun_PluginReleaseBuildsGoSourceSecretsPlugin(t *testing.T) {
 		t.Fatalf("expected %s in archive: %v", secretsReleaseSchemaPath, err)
 	}
 
-	sm, err := pluginhost.NewExecutableSecretManager(context.Background(), pluginhost.SecretsExecConfig{
+	sm, err := providerhost.NewExecutableSecretManager(context.Background(), providerhost.SecretsExecConfig{
 		Command: filepath.Join(extractDir, binaryName),
 		Name:    secretsReleasePluginName,
 	})
@@ -889,7 +889,7 @@ func TestRun_PluginReleaseBuildsRustSourceAuthPlugin(t *testing.T) {
 		t.Fatalf("expected %s in archive: %v", authReleaseSchemaPath, err)
 	}
 
-	auth, err := pluginhost.NewExecutableAuthProvider(context.Background(), pluginhost.AuthExecConfig{
+	auth, err := providerhost.NewExecutableAuthProvider(context.Background(), providerhost.AuthExecConfig{
 		Command:     filepath.Join(extractDir, binaryName),
 		Name:        "auth-release",
 		CallbackURL: "https://gestalt.example.test/api/v1/auth/login/callback",
@@ -986,7 +986,7 @@ func TestRun_PluginReleaseBuildsPythonSourceAuthPlugin(t *testing.T) {
 		t.Fatalf("expected %s in archive: %v", authReleaseSchemaPath, err)
 	}
 
-	auth, err := pluginhost.NewExecutableAuthProvider(context.Background(), pluginhost.AuthExecConfig{
+	auth, err := providerhost.NewExecutableAuthProvider(context.Background(), providerhost.AuthExecConfig{
 		Command:     filepath.Join(extractDir, binaryName),
 		Name:        pythonAuthReleasePluginName,
 		CallbackURL: "https://gestalt.example.test/api/v1/auth/login/callback",
@@ -1075,7 +1075,7 @@ func TestRun_PluginReleaseBuildsTypeScriptSourceAuthPlugin(t *testing.T) {
 		t.Fatalf("expected %s in archive: %v", authReleaseSchemaPath, err)
 	}
 
-	auth, err := pluginhost.NewExecutableAuthProvider(context.Background(), pluginhost.AuthExecConfig{
+	auth, err := providerhost.NewExecutableAuthProvider(context.Background(), providerhost.AuthExecConfig{
 		Command:     filepath.Join(extractDir, binaryName),
 		Name:        authReleasePluginName,
 		CallbackURL: "https://gestalt.example.test/api/v1/auth/login/callback",

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -24,8 +24,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
 	"github.com/valon-technologies/gestalt/server/internal/openapi"
 	"github.com/valon-technologies/gestalt/server/internal/operationexposure"
-	"github.com/valon-technologies/gestalt/server/internal/pluginhost"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -129,11 +129,11 @@ func buildProvider(ctx context.Context, name string, entry *config.ProviderEntry
 		if err != nil {
 			return nil, fmt.Errorf("build declarative provider %q: %w", name, err)
 		}
-		declarative, err := pluginhost.NewDeclarativeProvider(
+		declarative, err := providerhost.NewDeclarativeProvider(
 			manifest,
 			nil,
-			pluginhost.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
-			pluginhost.WithDeclarativeConnectionMode(plan.connectionMode()),
+			providerhost.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
+			providerhost.WithDeclarativeConnectionMode(plan.connectionMode()),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("create declarative provider %q: %w", name, err)
@@ -174,11 +174,11 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 	}
 
 	if manifestPlugin.IsDeclarative() {
-		declarative, err := pluginhost.NewDeclarativeProvider(
+		declarative, err := providerhost.NewDeclarativeProvider(
 			manifest,
 			nil,
-			pluginhost.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
-			pluginhost.WithDeclarativeConnectionMode(plan.connectionMode()),
+			providerhost.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
+			providerhost.WithDeclarativeConnectionMode(plan.connectionMode()),
 		)
 		if err != nil {
 			closeIfPossible(pluginProv)
@@ -457,7 +457,7 @@ func catalogOperationCount(cat *catalog.Catalog) int {
 	return len(cat.Operations)
 }
 
-func buildPluginProvider(ctx context.Context, entry *config.ProviderEntry, pluginConfig map[string]any, spec pluginhost.StaticProviderSpec, deps Deps) (core.Provider, error) {
+func buildPluginProvider(ctx context.Context, entry *config.ProviderEntry, pluginConfig map[string]any, spec providerhost.StaticProviderSpec, deps Deps) (core.Provider, error) {
 	command := entry.Command
 	args := entry.Args
 	env := clonePluginEnv(entry.Env)
@@ -494,7 +494,7 @@ func buildPluginProvider(ctx context.Context, entry *config.ProviderEntry, plugi
 		}()
 	}
 
-	execCfg := pluginhost.ExecConfig{
+	execCfg := providerhost.ExecConfig{
 		Command:       command,
 		Args:          args,
 		Env:           env,
@@ -507,11 +507,11 @@ func buildPluginProvider(ctx context.Context, entry *config.ProviderEntry, plugi
 	}
 	if len(entry.IndexedDBs) > 0 && deps.Services != nil {
 		execCfg.RegisterHost = func(srv *grpc.Server) {
-			proto.RegisterIndexedDBServer(srv, pluginhost.NewIndexedDBServer(deps.Services.DB, entry.Command))
+			proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(deps.Services.DB, entry.Command))
 		}
 		execCfg.HostSocketEnv = "GESTALT_INDEXEDDB_SOCKET"
 	}
-	prov, err := pluginhost.NewExecutableProvider(ctx, execCfg)
+	prov, err := providerhost.NewExecutableProvider(ctx, execCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -530,13 +530,13 @@ func clonePluginEnv(src map[string]string) map[string]string {
 	return dst
 }
 
-func buildPluginStaticSpec(name string, entry *config.ProviderEntry, manifest *providermanifestv1.Manifest, meta providerMetadata) (pluginhost.StaticProviderSpec, error) {
+func buildPluginStaticSpec(name string, entry *config.ProviderEntry, manifest *providermanifestv1.Manifest, meta providerMetadata) (providerhost.StaticProviderSpec, error) {
 	if manifest == nil || manifest.Spec == nil {
-		return pluginhost.StaticProviderSpec{}, fmt.Errorf("resolved manifest is required")
+		return providerhost.StaticProviderSpec{}, fmt.Errorf("resolved manifest is required")
 	}
 	plan, err := buildPluginConnectionPlan(entry, manifest.Spec)
 	if err != nil {
-		return pluginhost.StaticProviderSpec{}, err
+		return providerhost.StaticProviderSpec{}, err
 	}
 
 	displayName := meta.displayNameOr(manifest.DisplayName)
@@ -562,14 +562,14 @@ func buildPluginStaticSpec(name string, entry *config.ProviderEntry, manifest *p
 		var err error
 		staticCatalog, err = providerpkg.ReadStaticCatalog(manifestRoot, name)
 		if err != nil {
-			return pluginhost.StaticProviderSpec{}, err
+			return providerhost.StaticProviderSpec{}, err
 		}
 	}
 	if staticCatalog == nil && providerpkg.StaticCatalogRequired(manifest) {
 		if entry.ResolvedManifestPath == "" {
-			return pluginhost.StaticProviderSpec{}, fmt.Errorf("resolved manifest path is required for executable provider static catalog")
+			return providerhost.StaticProviderSpec{}, fmt.Errorf("resolved manifest path is required for executable provider static catalog")
 		}
-		return pluginhost.StaticProviderSpec{}, fmt.Errorf("executable providers without declarative or spec surfaces must define %s", providerpkg.StaticCatalogFile)
+		return providerhost.StaticProviderSpec{}, fmt.Errorf("executable providers without declarative or spec surfaces must define %s", providerpkg.StaticCatalogFile)
 	}
 	if staticCatalog != nil {
 		if displayName != "" {
@@ -583,7 +583,7 @@ func buildPluginStaticSpec(name string, entry *config.ProviderEntry, manifest *p
 		}
 	}
 
-	return pluginhost.StaticProviderSpec{
+	return providerhost.StaticProviderSpec{
 		Name:             name,
 		DisplayName:      displayName,
 		Description:      description,
@@ -591,9 +591,9 @@ func buildPluginStaticSpec(name string, entry *config.ProviderEntry, manifest *p
 		ConnectionMode:   connMode,
 		Catalog:          staticCatalog,
 		AuthTypes:        staticAuthTypes(conn.Auth.Type),
-		ConnectionParams: pluginhost.ConnectionParamDefsFromManifest(conn.ConnectionParams),
-		CredentialFields: pluginhost.CredentialFieldsFromManifest(conn.Auth.Credentials),
-		DiscoveryConfig:  pluginhost.DiscoveryConfigFromManifest(manifest.Spec.Discovery),
+		ConnectionParams: providerhost.ConnectionParamDefsFromManifest(conn.ConnectionParams),
+		CredentialFields: providerhost.CredentialFieldsFromManifest(conn.Auth.Credentials),
+		DiscoveryConfig:  providerhost.DiscoveryConfigFromManifest(manifest.Spec.Discovery),
 	}, nil
 }
 

--- a/gestaltd/internal/drivers/auth/plugin/factory.go
+++ b/gestaltd/internal/drivers/auth/plugin/factory.go
@@ -8,7 +8,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentplugin"
-	"github.com/valon-technologies/gestalt/server/internal/pluginhost"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"gopkg.in/yaml.v3"
 )
@@ -38,7 +38,7 @@ var Factory bootstrap.AuthFactory = func(node yaml.Node, deps bootstrap.Deps) (c
 	if callbackURL == "" && deps.BaseURL != "" {
 		callbackURL = deps.BaseURL + config.AuthCallbackPath
 	}
-	return pluginhost.NewExecutableAuthProvider(context.Background(), pluginhost.AuthExecConfig{
+	return providerhost.NewExecutableAuthProvider(context.Background(), providerhost.AuthExecConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Env:          cfg.Env,

--- a/gestaltd/internal/drivers/indexeddb/plugin/factory.go
+++ b/gestaltd/internal/drivers/indexeddb/plugin/factory.go
@@ -7,7 +7,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentplugin"
-	"github.com/valon-technologies/gestalt/server/internal/pluginhost"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"gopkg.in/yaml.v3"
 )
@@ -28,7 +28,7 @@ var Factory bootstrap.IndexedDBFactory = func(node yaml.Node) (indexeddb.Indexed
 	}
 	cfg = prepared.YAMLConfig
 
-	return pluginhost.NewExecutableIndexedDB(context.Background(), pluginhost.IndexedDBExecConfig{
+	return providerhost.NewExecutableIndexedDB(context.Background(), providerhost.IndexedDBExecConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Env:          cfg.Env,

--- a/gestaltd/internal/drivers/secrets/plugin/factory.go
+++ b/gestaltd/internal/drivers/secrets/plugin/factory.go
@@ -7,7 +7,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/drivers/componentplugin"
-	"github.com/valon-technologies/gestalt/server/internal/pluginhost"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"gopkg.in/yaml.v3"
 )
@@ -28,7 +28,7 @@ var Factory bootstrap.SecretManagerFactory = func(node yaml.Node) (core.SecretMa
 	}
 	cfg = prepared.YAMLConfig
 
-	return pluginhost.NewExecutableSecretManager(context.Background(), pluginhost.SecretsExecConfig{
+	return providerhost.NewExecutableSecretManager(context.Background(), providerhost.SecretsExecConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Env:          cfg.Env,

--- a/gestaltd/internal/providerhost/auth_client.go
+++ b/gestaltd/internal/providerhost/auth_client.go
@@ -1,4 +1,4 @@
-package pluginhost
+package providerhost
 
 import (
 	"context"

--- a/gestaltd/internal/providerhost/convert.go
+++ b/gestaltd/internal/providerhost/convert.go
@@ -1,4 +1,4 @@
-package pluginhost
+package providerhost
 
 import (
 	"encoding/json"

--- a/gestaltd/internal/providerhost/convert_test.go
+++ b/gestaltd/internal/providerhost/convert_test.go
@@ -1,4 +1,4 @@
-package pluginhost
+package providerhost
 
 import (
 	"testing"

--- a/gestaltd/internal/providerhost/cursor_test.go
+++ b/gestaltd/internal/providerhost/cursor_test.go
@@ -1,4 +1,4 @@
-package pluginhost
+package providerhost
 
 import (
 	"context"

--- a/gestaltd/internal/providerhost/declarative.go
+++ b/gestaltd/internal/providerhost/declarative.go
@@ -1,4 +1,4 @@
-package pluginhost
+package providerhost
 
 import (
 	"context"

--- a/gestaltd/internal/providerhost/grpc_test.go
+++ b/gestaltd/internal/providerhost/grpc_test.go
@@ -1,4 +1,4 @@
-package pluginhost
+package providerhost
 
 import (
 	"context"

--- a/gestaltd/internal/providerhost/indexeddb_client.go
+++ b/gestaltd/internal/providerhost/indexeddb_client.go
@@ -1,4 +1,4 @@
-package pluginhost
+package providerhost
 
 import (
 	"context"

--- a/gestaltd/internal/providerhost/indexeddb_server.go
+++ b/gestaltd/internal/providerhost/indexeddb_server.go
@@ -1,4 +1,4 @@
-package pluginhost
+package providerhost
 
 import (
 	"context"

--- a/gestaltd/internal/providerhost/manifest_core.go
+++ b/gestaltd/internal/providerhost/manifest_core.go
@@ -1,4 +1,4 @@
-package pluginhost
+package providerhost
 
 import (
 	"maps"

--- a/gestaltd/internal/providerhost/process.go
+++ b/gestaltd/internal/providerhost/process.go
@@ -1,4 +1,4 @@
-package pluginhost
+package providerhost
 
 import (
 	"context"

--- a/gestaltd/internal/providerhost/process_test.go
+++ b/gestaltd/internal/providerhost/process_test.go
@@ -1,4 +1,4 @@
-package pluginhost
+package providerhost
 
 import (
 	"os"

--- a/gestaltd/internal/providerhost/provider_client.go
+++ b/gestaltd/internal/providerhost/provider_client.go
@@ -1,4 +1,4 @@
-package pluginhost
+package providerhost
 
 import (
 	"context"

--- a/gestaltd/internal/providerhost/provider_server.go
+++ b/gestaltd/internal/providerhost/provider_server.go
@@ -1,4 +1,4 @@
-package pluginhost
+package providerhost
 
 import (
 	"context"

--- a/gestaltd/internal/providerhost/provider_test.go
+++ b/gestaltd/internal/providerhost/provider_test.go
@@ -1,4 +1,4 @@
-package pluginhost
+package providerhost
 
 import (
 	"context"

--- a/gestaltd/internal/providerhost/runtime_client.go
+++ b/gestaltd/internal/providerhost/runtime_client.go
@@ -1,4 +1,4 @@
-package pluginhost
+package providerhost
 
 import (
 	"context"

--- a/gestaltd/internal/providerhost/secrets_client.go
+++ b/gestaltd/internal/providerhost/secrets_client.go
@@ -1,4 +1,4 @@
-package pluginhost
+package providerhost
 
 import (
 	"context"

--- a/gestaltd/internal/testplugins/echo/main.go
+++ b/gestaltd/internal/testplugins/echo/main.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
-	"github.com/valon-technologies/gestalt/server/internal/pluginhost"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 )
 
 func main() {
@@ -32,7 +32,7 @@ func run() error {
 
 	switch os.Args[1] {
 	case "provider":
-		return pluginhost.ServeProvider(ctx, newProxyProvider(&echoProvider{}))
+		return providerhost.ServeProvider(ctx, newProxyProvider(&echoProvider{}))
 	default:
 		return fmt.Errorf("unknown mode %q", os.Args[1])
 	}

--- a/gestaltd/internal/testutil/indexeddbtransport/server.go
+++ b/gestaltd/internal/testutil/indexeddbtransport/server.go
@@ -8,7 +8,7 @@ import (
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
-	"github.com/valon-technologies/gestalt/server/internal/pluginhost"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"google.golang.org/grpc"
 )
 
@@ -30,7 +30,7 @@ func Start(socketPath string) (*Server, error) {
 	stub := &coretesting.StubIndexedDB{}
 	srv := grpc.NewServer()
 	// Empty prefix -- SDK clients don't expect prefixed store names.
-	proto.RegisterIndexedDBServer(srv, pluginhost.NewIndexedDBServer(stub, ""))
+	proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(stub, ""))
 	go func() { _ = srv.Serve(lis) }()
 	return &Server{srv: srv, lis: lis, Socket: socketPath}, nil
 }


### PR DESCRIPTION
## What changed

This renames the internal `gestaltd/internal/pluginhost` package to `gestaltd/internal/providerhost` and updates all call sites to use the new import path and package name.

## Why

`provider` is the umbrella term in the codebase now, while `plugin` is only one provider kind. The old `pluginhost` name was misleading because this package is also used for executable auth, indexeddb, and secrets providers.

## Impact

This is an internal refactor only. There are no protocol, config, or environment variable changes in this PR.

## Validation

- `go test ./internal/providerhost ./internal/bootstrap ./internal/drivers/auth/plugin ./internal/drivers/indexeddb/plugin ./internal/drivers/secrets/plugin ./internal/testutil/indexeddbtransport ./cmd/gestaltd`
- `go test ./internal/testplugins/echo`
