### PR TITLE
[codex] Fix stale locked artifact rehydration

### DIFF
--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -644,6 +644,19 @@ func lockEntryMatches(paths initPaths, name string, providerEntry *config.Provid
 	return true
 }
 
+func preparedManifestMatchesLock(entry LockEntry, manifest *providermanifestv1.Manifest) bool {
+	if manifest == nil {
+		return false
+	}
+	if entry.Source != "" && manifest.Source != entry.Source {
+		return false
+	}
+	if entry.Version != "" && manifest.Version != entry.Version {
+		return false
+	}
+	return true
+}
+
 // resolveArchiveForPlatform looks up a LockArchive for the given platform
 // string using a fallback chain: exact match → without libc → generic.
 func resolveArchiveForPlatform(entry LockEntry, platform string) (LockArchive, string, bool) {
@@ -1031,6 +1044,15 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths initPaths, lockEntry *LockUI
 				needMaterialize = true
 			}
 		}
+		if !needMaterialize {
+			_, manifest, err := providerpkg.ReadManifestFile(manifestPath)
+			if err != nil {
+				return "", fmt.Errorf("read prepared manifest for %s: %w", subject, err)
+			}
+			if !preparedManifestMatchesLock(*lockEntry, manifest) {
+				needMaterialize = true
+			}
+		}
 		if needMaterialize {
 			if err := l.materializeLockedUIProvider(context.Background(), paths, provider, *lockEntry, destDir, locked); err != nil {
 				return "", err
@@ -1220,6 +1242,15 @@ func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, na
 			needMaterialize = true
 		}
 	}
+	if !needMaterialize {
+		_, manifest, err := providerpkg.ReadManifestFile(manifestPath)
+		if err != nil {
+			return fmt.Errorf("read prepared manifest for provider %q: %w", name, err)
+		}
+		if !preparedManifestMatchesLock(entry, manifest) {
+			needMaterialize = true
+		}
+	}
 	if needMaterialize {
 		if err := l.materializeLockedProvider(context.Background(), paths, name, plugin, entry, locked); err != nil {
 			return err
@@ -1270,6 +1301,15 @@ func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry,
 	}
 	if !needMaterialize {
 		if _, err := os.Stat(executablePath); err != nil {
+			needMaterialize = true
+		}
+	}
+	if !needMaterialize {
+		_, manifest, err := providerpkg.ReadManifestFile(manifestPath)
+		if err != nil {
+			return fmt.Errorf("read prepared manifest for %s %q: %w", kind, name, err)
+		}
+		if !preparedManifestMatchesLock(*entry, manifest) {
 			needMaterialize = true
 		}
 	}

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -481,6 +481,109 @@ func TestSourcePluginLoadForExecution(t *testing.T) {
 	}
 }
 
+func TestSourcePluginLoadForExecution_RehydratesWhenCachedManifestVersionMismatchesLock(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := "github.com/acme/tools/gadget"
+	version := "2.0.0"
+	binaryContent := "fake-gadget-binary"
+
+	archivePath := buildV2Archive(t, dir, source, version, binaryContent)
+	archiveData, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	archiveSum := sha256.Sum256(archiveData)
+	archiveSHA := hex.EncodeToString(archiveSum[:])
+
+	var downloadCount atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downloadCount.Add(1)
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(archiveData)
+	}))
+	defer srv.Close()
+
+	resolver := &fakeResolver{
+		archivePath: archivePath,
+		resolvedURL: srv.URL + "/plugin.tar.gz",
+		sha256:      archiveSHA,
+	}
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	yaml := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+		"  plugins:",
+		"    gadget:",
+		"      source:",
+		"        ref: " + source,
+		"        version: " + version,
+		"server:",
+		"  indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(configPath, []byte(yaml), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle(resolver)
+	if _, err := lc.InitAtPath(configPath); err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+
+	lock, err := ReadLockfile(filepath.Join(filepath.Dir(configPath), InitLockfileName))
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	entry := lock.Providers["gadget"]
+	manifestPath := resolveLockPath(artifactsDir, entry.Manifest)
+
+	_, staleManifest, err := providerpkg.ReadManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadManifestFile(%s): %v", manifestPath, err)
+	}
+	staleManifest.Version = "1.9.9"
+	staleBytes, err := providerpkg.EncodeManifest(staleManifest)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(manifestPath, staleBytes, 0644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", manifestPath, err)
+	}
+
+	callsBefore := resolver.calls
+	downloadsBefore := downloadCount.Load()
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+	}
+	if resolver.calls != callsBefore {
+		t.Fatalf("resolver called during locked rehydration: got %d, want %d", resolver.calls, callsBefore)
+	}
+	if got := downloadCount.Load() - downloadsBefore; got != 1 {
+		t.Fatalf("download count during locked rehydration = %d, want 1", got)
+	}
+
+	gotManifest := cfg.Providers.Plugins["gadget"].ResolvedManifest
+	if gotManifest == nil {
+		t.Fatal("ResolvedManifest is nil")
+	}
+	if gotManifest.Version != version {
+		t.Fatalf("ResolvedManifest.Version = %q, want %q", gotManifest.Version, version)
+	}
+
+	_, readBack, err := providerpkg.ReadManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadManifestFile(%s) after rehydrate: %v", manifestPath, err)
+	}
+	if readBack.Version != version {
+		t.Fatalf("cached manifest version = %q, want %q", readBack.Version, version)
+	}
+}
+
 func TestSourceAuthPluginLoadForExecution(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

This fixes a stale prepared-artifact cache bug in `gestaltd`.

`LoadForExecution` was willing to reuse an existing prepared artifact as long as the config fingerprint still matched and the expected files existed. That was not strong enough when provider releases were deleted and re-released under the same configured version: an old cached `.gestaltd` manifest could survive and keep being loaded.

That behavior can leave manifest-backed providers like `linear` and `notion` out of sync with the lockfile and continue serving stale prepared artifacts.

## What changed

- require cached prepared manifests to match the lock entry's `source` and `version` before reusing them
- rematerialize stale cached artifacts for locked plugins, top-level components, and UI providers
- add a regression test that corrupts a cached prepared manifest version and verifies locked execution redownloads the correct artifact

## Root cause

The lockfile validation path checked config fingerprint and file existence, but not whether the already-materialized manifest on disk still matched the current lock entry.

## Validation

- `go test ./internal/operator -run 'TestSourcePluginLoadForExecution|TestSourcePluginLoadForExecution_RehydratesWhenCachedManifestVersionMismatchesLock' -count=1`
- `go test ./internal/operator -count=1`

## Follow-up

`valon-tools` still pins a specific `gestalt` commit in its deploy Dockerfile, so it will need a separate bump after this merges in order to pick up the fix.