### PR TITLE
Clarify production lockfile guidance

### DIFF
--- a/docs/content/deploy/index.mdx
+++ b/docs/content/deploy/index.mdx
@@ -1,3 +1,5 @@
+import { Callout } from 'nextra/components'
+
 ---
 asIndexPage: true
 ---
@@ -20,6 +22,14 @@ The server image `valontechnologies/gestaltd:latest` is published for `linux/amd
 2. **Serve** -- run `gestaltd serve --locked` in production. The server reads the lock file and refuses to start if any provider is missing or has drifted.
 
 This guarantees that the image you test is byte-for-byte the image you deploy.
+
+<Callout type="warning">
+  For production, strongly prefer `gestaltd init` plus
+  `gestaltd serve --locked`. Without a lockfile, startup can resolve newly
+  published provider artifacts or changed registry metadata, which weakens
+  reproducibility and integrity checks. Lockfiles pin the resolved artifacts and
+  verified hashes that the deployment was tested with.
+</Callout>
 
 **Prepared state and lockfiles.** `gestaltd init` writes a `deploy/` directory next to your config file:
 

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -31,7 +31,7 @@ Gestalt handles this so individual agents and applications don't have to. A sing
 
 ## What Gestalt is not
 
-Gestalt is not a SaaS platform. It is open source and self-hostable on any infrastructure you control, giving you full ownership of your data, credentials, and deployment. Gestalt will remain free and open source; self-hosting is a first-class feature and a permanent commitment to the community.
+Gestalt is not a SaaS platform. It is open source and self-hostable on any infrastructure you control, giving you full ownership of your data, credentials, and deployment. Gestalt will remain free and open source; self-hosting is a first-class feature.
 
 Gestalt does not replace your existing APIs. It sits between agents and upstream services, handling auth and credential lifecycle. Your APIs stay where they are.
 

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -1,3 +1,5 @@
+import { Callout } from 'nextra/components'
+
 # Server CLI
 
 `gestaltd` manages server lifecycle and provider releases.
@@ -15,6 +17,13 @@
 | `gestaltd validate --config PATH` | Validate config without serving. |
 | `gestaltd validate --artifacts-dir DIR` | Directory for prepared provider artifacts. |
 | `gestaltd --version` | Print the server version. |
+
+<Callout type="warning">
+  For production deployments, strongly prefer `gestaltd init` followed by
+  `gestaltd serve --locked`. The lockfile pins resolved provider artifacts and
+  verified hashes so startup cannot silently pick up new artifacts or mutate
+  deployment state.
+</Callout>
 
 ## Provider commands
 

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -552,8 +552,9 @@ func printServeUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd serve [--config PATH] [--artifacts-dir PATH] [--locked]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Start the server. Auto-inits if lock state is missing or stale.")
-	writeUsageLine(w, "Use --locked for production deployments to prevent automatic mutation")
-	writeUsageLine(w, "at startup. When locked, run `gestaltd init` first to prepare artifacts.")
+	writeUsageLine(w, "For production, strongly prefer --locked so startup uses the pinned")
+	writeUsageLine(w, "lockfile state instead of resolving new artifacts or mutating state.")
+	writeUsageLine(w, "When locked, run `gestaltd init` first to prepare artifacts.")
 }
 
 func printInitUsage(w io.Writer) {


### PR DESCRIPTION
## Summary
- recommend `gestaltd init` plus `gestaltd serve --locked` for production in user-facing deploy docs
- add the same production guidance to the CLI reference and `gestaltd serve` help text
- trim the self-hosting copy on the docs landing page to remove the permanence claim

## Verification
- `cd docs && npm run typecheck`
- `cd docs && npm run build`
