### PR TITLE
Promote authorization config to top level

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -4,13 +4,14 @@ Gestalt is configured from a single YAML file. This page covers the key concepts
 
 ## Config file structure
 
-A Gestalt config has two top-level keys: `server` for host settings and `providers` for all pluggable components.
+A Gestalt config has four top-level keys: `server` for host settings, `authorization` for shared human/workload access policy, `providers` for pluggable host components, and `plugins` for executable integrations.
 
 ```yaml
 server:
   encryptionKey: ...        # required, root deployment secret
   baseUrl: ...              # public URL for OAuth callbacks
-  indexeddb: ...            # name of the active storage provider
+  providers:
+    indexeddb: ...          # selected storage provider
   public:                   # public listener (default port 8080)
     host: ...
     port: ...
@@ -26,10 +27,11 @@ providers:
   telemetry: ...            # metrics and tracing (default: stdout)
   audit: ...                # audit log routing (default: inherit)
   ui: ...                   # web UI bundle (ProviderEntry)
-  plugins:                  # named plugin providers
+  indexeddb:                # named storage providers
     <name>: ...             # each is a ProviderEntry
-  indexeddbs:               # named storage providers
-    <name>: ...             # each is a ProviderEntry
+
+plugins:
+  <name>: ...               # each is a ProviderEntry
 ```
 
 Each provider entry accepts `source` (where to load it from), `config` (provider-specific settings), `disabled`, `allowedHosts`, `connections`, and optional metadata fields. See the [Config File](/reference/config-file) reference for every field.
@@ -47,19 +49,18 @@ Gestalt has six core concepts you configure in YAML:
 
 ## Adding a plugin
 
-Each entry under `providers.plugins` registers a plugin backed by a provider package:
+Each entry under `plugins` registers a plugin backed by a provider package:
 
 ```yaml
-providers:
-  plugins:
-    github:
-      displayName: GitHub
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/plugins/github
-        version: 0.0.1-alpha.1
-      surfaces:
-        openapi:
-          baseUrl: https://api.github.com
+plugins:
+  github:
+    displayName: GitHub
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/plugins/github
+      version: 0.0.1-alpha.1
+    surfaces:
+      openapi:
+        baseUrl: https://api.github.com
 ```
 
 `source.ref` points at a published provider package. Gestalt resolves and downloads it on startup. First-party providers are published to `github.com/valon-technologies/gestalt-providers/`.
@@ -67,11 +68,10 @@ providers:
 During development, point at a local provider manifest instead:
 
 ```yaml
-providers:
-  plugins:
-    support:
-      source:
-        path: ./plugins/support/manifest.yaml
+plugins:
+  support:
+    source:
+      path: ./plugins/support/manifest.yaml
 ```
 
 See [Custom Providers](/custom-providers) if you need to build your own.
@@ -81,17 +81,16 @@ See [Custom Providers](/custom-providers) if you need to build your own.
 A provider package may expose a large catalog. Use `allowedOperations` to publish only the subset you want:
 
 ```yaml
-providers:
-  plugins:
-    support:
-      source:
-        ref: github.com/acme/providers/support
-        version: 2.4.0
-      allowedOperations:
-        tickets.list:
-          alias: list_tickets
-        tickets.get:
-          alias: get_ticket
+plugins:
+  support:
+    source:
+      ref: github.com/acme/providers/support
+      version: 2.4.0
+    allowedOperations:
+      tickets.list:
+        alias: list_tickets
+      tickets.get:
+        alias: get_ticket
 ```
 
 Each entry can set an `alias` to rename the operation as it appears to callers.
@@ -101,15 +100,14 @@ Each entry can set an `alias` to rename the operation as it appears to callers.
 Every provider supports `allowedHosts` to restrict which upstream hosts it can reach. When `server.egress.defaultAction` is `deny`, providers without an explicit allowlist are blocked from all outbound requests. Executable plugin providers are additionally sandboxed at the OS level when egress restrictions are active.
 
 ```yaml
-providers:
-  plugins:
-    example:
-      source:
-        ref: github.com/acme/providers/example
-        version: 1.0.0
-      allowedHosts:
-        - api.example.com
-        - cdn.example.com
+plugins:
+  example:
+    source:
+      ref: github.com/acme/providers/example
+      version: 1.0.0
+    allowedHosts:
+      - api.example.com
+      - cdn.example.com
 ```
 
 ## Connecting to upstream APIs
@@ -117,14 +115,13 @@ providers:
 Connections define how Gestalt authenticates to upstream services on behalf of callers. Each plugin declares its connections under `connections:`:
 
 ```yaml
-providers:
-  plugins:
-    github:
-      connections:
-        default:
-          mode: user
-          auth:
-            type: oauth2
+plugins:
+  github:
+    connections:
+      default:
+        mode: user
+        auth:
+          type: oauth2
 ```
 
 ### Connection modes
