### PR TITLE
[codex] Split IndexedDB metric labels

### DIFF
--- a/docs/content/observability.mdx
+++ b/docs/content/observability.mdx
@@ -227,17 +227,21 @@ plugin host traffic are covered.
   </Tabs.Tab>
 </Tabs>
 
-These metrics carry two low-cardinality attributes:
+These metrics carry low-cardinality attributes:
 
-- `gestalt.store` identifies the table being accessed, such as `users`,
-  `integration_tokens`, or `api_tokens`. Plugins that declare IndexedDB
-  access produce their own store names here.
+- `gestalt.db` identifies the logical IndexedDB resource configured in
+  `gestaltd`, such as the server's primary IndexedDB binding.
+- `gestalt.object_store` identifies the IndexedDB object store being accessed,
+  such as `users`, `integration_tokens`, or `api_tokens`.
+- `gestalt.plugin` identifies the plugin namespace for plugin-hosted IndexedDB
+  traffic. Core services omit this attribute.
 - `gestalt.method` identifies the operation. Values correspond to the
   methods on the ObjectStore and Index interfaces inspired by the
   [IndexedDB API](https://www.w3.org/TR/IndexedDB/): `Get`, `GetKey`,
   `Put`, `Add`, `Delete`, `Clear`, `GetAll`, `GetAllKeys`, `Count`,
-  `DeleteRange`, `Index.Get`, `Index.GetKey`, `Index.GetAll`,
-  `Index.GetAllKeys`, `Index.Count`, and `Index.Delete`.
+  `DeleteRange`, `OpenCursor`, `OpenKeyCursor`, `Index.Get`,
+  `Index.GetKey`, `Index.GetAll`, `Index.GetAllKeys`, `Index.Count`,
+  `Index.Delete`, `Index.OpenCursor`, and `Index.OpenKeyCursor`.
 
 Expected misses that return `ErrNotFound` still increment
 `gestaltd.indexeddb.count` and `gestaltd.indexeddb.duration`, but do not

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -317,7 +317,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	if storeErr != nil {
 		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", cfg.Server.IndexedDB, storeErr)
 	}
-	store = metricutil.InstrumentIndexedDB(store)
+	store = metricutil.InstrumentIndexedDB(store, cfg.Server.IndexedDB)
 	svc, svcErr := coredata.New(store, enc)
 	if svcErr != nil {
 		_ = store.Close()
@@ -335,7 +335,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 			_ = closeIndexedDBs(extraIndexedDBs...)
 			return nil, fmt.Errorf("bootstrap: indexeddb from resource %q: %w", name, err)
 		}
-		ds = metricutil.InstrumentIndexedDB(ds)
+		ds = metricutil.InstrumentIndexedDB(ds, name)
 		hostIndexedDBs[name] = ds
 		extraIndexedDBs = append(extraIndexedDBs, ds)
 	}

