### PR TITLE
Add top-level app bindings for plugins and UIs

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -4,7 +4,7 @@ Gestalt is configured from a single YAML file. This page covers the key concepts
 
 ## Config file structure
 
-A Gestalt config has four top-level keys: `server` for host settings, `authorization` for shared human/workload access policy, `providers` for pluggable host components, and `plugins` for executable integrations.
+A Gestalt config has five top-level keys: `server` for host settings, `authorization` for shared human/workload access policy, `apps` for deployment-owned plugin/UI bindings, `providers` for host-scoped providers and web UIs, and `plugins` for executable integrations.
 
 ```yaml
 server:
@@ -20,6 +20,13 @@ server:
     port: ...
   egress:                   # outbound request policy
     defaultAction: ...      # "allow" or "deny"
+
+authorization:
+  policies: ...             # shared human access policies
+  workloads: ...            # workload bearer-token policy
+
+apps:
+  <name>: ...               # plugin/UI binding with path + auth policy
 
 providers:
   auth: ...                 # platform login (ProviderEntry)

--- a/docs/content/providers/web-uis.mdx
+++ b/docs/content/providers/web-uis.mdx
@@ -1,9 +1,9 @@
 # Web UIs
 
 Web UI providers are static asset bundles. Gestalt serves each configured
-bundle under the path prefix declared in `providers.ui.<name>.path`. The
-built-in admin UI at `/admin` remains available regardless of whether public UI
-bundles are configured.
+bundle either directly from `providers.ui.<name>.path` or via a top-level
+`apps.<name>.path` binding. The built-in admin UI at `/admin` remains available
+regardless of whether public UI bundles are configured.
 
 ## How web UI providers work
 
@@ -23,8 +23,10 @@ First-party UI bundles live under
 
 ## Configuring `providers.ui`
 
-Use `providers.ui` as a map of mounted bundles. Omit it entirely to run
-headless with no public UI bundles.
+Use `providers.ui` as a map of UI bundles. You can either mount a bundle
+directly from `providers.ui`, or bind it to a plugin-backed app through the
+top-level `apps` block. Omit `providers.ui` entirely to run headless with no
+public UI bundles.
 
 Point at a local source bundle during development:
 
@@ -36,6 +38,23 @@ providers:
         path: ./customer-roadmap-review/ui/manifest.yaml
       path: /create-customer-roadmap-review
       authorizationPolicy: roadmap_review
+```
+
+Bind a UI bundle to a plugin-backed app:
+
+```yaml
+providers:
+  ui:
+    roadmap:
+      source:
+        path: ./customer-roadmap-review/ui/manifest.yaml
+
+apps:
+  roadmap_review:
+    plugin: roadmap_review
+    ui: roadmap
+    path: /create-customer-roadmap-review
+    authorizationPolicy: roadmap_review
 ```
 
 Reference a published bundle in production:
@@ -58,7 +77,7 @@ associated static assets.
 
 ## Locked deployments
 
-When `providers.ui` references a published bundle, run:
+When a published UI bundle is referenced from `providers.ui`, run:
 
 ```sh
 gestaltd init --config ./config.yaml
@@ -82,6 +101,6 @@ Asset-root layout, build hooks, and release packaging now live under
 
 ## What to read next
 
-- [Configuration](/configuration): `providers.ui` and headless deployments
+- [Configuration](/configuration): `providers.ui`, `apps`, and headless deployments
 - [Client Web UI](/client/web): what the default client exposes
 - [Custom Web UIs](/custom-providers/web-uis): advanced authoring docs

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -2,7 +2,7 @@ import { Tabs } from 'nextra/components'
 
 # Config File
 
-Every `gestaltd` deployment reads a single YAML config file. The top-level keys are `server` (listener, encryption, egress, and indexeddb selection), `authorization` (shared human/workload access policy), `providers` (auth, secrets, telemetry, audit, mounted UI bundles, and indexeddb), and `plugins` (executable integrations):
+Every `gestaltd` deployment reads a single YAML config file. The top-level keys are `server` (listener, encryption, egress, and indexeddb selection), `authorization` (shared human/workload access policy), `apps` (deployment-owned bindings between plugins and web UIs), `providers` (auth, secrets, telemetry, audit, mounted UI bundles, and indexeddb), and `plugins` (executable integrations):
 
 ```yaml
 server:
