### PR TITLE
[codex] Default gestaltd to web/default alpha.4

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -26,7 +26,7 @@ const (
 	DefaultProviderRepo = "github.com/valon-technologies/gestalt-providers"
 
 	DefaultWebUIProvider = DefaultProviderRepo + "/web/default"
-	DefaultWebUIVersion  = "0.0.1-alpha.9"
+	DefaultWebUIVersion  = "0.0.1-alpha.4"
 
 	DefaultIndexedDBProvider = DefaultProviderRepo + "/indexeddb/relationaldb"
 	DefaultIndexedDBVersion  = "0.0.1-alpha.2"


### PR DESCRIPTION
## Summary
- update `DefaultWebUIVersion` from stale `0.0.1-alpha.9` to `0.0.1-alpha.4`

## Why
- `gestaltd` already defaults to the managed first-party `web/default` provider when `providers.ui` is omitted
- the pinned default version should match the latest released default UI bundle

## Testing
- `go test ./internal/config/...` (from `gestaltd/`)