### PR TITLE
[codex] Redact docs Terraform infrastructure identifiers

### DIFF
--- a/.github/workflows/deploy-gestalt-docs.yml
+++ b/.github/workflows/deploy-gestalt-docs.yml
@@ -12,6 +12,12 @@ env:
   PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
   REGION: ${{ vars.GCP_REGION }}
   SERVICE: ${{ vars.DOCS_SERVICE_NAME }}
+  DNS_PROJECT_ID: ${{ secrets.DOCS_DNS_PROJECT_ID }}
+  TERRAFORM_STATE_BUCKET: ${{ secrets.DOCS_TERRAFORM_STATE_BUCKET }}
+  TERRAFORM_STATE_PREFIX: ${{ vars.DOCS_TERRAFORM_STATE_PREFIX }}
+  DOCS_RESOURCE_PREFIX: ${{ vars.DOCS_RESOURCE_PREFIX }}
+  WIF_POOL_ID: ${{ vars.GCP_WIF_POOL_ID }}
+  WIF_PROVIDER_ID: ${{ vars.GCP_WIF_PROVIDER_ID }}
   IMAGE: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/cloud-run-source-deploy/${{ vars.DOCS_SERVICE_NAME }}
 
 jobs:
@@ -29,7 +35,7 @@ jobs:
         id: gcp-auth
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
-          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ env.WIF_POOL_ID }}/providers/${{ env.WIF_PROVIDER_ID }}
           service_account: github-actions@${{ env.PROJECT_ID }}.iam.gserviceaccount.com
           token_format: access_token
 
@@ -61,7 +67,10 @@ jobs:
 
       - name: Terraform Init
         working-directory: docs/terraform
-        run: terraform init
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ env.TERRAFORM_STATE_BUCKET }}" \
+            -backend-config="prefix=${{ env.TERRAFORM_STATE_PREFIX }}"
 
       - name: Terraform Apply
         working-directory: docs/terraform
@@ -69,6 +78,9 @@ jobs:
           TF_VAR_project_id: ${{ env.PROJECT_ID }}
           TF_VAR_project_number: ${{ secrets.GCP_PROJECT_NUMBER }}
           TF_VAR_region: ${{ env.REGION }}
+          TF_VAR_dns_project_id: ${{ env.DNS_PROJECT_ID }}
+          TF_VAR_resource_prefix: ${{ env.DOCS_RESOURCE_PREFIX }}
+          TF_VAR_wif_pool_id: ${{ env.WIF_POOL_ID }}
         run: |
           terraform apply -auto-approve \
             -var='docs_image=${{ env.IMAGE }}:${{ github.sha }}'

--- a/docs/terraform/backend.tf
+++ b/docs/terraform/backend.tf
@@ -1,6 +1,4 @@
 terraform {
   backend "gcs" {
-    bucket = "toolshed-terraform-state"
-    prefix = "toolshed-docs"
   }
 }

