### PR TITLE
Support named provider config and server-side provider selection

### DIFF
--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -31,10 +31,13 @@ func TestE2EValidateRejectsAuditConfigWhenProviderInheritsTelemetry(t *testing.T
 	if err != nil {
 		t.Fatalf("read config: %v", err)
 	}
-	cfgBytes = append(cfgBytes, []byte(`  audit:
-    config:
-      format: json
-`)...)
+	cfgText := strings.Replace(string(cfgBytes), "plugins:\n", `  audit:
+    primary:
+      config:
+        format: json
+plugins:
+`, 1)
+	cfgBytes = []byte(cfgText)
 	if err := os.WriteFile(cfgPath, cfgBytes, 0o644); err != nil {
 		t.Fatalf("write config audit: %v", err)
 	}
@@ -59,25 +62,28 @@ func TestE2EValidateRejectsInvalidAuditSettings(t *testing.T) {
 		{
 			name: "unknown audit provider",
 			auditYAML: `  audit:
-    source: bogus
+    primary:
+      source: bogus
 `,
 			wantError: "unknown audit provider",
 		},
 		{
 			name: "stdout audit requires mapping config",
 			auditYAML: `  audit:
-    source: stdout
-    config: nope
+    primary:
+      source: stdout
+      config: nope
 `,
 			wantError: "stdout audit: parsing config",
 		},
 		{
 			name: "otlp audit rejects non-otlp logs exporter",
 			auditYAML: `  audit:
-    source: otlp
-    config:
-      logs:
-        exporter: stdout
+    primary:
+      source: otlp
+      config:
+        logs:
+          exporter: stdout
 `,
 			wantError: "otlp audit: logs.exporter must be",
 		},
@@ -96,7 +102,8 @@ func TestE2EValidateRejectsInvalidAuditSettings(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read config: %v", err)
 			}
-			cfgBytes = append(cfgBytes, []byte(tc.auditYAML)...)
+			cfgText := strings.Replace(string(cfgBytes), "plugins:\n", tc.auditYAML+"plugins:\n", 1)
+			cfgBytes = []byte(cfgText)
 			if err := os.WriteFile(cfgPath, cfgBytes, 0o644); err != nil {
 				t.Fatalf("write config audit: %v", err)
 			}
@@ -152,7 +159,7 @@ params:
 
 			dir := t.TempDir()
 			cfgPath := filepath.Join(dir, "config.yaml")
-			cfg := "server:\n  encryptionKey: test-key\n" + authIndexedDBConfigYAML(t, dir, "local", "sqlite", filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`  plugins:
+			cfg := "server:\n  encryptionKey: test-key\n" + authIndexedDBConfigYAML(t, dir, "local", "sqlite", filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     example:
       %s
 `, strings.ReplaceAll(tc.pluginYAML, "\n", "\n      "))
@@ -268,23 +275,28 @@ func authIndexedDBConfigYAML(t *testing.T, dir, authName, datastoreName, dbPath 
 	t.Helper()
 
 	authBlock := ""
+	serverProvidersBlock := fmt.Sprintf(`  providers:
+    indexeddb: %s
+`, datastoreName)
 	if authName != "" {
 		authManifestPath := componentProviderManifestPath(t, setupAuthProviderDir(t, dir, authName))
+		serverProvidersBlock += fmt.Sprintf("    auth: %s\n", authName)
 		authBlock = fmt.Sprintf(`  auth:
-    source:
-      path: %s
-`, authManifestPath)
+    %s:
+      source:
+        path: %s
+`, authName, authManifestPath)
 	}
-	return fmt.Sprintf(`  indexeddb: %s
+	return fmt.Sprintf(`%s
 providers:
-%s  indexeddbs:
+%s  indexeddb:
     %s:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
         version: 0.0.1-alpha.2
       config:
         dsn: %q
-`, datastoreName, authBlock, datastoreName, "sqlite://"+dbPath)
+`, serverProvidersBlock, authBlock, datastoreName, "sqlite://"+dbPath)
 }
 
 func writeManifestFile(t *testing.T, pluginDir string, manifest *providermanifestv1.Manifest) {
@@ -434,31 +446,32 @@ func writeServeConfig(t *testing.T, dir string, port int, mountedUI *mountedUITe
 	if err != nil {
 		t.Fatalf("FindManifestFile(%s): %v", pluginDir, err)
 	}
-
-	cfg := fmt.Sprintf(`server:
-  public:
-    port: %d
-  encryptionKey: test-serve-e2e-key
-  indexeddb: inmem
-providers:
-  indexeddbs:
-    inmem:
-      source:
-        path: %s
-  plugins:
-    example:
-      source:
-        path: %s
-`, port, indexedDBManifest, pluginManifest)
-
+	uiBlock := ""
 	if mountedUI != nil {
-		cfg += fmt.Sprintf(`  ui:
+		uiBlock = fmt.Sprintf(`  ui:
     %s:
       source:
         path: %q
       path: %s
 `, mountedUI.Name, mountedUI.ManifestPath, mountedUI.Path)
 	}
+
+	cfg := fmt.Sprintf(`server:
+  public:
+    port: %d
+  encryptionKey: test-serve-e2e-key
+  providers:
+    indexeddb: inmem
+providers:
+  indexeddb:
+    inmem:
+      source:
+        path: %s
+%splugins:
+  example:
+    source:
+      path: %s
+`, port, indexedDBManifest, uiBlock, pluginManifest)
 
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
@@ -840,7 +853,7 @@ func writeE2EConfigWithPaths(t *testing.T, dir, pluginDir, dbPath, artifactsDir 
 	if artifactsDir != "" {
 		serverBlock += fmt.Sprintf("  artifactsDir: %s\n", artifactsDir)
 	}
-	cfg := serverBlock + authIndexedDBConfigYAML(t, dir, "", "sqlite", dbPath) + fmt.Sprintf(`  plugins:
+	cfg := serverBlock + authIndexedDBConfigYAML(t, dir, "", "sqlite", dbPath) + fmt.Sprintf(`plugins:
     example:
       source:
         path: %s

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -157,7 +157,7 @@ func runServer(env *bootstrapEnv) error {
 		DefaultConnection: connMaps.DefaultConnection,
 		CatalogConnection: connMaps.MCPConnection,
 		ConnectionAuth:    result.ConnectionAuth,
-		PluginDefs:        env.Config.Providers.Plugins,
+		PluginDefs:        env.Config.Plugins,
 		Authorizer:        result.Authorizer,
 		PublicBaseURL:     env.Config.Server.BaseURL,
 		SecureCookies:     strings.HasPrefix(env.Config.Server.BaseURL, "https://"),
@@ -365,7 +365,7 @@ func buildMCPSurface(cfg *config.Config, connMaps bootstrap.ConnectionMaps) mcpS
 		mcpConnection: make(map[string]string),
 	}
 
-	for name, entry := range cfg.Providers.Plugins {
+	for name, entry := range cfg.Plugins {
 		if entry == nil {
 			continue
 		}
@@ -465,12 +465,12 @@ func logConfigSummary(path string, cfg *config.Config) {
 		"server_management_addr", maskEmpty(cfg.Server.ManagementAddr()),
 		"server_base_url", maskEmpty(cfg.Server.BaseURL),
 		"server_encryption", maskSecret(cfg.Server.EncryptionKey),
-		"auth_provider", providerEntryLabel(cfg.Providers.Auth),
-		"secrets_provider", secretsProviderLabel(cfg.Providers.Secrets),
-		"telemetry_provider", providerEntryLabel(cfg.Providers.Telemetry),
+		"auth_provider", selectedProviderLabel(cfg.SelectedAuthProvider()),
+		"secrets_provider", selectedProviderLabel(cfg.SelectedSecretsProvider()),
+		"telemetry_provider", selectedProviderLabel(cfg.SelectedTelemetryProvider()),
 	)
 
-	for name, entry := range cfg.Providers.Plugins {
+	for name, entry := range cfg.Plugins {
 		if entry != nil {
 			slog.Info("integration configured", "integration", name, "type", "plugin")
 		}
@@ -493,9 +493,9 @@ func providerEntryLabel(entry *config.ProviderEntry) string {
 	}
 }
 
-func secretsProviderLabel(entry *config.ProviderEntry) string {
-	if entry == nil {
-		return "env"
+func selectedProviderLabel(_ string, entry *config.ProviderEntry, err error) string {
+	if err != nil {
+		return "(invalid)"
 	}
 	return providerEntryLabel(entry)
 }

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -302,12 +302,12 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		return nil, err
 	}
 
-	if cfg.Server.IndexedDB == "" {
-		return nil, fmt.Errorf("bootstrap: datastore resource name is required")
+	selectedIndexedDBName, def, err := cfg.SelectedIndexedDBProvider()
+	if err != nil {
+		return nil, err
 	}
-	def, ok := cfg.Providers.IndexedDBs[cfg.Server.IndexedDB]
-	if !ok {
-		return nil, fmt.Errorf("bootstrap: indexeddb references unknown indexeddb %q", cfg.Server.IndexedDB)
+	if selectedIndexedDBName == "" || def == nil {
+		return nil, fmt.Errorf("bootstrap: datastore resource name is required")
 	}
 	enc, encErr := crypto.NewAESGCM(encKey)
 	if encErr != nil {
@@ -315,18 +315,18 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	}
 	store, storeErr := buildIndexedDB(def, factories)
 	if storeErr != nil {
-		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", cfg.Server.IndexedDB, storeErr)
+		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", selectedIndexedDBName, storeErr)
 	}
 	store = metricutil.InstrumentIndexedDB(store)
 	svc, svcErr := coredata.New(store, enc)
 	if svcErr != nil {
 		_ = store.Close()
-		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", cfg.Server.IndexedDB, svcErr)
+		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", selectedIndexedDBName, svcErr)
 	}
-	hostIndexedDBs := map[string]indexeddb.IndexedDB{cfg.Server.IndexedDB: store}
+	hostIndexedDBs := map[string]indexeddb.IndexedDB{selectedIndexedDBName: store}
 	var extraIndexedDBs []indexeddb.IndexedDB
-	for name, entry := range cfg.Providers.IndexedDBs {
-		if name == cfg.Server.IndexedDB {
+	for name, entry := range cfg.Providers.IndexedDB {
+		if name == selectedIndexedDBName {
 			continue
 		}
 		ds, err := buildIndexedDB(entry, factories)
@@ -414,7 +414,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	if err != nil {
 		return nil, err
 	}
-	authz, err := authorization.New(cfg.Server.Authorization, cfg.Providers.Plugins, providers, connMaps.DefaultConnection)
+	authz, err := authorization.New(cfg.Server.Authorization, cfg.Plugins, providers, connMaps.DefaultConnection)
 	if err != nil {
 		return nil, err
 	}
@@ -456,7 +456,10 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 }
 
 func buildTelemetry(cfg *config.Config, factories *FactoryRegistry) (core.TelemetryProvider, error) {
-	tel := cfg.Providers.Telemetry
+	_, tel, err := cfg.SelectedTelemetryProvider()
+	if err != nil {
+		return nil, err
+	}
 	if tel != nil && tel.Disabled {
 		factory, ok := factories.Telemetry["noop"]
 		if !ok {
@@ -485,7 +488,10 @@ func buildTelemetry(cfg *config.Config, factories *FactoryRegistry) (core.Teleme
 }
 
 func buildAuditSink(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, telemetry core.TelemetryProvider) (core.AuditSink, func(context.Context) error, error) {
-	audit := cfg.Providers.Audit
+	_, audit, err := cfg.SelectedAuditProvider()
+	if err != nil {
+		return nil, nil, err
+	}
 	if audit != nil && audit.Disabled {
 		return invocation.NewLoggerAuditSink(slog.New(slog.DiscardHandler)), nil, nil
 	}
@@ -523,7 +529,10 @@ func (disabledSecretManager) GetSecret(_ context.Context, _ string) (string, err
 }
 
 func buildSecretManager(cfg *config.Config, factories *FactoryRegistry) (core.SecretManager, error) {
-	secrets := cfg.Providers.Secrets
+	_, secrets, err := cfg.SelectedSecretsProvider()
+	if err != nil {
+		return nil, err
+	}
 	if secrets != nil && secrets.Disabled {
 		return disabledSecretManager{}, nil
 	}
@@ -584,7 +593,10 @@ func closeSecretManager(sm core.SecretManager) error {
 }
 
 func buildAuth(cfg *config.Config, factories *FactoryRegistry, deps Deps) (core.AuthProvider, error) {
-	authEntry := cfg.Providers.Auth
+	_, authEntry, err := cfg.SelectedAuthProvider()
+	if err != nil {
+		return nil, err
+	}
 	if authEntry == nil || authEntry.Disabled {
 		return nil, nil
 	}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -58,24 +58,39 @@ func stubIndexedDBFactory() bootstrap.IndexedDBFactory {
 
 func validConfig() *config.Config {
 	return &config.Config{
+		Plugins: map[string]*config.ProviderEntry{},
 		Providers: config.ProvidersConfig{
-			Auth: &config.ProviderEntry{
-				Source: config.ProviderSource{Ref: "github.com/valon-technologies/gestalt-providers/auth/oidc", Version: "0.0.1-alpha.1"},
-				Config: yaml.Node{Kind: yaml.MappingNode},
+			Auth: map[string]*config.ProviderEntry{
+				"default": {
+					Source: config.ProviderSource{Ref: "github.com/valon-technologies/gestalt-providers/auth/oidc", Version: "0.0.1-alpha.1"},
+					Config: yaml.Node{Kind: yaml.MappingNode},
+				},
 			},
-			Secrets:   &config.ProviderEntry{Source: config.ProviderSource{Builtin: "test-secrets"}},
-			Telemetry: &config.ProviderEntry{Source: config.ProviderSource{Builtin: "test-telemetry"}},
-			IndexedDBs: map[string]*config.ProviderEntry{
+			Secrets: map[string]*config.ProviderEntry{
+				"default": {Source: config.ProviderSource{Builtin: "test-secrets"}},
+			},
+			Telemetry: map[string]*config.ProviderEntry{
+				"default": {Source: config.ProviderSource{Builtin: "test-telemetry"}},
+			},
+			IndexedDB: map[string]*config.ProviderEntry{
 				"test": {Source: config.ProviderSource{Path: "stub"}},
 			},
-			Plugins: map[string]*config.ProviderEntry{},
 		},
 		Server: config.ServerConfig{
 			Public:        config.ListenerConfig{Port: 8080},
 			EncryptionKey: "test-key",
-			IndexedDB:     "test",
+			Providers:     config.ServerProvidersConfig{IndexedDB: "test"},
 		},
 	}
+}
+
+func selectedAuthEntry(t *testing.T, cfg *config.Config) *config.ProviderEntry {
+	t.Helper()
+	_, entry, err := cfg.SelectedAuthProvider()
+	if err != nil {
+		t.Fatalf("SelectedAuthProvider: %v", err)
+	}
+	return entry
 }
 
 func validFactories() *bootstrap.FactoryRegistry {
@@ -194,7 +209,7 @@ func TestBootstrap(t *testing.T) {
 				defer srv.Close()
 
 				cfg := validConfig()
-				cfg.Providers.Plugins = map[string]*config.ProviderEntry{
+				cfg.Plugins = map[string]*config.ProviderEntry{
 					"slack": {
 						ResolvedManifest: &providermanifestv1.Manifest{
 							Spec: &providermanifestv1.Spec{
@@ -301,7 +316,7 @@ func TestBootstrapNoIntegrations(t *testing.T) {
 	ctx := context.Background()
 
 	cfg := validConfig()
-	cfg.Providers.Plugins = nil
+	cfg.Plugins = nil
 
 	result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
 	if err != nil {
@@ -318,7 +333,7 @@ func TestBootstrap_ReusesPreparedComponentRuntimeConfig(t *testing.T) {
 
 	cfg := validConfig()
 
-	authRuntime, err := config.BuildComponentRuntimeConfigNode("auth", "auth", cfg.Providers.Auth, yaml.Node{
+	authRuntime, err := config.BuildComponentRuntimeConfigNode("auth", "auth", selectedAuthEntry(t, cfg), yaml.Node{
 		Kind: yaml.MappingNode,
 		Content: []*yaml.Node{
 			{Kind: yaml.ScalarNode, Tag: "!!str", Value: "clientId"},
@@ -328,7 +343,7 @@ func TestBootstrap_ReusesPreparedComponentRuntimeConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildComponentRuntimeConfigNode(auth): %v", err)
 	}
-	cfg.Providers.Auth.Config = authRuntime
+	selectedAuthEntry(t, cfg).Config = authRuntime
 
 	var gotAuthNode yaml.Node
 	factories := validFactories()
@@ -573,7 +588,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 
 		cfg := validConfig()
-		cfg.Providers.Auth.Config = yaml.Node{
+		selectedAuthEntry(t, cfg).Config = yaml.Node{
 			Kind: yaml.MappingNode,
 			Content: []*yaml.Node{
 				{Kind: yaml.ScalarNode, Value: "clientSecret", Tag: "!!str"},
@@ -619,7 +634,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 
 		cfg := validConfig()
-		ds := cfg.Providers.IndexedDBs["test"]
+		ds := cfg.Providers.IndexedDB["test"]
 		ds.Config = yaml.Node{
 			Kind: yaml.MappingNode,
 			Content: []*yaml.Node{
@@ -627,7 +642,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 				{Kind: yaml.ScalarNode, Value: "secret://indexeddb-dsn", Tag: "!!str"},
 			},
 		}
-		cfg.Providers.IndexedDBs["test"] = ds
+		cfg.Providers.IndexedDB["test"] = ds
 
 		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
 		if err != nil {
@@ -715,8 +730,11 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		t.Parallel()
 
 		cfg := validConfig()
-		cfg.Providers.Auth = &config.ProviderEntry{Source: config.ProviderSource{Ref: "github.com/valon-technologies/gestalt-providers/auth/oidc", Version: "0.0.1-alpha.1"}}
-		cfg.Providers.Auth.Config = yaml.Node{
+		cfg.Providers.Auth = map[string]*config.ProviderEntry{
+			"secondary": {Source: config.ProviderSource{Ref: "github.com/valon-technologies/gestalt-providers/auth/oidc", Version: "0.0.1-alpha.1"}},
+		}
+		cfg.Server.Providers.Auth = "secondary"
+		cfg.Providers.Auth["secondary"].Config = yaml.Node{
 			Kind: yaml.MappingNode,
 			Content: []*yaml.Node{
 				{Kind: yaml.ScalarNode, Value: "issuerUrl", Tag: "!!str"},
@@ -757,6 +775,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 
 		cfg := validConfig()
 		cfg.Providers.Auth = nil
+		cfg.Server.Providers.Auth = ""
 
 		var authFactoryCalled atomic.Bool
 		factories := validFactories()
@@ -846,7 +865,7 @@ func TestBootstrapDisabledComponents(t *testing.T) {
 		t.Parallel()
 
 		cfg := validConfig()
-		cfg.Providers.Telemetry = &config.ProviderEntry{Disabled: true}
+		cfg.Providers.Telemetry = map[string]*config.ProviderEntry{"default": {Disabled: true}}
 
 		factories := validFactories()
 		factories.Telemetry["noop"] = telemetrynoop.Factory
@@ -868,7 +887,7 @@ func TestBootstrapDisabledComponents(t *testing.T) {
 		t.Parallel()
 
 		cfg := validConfig()
-		cfg.Providers.Secrets = &config.ProviderEntry{Disabled: true}
+		cfg.Providers.Secrets = map[string]*config.ProviderEntry{"default": {Disabled: true}}
 
 		result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
 		if err != nil {

--- a/gestaltd/internal/bootstrap/connections.go
+++ b/gestaltd/internal/bootstrap/connections.go
@@ -19,13 +19,14 @@ type ConnectionMaps struct {
 }
 
 func BuildConnectionMaps(cfg *config.Config) (ConnectionMaps, error) {
+	cfg.SyncCompatFields()
 	maps := ConnectionMaps{
-		DefaultConnection: make(map[string]string, len(cfg.Providers.Plugins)),
-		APIConnection:     make(map[string]string, len(cfg.Providers.Plugins)),
-		MCPConnection:     make(map[string]string, len(cfg.Providers.Plugins)),
+		DefaultConnection: make(map[string]string, len(cfg.Plugins)),
+		APIConnection:     make(map[string]string, len(cfg.Plugins)),
+		MCPConnection:     make(map[string]string, len(cfg.Plugins)),
 	}
 
-	for name, entry := range cfg.Providers.Plugins {
+	for name, entry := range cfg.Plugins {
 		defaultConnection := config.PluginConnectionName
 		apiConnection := config.PluginConnectionName
 		mcpConnection := config.PluginConnectionName

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -44,6 +44,7 @@ func buildRegistrationStore(deps Deps) mcpoauth.RegistrationStore {
 }
 
 func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.ProviderMap[core.Provider], <-chan struct{}, func() map[string]map[string]OAuthHandler, error) {
+	cfg.SyncCompatFields()
 	reg := registry.New()
 	connAuth := make(map[string]map[string]OAuthHandler)
 	var connMu sync.Mutex
@@ -58,14 +59,14 @@ func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryR
 	}
 
 	ready := make(chan struct{})
-	if len(cfg.Providers.Plugins) == 0 {
+	if len(cfg.Plugins) == 0 {
 		close(ready)
 		return &reg.Providers, ready, func() map[string]map[string]OAuthHandler { return connAuth }, nil
 	}
 
 	var wg sync.WaitGroup
-	for name := range cfg.Providers.Plugins {
-		intgDef := cfg.Providers.Plugins[name]
+	for name := range cfg.Plugins {
+		intgDef := cfg.Plugins[name]
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/gestaltd/internal/bootstrap/secret_resolution.go
+++ b/gestaltd/internal/bootstrap/secret_resolution.go
@@ -42,7 +42,7 @@ func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretMa
 	if err := resolveStringFields(&cfg.Server, resolve); err != nil {
 		return err
 	}
-	for name, entry := range cfg.Providers.Plugins {
+	for name, entry := range cfg.Plugins {
 		if entry == nil {
 			continue
 		}
@@ -56,12 +56,18 @@ func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretMa
 				}
 			}
 		}
-		cfg.Providers.Plugins[name] = entry
+		cfg.Plugins[name] = entry
 	}
-	for _, entry := range []*config.ProviderEntry{cfg.Providers.Auth, cfg.Providers.Telemetry, cfg.Providers.Audit} {
-		if entry != nil {
-			if err := resolveStringFields(entry, resolve); err != nil {
-				return err
+	for _, entries := range []map[string]*config.ProviderEntry{
+		cfg.Providers.Auth,
+		cfg.Providers.Telemetry,
+		cfg.Providers.Audit,
+	} {
+		for _, entry := range entries {
+			if entry != nil {
+				if err := resolveStringFields(entry, resolve); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -75,25 +81,29 @@ func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretMa
 		cfg.Providers.UI[name] = entry
 	}
 	// Resolve secrets provider struct fields (Source, Env, AllowedHosts, etc.)
-	// but skip its Config node to avoid self-referential resolution.
-	if cfg.Providers.Secrets != nil {
-		savedConfig := cfg.Providers.Secrets.Config
-		cfg.Providers.Secrets.Config = yaml.Node{}
-		if err := resolveStringFields(cfg.Providers.Secrets, resolve); err != nil {
-			cfg.Providers.Secrets.Config = savedConfig
+	// but skip their Config nodes to avoid self-referential resolution.
+	for name, entry := range cfg.Providers.Secrets {
+		if entry == nil {
+			continue
+		}
+		savedConfig := entry.Config
+		entry.Config = yaml.Node{}
+		if err := resolveStringFields(entry, resolve); err != nil {
+			entry.Config = savedConfig
 			return err
 		}
-		cfg.Providers.Secrets.Config = savedConfig
+		entry.Config = savedConfig
+		cfg.Providers.Secrets[name] = entry
 	}
 
-	for name, ds := range cfg.Providers.IndexedDBs {
+	for name, ds := range cfg.Providers.IndexedDB {
 		if ds == nil {
 			continue
 		}
 		if err := resolveStringFields(ds, resolve); err != nil {
 			return err
 		}
-		cfg.Providers.IndexedDBs[name] = ds
+		cfg.Providers.IndexedDB[name] = ds
 	}
 
 	return nil

--- a/gestaltd/internal/bootstrap/structured_logging_test.go
+++ b/gestaltd/internal/bootstrap/structured_logging_test.go
@@ -20,7 +20,7 @@ func TestBootstrapSkippedProviderLogsWarning(t *testing.T) { //nolint:parallelte
 	t.Cleanup(func() { slog.SetDefault(prev) })
 
 	cfg := validConfig()
-	cfg.Providers.Plugins = map[string]*config.ProviderEntry{
+	cfg.Plugins = map[string]*config.ProviderEntry{
 		"broken": {
 			Source: config.ProviderSource{Path: "./manifest.yaml"},
 		},

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -60,6 +60,7 @@ func validateMCPCatalogs(providers *registry.ProviderMap[core.Provider]) error {
 }
 
 func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.ProviderMap[core.Provider], map[string]map[string]OAuthHandler, error) {
+	cfg.SyncCompatFields()
 	reg := registry.New()
 	connAuth := make(map[string]map[string]OAuthHandler)
 
@@ -72,11 +73,11 @@ func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *Fa
 		}
 	}
 
-	names := slices.Sorted(maps.Keys(cfg.Providers.Plugins))
+	names := slices.Sorted(maps.Keys(cfg.Plugins))
 
 	var errs []error
 	for _, name := range names {
-		entry := cfg.Providers.Plugins[name]
+		entry := cfg.Plugins[name]
 		result, err := buildProviderForValidation(ctx, name, entry, deps)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("integration %q: %w", name, err))

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -27,6 +27,7 @@ const (
 
 	DefaultIndexedDBProvider = DefaultProviderRepo + "/indexeddb/relationaldb"
 	DefaultIndexedDBVersion  = "0.0.1-alpha.2"
+	DefaultProviderInstance  = "default"
 )
 
 // PluginConnectionName is the implicit connection name used when storing
@@ -39,18 +40,41 @@ const PluginConnectionName = "_plugin"
 const PluginConnectionAlias = "plugin"
 
 type Config struct {
-	Server    ServerConfig    `yaml:"server"`
-	Providers ProvidersConfig `yaml:"providers"`
+	Server    ServerConfig              `yaml:"server"`
+	Providers ProvidersConfig           `yaml:"providers"`
+	Plugins   map[string]*ProviderEntry `yaml:"plugins,omitempty"`
 }
 
 type ProvidersConfig struct {
-	Auth       *ProviderEntry            `yaml:"auth,omitempty"`
-	Secrets    *ProviderEntry            `yaml:"secrets,omitempty"`
-	Telemetry  *ProviderEntry            `yaml:"telemetry,omitempty"`
-	Audit      *ProviderEntry            `yaml:"audit,omitempty"`
-	UI         map[string]*UIEntry       `yaml:"ui,omitempty"`
-	IndexedDBs map[string]*ProviderEntry `yaml:"indexeddbs,omitempty"`
-	Plugins    map[string]*ProviderEntry `yaml:"plugins,omitempty"`
+	Auth      map[string]*ProviderEntry `yaml:"auth,omitempty"`
+	Secrets   map[string]*ProviderEntry `yaml:"secrets,omitempty"`
+	Telemetry map[string]*ProviderEntry `yaml:"telemetry,omitempty"`
+	Audit     map[string]*ProviderEntry `yaml:"audit,omitempty"`
+	UI        map[string]*UIEntry       `yaml:"ui,omitempty"`
+	IndexedDB map[string]*ProviderEntry `yaml:"indexeddb,omitempty"`
+
+	// Legacy aliases retained for internal call sites and tests while the
+	// canonical YAML shape is migrating to top-level plugins and indexeddb.
+	IndexedDBs map[string]*ProviderEntry `yaml:"-"`
+	Plugins    map[string]*ProviderEntry `yaml:"-"`
+}
+
+type HostProviderKind string
+
+const (
+	HostProviderKindAuth      HostProviderKind = "auth"
+	HostProviderKindSecrets   HostProviderKind = "secrets"
+	HostProviderKindTelemetry HostProviderKind = "telemetry"
+	HostProviderKindAudit     HostProviderKind = "audit"
+	HostProviderKindIndexedDB HostProviderKind = "indexeddb"
+)
+
+type ServerProvidersConfig struct {
+	Auth      string `yaml:"auth,omitempty"`
+	Secrets   string `yaml:"secrets,omitempty"`
+	Telemetry string `yaml:"telemetry,omitempty"`
+	Audit     string `yaml:"audit,omitempty"`
+	IndexedDB string `yaml:"indexeddb,omitempty"`
 }
 
 // ProviderSource supports three modes via custom UnmarshalYAML:
@@ -90,6 +114,7 @@ func (s ProviderSource) IsLocal() bool   { return s.Path != "" }
 type ProviderEntry struct {
 	Source       ProviderSource    `yaml:"source"`
 	Config       yaml.Node         `yaml:"config,omitempty"`
+	Default      bool              `yaml:"default,omitempty"`
 	Disabled     bool              `yaml:"disabled,omitempty"`
 	Env          map[string]string `yaml:"env,omitempty"`
 	AllowedHosts []string          `yaml:"allowedHosts,omitempty"`
@@ -100,7 +125,7 @@ type ProviderEntry struct {
 	// Plugin-specific config fields (parsed from YAML, only valid on plugin entries)
 	Connections       map[string]*ConnectionDef     `yaml:"connections,omitempty"`
 	AllowedOperations map[string]*OperationOverride `yaml:"allowedOperations,omitempty"`
-	IndexedDBs        []string                      `yaml:"indexeddbs,omitempty"`
+	IndexedDBs        []string                      `yaml:"indexeddb,omitempty"`
 	Surfaces          *ProviderSurfaceOverrides     `yaml:"surfaces,omitempty"`
 
 	// Runtime-resolved fields (populated during init/bootstrap, not from YAML)
@@ -227,15 +252,16 @@ type ListenerConfig struct {
 }
 
 type ServerConfig struct {
-	Public        ListenerConfig      `yaml:"public"`
-	Management    ListenerConfig      `yaml:"management"`
-	BaseURL       string              `yaml:"baseUrl"`
-	EncryptionKey string              `yaml:"encryptionKey"`
-	APITokenTTL   string              `yaml:"apiTokenTtl"`
-	ArtifactsDir  string              `yaml:"artifactsDir"`
-	IndexedDB     string              `yaml:"indexeddb,omitempty"`
-	Egress        EgressConfig        `yaml:"egress,omitempty"`
-	Authorization AuthorizationConfig `yaml:"authorization,omitempty"`
+	Public        ListenerConfig        `yaml:"public"`
+	Management    ListenerConfig        `yaml:"management"`
+	BaseURL       string                `yaml:"baseUrl"`
+	EncryptionKey string                `yaml:"encryptionKey"`
+	APITokenTTL   string                `yaml:"apiTokenTtl"`
+	ArtifactsDir  string                `yaml:"artifactsDir"`
+	Providers     ServerProvidersConfig `yaml:"providers,omitempty"`
+	IndexedDB     string                `yaml:"-"`
+	Egress        EgressConfig          `yaml:"egress,omitempty"`
+	Authorization AuthorizationConfig   `yaml:"authorization,omitempty"`
 }
 
 func (s ServerConfig) PublicListener() ListenerConfig {
@@ -576,9 +602,13 @@ func OverlayManagedPluginConfig(path string, cfg *Config) error {
 	if err := dec.Decode(&root); err != nil && err != io.EOF {
 		return fmt.Errorf("parsing config YAML: %w", err)
 	}
+	if err := normalizeConfigRoot(&root); err != nil {
+		return err
+	}
+	doc := documentValueNode(&root)
 	providersNode := mappingValueNode(documentValueNode(&root), "providers")
-	pluginsNode := mappingValueNode(providersNode, "plugins")
-	for name, entry := range cfg.Providers.Plugins {
+	pluginsNode := mappingValueNode(doc, "plugins")
+	for name, entry := range cfg.Plugins {
 		if entry == nil || !entry.HasManagedSource() {
 			continue
 		}
@@ -586,21 +616,25 @@ func OverlayManagedPluginConfig(path string, cfg *Config) error {
 			return err
 		}
 	}
-	for _, c := range []struct {
-		name  string
-		entry *ProviderEntry
+	for _, collection := range []struct {
+		kind    HostProviderKind
+		entries map[string]*ProviderEntry
 	}{
-		{"auth", cfg.Providers.Auth},
-		{"secrets", cfg.Providers.Secrets},
-		{"telemetry", cfg.Providers.Telemetry},
-		{"audit", cfg.Providers.Audit},
+		{HostProviderKindAuth, cfg.Providers.Auth},
+		{HostProviderKindSecrets, cfg.Providers.Secrets},
+		{HostProviderKindTelemetry, cfg.Providers.Telemetry},
+		{HostProviderKindAudit, cfg.Providers.Audit},
+		{HostProviderKindIndexedDB, cfg.Providers.IndexedDB},
 	} {
-		if c.entry == nil || !c.entry.HasManagedSource() {
-			continue
-		}
-		node := mappingValueNode(providersNode, c.name)
-		if err := overlayManagedEntryConfigNode(node, c.entry, c.name); err != nil {
-			return err
+		kindNode := mappingValueNode(providersNode, string(collection.kind))
+		for name, entry := range collection.entries {
+			if entry == nil || !entry.HasManagedSource() {
+				continue
+			}
+			subject := fmt.Sprintf("%s %q", collection.kind, name)
+			if err := overlayManagedEntryConfigNode(mappingValueNode(kindNode, name), entry, subject); err != nil {
+				return err
+			}
 		}
 	}
 	uiNode := mappingValueNode(providersNode, "ui")
@@ -654,6 +688,243 @@ func mappingValueNode(node *yaml.Node, key string) *yaml.Node {
 	return nil
 }
 
+type configShapeUsage struct {
+	legacy    bool
+	canonical bool
+}
+
+var legacyProviderEntryKeys = map[string]struct{}{
+	"source":            {},
+	"config":            {},
+	"default":           {},
+	"disabled":          {},
+	"env":               {},
+	"allowedHosts":      {},
+	"displayName":       {},
+	"description":       {},
+	"iconFile":          {},
+	"connections":       {},
+	"allowedOperations": {},
+	"indexeddb":         {},
+	"indexeddbs":        {},
+	"surfaces":          {},
+}
+
+func normalizeConfigRoot(root *yaml.Node) error {
+	doc := documentValueNode(root)
+	if doc == nil || doc.Kind == 0 {
+		return nil
+	}
+	if doc.Kind != yaml.MappingNode {
+		return fmt.Errorf("parsing config YAML: expected mapping document")
+	}
+
+	usage := configShapeUsage{}
+	providersNode := mappingValueNode(doc, "providers")
+	if err := normalizePluginsNode(doc, providersNode, &usage); err != nil {
+		return err
+	}
+	if err := normalizeProvidersNode(providersNode, &usage); err != nil {
+		return err
+	}
+	if err := normalizeServerNode(mappingValueNode(doc, "server"), &usage); err != nil {
+		return err
+	}
+	if err := normalizePluginBindings(mappingValueNode(doc, "plugins"), &usage); err != nil {
+		return err
+	}
+	return nil
+}
+
+func normalizePluginsNode(root, providersNode *yaml.Node, usage *configShapeUsage) error {
+	root = documentValueNode(root)
+	providersNode = documentValueNode(providersNode)
+	canonical := mappingValueNode(root, "plugins")
+	legacy := mappingValueNode(providersNode, "plugins")
+	if canonical != nil {
+		usage.canonical = true
+	}
+	if legacy != nil {
+		usage.legacy = true
+	}
+	if canonical != nil && legacy != nil {
+		return fmt.Errorf("config validation: plugins must be configured using top-level plugins or providers.plugins, not both")
+	}
+	if canonical == nil && legacy != nil {
+		setMappingValueNode(root, "plugins", legacy)
+		removeMappingKey(providersNode, "plugins")
+	}
+	return nil
+}
+
+func normalizeProvidersNode(providersNode *yaml.Node, usage *configShapeUsage) error {
+	providersNode = documentValueNode(providersNode)
+	if providersNode == nil {
+		return nil
+	}
+	legacyIndexedDB := mappingValueNode(providersNode, "indexeddbs")
+	canonicalIndexedDB := mappingValueNode(providersNode, "indexeddb")
+	if legacyIndexedDB != nil {
+		usage.legacy = true
+	}
+	if canonicalIndexedDB != nil {
+		usage.canonical = true
+	}
+	if legacyIndexedDB != nil && canonicalIndexedDB != nil {
+		return fmt.Errorf("config validation: providers.indexeddb must be configured using indexeddb or indexeddbs, not both")
+	}
+	if canonicalIndexedDB == nil && legacyIndexedDB != nil {
+		setMappingValueNode(providersNode, "indexeddb", legacyIndexedDB)
+		removeMappingKey(providersNode, "indexeddbs")
+	}
+
+	for _, kind := range []string{"auth", "secrets", "telemetry", "audit"} {
+		node := mappingValueNode(providersNode, kind)
+		if node == nil {
+			continue
+		}
+		if isLegacySingletonProviderNode(node) {
+			usage.legacy = true
+			setMappingValueNode(providersNode, kind, wrapLegacyProviderNode(kind, node))
+			continue
+		}
+		usage.canonical = true
+	}
+	return nil
+}
+
+func normalizeServerNode(serverNode *yaml.Node, usage *configShapeUsage) error {
+	serverNode = documentValueNode(serverNode)
+	if serverNode == nil {
+		return nil
+	}
+	providersNode := mappingValueNode(serverNode, "providers")
+	legacyIndexedDB := mappingValueNode(serverNode, "indexeddb")
+	if providersNode != nil {
+		usage.canonical = true
+	}
+	if legacyIndexedDB != nil {
+		usage.legacy = true
+	}
+	if providersNode != nil && legacyIndexedDB != nil && mappingValueNode(providersNode, "indexeddb") != nil {
+		return fmt.Errorf("config validation: server.providers.indexeddb and server.indexeddb cannot both be set")
+	}
+	if legacyIndexedDB != nil {
+		if providersNode == nil {
+			providersNode = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+			setMappingValueNode(serverNode, "providers", providersNode)
+		}
+		if mappingValueNode(providersNode, "indexeddb") == nil {
+			setMappingValueNode(providersNode, "indexeddb", legacyIndexedDB)
+		}
+		removeMappingKey(serverNode, "indexeddb")
+	}
+	return nil
+}
+
+func normalizePluginBindings(pluginsNode *yaml.Node, usage *configShapeUsage) error {
+	pluginsNode = documentValueNode(pluginsNode)
+	if pluginsNode == nil || pluginsNode.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(pluginsNode.Content); i += 2 {
+		entryNode := documentValueNode(pluginsNode.Content[i+1])
+		if entryNode == nil || entryNode.Kind != yaml.MappingNode {
+			continue
+		}
+		legacy := mappingValueNode(entryNode, "indexeddbs")
+		canonical := mappingValueNode(entryNode, "indexeddb")
+		if legacy != nil {
+			usage.legacy = true
+		}
+		if canonical != nil {
+			usage.canonical = true
+		}
+		if legacy != nil && canonical != nil {
+			return fmt.Errorf("config validation: plugin %q cannot set both indexeddb and indexeddbs", pluginsNode.Content[i].Value)
+		}
+		if canonical == nil && legacy != nil {
+			setMappingValueNode(entryNode, "indexeddb", legacy)
+			removeMappingKey(entryNode, "indexeddbs")
+		}
+	}
+	return nil
+}
+
+func isLegacySingletonProviderNode(node *yaml.Node) bool {
+	node = documentValueNode(node)
+	if node == nil || node.Kind != yaml.MappingNode || len(node.Content) == 0 {
+		return false
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i].Value
+		if _, ok := legacyProviderEntryKeys[key]; !ok {
+			return false
+		}
+		if !looksLikeProviderEntryMap(node.Content[i+1]) {
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikeProviderEntryMap(node *yaml.Node) bool {
+	node = documentValueNode(node)
+	if node == nil || node.Kind != yaml.MappingNode {
+		return false
+	}
+	if len(node.Content) == 0 {
+		return true
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if _, ok := legacyProviderEntryKeys[node.Content[i].Value]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func wrapLegacyProviderNode(name string, node *yaml.Node) *yaml.Node {
+	return &yaml.Node{
+		Kind: yaml.MappingNode,
+		Tag:  "!!map",
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: name},
+			node,
+		},
+	}
+}
+
+func setMappingValueNode(node *yaml.Node, key string, value *yaml.Node) {
+	node = documentValueNode(node)
+	if node == nil || node.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			node.Content[i+1] = value
+			return
+		}
+	}
+	node.Content = append(node.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		value,
+	)
+}
+
+func removeMappingKey(node *yaml.Node, key string) {
+	node = documentValueNode(node)
+	if node == nil || node.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			node.Content = append(node.Content[:i], node.Content[i+2:]...)
+			return
+		}
+	}
+}
+
 func loadWithLookup(path string, lookup func(string) (string, bool), allowMissing bool) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -668,8 +939,21 @@ func loadWithLookup(path string, lookup func(string) (string, bool), allowMissin
 		return nil, fmt.Errorf("expanding config environment variables: environment variable %q not set; use ${%s:-} to allow an empty default", firstMissing, firstMissing)
 	}
 
+	var root yaml.Node
+	normalizeDecoder := yaml.NewDecoder(strings.NewReader(resolved))
+	if err := normalizeDecoder.Decode(&root); err != nil && err != io.EOF {
+		return nil, fmt.Errorf("parsing config YAML: %w", err)
+	}
+	if err := normalizeConfigRoot(&root); err != nil {
+		return nil, err
+	}
+	normalized, err := yaml.Marshal(documentValueNode(&root))
+	if err != nil {
+		return nil, fmt.Errorf("marshaling normalized config YAML: %w", err)
+	}
+
 	var cfg Config
-	dec := yaml.NewDecoder(strings.NewReader(resolved))
+	dec := yaml.NewDecoder(strings.NewReader(string(normalized)))
 	dec.KnownFields(true)
 	if err := dec.Decode(&cfg); err != nil && err != io.EOF {
 		return nil, fmt.Errorf("parsing config YAML: %w", err)
@@ -764,24 +1048,53 @@ func overlayEnvIntoNode(node yaml.Node, lookup func(string) (string, bool), pres
 }
 
 func applyDefaults(cfg *Config) {
+	cfg.SyncCompatFields()
 	if cfg.Server.Public.Port == 0 {
 		cfg.Server.Public.Port = 8080
 	}
-	if cfg.Providers.Secrets == nil {
-		cfg.Providers.Secrets = &ProviderEntry{Source: ProviderSource{Builtin: "env"}}
-	} else if !cfg.Providers.Secrets.Disabled && !cfg.Providers.Secrets.Source.IsBuiltin() && !cfg.Providers.Secrets.Source.IsManaged() && !cfg.Providers.Secrets.Source.IsLocal() {
-		cfg.Providers.Secrets.Source.Builtin = "env"
+	cfg.Plugins = nonNilProviderEntryMap(cfg.Plugins)
+	cfg.Providers.UI = nonNilUIEntryMap(cfg.Providers.UI)
+	cfg.Providers.Auth = nonNilProviderEntryMap(cfg.Providers.Auth)
+	cfg.Providers.Secrets = applyDefaultBuiltinProviderEntries(cfg.Providers.Secrets, DefaultProviderInstance, "env")
+	cfg.Providers.Telemetry = applyDefaultBuiltinProviderEntries(cfg.Providers.Telemetry, DefaultProviderInstance, "stdout")
+	cfg.Providers.Audit = applyDefaultBuiltinProviderEntries(cfg.Providers.Audit, DefaultProviderInstance, "inherit")
+	cfg.Providers.IndexedDB = nonNilProviderEntryMap(cfg.Providers.IndexedDB)
+	cfg.Providers.Plugins = cfg.Plugins
+	cfg.Providers.IndexedDBs = cfg.Providers.IndexedDB
+	cfg.Server.IndexedDB = cfg.Server.Providers.IndexedDB
+	cfg.SyncCompatFields()
+}
+
+func nonNilProviderEntryMap(entries map[string]*ProviderEntry) map[string]*ProviderEntry {
+	if entries == nil {
+		return make(map[string]*ProviderEntry)
 	}
-	if cfg.Providers.Telemetry == nil {
-		cfg.Providers.Telemetry = &ProviderEntry{Source: ProviderSource{Builtin: "stdout"}}
-	} else if !cfg.Providers.Telemetry.Disabled && !cfg.Providers.Telemetry.Source.IsBuiltin() && !cfg.Providers.Telemetry.Source.IsManaged() && !cfg.Providers.Telemetry.Source.IsLocal() {
-		cfg.Providers.Telemetry.Source.Builtin = "stdout"
+	return entries
+}
+
+func nonNilUIEntryMap(entries map[string]*UIEntry) map[string]*UIEntry {
+	if entries == nil {
+		return make(map[string]*UIEntry)
 	}
-	if cfg.Providers.Audit == nil {
-		cfg.Providers.Audit = &ProviderEntry{Source: ProviderSource{Builtin: "inherit"}}
-	} else if !cfg.Providers.Audit.Disabled && !cfg.Providers.Audit.Source.IsBuiltin() && !cfg.Providers.Audit.Source.IsManaged() && !cfg.Providers.Audit.Source.IsLocal() {
-		cfg.Providers.Audit.Source.Builtin = "inherit"
+	return entries
+}
+
+func applyDefaultBuiltinProviderEntries(entries map[string]*ProviderEntry, defaultName, builtin string) map[string]*ProviderEntry {
+	if len(entries) == 0 {
+		return map[string]*ProviderEntry{
+			defaultName: {
+				Source:  ProviderSource{Builtin: builtin},
+				Default: true,
+			},
+		}
 	}
+	for _, entry := range entries {
+		if entry == nil || entry.Disabled || entry.Source.IsBuiltin() || entry.Source.IsManaged() || entry.Source.IsLocal() {
+			continue
+		}
+		entry.Source.Builtin = builtin
+	}
+	return entries
 }
 
 func resolveBaseURL(cfg *Config) {
@@ -806,19 +1119,27 @@ func resolveRelativePaths(configPath string, cfg *Config) {
 		entry.Source.Path = resolveRelativePath(baseDir, entry.Source.Path)
 	}
 
-	resolveEntry(cfg.Providers.Auth)
-	resolveEntry(cfg.Providers.Secrets)
-	resolveEntry(cfg.Providers.Telemetry)
-	resolveEntry(cfg.Providers.Audit)
+	for _, entry := range cfg.Providers.Auth {
+		resolveEntry(entry)
+	}
+	for _, entry := range cfg.Providers.Secrets {
+		resolveEntry(entry)
+	}
+	for _, entry := range cfg.Providers.Telemetry {
+		resolveEntry(entry)
+	}
+	for _, entry := range cfg.Providers.Audit {
+		resolveEntry(entry)
+	}
 	for _, entry := range cfg.Providers.UI {
 		if entry != nil {
 			resolveEntry(&entry.ProviderEntry)
 		}
 	}
-	for _, entry := range cfg.Providers.IndexedDBs {
+	for _, entry := range cfg.Providers.IndexedDB {
 		resolveEntry(entry)
 	}
-	for _, entry := range cfg.Providers.Plugins {
+	for _, entry := range cfg.Plugins {
 		resolveEntry(entry)
 	}
 }

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -31,29 +31,32 @@ func mustWriteConfigFile(t *testing.T, content string) string {
 	return path
 }
 
+func mustSelectedProvider(t *testing.T, cfg *Config, kind HostProviderKind) (string, *ProviderEntry) {
+	t.Helper()
+	name, entry, err := cfg.SelectedHostProvider(kind)
+	if err != nil {
+		t.Fatalf("SelectedHostProvider(%s): %v", kind, err)
+	}
+	return name, entry
+}
+
+func singletonProviderEntry(entry *ProviderEntry) map[string]*ProviderEntry {
+	if entry == nil {
+		return nil
+	}
+	return map[string]*ProviderEntry{
+		DefaultProviderInstance: entry,
+	}
+}
+
 func TestLoadConfigGenericFixture(t *testing.T) {
 	t.Parallel()
 
 	path := mustWriteConfigFile(t, `
-providers:
-  auth:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/auth/google
-      version: 1.0.0
-    config:
-      clientId: client-1
-      clientSecret: secret-1
-  indexeddbs:
-    sqlite:
-      source:
-        path: ./providers/datastore/sqlite
-  plugins:
-    service-a:
-      displayName: Service A
-      source:
-        path: /tmp/manifest.yaml
 server:
-  indexeddb: sqlite
+  providers:
+    auth: google
+    indexeddb: sqlite
   encryptionKey: server-key
   public:
     host: 127.0.0.1
@@ -61,6 +64,24 @@ server:
   management:
     host: 127.0.0.1
     port: 9191
+providers:
+  auth:
+    google:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/google
+        version: 1.0.0
+      config:
+        clientId: client-1
+        clientSecret: secret-1
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+plugins:
+  service-a:
+    displayName: Service A
+    source:
+      path: /tmp/manifest.yaml
 `)
 
 	cfg, err := Load(path)
@@ -74,8 +95,90 @@ server:
 	if cfg.Server.EncryptionKey != "server-key" {
 		t.Fatalf("Server.EncryptionKey = %q", cfg.Server.EncryptionKey)
 	}
-	if got := cfg.Providers.Plugins["service-a"].DisplayName; got != "Service A" {
+	if got := cfg.Plugins["service-a"].DisplayName; got != "Service A" {
 		t.Fatalf("Integrations[service-a].DisplayName = %q", got)
+	}
+}
+
+func TestLoadConfigSelectsDefaultProvidersFromNamedMaps(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+server:
+  encryptionKey: server-key
+providers:
+  auth:
+    primary:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/google
+        version: 1.0.0
+    backup:
+      default: true
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/github
+        version: 1.0.0
+  indexeddb:
+    main:
+      source:
+        path: ./providers/datastore/sqlite
+    archive:
+      default: true
+      source:
+        path: ./providers/datastore/archive
+plugins:
+  service-a:
+    source:
+      path: /tmp/manifest.yaml
+    indexeddb:
+      - archive
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	authName, authEntry := mustSelectedProvider(t, cfg, HostProviderKindAuth)
+	if authName != "backup" || authEntry == nil {
+		t.Fatalf("SelectedAuthProvider = (%q, %#v), want backup", authName, authEntry)
+	}
+	indexedDBName, indexedDBEntry := mustSelectedProvider(t, cfg, HostProviderKindIndexedDB)
+	if indexedDBName != "archive" || indexedDBEntry == nil {
+		t.Fatalf("SelectedIndexedDBProvider = (%q, %#v), want archive", indexedDBName, indexedDBEntry)
+	}
+	if got := cfg.Plugins["service-a"].IndexedDBs; !reflect.DeepEqual(got, []string{"archive"}) {
+		t.Fatalf("Plugins[service-a].IndexedDBs = %v, want [archive]", got)
+	}
+}
+
+func TestLoadConfigAcceptsLegacyAndCanonicalProviderFormsWhenKeysDoNotConflict(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+server:
+  providers:
+    indexeddb: main
+  encryptionKey: server-key
+providers:
+  indexeddbs:
+    main:
+      source:
+        path: ./providers/datastore/sqlite
+plugins:
+  service-a:
+    source:
+      path: /tmp/manifest.yaml
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Plugins["service-a"] == nil {
+		t.Fatal("Plugins[service-a] = nil")
+	}
+	if _, indexeddb := mustSelectedProvider(t, cfg, HostProviderKindIndexedDB); indexeddb == nil {
+		t.Fatal("SelectedIndexedDBProvider = nil")
 	}
 }
 
@@ -90,24 +193,27 @@ func TestLoadConfigDefaultsAndEnv(t *testing.T) {
 	}
 
 	path := mustWriteConfigFile(t, `
+server:
+  providers:
+    auth: local
+    indexeddb: sqlite
+  encryptionKey: ${TEST_ENCRYPTION}
 providers:
   auth:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/auth/google
-      version: 1.0.0
-    config:
-      clientId: ${TEST_CLIENT_ID}
-  indexeddbs:
+    local:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/google
+        version: 1.0.0
+      config:
+        clientId: ${TEST_CLIENT_ID}
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
-  plugins:
-    service-a:
-      source:
-        path: /tmp/manifest.yaml
-server:
-  indexeddb: sqlite
-  encryptionKey: ${TEST_ENCRYPTION}
+plugins:
+  service-a:
+    source:
+      path: /tmp/manifest.yaml
 `)
 
 	cfg, err := LoadWithLookup(path, func(key string) (string, bool) {
@@ -121,17 +227,22 @@ server:
 	if cfg.Server.Public.Port != 8080 {
 		t.Fatalf("Server.Public.Port = %d, want 8080", cfg.Server.Public.Port)
 	}
-	if cfg.Providers.Secrets.Source.Builtin != "env" {
-		t.Fatalf("Secrets.Source.Builtin = %q, want env", cfg.Providers.Secrets.Source.Builtin)
+	_, secrets := mustSelectedProvider(t, cfg, HostProviderKindSecrets)
+	if secrets == nil || secrets.Source.Builtin != "env" {
+		if secrets == nil {
+			t.Fatal("SelectedSecretsProvider = nil, want env builtin")
+		}
+		t.Fatalf("Secrets.Source.Builtin = %q, want env", secrets.Source.Builtin)
 	}
 	if cfg.Server.EncryptionKey != "encryption-from-env" {
 		t.Fatalf("Server.EncryptionKey = %q", cfg.Server.EncryptionKey)
 	}
 
-	if cfg.Providers.Auth == nil {
-		t.Fatal("Providers.Auth = nil")
+	_, auth := mustSelectedProvider(t, cfg, HostProviderKindAuth)
+	if auth == nil {
+		t.Fatal("SelectedAuthProvider = nil")
 	}
-	authCfg := mustDecodeNode(t, cfg.Providers.Auth.Config)
+	authCfg := mustDecodeNode(t, auth.Config)
 	if authCfg["clientId"] != "client-from-env" {
 		t.Fatalf("Auth.Config.clientId = %#v", authCfg["clientId"])
 	}
@@ -355,8 +466,11 @@ server:
 			if err != nil {
 				t.Fatalf("ValidateRuntime: %v", err)
 			}
-			if tc.name == "auth disabled is allowed" && !cfg.Providers.Auth.Disabled {
-				t.Fatal("Auth.Disabled = false, want true")
+			if tc.name == "auth disabled is allowed" {
+				_, auth := mustSelectedProvider(t, cfg, HostProviderKindAuth)
+				if auth == nil || !auth.Disabled {
+					t.Fatalf("SelectedAuthProvider = %#v, want disabled auth entry", auth)
+				}
 			}
 		})
 	}
@@ -377,7 +491,7 @@ providers:
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if got := cfg.Providers.Plugins["custom_tool"].SourcePath(); got != filepath.Join(filepath.Dir(path), "manifest.yaml") {
+	if got := cfg.Plugins["custom_tool"].SourcePath(); got != filepath.Join(filepath.Dir(path), "manifest.yaml") {
 		t.Fatalf("unexpected plugin source path: %q", got)
 	}
 }
@@ -720,15 +834,15 @@ func TestLoadConfigPluginIndexedDBBindings(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    indexeddb:
+      - sqlite
+      - archive
 providers:
-  plugins:
-    roadmap:
-      source:
-        path: ./plugin/manifest.yaml
-      indexeddbs:
-        - sqlite
-        - archive
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
@@ -736,7 +850,8 @@ providers:
       source:
         path: ./providers/datastore/archive
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: server-key
 `)
 
@@ -744,7 +859,7 @@ server:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		got := cfg.Providers.Plugins["roadmap"].IndexedDBs
+		got := cfg.Plugins["roadmap"].IndexedDBs
 		want := []string{"sqlite", "archive"}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("Plugins[roadmap].IndexedDBs = %v, want %v", got, want)
@@ -761,14 +876,15 @@ providers:
       source:
         path: ./web/root/manifest.yaml
       path: /app
-      indexeddbs:
+      indexeddb:
         - sqlite
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: server-key
 `)
 
@@ -776,7 +892,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `ui.root.indexeddbs is only supported on providers.plugins.*`) {
+		if !strings.Contains(err.Error(), `ui.root.indexeddb is only supported on plugins.*`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -785,20 +901,21 @@ server:
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
+plugins:
+  datadog:
+    source:
+      path: ./plugin/manifest.yaml
+    surfaces:
+      openapi:
+        baseUrl: https://api.us5.datadoghq.com
 providers:
-  plugins:
-    datadog:
-      source:
-        path: ./plugin/manifest.yaml
-      surfaces:
-        openapi:
-          baseUrl: https://api.us5.datadoghq.com
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: server-key
   `)
 
@@ -806,10 +923,10 @@ server:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		if cfg.Providers.Plugins["datadog"].Surfaces == nil || cfg.Providers.Plugins["datadog"].Surfaces.OpenAPI == nil {
+		if cfg.Plugins["datadog"].Surfaces == nil || cfg.Plugins["datadog"].Surfaces.OpenAPI == nil {
 			t.Fatal("Plugins[datadog].Surfaces.OpenAPI is nil")
 		}
-		if got := cfg.Providers.Plugins["datadog"].Surfaces.OpenAPI.BaseURL; got != "https://api.us5.datadoghq.com" {
+		if got := cfg.Plugins["datadog"].Surfaces.OpenAPI.BaseURL; got != "https://api.us5.datadoghq.com" {
 			t.Fatalf("Plugins[datadog].Surfaces.OpenAPI.BaseURL = %q, want %q", got, "https://api.us5.datadoghq.com")
 		}
 	})
@@ -827,12 +944,13 @@ providers:
       surfaces:
         mcp:
           url: https://mcp.example.test
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: server-key
 `)
 
@@ -840,7 +958,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `ui.root.surfaces is only supported on providers.plugins.*`) {
+		if !strings.Contains(err.Error(), `ui.root.surfaces is only supported on plugins.*`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -849,20 +967,21 @@ server:
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    indexeddb:
+      - sqlite
+      - missing
 providers:
-  plugins:
-    roadmap:
-      source:
-        path: ./plugin/manifest.yaml
-      indexeddbs:
-        - sqlite
-        - missing
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: server-key
 `)
 
@@ -870,7 +989,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `plugin "roadmap" indexeddbs[1] references unknown indexeddb "missing"`) {
+		if !strings.Contains(err.Error(), `plugin "roadmap" indexeddb[1] references unknown indexeddb "missing"`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -879,15 +998,15 @@ server:
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    indexeddb:
+      - main-db
+      - main_db
 providers:
-  plugins:
-    roadmap:
-      source:
-        path: ./plugin/manifest.yaml
-      indexeddbs:
-        - main-db
-        - main_db
-  indexeddbs:
+  indexeddb:
     main-db:
       source:
         path: ./providers/datastore/main-db
@@ -895,7 +1014,8 @@ providers:
       source:
         path: ./providers/datastore/main_db
 server:
-  indexeddb: main-db
+  providers:
+    indexeddb: main-db
   encryptionKey: server-key
 `)
 
@@ -903,7 +1023,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `plugin "roadmap" indexeddbs[1] "main_db" conflicts with "main-db" after IndexedDB env normalization (GESTALT_INDEXEDDB_SOCKET_MAIN_DB)`) {
+		if !strings.Contains(err.Error(), `plugin "roadmap" indexeddb[1] "main_db" conflicts with "main-db" after IndexedDB env normalization (GESTALT_INDEXEDDB_SOCKET_MAIN_DB)`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -922,7 +1042,8 @@ func TestLoadRejectsUnknownProviderFields(t *testing.T) {
 			yaml: `
 providers:
   secrets:
-    provider: none
+    primary:
+      provider: none
 `,
 			wantErr: `field provider not found`,
 		},
@@ -931,7 +1052,8 @@ providers:
 			yaml: `
 providers:
   telemetry:
-    builtin: stdout
+    primary:
+      builtin: stdout
 `,
 			wantErr: `field builtin not found`,
 		},
@@ -1022,6 +1144,56 @@ providers:
 server:
   egress:
     defaultAction: block
+`,
+		},
+		{
+			name: "server indexeddb selector cannot use legacy and canonical keys together",
+			yaml: `
+server:
+  indexeddb: legacy
+  providers:
+    indexeddb: canonical
+`,
+		},
+		{
+			name: "indexeddb collection cannot use legacy and canonical keys together",
+			yaml: `
+providers:
+  indexeddbs:
+    legacy:
+      source:
+        path: ./legacy/manifest.yaml
+  indexeddb:
+    canonical:
+      source:
+        path: ./canonical/manifest.yaml
+`,
+		},
+		{
+			name: "plugins cannot use legacy and canonical keys together",
+			yaml: `
+providers:
+  plugins:
+    legacy:
+      source:
+        path: ./legacy/manifest.yaml
+plugins:
+  canonical:
+    source:
+      path: ./canonical/manifest.yaml
+`,
+		},
+		{
+			name: "multiple auth providers require selection or default",
+			yaml: `
+providers:
+  auth:
+    one:
+      source:
+        path: ./one/manifest.yaml
+    two:
+      source:
+        path: ./two/manifest.yaml
 `,
 		},
 	}
@@ -1269,30 +1441,24 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 		{
 			name: "local source valid",
 			cfg: &Config{
-				Providers: ProvidersConfig{
-					Plugins: map[string]*ProviderEntry{
-						"sample": {Source: ProviderSource{Path: "./some-dir/manifest.yaml"}},
-					},
+				Plugins: map[string]*ProviderEntry{
+					"sample": {Source: ProviderSource{Path: "./some-dir/manifest.yaml"}},
 				},
 			},
 		},
 		{
 			name: "source valid",
 			cfg: &Config{
-				Providers: ProvidersConfig{
-					Plugins: map[string]*ProviderEntry{
-						"sample": {Source: ProviderSource{Ref: "github.com/test-org/test-repo/test-plugin", Version: "1.0.0"}},
-					},
+				Plugins: map[string]*ProviderEntry{
+					"sample": {Source: ProviderSource{Ref: "github.com/test-org/test-repo/test-plugin", Version: "1.0.0"}},
 				},
 			},
 		},
 		{
 			name: "source path and ref rejected",
 			cfg: &Config{
-				Providers: ProvidersConfig{
-					Plugins: map[string]*ProviderEntry{
-						"sample": {Source: ProviderSource{Path: "./manifest.yaml", Ref: "github.com/test-org/test-repo/test-plugin", Version: "1.0.0"}},
-					},
+				Plugins: map[string]*ProviderEntry{
+					"sample": {Source: ProviderSource{Path: "./manifest.yaml", Ref: "github.com/test-org/test-repo/test-plugin", Version: "1.0.0"}},
 				},
 			},
 			wantErr: "mutually exclusive",
@@ -1300,10 +1466,8 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 		{
 			name: "nil plugin rejected",
 			cfg: &Config{
-				Providers: ProvidersConfig{
-					Plugins: map[string]*ProviderEntry{
-						"sample": {},
-					},
+				Plugins: map[string]*ProviderEntry{
+					"sample": {},
 				},
 			},
 			wantErr: "source.path or source.ref is required",
@@ -1311,10 +1475,8 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 		{
 			name: "source without version rejected",
 			cfg: &Config{
-				Providers: ProvidersConfig{
-					Plugins: map[string]*ProviderEntry{
-						"sample": {Source: ProviderSource{Ref: "github.com/test-org/test-repo/test-plugin"}},
-					},
+				Plugins: map[string]*ProviderEntry{
+					"sample": {Source: ProviderSource{Ref: "github.com/test-org/test-repo/test-plugin"}},
 				},
 			},
 			wantErr: "source.version is required when source.ref is set",
@@ -1322,10 +1484,8 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 		{
 			name: "source version without ref rejected",
 			cfg: &Config{
-				Providers: ProvidersConfig{
-					Plugins: map[string]*ProviderEntry{
-						"sample": {Source: ProviderSource{Version: "1.0.0"}},
-					},
+				Plugins: map[string]*ProviderEntry{
+					"sample": {Source: ProviderSource{Version: "1.0.0"}},
 				},
 			},
 			wantErr: "source.path or source.ref is required",
@@ -1334,7 +1494,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 			name: "auth provider valid",
 			cfg: &Config{
 				Providers: ProvidersConfig{
-					Auth: &ProviderEntry{Source: ProviderSource{Ref: "github.com/test-org/test-repo/test-auth", Version: "1.0.0"}},
+					Auth: singletonProviderEntry(&ProviderEntry{Source: ProviderSource{Ref: "github.com/test-org/test-repo/test-auth", Version: "1.0.0"}}),
 				},
 			},
 		},
@@ -1346,7 +1506,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 			name: "auth provider invalid when source missing",
 			cfg: &Config{
 				Providers: ProvidersConfig{
-					Auth: &ProviderEntry{},
+					Auth: singletonProviderEntry(&ProviderEntry{}),
 				},
 			},
 			wantErr: `source.path or source.ref is required`,
@@ -1355,19 +1515,17 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 			name: "auth config accepted when auth disabled",
 			cfg: &Config{
 				Providers: ProvidersConfig{
-					Auth: &ProviderEntry{Config: yaml.Node{Kind: yaml.MappingNode}, Disabled: true},
+					Auth: singletonProviderEntry(&ProviderEntry{Config: yaml.Node{Kind: yaml.MappingNode}, Disabled: true}),
 				},
 			},
 		},
 		{
 			name: "plugin auth rejects mcp oauth early",
 			cfg: &Config{
-				Providers: ProvidersConfig{
-					Plugins: map[string]*ProviderEntry{
-						"sample": {
-							Source: ProviderSource{Path: "./manifest.yaml"},
-							Auth:   &ConnectionAuthDef{Type: providermanifestv1.AuthTypeMCPOAuth},
-						},
+				Plugins: map[string]*ProviderEntry{
+					"sample": {
+						Source: ProviderSource{Path: "./manifest.yaml"},
+						Auth:   &ConnectionAuthDef{Type: providermanifestv1.AuthTypeMCPOAuth},
 					},
 				},
 			},
@@ -1376,13 +1534,11 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 		{
 			name: "named connection rejects mcp oauth early",
 			cfg: &Config{
-				Providers: ProvidersConfig{
-					Plugins: map[string]*ProviderEntry{
-						"sample": {
-							Source: ProviderSource{Path: "./manifest.yaml"},
-							Connections: map[string]*ConnectionDef{
-								"default": {Auth: ConnectionAuthDef{Type: providermanifestv1.AuthTypeMCPOAuth}},
-							},
+				Plugins: map[string]*ProviderEntry{
+					"sample": {
+						Source: ProviderSource{Path: "./manifest.yaml"},
+						Connections: map[string]*ConnectionDef{
+							"default": {Auth: ConnectionAuthDef{Type: providermanifestv1.AuthTypeMCPOAuth}},
 						},
 					},
 				},
@@ -1453,13 +1609,17 @@ server:
 		t.Fatalf("Load: %v", err)
 	}
 
-	if got := cfg.Providers.Plugins["service-a"].IconFile; got != iconPath {
+	if got := cfg.Plugins["service-a"].IconFile; got != iconPath {
 		t.Fatalf("IconFile = %q, want %q", got, iconPath)
 	}
-	if got := cfg.Providers.Auth.SourcePath(); got != filepath.Join(dir, "auth-plugin", "provider.yaml") {
+	_, auth := mustSelectedProvider(t, cfg, HostProviderKindAuth)
+	if auth == nil {
+		t.Fatal("SelectedAuthProvider = nil")
+	}
+	if got := auth.SourcePath(); got != filepath.Join(dir, "auth-plugin", "provider.yaml") {
 		t.Fatalf("auth plugin source path = %q, want %q", got, filepath.Join(dir, "auth-plugin", "provider.yaml"))
 	}
-	if got := cfg.Providers.Plugins["service-a"].SourcePath(); got != filepath.Join(dir, "bin", "manifest.yaml") {
+	if got := cfg.Plugins["service-a"].SourcePath(); got != filepath.Join(dir, "bin", "manifest.yaml") {
 		t.Fatalf("integration plugin source path = %q, want %q", got, filepath.Join(dir, "bin", "manifest.yaml"))
 	}
 }
@@ -1491,10 +1651,11 @@ server:
 		t.Fatalf("Load: %v", err)
 	}
 
-	if cfg.Providers.Auth == nil {
-		t.Fatal("Providers.Auth = nil")
+	_, auth := mustSelectedProvider(t, cfg, HostProviderKindAuth)
+	if auth == nil {
+		t.Fatal("SelectedAuthProvider = nil")
 	}
-	authCfg := mustDecodeNode(t, cfg.Providers.Auth.Config)
+	authCfg := mustDecodeNode(t, auth.Config)
 	if len(authCfg) != 3 {
 		t.Fatalf("Auth.Config length = %d, want 3", len(authCfg))
 	}
@@ -1586,7 +1747,7 @@ func TestLoad_ResolvesRelativePluginSourcePath(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 
-	entry := loaded.Providers.Plugins["sample"]
+	entry := loaded.Plugins["sample"]
 	if entry == nil {
 		t.Fatal("expected plugin to be loaded")
 	}

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -31,47 +31,21 @@ func ValidateStructure(cfg *Config) error {
 		return err
 	}
 
-	// Validate singleton providers
-	if cfg.Providers.Auth != nil {
-		if cfg.Providers.Auth.Source.IsBuiltin() {
-			return fmt.Errorf("config validation: auth does not support builtin providers; use a provider source reference or omit auth")
-		}
-		if err := validateProviderEntrySource("auth", "auth", cfg.Providers.Auth); err != nil {
+	for _, collection := range []struct {
+		kind    HostProviderKind
+		entries map[string]*ProviderEntry
+	}{
+		{HostProviderKindAuth, cfg.Providers.Auth},
+		{HostProviderKindSecrets, cfg.Providers.Secrets},
+		{HostProviderKindTelemetry, cfg.Providers.Telemetry},
+		{HostProviderKindAudit, cfg.Providers.Audit},
+	} {
+		if err := validateHostProviderEntries(collection.kind, collection.entries); err != nil {
 			return err
 		}
-	}
-	if cfg.Providers.Secrets != nil && !cfg.Providers.Secrets.Disabled && !cfg.Providers.Secrets.Source.IsBuiltin() {
-		if err := validateProviderEntrySource("secrets", "secrets", cfg.Providers.Secrets); err != nil {
+		if _, _, err := cfg.SelectedHostProvider(collection.kind); err != nil {
 			return err
 		}
-	}
-	if cfg.Providers.Telemetry != nil && !cfg.Providers.Telemetry.Disabled && !cfg.Providers.Telemetry.Source.IsBuiltin() {
-		if err := validateProviderEntrySource("telemetry", "telemetry", cfg.Providers.Telemetry); err != nil {
-			return err
-		}
-	}
-	if cfg.Providers.Audit != nil && !cfg.Providers.Audit.Disabled {
-		if cfg.Providers.Audit.Source.IsBuiltin() {
-			if err := validateBuiltinAudit(cfg.Providers.Audit); err != nil {
-				return err
-			}
-		} else {
-			if err := validateProviderEntrySource("audit", "audit", cfg.Providers.Audit); err != nil {
-				return err
-			}
-		}
-	}
-	if err := validatePluginOnlyProviderFields("auth", cfg.Providers.Auth); err != nil {
-		return err
-	}
-	if err := validatePluginOnlyProviderFields("secrets", cfg.Providers.Secrets); err != nil {
-		return err
-	}
-	if err := validatePluginOnlyProviderFields("telemetry", cfg.Providers.Telemetry); err != nil {
-		return err
-	}
-	if err := validatePluginOnlyProviderFields("audit", cfg.Providers.Audit); err != nil {
-		return err
 	}
 	for name, entry := range cfg.Providers.UI {
 		if entry == nil {
@@ -103,9 +77,49 @@ func ValidateStructure(cfg *Config) error {
 	}
 
 	// Validate plugins
-	for name, entry := range cfg.Providers.Plugins {
+	for name, entry := range cfg.Plugins {
 		if err := validatePlugin(cfg, name, entry); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func validateHostProviderEntries(kind HostProviderKind, entries map[string]*ProviderEntry) error {
+	for name, entry := range entries {
+		if entry == nil {
+			return fmt.Errorf("config validation: providers.%s.%s is required", kind, name)
+		}
+		if err := validatePluginOnlyProviderFields("providers."+string(kind)+"."+name, entry); err != nil {
+			return err
+		}
+		switch kind {
+		case HostProviderKindAuth:
+			if entry.Source.IsBuiltin() {
+				return fmt.Errorf("config validation: auth provider %q does not support builtin providers; use a provider source reference or omit auth", name)
+			}
+			if err := validateProviderEntrySource("auth", name, entry); err != nil {
+				return err
+			}
+		case HostProviderKindSecrets, HostProviderKindTelemetry:
+			if !entry.Disabled && !entry.Source.IsBuiltin() {
+				if err := validateProviderEntrySource(string(kind), name, entry); err != nil {
+					return err
+				}
+			}
+		case HostProviderKindAudit:
+			if entry.Disabled {
+				continue
+			}
+			if entry.Source.IsBuiltin() {
+				if err := validateBuiltinAudit(entry); err != nil {
+					return err
+				}
+			} else {
+				if err := validateProviderEntrySource("audit", name, entry); err != nil {
+					return err
+				}
+			}
 		}
 	}
 	return nil
@@ -209,7 +223,7 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 // ValidateResolvedStructure checks integration fields whose support depends on
 // resolved managed plugin manifests.
 func ValidateResolvedStructure(cfg *Config) error {
-	for name, entry := range cfg.Providers.Plugins {
+	for name, entry := range cfg.Plugins {
 		if entry == nil {
 			return fmt.Errorf("config validation: integration %q requires a source", name)
 		}
@@ -223,11 +237,12 @@ func ValidateResolvedStructure(cfg *Config) error {
 // ValidateRuntime checks runtime-only requirements: encryption key plus the
 // required top-level datastore provider.
 func ValidateRuntime(cfg *Config) error {
-	if cfg.Server.IndexedDB == "" {
-		return fmt.Errorf("config validation: server.indexeddb is required (set server.indexeddb referencing a providers.indexeddbs entry)")
+	name, _, err := cfg.SelectedIndexedDBProvider()
+	if err != nil {
+		return err
 	}
-	if _, ok := cfg.Providers.IndexedDBs[cfg.Server.IndexedDB]; !ok {
-		return fmt.Errorf("config validation: server.indexeddb references unknown datastore %q", cfg.Server.IndexedDB)
+	if name == "" {
+		return fmt.Errorf("config validation: server.providers.indexeddb is required (set server.providers.indexeddb or mark one providers.indexeddb entry default: true)")
 	}
 	if cfg.Server.EncryptionKey == "" {
 		return fmt.Errorf("config validation: server.encryption_key is required")
@@ -239,6 +254,9 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry) error {
 	if entry == nil {
 		return fmt.Errorf("config validation: plugin %q requires a source", name)
 	}
+	if entry.Default {
+		return fmt.Errorf("config validation: plugins.%s.default is not supported on plugins", name)
+	}
 	if err := validateProviderEntrySource("plugin", name, entry); err != nil {
 		return err
 	}
@@ -249,21 +267,19 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry) error {
 }
 
 func validateDatastoreConfig(cfg *Config) error {
-	if cfg.Server.IndexedDB != "" {
-		if _, ok := cfg.Providers.IndexedDBs[cfg.Server.IndexedDB]; !ok {
-			return fmt.Errorf("config validation: server.indexeddb references unknown datastore %q", cfg.Server.IndexedDB)
-		}
-	}
-	for name, entry := range cfg.Providers.IndexedDBs {
+	for name, entry := range cfg.Providers.IndexedDB {
 		if entry == nil {
-			return fmt.Errorf("config validation: indexeddbs.%s is required", name)
+			return fmt.Errorf("config validation: providers.indexeddb.%s is required", name)
 		}
-		if err := validatePluginOnlyProviderFields("indexeddbs."+name, entry); err != nil {
+		if err := validatePluginOnlyProviderFields("providers.indexeddb."+name, entry); err != nil {
 			return err
 		}
 		if err := validateProviderEntrySource("indexeddb", name, entry); err != nil {
 			return err
 		}
+	}
+	if _, _, err := cfg.SelectedIndexedDBProvider(); err != nil {
+		return err
 	}
 	return nil
 }
@@ -273,10 +289,10 @@ func validatePluginOnlyProviderFields(subject string, entry *ProviderEntry) erro
 		return nil
 	}
 	if len(entry.IndexedDBs) > 0 {
-		return fmt.Errorf("config validation: %s.indexeddbs is only supported on providers.plugins.*", subject)
+		return fmt.Errorf("config validation: %s.indexeddb is only supported on plugins.*", subject)
 	}
 	if entry.Surfaces != nil {
-		return fmt.Errorf("config validation: %s.surfaces is only supported on providers.plugins.*", subject)
+		return fmt.Errorf("config validation: %s.surfaces is only supported on plugins.*", subject)
 	}
 	return nil
 }
@@ -290,17 +306,17 @@ func validatePluginIndexedDBBindings(cfg *Config, name string, entry *ProviderEn
 	for i, binding := range entry.IndexedDBs {
 		binding = strings.TrimSpace(binding)
 		if binding == "" {
-			return fmt.Errorf("config validation: plugin %q indexeddbs[%d] is required", name, i)
+			return fmt.Errorf("config validation: plugin %q indexeddb[%d] is required", name, i)
 		}
 		if _, exists := seen[binding]; exists {
-			return fmt.Errorf("config validation: plugin %q indexeddbs[%d] duplicates %q", name, i, binding)
+			return fmt.Errorf("config validation: plugin %q indexeddb[%d] duplicates %q", name, i, binding)
 		}
-		if _, ok := cfg.Providers.IndexedDBs[binding]; !ok {
-			return fmt.Errorf("config validation: plugin %q indexeddbs[%d] references unknown indexeddb %q", name, i, binding)
+		if _, ok := cfg.Providers.IndexedDB[binding]; !ok {
+			return fmt.Errorf("config validation: plugin %q indexeddb[%d] references unknown indexeddb %q", name, i, binding)
 		}
 		envName := indexedDBSocketEnv(binding)
 		if otherBinding, exists := envNames[envName]; exists {
-			return fmt.Errorf("config validation: plugin %q indexeddbs[%d] %q conflicts with %q after IndexedDB env normalization (%s)", name, i, binding, otherBinding, envName)
+			return fmt.Errorf("config validation: plugin %q indexeddb[%d] %q conflicts with %q after IndexedDB env normalization (%s)", name, i, binding, otherBinding, envName)
 		}
 		seen[binding] = struct{}{}
 		envNames[envName] = binding

--- a/gestaltd/internal/config/provider_selection.go
+++ b/gestaltd/internal/config/provider_selection.go
@@ -1,0 +1,151 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func (c *Config) SyncCompatFields() {
+	if c == nil {
+		return
+	}
+	if c.Plugins == nil && c.Providers.Plugins != nil {
+		c.Plugins = c.Providers.Plugins
+	}
+	if c.Providers.Plugins == nil && c.Plugins != nil {
+		c.Providers.Plugins = c.Plugins
+	}
+	if c.Providers.IndexedDB == nil && c.Providers.IndexedDBs != nil {
+		c.Providers.IndexedDB = c.Providers.IndexedDBs
+	}
+	if c.Providers.IndexedDBs == nil && c.Providers.IndexedDB != nil {
+		c.Providers.IndexedDBs = c.Providers.IndexedDB
+	}
+	if c.Server.Providers.IndexedDB == "" && c.Server.IndexedDB != "" {
+		c.Server.Providers.IndexedDB = c.Server.IndexedDB
+	}
+	if c.Server.IndexedDB == "" && c.Server.Providers.IndexedDB != "" {
+		c.Server.IndexedDB = c.Server.Providers.IndexedDB
+	}
+}
+
+func (s ServerProvidersConfig) Selection(kind HostProviderKind) string {
+	switch kind {
+	case HostProviderKindAuth:
+		return s.Auth
+	case HostProviderKindSecrets:
+		return s.Secrets
+	case HostProviderKindTelemetry:
+		return s.Telemetry
+	case HostProviderKindAudit:
+		return s.Audit
+	case HostProviderKindIndexedDB:
+		return s.IndexedDB
+	default:
+		return ""
+	}
+}
+
+func (c *Config) HostProviderEntries(kind HostProviderKind) map[string]*ProviderEntry {
+	if c == nil {
+		return nil
+	}
+	c.SyncCompatFields()
+	switch kind {
+	case HostProviderKindAuth:
+		return c.Providers.Auth
+	case HostProviderKindSecrets:
+		return c.Providers.Secrets
+	case HostProviderKindTelemetry:
+		return c.Providers.Telemetry
+	case HostProviderKindAudit:
+		return c.Providers.Audit
+	case HostProviderKindIndexedDB:
+		return c.Providers.IndexedDB
+	default:
+		return nil
+	}
+}
+
+func (c *Config) SelectedHostProvider(kind HostProviderKind) (string, *ProviderEntry, error) {
+	c.SyncCompatFields()
+	return ResolveSelectedHostProvider(kind, c.Server.Providers.Selection(kind), c.HostProviderEntries(kind))
+}
+
+func (c *Config) SelectedAuthProvider() (string, *ProviderEntry, error) {
+	return c.SelectedHostProvider(HostProviderKindAuth)
+}
+
+func (c *Config) SelectedSecretsProvider() (string, *ProviderEntry, error) {
+	return c.SelectedHostProvider(HostProviderKindSecrets)
+}
+
+func (c *Config) SelectedTelemetryProvider() (string, *ProviderEntry, error) {
+	return c.SelectedHostProvider(HostProviderKindTelemetry)
+}
+
+func (c *Config) SelectedAuditProvider() (string, *ProviderEntry, error) {
+	return c.SelectedHostProvider(HostProviderKindAudit)
+}
+
+func (c *Config) SelectedIndexedDBProvider() (string, *ProviderEntry, error) {
+	return c.SelectedHostProvider(HostProviderKindIndexedDB)
+}
+
+func ResolveSelectedHostProvider(kind HostProviderKind, explicit string, entries map[string]*ProviderEntry) (string, *ProviderEntry, error) {
+	if len(entries) == 0 {
+		return "", nil, nil
+	}
+	explicit = strings.TrimSpace(explicit)
+	if explicit != "" {
+		entry, ok := entries[explicit]
+		if !ok || entry == nil {
+			return "", nil, fmt.Errorf("config validation: server.providers.%s references unknown provider %q", kind, explicit)
+		}
+		if entry.Disabled {
+			return "", nil, fmt.Errorf("config validation: server.providers.%s references disabled provider %q", kind, explicit)
+		}
+		return explicit, entry, nil
+	}
+
+	allNames := make([]string, 0, len(entries))
+	enabledNames := make([]string, 0, len(entries))
+	defaultNames := make([]string, 0, len(entries))
+	for name, entry := range entries {
+		if entry == nil {
+			continue
+		}
+		allNames = append(allNames, name)
+		if entry.Default {
+			defaultNames = append(defaultNames, name)
+		}
+		if entry.Disabled {
+			continue
+		}
+		enabledNames = append(enabledNames, name)
+	}
+
+	switch {
+	case len(defaultNames) == 1:
+		name := defaultNames[0]
+		if entries[name].Disabled {
+			return "", nil, fmt.Errorf("config validation: providers.%s.%s cannot be both default and disabled", kind, name)
+		}
+		return name, entries[name], nil
+	case len(defaultNames) > 1:
+		sort.Strings(defaultNames)
+		return "", nil, fmt.Errorf("config validation: providers.%s declares multiple defaults: %s", kind, strings.Join(defaultNames, ", "))
+	case len(enabledNames) == 1:
+		name := enabledNames[0]
+		return name, entries[name], nil
+	case len(allNames) == 1:
+		name := allNames[0]
+		return name, entries[name], nil
+	case len(enabledNames) == 0:
+		return "", nil, nil
+	default:
+		sort.Strings(enabledNames)
+		return "", nil, fmt.Errorf("config validation: providers.%s has multiple enabled providers but no selection or default: %s", kind, strings.Join(enabledNames, ", "))
+	}
+}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
@@ -31,7 +30,7 @@ const (
 	PreparedTelemetryDir = ".gestaltd/telemetry"
 	PreparedAuditDir     = ".gestaltd/audit"
 	PreparedUIDir        = ".gestaltd/ui"
-	LockVersion          = 5
+	LockVersion          = 6
 
 	platformKeyGeneric = "generic"
 )
@@ -39,11 +38,11 @@ const (
 type Lockfile struct {
 	Version    int                          `json:"version"`
 	Providers  map[string]LockProviderEntry `json:"providers"`
-	Auth       *LockEntry                   `json:"auth,omitempty"`
+	Auth       map[string]LockEntry         `json:"auth,omitempty"`
 	IndexedDBs map[string]LockEntry         `json:"indexeddbs,omitempty"`
-	Secrets    *LockEntry                   `json:"secrets,omitempty"`
-	Telemetry  *LockEntry                   `json:"telemetry,omitempty"`
-	Audit      *LockEntry                   `json:"audit,omitempty"`
+	Secrets    map[string]LockEntry         `json:"secrets,omitempty"`
+	Telemetry  map[string]LockEntry         `json:"telemetry,omitempty"`
+	Audit      map[string]LockEntry         `json:"audit,omitempty"`
 	UIs        map[string]LockUIEntry       `json:"ui,omitempty"`
 }
 
@@ -122,7 +121,7 @@ func (l *Lifecycle) initAtPath(configPath, artifactsDir string) (*Lockfile, *con
 		return nil, nil, fmt.Errorf("loading config: %v", err)
 	}
 	paths := initPathsForConfigWithArtifactsDir(configPath, resolveArtifactsDir(configPath, cfg, artifactsDir))
-	secretsEntry, err := l.primeSecretsProviderForConfigResolution(context.Background(), paths, cfg, nil)
+	secretsEntries, err := l.primeSecretsProviderForConfigResolution(context.Background(), paths, cfg, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -136,7 +135,11 @@ func (l *Lifecycle) initAtPath(configPath, artifactsDir string) (*Lockfile, *con
 	lock := &Lockfile{
 		Version:    LockVersion,
 		Providers:  make(map[string]LockProviderEntry),
+		Auth:       make(map[string]LockEntry),
 		IndexedDBs: make(map[string]LockEntry),
+		Secrets:    make(map[string]LockEntry),
+		Telemetry:  make(map[string]LockEntry),
+		Audit:      make(map[string]LockEntry),
 		UIs:        make(map[string]LockUIEntry),
 	}
 
@@ -147,33 +150,30 @@ func (l *Lifecycle) initAtPath(configPath, artifactsDir string) (*Lockfile, *con
 	for name := range resolvedProviders {
 		lock.Providers[name] = resolvedProviders[name]
 	}
-	if cfg.Providers.Auth != nil && cfg.Providers.Auth.HasManagedSource() {
-		entry, err := l.writeComponentArtifact(context.Background(), paths, providermanifestv1.KindAuth, "auth", authDestDir(paths), cfg.Providers.Auth, cfg.Providers.Auth.Config)
-		if err != nil {
-			return nil, nil, err
+	for _, collection := range hostProviderCollections(cfg) {
+		for name, entry := range collection.entries {
+			if entry == nil || !entry.HasManagedSource() {
+				continue
+			}
+			if collection.kind == config.HostProviderKindSecrets {
+				if _, alreadyPrepared := secretsEntries[name]; alreadyPrepared {
+					continue
+				}
+			}
+			destDir := componentDestDir(paths, collection.kind, name)
+			lockEntry, err := l.writeComponentArtifact(context.Background(), paths, providerManifestKind(collection.kind), name, destDir, entry, entry.Config)
+			if err != nil {
+				return nil, nil, err
+			}
+			lockEntriesForKind(lock, collection.kind)[name] = lockEntry
 		}
-		lock.Auth = &entry
 	}
-	if secretsEntry != nil {
-		lock.Secrets = secretsEntry
+	for name, lockEntry := range secretsEntries {
+		lock.Secrets[name] = lockEntry
 	}
-	if cfg.Providers.Telemetry != nil && cfg.Providers.Telemetry.HasManagedSource() {
-		entry, err := l.writeComponentArtifact(context.Background(), paths, providermanifestv1.KindPlugin, "telemetry", telemetryDestDir(paths), cfg.Providers.Telemetry, cfg.Providers.Telemetry.Config)
-		if err != nil {
-			return nil, nil, err
-		}
-		lock.Telemetry = &entry
-	}
-	if cfg.Providers.Audit != nil && cfg.Providers.Audit.HasManagedSource() {
-		entry, err := l.writeComponentArtifact(context.Background(), paths, providermanifestv1.KindPlugin, "audit", auditDestDir(paths), cfg.Providers.Audit, cfg.Providers.Audit.Config)
-		if err != nil {
-			return nil, nil, err
-		}
-		lock.Audit = &entry
-	}
-	for name, def := range cfg.Providers.IndexedDBs {
+	for name, def := range cfg.Providers.IndexedDB {
 		if def != nil && def.HasManagedSource() {
-			entry, err := l.writeComponentArtifact(context.Background(), paths, providermanifestv1.KindIndexedDB, "indexeddb-"+name, indexeddbDestDir(paths, name), def, def.Config)
+			entry, err := l.writeComponentArtifact(context.Background(), paths, providermanifestv1.KindIndexedDB, name, indexeddbDestDir(paths, name), def, def.Config)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -200,24 +200,26 @@ func (l *Lifecycle) initAtPath(configPath, artifactsDir string) (*Lockfile, *con
 		return nil, nil, err
 	}
 
-	slog.Info("prepared locked artifacts", "providers", len(lock.Providers), "auth", lock.Auth != nil, "indexeddbs", len(lock.IndexedDBs), "secrets", lock.Secrets != nil, "telemetry", lock.Telemetry != nil, "audit", lock.Audit != nil, "uis", len(lock.UIs))
+	slog.Info("prepared locked artifacts", "providers", len(lock.Providers), "auth", len(lock.Auth), "indexeddbs", len(lock.IndexedDBs), "secrets", len(lock.Secrets), "telemetry", len(lock.Telemetry), "audit", len(lock.Audit), "uis", len(lock.UIs))
 	slog.Info("wrote lockfile", "path", paths.lockfilePath)
 	return lock, cfg, nil
 }
 
 func buildSourceTokenMap(cfg *config.Config) map[string]string {
 	tokens := make(map[string]string)
-	for _, entry := range cfg.Providers.Plugins {
+	for _, entry := range cfg.Plugins {
 		if entry != nil && entry.Source.Auth != nil {
 			tokens[entry.SourceRef()] = entry.Source.Auth.Token
 		}
 	}
-	for _, p := range []*config.ProviderEntry{cfg.Providers.Auth, cfg.Providers.Secrets, cfg.Providers.Telemetry, cfg.Providers.Audit} {
-		if p != nil && p.Source.Auth != nil {
-			tokens[p.SourceRef()] = p.Source.Auth.Token
+	for _, collection := range hostProviderCollections(cfg) {
+		for _, entry := range collection.entries {
+			if entry != nil && entry.Source.Auth != nil {
+				tokens[entry.SourceRef()] = entry.Source.Auth.Token
+			}
 		}
 	}
-	for _, def := range cfg.Providers.IndexedDBs {
+	for _, def := range cfg.Providers.IndexedDB {
 		if def != nil && def.Source.Auth != nil {
 			tokens[def.SourceRef()] = def.Source.Auth.Token
 		}
@@ -285,7 +287,14 @@ func (l *Lifecycle) resolveConfigSecrets(ctx context.Context, cfg *config.Config
 }
 
 func (l *Lifecycle) lockForSecretsBootstrap(configPath, artifactsDir string, paths initPaths, cfg *config.Config, locked bool) (*Lockfile, error) {
-	if cfg == nil || cfg.Providers.Secrets == nil || !cfg.Providers.Secrets.HasManagedSource() {
+	if cfg == nil {
+		return nil, nil
+	}
+	_, provider, err := cfg.SelectedSecretsProvider()
+	if err != nil {
+		return nil, err
+	}
+	if provider == nil || !provider.HasManagedSource() {
 		return nil, nil
 	}
 	if !configHasManagedProviderSources(cfg) {
@@ -302,35 +311,42 @@ func (l *Lifecycle) lockForSecretsBootstrap(configPath, artifactsDir string, pat
 	return lock, nil
 }
 
-func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context, paths initPaths, cfg *config.Config, lock *Lockfile) (*LockEntry, error) {
-	if cfg == nil || cfg.Providers.Secrets == nil {
+func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context, paths initPaths, cfg *config.Config, lock *Lockfile) (map[string]LockEntry, error) {
+	if cfg == nil {
 		return nil, nil
 	}
+	name, provider, err := cfg.SelectedSecretsProvider()
+	if err != nil || provider == nil {
+		return nil, err
+	}
 
-	provider := cfg.Providers.Secrets
-	configMap, err := config.NodeToMap(cfg.Providers.Secrets.Config)
+	configMap, err := config.NodeToMap(provider.Config)
 	if err != nil {
-		return nil, fmt.Errorf("decode provider config for %s %q: %w", providermanifestv1.KindSecrets, "secrets", err)
+		return nil, fmt.Errorf("decode provider config for %s %q: %w", providermanifestv1.KindSecrets, name, err)
 	}
 
 	switch {
 	case provider.HasManagedSource():
 		if lock != nil {
-			if err := l.applyLockedComponentEntry(paths, lock.Secrets, providermanifestv1.KindSecrets, "secrets", provider, configMap, false); err != nil {
+			lockEntry, ok := lock.Secrets[name]
+			if !ok {
+				return nil, fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", providermanifestv1.KindSecrets, name, paths.configPath)
+			}
+			if err := l.applyLockedComponentEntry(paths, &lockEntry, providermanifestv1.KindSecrets, name, provider, configMap, secretsDestDir(paths, name), false); err != nil {
 				return nil, err
 			}
 			return nil, nil
 		}
-		entry, err := l.writeComponentArtifact(ctx, paths, providermanifestv1.KindSecrets, "secrets", secretsDestDir(paths), provider, cfg.Providers.Secrets.Config)
+		entry, err := l.writeComponentArtifact(ctx, paths, providermanifestv1.KindSecrets, name, secretsDestDir(paths, name), provider, provider.Config)
 		if err != nil {
 			return nil, err
 		}
-		if err := l.applyLockedComponentEntry(paths, &entry, providermanifestv1.KindSecrets, "secrets", provider, configMap, false); err != nil {
+		if err := l.applyLockedComponentEntry(paths, &entry, providermanifestv1.KindSecrets, name, provider, configMap, secretsDestDir(paths, name), false); err != nil {
 			return nil, err
 		}
-		return &entry, nil
+		return map[string]LockEntry{name: entry}, nil
 	case provider.HasLocalSource():
-		if err := applyLocalComponentManifest(providermanifestv1.KindSecrets, "secrets", provider, configMap); err != nil {
+		if err := applyLocalComponentManifest(providermanifestv1.KindSecrets, name, provider, configMap); err != nil {
 			return nil, err
 		}
 	}
@@ -357,15 +373,52 @@ type providerFingerprintInput struct {
 	Version string `json:"version,omitempty"`
 }
 
+func hostProviderCollections(cfg *config.Config) []struct {
+	kind    config.HostProviderKind
+	entries map[string]*config.ProviderEntry
+} {
+	return []struct {
+		kind    config.HostProviderKind
+		entries map[string]*config.ProviderEntry
+	}{
+		{config.HostProviderKindAuth, cfg.Providers.Auth},
+		{config.HostProviderKindSecrets, cfg.Providers.Secrets},
+		{config.HostProviderKindTelemetry, cfg.Providers.Telemetry},
+		{config.HostProviderKindAudit, cfg.Providers.Audit},
+	}
+}
+
+func lockEntriesForKind(lock *Lockfile, kind config.HostProviderKind) map[string]LockEntry {
+	if lock == nil {
+		return nil
+	}
+	switch kind {
+	case config.HostProviderKindAuth:
+		return lock.Auth
+	case config.HostProviderKindSecrets:
+		return lock.Secrets
+	case config.HostProviderKindTelemetry:
+		return lock.Telemetry
+	case config.HostProviderKindAudit:
+		return lock.Audit
+	case config.HostProviderKindIndexedDB:
+		return lock.IndexedDBs
+	default:
+		return nil
+	}
+}
+
 func configHasProviderLoading(cfg *config.Config) bool {
-	for _, entry := range cfg.Providers.Plugins {
+	for _, entry := range cfg.Plugins {
 		if entry.HasManagedSource() || entry.HasLocalSource() {
 			return true
 		}
 	}
-	for _, p := range []*config.ProviderEntry{cfg.Providers.Auth, cfg.Providers.Secrets, cfg.Providers.Telemetry, cfg.Providers.Audit} {
-		if p != nil && (p.HasManagedSource() || p.HasLocalSource()) {
-			return true
+	for _, collection := range hostProviderCollections(cfg) {
+		for _, entry := range collection.entries {
+			if entry != nil && (entry.HasManagedSource() || entry.HasLocalSource()) {
+				return true
+			}
 		}
 	}
 	for _, entry := range cfg.Providers.UI {
@@ -373,7 +426,7 @@ func configHasProviderLoading(cfg *config.Config) bool {
 			return true
 		}
 	}
-	for _, def := range cfg.Providers.IndexedDBs {
+	for _, def := range cfg.Providers.IndexedDB {
 		if def != nil && (def.HasManagedSource() || def.HasLocalSource()) {
 			return true
 		}
@@ -382,14 +435,16 @@ func configHasProviderLoading(cfg *config.Config) bool {
 }
 
 func configHasManagedProviderSources(cfg *config.Config) bool {
-	for _, entry := range cfg.Providers.Plugins {
+	for _, entry := range cfg.Plugins {
 		if entry.HasManagedSource() {
 			return true
 		}
 	}
-	for _, p := range []*config.ProviderEntry{cfg.Providers.Auth, cfg.Providers.Secrets, cfg.Providers.Telemetry, cfg.Providers.Audit} {
-		if p != nil && p.HasManagedSource() {
-			return true
+	for _, collection := range hostProviderCollections(cfg) {
+		for _, entry := range collection.entries {
+			if entry != nil && entry.HasManagedSource() {
+				return true
+			}
 		}
 	}
 	for _, entry := range cfg.Providers.UI {
@@ -397,7 +452,7 @@ func configHasManagedProviderSources(cfg *config.Config) bool {
 			return true
 		}
 	}
-	for _, def := range cfg.Providers.IndexedDBs {
+	for _, def := range cfg.Providers.IndexedDB {
 		if def != nil && def.HasManagedSource() {
 			return true
 		}
@@ -459,24 +514,56 @@ func uiDestDir(paths initPaths, name string) string {
 	return filepath.Join(paths.uiDir, name)
 }
 
-func authDestDir(paths initPaths) string {
-	return paths.authDir
+func authDestDir(paths initPaths, name string) string {
+	return filepath.Join(paths.authDir, name)
 }
 
-func secretsDestDir(paths initPaths) string {
-	return paths.secretsDir
+func secretsDestDir(paths initPaths, name string) string {
+	return filepath.Join(paths.secretsDir, name)
 }
 
-func telemetryDestDir(paths initPaths) string {
-	return paths.telemetryDir
+func telemetryDestDir(paths initPaths, name string) string {
+	return filepath.Join(paths.telemetryDir, name)
 }
 
-func auditDestDir(paths initPaths) string {
-	return paths.auditDir
+func auditDestDir(paths initPaths, name string) string {
+	return filepath.Join(paths.auditDir, name)
 }
 
 func indexeddbDestDir(paths initPaths, name string) string {
 	return filepath.Join(paths.artifactsDir, "indexeddb", name)
+}
+
+func componentDestDir(paths initPaths, kind config.HostProviderKind, name string) string {
+	switch kind {
+	case config.HostProviderKindAuth:
+		return authDestDir(paths, name)
+	case config.HostProviderKindSecrets:
+		return secretsDestDir(paths, name)
+	case config.HostProviderKindTelemetry:
+		return telemetryDestDir(paths, name)
+	case config.HostProviderKindAudit:
+		return auditDestDir(paths, name)
+	case config.HostProviderKindIndexedDB:
+		return indexeddbDestDir(paths, name)
+	default:
+		return ""
+	}
+}
+
+func providerManifestKind(kind config.HostProviderKind) string {
+	switch kind {
+	case config.HostProviderKindAuth:
+		return providermanifestv1.KindAuth
+	case config.HostProviderKindSecrets:
+		return providermanifestv1.KindSecrets
+	case config.HostProviderKindTelemetry, config.HostProviderKindAudit:
+		return providermanifestv1.KindPlugin
+	case config.HostProviderKindIndexedDB:
+		return providermanifestv1.KindIndexedDB
+	default:
+		return ""
+	}
 }
 
 func writeJSONFile(path string, v any) error {
@@ -509,6 +596,18 @@ func ReadLockfile(path string) (*Lockfile, error) {
 	if lock.Providers == nil {
 		lock.Providers = make(map[string]LockProviderEntry)
 	}
+	if lock.Auth == nil {
+		lock.Auth = make(map[string]LockEntry)
+	}
+	if lock.Secrets == nil {
+		lock.Secrets = make(map[string]LockEntry)
+	}
+	if lock.Telemetry == nil {
+		lock.Telemetry = make(map[string]LockEntry)
+	}
+	if lock.Audit == nil {
+		lock.Audit = make(map[string]LockEntry)
+	}
 	if lock.IndexedDBs == nil {
 		lock.IndexedDBs = make(map[string]LockEntry)
 	}
@@ -529,7 +628,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 	if lock == nil || lock.Version != LockVersion {
 		return false
 	}
-	for name, entry := range cfg.Providers.Plugins {
+	for name, entry := range cfg.Plugins {
 		if !entry.HasManagedSource() {
 			continue
 		}
@@ -538,32 +637,24 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 			return false
 		}
 	}
-	if cfg.Providers.Auth != nil && cfg.Providers.Auth.HasManagedSource() {
-		if lock.Auth == nil || !lockEntryMatches(paths, "auth", cfg.Providers.Auth, *lock.Auth, true) {
-			return false
+	for _, collection := range hostProviderCollections(cfg) {
+		lockEntries := lockEntriesForKind(lock, collection.kind)
+		for name, entry := range collection.entries {
+			if entry == nil || !entry.HasManagedSource() {
+				continue
+			}
+			lockEntry, found := lockEntries[name]
+			if !lockEntryMatches(paths, name, entry, lockEntry, found) {
+				return false
+			}
 		}
 	}
-	if cfg.Providers.Secrets != nil && cfg.Providers.Secrets.HasManagedSource() {
-		if lock.Secrets == nil || !lockEntryMatches(paths, "secrets", cfg.Providers.Secrets, *lock.Secrets, true) {
-			return false
-		}
-	}
-	if cfg.Providers.Telemetry != nil && cfg.Providers.Telemetry.HasManagedSource() {
-		if lock.Telemetry == nil || !lockEntryMatches(paths, "telemetry", cfg.Providers.Telemetry, *lock.Telemetry, true) {
-			return false
-		}
-	}
-	if cfg.Providers.Audit != nil && cfg.Providers.Audit.HasManagedSource() {
-		if lock.Audit == nil || !lockEntryMatches(paths, "audit", cfg.Providers.Audit, *lock.Audit, true) {
-			return false
-		}
-	}
-	for name, entry := range cfg.Providers.IndexedDBs {
+	for name, entry := range cfg.Providers.IndexedDB {
 		if entry == nil || !entry.HasManagedSource() {
 			continue
 		}
 		lockEntry, found := lock.IndexedDBs[name]
-		if !lockEntryMatches(paths, "indexeddb-"+name, entry, lockEntry, found) {
+		if !lockEntryMatches(paths, name, entry, lockEntry, found) {
 			return false
 		}
 	}
@@ -706,7 +797,7 @@ func (l *Lifecycle) buildArchivesMap(ctx context.Context, src pluginsource.Sourc
 
 func (l *Lifecycle) writeProviderArtifacts(ctx context.Context, cfg *config.Config, paths initPaths) (map[string]LockProviderEntry, error) {
 	written := make(map[string]LockProviderEntry)
-	for name, entry := range cfg.Providers.Plugins {
+	for name, entry := range cfg.Plugins {
 		if entry == nil {
 			continue
 		}
@@ -943,7 +1034,7 @@ func (l *Lifecycle) applyLockedProviders(configPath, artifactsDir string, cfg *c
 		}
 	}
 
-	for name, entry := range cfg.Providers.Plugins {
+	for name, entry := range cfg.Plugins {
 		if entry == nil {
 			continue
 		}
@@ -969,29 +1060,24 @@ func (l *Lifecycle) applyLockedProviders(configPath, artifactsDir string, cfg *c
 		}
 		entry.IconFile = cmp.Or(entry.IconFile, entry.ResolvedIconFile)
 	}
-	if cfg.Providers.Auth != nil {
-		if err := l.applyComponentProvider(paths, lock, providermanifestv1.KindAuth, "auth", cfg.Providers.Auth, cfg.Providers.Auth.Config, &cfg.Providers.Auth.Config, locked); err != nil {
-			return err
+	for _, collection := range hostProviderCollections(cfg) {
+		lockEntries := lockEntriesForKind(lock, collection.kind)
+		for name, entry := range collection.entries {
+			if entry == nil {
+				continue
+			}
+			if err := l.applyComponentProvider(paths, lockEntries, providerManifestKind(collection.kind), name, entry, entry.Config, &entry.Config, componentDestDir(paths, collection.kind, name), locked); err != nil {
+				return err
+			}
 		}
 	}
-	if cfg.Providers.Secrets != nil {
-		if err := l.applyComponentProvider(paths, lock, providermanifestv1.KindSecrets, "secrets", cfg.Providers.Secrets, cfg.Providers.Secrets.Config, &cfg.Providers.Secrets.Config, locked); err != nil {
-			return err
-		}
+	indexedDBLocks := map[string]LockEntry(nil)
+	if lock != nil {
+		indexedDBLocks = lock.IndexedDBs
 	}
-	if cfg.Providers.Telemetry != nil {
-		if err := l.applyComponentProvider(paths, lock, providermanifestv1.KindPlugin, "telemetry", cfg.Providers.Telemetry, cfg.Providers.Telemetry.Config, &cfg.Providers.Telemetry.Config, locked); err != nil {
-			return err
-		}
-	}
-	if cfg.Providers.Audit != nil {
-		if err := l.applyComponentProvider(paths, lock, providermanifestv1.KindPlugin, "audit", cfg.Providers.Audit, cfg.Providers.Audit.Config, &cfg.Providers.Audit.Config, locked); err != nil {
-			return err
-		}
-	}
-	for name, def := range cfg.Providers.IndexedDBs {
+	for name, def := range cfg.Providers.IndexedDB {
 		if def != nil {
-			if err := l.applyComponentProvider(paths, lock, providermanifestv1.KindIndexedDB, "indexeddb-"+name, def, def.Config, &def.Config, locked); err != nil {
+			if err := l.applyComponentProvider(paths, indexedDBLocks, providermanifestv1.KindIndexedDB, name, def, def.Config, &def.Config, indexeddbDestDir(paths, name), locked); err != nil {
 				return err
 			}
 		}
@@ -1083,7 +1169,7 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths initPaths, lockEntry *LockUI
 	}
 }
 
-func (l *Lifecycle) applyComponentProvider(paths initPaths, lock *Lockfile, kind, name string, provider *config.ProviderEntry, providerConfig yaml.Node, targetNode *yaml.Node, locked bool) error {
+func (l *Lifecycle) applyComponentProvider(paths initPaths, lockEntries map[string]LockEntry, kind, name string, provider *config.ProviderEntry, providerConfig yaml.Node, targetNode *yaml.Node, destDir string, locked bool) error {
 	if provider == nil {
 		return nil
 	}
@@ -1093,28 +1179,14 @@ func (l *Lifecycle) applyComponentProvider(paths initPaths, lock *Lockfile, kind
 	}
 	switch {
 	case provider.HasManagedSource():
-		if lock == nil {
+		if lockEntries == nil {
 			return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", kind, name, paths.configPath)
 		}
-		var entry *LockEntry
-		switch name {
-		case "auth":
-			entry = lock.Auth
-		case "secrets":
-			entry = lock.Secrets
-		case "telemetry":
-			entry = lock.Telemetry
-		case "audit":
-			entry = lock.Audit
-		default:
-			if kind == providermanifestv1.KindIndexedDB && strings.HasPrefix(name, "indexeddb-") {
-				binding := strings.TrimPrefix(name, "indexeddb-")
-				if lockEntry, ok := lock.IndexedDBs[binding]; ok {
-					entry = &lockEntry
-				}
-			}
+		lockEntry, ok := lockEntries[name]
+		if !ok {
+			return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", kind, name, paths.configPath)
 		}
-		if err := l.applyLockedComponentEntry(paths, entry, kind, name, provider, configMap, locked); err != nil {
+		if err := l.applyLockedComponentEntry(paths, &lockEntry, kind, name, provider, configMap, destDir, locked); err != nil {
 			return err
 		}
 	case provider.HasLocalSource():
@@ -1281,7 +1353,7 @@ func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, na
 	return nil
 }
 
-func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry, kind, name string, plugin *config.ProviderEntry, configMap map[string]any, locked bool) error {
+func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry, kind, name string, plugin *config.ProviderEntry, configMap map[string]any, destDir string, locked bool) error {
 	if entry == nil {
 		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", kind, name, paths.configPath)
 	}
@@ -1314,7 +1386,7 @@ func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry,
 		}
 	}
 	if needMaterialize {
-		if err := l.materializeLockedComponent(context.Background(), paths, kind, name, plugin, *entry, locked); err != nil {
+		if err := l.materializeLockedComponent(context.Background(), paths, kind, name, plugin, *entry, destDir, locked); err != nil {
 			return err
 		}
 	}
@@ -1435,7 +1507,7 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPat
 	return nil
 }
 
-func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPaths, kind, name string, plugin *config.ProviderEntry, entry LockEntry, locked bool) error {
+func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPaths, kind, name string, plugin *config.ProviderEntry, entry LockEntry, destDir string, locked bool) error {
 	platform := providerpkg.CurrentPlatformString()
 	archive, _, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {
@@ -1470,21 +1542,7 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 		return fmt.Errorf("locked source provider digest mismatch for %s %q: got %s, want %s", kind, name, download.SHA256Hex, archive.SHA256)
 	}
 
-	var destDir string
-	switch name {
-	case "auth":
-		destDir = authDestDir(paths)
-	case "secrets":
-		destDir = secretsDestDir(paths)
-	case "telemetry":
-		destDir = telemetryDestDir(paths)
-	case "audit":
-		destDir = auditDestDir(paths)
-	default:
-		if kind == providermanifestv1.KindIndexedDB && strings.HasPrefix(name, "indexeddb-") {
-			destDir = indexeddbDestDir(paths, strings.TrimPrefix(name, "indexeddb-"))
-			break
-		}
+	if destDir == "" {
 		return fmt.Errorf("unsupported component %q", name)
 	}
 	if err := os.RemoveAll(destDir); err != nil {
@@ -1571,12 +1629,12 @@ func hashPlatformInEntries(ctx context.Context, lock *Lockfile, platformKey stri
 		}
 		lock.Providers[name] = entry
 	}
-	for _, entry := range []*LockEntry{lock.Auth, lock.Secrets, lock.Telemetry, lock.Audit} {
-		if entry == nil {
-			continue
-		}
-		if err := hashArchiveEntry(ctx, entry, platformKey, tokenForSource); err != nil {
-			return err
+	for _, lockEntries := range []map[string]LockEntry{lock.Auth, lock.Secrets, lock.Telemetry, lock.Audit} {
+		for name, entry := range lockEntries {
+			if err := hashArchiveEntry(ctx, &entry, platformKey, tokenForSource); err != nil {
+				return err
+			}
+			lockEntries[name] = entry
 		}
 	}
 	for name, entry := range lock.IndexedDBs {

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -476,8 +476,8 @@ func TestSourcePluginLoadForExecution(t *testing.T) {
 	if _, err := os.Stat(executablePath); err != nil {
 		t.Fatalf("executable not rehydrated at %s: %v", executablePath, err)
 	}
-	if cfg.Providers.Plugins["gadget"].Command != executablePath {
-		t.Fatalf("plugin command = %q, want %q", cfg.Providers.Plugins["gadget"].Command, executablePath)
+	if cfg.Plugins["gadget"].Command != executablePath {
+		t.Fatalf("plugin command = %q, want %q", cfg.Plugins["gadget"].Command, executablePath)
 	}
 }
 
@@ -567,7 +567,7 @@ func TestSourcePluginLoadForExecution_RehydratesWhenCachedManifestVersionMismatc
 		t.Fatalf("download count during locked rehydration = %d, want 1", got)
 	}
 
-	gotManifest := cfg.Providers.Plugins["gadget"].ResolvedManifest
+	gotManifest := cfg.Plugins["gadget"].ResolvedManifest
 	if gotManifest == nil {
 		t.Fatal("ResolvedManifest is nil")
 	}
@@ -652,13 +652,11 @@ func TestSourceAuthPluginLoadForExecution(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InitAtPath: %v", err)
 	}
-	if lock.Auth == nil {
-		t.Fatal("lock auth entry not found")
+	authLockEntry := mustLockEntryByName(t, lock.Auth, "auth")
+	if authLockEntry.Source != source {
+		t.Fatalf("lock.Auth[auth].Source = %q, want %q", authLockEntry.Source, source)
 	}
-	if lock.Auth.Source != source {
-		t.Fatalf("lock.Auth.Source = %q, want %q", lock.Auth.Source, source)
-	}
-	if lock.Auth.Executable == "" {
+	if authLockEntry.Executable == "" {
 		t.Fatal("lock.Auth.Executable is empty")
 	}
 	if resolver.lastSrc.String() != source {
@@ -694,14 +692,15 @@ func TestSourceAuthPluginLoadForExecution(t *testing.T) {
 		t.Fatalf("download count during locked rehydration = %d, want 1", got)
 	}
 
-	if cfg.Providers.Auth == nil {
+	authProvider := mustSelectedHostProviderEntry(t, cfg, config.HostProviderKindAuth)
+	if authProvider == nil {
 		t.Fatal("auth provider is nil after load")
 	}
-	executablePath := resolveLockPath(artifactsDir, lock.Auth.Executable)
-	if cfg.Providers.Auth.Command != executablePath {
-		t.Fatalf("auth provider command = %q, want %q", cfg.Providers.Auth.Command, executablePath)
+	executablePath := resolveLockPath(artifactsDir, authLockEntry.Executable)
+	if authProvider.Command != executablePath {
+		t.Fatalf("auth provider command = %q, want %q", authProvider.Command, executablePath)
 	}
-	authCfg, err := config.NodeToMap(cfg.Providers.Auth.Config)
+	authCfg, err := config.NodeToMap(authProvider.Config)
 	if err != nil {
 		t.Fatalf("NodeToMap(auth config): %v", err)
 	}
@@ -811,16 +810,16 @@ func TestManagedIndexedDBSourcesLoadForExecutionWithMultipleBindings(t *testing.
 	}
 
 	for _, name := range []string{"main", "archive"} {
-		entry := cfg.Providers.IndexedDBs[name]
+		entry := cfg.Providers.IndexedDB[name]
 		if entry == nil {
-			t.Fatalf("cfg.Providers.IndexedDBs[%q] = nil", name)
+			t.Fatalf("cfg.Providers.IndexedDB[%q] = nil", name)
 		}
 		if entry.ResolvedManifest == nil {
-			t.Fatalf("cfg.Providers.IndexedDBs[%q].ResolvedManifest = nil", name)
+			t.Fatalf("cfg.Providers.IndexedDB[%q].ResolvedManifest = nil", name)
 		}
 		wantCommand := resolveLockPath(artifactsDir, lock.IndexedDBs[name].Executable)
 		if entry.Command != wantCommand {
-			t.Fatalf("cfg.Providers.IndexedDBs[%q].Command = %q, want %q", name, entry.Command, wantCommand)
+			t.Fatalf("cfg.Providers.IndexedDB[%q].Command = %q, want %q", name, entry.Command, wantCommand)
 		}
 	}
 }
@@ -944,12 +943,8 @@ func TestSourceSecretsPluginBootstrapsManagedAuthSourceToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InitAtPath: %v", err)
 	}
-	if lock.Secrets == nil {
-		t.Fatal("lock secrets entry not found")
-	}
-	if lock.Auth == nil {
-		t.Fatal("lock auth entry not found")
-	}
+	secretsLockEntry := mustLockEntryByName(t, lock.Secrets, "secrets")
+	authLockEntry := mustLockEntryByName(t, lock.Auth, "auth")
 	if got := len(resolver.calls); got != 2 {
 		t.Fatalf("resolver calls = %d, want 2", got)
 	}
@@ -989,23 +984,25 @@ func TestSourceSecretsPluginBootstrapsManagedAuthSourceToken(t *testing.T) {
 	if got := authDownloads.Load(); got != 1 {
 		t.Fatalf("auth download count = %d, want 1", got)
 	}
-	if cfg.Providers.Auth == nil || cfg.Providers.Auth.Source.Auth == nil {
-		t.Fatalf("auth provider source auth = %#v", cfg.Providers.Auth)
+	authProvider := mustSelectedHostProviderEntry(t, cfg, config.HostProviderKindAuth)
+	if authProvider == nil || authProvider.Source.Auth == nil {
+		t.Fatalf("auth provider source auth = %#v", authProvider)
 	}
-	if cfg.Providers.Auth.Source.Auth.Token != "ghp_inline_auth_source_token" {
-		t.Fatalf("resolved auth source token = %q, want %q", cfg.Providers.Auth.Source.Auth.Token, "ghp_inline_auth_source_token")
+	if authProvider.Source.Auth.Token != "ghp_inline_auth_source_token" {
+		t.Fatalf("resolved auth source token = %q, want %q", authProvider.Source.Auth.Token, "ghp_inline_auth_source_token")
 	}
 
-	secretsExecutablePath := resolveLockPath(artifactsDir, lock.Secrets.Executable)
-	if cfg.Providers.Secrets == nil {
+	secretsExecutablePath := resolveLockPath(artifactsDir, secretsLockEntry.Executable)
+	secretsProvider := mustSelectedHostProviderEntry(t, cfg, config.HostProviderKindSecrets)
+	if secretsProvider == nil {
 		t.Fatal("secrets provider is nil after load")
 	}
-	if cfg.Providers.Secrets.Command != secretsExecutablePath {
-		t.Fatalf("secrets provider command = %q, want %q", cfg.Providers.Secrets.Command, secretsExecutablePath)
+	if secretsProvider.Command != secretsExecutablePath {
+		t.Fatalf("secrets provider command = %q, want %q", secretsProvider.Command, secretsExecutablePath)
 	}
-	authExecutablePath := resolveLockPath(artifactsDir, lock.Auth.Executable)
-	if cfg.Providers.Auth.Command != authExecutablePath {
-		t.Fatalf("auth provider command = %q, want %q", cfg.Providers.Auth.Command, authExecutablePath)
+	authExecutablePath := resolveLockPath(artifactsDir, authLockEntry.Executable)
+	if authProvider.Command != authExecutablePath {
+		t.Fatalf("auth provider command = %q, want %q", authProvider.Command, authExecutablePath)
 	}
 }
 
@@ -1197,7 +1194,7 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 	if got := assetCount.Load() - assetsBefore; got != 1 {
 		t.Errorf("asset request count during locked load = %d, want 1", got)
 	}
-	if cfg.Providers.Plugins["alpha"].Command != executablePath {
-		t.Errorf("plugin command = %q, want %q", cfg.Providers.Plugins["alpha"].Command, executablePath)
+	if cfg.Plugins["alpha"].Command != executablePath {
+		t.Errorf("plugin command = %q, want %q", cfg.Plugins["alpha"].Command, executablePath)
 	}
 }

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -99,6 +99,24 @@ func requiredIndexedDBConfigYAML(t *testing.T, dir, dbPath string) string {
 	return requiredComponentConfigYAML(t, dir, dbPath)
 }
 
+func mustSelectedHostProviderEntry(t *testing.T, cfg *config.Config, kind config.HostProviderKind) *config.ProviderEntry {
+	t.Helper()
+	_, entry, err := cfg.SelectedHostProvider(kind)
+	if err != nil {
+		t.Fatalf("SelectedHostProvider(%s): %v", kind, err)
+	}
+	return entry
+}
+
+func mustLockEntryByName(t *testing.T, entries map[string]LockEntry, name string) LockEntry {
+	t.Helper()
+	entry, ok := entries[name]
+	if !ok {
+		t.Fatalf("lock entry %q not found in %#v", name, entries)
+	}
+	return entry
+}
+
 func TestLoadForExecutionAtPath_ResolvesLocalManifestPluginWithoutLockfile(t *testing.T) {
 	t.Parallel()
 
@@ -141,7 +159,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalManifestPluginWithoutLockfile(t *te
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
 
-	intg := loaded.Providers.Plugins["example"]
+	intg := loaded.Plugins["example"]
 	if intg.DisplayName != "Local Provider" {
 		t.Fatalf("DisplayName = %q", intg.DisplayName)
 	}
@@ -202,7 +220,7 @@ spec:
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
 
-	intg := loaded.Providers.Plugins["notion"]
+	intg := loaded.Plugins["notion"]
 	if intg == nil || intg.ResolvedManifest == nil || intg.ResolvedManifest.Spec == nil {
 		t.Fatalf("ResolvedManifest = %+v", intg)
 	}
@@ -480,16 +498,17 @@ server:
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
 
-	if loaded.Providers.Auth == nil || loaded.Providers.Auth.ResolvedManifest == nil {
-		t.Fatalf("auth resolved manifest = %+v", loaded.Providers.Auth)
+	authEntry := mustSelectedHostProviderEntry(t, loaded, config.HostProviderKindAuth)
+	if authEntry == nil || authEntry.ResolvedManifest == nil {
+		t.Fatalf("auth resolved manifest = %+v", authEntry)
 	}
-	if loaded.Providers.Auth.Command != authExecutablePath {
-		t.Fatalf("auth command = %q, want %q", loaded.Providers.Auth.Command, authExecutablePath)
+	if authEntry.Command != authExecutablePath {
+		t.Fatalf("auth command = %q, want %q", authEntry.Command, authExecutablePath)
 	}
-	if got := loaded.Providers.Auth.Args; len(got) != 1 || got[0] != "serve-auth" {
+	if got := authEntry.Args; len(got) != 1 || got[0] != "serve-auth" {
 		t.Fatalf("auth args = %v, want [serve-auth]", got)
 	}
-	authCfg := decodeNodeMap(t, loaded.Providers.Auth.Config)
+	authCfg := decodeNodeMap(t, authEntry.Config)
 	if authCfg["command"] != authExecutablePath {
 		t.Fatalf("auth config command = %v, want %q", authCfg["command"], authExecutablePath)
 	}
@@ -563,13 +582,14 @@ server:
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
 
-	if loaded.Providers.Auth == nil || loaded.Providers.Auth.ResolvedManifest == nil {
-		t.Fatalf("auth resolved manifest = %+v", loaded.Providers.Auth)
+	authEntry := mustSelectedHostProviderEntry(t, loaded, config.HostProviderKindAuth)
+	if authEntry == nil || authEntry.ResolvedManifest == nil {
+		t.Fatalf("auth resolved manifest = %+v", authEntry)
 	}
-	if loaded.Providers.Auth.Command != "" {
-		t.Fatalf("auth command = %q, want empty", loaded.Providers.Auth.Command)
+	if authEntry.Command != "" {
+		t.Fatalf("auth command = %q, want empty", authEntry.Command)
 	}
-	authCfg := decodeNodeMap(t, loaded.Providers.Auth.Config)
+	authCfg := decodeNodeMap(t, authEntry.Config)
 	if authCfg["manifestPath"] != authManifestPath {
 		t.Fatalf("auth manifest_path = %v, want %q", authCfg["manifestPath"], authManifestPath)
 	}
@@ -626,7 +646,7 @@ func TestLoadForExecutionAtPath_GeneratesStaticCatalogForLocalSourceHybridPlugin
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
 
-	intg := loaded.Providers.Plugins["example"]
+	intg := loaded.Plugins["example"]
 	if intg == nil || intg.ResolvedManifest == nil {
 		t.Fatalf("ResolvedManifest = %+v", intg)
 	}
@@ -851,7 +871,7 @@ print(json.dumps({
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
 
-	intg := loaded.Providers.Plugins["example"]
+	intg := loaded.Plugins["example"]
 	if intg == nil || intg.ResolvedManifest == nil {
 		t.Fatalf("ResolvedManifest = %+v", intg)
 	}
@@ -1127,14 +1147,14 @@ func TestApplyLockedPlugins_SkipsNilIntegrationPlugins(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load config: %v", err)
 	}
-	loaded.Providers.Plugins["missing"] = &config.ProviderEntry{}
+	loaded.Plugins["missing"] = &config.ProviderEntry{}
 
 	lc := NewLifecycle(nil)
 	if err := lc.applyLockedProviders(cfgPath, "", loaded, false); err != nil {
 		t.Fatalf("applyLockedProviders: %v", err)
 	}
-	if loaded.Providers.Plugins["example"] == nil || loaded.Providers.Plugins["example"].ResolvedManifest == nil {
-		t.Fatalf("ResolvedManifest = %+v", loaded.Providers.Plugins["example"])
+	if loaded.Plugins["example"] == nil || loaded.Plugins["example"].ResolvedManifest == nil {
+		t.Fatalf("ResolvedManifest = %+v", loaded.Plugins["example"])
 	}
 }
 

--- a/gestaltd/internal/operator/localconfig.go
+++ b/gestaltd/internal/operator/localconfig.go
@@ -64,9 +64,10 @@ func defaultManagedConfig(dbPath, encryptionKey string) string {
   public:
     port: 8080
   encryptionKey: %q
-  indexeddb: main
+  providers:
+    indexeddb: main
 providers:
-  indexeddbs:
+  indexeddb:
     main:
       source:
         ref: %s
@@ -74,15 +75,16 @@ providers:
       config:
         dsn: %q
   secrets:
-    source: env
-  plugins:
-    httpbin:
-      displayName: HTTPBin
-      source:
-        ref: %s
-        version: %s
-      allowedHosts:
-        - httpbin.org
+    env:
+      source: env
+plugins:
+  httpbin:
+    displayName: HTTPBin
+    source:
+      ref: %s
+      version: %s
+    allowedHosts:
+      - httpbin.org
 `, encryptionKey, config.DefaultIndexedDBProvider, config.DefaultIndexedDBVersion, "sqlite://"+dbPath, defaultHTTPBinProvider, defaultHTTPBinVersion)
 }
 
@@ -91,18 +93,22 @@ func defaultLocalSourceConfig(providersDir, dbPath, encryptionKey string) string
   public:
     port: 8080
   encryptionKey: %q
-  indexeddb: main
+  providers:
+    indexeddb: main
 providers:
-  indexeddbs:
+  indexeddb:
     main:
       source:
         path: %q
       config:
         dsn: %q
   ui:
-    source:
-      path: %q
+    root:
+      source:
+        path: %q
+      path: /
   secrets:
-    source: env
+    env:
+      source: env
 `, encryptionKey, filepath.Join(providersDir, "indexeddb", "relationaldb", "manifest.yaml"), "sqlite://"+dbPath, filepath.Join(providersDir, "web", "default", "manifest.yaml"))
 }

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -408,6 +408,8 @@ func TestMountedWebUIRoutesHiddenOnManagementProfile(t *testing.T) {
 }
 
 func TestMountedRootWebUIRoutes(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>root-shell</html>"), 0o644); err != nil {
 		t.Fatalf("WriteFile index.html: %v", err)
@@ -497,6 +499,8 @@ func TestMountedRootWebUIRoutes(t *testing.T) {
 }
 
 func TestMountedRootWebUIRoutesHiddenOnManagementProfile(t *testing.T) {
+	t.Parallel()
+
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.RouteProfile = server.RouteProfileManagement
 		cfg.MountedWebUIs = []server.MountedWebUI{{


### PR DESCRIPTION
## Summary
- move plugin configuration from `providers.plugins` to top-level `plugins`
- support named maps for host-managed providers (`auth`, `secrets`, `telemetry`, `audit`, `indexeddb`) plus `server.providers.*` selection/default resolution
- rename YAML `providers.indexeddbs` to `providers.indexeddb` while keeping targeted legacy normalization/compatibility
- update bootstrap, operator, and runtime paths to use the selected host-provider entries
- update existing config, operator, bootstrap, server, and CLI e2e coverage around the canonical shape

## Public Interface

### YAML

```yaml
server:
  providers:
    auth: corp_sso
    secrets: vault
    telemetry: prod
    audit: primary
    indexeddb: main
  encryptionKey: test-key

providers:
  auth:
    corp_sso:
      source:
        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
        version: 0.0.1-alpha.1
      config:
        clientId: example-client-id
    backup_sso:
      default: true
      source:
        path: ./providers/auth/backup/manifest.yaml

  secrets:
    vault:
      source: env
    local:
      default: true
      source:
        path: ./providers/secrets/local/manifest.yaml

  telemetry:
    prod:
      source: stdout

  audit:
    primary:
      source: inherit

  indexeddb:
    main:
      source:
        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
        version: 0.0.1-alpha.2
      config:
        dsn: sqlite:///tmp/gestalt.db
    archive:
      source:
        path: ./providers/indexeddb/archive/manifest.yaml

plugins:
  github:
    source:
      path: ./plugins/github/manifest.yaml
    indexeddb:
      - main
      - archive
```

### Go

```go
type Config struct {
    Server    ServerConfig              `yaml:"server"`
    Providers ProvidersConfig           `yaml:"providers"`
    Plugins   map[string]*ProviderEntry `yaml:"plugins,omitempty"`
}

type ProvidersConfig struct {
    Auth      map[string]*ProviderEntry `yaml:"auth,omitempty"`
    Secrets   map[string]*ProviderEntry `yaml:"secrets,omitempty"`
    Telemetry map[string]*ProviderEntry `yaml:"telemetry,omitempty"`
    Audit     map[string]*ProviderEntry `yaml:"audit,omitempty"`
    UI        map[string]*UIEntry       `yaml:"ui,omitempty"`
    IndexedDB map[string]*ProviderEntry `yaml:"indexeddb,omitempty"`
}

type ServerConfig struct {
    Providers ServerProvidersConfig `yaml:"providers,omitempty"`
}

type ServerProvidersConfig struct {
    Auth      string `yaml:"auth,omitempty"`
    Secrets   string `yaml:"secrets,omitempty"`
    Telemetry string `yaml:"telemetry,omitempty"`
    Audit     string `yaml:"audit,omitempty"`
    IndexedDB string `yaml:"indexeddb,omitempty"`
}
```

### Selection Helpers

```go
authName, authEntry, err := cfg.SelectedHostProvider(config.HostProviderKindAuth)
indexeddbName, indexeddbEntry, err := cfg.SelectedIndexedDBProvider()
```

Selection behavior:
- `server.providers.<kind>` wins when set
- otherwise the sole `default: true` entry wins
- otherwise the sole enabled entry wins
- otherwise config validation fails

## Examples

Pick an explicit auth provider while letting secrets fall back to the default entry:

```yaml
server:
  providers:
    auth: corp_sso
    indexeddb: main

providers:
  auth:
    corp_sso:
      source:
        path: ./providers/auth/corp/manifest.yaml
    backup:
      source:
        path: ./providers/auth/backup/manifest.yaml

  secrets:
    vault:
      default: true
      source: env

  indexeddb:
    main:
      source:
        path: ./providers/indexeddb/main/manifest.yaml
```

Resolve the selected provider in Go:

```go
name, entry, err := cfg.SelectedHostProvider(config.HostProviderKindSecrets)
if err != nil {
    return err
}
fmt.Printf("selected secrets provider: %s (%v)\n", name, entry.Source)
```

## Notes
- this PR keeps the auth runtime singular: multiple auth providers can be configured, but the server still uses the selected/default auth provider instance
- `secret://...` replacement and provider-qualified secret refs are intentionally not in this PR

## Verification
- `golangci-lint run ./...`
- `go test ./internal/config ./internal/operator ./internal/server ./cmd/gestaltd`
- `go test ./...`
- `go build ./...`