@@ -153,15 +150,14 @@ Plugins that use `oauth2` connections typically require you to register an OAuth
 For example, the GitHub plugin requires OAuth app credentials from the [GitHub Developer Settings](https://github.com/settings/developers):
 
 ```yaml
-providers:
-  plugins:
-    github:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/plugins/github
-        version: 0.0.1
-      config:
-        clientId: ${GITHUB_CLIENT_ID}
-        clientSecret: secret://github-client-secret
+plugins:
+  github:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/plugins/github
+      version: 0.0.1
+    config:
+      clientId: ${GITHUB_CLIENT_ID}
+      clientSecret: secret://github-client-secret
 ```
 
 Not all providers need this. Some providers (like Slack) use OAuth flows that do not require operator-provided app credentials. Check the provider's documentation or config schema for required fields.
@@ -170,7 +166,7 @@ Not all providers need this. Some providers (like Slack) use OAuth flows that do
 
 `connections.default` is the common case. When a provider defines more than one connection, callers pass `_connection` and `_instance` through the [HTTP API](/reference/http-api) to select which stored credential to use. Connection parameters (`params`) and post-connect discovery are only supported on `connections.default`.
 
-Gestalt stores upstream credentials keyed by user, plugin name, connection name, and instance. Renaming a plugin key under `providers.plugins` is a breaking change for stored connections.
+Gestalt stores upstream credentials keyed by user, plugin name, connection name, and instance. Renaming a plugin key under `plugins` is a breaking change for stored connections.
 
 ## Exposing over MCP
 
@@ -257,14 +253,15 @@ For programmatic access, Gestalt issues API tokens prefixed with `gst_api_`. The
 
 ## Configuring storage
 
-The `providers.indexeddbs` block declares storage providers. The `server.indexeddb` field selects which one Gestalt uses:
+The `providers.indexeddb` block declares storage providers. `server.providers.indexeddb` selects which one Gestalt uses:
 
 ```yaml
 server:
-  indexeddb: main
+  providers:
+    indexeddb: main
 
 providers:
-  indexeddbs:
+  indexeddb:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
@@ -319,7 +316,7 @@ gestaltd validate --config ./config.yaml
 
 ### Defaults and required fields
 
-Gestalt defaults `server.public.port` to `8080`, `providers.secrets` to `env`, and `providers.telemetry` to `stdout`. The required fields are `providers.indexeddbs`, `server.indexeddb`, and `server.encryptionKey`. Platform auth is optional.
+Gestalt defaults `server.public.port` to `8080`, `providers.secrets` to `env`, and `providers.telemetry` to `stdout`. The required fields are `providers.indexeddb`, `server.providers.indexeddb`, and `server.encryptionKey`. Platform auth is optional.
 
 `server.encryptionKey` is the root deployment secret. Gestalt derives token encryption and session material from it. Changing this key invalidates all existing sessions and tokens, so treat it as a meaningful deployment event.
 

--- a/docs/content/providers/web-uis.mdx
+++ b/docs/content/providers/web-uis.mdx
@@ -52,7 +52,7 @@ providers:
 ```
 
 When `authorizationPolicy` is set, Gestalt authenticates the caller, resolves
-their role from `server.authorization.policies.<policy>`, and checks the web
+their role from `authorization.policies.<policy>`, and checks the web
 UI manifest's `spec.routes[].allowedRoles` before serving the route or its
 associated static assets.
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -2,19 +2,22 @@ import { Tabs } from 'nextra/components'
 
 # Config File
 
-Every `gestaltd` deployment reads a single YAML config file. The two top-level keys are `server` (listener, encryption, egress, and indexeddb selection) and `providers` (auth, secrets, telemetry, audit, mounted UI bundles, indexeddbs, and plugins):
+Every `gestaltd` deployment reads a single YAML config file. The top-level keys are `server` (listener, encryption, egress, and indexeddb selection), `authorization` (shared human/workload access policy), `providers` (auth, secrets, telemetry, audit, mounted UI bundles, and indexeddbs), and `plugins` (executable integrations):
 
 ```yaml
 server:
   # listener, encryption, egress, indexeddb selector
+authorization:
+  policies: {}
+  workloads: {}
 providers:
   auth: {}
   secrets: {}
   telemetry: {}
   audit: {}
   ui: {}
-  indexeddbs: {}
-  plugins: {}
+  indexeddb: {}
+plugins: {}
 ```
 
 ## Load Semantics
@@ -22,6 +25,8 @@ providers:
 `${ENV_VAR}` references are expanded before YAML decoding. When a referenced variable is unset, Gestalt checks for a corresponding `ENV_VAR_FILE` variable and reads that file path instead. If neither is set, config loading fails. Use `${ENV_VAR:-}` when an explicit empty default is intentional. Unknown YAML fields are rejected.
 
 Several fields carry defaults when omitted: `server.public.port` defaults to `8080`, `providers.secrets.source` to `env`, and `providers.telemetry.source` to `stdout`. Relative paths resolve relative to the config file's directory. `secret://...` values are resolved during bootstrap, not during YAML parsing.
+
+`authorization` is the canonical location for shared human and workload access policy. Existing deployments may continue to use `server.authorization` as a deprecated compatibility alias; Gestalt normalizes it into the top-level block during config load and bootstrap.
 
 ## `server`
 
@@ -37,29 +42,29 @@ server:
   encryptionKey: secret://gestalt-encryption-key
   apiTokenTtl: 30d
   artifactsDir: ./state
-  authorization:
-    policies:
-      support_staff:
-        default: deny
-        members:
-          - email: viewer@example.test
-            role: viewer
-          - subjectID: user:admin-user
-            role: admin
-    workloads:
-      triage-bot:
-        displayName: Triage Bot
-        token: secret://triage-bot-token
-        providers:
-          github:
-            connection: default
-            instance: default
-            allow:
-              - list_issues
-              - get_issue
-          weather:
-            allow:
-              - get_forecast
+authorization:
+  policies:
+    support_staff:
+      default: deny
+      members:
+        - email: viewer@example.test
+          role: viewer
+        - subjectID: user:admin-user
+          role: admin
+  workloads:
+    triage-bot:
+      displayName: Triage Bot
+      token: secret://triage-bot-token
+      providers:
+        github:
+          connection: default
+          instance: default
+          allow:
+            - list_issues
+            - get_issue
+        weather:
+          allow:
+            - get_forecast
 ```
 
 `public.host` and `public.port` control the public listener address. Both default to all-interfaces on port `8080`.
@@ -72,9 +77,9 @@ server:
 
 `apiTokenTtl` controls the lifetime of newly issued API tokens, defaulting to `30d`. It accepts Go duration strings (`1h`, `720h`) and day suffixes (`30d`). `artifactsDir` is a writable directory for prepared artifacts produced by `init` and consumed by `serve --locked` when no CLI override is supplied; it defaults to the config file's directory. See [Configuration](/configuration) for the full `init`/`serve` lifecycle.
 
-`server.authorization.policies` configures shared human access policies. Each policy resolves a caller to exactly one role by matching either `subjectID` or `email`, then applies a `default` fallback (`allow` or `deny`) when no member matches. Plugins opt into a policy explicitly through `authorizationPolicy`.
+`authorization.policies` configures shared human access policies. Each policy resolves a caller to exactly one role by matching either `subjectID` or `email`, then applies a `default` fallback (`allow` or `deny`) when no member matches. Plugins opt into a policy explicitly through `authorizationPolicy`.
 
-`server.authorization.workloads` configures non-human workload callers. Each workload uses a dedicated bearer token with the `gst_wld_` prefix and a per-provider allowlist. In v1, workloads may bind only to `identity` or `none` providers. For `identity` providers, `connection` and `instance` resolve the exact stored identity credential the workload may use; `instance` defaults to `default` and `connection` falls back to the provider's default connection when omitted. For `none` providers, omit `connection` and `instance`.
+`authorization.workloads` configures non-human workload callers. Each workload uses a dedicated bearer token with the `gst_wld_` prefix and a per-provider allowlist. In v1, workloads may bind only to `identity` or `none` providers. For `identity` providers, `connection` and `instance` resolve the exact stored identity credential the workload may use; `instance` defaults to `default` and `connection` falls back to the provider's default connection when omitted. For `none` providers, omit `connection` and `instance`.
 
 | Field | Default | Description |
 | --- | --- | --- |
@@ -169,16 +174,17 @@ Both `google` and `oidc` use the same PluginDef provider reference shape under `
 | `env` | Extra environment variables passed to the provider process. |
 | `allowedHosts` | Network allowlist for sandboxed provider processes. |
 
-## `providers.indexeddbs`
+## `providers.indexeddb`
 
-Indexed databases are provider-based. Configure one or more named entries under `providers.indexeddbs`, then set `server.indexeddb` to the name the host should use for system storage. First-party indexeddb providers are published at `github.com/valon-technologies/gestalt-providers/indexeddb/<name>`.
+Indexed databases are provider-based. Configure one or more named entries under `providers.indexeddb`, then set `server.providers.indexeddb` to the name the host should use for system storage. First-party indexeddb providers are published at `github.com/valon-technologies/gestalt-providers/indexeddb/<name>`.
 
 ```yaml
 server:
-  indexeddb: main
+  providers:
+    indexeddb: main
 
 providers:
-  indexeddbs:
+  indexeddb:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
@@ -187,7 +193,7 @@ providers:
         dsn: ${DATABASE_URL}
 ```
 
-The exact config fields depend on the selected external indexeddb provider package. Gestalt itself does not have a built-in indexeddb driver matrix; it loads the configured provider process and passes the selected `providers.indexeddbs.<name>.config` block through to that provider.
+The exact config fields depend on the selected external indexeddb provider package. Gestalt itself does not have a built-in indexeddb driver matrix; it loads the configured provider process and passes the selected `providers.indexeddb.<name>.config` block through to that provider.
 
 Common first-party IndexedDB packages:
 
@@ -428,34 +434,33 @@ providers:
 
 Disables audit output explicitly. `providers.audit.config` is not allowed when `providers.audit.source` is `noop`.
 
-## `providers.plugins`
+## `plugins`
 
-Each entry in the `providers.plugins` map is a named plugin backed by an executable provider package. The provider package is the source of truth for operations and transport details. Server config selects the provider, passes provider-specific config, and declares connection policy. The HTTP API route paths still use "integrations" (e.g. `/api/v1/integrations`) as stable code surface, but the CLI and config both use `plugins` as the canonical term.
+Each entry in the `plugins` map is a named plugin backed by an executable provider package. The provider package is the source of truth for operations and transport details. Server config selects the provider, passes provider-specific config, and declares connection policy. The HTTP API route paths still use "integrations" (e.g. `/api/v1/integrations`) as stable code surface, but the CLI and config both use `plugins` as the canonical term.
 
 ```yaml
-providers:
-  plugins:
-    github:
-      displayName: GitHub
-      description: Public GitHub operations
-      iconFile: ./icons/github.svg
-      authorizationPolicy: support_staff
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/github
-        version: 1.2.3
-      surfaces:
-        openapi:
-          baseUrl: https://api.github.com
-      connections:
-        default:
-          mode: user
-          auth:
-            type: oauth2
-      allowedOperations:
-        repos.get:
-          alias: get_repo
-          allowedRoles:
-            - admin
+plugins:
+  github:
+    displayName: GitHub
+    description: Public GitHub operations
+    iconFile: ./icons/github.svg
+    authorizationPolicy: support_staff
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/github
+      version: 1.2.3
+    surfaces:
+      openapi:
+        baseUrl: https://api.github.com
+    connections:
+      default:
+        mode: user
+        auth:
+          type: oauth2
+    allowedOperations:
+      repos.get:
+        alias: get_repo
+        allowedRoles:
+          - admin
 ```
 
 ### Plugin Fields
@@ -465,15 +470,15 @@ providers:
 | `displayName` | Human-readable name shown in the UI and API. |
 | `description` | Short description of the plugin. |
 | `iconFile` | SVG icon path, resolved relative to the config directory. |
-| `authorizationPolicy` | Optional shared human access policy from `server.authorization.policies`. When set, host-side operation filtering and execution checks use the resolved role for this plugin. |
-| `source` | **Required.** The backing provider source. See [source shape](#providerspluginssource) below. |
+| `authorizationPolicy` | Optional shared human access policy from `authorization.policies`. When set, host-side operation filtering and execution checks use the resolved role for this plugin. |
+| `source` | **Required.** The backing provider source. See [source shape](#pluginssource) below. |
 | `config` | Provider-specific configuration passed into the provider package. |
 | `surfaces` | Typed host-side overrides for manifest-declared surfaces, such as `surfaces.openapi.baseUrl` or `surfaces.graphql.url`. |
 | `connections` | Named connection declarations. See [connections](#connections) below. |
 | `allowedOperations` | Allowlist with optional `alias`, `description`, and `allowedRoles` overrides per operation. |
-| `indexeddbs` | Optional list of named `providers.indexeddbs` bindings exposed to the executable plugin through the SDK transport. Store names are automatically prefixed per plugin. A single binding also populates the default IndexedDB SDK env var for compatibility. |
+| `indexeddbs` | Optional list of named `providers.indexeddb` bindings exposed to the executable plugin through the SDK transport. Store names are automatically prefixed per plugin. A single binding also populates the default IndexedDB SDK env var for compatibility. |
 
-### `providers.plugins.*.source`
+### `plugins.*.source`
 
 Every plugin uses a `source` block to declare its backing provider.
 
@@ -707,17 +712,16 @@ server:
   egress:
     defaultAction: deny
 
-providers:
-  plugins:
-    github:
-      allowedHosts:
-        - api.github.com
-        - "*.github.com"
-    my-plugin:
-      source:
-        path: ./plugins/my-plugin
-      allowedHosts:
-        - external-api.com
+plugins:
+  github:
+    allowedHosts:
+      - api.github.com
+      - "*.github.com"
+  my-plugin:
+    source:
+      path: ./plugins/my-plugin
+    allowedHosts:
+      - external-api.com
 ```
 
 | Field | Description |
@@ -759,7 +763,7 @@ Structural validation runs at config load time (`init`, `validate`, `serve`). Ru
 
 Each plugin uses a `source` block. Every plugin must use exactly one loading mode: local `source.path` or managed `source.ref`. `source.version` is required with `source.ref` and invalid with `source.path`.
 
-Auth providers and indexeddb entries use the same external provider shape. When `providers.auth` or `providers.indexeddbs.<name>` is set, `source.ref` or `source.path` must be present. `providers.auth.config` and `providers.indexeddbs.<name>.config` are only allowed when their corresponding source is set.
+Auth providers and indexeddb entries use the same external provider shape. When `providers.auth` or `providers.indexeddb.<name>` is set, `source.ref` or `source.path` must be present. `providers.auth.config` and `providers.indexeddb.<name>.config` are only allowed when their corresponding source is set.
 
 Only `connections.default` may define `params` or `discovery`. All connections in a plugin must share the same mode.
 
@@ -769,10 +773,10 @@ Mounted UI bundles are served on the public listener only. The built-in admin UI
 
 `server.egress.defaultAction` must be `allow` or `deny`.
 
-`server.authorization.policies.<name>.default` must be `allow` or `deny` when set. Each policy member must set exactly one of `subjectID` or `email`, and every member must set a non-empty `role`.
+`authorization.policies.<name>.default` must be `allow` or `deny` when set. Each policy member must set exactly one of `subjectID` or `email`, and every member must set a non-empty `role`.
 
 Server listener ports must be greater than zero. When `server.management` is configured, it must differ from `server.public`.
 
 ### Runtime
 
-`server.indexeddb`, `providers.indexeddbs`, and `server.encryptionKey` are required at `serve` time. `providers.auth` is optional.
+`server.providers.indexeddb`, `providers.indexeddb`, and `server.encryptionKey` are required at `serve` time. `providers.auth` is optional.

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -264,6 +264,9 @@ func ResolveConfigSecrets(ctx context.Context, cfg *config.Config, factories *Fa
 }
 
 func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, requireEncryptionKey bool) (*preparedCore, error) {
+	if err := config.NormalizeCompatibility(cfg); err != nil {
+		return nil, err
+	}
 	sm, err := prepareSecretManager(ctx, cfg, factories)
 	if err != nil {
 		return nil, err
@@ -414,7 +417,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	if err != nil {
 		return nil, err
 	}
-	authz, err := authorization.New(cfg.Server.Authorization, cfg.Plugins, providers, connMaps.DefaultConnection)
+	authz, err := authorization.New(cfg.Authorization, cfg.Plugins, providers, connMaps.DefaultConnection)
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -141,6 +141,36 @@ func TestBootstrap(t *testing.T) {
 		t.Fatal("expected shared invoker and capability lister to be the same instance")
 	}
 
+	t.Run("normalizes equivalent top level and legacy authorization shapes", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := validConfig()
+		cfg.Authorization = config.AuthorizationConfig{
+			Policies: map[string]config.HumanPolicyDef{
+				"roadmap": {
+					Default: "deny",
+				},
+			},
+		}
+		cfg.Server.Authorization = config.AuthorizationConfig{
+			Policies: map[string]config.HumanPolicyDef{
+				"roadmap": {
+					Default: "deny",
+					Members: []config.HumanPolicyMemberDef{},
+				},
+			},
+		}
+
+		result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+		if err != nil {
+			t.Fatalf("Bootstrap: %v", err)
+		}
+		<-result.ProvidersReady
+		if result.Authorizer == nil {
+			t.Fatal("Authorizer is nil")
+		}
+	})
+
 	t.Run("invoker uses resolved REST connections", func(t *testing.T) {
 		t.Parallel()
 
@@ -665,39 +695,64 @@ func TestBootstrapSecretResolution(t *testing.T) {
 	t.Run("resolves secret:// in workload tokens", func(t *testing.T) {
 		t.Parallel()
 
-		factories := validFactories()
-		factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
-			return &coretesting.StubSecretManager{
-				Secrets: map[string]string{"workload-token": "gst_wld_resolved-workload-token"},
-			}, nil
-		}
-		factories.Builtins = []core.Provider{
-			&coretesting.StubIntegration{N: "weather", ConnMode: core.ConnectionModeNone},
-		}
-
-		cfg := validConfig()
-		cfg.Server.Authorization = config.AuthorizationConfig{
-			Workloads: map[string]config.WorkloadDef{
-				"triage-bot": {
-					Token: "secret://workload-token",
-					Providers: map[string]config.WorkloadProviderDef{
-						"weather": {Allow: []string{"forecast"}},
-					},
+		tests := []struct {
+			name  string
+			apply func(*config.Config, config.AuthorizationConfig)
+		}{
+			{
+				name: "top level authorization",
+				apply: func(cfg *config.Config, authz config.AuthorizationConfig) {
+					cfg.Authorization = authz
+				},
+			},
+			{
+				name: "legacy server authorization",
+				apply: func(cfg *config.Config, authz config.AuthorizationConfig) {
+					cfg.Server.Authorization = authz
 				},
 			},
 		}
 
-		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
-		if err != nil {
-			t.Fatalf("Bootstrap: %v", err)
-		}
-		<-result.ProvidersReady
+		for _, tc := range tests {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 
-		if result.Authorizer == nil {
-			t.Fatal("Authorizer is nil")
-		}
-		if _, ok := result.Authorizer.ResolveWorkloadToken("gst_wld_resolved-workload-token"); !ok {
-			t.Fatal("expected resolved workload token to authenticate")
+				factories := validFactories()
+				factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+					return &coretesting.StubSecretManager{
+						Secrets: map[string]string{"workload-token": "gst_wld_resolved-workload-token"},
+					}, nil
+				}
+				factories.Builtins = []core.Provider{
+					&coretesting.StubIntegration{N: "weather", ConnMode: core.ConnectionModeNone},
+				}
+
+				cfg := validConfig()
+				tc.apply(cfg, config.AuthorizationConfig{
+					Workloads: map[string]config.WorkloadDef{
+						"triage-bot": {
+							Token: "secret://workload-token",
+							Providers: map[string]config.WorkloadProviderDef{
+								"weather": {Allow: []string{"forecast"}},
+							},
+						},
+					},
+				})
+
+				result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+				if err != nil {
+					t.Fatalf("Bootstrap: %v", err)
+				}
+				<-result.ProvidersReady
+
+				if result.Authorizer == nil {
+					t.Fatal("Authorizer is nil")
+				}
+				if _, ok := result.Authorizer.ResolveWorkloadToken("gst_wld_resolved-workload-token"); !ok {
+					t.Fatal("expected resolved workload token to authenticate")
+				}
+			})
 		}
 	})
 
@@ -831,29 +886,54 @@ func TestBootstrapSecretResolution(t *testing.T) {
 func TestBootstrapWorkloadAuthorizationRejectsEitherProvider(t *testing.T) {
 	t.Parallel()
 
-	cfg := validConfig()
-	cfg.Server.Authorization = config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
-			"triage-bot": {
-				Token: "gst_wld_triage-bot-token",
-				Providers: map[string]config.WorkloadProviderDef{
-					"svc": {Allow: []string{"run"}},
-				},
+	tests := []struct {
+		name  string
+		apply func(*config.Config, config.AuthorizationConfig)
+	}{
+		{
+			name: "top level authorization",
+			apply: func(cfg *config.Config, authz config.AuthorizationConfig) {
+				cfg.Authorization = authz
+			},
+		},
+		{
+			name: "legacy server authorization",
+			apply: func(cfg *config.Config, authz config.AuthorizationConfig) {
+				cfg.Server.Authorization = authz
 			},
 		},
 	}
 
-	factories := validFactories()
-	factories.Builtins = []core.Provider{
-		&coretesting.StubIntegration{N: "svc", ConnMode: core.ConnectionModeEither},
-	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	_, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), `unsupported connection mode "either"`) {
-		t.Fatalf("unexpected error: %v", err)
+			cfg := validConfig()
+			tc.apply(cfg, config.AuthorizationConfig{
+				Workloads: map[string]config.WorkloadDef{
+					"triage-bot": {
+						Token: "gst_wld_triage-bot-token",
+						Providers: map[string]config.WorkloadProviderDef{
+							"svc": {Allow: []string{"run"}},
+						},
+					},
+				},
+			})
+
+			factories := validFactories()
+			factories.Builtins = []core.Provider{
+				&coretesting.StubIntegration{N: "svc", ConnMode: core.ConnectionModeEither},
+			}
+
+			_, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), `unsupported connection mode "either"`) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
 	}
 }
 

--- a/gestaltd/internal/bootstrap/secret_resolution.go
+++ b/gestaltd/internal/bootstrap/secret_resolution.go
@@ -42,6 +42,9 @@ func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretMa
 	if err := resolveStringFields(&cfg.Server, resolve); err != nil {
 		return err
 	}
+	if err := resolveStringFields(&cfg.Authorization, resolve); err != nil {
+		return err
+	}
 	for name, entry := range cfg.Plugins {
 		if entry == nil {
 			continue
@@ -104,6 +107,9 @@ func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretMa
 			return err
 		}
 		cfg.Providers.IndexedDB[name] = ds
+	}
+	if err := config.NormalizeCompatibility(cfg); err != nil {
+		return err
 	}
 
 	return nil

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -40,9 +41,10 @@ const PluginConnectionName = "_plugin"
 const PluginConnectionAlias = "plugin"
 
 type Config struct {
-	Server    ServerConfig              `yaml:"server"`
-	Providers ProvidersConfig           `yaml:"providers"`
-	Plugins   map[string]*ProviderEntry `yaml:"plugins,omitempty"`
+	Server        ServerConfig              `yaml:"server"`
+	Authorization AuthorizationConfig       `yaml:"authorization,omitempty"`
+	Providers     ProvidersConfig           `yaml:"providers"`
+	Plugins       map[string]*ProviderEntry `yaml:"plugins,omitempty"`
 }
 
 type ProvidersConfig struct {
@@ -605,6 +607,10 @@ func LoadAllowMissingEnv(path string) (*Config, error) {
 	return loadWithLookup(path, os.LookupEnv, true)
 }
 
+func NormalizeCompatibility(cfg *Config) error {
+	return normalizeAuthorizationConfig(cfg)
+}
+
 func OverlayManagedPluginConfig(path string, cfg *Config) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -974,6 +980,9 @@ func loadWithLookup(path string, lookup func(string) (string, bool), allowMissin
 	}
 
 	applyDefaults(&cfg)
+	if err := NormalizeCompatibility(&cfg); err != nil {
+		return nil, err
+	}
 	resolveBaseURL(&cfg)
 	resolveRelativePaths(path, &cfg)
 
@@ -1109,6 +1118,79 @@ func applyDefaultBuiltinProviderEntries(entries map[string]*ProviderEntry, defau
 		entry.Source.Builtin = builtin
 	}
 	return entries
+}
+
+func normalizeAuthorizationConfig(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	cfg.Authorization = normalizedAuthorizationConfig(cfg.Authorization)
+	cfg.Server.Authorization = normalizedAuthorizationConfig(cfg.Server.Authorization)
+	topLevelSet := hasAuthorizationConfig(cfg.Authorization)
+	legacySet := hasAuthorizationConfig(cfg.Server.Authorization)
+	switch {
+	case topLevelSet && legacySet:
+		if !reflect.DeepEqual(cfg.Authorization, cfg.Server.Authorization) {
+			return fmt.Errorf("config validation: authorization and server.authorization may not both be set with different values")
+		}
+	case topLevelSet:
+		cfg.Server.Authorization = cfg.Authorization
+	case legacySet:
+		cfg.Authorization = cfg.Server.Authorization
+	default:
+		cfg.Authorization = AuthorizationConfig{}
+		cfg.Server.Authorization = AuthorizationConfig{}
+	}
+	return nil
+}
+
+func hasAuthorizationConfig(cfg AuthorizationConfig) bool {
+	return len(cfg.Policies) > 0 || len(cfg.Workloads) > 0
+}
+
+func normalizedAuthorizationConfig(cfg AuthorizationConfig) AuthorizationConfig {
+	if len(cfg.Policies) == 0 {
+		cfg.Policies = nil
+	} else {
+		policies := make(map[string]HumanPolicyDef, len(cfg.Policies))
+		for name, policy := range cfg.Policies {
+			policies[name] = normalizedHumanPolicyDef(policy)
+		}
+		cfg.Policies = policies
+	}
+	if len(cfg.Workloads) == 0 {
+		cfg.Workloads = nil
+	} else {
+		workloads := make(map[string]WorkloadDef, len(cfg.Workloads))
+		for name, workload := range cfg.Workloads {
+			workloads[name] = normalizedWorkloadDef(workload)
+		}
+		cfg.Workloads = workloads
+	}
+	return cfg
+}
+
+func normalizedHumanPolicyDef(policy HumanPolicyDef) HumanPolicyDef {
+	if len(policy.Members) == 0 {
+		policy.Members = nil
+	}
+	return policy
+}
+
+func normalizedWorkloadDef(workload WorkloadDef) WorkloadDef {
+	if len(workload.Providers) == 0 {
+		workload.Providers = nil
+		return workload
+	}
+	providers := make(map[string]WorkloadProviderDef, len(workload.Providers))
+	for name, provider := range workload.Providers {
+		if len(provider.Allow) == 0 {
+			provider.Allow = nil
+		}
+		providers[name] = provider
+	}
+	workload.Providers = providers
+	return workload
 }
 
 func resolveBaseURL(cfg *Config) {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -17,6 +17,9 @@ import (
 // Called by Load (and therefore by init, validate, and serve). Does not require
 // runtime secrets like encryption_key.
 func ValidateStructure(cfg *Config) error {
+	if err := NormalizeCompatibility(cfg); err != nil {
+		return err
+	}
 	if err := normalizeMountedUIPaths(cfg); err != nil {
 		return err
 	}
@@ -325,14 +328,14 @@ func validatePluginOnlyProviderFields(subject string, entry *ProviderEntry) erro
 }
 
 func validateAuthorizationPolicies(cfg *Config) error {
-	for name, policy := range cfg.Server.Authorization.Policies {
+	for name, policy := range cfg.Authorization.Policies {
 		if strings.TrimSpace(name) == "" {
-			return fmt.Errorf("config validation: server.authorization.policies keys must be non-empty")
+			return fmt.Errorf("config validation: authorization.policies keys must be non-empty")
 		}
 		switch strings.TrimSpace(policy.Default) {
 		case "", "allow", "deny":
 		default:
-			return fmt.Errorf("config validation: server.authorization.policies.%s.default must be %q or %q", name, "allow", "deny")
+			return fmt.Errorf("config validation: authorization.policies.%s.default must be %q or %q", name, "allow", "deny")
 		}
 		seenSubjectIDs := make(map[string]int, len(policy.Members))
 		seenEmails := make(map[string]int, len(policy.Members))
@@ -342,21 +345,21 @@ func validateAuthorizationPolicies(cfg *Config) error {
 			role := strings.TrimSpace(member.Role)
 			switch {
 			case role == "":
-				return fmt.Errorf("config validation: server.authorization.policies.%s.members[%d].role is required", name, i)
+				return fmt.Errorf("config validation: authorization.policies.%s.members[%d].role is required", name, i)
 			case subjectID == "" && email == "":
-				return fmt.Errorf("config validation: server.authorization.policies.%s.members[%d] must set subjectID or email", name, i)
+				return fmt.Errorf("config validation: authorization.policies.%s.members[%d] must set subjectID or email", name, i)
 			case subjectID != "" && email != "":
-				return fmt.Errorf("config validation: server.authorization.policies.%s.members[%d] may not set both subjectID and email", name, i)
+				return fmt.Errorf("config validation: authorization.policies.%s.members[%d] may not set both subjectID and email", name, i)
 			}
 			if subjectID != "" {
 				if prev, exists := seenSubjectIDs[subjectID]; exists {
-					return fmt.Errorf("config validation: server.authorization.policies.%s.members[%d].subjectID duplicates members[%d]", name, i, prev)
+					return fmt.Errorf("config validation: authorization.policies.%s.members[%d].subjectID duplicates members[%d]", name, i, prev)
 				}
 				seenSubjectIDs[subjectID] = i
 			}
 			if email != "" {
 				if prev, exists := seenEmails[email]; exists {
-					return fmt.Errorf("config validation: server.authorization.policies.%s.members[%d].email duplicates members[%d]", name, i, prev)
+					return fmt.Errorf("config validation: authorization.policies.%s.members[%d].email duplicates members[%d]", name, i, prev)
 				}
 				seenEmails[email] = i
 			}
@@ -370,7 +373,7 @@ func validateAuthorizationPolicyReference(cfg *Config, kind, name, policy string
 	if policy == "" {
 		return nil
 	}
-	if _, ok := cfg.Server.Authorization.Policies[policy]; !ok {
+	if _, ok := cfg.Authorization.Policies[policy]; !ok {
 		return fmt.Errorf("config validation: %s %q authorizationPolicy references unknown policy %q", kind, name, policy)
 	}
 	return nil

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -398,25 +398,54 @@ func TestInitAtPath_RejectsPolicyBoundManagedMountedWebUIWithoutExplicitRouteCov
 			want: "must declare a route covering /",
 		},
 	}
+	authBlocks := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "top level authorization",
+			yaml: `authorization:
+  policies:
+    sample_policy:
+      default: deny
+      members:
+        - email: viewer@example.test
+          role: viewer
+`,
+		},
+		{
+			name: "legacy server authorization",
+			yaml: `  authorization:
+    policies:
+      sample_policy:
+        default: deny
+        members:
+          - email: viewer@example.test
+            role: viewer
+`,
+		},
+	}
 
 	for _, tc := range tests {
 		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+		for _, authBlock := range authBlocks {
+			authBlock := authBlock
+			t.Run(tc.name+"/"+authBlock.name, func(t *testing.T) {
+				t.Parallel()
 
-			dir := t.TempDir()
-			pkgPath := mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
-				Kind:        providermanifestv1.KindWebUI,
-				Source:      "github.com/testowner/web/sample-portal",
-				Version:     "0.0.1-alpha.1",
-				DisplayName: "Sample Portal",
-				Spec:        tc.spec,
-			}, map[string]string{
-				"dist/index.html": "<html>sample portal</html>",
-			}, false)
+				dir := t.TempDir()
+				pkgPath := mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
+					Kind:        providermanifestv1.KindWebUI,
+					Source:      "github.com/testowner/web/sample-portal",
+					Version:     "0.0.1-alpha.1",
+					DisplayName: "Sample Portal",
+					Spec:        tc.spec,
+				}, map[string]string{
+					"dist/index.html": "<html>sample portal</html>",
+				}, false)
 
-			cfgPath := filepath.Join(dir, "config.yaml")
-			cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
+				cfgPath := filepath.Join(dir, "config.yaml")
+				cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
     sample_portal:
       source:
         ref: github.com/testowner/web/sample-portal
@@ -425,24 +454,18 @@ func TestInitAtPath_RejectsPolicyBoundManagedMountedWebUIWithoutExplicitRouteCov
       authorizationPolicy: sample_policy
 ` + `server:
 ` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-  authorization:
-    policies:
-      sample_policy:
-        default: deny
-        members:
-          - email: viewer@example.test
-            role: viewer
-`
-			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
-				t.Fatalf("WriteFile config: %v", err)
-			}
+` + authBlock.yaml
+				if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+					t.Fatalf("WriteFile config: %v", err)
+				}
 
-			lc := NewLifecycle(staticSourceResolver{localPath: pkgPath})
-			_, err := lc.InitAtPath(cfgPath)
-			if err == nil || !strings.Contains(err.Error(), tc.want) {
-				t.Fatalf("InitAtPath error = %v, want substring %q", err, tc.want)
-			}
-		})
+				lc := NewLifecycle(staticSourceResolver{localPath: pkgPath})
+				_, err := lc.InitAtPath(cfgPath)
+				if err == nil || !strings.Contains(err.Error(), tc.want) {
+					t.Fatalf("InitAtPath error = %v, want substring %q", err, tc.want)
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- add canonical top-level `authorization` config alongside the existing deprecated `server.authorization` alias
- normalize the two shapes during config load, validation, bootstrap, and secret resolution so both file-loaded and programmatic configs behave identically
- update config and mounted-UI docs to point at top-level `authorization`
- extend existing bootstrap and lifecycle tests to cover both the canonical and legacy authorization shapes through the runtime path

## Testing
- `go test ./internal/config ./internal/bootstrap ./internal/operator -count=1`
- `go test ./internal/server ./internal/mcp -count=1`
- `go test ./... -count=1`

## Notes
- This is PR 1 of the mounted-app/app-ownership stack.
- It is intentionally limited to config/runtime compatibility for authorization placement; no app binding behavior changes are included here.