### PR TITLE
Document DynamoDB and MongoDB IndexedDB providers

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -273,7 +273,7 @@ providers:
         dsn: sqlite://./gestalt.db
 ```
 
-SQLite works for single-instance deployments. For production, use a Postgres or MySQL DSN. See [IndexedDB](/providers/indexeddb) for the full provider model.
+SQLite works for single-instance deployments. For production, use a networked IndexedDB provider such as `indexeddb/relationaldb` with Postgres or MySQL, `indexeddb/dynamodb`, or `indexeddb/mongodb`. See [IndexedDB](/providers/indexeddb) for the full provider model.
 
 ## Telemetry and audit
 

--- a/docs/content/deploy/index.mdx
+++ b/docs/content/deploy/index.mdx
@@ -8,7 +8,7 @@ The server image `valontechnologies/gestaltd:latest` is published for `linux/amd
 
 ## Production considerations
 
-**Database.** SQLite works for single-instance deployments. For multi-replica or horizontally scaled deployments, use a networked datastore provider such as the first-party `indexeddb/relationaldb` package with a Postgres or MySQL DSN. See [IndexedDB](/providers/indexeddb) for the provider model.
+**Database.** SQLite works for single-instance deployments. For multi-replica or horizontally scaled deployments, use a networked datastore provider such as the first-party `indexeddb/relationaldb`, `indexeddb/dynamodb`, or `indexeddb/mongodb` packages. See [IndexedDB](/providers/indexeddb) for the provider model.
 
 **Secrets.** Use `file` or a cloud secret manager instead of `env` in production. `file` is built in and works with Kubernetes volume-mounted secrets. Cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) are available as external providers from [`gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). Gestalt config supports `secret://` references that are resolved at boot time through the configured secrets provider. See [Secrets Providers](/providers/secrets) for setup details.
 

--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -20,6 +20,8 @@ First-party storage backends live under
 | Provider | Repository | Source ref | Notes |
 | --- | --- | --- | --- |
 | RelationalDB | [`indexeddb/relationaldb`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/relationaldb) | `github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb` | Supports PostgreSQL, MySQL, SQLite, and SQL Server through a `dsn` config value |
+| DynamoDB | [`indexeddb/dynamodb`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/dynamodb) | `github.com/valon-technologies/gestalt-providers/indexeddb/dynamodb` | Uses Amazon DynamoDB with `table`, `region`, and optional `endpoint` config |
+| MongoDB | [`indexeddb/mongodb`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/mongodb) | `github.com/valon-technologies/gestalt-providers/indexeddb/mongodb` | Uses MongoDB with `uri` and optional `database` config |
 
 ## Configuring storage
 
@@ -56,6 +58,33 @@ providers:
 
 The first-party RelationalDB provider accepts `postgres://`, `mysql://`,
 `sqlite://`, and `sqlserver://` DSN prefixes.
+
+Other first-party IndexedDB providers use their own config blocks:
+
+```yaml
+providers:
+  indexeddbs:
+    main:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/dynamodb
+        version: 0.0.1-alpha.1
+      config:
+        table: gestalt
+        region: us-east-1
+        # endpoint: http://localhost:8000
+```
+
+```yaml
+providers:
+  indexeddbs:
+    main:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/mongodb
+        version: 0.0.1-alpha.1
+      config:
+        uri: ${MONGODB_URI}
+        database: gestalt
+```
 
 ## Operational notes
 

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -45,6 +45,12 @@ providers:
         dsn: ${DATABASE_URL}
 ```
 
+| Name | Purpose |
+| --- | --- |
+| `relationaldb` | SQL-backed IndexedDB provider for PostgreSQL, MySQL, SQLite, and SQL Server. |
+| `dynamodb` | Amazon DynamoDB-backed IndexedDB provider for managed key-value and document storage. |
+| `mongodb` | MongoDB-backed IndexedDB provider for document-oriented storage. |
+
 ## Secret Managers
 
 Two secret managers are compiled into the `gestaltd` binary and resolve `secret://` references during bootstrap. Cloud secret backends are available as external providers published from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers).

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -178,6 +178,14 @@ providers:
 
 The exact config fields depend on the selected external indexeddb provider package. Gestalt itself does not have a built-in indexeddb driver matrix; it loads the configured provider process and passes the selected `providers.indexeddbs.<name>.config` block through to that provider.
 
+Common first-party IndexedDB packages:
+
+| Provider | Source ref | Config fields |
+| --- | --- | --- |
+| RelationalDB | `github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb` | `dsn` |
+| DynamoDB | `github.com/valon-technologies/gestalt-providers/indexeddb/dynamodb` | `table`, `region`, optional `endpoint` |
+| MongoDB | `github.com/valon-technologies/gestalt-providers/indexeddb/mongodb` | `uri`, optional `database` |
+
 ## `providers.secrets`
 
 The secrets manager resolves `secret://` references at startup. Two built-in sources (`env` and `file`) are selected by the `source` field. Cloud secret backends are loaded as external providers using `source.ref`, the same way auth and indexeddb providers work.


### PR DESCRIPTION
## Summary
- add DynamoDB and MongoDB to the first-party IndexedDB provider docs
- document their config fields in the config reference
- mention them in the configuration and deploy guides

## Testing
- git diff --check