### PR TITLE
[codex] Rename internal plugin leftovers to provider

### DIFF
--- a/gestaltd/cmd/gestaltd/factories.go
+++ b/gestaltd/cmd/gestaltd/factories.go
@@ -12,11 +12,11 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	authplugin "github.com/valon-technologies/gestalt/server/internal/drivers/auth/plugin"
-	indexeddbplugin "github.com/valon-technologies/gestalt/server/internal/drivers/indexeddb/plugin"
+	authprovider "github.com/valon-technologies/gestalt/server/internal/drivers/auth/provider"
+	indexeddbprovider "github.com/valon-technologies/gestalt/server/internal/drivers/indexeddb/provider"
 	secretsenv "github.com/valon-technologies/gestalt/server/internal/drivers/secrets/env"
 	secretsfile "github.com/valon-technologies/gestalt/server/internal/drivers/secrets/file"
-	secretsplugin "github.com/valon-technologies/gestalt/server/internal/drivers/secrets/plugin"
+	secretsprovider "github.com/valon-technologies/gestalt/server/internal/drivers/secrets/provider"
 	telemetrynoop "github.com/valon-technologies/gestalt/server/internal/drivers/telemetry/noop"
 	telemetryotlp "github.com/valon-technologies/gestalt/server/internal/drivers/telemetry/otlp"
 	telemetrystdout "github.com/valon-technologies/gestalt/server/internal/drivers/telemetry/stdout"