--- a/gestaltd/internal/metricutil/indexeddb.go
+++ b/gestaltd/internal/metricutil/indexeddb.go
@@ -9,12 +9,13 @@ import (
 
 type instrumentedIndexedDB struct {
 	inner indexeddb.IndexedDB
+	db    string
 }
 
 // InstrumentIndexedDB wraps an IndexedDB instance to record metrics on every
 // ObjectStore and Index operation.
-func InstrumentIndexedDB(db indexeddb.IndexedDB) indexeddb.IndexedDB {
-	return &instrumentedIndexedDB{inner: db}
+func InstrumentIndexedDB(db indexeddb.IndexedDB, dbName string) indexeddb.IndexedDB {
+	return &instrumentedIndexedDB{inner: db, db: dbName}
 }
 
 // UnwrapIndexedDB returns the underlying IndexedDB if db is instrumented,
@@ -27,8 +28,24 @@ func UnwrapIndexedDB(db indexeddb.IndexedDB) indexeddb.IndexedDB {
 	return db
 }
 
+// IndexedDBName returns the logical IndexedDB resource name when db is instrumented.
+func IndexedDBName(db indexeddb.IndexedDB) string {
+	if w, ok := db.(*instrumentedIndexedDB); ok {
+		return w.db
+	}
+	return ""
+}
+
+// InstrumentObjectStore wraps an ObjectStore to record metrics with the provided labels.
+func InstrumentObjectStore(store indexeddb.ObjectStore, labels IndexedDBMetricLabels) indexeddb.ObjectStore {
+	return &instrumentedObjectStore{inner: store, labels: labels}
+}
+
 func (d *instrumentedIndexedDB) ObjectStore(name string) indexeddb.ObjectStore {
-	return &instrumentedObjectStore{inner: d.inner.ObjectStore(name), store: name}
+	return InstrumentObjectStore(d.inner.ObjectStore(name), IndexedDBMetricLabels{
+		DB:          d.db,
+		ObjectStore: name,
+	})
 }
 
 func (d *instrumentedIndexedDB) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
@@ -48,155 +65,155 @@ func (d *instrumentedIndexedDB) Close() error {
 }
 
 type instrumentedObjectStore struct {
-	inner indexeddb.ObjectStore
-	store string
+	inner  indexeddb.ObjectStore
+	labels IndexedDBMetricLabels
 }
 
 func (s *instrumentedObjectStore) Get(ctx context.Context, id string) (indexeddb.Record, error) {
 	startedAt := time.Now()
 	rec, err := s.inner.Get(ctx, id)
-	RecordIndexedDBMetrics(ctx, startedAt, s.store, "Get", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "Get", err != nil)
 	return rec, err
 }
 
 func (s *instrumentedObjectStore) GetKey(ctx context.Context, id string) (string, error) {
 	startedAt := time.Now()
 	key, err := s.inner.GetKey(ctx, id)
-	RecordIndexedDBMetrics(ctx, startedAt, s.store, "GetKey", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "GetKey", err != nil)
 	return key, err
 }
 
 func (s *instrumentedObjectStore) Add(ctx context.Context, record indexeddb.Record) error {
 	startedAt := time.Now()
 	err := s.inner.Add(ctx, record)
-	RecordIndexedDBMetrics(ctx, startedAt, s.store, "Add", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "Add", err != nil)
 	return err
 }
 
 func (s *instrumentedObjectStore) Put(ctx context.Context, record indexeddb.Record) error {
 	startedAt := time.Now()
 	err := s.inner.Put(ctx, record)
-	RecordIndexedDBMetrics(ctx, startedAt, s.store, "Put", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "Put", err != nil)
 	return err
 }
 
 func (s *instrumentedObjectStore) Delete(ctx context.Context, id string) error {
 	startedAt := time.Now()
 	err := s.inner.Delete(ctx, id)
-	RecordIndexedDBMetrics(ctx, startedAt, s.store, "Delete", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "Delete", err != nil)
 	return err
 }
 
 func (s *instrumentedObjectStore) Clear(ctx context.Context) error {
 	startedAt := time.Now()
 	err := s.inner.Clear(ctx)
-	RecordIndexedDBMetrics(ctx, startedAt, s.store, "Clear", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "Clear", err != nil)
 	return err
 }
 
 func (s *instrumentedObjectStore) GetAll(ctx context.Context, r *indexeddb.KeyRange) ([]indexeddb.Record, error) {
 	startedAt := time.Now()
 	recs, err := s.inner.GetAll(ctx, r)
-	RecordIndexedDBMetrics(ctx, startedAt, s.store, "GetAll", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "GetAll", err != nil)
 	return recs, err
 }
 
 func (s *instrumentedObjectStore) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange) ([]string, error) {
 	startedAt := time.Now()
 	keys, err := s.inner.GetAllKeys(ctx, r)
-	RecordIndexedDBMetrics(ctx, startedAt, s.store, "GetAllKeys", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "GetAllKeys", err != nil)
 	return keys, err
 }
 
 func (s *instrumentedObjectStore) Count(ctx context.Context, r *indexeddb.KeyRange) (int64, error) {
 	startedAt := time.Now()
 	n, err := s.inner.Count(ctx, r)
-	RecordIndexedDBMetrics(ctx, startedAt, s.store, "Count", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "Count", err != nil)
 	return n, err
 }
 
 func (s *instrumentedObjectStore) DeleteRange(ctx context.Context, r indexeddb.KeyRange) (int64, error) {
 	startedAt := time.Now()
 	n, err := s.inner.DeleteRange(ctx, r)
-	RecordIndexedDBMetrics(ctx, startedAt, s.store, "DeleteRange", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "DeleteRange", err != nil)
 	return n, err
 }
 
 func (s *instrumentedObjectStore) Index(name string) indexeddb.Index {
-	return &instrumentedIndex{inner: s.inner.Index(name), store: s.store}
+	return &instrumentedIndex{inner: s.inner.Index(name), labels: s.labels}
 }
 
 func (s *instrumentedObjectStore) OpenCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection) (indexeddb.Cursor, error) {
 	startedAt := time.Now()
 	c, err := s.inner.OpenCursor(ctx, r, dir)
-	RecordIndexedDBMetrics(ctx, startedAt, s.store, "OpenCursor", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "OpenCursor", err != nil)
 	return c, err
 }
 
 func (s *instrumentedObjectStore) OpenKeyCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection) (indexeddb.Cursor, error) {
 	startedAt := time.Now()
 	c, err := s.inner.OpenKeyCursor(ctx, r, dir)
-	RecordIndexedDBMetrics(ctx, startedAt, s.store, "OpenKeyCursor", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, s.labels, "OpenKeyCursor", err != nil)
 	return c, err
 }
 
 type instrumentedIndex struct {
-	inner indexeddb.Index
-	store string
+	inner  indexeddb.Index
+	labels IndexedDBMetricLabels
 }
 
 func (i *instrumentedIndex) Get(ctx context.Context, values ...any) (indexeddb.Record, error) {
 	startedAt := time.Now()
 	rec, err := i.inner.Get(ctx, values...)
-	RecordIndexedDBMetrics(ctx, startedAt, i.store, "Index.Get", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, i.labels, "Index.Get", err != nil)
 	return rec, err
 }
 
 func (i *instrumentedIndex) GetKey(ctx context.Context, values ...any) (string, error) {
 	startedAt := time.Now()
 	key, err := i.inner.GetKey(ctx, values...)
-	RecordIndexedDBMetrics(ctx, startedAt, i.store, "Index.GetKey", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, i.labels, "Index.GetKey", err != nil)
 	return key, err
 }
 
 func (i *instrumentedIndex) GetAll(ctx context.Context, r *indexeddb.KeyRange, values ...any) ([]indexeddb.Record, error) {
 	startedAt := time.Now()
 	recs, err := i.inner.GetAll(ctx, r, values...)
-	RecordIndexedDBMetrics(ctx, startedAt, i.store, "Index.GetAll", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, i.labels, "Index.GetAll", err != nil)
 	return recs, err
 }
 
 func (i *instrumentedIndex) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange, values ...any) ([]string, error) {
 	startedAt := time.Now()
 	keys, err := i.inner.GetAllKeys(ctx, r, values...)
-	RecordIndexedDBMetrics(ctx, startedAt, i.store, "Index.GetAllKeys", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, i.labels, "Index.GetAllKeys", err != nil)
 	return keys, err
 }
 
 func (i *instrumentedIndex) Count(ctx context.Context, r *indexeddb.KeyRange, values ...any) (int64, error) {
 	startedAt := time.Now()
 	n, err := i.inner.Count(ctx, r, values...)
-	RecordIndexedDBMetrics(ctx, startedAt, i.store, "Index.Count", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, i.labels, "Index.Count", err != nil)
 	return n, err
 }
 
 func (i *instrumentedIndex) Delete(ctx context.Context, values ...any) (int64, error) {
 	startedAt := time.Now()
 	n, err := i.inner.Delete(ctx, values...)
-	RecordIndexedDBMetrics(ctx, startedAt, i.store, "Index.Delete", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, i.labels, "Index.Delete", err != nil)
 	return n, err
 }
 
 func (i *instrumentedIndex) OpenCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection, values ...any) (indexeddb.Cursor, error) {
 	startedAt := time.Now()
 	c, err := i.inner.OpenCursor(ctx, r, dir, values...)
-	RecordIndexedDBMetrics(ctx, startedAt, i.store, "Index.OpenCursor", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, i.labels, "Index.OpenCursor", err != nil)
 	return c, err
 }
 
 func (i *instrumentedIndex) OpenKeyCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection, values ...any) (indexeddb.Cursor, error) {
 	startedAt := time.Now()
 	c, err := i.inner.OpenKeyCursor(ctx, r, dir, values...)
-	RecordIndexedDBMetrics(ctx, startedAt, i.store, "Index.OpenKeyCursor", err != nil)
+	RecordIndexedDBMetrics(ctx, startedAt, i.labels, "Index.OpenKeyCursor", err != nil)
 	return c, err
 }

