### PR TITLE
Honor apiBaseUrl for spec-loaded providers

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -57,8 +57,9 @@ providers:
       source:
         ref: github.com/valon-technologies/gestalt-providers/plugins/github
         version: 0.0.1-alpha.1
-      config:
-        apiBaseUrl: https://api.github.com
+      surfaces:
+        openapi:
+          baseUrl: https://api.github.com
 ```
 
 `source.ref` points at a published provider package. Gestalt resolves and downloads it on startup. First-party providers are published to `github.com/valon-technologies/gestalt-providers/`.
@@ -356,8 +357,9 @@ providers:
       source:
         ref: github.com/valon-technologies/gestalt-providers/plugins/github
         version: 0.0.1-alpha.1
-      config:
-        apiBaseUrl: https://api.github.com
+      surfaces:
+        openapi:
+          baseUrl: https://api.github.com
       connections:
         api:
           mode: user

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -423,8 +423,9 @@ providers:
       source:
         ref: github.com/valon-technologies/gestalt-providers/github
         version: 1.2.3
-      config:
-        apiBaseUrl: https://api.github.com
+      surfaces:
+        openapi:
+          baseUrl: https://api.github.com
       connections:
         default:
           mode: user
@@ -444,6 +445,7 @@ providers:
 | `iconFile` | SVG icon path, resolved relative to the config directory. |
 | `source` | **Required.** The backing provider source. See [source shape](#providerspluginssource) below. |
 | `config` | Provider-specific configuration passed into the provider package. |
+| `surfaces` | Typed host-side overrides for manifest-declared surfaces, such as `surfaces.openapi.baseUrl` or `surfaces.graphql.url`. |
 | `connections` | Named connection declarations. See [connections](#connections) below. |
 | `allowedOperations` | Allowlist with optional `alias` and `description` overrides per operation. |
 | `indexeddbs` | Optional list of named `providers.indexeddbs` bindings exposed to the executable plugin through the SDK transport. Store names are automatically prefixed per plugin. A single binding also populates the default IndexedDB SDK env var for compatibility. |

--- a/gestaltd/internal/bootstrap/connections.go
+++ b/gestaltd/internal/bootstrap/connections.go
@@ -304,8 +304,8 @@ func resolveDefaultConnectionName(plugin *config.ProviderEntry, manifestPlugin *
 }
 
 func surfaceURL(plugin *config.ProviderEntry, manifestPlugin *providermanifestv1.Spec, surface config.SpecSurface) string {
-	if manifestPlugin == nil {
-		return ""
+	if url := config.ProviderSurfaceURLOverride(plugin, surface); url != "" {
+		return url
 	}
 	url := config.ManifestProviderSurfaceURL(manifestPlugin, surface)
 	if url == "" {

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -3,11 +3,14 @@ package bootstrap
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"sync/atomic"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -189,6 +192,122 @@ plugin = "provider"
 	}
 	if result.Body != `{"message":"Hi, Ada!"}` {
 		t.Fatalf("greet body = %q", result.Body)
+	}
+}
+
+func TestSpecLoadedOpenAPIProviderUsesConfiguredAPIBaseURL(t *testing.T) {
+	t.Parallel()
+
+	var docHits atomic.Int32
+	docSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		docHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"source":"document"}`))
+	}))
+	t.Cleanup(docSrv.Close)
+
+	var manifestHits atomic.Int32
+	manifestSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		manifestHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"source":"manifest"}`))
+	}))
+	t.Cleanup(manifestSrv.Close)
+
+	var configHits atomic.Int32
+	var configPath atomic.Value
+	configSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		configHits.Add(1)
+		configPath.Store(r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"source":"config"}`))
+	}))
+	t.Cleanup(configSrv.Close)
+
+	root := t.TempDir()
+	manifestPath := filepath.Join(root, "manifest.yaml")
+	if err := os.WriteFile(manifestPath, []byte("kind: plugin\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(manifest.yaml): %v", err)
+	}
+	openapiPath := filepath.Join(root, "openapi.yaml")
+	openapiDoc := fmt.Sprintf(`openapi: "3.1.0"
+info:
+  title: Example
+  version: "1.0.0"
+servers:
+  - url: %s
+paths:
+  /items:
+    get:
+      operationId: list_items
+      responses:
+        "200":
+          description: OK
+`, docSrv.URL)
+	if err := os.WriteFile(openapiPath, []byte(openapiDoc), 0o644); err != nil {
+		t.Fatalf("WriteFile(openapi.yaml): %v", err)
+	}
+
+	cfg := &config.Config{
+		Providers: config.ProvidersConfig{
+			Plugins: map[string]*config.ProviderEntry{
+				"example": {
+					ResolvedManifestPath: manifestPath,
+					ResolvedManifest: &providermanifestv1.Manifest{
+						Kind:        providermanifestv1.KindPlugin,
+						DisplayName: "Example",
+						Description: "OpenAPI example",
+						Spec: &providermanifestv1.Spec{
+							Surfaces: &providermanifestv1.ProviderSurfaces{
+								OpenAPI: &providermanifestv1.OpenAPISurface{
+									Document: "openapi.yaml",
+									BaseURL:  manifestSrv.URL,
+								},
+							},
+						},
+					},
+					Surfaces: &config.ProviderSurfaceOverrides{
+						OpenAPI: &config.ProviderOpenAPISurfaceOverride{
+							BaseURL: configSrv.URL,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseProviders(providers) })
+
+	prov, err := providers.Get("example")
+	if err != nil {
+		t.Fatalf("providers.Get(example): %v", err)
+	}
+
+	result, err := prov.Execute(context.Background(), "list_items", nil, "")
+	if err != nil {
+		t.Fatalf("Execute(list_items): %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", result.Status, http.StatusOK)
+	}
+	if got := result.Body; got != `{"source":"config"}` {
+		t.Fatalf("body = %q, want %q", got, `{"source":"config"}`)
+	}
+	if got, _ := configPath.Load().(string); got != "/items" {
+		t.Fatalf("request path = %q, want %q", got, "/items")
+	}
+	if got := configHits.Load(); got != 1 {
+		t.Fatalf("configured base URL hits = %d, want 1", got)
+	}
+	if got := manifestHits.Load(); got != 0 {
+		t.Fatalf("manifest base URL hits = %d, want 0", got)
+	}
+	if got := docHits.Load(); got != 0 {
+		t.Fatalf("document server hits = %d, want 0", got)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -219,7 +219,7 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 		manifestPlugin:       manifestPlugin,
 		allowedOperations:    allowedOperations,
 		allowedHosts:         entry.AllowedHosts,
-		baseURL:              manifestPlugin.SpecBaseURL(),
+		baseURL:              config.EffectiveProviderSpecBaseURL(entry, manifestPlugin),
 		applyResponseMapping: true,
 		providerBuildOptions: func(conn config.ConnectionDef) []provider.BuildOption {
 			return mcpOAuthBuildOpts(conn, manifestPlugin, deps)
@@ -293,7 +293,7 @@ func buildSpecLoadedProvider(ctx context.Context, name string, entry *config.Pro
 			manifestPlugin:       mp,
 			allowedOperations:    allowed,
 			allowedHosts:         entry.AllowedHosts,
-			baseURL:              mp.RESTBaseURL(),
+			baseURL:              config.EffectiveProviderSpecBaseURL(entry, mp),
 			applyResponseMapping: true,
 			providerBuildOptions: func(conn config.ConnectionDef) []provider.BuildOption {
 				return mcpOAuthBuildOpts(conn, mp, deps)

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -101,6 +101,7 @@ type ProviderEntry struct {
 	Connections       map[string]*ConnectionDef     `yaml:"connections,omitempty"`
 	AllowedOperations map[string]*OperationOverride `yaml:"allowedOperations,omitempty"`
 	IndexedDBs        []string                      `yaml:"indexeddbs,omitempty"`
+	Surfaces          *ProviderSurfaceOverrides     `yaml:"surfaces,omitempty"`
 
 	// Runtime-resolved fields (populated during init/bootstrap, not from YAML)
 	Command              string                                `yaml:"-"`
@@ -117,6 +118,29 @@ type ProviderEntry struct {
 	Discovery            *providermanifestv1.ProviderDiscovery `yaml:"-"`
 	ResolvedAssetRoot    string                                `yaml:"-"`
 	MCPToolPrefix        string                                `yaml:"-"`
+}
+
+type ProviderSurfaceOverrides struct {
+	REST    *ProviderRESTSurfaceOverride    `yaml:"rest,omitempty"`
+	OpenAPI *ProviderOpenAPISurfaceOverride `yaml:"openapi,omitempty"`
+	GraphQL *ProviderGraphQLSurfaceOverride `yaml:"graphql,omitempty"`
+	MCP     *ProviderMCPSurfaceOverride     `yaml:"mcp,omitempty"`
+}
+
+type ProviderRESTSurfaceOverride struct {
+	BaseURL string `yaml:"baseUrl,omitempty"`
+}
+
+type ProviderOpenAPISurfaceOverride struct {
+	BaseURL string `yaml:"baseUrl,omitempty"`
+}
+
+type ProviderGraphQLSurfaceOverride struct {
+	URL string `yaml:"url,omitempty"`
+}
+
+type ProviderMCPSurfaceOverride struct {
+	URL string `yaml:"url,omitempty"`
 }
 
 // UIEntry configures a mounted web UI bundle served under a fixed path prefix.

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -781,6 +781,70 @@ server:
 		}
 	})
 
+	t.Run("loads plugin surface overrides", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  plugins:
+    datadog:
+      source:
+        path: ./plugin/manifest.yaml
+      surfaces:
+        openapi:
+          baseUrl: https://api.us5.datadoghq.com
+  indexeddbs:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  indexeddb: sqlite
+  encryptionKey: server-key
+  `)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.Providers.Plugins["datadog"].Surfaces == nil || cfg.Providers.Plugins["datadog"].Surfaces.OpenAPI == nil {
+			t.Fatal("Plugins[datadog].Surfaces.OpenAPI is nil")
+		}
+		if got := cfg.Providers.Plugins["datadog"].Surfaces.OpenAPI.BaseURL; got != "https://api.us5.datadoghq.com" {
+			t.Fatalf("Plugins[datadog].Surfaces.OpenAPI.BaseURL = %q, want %q", got, "https://api.us5.datadoghq.com")
+		}
+	})
+
+	t.Run("rejects surface overrides outside plugins", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  ui:
+    root:
+      source:
+        path: ./web/root/manifest.yaml
+      path: /app
+      surfaces:
+        mcp:
+          url: https://mcp.example.test
+  indexeddbs:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  indexeddb: sqlite
+  encryptionKey: server-key
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `ui.root.surfaces is only supported on providers.plugins.*`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
 	t.Run("rejects unknown indexeddb binding names", func(t *testing.T) {
 		t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -275,6 +275,9 @@ func validatePluginOnlyProviderFields(subject string, entry *ProviderEntry) erro
 	if len(entry.IndexedDBs) > 0 {
 		return fmt.Errorf("config validation: %s.indexeddbs is only supported on providers.plugins.*", subject)
 	}
+	if entry.Surfaces != nil {
+		return fmt.Errorf("config validation: %s.surfaces is only supported on providers.plugins.*", subject)
+	}
 	return nil
 }
 

--- a/gestaltd/internal/config/surfaces.go
+++ b/gestaltd/internal/config/surfaces.go
@@ -1,6 +1,10 @@
 package config
 
-import providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+import (
+	"strings"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
 
 type SpecSurface string
 
@@ -50,4 +54,43 @@ func ManifestProviderSurfaceConnectionName(provider *providermanifestv1.Spec, su
 		return ""
 	}
 	return provider.SurfaceConnectionName(string(surface))
+}
+
+func ProviderSurfaceURLOverride(entry *ProviderEntry, surface SpecSurface) string {
+	if entry != nil && entry.Surfaces != nil {
+		switch surface {
+		case SpecSurfaceGraphQL:
+			if entry.Surfaces.GraphQL != nil {
+				if url := strings.TrimSpace(entry.Surfaces.GraphQL.URL); url != "" {
+					return url
+				}
+			}
+		case SpecSurfaceMCP:
+			if entry.Surfaces.MCP != nil {
+				if url := strings.TrimSpace(entry.Surfaces.MCP.URL); url != "" {
+					return url
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func EffectiveProviderSpecBaseURL(entry *ProviderEntry, provider *providermanifestv1.Spec) string {
+	if entry != nil && entry.Surfaces != nil {
+		if entry.Surfaces.REST != nil {
+			if baseURL := strings.TrimSpace(entry.Surfaces.REST.BaseURL); baseURL != "" {
+				return baseURL
+			}
+		}
+		if entry.Surfaces.OpenAPI != nil {
+			if baseURL := strings.TrimSpace(entry.Surfaces.OpenAPI.BaseURL); baseURL != "" {
+				return baseURL
+			}
+		}
+	}
+	if provider == nil {
+		return ""
+	}
+	return provider.SpecBaseURL()
 }

--- a/gestaltd/internal/config/surfaces_test.go
+++ b/gestaltd/internal/config/surfaces_test.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"testing"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func TestProviderSurfaceURLOverride(t *testing.T) {
+	t.Parallel()
+
+	entry := &ProviderEntry{
+		Surfaces: &ProviderSurfaceOverrides{
+			GraphQL: &ProviderGraphQLSurfaceOverride{URL: " https://config.example/graphql "},
+			MCP:     &ProviderMCPSurfaceOverride{URL: "https://config.example/mcp"},
+		},
+	}
+
+	if got := ProviderSurfaceURLOverride(entry, SpecSurfaceOpenAPI); got != "" {
+		t.Fatalf("ProviderSurfaceURLOverride(openapi) = %q, want empty", got)
+	}
+	if got := ProviderSurfaceURLOverride(entry, SpecSurfaceGraphQL); got != "https://config.example/graphql" {
+		t.Fatalf("ProviderSurfaceURLOverride(graphql) = %q, want %q", got, "https://config.example/graphql")
+	}
+	if got := ProviderSurfaceURLOverride(entry, SpecSurfaceMCP); got != "https://config.example/mcp" {
+		t.Fatalf("ProviderSurfaceURLOverride(mcp) = %q, want %q", got, "https://config.example/mcp")
+	}
+}
+
+func TestEffectiveProviderSpecBaseURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("prefers configured rest override", func(t *testing.T) {
+		t.Parallel()
+
+		entry := &ProviderEntry{
+			Surfaces: &ProviderSurfaceOverrides{
+				REST:    &ProviderRESTSurfaceOverride{BaseURL: " https://config.example/rest "},
+				OpenAPI: &ProviderOpenAPISurfaceOverride{BaseURL: "https://config.example/openapi"},
+			},
+		}
+		manifest := &providermanifestv1.Spec{
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				REST: &providermanifestv1.RESTSurface{BaseURL: "https://manifest.example/rest"},
+				OpenAPI: &providermanifestv1.OpenAPISurface{
+					Document: "openapi.yaml",
+					BaseURL:  "https://manifest.example/openapi",
+				},
+			},
+		}
+
+		if got := EffectiveProviderSpecBaseURL(entry, manifest); got != "https://config.example/rest" {
+			t.Fatalf("EffectiveProviderSpecBaseURL() = %q, want %q", got, "https://config.example/rest")
+		}
+	})
+
+	t.Run("falls back to configured openapi override", func(t *testing.T) {
+		t.Parallel()
+
+		entry := &ProviderEntry{
+			Surfaces: &ProviderSurfaceOverrides{
+				OpenAPI: &ProviderOpenAPISurfaceOverride{BaseURL: "https://config.example/openapi"},
+			},
+		}
+		manifest := &providermanifestv1.Spec{
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				OpenAPI: &providermanifestv1.OpenAPISurface{
+					Document: "openapi.yaml",
+					BaseURL:  "https://manifest.example/openapi",
+				},
+			},
+		}
+
+		if got := EffectiveProviderSpecBaseURL(entry, manifest); got != "https://config.example/openapi" {
+			t.Fatalf("EffectiveProviderSpecBaseURL() = %q, want %q", got, "https://config.example/openapi")
+		}
+	})
+
+	t.Run("falls back to manifest base urls", func(t *testing.T) {
+		t.Parallel()
+
+		manifest := &providermanifestv1.Spec{
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				OpenAPI: &providermanifestv1.OpenAPISurface{
+					Document: "openapi.yaml",
+					BaseURL:  "https://manifest.example/openapi",
+				},
+			},
+		}
+
+		if got := EffectiveProviderSpecBaseURL(nil, manifest); got != "https://manifest.example/openapi" {
+			t.Fatalf("EffectiveProviderSpecBaseURL() = %q, want %q", got, "https://manifest.example/openapi")
+		}
+	})
+
+	t.Run("returns empty when nothing is configured", func(t *testing.T) {
+		t.Parallel()
+
+		if got := EffectiveProviderSpecBaseURL(nil, nil); got != "" {
+			t.Fatalf("EffectiveProviderSpecBaseURL() = %q, want empty", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- honor plugin `config.apiBaseUrl` when building spec-loaded OpenAPI providers
- use the same base URL resolution path for hybrid executable+spec providers and spec-only providers
- add a regression test that verifies plugin config overrides both manifest `openapi.baseUrl` and the OpenAPI document `servers` URL

## Testing
- `go test ./internal/bootstrap`