### PR TITLE
Parse schema fields in YAML static catalogs

### DIFF
--- a/gestaltd/core/catalog/catalog.go
+++ b/gestaltd/core/catalog/catalog.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 var validSegment = regexp.MustCompile(`^[a-zA-Z0-9_]([a-zA-Z0-9_-]*[a-zA-Z0-9_])?$`)
@@ -36,8 +38,8 @@ type CatalogOperation struct {
 	Path           string               `yaml:"path"                     json:"path"`
 	Title          string               `yaml:"title,omitempty"          json:"title,omitempty"`
 	Description    string               `yaml:"description,omitempty"    json:"description,omitempty"`
-	InputSchema    json.RawMessage      `yaml:"-"                        json:"inputSchema,omitempty"`
-	OutputSchema   json.RawMessage      `yaml:"-"                        json:"outputSchema,omitempty"`
+	InputSchema    json.RawMessage      `yaml:"inputSchema,omitempty"    json:"inputSchema,omitempty"`
+	OutputSchema   json.RawMessage      `yaml:"outputSchema,omitempty"   json:"outputSchema,omitempty"`
 	Annotations    OperationAnnotations `yaml:"annotations,omitempty"    json:"annotations,omitempty"`
 	Parameters     []CatalogParameter   `yaml:"parameters,omitempty"     json:"parameters,omitempty"`
 	RequiredScopes []string             `yaml:"requiredScopes,omitempty" json:"requiredScopes,omitempty"`
@@ -46,6 +48,61 @@ type CatalogOperation struct {
 	Visible        *bool                `yaml:"visible,omitempty"        json:"visible,omitempty"`
 	Transport      string               `yaml:"transport,omitempty"      json:"transport,omitempty"`
 	Query          string               `yaml:"query,omitempty"          json:"query,omitempty"`
+}
+
+func (o *CatalogOperation) UnmarshalYAML(value *yaml.Node) error {
+	type catalogOperationYAML struct {
+		ID             string               `yaml:"id"`
+		ProviderID     string               `yaml:"providerId,omitempty"`
+		Method         string               `yaml:"method"`
+		Path           string               `yaml:"path"`
+		Title          string               `yaml:"title,omitempty"`
+		Description    string               `yaml:"description,omitempty"`
+		InputSchema    any                  `yaml:"inputSchema,omitempty"`
+		OutputSchema   any                  `yaml:"outputSchema,omitempty"`
+		Annotations    OperationAnnotations `yaml:"annotations,omitempty"`
+		Parameters     []CatalogParameter   `yaml:"parameters,omitempty"`
+		RequiredScopes []string             `yaml:"requiredScopes,omitempty"`
+		Tags           []string             `yaml:"tags,omitempty"`
+		ReadOnly       bool                 `yaml:"readOnly,omitempty"`
+		Visible        *bool                `yaml:"visible,omitempty"`
+		Transport      string               `yaml:"transport,omitempty"`
+		Query          string               `yaml:"query,omitempty"`
+	}
+
+	var aux catalogOperationYAML
+	if err := value.Decode(&aux); err != nil {
+		return err
+	}
+
+	inputSchema, err := rawJSONFromValue(aux.InputSchema)
+	if err != nil {
+		return fmt.Errorf("marshal inputSchema: %w", err)
+	}
+	outputSchema, err := rawJSONFromValue(aux.OutputSchema)
+	if err != nil {
+		return fmt.Errorf("marshal outputSchema: %w", err)
+	}
+
+	*o = CatalogOperation{
+		ID:             aux.ID,
+		ProviderID:     aux.ProviderID,
+		Method:         aux.Method,
+		Path:           aux.Path,
+		Title:          aux.Title,
+		Description:    aux.Description,
+		InputSchema:    inputSchema,
+		OutputSchema:   outputSchema,
+		Annotations:    aux.Annotations,
+		Parameters:     aux.Parameters,
+		RequiredScopes: aux.RequiredScopes,
+		Tags:           aux.Tags,
+		ReadOnly:       aux.ReadOnly,
+		Visible:        aux.Visible,
+		Transport:      aux.Transport,
+		Query:          aux.Query,
+	}
+	return nil
 }
 
 type OperationAnnotations struct {
@@ -161,4 +218,15 @@ func validateOperationID(id string) error {
 		}
 	}
 	return nil
+}
+
+func rawJSONFromValue(value any) (json.RawMessage, error) {
+	if value == nil {
+		return nil, nil
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(data), nil
 }

--- a/gestaltd/internal/providerpkg/catalog_test.go
+++ b/gestaltd/internal/providerpkg/catalog_test.go
@@ -1,0 +1,72 @@
+package providerpkg
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadStaticCatalogParsesYAMLSchemas(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	data := []byte(`
+name: provider
+displayName: Demo Provider
+operations:
+  - id: echo
+    method: POST
+    inputSchema:
+      type: object
+      properties:
+        message:
+          type: string
+      required:
+        - message
+    outputSchema:
+      type: object
+      properties:
+        echoed:
+          type: string
+`)
+	if err := os.WriteFile(filepath.Join(root, StaticCatalogFile), data, 0o644); err != nil {
+		t.Fatalf("WriteFile(catalog.yaml): %v", err)
+	}
+
+	cat, err := ReadStaticCatalog(root, "")
+	if err != nil {
+		t.Fatalf("ReadStaticCatalog: %v", err)
+	}
+	if cat == nil {
+		t.Fatal("expected catalog")
+	}
+	if cat.DisplayName != "Demo Provider" {
+		t.Fatalf("DisplayName = %q, want %q", cat.DisplayName, "Demo Provider")
+	}
+	if len(cat.Operations) != 1 {
+		t.Fatalf("operation count = %d, want 1", len(cat.Operations))
+	}
+	if len(cat.Operations[0].InputSchema) == 0 {
+		t.Fatal("expected inputSchema to be parsed")
+	}
+	if len(cat.Operations[0].OutputSchema) == 0 {
+		t.Fatal("expected outputSchema to be parsed")
+	}
+
+	var input map[string]any
+	if err := json.Unmarshal(cat.Operations[0].InputSchema, &input); err != nil {
+		t.Fatalf("Unmarshal(inputSchema): %v", err)
+	}
+	if input["type"] != "object" {
+		t.Fatalf("inputSchema.type = %v, want object", input["type"])
+	}
+
+	var output map[string]any
+	if err := json.Unmarshal(cat.Operations[0].OutputSchema, &output); err != nil {
+		t.Fatalf("Unmarshal(outputSchema): %v", err)
+	}
+	if output["type"] != "object" {
+		t.Fatalf("outputSchema.type = %v, want object", output["type"])
+	}
+}


### PR DESCRIPTION
## Summary
- teach static catalog YAML decoding to preserve `inputSchema` and `outputSchema`
- convert YAML schema objects into the JSON raw messages Gestalt already carries internally
- add a regression test for reading schema-bearing YAML catalogs through `ReadStaticCatalog`

## Verification
- `cd gestaltd && go test ./internal/providerpkg ./core/catalog`