### PR TITLE
[codex] Replace weak encryption key examples

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -383,7 +383,7 @@ server:
   public:
     port: 8080
   baseUrl: http://localhost:8080
-  encryptionKey: change-me
+  encryptionKey: "REPLACE-WITH-OUTPUT-OF-openssl-rand-hex-32"
   indexeddb: main
 
 providers:
@@ -395,5 +395,7 @@ providers:
       config:
         dsn: sqlite://./gestalt.db
 ```
+
+Generate `server.encryptionKey` once with `openssl rand -hex 32`. Do not use a shared placeholder value in a real deployment.
 
 See [Observability](/observability) for adding metrics, logs, and OTLP export. See [Deploy](/deploy) for production startup workflows, lockfiles, and prepared artifacts.

--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -383,7 +383,7 @@ server:
   public:
     port: 8080
   baseUrl: http://localhost:8080
-  encryptionKey: "REPLACE-WITH-OUTPUT-OF-openssl-rand-hex-32"
+  encryptionKey: ${GESTALT_ENCRYPTION_KEY}
   indexeddb: main
 
 providers:
@@ -396,6 +396,6 @@ providers:
         dsn: sqlite://./gestalt.db
 ```
 
-Generate `server.encryptionKey` once with `openssl rand -hex 32`. Do not use a shared placeholder value in a real deployment.
+Set `GESTALT_ENCRYPTION_KEY` once with `openssl rand -hex 32` before starting Gestalt. Do not use a shared placeholder value in a real deployment.
 
 See [Observability](/observability) for adding metrics, logs, and OTLP export. See [Deploy](/deploy) for production startup workflows, lockfiles, and prepared artifacts.

--- a/docs/content/deploy/docker.mdx
+++ b/docs/content/deploy/docker.mdx
@@ -5,13 +5,14 @@
 ```sh
 docker run --rm \
   -p 8080:8080 \
-  -e GESTALT_ENCRYPTION_KEY=change-me \
+  -e GESTALT_ENCRYPTION_KEY=REPLACE-WITH-OUTPUT-OF-openssl-rand-hex-32 \
   -v "$(pwd)/config.yaml:/etc/gestalt/config.yaml:ro" \
   -v gestalt-data:/data \
   valontechnologies/gestaltd:latest
 ```
 
 Mount a config file at `/etc/gestalt/config.yaml`. The image is not zero-config and will fail to start without one.
+Generate the encryption key once with `openssl rand -hex 32` and reuse that value for the deployment.
 
 ## Docker Compose
 
@@ -25,7 +26,7 @@ services:
       - ./config.yaml:/etc/gestalt/config.yaml:ro
       - gestalt-data:/data
     environment:
-      GESTALT_ENCRYPTION_KEY: change-me
+      GESTALT_ENCRYPTION_KEY: "REPLACE-WITH-OUTPUT-OF-openssl-rand-hex-32"
 
 volumes:
   gestalt-data:

--- a/docs/content/deploy/docker.mdx
+++ b/docs/content/deploy/docker.mdx
@@ -3,9 +3,11 @@
 ## Quick start
 
 ```sh
+export GESTALT_ENCRYPTION_KEY="$(openssl rand -hex 32)"
+
 docker run --rm \
   -p 8080:8080 \
-  -e GESTALT_ENCRYPTION_KEY=REPLACE-WITH-OUTPUT-OF-openssl-rand-hex-32 \
+  -e GESTALT_ENCRYPTION_KEY="${GESTALT_ENCRYPTION_KEY}" \
   -v "$(pwd)/config.yaml:/etc/gestalt/config.yaml:ro" \
   -v gestalt-data:/data \
   valontechnologies/gestaltd:latest
@@ -26,7 +28,7 @@ services:
       - ./config.yaml:/etc/gestalt/config.yaml:ro
       - gestalt-data:/data
     environment:
-      GESTALT_ENCRYPTION_KEY: "REPLACE-WITH-OUTPUT-OF-openssl-rand-hex-32"
+      GESTALT_ENCRYPTION_KEY: "${GESTALT_ENCRYPTION_KEY}"
 
 volumes:
   gestalt-data:

--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -25,7 +25,8 @@ The default chart profile is intentionally minimal:
 - no ingress
 
 That profile is suitable for local development and trusted internal clusters.
-It is not a production-ready security posture.
+It is not a production-ready security posture. Override `config.server.encryptionKey`
+before any shared, persistent, or production deployment.
 
 ## Production Install Pattern
 

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -45,11 +45,13 @@ Mount a config file and writable `/data` volume before starting the container:
 ```sh
 docker run --rm \
   -p 8080:8080 \
-  -e GESTALT_ENCRYPTION_KEY=change-me \
+  -e GESTALT_ENCRYPTION_KEY=REPLACE-WITH-OUTPUT-OF-openssl-rand-hex-32 \
   -v "$(pwd)/gestalt.yaml:/etc/gestalt/config.yaml:ro" \
   -v gestalt-data:/data \
   valontechnologies/gestaltd:latest
 ```
+
+Generate the encryption key once with `openssl rand -hex 32` and use that value for the deployment.
 
 Example minimal config:
 
@@ -86,7 +88,7 @@ services:
       - ./config.yaml:/etc/gestalt/config.yaml:ro
       - gestalt-data:/data
     environment:
-      GESTALT_ENCRYPTION_KEY: change-me
+      GESTALT_ENCRYPTION_KEY: "REPLACE-WITH-OUTPUT-OF-openssl-rand-hex-32"
 
 volumes:
   gestalt-data:

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -43,9 +43,11 @@ a shell, `ca-certificates`, and a writable `/data` directory owned by `nobody`.
 Mount a config file and writable `/data` volume before starting the container:
 
 ```sh
+export GESTALT_ENCRYPTION_KEY="$(openssl rand -hex 32)"
+
 docker run --rm \
   -p 8080:8080 \
-  -e GESTALT_ENCRYPTION_KEY=REPLACE-WITH-OUTPUT-OF-openssl-rand-hex-32 \
+  -e GESTALT_ENCRYPTION_KEY="${GESTALT_ENCRYPTION_KEY}" \
   -v "$(pwd)/gestalt.yaml:/etc/gestalt/config.yaml:ro" \
   -v gestalt-data:/data \
   valontechnologies/gestaltd:latest
@@ -88,7 +90,7 @@ services:
       - ./config.yaml:/etc/gestalt/config.yaml:ro
       - gestalt-data:/data
     environment:
-      GESTALT_ENCRYPTION_KEY: "REPLACE-WITH-OUTPUT-OF-openssl-rand-hex-32"
+      GESTALT_ENCRYPTION_KEY: "${GESTALT_ENCRYPTION_KEY}"
 
 volumes:
   gestalt-data:


### PR DESCRIPTION
## What changed
- replaced `change-me` encryption-key examples in the public docs with an explicit placeholder
- added a short note pointing readers to `openssl rand -hex 32`

## Why
The existing examples suggested a weak shared value for the deployment encryption key. Public docs should make the safe path the obvious path.

## Impact
New deployments following the docs are less likely to reuse a trivial shared key by accident.

## Validation
- `rg -n "change-me|REPLACE-WITH-OUTPUT-OF-openssl-rand-hex-32" docs/content/configuration.mdx docs/content/deploy/docker.mdx docs/dockerhub/gestaltd.md`
