### PR TITLE
Sanitize MCP tool invocation errors

### DIFF
--- a/gestaltd/internal/mcp/handlers.go
+++ b/gestaltd/internal/mcp/handlers.go
@@ -33,7 +33,13 @@ func makeHandler(invoker invocation.Invoker, provName, opName, connection string
 			if errors.Is(err, invocation.ErrAuthorizationDenied) || errors.Is(err, invocation.ErrScopeDenied) {
 				return mcpgo.NewToolResultError("operation access denied"), nil
 			}
-			return mcpgo.NewToolResultError("operation failed"), nil
+			if errors.Is(err, invocation.ErrUserResolution) {
+				return mcpgo.NewToolResultError("failed to resolve user"), nil
+			}
+			if errors.Is(err, invocation.ErrInternal) {
+				return mcpgo.NewToolResultError("internal error"), nil
+			}
+			return mcpgo.NewToolResultError(err.Error()), nil
 		}
 		if result == nil {
 			return mcpgo.NewToolResultText("{}"), nil

--- a/gestaltd/internal/mcp/handlers.go
+++ b/gestaltd/internal/mcp/handlers.go
@@ -33,7 +33,7 @@ func makeHandler(invoker invocation.Invoker, provName, opName, connection string
 			if errors.Is(err, invocation.ErrAuthorizationDenied) || errors.Is(err, invocation.ErrScopeDenied) {
 				return mcpgo.NewToolResultError("operation access denied"), nil
 			}
-			return mcpgo.NewToolResultError(err.Error()), nil
+			return mcpgo.NewToolResultError("operation failed"), nil
 		}
 		if result == nil {
 			return mcpgo.NewToolResultText("{}"), nil

--- a/gestaltd/internal/mcp/handlers_test.go
+++ b/gestaltd/internal/mcp/handlers_test.go
@@ -1,0 +1,74 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+type stubInvoker struct {
+	result *core.OperationResult
+	err    error
+}
+
+func (s stubInvoker) Invoke(context.Context, *principal.Principal, string, string, string, map[string]any) (*core.OperationResult, error) {
+	return s.result, s.err
+}
+
+func TestMakeHandlerSanitizesInvokerErrors(t *testing.T) {
+	handler := makeHandler(stubInvoker{err: errors.New("database DSN leaked")}, "demo", "op", "")
+
+	result, err := handler(testPrincipalContext(), mcpgo.CallToolRequest{
+		Params: mcpgo.CallToolParams{Arguments: map[string]any{}},
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected tool error result")
+	}
+	if text := toolResultText(t, result); text != "operation failed" {
+		t.Fatalf("unexpected tool error text %q", text)
+	}
+}
+
+func TestMakeHandlerPreservesAccessDeniedErrors(t *testing.T) {
+	handler := makeHandler(stubInvoker{err: invocation.ErrAuthorizationDenied}, "demo", "op", "")
+
+	result, err := handler(testPrincipalContext(), mcpgo.CallToolRequest{
+		Params: mcpgo.CallToolParams{Arguments: map[string]any{}},
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected tool error result")
+	}
+	if text := toolResultText(t, result); text != "operation access denied" {
+		t.Fatalf("unexpected tool error text %q", text)
+	}
+}
+
+func testPrincipalContext() context.Context {
+	return principal.WithPrincipal(context.Background(), &principal.Principal{
+		UserID: "user-1",
+		Source: principal.SourceAPIToken,
+	})
+}
+
+func toolResultText(t *testing.T, result *mcpgo.CallToolResult) string {
+	t.Helper()
+	if len(result.Content) != 1 {
+		t.Fatalf("expected one content item, got %d", len(result.Content))
+	}
+	text, ok := result.Content[0].(mcpgo.TextContent)
+	if !ok {
+		t.Fatalf("expected text content, got %T", result.Content[0])
+	}
+	return text.Text
+}

--- a/gestaltd/internal/mcp/handlers_test.go
+++ b/gestaltd/internal/mcp/handlers_test.go
@@ -2,7 +2,7 @@ package mcp
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"testing"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -20,8 +20,8 @@ func (s stubInvoker) Invoke(context.Context, *principal.Principal, string, strin
 	return s.result, s.err
 }
 
-func TestMakeHandlerSanitizesInvokerErrors(t *testing.T) {
-	handler := makeHandler(stubInvoker{err: errors.New("database DSN leaked")}, "demo", "op", "")
+func TestMakeHandlerSanitizesInternalErrors(t *testing.T) {
+	handler := makeHandler(stubInvoker{err: fmt.Errorf("%w: database DSN leaked", invocation.ErrInternal)}, "demo", "op", "")
 
 	result, err := handler(testPrincipalContext(), mcpgo.CallToolRequest{
 		Params: mcpgo.CallToolParams{Arguments: map[string]any{}},
@@ -32,7 +32,7 @@ func TestMakeHandlerSanitizesInvokerErrors(t *testing.T) {
 	if !result.IsError {
 		t.Fatalf("expected tool error result")
 	}
-	if text := toolResultText(t, result); text != "operation failed" {
+	if text := toolResultText(t, result); text != "internal error" {
 		t.Fatalf("unexpected tool error text %q", text)
 	}
 }
@@ -50,6 +50,23 @@ func TestMakeHandlerPreservesAccessDeniedErrors(t *testing.T) {
 		t.Fatalf("expected tool error result")
 	}
 	if text := toolResultText(t, result); text != "operation access denied" {
+		t.Fatalf("unexpected tool error text %q", text)
+	}
+}
+
+func TestMakeHandlerPreservesNoTokenErrors(t *testing.T) {
+	handler := makeHandler(stubInvoker{err: fmt.Errorf("%w: no token stored for integration %q", invocation.ErrNoToken, "demo")}, "demo", "op", "")
+
+	result, err := handler(testPrincipalContext(), mcpgo.CallToolRequest{
+		Params: mcpgo.CallToolParams{Arguments: map[string]any{}},
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected tool error result")
+	}
+	if text := toolResultText(t, result); text != `no integration token: no token stored for integration "demo"` {
 		t.Fatalf("unexpected tool error text %q", text)
 	}
 }

--- a/gestaltd/internal/mcp/handlers_test.go
+++ b/gestaltd/internal/mcp/handlers_test.go
@@ -71,6 +71,23 @@ func TestMakeHandlerPreservesNoTokenErrors(t *testing.T) {
 	}
 }
 
+func TestMakeHandlerSanitizesUserResolutionErrors(t *testing.T) {
+	handler := makeHandler(stubInvoker{err: fmt.Errorf("%w: principal has no user ID or email", invocation.ErrUserResolution)}, "demo", "op", "")
+
+	result, err := handler(testPrincipalContext(), mcpgo.CallToolRequest{
+		Params: mcpgo.CallToolParams{Arguments: map[string]any{}},
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected tool error result")
+	}
+	if text := toolResultText(t, result); text != "failed to resolve user" {
+		t.Fatalf("unexpected tool error text %q", text)
+	}
+}
+
 func testPrincipalContext() context.Context {
 	return principal.WithPrincipal(context.Background(), &principal.Principal{
 		UserID: "user-1",


### PR DESCRIPTION
## Summary
- stop returning raw invoker error strings from MCP tool handlers
- keep access-denied responses unchanged
- add direct unit coverage for sanitized and denied error paths

## Testing
- `go test ./internal/mcp`