--- a/gestaltd/internal/metricutil/indexeddb_test.go
+++ b/gestaltd/internal/metricutil/indexeddb_test.go
@@ -1,0 +1,28 @@
+package metricutil
+
+import (
+	"context"
+	"testing"
+
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
+)
+
+func TestInstrumentIndexedDBRecordsDBAndObjectStoreAttributes(t *testing.T) {
+	reader := metrictest.UseManualMeterProvider(t)
+	ctx := context.Background()
+
+	db := InstrumentIndexedDB(&coretesting.StubIndexedDB{}, "system")
+	if err := db.ObjectStore("users").Put(ctx, map[string]any{"id": "user-1"}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	rm := metrictest.CollectMetrics(t, reader)
+	attrs := map[string]string{
+		"gestalt.db":           "system",
+		"gestalt.object_store": "users",
+		"gestalt.method":       "Put",
+	}
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.indexeddb.count", 1, attrs)
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.indexeddb.duration", attrs)
+}

--- a/gestaltd/internal/metricutil/indexeddb_test.go
+++ b/gestaltd/internal/metricutil/indexeddb_test.go
@@ -9,20 +9,22 @@ import (
 )
 
 func TestInstrumentIndexedDBRecordsDBAndObjectStoreAttributes(t *testing.T) {
-	reader := metrictest.UseManualMeterProvider(t)
-	ctx := context.Background()
+	metrics := metrictest.NewManualMeterProvider(t)
+	ctx := WithMeterProvider(context.Background(), metrics.Provider)
 
 	db := InstrumentIndexedDB(&coretesting.StubIndexedDB{}, "system")
 	if err := db.ObjectStore("users").Put(ctx, map[string]any{"id": "user-1"}); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
 
-	rm := metrictest.CollectMetrics(t, reader)
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
 	attrs := map[string]string{
 		"gestalt.db":           "system",
 		"gestalt.object_store": "users",
 		"gestalt.method":       "Put",
 	}
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.indexeddb.count", 1, attrs)
+	metrictest.RequireInt64SumOmitsAttr(t, rm, "gestaltd.indexeddb.count", attrs, "gestalt.plugin")
+	metrictest.RequireInt64SumOmitsAttr(t, rm, "gestaltd.indexeddb.count", attrs, "gestalt.store")
 	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.indexeddb.duration", attrs)
 }

--- a/gestaltd/internal/metricutil/indexeddb_test.go
+++ b/gestaltd/internal/metricutil/indexeddb_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestInstrumentIndexedDBRecordsDBAndObjectStoreAttributes(t *testing.T) {
+	t.Parallel()
+
 	metrics := metrictest.NewManualMeterProvider(t)
 	ctx := WithMeterProvider(context.Background(), metrics.Provider)
 

--- a/gestaltd/internal/metricutil/semantic_metrics.go
+++ b/gestaltd/internal/metricutil/semantic_metrics.go
@@ -13,9 +13,11 @@ const meterName = "gestaltd"
 var (
 	attrProvider       = attribute.Key("gestalt.provider")
 	attrAction         = attribute.Key("gestalt.action")
+	attrDB             = attribute.Key("gestalt.db")
 	attrType           = attribute.Key("gestalt.type")
 	attrMethod         = attribute.Key("gestalt.method")
-	attrStore          = attribute.Key("gestalt.store")
+	attrObjectStore    = attribute.Key("gestalt.object_store")
+	attrPlugin         = attribute.Key("gestalt.plugin")
 	attrConnectionMode = attribute.Key("gestalt.connection_mode")
 )
 
@@ -74,14 +76,25 @@ func RecordConnectionAuthMetrics(ctx context.Context, startedAt time.Time, provi
 	)
 }
 
-func RecordIndexedDBMetrics(ctx context.Context, startedAt time.Time, store string, method string, failed bool) {
+type IndexedDBMetricLabels struct {
+	DB          string
+	Plugin      string
+	ObjectStore string
+}
+
+func RecordIndexedDBMetrics(ctx context.Context, startedAt time.Time, labels IndexedDBMetricLabels, method string, failed bool) {
 	metrics := indexedDBMetricsCache.Load(ctx, meterName, func(meter metric.Meter) counterMetrics {
 		return newCounterMetrics(meter, "gestaltd.indexeddb", "gestaltd indexeddb operations")
 	})
-	recordCounterMetrics(ctx, metrics, startedAt, failed,
-		attrStore.String(AttrValue(store)),
+	attrs := []attribute.KeyValue{
+		attrDB.String(AttrValue(labels.DB)),
+		attrObjectStore.String(AttrValue(labels.ObjectStore)),
 		attrMethod.String(AttrValue(method)),
-	)
+	}
+	if labels.Plugin != "" {
+		attrs = append(attrs, attrPlugin.String(AttrValue(labels.Plugin)))
+	}
+	recordCounterMetrics(ctx, metrics, startedAt, failed, attrs...)
 }
 
 func recordCounterMetrics(ctx context.Context, metrics counterMetrics, startedAt time.Time, failed bool, attrs ...attribute.KeyValue) {

--- a/gestaltd/internal/providerhost/indexeddb_server.go
+++ b/gestaltd/internal/providerhost/indexeddb_server.go
@@ -8,6 +8,7 @@ import (
 	gestalt "github.com/valon-technologies/gestalt/sdk/go"
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -16,15 +17,33 @@ import (
 type indexedDBServer struct {
 	proto.UnimplementedIndexedDBServer
 	ds     indexeddb.IndexedDB
+	db     string
+	plugin string
 	prefix string
 }
 
 func NewIndexedDBServer(ds indexeddb.IndexedDB, pluginName string) proto.IndexedDBServer {
-	return &indexedDBServer{ds: ds, prefix: "plugin_" + pluginName + "_"}
+	return &indexedDBServer{
+		ds:     ds,
+		db:     metricutil.IndexedDBName(ds),
+		plugin: pluginName,
+		prefix: "plugin_" + pluginName + "_",
+	}
 }
 
 func (s *indexedDBServer) storeName(name string) string {
 	return s.prefix + name
+}
+
+func (s *indexedDBServer) objectStore(name string) indexeddb.ObjectStore {
+	return metricutil.InstrumentObjectStore(
+		metricutil.UnwrapIndexedDB(s.ds).ObjectStore(s.storeName(name)),
+		metricutil.IndexedDBMetricLabels{
+			DB:          s.db,
+			Plugin:      s.plugin,
+			ObjectStore: name,
+		},
+	)
 }
 
 func (s *indexedDBServer) CreateObjectStore(ctx context.Context, req *proto.CreateObjectStoreRequest) (*emptypb.Empty, error) {
@@ -43,7 +62,7 @@ func (s *indexedDBServer) DeleteObjectStore(ctx context.Context, req *proto.Dele
 }
 
 func (s *indexedDBServer) Get(ctx context.Context, req *proto.ObjectStoreRequest) (*proto.RecordResponse, error) {
-	rec, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Get(ctx, req.GetId())
+	rec, err := s.objectStore(req.GetStore()).Get(ctx, req.GetId())
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -51,7 +70,7 @@ func (s *indexedDBServer) Get(ctx context.Context, req *proto.ObjectStoreRequest
 }
 
 func (s *indexedDBServer) GetKey(ctx context.Context, req *proto.ObjectStoreRequest) (*proto.KeyResponse, error) {
-	key, err := s.ds.ObjectStore(s.storeName(req.GetStore())).GetKey(ctx, req.GetId())
+	key, err := s.objectStore(req.GetStore()).GetKey(ctx, req.GetId())
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -63,7 +82,7 @@ func (s *indexedDBServer) Add(ctx context.Context, req *proto.RecordRequest) (*e
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal record: %v", err)
 	}
-	if err := s.ds.ObjectStore(s.storeName(req.GetStore())).Add(ctx, record); err != nil {
+	if err := s.objectStore(req.GetStore()).Add(ctx, record); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
 	return &emptypb.Empty{}, nil
@@ -74,21 +93,21 @@ func (s *indexedDBServer) Put(ctx context.Context, req *proto.RecordRequest) (*e
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal record: %v", err)
 	}
-	if err := s.ds.ObjectStore(s.storeName(req.GetStore())).Put(ctx, record); err != nil {
+	if err := s.objectStore(req.GetStore()).Put(ctx, record); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
 	return &emptypb.Empty{}, nil
 }
 
 func (s *indexedDBServer) Delete(ctx context.Context, req *proto.ObjectStoreRequest) (*emptypb.Empty, error) {
-	if err := s.ds.ObjectStore(s.storeName(req.GetStore())).Delete(ctx, req.GetId()); err != nil {
+	if err := s.objectStore(req.GetStore()).Delete(ctx, req.GetId()); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
 	return &emptypb.Empty{}, nil
 }
 
 func (s *indexedDBServer) Clear(ctx context.Context, req *proto.ObjectStoreNameRequest) (*emptypb.Empty, error) {
-	if err := s.ds.ObjectStore(s.storeName(req.GetStore())).Clear(ctx); err != nil {
+	if err := s.objectStore(req.GetStore()).Clear(ctx); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
 	return &emptypb.Empty{}, nil
@@ -99,7 +118,7 @@ func (s *indexedDBServer) GetAll(ctx context.Context, req *proto.ObjectStoreRang
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal key range: %v", err)
 	}
-	recs, err := s.ds.ObjectStore(s.storeName(req.GetStore())).GetAll(ctx, keyRange)
+	recs, err := s.objectStore(req.GetStore()).GetAll(ctx, keyRange)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -111,7 +130,7 @@ func (s *indexedDBServer) GetAllKeys(ctx context.Context, req *proto.ObjectStore
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal key range: %v", err)
 	}
-	keys, err := s.ds.ObjectStore(s.storeName(req.GetStore())).GetAllKeys(ctx, keyRange)
+	keys, err := s.objectStore(req.GetStore()).GetAllKeys(ctx, keyRange)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -123,7 +142,7 @@ func (s *indexedDBServer) Count(ctx context.Context, req *proto.ObjectStoreRange
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal key range: %v", err)
 	}
-	count, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Count(ctx, keyRange)
+	count, err := s.objectStore(req.GetStore()).Count(ctx, keyRange)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -138,7 +157,7 @@ func (s *indexedDBServer) DeleteRange(ctx context.Context, req *proto.ObjectStor
 	if kr == nil {
 		return nil, status.Error(codes.InvalidArgument, "key range is required for DeleteRange")
 	}
-	deleted, err := s.ds.ObjectStore(s.storeName(req.GetStore())).DeleteRange(ctx, *kr)
+	deleted, err := s.objectStore(req.GetStore()).DeleteRange(ctx, *kr)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -150,7 +169,7 @@ func (s *indexedDBServer) IndexGet(ctx context.Context, req *proto.IndexQueryReq
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", err)
 	}
-	rec, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).Get(ctx, values...)
+	rec, err := s.objectStore(req.GetStore()).Index(req.GetIndex()).Get(ctx, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -162,7 +181,7 @@ func (s *indexedDBServer) IndexGetKey(ctx context.Context, req *proto.IndexQuery
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", err)
 	}
-	key, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).GetKey(ctx, values...)
+	key, err := s.objectStore(req.GetStore()).Index(req.GetIndex()).GetKey(ctx, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -178,7 +197,7 @@ func (s *indexedDBServer) IndexGetAll(ctx context.Context, req *proto.IndexQuery
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", err)
 	}
-	recs, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).GetAll(ctx, keyRange, values...)
+	recs, err := s.objectStore(req.GetStore()).Index(req.GetIndex()).GetAll(ctx, keyRange, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -194,7 +213,7 @@ func (s *indexedDBServer) IndexGetAllKeys(ctx context.Context, req *proto.IndexQ
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", err)
 	}
-	keys, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).GetAllKeys(ctx, keyRange, values...)
+	keys, err := s.objectStore(req.GetStore()).Index(req.GetIndex()).GetAllKeys(ctx, keyRange, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -210,7 +229,7 @@ func (s *indexedDBServer) IndexCount(ctx context.Context, req *proto.IndexQueryR
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", err)
 	}
-	count, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).Count(ctx, keyRange, values...)
+	count, err := s.objectStore(req.GetStore()).Index(req.GetIndex()).Count(ctx, keyRange, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -222,7 +241,7 @@ func (s *indexedDBServer) IndexDelete(ctx context.Context, req *proto.IndexQuery
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", err)
 	}
-	deleted, err := s.ds.ObjectStore(s.storeName(req.GetStore())).Index(req.GetIndex()).Delete(ctx, values...)
+	deleted, err := s.objectStore(req.GetStore()).Index(req.GetIndex()).Delete(ctx, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -260,7 +279,7 @@ func (s *indexedDBServer) OpenCursor(stream proto.IndexedDB_OpenCursorServer) er
 	ctx := stream.Context()
 
 	var cursor indexeddb.Cursor
-	store := s.ds.ObjectStore(s.storeName(openReq.GetStore()))
+	store := s.objectStore(openReq.GetStore())
 
 	if openReq.GetIndex() != "" {
 		values, vErr := protoValuesToAny(openReq.GetValues())

--- a/gestaltd/internal/providerhost/indexeddb_server_test.go
+++ b/gestaltd/internal/providerhost/indexeddb_server_test.go
@@ -6,7 +6,10 @@ import (
 
 	gestalt "github.com/valon-technologies/gestalt/sdk/go"
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
+	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 )
 
 func TestIndexedDBServerPrefixesStoreNamesPerPlugin(t *testing.T) {
@@ -33,4 +36,60 @@ func TestIndexedDBServerPrefixesStoreNamesPerPlugin(t *testing.T) {
 	if _, err := db.ObjectStore("snapshots").Get(ctx, "snap-1"); err == nil {
 		t.Fatal("unprefixed object store should not contain the record")
 	}
+}
+
+func TestIndexedDBServerRecordsPluginMetricAttributes(t *testing.T) {
+	reader := metrictest.UseManualMeterProvider(t)
+	ctx := context.Background()
+
+	db := metricutil.InstrumentIndexedDB(&coretesting.StubIndexedDB{}, "system")
+	srv := NewIndexedDBServer(db, "roadmap")
+	if err := metricutil.UnwrapIndexedDB(db).CreateObjectStore(ctx, "plugin_roadmap_snapshots", indexeddb.ObjectStoreSchema{
+		Indexes: []indexeddb.IndexSchema{{Name: "by_type", KeyPath: []string{"type"}}},
+	}); err != nil {
+		t.Fatalf("CreateObjectStore: %v", err)
+	}
+
+	if _, err := srv.(*indexedDBServer).Put(ctx, &proto.RecordRequest{
+		Store: "snapshots",
+		Record: func() *proto.Record {
+			rec, err := gestalt.RecordToProto(map[string]any{"id": "snap-1", "type": "daily"})
+			if err != nil {
+				t.Fatalf("RecordToProto with type: %v", err)
+			}
+			return rec
+		}(),
+	}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	value, err := gestalt.TypedValueFromAny("daily")
+	if err != nil {
+		t.Fatalf("TypedValueFromAny: %v", err)
+	}
+	if _, err := srv.(*indexedDBServer).IndexGet(ctx, &proto.IndexQueryRequest{
+		Store:  "snapshots",
+		Index:  "by_type",
+		Values: []*proto.TypedValue{value},
+	}); err != nil {
+		t.Fatalf("IndexGet: %v", err)
+	}
+
+	rm := metrictest.CollectMetrics(t, reader)
+	putAttrs := map[string]string{
+		"gestalt.db":           "system",
+		"gestalt.plugin":       "roadmap",
+		"gestalt.object_store": "snapshots",
+		"gestalt.method":       "Put",
+	}
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.indexeddb.count", 1, putAttrs)
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.indexeddb.duration", putAttrs)
+
+	indexAttrs := map[string]string{
+		"gestalt.db":           "system",
+		"gestalt.plugin":       "roadmap",
+		"gestalt.object_store": "snapshots",
+		"gestalt.method":       "Index.Get",
+	}
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.indexeddb.count", 1, indexAttrs)
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.indexeddb.duration", indexAttrs)
 }

--- a/gestaltd/internal/providerhost/indexeddb_server_test.go
+++ b/gestaltd/internal/providerhost/indexeddb_server_test.go
@@ -39,8 +39,8 @@ func TestIndexedDBServerPrefixesStoreNamesPerPlugin(t *testing.T) {
 }
 
 func TestIndexedDBServerRecordsPluginMetricAttributes(t *testing.T) {
-	reader := metrictest.UseManualMeterProvider(t)
-	ctx := context.Background()
+	metrics := metrictest.NewManualMeterProvider(t)
+	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
 
 	db := metricutil.InstrumentIndexedDB(&coretesting.StubIndexedDB{}, "system")
 	srv := NewIndexedDBServer(db, "roadmap")
@@ -74,7 +74,7 @@ func TestIndexedDBServerRecordsPluginMetricAttributes(t *testing.T) {
 		t.Fatalf("IndexGet: %v", err)
 	}
 
-	rm := metrictest.CollectMetrics(t, reader)
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
 	putAttrs := map[string]string{
 		"gestalt.db":           "system",
 		"gestalt.plugin":       "roadmap",
@@ -82,6 +82,7 @@ func TestIndexedDBServerRecordsPluginMetricAttributes(t *testing.T) {
 		"gestalt.method":       "Put",
 	}
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.indexeddb.count", 1, putAttrs)
+	metrictest.RequireInt64SumOmitsAttr(t, rm, "gestaltd.indexeddb.count", putAttrs, "gestalt.store")
 	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.indexeddb.duration", putAttrs)
 
 	indexAttrs := map[string]string{
@@ -91,5 +92,6 @@ func TestIndexedDBServerRecordsPluginMetricAttributes(t *testing.T) {
 		"gestalt.method":       "Index.Get",
 	}
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.indexeddb.count", 1, indexAttrs)
+	metrictest.RequireInt64SumOmitsAttr(t, rm, "gestaltd.indexeddb.count", indexAttrs, "gestalt.store")
 	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.indexeddb.duration", indexAttrs)
 }

--- a/gestaltd/internal/providerhost/indexeddb_server_test.go
+++ b/gestaltd/internal/providerhost/indexeddb_server_test.go
@@ -39,6 +39,8 @@ func TestIndexedDBServerPrefixesStoreNamesPerPlugin(t *testing.T) {
 }
 
 func TestIndexedDBServerRecordsPluginMetricAttributes(t *testing.T) {
+	t.Parallel()
+
 	metrics := metrictest.NewManualMeterProvider(t)
 	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
 

--- a/gestaltd/internal/testutil/metrictest/metrictest.go
+++ b/gestaltd/internal/testutil/metrictest/metrictest.go
@@ -85,6 +85,36 @@ func RequireNoInt64Sum(t *testing.T, rm metricdata.ResourceMetrics, name string,
 	}
 }
 
+func RequireInt64SumOmitsAttr(t *testing.T, rm metricdata.ResourceMetrics, name string, attrs map[string]string, forbiddenKey string) {
+	t.Helper()
+
+	found := false
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != name {
+				continue
+			}
+			sum, ok := metric.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("metric %q is %T, want Sum[int64]", name, metric.Data)
+			}
+			for _, point := range sum.DataPoints {
+				if !AttrsMatch(point.Attributes, attrs) {
+					continue
+				}
+				found = true
+				if _, ok := point.Attributes.Value(attribute.Key(forbiddenKey)); ok {
+					t.Fatalf("metric %q attrs %v unexpectedly include %q", name, attrs, forbiddenKey)
+				}
+			}
+		}
+	}
+
+	if !found {
+		t.Fatalf("metric %q with attrs %v not found", name, attrs)
+	}
+}
+
 func RequireFloat64Histogram(t *testing.T, rm metricdata.ResourceMetrics, name string, attrs map[string]string) {
 	t.Helper()
 


### PR DESCRIPTION
## What changed
- replace the legacy gestalt.store IndexedDB metric tag with gestalt.db and gestalt.object_store on gestaltd.indexeddb.*
- add gestalt.plugin for plugin-hosted IndexedDB traffic
- preserve raw object-store and plugin metadata at the providerhost boundary before host-side store prefixing is applied
- thread the logical IndexedDB resource name from bootstrap into the metric wrapper
- update the observability docs to describe the final tag set and current IndexedDB method coverage
- add focused tests for direct IndexedDB metrics, plugin-hosted index access, and explicit absence of the removed legacy tag

## Why it changed
The old IndexedDB metrics only exposed the final backing store name seen by the host datastore layer. For plugin-hosted traffic that value was already prefixed, so the metrics flattened together the logical database, the actual object store, and the plugin namespace.

## Impact
Dashboards and monitors should query gestalt.db, gestalt.object_store, and optional gestalt.plugin for IndexedDB metrics. gestalt.store is removed entirely, so any existing queries on that tag need to be updated.

## Root cause
The metric wrapper previously recorded only the host-visible store name. By the time plugin-hosted requests hit that layer, the object store name had already been rewritten to include the plugin prefix, so there was no structured way to separate namespace from object store identity.

## Validation
- go test ./internal/providerhost ./internal/metricutil ./internal/bootstrap
- go test ./internal/server -run TestRefreshAndOperationResultMetrics|TestPlatformAuthMetrics|TestManualConnectionMetrics|TestConnectionAuthMetricsUseUnknownProviderForMissingIntegration