### PR TITLE
[codex] Sanitize SDK internal error responses

### DIFF
--- a/sdk/go/auth_transport_test.go
+++ b/sdk/go/auth_transport_test.go
@@ -3,6 +3,8 @@ package gestalt_test
 import (
 	"bytes"
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,10 +24,14 @@ type configCall struct {
 
 type fullAuthProvider struct {
 	closeTracker
-	configured []configCall
+	configured   []configCall
+	configureErr error
 }
 
 func (p *fullAuthProvider) Configure(_ context.Context, name string, config map[string]any) error {
+	if p.configureErr != nil {
+		return p.configureErr
+	}
 	p.configured = append(p.configured, configCall{name: name, config: config})
 	return nil
 }
@@ -175,7 +181,7 @@ func TestAuthProviderRoundTrip(t *testing.T) {
 	completeResp, err := authClient.CompleteLogin(rpcCtx, &proto.CompleteLoginRequest{
 		Query:         map[string]string{"code": "auth-code"},
 		ProviderState: []byte("state-data"),
-		CallbackUrl: "https://app.example.test/callback",
+		CallbackUrl:   "https://app.example.test/callback",
 	})
 	if err != nil {
 		t.Fatalf("CompleteLogin: %v", err)
@@ -203,6 +209,39 @@ func TestAuthProviderRoundTrip(t *testing.T) {
 	const expectedTTL int64 = 1800
 	if sessionResp.GetSessionTtlSeconds() != expectedTTL {
 		t.Fatalf("session_ttl_seconds = %d, want %d", sessionResp.GetSessionTtlSeconds(), expectedTTL)
+	}
+}
+
+func TestAuthProviderConfigureProviderSanitizesErrors(t *testing.T) {
+	socket := newSocketPath(t, "auth-config-error.sock")
+	t.Setenv(proto.EnvProviderSocket, socket)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	provider := &fullAuthProvider{configureErr: errors.New("configure exploded")}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- gestalt.ServeAuthProvider(ctx, provider)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		waitServeResult(t, errCh)
+	})
+
+	conn := newUnixConn(t, socket)
+	runtimeClient := proto.NewProviderLifecycleClient(conn)
+
+	rpcCtx, rpcCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer rpcCancel()
+
+	_, err := runtimeClient.ConfigureProvider(rpcCtx, &proto.ConfigureProviderRequest{
+		Name:            "my-auth",
+		ProtocolVersion: proto.CurrentProtocolVersion,
+	})
+	if err == nil {
+		t.Fatal("ConfigureProvider should return error")
+	}
+	if got := err.Error(); !strings.Contains(got, "configure provider: internal error") {
+		t.Fatalf("ConfigureProvider error = %q, want sanitized message", got)
 	}
 }
 

--- a/sdk/go/errors.go
+++ b/sdk/go/errors.go
@@ -17,6 +17,7 @@ const (
 	unknownOperationMessage   = "unknown operation"
 	routerNilMessage          = "router is nil"
 	nilResultMessage          = "provider returned nil result"
+	internalErrorMessage      = "internal error"
 	internalErrorBodyFallback = `{"error":"internal error"}`
 )
 
@@ -59,29 +60,25 @@ func operationResultFromError(err error) *OperationResult {
 		return nil
 	}
 	status := http.StatusInternalServerError
-	message := err.Error()
+	message := internalErrorMessage
 	var opErr *operationError
 	if errors.As(err, &opErr) {
 		if opErr.status != 0 {
 			status = opErr.status
 		}
 		message = opErr.message
-		if message == "" {
-			message = opErr.Error()
-		}
 	}
 	return operationResult(status, message)
 }
 
 func recoveredOperationResult(operation string, recovered any) *OperationResult {
-	message := fmt.Sprint(recovered)
 	if operation == "" {
 		fmt.Fprintf(os.Stderr, "panic in Gestalt operation: %v\n", recovered)
 	} else {
 		fmt.Fprintf(os.Stderr, "panic in Gestalt operation %q: %v\n", operation, recovered)
 	}
 	_, _ = os.Stderr.Write(debug.Stack())
-	return operationResult(http.StatusInternalServerError, message)
+	return operationResult(http.StatusInternalServerError, internalErrorMessage)
 }
 
 func protectedOperationResult(operation string, fn func() (*OperationResult, error)) (result *OperationResult) {
@@ -132,5 +129,5 @@ func providerRPCError(operation string, err error) error {
 	if st, ok := status.FromError(err); ok {
 		return st.Err()
 	}
-	return status.Errorf(codes.Unknown, "%s: %v", operation, err)
+	return status.Errorf(codes.Unknown, "%s: %s", operation, internalErrorMessage)
 }

--- a/sdk/go/provider_server.go
+++ b/sdk/go/provider_server.go
@@ -49,7 +49,7 @@ func (s *ProviderServer) StartProvider(ctx context.Context, req *proto.StartProv
 		config = map[string]any{}
 	}
 	if err := s.provider.Configure(ctx, req.GetName(), config); err != nil {
-		return nil, status.Errorf(codes.Unknown, "configure provider: %v", err)
+		return nil, status.Errorf(codes.Unknown, "configure provider: %s", internalErrorMessage)
 	}
 	return &proto.StartProviderResponse{
 		ProtocolVersion: proto.CurrentProtocolVersion,
@@ -92,7 +92,7 @@ func (s *ProviderServer) GetSessionCatalog(ctx context.Context, req *proto.GetSe
 	}
 	cat, err := scp.CatalogForRequest(ctx, req.GetToken())
 	if err != nil {
-		return nil, status.Errorf(codes.Unknown, "session catalog: %v", err)
+		return nil, status.Errorf(codes.Unknown, "session catalog: %s", internalErrorMessage)
 	}
 	return &proto.GetSessionCatalogResponse{Catalog: cat}, nil
 }

--- a/sdk/go/router.go
+++ b/sdk/go/router.go
@@ -89,7 +89,7 @@ func Register[P any, In any, Out any](
 			}
 			body, err := json.Marshal(resp.Body)
 			if err != nil {
-				return nil, newOperationError(http.StatusInternalServerError, fmt.Sprintf("marshal response for %q: %v", op.ID, err), err)
+				return nil, newOperationError(http.StatusInternalServerError, internalErrorMessage, err)
 			}
 			return &OperationResult{Status: status, Body: string(body)}, nil
 		},

--- a/sdk/go/router_test.go
+++ b/sdk/go/router_test.go
@@ -110,6 +110,10 @@ type execOutput struct {
 	CredentialSubjectID string `json:"credential_subject_id"`
 }
 
+type invalidJSONOutput struct {
+	Ch chan int `json:"ch"`
+}
+
 type execProvider struct{}
 
 func (p *execProvider) Configure(context.Context, string, map[string]any) error { return nil }
@@ -154,6 +158,15 @@ func TestRouterOperationExecution(t *testing.T) {
 			},
 			func(*execProvider, context.Context, struct{}, gestalt.Request) (gestalt.Response[struct{}], error) {
 				return gestalt.Response[struct{}]{}, errors.New("boom")
+			},
+		),
+		gestalt.Register(
+			gestalt.Operation[struct{}, invalidJSONOutput]{
+				ID:     "marshal_error",
+				Method: http.MethodPost,
+			},
+			func(*execProvider, context.Context, struct{}, gestalt.Request) (gestalt.Response[invalidJSONOutput], error) {
+				return gestalt.OK(invalidJSONOutput{Ch: make(chan int)}), nil
 			},
 		),
 	)