@@ -86,7 +86,7 @@ func buildFactories() *bootstrap.FactoryRegistry {
 	factories.Telemetry["otlp"] = telemetryotlp.Factory
 	factories.Audit = func(ctx context.Context, cfg config.ProviderEntry, telemetry core.TelemetryProvider) (core.AuditSink, func(context.Context) error, error) {
 		if cfg.Source.IsManaged() || cfg.Source.IsLocal() {
-			return nil, nil, fmt.Errorf("plugin-based audit providers are not yet supported")
+			return nil, nil, fmt.Errorf("provider-based audit providers are not yet supported")
 		}
 		switch cfg.Source.Builtin {
 		case "", "inherit":
@@ -114,11 +114,11 @@ func buildFactories() *bootstrap.FactoryRegistry {
 			return nil, nil, fmt.Errorf("unknown audit provider %q", cfg.Source.Builtin)
 		}
 	}
-	factories.Auth = authplugin.Factory
-	factories.IndexedDB = indexeddbplugin.Factory
+	factories.Auth = authprovider.Factory
+	factories.IndexedDB = indexeddbprovider.Factory
 	factories.Secrets["env"] = secretsenv.Factory
 	factories.Secrets["file"] = secretsfile.Factory
-	factories.Secrets["plugin"] = secretsplugin.Factory
+	factories.Secrets["provider"] = secretsprovider.Factory
 	return factories
 }
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -152,7 +152,7 @@ func NewFactoryRegistry() *FactoryRegistry {
 type Result struct {
 	Auth             core.AuthProvider
 	Services         *coredata.Services
-	Providers        *registry.PluginMap[core.Provider]
+	Providers        *registry.ProviderMap[core.Provider]
 	ProvidersReady   <-chan struct{}
 	ConnectionAuth   func() map[string]map[string]OAuthHandler
 	Invoker          invocation.Invoker
@@ -416,7 +416,7 @@ func buildTelemetry(cfg *config.Config, factories *FactoryRegistry) (core.Teleme
 		return factory(tel.Config)
 	}
 	if tel != nil && !tel.Source.IsBuiltin() {
-		return nil, fmt.Errorf("bootstrap: plugin-based telemetry providers are not yet supported")
+		return nil, fmt.Errorf("bootstrap: provider-based telemetry providers are not yet supported")
 	}
 	builtin := ""
 	var configNode yaml.Node
@@ -441,7 +441,7 @@ func buildAuditSink(ctx context.Context, cfg *config.Config, factories *FactoryR
 		return invocation.NewLoggerAuditSink(slog.New(slog.DiscardHandler)), nil, nil
 	}
 	if audit != nil && !audit.Source.IsBuiltin() {
-		return nil, nil, fmt.Errorf("bootstrap: plugin-based audit providers are not yet supported")
+		return nil, nil, fmt.Errorf("bootstrap: provider-based audit providers are not yet supported")
 	}
 	builtin := ""
 	if audit != nil {
@@ -479,21 +479,21 @@ func buildSecretManager(cfg *config.Config, factories *FactoryRegistry) (core.Se
 		return disabledSecretManager{}, nil
 	}
 	if secrets != nil && !secrets.Source.IsBuiltin() {
-		factory, ok := factories.Secrets["plugin"]
+		factory, ok := factories.Secrets["provider"]
 		if !ok {
-			return nil, fmt.Errorf("bootstrap: secrets plugin factory is not registered")
+			return nil, fmt.Errorf("bootstrap: secrets provider factory is not registered")
 		}
 		node := secrets.Config
 		if !config.IsComponentRuntimeConfigNode(node) {
 			var err error
 			node, err = config.BuildComponentRuntimeConfigNode("secrets", "secrets", secrets, secrets.Config)
 			if err != nil {
-				return nil, fmt.Errorf("bootstrap: secrets plugin: %w", err)
+				return nil, fmt.Errorf("bootstrap: secrets provider: %w", err)
 			}
 		}
 		sm, err := factory(node)
 		if err != nil {
-			return nil, fmt.Errorf("bootstrap: secrets plugin: %w", err)
+			return nil, fmt.Errorf("bootstrap: secrets provider: %w", err)
 		}
 		return sm, nil
 	}
@@ -547,12 +547,12 @@ func buildAuth(cfg *config.Config, factories *FactoryRegistry, deps Deps) (core.
 		var err error
 		node, err = config.BuildComponentRuntimeConfigNode("auth", "auth", authEntry, authEntry.Config)
 		if err != nil {
-			return nil, fmt.Errorf("bootstrap: auth plugin: %w", err)
+			return nil, fmt.Errorf("bootstrap: auth provider: %w", err)
 		}
 	}
 	auth, err := factories.Auth(node, deps)
 	if err != nil {
-		return nil, fmt.Errorf("bootstrap: auth plugin: %w", err)
+		return nil, fmt.Errorf("bootstrap: auth provider: %w", err)
 	}
 	return auth, nil
 }
@@ -569,12 +569,12 @@ func buildIndexedDB(entry *config.ProviderEntry, factories *FactoryRegistry) (in
 		var err error
 		node, err = config.BuildComponentRuntimeConfigNode("indexeddb", "indexeddb", entry, entry.Config)
 		if err != nil {
-			return nil, fmt.Errorf("datastore plugin: %w", err)
+			return nil, fmt.Errorf("datastore provider: %w", err)
 		}
 	}
 	ds, err := factories.IndexedDB(node)
 	if err != nil {
-		return nil, fmt.Errorf("datastore plugin: %w", err)
+		return nil, fmt.Errorf("datastore provider: %w", err)
 	}
 	return ds, nil
 }

--- a/gestaltd/internal/bootstrap/cleanup.go
+++ b/gestaltd/internal/bootstrap/cleanup.go
@@ -10,7 +10,7 @@ import (
 )
 
 // CloseProviders closes all registered providers that implement io.Closer.
-func CloseProviders(providers *registry.PluginMap[core.Provider]) error {
+func CloseProviders(providers *registry.ProviderMap[core.Provider]) error {
 	if providers == nil {
 		return nil
 	}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -42,7 +42,7 @@ func buildRegistrationStore(deps Deps) mcpoauth.RegistrationStore {
 	return nil
 }
 
-func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.PluginMap[core.Provider], <-chan struct{}, func() map[string]map[string]OAuthHandler, error) {
+func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.ProviderMap[core.Provider], <-chan struct{}, func() map[string]map[string]OAuthHandler, error) {
 	reg := registry.New()
 	connAuth := make(map[string]map[string]OAuthHandler)
 	var connMu sync.Mutex

--- a/gestaltd/internal/bootstrap/result_boundary_test.go
+++ b/gestaltd/internal/bootstrap/result_boundary_test.go
@@ -71,7 +71,7 @@ func TestResultClose_ShutsDownConstructedResources(t *testing.T) {
 	}
 }
 
-func registryWithProvider(t *testing.T, name string, p *closableProvider) *registry.PluginMap[core.Provider] {
+func registryWithProvider(t *testing.T, name string, p *closableProvider) *registry.ProviderMap[core.Provider] {
 	t.Helper()
 	r := registry.New()
 	_ = r.Providers.Register(name, p)

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -42,7 +42,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 	return warnings, nil
 }
 
-func validateMCPCatalogs(providers *registry.PluginMap[core.Provider]) error {
+func validateMCPCatalogs(providers *registry.ProviderMap[core.Provider]) error {
 	for _, name := range providers.List() {
 		prov, err := providers.Get(name)
 		if err != nil {
@@ -59,7 +59,7 @@ func validateMCPCatalogs(providers *registry.PluginMap[core.Provider]) error {
 	return nil
 }
 
-func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.PluginMap[core.Provider], map[string]map[string]OAuthHandler, error) {
+func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.ProviderMap[core.Provider], map[string]map[string]OAuthHandler, error) {
 	reg := registry.New()
 	connAuth := make(map[string]map[string]OAuthHandler)
 

--- a/gestaltd/internal/drivers/auth/provider/factory.go
+++ b/gestaltd/internal/drivers/auth/provider/factory.go
@@ -1,4 +1,4 @@
-package plugin
+package provider
 
 import (
 	"context"
@@ -7,26 +7,26 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/internal/drivers/componentplugin"
+	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"gopkg.in/yaml.v3"
 )
 
 type yamlConfig struct {
-	componentplugin.YAMLConfig `yaml:",inline"`
-	CallbackURL                string `yaml:"callbackUrl"`
+	componentprovider.YAMLConfig `yaml:",inline"`
+	CallbackURL                  string `yaml:"callbackUrl"`
 }
 
 var Factory bootstrap.AuthFactory = func(node yaml.Node, deps bootstrap.Deps) (core.AuthProvider, error) {
 	var cfg yamlConfig
 	if err := node.Decode(&cfg); err != nil {
-		return nil, fmt.Errorf("plugin auth: parsing config: %w", err)
+		return nil, fmt.Errorf("auth provider: parsing config: %w", err)
 	}
-	prepared, err := componentplugin.PrepareExecution(componentplugin.PrepareParams{
+	prepared, err := componentprovider.PrepareExecution(componentprovider.PrepareParams{
 		Kind:                 providermanifestv1.KindAuth,
-		Subject:              "plugin auth",
-		SourceMissingMessage: "no Go, Rust, or Python auth source package found",
+		Subject:              "auth provider",
+		SourceMissingMessage: "no Go, Rust, or Python auth provider source package found",
 		Config:               cfg.YAMLConfig,
 	})
 	if err != nil {

--- a/gestaltd/internal/drivers/componentprovider/factory.go
+++ b/gestaltd/internal/drivers/componentprovider/factory.go
@@ -1,4 +1,4 @@
-package componentplugin
+package componentprovider
 
 import (
 	"errors"

--- a/gestaltd/internal/drivers/indexeddb/provider/factory.go
+++ b/gestaltd/internal/drivers/indexeddb/provider/factory.go
@@ -1,4 +1,4 @@
-package plugin
+package provider
 
 import (
 	"context"
@@ -6,21 +6,21 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
-	"github.com/valon-technologies/gestalt/server/internal/drivers/componentplugin"
+	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"gopkg.in/yaml.v3"
 )
 
 var Factory bootstrap.IndexedDBFactory = func(node yaml.Node) (indexeddb.IndexedDB, error) {
-	var cfg componentplugin.YAMLConfig
+	var cfg componentprovider.YAMLConfig
 	if err := node.Decode(&cfg); err != nil {
-		return nil, fmt.Errorf("plugin datastore: parsing config: %w", err)
+		return nil, fmt.Errorf("datastore provider: parsing config: %w", err)
 	}
-	prepared, err := componentplugin.PrepareExecution(componentplugin.PrepareParams{
+	prepared, err := componentprovider.PrepareExecution(componentprovider.PrepareParams{
 		Kind:                 providermanifestv1.KindIndexedDB,
-		Subject:              "plugin datastore",
-		SourceMissingMessage: "no Go, Rust, or Python datastore source package found",
+		Subject:              "datastore provider",
+		SourceMissingMessage: "no Go, Rust, or Python datastore provider source package found",
 		Config:               cfg,
 	})
 	if err != nil {

--- a/gestaltd/internal/drivers/secrets/provider/factory.go
+++ b/gestaltd/internal/drivers/secrets/provider/factory.go
@@ -1,4 +1,4 @@
-package plugin
+package provider
 
 import (
 	"context"
@@ -6,21 +6,21 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
-	"github.com/valon-technologies/gestalt/server/internal/drivers/componentplugin"
+	"github.com/valon-technologies/gestalt/server/internal/drivers/componentprovider"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"gopkg.in/yaml.v3"
 )
 
 var Factory bootstrap.SecretManagerFactory = func(node yaml.Node) (core.SecretManager, error) {
-	var cfg componentplugin.YAMLConfig
+	var cfg componentprovider.YAMLConfig
 	if err := node.Decode(&cfg); err != nil {
-		return nil, fmt.Errorf("plugin secrets: parsing config: %w", err)
+		return nil, fmt.Errorf("secrets provider: parsing config: %w", err)
 	}
-	prepared, err := componentplugin.PrepareExecution(componentplugin.PrepareParams{
+	prepared, err := componentprovider.PrepareExecution(componentprovider.PrepareParams{
 		Kind:                 providermanifestv1.KindSecrets,
-		Subject:              "plugin secrets",
-		SourceMissingMessage: "no Go, Rust, or Python secrets source package found",
+		Subject:              "secrets provider",
+		SourceMissingMessage: "no Go, Rust, or Python secrets provider source package found",
 		Config:               cfg,
 	})
 	if err != nil {

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -85,7 +85,7 @@ type OAuthRefresher interface {
 type RefresherResolver func() map[string]map[string]OAuthRefresher
 
 type Broker struct {
-	providers      *registry.PluginMap[core.Provider]
+	providers      *registry.ProviderMap[core.Provider]
 	users          *coredata.UserService
 	tokens         *coredata.TokenService
 	connMapper     ConnectionMapper
@@ -108,7 +108,7 @@ func WithConnectionAuth(r RefresherResolver) BrokerOption {
 	return func(b *Broker) { b.connectionAuth = r }
 }
 
-func NewBroker(providers *registry.PluginMap[core.Provider], users *coredata.UserService, tokens *coredata.TokenService, opts ...BrokerOption) *Broker {
+func NewBroker(providers *registry.ProviderMap[core.Provider], users *coredata.UserService, tokens *coredata.TokenService, opts ...BrokerOption) *Broker {
 	b := &Broker{providers: providers, users: users, tokens: tokens}
 	for _, o := range opts {
 		o(b)

--- a/gestaltd/internal/mcp/binding.go
+++ b/gestaltd/internal/mcp/binding.go
@@ -21,7 +21,7 @@ type Config struct {
 	Invoker          invocation.Invoker
 	TokenResolver    invocation.TokenResolver
 	AuditSink        core.AuditSink
-	Providers        *registry.PluginMap[core.Provider]
+	Providers        *registry.ProviderMap[core.Provider]
 	AllowedProviders []string
 	ToolPrefixes     map[string]string
 	IncludeREST      map[string]bool

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -549,15 +549,15 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 	return true
 }
 
-func PluginFingerprint(name string, plugin *config.ProviderEntry, configDir string) (string, error) {
-	if plugin == nil {
+func ProviderFingerprint(name string, entry *config.ProviderEntry, configDir string) (string, error) {
+	if entry == nil {
 		return "", nil
 	}
 
 	input := pluginFingerprintInput{
 		Name:    name,
-		Source:  plugin.SourceRef(),
-		Version: plugin.SourceVersion(),
+		Source:  entry.SourceRef(),
+		Version: entry.SourceVersion(),
 	}
 
 	payload, err := json.Marshal(input)
@@ -568,19 +568,19 @@ func PluginFingerprint(name string, plugin *config.ProviderEntry, configDir stri
 	return hex.EncodeToString(sum[:]), nil
 }
 
-func UIProviderFingerprint(plugin *config.ProviderEntry) (string, error) {
-	return PluginFingerprint("ui", plugin, "")
+func UIProviderFingerprint(entry *config.ProviderEntry) (string, error) {
+	return ProviderFingerprint("ui", entry, "")
 }
 
-func lockEntryMatches(paths initPaths, name string, plugin *config.ProviderEntry, entry LockEntry, found bool) bool {
+func lockEntryMatches(paths initPaths, name string, providerEntry *config.ProviderEntry, entry LockEntry, found bool) bool {
 	if !found {
 		return false
 	}
-	fingerprint, err := PluginFingerprint(name, plugin, paths.configDir)
+	fingerprint, err := ProviderFingerprint(name, providerEntry, paths.configDir)
 	if err != nil || entry.Fingerprint != fingerprint {
 		return false
 	}
-	if entry.Source != plugin.SourceRef() || entry.Version != plugin.SourceVersion() {
+	if entry.Source != providerEntry.SourceRef() || entry.Version != providerEntry.SourceVersion() {
 		return false
 	}
 	if len(entry.Archives) > 0 {
@@ -715,7 +715,7 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initP
 	if entrypoint == nil {
 		return LockEntry{}, fmt.Errorf("%s %q manifest does not define a %s entrypoint", kind, name, kind)
 	}
-	fingerprint, err := PluginFingerprint(name, plugin, paths.configDir)
+	fingerprint, err := ProviderFingerprint(name, plugin, paths.configDir)
 	if err != nil {
 		return LockEntry{}, fmt.Errorf("fingerprinting %s %q plugin: %w", kind, name, err)
 	}
@@ -771,7 +771,7 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 	if err := providerpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, providermanifestv1.KindPlugin, configMap); err != nil {
 		return LockProviderEntry{}, fmt.Errorf("plugin config validation for provider %q: %w", name, err)
 	}
-	fingerprint, err := PluginFingerprint(name, plugin, paths.configDir)
+	fingerprint, err := ProviderFingerprint(name, plugin, paths.configDir)
 	if err != nil {
 		return LockProviderEntry{}, fmt.Errorf("fingerprinting provider %q plugin: %w", name, err)
 	}
@@ -1134,7 +1134,7 @@ func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, na
 	if !ok {
 		return fmt.Errorf("prepared artifact for provider %q is missing or stale; run `gestaltd init --config %s`", name, paths.configPath)
 	}
-	fingerprint, err := PluginFingerprint(name, plugin, paths.configDir)
+	fingerprint, err := ProviderFingerprint(name, plugin, paths.configDir)
 	if err != nil {
 		return fmt.Errorf("fingerprinting provider %q plugin: %w", name, err)
 	}
@@ -1187,7 +1187,7 @@ func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry,
 	if entry == nil {
 		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", kind, name, paths.configPath)
 	}
-	fingerprint, err := PluginFingerprint(name, plugin, paths.configDir)
+	fingerprint, err := ProviderFingerprint(name, plugin, paths.configDir)
 	if err != nil {
 		return fmt.Errorf("fingerprinting %s %q plugin: %w", kind, name, err)
 	}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -188,7 +188,7 @@ func (l *Lifecycle) initAtPath(configPath, artifactsDir string) (*Lockfile, *con
 	if err := WriteLockfile(paths.lockfilePath, lock); err != nil {
 		return nil, nil, err
 	}
-	if err := l.applyLockedPlugins(configPath, artifactsDir, cfg, true); err != nil {
+	if err := l.applyLockedProviders(configPath, artifactsDir, cfg, true); err != nil {
 		return nil, nil, err
 	}
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
@@ -257,7 +257,7 @@ func (l *Lifecycle) LoadForExecutionAtPathWithArtifactsDir(configPath, artifacts
 		return nil, nil, err
 	}
 
-	if err := l.applyLockedPlugins(configPath, artifactsDir, cfg, locked); err != nil {
+	if err := l.applyLockedProviders(configPath, artifactsDir, cfg, locked); err != nil {
 		return nil, nil, err
 	}
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
@@ -281,7 +281,7 @@ func (l *Lifecycle) lockForSecretsBootstrap(configPath, artifactsDir string, pat
 	if cfg == nil || cfg.Providers.Secrets == nil || !cfg.Providers.Secrets.HasManagedSource() {
 		return nil, nil
 	}
-	if !configHasManagedPlugins(cfg) {
+	if !configHasManagedProviderSources(cfg) {
 		return nil, nil
 	}
 
@@ -290,7 +290,7 @@ func (l *Lifecycle) lockForSecretsBootstrap(configPath, artifactsDir string, pat
 		lock, err = l.InitAtPathWithArtifactsDir(configPath, artifactsDir)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("managed plugins require prepared artifacts; run `gestaltd init --config %s`: %w", configPath, err)
+		return nil, fmt.Errorf("managed providers require prepared artifacts; run `gestaltd init --config %s`: %w", configPath, err)
 	}
 	return lock, nil
 }
@@ -344,13 +344,13 @@ type initPaths struct {
 	uiDir        string
 }
 
-type pluginFingerprintInput struct {
+type providerFingerprintInput struct {
 	Name    string `json:"name"`
 	Source  string `json:"source,omitempty"`
 	Version string `json:"version,omitempty"`
 }
 
-func configHasPluginLoading(cfg *config.Config) bool {
+func configHasProviderLoading(cfg *config.Config) bool {
 	for _, entry := range cfg.Providers.Plugins {
 		if entry.HasManagedSource() || entry.HasLocalSource() {
 			return true
@@ -369,7 +369,7 @@ func configHasPluginLoading(cfg *config.Config) bool {
 	return false
 }
 
-func configHasManagedPlugins(cfg *config.Config) bool {
+func configHasManagedProviderSources(cfg *config.Config) bool {
 	for _, entry := range cfg.Providers.Plugins {
 		if entry.HasManagedSource() {
 			return true
@@ -554,7 +554,7 @@ func ProviderFingerprint(name string, entry *config.ProviderEntry, configDir str
 		return "", nil
 	}
 
-	input := pluginFingerprintInput{
+	input := providerFingerprintInput{
 		Name:    name,
 		Source:  entry.SourceRef(),
 		Version: entry.SourceVersion(),
@@ -657,7 +657,7 @@ func (l *Lifecycle) writeProviderArtifacts(ctx context.Context, cfg *config.Conf
 		}
 		configMap, err := config.NodeToMap(entry.Config)
 		if err != nil {
-			return nil, fmt.Errorf("decode plugin config for provider %q: %w", name, err)
+			return nil, fmt.Errorf("decode provider config for provider %q: %w", name, err)
 		}
 		if !entry.HasManagedSource() {
 			continue
@@ -675,18 +675,18 @@ func (l *Lifecycle) writeProviderArtifacts(ctx context.Context, cfg *config.Conf
 func (l *Lifecycle) writeComponentArtifact(ctx context.Context, paths initPaths, kind, name, destDir string, plugin *config.ProviderEntry, configNode yaml.Node) (LockEntry, error) {
 	configMap, err := config.NodeToMap(configNode)
 	if err != nil {
-		return LockEntry{}, fmt.Errorf("decode plugin config for %s %q: %w", kind, name, err)
+		return LockEntry{}, fmt.Errorf("decode provider config for %s %q: %w", kind, name, err)
 	}
 	return l.lockComponentEntryForSource(ctx, paths, kind, name, destDir, plugin, configMap)
 }
 
 func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initPaths, kind, name, destDir string, plugin *config.ProviderEntry, configMap map[string]any) (LockEntry, error) {
-	src, err := sourceForPlugin(plugin)
+	src, err := sourceForProvider(plugin)
 	if err != nil {
-		return LockEntry{}, fmt.Errorf("%s %q plugin.source.ref %q: %w", kind, name, plugin.SourceRef(), err)
+		return LockEntry{}, fmt.Errorf("%s %q source.ref %q: %w", kind, name, plugin.SourceRef(), err)
 	}
 	if l.sourceResolver == nil {
-		return LockEntry{}, fmt.Errorf("%s %q: source plugin resolution requires a source resolver", kind, name)
+		return LockEntry{}, fmt.Errorf("%s %q: source provider resolution requires a source resolver", kind, name)
 	}
 	resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
 	if err != nil {
@@ -696,7 +696,7 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initP
 
 	installed, err := pluginstore.Install(resolved.LocalPath, destDir)
 	if err != nil {
-		return LockEntry{}, fmt.Errorf("%s %q install source plugin: %w", kind, name, err)
+		return LockEntry{}, fmt.Errorf("%s %q install source provider: %w", kind, name, err)
 	}
 	if err := validateInstalledManifestKind(kind, name, installed.Manifest); err != nil {
 		return LockEntry{}, err
@@ -708,7 +708,7 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initP
 		return LockEntry{}, fmt.Errorf("%s %q: manifest version %q does not match config version %q", kind, name, installed.Manifest.Version, plugin.SourceVersion())
 	}
 	if err := providerpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, kind, configMap); err != nil {
-		return LockEntry{}, fmt.Errorf("plugin config validation for %s %q: %w", kind, name, err)
+		return LockEntry{}, fmt.Errorf("provider config validation for %s %q: %w", kind, name, err)
 	}
 
 	entrypoint := providerpkg.EntrypointForKind(installed.Manifest, kind)
@@ -717,7 +717,7 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initP
 	}
 	fingerprint, err := ProviderFingerprint(name, plugin, paths.configDir)
 	if err != nil {
-		return LockEntry{}, fmt.Errorf("fingerprinting %s %q plugin: %w", kind, name, err)
+		return LockEntry{}, fmt.Errorf("fingerprinting %s %q provider: %w", kind, name, err)
 	}
 	manifestPath, err := filepath.Rel(paths.artifactsDir, installed.ManifestPath)
 	if err != nil {
@@ -739,12 +739,12 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initP
 }
 
 func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPaths, name string, plugin *config.ProviderEntry, configMap map[string]any) (LockProviderEntry, error) {
-	src, err := sourceForPlugin(plugin)
+	src, err := sourceForProvider(plugin)
 	if err != nil {
-		return LockProviderEntry{}, fmt.Errorf("provider %q plugin.source.ref %q: %w", name, plugin.SourceRef(), err)
+		return LockProviderEntry{}, fmt.Errorf("provider %q source.ref %q: %w", name, plugin.SourceRef(), err)
 	}
 	if l.sourceResolver == nil {
-		return LockProviderEntry{}, fmt.Errorf("provider %q: source plugin resolution requires a source resolver", name)
+		return LockProviderEntry{}, fmt.Errorf("provider %q: source provider resolution requires a source resolver", name)
 	}
 	resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
 	if err != nil {
@@ -755,7 +755,7 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 	destDir := providerDestDir(paths, name)
 	installed, err := pluginstore.Install(resolved.LocalPath, destDir)
 	if err != nil {
-		return LockProviderEntry{}, fmt.Errorf("provider %q install source plugin: %w", name, err)
+		return LockProviderEntry{}, fmt.Errorf("provider %q install source provider: %w", name, err)
 	}
 	if err := validateInstalledManifestKind(providermanifestv1.KindPlugin, name, installed.Manifest); err != nil {
 		return LockProviderEntry{}, err
@@ -769,11 +769,11 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 	}
 
 	if err := providerpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, providermanifestv1.KindPlugin, configMap); err != nil {
-		return LockProviderEntry{}, fmt.Errorf("plugin config validation for provider %q: %w", name, err)
+		return LockProviderEntry{}, fmt.Errorf("provider config validation for provider %q: %w", name, err)
 	}
 	fingerprint, err := ProviderFingerprint(name, plugin, paths.configDir)
 	if err != nil {
-		return LockProviderEntry{}, fmt.Errorf("fingerprinting provider %q plugin: %w", name, err)
+		return LockProviderEntry{}, fmt.Errorf("fingerprinting provider %q: %w", name, err)
 	}
 	manifestPath, err := filepath.Rel(paths.artifactsDir, installed.ManifestPath)
 	if err != nil {
@@ -812,7 +812,7 @@ func (l *Lifecycle) writeUIProviderArtifact(ctx context.Context, cfg *config.Con
 	}
 
 	destDir := uiDestDir(paths)
-	src, err := sourceForPlugin(plugin)
+	src, err := sourceForProvider(plugin)
 	if err != nil {
 		return LockUIEntry{}, fmt.Errorf("ui provider source.ref %q: %w", plugin.SourceRef(), err)
 	}
@@ -839,7 +839,7 @@ func (l *Lifecycle) writeUIProviderArtifact(ctx context.Context, cfg *config.Con
 		return LockUIEntry{}, fmt.Errorf("ui provider manifest version %q does not match config version %q", installed.Manifest.Version, plugin.SourceVersion())
 	}
 	if err := providerpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, providermanifestv1.KindWebUI, configMap); err != nil {
-		return LockUIEntry{}, fmt.Errorf("plugin config validation for ui provider: %w", err)
+		return LockUIEntry{}, fmt.Errorf("provider config validation for ui provider: %w", err)
 	}
 	manifestPath, err := filepath.Rel(paths.artifactsDir, installed.ManifestPath)
 	if err != nil {
@@ -860,33 +860,33 @@ func (l *Lifecycle) writeUIProviderArtifact(ctx context.Context, cfg *config.Con
 	}, nil
 }
 
-func sourceForPlugin(plugin *config.ProviderEntry) (pluginsource.Source, error) {
-	src, err := pluginsource.Parse(plugin.SourceRef())
+func sourceForProvider(providerEntry *config.ProviderEntry) (pluginsource.Source, error) {
+	src, err := pluginsource.Parse(providerEntry.SourceRef())
 	if err != nil {
 		return pluginsource.Source{}, err
 	}
-	if plugin != nil && plugin.Source.Auth != nil {
-		auth := plugin.Source.Auth
+	if providerEntry != nil && providerEntry.Source.Auth != nil {
+		auth := providerEntry.Source.Auth
 		src.Token = auth.Token
 	}
 	return src, nil
 }
 
-func (l *Lifecycle) applyLockedPlugins(configPath, artifactsDir string, cfg *config.Config, locked bool) error {
-	if !configHasPluginLoading(cfg) {
+func (l *Lifecycle) applyLockedProviders(configPath, artifactsDir string, cfg *config.Config, locked bool) error {
+	if !configHasProviderLoading(cfg) {
 		return nil
 	}
 
 	paths := initPathsForConfigWithArtifactsDir(configPath, resolveArtifactsDir(configPath, cfg, artifactsDir))
 	var lock *Lockfile
 	var err error
-	if configHasManagedPlugins(cfg) {
+	if configHasManagedProviderSources(cfg) {
 		lock, err = ReadLockfile(paths.lockfilePath)
 		if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock)) {
 			lock, err = l.InitAtPathWithArtifactsDir(configPath, artifactsDir)
 		}
 		if err != nil {
-			return fmt.Errorf("managed plugins require prepared artifacts; run `gestaltd init --config %s`: %w", configPath, err)
+			return fmt.Errorf("managed providers require prepared artifacts; run `gestaltd init --config %s`: %w", configPath, err)
 		}
 	}
 
@@ -896,7 +896,7 @@ func (l *Lifecycle) applyLockedPlugins(configPath, artifactsDir string, cfg *con
 		}
 		configMap, err := config.NodeToMap(entry.Config)
 		if err != nil {
-			return fmt.Errorf("decode plugin config for provider %q: %w", name, err)
+			return fmt.Errorf("decode provider config for provider %q: %w", name, err)
 		}
 		switch {
 		case entry.HasManagedSource():
@@ -1136,7 +1136,7 @@ func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, na
 	}
 	fingerprint, err := ProviderFingerprint(name, plugin, paths.configDir)
 	if err != nil {
-		return fmt.Errorf("fingerprinting provider %q plugin: %w", name, err)
+		return fmt.Errorf("fingerprinting provider %q: %w", name, err)
 	}
 	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRef() || entry.Version != plugin.SourceVersion() {
 		return fmt.Errorf("prepared artifact for provider %q is missing or stale; run `gestaltd init --config %s`", name, paths.configPath)
@@ -1189,7 +1189,7 @@ func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry,
 	}
 	fingerprint, err := ProviderFingerprint(name, plugin, paths.configDir)
 	if err != nil {
-		return fmt.Errorf("fingerprinting %s %q plugin: %w", kind, name, err)
+		return fmt.Errorf("fingerprinting %s %q provider: %w", kind, name, err)
 	}
 	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRef() || entry.Version != plugin.SourceVersion() {
 		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", kind, name, paths.configPath)
@@ -1240,9 +1240,9 @@ func bindResolvedProviderManifest(name string, plugin *config.ProviderEntry, man
 		return err
 	}
 	if err := providerpkg.ValidateConfigForManifest(manifestPath, manifest, providermanifestv1.KindPlugin, configMap); err != nil {
-		return fmt.Errorf("plugin config validation for provider %q: %w", name, err)
+		return fmt.Errorf("provider config validation for provider %q: %w", name, err)
 	}
-	resolvePluginIcon(manifest, manifestPath, plugin)
+	resolveProviderIcon(manifest, manifestPath, plugin)
 	plugin.ResolvedManifestPath = manifestPath
 	plugin.ResolvedManifest = manifest
 	return nil
@@ -1254,9 +1254,9 @@ func bindResolvedComponentManifest(kind, name string, plugin *config.ProviderEnt
 		return err
 	}
 	if err := providerpkg.ValidateConfigForManifest(manifestPath, manifest, kind, configMap); err != nil {
-		return fmt.Errorf("plugin config validation for %s %q: %w", kind, name, err)
+		return fmt.Errorf("provider config validation for %s %q: %w", kind, name, err)
 	}
-	resolvePluginIcon(manifest, manifestPath, plugin)
+	resolveProviderIcon(manifest, manifestPath, plugin)
 	plugin.ResolvedManifestPath = manifestPath
 	plugin.ResolvedManifest = manifest
 	return nil
@@ -1268,9 +1268,9 @@ func bindResolvedUIManifest(plugin *config.ProviderEntry, manifestPath string, m
 		return err
 	}
 	if err := providerpkg.ValidateConfigForManifest(manifestPath, manifest, providermanifestv1.KindWebUI, configMap); err != nil {
-		return fmt.Errorf("plugin config validation for ui provider: %w", err)
+		return fmt.Errorf("provider config validation for ui provider: %w", err)
 	}
-	resolvePluginIcon(manifest, manifestPath, plugin)
+	resolveProviderIcon(manifest, manifestPath, plugin)
 	plugin.ResolvedManifestPath = manifestPath
 	plugin.ResolvedManifest = manifest
 	return nil
@@ -1286,7 +1286,7 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPat
 		return fmt.Errorf("no verified hash for platform %s for provider %q; run `gestaltd init --platform %s`", platform, name, platform)
 	}
 
-	src, parseErr := sourceForPlugin(plugin)
+	src, parseErr := sourceForProvider(plugin)
 	if parseErr != nil {
 		src, parseErr = pluginsource.Parse(entry.Source)
 	}
@@ -1299,31 +1299,31 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPat
 	} else {
 		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, archive.URL, nil)
 		if reqErr != nil {
-			return fmt.Errorf("create locked source plugin request for provider %q: %w", name, reqErr)
+			return fmt.Errorf("create locked source provider request for provider %q: %w", name, reqErr)
 		}
 		download, err = providerpkg.DownloadRequest(http.DefaultClient, req)
 	}
 	if err != nil {
-		return fmt.Errorf("download locked source plugin for provider %q: %w", name, err)
+		return fmt.Errorf("download locked source provider for provider %q: %w", name, err)
 	}
 	defer download.Cleanup()
 	if archive.SHA256 != "" && download.SHA256Hex != archive.SHA256 {
-		return fmt.Errorf("locked source plugin digest mismatch for provider %q: got %s, want %s", name, download.SHA256Hex, archive.SHA256)
+		return fmt.Errorf("locked source provider digest mismatch for provider %q: got %s, want %s", name, download.SHA256Hex, archive.SHA256)
 	}
 
 	destDir := providerDestDir(paths, name)
 	if err := os.RemoveAll(destDir); err != nil {
-		return fmt.Errorf("remove stale plugin cache for provider %q: %w", name, err)
+		return fmt.Errorf("remove stale provider cache for provider %q: %w", name, err)
 	}
 	installed, err := pluginstore.Install(download.LocalPath, destDir)
 	if err != nil {
-		return fmt.Errorf("install locked source plugin for provider %q: %w", name, err)
+		return fmt.Errorf("install locked source provider for provider %q: %w", name, err)
 	}
 	if installed.Manifest.Source != entry.Source {
-		return fmt.Errorf("locked source plugin manifest source mismatch for provider %q: got %q, want %q", name, installed.Manifest.Source, entry.Source)
+		return fmt.Errorf("locked source provider manifest source mismatch for provider %q: got %q, want %q", name, installed.Manifest.Source, entry.Source)
 	}
 	if installed.Manifest.Version != entry.Version {
-		return fmt.Errorf("locked source plugin manifest version mismatch for provider %q: got %q, want %q", name, installed.Manifest.Version, entry.Version)
+		return fmt.Errorf("locked source provider manifest version mismatch for provider %q: got %q, want %q", name, installed.Manifest.Version, entry.Version)
 	}
 	return nil
 }
@@ -1338,7 +1338,7 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 		return fmt.Errorf("no verified hash for platform %s for %s %q; run `gestaltd init --platform %s`", platform, kind, name, platform)
 	}
 
-	src, parseErr := sourceForPlugin(plugin)
+	src, parseErr := sourceForProvider(plugin)
 	if parseErr != nil {
 		src, parseErr = pluginsource.Parse(entry.Source)
 	}
@@ -1351,16 +1351,16 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 	} else {
 		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, archive.URL, nil)
 		if reqErr != nil {
-			return fmt.Errorf("create locked source plugin request for %s %q: %w", kind, name, reqErr)
+			return fmt.Errorf("create locked source provider request for %s %q: %w", kind, name, reqErr)
 		}
 		download, err = providerpkg.DownloadRequest(http.DefaultClient, req)
 	}
 	if err != nil {
-		return fmt.Errorf("download locked source plugin for %s %q: %w", kind, name, err)
+		return fmt.Errorf("download locked source provider for %s %q: %w", kind, name, err)
 	}
 	defer download.Cleanup()
 	if archive.SHA256 != "" && download.SHA256Hex != archive.SHA256 {
-		return fmt.Errorf("locked source plugin digest mismatch for %s %q: got %s, want %s", kind, name, download.SHA256Hex, archive.SHA256)
+		return fmt.Errorf("locked source provider digest mismatch for %s %q: got %s, want %s", kind, name, download.SHA256Hex, archive.SHA256)
 	}
 
 	var destDir string
@@ -1381,20 +1381,20 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 		return fmt.Errorf("unsupported component %q", name)
 	}
 	if err := os.RemoveAll(destDir); err != nil {
-		return fmt.Errorf("remove stale plugin cache for %s %q: %w", kind, name, err)
+		return fmt.Errorf("remove stale provider cache for %s %q: %w", kind, name, err)
 	}
 	installed, err := pluginstore.Install(download.LocalPath, destDir)
 	if err != nil {
-		return fmt.Errorf("install locked source plugin for %s %q: %w", kind, name, err)
+		return fmt.Errorf("install locked source provider for %s %q: %w", kind, name, err)
 	}
 	if err := validateInstalledManifestKind(kind, name, installed.Manifest); err != nil {
 		return err
 	}
 	if installed.Manifest.Source != entry.Source {
-		return fmt.Errorf("locked source plugin manifest source mismatch for %s %q: got %q, want %q", kind, name, installed.Manifest.Source, entry.Source)
+		return fmt.Errorf("locked source provider manifest source mismatch for %s %q: got %q, want %q", kind, name, installed.Manifest.Source, entry.Source)
 	}
 	if installed.Manifest.Version != entry.Version {
-		return fmt.Errorf("locked source plugin manifest version mismatch for %s %q: got %q, want %q", kind, name, installed.Manifest.Version, entry.Version)
+		return fmt.Errorf("locked source provider manifest version mismatch for %s %q: got %q, want %q", kind, name, installed.Manifest.Version, entry.Version)
 	}
 	return nil
 }
@@ -1409,7 +1409,7 @@ func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths initP
 		return fmt.Errorf("no verified hash for platform %s for ui provider; run `gestaltd init --platform %s`", platform, platform)
 	}
 
-	src, parseErr := sourceForPlugin(plugin)
+	src, parseErr := sourceForProvider(plugin)
 	if parseErr != nil {
 		src, parseErr = pluginsource.Parse(entry.Source)
 	}
@@ -1508,13 +1508,13 @@ func hashArchiveEntry(ctx context.Context, entry *LockEntry, platformKey string,
 	return nil
 }
 
-func resolvePluginIcon(manifest *providermanifestv1.Manifest, manifestPath string, plugin *config.ProviderEntry) {
+func resolveProviderIcon(manifest *providermanifestv1.Manifest, manifestPath string, plugin *config.ProviderEntry) {
 	if manifest.IconFile == "" {
 		return
 	}
 	iconPath := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(manifest.IconFile))
 	if _, err := os.Stat(iconPath); err != nil {
-		slog.Warn("plugin icon_file not found", "path", iconPath, "error", err)
+		slog.Warn("provider icon_file not found", "path", iconPath, "error", err)
 		return
 	}
 	plugin.ResolvedIconFile = iconPath

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -19,7 +19,7 @@ import (
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	secretsplugin "github.com/valon-technologies/gestalt/server/internal/drivers/secrets/plugin"
+	secretsprovider "github.com/valon-technologies/gestalt/server/internal/drivers/secrets/provider"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
 	ghresolver "github.com/valon-technologies/gestalt/server/internal/pluginsource/github"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
@@ -729,7 +729,7 @@ func TestSourceSecretsPluginBootstrapsManagedAuthSourceToken(t *testing.T) {
 	}
 
 	factories := bootstrap.NewFactoryRegistry()
-	factories.Secrets["plugin"] = secretsplugin.Factory
+	factories.Secrets["provider"] = secretsprovider.Factory
 
 	lc := NewLifecycle(resolver).WithConfigSecretResolver(func(ctx context.Context, cfg *config.Config) error {
 		return bootstrap.ResolveConfigSecrets(ctx, cfg, factories)

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -969,8 +969,8 @@ func TestApplyLockedPlugins_SkipsNilIntegrationPlugins(t *testing.T) {
 	loaded.Providers.Plugins["missing"] = &config.ProviderEntry{}
 
 	lc := NewLifecycle(nil)
-	if err := lc.applyLockedPlugins(cfgPath, "", loaded, false); err != nil {
-		t.Fatalf("applyLockedPlugins: %v", err)
+	if err := lc.applyLockedProviders(cfgPath, "", loaded, false); err != nil {
+		t.Fatalf("applyLockedProviders: %v", err)
 	}
 	if loaded.Providers.Plugins["example"] == nil || loaded.Providers.Plugins["example"].ResolvedManifest == nil {
 		t.Fatalf("ResolvedManifest = %+v", loaded.Providers.Plugins["example"])

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -997,38 +997,38 @@ func TestLockMatchesConfig_FalseWithNilLock(t *testing.T) {
 	}
 }
 
-func TestPluginFingerprint_Stable(t *testing.T) {
+func TestProviderFingerprint_Stable(t *testing.T) {
 	t.Parallel()
 
 	plugin := &config.ProviderEntry{
 		Source: config.ProviderSource{Ref: "github.com/test-org/test-repo/test-plugin", Version: "1.0.0"},
 	}
-	first, err := PluginFingerprint("example", plugin, ".")
+	first, err := ProviderFingerprint("example", plugin, ".")
 	if err != nil {
-		t.Fatalf("PluginFingerprint: %v", err)
+		t.Fatalf("ProviderFingerprint: %v", err)
 	}
-	second, err := PluginFingerprint("example", plugin, ".")
+	second, err := ProviderFingerprint("example", plugin, ".")
 	if err != nil {
-		t.Fatalf("PluginFingerprint: %v", err)
+		t.Fatalf("ProviderFingerprint: %v", err)
 	}
 	if first != second {
 		t.Fatalf("fingerprint not stable: %q != %q", first, second)
 	}
 }
 
-func TestPluginFingerprint_ChangesWithName(t *testing.T) {
+func TestProviderFingerprint_ChangesWithName(t *testing.T) {
 	t.Parallel()
 
 	plugin := &config.ProviderEntry{
 		Source: config.ProviderSource{Ref: "github.com/test-org/test-repo/test-plugin", Version: "1.0.0"},
 	}
-	first, err := PluginFingerprint("alpha", plugin, ".")
+	first, err := ProviderFingerprint("alpha", plugin, ".")
 	if err != nil {
-		t.Fatalf("PluginFingerprint: %v", err)
+		t.Fatalf("ProviderFingerprint: %v", err)
 	}
-	second, err := PluginFingerprint("beta", plugin, ".")
+	second, err := ProviderFingerprint("beta", plugin, ".")
 	if err != nil {
-		t.Fatalf("PluginFingerprint: %v", err)
+		t.Fatalf("ProviderFingerprint: %v", err)
 	}
 	if first == second {
 		t.Fatal("fingerprint should differ with different name")

--- a/gestaltd/internal/registry/registry.go
+++ b/gestaltd/internal/registry/registry.go
@@ -8,18 +8,18 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 )
 
-// PluginMap is a thread-safe, named collection of plugins of a single type.
-type PluginMap[T any] struct {
+// ProviderMap is a thread-safe, named collection of providers of a single type.
+type ProviderMap[T any] struct {
 	mu    sync.RWMutex
 	items map[string]T
 	kind  string
 }
 
-func newPluginMap[T any](kind string) PluginMap[T] {
-	return PluginMap[T]{items: make(map[string]T), kind: kind}
+func newProviderMap[T any](kind string) ProviderMap[T] {
+	return ProviderMap[T]{items: make(map[string]T), kind: kind}
 }
 
-func (m *PluginMap[T]) Register(name string, val T) error {
+func (m *ProviderMap[T]) Register(name string, val T) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, exists := m.items[name]; exists {
@@ -29,7 +29,7 @@ func (m *PluginMap[T]) Register(name string, val T) error {
 	return nil
 }
 
-func (m *PluginMap[T]) Get(name string) (T, error) {
+func (m *ProviderMap[T]) Get(name string) (T, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	val, ok := m.items[name]
@@ -41,7 +41,7 @@ func (m *PluginMap[T]) Get(name string) (T, error) {
 }
 
 // List returns all registered names, sorted alphabetically.
-func (m *PluginMap[T]) List() []string {
+func (m *ProviderMap[T]) List() []string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	names := make([]string, 0, len(m.items))
@@ -53,13 +53,13 @@ func (m *PluginMap[T]) List() []string {
 }
 
 type Registry struct {
-	AuthProviders PluginMap[core.AuthProvider]
-	Providers     PluginMap[core.Provider]
+	AuthProviders ProviderMap[core.AuthProvider]
+	Providers     ProviderMap[core.Provider]
 }
 
 func New() *Registry {
 	return &Registry{
-		AuthProviders: newPluginMap[core.AuthProvider]("auth provider"),
-		Providers:     newPluginMap[core.Provider]("provider"),
+		AuthProviders: newProviderMap[core.AuthProvider]("auth provider"),
+		Providers:     newProviderMap[core.Provider]("provider"),
 	}
 }

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -40,7 +40,7 @@ type Server struct {
 	users              *coredata.UserService
 	tokens             *coredata.TokenService
 	apiTokens          *coredata.APITokenService
-	providers          *registry.PluginMap[core.Provider]
+	providers          *registry.ProviderMap[core.Provider]
 	resolver           *principal.Resolver
 	invoker            invocation.Invoker
 	defaultConnection  map[string]string
@@ -68,7 +68,7 @@ type Config struct {
 	Auth              core.AuthProvider
 	AuditSink         core.AuditSink
 	Services          *coredata.Services
-	Providers         *registry.PluginMap[core.Provider]
+	Providers         *registry.ProviderMap[core.Provider]
 	Invoker           invocation.Invoker
 	DefaultConnection map[string]string
 	CatalogConnection map[string]string

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -46,7 +46,7 @@ func newTestServer(t *testing.T, opts ...func(*server.Config)) *httptest.Server 
 	cfg := server.Config{
 		Auth:     &coretesting.StubAuthProvider{N: "none"},
 		Services: coretesting.NewStubServices(t),
-		Providers: func() *registry.PluginMap[core.Provider] {
+		Providers: func() *registry.ProviderMap[core.Provider] {
 			reg := registry.New()
 			return &reg.Providers
 		}(),
@@ -229,7 +229,7 @@ func seedToken(t *testing.T, svc *coredata.Services, tok *core.IntegrationToken)
 func TestNewServerRequiresStateSecretWithAuth(t *testing.T) {
 	t.Parallel()
 	svc := coretesting.NewStubServices(t)
-	providers := func() *registry.PluginMap[core.Provider] {
+	providers := func() *registry.ProviderMap[core.Provider] {
 		reg := registry.New()
 		return &reg.Providers
 	}()
@@ -5586,7 +5586,7 @@ func TestRefresh_UsesConnectionAuth(t *testing.T) {
 	}
 }
 
-func newMCPHandler(t *testing.T, providers *registry.PluginMap[core.Provider], svc *coredata.Services, auditSink core.AuditSink) http.Handler {
+func newMCPHandler(t *testing.T, providers *registry.ProviderMap[core.Provider], svc *coredata.Services, auditSink core.AuditSink) http.Handler {
 	t.Helper()
 	broker := invocation.NewBroker(providers, svc.Users, svc.Tokens)
 	mcpInvoker := invocation.NewGuarded(broker, broker, "mcp", auditSink)
@@ -5688,7 +5688,7 @@ func TestMCPEndpoint_InitializeAndListTools(t *testing.T) {
 func TestMCPEndpoint_RequiresAuth(t *testing.T) {
 	t.Parallel()
 
-	providers := func() *registry.PluginMap[core.Provider] {
+	providers := func() *registry.ProviderMap[core.Provider] {
 		reg := registry.New()
 		return &reg.Providers
 	}()

--- a/gestaltd/internal/testutil/providers.go
+++ b/gestaltd/internal/testutil/providers.go
@@ -7,8 +7,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 )
 
-// NewProviderRegistry creates a PluginMap populated with the given providers.
-func NewProviderRegistry(t *testing.T, providers ...core.Provider) *registry.PluginMap[core.Provider] {
+// NewProviderRegistry creates a ProviderMap populated with the given providers.
+func NewProviderRegistry(t *testing.T, providers ...core.Provider) *registry.ProviderMap[core.Provider] {
 	t.Helper()
 	reg := registry.New()
 	for _, p := range providers {


### PR DESCRIPTION
## What changed

This follows the `pluginhost -> providerhost` rename with the remaining internal-only terminology cleanup that was still using old plugin-era names for generic provider infrastructure.

The PR renames:

- `registry.PluginMap` to `registry.ProviderMap`
- `PluginFingerprint` to `ProviderFingerprint`
- `internal/drivers/componentplugin` to `internal/drivers/componentprovider`
- the auth/indexeddb/secrets external-provider driver paths from `.../plugin` to `.../provider`

It also updates the related internal factory keys, comments, and error messages where those paths and symbols were no longer specific to `kind: plugin` integrations.

## Why

These names were describing generic provider infrastructure, not the plugin-kind integration surface. Keeping the old `plugin` terminology made the internals read as if they were specific to integration plugins when they are also used for auth, indexeddb, and secrets providers.

## Impact

This is an internal refactor only. It does not change the public config shape, protocol surface, or CLI terminology for `kind: plugin` integrations.

## Validation

- `go test ./cmd/gestaltd ./internal/bootstrap ./internal/operator ./internal/server ./internal/invocation ./internal/mcp ./internal/registry ./internal/drivers/auth/provider ./internal/drivers/indexeddb/provider ./internal/drivers/secrets/provider ./internal/drivers/componentprovider`