@@ -10,6 +10,7 @@ server:
 authorization:
   policies: {}
   workloads: {}
+apps: {}
 providers:
   auth: {}
   secrets: {}
@@ -751,16 +752,38 @@ providers:
         brandName: Acme
 ```
 
-`providers.ui` is a map of mounted `webui` bundles. Each entry is served under an explicit non-root path prefix on the public listener. The built-in admin UI remains available at `/admin`. Omit `providers.ui` entirely to run headless with no public UI bundles.
+`providers.ui` is a map of `webui` bundles. Entries may mount directly by setting `path`, or they may act as app-owned UI artifacts that are bound through the top-level `apps` block. The built-in admin UI remains available at `/admin`. Omit `providers.ui` entirely to run headless with no public UI bundles.
 
 When `authorizationPolicy` is set on a mounted UI, the referenced web UI manifest must declare `spec.routes` with non-empty `allowedRoles`, and at least one route must cover `/`.
 
 | Field | Description |
 | --- | --- |
-| `path` | Required mount prefix. Must start with `/`, may not be `/`, and may not conflict with `/api`, auth routes, `/mcp`, `/admin`, `/metrics`, `/health`, `/ready`, or another mounted UI prefix. |
+| `path` | Direct mount prefix for this UI when not bound through `apps`. |
+| `authorizationPolicy` | Direct policy binding for this UI when not bound through `apps`. |
 | `disabled` | `true` to disable an individual mounted UI entry. |
 | `source` | A source mapping with `source.path` or `source.ref`. |
 | `config` | Optional UI-provider config validated against the bundle schema when present. |
+
+## `apps`
+
+```yaml
+apps:
+  roadmap_review:
+    plugin: roadmap_review
+    ui: roadmap_review_ui
+    path: /create-customer-roadmap-review
+    authorizationPolicy: support_staff
+```
+
+`apps` is a deployment-owned binding layer for plugin-backed mounted apps. Each entry references an existing `plugins.<name>` entry and an existing `providers.ui.<name>` bundle, then supplies the public path and optional shared human authorization policy for both surfaces.
+
+| Field | Description |
+| --- | --- |
+| `plugin` | Required plugin key from `plugins`. |
+| `ui` | Required UI key from `providers.ui`. |
+| `path` | Required public mount path for the app-owned UI bundle. |
+| `authorizationPolicy` | Optional shared policy from `authorization.policies` applied to both the mounted UI and referenced plugin. |
+| `disabled` | `true` to disable the app binding without removing the underlying plugin or UI entries. |
 
 ## Validation rules
 
@@ -775,6 +798,8 @@ Auth providers and indexeddb entries use the same external provider shape. When 
 Only `connections.default` may define `params` or `discovery`. All connections in a plugin must share the same mode.
 
 Each `providers.ui.<name>` entry must use exactly one mode: `disabled: true`, or a source mapping with exactly one loading mode: local `providers.ui.<name>.source.path` or managed `providers.ui.<name>.source.ref`. `providers.ui.<name>.source.version` is required with `providers.ui.<name>.source.ref` and invalid with `providers.ui.<name>.source.path`. `providers.ui.<name>.config` is only allowed when `providers.ui.<name>.source` is set.
+
+Each enabled `apps.<name>` entry must reference an existing enabled plugin and an existing enabled UI bundle. A given plugin or UI may be bound by at most one enabled app entry. `apps.<name>.path` must use the same path rules as a directly mounted UI, and `apps.<name>.authorizationPolicy` must reference `authorization.policies` when set.
 
 Mounted UI bundles are served on the public listener only. The built-in admin UI remains at `/admin`.
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -43,8 +43,17 @@ const PluginConnectionAlias = "plugin"
 type Config struct {
 	Server        ServerConfig              `yaml:"server"`
 	Authorization AuthorizationConfig       `yaml:"authorization,omitempty"`
+	Apps          map[string]*AppEntry      `yaml:"apps,omitempty"`
 	Providers     ProvidersConfig           `yaml:"providers"`
 	Plugins       map[string]*ProviderEntry `yaml:"plugins,omitempty"`
+}
+
+type AppEntry struct {
+	Plugin              string `yaml:"plugin"`
+	UI                  string `yaml:"ui"`
+	Path                string `yaml:"path,omitempty"`
+	AuthorizationPolicy string `yaml:"authorizationPolicy,omitempty"`
+	Disabled            bool   `yaml:"disabled,omitempty"`
 }
 
 type ProvidersConfig struct {
@@ -623,7 +632,10 @@ func LoadAllowMissingEnv(path string) (*Config, error) {
 }
 
 func NormalizeCompatibility(cfg *Config) error {
-	return normalizeAuthorizationConfig(cfg)
+	if err := normalizeAuthorizationConfig(cfg); err != nil {
+		return err
+	}
+	return applyAppBindings(cfg)
 }
 
 func OverlayManagedPluginConfig(path string, cfg *Config) error {
@@ -1206,6 +1218,89 @@ func normalizedWorkloadDef(workload WorkloadDef) WorkloadDef {
 	}
 	workload.Providers = providers
 	return workload
+}
+
+func applyAppBindings(cfg *Config) error {
+	if cfg == nil || len(cfg.Apps) == 0 {
+		return nil
+	}
+
+	appNames := mapsKeys(cfg.Apps)
+	slices.Sort(appNames)
+	seenPlugins := make(map[string]string, len(appNames))
+	seenUIs := make(map[string]string, len(appNames))
+	for _, appName := range appNames {
+		app := cfg.Apps[appName]
+		if app == nil {
+			return fmt.Errorf("config validation: apps.%s is required", appName)
+		}
+		if app.Disabled {
+			continue
+		}
+		if strings.TrimSpace(appName) == "" {
+			return fmt.Errorf("config validation: apps keys must be non-empty")
+		}
+		app.Plugin = strings.TrimSpace(app.Plugin)
+		app.UI = strings.TrimSpace(app.UI)
+		app.Path = strings.TrimSpace(app.Path)
+		app.AuthorizationPolicy = strings.TrimSpace(app.AuthorizationPolicy)
+
+		if app.Plugin == "" {
+			return fmt.Errorf("config validation: apps.%s.plugin is required", appName)
+		}
+		if app.UI == "" {
+			return fmt.Errorf("config validation: apps.%s.ui is required", appName)
+		}
+		if app.Path == "" {
+			return fmt.Errorf("config validation: apps.%s.path is required", appName)
+		}
+		normalizedPath, err := normalizeMountedUIPath(app.Path)
+		if err != nil {
+			return fmt.Errorf("config validation: apps.%s.path: %w", appName, err)
+		}
+		app.Path = normalizedPath
+		if err := validateAuthorizationPolicyReference(cfg, "app", appName, app.AuthorizationPolicy); err != nil {
+			return err
+		}
+		if prev, exists := seenPlugins[app.Plugin]; exists && prev != appName {
+			return fmt.Errorf("config validation: apps.%s.plugin %q duplicates apps.%s", appName, app.Plugin, prev)
+		}
+		if prev, exists := seenUIs[app.UI]; exists && prev != appName {
+			return fmt.Errorf("config validation: apps.%s.ui %q duplicates apps.%s", appName, app.UI, prev)
+		}
+
+		plugin := cfg.Plugins[app.Plugin]
+		if plugin == nil {
+			return fmt.Errorf("config validation: apps.%s.plugin references unknown plugin %q", appName, app.Plugin)
+		}
+		if plugin.Disabled {
+			return fmt.Errorf("config validation: apps.%s.plugin references disabled plugin %q", appName, app.Plugin)
+		}
+		ui := cfg.Providers.UI[app.UI]
+		if ui == nil {
+			return fmt.Errorf("config validation: apps.%s.ui references unknown ui %q", appName, app.UI)
+		}
+		if ui.Disabled {
+			return fmt.Errorf("config validation: apps.%s.ui references disabled ui %q", appName, app.UI)
+		}
+		if current := strings.TrimSpace(plugin.AuthorizationPolicy); current != "" && current != app.AuthorizationPolicy {
+			return fmt.Errorf("config validation: apps.%s.plugin %q conflicts with plugins.%s.authorizationPolicy", appName, app.Plugin, app.Plugin)
+		}
+		if current := strings.TrimSpace(ui.AuthorizationPolicy); current != "" && current != app.AuthorizationPolicy {
+			return fmt.Errorf("config validation: apps.%s.ui %q conflicts with providers.ui.%s.authorizationPolicy", appName, app.UI, app.UI)
+		}
+		if current := strings.TrimSpace(ui.Path); current != "" && current != app.Path {
+			return fmt.Errorf("config validation: apps.%s.ui %q conflicts with providers.ui.%s.path", appName, app.UI, app.UI)
+		}
+
+		plugin.AuthorizationPolicy = app.AuthorizationPolicy
+		ui.AuthorizationPolicy = app.AuthorizationPolicy
+		ui.Path = app.Path
+		seenPlugins[app.Plugin] = appName
+		seenUIs[app.UI] = appName
+	}
+
+	return nil
 }
 
 func resolveBaseURL(cfg *Config) {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -20,7 +20,8 @@ func ValidateStructure(cfg *Config) error {
 	if err := NormalizeCompatibility(cfg); err != nil {
 		return err
 	}
-	if err := normalizeMountedUIPaths(cfg); err != nil {
+	appUIRefs := appReferencedUIs(cfg)
+	if err := normalizeMountedUIPaths(cfg, appUIRefs); err != nil {
 		return err
 	}
 	if err := validateAuthorizationPolicies(cfg); err != nil {
@@ -74,6 +75,9 @@ func ValidateStructure(cfg *Config) error {
 			return err
 		}
 		if entry.Path == "" {
+			if _, ok := appUIRefs[name]; ok {
+				continue
+			}
 			return fmt.Errorf("config validation: ui.%s.path is required", name)
 		}
 	}
@@ -459,10 +463,15 @@ func indexedDBSocketEnv(name string) string {
 	return b.String()
 }
 
-func normalizeMountedUIPaths(cfg *Config) error {
+func normalizeMountedUIPaths(cfg *Config, appUIRefs map[string]struct{}) error {
 	for name, entry := range cfg.Providers.UI {
 		if entry == nil || entry.Disabled {
 			continue
+		}
+		if strings.TrimSpace(entry.Path) == "" {
+			if _, ok := appUIRefs[name]; ok {
+				continue
+			}
 		}
 		normalized, err := normalizeMountedUIPath(entry.Path)
 		if err != nil {
@@ -507,7 +516,7 @@ func validateMountedUICollisions(cfg *Config) error {
 	sort.Strings(names)
 	for i, name := range names {
 		entry := cfg.Providers.UI[name]
-		if entry == nil || entry.Disabled {
+		if entry == nil || entry.Disabled || strings.TrimSpace(entry.Path) == "" {
 			continue
 		}
 		if entry.Path == "/" {
@@ -529,7 +538,7 @@ func validateMountedUICollisions(cfg *Config) error {
 		}
 		for _, otherName := range names[i+1:] {
 			other := cfg.Providers.UI[otherName]
-			if other == nil || other.Disabled {
+			if other == nil || other.Disabled || strings.TrimSpace(other.Path) == "" {
 				continue
 			}
 			if mountedUIPathsConflict(entry.Path, other.Path) {
@@ -545,6 +554,19 @@ func mountedUIPathsConflict(a, b string) bool {
 		return true
 	}
 	return strings.HasPrefix(a, b+"/") || strings.HasPrefix(b, a+"/")
+}
+
+func appReferencedUIs(cfg *Config) map[string]struct{} {
+	refs := make(map[string]struct{}, len(cfg.Apps))
+	for _, app := range cfg.Apps {
+		if app == nil || app.Disabled {
+			continue
+		}
+		if ui := strings.TrimSpace(app.UI); ui != "" {
+			refs[ui] = struct{}{}
+		}
+	}
+	return refs
 }
 
 func mapsKeys[V any](m map[string]V) []string {

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -242,67 +242,193 @@ spec:
 func TestLoadForExecutionAtPath_ResolvesLocalMountedWebUIWithoutLockfile(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	webUIDir := filepath.Join(dir, "webui")
-	if err := os.MkdirAll(filepath.Join(webUIDir, "dist"), 0o755); err != nil {
-		t.Fatalf("MkdirAll webui dist: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(webUIDir, "dist", "index.html"), []byte("<html>roadmap</html>"), 0o644); err != nil {
-		t.Fatalf("WriteFile index.html: %v", err)
-	}
-	manifestPath := filepath.Join(webUIDir, "manifest.yaml")
-	manifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
-		Kind:        providermanifestv1.KindWebUI,
-		Source:      "github.com/testowner/web/roadmap",
-		Version:     "0.0.1-alpha.1",
-		DisplayName: "Roadmap UI",
-		Spec:        &providermanifestv1.Spec{AssetRoot: "dist"},
-	}, providerpkg.ManifestFormatYAML)
-	if err != nil {
-		t.Fatalf("EncodeManifest: %v", err)
-	}
-	if err := os.WriteFile(manifestPath, manifest, 0o644); err != nil {
-		t.Fatalf("WriteFile manifest: %v", err)
-	}
-
-	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
+	tests := []struct {
+		name         string
+		uiConfigYAML string
+		extraYAML    string
+		wantPath     string
+		wantPolicy   string
+		wantErr      string
+	}{
+		{
+			name: "direct mounted ui",
+			uiConfigYAML: `  ui:
     roadmap:
       source:
         path: ./webui/manifest.yaml
       path: /create-customer-roadmap-review
