### PR TITLE
Scope plugin IndexedDB bindings by schema and object store

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -29,7 +29,6 @@ providers:
   ui: ...                   # web UI bundle (ProviderEntry)
   indexeddb:                # named storage providers
     <name>: ...             # each is a ProviderEntry
-
 plugins:
   <name>: ...               # each is a ProviderEntry
 ```
@@ -328,7 +327,8 @@ A production deployment with OIDC auth, a GitHub plugin with per-user connection
 server:
   baseUrl: https://gestalt.example.com
   encryptionKey: secret://gestalt-encryption-key
-  indexeddb: main
+  providers:
+    indexeddb: main
 
 providers:
   auth:
@@ -340,7 +340,7 @@ providers:
       clientId: ${OIDC_CLIENT_ID}
       clientSecret: secret://oidc-client-secret
 
-  indexeddbs:
+  indexeddb:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
@@ -348,27 +348,27 @@ providers:
       config:
         dsn: sqlite://./gestalt.db
 
-  plugins:
-    github:
-      displayName: GitHub
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/plugins/github
-        version: 0.0.1-alpha.1
-      surfaces:
-        openapi:
-          baseUrl: https://api.github.com
-      connections:
-        api:
-          mode: user
-          auth:
-            type: bearer
-            credentials:
-              - name: token
-                label: Personal Access Token
-        mcp:
-          mode: user
-          auth:
-            type: mcp_oauth
+plugins:
+  github:
+    displayName: GitHub
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/plugins/github
+      version: 0.0.1-alpha.1
+    surfaces:
+      openapi:
+        baseUrl: https://api.github.com
+    connections:
+      api:
+        mode: user
+        auth:
+          type: bearer
+          credentials:
+            - name: token
+              label: Personal Access Token
+      mcp:
+        mode: user
+        auth:
+          type: mcp_oauth
 ```
 
 ## Minimal config
@@ -381,10 +381,11 @@ server:
     port: 8080
   baseUrl: http://localhost:8080
   encryptionKey: ${GESTALT_ENCRYPTION_KEY}
-  indexeddb: main
+  providers:
+    indexeddb: main
 
 providers:
-  indexeddbs:
+  indexeddb:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb

--- a/docs/content/custom-providers/indexeddb.mdx
+++ b/docs/content/custom-providers/indexeddb.mdx
@@ -230,6 +230,16 @@ You implement the [IndexedDB gRPC service](https://www.w3.org/TR/IndexedDB/#obje
 
 Plugins access the IndexedDB provider through the SDK. The host serves the IndexedDB interface over a gRPC socket, and the SDK wraps it into native types for each language.
 
+When a plugin binds a datastore through `plugins.<name>.indexeddb`, the host now rebuilds
+that provider with a plugin-scoped namespace before exposing it over the SDK
+socket. Plugins still use plain store names like `tasks` or `snapshots`; the
+host applies isolation outside the plugin. For schema-capable backends, that
+means a plugin-specific schema or namespace. For SQLite-backed relationaldb
+bindings, the host falls back to `<indexeddbSchema>_` table prefixes. Other
+IndexedDB providers fall back to transport-level `<indexeddbSchema>_` store
+prefixes. Plugin bindings can also declare `objectStore` allowlists so the host rejects stores
+that were assigned to a different binding.
+
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
@@ -372,14 +382,15 @@ the SDK call makes the store portable across both styles of backend.
 
 ## Config reference
 
-Reference an IndexedDB provider in the `providers.indexeddbs` section, and set `server.indexeddb` to the name of the active provider. For local development, SQLite keeps things simple with a file path:
+Reference an IndexedDB provider in the `providers.indexeddb` section, and set `server.providers.indexeddb` to the name of the active provider. For local development, SQLite keeps things simple with a file path:
 
 ```yaml
 server:
-  indexeddb: main
+  providers:
+    indexeddb: main
 
 providers:
-  indexeddbs:
+  indexeddb:
     main:
       source:
         path: ./relationaldb/manifest.yaml
@@ -391,7 +402,7 @@ For production, use `source.ref` and `version` to reference a published release:
 
 ```yaml
 providers:
-  indexeddbs:
+  indexeddb:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
@@ -402,7 +413,7 @@ providers:
 
 `DATABASE_URL` is a connection string for your database. The RelationalDB provider accepts `postgres://`, `mysql://`, `sqlite://`, and `sqlserver://` prefixes.
 
-Object store names are automatically namespaced per plugin to prevent cross-plugin data access.
+Object store names remain logical inside plugins. The host scopes plugin data by rebuilding schema-capable providers with a plugin-specific schema or namespace, or by applying a `<indexeddbSchema>_` prefix on backends without schema support.
 
 ## What to read next
 

--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -6,7 +6,7 @@ This page covers building custom plugin providers. If you only need to
 configure a published plugin in a Gestalt deployment, use
 [Providers > Plugins](/providers/plugins).
 
-Plugins are one provider kind. Their manifests use a top-level `spec:` block, and deployments reference them under `providers.plugins`. A plugin can define operations as executable code (handled by the provider process), as passthrough surfaces (REST, OpenAPI, GraphQL, or MCP endpoints forwarded by the host), or both.
+Plugins are one provider kind. Their manifests use a top-level `spec:` block, and deployments reference them under `plugins`. A plugin can define operations as executable code (handled by the provider process), as passthrough surfaces (REST, OpenAPI, GraphQL, or MCP endpoints forwarded by the host), or both.
 
 The examples on this page use a Slack plugin as the running example, since it demonstrates most plugin features: OAuth connections, REST passthrough surfaces, executable operations, and MCP.
 
@@ -515,11 +515,10 @@ spec:
 You configure a declarative plugin the same way as any other. Point the config at the manifest, and the declared operations appear in the catalog:
 
 ```yaml
-providers:
-  plugins:
-    slack-readonly:
-      source:
-        path: ./slack-readonly/manifest.yaml
+plugins:
+  slack-readonly:
+    source:
+      path: ./slack-readonly/manifest.yaml
 ```
 
 ```sh
@@ -644,13 +643,12 @@ A Slack plugin could use this to check which Slack workspace the caller is conne
 Point a local config at the source plugin. Gestalt synthesizes the executable wrapper and materializes the catalog automatically:
 
 ```yaml
-providers:
-  plugins:
-    slack:
-      source:
-        path: ./slack/manifest.yaml
-      allowedHosts:
-        - slack.com
+plugins:
+  slack:
+    source:
+      path: ./slack/manifest.yaml
+    allowedHosts:
+      - slack.com
 ```
 
 Start the server and invoke an operation:

--- a/docs/content/custom-providers/releasing.mdx
+++ b/docs/content/custom-providers/releasing.mdx
@@ -217,11 +217,10 @@ binaries during release.
 Use `source.path` to point at the source tree directly. Gestalt synthesizes the executable wrapper and materializes the catalog automatically:
 
 ```yaml
-providers:
-  plugins:
-    my-plugin:
-      source:
-        path: ./plugins/my-plugin/manifest.yaml
+plugins:
+  my-plugin:
+    source:
+      path: ./plugins/my-plugin/manifest.yaml
 ```
 
 UI bundles work the same way:
@@ -240,12 +239,11 @@ providers:
 Reference a published release by source and version:
 
 ```yaml
-providers:
-  plugins:
-    my-plugin:
-      source:
-        ref: github.com/your-org/your-plugins/my-plugin
-        version: 0.0.1-alpha.1
+plugins:
+  my-plugin:
+    source:
+      ref: github.com/your-org/your-plugins/my-plugin
+      version: 0.0.1-alpha.1
 ```
 
 UI bundles use the same pattern under `providers.ui.<name>`:

--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -50,7 +50,7 @@ config:
         issuerUrl: "${OIDC_ISSUER_URL}"
         clientId: "${OIDC_CLIENT_ID}"
         clientSecret: "${OIDC_CLIENT_SECRET}"
-    indexeddbs:
+    indexeddb:
       main:
         source:
           ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
@@ -130,7 +130,7 @@ config:
         clientId: "${OIDC_CLIENT_ID}"
         clientSecret: "${OIDC_CLIENT_SECRET}"
         redirectUrl: "${OIDC_REDIRECT_URL}"
-    indexeddbs:
+    indexeddb:
       main:
         source:
           ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
@@ -178,7 +178,7 @@ Service rather than exposing it on the public ingress.
 
 ## When to enable `pluginInit`
 
-Enable the init container when your config uses `providers.plugins.*.source.ref`, `providers.auth.source.ref`, `providers.indexeddbs.*.source.ref`, or `providers.ui.*.source.ref` and you want that state prepared before the main container starts. The init container copies the rendered config and runs:
+Enable the init container when your config uses `plugins.*.source.ref`, `providers.auth.source.ref`, `providers.indexeddb.*.source.ref`, or `providers.ui.*.source.ref` and you want that state prepared before the main container starts. The init container copies the rendered config and runs:
 
 `/gestaltd init --config /etc/gestalt/config.yaml`
 

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -14,9 +14,9 @@ starts it with the permissions and request context it needs.
 
 | Kind | Purpose | Config location |
 | --- | --- | --- |
-| `plugin` | Tool providers that expose operations over CLI, HTTP API, and MCP | `providers.plugins.<name>` |
+| `plugin` | Tool providers that expose operations over CLI, HTTP API, and MCP | `plugins.<name>` |
 | `auth` | Platform login backends | `providers.auth` |
-| `indexeddb` | Persistent state backends for users, sessions, tokens, and credentials | `providers.indexeddbs.<name>` |
+| `indexeddb` | Persistent state backends for users, sessions, tokens, and credentials | `providers.indexeddb.<name>` |
 | `secrets` | Secret managers that resolve `secret://` references | `providers.secrets` |
 | `webui` | Public UI bundles served under configured path prefixes | `providers.ui` |
 
@@ -41,9 +41,9 @@ The repository is organized by provider type:
 
 | Type | Repository path | Typical config key |
 | --- | --- | --- |
-| Plugins | [`plugins/`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins) | `providers.plugins.<name>` |
+| Plugins | [`plugins/`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins) | `plugins.<name>` |
 | Auth | [`auth/`](https://github.com/valon-technologies/gestalt-providers/tree/main/auth) | `providers.auth` |
-| IndexedDB | [`indexeddb/`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb) | `providers.indexeddbs.<name>` |
+| IndexedDB | [`indexeddb/`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb) | `providers.indexeddb.<name>` |
 | Secrets | [`secrets/`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets) | `providers.secrets` |
 | Web UI bundles | [`web/`](https://github.com/valon-technologies/gestalt-providers/tree/main/web) | `providers.ui` |
 
@@ -53,7 +53,8 @@ Reference the package you want to run, then initialize or start the server:
 
 ```yaml
 server:
-  indexeddb: main
+  providers:
+    indexeddb: main
 
 providers:
   auth:
@@ -65,7 +66,7 @@ providers:
       clientId: ${OIDC_CLIENT_ID}
       clientSecret: secret://oidc-client-secret
 
-  indexeddbs:
+  indexeddb:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
@@ -73,11 +74,11 @@ providers:
       config:
         dsn: ${DATABASE_URL}
 
-  plugins:
-    github:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/plugins/github
-        version: 0.0.1-alpha.1
+plugins:
+  github:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/plugins/github
+      version: 0.0.1-alpha.1
 ```
 
 Run `gestaltd init` when you want to resolve and pin published releases ahead

--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -7,10 +7,17 @@ contract can map cleanly to relational, document, or key-value backends.
 
 ## How IndexedDB providers work
 
-The active datastore is selected by `server.indexeddb`, which points to one of
-the named entries under `providers.indexeddbs`. Gestalt talks to that provider
-through the IndexedDB service contract while keeping plugin state namespaced so
-plugins cannot read or overwrite each other's records directly.
+The active datastore is selected by `server.providers.indexeddb`, which points
+to one of the named entries under `providers.indexeddb`. Gestalt talks to that provider
+through the IndexedDB service contract while keeping plugin state isolated with
+plugin-scoped datastore instances. By default, a plugin binding uses the plugin
+name as its IndexedDB schema; `plugins.<name>.indexeddbSchema` can
+override that namespace. Plugin bindings can also declare `objectStore`
+allowlists so a store like `tasks` is only served through one configured
+binding. With the first-party RelationalDB provider, Postgres, MySQL, and SQL
+Server receive the namespace as `schema` / `namespace`, while SQLite falls back
+to `<schema>_` table prefixes because it has no schema support. Other IndexedDB
+providers fall back to `<schema>_` transport-level store prefixes.
 
 ## First-party IndexedDB providers
 
@@ -29,10 +36,11 @@ For local development, SQLite keeps setup simple:
 
 ```yaml
 server:
-  indexeddb: main
+  providers:
+    indexeddb: main
 
 providers:
-  indexeddbs:
+  indexeddb:
     main:
       source:
         path: ./relationaldb/manifest.yaml
@@ -44,10 +52,11 @@ For production, reference a published release:
 
 ```yaml
 server:
-  indexeddb: main
+  providers:
+    indexeddb: main
 
 providers:
-  indexeddbs:
+  indexeddb:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
@@ -63,7 +72,7 @@ Other first-party IndexedDB providers use their own config blocks:
 
 ```yaml
 providers:
-  indexeddbs:
+  indexeddb:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/dynamodb
@@ -76,7 +85,7 @@ providers:
 
 ```yaml
 providers:
-  indexeddbs:
+  indexeddb:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/mongodb
@@ -88,7 +97,7 @@ providers:
 
 ## Operational notes
 
-- Gestalt needs exactly one active datastore selected by `server.indexeddb`.
+- Gestalt needs exactly one active datastore selected by `server.providers.indexeddb`.
 - Published datastore packages can be prepared with `gestaltd init` just like
   other provider types.
 - Plugins still go through the host's request and auth model; they do not talk

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -1,7 +1,7 @@
 # Plugins
 
 Plugin providers are the packages that expose tools through Gestalt. Operators
-configure them under `providers.plugins`, while the host takes care of catalog
+configure them under `plugins`, while the host takes care of catalog
 loading, token storage, connection management, HTTP routing, and MCP exposure.
 
 ## How plugin providers work
@@ -38,27 +38,25 @@ their package layouts.
 ## Configuring a plugin provider
 
 ```yaml
-providers:
-  plugins:
-    github:
-      displayName: GitHub
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/plugins/github
-        version: 0.0.1-alpha.1
-      config:
-        apiBaseUrl: https://api.github.com
-        clientId: ${GITHUB_CLIENT_ID}
-        clientSecret: secret://github-client-secret
+plugins:
+  github:
+    displayName: GitHub
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/plugins/github
+      version: 0.0.1-alpha.1
+    config:
+      apiBaseUrl: https://api.github.com
+      clientId: ${GITHUB_CLIENT_ID}
+      clientSecret: secret://github-client-secret
 ```
 
 During local development, point at a source manifest instead:
 
 ```yaml
-providers:
-  plugins:
-    support:
-      source:
-        path: ./plugins/support/manifest.yaml
+plugins:
+  support:
+    source:
+      path: ./plugins/support/manifest.yaml
 ```
 
 ## Connections and credentials
@@ -82,28 +80,26 @@ the plugin's `config` block when the provider requires them.
 Use `allowedOperations` to publish only a subset of a large plugin catalog:
 
 ```yaml
-providers:
-  plugins:
-    support:
-      source:
-        ref: github.com/acme/providers/support
-        version: 2.4.0
-      allowedOperations:
-        tickets.list:
-          alias: list_tickets
-        tickets.get:
-          alias: get_ticket
+plugins:
+  support:
+    source:
+      ref: github.com/acme/providers/support
+      version: 2.4.0
+    allowedOperations:
+      tickets.list:
+        alias: list_tickets
+      tickets.get:
+        alias: get_ticket
 ```
 
 Use `allowedHosts` when a plugin needs explicit outbound access:
 
 ```yaml
-providers:
-  plugins:
-    github:
-      allowedHosts:
-        - api.github.com
-        - "*.github.com"
+plugins:
+  github:
+    allowedHosts:
+      - api.github.com
+      - "*.github.com"
 ```
 
 ## Building your own plugin

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -29,14 +29,15 @@ To disable platform auth entirely, omit the `providers.auth` block or set `provi
 
 ## IndexedDB Providers
 
-Datastore providers back the persistent state layer. They are configured under named entries in `providers.indexeddbs`, and `server.indexeddb` selects which one the host uses. Gestalt does not compile datastore drivers into the binary; it starts the configured external datastore provider process at runtime.
+Datastore providers back the persistent state layer. They are configured under named entries in `providers.indexeddb`, and `server.providers.indexeddb` selects which one the host uses. Gestalt does not compile datastore drivers into the binary; it starts the configured external datastore provider process at runtime.
 
 ```yaml
 server:
-  indexeddb: main
+  providers:
+    indexeddb: main
 
 providers:
-  indexeddbs:
+  indexeddb:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
@@ -74,15 +75,14 @@ Telemetry providers are compiled into the binary.
 
 ## Plugins
 
-Plugins (BigQuery, Jira, Slack, and others) are published separately from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). They are configured under `providers.plugins`:
+Plugins (BigQuery, Jira, Slack, and others) are published separately from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). They are configured under `plugins`:
 
 ```yaml
-providers:
-  plugins:
-    jira:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/jira
-        version: 1.0.0
+plugins:
+  jira:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/jira
+      version: 1.0.0
 ```
 
 ## Community and Custom Providers

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -2,7 +2,7 @@ import { Tabs } from 'nextra/components'
 
 # Config File
 
-Every `gestaltd` deployment reads a single YAML config file. The top-level keys are `server` (listener, encryption, egress, and indexeddb selection), `authorization` (shared human/workload access policy), `providers` (auth, secrets, telemetry, audit, mounted UI bundles, and indexeddbs), and `plugins` (executable integrations):
+Every `gestaltd` deployment reads a single YAML config file. The top-level keys are `server` (listener, encryption, egress, and indexeddb selection), `authorization` (shared human/workload access policy), `providers` (auth, secrets, telemetry, audit, mounted UI bundles, and indexeddb), and `plugins` (executable integrations):
 
 ```yaml
 server:
@@ -451,6 +451,12 @@ plugins:
     surfaces:
       openapi:
         baseUrl: https://api.github.com
+    indexeddb:
+      - name: main
+        objectStore:
+          - tasks
+          - snapshots
+    indexeddbSchema: github_plugin
     connections:
       default:
         mode: user
@@ -476,7 +482,8 @@ plugins:
 | `surfaces` | Typed host-side overrides for manifest-declared surfaces, such as `surfaces.openapi.baseUrl` or `surfaces.graphql.url`. |
 | `connections` | Named connection declarations. See [connections](#connections) below. |
 | `allowedOperations` | Allowlist with optional `alias`, `description`, and `allowedRoles` overrides per operation. |
-| `indexeddbs` | Optional list of named `providers.indexeddb` bindings exposed to the executable plugin through the SDK transport. Store names are automatically prefixed per plugin. A single binding also populates the default IndexedDB SDK env var for compatibility. |
+| `indexeddb` | Optional list of plugin IndexedDB bindings. The scalar shorthand `- main` is still supported; the object form accepts `name` plus optional `objectStore` allowlists to pin logical stores to a binding. A given `objectStore` may appear in at most one binding; duplicates are rejected during config validation. When any binding declares `objectStore`, one additional binding may omit it and acts as the catch-all for unassigned stores. Each binding is rebuilt as a plugin-scoped IndexedDB instance before being served to the plugin. A single binding also populates the default IndexedDB SDK env var for compatibility. |
+| `indexeddbSchema` | Optional override for the plugin IndexedDB namespace. When omitted, Gestalt uses the plugin name. RelationalDB bindings pass this through as `schema` / `namespace` on Postgres, MySQL, and SQL Server, use `<indexeddbSchema>_` table prefixes on SQLite, and other IndexedDB backends fall back to `<indexeddbSchema>_` transport-level store prefixes. |
 
 ### `plugins.*.source`
 

--- a/docs/content/security.mdx
+++ b/docs/content/security.mdx
@@ -62,15 +62,14 @@ server:
   egress:
     defaultAction: deny
 
-providers:
-  plugins:
-    my-plugin:
-      source:
-        ref: github.com/acme/plugins/my-plugin
-        version: 1.0.0
-      allowedHosts:
-        - "api.example.com"
-        - "*.slack.com"
+plugins:
+  my-plugin:
+    source:
+      ref: github.com/acme/plugins/my-plugin
+      version: 1.0.0
+    allowedHosts:
+      - "api.example.com"
+      - "*.slack.com"
 ```
 
 Wildcards are supported (`*.example.com` matches `api.example.com`). The same check applies uniformly to REST, GraphQL, and MCP providers.
@@ -94,7 +93,7 @@ Executable plugin providers run with additional OS-level isolation when `allowed
 | `server.baseUrl` | Must match the public URL exactly. OAuth callbacks are derived from it. |
 | TLS termination | Gestalt does not terminate TLS. Deploy behind a reverse proxy that handles TLS. |
 | `providers.secrets` | Use a dedicated secret manager in production. `env` is acceptable but secrets may appear in process listings. |
-| `providers.indexeddbs` and `server.indexeddb` | Use a production-grade datastore provider for multi-replica deployments. SQLite is single-writer and not suitable for multi-replica deployments. |
+| `providers.indexeddb` and `server.providers.indexeddb` | Use a production-grade datastore provider for multi-replica deployments. SQLite is single-writer and not suitable for multi-replica deployments. |
 
 ## Known limitations
 

--- a/docs/content/troubleshooting.mdx
+++ b/docs/content/troubleshooting.mdx
@@ -16,7 +16,7 @@ When `/ready` returns `503`, the server has not finished initialization. Readine
 
 ## Operation invocation
 
-A "provider not found" error means the plugin key in the request does not match any entry in `providers.plugins`. Verify the spelling and confirm the plugin loaded without errors at startup.
+A "provider not found" error means the plugin key in the request does not match any entry in `plugins`. Verify the spelling and confirm the plugin loaded without errors at startup.
 
 An "operation not found" error means the operation ID does not exist in the plugin's catalog. Check that the operation is exposed and that `allowedOperations`, if set, includes it.
 

--- a/gestaltd/core/testing/indexeddb_stub.go
+++ b/gestaltd/core/testing/indexeddb_stub.go
@@ -54,6 +54,16 @@ func (s *StubIndexedDB) DeleteObjectStore(_ context.Context, name string) error 
 func (s *StubIndexedDB) Ping(context.Context) error { return s.Err }
 func (s *StubIndexedDB) Close() error               { return nil }
 
+func (s *StubIndexedDB) HasObjectStore(name string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.stores == nil {
+		return false
+	}
+	_, ok := s.stores[name]
+	return ok
+}
+
 type stubObjectStore struct {
 	db      *StubIndexedDB
 	mu      sync.RWMutex

--- a/gestaltd/deploy/helm/gestalt/values.yaml
+++ b/gestaltd/deploy/helm/gestalt/values.yaml
@@ -89,9 +89,10 @@ config:
     # Set it to your public HTTPS URL when auth callbacks or external
     # integrations need it.
     # baseUrl: "${GESTALT_BASE_URL}"
-    indexeddb: main
+    providers:
+      indexeddb: main
   providers:
-    indexeddbs:
+    indexeddb:
       main:
         # SQLite is appropriate for local development or single-instance
         # deployments with mounted persistent storage at /data.

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -120,12 +120,14 @@ func (m providerMetadata) descriptionOr(v string) string {
 }
 
 type Deps struct {
-	EncryptionKey []byte
-	BaseURL       string
-	SecretManager core.SecretManager
-	Services      *coredata.Services
-	IndexedDBs    map[string]indexeddb.IndexedDB
-	Egress        EgressDeps
+	EncryptionKey    []byte
+	BaseURL          string
+	SecretManager    core.SecretManager
+	Services         *coredata.Services
+	IndexedDBs       map[string]indexeddb.IndexedDB
+	IndexedDBDefs    map[string]*config.ProviderEntry
+	IndexedDBFactory IndexedDBFactory
+	Egress           EgressDeps
 }
 
 type AuthFactory func(node yaml.Node, deps Deps) (core.AuthProvider, error)
@@ -356,6 +358,8 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	deps.Egress = newEgressDeps(cfg)
 	deps.Services = svc
 	deps.IndexedDBs = hostIndexedDBs
+	deps.IndexedDBDefs = cfg.Providers.IndexedDBs
+	deps.IndexedDBFactory = factories.IndexedDB
 
 	closeSM = false
 	shutdownTelemetry = false

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -798,7 +798,7 @@ func TestPluginIndexedDBBindingsExposeHostSocketEnv(t *testing.T) {
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 
-	makeConfig := func(bindings []string) *config.Config {
+	makeConfig := func(bindings []config.PluginIndexedDBBinding) *config.Config {
 		return &config.Config{
 			Providers: config.ProvidersConfig{
 				Plugins: map[string]*config.ProviderEntry{
@@ -814,17 +814,22 @@ func TestPluginIndexedDBBindingsExposeHostSocketEnv(t *testing.T) {
 		}
 	}
 
-	services := coretesting.NewStubServices(t)
-	indexedDBBindings := map[string]indexeddb.IndexedDB{
-		"main":    services.DB,
-		"archive": &coretesting.StubIndexedDB{},
+	indexedDBBindings := map[string]*config.ProviderEntry{
+		"main": {
+			Config: mustNode(t, map[string]any{"dsn": "postgres://main.example.test/gestalt"}),
+		},
+		"archive": {
+			Config: mustNode(t, map[string]any{"dsn": "sqlite://archive.db"}),
+		},
 	}
 
-	checkEnv := func(t *testing.T, bindings []string, envName string) bool {
+	checkEnv := func(t *testing.T, bindings []config.PluginIndexedDBBinding, envName string) bool {
 		t.Helper()
 		providers, _, err := buildProvidersStrict(context.Background(), makeConfig(bindings), NewFactoryRegistry(), Deps{
-			Services:   services,
-			IndexedDBs: indexedDBBindings,
+			IndexedDBDefs: indexedDBBindings,
+			IndexedDBFactory: func(yaml.Node) (indexeddb.IndexedDB, error) {
+				return &coretesting.StubIndexedDB{}, nil
+			},
 		})
 		if err != nil {
 			t.Fatalf("buildProvidersStrict: %v", err)
@@ -852,32 +857,523 @@ func TestPluginIndexedDBBindingsExposeHostSocketEnv(t *testing.T) {
 	if got := checkEnv(t, nil, providerhost.DefaultIndexedDBSocketEnv); got {
 		t.Fatal("default IndexedDB env should not be set without plugin indexeddb bindings")
 	}
-	if got := checkEnv(t, []string{"main"}, providerhost.DefaultIndexedDBSocketEnv); !got {
+	if got := checkEnv(t, []config.PluginIndexedDBBinding{{Name: "main"}}, providerhost.DefaultIndexedDBSocketEnv); !got {
 		t.Fatal("default IndexedDB env should be set with a single plugin indexeddb binding")
 	}
-	if got := checkEnv(t, []string{"main"}, providerhost.IndexedDBSocketEnv("main")); !got {
+	if got := checkEnv(t, []config.PluginIndexedDBBinding{{Name: "main"}}, providerhost.IndexedDBSocketEnv("main")); !got {
 		t.Fatal("named IndexedDB env should be set with a single plugin indexeddb binding")
 	}
-	if got := checkEnv(t, []string{"main", "archive"}, providerhost.DefaultIndexedDBSocketEnv); got {
+	if got := checkEnv(t, []config.PluginIndexedDBBinding{{Name: "main"}, {Name: "archive"}}, providerhost.DefaultIndexedDBSocketEnv); got {
 		t.Fatal("default IndexedDB env should not be set with multiple plugin indexeddb bindings")
 	}
-	if got := checkEnv(t, []string{"main", "archive"}, providerhost.IndexedDBSocketEnv("main")); !got {
+	if got := checkEnv(t, []config.PluginIndexedDBBinding{{Name: "main"}, {Name: "archive"}}, providerhost.IndexedDBSocketEnv("main")); !got {
 		t.Fatal(`named IndexedDB env for "main" should be set with multiple plugin indexeddb bindings`)
 	}
-	if got := checkEnv(t, []string{"main", "archive"}, providerhost.IndexedDBSocketEnv("archive")); !got {
+	if got := checkEnv(t, []config.PluginIndexedDBBinding{{Name: "main"}, {Name: "archive"}}, providerhost.IndexedDBSocketEnv("archive")); !got {
 		t.Fatal(`named IndexedDB env for "archive" should be set with multiple plugin indexeddb bindings`)
 	}
 }
 
-func TestIndexedDBNamespaceUsesProviderName(t *testing.T) {
+func TestPluginIndexedDBBindingsBuildScopedConfig(t *testing.T) {
 	t.Parallel()
 
-	if got := indexedDBNamespace("roadmap-review"); got != "roadmap-review" {
-		t.Fatalf("indexedDBNamespace() = %q, want %q", got, "roadmap-review")
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+
+	type capturedIndexedDBConfig struct {
+		Config map[string]any `yaml:"config"`
 	}
-	if got := indexedDBNamespace("source-backed"); got != "source-backed" {
-		t.Fatalf("indexedDBNamespace() = %q, want %q", got, "source-backed")
+
+	makeConfig := func(schema string) *config.Config {
+		entry := &config.ProviderEntry{
+			Command:              bin,
+			Args:                 []string{"provider"},
+			ResolvedManifest:     manifest,
+			ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+			IndexedDBs: []config.PluginIndexedDBBinding{
+				{Name: "postgres"},
+				{Name: "sqlite"},
+				{Name: "local-postgres"},
+			},
+		}
+		if schema != "" {
+			entry.IndexedDBSchema = schema
+		}
+		return &config.Config{
+			Providers: config.ProvidersConfig{
+				Plugins: map[string]*config.ProviderEntry{
+					"echoext": entry,
+				},
+			},
+		}
 	}
+
+	bindingDefs := map[string]*config.ProviderEntry{
+		"postgres": {
+			Source: config.ProviderSource{Ref: "github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb"},
+			Config: mustNode(t, map[string]any{
+				"dsn":       "postgres://db.example.test/gestalt",
+				"schema":    "host_schema",
+				"namespace": "host_schema",
+			}),
+		},
+		"sqlite": {
+			Source: config.ProviderSource{Ref: "github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb"},
+			Config: mustNode(t, map[string]any{
+				"dsn":          "sqlite://plugin-state.db",
+				"table_prefix": "host_",
+				"prefix":       "host_",
+				"schema":       "should_be_removed",
+				"namespace":    "should_be_removed",
+			}),
+		},
+		"local-postgres": {
+			Source: config.ProviderSource{Path: "./relationaldb/manifest.yaml"},
+			Config: mustNode(t, map[string]any{
+				"dsn":       "postgres://local.example.test/gestalt",
+				"schema":    "host_local",
+				"namespace": "host_local",
+			}),
+		},
+	}
+
+	cases := []struct {
+		name          string
+		schema        string
+		wantNamespace string
+	}{
+		{name: "defaults to plugin name", wantNamespace: "echoext"},
+		{name: "uses plugin override", schema: "roadmap_state", wantNamespace: "roadmap_state"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var closeCount atomic.Int32
+			captured := make(map[string]capturedIndexedDBConfig)
+			providers, _, err := buildProvidersStrict(context.Background(), makeConfig(tc.schema), NewFactoryRegistry(), Deps{
+				IndexedDBDefs: bindingDefs,
+				IndexedDBFactory: func(node yaml.Node) (indexeddb.IndexedDB, error) {
+					var decoded capturedIndexedDBConfig
+					if err := node.Decode(&decoded); err != nil {
+						return nil, err
+					}
+					dsn, _ := decoded.Config["dsn"].(string)
+					captured[dsn] = decoded
+					return &trackedIndexedDB{
+						StubIndexedDB: coretesting.StubIndexedDB{},
+						onClose:       closeCount.Add,
+					}, nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("buildProvidersStrict: %v", err)
+			}
+			t.Cleanup(func() {
+				if providers != nil {
+					_ = CloseProviders(providers)
+				}
+			})
+
+			if got := closeCount.Load(); got != 0 {
+				t.Fatalf("closeCount before provider shutdown = %d, want 0", got)
+			}
+
+			postgresCfg, ok := captured["postgres://db.example.test/gestalt"]
+			if !ok {
+				t.Fatal("missing captured postgres indexeddb config")
+			}
+			if got := postgresCfg.Config["schema"]; got != tc.wantNamespace {
+				t.Fatalf("postgres schema = %#v, want %q", got, tc.wantNamespace)
+			}
+			if got := postgresCfg.Config["namespace"]; got != tc.wantNamespace {
+				t.Fatalf("postgres namespace = %#v, want %q", got, tc.wantNamespace)
+			}
+			if got := postgresCfg.Config["legacy_table_prefix"]; got != "plugin_echoext_" {
+				t.Fatalf("postgres legacy_table_prefix = %#v, want %q", got, "plugin_echoext_")
+			}
+			if got := postgresCfg.Config["legacy_prefix"]; got != "plugin_echoext_" {
+				t.Fatalf("postgres legacy_prefix = %#v, want %q", got, "plugin_echoext_")
+			}
+			if _, ok := postgresCfg.Config["table_prefix"]; ok {
+				t.Fatalf("postgres table_prefix should be removed, got %#v", postgresCfg.Config["table_prefix"])
+			}
+			if _, ok := postgresCfg.Config["prefix"]; ok {
+				t.Fatalf("postgres prefix should be removed, got %#v", postgresCfg.Config["prefix"])
+			}
+
+			localPostgresCfg, ok := captured["postgres://local.example.test/gestalt"]
+			if !ok {
+				t.Fatal("missing captured local postgres indexeddb config")
+			}
+			if got := localPostgresCfg.Config["schema"]; got != tc.wantNamespace {
+				t.Fatalf("local postgres schema = %#v, want %q", got, tc.wantNamespace)
+			}
+			if got := localPostgresCfg.Config["namespace"]; got != tc.wantNamespace {
+				t.Fatalf("local postgres namespace = %#v, want %q", got, tc.wantNamespace)
+			}
+			if got := localPostgresCfg.Config["legacy_table_prefix"]; got != "plugin_echoext_" {
+				t.Fatalf("local postgres legacy_table_prefix = %#v, want %q", got, "plugin_echoext_")
+			}
+			if got := localPostgresCfg.Config["legacy_prefix"]; got != "plugin_echoext_" {
+				t.Fatalf("local postgres legacy_prefix = %#v, want %q", got, "plugin_echoext_")
+			}
+
+			sqliteCfg, ok := captured["sqlite://plugin-state.db"]
+			if !ok {
+				t.Fatal("missing captured sqlite indexeddb config")
+			}
+			wantPrefix := tc.wantNamespace + "_"
+			if got := sqliteCfg.Config["table_prefix"]; got != wantPrefix {
+				t.Fatalf("sqlite table_prefix = %#v, want %q", got, wantPrefix)
+			}
+			if got := sqliteCfg.Config["prefix"]; got != wantPrefix {
+				t.Fatalf("sqlite prefix = %#v, want %q", got, wantPrefix)
+			}
+			if _, ok := sqliteCfg.Config["schema"]; ok {
+				t.Fatalf("sqlite schema should be removed, got %#v", sqliteCfg.Config["schema"])
+			}
+			if _, ok := sqliteCfg.Config["namespace"]; ok {
+				t.Fatalf("sqlite namespace should be removed, got %#v", sqliteCfg.Config["namespace"])
+			}
+			if got := sqliteCfg.Config["legacy_table_prefix"]; got != "plugin_echoext_" {
+				t.Fatalf("sqlite legacy_table_prefix = %#v, want %q", got, "plugin_echoext_")
+			}
+			if got := sqliteCfg.Config["legacy_prefix"]; got != "plugin_echoext_" {
+				t.Fatalf("sqlite legacy_prefix = %#v, want %q", got, "plugin_echoext_")
+			}
+
+			_ = CloseProviders(providers)
+			providers = nil
+			if got := closeCount.Load(); got != 3 {
+				t.Fatalf("closeCount after provider shutdown = %d, want 3", got)
+			}
+		})
+	}
+}
+
+func TestPluginIndexedDBBindingsRouteObjectStoresAndTransportPrefix(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:     "indexeddb_roundtrip",
+				Method: http.MethodPost,
+				Parameters: []catalog.CatalogParameter{
+					{Name: "store", Type: "string", Required: true},
+					{Name: "id", Type: "string", Required: true},
+					{Name: "value", Type: "string", Required: true},
+				},
+			},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+
+	var (
+		closeCount atomic.Int32
+		boundDB    *trackedIndexedDB
+	)
+	providers, _, err := buildProvidersStrict(context.Background(), &config.Config{
+		Providers: config.ProvidersConfig{
+			Plugins: map[string]*config.ProviderEntry{
+				"echoext": {
+					Command:              bin,
+					Args:                 []string{"provider"},
+					ResolvedManifest:     manifest,
+					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+					IndexedDBSchema:      "roadmap",
+					IndexedDBs: []config.PluginIndexedDBBinding{
+						{Name: "memory", ObjectStores: []string{"tasks"}},
+					},
+				},
+			},
+		},
+	}, NewFactoryRegistry(), Deps{
+		IndexedDBDefs: map[string]*config.ProviderEntry{
+			"memory": {
+				Source: config.ProviderSource{Path: "./providers/datastore/memory"},
+				Config: mustNode(t, map[string]any{"bucket": "plugin-state"}),
+			},
+		},
+		IndexedDBFactory: func(yaml.Node) (indexeddb.IndexedDB, error) {
+			boundDB = &trackedIndexedDB{
+				StubIndexedDB: coretesting.StubIndexedDB{},
+				onClose:       closeCount.Add,
+			}
+			return boundDB, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseProviders(providers) })
+
+	prov, err := providers.Get("echoext")
+	if err != nil {
+		t.Fatalf("providers.Get: %v", err)
+	}
+
+	result, err := prov.Execute(context.Background(), "indexeddb_roundtrip", map[string]any{
+		"store": "tasks",
+		"id":    "task-1",
+		"value": "ship-it",
+	}, "")
+	if err != nil {
+		t.Fatalf("Execute indexeddb_roundtrip: %v", err)
+	}
+	var record map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &record); err != nil {
+		t.Fatalf("unmarshal record: %v", err)
+	}
+	if got := record["value"]; got != "ship-it" {
+		t.Fatalf("record value = %#v, want %q", got, "ship-it")
+	}
+	if _, err := boundDB.ObjectStore("roadmap_tasks").Get(context.Background(), "task-1"); err != nil {
+		t.Fatalf("prefixed backing store should contain task: %v", err)
+	}
+	if _, err := boundDB.ObjectStore("tasks").Get(context.Background(), "task-1"); err == nil {
+		t.Fatal("unprefixed backing store should remain empty")
+	}
+
+	if _, err := prov.Execute(context.Background(), "indexeddb_roundtrip", map[string]any{
+		"store": "events",
+		"id":    "evt-1",
+		"value": "blocked",
+	}, ""); err == nil {
+		t.Fatal("indexeddb_roundtrip on disallowed object store should fail")
+	}
+
+	_ = CloseProviders(providers)
+	providers = nil
+	if got := closeCount.Load(); got != 1 {
+		t.Fatalf("closeCount after provider shutdown = %d, want 1", got)
+	}
+}
+
+func TestPluginIndexedDBBindingsPreserveLegacyTransportPrefixedData(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:     "indexeddb_roundtrip",
+				Method: http.MethodPost,
+				Parameters: []catalog.CatalogParameter{
+					{Name: "store", Type: "string", Required: true},
+					{Name: "id", Type: "string", Required: true},
+					{Name: "value", Type: "string", Required: true},
+				},
+			},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+
+	var boundDB *trackedIndexedDB
+	providers, _, err := buildProvidersStrict(context.Background(), &config.Config{
+		Providers: config.ProvidersConfig{
+			Plugins: map[string]*config.ProviderEntry{
+				"echoext": {
+					Command:              bin,
+					Args:                 []string{"provider"},
+					ResolvedManifest:     manifest,
+					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+					IndexedDBSchema:      "roadmap",
+					IndexedDBs: []config.PluginIndexedDBBinding{
+						{Name: "memory", ObjectStores: []string{"tasks"}},
+					},
+				},
+			},
+		},
+	}, NewFactoryRegistry(), Deps{
+		IndexedDBDefs: map[string]*config.ProviderEntry{
+			"memory": {
+				Source: config.ProviderSource{Path: "./providers/datastore/memory"},
+				Config: mustNode(t, map[string]any{"bucket": "plugin-state"}),
+			},
+		},
+		IndexedDBFactory: func(yaml.Node) (indexeddb.IndexedDB, error) {
+			boundDB = &trackedIndexedDB{
+				StubIndexedDB: coretesting.StubIndexedDB{},
+			}
+			return boundDB, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseProviders(providers) })
+
+	if err := boundDB.CreateObjectStore(context.Background(), "plugin_echoext_tasks", indexeddb.ObjectStoreSchema{}); err != nil {
+		t.Fatalf("CreateObjectStore legacy tasks: %v", err)
+	}
+	if err := boundDB.ObjectStore("plugin_echoext_tasks").Put(context.Background(), indexeddb.Record{
+		"id":    "legacy-task",
+		"value": "already-there",
+	}); err != nil {
+		t.Fatalf("Put legacy task: %v", err)
+	}
+
+	prov, err := providers.Get("echoext")
+	if err != nil {
+		t.Fatalf("providers.Get: %v", err)
+	}
+	if _, err := prov.Execute(context.Background(), "indexeddb_roundtrip", map[string]any{
+		"store": "tasks",
+		"id":    "task-1",
+		"value": "ship-it",
+	}, ""); err != nil {
+		t.Fatalf("Execute indexeddb_roundtrip: %v", err)
+	}
+
+	if _, err := boundDB.ObjectStore("plugin_echoext_tasks").Get(context.Background(), "task-1"); err != nil {
+		t.Fatalf("legacy backing store should receive new writes: %v", err)
+	}
+	if _, err := boundDB.ObjectStore("plugin_echoext_tasks").Get(context.Background(), "legacy-task"); err != nil {
+		t.Fatalf("legacy backing store should keep old rows: %v", err)
+	}
+	if _, err := boundDB.ObjectStore("roadmap_tasks").Get(context.Background(), "task-1"); err == nil {
+		t.Fatal("new transport-prefixed store should remain unused while only legacy data exists")
+	}
+}
+
+func TestPluginIndexedDBBindingsRouteExplicitAndCatchAllStores(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:     "indexeddb_roundtrip",
+				Method: http.MethodPost,
+				Parameters: []catalog.CatalogParameter{
+					{Name: "binding", Type: "string"},
+					{Name: "store", Type: "string", Required: true},
+					{Name: "id", Type: "string", Required: true},
+					{Name: "value", Type: "string", Required: true},
+				},
+			},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+
+	boundDBs := make(map[string]*trackedIndexedDB)
+	providers, _, err := buildProvidersStrict(context.Background(), &config.Config{
+		Providers: config.ProvidersConfig{
+			Plugins: map[string]*config.ProviderEntry{
+				"echoext": {
+					Command:              bin,
+					Args:                 []string{"provider"},
+					ResolvedManifest:     manifest,
+					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+					IndexedDBSchema:      "roadmap",
+					IndexedDBs: []config.PluginIndexedDBBinding{
+						{Name: "main", ObjectStores: []string{"tasks"}},
+						{Name: "archive"},
+					},
+				},
+			},
+		},
+	}, NewFactoryRegistry(), Deps{
+		IndexedDBDefs: map[string]*config.ProviderEntry{
+			"main": {
+				Source: config.ProviderSource{Path: "./providers/datastore/main"},
+				Config: mustNode(t, map[string]any{"bucket": "main"}),
+			},
+			"archive": {
+				Source: config.ProviderSource{Path: "./providers/datastore/archive"},
+				Config: mustNode(t, map[string]any{"bucket": "archive"}),
+			},
+		},
+		IndexedDBFactory: func(node yaml.Node) (indexeddb.IndexedDB, error) {
+			var decoded struct {
+				Config map[string]any `yaml:"config"`
+			}
+			if err := node.Decode(&decoded); err != nil {
+				return nil, err
+			}
+			bucket, _ := decoded.Config["bucket"].(string)
+			db := &trackedIndexedDB{StubIndexedDB: coretesting.StubIndexedDB{}}
+			boundDBs[bucket] = db
+			return db, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseProviders(providers) })
+
+	prov, err := providers.Get("echoext")
+	if err != nil {
+		t.Fatalf("providers.Get: %v", err)
+	}
+
+	if _, err := prov.Execute(context.Background(), "indexeddb_roundtrip", map[string]any{
+		"binding": "main",
+		"store":   "tasks",
+		"id":      "task-1",
+		"value":   "ship-it",
+	}, ""); err != nil {
+		t.Fatalf("Execute main tasks roundtrip: %v", err)
+	}
+	if _, err := boundDBs["main"].ObjectStore("roadmap_tasks").Get(context.Background(), "task-1"); err != nil {
+		t.Fatalf("main binding should own tasks store: %v", err)
+	}
+
+	if _, err := prov.Execute(context.Background(), "indexeddb_roundtrip", map[string]any{
+		"binding": "main",
+		"store":   "events",
+		"id":      "evt-main",
+		"value":   "blocked",
+	}, ""); err == nil {
+		t.Fatal("main binding should reject stores outside its explicit objectStore allowlist")
+	}
+
+	if _, err := prov.Execute(context.Background(), "indexeddb_roundtrip", map[string]any{
+		"binding": "archive",
+		"store":   "events",
+		"id":      "evt-1",
+		"value":   "stored",
+	}, ""); err != nil {
+		t.Fatalf("Execute archive events roundtrip: %v", err)
+	}
+	if _, err := boundDBs["archive"].ObjectStore("roadmap_events").Get(context.Background(), "evt-1"); err != nil {
+		t.Fatalf("archive binding should act as catch-all for unassigned stores: %v", err)
+	}
+
+	if _, err := prov.Execute(context.Background(), "indexeddb_roundtrip", map[string]any{
+		"binding": "archive",
+		"store":   "tasks",
+		"id":      "task-archive",
+		"value":   "blocked",
+	}, ""); err == nil {
+		t.Fatal("archive catch-all binding should reject stores explicitly assigned to another binding")
+	}
+}
+
+type trackedIndexedDB struct {
+	coretesting.StubIndexedDB
+	onClose func(int32) int32
+}
+
+func (t *trackedIndexedDB) Close() error {
+	if t.onClose != nil {
+		t.onClose(1)
+	}
+	return t.StubIndexedDB.Close()
 }
 
 func TestExecutablePluginRequiresManifest(t *testing.T) {

--- a/gestaltd/internal/bootstrap/plugin_indexeddb.go
+++ b/gestaltd/internal/bootstrap/plugin_indexeddb.go
@@ -1,0 +1,436 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+type pluginIndexedDBTransportOptions struct {
+	StorePrefix       string
+	LegacyStorePrefix string
+	AllowedStores     []string
+	DeniedStores      []string
+}
+
+func newPluginIndexedDBTransport(ds indexeddb.IndexedDB, opts pluginIndexedDBTransportOptions) indexeddb.IndexedDB {
+	if ds == nil {
+		return nil
+	}
+	if opts.StorePrefix == "" && opts.LegacyStorePrefix == "" && len(opts.AllowedStores) == 0 && len(opts.DeniedStores) == 0 {
+		return ds
+	}
+	allowed := make(map[string]struct{}, len(opts.AllowedStores))
+	for _, store := range opts.AllowedStores {
+		allowed[store] = struct{}{}
+	}
+	if len(allowed) == 0 {
+		allowed = nil
+	}
+	denied := make(map[string]struct{}, len(opts.DeniedStores))
+	for _, store := range opts.DeniedStores {
+		denied[store] = struct{}{}
+	}
+	if len(denied) == 0 {
+		denied = nil
+	}
+	return &pluginIndexedDBTransport{
+		inner:        ds,
+		prefix:       opts.StorePrefix,
+		legacyPrefix: opts.LegacyStorePrefix,
+		allowed:      allowed,
+		denied:       denied,
+	}
+}
+
+type pluginIndexedDBTransport struct {
+	inner        indexeddb.IndexedDB
+	prefix       string
+	legacyPrefix string
+	allowed      map[string]struct{}
+	denied       map[string]struct{}
+}
+
+func (d *pluginIndexedDBTransport) translateStore(name string) (string, string, error) {
+	if len(d.allowed) > 0 {
+		if _, ok := d.allowed[name]; !ok {
+			return "", "", indexeddb.ErrNotFound
+		}
+	}
+	if len(d.denied) > 0 {
+		if _, ok := d.denied[name]; ok {
+			return "", "", indexeddb.ErrNotFound
+		}
+	}
+	return d.prefix + name, d.legacyPrefix + name, nil
+}
+
+func (d *pluginIndexedDBTransport) ObjectStore(name string) indexeddb.ObjectStore {
+	primary, legacy, err := d.translateStore(name)
+	if err != nil {
+		return missingObjectStore{}
+	}
+	return &pluginIndexedDBObjectStore{
+		inner:   d.inner,
+		primary: primary,
+		legacy:  legacy,
+	}
+}
+
+func (d *pluginIndexedDBTransport) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
+	primary, legacy, err := d.translateStore(name)
+	if err != nil {
+		return err
+	}
+	storeName, exists, err := resolveActiveStoreName(ctx, d.inner, primary, legacy)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		storeName = primary
+	}
+	return d.inner.CreateObjectStore(ctx, storeName, schema)
+}
+
+func (d *pluginIndexedDBTransport) DeleteObjectStore(ctx context.Context, name string) error {
+	primary, legacy, err := d.translateStore(name)
+	if err != nil {
+		return err
+	}
+	storeName, exists, err := resolveActiveStoreName(ctx, d.inner, primary, legacy)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		storeName = primary
+	}
+	return d.inner.DeleteObjectStore(ctx, storeName)
+}
+
+func (d *pluginIndexedDBTransport) Ping(ctx context.Context) error {
+	return d.inner.Ping(ctx)
+}
+
+func (d *pluginIndexedDBTransport) Close() error {
+	return d.inner.Close()
+}
+
+type pluginIndexedDBObjectStore struct {
+	inner   indexeddb.IndexedDB
+	primary string
+	legacy  string
+}
+
+func (s *pluginIndexedDBObjectStore) resolve(ctx context.Context) (indexeddb.ObjectStore, error) {
+	storeName, _, err := resolveActiveStoreName(ctx, s.inner, s.primary, s.legacy)
+	if err != nil {
+		return nil, err
+	}
+	return s.inner.ObjectStore(storeName), nil
+}
+
+func (s *pluginIndexedDBObjectStore) Get(ctx context.Context, id string) (indexeddb.Record, error) {
+	store, err := s.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return store.Get(ctx, id)
+}
+
+func (s *pluginIndexedDBObjectStore) GetKey(ctx context.Context, id string) (string, error) {
+	store, err := s.resolve(ctx)
+	if err != nil {
+		return "", err
+	}
+	return store.GetKey(ctx, id)
+}
+
+func (s *pluginIndexedDBObjectStore) Add(ctx context.Context, record indexeddb.Record) error {
+	store, err := s.resolve(ctx)
+	if err != nil {
+		return err
+	}
+	return store.Add(ctx, record)
+}
+
+func (s *pluginIndexedDBObjectStore) Put(ctx context.Context, record indexeddb.Record) error {
+	store, err := s.resolve(ctx)
+	if err != nil {
+		return err
+	}
+	return store.Put(ctx, record)
+}
+
+func (s *pluginIndexedDBObjectStore) Delete(ctx context.Context, id string) error {
+	store, err := s.resolve(ctx)
+	if err != nil {
+		return err
+	}
+	return store.Delete(ctx, id)
+}
+
+func (s *pluginIndexedDBObjectStore) Clear(ctx context.Context) error {
+	store, err := s.resolve(ctx)
+	if err != nil {
+		return err
+	}
+	return store.Clear(ctx)
+}
+
+func (s *pluginIndexedDBObjectStore) GetAll(ctx context.Context, r *indexeddb.KeyRange) ([]indexeddb.Record, error) {
+	store, err := s.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return store.GetAll(ctx, r)
+}
+
+func (s *pluginIndexedDBObjectStore) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange) ([]string, error) {
+	store, err := s.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return store.GetAllKeys(ctx, r)
+}
+
+func (s *pluginIndexedDBObjectStore) Count(ctx context.Context, r *indexeddb.KeyRange) (int64, error) {
+	store, err := s.resolve(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return store.Count(ctx, r)
+}
+
+func (s *pluginIndexedDBObjectStore) DeleteRange(ctx context.Context, r indexeddb.KeyRange) (int64, error) {
+	store, err := s.resolve(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return store.DeleteRange(ctx, r)
+}
+
+func (s *pluginIndexedDBObjectStore) Index(name string) indexeddb.Index {
+	return &pluginIndexedDBIndex{
+		store: s,
+		name:  name,
+	}
+}
+
+func (s *pluginIndexedDBObjectStore) OpenCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	store, err := s.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return store.OpenCursor(ctx, r, dir)
+}
+
+func (s *pluginIndexedDBObjectStore) OpenKeyCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	store, err := s.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return store.OpenKeyCursor(ctx, r, dir)
+}
+
+type pluginIndexedDBIndex struct {
+	store *pluginIndexedDBObjectStore
+	name  string
+}
+
+func (i *pluginIndexedDBIndex) resolve(ctx context.Context) (indexeddb.Index, error) {
+	store, err := i.store.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return store.Index(i.name), nil
+}
+
+func (i *pluginIndexedDBIndex) Get(ctx context.Context, values ...any) (indexeddb.Record, error) {
+	index, err := i.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return index.Get(ctx, values...)
+}
+
+func (i *pluginIndexedDBIndex) GetKey(ctx context.Context, values ...any) (string, error) {
+	index, err := i.resolve(ctx)
+	if err != nil {
+		return "", err
+	}
+	return index.GetKey(ctx, values...)
+}
+
+func (i *pluginIndexedDBIndex) GetAll(ctx context.Context, r *indexeddb.KeyRange, values ...any) ([]indexeddb.Record, error) {
+	index, err := i.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return index.GetAll(ctx, r, values...)
+}
+
+func (i *pluginIndexedDBIndex) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange, values ...any) ([]string, error) {
+	index, err := i.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return index.GetAllKeys(ctx, r, values...)
+}
+
+func (i *pluginIndexedDBIndex) Count(ctx context.Context, r *indexeddb.KeyRange, values ...any) (int64, error) {
+	index, err := i.resolve(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return index.Count(ctx, r, values...)
+}
+
+func (i *pluginIndexedDBIndex) Delete(ctx context.Context, values ...any) (int64, error) {
+	index, err := i.resolve(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return index.Delete(ctx, values...)
+}
+
+func (i *pluginIndexedDBIndex) OpenCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection, values ...any) (indexeddb.Cursor, error) {
+	index, err := i.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return index.OpenCursor(ctx, r, dir, values...)
+}
+
+func (i *pluginIndexedDBIndex) OpenKeyCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection, values ...any) (indexeddb.Cursor, error) {
+	index, err := i.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return index.OpenKeyCursor(ctx, r, dir, values...)
+}
+
+func resolveActiveStoreName(ctx context.Context, db indexeddb.IndexedDB, primary, legacy string) (string, bool, error) {
+	if exists, err := storeExists(ctx, db, primary); err != nil {
+		return "", false, err
+	} else if exists {
+		return primary, true, nil
+	}
+	if legacy != "" && legacy != primary {
+		if exists, err := storeExists(ctx, db, legacy); err != nil {
+			return "", false, err
+		} else if exists {
+			return legacy, true, nil
+		}
+	}
+	return primary, false, nil
+}
+
+func storeExists(ctx context.Context, db indexeddb.IndexedDB, storeName string) (bool, error) {
+	if storeName == "" {
+		return false, nil
+	}
+	type objectStoreExistenceChecker interface {
+		HasObjectStore(name string) bool
+	}
+	if checker, ok := db.(objectStoreExistenceChecker); ok {
+		return checker.HasObjectStore(storeName), nil
+	}
+	_, err := db.ObjectStore(storeName).Count(ctx, nil)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, indexeddb.ErrNotFound):
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+type missingObjectStore struct{}
+
+func (missingObjectStore) Get(context.Context, string) (indexeddb.Record, error) {
+	return nil, indexeddb.ErrNotFound
+}
+
+func (missingObjectStore) GetKey(context.Context, string) (string, error) {
+	return "", indexeddb.ErrNotFound
+}
+
+func (missingObjectStore) Add(context.Context, indexeddb.Record) error {
+	return indexeddb.ErrNotFound
+}
+
+func (missingObjectStore) Put(context.Context, indexeddb.Record) error {
+	return indexeddb.ErrNotFound
+}
+
+func (missingObjectStore) Delete(context.Context, string) error {
+	return indexeddb.ErrNotFound
+}
+
+func (missingObjectStore) Clear(context.Context) error {
+	return indexeddb.ErrNotFound
+}
+
+func (missingObjectStore) GetAll(context.Context, *indexeddb.KeyRange) ([]indexeddb.Record, error) {
+	return nil, indexeddb.ErrNotFound
+}
+
+func (missingObjectStore) GetAllKeys(context.Context, *indexeddb.KeyRange) ([]string, error) {
+	return nil, indexeddb.ErrNotFound
+}
+
+func (missingObjectStore) Count(context.Context, *indexeddb.KeyRange) (int64, error) {
+	return 0, indexeddb.ErrNotFound
+}
+
+func (missingObjectStore) DeleteRange(context.Context, indexeddb.KeyRange) (int64, error) {
+	return 0, indexeddb.ErrNotFound
+}
+
+func (missingObjectStore) Index(string) indexeddb.Index {
+	return missingIndex{}
+}
+
+func (missingObjectStore) OpenCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	return nil, indexeddb.ErrNotFound
+}
+
+func (missingObjectStore) OpenKeyCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	return nil, indexeddb.ErrNotFound
+}
+
+type missingIndex struct{}
+
+func (missingIndex) Get(context.Context, ...any) (indexeddb.Record, error) {
+	return nil, indexeddb.ErrNotFound
+}
+
+func (missingIndex) GetKey(context.Context, ...any) (string, error) {
+	return "", indexeddb.ErrNotFound
+}
+
+func (missingIndex) GetAll(context.Context, *indexeddb.KeyRange, ...any) ([]indexeddb.Record, error) {
+	return nil, indexeddb.ErrNotFound
+}
+
+func (missingIndex) GetAllKeys(context.Context, *indexeddb.KeyRange, ...any) ([]string, error) {
+	return nil, indexeddb.ErrNotFound
+}
+
+func (missingIndex) Count(context.Context, *indexeddb.KeyRange, ...any) (int64, error) {
+	return 0, indexeddb.ErrNotFound
+}
+
+func (missingIndex) Delete(context.Context, ...any) (int64, error) {
+	return 0, indexeddb.ErrNotFound
+}
+
+func (missingIndex) OpenCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection, ...any) (indexeddb.Cursor, error) {
+	return nil, indexeddb.ErrNotFound
+}
+
+func (missingIndex) OpenKeyCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection, ...any) (indexeddb.Cursor, error) {
+	return nil, indexeddb.ErrNotFound
+}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -31,6 +32,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"google.golang.org/grpc"
+	"gopkg.in/yaml.v3"
 )
 
 func buildRegistrationStore(deps Deps) mcpoauth.RegistrationStore {
@@ -505,37 +507,16 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		AllowedHosts:  entry.AllowedHosts,
 		DefaultAction: deps.Egress.DefaultAction,
 		HostBinary:    entry.HostBinary,
-		Cleanup:       cleanup,
 	}
 	if len(entry.IndexedDBs) > 0 {
-		if len(deps.IndexedDBs) == 0 {
-			return nil, fmt.Errorf("indexeddb host services are not available")
+		hostServices, indexedDBCleanup, err := buildPluginIndexedDBHostServices(name, entry, deps)
+		if err != nil {
+			return nil, err
 		}
-		execCfg.HostServices = make([]providerhost.HostService, 0, len(entry.IndexedDBs)+1)
-		for _, binding := range entry.IndexedDBs {
-			ds, ok := deps.IndexedDBs[binding]
-			if !ok || ds == nil {
-				return nil, fmt.Errorf("indexeddb %q is not available", binding)
-			}
-			execCfg.HostServices = append(execCfg.HostServices, providerhost.HostService{
-				EnvVar: providerhost.IndexedDBSocketEnv(binding),
-				Register: func(ds indexeddb.IndexedDB) func(*grpc.Server) {
-					return func(srv *grpc.Server) {
-						proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(ds, indexedDBNamespace(name)))
-					}
-				}(ds),
-			})
-		}
-		if len(entry.IndexedDBs) == 1 {
-			ds := deps.IndexedDBs[entry.IndexedDBs[0]]
-			execCfg.HostServices = append(execCfg.HostServices, providerhost.HostService{
-				EnvVar: providerhost.DefaultIndexedDBSocketEnv,
-				Register: func(srv *grpc.Server) {
-					proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(ds, indexedDBNamespace(name)))
-				},
-			})
-		}
+		execCfg.HostServices = hostServices
+		cleanup = chainCleanup(cleanup, indexedDBCleanup)
 	}
+	execCfg.Cleanup = cleanup
 	prov, err := providerhost.NewExecutableProvider(ctx, execCfg)
 	if err != nil {
 		return nil, err
@@ -544,8 +525,213 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 	return prov, nil
 }
 
-func indexedDBNamespace(providerName string) string {
-	return providerName
+func buildPluginIndexedDBHostServices(pluginName string, entry *config.ProviderEntry, deps Deps) ([]providerhost.HostService, func(), error) {
+	if deps.IndexedDBFactory == nil || len(deps.IndexedDBDefs) == 0 {
+		return nil, nil, fmt.Errorf("indexeddb host services are not available")
+	}
+
+	effectiveSchema := effectivePluginIndexedDBSchema(pluginName, entry)
+	explicitStores := make(map[string]struct{})
+	for _, binding := range entry.IndexedDBs {
+		for _, store := range binding.ObjectStores {
+			explicitStores[store] = struct{}{}
+		}
+	}
+	reservedStores := make([]string, 0, len(explicitStores))
+	for store := range explicitStores {
+		reservedStores = append(reservedStores, store)
+	}
+	hostServices := make([]providerhost.HostService, 0, len(entry.IndexedDBs)+1)
+	boundStores := make([]indexeddb.IndexedDB, 0, len(entry.IndexedDBs))
+	for _, binding := range entry.IndexedDBs {
+		var deniedStores []string
+		if len(binding.ObjectStores) == 0 && len(reservedStores) > 0 {
+			deniedStores = reservedStores
+		}
+		ds, err := buildPluginScopedIndexedDB(pluginName, binding, effectiveSchema, deniedStores, deps)
+		if err != nil {
+			_ = closeIndexedDBs(boundStores...)
+			return nil, nil, err
+		}
+		boundStores = append(boundStores, ds)
+		hostServices = append(hostServices, providerhost.HostService{
+			EnvVar: providerhost.IndexedDBSocketEnv(binding.Name),
+			Register: func(ds indexeddb.IndexedDB) func(*grpc.Server) {
+				return func(srv *grpc.Server) {
+					proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(ds, pluginName))
+				}
+			}(ds),
+		})
+	}
+	if len(boundStores) == 1 {
+		ds := boundStores[0]
+		hostServices = append(hostServices, providerhost.HostService{
+			EnvVar: providerhost.DefaultIndexedDBSocketEnv,
+			Register: func(srv *grpc.Server) {
+				proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(ds, pluginName))
+			},
+		})
+	}
+
+	return hostServices, func() {
+		_ = closeIndexedDBs(boundStores...)
+	}, nil
+}
+
+func buildPluginScopedIndexedDB(pluginName string, binding config.PluginIndexedDBBinding, schema string, deniedStores []string, deps Deps) (indexeddb.IndexedDB, error) {
+	def, ok := deps.IndexedDBDefs[binding.Name]
+	if !ok || def == nil {
+		return nil, fmt.Errorf("indexeddb %q is not available", binding.Name)
+	}
+	scopedDef, transportPrefix, err := newPluginScopedIndexedDBDef(def, pluginName, schema)
+	if err != nil {
+		return nil, fmt.Errorf("indexeddb %q: %w", binding.Name, err)
+	}
+	ds, err := buildIndexedDB(scopedDef, &FactoryRegistry{IndexedDB: deps.IndexedDBFactory})
+	if err != nil {
+		return nil, fmt.Errorf("indexeddb %q: %w", binding.Name, err)
+	}
+	ds = newPluginIndexedDBTransport(ds, pluginIndexedDBTransportOptions{
+		StorePrefix:       transportPrefix,
+		LegacyStorePrefix: legacyPluginIndexedDBPrefix(pluginName),
+		AllowedStores:     binding.ObjectStores,
+		DeniedStores:      deniedStores,
+	})
+	return metricutil.InstrumentIndexedDB(ds, binding.Name), nil
+}
+
+func newPluginScopedIndexedDBDef(entry *config.ProviderEntry, pluginName, schema string) (*config.ProviderEntry, string, error) {
+	if entry == nil {
+		return nil, "", fmt.Errorf("datastore provider is required")
+	}
+	cfg, err := config.NodeToMap(entry.Config)
+	if err != nil {
+		return nil, "", fmt.Errorf("decode config: %w", err)
+	}
+	if cfg == nil {
+		cfg = make(map[string]any)
+	}
+
+	transportPrefix := ""
+	if pluginIndexedDBUsesScopedProviderConfig(entry, cfg) {
+		if legacyPrefix := legacyPluginIndexedDBPrefix(pluginName); legacyPrefix != "" {
+			cfg["legacy_table_prefix"] = legacyPrefix
+			cfg["legacy_prefix"] = legacyPrefix
+		}
+		if isSQLiteIndexedDBConfig(cfg) {
+			delete(cfg, "schema")
+			delete(cfg, "namespace")
+			cfg["table_prefix"] = schema + "_"
+			cfg["prefix"] = schema + "_"
+		} else {
+			delete(cfg, "table_prefix")
+			delete(cfg, "prefix")
+			cfg["schema"] = schema
+			cfg["namespace"] = schema
+		}
+	} else {
+		transportPrefix = schema + "_"
+	}
+
+	configNode, err := mapToYAMLNode(cfg)
+	if err != nil {
+		return nil, "", fmt.Errorf("encode config: %w", err)
+	}
+
+	cloned := *entry
+	cloned.Config = configNode
+	return &cloned, transportPrefix, nil
+}
+
+func pluginIndexedDBUsesScopedProviderConfig(entry *config.ProviderEntry, cfg map[string]any) bool {
+	if !isRelationalIndexedDBEntry(entry) {
+		return false
+	}
+	dsn, _ := cfg["dsn"].(string)
+	return strings.TrimSpace(dsn) != ""
+}
+
+func isRelationalIndexedDBEntry(entry *config.ProviderEntry) bool {
+	if entry == nil {
+		return false
+	}
+	if ref := strings.TrimSpace(entry.SourceRef()); ref != "" {
+		return strings.HasSuffix(ref, "/indexeddb/relationaldb")
+	}
+	if path := strings.TrimSpace(entry.SourcePath()); path != "" {
+		path = filepath.ToSlash(path)
+		return strings.HasSuffix(path, "/indexeddb/relationaldb") ||
+			strings.HasSuffix(path, "/relationaldb") ||
+			strings.HasSuffix(path, "/indexeddb/relationaldb/manifest.yaml") ||
+			strings.HasSuffix(path, "/relationaldb/manifest.yaml")
+	}
+	return false
+}
+
+func legacyPluginIndexedDBPrefix(pluginName string) string {
+	pluginName = strings.TrimSpace(pluginName)
+	if pluginName == "" {
+		return ""
+	}
+	return "plugin_" + pluginName + "_"
+}
+
+func isSQLiteIndexedDBConfig(cfg map[string]any) bool {
+	dsn, _ := cfg["dsn"].(string)
+	dsn = strings.TrimSpace(dsn)
+	if dsn == "" {
+		return false
+	}
+	switch {
+	case strings.HasPrefix(dsn, "postgres://"), strings.HasPrefix(dsn, "postgresql://"):
+		return false
+	case strings.HasPrefix(dsn, "mysql://"), strings.Contains(dsn, "@tcp("), strings.Contains(dsn, "@unix("):
+		return false
+	case strings.HasPrefix(dsn, "sqlserver://"):
+		return false
+	default:
+		return true
+	}
+}
+
+func mapToYAMLNode(value map[string]any) (yaml.Node, error) {
+	data, err := yaml.Marshal(value)
+	if err != nil {
+		return yaml.Node{}, err
+	}
+	var out yaml.Node
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	if err := dec.Decode(&out); err != nil {
+		return yaml.Node{}, err
+	}
+	if out.Kind == yaml.DocumentNode && len(out.Content) == 1 {
+		return *out.Content[0], nil
+	}
+	return out, nil
+}
+
+func effectivePluginIndexedDBSchema(pluginName string, entry *config.ProviderEntry) string {
+	if entry != nil && strings.TrimSpace(entry.IndexedDBSchema) != "" {
+		return strings.TrimSpace(entry.IndexedDBSchema)
+	}
+	return pluginName
+}
+
+func chainCleanup(cleanups ...func()) func() {
+	var combined []func()
+	for _, cleanup := range cleanups {
+		if cleanup != nil {
+			combined = append(combined, cleanup)
+		}
+	}
+	if len(combined) == 0 {
+		return nil
+	}
+	return func() {
+		for i := len(combined) - 1; i >= 0; i-- {
+			combined[i]()
+		}
+	}
 }
 
 func clonePluginEnv(src map[string]string) map[string]string {

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -129,7 +129,8 @@ type ProviderEntry struct {
 	// Plugin-specific config fields (parsed from YAML, only valid on plugin entries)
 	Connections       map[string]*ConnectionDef     `yaml:"connections,omitempty"`
 	AllowedOperations map[string]*OperationOverride `yaml:"allowedOperations,omitempty"`
-	IndexedDBs        []string                      `yaml:"indexeddb,omitempty"`
+	IndexedDBs        []PluginIndexedDBBinding      `yaml:"indexeddb,omitempty"`
+	IndexedDBSchema   string                        `yaml:"indexeddbSchema,omitempty"`
 	Surfaces          *ProviderSurfaceOverrides     `yaml:"surfaces,omitempty"`
 
 	// Runtime-resolved fields (populated during init/bootstrap, not from YAML)
@@ -154,6 +155,20 @@ type ProviderSurfaceOverrides struct {
 	OpenAPI *ProviderOpenAPISurfaceOverride `yaml:"openapi,omitempty"`
 	GraphQL *ProviderGraphQLSurfaceOverride `yaml:"graphql,omitempty"`
 	MCP     *ProviderMCPSurfaceOverride     `yaml:"mcp,omitempty"`
+}
+
+type PluginIndexedDBBinding struct {
+	Name         string   `yaml:"name,omitempty"`
+	ObjectStores []string `yaml:"objectStore,omitempty"`
+}
+
+func (b *PluginIndexedDBBinding) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		b.Name = strings.TrimSpace(value.Value)
+		return nil
+	}
+	type raw PluginIndexedDBBinding
+	return value.Decode((*raw)(b))
 }
 
 type ProviderRESTSurfaceOverride struct {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -146,8 +146,9 @@ plugins:
 	if indexedDBName != "archive" || indexedDBEntry == nil {
 		t.Fatalf("SelectedIndexedDBProvider = (%q, %#v), want archive", indexedDBName, indexedDBEntry)
 	}
-	if got := cfg.Plugins["service-a"].IndexedDBs; !reflect.DeepEqual(got, []string{"archive"}) {
-		t.Fatalf("Plugins[service-a].IndexedDBs = %v, want [archive]", got)
+	wantBindings := []PluginIndexedDBBinding{{Name: "archive"}}
+	if got := cfg.Plugins["service-a"].IndexedDBs; !reflect.DeepEqual(got, wantBindings) {
+		t.Fatalf("Plugins[service-a].IndexedDBs = %v, want %v", got, wantBindings)
 	}
 }
 
@@ -911,10 +912,57 @@ server:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
+		want := []PluginIndexedDBBinding{
+			{Name: "sqlite"},
+			{Name: "archive"},
+		}
 		got := cfg.Plugins["roadmap"].IndexedDBs
-		want := []string{"sqlite", "archive"}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("Plugins[roadmap].IndexedDBs = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("loads plugin indexeddb object store routing", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    indexeddb:
+      - name: sqlite
+        objectStore:
+          - tasks
+          - snapshots
+      - name: archive
+        objectStore:
+          - events
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+    archive:
+      source:
+        path: ./providers/datastore/archive
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		got := cfg.Plugins["roadmap"].IndexedDBs
+		want := []PluginIndexedDBBinding{
+			{Name: "sqlite", ObjectStores: []string{"tasks", "snapshots"}},
+			{Name: "archive", ObjectStores: []string{"events"}},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("Plugins[roadmap].IndexedDBs = %#v, want %#v", got, want)
 		}
 	})
 
@@ -983,6 +1031,35 @@ server:
 		}
 	})
 
+	t.Run("loads plugin indexeddb schema override", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  datadog:
+    source:
+      path: ./plugin/manifest.yaml
+    indexeddbSchema: plugin_data
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+  `)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := cfg.Plugins["datadog"].IndexedDBSchema; got != "plugin_data" {
+			t.Fatalf("Plugins[datadog].IndexedDBSchema = %q, want %q", got, "plugin_data")
+		}
+	})
+
 	t.Run("rejects surface overrides outside plugins", func(t *testing.T) {
 		t.Parallel()
 
@@ -1011,6 +1088,36 @@ server:
 			t.Fatal("Load: expected error, got nil")
 		}
 		if !strings.Contains(err.Error(), `ui.root.surfaces is only supported on plugins.*`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects indexeddb schema overrides outside plugins", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  ui:
+    root:
+      source:
+        path: ./web/root/manifest.yaml
+      path: /app
+      indexeddbSchema: root_ui
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `ui.root.indexeddbSchema is only supported on plugins.*`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -1076,6 +1183,124 @@ server:
 			t.Fatal("Load: expected error, got nil")
 		}
 		if !strings.Contains(err.Error(), `plugin "roadmap" indexeddb[1] "main_db" conflicts with "main-db" after IndexedDB env normalization (GESTALT_INDEXEDDB_SOCKET_MAIN_DB)`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects duplicate indexeddb object stores across bindings", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    indexeddb:
+      - name: main
+        objectStore:
+          - tasks
+      - name: archive
+        objectStore:
+          - tasks
+providers:
+  indexeddb:
+    main:
+      source:
+        path: ./providers/datastore/main
+    archive:
+      source:
+        path: ./providers/datastore/archive
+server:
+  providers:
+    indexeddb: main
+  encryptionKey: server-key
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `plugin "roadmap" indexeddb[1].objectStore[0] "tasks" duplicates indexeddb "main"`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("loads mixed explicit and catch-all indexeddb bindings", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    indexeddb:
+      - name: main
+        objectStore:
+          - tasks
+      - name: archive
+providers:
+  indexeddb:
+    main:
+      source:
+        path: ./providers/datastore/main
+    archive:
+      source:
+        path: ./providers/datastore/archive
+server:
+  providers:
+    indexeddb: main
+  encryptionKey: server-key
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		want := []PluginIndexedDBBinding{
+			{Name: "main", ObjectStores: []string{"tasks"}},
+			{Name: "archive"},
+		}
+		if got := cfg.Plugins["roadmap"].IndexedDBs; !reflect.DeepEqual(got, want) {
+			t.Fatalf("Plugins[roadmap].IndexedDBs = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("rejects multiple catch-all indexeddb bindings when allowlists are used", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    indexeddb:
+      - name: main
+        objectStore:
+          - tasks
+      - name: archive
+      - name: backup
+providers:
+  indexeddb:
+    main:
+      source:
+        path: ./providers/datastore/main
+    archive:
+      source:
+        path: ./providers/datastore/archive
+    backup:
+      source:
+        path: ./providers/datastore/backup
+server:
+  providers:
+    indexeddb: main
+  encryptionKey: server-key
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `plugin "roadmap" indexeddb may declare at most one unrestricted binding when objectStore allowlists are used`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -281,6 +281,7 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry) error {
 	if entry.Default {
 		return fmt.Errorf("config validation: plugins.%s.default is not supported on plugins", name)
 	}
+	entry.IndexedDBSchema = strings.TrimSpace(entry.IndexedDBSchema)
 	if err := validateProviderEntrySource("plugin", name, entry); err != nil {
 		return err
 	}
@@ -318,11 +319,14 @@ func validatePluginOnlyProviderFields(subject string, entry *ProviderEntry) erro
 	if len(entry.IndexedDBs) > 0 {
 		return fmt.Errorf("config validation: %s.indexeddb is only supported on plugins.*", subject)
 	}
+	if strings.TrimSpace(entry.IndexedDBSchema) != "" {
+		return fmt.Errorf("config validation: %s.indexeddbSchema is only supported on plugins.*", subject)
+	}
 	if entry.Surfaces != nil {
 		return fmt.Errorf("config validation: %s.surfaces is only supported on plugins.*", subject)
 	}
 	if entry.AuthorizationPolicy != "" && !strings.HasPrefix(subject, "ui.") {
-		return fmt.Errorf("config validation: %s.authorizationPolicy is only supported on providers.plugins.* and providers.ui.*", subject)
+		return fmt.Errorf("config validation: %s.authorizationPolicy is only supported on plugins.* and ui.*", subject)
 	}
 	return nil
 }
@@ -385,24 +389,51 @@ func validatePluginIndexedDBBindings(cfg *Config, name string, entry *ProviderEn
 	}
 	seen := make(map[string]struct{}, len(entry.IndexedDBs))
 	envNames := make(map[string]string, len(entry.IndexedDBs))
-	for i, binding := range entry.IndexedDBs {
-		binding = strings.TrimSpace(binding)
-		if binding == "" {
+	objectStores := make(map[string]string)
+	restrictedBindingCount := 0
+	unrestrictedBindingCount := 0
+	for i := range entry.IndexedDBs {
+		binding := &entry.IndexedDBs[i]
+		binding.Name = strings.TrimSpace(binding.Name)
+		if binding.Name == "" {
 			return fmt.Errorf("config validation: plugin %q indexeddb[%d] is required", name, i)
 		}
-		if _, exists := seen[binding]; exists {
-			return fmt.Errorf("config validation: plugin %q indexeddb[%d] duplicates %q", name, i, binding)
+		if _, exists := seen[binding.Name]; exists {
+			return fmt.Errorf("config validation: plugin %q indexeddb[%d] duplicates %q", name, i, binding.Name)
 		}
-		if _, ok := cfg.Providers.IndexedDB[binding]; !ok {
-			return fmt.Errorf("config validation: plugin %q indexeddb[%d] references unknown indexeddb %q", name, i, binding)
+		if _, ok := cfg.Providers.IndexedDB[binding.Name]; !ok {
+			return fmt.Errorf("config validation: plugin %q indexeddb[%d] references unknown indexeddb %q", name, i, binding.Name)
 		}
-		envName := indexedDBSocketEnv(binding)
+		envName := indexedDBSocketEnv(binding.Name)
 		if otherBinding, exists := envNames[envName]; exists {
-			return fmt.Errorf("config validation: plugin %q indexeddb[%d] %q conflicts with %q after IndexedDB env normalization (%s)", name, i, binding, otherBinding, envName)
+			return fmt.Errorf("config validation: plugin %q indexeddb[%d] %q conflicts with %q after IndexedDB env normalization (%s)", name, i, binding.Name, otherBinding, envName)
 		}
-		seen[binding] = struct{}{}
-		envNames[envName] = binding
-		entry.IndexedDBs[i] = binding
+		seenStores := make(map[string]struct{}, len(binding.ObjectStores))
+		if len(binding.ObjectStores) > 0 {
+			restrictedBindingCount++
+		} else {
+			unrestrictedBindingCount++
+		}
+		for j, store := range binding.ObjectStores {
+			store = strings.TrimSpace(store)
+			if store == "" {
+				return fmt.Errorf("config validation: plugin %q indexeddb[%d].objectStore[%d] is required", name, i, j)
+			}
+			if _, exists := seenStores[store]; exists {
+				return fmt.Errorf("config validation: plugin %q indexeddb[%d].objectStore[%d] duplicates %q", name, i, j, store)
+			}
+			if otherBinding, exists := objectStores[store]; exists {
+				return fmt.Errorf("config validation: plugin %q indexeddb[%d].objectStore[%d] %q duplicates indexeddb %q", name, i, j, store, otherBinding)
+			}
+			seenStores[store] = struct{}{}
+			objectStores[store] = binding.Name
+			binding.ObjectStores[j] = store
+		}
+		seen[binding.Name] = struct{}{}
+		envNames[envName] = binding.Name
+	}
+	if restrictedBindingCount > 0 && unrestrictedBindingCount > 1 {
+		return fmt.Errorf("config validation: plugin %q indexeddb may declare at most one unrestricted binding when objectStore allowlists are used", name)
 	}
 	return nil
 }

--- a/gestaltd/internal/providerhost/cursor_test.go
+++ b/gestaltd/internal/providerhost/cursor_test.go
@@ -24,11 +24,11 @@ func newCursorTestDB(t *testing.T) (*coretesting.StubIndexedDB, indexeddb.Indexe
 		},
 	}
 	ctx := context.Background()
-	if err := stub.CreateObjectStore(ctx, "plugin_test_items", schema); err != nil {
+	if err := stub.CreateObjectStore(ctx, "items", schema); err != nil {
 		t.Fatal(err)
 	}
 
-	store := stub.ObjectStore("plugin_test_items")
+	store := stub.ObjectStore("items")
 	records := []indexeddb.Record{
 		{"id": "a", "name": "Alice", "status": "active", "email": "alice@test.com"},
 		{"id": "b", "name": "Bob", "status": "active", "email": "bob@test.com"},
@@ -42,7 +42,7 @@ func newCursorTestDB(t *testing.T) (*coretesting.StubIndexedDB, indexeddb.Indexe
 	}
 
 	conn := newBufconnConn(t, func(srv *grpc.Server) {
-		proto.RegisterIndexedDBServer(srv, NewIndexedDBServer(stub, "test"))
+		proto.RegisterIndexedDBServer(srv, NewIndexedDBServer(stub, ""))
 	})
 	remote := &remoteIndexedDB{
 		client: proto.NewIndexedDBClient(conn),
@@ -88,10 +88,10 @@ func TestCursor_EmptyCursor(t *testing.T) {
 
 	stub := &coretesting.StubIndexedDB{}
 	ctx := context.Background()
-	_ = stub.CreateObjectStore(ctx, "plugin_test_empty", indexeddb.ObjectStoreSchema{})
+	_ = stub.CreateObjectStore(ctx, "empty", indexeddb.ObjectStoreSchema{})
 
 	conn := newBufconnConn(t, func(srv *grpc.Server) {
-		proto.RegisterIndexedDBServer(srv, NewIndexedDBServer(stub, "test"))
+		proto.RegisterIndexedDBServer(srv, NewIndexedDBServer(stub, ""))
 	})
 	remote := &remoteIndexedDB{client: proto.NewIndexedDBClient(conn)}
 
@@ -548,11 +548,11 @@ func TestCursor_IndexContinueToKeyRoundTrip(t *testing.T) {
 	schema := indexeddb.ObjectStoreSchema{
 		Indexes: []indexeddb.IndexSchema{{Name: "by_num", KeyPath: []string{"n"}}},
 	}
-	if err := stub.CreateObjectStore(ctx, "plugin_test_items", schema); err != nil {
+	if err := stub.CreateObjectStore(ctx, "items", schema); err != nil {
 		t.Fatal(err)
 	}
 
-	store := stub.ObjectStore("plugin_test_items")
+	store := stub.ObjectStore("items")
 	for _, r := range []indexeddb.Record{
 		{"id": "a", "n": 1},
 		{"id": "b", "n": 2},
@@ -564,7 +564,7 @@ func TestCursor_IndexContinueToKeyRoundTrip(t *testing.T) {
 	}
 
 	conn := newBufconnConn(t, func(srv *grpc.Server) {
-		proto.RegisterIndexedDBServer(srv, NewIndexedDBServer(stub, "test"))
+		proto.RegisterIndexedDBServer(srv, NewIndexedDBServer(stub, ""))
 	})
 	remote := &remoteIndexedDB{client: proto.NewIndexedDBClient(conn)}
 
@@ -591,7 +591,7 @@ func TestCursor_StubSingleFieldIndexKeyMatchesRemoteShape(t *testing.T) {
 	stub, _ := newCursorTestDB(t)
 	ctx := context.Background()
 
-	cursor, err := stub.ObjectStore("plugin_test_items").Index("by_status").OpenCursor(ctx, nil, indexeddb.CursorNext)
+	cursor, err := stub.ObjectStore("items").Index("by_status").OpenCursor(ctx, nil, indexeddb.CursorNext)
 	if err != nil {
 		t.Fatalf("OpenCursor: %v", err)
 	}
@@ -616,10 +616,10 @@ func TestCursor_EmptyResultSetDoneOnly(t *testing.T) {
 	t.Parallel()
 	stub := &coretesting.StubIndexedDB{}
 	ctx := context.Background()
-	_ = stub.CreateObjectStore(ctx, "plugin_test_empty", indexeddb.ObjectStoreSchema{})
+	_ = stub.CreateObjectStore(ctx, "empty", indexeddb.ObjectStoreSchema{})
 
 	conn := newBufconnConn(t, func(srv *grpc.Server) {
-		proto.RegisterIndexedDBServer(srv, NewIndexedDBServer(stub, "test"))
+		proto.RegisterIndexedDBServer(srv, NewIndexedDBServer(stub, ""))
 	})
 	remote := &remoteIndexedDB{client: proto.NewIndexedDBClient(conn)}
 

--- a/gestaltd/internal/providerhost/indexeddb_server.go
+++ b/gestaltd/internal/providerhost/indexeddb_server.go
@@ -19,7 +19,6 @@ type indexedDBServer struct {
 	ds     indexeddb.IndexedDB
 	db     string
 	plugin string
-	prefix string
 }
 
 func NewIndexedDBServer(ds indexeddb.IndexedDB, pluginName string) proto.IndexedDBServer {
@@ -27,12 +26,11 @@ func NewIndexedDBServer(ds indexeddb.IndexedDB, pluginName string) proto.Indexed
 		ds:     ds,
 		db:     metricutil.IndexedDBName(ds),
 		plugin: pluginName,
-		prefix: "plugin_" + pluginName + "_",
 	}
 }
 
 func (s *indexedDBServer) storeName(name string) string {
-	return s.prefix + name
+	return name
 }
 
 func (s *indexedDBServer) objectStore(name string) indexeddb.ObjectStore {

--- a/gestaltd/internal/providerhost/indexeddb_server_test.go
+++ b/gestaltd/internal/providerhost/indexeddb_server_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
 )
 
-func TestIndexedDBServerPrefixesStoreNamesPerPlugin(t *testing.T) {
+func TestIndexedDBServerUsesStoreNamesAsProvided(t *testing.T) {
 	t.Parallel()
 
 	db := &coretesting.StubIndexedDB{}
@@ -30,11 +30,8 @@ func TestIndexedDBServerPrefixesStoreNamesPerPlugin(t *testing.T) {
 		t.Fatalf("Put: %v", err)
 	}
 
-	if _, err := db.ObjectStore("plugin_roadmap_snapshots").Get(ctx, "snap-1"); err != nil {
-		t.Fatalf("expected prefixed object store record to exist")
-	}
-	if _, err := db.ObjectStore("snapshots").Get(ctx, "snap-1"); err == nil {
-		t.Fatal("unprefixed object store should not contain the record")
+	if _, err := db.ObjectStore("snapshots").Get(ctx, "snap-1"); err != nil {
+		t.Fatalf("expected object store record to exist: %v", err)
 	}
 }
 
@@ -46,7 +43,7 @@ func TestIndexedDBServerRecordsPluginMetricAttributes(t *testing.T) {
 
 	db := metricutil.InstrumentIndexedDB(&coretesting.StubIndexedDB{}, "system")
 	srv := NewIndexedDBServer(db, "roadmap")
-	if err := metricutil.UnwrapIndexedDB(db).CreateObjectStore(ctx, "plugin_roadmap_snapshots", indexeddb.ObjectStoreSchema{
+	if err := metricutil.UnwrapIndexedDB(db).CreateObjectStore(ctx, "snapshots", indexeddb.ObjectStoreSchema{
 		Indexes: []indexeddb.IndexSchema{{Name: "by_type", KeyPath: []string{"type"}}},
 	}); err != nil {
 		t.Fatalf("CreateObjectStore: %v", err)

--- a/gestaltd/internal/testplugins/echo/proxy_provider.go
+++ b/gestaltd/internal/testplugins/echo/proxy_provider.go
@@ -3,11 +3,13 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 )
@@ -60,6 +62,17 @@ func (p *proxyProvider) Catalog() *catalog.Catalog {
 				{Name: "url", Type: "string", Required: true},
 			},
 		},
+		catalog.CatalogOperation{
+			ID:        "indexeddb_roundtrip",
+			Method:    http.MethodPost,
+			Transport: catalog.TransportPlugin,
+			Parameters: []catalog.CatalogParameter{
+				{Name: "binding", Type: "string"},
+				{Name: "store", Type: "string", Required: true},
+				{Name: "id", Type: "string", Required: true},
+				{Name: "value", Type: "string", Required: true},
+			},
+		},
 	)
 	return cat
 }
@@ -110,6 +123,39 @@ func (p *proxyProvider) Execute(ctx context.Context, operation string, params ma
 			"status": resp.StatusCode,
 			"body":   string(respBody),
 		})
+		return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
+
+	case "indexeddb_roundtrip":
+		binding, _ := params["binding"].(string)
+		store, _ := params["store"].(string)
+		id, _ := params["id"].(string)
+		value, _ := params["value"].(string)
+
+		var (
+			db  *gestalt.IndexedDBClient
+			err error
+		)
+		if binding != "" {
+			db, err = gestalt.IndexedDB(binding)
+		} else {
+			db, err = gestalt.IndexedDB()
+		}
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = db.Close() }()
+
+		if err := db.CreateObjectStore(ctx, store, gestalt.ObjectStoreSchema{}); err != nil && !errors.Is(err, gestalt.ErrAlreadyExists) {
+			return nil, err
+		}
+		if err := db.ObjectStore(store).Put(ctx, map[string]any{"id": id, "value": value}); err != nil {
+			return nil, err
+		}
+		record, err := db.ObjectStore(store).Get(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		body, _ := json.Marshal(record)
 		return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
 
 	default:

--- a/gestaltd/internal/testutil/indexeddbtransport/server.go
+++ b/gestaltd/internal/testutil/indexeddbtransport/server.go
@@ -29,7 +29,6 @@ func Start(socketPath string) (*Server, error) {
 	}
 	stub := &coretesting.StubIndexedDB{}
 	srv := grpc.NewServer()
-	// Empty prefix -- SDK clients don't expect prefixed store names.
 	proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(stub, ""))
 	go func() { _ = srv.Serve(lis) }()
 	return &Server{srv: srv, lis: lis, Socket: socketPath}, nil


### PR DESCRIPTION
## Summary

This rebases the plugin IndexedDB schema/object-store work onto current `main` and switches the feature to the canonical config shape:

- top-level `plugins`
- `providers.indexeddb`
- `server.providers.indexeddb`

It also keeps legacy `plugin_<plugin>_<store>` data reachable during migration:

- generic/non-schema backends fall back through the host transport
- `relationaldb` backends receive `legacy_table_prefix` / `legacy_prefix` so the provider can migrate old flat tables into the new scoped layout

## Go interface

```go
type PluginIndexedDBBinding struct {
    Name         string
    ObjectStores []string
}

type ProviderEntry struct {
    IndexedDBs      []PluginIndexedDBBinding
    IndexedDBSchema string
}
```

Behavior:

- `IndexedDBSchema` defaults to the plugin name when omitted
- `ObjectStores` pins named logical stores to a binding
- one binding may omit `ObjectStores` and act as the catch-all for unassigned stores

## YAML interface

```yaml
plugins:
  roadmap:
    source:
      path: ./plugin/manifest.yaml
    indexeddb:
      - name: main
        objectStore:
          - tasks
          - snapshots
      - name: archive
    indexeddbSchema: roadmap_state

providers:
  indexeddb:
    main:
      source:
        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
        version: 0.0.1-alpha.2
      config:
        dsn: ${DATABASE_URL}
    archive:
      source:
        path: ./providers/datastore/archive

server:
  providers:
    indexeddb: main
```

Examples:

- If `indexeddbSchema` is omitted, `roadmap` uses `roadmap` as its namespace.
- `tasks` and `snapshots` are pinned to `main`.
- `archive` is the catch-all binding for every other store.
- On schema-capable `relationaldb` backends, the provider receives `schema` / `namespace` plus `legacy_table_prefix` / `legacy_prefix`.
- On SQLite, the provider receives `table_prefix` / `prefix` plus `legacy_table_prefix` / `legacy_prefix`.
- On other IndexedDB backends, the host uses `<indexeddbSchema>_` transport prefixes and falls back to legacy `plugin_<plugin>_` stores during migration.

## Tests

Host tests run:

- `go test ./internal/bootstrap -run 'TestPluginIndexedDBBindings(ExposeHostSocketEnv|BuildScopedConfig|RouteObjectStoresAndTransportPrefix|PreserveLegacyTransportPrefixedData|RouteExplicitAndCatchAllStores)$'`
- `go test ./internal/config -run '^TestLoadConfigPluginIndexedDBBindings$'`
- `go test ./internal/providerhost -run '^$'`

Checks:

- `git diff --check`

## Dependency

This PR expects the `relationaldb` migration support in `valon-technologies/gestalt-providers#93`.