@@ -218,6 +231,17 @@ func TestRouterOperationExecution(t *testing.T) {
 	}
 	if result.Body != `{"error":"internal error"}` {
 		t.Fatalf("plain_error body = %q, want %q", result.Body, `{"error":"internal error"}`)
+	}
+
+	result, err = router.Execute(ctx, provider, "marshal_error", nil, "tok")
+	if err != nil {
+		t.Fatalf("Execute(marshal_error): %v", err)
+	}
+	if result.Status != http.StatusInternalServerError {
+		t.Fatalf("marshal_error status = %d, want %d", result.Status, http.StatusInternalServerError)
+	}
+	if result.Body != `{"error":"internal error"}` {
+		t.Fatalf("marshal_error body = %q, want %q", result.Body, `{"error":"internal error"}`)
 	}
 
 	var nilRouter *gestalt.Router[execProvider]

--- a/sdk/go/router_test.go
+++ b/sdk/go/router_test.go
@@ -216,8 +216,8 @@ func TestRouterOperationExecution(t *testing.T) {
 	if result.Status != http.StatusInternalServerError {
 		t.Fatalf("plain_error status = %d, want %d", result.Status, http.StatusInternalServerError)
 	}
-	if result.Body != `{"error":"boom"}` {
-		t.Fatalf("plain_error body = %q, want %q", result.Body, `{"error":"boom"}`)
+	if result.Body != `{"error":"internal error"}` {
+		t.Fatalf("plain_error body = %q, want %q", result.Body, `{"error":"internal error"}`)
 	}
 
 	var nilRouter *gestalt.Router[execProvider]

--- a/sdk/go/runtime_server.go
+++ b/sdk/go/runtime_server.go
@@ -62,7 +62,7 @@ func (s *runtimeServer) ConfigureProvider(ctx context.Context, req *proto.Config
 		config = map[string]any{}
 	}
 	if err := s.provider.Configure(ctx, req.GetName(), config); err != nil {
-		return nil, status.Errorf(codes.Unknown, "configure provider: %v", err)
+		return nil, status.Errorf(codes.Unknown, "configure provider: %s", internalErrorMessage)
 	}
 	return &proto.ConfigureProviderResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
 }

--- a/sdk/go/serve_test.go
+++ b/sdk/go/serve_test.go
@@ -92,11 +92,15 @@ func (p *stubProvider) panicOp(_ context.Context, _ stubInput, _ gestalt.Request
 
 type startableStubProvider struct {
 	stubProvider
-	name   string
-	config map[string]any
+	name         string
+	config       map[string]any
+	configureErr error
 }
 
 func (p *startableStubProvider) Configure(_ context.Context, name string, config map[string]any) error {
+	if p.configureErr != nil {
+		return p.configureErr
+	}
 	p.name = name
 	p.config = config
 	return nil
@@ -105,9 +109,13 @@ func (p *startableStubProvider) Configure(_ context.Context, name string, config
 type sessionCatalogStubProvider struct {
 	stubProvider
 	sessionCatalog *proto.Catalog
+	catalogErr     error
 }
 
 func (p *sessionCatalogStubProvider) CatalogForRequest(ctx context.Context, _ string) (*proto.Catalog, error) {
+	if p.catalogErr != nil {
+		return nil, p.catalogErr
+	}
 	cat := protoutil.Clone(p.sessionCatalog).(*proto.Catalog)
 	if cat != nil {
 		subject := gestalt.SubjectFromContext(ctx)
@@ -191,6 +199,19 @@ func TestProviderServerGetSessionCatalog(t *testing.T) {
 		_, err := client.GetSessionCatalog(context.Background(), &proto.GetSessionCatalogRequest{Token: "t"})
 		if err == nil {
 			t.Fatal("GetSessionCatalog should return error for unsupported provider")
+		}
+	})
+
+	t.Run("provider error is sanitized", func(t *testing.T) {
+		client := newIntegrationProviderClient(t, &sessionCatalogStubProvider{
+			catalogErr: errors.New("catalog exploded"),
+		}, sessionCatalogStubRouter)
+		_, err := client.GetSessionCatalog(context.Background(), &proto.GetSessionCatalogRequest{Token: "t"})
+		if err == nil {
+			t.Fatal("GetSessionCatalog should return error")
+		}
+		if got := err.Error(); !strings.Contains(got, "session catalog: internal error") {
+			t.Fatalf("GetSessionCatalog error = %q, want sanitized message", got)
 		}
 	})
 }
@@ -320,26 +341,44 @@ func TestProviderServerExecute(t *testing.T) {
 func TestProviderServerStartProvider(t *testing.T) {
 	t.Parallel()
 
-	prov := &startableStubProvider{}
-	client := newIntegrationProviderClient(t, prov, startableStubRouter)
-	ctx := context.Background()
+	t.Run("success", func(t *testing.T) {
+		prov := &startableStubProvider{}
+		client := newIntegrationProviderClient(t, prov, startableStubRouter)
+		ctx := context.Background()
 
-	cfg, _ := structpb.NewStruct(map[string]any{"key": "val"})
-	resp, err := client.StartProvider(ctx, &proto.StartProviderRequest{
-		Name:            "my-instance",
-		Config:          cfg,
-		ProtocolVersion: proto.CurrentProtocolVersion,
+		cfg, _ := structpb.NewStruct(map[string]any{"key": "val"})
+		resp, err := client.StartProvider(ctx, &proto.StartProviderRequest{
+			Name:            "my-instance",
+			Config:          cfg,
+			ProtocolVersion: proto.CurrentProtocolVersion,
+		})
+		if err != nil {
+			t.Fatalf("StartProvider: %v", err)
+		}
+		if resp.GetProtocolVersion() != proto.CurrentProtocolVersion {
+			t.Errorf("ProtocolVersion = %d, want %d", resp.GetProtocolVersion(), proto.CurrentProtocolVersion)
+		}
+		if prov.name != "my-instance" {
+			t.Errorf("name = %q, want %q", prov.name, "my-instance")
+		}
+		if prov.config["key"] != "val" {
+			t.Errorf("config[key] = %v, want %q", prov.config["key"], "val")
+		}
 	})
-	if err != nil {
-		t.Fatalf("StartProvider: %v", err)
-	}
-	if resp.GetProtocolVersion() != proto.CurrentProtocolVersion {
-		t.Errorf("ProtocolVersion = %d, want %d", resp.GetProtocolVersion(), proto.CurrentProtocolVersion)
-	}
-	if prov.name != "my-instance" {
-		t.Errorf("name = %q, want %q", prov.name, "my-instance")
-	}
-	if prov.config["key"] != "val" {
-		t.Errorf("config[key] = %v, want %q", prov.config["key"], "val")
-	}
+
+	t.Run("configure failure is sanitized", func(t *testing.T) {
+		client := newIntegrationProviderClient(t, &startableStubProvider{
+			configureErr: errors.New("config exploded"),
+		}, startableStubRouter)
+		_, err := client.StartProvider(context.Background(), &proto.StartProviderRequest{
+			Name:            "my-instance",
+			ProtocolVersion: proto.CurrentProtocolVersion,
+		})
+		if err == nil {
+			t.Fatal("StartProvider should return error")
+		}
+		if got := err.Error(); !strings.Contains(got, "configure provider: internal error") {
+			t.Fatalf("StartProvider error = %q, want sanitized message", got)
+		}
+	})
 }

--- a/sdk/go/serve_test.go
+++ b/sdk/go/serve_test.go
@@ -278,7 +278,7 @@ func TestProviderServerExecute(t *testing.T) {
 			name:       "handler error",
 			router:     errorRouter,
 			wantStatus: http.StatusInternalServerError,
-			wantBody:   `{"error":"boom"}`,
+			wantBody:   `{"error":"internal error"}`,
 			request: &proto.ExecuteRequest{
 				Operation: "error_op",
 			},
@@ -287,7 +287,7 @@ func TestProviderServerExecute(t *testing.T) {
 			name:       "panic",
 			router:     panicRouter,
 			wantStatus: http.StatusInternalServerError,
-			wantBody:   `{"error":"boom"}`,
+			wantBody:   `{"error":"internal error"}`,
 			request: &proto.ExecuteRequest{
 				Operation: "panic_op",
 			},

--- a/sdk/python/gestalt/_operations.py
+++ b/sdk/python/gestalt/_operations.py
@@ -10,6 +10,8 @@ from typing import Any, Union, get_args, get_origin, get_type_hints
 from ._api import Error, Request, Response
 from ._serialization import json_body
 
+INTERNAL_ERROR_MESSAGE = "internal error"
+
 
 @dataclass(frozen=True, slots=True)
 class OperationDefinition:
@@ -91,7 +93,7 @@ def execute_operation(
         return _error_result(error.status, error.message)
     except Exception as error:
         traceback.print_exception(error)
-        return _error_result(HTTPStatus.INTERNAL_SERVER_ERROR, str(error))
+        return _error_result(HTTPStatus.INTERNAL_SERVER_ERROR, INTERNAL_ERROR_MESSAGE)
 
 
 def decode_input(input_type: Any, params: dict[str, Any]) -> Any:

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -455,7 +455,7 @@ def _auth_servicer(*, provider: PluginProvider) -> Any:
                 traceback.print_exception(error)
                 return context.abort(
                     grpc.StatusCode.UNKNOWN,
-                    f"validate external token: {error}",
+                    f"validate external token: {INTERNAL_ERROR_MESSAGE}",
                 )
             if user is None:
                 return context.abort(

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -58,6 +58,7 @@ CURRENT_PROTOCOL_VERSION: Final[int] = 2
 GRPC_SERVER_MAX_WORKERS: Final[int] = 4
 GRPC_SHUTDOWN_GRACE_SECONDS: Final[int] = 2
 USAGE: Final[str] = "usage: python -m gestalt._runtime ROOT MODULE[:ATTRIBUTE] [RUNTIME_KIND]"
+INTERNAL_ERROR_MESSAGE: Final[str] = "internal error"
 
 
 @dataclass(frozen=True)
@@ -78,7 +79,7 @@ def _grpc_handler(label: str):
                 if context.code() is not None:
                     raise
                 traceback.print_exception(error)
-                context.abort(grpc.StatusCode.UNKNOWN, f"{label}: {error}")
+                context.abort(grpc.StatusCode.UNKNOWN, f"{label}: {INTERNAL_ERROR_MESSAGE}")
         return wrapper
     return decorator
 
@@ -339,7 +340,7 @@ def _provider_servicer(*, plugin: Plugin) -> Any:
             except Exception as error:
                 traceback.print_exception(error)
                 status = HTTPStatus.INTERNAL_SERVER_ERROR
-                body = json_body({"error": str(error)})
+                body = json_body({"error": INTERNAL_ERROR_MESSAGE})
                 return plugin_pb2.OperationResult(status=status, body=body)
             return plugin_pb2.OperationResult(status=result.status, body=result.body)
 
@@ -352,18 +353,18 @@ def _provider_servicer(*, plugin: Plugin) -> Any:
 
             try:
                 catalog = plugin.catalog_for_request(_plugin_request(request))
-            except Exception as error:
+            except Exception:
                 return context.abort(
                     grpc.StatusCode.UNKNOWN,
-                    f"session catalog: {error}",
+                    f"session catalog: {INTERNAL_ERROR_MESSAGE}",
                 )
 
             try:
                 proto_catalog = catalog_to_proto(catalog)
-            except Exception as error:
+            except Exception:
                 return context.abort(
                     grpc.StatusCode.INTERNAL,
-                    f"encode session catalog: {error}",
+                    f"encode session catalog: {INTERNAL_ERROR_MESSAGE}",
                 )
 
             return plugin_pb2.GetSessionCatalogResponse(catalog=proto_catalog)

--- a/sdk/python/tests/test_plugin.py
+++ b/sdk/python/tests/test_plugin.py
@@ -148,7 +148,7 @@ class PluginOperationTests(unittest.TestCase):
 
         result = plugin.execute("broken", {}, Request())
         self.assertEqual(result.status, 500)
-        self.assertIn("something broke", json.loads(result.body)["error"])
+        self.assertEqual(json.loads(result.body), {"error": "internal error"})
 
         result = plugin.execute("missing", {}, Request())
         self.assertEqual(result.status, 404)

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -391,6 +391,24 @@ class AuthRuntimeTests(unittest.TestCase):
             "token not recognized",
         )
 
+    def test_auth_validator_exception_is_sanitized(self) -> None:
+        class RaisingValidator(self.StubAuthProvider):
+            def validate_external_token(self, token: str) -> Any:
+                raise RuntimeError("token exploded")
+
+        context = mock.Mock()
+        servicer = _runtime._auth_servicer(provider=RaisingValidator())
+
+        servicer.ValidateExternalToken(
+            auth_pb2.ValidateExternalTokenRequest(token="broken"),
+            context,
+        )
+
+        context.abort.assert_called_once_with(
+            grpc.StatusCode.UNKNOWN,
+            "validate external token: internal error",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed
- changed the Go SDK to return a generic `internal error` for uncaught handler errors and panics unless the plugin used the explicit user-facing error API
- changed the Python SDK to stop serializing raw exception text in generic internal error paths
- updated the affected SDK tests to assert the sanitized behavior

## Why
The SDKs were reflecting raw internal exception text back to callers on fallback error paths. That leaks implementation details and makes the safe path more complicated than it needs to be.

## Impact
Plugin authors still have an explicit way to return intentional user-facing errors. Unhandled internal failures now return a generic internal error while logging the underlying stack trace locally.

## Validation
- `go test ./...` in `sdk/go`
- `uv run ruff check gestalt/_operations.py gestalt/_runtime.py tests/test_plugin.py` in `sdk/python`
- `uv run python -m unittest discover -s tests` in `sdk/python`