--- a/docs/terraform/main.tf
+++ b/docs/terraform/main.tf
@@ -20,13 +20,13 @@ provider "google" {
 }
 
 locals {
-  docs_cert_name = "toolshed-docs-cert-${replace(var.domain, ".", "-")}"
+  docs_cert_name = "${var.resource_prefix}-cert-${replace(var.domain, ".", "-")}"
 }
 
 # ---------- Cloud Run ----------
 
 resource "google_cloud_run_v2_service" "docs" {
-  name     = "toolshed-docs"
+  name     = var.resource_prefix
   location = var.region
   ingress  = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
 
@@ -61,7 +61,7 @@ resource "google_cloud_run_v2_service_iam_member" "public" {
 # ---------- Load Balancer ----------
 
 resource "google_compute_region_network_endpoint_group" "docs" {
-  name                  = "toolshed-docs-neg"
+  name                  = "${var.resource_prefix}-neg"
   region                = var.region
   network_endpoint_type = "SERVERLESS"
 
@@ -71,7 +71,7 @@ resource "google_compute_region_network_endpoint_group" "docs" {
 }
 
 resource "google_compute_backend_service" "docs" {
-  name                  = "toolshed-docs-backend"
+  name                  = "${var.resource_prefix}-backend"
   load_balancing_scheme = "EXTERNAL_MANAGED"
 
   backend {
@@ -80,7 +80,7 @@ resource "google_compute_backend_service" "docs" {
 }
 
 resource "google_compute_url_map" "docs" {
-  name            = "toolshed-docs-url-map"
+  name            = "${var.resource_prefix}-url-map"
   default_service = google_compute_backend_service.docs.id
 }
 
@@ -97,17 +97,17 @@ resource "google_compute_managed_ssl_certificate" "docs" {
 }
 
 resource "google_compute_target_https_proxy" "docs" {
-  name             = "toolshed-docs-https-proxy"
+  name             = "${var.resource_prefix}-https-proxy"
   url_map          = google_compute_url_map.docs.id
   ssl_certificates = [google_compute_managed_ssl_certificate.docs.id]
 }
 
 resource "google_compute_global_address" "docs" {
-  name = "toolshed-docs-ip"
+  name = "${var.resource_prefix}-ip"
 }
 
 resource "google_compute_global_forwarding_rule" "docs" {
-  name                  = "toolshed-docs-forwarding-rule"
+  name                  = "${var.resource_prefix}-forwarding-rule"
   load_balancing_scheme = "EXTERNAL_MANAGED"
   target                = google_compute_target_https_proxy.docs.id
   port_range            = "443"
@@ -117,7 +117,7 @@ resource "google_compute_global_forwarding_rule" "docs" {
 # ---------- HTTP-to-HTTPS Redirect ----------
 
 resource "google_compute_url_map" "docs_http_redirect" {
-  name = "toolshed-docs-http-redirect"
+  name = "${var.resource_prefix}-http-redirect"
 
   default_url_redirect {
     https_redirect         = true
@@ -127,12 +127,12 @@ resource "google_compute_url_map" "docs_http_redirect" {
 }
 
 resource "google_compute_target_http_proxy" "docs_redirect" {
-  name    = "toolshed-docs-http-proxy"
+  name    = "${var.resource_prefix}-http-proxy"
   url_map = google_compute_url_map.docs_http_redirect.id
 }
 
 resource "google_compute_global_forwarding_rule" "docs_http" {
-  name                  = "toolshed-docs-http-forwarding-rule"
+  name                  = "${var.resource_prefix}-http-forwarding-rule"
   load_balancing_scheme = "EXTERNAL_MANAGED"
   target                = google_compute_target_http_proxy.docs_redirect.id
   port_range            = "80"
@@ -143,7 +143,7 @@ resource "google_compute_global_forwarding_rule" "docs_http" {
 
 resource "google_dns_managed_zone" "docs" {
   provider    = google.dns
-  name        = "gestaltd-ai"
+  name        = replace(var.domain, ".", "-")
   dns_name    = "${var.domain}."
   description = "DNS zone for ${var.domain}"
 }

--- a/docs/terraform/variables.tf
+++ b/docs/terraform/variables.tf
@@ -1,7 +1,6 @@
 variable "project_id" {
   description = "GCP project hosting the Cloud Run service"
   type        = string
-  default     = "REDACTED_GCP_PROJECT"
 }
 
 variable "project_number" {
@@ -12,13 +11,11 @@ variable "project_number" {
 variable "region" {
   description = "GCP region for Cloud Run"
   type        = string
-  default     = "us-east4"
 }
 
 variable "dns_project_id" {
   description = "GCP project containing the DNS zone"
   type        = string
-  default     = "serviceone"
 }
 
 variable "domain" {
@@ -32,10 +29,14 @@ variable "docs_image" {
   type        = string
 }
 
+variable "resource_prefix" {
+  description = "Prefix used for docs infrastructure resource names"
+  type        = string
+}
+
 variable "wif_pool_id" {
   description = "Workload Identity Pool ID for GitHub Actions OIDC"
   type        = string
-  default     = "github-pool"
 }
 
 variable "github_repository" {


### PR DESCRIPTION
## What changed
- remove tracked GCS backend coordinates from `docs/terraform/backend.tf`
- make the docs Terraform use runtime inputs for the GCP project IDs, WIF pool ID, and docs resource prefix instead of hardcoded internal identifiers
- parameterize the `toolshed-docs-*` infrastructure names so the live values come from GitHub Actions variables rather than the public repo
- update `.github/workflows/deploy-gestalt-docs.yml` to pass the backend config and Terraform variables from GitHub Actions secrets/variables at deploy time

## Why
The public repo was exposing internal GCP infrastructure details in `docs/terraform/`, including the DNS project ID, Terraform state bucket, WIF pool identifier, and live resource naming scheme.

## Impact
- no intended infrastructure change; the workflow now supplies the same live values at runtime
- DNS management remains in place for now because the current docs deploy workflow is active on `main`; this PR only removes the public exposure, it does not migrate infra ownership
- repo-side Actions inputs were added to support the redacted workflow:
  - secrets: `DOCS_DNS_PROJECT_ID`, `DOCS_TERRAFORM_STATE_BUCKET`
  - variables: `DOCS_TERRAFORM_STATE_PREFIX`, `DOCS_RESOURCE_PREFIX`, `GCP_WIF_POOL_ID`, `GCP_WIF_PROVIDER_ID`

## Validation
- `terraform -chdir=docs/terraform init -backend=false`
- `terraform -chdir=docs/terraform validate`
- `actionlint .github/workflows/deploy-gestalt-docs.yml`