### PR TITLE
Enforce human auth on mounted UI routes

### DIFF
--- a/docs/content/custom-providers/web-uis.mdx
+++ b/docs/content/custom-providers/web-uis.mdx
@@ -29,9 +29,20 @@ release:
       - ./build.sh
 spec:
   assetRoot: out
+  routes:
+    - path: /
+      allowedRoles: [viewer, admin]
+    - path: /admin/*
+      allowedRoles: [admin]
 ```
 
 The `assetRoot` path is relative to the manifest file. It should contain the output of your frontend build (typically an `index.html` and accompanying JS, CSS, and image files).
+
+`spec.routes` is optional unless a deployment binds the UI to
+`providers.ui.<name>.authorizationPolicy`. In that case, Gestalt uses these
+route rules to enforce role-based access before serving the mounted route or
+its static assets. At least one route must cover `/`, and every route must
+declare non-empty `allowedRoles`.
 
 ## Build step
 
@@ -67,6 +78,7 @@ providers:
       source:
         path: ./web-default/manifest.yaml
       path: /dashboard
+      authorizationPolicy: dashboard_users
 ```
 
 For production, reference a published release by source and version:
@@ -79,6 +91,7 @@ providers:
         ref: github.com/valon-technologies/gestalt-providers/web/default
         version: 0.0.1
       path: /dashboard
+      authorizationPolicy: dashboard_users
 ```
 
 When a config references a published UI bundle, run `gestaltd init` to resolve

--- a/docs/content/providers/web-uis.mdx
+++ b/docs/content/providers/web-uis.mdx
@@ -35,6 +35,7 @@ providers:
       source:
         path: ./customer-roadmap-review/ui/manifest.yaml
       path: /create-customer-roadmap-review
+      authorizationPolicy: roadmap_review
 ```
 
 Reference a published bundle in production:
@@ -47,7 +48,13 @@ providers:
         ref: github.com/your-org/web/customer-roadmap-review
         version: 0.0.1
       path: /create-customer-roadmap-review
+      authorizationPolicy: roadmap_review
 ```
+
+When `authorizationPolicy` is set, Gestalt authenticates the caller, resolves
+their role from `server.authorization.policies.<policy>`, and checks the web
+UI manifest's `spec.routes[].allowedRoles` before serving the route or its
+associated static assets.
 
 ## Locked deployments
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -742,6 +742,8 @@ providers:
 
 `providers.ui` is a map of mounted `webui` bundles. Each entry is served under an explicit non-root path prefix on the public listener. The built-in admin UI remains available at `/admin`. Omit `providers.ui` entirely to run headless with no public UI bundles.
 
+When `authorizationPolicy` is set on a mounted UI, the referenced web UI manifest must declare `spec.routes` with non-empty `allowedRoles`, and at least one route must cover `/`.
+
 | Field | Description |
 | --- | --- |
 | `path` | Required mount prefix. Must start with `/`, may not be `/`, and may not conflict with `/api`, auth routes, `/mcp`, `/admin`, `/metrics`, `/health`, `/ready`, or another mounted UI prefix. |

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -303,6 +303,14 @@ The `spec` block for a `kind: webui` manifest describes a static UI package.
 | Field | Type | Required | Purpose |
 | --- | --- | --- | --- |
 | `assetRoot` | string | yes | Directory containing the built static assets. |
+| `routes` | WebUIRoute[] | no | Optional route-level authorization rules used when a deployment binds this UI to `providers.ui.<name>.authorizationPolicy`. |
+
+Each `spec.routes` entry declares a mounted path and the allowed human roles for that path. Path matching is exact or longest-prefix with a terminal `/*`. When a deployment sets `authorizationPolicy`, route definitions must have non-empty `allowedRoles`, and the manifest must include a route that covers `/`.
+
+| Route field | Type | Required | Purpose |
+| --- | --- | --- | --- |
+| `path` | string | yes | Route path such as `/`, `/reports`, or `/admin/*`. |
+| `allowedRoles` | string[] | yes | Roles permitted to load the route or its associated static assets. |
 
 ```yaml
 kind: webui
@@ -311,6 +319,11 @@ version: 1.0.0
 displayName: Custom UI
 spec:
   assetRoot: ui/out
+  routes:
+    - path: /
+      allowedRoles: [viewer, admin]
+    - path: /admin/*
+      allowedRoles: [admin]
 ```
 
 ## Artifacts

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -333,9 +333,22 @@ func resolveMountedWebUIHandlers(cfg *config.Config) ([]server.MountedWebUI, err
 		if err != nil {
 			return nil, fmt.Errorf("ui %q: %w", name, err)
 		}
+		var routes []server.MountedWebUIRoute
+		if spec := entry.ManifestSpec(); spec != nil && len(spec.Routes) > 0 {
+			routes = make([]server.MountedWebUIRoute, 0, len(spec.Routes))
+			for _, route := range spec.Routes {
+				routes = append(routes, server.MountedWebUIRoute{
+					Path:         route.Path,
+					AllowedRoles: append([]string(nil), route.AllowedRoles...),
+				})
+			}
+		}
 		mounted = append(mounted, server.MountedWebUI{
-			Path:    entry.Path,
-			Handler: handler,
+			Name:                name,
+			Path:                entry.Path,
+			AuthorizationPolicy: entry.AuthorizationPolicy,
+			Routes:              routes,
+			Handler:             handler,
 		})
 	}
 	return mounted, nil

--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -194,12 +194,19 @@ func (a *Authorizer) Binding(p *principal.Principal, provider string) (Credentia
 }
 
 func (a *Authorizer) ResolveAccess(p *principal.Principal, provider string) (AccessContext, bool) {
-	if a == nil || a.IsWorkload(p) {
+	policyName := strings.TrimSpace(a.providerPolicies[provider])
+	return a.ResolvePolicyAccess(p, policyName)
+}
+
+func (a *Authorizer) ResolvePolicyAccess(p *principal.Principal, policyName string) (AccessContext, bool) {
+	if a == nil {
 		return AccessContext{}, true
 	}
-	policyName := strings.TrimSpace(a.providerPolicies[provider])
 	if policyName == "" {
 		return AccessContext{}, true
+	}
+	if a.IsWorkload(p) {
+		return AccessContext{Policy: policyName}, false
 	}
 	policy := a.policies[policyName]
 	if policy == nil {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
+	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
@@ -221,6 +222,20 @@ func ValidateResolvedStructure(cfg *Config) error {
 		}
 		if err := validateManifestBackedIntegration(name, entry); err != nil {
 			return err
+		}
+	}
+	for name, entry := range cfg.Providers.UI {
+		if entry == nil {
+			return fmt.Errorf("config validation: ui %q requires a source", name)
+		}
+		if entry.Disabled || entry.AuthorizationPolicy == "" {
+			continue
+		}
+		if entry.ResolvedManifest == nil || entry.ManifestSpec() == nil {
+			return fmt.Errorf("config validation: ui %q authorizationPolicy requires a resolved webui manifest", name)
+		}
+		if err := providerpkg.ValidatePolicyBoundWebUIRoutes(entry.ManifestSpec().Routes); err != nil {
+			return fmt.Errorf("config validation: ui %q authorizationPolicy: %w", name, err)
 		}
 	}
 	return nil

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -356,6 +356,78 @@ func TestInitAtPath_SkipsDisabledManagedMountedWebUI(t *testing.T) {
 	}
 }
 
+func TestInitAtPath_RejectsPolicyBoundManagedMountedWebUIWithoutExplicitRouteCoverage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		spec *providermanifestv1.Spec
+		want string
+	}{
+		{
+			name: "missing routes",
+			spec: &providermanifestv1.Spec{AssetRoot: "dist"},
+			want: "must declare at least one route",
+		},
+		{
+			name: "missing root coverage",
+			spec: &providermanifestv1.Spec{
+				AssetRoot: "dist",
+				Routes: []providermanifestv1.WebUIRoute{
+					{Path: "/reports", AllowedRoles: []string{"admin"}},
+				},
+			},
+			want: "must declare a route covering /",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			pkgPath := mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
+				Kind:        providermanifestv1.KindWebUI,
+				Source:      "github.com/testowner/web/sample-portal",
+				Version:     "0.0.1-alpha.1",
+				DisplayName: "Sample Portal",
+				Spec:        tc.spec,
+			}, map[string]string{
+				"dist/index.html": "<html>sample portal</html>",
+			}, false)
+
+			cfgPath := filepath.Join(dir, "config.yaml")
+			cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
+    sample_portal:
+      source:
+        ref: github.com/testowner/web/sample-portal
+        version: 0.0.1-alpha.1
+      path: /sample-portal
+      authorizationPolicy: sample_policy
+` + `server:
+` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  authorization:
+    policies:
+      sample_policy:
+        default: deny
+        members:
+          - email: viewer@example.test
+            role: viewer
+`
+			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+				t.Fatalf("WriteFile config: %v", err)
+			}
+
+			lc := NewLifecycle(staticSourceResolver{localPath: pkgPath})
+			_, err := lc.InitAtPath(cfgPath)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("InitAtPath error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestLockProviderEntryForSource_RejectsManifestWithoutProviderKind(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/providerpkg/manifest.go
+++ b/gestaltd/internal/providerpkg/manifest.go
@@ -212,10 +212,54 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 		if err := validateRelativePackagePath(spec.AssetRoot, "spec.assetRoot"); err != nil {
 			return err
 		}
+		if err := validateWebUIRoutes(spec.Routes); err != nil {
+			return err
+		}
 	default:
 		return fmt.Errorf("unsupported manifest kind %q", kind)
 	}
 
+	return nil
+}
+
+func validateWebUIRoutes(routes []providermanifestv1.WebUIRoute) error {
+	seenPaths := make(map[string]struct{}, len(routes))
+	for i := range routes {
+		normalized, err := NormalizeWebUIRoutePath(fmt.Sprintf("spec.routes[%d].path", i), routes[i].Path)
+		if err != nil {
+			return err
+		}
+		routes[i].Path = normalized
+		if _, exists := seenPaths[normalized]; exists {
+			return fmt.Errorf("spec.routes[%d].path %q duplicates another route", i, normalized)
+		}
+		seenPaths[normalized] = struct{}{}
+
+		roles, err := NormalizeWebUIAllowedRoles(fmt.Sprintf("spec.routes[%d].allowedRoles", i), routes[i].AllowedRoles)
+		if err != nil {
+			return err
+		}
+		routes[i].AllowedRoles = roles
+	}
+	return nil
+}
+
+func ValidatePolicyBoundWebUIRoutes(routes []providermanifestv1.WebUIRoute) error {
+	if len(routes) == 0 {
+		return fmt.Errorf("policy-bound UIs must declare at least one route")
+	}
+	coversRoot := false
+	for i := range routes {
+		if len(routes[i].AllowedRoles) == 0 {
+			return fmt.Errorf("spec.routes[%d].allowedRoles must not be empty", i)
+		}
+		if WebUIRouteMatches(routes[i].Path, "/") {
+			coversRoot = true
+		}
+	}
+	if !coversRoot {
+		return fmt.Errorf("policy-bound UIs must declare a route covering /")
+	}
 	return nil
 }
 

--- a/gestaltd/internal/providerpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/providerpkg/manifest_workflow_test.go
@@ -78,7 +78,13 @@ func TestManifestWorkflow_RoundTripsWebUIPackage(t *testing.T) {
 		Kind:    providermanifestv1.KindWebUI,
 		Source:  "github.com/acme/plugins/webui",
 		Version: "1.0.0",
-		Spec:    &providermanifestv1.Spec{AssetRoot: "ui/dist"},
+		Spec: &providermanifestv1.Spec{
+			AssetRoot: "ui/dist",
+			Routes: []providermanifestv1.WebUIRoute{
+				{Path: "/admin/*", AllowedRoles: []string{"admin"}},
+				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
+			},
+		},
 	}
 
 	mustWriteManifestData(t, sourceDir, "manifest.yml", mustManifestYAML(t, manifest))
@@ -93,6 +99,9 @@ func TestManifestWorkflow_RoundTripsWebUIPackage(t *testing.T) {
 	}
 	if manifest.Spec == nil || manifest.Spec.AssetRoot != "ui/dist" {
 		t.Fatalf("unexpected webui manifest: %#v", manifest.Spec)
+	}
+	if len(manifest.Spec.Routes) != 2 || manifest.Spec.Routes[0].Path != "/admin/*" || manifest.Spec.Routes[1].Path != "/*" {
+		t.Fatalf("unexpected webui routes: %#v", manifest.Spec.Routes)
 	}
 
 	archivePath := filepath.Join(root, "webui.tar.gz")
@@ -217,6 +226,39 @@ func TestManifestWorkflow_RejectsInvalidPackageInputs(t *testing.T) {
 				}))
 			},
 			wantError: "manifest kind is required",
+		},
+		{
+			name: "rejects webui route without allowed roles",
+			buildData: func(t *testing.T, dir string) string {
+				mustWriteFile(t, filepath.Join(dir, "ui", "dist", "index.html"), []byte("<html/>"), 0o644)
+				return mustWriteManifestData(t, dir, "manifest.yml", []byte(`
+kind: webui
+source: github.com/acme/plugins/webui-routes
+version: 1.0.0
+spec:
+  assetRoot: ui/dist
+  routes:
+    - path: /admin
+`))
+			},
+			wantError: "allowedRoles must not be empty",
+		},
+		{
+			name: "rejects non-terminal wildcard webui route",
+			buildData: func(t *testing.T, dir string) string {
+				mustWriteFile(t, filepath.Join(dir, "ui", "dist", "index.html"), []byte("<html/>"), 0o644)
+				return mustWriteManifestData(t, dir, "manifest.yml", []byte(`
+kind: webui
+source: github.com/acme/plugins/webui-routes
+version: 1.0.0
+spec:
+  assetRoot: ui/dist
+  routes:
+    - path: /admin/*/settings
+      allowedRoles: [admin]
+`))
+			},
+			wantError: "wildcards are only supported as a terminal /*",
 		},
 		{
 			name: "entrypoint references unknown artifact",

--- a/gestaltd/internal/providerpkg/webui_routes.go
+++ b/gestaltd/internal/providerpkg/webui_routes.go
@@ -1,0 +1,81 @@
+package providerpkg
+
+import (
+	"fmt"
+	stdpath "path"
+	"strings"
+)
+
+func NormalizeWebUIRoutePath(label, routePath string) (string, error) {
+	routePath = strings.TrimSpace(routePath)
+	if routePath == "" {
+		return "", fmt.Errorf("%s is required", label)
+	}
+	if !strings.HasPrefix(routePath, "/") {
+		return "", fmt.Errorf("%s must start with /", label)
+	}
+	if strings.ContainsAny(routePath, "{}") {
+		return "", fmt.Errorf("%s route patterns are not supported", label)
+	}
+	if strings.Contains(routePath, "*") {
+		if routePath != "/*" && (!strings.HasSuffix(routePath, "/*") || strings.Count(routePath, "*") != 1) {
+			return "", fmt.Errorf("%s wildcards are only supported as a terminal /*", label)
+		}
+		base := strings.TrimSuffix(routePath, "/*")
+		if base == "" {
+			return "/*", nil
+		}
+		base = stdpath.Clean(base)
+		if base == "." {
+			base = "/"
+		}
+		if base == "/" {
+			return "/*", nil
+		}
+		base = strings.TrimRight(base, "/")
+		return base + "/*", nil
+	}
+
+	routePath = stdpath.Clean(routePath)
+	if routePath == "." {
+		routePath = "/"
+	}
+	if routePath != "/" {
+		routePath = strings.TrimRight(routePath, "/")
+	}
+	return routePath, nil
+}
+
+func NormalizeWebUIAllowedRoles(label string, allowedRoles []string) ([]string, error) {
+	if len(allowedRoles) == 0 {
+		return nil, fmt.Errorf("%s must not be empty", label)
+	}
+	roles := allowedRoles[:0]
+	seenRoles := make(map[string]struct{}, len(allowedRoles))
+	for i, role := range allowedRoles {
+		role = strings.TrimSpace(role)
+		if role == "" {
+			return nil, fmt.Errorf("%s[%d] is required", label, i)
+		}
+		if _, exists := seenRoles[role]; exists {
+			continue
+		}
+		seenRoles[role] = struct{}{}
+		roles = append(roles, role)
+	}
+	return roles, nil
+}
+
+func WebUIRouteMatches(routePath, requestPath string) bool {
+	if routePath == "/*" {
+		return true
+	}
+	if strings.HasSuffix(routePath, "/*") {
+		base := strings.TrimSuffix(routePath, "/*")
+		return requestPath == base || strings.HasPrefix(requestPath, base+"/")
+	}
+	if routePath == "/" {
+		return requestPath == "/"
+	}
+	return requestPath == routePath
+}

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -77,27 +78,74 @@ func (s *Server) startLogin(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "auth is disabled")
 		return
 	}
-	url, err := loginURLForRequest(r.Context(), s.auth, state)
+	loginURL, err := s.beginLogin(w, r, state, "")
 	if err != nil {
-		auditErr = errors.New("failed to generate login URL")
-		writeError(w, http.StatusInternalServerError, "failed to generate login URL")
+		auditErr = err
+		status := http.StatusInternalServerError
+		if errors.Is(err, errBadLoginRedirectPath) {
+			status = http.StatusBadRequest
+		}
+		writeError(w, status, err.Error())
 		return
 	}
-	loginURL, err := s.resolvePublicURL(r, url)
+	auditAllowed = true
+	auditErr = nil
+	writeJSON(w, http.StatusOK, map[string]string{"url": loginURL})
+}
+
+var errBadLoginRedirectPath = errors.New("invalid next path")
+
+func (s *Server) startBrowserLogin(w http.ResponseWriter, r *http.Request) {
+	startedAt := time.Now()
+	auditAllowed := false
+	auditErr := errors.New("login start failed")
+	providerName := s.authProviderName()
+	defer func() {
+		metricutil.RecordAuthMetrics(r.Context(), startedAt, providerName, "begin_login", auditErr != nil)
+		s.auditHTTPEvent(r.Context(), nil, s.authProviderName(), "auth.login.start", auditAllowed, auditErr)
+	}()
+
+	nextPath, err := resolveLoginRedirectPath(r.URL.Query().Get("next"))
 	if err != nil {
-		auditErr = errors.New("failed to resolve login URL")
-		writeError(w, http.StatusInternalServerError, "failed to resolve login URL")
+		auditErr = err
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
+	}
+	if !s.authEnabled() {
+		auditErr = errors.New("auth is disabled")
+		writeError(w, http.StatusNotFound, "auth is disabled")
+		return
+	}
+
+	loginURL, err := s.beginLogin(w, r, browserLoginStateForNextPath(nextPath), nextPath)
+	if err != nil {
+		auditErr = err
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	auditAllowed = true
+	auditErr = nil
+	http.Redirect(w, r, loginURL, http.StatusFound)
+}
+
+func (s *Server) beginLogin(w http.ResponseWriter, r *http.Request, state, nextPath string) (string, error) {
+	loginURLRaw, err := loginURLForRequest(r.Context(), s.auth, state)
+	if err != nil {
+		return "", errors.New("failed to generate login URL")
+	}
+	loginURL, err := s.resolvePublicURL(r, loginURLRaw)
+	if err != nil {
+		return "", errors.New("failed to resolve login URL")
 	}
 	if s.encryptor != nil {
 		encoded, encErr := encodeLoginState(s.encryptor, loginState{
-			State:     req.State,
+			State:     state,
+			NextPath:  nextPath,
 			ExpiresAt: s.now().Add(loginStateTTL).Unix(),
 		})
 		if encErr != nil {
-			auditErr = errors.New("failed to encode login state")
-			writeError(w, http.StatusInternalServerError, "failed to encode login state")
-			return
+			return "", errors.New("failed to encode login state")
 		}
 		http.SetCookie(w, &http.Cookie{
 			Name:     loginStateCookieName,
@@ -109,9 +157,34 @@ func (s *Server) startLogin(w http.ResponseWriter, r *http.Request) {
 			SameSite: http.SameSiteLaxMode,
 		})
 	}
-	auditAllowed = true
-	auditErr = nil
-	writeJSON(w, http.StatusOK, map[string]string{"url": loginURL})
+	return loginURL, nil
+}
+
+func resolveLoginRedirectPath(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "/", nil
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", errBadLoginRedirectPath
+	}
+	if parsed.IsAbs() || parsed.Host != "" || !strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, "//") {
+		return "", errBadLoginRedirectPath
+	}
+	parsed.Fragment = ""
+	if parsed.Path == "" {
+		parsed.Path = "/"
+	}
+	return parsed.RequestURI(), nil
+}
+
+func browserLoginStateForNextPath(nextPath string) string {
+	parsed, err := url.Parse(nextPath)
+	if err != nil || parsed.Path == "" {
+		return "/"
+	}
+	return parsed.Path
 }
 
 func loginURLForRequest(ctx context.Context, provider core.AuthProvider, state string) (string, error) {
@@ -257,7 +330,8 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if csrfErr := s.validateLoginState(r, originalState); csrfErr != nil {
+	loginState, csrfErr := s.validateLoginState(r, originalState)
+	if csrfErr != nil {
 		auditErr = errors.New("login state validation failed")
 		slog.ErrorContext(r.Context(), "login state validation failed", "error", csrfErr)
 		writeError(w, http.StatusForbidden, "login state validation failed")
@@ -319,25 +393,29 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 
 	auditAllowed = true
 	auditErr = nil
+	if loginState != nil && loginState.NextPath != "" {
+		http.Redirect(w, r, loginState.NextPath, http.StatusFound)
+		return
+	}
 	writeJSON(w, http.StatusOK, resp)
 }
 
-func (s *Server) validateLoginState(r *http.Request, originalState string) error {
+func (s *Server) validateLoginState(r *http.Request, originalState string) (*loginState, error) {
 	if s.encryptor == nil {
-		return nil
+		return &loginState{State: originalState}, nil
 	}
 	cookie, err := r.Cookie(loginStateCookieName)
 	if err != nil {
-		return fmt.Errorf("missing login state cookie")
+		return nil, fmt.Errorf("missing login state cookie")
 	}
 	expected, err := decodeLoginState(s.encryptor, cookie.Value, s.now())
 	if err != nil {
-		return fmt.Errorf("invalid login state cookie: %w", err)
+		return nil, fmt.Errorf("invalid login state cookie: %w", err)
 	}
 	if expected.State != originalState {
-		return fmt.Errorf("login state mismatch")
+		return nil, fmt.Errorf("login state mismatch")
 	}
-	return nil
+	return expected, nil
 }
 
 func (s *Server) clearLoginStateCookie(w http.ResponseWriter) {

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -1,0 +1,289 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	stdpath "path"
+	"slices"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
+)
+
+const browserLoginPath = "/api/v1/auth/login"
+
+type mountedWebUINavigationPathResolver interface {
+	NavigationPathForRequest(string) (string, bool)
+}
+
+func normalizeMountedWebUIs(mounted []MountedWebUI) ([]MountedWebUI, error) {
+	if len(mounted) == 0 {
+		return nil, nil
+	}
+
+	normalized := append([]MountedWebUI(nil), mounted...)
+	for i := range normalized {
+		routes, err := normalizeMountedWebUIRoutes(normalized[i].Routes)
+		if err != nil {
+			name := normalized[i].Name
+			if name == "" {
+				name = normalized[i].Path
+			}
+			return nil, fmt.Errorf("normalize mounted ui %q routes: %w", name, err)
+		}
+		normalized[i].Routes = routes
+		if err := validatePolicyBoundMountedWebUIRoutes(normalized[i]); err != nil {
+			name := normalized[i].Name
+			if name == "" {
+				name = normalized[i].Path
+			}
+			return nil, fmt.Errorf("normalize mounted ui %q routes: %w", name, err)
+		}
+	}
+	return normalized, nil
+}
+
+func normalizeMountedWebUIRoutes(routes []MountedWebUIRoute) ([]MountedWebUIRoute, error) {
+	if len(routes) == 0 {
+		return nil, nil
+	}
+
+	normalized := append([]MountedWebUIRoute(nil), routes...)
+	seenPaths := make(map[string]struct{}, len(normalized))
+	for i := range normalized {
+		routePath, err := providerpkg.NormalizeWebUIRoutePath(fmt.Sprintf("route %d path", i), normalized[i].Path)
+		if err != nil {
+			return nil, err
+		}
+		normalized[i].Path = routePath
+		if _, exists := seenPaths[routePath]; exists {
+			return nil, fmt.Errorf("route %d path %q duplicates another route", i, routePath)
+		}
+		seenPaths[routePath] = struct{}{}
+
+		roles, err := providerpkg.NormalizeWebUIAllowedRoles(fmt.Sprintf("route %d allowedRoles", i), normalized[i].AllowedRoles)
+		if err != nil {
+			return nil, err
+		}
+		normalized[i].AllowedRoles = roles
+	}
+
+	slices.SortFunc(normalized, func(a, b MountedWebUIRoute) int {
+		aLen, aWildcard := mountedWebUIRouteSpecificity(a.Path)
+		bLen, bWildcard := mountedWebUIRouteSpecificity(b.Path)
+		if aLen != bLen {
+			return bLen - aLen
+		}
+		if aWildcard != bWildcard {
+			if aWildcard {
+				return 1
+			}
+			return -1
+		}
+		return strings.Compare(a.Path, b.Path)
+	})
+	return normalized, nil
+}
+
+func validatePolicyBoundMountedWebUIRoutes(mounted MountedWebUI) error {
+	if mounted.AuthorizationPolicy == "" {
+		return nil
+	}
+	if len(mounted.Routes) == 0 {
+		return fmt.Errorf("policy-bound UIs must declare at least one route")
+	}
+	coversRoot := false
+	for i := range mounted.Routes {
+		if len(mounted.Routes[i].AllowedRoles) == 0 {
+			return fmt.Errorf("route %q allowedRoles must not be empty", mounted.Routes[i].Path)
+		}
+		if providerpkg.WebUIRouteMatches(mounted.Routes[i].Path, "/") {
+			coversRoot = true
+		}
+	}
+	if !coversRoot {
+		return fmt.Errorf("policy-bound UIs must declare a route covering /")
+	}
+	return nil
+}
+
+func (s *Server) mountedWebUIHandler(mounted MountedWebUI) http.Handler {
+	inner := mounted.Handler
+	if inner == nil {
+		return http.NotFoundHandler()
+	}
+	if mounted.Path != "/" {
+		inner = http.StripPrefix(mounted.Path, inner)
+	}
+	if mounted.AuthorizationPolicy == "" {
+		return inner
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, ok := s.authorizeMountedWebUIRequest(w, r, mounted)
+		if !ok {
+			return
+		}
+		inner.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func (s *Server) authorizeMountedWebUIRequest(w http.ResponseWriter, r *http.Request, mounted MountedWebUI) (context.Context, bool) {
+	if s.authorizer == nil {
+		writeError(w, http.StatusInternalServerError, "app authorization is unavailable")
+		return nil, false
+	}
+
+	p, authenticated, err := s.resolveMountedWebUIPrincipal(r)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to resolve user")
+		return nil, false
+	}
+	if !authenticated {
+		s.redirectMountedWebUILogin(w, r)
+		return nil, false
+	}
+	if p != nil && p.Kind == principal.KindWorkload {
+		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		return nil, false
+	}
+
+	access, allowed := s.authorizer.ResolvePolicyAccess(p, mounted.AuthorizationPolicy)
+	if !allowed {
+		writeError(w, http.StatusForbidden, "app access denied")
+		return nil, false
+	}
+	route, matched := mounted.routeForRequestPath(r.URL.Path)
+	if !matched || len(route.AllowedRoles) == 0 || !mountedWebUIRoleAllowed(access.Role, route.AllowedRoles) {
+		writeError(w, http.StatusForbidden, "app access denied")
+		return nil, false
+	}
+
+	ctx := r.Context()
+	if p != nil {
+		ctx = principal.WithPrincipal(ctx, p)
+	}
+	if access.Policy != "" || access.Role != "" {
+		ctx = invocation.WithAccessContext(ctx, access)
+	}
+	return ctx, true
+}
+
+func (s *Server) resolveMountedWebUIPrincipal(r *http.Request) (*principal.Principal, bool, error) {
+	if s.noAuth {
+		return s.anonymousPrincipal, true, nil
+	}
+
+	p, err := s.resolveRequestPrincipal(r)
+	switch {
+	case err == nil && p != nil:
+		enriched, enrichErr := s.resolvePrincipalUserID(r.Context(), p)
+		if enrichErr != nil {
+			return nil, false, enrichErr
+		}
+		return enriched, true, nil
+	case err == nil:
+		return nil, false, nil
+	case errors.Is(err, errInvalidAuthorizationHeader), errors.Is(err, principal.ErrInvalidToken):
+		return nil, false, nil
+	default:
+		return nil, false, err
+	}
+}
+
+func (s *Server) redirectMountedWebUILogin(w http.ResponseWriter, r *http.Request) {
+	target := browserLoginPath + "?next=" + url.QueryEscape(r.URL.RequestURI())
+	http.Redirect(w, r, target, http.StatusFound)
+}
+
+func (m MountedWebUI) routeForRequestPath(requestPath string) (MountedWebUIRoute, bool) {
+	var (
+		best        MountedWebUIRoute
+		bestMatched bool
+		bestLen     int
+		bestWild    bool
+	)
+	for _, routePath := range m.authorizationPathsForRequest(requestPath) {
+		for _, route := range m.Routes {
+			if providerpkg.WebUIRouteMatches(route.Path, routePath) {
+				routeLen, routeWild := mountedWebUIRouteSpecificity(route.Path)
+				if !bestMatched || routeLen > bestLen || (routeLen == bestLen && bestWild && !routeWild) {
+					best = route
+					bestMatched = true
+					bestLen = routeLen
+					bestWild = routeWild
+				}
+			}
+		}
+	}
+	return best, bestMatched
+}
+
+func (m MountedWebUI) authorizationPathsForRequest(requestPath string) []string {
+	relativePath := requestPath
+	if m.Path != "/" {
+		relativePath = strings.TrimPrefix(requestPath, m.Path)
+	}
+	if relativePath == "" {
+		relativePath = "/"
+	}
+	if !strings.HasPrefix(relativePath, "/") {
+		relativePath = "/" + relativePath
+	}
+	requestAuthorizationPath := cleanMountedWebUIAuthorizationPath(relativePath)
+	paths := []string{requestAuthorizationPath}
+	if resolver, ok := m.Handler.(mountedWebUINavigationPathResolver); ok {
+		if routePath, navigation := resolver.NavigationPathForRequest(relativePath); navigation {
+			return appendMountedWebUIAuthorizationPath(paths, cleanMountedWebUIAuthorizationPath(routePath))
+		}
+		for path := cleanMountedWebUIAuthorizationPath(stdpath.Dir(relativePath)); ; {
+			paths = appendMountedWebUIAuthorizationPath(paths, path)
+			if path == "/" {
+				break
+			}
+			path = cleanMountedWebUIAuthorizationPath(stdpath.Dir(path))
+		}
+		return paths
+	}
+	return paths
+}
+
+func cleanMountedWebUIAuthorizationPath(routePath string) string {
+	routePath = stdpath.Clean(routePath)
+	if routePath == "." {
+		return "/"
+	}
+	return routePath
+}
+
+func appendMountedWebUIAuthorizationPath(paths []string, path string) []string {
+	if len(paths) == 0 || paths[len(paths)-1] != path {
+		return append(paths, path)
+	}
+	return paths
+}
+
+func mountedWebUIRouteSpecificity(routePath string) (int, bool) {
+	if strings.HasSuffix(routePath, "/*") {
+		return len(strings.TrimSuffix(routePath, "/*")), true
+	}
+	return len(routePath), false
+}
+
+func mountedWebUIRoleAllowed(role string, allowedRoles []string) bool {
+	role = strings.TrimSpace(role)
+	if role == "" {
+		return false
+	}
+	for _, allowed := range allowedRoles {
+		if strings.TrimSpace(allowed) == role {
+			return true
+		}
+	}
+	return false
+}

--- a/gestaltd/internal/server/oauth_state.go
+++ b/gestaltd/internal/server/oauth_state.go
@@ -100,6 +100,7 @@ const loginStateCookieName = "login_state"
 
 type loginState struct {
 	State     string `json:"s"`
+	NextPath  string `json:"n,omitempty"`
 	ExpiresAt int64  `json:"exp"`
 }
 

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -84,14 +84,15 @@ func (s *Server) mountMountedWebUIRoutes(r chi.Router) {
 			continue
 		}
 		path := mounted.Path
+		handler := s.mountedWebUIHandler(mounted)
 		if path == "/" {
-			rootHandler = mounted.Handler
+			rootHandler = handler
 			continue
 		}
 		r.Get(path, func(w http.ResponseWriter, r *http.Request) {
 			redirectPreservingQuery(w, r, path+"/", http.StatusMovedPermanently)
 		})
-		r.Handle(path+"/*", http.StripPrefix(path, mounted.Handler))
+		r.Handle(path+"/*", handler)
 	}
 	if rootHandler != nil {
 		r.NotFound(rootHandler.ServeHTTP)

--- a/gestaltd/internal/server/routes_auth.go
+++ b/gestaltd/internal/server/routes_auth.go
@@ -4,6 +4,7 @@ import "github.com/go-chi/chi/v5"
 
 func (s *Server) mountAuthRoutes(r chi.Router) {
 	r.Get("/auth/info", s.authInfo)
+	r.Get("/auth/login", s.startBrowserLogin)
 	r.Post("/auth/login", s.startLogin)
 	r.Get("/auth/login/callback", s.loginCallback)
 	r.Post("/auth/logout", s.logout)

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -35,9 +35,17 @@ const (
 	RouteProfileManagement
 )
 
+type MountedWebUIRoute struct {
+	Path         string
+	AllowedRoles []string
+}
+
 type MountedWebUI struct {
-	Path    string
-	Handler http.Handler
+	Name                string
+	Path                string
+	AuthorizationPolicy string
+	Routes              []MountedWebUIRoute
+	Handler             http.Handler
 }
 
 type Server struct {
@@ -123,6 +131,10 @@ func New(cfg Config) (*Server, error) {
 	if now == nil {
 		now = time.Now
 	}
+	mountedWebUIs, err := normalizeMountedWebUIs(cfg.MountedWebUIs)
+	if err != nil {
+		return nil, err
+	}
 
 	users := cfg.Services.Users
 	tokens := cfg.Services.Tokens
@@ -161,7 +173,7 @@ func New(cfg Config) (*Server, error) {
 		readiness:         cfg.Readiness,
 		prometheusMetrics: cfg.PrometheusMetrics,
 		mcpHandler:        cfg.MCPHandler,
-		mountedWebUIs:     append([]MountedWebUI(nil), cfg.MountedWebUIs...),
+		mountedWebUIs:     mountedWebUIs,
 		adminUI:           cfg.AdminUI,
 		routeProfile:      cfg.RouteProfile,
 	}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -303,13 +303,13 @@ func TestMountedWebUIRoutes(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>roadmap-shell</html>"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>sample-shell</html>"), 0o644); err != nil {
 		t.Fatalf("WriteFile index.html: %v", err)
 	}
 	if err := os.MkdirAll(filepath.Join(dir, "assets"), 0o755); err != nil {
 		t.Fatalf("MkdirAll assets: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "assets", "app.js"), []byte("console.log('roadmap')"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "assets", "app.js"), []byte("console.log('sample')"), 0o644); err != nil {
 		t.Fatalf("WriteFile app.js: %v", err)
 	}
 	handler, err := testutilWebUIHandler(dir)
@@ -319,7 +319,7 @@ func TestMountedWebUIRoutes(t *testing.T) {
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.MountedWebUIs = []server.MountedWebUI{{
-			Path:    "/create-customer-roadmap-review",
+			Path:    "/sample-portal",
 			Handler: handler,
 		}}
 	})
@@ -328,7 +328,7 @@ func TestMountedWebUIRoutes(t *testing.T) {
 	noRedirect := &http.Client{CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 		return http.ErrUseLastResponse
 	}}
-	resp, err := noRedirect.Get(ts.URL + "/create-customer-roadmap-review")
+	resp, err := noRedirect.Get(ts.URL + "/sample-portal")
 	if err != nil {
 		t.Fatalf("GET mounted root: %v", err)
 	}
@@ -336,11 +336,11 @@ func TestMountedWebUIRoutes(t *testing.T) {
 	if resp.StatusCode != http.StatusMovedPermanently {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
 	}
-	if got := resp.Header.Get("Location"); got != "/create-customer-roadmap-review/" {
-		t.Fatalf("Location = %q, want %q", got, "/create-customer-roadmap-review/")
+	if got := resp.Header.Get("Location"); got != "/sample-portal/" {
+		t.Fatalf("Location = %q, want %q", got, "/sample-portal/")
 	}
 
-	resp, err = noRedirect.Get(ts.URL + "/create-customer-roadmap-review?code=invite-code&state=abc123")
+	resp, err = noRedirect.Get(ts.URL + "/sample-portal?code=invite-code&state=abc123")
 	if err != nil {
 		t.Fatalf("GET mounted root with query: %v", err)
 	}
@@ -348,11 +348,11 @@ func TestMountedWebUIRoutes(t *testing.T) {
 	if resp.StatusCode != http.StatusMovedPermanently {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusMovedPermanently)
 	}
-	if got := resp.Header.Get("Location"); got != "/create-customer-roadmap-review/?code=invite-code&state=abc123" {
-		t.Fatalf("Location = %q, want %q", got, "/create-customer-roadmap-review/?code=invite-code&state=abc123")
+	if got := resp.Header.Get("Location"); got != "/sample-portal/?code=invite-code&state=abc123" {
+		t.Fatalf("Location = %q, want %q", got, "/sample-portal/?code=invite-code&state=abc123")
 	}
 
-	resp, err = http.Get(ts.URL + "/create-customer-roadmap-review/sync")
+	resp, err = http.Get(ts.URL + "/sample-portal/sync")
 	if err != nil {
 		t.Fatalf("GET mounted sync: %v", err)
 	}
@@ -364,11 +364,11 @@ func TestMountedWebUIRoutes(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
-	if !strings.Contains(string(body), "roadmap-shell") {
-		t.Fatalf("body = %q, want roadmap shell", body)
+	if !strings.Contains(string(body), "sample-shell") {
+		t.Fatalf("body = %q, want sample shell", body)
 	}
 
-	resp, err = http.Get(ts.URL + "/create-customer-roadmap-review/assets/app.js")
+	resp, err = http.Get(ts.URL + "/sample-portal/assets/app.js")
 	if err != nil {
 		t.Fatalf("GET mounted asset: %v", err)
 	}
@@ -380,8 +380,143 @@ func TestMountedWebUIRoutes(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("asset status = %d, want 200", resp.StatusCode)
 	}
-	if !strings.Contains(string(body), "roadmap") {
-		t.Fatalf("asset body = %q, want roadmap asset", body)
+	if !strings.Contains(string(body), "sample") {
+		t.Fatalf("asset body = %q, want sample asset", body)
+	}
+}
+
+func TestMountedWebUIRoutes_HumanAuthorization(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-sample-shell</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "assets"), 0o755); err != nil {
+		t.Fatalf("MkdirAll assets: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "assets", "app.js"), []byte("console.log('protected-sample')"), 0o644); err != nil {
+		t.Fatalf("WriteFile app.js: %v", err)
+	}
+	handler, err := testutilWebUIHandler(dir)
+	if err != nil {
+		t.Fatalf("webui handler: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	viewer := seedUser(t, svc, "viewer@example.test")
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{SubjectID: principal.UserSubjectID(viewer.ID), Role: "viewer"},
+				},
+			},
+		},
+	}, nil, map[string]*config.ProviderEntry{
+		"sample_portal": {AuthorizationPolicy: "sample_policy"},
+	}, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				switch token {
+				case "viewer-session":
+					return &core.UserIdentity{Email: "viewer@example.test"}, nil
+				default:
+					return nil, fmt.Errorf("invalid token")
+				}
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.MountedWebUIs = []server.MountedWebUI{{
+			Name:                "sample_portal",
+			Path:                "/sample-portal",
+			AuthorizationPolicy: "sample_policy",
+			Routes: []server.MountedWebUIRoute{
+				{Path: "/admin/*", AllowedRoles: []string{"admin"}},
+				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
+			},
+			Handler: handler,
+		}}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	noRedirect := &http.Client{CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+
+	resp, err := noRedirect.Get(ts.URL + "/sample-portal/sync?code=invite-code&state=abc123")
+	if err != nil {
+		t.Fatalf("GET protected mounted sync without auth: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusFound)
+	}
+	if got, want := resp.Header.Get("Location"), "/api/v1/auth/login?next=%2Fsample-portal%2Fsync%3Fcode%3Dinvite-code%26state%3Dabc123"; got != want {
+		t.Fatalf("Location = %q, want %q", got, want)
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/sync", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET protected mounted sync with viewer session: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll protected mounted sync: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "protected-sample-shell") {
+		t.Fatalf("body = %q, want protected sample shell", body)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/admin", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET protected mounted admin: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("admin status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/admin/index.html", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET protected mounted admin/index.html: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("admin/index.html status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/assets/app.js", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET protected mounted asset: %v", err)
+	}
+	body, err = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll protected mounted asset: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("asset status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "protected-sample") {
+		t.Fatalf("asset body = %q, want protected sample asset", body)
 	}
 }
 
@@ -391,19 +526,558 @@ func TestMountedWebUIRoutesHiddenOnManagementProfile(t *testing.T) {
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.RouteProfile = server.RouteProfileManagement
 		cfg.MountedWebUIs = []server.MountedWebUI{{
-			Path:    "/create-customer-roadmap-review",
+			Path:    "/sample-portal",
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("unexpected")) }),
 		}}
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	resp, err := http.Get(ts.URL + "/create-customer-roadmap-review/sync")
+	resp, err := http.Get(ts.URL + "/sample-portal/sync")
 	if err != nil {
 		t.Fatalf("GET management mounted route: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestMountedWebUIAuthorizationPolicyRequiresExplicitRouteCoverage(t *testing.T) {
+	t.Parallel()
+
+	makeConfig := func(mounted server.MountedWebUI) server.Config {
+		svc := coretesting.NewStubServices(t)
+		authz := mustAuthorizer(t, config.AuthorizationConfig{
+			Policies: map[string]config.HumanPolicyDef{
+				"sample_policy": {
+					Default: "deny",
+					Members: []config.HumanPolicyMemberDef{
+						{Email: "viewer@example.test", Role: "viewer"},
+					},
+				},
+			},
+		}, nil, map[string]*config.ProviderEntry{
+			"sample_portal": {AuthorizationPolicy: "sample_policy"},
+		}, nil)
+		return server.Config{
+			Auth:          &coretesting.StubAuthProvider{N: "test"},
+			Services:      svc,
+			Invoker:       &testutil.StubInvoker{},
+			Authorizer:    authz,
+			StateSecret:   []byte("0123456789abcdef0123456789abcdef"),
+			MountedWebUIs: []server.MountedWebUI{mounted},
+			Providers: func() *registry.ProviderMap[core.Provider] {
+				reg := registry.New()
+				return &reg.Providers
+			}(),
+		}
+	}
+
+	tests := []struct {
+		name    string
+		mounted server.MountedWebUI
+		want    string
+	}{
+		{
+			name: "missing routes",
+			mounted: server.MountedWebUI{
+				Name:                "sample_portal",
+				Path:                "/sample-portal",
+				AuthorizationPolicy: "sample_policy",
+				Handler:             http.NotFoundHandler(),
+			},
+			want: "must declare at least one route",
+		},
+		{
+			name: "missing root coverage",
+			mounted: server.MountedWebUI{
+				Name:                "sample_portal",
+				Path:                "/sample-portal",
+				AuthorizationPolicy: "sample_policy",
+				Routes: []server.MountedWebUIRoute{
+					{Path: "/sync/*", AllowedRoles: []string{"viewer", "admin"}},
+				},
+				Handler: http.NotFoundHandler(),
+			},
+			want: "must declare a route covering /",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := server.New(makeConfig(tc.mounted))
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("server.New error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestMountedWebUIAuthorizationPolicyDeniesUnmatchedNavigationRoute(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-sample-shell</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	handler, err := testutilWebUIHandler(dir)
+	if err != nil {
+		t.Fatalf("webui handler: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	viewer := seedUser(t, svc, "viewer@example.test")
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{SubjectID: principal.UserSubjectID(viewer.ID), Role: "viewer"},
+				},
+			},
+		},
+	}, nil, map[string]*config.ProviderEntry{
+		"sample_portal": {AuthorizationPolicy: "sample_policy"},
+	}, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "viewer-session" {
+					return nil, fmt.Errorf("invalid token")
+				}
+				return &core.UserIdentity{Email: "viewer@example.test"}, nil
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.MountedWebUIs = []server.MountedWebUI{{
+			Name:                "sample_portal",
+			Path:                "/sample-portal",
+			AuthorizationPolicy: "sample_policy",
+			Routes: []server.MountedWebUIRoute{
+				{Path: "/", AllowedRoles: []string{"viewer", "admin"}},
+				{Path: "/sync/*", AllowedRoles: []string{"viewer", "admin"}},
+			},
+			Handler: handler,
+		}}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/admin", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET unmatched protected mounted route: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+}
+
+func TestMountedWebUIAuthorizationPolicyUsesCanonicalNavigationPaths(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-sample-shell</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "assets"), 0o755); err != nil {
+		t.Fatalf("MkdirAll assets: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "assets", "app.js"), []byte("console.log('protected-sample')"), 0o644); err != nil {
+		t.Fatalf("WriteFile app.js: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "reports"), 0o755); err != nil {
+		t.Fatalf("MkdirAll reports: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "reports", "index.html"), []byte("<html>reports</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile reports/index.html: %v", err)
+	}
+	handler, err := testutilWebUIHandler(dir)
+	if err != nil {
+		t.Fatalf("webui handler: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	viewer := seedUser(t, svc, "viewer@example.test")
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{SubjectID: principal.UserSubjectID(viewer.ID), Role: "viewer"},
+				},
+			},
+		},
+	}, nil, map[string]*config.ProviderEntry{
+		"sample_portal": {AuthorizationPolicy: "sample_policy"},
+	}, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "viewer-session" {
+					return nil, fmt.Errorf("invalid token")
+				}
+				return &core.UserIdentity{Email: "viewer@example.test"}, nil
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.MountedWebUIs = []server.MountedWebUI{{
+			Name:                "sample_portal",
+			Path:                "/sample-portal",
+			AuthorizationPolicy: "sample_policy",
+			Routes: []server.MountedWebUIRoute{
+				{Path: "/", AllowedRoles: []string{"viewer", "admin"}},
+				{Path: "/reports", AllowedRoles: []string{"viewer", "admin"}},
+			},
+			Handler: handler,
+		}}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	assetReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/assets/app.js", nil)
+	assetReq.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	assetResp, err := http.DefaultClient.Do(assetReq)
+	if err != nil {
+		t.Fatalf("GET protected mounted asset: %v", err)
+	}
+	defer func() { _ = assetResp.Body.Close() }()
+	if assetResp.StatusCode != http.StatusOK {
+		t.Fatalf("asset status = %d, want %d", assetResp.StatusCode, http.StatusOK)
+	}
+
+	reportsReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/reports/index.html", nil)
+	reportsReq.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	reportsResp, err := http.DefaultClient.Do(reportsReq)
+	if err != nil {
+		t.Fatalf("GET protected mounted reports html: %v", err)
+	}
+	defer func() { _ = reportsResp.Body.Close() }()
+	if reportsResp.StatusCode != http.StatusOK {
+		t.Fatalf("reports html status = %d, want %d", reportsResp.StatusCode, http.StatusOK)
+	}
+}
+
+func TestMountedWebUIAuthorizationPolicyUsesNearestAncestorRouteForNestedAssets(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-sample-shell</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "reports", "assets"), 0o755); err != nil {
+		t.Fatalf("MkdirAll reports/assets: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "reports", "assets", "app.js"), []byte("console.log('reports-only')"), 0o644); err != nil {
+		t.Fatalf("WriteFile reports/assets/app.js: %v", err)
+	}
+	handler, err := testutilWebUIHandler(dir)
+	if err != nil {
+		t.Fatalf("webui handler: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	viewer := seedUser(t, svc, "viewer@example.test")
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{SubjectID: principal.UserSubjectID(viewer.ID), Role: "viewer"},
+				},
+			},
+		},
+	}, nil, map[string]*config.ProviderEntry{
+		"sample_portal": {AuthorizationPolicy: "sample_policy"},
+	}, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "viewer-session" {
+					return nil, fmt.Errorf("invalid token")
+				}
+				return &core.UserIdentity{Email: "viewer@example.test"}, nil
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.MountedWebUIs = []server.MountedWebUI{{
+			Name:                "sample_portal",
+			Path:                "/sample-portal",
+			AuthorizationPolicy: "sample_policy",
+			Routes: []server.MountedWebUIRoute{
+				{Path: "/", AllowedRoles: []string{"viewer", "admin"}},
+				{Path: "/reports", AllowedRoles: []string{"admin"}},
+			},
+			Handler: handler,
+		}}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/reports/assets/app.js", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET nested protected mounted asset: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("nested asset status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+}
+
+func TestMountedWebUIAuthorizationPolicyAllowsExplicitCatchAllAndDottedRoutes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-sample-shell</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "admin"), 0o755); err != nil {
+		t.Fatalf("MkdirAll admin: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "admin", "widget.js"), []byte("console.log('admin-only')"), 0o644); err != nil {
+		t.Fatalf("WriteFile admin/widget.js: %v", err)
+	}
+	handler, err := testutilWebUIHandler(dir)
+	if err != nil {
+		t.Fatalf("webui handler: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	viewer := seedUser(t, svc, "viewer@example.test")
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{SubjectID: principal.UserSubjectID(viewer.ID), Role: "viewer"},
+				},
+			},
+		},
+	}, nil, map[string]*config.ProviderEntry{
+		"sample_portal": {AuthorizationPolicy: "sample_policy"},
+	}, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "viewer-session" {
+					return nil, fmt.Errorf("invalid token")
+				}
+				return &core.UserIdentity{Email: "viewer@example.test"}, nil
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.MountedWebUIs = []server.MountedWebUI{{
+			Name:                "sample_portal",
+			Path:                "/sample-portal",
+			AuthorizationPolicy: "sample_policy",
+			Routes: []server.MountedWebUIRoute{
+				{Path: "/admin/widget.js", AllowedRoles: []string{"admin"}},
+				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
+			},
+			Handler: handler,
+		}}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	dottedReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/customers/acme.test", nil)
+	dottedReq.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	dottedResp, err := http.DefaultClient.Do(dottedReq)
+	if err != nil {
+		t.Fatalf("GET dotted protected mounted route: %v", err)
+	}
+	defer func() { _ = dottedResp.Body.Close() }()
+	if dottedResp.StatusCode != http.StatusOK {
+		t.Fatalf("dotted route status = %d, want %d", dottedResp.StatusCode, http.StatusOK)
+	}
+
+	adminReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/admin/widget.js", nil)
+	adminReq.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	adminResp, err := http.DefaultClient.Do(adminReq)
+	if err != nil {
+		t.Fatalf("GET asset-like protected mounted route: %v", err)
+	}
+	defer func() { _ = adminResp.Body.Close() }()
+	if adminResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("asset-like route status = %d, want %d", adminResp.StatusCode, http.StatusForbidden)
+	}
+}
+
+func TestMountedWebUIAuthorizationPolicyPrefersExactRoutesOverWildcards(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-sample-shell</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	handler, err := testutilWebUIHandler(dir)
+	if err != nil {
+		t.Fatalf("webui handler: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	viewer := seedUser(t, svc, "viewer@example.test")
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{SubjectID: principal.UserSubjectID(viewer.ID), Role: "viewer"},
+				},
+			},
+		},
+	}, nil, map[string]*config.ProviderEntry{
+		"sample_portal": {AuthorizationPolicy: "sample_policy"},
+	}, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "viewer-session" {
+					return nil, fmt.Errorf("invalid token")
+				}
+				return &core.UserIdentity{Email: "viewer@example.test"}, nil
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.MountedWebUIs = []server.MountedWebUI{{
+			Name:                "sample_portal",
+			Path:                "/sample-portal",
+			AuthorizationPolicy: "sample_policy",
+			Routes: []server.MountedWebUIRoute{
+				{Path: "/admin/settings", AllowedRoles: []string{"admin"}},
+				{Path: "/admin/*", AllowedRoles: []string{"viewer", "admin"}},
+				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
+			},
+			Handler: handler,
+		}}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	exactReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/admin/settings", nil)
+	exactReq.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	exactResp, err := http.DefaultClient.Do(exactReq)
+	if err != nil {
+		t.Fatalf("GET exact protected mounted route: %v", err)
+	}
+	defer func() { _ = exactResp.Body.Close() }()
+	if exactResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("exact route status = %d, want %d", exactResp.StatusCode, http.StatusForbidden)
+	}
+
+	wildReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/admin/overview", nil)
+	wildReq.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	wildResp, err := http.DefaultClient.Do(wildReq)
+	if err != nil {
+		t.Fatalf("GET wildcard protected mounted route: %v", err)
+	}
+	defer func() { _ = wildResp.Body.Close() }()
+	if wildResp.StatusCode != http.StatusOK {
+		t.Fatalf("wildcard route status = %d, want %d", wildResp.StatusCode, http.StatusOK)
+	}
+}
+
+func TestMountedWebUIAuthorizationPolicyExactRoutesDoNotMatchDescendants(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-sample-shell</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	handler, err := testutilWebUIHandler(dir)
+	if err != nil {
+		t.Fatalf("webui handler: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	viewer := seedUser(t, svc, "viewer@example.test")
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{SubjectID: principal.UserSubjectID(viewer.ID), Role: "viewer"},
+				},
+			},
+		},
+	}, nil, map[string]*config.ProviderEntry{
+		"sample_portal": {AuthorizationPolicy: "sample_policy"},
+	}, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "viewer-session" {
+					return nil, fmt.Errorf("invalid token")
+				}
+				return &core.UserIdentity{Email: "viewer@example.test"}, nil
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.MountedWebUIs = []server.MountedWebUI{{
+			Name:                "sample_portal",
+			Path:                "/sample-portal",
+			AuthorizationPolicy: "sample_policy",
+			Routes: []server.MountedWebUIRoute{
+				{Path: "/admin", AllowedRoles: []string{"viewer", "admin"}},
+				{Path: "/admin/*", AllowedRoles: []string{"admin"}},
+				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
+			},
+			Handler: handler,
+		}}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	exactReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/admin", nil)
+	exactReq.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	exactResp, err := http.DefaultClient.Do(exactReq)
+	if err != nil {
+		t.Fatalf("GET exact protected mounted route: %v", err)
+	}
+	defer func() { _ = exactResp.Body.Close() }()
+	if exactResp.StatusCode != http.StatusOK {
+		t.Fatalf("exact route status = %d, want %d", exactResp.StatusCode, http.StatusOK)
+	}
+
+	descendantReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/admin/reports", nil)
+	descendantReq.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	descendantResp, err := http.DefaultClient.Do(descendantReq)
+	if err != nil {
+		t.Fatalf("GET descendant protected mounted route: %v", err)
+	}
+	defer func() { _ = descendantResp.Body.Close() }()
+	if descendantResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("descendant route status = %d, want %d", descendantResp.StatusCode, http.StatusForbidden)
+	}
+
+	htmlReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/admin/index.html", nil)
+	htmlReq.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	htmlResp, err := http.DefaultClient.Do(htmlReq)
+	if err != nil {
+		t.Fatalf("GET html descendant protected mounted route: %v", err)
+	}
+	defer func() { _ = htmlResp.Body.Close() }()
+	if htmlResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("html descendant route status = %d, want %d", htmlResp.StatusCode, http.StatusForbidden)
 	}
 }
 
@@ -8500,6 +9174,71 @@ func TestLoginCallback_HostIssuesSessionWhenProviderDoesNot(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode == http.StatusUnauthorized {
 		t.Fatal("host-issued session cookie should authenticate subsequent requests")
+	}
+}
+
+func TestBrowserLoginRedirect_RedirectsBackToNextPath(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	auth := &stubHostIssuedSessionAuth{secret: secret}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New: %v", err)
+	}
+	client := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = auth
+		cfg.StateSecret = secret
+		cfg.Services = coretesting.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	startResp, err := client.Get(ts.URL + "/api/v1/auth/login?next=%2Fsample-portal%2Fadmin%3Ftab%3Dmembers")
+	if err != nil {
+		t.Fatalf("start browser login: %v", err)
+	}
+	defer func() { _ = startResp.Body.Close() }()
+	if startResp.StatusCode != http.StatusFound {
+		t.Fatalf("start status = %d, want %d", startResp.StatusCode, http.StatusFound)
+	}
+	loginURL, err := url.Parse(startResp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse start login redirect: %v", err)
+	}
+	if got := loginURL.Host; got != "idp.example.test" {
+		t.Fatalf("login redirect host = %q, want %q", got, "idp.example.test")
+	}
+	if got := loginURL.Query().Get("state"); got != "/sample-portal/admin" {
+		t.Fatalf("login redirect state = %q, want %q", got, "/sample-portal/admin")
+	}
+
+	callbackResp, err := client.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=" + url.QueryEscape(loginURL.Query().Get("state")))
+	if err != nil {
+		t.Fatalf("browser login callback: %v", err)
+	}
+	defer func() { _ = callbackResp.Body.Close() }()
+	if callbackResp.StatusCode != http.StatusFound {
+		t.Fatalf("callback status = %d, want %d", callbackResp.StatusCode, http.StatusFound)
+	}
+	if got, want := callbackResp.Header.Get("Location"), "/sample-portal/admin?tab=members"; got != want {
+		t.Fatalf("callback redirect = %q, want %q", got, want)
+	}
+
+	foundSession := false
+	for _, cookie := range jar.Cookies(callbackResp.Request.URL) {
+		if cookie.Name == "session_token" && cookie.Value != "" {
+			foundSession = true
+		}
+	}
+	if !foundSession {
+		t.Fatal("expected session cookie after browser login callback")
 	}
 }
 

--- a/gestaltd/internal/staticui/staticui.go
+++ b/gestaltd/internal/staticui/staticui.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net/http"
+	stdpath "path"
 	"strings"
 	"time"
 )
@@ -48,34 +49,102 @@ func Handler(cfg Config) (http.Handler, error) {
 
 	fileServer := http.FileServer(http.FS(cfg.FS))
 
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		path := strings.TrimPrefix(r.URL.Path, "/")
-		if path == "" {
-			path = "index.html"
-		}
+	return &handler{
+		fs:         cfg.FS,
+		fileServer: fileServer,
+		readIndex:  readIndex,
+	}, nil
+}
 
-		if info, err := fs.Stat(cfg.FS, path); err == nil && !info.IsDir() {
+type handler struct {
+	fs         fs.FS
+	fileServer http.Handler
+	readIndex  func() ([]byte, error)
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	resolution := h.resolve(strings.TrimPrefix(r.URL.Path, "/"))
+	switch {
+	case resolution.serveIndex:
+		serveIndex(w, r, h.readIndex)
+	case resolution.servePath != "":
+		serve(h.fileServer, w, r, resolution.servePath)
+	default:
+		serveIndex(w, r, h.readIndex)
+	}
+}
+
+func (h *handler) NavigationPathForRequest(requestPath string) (string, bool) {
+	resolution := h.resolve(strings.TrimPrefix(requestPath, "/"))
+	return resolution.routePath, resolution.navigation
+}
+
+type requestResolution struct {
+	navigation bool
+	routePath  string
+	serveIndex bool
+	servePath  string
+}
+
+func (h *handler) resolve(path string) requestResolution {
+	if path == "" {
+		path = "index.html"
+	}
+	path = strings.TrimPrefix(path, "/")
+
+	if info, err := fs.Stat(h.fs, path); err == nil && !info.IsDir() {
+		if routePath, ok := navigationRoutePath(path); ok {
 			if path == "index.html" {
-				serveIndex(w, r, readIndex)
-				return
+				return requestResolution{navigation: true, routePath: routePath, serveIndex: true}
 			}
-			fileServer.ServeHTTP(w, r)
-			return
+			return requestResolution{navigation: true, routePath: routePath, servePath: "/" + path}
 		}
+		return requestResolution{servePath: "/" + path}
+	}
 
-		if !strings.Contains(path, ".") {
-			if _, err := fs.Stat(cfg.FS, path+".html"); err == nil {
-				serve(fileServer, w, r, "/"+path+".html")
-				return
-			}
-			if _, err := fs.Stat(cfg.FS, path+"/index.html"); err == nil {
-				serve(fileServer, w, r, "/"+path+"/index.html")
-				return
+	if !strings.Contains(path, ".") {
+		if _, err := fs.Stat(h.fs, path+".html"); err == nil {
+			return requestResolution{
+				navigation: true,
+				routePath:  cleanRoutePath("/" + path),
+				servePath:  "/" + path + ".html",
 			}
 		}
+		if _, err := fs.Stat(h.fs, path+"/index.html"); err == nil {
+			return requestResolution{
+				navigation: true,
+				routePath:  cleanRoutePath("/" + path),
+				servePath:  "/" + path + "/index.html",
+			}
+		}
+	}
 
-		serveIndex(w, r, readIndex)
-	}), nil
+	return requestResolution{
+		navigation: true,
+		routePath:  cleanRoutePath("/" + path),
+		serveIndex: true,
+	}
+}
+
+func navigationRoutePath(path string) (string, bool) {
+	switch {
+	case path == "index.html":
+		return "/", true
+	case strings.HasSuffix(path, "/index.html"):
+		return cleanRoutePath("/" + strings.TrimSuffix(path, "/index.html")), true
+	case strings.HasSuffix(path, ".html"):
+		return cleanRoutePath("/" + strings.TrimSuffix(path, ".html")), true
+	default:
+		return "", false
+	}
+}
+
+func cleanRoutePath(path string) string {
+	path = stdpath.Clean(path)
+	if path == "." {
+		return "/"
+	}
+	return path
 }
 
 func serveIndex(w http.ResponseWriter, r *http.Request, readIndex func() ([]byte, error)) {

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -164,6 +164,12 @@
         "assetRoot": {
           "type": "string",
           "minLength": 1
+        },
+        "routes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/webuiRoute"
+          }
         }
       }
     },
@@ -675,6 +681,26 @@
           "type": "array",
           "items": {
             "$ref": "#/$defs/providerParameter"
+          }
+        }
+      }
+    },
+    "webuiRoute": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "allowedRoles": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
           }
         }
       }

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -57,7 +57,8 @@ type Spec struct {
 	Requires          []string                              `json:"requires,omitempty" yaml:"requires,omitempty"`
 
 	// WebUI-specific fields
-	AssetRoot string `json:"assetRoot,omitempty" yaml:"assetRoot,omitempty"`
+	AssetRoot string       `json:"assetRoot,omitempty" yaml:"assetRoot,omitempty"`
+	Routes    []WebUIRoute `json:"routes,omitempty" yaml:"routes,omitempty"`
 }
 
 func (s *Spec) IsDeclarative() bool {
@@ -236,6 +237,11 @@ type ManifestConnectionDef struct {
 	Auth        *ProviderAuth                      `json:"auth,omitempty" yaml:"auth,omitempty"`
 	Params      map[string]ProviderConnectionParam `json:"params,omitempty" yaml:"params,omitempty"`
 	Discovery   *ProviderDiscovery                 `json:"discovery,omitempty" yaml:"discovery,omitempty"`
+}
+
+type WebUIRoute struct {
+	Path         string   `json:"path" yaml:"path"`
+	AllowedRoles []string `json:"allowedRoles,omitempty" yaml:"allowedRoles,omitempty"`
 }
 
 type ProviderOperation struct {


### PR DESCRIPTION
## Summary
- add WebUI manifest route metadata with `allowedRoles`
- enforce `authorizationPolicy` on mounted UI requests, including route-level role checks for navigation paths
- add browser login redirect support so protected mounted routes can round-trip users back after auth callback

## Notes
- stacked on top of #945
- assets require app membership but do not require route-role matches
- route-role checks apply to SPA/navigation requests, including static-export HTML routes like `/admin/index.html`

## Validation
- `go test ./internal/authorization ./internal/providerpkg ./internal/server ./cmd/gestaltd`
- `golangci-lint run ./internal/authorization ./internal/providerpkg ./internal/server ./cmd/gestaltd`