### PR TITLE
[codex] Replace internal publish email in release workflow

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -247,7 +247,7 @@ jobs:
               password_b64="$(printf '%s' "$GESTALT_TYPESCRIPT_PUBLISH_PASSWORD" | base64 | tr -d '\n')"
               printf "%s:username=%s\n" "$registry_host" "$GESTALT_TYPESCRIPT_PUBLISH_USERNAME"
               printf "%s:_password=%s\n" "$registry_host" "$password_b64"
-              printf "%s:email=%s\n" "$registry_host" "gestalt-ci@valon.com"
+              printf "%s:email=%s\n" "$registry_host" "github-actions[bot]@users.noreply.github.com"
             fi
           } > "$userconfig"
 


### PR DESCRIPTION
## Summary
- replace the internal `gestalt-ci@valon.com` address in the TypeScript SDK release workflow
- use GitHub's public noreply automation address instead
- align this workflow with the repo's existing automation identity convention

## Why
The workflow was writing an internal email address into the temporary `.npmrc` used for package publishing. That is not a secret by itself, but it exposes an internal automation identity that can be targeted for phishing, impersonation, and registry-account enumeration.

## Impact
This keeps the publish behavior unchanged while removing unnecessary disclosure of an internal address from repository-visible workflow configuration.

## Validation
- inspected the workflow diff
- ran `git diff --check`
