### PR TITLE
Preserve camelCase in TypeScript catalog YAML

### DIFF
--- a/sdk/typescript/src/catalog.ts
+++ b/sdk/typescript/src/catalog.ts
@@ -105,7 +105,7 @@ export function catalogToJson(catalog: Catalog | Record<string, unknown> | null 
 }
 
 export function catalogToYaml(catalog: Catalog | Record<string, unknown>): string {
-  return YAML.stringify(toCatalogYamlObject(catalog));
+  return YAML.stringify(toCatalogJsonObject(catalog));
 }
 
 export function writeCatalogYaml(path: string, catalog: Catalog | Record<string, unknown>): void {
@@ -168,26 +168,4 @@ function toCatalogJsonObject(catalog: Catalog | Record<string, unknown>): Record
   }
 
   return output;
-}
-
-function toCatalogYamlObject(catalog: Catalog | Record<string, unknown>): Record<string, unknown> {
-  return snakeCaseKeys(toCatalogJsonObject(catalog)) as Record<string, unknown>;
-}
-
-function snakeCaseKeys(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map((entry) => snakeCaseKeys(entry));
-  }
-  if (value === null || typeof value !== "object") {
-    return value;
-  }
-  const output: Record<string, unknown> = {};
-  for (const [key, entry] of Object.entries(value)) {
-    output[toSnakeCase(key)] = snakeCaseKeys(entry);
-  }
-  return output;
-}
-
-function toSnakeCase(input: string): string {
-  return input.replace(/[A-Z]/g, (match) => `_${match.toLowerCase()}`);
 }

--- a/sdk/typescript/tests/plugin.test.ts
+++ b/sdk/typescript/tests/plugin.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 
 import { connectionParam, ok, request, response } from "../src/api.ts";
+import { catalogToYaml } from "../src/catalog.ts";
 import { definePlugin, operation } from "../src/plugin.ts";
 import { s } from "../src/schema.ts";
 
@@ -154,6 +155,36 @@ test("plugin rejects duplicate operation identifiers after trimming", () => {
       ],
     }),
   ).toThrow('duplicate operation id "ping"');
+});
+
+test("catalog yaml preserves camelCase schema and metadata fields", () => {
+  const plugin = definePlugin({
+    name: "demo",
+    displayName: "Demo Provider",
+    operations: [
+      operation({
+        id: "ping",
+        input: s.object({
+          projectId: s.string(),
+        }),
+        output: s.object({
+          ok: s.boolean(),
+        }),
+        handler() {
+          return { ok: true };
+        },
+      }),
+    ],
+  });
+
+  const yaml = catalogToYaml(plugin.staticCatalog());
+  expect(yaml).toContain("displayName: Demo Provider");
+  expect(yaml).toContain("inputSchema:");
+  expect(yaml).toContain("projectId:");
+  expect(yaml).toContain("outputSchema:");
+  expect(yaml).not.toContain("display_name:");
+  expect(yaml).not.toContain("input_schema:");
+  expect(yaml).not.toContain("output_schema:");
 });
 
 test("plugin treats raw outputs with a body field as plain output values", async () => {


### PR DESCRIPTION
## Summary
- stop lowercasing TypeScript SDK catalog YAML keys to snake_case
- keep YAML output aligned with Gestalt's static catalog parser expectations
- add a focused SDK test covering `displayName`, `inputSchema`, and `outputSchema`

## Verification
- `cd sdk/typescript && bun test tests/plugin.test.ts`
- `cd sdk/typescript && bun run typecheck`