-` + `server:
+`,
+			wantPath: "/create-customer-roadmap-review",
+		},
+		{
+			name: "app bound mounted ui",
+			uiConfigYAML: `  ui:
+    roadmap:
+      source:
+        path: ./webui/manifest.yaml
+  plugins:
+    roadmap:
+      source:
+        path: ./plugin/manifest.yaml
+`,
+			extraYAML: `apps:
+  roadmap_review:
+    plugin: roadmap
+    ui: roadmap
+    path: /create-customer-roadmap-review
+    authorizationPolicy: roadmap_policy
+authorization:
+  policies:
+    roadmap_policy:
+      default: deny
+      members:
+        - email: viewer@example.test
+          role: viewer
+`,
+			wantPath:   "/create-customer-roadmap-review",
+			wantPolicy: "roadmap_policy",
+		},
+		{
+			name: "disabled app binding does not suppress ui path validation",
+			uiConfigYAML: `  ui:
+    roadmap:
+      source:
+        path: ./webui/manifest.yaml
+    console:
+      source:
+        path: ./webui/manifest.yaml
+      path: /console
+  plugins:
+    roadmap:
+      source:
+        path: ./plugin/manifest.yaml
+`,
+			extraYAML: `apps:
+  roadmap_review:
+    disabled: true
+    plugin: roadmap
+    ui: roadmap
+    path: /create-customer-roadmap-review
+    authorizationPolicy: roadmap_policy
+`,
+			wantErr: "config validation: ui.roadmap.path: path is required",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			webUIDir := filepath.Join(dir, "webui")
+			if err := os.MkdirAll(filepath.Join(webUIDir, "dist"), 0o755); err != nil {
+				t.Fatalf("MkdirAll webui dist: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(webUIDir, "dist", "index.html"), []byte("<html>roadmap</html>"), 0o644); err != nil {
+				t.Fatalf("WriteFile index.html: %v", err)
+			}
+			manifestPath := filepath.Join(webUIDir, "manifest.yaml")
+			spec := &providermanifestv1.Spec{AssetRoot: "dist"}
+			if tc.wantPolicy != "" {
+				spec.Routes = []providermanifestv1.WebUIRoute{
+					{Path: "/", AllowedRoles: []string{"viewer"}},
+				}
+			}
+			manifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
+				Kind:        providermanifestv1.KindWebUI,
+				Source:      "github.com/testowner/web/roadmap",
+				Version:     "0.0.1-alpha.1",
+				DisplayName: "Roadmap UI",
+				Spec:        spec,
+			}, providerpkg.ManifestFormatYAML)
+			if err != nil {
+				t.Fatalf("EncodeManifest: %v", err)
+			}
+			if err := os.WriteFile(manifestPath, manifest, 0o644); err != nil {
+				t.Fatalf("WriteFile manifest: %v", err)
+			}
+			if tc.extraYAML != "" {
+				pluginManifestPath := filepath.Join(dir, "plugin", "manifest.yaml")
+				if err := os.MkdirAll(filepath.Dir(pluginManifestPath), 0o755); err != nil {
+					t.Fatalf("MkdirAll plugin dir: %v", err)
+				}
+				pluginManifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
+					Source:      "github.com/testowner/plugins/roadmap",
+					Version:     "0.0.1-alpha.1",
+					DisplayName: "Roadmap Plugin",
+					Kind:        providermanifestv1.KindPlugin,
+					Spec: &providermanifestv1.Spec{
+						Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+					},
+				}, providerpkg.ManifestFormatYAML)
+				if err != nil {
+					t.Fatalf("EncodePluginManifest: %v", err)
+				}
+				if err := os.WriteFile(pluginManifestPath, pluginManifest, 0o644); err != nil {
+					t.Fatalf("WriteFile plugin manifest: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "plugin", "catalog.yaml"), []byte("name: roadmap\noperations:\n  - id: ping\n    method: GET\n"), 0o644); err != nil {
+					t.Fatalf("WriteFile plugin catalog: %v", err)
+				}
+			}
+
+			cfgPath := filepath.Join(dir, "config.yaml")
+			cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + tc.uiConfigYAML + tc.extraYAML + `server:
 ` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `
-	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
-		t.Fatalf("WriteFile config: %v", err)
-	}
+			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+				t.Fatalf("WriteFile config: %v", err)
+			}
 
-	lc := NewLifecycle(nil)
-	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
-	if err != nil {
-		t.Fatalf("LoadForExecutionAtPath: %v", err)
-	}
+			lc := NewLifecycle(nil)
+			loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("LoadForExecutionAtPath: expected error containing %q", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("LoadForExecutionAtPath error = %q, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadForExecutionAtPath: %v", err)
+			}
 
-	entry := loaded.Providers.UI["roadmap"]
-	if entry == nil {
-		t.Fatal(`Providers.UI["roadmap"] = nil`)
-	}
-	if entry.ResolvedManifest == nil {
-		t.Fatal("ResolvedManifest = nil")
-	}
-	if got := entry.ResolvedManifestPath; got != manifestPath {
-		t.Fatalf("ResolvedManifestPath = %q, want %q", got, manifestPath)
-	}
-	wantAssetRoot := filepath.Join(webUIDir, "dist")
-	if got := entry.ResolvedAssetRoot; got != wantAssetRoot {
-		t.Fatalf("ResolvedAssetRoot = %q, want %q", got, wantAssetRoot)
-	}
-	if got := entry.Path; got != "/create-customer-roadmap-review" {
-		t.Fatalf("Path = %q, want %q", got, "/create-customer-roadmap-review")
-	}
-	if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); !os.IsNotExist(err) {
-		t.Fatalf("lockfile should not be created, got err=%v", err)
+			entry := loaded.Providers.UI["roadmap"]
+			if entry == nil {
+				t.Fatal(`Providers.UI["roadmap"] = nil`)
+			}
+			if entry.ResolvedManifest == nil {
+				t.Fatal("ResolvedManifest = nil")
+			}
+			if got := entry.ResolvedManifestPath; got != manifestPath {
+				t.Fatalf("ResolvedManifestPath = %q, want %q", got, manifestPath)
+			}
+			wantAssetRoot := filepath.Join(webUIDir, "dist")
+			if got := entry.ResolvedAssetRoot; got != wantAssetRoot {
+				t.Fatalf("ResolvedAssetRoot = %q, want %q", got, wantAssetRoot)
+			}
+			if got := entry.Path; got != tc.wantPath {
+				t.Fatalf("Path = %q, want %q", got, tc.wantPath)
+			}
+			if got := entry.AuthorizationPolicy; got != tc.wantPolicy {
+				t.Fatalf("AuthorizationPolicy = %q, want %q", got, tc.wantPolicy)
+			}
+			if tc.wantPolicy != "" {
+				plugin := loaded.Plugins["roadmap"]
+				if plugin == nil {
+					t.Fatal(`Plugins["roadmap"] = nil`)
+				}
+				if got := plugin.AuthorizationPolicy; got != tc.wantPolicy {
+					t.Fatalf("Plugin AuthorizationPolicy = %q, want %q", got, tc.wantPolicy)
+				}
+			}
+			if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); !os.IsNotExist(err) {
+				t.Fatalf("lockfile should not be created, got err=%v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- add top-level `apps` config entries that bind an existing plugin and an existing UI bundle to a public path and shared authorization policy
- normalize app bindings into the existing plugin/UI runtime fields so the current lifecycle, lockfile, bootstrap, and mounted-UI server paths do not need a second execution path yet
- allow disabled app bindings to keep their plugin/UI artifacts declared without requiring a direct UI mount path
- update configuration and web-UI docs to describe `apps` as the deployment-owned binding layer

## Testing
- `go test ./internal/config ./internal/operator -count=1`
- `go test ./... -count=1`

## Notes
- This is PR 2 of the mounted-app/app-ownership stack.
- It stacks on #949 and is intentionally limited to the deployment binding primitive; plugin manifests still declare UI ownership separately in the next PR.